### PR TITLE
cmake: correct ceph_test_librbd/ceph_test_rbd_mirror linkage

### DIFF
--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -2,8 +2,10 @@ add_library(librados_objs OBJECT
   IoCtxImpl.cc
   RadosXattrIter.cc
   RadosClient.cc)
+add_library(librados_api_obj OBJECT
+  librados.cc)
 add_library(librados ${CEPH_SHARED}
-  librados.cc
+  $<TARGET_OBJECTS:librados_api_obj>
   $<TARGET_OBJECTS:librados_objs>
   $<TARGET_OBJECTS:common_buffer_obj>)
 add_dependencies(librados osdc)

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -86,11 +86,12 @@ target_link_libraries(unittest_librbd
 add_executable(ceph_test_librbd
   test_main.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+  $<TARGET_OBJECTS:librados_api_obj>
+  $<TARGET_OBJECTS:librados_objs>
   $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:parse_secret_objs>
   )
 target_link_libraries(ceph_test_librbd
-  librados
   rbd_test
   rbd_api
   rbd_internal

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -56,6 +56,8 @@ target_link_libraries(unittest_rbd_mirror
 add_executable(ceph_test_rbd_mirror
   test_main.cc
   ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
+  $<TARGET_OBJECTS:librados_api_obj>
+  $<TARGET_OBJECTS:librados_objs>
   )
 set_target_properties(ceph_test_rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
@@ -69,7 +71,6 @@ target_link_libraries(ceph_test_rbd_mirror
   cls_lock_client
   cls_journal_client
   rbd_types
-  librados
   osdc
   global
   radostest


### PR DESCRIPTION
This now matches the autotools configuration and fixes the failed
assertion during test execution.

Fixes: http://tracker.ceph.com/issues/16882
Signed-off-by: Jason Dillaman <dillaman@redhat.com>