### PR TITLE
journal: increase concurrency/parallelism of journal recorder

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -104,6 +104,8 @@ do
 
   snap_name="snap${i}"
   create_snap ${CLUSTER2} ${POOL} ${image} ${snap_name}
+  wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
+  wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
   wait_for_snap_present ${CLUSTER1} ${POOL} ${image} ${snap_name}
   compare_image_snaps ${POOL} ${image} ${snap_name}
 done

--- a/src/journal/JournalMetadata.h
+++ b/src/journal/JournalMetadata.h
@@ -98,6 +98,10 @@ public:
     m_work_queue->queue(on_finish, r);
   }
 
+  inline ContextWQ *get_work_queue() {
+    return m_work_queue;
+  }
+
   inline SafeTimer &get_timer() {
     return *m_timer;
   }

--- a/src/journal/JournalRecorder.cc
+++ b/src/journal/JournalRecorder.cc
@@ -61,10 +61,12 @@ JournalRecorder::JournalRecorder(librados::IoCtx &ioctx,
 
   uint8_t splay_width = m_journal_metadata->get_splay_width();
   for (uint8_t splay_offset = 0; splay_offset < splay_width; ++splay_offset) {
-    m_object_locks.push_back(shared_ptr<Mutex>(new Mutex("ObjectRecorder::m_lock::"+
-                                       std::to_string(splay_offset))));
+    m_object_locks.push_back(shared_ptr<Mutex>(
+                                          new Mutex("ObjectRecorder::m_lock::"+
+                                          std::to_string(splay_offset))));
     uint64_t object_number = splay_offset + (m_current_set * splay_width);
-    m_object_ptrs[splay_offset] = create_object_recorder(object_number,
+    m_object_ptrs[splay_offset] = create_object_recorder(
+                                                object_number,
                                                 m_object_locks[splay_offset]);
   }
 
@@ -206,14 +208,17 @@ void JournalRecorder::open_object_set() {
   for (ObjectRecorderPtrs::iterator it = m_object_ptrs.begin();
        it != m_object_ptrs.end(); ++it) {
     ObjectRecorderPtr object_recorder = it->second;
-    if (object_recorder->get_object_number() / splay_width != m_current_set) {
+    uint64_t object_number = object_recorder->get_object_number();
+    if (object_number / splay_width != m_current_set) {
       assert(object_recorder->is_closed());
 
       // ready to close object and open object in active set
-      create_next_object_recorder(object_recorder);
+      create_next_object_recorder_unlock(object_recorder);
+    } else {
+      uint8_t splay_offset = object_number % splay_width;
+      m_object_locks[splay_offset]->Unlock();
     }
   }
-  unlock_object_recorders();
 }
 
 bool JournalRecorder::close_object_set(uint64_t active_set) {
@@ -246,14 +251,14 @@ ObjectRecorderPtr JournalRecorder::create_object_recorder(
     uint64_t object_number, shared_ptr<Mutex> lock) {
   ObjectRecorderPtr object_recorder(new ObjectRecorder(
     m_ioctx, utils::get_object_name(m_object_oid_prefix, object_number),
-    object_number, lock, m_journal_metadata->get_timer(),
-    m_journal_metadata->get_timer_lock(), &m_object_handler,
-    m_journal_metadata->get_order(), m_flush_interval, m_flush_bytes,
-    m_flush_age));
+    object_number, lock, m_journal_metadata->get_work_queue(),
+    m_journal_metadata->get_timer(), m_journal_metadata->get_timer_lock(),
+    &m_object_handler, m_journal_metadata->get_order(), m_flush_interval,
+    m_flush_bytes, m_flush_age));
   return object_recorder;
 }
 
-void JournalRecorder::create_next_object_recorder(
+void JournalRecorder::create_next_object_recorder_unlock(
     ObjectRecorderPtr object_recorder) {
   assert(m_lock.is_locked());
 
@@ -279,7 +284,7 @@ void JournalRecorder::create_next_object_recorder(
       new_object_recorder->get_object_number());
   }
 
-  new_object_recorder->append(append_buffers, false);
+  new_object_recorder->append_unlock(append_buffers);
 
   m_object_ptrs[splay_offset] = new_object_recorder;
 }

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -92,6 +92,7 @@ private:
   uint32_t m_in_flight_object_closes = 0;
   uint64_t m_current_set;
   ObjectRecorderPtrs m_object_ptrs;
+  std::vector<std::shared_ptr<Mutex>> m_object_locks;
 
   FutureImplPtr m_prev_future;
 
@@ -103,13 +104,26 @@ private:
 
   void close_and_advance_object_set(uint64_t object_set);
 
-  ObjectRecorderPtr create_object_recorder(uint64_t object_number);
+  ObjectRecorderPtr create_object_recorder(uint64_t object_number,
+                                           std::shared_ptr<Mutex> lock);
   void create_next_object_recorder(ObjectRecorderPtr object_recorder);
 
   void handle_update();
 
   void handle_closed(ObjectRecorder *object_recorder);
   void handle_overflow(ObjectRecorder *object_recorder);
+
+  void lock_object_recorders() {
+    for (auto& lock : m_object_locks) {
+      lock->Lock();
+    }
+  }
+
+  void unlock_object_recorders() {
+    for (auto& lock : m_object_locks) {
+      lock->Unlock();
+    }
+  }
 };
 
 } // namespace journal

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -106,7 +106,7 @@ private:
 
   ObjectRecorderPtr create_object_recorder(uint64_t object_number,
                                            std::shared_ptr<Mutex> lock);
