### PR TITLE
cmake changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,9 +382,13 @@ set(OperatingSystem "Mac OS X")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # enables testing and creates Make check command
+add_custom_target(tests
+  COMMENT "Building tests")
 enable_testing()
 set(CMAKE_CTEST_COMMAND ctest)
-add_custom_target(check COMMAND ${CMAKE_CTEST_COMMAND})
+add_custom_target(check
+  COMMAND ${CMAKE_CTEST_COMMAND}
+  DEPENDS tests)
 
 add_subdirectory(src)
 

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -15,6 +15,10 @@ function(add_ceph_test test_name test_path)
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
     PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.linux-x86_64-2.7:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
+  # none of the tests should take more than 1 hour to complete
+  set_property(TEST
+    ${test_name}
+    PROPERTY TIMEOUT 3600)
 endfunction()
 
 #sets uniform compiler flags and link libraries

--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -3,8 +3,8 @@
 #adds makes target/script into a test, test to check target, sets necessary environment variables
 function(add_ceph_test test_name test_path)
   add_test(NAME ${test_name} COMMAND ${test_path})
-  add_dependencies(check ${test_name})
-  set_property(TEST 
+  add_dependencies(tests ${test_name})
+  set_property(TEST
     ${test_name}
     PROPERTY ENVIRONMENT 
     CEPH_ROOT=${CMAKE_SOURCE_DIR}

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -68,8 +68,8 @@ function run() {
     if test -x ./do_cmake.sh ; then
         $DRY_RUN ./do_cmake.sh || return 1
         cd build
-        export CTEST_OUTPUT_ON_FAILURE=1 CTEST_PARALLEL_LEVEL=$(get_processors)
-        $DRY_RUN make $BUILD_MAKEOPTS check || return 1
+        $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
+        $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure || return 1
     else
         $DRY_RUN ./autogen.sh || return 1
         $DRY_RUN ./configure "$@"  --with-librocksdb-static --disable-static --with-radosgw --with-debug --without-lttng \

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -69,7 +69,8 @@ function run() {
         $DRY_RUN ./do_cmake.sh || return 1
         cd build
         $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
-        $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure || return 1
+        $DRY_RUN ctest -L Racing -j1 --output-on-failure || return 1
+        $DRY_RUN ctest -LE Racing $CHECK_MAKEOPTS --output-on-failure || return 1
     else
         $DRY_RUN ./autogen.sh || return 1
         $DRY_RUN ./configure "$@"  --with-librocksdb-static --disable-static --with-radosgw --with-debug --without-lttng \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -491,7 +491,7 @@ endif(ENABLE_SHARED)
 add_library(common STATIC ${libcommon_files}
   $<TARGET_OBJECTS:mon_common_objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>)
-target_link_libraries(common ${CMAKE_DL_LIBS})
+target_link_libraries(common ${CRYPTO_LIBS} ${CMAKE_DL_LIBS})
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/common/version.cc
@@ -525,8 +525,7 @@ set(global_common_files
 add_library(global_common_objs OBJECT ${global_common_files})
 add_library(global STATIC ${libglobal_srcs}
   $<TARGET_OBJECTS:global_common_objs>)
-target_link_libraries(global common ${CMAKE_THREAD_LIBS_INIT} ${CRYPTO_LIBS}
-  ${EXTRALIBS})
+target_link_libraries(global common ${CMAKE_THREAD_LIBS_INIT} ${EXTRALIBS})
 
 # rados object classes
 add_subdirectory(cls)
@@ -1413,7 +1412,8 @@ if(${WITH_RADOSGW})
   target_include_directories(rgw_a PUBLIC ${FCGI_INCLUDE_DIR})
   target_link_libraries(rgw_a librados cls_rgw_client cls_refcount_client
     cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
-    cls_replica_log_client cls_user_client curl global expat ${OPENLDAP_LIBS})
+    cls_replica_log_client cls_user_client curl global expat ${OPENLDAP_LIBS}
+    ${CRYPTO_LIBS})
 
   set(radosgw_srcs
     rgw/rgw_fcgi_process.cc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1029,44 +1029,7 @@ set_target_properties(cephfstool PROPERTIES OUTPUT_NAME cephfs)
 install(TARGETS cephfstool DESTINATION bin)
 
 add_subdirectory(compressor)
-
-add_executable(ceph-client-debug tools/ceph-client-debug.cc)
-target_link_libraries(ceph-client-debug cephfs librados global common)
-install(TARGETS ceph-client-debug DESTINATION bin)
-
-add_executable(ceph-kvstore-tool tools/ceph_kvstore_tool.cc)
-target_link_libraries(ceph-kvstore-tool os global ${UNITTEST_CXX_FLAGS})
-install(TARGETS ceph-kvstore-tool DESTINATION bin)
-
-set(ceph_conf_srcs
-  tools/ceph_conf.cc)
-add_executable(ceph-conf ${ceph_conf_srcs})
-target_link_libraries(ceph-conf global)
-install(TARGETS ceph-conf DESTINATION bin)
-
-set(monmaptool_srcs
-  tools/monmaptool.cc)
-add_executable(monmaptool ${monmaptool_srcs})
-target_link_libraries(monmaptool global)
-install(TARGETS monmaptool DESTINATION bin)
-
-set(osdomaptool_srcs
-  tools/osdmaptool.cc)
-add_executable(osdmaptool ${osdomaptool_srcs})
-target_link_libraries(osdmaptool global)
-install(TARGETS osdmaptool DESTINATION bin)
-
-set(ceph_psim_srcs
-  tools/psim.cc)
-add_executable(ceph_psim ${ceph_psim_srcs})
-target_link_libraries(ceph_psim global)
-install(TARGETS ceph_psim DESTINATION bin)
-
-set(ceph_authtool_srcs
-  tools/ceph_authtool.cc)
-add_executable(ceph-authtool ${ceph_authtool_srcs})
-target_link_libraries(ceph-authtool global ${EXTRALIBS} ${CRYPTO_LIBS})
-install(TARGETS ceph-authtool DESTINATION bin)
+add_subdirectory(tools)
 
 configure_file(${CMAKE_SOURCE_DIR}/src/ceph-coverage.in
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/ceph-coverage @ONLY)
@@ -1204,37 +1167,6 @@ if(${WITH_RBD})
     include/rbd/librbd.hpp
     DESTINATION include/rbd)
 
-  add_executable(rbd-nbd tools/rbd_nbd/rbd-nbd.cc
-    $<TARGET_OBJECTS:parse_secret_objs>)
-  target_link_libraries(rbd-nbd librbd librados global keyutils
-    ${Boost_REGEX_LIBRARY})
-
-  set(rbd_mirror_internal
-    tools/rbd_mirror/ClusterWatcher.cc
-    tools/rbd_mirror/ImageReplayer.cc
-    tools/rbd_mirror/ImageDeleter.cc
-    tools/rbd_mirror/ImageSync.cc
-    tools/rbd_mirror/ImageSyncThrottler.cc
-    tools/rbd_mirror/Mirror.cc
-    tools/rbd_mirror/PoolWatcher.cc
-    tools/rbd_mirror/Replayer.cc
-    tools/rbd_mirror/Threads.cc
-    tools/rbd_mirror/types.cc
-    tools/rbd_mirror/image_replayer/BootstrapRequest.cc
-    tools/rbd_mirror/image_replayer/CloseImageRequest.cc
-    tools/rbd_mirror/image_replayer/CreateImageRequest.cc
-    tools/rbd_mirror/image_replayer/OpenImageRequest.cc
-    tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
-    tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
-    tools/rbd_mirror/image_sync/ImageCopyRequest.cc
-    tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
-    tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
-    tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
-    tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
-    tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc)
-  add_library(rbd_mirror_internal STATIC
-    ${rbd_mirror_internal})
-
   if(WITH_FUSE)
     add_executable(rbd-fuse
       rbd_fuse/rbd-fuse.cc)
@@ -1243,70 +1175,6 @@ if(${WITH_RBD})
     install(TARGETS rbd-fuse DESTINATION bin)
   endif()
 
-  add_executable(rbd-mirror
-    tools/rbd_mirror/main.cc
-    common/ContextCompletion.cc)
-  target_link_libraries(rbd-mirror
-    rbd_mirror_internal
-    rbd_internal
-    rbd_api
-    rbd_types
-    journal
-    librados
-    osdc
-    cls_rbd_client
-    cls_lock_client
-    cls_journal_client
-    global)
-
-  set(rbd_srcs
-    tools/rbd/rbd.cc
-    tools/rbd/ArgumentTypes.cc
-    tools/rbd/IndentStream.cc
-    tools/rbd/OptionPrinter.cc
-    tools/rbd/Shell.cc
-    tools/rbd/Utils.cc
-    tools/rbd/action/Bench.cc
-    tools/rbd/action/Children.cc
-    tools/rbd/action/Clone.cc
-    tools/rbd/action/Copy.cc
-    tools/rbd/action/Create.cc
-    tools/rbd/action/Diff.cc
-    tools/rbd/action/DiskUsage.cc
-    tools/rbd/action/Export.cc
-    tools/rbd/action/ExportDiff.cc
-    tools/rbd/action/Feature.cc
-    tools/rbd/action/Flatten.cc
-    tools/rbd/action/Group.cc
-    tools/rbd/action/ImageMeta.cc
-    tools/rbd/action/Import.cc
-    tools/rbd/action/ImportDiff.cc
-    tools/rbd/action/Info.cc
-    tools/rbd/action/Journal.cc
-    tools/rbd/action/Kernel.cc
-    tools/rbd/action/List.cc
-    tools/rbd/action/Lock.cc
-    tools/rbd/action/MergeDiff.cc
-    tools/rbd/action/MirrorPool.cc
-    tools/rbd/action/MirrorImage.cc
-    tools/rbd/action/Nbd.cc
-    tools/rbd/action/ObjectMap.cc
-    tools/rbd/action/Remove.cc
-    tools/rbd/action/Rename.cc
-    tools/rbd/action/Resize.cc
-    tools/rbd/action/Snap.cc
-    tools/rbd/action/Status.cc
-    tools/rbd/action/Watch.cc)
-  add_executable(rbd ${rbd_srcs}
-    $<TARGET_OBJECTS:common_util_obj>
-    $<TARGET_OBJECTS:parse_secret_objs>
-    $<TARGET_OBJECTS:common_texttable_obj>
-    $<TARGET_OBJECTS:krbd_objs>)
-  set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
-  target_link_libraries(rbd librbd librados global common keyutils udev
-    ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
-    ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
-  install(TARGETS rbd rbd-nbd rbd-mirror DESTINATION bin)
   install(PROGRAMS
     ${CMAKE_SOURCE_DIR}/src/ceph-rbdnamer
     ${CMAKE_SOURCE_DIR}/src/rbd-replay-many

--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_target(ceph-detect-init
   ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --disable-pip-version-check --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-detect-init
   COMMENT "ceph-detect-init is being created")
+add_dependencies(tests ceph-detect-init)
 
 include(Distutils)
 distutils_install_module(ceph_detect_init)

--- a/src/ceph-detect-init/CMakeLists.txt
+++ b/src/ceph-detect-init/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtua
 add_custom_target(ceph-detect-init
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CEPH_DETECT_INIT_VIRTUALENV} &&
-  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --disable-pip-version-check --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
+  ${CEPH_DETECT_INIT_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-detect-init/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-detect-init
   COMMENT "ceph-detect-init is being created")
 add_dependencies(tests ceph-detect-init)

--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -25,8 +25,15 @@ fi
 # run from the ceph-detect-init directory or from its parent
 : ${CEPH_DETECT_INIT_VIRTUALENV:=/tmp/ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init
+
+if [ -e tox.ini ]; then
+    TOX_PATH=`readlink -f tox.ini`
+else
+    TOX_PATH=`readlink -f $(dirname $0)/tox.ini`
+fi
+
 source ${CEPH_DETECT_INIT_VIRTUALENV}/bin/activate
-tox > ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out 2>&1
+tox -c ${TOX_PATH} > ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out 2>&1
 status=$?
 grep -v InterpreterNotFound < ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out
 exit $status

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -6,6 +6,7 @@ add_custom_target(ceph-disk
   ${CEPH_DISK_VIRTUALENV}/bin/pip install --disable-pip-version-check --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-disk
   COMMENT "ceph-disk is being created")
+add_dependencies(tests ceph-disk)
 
 include(Distutils)
 distutils_install_module(ceph_disk

--- a/src/ceph-disk/CMakeLists.txt
+++ b/src/ceph-disk/CMakeLists.txt
@@ -3,7 +3,7 @@ set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 add_custom_target(ceph-disk
   COMMAND
   ${CMAKE_SOURCE_DIR}/src/tools/setup-virtualenv.sh ${CEPH_DISK_VIRTUALENV} &&
-  ${CEPH_DISK_VIRTUALENV}/bin/pip install --disable-pip-version-check --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
+  ${CEPH_DISK_VIRTUALENV}/bin/pip install --no-index --use-wheel --find-links=file:${CMAKE_SOURCE_DIR}/src/ceph-disk/wheelhouse -e .
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/ceph-disk
   COMMENT "ceph-disk is being created")
 add_dependencies(tests ceph-disk)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -1,8 +1,5 @@
 add_executable(ceph_rgw_jsonparser
-  rgw_jsonparser.cc
-  rgw_common.cc
-  rgw_env.cc
-  rgw_json_enc.cc)
+  rgw_jsonparser.cc)
 target_link_libraries(ceph_rgw_jsonparser
   rgw_a
   global)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -478,7 +478,7 @@ target_link_libraries(ceph_test_get_blkdev_size
 #make check starts here
 
 #following dependencies are run inside make check unit tests
-add_dependencies(check 
+add_dependencies(tests
   ceph-mon
   ceph
   ceph-authtool

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -521,10 +521,7 @@ add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
 add_ceph_test(unittest_bufferlist.sh ${CMAKE_SOURCE_DIR}/src/unittest_bufferlist.sh)
 
 add_test(NAME run-tox-ceph-disk COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-disk/run-tox.sh)
-add_dependencies(check run-tox-ceph-disk)
-
-add_test(NAME run-tox-ceph-detect-init COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-detect-init/run-tox.sh WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src)
-add_dependencies(check run-tox-ceph-detect-init)
+add_test(NAME run-tox-ceph-detect-init COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-detect-init/run-tox.sh)
 
 set(CEPH_DISK_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-disk-virtualenv)
 set(CEPH_DETECT_INIT_VIRTUALENV ${CEPH_BUILD_VIRTUALENV}/ceph-detect-init-virtualenv)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -507,9 +507,12 @@ add_dependencies(tests
   cython_modules)
 
 add_ceph_test(test-ceph-helpers.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-helpers.sh)
+add_ceph_test(ceph_objectstore_tool.py ${CMAKE_CURRENT_SOURCE_DIR}/ceph_objectstore_tool.py)
+set_property(TEST test-ceph-helpers.sh ceph_objectstore_tool.py
+  PROPERTY LABELS Racing LongRunning)
+
 add_ceph_test(erasure-decode-non-regression.sh ${CMAKE_SOURCE_DIR}/qa/workunits/erasure-code/encode-decode-non-regression.sh)
 
-add_ceph_test(ceph_objectstore_tool.py ${CMAKE_CURRENT_SOURCE_DIR}/ceph_objectstore_tool.py)
 add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
 add_ceph_test(cephtool-test-mon.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mon.sh)
 add_ceph_test(cephtool-test-osd.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-osd.sh)

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -1,0 +1,38 @@
+add_executable(ceph-client-debug ceph-client-debug.cc)
+target_link_libraries(ceph-client-debug cephfs librados global common)
+install(TARGETS ceph-client-debug DESTINATION bin)
+
+add_executable(ceph-kvstore-tool ceph_kvstore_tool.cc)
+target_link_libraries(ceph-kvstore-tool os global ${UNITTEST_CXX_FLAGS})
+install(TARGETS ceph-kvstore-tool DESTINATION bin)
+
+set(ceph_conf_srcs ceph_conf.cc)
+add_executable(ceph-conf ${ceph_conf_srcs})
+target_link_libraries(ceph-conf global)
+install(TARGETS ceph-conf DESTINATION bin)
+
+set(monmaptool_srcs monmaptool.cc)
+add_executable(monmaptool ${monmaptool_srcs})
+target_link_libraries(monmaptool global)
+install(TARGETS monmaptool DESTINATION bin)
+
+set(osdomaptool_srcs osdmaptool.cc)
+add_executable(osdmaptool ${osdomaptool_srcs})
+target_link_libraries(osdmaptool global)
+install(TARGETS osdmaptool DESTINATION bin)
+
+set(ceph_psim_srcs psim.cc)
+add_executable(ceph_psim ${ceph_psim_srcs})
+target_link_libraries(ceph_psim global)
+install(TARGETS ceph_psim DESTINATION bin)
+
+set(ceph_authtool_srcs ceph_authtool.cc)
+add_executable(ceph-authtool ${ceph_authtool_srcs})
+target_link_libraries(ceph-authtool global ${EXTRALIBS} ${CRYPTO_LIBS})
+install(TARGETS ceph-authtool DESTINATION bin)
+
+if(WITH_RBD)
+  add_subdirectory(rbd)
+  add_subdirectory(rbd_mirror)
+  add_subdirectory(rbd_nbd)
+endif(WITH_RBD)

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -1,0 +1,48 @@
+set(rbd_srcs
+  rbd.cc
+  ArgumentTypes.cc
+  IndentStream.cc
+  OptionPrinter.cc
+  Shell.cc
+  Utils.cc
+  action/Bench.cc
+  action/Children.cc
+  action/Clone.cc
+  action/Copy.cc
+  action/Create.cc
+  action/Diff.cc
+  action/DiskUsage.cc
+  action/Export.cc
+  action/ExportDiff.cc
+  action/Feature.cc
+  action/Flatten.cc
+  action/Group.cc
+  action/ImageMeta.cc
+  action/Import.cc
+  action/ImportDiff.cc
+  action/Info.cc
+  action/Journal.cc
+  action/Kernel.cc
+  action/List.cc
+  action/Lock.cc
+  action/MergeDiff.cc
+  action/MirrorPool.cc
+  action/MirrorImage.cc
+  action/Nbd.cc
+  action/ObjectMap.cc
+  action/Remove.cc
+  action/Rename.cc
+  action/Resize.cc
+  action/Snap.cc
+  action/Status.cc
+  action/Watch.cc)
+add_executable(rbd ${rbd_srcs}
+  $<TARGET_OBJECTS:common_util_obj>
+  $<TARGET_OBJECTS:parse_secret_objs>
+  $<TARGET_OBJECTS:common_texttable_obj>
+  $<TARGET_OBJECTS:krbd_objs>)
+set_target_properties(rbd PROPERTIES OUTPUT_NAME rbd)
+target_link_libraries(rbd librbd librados global common keyutils udev
+  ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+install(TARGETS rbd DESTINATION bin)

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -1,0 +1,42 @@
+set(rbd_mirror_internal
+  ClusterWatcher.cc
+  ImageReplayer.cc
+  ImageDeleter.cc
+  ImageSync.cc
+  ImageSyncThrottler.cc
+  Mirror.cc
+  PoolWatcher.cc
+  Replayer.cc
+  Threads.cc
+  types.cc
+  image_replayer/BootstrapRequest.cc
+  image_replayer/CloseImageRequest.cc
+  image_replayer/CreateImageRequest.cc
+  image_replayer/OpenImageRequest.cc
+  image_replayer/OpenLocalImageRequest.cc
+  image_replayer/ReplayStatusFormatter.cc
+  image_sync/ImageCopyRequest.cc
+  image_sync/ObjectCopyRequest.cc
+  image_sync/SnapshotCopyRequest.cc
+  image_sync/SnapshotCreateRequest.cc
+  image_sync/SyncPointCreateRequest.cc
+  image_sync/SyncPointPruneRequest.cc)
+add_library(rbd_mirror_internal STATIC
+  ${rbd_mirror_internal})
+
+add_executable(rbd-mirror
+  main.cc
+  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
+target_link_libraries(rbd-mirror
+  rbd_mirror_internal
+  rbd_internal
+  rbd_api
+  rbd_types
+  journal
+  librados
+  osdc
+  cls_rbd_client
+  cls_lock_client
+  cls_journal_client
+  global)
+install(TARGETS rbd-mirror DESTINATION bin)

--- a/src/tools/rbd_nbd/CMakeLists.txt
+++ b/src/tools/rbd_nbd/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_executable(rbd-nbd rbd-nbd.cc
+  $<TARGET_OBJECTS:parse_secret_objs>)
+target_link_libraries(rbd-nbd librbd librados global keyutils
+  ${Boost_REGEX_LIBRARY})
+install(TARGETS rbd-nbd DESTINATION bin)

--- a/src/tools/setup-virtualenv.sh
+++ b/src/tools/setup-virtualenv.sh
@@ -20,14 +20,28 @@ rm -fr $DIR
 mkdir -p $DIR
 virtualenv --python python2.7 $DIR
 . $DIR/bin/activate
+
+if pip --help | grep -q disable-pip-version-check; then
+    DISABLE_PIP_VERSION_CHECK=--disable-pip-version-check
+else
+    DISABLE_PIP_VERSION_CHECK=
+fi
+
 # older versions of pip will not install wrap_console scripts
 # when using wheel packages
-pip --disable-pip-version-check --log $DIR/log.txt install --upgrade 'pip >= 6.1'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install --upgrade 'pip >= 6.1'
+
+if pip --help | grep -q disable-pip-version-check; then
+    DISABLE_PIP_VERSION_CHECK=--disable-pip-version-check
+else
+    DISABLE_PIP_VERSION_CHECK=
+fi
+
 if test -d wheelhouse ; then
     export NO_INDEX=--no-index
 fi
 
-pip --disable-pip-version-check --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
+pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse 'tox >=1.9'
 if test -f requirements.txt ; then
-    pip --disable-pip-version-check --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
+    pip $DISABLE_PIP_VERSION_CHECK --log $DIR/log.txt install $NO_INDEX --use-wheel --find-links=file://$(pwd)/wheelhouse -r requirements.txt
 fi


### PR DESCRIPTION
this changeset addresses following issues

- silence the "no such option: --disable-pip-version-check" warnings
- "make tests all" for preparing the "make test" // yeah, tests + all builds more artifacts than what is actually needed for "make test", we will fix this later
- run tests in two steps as a workaround of the annoying jenkins "make check" timeout 
- cmake cleanup