### PR TITLE
msg/test: fix the guided compile-command to ceph_test_msgr

### DIFF
--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -1489,6 +1489,6 @@ int main(int argc, char **argv) {
 
 /*
  * Local Variables:
- * compile-command: "cd ../.. ; make -j4 unittest_msgr && valgrind --tool=memcheck ./unittest_msgr"
+ * compile-command: "cd ../.. ; make -j4 ceph_test_msgr && valgrind --tool=memcheck ./ceph_test_msgr"
  * End:
  */


### PR DESCRIPTION
`unittest_msgr` was renamed to `ceph_test_msgr`

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>