### PR TITLE
os/bluestore: Improve 4K overwrite performance by eliminating DB update and doing direct block write when possible

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1013,6 +1013,7 @@ OPTION(bluestore_debug_prefill, OPT_FLOAT, 0)
 OPTION(bluestore_debug_prefragment_max, OPT_INT, 1048576)
 OPTION(bluestore_inject_wal_apply_delay, OPT_FLOAT, 0)
 OPTION(bluestore_shard_finishers, OPT_BOOL, false)
+OPTION(bluestore_fast_overwrite, OPT_BOOL, false)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -876,6 +876,7 @@ public:
     boost::intrusive::list_member_hook<> sequencer_item;
 
     uint64_t ops, bytes;
+    uint64_t cur_transact_ops;
 
     set<OnodeRef> onodes;     ///< these onodes need to be updated/written
     set<BnodeRef> bnodes;     ///< these bnodes need to be updated/written
@@ -970,6 +971,7 @@ public:
 	osr(o),
 	ops(0),
 	bytes(0),
+	cur_transact_ops(0),
 	oncommit(NULL),
 	onreadable(NULL),
 	onreadable_sync(NULL),
@@ -1588,6 +1590,13 @@ private:
   };
 
   void _do_write_small(
+    TransContext *txc,
+    CollectionRef &c,
+    OnodeRef o,
+    uint64_t offset, uint64_t length,
+    bufferlist::iterator& blp,
+    WriteContext *wctx);
+  void _do_write_big_fast(
     TransContext *txc,
     CollectionRef &c,
     OnodeRef o,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1294,7 +1294,7 @@ private:
   TransContext *_txc_create(OpSequencer *osr);
   void _txc_update_store_statfs(TransContext *txc);
   void _txc_add_transaction(TransContext *txc, Transaction *t);
-  void _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
+  bool _txc_write_nodes(TransContext *txc, KeyValueDB::Transaction t);
   void _txc_state_proc(TransContext *txc);
   void _txc_aio_submit(TransContext *txc);
   void _txc_finalize_kv(TransContext *txc, KeyValueDB::Transaction t);
@@ -1565,6 +1565,7 @@ private:
     bool compress = false;       ///< compressed write
     uint64_t comp_blob_size = 0; ///< target compressed blob size
     unsigned csum_order = 0;     ///< target checksum chunk order
+    bool onode_changed = false;  ///< if onode needs update in DB 
 
     vector<std::pair<uint64_t, bluestore_lextent_t> > lex_old; ///< must deref blobs
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1323,7 +1323,8 @@ private:
   bluestore_wal_op_t *_get_wal_op(TransContext *txc, OnodeRef o);
   int _wal_apply(TransContext *txc);
   int _wal_finish(TransContext *txc);
-  int _do_wal_op(TransContext *txc, bluestore_wal_op_t& wo);
+  void _do_wal_ops(TransContext *txc, bool increment_counter);
+  int _do_wal_op(TransContext *txc, bluestore_wal_op_t& wo, bool increment_counter);
   int _wal_replay();
 
   // for fsck

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1130,6 +1130,20 @@ void bluestore_wal_op_t::generate_test_instances(list<bluestore_wal_op_t*>& o)
   o.back()->data.append("my data");
 }
 
