### PR TITLE
cmake: fix the tracing header dependencies

### DIFF
--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(librados ${CEPH_SHARED}
   $<TARGET_OBJECTS:common_buffer_obj>)
 add_dependencies(librados osdc)
 if(WITH_LTTNG)
-  add_dependencies(librados rados-tp)
+  add_dependencies(librados_api_obj rados-tp)
 endif()
 # LINK_PRIVATE instead of PRIVATE is used to backward compatibility with cmake 2.8.11
 target_link_libraries(librados LINK_PRIVATE osdc common cls_lock_client

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -73,7 +73,7 @@ add_library(rbd_internal STATIC
   ${librbd_internal_srcs}
   $<TARGET_OBJECTS:rados_snap_set_diff_obj>)
 if(WITH_LTTNG)
-  add_dependencies(rbd_internal rbd-tp)
+  add_dependencies(rbd_api rbd-tp)
 endif()
 
 add_library(librbd ${CEPH_SHARED}


### PR DESCRIPTION
in aa679df, we move librados.cc into a separated obj target. this broken
the dependency from librados.o to its tracing header. we need to update
it accordingly.

this change fixes the following compilation error:
```
/var/ceph/ceph/src/librados/librados.cc:47:30: fatal error:
tracing/librados.h: No such file or directory
 #include "tracing/librados.h"
                              ^
compilation terminated.
```

Signed-off-by: Kefu Chai <kchai@redhat.com>