### PR TITLE
man/Makefile-client.am: drop legacy cephfs tool

### DIFF
--- a/man/Makefile-client.am
+++ b/man/Makefile-client.am
@@ -24,11 +24,6 @@ dist_man_MANS += \
 	rbdmap.8
 endif
 
-if WITH_CEPHFS
-dist_man_MANS += \
-	cephfs.8
-endif
-
 if WITH_FUSE
 dist_man_MANS += \
 	rbd-fuse.8 \


### PR DESCRIPTION
Somehow c76c31d312ce7a623acd99dbdedfe471c0cd445f missed this bit.

Signed-off-by: Nathan Cutler <ncutler@suse.com>