### PR TITLE
os/bluestore: add multiple finishers to bluestore

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1009,6 +1009,7 @@ OPTION(bluestore_debug_freelist, OPT_BOOL, false)
 OPTION(bluestore_debug_prefill, OPT_FLOAT, 0)
 OPTION(bluestore_debug_prefragment_max, OPT_INT, 1048576)
 OPTION(bluestore_inject_wal_apply_delay, OPT_FLOAT, 0)
+OPTION(bluestore_use_multiple_finishers, OPT_BOOL, false)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -179,10 +179,11 @@ public:
    */
   struct Sequencer {
     string name;
+    spg_t shard_hint;
     Sequencer_implRef p;
 
     explicit Sequencer(string n)
-      : name(n), p(NULL) {}
+      : name(n), shard_hint(spg_t()), p(NULL) {}
     ~Sequencer() {
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1139,7 +1139,8 @@ private:
   ThreadPool wal_tp;
   WALWQ wal_wq;
 
-  Finisher finisher;
+  int m_finisher_num;
+  vector<Finisher*> finishers;
 
   KVSyncThread kv_sync_thread;
   std::mutex kv_lock;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -249,6 +249,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
 #endif
+  osr->shard_hint = p;
 }
 
 PG::~PG()


### PR DESCRIPTION
- The single finisher of a bluestore can be a bottleneck when using an SSD as a backend device. If too much load is given to the single finisher, client-side IO latency increases. So we add multiple finishers to the bluestore, which shows better performance.
- ‘bluestore_finisher_threads' option is added to be able to configure the number of finisher threads.

Signed-off-by: Ilsoo Byun <ilsoo.byun@sk.com>