-  void create_next_object_recorder(ObjectRecorderPtr object_recorder);
+  void create_next_object_recorder_unlock(ObjectRecorderPtr object_recorder);
 
   void handle_update();
 

--- a/src/journal/ObjectRecorder.h
+++ b/src/journal/ObjectRecorder.h
@@ -9,6 +9,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/RefCountedObj.h"
+#include "common/WorkQueue.h"
 #include "journal/FutureImpl.h"
 #include <list>
 #include <map>
@@ -38,9 +39,9 @@ public:
 
   ObjectRecorder(librados::IoCtx &ioctx, const std::string &oid,
                  uint64_t object_number, std::shared_ptr<Mutex> lock,
-                 SafeTimer &timer, Mutex &timer_lock, Handler *handler,
-                 uint8_t order, uint32_t flush_interval, uint64_t flush_bytes,
-                 double flush_age);
+                 ContextWQ *work_queue, SafeTimer &timer, Mutex &timer_lock,
+                 Handler *handler, uint8_t order, uint32_t flush_interval,
+                 uint64_t flush_bytes, double flush_age);
   ~ObjectRecorder();
 
   inline uint64_t get_object_number() const {
@@ -51,7 +52,6 @@ public:
   }
 
   bool append_unlock(const AppendBuffers &append_buffers);
-  bool append(const AppendBuffers &append_buffers, bool unlock);
   void flush(Context *on_safe);
   void flush(const FutureImplPtr &future);
 
@@ -86,6 +86,7 @@ private:
       object_recorder->put();
     }
     virtual void flush(const FutureImplPtr &future) {
+      Mutex::Locker locker(*(object_recorder->m_lock));
       object_recorder->flush(future);
     }
   };
@@ -114,6 +115,8 @@ private:
   std::string m_oid;
   uint64_t m_object_number;
   CephContext *m_cct;
+
+  ContextWQ *m_op_work_queue;
 
   SafeTimer &m_timer;
   Mutex &m_timer_lock;
@@ -147,6 +150,9 @@ private:
   bool m_in_flight_flushes;
   Cond m_in_flight_flushes_cond;
 
+  AppendBuffers m_pending_buffers;
+  bool m_aio_scheduled;
+
   void handle_append_task();
   void cancel_append_task();
   void schedule_append_task();
@@ -156,6 +162,7 @@ private:
   void handle_append_flushed(uint64_t tid, int r);
   void append_overflowed(uint64_t tid);
   void send_appends(AppendBuffers *append_buffers);
+  void send_appends_aio();
 
   void notify_handler();
 };

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -861,17 +861,19 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
   Futures futures;
   uint64_t tid;
   {
-    Mutex::Locker locker(m_lock);
-    assert(m_state == STATE_READY);
+    {
+      Mutex::Locker locker(m_lock);
+      assert(m_state == STATE_READY);
 
-    Mutex::Locker event_locker(m_event_lock);
-    tid = ++m_event_tid;
-    assert(tid != 0);
+      tid = ++m_event_tid;
+      assert(tid != 0);
+    }
 
     for (auto &bl : bufferlists) {
       assert(bl.length() <= m_max_append_size);
       futures.push_back(m_journaler->append(m_tag_tid, bl));
     }
+    Mutex::Locker event_locker(m_event_lock);
     m_events[tid] = Event(futures, requests, offset, length);
   }
 

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -20,6 +20,7 @@
 #include "librbd/journal/CreateRequest.h"
 
 #include <boost/scope_exit.hpp>
+#include <utility>
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
@@ -670,50 +671,56 @@ int Journal<I>::demote() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << __func__ << dendl;
 
