### PR TITLE
librbd: Zipkin tracing [GSOC 2016]

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -33,3 +33,6 @@
 [submodule "src/isa-l"]
 	path = src/isa-l
 	url = https://github.com/ceph/isa-l
+[submodule "src/blkin"]
+	path = src/blkin
+	url = https://github.com/linuxbox2/blkin

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,12 @@ if(WITH_XIO)
 set(HAVE_XIO ${XIO_FOUND})
 endif(WITH_XIO)
 
+option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
+if(WITH_BLKIN)
+  find_package(blkin REQUIRED)
+  include_directories(${BLKIN_INCLUDE_DIR})
+endif(WITH_BLKIN)
+
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 

--- a/cmake/modules/Findblkin.cmake
+++ b/cmake/modules/Findblkin.cmake
@@ -1,0 +1,23 @@
+# - Try to find blkin
+# Once done this will define
+#  BLKIN_FOUND - System has blkin
+#  BLKIN_INCLUDE_DIR - The blkin include directories
+#  BLKIN_LIBRARIES - The libraries needed to use blkin
+
+find_package(PkgConfig)
+pkg_check_modules(PC_BLKIN QUIET libblkin)
+
+find_path(BLKIN_INCLUDE_DIR ztracer.hpp
+	HINTS ${PC_BLKIN_INCLUDEDIR} ${PC_BLKIN_INCLUDE_DIRS}
+	PATH_SUFFIXES blkin)
+find_library(BLKIN_LIBRARY NAMES blkin
+	HINTS ${PC_BLKIN_LIBDIR} ${PC_BLKIN_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set BLKIN_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(blkin DEFAULT_MSG
+	BLKIN_LIBRARY BLKIN_INCLUDE_DIR)
+
+set(BLKIN_LIBRARIES ${BLKIN_LIBRARY} lttng-ust)
+mark_as_advanced(BLKIN_INCLUDE_DIR BLKIN_LIBRARIES)

--- a/configure.ac
+++ b/configure.ac
@@ -528,6 +528,17 @@ if test "x$enable_coverage" != xno; then
 fi
 AC_SUBST(GCOV_PREFIX_STRIP, `echo $(pwd)/src | tr -dc / | wc -c`)
 
+# blkin (lttng+zipkin) tracing?
+AC_ARG_WITH([blkin],
+	    [AS_HELP_STRING([--with-blkin], [blkin (lttng + zipkin) tracing])],
+	    [],
+	    [with_blkin=no])
+have_blkin=no
+AS_IF([test "x$with_blkin" == "xyes"],
+    [PKG_CHECK_MODULES([BLKIN], [blkin], [have_blkin=yes])])
+AM_CONDITIONAL(WITH_BLKIN, test "x$have_blkin" == xyes)
+AM_COND_IF([WITH_BLKIN], [AC_DEFINE([WITH_BLKIN], [1], [Defined if using BlkKin])])
+
 # is radosgw available?
 RADOSGW=0
 AS_IF([test "x$with_radosgw" != xno],

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -4,6 +4,7 @@ usage() {
     cat <<EOF
 do_autogen.sh: make a ceph build by running autogen, etc.
 
+-b                               blkin tracing
 -C <parameter>                   add parameters to configure
 -c                               use cryptopp
 -d <level>                       debug build
@@ -36,9 +37,10 @@ verbose=0
 profile=0
 rocksdb=1
 CONFIGURE_FLAGS="--disable-static --with-lttng"
-while getopts  "C:cd:e:hjJLO:pPRTv" flag
+while getopts  "bC:cd:e:hjJLO:pPRTv" flag
 do
     case $flag in
+    b) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-blkin";;
     C) CONFIGURE_FLAGS="$CONFIGURE_FLAGS $OPTARG";;
     c) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-cryptopp --without-nss";;
     d) debug_level=$OPTARG;;

--- a/doc/dev/blkin.rst
+++ b/doc/dev/blkin.rst
@@ -1,0 +1,167 @@
+=========================
+ Tracing Ceph With BlkKin
+=========================
+
+Ceph can use Blkin, a library created by Marios Kogias and others,
+which enables tracking a specific request from the time it enters
+the system at higher levels till it is finally served by RADOS.
+
+In general, Blkin implements the Dapper_ tracing semantics
+in order to show the causal relationships between the different
+processing phases that an IO request may trigger. The goal is an
+end-to-end visualisation of the request's route in the system,
+accompanied by information concerning latencies in each processing
+phase. Thanks to LTTng this can happen with a minimal overhead and
+in realtime. The LTTng traces can then be visualized with Twitter's
+Zipkin_.
+
+.. _Dapper: http://static.googleusercontent.com/media/research.google.com/el//pubs/archive/36356.pdf
+.. _Zipkin: http://twitter.github.io/zipkin/
+
+
+Installing Blkin
+================
+
+You can install Markos Kogias' upstream Blkin_ by hand.::
+
+  cd blkin/
+  make && make install
+
+or build distribution packages using DistroReadyBlkin_, which also comes with
+pkgconfig support. If you choose the latter, then you must generate the
+configure and make files first.::
+
+  cd blkin
+  autoreconf -i
+
+.. _Blkin: https://github.com/marioskogias/blkin
+.. _DistroReadyBlkin: https://github.com/agshew/blkin
+
+
+Configuring Ceph with Blkin
+===========================
+
+If you built and installed Blkin by hand, rather than building and
+installing packages, then set these variables before configuring
+Ceph.::
+
+  export BLKIN_CFLAGS=-Iblkin/
+  export BLKIN_LIBS=-lzipkin-cpp
+
+Since there are separate lttng and blkin changes to Ceph, you may
+want to configure with something like::
+
+  ./configure --with-blkin --without-lttng --with-debug
+
+
+Testing Blkin
+=============
+
+It's easy to test Ceph's Blkin tracing. Let's assume you don't have
+Ceph already running, and you compiled Ceph with Blkin support but
+you did't install it. Then launch Ceph with the ``vstart.sh`` script
+in Ceph's src directgory so you can see the possible tracepoints.::
+
+  cd src
+  OSD=3 MON=3 RGW=1 ./vstart.sh -n
+  lttng list --userspace
+
+You'll see something like the following:::
+
+  UST events:
+  -------------
+  PID: 8987 - Name: ./ceph-osd
+        zipkin:timestamp (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        zipkin:keyval (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        ust_baddr_statedump:soinfo (loglevel: TRACE_DEBUG_LINE (13)) (type: tracepoint)
+
+  PID: 8407 - Name: ./ceph-mon
+        zipkin:timestamp (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        zipkin:keyval (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        ust_baddr_statedump:soinfo (loglevel: TRACE_DEBUG_LINE (13)) (type: tracepoint)
+
+  ...
+
+Next, stop Ceph so that the tracepoints can be enabled.::
+
+  ./stop.sh
+
+Start up an LTTng session and enable the tracepoints.::
+
+  lttng create blkin-test
+  lttng enable-event --userspace zipkin:timestamp
+  lttng enable-event --userspace zipkin:keyval
+  lttng start
+
+Then start up Ceph again.::
+
+  OSD=3 MON=3 RGW=1 ./vstart.sh -n
+
+You may want to check that ceph is up.::
+
+  ./ceph status
+
+Now put something in usin rados, check that it made it, get it back, and remove it.::
+
+  ./rados mkpool test-blkin
+  ./rados put test-object-1 ./vstart.sh --pool=test-blkin
+  ./rados -p test-blkin ls
+  ./ceph osd map test-blkin test-object-1
+  ./rados get test-object-1 ./vstart-copy.sh --pool=test-blkin
+  md5sum vstart*
+  ./rados rm test-object-1 --pool=test-blkin
+
+You could also use the example in ``examples/librados/`` or ``rados bench``.
+
+Then stop the LTTng session and see what was collected.::
+
+  lttng stop
+  lttng view
+
+You'll see something like:::
+
+  [13:09:07.755054973] (+?.?????????) scruffy zipkin:timestamp: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, event = "Message allocated" }
+  [13:09:07.755071569] (+0.000016596) scruffy zipkin:keyval: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, key = "Type", val = "MOSDOp" }
+  [13:09:07.755074217] (+0.000002648) scruffy zipkin:keyval: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, key = "Reqid", val = "client.4126.0:1" }
+  ...
+
+
+Install  Zipkin
+===============
+One of the points of using Blkin is so that you can look at the traces
+using Zipkin. Users should run Zipkin as a tracepoints collector and
+also a web service, which means users need to run three services,
+zipkin-collector, zipkin-query and zipkin-web.
+
+Download Zipkin Package::
+
+  wget https://github.com/twitter/zipkin/archive/1.1.0.tar.gz
+  tar zxf 1.1.0.tar.gz
+  cd zipkin-1.1.0
+  bin/collector cassandra &
+  bin/query cassandra &
+  bin/web &
+
+Check Zipkin::
+
+  bin/test
+  Browse http://${zipkin-web-ip}:8080
+
+
+Show Ceph's Blkin Traces in Zipkin-web
+======================================
+Blkin provides a script which translates lttng result to Zipkin
+(Dapper) semantics.
+
+Send lttng data to Zipkin::
+
+  python3 babeltrace_zipkin.py ${lttng-traces-dir}/${blkin-test}/ust/uid/0/64-bit/ -p ${zipkin-collector-port(9410 by default)} -s ${zipkin-collector-ip}
+
+Example::
+
+  python3 babeltrace_zipkin.py ~/lttng-traces-dir/blkin-test-20150225-160222/ust/uid/0/64-bit/ -p 9410 -s 127.0.0.1
+
+Check Ceph traces on webpage::
+
+  Browse http://${zipkin-web-ip}:8080
+  Click "Find traces"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -523,6 +523,7 @@ endif(HAVE_ARMV8_CRC)
 
 add_library(common_utf8 STATIC common/utf8.c)
 
+target_link_libraries(common json_spirit common_utf8 erasure_code rt uuid resolv ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES} ${BLKIN_LIBRARIES})
 if(${WITH_LTTNG})
   add_subdirectory(tracing)
 endif(${WITH_LTTNG})

--- a/src/Makefile-env.am
+++ b/src/Makefile-env.am
@@ -257,6 +257,12 @@ if ENABLE_COVERAGE
 EXTRALIBS += -lgcov
 endif # ENABLE_COVERAGE
 
+if WITH_BLKIN
+AM_CPPFLAGS += -DWITH_BLKIN
+AM_CXXFLAGS += $(BLKIN_CFLAGS)
+EXTRALIBS += $(BLKIN_LIBS)
+endif
+
 # Libosd always needs osdc and os
 LIBOSD += $(LIBOSDC) $(LIBOS)
 

--- a/src/Makefile-server.am
+++ b/src/Makefile-server.am
@@ -21,6 +21,9 @@ if WITH_MON
 
 ceph_mon_SOURCES = ceph_mon.cc
 ceph_mon_LDADD = $(LIBMON) $(LIBOS) $(CEPH_GLOBAL) $(LIBCOMMON) $(LIBAUTH) $(LIBCOMMON) $(LIBMON_TYPES)
+if WITH_BLKIN
+ceph_mon_LDADD += $(BLKIN_LIBS)
+endif
 bin_PROGRAMS += ceph-mon
 
 endif # WITH_MON
@@ -41,6 +44,9 @@ ceph_osd_LDADD = \
 	$(CEPH_GLOBAL) $(LIBCOMMON)
 if WITH_LTTNG
 ceph_osd_LDADD += $(LIBOSD_TP)
