### PR TITLE
ceph-osd,ceph-mon,ceph-mds: daemonize before creating messenger

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -135,6 +135,8 @@ int main(int argc, const char **argv)
       << "' is invalid and will be forbidden in a future version.  "
       "MDS names may not start with a numeric digit." << dendl;
   }
+  // daemonize
+  global_init_daemonize(g_ceph_context);
 
   Messenger *msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
 				      entity_name_t::MDS(-1), "mds",
@@ -172,7 +174,6 @@ int main(int argc, const char **argv)
   if (r < 0)
     exit(1);
 
-  global_init_daemonize(g_ceph_context);
   common_init_finish(g_ceph_context);
 
   // get monmap

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -660,6 +660,11 @@ int main(int argc, const char **argv)
     }
   }
 
+  if (g_conf->daemonize) {
+    global_init_postfork_finish(g_ceph_context);
+    prefork.daemonize();
+  }
+
   // bind
   int rank = monmap.get_rank(g_conf->name.get_id());
   Messenger *msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
@@ -746,11 +751,6 @@ int main(int argc, const char **argv)
     derr << "compacting monitor store ..." << dendl;
     mon->store->compact();
     derr << "done compacting" << dendl;
-  }
-
-  if (g_conf->daemonize) {
-    global_init_postfork_finish(g_ceph_context);
-    prefork.daemonize();
   }
 
   msgr->start();

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -444,6 +444,8 @@ int main(int argc, const char **argv)
 	 << " **          you specify neither or both.                             **"
 	 << TEXT_NORMAL << dendl;
   }
+  // daemonize
+  global_init_daemonize(g_ceph_context);
 
   Messenger *ms_public = Messenger::create(g_ceph_context, g_conf->ms_type,
 					   entity_name_t::OSD(whoami), "client",
@@ -563,8 +565,7 @@ int main(int argc, const char **argv)
   if (r < 0)
     exit(1);
 
-  // Set up crypto, daemonize, etc.
-  global_init_daemonize(g_ceph_context);
+  // Set up crypto etc.
   common_init_finish(g_ceph_context);
 
   TracepointProvider::initialize<osd_tracepoint_traits>(g_ceph_context);


### PR DESCRIPTION
ceph-osd/ceph-mon/ceph-mds daemonize (fork) after creating messengers
Xio messenger will initialize accelio library and register RDMA memory
in the 1st call to XioMessenger constructor. This situation is very
problematic where child process do rdma operations (using rdma resources
created by parent)

http://www.rdmamojo.com/2012/05/24/ibv_fork_init
http://www.spinics.net/lists/linux-rdma/msg03364.html

This patch force to daemonize/fork before creating messenger
(ie. initializing and registering rdma memory before daemonizing
for xio messenger)

Signed-off-by: Avner BenHanoch avnerb@mellanox.com
Signed-off-by: Vu Pham vu@mellanox.com
