### PR TITLE
tests: populate /dev/disk/by-partuuid for scsi_debug

### DIFF
--- a/qa/workunits/ceph-disk/60-ceph-by-partuuid.rules
+++ b/qa/workunits/ceph-disk/60-ceph-by-partuuid.rules
@@ -1,0 +1,29 @@
+#
+# Make sure /dev/disk/by-partuuid is populated
+#
+
+# forward scsi device event to corresponding block device
+ACTION=="change", SUBSYSTEM=="scsi", ENV{DEVTYPE}=="scsi_device", TEST=="block", ATTR{block/*/uevent}="change"
+
+ACTION=="remove", GOTO="persistent_storage_end_two"
+
+SUBSYSTEM!="block", GOTO="persistent_storage_end_two"
+
+# skip rules for inappropriate block devices
+KERNEL=="fd*|mtd*|nbd*|gnbd*|btibm*|md*", GOTO="persistent_storage_end_two"
+
+# ignore partitions that span the entire disk
+TEST=="whole_disk", GOTO="persistent_storage_end_two"
+
+# for partitions import parent information
+ENV{DEVTYPE}=="partition", IMPORT{parent}="ID_*"
+
+# skip unpartitioned removable media devices from drivers which do not send "change" events
+ENV{DEVTYPE}=="disk", KERNEL!="sd*|sr*", ATTR{removable}=="1", GOTO="persistent_storage_end_two"
+
+# probe filesystem metadata of disks
+KERNEL!="sr*", IMPORT{program}="/sbin/blkid -o udev -p $tempnode"
+
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
+
+LABEL="persistent_storage_end_two"

--- a/qa/workunits/ceph-disk/ceph-disk.sh
+++ b/qa/workunits/ceph-disk/ceph-disk.sh
@@ -20,6 +20,9 @@ fi
 sudo ceph osd crush rm osd.0 || true
 sudo ceph osd crush rm osd.1 || true
 
+sudo cp $(dirname $0)/60-ceph-by-partuuid.rules /lib/udev/rules.d
+sudo udevadm control --reload
+
 perl -pi -e 's|pid file.*|pid file = /var/run/ceph/\$cluster-\$name.pid|' /etc/ceph/ceph.conf
 
 PATH=$(dirname $0):$(dirname $0)/..:$PATH
@@ -32,6 +35,7 @@ fi
 sudo env PATH=$(dirname $0):$(dirname $0)/..:$PATH py.test -s -v $(dirname $0)/ceph-disk-test.py
 result=$?
 
+sudo rm -f /lib/udev/rules.d/60-ceph-by-partuuid.rules
 # own whatever was created as a side effect of the py.test run
 # so that it can successfully be removed later on by a non privileged 
 # process


### PR DESCRIPTION
The scsi_debug SCSI devices do not have a symlink in /dev/disk/by-partuuid
because they are filtered out by 60-persistent-storage.rules. That was
worked around by 60-ceph-partuuid-workaround-rules which has been
removed by 9f76b9ff31525eac01f04450d72559ec99927496.

Add create rules targetting this specific case, only for tests since the
problem does not show in real use cases.

Fixes: http://tracker.ceph.com/issues/17100

Signed-off-by: Loic Dachary <loic@dachary.org>