### PR TITLE
doc: rm "type=rpm-md" from yum repositories

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -178,7 +178,6 @@ over standard packages, so you must ensure that you set
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
@@ -187,7 +186,6 @@ over standard packages, so you must ensure that you set
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
@@ -196,7 +194,6 @@ over standard packages, so you must ensure that you set
 	enabled=0
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
@@ -209,7 +206,6 @@ for development releases instead. ::
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
@@ -218,7 +214,6 @@ for development releases instead. ::
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
@@ -227,7 +222,6 @@ for development releases instead. ::
 	enabled=0
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
@@ -287,7 +281,6 @@ below, replace ``{distro}`` with your Linux distribution (e.g., ``el7``), and
 	baseurl=http://gitbuilder.ceph.com/ceph-rpm-{distro}-x86_64-basic/ref/{branch}/SRPMS
 	enabled=0
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 
@@ -329,7 +322,6 @@ directory to see which distributions Ceph supports.
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[apache2-ceph-source]
@@ -338,7 +330,6 @@ directory to see which distributions Ceph supports.
 	enabled=0
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 
@@ -350,7 +341,6 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[fastcgi-ceph-noarch]
@@ -359,7 +349,6 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 	[fastcgi-ceph-source]
@@ -368,7 +357,6 @@ Repeat the forgoing process by creating a ``ceph-fastcgi.repo`` file. ::
 	enabled=0
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/autobuild.asc
 
 

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -46,7 +46,6 @@ To install Ceph with RPMs, execute the following steps:
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-noarch]
@@ -55,7 +54,6 @@ To install Ceph with RPMs, execute the following steps:
 	enabled=1
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 	[ceph-source]
@@ -64,7 +62,6 @@ To install Ceph with RPMs, execute the following steps:
 	enabled=0
 	priority=2
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 

--- a/doc/install/upgrading-ceph.rst
+++ b/doc/install/upgrading-ceph.rst
@@ -274,7 +274,6 @@ Then add a new ``ceph.repo`` repository entry with the following contents.
 	baseurl=http://download.ceph.com/rpm/el6/$basearch
 	enabled=1
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
@@ -312,7 +311,6 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``, etc).
 	baseurl=http://download.ceph.com/rpm-emperor/{distro}/$basearch
 	enabled=1
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
@@ -438,7 +436,6 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``,
 	baseurl=http://download.ceph.com/rpm-firefly/{distro}/$basearch
 	enabled=1
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 
@@ -511,7 +508,6 @@ replace ``{distro}`` with your distribution (e.g., ``el6``, ``rhel6``,
 	baseurl=http://download.ceph.com/rpm/{distro}/$basearch
 	enabled=1
 	gpgcheck=1
-	type=rpm-md
 	gpgkey=https://download.ceph.com/keys/release.asc
 
 


### PR DESCRIPTION
As far as I can tell, this is only relevant to SUSE's Zypper, and yum does not need it.
