### PR TITLE
doc/radosgw: rename config.rst to config-fcgi.rst

### DIFF
--- a/doc/radosgw/config-fcgi.rst
+++ b/doc/radosgw/config-fcgi.rst
@@ -1,9 +1,13 @@
-=================================
- Configuring Ceph Object Gateway
-=================================
+=====================================================
+ Configuring Ceph Object Gateway with Apache/FastCGI
+=====================================================
 
-Configuring a Ceph Object Gateway requires a running Ceph Storage Cluster, 
-and an Apache web server with the FastCGI module.
+Configuring a Ceph Object Gateway requires a running Ceph Storage Cluster.
+Since it contains an embedded webserver (civetweb), the Ceph Object Gateway
+does not require an external web server, but it can be configured to use
+Apache with the FastCGI module.
+
+.. note:: CGI can pose a security risk.
 
 The Ceph Object Gateway is a client of the Ceph Storage Cluster. As a 
 Ceph Storage Cluster client, it requires:

--- a/doc/radosgw/index.rst
+++ b/doc/radosgw/index.rst
@@ -37,7 +37,7 @@ you may write data with one API and retrieve it with the other.
 	:maxdepth: 1
 
 	Manual Install <../../install/install-ceph-gateway>
-	Simple Configuration <config>
+	Simple Configuration with FastCGI <config-fcgi>
 	Federated Configuration <federated-config>
 	Multisite Configuration <multisite>
 	Config Reference <config-ref>


### PR DESCRIPTION
This file documents how to configure RGW to use Apache/FastCGI, so rename
the file and modify the title and intro to make that clear.

Also, add a note that CGI can pose a security risk - e.g. http://httpoxy.org

Signed-off-by: Nathan Cutler <ncutler@suse.com>