### PR TITLE
tests: Add test for global static non-POD segfault

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -189,3 +189,12 @@ add_executable(unittest_shunique_lock
   )
 add_ceph_unittest(unittest_shunique_lock ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_shunique_lock)
 target_link_libraries(unittest_shunique_lock global ${BLKID_LIBRARIES} ${EXTRALIBS})
+
+# unittest_global_doublefree
+if(WITH_CEPHFS)
+  add_executable(unittest_global_doublefree
+    test_global_doublefree.cc
+    )
+  add_ceph_unittest(unittest_global_doublefree ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_global_doublefree)
+  target_link_libraries(unittest_global_doublefree cephfs librados)
+endif(WITH_CEPHFS)

--- a/src/test/common/test_global_doublefree.cc
+++ b/src/test/common/test_global_doublefree.cc
@@ -1,0 +1,30 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+/*
+ * This test is linked against librados and libcephfs to try and detect issues
+ * with global, static, non-POD variables as seen in the following trackers.
+ * http://tracker.ceph.com/issues/16504
+ * http://tracker.ceph.com/issues/16686
+ * In those trackers such variables caused segfaults with glibc reporting
+ * "double free or corruption".
+ *
+ * Don't be fooled by its emptiness. It does serve a purpose :)
+ */
+
+int main(int, char**)
+{
+    return 0;
+}


### PR DESCRIPTION
libcommon.a is linked statically to librados and libcephfs. When the global
destructors for these libraries are called malloc code can report "double free
or corrpution" as the same resource may be deleted twice (global static
non-POD variable types). This test attempts to detect this issue.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>