### PR TITLE
mon: remove the redundant cancel_probe_timeout function

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1828,8 +1828,6 @@ void Monitor::start_election()
   logger->inc(l_mon_num_elections);
   logger->inc(l_mon_election_call);
 
-  cancel_probe_timeout();
-
   clog->info() << "mon." << name << " calling new monitor election\n";
   elector.call_election();
 }


### PR DESCRIPTION
 mon: remove the redundant cancel_probe_timeout function

   In _reset function we have cancel once, so here is no need.

Signed-off-by: song baisen <song.baisen@zte.com.cn>