### PR TITLE
mon: fix synchronise pgmap with others

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -243,7 +243,9 @@ void PGMonitor::update_from_paxos(bool *need_bootstrap)
       int r = get_version(pg_map.version + 1, bl);
       if (r == -ENOENT) {
 	dout(10) << __func__ << " failed to read_incremental, read_full" << dendl;
-	read_pgmap_full();
+       // reset pg map
+	pg_map = PGMap();
+       read_pgmap_full();
 	goto out;
       }
       assert(r == 0);


### PR DESCRIPTION
leader mon down for a long time and then the local pgmap/osdmap was behind latest map a lot,
when it start and sync ,it will read full map from other mons;
if serveral osds/pgs were deleted during mon offline, these osds/pgs will be left over in pgmap until manully restart ceph-mon process

Solution:
reset pgmap before read pgmap full,make sure local maps are the same as the latest map

Signed-off-by: z09440 zhao.mingyue@h3c.com
