### PR TITLE
mds/CDir: remove the part of judgment for _next_dentry_on_set

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -3047,7 +3047,7 @@ int CDir::scrub_dentry_next(MDSInternalContext *cb, CDentry **dnout)
     dout(20) << __func__ << " inserted to directories scrubbing: "
       << *dnout << dendl;
     scrub_infop->directories_scrubbing.insert((*dnout)->key());
-  } else if (rval < 0 || rval == EAGAIN) {
+  } else if (rval == EAGAIN) {
     // we don't need to do anything else
   } else { // we emptied out the directory scrub set
     assert(rval == ENOENT);


### PR DESCRIPTION
the function for _next_dentry_on_set returned 0, EAGAIN or ENOENT (the return value is not '< 0'), so fixing the judgment.
 
Signed-off-by: zhang.zezhu <zhang.zezhu@zte.com.cn>