### PR TITLE
[DNM] hammer: mon/Monitor: clear routed_requests after resend

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3203,20 +3203,21 @@ void Monitor::resend_routed_requests()
       dout(10) << " requeue for self tid " << rr->tid << " " << *req << dendl;
       req->set_connection(rr->con);
       retry.push_back(new C_RetryMessage(this, req));
-      delete rr;
     } else {
       dout(10) << " resend to mon." << mon << " tid " << rr->tid << " " << *req << dendl;
       MForward *forward = new MForward(rr->tid, req, rr->con_features,
 				       rr->session->caps);
       forward->client = rr->client_inst;
       forward->set_priority(req->get_priority());
+      forward->entity_name = rr->session->entity_name;
       messenger->send_message(forward, monmap->get_inst(mon));
     }
+    delete rr;
   }
-  if (mon == rank) {
-    routed_requests.clear();
+  routed_requests.clear();
+
+  if (mon == rank)
     finish_contexts(g_ceph_context, retry);
-  }
 }
 
 void Monitor::remove_session(MonSession *s)


### PR DESCRIPTION
When monitor which is not the leader, gets message from
e.g. MDS, it routes it to leader, but messages from
routed_requests are not deleted. In hazard cases, such as
bad network connection, when monitors have problem with
forming a quorum, routed_requests are getting quite fat.
Monitor::resend_routed_requests() sends all messages each time,
old and newly added. If this hazard state is long enough,
leader is constantly flooded by those routed messages.

Also entity_name wasn't set when sending routed requests.

Signed-off-by: Igor Podoski <igor.podoski@ts.fujitsu.com>