### PR TITLE
[DNM] Garbage Collection for partially overlapped blobs (with overlap count equal to 3)

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -971,6 +971,8 @@ OPTION(bluestore_compression, OPT_STR, "none")  // force|aggressive|passive|none
 OPTION(bluestore_compression_algorithm, OPT_STR, "snappy")
 OPTION(bluestore_compression_min_blob_size, OPT_U32, 256*1024)
 OPTION(bluestore_compression_max_blob_size, OPT_U32, 4*1024*1024)
+OPTION(bluestore_blob_depth_for_gc, OPT_U32, 3)
+OPTION(bluestore_merge_gc_data, OPT_BOOL, true)
 /*
  * Require the net gain of compression at least to be at this ratio,
  * otherwise we don't compress.

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -70,6 +70,7 @@ enum {
   l_bluestore_compressed,
   l_bluestore_compressed_allocated,
   l_bluestore_compressed_original,
+  l_bluestore_gc_bytes,
   l_bluestore_last
 };
 
@@ -1564,6 +1565,7 @@ private:
     bool buffered = false;       ///< buffered write
     bool compress = false;       ///< compressed write
     uint64_t comp_blob_size = 0; ///< target compressed blob size
+    uint8_t le_depth = 0;       ///< depth of the logical extent
     unsigned csum_order = 0;     ///< target checksum chunk order
 
     vector<std::pair<uint64_t, bluestore_lextent_t> > lex_old; ///< must deref blobs
@@ -1620,12 +1622,29 @@ private:
 	     uint32_t fadvise_flags);
   void _pad_zeros(bufferlist *bl, uint64_t *offset,
 		  uint64_t chunk_size);
+
+bool blobs_need_garbage_collection(OnodeRef o,
+                          uint64_t start_offset,
+                          uint64_t end_offset,
+                          uint8_t  *blob_depth,
+                          uint64_t *gc_start_offset,
+                          uint64_t *gc_end_offset);
+
   int _do_write(TransContext *txc,
 		CollectionRef &c,
 		OnodeRef o,
 		uint64_t offset, uint64_t length,
 		bufferlist& bl,
 		uint32_t fadvise_flags);
+void _do_write_data(
+  TransContext *txc,
+  CollectionRef& c,
+  OnodeRef o,
+  uint64_t offset,
+  uint64_t length,
+  bufferlist& bl,
+  WriteContext *wctx);
+
   int _touch(TransContext *txc,
 	     CollectionRef& c,
 	     OnodeRef& o);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -791,15 +791,21 @@ int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl,
 // bluestore_lextent_t
 void bluestore_lextent_t::encode(bufferlist& bl) const
 {
+  ENCODE_START(1, 1, bl);
   small_encode_signed_varint(blob, bl);
   small_encode_varint_lowz(offset, bl);
   small_encode_varint_lowz(length, bl);
+  ::encode(blob_depth, bl);
+  ENCODE_FINISH(bl);
 }
 void bluestore_lextent_t::decode(bufferlist::iterator& p)
 {
+  DECODE_START(1, p);
   small_decode_signed_varint(blob, p);
   small_decode_varint_lowz(offset, p);
   small_decode_varint_lowz(length, p);
+  ::decode(blob_depth, p);
+  DECODE_FINISH(p);
 }
 
 void bluestore_lextent_t::dump(Formatter *f) const
@@ -807,6 +813,7 @@ void bluestore_lextent_t::dump(Formatter *f) const
   f->dump_int("blob", blob);
   f->dump_unsigned("offset", offset);
   f->dump_unsigned("length", length);
+  f->dump_unsigned("blob_depth", blob_depth);
 }
 
 void bluestore_lextent_t::generate_test_instances(list<bluestore_lextent_t*>& ls)

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -584,13 +584,16 @@ struct bluestore_lextent_t {
   bluestore_blob_id_t blob;  ///< blob
   uint32_t offset;           ///< relative offset within the blob
   uint32_t length;           ///< length within the blob
+  uint8_t  blob_depth;       /// How many blobs overlaps the lolgical offset
 
   bluestore_lextent_t(bluestore_blob_id_t _blob = 0,
 		      uint32_t o = 0,
-		      uint32_t l = 0)
+		      uint32_t l = 0,
+                      uint8_t d = 1)
     : blob(_blob),
       offset(o),
-      length(l) {}
+      length(l),
+      blob_depth(d) {}
 
   uint64_t end() const {
     return offset + length;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -903,6 +903,243 @@ TEST_P(StoreTest, CompressionTest) {
   g_ceph_context->_conf->apply_changes(NULL);
 }
 
+TEST_P(StoreTest, garbageCollection) {
+  ObjectStore::Sequencer osr("test");
+  int r;
+  int64_t waste1, waste2;
+  coll_t cid;
+  int buf_len = 256 * 1024;
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  g_conf->set_val("bluestore_compression", "force");
+  g_conf->set_val("bluestore_merge_gc_data", "true"); 
+  g_ceph_context->_conf->apply_changes(NULL);
+
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  {
+    bufferlist in;
+    r = store->read(cid, hoid, 0, 5, in);
+    ASSERT_EQ(-ENOENT, r);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+
+  std::string data;
+  data.resize(buf_len);
+
+  {
+    { 
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = 'R';
+
+    bl.append(data);
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 0, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 2 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+  }
+  {
+    {
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = i  % 256;
+    bl.append(data);
+
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 2 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 50 * 1024, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+     }
+  }
+  {
+    {
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = i  % 256;
+    bl.append(data);
+
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 5 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 4 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 40 * 1024, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 5 * (buf_len - 3 * 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      t.remove_collection(cid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+     }
+  }
+  g_conf->set_val("bluestore_compression", "none");
+  g_ceph_context->_conf->apply_changes(NULL);
+}
+
 TEST_P(StoreTest, SimpleObjectTest) {
   ObjectStore::Sequencer osr("test");
   int r;


### PR DESCRIPTION
Because of overwrite operation, a new blob is created instead of merging data with the old blob. This leads to overlapping of blobs(example given below).
         ...................
            ......................
                 ......................
Because of overlapping blobs, space is wasted and read-performance can degrade. As part of this code change, we try to garbage collect the overlapping blobs. If the new write request results in overlapping count of more than 3, we extent the write request so that it completely overwrite the blobs adjacent to the new write request.

To keep track of the overlapping count, a new persistent field "blob_depth" is added to lextent. Whenever we add a new lextent, the "blob_depth" is set to the max of all the overlapping lextents + 1 (In fact we need not check all the overlapping lextents, we just need to check only two lextents covering the two ends of the new lextents)  . This will not always give the correct depth. It may over count in certain scenarios but will never undercount. Note: if lextents are splitted at the blobs boundary, it may be possible to correctly keep track of the depth, but that will increase the lextent counts and make "depth" update operation complicated. 