### PR TITLE
os/bluestore: fix decoding hash of bnode

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -276,7 +276,9 @@ static int get_key_bnode(const string& key, shard_id_t *shard,
   p = _key_decode_shard(p, shard);
   p = _key_decode_u64(p, (uint64_t*)pool);
   *pool -= 0x8000000000000000ull;
-  p = _key_decode_u32(p, hash);
+  uint32_t hash_reverse_bits;
+  p = _key_decode_u32(p, &hash_reverse_bits);
+  *hash = hobject_t::_reverse_bits(hash_reverse_bits);
   return 0;
 }
 


### PR DESCRIPTION
We encode reversed bits of hash and then write it onto disk,
therefore we shall decode and then reserse to get it back.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>