### PR TITLE
os/bluestore: fix bitmap allocating failure if max_alloc_size is 0

### DIFF
--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -191,8 +191,8 @@ int BitMapAllocator::alloc_extents_cont(
 
   while (need_blks > 0) {
     int64_t count = 0;
-    count = m_bit_alloc->alloc_blocks_res(need_blks > max_blks? max_blks: need_blks,
-                                          &start_blk);
+    count = m_bit_alloc->alloc_blocks_res(
+      (max_blks && need_blks > max_blks) ? max_blks : need_blks, &start_blk);
     if (count == 0) {
       break;
     }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1397,13 +1397,12 @@ int BlueFS::_allocate(unsigned id, uint64_t len, vector<bluefs_extent_t> *ev)
 
   r = alloc[id]->alloc_extents(left, min_alloc_size,
                                hint, &extents, &count);
-  assert(r == 0);
+  if (r < 0) {
+    assert(0 == "allocate failed... wtf");
+    return r;
+  }
   for (int i = 0; i < count; i++) {
     bluefs_extent_t e = bluefs_extent_t(id, extents[i].offset, extents[i].length);
-    if (r < 0) {
-      assert(0 == "allocate failed... wtf");
-      return r;
-    }
     if (!ev->empty() && ev->back().end() == (uint64_t) e.offset) {
       ev->back().length += e.length;
     } else {


### PR DESCRIPTION
If max_alloc_size is 0(means no limit), the original logic will
always hardcode need_blks to 0, which is incorrect.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>