### PR TITLE
os/bluestore/bluefs: use map to track dirty files

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -156,7 +156,7 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
 {
   std::unique_lock<std::mutex> l(lock);
   dout(1) << __func__ << " bdev " << id
-          << " want 0x" << std::hex << want << std:: dec << dendl;
+          << " want 0x" << std::hex << want << std::dec << dendl;
   assert(id < alloc.size());
   assert(alloc[id]);
   int r = alloc[id]->reserve(want);
@@ -1770,7 +1770,6 @@ int BlueFS::open_for_write(
     }
     file = new File;
     file->fnode.ino = ++ino_last;
-    file->fnode.mtime = ceph_clock_now(NULL);
     file_map[ino_last] = file;
     dir->file_map[filename] = file;
     ++file->refs;
@@ -1792,9 +1791,9 @@ int BlueFS::open_for_write(
       }
       file->fnode.extents.clear();
     }
-    file->fnode.mtime = ceph_clock_now(NULL);
   }
 
+  file->fnode.mtime = ceph_clock_now(NULL);
   file->fnode.prefer_bdev = BlueFS::BDEV_DB;
   if (dirname.length() > 5) {
     // the "db.slow" and "db.wal" directory names are hard-coded at

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -837,10 +837,6 @@ int BlueFS::_read_random(
     uint64_t x_off = 0;
     vector<bluefs_extent_t>::iterator p = h->file->fnode.seek(off, &x_off);
     uint64_t l = MIN(p->length - x_off, len);
-    if (!h->ignore_eof &&
-	off + l > h->file->fnode.size) {
-      l = h->file->fnode.size - off;
-    }
     dout(20) << __func__ << " read buffered 0x"
              << std::hex << x_off << "~" << l << std::dec
              << " of " << *p << dendl;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -196,7 +196,9 @@ private:
   // cache
   map<string, DirRef> dir_map;                    ///< dirname -> Dir
   ceph::unordered_map<uint64_t,FileRef> file_map; ///< ino -> File
-  dirty_file_list_t dirty_files;                  ///< list of dirty files
+
+  // map of dirty files, files of same dirty_seq are grouped into list.
+  map<uint64_t, dirty_file_list_t> dirty_files;
 
   bluefs_super_t super;        ///< latest superblock (as last written)
   uint64_t ino_last = 0;       ///< last assigned ino (this one is in use)


### PR DESCRIPTION
Therefore dirty files are arranged by dirty_seq and then
dirty files of same dirty_seq are grouped into list and
as a result we can clean up dirty files much faster during
_flush_and_sync_log().

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>