### PR TITLE
  cmake: reconstruct the cmake files and extract one common module

### DIFF
--- a/cmake/modules/CheckCompileTargets.cmake
+++ b/cmake/modules/CheckCompileTargets.cmake
@@ -1,0 +1,77 @@
+# CMake module to get the compile options to match the target 
+#
+# If ARM NEON instruments set is supported, the following flags are set:
+# ARM_NEON
+# ARM_NEON2
+# If ARM CRC instrument set is supported, the flag HAVE_ARMV8_CRC is set,
+# and the related compile options are set
+# If INTEL SSE instruments set are supported, the related flags and 
+# compile options are set
+
+set(sse_srcs "${CMAKE_BINARY_DIR}/src/test/erasure-code/tmp_sse.c")
+file(WRITE ${sse_srcs} "void main() {}")
+
+# try each -msse flag
+try_compile(INTEL_SSE ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-msse")
+try_compile(INTEL_SSE2 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-msse2")
+try_compile(INTEL_SSE3 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-msse3")
+try_compile(INTEL_SSSE3 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-mssse3")
+try_compile(INTEL_SSE4_1 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-msse4.1")
+try_compile(INTEL_SSE4_2 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-msse4.2")
+try_compile(ARM_NEON ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-mfpu=neon")
+try_compile(ARM_NEON2 ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-march=armv8-a+simd")
+try_compile(ARM_CRC ${CMAKE_BINARY_DIR} ${sse_srcs}
+  COMPILE_DEFINITIONS "-march=armv8-a+crc")
+
+# clean up tmp file
+file(REMOVE ${sse_srcs})
+
+if(ARM_CRC)
+  set(HAVE_ARMV8_CRC 1)
+  set(ARM_CRC_FLAGS "-march=armv8-a+crc -DARCH_AARCH64")
+endif(ARM_CRC)
+
+if(ARM_NEON OR ARM_NEON2)
+  set(HAVE_NEON 1)
+  if(ARM_NEON)
+    set(ARM_NEON_FLAGS "-mfpu=neon -DARM_NEON")
+  else(ARM_NEON)
+    set(ARM_NEON_FLAGS "-march=armv8-a+simd -DARCH_AARCH64 -DARM_NEON")
+  endif(ARM_NEON)
+else(ARM_NEON OR ARM_NEON2)
+  message(STATUS "Skipping target ec_jerasure_neon & ec_shec_neon: Architecture not ARM")
+endif(ARM_NEON OR ARM_NEON2)
+
+if(INTEL_SSE)
+  set(HAVE_SSE 1)
+  set(SSE3_FLAGS "-msse")
+  if (INTEL_SSE2)
+    set(HAVE_SSE2 1)
+    set(SSE3_FLAGS "${SSE3_FLAGS} -msse2")
+  endif (INTEL_SSE2)
+  if (INTEL_SSE3)
+    set(SSE3_FLAGS "${SSE3_FLAGS} -msse3")
+  endif (INTEL_SSE3)
+  if (INTEL_SSSE3)
+    set(SSE3_FLAGS "${SSE3_FLAGS} -mssse3")
+  endif (INTEL_SSSE3)
+else(INTEL_SSE)
+  message(STATUS "Skipping target ec_jerasure_sse3 & ec_shec_sse3: -msse not supported")
+endif(INTEL_SSE)
+
+if(INTEL_SSE4_1)
+  set(SSE4_FLAGS "${SSE3_FLAGS} -msse4.1")
+  if (INTEL_SSE4_2)
+    set(SSE4_FLAGS "${SSE4_FLAGS} -msse4.2")
+  endif (INTEL_SSE4_2)
+else(INTEL_SSE4_1)
+  message(STATUS "Skipping target ec_jerasure_sse4 & ec_shec_sse4: -msse4.1 not supported")
+endif(INTEL_SSE4_1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -145,78 +145,6 @@ if(COMPILER_SUPPORTS_DIAGNOSTICS_COLOR)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=${DIAGNOSTICS_COLOR}")
 endif()
 
-
-## detect sse support
-
-# create a tmp file with an empty main()
-set(sse_srcs "${CMAKE_BINARY_DIR}/src/erasure-code/jerasure/tmp_sse.c")
-file(WRITE ${sse_srcs} "void main() {}")
-
-# try each -msse flag
-try_compile(INTEL_SSE ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-msse")
-try_compile(INTEL_SSE2 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-msse2")
-try_compile(INTEL_SSE3 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-msse3")
-try_compile(INTEL_SSSE3 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-mssse3")
-try_compile(INTEL_SSE4_1 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-msse4.1")
-try_compile(INTEL_SSE4_2 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-msse4.2")
-try_compile(ARM_NEON ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-mfpu=neon")
-try_compile(ARM_NEON2 ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-march=armv8-a+simd")
-try_compile(ARM_CRC ${CMAKE_BINARY_DIR} ${sse_srcs}
-  COMPILE_DEFINITIONS "-march=armv8-a+crc")
-
-# clean up tmp file
-file(REMOVE ${sse_srcs})
-
-if(ARM_CRC)
-  set(HAVE_ARMV8_CRC 1)
-  set(ARM_CRC_FLAGS "-march=armv8-a+crc -DARCH_AARCH64")
-endif(ARM_CRC)
-
-if(ARM_NEON OR ARM_NEON2)
-  set(HAVE_NEON 1)
-  if(ARM_NEON)
-    set(ARM_NEON_FLAGS "-mfpu=neon -DARM_NEON")
-  else(ARM_NEON)
-    set(ARM_NEON_FLAGS "-march=armv8-a+simd -DARCH_AARCH64 -DARM_NEON")
-  endif(ARM_NEON)
-else(ARM_NEON OR ARM_NEON2)
-  message(STATUS "Skipping target ec_jerasure_neon & ec_shec_neon: Architecture not ARM")
-endif(ARM_NEON OR ARM_NEON2)
-
-if(INTEL_SSE)
-  set(HAVE_SSE 1)
-  set(SSE3_FLAGS "-msse")
-  if (INTEL_SSE2)
-    set(HAVE_SSE2 1)
-    set(SSE3_FLAGS "${SSE3_FLAGS} -msse2")
-  endif (INTEL_SSE2)
-  if (INTEL_SSE3)
-    set(SSE3_FLAGS "${SSE3_FLAGS} -msse3")
-  endif (INTEL_SSE3)
-  if (INTEL_SSSE3)
-    set(SSE3_FLAGS "${SSE3_FLAGS} -mssse3")
-  endif (INTEL_SSSE3)
-else(INTEL_SSE)
-  message(STATUS "Skipping target ec_jerasure_sse3 & ec_shec_sse3: -msse not supported")
-endif(INTEL_SSE)
-
-if(INTEL_SSE4_1)
-  set(SSE4_FLAGS "${SSE3_FLAGS} -msse4.1")
-  if (INTEL_SSE4_2)
-    set(SSE4_FLAGS "${SSE4_FLAGS} -msse4.2")
-  endif (INTEL_SSE4_2)
-else(INTEL_SSE4_1)
-  message(STATUS "Skipping target ec_jerasure_sse4 & ec_shec_sse4: -msse4.1 not supported")
-endif(INTEL_SSE4_1)
-
 set(EXTRALIBS rt ${CMAKE_DL_LIBS} ${ATOMIC_OPS_LIBRARIES})
 if(LINUX)
   set(LIB_RESOLV resolv)
@@ -546,6 +474,7 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/test/encoding/ceph_dencoder.cc
   APPEND PROPERTY OBJECT_DEPENDS ${CMAKE_BINARY_DIR}/src/include/ceph_ver.h)
 
+include(CheckCompileTargets)
 if(HAVE_ARMV8_CRC)
   add_library(common_crc_aarch64 STATIC common/crc32c_aarch64.c)
   set_target_properties(common_crc_aarch64 PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} ${ARM_CRC_FLAGS}")


### PR DESCRIPTION
The PR comes from cmake: fix the build on AArch64 #10427 because #10427 is polluted by myself.
I'm sorry for the inconvenience. And thanks a lot for your patience.

Extract the CheckCompileTargets.cmake module out of
src/CMakeLists.txt. It is a used to generate some the compiler options
according to the CPU type.
Update the CMakeLists.txt files to invoke the common module

Signed-off-by: tone.zhang <tone.zhang@linaro.org>