### PR TITLE
os/bluestore/BitAllocator: batch is_allocated bit checks

### DIFF
--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -143,14 +143,10 @@ bmap_t BmapEntry::atomic_fetch()
   return m_bits;
 }
 
-bool BmapEntry::is_allocated(int64_t start_bit, int64_t num_bits)
+bool BmapEntry::is_allocated(int64_t offset, int64_t num_bits)
 {
-  for (int i = start_bit; i < num_bits + start_bit; i++) {
-    if (!check_bit(i)) {
-      return false;
-    }
-  }
-  return true;
+  bmap_t bmask = BmapEntry::align_mask(num_bits) >> offset;
+  return ((m_bits & bmask) == bmask);
 }
 
 void BmapEntry::clear_bit(int bit)


### PR DESCRIPTION
os/bluestore: Made is_allocated code check bits in batch.
Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>