### PR TITLE
src/rgw/rgw_coroutine.cc: fix memory leak

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -608,6 +608,7 @@ int RGWCoroutinesManager::run(RGWCoroutine *op)
   }
   op->put();
 
+  delete stack;
   return r;
 }
 


### PR DESCRIPTION
Greetings, on line number `611` of '[/src/rgw/rgw_coroutine.cc](https://github.com/ceph/ceph/blob/master/src/rgw/rgw_coroutine.cc#L611)' there is a memory leak, which is an error. The reason we should delete is that memory is a finite resource within our running programs. Sure in very short running simple programs, failing to delete memory won't have a noticeable effect. However on long running programs, failing to delete memory means we will be consuming a finite resource without replenishing it. Eventually it will run out and our program will abruptly crash. This is why we must free memory.

Signed-off-by: Bryon Gloden, CISSP® <cissp@bryongloden.com>