### PR TITLE
os/bluestore: precondition rocksdb/bluefs during mkfs

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -960,6 +960,8 @@ OPTION(bluestore_block_wal_path, OPT_STR, "")
 OPTION(bluestore_block_wal_size, OPT_U64, 96 * 1024*1024) // rocksdb wal
 OPTION(bluestore_block_wal_create, OPT_BOOL, false)
 OPTION(bluestore_block_preallocate_file, OPT_BOOL, false) //whether preallocate space if block/db_path/wal_path is file rather that block device.
+OPTION(bluestore_precondition_bluefs, OPT_U64, 128*1024*1024)  // write this much data at mkfs
+OPTION(bluestore_precondition_bluefs_block, OPT_U64, 1048576)
 OPTION(bluestore_csum_type, OPT_STR, "crc32c") // none|xxhash32|xxhash64|crc32c|crc32c_16|crc32c_8
 OPTION(bluestore_min_csum_block, OPT_U32, 4096)
 OPTION(bluestore_max_csum_block, OPT_U32, 64*1024)


### PR DESCRIPTION
Write a bunc hof data through rocksdb so that we get all of the rocksdb log
files preallocated and there isn't a weird performance anamoly once the real
workload starts.

Simplify rocksdb options.