+endif
+if WITH_BLKIN
+ceph_osd_LDADD += $(BLKIN_LIBS)
 endif
 bin_PROGRAMS += ceph-osd
 

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -34,7 +34,7 @@ class ObjecterWriteback : public WritebackHandler {
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit) {
+			   Context *oncommit, const blkin_trace_info *trace_info = nullptr) {
     return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
 				   trunc_size, trunc_seq, NULL,
 				   new C_OnFinisher(new C_Lock(m_lock,

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -17,7 +17,8 @@ class ObjecterWriteback : public WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish) {
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        const blkin_trace_info *trace_info = nullptr) {
     m_objecter->read_trunc(oid, oloc, off, len, snapid, pbl, 0,
 			   trunc_size, trunc_seq,
 			   new C_OnFinisher(new C_Lock(m_lock, onfinish),

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -18,7 +18,7 @@ class ObjecterWriteback : public WritebackHandler {
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags, Context *onfinish,
-        const blkin_trace_info *trace_info = nullptr) {
+        ZTracer::Trace *trace = nullptr) {
     m_objecter->read_trunc(oid, oloc, off, len, snapid, pbl, 0,
 			   trunc_size, trunc_seq,
 			   new C_OnFinisher(new C_Lock(m_lock, onfinish),
@@ -35,7 +35,7 @@ class ObjecterWriteback : public WritebackHandler {
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit, const blkin_trace_info *trace_info = nullptr) {
+			   Context *oncommit, ZTracer::Trace *trace = nullptr) {
     return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
 				   trunc_size, trunc_seq, NULL,
 				   new C_OnFinisher(new C_Lock(m_lock,

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -185,6 +185,8 @@ protected:
 public:
   ZTracer::Trace osd_trace;
   ZTracer::Trace pg_trace;
+  ZTracer::Trace store_trace;
+  ZTracer::Trace journal_trace;
 
   virtual ~TrackedOp() {}
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -18,6 +18,7 @@
 #include <include/utime.h>
 #include "common/Mutex.h"
 #include "common/histogram.h"
+#include "common/zipkin_trace.h"
 #include "include/xlist.h"
 #include "msg/Message.h"
 #include "include/memory.h"
@@ -182,6 +183,8 @@ protected:
   virtual void _unregistered() {};
 
 public:
+  ZTracer::Trace osd_trace;
+
   virtual ~TrackedOp() {}
 
   const utime_t& get_initiated() const {

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -184,6 +184,7 @@ protected:
 
 public:
   ZTracer::Trace osd_trace;
+  ZTracer::Trace pg_trace;
 
   virtual ~TrackedOp() {}
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -24,6 +24,7 @@
 #include "common/safe_io.h"
 #include "common/valgrind.h"
 #include "common/version.h"
+#include "common/zipkin_trace.h"
 #include "include/color.h"
 
 #include <errno.h>

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -123,6 +123,7 @@ void complain_about_parse_errors(CephContext *cct,
 void common_init_finish(CephContext *cct)
 {
   cct->init_crypto();
+  ZTracer::ztrace_init();
 
   int flags = cct->get_init_flags();
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -906,6 +906,7 @@ OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64M
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
 OPTION(osd_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all osd requests
+OPTION(osdc_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all objecter requests
 
 OPTION(osd_discard_disconnected_ops, OPT_BOOL, true)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -905,6 +905,8 @@ OPTION(osd_bench_large_size_max_throughput, OPT_U64, 100 << 20) // 100 MB/s
 OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64MB
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
+OPTION(osd_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all osd requests
+
 OPTION(osd_discard_disconnected_ops, OPT_BOOL, true)
 
 OPTION(memstore_device_bytes, OPT_U64, 1024*1024*1024)

--- a/src/common/zipkin_trace.h
+++ b/src/common/zipkin_trace.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef COMMON_ZIPKIN_TRACE_H
+#define COMMON_ZIPKIN_TRACE_H
+
+#include <string>
+#include "acconfig.h"
+
+#ifdef WITH_BLKIN
+
+#include <ztracer.hpp>
+
+#else // !WITH_BLKIN
+
+// add stubs for noop Trace and Endpoint
+struct blkin_trace_info {};
+
+namespace ZTracer
+{
+static inline int ztrace_init() { return 0; }
+
+class Endpoint {
+ public:
+  Endpoint(const char *name) {}
+  Endpoint(const char *ip, int port, const char *name) {}
+
+  void copy_ip(const std::string &newip) {}
+  void copy_name(const std::string &newname) {}
+  void copy_address_from(const Endpoint *endpoint) {}
+  void share_address_from(const Endpoint *endpoint) {}
+  void set_port(int p) {}
+};
+
+class Trace {
+ public:
+  Trace() {}
+  Trace(const char *name, const Endpoint *ep, const Trace *parent = NULL) {}
+  Trace(const char *name, const Endpoint *ep,
+        const blkin_trace_info *i, bool child=false) {}
+
+  bool valid() const { return false; }
+  operator bool() const { return false; }
+
+  int init(const char *name, const Endpoint *ep, const Trace *parent = NULL) {
+    return 0;
+  }
+  int init(const char *name, const Endpoint *ep,
+           const blkin_trace_info *i, bool child=false) {
+    return 0;
+  }
+
+  void copy_name(const std::string &newname) {}
+
+  const blkin_trace_info* get_info() const { return NULL; }
+  void set_info(const blkin_trace_info *i) {}
+
+  void keyval(const char *key, const char *val) const {}
+  void keyval(const char *key, int64_t val) const {}
+  void keyval(const char *key, const char *val, const Endpoint *ep) const {}
+  void keyval(const char *key, int64_t val, const Endpoint *ep) const {}
+
+  void event(const char *event) const {}
+  void event(const char *event, const Endpoint *ep) const {}
+};
+} // namespace ZTrace
+
+#endif // !WITH_BLKIN
+
+#endif // COMMON_ZIPKIN_TRACE_H

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -76,6 +76,7 @@
 #define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<54)
 #define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
+#define CEPH_FEATURE_BLKIN_TRACING (1ULL<<57) // enabled by ifdef, don't overlap
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 #define CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT (1ULL<<57) /* overlap, drop unused SnapContext in v12 */
@@ -110,6 +111,13 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 		return f;
 	}
 }
+
+// conditionally include blkin in CEPH_FEATURES_ALL/SUPPORTED_DEFAULT
+#ifdef WITH_BLKIN
+#define CEPH_FEATURES_BLKIN CEPH_FEATURE_BLKIN_TRACING
+#else
+#define CEPH_FEATURES_BLKIN 0
+#endif
 
 /*
  * Features supported.  Should be everything above.
@@ -174,6 +182,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
          CEPH_FEATURE_OSD_PROXY_WRITE_FEATURES |         \
 	 CEPH_FEATURE_OSD_HITSET_GMT |			 \
 	 CEPH_FEATURE_HAMMER_0_94_4 |		 \
+	 CEPH_FEATURES_BLKIN | \
 	 CEPH_FEATURE_MON_STATEFUL_SUB |	 \
 	 CEPH_FEATURE_MON_ROUTE_OSDMAP |	 \
 	 CEPH_FEATURE_CRUSH_TUNABLES5 |	    \

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -76,7 +76,6 @@
 #define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<54)
 #define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
-#define CEPH_FEATURE_BLKIN_TRACING (1ULL<<57) // enabled by ifdef, don't overlap
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 #define CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT (1ULL<<57) /* overlap, drop unused SnapContext in v12 */
@@ -85,6 +84,7 @@
 // duplicated since it was introduced at the same time as CEPH_FEATURE_CRUSH_TUNABLES5
 #define CEPH_FEATURE_NEW_OSDOPREPLY_ENCODING (1ULL<<58) /* New, v7 encoding */
 #define CEPH_FEATURE_FS_FILE_LAYOUT_V2       (1ULL<<58) /* file_layout_t */
+#define CEPH_FEATURE_BLKIN_TRACING (1ULL<<59) // don't overlap
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -267,8 +267,8 @@
 /* Version number of package */
 #cmakedefine VERSION "@VERSION@"
 
-/* Defined if pthread_setname_np() is available */
-#cmakedefine HAVE_PTHREAD_SETNAME_NP 1
+/* Defined if blkin enabled */
+#cmakedefine WITH_BLKIN
 
 /* Defined if pthread_set_name_np() is available */
 #cmakedefine HAVE_PTHREAD_SET_NAME_NP

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1902,6 +1902,33 @@ CEPH_RADOS_API int rados_aio_write(rados_ioctx_t io, const char *oid,
 		                   const char *buf, size_t len, uint64_t off);
 
 /**
+ * Write data to an object asynchronously
+ * 
+ * Passes blkin trace information as one of the parameters
+ *
+ * Queues the write and returns. The return value of the completion
+ * will be 0 on success, negative error code on failure.
+ *
+ * @param io the context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the write is safe and complete
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @param off byte offset in the object to begin writing at
+ * @param info blkin trace information
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+ struct blkin_trace_info;
+CEPH_RADOS_API int rados_aio_write_traced(rados_ioctx_t io,
+					  const char *oid,
+					  rados_completion_t completion,
+					  const char *buf,
+					  size_t len,
+					  uint64_t off,
+					  struct blkin_trace_info *info);
+
+/**
  * Asychronously append data to an object
  *
  * Queues the append and returns.
@@ -2005,6 +2032,34 @@ CEPH_RADOS_API int rados_aio_remove(rados_ioctx_t io, const char *oid,
 CEPH_RADOS_API int rados_aio_read(rados_ioctx_t io, const char *oid,
 		                  rados_completion_t completion,
 		                  char *buf, size_t len, uint64_t off);
+
+/**
+ * Asychronously read data from an object
+ *
+ * The io context determines the snapshot to read from, if any was set
+ * by rados_ioctx_snap_set_read().
+ *
+ * The return value of the completion will be number of bytes read on
+ * success, negative error code on failure.
+ *
+ * @note only the 'complete' callback of the completion will be called.
+ *
+ * @param io the context in which to perform the read
+ * @param oid the name of the object to read from
+ * @param completion what to do when the read is complete
+ * @param buf where to store the results
+ * @param len the number of bytes to read
+ * @param off the offset to start reading from in the object
+ * @param info blkin trace information
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_aio_read_traced(rados_ioctx_t io,
+					 const char *oid,
+					 rados_completion_t completion,
+					 char *buf,
+					 size_t len,
+					 uint64_t off,
+					 struct blkin_trace_info *info);
 
 /**
  * Block until all pending writes in an io context are safe

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1003,7 +1003,7 @@ namespace librados
      */
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectWriteOperation *op, snap_t seq,
-		    std::vector<snap_t>& snaps);
+		    std::vector<snap_t>& snaps, const blkin_trace_info *trace_info = nullptr);
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, bufferlist *pbl);
 

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1014,7 +1014,7 @@ namespace librados
 
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, int flags,
-		    bufferlist *pbl);
+		    bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 
     // watch/notify
     int watch2(const std::string& o, uint64_t *handle,

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1003,7 +1003,10 @@ namespace librados
      */
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectWriteOperation *op, snap_t seq,
-		    std::vector<snap_t>& snaps, const blkin_trace_info *trace_info = nullptr);
+		    std::vector<snap_t>& snaps);
+    int aio_operate(const std::string& oid, AioCompletion *c,
+        ObjectWriteOperation *op, snap_t seq,
+        std::vector<snap_t>& snaps, const blkin_trace_info *trace_info);
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, bufferlist *pbl);
 
@@ -1014,8 +1017,10 @@ namespace librados
 
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, int flags,
-		    bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
-
+		    bufferlist *pbl);
+    int aio_operate(const std::string& oid, AioCompletion *c,
+        ObjectReadOperation *op, int flags,
+        bufferlist *pbl, const blkin_trace_info *trace_info);
     // watch/notify
     int watch2(const std::string& o, uint64_t *handle,
 	       librados::WatchCtx2 *ctx);

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -599,6 +599,8 @@ CEPH_RBD_API int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,
  */
 CEPH_RBD_API int rbd_aio_read2(rbd_image_t image, uint64_t off, size_t len,
                                char *buf, rbd_completion_t c, int op_flags);
+CEPH_RBD_API int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
+                              char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info);
 CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
                                  rbd_completion_t c);
 

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -590,6 +590,8 @@ CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
  */
 CEPH_RBD_API int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
                                 const char *buf, rbd_completion_t c, int op_flags);
+CEPH_RBD_API int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
+                               const char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info);
 CEPH_RBD_API int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,
                               char *buf, rbd_completion_t c);
 /*

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -782,7 +782,7 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
 
 int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 				  bufferlist *pbl, size_t len, uint64_t off,
-				  uint64_t snapid)
+				  uint64_t snapid, const blkin_trace_info *info)
 {
   if (len > (size_t) INT_MAX)
     return -EDOM;
@@ -793,17 +793,21 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   c->io = this;
   c->blp = pbl;
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados read", &objecter->trace_endpoint, info);
+
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
     off, len, snapid, pbl, 0,
-    onack, &c->objver);
+    onack, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
 
 int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 				  char *buf, size_t len, uint64_t off,
-				  uint64_t snapid)
+				  uint64_t snapid, const blkin_trace_info *info)
 {
   if (len > (size_t) INT_MAX)
     return -EDOM;
@@ -817,10 +821,14 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   c->blp = &c->bl;
   c->out_buf = buf;
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados read", &objecter->trace_endpoint, info);
+
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
     off, len, snapid, &c->bl, 0,
-    onack, &c->objver);
+    onack, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -863,7 +871,7 @@ int librados::IoCtxImpl::aio_sparse_read(const object_t oid,
 
 int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 				   const bufferlist& bl, size_t len,
-				   uint64_t off)
+				   uint64_t off, const blkin_trace_info *info)
 {
   auto ut = ceph::real_clock::now(client->cct);
   ldout(client->cct, 20) << "aio_write " << oid << " " << off << "~" << len << " snapc=" << snapc << " snap_seq=" << snap_seq << dendl;
@@ -877,13 +885,17 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados write", &objecter->trace_endpoint, info);
+
   c->io = this;
   queue_aio_write(c);
 
   Objecter::Op *o = objecter->prepare_write_op(
     oid, oloc,
     off, len, snapc, bl, ut, 0,
-    onack, onsafe, &c->objver);
+    onack, onsafe, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
 
   return 0;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -743,16 +743,22 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 					  ::ObjectOperation *o,
 					  AioCompletionImpl *c,
 					  int flags,
-					  bufferlist *pbl)
+					  bufferlist *pbl,
+            const blkin_trace_info *trace_info)
 {
   Context *onack = new C_aio_Ack(c);
 
   c->is_read = true;
   c->io = this;
 
+  ZTracer::Trace trace;
+  if (trace_info) {
+    trace.init("rados read", &objecter->trace_endpoint, trace_info);
+  }
+
   Objecter::Op *objecter_op = objecter->prepare_read_op(oid, oloc,
 		 *o, snap_seq, pbl, flags,
-		 onack, &c->objver);
+		 onack, &c->objver, NULL, 0, &trace);
   objecter->op_submit(objecter_op, &c->tid);
   return 0;
 }

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -780,14 +780,17 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
   queue_aio_write(c);
 
   ZTracer::Trace trace;
-  if (trace_info)
+  if (trace_info) {
     trace.init("rados operate", &objecter->trace_endpoint, trace_info);
+    trace.event("rados operate init root span");
+  }
 
   Objecter::Op *op = objecter->prepare_mutate_op(
     oid, oloc, *o, snap_context, ut, flags, onack,
     oncommit, &c->objver, &trace);
   objecter->op_submit(op, &c->tid);
-
+  if (trace_info)
+    trace.event("rados operate op submitted");
   return 0;
 }
 

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -744,7 +744,7 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 					  AioCompletionImpl *c,
 					  int flags,
 					  bufferlist *pbl,
-            const blkin_trace_info *trace_info)
+                const blkin_trace_info *trace_info)
 {
   Context *onack = new C_aio_Ack(c);
 

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -18,6 +18,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/snap_types.h"
+#include "common/zipkin_trace.h"
 #include "include/atomic.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
@@ -188,14 +189,17 @@ struct librados::IoCtxImpl {
   };
 
   int aio_read(const object_t oid, AioCompletionImpl *c,
-	       bufferlist *pbl, size_t len, uint64_t off, uint64_t snapid);
+	       bufferlist *pbl, size_t len, uint64_t off, uint64_t snapid,
+	       const blkin_trace_info *info = nullptr);
   int aio_read(object_t oid, AioCompletionImpl *c,
-	       char *buf, size_t len, uint64_t off, uint64_t snapid);
+	       char *buf, size_t len, uint64_t off, uint64_t snapid,
+	       const blkin_trace_info *info = nullptr);
   int aio_sparse_read(const object_t oid, AioCompletionImpl *c,
 		      std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
 		      size_t len, uint64_t off, uint64_t snapid);
   int aio_write(const object_t &oid, AioCompletionImpl *c,
-		const bufferlist& bl, size_t len, uint64_t off);
+		const bufferlist& bl, size_t len, uint64_t off,
+		const blkin_trace_info *info = nullptr);
   int aio_append(const object_t &oid, AioCompletionImpl *c,
 		 const bufferlist& bl, size_t len);
   int aio_write_full(const object_t &oid, AioCompletionImpl *c,

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -156,7 +156,7 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags);
+		  int flags, const blkin_trace_info *trace_info = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl);
 

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -158,7 +158,8 @@ struct librados::IoCtxImpl {
 		  AioCompletionImpl *c, const SnapContext& snap_context,
 		  int flags, const blkin_trace_info *trace_info = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
-		       AioCompletionImpl *c, int flags, bufferlist *pbl);
+		       AioCompletionImpl *c, int flags, bufferlist *pbl,
+           const blkin_trace_info *trace_info = nullptr);
 
   struct C_aio_Ack : public Context {
     librados::AioCompletionImpl *c;

--- a/src/librados/Makefile.am
+++ b/src/librados/Makefile.am
@@ -25,6 +25,11 @@ LIBRADOS_DEPS += \
 	$(LIBOSDC) $(LIBCOMMON_DEPS)
 
 librados_la_LIBADD = $(LIBRADOS_DEPS) $(PTHREAD_LIBS) $(CRYPTO_LIBS) $(EXTRALIBS)
+
+if WITH_BLKIN
+librados_la_LIBADD += $(BLKIN_LIBS)
+endif
+
 librados_la_LDFLAGS = ${AM_LDFLAGS} -version-info 2:0:0
 if LINUX
 librados_la_CXXFLAGS += -fvisibility=hidden -fvisibility-inlines-hidden

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1515,11 +1515,11 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 librados::ObjectReadOperation *o,
-				 int flags, bufferlist *pbl)
+				 int flags, bufferlist *pbl, const blkin_trace_info *trace_info)
 {
   object_t obj(oid);
   return io_ctx_impl->aio_operate_read(obj, &o->impl->o, c->pc,
-				       translate_flags(flags), pbl);
+				       translate_flags(flags), pbl, trace_info);
 }
 
 

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1473,7 +1473,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 librados::ObjectWriteOperation *o,
-				 snap_t snap_seq, std::vector<snap_t>& snaps)
+				 snap_t snap_seq, std::vector<snap_t>& snaps, const blkin_trace_info *trace_info)
 {
   object_t obj(oid);
   vector<snapid_t> snv;
@@ -1482,7 +1482,7 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
     snv[i] = snaps[i];
   SnapContext snapc(snap_seq, snv);
   return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
-				  snapc, 0);
+				  snapc, 0, trace_info);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4359,11 +4359,10 @@ extern "C" int rados_aio_read(rados_ioctx_t io, const char *o,
   return retval;
 }
 
-#ifdef WITH_BLKIN
 extern "C" int rados_aio_read_traced(rados_ioctx_t io, const char *o,
-				     rados_completion_t completion,
-				     char *buf, size_t len, uint64_t off,
-				     struct blkin_trace_info *info)
+             rados_completion_t completion,
+             char *buf, size_t len, uint64_t off,
+             struct blkin_trace_info *info)
 {
   tracepoint(librados, rados_aio_read_enter, io, o, completion, len, off);
   librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
@@ -4373,7 +4372,6 @@ extern "C" int rados_aio_read_traced(rados_ioctx_t io, const char *o,
   tracepoint(librados, rados_aio_read_exit, retval);
   return retval;
 }
-#endif
 
 extern "C" int rados_aio_write(rados_ioctx_t io, const char *o,
 				rados_completion_t completion,
@@ -4392,7 +4390,6 @@ extern "C" int rados_aio_write(rados_ioctx_t io, const char *o,
   return retval;
 }
 
-#ifdef WITH_BLKIN
 extern "C" int rados_aio_write_traced(rados_ioctx_t io, const char *o,
                                       rados_completion_t completion,
                                       const char *buf, size_t len, uint64_t off,
@@ -4410,7 +4407,6 @@ extern "C" int rados_aio_write_traced(rados_ioctx_t io, const char *o,
   tracepoint(librados, rados_aio_write_exit, retval);
   return retval;
 }
-#endif
 
 extern "C" int rados_aio_append(rados_ioctx_t io, const char *o,
 				rados_completion_t completion,

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1472,6 +1472,20 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+         librados::ObjectWriteOperation *o,
+         snap_t snap_seq, std::vector<snap_t>& snaps)
+{
+  object_t obj(oid);
+  vector<snapid_t> snv;
+  snv.resize(snaps.size());
+  for (size_t i = 0; i < snaps.size(); ++i)
+    snv[i] = snaps[i];
+  SnapContext snapc(snap_seq, snv);
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
+          snapc, 0);
+}
+
+int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 librados::ObjectWriteOperation *o,
 				 snap_t snap_seq, std::vector<snap_t>& snaps, const blkin_trace_info *trace_info)
 {
@@ -1511,6 +1525,15 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
   return io_ctx_impl->aio_operate_read(obj, &o->impl->o, c->pc,
 				       op_flags, pbl);
+}
+
+int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+         librados::ObjectReadOperation *o,
+         int flags, bufferlist *pbl)
+{
+  object_t obj(oid);
+  return io_ctx_impl->aio_operate_read(obj, &o->impl->o, c->pc,
+               translate_flags(flags), pbl);
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -218,7 +218,7 @@ void AioImageRead<I>::send_request() {
 
   if (image_ctx.object_cacher && image_ctx.readahead_max_bytes > 0 &&
       !(m_op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
-    readahead(&m_image_ctx, m_image_extents, m_trace_info);
+    readahead(get_image_ctx(&image_ctx), m_image_extents, this->m_trace_info);
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;
@@ -274,15 +274,14 @@ void AioImageRead<I>::send_request() {
       AioObjectRead<I> *req = AioObjectRead<I>::create(
         &image_ctx, extent.oid.name, extent.objectno, extent.offset,
         extent.length, extent.buffer_extents, snap_id, true, req_comp,
-        m_op_flags);
-                                             true, req_comp, m_op_flags, m_trace_info);
+        m_op_flags, this->m_trace_info);
       req_comp->set_req(req);
 
       if (image_ctx.object_cacher) {
         C_CacheRead<I> *cache_comp = new C_CacheRead<I>(image_ctx, req);
         image_ctx.aio_read_from_cache(extent.oid, extent.objectno,
                                       &req->data(), extent.length,
-                                        extent.offset, cache_comp, m_op_flags, m_trace_info);
+                                      extent.offset, cache_comp, m_op_flags, this->m_trace_info);
       } else {
         req->send();
       }
@@ -432,7 +431,7 @@ void AioImageWrite<I>::send_cache_requests(const ObjectExtents &object_extents,
     C_AioRequest *req_comp = new C_AioRequest(aio_comp);
     image_ctx.write_to_cache(object_extent.oid, bl, object_extent.length,
                              object_extent.offset, req_comp, m_op_flags,
-                               journal_tid, m_trace_info);
+                               journal_tid, this->m_trace_info);
   }
 }
 

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -168,8 +168,8 @@ void AioImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
 template <typename I>
 void AioImageRequest<I>::aio_write(I *ictx, AioCompletion *c,
                                    uint64_t off, size_t len, const char *buf,
-                                   int op_flags) {
-  AioImageWrite<I> req(*ictx, c, off, len, buf, op_flags);
+                                   int op_flags, const blkin_trace_info *trace_info) {
+  AioImageWrite<I> req(*ictx, c, off, len, buf, op_flags, trace_info);
   req.send();
 }
 
@@ -429,7 +429,7 @@ void AioImageWrite<I>::send_cache_requests(const ObjectExtents &object_extents,
     C_AioRequest *req_comp = new C_AioRequest(aio_comp);
     image_ctx.write_to_cache(object_extent.oid, bl, object_extent.length,
                              object_extent.offset, req_comp, m_op_flags,
-                               journal_tid);
+                               journal_tid, m_trace_info);
   }
 }
 

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -72,9 +72,11 @@ template <typename ImageCtxT = ImageCtx>
 class AioImageRead : public AioImageRequest<ImageCtxT> {
 public:
   using typename AioImageRequest<ImageCtxT>::Extents;
+
+  AioImageRead(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
                size_t len, char *buf, bufferlist *pbl, int op_flags,
                const blkin_trace_info *trace_info = nullptr)
-    : AioImageRequest(image_ctx, aio_comp, trace_info), m_buf(buf), m_pbl(pbl),
+    : AioImageRequest<ImageCtxT>(image_ctx, aio_comp, trace_info), m_buf(buf), m_pbl(pbl),
       m_op_flags(op_flags) {
     m_image_extents.push_back(std::make_pair(off, len));
   }
@@ -124,7 +126,7 @@ protected:
   AbstractAioImageWrite(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                         uint64_t off, size_t len,
                         const blkin_trace_info *trace_info = nullptr)
-    : AioImageRequest(image_ctx, aio_comp, trace_info), m_off(off), m_len(len),
+    : AioImageRequest<ImageCtxT>(image_ctx, aio_comp, trace_info), m_off(off), m_len(len),
       m_synchronous(false) {
   }
 
@@ -159,7 +161,8 @@ public:
   AioImageWrite(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
                 size_t len, const char *buf, int op_flags,
                 const blkin_trace_info *trace_info = nullptr)
-    : AbstractAioImageWrite(image_ctx, aio_comp, off, len, trace_info), m_buf(buf),
+    : AbstractAioImageWrite<ImageCtxT>(image_ctx, aio_comp, off, len, trace_info),
+    m_buf(buf), m_op_flags(op_flags) {
   }
 
 protected:

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -29,9 +29,11 @@ public:
 
   static void aio_read(ImageCtxT *ictx, AioCompletion *c,
                        const std::vector<std::pair<uint64_t,uint64_t> > &extents,
-                       char *buf, bufferlist *pbl, int op_flags);
+                       char *buf, bufferlist *pbl, int op_flags,
+                       const blkin_trace_info *trace_info = nullptr);
   static void aio_read(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
-                       size_t len, char *buf, bufferlist *pbl, int op_flags);
+                       size_t len, char *buf, bufferlist *pbl, int op_flags,
+                       const blkin_trace_info *trace_info = nullptr);
   static void aio_write(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
                         size_t len, const char *buf, int op_flags,
                         const blkin_trace_info *trace_info = nullptr);
@@ -70,18 +72,17 @@ template <typename ImageCtxT = ImageCtx>
 class AioImageRead : public AioImageRequest<ImageCtxT> {
 public:
   using typename AioImageRequest<ImageCtxT>::Extents;
-
-  AioImageRead(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
-               size_t len, char *buf, bufferlist *pbl, int op_flags)
-    : AioImageRequest<ImageCtxT>(image_ctx, aio_comp), m_buf(buf), m_pbl(pbl),
+               size_t len, char *buf, bufferlist *pbl, int op_flags,
+               const blkin_trace_info *trace_info = nullptr)
+    : AioImageRequest(image_ctx, aio_comp, trace_info), m_buf(buf), m_pbl(pbl),
       m_op_flags(op_flags) {
     m_image_extents.push_back(std::make_pair(off, len));
   }
 
   AioImageRead(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                const Extents &image_extents, char *buf, bufferlist *pbl,
-               int op_flags)
-    : AioImageRequest<ImageCtxT>(image_ctx, aio_comp),
+               int op_flags, const blkin_trace_info *trace_info = nullptr)
+    : AioImageRequest<ImageCtxT>(image_ctx, aio_comp, trace_info),
       m_image_extents(image_extents), m_buf(buf), m_pbl(pbl),
       m_op_flags(op_flags) {
   }

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -145,7 +145,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish) = 0;
+      Context *on_finish, const blkin_trace_info *trace_info = nullptr) = 0;
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous) = 0;
@@ -186,7 +186,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish);
+      Context *on_finish, const blkin_trace_info *trace_info = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);
@@ -222,7 +222,7 @@ protected:
 
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish);
+      Context *on_finish, const blkin_trace_info *trace_info = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -57,11 +57,15 @@ protected:
 
   ImageCtxT &m_image_ctx;
   AioCompletion *m_aio_comp;
-  const blkin_trace_info *m_trace_info;
+  ZTracer::Endpoint trace_endpoint;
+  ZTracer::Trace trace;
 
   AioImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
     const blkin_trace_info *trace_info = nullptr)
-    : m_image_ctx(image_ctx), m_aio_comp(aio_comp), m_trace_info(trace_info) {}
+    : m_image_ctx(image_ctx), m_aio_comp(aio_comp), trace_endpoint("AioImageRequest") {
+      if (trace_info)
+        trace.init("aioimgreq", &trace_endpoint, trace_info);
+    }
 
   virtual void send_request() = 0;
   virtual aio_type_t get_aio_type() const = 0;
@@ -145,7 +149,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish, const blkin_trace_info *trace_info = nullptr) = 0;
+      Context *on_finish, ZTracer::Trace *trace = nullptr) = 0;
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous) = 0;
@@ -186,7 +190,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish, const blkin_trace_info *trace_info = nullptr);
+      Context *on_finish, ZTracer::Trace *trace = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);
@@ -222,7 +226,7 @@ protected:
 
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish, const blkin_trace_info *trace_info = nullptr);
+      Context *on_finish, ZTracer::Trace *trace = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -93,7 +93,7 @@ int AioImageRequestWQ::discard(uint64_t off, uint64_t len) {
 
 void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
                                  char *buf, bufferlist *pbl, int op_flags,
-                                 bool native_async) {
+                                 bool native_async, const blkin_trace_info *trace_info) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_READ);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_read: ictx=" << &m_image_ctx << ", "
@@ -120,10 +120,10 @@ void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
 
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty() ||
       lock_required) {
-    queue(new AioImageRead<>(m_image_ctx, c, off, len, buf, pbl, op_flags));
+    queue(new AioImageRead(m_image_ctx, c, off, len, buf, pbl, op_flags, trace_info));
   } else {
     c->start_op();
-    AioImageRequest<>::aio_read(&m_image_ctx, c, off, len, buf, pbl, op_flags);
+    AioImageRequest<>::aio_read(&m_image_ctx, c, off, len, buf, pbl, op_flags, trace_info);
     finish_in_flight_op();
   }
 }

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -120,7 +120,7 @@ void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
 
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty() ||
       lock_required) {
-    queue(new AioImageRead(m_image_ctx, c, off, len, buf, pbl, op_flags, trace_info));
+    queue(new AioImageRead<>(m_image_ctx, c, off, len, buf, pbl, op_flags, trace_info));
   } else {
     c->start_op();
     AioImageRequest<>::aio_read(&m_image_ctx, c, off, len, buf, pbl, op_flags, trace_info);
@@ -147,7 +147,7 @@ void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(new AioImageWrite(m_image_ctx, c, off, len, buf, op_flags, trace_info));
+    queue(new AioImageWrite<>(m_image_ctx, c, off, len, buf, op_flags, trace_info));
   } else {
     c->start_op();
     AioImageRequest<>::aio_write(&m_image_ctx, c, off, len, buf, op_flags, trace_info);

--- a/src/librbd/AioImageRequestWQ.h
+++ b/src/librbd/AioImageRequestWQ.h
@@ -27,7 +27,8 @@ public:
   int discard(uint64_t off, uint64_t len);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len, char *buf,
-                bufferlist *pbl, int op_flags, bool native_async=true);
+                bufferlist *pbl, int op_flags, bool native_async=true,
+                const blkin_trace_info *trace_info = nullptr);
   void aio_write(AioCompletion *c, uint64_t off, uint64_t len, const char *buf,
                  int op_flags, bool native_async=true,
                  const blkin_trace_info *trace_info = nullptr);

--- a/src/librbd/AioImageRequestWQ.h
+++ b/src/librbd/AioImageRequestWQ.h
@@ -8,6 +8,7 @@
 #include "include/atomic.h"
 #include "common/RWLock.h"
 #include "common/WorkQueue.h"
+#include "common/zipkin_trace.h"
 #include <list>
 
 namespace librbd {
@@ -28,7 +29,8 @@ public:
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len, char *buf,
                 bufferlist *pbl, int op_flags, bool native_async=true);
   void aio_write(AioCompletion *c, uint64_t off, uint64_t len, const char *buf,
-                 int op_flags, bool native_async=true);
+                 int op_flags, bool native_async=true,
+                 const blkin_trace_info *trace_info = nullptr);
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
                    bool native_async=true);
   void aio_flush(AioCompletion *c, bool native_async=true);

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -570,7 +570,7 @@ void AbstractAioObjectWrite::send_write_op(bool write_guard)
   librados::AioCompletion *rados_completion =
     util::create_rados_safe_callback(this);
   int r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
-                                       m_snap_seq, m_snaps);
+					 m_snap_seq, m_snaps, m_trace_info);
   assert(r == 0);
   rados_completion->release();
 }

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -145,9 +145,9 @@ AioObjectRead<I>::AioObjectRead(I *ictx, const std::string &oid,
                                 uint64_t len,
                                 vector<pair<uint64_t,uint64_t> >& be,
                                 librados::snap_t snap_id, bool sparse,
-                                Context *completion, int op_flags)
+                               Context *completion, int op_flags,
   : AioObjectRequest<I>(util::get_image_ctx(ictx), oid, objectno, offset, len,
-                        snap_id, completion, false),
+                        snap_id, completion, false, trace_info),
     m_buffer_extents(be), m_tried_parent(false), m_sparse(sparse),
     m_op_flags(op_flags), m_parent_completion(NULL),
     m_state(LIBRBD_AIO_READ_FLAT) {
@@ -291,7 +291,7 @@ void AioObjectRead<I>::send() {
   librados::AioCompletion *rados_completion =
     util::create_rados_ack_callback(this);
   int r = image_ctx->data_ctx.aio_operate(this->m_oid, rados_completion, &op,
-                                          flags, nullptr);
+                                        flags, nullptr, m_trace_info);
   assert(r == 0);
 
   rados_completion->release();

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -292,7 +292,7 @@ void AioObjectRead<I>::send() {
   librados::AioCompletion *rados_completion =
     util::create_rados_ack_callback(this);
   int r = image_ctx->data_ctx.aio_operate(this->m_oid, rados_completion, &op,
-                                        flags, nullptr, this->m_trace_info);
+                                        flags, nullptr);
   assert(r == 0);
 
   rados_completion->release();
@@ -570,8 +570,13 @@ void AbstractAioObjectWrite::send_write_op(bool write_guard)
 
   librados::AioCompletion *rados_completion =
     util::create_rados_safe_callback(this);
-  int r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
+  int r;
+  if (m_trace_info)
+    r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
 					 m_snap_seq, m_snaps, m_trace_info);
+  else
+    r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
+           m_snap_seq, m_snaps);
   assert(r == 0);
   rados_completion->release();
 }

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -73,10 +73,11 @@ template <typename I>
 AioObjectRequest<I>::AioObjectRequest(ImageCtx *ictx, const std::string &oid,
                                       uint64_t objectno, uint64_t off,
                                       uint64_t len, librados::snap_t snap_id,
-                                      Context *completion, bool hide_enoent)
+                                     Context *completion, bool hide_enoent,
+                                     const blkin_trace_info *trace_info)
   : m_ictx(ictx), m_oid(oid), m_object_no(objectno), m_object_off(off),
     m_object_len(len), m_snap_id(snap_id), m_completion(completion),
-    m_hide_enoent(hide_enoent) {
+      m_hide_enoent(hide_enoent), m_trace_info(trace_info) {
 
   Striper::extent_to_file(m_ictx->cct, &m_ictx->layout, m_object_no,
                           0, m_ictx->layout.object_size, m_parent_extents);
@@ -355,9 +356,10 @@ AbstractAioObjectWrite::AbstractAioObjectWrite(ImageCtx *ictx,
                                                uint64_t len,
                                                const ::SnapContext &snapc,
                                                Context *completion,
-                                               bool hide_enoent)
+                                                 bool hide_enoent,
+                                                 const blkin_trace_info *trace_info)
   : AioObjectRequest(ictx, oid, object_no, object_off, len, CEPH_NOSNAP,
-                     completion, hide_enoent),
+                       completion, hide_enoent, trace_info),
     m_state(LIBRBD_AIO_WRITE_FLAT), m_snap_seq(snapc.seq.val)
 {
   m_snaps.insert(m_snaps.end(), snapc.snaps.begin(), snapc.snaps.end());

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -53,9 +53,10 @@ AioObjectRequest<I>::create_write(I *ictx, const std::string &oid,
                                   uint64_t object_no, uint64_t object_off,
                                   const ceph::bufferlist &data,
                                   const ::SnapContext &snapc,
-                                  Context *completion, int op_flags) {
+                                  Context *completion, int op_flags,
+                                  const blkin_trace_info *trace_info) {
   return new AioObjectWrite(util::get_image_ctx(ictx), oid, object_no,
-                            object_off, data, snapc, completion, op_flags);
+                            object_off, data, snapc, completion, op_flags, trace_info);
 }
 
 template <typename I>
@@ -78,7 +79,6 @@ AioObjectRequest<I>::AioObjectRequest(ImageCtx *ictx, const std::string &oid,
   : m_ictx(ictx), m_oid(oid), m_object_no(objectno), m_object_off(off),
     m_object_len(len), m_snap_id(snap_id), m_completion(completion),
     m_hide_enoent(hide_enoent), m_trace_info(trace_info) {
-
   Striper::extent_to_file(m_ictx->cct, &m_ictx->layout, m_object_no,
                           0, m_ictx->layout.object_size, m_parent_extents);
 

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -110,13 +110,14 @@ public:
                                librados::snap_t snap_id, bool sparse,
                                Context *completion, int op_flags) {
     return new AioObjectRead(ictx, oid, objectno, offset, len, buffer_extents,
-                             snap_id, sparse, completion, op_flags);
+                                                       snap_id, sparse, completion, op_flags);
   }
 
   AioObjectRead(ImageCtxT *ictx, const std::string &oid,
                 uint64_t objectno, uint64_t offset, uint64_t len,
                 Extents& buffer_extents, librados::snap_t snap_id, bool sparse,
-                Context *completion, int op_flags);
+                Context *completion, int op_flags,
+                const blkin_trace_info *trace_info = nullptr);
 
   virtual bool should_complete(int r);
   virtual void send();

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -61,7 +61,7 @@ public:
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
                                         Context *completion, int op_flags,
-                                        const blkin_trace_info *trace_info = nullptr);
+                                        ZTracer::Trace *trace = nullptr);
   static AioObjectRequest* create_zero(ImageCtxT *ictx, const std::string &oid,
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,
@@ -72,7 +72,7 @@ public:
                    uint64_t objectno, uint64_t off, uint64_t len,
                    librados::snap_t snap_id,
                      Context *completion, bool hide_enoent,
-                     const blkin_trace_info *trace_info = nullptr);
+                     ZTracer::Trace *trace = nullptr);
   virtual ~AioObjectRequest() {}
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr) {};
@@ -96,7 +96,7 @@ protected:
   Context *m_completion;
   Extents m_parent_extents;
   bool m_hide_enoent;
-  const blkin_trace_info *m_trace_info;
+  ZTracer::Trace *m_trace;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -110,16 +110,16 @@ public:
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
                                Context *completion, int op_flags,
-                               const blkin_trace_info *trace_info = nullptr) {
+                               ZTracer::Trace *trace = nullptr) {
     return new AioObjectRead(ictx, oid, objectno, offset, len, buffer_extents,
-                              snap_id, sparse, completion, op_flags, trace_info);
+                              snap_id, sparse, completion, op_flags, trace);
   }
 
   AioObjectRead(ImageCtxT *ictx, const std::string &oid,
                 uint64_t objectno, uint64_t offset, uint64_t len,
                 Extents& buffer_extents, librados::snap_t snap_id, bool sparse,
                 Context *completion, int op_flags,
-                const blkin_trace_info *trace_info = nullptr);
+                ZTracer::Trace *trace = nullptr);
 
   virtual bool should_complete(int r);
   virtual void send();
@@ -184,7 +184,7 @@ public:
                          uint64_t object_no, uint64_t object_off,
                          uint64_t len, const ::SnapContext &snapc,
                          Context *completion, bool hide_enoent,
-                         const blkin_trace_info *trace_info = nullptr);
+                         ZTracer::Trace *trace = nullptr);
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr)
   {
@@ -266,9 +266,9 @@ public:
   AioObjectWrite(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                  uint64_t object_off, const ceph::bufferlist &data,
                  const ::SnapContext &snapc, Context *completion,
-                 int op_flags, const blkin_trace_info *trace_info =  nullptr)
+                 int op_flags, ZTracer::Trace *trace =  nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, data.length(),
-                             snapc, completion, false, trace_info),
+                             snapc, completion, false, trace),
       m_write_data(data), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "common/snap_types.h"
+#include "common/zipkin_trace.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
 #include "librbd/ObjectMap.h"
@@ -69,7 +70,8 @@ public:
   AioObjectRequest(ImageCtx *ictx, const std::string &oid,
                    uint64_t objectno, uint64_t off, uint64_t len,
                    librados::snap_t snap_id,
-                   Context *completion, bool hide_enoent);
+                     Context *completion, bool hide_enoent,
+                     const blkin_trace_info *trace_info = nullptr);
   virtual ~AioObjectRequest() {}
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr) {};
@@ -93,6 +95,7 @@ protected:
   Context *m_completion;
   Extents m_parent_extents;
   bool m_hide_enoent;
+    const blkin_trace_info *m_trace_info;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -177,7 +180,8 @@ public:
   AbstractAioObjectWrite(ImageCtx *ictx, const std::string &oid,
                          uint64_t object_no, uint64_t object_off,
                          uint64_t len, const ::SnapContext &snapc,
-                         Context *completion, bool hide_enoent);
+                           Context *completion, bool hide_enoent,
+                           const blkin_trace_info *trace_info = nullptr);
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr)
   {
@@ -259,9 +263,9 @@ public:
   AioObjectWrite(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                  uint64_t object_off, const ceph::bufferlist &data,
                  const ::SnapContext &snapc, Context *completion,
-                 int op_flags)
+                 int op_flags, const blkin_trace_info *trace_info =  nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, data.length(),
-                             snapc, completion, false),
+                               snapc, completion, false, trace_info),
       m_write_data(data), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -95,7 +95,7 @@ protected:
   Context *m_completion;
   Extents m_parent_extents;
   bool m_hide_enoent;
-    const blkin_trace_info *m_trace_info;
+  const blkin_trace_info *m_trace_info;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -108,9 +108,10 @@ public:
                                uint64_t objectno, uint64_t offset,
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
-                               Context *completion, int op_flags) {
+                               Context *completion, int op_flags,
+                               const blkin_trace_info *trace_info = nullptr) {
     return new AioObjectRead(ictx, oid, objectno, offset, len, buffer_extents,
-                                                       snap_id, sparse, completion, op_flags);
+                              snap_id, sparse, completion, op_flags, trace_info);
   }
 
   AioObjectRead(ImageCtxT *ictx, const std::string &oid,
@@ -181,8 +182,8 @@ public:
   AbstractAioObjectWrite(ImageCtx *ictx, const std::string &oid,
                          uint64_t object_no, uint64_t object_off,
                          uint64_t len, const ::SnapContext &snapc,
-                           Context *completion, bool hide_enoent,
-                           const blkin_trace_info *trace_info = nullptr);
+                         Context *completion, bool hide_enoent,
+                         const blkin_trace_info *trace_info = nullptr);
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr)
   {
@@ -266,7 +267,7 @@ public:
                  const ::SnapContext &snapc, Context *completion,
                  int op_flags, const blkin_trace_info *trace_info =  nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, data.length(),
-                               snapc, completion, false, trace_info),
+                             snapc, completion, false, trace_info),
       m_write_data(data), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -60,7 +60,8 @@ public:
                                         uint64_t object_off,
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
-                                        Context *completion, int op_flags);
+                                        Context *completion, int op_flags,
+                                        const blkin_trace_info *trace_info = nullptr);
   static AioObjectRequest* create_zero(ImageCtxT *ictx, const std::string &oid,
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -666,7 +666,7 @@ struct C_InvalidateCache : public Context {
   void ImageCtx::aio_read_from_cache(object_t o, uint64_t object_no,
 				     bufferlist *bl, size_t len,
 				     uint64_t off, Context *onfinish,
-				     int fadvise_flags) {
+				     int fadvise_flags, const blkin_trace_info *trace_info) {
     snap_lock.get_read();
     ObjectCacher::OSDRead *rd = object_cacher->prepare_read(snap_id, bl, fadvise_flags);
     snap_lock.put_read();
@@ -675,7 +675,7 @@ struct C_InvalidateCache : public Context {
     extent.buffer_extents.push_back(make_pair(0, len));
     rd->extents.push_back(extent);
     cache_lock.Lock();
-    int r = object_cacher->readx(rd, object_set, onfinish);
+    int r = object_cacher->readx(rd, object_set, onfinish, trace_info);
     cache_lock.Unlock();
     if (r != 0)
       onfinish->complete(r);

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -683,7 +683,7 @@ struct C_InvalidateCache : public Context {
 
   void ImageCtx::write_to_cache(object_t o, const bufferlist& bl, size_t len,
 				uint64_t off, Context *onfinish,
-				int fadvise_flags, uint64_t journal_tid) {
+				int fadvise_flags, uint64_t journal_tid, const blkin_trace_info *trace_info) {
     snap_lock.get_read();
     ObjectCacher::OSDWrite *wr = object_cacher->prepare_write(
       snapc, bl, ceph::real_time::min(), fadvise_flags, journal_tid);
@@ -696,7 +696,7 @@ struct C_InvalidateCache : public Context {
     wr->extents.push_back(extent);
     {
       Mutex::Locker l(cache_lock);
-      object_cacher->writex(wr, object_set, onfinish);
+      object_cacher->writex(wr, object_set, onfinish, trace_info);
     }
   }
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -259,7 +259,7 @@ namespace librbd {
 			   uint64_t *overlap) const;
     void aio_read_from_cache(object_t o, uint64_t object_no, bufferlist *bl,
 			     size_t len, uint64_t off, Context *onfinish,
-			     int fadvise_flags);
+			     int fadvise_flags, const blkin_trace_info *trace_info = nullptr);
     void write_to_cache(object_t o, const bufferlist& bl, size_t len,
 			uint64_t off, Context *onfinish, int fadvise_flags,
                         uint64_t journal_tid, const blkin_trace_info *trace_info = nullptr);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -259,10 +259,10 @@ namespace librbd {
 			   uint64_t *overlap) const;
     void aio_read_from_cache(object_t o, uint64_t object_no, bufferlist *bl,
 			     size_t len, uint64_t off, Context *onfinish,
-			     int fadvise_flags, const blkin_trace_info *trace_info = nullptr);
+			     int fadvise_flags, ZTracer::Trace *trace = nullptr);
     void write_to_cache(object_t o, const bufferlist& bl, size_t len,
 			uint64_t off, Context *onfinish, int fadvise_flags,
-                        uint64_t journal_tid, const blkin_trace_info *trace_info = nullptr);
+                        uint64_t journal_tid, ZTracer::Trace *trace = nullptr);
     void user_flushed();
     void flush_cache(Context *onfinish);
     void shut_down_cache(Context *on_finish);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -15,7 +15,7 @@
 #include "common/Readahead.h"
 #include "common/RWLock.h"
 #include "common/snap_types.h"
-
+#include "common/zipkin_trace.h"
 #include "include/buffer_fwd.h"
 #include "include/rbd/librbd.hpp"
 #include "include/rbd_types.h"
@@ -262,7 +262,7 @@ namespace librbd {
 			     int fadvise_flags);
     void write_to_cache(object_t o, const bufferlist& bl, size_t len,
 			uint64_t off, Context *onfinish, int fadvise_flags,
-                        uint64_t journal_tid);
+                        uint64_t journal_tid, const blkin_trace_info *trace_info = nullptr);
     void user_flushed();
     void flush_cache(Context *onfinish);
     void shut_down_cache(Context *on_finish);

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -196,7 +196,8 @@ namespace librbd {
 			     const object_locator_t& oloc,
 			     uint64_t off, uint64_t len, snapid_t snapid,
 			     bufferlist *pbl, uint64_t trunc_size,
-			     __u32 trunc_seq, int op_flags, Context *onfinish)
+			     __u32 trunc_seq, int op_flags, Context *onfinish,
+           const blkin_trace_info *trace_info)
   {
     // on completion, take the mutex and then call onfinish.
     Context *req = new C_ReadRequest(m_ictx->cct, onfinish, &m_ictx->owner_lock,
@@ -219,7 +220,7 @@ namespace librbd {
     librados::AioCompletion *rados_completion =
       util::create_rados_ack_callback(req);
     int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
-					 flags, NULL);
+					 flags, NULL, trace_info);
     rados_completion->release();
     assert(r >= 0);
   }

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -255,7 +255,7 @@ namespace librbd {
 				    const bufferlist &bl,
 				    ceph::real_time mtime, uint64_t trunc_size,
 				    __u32 trunc_seq, ceph_tid_t journal_tid,
-				    Context *oncommit)
+				    Context *oncommit, const blkin_trace_info *trace_info)
   {
     assert(m_ictx->owner_lock.is_locked());
     uint64_t object_no = oid_to_object_no(oid.name, m_ictx->object_prefix);
@@ -274,7 +274,7 @@ namespace librbd {
 					      journal_tid));
     } else {
       AioObjectWrite *req = new AioObjectWrite(m_ictx, oid.name, object_no,
-					       off, bl, snapc, req_comp, 0);
+					       off, bl, snapc, req_comp, 0, trace_info);
       req->send();
     }
     return ++m_tid;

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -219,8 +219,13 @@ namespace librbd {
 
     librados::AioCompletion *rados_completion =
       util::create_rados_ack_callback(req);
-    int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
+    int r;
+    if (trace_info)
+      r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
 					 flags, NULL, trace_info);
+    else
+      r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
+           flags, NULL);
     rados_completion->release();
     assert(r >= 0);
   }

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -197,7 +197,7 @@ namespace librbd {
 			     uint64_t off, uint64_t len, snapid_t snapid,
 			     bufferlist *pbl, uint64_t trunc_size,
 			     __u32 trunc_seq, int op_flags, Context *onfinish,
-           const blkin_trace_info *trace_info)
+           ZTracer::Trace *trace)
   {
     // on completion, take the mutex and then call onfinish.
     Context *req = new C_ReadRequest(m_ictx->cct, onfinish, &m_ictx->owner_lock,
@@ -220,9 +220,9 @@ namespace librbd {
     librados::AioCompletion *rados_completion =
       util::create_rados_ack_callback(req);
     int r;
-    if (trace_info)
+    if (trace)
       r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
-					 flags, NULL, trace_info);
+					 flags, NULL, trace->get_info());
     else
       r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
            flags, NULL);
@@ -261,7 +261,7 @@ namespace librbd {
 				    const bufferlist &bl,
 				    ceph::real_time mtime, uint64_t trunc_size,
 				    __u32 trunc_seq, ceph_tid_t journal_tid,
-				    Context *oncommit, const blkin_trace_info *trace_info)
+				    Context *oncommit, ZTracer::Trace *trace)
   {
     assert(m_ictx->owner_lock.is_locked());
     uint64_t object_no = oid_to_object_no(oid.name, m_ictx->object_prefix);
@@ -280,7 +280,7 @@ namespace librbd {
 					      journal_tid));
     } else {
       AioObjectWrite *req = new AioObjectWrite(m_ictx, oid.name, object_no,
-					       off, bl, snapc, req_comp, 0, trace_info);
+					       off, bl, snapc, req_comp, 0, trace);
       req->send();
     }
     return ++m_tid;

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -24,7 +24,8 @@ namespace librbd {
     virtual void read(const object_t& oid, uint64_t object_no,
 		      const object_locator_t& oloc, uint64_t off, uint64_t len,
 		      snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		      __u32 trunc_seq, int op_flags, Context *onfinish);
+		      __u32 trunc_seq, int op_flags, Context *onfinish,
+          const blkin_trace_info *trace_info = nullptr);
 
     // Determine whether a read to this extent could be affected by a
     // write-triggered copy-on-write

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -25,7 +25,7 @@ namespace librbd {
 		      const object_locator_t& oloc, uint64_t off, uint64_t len,
 		      snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		      __u32 trunc_seq, int op_flags, Context *onfinish,
-          const blkin_trace_info *trace_info = nullptr);
+          ZTracer::Trace *trace = nullptr);
 
     // Determine whether a read to this extent could be affected by a
     // write-triggered copy-on-write
@@ -38,7 +38,7 @@ namespace librbd {
 			     const SnapContext& snapc, const bufferlist &bl,
 			     ceph::real_time mtime, uint64_t trunc_size,
 			     __u32 trunc_seq, ceph_tid_t journal_tid,
-			     Context *oncommit, const blkin_trace_info *trace_info = nullptr);
+			     Context *oncommit, ZTracer::Trace *trace = nullptr);
     using WritebackHandler::write;
 
     virtual void overwrite_extent(const object_t& oid, uint64_t off,

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -37,7 +37,7 @@ namespace librbd {
 			     const SnapContext& snapc, const bufferlist &bl,
 			     ceph::real_time mtime, uint64_t trunc_size,
 			     __u32 trunc_seq, ceph_tid_t journal_tid,
-			     Context *oncommit);
+			     Context *oncommit, const blkin_trace_info *trace_info = nullptr);
     using WritebackHandler::write;
 
     virtual void overwrite_extent(const object_t& oid, uint64_t off,

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -84,6 +84,10 @@ librbd_la_LIBADD = \
 	libcls_journal_client.la \
 	$(PTHREAD_LIBS) $(EXTRALIBS)
 
+if WITH_BLKIN
+librbd_la_LIBADD += $(BLKIN_LIBS)
+endif
+
 librbd_la_LDFLAGS = ${AM_LDFLAGS} -version-info 1:0:0
 if LINUX
 librbd_la_CXXFLAGS = -fvisibility=hidden -fvisibility-inlines-hidden

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3841,7 +3841,8 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   };
 
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents)
+                 const vector<pair<uint64_t,uint64_t> >& image_extents,
+                 const struct blkin_trace_info *trace_info)
   {
     uint64_t total_bytes = 0;
     for (vector<pair<uint64_t,uint64_t> >::const_iterator p = image_extents.begin();
@@ -3880,7 +3881,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 	  ictx->readahead.inc_pending();
 	  ictx->aio_read_from_cache(q->oid, q->objectno, NULL,
 				    q->length, q->offset,
-				    req_comp, 0);
+				    req_comp, 0, trace_info);
 	}
       }
       ictx->perfcounter->inc(l_librbd_readahead);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3842,7 +3842,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 
   void readahead(ImageCtx *ictx,
                  const vector<pair<uint64_t,uint64_t> >& image_extents,
-                 const struct blkin_trace_info *trace_info)
+                 ZTracer::Trace *trace)
   {
     uint64_t total_bytes = 0;
     for (vector<pair<uint64_t,uint64_t> >::const_iterator p = image_extents.begin();
@@ -3881,7 +3881,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 	  ictx->readahead.inc_pending();
 	  ictx->aio_read_from_cache(q->oid, q->objectno, NULL,
 				    q->length, q->offset,
-				    req_comp, 0, trace_info);
+				    req_comp, 0, trace);
 	}
       }
       ictx->perfcounter->inc(l_librbd_readahead);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -186,7 +186,8 @@ namespace librbd {
 		   int (*cb)(uint64_t, size_t, int, void *),
 		   void *arg);
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents);
+                 const vector<pair<uint64_t,uint64_t> >& image_extents,
+                 const struct blkin_trace_info *trace_info = nullptr);
 
   int flush(ImageCtx *ictx);
   int invalidate_cache(ImageCtx *ictx);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -9,7 +9,7 @@
 #include <set>
 #include <string>
 #include <vector>
-
+#include "common/zipkin_trace.h"
 #include "include/buffer_fwd.h"
 #include "include/rbd/librbd.hpp"
 #include "include/rbd_types.h"
@@ -187,7 +187,7 @@ namespace librbd {
 		   void *arg);
   void readahead(ImageCtx *ictx,
                  const vector<pair<uint64_t,uint64_t> >& image_extents,
-                 const struct blkin_trace_info *trace_info = nullptr);
+                 ZTracer::Trace *trace = nullptr);
 
   int flush(ImageCtx *ictx);
   int invalidate_cache(ImageCtx *ictx);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2730,6 +2730,18 @@ extern "C" int rbd_aio_read2(rbd_image_t image, uint64_t off, size_t len,
   return 0;
 }
 
+extern "C" int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
+          char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
+  ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
+                                 0, true, trace_info);
+  tracepoint(librbd, aio_read_exit, 0);
+  return 0;
+}
+
 extern "C" int rbd_flush(rbd_image_t image)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2683,6 +2683,16 @@ extern "C" int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
   return 0;
 }
 
+extern "C" int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
+           const char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_write_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
+  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, true, trace_info);
+  tracepoint(librbd, aio_write_exit, 0);
+  return 0;
+}
 
 extern "C" int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
 			       rbd_completion_t c)

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpRead : public Message {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 3) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload, features);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpRead"; }

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpReadReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpReadReply"; }

--- a/src/messages/MOSDECSubOpWrite.h
+++ b/src/messages/MOSDECSubOpWrite.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpWrite : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -45,12 +45,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpWrite"; }

--- a/src/messages/MOSDECSubOpWriteReply.h
+++ b/src/messages/MOSDECSubOpWriteReply.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpWriteReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpWriteReply"; }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -33,7 +33,7 @@ class OSD;
 
 class MOSDOp : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 3;
 
 private:
@@ -349,6 +349,8 @@ struct ceph_osd_request_head {
 
       ::encode(retry_attempt, payload);
       ::encode(features, payload);
+
+      encode_trace(payload, features);
     }
   }
 
@@ -494,6 +496,10 @@ struct ceph_osd_request_head {
     ::decode(retry_attempt, p);
 
     ::decode(features, p);
+
+    if (header.version >= 8) {
+      decode_trace(p);
+    }
 
     OSDOp::split_osd_op_vector_in_data(ops, data);
 

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -32,7 +32,7 @@
 
 class MOSDOpReply : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 2;
 
   object_t oid;
@@ -203,6 +203,7 @@ public:
           ::encode(redirect, payload);
         }
       }
+      encode_trace(payload, features);
     }
   }
   virtual void decode_payload() {
@@ -292,6 +293,9 @@ public:
         if (do_redirect) {
 	  ::decode(redirect, p);
         }
+      }
+      if (header.version >= 8) {
+        decode_trace(p);
       }
     }
   }

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -25,7 +25,7 @@
 
 class MOSDRepOp : public Message {
 
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -95,6 +95,9 @@ public:
     ::decode(updated_hit_set_history, p);
     ::decode(pg_trim_rollback_to, p);
     final_decode_needed = false;
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
@@ -113,6 +116,7 @@ public:
     ::encode(from, payload);
     ::encode(updated_hit_set_history, payload);
     ::encode(pg_trim_rollback_to, payload);
+    encode_trace(payload, features);
   }
 
   MOSDRepOp()

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -29,7 +29,7 @@
  */
 
 class MOSDRepOpReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 public:
   epoch_t map_epoch;
@@ -66,6 +66,9 @@ public:
 
     ::decode(from, p);
     final_decode_needed = false;
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
   virtual void encode_payload(uint64_t features) {
     ::encode(map_epoch, payload);
@@ -75,6 +78,7 @@ public:
     ::encode(result, payload);
     ::encode(last_complete_ondisk, payload);
     ::encode(from, payload);
+    encode_trace(payload, features);
   }
 
   epoch_t get_map_epoch() { return map_epoch; }

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -27,7 +27,7 @@
 
 class MOSDSubOp : public Message {
 
-  static const int HEAD_VERSION = 12;
+  static const int HEAD_VERSION = 13;
   static const int COMPAT_VERSION = 7;
 
 public:
@@ -176,6 +176,9 @@ public:
     } else {
       pg_trim_rollback_to = pg_trim_to;
     }
+    if (header.version >= 13) {
+      decode_trace(p);
+    }
   }
 
   void finish_decode() { }
@@ -235,6 +238,7 @@ public:
     ::encode(pgid.shard, payload);
     ::encode(updated_hit_set_history, payload);
     ::encode(pg_trim_rollback_to, payload);
+    encode_trace(payload, features);
   }
 
   MOSDSubOp()

--- a/src/messages/MOSDSubOpReply.h
+++ b/src/messages/MOSDSubOpReply.h
@@ -30,7 +30,7 @@
  */
 
 class MOSDSubOpReply : public Message {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 public:
   epoch_t map_epoch;
@@ -84,6 +84,9 @@ public:
 	shard_id_t::NO_SHARD);
       pgid.shard = shard_id_t::NO_SHARD;
     }
