### PR TITLE
common/WorkQueue: " _lock.Lock()" location tunnel in "ThreadPool::worker"

### DIFF
--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -130,8 +130,8 @@ void ThreadPool::worker(WorkThread *wt)
 	  tp_handle.reset_tp_timeout();
 	  _lock.Unlock();
 	  wq->_void_process(item, tp_handle);
-	  _lock.Lock();
 	  wq->_void_process_finish(item);
+	  _lock.Lock();
 	  processing--;
 	  ldout(cct,15) << "worker wq " << wq->name << " done processing " << item
 			<< " (" << processing << " active)" << dendl;


### PR DESCRIPTION
I think that _lock.Lock() in front of the _void_process_finish will affect the timing of the other threads for _lock in a multithreaded environment , especially when  _void_process_finish is a time-consuming operation. (eg. in FileStore.h OpWQ::_process_finish(OpSequencer *osr) )
Signed-off-by: jimifm 316929299@qq.com