### PR TITLE
jewel: ceph-disk should timeout when a lock cannot be acquired

### DIFF
--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -4,5 +4,5 @@ Description=Ceph disk activation: %f
 [Service]
 Type=oneshot
 KillMode=none
-ExecStart=/bin/sh -c 'flock /var/lock/ceph-disk /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
+ExecStart=/bin/sh -c 'timeout 120 flock /var/lock/ceph-disk /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
 TimeoutSec=0


### PR DESCRIPTION
http://tracker.ceph.com/issues/17007