### PR TITLE
rgw: fix for object names ending with underscores

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1584,7 +1584,12 @@ public:
       return;
     }
 
-    init_ns(b, key.name.substr(pos + 1), key.name.substr(1, pos -1));
+    // skip setting ns if object itself ends with an underscore
+    if (pos != (ssize_t)(key.name.size() -1)){
+      init_ns(b, key.name.substr(pos + 1), key.name.substr(1, pos -1));
+    } else {
+      init(b, key.name);
+    }
     set_instance(key.instance);
   }
 


### PR DESCRIPTION
currently if an object name ends with an underscore, we will end up
returning 404, as we are setting the rados namespace for an object to
the object name. So avoid setting a ns when there is no object name left
to set

Fixes: http://tracker.ceph.com/issues/16856

Reported-by: Martin Born <martin.born@udg.de>
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>