### PR TITLE
mon/MonDBStore: fix assert which never fires

### DIFF
--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -597,7 +597,7 @@ class MonitorDBStore
       derr << __func__ << " error initializing "
 	   << kv_type << " db back storage in "
 	   << full_path << dendl;
-      assert(0 != "MonitorDBStore: error initializing keyvaluedb back storage");
+      assert(0 == "MonitorDBStore: error initializing keyvaluedb back storage");
     }
     db.reset(db_ptr);
 


### PR DESCRIPTION
The condition is always true and thus the assert never fires,
which is obvious not our plan.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>