### PR TITLE
rbd-mirror: replaying state should include flush action

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -295,7 +295,8 @@ private:
     return !is_stopped_() && m_state != STATE_STOPPING && !m_stop_requested;
   }
   bool is_replaying_() const {
-    return m_state == STATE_REPLAYING;
+    return (m_state == STATE_REPLAYING ||
+            m_state == STATE_REPLAY_FLUSHING);
   }
 
   bool update_mirror_image_status(bool force, const OptionalState &state);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16970
Signed-off-by: Jason Dillaman <dillaman@redhat.com>