### PR TITLE
rgw: fix radosgw daemon core when reopen logs

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3164,7 +3164,6 @@ void RGWRados::finalize()
     data_notifier->stop();
     delete data_notifier;
   }
-  delete meta_mgr;
   delete data_log;
   if (async_rados) {
     delete async_rados;
@@ -3201,6 +3200,7 @@ void RGWRados::finalize()
   if (cr_registry) {
     cr_registry->put();
   }
+  delete meta_mgr;
   delete binfo_cache;
   delete obj_tombstone_cache;
 }


### PR DESCRIPTION
the ``rgw_user_st_syn`` thread use the pointer ``meta_mgr`` in ``RGWUserStatsCache::sync_all_users()`` fuction, so we should close the thread before delete the pointer in ``RGWRados::finalize()`` function when close storage before reopen_logs.

Fixes: http://tracker.ceph.com/issues/17036

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>