### PR TITLE
cmake: disable -fvar-tracking-assignments for ceph_dencoder.cc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -684,6 +684,12 @@ add_subdirectory(ceph-disk)
 add_subdirectory(ceph-detect-init)
 
 ## dencoder
+CHECK_C_COMPILER_FLAG("-fvar-tracking-assignments" HAS_VTA)
+if(HAS_VTA)
+  set_source_files_properties(test/encoding/ceph_dencoder.cc
+    PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
+endif()
+
 set(dencoder_srcs
   test/encoding/ceph_dencoder.cc
   $<TARGET_OBJECTS:krbd_objs>


### PR DESCRIPTION
there are too many variables involved in main() of ceph_dencoder.cc, but
-fvar-tracking-assignments is enabled by default, when the compiler
finds that the number of variables exceeds the limit
"max-vartrack-size", it gives up, and tries again disabling this option.

this change avoids the recompilation of ceph_dencoder.cc and also silences
the warning of
```
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/encoding/ceph_dencoder.cc:
In function ‘int main(int, const char**)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/encoding/ceph_dencoder.cc:289:5:
note: variable tracking size limit exceeded with
-fvar-tracking-assignments, retrying without
 int main(int argc, const char **argv)
     ^
```

Signed-off-by: Kefu Chai <kchai@redhat.com>