+    if (header.version >= 3) {
+      decode_trace(p);
+    }
   }
 
   void finish_decode() { }
@@ -105,6 +108,7 @@ public:
     ::encode(attrset, payload);
     ::encode(from, payload);
     ::encode(pgid.shard, payload);
+    encode_trace(payload, features);
   }
 
   epoch_t get_map_epoch() { return map_epoch; }

--- a/src/msg/Makefile.am
+++ b/src/msg/Makefile.am
@@ -4,6 +4,10 @@ libmsg_la_SOURCES = \
 	msg/DispatchQueue.cc \
 	msg/msg_types.cc
 
+if WITH_BLKIN
+libmsg_la_LIBADD = $(BLKIN_LIBS)
+endif
+
 noinst_HEADERS += \
 	msg/Connection.h \
 	msg/Dispatcher.h \

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -258,7 +258,7 @@ Message *decode_message(CephContext *cct, int crcflags,
 			ceph_msg_header& header,
 			ceph_msg_footer& footer,
 			bufferlist& front, bufferlist& middle,
-			bufferlist& data)
+			bufferlist& data, Connection* conn)
 {
   // verify crc
   if (crcflags & MSG_CRC_HEADER) {
@@ -752,6 +752,7 @@ Message *decode_message(CephContext *cct, int crcflags,
     return 0;
   }
 
+  m->set_connection(conn);
   m->set_header(header);
   m->set_footer(footer);
   m->set_payload(front);
@@ -830,6 +831,6 @@ Message *decode_message(CephContext *cct, int crcflags, bufferlist::iterator& p)
   ::decode(fr, p);
   ::decode(mi, p);
   ::decode(da, p);
-  return decode_message(cct, crcflags, h, f, fr, mi, da);
+  return decode_message(cct, crcflags, h, f, fr, mi, da, nullptr);
 }
 

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -782,6 +782,43 @@ Message *decode_message(CephContext *cct, int crcflags,
 }
 
 
+WRITE_RAW_ENCODER(blkin_trace_info)
+
+void Message::encode_trace(bufferlist &bl, uint64_t features) const
+{
+#ifdef WITH_BLKIN
+  if (features & CEPH_FEATURE_BLKIN_TRACING)
+    ::encode(*trace.get_info(), bl);
+#endif
+}
+
+void Message::decode_trace(bufferlist::iterator &p, bool create)
+{
+#ifdef WITH_BLKIN
+  if (!connection)
+    return;
+
+  const auto endpoint = connection->get_messenger()->get_trace_endpoint();
+  blkin_trace_info info = {};
+
+  // only decode a trace if both sides of the connection agree
+  if (connection->has_feature(CEPH_FEATURE_BLKIN_TRACING))
+    ::decode(info, p);
+
+  if (info.trace_id) {
+    trace.init(get_type_name(), endpoint, &info, true);
+    trace.event("decoded trace");
+  } else if (create) { // create a trace even if we didn't get one on the wire
+    trace.init(get_type_name(), endpoint);
+    trace.event("created trace");
+  }
+  trace.keyval("tid", get_tid());
+  trace.keyval("entity type", get_source().type_str());
+  trace.keyval("entity num", get_source().num());
+#endif
+}
+
+
 // This routine is not used for ordinary messages, but only when encapsulating a message
 // for forwarding and routing.  It's also used in a backward compatibility test, which only
 // effectively tests backward compability for those functions.  To avoid backward compatibility

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -26,6 +26,7 @@
 #include "include/types.h"
 #include "include/buffer.h"
 #include "common/Throttle.h"
+#include "common/zipkin_trace.h"
 #include "msg_types.h"
 
 #include "common/RefCountedObj.h"
@@ -228,6 +229,11 @@ protected:
   bi::list_member_hook<> dispatch_q;
 
 public:
+  // zipkin tracing
+  ZTracer::Trace trace;
+  void encode_trace(bufferlist &bl, uint64_t features) const;
+  void decode_trace(bufferlist::iterator &p, bool create = false);
+
   class CompletionHook : public Context {
   protected:
     Message *m;
@@ -285,6 +291,7 @@ protected:
     if (byte_throttler)
       byte_throttler->put(payload.length() + middle.length() + data.length());
     release_message_throttle();
+    trace.event("message destructed");
     /* call completion hooks (if any) */
     if (completion_hook)
       completion_hook->complete(0);

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -457,8 +457,9 @@ typedef boost::intrusive_ptr<Message> MessageRef;
 extern Message *decode_message(CephContext *cct, int crcflags,
 			       ceph_msg_header &header,
 			       ceph_msg_footer& footer, bufferlist& front,
-			       bufferlist& middle, bufferlist& data);
-inline ostream& operator<<(ostream &out, const Message &m) {
+			       bufferlist& middle, bufferlist& data,
+			       Connection* conn);
+inline ostream& operator<<(ostream& out, const Message& m) {
   m.print(out);
   if (m.get_header().version)
     out << " v" << m.get_header().version;

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -47,27 +47,6 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
   return nullptr;
 }
 
-void Messenger::set_endpoint_addr(const entity_addr_t& a, 
-                                  const entity_name_t &name)
-{
-  size_t hostlen;
-  if (a.get_family() == AF_INET)
-    hostlen = sizeof(struct sockaddr_in);
-  else if (a.get_family() == AF_INET6)
-    hostlen = sizeof(struct sockaddr_in6);
-  else
-    hostlen = 0;
-
-  if (hostlen) {
-    char buf[NI_MAXHOST] = { 0 };
-    getnameinfo(a.get_sockaddr(), hostlen, buf, sizeof(buf),
-                NULL, 0, NI_NUMERICHOST);
-
-    trace_endpoint.copy_ip(buf);
-  }
-  trace_endpoint.set_port(a.get_port());
-}
-
 /*
  * Pre-calculate desired software CRC settings.  CRC computation may
  * be disabled by default for some transports (e.g., those with strong

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -3,6 +3,7 @@
 
 #include <random>
 #include "include/Spinlock.h"
+
 #include "include/types.h"
 #include "Messenger.h"
 
@@ -44,6 +45,27 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
 #endif
   lderr(cct) << "unrecognized ms_type '" << type << "'" << dendl;
   return nullptr;
+}
+
+void Messenger::set_endpoint_addr(const entity_addr_t& a, 
+                                  const entity_name_t &name)
+{
+  size_t hostlen;
+  if (a.get_family() == AF_INET)
+    hostlen = sizeof(struct sockaddr_in);
+  else if (a.get_family() == AF_INET6)
+    hostlen = sizeof(struct sockaddr_in6);
+  else
+    hostlen = 0;
+
+  if (hostlen) {
+    char buf[NI_MAXHOST] = { 0 };
+    getnameinfo(a.get_sockaddr(), hostlen, buf, sizeof(buf),
+                NULL, 0, NI_NUMERICHOST);
+
+    trace_endpoint.copy_ip(buf);
+  }
+  trace_endpoint.set_port(a.get_port());
 }
 
 /*

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -41,6 +41,10 @@ class Messenger {
 private:
   list<Dispatcher*> dispatchers;
   list <Dispatcher*> fast_dispatchers;
+  ZTracer::Endpoint trace_endpoint;
+
+  void set_endpoint_addr(const entity_addr_t& a,
+                         const entity_name_t &name);
 
 protected:
   /// the "name" of the local daemon. eg client.99
@@ -136,7 +140,8 @@ public:
    * or use the create() function.
    */
   Messenger(CephContext *cct_, entity_name_t w)
-    : my_inst(),
+    : trace_endpoint("0.0.0.0", 0, "Messenger"),
+      my_inst(),
       default_send_priority(CEPH_MSG_PRIO_DEFAULT), started(false),
       magic(0),
       socket_priority(-1),
@@ -214,8 +219,18 @@ protected:
   /**
    * set messenger's address
    */
-  virtual void set_myaddr(const entity_addr_t& a) { my_inst.addr = a; }
+  virtual void set_myaddr(const entity_addr_t& a) {
+    my_inst.addr = a;
+    set_endpoint_addr(a, my_inst.name);
+  }
 public:
+  /**
+   * @return the zipkin trace endpoint
+   */
+  const ZTracer::Endpoint* get_trace_endpoint() const {
+    return &trace_endpoint;
+  }
+
   /**
    * Retrieve the Messenger's name.
    *

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -43,9 +43,6 @@ private:
   list <Dispatcher*> fast_dispatchers;
   ZTracer::Endpoint trace_endpoint;
 
-  void set_endpoint_addr(const entity_addr_t& a,
-                         const entity_name_t &name);
-
 protected:
   /// the "name" of the local daemon. eg client.99
   entity_inst_t my_inst;
@@ -219,10 +216,8 @@ protected:
   /**
    * set messenger's address
    */
-  virtual void set_myaddr(const entity_addr_t& a) {
-    my_inst.addr = a;
-    set_endpoint_addr(a, my_inst.name);
-  }
+  virtual void set_myaddr(const entity_addr_t& a) { my_inst.addr = a; }
+  
 public:
   /**
    * @return the zipkin trace endpoint

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2085,6 +2085,7 @@ int AsyncConnection::send_message(Message *m)
                                << " Drop message " << m << dendl;
     m->put();
   } else {
+    m->trace.event("async enqueueing message");
     out_q[m->get_priority()].emplace_back(std::move(bl), m);
     ldout(async_msgr->cct, 15) << __func__ << " inline write is denied, reschedule m=" << m << dendl;
     if (can_write != WriteStatus::REPLACING)
@@ -2402,6 +2403,7 @@ ssize_t AsyncConnection::write_message(Message *m, bufferlist& bl, bool more)
     outcoming_bl.append((char*)&old_footer, sizeof(old_footer));
   }
 
+  m->trace.event("async writing message");
   logger->inc(l_msgr_send_bytes, outcoming_bl.length() - original_bl_len);
   ldout(async_msgr->cct, 20) << __func__ << " sending " << m->get_seq()
                              << " " << m << dendl;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -840,7 +840,8 @@ void AsyncConnection::process()
 
           ldout(async_msgr->cct, 20) << __func__ << " got " << front.length() << " + " << middle.length()
                               << " + " << data.length() << " byte message" << dendl;
-          Message *message = decode_message(async_msgr->cct, async_msgr->crcflags, current_header, footer, front, middle, data);
+          Message *message = decode_message(async_msgr->cct, async_msgr->crcflags, current_header, footer,
+                                            front, middle, data, this);
           if (!message) {
             ldout(async_msgr->cct, 1) << __func__ << " decode message failed " << dendl;
             goto fail;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1613,6 +1613,8 @@ void Pipe::reader()
 	continue;
       }
 
+      m->trace.event("pipe read message");
+
       if (state == STATE_CLOSED ||
 	  state == STATE_CONNECTING) {
 	in_q->dispatch_throttle_release(m->get_dispatch_throttle_size());
@@ -1846,6 +1848,8 @@ void Pipe::writer()
 	blist.append(m->get_data());
 
         pipe_lock.Unlock();
+
+        m->trace.event("pipe writing message");
 
         ldout(msgr->cct,20) << "writer sending " << m->get_seq() << " " << m << dendl;
 	int rc = write_message(header, footer, blist);

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2091,7 +2091,8 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
 
   ldout(msgr->cct,20) << "reader got " << front.length() << " + " << middle.length() << " + " << data.length()
 	   << " byte message" << dendl;
-  message = decode_message(msgr->cct, msgr->crcflags, header, footer, front, middle, data);
+  message = decode_message(msgr->cct, msgr->crcflags, header, footer,
+                           front, middle, data, connection_state.get());
   if (!message) {
     ret = -EINVAL;
     goto out_dethrottle;

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -419,6 +419,7 @@ void SimpleMessenger::submit_message(Message *m, PipeConnection *con,
 				     const entity_addr_t& dest_addr, int dest_type,
 				     bool already_locked)
 {
+  m->trace.event("simple submitting message");
   if (cct->_conf->ms_dump_on_send) {
     m->encode(-1, true);
     ldout(cct, 0) << "submit_message " << *m << "\n";

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -429,9 +429,8 @@ int XioConnection::handle_data_msg(struct xio_session *session,
   /* update connection timestamp */
   recv.set(tmsg->timestamp);
 
-  Message *m =
-    decode_message(msgr->cct, msgr->crcflags, header, footer, payload, middle,
-		   data);
+  Message *m = decode_message(msgr->cct, msgr->crcflags, header, footer,
+                              payload, middle, data, this);
 
   if (m) {
     /* completion */

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -938,7 +938,10 @@ assert(req->out.pdata_iov.nents || !nbuffers);
      }
     tail->next = NULL;
   }
-  xcon->portal->enqueue(xcon, xmsg);
+  xmsg->trace = m->trace;
+  m->trace.event("xio portal enqueue for send");
+  m->trace.keyval("xio message segments", xmsg->hdr.msg_cnt);
+  xcon->portal->enqueue_for_send(xcon, xmsg);
 
   return code;
 } /* send_message(Message *, Connection *) */

