### PR TITLE
rgw_file: unlock() must precede out label

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1000,9 +1000,9 @@ namespace rgw {
 	goto retry; /* !LATCHED */
       }
       /* LATCHED */
+      fh->mtx.unlock(); /* !LOCKED */
     out:
       lat.lock->unlock(); /* !LATCHED */
-      fh->mtx.unlock(); /* !LOCKED */
       return fh;
     }
 


### PR DESCRIPTION
In lookup_handle(...).

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>