### PR TITLE
msg/simple/Pipe:the returned value for do_recv unequal to zero

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2636,7 +2636,7 @@ ssize_t Pipe::buffered_recv(char *buf, size_t len, int flags)
 
 
   ssize_t got = do_recv(recv_buf, recv_max_prefetch, flags);
-  if (got <= 0) {
+  if (got < 0) {
     if (total_recv > 0)
       return total_recv;
 


### PR DESCRIPTION
the returned value for do_recv unequal to zero:
```c++
ssize_t Pipe::do_recv(char *buf, size_t len, int flags)
{
again:
  ssize_t got = ::recv( sd, buf, len, flags );
  if (got < 0) {
    if (errno == EINTR) {
      goto again;
    }
    ldout(msgr->cct, 10) << **func** << " socket " << sd << " returned "
             << got << " " << cpp_strerror(errno) << dendl;
    return -1;
  }
  if (got == 0) {
    return -1;
  }
  return got;
}
```

so here '=' can be removed
Signed-off-by: zhang.zezhu zhang.zezhu@zte.com.cn
