### PR TITLE
messages/MOSDMap: mark as enlighten OSDMap encoder

### DIFF
--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -109,9 +109,9 @@ public:
 	  OSDMap m;
 	  m.decode(inc.fullmap);
 	  inc.fullmap.clear();
-	  m.encode(inc.fullmap, features);
+	  m.encode(inc.fullmap, features | CEPH_FEATURE_RESERVED);
 	}
-	inc.encode(p->second, features);
+	inc.encode(p->second, features | CEPH_FEATURE_RESERVED);
       }
       for (map<epoch_t,bufferlist>::iterator p = maps.begin();
 	   p != maps.end();
@@ -119,7 +119,7 @@ public:
 	OSDMap m;
 	m.decode(p->second);
 	p->second.clear();
-	m.encode(p->second, features);
+	m.encode(p->second, features | CEPH_FEATURE_RESERVED);
       }
     }
     ::encode(incremental_maps, payload);


### PR DESCRIPTION
Back in 70094407c184baaf963577cc0d98edde12e8e9da we require that anyone
encoding an OSDMap pass in a special feature bit indicating that they are
'enlightened' and understand the rules around encoding OSDMaps (basically,
only mons get to do it).  We forgot to update MOSDMap, which may have to
reencode an OSDMap without some features to talk to a really old client.
We haven't noticed until now because the old set of features we had to do
this for are really old.

We are about to introduce new features (for addr2 encoding) that change
that, and this fix is needed to prevent an assert when doing a reencode.

Signed-off-by: Sage Weil <sage@redhat.com>