### PR TITLE
bluestore_extent_ref_map_t::put should use vector<bluestore_lextent_t>

### DIFF
--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -210,7 +210,7 @@ void bluestore_extent_ref_map_t::get(uint32_t offset, uint32_t length)
 
 void bluestore_extent_ref_map_t::put(
   uint32_t offset, uint32_t length,
-  vector<bluestore_pextent_t> *release)
+  vector<bluestore_lextent_t> *release)
 {
   map<uint32_t,record_t>::iterator p = ref_map.lower_bound(offset);
   if (p == ref_map.end() || p->first > offset) {
@@ -240,7 +240,7 @@ void bluestore_extent_ref_map_t::put(
 	_maybe_merge_left(p);
       } else {
 	if (release)
-	  release->push_back(bluestore_pextent_t(p->first, length));
+	  release->push_back(bluestore_lextent_t(0, p->first, length));
 	ref_map.erase(p);
       }
       return;
@@ -253,7 +253,7 @@ void bluestore_extent_ref_map_t::put(
       ++p;
     } else {
       if (release)
-	release->push_back(bluestore_pextent_t(p->first, p->second.length));
+	release->push_back(bluestore_lextent_t(0, p->first, p->second.length));
       ref_map.erase(p++);
     }
   }
@@ -538,7 +538,7 @@ void bluestore_blob_t::put_ref(
   uint64_t min_release_size,
   vector<bluestore_pextent_t> *r)
 {
-  vector<bluestore_pextent_t> logical;
+  vector<bluestore_lextent_t> logical;
   ref_map.put(offset, length, &logical);
 
   r->clear();

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -84,7 +84,7 @@ TEST(bluestore_extent_ref_map_t, get)
 TEST(bluestore_extent_ref_map_t, put)
 {
   bluestore_extent_ref_map_t m;
-  vector<bluestore_pextent_t> r;
+  vector<bluestore_lextent_t> r;
   m.get(10, 30);
   m.put(10, 30, &r);
   cout << m << " " << r << std::endl;


### PR DESCRIPTION
bluestore_extent_ref_map_t::put should use vector<bluestore_lextent_t>

Signed-off-by: Wu Dong archer.wudong@gmail.com