### PR TITLE
jewel: rbd-mirror: include local pool id in resync throttle unique key

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -408,14 +408,28 @@ wait_for_replay_complete()
     local cluster=$2
     local pool=$3
     local image=$4
-    local s master_pos mirror_pos
+    local s master_pos mirror_pos last_mirror_pos
+    local master_tag master_entry mirror_tag mirror_entry
 
-    for s in 0.2 0.4 0.8 1.6 2 2 4 4 8 8 16 16 32 32; do
-	sleep ${s}
-	flush "${local_cluster}" "${pool}" "${image}"
-	master_pos=$(get_master_position "${cluster}" "${pool}" "${image}")
-	mirror_pos=$(get_mirror_position "${cluster}" "${pool}" "${image}")
-	test -n "${master_pos}" -a "${master_pos}" = "${mirror_pos}" && return 0
+    while true; do
+        for s in 0.2 0.4 0.8 1.6 2 2 4 4 8 8 16 16 32 32; do
+	    sleep ${s}
+	    flush "${local_cluster}" "${pool}" "${image}"
+	    master_pos=$(get_master_position "${cluster}" "${pool}" "${image}")
+	    mirror_pos=$(get_mirror_position "${cluster}" "${pool}" "${image}")
+	    test -n "${master_pos}" -a "${master_pos}" = "${mirror_pos}" && return 0
+            test "${mirror_pos}" != "${last_mirror_pos}" && break
+        done
+
+        test "${mirror_pos}" = "${last_mirror_pos}" && return 1
+        last_mirror_pos="${mirror_pos}"
+
+        # handle the case where the mirror is ahead of the master
+        master_tag=$(echo "${master_pos}" | grep -Eo "tag_tid=[0-9]*" | cut -d'=' -f 2)
+        mirror_tag=$(echo "${mirror_pos}" | grep -Eo "tag_tid=[0-9]*" | cut -d'=' -f 2)
+        master_entry=$(echo "${master_pos}" | grep -Eo "entry_tid=[0-9]*" | cut -d'=' -f 2)
+        mirror_entry=$(echo "${mirror_pos}" | grep -Eo "entry_tid=[0-9]*" | cut -d'=' -f 2)
+        test "${master_tag}" = "${mirror_tag}" -a ${master_entry} -le ${mirror_entry} && return 0
     done
     return 1
 }

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -660,6 +660,15 @@ wait_for_image_present()
     return 1
 }
 
+request_resync_image()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+
+    rbd --cluster=${cluster} -p ${pool} mirror image resync ${image}
+}
+
 #
 # Main
 #

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -2,6 +2,11 @@
 #
 # rbd_mirror_stress.sh - stress test rbd-mirror daemon
 #
+# The following additional environment variables affect the test:
+#
+#  RBD_MIRROR_REDUCE_WRITES - if not empty, don't run the stress bench write
+#                             tool during the many image test
+#
 
 IMAGE_COUNT=50
 export LOCKDEP=0
@@ -40,23 +45,43 @@ compare_image_snaps()
     rm -f ${rmt_export} ${loc_export}
 }
 
-wait_for_pool_healthy()
+wait_for_pool_images()
 {
     local cluster=$1
     local pool=$2
     local image_count=$3
     local s
     local count
+    local last_count=0
+
+    while true; do
+        for s in `seq 1 40`; do
+            count=$(rbd --cluster ${cluster} -p ${pool} mirror pool status | grep 'images: ' | cut -d' ' -f 2)
+            test "${count}" = "${image_count}" && return 0
+
+            # reset timeout if making forward progress
+            test $count -gt $last_count && break
+            sleep 30
+        done
+
+        test $count -eq $last_count && return 1
+        $last_count=$count
+    done
+    return 1
+}
+
+wait_for_pool_healthy()
+{
+    local cluster=$1
+    local pool=$2
+    local s
     local state
 
     for s in `seq 1 40`; do
+        state=$(rbd --cluster ${cluster} -p ${pool} mirror pool status | grep 'health:' | cut -d' ' -f 2)
+        test "${state}" = "ERROR" && return 1
+        test "${state}" = "OK" && return 0
 	sleep 30
-        count=$(rbd --cluster ${cluster} -p ${pool} mirror pool status | grep 'images: ')
-        test "${count}" = "images: ${image_count} total" || continue
-
-        state=$(rbd --cluster ${cluster} -p ${pool} mirror pool status | grep 'health:')
-        test "${state}" = "health: ERROR" && return 1
-        test "${state}" = "health: OK" && return 0
     done
     return 1
 }
@@ -91,29 +116,40 @@ remove_image ${CLUSTER2} ${POOL} ${image}
 wait_for_image_present ${CLUSTER1} ${POOL} ${image} 'deleted'
 
 testlog "TEST: create many images"
+snap_name="snap"
 for i in `seq 1 ${IMAGE_COUNT}`
 do
   image="image_${i}"
   create_image ${CLUSTER2} ${POOL} ${image} '128M'
-  write_image ${CLUSTER2} ${POOL} ${image} 100
+  if [ -n "${RBD_MIRROR_REDUCE_WRITES}" ]; then
+    write_image ${CLUSTER2} ${POOL} ${image} 100
+  else
+    stress_write_image ${CLUSTER2} ${POOL} ${image}
+  fi
 done
 
-wait_for_pool_healthy ${CLUSTER2} ${POOL} ${IMAGE_COUNT}
-wait_for_pool_healthy ${CLUSTER1} ${POOL} ${IMAGE_COUNT}
+wait_for_pool_images ${CLUSTER2} ${POOL} ${IMAGE_COUNT}
+wait_for_pool_healthy ${CLUSTER2} ${POOL}
+
+wait_for_pool_images ${CLUSTER1} ${POOL} ${IMAGE_COUNT}
+wait_for_pool_healthy ${CLUSTER1} ${POOL}
 
 testlog "TEST: compare many images"
 for i in `seq 1 ${IMAGE_COUNT}`
 do
   image="image_${i}"
+  create_snap ${CLUSTER2} ${POOL} ${image} ${snap_name}
   wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
   wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
-  compare_images ${POOL} ${image}
+  wait_for_snap_present ${CLUSTER1} ${POOL} ${image} ${snap_name}
+  compare_image_snaps ${POOL} ${image} ${snap_name}
 done
 
 testlog "TEST: delete many images"
 for i in `seq 1 ${IMAGE_COUNT}`
 do
   image="image_${i}"
+  remove_snapshot ${CLUSTER2} ${POOL} ${image} ${snap_name}
   remove_image ${CLUSTER2} ${POOL} ${image}
 done
 

--- a/qa/workunits/rbd/rbd_mirror_stress.sh
+++ b/qa/workunits/rbd/rbd_mirror_stress.sh
@@ -37,6 +37,7 @@ compare_image_snaps()
     rbd --cluster ${CLUSTER2} -p ${pool} export ${image}@${snap_name} ${rmt_export}
     rbd --cluster ${CLUSTER1} -p ${pool} export ${image}@${snap_name} ${loc_export}
     cmp ${rmt_export} ${loc_export}
+    rm -f ${rmt_export} ${loc_export}
 }
 
 wait_for_pool_healthy()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1003,6 +1003,7 @@ if(${WITH_RBD})
     tools/rbd_mirror/ImageReplayer.cc
     tools/rbd_mirror/ImageDeleter.cc
     tools/rbd_mirror/ImageSync.cc
+    tools/rbd_mirror/ImageSyncThrottler.cc
     tools/rbd_mirror/Mirror.cc
     tools/rbd_mirror/PoolWatcher.cc
     tools/rbd_mirror/Replayer.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1215,6 +1215,7 @@ OPTION(rbd_journal_pool, OPT_STR, "") // pool for journal objects
  * RBD Mirror options
  */
 OPTION(rbd_mirror_sync_point_update_age, OPT_DOUBLE, 30) // number of seconds between each update of the image sync point object number
+OPTION(rbd_mirror_concurrent_image_syncs, OPT_U32, 5) // maximum number of image syncs in parallel
 
 OPTION(nss_db_path, OPT_STR, "") // path to nss db
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1211,6 +1211,11 @@ OPTION(rbd_journal_object_flush_bytes, OPT_INT, 0) // maximum number of pending 
 OPTION(rbd_journal_object_flush_age, OPT_DOUBLE, 0) // maximum age (in seconds) for pending commits
 OPTION(rbd_journal_pool, OPT_STR, "") // pool for journal objects
 
+/**
+ * RBD Mirror options
+ */
+OPTION(rbd_mirror_sync_point_update_age, OPT_DOUBLE, 30) // number of seconds between each update of the image sync point object number
+
 OPTION(nss_db_path, OPT_STR, "") // path to nss db
 
 

--- a/src/journal/JournalMetadata.cc
+++ b/src/journal/JournalMetadata.cc
@@ -587,7 +587,7 @@ void JournalMetadata::get_tags(const boost::optional<uint64_t> &tag_class,
   ctx->send();
 }
 
