### PR TITLE
cmake: specify distutils build path explicitly

### DIFF
--- a/cmake/modules/AddCephTest.cmake
+++ b/cmake/modules/AddCephTest.cmake
@@ -13,7 +13,7 @@ function(add_ceph_test test_name test_path)
     CEPH_BUILD_DIR=${CMAKE_BINARY_DIR}
     LD_LIBRARY_PATH=${CMAKE_BINARY_DIR}/lib
     PATH=${CMAKE_RUNTIME_OUTPUT_DIRECTORY}:${CMAKE_SOURCE_DIR}/src:$ENV{PATH}
-    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules/lib.linux-x86_64-2.7:${CMAKE_SOURCE_DIR}/src/pybind
+    PYTHONPATH=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/cython_modules:${CMAKE_SOURCE_DIR}/src/pybind
     CEPH_BUILD_VIRTUALENV=${CEPH_BUILD_VIRTUALENV})
   # none of the tests should take more than 1 hour to complete
   set_property(TEST

--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -46,7 +46,8 @@ function(distutils_add_cython_module name src)
     CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     CFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
-    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py build --build-base ${CYTHON_MODULE_DIR} --verbose
+    ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
+    build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_DIR} --verbose
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${src})
 endfunction(distutils_add_cython_module)
@@ -70,7 +71,7 @@ function(distutils_install_cython_module name)
            CPPFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
            LDFLAGS=\"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\"
            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-           build --build-base ${CYTHON_MODULE_DIR} --verbose
+           build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_LIB} --verbose
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
            install \${options} --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -66,20 +66,12 @@ def respawn_in_path(lib_path, pybind_path, pythonlib_path):
     sys.path.insert(0, os.path.join(MYDIR, pybind_path))
     sys.path.insert(0, os.path.join(MYDIR, pythonlib_path))
 
-def get_pythonlib_dir():
-    """Returns the name of a distutils build directory"""
-    import sysconfig
-    f = "lib.{platform}-{version[0]}.{version[1]}"
-    name = f.format(platform=sysconfig.get_platform(),
-                    version=sys.version_info)
-    return name
-
 if MYDIR.endswith('src') and \
    os.path.exists(os.path.join(MYDIR, '.libs')) and \
    os.path.exists(os.path.join(MYDIR, 'pybind')) and \
    os.path.exists(os.path.join(MYDIR, 'build')):
 
-    python_libpath = os.path.join(MYDIR, 'build', get_pythonlib_dir())
+    python_libpath = os.path.join(MYDIR, 'build')
     respawn_in_path(os.path.join(MYDIR, '.libs'), 'pybind', python_libpath)
     if 'PATH' in os.environ and MYDIR not in os.environ['PATH']:
         os.environ['PATH'] += ':' + MYDIR
@@ -100,12 +92,7 @@ elif os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
         lib_path = os.path.join(os.getcwd(), "lib")
         bin_path = os.path.join(os.getcwd(), "bin")
         pybind_path = os.path.join(src_path, "src", "pybind")
-
-        import sysconfig
-        f = "lib.{platform}-{version[0]}.{version[1]}"
-        name = f.format(platform=sysconfig.get_platform(),
-                        version=sys.version_info)
-        pythonlib_path = os.path.join(os.getcwd(), "lib/cython_modules", name)
+        pythonlib_path = os.path.join(lib_path, "cython_modules")
 
         respawn_in_path(lib_path, pybind_path, pythonlib_path)
 

--- a/src/pybind/cephfs/Makefile.am
+++ b/src/pybind/cephfs/Makefile.am
@@ -23,6 +23,7 @@ cephfs-pybind-install-exec: ${srcdir}/ceph_ver.h
 	fi ; \
 	cd $(srcdir)/pybind/cephfs; $(PY_DISTUTILS) build \
 	--build-base $(shell readlink -f $(builddir))/build \
+	--build-platlib $(shell readlink -f $(builddir))/build \
 	install \
 	$$options $$root \
 	--single-version-externally-managed \

--- a/src/pybind/rados/Makefile.am
+++ b/src/pybind/rados/Makefile.am
@@ -23,6 +23,7 @@ rados-pybind-install-exec: ${srcdir}/ceph_ver.h
 	fi ; \
 	cd $(srcdir)/pybind/rados; $(PY_DISTUTILS) build \
 	--build-base $(shell readlink -f $(builddir))/build \
+	--build-platlib $(shell readlink -f $(builddir))/build \
 	install \
 	$$options $$root \
 	--single-version-externally-managed \

--- a/src/pybind/rbd/Makefile.am
+++ b/src/pybind/rbd/Makefile.am
@@ -23,6 +23,7 @@ rbd-pybind-install-exec: ${srcdir}/ceph_ver.h
 	fi ; \
 	cd $(srcdir)/pybind/rbd; $(PY_DISTUTILS) build \
 	--build-base $(shell readlink -f $(builddir))/build \
+	--build-platlib $(shell readlink -f $(builddir))/build \
 	install \
 	$$options $$root \
 	--single-version-externally-managed \


### PR DESCRIPTION
so we don't need to replicate the logic in distutils/command/build.py
at different places.

Signed-off-by: Kefu Chai <kchai@redhat.com>