--- a/src/msg/xio/XioMsg.cc
+++ b/src/msg/xio/XioMsg.cc
@@ -27,6 +27,7 @@ int XioDispatchHook::release_msgs()
   /* queue for release */
   xcmp = static_cast<XioCompletion *>(rsp_pool.alloc(sizeof(XioCompletion)));
   new (xcmp) XioCompletion(xcon, this);
+  xcmp->trace = m->trace;
 
   /* merge with portal traffic */
   xcon->portal->enqueue(xcon, xcmp);

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -170,6 +170,7 @@ public:
 	xcmp->xcon->msg_release_fail(msg, code);
       msg = next_msg;
     }
+    xcmp->trace.event("xio_release_msg");
     xcmp->finalize(); /* unconditional finalize */
   }
 
@@ -273,6 +274,7 @@ public:
 		  goto restart;
 		}
 
+		xs->trace.event("xio_send_msg");
 		msg = xsend->get_xio_msg();
 		code = xio_send_msg(xcon->conn, msg);
 		/* header trace moved here to capture xio serial# */

--- a/src/msg/xio/XioSubmit.h
+++ b/src/msg/xio/XioSubmit.h
@@ -40,6 +40,7 @@ public:
   enum submit_type type;
   bi::list_member_hook<> submit_list;
   XioConnection *xcon;
