### PR TITLE
doc/install: Use https:// for download.ceph.com

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -101,11 +101,11 @@ Yellowdog Updater, Modified (YUM), you must add Ceph repositories.
 
 You may find releases for Debian/Ubuntu (installed with APT) at::
 
-	http://download.ceph.com/debian-{release-name}
+	https://download.ceph.com/debian-{release-name}
 
 You may find releases for CentOS/RHEL and others (installed with YUM) at::
 
-	http://download.ceph.com/rpm-{release-name}
+	https://download.ceph.com/rpm-{release-name}
 
 The major releases of Ceph include:
 
@@ -141,36 +141,36 @@ Add a Ceph package repository to your system's list of APT sources. For newer
 versions of Debian/Ubuntu, call ``lsb_release -sc`` on the command line to
 get the short codename, and replace ``{codename}`` in the following command. ::
 
-	sudo apt-add-repository 'deb http://download.ceph.com/debian-jewel/ {codename} main'
+	sudo apt-add-repository 'deb https://download.ceph.com/debian-jewel/ {codename} main'
 
 For early Linux distributions, you may execute the following command::
 
-	echo deb http://download.ceph.com/debian-jewel/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb https://download.ceph.com/debian-jewel/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 For earlier Ceph releases, replace ``{release-name}`` with the name  with the
 name of the Ceph release. You may call ``lsb_release -sc`` on the command  line
 to get the short codename, and replace ``{codename}`` in the following command.
 ::
 
-	sudo apt-add-repository 'deb http://download.ceph.com/debian-{release-name}/ {codename} main'
+	sudo apt-add-repository 'deb https://download.ceph.com/debian-{release-name}/ {codename} main'
 
 For older Linux distributions, replace ``{release-name}`` with the name of the
 release::
 
-	echo deb http://download.ceph.com/debian-{release-name}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb https://download.ceph.com/debian-{release-name}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 Ceph on ARM processors requires Google's memory profiling tools (``google-perftools``).
 The Ceph repository should have a copy at
-http://download.ceph.com/packages/google-perftools/debian. ::
+https://download.ceph.com/packages/google-perftools/debian. ::
 
-	echo deb http://download.ceph.com/packages/google-perftools/debian  $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/google-perftools.list
+	echo deb https://download.ceph.com/packages/google-perftools/debian  $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/google-perftools.list
 
 
 For development release packages, add our package repository to your system's
 list of APT sources.  See `the testing Debian repository`_ for a complete list
 of Debian and Ubuntu releases supported. ::
 
-	echo deb http://download.ceph.com/debian-testing/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb https://download.ceph.com/debian-testing/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 .. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
@@ -181,14 +181,14 @@ For major releases, you may add a Ceph entry to the ``/etc/yum.repos.d``
 directory. Create a ``ceph.repo`` file. In the example below, replace
 ``{ceph-release}`` with  a major release of Ceph (e.g., ``hammer``, ``jewel``,
 etc.) and ``{distro}`` with your Linux distribution (e.g., ``el7``, etc.).  You
-may view http://download.ceph.com/rpm-{ceph-release}/ directory to see which
+may view https://download.ceph.com/rpm-{ceph-release}/ directory to see which
 distributions Ceph supports. Some Ceph packages (e.g., EPEL) must take priority
 over standard packages, so you must ensure that you set
 ``priority=2``. ::
 
 	[ceph]
 	name=Ceph packages for $basearch
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -197,7 +197,7 @@ over standard packages, so you must ensure that you set
 
 	[ceph-noarch]
 	name=Ceph noarch packages
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -206,7 +206,7 @@ over standard packages, so you must ensure that you set
 
 	[ceph-source]
 	name=Ceph source packages
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
 	enabled=0
 	priority=2
 	gpgcheck=1
@@ -219,7 +219,7 @@ for development releases instead. ::
 
 	[ceph]
 	name=Ceph packages for $basearch/$releasever
-	baseurl=http://download.ceph.com/rpm-testing/{distro}/$basearch
+	baseurl=https://download.ceph.com/rpm-testing/{distro}/$basearch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -228,7 +228,7 @@ for development releases instead. ::
 
 	[ceph-noarch]
 	name=Ceph noarch packages
-	baseurl=http://download.ceph.com/rpm-testing/{distro}/noarch
+	baseurl=https://download.ceph.com/rpm-testing/{distro}/noarch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -237,7 +237,7 @@ for development releases instead. ::
 
 	[ceph-source]
 	name=Ceph source packages
-	baseurl=http://download.ceph.com/rpm-testing/{distro}/SRPMS
+	baseurl=https://download.ceph.com/rpm-testing/{distro}/SRPMS
 	enabled=0
 	priority=2
 	gpgcheck=1
