### PR TITLE
debian: replace SysV rbdmap with systemd service

### DIFF
--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -34,7 +34,6 @@ usr/share/ceph/known_hosts_drop.ceph.com
 usr/share/ceph/id_dsa_drop.ceph.com
 usr/share/ceph/id_dsa_drop.ceph.com.pub
 etc/ceph/rbdmap
-etc/init.d/rbdmap
 lib/udev/rules.d/50-rbd.rules
 usr/lib/python*/dist-packages/ceph_argparse.py*
 usr/lib/python*/dist-packages/ceph_daemon.py*

--- a/debian/rules
+++ b/debian/rules
@@ -39,7 +39,6 @@ override_dh_auto_install:
 	install -D -m 644 udev/95-ceph-osd.rules $(DESTDIR)/lib/udev/rules.d/95-ceph-osd.rules
 	install -D -m 644 udev/60-ceph-by-parttypeuuid.rules $(DESTDIR)/lib/udev/rules.d/60-ceph-by-parttypeuuid.rules
 	install -D -m 644 src/etc-rbdmap $(DESTDIR)/etc/ceph/rbdmap
-	install -D -m 755 src/init-rbdmap $(DESTDIR)/etc/init.d/rbdmap
 
 # doc/changelog is a directory, which confuses dh_installchangelogs
 override_dh_installchangelogs:
@@ -85,6 +84,7 @@ override_dh_installinit:
 	install -m0644 systemd/ceph-create-keys@.service debian/ceph-base/lib/systemd/system
 	install -m0644 systemd/ceph-osd@.service debian/ceph-osd/lib/systemd/system
 	install -m0644 systemd/ceph-disk@.service debian/ceph-osd/lib/systemd/system
+	install -m0644 systemd/rbdmap.service debian/ceph-common/lib/systemd/system
 	sed -i s./etc/sysconfig/./etc/default/.g debian/ceph-mon/lib/systemd/system/ceph-mon@.service
 	sed -i s./etc/sysconfig/./etc/default/.g debian/ceph-base/lib/systemd/system/ceph-create-keys@.service
 	sed -i s./etc/sysconfig/./etc/default/.g debian/ceph-osd/lib/systemd/system/ceph-osd@.service


### PR DESCRIPTION
Stop shipping `/etc/init.d/rbdmap` in the Debian packages. Ship the `rbdmap.service` systemd unit file instead.

The corresponding change has already been made for RPMs, in 9224ac2ad25f7d017916f58b642c0ea25305c3e5.

For Upstart-based systems (eg Ubuntu Trusty), the Debian packages already contain `rbdmap.conf`.

(This gets us a tiny bit closer to being able to remove the rbdmap SysV script from our tree entirely.)