### PR TITLE
mon: have mon-specific features & rework internal monmap structures

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -436,6 +436,7 @@ set(libcommon_files
   common/TracepointProvider.cc
   common/Cycles.cc
   common/scrub_types.cc
+  common/bit_str.cc
   osdc/Striper.cc
   osdc/Objecter.cc
   common/Graylog.cc

--- a/src/common/bit_str.cc
+++ b/src/common/bit_str.cc
@@ -14,12 +14,14 @@
 #include "common/bit_str.h"
 #include "common/Formatter.h"
 #include "include/assert.h"
+#include "common/debug.h"
 
 static void _dump_bit_str(
     uint64_t bits,
     std::ostream *out,
     ceph::Formatter *f,
-    std::function<const char*(uint64_t)> func)
+    std::function<const char*(uint64_t)> func,
+    bool dump_bit_val)
 {
   uint64_t b = bits;
   int cnt = 0;
@@ -32,9 +34,17 @@ static void _dump_bit_str(
         if (outted)
           *out << ",";
         *out << func(r);
+        if (dump_bit_val) {
+          *out << "(" << r << ")";
+        }
       } else {
         assert(f != NULL);
-        f->dump_stream("bit_flag") << func(r);
+        if (dump_bit_val) {
+          f->dump_stream("bit_flag") << func(r)
+                                     << "(" << r << ")";
+        } else {
+          f->dump_stream("bit_flag") << func(r);
+        }
       }
       outted = true;
     }
@@ -47,15 +57,17 @@ static void _dump_bit_str(
 void print_bit_str(
     uint64_t bits,
     std::ostream &out,
-    std::function<const char*(uint64_t)> func)
+    std::function<const char*(uint64_t)> func,
+    bool dump_bit_val)
 {
-  _dump_bit_str(bits, &out, NULL, func);
+  _dump_bit_str(bits, &out, NULL, func, dump_bit_val);
 }
 
 void dump_bit_str(
     uint64_t bits,
     ceph::Formatter *f,
-    std::function<const char*(uint64_t)> func)
+    std::function<const char*(uint64_t)> func,
+    bool dump_bit_val)
 {
-  _dump_bit_str(bits, NULL, f, func);
+  _dump_bit_str(bits, NULL, f, func, dump_bit_val);
 }

--- a/src/common/bit_str.cc
+++ b/src/common/bit_str.cc
@@ -1,0 +1,61 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include "common/bit_str.h"
+#include "common/Formatter.h"
+#include "include/assert.h"
+
+static void _dump_bit_str(
+    uint64_t bits,
+    std::ostream *out,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func)
+{
+  uint64_t b = bits;
+  int cnt = 0;
+  bool outted = false;
+
+  while (b && cnt < 64) {
+    uint64_t r = bits & (1ULL << cnt++);
+    if (r) {
+      if (out) {
+        if (outted)
+          *out << ",";
+        *out << func(r);
+      } else {
+        assert(f != NULL);
+        f->dump_stream("bit_flag") << func(r);
+      }
+      outted = true;
+    }
+    b >>= 1;
+  }
+  if (!outted && out)
+      *out << "none";
+}
+
+void print_bit_str(
+    uint64_t bits,
+    std::ostream &out,
+    std::function<const char*(uint64_t)> func)
+{
+  _dump_bit_str(bits, &out, NULL, func);
+}
+
+void dump_bit_str(
+    uint64_t bits,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func)
+{
+  _dump_bit_str(bits, NULL, f, func);
+}

--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -25,11 +25,13 @@ namespace ceph {
 extern void print_bit_str(
     uint64_t bits,
     std::ostream &out,
-    std::function<const char*(uint64_t)> func);
+    std::function<const char*(uint64_t)> func,
+    bool dump_bit_val = false);
 
 extern void dump_bit_str(
     uint64_t bits,
     ceph::Formatter *f,
-    std::function<const char*(uint64_t)> func);
+    std::function<const char*(uint64_t)> func,
+    bool dump_bit_val = false);
 
 #endif /* CEPH_COMMON_BIT_STR_H */

--- a/src/common/bit_str.h
+++ b/src/common/bit_str.h
@@ -1,0 +1,35 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#ifndef CEPH_COMMON_BIT_STR_H
+#define CEPH_COMMON_BIT_STR_H
+
+#include <ostream>
+#include <functional>
+#include <stdint.h>
+
+namespace ceph {
+  class Formatter;
+}
+
+extern void print_bit_str(
+    uint64_t bits,
+    std::ostream &out,
+    std::function<const char*(uint64_t)> func);
+
+extern void dump_bit_str(
+    uint64_t bits,
+    ceph::Formatter *f,
+    std::function<const char*(uint64_t)> func);
+
+#endif /* CEPH_COMMON_BIT_STR_H */

--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -118,12 +118,14 @@ static int build_map_buf(CephContext *cct, const char *pool, const char *image,
   if (r < 0)
     return r;
 
-  for (map<string, entity_addr_t>::const_iterator it = monmap.mon_addr.begin();
-       it != monmap.mon_addr.end();
-       ++it) {
-    if (it != monmap.mon_addr.begin())
+  list<entity_addr_t> mon_addr;
+  monmap.list_addrs(mon_addr);
+
+  for (const auto &p : mon_addr) {
+    if (oss.tellp() > 0) {
       oss << ",";
-    oss << it->second.get_sockaddr();
+    }
+    oss << p;
   }
 
   oss << " name=" << cct->_conf->name.get_id();

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -236,7 +236,7 @@ void AuthMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   ::encode(v, bl);
   vector<Incremental>::iterator p;
   for (p = pending_auth.begin(); p != pending_auth.end(); ++p)
-    p->encode(bl, mon->get_quorum_features());
+    p->encode(bl, mon->get_quorum_con_features());
 
   version_t version = get_last_committed() + 1;
   put_version(t, version, bl);

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -88,13 +88,16 @@ void Elector::start()
   }
   start_stamp = ceph_clock_now(g_ceph_context);
   electing_me = true;
-  acked_me[mon->rank] = CEPH_FEATURES_ALL;
+  acked_me[mon->rank].cluster_features = CEPH_FEATURES_ALL;
+  acked_me[mon->rank].mon_features = ceph::features::mon::get_supported();
   leader_acked = -1;
 
   // bcast to everyone else
   for (unsigned i=0; i<mon->monmap->size(); ++i) {
     if ((int)i == mon->rank) continue;
-    Message *m = new MMonElection(MMonElection::OP_PROPOSE, epoch, mon->monmap);
+    MMonElection *m =
+      new MMonElection(MMonElection::OP_PROPOSE, epoch, mon->monmap);
+    m->mon_features = ceph::features::mon::get_supported();
     mon->messenger->send_message(m, mon->monmap->get_inst(i));
   }
   
@@ -116,6 +119,7 @@ void Elector::defer(int who)
   leader_acked = who;
   ack_stamp = ceph_clock_now(g_ceph_context);
   MMonElection *m = new MMonElection(MMonElection::OP_ACK, epoch, mon->monmap);
+  m->mon_features = ceph::features::mon::get_supported();
   m->sharing_bl = mon->get_supported_commands_bl();
   mon->messenger->send_message(m, mon->monmap->get_inst(who));
   
@@ -187,12 +191,15 @@ void Elector::victory()
   leader_acked = -1;
   electing_me = false;
 
-  uint64_t features = CEPH_FEATURES_ALL;
+  uint64_t cluster_features = CEPH_FEATURES_ALL;
+  mon_feature_t mon_features = ceph::features::mon::get_supported();
   set<int> quorum;
-  for (map<int, uint64_t>::iterator p = acked_me.begin(); p != acked_me.end();
+  for (map<int, elector_features_t>::iterator p = acked_me.begin();
+       p != acked_me.end();
        ++p) {
     quorum.insert(p->first);
-    features &= p->second;
+    cluster_features &= p->second.cluster_features;
+    mon_features &= p->second.mon_features;
   }
 
   // decide what command set we're supporting
@@ -224,13 +231,16 @@ void Elector::victory()
     if (*p == mon->rank) continue;
     MMonElection *m = new MMonElection(MMonElection::OP_VICTORY, epoch, mon->monmap);
     m->quorum = quorum;
-    m->quorum_features = features;
+    m->quorum_features = cluster_features;
+    m->mon_features = mon_features;
     m->sharing_bl = *cmds_bl;
     mon->messenger->send_message(m, mon->monmap->get_inst(*p));
   }
     
   // tell monitor
-  mon->win_election(epoch, quorum, features, cmds, cmdsize, &copy_classic_mons);
+  mon->win_election(epoch, quorum,
+                    cluster_features, mon_features,
+                    cmds, cmdsize, &copy_classic_mons);
 }
 
 
@@ -315,13 +325,24 @@ void Elector::handle_ack(MonOpRequestRef op)
 	    << " without required features" << dendl;
     return;
   }
-  
+
   if (electing_me) {
     // thanks
-    acked_me[from] = m->get_connection()->get_features();
+    acked_me[from].cluster_features = m->get_connection()->get_features();
+    acked_me[from].mon_features = m->mon_features;
     if (!m->sharing_bl.length())
       classic_mons.insert(from);
-    dout(5) << " so far i have " << acked_me << dendl;
+    dout(5) << " so far i have {";
+    for (map<int, elector_features_t>::const_iterator p = acked_me.begin();
+         p != acked_me.end();
+         ++p) {
+      if (p != acked_me.begin())
+        *_dout << ",";
+      *_dout << " mon." << p->first << ":"
+             << " features " << p->second.cluster_features
+             << " " << p->second.mon_features;
+    }
+    *_dout << " }" << dendl;
     
     // is that _everyone_?
     if (acked_me.size() == mon->monmap->size()) {
@@ -339,7 +360,10 @@ void Elector::handle_victory(MonOpRequestRef op)
 {
   op->mark_event("elector:handle_victory");
   MMonElection *m = static_cast<MMonElection*>(op->get_req());
-  dout(5) << "handle_victory from " << m->get_source() << " quorum_features " << m->quorum_features << dendl;
+  dout(5) << "handle_victory from " << m->get_source()
+          << " quorum_features " << m->quorum_features
+          << " " << m->mon_features
+          << dendl;
   int from = m->get_source().num();
 
   assert(from < mon->rank);
@@ -356,10 +380,11 @@ void Elector::handle_victory(MonOpRequestRef op)
   }
 
   bump_epoch(m->epoch);
-  
+
   // they win
-  mon->lose_election(epoch, m->quorum, from, m->quorum_features);
-  
+  mon->lose_election(epoch, m->quorum, from,
+                     m->quorum_features, m->mon_features);
+
   // cancel my timer
   cancel_timer();
 

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -253,15 +253,27 @@ void Elector::handle_propose(MonOpRequestRef op)
 
   assert(m->epoch % 2 == 1); // election
   uint64_t required_features = mon->get_required_features();
+  mon_feature_t required_mon_features = mon->get_required_mon_features();
+
   dout(10) << __func__ << " required features " << required_features
+           << " " << required_mon_features
            << ", peer features " << m->get_connection()->get_features()
+           << " " << m->mon_features
            << dendl;
+
   if ((required_features ^ m->get_connection()->get_features()) &
       required_features) {
     dout(5) << " ignoring propose from mon" << from
 	    << " without required features" << dendl;
     nak_old_peer(op);
     return;
+  } else if (!m->mon_features.contains_all(required_mon_features)) {
+    // all the features in 'required_mon_features' not in 'm->mon_features'
+    mon_feature_t missing = required_mon_features.diff(m->mon_features);
+    dout(5) << " ignoring propose from mon." << from
+            << " without required mon_features " << missing
+            << dendl;
+    nak_old_peer(op);
   } else if (m->epoch > epoch) {
     bump_epoch(m->epoch);
   } else if (m->epoch < epoch) {
@@ -302,7 +314,7 @@ void Elector::handle_propose(MonOpRequestRef op)
     }
   }
 }
