### PR TITLE
os/bluestore: remove cmake warning from extent alloc functions

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,9 +43,8 @@ public:
                             uint64_t max_alloc_size, int64_t hint,
                             std::vector<AllocExtent> *extents, int *count) = 0;
 
-  virtual int alloc_extents(uint64_t want_size, uint64_t alloc_unit,
-                            int64_t hint, std::vector<AllocExtent> *extents,
-			    int *count) {
+  int alloc_extents(uint64_t want_size, uint64_t alloc_unit,
+                    int64_t hint, std::vector<AllocExtent> *extents, int *count) {
     return alloc_extents(want_size, alloc_unit, want_size, hint, extents, count);
   }
 

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -194,10 +194,6 @@ public:
   static int get_level(int64_t total_blocks);
   static int64_t get_level_factor(int level);
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks) = 0;
-  virtual bool is_allocated(ExtentList *blocks, int64_t num_blocks, int blk_off) {
-    debug_assert(0);
-    return true;
-  }
   virtual bool is_exhausted() = 0;
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required) {
       debug_assert(0);
@@ -364,6 +360,7 @@ public:
   }
 
   int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
+  using BitMapArea::alloc_blocks_dis;
   int64_t alloc_blocks_dis(int64_t num_blocks,
         int64_t blk_off, ExtentList *block_list);  
   void set_blocks_used(int64_t start_block, int64_t num_blocks);


### PR DESCRIPTION
Removing cmake related warning from alloc extents functions
Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>