### PR TITLE
Revert "osd/ReplicatedPG: for sync-read it don't cacl l_osd_op_r_prep…

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2139,13 +2139,12 @@ void ReplicatedPG::do_op(OpRequestRef& op)
   execute_ctx(ctx);
   utime_t prepare_latency = ceph_clock_now(cct);
   prepare_latency -= op->get_dequeued_time();
+  osd->logger->tinc(l_osd_op_prepare_lat, prepare_latency);
   if (op->may_read() && op->may_write()) {
-    osd->logger->tinc(l_osd_op_prepare_lat, prepare_latency);
     osd->logger->tinc(l_osd_op_rw_prepare_lat, prepare_latency);
-  } else if (!ctx->pending_async_reads.empty() && op->may_read()) {
+  } else if (op->may_read()) {
     osd->logger->tinc(l_osd_op_r_prepare_lat, prepare_latency);
   } else if (op->may_write() || op->may_cache()) {
-    osd->logger->tinc(l_osd_op_prepare_lat, prepare_latency);
     osd->logger->tinc(l_osd_op_w_prepare_lat, prepare_latency);
   }
 }


### PR DESCRIPTION
…are_lat."

Accessing the OpContext* after execute_ctx is invalid, on error, it
will have been deleted.

This reverts commit 52be772788d9d96accaa7af9eaf9f29a3792df49.