- 
+
 void Elector::handle_ack(MonOpRequestRef op)
 {
   op->mark_event("elector:handle_ack");
@@ -326,6 +338,15 @@ void Elector::handle_ack(MonOpRequestRef op)
     return;
   }
 
+  mon_feature_t required_mon_features = mon->get_required_mon_features();
+  if (!m->mon_features.contains_all(required_mon_features)) {
+    mon_feature_t missing = required_mon_features.diff(m->mon_features);
+    dout(5) << " ignoring ack from mon." << from
+            << " without required mon_features " << missing
+            << dendl;
+    return;
+  }
+
   if (electing_me) {
     // thanks
     acked_me[from].cluster_features = m->get_connection()->get_features();
@@ -343,7 +364,7 @@ void Elector::handle_ack(MonOpRequestRef op)
              << " " << p->second.mon_features;
     }
     *_dout << " }" << dendl;
-    
+
     // is that _everyone_?
     if (acked_me.size() == mon->monmap->size()) {
       // if yes, shortcut to election finish
@@ -408,19 +429,21 @@ void Elector::nak_old_peer(MonOpRequestRef op)
   op->mark_event("elector:nak_old_peer");
   MMonElection *m = static_cast<MMonElection*>(op->get_req());
   uint64_t supported_features = m->get_connection()->get_features();
+  uint64_t required_features = mon->get_required_features();
+  mon_feature_t required_mon_features = mon->get_required_mon_features();
+  dout(10) << "sending nak to peer " << m->get_source()
+    << " that only supports " << supported_features
+    << " " << m->mon_features
+    << " of the required " << required_features
+    << " " << required_mon_features
+    << dendl;
 
-  if (supported_features & CEPH_FEATURE_OSDMAP_ENC) {
-    uint64_t required_features = mon->get_required_features();
-    dout(10) << "sending nak to peer " << m->get_source()
-	     << " that only supports " << supported_features
-	     << " of the required " << required_features << dendl;
-    
-    MMonElection *reply = new MMonElection(MMonElection::OP_NAK, m->epoch,
-					   mon->monmap);
-    reply->quorum_features = required_features;
-    mon->features.encode(reply->sharing_bl);
-    m->get_connection()->send_message(reply);
-  }
+  MMonElection *reply = new MMonElection(MMonElection::OP_NAK, m->epoch,
+                                         mon->monmap);
+  reply->quorum_features = required_features;
+  reply->mon_features = required_mon_features;
+  mon->features.encode(reply->sharing_bl);
+  m->get_connection()->send_message(reply);
 }
 
 void Elector::handle_nak(MonOpRequestRef op)
@@ -428,16 +451,22 @@ void Elector::handle_nak(MonOpRequestRef op)
   op->mark_event("elector:handle_nak");
   MMonElection *m = static_cast<MMonElection*>(op->get_req());
   dout(1) << "handle_nak from " << m->get_source()
-	  << " quorum_features " << m->quorum_features << dendl;
+	  << " quorum_features " << m->quorum_features
+          << " " << m->mon_features
+          << dendl;
 
   CompatSet other;
   bufferlist::iterator bi = m->sharing_bl.begin();
   other.decode(bi);
   CompatSet diff = Monitor::get_supported_features().unsupported(other);
-  
+
+  mon_feature_t mon_supported = ceph::features::mon::get_supported();
+  // all features in 'm->mon_features' not in 'mon_supported'
+  mon_feature_t mon_diff = m->mon_features.diff(mon_supported);
+
   derr << "Shutting down because I do not support required monitor features: { "
-       << diff << " }" << dendl;
-  
+       << diff << " } " << mon_diff << dendl;
+
   exit(0);
   // the end!
 }

--- a/src/mon/Elector.h
+++ b/src/mon/Elector.h
@@ -22,6 +22,7 @@ using namespace std;
 #include "include/types.h"
 #include "include/Context.h"
 #include "mon/MonOpRequest.h"
+#include "mon/mon_types.h"
 
 class Monitor;
 
