### PR TITLE
cmake: recompile erasure src for different variants

### DIFF
--- a/src/erasure-code/CMakeLists.txt
+++ b/src/erasure-code/CMakeLists.txt
@@ -6,6 +6,24 @@ set(erasure_plugin_dir ${CMAKE_INSTALL_PKGLIBDIR}/erasure-code)
 include_directories(jerasure/jerasure/include)
 include_directories(jerasure/gf-complete/include)
 include_directories(jerasure)
+
+
+if(TRUE)
+  list(APPEND jerasure_flavors generic)
+endif()
+
+if(ARM_NEON OR ARM_NEON2)
+  list(APPEND jerasure_flavors neon)
+endif()
+
+if(INTEL_SSE)
+  list(APPEND jerasure_flavors sse3)
+endif()
+
+if(INTEL_SSE4_1)
+  list(APPEND jerasure_flavors sse4)
+endif()
+
 add_subdirectory(jerasure)
 add_subdirectory(lrc)
 add_subdirectory(shec)

--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -1,6 +1,16 @@
 # jerasure plugin
 
-set(jerasure_obj_srcs
+add_library(jerasure_utils OBJECT
+  ErasureCodePluginJerasure.cc
+  ErasureCodeJerasure.cc)
+add_dependencies(jerasure_utils ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
+
+add_library(ec_jerasure SHARED ErasureCodePluginSelectJerasure.cc)
+add_dependencies(ec_jerasure ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
+target_link_libraries(ec_jerasure ${EXTRALIBS})
+install(TARGETS ec_jerasure DESTINATION ${erasure_plugin_dir})
+
+set(jerasure_srcs
   jerasure/src/cauchy.c
   jerasure/src/galois.c
   jerasure/src/jerasure.c
@@ -16,81 +26,45 @@ set(jerasure_obj_srcs
   gf-complete/src/gf_general.c
   gf-complete/src/gf_w4.c
   gf-complete/src/gf_rand.c
-  gf-complete/src/gf_w8.c
-  )
-add_library(jerasure_objs OBJECT ${jerasure_obj_srcs})
+  gf-complete/src/gf_w8.c)
 
-add_library(ec_jerasure_objs OBJECT
-  ErasureCodePluginJerasure.cc
-  ErasureCodeJerasure.cc
-  )
+list(FIND jerasure_flavors generic found)
+if(found GREATER -1)
+  add_library(jerasure_generic OBJECT ${jerasure_srcs})
+endif()
 
-add_library(ec_jerasure_generic SHARED 
-  $<TARGET_OBJECTS:ec_jerasure_objs>
-  $<TARGET_OBJECTS:jerasure_objs>
-  $<TARGET_OBJECTS:erasure_code_objs>
-  )
-add_dependencies(ec_jerasure_generic ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ec_jerasure_generic ${EXTRALIBS})
-set_target_properties(ec_jerasure_generic PROPERTIES VERSION 2.0.0 SOVERSION 2)
-install(TARGETS ec_jerasure_generic DESTINATION ${erasure_plugin_dir})
-
-# ec_jerasure_neon
-#TODO:build libec_jerasure_neon library on an ARM machine
-if(ARM_NEON OR ARM_NEON2)
-  set(neon_objs_srcs
+list(FIND jerasure_flavors neon found)
+if(found GREATER -1)
+  add_library(jerasure_neon OBJECT
     gf-complete/src/neon/gf_w4_neon.c
     gf-complete/src/neon/gf_w8_neon.c
     gf-complete/src/neon/gf_w16_neon.c
     gf-complete/src/neon/gf_w32_neon.c
     gf-complete/src/neon/gf_w64_neon.c)
-  add_library(neon_objs OBJECT ${neon_objs_srcs})
-  set_target_properties(neon_objs PROPERTIES COMPILE_FLAGS ${ARM_NEON_FLAGS})
-
-  set(jerasure_neon_srcs
-    $<TARGET_OBJECTS:ec_jerasure_objs>
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:neon_objs>
-    $<TARGET_OBJECTS:erasure_code_objs>
-    )
-  add_library(ec_jerasure_neon SHARED ${jerasure_neon_srcs})
-  add_dependencies(ec_jerasure_neon ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_jerasure_neon crush pthread ${EXTRALIBS})
-  set_target_properties(ec_jerasure_neon PROPERTIES VERSION 2.0.0 SOVERSION 2
+  set_target_properties(jerasure_neon PROPERTIES
     COMPILE_FLAGS ${ARM_NEON_FLAGS})
-  install(TARGETS ec_jerasure_neon DESTINATION ${erasure_plugin_dir})
-endif(ARM_NEON OR ARM_NEON2)
+endif()
 
-# ec_jerasure_sse3
-if(INTEL_SSE)
-  add_library(ec_jerasure_sse3 SHARED 
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:ec_jerasure_objs>
-    $<TARGET_OBJECTS:erasure_code_objs>
-    )
-  add_dependencies(ec_jerasure_sse3 ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_jerasure_sse3 crush ${EXTRALIBS})
-  set_target_properties(ec_jerasure_sse3 PROPERTIES VERSION 2.0.0 SOVERSION 2
+list(FIND jerasure_flavors sse3 found)
+if(found GREATER -1)
+  add_library(jerasure_sse3 OBJECT ${jerasure_srcs})
+  set_target_properties(jerasure_sse3 PROPERTIES
     COMPILE_FLAGS ${SSE3_FLAGS})
-  install(TARGETS ec_jerasure_sse3 DESTINATION ${erasure_plugin_dir})
-endif(INTEL_SSE)
+endif()
 
-# ec_jerasure_sse4
-if(INTEL_SSE4_1)
-  add_library(ec_jerasure_sse4 SHARED 
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:ec_jerasure_objs>
-    $<TARGET_OBJECTS:erasure_code_objs>
-    )
-  add_dependencies(ec_jerasure_sse4 ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_jerasure_sse4 crush ${EXTRALIBS})
-  set_target_properties(ec_jerasure_sse4 PROPERTIES VERSION 2.0.0 SOVERSION 2
+list(FIND jerasure_flavors sse4 found)
+if(found GREATER -1)
+  add_library(jerasure_sse4 OBJECT ${jerasure_srcs})
+  set_target_properties(jerasure_sse4 PROPERTIES
     COMPILE_FLAGS ${SSE4_FLAGS})
-  install(TARGETS ec_jerasure_sse4 DESTINATION ${erasure_plugin_dir})
-endif(INTEL_SSE4_1)
+endif()
 
-add_library(ec_jerasure SHARED ErasureCodePluginSelectJerasure.cc)
-add_dependencies(ec_jerasure ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ec_jerasure ${EXTRALIBS})
-set_target_properties(ec_jerasure PROPERTIES VERSION 2.0.0 SOVERSION 2)
-install(TARGETS ec_jerasure DESTINATION ${erasure_plugin_dir})
+foreach(flavor ${jerasure_flavors})
+  set(plugin_name "ec_jerasure_${flavor}")
+  add_library(${plugin_name} SHARED
+    $<TARGET_OBJECTS:jerasure_${flavor}>
+    $<TARGET_OBJECTS:jerasure_utils>
+    $<TARGET_OBJECTS:erasure_code_objs>)
+  target_link_libraries(${plugin_name} ${EXTRALIBS})
+  install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})
+endforeach(flavor flavors)

--- a/src/erasure-code/lrc/CMakeLists.txt
+++ b/src/erasure-code/lrc/CMakeLists.txt
@@ -10,5 +10,4 @@ set(lrc_srcs
 add_library(ec_lrc SHARED ${lrc_srcs})
 add_dependencies(ec_lrc ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_lrc crush json_spirit)
-set_target_properties(ec_lrc PROPERTIES VERSION 1.0.0 SOVERSION 1)
 install(TARGETS ec_lrc DESTINATION ${erasure_plugin_dir})

--- a/src/erasure-code/shec/CMakeLists.txt
+++ b/src/erasure-code/shec/CMakeLists.txt
@@ -2,66 +2,24 @@
 
 include_directories(.)
 
-set(shec_objs_srcs
+add_library(shec_utils OBJECT
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc 
   ErasureCodePluginShec.cc 
   ErasureCodeShec.cc 
   ErasureCodeShecTableCache.cc 
-  determinant.c 
-  )
-
-add_library(shec_objs OBJECT ${shec_objs_srcs})
-
-add_library(ec_shec_generic SHARED 
-  $<TARGET_OBJECTS:jerasure_objs>
-  $<TARGET_OBJECTS:shec_objs>)
-target_link_libraries(ec_shec_generic crush pthread)
-add_dependencies(ec_shec_generic ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-set_target_properties(ec_shec_generic PROPERTIES VERSION 1.0.0 SOVERSION 1)
-install(TARGETS ec_shec_generic DESTINATION ${erasure_plugin_dir})
-
-# ec_shec_neon
-#TODO:build libec_shec_neon library on an ARM machine
-if(ARM_NEON OR ARM_NEON2)
-  set(shec_neon_srcs
-    $<TARGET_OBJECTS:shec_objs>
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:neon_objs>
-    )
-  add_library(ec_shec_neon SHARED ${shec_neon_srcs})
-  add_dependencies(ec_shec_neon ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_shec_neon ${EXTRALIBS})
-  set_target_properties(ec_shec_neon PROPERTIES VERSION 2.0.0 SOVERSION 2
-    COMPILE_FLAGS ${ARM_NEON_FLAGS})
-  install(TARGETS ec_shec_neon DESTINATION ${erasure_plugin_dir})
-endif(ARM_NEON OR ARM_NEON2)
-
-# ec_shec_sse3
-if(INTEL_SSE)
-  add_library(ec_shec_sse3 SHARED 
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:shec_objs>)
-  add_dependencies(ec_shec_sse3 ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_shec_sse3 crush ${EXTRALIBS})
-  set_target_properties(ec_shec_sse3 PROPERTIES VERSION 2.0.0 SOVERSION 2
-    COMPILE_FLAGS ${SSE3_FLAGS})
-  install(TARGETS ec_shec_sse3 DESTINATION ${erasure_plugin_dir})
-endif(INTEL_SSE)
-
-# ec_shec_sse4
-if(INTEL_SSE4_1)
-  add_library(ec_shec_sse4 SHARED 
-    $<TARGET_OBJECTS:jerasure_objs>
-    $<TARGET_OBJECTS:shec_objs>)
-  add_dependencies(ec_shec_sse4 ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-  target_link_libraries(ec_shec_sse4 crush ${EXTRALIBS})
-  set_target_properties(ec_shec_sse4 PROPERTIES VERSION 2.0.0 SOVERSION 2
-    COMPILE_FLAGS ${SSE4_FLAGS})
-  install(TARGETS ec_shec_sse4 DESTINATION ${erasure_plugin_dir})
-endif(INTEL_SSE4_1)
+  determinant.c)
+add_dependencies(shec_utils ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 
 add_library(ec_shec SHARED ErasureCodePluginSelectShec.cc)
 add_dependencies(ec_shec ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_shec ${EXTRALIBS})
-set_target_properties(ec_shec PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ec_shec DESTINATION ${erasure_plugin_dir})
+
+foreach(flavor ${jerasure_flavors})
+  set(plugin_name "ec_shec_${flavor}")
+  add_library(${plugin_name} SHARED
+    $<TARGET_OBJECTS:jerasure_${flavor}>
+    $<TARGET_OBJECTS:shec_utils>)
+  target_link_libraries(${plugin_name} ${EXTRALIBS})
+  install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})
+endforeach(flavor flavors)


### PR DESCRIPTION
* instead of reusing the object libraries, we should recompile jerasure
  code for different plugin flavors like neon, sse3, sse4.
* do not version plugin so, as they are not supposed to be used by
  user directly.

Signed-off-by: Kefu Chai <kchai@redhat.com>