### PR TITLE
common: only call crypto::init once per CephContext

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -599,8 +599,10 @@ void CephContext::put() {
 
 void CephContext::init_crypto()
 {
-  ceph::crypto::init(this);
-  _crypto_inited = true;
+  if (!_crypto_inited) {
+    ceph::crypto::init(this);
+    _crypto_inited = true;
+  }
 }
 
 void CephContext::start_service_thread()


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17205

Signed-off-by: Casey Bodley <cbodley@redhat.com>