### PR TITLE
rpm: add udev BuildRequires to provide /usr/lib/udev directory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -117,6 +117,7 @@ BuildRequires:	python-requests
 BuildRequires:	python-sphinx
 BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel
+BuildRequires:	udev
 BuildRequires:	util-linux
 BuildRequires:	valgrind-devel
 BuildRequires:	xfsprogs
@@ -880,6 +881,7 @@ DISABLE_RESTART_ON_UPDATE="yes"
 %{_unitdir}/rbdmap.service
 %{python_sitelib}/ceph_argparse.py*
 %{python_sitelib}/ceph_daemon.py*
+%dir %{_udevrulesdir}
 %{_udevrulesdir}/50-rbd.rules
 %attr(3770,ceph,ceph) %dir %{_localstatedir}/log/ceph/
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/
@@ -1157,6 +1159,7 @@ fi
 %{_sbindir}/ceph-disk
 %{_sbindir}/ceph-disk-udev
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
+%dir %{_udevrulesdir}
 %{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
 %{_udevrulesdir}/95-ceph-osd.rules
 %{_mandir}/man8/ceph-clsinfo.8*


### PR DESCRIPTION
The issue here is that ceph.spec.in does not package the directories `/usr/lib/udev` and `/usr/lib/udev/rules.d`. The problem was not showing because hdparm, which is brought in as a build dependency, packages these directories. However, in SUSE a recent update to hdparm changes that and the RPM build fails.

This PR addresses the issue by adding `udev` as a build dependency, which should cover `/usr/lib/udev`, and by adding explicit `%dir %{_udevrulesdir}` to the packages that put files in this directory.

Fixes: http://tracker.ceph.com/issues/16949
Signed-off-by: Nathan Cutler <ncutler@suse.com>