### PR TITLE
rgw: remove the field ret from class RGWPutLC

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3875,26 +3875,25 @@ void RGWPutLC::execute()
   RGWLifecycleConfiguration_S3 *config = NULL;
   RGWLCXMLParser_S3 parser(s->cct);
   RGWLifecycleConfiguration_S3 new_config(s->cct);
-  ret = 0;
 
   if (!parser.init()) {
-    ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
-  ret = get_params();
-  if (ret < 0)
+  op_ret = get_params();
+  if (op_ret < 0)
     return;
 
   ldout(s->cct, 15) << "read len=" << len << " data=" << (data ? data : "") << dendl;
 
   if (!parser.parse(data, len, 1)) {
-    ret = -EACCES;
+    op_ret = -EACCES;
     return;
   }
   config = static_cast<RGWLifecycleConfiguration_S3 *>(parser.find_first("LifecycleConfiguration"));
   if (!config) {
-    ret = -EINVAL;
+    op_ret = -EINVAL;
     return;
   }
 
@@ -3904,8 +3903,8 @@ void RGWPutLC::execute()
     *_dout << dendl;
   }
 
-  ret = config->rebuild(store, new_config);
-  if (ret < 0)
+  op_ret = config->rebuild(store, new_config);
+  if (op_ret < 0)
     return;
 
   if (s->cct->_conf->subsys.should_gather(ceph_subsys_rgw, 15)) {
@@ -3918,8 +3917,8 @@ void RGWPutLC::execute()
   map<string, bufferlist> attrs;
   attrs = s->bucket_attrs;
   attrs[RGW_ATTR_LC] = bl;
-  ret =rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
-  if (ret < 0)
+  op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
+  if (op_ret < 0)
     return;
   string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' + s->bucket.bucket_id;  
   string oid; 
@@ -3931,19 +3930,19 @@ void RGWPutLC::execute()
   l.set_duration(time);
   librados::IoCtx *ctx = store->get_lc_pool_ctx();
   do {
-    ret = l.lock_exclusive(ctx, oid);
-    if (ret == -EBUSY) {
+    op_ret = l.lock_exclusive(ctx, oid);
+    if (op_ret == -EBUSY) {
       dout(0) << "RGWLC::RGWPutLC() failed to acquire lock on, sleep 5, try again" << oid << dendl;
       sleep(5);
       continue;
     }
-    if (ret < 0) {
-      dout(0) << "RGWLC::RGWPutLC() failed to acquire lock " << oid << ret << dendl;
+    if (op_ret < 0) {
+      dout(0) << "RGWLC::RGWPutLC() failed to acquire lock " << oid << op_ret << dendl;
       break;
     }
-    ret = cls_rgw_lc_set_entry(*ctx, oid, entry);
-    if (ret < 0) {
-      dout(0) << "RGWLC::RGWPutLC() failed to set entry " << oid << ret << dendl;     
+    op_ret = cls_rgw_lc_set_entry(*ctx, oid, entry);
+    if (op_ret < 0) {
+      dout(0) << "RGWLC::RGWPutLC() failed to set entry " << oid << op_ret << dendl;     
     }
     break;
   }while(1);
@@ -3959,7 +3958,7 @@ void RGWDeleteLC::execute()
   rgw_obj obj;
   store->get_bucket_instance_obj(s->bucket, obj);
   store->set_atomic(s->obj_ctx, obj);
-  ret = get_system_obj_attrs(store, s, obj, orig_attrs, NULL, &s->bucket_info.objv_tracker);
+  op_ret = get_system_obj_attrs(store, s, obj, orig_attrs, NULL, &s->bucket_info.objv_tracker);
   if (op_ret < 0)
     return;
     
@@ -3972,7 +3971,7 @@ void RGWDeleteLC::execute()
         }
       }
     }
-  ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
+  op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
   string shard_id = s->bucket.name + ':' +s->bucket.bucket_id;
   pair<string, int> entry(shard_id, lc_uninitial);
   string oid; 
@@ -3983,19 +3982,19 @@ void RGWDeleteLC::execute()
   utime_t time(max_lock_secs, 0);
   l.set_duration(time);
   do {
-    ret = l.lock_exclusive(ctx, oid);
-    if (ret == -EBUSY) {
+    op_ret = l.lock_exclusive(ctx, oid);
+    if (op_ret == -EBUSY) {
       dout(0) << "RGWLC::RGWPutLC() failed to acquire lock on, sleep 5, try again" << oid << dendl;
       sleep(5);
       continue;
     }
-    if (ret < 0) {
-      dout(0) << "RGWLC::RGWPutLC() failed to acquire lock " << oid << ret << dendl;
+    if (op_ret < 0) {
+      dout(0) << "RGWLC::RGWPutLC() failed to acquire lock " << oid << op_ret << dendl;
       break;
     }
-    ret = cls_rgw_lc_rm_entry(*ctx, oid, entry);
-    if (ret < 0) {
-      dout(0) << "RGWLC::RGWPutLC() failed to set entry " << oid << ret << dendl;     
+    op_ret = cls_rgw_lc_rm_entry(*ctx, oid, entry);
+    if (op_ret < 0) {
+      dout(0) << "RGWLC::RGWPutLC() failed to set entry " << oid << op_ret << dendl;     
     }
     break;
   }while(1);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1013,10 +1013,9 @@ public:
 
 class RGWGetLC : public RGWOp {
 protected:
-  int ret;
-
+    
 public:
-  RGWGetLC() : ret(0) { }
+  RGWGetLC() { }
   virtual ~RGWGetLC() { }
 
   int verify_permission();
@@ -1030,13 +1029,11 @@ public:
 
 class RGWPutLC : public RGWOp {
 protected:
-  int ret;
   size_t len;
   char *data;
 
 public:
   RGWPutLC() {
-    ret = 0;
     len = 0;
     data = NULL;
   }
@@ -1057,13 +1054,11 @@ public:
 
 class RGWDeleteLC : public RGWOp {
 protected:
-  int ret;
   size_t len;
   char *data;
 
 public:
   RGWDeleteLC() {
-    ret = 0;
     len = 0;
     data = NULL;
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1189,8 +1189,8 @@ int RGWPutLC_ObjStore::get_params()
   if (cl) {
     data = (char *)malloc(cl + 1);
     if (!data) {
-       ret = -ENOMEM;
-       return ret;
+       op_ret = -ENOMEM;
+       return op_ret;
     }
     int read_len;
     int r = STREAM_IO(s)->read(data, cl, &read_len, s->aws4_auth_needs_complete);
@@ -1202,7 +1202,7 @@ int RGWPutLC_ObjStore::get_params()
     len = 0;
   }
 
-  return ret;
+  return op_ret;
 }
 
 static int read_all_chunked_input(req_state *s, char **pdata, int *plen, int max_read)

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2239,12 +2239,11 @@ void RGWPutACLs_ObjStore_S3::send_response()
 
 void RGWGetLC_ObjStore_S3::execute()
 {
-
   config.set_ctx(s->cct);
 
   map<string, bufferlist>::iterator aiter = s->bucket_attrs.find(RGW_ATTR_LC);
   if (aiter == s->bucket_attrs.end()) {
-    ret = -ENOENT;
+    op_ret = -ENOENT;
     return;
   }
 
@@ -2253,18 +2252,18 @@ void RGWGetLC_ObjStore_S3::execute()
       config.decode(iter);
     } catch (const buffer::error& e) {
       ldout(s->cct, 0) << __func__ <<  "decode life cycle config failed" << dendl;
-      ret = -EIO;
+      op_ret = -EIO;
       return;
     }
 }
 
 void RGWGetLC_ObjStore_S3::send_response()
 {
-  if (ret) {
-    if (ret == -ENOENT) {	
+  if (op_ret) {
+    if (op_ret == -ENOENT) {	
       set_req_state_err(s, ERR_NO_SUCH_LC);
     } else {
-      set_req_state_err(s, ret);
+      set_req_state_err(s, op_ret);
     }
   }
   dump_errno(s);
@@ -2277,8 +2276,8 @@ void RGWGetLC_ObjStore_S3::send_response()
 
 void RGWPutLC_ObjStore_S3::send_response()
 {
-  if (ret)
-    set_req_state_err(s, ret);
+  if (op_ret)
+    set_req_state_err(s, op_ret);
   dump_errno(s);
   end_header(s, this, "application/xml");
   dump_start(s);
@@ -2286,10 +2285,10 @@ void RGWPutLC_ObjStore_S3::send_response()
 
 void RGWDeleteLC_ObjStore_S3::send_response()
 {
-  if (ret == 0)
-      ret = STATUS_NO_CONTENT;
-  if (ret) {   
-    set_req_state_err(s, ret);
+  if (op_ret == 0)
+      op_ret = STATUS_NO_CONTENT;
+  if (op_ret) {   
+    set_req_state_err(s, op_ret);
   }
   dump_errno(s);
   end_header(s, this, "application/xml");


### PR DESCRIPTION
remove the field ret from class RGWPutLC, because it should use op_ret which had defined in class RGWOp.

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>