### PR TITLE
rgw: Fix civetweb IPv6

### DIFF
--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -160,7 +160,7 @@ radosgw_SOURCES = \
 	civetweb/src/civetweb.c \
 	rgw/rgw_main.cc
 
-radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash
+radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE}
 radosgw_CXXFLAGS = ${RGW_CXXFLAGS} ${AM_CXXFLAGS}
 radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) $(RESOLV_LIBS) \
 	$(CEPH_GLOBAL)


### PR DESCRIPTION
Commit c38e3cbb6f7c6221209f2b512cba18c564c895a4 introduced a second
compiled version of src/civetweb/src/civetweb.c, but did not pass the
configuration header (civetweb/include/civetweb_conf.h).

As a result, USE_IPV6 was not defined when it was compiled, and that
copy was included into the radosgw binary. This caused breakage for the
civetweb frontend when used with IPv6:
  rgw frontends = civetweb port=[::]:7480

Reintroduce the header so that civetweb is compiled correctly again.

Fixes: http://tracker.ceph.com/issues/16928
Backport: jewel
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>