### PR TITLE
selinux: allow read /proc/<pid>/cmdline

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -75,6 +75,8 @@ corecmd_exec_shell(ceph_t)
 
 dev_read_urand(ceph_t)
 
+domain_read_all_domains_state(ceph_t)
+
 fs_getattr_all_fs(ceph_t)
 
 auth_use_nsswitch(ceph_t)


### PR DESCRIPTION
we read /proc/<pid>/cmdline to figure out who is terminating us.

Fixes: http://tracker.ceph.com/issues/16675
Signed-off-by: Kefu Chai <kchai@redhat.com>