### PR TITLE
os/bluestore: extent alloc functionality for stupid and bitmap allocator

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -15,6 +15,7 @@
 #include "kv/KeyValueDB.h"
 #include <ostream>
 #include "include/assert.h"
+#include "os/bluestore/bluestore_types.h"
 
 class FreelistManager;
 
@@ -29,8 +30,38 @@ public:
     uint64_t need_size, uint64_t alloc_unit, int64_t hint,
     uint64_t *offset, uint32_t *length) = 0;
 
+  /*
+   * Allocate required number of blocks in n number of extents.
+   * Min and Max number of extents are limited by:
+   * a. alloc unit
+   * b. max_alloc_size.
+   * as no extent can be lesser than alloc_unit and greater than max_alloc size.
+   * Apart from that extents can vary between these lower and higher limits according
+   * to free block search algorithm and availability of contiguous space.
+   */
+  virtual int alloc_extents(uint64_t want_size, uint64_t alloc_unit,
+                            uint64_t max_alloc_size, int64_t hint,
+                            std::vector<AllocExtent> *extents, int *count) = 0;
+
+  virtual int alloc_extents(uint64_t want_size, uint64_t alloc_unit,
+                            int64_t hint, std::vector<AllocExtent> *extents,
+			    int *count) {
+    return alloc_extents(want_size, alloc_unit, want_size, hint, extents, count);
+  }
+
   virtual int release(
     uint64_t offset, uint64_t length) = 0;