-void JournalMetadata::add_listener(Listener *listener) {
+void JournalMetadata::add_listener(JournalMetadataListener *listener) {
   Mutex::Locker locker(m_lock);
   while (m_update_notifications > 0) {
     m_update_cond.Wait(m_lock);
@@ -595,7 +595,7 @@ void JournalMetadata::add_listener(Listener *listener) {
   m_listeners.push_back(listener);
 }
 
-void JournalMetadata::remove_listener(Listener *listener) {
+void JournalMetadata::remove_listener(JournalMetadataListener *listener) {
   Mutex::Locker locker(m_lock);
   while (m_update_notifications > 0) {
     m_update_cond.Wait(m_lock);

--- a/src/journal/JournalMetadataListener.h
+++ b/src/journal/JournalMetadataListener.h
@@ -1,0 +1,30 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_JOURNAL_JOURNAL_METADATA_LISTENER_H
+#define CEPH_JOURNAL_JOURNAL_METADATA_LISTENER_H
+
+namespace journal {
+
+class JournalMetadata;
+
+struct JournalMetadataListener {
+  virtual ~JournalMetadataListener() {};
+  virtual void handle_update(JournalMetadata *) = 0;
+};
+
+} // namespace journal
+
+#endif // CEPH_JOURNAL_JOURNAL_METADATA_LISTENER_H
+

--- a/src/journal/JournalRecorder.h
+++ b/src/journal/JournalRecorder.h
@@ -36,7 +36,7 @@ public:
 private:
   typedef std::map<uint8_t, ObjectRecorderPtr> ObjectRecorderPtrs;
 
-  struct Listener : public JournalMetadata::Listener {
+  struct Listener : public JournalMetadataListener {
     JournalRecorder *journal_recorder;
 
     Listener(JournalRecorder *_journal_recorder)

--- a/src/journal/JournalTrimmer.h
+++ b/src/journal/JournalTrimmer.h
@@ -33,7 +33,7 @@ public:
 private:
   typedef std::function<Context*()> CreateContext;
 
-  struct MetadataListener : public JournalMetadata::Listener {
+  struct MetadataListener : public JournalMetadataListener {
     JournalTrimmer *journal_trimmmer;
 
     MetadataListener(JournalTrimmer *journal_trimmmer)

--- a/src/journal/Journaler.cc
+++ b/src/journal/Journaler.cc
@@ -244,6 +244,14 @@ void Journaler::flush_commit_position(Context *on_safe) {
   m_metadata->flush_commit_position(on_safe);
 }
 
+void Journaler::add_listener(JournalMetadataListener *listener) {
+  m_metadata->add_listener(listener);
+}
+
+void Journaler::remove_listener(JournalMetadataListener *listener) {
+  m_metadata->remove_listener(listener);
+}
+
 int Journaler::register_client(const bufferlist &data) {
   C_SaferCond cond;
   register_client(data, &cond);

--- a/src/journal/Journaler.h
+++ b/src/journal/Journaler.h
@@ -9,6 +9,7 @@
 #include "include/Context.h"
 #include "include/rados/librados.hpp"
 #include "journal/Future.h"
+#include "journal/JournalMetadataListener.h"
 #include "cls/journal/cls_journal_types.h"
 #include <list>
 #include <map>
@@ -70,6 +71,9 @@ public:
 			      int64_t *pool_id, Context *on_finish);
   void get_mutable_metadata(uint64_t *minimum_set, uint64_t *active_set,
 			    RegisteredClients *clients, Context *on_finish);
+
+  void add_listener(JournalMetadataListener *listener);
+  void remove_listener(JournalMetadataListener *listener);
 
   int register_client(const bufferlist &data);
   void register_client(const bufferlist &data, Context *on_finish);

--- a/src/journal/Makefile.am
+++ b/src/journal/Makefile.am
@@ -23,6 +23,7 @@ noinst_HEADERS += \
 	journal/FutureImpl.h \
 	journal/Journaler.h \
 	journal/JournalMetadata.h \
+	journal/JournalMetadataListener.h \
 	journal/JournalPlayer.h \
 	journal/JournalRecorder.h \
 	journal/JournalTrimmer.h \

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -11,6 +11,7 @@
 #include "include/rados/librados.hpp"
 #include "common/Mutex.h"
 #include "journal/Future.h"
+#include "journal/JournalMetadataListener.h"
 #include "journal/ReplayEntry.h"
 #include "journal/ReplayHandler.h"
 #include "librbd/journal/Types.h"
@@ -158,6 +159,13 @@ public:
                              Context *on_start, Context *on_close_request);
   void stop_external_replay();
 
+  void add_listener(journal::ListenerType type,
+                    journal::JournalListenerPtr listener);
+  void remove_listener(journal::ListenerType type,
+                       journal::JournalListenerPtr listener);
+
+  int check_resync_requested(bool *do_resync);
+
 private:
   ImageCtxT &m_image_ctx;
 
@@ -288,6 +296,23 @@ private:
   journal::Replay<ImageCtxT> *m_journal_replay;
   Context *m_on_replay_close_request = nullptr;
 
+  struct MetadataListener : public ::journal::JournalMetadataListener {
+    Journal<ImageCtxT> *journal;
+
+    MetadataListener(Journal<ImageCtxT> *journal) : journal(journal) { }
+
+    void handle_update(::journal::JournalMetadata *) {
+      FunctionContext *ctx = new FunctionContext([this](int r) {
+        journal->handle_metadata_updated();
+      });
+      journal->m_work_queue->queue(ctx, 0);
+    }
+  } m_metadata_listener;
+
+  typedef std::map<journal::ListenerType,
+                   std::list<journal::JournalListenerPtr> > ListenerMap;
+  ListenerMap m_listener_map;
+
   uint64_t append_io_events(journal::EventType event_type,
                             const Bufferlists &bufferlists,
                             const AioObjectRequests &requests,
@@ -331,6 +356,10 @@ private:
 
   bool is_steady_state() const;
   void wait_for_steady_state(Context *on_state);
+
+  int check_resync_requested_internal(bool *do_resync);
+
+  void handle_metadata_updated();
 };
 
 } // namespace librbd

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -483,6 +483,18 @@ std::ostream &operator<<(std::ostream &out, const MirrorPeerState &meta);
 std::ostream &operator<<(std::ostream &out, const MirrorPeerClientMeta &meta);
 std::ostream &operator<<(std::ostream &out, const TagData &tag_data);
 
+enum class ListenerType : int8_t {
+  RESYNC
+};
+
+struct ResyncListener {
+  virtual ~ResyncListener() {}
+  virtual void handle_resync() = 0;
+};
+
+typedef boost::variant<ResyncListener *> JournalListenerPtr;
+
+
 } // namespace journal
 } // namespace librbd
 

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -476,6 +476,7 @@ unittest_rbd_mirror_SOURCES = \
 	test/rbd_mirror/test_mock_fixture.cc \
 	test/rbd_mirror/test_mock_ImageReplayer.cc \
 	test/rbd_mirror/test_mock_ImageSync.cc \
+	test/rbd_mirror/test_mock_ImageSyncThrottler.cc \
 	test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc \
 	test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc \
 	test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc \

--- a/src/test/journal/RadosTestFixture.h
+++ b/src/test/journal/RadosTestFixture.h
@@ -35,7 +35,7 @@ public:
 
   bufferlist create_payload(const std::string &payload);
 
-  struct Listener : public journal::JournalMetadata::Listener {
+  struct Listener : public journal::JournalMetadataListener {
     RadosTestFixture *test_fixture;
     Mutex mutex;
     Cond cond;

--- a/src/test/journal/mock/MockJournaler.h
+++ b/src/test/journal/mock/MockJournaler.h
@@ -128,6 +128,9 @@ struct MockJournaler {
   MOCK_METHOD1(committed, void(const MockFutureProxy &future));
   MOCK_METHOD1(flush_commit_position, void(Context*));
 
+  MOCK_METHOD1(add_listener, void(JournalMetadataListener *));
+  MOCK_METHOD1(remove_listener, void(JournalMetadataListener *));
+
 };
 
 struct MockJournalerProxy {
@@ -155,6 +158,10 @@ struct MockJournalerProxy {
   int register_client(const bufferlist &data) {
     return -EINVAL;
   }
+  void unregister_client(Context *ctx) {
+    ctx->complete(-EINVAL);
+  }
+
   void allocate_tag(uint64_t, const bufferlist &,
                     cls::journal::Tag*, Context *on_finish) {
     on_finish->complete(-EINVAL);
@@ -265,6 +272,14 @@ struct MockJournalerProxy {
 
   void flush_commit_position(Context *on_finish) {
     MockJournaler::get_instance().flush_commit_position(on_finish);
+  }
+
+  void add_listener(JournalMetadataListener *listener) {
+    MockJournaler::get_instance().add_listener(listener);
+  }
+
+  void remove_listener(JournalMetadataListener *listener) {
+    MockJournaler::get_instance().remove_listener(listener);
   }
 };
 

--- a/src/test/librbd/mock/MockJournal.h
+++ b/src/test/librbd/mock/MockJournal.h
@@ -57,6 +57,13 @@ struct MockJournal {
 
   MOCK_METHOD2(commit_op_event, void(uint64_t, int));
   MOCK_METHOD2(replay_op_ready, void(uint64_t, Context *));
+
+  MOCK_METHOD2(add_listener, void(journal::ListenerType,
+                                  journal::JournalListenerPtr));
+  MOCK_METHOD2(remove_listener, void(journal::ListenerType,
+                                     journal::JournalListenerPtr));
+
+  MOCK_METHOD1(check_resync_requested, int(bool *));
 };
 
 } // namespace librbd

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(unittest_rbd_mirror EXCLUDE_FROM_ALL
   test_main.cc
   test_mock_fixture.cc
   test_mock_ImageSync.cc
+  test_mock_ImageSyncThrottler.cc
   image_replayer/test_mock_BootstrapRequest.cc
   image_replayer/test_mock_CreateImageRequest.cc
   image_sync/test_mock_ImageCopyRequest.cc

--- a/src/test/rbd_mirror/image_replay.cc
+++ b/src/test/rbd_mirror/image_replay.cc
@@ -10,6 +10,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
 #include "tools/rbd_mirror/ImageReplayer.h"
+#include "tools/rbd_mirror/ImageDeleter.h"
 #include "tools/rbd_mirror/Threads.h"
 
 #include <string>
@@ -130,6 +131,7 @@ int main(int argc, const char **argv)
   rbd::mirror::RadosRef local(new librados::Rados());
   rbd::mirror::RadosRef remote(new librados::Rados());
   rbd::mirror::Threads *threads = nullptr;
+  std::shared_ptr<rbd::mirror::ImageDeleter> image_deleter;
 
   C_SaferCond start_cond, stop_cond;
 
@@ -184,7 +186,12 @@ int main(int argc, const char **argv)
 
   threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
     local->cct()));
-  replayer = new rbd::mirror::ImageReplayer<>(threads, local, remote, client_id,
+
+  image_deleter.reset(new rbd::mirror::ImageDeleter(local, threads->timer,
+                                                    &threads->timer_lock));
+
+  replayer = new rbd::mirror::ImageReplayer<>(threads, image_deleter, local,
+                                              remote, client_id,
 					      "remote mirror uuid",
                                               local_pool_id, remote_pool_id,
                                               remote_image_id,

--- a/src/test/rbd_mirror/image_replay.cc
+++ b/src/test/rbd_mirror/image_replay.cc
@@ -189,7 +189,8 @@ int main(int argc, const char **argv)
   threads = new rbd::mirror::Threads(reinterpret_cast<CephContext*>(
     local->cct()));
 
-  image_deleter.reset(new rbd::mirror::ImageDeleter(local, threads->timer,
+  image_deleter.reset(new rbd::mirror::ImageDeleter(local, threads->work_queue,
+                                                    threads->timer,
                                                     &threads->timer_lock));
 
   image_sync_throttler.reset(new rbd::mirror::ImageSyncThrottler<>());

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -81,7 +81,8 @@ struct ImageSyncThrottler<librbd::MockTestImageCtx> {
                                  librbd::journal::MirrorPeerClientMeta *client_meta,
                                  ContextWQ *work_queue, Context *on_finish,
                                  ProgressContext *progress_ctx));
-  MOCK_METHOD1(cancel_sync, void(const std::string& mirror_uuid));
+  MOCK_METHOD2(cancel_sync, void(librados::IoCtx &local_io_ctx,
+                                 const std::string& mirror_uuid));
 };
 
 namespace image_replayer {

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -4,6 +4,7 @@
 #include "test/rbd_mirror/test_mock_fixture.h"
 #include "librbd/journal/TypeTraits.h"
 #include "tools/rbd_mirror/ImageSync.h"
+#include "tools/rbd_mirror/ImageSyncThrottler.h"
 #include "tools/rbd_mirror/image_replayer/BootstrapRequest.h"
 #include "tools/rbd_mirror/image_replayer/CloseImageRequest.h"
 #include "tools/rbd_mirror/image_replayer/CreateImageRequest.h"
@@ -69,6 +70,19 @@ struct ImageSync<librbd::MockTestImageCtx> {
 };
 
 ImageSync<librbd::MockTestImageCtx>* ImageSync<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+template<>
+struct ImageSyncThrottler<librbd::MockTestImageCtx> {
+  MOCK_METHOD10(start_sync, void(librbd::MockTestImageCtx *local_image_ctx,
+                                 librbd::MockTestImageCtx *remote_image_ctx,
+                                 SafeTimer *timer, Mutex *timer_lock,
+                                 const std::string &mirror_uuid,
+                                 ::journal::MockJournaler *journaler,
+                                 librbd::journal::MirrorPeerClientMeta *client_meta,
+                                 ContextWQ *work_queue, Context *on_finish,
+                                 ProgressContext *progress_ctx));
+  MOCK_METHOD1(cancel_sync, void(const std::string& mirror_uuid));
+};
 
 namespace image_replayer {
 

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -16,10 +16,21 @@
 #include <boost/scope_exit.hpp>
 
 namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
 namespace journal {
 
 template <>
-struct TypeTraits<librbd::MockImageCtx> {
+struct TypeTraits<librbd::MockTestImageCtx> {
   typedef ::journal::MockJournaler Journaler;
 };
 
@@ -31,11 +42,11 @@ namespace mirror {
 namespace image_sync {
 
 template <>
-struct ObjectCopyRequest<librbd::MockImageCtx> {
+struct ObjectCopyRequest<librbd::MockTestImageCtx> {
   static ObjectCopyRequest* s_instance;
-  static ObjectCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
-                                   librbd::MockImageCtx *remote_image_ctx,
-                                   const ImageCopyRequest<librbd::MockImageCtx>::SnapMap *snap_map,
+  static ObjectCopyRequest* create(librbd::MockTestImageCtx *local_image_ctx,
+                                   librbd::MockTestImageCtx *remote_image_ctx,
+                                   const ImageCopyRequest<librbd::MockTestImageCtx>::SnapMap *snap_map,
                                    uint64_t object_number, Context *on_finish) {
     assert(s_instance != nullptr);
     Mutex::Locker locker(s_instance->lock);
@@ -50,7 +61,7 @@ struct ObjectCopyRequest<librbd::MockImageCtx> {
   Mutex lock;
   Cond cond;
 
-  const ImageCopyRequest<librbd::MockImageCtx>::SnapMap *snap_map = nullptr;
+  const ImageCopyRequest<librbd::MockTestImageCtx>::SnapMap *snap_map = nullptr;
   std::map<uint64_t, Context *> object_contexts;
 
   ObjectCopyRequest() : lock("lock") {
@@ -58,7 +69,7 @@ struct ObjectCopyRequest<librbd::MockImageCtx> {
   }
 };
 
-ObjectCopyRequest<librbd::MockImageCtx>* ObjectCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
+ObjectCopyRequest<librbd::MockTestImageCtx>* ObjectCopyRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
 } // namespace image_sync
 } // namespace mirror
@@ -66,7 +77,7 @@ ObjectCopyRequest<librbd::MockImageCtx>* ObjectCopyRequest<librbd::MockImageCtx>
 
 // template definitions
 #include "tools/rbd_mirror/image_sync/ImageCopyRequest.cc"
-template class rbd::mirror::image_sync::ImageCopyRequest<librbd::MockImageCtx>;
+template class rbd::mirror::image_sync::ImageCopyRequest<librbd::MockTestImageCtx>;
 
 namespace rbd {
 namespace mirror {
@@ -81,8 +92,8 @@ using ::testing::InvokeWithoutArgs;
 
 class TestMockImageSyncImageCopyRequest : public TestMockFixture {
 public:
-  typedef ImageCopyRequest<librbd::MockImageCtx> MockImageCopyRequest;
-  typedef ObjectCopyRequest<librbd::MockImageCtx> MockObjectCopyRequest;
+  typedef ImageCopyRequest<librbd::MockTestImageCtx> MockImageCopyRequest;
+  typedef ObjectCopyRequest<librbd::MockTestImageCtx> MockObjectCopyRequest;
 
   virtual void SetUp() {
     TestMockFixture::SetUp();
@@ -95,7 +106,7 @@ public:
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
   }
 
-  void expect_get_snap_id(librbd::MockImageCtx &mock_image_ctx) {
+  void expect_get_snap_id(librbd::MockTestImageCtx &mock_image_ctx) {
     EXPECT_CALL(mock_image_ctx, get_snap_id(_))
       .WillRepeatedly(Invoke([&mock_image_ctx](std::string snap_name) {
         RWLock::RLocker snap_locker(mock_image_ctx.image_ctx->snap_lock);
@@ -103,7 +114,7 @@ public:
       }));
   }
 
-  void expect_get_object_count(librbd::MockImageCtx &mock_image_ctx,
+  void expect_get_object_count(librbd::MockTestImageCtx &mock_image_ctx,
                                uint64_t count) {
     EXPECT_CALL(mock_image_ctx, get_object_count(_))
       .WillOnce(Return(count)).RetiresOnSaturation();
@@ -151,8 +162,8 @@ public:
     return *mock_object_copy_request.snap_map;
   }
 
-  MockImageCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
-                                       librbd::MockImageCtx &mock_local_image_ctx,
+  MockImageCopyRequest *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,
+                                       librbd::MockTestImageCtx &mock_local_image_ctx,
                                        journal::MockJournaler &mock_journaler,
                                        librbd::journal::MirrorPeerSyncPoint &sync_point,
                                        Context *ctx) {
@@ -199,8 +210,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, SimpleImage) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -244,8 +255,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, Throttled) {
 
   uint64_t object_count = 55;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -306,8 +317,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, SnapshotSubset) {
   ASSERT_EQ(0, create_snap("snap3"));
   m_client_meta.sync_points = {{"snap3", "snap2", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -344,8 +355,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartCatchup) {
   m_client_meta.sync_points = {{"snap1", boost::none},
                                {"snap2", "snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -376,8 +387,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartPartialSync) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", librbd::journal::MirrorPeerSyncPoint::ObjectNumber{0U}}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -413,8 +424,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -459,8 +470,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel_Inflight_Sync) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -507,8 +518,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel1) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
@@ -538,8 +549,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, MissingSnap) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"missing-snap", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   expect_get_snap_id(mock_remote_image_ctx);
@@ -558,8 +569,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, MissingFromSnap) {
   ASSERT_EQ(0, create_snap("snap1"));
   m_client_meta.sync_points = {{"snap1", "missing-snap", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   expect_get_snap_id(mock_remote_image_ctx);
@@ -580,8 +591,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapMap) {
   m_client_meta.snap_seqs = {{0, 0}};
   m_client_meta.sync_points = {{"snap2", "snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   expect_get_snap_id(mock_remote_image_ctx);
@@ -602,8 +613,8 @@ TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapSeqs) {
   m_client_meta.snap_seqs = {};
   m_client_meta.sync_points = {{"snap2", "snap1", boost::none}};
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   expect_get_snap_id(mock_remote_image_ctx);

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -596,6 +596,28 @@ TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapMap) {
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
+TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapSeqs) {
+  ASSERT_EQ(0, create_snap("snap1"));
+  ASSERT_EQ(0, create_snap("snap2"));
+  m_client_meta.snap_seqs = {};
+  m_client_meta.sync_points = {{"snap2", "snap1", boost::none}};
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  expect_get_snap_id(mock_remote_image_ctx);
+
+  C_SaferCond ctx;
+  MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                 mock_local_image_ctx,
+                                                 mock_journaler,
+                                                 m_client_meta.sync_points.front(),
+                                                 &ctx);
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
 } // namespace image_sync
 } // namespace mirror
 } // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -14,9 +14,21 @@
 #include "tools/rbd_mirror/Threads.h"
 #include "tools/rbd_mirror/image_sync/ObjectCopyRequest.h"
 
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
 // template definitions
 #include "tools/rbd_mirror/image_sync/ObjectCopyRequest.cc"
-template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::MockImageCtx>;
+template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::MockTestImageCtx>;
 
 namespace rbd {
 namespace mirror {
@@ -56,7 +68,7 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size,
 
 class TestMockImageSyncObjectCopyRequest : public TestMockFixture {
 public:
-  typedef ObjectCopyRequest<librbd::MockImageCtx> MockObjectCopyRequest;
+  typedef ObjectCopyRequest<librbd::MockTestImageCtx> MockObjectCopyRequest;
 
   virtual void SetUp() {
     TestMockFixture::SetUp();
@@ -69,7 +81,7 @@ public:
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
   }
 
-  void expect_list_snaps(librbd::MockImageCtx &mock_image_ctx,
+  void expect_list_snaps(librbd::MockTestImageCtx &mock_image_ctx,
                          librados::MockTestMemIoCtxImpl &mock_io_ctx, int r) {
     auto &expect = EXPECT_CALL(mock_io_ctx,
                                list_snaps(mock_image_ctx.image_ctx->get_object_name(0),
@@ -81,13 +93,13 @@ public:
     }
   }
 
-  void expect_get_object_name(librbd::MockImageCtx &mock_image_ctx) {
+  void expect_get_object_name(librbd::MockTestImageCtx &mock_image_ctx) {
     EXPECT_CALL(mock_image_ctx, get_object_name(0))
                   .WillOnce(Return(mock_image_ctx.image_ctx->get_object_name(0)));
   }
 
-  MockObjectCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
-                                        librbd::MockImageCtx &mock_local_image_ctx,
+  MockObjectCopyRequest *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,
+                                        librbd::MockTestImageCtx &mock_local_image_ctx,
                                         Context *on_finish) {
     expect_get_object_name(mock_local_image_ctx);
     expect_get_object_name(mock_remote_image_ctx);
@@ -155,7 +167,7 @@ public:
     }
   }
 
-  void expect_update_object_map(librbd::MockImageCtx &mock_image_ctx,
+  void expect_update_object_map(librbd::MockTestImageCtx &mock_image_ctx,
                                 librbd::MockObjectMap &mock_object_map,
                                 librados::snap_t snap_id, uint8_t state,
                                 int r) {
@@ -289,8 +301,8 @@ public:
 
 TEST_F(TestMockImageSyncObjectCopyRequest, DNE) {
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -317,8 +329,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Write) {
   scribble(m_remote_image_ctx, 10, 102400, &one);
 
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -352,8 +364,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, ReadError) {
   scribble(m_remote_image_ctx, 10, 102400, &one);
 
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -381,8 +393,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, WriteError) {
   scribble(m_remote_image_ctx, 10, 102400, &one);
 
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -424,8 +436,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, WriteSnaps) {
   }
 
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -471,8 +483,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Trim) {
     trim_offset, one.range_end() - trim_offset));
   ASSERT_EQ(0, create_snap("sync"));
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;
@@ -513,8 +525,8 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Remove) {
   uint64_t object_size = 1 << m_remote_image_ctx->order;
   ASSERT_LE(0, m_remote_image_ctx->aio_work_queue->discard(0, object_size));
   ASSERT_EQ(0, create_snap("sync"));
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
 
   librbd::MockObjectMap mock_object_map;
   mock_local_image_ctx.object_map = &mock_object_map;

--- a/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SnapshotCopyRequest.cc
@@ -15,10 +15,21 @@
 #include "tools/rbd_mirror/Threads.h"
 
 namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
 namespace journal {
 
 template <>
-struct TypeTraits<librbd::MockImageCtx> {
+struct TypeTraits<librbd::MockTestImageCtx> {
   typedef ::journal::MockJournaler Journaler;
 };
 
@@ -30,9 +41,9 @@ namespace mirror {
 namespace image_sync {
 
 template <>
-struct SnapshotCreateRequest<librbd::MockImageCtx> {
+struct SnapshotCreateRequest<librbd::MockTestImageCtx> {
   static SnapshotCreateRequest* s_instance;
-  static SnapshotCreateRequest* create(librbd::MockImageCtx* image_ctx,
+  static SnapshotCreateRequest* create(librbd::MockTestImageCtx* image_ctx,
                                        const std::string &snap_name,
                                        uint64_t size,
                                        const librbd::parent_spec &parent_spec,
@@ -52,7 +63,7 @@ struct SnapshotCreateRequest<librbd::MockImageCtx> {
   MOCK_METHOD0(send, void());
 };
 
-SnapshotCreateRequest<librbd::MockImageCtx>* SnapshotCreateRequest<librbd::MockImageCtx>::s_instance = nullptr;
+SnapshotCreateRequest<librbd::MockTestImageCtx>* SnapshotCreateRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
 } // namespace image_sync
 } // namespace mirror
@@ -60,7 +71,7 @@ SnapshotCreateRequest<librbd::MockImageCtx>* SnapshotCreateRequest<librbd::MockI
 
 // template definitions
 #include "tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc"
-template class rbd::mirror::image_sync::SnapshotCopyRequest<librbd::MockImageCtx>;
+template class rbd::mirror::image_sync::SnapshotCopyRequest<librbd::MockTestImageCtx>;
 
 namespace rbd {
 namespace mirror {
@@ -79,8 +90,8 @@ using ::testing::WithArg;
 
 class TestMockImageSyncSnapshotCopyRequest : public TestMockFixture {
 public:
-  typedef SnapshotCopyRequest<librbd::MockImageCtx> MockSnapshotCopyRequest;
-  typedef SnapshotCreateRequest<librbd::MockImageCtx> MockSnapshotCreateRequest;
+  typedef SnapshotCopyRequest<librbd::MockTestImageCtx> MockSnapshotCopyRequest;
+  typedef SnapshotCreateRequest<librbd::MockTestImageCtx> MockSnapshotCreateRequest;
 
   virtual void SetUp() {
     TestMockFixture::SetUp();
@@ -93,7 +104,7 @@ public:
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
   }
 
-  void expect_snap_create(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_create(librbd::MockTestImageCtx &mock_image_ctx,
                           MockSnapshotCreateRequest &mock_snapshot_create_request,
                           const std::string &snap_name, uint64_t snap_id, int r) {
     EXPECT_CALL(mock_snapshot_create_request, send())
@@ -105,7 +116,7 @@ public:
                       })));
   }
 
-  void expect_snap_remove(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_remove(librbd::MockTestImageCtx &mock_image_ctx,
                           const std::string &snap_name, int r) {
     EXPECT_CALL(*mock_image_ctx.operations, execute_snap_remove(StrEq(snap_name), _))
                   .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
@@ -113,7 +124,7 @@ public:
                             })));
   }
 
-  void expect_snap_protect(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_protect(librbd::MockTestImageCtx &mock_image_ctx,
                            const std::string &snap_name, int r) {
     EXPECT_CALL(*mock_image_ctx.operations, execute_snap_protect(StrEq(snap_name), _))
                   .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
@@ -121,7 +132,7 @@ public:
                             })));
   }
 
-  void expect_snap_unprotect(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_unprotect(librbd::MockTestImageCtx &mock_image_ctx,
                              const std::string &snap_name, int r) {
     EXPECT_CALL(*mock_image_ctx.operations, execute_snap_unprotect(StrEq(snap_name), _))
                   .WillOnce(WithArg<1>(Invoke([this, r](Context *ctx) {
@@ -129,14 +140,14 @@ public:
                             })));
   }
 
-  void expect_snap_is_protected(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_is_protected(librbd::MockTestImageCtx &mock_image_ctx,
                                 uint64_t snap_id, bool is_protected, int r) {
     EXPECT_CALL(mock_image_ctx, is_snap_protected(snap_id, _))
                   .WillOnce(DoAll(SetArgPointee<1>(is_protected),
                                   Return(r)));
   }
 
-  void expect_snap_is_unprotected(librbd::MockImageCtx &mock_image_ctx,
+  void expect_snap_is_unprotected(librbd::MockTestImageCtx &mock_image_ctx,
                                   uint64_t snap_id, bool is_unprotected, int r) {
     EXPECT_CALL(mock_image_ctx, is_snap_unprotected(snap_id, _))
                   .WillOnce(DoAll(SetArgPointee<1>(is_unprotected),
@@ -148,13 +159,13 @@ public:
                   .WillOnce(WithArg<1>(CompleteContext(r)));
   }
 
-  static void inject_snap(librbd::MockImageCtx &mock_image_ctx,
-                   uint64_t snap_id, const std::string &snap_name) {
+  static void inject_snap(librbd::MockTestImageCtx &mock_image_ctx,
+                          uint64_t snap_id, const std::string &snap_name) {
     mock_image_ctx.snap_ids[snap_name] = snap_id;
   }
 
-  MockSnapshotCopyRequest *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
-                                          librbd::MockImageCtx &mock_local_image_ctx,
+  MockSnapshotCopyRequest *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,
+                                          librbd::MockTestImageCtx &mock_local_image_ctx,
                                           journal::MockJournaler &mock_journaler,
                                           Context *on_finish) {
     return new MockSnapshotCopyRequest(&mock_local_image_ctx,
@@ -200,8 +211,8 @@ public:
 };
 
 TEST_F(TestMockImageSyncSnapshotCopyRequest, Empty) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -219,8 +230,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, Empty) {
 }
 
 TEST_F(TestMockImageSyncSnapshotCopyRequest, UpdateClientError) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -235,8 +246,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, UpdateClientError) {
 }
 
 TEST_F(TestMockImageSyncSnapshotCopyRequest, UpdateClientCancel) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   C_SaferCond ctx;
@@ -261,8 +272,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreate) {
   uint64_t remote_snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
   uint64_t remote_snap_id2 = m_remote_image_ctx->snap_ids["snap2"];
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -287,8 +298,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreate) {
 TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreateError) {
   ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap1"));
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -306,8 +317,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreateError) {
 TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreateCancel) {
   ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap1"));
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -334,8 +345,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapRemoveAndCreate) {
 
   uint64_t remote_snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -361,8 +372,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapRemoveAndCreate) {
 TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapRemoveError) {
   ASSERT_EQ(0, create_snap(m_local_image_ctx, "snap1"));
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -386,8 +397,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapUnprotect) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -416,8 +427,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapUnprotectError) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -441,8 +452,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapUnprotectCancel) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   C_SaferCond ctx;
@@ -471,8 +482,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapUnprotectRemove) {
 
   uint64_t remote_snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -501,8 +512,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapCreateProtect) {
 
   uint64_t remote_snap_id1 = m_remote_image_ctx->snap_ids["snap1"];
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   MockSnapshotCreateRequest mock_snapshot_create_request;
   journal::MockJournaler mock_journaler;
 
@@ -532,8 +543,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapProtect) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -562,8 +573,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapProtectError) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
@@ -588,8 +599,8 @@ TEST_F(TestMockImageSyncSnapshotCopyRequest, SnapProtectCancel) {
   uint64_t local_snap_id1 = m_local_image_ctx->snap_ids["snap1"];
   m_client_meta.snap_seqs[remote_snap_id1] = local_snap_id1;
 
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
   C_SaferCond ctx;

--- a/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_SyncPointPruneRequest.cc
@@ -31,6 +31,7 @@ namespace image_sync {
 
 using ::testing::_;
 using ::testing::InSequence;
+using ::testing::Return;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
@@ -49,6 +50,12 @@ public:
   void expect_update_client(journal::MockJournaler &mock_journaler, int r) {
     EXPECT_CALL(mock_journaler, update_client(_, _))
       .WillOnce(WithArg<1>(CompleteContext(r)));
+  }
+
+  void expect_get_snap_id(librbd::MockImageCtx &mock_remote_image_ctx,
+                          const std::string &snap_name, uint64_t snap_id) {
+    EXPECT_CALL(mock_remote_image_ctx, get_snap_id(StrEq(snap_name)))
+      .WillOnce(Return(snap_id));
   }
 
   void expect_image_refresh(librbd::MockImageCtx &mock_remote_image_ctx, int r) {
@@ -82,6 +89,7 @@ TEST_F(TestMockImageSyncSyncPointPruneRequest, SyncInProgressSuccess) {
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
+  expect_get_snap_id(mock_remote_image_ctx, "snap1", 123);
   expect_image_refresh(mock_remote_image_ctx, 0);
   expect_update_client(mock_journaler, 0);
 
@@ -103,6 +111,7 @@ TEST_F(TestMockImageSyncSyncPointPruneRequest, RestartedSyncInProgressSuccess) {
   journal::MockJournaler mock_journaler;
 
   InSequence seq;
+  expect_get_snap_id(mock_remote_image_ctx, "snap1", 123);
   expect_snap_remove(mock_remote_image_ctx, "snap2", 0);
   expect_image_refresh(mock_remote_image_ctx, 0);
   expect_update_client(mock_journaler, 0);
@@ -114,6 +123,57 @@ TEST_F(TestMockImageSyncSyncPointPruneRequest, RestartedSyncInProgressSuccess) {
   ASSERT_EQ(0, ctx.wait());
 
   client_meta.sync_points.pop_back();
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, SyncInProgressMissingSnapSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  client_meta.sync_points.emplace_front("snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_get_snap_id(mock_remote_image_ctx, "snap1", CEPH_NOSNAP);
+  expect_snap_remove(mock_remote_image_ctx, "snap2", 0);
+  expect_snap_remove(mock_remote_image_ctx, "snap1", 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, false, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  client_meta.sync_points.clear();
+  ASSERT_EQ(client_meta, m_client_meta);
+}
+
+TEST_F(TestMockImageSyncSyncPointPruneRequest, SyncInProgressUnexpectedFromSnapSuccess) {
+  librbd::journal::MirrorPeerClientMeta client_meta;
+  client_meta.sync_points.emplace_front("snap2", "snap1", boost::none);
+  m_client_meta = client_meta;
+
+  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  journal::MockJournaler mock_journaler;
+
+  InSequence seq;
+  expect_get_snap_id(mock_remote_image_ctx, "snap2", 124);
+  expect_snap_remove(mock_remote_image_ctx, "snap2", 0);
+  expect_snap_remove(mock_remote_image_ctx, "snap1", 0);
+  expect_image_refresh(mock_remote_image_ctx, 0);
+  expect_update_client(mock_journaler, 0);
+
+  C_SaferCond ctx;
+  MockSyncPointPruneRequest *req = create_request(mock_remote_image_ctx,
+                                                  mock_journaler, false, &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+
+  client_meta.sync_points.clear();
   ASSERT_EQ(client_meta, m_client_meta);
 }
 

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -63,7 +63,7 @@ public:
     librbd::mirror_mode_set(m_local_io_ctx, RBD_MIRROR_MODE_IMAGE);
 
     m_deleter = new rbd::mirror::ImageDeleter(_rados,
-        m_threads->timer, &m_threads->timer_lock);
+        m_threads->work_queue, m_threads->timer, &m_threads->timer_lock);
 
     EXPECT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, 1 << 20));
     ImageCtx *ictx = new ImageCtx(m_image_name, "", "", m_local_io_ctx,

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -107,9 +107,9 @@ public:
       m_local_ioctx.cct()));
 
     m_image_deleter.reset(new rbd::mirror::ImageDeleter(m_local_cluster,
-                                                      m_threads->timer,
-                                                      &m_threads->timer_lock));
-
+                                                        m_threads->work_queue,
+                                                        m_threads->timer,
+                                                        &m_threads->timer_lock));
     m_image_sync_throttler.reset(new rbd::mirror::ImageSyncThrottler<>());
   }
 

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -576,6 +576,11 @@ TEST_F(TestImageReplayer, Resync)
   m_replayer->resync_image(&ctx);
   ASSERT_EQ(0, ctx.wait());
 
+  C_SaferCond delete_ctx;
+  m_image_deleter->wait_for_scheduled_deletion(
+    m_replayer->get_local_image_name(), &delete_ctx);
+  EXPECT_EQ(0, delete_ctx.wait());
+
   C_SaferCond cond;
   m_replayer->start(&cond);
   ASSERT_EQ(0, cond.wait());
@@ -636,6 +641,11 @@ TEST_F(TestImageReplayer, Resync_While_Stop)
 
   ASSERT_TRUE(m_replayer->is_stopped());
 
+  C_SaferCond delete_ctx;
+  m_image_deleter->wait_for_scheduled_deletion(
+    m_replayer->get_local_image_name(), &delete_ctx);
+  EXPECT_EQ(0, delete_ctx.wait());
+
   C_SaferCond cond3;
   m_replayer->start(&cond3);
   ASSERT_EQ(0, cond3.wait());
@@ -671,6 +681,11 @@ TEST_F(TestImageReplayer, Resync_StartInterrupted)
   ASSERT_EQ(0, cond.wait());
 
   ASSERT_TRUE(m_replayer->is_stopped());
+
+  C_SaferCond delete_ctx;
+  m_image_deleter->wait_for_scheduled_deletion(
+    m_replayer->get_local_image_name(), &delete_ctx);
+  EXPECT_EQ(0, delete_ctx.wait());
 
   C_SaferCond cond2;
   m_replayer->start(&cond2);

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -6,6 +6,7 @@
 #include "tools/rbd_mirror/ImageReplayer.h"
 #include "tools/rbd_mirror/image_replayer/BootstrapRequest.h"
 #include "tools/rbd_mirror/image_replayer/CloseImageRequest.h"
+#include "tools/rbd_mirror/ImageSyncThrottler.h"
 #include "test/journal/mock/MockJournaler.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/librbd/mock/MockJournal.h"
@@ -59,19 +60,20 @@ struct BootstrapRequest<librbd::MockTestImageCtx> {
   Context *on_finish = nullptr;
 
   static BootstrapRequest* create(librados::IoCtx &local_io_ctx,
-                                  librados::IoCtx &remote_io_ctx,
-                                  librbd::MockTestImageCtx **local_image_ctx,
-                                  const std::string &local_image_name,
-                                  const std::string &remote_image_id,
-                                  const std::string &global_image_id,
-                                  ContextWQ *work_queue, SafeTimer *timer,
-                                  Mutex *timer_lock,
-                                  const std::string &local_mirror_uuid,
-                                  const std::string &remote_mirror_uuid,
-                                  ::journal::MockJournalerProxy *journaler,
-                                  librbd::journal::MirrorPeerClientMeta *client_meta,
-                                  Context *on_finish,
-                                  rbd::mirror::ProgressContext *progress_ctx = nullptr) {
+        librados::IoCtx &remote_io_ctx,
+        rbd::mirror::ImageSyncThrottlerRef<librbd::MockTestImageCtx> image_sync_throttler,
+        librbd::MockTestImageCtx **local_image_ctx,
+        const std::string &local_image_name,
+        const std::string &remote_image_id,
+        const std::string &global_image_id,
+        ContextWQ *work_queue, SafeTimer *timer,
+        Mutex *timer_lock,
+        const std::string &local_mirror_uuid,
+        const std::string &remote_mirror_uuid,
+        ::journal::MockJournalerProxy *journaler,
+        librbd::journal::MirrorPeerClientMeta *client_meta,
+        Context *on_finish,
+        rbd::mirror::ProgressContext *progress_ctx = nullptr) {
     assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
     return s_instance;

--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -340,6 +340,7 @@ TEST_F(TestMockImageSync, CancelImageCopy) {
   m_client_meta.sync_points = {{"snap1", boost::none}};
 
   InSequence seq;
+  expect_prune_sync_point(mock_sync_point_prune_request, false, 0);
   expect_copy_snapshots(mock_snapshot_copy_request, 0);
 
   C_SaferCond image_copy_ctx;

--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -17,10 +17,21 @@
 #include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.h"
 
 namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+
 namespace journal {
 
 template <>
-struct TypeTraits<librbd::MockImageCtx> {
+struct TypeTraits<librbd::MockTestImageCtx> {
   typedef ::journal::MockJournaler Journaler;
 };
 
@@ -29,7 +40,7 @@ struct TypeTraits<librbd::MockImageCtx> {
 
 // template definitions
 #include "tools/rbd_mirror/ImageSync.cc"
-template class rbd::mirror::ImageSync<librbd::MockImageCtx>;
+template class rbd::mirror::ImageSync<librbd::MockTestImageCtx>;
 
 namespace rbd {
 namespace mirror {
@@ -37,13 +48,13 @@ namespace mirror {
 namespace image_sync {
 
 template <>
-class ImageCopyRequest<librbd::MockImageCtx> {
+class ImageCopyRequest<librbd::MockTestImageCtx> {
 public:
   static ImageCopyRequest* s_instance;
   Context *on_finish;
 
-  static ImageCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
-                                  librbd::MockImageCtx *remote_image_ctx,
+  static ImageCopyRequest* create(librbd::MockTestImageCtx *local_image_ctx,
+                                  librbd::MockTestImageCtx *remote_image_ctx,
                                   SafeTimer *timer, Mutex *timer_lock,
                                   journal::MockJournaler *journaler,
                                   librbd::journal::MirrorPeerClientMeta *client_meta,
@@ -70,13 +81,13 @@ public:
 };
 
 template <>
-class SnapshotCopyRequest<librbd::MockImageCtx> {
+class SnapshotCopyRequest<librbd::MockTestImageCtx> {
 public:
   static SnapshotCopyRequest* s_instance;
   Context *on_finish;
 
-  static SnapshotCopyRequest* create(librbd::MockImageCtx *local_image_ctx,
-                                     librbd::MockImageCtx *remote_image_ctx,
+  static SnapshotCopyRequest* create(librbd::MockTestImageCtx *local_image_ctx,
+                                     librbd::MockTestImageCtx *remote_image_ctx,
                                      SnapshotCopyRequest<librbd::ImageCtx>::SnapMap *snap_map,
                                      journal::MockJournaler *journaler,
                                      librbd::journal::MirrorPeerClientMeta *client_meta,
@@ -102,12 +113,12 @@ public:
 };
 
 template <>
-class SyncPointCreateRequest<librbd::MockImageCtx> {
+class SyncPointCreateRequest<librbd::MockTestImageCtx> {
 public:
   static SyncPointCreateRequest *s_instance;
   Context *on_finish;
 
-  static SyncPointCreateRequest* create(librbd::MockImageCtx *remote_image_ctx,
+  static SyncPointCreateRequest* create(librbd::MockTestImageCtx *remote_image_ctx,
                                         const std::string &mirror_uuid,
                                         journal::MockJournaler *journaler,
                                         librbd::journal::MirrorPeerClientMeta *client_meta,
@@ -124,13 +135,13 @@ public:
 };
 
 template <>
-class SyncPointPruneRequest<librbd::MockImageCtx> {
+class SyncPointPruneRequest<librbd::MockTestImageCtx> {
 public:
   static SyncPointPruneRequest *s_instance;
   Context *on_finish;
   bool sync_complete;
 
-  static SyncPointPruneRequest* create(librbd::MockImageCtx *remote_image_ctx,
+  static SyncPointPruneRequest* create(librbd::MockTestImageCtx *remote_image_ctx,
                                        bool sync_complete,
                                        journal::MockJournaler *journaler,
                                        librbd::journal::MirrorPeerClientMeta *client_meta,
@@ -147,10 +158,10 @@ public:
   MOCK_METHOD0(send, void());
 };
 
-ImageCopyRequest<librbd::MockImageCtx>* ImageCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
-SnapshotCopyRequest<librbd::MockImageCtx>* SnapshotCopyRequest<librbd::MockImageCtx>::s_instance = nullptr;
-SyncPointCreateRequest<librbd::MockImageCtx>* SyncPointCreateRequest<librbd::MockImageCtx>::s_instance = nullptr;
-SyncPointPruneRequest<librbd::MockImageCtx>* SyncPointPruneRequest<librbd::MockImageCtx>::s_instance = nullptr;
+ImageCopyRequest<librbd::MockTestImageCtx>* ImageCopyRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+SnapshotCopyRequest<librbd::MockTestImageCtx>* SnapshotCopyRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+SyncPointCreateRequest<librbd::MockTestImageCtx>* SyncPointCreateRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
+SyncPointPruneRequest<librbd::MockTestImageCtx>* SyncPointPruneRequest<librbd::MockTestImageCtx>::s_instance = nullptr;
 
 } // namespace image_sync
 
@@ -163,11 +174,11 @@ using ::testing::InvokeWithoutArgs;
 
 class TestMockImageSync : public TestMockFixture {
 public:
-  typedef ImageSync<librbd::MockImageCtx> MockImageSync;
-  typedef image_sync::ImageCopyRequest<librbd::MockImageCtx> MockImageCopyRequest;
-  typedef image_sync::SnapshotCopyRequest<librbd::MockImageCtx> MockSnapshotCopyRequest;
-  typedef image_sync::SyncPointCreateRequest<librbd::MockImageCtx> MockSyncPointCreateRequest;
-  typedef image_sync::SyncPointPruneRequest<librbd::MockImageCtx> MockSyncPointPruneRequest;
+  typedef ImageSync<librbd::MockTestImageCtx> MockImageSync;
+  typedef image_sync::ImageCopyRequest<librbd::MockTestImageCtx> MockImageCopyRequest;
+  typedef image_sync::SnapshotCopyRequest<librbd::MockTestImageCtx> MockSnapshotCopyRequest;
+  typedef image_sync::SyncPointCreateRequest<librbd::MockTestImageCtx> MockSyncPointCreateRequest;
+  typedef image_sync::SyncPointPruneRequest<librbd::MockTestImageCtx> MockSyncPointPruneRequest;
 
   virtual void SetUp() {
     TestMockFixture::SetUp();
@@ -180,7 +191,7 @@ public:
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
   }
 
-  void expect_create_sync_point(librbd::MockImageCtx &mock_local_image_ctx,
+  void expect_create_sync_point(librbd::MockTestImageCtx &mock_local_image_ctx,
                                 MockSyncPointCreateRequest &mock_sync_point_create_request,
                                 int r) {
     EXPECT_CALL(mock_sync_point_create_request, send())
@@ -216,13 +227,13 @@ public:
     }
   }
 
-  void expect_create_object_map(librbd::MockImageCtx &mock_image_ctx,
+  void expect_create_object_map(librbd::MockTestImageCtx &mock_image_ctx,
                                 librbd::MockObjectMap *mock_object_map) {
     EXPECT_CALL(mock_image_ctx, create_object_map(CEPH_NOSNAP))
       .WillOnce(Return(mock_object_map));
   }
 
-  void expect_open_object_map(librbd::MockImageCtx &mock_image_ctx,
+  void expect_open_object_map(librbd::MockTestImageCtx &mock_image_ctx,
                               librbd::MockObjectMap &mock_object_map) {
     EXPECT_CALL(mock_object_map, open(_))
       .WillOnce(Invoke([this](Context *ctx) {
@@ -248,8 +259,8 @@ public:
         }));
   }
 
-  MockImageSync *create_request(librbd::MockImageCtx &mock_remote_image_ctx,
-                                librbd::MockImageCtx &mock_local_image_ctx,
+  MockImageSync *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,
+                                librbd::MockTestImageCtx &mock_local_image_ctx,
                                 journal::MockJournaler &mock_journaler,
                                 Context *ctx) {
     return new MockImageSync(&mock_local_image_ctx, &mock_remote_image_ctx,
@@ -264,8 +275,8 @@ public:
 };
 
 TEST_F(TestMockImageSync, SimpleSync) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockImageCopyRequest mock_image_copy_request;
   MockSnapshotCopyRequest mock_snapshot_copy_request;
@@ -294,8 +305,8 @@ TEST_F(TestMockImageSync, SimpleSync) {
 }
 
 TEST_F(TestMockImageSync, RestartSync) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockImageCopyRequest mock_image_copy_request;
   MockSnapshotCopyRequest mock_snapshot_copy_request;
@@ -329,8 +340,8 @@ TEST_F(TestMockImageSync, RestartSync) {
 }
 
 TEST_F(TestMockImageSync, CancelImageCopy) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockImageCopyRequest mock_image_copy_request;
   MockSnapshotCopyRequest mock_snapshot_copy_request;
@@ -367,8 +378,8 @@ TEST_F(TestMockImageSync, CancelImageCopy) {
 }
 
 TEST_F(TestMockImageSync, CancelAfterCopySnapshots) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockSnapshotCopyRequest mock_snapshot_copy_request;
   MockSyncPointCreateRequest mock_sync_point_create_request;
@@ -397,8 +408,8 @@ TEST_F(TestMockImageSync, CancelAfterCopySnapshots) {
 }
 
 TEST_F(TestMockImageSync, CancelAfterCopyImage) {
-  librbd::MockImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
-  librbd::MockImageCtx mock_local_image_ctx(*m_local_image_ctx);
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
   MockImageCopyRequest mock_image_copy_request;
   MockSnapshotCopyRequest mock_snapshot_copy_request;

--- a/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
@@ -1,0 +1,398 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "librbd/journal/TypeTraits.h"
+#include "test/journal/mock/MockJournaler.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "librbd/ImageState.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/ImageSync.h"
+
+namespace librbd {
+namespace journal {
+
+template <>
+struct TypeTraits<librbd::MockImageCtx> {
+  typedef ::journal::MockJournaler Journaler;
+};
+
+} // namespace journal
+} // namespace librbd
+
+namespace rbd {
+namespace mirror {
+
+using ::testing::Invoke;
+
+typedef ImageSync<librbd::MockImageCtx> MockImageSync;
+
+template<>
+class ImageSync<librbd::MockImageCtx> {
+public:
+  static std::vector<MockImageSync *> instances;
+
+  Context *on_finish;
+  bool syncing = false;
+
+  static ImageSync* create(librbd::MockImageCtx *local_image_ctx,
+                           librbd::MockImageCtx *remote_image_ctx,
+                           SafeTimer *timer, Mutex *timer_lock,
+                           const std::string &mirror_uuid,
+                           journal::MockJournaler *journaler,
+                           librbd::journal::MirrorPeerClientMeta *client_meta,
+                           ContextWQ *work_queue, Context *on_finish,
+                           ProgressContext *progress_ctx = nullptr) {
+    ImageSync *sync = new ImageSync();
+    sync->on_finish = on_finish;
+
+    EXPECT_CALL(*sync, send())
+      .WillRepeatedly(Invoke([sync]() {
+            sync->syncing = true;
+          }));
+
+    return sync;
+  }
+
+  void finish(int r) {
+    on_finish->complete(r);
+    put();
+  }
+
+  void get() {
+    instances.push_back(this);
+  }
+
+  void put() { delete this; }
+
+  MOCK_METHOD0(cancel, void());
+  MOCK_METHOD0(send, void());
+
+};
+
+
+std::vector<MockImageSync *> MockImageSync::instances;
+
+} // namespace mirror
+} // namespace rbd
+
+
+// template definitions
+#include "tools/rbd_mirror/ImageSyncThrottler.cc"
+template class rbd::mirror::ImageSyncThrottler<librbd::MockImageCtx>;
+
+namespace rbd {
+namespace mirror {
+
+class TestMockImageSyncThrottler : public TestMockFixture {
+public:
+  typedef ImageSyncThrottler<librbd::MockImageCtx> MockImageSyncThrottler;
+
+  virtual void SetUp() {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+
+    mock_sync_throttler = new MockImageSyncThrottler();
+
+    m_mock_local_image_ctx = new librbd::MockImageCtx(*m_local_image_ctx);
+    m_mock_remote_image_ctx = new librbd::MockImageCtx(*m_remote_image_ctx);
+    m_mock_journaler = new journal::MockJournaler();
+  }
+
+  virtual void TearDown() {
+    MockImageSync::instances.clear();
+    delete mock_sync_throttler;
+    delete m_mock_local_image_ctx;
+    delete m_mock_remote_image_ctx;
+    delete m_mock_journaler;
+    TestMockFixture::TearDown();
+  }
+
+  void start_sync(const std::string& image_id, Context *ctx) {
+    m_mock_local_image_ctx->id = image_id;
+    mock_sync_throttler->start_sync(m_mock_local_image_ctx,
+                                    m_mock_remote_image_ctx,
+                                    m_threads->timer,
+                                    &m_threads->timer_lock,
+                                    "mirror_uuid",
+                                    m_mock_journaler,
+                                    &m_client_meta,
+                                    m_threads->work_queue,
+                                    ctx);
+  }
+
+  void cancel(const std::string& mirror_uuid, MockImageSync *sync,
+              bool running=true) {
+    if (running) {
+      EXPECT_CALL(*sync, cancel())
+        .WillOnce(Invoke([sync]() {
+              sync->finish(-ECANCELED);
+            }));
+    } else {
+      EXPECT_CALL(*sync, cancel()).Times(0);
+    }
+    mock_sync_throttler->cancel_sync(mirror_uuid);
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+  librbd::MockImageCtx *m_mock_local_image_ctx;
+  librbd::MockImageCtx *m_mock_remote_image_ctx;
+  journal::MockJournaler *m_mock_journaler;
+  librbd::journal::MirrorPeerClientMeta m_client_meta;
+  MockImageSyncThrottler *mock_sync_throttler;
+};
+
+TEST_F(TestMockImageSyncThrottler, Single_Sync) {
+  C_SaferCond ctx;
+  start_sync("image_id", &ctx);
+
+  ASSERT_EQ(1u, MockImageSync::instances.size());
+  MockImageSync *sync = MockImageSync::instances[0];
+  ASSERT_EQ(true, sync->syncing);
+  sync->finish(0);
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Multiple_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+
+  ASSERT_EQ(4u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_FALSE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_FALSE(sync4->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_TRUE(sync3->syncing);
+  sync3->finish(-EINVAL);
+  ASSERT_EQ(-EINVAL, ctx3.wait());
+
+  ASSERT_TRUE(sync4->syncing);
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Running_Sync) {
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  cancel("image_id_2", sync2);
+  ASSERT_EQ(-ECANCELED, ctx2.wait());
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Waiting_Sync) {
+  mock_sync_throttler->set_max_concurrent_syncs(1);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_FALSE(sync2->syncing);
+
+  cancel("image_id_2", sync2, false);
+  ASSERT_EQ(-ECANCELED, ctx2.wait());
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Cancel_Running_Sync_Start_Waiting) {
+  mock_sync_throttler->set_max_concurrent_syncs(1);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+
+  ASSERT_EQ(2u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_FALSE(sync2->syncing);
+
+  cancel("image_id_1", sync1);
+  ASSERT_EQ(-ECANCELED, ctx1.wait());
+
+  ASSERT_TRUE(sync2->syncing);
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Increase_Max_Concurrent_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+  C_SaferCond ctx5;
+  start_sync("image_id_5", &ctx5);
+
+  ASSERT_EQ(5u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_FALSE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_FALSE(sync4->syncing);
+
+  MockImageSync *sync5 = MockImageSync::instances[4];
+  ASSERT_FALSE(sync5->syncing);
+
+  mock_sync_throttler->set_max_concurrent_syncs(4);
+
+  ASSERT_TRUE(sync3->syncing);
+  ASSERT_TRUE(sync4->syncing);
+  ASSERT_FALSE(sync5->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_TRUE(sync5->syncing);
+  sync5->finish(-EINVAL);
+  ASSERT_EQ(-EINVAL, ctx5.wait());
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  sync3->finish(0);
+  ASSERT_EQ(0, ctx3.wait());
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+}
+
+TEST_F(TestMockImageSyncThrottler, Decrease_Max_Concurrent_Syncs) {
+  mock_sync_throttler->set_max_concurrent_syncs(4);
+
+  C_SaferCond ctx1;
+  start_sync("image_id_1", &ctx1);
+  C_SaferCond ctx2;
+  start_sync("image_id_2", &ctx2);
+  C_SaferCond ctx3;
+  start_sync("image_id_3", &ctx3);
+  C_SaferCond ctx4;
+  start_sync("image_id_4", &ctx4);
+  C_SaferCond ctx5;
+  start_sync("image_id_5", &ctx5);
+
+  ASSERT_EQ(5u, MockImageSync::instances.size());
+
+  MockImageSync *sync1 = MockImageSync::instances[0];
+  ASSERT_TRUE(sync1->syncing);
+
+  MockImageSync *sync2 = MockImageSync::instances[1];
+  ASSERT_TRUE(sync2->syncing);
+
+  MockImageSync *sync3 = MockImageSync::instances[2];
+  ASSERT_TRUE(sync3->syncing);
+
+  MockImageSync *sync4 = MockImageSync::instances[3];
+  ASSERT_TRUE(sync4->syncing);
+
+  MockImageSync *sync5 = MockImageSync::instances[4];
+  ASSERT_FALSE(sync5->syncing);
+
+  mock_sync_throttler->set_max_concurrent_syncs(2);
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync1->finish(0);
+  ASSERT_EQ(0, ctx1.wait());
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync2->finish(0);
+  ASSERT_EQ(0, ctx2.wait());
+
+  ASSERT_FALSE(sync5->syncing);
+
+  sync3->finish(0);
+  ASSERT_EQ(0, ctx3.wait());
+
+  ASSERT_TRUE(sync5->syncing);
+
+  sync4->finish(0);
+  ASSERT_EQ(0, ctx4.wait());
+
+  sync5->finish(0);
+  ASSERT_EQ(0, ctx5.wait());
+}
+
+
+} // namespace mirror
+} // namespace rbd
+

--- a/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSyncThrottler.cc
@@ -159,7 +159,7 @@ public:
     } else {
       EXPECT_CALL(*sync, cancel()).Times(0);
     }
-    mock_sync_throttler->cancel_sync(mirror_uuid);
+    mock_sync_throttler->cancel_sync(m_local_io_ctx, mirror_uuid);
   }
 
   librbd::ImageCtx *m_remote_image_ctx;

--- a/src/tools/Makefile-client.am
+++ b/src/tools/Makefile-client.am
@@ -92,6 +92,7 @@ librbd_mirror_internal_la_SOURCES = \
 	tools/rbd_mirror/ClusterWatcher.cc \
 	tools/rbd_mirror/ImageReplayer.cc \
 	tools/rbd_mirror/ImageSync.cc \
+        tools/rbd_mirror/ImageSyncThrottler.cc \
 	tools/rbd_mirror/Mirror.cc \
 	tools/rbd_mirror/PoolWatcher.cc \
 	tools/rbd_mirror/Replayer.cc \
@@ -116,6 +117,7 @@ noinst_HEADERS += \
 	tools/rbd_mirror/ClusterWatcher.h \
 	tools/rbd_mirror/ImageReplayer.h \
 	tools/rbd_mirror/ImageSync.h \
+	tools/rbd_mirror/ImageSyncThrottler.h \
 	tools/rbd_mirror/Mirror.h \
 	tools/rbd_mirror/PoolWatcher.h \
 	tools/rbd_mirror/ProgressContext.h \

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -229,6 +229,9 @@ void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
     return;
   }
 
+  if ((*del_info)->on_delete != nullptr) {
+    (*del_info)->on_delete->complete(-ESTALE);
+  }
   (*del_info)->on_delete = ctx;
   (*del_info)->notify_on_failed_retry = notify_on_failed_retry;
 }

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -236,6 +236,19 @@ void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
   (*del_info)->notify_on_failed_retry = notify_on_failed_retry;
 }
 
+void ImageDeleter::cancel_waiter(const std::string& image_name) {
+  Mutex::Locker locker(m_delete_lock);
+  auto del_info = find_delete_info(image_name);
+  if (!del_info) {
+    return;
+  }
+
+  if ((*del_info)->on_delete != nullptr) {
+    (*del_info)->on_delete->complete(-ECANCELED);
+    (*del_info)->on_delete = nullptr;
+  }
+}
+
 bool ImageDeleter::process_image_delete() {
 
   stringstream ss;

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -21,6 +21,7 @@
 #include "common/admin_socket.h"
 #include "common/debug.h"
 #include "common/errno.h"
+#include "common/WorkQueue.h"
 #include "librbd/internal.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/ImageState.h"
@@ -126,10 +127,11 @@ private:
   Commands commands;
 };
 
-ImageDeleter::ImageDeleter(RadosRef local_cluster, SafeTimer *timer,
-                           Mutex *timer_lock)
+ImageDeleter::ImageDeleter(RadosRef local_cluster, ContextWQ *work_queue,
+                           SafeTimer *timer, Mutex *timer_lock)
   : m_local(local_cluster),
     m_running(1),
+    m_work_queue(work_queue),
     m_delete_lock("rbd::mirror::ImageDeleter::Delete"),
     m_image_deleter_thread(this),
     m_failed_timer(timer),
@@ -214,19 +216,21 @@ void ImageDeleter::schedule_image_delete(uint64_t local_pool_id,
 void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
                                                Context *ctx,
                                                bool notify_on_failed_retry) {
-  {
-    Mutex::Locker l(m_delete_lock);
 
-    auto del_info = find_delete_info(image_name);
-    if (del_info) {
-      (*del_info)->on_delete = ctx;
-      (*del_info)->notify_on_failed_retry = notify_on_failed_retry;
-      return;
-    }
+  ctx = new FunctionContext([this, ctx](int r) {
+      m_work_queue->queue(ctx, r);
+    });
+
+  Mutex::Locker l(m_delete_lock);
+  auto del_info = find_delete_info(image_name);
+  if (!del_info) {
+    // image not scheduled for deletion
+    ctx->complete(0);
+    return;
   }
 
-  // image not scheduled for deletion
-  ctx->complete(0);
+  (*del_info)->on_delete = ctx;
+  (*del_info)->notify_on_failed_retry = notify_on_failed_retry;
 }
 
 bool ImageDeleter::process_image_delete() {
@@ -510,8 +514,10 @@ void ImageDeleter::print_status(Formatter *f, stringstream *ss) {
 void ImageDeleter::DeleteInfo::notify(int r) {
   if (on_delete) {
     dout(20) << "executing image deletion handler r=" << r << dendl;
-    on_delete->complete(r);
+
+    Context *ctx = on_delete;
     on_delete = nullptr;
+    ctx->complete(r);
   }
 }
 

--- a/src/tools/rbd_mirror/ImageDeleter.h
+++ b/src/tools/rbd_mirror/ImageDeleter.h
@@ -51,6 +51,7 @@ public:
   void wait_for_scheduled_deletion(const std::string& image_name,
                                    Context *ctx,
                                    bool notify_on_failed_retry=true);
+  void cancel_waiter(const std::string& image_name);
 
   void print_status(Formatter *f, std::stringstream *ss);
 

--- a/src/tools/rbd_mirror/ImageDeleter.h
+++ b/src/tools/rbd_mirror/ImageDeleter.h
@@ -24,6 +24,8 @@
 #include "common/Timer.h"
 #include "types.h"
 
+class ContextWQ;
+
 namespace rbd {
 namespace mirror {
 
@@ -36,7 +38,8 @@ class ImageDeleter {
 public:
   static const int EISPRM = 1000;
 
-  ImageDeleter(RadosRef local_cluster, SafeTimer *timer, Mutex *timer_lock);
+  ImageDeleter(RadosRef local_cluster, ContextWQ *work_queue,
+               SafeTimer *timer, Mutex *timer_lock);
   ~ImageDeleter();
   ImageDeleter(const ImageDeleter&) = delete;
   ImageDeleter& operator=(const ImageDeleter&) = delete;
@@ -99,6 +102,8 @@ private:
 
   RadosRef m_local;
   atomic_t m_running;
+
+  ContextWQ *m_work_queue;
 
   std::deque<std::unique_ptr<DeleteInfo> > m_delete_queue;
   Mutex m_delete_lock;

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -32,6 +32,7 @@
 using std::map;
 using std::string;
 using std::unique_ptr;
+using std::shared_ptr;
 using std::vector;
 
 namespace rbd {
@@ -220,6 +221,19 @@ private:
   Commands commands;
 };
 
+template <typename I>
+struct ResyncListener : public librbd::journal::ResyncListener {
+  ImageReplayer<I> *img_replayer;
+
+  ResyncListener(ImageReplayer<I> *img_replayer)
+    : img_replayer(img_replayer) {
+  }
+
+  virtual void handle_resync() {
+    img_replayer->resync_image();
+  }
+};
+
 } // anonymous namespace
 
 template <typename I>
@@ -234,7 +248,9 @@ void ImageReplayer<I>::BootstrapProgressContext::update_progress(
 }
 
 template <typename I>
-ImageReplayer<I>::ImageReplayer(Threads *threads, RadosRef local, RadosRef remote,
+ImageReplayer<I>::ImageReplayer(Threads *threads,
+                             shared_ptr<ImageDeleter> image_deleter,
+                             RadosRef local, RadosRef remote,
 			     const std::string &local_mirror_uuid,
 			     const std::string &remote_mirror_uuid,
 			     int64_t local_pool_id,
@@ -242,6 +258,7 @@ ImageReplayer<I>::ImageReplayer(Threads *threads, RadosRef local, RadosRef remot
 			     const std::string &remote_image_id,
                              const std::string &global_image_id) :
   m_threads(threads),
+  m_image_deleter(image_deleter),
   m_local(local),
   m_remote(remote),
   m_local_mirror_uuid(local_mirror_uuid),
@@ -253,7 +270,8 @@ ImageReplayer<I>::ImageReplayer(Threads *threads, RadosRef local, RadosRef remot
   m_name(stringify(remote_pool_id) + "/" + remote_image_id),
   m_lock("rbd::mirror::ImageReplayer " + stringify(remote_pool_id) + " " +
 	 remote_image_id),
-  m_progress_cxt(this)
+  m_progress_cxt(this),
+  m_resync_listener(new ResyncListener<I>(this))
 {
   // Register asok commands using a temporary "remote_pool_name/global_image_id"
   // name.  When the image name becomes known on start the asok commands will be
@@ -284,6 +302,8 @@ ImageReplayer<I>::~ImageReplayer()
   assert(m_on_stop_finish == nullptr);
   assert(m_bootstrap_request == nullptr);
   assert(m_in_flight_status_updates == 0);
+
+  delete m_resync_listener;
   delete m_asok_hook;
 }
 
@@ -417,6 +437,24 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
   {
     Mutex::Locker locker(m_lock);
 
+    m_local_image_ctx->journal->add_listener(
+                                    librbd::journal::ListenerType::RESYNC,
+                                    m_resync_listener);
+
+    bool do_resync = false;
+    r = m_local_image_ctx->journal->check_resync_requested(&do_resync);
+    if (r < 0) {
+      derr << "failed to check if a resync was requested" << dendl;
+    }
+
+    if (do_resync) {
+      Context *on_finish = m_on_start_finish;
+      FunctionContext *ctx = new FunctionContext([this, on_finish](int r) {
+          resync_image(on_finish);
+        });
+      m_on_start_finish = ctx;
+    }
+
     std::string name = m_local_ioctx.get_pool_name() + "/" +
       m_local_image_ctx->name;
     if (m_name != name) {
@@ -517,6 +555,10 @@ void ImageReplayer<I>::handle_start_replay(int r) {
     on_finish->complete(r);
   }
 
+  if (on_replay_interrupted()) {
+    return;
+  }
+
   {
     Mutex::Locker locker(m_lock);
     m_replay_handler = new ReplayHandler<I>(this);
@@ -526,7 +568,6 @@ void ImageReplayer<I>::handle_start_replay(int r) {
     dout(20) << "m_remote_journaler=" << *m_remote_journaler << dendl;
   }
 
-  on_replay_interrupted();
 }
 
 template <typename I>
@@ -603,10 +644,10 @@ void ImageReplayer<I>::stop(Context *on_finish, bool manual)
 	  shut_down_replay = true;
 	}
 
-	assert(m_on_stop_finish == nullptr);
-	std::swap(m_on_stop_finish, on_finish);
-	m_stop_requested = true;
-	m_manual_stop = manual;
+        assert(m_on_stop_finish == nullptr);
+        std::swap(m_on_stop_finish, on_finish);
+        m_stop_requested = true;
+        m_manual_stop = manual;
       }
     }
   }
@@ -980,7 +1021,9 @@ void ImageReplayer<I>::handle_process_entry_safe(const ReplayEntry& replay_entry
     return;
   }
 
-  m_remote_journaler->committed(replay_entry);
+  if (m_remote_journaler) {
+    m_remote_journaler->committed(replay_entry);
+  }
 }
 
 template <typename I>
@@ -1244,6 +1287,11 @@ void ImageReplayer<I>::shut_down(int r, Context *on_start) {
     ctx = new FunctionContext([this, ctx](int r) {
         m_remote_journaler->shut_down(ctx);
       });
+    if (m_stopping_for_resync) {
+      ctx = new FunctionContext([this, ctx](int r) {
+          m_remote_journaler->unregister_client(ctx);
+        });
+    }
   }
   if (m_local_replay != nullptr) {
     ctx = new FunctionContext([this, ctx](int r) {
@@ -1256,6 +1304,8 @@ void ImageReplayer<I>::shut_down(int r, Context *on_start) {
         ctx->complete(0);
       });
     ctx = new FunctionContext([this, ctx](int r) {
+        m_local_image_ctx->journal->remove_listener(
+            librbd::journal::ListenerType::RESYNC, m_resync_listener);
         m_local_replay->shut_down(true, ctx);
       });
   }
@@ -1289,6 +1339,23 @@ void ImageReplayer<I>::handle_shut_down(int r, Context *on_start) {
         [this, r, on_start](int _r) {
           handle_shut_down(r, on_start);
         });
+      return;
+    }
+
+    if (m_stopping_for_resync) {
+      m_image_deleter->schedule_image_delete(m_local_pool_id,
+                                             m_local_image_id,
+                                             m_local_image_name,
+                                             m_global_image_id);
+      m_stopping_for_resync = false;
+
+      FunctionContext *ctx = new FunctionContext(
+          [this, r, on_start] (int r) {
+            handle_shut_down(r, on_start);
+          }
+      );
+      m_image_deleter->wait_for_scheduled_deletion(m_local_image_name,
+                                                   ctx, false);
       return;
     }
 
@@ -1335,6 +1402,18 @@ std::string ImageReplayer<I>::to_string(const State state) {
     break;
   }
   return "Unknown(" + stringify(state) + ")";
+}
+
+template <typename I>
+void ImageReplayer<I>::resync_image(Context *on_finish) {
+  dout(20) << dendl;
+
+  {
+    Mutex::Locker l(m_lock);
+    m_stopping_for_resync = true;
+  }
+
+  stop(on_finish);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1350,15 +1350,6 @@ void ImageReplayer<I>::handle_shut_down(int r, Context *on_start) {
                                              m_local_image_name,
                                              m_global_image_id);
       m_stopping_for_resync = false;
-
-      FunctionContext *ctx = new FunctionContext(
-          [this, r, on_start] (int r) {
-            handle_shut_down(r, on_start);
-          }
-      );
-      m_image_deleter->wait_for_scheduled_deletion(m_local_image_name,
-                                                   ctx, false);
-      return;
     }
 
     std::swap(on_stop, m_on_stop_finish);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1304,7 +1304,7 @@ void ImageReplayer<I>::shut_down(int r, Context *on_start) {
         ctx->complete(0);
       });
     ctx = new FunctionContext([this, ctx](int r) {
-        m_local_image_ctx->journal->remove_listener(
+        m_local_journal->remove_listener(
             librbd::journal::ListenerType::RESYNC, m_resync_listener);
         m_local_replay->shut_down(true, ctx);
       });

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -77,6 +77,7 @@ public:
   };
 
   ImageReplayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+                ImageSyncThrottlerRef<ImageCtxT> image_sync_throttler,
                 RadosRef local, RadosRef remote,
                 const std::string &local_mirror_uuid,
                 const std::string &remote_mirror_uuid, int64_t local_pool_id,
@@ -223,6 +224,7 @@ private:
 
   Threads *m_threads;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<ImageCtxT> m_image_sync_throttler;
   RadosRef m_local, m_remote;
   std::string m_local_mirror_uuid;
   std::string m_remote_mirror_uuid;

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -18,6 +18,7 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/journal/Types.h"
 #include "librbd/journal/TypeTraits.h"
+#include "ImageDeleter.h"
 #include "ProgressContext.h"
 #include "types.h"
 #include <boost/optional.hpp>
@@ -75,8 +76,9 @@ public:
     }
   };
 
-  ImageReplayer(Threads *threads, RadosRef local, RadosRef remote,
-		const std::string &local_mirror_uuid,
+  ImageReplayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+                RadosRef local, RadosRef remote,
+                const std::string &local_mirror_uuid,
                 const std::string &remote_mirror_uuid, int64_t local_pool_id,
 		int64_t remote_pool_id, const std::string &remote_image_id,
                 const std::string &global_image_id);
@@ -87,6 +89,7 @@ public:
   State get_state() { Mutex::Locker l(m_lock); return get_state_(); }
   bool is_stopped() { Mutex::Locker l(m_lock); return is_stopped_(); }
   bool is_running() { Mutex::Locker l(m_lock); return is_running_(); }
+  bool is_replaying() { Mutex::Locker l(m_lock); return is_replaying_(); }
 
   std::string get_name() { Mutex::Locker l(m_lock); return m_name; };
   void set_state_description(int r, const std::string &desc);
@@ -118,6 +121,8 @@ public:
   void stop(Context *on_finish = nullptr, bool manual = false);
   void restart(Context *on_finish = nullptr);
   void flush(Context *on_finish = nullptr);
+
+  void resync_image(Context *on_finish=nullptr);
 
   void print_status(Formatter *f, stringstream *ss);
 
@@ -217,6 +222,7 @@ private:
   };
 
   Threads *m_threads;
+  std::shared_ptr<ImageDeleter> m_image_deleter;
   RadosRef m_local, m_remote;
   std::string m_local_mirror_uuid;
   std::string m_remote_mirror_uuid;
@@ -238,6 +244,8 @@ private:
   librbd::journal::Replay<ImageCtxT> *m_local_replay = nullptr;
   Journaler* m_remote_journaler = nullptr;
   ::journal::ReplayHandler *m_replay_handler = nullptr;
+  librbd::journal::ResyncListener *m_resync_listener;
+  bool m_stopping_for_resync = false;
 
   Context *m_on_start_finish = nullptr;
   Context *m_on_stop_finish = nullptr;
@@ -286,6 +294,9 @@ private:
   }
   bool is_running_() const {
     return !is_stopped_() && m_state != STATE_STOPPING && !m_stop_requested;
+  }
+  bool is_replaying_() const {
+    return m_state == STATE_REPLAYING;
   }
 
   bool update_mirror_image_status(bool force, const OptionalState &state);

--- a/src/tools/rbd_mirror/ImageSync.cc
+++ b/src/tools/rbd_mirror/ImageSync.cc
@@ -73,13 +73,16 @@ template <typename I>
 void ImageSync<I>::send_prune_catch_up_sync_point() {
   update_progress("PRUNE_CATCH_UP_SYNC_POINT");
 
-  if (m_client_meta->sync_points.size() <= 1) {
+  if (m_client_meta->sync_points.empty()) {
     send_create_sync_point();
     return;
   }
 
   dout(20) << dendl;
 
+  // prune will remove sync points with missing snapshots and
+  // ensure we have a maximum of one sync point (in case we
+  // restarted)
   Context *ctx = create_context_callback<
     ImageSync<I>, &ImageSync<I>::handle_prune_catch_up_sync_point>(this);
   SyncPointPruneRequest<I> *request = SyncPointPruneRequest<I>::create(

--- a/src/tools/rbd_mirror/ImageSyncThrottler.cc
+++ b/src/tools/rbd_mirror/ImageSyncThrottler.cc
@@ -1,0 +1,243 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "ImageSyncThrottler.h"
+#include "ImageSync.h"
+#include "common/ceph_context.h"
+
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::ImageSyncThrottler:: " << this \
+                           << " " << __func__ << ": "
+using std::unique_ptr;
+using std::string;
+using std::set;
+
+namespace rbd {
+namespace mirror {
+
+template <typename I>
+ImageSyncThrottler<I>::ImageSyncThrottler()
+  : m_max_concurrent_syncs(g_ceph_context->_conf->rbd_mirror_concurrent_image_syncs),
+    m_lock("rbd::mirror::ImageSyncThrottler")
+{
+  dout(20) << "Initialized max_concurrent_syncs=" << m_max_concurrent_syncs
+           << dendl;
+  g_ceph_context->_conf->add_observer(this);
+}
+
+template <typename I>
+ImageSyncThrottler<I>::~ImageSyncThrottler() {
+  {
+    Mutex::Locker l(m_lock);
+    assert(m_sync_queue.empty());
+    assert(m_inflight_syncs.empty());
+  }
+
+  g_ceph_context->_conf->remove_observer(this);
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::start_sync(
+                            I *local_image_ctx, I *remote_image_ctx,
+                            SafeTimer *timer, Mutex *timer_lock,
+                            const std::string &mirror_uuid,
+                            Journaler *journaler,
+                            MirrorPeerClientMeta *client_meta,
+                            ContextWQ *work_queue, Context *on_finish,
+                            ProgressContext *progress_ctx) {
+  dout(20) << dendl;
+
+  C_SyncHolder *sync_holder_ctx = new C_SyncHolder(this, local_image_ctx->id,
+                                                   on_finish);
+  sync_holder_ctx->m_sync = ImageSync<I>::create(local_image_ctx,
+                                         remote_image_ctx, timer,
+                                         timer_lock, mirror_uuid,
+                                         journaler, client_meta,
+                                         work_queue, sync_holder_ctx,
+	                                 progress_ctx);
+  sync_holder_ctx->m_sync->get();
+
+  bool start = false;
+  {
+    Mutex::Locker l(m_lock);
+
+    if (m_inflight_syncs.size() < m_max_concurrent_syncs) {
+      m_inflight_syncs.insert(std::make_pair(local_image_ctx->id,
+                                             sync_holder_ctx));
+      start = true;
+      dout(10) << "ready to start image sync for local_image_id "
+               << local_image_ctx->id << " [" << m_inflight_syncs.size() << "/"
+               << m_max_concurrent_syncs << "]" << dendl;
+    } else {
+      m_sync_queue.push_front(sync_holder_ctx);
+      dout(10) << "image sync for local_image_id " << local_image_ctx->id
+               << " has been queued" << dendl;
+    }
+  }
+
+  if (start) {
+      sync_holder_ctx->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::cancel_sync(const std::string& local_image_id) {
+  dout(20) << dendl;
+
+  C_SyncHolder *sync_holder = nullptr;
+  bool running_sync = true;
+
+  {
+    Mutex::Locker l(m_lock);
+
+    if (m_inflight_syncs.empty()) {
+      // no image sync currently running and neither waiting
+      return;
+    }
+
+    auto it = m_inflight_syncs.find(local_image_id);
+    if (it != m_inflight_syncs.end()) {
+      sync_holder = it->second;
+    }
+
+    if (!sync_holder) {
+      for (auto it=m_sync_queue.begin(); it != m_sync_queue.end(); ++it) {
+        if ((*it)->m_local_image_id == local_image_id) {
+          sync_holder = (*it);
+          m_sync_queue.erase(it);
+          running_sync = false;
+          break;
+        }
+      }
+    }
+  }
+
+  if (sync_holder) {
+    if (running_sync) {
+      dout(10) << "canceled running image sync for local_image_id "
+               << sync_holder->m_local_image_id << dendl;
+      sync_holder->m_sync->cancel();
+    } else {
+      dout(10) << "canceled waiting image sync for local_image_id "
+               << sync_holder->m_local_image_id << dendl;
+      sync_holder->m_on_finish->complete(-ECANCELED);
+      sync_holder->m_sync->put();
+      delete sync_holder;
+    }
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::handle_sync_finished(C_SyncHolder *sync_holder) {
+  dout(20) << dendl;
+
+  C_SyncHolder *next_sync_holder = nullptr;
+
+  {
+    Mutex::Locker l(m_lock);
+
+    m_inflight_syncs.erase(sync_holder->m_local_image_id);
+
+    if (m_inflight_syncs.size() < m_max_concurrent_syncs
+        && !m_sync_queue.empty()) {
+      next_sync_holder = m_sync_queue.back();
+      m_sync_queue.pop_back();
+      m_inflight_syncs.insert(std::make_pair(next_sync_holder->m_local_image_id,
+                                             next_sync_holder));
+      dout(10) << "ready to start image sync for local_image_id "
+               << next_sync_holder->m_local_image_id
+               << " [" << m_inflight_syncs.size() << "/"
+               << m_max_concurrent_syncs << "]" << dendl;
+    }
+
+    dout(10) << "currently running image syncs [" << m_inflight_syncs.size()
+             << "/" << m_max_concurrent_syncs << "]" << dendl;
+  }
+
+  if (next_sync_holder) {
+    next_sync_holder->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::set_max_concurrent_syncs(uint32_t max) {
+  dout(20) << " max=" << max << dendl;
+
+  assert(max > 0);
+
+  std::list<C_SyncHolder *> next_sync_holders;
+  {
+    Mutex::Locker l(m_lock);
+    this->m_max_concurrent_syncs = max;
+
+    // Start waiting syncs in the case of available free slots
+    while(m_inflight_syncs.size() < m_max_concurrent_syncs
+          && !m_sync_queue.empty()) {
+        C_SyncHolder *next_sync_holder = m_sync_queue.back();
+        next_sync_holders.push_back(next_sync_holder);
+        m_sync_queue.pop_back();
+        m_inflight_syncs.insert(std::make_pair(next_sync_holder->m_local_image_id,
+                                               next_sync_holder));
+        dout(10) << "ready to start image sync for local_image_id "
+                 << next_sync_holder->m_local_image_id
+                 << " [" << m_inflight_syncs.size() << "/"
+                 << m_max_concurrent_syncs << "]" << dendl;
+    }
+  }
+
+  for (const auto& sync_holder : next_sync_holders) {
+    sync_holder->m_sync->send();
+  }
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::print_status(Formatter *f, stringstream *ss) {
+  Mutex::Locker l(m_lock);
+
+  if (f) {
+    f->dump_int("max_parallel_syncs", m_max_concurrent_syncs);
+    f->dump_int("running_syncs", m_inflight_syncs.size());
+    f->dump_int("waiting_syncs", m_sync_queue.size());
+    f->flush(*ss);
+  } else {
+    *ss << "[ ";
+    *ss << "max_parallel_syncs=" << m_max_concurrent_syncs << ", ";
+    *ss << "running_syncs=" << m_inflight_syncs.size() << ", ";
+    *ss << "waiting_syncs=" << m_sync_queue.size() << " ]";
+  }
+}
+
+template <typename I>
+const char** ImageSyncThrottler<I>::get_tracked_conf_keys() const {
+  static const char* KEYS[] = {
+    "rbd_mirror_concurrent_image_syncs",
+    NULL
+  };
+  return KEYS;
+}
+
+template <typename I>
+void ImageSyncThrottler<I>::handle_conf_change(
+                                              const struct md_config_t *conf,
+                                              const set<string> &changed) {
+  if (changed.count("rbd_mirror_concurrent_image_syncs")) {
+    set_max_concurrent_syncs(conf->rbd_mirror_concurrent_image_syncs);
+  }
+}
+
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::ImageSyncThrottler<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/ImageSyncThrottler.h
+++ b/src/tools/rbd_mirror/ImageSyncThrottler.h
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H
+#define CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H
+
+#include <list>
+#include <map>
+#include "common/Mutex.h"
+#include "librbd/ImageCtx.h"
+#include "include/Context.h"
+#include "librbd/journal/TypeTraits.h"
+
+class CephContext;
+class Context;
+class ContextWQ;
+class SafeTimer;
+namespace journal { class Journaler; }
+namespace librbd { namespace journal { struct MirrorPeerClientMeta; } }
+
+namespace rbd {
+namespace mirror {
+
+template <typename> class ImageSync;
+
+class ProgressContext;
+
+/**
+ * Manage concurrent image-syncs
+ */
+template <typename ImageCtxT = librbd::ImageCtx>
+class ImageSyncThrottler : public md_config_obs_t {
+public:
+
+  typedef librbd::journal::TypeTraits<ImageCtxT> TypeTraits;
+  typedef typename TypeTraits::Journaler Journaler;
+  typedef librbd::journal::MirrorPeerClientMeta MirrorPeerClientMeta;
+
+  ImageSyncThrottler();
+  ~ImageSyncThrottler();
+  ImageSyncThrottler(const ImageSyncThrottler&) = delete;
+  ImageSyncThrottler& operator=(const ImageSyncThrottler&) = delete;
+
+  void start_sync(ImageCtxT *local_image_ctx,
+                  ImageCtxT *remote_image_ctx, SafeTimer *timer,
+                  Mutex *timer_lock, const std::string &mirror_uuid,
+                  Journaler *journaler, MirrorPeerClientMeta *client_meta,
+                  ContextWQ *work_queue, Context *on_finish,
+                  ProgressContext *progress_ctx = nullptr);
+
+  void cancel_sync(const std::string& mirror_uuid);
+
+  void set_max_concurrent_syncs(uint32_t max);
+
+  void print_status(Formatter *f, std::stringstream *ss);
+
+private:
+
+  struct C_SyncHolder : public Context {
+    ImageSyncThrottler<ImageCtxT> *m_sync_throttler;
+    std::string m_local_image_id;
+    ImageSync<ImageCtxT> *m_sync;
+    Context *m_on_finish;
+
+    C_SyncHolder(ImageSyncThrottler<ImageCtxT> *sync_throttler,
+                 const std::string& local_image_id, Context *on_finish)
+      : m_sync_throttler(sync_throttler), m_local_image_id(local_image_id),
+        m_sync(nullptr), m_on_finish(on_finish) {}
+
+    virtual void finish(int r) {
+      m_sync_throttler->handle_sync_finished(this);
+      m_on_finish->complete(r);
+    }
+  };
+
+  void handle_sync_finished(C_SyncHolder *sync_holder);
+
+  const char **get_tracked_conf_keys() const;
+  void handle_conf_change(const struct md_config_t *conf,
+                          const std::set<std::string> &changed);
+
+  uint32_t m_max_concurrent_syncs;
+  Mutex m_lock;
+  std::list<C_SyncHolder *> m_sync_queue;
+  std::map<std::string, C_SyncHolder *> m_inflight_syncs;
+
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_IMAGE_SYNC_THROTTLER_H

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -9,6 +9,7 @@
 #include "common/errno.h"
 #include "Mirror.h"
 #include "Threads.h"
+#include "ImageSync.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -220,6 +221,8 @@ int Mirror::init()
   m_image_deleter.reset(new ImageDeleter(m_local, m_threads->timer,
                                          &m_threads->timer_lock));
 
+  m_image_sync_throttler.reset(new ImageSyncThrottler<>());
+
   return r;
 }
 
@@ -264,6 +267,13 @@ void Mirror::print_status(Formatter *f, stringstream *ss)
   }
 
   m_image_deleter->print_status(f, ss);
+
+  if (f) {
+    f->close_section();
+    f->open_object_section("sync_throttler");
+  }
+
+  m_image_sync_throttler->print_status(f, ss);
 
   if (f) {
     f->close_section();
@@ -363,6 +373,7 @@ void Mirror::update_replayers(const PoolPeers &pool_peers)
       if (m_replayers.find(pool_peer) == m_replayers.end()) {
         dout(20) << "starting replayer for " << peer << dendl;
         unique_ptr<Replayer> replayer(new Replayer(m_threads, m_image_deleter,
+                                                   m_image_sync_throttler,
                                                    m_local, kv.first, peer,
                                                    m_args));
         // TODO: make async, and retry connecting within replayer

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -218,7 +218,8 @@ int Mirror::init()
   // TODO: make interval configurable
   m_local_cluster_watcher.reset(new ClusterWatcher(m_local, m_lock));
 
-  m_image_deleter.reset(new ImageDeleter(m_local, m_threads->timer,
+  m_image_deleter.reset(new ImageDeleter(m_local, m_threads->work_queue,
+                                         m_threads->timer,
                                          &m_threads->timer_lock));
 
   m_image_sync_throttler.reset(new ImageSyncThrottler<>());

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -62,6 +62,7 @@ private:
   // monitor local cluster for config changes in peers
   std::unique_ptr<ClusterWatcher> m_local_cluster_watcher;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<> m_image_sync_throttler;
   std::map<PoolPeer, std::unique_ptr<Replayer> > m_replayers;
   atomic_t m_stopping;
   bool m_manual_stop = false;

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -709,6 +709,7 @@ bool Replayer::stop_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer)
   dout(20) << "global_image_id=" << image_replayer->get_global_image_id()
            << dendl;
 
+  // TODO: check how long it is stopping and alert if it is too long.
   if (image_replayer->is_stopped()) {
     m_image_deleter->cancel_waiter(image_replayer->get_local_image_name());
     if (!m_stopping.read()) {
@@ -720,9 +721,7 @@ bool Replayer::stop_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer)
         image_replayer->get_global_image_id());
     }
     return true;
-  }
-
-  if (image_replayer->is_running()) {
+  } else {
     if (!m_stopping.read()) {
       dout(20) << "scheduling delete after image replayer stopped" << dendl;
     }
@@ -738,8 +737,6 @@ bool Replayer::stop_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer)
         }
     );
     image_replayer->stop(ctx);
-  } else {
-    // TODO: checkhow long it is stopping and alert if it is too long.
   }
 
   return false;

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -611,8 +611,9 @@ void Replayer::set_sources(const ImageIds &image_ids)
     auto it = m_image_replayers.find(image_id.id);
     if (it == m_image_replayers.end()) {
       unique_ptr<ImageReplayer<> > image_replayer(new ImageReplayer<>(
-        m_threads, m_local, m_remote, local_mirror_uuid, remote_mirror_uuid,
-        m_local_pool_id, m_remote_pool_id, image_id.id, image_id.global_id));
+        m_threads, m_image_deleter, m_local, m_remote, local_mirror_uuid,
+        remote_mirror_uuid, m_local_pool_id, m_remote_pool_id, image_id.id,
+        image_id.global_id));
       it = m_image_replayers.insert(
         std::make_pair(image_id.id, std::move(image_replayer))).first;
     }

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -681,6 +681,10 @@ void Replayer::start_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer
   if (image_name) {
     FunctionContext *ctx = new FunctionContext(
         [&] (int r) {
+          if (r == -ESTALE) {
+            return;
+          }
+
           if (r >= 0) {
             image_replayer->start();
           } else {

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -229,10 +229,12 @@ private:
 };
 
 Replayer::Replayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+                   ImageSyncThrottlerRef<> image_sync_throttler,
                    RadosRef local_cluster, int64_t local_pool_id,
                    const peer_t &peer, const std::vector<const char*> &args) :
   m_threads(threads),
   m_image_deleter(image_deleter),
+  m_image_sync_throttler(image_sync_throttler),
   m_lock(stringify("rbd::mirror::Replayer ") + stringify(peer)),
   m_peer(peer),
   m_args(args),
@@ -611,9 +613,9 @@ void Replayer::set_sources(const ImageIds &image_ids)
     auto it = m_image_replayers.find(image_id.id);
     if (it == m_image_replayers.end()) {
       unique_ptr<ImageReplayer<> > image_replayer(new ImageReplayer<>(
-        m_threads, m_image_deleter, m_local, m_remote, local_mirror_uuid,
-        remote_mirror_uuid, m_local_pool_id, m_remote_pool_id, image_id.id,
-        image_id.global_id));
+        m_threads, m_image_deleter, m_image_sync_throttler, m_local, m_remote,
+        local_mirror_uuid, remote_mirror_uuid, m_local_pool_id,
+        m_remote_pool_id, image_id.id, image_id.global_id));
       it = m_image_replayers.insert(
         std::make_pair(image_id.id, std::move(image_replayer))).first;
     }

--- a/src/tools/rbd_mirror/Replayer.h
+++ b/src/tools/rbd_mirror/Replayer.h
@@ -58,6 +58,7 @@ private:
   void set_sources(const ImageIds &image_ids);
 
   void start_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer,
+                            const std::string &image_id,
                             const boost::optional<std::string>& image_name);
   bool stop_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer);
 

--- a/src/tools/rbd_mirror/Replayer.h
+++ b/src/tools/rbd_mirror/Replayer.h
@@ -34,6 +34,7 @@ class MirrorStatusWatchCtx;
 class Replayer {
 public:
   Replayer(Threads *threads, std::shared_ptr<ImageDeleter> image_deleter,
+           ImageSyncThrottlerRef<> image_sync_throttler,
            RadosRef local_cluster, int64_t local_pool_id, const peer_t &peer,
            const std::vector<const char*> &args);
   ~Replayer();
@@ -65,6 +66,7 @@ private:
 
   Threads *m_threads;
   std::shared_ptr<ImageDeleter> m_image_deleter;
+  ImageSyncThrottlerRef<> m_image_sync_throttler;
   Mutex m_lock;
   Cond m_cond;
   atomic_t m_stopping;

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -82,7 +82,7 @@ void BootstrapRequest<I>::cancel() {
   Mutex::Locker locker(m_lock);
   m_canceled = true;
 
-  m_image_sync_throttler->cancel_sync(m_local_image_id);
+  m_image_sync_throttler->cancel_sync(m_local_io_ctx, m_local_image_id);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -20,6 +20,7 @@
 #include "librbd/journal/Types.h"
 #include "tools/rbd_mirror/ImageSync.h"
 #include "tools/rbd_mirror/ProgressContext.h"
+#include "tools/rbd_mirror/ImageSyncThrottler.h"
 
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
@@ -35,23 +36,26 @@ using librbd::util::create_rados_ack_callback;
 using librbd::util::unique_lock_name;
 
 template <typename I>
-BootstrapRequest<I>::BootstrapRequest(librados::IoCtx &local_io_ctx,
-                                      librados::IoCtx &remote_io_ctx,
-                                      I **local_image_ctx,
-                                      const std::string &local_image_name,
-                                      const std::string &remote_image_id,
-                                      const std::string &global_image_id,
-                                      ContextWQ *work_queue, SafeTimer *timer,
-                                      Mutex *timer_lock,
-                                      const std::string &local_mirror_uuid,
-                                      const std::string &remote_mirror_uuid,
-                                      Journaler *journaler,
-                                      MirrorPeerClientMeta *client_meta,
-                                      Context *on_finish,
-				      rbd::mirror::ProgressContext *progress_ctx)
+BootstrapRequest<I>::BootstrapRequest(
+        librados::IoCtx &local_io_ctx,
+        librados::IoCtx &remote_io_ctx,
+        std::shared_ptr<ImageSyncThrottler<I>> image_sync_throttler,
+        I **local_image_ctx,
+        const std::string &local_image_name,
+        const std::string &remote_image_id,
+        const std::string &global_image_id,
+        ContextWQ *work_queue, SafeTimer *timer,
+        Mutex *timer_lock,
+        const std::string &local_mirror_uuid,
+        const std::string &remote_mirror_uuid,
+        Journaler *journaler,
+        MirrorPeerClientMeta *client_meta,
+        Context *on_finish,
+        rbd::mirror::ProgressContext *progress_ctx)
   : BaseRequest("rbd::mirror::image_replayer::BootstrapRequest",
 		reinterpret_cast<CephContext*>(local_io_ctx.cct()), on_finish),
     m_local_io_ctx(local_io_ctx), m_remote_io_ctx(remote_io_ctx),
+    m_image_sync_throttler(image_sync_throttler),
     m_local_image_ctx(local_image_ctx), m_local_image_name(local_image_name),
     m_remote_image_id(remote_image_id), m_global_image_id(global_image_id),
     m_work_queue(work_queue), m_timer(timer), m_timer_lock(timer_lock),
@@ -63,7 +67,6 @@ BootstrapRequest<I>::BootstrapRequest(librados::IoCtx &local_io_ctx,
 
 template <typename I>
 BootstrapRequest<I>::~BootstrapRequest() {
-  assert(m_image_sync_request == nullptr);
   assert(m_remote_image_ctx == nullptr);
 }
 
@@ -79,9 +82,7 @@ void BootstrapRequest<I>::cancel() {
   Mutex::Locker locker(m_lock);
   m_canceled = true;
 
-  if (m_image_sync_request) {
-    m_image_sync_request->cancel();
-  }
+  m_image_sync_throttler->cancel_sync(m_local_image_id);
 }
 
 template <typename I>
@@ -547,30 +548,18 @@ void BootstrapRequest<I>::image_sync() {
   Context *ctx = create_context_callback<
     BootstrapRequest<I>, &BootstrapRequest<I>::handle_image_sync>(
       this);
-  ImageSync<I> *request = ImageSync<I>::create(*m_local_image_ctx,
-                                               m_remote_image_ctx, m_timer,
-                                               m_timer_lock,
-                                               m_local_mirror_uuid, m_journaler,
-                                               m_client_meta, m_work_queue, ctx,
-					       m_progress_ctx);
-  {
-    Mutex::Locker locker(m_lock);
-    request->get();
-    m_image_sync_request = request;
-  }
 
-  request->send();
+  m_image_sync_throttler->start_sync(*m_local_image_ctx,
+                                     m_remote_image_ctx, m_timer,
+                                     m_timer_lock,
+                                     m_local_mirror_uuid, m_journaler,
+                                     m_client_meta, m_work_queue, ctx,
+                                     m_progress_ctx);
 }
 
 template <typename I>
 void BootstrapRequest<I>::handle_image_sync(int r) {
   dout(20) << ": r=" << r << dendl;
-
-  {
-    Mutex::Locker locker(m_lock);
-    m_image_sync_request->put();
-    m_image_sync_request = nullptr;
-  }
 
   if (m_canceled) {
     dout(10) << ": request canceled" << dendl;

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
@@ -41,7 +41,6 @@ ImageCopyRequest<I>::ImageCopyRequest(I *local_image_ctx, I *remote_image_ctx,
     m_update_sync_point_interval(g_ceph_context->_conf->rbd_mirror_sync_point_update_age),
     m_client_meta_copy(*client_meta) {
   assert(!m_client_meta_copy.sync_points.empty());
-  assert(!m_client_meta_copy.snap_seqs.empty());
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
@@ -5,6 +5,7 @@
 #include "ObjectCopyRequest.h"
 #include "include/stringify.h"
 #include "common/errno.h"
+#include "common/Timer.h"
 #include "journal/Journaler.h"
 #include "librbd/Utils.h"
 #include "tools/rbd_mirror/ProgressContext.h"
@@ -36,6 +37,8 @@ ImageCopyRequest<I>::ImageCopyRequest(I *local_image_ctx, I *remote_image_ctx,
     m_client_meta(client_meta), m_sync_point(sync_point),
     m_progress_ctx(progress_ctx),
     m_lock(unique_lock_name("ImageCopyRequest::m_lock", this)),
+    m_updating_sync_point(false), m_update_sync_ctx(nullptr),
+    m_update_sync_point_interval(g_ceph_context->_conf->rbd_mirror_sync_point_update_age),
     m_client_meta_copy(*client_meta) {
   assert(!m_client_meta_copy.sync_points.empty());
   assert(!m_client_meta_copy.snap_seqs.empty());
@@ -146,7 +149,22 @@ void ImageCopyRequest<I>::send_object_copies() {
       }
     }
     complete = (m_current_ops == 0);
+
+    if (!complete) {
+      m_update_sync_ctx = new FunctionContext([this](int r) {
+          this->send_update_sync_point();
+      });
+    }
   }
+
+  {
+    Mutex::Locker timer_locker(*m_timer_lock);
+    if (m_update_sync_ctx) {
+      m_timer->add_event_after(m_update_sync_point_interval,
+                               m_update_sync_ctx);
+    }
+  }
+
   if (complete) {
     send_flush_sync_point();
   }
@@ -205,6 +223,92 @@ void ImageCopyRequest<I>::handle_object_copy(int r) {
   update_progress("COPY_OBJECT " + stringify(percent) + "%", false);
 
   if (complete) {
+    bool do_flush = true;
+    {
+      Mutex::Locker timer_locker(*m_timer_lock);
+      Mutex::Locker locker(m_lock);
+      if (!m_updating_sync_point) {
+        if (m_update_sync_ctx != nullptr) {
+          m_timer->cancel_event(m_update_sync_ctx);
+          m_update_sync_ctx = nullptr;
+        }
+      } else {
+        do_flush = false;
+      }
+    }
+
+    if (do_flush) {
+      send_flush_sync_point();
+    }
+  }
+}
+
+template <typename I>
+void ImageCopyRequest<I>::send_update_sync_point() {
+  Mutex::Locker l(m_lock);
+
+  m_update_sync_ctx = nullptr;
+
+  if (m_canceled || m_ret_val < 0 || m_current_ops == 0) {
+    return;
+  }
+
+  if (m_sync_point->object_number &&
+      (m_object_no-1) == m_sync_point->object_number.get()) {
+    // update sync point did not progress since last sync
+    return;
+  }
+
+  m_updating_sync_point = true;
+
+  m_client_meta_copy = *m_client_meta;
+  m_sync_point->object_number = m_object_no - 1;
+
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": sync_point=" << *m_sync_point << dendl;
+
+  bufferlist client_data_bl;
+  librbd::journal::ClientData client_data(*m_client_meta);
+  ::encode(client_data, client_data_bl);
+
+  Context *ctx = create_context_callback<
+    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_update_sync_point>(
+      this);
+  m_journaler->update_client(client_data_bl, ctx);
+}
+
+template <typename I>
+void ImageCopyRequest<I>::handle_update_sync_point(int r) {
+  CephContext *cct = m_local_image_ctx->cct;
+  ldout(cct, 20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    *m_client_meta = m_client_meta_copy;
+    lderr(cct) << ": failed to update client data: " << cpp_strerror(r)
+               << dendl;
+  }
+
+  bool complete;
+  {
+    Mutex::Locker l(m_lock);
+    m_updating_sync_point = false;
+
+    complete = m_current_ops == 0 || m_canceled || m_ret_val < 0;
+
+    if (!complete) {
+      m_update_sync_ctx = new FunctionContext([this](int r) {
+          this->send_update_sync_point();
+      });
+    }
+  }
+
+  if (!complete) {
+    Mutex::Locker timer_lock(*m_timer_lock);
+    if (m_update_sync_ctx) {
+      m_timer->add_event_after(m_update_sync_point_interval,
+                               m_update_sync_ctx);
+    }
+  } else {
     send_flush_sync_point();
   }
 }

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.h
@@ -100,6 +100,10 @@ private:
   uint64_t m_current_ops = 0;
   int m_ret_val = 0;
 
+  bool m_updating_sync_point;
+  Context *m_update_sync_ctx;
+  double m_update_sync_point_interval;
+
   MirrorPeerClientMeta m_client_meta_copy;
 
   void send_update_max_object_count();
@@ -108,6 +112,9 @@ private:
   void send_object_copies();
   void send_next_object_copy();
   void handle_object_copy(int r);
+
+  void send_update_sync_point();
+  void handle_update_sync_point(int r);
 
   void send_flush_sync_point();
   void handle_flush_sync_point(int r);

--- a/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.h
@@ -73,6 +73,8 @@ private:
   MirrorPeerClientMeta m_client_meta_copy;
   std::list<std::string> m_snap_names;
 
+  bool m_invalid_master_sync_point = false;
+
   void send_remove_snap();
   void handle_remove_snap(int r);
 

--- a/src/tools/rbd_mirror/types.h
+++ b/src/tools/rbd_mirror/types.h
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "include/rbd/librbd.hpp"
+#include "ImageSyncThrottler.h"
 
 namespace rbd {
 namespace mirror {
@@ -17,6 +18,9 @@ namespace mirror {
 typedef shared_ptr<librados::Rados> RadosRef;
 typedef shared_ptr<librados::IoCtx> IoCtxRef;
 typedef shared_ptr<librbd::Image> ImageRef;
+
+template <typename I = librbd::ImageCtx>
+using ImageSyncThrottlerRef = std::shared_ptr<ImageSyncThrottler<I>>;
 
 struct peer_t {
   peer_t() = default;


### PR DESCRIPTION
http://tracker.ceph.com/issues/16701