### PR TITLE
os/bluestore: fix error handling of posix_fallocate()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2432,7 +2432,7 @@ int BlueStore::_setup_block_symlink_or_file(
   if (create)
     flags |= O_CREAT;
   if (epath.length()) {
-    if (!epath.compare(0, sizeof(SPDK_PREFIX)-1, SPDK_PREFIX)) {
+    if (!epath.compare(0, strlen(SPDK_PREFIX), SPDK_PREFIX)) {
       r = ::symlinkat(epath.c_str(), path_fd, name.c_str());
       if (r < 0) {
         r = -errno;
@@ -2447,7 +2447,7 @@ int BlueStore::_setup_block_symlink_or_file(
 	     << cpp_strerror(r) << dendl;
 	return r;
       }
-      string serial_number = epath.substr(sizeof(SPDK_PREFIX)-1);
+      string serial_number = epath.substr(strlen(SPDK_PREFIX));
       r = ::write(fd, serial_number.c_str(), serial_number.size());
       assert(r == (int)serial_number.size());
       dout(1) << __func__ << " created " << name << " file with " << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2483,12 +2483,11 @@ int BlueStore::_setup_block_symlink_or_file(
 	if (g_conf->bluestore_block_preallocate_file) {
 #ifdef HAVE_POSIX_FALLOCATE
 	  r = ::posix_fallocate(fd, 0, size);
-	  if (r < 0) {
-	    r = -errno;
+	  if (r) {
 	    derr << __func__ << " failed to prefallocate " << name << " file to "
 	      << size << ": " << cpp_strerror(r) << dendl;
 	    VOID_TEMP_FAILURE_RETRY(::close(fd));
-	    return r;
+	    return -r;
 	  }
 #else
 	  char data[1024*128];


### PR DESCRIPTION
 According to Linux man page:
    
 posix_fallocate() returns zero on success, or an error number on failure.
 Note that errno is not set.
    
 Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>