### PR TITLE
osd:  add is_split check before _start_split

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -354,9 +354,10 @@ void OSDService::_maybe_split_pgid(OSDMapRef old_map,
   assert(old_map->have_pg_pool(pgid.pool()));
   if (pgid.ps() < static_cast<unsigned>(old_map->get_pg_num(pgid.pool()))) {
     set<spg_t> children;
-    pgid.is_split(old_map->get_pg_num(pgid.pool()),
-		  new_map->get_pg_num(pgid.pool()), &children);
-    _start_split(pgid, children);
+    if (pgid.is_split(old_map->get_pg_num(pgid.pool()),
+         new_map->get_pg_num(pgid.pool()), &children)) {
+       _start_split(pgid, children);
+    }
   } else {
     assert(pgid.ps() < static_cast<unsigned>(new_map->get_pg_num(pgid.pool())));
   }


### PR DESCRIPTION
osd: add is_split check before _start_split

If the pg is not split,we do not need to start pg split.

Signed-off-by:song baisen song.baisen@zte.com.cn
