### PR TITLE
common/ceph_context.cc: Use CEPH_DEV to reduce logfile noise

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -305,6 +305,17 @@ public:
 	conf->enable_experimental_unrecoverable_data_corrupting_features,
 	cct->_experimental_features);
       ceph_spin_unlock(&cct->_feature_lock);
+      if (getenv("CEPH_DEV") == NULL) {
+        if (!cct->_experimental_features.empty()) {
+          if (cct->_experimental_features.count("*")) {
+            lderr(cct) << "WARNING: all dangerous and experimental features are enabled." << dendl;
+          } else {
+            lderr(cct) << "WARNING: the following dangerous and experimental features are enabled: "
+              << cct->_experimental_features << dendl;
+          }
+        }
+      }
+
     }
     if (changed.count("crush_location")) {
       cct->crush_location.update_from_conf();


### PR DESCRIPTION
Logfiles contain a lot of warnings about features set to '*' 
Setting the CEPH_DEV option allows suppression of these warnings.
Can be set in vstart.sh for example.

Signed-off-by: Willem Jan Withagen wjw@digiware.nl
