### PR TITLE
cmake: install ceph_test_rados_striper_api_*

### DIFF
--- a/src/test/libradosstriper/CMakeLists.txt
+++ b/src/test/libradosstriper/CMakeLists.txt
@@ -10,6 +10,8 @@ target_link_libraries(ceph_test_rados_striper_api_striping librados radosstriper
   ${UNITTEST_LIBS} rados_striper_test)
 set_target_properties(ceph_test_rados_striper_api_striping PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
+install(TARGETS ceph_test_rados_striper_api_striping
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_ceph_test(rados-striper.sh ${CMAKE_SOURCE_DIR}/src/test/libradosstriper/rados-striper.sh)
 
@@ -19,6 +21,8 @@ target_link_libraries(ceph_test_rados_striper_api_io librados radosstriper
   ${UNITTEST_LIBS} rados_striper_test)
 set_target_properties(ceph_test_rados_striper_api_io PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
+install(TARGETS ceph_test_rados_striper_api_io
+  DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 add_executable(ceph_test_rados_striper_api_aio
   aio.cc)
@@ -26,3 +30,5 @@ target_link_libraries(ceph_test_rados_striper_api_aio librados radosstriper
   ${UNITTEST_LIBS} rados_striper_test)
 set_target_properties(ceph_test_rados_striper_api_aio PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
+install(TARGETS ceph_test_rados_striper_api_aio
+  DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
so we can test them in ceph-qa-suite

Signed-off-by: Kefu Chai <kchai@redhat.com>