### PR TITLE
preforker: prevent call to 'write' on an fd that was already closed, …

### DIFF
--- a/src/common/Preforker.h
+++ b/src/common/Preforker.h
@@ -39,7 +39,7 @@ public:
 
   int prefork(std::string &err) {
     assert(!forked);
-    int r = socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
+    int r = ::socketpair(AF_UNIX, SOCK_STREAM, 0, fd);
     std::ostringstream oss;
     if (r < 0) {
       oss << "[" << getpid() << "]: unable to create socketpair: " << cpp_strerror(errno);
@@ -56,7 +56,7 @@ public:
       err = oss.str();
       return r;
     }
-    if (childpid == 0) {
+    if (is_child()) {
       ::close(fd[0]);
     } else {
       ::close(fd[1]);
@@ -117,7 +117,8 @@ public:
     return r;
   }
   void exit(int r) {
-    signal_exit(r);
+    if (is_child())
+        signal_exit(r);
     ::exit(r);
   }
 


### PR DESCRIPTION
…plus minor code fixups

upon ceph_mon parent exiting it calls prefork.exit(err) that was resulting in
writing the exit status to fd[1] whis was previously closed in this process.
for fixing it, I guarded the call to 'signal_exit(r)' with 'if (is_child())'

on the way, I provided 2 minor code fixups in this file

Signed-off-by: Avner BenHanoch <avnerb@mellanox.com>