### PR TITLE
rgw: Replacing '+' with "%20" in canonical uri for s3 v4 auth.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -11,6 +11,7 @@
 #include "common/ceph_json.h"
 #include "common/safe_io.h"
 #include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/replace.hpp>
 
 #include "rgw_rest.h"
 #include "rgw_rest_s3.h"
@@ -3595,6 +3596,8 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s)
 
   if (s->aws4_auth->canonical_uri.empty()) {
     s->aws4_auth->canonical_uri = "/";
+  } else {
+    boost::replace_all(s->aws4_auth->canonical_uri, "+", "%20");
   }
 
   /* craft canonical query string */


### PR DESCRIPTION
s3cmd encodes space as "%20" while signature computation and
encodes space as '+' while sending the canonical uri. This
results in a SignatureMismatch Error in rgw, since rgw
computes the signature based on the request received from
the client (s3cmd in this case).

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>