### PR TITLE
msg/simple: fix wrong condition checking of writing TAG_CLOSE on closing

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -887,7 +887,7 @@ int Pipe::connect()
   __u32 cseq = connect_seq;
   __u32 gseq = msgr->get_global_seq();
 
-  // stop reader thrad
+  // stop reader thread
   join_reader();
 
   pipe_lock.Unlock();
@@ -1736,7 +1736,7 @@ void Pipe::writer()
       state = STATE_CLOSED;
       state_closed.set(1);
       pipe_lock.Unlock();
-      if (sd) {
+      if (sd >= 0) {
 	// we can ignore return value, actually; we don't care if this succeeds.
 	int r = ::write(sd, &tag, 1);
 	(void)r;


### PR DESCRIPTION
The sd is initialized to -1 and will be resetted to -1 whenever it is
invalidated. So "if (sd)" is not reasonable enough to determine whether
or not the sd is currently still in use.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>