### PR TITLE
hammer: osd: Avoid creation of stray TEMP directories in filestore after split

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7028,12 +7028,13 @@ void OSD::split_pgs(
     dout(10) << "m_seed " << i->ps() << dendl;
     dout(10) << "split_bits is " << split_bits << dendl;
 
-    parent->split_colls(
+    if (parent->split_colls(
       *i,
       split_bits,
       i->ps(),
       &child->pool.info,
-      rctx->transaction);
+      rctx->transaction))
+        child->set_temp_coll();
     parent->split_into(
       i->pgid,
       child,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1210,7 +1210,8 @@ public:
   virtual void _scrub_clear_state() { }
   virtual void _scrub_finish() { }
   virtual void get_colls(list<coll_t> *out) = 0;
-  virtual void split_colls(
+  virtual void set_temp_coll() { }
+  virtual bool split_colls(
     spg_t child,
     int split_bits,
     int seed,

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -325,20 +325,21 @@
      if (temp_created)
        out->push_back(temp_coll);
    }
-   void split_colls(
+   bool split_colls(
      spg_t child,
      int split_bits,
      int seed,
      ObjectStore::Transaction *t) {
      coll_t target = coll_t::make_temp_coll(child);
      if (!temp_created)
-       return;
+       return false;
      t->create_collection(target);
      t->split_collection(
        temp_coll,
        split_bits,
        seed,
        target);
+     return true;
    }
 
    virtual void dump_recovery_info(Formatter *f) const = 0;
@@ -352,6 +353,7 @@
     return temp_coll;
    }
    bool have_temp_coll() const { return temp_created; }
+   void set_temp_coll() { temp_created = true; }
 
    // Track contents of temp collection, clear on reset
    void add_temp_obj(const hobject_t &oid) {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1444,7 +1444,10 @@ public:
     out->push_back(coll);
     return pgbackend->temp_colls(out);
   }
-  void split_colls(
+  void set_temp_coll() {
+    pgbackend->set_temp_coll();
+  }
+  bool split_colls(
     spg_t child,
     int split_bits,
     int seed,
@@ -1458,7 +1461,7 @@ public:
       seed,
       target);
     PG::_init(*t, child, pool);
-    pgbackend->split_colls(child, split_bits, seed, t);
+    return pgbackend->split_colls(child, split_bits, seed, t);
   }
 private:
   struct NotTrimming;


### PR DESCRIPTION
http://tracker.ceph.com/issues/16917

Includes the backport of a simple fix which improves the _destroy_collection() debug output.