+
+  virtual int release_extents(std::vector<AllocExtent> *extents, int count) {
+    int res = 0;
+      for (int i = 0; i < count; i++) {
+        res = release((*extents)[i].offset, (*extents)[i].length);
+        if (res != 0) {
+	  break;
+        }
+      }
+    return res;
+  }
 
   virtual void commit_start() = 0;
   virtual void commit_finish() = 0;

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -312,8 +312,7 @@ BmapEntry::find_first_set_bits(int64_t required_blocks,
  * Find N number of free bits in bitmap. Need not be contiguous.
  */
 int BmapEntry::find_any_free_bits(int start_offset, int64_t num_blocks,
-            int64_t *allocated_blocks, int64_t block_offset,
-            int64_t *scanned)
+        ExtentList *allocated_blocks, int64_t block_offset, int64_t *scanned)
 {
   int allocated = 0;
   int required = num_blocks;
@@ -331,7 +330,7 @@ int BmapEntry::find_any_free_bits(int start_offset, int64_t num_blocks,
   for (i = start_offset; i < BmapEntry::size() &&
         allocated < required; i++) {
     if (check_n_set_bit(i)) {
-      allocated_blocks[allocated] = i + block_offset;
+      allocated_blocks->add_extents(i + block_offset, 1);
       allocated++;
     }
   }
@@ -601,7 +600,9 @@ void BitMapZone::free_blocks(int64_t start_block, int64_t num_blocks)
 /*
  * Allocate N blocks, dis-contiguous are fine
  */
-int64_t BitMapZone::alloc_blocks_dis(int64_t num_blocks, int64_t zone_blk_off, int64_t *alloc_blocks)
+int64_t BitMapZone::alloc_blocks_dis(int64_t num_blocks,
+                                   int64_t zone_blk_off, 
+                                   ExtentList *alloc_blocks)
 {
   int64_t bmap_idx = 0;
   int bit = 0;
@@ -617,8 +618,11 @@ int64_t BitMapZone::alloc_blocks_dis(int64_t num_blocks, int64_t zone_blk_off, i
     int64_t scanned = 0;
     blk_off = (iter.index() - 1) * BmapEntry::size() + zone_blk_off;
     allocated += bmap->find_any_free_bits(bit, num_blocks - allocated,
-            &alloc_blocks[allocated], blk_off, &scanned);
+            alloc_blocks, blk_off, &scanned);
 
+    if (allocated == num_blocks) {
+      break;
+    }
   }
 
   add_used_blocks(allocated);
@@ -868,17 +872,6 @@ bool BitMapAreaIN::is_allocated(int64_t start_block, int64_t num_blocks)
   return true;
 }
 
-bool BitMapAreaIN::is_allocated(int64_t *alloc_blocks, int64_t num_blocks, int64_t blk_off)
-{
-  for (int64_t i = 0; i < num_blocks; i++) {
-    if (!is_allocated(alloc_blocks[i] - blk_off, 1)) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 int64_t BitMapAreaIN::alloc_blocks_int(bool wait, bool wrap,
                          int64_t num_blocks, int64_t *start_block)
 {
@@ -931,7 +924,7 @@ exit:
 }
 
 int64_t BitMapAreaIN::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
-           int64_t area_blk_off, int64_t *block_list)
+           int64_t area_blk_off, ExtentList *block_list)
 {
   BitMapArea *child = NULL;
   int64_t allocated = 0;
@@ -947,7 +940,7 @@ int64_t BitMapAreaIN::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
 
     blk_off = child->get_index() * m_child_size_blocks + area_blk_off;
     allocated += child->alloc_blocks_dis(wait, num_blocks - allocated,
-                            blk_off, &block_list[allocated]);
+                            blk_off, block_list);
     child_unlock(child);
     if (allocated == num_blocks) {
       break;
@@ -958,14 +951,13 @@ int64_t BitMapAreaIN::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
 }
 
 int64_t BitMapAreaIN::alloc_blocks_dis(bool wait, int64_t num_blocks,
-           int64_t blk_off, int64_t *block_list)
+           int64_t blk_off, ExtentList *block_list)
 {
   int64_t allocated = 0;
 
   lock_shared();
-  allocated += alloc_blocks_dis_int(wait, num_blocks, blk_off, &block_list[allocated]);
+  allocated += alloc_blocks_dis_int(wait, num_blocks, blk_off, block_list);
   add_used_blocks(allocated);
-  debug_assert(is_allocated(block_list, allocated, blk_off));
 
   unlock();
   return allocated;
@@ -1159,7 +1151,7 @@ int64_t BitMapAreaLeaf::alloc_blocks_int(bool wait, bool wrap,
 }
 
 int64_t BitMapAreaLeaf::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
-                                 int64_t area_blk_off, int64_t *block_list)
+                                 int64_t area_blk_off, ExtentList *block_list)
 {
   BitMapArea *child = NULL;
   int64_t allocated = 0;
@@ -1174,8 +1166,7 @@ int64_t BitMapAreaLeaf::alloc_blocks_dis_int(bool wait, int64_t num_blocks,
     }
 
     blk_off = child->get_index() * m_child_size_blocks + area_blk_off;
-    allocated += child->alloc_blocks_dis(num_blocks - allocated,
-      blk_off, &block_list[allocated]);
+    allocated += child->alloc_blocks_dis(num_blocks - allocated, blk_off, block_list);
     child_unlock(child);
     if (allocated == num_blocks) {
       break;
@@ -1266,6 +1257,7 @@ void BitAllocator::init_check(int64_t total_blocks, int64_t zone_size_block,
         BmapEntry::size();
 
   unaligned_blocks = total_blocks % zone_size_block;
+  m_extra_blocks = unaligned_blocks? zone_size_block - unaligned_blocks: 0;
   total_blocks = ROUND_UP_TO(total_blocks, zone_size_block);
 
   m_alloc_mode = mode;
@@ -1280,8 +1272,7 @@ void BitAllocator::init_check(int64_t total_blocks, int64_t zone_size_block,
     /*
      * Mark extra padded blocks used from begning.
      */
-    set_blocks_used(total_blocks - (zone_size_block - unaligned_blocks),
-                 (zone_size_block - unaligned_blocks));
+    set_blocks_used(total_blocks - m_extra_blocks, m_extra_blocks);
   }
 }
 
@@ -1451,6 +1442,7 @@ int64_t BitAllocator::alloc_blocks(int64_t num_blocks, int64_t *start_block)
   if (!reserve_blocks(num_blocks)) {
     goto exit;
   }
+
   if (is_stats_on()) {
     m_stats->add_alloc_calls(1);
     m_stats->add_allocated(num_blocks);
@@ -1535,7 +1527,17 @@ void BitAllocator::set_blocks_used(int64_t start_block, int64_t num_blocks)
 /*
  * Allocate N dis-contiguous blocks.
  */
-int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
+int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, ExtentList *block_list)
+{
+  return alloc_blocks_dis_work(num_blocks, block_list, false);
+}
+
+int64_t BitAllocator::alloc_blocks_dis_res(int64_t num_blocks, ExtentList *block_list)
+{
+  return alloc_blocks_dis_work(num_blocks, block_list, true);
+}
+
+int64_t BitAllocator::alloc_blocks_dis_work(int64_t num_blocks, ExtentList *block_list, bool reserved)
 {
   int scans = 1;
   int64_t allocated = 0;
@@ -1555,7 +1557,7 @@ int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
 
   lock_shared();
   serial_lock();
-  if (!reserve_blocks(num_blocks)) {
+  if (!reserved && !reserve_blocks(num_blocks)) {
     goto exit;
   }
 
@@ -1564,8 +1566,7 @@ int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
   }
 
   while (scans && allocated < num_blocks) {
-    allocated += alloc_blocks_dis_int(false, num_blocks - allocated,
-      blk_off, &block_list[allocated]);
+    allocated += alloc_blocks_dis_int(false, num_blocks - allocated, blk_off, block_list);
     scans--;
   }
 
@@ -1579,15 +1580,14 @@ int64_t BitAllocator::alloc_blocks_dis(int64_t num_blocks, int64_t *block_list)
     unlock();
     lock_excl();
     serial_lock();
-    allocated += alloc_blocks_dis_int(false, num_blocks - allocated,
-      blk_off, &block_list[allocated]);
+    allocated += alloc_blocks_dis_int(false, num_blocks - allocated, blk_off, block_list);
     if (is_stats_on()) {
       m_stats->add_serial_scans(1);
     }
   }
 
   unreserve(num_blocks, allocated);
-  debug_assert(is_allocated(block_list, allocated, 0));
+  debug_assert(is_allocated_dis(block_list, allocated));
 
 exit:
   serial_unlock();
@@ -1596,18 +1596,37 @@ exit:
   return allocated;
 }
 
-void BitAllocator::free_blocks_dis(int64_t num_blocks, int64_t *block_list)
+bool BitAllocator::is_allocated_dis(ExtentList *blocks, int64_t num_blocks)
 {
+  int64_t count = 0;
+  for (int64_t j = 0; j < blocks->get_extent_count(); j++) {
+    auto p = blocks->get_nth_extent(j);
+    count += p.second;
+    if (!is_allocated(p.first, p.second)) {
+      return false;
+    }
+  }
+
+  debug_assert(count == num_blocks);
+  return true;
+}
+
+void BitAllocator::free_blocks_dis(int64_t num_blocks, ExtentList *block_list)
+{
+  int64_t freed = 0;
   lock_shared();
   if (is_stats_on()) {
     m_stats->add_free_calls(1);
     m_stats->add_freed(num_blocks);
   }
 
-  for (int64_t i = 0; i < num_blocks; i++) {
-    free_blocks_int(block_list[i], 1);
+  for (int64_t i = 0; i < block_list->get_extent_count(); i++) {
+    free_blocks_int(block_list->get_nth_extent(i).first,
+                    block_list->get_nth_extent(i).second);
+    freed += block_list->get_nth_extent(i).second;
   }
 
+  debug_assert(num_blocks == freed);
   sub_used_blocks(num_blocks);
   debug_assert(get_used_blocks() >= 0);
   unlock();

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -17,6 +17,8 @@
 #include <atomic>
 #include <vector>
 #include "include/intarith.h"
+#include "os/bluestore/bluestore_types.h"
+
 
 class BitAllocatorStats {
 public:
@@ -166,7 +168,7 @@ public:
           int *start_offset, int64_t *scanned);
 
   int find_any_free_bits(int start_offset, int64_t num_blocks,
-        int64_t *alloc_list, int64_t block_offset,
+        ExtentList *alloc_list, int64_t block_offset,
         int64_t *scanned);
 
   ~BmapEntry();
@@ -192,6 +194,10 @@ public:
   static int get_level(int64_t total_blocks);
   static int64_t get_level_factor(int level);
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks) = 0;
+  virtual bool is_allocated(ExtentList *blocks, int64_t num_blocks, int blk_off) {
+    debug_assert(0);
+    return true;
+  }
   virtual bool is_exhausted() = 0;
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required) {
       debug_assert(0);
@@ -234,12 +240,12 @@ public:
   }
 
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
-             int64_t blk_off, int64_t *block_list) {
+             int64_t blk_off, ExtentList *block_list) {
     debug_assert(0);
     return 0;
   }
   virtual int64_t alloc_blocks_dis(int64_t num_blocks,
-                         int64_t blk_offset, int64_t *block_list) {
+             int64_t blk_off, ExtentList *block_list) {
     debug_assert(0);
     return 0;
   }
