### PR TITLE
mon:  remove the redudant jugement in LogMonitor tick function

### DIFF
--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -56,8 +56,6 @@ void LogMonitor::tick()
 
   dout(10) << *this << dendl;
 
-  if (!mon->is_leader()) return; 
-
 }
 
 void LogMonitor::create_initial()


### PR DESCRIPTION
mon: remove the redudant jugement in LogMonitor tick function

Signed-off-by: song baisen song.baisen@zte.com.cn
