### PR TITLE
hammer: mon: fix memory leak in prepare_beacon

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -432,6 +432,7 @@ bool MDSMonitor::prepare_beacon(MMDSBeacon *m)
   // Ignore beacons if filesystem is disabled
   if (!mdsmap.get_enabled()) {
     dout(1) << "warning, MDS " << m->get_orig_source_inst() << " up but filesystem disabled" << dendl;
+    m->put();
     return false;
   }
 
@@ -501,6 +502,7 @@ bool MDSMonitor::prepare_beacon(MMDSBeacon *m)
       dout(0) << "got beacon for MDS in STATE_STOPPING, ignoring requested state change"
 	       << dendl;
       _note_beacon(m);
+      m->put();
       return true;
     }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/17285

prepare_beacon() case of prepare_update() should put()
message in two more cases, because is the last step
of dispatch()

Signed-off-by: Igor Podoski igor.podoski@ts.fujitsu.com
