### PR TITLE
libcephfs: kill compiling warning

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -25,6 +25,7 @@
 #include <sys/socket.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <fcntl.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
As below:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/include/cephfs/libcephfs.h:1499:20: warning: ‘struct flock’ declared inside parameter list [enabled by default]
     Fh *fh, struct flock *fl, uint64_t owner);
                    ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/include/cephfs/libcephfs.h:1499:20: warning: its scope is only this definition or declaration, which is probably not what you want [enabled by default]
/home/jenkins-build/build/workspace/ceph-pull-requests/src/include/cephfs/libcephfs.h:1501:20: warning: ‘struct flock’ declared inside parameter list [enabled by default]
     Fh *fh, struct flock *fl, uint64_t owner, int sleep);

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>