### PR TITLE
rgw: remove duplicated calls to getattr 

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1284,12 +1284,6 @@ int rgw_getattr(struct rgw_fs *rgw_fs,
   RGWLibFS *fs = static_cast<RGWLibFS*>(rgw_fs->fs_private);
   RGWFileHandle* rgw_fh = get_rgwfh(fh);
 
-  int rc = -(fs->getattr(rgw_fh, st));
-  if (rc != 0) {
-    // do it again
-    rc = -(fs->getattr(rgw_fh, st));
-  }
-
   return -(fs->getattr(rgw_fh, st));
 }
 


### PR DESCRIPTION
We do not need the duplicated calls to getattr. Remove the unnecessary code.

Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>