### PR TITLE
rgw file: remove busy-wait in RGWLibFS::gc()

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -679,6 +679,7 @@ namespace rgw {
 	  } /* rgw_fh */
 	} /* event::type::READDIR */
       } /* ev */
+      std::this_thread::sleep_for(gc_interval);
     } while (! stop);
   } /* RGWLibFS::gc */
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -687,6 +687,9 @@ namespace rgw {
     struct rgw_fs fs;
     RGWFileHandle root_fh;
 
+    static constexpr std::chrono::seconds gc_interval =
+      std::chrono::seconds(120);
+
     mutable std::atomic<uint64_t> refcnt;
 
     RGWFileHandle::FHCache fh_cache;


### PR DESCRIPTION
This is a background thread.  However, CPU is wasted.

Fixes tracker issue #16976

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>