### PR TITLE
tracing: link correct version of shared libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,9 @@ if(${WITH_LTTNG})
   find_package(lttng-ust REQUIRED)
 endif(${WITH_LTTNG})
 
+set(LIBRBD_TP_SONAME "librbd_tp.so.1")
+set(LIBRADOS_TP_SONAME "librados_tp.so.2")
+
 #option for Babeltrace
 option(HAVE_BABELTRACE "Babeltrace libraries are enabled" ON)
 if(${HAVE_BABELTRACE})

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -276,4 +276,10 @@
 /* Defined if pthread_getname_np() is available */
 #cmakedefine HAVE_PTHREAD_GETNAME_NP 1
 
+/* Name of librbd tracing point shared library */
+#cmakedefine LIBRBD_TP_SONAME "@LIBRBD_TP_SONAME@"
+
+/* Name of librados tracing point shared library */
+#cmakedefine LIBRADOS_TP_SONAME "@LIBRADOS_TP_SONAME@"
+
 #endif /* CONFIG_H */

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -14,6 +14,7 @@
 
 #include <limits.h>
 
+#include "acconfig.h"
 #include "common/config.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
@@ -66,7 +67,7 @@ using std::runtime_error;
 
 namespace {
 
-TracepointProvider::Traits tracepoint_traits("librados_tp.so", "rados_tracing");
+TracepointProvider::Traits tracepoint_traits(LIBRADOS_TP_SONAME, "rados_tracing");
 
 } // anonymous namespace
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -12,9 +12,9 @@
  *
  */
 #include "include/int_types.h"
-
 #include <errno.h>
 
+#include "acconfig.h"
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/TracepointProvider.h"
@@ -55,7 +55,7 @@ using librados::IoCtx;
 
 namespace {
 
-TracepointProvider::Traits tracepoint_traits("librbd_tp.so", "rbd_tracing");
+TracepointProvider::Traits tracepoint_traits(LIBRBD_TP_SONAME, "rbd_tracing");
 
 CephContext* get_cct(IoCtx &io_ctx) {
   return reinterpret_cast<CephContext*>(io_ctx.cct());


### PR DESCRIPTION
Presently `dlopen()` fails to find the correct shared library to link with because of a SONAME mismatch. This results in no LTTng-UST trace being generated even when `rbd_tracing` or `rados_tracing` is set to `true` in the `ceph.conf`. This change attempts to fix the above issue without hardcoding the actual versioned names in the code.

The shared object name for both the files are shown as below:

``` bash
$ readelf -d librbd.so.* | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [librbd.so.1]

$ readelf -d librados.so.* | grep SONAME
 0x000000000000000e (SONAME)             Library soname: [librados.so.2]
```

r: @dillaman 

Signed-off-by: Vaibhav Bhembre vaibhav@digitalocean.com
