### PR TITLE
jewel: rbd-mirror: image deleter should use pool id + global image uuid for key

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1559,7 +1559,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   err_close_child:
     c_imctx->state->close();
   err_remove:
-    partial_r = remove(c_ioctx, c_name, no_op);
+    partial_r = remove(c_ioctx, c_name, "", no_op);
     if (partial_r < 0) {
       lderr(cct) << "Error removing failed clone: "
 		 << cpp_strerror(partial_r) << dendl;
@@ -2013,16 +2013,20 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     return 0;
   }
 
-  int remove(IoCtx& io_ctx, const char *imgname, ProgressContext& prog_ctx,
+  int remove(IoCtx& io_ctx, const std::string &image_name,
+             const std::string &image_id, ProgressContext& prog_ctx,
              bool force)
   {
     CephContext *cct((CephContext *)io_ctx.cct());
-    ldout(cct, 20) << "remove " << &io_ctx << " " << imgname << dendl;
+    ldout(cct, 20) << "remove " << &io_ctx << " "
+                   << (image_id.empty() ? image_name : image_id) << dendl;
 
-    string id;
+    std::string name(image_name);
+    std::string id(image_id);
     bool old_format = false;
     bool unknown_format = true;
-    ImageCtx *ictx = new ImageCtx(imgname, "", NULL, io_ctx, false);
+    ImageCtx *ictx = new ImageCtx(
+      (id.empty() ? name : std::string()), id, nullptr, io_ctx, false);
     int r = ictx->state->open();
     if (r < 0) {
       ldout(cct, 2) << "error opening image: " << cpp_strerror(-r) << dendl;
@@ -2031,6 +2035,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       string header_oid = ictx->header_oid;
       old_format = ictx->old_format;
       unknown_format = false;
+      name = ictx->name;
       id = ictx->id;
 
       ictx->owner_lock.get_read();
@@ -2125,7 +2130,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 
     if (old_format || unknown_format) {
       ldout(cct, 2) << "removing rbd image from v1 directory..." << dendl;
-      r = tmap_rm(io_ctx, imgname);
+      r = tmap_rm(io_ctx, name);
       old_format = (r == 0);
       if (r < 0 && !unknown_format) {
         if (r != -ENOENT) {
@@ -2138,12 +2143,20 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     if (!old_format) {
       if (id.empty()) {
         ldout(cct, 5) << "attempting to determine image id" << dendl;
-        r = cls_client::dir_get_id(&io_ctx, RBD_DIRECTORY, imgname, &id);
+        r = cls_client::dir_get_id(&io_ctx, RBD_DIRECTORY, name, &id);
         if (r < 0 && r != -ENOENT) {
           lderr(cct) << "error getting id of image" << dendl;
           return r;
         }
+      } else if (name.empty()) {
+        ldout(cct, 5) << "attempting to determine image name" << dendl;
+        r = cls_client::dir_get_name(&io_ctx, RBD_DIRECTORY, id, &name);
+        if (r < 0 && r != -ENOENT) {
+          lderr(cct) << "error getting name of image" << dendl;
+          return r;
+        }
       }
+
       if (!id.empty()) {
         ldout(cct, 10) << "removing journal..." << dendl;
         r = Journal<>::remove(io_ctx, id);
@@ -2170,7 +2183,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       }
 
       ldout(cct, 2) << "removing id object..." << dendl;
-      r = io_ctx.remove(util::id_obj_name(imgname));
+      r = io_ctx.remove(util::id_obj_name(name));
       if (r < 0 && r != -ENOENT) {
 	lderr(cct) << "error removing id object: " << cpp_strerror(r)
                    << dendl;
@@ -2178,7 +2191,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       }
 
       ldout(cct, 2) << "removing rbd image from v2 directory..." << dendl;
-      r = cls_client::dir_remove_image(&io_ctx, RBD_DIRECTORY, imgname, id);
+      r = cls_client::dir_remove_image(&io_ctx, RBD_DIRECTORY, name, id);
       if (r < 0) {
         if (r != -ENOENT) {
           lderr(cct) << "error removing image from v2 directory: "

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -134,8 +134,9 @@ namespace librbd {
   int set_image_notification(ImageCtx *ictx, int fd, int type);
   int is_exclusive_lock_owner(ImageCtx *ictx, bool *is_owner);
 
-  int remove(librados::IoCtx& io_ctx, const char *imgname,
-	     ProgressContext& prog_ctx, bool force=false);
+  int remove(librados::IoCtx& io_ctx, const std::string &image_name,
+             const std::string &image_id, ProgressContext& prog_ctx,
+             bool force=false);
   int snap_list(ImageCtx *ictx, std::vector<snap_info_t>& snaps);
   int snap_exists(ImageCtx *ictx, const char *snap_name, bool *exists);
   int snap_is_protected(ImageCtx *ictx, const char *snap_name,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -371,7 +371,7 @@ namespace librbd {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
     librbd::NoOpProgressContext prog_ctx;
-    int r = librbd::remove(io_ctx, name, prog_ctx);
+    int r = librbd::remove(io_ctx, name, "", prog_ctx);
     tracepoint(librbd, remove_exit, r);
     return r;
   }
@@ -381,7 +381,7 @@ namespace librbd {
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
-    int r = librbd::remove(io_ctx, name, pctx);
+    int r = librbd::remove(io_ctx, name, "", pctx);
     tracepoint(librbd, remove_exit, r);
     return r;
   }
@@ -1706,7 +1706,7 @@ extern "C" int rbd_remove(rados_ioctx_t p, const char *name)
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
   librbd::NoOpProgressContext prog_ctx;
-  int r = librbd::remove(io_ctx, name, prog_ctx);
+  int r = librbd::remove(io_ctx, name, "", prog_ctx);
   tracepoint(librbd, remove_exit, r);
   return r;
 }
@@ -1719,7 +1719,7 @@ extern "C" int rbd_remove_with_progress(rados_ioctx_t p, const char *name,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
   librbd::CProgressContext prog_ctx(cb, cbdata);
-  int r = librbd::remove(io_ctx, name, prog_ctx);
+  int r = librbd::remove(io_ctx, name, "", prog_ctx);
   tracepoint(librbd, remove_exit, r);
   return r;
 }

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -447,7 +447,7 @@ TEST_F(TestMockImageRefreshRequest, SuccessChild) {
     }
 
     librbd::NoOpProgressContext no_op;
-    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name.c_str(), no_op));
+    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name, "", no_op));
     ASSERT_EQ(0, ictx->operations->snap_unprotect("snap"));
   };
 

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -252,7 +252,7 @@ TEST_F(TestInternal, FlattenFailsToLockImage) {
       parent->unlock_image();
     }
     librbd::NoOpProgressContext no_op;
-    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name.c_str(), no_op));
+    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name, "", no_op));
   } BOOST_SCOPE_EXIT_END;
 
   ASSERT_EQ(0, open_image(clone_name, &ictx2));
