### PR TITLE
rpm: ExclusiveArch for suse_version

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -64,6 +64,13 @@ Group:         System/Filesystems
 %endif
 URL:		http://ceph.com/
 Source0:	http://ceph.com/download/%{name}-%{version}.tar.bz2
+%if 0%{?suse_version}
+%if 0%{?is_opensuse}
+ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le
+%else
+ExclusiveArch:  x86_64 aarch64
+%endif
+%endif
 #################################################################################
 # dependencies that apply across all distro families
 #################################################################################


### PR DESCRIPTION
for SLES supports only x86_64 and aarch64 targets
for openSUSE (Tumbleweed and Leap) add ppc64/ppc64le targets.

fixes: http://tracker.ceph.com/issues/16936
Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>

This time I made the 2nd commit in another branch to avoid conflict.
@smithfarm  comments ? 