### PR TITLE
librbd: cache was not switching to writeback after first flush

### DIFF
--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -563,6 +563,8 @@ void AioImageDiscard<I>::update_stats(size_t length) {
 template <typename I>
 void AioImageFlush<I>::send_request() {
   I &image_ctx = this->m_image_ctx;
+  image_ctx.user_flushed();
+
   bool journaling = false;
   {
     RWLock::RLocker snap_locker(image_ctx.snap_lock);

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -687,6 +687,12 @@ TEST_F(TestJournalReplay, ObjectPosition) {
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 
+  {
+    // user flush requests are ignored when journaling + cache are enabled
+    RWLock::RLocker owner_lock(ictx->owner_lock);
+    ictx->flush();
+  }
+
   // check the commit position updated
   get_journal_commit_position(ictx, &current_tag, &current_entry);
   ASSERT_EQ(initial_tag + 1, current_tag);

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -148,6 +148,7 @@ struct MockImageCtx {
                               uint8_t protection_status, uint64_t flags));
   MOCK_METHOD2(rm_snap, void(std::string in_snap_name, librados::snap_t id));
 
+  MOCK_METHOD0(user_flushed, void());
   MOCK_METHOD1(flush, void(Context *));
   MOCK_METHOD1(flush_async_operations, void(Context *));
   MOCK_METHOD1(flush_copyup, void(Context *));

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -169,6 +169,10 @@ struct TestMockAioImageRequest : public TestMockFixture {
                 }));
   }
 
+  void expect_user_flushed(MockImageCtx &mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, user_flushed());
+  }
+
   void expect_flush(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(mock_image_ctx, flush(_))
       .WillOnce(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue));
@@ -240,6 +244,7 @@ TEST_F(TestMockAioImageRequest, AioFlushJournalAppendDisabled) {
   mock_image_ctx.journal = &mock_journal;
 
   InSequence seq;
+  expect_user_flushed(mock_image_ctx);
   expect_is_journal_appending(mock_journal, false);
   expect_flush(mock_image_ctx, 0);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16654
Signed-off-by: Jason Dillaman <dillaman@redhat.com>