### PR TITLE
mds: add assertions for standby_daemons invariant

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -430,9 +430,7 @@ void FSMap::decode(bufferlist::iterator& p)
           p.second.rank = p.second.standby_for_rank;
         }
         if (p.second.rank == MDS_RANK_NONE) {
-          standby_daemons[p.first] = p.second;
-          standby_epochs[p.first] = epoch;
-          mds_roles[p.first] = FS_CLUSTER_ID_NONE;
+          insert(p.second); // into standby_daemons
         } else {
           mds_roles[p.first] = migrate_fs->fscid;
         }

--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -787,6 +787,8 @@ bool FSMap::undamaged(const fs_cluster_id_t fscid, const mds_rank_t rank)
 
 void FSMap::insert(const MDSMap::mds_info_t &new_info)
 {
+  assert(new_info.state == MDSMap::STATE_STANDBY);
+  assert(new_info.rank == MDS_RANK_NONE);
   mds_roles[new_info.global_id] = FS_CLUSTER_ID_NONE;
   standby_daemons[new_info.global_id] = new_info;
   standby_epochs[new_info.global_id] = epoch;

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -311,7 +311,9 @@ public:
       std::function<void(MDSMap::mds_info_t *info)> fn)
   {
     if (mds_roles.at(who) == FS_CLUSTER_ID_NONE) {
-      fn(&standby_daemons.at(who));
+      auto &info = standby_daemons.at(who);
+      fn(&info);
+      assert(info.state == MDSMap::STATE_STANDBY);
       standby_epochs[who] = epoch;
     } else {
       auto fs = filesystems[mds_roles.at(who)];


### PR DESCRIPTION
These assertions catch state changes of an mds in standby_daemons to a state
other than MDSMap::STATE_STANDBY. Currently this invariant is (sometimes!)
checked in other locations on access of standby_daemons. This commit allows us
catch the violated invariant at the time it occurred.
    
Related to: http://tracker.ceph.com/issues/16592
    
Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>