### PR TITLE
multimds: enforce allow_multimds during conf load

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -10,6 +10,12 @@
 :Type: Boolean
 :Default: ``true`` 
 
+``mon allow multimds``
+
+:Description: Set to ``true`` to enable multiple active MDS servers. ``max mds`` is ignored unless this option is true.
+
+:Type:  Boolean
+:Default: ``false``
 
 ``max mds``
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -269,6 +269,7 @@ OPTION(mon_allow_pool_delete, OPT_BOOL, true) // allow pool deletion
 OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
 OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active
+OPTION(mon_allow_multimds, OPT_BOOL, false) // allow multimds?
 OPTION(mon_warn_on_old_mons, OPT_BOOL, true) // should mons set health to WARN if part of quorum is old?
 OPTION(mon_warn_on_legacy_crush_tunables, OPT_BOOL, true) // warn if crush tunables are too old (older than mon_min_crush_required_version)
 OPTION(mon_crush_min_required_version, OPT_STR, "firefly")

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -90,7 +90,9 @@ void MDSMonitor::create_new_fs(FSMap &fsm, const std::string &name,
 {
   auto fs = std::make_shared<Filesystem>();
   fs->mds_map.fs_name = name;
-  fs->mds_map.max_mds = g_conf->max_mds;
+  fs->mds_map.max_mds = g_conf->mon_allow_multimds ? g_conf->max_mds : 1;
+  if (g_conf->mon_allow_multimds)
+    fs->mds_map.set_multimds_allowed();
   fs->mds_map.data_pools.insert(data_pool);
   fs->mds_map.metadata_pool = metadata_pool;
   fs->mds_map.cas_pool = -1;
@@ -1727,7 +1729,9 @@ int MDSMonitor::management_command(
     // Carry forward what makes sense
     new_fs->fscid = fs->fscid;
     new_fs->mds_map.inline_data_enabled = fs->mds_map.inline_data_enabled;
-    new_fs->mds_map.max_mds = g_conf->max_mds;
+    new_fs->mds_map.max_mds = g_conf->mon_allow_multimds ? g_conf->max_mds : 1;
+    if (g_conf->mon_allow_multimds)
+      new_fs->mds_map.set_multimds_allowed();
     new_fs->mds_map.data_pools = fs->mds_map.data_pools;
     new_fs->mds_map.metadata_pool = fs->mds_map.metadata_pool;
     new_fs->mds_map.cas_pool = fs->mds_map.cas_pool;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -98,6 +98,8 @@ cache=""
 memstore=0
 bluestore=0
 lockdep=${LOCKDEP:-1}
+max_mds=1
+allow_multimds="false"
 
 VSTART_SEC="client.vstart.sh"
 
@@ -135,6 +137,7 @@ usage=$usage"\t--memstore use memstore as the osd objectstore backend\n"
 usage=$usage"\t--cache <pool>: enable cache tiering on pool\n"
 usage=$usage"\t--short: short object names only; necessary for ext4 dev\n"
 usage=$usage"\t--nolockdep disable lockdep\n"
+usage=$usage"\t--multimds <count> allow multimds with maximum active count\n"
 
 usage_exit() {
 	printf "$usage"
@@ -274,6 +277,11 @@ case $1 in
     --nolockdep )
             lockdep=0
             ;;
+    --multimds)
+        max_mds="$2"
+        allow_multimds="true"
+        shift
+        ;;
     * )
 	    usage_exit
 esac
@@ -570,6 +578,8 @@ $extra_conf
         mon reweight min pgs per osd = 4
         mon osd prime pg temp = true
         crushtool = $CEPH_BIN/crushtool
+        max mds = ${max_mds}
+        mon allow multimds = ${allow_multimds}
 $DAEMONOPTS
 $CMONDEBUG
 $extra_conf


### PR DESCRIPTION
Add a configuration option for allow_multimds which allows setting
max_mds. Previously it was possible to set max_mds in ceph.conf which
would circumvent the allow_multimds protection.

Fixes: http://tracker.ceph.com/issues/17105