+  ZTracer::Trace trace;
 
   XioSubmit(enum submit_type _type, XioConnection *_xcon) :
     type(_type), xcon(_xcon)

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -542,6 +542,7 @@ FileStore::FileStore(const std::string &base, const std::string &jdev, osflagbit
   op_wq(this, g_conf->filestore_op_thread_timeout,
 	g_conf->filestore_op_thread_suicide_timeout, &op_tp),
   logger(NULL),
+  trace_endpoint("0.0.0.0", 0, "FileStore"),
   read_error_lock("FileStore::read_error_lock"),
   m_filestore_commit_timeout(g_conf->filestore_commit_timeout),
   m_filestore_journal_parallel(g_conf->filestore_journal_parallel ),
@@ -1945,6 +1946,7 @@ void FileStore::queue_op(OpSequencer *osr, Op *o)
   // sequencer, the op order will be preserved.
 
   osr->queue(o);
+  o->trace.event("queued");
 
   logger->inc(l_os_ops);
   logger->inc(l_os_bytes, o->bytes);
@@ -1991,9 +1993,12 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
 
   osr->apply_lock.Lock();
   Op *o = osr->peek_queue();
+  o->trace.event("op_apply_start");
   apply_manager.op_apply_start(o->op);
   dout(5) << "_do_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " start" << dendl;
+  o->trace.event("_do_transactions start");
   int r = _do_transactions(o->tls, o->op, &handle);
+  o->trace.event("op_apply_finish");
   apply_manager.op_apply_finish(o->op);
   dout(10) << "_do_op " << o << " seq " << o->op << " r = " << r
 	   << ", finisher " << o->onreadable << " " << o->onreadable_sync << dendl;
@@ -2012,6 +2017,7 @@ void FileStore::_finish_op(OpSequencer *osr)
 
   dout(10) << "_finish_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " lat " << lat << dendl;
   osr->apply_lock.Unlock();  // locked in _do_op
+  o->trace.event("_finish_op");
 
   // called with tp lock held
   op_queue_release_throttle(o);
@@ -2081,6 +2087,12 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     (*i).set_osr(osr);
   }
 
