### PR TITLE
osd/ReplicatedPG: remove unused param "op" from generate_subop()

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -993,7 +993,6 @@ Message * ReplicatedBackend::generate_subop(
   hobject_t discard_temp_oid,
   const vector<pg_log_entry_t> &log_entries,
   boost::optional<pg_hit_set_history_t> &hset_hist,
-  InProgressOp *op,
   ObjectStore::Transaction &op_t,
   pg_shard_t peer,
   const pg_info_t &pinfo)
@@ -1079,7 +1078,6 @@ void ReplicatedBackend::issue_op(
       discard_temp_oid,
       log_entries,
       hset_hist,
-      op,
       op_t,
       peer,
       pinfo);

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -371,7 +371,6 @@ private:
     hobject_t discard_temp_oid,
     const vector<pg_log_entry_t> &log_entries,
     boost::optional<pg_hit_set_history_t> &hset_history,
-    InProgressOp *op,
     ObjectStore::Transaction &op_t,
     pg_shard_t peer,
     const pg_info_t &pinfo);


### PR DESCRIPTION
Signed-off-by: jimifm <hong.zhangoole@gmail.com>