### PR TITLE
mds: fix double-unlock on shutdown

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -242,13 +242,7 @@ void MDSRankDispatcher::shutdown()
   mds_lock.Unlock();
 
   finisher->stop(); // no flushing
-
-  // shut down messenger
-  // release mds_lock first because messenger thread might call 
-  // MDSDaemon::ms_handle_reset which will try to hold mds_lock
-  mds_lock.Unlock();
   messenger->shutdown();
-  mds_lock.Lock();
 
   mds_lock.Lock();
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/17126

We did a bad backport or something and accidentally ended up with two Unlock()
calls on mds_lock. Don't.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>