### PR TITLE
os/bluestore: fix potential access violation

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -127,7 +127,7 @@ int BlueFS::add_block_device(unsigned id, string path)
 
 uint64_t BlueFS::get_block_device_size(unsigned id)
 {
-  if (bdev[id])
+  if (id < bdev.size() && bdev[id])
     return bdev[id]->get_size();
   return 0;
 }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -144,7 +144,7 @@ void BlueFS::add_block_extent(unsigned id, uint64_t offset, uint64_t length)
   block_all[id].insert(offset, length);
   block_total[id] += length;
 
-  if (alloc.size()) {
+  if (id < alloc.size() && alloc[id]) {
     log_t.op_alloc_add(id, offset, length);
     int r = _flush_and_sync_log(l);
     assert(r == 0);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -739,7 +739,9 @@ void BlueStore::TwoQCache::trim(uint64_t onode_max, uint64_t buffer_max)
       Buffer *b = &*p;
       assert(b->is_clean());
       dout(20) << __func__ << " buffer_warm_in -> out " << *b << dendl;
+      assert(buffer_bytes >= b->length);
       buffer_bytes -= b->length;
+      assert(buffer_list_bytes[BUFFER_WARM_IN] >= b->length);
       buffer_list_bytes[BUFFER_WARM_IN] -= b->length;
       to_evict_bytes -= b->length;
       evicted += b->length;

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -804,7 +804,7 @@ void bluestore_lextent_t::decode(bufferlist::iterator& p)
 
 void bluestore_lextent_t::dump(Formatter *f) const
 {
-  f->dump_unsigned("blob", blob);
+  f->dump_int("blob", blob);
   f->dump_unsigned("offset", offset);
   f->dump_unsigned("length", length);
 }

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -555,7 +555,7 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
   out << "blob(" << o.extents
       << " clen 0x" << std::hex
       << o.compressed_length_orig
-      << " -> " << std::hex
+      << " -> 0x"
       << o.compressed_length
       << std::dec;
   if (o.flags) {


### PR DESCRIPTION
According to BlueFS::_init_alloc(), if the relevant bdev
does not exist, we will skip initializing the corresponding
allocator too.

So below here we shall check the existence of the specific
allocator instead.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>