### PR TITLE
osdc:  remove the repeat jugement in handle_osd_map function

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1249,8 +1249,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
     || _osdmap_has_pool_full();
 
   // was/is paused?
-  if (was_pauserd || was_pausewr || pauserd || pausewr ||
-      osdmap->get_epoch() < epoch_barrier) {
+  if (pauserd || pausewr || osdmap->get_epoch() < epoch_barrier) {
     _maybe_request_map();
   }
 


### PR DESCRIPTION
osdc:  remove the repeat jugement in handle_osd_map function

from A || B || A || B || C to A || B || C

Signed-off-by: song baisen song.baisen@zte.com.cn
