### PR TITLE
ceph.spec.in: don't try to package __pycache__

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1433,15 +1433,19 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{python3_sitearch}/cephfs.cpython*.so
 %{python3_sitearch}/cephfs-*.egg-info
 %{python3_sitelib}/ceph_volume_client.py
+%if ! 0%{?suse_version}
 %{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
+%endif
 
 #################################################################################
 %files -n python%{python3_pkgversion}-ceph-argparse
 %defattr(-,root,root,-)
 %{python3_sitelib}/ceph_argparse.py
-%{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
 %{python3_sitelib}/ceph_daemon.py
+%if ! 0%{?suse_version}
+%{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
 %{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
+%endif
 
 #################################################################################
 %files -n ceph-test


### PR DESCRIPTION
When building on openSUSE Tumbleweed, nothing seems to create
the various `__pycache__` directories (so the build fails because
those files don't exist), and in any case they should be
created automatically at runtime, so shouldn't need to be
packaged.

Signed-off-by: Tim Serong <tserong@suse.com>