### PR TITLE
rgw: add suport for creating S3 type subuser of admin rest api

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -336,11 +336,13 @@ void RGWOp_Subuser_Create::execute()
   std::string uid_str;
   std::string subuser;
   std::string secret_key;
+  std::string access_key;
   std::string perm_str;
   std::string key_type_str;
 
   bool gen_subuser = false; // FIXME placeholder
   bool gen_secret;
+  bool gen_access;
 
   uint32_t perm_mask = 0;
   int32_t key_type = KEY_TYPE_SWIFT;
@@ -351,12 +353,14 @@ void RGWOp_Subuser_Create::execute()
   rgw_user uid(uid_str);
 
   RESTArgs::get_string(s, "subuser", subuser, &subuser);
+  RESTArgs::get_string(s, "access-key", access_key, &access_key);
   RESTArgs::get_string(s, "secret-key", secret_key, &secret_key);
   RESTArgs::get_string(s, "access", perm_str, &perm_str);
   RESTArgs::get_string(s, "key-type", key_type_str, &key_type_str);
   //RESTArgs::get_bool(s, "generate-subuser", false, &gen_subuser);
   RESTArgs::get_bool(s, "generate-secret", false, &gen_secret);
-
+  RESTArgs::get_bool(s, "gen-access-key", false, &gen_access);
+  
   perm_mask = rgw_str_to_perm(perm_str.c_str());
   op_state.set_perm(perm_mask);
 
@@ -367,10 +371,16 @@ void RGWOp_Subuser_Create::execute()
   if (!subuser.empty())
     op_state.set_subuser(subuser);
 
+  if (!access_key.empty())
+    op_state.set_access_key(access_key);
+  
   if (!secret_key.empty())
     op_state.set_secret_key(secret_key);
 
   op_state.set_generate_subuser(gen_subuser);
+
+  if (gen_access)
+    op_state.set_gen_access();
 
   if (gen_secret)
     op_state.set_gen_secret();

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1391,6 +1391,7 @@ int RGWSubUserPool::add(RGWUserAdminOpState& op_state, std::string *err_msg, boo
 {
   std::string subprocess_msg;
   int ret;
+  int32_t key_type = op_state.get_key_type();
 
   ret = check_op(op_state, &subprocess_msg);
   if (ret < 0) {
@@ -1398,6 +1399,10 @@ int RGWSubUserPool::add(RGWUserAdminOpState& op_state, std::string *err_msg, boo
     return ret;
   }
 
+  if (key_type == KEY_TYPE_S3 && op_state.get_access_key().empty()) {
+    op_state.set_gen_access();
+  }
+  
   if (op_state.get_secret_key().empty()) {
     op_state.set_gen_secret();
   }


### PR DESCRIPTION
 Fixes: http://tracker.ceph.com/issues/16682

The original code cannot support create s3 type subuser of admin rest api as when i execute the following command:

  ./s3curl.pl --id=personal --put -- http://radosgw.h3c.com:8000/admin/user?subuser\&uid=yrf2\&subuser=yrf2:yrf1\&key-type=s3 -v

it would return msg as follows :+1: 


	 < HTTP/1.1 403 Forbidden
	< Date: Thu, 14 Jul 2016 07:04:40 GMT
	* Server Apache/2.4.7 (Ubuntu) is not blacklisted
	< Server: Apache/2.4.7 (Ubuntu)
	< x-amz-request-id: tx00000000000000006608f-0057873988-8551-slave
	< Accept-Ranges: bytes
	< Content-Length: 114
	< Content-Type: application/json
	<
	* Connection #0 to host slave.com left intact
	{"Code":"InvalidAccessKeyId","RequestId":"tx00000000000000006608f-0057873988-8551-slave","HostId":"8551-slave-us"}

 But i have modified the codes for support it ,and it will return actual msg as follows :

  "subusers": [
        {
            "id": "yrf2:yrf1",
            "permissions": "<none>"
        }
    ],
    "keys": [
        {
            "user": "yrf2",
            "access_key": "B46PXYFEWUX0IMHGKP8C",
            "secret_key": "2JYxywXizqwiiMd74UXrJdSJMPNlBtYwF5z8rNvh"
        },
        {
            "user": "yrf2:yrf1",
            "access_key": "INO55WXJ7JQ1ZZGSAB6B",
            "secret_key": "GgCKEfF9hArV2hglunbO7KtvKZnbhmsDpqjSj5DL"
        }
    ],

Please check it ,thanks .

Signed-off-by: snakeAngel2015 <li.jieA@h3c.com>