### PR TITLE
msg/AsyncMessenger: change return type to void

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -237,7 +237,7 @@ int Processor::rebind(const set<int>& avoid_ports)
   return bind(addr, new_avoid);
 }
 
-int Processor::start(Worker *w)
+void Processor::start(Worker *w)
 {
   ldout(msgr->cct, 1) << __func__ << " " << dendl;
 
@@ -246,8 +246,6 @@ int Processor::start(Worker *w)
     worker = w;
     w->center.create_file_event(listen_sd, EVENT_READABLE, listen_handler);
   }
-
-  return 0;
 }
 
 void Processor::accept()

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -123,7 +123,7 @@ class Processor {
   void stop();
   int bind(const entity_addr_t &bind_addr, const set<int>& avoid_ports);
   int rebind(const set<int>& avoid_port);
-  int start(Worker *w);
+  void start(Worker *w);
   void accept();
 };
 


### PR DESCRIPTION
Change the return type of function Processor::start to void. It
doesn't make sense to return constant value(zero).

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>