### PR TITLE
Allow compressor build without YASM

### DIFF
--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -1,6 +1,6 @@
 # zlib
 
-if(INTEL_SSE4_1)
+if(INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 	set(zlib_sources
 	  CompressionPluginZlib.cc
 	  ZlibCompressor.cc
@@ -20,12 +20,12 @@ if(INTEL_SSE4_1)
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_stateless_base.c
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_base.c
 	)
-else(INTEL_SSE4_1)
+else(INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 	set(zlib_sources
 	  CompressionPluginZlib.cc
 	  ZlibCompressor.cc
 	)
-endif(INTEL_SSE4_1)
+endif(INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -99,7 +99,7 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out)
   return 0;
 }
 
-#if __x86_64__
+#if __x86_64__ && defined(HAVE_BETTER_YASM_ELF64)
 int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out)
 {
   int ret;
@@ -154,7 +154,7 @@ int ZlibCompressor::isal_compress(const bufferlist &in, bufferlist &out)
 
 int ZlibCompressor::compress(const bufferlist &in, bufferlist &out)
 {
-#if __x86_64__
+#if __x86_64__ && defined(HAVE_BETTER_YASM_ELF64)
   if (isal_enabled)
     return isal_compress(in, out);
   else


### PR DESCRIPTION
The isa-l compressors need YASM to build.  Conditionalize on that.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>