### PR TITLE
src/vstart.sh: stop script aborting when ceph.cfg is not there

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -290,7 +290,7 @@ if [ "$overwrite_conf" -eq 0 ]; then
     RGW=`$CEPH_BIN/ceph-conf -c $conf_fn --name $VSTART_SEC num_rgw 2>/dev/null` && \
         CEPH_NUM_RGW="$RGW"
 else
-	rm -- "$conf_fn"
+	[ -e "$conf_fn" ] && rm -- "$conf_fn"
 fi
 
 if [ "$start_all" -eq 1 ]; then


### PR DESCRIPTION
When vstart.sh starts with a fresh directory, then there is no ceph.cfg
and the script aborts because it runs with `bash -e`
So better check to see if file is there before trying to delete is.
Otherwise you never get any ceph-{mon,osd,mds} running

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>