### PR TITLE
libcephfs: fixup possible overflow

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1112,18 +1112,20 @@ int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path)
  *
  * @param cmount the ceph mount handle to use.
  * @param fh the open file descriptor referring to the file to get the object size of.
- * @returns the object size of the file or a negative error code on failure.
+ * @param the object size of the file
+ * @returns a negative error code on failure.
  */
-int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh);
+int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh, uint32_t *object_size);
 
 /**
  * Get the file object size.
  *
  * @param cmount the ceph mount handle to use.
  * @param path the path of the file/directory get the object size of.
- * @returns the object size of the file or a negative error code on failure.
+ * @param the object size of the path
+ * @return a negative error code on failure.
  */
-int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path);
+int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path, uint32_t *object_size);
 
 /**
  * Get the file pool information from an open file descriptor.

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1132,18 +1132,20 @@ int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path, 
  *
  * @param cmount the ceph mount handle to use.
  * @param fh the open file descriptor referring to the file to get the pool information of.
- * @returns the ceph pool id that the file is in
+ * @param return the ceph pool id that the file is in
+ * @returns a negative error code on failure.
  */
-int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh);
+int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh, int64_t *pool_id);
 
 /**
  * Get the file pool information.
  *
  * @param cmount the ceph mount handle to use.
  * @param path the path of the file/directory get the pool information of.
- * @returns the ceph pool id that the file is in
+ * @param return the ceph pool id that the path is in
+ * @returns a negative error code on failure.
  */
-int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path);
+int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path, int64_t *pool_id);
 
 /**
  * Get the name of the pool a opened file is stored in,
@@ -1235,9 +1237,10 @@ int ceph_get_path_replication(struct ceph_mount_info *cmount, const char *path);
  *
  * @param cmount the ceph mount handle to use.
  * @param pool_name the name of the pool.
- * @returns the pool id, or a negative error code on failure.
+ * @param returns the pool id.
+ * @returns a negative error code on failure.
  */
-int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name);
+int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name, int64_t *pool_id);
 
 /**
  * Get the pool replication factor.

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1076,36 +1076,40 @@ int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char 
  *
  * @param cmount the ceph mount handle to use.
  * @param fh the open file descriptor referring to the file to get the striping unit of.
- * @returns the striping unit of the file or a negative error code on failure.
+ * @param return the striping unit of the file.
+ * @returns a negative error code on failure.
  */
-int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh);
+int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh, uint32_t *stripe_unit);
 
 /**
  * Get the file striping unit.
  *
  * @param cmount the ceph mount handle to use.
  * @param path the path of the file/directory get the striping unit of.
- * @returns the striping unit of the file or a negative error code on failure.
+ * @param return the striping unit of the path.
+ * @returns a negative error code on failure.
  */
-int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path);
+int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path, uint32_t *stripe_unit);
 
 /**
  * Get the file striping count from an open file descriptor.
  *
  * @param cmount the ceph mount handle to use.
  * @param fh the open file descriptor referring to the file to get the striping count of.
- * @returns the striping count of the file or a negative error code on failure.
+ * @param return the striping count of the file.
+ * @returns a negative error code on failure.
  */
-int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh);
+int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh, uint32_t *stripe_count);
 
 /**
  * Get the file striping count.
  *
  * @param cmount the ceph mount handle to use.
  * @param path the path of the file/directory get the striping count of.
- * @returns the striping count of the file or a negative error code on failure.
+ * @param return the striping count of the path.
+ * @returns a negative error code on failure.
  */
