### PR TITLE
src/kv/MemDB.cc: the type of the parameter of push_back() does not match the ops's value_type

### DIFF
--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -227,7 +227,7 @@ void MemDB::MDBTransactionImpl::rmkey(const string &prefix,
   dtrace << __func__ << " " << prefix << " " << k << dendl;
   ops.push_back(make_pair(DELETE,
                           std::make_pair(std::make_pair(prefix, k),
-                          NULL)));
+                          bufferlist())));
 }
 
 void MemDB::MDBTransactionImpl::rmkeys_by_prefix(const string &prefix)


### PR DESCRIPTION
 - NULL is a C-type usuage, which is allow by GCC.
   But Clang is more strick in checking:

Error looks like:
src/kv/MemDB.cc:228:7r error: no matching member function
for call to 'push_back'
  ops.push_back(make_pair(DELETE,
  ~~~~^~~~~~~~~
/usr/include/c++/v1/vector:685:36: note: candidate function not viable:
no known conversion from 'pair<[...], pair<[...], nullptr_t>>' to
      'const pair<[...], pair<[...], ceph::buffer::list>>' for 1st argument
    _LIBCPP_INLINE_VISIBILITY void push_back(const_reference __x);
                                   ^

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>