### PR TITLE
xml: dump_string_linewrap

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -483,6 +483,53 @@ void XMLFormatter::dump_string_with_attrs(const char *name, const std::string& s
     m_ss << "\n";
 }
 
+void XMLFormatter::dump_string_linewrap(const char *name, const std::string& s)
+{
+  std::string e(name);
+  std::string escaped = escape_xml_str(s.c_str());
+  print_spaces();
+  m_ss << "<" << e << ">";
+  if (m_pretty) {
+    int lw = 0;
+    int dont_break = 0;
+    m_sections.push_back("");
+    m_ss << "\n";
+    for (unsigned i = 0; i < escaped.length(); ++i) {
+      if (!dont_break && lw >= 72) {
+	m_ss << '\n';
+	lw = 0;
+      }
+      if (!lw) {
+        print_spaces();
+        lw = m_sections.size();
+      }
+      m_ss << escaped[i];
+      switch(dont_break) {
+      case 0:
+	if (escaped[i] == '=') dont_break = 2;
+	else if (escaped[i] == '&') dont_break = 1;
+	break;
+      case 1:
+	if (escaped[i] == ';') dont_break = 0;
+	break;
+      case 2:
+	if (escaped[i] != '=') dont_break = 0;
+      }
+      ++lw;
+    }
+    if (lw) m_ss << '\n';
+  } else {
+    m_ss << escaped;
+  }
+  if (m_pretty) {
+    m_sections.pop_back();
+    print_spaces();
+  }
+  m_ss << "</" << e << ">";
+  if (m_pretty)
+    m_ss << '\n';
+}
+
 std::ostream& XMLFormatter::dump_stream(const char *name)
 {
   print_spaces();

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -87,6 +87,10 @@ namespace ceph {
     {
       dump_string(name, s);
     }
+    virtual void dump_string_linewrap(const char *name, const std::string& s)
+    {
+      dump_string(name, s);
+    }
   };
 
   class JSONFormatter : public Formatter {
@@ -163,6 +167,7 @@ namespace ceph {
     void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
     void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
     void dump_string_with_attrs(const char *name, const std::string& s, const FormatterAttrs& attrs);
+    void dump_string_linewrap(const char *name, const std::string& s);
   protected:
     void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
     void finish_pending_string();


### PR DESCRIPTION
[ This is functionality for radosgw STS.  While not absolutely required, it makes it a lot easier to compare output with amazon.  See github.com/linuxbox2/linuxbox-ceph wip-rgw-sts-7 src/sts/rgw_rest_sts.cc for intended usage. ]

This is to pretty-print xml strings where whitespace doesn't matter
(ie, base64).  For other formats this is a 'no-op' (ie the same as
plain dump_string).

Signed-off-by: Marcus Watts mwatts@redhat.com
