### PR TITLE
ceph-osd-prestart.sh: check existence of OSD data directory

### DIFF
--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -18,6 +18,13 @@ if [ -z "$id"  ]; then
 fi
 
 data="/var/lib/ceph/osd/${cluster:-ceph}-$id"
+
+# assert data directory exists - see http://tracker.ceph.com/issues/17091
+if [ ! -d "$data" ]; then
+    echo "OSD data directory $data does not exist; bailing out." 1>&2
+    exit 1
+fi
+
 journal="$data/journal"
 
 if [ -L "$journal" -a ! -e "$journal" ]; then


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17091
Signed-off-by: Nathan Cutler <ncutler@suse.com>