### PR TITLE
hammer: rados: do not unlock object twice for avoiding crash

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -628,8 +628,6 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     if (memcmp(data.object_contents, cur_contents->c_str(), data.object_size) != 0) {
       cerr << name[slot] << " is not correct!" << std::endl;
       ++errors;
-    } else {
-      lock.Unlock();
     }
 
     name[slot] = newName;


### PR DESCRIPTION
In Hammer release during ceph sequential read benchmarking if user
execute  $ rados bench -p <pool_name> 10 seq; then its crashing.
This is crashing because we are unlocking object two time while
taking lock single time.

fixes: http://tracker.ceph.com/issues/15556

Reported by: Ivan Jobs <ivan1377@163.com> 
Signed-off-by: GAURAV KUMAR GARG <ggarg@suse.com>