### PR TITLE
mds/mdsmonitor: kill mds dump

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -930,53 +930,6 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
       ds << fsmap;
     }
     r = 0;
-  } else if (prefix == "mds dump") {
-    int64_t epocharg;
-    epoch_t epoch;
-
-    FSMap *p = &fsmap;
-    if (cmd_getval(g_ceph_context, cmdmap, "epoch", epocharg)) {
-      epoch = epocharg;
-      bufferlist b;
-      int err = get_version(epoch, b);
-      if (err == -ENOENT) {
-	p = 0;
-	r = -ENOENT;
-      } else {
-	assert(err == 0);
-	assert(b.length());
-	p = new FSMap;
-	p->decode(b);
-      }
-    }
-    if (p) {
-      stringstream ds;
-      const MDSMap *mdsmap = nullptr;
-      MDSMap blank;
-      blank.epoch = fsmap.epoch;
-      if (fsmap.legacy_client_fscid != FS_CLUSTER_ID_NONE) {
-        mdsmap = &(fsmap.filesystems[fsmap.legacy_client_fscid]->mds_map);
-      } else {
-        mdsmap = &blank;
-      }
-      if (f != NULL) {
-	f->open_object_section("mdsmap");
-	mdsmap->dump(f.get());
-	f->close_section();
-	f->flush(ds);
-	r = 0;
-      } else {
-	mdsmap->print(ds);
-	r = 0;
-      } 
-      if (r == 0) {
-	rdata.append(ds);
-	ss << "dumped fsmap epoch " << p->get_epoch();
-      }
-      if (p != &fsmap) {
-	delete p;
-      }
-    }
   } else if (prefix == "fs dump") {
     int64_t epocharg;
     epoch_t epoch;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -302,10 +302,6 @@ COMMAND("mon metadata name=id,type=CephString,req=false",
  */
 
 COMMAND("mds stat", "show MDS status", "mds", "r", "cli,rest")
-COMMAND("mds dump " 
-	"name=epoch,type=CephInt,req=false,range=0", \
-	"dump legacy MDS cluster info, optionally from epoch",
-        "mds", "r", "cli,rest")
 COMMAND("fs dump "
 	"name=epoch,type=CephInt,req=false,range=0", \
 	"dump all CephFS status, optionally from epoch", "mds", "r", "cli,rest")

--- a/src/test/cephtool-test-mds.sh
+++ b/src/test/cephtool-test-mds.sh
@@ -18,7 +18,7 @@
 source $(dirname $0)/detect-build-env-vars.sh
 
 CEPH_CLI_TEST_DUP_COMMAND=1 \
-MDS=1 MON=1 OSD=3 CEPH_START='mon osd mds' CEPH_PORT=7200 $CEPH_ROOT/src/test/vstart_wrapper.sh \
+MDS=1 MON=1 OSD=3 CEPH_START='mon osd fs' CEPH_PORT=7200 $CEPH_ROOT/src/test/vstart_wrapper.sh \
     $CEPH_ROOT/qa/workunits/cephtool/test.sh \
     --test-mds \
     --asok-does-not-need-root

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -348,7 +348,7 @@ class TestMDS(TestArgparse):
         self.check_no_arg('mds', 'stat')
 
     def test_dump(self):
-        self.check_0_or_1_natural_arg('mds', 'dump')
+        self.check_0_or_1_natural_arg('fs', 'dump')
 
     def test_tell(self):
         self.assert_valid_command(['mds', 'tell',


### PR DESCRIPTION
"mds dump" and "fs dump" are repeated, and "mds dump" display incomplete.
see http://tracker.ceph.com/issues/16730

Fixes: 16730

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>