### PR TITLE
filestore: fix skip omap clone in _collection_move_rename

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2222,7 +2222,8 @@ void FileStore::_set_replay_guard(const coll_t& cid,
 void FileStore::_set_replay_guard(int fd,
 				  const SequencerPosition& spos,
 				  const ghobject_t *hoid,
-				  bool in_progress)
+				  bool in_progress,
+				  bool sync_omap)
 {
   if (backend->can_checkpoint())
     return;
@@ -2237,7 +2238,8 @@ void FileStore::_set_replay_guard(int fd,
   // sync object_map too.  even if this object has a header or keys,
   // it have had them in the past and then removed them, so always
   // sync.
-  object_map->sync(hoid, &spos);
+  if (sync_omap)
+    object_map->sync(hoid, &spos);
 
   _inject_failure();
 
@@ -5209,7 +5211,7 @@ int FileStore::_collection_move_rename(const coll_t& oldcid, const ghobject_t& o
       return 0;
     }
     if (dstcmp > 0) {      // if dstcmp == 0 the guard already says "in-progress"
-      _set_replay_guard(**fd, spos, &o, true);
+      _set_replay_guard(**fd, spos, &o, true, false);
     }
 
     r = lfn_link(oldcid, c, oldoid, o);
@@ -5224,6 +5226,8 @@ int FileStore::_collection_move_rename(const coll_t& oldcid, const ghobject_t& o
       r = object_map->clone(oldoid, o, &spos);
       if (r == -ENOENT)
 	r = 0;
+      if (r == 0)
+        object_map->sync(&o, &spos);
     }
 
     _inject_failure();

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -491,7 +491,8 @@ public:
   void _set_replay_guard(int fd,
 			 const SequencerPosition& spos,
 			 const ghobject_t *oid=0,
-			 bool in_progress=false);
+			 bool in_progress=false,
+			 bool sync_omap=true);
   void _set_replay_guard(const coll_t& cid,
                          const SequencerPosition& spos,
                          bool in_progress);


### PR DESCRIPTION
object_map->clone would be skip because the spos is sync
in _set_replay_guard

Fixes: http://tracker.ceph.com/issues/16948
Signed-off-by: Xinze Chi <xinze@xsky.com>