### PR TITLE
jewel: build/ops: ceph-osd-prestart.sh fails confusingly when data directory does not exist

### DIFF
--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -18,6 +18,13 @@ if [ -z "$id"  ]; then
 fi
 
 data="/var/lib/ceph/osd/${cluster:-ceph}-$id"
+
+# assert data directory exists - see http://tracker.ceph.com/issues/17091
+if [ ! -d "$data" ]; then
+    echo "OSD data directory $data does not exist; bailing out." 1>&2
+    exit 1
+fi
+
 journal="$data/journal"
 
 update="$(ceph-conf --cluster=${cluster:-ceph} --name=osd.$id --lookup osd_crush_update_on_start || :)"


### PR DESCRIPTION
http://tracker.ceph.com/issues/17094