### PR TITLE
FIX: use ceph::buffer::list instead of buffer::list

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -393,7 +393,7 @@ namespace librados
     void zero(uint64_t off, uint64_t len);
     void rmxattr(const char *name);
     void setxattr(const char *name, const bufferlist& bl);
-    void setxattr(const char *name, const buffer::list&& bl);
+    void setxattr(const char *name, const bufferlist&& bl);
     void tmap_update(const bufferlist& cmdbl);
     void tmap_put(const bufferlist& bl);
     void clone_range(uint64_t dst_off,


### PR DESCRIPTION
use ceph::buffer::list instead of buffer::list so that things outside ceph can use librados.hpp