### PR TITLE
mon: remove the redudant jugement in paxosservice is_writeable function

### DIFF
--- a/src/mon/PaxosService.h
+++ b/src/mon/PaxosService.h
@@ -576,10 +576,7 @@ public:
    * @returns true if writeable; false otherwise
    */
   bool is_writeable() {
-    return
-      !is_proposing() &&
-      is_write_ready() &&
-      (paxos->is_active() || paxos->is_updating() || paxos->is_writing());
+    return is_write_ready(); 
   }
 
   /**


### PR DESCRIPTION
mon: remove the redudant jugement in paxosservice is_writeable function

From
```
      !is_proposing() &&
      !is_proposing() &&
     (paxos->is_active() || paxos->is_updating() || paxos->is_writing())&& have_pending&&
     (paxos->is_active() || paxos->is_updating() || paxos->is_writing())
```
To
```
      !is_proposing() &&
     (paxos->is_active() || paxos->is_updating() || paxos->is_writing())&& have_pending
```
Signed-off-by: song baisen song.baisen@zte.com.cn
