### PR TITLE
rgw, doc: fix formatting around Keystone-related options.

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -1054,6 +1054,7 @@ Keystone Settings
 
 
 ``rgw keystone admin user``
+
 :Description: The name of OpenStack user with admin privilege for Keystone
               authentication (Service User) when OpenStack Identity API v2
 :Type: String
@@ -1061,6 +1062,7 @@ Keystone Settings
 
 
 ``rgw keystone admin password``
+
 :Description: The password for OpenStack admin user when using OpenStack
               Identity API v2
 :Type: String


### PR DESCRIPTION
This patch brings a small fix for broken formatting around
two configurables in doc/radosgw/config-ref.rst. Those are:
  * `rgw keystone admin user`,
  * `rgw keystone admin password`.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>