### PR TITLE
install-deps: exit non-zero when we cannot match distro 

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -119,6 +119,7 @@ else
         ;;
     *)
         echo "$ID is unknown, dependencies will have to be installed manually."
+	exit 1
         ;;
     esac
 fi


### PR DESCRIPTION
exit 1 if we cannot find a match for linux distribution defined in /etc/os_release