### PR TITLE
make-dist/ceph.spec.in: Fix srpm build breakage.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -66,7 +66,7 @@ License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-auto
 Group:         System/Filesystems
 %endif
 URL:		http://ceph.com/
-Source0:	http://ceph.com/download/%{name}-%{version}.tar.bz2
+Source0:	http://ceph.com/download/@TARBALL_BASENAME@.tar.bz2
 %if 0%{?suse_version}
 %if 0%{?is_opensuse}
 ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le
@@ -664,7 +664,7 @@ python-cephfs instead.
 # common
 #################################################################################
 %prep
-%autosetup -p1
+%autosetup -p1 -n @TARBALL_BASENAME@
 
 %build
 %if 0%{with cephfs_java}

--- a/make-dist
+++ b/make-dist
@@ -37,10 +37,11 @@ src/make_version -g src/.git_version -c src/ceph_ver.h
 
 rpm_version=`echo $version | cut -d - -f 1-1`
 rpm_release=`echo $version | cut -d - -f 2- | sed 's/-/./'`
+
 cat ceph.spec.in | \
     sed "s/@VERSION@/$rpm_version/g" | \
-    sed "s/@RPM_RELEASE@/$rpm_release/g" > ceph.spec
-
+    sed "s/@RPM_RELEASE@/$rpm_release/g" |
+    sed "s/@TARBALL_BASENAME@/ceph-$version/g" > ceph.spec
 ln -s . $outfile
 tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/src/ceph_ver.h $outfile/ceph.spec
 tar --concatenate -f $outfile.both.tar $outfile.version.tar


### PR DESCRIPTION
This allows the make-dist script to create a .spec file that
can actually use the tarball created to build srpms.

Tested on Fedora 24, using mock.

Signed-off-by: Ira Cooper <ira@redhat.com>