### PR TITLE
DNM: jewel: rgw: Fix Host->bucket fallback logic inversion

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1770,7 +1770,7 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO* cio)
     if (subdomain.empty()
         && (domain.empty() || domain != info.host)
         && !looks_like_ip_address(info.host.c_str())
-        && RGWHandler_REST::validate_bucket_name(info.host)) {
+        && RGWHandler_REST::validate_bucket_name(info.host) == 0) {
       subdomain.append(info.host);
       in_hosted_domain = 1;
     }


### PR DESCRIPTION
The logic (added in 46aae19ee) for falling back to just using the hostname as
the possible bucket name contained an accidental inversion, because
RGWHandler_REST::validate_bucket_name returns success as zero.

Backport: jewel
Fixes: http://tracker.ceph.com/issues/17136
Re-Fixes: http://tracker.ceph.com/issues/15975
Signed-off-by: Robin H. Johnson robin.johnson@dreamhost.com
(cherry picked from commit 0e0a4bc3dcb61c2e8dfe65daefe207c62b36306c)
