### PR TITLE
mds: ensure fragmentation happens promptly

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -446,6 +446,12 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
   // finish any triggered contexts
   _advance_queues();
 
+  // In case any dirs hit in this request are now enqueued for
+  // split or merge -- avoid waiting for the next tick() to do so
+  // so that the split happens before any subsequent requests that
+  // might otherwise lead to an oversized fragment.
+  balancer->do_fragmenting();
+
   if (beacon.is_laggy()) {
     // We've gone laggy during dispatch, don't do any
     // more housekeeping

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3289,6 +3289,9 @@ void Server::handle_client_openc(MDRequestRef& mdr)
     ::encode(in->inode.ino, mdr->reply_extra_bl);
   }
 
+  mds->balancer->hit_dir(ceph_clock_now(nullptr), dn->get_dir(),
+      META_POP_IWR);
+
   journal_and_reply(mdr, in, dn, le, fin);
 }
 


### PR DESCRIPTION
Hit directories during file creation so that we
don't create oversized fragments (previously
would wait until other metadata ops to break them up).

Call MDBalancer::do_fragmenting at the end of
MDSRank dispatch, to avoid waiting for the next
tick to fragment dirs.  Previously, we would end up
processing up to 5 seconds of extra creates before
actually doing the split, leading to oversized fragments.

Signed-off-by: John Spray john.spray@redhat.com
