### PR TITLE
msg/async/AsyncMessenger: fix osd crash when set ms_async_op_threads=1

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -460,8 +460,13 @@ Worker* WorkerPool::get_worker()
      ldout(cct, 20) << __func__ << " creating worker" << dendl;
      current_best = new Worker(cct, this, workers.size());
      workers.push_back(current_best);
-     pending++;
-     current_best->create("ms_async_worker");
+     if (started) {
+       pending++;
+       current_best->create("ms_async_worker");
+     } else {
+       ldout(cct, 20) << __func__ << " WorkerPool not started, push " << current_best
+                      << " to workers and let WorkerPool::start to create the worker" << dendl; 
+     }
   } else {
     ldout(cct, 20) << __func__ << " picked " << current_best 
                    << " as best worker with load " << min_load << dendl;


### PR DESCRIPTION
set ms_async_op_threads to 1, when osd start, will create several asyncmessengers, which call WorkerPool::get_worker(),
because of the worker load balance, will make a new worker and current_best->create("ms_async_worker"), this is before WorkerPool::start(),
which will fail the assert "  assert(global_centers && !global_centers->centers[idx])", so we need to check whether workerpool started in
WorkerPool::get_worker().

Fixs:http://tracker.ceph.com/issues/17001
Signed-off-by:Dong Wu<archer.wudong@gmail.com>