### PR TITLE
cmake: FreeBSD specific excludes in CMakeLists.txt files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -605,11 +605,20 @@ if(${WITH_RADOSGW})
     cls_rgw_client
   )
 endif(${WITH_RADOSGW})
-if(${WITH_RBD})
+if(WITH_RBD)
   set(DENCODER_EXTRALIBS
       ${DENCODER_EXTRALIBS}
       rbd_replay_types)
-endif(${WITH_RBD})
+  if(LINUX)
+    list(APPEND dencoder_srcs
+      $<TARGET_OBJECTS:krbd_objs>
+      $<TARGET_OBJECTS:parse_secret_objs>)
+    set(DENCODER_EXTRALIBS
+      ${DENCODER_EXTRALIBS}
+      keyutils
+      udev)
+  endif(LINUX)
+endif(WITH_RBD)
 
 add_executable(ceph-dencoder ${dencoder_srcs})
 target_link_libraries(ceph-dencoder
@@ -801,7 +810,7 @@ if(WITH_LIBCEPHFS)
   install(TARGETS ceph-syn DESTINATION bin)
   install(TARGETS mount.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})
 
-  if(HAVE_LIBFUSE)
+  if(WITH_FUSE)
     set(ceph_fuse_srcs
       ceph_fuse.cc
       client/fuse_ll.cc)
@@ -810,7 +819,7 @@ if(WITH_LIBCEPHFS)
     set_target_properties(ceph-fuse PROPERTIES COMPILE_FLAGS "-I${FUSE_INCLUDE_DIRS}")
     install(TARGETS ceph-fuse DESTINATION bin)
     install(PROGRAMS mount.fuse.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})
-  endif(HAVE_LIBFUSE)
+  endif(WITH_FUSE)
 endif(WITH_LIBCEPHFS)
 
 add_subdirectory(journal)
@@ -836,7 +845,7 @@ if(WITH_KVS)
   add_subdirectory(key_value_store)
 endif(WITH_KVS)
 
-if(${WITH_RADOSGW})
+if(WITH_RADOSGW)
   set(civetweb_common_files civetweb/src/civetweb.c)
   add_library(civetweb_common_objs OBJECT ${civetweb_common_files})
   target_include_directories(civetweb_common_objs PUBLIC
@@ -848,7 +857,7 @@ if(${WITH_RADOSGW})
       "${SSL_INCLUDE_DIR}")
   endif(HAVE_SSL)
   add_subdirectory(rgw)
