### PR TITLE
osd:  remove the redundant clear method in consume_map function

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7263,7 +7263,6 @@ void OSD::consume_map()
     _remove_pg(&**i);
     (*i)->unlock();
   }
-  to_remove.clear();
 
   service.expand_pg_num(service.get_osdmap(), osdmap);
 


### PR DESCRIPTION
osd:  remove the redundant clear method in consume_map function

In the above loop before this to_remove to clear,we have remove all
the element.So this clear method is redundant.

Signed-off-by: song baisen song.baisen@zte.com.cn
