### PR TITLE
mds: remove max_mds config option

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -11,15 +11,6 @@
 :Default: ``true`` 
 
 
-``max mds``
-
-:Description: The number of active MDS daemons during cluster creation. Set
-              under ``[mon]`` or ``[global]``.
-              
-:Type:  32-bit Integer
-:Default: ``1``
-
-
 ``mds max file size``
 
 :Description: The maximum allowed file size to set when creating a 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -530,7 +530,6 @@ OPTION(mds_inject_traceless_reply_probability, OPT_DOUBLE, 0) /* percentage
 OPTION(mds_wipe_sessions, OPT_BOOL, 0)
 OPTION(mds_wipe_ino_prealloc, OPT_BOOL, 0)
 OPTION(mds_skip_ino, OPT_INT, 0)
-OPTION(max_mds, OPT_INT, 1)
 OPTION(mds_standby_for_name, OPT_STR, "")
 OPTION(mds_standby_for_rank, OPT_INT, -1)
 OPTION(mds_standby_for_fscid, OPT_INT, -1)

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -90,7 +90,7 @@ void MDSMonitor::create_new_fs(FSMap &fsm, const std::string &name,
 {
   auto fs = std::make_shared<Filesystem>();
   fs->mds_map.fs_name = name;
-  fs->mds_map.max_mds = g_conf->max_mds;
+  fs->mds_map.max_mds = 1;
   fs->mds_map.data_pools.insert(data_pool);
   fs->mds_map.metadata_pool = metadata_pool;
   fs->mds_map.cas_pool = -1;
@@ -1727,7 +1727,7 @@ int MDSMonitor::management_command(
     // Carry forward what makes sense
     new_fs->fscid = fs->fscid;
     new_fs->mds_map.inline_data_enabled = fs->mds_map.inline_data_enabled;
-    new_fs->mds_map.max_mds = g_conf->max_mds;
+    new_fs->mds_map.max_mds = 1;
     new_fs->mds_map.data_pools = fs->mds_map.data_pools;
     new_fs->mds_map.metadata_pool = fs->mds_map.metadata_pool;
     new_fs->mds_map.cas_pool = fs->mds_map.cas_pool;


### PR DESCRIPTION
It is now required that all changes to max_mds use the run-time `ceph fs set max_mds` command. The rationale for this change is that it is confusing to have a configuration for max_mds which is only observed at file system creation.

Fixes: http://tracker.ceph.com/issues/17105