@@ -804,7 +804,7 @@ TEST_F(TestInternal, WriteFullCopyup) {
     }
 
     librbd::NoOpProgressContext remove_no_op;
-    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name.c_str(), remove_no_op));
+    ASSERT_EQ(0, librbd::remove(m_ioctx, clone_name, "", remove_no_op));
   } BOOST_SCOPE_EXIT_END;
 
   ASSERT_EQ(0, open_image(clone_name, &ictx2));
@@ -830,4 +830,17 @@ TEST_F(TestInternal, WriteFullCopyup) {
   ASSERT_EQ(read_bl.length(), ictx2->aio_work_queue->read(0, read_bl.length(),
                                                           read_bl.c_str(), 0));
   ASSERT_TRUE(bl.contents_equal(read_bl));
+}
+
+TEST_F(TestInternal, RemoveById) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  std::string image_id = ictx->id;
+  close_image(ictx);
+
+  librbd::NoOpProgressContext remove_no_op;
+  ASSERT_EQ(0, librbd::remove(m_ioctx, "", image_id, remove_no_op));
 }

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -216,7 +216,8 @@ TEST_F(TestImageDeleter, Delete_NonPrimary_Image) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -232,7 +233,8 @@ TEST_F(TestImageDeleter, Fail_Delete_Primary_Image) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-rbd::mirror::ImageDeleter::EISPRM, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -247,7 +249,8 @@ TEST_F(TestImageDeleter, Fail_Delete_Diff_GlobalId) {
       m_image_name, "diff global id");
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, "diff global id",
+                                         &ctx);
   EXPECT_EQ(-EINVAL, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -261,7 +264,8 @@ TEST_F(TestImageDeleter, Delete_Image_With_Child) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -276,7 +280,8 @@ TEST_F(TestImageDeleter, Delete_Image_With_Children) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -290,7 +295,8 @@ TEST_F(TestImageDeleter, Delete_Image_With_ProtectedChild) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -305,7 +311,8 @@ TEST_F(TestImageDeleter, Delete_Image_With_ProtectedChildren) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -319,7 +326,8 @@ TEST_F(TestImageDeleter, Delete_Image_With_Clone) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-EBUSY, ctx.wait());
 
   ASSERT_EQ(1u, m_deleter->get_delete_queue_items().size());
