### PR TITLE
test: More portable use of mmap(MAP_ANON)

### DIFF
--- a/src/test/on_exit.cc
+++ b/src/test/on_exit.cc
@@ -64,7 +64,7 @@ int main(int argc, char **argv)
 
   // shared mem for exit tests
   shared_val = (int*)mmap(NULL, sizeof(int),
-      PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, 0, 0);
+      PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0);
   assert(shared_val != MAP_FAILED);
 
   // test normal exit returning from main

--- a/src/test/system/cross_process_sem.cc
+++ b/src/test/system/cross_process_sem.cc
@@ -36,7 +36,7 @@ create(int initial_val, CrossProcessSem** res)
 {
   struct cross_process_sem_data_t *data = static_cast < cross_process_sem_data_t*> (
     mmap(NULL, sizeof(struct cross_process_sem_data_t),
-       PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, 0, 0));
+       PROT_READ|PROT_WRITE, MAP_SHARED|MAP_ANONYMOUS, -1, 0));
   if (data == MAP_FAILED) {
     int err = errno;
     return err;


### PR DESCRIPTION
From the Linux manual:
  MAP_ANONYMOUS
     The  mapping  is  not  backed  by any file; its contents
     are initialized to zero.  The fd and offset arguments are
     ignored; however, some implementations require fd to be -1
     if MAP_ANONYMOUS (or MAP_ANON) is specified, and portable
     applications  should  ensure  this.

FreeBSD is such a case, it wil just return an error.

 - Used in:
     src/test/on_exit.cc
     src/test/system/cross_process_sem.cc

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>