### PR TITLE
osd/ReplicatedPG: fix cache tier promotion for non-existent clone obj…

### DIFF
--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -88,6 +88,7 @@ public:
     vector<snapid_t> snaps;  ///< src's snaps (if clone)
     snapid_t snap_seq;       ///< src's snap_seq (if head)
     librados::snap_set_t snapset; ///< src snapset (if head)
+    int list_snaps_ret;	     ///< return value of list_snaps (if head)
     bool mirror_snapset;
     bool has_omap;
     uint32_t flags;    // object_copy_data_t::FLAG_*
@@ -105,8 +106,8 @@ public:
     }
     CopyResults()
       : object_size(0), started_temp_obj(false),
-	user_version(0),
-	should_requeue(false), mirror_snapset(false),
+	user_version(0), should_requeue(false),
+	list_snaps_ret(0), mirror_snapset(false),
 	has_omap(false),
 	flags(0),
 	source_data_digest(-1), source_omap_digest(-1),
@@ -1139,6 +1140,7 @@ protected:
 		     const object_locator_t& oloc,
 		     bool in_hit_set,
 		     uint32_t recency,
+		     bool op_may_write,
 		     OpRequestRef promote_op,
 		     ObjectContextRef *promote_obc = nullptr);
   /**
@@ -1155,6 +1157,7 @@ protected:
     ObjectContextRef obc,            ///< [optional] obc
     const hobject_t& missing_object, ///< oid (if !obc)
     const object_locator_t& oloc,    ///< locator for obc|oid
+    bool op_may_write,		     ///< orig op may write or not
     OpRequestRef op,                 ///< [optional] client op
     ObjectContextRef *promote_obc = nullptr ///< [optional] new obc for object
     );
@@ -1259,7 +1262,7 @@ protected:
   }
   void _copy_some(ObjectContextRef obc, CopyOpRef cop);
   void finish_copyfrom(OpContext *ctx);
-  void finish_promote(int r, CopyResults *results, ObjectContextRef obc);
+  void finish_promote(int r, CopyResults *results, ObjectContextRef obc, bool may_write);
   void cancel_copy(CopyOpRef cop, bool requeue);
   void cancel_copy_ops(bool requeue);
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3148,6 +3148,110 @@ TYPED_TEST(DiffIterateTest, DiffIterateParentDiscard)
   ASSERT_TRUE(two.subset_of(diff));
 }
 
+TYPED_TEST(DiffIterateTest, DiffIterateLayeredImageCachePromotion)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  string base_pool_name = this->m_pool_name;
+  string layered_pool_name = this->create_pool(true);
+  string cache_pool_name = this->create_pool(true);
+  ASSERT_NE("", layered_pool_name);
+  ASSERT_NE("", cache_pool_name);
+
+  string parent_name = this->get_temp_image_name();
+  string clone_name = this->get_temp_image_name();
+
+  librados::IoCtx ioctx_base, ioctx_layered;
+  ASSERT_EQ(0, this->_rados.ioctx_create(base_pool_name.c_str(), ioctx_base));
+  ASSERT_EQ(0, this->_rados.ioctx_create(layered_pool_name.c_str(), ioctx_layered));
+
+  librbd::RBD rbd;
+  librbd::Image parent_image;
+  int order = 0;
+  uint64_t size = 20 << 20;
+
+  // make a parent to clone from
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx_base, parent_name.c_str(), size, &order));
+  ASSERT_EQ(0, rbd.open(ioctx_base, parent_image, parent_name.c_str(), NULL));
+
+  uint64_t object_size = 0;
+  if (this->whole_object) {
+    object_size = 1 << order;
+  }
+
+  ceph::bufferlist bl;
+  char data[256];
+  memset(data, 1, sizeof(data));
+  bl.append(data, 256);
+  ASSERT_EQ(256, parent_image.write(0, 256, bl));
+
+  ASSERT_EQ(0, parent_image.snap_create("snap"));
+  ASSERT_EQ(0, parent_image.snap_protect("snap"));
+
+  ASSERT_EQ(0, rbd.clone(ioctx_base, parent_name.c_str(), "snap",
+                         ioctx_layered, clone_name.c_str(),
+                         RBD_FEATURE_LAYERING, &order));
+  librbd::Image clone_image ;
+  ASSERT_EQ(0, rbd.open(ioctx_layered, clone_image, clone_name.c_str(), NULL));
+  ASSERT_EQ(0, clone_image.snap_create("snap"));
+  ASSERT_EQ(0, clone_image.snap_set("snap"));
+
+  vector<diff_extent> extents;
+  ASSERT_EQ(0, clone_image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, (void *)&extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+
+  std::string cmdstr = "{\"prefix\": \"osd tier add\", \"pool\": \"" +
+     layered_pool_name + "\", \"tierpool\":\"" + cache_pool_name +
+     "\", \"force_nonempty\":\"\"}";
+  char *cmd[1];
+  cmd[0] = (char *)cmdstr.c_str();
+  ASSERT_EQ(0, rados_mon_command(this->_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
+
+  cmdstr = "{\"prefix\": \"osd tier cache-mode\", \"pool\": \"" +
+     cache_pool_name + "\", \"mode\":\"writeback\"}";
+  cmd[0] = (char *)cmdstr.c_str();
+  ASSERT_EQ(0, rados_mon_command(this->_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
+
+  cmdstr = "{\"prefix\": \"osd tier set-overlay\", \"pool\": \"" +
+     layered_pool_name + "\", \"overlaypool\":\"" + cache_pool_name + "\"}";
+  cmd[0] = (char *)cmdstr.c_str();
+  ASSERT_EQ(0, rados_mon_command(this->_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
+
+  EXPECT_EQ(0, rados_wait_for_latest_osdmap(this->_cluster));
+
+  // do diff again
+  extents.clear();
+  ASSERT_EQ(0, clone_image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, (void *)&extents));
+  ASSERT_EQ(1u, extents.size());
+  ASSERT_EQ(diff_extent(0, 256, true, object_size), extents[0]);
+
+  // do diff the 3rd time (after cache tier promotion)
+  extents.clear();
+  ASSERT_EQ(0, clone_image.diff_iterate2(NULL, 0, size, true, this->whole_object,
+                                   vector_iterate_cb, (void *)&extents));
+  ASSERT_EQ(1u, extents.size());
+
+  ASSERT_EQ(0, clone_image.snap_remove("snap"));
+  ASSERT_EQ(0, clone_image.close());
+  ASSERT_EQ(0, rbd.remove(ioctx_layered, clone_name.c_str()));
+  ASSERT_EQ(0, parent_image.snap_unprotect("snap"));
+  ASSERT_EQ(0, parent_image.snap_remove("snap"));
+  ASSERT_EQ(0, parent_image.close());
+  ASSERT_EQ(0, rbd.remove(ioctx_base, parent_name.c_str()));
+
+  cmdstr = "{\"prefix\": \"osd tier remove-overlay\", \"pool\": \"" +
+     layered_pool_name + "\"}";
+  cmd[0] = (char *)cmdstr.c_str();
+  ASSERT_EQ(0, rados_mon_command(this->_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
+  cmdstr = "{\"prefix\": \"osd tier remove\", \"pool\": \"" +
+     layered_pool_name + "\", \"tierpool\":\"" + cache_pool_name + "\"}";
+  cmd[0] = (char *)cmdstr.c_str();
+  ASSERT_EQ(0, rados_mon_command(this->_cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0));
+}
+
 TEST_F(TestLibRBD, ZeroLengthWrite)
 {
   rados_ioctx_t ioctx;


### PR DESCRIPTION
…ect.

When doing list_snaps on an non-existent object in base pool, a whiteouted
object is created in the writeback cache tier, and an empty snapset is
attached to it. Then the list_snaps op succeeds and gets the empty snapset,
which makes librbd::DiffIterate work improperly.

This patch add return value of list_snaps to ReplicatedPG::CopyResults, and
also pass op->may_write() to ReplicatedPG::finishi_promote. A whiteouted
object is only created when the head object is not exist and if list_snaps
doesn't fail or the original op is write.

Fixes: #16890

Signed-off-by: Zhao Chao zhaochao1984@gmail.com
