### PR TITLE
mon/PaxosService: make the return value type inconsistent

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1833,7 +1833,7 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
   if (m->if_osd_failed()) {
     // add a report
     mon->clog->debug() << m->get_target() << " reported failed by "
-		      << m->get_orig_source_inst() << "\n";
+                       << m->get_orig_source_inst() << "\n";
     failure_info_t& fi = failure_info[target_osd];
     MonOpRequestRef old_op = fi.add_report(reporter, failed_since, op);
     if (old_op) {

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -207,7 +207,7 @@ bool PaxosService::should_stash_full()
    */
   return (!latest_full ||
 	  (latest_full <= get_trim_to()) ||
-	  (get_last_committed() - latest_full > (unsigned)g_conf->paxos_stash_full_interval));
+	  (get_last_committed() - latest_full > (version_t)g_conf->paxos_stash_full_interval));
 }
 
 void PaxosService::restart()

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -374,7 +374,7 @@ static int do_copy_pool(Rados& rados, const char *src_pool, const char *target_p
     if (locator.size())
         src_name += "(@" + locator + ")";
     cout << src_pool << ":" << src_name  << " => "
-      << target_pool << ":" << target_name << std::endl;
+         << target_pool << ":" << target_name << std::endl;
 
     src_ctx.locator_set_key(locator);
     src_ctx.set_namespace(nspace);


### PR DESCRIPTION
This is inconsistent problem for the return value type. the type for get_last_committed() and latest_full is the type of version_t, so I fixup the return type of paxos_stash_full_interval for version_t yet.
Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>