### PR TITLE
mds/MDSMap: add 'fsid' set to MDSMap

### DIFF
--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -129,6 +129,7 @@ void MDSMap::mds_info_t::generate_test_instances(list<mds_info_t*>& ls)
 void MDSMap::dump(Formatter *f) const
 {
   f->dump_int("epoch", epoch);
+  f->dump_stream("fsid") << get_fsid();
   f->dump_unsigned("flags", flags);
   f->dump_unsigned("ever_allowed_features", ever_allowed_features);
   f->dump_unsigned("explicitly_allowed_features", explicitly_allowed_features);
@@ -206,6 +207,7 @@ void MDSMap::print(ostream& out) const
 {
   out << "fs_name\t" << fs_name << "\n";
   out << "epoch\t" << epoch << "\n";
+  out << "fsid\t" << get_fsid() << "\n";
   out << "flags\t" << hex << flags << dec << "\n";
   out << "created\t" << created << "\n";
   out << "modified\t" << modified << "\n";
@@ -556,7 +558,7 @@ void MDSMap::encode(bufferlist& bl, uint64_t features) const
   ::encode(cas_pool, bl);
 
   // kclient ignores everything from here
-  __u16 ev = 10;
+  __u16 ev = 11;
   ::encode(ev, bl);
   ::encode(compat, bl);
   ::encode(metadata_pool, bl);
@@ -575,6 +577,7 @@ void MDSMap::encode(bufferlist& bl, uint64_t features) const
   ::encode(enabled, bl);
   ::encode(fs_name, bl);
   ::encode(damaged, bl);
+  ::encode(fsid, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -678,6 +681,9 @@ void MDSMap::decode(bufferlist::iterator& p)
 
   if (ev >= 9) {
     ::decode(damaged, p);
+  }
+  if (ev >= 11) {
+    ::decode(fsid, p);
   }
   DECODE_FINISH(p);
 }

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -163,6 +163,7 @@ public:
 protected:
   // base map
   epoch_t epoch;
+  uuid_d fsid;
   bool enabled;
   std::string fs_name;
   uint32_t flags;        // flags
@@ -230,8 +231,9 @@ public:
       ever_allowed_features(0),
       explicitly_allowed_features(0),
       inline_data_enabled(false),
-      cached_up_features(0)
-  { }
+      cached_up_features(0) {
+    memset(&fsid, 0, sizeof(fsid));
+  }
 
   bool get_inline_data_enabled() { return inline_data_enabled; }
   void set_inline_data_enabled(bool enabled) { inline_data_enabled = enabled; }
@@ -274,6 +276,7 @@ public:
   bool allows_dirfrags() const { return test_flag(CEPH_MDSMAP_ALLOW_DIRFRAGS); }
 
   epoch_t get_epoch() const { return epoch; }
+  const uuid_d& get_fsid() const { return fsid; }
   void inc_epoch() { epoch++; }
 
   bool get_enabled() const { return enabled; }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -101,6 +101,7 @@ void MDSMonitor::create_new_fs(FSMap &fsm, const std::string &name,
   fs->mds_map.session_timeout = g_conf->mds_session_timeout;
   fs->mds_map.session_autoclose = g_conf->mds_session_autoclose;
   fs->mds_map.enabled = true;
+  fs->mds_map.fsid = mon->monmap->fsid;
   if (mon->get_quorum_features() & CEPH_FEATURE_SERVER_JEWEL) {
     fs->fscid = fsm.next_filesystem_id++;
     // ANONYMOUS is only for upgrades from legacy mdsmaps, we should

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2204,7 +2204,7 @@ int MDSMonitor::filesystem_command(
 	 << ") to deactivate";
     } else if (fs->mds_map.get_num_in_mds() <= size_t(fs->mds_map.get_max_mds())) {
       r = -EBUSY;
-      ss << "must decrease max_mds or else MDS will immediately reactivate";
+      ss << "must decrease max_mds ("<< pending_mdsmap.get_max_mds() << ") or else MDS will immediately reactivate";
     } else {
       r = 0;
       mds_gid_t gid = fs->mds_map.up.at(role.rank);


### PR DESCRIPTION
To track which cluster of MDSMap by the 'fsid';
add display max_mds when run "ceph mds stop"

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>