### PR TITLE
jewel: client: fix shutdown with open inodes

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5651,9 +5651,10 @@ void Client::unmount()
   
   while (!ll_unclosed_fh_set.empty()) {
     set<Fh*>::iterator it = ll_unclosed_fh_set.begin();
-    ll_unclosed_fh_set.erase(*it);
-    ldout(cct, 0) << " destroyed lost open file " << *it << " on " << *((*it)->inode) << dendl;
-    _release_fh(*it);
+    Fh *fh = *it;
+    ll_unclosed_fh_set.erase(fh);
+    ldout(cct, 0) << " destroyed lost open file " << fh << " on " << *(fh->inode) << dendl;
+    _release_fh(fh);
   }
 
   while (!opened_dirs.empty()) {


### PR DESCRIPTION
This piece of code was dereferencing an invalid
iterator (invalidated by call to erase())

Fixes:  http://tracker.ceph.com/issues/16764
Signed-off-by: John Spray <john.spray@redhat.com>
(cherry picked from commit d642b4faec3266f609e4871ccdccdcd73707dc23)