### PR TITLE
cephfs: Support scrub with multiple MDS

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3932,6 +3932,9 @@ next:
           p != frags.end();
           ++p) {
         CDir *dir = in->get_or_open_dirfrag(in->mdcache, *p);
+	if (in->scrub_infop && !dir->is_auth()) {
+	  return immediate(DIRFRAGS, 0);
+	}
 	dir->scrub_info();
 	if (!dir->scrub_infop->header && in->scrub_infop)
 	  dir->scrub_infop->header = in->scrub_infop->header;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -77,6 +77,8 @@
 #include "messages/MDentryLink.h"
 #include "messages/MDentryUnlink.h"
 
+#include "messages/MMDSScrubPath.h"
+
 #include "messages/MMDSFindIno.h"
 #include "messages/MMDSFindInoReply.h"
 
@@ -7696,6 +7698,10 @@ void MDCache::dispatch(Message *m)
   case MSG_MDS_OPENINOREPLY:
     handle_open_ino_reply(static_cast<MMDSOpenInoReply *>(m));
     break;
+
+  case MSG_MDS_SCRUBPATH:
+    handle_scrub_path(static_cast<MMDSScrubPath *>(m));
+    break;
     
   default:
     derr << "cache unknown message " << m->get_type() << dendl;
@@ -8608,6 +8614,13 @@ void MDCache::handle_open_ino_reply(MMDSOpenInoReply *m)
     }
   }
   m->put();
+}
+
+void MDCache::handle_scrub_path(MMDSScrubPath *m)
+{
+  dout(10) << "handle_scrub_path " << *m << dendl;
+
+  enqueue_scrub(m->path, m->tag, m->force, true, m->repair, NULL, NULL);
 }
 
 void MDCache::kick_open_ino_peers(mds_rank_t who)
@@ -11871,12 +11884,9 @@ void MDCache::enqueue_scrub(
 void MDCache::enqueue_scrub_work(MDRequestRef& mdr)
 {
   set<SimpleLock*> rdlocks, wrlocks, xlocks;
-  CInode *in = mds->server->rdlock_path_pin_ref(mdr, 0, rdlocks, true);
+  CInode *in = mds->server->rdlock_path_pin_ref(mdr, 0, rdlocks, false);
   if (NULL == in)
     return;
-
-  // TODO: Remove this restriction
-  assert(in->is_auth());
 
   bool locked = mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks);
   if (!locked)

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -33,6 +33,7 @@
 #include "MDSMap.h"
 
 #include "messages/MClientRequest.h"
+#include "messages/MMDSScrubPath.h"
 #include "messages/MMDSSlaveRequest.h"
 
 class PerfCounters;
@@ -1170,6 +1171,8 @@ public:
 		     Formatter *f, Context *fin);
   void repair_inode_stats(CInode *diri);
   void repair_dirfrag_stats(CDir *dir);
+
+  void handle_scrub_path(MMDSScrubPath *m);
 };
 
 class C_MDS_RetryRequest : public MDSInternalContext {

--- a/src/messages/MMDSScrubPath.h
+++ b/src/messages/MMDSScrubPath.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+
+#ifndef CEPH_MMDSSCRUBPATH_H
+#define CEPH_MMDSSCRUBPATH_H
+
+#include "msg/Message.h"
+
+
+class MMDSScrubPath : public Message {
+ public:  
+  std::string path;
+  std::string tag;
+  bool force;
+  bool repair;
+
+  MMDSScrubPath() : Message(MSG_MDS_SCRUBPATH) {}
+  MMDSScrubPath(const std::string& _path, ScrubHeaderRefConst header)
+    : Message(MSG_MDS_SCRUBPATH) {
+    path = _path;
+    tag = header->tag;
+    force = header->force;
+    repair = header->repair;
+  }
+private:
+  ~MMDSScrubPath() {}
+
+public:
+  const char *get_type_name() const { return "Sc"; }
+  void print(ostream& o) const {
+    o << "scrub(" << path << " tag " << tag << " force=" << force
+      << " repair=" << repair << ")";
+  }
+
+  void encode_payload(uint64_t features) {
+    ::encode(path, payload);
+    ::encode(tag, payload);
+    ::encode(force, payload);
+    ::encode(repair, payload);
+  }
+  void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(path, p);
+    ::decode(tag, p);
+    ::decode(force, p);
+    ::decode(repair, p);
+  }
+
+};
+
+#endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -123,6 +123,8 @@ using namespace std;
 #include "messages/MMDSOpenIno.h"
 #include "messages/MMDSOpenInoReply.h"
 
+#include "messages/MMDSScrubPath.h"
+
 #include "messages/MDirUpdate.h"
 #include "messages/MDiscover.h"
 #include "messages/MDiscoverReply.h"
@@ -621,6 +623,10 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case MSG_MDS_OPENINOREPLY:
     m = new MMDSOpenInoReply;
+    break;
+
+  case MSG_MDS_SCRUBPATH:
+    m = new MMDSScrubPath;
     break;
 
   case MSG_MDS_FRAGMENTNOTIFY:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -136,6 +136,7 @@
 #define MSG_MDS_FINDINOREPLY       0x20e
 #define MSG_MDS_OPENINO            0x20f
 #define MSG_MDS_OPENINOREPLY       0x210
+#define MSG_MDS_SCRUBPATH          0x211
 
 #define MSG_MDS_LOCK               0x300
 #define MSG_MDS_INODEFILECAPS      0x301


### PR DESCRIPTION
Support scrubbing with more than one MDS. When a subtree boundary
is encountered during scrub, send a new MMDSScrubPath message to the
authoritative MDS and continue without waiting.

Fixes: http://tracker.ceph.com/issues/12274
Signed-off-by: Douglas Fuller <dfuller@redhat.com>