### PR TITLE
mon/MonClient.h: delete copy constr and assing op

### DIFF
--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -297,6 +297,8 @@ public:
 
  public:
   explicit MonClient(CephContext *cct_);
+  MonClient(const MonClient &) = delete;
+  MonClient& operator=(const MonClient &) = delete;
   ~MonClient();
 
   int init();
@@ -459,8 +461,6 @@ private:
   void handle_get_version_reply(MMonGetVersionReply* m);
 
 
-  MonClient(const MonClient &rhs);
-  MonClient& operator=(const MonClient &rhs);
 };
 
 #endif


### PR DESCRIPTION
Declaring a copy constructor and assignment operator without an
implementation will prevent copy and assignment, but it will be
caught only during linking. Deleting them moves the checking to
compile time.

Signed-off-by: Michal Jarzabek <stiopa@gmail.com>