+  ZTracer::Trace trace;
+  if (osd_op && osd_op->pg_trace) {
+    osd_op->store_trace.init("filestore op", &trace_endpoint, &osd_op->pg_trace);
+    trace = osd_op->store_trace;
+  }
+
   if (journal && journal->is_writeable() && !m_filestore_journal_trailing) {
     Op *o = build_op(tls, onreadable, onreadable_sync, osd_op);
 
@@ -2099,6 +2111,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
 
     uint64_t op_num = submit_manager.op_submit_start();
     o->op = op_num;
+    trace.keyval("opnum", op_num);
 
     if (m_filestore_do_dump)
       dump_transactions(o->tls, o->op, osr);
@@ -2106,15 +2119,20 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     if (m_filestore_journal_parallel) {
       dout(5) << "queue_transactions (parallel) " << o->op << " " << o->tls << dendl;
 
+      trace.keyval("journal mode", "parallel");
+      trace.event("journal started");
       _op_journal_transactions(tbl, orig_len, o->op, ondisk, osd_op);
 
       // queue inside submit_manager op submission lock
       queue_op(osr, o);
+      trace.event("op queued");
     } else if (m_filestore_journal_writeahead) {
       dout(5) << "queue_transactions (writeahead) " << o->op << " " << o->tls << dendl;
 
       osr->queue_journal(o->op);
 
+      trace.keyval("journal mode", "writeahead");
+      trace.event("journal started");
       _op_journal_transactions(tbl, orig_len, o->op,
 			       new C_JournaledAhead(this, osr, o, ondisk),
 			       osd_op);
@@ -2146,6 +2164,9 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
       dump_transactions(o->tls, o->op, osr);
 
     queue_op(osr, o);
+    trace.keyval("opnum", op_num);
+    trace.keyval("journal mode", "none");
+    trace.event("op queued");
 
     if (ondisk)
       apply_manager.add_waiter(op_num, ondisk);
@@ -2168,10 +2189,15 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   if (m_filestore_do_dump)
     dump_transactions(tls, op, osr);
 
+  trace.event("op_apply_start");
+  trace.keyval("opnum", op);
+  trace.keyval("journal mode", "trailing");
   apply_manager.op_apply_start(op);
+  trace.event("do_transactions");
   int r = do_transactions(tls, op);
 
   if (r >= 0) {
+    trace.event("journal started");
     _op_journal_transactions(tbl, orig_len, op, ondisk, osd_op);
   } else {
     delete ondisk;
@@ -2185,6 +2211,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   apply_finishers[osr->id % m_apply_finisher_num]->queue(onreadable, r);
 
   submit_manager.op_submit_finish(op);
+  trace.event("op_apply_finish");
   apply_manager.op_apply_finish(op);
 
   utime_t end = ceph_clock_now(g_ceph_context);
@@ -2195,6 +2222,8 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
 void FileStore::_journaled_ahead(OpSequencer *osr, Op *o, Context *ondisk)
 {
   dout(5) << "_journaled_ahead " << o << " seq " << o->op << " " << *osr << " " << o->tls << dendl;
+
+  o->trace.event("writeahead journal finished");
 
   // this should queue in order because the journal does it's completions in order.
   queue_op(osr, o);

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -23,6 +23,7 @@
 #include "common/Finisher.h"
 #include "common/TrackedOp.h"
 #include "os/ObjectStore.h"
+#include "common/zipkin_trace.h"
 
 class PerfCounters;
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -680,14 +680,14 @@ bool ECBackend::handle_message(
   switch (_op->get_req()->get_type()) {
   case MSG_OSD_EC_WRITE: {
     MOSDECSubOpWrite *op = static_cast<MOSDECSubOpWrite*>(_op->get_req());
-    handle_sub_write(op->op.from, _op, op->op);
+    handle_sub_write(op->op.from, _op, op->op, _op->pg_trace);
     return true;
   }
   case MSG_OSD_EC_WRITE_REPLY: {
     MOSDECSubOpWriteReply *op = static_cast<MOSDECSubOpWriteReply*>(
       _op->get_req());
     op->set_priority(priority);
-    handle_sub_write_reply(op->op.from, op->op);
+    handle_sub_write_reply(op->op.from, op->op, _op->pg_trace);
     return true;
   }
   case MSG_OSD_EC_READ: {
@@ -695,8 +695,9 @@ bool ECBackend::handle_message(
     MOSDECSubOpReadReply *reply = new MOSDECSubOpReadReply;
     reply->pgid = get_parent()->primary_spg_t();
     reply->map_epoch = get_parent()->get_epoch();
-    handle_sub_read(op->op.from, op->op, &(reply->op));
+    handle_sub_read(op->op.from, op->op, &(reply->op), _op->pg_trace);
     op->set_priority(priority);
+    reply->trace = _op->pg_trace;
     get_parent()->send_message_osd_cluster(
       op->op.from.osd, reply, get_parent()->get_epoch());
     return true;
@@ -705,7 +706,7 @@ bool ECBackend::handle_message(
     MOSDECSubOpReadReply *op = static_cast<MOSDECSubOpReadReply*>(
       _op->get_req());
     RecoveryMessages rm;
-    handle_sub_read_reply(op->op.from, op->op, &rm);
+    handle_sub_read_reply(op->op.from, op->op, &rm, _op->pg_trace);
     dispatch_recovery_messages(rm, priority);
     return true;
   }
@@ -743,22 +744,25 @@ struct SubWriteCommitted : public Context {
   ceph_tid_t tid;
   eversion_t version;
   eversion_t last_complete;
+  const ZTracer::Trace trace;
   SubWriteCommitted(
     ECBackend *pg,
     OpRequestRef msg,
     ceph_tid_t tid,
     eversion_t version,
-    eversion_t last_complete)
+    eversion_t last_complete,
+    const ZTracer::Trace &trace)
     : pg(pg), msg(msg), tid(tid),
-      version(version), last_complete(last_complete) {}
+      version(version), last_complete(last_complete), trace(trace) {}
   void finish(int) {
     if (msg)
       msg->mark_event("sub_op_committed");
-    pg->sub_write_committed(tid, version, last_complete);
+    pg->sub_write_committed(tid, version, last_complete, trace);
   }
 };
 void ECBackend::sub_write_committed(
-  ceph_tid_t tid, eversion_t version, eversion_t last_complete) {
+  ceph_tid_t tid, eversion_t version, eversion_t last_complete,
+  const ZTracer::Trace &trace) {
   if (get_parent()->pgb_is_primary()) {
     ECSubWriteReply reply;
     reply.tid = tid;
@@ -767,7 +771,7 @@ void ECBackend::sub_write_committed(
     reply.from = get_parent()->whoami_shard();
     handle_sub_write_reply(
       get_parent()->whoami_shard(),
-      reply);
+      reply, trace);
   } else {
     get_parent()->update_last_complete_ondisk(last_complete);
     MOSDECSubOpWriteReply *r = new MOSDECSubOpWriteReply;
@@ -778,6 +782,8 @@ void ECBackend::sub_write_committed(
     r->op.committed = true;
     r->op.from = get_parent()->whoami_shard();
     r->set_priority(CEPH_MSG_PRIO_HIGH);
+    r->trace = trace;
+    r->trace.event("sending sub op commit");
     get_parent()->send_message_osd_cluster(
       get_parent()->primary_shard().osd, r, get_parent()->get_epoch());
   }
@@ -788,20 +794,23 @@ struct SubWriteApplied : public Context {
   OpRequestRef msg;
   ceph_tid_t tid;
   eversion_t version;
+  const ZTracer::Trace trace;
   SubWriteApplied(
     ECBackend *pg,
     OpRequestRef msg,
     ceph_tid_t tid,
-    eversion_t version)
-    : pg(pg), msg(msg), tid(tid), version(version) {}
+    eversion_t version,
+    const ZTracer::Trace &trace)
+    : pg(pg), msg(msg), tid(tid), version(version), trace(trace) {}
   void finish(int) {
     if (msg)
       msg->mark_event("sub_op_applied");
-    pg->sub_write_applied(tid, version);
+    pg->sub_write_applied(tid, version, trace);
   }
 };
 void ECBackend::sub_write_applied(
-  ceph_tid_t tid, eversion_t version) {
+  ceph_tid_t tid, eversion_t version,
+  const ZTracer::Trace &trace) {
   parent->op_applied(version);
   if (get_parent()->pgb_is_primary()) {
     ECSubWriteReply reply;
@@ -810,7 +819,7 @@ void ECBackend::sub_write_applied(
     reply.applied = true;
     handle_sub_write_reply(
       get_parent()->whoami_shard(),
-      reply);
+      reply, trace);
   } else {
     MOSDECSubOpWriteReply *r = new MOSDECSubOpWriteReply;
     r->pgid = get_parent()->primary_spg_t();
@@ -819,6 +828,8 @@ void ECBackend::sub_write_applied(
     r->op.tid = tid;
     r->op.applied = true;
     r->set_priority(CEPH_MSG_PRIO_HIGH);
+    r->trace = trace;
+    r->trace.event("sending sub op apply");
     get_parent()->send_message_osd_cluster(
       get_parent()->primary_shard().osd, r, get_parent()->get_epoch());
   }
@@ -828,10 +839,12 @@ void ECBackend::handle_sub_write(
   pg_shard_t from,
   OpRequestRef msg,
   ECSubWrite &op,
+  const ZTracer::Trace &trace,
   Context *on_local_applied_sync)
 {
   if (msg)
     msg->mark_started();
+  trace.event("handle_sub_write");
   assert(!get_parent()->get_log().get_missing().is_missing(op.soid));
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
@@ -876,10 +889,10 @@ void ECBackend::handle_sub_write(
       new SubWriteCommitted(
 	this, msg, op.tid,
 	op.at_version,
-	get_parent()->get_info().last_complete)));
+	get_parent()->get_info().last_complete, trace)));
   localt.register_on_applied(
     get_parent()->bless_context(
-      new SubWriteApplied(this, msg, op.tid, op.at_version)));
+      new SubWriteApplied(this, msg, op.tid, op.at_version, trace)));
   vector<ObjectStore::Transaction> tls;
   tls.reserve(2);
   tls.push_back(std::move(localt));
@@ -890,9 +903,11 @@ void ECBackend::handle_sub_write(
 void ECBackend::handle_sub_read(
   pg_shard_t from,
   ECSubRead &op,
-  ECSubReadReply *reply)
+  ECSubReadReply *reply,
+  const ZTracer::Trace &trace)
 {
   shard_id_t shard = get_parent()->whoami_shard().shard;
+  trace.event("handle sub read");
   for(map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator>::iterator i =
         op.to_read.begin();
       i != op.to_read.end();
@@ -981,11 +996,13 @@ error:
 
 void ECBackend::handle_sub_write_reply(
   pg_shard_t from,
-  ECSubWriteReply &op)
+  ECSubWriteReply &op,
+  const ZTracer::Trace &trace)
 {
   map<ceph_tid_t, Op>::iterator i = tid_to_op_map.find(op.tid);
   assert(i != tid_to_op_map.end());
   if (op.committed) {
+    trace.event("sub write committed");
     assert(i->second.pending_commit.count(from));
     i->second.pending_commit.erase(from);
     if (from != get_parent()->whoami_shard()) {
@@ -993,6 +1010,7 @@ void ECBackend::handle_sub_write_reply(
     }
   }
   if (op.applied) {
+    trace.event("sub write applied");
     assert(i->second.pending_apply.count(from));
     i->second.pending_apply.erase(from);
   }
@@ -1002,8 +1020,10 @@ void ECBackend::handle_sub_write_reply(
 void ECBackend::handle_sub_read_reply(
   pg_shard_t from,
   ECSubReadReply &op,
-  RecoveryMessages *m)
+  RecoveryMessages *m,
+  const ZTracer::Trace &trace)
 {
+  trace.event("ec sub read reply");
   dout(10) << __func__ << ": reply " << op << dendl;
   map<ceph_tid_t, ReadOp>::iterator iter = tid_to_read_map.find(op.tid);
   if (iter == tid_to_read_map.end()) {
@@ -1133,6 +1153,7 @@ void ECBackend::handle_sub_read_reply(
   }
   if (rop.in_progress.empty() || is_complete == rop.complete.size()) {
     dout(20) << __func__ << " Complete: " << rop << dendl;
+    rop.trace.event("ec read complete");
     complete_read_op(rop, m);
   } else {
     dout(10) << __func__ << " readop not complete: " << rop << dendl;
@@ -1371,6 +1392,8 @@ void ECBackend::submit_transaction(
   op->tid = tid;
   op->reqid = reqid;
   op->client_op = client_op;
+  if (client_op)
+    op->trace = client_op->pg_trace;
   
   op->t.reset(static_cast<ECTransaction*>(_t.release()));
 
@@ -1560,6 +1583,10 @@ void ECBackend::start_read_op(
   op.op = _op;
   op.do_redundant_reads = do_redundant_reads;
   op.for_recovery = for_recovery;
+  if (_op) {
+    op.trace = _op->pg_trace;
+    op.trace.event("start ec read");
+  }
   dout(10) << __func__ << ": starting " << op << dendl;
 
   map<pg_shard_t, ECSubRead> messages;
@@ -1617,6 +1644,11 @@ void ECBackend::start_read_op(
     msg->op = i->second;
     msg->op.from = get_parent()->whoami_shard();
     msg->op.tid = tid;
+    if (op.trace) {
+      // initialize a child span for this shard
+      msg->trace.init("ec sub read", nullptr, &op.trace);
+      msg->trace.keyval("shard", i->first.shard.id);
+    }
     get_parent()->send_message_osd_cluster(
       i->first.osd,
       msg,
@@ -1750,11 +1782,13 @@ void ECBackend::check_op(Op *op)
     dout(10) << __func__ << " Calling on_all_applied on " << *op << dendl;
     op->on_all_applied->complete(0);
     op->on_all_applied = 0;
+    op->trace.event("ec write all applied");
   }
   if (op->pending_commit.empty() && op->on_all_commit) {
     dout(10) << __func__ << " Calling on_all_commit on " << *op << dendl;
     op->on_all_commit->complete(0);
     op->on_all_commit = 0;
+    op->trace.event("ec write all committed");
   }
   if (op->pending_apply.empty() && op->pending_commit.empty()) {
     // done!
@@ -1762,6 +1796,7 @@ void ECBackend::check_op(Op *op)
     dout(10) << __func__ << " Completing " << *op << dendl;
     writing.pop_front();
     tid_to_op_map.erase(op->tid);
+    op->trace.event("ec write complete");
   }
   for (map<ceph_tid_t, Op>::iterator i = tid_to_op_map.begin();
        i != tid_to_op_map.end();
@@ -1780,6 +1815,7 @@ void ECBackend::start_write(Op *op) {
   }
   ObjectStore::Transaction empty;
 
+  op->trace.event("start ec write");
   op->t->generate_transactions(
     op->unstable_hash_infos,
     ec_impl,
@@ -1820,17 +1856,27 @@ void ECBackend::start_write(Op *op) {
       op->updated_hit_set_history,
       op->temp_added,
       op->temp_cleared);
+
+    ZTracer::Trace trace;
+    if (op->trace) {
+      // initialize a child span for this shard
+      trace.init("ec sub write", nullptr, &op->trace);
+      trace.keyval("shard", i->shard.id);
+    }
+
     if (*i == get_parent()->whoami_shard()) {
       handle_sub_write(
 	get_parent()->whoami_shard(),
 	op->client_op,
 	sop,
+	trace,
 	op->on_local_applied_sync);
       op->on_local_applied_sync = 0;
     } else {
       MOSDECSubOpWrite *r = new MOSDECSubOpWrite(sop);
       r->pgid = spg_t(get_parent()->primary_spg_t().pgid, i->shard);
       r->map_epoch = get_parent()->get_epoch();
+      r->trace = trace;
       get_parent()->send_message_osd_cluster(
 	i->osd, r, get_parent()->get_epoch());
     }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -55,28 +55,37 @@ public:
   friend struct SubWriteApplied;
   friend struct SubWriteCommitted;
   void sub_write_applied(
-    ceph_tid_t tid, eversion_t version);
+    ceph_tid_t tid,
+    eversion_t version,
+    const ZTracer::Trace &trace);
   void sub_write_committed(
-    ceph_tid_t tid, eversion_t version, eversion_t last_complete);
+    ceph_tid_t tid,
+    eversion_t version,
+    eversion_t last_complete,
+    const ZTracer::Trace &trace);
   void handle_sub_write(
     pg_shard_t from,
     OpRequestRef msg,
     ECSubWrite &op,
+    const ZTracer::Trace &trace,
     Context *on_local_applied_sync = 0
     );
   void handle_sub_read(
     pg_shard_t from,
     ECSubRead &op,
-    ECSubReadReply *reply
+    ECSubReadReply *reply,
+    const ZTracer::Trace &trace
     );
   void handle_sub_write_reply(
     pg_shard_t from,
-    ECSubWriteReply &op
+    ECSubWriteReply &op,
+    const ZTracer::Trace &trace
     );
   void handle_sub_read_reply(
     pg_shard_t from,
     ECSubReadReply &op,
-    RecoveryMessages *m
+    RecoveryMessages *m,
+    const ZTracer::Trace &trace
     );
 
   /// @see ReadOp below
@@ -301,6 +310,8 @@ public:
     // of the available shards.
     bool for_recovery;
 
+    ZTracer::Trace trace;
+
     map<hobject_t, read_request_t, hobject_t::BitwiseComparator> to_read;
     map<hobject_t, read_result_t, hobject_t::BitwiseComparator> complete;
 
@@ -358,6 +369,7 @@ public:
     ceph_tid_t tid;
     osd_reqid_t reqid;
     OpRequestRef client_op;
+    ZTracer::Trace trace;
 
     std::unique_ptr<ECTransaction> t;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1652,6 +1652,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   clog(log_client.create_channel()),
   whoami(id),
   dev_path(dev), journal_path(jdev),
+  trace_endpoint("0.0.0.0", 0, "osd"),
   asok_hook(NULL),
   osd_compat(get_osd_compat_set()),
   osd_tp(cct, "OSD::osd_tp", "tp_osd", cct->_conf->osd_op_threads, "osd_op_threads"),
@@ -1713,6 +1714,11 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
                                          cct->_conf->osd_op_log_threshold);
   op_tracker.set_history_size_and_duration(cct->_conf->osd_op_history_size,
                                            cct->_conf->osd_op_history_duration);
+#ifdef WITH_BLKIN
+  std::stringstream ss;
+  ss << "osd." << whoami;
+  trace_endpoint.copy_name(ss.str());
+#endif
 }
 
 OSD::~OSD()
@@ -5948,6 +5954,8 @@ void OSD::ms_fast_dispatch(Message *m)
     tracepoint(osd, ms_fast_dispatch, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+  if (m->trace)
+    op->osd_trace.init("osd op", &trace_endpoint, &m->trace);
   OSDMapRef nextmap = service.get_nextmap_reserved();
   Session *session = static_cast<Session*>(m->get_connection()->get_priv());
   if (session) {
@@ -6310,6 +6318,8 @@ void OSD::_dispatch(Message *m)
   default:
     {
       OpRequestRef op = op_tracker.create_request<OpRequest, Message*>(m);
+      if (m->trace)
+        op->osd_trace.init("osd op", &trace_endpoint, &m->trace);
       // no map?  starting up?
       if (!osdmap) {
         dout(7) << "no OSDMap, not booted" << dendl;
@@ -8687,10 +8697,16 @@ bool OSD::op_is_discardable(MOSDOp *op)
 void OSD::enqueue_op(PG *pg, OpRequestRef& op)
 {
   utime_t latency = ceph_clock_now(cct) - op->get_req()->get_recv_stamp();
-  dout(15) << "enqueue_op " << op << " prio " << op->get_req()->get_priority()
-	   << " cost " << op->get_req()->get_cost()
-	   << " latency " << latency
+  auto priority = op->get_req()->get_priority();
+  auto cost = op->get_req()->get_cost();
+
+  dout(15) << "enqueue_op " << op << " prio " << priority
+	   << " cost " << cost << " latency " << latency
 	   << " " << *(op->get_req()) << dendl;
+  op->osd_trace.event("enqueue op");
+  op->osd_trace.keyval("priority", priority);
+  op->osd_trace.keyval("cost", cost);
+
   pg->queue_op(op);
 }
 
@@ -8877,6 +8893,7 @@ void OSD::dequeue_op(
     return;
 
   op->mark_reached_pg();
+  op->osd_trace.event("dequeue_op");
 
   pg->do_request(op, handle);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -24,6 +24,9 @@
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
 #include "common/AsyncReserver.h"
+#include "common/ceph_context.h"
+#include "common/zipkin_trace.h"
+
 #include "os/ObjectStore.h"
 #include "OSDCap.h" 
  
@@ -1218,6 +1221,7 @@ protected:
   int whoami;
   std::string dev_path, journal_path;
 
+  ZTracer::Endpoint trace_endpoint;
   void create_logger();
   void create_recoverystate_perf();
   void tick();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -211,7 +211,9 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   #ifdef PG_DEBUG_REFS
   _ref_id_lock("PG::_ref_id_lock"), _ref_id(0),
   #endif
-  deleting(false), dirty_info(false), dirty_big_info(false),
+  deleting(false),
+  trace_endpoint("0.0.0.0", 0, "PG"),
+  dirty_info(false), dirty_big_info(false),
   info(p),
   info_struct_v(0),
   coll(p), pg_log(cct),
@@ -248,6 +250,11 @@ PG::PG(OSDService *o, OSDMapRef curmap,
 {
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
+#endif
+#ifdef WITH_BLKIN
+  std::stringstream ss;
+  ss << "PG " << info.pgid;
+  trace_endpoint.copy_name(ss.str());
 #endif
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -263,6 +263,7 @@ protected:
 public:
   bool deleting;  // true while in removing or OSD is shutting down
 
+  ZTracer::Endpoint trace_endpoint;
 
   void lock_suspend_timeout(ThreadPool::TPHandle &handle);
   void lock(bool no_lockdep = false) const;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -628,8 +628,10 @@ void ReplicatedBackend::op_applied(
   InProgressOp *op)
 {
   dout(10) << __func__ << ": " << op->tid << dendl;
-  if (op->op)
+  if (op->op) {
     op->op->mark_event("op_applied");
+    op->op->pg_trace.event("op applied");
+  }
 
   op->waiting_for_applied.erase(get_parent()->whoami_shard());
   parent->op_applied(op->v);
@@ -648,8 +650,10 @@ void ReplicatedBackend::op_commit(
   InProgressOp *op)
 {
   dout(10) << __func__ << ": " << op->tid << dendl;
-  if (op->op)
+  if (op->op) {
     op->op->mark_event("op_commit");
+    op->op->pg_trace.event("op commit");
+  }
 
   op->waiting_for_commit.erase(get_parent()->whoami_shard());
 
@@ -703,6 +707,7 @@ void ReplicatedBackend::sub_op_modify_reply(OpRequestRef op)
         ostringstream ss;
         ss << "sub_op_commit_rec from " << from;
 	ip_op.op->mark_event(ss.str());
+	ip_op.op->pg_trace.event("sub_op_commit_rec");
       }
     } else {
       assert(ip_op.waiting_for_applied.count(from));
@@ -710,6 +715,7 @@ void ReplicatedBackend::sub_op_modify_reply(OpRequestRef op)
         ostringstream ss;
         ss << "sub_op_applied_rec from " << from;
 	ip_op.op->mark_event(ss.str());
+	ip_op.op->pg_trace.event("sub_op_applied_rec");
       }
     }
     ip_op.waiting_for_applied.erase(from);
@@ -1050,6 +1056,8 @@ void ReplicatedBackend::issue_op(
   InProgressOp *op,
   ObjectStore::Transaction &op_t)
 {
+  if (op->op)
+    op->op->pg_trace.event("issue replication ops");
 
   if (parent->get_actingbackfill_shards().size() > 1) {
     ostringstream ss;
@@ -1083,7 +1091,8 @@ void ReplicatedBackend::issue_op(
       op_t,
       peer,
       pinfo);
-
+    if (op->op)
+      wr->trace.init("replicated op", nullptr, &op->op->pg_trace);
     get_parent()->send_message_osd_cluster(
       peer.osd, wr, get_osdmap()->get_epoch());
   }
@@ -1183,9 +1192,10 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
   rm->op->mark_event("sub_op_applied");
   rm->applied = true;
 
-  dout(10) << "sub_op_modify_applied on " << rm << " op "
-	   << *rm->op->get_req() << dendl;
+  rm->op->pg_trace.event("sup_op_applied");
+
   Message *m = rm->op->get_req();
+  dout(10) << "sub_op_modify_applied on " << rm << " op " << *m << dendl;
 
   Message *ack = NULL;
   eversion_t version;
@@ -1212,6 +1222,7 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
   // send ack to acker only if we haven't sent a commit already
   if (ack) {
     ack->set_priority(CEPH_MSG_PRIO_HIGH); // this better match commit priority!
+    ack->trace = rm->op->pg_trace;
     get_parent()->send_message_osd_cluster(
       rm->ackerosd, ack, get_osdmap()->get_epoch());
   }
@@ -1222,17 +1233,18 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
 void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
 {
   rm->op->mark_commit_sent();
+  rm->op->pg_trace.event("sup_op_commit");
   rm->committed = true;
 
   // send commit.
-  dout(10) << "sub_op_modify_commit on op " << *rm->op->get_req()
+  Message *m = rm->op->get_req();
+  dout(10) << "sub_op_modify_commit on op " << *m
 	   << ", sending commit to osd." << rm->ackerosd
 	   << dendl;
 
   assert(get_osdmap()->is_up(rm->ackerosd));
   get_parent()->update_last_complete_ondisk(rm->last_complete);
 
-  Message *m = rm->op->get_req();
   Message *commit = NULL;
   if (m->get_type() == MSG_OSD_SUBOP) {
     // doesn't have CLIENT SUBOP feature ,use Subop
@@ -1255,6 +1267,7 @@ void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
   }
 
   commit->set_priority(CEPH_MSG_PRIO_HIGH); // this better match ack priority!
+  commit->trace = rm->op->pg_trace;
   get_parent()->send_message_osd_cluster(
     rm->ackerosd, commit, get_osdmap()->get_epoch());
 

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1427,6 +1427,10 @@ void ReplicatedPG::do_request(
   OpRequestRef& op,
   ThreadPool::TPHandle &handle)
 {
+  if (op->osd_trace) {
+    op->pg_trace.init("pg op", &trace_endpoint, &op->osd_trace);
+    op->pg_trace.event("do request");
+  }
   assert(!op_must_wait_for_map(get_osdmap()->get_epoch(), op));
   if (can_discard_request(op)) {
     return;

--- a/src/osdc/Makefile.am
+++ b/src/osdc/Makefile.am
@@ -4,6 +4,11 @@ libosdc_la_SOURCES = \
 	osdc/Filer.cc \
 	osdc/Striper.cc \
 	osdc/Journaler.cc
+
+if WITH_BLKIN
+libosdc_la_LIBADD = $(BLKIN_LIBS)
+endif
+
 noinst_LTLIBRARIES += libosdc.la
 
 noinst_HEADERS += \

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -348,10 +348,10 @@ class ObjectCacher {
                  map<loff_t, BufferHead*>& hits,
                  map<loff_t, BufferHead*>& missing,
                  map<loff_t, BufferHead*>& rx,
-		 map<loff_t, BufferHead*>& errors,
-     const blkin_trace_info *trace_info = nullptr);
-    BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid,
-      const blkin_trace_info *trace_info = nullptr);
+                 map<loff_t, BufferHead*>& errors,
+                 const blkin_trace_info *trace_info = nullptr);
+                 BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid,
+                 const blkin_trace_info *trace_info = nullptr);
     
     void replace_journal_tid(BufferHead *bh, ceph_tid_t tid);
     void truncate(loff_t s);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3048,6 +3048,8 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   m->set_mtime(op->mtime);
   m->set_retry_attempt(op->attempts++);
   m->trace = op->trace;
+  if (!m->trace && cct->_conf->osdc_blkin_trace_all)
+    m->trace.init("objecter op", &trace_endpoint);
 
   if (op->replay_version != eversion_t())
     m->set_version(op->replay_version);  // we're replaying this op!

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3047,6 +3047,7 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   m->ops = op->ops;
   m->set_mtime(op->mtime);
   m->set_retry_attempt(op->attempts++);
+  m->trace = op->trace;
 
   if (op->replay_version != eversion_t())
     m->set_version(op->replay_version);  // we're replaying this op!

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2167,10 +2167,12 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     ObjectOperation& op, const SnapContext& snapc,
     ceph::real_time mtime, int flags, Context *onack,
-    Context *oncommit, version_t *objver = NULL,
+    Context *oncommit,
+    version_t *objver = NULL,
+    ZTracer::Trace *parent_trace = nullptr,
     osd_reqid_t reqid = osd_reqid_t()) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver, NULL, parent_trace);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
@@ -2185,7 +2187,7 @@ public:
     Context *oncommit, version_t *objver = NULL,
     osd_reqid_t reqid = osd_reqid_t()) {
     Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags, onack,
-			      oncommit, objver, reqid);
+			      oncommit, objver, nullptr, reqid);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2198,7 +2198,8 @@ public:
     snapid_t snapid, bufferlist *pbl, int flags,
     Context *onack, version_t *objver = NULL,
     int *data_offset = NULL,
-    uint64_t features = 0) {
+    uint64_t features = 0,
+    ZTracer::Trace *parent_trace = nullptr) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() |
 		   CEPH_OSD_FLAG_READ, onack, NULL, objver, data_offset);
     o->priority = op.priority;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -35,10 +35,10 @@
 #include "common/ceph_timer.h"
 #include "common/Finisher.h"
 #include "common/shunique_lock.h"
+#include "common/zipkin_trace.h"
 
 #include "messages/MOSDOp.h"
 #include "osd/OSDMap.h"
-
 
 using namespace std;
 
@@ -1110,6 +1110,7 @@ public:
   Messenger *messenger;
   MonClient *monc;
   Finisher *finisher;
+  ZTracer::Endpoint trace_endpoint;
 private:
   OSDMap    *osdmap;
 public:
@@ -1269,9 +1270,11 @@ public:
     epoch_t last_force_resend;
 
     osd_reqid_t reqid; // explicitly setting reqid
+    ZTracer::Trace trace;
 
     Op(const object_t& o, const object_locator_t& ol, vector<OSDOp>& op,
-       int f, Context *ac, Context *co, version_t *ov, int *offset = NULL) :
+       int f, Context *ac, Context *co, version_t *ov, int *offset = NULL,
+       ZTracer::Trace *parent_trace = nullptr) :
       session(NULL), incarnation(0),
       target(o, ol, f),
       con(NULL),
@@ -1307,6 +1310,9 @@ public:
 
       if (target.base_oloc.key == o)
 	target.base_oloc.key.clear();
+
+      if (parent_trace && parent_trace->valid())
+        trace.init("op", nullptr, parent_trace);
     }
 
     bool operator<(const Op& other) const {
@@ -1939,6 +1945,7 @@ private:
 	   double mon_timeout,
 	   double osd_timeout) :
     Dispatcher(cct_), messenger(m), monc(mc), finisher(fin),
+    trace_endpoint("0.0.0.0", 0, "Objecter"),
     osdmap(new OSDMap), initialized(0), last_tid(0), client_inc(-1),
     max_linger_id(0), num_unacked(0), num_uncommitted(0), global_op_flags(0),
     keep_balanced_budget(false), honor_osdmap_full(true),
@@ -2332,7 +2339,8 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t off, uint64_t len, snapid_t snap, bufferlist *pbl,
     int flags, Context *onfinish, version_t *objver = NULL,
-    ObjectOperation *extra_ops = NULL, int op_flags = 0) {
+    ObjectOperation *extra_ops = NULL, int op_flags = 0,
+    ZTracer::Trace *parent_trace = nullptr) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_READ;
@@ -2342,7 +2350,8 @@ public:
     ops[i].op.extent.truncate_seq = 0;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_READ, onfinish, 0, objver);
+		   CEPH_OSD_FLAG_READ, onfinish, 0, objver,
+                   nullptr, parent_trace);
     o->snapid = snap;
     o->outbl = pbl;
     return o;
@@ -2465,7 +2474,8 @@ public:
     uint64_t off, uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
     Context *onack, Context *oncommit, version_t *objver = NULL,
-    ObjectOperation *extra_ops = NULL, int op_flags = 0) {
+    ObjectOperation *extra_ops = NULL, int op_flags = 0,
+    ZTracer::Trace *parent_trace = nullptr) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_WRITE;
@@ -2476,7 +2486,8 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver,
+                   nullptr, parent_trace);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -40,6 +40,7 @@
 #include "messages/MOSDOp.h"
 #include "osd/OSDMap.h"
 
+
 using namespace std;
 
 class Context;

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -3,6 +3,7 @@
 #ifndef CEPH_OSDC_WRITEBACKHANDLER_H
 #define CEPH_OSDC_WRITEBACKHANDLER_H
 
+#include "common/zipkin_trace.h"
 #include "include/Context.h"
 #include "include/types.h"
 #include "osd/osd_types.h"
@@ -34,7 +35,8 @@ class WritebackHandler {
 			   const SnapContext& snapc,
 			   const bufferlist &bl, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
-                           ceph_tid_t journal_tid, Context *oncommit) = 0;
+                           ceph_tid_t journal_tid, Context *oncommit,
+                           const blkin_trace_info *trace_info = nullptr) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,
                                 ceph_tid_t original_journal_tid,

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -16,7 +16,8 @@ class WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish) = 0;
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        const blkin_trace_info *trace_info = nullptr) = 0;
   /**
    * check if a given extent read result may change due to a write
    *

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -17,7 +17,7 @@ class WritebackHandler {
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags, Context *onfinish,
-        const blkin_trace_info *trace_info = nullptr) = 0;
+        ZTracer::Trace *trace = nullptr) = 0;
   /**
    * check if a given extent read result may change due to a write
    *
@@ -37,7 +37,7 @@ class WritebackHandler {
 			   const bufferlist &bl, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
                            ceph_tid_t journal_tid, Context *oncommit,
-                           const blkin_trace_info *trace_info = nullptr) = 0;
+                           ZTracer::Trace *trace = nullptr) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,
                                 ceph_tid_t original_journal_tid,

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -396,7 +396,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op, snap_t seq,
-                       std::vector<snap_t>& snaps) {
+                       std::vector<snap_t>& snaps, const blkin_trace_info *trace_info) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -381,7 +381,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectReadOperation *op, int flags,
-                       bufferlist *pbl) {
+                       bufferlist *pbl, const blkin_trace_info *trace_info) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
   return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl);

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -381,7 +381,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectReadOperation *op, int flags,
-                       bufferlist *pbl, const blkin_trace_info *trace_info) {
+                       bufferlist *pbl) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
   return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl);
@@ -396,7 +396,7 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op, snap_t seq,
-                       std::vector<snap_t>& snaps, const blkin_trace_info *trace_info) {
+                       std::vector<snap_t>& snaps) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
 

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -170,10 +170,10 @@ struct MockImageCtx {
 
   MOCK_CONST_METHOD0(get_journal_policy, journal::Policy*());
 
-  MOCK_METHOD7(aio_read_from_cache, void(object_t, uint64_t, bufferlist *,
-                                         size_t, uint64_t, Context *, int));
-  MOCK_METHOD7(write_to_cache, void(object_t, const bufferlist&, size_t,
-                                    uint64_t, Context *, int, uint64_t));
+  MOCK_METHOD8(aio_read_from_cache, void(object_t, uint64_t, bufferlist *,
+                                         size_t, uint64_t, Context *, int, const blkin_trace_info *trace_info));
+  MOCK_METHOD8(write_to_cache, void(object_t, const bufferlist&, size_t,
+                                    uint64_t, Context *, int, uint64_t, const blkin_trace_info *trace_info));
 
   ImageCtx *image_ctx;
   CephContext *cct;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -171,9 +171,9 @@ struct MockImageCtx {
   MOCK_CONST_METHOD0(get_journal_policy, journal::Policy*());
 
   MOCK_METHOD8(aio_read_from_cache, void(object_t, uint64_t, bufferlist *,
-                                         size_t, uint64_t, Context *, int, const blkin_trace_info *trace_info));
+                                         size_t, uint64_t, Context *, int, ZTracer::Trace *trace));
   MOCK_METHOD8(write_to_cache, void(object_t, const bufferlist&, size_t,
-                                    uint64_t, Context *, int, uint64_t, const blkin_trace_info *trace_info));
+                                    uint64_t, Context *, int, uint64_t, ZTracer::Trace *trace));
 
   ImageCtx *image_ctx;
   CephContext *cct;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -46,6 +46,7 @@
 #include "common/ceph_context.h"
 #include "common/errno.h"
 #include "common/event_socket.h"
+#include "common/zipkin_trace.h"
 #include "include/interval_set.h"
 #include "include/stringify.h"
 
@@ -1050,6 +1051,23 @@ void aio_write_test_data(rbd_image_t image, const char *test_data, uint64_t off,
   *passed = true;
 }
 
+void aio_write_test_data_traced(rbd_image_t image, const char *test_data, uint64_t off, size_t len, bool *passed)
+{
+  rbd_completion_t comp;
+  rbd_aio_create_completion(NULL, (rbd_callback_t) simple_write_cb, &comp);
+  printf("created completion\n");
+  struct blkin_trace_info trace_info;
+  rbd_aio_write_traced(image, off, len, test_data, comp, &trace_info);
+  printf("started traced write\n");
+  rbd_aio_wait_for_complete(comp);
+  int r = rbd_aio_get_return_value(comp);
+  printf("return value is: %d\n", r);
+  ASSERT_EQ(0, r);
+  printf("finished traced write\n");
+  rbd_aio_release(comp);
+  *passed = true;
+}
+
 void write_test_data(rbd_image_t image, const char *test_data, uint64_t off, size_t len, uint32_t iohint, bool *passed)
 {
   ssize_t written;
@@ -1151,6 +1169,30 @@ void aio_read_test_data(rbd_image_t image, const char *expected, uint64_t off, s
   *passed = true;
 }
 
+void aio_read_test_data_traced(rbd_image_t image, const char *expected, uint64_t off, size_t len, bool *passed)
+{
+  rbd_completion_t comp;
+  char *result = (char *)malloc(len + 1);
+
+  ASSERT_NE(static_cast<char *>(NULL), result);
+  rbd_aio_create_completion(NULL, (rbd_callback_t) simple_read_cb, &comp);
+  printf("created completion\n");
+  struct blkin_trace_info trace_info;
+  rbd_aio_read_traced(image, off, len, result, comp, &trace_info);
+  printf("started traced read\n");
+  rbd_aio_wait_for_complete(comp);
+  int r = rbd_aio_get_return_value(comp);
+  printf("return value is: %d\n", r);
+  ASSERT_EQ(len, static_cast<size_t>(r));
+  rbd_aio_release(comp);
+  if (memcmp(result, expected, len)) {
+    printf("traced read: %s\nexpected: %s\n", result, expected);
+    ASSERT_EQ(0, memcmp(result, expected, len));
+  }
+  free(result);
+  *passed = true;
+}
+
 void read_test_data(rbd_image_t image, const char *expected, uint64_t off, size_t len, uint32_t iohint, bool *passed)
 {
   ssize_t read;
@@ -1204,11 +1246,17 @@ TEST_F(TestLibRBD, TestIO)
   for (i = 5; i < 10; ++i)
     ASSERT_PASSED(aio_write_test_data, image, test_data, TEST_IO_SIZE * i, TEST_IO_SIZE, 0);
 
+  for (i = 5; i < 10; ++i)
+    ASSERT_PASSED(aio_write_test_data_traced, image, test_data, TEST_IO_SIZE * i, TEST_IO_SIZE);
+
   for (i = 0; i < 5; ++i)
     ASSERT_PASSED(read_test_data, image, test_data, TEST_IO_SIZE * i, TEST_IO_SIZE, 0);
 
   for (i = 5; i < 10; ++i)
     ASSERT_PASSED(aio_read_test_data, image, test_data, TEST_IO_SIZE * i, TEST_IO_SIZE, 0);
+
+  for (i = 5; i < 10; ++i)
+    ASSERT_PASSED(aio_read_test_data_traced, image, test_data, TEST_IO_SIZE * i, TEST_IO_SIZE);
 
   // discard 2nd, 4th sections.
   ASSERT_PASSED(discard_test_data, image, TEST_IO_SIZE, TEST_IO_SIZE);
@@ -1239,8 +1287,21 @@ TEST_F(TestLibRBD, TestIO)
   ASSERT_EQ(-EINVAL, rbd_aio_get_return_value(comp));
   rbd_aio_release(comp);
 
+  struct blkin_trace_info trace_info;
+  rbd_aio_create_completion(NULL, (rbd_callback_t) simple_read_cb, &comp);
+  ASSERT_EQ(0, rbd_aio_write_traced(image, info.size, 1, test_data, comp, &trace_info));
+  ASSERT_EQ(0, rbd_aio_wait_for_complete(comp));
+  ASSERT_EQ(-EINVAL, rbd_aio_get_return_value(comp));
+  rbd_aio_release(comp);
+
   rbd_aio_create_completion(NULL, (rbd_callback_t) simple_read_cb, &comp);
   ASSERT_EQ(0, rbd_aio_read(image, info.size, 1, test_data, comp));
+  ASSERT_EQ(0, rbd_aio_wait_for_complete(comp));
+  ASSERT_EQ(-EINVAL, rbd_aio_get_return_value(comp));
+  rbd_aio_release(comp);
+
+  rbd_aio_create_completion(NULL, (rbd_callback_t) simple_read_cb, &comp);
+  ASSERT_EQ(0, rbd_aio_read_traced(image, info.size, 1, test_data, comp, &trace_info));
   ASSERT_EQ(0, rbd_aio_wait_for_complete(comp));
   ASSERT_EQ(-EINVAL, rbd_aio_get_return_value(comp));
   rbd_aio_release(comp);

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -59,7 +59,8 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                         uint64_t object_off,
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
-                                        Context *completion, int op_flags) {
+                                        Context *completion, int op_flags,
+                                        const blkin_trace_info *trace_info) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -60,7 +60,7 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
                                         Context *completion, int op_flags,
-                                        const blkin_trace_info *trace_info) {
+                                        ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;
@@ -101,7 +101,7 @@ struct AioObjectRead<librbd::MockTestImageCtx> : public AioObjectRequest<librbd:
                                uint64_t objectno, uint64_t offset,
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
-                               Context *completion, int op_flags, const blkin_trace_info *trace_info = nullptr) {
+                               Context *completion, int op_flags, ZTracer::Trace *trace = nullptr) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;
@@ -156,7 +156,7 @@ struct TestMockAioImageRequest : public TestMockFixture {
                              const object_t &object,
                              uint64_t offset, uint64_t length,
                              uint64_t journal_tid, int r,
-                             const blkin_trace_info *trace_info = nullptr) {
+                             ZTracer::Trace *trace = nullptr) {
     EXPECT_CALL(mock_image_ctx, write_to_cache(object, _, length, offset, _, _,
                 journal_tid, nullptr))
       .WillOnce(WithArg<4>(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -75,7 +75,8 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
 				const SnapContext& snapc,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
-				ceph_tid_t journal_tid, Context *oncommit)
+				ceph_tid_t journal_tid, Context *oncommit,
+        const blkin_trace_info *trace_info)
 {
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,
 				 m_delay_ns);

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -62,7 +62,8 @@ void FakeWriteback::read(const object_t& oid, uint64_t object_no,
 			 const object_locator_t& oloc,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
-			 __u32 trunc_seq, int op_flags, Context *onfinish)
+			 __u32 trunc_seq, int op_flags, Context *onfinish,
+       const blkin_trace_info *trace_info)
 {
   C_Delay *wrapper = new C_Delay(m_cct, onfinish, m_lock, off, pbl,
 				 m_delay_ns);

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -63,7 +63,7 @@ void FakeWriteback::read(const object_t& oid, uint64_t object_no,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
 			 __u32 trunc_seq, int op_flags, Context *onfinish,
-       const blkin_trace_info *trace_info)
+       ZTracer::Trace *trace)
 {
   C_Delay *wrapper = new C_Delay(m_cct, onfinish, m_lock, off, pbl,
 				 m_delay_ns);
@@ -77,7 +77,7 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid, Context *oncommit,
-        const blkin_trace_info *trace_info)
+        ZTracer::Trace *trace)
 {
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,
 				 m_delay_ns);

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -27,7 +27,7 @@ public:
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit);
+			   Context *oncommit, const blkin_trace_info *trace_info = nullptr);
 
   using WritebackHandler::write;
 

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -20,7 +20,8 @@ public:
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish);
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        const blkin_trace_info *trace_info = nullptr);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -21,14 +21,14 @@ public:
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags, Context *onfinish,
-        const blkin_trace_info *trace_info = nullptr);
+        ZTracer::Trace *trace = nullptr);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit, const blkin_trace_info *trace_info = nullptr);
+			   Context *oncommit, ZTracer::Trace *trace = nullptr);
 
   using WritebackHandler::write;
 

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -91,7 +91,8 @@ void MemWriteback::read(const object_t& oid, uint64_t object_no,
 			 const object_locator_t& oloc,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
-			 __u32 trunc_seq, int op_flags, Context *onfinish)
+			 __u32 trunc_seq, int op_flags, Context *onfinish,
+       const blkin_trace_info *trace_info)
 {
   assert(snapid == CEPH_NOSNAP);
   C_DelayRead *wrapper = new C_DelayRead(this, m_cct, onfinish, m_lock, oid,
@@ -105,7 +106,8 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
 				const SnapContext& snapc,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
-				ceph_tid_t journal_tid, Context *oncommit)
+				ceph_tid_t journal_tid, Context *oncommit,
+        const blkin_trace_info *trace_info)
 {
   assert(snapc.seq == 0);
   C_DelayWrite *wrapper = new C_DelayWrite(this, m_cct, oncommit, m_lock, oid,

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -92,7 +92,7 @@ void MemWriteback::read(const object_t& oid, uint64_t object_no,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
 			 __u32 trunc_seq, int op_flags, Context *onfinish,
-       const blkin_trace_info *trace_info)
+       ZTracer::Trace *trace)
 {
   assert(snapid == CEPH_NOSNAP);
   C_DelayRead *wrapper = new C_DelayRead(this, m_cct, onfinish, m_lock, oid,
@@ -107,7 +107,7 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
 				ceph_tid_t journal_tid, Context *oncommit,
-        const blkin_trace_info *trace_info)
+        ZTracer::Trace *trace)
 {
   assert(snapc.seq == 0);
   C_DelayWrite *wrapper = new C_DelayWrite(this, m_cct, oncommit, m_lock, oid,

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -20,14 +20,15 @@ public:
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish);
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        const blkin_trace_info *trace_info = nullptr);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit);
+			   Context *oncommit, const blkin_trace_info *trace_info = nullptr);
 
   using WritebackHandler::write;
 

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -21,14 +21,14 @@ public:
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		    __u32 trunc_seq, int op_flags, Context *onfinish,
-        const blkin_trace_info *trace_info = nullptr);
+        ZTracer::Trace *trace = nullptr);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit, const blkin_trace_info *trace_info = nullptr);
+			   Context *oncommit, ZTracer::Trace *trace = nullptr);
 
   using WritebackHandler::write;
 


### PR DESCRIPTION
Pass trace information from librbd to librados. This is part of the end-to-end performance visualization Google Summer of Code project, to initialize traces in fio rbd engine and pass them to librados. It is built on the wip-blkin-osdc branch that added Zipkin tracing support to Messenger and Objecter.

Trace information is passed to librbd through new rbd_aio_write_traced and rbd_aio_read_traced functions, that take trace information as one of the parameters. 

Signed-off-by: Victor Araujo <ve.ar91@gmail.com>
