### PR TITLE
qa/workunits/rados/test_python.sh: Allow specifying Python executable

### DIFF
--- a/qa/workunits/rados/test_python.sh
+++ b/qa/workunits/rados/test_python.sh
@@ -4,5 +4,5 @@ CEPH_REF=${CEPH_REF:-master}
 #wget -q https://raw.github.com/ceph/ceph/$CEPH_REF/src/test/pybind/test_rados.py
 wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=$CEPH_REF;f=src/test/pybind/test_rados.py" || \
     wget -O test_rados.py "https://git.ceph.com/?p=ceph.git;a=blob_plain;hb=ref/heads/$CEPH_REF;f=src/test/pybind/test_rados.py"
-nosetests -v test_rados
+${PYTHON:-python} -m nose -v test_rados
 exit 0


### PR DESCRIPTION
`python -m nose` is equivalent to `nosetests`, so the default behavior is unchanged, but setting the `PYTHON` environment variable allows the used Python executable to be overridden, so the tests can run against a different Python version.