### PR TITLE
rgw: fix wrong variable definition in rgw_cls_lc_set_entry function

### DIFF
--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -714,11 +714,11 @@ int cls_rgw_lc_rm_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
 
 int cls_rgw_lc_set_entry(IoCtx& io_ctx, string& oid, pair<string, int>& entry)
 {
-   bufferlist in, out;
-   cls_rgw_lc_rm_entry_op call;
-   call.entry = entry;
-   ::encode(call, in);
-   int r = io_ctx.exec(oid, "rgw", "lc_set_entry", in, out);
+  bufferlist in, out;
+  cls_rgw_lc_set_entry_op call;
+  call.entry = entry;
+  ::encode(call, in);
+  int r = io_ctx.exec(oid, "rgw", "lc_set_entry", in, out);
   return r;
 }
 


### PR DESCRIPTION
Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>