### PR TITLE
kv: fix some bugs in memdb

### DIFF
--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -478,8 +478,8 @@ int MemDB::MDBWholeSpaceIteratorImpl:: prev()
     return -1;
   }
   free_last();
-  m_iter--;
-  if (m_iter != m_btree_p->end()) {
+  if (m_iter != m_btree_p->begin()) {
+    m_iter--;
     fill_current();
     return 0;
   } else {

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -503,6 +503,7 @@ int MemDB::MDBWholeSpaceIteratorImpl::seek_to_first(const std::string &k)
   if (m_iter == m_btree_p->end()) {
     return -1;
   }
+  fill_current();
   return 0;
 }
 
@@ -520,6 +521,7 @@ int MemDB::MDBWholeSpaceIteratorImpl::seek_to_last(const std::string &k)
   if (m_iter == m_btree_p->end()) {
     return -1;
   }
+  fill_current();
   return 0;
 }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2716,12 +2716,6 @@ int OSD::shutdown()
 	 << cpp_strerror(r) << dendl;
   }
 
-  dout(10) << "syncing store" << dendl;
-  enable_disable_fuse(true);
-  store->umount();
-  delete store;
-  store = 0;
-  dout(10) << "Store synced" << dendl;
 
   {
     Mutex::Locker l(pg_stat_queue_lock);
@@ -2756,6 +2750,13 @@ int OSD::shutdown()
   service.dump_live_pgids();
 #endif
   cct->_conf->remove_observer(this);
+
+  dout(10) << "syncing store" << dendl;
+  enable_disable_fuse(true);
+  store->umount();
+  delete store;
+  store = 0;
+  dout(10) << "Store synced" << dendl;
 
   monc->shutdown();
   osd_lock.Unlock();


### PR DESCRIPTION
I'm trying to replace rocksdb with memdb to identify the overheads of rocksdb for bluestore, but I hit a few errors.
1. Can't kill ceph-osd process and then restart it.
2. if using memdb for bitmap allocator, it will hit assert fault in 'split_key' function.
3. fix iterator invalidation in memdb.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>