### PR TITLE
cephfs: Permit recovering metadata into a new RADOS pool

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -291,9 +291,15 @@ class MDSCluster(CephCluster):
                                              '--yes-i-really-really-mean-it')
             for data_pool in mdsmap['data_pools']:
                 data_pool = pool_id_name[data_pool]
-                self.mon_manager.raw_cluster_cmd('osd', 'pool', 'delete',
-                                                 data_pool, data_pool,
-                                                 '--yes-i-really-really-mean-it')
+                try:
+                    self.mon_manager.raw_cluster_cmd('osd', 'pool', 'delete',
+                                                     data_pool, data_pool,
+                                                     '--yes-i-really-really-mean-it')
+                except CommandFailedError as e:
+                    if e.exitstatus == 16: # EBUSY, this data pool is used
+                        pass               # by two metadata pools, let the 2nd
+                    else:                  # pass delete it
+                        raise
 
     def get_standby_daemons(self):
         return set([s['name'] for s in self.status().get_standbys()])

--- a/qa/tasks/cephfs/test_data_scan.py
+++ b/qa/tasks/cephfs/test_data_scan.py
@@ -294,7 +294,7 @@ class NonDefaultLayout(Workload):
         self._initial_state = self._mount.stat("datafile")
 
     def validate(self):
-        p = self._mount.run_shell(["getfattr", "--only-values", "-n", "ceph.file.layout.object_size", "./datafile"])
+        p = self._mount.run_shell(["sudo", "getfattr", "--only-values", "-n", "ceph.file.layout.object_size", "./datafile"])
 
         # Check we got the layout reconstructed properly
         object_size = int(p.stdout.getvalue().strip())
@@ -312,19 +312,38 @@ class TestDataScan(CephFSTestCase):
         mds_map = self.fs.get_mds_map()
         return rank in mds_map['damaged']
 
-    def _rebuild_metadata(self, workload, workers=1):
+    def _rebuild_metadata(self, workload, other_pool=None, workers=1):
         """
         That when all objects in metadata pool are removed, we can rebuild a metadata pool
         based on the contents of a data pool, and a client can see and read our files.
         """
 
         # First, inject some files
+
+        other_fs = other_pool + '-fs' if other_pool else None
         workload.write()
 
         # Unmount the client and flush the journal: the tool should also cope with
         # situations where there is dirty metadata, but we'll test that separately
         self.mount_a.umount_wait()
         workload.flush()
+
+        # Create the alternate pool if requested
+        if other_pool:
+            self.fs.rados(['mkpool', other_pool])
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'flag', 'set',
+                                                'enable_multiple', 'true',
+                                                '--yes-i-really-mean-it')
+            self.fs.mon_manager.raw_cluster_cmd('fs', 'new', other_fs,
+                                                other_pool,
+                                                self.fs.get_data_pool_name(),
+                                                '--allow-dangerous-metadata-overlay')
+            self.fs.data_scan(['init', '--force-init', '--filesystem',
+                               other_fs, '--alternate-pool', other_pool])
+            self.fs.mon_manager.raw_cluster_cmd('-s')
+            self.fs.table_tool([other_fs + ":0", "reset", "session"])
+            self.fs.table_tool([other_fs + ":0", "reset", "snap"])
+            self.fs.table_tool([other_fs + ":0", "reset", "inode"])
 
         # Stop the MDS
         self.fs.mds_stop()
@@ -343,32 +362,63 @@ class TestDataScan(CephFSTestCase):
         self.fs.mon_manager.raw_cluster_cmd('fs', 'reset', self.fs.name,
                 '--yes-i-really-mean-it')
 
-        # Attempt to start an MDS, see that it goes into damaged state
-        self.fs.mds_restart()
+        if other_pool is None:
+            self.fs.mds_restart()
 
         def get_state(mds_id):
             info = self.mds_cluster.get_mds_info(mds_id)
             return info['state'] if info is not None else None
 
