### PR TITLE
tox.ini: remove extraneous coverage --omit option

### DIFF
--- a/src/ceph-detect-init/tox.ini
+++ b/src/ceph-detect-init/tox.ini
@@ -16,7 +16,7 @@ deps =
   -r{toxinidir}/test-requirements.txt
 
 commands = coverage run --source=ceph_detect_init {envbindir}/py.test -v tests
-           coverage report --omit=*test*,*tox* --show-missing --fail-under=100
+           coverage report --show-missing --fail-under=100
 
 [testenv:pep8]
 basepython = python2

--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -20,7 +20,7 @@ changedir = {env:CEPH_BUILD_DIR}
 commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py
            coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_prepare.py
            {toxinidir}/tests/ceph-disk.sh
-           coverage report --omit=*test*,*tox* --show-missing
+           coverage report --show-missing
 
 [testenv:flake8]
 commands = flake8 --ignore=H105,H405 ceph_disk tests


### PR DESCRIPTION
This option isn't eliminating anything in the runs I've seen, and it
causes the coverage command (and thus 'make check') to fail spuriously
if a parent directory contains 'test' or 'tox', since it filters out
all of the coverage data.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>