### PR TITLE
AddCephTest.cmake: Make PYTHONPATH a bit more flexible

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -1,5 +1,31 @@
 #AddCephTest is a module for adding tests to the "make check" target which runs CTest
 
+execute_process(
+    COMMAND uname -m
+    OUTPUT_VARIABLE ARCHSTR
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+if(LINUX)
+  set(OSSTR linux)
+elseif(FREEBSD)
+  execute_process(
+    COMMAND uname -r
+    OUTPUT_VARIABLE OSVER
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  set(OSSTR freebsd-${OSVER})
+else()
+  message(FATAL_ERROR "unsupported OS, please fix PYTHONPATH construction first.")
+  #
+  # If you get this message for your OS you need to work out where
+  # cython would put its libs.
+  # For Linux is is something like:
+  #    ceph/build/lib/cython_modules/lib.linux-x86_64-2.7
+  # For FreeBSD it is something like:
+  #    ceph/build/lib/cython_modules/lib.freebsd-11.0-CURRENT-amd64-2.7
+endif(LINUX)
+
+set(PYVER "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}")
+
 #adds makes target/script into a test, test to check target, sets necessary environment variables
 function(add_ceph_test test_name test_path)
   add_test(NAME ${test_name} COMMAND ${test_path})
@@ -13,7 +39,7 @@ function(add_ceph_test test_name test_path)
     CEPH_BUILD_DIR=${CMAKE_BINARY_DIR}
     LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
-    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.linux-x86_64-2.7:${CMAKE_SOURCE_DIR}/src/pybind
+    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.${OSSTR}-${ARCHSTR}-${PYVER}:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
   # none of the tests should take more than 1 hour to complete
   set_property(TEST


### PR DESCRIPTION
 - Other OSes will have different diretories where cython results
   will be delivered.
   Path is now made flexibel by using Variables
   A version for FreeBSD is added

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>