### PR TITLE
rgw_file: restore local definition of RGWLibFS gc interval

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -679,7 +679,7 @@ namespace rgw {
 	  } /* rgw_fh */
 	} /* event::type::READDIR */
       } /* ev */
-      std::this_thread::sleep_for(gc_interval);
+      std::this_thread::sleep_for(std::chrono::seconds(120));
     } while (! stop);
   } /* RGWLibFS::gc */
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -687,9 +687,6 @@ namespace rgw {
     struct rgw_fs fs;
     RGWFileHandle root_fh;
 
-    static constexpr std::chrono::seconds gc_interval =
-      std::chrono::seconds(120);
-
     mutable std::atomic<uint64_t> refcnt;
 
     RGWFileHandle::FHCache fh_cache;


### PR DESCRIPTION
The offending code seems to cause compile problems--inconsistently.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>