### PR TITLE
doc: fix wrong osdkeepalive name in mount.ceph manpage

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -56,7 +56,7 @@ Options
 :command:`osdtimeout`
   int (seconds), Default: 60
 
-:command:`osdkeepalivetimeout`
+:command:`osdkeepalive`
   int, Default: 5
 
 :command:`mount_timeout`


### PR DESCRIPTION
This option osdkeepalivetimeout is documented in manpage and officical website, but the valid option name can be used is osdkeepalive.

See https://github.com/ceph/ceph-client/pull/14

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>