### PR TITLE
rgw: fix period update --commit return error

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1207,6 +1207,11 @@ int RGWPeriod::update()
       ldout(cct, 20) << "skipping zonegroup " << zg.get_name() << " zone realm id " << zg.realm_id << ", not on our realm " << realm_id << dendl;
       continue;
     }
+
+    if (zg.master_zone.empty()) {
+      ldout(cct, 0) << "ERROR: zonegroup " << zg.get_name() << " should have a master zone " << dendl;
+      return -EINVAL;
+    }  
     
     if (zg.is_master_zonegroup()) {
       master_zonegroup = zg.get_id();


### PR DESCRIPTION
period commit return error when the current period has a zonegroup which doesn't have a master zone

Fixes: http://tracker.ceph.com/issues/17110
Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>