### PR TITLE
ceph-detect-init: fix the py3 test

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/gentoo/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/gentoo/__init__.py
@@ -10,11 +10,8 @@ def is_systemd():
     Detect whether systemd is running;
     WARNING: not mutually exclusive with openrc
     """
-    with open('/proc/1/comm', 'rb') as i:
-        for line in i:
-            if 'systemd' in line:
-                return True
-    return False
+    with open('/proc/1/comm') as i:
+        return 'systemd' in i.read()
 
 
 def is_openrc():

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -103,16 +103,22 @@ class TestCephDetectInit(testtools.TestCase):
             self.assertEqual(gentoo.is_openrc(), False)
 
     def test_gentoo_is_systemd(self):
+        import sys
+        if sys.version_info >= (3, 0):
+            mocked_fn = 'builtins.open'
+        else:
+            mocked_fn = '__builtin__.open'
+
         f = mock.mock_open(read_data='systemd')
-        with mock.patch('__main__.file', f, create=True) as m:
+        with mock.patch(mocked_fn, f, create=True) as m:
             self.assertEqual(gentoo.is_systemd(), True)
             m.assert_called_once_with('/proc/1/comm')
         f = mock.mock_open(read_data='init')
-        with mock.patch('__main__.file', f, create=True) as m:
+        with mock.patch(mocked_fn, f, create=True) as m:
             self.assertEqual(gentoo.is_systemd(), False)
             m.assert_called_once_with('/proc/1/comm')
         f = mock.mock_open(read_data='upstart')
-        with mock.patch('__main__.file', f, create=True) as m:
+        with mock.patch(mocked_fn, f, create=True) as m:
             self.assertEqual(gentoo.is_systemd(), False)
             m.assert_called_once_with('/proc/1/comm')
 

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -118,20 +118,20 @@ class TestCephDetectInit(testtools.TestCase):
 
     def test_gentoo(self):
         with mock.patch.multiple('ceph_detect_init.gentoo',
-                is_systemd=(lambda: True),
-                is_openrc=(lambda: True)):
+                                 is_systemd=(lambda: True),
+                                 is_openrc=(lambda: True)):
             self.assertEqual('openrc', gentoo.choose_init())
         with mock.patch.multiple('ceph_detect_init.gentoo',
-                is_systemd=(lambda: True),
-                is_openrc=(lambda: False)):
+                                 is_systemd=(lambda: True),
+                                 is_openrc=(lambda: False)):
             self.assertEqual('systemd', gentoo.choose_init())
         with mock.patch.multiple('ceph_detect_init.gentoo',
-                is_systemd=(lambda: False),
-                is_openrc=(lambda: True)):
+                                 is_systemd=(lambda: False),
+                                 is_openrc=(lambda: True)):
             self.assertEqual('openrc', gentoo.choose_init())
         with mock.patch.multiple('ceph_detect_init.gentoo',
-                is_systemd=(lambda: False),
-                is_openrc=(lambda: False)):
+                                 is_systemd=(lambda: False),
+                                 is_openrc=(lambda: False)):
             self.assertEqual('unknown', gentoo.choose_init())
 
     def test_get(self):


### PR DESCRIPTION
this fixes following failure:
```
testtools.testresult.real._StringException: Traceback (most recent call
last):
  File
"/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-detect-init/tests/test_all.py",
line 108, in test_gentoo_is_systemd
    self.assertEqual(gentoo.is_systemd(), True)
  File
"/home/jenkins-build/build/workspace/ceph-pull-requests/src/ceph-detect-init/ceph_detect_init/gentoo/__init__.py",
line 15, in is_systemd
    if 'systemd' in line:
TypeError: 'str' does not support the buffer interface
```

Signed-off-by: Kefu Chai <kchai@redhat.com>