### PR TITLE
os/bluestore:Fix size calculation in bitallocator

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -529,7 +529,7 @@ public:
   void free_blocks_dis(int64_t num_blocks, ExtentList *block_list);
   bool is_allocated_dis(ExtentList *blocks, int64_t num_blocks);
 
-  int64_t size() {
+  int64_t total_blocks() const {
     return m_total_blocks - m_extra_blocks;
   }
   int64_t get_used_blocks() {

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -86,7 +86,7 @@ int BitMapAllocator::reserve(uint64_t need)
   assert(!(need % m_block_size));
   dout(10) << __func__ << " instance " << (uint64_t) this
            << " num_used " << m_bit_alloc->get_used_blocks()
-           << " total " << m_bit_alloc->size()
+           << " total " << m_bit_alloc->total_blocks()
            << dendl;
 
   if (!m_bit_alloc->reserve_blocks(nblks)) {
@@ -103,7 +103,7 @@ void BitMapAllocator::unreserve(uint64_t unused)
   dout(10) << __func__ << " instance " << (uint64_t) this
            << " unused " << nblks
            << " num used " << m_bit_alloc->get_used_blocks()
-           << " total " << m_bit_alloc->size()
+           << " total " << m_bit_alloc->total_blocks()
            << dendl;
 
   m_bit_alloc->unreserve_blocks(nblks);
@@ -244,9 +244,9 @@ int BitMapAllocator::release(
 
 uint64_t BitMapAllocator::get_free()
 {
-  assert(m_bit_alloc->size() >= m_bit_alloc->get_used_blocks());
+  assert(m_bit_alloc->total_blocks() >= m_bit_alloc->get_used_blocks());
   return ((
-    m_bit_alloc->size() - m_bit_alloc->get_used_blocks()) *
+    m_bit_alloc->total_blocks() - m_bit_alloc->get_used_blocks()) *
     m_block_size);
 }
 

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -420,28 +420,29 @@ TEST(BitAllocator, test_bmap_alloc)
       alloc->free_blocks(i, 1);
     }
 
-		int64_t blk_size = 1024;
-		std::vector<AllocExtent> extents = std::vector<AllocExtent>
-					(alloc->size(), AllocExtent(-1, -1));
+    int64_t blk_size = 1024;
+    auto extents = std::vector<AllocExtent>
+          (alloc->size(), AllocExtent(-1, -1));
 
-		ExtentList *block_list = new ExtentList(&extents, blk_size);
+    ExtentList *block_list = new ExtentList(&extents, blk_size);
 
-		allocated = alloc->alloc_blocks_dis(alloc->size()/2, block_list);
-		bmap_test_assert(allocated == alloc->size() / 2);
+    allocated = alloc->alloc_blocks_dis(alloc->size()/2, block_list);
+    ASSERT_EQ(alloc->size()/2, allocated);
 
-		block_list->reset();
-		allocated = alloc->alloc_blocks_dis(1, block_list);
-		bmap_test_assert(allocated == 0);
+    block_list->reset();
+    allocated = alloc->alloc_blocks_dis(1, block_list);
+    bmap_test_assert(allocated == 0);
 
-		alloc->free_blocks(alloc->size()/2, 1);
+    alloc->free_blocks(alloc->size()/2, 1);
 
-		block_list->reset();
-		allocated = alloc->alloc_blocks_dis(1, block_list);
-		bmap_test_assert(allocated == 1);
+    block_list->reset();
+    allocated = alloc->alloc_blocks_dis(1, block_list);
+    bmap_test_assert(allocated == 1);
 
-		bmap_test_assert((int64_t) extents[0].offset == alloc->size()/2 * blk_size);
+    bmap_test_assert((int64_t) extents[0].offset == alloc->size()/2 * blk_size);
 
-		delete alloc;
+    delete block_list;
+    delete alloc;
 
     // unaligned zones
     total_blocks = zone_size * 2 + 11;


### PR DESCRIPTION
Internal size and external size are different got Bitallocator. 
Hence creating separate function.

Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>