### PR TITLE
osd:  remove the double cancel events in OSDService shutdown

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -465,7 +465,6 @@ void OSDService::start_shutdown()
 {
   {
     Mutex::Locker l(agent_timer_lock);
-    agent_timer.cancel_all_events();
     agent_timer.shutdown();
   }
 }


### PR DESCRIPTION
osd:  remove the double cancel events in OSDService shutdown

When agent_time shutdown,it will cancel all events.So here is no need to

do it for twice.

Signed-off-by:song baisen song.baisen@zte.com.cn
