### PR TITLE
mds/MDCache.h: remove unneeded access specifier

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -312,7 +312,6 @@ protected:
 
 
   // -- requests --
-protected:
   ceph::unordered_map<metareqid_t, MDRequestRef> active_requests;
 
 public:


### PR DESCRIPTION
Signed-off-by: Michal Jarzabek <stiopa@gmail.com>