### PR TITLE
src/common/dns_resolve.cc: reorder the includes

### DIFF
--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -11,13 +11,14 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "dns_resolve.h"
 
 #include <sys/types.h>
 #include <netinet/in.h>
 #include <arpa/nameser.h>
 #include <arpa/inet.h>
 #include <resolv.h>
+
+#include "dns_resolve.h"
 
 #include "acconfig.h"
 #include "common/debug.h"

--- a/src/common/dns_resolve.h
+++ b/src/common/dns_resolve.h
@@ -16,6 +16,7 @@
 
 #include <string>
 #include <sys/types.h>
+#include <netinet/in.h>
 #include <resolv.h>
 
 #include "common/Mutex.h"


### PR DESCRIPTION
 - dns_resolv.h should only be include after all the std-includes are
   made. Otherwise it will result into undefined structs/variables on
   FreeBSD/Clang

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>