### PR TITLE
cmake: add dependency from ceph_smalliobenchrbd to cls libraries

### DIFF
--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -33,6 +33,10 @@ if(WITH_RBD)
     ${CMAKE_DL_LIBS}
     keyutils
     )
+  add_dependencies(ceph_smalliobenchrbd
+    cls_rbd
+    cls_journal
+    cls_lock)
   install(TARGETS
     ceph_smalliobenchrbd
     DESTINATION bin)


### PR DESCRIPTION
Add osd dependency to cls_rbd library when WITH_RBD specified. Otherwise, for example, "make vstart smalliobenchrbd" will not build necessary cls_rbd shared library.