-int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path);
+int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path, uint32_t *stripe_count);
 
 /**
  * Get the file object size from an open file descriptor.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -962,7 +962,7 @@ extern "C" int ceph_get_path_object_size(struct ceph_mount_info *cmount, const c
   return 0;
 }
 
-extern "C" int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh)
+extern "C" int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh, int64_t *pool_id)
 {
   file_layout_t l;
   int r;
@@ -972,10 +972,11 @@ extern "C" int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh)
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
-  return l.pool_id;
+  *pool_id = l.pool_id;
+  return 0;
 }
 
-extern "C" int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path)
+extern "C" int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path, int64_t *pool_id)
 {
   file_layout_t l;
   int r;
@@ -985,7 +986,8 @@ extern "C" int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *pa
   r = cmount->get_client()->describe_layout(path, &l);
   if (r < 0)
     return r;
-  return l.pool_id;
+  *pool_id = l.pool_id;
+  return 0;
 }
 
 extern "C" int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, char *buf, size_t len)
@@ -1289,7 +1291,7 @@ extern "C" int ceph_get_stripe_unit_granularity(struct ceph_mount_info *cmount)
   return CEPH_MIN_STRIPE_UNIT;
 }
 
-extern "C" int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name)
+extern "C" int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name, int64_t *pool_id)
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
@@ -1297,13 +1299,8 @@ extern "C" int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool
   if (!pool_name || !pool_name[0])
     return -EINVAL;
 
-  /* negative range reserved for errors */
-  int64_t pool_id = cmount->get_client()->get_pool_id(pool_name);
-  if (pool_id > 0x7fffffff)
-    return -ERANGE;
-
-  /* get_pool_id error codes fit in int */
-  return (int)pool_id;
+  *pool_id = cmount->get_client()->get_pool_id(pool_name);
+  return 0;
 }
 
 extern "C" int ceph_get_pool_replication(struct ceph_mount_info *cmount,

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -882,7 +882,7 @@ extern "C" int ceph_sync_fs(struct ceph_mount_info *cmount)
 }
 
 
-extern "C" int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh)
+extern "C" int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh, uint32_t *stripe_unit)
 {
   file_layout_t l;
   int r;
@@ -892,10 +892,11 @@ extern "C" int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh)
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
-  return l.stripe_unit;
+  *stripe_unit = l.stripe_unit;
+  return 0;
 }
 
-extern "C" int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path)
+extern "C" int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path, uint32_t *stripe_unit)
 {
   file_layout_t l;
   int r;
@@ -905,10 +906,11 @@ extern "C" int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const c
   r = cmount->get_client()->describe_layout(path, &l);
   if (r < 0)
     return r;
-  return l.stripe_unit;
+  *stripe_unit = l.stripe_unit;
+  return 0;
 }
 
-extern "C" int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh)
+extern "C" int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh, uint32_t *stripe_count)
 {
   file_layout_t l;
   int r;
@@ -918,10 +920,11 @@ extern "C" int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
-  return l.stripe_count;
+  *stripe_count = l.stripe_count;
+  return 0;
 }
 
-extern "C" int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path)
+extern "C" int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path, uint32_t *stripe_count)
 {
   file_layout_t l;
   int r;
@@ -931,7 +934,8 @@ extern "C" int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const 
   r = cmount->get_client()->describe_layout(path, &l);
   if (r < 0)
     return r;
-  return l.stripe_count;
+  *stripe_count = l.stripe_count;
+  return 0;
 }
 
 extern "C" int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh, uint32_t *object_size)

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -934,7 +934,7 @@ extern "C" int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const 
   return l.stripe_count;
 }
 
-extern "C" int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh)
+extern "C" int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh, uint32_t *object_size)
 {
   file_layout_t l;
   int r;
@@ -944,10 +944,11 @@ extern "C" int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh)
   r = cmount->get_client()->fdescribe_layout(fh, &l);
   if (r < 0)
     return r;
-  return l.object_size;
+  *object_size = l.object_size;
+  return 0;
 }
 
