### PR TITLE
os/bluestore/BlueFS: factor unflushed log into runway calculation

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1284,8 +1284,9 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>& l,
   assert(!log_t.empty());
 
   // allocate some more space (before we run out)?
-  uint64_t runway = log_writer->file->fnode.get_allocated() - log_writer->pos;
-  if (runway < g_conf->bluefs_min_log_runway) {
+  int64_t runway = log_writer->file->fnode.get_allocated() -
+    log_writer->get_effective_write_pos();
+  if (runway < (int64_t)g_conf->bluefs_min_log_runway) {
     dout(10) << __func__ << " allocating more log runway (0x"
 	     << std::hex << runway << std::dec  << " remaining)" << dendl;
     while (new_log_writer) {

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -135,6 +135,10 @@ public:
     void append(bufferptr& bp) {
       buffer.append(bp);
     }
+
+    uint64_t get_effective_write_pos() {
+      return pos + buffer.length();
+    }
   };
 
   struct FileReaderBuffer {


### PR DESCRIPTION
Include the size of the in-memory buffer we haven't yet flushed
into the runway calculation when deciding whether to allocate
more log space.

Reported-by: Somnath Roy <somnath.roy@sandisk.com>
Signed-off-by: Sage Weil <sage@redhat.com>