@@ -329,11 +337,13 @@ TEST_F(TestImageDeleter, Delete_Image_With_Clone) {
       "clone1", GLOBAL_CLONE_IMAGE_ID);
 
   C_SaferCond ctx2;
-  m_deleter->wait_for_scheduled_deletion("clone1", &ctx2);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_CLONE_IMAGE_ID,
+                                         &ctx2);
   EXPECT_EQ(0, ctx2.wait());
 
   C_SaferCond ctx3;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx3);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx3);
   EXPECT_EQ(0, ctx3.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -352,7 +362,8 @@ TEST_F(TestImageDeleter, Delete_NonExistent_Image) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -376,7 +387,8 @@ TEST_F(TestImageDeleter, Delete_NonExistent_Image_With_MirroringState) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(0, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -392,7 +404,8 @@ TEST_F(TestImageDeleter, Delete_NonExistent_Image_Without_MirroringState) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-ENOENT, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -410,7 +423,8 @@ TEST_F(TestImageDeleter, Fail_Delete_NonPrimary_Image) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-EBUSY, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -430,13 +444,15 @@ TEST_F(TestImageDeleter, Retry_Failed_Deletes) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-EBUSY, ctx.wait());
 
   EXPECT_EQ(0, ictx->state->close());
 
   C_SaferCond ctx2;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx2);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx2);
   EXPECT_EQ(0, ctx2.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());
@@ -454,7 +470,8 @@ TEST_F(TestImageDeleter, Delete_Is_Idempotent) {
       m_image_name, GLOBAL_IMAGE_ID);
 
   C_SaferCond ctx;
-  m_deleter->wait_for_scheduled_deletion(m_image_name, &ctx);
+  m_deleter->wait_for_scheduled_deletion(m_local_pool_id, GLOBAL_IMAGE_ID,
+                                         &ctx);
   EXPECT_EQ(-EBUSY, ctx.wait());
 
   ASSERT_EQ(0u, m_deleter->get_delete_queue_items().size());

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -102,7 +102,7 @@ public:
       promote_image();
     }
     NoOpProgressContext ctx;
-    int r = remove(m_local_io_ctx, m_image_name.c_str(), ctx, force);
+    int r = remove(m_local_io_ctx, m_image_name, "", ctx, force);
     EXPECT_EQ(1, r == 0 || r == -ENOENT);
   }
 

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -567,7 +567,7 @@ TEST_F(TestImageReplayer, Resync)
 
   C_SaferCond delete_ctx;
   m_image_deleter->wait_for_scheduled_deletion(
-    m_replayer->get_local_image_name(), &delete_ctx);
+    m_local_ioctx.get_id(), m_replayer->get_global_image_id(), &delete_ctx);
   EXPECT_EQ(0, delete_ctx.wait());
 
   C_SaferCond cond;
@@ -632,7 +632,7 @@ TEST_F(TestImageReplayer, Resync_While_Stop)
 
   C_SaferCond delete_ctx;
   m_image_deleter->wait_for_scheduled_deletion(
-    m_replayer->get_local_image_name(), &delete_ctx);
+    m_local_ioctx.get_id(), m_replayer->get_global_image_id(), &delete_ctx);
   EXPECT_EQ(0, delete_ctx.wait());
 
   C_SaferCond cond3;
@@ -673,7 +673,7 @@ TEST_F(TestImageReplayer, Resync_StartInterrupted)
 
   C_SaferCond delete_ctx;
   m_image_deleter->wait_for_scheduled_deletion(
-    m_replayer->get_local_image_name(), &delete_ctx);
+    m_local_ioctx.get_id(), m_replayer->get_global_image_id(), &delete_ctx);
   EXPECT_EQ(0, delete_ctx.wait());
 
   C_SaferCond cond2;

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -407,8 +407,7 @@ bool ImageDeleter::process_image_delete() {
   }
 
   librbd::NoOpProgressContext ctx;
