### PR TITLE
ARM64 fixes

### DIFF
--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -45,6 +45,7 @@ if(ARM_NEON OR ARM_NEON2)
     gf-complete/src/neon/gf_w32_neon.c
     gf-complete/src/neon/gf_w64_neon.c)
   add_library(neon_objs OBJECT ${neon_objs_srcs})
+  set_target_properties(neon_objs PROPERTIES COMPILE_FLAGS ${ARM_NEON_FLAGS})
 
   set(jerasure_neon_srcs
     $<TARGET_OBJECTS:ec_jerasure_objs>

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -356,8 +356,12 @@ target_link_libraries(ceph_multi_stress_watch librados global radostest
 add_executable(ceph_perf_local 
   perf_local.cc
   perf_helper.cc)
-#INTEL_SSE & INTEL_SSE2 flags
-set(PERF_LOCAL_FLAGS "-msse -msse2")
+if(HAVE_SSE)
+  set(PERF_LOCAL_FLAGS ${SSE3_FLAGS})
+endif(HAVE_SSE)
+if(HAVE_NEON)
+  set(PERF_LOCAL_FLAGS ${ARM_NEON_FLAGS})
+endif(HAVE_NEON)
 set_target_properties(ceph_perf_local PROPERTIES COMPILE_FLAGS
   ${PERF_LOCAL_FLAGS})
 target_link_libraries(ceph_perf_local os global ${UNITTEST_LIBS})


### PR DESCRIPTION
Three things to fix build on arm64.  The changes for jerasure and test should not affect x86, but the rocksdb update certainly might; marking needs-qa because of that.

(We need a CI builder for arm64.  Something happened to the Cavium-supplied gitbuilder and I'm not sure what.)