### PR TITLE
os/bluestore: refactor dirty blob tracking along with some related fixes

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3561,6 +3561,30 @@ int BlueStore::read(
   return r;
 }
 
+// --------------------------------------------------------
+// intermediate data structures used while reading
+struct region_t {
+  uint64_t logical_offset;
+  uint64_t blob_xoffset;   //region offset within the blob
+  uint64_t length;
+
+  region_t(uint64_t offset, uint64_t b_offs, uint64_t len)
+    : logical_offset(offset),
+    blob_xoffset(b_offs),
+    length(len) {}
+  region_t(const region_t& from)
+    : logical_offset(from.logical_offset),
+    blob_xoffset(from.blob_xoffset),
+    length(from.length) {}
+
+  friend ostream& operator<<(ostream& out, const region_t& r) {
+    return out << "0x" << std::hex << r.logical_offset << ":"
+      << r.blob_xoffset << "~" << r.length << std::dec;
+  }
+};
+typedef list<region_t> regions2read_t;
+typedef map<Blob*, regions2read_t> blobs2read_t;
+
 int BlueStore::_do_read(
   Collection *c,
   OnodeRef o,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1193,6 +1193,7 @@ void BlueStore::BlobMap::decode(bufferlist::iterator& p, Cache *c)
     ::decode(id, p);
     Blob *b = new Blob(id, c);
     ::decode(b->blob, p);
+    b->get();
     blob_map.insert(*b);
   }
 }
@@ -3582,8 +3583,13 @@ struct region_t {
       << r.blob_xoffset << "~" << r.length << std::dec;
   }
 };
+
+bool less(const BlueStore::BlobRef& a, const BlueStore::BlobRef& b)
+{
+  return *a < *b;
+}
 typedef list<region_t> regions2read_t;
