### PR TITLE
msg/simple: apply prefetch policy more precisely

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2554,7 +2554,7 @@ ssize_t Pipe::buffered_recv(char *buf, size_t len, int flags)
 
   /* nothing left in the prefetch buffer */
 
-  if (len > (size_t)recv_max_prefetch) {
+  if (left > (size_t)recv_max_prefetch) {
     /* this was a large read, we don't prefetch for these */
     ssize_t ret = do_recv(buf, left, flags );
     if (ret < 0) {


### PR DESCRIPTION
We shall apply prefetch policy based on the residual length aftering
checking cache instead of the original request length.

E.g., if the reading sequences are 1K, 5K, 2K, the improved logic
will trigger another prefetch of 4K(as 5K - 3K(from recv_buf) == 2K, and we
now have 8K prefetched data total) by the second 5K reading(which we
don't do this according to the old logic), and thus the last reading request
which asks for 2K data can be also benefited from this prefetch,
which is good for performance.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>