-  r = librbd::remove(ioctx, m_active_delete->local_image_name.c_str(), ctx,
-                     true);
+  r = librbd::remove(ioctx, "", m_active_delete->local_image_id, ctx, true);
   if (r < 0 && r != -ENOENT) {
     derr << "error removing image " << m_active_delete->local_image_name
          << " from local pool: " << cpp_strerror(r) << dendl;

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -192,18 +192,18 @@ void ImageDeleter::run() {
 }
 
 void ImageDeleter::schedule_image_delete(RadosRef local_rados,
-                                         uint64_t local_pool_id,
+                                         int64_t local_pool_id,
                                          const std::string& local_image_id,
                                          const std::string& local_image_name,
                                          const std::string& global_image_id) {
   dout(20) << "enter" << dendl;
 
-  Mutex::Locker l(m_delete_lock);
+  Mutex::Locker locker(m_delete_lock);
 
-  auto del_info = find_delete_info(local_image_name);
+  auto del_info = find_delete_info(local_pool_id, global_image_id);
   if (del_info != nullptr) {
-    dout(20) << "image " << local_image_name << " was already scheduled for "
-             << "deletion" << dendl;
+    dout(20) << "image " << local_image_name << " (" << global_image_id << ") "
+             << "was already scheduled for deletion" << dendl;
     return;
   }
 
@@ -213,7 +213,8 @@ void ImageDeleter::schedule_image_delete(RadosRef local_rados,
   m_delete_queue_cond.Signal();
 }
 
-void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
+void ImageDeleter::wait_for_scheduled_deletion(int64_t local_pool_id,
+                                               const std::string &global_image_id,
                                                Context *ctx,
                                                bool notify_on_failed_retry) {
 
@@ -221,8 +222,8 @@ void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
       m_work_queue->queue(ctx, r);
     });
 
-  Mutex::Locker l(m_delete_lock);
-  auto del_info = find_delete_info(image_name);
+  Mutex::Locker locker(m_delete_lock);
+  auto del_info = find_delete_info(local_pool_id, global_image_id);
   if (!del_info) {
     // image not scheduled for deletion
     ctx->complete(0);
@@ -236,9 +237,10 @@ void ImageDeleter::wait_for_scheduled_deletion(const std::string& image_name,
   (*del_info)->notify_on_failed_retry = notify_on_failed_retry;
 }
 
-void ImageDeleter::cancel_waiter(const std::string& image_name) {
+void ImageDeleter::cancel_waiter(int64_t local_pool_id,
+                                 const std::string &global_image_id) {
   Mutex::Locker locker(m_delete_lock);
-  auto del_info = find_delete_info(image_name);
+  auto del_info = find_delete_info(local_pool_id, global_image_id);
   if (!del_info) {
     return;
   }
@@ -506,21 +508,22 @@ void ImageDeleter::retry_failed_deletions() {
 }
 
 unique_ptr<ImageDeleter::DeleteInfo> const* ImageDeleter::find_delete_info(
-    const std::string& image_name) {
+    int64_t local_pool_id, const std::string &global_image_id) {
   assert(m_delete_lock.is_locked());
 
-  if (m_active_delete && m_active_delete->match(image_name)) {
+  if (m_active_delete && m_active_delete->match(local_pool_id,
+                                                global_image_id)) {
     return &m_active_delete;
   }
 
   for (const auto& del_info : m_delete_queue) {
-    if (del_info->match(image_name)) {
+    if (del_info->match(local_pool_id, global_image_id)) {
       return &del_info;
     }
   }
 
   for (const auto& del_info : m_failed_queue) {
-    if (del_info->match(image_name)) {
+    if (del_info->match(local_pool_id, global_image_id)) {
       return &del_info;
     }
   }

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -740,7 +740,9 @@ void Replayer::start_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer
           }
        }
     );
-    m_image_deleter->wait_for_scheduled_deletion(image_name.get(), ctx, false);
+
+    m_image_deleter->wait_for_scheduled_deletion(
+      m_local_pool_id, image_replayer->get_global_image_id(), ctx, false);
   }
 }
 
@@ -752,7 +754,9 @@ bool Replayer::stop_image_replayer(unique_ptr<ImageReplayer<> > &image_replayer)
 
   // TODO: check how long it is stopping and alert if it is too long.
   if (image_replayer->is_stopped()) {
-    m_image_deleter->cancel_waiter(image_replayer->get_local_image_name());
+    m_image_deleter->cancel_waiter(m_local_pool_id,
+                                   image_replayer->get_global_image_id());
+
     if (!m_stopping.read()) {
       dout(20) << "scheduling delete" << dendl;
       m_image_deleter->schedule_image_delete(


### PR DESCRIPTION
http://tracker.ceph.com/issues/16902