### PR TITLE
os/bluestore: use small encoding for bluefs extent and fnode

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1357,7 +1357,7 @@ void BlueFS::flush_bdev()
   }
 }
 
-int BlueFS::_allocate(unsigned id, uint64_t len, vector<bluefs_extent_t> *ev)
+int BlueFS::_allocate(uint8_t id, uint64_t len, vector<bluefs_extent_t> *ev)
 {
   dout(10) << __func__ << " len 0x" << std::hex << len << std::dec
            << " from " << id << dendl;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -232,7 +232,7 @@ private:
   FileRef _get_file(uint64_t ino);
   void _drop_link(FileRef f);
 
-  int _allocate(unsigned bdev, uint64_t len, vector<bluefs_extent_t> *ev);
+  int _allocate(uint8_t bdev, uint64_t len, vector<bluefs_extent_t> *ev);
   int _flush_range(FileWriter *h, uint64_t offset, uint64_t length);
   int _flush(FileWriter *h, bool force);
   void wait_for_aio(FileWriter *h);  // safe to call without a lock

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -5,14 +5,15 @@
 #include "common/Formatter.h"
 #include "include/uuid.h"
 #include "include/stringify.h"
+#include "include/small_encoding.h"
 
 // bluefs_extent_t
 
 void bluefs_extent_t::encode(bufferlist& bl) const
 {
   ENCODE_START(1, 1, bl);
-  ::encode(offset, bl);
-  ::encode(length, bl);
+  small_encode_lba(offset, bl);
+  small_encode_varint_lowz(length, bl);
   ::encode(bdev, bl);
   ENCODE_FINISH(bl);
 }
@@ -20,8 +21,8 @@ void bluefs_extent_t::encode(bufferlist& bl) const
 void bluefs_extent_t::decode(bufferlist::iterator& p)
 {
   DECODE_START(1, p);
-  ::decode(offset, p);
-  ::decode(length, p);
+  small_decode_lba(offset, p);
+  small_decode_varint_lowz(length, p);
   ::decode(bdev, p);
   DECODE_FINISH(p);
 }
@@ -119,8 +120,8 @@ vector<bluefs_extent_t>::iterator bluefs_fnode_t::seek(
 void bluefs_fnode_t::encode(bufferlist& bl) const
 {
   ENCODE_START(1, 1, bl);
-  ::encode(ino, bl);
-  ::encode(size, bl);
+  small_encode_varint(ino, bl);
+  small_encode_varint(size, bl);
   ::encode(mtime, bl);
   ::encode(prefer_bdev, bl);
   ::encode(extents, bl);
@@ -130,8 +131,8 @@ void bluefs_fnode_t::encode(bufferlist& bl) const
 void bluefs_fnode_t::decode(bufferlist::iterator& p)
 {
   DECODE_START(1, p);
-  ::decode(ino, p);
-  ::decode(size, p);
+  small_decode_varint(ino, p);
+  small_decode_varint(size, p);
   ::decode(mtime, p);
   ::decode(prefer_bdev, p);
   ::decode(extents, p);

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -9,9 +9,9 @@
 
 class bluefs_extent_t : public AllocExtent{
 public:
-  uint16_t bdev;
+  uint8_t bdev;
 
-  bluefs_extent_t(uint16_t b = 0, uint64_t o = 0, uint32_t l = 0)
+  bluefs_extent_t(uint8_t b = 0, uint64_t o = 0, uint32_t l = 0)
     : AllocExtent(o, l), bdev(b) {}
 
   void encode(bufferlist&) const;


### PR DESCRIPTION
Also change bdev of extent from uint16_t to uint8_t, which matches
the fnode prefer_bdev field better, and is good for efficiency.
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>