### PR TITLE
subman: use replace instead of format

### DIFF
--- a/src/script/subman
+++ b/src/script/subman
@@ -1,6 +1,7 @@
-#!/usr/bin/env python -B
+#!/usr/bin/env python
 
 import json
+import os
 import re
 import subprocess
 
@@ -13,8 +14,9 @@ for disk in disks:
             df = subprocess.check_output("df --output=used " + partition['path'], shell=True)
             used += int(re.findall('\d+', df)[0])
 
-open("/etc/rhsm/facts/ceph_usage.facts", 'w').write("""
+facts_file = os.environ.get("CEPH_FACTS_FILE", "/etc/rhsm/facts/ceph_usage.facts")
+open(facts_file, 'w').write("""\
 {
 "band.storage.usage": {used}
 }
-""".format(used=used/(1024*1024*1024)))
+""".replace('{used}', str(int(used/(1024*1024*1024)))))

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -523,6 +523,7 @@ add_ceph_test(run-rbd-unit-tests.sh ${CMAKE_CURRENT_SOURCE_DIR}/run-rbd-unit-tes
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
 add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
+add_ceph_test(test_subman.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_subman.sh)
 add_ceph_test(unittest_bufferlist.sh ${CMAKE_SOURCE_DIR}/src/unittest_bufferlist.sh)
 
 add_test(NAME run-tox-ceph-disk COMMAND bash ${CMAKE_SOURCE_DIR}/src/ceph-disk/run-tox.sh)

--- a/src/test/Makefile.am
+++ b/src/test/Makefile.am
@@ -93,7 +93,8 @@ check_SCRIPTS += \
 	test/mon/mon-handle-forward.sh \
 	test/libradosstriper/rados-striper.sh \
 	test/test_objectstore_memstore.sh \
-        test/test_pidfile.sh
+        test/test_pidfile.sh \
+	test/test_subman.sh
 
 EXTRA_DIST += \
 	$(srcdir)/test/python/brag-client/setup.py \

--- a/src/test/test_subman.sh
+++ b/src/test/test_subman.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+
+source $(dirname $0)/detect-build-env-vars.sh
+
+TMP=$(mktemp --tmpdir -d)
+trap "rm -fr $TMP" EXIT
+
+export PATH=$TMP:$PATH
+
+cat > $TMP/ceph-disk <<EOF
+echo '[{"partition":[{"type":"data","path":"/dev/foo/bar"}]}]'
+EOF
+chmod +x $TMP/ceph-disk
+
+cat > $TMP/df <<EOF
+echo Used
+echo $((2 * 1024 * 1024 * 1024))
+EOF
+chmod +x $TMP/df
+
+cat > $TMP/expected <<EOF
+{
+"band.storage.usage": 2
+}
+EOF
+export CEPH_FACTS_FILE=$TMP/facts
+$CEPH_ROOT/src/script/subman
+diff -u $CEPH_FACTS_FILE $TMP/expected


### PR DESCRIPTION
Otherwise all {} are assumed to be substituted. Add a test.

Signed-off-by: Loic Dachary <ldachary@redhat.com>