### PR TITLE
Add ID for Ceph Encrypt

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -336,6 +336,11 @@ class TestCephDisk(object):
         osd_uuid = self.activate_dmcrypt('ceph-disk')
         c.destroy_osd(osd_uuid)
 
+    def test_activate_dmcrypt_luks_with_lockbox_custom_cephx(self):
+        c = CephDisk()
+        osd_uuid = self.activate_dmcrypt_with_cephx_user('ceph-disk')
+        c.destroy_osd(osd_uuid)
+
     def test_activate_lockbox(self):
         c = CephDisk()
         osd_uuid = self.activate_dmcrypt('ceph-disk')
@@ -363,6 +368,23 @@ class TestCephDisk(object):
         journal_uuid = str(uuid.uuid1())
         c.sh("ceph-disk --verbose zap " + disk)
         c.sh(ceph_disk + " --verbose prepare " +
+             " --osd-uuid " + osd_uuid +
+             " --journal-uuid " + journal_uuid +
+             " --dmcrypt " +
+             " " + disk)
+        c.wait_for_osd_up(osd_uuid)
+        c.check_osd_status(osd_uuid, 'journal')
+        return osd_uuid
+
+    def activate_dmcrypt_with_cephx_user(self, ceph_disk):
+        c = CephDisk()
+        disk = c.unused_disks()[0]
+        cephx_user = "lockbox_cephx"
+        osd_uuid = str(uuid.uuid1())
+        journal_uuid = str(uuid.uuid1())
+        c.sh("ceph-disk --verbose zap " + disk)
+        c.sh(ceph_disk + " --verbose prepare " +
+             " --id " + cephx_user +
              " --osd-uuid " + osd_uuid +
              " --journal-uuid " + journal_uuid +
              " --dmcrypt " +

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1728,6 +1728,11 @@ class Prepare(object):
             help='unique OSD uuid to assign this disk to',
         )
         parser.add_argument(
+            '--id',
+            metavar='cephx_user',
+            help='Initial cephx user to create lockbox cephx with',
+        )
+        parser.add_argument(
             '--dmcrypt',
             action='store_true', default=None,
             help='encrypt DATA and/or JOURNAL devices with dm-crypt',
@@ -2257,26 +2262,31 @@ class Lockbox(object):
         key_size = CryptHelpers.get_dmcrypt_keysize(self.args)
         key = open('/dev/urandom', 'rb').read(key_size / 8)
         base64_key = base64.b64encode(key)
-        command_check_call(
-            [
-                'ceph',
-                'config-key',
-                'put',
-                'dm-crypt/osd/' + self.args.osd_uuid + '/luks',
-                base64_key,
-            ],
-        )
-        keyring, stderr, ret = command(
-            [
-                'ceph',
-                'auth',
-                'get-or-create',
-                'client.osd-lockbox.' + self.args.osd_uuid,
-                'mon',
-                ('allow command "config-key get" with key="dm-crypt/osd/' +
-                 self.args.osd_uuid + '/luks"'),
-            ],
-        )
+
+        ceph_cmd = ['ceph']
+        # If args.id is set use that specific user
+        # else default to the admin user
+        if self.args.id:
+            ceph_cmd = ['ceph', '--id', self.args.id]
+
+        config_key_args = [
+            'config-key',
+            'put',
+            'dm-crypt/osd/' + self.args.osd_uuid + '/luks',
+            base64_key,
+        ]
+        command_check_call(ceph_cmd + config_key_args)
+
+        create_key_args = [
+            'auth',
+            'get-or-create',
+            'client.osd-lockbox.' + self.args.osd_uuid,
+            'mon',
+            ('allow command "config-key get" with key="dm-crypt/osd/' +
+             self.args.osd_uuid + '/luks"'),
+        ]
+        keyring, stderr, ret = command(ceph_cmd + create_key_args)
+
         LOG.debug("stderr " + stderr)
         assert ret == 0
         path = self.get_mount_point()


### PR DESCRIPTION
I've added an --id field to the ceph-disk prepare function so that a cephx key other than admin can be used when setting up dmcrypt.  If the admin key is not present on the osd cluster ceph-disk prepare fails with a permission denied error.  
