### PR TITLE
bluestore: do not use freelist to track bluefs_extents

### DIFF
--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -303,13 +303,20 @@ void BitMapAllocator::init_rm_free(uint64_t offset, uint64_t length)
            << " length 0x" << length << std::dec
            << dendl;
 
-  assert(!(offset % m_block_size));
-  assert(!(length % m_block_size));
+  // we use the same adjustment/alignment that init_add_free does
+  // above so that we can yank back some of the space.
+  uint64_t offset_adj = ROUND_UP_TO(offset, m_block_size);
+  uint64_t length_adj = ((length - (offset_adj - offset)) /
+                         m_block_size) * m_block_size;
 
-  int64_t first_blk = offset / m_block_size;
-  int64_t count = length / m_block_size;
+  assert(!(offset_adj % m_block_size));
+  assert(!(length_adj % m_block_size));
 
-  m_bit_alloc->set_blocks_used(first_blk, count);
+  int64_t first_blk = offset_adj / m_block_size;
+  int64_t count = length_adj / m_block_size;
+
+  if (count)
+    m_bit_alloc->set_blocks_used(first_blk, count);
 }
 
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1777,7 +1777,10 @@ int BlueStore::_open_fm(bool create)
     } else {
       reserved = BLUEFS_START;
     }
-    fm->allocate(0, reserved, t);
+
+    // note: we do not mark bluefs space as allocated in the freelist; we
+    // instead rely on bluefs_extents.
+    fm->allocate(0, BLUEFS_START, t);
 
     if (g_conf->bluestore_debug_prefill > 0) {
       uint64_t end = bdev->get_size() - reserved;
@@ -1850,6 +1853,8 @@ int BlueStore::_open_alloc()
                             bdev->get_size(),
                             min_alloc_size);
   uint64_t num = 0, bytes = 0;
+
+  // initialize from freelist
   fm->enumerate_reset();
   uint64_t offset, length;
   while (fm->enumerate_next(&offset, &length)) {
@@ -1860,6 +1865,14 @@ int BlueStore::_open_alloc()
   dout(10) << __func__ << " loaded " << pretty_si_t(bytes)
 	   << " in " << num << " extents"
 	   << dendl;
+
+  // also mark bluefs space as allocated
+  for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
+    alloc->init_rm_free(e.get_start(), e.get_len());
+  }
+  dout(10) << __func__ << " marked bluefs_extents 0x" << std::hex
+	   << bluefs_extents << std::dec << " as allocated" << dendl;
+
   return 0;
 }
 
@@ -2288,8 +2301,7 @@ int BlueStore::_reconcile_bluefs_freespace()
   return 0;
 }
 
-int BlueStore::_balance_bluefs_freespace(vector<bluestore_pextent_t> *extents,
-					 KeyValueDB::Transaction t)
+int BlueStore::_balance_bluefs_freespace(vector<bluestore_pextent_t> *extents)
 {
   int ret = 0;
   assert(bluefs);
@@ -2407,7 +2419,6 @@ int BlueStore::_balance_bluefs_freespace(vector<bluestore_pextent_t> *extents,
 
       bluefs_extents.erase(offset, length);
 
-      fm->release(offset, length, t);
       alloc->release(offset, length);
 
       reclaim -= length;
@@ -3016,7 +3027,7 @@ int BlueStore::fsck()
         [&](uint64_t pos, boost::dynamic_bitset<> &bs) {
           bs.set(pos);
         }
-      );
+	);
     }
     r = bluefs->fsck();
     if (r < 0) {
@@ -3261,6 +3272,16 @@ int BlueStore::fsck()
 
   dout(1) << __func__ << " checking freelist vs allocated" << dendl;
   {
+    // remove bluefs_extents from used set since the freelist doesn't
+    // know they are allocated.
+    for (auto e = bluefs_extents.begin(); e != bluefs_extents.end(); ++e) {
+      apply(
+        e.get_start(), e.get_len(), min_alloc_size, used_blocks,
+        [&](uint64_t pos, boost::dynamic_bitset<> &bs) {
+          bs.reset(pos);
+        }
+      );
+    }
     fm->enumerate_reset();
     uint64_t offset, length;
     while (fm->enumerate_next(&offset, &length)) {
@@ -5075,11 +5096,10 @@ void BlueStore::_kv_sync_thread()
 
       vector<bluestore_pextent_t> bluefs_gift_extents;
       if (bluefs) {
-	int r = _balance_bluefs_freespace(&bluefs_gift_extents, t);
+	int r = _balance_bluefs_freespace(&bluefs_gift_extents);
 	assert(r >= 0);
 	if (r > 0) {
 	  for (auto& p : bluefs_gift_extents) {
-	    fm->allocate(p.offset, p.length, t);
 	    bluefs_extents.insert(p.offset, p.length);
 	  }
 	  bufferlist bl;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1216,8 +1216,7 @@ private:
   int _open_super_meta();
 
   int _reconcile_bluefs_freespace();
-  int _balance_bluefs_freespace(vector<bluestore_pextent_t> *extents,
-				KeyValueDB::Transaction t);
+  int _balance_bluefs_freespace(vector<bluestore_pextent_t> *extents);
   void _commit_bluefs_freespace(const vector<bluestore_pextent_t>& extents);
 
   CollectionRef _get_collection(const coll_t& cid);

--- a/src/os/bluestore/ExtentFreelistManager.cc
+++ b/src/os/bluestore/ExtentFreelistManager.cc
@@ -11,6 +11,12 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "
 
+int ExtentFreelistManager::create(uint64_t size, KeyValueDB::Transaction txn)
+{
+  release(0, size, txn);
+  return 0;
+}
+
 int ExtentFreelistManager::init()
 {
   dout(1) << __func__ << dendl;

--- a/src/os/bluestore/ExtentFreelistManager.h
+++ b/src/os/bluestore/ExtentFreelistManager.h
@@ -35,6 +35,8 @@ public:
     total_free(0) {
   }
 
+  int create(uint64_t size, KeyValueDB::Transaction txn) override;
+
   int init() override;
   void shutdown() override;
 

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -22,10 +22,7 @@ public:
 
   static void setup_merge_operators(KeyValueDB *db);
 
-  virtual int create(uint64_t size, KeyValueDB::Transaction txn) {
-    release(0, size, txn);
-    return 0;
-  }
+  virtual int create(uint64_t size, KeyValueDB::Transaction txn) = 0;
 
   virtual int init() = 0;
   virtual void shutdown() = 0;


### PR DESCRIPTION
We track these explicitly in the bluestore superblock in bluefs_extents--we
dont' need to flip bits.  This speeds up mkfs and balancing significantly.