### PR TITLE
doc: add missing PR to hammer 0.94.8 release notes

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -14,6 +14,7 @@ For more detailed information, see :download:`the complete changelog <changelog/
 Notable Changes
 ---------------
 
+* build/ops: rocksdb do not link against tcmalloc if it's disabled (`issue#14799 <http://tracker.ceph.com/issues/14799`_, `pr#10750 <http://github.com/ceph/ceph/pull/10750>`_, Sage Weil, Kefu Chai)
 * ceph: cli: exception when pool name has non-ascii characters (`issue#15913 <http://tracker.ceph.com/issues/15913>`_, `pr#9320 <http://github.com/ceph/ceph/pull/9320>`_, Ricardo Dias)
 * ceph-disk: workaround gperftool hang (`issue#13522 <http://tracker.ceph.com/issues/13522>`_, `issue#16103 <http://tracker.ceph.com/issues/16103>`_, `pr#9427 <http://github.com/ceph/ceph/pull/9427>`_, Loic Dachary)
 * cephfs: backports needed for Manila (`issue#15599 <http://tracker.ceph.com/issues/15599>`_, `issue#15417 <http://tracker.ceph.com/issues/15417>`_, `issue#15045 <http://tracker.ceph.com/issues/15045>`_, `pr#9430 <http://github.com/ceph/ceph/pull/9430>`_, John Spray, Ramana Raja, Xiaoxi Chen)


### PR DESCRIPTION
This PR was merged at the last minute, so it was not included in #10730 