-typedef map<Blob*, regions2read_t> blobs2read_t;
+typedef map<BlueStore::BlobRef, regions2read_t> blobs2read_t;
 
 int BlueStore::_do_read(
   Collection *c,
@@ -3643,7 +3649,7 @@ int BlueStore::_do_read(
       pos += hole;
       left -= hole;
     }
-    Blob *bptr = c->get_blob(o, lp->second.blob);
+    BlobRef bptr = c->get_blob(o, lp->second.blob);
     if (bptr == nullptr) {
       dout(20) << __func__ << "  missed blob " << lp->second.blob << dendl;
       assert(bptr != nullptr);
@@ -3691,7 +3697,7 @@ int BlueStore::_do_read(
   //enumerate and read/decompress desired blobs
   blobs2read_t::iterator b2r_it = blobs2read.begin();
   while (b2r_it != blobs2read.end()) {
-    Blob* bptr = b2r_it->first;
+    BlobRef bptr = b2r_it->first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
 	     << " need 0x" << b2r_it->second << std::dec << dendl;
     if (bptr->blob.has_flag(bluestore_blob_t::FLAG_COMPRESSED)) {
@@ -5297,7 +5303,7 @@ int BlueStore::queue_transactions(
 
   // delayed csum calculation?
   for (auto& d : txc->deferred_csum) {
-    Blob *b = d.onode->get_blob(d.blob);
+    BlobRef b = d.onode->get_blob(d.blob);
     dout(20) << __func__ << "  deferred csum calc blob " << d.blob
 	     << " b_off 0x" << std::hex << d.b_off << std::dec
 	     << " on " << d.onode->oid << dendl;
@@ -5861,7 +5867,7 @@ void BlueStore::_do_write_small(
   blp.copy(length, bl);
 
   // look for an existing mutable blob we can use
-  Blob *b = 0;
+  BlobRef b = 0;
   map<uint64_t,bluestore_lextent_t>::iterator ep = o->onode.seek_lextent(offset);
   if (ep != o->onode.extent_map.begin()) {
     --ep;
@@ -6061,7 +6067,7 @@ void BlueStore::_do_write_big(
 	   << " compress " << (int)wctx->compress
 	   << std::dec << dendl;
   while (length > 0) {
-    Blob *b = o->blob_map.new_blob(c->cache);
+    BlobRef b = o->blob_map.new_blob(c->cache);
     auto l = MIN(max_blob_len, length);
     bufferlist t;
     blp.copy(l, t);
@@ -6099,7 +6105,7 @@ int BlueStore::_do_alloc_write(
 
   uint64_t hint = 0;
   for (auto& wi : wctx->writes) {
-    Blob *b = wi.b;
+    BlobRef b = wi.b;
     uint64_t b_off = wi.b_off;
     bufferlist *l = &wi.bl;
     uint64_t final_length = wi.blob_length;
@@ -6222,10 +6228,10 @@ void BlueStore::_wctx_finish(
   WriteContext *wctx)
 {
   dout(10) << __func__ << " lex_old " << wctx->lex_old << dendl;
-  set<pair<bool, Blob*> > blobs2remove;
+  set<pair<bool, BlobRef> > blobs2remove;
   for (auto &lo : wctx->lex_old) {
     bluestore_lextent_t& l = lo.second;
-    Blob *b = c->get_blob(o, l.blob);
+    BlobRef b = c->get_blob(o, l.blob);
     vector<bluestore_pextent_t> r;
     bool compressed = b->blob.is_compressed();
     if (o->onode.deref_lextent(lo.first, l, &b->blob, min_alloc_size, &r)) {
@@ -6255,13 +6261,12 @@ void BlueStore::_wctx_finish(
     }
   }
   for (auto br : blobs2remove) {
-    Blob* b = br.second;
-    dout(20) << __func__ << " rm blob " << *b << dendl;
-    txc->statfs_delta.compressed() -= b->blob.get_compressed_payload_length();
+    dout(20) << __func__ << " rm blob " << *br.second << dendl;
+    txc->statfs_delta.compressed() -= br.second->blob.get_compressed_payload_length();
     if (br.first) {
-      o->blob_map.erase(b);
+      o->blob_map.erase(br.second);
     } else {
-      o->bnode->blob_map.erase(b);
+      o->bnode->blob_map.erase(br.second);
     }
   }
 
@@ -6807,7 +6812,7 @@ int BlueStore::_clone(TransContext *txc,
       map<int64_t,int64_t> moved_blobs;
       for (auto& p : oldo->onode.extent_map) {
         if (!p.second.is_shared()) {
-          Blob *b;
+          BlobRef b;
           if (moved_blobs.count(p.second.blob) == 0) {
             b = oldo->blob_map.get(p.second.blob);
             oldo->blob_map.erase(b);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -820,6 +820,8 @@ public:
 
     set<OnodeRef> onodes;     ///< these onodes need to be updated/written
     set<BnodeRef> bnodes;     ///< these bnodes need to be updated/written
+    set<BlobRef> blobs;       ///< these blobs need to be updated on io completion
+
     KeyValueDB::Transaction t; ///< then we will commit this
     Context *oncommit;         ///< signal on commit
     Context *onreadable;         ///< signal on readable
@@ -1272,6 +1274,15 @@ private:
     boost::dynamic_bitset<> &used_blocks,
     store_statfs_t& expected_statfs);
 
+  void _buffer_cache_write(
+    TransContext *txc,
+    BlobRef b,
+    uint64_t offset,
+    bufferlist& bl,
+    unsigned flags) {
+    b->bc.write(txc->seq, offset, bl, flags);
+    txc->blobs.insert(b);
+  }
 public:
   BlueStore(CephContext *cct, const string& path);
   ~BlueStore();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -82,29 +82,6 @@ public:
   class TransContext;
   class Blob;
 
-  // --------------------------------------------------------
-  // intermediate data structures used while reading
-  struct region_t {
-    uint64_t logical_offset;
-    uint64_t blob_xoffset;   //region offset within the blob
-    uint64_t length;
-
-    region_t(uint64_t offset, uint64_t b_offs, uint64_t len)
-      : logical_offset(offset),
-      blob_xoffset(b_offs),
-      length(len) {}
-    region_t(const region_t& from)
-      : logical_offset(from.logical_offset),
-      blob_xoffset(from.blob_xoffset),
-      length(from.length) {}
-
-    friend ostream& operator<<(ostream& out, const region_t& r) {
-      return out << "0x" << std::hex << r.logical_offset << ":"
-		 << r.blob_xoffset << "~" << r.length << std::dec;
-    }
-  };
-  typedef list<region_t> regions2read_t;
-  typedef map<Blob*, regions2read_t> blobs2read_t;
   typedef map<uint64_t, bufferlist> ready_regions_t;
 
   struct BufferSpace;


### PR DESCRIPTION
This is an intermediate patch before introducing refcounting for Blob instances.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>