### PR TITLE
mon:  paxos add the timeout function when peon recovery

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -195,6 +195,7 @@ void Paxos::collect(version_t oldpn)
 // peon
 void Paxos::handle_collect(MonOpRequestRef op)
 {
+  
   op->mark_paxos_event("handle_collect");
 
   MMonPaxos *collect = static_cast<MMonPaxos*>(op->get_req());
@@ -204,6 +205,9 @@ void Paxos::handle_collect(MonOpRequestRef op)
 
   // we're recoverying, it seems!
   state = STATE_RECOVERING;
+
+  //update the peon recovery timeout 
+  reset_lease_timeout();
 
   if (collect->first_committed > last_committed+1) {
     dout(2) << __func__


### PR DESCRIPTION
 mon:  paxos add the timeout function when peon recovery

 Now the peon only have 10s from init to active.But when the leader

 from init to active he may start twice or more recovery collect when

 meet a higher pn than himself.It means the leader from init to active

 may spend more than 10S. So it is not reasonable for the peon only have

 one 10s timeout event.

Signed-off-by: song baisen <song.baisen@zte.com.cn>