### PR TITLE
bug fix for install-deps.sh

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -55,7 +55,7 @@ if [ x`uname`x = xFreeBSDx ]; then
 
     exit
 else
-    DISTRO=$(grep  "^ID=" /etc/os-release | sed "s/ID=//")
+    DISTRO=$(grep  "^ID=" /etc/os-release | sed "s/ID=//" | tr -d '"')
     case $DISTRO in
     debian|ubuntu|devuan)
         echo "Using apt-get to install dependencies"


### PR DESCRIPTION
Right now, the install-deps.sh can not run on centos, so fix
it.