### PR TITLE
doc: fix typo in mon-config-ref

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -591,7 +591,7 @@ Trimming requires that the placement groups are ``active + clean``.
 
 ``paxos trim disabled max versions``
 
-:Description: The maximimum number of version allowed to pass without trimming.
+:Description: The maximum number of version allowed to pass without trimming.
 :Type: Integer
 :Default: ``100``
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17038

Signed-off-by: MinSheng Lin <minsheng.l@inwinstack.com>