### PR TITLE
msg/async/Event: ensure not refer to member variable which may destroyed

### DIFF
--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -183,8 +183,9 @@ class EventCenter {
       lock.lock();
       cond.notify_all();
       done = true;
+      bool del = nonwait;
       lock.unlock();
-      if (nonwait)
+      if (del)
         delete this;
     }
     void wait() {


### PR DESCRIPTION
If nonwait is false, another thread is waiting for complete. After calling f()
this thread will notify for finishing and at this moment another thread will
destroy this C_submit_event right now. So we may refer to nonwait when
C_submit_event is disappeared.

Signed-off-by: Haomai Wang <haomai@xsky.com>