### PR TITLE
os/bluestore: fix when block device is not a multiple of the block size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -989,6 +989,7 @@ OPTION(bluestore_bitmapallocator_span_size, OPT_INT, 1024) // must be power of 2
 OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=16,min_write_buffer_number_to_merge=3,recycle_log_file_num=16")
 OPTION(bluestore_fsck_on_mount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_umount, OPT_BOOL, false)
+OPTION(bluestore_fsck_on_mkfs, OPT_BOOL, true)
 OPTION(bluestore_sync_transaction, OPT_BOOL, false)  // perform kv txn synchronously
 OPTION(bluestore_sync_submit_transaction, OPT_BOOL, false)
 OPTION(bluestore_sync_wal_apply, OPT_BOOL, true)     // perform initial wal work synchronously (possibly in combination with aio so we only *queue* ios)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2933,8 +2933,8 @@ void apply(uint64_t off,
           std::function<void(uint64_t, boost::dynamic_bitset<> &)> f) {
   auto end = ROUND_UP_TO(off + len, granularity);
   while (off < end) {
-  uint64_t pos = off / granularity;
-  f( pos, bitset);
+    uint64_t pos = off / granularity;
+    f(pos, bitset);
     off += granularity;
   }
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2750,6 +2750,17 @@ int BlueStore::mkfs()
   _close_fsid();
  out_path_fd:
   _close_path();
+
+  if (r == 0 &&
+      g_conf->bluestore_fsck_on_mkfs) {
+    int rc = fsck();
+    if (rc < 0)
+      return rc;
+    if (rc > 0) {
+      derr << __func__ << " fsck found " << rc << " errors" << dendl;
+      r = -EIO;
+    }
+  }
   return r;
 }
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -140,6 +140,9 @@ int KernelDevice::open(string p)
   fs = FS::create_by_fd(fd_direct);
   assert(fs);
 
+  // round size down to an even block
+  size &= ~(block_size - 1);
+
   r = _aio_start();
   assert(r == 0);
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -813,6 +813,9 @@ int NVMEDevice::open(string p)
   //nvme is non-rotational device.
   rotational = false;
 
+  // round size down to an even block
+  size &= ~(block_size - 1);
+
   dout(1) << __func__ << " size " << size << " (" << pretty_si_t(size) << "B)"
           << " block_size " << block_size << " (" << pretty_si_t(block_size)
           << "B)" << dendl;

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -44,7 +44,7 @@ void rm_temp_bdev(string f)
 }
 
 TEST(BlueFS, mkfs) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   uuid_d fsid;
   BlueFS fs;
@@ -55,7 +55,7 @@ TEST(BlueFS, mkfs) {
 }
 
 TEST(BlueFS, mkfs_mount) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   BlueFS fs;
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
@@ -70,7 +70,7 @@ TEST(BlueFS, mkfs_mount) {
 }
 
 TEST(BlueFS, write_read) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   BlueFS fs;
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
@@ -106,7 +106,7 @@ TEST(BlueFS, write_read) {
 }
 
 TEST(BlueFS, small_appends) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   BlueFS fs;
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
@@ -256,7 +256,7 @@ void join_all(std::vector<std::thread>& v)
 #define NUM_MULTIPLE_FILE_WRITERS 2
 
 TEST(BlueFS, test_flush_1) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",
@@ -291,7 +291,7 @@ TEST(BlueFS, test_flush_1) {
 }
 
 TEST(BlueFS, test_flush_2) {
-  uint64_t size = 1048476 * 256;
+  uint64_t size = 1048576 * 256;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",
@@ -319,7 +319,7 @@ TEST(BlueFS, test_flush_2) {
 }
 
 TEST(BlueFS, test_flush_3) {
-  uint64_t size = 1048476 * 256;
+  uint64_t size = 1048576 * 256;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",
@@ -357,7 +357,7 @@ TEST(BlueFS, test_simple_compaction_sync) {
   g_ceph_context->_conf->set_val(
     "bluefs_compact_log_sync",
     "true");
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
   BlueFS fs;
@@ -410,7 +410,7 @@ TEST(BlueFS, test_simple_compaction_async) {
   g_ceph_context->_conf->set_val(
     "bluefs_compact_log_sync",
     "false");
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
   BlueFS fs;
@@ -460,7 +460,7 @@ TEST(BlueFS, test_simple_compaction_async) {
 }
 
 TEST(BlueFS, test_compaction_sync) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",
@@ -498,7 +498,7 @@ TEST(BlueFS, test_compaction_sync) {
 }
 
 TEST(BlueFS, test_compaction_async) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",
@@ -536,7 +536,7 @@ TEST(BlueFS, test_compaction_async) {
 }
 
 TEST(BlueFS, test_replay) {
-  uint64_t size = 1048476 * 128;
+  uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   g_ceph_context->_conf->set_val(
     "bluefs_alloc_size",


### PR DESCRIPTION
Also fsck after mkfs by default.