@@ -36,6 +37,25 @@ class Elector {
    * @{
    */
  private:
+   /**
+   * @defgroup Elector_h_internal_types Internal Types
+   * @{
+   */
+  /**
+   * This struct will hold the features from a given peer.
+   * Features may both be the cluster's (in the form of a uint64_t), or
+   * mon-specific features. Instead of keeping maps to hold them both, or
+   * a pair, which would be weird, a struct to keep them seems appropriate.
+   */
+  struct elector_features_t {
+    uint64_t cluster_features;
+    mon_feature_t mon_features;
+  };
+
+  /**
+   * @}
+   */
+
   /**
    * The Monitor instance associated with this class.
    */
@@ -110,7 +130,7 @@ class Elector {
    * If we are acked by everyone in the MonMap, we will declare
    * victory.  Also note each peer's feature set.
    */
-  map<int, uint64_t> acked_me;
+  map<int, elector_features_t> acked_me;
   set<int> classic_mons;
   /**
    * @}

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -216,7 +216,7 @@ void LogMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   ::encode(v, bl);
   multimap<utime_t,LogEntry>::iterator p;
   for (p = pending_log.begin(); p != pending_log.end(); ++p)
-    p->second.encode(bl, mon->quorum_features);
+    p->second.encode(bl, mon->get_quorum_con_features());
 
   put_version(t, version, bl);
   put_last_committed(t, version);
@@ -228,7 +228,7 @@ void LogMonitor::encode_full(MonitorDBStore::TransactionRef t)
   assert(get_last_committed() == summary.version);
 
   bufferlist summary_bl;
-  ::encode(summary, summary_bl, mon->quorum_features);
+  ::encode(summary, summary_bl, mon->get_quorum_con_features());
 
   put_version_full(t, summary.version, summary_bl);
   put_version_latest_full(t, summary.version);

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -101,7 +101,7 @@ void MDSMonitor::create_new_fs(FSMap &fsm, const std::string &name,
   fs->mds_map.session_timeout = g_conf->mds_session_timeout;
   fs->mds_map.session_autoclose = g_conf->mds_session_autoclose;
   fs->mds_map.enabled = true;
-  if (mon->get_quorum_features() & CEPH_FEATURE_SERVER_JEWEL) {
+  if (mon->get_quorum_con_features() & CEPH_FEATURE_SERVER_JEWEL) {
     fs->fscid = fsm.next_filesystem_id++;
     // ANONYMOUS is only for upgrades from legacy mdsmaps, we should
     // have initialized next_filesystem_id such that it's never used here.
@@ -196,7 +196,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // apply to paxos
   assert(get_last_committed() + 1 == pending_fsmap.epoch);
   bufferlist fsmap_bl;
-  pending_fsmap.encode(fsmap_bl, mon->get_quorum_features());
+  pending_fsmap.encode(fsmap_bl, mon->get_quorum_con_features());
 
   /* put everything in the transaction */
   put_version(t, pending_fsmap.epoch, fsmap_bl);
@@ -1545,7 +1545,7 @@ class FlagSetHandler : public FileSystemCommandHandler
         return r;
       }
 
-      bool jewel = mon->get_quorum_features() & CEPH_FEATURE_SERVER_JEWEL;
+      bool jewel = mon->get_quorum_con_features() && CEPH_FEATURE_SERVER_JEWEL;
       if (flag_bool && !jewel) {
         ss << "Multiple-filesystems are forbidden until all mons are updated";
         return -EINVAL;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -438,6 +438,22 @@ COMMAND("mon remove " \
 COMMAND("mon rm " \
 	"name=name,type=CephString", \
 	"remove monitor named <name>", "mon", "rw", "cli,rest")
+COMMAND("mon debug set_feature" \
+        "name=feature_type,type=CephChoices,strings=persistent|optional " \
+        "name=feature_name,type=CephString " \
+        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "set provided feature on mon map", \
+        "mon", "rw", "cli")
+COMMAND("mon debug list_features " \
+        "name=feature_type,type=CephString,req=false", \
+        "list available mon map features to be set/unset", \
+        "mon", "rw", "cli")
+COMMAND("mon debug unset_feature " \
+        "name=feature_type,type=CephChoices,strings=persistent|optional " \
+        "name=feature_name,type=CephString " \
+        "name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+        "unset provided feature from monmap", \
+        "mon", "rw", "cli")
 
 /*
  * OSD commands

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -134,6 +134,30 @@ void MonMap::generate_test_instances(list<MonMap*>& o)
   o.back()->last_changed = utime_t(123, 456);
   o.back()->created = utime_t(789, 101112);
   o.back()->add("one", entity_addr_t());
+
+  MonMap *m = new MonMap;
+  {
+    m->epoch = 1;
+    m->last_changed = utime_t(123, 456);
+
+    entity_addr_t empty_addr_one;
+    empty_addr_one.set_nonce(1);
+    m->add("empty_addr_one", empty_addr_one);
+    entity_addr_t empty_addr_two;
+    empty_addr_two.set_nonce(2);
+    m->add("empty_adrr_two", empty_addr_two);
+
+    const char *local_pub_addr_s = "127.0.1.2";
+
+    const char *end_p = local_pub_addr_s + strlen(local_pub_addr_s);
+    entity_addr_t local_pub_addr;
+    local_pub_addr.parse(local_pub_addr_s, &end_p);
+
+    m->add("filled_pub_addr", local_pub_addr);
+
+    m->add("empty_addr_zero", entity_addr_t());
+  }
+  o.push_back(m);
 }
 
 // read from/write to a file

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -18,8 +18,44 @@
 
 using ceph::Formatter;
 
+void mon_info_t::encode(bufferlist& bl, uint64_t features) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(name, bl);
+  ::encode(public_addr, bl, features);
+  ENCODE_FINISH(bl);
+}
+
+void mon_info_t::decode(bufferlist::iterator& p)
+{
+  DECODE_START(1, p);
+  ::decode(name, p);
+  ::decode(public_addr, p);
+  DECODE_FINISH(p);
+}
+
+void mon_info_t::print(ostream& out) const
+{
+  out << "mon." << name
+      << " public " << public_addr;
+}
+
 void MonMap::encode(bufferlist& blist, uint64_t con_features) const
 {
+  /* we keep the mon_addr map when encoding to ensure compatibility
+   * with clients and other monitors that do not yet support the 'mons'
+   * map. This map keeps its original behavior, containing a mapping of
+   * monitor id (i.e., 'foo' in 'mon.foo') to the monitor's public
+   * address -- which is obtained from the public address of each entry
+   * in the 'mons' map.
+   */
+  map<string,entity_addr_t> mon_addr;
+  for (map<string,mon_info_t>::const_iterator p = mon_info.begin();
+       p != mon_info.end();
+       ++p) {
+    mon_addr[p->first] = p->second.public_addr;
+  }
+
   if ((con_features & CEPH_FEATURE_MONNAMES) == 0) {
     __u16 v = 1;
     ::encode(v, blist);
@@ -44,7 +80,7 @@ void MonMap::encode(bufferlist& blist, uint64_t con_features) const
     ::encode(created, blist);
   }
 
-  ENCODE_START(4, 3, blist);
+  ENCODE_START(5, 3, blist);
   ::encode_raw(fsid, blist);
   ::encode(epoch, blist);
   ::encode(mon_addr, blist, con_features);
@@ -52,12 +88,15 @@ void MonMap::encode(bufferlist& blist, uint64_t con_features) const
   ::encode(created, blist);
   ::encode(persistent_features, blist);
   ::encode(optional_features, blist);
+  // this superseeds 'mon_addr'
+  ::encode(mon_info, blist, con_features);
   ENCODE_FINISH(blist);
 }
 
 void MonMap::decode(bufferlist::iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN_16(4, 3, 3, p);
+  map<string,entity_addr_t> mon_addr;
+  DECODE_START_LEGACY_COMPAT_LEN_16(5, 3, 3, p);
   ::decode_raw(fsid, p);
   ::decode(epoch, p);
   if (struct_v == 1) {
@@ -79,8 +118,11 @@ void MonMap::decode(bufferlist::iterator &p)
     ::decode(persistent_features, p);
     ::decode(optional_features, p);
   }
-
+  if (struct_v >= 5) {
+    ::decode(mon_info, p);
+  }
   DECODE_FINISH(p);
+  sanitize_mons(mon_addr);
   calc_ranks();
 }
 
@@ -119,8 +161,21 @@ int MonMap::read(const char *fn)
 void MonMap::print_summary(ostream& out) const
 {
   out << "e" << epoch << ": "
-      << mon_addr.size() << " mons at "
-      << mon_addr;
+      << mon_info.size() << " mons at {";
+  // the map that we used to print, as it was, no longer
+  // maps strings to the monitor's public address, but to
+  // mon_info_t instead. As such, print the map in a way
+  // that keeps the expected format.
+  bool has_printed = false;
+  for (map<string,mon_info_t>::const_iterator p = mon_info.begin();
+       p != mon_info.end();
+       ++p) {
+    if (has_printed)
+      out << ",";
+    out << p->first << "=" << p->second.public_addr;
+    has_printed = true;
+  }
+  out << "}";
 }
  
 void MonMap::print(ostream& out) const
@@ -130,10 +185,11 @@ void MonMap::print(ostream& out) const
   out << "last_changed " << last_changed << "\n";
   out << "created " << created << "\n";
   unsigned i = 0;
-  for (map<entity_addr_t,string>::const_iterator p = addr_name.begin();
-       p != addr_name.end();
-       ++p)
-    out << i++ << ": " << p->first << " mon." << p->second << "\n";
+  for (vector<string>::const_iterator p = ranks.begin();
+       p != ranks.end();
+       ++p) {
+    out << i++ << ": " << get_addr(*p) << " mon." << *p << "\n";
+  }
 }
 
 void MonMap::dump(Formatter *f) const
@@ -148,13 +204,14 @@ void MonMap::dump(Formatter *f) const
   f->close_section();
   f->open_array_section("mons");
   int i = 0;
-  for (map<entity_addr_t,string>::const_iterator p = addr_name.begin();
-       p != addr_name.end();
+  for (vector<string>::const_iterator p = ranks.begin();
+       p != ranks.end();
        ++p, ++i) {
     f->open_object_section("mon");
     f->dump_int("rank", i);
-    f->dump_string("name", p->second);
-    f->dump_stream("addr") << p->first;
+    f->dump_string("name", *p);
+    f->dump_stream("addr") << get_addr(*p);
+    f->dump_stream("public_addr") << get_addr(*p);
     f->close_section();
   }
   f->close_section();

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -40,6 +40,95 @@ void mon_info_t::print(ostream& out) const
       << " public " << public_addr;
 }
 
+void MonMap::sanitize_mons(map<string,entity_addr_t>& o)
+{
+  // if mon_info is populated, it means we decoded a map encoded
+  // by someone who understands the new format (i.e., is able to
+  // encode 'mon_info'). This means they must also have provided
+  // a properly populated 'mon_addr' (which we have dropped with
+  // this patch), 'o' being the contents of said map. In this
+  // case, 'o' must have the same number of entries as 'mon_info'.
+  //
+  // Also, for each entry in 'o', there has to be a matching
+  // 'mon_info' entry, properly populated with a name and a matching
+  // 'public_addr'.
+  //
+  // OTOH, if 'mon_info' is not populated, it means the one that
+  // originally encoded the map does not know the new format, and
+  // 'o' will be our only source of info about the monitors in the
+  // cluster -- and we will use it to populate our 'mon_info' map.
+
+  bool has_mon_info = false;
+  if (mon_info.size() > 0) {
+    assert(o.size() == mon_info.size());
+    has_mon_info = true;
+  }
+
+  for (auto p : o) {
+    if (has_mon_info) {
+      // make sure the info we have is accurate
+      assert(mon_info.count(p.first));
+      assert(mon_info[p.first].name == p.first);
+      assert(mon_info[p.first].public_addr == p.second);
+    } else {
+      mon_info_t &m = mon_info[p.first];
+      m.name = p.first;
+      m.public_addr = p.second;
+    }
+  }
+}
+
+namespace {
+  struct rank_cmp {
+    bool operator()(const mon_info_t &a, const mon_info_t &b) const {
+      if (a.public_addr == b.public_addr)
+        return a.name < b.name;
+      return a.public_addr < b.public_addr;
+    }
+  };
+}
+
+void MonMap::calc_ranks() {
+
+  ranks.resize(mon_info.size());
+  addr_mons.clear();
+
+  // Used to order entries according to public_addr, because that's
+  // how the ranks are expected to be ordered by. We may expand this
+  // later on, according to some other criteria, by specifying a
+  // different comparator.
+  //
+  // Please note that we use a 'set' here instead of resorting to
+  // std::sort() because we need more info than that's available in
+  // the vector. The vector will thus be ordered by, e.g., public_addr
+  // while only containing the names of each individual monitor.
+  // The only way of achieving this with std::sort() would be to first
+  // insert every mon_info_t entry into a vector 'foo', std::sort() 'foo'
+  // with custom comparison functions, and then copy each invidual entry
+  // to a new vector. Unless there's a simpler way, we don't think the
+  // added complexity makes up for the additional memory usage of a 'set'.
+  set<mon_info_t, rank_cmp> tmp;
+
+  for (map<string,mon_info_t>::iterator p = mon_info.begin();
+      p != mon_info.end();
+      ++p) {
+    mon_info_t &m = p->second;
+    tmp.insert(m);
+
+    // populate addr_mons
+    assert(addr_mons.count(m.public_addr) == 0);
+    addr_mons[m.public_addr] = m.name;
+  }
+
+  // map the set to the actual ranks etc
+  unsigned i = 0;
+  for (set<mon_info_t>::iterator p = tmp.begin();
+      p != tmp.end();
+      ++p, ++i) {
+    ranks[i] = p->name;
+  }
+}
+
 void MonMap::encode(bufferlist& blist, uint64_t con_features) const
 {
   /* we keep the mon_addr map when encoding to ensure compatibility

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -18,9 +18,9 @@
 
 using ceph::Formatter;
 
-void MonMap::encode(bufferlist& blist, uint64_t features) const
+void MonMap::encode(bufferlist& blist, uint64_t con_features) const
 {
-  if ((features & CEPH_FEATURE_MONNAMES) == 0) {
+  if ((con_features & CEPH_FEATURE_MONNAMES) == 0) {
     __u16 v = 1;
     ::encode(v, blist);
     ::encode_raw(fsid, blist);
@@ -28,34 +28,36 @@ void MonMap::encode(bufferlist& blist, uint64_t features) const
     vector<entity_inst_t> mon_inst(mon_addr.size());
     for (unsigned n = 0; n < mon_addr.size(); n++)
       mon_inst[n] = get_inst(n);
-    ::encode(mon_inst, blist, features);
+    ::encode(mon_inst, blist, con_features);
     ::encode(last_changed, blist);
     ::encode(created, blist);
     return;
   }
 
-  if ((features & CEPH_FEATURE_MONENC) == 0) {
+  if ((con_features & CEPH_FEATURE_MONENC) == 0) {
     __u16 v = 2;
     ::encode(v, blist);
     ::encode_raw(fsid, blist);
     ::encode(epoch, blist);
-    ::encode(mon_addr, blist, features);
+    ::encode(mon_addr, blist, con_features);
     ::encode(last_changed, blist);
     ::encode(created, blist);
   }
 
-  ENCODE_START(3, 3, blist);
+  ENCODE_START(4, 3, blist);
   ::encode_raw(fsid, blist);
   ::encode(epoch, blist);
-  ::encode(mon_addr, blist, features);
+  ::encode(mon_addr, blist, con_features);
   ::encode(last_changed, blist);
   ::encode(created, blist);
+  ::encode(persistent_features, blist);
+  ::encode(optional_features, blist);
   ENCODE_FINISH(blist);
 }
 
 void MonMap::decode(bufferlist::iterator &p)
 {
-  DECODE_START_LEGACY_COMPAT_LEN_16(3, 3, 3, p);
+  DECODE_START_LEGACY_COMPAT_LEN_16(4, 3, 3, p);
   ::decode_raw(fsid, p);
   ::decode(epoch, p);
   if (struct_v == 1) {
@@ -73,6 +75,11 @@ void MonMap::decode(bufferlist::iterator &p)
   }
   ::decode(last_changed, p);
   ::decode(created, p);
+  if (struct_v >= 4) {
+    ::decode(persistent_features, p);
+    ::decode(optional_features, p);
+  }
+
   DECODE_FINISH(p);
   calc_ranks();
 }
@@ -135,6 +142,10 @@ void MonMap::dump(Formatter *f) const
   f->dump_stream("fsid") <<  fsid;
   f->dump_stream("modified") << last_changed;
   f->dump_stream("created") << created;
+  f->open_object_section("features");
+  persistent_features.dump(f, "persistent");
+  optional_features.dump(f, "optional");
+  f->close_section();
   f->open_array_section("mons");
   int i = 0;
   for (map<entity_addr_t,string>::const_iterator p = addr_name.begin();

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -25,18 +25,50 @@ namespace ceph {
   class Formatter;
 }
 
+struct mon_info_t {
+  /**
+   * monitor name
+   *
+   * i.e., 'foo' in 'mon.foo'
+   */
+  string name;
+  /**
+   * monitor's public address
+   *
+   * public facing address, traditionally used to communicate with all clients
+   * and other monitors.
+   */
+  entity_addr_t public_addr;
+
+  mon_info_t(string &n, entity_addr_t& p_addr)
+    : name(n), public_addr(p_addr)
+  { }
+
+  mon_info_t() { }
+
+
+  void encode(bufferlist& bl, uint64_t features) const;
+  void decode(bufferlist::iterator& p);
+  void print(ostream& out) const;
+};
+WRITE_CLASS_ENCODER_FEATURES(mon_info_t)
+
+inline ostream& operator<<(ostream& out, const mon_info_t& mon) {
+  mon.print(out);
+  return out;
+}
 
 class MonMap {
  public:
   epoch_t epoch;       // what epoch/version of the monmap
   uuid_d fsid;
-  map<string, entity_addr_t> mon_addr;
   utime_t last_changed;
   utime_t created;
 
-  map<entity_addr_t,string> addr_name;
-  vector<string> rank_name;
-  vector<entity_addr_t> rank_addr;
+  map<string, mon_info_t> mon_info;
+  map<entity_addr_t, string> addr_mons;
+
+  vector<string> ranks;
 
   /**
    * Persistent Features are all those features that once set on a
@@ -73,22 +105,86 @@ class MonMap {
     return (persistent_features | optional_features);
   }
 
-  void calc_ranks() {
-    rank_name.resize(mon_addr.size());
-    rank_addr.resize(mon_addr.size());
-    addr_name.clear();
-    for (map<string,entity_addr_t>::iterator p = mon_addr.begin();
-	 p != mon_addr.end();
-	 ++p) {
-      assert(addr_name.count(p->second) == 0);
-      addr_name[p->second] = p->first;
+  void sanitize_mons(map<string,entity_addr_t>& o) {
+
+    // if mon_info is populated, it means we decoded a map encoded
+    // by someone who understands the new format (i.e., is able to
+    // encode 'mon_info'). This means they must also have provided
+    // a properly populated 'mon_addr' (which we have dropped with
+    // this patch), 'o' being the contents of said map. In this
+    // case, 'o' must have the same number of entries as 'mon_info'.
+    //
+    // Also, for each entry in 'o', there has to be a matching
+    // 'mon_info' entry, properly populated with a name and a matching
+    // 'public_addr'.
+    //
+    // OTOH, if 'mon_info' is not populated, it means the one that
+    // originally encoded the map does not know the new format, and
+    // 'o' will be our only source of info about the monitors in the
+    // cluster -- and we will use it to populate our 'mon_info' map.
+
+    bool has_mon_info = false;
+    if (mon_info.size() > 0) {
+      assert(o.size() == mon_info.size());
+      has_mon_info = true;
     }
+
+    for (map<string, entity_addr_t>::const_iterator p = o.begin();
+         p != o.end();
+         ++p) {
+
+      // make sure the info we have is accurate
+      if (has_mon_info) {
+        assert(mon_info.count(p->first));
+        assert(mon_info[p->first].name == p->first);
+        assert(mon_info[p->first].public_addr == p->second);
+        continue;
+      }
+
+      mon_info_t &m = mon_info[p->first];
+      m.name = p->first;
+      m.public_addr = p->second;    
+    }
+  }
+
+  void calc_ranks() {
+
+    ranks.resize(mon_info.size());
+    addr_mons.clear();
+
+    // Used to order entries according to public_addr, because that's
+    // how the ranks are expected to be ordered by. We may expand this
+    // later on, according to some other criteria, by specifying a
+    // different comparator.
+    //
+    // Please note that we use a 'set' here instead of resorting to
+    // std::sort() because we need more info than that's available in
+    // the vector. The vector will thus be ordered by, e.g., public_addr
+    // while only containing the names of each individual monitor.
+    // The only way of achieving this with std::sort() would be to first
+    // insert every mon_info_t entry into a vector 'foo', std::sort() 'foo'
+    // with custom comparison functions, and then copy each invidual entry
+    // to a new vector. Unless there's a simpler way, we don't think the
+    // added complexity makes up for the additional memory usage of a 'set'.
+    set<mon_info_t, rank_cmp> tmp;
+
+    for (map<string,mon_info_t>::iterator p = mon_info.begin();
+         p != mon_info.end();
+         ++p) {
+      mon_info_t &m = p->second;
+      tmp.insert(m);
+
+      // populate addr_mons
+      assert(addr_mons.count(m.public_addr) == 0);
+      addr_mons[m.public_addr] = m.name;
+    }
+
+    // map the set to the actual ranks etc
     unsigned i = 0;
-    for (map<entity_addr_t,string>::iterator p = addr_name.begin();
-	 p != addr_name.end();
-	 ++p, i++) {
-      rank_name[i] = p->second;
-      rank_addr[i] = p->first;
+    for (set<mon_info_t>::iterator p = tmp.begin();
+         p != tmp.end();
+         ++p, ++i) {
+      ranks[i] = p->name;
     }
   }
 
@@ -99,112 +195,150 @@ class MonMap {
 
   uuid_d& get_fsid() { return fsid; }
 
-  unsigned size() {
-    return mon_addr.size();
+  unsigned size() const {
+    return mon_info.size();
   }
 
-  epoch_t get_epoch() { return epoch; }
+  epoch_t get_epoch() const { return epoch; }
   void set_epoch(epoch_t e) { epoch = e; }
 
+  /**
+   * Obtain list of public facing addresses
+   *
+   * @param ls list to populate with the monitors' addresses
+   */
   void list_addrs(list<entity_addr_t>& ls) const {
-    for (map<string,entity_addr_t>::const_iterator p = mon_addr.begin();
-	 p != mon_addr.end();
-	 ++p)
-      ls.push_back(p->second);
+    for (map<string,mon_info_t>::const_iterator p = mon_info.begin();
+         p != mon_info.end();
+         ++p) {
+      ls.push_back(p->second.public_addr);
+    }
   }
 
+  /**
+   * Add new monitor to the monmap
+   *
+   * @param name Monitor name (i.e., 'foo' in 'mon.foo')
+   * @param addr Monitor's public address
+   */
   void add(const string &name, const entity_addr_t &addr) {
-    assert(mon_addr.count(name) == 0);
-    assert(addr_name.count(addr) == 0);
-    mon_addr[name] = addr;
+    assert(mon_info.count(name) == 0);
+    assert(addr_mons.count(addr) == 0);
+    mon_info_t &m = mon_info[name];
+    m.name = name;
+    m.public_addr = addr;
     calc_ranks();
   }
-
+ 
+  /**
+   * Remove monitor from the monmap
+   *
+   * @param name Monitor name (i.e., 'foo' in 'mon.foo')
+   */
   void remove(const string &name) {
-    assert(mon_addr.count(name));
-    mon_addr.erase(name);
+    assert(mon_info.count(name));
+    mon_info.erase(name);
+    assert(mon_info.count(name) == 0);
     calc_ranks();
   }
 
+  /**
+   * Rename monitor from @p oldname to @p newname
+   *
+   * @param oldname monitor's current name (i.e., 'foo' in 'mon.foo')
+   * @param newname monitor's new name (i.e., 'bar' in 'mon.bar')
+   */
   void rename(string oldname, string newname) {
     assert(contains(oldname));
     assert(!contains(newname));
-    mon_addr[newname] = mon_addr[oldname];
-    mon_addr.erase(oldname);
+    mon_info[newname] = mon_info[oldname];
+    mon_info.erase(oldname);
+    mon_info[newname].name = newname;
     calc_ranks();
   }
 
-  bool contains(const string& name) {
-    return mon_addr.count(name);
+  bool contains(const string& name) const {
+    return mon_info.count(name);
   }
 
-  bool contains(const entity_addr_t &a) {
-    for (map<string,entity_addr_t>::iterator p = mon_addr.begin();
-	 p != mon_addr.end();
-	 ++p) {
-      if (p->second == a)
-	return true;
+  /**
+   * Check if monmap contains a monitor with address @p a
+   *
+   * @note checks for all addresses a monitor may have, public or otherwise.
+   *
+   * @param a monitor address
+   * @returns true if monmap contains a monitor with address @p;
+   *          false otherwise.
+   */
+  bool contains(const entity_addr_t &a) const {
+    for (map<string,mon_info_t>::const_iterator p = mon_info.begin();
+         p != mon_info.end();
+         ++p) {
+      if (p->second.public_addr == a)
+        return true;
     }
     return false;
   }
 
   string get_name(unsigned n) const {
-    assert(n < rank_name.size());
-    return rank_name[n];
+    assert(n < ranks.size());
+    return ranks[n];
   }
   string get_name(const entity_addr_t& a) const {
-    map<entity_addr_t,string>::const_iterator p = addr_name.find(a);
-    if (p == addr_name.end())
+    map<entity_addr_t,string>::const_iterator p = addr_mons.find(a);
+    if (p == addr_mons.end())
       return string();
     else
       return p->second;
   }
 
   int get_rank(const string& n) {
-    for (unsigned i=0; i<rank_name.size(); i++)
-      if (rank_name[i] == n)
+    for (unsigned i = 0; i < ranks.size(); i++)
+      if (ranks[i] == n)
 	return i;
     return -1;
   }
   int get_rank(const entity_addr_t& a) {
-    for (unsigned i=0; i<rank_addr.size(); i++)
-      if (rank_addr[i] == a)
+    string n = get_name(a);
+    if (n.empty())
+      return -1;
+
+    for (unsigned i = 0; i < ranks.size(); i++)
+      if (ranks[i] == n)
 	return i;
     return -1;
   }
   bool get_addr_name(const entity_addr_t& a, string& name) {
-    if (addr_name.count(a) == 0)
+    if (addr_mons.count(a) == 0)
       return false;
-    name = addr_name[a];
+    name = addr_mons[a];
     return true;
   }
 
-  const entity_addr_t& get_addr(const string& n) {
-    assert(mon_addr.count(n));
-    return mon_addr[n];
+  const entity_addr_t& get_addr(const string& n) const {
+    assert(mon_info.count(n));
+    map<string,mon_info_t>::const_iterator p = mon_info.find(n);
+    return p->second.public_addr;
   }
-  const entity_addr_t& get_addr(unsigned m) {
-    assert(m < rank_addr.size());
-    return rank_addr[m];
+  const entity_addr_t& get_addr(unsigned m) const {
+    assert(m < ranks.size());
+    return get_addr(ranks[m]);
   }
   void set_addr(const string& n, const entity_addr_t& a) {
-    assert(mon_addr.count(n));
-    mon_addr[n] = a;
+    assert(mon_info.count(n));
+    mon_info[n].public_addr = a;
     calc_ranks();
   }
   entity_inst_t get_inst(const string& n) {
-    assert(mon_addr.count(n));
+    assert(mon_info.count(n));
     int m = get_rank(n);
     assert(m >= 0); // vector can't take negative indicies
-    entity_inst_t i;
-    i.addr = rank_addr[m];
-    i.name = entity_name_t::MON(m);
-    return i;
+    return get_inst(m);
   }
   entity_inst_t get_inst(unsigned m) const {
-    assert(m < rank_addr.size());
+    assert(m < ranks.size());
     entity_inst_t i;
-    i.addr = rank_addr[m];
+    i.addr = get_addr(m);
     i.name = entity_name_t::MON(m);
     return i;
   }
@@ -273,6 +407,15 @@ class MonMap {
   void dump(ceph::Formatter *f) const;
 
   static void generate_test_instances(list<MonMap*>& o);
+
+private:
+  struct rank_cmp {
+    bool operator()(const mon_info_t &a, const mon_info_t &b) const {
+      if (a.public_addr == b.public_addr)
+        return a.name < b.name;
+      return a.public_addr < b.public_addr;
+    }
+  };
 };
 WRITE_CLASS_ENCODER_FEATURES(MonMap)
 

--- a/src/mon/MonMap.h
+++ b/src/mon/MonMap.h
@@ -19,10 +19,12 @@
 
 #include "msg/Message.h"
 #include "include/types.h"
+#include "mon/mon_types.h"
 
 namespace ceph {
   class Formatter;
 }
+
 
 class MonMap {
  public:
@@ -35,6 +37,41 @@ class MonMap {
   map<entity_addr_t,string> addr_name;
   vector<string> rank_name;
   vector<entity_addr_t> rank_addr;
+
+  /**
+   * Persistent Features are all those features that once set on a
+   * monmap cannot, and should not, be removed. These will define the
+   * non-negotiable features that a given monitor must support to
+   * properly operate in a given quorum.
+   *
+   * Should be reserved for features that we really want to make sure
+   * are sticky, and are important enough to tolerate not being able
+   * to downgrade a monitor.
+   */
+  mon_feature_t persistent_features;
+  /**
+   * Optional Features are all those features that can be enabled or
+   * disabled following a given criteria -- e.g., user-mandated via the
+   * cli --, and act much like indicators of what the cluster currently
+   * supports.
+   *
+   * They are by no means "optional" in the sense that monitors can
+   * ignore them. Just that they are not persistent.
+   */
+  mon_feature_t optional_features;
+
+  /**
+   * Returns the set of features required by this monmap.
+   *
+   * The features required by this monmap is the union of all the
+   * currently set persistent features and the currently set optional
+   * features.
+   *
+   * @returns the set of features required by this monmap
+   */
+  mon_feature_t get_required_features() const {
+    return (persistent_features | optional_features);
+  }
 
   void calc_ranks() {
     rank_name.resize(mon_addr.size());
@@ -55,7 +92,7 @@ class MonMap {
     }
   }
 
-  MonMap() 
+  MonMap()
     : epoch(0) {
     memset(&fsid, 0, sizeof(fsid));
   }
@@ -82,7 +119,7 @@ class MonMap {
     mon_addr[name] = addr;
     calc_ranks();
   }
-  
+
   void remove(const string &name) {
     assert(mon_addr.count(name));
     mon_addr.erase(name);
@@ -172,7 +209,7 @@ class MonMap {
     return i;
   }
 
-  void encode(bufferlist& blist, uint64_t features) const;
+  void encode(bufferlist& blist, uint64_t con_features) const;
   void decode(bufferlist& blist) {
     bufferlist::iterator p = blist.begin();
     decode(p);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1603,8 +1603,8 @@ void Monitor::handle_probe(MonOpRequestRef op)
 
   case MMonProbe::OP_MISSING_FEATURES:
     derr << __func__ << " missing features, have " << CEPH_FEATURES_ALL
-	 << ", required " << required_features
-	 << ", missing " << (required_features & ~CEPH_FEATURES_ALL)
+	 << ", required " << m->required_features
+	 << ", missing " << (m->required_features & ~CEPH_FEATURES_ALL)
 	 << dendl;
     break;
   }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1610,9 +1610,6 @@ void Monitor::handle_probe(MonOpRequestRef op)
   }
 }
 
-/**
- * @todo fix this. This is going to cause trouble.
- */
 void Monitor::handle_probe_probe(MonOpRequestRef op)
 {
   MMonProbe *m = static_cast<MMonProbe*>(op->get_req());

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2109,6 +2109,14 @@ void Monitor::get_mon_status(Formatter *f, ostream& ss)
 
   f->close_section(); // quorum
 
+  f->open_object_section("features");
+  f->dump_stream("required_con") << required_features;
+  mon_feature_t req_mon_features = get_required_mon_features();
+  req_mon_features.dump(f, "required_mon");
+  f->dump_stream("quorum_con") << quorum_con_features;
+  quorum_mon_features.dump(f, "quorum_mon");
+  f->close_section(); // features
+
   f->open_array_section("outside_quorum");
   for (set<string>::iterator p = outside_quorum.begin(); p != outside_quorum.end(); ++p)
     f->dump_string("mon", *p);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -596,6 +596,9 @@ public:
   uint64_t get_required_features() const {
     return required_features;
   }
+  mon_feature_t get_required_mon_features() const {
+    return monmap->get_required_features();
+  }
   void apply_quorum_to_compatset_features();
   void apply_compatset_features_to_quorum_requirements();
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -216,6 +216,10 @@ private:
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
   uint64_t quorum_features;  ///< intersection of quorum member feature bits
+  /**
+   * Intersection of quorum members mon-specific feature bits
+   */
+  mon_feature_t quorum_mon_features;
   bufferlist supported_commands_bl; // encoded MonCommands we support
   bufferlist classic_commands_bl; // encoded MonCommands supported by Dumpling
   set<int> classic_mons; // set of "classic" monitors; only valid on leader
@@ -601,10 +605,13 @@ public:
   // end election (called by Elector)
   void win_election(epoch_t epoch, set<int>& q,
 		    uint64_t features,
+                    const mon_feature_t& mon_features,
 		    const MonCommand *cmdset, int cmdsize,
 		    const set<int> *classic_monitors);
   void lose_election(epoch_t epoch, set<int>& q, int l,
-		     uint64_t features); // end election (called by Elector)
+		     uint64_t features,
+                     const mon_feature_t& mon_features);
+  // end election (called by Elector)
   void finish_election();
 
   const bufferlist& get_supported_commands_bl() {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -577,6 +577,8 @@ private:
   void cancel_probe_timeout();
   void probe_timeout(int r);
 
+  void _apply_compatset_features(CompatSet &new_features);
+
 public:
   epoch_t get_epoch();
   int get_leader() { return leader; }
@@ -600,6 +602,7 @@ public:
     return monmap->get_required_features();
   }
   void apply_quorum_to_compatset_features();
+  void apply_monmap_to_compatset_features();
   void apply_compatset_features_to_quorum_requirements();
 
 private:
@@ -992,6 +995,7 @@ public:
 #define CEPH_MON_FEATURE_INCOMPAT_OSDMAP_ENC CompatSet::Feature(5, "new-style osdmap encoding")
 #define CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V2 CompatSet::Feature(6, "support isa/lrc erasure code")
 #define CEPH_MON_FEATURE_INCOMPAT_ERASURE_CODE_PLUGINS_V3 CompatSet::Feature(7, "support shec erasure code")
+#define CEPH_MON_FEATURE_INCOMPAT_KRAKEN CompatSet::Feature(8, "support monmap features")
 // make sure you add your feature to Monitor::get_supported_features
 
 long parse_pos_long(const char *s, ostream *pss = NULL);

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -592,6 +592,7 @@ public:
 private:
   void _reset();   ///< called from bootstrap, start_, or join_election
   void wait_for_paxos_write();
+  void _finish_svc_election(); ///< called by {win,lose}_election
 public:
   void bootstrap();
   void join_election();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -590,6 +590,9 @@ public:
   uint64_t get_quorum_con_features() const {
     return quorum_con_features;
   }
+  mon_feature_t get_quorum_mon_features() const {
+    return quorum_mon_features;
+  }
   uint64_t get_required_features() const {
     return required_features;
   }

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -215,7 +215,10 @@ private:
   set<int> quorum;       // current active set of monitors (if !starting)
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
-  uint64_t quorum_features;  ///< intersection of quorum member feature bits
+  /**
+   * Intersection of quorum member's connection feature bits.
+   */
+  uint64_t quorum_con_features;
   /**
    * Intersection of quorum members mon-specific feature bits
    */
@@ -584,8 +587,8 @@ public:
       q.push_back(monmap->get_name(*p));
     return q;
   }
-  uint64_t get_quorum_features() const {
-    return quorum_features;
+  uint64_t get_quorum_con_features() const {
+    return quorum_con_features;
   }
   uint64_t get_required_features() const {
     return required_features;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -89,7 +89,7 @@ void MonmapMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   assert(mon->monmap->epoch + 1 == pending_map.epoch ||
 	 pending_map.epoch == 1);  // special case mkfs!
   bufferlist bl;
-  pending_map.encode(bl, mon->get_quorum_features());
+  pending_map.encode(bl, mon->get_quorum_con_features());
 
   put_version(t, pending_map.epoch, bl);
   put_last_committed(t, pending_map.epoch);

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -100,6 +100,55 @@ void MonmapMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   }
 }
 
+class C_ApplyFeatures : public Context {
+  MonmapMonitor *svc;
+  mon_feature_t features;
+  public:
+  C_ApplyFeatures(MonmapMonitor *s, const mon_feature_t& f) :
+    svc(s), features(f) { }
+  void finish(int r) {
+    if (r >= 0) {
+      svc->apply_mon_features(features);
+    } else if (r == -EAGAIN || r == -ECANCELED) {
+      // discard features if we're no longer on the quorum that
+      // established them in the first place.
+      return;
+    } else {
+      assert(0 == "bad C_ApplyFeatures return value");
+    }
+  }
+};
+
+void MonmapMonitor::apply_mon_features(const mon_feature_t& features)
+{
+  if (!is_writeable()) {
+    dout(5) << __func__ << " wait for service to be writeable" << dendl;
+    wait_for_writeable_ctx(new C_ApplyFeatures(this, features));
+    return;
+  }
+
+  assert(is_writeable());
+  assert(features.contains_all(pending_map.persistent_features));
+
+  mon_feature_t new_features =
+    (pending_map.persistent_features ^
+     (features & ceph::features::mon::get_persistent()));
+
+  if (new_features.empty()) {
+    dout(10) << __func__ << " features match current pending: "
+             << features << dendl;
+    return;
+  }
+
+  new_features |= pending_map.persistent_features;
+
+  dout(5) << __func__ << " applying new features to monmap;"
+          << " had " << pending_map.persistent_features
+          << ", will have " << new_features << dendl;
+  pending_map.persistent_features = new_features;
+  propose_pending();
+}
+
 void MonmapMonitor::on_active()
 {
   if (get_last_committed() >= 1 && !mon->has_ever_joined) {
@@ -120,6 +169,8 @@ void MonmapMonitor::on_active()
 
   if (mon->is_leader())
     mon->clog->info() << "monmap " << *mon->monmap << "\n";
+
+  apply_mon_features(mon->get_quorum_mon_features());
 }
 
 bool MonmapMonitor::preprocess_query(MonOpRequestRef op)

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -55,6 +55,7 @@ class MonmapMonitor : public PaxosService {
   virtual void encode_full(MonitorDBStore::TransactionRef t) { }
 
   void on_active();
+  void apply_mon_features(const mon_feature_t& features);
 
   void dump_info(Formatter *f);
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -132,7 +132,8 @@ void OSDMonitor::create_initial()
   newmap.set_flag(CEPH_OSDMAP_REQUIRE_KRAKEN);
 
   // encode into pending incremental
-  newmap.encode(pending_inc.fullmap, mon->quorum_features | CEPH_FEATURE_RESERVED);
+  newmap.encode(pending_inc.fullmap,
+                mon->get_quorum_con_features() | CEPH_FEATURE_RESERVED);
   pending_inc.full_crc = newmap.get_crc();
   dout(20) << " full crc " << pending_inc.full_crc << dendl;
 }
@@ -238,7 +239,7 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
     // encode with all features.
     uint64_t f = inc.encode_features;
     if (!f)
-      f = mon->quorum_features;
+      f = mon->get_quorum_con_features();
     if (!f)
       f = -1;
     bufferlist full_bl;
@@ -1223,7 +1224,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   }
 
   // features for osdmap and its incremental
-  uint64_t features = mon->quorum_features;
+  uint64_t features = mon->get_quorum_con_features();
 
   // encode full map and determine its crc
   OSDMap tmp;
@@ -4624,7 +4625,7 @@ int OSDMonitor::check_cluster_features(uint64_t features,
 {
   stringstream unsupported_ss;
   int unsupported_count = 0;
-  if ((mon->get_quorum_features() & features) != features) {
+  if ((mon->get_quorum_con_features() & features) != features) {
     unsupported_ss << "the monitor cluster";
     ++unsupported_count;
   }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -479,7 +479,7 @@ void PGMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   assert(get_last_committed() + 1 == version);
   pending_inc.stamp = ceph_clock_now(g_ceph_context);
 
-  uint64_t features = mon->get_quorum_features();
+  uint64_t features = mon->get_quorum_con_features();
 
   string prefix = pgmap_meta_prefix;
 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -18,6 +18,7 @@
 #include "include/utime.h"
 #include "include/util.h"
 #include "common/Formatter.h"
+#include "common/bit_str.h"
 #include "include/Context.h"
 #include "mon/MonOpRequest.h"
 
@@ -235,5 +236,228 @@ struct C_MonOp : public Context
 
   virtual void _finish(int r) = 0;
 };
+
+namespace ceph {
+  namespace features {
+    namespace mon {
+      /**
+       * Get a feature's name based on its value.
+       *
+       * @param b raw feature value
+       *
+       * @remarks
+       *    Consumers should not assume this interface will never change.
+       * @remarks
+       *    As the number of features increase, so may the internal representation
+       *    of the raw features. When this happens, this interface will change
+       *    accordingly. So should consumers of this interface.
+       */
+      static inline const char *get_feature_name(uint64_t b);
+    }
+  }
+}
+
+
+inline const char *ceph_mon_feature_name(uint64_t b)
+{
+  return ceph::features::mon::get_feature_name(b);
+};
+
+class mon_feature_t {
+
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  // mon-specific features
+  uint64_t features;
+
+public:
+
+  explicit constexpr
+  mon_feature_t(const uint64_t f) : features(f) { }
+
+  mon_feature_t() :
+    features(0) { }
+
+  constexpr
+  mon_feature_t(const mon_feature_t &o) :
+    features(o.features) { }
+
+  mon_feature_t& operator&=(const mon_feature_t other) {
+    features &= other.features;
+    return (*this);
+  }
+
+  constexpr
+  friend mon_feature_t operator&(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features & b.features);
+  }
+
+  mon_feature_t& operator|=(const mon_feature_t other) {
+    features |= other.features;
+    return (*this);
+  }
+
+  constexpr
+  friend mon_feature_t operator|(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features | b.features);
+  }
+
+  constexpr
+  friend mon_feature_t operator^(const mon_feature_t a,
+                                 const mon_feature_t b) {
+    return mon_feature_t(a.features ^ b.features);
+  }
+
+  mon_feature_t& operator^=(const mon_feature_t other) {
+    features ^= other.features;
+    return (*this);
+  }
+
+  bool operator==(const mon_feature_t other) const {
+    return (features == other.features);
+  }
+
+  bool operator!=(const mon_feature_t other) const {
+    return (features != other.features);
+  }
+
+  bool empty() const {
+    return features == 0;
+  }
+
+  /**
+   * Set difference of our features in respect to @p other
+   *
+   * Returns all the elements in our features that are not in @p other
+   *
+   * @returns all the features not in @p other
+   */
+  mon_feature_t diff(const mon_feature_t other) const {
+    return mon_feature_t((features ^ other.features) & features);
+  }
+
+  /**
+   * Set intersection of our features and @p other
+   *
+   * Returns all the elements common to both our features and the
+   * features of @p other
+   *
+   * @returns the features common to @p other and us
+   */
+  mon_feature_t intersection(const mon_feature_t other) const {
+    return mon_feature_t((features & other.features));
+  }
+
+  /**
+   * Checks whether we have all the features in @p other
+   *
+   * Returns true if we have all the features in @p other
+   *
+   * @returns true if we contain all the features in @p other
+   * @returns false if we do not contain some of the features in @p other
+   */
+  bool contains_all(const mon_feature_t other) const {
+    mon_feature_t d = intersection(other);
+    return d == other;
+  }
+
+  /**
+   * Checks whether we contain any of the features in @p other.
+   *
+   * @returns true if we contain any of the features in @p other
+   * @returns false if we don't contain any of the features in @p other
+   */
+  bool contains_any(const mon_feature_t other) const {
+    mon_feature_t d = intersection(other);
+    return !d.empty();
+  }
+
+  void set_feature(const mon_feature_t f) {
+    features |= f.features;
+  }
+
+  void print(ostream& out) const {
+    out << "[";
+    print_bit_str(features, out, ceph::features::mon::get_feature_name);
+    out << "]";
+  }
+
+  void dump(Formatter *f, const char *sec_name = NULL) const {
+    f->open_array_section((sec_name ? sec_name : "features"));
+    dump_bit_str(features, f, ceph::features::mon::get_feature_name);
+    f->close_section();
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(HEAD_VERSION, COMPAT_VERSION, bl);
+    ::encode(features, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& p) {
+    DECODE_START(COMPAT_VERSION, p);
+    ::decode(features, p);
+    DECODE_FINISH(p);
+  }
+};
+WRITE_CLASS_ENCODER(mon_feature_t)
+
+namespace ceph {
+  namespace features {
+    namespace mon {
+      constexpr mon_feature_t FEATURE_KRAKEN(      (1ULL << 0));
+      constexpr mon_feature_t FEATURE_RESERVED(   (1ULL << 63));
+      constexpr mon_feature_t FEATURE_NONE(       (0ULL));
+
+      /**
+       * All the features this monitor supports
+       *
+       * If there's a feature above, it should be OR'ed to this list.
+       */
+      constexpr mon_feature_t get_supported() {
+        return (
+            FEATURE_KRAKEN |
+            FEATURE_NONE
+            );
+      }
+      /**
+       * All the features that, once set, cannot be removed.
+       *
+       * Features should only be added to this list if you want to make
+       * sure downgrades are not possible after a quorum supporting all
+       * these features has been formed.
+       *
+       * Any feature in this list will be automatically set on the monmap's
+       * features once all the monitors in the quorum support it.
+       */
+      constexpr mon_feature_t get_persistent() {
+        return (
+            FEATURE_KRAKEN |
+            FEATURE_NONE
+            );
+      }
+    }
+  }
+}
+
+static inline const char *ceph::features::mon::get_feature_name(uint64_t b) {
+  mon_feature_t f(b);
+
+  if (f == FEATURE_KRAKEN) {
+    return "kraken";
+  } else if (f == FEATURE_RESERVED) {
+    return "reserved";
+  }
+  return "unknown";
+}
+
+static inline ostream& operator<<(ostream& out, const mon_feature_t& f) {
+  out << "mon_feature_t(";
+  f.print(out);
+  out << ")";
+  return out;
+}
 
 #endif

--- a/src/test/cli/monmaptool/add-exists.t
+++ b/src/test/cli/monmaptool/add-exists.t
@@ -11,7 +11,12 @@
   $ monmaptool --add foo 3.4.5.6:7890 mymonmap
   monmaptool: monmap file mymonmap
   monmaptool: map already contains mon.foo
-   usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
+   usage: [--print] [--create [--clobber][--fsid uuid]]
+          [--generate] [--set-initial-members]
+          [--add name 1.2.3.4:567] [--rm name]
+          [--feature-list [plain|parseable]]
+          [--feature-set <value> [--optional|--persistent]]
+          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
   [1]
 
   $ monmaptool --print mymonmap

--- a/src/test/cli/monmaptool/feature-set-unset-list.t
+++ b/src/test/cli/monmaptool/feature-set-unset-list.t
@@ -1,0 +1,91 @@
+  $ monmaptool --create --add a 10.10.10.10:1234 /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  monmaptool: generated fsid [0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12} (re)
+  monmaptool: writing epoch 0 to /tmp/test.monmap.1234 (1 monitors)
+
+  $ monmaptool --feature-list --feature-list plain --feature-list parseable /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  MONMAP FEATURES:
+      persistent: [none]
+      optional:   [none]
+      required:   [none]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+  MONMAP FEATURES:
+      persistent: [none]
+      optional:   [none]
+      required:   [none]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+  monmap:persistent:[none]
+  monmap:optional:[none]
+  monmap:required:[none]
+  available:supported:[kraken(1)]
+  available:persistent:[kraken(1)]
+
+  $ monmaptool --feature-set foo /tmp/test.monmap.1234
+  unknown features name 'foo' or unable to parse value: Expected option value to be integer, got 'foo'
+   usage: [--print] [--create [--clobber][--fsid uuid]]
+          [--generate] [--set-initial-members]
+          [--add name 1.2.3.4:567] [--rm name]
+          [--feature-list [plain|parseable]]
+          [--feature-set <value> [--optional|--persistent]]
+          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
+  [1]
+
+  $ monmaptool --feature-set kraken --feature-set 16 --optional --feature-set 32 --persistent /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  monmaptool: writing epoch 0 to /tmp/test.monmap.1234 (1 monitors)
+
+  $ monmaptool --feature-list /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  MONMAP FEATURES:
+      persistent: [kraken(1),unknown(32)]
+      optional:   [unknown(16)]
+      required:   [kraken(1),unknown(16),unknown(32)]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+
+  $ monmaptool --feature-unset 32 --optional --feature-list /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  MONMAP FEATURES:
+      persistent: [kraken(1),unknown(32)]
+      optional:   [unknown(16)]
+      required:   [kraken(1),unknown(16),unknown(32)]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+  monmaptool: writing epoch 0 to /tmp/test.monmap.1234 (1 monitors)
+
+  $ monmaptool --feature-unset 32 --persistent --feature-unset 16 --optional --feature-list /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  MONMAP FEATURES:
+      persistent: [kraken(1)]
+      optional:   [none]
+      required:   [kraken(1)]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+  monmaptool: writing epoch 0 to /tmp/test.monmap.1234 (1 monitors)
+
+  $ monmaptool --feature-unset kraken --feature-list /tmp/test.monmap.1234
+  monmaptool: monmap file /tmp/test.monmap.1234
+  MONMAP FEATURES:
+      persistent: [none]
+      optional:   [none]
+      required:   [none]
+  
+  AVAILABLE FEATURES:
+      supported:  [kraken(1)]
+      persistent: [kraken(1)]
+  monmaptool: writing epoch 0 to /tmp/test.monmap.1234 (1 monitors)
+
+  $ rm /tmp/test.monmap.1234

--- a/src/test/cli/monmaptool/help.t
+++ b/src/test/cli/monmaptool/help.t
@@ -1,3 +1,8 @@
   $ monmaptool --help
-   usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
+   usage: [--print] [--create [--clobber][--fsid uuid]]
+          [--generate] [--set-initial-members]
+          [--add name 1.2.3.4:567] [--rm name]
+          [--feature-list [plain|parseable]]
+          [--feature-set <value> [--optional|--persistent]]
+          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
   [1]

--- a/src/test/cli/monmaptool/rm-nonexistent.t
+++ b/src/test/cli/monmaptool/rm-nonexistent.t
@@ -9,7 +9,12 @@
   monmaptool: monmap file mymonmap
   monmaptool: removing doesnotexist
   monmaptool: map does not contain doesnotexist
-   usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
+   usage: [--print] [--create [--clobber][--fsid uuid]]
+          [--generate] [--set-initial-members]
+          [--add name 1.2.3.4:567] [--rm name]
+          [--feature-list [plain|parseable]]
+          [--feature-set <value> [--optional|--persistent]]
+          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
   [1]
 
   $ monmaptool --print mymonmap

--- a/src/test/cli/monmaptool/simple.t
+++ b/src/test/cli/monmaptool/simple.t
@@ -1,4 +1,9 @@
   $ monmaptool
   monmaptool: must specify monmap filename
-   usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>
+   usage: [--print] [--create [--clobber][--fsid uuid]]
+          [--generate] [--set-initial-members]
+          [--add name 1.2.3.4:567] [--rm name]
+          [--feature-list [plain|parseable]]
+          [--feature-set <value> [--optional|--persistent]]
+          [--feature-unset <value> [--optional|--persistent]] <mapfilename>
   [1]

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -46,3 +46,9 @@ add_executable(unittest_mon_pgmap
 add_ceph_unittest(unittest_mon_pgmap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mon_pgmap)
 target_link_libraries(unittest_mon_pgmap mon global)
 
+# unittest_mon_montypes
+add_executable(unittest_mon_montypes
+  test_mon_types.cc
+  )
+add_ceph_unittest(unittest_mon_montypes ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mon_montypes)
+target_link_libraries(unittest_mon_montypes mon global)

--- a/src/test/mon/test_mon_types.cc
+++ b/src/test/mon/test_mon_types.cc
@@ -112,3 +112,30 @@ TEST(mon_features, set_funcs) {
   ASSERT_EQ(foo.intersection(FEATURE_ALL), foo);
   ASSERT_EQ(bar.intersection(FEATURE_ALL), bar);
 }
+
+TEST(mon_features, set_unset) {
+
+  mon_feature_t FEATURE_A((1ULL << 1));
+  mon_feature_t FEATURE_B((1ULL << 2));
+  mon_feature_t FEATURE_C((1ULL << 3));
+
+  mon_feature_t foo;
+  ASSERT_EQ(ceph::features::mon::FEATURE_NONE, foo);
+
+  foo.set_feature(FEATURE_A);
+  ASSERT_EQ(FEATURE_A, foo);
+  ASSERT_TRUE(foo.contains_all(FEATURE_A));
+
+  foo.set_feature(FEATURE_B|FEATURE_C);
+  ASSERT_EQ((FEATURE_A|FEATURE_B|FEATURE_C), foo);
+  ASSERT_TRUE(foo.contains_all((FEATURE_A|FEATURE_B|FEATURE_C)));
+
+  foo.unset_feature(FEATURE_A);
+  ASSERT_EQ((FEATURE_B|FEATURE_C), foo);
+  ASSERT_FALSE(foo.contains_any(FEATURE_A));
+  ASSERT_TRUE(foo.contains_all((FEATURE_B|FEATURE_C)));
+
+  foo.unset_feature(FEATURE_B|FEATURE_C);
+  ASSERT_EQ(ceph::features::mon::FEATURE_NONE, foo);
+  ASSERT_FALSE(foo.contains_any(FEATURE_A|FEATURE_B|FEATURE_C));
+}

--- a/src/test/mon/test_mon_types.cc
+++ b/src/test/mon/test_mon_types.cc
@@ -1,0 +1,114 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 Inktank
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+#include <iostream>
+#include "mon/mon_types.h"
+
+#include "gtest/gtest.h"
+
+TEST(mon_features, supported_v_persistent) {
+
+  mon_feature_t supported = ceph::features::mon::get_supported();
+  mon_feature_t persistent = ceph::features::mon::get_persistent();
+
+  ASSERT_EQ(supported.intersection(persistent), persistent);
+  ASSERT_TRUE(supported.contains_all(persistent));
+
+  mon_feature_t diff = supported.diff(persistent);
+  ASSERT_TRUE((persistent | diff) == supported);
+  ASSERT_TRUE((supported & persistent) == persistent);
+}
+
+TEST(mon_features, binary_ops) {
+
+  mon_feature_t FEATURE_NONE(0ULL);
+  mon_feature_t FEATURE_A((1ULL << 1));
+  mon_feature_t FEATURE_B((1ULL << 2));
+  mon_feature_t FEATURE_C((1ULL << 3));
+  mon_feature_t FEATURE_D((1ULL << 4));
+
+  mon_feature_t FEATURE_ALL(
+      FEATURE_A | FEATURE_B |
+      FEATURE_C | FEATURE_D
+  );
+
+  mon_feature_t foo(FEATURE_A|FEATURE_B);
+  mon_feature_t bar(FEATURE_C|FEATURE_D);
+
+  ASSERT_EQ(FEATURE_A|FEATURE_B, foo);
+  ASSERT_EQ(FEATURE_C|FEATURE_D, bar);
+
+  ASSERT_NE(FEATURE_C, foo);
+  ASSERT_NE(FEATURE_B, bar);
+  ASSERT_NE(FEATURE_NONE, foo);
+  ASSERT_NE(FEATURE_NONE, bar);
+
+  ASSERT_FALSE(foo.empty());
+  ASSERT_FALSE(bar.empty());
+  ASSERT_TRUE(FEATURE_NONE.empty());
+
+  ASSERT_EQ(FEATURE_ALL, (foo ^ bar));
+  ASSERT_EQ(FEATURE_NONE, (foo & bar));
+
+  mon_feature_t baz = foo;
+  ASSERT_EQ(baz, foo);
+
+  baz |= bar;
+  ASSERT_EQ(FEATURE_ALL, baz);
+  baz ^= foo;
+  ASSERT_EQ(baz, bar);
+
+  baz |= FEATURE_A;
+  ASSERT_EQ(FEATURE_C, baz & FEATURE_C);
+  ASSERT_EQ((FEATURE_A|FEATURE_D), baz & (FEATURE_A|FEATURE_D));
+  ASSERT_EQ(FEATURE_B|FEATURE_C|FEATURE_D, (baz ^ foo));
+}
+
+TEST(mon_features, set_funcs) {
+
+  mon_feature_t FEATURE_NONE(0ULL);
+  mon_feature_t FEATURE_A((1ULL << 1));
+  mon_feature_t FEATURE_B((1ULL << 2));
+  mon_feature_t FEATURE_C((1ULL << 3));
+  mon_feature_t FEATURE_D((1ULL << 4));
+
+  mon_feature_t FEATURE_ALL(
+      FEATURE_A | FEATURE_B |
+      FEATURE_C | FEATURE_D
+  );
+
+  mon_feature_t foo(FEATURE_A|FEATURE_B);
+  mon_feature_t bar(FEATURE_C|FEATURE_D);
+
+  ASSERT_TRUE(FEATURE_ALL.contains_all(foo));
+  ASSERT_TRUE(FEATURE_ALL.contains_all(bar));
+  ASSERT_TRUE(FEATURE_ALL.contains_all(foo|bar));
+
+  ASSERT_EQ(foo.diff(bar), foo);
+  ASSERT_EQ(bar.diff(foo), bar);
+  ASSERT_EQ(FEATURE_ALL.diff(foo), bar);
+  ASSERT_EQ(FEATURE_ALL.diff(bar), foo);
+
+  ASSERT_TRUE(foo.contains_any(FEATURE_A|bar));
+  ASSERT_TRUE(bar.contains_any(FEATURE_ALL));
+  ASSERT_TRUE(FEATURE_ALL.contains_any(foo));
+
+  mon_feature_t FEATURE_X((1ULL << 10));
+
+  ASSERT_FALSE(FEATURE_ALL.contains_any(FEATURE_X));
+  ASSERT_FALSE(FEATURE_ALL.contains_all(FEATURE_X));
+  ASSERT_EQ(FEATURE_ALL.diff(FEATURE_X), FEATURE_ALL);
+
+  ASSERT_EQ(foo.intersection(FEATURE_ALL), foo);
+  ASSERT_EQ(bar.intersection(FEATURE_ALL), bar);
+}

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -24,8 +24,144 @@ using namespace std;
 
 void usage()
 {
-  cout << " usage: [--print] [--create [--clobber][--fsid uuid]] [--generate] [--set-initial-members] [--add name 1.2.3.4:567] [--rm name] <mapfilename>" << std::endl;
+  cout << " usage: [--print] [--create [--clobber][--fsid uuid]]\n"
+       << "        [--generate] [--set-initial-members]\n"
+       << "        [--add name 1.2.3.4:567] [--rm name]\n"
+       << "        [--feature-list [plain|parseable]]\n"
+       << "        [--feature-set <value> [--optional|--persistent]]\n"
+       << "        [--feature-unset <value> [--optional|--persistent]] "
+       << "<mapfilename>"
+       << std::endl;
   exit(1);
+}
+
+struct feature_op_t {
+  enum type_t {
+    PERSISTENT,
+    OPTIONAL,
+    PLAIN,
+    PARSEABLE,
+    NONE
+  };
+
+  enum op_t {
+    OP_SET,
+    OP_UNSET,
+    OP_LIST
+  };
+
+  op_t op;
+  type_t type;
+  mon_feature_t feature;
+
+  feature_op_t() : op(OP_LIST), type(NONE) { }
+  // default to 'persistent' feature if not specified
+  feature_op_t(op_t o) : op(o), type(PERSISTENT) { }
+  feature_op_t(op_t o, type_t t) : op(o), type(t) { }
+  feature_op_t(op_t o, type_t t, mon_feature_t &f) :
+    op(o), type(t), feature(t) { }
+
+  void set_optional() {
+    type = OPTIONAL;
+  }
+  void set_persistent() {
+    type = PERSISTENT;
+  }
+  bool parse_value(string &s, ostream *errout = NULL) {
+
+    feature = ceph::features::mon::get_feature_by_name(s);
+    if (feature != ceph::features::mon::FEATURE_NONE) {
+      return true;
+    }
+
+    // try parsing as numerical value
+    uint64_t feature_val;
+    string interr;
+    feature_val = strict_strtoll(s.c_str(), 10, &interr);
+    if (!interr.empty()) {
+      if (errout) {
+        *errout << "unknown features name '" << s
+                << "' or unable to parse value: " << interr << std::endl;
+      }
+      return false;
+    }
+    feature = mon_feature_t(feature_val);
+    return true;
+  }
+};
+
+void features_list(feature_op_t &f, MonMap &m)
+{
+  if (f.type == feature_op_t::type_t::PLAIN) {
+
+    cout << "MONMAP FEATURES:" << std::endl;
+    cout << "    persistent: ";
+    m.persistent_features.print_with_value(cout);
+    cout << std::endl;
+    cout << "    optional:   ";
+    m.optional_features.print_with_value(cout);
+    cout << std::endl;
+    cout << "    required:   ";
+    m.get_required_features().print_with_value(cout);
+    cout << std::endl;
+
+    cout << std::endl;
+    cout << "AVAILABLE FEATURES:" << std::endl;
+    cout << "    supported:  ";
+    ceph::features::mon::get_supported().print_with_value(cout);
+    cout << std::endl;
+    cout << "    persistent: ";
+    ceph::features::mon::get_persistent().print_with_value(cout);
+    cout << std::endl;
+  } else if (f.type == feature_op_t::type_t::PARSEABLE) {
+
+    cout << "monmap:persistent:";
+    m.persistent_features.print_with_value(cout);
+    cout << std::endl;
+    cout << "monmap:optional:";
+    m.optional_features.print_with_value(cout);
+    cout << std::endl;
+    cout << "monmap:required:";
+    m.get_required_features().print_with_value(cout);
+    cout << std::endl;
+    cout << "available:supported:";
+    ceph::features::mon::get_supported().print_with_value(cout);
+    cout << std::endl;
+    cout << "available:persistent:";
+    ceph::features::mon::get_persistent().print_with_value(cout);
+    cout << std::endl;
+  }
+}
+
+bool handle_features(list<feature_op_t>& lst, MonMap &m)
+{
+  if (lst.empty())
+    return false;
+
+  bool modified = false;
+
+  for (auto &f : lst) {
+    if (f.op == feature_op_t::op_t::OP_LIST) {
+      features_list(f, m);
+    } else if (f.op == feature_op_t::op_t::OP_SET ||
+               f.op == feature_op_t::op_t::OP_UNSET) {
+
+      modified = true;
+
+      mon_feature_t &target =
+        ( f.type == feature_op_t::type_t::OPTIONAL ?
+            m.optional_features : m.persistent_features );
+
+      if (f.op == feature_op_t::op_t::OP_SET) {
+        target.set_feature(f.feature);
+      } else {
+        target.unset_feature(f.feature);
+      }
+    } else {
+      cerr << "unknow feature operation type '" << f.op << "'" << std::endl; 
+    }
+  }
+  return modified;
 }
 
 int main(int argc, const char **argv)
@@ -40,10 +176,12 @@ int main(int argc, const char **argv)
   bool create = false;
   bool clobber = false;
   bool modified = false;
+  bool show_features = false;
   bool generate = false;
   bool filter = false;
   map<string,entity_addr_t> add;
   list<string> rm;
+  list<feature_op_t> features;
 
   global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
 	      CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
@@ -82,6 +220,53 @@ int main(int argc, const char **argv)
     } else if (ceph_argparse_witharg(args, i, &val, "--rm", (char*)NULL)) {
       rm.push_back(val);
       modified = true;
+    } else if (ceph_argparse_flag(args, i, "--feature-list", (char*)NULL)) {
+      string format = *i;
+      if (format == "plain" || format == "parseable") {
+        i = args.erase(i);
+      } else {
+        format = "plain";
+      }
+
+      feature_op_t f(feature_op_t::op_t::OP_LIST,
+                   feature_op_t::type_t::PLAIN);
+
+      if (format == "parseable") {
+        f.type = feature_op_t::type_t::PARSEABLE;
+      } else if (format != "plain") {
+        cerr << "invalid format type for list: '" << val << "'" << std::endl;
+        usage();
+      }
+
+      features.push_back(f);
+      show_features = true;
+    } else if (ceph_argparse_witharg(args, i, &val,
+                                     "--feature-set", (char*)NULL)) {
+      // parse value
+      feature_op_t f(feature_op_t::op_t::OP_SET);
+      if (!f.parse_value(val, &cerr)) {
+        usage();
+      }
+      features.push_back(f);
+
+    } else if (ceph_argparse_witharg(args, i, &val,
+                                     "--feature-unset", (char*)NULL)) {
+      // parse value
+      feature_op_t f(feature_op_t::op_t::OP_UNSET);
+      if (!f.parse_value(val, &cerr)) {
+        usage();
+      }
+      features.push_back(f);
+    } else if (ceph_argparse_flag(args, i, "--optional", (char*)NULL)) {
+      if (features.empty()) {
+        usage();
+      }
+      features.back().set_optional();
+    } else if (ceph_argparse_flag(args, i, "--persistent", (char*)NULL)) {
+      if (features.empty()) {
+        usage();
+      }
+      features.back().set_persistent();
     } else {
       ++i;
     }
@@ -178,7 +363,11 @@ int main(int argc, const char **argv)
     monmap.remove(*p);
   }
 
-  if (!print && !modified)
+  if (handle_features(features, monmap)) {
+    modified = true;
+  }
+
+  if (!print && !modified && !show_features)
     usage();
 
   if (print) 


### PR DESCRIPTION
This pull request is pretty much the result of PR #8126 with a few additions on tests, a somewhat useful admin socket set of commands to change the (in-memory) monmap features on-the-fly, and monmaptool support.

It has been rebased on master, although I suspect it may need yet another rebase before merging. This has been manually tested to make sure features work with pre-kraken monitors and with kraken itself. In the mean time it will go through a rados suite.

Reviews are welcome.
