### PR TITLE
qa/workunits/rbd: wait for image deleted before checking health

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -156,7 +156,7 @@ do
 done
 
 testlog "TEST: image deletions should propagate"
-wait_for_pool_images ${CLUSTER2} ${POOL} 0
+wait_for_pool_images ${CLUSTER1} ${POOL} 0
 wait_for_pool_healthy ${CLUSTER1} ${POOL} 0
 for i in `seq 1 ${IMAGE_COUNT}`
 do


### PR DESCRIPTION
This is a fixup to the previous commit.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>