### PR TITLE
LTTng-UST disabled for openSUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -33,9 +33,11 @@
 %bcond_with selinux
 %endif
 
-# LTTng-UST enabled on Fedora, RHEL 6+, and SLES 12
-%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?suse_version} == 1315
+# LTTng-UST enabled on Fedora, RHEL 6+, and SLE (not openSUSE)
+%if 0%{?fedora} || 0%{?rhel} >= 6 || 0%{?suse_version}
+%if ! 0%{?is_opensuse}
 %bcond_without lttng
+%endif
 %endif
 
 %if %{with selinux}


### PR DESCRIPTION
as per suse_version definition from url:
https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto#Detect_a_distribution_flavor_for_special_code

Fixes: http://tracker.ceph.com/issues/16937
Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

@smithfarm  comments ?