### PR TITLE
Wip buildfix python out of tree

### DIFF
--- a/cmake/modules/Distutils.cmake
+++ b/cmake/modules/Distutils.cmake
@@ -45,6 +45,7 @@ function(distutils_add_cython_module name src)
     LDFLAGS=-L${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
     CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
     CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
+    CEPH_BUILD_TOP=${CMAKE_BINARY_DIR}
     CFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"
     ${PYTHON${PYTHON_VERSION}_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/setup.py
     build --verbose --build-base ${CYTHON_MODULE_DIR}
@@ -67,6 +68,7 @@ function(distutils_install_cython_module name)
     execute_process(
        COMMAND env
            CYTHON_BUILD_DIR=${CMAKE_CURRENT_BINARY_DIR}
+	   CEPH_BUILD_TOP=${CMAKE_BINARY_DIR}
            CEPH_LIBDIR=${CMAKE_LIBRARY_OUTPUT_DIRECTORY}
            CC=${CMAKE_C_COMPILER}
            CPPFLAGS=\"-iquote${CMAKE_SOURCE_DIR}/src/include\"

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -26,15 +26,22 @@ from distutils.sysconfig import customize_compiler
 __version__ = '2.0.0'
 
 
-def get_ceph_version():
+def get_version():
+  where = []
+  top = os.getenv("CEPH_BUILD_TOP")
+  if top:
+    where.append(top)
+    where.append(os.path.join(top, "src", "include"))
+  else:
+    where.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+  for dir in where:
     try:
-        for line in open(os.path.join(os.path.dirname(__file__), "..", "..", "ceph_ver.h")):
+        for line in open(os.path.join(dir, "ceph_ver.h")):
             if "CEPH_GIT_NICE_VER" in line:
                 return line.split()[2].strip('"')
-        else:
-            return "0"
     except IOError:
-        return "0"
+	pass
+  return "0"
 
 
 def get_python_flags():

--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -38,9 +38,17 @@ def get_version():
     try:
         for line in open(os.path.join(dir, "ceph_ver.h")):
             if "CEPH_GIT_NICE_VER" in line:
-                return line.split()[2].strip('"')
+                l=line.split()[2].strip('"')
+                if len(l) > 1 and l[0] == 'v': l = l[1:]
+                a=l.split("-",2)
+                if len(a) > 2:
+                    return "{}.post{}+{}".format( a[0], a[1], a[2] )
+                elif len(a) > 1:
+                    return "{}+{}".format( a[0], a[1] )
+                else:
+                    return l
     except IOError:
-	pass
+        pass
   return "0"
 
 


### PR DESCRIPTION
[ More build fixes from STS - but! changes upstream makes these mostly obsolete.  PR for the sake of making this visible to the people who care, but I expect they will have some other fix they'd rather do instead. ]

Originally, these were 2 things: "out of tree" fixes for autoconf/automake, and python fixes for out of tree and other behaviors.  The automake stuff probably longer matters.

So the python fixes: people have been changing the behavior of src/pybind/*/setup.py to get rid of referencing ceph_ver.h - but the the fixes aren't very systematic and src/pybind/rbd/ still uses this (it's the last such reference).  My fix does include "pep440" changes, which you want if you want to use the ceph version from ceph_ver.h.  Also note rados get_ceph_version() which isn't used (and goes away here.)  It would be good to see a proper systematic fix (probably one that doesn't use ceph_ver.h).
