### PR TITLE
Change debug levels for certain log messages

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -975,7 +975,7 @@ int RGWPeriod::read_latest_epoch(RGWPeriodLatestEpochInfo& info)
   RGWObjectCtx obj_ctx(store);
   int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
   if (ret < 0) {
-    ldout(cct, 0) << "error read_lastest_epoch " << pool << ":" << oid << dendl;
+    ldout(cct, 1) << "error read_lastest_epoch " << pool << ":" << oid << dendl;
     return ret;
   }
   try {
@@ -3699,7 +3699,7 @@ int RGWRados::init_complete()
       lderr(cct) << "Cannot find zone id=" << zone_params.get_id() << " (name=" << zone_params.get_name() << ")" << dendl;
       return -EINVAL;
     }
-    ldout(cct, 0) << "Cannot find zone id=" << zone_params.get_id() << " (name=" << zone_params.get_name() << "), switching to local zonegroup configuration" << dendl;
+    ldout(cct, 1) << "Cannot find zone id=" << zone_params.get_id() << " (name=" << zone_params.get_name() << "), switching to local zonegroup configuration" << dendl;
     ret = init_zg_from_local(&creating_defaults);
     if (ret < 0) {
       return ret;


### PR DESCRIPTION
Currently while running radosgw-admin command we see these messages thrown at
the endusers since debug level is set to 0:

2016-08-02 14:48:28.672409 7f9e630639c0  0 error in read_id for id  : (2) No
such file or directory
2016-08-02 14:48:28.687251 7f9e630639c0  0 Cannot find zone
id=7a2a89b9-4f5e-4f60-a29e-451ac9acc5a8 (name=us-west), switching to local
zonegroup configuration
2016-08-02 14:48:35.742185 7f9e630639c0  0 error read_lastest_epoch
.rgw.root:periods.a3db7884-2445-4bab-a165-6730f8573b8f:staging.latest_epoch

Raising the log level to 20 since the command succeeds and these are not actual
errors.

Fixes: http://tracker.ceph.com/issues/16935
Signed-off-by: Shilpa Jagannath <smanjara@redhat.com>