### PR TITLE
[DNM] hammer: osd: handle full pool in the same way as a full cluster

### DIFF
--- a/qa/workunits/rados/test_pool_quota.sh
+++ b/qa/workunits/rados/test_pool_quota.sh
@@ -12,27 +12,55 @@ done
 
 sleep 30
 
-rados -p $p put onemore /etc/passwd  && exit 1 || true
+rados -p $p put onemore /etc/passwd  &
+pid=$!
 
 ceph osd pool set-quota $p max_objects 100
-sleep 30
+wait $pid 
+[ $? -ne 0 ] && exit 1 || true
 
-rados -p $p put onemore /etc/passwd
+rados -p $p put twomore /etc/passwd
 
 # bytes
 ceph osd pool set-quota $p max_bytes 100
 sleep 30
 
-rados -p $p put two /etc/passwd && exit 1 || true
+rados -p $p put two /etc/passwd &
+pid=$!
 
 ceph osd pool set-quota $p max_bytes 0
 ceph osd pool set-quota $p max_objects 0
-sleep 30
+wait $pid 
+[ $? -ne 0 ] && exit 1 || true
 
 rados -p $p put three /etc/passwd
 
+
+#one pool being full does not block a different pool
+
+pp=`uuidgen`
+
+ceph osd pool create $pp 12
+
+# set objects quota 
+ceph osd pool set-quota $pp max_objects 10
+sleep 30
+
+for f in `seq 1 10` ; do
+ rados -p $pp put obj$f /etc/passwd
+done
+
+sleep 30
+
+rados -p $p put threemore /etc/passwd 
+
+ceph osd pool set-quota $p max_bytes 0
+ceph osd pool set-quota $p max_objects 0
+
+sleep 30
 # done
 ceph osd pool delete $p $p --yes-i-really-really-mean-it
+ceph osd pool delete $pp $pp --yes-i-really-really-mean-it
 
 echo OK
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6301,6 +6301,7 @@ void OSD::handle_osd_map(MOSDMap *m)
       o->decode(bl);
       if (o->test_flag(CEPH_OSDMAP_FULL))
 	last_marked_full = e;
+      set_pool_last_map_marked_full(o, e);
 
       hobject_t fulloid = get_osdmap_pobject_name(e);
       t.write(META_COLL, fulloid, 0, bl.length(), bl);
@@ -6334,6 +6335,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 
       if (o->test_flag(CEPH_OSDMAP_FULL))
 	last_marked_full = e;
+      set_pool_last_map_marked_full(o, e);
 
       bufferlist fbl;
       o->encode(fbl, inc.encode_features | CEPH_FEATURE_RESERVED);
@@ -8212,6 +8214,9 @@ void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
     }
   }
 
+  // calc actual pgid
+  pg_t _pgid = m->get_pg();
+  int64_t pool = _pgid.pool();
   if (op->may_write()) {
     // full?
     if ((service.check_failsafe_full() ||
@@ -8223,6 +8228,17 @@ void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
       return;
     }
 
+    const pg_pool_t *pi = osdmap->get_pg_pool(pool);
+    if (!pi) {
+      return;
+    }
+    // pool is full ?
+    map<int64_t, epoch_t> &pool_last_map_marked_full = superblock.pool_last_map_marked_full;
+    if (pi->has_flag(pg_pool_t::FLAG_FULL) || 
+       (pool_last_map_marked_full.count(pool) && (m->get_map_epoch() < pool_last_map_marked_full[pool]))) {
+      return;
+    }
+    
     // invalid?
     if (m->get_snapid() != CEPH_NOSNAP) {
       service.reply_op_error(op, -EINVAL);
@@ -8241,9 +8257,6 @@ void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
     }
   }
 
-  // calc actual pgid
-  pg_t _pgid = m->get_pg();
-  int64_t pool = _pgid.pool();
   if ((m->get_flags() & CEPH_OSD_FLAG_PGOP) == 0 &&
       osdmap->have_pg_pool(pool))
     _pgid = osdmap->raw_pg_to_pg(_pgid);
@@ -8878,4 +8891,18 @@ void OSD::PeeringWQ::_dequeue(list<PG*> *out) {
         }
   }
   in_use.insert(got.begin(), got.end());
