### PR TITLE
tools: fix the core dump when get the crushmap do not exist

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -697,9 +697,11 @@ int main(int argc, char **argv) {
     } else if (map_type == "crushmap") {
       bufferlist tmp;
       r = st.get("osdmap", st.combine_strings("full", v), tmp);
-      OSDMap osdmap;
-      osdmap.decode(tmp);
-      osdmap.crush->encode(bl);
+      if (r >= 0) {
+        OSDMap osdmap;
+        osdmap.decode(tmp);
+        osdmap.crush->encode(bl);
+      }
     } else {
       r = st.get(map_type, v, bl);
     }


### PR DESCRIPTION
tools: fix the core dump when get the crushmap version which it  does not exist

Signed-off-by:song baisen <song.baisen@zte.com.cn>