### PR TITLE
rgw: rgw file fix bug of rgw_lookup can not exact match file name

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -163,6 +163,15 @@ namespace rgw {
 	if ((rc == 0) &&
 	    (req.get_ret() == 0)) {
 	  if (req.matched) {
+	    // we need rgw object's key name equal to file name, if not return NULL
+	    if ((flags & RGWFileHandle::FLAG_EXACT_MATCH) &&
+		!req.exact_matched) {
+	      lsubdout(get_context(), rgw, 15)
+	        << __func__
+		<< ": stat leaf not exact match file name = "
+		<< path << dendl;
+	      goto done;
+	    }
 	    fhr = lookup_fh(parent, path,
 			    RGWFileHandle::FLAG_CREATE|
 			    ((req.is_dir) ?
@@ -1226,7 +1235,7 @@ int rgw_lookup(struct rgw_fs *rgw_fs,
 	return -ENOENT;
     }
   } else {
-    fhr = fs->stat_leaf(parent, path, RGWFileHandle::FLAG_NONE);
+    fhr = fs->stat_leaf(parent, path, RGWFileHandle::FLAG_EXACT_MATCH);
     if (! get<0>(fhr)) {
       if (! (flags & RGW_LOOKUP_FLAG_CREATE))
 	return -ENOENT;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -234,6 +234,7 @@ namespace rgw {
     static constexpr uint32_t FLAG_DELETED = 0x0080;
     static constexpr uint32_t FLAG_UNLINK_THIS = 0x0100;
     static constexpr uint32_t FLAG_LOCKED = 0x0200;
+    static constexpr uint32_t FLAG_EXACT_MATCH = 0x0400;
 
 #define CREATE_FLAGS(x) \
     ((x) & ~(RGWFileHandle::FLAG_CREATE|RGWFileHandle::FLAG_LOCK))
@@ -1836,11 +1837,12 @@ public:
   std::string path;
   bool matched;
   bool is_dir;
+  bool exact_matched;
 
   RGWStatLeafRequest(CephContext* _cct, RGWUserInfo *_user,
 		     RGWFileHandle* _rgw_fh, const std::string& _path)
     : RGWLibRequest(_cct, _user), rgw_fh(_rgw_fh), path(_path),
-      matched(false), is_dir(false) {
+      matched(false), is_dir(false), exact_matched(false) {
     default_max = 1000; // logical max {"foo", "foo/"}
     op = this;
   }
@@ -1899,9 +1901,12 @@ public:
 			     << "list uri=" << s->relative_uri << " "
 			     << " prefix=" << prefix << " "
 			     << " obj path=" << name << ""
+			     << " target = " << path << ""
 			     << dendl;
       /* XXX is there a missing match-dir case (trailing '/')? */
       matched = true;
+      if (name == path)
+	exact_matched = true;
       return;
     }
     // try prefixes
@@ -1912,6 +1917,7 @@ public:
 			     << "list uri=" << s->relative_uri << " "
 			     << " prefix=" << prefix << " "
 			     << " pref path=" << name << " (not chomped)"
+			     << " target = " << path << ""
 			     << dendl;
       matched = true;
       is_dir = true;


### PR DESCRIPTION
bug reproduce steps:
in nfs-client (connect to nfs-ganesha server):
1. mv file file.rename
2. stat file // get file attrs, not return with -ENOENT

the reason is that:
RGWStatLeafRequest does not exact match the file name,
just take file name as a prefix filter

Signed-off-by: Min Chen <chenmin@xsky.com>