-  Mutex::Locker locker(m_lock);
-  assert(m_journaler != nullptr && is_tag_owner(m_lock));
-
-  cls::journal::Client client;
-  int r = m_journaler->get_cached_client(IMAGE_CLIENT_ID, &client);
-  if (r < 0) {
-    lderr(cct) << this << " " << __func__ << ": "
-               << "failed to retrieve client: " << cpp_strerror(r) << dendl;
-    return r;
-  }
-
-  assert(m_tag_data.mirror_uuid == LOCAL_MIRROR_UUID);
-  journal::TagPredecessor predecessor;
-  predecessor.mirror_uuid = LOCAL_MIRROR_UUID;
-  if (!client.commit_position.object_positions.empty()) {
-    auto position = client.commit_position.object_positions.front();
-    predecessor.commit_valid = true;
-    predecessor.tag_tid = position.tag_tid;
-    predecessor.entry_tid = position.entry_tid;
-  }
-
-  cls::journal::Tag new_tag;
-  r = allocate_journaler_tag(cct, m_journaler, client, m_tag_class,
-                             predecessor, ORPHAN_MIRROR_UUID, &new_tag);
-  if (r < 0) {
-    return r;
-  }
-
-  bufferlist::iterator tag_data_bl_it = new_tag.data.begin();
-  r = C_DecodeTag::decode(&tag_data_bl_it, &m_tag_data);
-  if (r < 0) {
-    lderr(cct) << this << " " << __func__ << ": "
-               << "failed to decode newly allocated tag" << dendl;
-    return r;
-  }
-
-  journal::EventEntry event_entry{journal::DemoteEvent{}};
-  bufferlist event_entry_bl;
-  ::encode(event_entry, event_entry_bl);
-
-  m_tag_tid = new_tag.tid;
-  Future future = m_journaler->append(m_tag_tid, event_entry_bl);
+  int r;
   C_SaferCond ctx;
