### PR TITLE
ObjectCacher: fix last_write check in bh_write_adjacencies()

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -888,7 +888,7 @@ void ObjectCacher::bh_write_adjacencies(BufferHead *bh, ceph::real_time cutoff,
     BufferHead *obh = *p;
     if (obh->ob != bh->ob)
       break;
-    if (obh->is_dirty() && obh->last_write < cutoff) {
+    if (obh->is_dirty() && obh->last_write <= cutoff) {
       blist.push_back(obh);
       ++count;
       total_len += obh->length();
@@ -903,7 +903,7 @@ void ObjectCacher::bh_write_adjacencies(BufferHead *bh, ceph::real_time cutoff,
     BufferHead *obh = *it;
     if (obh->ob != bh->ob)
       break;
-    if (obh->is_dirty() && obh->last_write < cutoff) {
+    if (obh->is_dirty() && obh->last_write <= cutoff) {
       blist.push_front(obh);
       ++count;
       total_len += obh->length();
@@ -1778,7 +1778,7 @@ void ObjectCacher::flusher_entry()
       int max = MAX_FLUSH_UNDER_LOCK;
       while ((bh = static_cast<BufferHead*>(bh_lru_dirty.
 					    lru_get_next_expire())) != 0 &&
-	     bh->last_write < cutoff &&
+	     bh->last_write <= cutoff &&
 	     max > 0) {
 	ldout(cct, 10) << "flusher flushing aged dirty bh " << *bh << dendl;
 	if (scattered_write) {


### PR DESCRIPTION
Make the last_write check in bh_write_adjacencies() match corresponding
check in flush().

Fixes: http://tracker.ceph.com/issues/16610
Signed-off-by: Yan, Zheng <zyan@redhat.com>