### PR TITLE
osd/OSD: optimize get_nextmap_reserved() and release_map()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5957,9 +5957,7 @@ void OSD::ms_fast_preprocess(Message *m)
       MOSDMap *mm = static_cast<MOSDMap*>(m);
       Session *s = static_cast<Session*>(m->get_connection()->get_priv());
       if (s) {
-	s->received_map_lock.lock();
 	s->received_map_epoch = mm->get_last();
-	s->received_map_lock.unlock();
 	s->put();
       }
     }
@@ -6177,9 +6175,7 @@ bool OSD::dispatch_op_fast(OpRequestRef& op, OSDMapRef& osdmap)
     Session *s = static_cast<Session*>(op->get_req()->
 				       get_connection()->get_priv());
     if (s) {
-      s->received_map_lock.lock();
       epoch_t received_epoch = s->received_map_epoch;
-      s->received_map_lock.unlock();
       if (received_epoch < msg_epoch) {
 	osdmap_subscribe(msg_epoch, false);
       }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -529,54 +529,76 @@ public:
    * down, without worrying about reopening connections from threads
    * working from old maps.
    */
+  using OSDMapRaw = const OSDMap*;
 private:
-  OSDMapRef next_osdmap;
+  // Uses two element sized vector to store two OSDMap references. Since
+  // we must await old osdmap release, so up to 2 element size is enough.
+  std::vector<OSDMapRef> saved_osdmaps;
+  std::atomic<OSDMapRaw> next_osdmap;
   Cond pre_publish_cond;
 
 public:
   void pre_publish_map(OSDMapRef map) {
     Mutex::Locker l(pre_publish_lock);
-    next_osdmap = std::move(map);
+    if (next_osdmap)
+      saved_osdmaps[1] = map;
+    else
+      saved_osdmaps[0] = map;
+    next_osdmap = map.get();
   }
 
   void activate_map();
-  /// map epochs reserved below
-  map<epoch_t, unsigned> map_reservations;
+  // the advanced seq
+  std::atomic<uint64_t> map_reserve_seq;
+  // the completed seq number
+  std::atomic<uint64_t> map_completed_seq;
+  std::atomic<uint64_t> map_reserved_waiters;
+  uint64_t map_wait_version = 0;
+  // wait_version -> pair(seq, count)
+  std::map<uint64_t, std::pair<uint64_t, uint64_t> > map_wait_pending;
 
   /// gets ref to next_osdmap and registers the epoch as reserved
-  OSDMapRef get_nextmap_reserved() {
-    Mutex::Locker l(pre_publish_lock);
-    if (!next_osdmap)
-      return OSDMapRef();
-    epoch_t e = next_osdmap->get_epoch();
-    map<epoch_t, unsigned>::iterator i =
-      map_reservations.insert(make_pair(e, 0)).first;
-    i->second++;
+  OSDMapRaw get_nextmap_reserved(uint64_t &s) {
+    s = ++map_reserve_seq;
     return next_osdmap;
   }
   /// releases reservation on map
-  void release_map(OSDMapRef osdmap) {
-    Mutex::Locker l(pre_publish_lock);
-    map<epoch_t, unsigned>::iterator i =
-      map_reservations.find(osdmap->get_epoch());
-    assert(i != map_reservations.end());
-    assert(i->second > 0);
-    if (--(i->second) == 0) {
-      map_reservations.erase(i);
+  void release_map(uint64_t seq) {
+    map_completed_seq++;
+    if (map_reserved_waiters) {
+      int has_empty = 0;
+      Mutex::Locker l(pre_publish_lock);
+      for (std::map<uint64_t, std::pair<uint64_t, uint64_t> >::iterator it = map_wait_pending.begin();
+           it != map_wait_pending.end(); ++it) {
+        if (seq <= it->second.first)
+          has_empty += (--it->second.second == 0);
+      }
+      if (has_empty)
+        pre_publish_cond.Signal();
     }
-    pre_publish_cond.Signal();
   }
   /// blocks until there are no reserved maps prior to next_osdmap
   void await_reserved_maps() {
     Mutex::Locker l(pre_publish_lock);
     assert(next_osdmap);
-    while (true) {
-      map<epoch_t, unsigned>::const_iterator i = map_reservations.cbegin();
-      if (i == map_reservations.cend() || i->first >= next_osdmap->get_epoch()) {
-	break;
-      } else {
-	pre_publish_cond.Wait(pre_publish_lock);
-      }
+    map_reserved_waiters++;
+    // barrier seq
+    uint64_t cur_seq = map_reserve_seq;
+    uint64_t completed_seq = map_completed_seq;
+    if (cur_seq == completed_seq) {
+      map_reserved_waiters--;
+    } else {
+      assert(cur_seq > completed_seq);
+      uint64_t wait_version = ++map_wait_version;
+      map_wait_pending[wait_version] = make_pair(cur_seq, cur_seq - completed_seq);
+      while (map_wait_pending[wait_version].second)
+        pre_publish_cond.Wait(pre_publish_lock);
+      map_wait_pending.erase(wait_version);
+      map_reserved_waiters--;
+    }
+    if (saved_osdmaps[1]) {
+      std::swap(saved_osdmaps[0], saved_osdmaps[1]);
+      saved_osdmaps[1] = nullptr;
     }
   }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1421,8 +1421,7 @@ public:
 
     Spinlock sent_epoch_lock;
     epoch_t last_sent_epoch;
-    Spinlock received_map_lock;
-    epoch_t received_map_epoch; // largest epoch seen in MOSDMap from here
+    std::atomic<epoch_t> received_map_epoch; // largest epoch seen in MOSDMap from here
 
     explicit Session(CephContext *cct) :
       RefCountedObject(cct),


### PR DESCRIPTION
For async messenger backend, it won't see any potential lock hold in ms_fast_dispatch. Otherwise will it trigger thundering herd, lots of connections will be affected. It doesn't mean little effect for simple backend. If lock hold happen in async backend, it means lots of pipe threads will race in fast dispatch path too, I think it also hurt for performance hugely.

So I introduce several commits to avoid potential lock in fast path. When osd facing 1w+ messages, it will help for single async worker throughput and latency. Lots of lock wait is avoided.
