### PR TITLE
os/bluestore: get rid off "isa-l" type in ZLibCompressor ctor

### DIFF
--- a/src/compressor/zlib/ZlibCompressor.h
+++ b/src/compressor/zlib/ZlibCompressor.h
@@ -22,11 +22,7 @@
 class ZlibCompressor : public Compressor {
   bool isal_enabled;
 public:
-  ZlibCompressor(bool isal) : Compressor("zlib"), isal_enabled(isal)
-  {
-    if (isal)
-      Compressor::type = "isa-l";
-  }
+  ZlibCompressor(bool isal) : Compressor("zlib"), isal_enabled(isal) {}
 
   int compress(const bufferlist &in, bufferlist &out) override;
   int decompress(const bufferlist &in, bufferlist &out) override;

--- a/src/test/compressor/test_compression_zlib.cc
+++ b/src/test/compressor/test_compression_zlib.cc
@@ -72,7 +72,7 @@ TEST(ZlibCompressor, compress_decompress_chunk)
 TEST(ZlibCompressor, compress_decompress_isal)
 {
   ZlibCompressor sp(true);
-  EXPECT_STREQ(sp.get_type().c_str(), "isa-l");
+  EXPECT_STREQ(sp.get_type().c_str(), "zlib");
   const char* test = "This is test text";
   int len = strlen(test);
   bufferlist in, out;
@@ -97,7 +97,7 @@ TEST(ZlibCompressor, compress_decompress_isal)
 TEST(ZlibCompressor, compress_decompress_chunk_isal)
 {
   ZlibCompressor sp(true);
-  EXPECT_STREQ(sp.get_type().c_str(), "isa-l");
+  EXPECT_STREQ(sp.get_type().c_str(), "zlib");
   const char* test = "This is test text";
   buffer::ptr test2 ("1234567890", 10);
   int len = strlen(test);
@@ -117,7 +117,7 @@ TEST(ZlibCompressor, compress_decompress_chunk_isal)
 TEST(ZlibCompressor, zlib_isal_compatibility)
 {
   ZlibCompressor isal(true);
-  EXPECT_STREQ(isal.get_type().c_str(), "isa-l");
+  EXPECT_STREQ(isal.get_type().c_str(), "zlib");
   ZlibCompressor zlib(false);
   EXPECT_STREQ(zlib.get_type().c_str(), "zlib");
   char test[101];


### PR DESCRIPTION
This is introduced by https://github.com/ceph/ceph/pull/10158 and causes
the following failure:

/home/xxg/ceph-dev/src/os/bluestore/bluestore_types.h: 284: FAILED assert(0 == "invalid compression algorithm")

 ceph version v11.0.0-1941-g47c8a21 (47c8a214356983f0539f24fe1c5724b3bbae0406)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x85) [0x7f5668c1ad45]
 2: (BlueStore::_do_alloc_write(BlueStore::TransContext*, BlueStore::WriteContext*)+0x1a65) [0x7f5668b19d55]
 3: (BlueStore::_do_write(BlueStore::TransContext*, boost::intrusive_ptr<BlueStore::Collection>&, boost::intrusive_ptr<BlueStore::Onode>, unsigned long, unsigned long, ceph::buffer::list&, unsigned int)+0x4ac) [0x7f5668b3b3fc]
 4: (BlueStore::_write(BlueStore::TransContext*, boost::intrusive_ptr<BlueStore::Collection>&, boost::intrusive_ptr<BlueStore::Onode>&, unsigned long, unsigned long, ceph::buffer::list&, unsigned int)+0x10f) [0x7f5668b3bf2f]
 5: (BlueStore::_txc_add_transaction(BlueStore::TransContext*, ObjectStore::Transaction*)+0x1067) [0x7f5668b405f7]
 6: (BlueStore::queue_transactions(ObjectStore::Sequencer*, std::vector<ObjectStore::Transaction, std::allocator<ObjectStore::Transaction> >&, std::shared_ptr<TrackedOp>, ThreadPool::TPHandle*)+0x382) [0x7f5668b42432]
 7: (SyntheticWorkloadState::write()+0x3a5) [0x7f5668a2ace5]
 8: (doSyntheticTest(boost::scoped_ptr<ObjectStore>&, unsigned long, unsigned long, unsigned long)+0xb9d) [0x7f56689dfa7d]
 9: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x29d) [0x7f56689dfffd]
 10: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x9e) [0x7f56689dfdfe]
 11: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x9e) [0x7f56689dfdfe]
 12: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x9e) [0x7f56689dfdfe]
 13: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x9e) [0x7f56689dfdfe]
 14: (do_matrix_choose(char const* (*) [10], int, int, int, boost::scoped_ptr<ObjectStore>&)+0x9e) [0x7f56689dfdfe]
 15: (do_matrix(char const* (*) [10], boost::scoped_ptr<ObjectStore>&)+0x317) [0x7f56689e0347]
 16: (()+0x297f3c) [0x7f56689e0f3c]
 17: (StoreTest_SyntheticMatrixCompressionAlgorithm_Test::TestBody()+0x118) [0x7f56689e1078]
 18: (void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*)+0x43) [0x7f5668d673e3]
 19: (testing::Test::Run()+0xb7) [0x7f5668d5a127]
 20: (testing::TestInfo::Run()+0x9e) [0x7f5668d5a1ce]
 21: (testing::TestCase::Run()+0xa5) [0x7f5668d5a2d5]
 22: (testing::internal::UnitTestImpl::RunAllTests()+0x278) [0x7f5668d5a5b8]
 23: (testing::UnitTest::Run()+0x68) [0x7f5668d5a888]
 24: (main()+0x2f4) [0x7f566895be84]
 25: (__libc_start_main()+0xf5) [0x7f5663e5ab15]
 26: (()+0x265ba5) [0x7f56689aeba5]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>