### PR TITLE
rgw: delete region map after upgrade to zonegroup map

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3310,6 +3310,15 @@ int RGWRados::convert_regionmap()
   current_period.set_user_quota(zonegroupmap.user_quota);
   current_period.set_bucket_quota(zonegroupmap.bucket_quota);
 
+  // remove the region_map so we don't try to convert again
+  rgw_obj obj(pool, oid);
+  ret = delete_system_obj(obj);
+  if (ret < 0) {
+    ldout(cct, 0) << "Error could not remove " << obj
+        << " after upgrading to zonegroup map: " << cpp_strerror(ret) << dendl;
+    return ret;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
convert_regionmap() reads the region map and uses it to initialize the zonegroup map.  but it doesn't remove the region_map afterwards, so radosgw (and some radosgw-admin commands) will keep doing this on startup, overwriting any changes made to the period/zonegroup map

Fixes: http://tracker.ceph.com/issues/17051