### PR TITLE
doc: fix standby replay config

### DIFF
--- a/doc/cephfs/standby.rst
+++ b/doc/cephfs/standby.rst
@@ -166,12 +166,12 @@ of the other.
 ::
 
     [mds.a]
-    standby replay = true
-    standby for rank = 0
+    mds standby replay = true
+    mds standby for rank = 0
 
     [mds.b]
-    standby replay = true
-    standby for rank = 0
+    mds standby replay = true
+    mds standby for rank = 0
 
 Floating standby
 ~~~~~~~~~~~~~~~~
@@ -195,14 +195,14 @@ for the other filesystem.
 ::
 
     [mds.a]
-    standby for fscid = 1
+    mds standby for fscid = 1
 
     [mds.b]
-    standby for fscid = 1
+    mds standby for fscid = 1
 
     [mds.c]
-    standby for fscid = 2
+    mds standby for fscid = 2
 
     [mds.d]
-    standby for fscid = 2
+    mds standby for fscid = 2
 


### PR DESCRIPTION
I tried using these settings in tests without success. The correct config names
are prefixed with "mds".

Fixes: http://tracker.ceph.com/issues/16664

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>