### PR TITLE
rgw: fix for s3tests failure when ldap auth is not applied

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3895,7 +3895,7 @@ int RGW_Auth_S3::authorize_v2(RGWRados *store, struct req_state *s)
   }
 
   /* try keystone auth first */
-  int external_auth_result = -ERR_INVALID_ACCESS_KEY;;
+  int external_auth_result = -ERR_INVALID_ACCESS_KEY;
   if (store->ctx()->_conf->rgw_s3_auth_use_keystone
       && !store->ctx()->_conf->rgw_keystone_url.empty()) {
     dout(20) << "s3 keystone: trying keystone auth" << dendl;
@@ -3952,9 +3952,7 @@ int RGW_Auth_S3::authorize_v2(RGWRados *store, struct req_state *s)
   RGWLDAPTokenExtractor token_extr(s);
   RGWLDAPAuthEngine ldap(s->cct, store, token_extr, &aplfact);
 
-  if (! ldap.is_applicable()) {
-    external_auth_result = -EACCES;
-  } else {
+  if (ldap.is_applicable()) {
     auto applier = ldap.authenticate();
     if (!applier) {
       external_auth_result = -EACCES;


### PR DESCRIPTION
```
======================================================================
FAIL: s3tests.functional.test_s3.test_list_buckets_invalid_auth
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/cbodley/s3-tests/virtualenv/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/cbodley/s3-tests/s3tests/functional/test_s3.py", line 4611, in test_list_buckets_invalid_auth
    eq(e.error_code, 'InvalidAccessKeyId')
AssertionError: u'AccessDenied' != 'InvalidAccessKeyId'
```