### PR TITLE
test/common/test_util.cc: FreeBSD does not have distro information

### DIFF
--- a/src/test/common/test_util.cc
+++ b/src/test/common/test_util.cc
@@ -32,6 +32,7 @@ TEST(util, unit_to_bytesize)
   ASSERT_EQ(65536ll, unit_to_bytesize(" 64K", &cerr));
 }
 
+#if defined(__linux__)
 TEST(util, collect_sys_info)
 {
   map<string, string> sys_info;
@@ -45,3 +46,4 @@ TEST(util, collect_sys_info)
 
   cct->put();
 }
+#endif


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>