### PR TITLE
Add udev rule to set readahead on mapped rbd's

### DIFF
--- a/udev/50-rbd.rules
+++ b/udev/50-rbd.rules
@@ -1,2 +1,5 @@
 KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="disk", PROGRAM="/usr/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c{1}/%c{2}"
 KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="partition", PROGRAM="/usr/bin/ceph-rbdnamer %k", SYMLINK+="rbd/%c{1}/%c{2}-part%n"
+
+# This is a placeholder, uncomment and edit as necessary
+#KERNEL=="rbd[0-9]*", ENV{DEVTYPE}=="disk", ACTION=="add|change", ATTR{bdi/read_ahead_kb}="128"


### PR DESCRIPTION
Set to 128kb by default, so no change from current behaviour