### PR TITLE
osdc/Objecter: move RequestStateHook class to .cc

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -154,6 +154,14 @@ static const char *config_keys[] = {
   NULL
 };
 
+class Objecter::RequestStateHook : public AdminSocketHook {
+  Objecter *m_objecter;
+public:
+  explicit RequestStateHook(Objecter *objecter);
+  bool call(std::string command, cmdmap_t& cmdmap, std::string format,
+            bufferlist& out);
+};
+
 /**
  * This is a more limited form of C_Contexts, but that requires
  * a ceph_context which we don't have here.

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1153,13 +1153,7 @@ private:
   void tick();
   void update_crush_location();
 
-  class RequestStateHook : public AdminSocketHook {
-    Objecter *m_objecter;
-  public:
-    explicit RequestStateHook(Objecter *objecter);
-    bool call(std::string command, cmdmap_t& cmdmap, std::string format,
-	      bufferlist& out);
-  };
+  class RequestStateHook;
 
   RequestStateHook *m_request_state_hook;
 


### PR DESCRIPTION
Signed-off-by: Michal Jarzabek <stiopa@gmail.com>