### PR TITLE
test/librados: kill ConnectFailure testing case

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -48,31 +48,6 @@ static void test_rados_log_cb(void *arg,
     std::cerr << "monitor log callback invoked" << std::endl;
 }
 
-TEST(LibRadosMiscConnectFailure, ConnectFailure) {
-  rados_t cluster;
-
-  char *id = getenv("CEPH_CLIENT_ID");
-  if (id)
-    std::cerr << "Client id is: " << id << std::endl;
-
-  ASSERT_EQ(0, rados_create(&cluster, NULL));
-  ASSERT_EQ(0, rados_conf_read_file(cluster, NULL));
-  ASSERT_EQ(0, rados_conf_parse_env(cluster, NULL));
-
-  ASSERT_EQ(0, rados_conf_set(cluster, "client_mount_timeout", "0.000000001"));
-  ASSERT_EQ(0, rados_conf_set(cluster, "debug_monc", "20"));
-  ASSERT_EQ(0, rados_conf_set(cluster, "debug_ms", "1"));
-  ASSERT_EQ(0, rados_conf_set(cluster, "log_to_stderr", "true"));
-
-  ASSERT_EQ(-ENOTCONN, rados_monitor_log(cluster, "error",
-                                         test_rados_log_cb, NULL));
-
-  ASSERT_NE(0, rados_connect(cluster));
-  ASSERT_NE(0, rados_connect(cluster));
-
-  rados_shutdown(cluster);
-}
-
 TEST_F(LibRadosMisc, ClusterFSID) {
   char fsid[37];
   ASSERT_EQ(-ERANGE, rados_cluster_fsid(cluster, fsid, sizeof(fsid) - 1));


### PR DESCRIPTION
Because the result of this testing case is non-deterministic
and can be false negative in our testing environment, as below:

```
2016-09-01T19:50:56.877 INFO:tasks.workunit.client.0.plana133.stdout:                 api_misc: /srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.0-1780-g9f065bb/src/test/librados/misc.cc:70: Failure
2016-09-01T19:50:56.879 INFO:tasks.workunit.client.0.plana133.stdout:                 api_misc: Expected: (0) != (rados_connect(cluster)), actual: 0 vs 0
2016-09-01T19:50:56.881 INFO:tasks.workunit.client.0.plana133.stdout:                 api_misc: [  FAILED  ] LibRadosMiscConnectFailure.ConnectFailure (165 ms)
```
The reason is that sometimes we're still able to finish authentication within the
given client_mount_timeout, which is relative small though.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>

For more details, check file attached below:

[ConnectFailure.txt](https://github.com/ceph/ceph/files/449700/ConnectFailure.txt)
