### PR TITLE
common/Formatter: Smarter JSON escape logic

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1019,9 +1019,9 @@ static void update_olh_log(struct rgw_bucket_olh_entry& olh_data_entry, OLHLogOp
 
 static string escape_str(const string& s)
 {
-   int len = escape_json_attr_len(s.c_str(), s.size());
+   int len = escape_json_attr_len(s.c_str(), s.size(), 0);
    char escaped[len];
-   escape_json_attr(s.c_str(), s.size(), escaped);
+   escape_json_attr(s.c_str(), s.size(), escaped, 0);
    return string(escaped);
 }
 

--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -134,8 +134,8 @@ void Formatter::dump_format_unquoted(const char *name, const char *fmt, ...)
 
 // -----------------------
 
-JSONFormatter::JSONFormatter(bool p)
-: m_pretty(p), m_is_pending_string(false)
+JSONFormatter::JSONFormatter(bool p, Escape c)
+: m_pretty(p), m_is_pending_string(false), cook(c)
 {
   reset();
 }
@@ -178,9 +178,9 @@ void JSONFormatter::print_comma(json_formatter_stack_entry_d& entry)
 
 void JSONFormatter::print_quoted_string(const std::string& s)
 {
-  int len = escape_json_attr_len(s.c_str(), s.size());
+  int len = escape_json_attr_len(s.c_str(), s.size(), static_cast<int>(cook));
   char escaped[len];
-  escape_json_attr(s.c_str(), s.size(), escaped);
+  escape_json_attr(s.c_str(), s.size(), escaped, static_cast<int>(cook));
   m_ss << '\"' << escaped << '\"';
 }
 

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -91,7 +91,12 @@ namespace ceph {
 
   class JSONFormatter : public Formatter {
   public:
-    explicit JSONFormatter(bool p = false);
+    enum Escape {
+      Always = 0,
+      Least = 1,
+      SmartHtml = 2,
+    };
+    explicit JSONFormatter(bool p = false, Escape c = Always);
 
     virtual void set_status(int status, const char* status_name) {};
     virtual void output_header() {};
@@ -131,6 +136,7 @@ namespace ceph {
     std::stringstream m_ss, m_pending_string;
     std::list<json_formatter_stack_entry_d> m_stack;
     bool m_is_pending_string;
+    Escape cook;
   };
 
   class XMLFormatter : public Formatter {

--- a/src/common/escape.h
+++ b/src/common/escape.h
@@ -33,13 +33,17 @@ void escape_xml_attr(const char *buf, char *out);
 /* Returns the length of a buffer that would be needed to escape 'buf'
  * as an JSON attrribute
  */
-int escape_json_attr_len(const char *buf, int src_len);
+int escape_json_attr_len(const char *buf, int src_len, int cooked);
 
 /* Escapes 'buf' as an JSON attribute. Assumes that 'out' is at least long
  * enough to fit the output. You can find out the required length by calling
  * escape_json_attr_len first.
+ * cooked: 0=always, 1=least, 2=SmartHTML
+ *	controls whether / is escaped...
+ * json doesn't require this, but because people embed json in html/xml and
+ * embedding things that look like xml tags in json can confuse this.
  */
-void escape_json_attr(const char *buf, int src_len, char *out);
+void escape_json_attr(const char *buf, int src_len, char *out, int cooked);
 
 /* Note: we escape control characters. Although the XML spec doesn't actually
  * require this, Amazon does it in their XML responses.

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -54,12 +54,12 @@ TEST(EscapeXml, Utf8) {
   ASSERT_EQ(escape_xml_attrs((const char*)cc2), (const char*)cc2_out);
 }
 
-static std::string escape_json_attrs(const char *str)
+static std::string escape_json_attrs(const char *str, int cooked = 0)
 {
   int src_len = strlen(str);
-  int len = escape_json_attr_len(str, src_len);
+  int len = escape_json_attr_len(str, src_len, cooked);
   char out[len];
-  escape_json_attr(str, src_len, out);
+  escape_json_attr(str, src_len, out, cooked);
   return out;
 }
 
@@ -80,6 +80,12 @@ TEST(EscapeJson, Escapes1) {
       "Some 'single' \\\"quotes\\\" here");
   ASSERT_EQ(escape_json_attrs("tabs\tand\tnewlines\n, oh my"),
       "tabs\\tand\\tnewlines\\n, oh my");
+  ASSERT_EQ(escape_json_attrs(
+      "JSON calls a slash / backslash a solidus / </br>reverse solidus", 1),
+      "JSON calls a slash / backslash a solidus / </br>reverse solidus");
+  ASSERT_EQ(escape_json_attrs(
+      "JSON calls a slash / backslash a solidus / </br>reverse solidus", 2),
+      "JSON calls a slash / backslash a solidus / <\\/br>reverse solidus");
 }
 
 TEST(EscapeJson, ControlChars) {


### PR DESCRIPTION
[This is for radosgw STS.  In theory, escaping /'s should be legal (but only rarely required).  Amazon (for STS) never does this (and doesn't need to), so there are probably clients that don't understand \/.  This change is designed to be something that can be enabled per-use, so won't break the rest of ceph. See github.com/github.com:linuxbox2/linuxbox-ceph wip-rgw-sts-7 src/sts/rgw_rest_sts.cc for intended use. ]

Json doesn't require anything be escaped.  But embedding json in html
requires special treatment for forward slashes.  This change makes doing
that optional, and adds a new "smarter" escape mode that only expands
forward slashes contained inside < > .

Signed-off-by: Marcus Watts mwatts@redhat.com
