### PR TITLE
src/CMakeLists.txt: supress more warnings

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,9 +113,9 @@ else(no_yasm)
 endif(no_yasm)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_C_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Woverloaded-virtual")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-null-sentinel")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wstrict-null-sentinel -Woverloaded-virtual")
 endif(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
 
 # require c++11


### PR DESCRIPTION
 - We already have -Wall
   So these options without no- are redundant.
   and overloaded-virtual generates one warning for every line
   when compiling with Clang.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>