### PR TITLE
cmake changes for pypi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ find_package(libuuid REQUIRED)
 find_package(CURL REQUIRED)
 set(CMAKE_REQUIRED_INCLUDES ${CURL_INCLUDE_DIRS})
 set(CMAKE_REQUIRED_LIBRARIES ${CURL_LIBRARIES})
-CHECK_SYMBOL_EXISTS(curl_multi_wait "curl.h" HAVE_CURL_MULTI_WAIT)
+CHECK_SYMBOL_EXISTS(curl_multi_wait curl/curl.h HAVE_CURL_MULTI_WAIT)
 
 # nss or cryptopp?
 option(WITH_NSS "Use NSS crypto and SSL implementations" ON)

--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -67,7 +67,8 @@ function(distutils_install_cython_module name)
            CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
            CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
            CC=${CMAKE_C_COMPILER}
-           CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"
+           CPPFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
+           LDFLAGS=\"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\"
            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
            build --build-base ${CYTHON_MODULE_DIR} --verbose
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados

--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -70,6 +70,7 @@ function(distutils_install_cython_module name)
            CFLAGS=\"-iquote ${CMAKE_SOURCE_DIR}/src/include\"
            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
            build --build-base ${CYTHON_MODULE_DIR} --verbose
+           build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
            install \${options} --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}
            --verbose

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -6,6 +6,8 @@ from setuptools.command.egg_info import egg_info
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
+from Cython.Distutils import build_ext
+
 
 def get_version():
     try:
@@ -48,6 +50,7 @@ setup(
         os.path.join(os.path.dirname(__file__), "..", "rados")]
     ),
     cmdclass={
+        "build_ext": build_ext,
         "egg_info": EggInfoCommand,
     },
 )

--- a/src/pybind/rados/MANIFEST.in
+++ b/src/pybind/rados/MANIFEST.in
@@ -1,3 +1,2 @@
 include rados.pyx
 include rados.pxd
-include rados.c

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -130,8 +130,11 @@ def check_sanity():
 if not check_sanity():
     sys.exit(1)
 
+cmdclass = {}
 try:
     from Cython.Build import cythonize
+    from Cython.Distutils import build_ext
+    cmdclass = {'build_ext': build_ext}
 except ImportError:
     print("WARNING: Cython is not installed.")
 
@@ -141,8 +144,6 @@ except ImportError:
     else:
         def cythonize(x, **kwargs):
             return x
-
-
         source = "rados.c"
 else:
     source = "rados.pyx"
@@ -169,6 +170,7 @@ setup(
     ),
     url='https://github.com/ceph/ceph/tree/master/src/pybind/rados',
     license='LGPLv2+',
+    platforms='Linux',
     ext_modules=cythonize(
         [
             Extension(
@@ -191,4 +193,5 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5'
     ],
+    cmdclass=cmdclass,
 )

--- a/src/pybind/rbd/setup.py
+++ b/src/pybind/rbd/setup.py
@@ -6,6 +6,7 @@ from setuptools.command.egg_info import egg_info
 from distutils.core import setup
 from distutils.extension import Extension
 from Cython.Build import cythonize
+from Cython.Distutils import build_ext
 
 def get_version():
     try:
@@ -49,5 +50,6 @@ setup(
     ),
     cmdclass={
         "egg_info": EggInfoCommand,
+        "build_ext": build_ext,
     },
 )


### PR DESCRIPTION
this fixes
```
running egg_info
creating /srv/autobuild-ceph/gitbuilder.git/build/build/src/pybind/rados/rados.egg-info
writing /srv/autobuild-ceph/gitbuilder.git/build/build/src/pybind/rados/rados.egg-info/PKG-INFO
writing top-level names to /srv/autobuild-ceph/gitbuilder.git/build/build/src/pybind/rados/rados.egg-info/top_level.txt
writing dependency_links to /srv/autobuild-ceph/gitbuilder.git/build/build/src/pybind/rados/rados.egg-info/dependency_links.txt
writing manifest file '/srv/autobuild-ceph/gitbuilder.git/build/build/src/pybind/rados/rados.egg-info/SOURCES.txt'
warning: no files found matching 'rados.c'
```

in http://gitbuilder.sepia.ceph.com/gitbuilder-ceph-tarball-trusty-amd64-cmake/log.cgi?log=21402181f555d9bf4c34e5aa05c1b6d169f47b42