### PR TITLE
qa/workunits/cephtool/test.sh: s/TMPDIR/TEMP_DIR/

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -149,7 +149,7 @@ function ceph_watch_start()
 	whatch_opt=--watch-$1
     fi
 
-    CEPH_WATCH_FILE=${TMPDIR}/CEPH_WATCH_$$
+    CEPH_WATCH_FILE=${TEMP_DIR}/CEPH_WATCH_$$
     ceph $whatch_opt > $CEPH_WATCH_FILE &
     CEPH_WATCH_PID=$!
 
@@ -1760,7 +1760,7 @@ function test_mon_crushmap_validation()
   local map=$TEMP_DIR/map
   ceph osd getcrushmap -o $map
 
-  local crushtool_path="${TMPDIR}/crushtool"
+  local crushtool_path="${TEMP_DIR}/crushtool"
   touch "${crushtool_path}"
   chmod +x "${crushtool_path}"
   local crushtool_path_old=`ceph-conf --show-config-value crushtool`

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -36,7 +36,7 @@ function expect_false()
 TEMP_DIR=$(mktemp -d cephtool.XXX)
 trap "rm -fr $TEMP_DIR" 0
 
-TMPFILE=$(mktemp -p $TEMP_DIR test_invalid.XXX)
+TMPFILE=$(mktemp $TEMP_DIR/test_invalid.XXX)
 
 #
 # retry_eagain max cmd args ...

--- a/src/test/objectstore/run_seed_to_range.sh
+++ b/src/test/objectstore/run_seed_to_range.sh
@@ -12,7 +12,7 @@ mydir=`dirname $0`
 for f in `seq $from $to`
 do
     if ! $mydir/run_seed_to.sh $seed $f; then
-	if [ -d $dir ]; then
+	if [ -d "$dir" ]; then
 	    echo copying evidence to $dir
 	    cp -a . $dir
 	else


### PR DESCRIPTION
mktemp -p is not supported on FreeBSD

Signed-off-by: Kefu Chai <kchai@redhat.com>