### PR TITLE
jewel: doc: fix by-parttypeuuid in ceph-disk(8) nroff

### DIFF
--- a/man/ceph-disk.8
+++ b/man/ceph-disk.8
@@ -190,7 +190,7 @@ ceph\-disk activate\-journal [\-\-activate\-key PATH] [\-\-mark\-init INITSYSTEM
 .SS activate\-all
 .sp
 Activate all tagged OSD partitions. \fBactivate\-all\fP relies on
-\fB/dev/disk/by\-parttype\-uuid/$typeuuid.$uuid\fP to find all partitions. Special
+\fB/dev/disk/by\-parttypeuuid/$typeuuid.$uuid\fP to find all partitions. Special
 \fBudev\fP rules are installed to create these links. It is triggered on ceph
 service start or run directly.
 .sp


### PR DESCRIPTION
Commit 221efb0b893adbfd7a19df171cf967fee87afcc7 altered the rST source for the ceph-disk man page. In Hammer, we also have to modify the nroff sources, because static copies of the generated man pages are stored in Git.

Fixes: http://tracker.ceph.com/issues/15867