### PR TITLE
rgw/swift: fix updating metadata failed for swift CORS 

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3130,7 +3130,7 @@ void RGWPutMetadataBucket::execute()
   if (has_cors) {
     buffer::list bl;
     cors_config.encode(bl);
-    emplace_attr(RGW_ATTR_CORS, std::move(bl));
+    attrs[RGW_ATTR_CORS] = std::move(bl);
   }
 
   /* It's supposed that following functions WILL NOT change any special

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -387,9 +387,7 @@ static int encode_token(CephContext *cct, string& swift_user, string& key,
   utime_t expiration = ceph_clock_now(cct);
   expiration += cct->_conf->rgw_swift_token_expiration;
 
-  ret = build_token(swift_user, key, nonce, expiration, bl);
-
-  return ret;
+  return build_token(swift_user, key, nonce, expiration, bl);
 }
 
 


### PR DESCRIPTION
I found it doesn't work when I try to update the CORS metadata
of swift buckets. as the following steps:

1) use the following command to create a swift bucket and post the CORS metadata;
`swift post swiftbkt0011 -H "X-Container-Meta-Access-Control-Allow-Origin: http://192.9.9.22" -H "X-Container-Meta-Access-Control-Request-Method: HEAD,POST,PUT,GET,OPTIONS,DELETE"`

2) use the command to update the `Access-Control-Allow-Origin` attr;
`swift post swiftbkt0011 -H "X-Container-Meta-Access-Control-Allow-Origin: http://192.9.9.130" -H "X-Container-Meta-Access-Control-Request-Method: HEAD,POST,PUT,GET,OPTIONS,DELETE"`

3) test the CORS,  access my swift bucket `swiftbkt0011` from the website at `192.9.9.130`

then I got the following failed log message:
```
2016-07-09 16:49:14.070218 7f6be3fef700 15 Read RGWCORSConfiguration<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><CORSRule><AllowedMethod>GET</AllowedMethod><AllowedMethod>PUT</AllowedMethod><AllowedMethod>DELETE</AllowedMethod><AllowedMethod>HEAD</AllowedMethod><AllowedMethod>POST</AllowedMethod><AllowedMethod>COPY</AllowedMethod><AllowedOrigin>http://192.9.9.22</AllowedOrigin></CORSRule></CORSConfiguration>
2016-07-09 16:49:14.070300 7f6be3fef700 10 There is no cors rule present for http://192.9.9.130
```

the `AllowedOrigin` has not yet update(still `http://192.9.9.22`), so maybe we should not
use `emplace` which will not update the attrs if they are already present in attrs.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>