### PR TITLE
msg/simple/Pipe: eliminating casts for the comparing of len and recv_max_prefetch

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2554,7 +2554,7 @@ ssize_t Pipe::buffered_recv(char *buf, size_t len, int flags)
 
   /* nothing left in the prefetch buffer */
 
-  if (len > (size_t)recv_max_prefetch) {
+  if (len > recv_max_prefetch) {
     /* this was a large read, we don't prefetch for these */
     ssize_t ret = do_recv(buf, left, flags );
     if (ret < 0) {


### PR DESCRIPTION
the returned value type for len and recv_max_prefetch are both size_t, so in comparing for them should eliminate casts

Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>