### PR TITLE
osd/ReplicatedPG: remove redundant check for balance/localize read

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1837,12 +1837,9 @@ void ReplicatedPG::do_op(OpRequestRef& op)
     &missing_oid);
 
   if (r == -EAGAIN) {
-    // If we're not the primary of this OSD, and we have
-    // CEPH_OSD_FLAG_LOCALIZE_READS set, we just return -EAGAIN. Otherwise,
+    // If we're not the primary of this OSD, we just return -EAGAIN. Otherwise,
     // we have to wait for the object.
-    if (is_primary() ||
-	(!(m->has_flag(CEPH_OSD_FLAG_BALANCE_READS)) &&
-	 !(m->has_flag(CEPH_OSD_FLAG_LOCALIZE_READS)))) {
+    if (is_primary()) {
       // missing the specific snap we need; requeue and wait.
       assert(!op->may_write()); // only happens on a read/cache
       wait_for_unreadable_object(missing_oid, op);


### PR DESCRIPTION
given an op if the PG is a replica and is able to handle it, then the
op must have the BALANCE_READS or LOCALIZE_READS flag(s) set, otherwise
the op was misdirected and had been rejected at the every beginning of
the function.

Signed-off-by: runsisi runsisi@zte.com.cn
