### PR TITLE
os/bluestore: add a boundary check of cache read

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1008,6 +1008,8 @@ void BlueStore::BufferSpace::read(
       } else {
 	res[offset].append(b->data);
 	res_intervals.insert(offset, b->length);
+        if (b->length == length)
+          break;
 	offset += b->length;
 	length -= b->length;
       }


### PR DESCRIPTION
By trapping the "==" case and break, we can finish
the cache read just in time. As a result, we can avoid
two extra operations(adjusting "offset" and "length") and
the final loop check.

Since this is one of key methods of cache, it deserves this
fix.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>