### PR TITLE
RGWHTTPArgs::get_str() - return argument string that was set.

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -348,6 +348,9 @@ class RGWHTTPArgs
       val_map[iter->first] = iter->second;
     }
   }
+  const string& get_str() {
+    return str;
+  }
 };
 
 class RGWEnv;


### PR DESCRIPTION
[This functionality is required for radosgw STS.  See github.com/github.com:linuxbox2/linuxbox-ceph wip-rgw-sts-7 src/sts/rgw_rest_sts.cc for usage. ]

sts shares code between get/post; the post code needs
to be able to validate that "get style" arguments weren't also passed.

Signed-off-by: Marcus Watts mwatts@redhat.com