-  future.flush(&ctx);
+  Future future;
+  C_SaferCond flush_ctx;
+
+  {
+    Mutex::Locker locker(m_lock);
+    assert(m_journaler != nullptr && is_tag_owner(m_lock));
+
+    cls::journal::Client client;
+    r = m_journaler->get_cached_client(IMAGE_CLIENT_ID, &client);
+    if (r < 0) {
+      lderr(cct) << this << " " << __func__ << ": "
+                 << "failed to retrieve client: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    assert(m_tag_data.mirror_uuid == LOCAL_MIRROR_UUID);
+    journal::TagPredecessor predecessor;
+    predecessor.mirror_uuid = LOCAL_MIRROR_UUID;
+    if (!client.commit_position.object_positions.empty()) {
+      auto position = client.commit_position.object_positions.front();
+      predecessor.commit_valid = true;
+      predecessor.tag_tid = position.tag_tid;
+      predecessor.entry_tid = position.entry_tid;
+    }
+
+    cls::journal::Tag new_tag;
+    r = allocate_journaler_tag(cct, m_journaler, client, m_tag_class,
+                               predecessor, ORPHAN_MIRROR_UUID, &new_tag);
+    if (r < 0) {
+      return r;
+    }
+
+    bufferlist::iterator tag_data_bl_it = new_tag.data.begin();
+    r = C_DecodeTag::decode(&tag_data_bl_it, &m_tag_data);
+    if (r < 0) {
+      lderr(cct) << this << " " << __func__ << ": "
+                 << "failed to decode newly allocated tag" << dendl;
+      return r;
+    }
+
+    journal::EventEntry event_entry{journal::DemoteEvent{}};
+    bufferlist event_entry_bl;
+    ::encode(event_entry, event_entry_bl);
+
+    m_tag_tid = new_tag.tid;
+    future = m_journaler->append(m_tag_tid, event_entry_bl);
+    future.flush(&ctx);
+  }
 
   r = ctx.wait();
   if (r < 0) {
@@ -723,9 +730,11 @@ int Journal<I>::demote() {
     return r;
   }
 
-  m_journaler->committed(future);
-  C_SaferCond flush_ctx;
-  m_journaler->flush_commit_position(&flush_ctx);
+  {
+    Mutex::Locker l(m_lock);
+    m_journaler->committed(future);
+    m_journaler->flush_commit_position(&flush_ctx);
+  }
 
   r = flush_ctx.wait();
   if (r < 0) {
@@ -858,21 +867,22 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
                                       bool flush_entry) {
   assert(!bufferlists.empty());
 
-  Futures futures;
   uint64_t tid;
   {
-    {
-      Mutex::Locker locker(m_lock);
-      assert(m_state == STATE_READY);
+    Mutex::Locker locker(m_lock);
+    assert(m_state == STATE_READY);
 
-      tid = ++m_event_tid;
-      assert(tid != 0);
-    }
+    tid = ++m_event_tid;
+    assert(tid != 0);
+  }
 
-    for (auto &bl : bufferlists) {
-      assert(bl.length() <= m_max_append_size);
-      futures.push_back(m_journaler->append(m_tag_tid, bl));
-    }
+  Futures futures;
+  for (auto &bl : bufferlists) {
+    assert(bl.length() <= m_max_append_size);
+    futures.push_back(m_journaler->append(m_tag_tid, bl));
+  }
+
+  {
     Mutex::Locker event_locker(m_event_lock);
     m_events[tid] = Event(futures, requests, offset, length);
   }
@@ -892,6 +902,7 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
   } else {
     futures.back().wait(on_safe);
   }
+
   return tid;
 }
 

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -10,6 +10,7 @@
 #include "include/interval_set.h"
 #include "common/Cond.h"
 #include "common/Mutex.h"
+#include "common/Cond.h"
 #include "journal/Future.h"
 #include "journal/JournalMetadataListener.h"
 #include "journal/ReplayEntry.h"
@@ -165,6 +166,10 @@ public:
   void remove_listener(journal::Listener *listener);
 
   int is_resync_requested(bool *do_resync);
+
+  inline ContextWQ *get_work_queue() {
+    return m_work_queue;
+  }
 
 private:
   ImageCtxT &m_image_ctx;

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -950,11 +950,13 @@ TEST_F(TestMockJournal, EventAndIOCommitOrder) {
   expect_append_journaler(mock_journaler);
   expect_wait_future(mock_future, &on_journal_safe1);
   ASSERT_EQ(1U, when_append_io_event(mock_image_ctx, mock_journal));
+  mock_journal.get_work_queue()->drain();
 
   Context *on_journal_safe2;
   expect_append_journaler(mock_journaler);
   expect_wait_future(mock_future, &on_journal_safe2);
   ASSERT_EQ(2U, when_append_io_event(mock_image_ctx, mock_journal));
+  mock_journal.get_work_queue()->drain();
 
   // commit journal event followed by IO event (standard)
   on_journal_safe1->complete(0);
@@ -998,6 +1000,7 @@ TEST_F(TestMockJournal, AppendWriteEvent) {
   expect_append_journaler(mock_journaler);
   expect_wait_future(mock_future, &on_journal_safe);
   ASSERT_EQ(1U, when_append_write_event(mock_image_ctx, mock_journal, 1 << 17));
+  mock_journal.get_work_queue()->drain();
 
   on_journal_safe->complete(0);
   C_SaferCond event_ctx;
@@ -1037,6 +1040,7 @@ TEST_F(TestMockJournal, EventCommitError) {
   expect_wait_future(mock_future, &on_journal_safe);
   ASSERT_EQ(1U, when_append_io_event(mock_image_ctx, mock_journal,
                                      object_request));
+  mock_journal.get_work_queue()->drain();
 
   // commit the event in the journal w/o waiting writeback
   expect_future_committed(mock_journaler);
@@ -1076,6 +1080,7 @@ TEST_F(TestMockJournal, EventCommitErrorWithPendingWriteback) {
   expect_wait_future(mock_future, &on_journal_safe);
   ASSERT_EQ(1U, when_append_io_event(mock_image_ctx, mock_journal,
                                      object_request));
+  mock_journal.get_work_queue()->drain();
 
   expect_future_is_valid(mock_future);
   C_SaferCond flush_ctx;
@@ -1111,6 +1116,7 @@ TEST_F(TestMockJournal, IOCommitError) {
   expect_append_journaler(mock_journaler);
   expect_wait_future(mock_future, &on_journal_safe);
   ASSERT_EQ(1U, when_append_io_event(mock_image_ctx, mock_journal));
+  mock_journal.get_work_queue()->drain();
 
   // failed IO remains uncommitted in journal
   on_journal_safe->complete(0);


### PR DESCRIPTION
This is a preliminary solution to the problem of increasing the throughput of write operations to RBD images' journals.

The current solution might still have data races in some fields of `JournalRecorder` class, that were protected by the `JournalRecorder::m_lock`.
Also, this implementation still needs testing, not even "make check" was run against this.

Related tracker ticket: http://tracker.ceph.com/issues/15259

Signed-off-by: Ricardo Dias <rdias@suse.com>