### PR TITLE
os/bluestore: revert preferred csum behavior

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6157,7 +6157,11 @@ int BlueStore::_do_write(
     dout(20) << __func__ << " will do buffered write" << dendl;
     wctx.buffered = true;
   }
-  wctx.csum_order = MAX(block_size_order, o->onode.get_preferred_csum_order());
+
+  // FIXME: Using the MAX of the block_size_order and preferred_csum_order
+  // results in poor small random read performance when data was initially 
+  // written out in large chunks.  Reverting to previous behavior for now.
+  wctx.csum_order = block_size_order;
 
   // compression parameters
   unsigned alloc_hints = o->onode.alloc_hint_flags;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -852,6 +852,8 @@ void bluestore_onode_t::generate_test_instances(list<bluestore_onode_t*>& o)
   // FIXME
 }
 
+// FIXME: Using this to compute the ctx.csum_order can lead to poor small
+// random read performance when initial writes are large.
 size_t bluestore_onode_t::get_preferred_csum_order() const
 {
   uint32_t t = expected_write_size;


### PR DESCRIPTION
Back in https://github.com/ceph/ceph/commit/0e8294c9a we changed the behavior of wctx.csum_order to use the MAX of the block_size_order and get_preferred_csum_order() from the onode.  It turns out that if the initial write to an object is large (say you are copying/filling RBD blocks), subsequent small random reads to those objects will be incredibly slow on fast devices.

I'm reverting to the previous behavior until we come up with a better solution.

Signed-off-by: Mark Nelson <mnelson@redhat.com>