### PR TITLE
msg/async/Event: fix valgrind issue init "owner" to zero

### DIFF
--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -113,7 +113,7 @@ class EventCenter {
   CephContext *cct;
   int nevent;
   // Used only to external event
-  pthread_t owner;
+  pthread_t owner = 0;
   std::mutex external_lock;
   std::atomic_ulong external_num_events;
   deque<EventCallbackRef> external_events;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16685
Signed-off-by: Haomai Wang <haomai@xsky.com>