### PR TITLE
lockdep: verbose even if no logging is set

### DIFF
--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -78,7 +78,7 @@ void lockdep_register_ceph_context(CephContext *cct)
                                "lockdep enabled");
     g_lockdep = true;
     g_lockdep_ceph_ctx = cct;
-    lockdep_dout(0) << "lockdep start" << dendl;
+    lockdep_dout(1) << "lockdep start" << dendl;
     current_maxid = 0;
 	last_freed_id = -1;
 
@@ -91,7 +91,7 @@ void lockdep_unregister_ceph_context(CephContext *cct)
 {
   pthread_mutex_lock(&lockdep_mutex);
   if (cct == g_lockdep_ceph_ctx) {
-    lockdep_dout(0) << "lockdep stop" << dendl;
+    lockdep_dout(1) << "lockdep stop" << dendl;
     // this cct is going away; shut it down!
     g_lockdep = false;
     g_lockdep_ceph_ctx = NULL;


### PR DESCRIPTION
Set logging level to 1 for start and stop.
So logfiles are not swamped with unneeded lockdep info