### PR TITLE
Orphan data gets leaked on Bucket deletion

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7344,15 +7344,8 @@ int RGWRados::delete_bucket(rgw_bucket& bucket, RGWObjVersionTracker& objv_track
     if (r < 0)
       return r;
 
-    string ns;
-    std::map<string, RGWObjEnt>::iterator eiter;
-    rgw_obj_key obj;
-    string instance;
-    for (eiter = ent_map.begin(); eiter != ent_map.end(); ++eiter) {
-      obj = eiter->second.key;
-
-      if (rgw_obj::translate_raw_obj_to_obj_in_ns(obj.name, instance, ns))
-        return -ENOTEMPTY;
+    if (ent_map.size() != 0) {
+      return -ENOTEMPTY;
     }
   } while (is_truncated);
 


### PR DESCRIPTION
Problem: 

If we have orphan data in the bucket because of partial Multipart upload. The rados objects corresponding to the Multipart upload gets leaked when we delete the bucket.

Solution: 

We should return ENOTEMPTY if we find any kind of object and not just objects that are visible to users, i.e. if ent_map.size() is not equal zero, we should return ENOTEMPTY

Tracker info :
http://tracker.ceph.com/issues/17164