### PR TITLE
jewel: rbd: bench io-size should not be larger than image size

### DIFF
--- a/src/tools/rbd/action/BenchWrite.cc
+++ b/src/tools/rbd/action/BenchWrite.cc
@@ -118,6 +118,14 @@ int do_bench_write(librbd::Image& image, uint64_t io_size,
                    uint64_t io_threads, uint64_t io_bytes,
                    bool random)
 {
+  uint64_t size = 0;
+  image.size(&size);
+  if (io_size > size) {
+    std::cerr << "rbd: io-size " << prettybyte_t(io_size) << " "
+              << "larger than image size " << prettybyte_t(size) << std::endl;
+    return -EINVAL;
+  }
+
   rbd_bencher b(&image);
 
   std::cout << "bench-write "
@@ -137,9 +145,6 @@ int do_bench_write(librbd::Image& image, uint64_t io_size,
   utime_t start = ceph_clock_now(NULL);
   utime_t last;
   unsigned ios = 0;
-
-  uint64_t size = 0;
-  image.size(&size);
 
   vector<uint64_t> thread_offset;
   uint64_t i;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17059