### PR TITLE
rpm: pass --disable-static to configure

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -633,6 +633,7 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
                 --libexecdir=%{_libexecdir} \
 		--localstatedir=%{_localstatedir} \
 		--sysconfdir=%{_sysconfdir} \
+                --disable-static \
 %if 0%{?rhel} && ! 0%{?centos}
                 --enable-subman \
 %endif
@@ -684,7 +685,6 @@ make %{?_smp_mflags} check
 %install
 make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -exec rm -f {} ';'
-find %{buildroot} -type f -name "*.a" -exec rm -f {} ';'
 install -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
 %if 0%{?fedora} || 0%{?rhel}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph


### PR DESCRIPTION
This makes the build consume less resources and we can drop the ancient
"rm -rf" lines from %install.

Fixes: http://tracker.ceph.com/issues/16960
Signed-off-by: Nathan Cutler <ncutler@suse.com>