### PR TITLE
rgw: Fix for incorrect access key id in reworked ldap auth code.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1714,7 +1714,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
     op_ret = rgw_get_user_info_by_access_key(store, s3_access_key, user_info);
     if (op_ret < 0) {
       S3AuthFactory aplfact(store, s->account_name);
-      RGWLDAPTokenExtractor token_extr(s);
+      RGWGetPolicyLDAPTokenExtractor token_extr(s3_access_key);
       RGWLDAPAuthEngine ldap(s->cct, store, token_extr, &aplfact);
         // try external authenticators
       if (store->ctx()->_conf->rgw_s3_auth_use_keystone &&

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -689,6 +689,18 @@ public:
   std::string get_token() const override;
 };
 
+class RGWGetPolicyLDAPTokenExtractor : public RGWTokenBasedAuthEngine::Extractor {
+  std::string access_key_id;
+public:
+  RGWGetPolicyLDAPTokenExtractor(std::string access_key_id) {
+    access_key_id = std::move(access_key_id);
+  }
+
+  std::string get_token() const {
+    return access_key_id;
+  }
+};
+
 class S3AuthFactory : public RGWRemoteAuthApplier::Factory {
   typedef RGWAuthApplier::aplptr_t aplptr_t;
   RGWRados * const store;


### PR DESCRIPTION
The reworked ldap code does not use the correct access key id in get_policy.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>