### PR TITLE
test: ceph-disk.sh do not kill all daemons

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -69,8 +69,7 @@ function run() {
         $DRY_RUN ./do_cmake.sh || return 1
         cd build
         $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
-        $DRY_RUN ctest -L Racing -j1 --output-on-failure || return 1
-        $DRY_RUN ctest -LE Racing $CHECK_MAKEOPTS --output-on-failure || return 1
+        $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure || return 1
     else
         $DRY_RUN ./autogen.sh || return 1
         $DRY_RUN ./configure "$@"  --with-librocksdb-static --disable-static --with-radosgw --with-debug --without-lttng \

--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -58,7 +58,7 @@ function teardown() {
     if ! test -e $dir ; then
         return
     fi
-    kill_daemons
+    kill_daemons $dir
     if [ $(stat -f -c '%T' .) == "btrfs" ]; then
         rm -fr $dir/*/*db
         __teardown_btrfs $dir

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -507,12 +507,9 @@ add_dependencies(tests
   cython_modules)
 
 add_ceph_test(test-ceph-helpers.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-helpers.sh)
-add_ceph_test(ceph_objectstore_tool.py ${CMAKE_CURRENT_SOURCE_DIR}/ceph_objectstore_tool.py)
-set_property(TEST test-ceph-helpers.sh ceph_objectstore_tool.py
-  PROPERTY LABELS Racing LongRunning)
-
 add_ceph_test(erasure-decode-non-regression.sh ${CMAKE_SOURCE_DIR}/qa/workunits/erasure-code/encode-decode-non-regression.sh)
 
+add_ceph_test(ceph_objectstore_tool.py ${CMAKE_CURRENT_SOURCE_DIR}/ceph_objectstore_tool.py)
 add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
 add_ceph_test(cephtool-test-mon.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mon.sh)
 add_ceph_test(cephtool-test-osd.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-osd.sh)


### PR DESCRIPTION
this fixes mysterious "racing" issues when running ceph-helper tests in parallel.