### PR TITLE
rados: check for negative return value of rados_create_with_context() as its comment put

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -1768,9 +1768,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
   // open rados
   ret = rados.init_with_context(g_ceph_context);
-  if (ret) {
+  if (ret < 0) {
      cerr << "couldn't initialize rados: " << cpp_strerror(ret) << std::endl;
-     ret = -1;
      goto out;
   }
 


### PR DESCRIPTION
 rados.init_with_context returned value is '<=0'

Signed-off-by: zhang.zezhu zhang.zezhu@zte.com.cn
