### PR TITLE
doc/radosgw/s3/cpp.rst: update usage of libs3 APIs to make the examples work

### DIFF
--- a/doc/radosgw/s3/cpp.rst
+++ b/doc/radosgw/s3/cpp.rst
@@ -105,7 +105,7 @@ for each bucket.
 		&listServiceCallback
 	};
 	bool header_printed = false;
-	S3_list_service(S3ProtocolHTTP, access_key, secret_key, host, 0, &listServiceHandler, &header_printed);
+	S3_list_service(S3ProtocolHTTP, access_key, secret_key, host, 0, NULL, &listServiceHandler, &header_printed);
 
 
 Creating a Bucket
@@ -115,7 +115,7 @@ This creates a new bucket.
 
 .. code-block:: cpp
 
-	S3_create_bucket(S3ProtocolHTTP, access_key, secret_key, host, sample_bucket, S3CannedAclPrivate, NULL, NULL, &responseHandler, NULL);
+	S3_create_bucket(S3ProtocolHTTP, access_key, secret_key, NULL, host, sample_bucket, S3CannedAclPrivate, NULL, NULL, &responseHandler, NULL);
 
 
 Listing a Bucket's Content


### PR DESCRIPTION
The libs3 APIs are changed in the current libs3 packages from https://github.com/bji/libs3. It leads to compiling errors with the current S3 cpp API examples.

s3-api-test.cc: In function ‘int main(int, char*_)’:
s3-api-test.cc:166:103: error: cannot convert ‘S3ListServiceHandler_’ to ‘S3RequestContext_’ for argument ‘6’ to ‘void S3_list_service(S3Protocol, const char_, const char_, const char_, const char_, S3RequestContext_, const S3ListServiceHandler_, void_)’
  S3_list_service(S3ProtocolHTTP, access_key, secret_key, host, 0, &listServiceHandler, &header_printed);
                                                                                                       ^
s3-api-test.cc:168:134: error: cannot convert ‘S3CannedAcl’ to ‘const char_’ for argument ‘6’ to ‘void S3_create_bucket(S3Protocol, const char_, const char_, const char_, const char_, const char_, S3CannedAcl, const char_, S3RequestContext_, const S3ResponseHandler_, void_)’
  S3_create_bucket(S3ProtocolHTTP, access_key, secret_key, host, sample_bucket, S3CannedAclPrivate, NULL, NULL, &responseHandler, NULL);
                                                                                                                                      ^

The reason is that the related APIs are changed.

void S3_list_service(S3Protocol protocol, const char *accessKeyId,
                     const char *secretAccessKey, const char *securityToken,
                     const char *hostName, S3RequestContext *requestContext,
                     const S3ListServiceHandler *handler,
                     void *callbackData);

void S3_create_bucket(S3Protocol protocol, const char *accessKeyId,
                      const char *secretAccessKey, const char *securityToken,
                      const char *hostName, const char *bucketName,
                      S3CannedAcl cannedAcl, const char *locationConstraint,
                      S3RequestContext *requestContext,
                      const S3ResponseHandler *handler, void *callbackData);

We do not use security token in the examples.
Change the document accordingly to make the examples work.
Signed-off-by: Weibing Zhang zhangweibing@unitedstack.com
