### PR TITLE
rgw: do not try to encode or decode time_t and fix compiling warnings

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -474,7 +474,7 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
       decode_list_index_key(kiter->first, &key, &ver);
 
       start_key = kiter->first;
-      CLS_LOG(20, "start_key=%s len=%lu", start_key.c_str(), start_key.size());
+      CLS_LOG(20, "start_key=%s len=%zu", start_key.c_str(), start_key.size());
 
       if (!entry.is_valid()) {
         CLS_LOG(20, "entry %s[%s] is not valid\n", key.name.c_str(), key.instance.c_str());

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -939,14 +939,17 @@ struct cls_rgw_lc_obj_head
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
-    ::encode(start_date, bl);
+    uint64_t t = start_date;
+    ::encode(t, bl);
     ::encode(marker, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
     DECODE_START(1, bl);
-    ::decode(start_date, bl);
+    uint64_t t;
+    ::decode(t, bl);
+    start_date = static_cast<time_t>(t);
     ::decode(marker, bl);
     DECODE_FINISH(bl);
   }

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -146,7 +146,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   {
     suppress_sigpipe();
 
-    ssize_t sent = 0;
+    size_t sent = 0;
     while (1) {
       ssize_t r;
   #if defined(MSG_NOSIGNAL)
@@ -185,7 +185,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
   }
 
   virtual ssize_t send(bufferlist &bl, bool more) {
-    ssize_t sent_bytes = 0;
+    size_t sent_bytes = 0;
     std::list<bufferptr>::const_iterator pb = bl.buffers().begin();
     uint64_t left_pbrs = bl.buffers().size();
     while (left_pbrs) {
@@ -212,7 +212,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
 
       // "r" is the remaining length
       sent_bytes += r;
-      if (r < msglen)
+      if (static_cast<unsigned>(r) < msglen)
         break;
       // only "r" == 0 continue
     }
@@ -227,7 +227,7 @@ class PosixConnectedSocketImpl final : public ConnectedSocketImpl {
       }
     }
 
-    return sent_bytes;
+    return static_cast<ssize_t>(sent_bytes);
   }
   virtual void shutdown() {
     ::shutdown(_fd, SHUT_RDWR);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -52,13 +52,13 @@ using namespace std;
 
 #if defined(__linux__)
 # ifndef BTRFS_SUPER_MAGIC
-#define BTRFS_SUPER_MAGIC 0x9123683E
+#define BTRFS_SUPER_MAGIC 0x9123683EL
 # endif
 # ifndef XFS_SUPER_MAGIC
-#define XFS_SUPER_MAGIC 0x58465342
+#define XFS_SUPER_MAGIC 0x58465342L
 # endif
 # ifndef ZFS_SUPER_MAGIC
-#define ZFS_SUPER_MAGIC 0x2fc12fc1
+#define ZFS_SUPER_MAGIC 0x2fc12fc1L
 # endif
 #endif
 

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -253,7 +253,7 @@ void seed::do_encode()
   dencode.bencode(PIECE_LENGTH, info.piece_length, bl);
 
   char info_sha[100] = { 0 };
-  sprintf(info_sha, "%ld", sha_len);
+  sprintf(info_sha, "%" PRIu64, sha_len);
   string sha_len_str = info_sha;
   dencode.bencode_key(PIECES, bl);
   bl.append(sha_len_str.c_str(), sha_len_str.length());

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -1586,8 +1586,9 @@ doread(unsigned offset, unsigned size)
 		((progressinterval && testcalls % progressinterval == 0)  ||
 		(debug &&
 		       (monitorstart == -1 ||
-			(offset + size > monitorstart &&
-			(monitorend == -1 || offset <= monitorend))))))
+			(static_cast<long>(offset + size) > monitorstart &&
+			 (monitorend == -1 ||
+			  static_cast<long>(offset) <= monitorend))))))
 		prt("%lu read\t0x%x thru\t0x%x\t(0x%x bytes)\n", testcalls,
 		    offset, offset + size - 1, size);
 
@@ -1686,8 +1687,9 @@ dowrite(unsigned offset, unsigned size)
 		((progressinterval && testcalls % progressinterval == 0) ||
 		       (debug &&
 		       (monitorstart == -1 ||
-			(offset + size > monitorstart &&
-			 (monitorend == -1 || (long)offset <= monitorend))))))
+			(static_cast<long>(offset + size) > monitorstart &&
+			 (monitorend == -1 ||
+			  static_cast<long>(offset) <= monitorend))))))
 		prt("%lu write\t0x%x thru\t0x%x\t(0x%x bytes)\n", testcalls,
 		    offset, offset + size - 1, size);
 


### PR DESCRIPTION
time_t is `signed int` on linux, which is ambiguous when encode() or decode() on i386-linux.
see also 8f9e7b0.

Signed-off-by: Kefu Chai <kchai@redhat.com>