### PR TITLE
test: break out librados-using cephfs test

### DIFF
--- a/qa/workunits/libcephfs/test.sh
+++ b/qa/workunits/libcephfs/test.sh
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 
 ceph_test_libcephfs
+ceph_test_libcephfs_access
 
 exit 0

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -6,18 +6,32 @@ if(${WITH_CEPHFS})
     multiclient.cc
     flock.cc
     acl.cc
-    access.cc
   )
   set_target_properties(ceph_test_libcephfs PROPERTIES COMPILE_FLAGS
     ${UNITTEST_CXX_FLAGS})
   target_link_libraries(ceph_test_libcephfs
+    cephfs
+    ${UNITTEST_LIBS}
+    ${EXTRALIBS}
+    ${CMAKE_DL_LIBS}
+    )
+  install(TARGETS ceph_test_libcephfs
+    DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+  add_executable(ceph_test_libcephfs_access
+    test.cc
+    access.cc
+  )
+  set_target_properties(ceph_test_libcephfs_access PROPERTIES COMPILE_FLAGS
+    ${UNITTEST_CXX_FLAGS})
+  target_link_libraries(ceph_test_libcephfs_access
     cephfs
     librados
     ${UNITTEST_LIBS}
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
     )
-  install(TARGETS ceph_test_libcephfs
+  install(TARGETS ceph_test_libcephfs_access
     DESTINATION ${CMAKE_INSTALL_BINDIR})
 endif(${WITH_CEPHFS})  
 

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -72,7 +72,7 @@ int do_mon_command(string s, string *key)
 
 string get_unique_dir()
 {
-  return string("/ceph_test_libcephfs.") + stringify(rand());
+  return string("/ceph_test_libcephfs_access.") + stringify(rand());
 }
 
 TEST(AccessTest, Foo) {


### PR DESCRIPTION
We are seeing an issue due to the lockdep symbols
in libcephfs and librados clashing, which shows itself
after a fork in the flock tests.  We can avoid this
by splitting the libcephfs tests that require librados
(access.cc) into their own compilation unit so that
the flock tests can run in a libcephfs-only process.

Fixes: http://tracker.ceph.com/issues/16556
Signed-off-by: John Spray <john.spray@redhat.com>