### PR TITLE
Add ceph_dirfd in libcephfs and the test for it

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2766,8 +2766,6 @@ void Client::kick_requests_closed(MetaSession *session)
 }
 
 
-
-
 /************
  * leases
  */
@@ -7525,6 +7523,28 @@ int Client::getdir(const char *relpath, list<string>& contents)
   return gr.num;
 }
 
+int Client::dirfd(dir_result_t *dirp)
+{
+  Mutex::Locker lock(client_lock);
+
+  ldout(cct, 10) << "dirfd(" << dirp << ")" << dendl;
+  return _dirfd(dirp);
+}
+
+int Client::_dirfd(dir_result_t *dirp)
+{
+  int fd = -1;
+  for (ceph::unordered_map<int, Fh*>::iterator it = fd_map.begin();
+      it != fd_map.end(); ++it) {
+    Fh *fh = it->second;
+    if (fh->inode == dirp->inode) {
+      fd = it->first;
+      break;
+    }
+  }
+
+  return fd;
+}
 
 /****** file i/o **********/
 int Client::open(const char *relpath, int flags, mode_t mode, int stripe_unit,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -724,6 +724,7 @@ private:
   int _readdir_get_frag(dir_result_t *dirp);
   int _readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p);
   void _closedir(dir_result_t *dirp);
+  int _dirfd(dir_result_t *dirp);
 
   // other helpers
   void _fragmap_remove_non_leaves(Inode *in);
@@ -944,6 +945,7 @@ public:
   int readdirplus_r(dir_result_t *dirp, struct dirent *de, struct stat *st, int *stmask);
 
   int getdir(const char *relpath, list<string>& names);  // get the whole dir at once.
+  int dirfd(dir_result_t *dirp);
 
   /**
    * Returns the length of the buffer that got filled in, or -errno.

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -31,9 +31,9 @@
 extern "C" {
 #endif
 
-#define LIBCEPHFS_VER_MAJOR 10
+#define LIBCEPHFS_VER_MAJOR 11
 #define LIBCEPHFS_VER_MINOR 0
-#define LIBCEPHFS_VER_EXTRA 2
+#define LIBCEPHFS_VER_EXTRA 0
 
 #define LIBCEPHFS_VERSION(maj, min, extra) ((maj << 16) + (min << 8) + extra)
 #define LIBCEPHFS_VERSION_CODE LIBCEPHFS_VERSION(LIBCEPHFS_VER_MAJOR, LIBCEPHFS_VER_MINOR, LIBCEPHFS_VER_EXTRA)
@@ -451,6 +451,16 @@ int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp,
  */
 int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de,
 		       struct stat *st, int *stmask);
+
+/**
+ * Returns the integer file descriptor associated with the named directory stream.
+ *
+ * @param cmount the ceph mount handle to use for performing the dirfd.
+ * @param dirp the directory stream pointer from an opendir holding the state of the
+ *        next entry to return.
+ * @returns a non-negative file descriptor number on success or a negative error code on      failure.
+ */
+int ceph_dirfd(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
 
 /**
  * Gets multiple directory entries.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -502,6 +502,13 @@ extern "C" int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_di
   return cmount->get_client()->readdirplus_r(reinterpret_cast<dir_result_t*>(dirp), de, st, stmask);
 }
 
+extern "C" int ceph_dirfd(struct ceph_mount_info *cmount, struct ceph_dir_result * dirp)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->dirfd(reinterpret_cast<dir_result_t*>(dirp));
+}
+
 extern "C" int ceph_getdents(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp,
 			     char *buf, int buflen)
 {

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -444,6 +444,38 @@ TEST(LibCephFS, DirLs) {
   ceph_shutdown(cmount);
 }
 
+TEST(LibCephFS, DirFd) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  pid_t mypid = getpid();
+  struct ceph_dir_result *dirfd = NULL;
+  char foostr[256];
+  sprintf(foostr, "dirfd%d", mypid);
+  ASSERT_EQ(ceph_mkdir(cmount, foostr, 0777), 0);
+  int fd1 = ceph_open(cmount, foostr, O_RDONLY, 0);
+  ASSERT_GT(fd1, 0);
+  ASSERT_EQ(ceph_opendir(cmount, foostr, &dirfd), 0);
+
+  int fd2 = ceph_dirfd(cmount, dirfd);
+  ASSERT_GT(fd2, 0);
+  struct stat statbuf;
+  ASSERT_EQ(ceph_fstat(cmount, fd2, &statbuf), 0);
+
+  struct dirent *result = ceph_readdir(cmount, dirfd);
+  ASSERT_TRUE(result != NULL);
+
+  ASSERT_EQ(statbuf.st_ino, result->d_ino);
+
+  ASSERT_EQ(ceph_closedir(cmount, dirfd), 0);
+  ASSERT_EQ(ceph_close(cmount, fd1), 0);
+  ASSERT_EQ(ceph_rmdir(cmount, foostr), 0);
+  ceph_shutdown(cmount);
+}
+
 TEST(LibCephFS, ManyNestedDirs) {
   struct ceph_mount_info *cmount;
   ASSERT_EQ(ceph_create(&cmount, NULL), 0);


### PR DESCRIPTION
Add ceph_dirfd in libcephfs to enable users to get the file descriptor from the named directory stream.