### PR TITLE
rgw_file: fix return value signedness (rgw_readdir)

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1366,7 +1366,7 @@ int rgw_readdir(struct rgw_fs *rgw_fs,
     return -EINVAL;
   }
   int rc = parent->readdir(rcb, cb_arg, offset, eof, flags);
-  return -rc;
+  return rc;
 }
 
 /*


### PR DESCRIPTION
Here `parent->readdir(.)` will return negative numbers when there is an error.
so we should just return it.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>