### PR TITLE
mds: add assertion in handle_slave_rename_prep

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7153,10 +7153,13 @@ void Server::handle_slave_rename_prep(MDRequestRef& mdr)
   // discover srcdn
   filepath srcpath(mdr->slave_request->srcdnpath);
   dout(10) << " src " << srcpath << dendl;
-  CInode *srci;
+  CInode *srci = nullptr;
   r = mdcache->path_traverse(mdr, NULL, NULL, srcpath, &trace, &srci, MDS_TRAVERSE_DISCOVERXLOCK);
   if (r > 0) return;
   assert(r == 0);
+
+  // srcpath must not point to a null dentry
+  assert(srci != nullptr);
       
   CDentry *srcdn = trace[trace.size()-1];
   CDentry::linkage_t *srcdnl = srcdn->get_projected_linkage();


### PR DESCRIPTION
This function assumes that the source path
does not point to a null dentry, and that
path_traverse is therefore setting the
passed inode.

Candidate code path for crash
in http://tracker.ceph.com/issues/16807

Signed-off-by: John Spray <john.spray@redhat.com>