### PR TITLE
os/bluestore: fix locking for finish_write

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -468,9 +468,11 @@ public:
   };
 
   struct OnodeSpace;
+  struct Collection;
 
   /// an in-memory object
   struct Onode {
+    Collection *collection;
     std::atomic_int nref;  ///< reference count
 
     ghobject_t oid;
@@ -490,8 +492,9 @@ public:
     std::condition_variable flush_cond;   ///< wait here for unapplied txns
     set<TransContext*> flush_txns;   ///< committing or wal txns
 
-    Onode(OnodeSpace *s, const ghobject_t& o, const string& k)
-      : nref(0),
+    Onode(Collection *c, OnodeSpace *s, const ghobject_t& o, const string& k)
+      : collection(c),
+	nref(0),
 	oid(o),
 	key(k),
 	space(s),

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -37,15 +37,15 @@ TEST_P(AllocTest, test_alloc_init)
 {
   int64_t blocks = BmapEntry::size();
   init_alloc(blocks, 1);
-  ASSERT_EQ(alloc->get_free(), 0);
+  ASSERT_EQ(alloc->get_free(), 0u);
   alloc->shutdown(); 
   blocks = BitMapZone::get_total_blocks() * 2 + 16;
   init_alloc(blocks, 1);
-  ASSERT_EQ(alloc->get_free(), 0);
+  ASSERT_EQ(alloc->get_free(), 0u);
   alloc->shutdown(); 
   blocks = BitMapZone::get_total_blocks() * 2;
   init_alloc(blocks, 1);
-  ASSERT_EQ(alloc->get_free(), 0);
+  ASSERT_EQ(alloc->get_free(), 0u);
 }
 
 TEST_P(AllocTest, test_alloc_min_alloc)
@@ -73,7 +73,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     EXPECT_EQ(alloc->alloc_extents(4 * (uint64_t)block_size, (uint64_t) block_size, 
                                    0, (int64_t) 0, &extents, &count), 0);
     EXPECT_EQ(extents[0].length, 4 * block_size);
-    EXPECT_EQ(extents[1].length, 0);
+    EXPECT_EQ(extents[1].length, 0u);
     EXPECT_EQ(count, 1);
   }
 
@@ -91,7 +91,7 @@ TEST_P(AllocTest, test_alloc_min_alloc)
                                    0, (int64_t) 0, &extents, &count), 0);
     EXPECT_EQ(extents[0].length, 2 * block_size);
     EXPECT_EQ(extents[1].length, 2 * block_size);
-    EXPECT_EQ(extents[2].length, 0);
+    EXPECT_EQ(extents[2].length, 0u);
     EXPECT_EQ(count, 2);
   }
   alloc->shutdown();


### PR DESCRIPTION
In 0633c710584d34261a6164445939d23414bc4799 we adding
locking (which we need), but used first_collection,
which may not be the right collection for the given
onode.  Add an onode->collection pointer so that we can
lock the correct thing.

Signed-off-by: Sage Weil <sage@redhat.com>