### PR TITLE
librbd: interlock image refresh and exclusive lock operations

### DIFF
--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -45,6 +45,7 @@ cls_method_handle_t h_break_lock;
 cls_method_handle_t h_get_info;
 cls_method_handle_t h_list_locks;
 cls_method_handle_t h_assert_locked;
+cls_method_handle_t h_set_cookie;
 
 #define LOCK_PREFIX    "lock."
 
@@ -512,6 +513,94 @@ int assert_locked(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   return 0;
 }
 
+/**
+ * Update the cookie associated with an object lock
+ *
+ * Input:
+ * @param cls_lock_set_cookie_op request input
+ *
+ * Output:
+ * @param none
+ *
+ * @return 0 on success, -errno on failure.
+ */
+int set_cookie(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  CLS_LOG(20, "set_cookie");
+
+  cls_lock_set_cookie_op op;
+  try {
+    bufferlist::iterator iter = in->begin();
+    ::decode(op, iter);
+  } catch (const buffer::error& err) {
+    return -EINVAL;
+  }
+
+  if (op.type != LOCK_EXCLUSIVE && op.type != LOCK_SHARED) {
+    return -EINVAL;
+  }
+
+  if (op.name.empty()) {
+    return -EINVAL;
+  }
+
+  // see if there's already a locker
+  lock_info_t linfo;
+  int r = read_lock(hctx, op.name, &linfo);
+  if (r < 0) {
+    CLS_ERR("Could not read lock info: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  if (linfo.lockers.empty()) {
+    CLS_LOG(20, "object not locked");
+    return -EBUSY;
+  }
+
+  if (linfo.lock_type != op.type) {
+    CLS_LOG(20, "lock type mismatch: current=%s, assert=%s",
+            cls_lock_type_str(linfo.lock_type), cls_lock_type_str(op.type));
+    return -EBUSY;
+  }
+
+  if (linfo.tag != op.tag) {
+    CLS_LOG(20, "lock tag mismatch: current=%s, assert=%s", linfo.tag.c_str(),
+            op.tag.c_str());
+    return -EBUSY;
+  }
+
+  entity_inst_t inst;
+  r = cls_get_request_origin(hctx, &inst);
+  assert(r == 0);
+
+  locker_id_t id;
+  id.cookie = op.cookie;
+  id.locker = inst.name;
+
+  map<locker_id_t, locker_info_t>::iterator iter = linfo.lockers.find(id);
+  if (iter == linfo.lockers.end()) {
+    CLS_LOG(20, "not locked by client");
+    return -EBUSY;
+  }
+
+  id.cookie = op.new_cookie;
+  if (linfo.lockers.count(id) != 0) {
+    CLS_LOG(20, "lock cookie in-use");
+    return -EBUSY;
+  }
+
+  locker_info_t locker_info(iter->second);
+  linfo.lockers.erase(iter);
+
+  linfo.lockers[id] = locker_info;
+  r = write_lock(hctx, op.name, linfo);
+  if (r < 0) {
+    CLS_ERR("Could not update lock info: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+  return 0;
+}
+
 void __cls_init()
 {
   CLS_LOG(20, "Loaded lock class!");
@@ -535,6 +624,9 @@ void __cls_init()
   cls_register_cxx_method(h_class, "assert_locked",
                           CLS_METHOD_RD | CLS_METHOD_PROMOTE,
                           assert_locked, &h_assert_locked);
+  cls_register_cxx_method(h_class, "set_cookie",
+                          CLS_METHOD_RD | CLS_METHOD_WR | CLS_METHOD_PROMOTE,
+                          set_cookie, &h_set_cookie);
 
   return;
 }

--- a/src/cls/lock/cls_lock_client.cc
+++ b/src/cls/lock/cls_lock_client.cc
@@ -189,6 +189,22 @@ namespace rados {
         rados_op->exec("lock", "assert_locked", in);
       }
 
+      void set_cookie(librados::ObjectWriteOperation *rados_op,
+                      const std::string& name, ClsLockType type,
+                      const std::string& cookie, const std::string& tag,
+                      const std::string& new_cookie)
+      {
+        cls_lock_set_cookie_op op;
+        op.name = name;
+        op.type = type;
+        op.cookie = cookie;
+        op.tag = tag;
+        op.new_cookie = new_cookie;
+        bufferlist in;
+        ::encode(op, in);
+        rados_op->exec("lock", "set_cookie", in);
+      }
+
       void Lock::assert_locked_exclusive(ObjectOperation *op)
       {
         assert_locked(op, name, LOCK_EXCLUSIVE, cookie, tag);

--- a/src/cls/lock/cls_lock_client.h
+++ b/src/cls/lock/cls_lock_client.h
@@ -59,6 +59,11 @@ namespace rados {
                                 const std::string& cookie,
                                 const std::string& tag);
 
+      extern void set_cookie(librados::ObjectWriteOperation *rados_op,
+                             const std::string& name, ClsLockType type,
+                             const std::string& cookie, const std::string& tag,
+                             const std::string& new_cookie);
+
       class Lock {
 	std::string name;
 	std::string cookie;

--- a/src/cls/lock/cls_lock_ops.cc
+++ b/src/cls/lock/cls_lock_ops.cc
@@ -188,3 +188,24 @@ void cls_lock_assert_op::generate_test_instances(list<cls_lock_assert_op*>& o)
   o.push_back(new cls_lock_assert_op);
 }
 
+void cls_lock_set_cookie_op::dump(Formatter *f) const
+{
+  f->dump_string("name", name);
+  f->dump_string("type", cls_lock_type_str(type));
+  f->dump_string("cookie", cookie);
+  f->dump_string("tag", tag);
+  f->dump_string("new_cookie", new_cookie);
+}
+
+void cls_lock_set_cookie_op::generate_test_instances(list<cls_lock_set_cookie_op*>& o)
+{
+  cls_lock_set_cookie_op *i = new cls_lock_set_cookie_op;
+  i->name = "name";
+  i->type = LOCK_SHARED;
+  i->cookie = "cookie";
+  i->tag = "tag";
+  i->new_cookie = "new cookie";
+  o.push_back(i);
+  o.push_back(new cls_lock_set_cookie_op);
+}
+

--- a/src/cls/lock/cls_lock_ops.h
+++ b/src/cls/lock/cls_lock_ops.h
@@ -203,4 +203,40 @@ struct cls_lock_assert_op
 };
 WRITE_CLASS_ENCODER(cls_lock_assert_op)
 
+struct cls_lock_set_cookie_op
+{
+  string name;
+  ClsLockType type;
+  string cookie;
+  string tag;
+  string new_cookie;
+
+  cls_lock_set_cookie_op() : type(LOCK_NONE) {}
+
+  void encode(bufferlist &bl) const {
+    ENCODE_START(1, 1, bl);
+    ::encode(name, bl);
+    uint8_t t = (uint8_t)type;
+    ::encode(t, bl);
+    ::encode(cookie, bl);
+    ::encode(tag, bl);
+    ::encode(new_cookie, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator &bl) {
+    DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+    ::decode(name, bl);
+    uint8_t t;
+    ::decode(t, bl);
+    type = (ClsLockType)t;
+    ::decode(cookie, bl);
+    ::decode(tag, bl);
+    ::decode(new_cookie, bl);
+    DECODE_FINISH(bl);
+  }
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<cls_lock_set_cookie_op*>& o);
+};
+WRITE_CLASS_ENCODER(cls_lock_set_cookie_op)
+
 #endif

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -38,6 +38,7 @@ set(librbd_internal_srcs
   image/SetSnapRequest.cc
   image_watcher/Notifier.cc
   image_watcher/NotifyLockOwner.cc
+  image_watcher/RewatchRequest.cc
   journal/RemoveRequest.cc
   journal/CreateRequest.cc
   journal/Replay.cc

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -27,6 +27,7 @@ set(librbd_internal_srcs
   Operations.cc
   Utils.cc
   exclusive_lock/AcquireRequest.cc
+  exclusive_lock/ReacquireRequest.cc
   exclusive_lock/ReleaseRequest.cc
   exclusive_lock/StandardPolicy.cc
   image/CloseRequest.cc

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -43,7 +43,6 @@ public:
 
   void reacquire_lock(Context *on_reacquired = nullptr);
 
-  void handle_watch_registered();
   void handle_peer_notification();
 
   void assert_header_locked(librados::ObjectWriteOperation *op);

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -130,6 +130,7 @@ private:
 
   mutable Mutex m_lock;
   State m_state;
+  std::string m_cookie;
   uint64_t m_watch_handle;
 
   ActionsContexts m_actions_contexts;

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -41,6 +41,8 @@ public:
   void request_lock(Context *on_locked);
   void release_lock(Context *on_released);
 
+  void reacquire_lock(Context *on_reacquired = nullptr);
+
   void handle_watch_registered();
   void handle_peer_notification();
 
@@ -51,6 +53,8 @@ public:
 private:
 
   /**
+   * @verbatim
+   *
    * <start>                              * * > WAITING_FOR_REGISTER --------\
    *    |                                 * (watch not registered)           |
    *    |                                 *                                  |
@@ -69,11 +73,21 @@ private:
    *                            |          (release_lock)           v
    *                      PRE_RELEASING <------------------------ LOCKED
    *
+   * <LOCKED state>
+   *    |
+   *    v
+   * REACQUIRING -------------------------------------> <finish>
+   *    .                                                 ^
+   *    .                                                 |
+   *    . . . > <RELEASE action> ---> <ACQUIRE action> ---/
+   *
    * <UNLOCKED/LOCKED states>
    *    |
    *    |
    *    v
    * PRE_SHUTTING_DOWN ---> SHUTTING_DOWN ---> SHUTDOWN ---> <finish>
+   *
+   * @endverbatim
    */
   enum State {
     STATE_UNINITIALIZED,
@@ -84,16 +98,18 @@ private:
     STATE_POST_ACQUIRING,
     STATE_WAITING_FOR_PEER,
     STATE_WAITING_FOR_REGISTER,
+    STATE_REACQUIRING,
     STATE_PRE_RELEASING,
     STATE_RELEASING,
     STATE_PRE_SHUTTING_DOWN,
     STATE_SHUTTING_DOWN,
-    STATE_SHUTDOWN,
+    STATE_SHUTDOWN
   };
 
   enum Action {
     ACTION_TRY_LOCK,
     ACTION_REQUEST_LOCK,
+    ACTION_REACQUIRE_LOCK,
     ACTION_RELEASE_LOCK,
     ACTION_SHUT_DOWN
   };
@@ -131,6 +147,7 @@ private:
   mutable Mutex m_lock;
   State m_state;
   std::string m_cookie;
+  std::string m_new_cookie;
   uint64_t m_watch_handle;
 
   ActionsContexts m_actions_contexts;
@@ -156,6 +173,9 @@ private:
   void send_acquire_lock();
   void handle_acquiring_lock(int r);
   void handle_acquire_lock(int r);
+
+  void send_reacquire_lock();
+  void handle_reacquire_lock(int r);
 
   void send_release_lock();
   void handle_releasing_lock(int r);

--- a/src/librbd/ImageState.cc
+++ b/src/librbd/ImageState.cc
@@ -318,18 +318,6 @@ template <typename I>
 void ImageState<I>::refresh(Context *on_finish) {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 20) << __func__ << dendl;
-  refresh(false, on_finish);
-}
-
-template <typename I>
-void ImageState<I>::acquire_lock_refresh(Context *on_finish) {
-  CephContext *cct = m_image_ctx->cct;
-  ldout(cct, 20) << __func__ << dendl;
-  refresh(true, on_finish);
-}
-
-template <typename I>
-void ImageState<I>::refresh(bool acquiring_lock, Context *on_finish) {
 
   m_lock.Lock();
   if (is_closed()) {
@@ -340,7 +328,6 @@ void ImageState<I>::refresh(bool acquiring_lock, Context *on_finish) {
 
   Action action(ACTION_TYPE_REFRESH);
   action.refresh_seq = m_refresh_seq;
-  action.refresh_acquiring_lock = acquiring_lock;
   execute_action_unlock(action, on_finish);
 }
 
@@ -633,7 +620,7 @@ void ImageState<I>::send_refresh_unlock() {
     *m_image_ctx, create_context_callback<
       ImageState<I>, &ImageState<I>::handle_refresh>(this));
   image::RefreshRequest<I> *req = image::RefreshRequest<I>::create(
-    *m_image_ctx, action_context.refresh_acquiring_lock, ctx);
+    *m_image_ctx, false, ctx);
 
   m_lock.Unlock();
   req->send();

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -38,7 +38,6 @@ public:
   int refresh();
   int refresh_if_required();
   void refresh(Context *on_finish);
-  void acquire_lock_refresh(Context *on_finish);
 
   void snap_set(const std::string &snap_name, Context *on_finish);
 
@@ -73,7 +72,6 @@ private:
   struct Action {
     ActionType action_type;
     uint64_t refresh_seq = 0;
-    bool refresh_acquiring_lock = false;
     std::string snap_name;
     Context *on_ready = nullptr;
 
@@ -85,8 +83,7 @@ private:
       }
       switch (action_type) {
       case ACTION_TYPE_REFRESH:
-        return (refresh_seq == action.refresh_seq &&
-                refresh_acquiring_lock == action.refresh_acquiring_lock);
+        return (refresh_seq == action.refresh_seq);
       case ACTION_TYPE_SET_SNAP:
         return snap_name == action.snap_name;
       case ACTION_TYPE_LOCK:
@@ -114,8 +111,6 @@ private:
 
   bool is_transition_state() const;
   bool is_closed() const;
-
-  void refresh(bool acquiring_lock, Context *on_finish);
 
   void append_context(const Action &action, Context *context);
   void execute_next_action_unlock();

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -42,6 +42,9 @@ public:
 
   void snap_set(const std::string &snap_name, Context *on_finish);
 
+  void prepare_lock(Context *on_ready);
+  void handle_prepare_lock_complete();
+
   int register_update_watcher(UpdateWatchCtx *watcher, uint64_t *handle);
   int unregister_update_watcher(uint64_t handle);
   void flush_update_watchers(Context *on_finish);
@@ -55,14 +58,16 @@ private:
     STATE_OPENING,
     STATE_CLOSING,
     STATE_REFRESHING,
-    STATE_SETTING_SNAP
+    STATE_SETTING_SNAP,
+    STATE_PREPARING_LOCK
   };
 
   enum ActionType {
     ACTION_TYPE_OPEN,
     ACTION_TYPE_CLOSE,
     ACTION_TYPE_REFRESH,
-    ACTION_TYPE_SET_SNAP
+    ACTION_TYPE_SET_SNAP,
+    ACTION_TYPE_LOCK
   };
 
   struct Action {
@@ -70,6 +75,7 @@ private:
     uint64_t refresh_seq = 0;
     bool refresh_acquiring_lock = false;
     std::string snap_name;
+    Context *on_ready = nullptr;
 
     Action(ActionType action_type) : action_type(action_type) {
     }
@@ -83,6 +89,8 @@ private:
                 refresh_acquiring_lock == action.refresh_acquiring_lock);
       case ACTION_TYPE_SET_SNAP:
         return snap_name == action.snap_name;
+      case ACTION_TYPE_LOCK:
+        return false;
       default:
         return true;
       }
@@ -125,6 +133,8 @@ private:
 
   void send_set_snap_unlock();
   void handle_set_snap(int r);
+
+  void send_prepare_lock_unlock();
 
 };
 

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -64,7 +64,8 @@ private:
   enum WatchState {
     WATCH_STATE_UNREGISTERED,
     WATCH_STATE_REGISTERED,
-    WATCH_STATE_ERROR
+    WATCH_STATE_ERROR,
+    WATCH_STATE_REWATCHING
   };
 
   enum TaskCode {
@@ -226,6 +227,7 @@ private:
   WatchCtx m_watch_ctx;
   uint64_t m_watch_handle;
   WatchState m_watch_state;
+  Context *m_unregister_watch_ctx = nullptr;
 
   TaskFinisher<Task> *m_task_finisher;
 
@@ -310,7 +312,8 @@ private:
   void handle_error(uint64_t cookie, int err);
   void acknowledge_notify(uint64_t notify_id, uint64_t handle, bufferlist &out);
 
-  void reregister_watch();
+  void rewatch();
+  void handle_rewatch(int r);
 };
 
 } // namespace librbd

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -43,6 +43,7 @@ librbd_internal_la_SOURCES = \
 	librbd/image/SetSnapRequest.cc \
 	librbd/image_watcher/Notifier.cc \
 	librbd/image_watcher/NotifyLockOwner.cc \
+	librbd/image_watcher/RewatchRequest.cc \
 	librbd/journal/RemoveRequest.cc \
 	librbd/journal/CreateRequest.cc \
 	librbd/journal/Replay.cc \
@@ -135,6 +136,7 @@ noinst_HEADERS += \
 	librbd/image/SetSnapRequest.h \
 	librbd/image_watcher/Notifier.h \
 	librbd/image_watcher/NotifyLockOwner.h \
+	librbd/image_watcher/RewatchRequest.h \
 	librbd/journal/CreateRequest.h \
 	librbd/journal/DisabledPolicy.h \
 	librbd/journal/Policy.h \

--- a/src/librbd/Makefile.am
+++ b/src/librbd/Makefile.am
@@ -32,6 +32,7 @@ librbd_internal_la_SOURCES = \
 	librbd/Operations.cc \
 	librbd/Utils.cc \
 	librbd/exclusive_lock/AcquireRequest.cc \
+	librbd/exclusive_lock/ReacquireRequest.cc \
 	librbd/exclusive_lock/ReleaseRequest.cc \
 	librbd/exclusive_lock/StandardPolicy.cc \
 	librbd/image/CloseRequest.cc \
@@ -123,6 +124,7 @@ noinst_HEADERS += \
 	librbd/WatchNotifyTypes.h \
 	librbd/exclusive_lock/AcquireRequest.h \
 	librbd/exclusive_lock/Policy.h \
+	librbd/exclusive_lock/ReacquireRequest.h \
 	librbd/exclusive_lock/ReleaseRequest.h \
 	librbd/exclusive_lock/StandardPolicy.h \
 	librbd/image/CloseRequest.h \

--- a/src/librbd/exclusive_lock/ReacquireRequest.cc
+++ b/src/librbd/exclusive_lock/ReacquireRequest.cc
@@ -1,0 +1,72 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/exclusive_lock/ReacquireRequest.h"
+#include "cls/lock/cls_lock_client.h"
+#include "cls/lock/cls_lock_types.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::exclusive_lock::ReacquireRequest: " \
+                           << this << ": " << __func__
+
+namespace librbd {
+namespace exclusive_lock {
+
+using librbd::util::create_rados_safe_callback;
+
+template <typename I>
+ReacquireRequest<I>::ReacquireRequest(I &image_ctx,
+                                      const std::string &old_cookie,
+                                      const std::string &new_cookie,
+                                      Context *on_finish)
+  : m_image_ctx(image_ctx), m_old_cookie(old_cookie), m_new_cookie(new_cookie),
+    m_on_finish(on_finish) {
+}
+
+template <typename I>
+void ReacquireRequest<I>::send() {
+  set_cookie();
+}
+
+template <typename I>
+void ReacquireRequest<I>::set_cookie() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  librados::ObjectWriteOperation op;
+  rados::cls::lock::set_cookie(&op, RBD_LOCK_NAME, LOCK_EXCLUSIVE, m_old_cookie,
+                               ExclusiveLock<>::WATCHER_LOCK_TAG, m_new_cookie);
+
+  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+    ReacquireRequest<I>, &ReacquireRequest<I>::handle_set_cookie>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+void ReacquireRequest<I>::handle_set_cookie(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << ": r=" << r << dendl;
+
+  if (r == -EOPNOTSUPP) {
+    ldout(cct, 10) << ": OSD doesn't support updating lock" << dendl;
+  } else if (r < 0) {
+    lderr(cct) << ": failed to update lock: " << cpp_strerror(r) << dendl;
+  }
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+template class librbd::exclusive_lock::ReacquireRequest<librbd::ImageCtx>;

--- a/src/librbd/exclusive_lock/ReacquireRequest.h
+++ b/src/librbd/exclusive_lock/ReacquireRequest.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_EXCLUSIVE_LOCK_REACQUIRE_REQUEST_H
+#define CEPH_LIBRBD_EXCLUSIVE_LOCK_REACQUIRE_REQUEST_H
+
+#include "include/int_types.h"
+#include <string>
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace exclusive_lock {
+
+template <typename ImageCtxT = ImageCtx>
+class ReacquireRequest {
+public:
+
+  static ReacquireRequest *create(ImageCtxT &image_ctx,
+                                  const std::string &old_cookie,
+                                  const std::string &new_cookie,
+                                  Context *on_finish) {
+    return new ReacquireRequest(image_ctx, old_cookie, new_cookie, on_finish);
+  }
+
+  ReacquireRequest(ImageCtxT &image_ctx, const std::string &old_cookie,
+                   const std::string &new_cookie, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * SET_COOKIE
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+  ImageCtxT &m_image_ctx;
+  std::string m_old_cookie;
+  std::string m_new_cookie;
+  Context *m_on_finish;
+
+  void set_cookie();
+  void handle_set_cookie(int r);
+
+};
+
+} // namespace exclusive_lock
+} // namespace librbd
+
+extern template class librbd::exclusive_lock::ReacquireRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_EXCLUSIVE_LOCK_REACQUIRE_REQUEST_H

--- a/src/librbd/image_watcher/RewatchRequest.cc
+++ b/src/librbd/image_watcher/RewatchRequest.cc
@@ -1,0 +1,125 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/image_watcher/RewatchRequest.h"
+#include "common/errno.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image_watcher::RewatchRequest: " \
+                           << this << ": " << __func__
+
+namespace librbd {
+namespace image_watcher {
+
+using librbd::util::create_context_callback;
+using librbd::util::create_rados_safe_callback;
+
+template <typename I>
+RewatchRequest<I>::RewatchRequest(I &image_ctx, RWLock &watch_lock,
+                                  librados::WatchCtx2 *watch_ctx,
+                                  uint64_t *watch_handle, Context *on_finish)
+  : m_image_ctx(image_ctx), m_watch_lock(watch_lock), m_watch_ctx(watch_ctx),
+    m_watch_handle(watch_handle), m_on_finish(on_finish) {
+}
+
+template <typename I>
+void RewatchRequest<I>::send() {
+  unwatch();
+}
+
+template <typename I>
+void RewatchRequest<I>::unwatch() {
+  assert(m_watch_lock.is_wlocked());
+  assert(*m_watch_handle != 0);
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  librados::AioCompletion *aio_comp = create_rados_safe_callback<
+    RewatchRequest<I>, &RewatchRequest<I>::handle_unwatch>(this);
+  int r = m_image_ctx.md_ctx.aio_unwatch(*m_watch_handle, aio_comp);
+  assert(r == 0);
+  aio_comp->release();
+
+  *m_watch_handle = 0;
+}
+
+template <typename I>
+void RewatchRequest<I>::handle_unwatch(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  if (r == -EBLACKLISTED) {
+    lderr(cct) << "client blacklisted" << dendl;
+    finish(r);
+  } else if (r < 0) {
+    lderr(cct) << "failed to unwatch: " << cpp_strerror(r) << dendl;
+  }
+  rewatch();
+}
+
+template <typename I>
+void RewatchRequest<I>::rewatch() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  librados::AioCompletion *aio_comp = create_rados_safe_callback<
+    RewatchRequest<I>, &RewatchRequest<I>::handle_rewatch>(this);
+  int r = m_image_ctx.md_ctx.aio_watch(m_image_ctx.header_oid, aio_comp,
+                                       &m_rewatch_handle, m_watch_ctx);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void RewatchRequest<I>::handle_rewatch(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  if (r == -EBLACKLISTED) {
+    lderr(cct) << "client blacklisted" << dendl;
+    finish(r);
+    return;
+  } else if (r == -ENOENT) {
+    ldout(cct, 5) << "image header deleted" << dendl;
+    finish(r);
+    return;
+  } else if (r < 0) {
+    lderr(cct) << "failed to watch image header: " << cpp_strerror(r)
+               << dendl;
+    rewatch();
+    return;
+  }
+
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    *m_watch_handle = m_rewatch_handle;
+  }
+
+  {
+    RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+    if (m_image_ctx.exclusive_lock != nullptr) {
+      // update the lock cookie with the new watch handle
+      m_image_ctx.exclusive_lock->reacquire_lock();
+    }
+  }
+  finish(0);
+}
+
+template <typename I>
+void RewatchRequest<I>::finish(int r) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_watcher
+} // namespace librbd
+
+template class librbd::image_watcher::RewatchRequest<librbd::ImageCtx>;

--- a/src/librbd/image_watcher/RewatchRequest.h
+++ b/src/librbd/image_watcher/RewatchRequest.h
@@ -1,0 +1,78 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_WATCHER_REWATCH_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_WATCHER_REWATCH_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/rados/librados.hpp"
+
+struct Context;
+struct RWLock;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace image_watcher {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class RewatchRequest {
+public:
+
+  static RewatchRequest *create(ImageCtxT &image_ctx, RWLock &watch_lock,
+                                librados::WatchCtx2 *watch_ctx,
+                                uint64_t *watch_handle, Context *on_finish) {
+    return new RewatchRequest(image_ctx, watch_lock, watch_ctx, watch_handle,
+                              on_finish);
+  }
+
+  RewatchRequest(ImageCtxT &image_ctx, RWLock &watch_lock,
+                 librados::WatchCtx2 *watch_ctx, uint64_t *watch_handle,
+                 Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * UNWATCH
+   *    |
+   *    |  . . . .
+   *    |  .     . (recoverable error)
+   *    v  v     .
+   * REWATCH . . .
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ImageCtxT &m_image_ctx;
+  RWLock &m_watch_lock;
+  librados::WatchCtx2 *m_watch_ctx;
+  uint64_t *m_watch_handle;
+  Context *m_on_finish;
+
+  uint64_t m_rewatch_handle = 0;
+
+  void unwatch();
+  void handle_unwatch(int r);
+
+  void rewatch();
+  void handle_rewatch(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_watcher
+} // namespace librbd
+
+extern template class librbd::image_watcher::RewatchRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_WATCHER_REWATCH_REQUEST_H

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -390,6 +390,7 @@ unittest_librbd_SOURCES = \
 	test/librbd/test_mock_Journal.cc \
 	test/librbd/test_mock_ObjectWatcher.cc \
 	test/librbd/exclusive_lock/test_mock_AcquireRequest.cc \
+	test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc \
 	test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc \
 	test/librbd/image/test_mock_RefreshRequest.cc \
 	test/librbd/journal/test_mock_Replay.cc \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -393,6 +393,7 @@ unittest_librbd_SOURCES = \
 	test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc \
 	test/librbd/exclusive_lock/test_mock_ReleaseRequest.cc \
 	test/librbd/image/test_mock_RefreshRequest.cc \
+	test/librbd/image_watcher/test_mock_RewatchRequest.cc \
 	test/librbd/journal/test_mock_Replay.cc \
 	test/librbd/object_map/test_mock_InvalidateRequest.cc \
 	test/librbd/object_map/test_mock_LockRequest.cc \

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -384,6 +384,7 @@ TYPE(cls_lock_get_info_op)
 TYPE_FEATUREFUL(cls_lock_get_info_reply)
 TYPE(cls_lock_list_locks_reply)
 TYPE(cls_lock_assert_op)
+TYPE(cls_lock_set_cookie_op)
 
 #include "cls/replica_log/cls_replica_log_types.h"
 TYPE(cls_replica_log_item_marker)

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -30,6 +30,7 @@ set(unittest_librbd_srcs
   test_mock_Journal.cc
   test_mock_ObjectWatcher.cc
   exclusive_lock/test_mock_AcquireRequest.cc
+  exclusive_lock/test_mock_ReacquireRequest.cc
   exclusive_lock/test_mock_ReleaseRequest.cc
   image/test_mock_RefreshRequest.cc
   journal/test_mock_Replay.cc

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -33,6 +33,7 @@ set(unittest_librbd_srcs
   exclusive_lock/test_mock_ReacquireRequest.cc
   exclusive_lock/test_mock_ReleaseRequest.cc
   image/test_mock_RefreshRequest.cc
+  image_watcher/test_mock_RewatchRequest.cc
   journal/test_mock_Replay.cc
   object_map/test_mock_InvalidateRequest.cc
   object_map/test_mock_LockRequest.cc

--- a/src/test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc
@@ -15,20 +15,9 @@
 #include <arpa/inet.h>
 #include <list>
 
-namespace librbd {
-namespace {
-
-struct MockTestImageCtx : public librbd::MockImageCtx {
-  MockTestImageCtx(librbd::ImageCtx &image_ctx)
-    : librbd::MockImageCtx(image_ctx) {
-  }
-};
-
-} // anonymous namespace
-} // namespace librbd
-
 // template definitions
 #include "librbd/exclusive_lock/ReacquireRequest.cc"
+template class librbd::exclusive_lock::ReacquireRequest<librbd::MockImageCtx>;
 
 namespace librbd {
 namespace exclusive_lock {
@@ -40,10 +29,10 @@ using ::testing::StrEq;
 
 class TestMockExclusiveLockReacquireRequest : public TestMockFixture {
 public:
-  typedef ReacquireRequest<MockTestImageCtx> MockReacquireRequest;
-  typedef ExclusiveLock<MockTestImageCtx> MockExclusiveLock;
+  typedef ReacquireRequest<MockImageCtx> MockReacquireRequest;
+  typedef ExclusiveLock<MockImageCtx> MockExclusiveLock;
 
-  void expect_set_cookie(MockTestImageCtx &mock_image_ctx, int r) {
+  void expect_set_cookie(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                 exec(mock_image_ctx.header_oid, _, StrEq("lock"),
                      StrEq("set_cookie"), _, _, _))
@@ -57,7 +46,7 @@ TEST_F(TestMockExclusiveLockReacquireRequest, Success) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageCtx mock_image_ctx(*ictx);
 
   InSequence seq;
   expect_set_cookie(mock_image_ctx, 0);
@@ -76,7 +65,7 @@ TEST_F(TestMockExclusiveLockReacquireRequest, NotSupported) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageCtx mock_image_ctx(*ictx);
 
   InSequence seq;
   expect_set_cookie(mock_image_ctx, -EOPNOTSUPP);
@@ -95,7 +84,7 @@ TEST_F(TestMockExclusiveLockReacquireRequest, Error) {
   librbd::ImageCtx *ictx;
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
-  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageCtx mock_image_ctx(*ictx);
 
   InSequence seq;
   expect_set_cookie(mock_image_ctx, -EBUSY);

--- a/src/test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_ReacquireRequest.cc
@@ -1,0 +1,112 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockImageState.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "cls/lock/cls_lock_ops.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/exclusive_lock/ReacquireRequest.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <arpa/inet.h>
+#include <list>
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+// template definitions
+#include "librbd/exclusive_lock/ReacquireRequest.cc"
+
+namespace librbd {
+namespace exclusive_lock {
+
+using ::testing::_;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::StrEq;
+
+class TestMockExclusiveLockReacquireRequest : public TestMockFixture {
+public:
+  typedef ReacquireRequest<MockTestImageCtx> MockReacquireRequest;
+  typedef ExclusiveLock<MockTestImageCtx> MockExclusiveLock;
+
+  void expect_set_cookie(MockTestImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, StrEq("lock"),
+                     StrEq("set_cookie"), _, _, _))
+                  .WillOnce(Return(r));
+  }
+};
+
+TEST_F(TestMockExclusiveLockReacquireRequest, Success) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_set_cookie(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockReacquireRequest *req = MockReacquireRequest::create(mock_image_ctx,
+                                                           "old cookie",
+                                                           "new cookie", &ctx);
+  req->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockReacquireRequest, NotSupported) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_set_cookie(mock_image_ctx, -EOPNOTSUPP);
+
+  C_SaferCond ctx;
+  MockReacquireRequest *req = MockReacquireRequest::create(mock_image_ctx,
+                                                           "old cookie",
+                                                           "new cookie", &ctx);
+  req->send();
+  ASSERT_EQ(-EOPNOTSUPP, ctx.wait());
+}
+
+TEST_F(TestMockExclusiveLockReacquireRequest, Error) {
+  REQUIRE_FEATURE(RBD_FEATURE_EXCLUSIVE_LOCK);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_set_cookie(mock_image_ctx, -EBUSY);
+
+  C_SaferCond ctx;
+  MockReacquireRequest *req = MockReacquireRequest::create(mock_image_ctx,
+                                                           "old cookie",
+                                                           "new cookie", &ctx);
+  req->send();
+  ASSERT_EQ(-EBUSY, ctx.wait());
+}
+
+} // namespace exclusive_lock
+} // namespace librbd

--- a/src/test/librbd/image_watcher/test_mock_RewatchRequest.cc
+++ b/src/test/librbd/image_watcher/test_mock_RewatchRequest.cc
@@ -1,0 +1,215 @@
+// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "include/rados/librados.hpp"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "test/librbd/test_support.h"
+#include "test/librbd/mock/MockExclusiveLock.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "librados/AioCompletionImpl.h"
+#include "librbd/image_watcher/RewatchRequest.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public MockImageCtx {
+  MockTestImageCtx(ImageCtx &image_ctx) : MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+#include "librbd/image_watcher/RewatchRequest.cc"
+
+namespace librbd {
+namespace image_watcher {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::WithArg;
+
+struct TestMockImageWatcherRewatchRequest : public TestMockFixture {
+  typedef RewatchRequest<librbd::MockTestImageCtx> MockRewatchRequest;
+
+  TestMockImageWatcherRewatchRequest()
+    : m_watch_lock("watch_lock") {
+  }
+
+  void expect_aio_watch(MockImageCtx &mock_image_ctx, int r) {
+    librados::MockTestMemIoCtxImpl &mock_io_ctx(get_mock_io_ctx(
+      mock_image_ctx.md_ctx));
+
+    EXPECT_CALL(mock_io_ctx, aio_watch(mock_image_ctx.header_oid, _, _, _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([&mock_image_ctx, &mock_io_ctx, r](librados::AioCompletionImpl *c) {
+                                   c->get();
+                                   mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([&mock_io_ctx, c](int r) {
+                                       mock_io_ctx.get_mock_rados_client()->finish_aio_completion(c, r);
+                                     }), r);
+                                   })),
+                      Return(0)));
+  }
+
+  void expect_aio_unwatch(MockImageCtx &mock_image_ctx, int r) {
+    librados::MockTestMemIoCtxImpl &mock_io_ctx(get_mock_io_ctx(
+      mock_image_ctx.md_ctx));
+
+    EXPECT_CALL(mock_io_ctx, aio_unwatch(m_watch_handle, _))
+      .WillOnce(DoAll(Invoke([&mock_image_ctx, &mock_io_ctx, r](uint64_t handle,
+                                                                librados::AioCompletionImpl *c) {
+                        c->get();
+                        mock_image_ctx.image_ctx->op_work_queue->queue(new FunctionContext([&mock_io_ctx, c](int r) {
+                            mock_io_ctx.get_mock_rados_client()->finish_aio_completion(c, r);
+                          }), r);
+                        }),
+                      Return(0)));
+  }
+
+  void expect_reacquire_lock(MockExclusiveLock &mock_exclusive_lock) {
+    EXPECT_CALL(mock_exclusive_lock, reacquire_lock());
+  }
+
+  struct WatchCtx : public librados::WatchCtx2 {
+    virtual void handle_notify(uint64_t, uint64_t, uint64_t,
+                               ceph::bufferlist&) {
+      assert(false);
+    }
+    virtual void handle_error(uint64_t, int) {
+      assert(false);
+    }
+  };
+
+  RWLock m_watch_lock;
+  WatchCtx m_watch_ctx;
+  uint64_t m_watch_handle = 123;
+};
+
+TEST_F(TestMockImageWatcherRewatchRequest, Success) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_aio_unwatch(mock_image_ctx, 0);
+  expect_aio_watch(mock_image_ctx, 0);
+
+  MockExclusiveLock mock_exclusive_lock;
+  if (ictx->test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+    mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+    expect_reacquire_lock(mock_exclusive_lock);
+  }
+
+  C_SaferCond ctx;
+  MockRewatchRequest *req = MockRewatchRequest::create(mock_image_ctx,
+                                                       m_watch_lock,
+                                                       &m_watch_ctx,
+                                                       &m_watch_handle,
+                                                       &ctx);
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    req->send();
+  }
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageWatcherRewatchRequest, UnwatchError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_aio_unwatch(mock_image_ctx, -EINVAL);
+  expect_aio_watch(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockRewatchRequest *req = MockRewatchRequest::create(mock_image_ctx,
+                                                       m_watch_lock,
+                                                       &m_watch_ctx,
+                                                       &m_watch_handle,
+                                                       &ctx);
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    req->send();
+  }
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageWatcherRewatchRequest, WatchBlacklist) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_aio_unwatch(mock_image_ctx, 0);
+  expect_aio_watch(mock_image_ctx, -EBLACKLISTED);
+
+  C_SaferCond ctx;
+  MockRewatchRequest *req = MockRewatchRequest::create(mock_image_ctx,
+                                                       m_watch_lock,
+                                                       &m_watch_ctx,
+                                                       &m_watch_handle,
+                                                       &ctx);
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    req->send();
+  }
+  ASSERT_EQ(-EBLACKLISTED, ctx.wait());
+}
+
+TEST_F(TestMockImageWatcherRewatchRequest, WatchDNE) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_aio_unwatch(mock_image_ctx, 0);
+  expect_aio_watch(mock_image_ctx, -ENOENT);
+
+  C_SaferCond ctx;
+  MockRewatchRequest *req = MockRewatchRequest::create(mock_image_ctx,
+                                                       m_watch_lock,
+                                                       &m_watch_ctx,
+                                                       &m_watch_handle,
+                                                       &ctx);
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    req->send();
+  }
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageWatcherRewatchRequest, WatchError) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+
+  InSequence seq;
+  expect_aio_unwatch(mock_image_ctx, 0);
+  expect_aio_watch(mock_image_ctx, -EINVAL);
+  expect_aio_watch(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  MockRewatchRequest *req = MockRewatchRequest::create(mock_image_ctx,
+                                                       m_watch_lock,
+                                                       &m_watch_ctx,
+                                                       &m_watch_handle,
+                                                       &ctx);
+  {
+    RWLock::WLocker watch_locker(m_watch_lock);
+    req->send();
+  }
+  ASSERT_EQ(0, ctx.wait());
+}
+
+} // namespace image_watcher
+} // namespace librbd

--- a/src/test/librbd/mock/MockExclusiveLock.h
+++ b/src/test/librbd/mock/MockExclusiveLock.h
@@ -19,6 +19,8 @@ struct MockExclusiveLock {
 
   MOCK_METHOD2(init, void(uint64_t features, Context*));
   MOCK_METHOD1(shut_down, void(Context*));
+
+  MOCK_METHOD0(reacquire_lock, void());
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockImageState.h
+++ b/src/test/librbd/mock/MockImageState.h
@@ -13,7 +13,6 @@ namespace librbd {
 struct MockImageState {
   MOCK_CONST_METHOD0(is_refresh_required, bool());
   MOCK_METHOD1(refresh, void(Context*));
-  MOCK_METHOD1(acquire_lock_refresh, void(Context*));
 
   MOCK_METHOD1(open, void(Context*));
 

--- a/src/test/librbd/mock/MockImageState.h
+++ b/src/test/librbd/mock/MockImageState.h
@@ -21,6 +21,9 @@ struct MockImageState {
   MOCK_METHOD1(close, void(Context*));
 
   MOCK_METHOD2(snap_set, void(const std::string &, Context*));
+
+  MOCK_METHOD1(prepare_lock, void(Context*));
+  MOCK_METHOD0(handle_prepare_lock_complete, void());
 };
 
 } // namespace librbd

--- a/src/test/librbd/test_mock_fixture.cc
+++ b/src/test/librbd/test_mock_fixture.cc
@@ -9,12 +9,10 @@
 // template definitions
 #include "librbd/AsyncRequest.cc"
 #include "librbd/AsyncObjectThrottle.cc"
-#include "librbd/ExclusiveLock.cc"
 #include "librbd/operation/Request.cc"
 
 template class librbd::AsyncRequest<librbd::MockImageCtx>;
 template class librbd::AsyncObjectThrottle<librbd::MockImageCtx>;
-template class librbd::ExclusiveLock<librbd::MockImageCtx>;
 template class librbd::operation::Request<librbd::MockImageCtx>;
 
 using ::testing::_;


### PR DESCRIPTION
It was previously possible for an image refresh and lock operation to race and result in sporadic assertion failures.