### PR TITLE
src/global/pidfile.cc: Assign elements in structures individually

### DIFF
--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -162,7 +162,12 @@ int pidfh::open(const md_config_t *conf)
   pf_dev = st.st_dev;
   pf_ino = st.st_ino;
 
-  struct flock l = { F_WRLCK, SEEK_SET, 0, 0, 0 };
+  struct flock l = {
+    .l_type = F_WRLCK,
+    .l_whence = SEEK_SET,
+    .l_start = 0,
+    .l_len = 0
+  };
   int r = ::fcntl(pf_fd, F_SETLK, &l);
   if (r < 0) {
     derr << __func__ << ": failed to lock pidfile "


### PR DESCRIPTION
 - Assigning structure is better per element.
   The order of elements is not always the same in very OS.
   So "hardcoding" can/will assign to the wrong elements

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>