-endif(${WITH_RADOSGW})
+endif(WITH_RADOSGW)
 
 install(FILES
   sample.ceph.conf

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -79,10 +79,15 @@ endif()
 add_library(librbd ${CEPH_SHARED}
   $<TARGET_OBJECTS:osdc_rbd_objs>
   $<TARGET_OBJECTS:common_util_obj>
-  $<TARGET_OBJECTS:krbd_objs>
-  $<TARGET_OBJECTS:parse_secret_objs>  
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   librbd.cc)
+if(LINUX)
+  list(APPEND librbd 
+    $<TARGET_OBJECTS:parse_secret_objs>  
+    $<TARGET_OBJECTS:krbd_objs>
+    )
+endif(LINUX)
+
 target_link_libraries(librbd LINK_PRIVATE 
   rbd_internal
   rbd_types

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -29,7 +29,6 @@ set(libos_srcs
 
 if(HAVE_LIBAIO)
   list(APPEND libos_srcs
-    bluestore/kv.cc
     bluestore/Allocator.cc
     bluestore/BitmapFreelistManager.cc
     bluestore/BlockDevice.cc

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -21,30 +21,36 @@ set(libos_srcs
   filestore/WBThrottle.cc
   filestore/ZFSFileStoreBackend.cc
   memstore/MemStore.cc
+  kstore/kv.cc
   kstore/KStore.cc
   kstore/kstore_types.cc
-  bluestore/kv.cc
-  bluestore/Allocator.cc
-  bluestore/BitmapFreelistManager.cc
-  bluestore/BlockDevice.cc
-  bluestore/BlueFS.cc
-  bluestore/bluefs_types.cc
-  bluestore/BlueRocksEnv.cc
-  bluestore/BlueStore.cc
-  bluestore/bluestore_types.cc
-  bluestore/ExtentFreelistManager.cc
-  bluestore/FreelistManager.cc
-  bluestore/KernelDevice.cc
-  bluestore/StupidAllocator.cc
-  bluestore/BitMapAllocator.cc
-  bluestore/BitAllocator.cc
   fs/FS.cc
   ${libos_xfs_srcs})
+
+if(HAVE_LIBAIO)
+  list(APPEND libos_srcs
+    bluestore/kv.cc
+    bluestore/Allocator.cc
+    bluestore/BitmapFreelistManager.cc
+    bluestore/BlockDevice.cc
+    bluestore/BlueFS.cc
+    bluestore/bluefs_types.cc
+    bluestore/BlueRocksEnv.cc
+    bluestore/BlueStore.cc
+    bluestore/bluestore_types.cc
+    bluestore/ExtentFreelistManager.cc
+    bluestore/FreelistManager.cc
+    bluestore/KernelDevice.cc
+    bluestore/StupidAllocator.cc
+    bluestore/BitMapAllocator.cc
+    bluestore/BitAllocator.cc
+  )
+endif(HAVE_LIBAIO)
 
 if(WITH_FUSE)
   list(APPEND libos_srcs
     FuseStore.cc)
-endif()
+endif(WITH_FUSE)
 
 if(WITH_SPDK)
   list(APPEND libos_srcs
@@ -55,9 +61,9 @@ add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)
 
 if(HAVE_LIBAIO)
   target_link_libraries(os ${AIO_LIBRARIES})
-endif()
+endif(HAVE_LIBAIO)
 
-if(HAVE_LIBFUSE)
+if(WITH_FUSE)
   target_link_libraries(os ${FUSE_LIBRARIES})
 endif()
 

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -8,7 +8,9 @@ add_subdirectory(cls_hello)
 add_subdirectory(cls_lock)
 add_subdirectory(cls_log)
 add_subdirectory(cls_numops)
-add_subdirectory(cls_rbd)
+if(WITH_RBD)
+  add_subdirectory(cls_rbd)
+endif(WITH_RBD)
 add_subdirectory(cls_refcount)
 add_subdirectory(cls_replica_log)
 add_subdirectory(cls_rgw)
@@ -26,7 +28,9 @@ add_subdirectory(libcephfs)
 add_subdirectory(librados)
 add_subdirectory(librados_test_stub)
 add_subdirectory(libradosstriper)
-add_subdirectory(librbd)
+if(WITH_RBD)
+  add_subdirectory(librbd)
+endif(WITH_RBD)
 add_subdirectory(messenger)
 add_subdirectory(mds)
 add_subdirectory(mon)
@@ -40,7 +44,9 @@ add_subdirectory(pybind)
 if(${WITH_RADOSGW})
   add_subdirectory(rgw)
 endif(${WITH_RADOSGW})
-add_subdirectory(rbd_mirror)
+if(WITH_RBD)
+  add_subdirectory(rbd_mirror)
+endif(WITH_RBD)
 add_subdirectory(system)
 
 # test_timers
@@ -79,14 +85,16 @@ target_link_libraries(test_crypto
 add_executable(test_build_libcommon buildtest_skeleton.cc)
 target_link_libraries(test_build_libcommon common pthread ${CRYPTO_LIBS} ${EXTRALIBS})
 
-if(${WITH_RADOSGW})
-add_executable(test_build_librgw buildtest_skeleton.cc)
-target_link_libraries(test_build_librgw rgw_a global pthread ${CRYPTO_LIBS} ${EXTRALIBS})
-endif(${WITH_RADOSGW})
+if(WITH_RADOSGW)
+  add_executable(test_build_librgw buildtest_skeleton.cc)
+  target_link_libraries(test_build_librgw rgw_a global pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+endif(WITH_RADOSGW)
 
-# From src/test/Makefile-client.am: I dont get this one... testing the osdc build but link in libcephfs?
-add_executable(test_build_libcephfs buildtest_skeleton.cc)
-target_link_libraries(test_build_libcephfs cephfs pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+if(WITH_LIBCEPHFS)
+  # From src/test/Makefile-client.am: I dont get this one... testing the osdc build but link in libcephfs?
+  add_executable(test_build_libcephfs buildtest_skeleton.cc)
+  target_link_libraries(test_build_libcephfs cephfs pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+endif(WITH_LIBCEPHFS)
 
 add_executable(test_build_librados buildtest_skeleton.cc)
 target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os common cls_lock_client ${BLKID_LIBRARIES})
@@ -104,7 +112,7 @@ target_link_libraries(ceph_bench_log global pthread rt ${BLKID_LIBRARIES} ${CMAK
 add_executable(ceph_test_mutate
   test_mutate.cc
   )
-target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES}
+target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES} 
   ${CMAKE_DL_LIBS})
 
 # test_trans
@@ -131,15 +139,16 @@ target_link_libraries(ceph_omapbench
   ${CMAKE_DL_LIBS}
   )
 
-# ceph_kvstorebench
-set(kvstorebench_srcs
-  kv_store_bench.cc
-  ${CMAKE_SOURCE_DIR}/src/key_value_store/kv_flat_btree_async.cc
-  )
-add_executable(ceph_kvstorebench
-  ${kvstorebench_srcs}
-  )
-target_link_libraries(ceph_kvstorebench librados global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+if(WITH_KVS)
+  # ceph_kvstorebench
+  set(kvstorebench_srcs
+    kv_store_bench.cc
+    ${CMAKE_SOURCE_DIR}/src/key_value_store/kv_flat_btree_async.cc
+    )
+  add_executable(ceph_kvstorebench ${kvstorebench_srcs})
+  target_link_libraries(ceph_kvstorebench librados global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+  install(TARGETS ceph_kvstorebench DESTINATION bin)
+endif(WITH_KVS)
 
 # ceph_objectstore_bench
 add_executable(ceph_objectstore_bench objectstore_bench.cc)
@@ -387,7 +396,6 @@ target_link_libraries(ceph_xattr_bench
 
 install(TARGETS
   ceph_bench_log
-  ceph_kvstorebench
   ceph_multi_stress_watch
   ceph_objectstore_bench
   ceph_omapbench
@@ -497,12 +505,9 @@ add_dependencies(tests
   monmaptool
   ceph-osd
   ceph-dencoder
-  unittest_librbd
   ceph-objectstore-tool
   ceph-monstore-tool
   osdmaptool
-  rbd
-  radosgw-admin
   ceph_example
   ceph_snappy
   cls_lock
@@ -510,18 +515,30 @@ add_dependencies(tests
   ceph_erasure_code_non_regression
   ceph_erasure_code
   ceph-disk
-  ceph-detect-init
   cython_modules)
+if(WITH_RBD)
+  add_dependencies(tests unittest_librbd rbd)
+endif(WITH_RBD)
+if(WITH_RADOSGW)
+  add_dependencies(tests radosgw-admin)
+endif(WITH_RADOSGW)
+if(NOT FREEBSD)
+  add_dependencies(tests ceph-detect-init)
+endif(NOT FREEBSD)
 
 add_ceph_test(test-ceph-helpers.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-ceph-helpers.sh)
 add_ceph_test(erasure-decode-non-regression.sh ${CMAKE_SOURCE_DIR}/qa/workunits/erasure-code/encode-decode-non-regression.sh)
 
 add_ceph_test(ceph_objectstore_tool.py ${CMAKE_CURRENT_SOURCE_DIR}/ceph_objectstore_tool.py)
-add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
+if(WITH_LIBCEPHFS)
+  add_ceph_test(cephtool-test-mds.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mds.sh)
+endif(WITH_LIBCEPHFS)
 add_ceph_test(cephtool-test-mon.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-mon.sh)
 add_ceph_test(cephtool-test-osd.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-osd.sh)
 add_ceph_test(cephtool-test-rados.sh ${CMAKE_CURRENT_SOURCE_DIR}/cephtool-test-rados.sh)
-add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh)
+if(WITH_RBD)
+  add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tests.sh)
+endif(WITH_RBD)
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
 add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
@@ -769,13 +786,16 @@ target_link_libraries(unittest_daemon_config
   ${EXTRALIBS}
   )
 
+if(WITH_LIBCEPHFS)
 # unittest_libcephfs_config
 add_executable(unittest_libcephfs_config
   libcephfs_config.cc
   )
 add_ceph_unittest(unittest_libcephfs_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_libcephfs_config)
 target_link_libraries(unittest_libcephfs_config cephfs)
+endif(WITH_LIBCEPHFS)
 
+if(WITH_RBD)
 # unittest_rbd_replay
 add_executable(unittest_rbd_replay
   test_rbd_replay.cc)
@@ -789,6 +809,7 @@ target_link_libraries(unittest_rbd_replay
   keyutils
   ${BLKID_LIBRARIES}
   )
+endif(WITH_RBD)
 
 # unittest_ipaddr
 add_executable(unittest_ipaddr

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -12,7 +12,7 @@ target_link_libraries(ceph_smalliobench librados ${Boost_PROGRAM_OPTIONS_LIBRARY
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
 
 # ceph_smalliobenchrbd
-if (${WITH_RBD})
+if(WITH_RBD)
   set(smalliobenchrbd_srcs
     small_io_bench_rbd.cc
     rbd_backend.cc
@@ -30,8 +30,13 @@ if (${WITH_RBD})
     ${Boost_PROGRAM_OPTIONS_LIBRARY}
     udev
     ${BLKID_LIBRARIES}
-    ${CMAKE_DL_LIBS})
-endif (${WITH_RBD})
+    ${CMAKE_DL_LIBS}
+    keyutils
+    )
+  install(TARGETS
+    ceph_smalliobenchrbd
+    DESTINATION bin)
+endif(WITH_RBD)
 
 # ceph_smalliobenchfs
 set(ceph_smalliobenchfs_srcs
@@ -71,7 +76,6 @@ target_link_libraries(ceph_tpbench librados ${Boost_PROGRAM_OPTIONS_LIBRARY} glo
 
 install(TARGETS
   ceph_smalliobench
-  ceph_smalliobenchrbd
   ceph_smalliobenchfs
   ceph_smalliobenchdumb
   ceph_tpbench

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -12,12 +12,14 @@ target_link_libraries(get_command_descriptions
   ${CMAKE_DL_LIBS}
   )
 
+if(HAVE_BLKID)
 # unittest_blkdev
 add_executable(unittest_blkdev
   test_blkdev.cc
   )
 add_ceph_unittest(unittest_blkdev ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_blkdev)
 target_link_libraries(unittest_blkdev global ${BLKID_LIBRARIES})
+endif(HAVE_BLKID)
 
 # unittest_bloom_filter
 add_executable(unittest_bloom_filter


### PR DESCRIPTION
Changes to the CMakeLists.txt files specific for FreeBSD building.
These are the items that can not (yet) be build on FreeBSD
Excluding build target based on
- RBD
- KVS
- BLKID
- LIBFUSE
- AIO
- RADOSGW