@@ -255,11 +255,11 @@ The repository package installs the repository details on your local system for
 use with ``yum``. Replace ``{distro}`` with your Linux distribution, and
 ``{release}`` with the specific release of Ceph::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpms/{distro}/x86_64/ceph-{release}.el7.noarch.rpm'
+    su -c 'rpm -Uvh https://download.ceph.com/rpms/{distro}/x86_64/ceph-{release}.el7.noarch.rpm'
 
 You can download the RPMs directly from::
 
-     http://download.ceph.com/rpm-testing
+     https://download.ceph.com/rpm-testing
 
 .. tip:: For international users: There might be a mirror close to you where download Ceph from. For more information see: `Ceph Mirrors`_.
 
@@ -414,7 +414,7 @@ your Linux distribution codename. Replace ``{arch}`` with the CPU architecture.
 
 ::
 
-	wget -q http://download.ceph.com/debian-{release}/pool/main/c/ceph/ceph_{version}{distro}_{arch}.deb
+	wget -q https://download.ceph.com/debian-{release}/pool/main/c/ceph/ceph_{version}{distro}_{arch}.deb
 
 
 RPM Packages
@@ -438,27 +438,27 @@ Packages are currently built for the RHEL/CentOS7 (``el7``) platforms.  The
 repository package installs the repository details on your local system for use
 with ``yum``. Replace ``{distro}`` with your distribution. ::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpm-jewel/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
+    su -c 'rpm -Uvh https://download.ceph.com/rpm-jewel/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
 
 For example, for CentOS 7  (``el7``)::
 
-    su -c 'rpm -Uvh http://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-0.el7.noarch.rpm'
+    su -c 'rpm -Uvh https://download.ceph.com/rpm-jewel/el7/noarch/ceph-release-1-0.el7.noarch.rpm'
 
 You can download the RPMs directly from::
 
-	http://download.ceph.com/rpm-jewel
+	https://download.ceph.com/rpm-jewel
 
 
 For earlier Ceph releases, replace ``{release-name}`` with the name
 with the name of the Ceph release. You may call ``lsb_release -sc`` on the command
 line to get the short codename. ::
 
-	su -c 'rpm -Uvh http://download.ceph.com/rpm-{release-name}/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
+	su -c 'rpm -Uvh https://download.ceph.com/rpm-{release-name}/{distro}/noarch/ceph-{version}.{distro}.noarch.rpm'
 
 
 
 
 .. _Install Ceph Object Storage: ../install-storage-cluster
-.. _the testing Debian repository: http://download.ceph.com/debian-testing/dists
+.. _the testing Debian repository: https://download.ceph.com/debian-testing/dists
 .. _the gitbuilder page: http://gitbuilder.ceph.com
 .. _Ceph Mirrors: ../mirrors

--- a/doc/install/install-storage-cluster.rst
+++ b/doc/install/install-storage-cluster.rst
@@ -42,7 +42,7 @@ To install Ceph with RPMs, execute the following steps:
 
 	[ceph]
 	name=Ceph packages for $basearch
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/$basearch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -51,7 +51,7 @@ To install Ceph with RPMs, execute the following steps:
 
 	[ceph-noarch]
 	name=Ceph noarch packages
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
 	enabled=1
 	priority=2
 	gpgcheck=1
@@ -60,7 +60,7 @@ To install Ceph with RPMs, execute the following steps:
 
 	[ceph-source]
 	name=Ceph source packages
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/SRPMS
 	enabled=0
 	priority=2
 	gpgcheck=1

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -37,7 +37,7 @@ For Debian and Ubuntu distributions, perform the following steps:
    with a stable Ceph release (e.g., ``hammer``, ``jewel``, etc.)
    For example::
 
-	echo deb http://download.ceph.com/debian-{ceph-stable-release}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
+	echo deb https://download.ceph.com/debian-{ceph-stable-release}/ $(lsb_release -sc) main | sudo tee /etc/apt/sources.list.d/ceph.list
 
 #. Update your repository and install ``ceph-deploy``::
 
@@ -77,7 +77,7 @@ For CentOS 7, perform the following steps:
 
 	[ceph-noarch]
 	name=Ceph noarch packages
-	baseurl=http://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
+	baseurl=https://download.ceph.com/rpm-{ceph-release}/{distro}/noarch
 	enabled=1
 	gpgcheck=1
 	type=rpm-md


### PR DESCRIPTION
While the Ceph RPMs etc. are GPG signed, there are various
attacks against signed RPMs without signed/trusted *metadata*
that are elaborated on in https://theupdateframework.github.io/

Since download.ceph.com handles it today, let's make it the default.
(Might want to run this by the server admins though).