### PR TITLE
cmake: fix the build of unittest_async_compressor

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -155,11 +155,12 @@ add_ceph_unittest(unittest_bit_vector ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest
 target_link_libraries(unittest_bit_vector global)
 
 # unittest_async_compressor
+# the test is disabled, because async_compressor is not used anywhere yet.
 add_executable(unittest_async_compressor
-  test_async_compressor.cc
-)
-target_link_libraries(unittest_async_compressor global)
+  test_async_compressor.cc)
+target_link_libraries(unittest_async_compressor global ${UNITTEST_LIBS})
 add_dependencies(unittest_async_compressor ceph_snappy)
+set_target_properties(unittest_async_compressor PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
 # unittest_interval_set
 add_executable(unittest_interval_set


### PR DESCRIPTION
it was broken by 1e8388c

Signed-off-by: Kefu Chai <kchai@redhat.com>