### PR TITLE
qa/workunits/cephtool/test.sh: use absolute path for TEMP_DIR

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -33,7 +33,7 @@ function expect_false()
 }
 
 
-TEMP_DIR=$(mktemp -d cephtool.XXX)
+TEMP_DIR=$(mktemp -d ${TMPDIR-/tmp}/cephtool.XXX)
 trap "rm -fr $TEMP_DIR" 0
 
 TMPFILE=$(mktemp $TEMP_DIR/test_invalid.XXX)


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>