-        self.wait_until_true(lambda: self.is_marked_damaged(0), 60)
-        for mds_id in self.fs.mds_ids:
-            self.wait_until_equal(
-                    lambda: get_state(mds_id),
-                    "up:standby",
-                    timeout=60)
+        if other_pool is None:
+            self.wait_until_true(lambda: self.is_marked_damaged(0), 60)
+            for mds_id in self.fs.mds_ids:
+                self.wait_until_equal(
+                        lambda: get_state(mds_id),
+                        "up:standby",
+                        timeout=60)
+
+        self.fs.table_tool([self.fs.name + ":0", "reset", "session"])
+        self.fs.table_tool([self.fs.name + ":0", "reset", "snap"])
+        self.fs.table_tool([self.fs.name + ":0", "reset", "inode"])
 
         # Run the recovery procedure
-        self.fs.table_tool(["0", "reset", "session"])
-        self.fs.table_tool(["0", "reset", "snap"])
-        self.fs.table_tool(["0", "reset", "inode"])
         if False:
             with self.assertRaises(CommandFailedError):
                 # Normal reset should fail when no objects are present, we'll use --force instead
                 self.fs.journal_tool(["journal", "reset"])
-        self.fs.journal_tool(["journal", "reset", "--force"])
-        self.fs.data_scan(["init"])
-        self.fs.data_scan(["scan_extents", self.fs.get_data_pool_name()], worker_count=workers)
-        self.fs.data_scan(["scan_inodes", self.fs.get_data_pool_name()], worker_count=workers)
+
+        if other_pool:
+            self.fs.mds_stop()
+            self.fs.data_scan(['scan_extents', '--alternate-pool',
+                               other_pool, '--filesystem', self.fs.name,
+                               self.fs.get_data_pool_name()])
+            self.fs.data_scan(['scan_inodes', '--alternate-pool',
+                               other_pool, '--filesystem', self.fs.name,
+                               '--force-corrupt', '--force-init',
+                               self.fs.get_data_pool_name()])
+            self.fs.journal_tool(['--rank=' + self.fs.name + ":0", 'event',
+                                  'recover_dentries', 'list',
+                                  '--alternate-pool', other_pool])
+
+            self.fs.data_scan(['init', '--force-init', '--filesystem',
+                               self.fs.name])
+            self.fs.data_scan(['scan_inodes', '--filesystem', self.fs.name,
+                               '--force-corrupt', '--force-init',
+                               self.fs.get_data_pool_name()])
+            self.fs.journal_tool(['--rank=' + self.fs.name + ":0", 'event',
+                                  'recover_dentries', 'list'])
+
+            self.fs.journal_tool(['--rank=' + other_fs + ":0", 'journal',
+                                  'reset', '--force'])
+            self.fs.journal_tool(['--rank=' + self.fs.name + ":0", 'journal',
+                                  'reset', '--force'])
+            self.fs.mon_manager.raw_cluster_cmd('mds', 'repaired',
+                                                other_fs + ":0")
+        else:
+            self.fs.journal_tool(["journal", "reset", "--force"])
+            self.fs.data_scan(["init"])
+            self.fs.data_scan(["scan_extents", self.fs.get_data_pool_name()], worker_count=workers)
+            self.fs.data_scan(["scan_inodes", self.fs.get_data_pool_name()], worker_count=workers)
 
         # Mark the MDS repaired
         self.fs.mon_manager.raw_cluster_cmd('mds', 'repaired', '0')
@@ -376,10 +426,26 @@ class TestDataScan(CephFSTestCase):
         # Start the MDS
         self.fs.mds_restart()
         self.fs.wait_for_daemons()
+        if other_pool:
+            for mds_id in self.fs.mds_ids:
+                self.wait_until_equal(
+                        lambda: get_state(mds_id),
+                        "up:active",
+                        timeout=60)
+            self.fs.mon_manager.raw_cluster_cmd('tell', 'mds.a',
+                                                'injectargs', '--debug-mds=20')
+            self.fs.mon_manager.raw_cluster_cmd('tell', 'mds.b',
+                                                'injectargs', '--debug-mds=20')
+            self.fs.mon_manager.raw_cluster_cmd('daemon', 'mds.a',
+                                                'scrub_path', '/',
+                                                'recursive', 'repair')
+            self.fs.mon_manager.raw_cluster_cmd('daemon', 'mds.b',
+                                                'scrub_path', '/',
+                                                'recursive', 'repair')
         log.info(str(self.mds_cluster.status()))
 
         # Mount a client
