### PR TITLE
jerasure: include generic objects in neon jerasure lib (like sse3/4)

### DIFF
--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -36,6 +36,7 @@ endif()
 list(FIND jerasure_flavors neon found)
 if(found GREATER -1)
   add_library(jerasure_neon OBJECT
+    ${jerasure_srcs}
     gf-complete/src/neon/gf_w4_neon.c
     gf-complete/src/neon/gf_w8_neon.c
     gf-complete/src/neon/gf_w16_neon.c


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>