@@ -358,7 +364,8 @@ public:
   }
 
   int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
-  int64_t alloc_blocks_dis(int64_t num_blocks, int64_t blk_off, int64_t *block_list);
+  int64_t alloc_blocks_dis(int64_t num_blocks,
+        int64_t blk_off, ExtentList *block_list);  
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
 
   void free_blocks(int64_t start_block, int64_t num_blocks);
@@ -377,8 +384,7 @@ protected:
   std::mutex m_blocks_lock;
   BitMapAreaList *m_child_list;
 
-  bool is_allocated(int64_t start_block, int64_t num_blocks);
-  virtual bool is_allocated(int64_t *blocks, int64_t num_blocks, int64_t blk_off);
+  virtual bool is_allocated(int64_t start_block, int64_t num_blocks);
   virtual bool is_exhausted();
   
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock) {
@@ -425,9 +431,9 @@ public:
   using BitMapArea::alloc_blocks_dis; //non-wait version
   virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block);
   virtual int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
-               int64_t blk_off, int64_t *block_list);
+        int64_t blk_off, ExtentList *block_list);  
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
-             int64_t blk_off, int64_t *block_list);
+        int64_t blk_off, ExtentList *block_list);  
   virtual void set_blocks_used_int(int64_t start_block, int64_t num_blocks);
   virtual void set_blocks_used(int64_t start_block, int64_t num_blocks);
 
