### PR TITLE
bluestore: initialize csum_order properly

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6142,7 +6142,7 @@ int BlueStore::_do_alloc_write(
     bufferlist *l = &wi.bl;
     uint64_t final_length = wi.blob_length;
     uint64_t csum_length = wi.blob_length;
-    unsigned csum_order;
+    unsigned csum_order = block_size_order;
     bufferlist compressed_bl;
     CompressorRef c;
     bool compressed = false;


### PR DESCRIPTION
To kill the following warning:

In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BlueStore.h:39:0,
                 from /home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BlueStore.cc:22:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/bluestore_types.h: In member function ‘int BlueStore::_do_alloc_write(BlueStore::TransContext*, BlueStore::WriteContext*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/bluestore_types.h:558:29: warning: ‘csum_order’ may be used uninitialized in this function [-Wmaybe-uninitialized]
     csum_chunk_order = order;
                             ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BlueStore.cc:6145:14: note: ‘csum_order’ was declared here
     unsigned csum_order;

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>