### PR TITLE
os/bluestore: proper handling for csum enable/disable settings

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -328,8 +328,8 @@ struct bluestore_blob_t {
   }
 
   /// return chunk (i.e. min readable block) size for the blob
-  uint64_t get_chunk_size(uint64_t dev_block_size) {
-    return has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
+  uint64_t get_chunk_size(bool csum_enabled, uint64_t dev_block_size) {
+    return csum_enabled && has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
   }
   uint32_t get_csum_chunk_size() const {
     return 1 << csum_chunk_order;


### PR DESCRIPTION
There is no need to read 'csum aligned' chunks when reading with csum verification disabled. Hence we can tune read performance.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>