@@ -459,7 +465,7 @@ public:
   int64_t alloc_blocks_int(bool wait, bool wrap,
                          int64_t num_blocks, int64_t *start_block);
   int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
-                               int64_t blk_off, int64_t *block_list);
+        int64_t blk_off, ExtentList *block_list);  
   void free_blocks_int(int64_t start_block, int64_t num_blocks);
 
   virtual ~BitMapAreaLeaf();
@@ -478,8 +484,7 @@ private:
   pthread_rwlock_t m_rw_lock;
   BitAllocatorStats *m_stats;
   bool m_is_stats_on;
-
-  int64_t truncated_blocks; //see init_check
+  int64_t m_extra_blocks;
 
   bool is_stats_on() {
     return m_is_stats_on;
@@ -499,6 +504,7 @@ private:
   bool check_input_dis(int64_t num_blocks);
   void init_check(int64_t total_blocks, int64_t zone_size_block,
                  bmap_alloc_mode_t mode, bool def, bool stats_on);
+  int64_t alloc_blocks_dis_work(int64_t num_blocks, ExtentList *block_list, bool reserved);
 
 public:
 
@@ -517,10 +523,19 @@ public:
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
   void unreserve_blocks(int64_t blocks);
 
-  int64_t alloc_blocks_dis(int64_t num_blocks, int64_t *block_list);
-  void free_blocks_dis(int64_t num_blocks, int64_t *block_list);
+  int64_t alloc_blocks_dis(int64_t num_blocks, ExtentList *block_list);
+  int64_t alloc_blocks_dis_res(int64_t num_blocks, ExtentList *block_list);
 
-  int64_t get_truncated_blocks() { return truncated_blocks; }
+  void free_blocks_dis(int64_t num_blocks, ExtentList *block_list);
+  bool is_allocated_dis(ExtentList *blocks, int64_t num_blocks);
+
+  int64_t size() {
+    return m_total_blocks - m_extra_blocks;
+  }
+  int64_t get_used_blocks() {
+    return BitMapAreaIN::get_used_blocks() - (m_extra_blocks + m_reserved_blocks);
+  }
+
   BitAllocatorStats *get_stats() {
       return m_stats;
   }

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -24,6 +24,12 @@ class BitMapAllocator : public Allocator {
 
   void insert_free(uint64_t offset, uint64_t len);
 
+  int alloc_extents_cont(uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
+                         int64_t hint, std::vector<AllocExtent> *extents, int *count);
+
+  int alloc_extents_dis(uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
+                        int64_t hint, std::vector<AllocExtent> *extents, int *count);
+
 public:
   BitMapAllocator();
   BitMapAllocator(int64_t device_size, int64_t block_size);
@@ -35,6 +41,10 @@ public:
   int allocate(
     uint64_t want_size, uint64_t alloc_unit, int64_t hint,
     uint64_t *offset, uint32_t *length);
+
+  int alloc_extents(
+    uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
+    int64_t hint, std::vector<AllocExtent> *extents, int *count);
 
   int release(
     uint64_t offset, uint64_t length);

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -8,6 +8,7 @@
 
 #include "Allocator.h"
 #include "include/btree_interval_set.h"
+#include "os/bluestore/bluestore_types.h"
 
 class StupidAllocator : public Allocator {
   std::mutex lock;
@@ -32,6 +33,10 @@ public:
 
   int reserve(uint64_t need);
   void unreserve(uint64_t unused);
+
+  int alloc_extents(
+    uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
+    int64_t hint, std::vector<AllocExtent> *extents, int *count);
 
   int allocate(
     uint64_t want_size, uint64_t alloc_unit, int64_t hint,

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -105,7 +105,7 @@ vector<bluefs_extent_t>::iterator bluefs_fnode_t::seek(
 {
   vector<bluefs_extent_t>::iterator p = extents.begin();
   while (p != extents.end()) {
-    if (offset >= p->length) {
+    if ((int64_t) offset >= p->length) {
       offset -= p->length;
       ++p;
     } else {

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -7,17 +7,12 @@
 #include "include/utime.h"
 #include "include/encoding.h"
 
-struct bluefs_extent_t {
-  uint64_t offset;
-  uint32_t length;
+class bluefs_extent_t : public AllocExtent{
+public:
   uint16_t bdev;
 
   bluefs_extent_t(uint16_t b = 0, uint64_t o = 0, uint32_t l = 0)
-    : offset(o), length(l), bdev(b) {}
-
-  uint64_t end() const {
-    return offset + length;
-  }
+    : AllocExtent(o, l), bdev(b) {}
 
   void encode(bufferlist&) const;
   void decode(bufferlist::iterator&);

--- a/src/test/Makefile-server.am
+++ b/src/test/Makefile-server.am
@@ -71,6 +71,11 @@ unittest_bit_alloc_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_bit_alloc_CXXFLAGS = $(UNITTEST_CXXFLAGS)
 check_TESTPROGRAMS += unittest_bit_alloc
 
+unittest_alloc_SOURCES = test/objectstore/Allocator_test.cc
+unittest_alloc_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
+unittest_alloc_CXXFLAGS = $(UNITTEST_CXXFLAGS)
+check_TESTPROGRAMS += unittest_alloc
+
 unittest_bluestore_types_SOURCES = test/objectstore/test_bluestore_types.cc
 unittest_bluestore_types_LDADD = $(LIBOS) $(UNITTEST_LDADD) $(CEPH_GLOBAL)
 unittest_bluestore_types_CXXFLAGS = $(UNITTEST_CXXFLAGS)

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -1,0 +1,210 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * In memory space allocator test cases.
+ * Author: Ramesh Chander, Ramesh.Chander@sandisk.com
+ */
+#include "os/bluestore/Allocator.h"
+#include "global/global_init.h"
+#include <iostream>
+#include "include/Context.h"
+#include "common/ceph_argparse.h"
+#include "global/global_init.h"
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "common/errno.h"
+#include "include/stringify.h"
+#include <gtest/gtest.h>
+#include <os/bluestore/BitAllocator.h>
+
+#if GTEST_HAS_PARAM_TEST
+
+class AllocTest : public ::testing::TestWithParam<const char*> {
+public:
+    boost::scoped_ptr<Allocator> alloc;
+    AllocTest(): alloc(0) { }
+    void init_alloc(int64_t size, uint64_t min_alloc_size) {
+      std::cout << "Creating alloc type " << string(GetParam()) << " \n";
+      alloc.reset(Allocator::create(string(GetParam()), size, min_alloc_size));
+    }
+
+    void init_close() {
+      alloc.reset(0);
+    }
+};
+
+TEST_P(AllocTest, test_alloc_init)
+{
+  int64_t blocks = BmapEntry::size();
+  init_alloc(blocks, 1);
+  ASSERT_EQ(alloc->get_free(), 0);
+  alloc->shutdown(); 
+  blocks = BitMapZone::get_total_blocks() * 2 + 16;
+  init_alloc(blocks, 1);
+  ASSERT_EQ(alloc->get_free(), 0);
+  alloc->shutdown(); 
+  blocks = BitMapZone::get_total_blocks() * 2;
+  init_alloc(blocks, 1);
+  ASSERT_EQ(alloc->get_free(), 0);
+}
+
+TEST_P(AllocTest, test_alloc_min_alloc)
+{
+  int64_t block_size = 1024;
+  int64_t blocks = BitMapZone::get_total_blocks() * 2 * block_size;
+  uint64_t offset = 0;
+  uint32_t length = 0;
+  int count = 0;
+
+  init_alloc(blocks, block_size);
+  alloc->init_add_free(block_size, block_size);
+  EXPECT_EQ(alloc->reserve(block_size), 0);
+  EXPECT_EQ(alloc->allocate(block_size, block_size, 0, &offset, &length), 0);
+
+  /*
+   * Allocate extent and make sure all comes in single extent.
+   */   
+  {
+    alloc->init_add_free(0, block_size * 4);
+    EXPECT_EQ(alloc->reserve(block_size * 4), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (4, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(4 * (uint64_t)block_size, (uint64_t) block_size, 
+                                   0, (int64_t) 0, &extents, &count), 0);
+    EXPECT_EQ(extents[0].length, 4 * block_size);
+    EXPECT_EQ(extents[1].length, 0);
+    EXPECT_EQ(count, 1);
+  }
+
+  /*
+   * Allocate extent and make sure we get two different extents.
+   */
+  {
+    alloc->init_add_free(0, block_size * 2);
+    alloc->init_add_free(3 * block_size, block_size * 2);
+    EXPECT_EQ(alloc->reserve(block_size * 4), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (4, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(4 * (uint64_t)block_size, (uint64_t) block_size, 
+                                   0, (int64_t) 0, &extents, &count), 0);
+    EXPECT_EQ(extents[0].length, 2 * block_size);
+    EXPECT_EQ(extents[1].length, 2 * block_size);
+    EXPECT_EQ(extents[2].length, 0);
+    EXPECT_EQ(count, 2);
+  }
+  alloc->shutdown();
+}
+
+TEST_P(AllocTest, test_alloc_min_max_alloc)
+{
+  int64_t block_size = 1024;
+  int64_t blocks = BitMapZone::get_total_blocks() * 2 * block_size;
+  int count = 0;
+
+  init_alloc(blocks, block_size);
+
+  /*
+   * Make sure we get all extents different when
+   * min_alloc_size == max_alloc_size
+   */
+  {
+    alloc->init_add_free(0, block_size * 4);
+    EXPECT_EQ(alloc->reserve(block_size * 4), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (4, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(4 * (uint64_t)block_size, (uint64_t) block_size, 
+                                   block_size, (int64_t) 0, &extents, &count), 0);
+    for (int i = 0; i < 4; i++) {
+      EXPECT_EQ(extents[i].length, block_size);
+    }
+    EXPECT_EQ(count, 4);
+  }
+
+
+  /*
+   * Make sure we get extents of length max_alloc size
+   * when max alloc size > min_alloc size
+   */
+  {
+    alloc->init_add_free(0, block_size * 4);
+    EXPECT_EQ(alloc->reserve(block_size * 4), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (2, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(4 * (uint64_t)block_size, (uint64_t) block_size, 
+                                   2 * block_size, (int64_t) 0, &extents, &count), 0);
+    for (int i = 0; i < 2; i++) {
+      EXPECT_EQ(extents[i].length, block_size * 2);
+    }
+    EXPECT_EQ(count, 2);
+  }
+
+  /*
+   * Allocate and free.
+   */
+  {
+    alloc->init_add_free(0, block_size * 16);
+    EXPECT_EQ(alloc->reserve(block_size * 16), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (8, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(16 * (uint64_t)block_size, (uint64_t) block_size, 
+                                   2 * block_size, (int64_t) 0, &extents, &count), 0);
+
+    EXPECT_EQ(count, 8);
+    for (int i = 0; i < 8; i++) {
+      EXPECT_EQ(extents[i].length, 2 * block_size);
+    }
+    EXPECT_EQ(alloc->release_extents(&extents, count), 0);
+  }
+}
+
+TEST_P(AllocTest, test_alloc_failure)
+{
+  int64_t block_size = 1024;
+  int64_t blocks = BitMapZone::get_total_blocks() * block_size;
+  int count = 0;
+
+  init_alloc(blocks, block_size);
+  {
+    alloc->init_add_free(0, block_size * 256);
+    alloc->init_add_free(block_size * 512, block_size * 256);
+
+    EXPECT_EQ(alloc->reserve(block_size * 512), 0);
+    std::vector<AllocExtent> extents = std::vector<AllocExtent> 
+                        (4, AllocExtent(0, 0));
+  
+    EXPECT_EQ(alloc->alloc_extents(512 * (uint64_t)block_size, (uint64_t) block_size * 256, 
+                                   block_size * 256, (int64_t) 0, &extents, &count), 0);
+    alloc->init_add_free(0, block_size * 256);
+    alloc->init_add_free(block_size * 512, block_size * 256);
+    EXPECT_EQ(alloc->reserve(block_size * 512), 0);
+    EXPECT_EQ(alloc->alloc_extents(512 * (uint64_t)block_size, (uint64_t) block_size * 512,
+                                   block_size * 512, (int64_t) 0, &extents, &count), -ENOSPC);
+  }
+}
+
+INSTANTIATE_TEST_CASE_P(
+  Allocator,
+  AllocTest,
+  ::testing::Values("stupid", "bitmap"));
+
+#else
+
+TEST(DummyTest, ValueParameterizedTestsAreNotSupportedOnThisPlatform) {}
+#endif
+
+int main(int argc, char **argv)
+{
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+  env_to_vec(args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <gtest/gtest.h>
 
-#define bmap_test_assert(x) EXPECT_EQ(true, (x))
+#define bmap_test_assert(x) ASSERT_EQ(true, (x))
 #define NUM_THREADS 16
 #define MAX_BLOCKS (1024 * 1024 * 1)
 
@@ -53,7 +53,6 @@ TEST(BitAllocator, test_bmap_iter)
   for (i = 0; i < num_items; i++) {
     (*arr)[i].init(i);
   }
-  //BitMapList<BmapEntityTmp> *list = new BitMapList<BmapEntityTmp>(arr, num_items, 0);
   BitMapEntityIter<BmapEntityTmp> iter = BitMapEntityIter<BmapEntityTmp>(arr, off, false);
 
   i = off;
@@ -330,7 +329,6 @@ TEST(BitAllocator, test_zone_alloc)
   zone = new BitMapZone(total_blocks, 0);
   lock = zone->lock_excl_try();
   bmap_test_assert(lock);
-  int64_t blocks[1024] = {0};
   for (int i = 0; i < zone->size(); i++) {
     allocated = zone->alloc_blocks(1, &start_block);
     bmap_test_assert(allocated == 1);
@@ -339,7 +337,12 @@ TEST(BitAllocator, test_zone_alloc)
     zone->free_blocks(i, 1);
   }
 
-  allocated = zone->alloc_blocks_dis(zone->size() / 2, 0, blocks);
+  int64_t blk_size = 1024;
+  std::vector<AllocExtent> extents = std::vector<AllocExtent>
+        (zone->size() / 2, AllocExtent(-1, -1));
+
+  ExtentList *block_list = new ExtentList(&extents, blk_size);
+  allocated = zone->alloc_blocks_dis(zone->size() / 2, 0, block_list);
   bmap_test_assert(allocated == zone->size() / 2);
 }
 
@@ -417,22 +420,28 @@ TEST(BitAllocator, test_bmap_alloc)
       alloc->free_blocks(i, 1);
     }
 
-    int64_t blocks[alloc->size() / 2];
-    memset(blocks, 0, sizeof(blocks));
-    allocated = alloc->alloc_blocks_dis(alloc->size()/2, blocks);
-    bmap_test_assert(allocated == alloc->size() / 2);
+		int64_t blk_size = 1024;
+		std::vector<AllocExtent> extents = std::vector<AllocExtent>
+					(alloc->size(), AllocExtent(-1, -1));
 
-    allocated = alloc->alloc_blocks_dis(1, blocks);
-    bmap_test_assert(allocated == 0);
+		ExtentList *block_list = new ExtentList(&extents, blk_size);
 
-    alloc->free_blocks(alloc->size()/2, 1);
-    allocated = alloc->alloc_blocks_dis(1, blocks);
+		allocated = alloc->alloc_blocks_dis(alloc->size()/2, block_list);
+		bmap_test_assert(allocated == alloc->size() / 2);
 
-    bmap_test_assert(allocated == 1);
-    bmap_test_assert(blocks[0] == alloc->size()/2);
+		block_list->reset();
+		allocated = alloc->alloc_blocks_dis(1, block_list);
+		bmap_test_assert(allocated == 0);
 
-    alloc->free_blocks(0, alloc->size());
-    delete alloc;
+		alloc->free_blocks(alloc->size()/2, 1);
+
+		block_list->reset();
+		allocated = alloc->alloc_blocks_dis(1, block_list);
+		bmap_test_assert(allocated == 1);
+
+		bmap_test_assert((int64_t) extents[0].offset == alloc->size()/2 * blk_size);
+
+		delete alloc;
 
     // unaligned zones
     total_blocks = zone_size * 2 + 11;
@@ -502,6 +511,49 @@ TEST(BitAllocator, test_bmap_alloc)
   g_ceph_context->_conf->apply_changes(NULL);
 }
 
+bool alloc_extents_max_block(BitAllocator *alloc,
+           int64_t max_alloc,
+           int64_t total_alloc)
+{
+  int64_t blk_size = 1;
+  int64_t allocated = 0;
+  int64_t verified = 0;
+  int64_t count = 0;
+  std::vector<AllocExtent> extents = std::vector<AllocExtent>
+        (total_alloc, AllocExtent(-1, -1));
+
+  ExtentList *block_list = new ExtentList(&extents, blk_size, max_alloc);
+
+  allocated = alloc->alloc_blocks_dis(total_alloc, block_list);
+  EXPECT_EQ(allocated, total_alloc);
+
+  max_alloc = total_alloc > max_alloc? max_alloc: total_alloc;
+
+  for (auto &p: extents) {
+    count++;
+    EXPECT_EQ(p.length,  max_alloc);
+    verified += p.length;
+    if (verified >= total_alloc) {
+      break;
+    }
+  }
+
+  EXPECT_EQ(total_alloc / max_alloc, count);
+  return true;
+}
+
+TEST(BitAllocator2, test_bmap_alloc)
+{
+  int64_t total_blocks = 1024 * 4;
+  int64_t zone_size = 1024;
+  BitAllocator *alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
+
+  alloc_extents_max_block(alloc, 1, 16);
+  alloc_extents_max_block(alloc, 4, 16);
+  alloc_extents_max_block(alloc, 16, 16);
+  alloc_extents_max_block(alloc, 32, 16);
+}
+
 void
 verify_blocks(int64_t num_blocks, int64_t *blocks)
 {
@@ -529,8 +581,9 @@ do_work(BitAllocator *alloc)
 
   while (num_iters--) {
     printf("Allocating in tid %d.\n", my_tid);
+    debug_assert(alloc->reserve_blocks(num_blocks));
     for (int i = 0; i < num_blocks; i++) {
-      alloced = alloc->alloc_blocks(1, &start_block);
+      alloced = alloc->alloc_blocks_res(1, &start_block);
       bmap_test_assert(alloced == 1);
       total_alloced++;
       allocated_blocks[i] = start_block;
@@ -546,14 +599,43 @@ do_work(BitAllocator *alloc)
   }
 }
 
+void
+do_work_dis(BitAllocator *alloc)
+{
+  int num_iters = 10;
+  int64_t alloced = 0;
+  int64_t num_blocks = alloc->size() / NUM_THREADS;
+
+  std::vector<AllocExtent> extents = std::vector<AllocExtent>
+        (num_blocks, AllocExtent(-1, -1));
+  ExtentList *block_list = new ExtentList(&extents, 4096);
+
+  while (num_iters--) {
+      debug_assert(alloc->reserve_blocks(num_blocks));
+      alloced = alloc->alloc_blocks_dis_res(num_blocks, block_list);
+      debug_assert(alloced == num_blocks);
+
+      debug_assert(alloc->is_allocated_dis(block_list, num_blocks));
+      alloc->free_blocks_dis(num_blocks, block_list);
+      block_list->reset();
+  }
+}
+
 int tid = 0;
+static bool cont = true;
+
 void *
 worker(void *args)
 {
   my_tid = __sync_fetch_and_add(&tid, 1);
   BitAllocator *alloc = (BitAllocator *) args;
   printf("Starting thread %d", my_tid);
-  do_work(alloc);
+  if (cont) {
+    do_work(alloc);
+  } else {
+    do_work_dis(alloc);
+  }
+
   return NULL;
 }
 
@@ -566,23 +648,22 @@ TEST(BitAllocator, test_bmap_alloc_concurrent)
   bmap_test_assert(total_blocks <= MAX_BLOCKS);
 
   BitAllocator *alloc = new BitAllocator(total_blocks, zone_size, CONCURRENT);
-  printf("Spawning %d threads for parallel test.....\n", NUM_THREADS);
 
-  for (int j = 0; j < NUM_THREADS; j++) {
-    if (pthread_create(&pthreads[j], NULL, worker, alloc)) {
-      printf("Unable to create worker thread.\n");
-      exit(0);
+  for (int k = 0; k < 2; k++) {
+    cont = k;
+    printf("Spawning %d threads for parallel test. Mode Cont = %d.....\n", NUM_THREADS, cont);
+    for (int j = 0; j < NUM_THREADS; j++) {
+      if (pthread_create(&pthreads[j], NULL, worker, alloc)) {
+        printf("Unable to create worker thread.\n");
+        exit(0);
+      }
+    }
+
+    for (int j = 0; j < NUM_THREADS; j++) {
+      pthread_join(pthreads[j], NULL);
     }
   }
 
-  for (int j = 0; j < NUM_THREADS; j++) {
-    pthread_join(pthreads[j], NULL);
-  }
-
-  // max_blks / num threads and free those. Make sure threads
-  // always gets blocks
-  // Do this with dis-contiguous and contiguous allocations
-  // do multithreaded allocation and check allocations are unique
 }
 
 int main(int argc, char **argv)

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -109,6 +109,12 @@ add_executable(unittest_bit_alloc
 add_ceph_unittest(unittest_bit_alloc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bit_alloc)
 target_link_libraries(unittest_bit_alloc os global)
 
+add_executable(unittest_alloc
+  Allocator_test.cc
+  )
+add_ceph_unittest(unittest_alloc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_alloc)
+target_link_libraries(unittest_alloc os global)
+
 # unittest_bluefs
 add_executable(unittest_bluefs
   test_bluefs.cc


### PR DESCRIPTION
This change does following changes:
1. Functionality to allocate blocks in terms of extents. Extent size controlled by min_alloc and max_alloc_size.
2. Change calls in BlueFS and BlueStore to allocate extents in single calls.
3. Add basic generic unit test cases for Allocators.

Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>