### PR TITLE
rgw ldap:  protect rgw::from_base64 from non-base64 input

### DIFF
--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -710,7 +710,12 @@ public:
       store(store),
       apl_factory(apl_factory) {
       init(cct);
-      base64_token = rgw::from_base64(access_key_id);
+      /* boost filters and/or string_ref may throw on invalid input */
+      try {
+	base64_token = rgw::from_base64(access_key_id);
+      } catch(...) {
+	base64_token = std::string("");
+      }
   }
   const char* get_name() const noexcept override {
     return "RGWLDAPAuthEngine";

--- a/src/test/test_rgw_token.cc
+++ b/src/test/test_rgw_token.cc
@@ -43,6 +43,9 @@ namespace {
 
   std::string enc_ldap{"ewogICAgIlJHV19UT0tFTiI6IHsKICAgICAgICAidmVyc2lvbiI6IDEsCiAgICAgICAgInR5cGUiOiAibGRhcCIsCiAgICAgICAgImlkIjogIlNtb25ueSIsCiAgICAgICAgImtleSI6ICJUdXJqYW4gb2YgTWlpciIKICAgIH0KfQo="};
 
+  std::string non_base64{"stuff here"};
+  std::string non_base64_sploded{"90KLscc0Dz4U49HX-7Tx"};
+
   Formatter* formatter{nullptr};
   bool verbose {false};
 }
@@ -69,6 +72,31 @@ TEST(TOKEN, DECODE) {
     ASSERT_EQ(token.id, access_key);
     ASSERT_EQ(token.key, secret_key);
   }
+}
+
+TEST(TOKEN, EMPTY) {
+    std::string empty{""};
+    RGWToken token{from_base64(empty)}; // decode ctor
+    ASSERT_FALSE(token.valid());
+}
+
+TEST(TOKEN, BADINPUT) {
+    RGWToken token{from_base64(non_base64)}; // decode ctor
+    ASSERT_FALSE(token.valid());
+}
+
+TEST(TOKEN, BADINPUT2) {
+    RGWToken token{from_base64(non_base64_sploded)}; // decode ctor
+    ASSERT_FALSE(token.valid());
+}
+
+TEST(TOKEN, BADINPUT3) {
+  try {
+    std::string stuff = from_base64(non_base64_sploded); // decode
+  } catch(...) {
+    // do nothing
+  }
+  ASSERT_EQ(1, 1);
 }
 
 TEST(TOKEN, SHUTDOWN) {


### PR DESCRIPTION
Also adds unit tests for:
1. empty output from from_base64 (turns out to be harmless)
2. random and specific non-base64 and sort strings

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>