-extern "C" int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path)
+extern "C" int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path, uint32_t *object_size)
 {
   file_layout_t l;
   int r;
@@ -957,7 +958,8 @@ extern "C" int ceph_get_path_object_size(struct ceph_mount_info *cmount, const c
   r = cmount->get_client()->describe_layout(path, &l);
   if (r < 0)
     return r;
-  return l.object_size;
+  *object_size = l.object_size;
+  return 0;
 }
 
 extern "C" int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh)

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -991,8 +991,9 @@ TEST(LibCephFS, BadFileDesc) {
 
   struct sockaddr_storage addr;
   ASSERT_EQ(ceph_get_file_stripe_address(cmount, -1, 0, &addr, 1), -EBADF);
-
-  ASSERT_EQ(ceph_get_file_stripe_unit(cmount, -1), -EBADF);
+  
+  uint32_t stripe_unit;
+  ASSERT_EQ(ceph_get_file_stripe_unit(cmount, -1, &stripe_unit), -EBADF);
   ASSERT_EQ(ceph_get_file_pool(cmount, -1), -EBADF);
   ASSERT_EQ(ceph_get_file_replication(cmount, -1), -EBADF);
 
@@ -1177,7 +1178,9 @@ TEST(LibCephFS, UseUnmounted) {
   EXPECT_EQ(-ENOTCONN, ceph_fsync(cmount, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_fstat(cmount, 0, &st));
   EXPECT_EQ(-ENOTCONN, ceph_sync_fs(cmount));
-  EXPECT_EQ(-ENOTCONN, ceph_get_file_stripe_unit(cmount, 0));
+  
+  uint32_t stripe_unit;
+  EXPECT_EQ(-ENOTCONN, ceph_get_file_stripe_unit(cmount, 0, &stripe_unit));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_pool(cmount, 0));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_pool_name(cmount, 0, NULL, 0));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_replication(cmount, 0));

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -994,7 +994,9 @@ TEST(LibCephFS, BadFileDesc) {
   
   uint32_t stripe_unit;
   ASSERT_EQ(ceph_get_file_stripe_unit(cmount, -1, &stripe_unit), -EBADF);
-  ASSERT_EQ(ceph_get_file_pool(cmount, -1), -EBADF);
+  
+  int64_t file_pool_id;
+  ASSERT_EQ(ceph_get_file_pool(cmount, -1, &file_pool_id), -EBADF);
   ASSERT_EQ(ceph_get_file_replication(cmount, -1), -EBADF);
 
   ceph_shutdown(cmount);
@@ -1181,7 +1183,9 @@ TEST(LibCephFS, UseUnmounted) {
   
   uint32_t stripe_unit;
   EXPECT_EQ(-ENOTCONN, ceph_get_file_stripe_unit(cmount, 0, &stripe_unit));
-  EXPECT_EQ(-ENOTCONN, ceph_get_file_pool(cmount, 0));
+  
+  int64_t file_pool_id;
+  EXPECT_EQ(-ENOTCONN, ceph_get_file_pool(cmount, 0, &file_pool_id));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_pool_name(cmount, 0, NULL, 0));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_replication(cmount, 0));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_stripe_address(cmount, 0, 0, NULL, 0));
@@ -1189,7 +1193,9 @@ TEST(LibCephFS, UseUnmounted) {
   EXPECT_EQ(-ENOTCONN, ceph_debug_get_fd_caps(cmount, 0));
   EXPECT_EQ(-ENOTCONN, ceph_debug_get_file_caps(cmount, "/path"));
   EXPECT_EQ(-ENOTCONN, ceph_get_stripe_unit_granularity(cmount));
-  EXPECT_EQ(-ENOTCONN, ceph_get_pool_id(cmount, "data"));
+  
+  int64_t pool_id;
+  EXPECT_EQ(-ENOTCONN, ceph_get_pool_id(cmount, "data", &pool_id));
   EXPECT_EQ(-ENOTCONN, ceph_get_pool_replication(cmount, 1));
 
   ceph_release(cmount);
@@ -1205,8 +1211,10 @@ TEST(LibCephFS, GetPoolId) {
   char name[80];
   memset(name, 0, sizeof(name));
   ASSERT_LE(0, ceph_get_path_pool_name(cmount, "/", name, sizeof(name)));
-  ASSERT_GE(ceph_get_pool_id(cmount, name), 0);
-  ASSERT_EQ(ceph_get_pool_id(cmount, "weflkjwelfjwlkejf"), -ENOENT);
+  
+  int64_t pool_id;
+  ASSERT_GE(ceph_get_pool_id(cmount, name, &pool_id), 0);
+  ASSERT_EQ(ceph_get_pool_id(cmount, "weflkjwelfjwlkejf", &pool_id), -ENOENT);
 
   ceph_shutdown(cmount);
 }


### PR DESCRIPTION
including：
fixup get object_size way
fixup get pool_id way
fixup get stripe_count&& stripe_unit way

fix the lowest cost, in front of the not fully use these function interfaces

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>