### PR TITLE
osd: bail out if transaction size overflows

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1667,6 +1667,7 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 	  << " len " << e.length()
 	  << " (" << oncommit << ")" << dendl;
   assert(e.length() > 0);
+  assert(e.length() < header.max_size);
 
   if (osd_op)
     osd_op->mark_event("commit_queued_for_journal_write");

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6704,10 +6704,16 @@ void OSD::handle_osd_map(MOSDMap *m)
   }
 
   ObjectStore::Transaction t;
+  uint64_t txn_size = 0;
 
   // store new maps: queue for disk and put in the osdmap cache
   epoch_t start = MAX(superblock.newest_map + 1, first);
   for (epoch_t e = start; e <= last; e++) {
+    if (txn_size >= t.get_num_bytes()) {
+      derr << __func__ << " transaction size overflowed" << dendl;
+      assert(txn_size < t.get_num_bytes());
+    }
+    txn_size = t.get_num_bytes();
     map<epoch_t,bufferlist>::iterator p;
     p = m->maps.find(e);
     if (p != m->maps.end()) {


### PR DESCRIPTION
with a large MOSDMap message, the transaction size could be greater than
UINT_MAX. so fail early with error messages.

Fixes: http://tracker.ceph.com/issues/16982
Signed-off-by: Kefu Chai <kchai@redhat.com>