### PR TITLE
rpm: Remove trailing whitespace in usermod command (SUSE)

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -903,7 +903,7 @@ if ! getent passwd ceph >/dev/null ; then
     useradd ceph $CEPH_USER_ID_OPTION -r -g ceph -s /sbin/nologin 2>/dev/null || :
 fi
 usermod -c "Ceph storage service" \
-        -d %{_localstatedir}/lib/ceph \   
+        -d %{_localstatedir}/lib/ceph \
         -g ceph \
         -s /sbin/nologin \
         ceph


### PR DESCRIPTION
Trailing whitespace after the backslash on the -d line of the
usermod command effectively splits it in two, breaking the
rpm %pre script for SUSE builds.

Signed-off-by: Tim Serong tserong@suse.com
