### PR TITLE
gcc 6.1.1 complains about missing include: <random>. 4.8.3 does not c…

### DIFF
--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <atomic>
 #include <iostream>
+#include <random>
 #include <string>
 #include <set>
 #include <vector>


### PR DESCRIPTION
…omplain about it

Signed-off-by: Daniel Oliveira <doliveira@suse.com>