-        self.mount_a.mount()
+        self.mount_a.mount(mount_fs_name=other_fs)
         self.mount_a.wait_until_mounted()
 
         # See that the files are present and correct
@@ -414,7 +480,12 @@ class TestDataScan(CephFSTestCase):
     def test_stashed_layout(self):
         self._rebuild_metadata(StripedStashedLayout(self.fs, self.mount_a))
 
+    def test_rebuild_simple_altpool(self):
+        self._rebuild_metadata(SimpleWorkload(self.fs, self.mount_a), other_pool="recovery")
+
     def _dirfrag_keys(self, object_id):
+        self.other_pool = 'recovery'
+        self.other_fs = self.other_pool + '-fs'
         keys_str = self.fs.rados(["listomapkeys", object_id])
         if keys_str:
             return keys_str.split("\n")

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1954,6 +1954,7 @@ void CDir::_go_bad()
 
 void CDir::go_bad_dentry(snapid_t last, const std::string &dname)
 {
+  dout(10) << "go_bad_dentry " << dname << dendl;
   const bool fatal = cache->mds->damage_table.notify_dentry(
       inode->ino(), frag, last, dname);
   if (fatal) {
@@ -1964,6 +1965,7 @@ void CDir::go_bad_dentry(snapid_t last, const std::string &dname)
 
 void CDir::go_bad(bool complete)
 {
+  dout(10) << "go_bad " << frag << dendl;
   const bool fatal = cache->mds->damage_table.notify_dirfrag(inode->ino(), frag);
   if (fatal) {
     cache->mds->damaged();

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -434,6 +434,14 @@ public:
     }
     return nullptr;
   }
+  std::list<std::shared_ptr<const Filesystem> > get_filesystems(void) const
+    {
+      std::list<std::shared_ptr<const Filesystem> > ret;
+      for (const auto &i : filesystems) {
+	ret.push_back(std::const_pointer_cast<const Filesystem>(i.second));
+      }
+      return ret;
+    }
 
   int parse_filesystem(
       std::string const &ns_str,

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -151,6 +151,19 @@ class FsNewHandler : public FileSystemCommandHandler
       return -EINVAL;
     }
 
+    for (auto fs : pending_fsmap.get_filesystems()) {
+      const set<int64_t>& data_pools = fs.second->mds_map.get_data_pools();
+      string sure;
+      if ((data_pools.find(data) != data_pools.end()
+	   || fs.second->mds_map.metadata_pool == metadata)
+	  && ((!cmd_getval(g_ceph_context, cmdmap, "sure", sure)
+	       || sure != "--allow-dangerous-metadata-overlay"))) {
+	ss << "Filesystem '" << fs_name
+	   << "' is already using one of the specified RADOS pools. This should ONLY be done in emergencies and after careful reading of the documentation. Pass --allow-dangerous-metadata-overlay to permit this.";
+	return -EEXIST;
+      }
+    }
+
     pg_pool_t const *data_pool = mon->osdmon()->osdmap.get_pg_pool(data);
     assert(data_pool != NULL);  // Checked it existed above
     pg_pool_t const *metadata_pool = mon->osdmon()->osdmap.get_pg_pool(metadata);

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -151,11 +151,11 @@ class FsNewHandler : public FileSystemCommandHandler
       return -EINVAL;
     }
 
-    for (auto fs : pending_fsmap.get_filesystems()) {
-      const set<int64_t>& data_pools = fs.second->mds_map.get_data_pools();
+    for (auto fs : fsmap.get_filesystems()) {
+      const set<int64_t>& data_pools = fs->mds_map.get_data_pools();
       string sure;
       if ((data_pools.find(data) != data_pools.end()
-	   || fs.second->mds_map.metadata_pool == metadata)
+	   || fs->mds_map.get_metadata_pool() == metadata)
 	  && ((!cmd_getval(g_ceph_context, cmdmap, "sure", sure)
 	       || sure != "--allow-dangerous-metadata-overlay"))) {
 	ss << "Filesystem '" << fs_name

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -332,8 +332,8 @@ COMMAND("fs new " \
 	"name=fs_name,type=CephString " \
 	"name=metadata,type=CephString " \
 	"name=data,type=CephString " \
-	"name=force,type=CephChoices,strings=--force,req=false", \
-	"name=allow_overlay,type=CephChoices,strings=--allow-dangerous-metadata-overlay,req=false", \
+	"name=force,type=CephChoices,strings=--force,req=false " \
+	"name=sure,type=CephChoices,strings=--allow-dangerous-metadata-overlay,req=false", \
 	"make new filesystem using named pools <metadata> and <data>", \
 	"fs", "rw", "cli,rest")
 COMMAND("fs rm " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -333,6 +333,7 @@ COMMAND("fs new " \
 	"name=metadata,type=CephString " \
 	"name=data,type=CephString " \
 	"name=force,type=CephChoices,strings=--force,req=false", \
+	"name=allow_overlay,type=CephChoices,strings=--allow-dangerous-metadata-overlay,req=false", \
 	"make new filesystem using named pools <metadata> and <data>", \
 	"fs", "rw", "cli,rest")
 COMMAND("fs rm " \

--- a/src/tools/cephfs/DataScan.h
+++ b/src/tools/cephfs/DataScan.h
@@ -30,6 +30,7 @@ class RecoveryDriver {
   public:
     virtual int init(
         librados::Rados &rados,
+	std::string &metadata_pool_name,
         const FSMap *fsmap,
         fs_cluster_id_t fscid) = 0;
 
@@ -118,6 +119,7 @@ class LocalFileDriver : public RecoveryDriver
     // Implement RecoveryDriver interface
     int init(
         librados::Rados &rados,
+	std::string &metadata_pool_name,
         const FSMap *fsmap,
         fs_cluster_id_t fscid) override;
 
@@ -211,6 +213,7 @@ class MetadataDriver : public RecoveryDriver, public MetadataTool
     // Implement RecoveryDriver interface
     int init(
         librados::Rados &rados,
+	std::string &metadata_pool_name,
         const FSMap *fsmap,
         fs_cluster_id_t fscid) override;
 
@@ -241,6 +244,7 @@ class DataScan : public MDSUtility, public MetadataTool
     librados::IoCtx data_io;
     // Remember the data pool ID for use in layouts
     int64_t data_pool_id;
+    string metadata_pool_name;
 
     uint32_t n;
     uint32_t m;
@@ -316,7 +320,8 @@ class DataScan : public MDSUtility, public MetadataTool
     int main(const std::vector<const char *> &args);
 
     DataScan()
-      : driver(NULL), fscid(FS_CLUSTER_ID_NONE), data_pool_id(-1), n(0), m(1),
+      : driver(NULL), fscid(FS_CLUSTER_ID_NONE),
+	data_pool_id(-1), metadata_pool_name(""), n(0), m(1),
         force_pool(false), force_corrupt(false),
         force_init(false)
     {

--- a/src/tools/cephfs/JournalTool.h
+++ b/src/tools/cephfs/JournalTool.h
@@ -56,9 +56,13 @@ class JournalTool : public MDSUtility
 
     // I/O handles
     librados::Rados rados;
-    librados::IoCtx io;
+    librados::IoCtx input;
+    librados::IoCtx output;
+
+    bool other_pool;
 
     // Metadata backing store manipulation
+    int read_lost_found(std::set<std::string> &lost);
     int scavenge_dentries(
         EMetaBlob const &metablob,
         bool const dry_run,
@@ -78,7 +82,7 @@ class JournalTool : public MDSUtility
   public:
     void usage();
     JournalTool() :
-      rank(0) {}
+      rank(0), other_pool(false) {}
     int main(std::vector<const char*> &argv);
 };
 


### PR DESCRIPTION
Add a procedure that permits reconstructing metadata in a potentially
damaged cephfs metadata pool and writing the results into a
freshly-initialized pool that refers to the same data pool. Add option
flags to override checks that would ordinarily prevent this and add
options to the recovery tools to write output to a separate pool instead of
the one selected for recovery. See docs/cephfs/disaster-recovery.rst for
details.

cf. https://github.com/fullerdj/ceph-qa-suite/tree/wip-djf-15069

Fixes: http://tracker.ceph.com/issues/15068
Fixes: http://tracker.ceph.com/issues/15069
Signed-off-by: Douglas Fuller dfuller@redhat.com