+bool bluestore_wal_transaction_t::can_bypass_wal(uint64_t block_size) const
+{
+  bool res = false;
+  if (released.size() == 0 &&
+      ops.size() == 1 &&
+      ops.front().op == bluestore_wal_op_t::OP_WRITE &&
+      ops.front().extents.size() == 1 &&
+      ops.front().extents.front().length == block_size &&
+      (ops.front().extents.front().offset % block_size) == 0) {
+    res = true;
+  }
+  return res;
+}
+
 void bluestore_wal_transaction_t::encode(bufferlist& bl) const
 {
   ENCODE_START(1, 1, bl);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -741,6 +741,7 @@ struct bluestore_wal_transaction_t {
 
   bluestore_wal_transaction_t() : seq(0) {}
 
+  bool can_bypass_wal(uint64_t block_size) const;
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);
   void dump(Formatter *f) const;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5332,6 +5332,7 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("bluestore_debug_freelist", "true");
   g_ceph_context->_conf->set_val("bluestore_clone_cow", "true");
   g_ceph_context->_conf->set_val("bluestore_max_alloc_size", "196608");
+  g_ceph_context->_conf->set_val("bluestore_fast_overwrite", "true");
 
   // set small cache sizes so we see trimming during Synthetic tests
   g_ceph_context->_conf->set_val("bluestore_buffer_cache_size", "2000000");

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -903,6 +903,201 @@ TEST_P(StoreTest, CompressionTest) {
   g_ceph_context->_conf->apply_changes(NULL);
 }
 
+TEST_P(StoreTest, FastWALTest) {
+  ObjectStore::Sequencer osr("test");
+  int r;
+  coll_t cid;
+
+  g_conf->set_val("bluestore_csum", "false");
+  g_conf->set_val("bluestore_min_alloc_size", "65536");
+  g_ceph_context->_conf->apply_changes(NULL);
+  store->umount();
+  store->mount(); //to apply min_alloc_size setting
+
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bool exists = store->exists(cid, hoid);
+    ASSERT_TRUE(!exists);
+
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid);
+    cerr << "Creating object " << hoid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+
+    exists = store->exists(cid, hoid);
+    ASSERT_EQ(true, exists);
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl, orig;
+    string s(0x20000, 'a');
+    bl.append(s);
+    orig = bl;
+    t.write(cid, hoid, 0, bl.length(), bl);
+    cerr << "Write 128K.." << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    string s(0x1000, 'b');
+    bl.append(s);
+
+    t.write(cid, hoid, 0x1000, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
+    cerr << "WAL overwrite" << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bufferlist in, exp;
+    r = store->read(cid, hoid, 0x1000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ab");
+    ASSERT_TRUE(bl_eq(exp, in));
+
+    in.clear();
+    exp.clear();
+    r = store->read(cid, hoid, 0x2000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ba");
+    ASSERT_TRUE(bl_eq(exp, in));
+  }
+  EXPECT_EQ(store->umount(), 0);
+  EXPECT_EQ(store->mount(), 0);
+  {
+    bufferlist in, exp;
+    r = store->read(cid, hoid, 0x1000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ab");
+    ASSERT_TRUE(bl_eq(exp, in));
+
+    in.clear();
+    exp.clear();
+    r = store->read(cid, hoid, 0x2000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ba");
+    ASSERT_TRUE(bl_eq(exp, in));
+  }
+  
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  g_conf->set_val("bluestore_csum", "true");
+  g_conf->set_val("bluestore_min_alloc_size", "0");
+}
+
+TEST_P(StoreTest, FastBigOverwriteTest) {
+  ObjectStore::Sequencer osr("test");
+  int r;
+  coll_t cid;
+
+  g_conf->set_val("bluestore_csum", "false");
+  g_conf->set_val("bluestore_min_alloc_size", "4096");
+  g_ceph_context->_conf->apply_changes(NULL);
+  store->umount();
+  store->mount(); //to apply min_alloc_size
+
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bool exists = store->exists(cid, hoid);
+    ASSERT_TRUE(!exists);
+
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid);
+    cerr << "Creating object " << hoid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+
+    exists = store->exists(cid, hoid);
+    ASSERT_EQ(true, exists);
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl, orig;
+    string s(0x4000, 'a');
+    bl.append(s);
+    orig = bl;
+    t.write(cid, hoid, 0, bl.length(), bl);
+    cerr << "Write 16K.." << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+
+  }
+  {
+    ObjectStore::Transaction t;
+    bufferlist bl;
+    string s(0x1000, 'b');
+    bl.append(s);
+
+    t.write(cid, hoid, 0x1000, bl.length(), bl);
+    cerr << "'BIG' overwrite" << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    bufferlist in, exp;
+    r = store->read(cid, hoid, 0x1000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ab");
+    ASSERT_TRUE(bl_eq(exp, in));
+
+    in.clear();
+    exp.clear();
+    r = store->read(cid, hoid, 0x2000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ba");
+    ASSERT_TRUE(bl_eq(exp, in));
+  }
+  EXPECT_EQ(store->umount(), 0);
+  EXPECT_EQ(store->mount(), 0);
+  {
+    bufferlist in, exp;
+    r = store->read(cid, hoid, 0x1000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ab");
+    ASSERT_TRUE(bl_eq(exp, in));
+
+    in.clear();
+    exp.clear();
+    r = store->read(cid, hoid, 0x2000-1, 2, in);
+    ASSERT_EQ(2, r);
+    exp.append("ba");
+    ASSERT_TRUE(bl_eq(exp, in));
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  g_conf->set_val("bluestore_csum", "true");
+  g_conf->set_val("bluestore_min_alloc_size", "0");
+}
+
 TEST_P(StoreTest, SimpleObjectTest) {
   ObjectStore::Sequencer osr("test");
   int r;
@@ -1216,6 +1411,7 @@ TEST_P(StoreTest, BluestoreStatFSTest) {
     t.zero(cid, hoid, 0x20000, 9);
     cerr << "Punch hole at 1~3, 0x20000~9" << std::endl;
     r = apply_transaction(store, &osr, std::move(t));
+
     ASSERT_EQ(r, 0);
 
     struct store_statfs_t statfs;


### PR DESCRIPTION
If csum is off and single 4K chunk overwrite takes place one can safely bypass onode metadata update.
This gives ~10-15% performance boost for rand R/W fio benchmarks. (Note: min_alloc_size set to 64K)

Additionally given the assumption that single device block overwrite is atomic one can eliminate WAL  (and corresponding DB update) totally and do the write directly over an old block.

Both fixes gives >100% performance gain for my benchmarks.

The next step using the same concept is to omit new blob creation on 'big' blob overwrite if min_alloc_size == block_size. No need for onode metadata update in this case too.

Signed-off-by: Igor Fedotov ifedotov@mirantis.com
