### PR TITLE
rgw: add tenant to shard_id in RGWDeleteLC::execute()

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4847,7 +4847,7 @@ void RGWDeleteLC::execute()
             << " returned err=" << op_ret << dendl;
     return;
   }
-  string shard_id = s->bucket.name + ':' +s->bucket.bucket_id;
+  string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.bucket_id;
   pair<string, int> entry(shard_id, lc_uninitial);
   string oid; 
   get_lc_oid(s, oid);


### PR DESCRIPTION
in RGWDeleteLC::execute(), we should add bucket.tenant to shard_id,
otherwise, the lc entry can't delete after this op

Signed-off-by: Wei Qiaomiao wei.qiaomiao@zte.com.cn