+}
+
+void OSD::set_pool_last_map_marked_full(OSDMap *o, epoch_t &e)
+{
+  map<int64_t, epoch_t> &pool_last_map_marked_full = superblock.pool_last_map_marked_full;
+  for (map<int64_t, pg_pool_t>::const_iterator it = o->get_pools().begin();
+       it != o->get_pools().end(); it++) {
+    bool exist = pool_last_map_marked_full.count(it->first);
+    if (it->second.has_flag(pg_pool_t::FLAG_FULL) && !exist)
+      pool_last_map_marked_full[it->first] = e;
+    if (it->second.has_flag(pg_pool_t::FLAG_FULL) &&
+      (exist && pool_last_map_marked_full.count(it->first) < e))
+       pool_last_map_marked_full[it->first] = e;
+    }
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1666,6 +1666,7 @@ private:
   void trim_maps(epoch_t oldest, int nreceived, bool skip_maps);
   void note_down_osd(int osd);
   void note_up_osd(int osd);
+  void set_pool_last_map_marked_full(OSDMap *o, epoch_t &e);
   
   bool advance_pg(
     epoch_t advance_to, PG *pg,

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3994,7 +3994,7 @@ ostream& operator<<(ostream& out, const osd_peer_stat_t &stat)
 
 void OSDSuperblock::encode(bufferlist &bl) const
 {
-  ENCODE_START(6, 5, bl);
+  ENCODE_START(7, 5, bl);
   ::encode(cluster_fsid, bl);
   ::encode(whoami, bl);
   ::encode(current_epoch, bl);
@@ -4006,6 +4006,7 @@ void OSDSuperblock::encode(bufferlist &bl) const
   ::encode(mounted, bl);
   ::encode(osd_fsid, bl);
   ::encode(last_map_marked_full, bl);
+  ::encode(pool_last_map_marked_full, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -4033,6 +4034,8 @@ void OSDSuperblock::decode(bufferlist::iterator &bl)
     ::decode(osd_fsid, bl);
   if (struct_v >= 6)
     ::decode(last_map_marked_full, bl);
+  if (struct_v >= 7)
+    ::decode(pool_last_map_marked_full, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2714,6 +2714,7 @@ public:
   epoch_t mounted;     // last epoch i mounted
   epoch_t clean_thru;  // epoch i was active and clean thru
   epoch_t last_map_marked_full; // last epoch osdmap was marked full
+  map<int64_t, epoch_t> pool_last_map_marked_full; // last epoch pool was marked full
 
   OSDSuperblock() : 
     whoami(-1), 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2299,7 +2299,7 @@ start:
  *
  * @return the latest possible epoch in which a cancelled op could have existed
  */
-epoch_t Objecter::op_cancel_writes(int r)
+epoch_t Objecter::op_cancel_writes(int r, int64_t pool)
 {
   rwlock.get_write();
 
@@ -2310,7 +2310,8 @@ epoch_t Objecter::op_cancel_writes(int r)
     OSDSession *s = siter->second;
     s->lock.get_read();
     for (map<ceph_tid_t, Op*>::iterator op_i = s->ops.begin(); op_i != s->ops.end(); ++op_i) {
-      if (op_i->second->target.flags & CEPH_OSD_FLAG_WRITE) {
+      if (op_i->second->target.flags & CEPH_OSD_FLAG_WRITE
+        && (pool == -1 || op_i->second->target.target_oloc.pool == pool)) {
         to_cancel.push_back(op_i->first);
       }
     }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -898,7 +898,8 @@ bool Objecter::ms_dispatch(Message *m)
 
 void Objecter::_scan_requests(OSDSession *s,
                              bool force_resend,
-			     bool force_resend_writes,
+			     bool cluster_full,
+                             map<int64_t, bool> *pool_full_map,
 			     map<ceph_tid_t, Op*>& need_resend,
 			     list<LingerOp*>& need_resend_linger,
 			     map<ceph_tid_t, CommandOp*>& need_resend_command)
@@ -918,8 +919,10 @@ void Objecter::_scan_requests(OSDSession *s,
     assert(op->session == s);
     ++lp;   // check_linger_pool_dne() may touch linger_ops; prevent iterator invalidation
     ldout(cct, 10) << " checking linger op " << op->linger_id << dendl;
-    bool unregister;
+    bool unregister, force_resend_writes = cluster_full;
     int r = _recalc_linger_op_target(op, lc);
+    if (pool_full_map)
+      force_resend_writes = force_resend_writes || (*pool_full_map)[op->target.base_oloc.pool];
     switch (r) {
     case RECALC_OP_TARGET_NO_ACTION:
       if (!force_resend && !force_resend_writes)
@@ -947,6 +950,9 @@ void Objecter::_scan_requests(OSDSession *s,
     Op *op = p->second;
     ++p;   // check_op_pool_dne() may touch ops; prevent iterator invalidation
     ldout(cct, 10) << " checking op " << op->tid << dendl;
+    bool force_resend_writes = cluster_full;
+    if (pool_full_map)
+      force_resend_writes = force_resend_writes || (*pool_full_map)[op->target.base_oloc.pool];
     int r = _calc_target(&op->target, &op->last_force_resend);
     switch (r) {
     case RECALC_OP_TARGET_NO_ACTION:
@@ -973,6 +979,9 @@ void Objecter::_scan_requests(OSDSession *s,
     CommandOp *c = cp->second;
     ++cp;
     ldout(cct, 10) << " checking command " << c->tid << dendl;
+    bool force_resend_writes = cluster_full;
+    if (pool_full_map)
+      force_resend_writes = force_resend_writes || (*pool_full_map)[c->target_pg.pool()];
     int r = _calc_command_target(c);
     switch (r) {
     case RECALC_OP_TARGET_NO_ACTION:
@@ -1020,9 +1029,14 @@ void Objecter::handle_osd_map(MOSDMap *m)
   }
 
   bool was_pauserd = osdmap->test_flag(CEPH_OSDMAP_PAUSERD);
-  bool was_full = _osdmap_full_flag();
-  bool was_pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || was_full;
+  bool cluster_full = _osdmap_full_flag();
+  bool was_pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || cluster_full || _osdmap_has_pool_full();
+  map<int64_t, bool> pool_full_map;
+  for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
+       it != osdmap->get_pools().end(); it++)
+    pool_full_map[it->first] = it->second.has_flag(pg_pool_t::FLAG_FULL);
 
+  
   list<LingerOp*> need_resend_linger;
   map<ceph_tid_t, Op*> need_resend;
   map<ceph_tid_t, CommandOp*> need_resend_command;
@@ -1073,18 +1087,19 @@ void Objecter::handle_osd_map(MOSDMap *m)
 	}
 	logger->set(l_osdc_map_epoch, osdmap->get_epoch());
 
-	was_full = was_full || _osdmap_full_flag();
-	_scan_requests(homeless_session, skipped_map, was_full,
-		       need_resend, need_resend_linger,
-		       need_resend_command);
+	cluster_full = cluster_full || _osdmap_full_flag();
+        update_pool_full_map(pool_full_map);
+	_scan_requests(homeless_session, skipped_map, cluster_full,
+                       &pool_full_map, need_resend,
+                       need_resend_linger, need_resend_command);
 
 	// osd addr changes?
 	for (map<int,OSDSession*>::iterator p = osd_sessions.begin();
 	     p != osd_sessions.end(); ) {
 	  OSDSession *s = p->second;
-	  _scan_requests(s, skipped_map, was_full,
-			 need_resend, need_resend_linger,
-			 need_resend_command);
+	  _scan_requests(s, skipped_map, cluster_full,
+			 &pool_full_map, need_resend,
+                         need_resend_linger, need_resend_command);
 	  ++p;
 	  if (!osdmap->is_up(s->osd) ||
 	      (s->con &&
@@ -1102,14 +1117,14 @@ void Objecter::handle_osd_map(MOSDMap *m)
         for (map<int,OSDSession*>::iterator p = osd_sessions.begin();
 	     p != osd_sessions.end(); ++p) {
 	  OSDSession *s = p->second;
-	  _scan_requests(s, false, false, need_resend, need_resend_linger,
-			 need_resend_command);
+	  _scan_requests(s, false, false, NULL, need_resend,
+                         need_resend_linger, need_resend_command);
         }
 	ldout(cct, 3) << "handle_osd_map decoding full epoch "
 		      << m->get_last() << dendl;
 	osdmap->decode(m->maps[m->get_last()]);
 
-	_scan_requests(homeless_session, false, false,
+	_scan_requests(homeless_session, false, false, NULL,
 		       need_resend, need_resend_linger,
 		       need_resend_command);
       } else {
@@ -1122,7 +1137,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
   }
 
   bool pauserd = osdmap->test_flag(CEPH_OSDMAP_PAUSERD);
-  bool pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || _osdmap_full_flag();
+  bool pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || _osdmap_full_flag() || _osdmap_has_pool_full();
 
   // was/is paused?
   if (was_pauserd || was_pausewr || pauserd || pausewr || osdmap->get_epoch() < epoch_barrier) {
@@ -2154,7 +2169,8 @@ ceph_tid_t Objecter::_op_submit(Op *op, RWLock::Context& lc)
     ldout(cct, 10) << " paused read " << op << " tid " << last_tid.read() << dendl;
     op->target.paused = true;
     _maybe_request_map();
-  } else if ((op->target.flags & CEPH_OSD_FLAG_WRITE) && _osdmap_full_flag()) {
+  } else if ((op->target.flags & CEPH_OSD_FLAG_WRITE) &&
+             (_osdmap_full_flag() || _osdmap_pool_full(op->target.base_oloc.pool))) {
     ldout(cct, 0) << " FULL, paused modify " << op << " tid " << last_tid.read() << dendl;
     op->target.paused = true;
     _maybe_request_map();
@@ -2352,8 +2368,9 @@ bool Objecter::is_pg_changed(
 
 bool Objecter::target_should_be_paused(op_target_t *t)
 {
+  const pg_pool_t *pi = osdmap->get_pg_pool(t->base_oloc.pool);
   bool pauserd = osdmap->test_flag(CEPH_OSDMAP_PAUSERD);
-  bool pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || _osdmap_full_flag();
+  bool pausewr = osdmap->test_flag(CEPH_OSDMAP_PAUSEWR) || _osdmap_full_flag() || pi->has_flag(pg_pool_t::FLAG_FULL);
 
   return (t->flags & CEPH_OSD_FLAG_READ && pauserd) ||
          (t->flags & CEPH_OSD_FLAG_WRITE && pausewr) ||
@@ -2378,6 +2395,11 @@ bool Objecter::osdmap_pool_full(const int64_t pool_id) const
     return true;
   }
 
+  return _osdmap_pool_full(pool_id);
+}
+
+bool Objecter::_osdmap_pool_full(const int64_t pool_id) const
+{
   const pg_pool_t *pool = osdmap->get_pg_pool(pool_id);
   if (pool == NULL) {
     ldout(cct, 4) << __func__ << ": DNE pool " << pool_id << dendl;
@@ -2385,6 +2407,16 @@ bool Objecter::osdmap_pool_full(const int64_t pool_id) const
   }
 
   return pool->has_flag(pg_pool_t::FLAG_FULL);
+}
+
+bool Objecter::_osdmap_has_pool_full() const
+{
+  for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
+       it != osdmap->get_pools().end(); it++) {
+    if (it->second.has_flag(pg_pool_t::FLAG_FULL))
+      return true;
+  }
+  return false;
 }
 
 /**
@@ -2396,6 +2428,17 @@ bool Objecter::_osdmap_full_flag() const
   return osdmap->test_flag(CEPH_OSDMAP_FULL) && honor_osdmap_full;
 }
 
+void Objecter::update_pool_full_map(map<int64_t, bool>& pool_full_map)
+{
+  for (map<int64_t, pg_pool_t>::const_iterator it = osdmap->get_pools().begin();
+       it != osdmap->get_pools().end(); it++) {
+    if (pool_full_map.find(it->first) == pool_full_map.end()) {
+      pool_full_map[it->first] = it->second.has_flag(pg_pool_t::FLAG_FULL);
+    } else {
+      pool_full_map[it->first] = it->second.has_flag(pg_pool_t::FLAG_FULL) || pool_full_map[it->first];
+    }
+  }
+}
 
 int64_t Objecter::get_object_hash_position(int64_t pool, const string& key,
 					   const string& ns)

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1718,6 +1718,8 @@ public:
    *         the global full flag is set, else false
    */
   bool osdmap_pool_full(const int64_t pool_id) const;
+  bool _osdmap_pool_full(const int64_t pool_id) const;
+  void update_pool_full_map(map<int64_t, bool>& pool_full_map);
 
  private:
   map<uint64_t, LingerOp*>  linger_ops;
@@ -1764,6 +1766,7 @@ public:
     RECALC_OP_TARGET_OSD_DOWN,
   };
   bool _osdmap_full_flag() const;
+  bool _osdmap_has_pool_full() const;
 
   bool target_should_be_paused(op_target_t *op);
   int _calc_target(op_target_t *t, epoch_t *last_force_resend=0, bool any_change=false);
@@ -1927,7 +1930,8 @@ private:
 
   void _scan_requests(OSDSession *s,
                      bool force_resend,
-		     bool force_resend_writes,
+		     bool cluster_full,
+                     map<int64_t, bool> *pool_full_map,
 		     map<ceph_tid_t, Op*>& need_resend,
 		     list<LingerOp*>& need_resend_linger,
 		     map<ceph_tid_t, CommandOp*>& need_resend_command);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1711,6 +1711,14 @@ public:
 
   bool osdmap_full_flag() const;
 
+  /**
+   * Test pg_pool_t::FLAG_FULL on a pool
+   *
+   * @return true if the pool exists and has the flag set, or
+   *         the global full flag is set, else false
+   */
+  bool osdmap_pool_full(const int64_t pool_id) const;
+
  private:
   map<uint64_t, LingerOp*>  linger_ops;
   // we use this just to confirm a cookie is valid before dereferencing the ptr

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2011,7 +2011,7 @@ private:
   friend class C_CancelOp;
 public:
   int op_cancel(ceph_tid_t tid, int r);
-  epoch_t op_cancel_writes(int r);
+  epoch_t op_cancel_writes(int r, int64_t pool=-1);
 
   // commands
   int osd_command(int osd, vector<string>& cmd,


### PR DESCRIPTION
Addresses http://tracker.ceph.com/issues/14824

However the new behavior of a full rbd pool (which matches that in Jewel and master) is
still far from perfect: removing an image (or a snapshot) from a full pool blocks forever.

> I think this is a general issue with pool quota handling. It should be treated
> the same as cluster full handling, but currently is not.

A cluster running out of space is certainly an abnormal condition, it's ought
to be noticed and fixed by operator(s). So waiting for free space to become
available might be a sensible work around (the proper solution is to handle
the problem on the client side). However waiting (for more space) makes
little sense for a full pool: preventing the clients from comsuming
"too much" disk space is exactly the purpose of quotas.

> Essentially make the osd drop the request, and update the client side to
> resend all requests to a particular pool when that pool goes from
> FULL -> not FULL according to the osdmap. The main diffence from entire
> cluster full handling is that it only affects requests to particular pools.

Many rbd operations modify the metadata which involves writing to 'rbd_directory'
and possibly other objects. Thus dropping _all_ requests will make impossible
removing images (and snapshots) from a full pool. 
