### PR TITLE
build/ops: force Python 3 packages to build in SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -763,6 +763,11 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 
+%if 0%{?suse_version}
+# create __pycache__ directories and their contents
+%py3_compile %{buildroot}%{python3_sitelib}
+%endif
+
 %clean
 rm -rf %{buildroot}
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1379,18 +1379,14 @@ ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
 %{python3_sitearch}/cephfs.cpython*.so
 %{python3_sitearch}/cephfs-*.egg-info
 %{python3_sitelib}/ceph_volume_client.py
-%if ! 0%{?suse_version}
 %{python3_sitelib}/__pycache__/ceph_volume_client.cpython*.py*
-%endif
 
 %files -n python%{python3_pkgversion}-ceph-argparse
 %defattr(-,root,root,-)
 %{python3_sitelib}/ceph_argparse.py
-%{python3_sitelib}/ceph_daemon.py
-%if ! 0%{?suse_version}
 %{python3_sitelib}/__pycache__/ceph_argparse.cpython*.py*
+%{python3_sitelib}/ceph_daemon.py
 %{python3_sitelib}/__pycache__/ceph_daemon.cpython*.py*
-%endif
 
 %files -n ceph-test
 %defattr(-,root,root,-)


### PR DESCRIPTION
#10805 fixed http://tracker.ceph.com/issues/17106 by not packaging the `__pycache__` directories and their contents for Python 3. This PR reverts that and modifies the spec file to ensure the Python 3 stuff gets built on SUSE.