### PR TITLE
cmake: fix wrong path introduced by bb163e9

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -71,7 +71,7 @@ function(distutils_install_cython_module name)
            CPPFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
            LDFLAGS=\"-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}\"
            ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
-           build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_LIB} --verbose
+           build --build-base ${CYTHON_MODULE_DIR} --build-platlib ${CYTHON_MODULE_DIR} --verbose
            build_ext --cython-c-in-temp --build-temp ${CMAKE_CURRENT_BINARY_DIR} --cython-include-dirs ${PROJECT_SOURCE_DIR}/src/pybind/rados
            install \${options} --single-version-externally-managed --record /dev/null
            egg_info --egg-base ${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
s/CYTHON_MODULE_LIB/CYTHON_MODULE_DIR/

Signed-off-by: Kefu Chai <kchai@redhat.com>