### PR TITLE
include/ceph_fs.h: guard `#define CEPH_SETATTR_*` with #ifndef

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -369,7 +369,7 @@ enum {
 
 extern const char *ceph_mds_op_name(int op);
 
-
+#ifndef CEPH_SETATTR_MODE
 #define CEPH_SETATTR_MODE	(1 << 0)
 #define CEPH_SETATTR_UID	(1 << 1)
 #define CEPH_SETATTR_GID	(1 << 2)
@@ -377,6 +377,7 @@ extern const char *ceph_mds_op_name(int op);
 #define CEPH_SETATTR_ATIME	(1 << 4)
 #define CEPH_SETATTR_SIZE	(1 << 5)
 #define CEPH_SETATTR_CTIME	(1 << 6)
+#endif
 #define CEPH_SETATTR_MTIME_NOW	(1 << 7)
 #define CEPH_SETATTR_ATIME_NOW	(1 << 8)
 


### PR DESCRIPTION
this silences the warnings like:

```
from
/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.0-513-gfe98b0b/src/java/native/libcephfs_jni.cc:33:
warning:
/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.0-513-gfe98b0b/src/include/ceph_fs.h:373:0:
"CEPH_SETATTR_MODE" redefined [enabled by default]
^
In file included from
/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.0-513-gfe98b0b/src/java/native/libcephfs_jni.cc:32:0:
/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.0-513-gfe98b0b/src/include/cephfs/libcephfs.h:106:0:
note: this is the location of the previous definition
^
```

Signed-off-by: Kefu Chai <kchai@redhat.com>