### PR TITLE
test/librados: rados_connect() should succeed

### DIFF
--- a/src/test/librados/io.cc
+++ b/src/test/librados/io.cc
@@ -54,7 +54,7 @@ TEST_F(LibRadosIo, ReadTimeout) {
     ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
     ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
     ASSERT_EQ(0, rados_conf_set(cluster, "rados_osd_op_timeout", "0.00001")); // use any small value that will result in a timeout
-    ASSERT_NE(0, rados_connect(cluster));
+    ASSERT_EQ(0, rados_connect(cluster));
     ASSERT_EQ(0, rados_ioctx_create(cluster, pool_name.c_str(), &ioctx));
     rados_ioctx_set_namespace(ioctx, nspace.c_str());
 


### PR DESCRIPTION
the "rados_osd_op_timeout" setting does not apply to the initial connection.
this regression was introduced by 6c67073

Fixes: http://tracker.ceph.com/issues/17087
Signed-off-by: Kefu Chai <kchai@redhat.com>