### PR TITLE
msg/simple/Accepter.cc: replace shutdown() with selfpipe event in poll() (FreeBSD)

### DIFF
--- a/src/msg/simple/Accepter.h
+++ b/src/msg/simple/Accepter.h
@@ -29,9 +29,15 @@ class Accepter : public Thread {
   bool done;
   int listen_sd;
   uint64_t nonce;
+  int shutdown_rd_fd;
+  int shutdown_wr_fd;
+  int create_selfpipe(int *pipe_rd, int *pipe_wr);
 
 public:
-  Accepter(SimpleMessenger *r, uint64_t n) : msgr(r), done(false), listen_sd(-1), nonce(n) {}
+  Accepter(SimpleMessenger *r, uint64_t n) 
+    : msgr(r), done(false), listen_sd(-1), nonce(n),
+      shutdown_rd_fd(-1), shutdown_wr_fd(-1)
+    {}
     
   void *entry() override;
   void stop();


### PR DESCRIPTION
…socket.

In FreeBSD a shutdown on the socket here can generate:
  accepter.stop shutdown failed:  errno 57 (57) Socket is not connected
But that does not trigger an event with the poll on the socket.

Closing the socket does.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>