### PR TITLE
rgw: kill a compiler warning

### DIFF
--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -66,10 +66,11 @@ namespace rgw {
 
     int rebind() {
       if (ldap) {
-	(void) ldap_unbind(ldap);
-	(void) init();
-	return bind();
+        (void) ldap_unbind(ldap);
+        (void) init();
+        return bind();
       }
+      return -EINVAL;
     }
 
     int simple_bind(const char *dn, const std::string& pwd) {


### PR DESCRIPTION
```
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_ldap.cc:4:0:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_ldap.h: In member function ‘int rgw::LDAPHelper::rebind()’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_ldap.h:73:5: warning: control reaches end of non-void function [-Wreturn-type]
     }
     ^
```

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>