### PR TITLE
hammer: rocksdb do not link against tcmalloc if it's disabled

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -466,7 +466,7 @@ done
 %endif
 
 ./autogen.sh
-MY_CONF_OPT=""
+MY_CONF_OPT="$CEPH_EXTRA_CONFIGURE_ARGS"
 
 MY_CONF_OPT="$MY_CONF_OPT --with-radosgw"
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/14799