### PR TITLE
kraken: remove SYSTEMD_RUN from initscript

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -17,17 +17,12 @@ if [ -e /lib/lsb/init-functions ]; then
     . /lib/lsb/init-functions
 fi
 
-# detect systemd, also check whether the systemd-run binary exists
-SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
-grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
-
 if [ `dirname $0` = "." ] && [ $PWD != "/etc/init.d" ]; then
     # looks like an autotools src dir build
     BINDIR=.
     SBINDIR=.
     LIBEXECDIR=.
     ETCDIR=.
-    SYSTEMD_RUN=""
     ASSUME_DEV=1
 else
     if [ -e CMakeCache.txt ] && [ -e bin/init-ceph ]; then
@@ -37,7 +32,6 @@ else
 	SBINDIR=bin
 	LIBEXECDIR=$CEPH_ROOT/src
 	ETCDIR=.
-	SYSTEMD_RUN=""
 	ASSUME_DEV=1
     else
 	BINDIR=@bindir@
@@ -53,7 +47,6 @@ if [ -n "$CEPH_BIN" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BUILD_DIR" ]; then
   SBINDIR=$CEPH_ROOT/src
   ETCDIR=$CEPH_BIN
   LIBEXECDIR=$CEPH_ROOT/src
-  SYSTEMD_RUN=""
   ASSUME_DEV=1
 fi
 
@@ -359,12 +352,7 @@ for name in $what; do
 
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
-	    if [ -n "$SYSTEMD_RUN" ]; then
-                time=`date +%s.%N` 
-		cmd="$SYSTEMD_RUN --unit=ceph-$name.$time -r bash -c '$files $tcmalloc $cmd --cluster $cluster --setuser ceph --setgroup ceph -f'"
-	    else
-		cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
-	    fi
+	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then
 		get_conf pre_mount "true" "pre mount command"

--- a/src/init-radosgw
+++ b/src/init-radosgw
@@ -17,10 +17,6 @@ if [ -x /sbin/start-stop-daemon ]; then
 else
     . /etc/rc.d/init.d/functions
     DEBIAN=0
-
-    # detect systemd, also check whether the systemd-run binary exists
-    SYSTEMD_RUN=$(which systemd-run 2>/dev/null)
-    grep -qs systemd /proc/1/comm || SYSTEMD_RUN=""
 fi
 
 daemon_is_running() {
@@ -99,10 +95,8 @@ case "$1" in
             fi
 
             echo "Starting $name..."
-	    if [ $DEBIAN -eq 1 ]; then
-		start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
-	    elif [ -n "$SYSTEMD_RUN" ]; then
-                $SYSTEMD_RUN -r su "$user" -c "ulimit -n 32768; $RADOSGW -n $name"
+            if [ $DEBIAN -eq 1 ]; then
+                start-stop-daemon --start -u $user -x $RADOSGW -p /var/run/ceph/client-$name.pid -- -n $name
             else
                 ulimit -n 32768
                 core_limit=`ceph-conf -n $name 'core file limit'`


### PR DESCRIPTION
Closes: http://tracker.ceph.com/issues/16652

`systemd-run` logic in initscripts was introduced because of ticket http://tracker.ceph.com/issues/7627.
If we have systemd-based distro, we should use systemd unit files from systemd directory to start/stop ceph daemons.
Otherwise, `daemon()` from `/etc/init.d/functions` on systemd distro starts service in `system.slice` and everything works well for case, for example, when we use hammer on RH7. With this code it will start daemon with `daemon()` function from `init.d/functions`.
`systemd-run` can not be run on non-systemd distros, so it's not needed on SysV systems.

Backport of: #9871

Signed-off-by: Vladislav Odintsov <odivlad@gmail.com>