### PR TITLE
RFC: buffer: add safe_appender and unsafe_appender

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -46,8 +46,8 @@ using namespace ceph;
 // --------------------------------------
 // base types
 
-template<class T>
-inline void encode_raw(const T& t, bufferlist& bl)
+template<class T, class A>
+inline void encode_raw(const T& t, A& bl)
 {
   bl.append((char*)&t, sizeof(t));
 }
@@ -58,8 +58,13 @@ inline void decode_raw(T& t, bufferlist::iterator &p)
 }
 
 #define WRITE_RAW_ENCODER(type)						\
-  inline void encode(const type &v, bufferlist& bl, uint64_t features=0) { encode_raw(v, bl); } \
-  inline void decode(type &v, bufferlist::iterator& p) { __ASSERT_FUNCTION decode_raw(v, p); }
+  template<class A>							\
+  inline void encode(const type &v, A& bl, uint64_t features=0) {	\
+    encode_raw(v, bl);							\
+  }									\
+  inline void decode(type &v, bufferlist::iterator& p) {		\
+    __ASSERT_FUNCTION decode_raw(v, p);					\
+  }
 
 WRITE_RAW_ENCODER(__u8)
 #ifndef _CHAR_IS_SIGNED
@@ -89,7 +94,8 @@ inline void decode(bool &v, bufferlist::iterator& p) {
 // int types
 
 #define WRITE_INTTYPE_ENCODER(type, etype)				\
-  inline void encode(type v, bufferlist& bl, uint64_t features=0) {	\
+  template<class A>							\
+  inline void encode(type v, A& bl, uint64_t features=0) {		\
     ceph_##etype e;					                \
     e = v;                                                              \
     encode_raw(e, bl);							\

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2269,6 +2269,322 @@ TEST(BufferList, append_zero) {
   EXPECT_EQ('\0', bl[1]);
 }
 
+TEST(BufferList, appender_bench) {
+  unsigned long long ma = 16 * 16, mb = 65536;
+  cout << "appending " << 16 * (ma * mb) << " uint64_t's" << std::endl;
+  size_t bufmax = 1048576 * 1024;
+  char *buf = new char[bufmax];
+  uint64_t *p;
+  memset(buf, 0, bufmax);
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+	bl.append((char*)(p++), sizeof(*p));
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::append " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+	::encode(*(p++), bl);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list encode " << dur << std::endl;
+  }
+
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::safe_appender ap = bl.get_safe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::safe_appender::append " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::safe_appender ap = bl.get_safe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	bufferlist::unsafe_appender uap = ap.reserve(sizeof(*p) * 16);
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+	uap.append((char*)(p++), sizeof(*p));
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::safe_appender::append (reserve 16) " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::safe_appender ap = bl.get_safe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::safe_appender::append_v " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::safe_appender ap = bl.get_safe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	bufferlist::unsafe_appender uap = ap.reserve(sizeof(*p) * 16);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+	uap.append_v(*p++);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::safe_appender::append_v (reserve 16) " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::safe_appender ap = bl.get_safe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::safe_appender encode " << dur << std::endl;
+  }
+
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::unsafe_appender ap = bl.get_unsafe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+	ap.append((char*)(p++), sizeof(*p));
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::unsafe_appender::append " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::unsafe_appender ap = bl.get_unsafe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+	ap.append_v(*p++);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::unsafe_appender::append_v " << dur << std::endl;
+  }
+  {
+    utime_t start = ceph_clock_now(NULL);
+    for (unsigned a = 0; a < ma; ++a) {
+      bufferlist bl;
+      bufferlist::unsafe_appender ap = bl.get_unsafe_appender(16 * sizeof(*p) * mb);
+      for (unsigned b = 0; b < mb; ++b) {
+	p = (uint64_t*)buf +
+	  (1234567 * a + 45678907 * b) % (bufmax/2/sizeof(uint64_t)) +
+	  123 * a;
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+	::encode(*(p++), ap);
+      }
+    }
+    utime_t dur = ceph_clock_now(NULL) - start;
+    cout << "buffer::list::unsafe_appender encode " << dur << std::endl;
+  }
+}
+
+TEST(BufferList, safe_appender) {
+  bufferlist bl;
+  bufferlist::appender a = bl.get_safe_appender();
+}
+
 TEST(BufferList, operator_brackets) {
   bufferlist bl;
   EXPECT_THROW(bl[1], buffer::end_of_buffer);
@@ -2954,6 +3270,7 @@ TEST(BufferHash, all) {
     EXPECT_EQ((unsigned)0xB3109EBF, hash.digest());
   }
 }
+
 
 /*
  * Local Variables:


### PR DESCRIPTION
A lot of time in current encoding methods is spent in buffer::append().  This is because it does a lot of bounds checking, and because it has to update both the buffer::list size, buffer::ptr (buffer::list::append_buffer) size.

The idea here is to build a new paradigm around appenders that skip all this housekeeping until the appender is destroyed and it does a flush() to the appropriate list.  That way each individual append is just a memcpy and pointer update.

The safe_appender does bounds checking and flushes as needed.

The idea with unsafe_appender is that when you know an upper bound on how much you will append, you can skip the bounds check on every call.

Initial results:

[ RUN      ] BufferList.appender_bench
appending 1073741824 bytes
buffer::list::append 20.285963
buffer::list encode 19.719120
buffer::list::safe_appender::append 2.588926
buffer::list::safe_appender::append_v 2.837026
buffer::list::safe_appender encode 3.000614
buffer::list::unsafe_appender::append 2.452116
buffer::list::unsafe_appender::append_v 2.553745
buffer::list::unsafe_appender encode 2.200110
[       OK ] BufferList.appender_bench (55637 ms)

The unsafe vs safe results are surprising... unsafe isn't actually much master.  I suspect that this bounds check is actually quite cheap since the CPU is doing branch prediction.  So maybe we don't even need it?