### PR TITLE
Document min_size default and provide examples

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -724,6 +724,21 @@ For example::
 This ensures that no object in the data pool will receive I/O with fewer than
 ``min_size`` replicas.
 
+If unset, ``min_size`` defaults to ``size - size/2``. For example:
+
++------+----------+
+| size + min_size |
++======+==========+
+| 1    | 1        |
++------+----------+
+| 2    | 1        |
++------+----------+
+| 3    | 2        |
++------+----------+
+| 4    | 2        |
++------+----------+
+| 5    | 3        |
++------+----------+
 
 Get the Number of Object Replicas
 =================================


### PR DESCRIPTION
We've had users be a bit confused about how the default for min_size is calculated. A simple table for the most common num_replicas settings seemed easiest to add.
