### PR TITLE
systemd: add install section to rbdmap.service file

### DIFF
--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -12,3 +12,6 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/rbdmap map
 ExecReload=/usr/bin/rbdmap map
 ExecStop=/usr/bin/rbdmap unmap
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The systemd rbdmap.service unit file missed the Install section, therefore it wasn't possible to enable the rbdmap service at boottime.

Signed-off-by: Jelle vd Kooij <vdkooij.jelle@gmail.com>