### PR TITLE
global: fix memory leaks related to global_init_daemonize()

### DIFF
--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -77,13 +77,13 @@ public:
 
   bool init(const std::string &path);
 
+  void shutdown();
+
   void chown(uid_t uid, gid_t gid);
 
 private:
   AdminSocket(const AdminSocket& rhs);
   AdminSocket& operator=(const AdminSocket &rhs);
-
-  void shutdown();
 
   std::string create_shutdown_pipe(int *pipe_rd, int *pipe_wr);
   std::string destroy_shutdown_pipe();

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -583,8 +583,7 @@ CephContext::~CephContext()
 
   delete _crypto_none;
   delete _crypto_aes;
-  if (_crypto_inited)
-    ceph::crypto::shutdown();
+  shutdown_crypto();
 }
 
 void CephContext::put() {
@@ -601,6 +600,14 @@ void CephContext::init_crypto()
 {
   ceph::crypto::init(this);
   _crypto_inited = true;
+}
+
+void CephContext::shutdown_crypto()
+{
+  if (_crypto_inited) {
+    ceph::crypto::shutdown();
+    _crypto_inited = false;
+  }
 }
 
 void CephContext::start_service_thread()

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -650,6 +650,10 @@ void CephContext::join_service_thread()
   thread->exit_thread();
   thread->join();
   delete thread;
+
+  // shut down admin socket
+  if (_conf->admin_socket.length())
+    _admin_socket->shutdown();
 }
 
 uint32_t CephContext::get_module_type() const

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -76,6 +76,9 @@ public:
   /* init ceph::crypto */
   void init_crypto();
 
+  /* shutdown ceph::crypto */
+  void shutdown_crypto();
+
   /* Start the Ceph Context's service thread */
   void start_service_thread();
 

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -79,6 +79,9 @@ public:
   /* Start the Ceph Context's service thread */
   void start_service_thread();
 
+  /* Stop and join the Ceph Context's service thread */
+  void join_service_thread();
+
   /* Reopen the log files */
   void reopen_logs();
 
@@ -222,9 +225,6 @@ private:
 
   CephContext(const CephContext &rhs);
   CephContext &operator=(const CephContext &rhs);
-
-  /* Stop and join the Ceph Context's service thread */
-  void join_service_thread();
 
   uint32_t _module_type;
 

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -340,6 +340,8 @@ int global_init_prefork(CephContext *cct)
   }
 
   cct->notify_pre_fork();
+  // stop service thread
+  cct->join_service_thread();
   // stop log thread
   cct->_log->flush();
   cct->_log->stop();
@@ -371,6 +373,8 @@ void global_init_postfork_start(CephContext *cct)
 {
   // restart log thread
   cct->_log->start();
+  // restart service thread
+  cct->start_service_thread();
   cct->notify_post_fork();
 
   /* This is the old trick where we make file descriptors 0, 1, and possibly 2

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -340,6 +340,8 @@ int global_init_prefork(CephContext *cct)
   }
 
   cct->notify_pre_fork();
+  // shutdown crypto
+  cct->shutdown_crypto();
   // stop service thread
   cct->join_service_thread();
   // stop log thread
@@ -371,6 +373,8 @@ void global_init_daemonize(CephContext *cct)
 
 void global_init_postfork_start(CephContext *cct)
 {
+  // reinit crypto
+  cct->init_crypto();
   // restart log thread
   cct->_log->start();
   // restart service thread


### PR DESCRIPTION
These are two band-aids to fix memory leaks related to `global_init_daemonize()`.

Fixes: http://tracker.ceph.com/issues/17108
Fixes: http://tracker.ceph.com/issues/17109