### PR TITLE
osd: peering optimizations

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8093,12 +8093,29 @@ void OSD::handle_pg_query(OpRequestRef op)
     }
 
     if (service.splitting(pgid)) {
-      peering_wait_for_split[pgid].push_back(
-	PG::CephPeeringEvtRef(
-	  new PG::CephPeeringEvt(
-	    it->second.epoch_sent, it->second.epoch_sent,
-	    PG::MQuery(pg_shard_t(from, it->second.from),
-		       it->second, it->second.epoch_sent))));
+      if (it->second.type != pg_query_t::ALL) {
+        peering_wait_for_split[pgid].push_back(
+	  PG::CephPeeringEvtRef(
+	    new PG::CephPeeringEvt(
+	      it->second.epoch_sent, it->second.epoch_sent,
+	      PG::MQuery(pg_shard_t(from, it->second.from),
+		         it->second, it->second.epoch_sent))));
+      } else {
+        it->second.type = pg_query_t::INFO;
+        peering_wait_for_split[pgid].push_back(
+	  PG::CephPeeringEvtRef(
+	    new PG::CephPeeringEvt(
+	      it->second.epoch_sent, it->second.epoch_sent,
+	      PG::MQuery(pg_shard_t(from, it->second.from),
+		         it->second, it->second.epoch_sent))));
+        it->second.type = pg_query_t::FULLLOG;
+        peering_wait_for_split[pgid].push_back(
+	  PG::CephPeeringEvtRef(
+	    new PG::CephPeeringEvt(
+	      it->second.epoch_sent, it->second.epoch_sent,
+	      PG::MQuery(pg_shard_t(from, it->second.from),
+		         it->second, it->second.epoch_sent))));
+      }
       continue;
     }
 
@@ -8107,9 +8124,20 @@ void OSD::handle_pg_query(OpRequestRef op)
       if (pg_map.count(pgid)) {
         PG *pg = 0;
         pg = _lookup_lock_pg_with_map_lock_held(pgid);
-        pg->queue_query(
-            it->second.epoch_sent, it->second.epoch_sent,
-            pg_shard_t(from, it->second.from), it->second);
+        if (it->second.type != pg_query_t::ALL) {
+          pg->queue_query(
+              it->second.epoch_sent, it->second.epoch_sent,
+              pg_shard_t(from, it->second.from), it->second);
+        } else {
+          it->second.type = pg_query_t::INFO;
+          pg->queue_query(
+              it->second.epoch_sent, it->second.epoch_sent,
+              pg_shard_t(from, it->second.from), it->second);
+          it->second.type = pg_query_t::FULLLOG;
+          pg->queue_query(
+              it->second.epoch_sent, it->second.epoch_sent,
+              pg_shard_t(from, it->second.from), it->second);
+        }
         pg->unlock();
         continue;
       }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7377,6 +7377,13 @@ PG::RecoveryState::GetLog::GetLog(my_context ctx)
     return;
   }
 
+  if (peer_missing_requested.count(auth_log_shard)) {
+    if (msgs[auth_log_shard]) {
+      msg = msgs[auth_log_shard];
+      post_event(GotLog());
+    }
+    return;
+  }
   // how much log to request?
   eversion_t request_log_from = pg->info.last_update;
   assert(!pg->actingbackfill.empty());

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -555,6 +555,7 @@ public:
   struct PriorSet {
     const bool ec_pool;
     set<pg_shard_t> probe; /// current+prior OSDs we need to probe.
+    set<pg_shard_t> request_log;
     set<int> down;  /// down osds that would normally be in @a probe and might be interesting.
     map<int, epoch_t> blocked_by;  /// current lost_at values for any OSDs in cur set for which (re)marking them lost would affect cur set
 
@@ -1731,6 +1732,8 @@ public:
 
     struct Peering : boost::statechart::state< Peering, Primary, GetInfo >, NamedState {
       std::unique_ptr< PriorSet > prior_set;
+      set<pg_shard_t> peer_missing_requested;
+      map<pg_shard_t, boost::intrusive_ptr<MOSDPGLog> > msgs;
       bool history_les_bound;  //< need osd_find_best_info_ignore_history_les
 
       explicit Peering(my_context ctx);
@@ -1979,10 +1982,12 @@ public:
       typedef boost::mpl::list <
 	boost::statechart::custom_reaction< QueryState >,
 	boost::statechart::transition< GotInfo, GetLog >,
+       boost::statechart::custom_reaction< MLogRec >,
 	boost::statechart::custom_reaction< MNotifyRec >
 	> reactions;
       boost::statechart::result react(const QueryState& q);
       boost::statechart::result react(const MNotifyRec& infoevt);
+      boost::statechart::result react(const MLogRec& logevt);
     };
 
     struct GetMissing;
@@ -2013,8 +2018,6 @@ public:
     struct WaitUpThru;
 
     struct GetMissing : boost::statechart::state< GetMissing, Peering >, NamedState {
-      set<pg_shard_t> peer_missing_requested;
-
       explicit GetMissing(my_context ctx);
       void exit();
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2315,6 +2315,7 @@ struct pg_query_t {
     LOG = 1,
     MISSING = 4,
     FULLLOG = 5,
+    ALL = 6,
   };
   const char *get_type_name() const {
     switch (type) {
@@ -2322,6 +2323,7 @@ struct pg_query_t {
     case LOG: return "log";
     case MISSING: return "missing";
     case FULLLOG: return "fulllog";
+    case ALL: return "all";
     default: return "???";
     }
   }


### PR DESCRIPTION
This patch optimizes peering by speculatively prefetching logs in GetInfo state. 
The osd set to contact consists of the current up+acting osds as well as the ones 
from the latest interval. It thus hopefully saves the time to request authoritative log 
in GetLog and request logs in GetMissing.
