### PR TITLE
add ldap auth custom search filter feature patch

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1347,6 +1347,8 @@ OPTION(rgw_ldap_dnattr, OPT_STR, "uid")
 OPTION(rgw_ldap_secret, OPT_STR, "/etc/openldap/secret")
 /* rgw_s3_auth_use_ldap  use LDAP for RGW auth? */
 OPTION(rgw_s3_auth_use_ldap, OPT_BOOL, false)
+/* rgw_ldap_searchfilter  LDAP search filter */
+OPTION(rgw_ldap_searchfilter, OPT_STR, "")
 
 OPTION(rgw_admin_entry, OPT_STR, "admin")  // entry point for which a url is considered an admin request
 OPTION(rgw_enforce_swift_acls, OPT_BOOL, true)

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -494,12 +494,13 @@ namespace rgw {
     const string& ldap_uri = store->ctx()->_conf->rgw_ldap_uri;
     const string& ldap_binddn = store->ctx()->_conf->rgw_ldap_binddn;
     const string& ldap_searchdn = store->ctx()->_conf->rgw_ldap_searchdn;
+    const string& ldap_searchfilter = store->ctx()->_conf->rgw_ldap_searchfilter;
     const string& ldap_dnattr =
       store->ctx()->_conf->rgw_ldap_dnattr;
     std::string ldap_bindpw = parse_rgw_ldap_bindpw(store->ctx());
 
     ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw.c_str(),
-			      ldap_searchdn, ldap_dnattr);
+			      ldap_searchdn, ldap_searchfilter, ldap_dnattr);
     ldh->init();
     ldh->bind();
 

--- a/src/rgw/rgw_ldap.h
+++ b/src/rgw/rgw_ldap.h
@@ -28,6 +28,7 @@ namespace rgw {
     std::string binddn;
     std::string bindpw;
     std::string searchdn;
+    std::string searchfilter;
     std::string dnattr;
     LDAP *ldap;
     bool msad = false; /* TODO: possible future specialization */
@@ -37,9 +38,9 @@ namespace rgw {
     using lock_guard = std::lock_guard<std::mutex>;
 
     LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _dnattr)
+	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
       : uri(std::move(_uri)), binddn(std::move(_binddn)),
-	bindpw(std::move(_bindpw)), searchdn(_searchdn), dnattr(_dnattr),
+	bindpw(std::move(_bindpw)), searchdn(_searchdn), searchfilter(_searchfilter), dnattr(_dnattr),
 	ldap(nullptr) {
       // nothing
     }
@@ -105,7 +106,7 @@ namespace rgw {
   {
   public:
     LDAPHelper(std::string _uri, std::string _binddn, std::string _bindpw,
-	       std::string _searchdn, std::string _dnattr)
+	       std::string _searchdn, std::string _searchfilter, std::string _dnattr)
       {}
 
     int init() {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4310,11 +4310,12 @@ void RGWLDAPAuthEngine::init(CephContext* const cct)
       const string& ldap_uri = cct->_conf->rgw_ldap_uri;
       const string& ldap_binddn = cct->_conf->rgw_ldap_binddn;
       const string& ldap_searchdn = cct->_conf->rgw_ldap_searchdn;
+      const string& ldap_searchfilter = cct->_conf->rgw_ldap_searchfilter;
       const string& ldap_dnattr = cct->_conf->rgw_ldap_dnattr;
       std::string ldap_bindpw = parse_rgw_ldap_bindpw(cct);
 
       ldh = new rgw::LDAPHelper(ldap_uri, ldap_binddn, ldap_bindpw,
-                                ldap_searchdn, ldap_dnattr);
+                                ldap_searchdn, ldap_searchfilter, ldap_dnattr);
 
       ldh->init();
       ldh->bind();


### PR DESCRIPTION
This patch allows to supply a custom search filter for ldap authentication. Currently rgw ldap auth code allows to limit users based on the search base. This might not be applicable for all environments. E.g. flat structures in smaller environments (ou=People, dc=corp, dc=com). Sometimes the structure is based on geo location and not on organisational units. In many cases one might not want to grant access to all accounts in a unit.

This PR implements a new "rgw search filter" option. These are the possible options:

1) parameter is left empty (default)

rgw LDAP auth will behave as usual, constructing its own search filter based on the "dnattr" option.

2) parameter is set to a "partial" filter like "objectclass=inetOrgperson"

The LDAP auth code takes the user specified partial filter and adds the user id specific filter to it (which is constructed as usual, by using the dn attr and the uid). The resulting filter will be "(&(<custom search filter>)(<dnattr>=<uid>))". So the above example becomes: "(&(objectClass=inetOrgPerson)(uid=hari))" (assuming a username of hari in the authentication request and an "uid" dnattr)

3) parameter is set to a "complete" filter with a special @USERNAME@ placeholder

An example would be "(&(uid=@USERNAME@)(memberOf=cn=ceph-users,ou=groups,dc=mycompany,dc=com))". The LDAP auth code will substitute the "@USERNAME@" placeholder with the uid of the auth request, leading to this search filter: "(&(uid=hari)(memberOf=cn=ceph-users,ou=groups,dc=mycompany,dc=com))"