### PR TITLE
cmake: disable unittest_async_compressor

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -158,7 +158,6 @@ target_link_libraries(unittest_bit_vector global)
 add_executable(unittest_async_compressor
   test_async_compressor.cc
 )
-add_ceph_unittest(unittest_async_compressor ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_async_compressor)
 target_link_libraries(unittest_async_compressor global)
 add_dependencies(unittest_async_compressor ceph_snappy)
 


### PR DESCRIPTION
as async compressor is not used anywhere. and haomai agrees to disable
this test.

Signed-off-by: Kefu Chai <kchai@redhat.com>