### PR TITLE
mon/osdmonitor: fix incorrect output of "osd df" due to osd out

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -808,8 +808,15 @@ protected:
 
   bool get_bucket_utilization(int id, int64_t* kb, int64_t* kb_used,
 			      int64_t* kb_avail) const {
-    if (id >= 0)
+    if (id >= 0) {
+      if (osdmap->is_out(id)) {
+        *kb = 0;
+        *kb_used = 0;
+        *kb_avail = 0;
+        return true;
+      }
       return get_osd_utilization(id, kb, kb_used, kb_avail);
+    }
 
     *kb = 0;
     *kb_used = 0;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -817,7 +817,7 @@ protected:
 
     for (int k = osdmap->crush->get_bucket_size(id) - 1; k >= 0; k--) {
       int item = osdmap->crush->get_bucket_item(id, k);
-      int64_t kb_i = 0, kb_used_i = 0, kb_avail_i;
+      int64_t kb_i = 0, kb_used_i = 0, kb_avail_i = 0;
       if (!get_bucket_utilization(item, &kb_i, &kb_used_i, &kb_avail_i))
 	return false;
       *kb += kb_i;


### PR DESCRIPTION
 If an osd is automatically marked as out, the output of "osd df"
    is not right, as follow:
    
    -5 10.00999        -  5586G  2989G  2596G     0    0     host ceph192-9-9-8
    11  0.90999  1.00000   931G   542G   388G 58.25 0.99         osd.11
    14  0.90999  1.00000   931G   530G   400G 56.97 0.97         osd.14
    20  0.90999  1.00000   931G   716G   214G 76.99 1.31         osd.20
    22  0.90999  1.00000   931G   477G   453G 51.29 0.87         osd.22
    26  0.90999        0      0      0      0     0    0         osd.26
    28  0.90999  1.00000   931G   587G   343G 63.09 1.07         osd.28
    30  0.90999  1.00000   931G   602G   328G 64.75 1.10         osd.30
    16  0.90999  1.00000   931G   589G   341G 63.34 1.08         osd.16
    18  0.90999  1.00000   931G   530G   400G 56.93 0.97         osd.18
    24  0.90999  1.00000   931G   202G   728G 21.77 0.37         osd.24
    32  0.90999  1.00000   931G   477G   454G 51.23 0.87         osd.32

Two problems are identified from the above output:

1. the total capacity(total, total used, total avial) 
only includes osd.32, osd.24, osd.18, osd.16, osd.30, osd.28, and other
healthy osds such as osd.11, osd.14 etc. are excluded.

2. the average utilization/deviation are forced resetted.

Fixes: http://tracker.ceph.com/issues/16706