### PR TITLE
rgw/rest: don't print empty x-amz-request-id

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -588,7 +588,7 @@ void dump_trans_id(req_state *s)
   if (s->prot_flags & RGW_REST_SWIFT) {
     STREAM_IO(s)->print("X-Trans-Id: %s\r\n", s->trans_id.c_str());
   }
-  else {
+  else if (s->trans_id.length()) {
     STREAM_IO(s)->print("x-amz-request-id: %s\r\n", s->trans_id.c_str());
   }
 }


### PR DESCRIPTION
[This is required for radosgw STS.  In STS, x-amz-request-id is not used, and not set.  Without this fix, an empty string is emitted, which can't be right.  See github.com/github.com:linuxbox2/linuxbox-ceph wip-rgw-sts-7 for use (no explicit interface/hook.) ]

I don't believe an empty string is ever a valid "x-amz-request-id" record.

Signed-off-by: Marcus Watts <mwatts@redhat.com>