### PR TITLE
mds: remove unused MDSDaemon::objecter

### DIFF
--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -82,7 +82,6 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
   Messenger    *messenger;
   MonClient    *monc;
   MDSMap       *mdsmap;
-  Objecter     *objecter;
   LogClient    log_client;
   LogChannelRef clog;
 


### PR DESCRIPTION
Leftover from a2682edb76ceac428c686e0ac21c06511e27693e.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>