### PR TITLE
os/bluestore: avoid blob_t reencode when unchanged

### DIFF
--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -12,7 +12,7 @@
 
 #include "BitMapAllocator.h"
 #include "bluestore_types.h"
-#include "BlueStore.h"
+#include "common/debug.h"
 
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1182,7 +1182,7 @@ void BlueStore::BlobMap::encode(bufferlist& bl) const
   ::encode(n, bl);
   for (auto p = blob_map.begin(); n--; ++p) {
     ::encode(p->id, bl);
-    ::encode(p->blob, bl);
+    p->encode(bl);
   }
 }
 
@@ -1195,7 +1195,7 @@ void BlueStore::BlobMap::decode(bufferlist::iterator& p, Cache *c)
     int64_t id;
     ::decode(id, p);
     Blob *b = new Blob(id, c);
-    ::decode(b->blob, p);
+    b->decode(p);
     b->get();
     blob_map.insert(*b);
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1145,6 +1145,7 @@ bool BlueStore::OnodeSpace::map_any(std::function<bool(OnodeRef)> f)
 
 void BlueStore::Blob::discard_unallocated()
 {
+  get_blob();
   size_t pos = 0;
   if (blob.is_compressed()) {
     bool discard = false;
@@ -5857,8 +5858,10 @@ void BlueStore::_dump_blob_map(BlobMap &bm, int log_level)
 {
   for (auto& b : bm.blob_map) {
     dout(log_level) << __func__ << "  " << b
-		    << " blob_bl " << b.blob_bl.length()
-		    << (b.blob_bl.length() ? "" : " (dirty)") << dendl;
+		    << " blob_bl " << b.get_encoded_length()
+		    << (b.is_dirty() ? " (dirty)" : "")
+		    << (b.is_undecoded() ? " (was undecoded)" : "")
+		    << dendl;
     if (b.get_blob().has_csum()) {
       vector<uint64_t> v;
       unsigned n = b.get_blob().get_csum_count();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -288,7 +288,9 @@ public:
   struct Blob : public boost::intrusive::set_base_hook<> {
     std::atomic_int nref;  ///< reference count
     int64_t id = 0;          ///< id
+  private:
     bluestore_blob_t blob;   ///< blob metadata
+  public:
     BufferSpace bc;          ///< buffer cache
 
     Blob(int64_t i, Cache *c) : nref(0), id(i), bc(c) {}
@@ -312,6 +314,13 @@ public:
 
     friend ostream& operator<<(ostream& out, const Blob &b) {
       return out << b.id << ":" << b.blob;
+    }
+
+    const bluestore_blob_t& get_blob() const {
+      return blob;
+    }
+    bluestore_blob_t& dirty_blob() {
+      return blob;
     }
 
     /// discard buffers for unallocated regions
@@ -389,7 +398,7 @@ public:
 	if (p != m.blob_map.begin()) {
 	  out << ',';
 	}
-	out << p->id << '=' << p->blob;
+	out << p->id << '=' << p->get_blob();
       }
       return out << '}';
     }

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -3,7 +3,7 @@
 
 #include "StupidAllocator.h"
 #include "bluestore_types.h"
-#include "BlueStore.h"
+#include "common/debug.h"
 
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -342,8 +342,9 @@ struct bluestore_blob_t {
   }
 
   /// return chunk (i.e. min readable block) size for the blob
-  uint64_t get_chunk_size(bool csum_enabled, uint64_t dev_block_size) {
-    return csum_enabled && has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
+  uint64_t get_chunk_size(bool csum_enabled, uint64_t dev_block_size) const {
+    return csum_enabled &&
+      has_csum() ? MAX(dev_block_size, get_csum_chunk_size()) : dev_block_size;
   }
   uint32_t get_csum_chunk_size() const {
     return 1 << csum_chunk_order;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -130,7 +130,7 @@ usage=$usage"\t--mon_num specify ceph monitor count\n"
 usage=$usage"\t--osd_num specify ceph osd count\n"
 usage=$usage"\t--mds_num specify ceph mds count\n"
 usage=$usage"\t--rgw_port specify ceph rgw http listen port\n"
-usage=$usage"\t--bluestore use bluestore as the osd objectstore backend\n"
+usage=$usage"\t-b, --bluestore use bluestore as the osd objectstore backend\n"
 usage=$usage"\t--memstore use memstore as the osd objectstore backend\n"
 usage=$usage"\t--cache <pool>: enable cache tiering on pool\n"
 usage=$usage"\t--short: short object names only; necessary for ext4 dev\n"
@@ -250,7 +250,7 @@ case $1 in
     --memstore )
 	    memstore=1
 	    ;;
-    --bluestore )
+    -b | --bluestore )
 	    bluestore=1
 	    ;;
     --hitset )


### PR DESCRIPTION
This improves 4k random io iops by 9% on my nvme vstart cluster.