### PR TITLE
hammer: mon: return size_t from MonitorDBStore::Transaction::size()

### DIFF
--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -187,7 +187,7 @@ class MonitorDBStore
       return (size() == 0);
     }
 
-    bool size() {
+    size_t size() const {
       return ops.size();
     }
     uint64_t get_keys() const {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/14217
Signed-off-by: Kefu Chai kchai@redhat.com
(cherry picked from commit 3971274b342b00d76c2e19211becdc3ee81cf1c1)
