### PR TITLE
yasm-wrapper: dont echo the yasm command line

### DIFF
--- a/src/yasm-wrapper
+++ b/src/yasm-wrapper
@@ -2,7 +2,7 @@
 
 # libtool and yasm do not get along.
 # filter out any crap that libtool feeds us that yasm does not understand.
-echo $0: got $*
+#echo $0: got $*
 new=""
 touch=""
 while [ -n "$*" ]; do
@@ -36,7 +36,7 @@ while [ -n "$*" ]; do
     esac
 done
 
-echo $0: yasm $new
+#echo $0: yasm $new
 yasm $new
 
 [ -n "$touch" ] && touch $touch


### PR DESCRIPTION
commented out the echos because they're noisy. if anyone needs to debug the wrapper in the future, they can uncomment