### PR TITLE
os/bluestore: Hint based allocation in bitmap Allocator

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -226,11 +226,12 @@ public:
   virtual int64_t get_used_blocks() = 0;
 
   virtual void shutdown() = 0;
-  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block) {
+  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks,
+                               int64_t hint, int64_t *start_block) {
     debug_assert(0);
     return 0;
   }
-  virtual int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block) {
+  virtual int64_t alloc_blocks(int64_t num_blocks, int64_t hint, int64_t *start_block) {
     debug_assert(0);
     return 0;
   }
@@ -348,7 +349,8 @@ public:
   ~BitMapZone();
   void shutdown();
 
-  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block) {
+  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks,
+                               int64_t hint, int64_t *start_block) {
     debug_assert(0);
     return 0;
   }
@@ -359,7 +361,7 @@ public:
     return 0;
   }
 
-  int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
+  int64_t alloc_blocks(int64_t num_blocks, int64_t hint, int64_t *start_block);
   using BitMapArea::alloc_blocks_dis;
   int64_t alloc_blocks_dis(int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
@@ -406,7 +408,7 @@ protected:
   void init_common(int64_t total_blocks, int64_t zone_size_block, bool def);
 
   int64_t alloc_blocks_int_work(bool wait, bool wrap,
-                         int64_t num_blocks, int64_t *start_block);
+                         int64_t num_blocks, int64_t hint, int64_t *start_block);
   int64_t alloc_blocks_dis_int_work(bool wait, bool wrap, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
 
@@ -427,11 +429,11 @@ public:
     return m_total_blocks;
   }
 
-  virtual int64_t alloc_blocks_int(bool wait,
-                     int64_t num_blocks, int64_t *start_block);
+  virtual int64_t alloc_blocks_int(bool wait, int64_t num_blocks,
+		  int64_t hint, int64_t *start_block);
   using BitMapArea::alloc_blocks; //non-wait version
   using BitMapArea::alloc_blocks_dis; //non-wait version
-  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block);
+  virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t hint, int64_t *start_block);
   virtual int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks, int64_t hint,
@@ -464,8 +466,7 @@ public:
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock);
   void child_unlock(BitMapArea *child);
 
-  int64_t alloc_blocks_int(bool wait,
-                         int64_t num_blocks, int64_t *start_block);
+  int64_t alloc_blocks_int(bool wait, int64_t num_blocks, int64_t hint, int64_t *start_block);
   int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
   void free_blocks_int(int64_t start_block, int64_t num_blocks);
@@ -507,6 +508,10 @@ private:
   void init_check(int64_t total_blocks, int64_t zone_size_block,
                  bmap_alloc_mode_t mode, bool def, bool stats_on);
   int64_t alloc_blocks_dis_work(int64_t num_blocks, int64_t hint, ExtentList *block_list, bool reserved);
+  int64_t alloc_blocks_int(bool wait, int64_t num_blocks, int64_t hint, int64_t *start_block);
+
+  int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
+           int64_t hint, int64_t area_blk_off, ExtentList *block_list);
 
 public:
 
@@ -519,17 +524,12 @@ public:
   using BitMapAreaIN::alloc_blocks; //Wait version
   using BitMapAreaIN::alloc_blocks_dis; //Wait version
 
-  int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
-  int64_t alloc_blocks_res(int64_t num_blocks, int64_t *start_block);
+  int64_t alloc_blocks(int64_t num_blocks, int64_t hint, int64_t *start_block);
+  int64_t alloc_blocks_res(int64_t num_blocks, int64_t hint, int64_t *start_block);
   void free_blocks(int64_t start_block, int64_t num_blocks);
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
   void unreserve_blocks(int64_t blocks);
 
-  int64_t alloc_blocks_int(bool wait,
-                         int64_t num_blocks, int64_t *start_block);
-
-  int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
-           int64_t hint, int64_t area_blk_off, ExtentList *block_list);
   int64_t alloc_blocks_dis(int64_t num_blocks, int64_t hint, ExtentList *block_list);
   int64_t alloc_blocks_dis_res(int64_t num_blocks, int64_t hint, ExtentList *block_list);
 

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -405,6 +405,11 @@ protected:
   void init(int64_t total_blocks, int64_t zone_size_block, bool def);
   void init_common(int64_t total_blocks, int64_t zone_size_block, bool def);
 
+  int64_t alloc_blocks_int_work(bool wait, bool wrap,
+                         int64_t num_blocks, int64_t *start_block);
+  int64_t alloc_blocks_dis_int_work(bool wait, bool wrap, int64_t num_blocks, int64_t hint,
+        int64_t blk_off, ExtentList *block_list);  
+
 public:
   BitMapAreaIN();
   BitMapAreaIN(int64_t zone_num, int64_t total_blocks);
@@ -422,7 +427,7 @@ public:
     return m_total_blocks;
   }
 
-  virtual int64_t alloc_blocks_int(bool wait, bool wrap,
+  virtual int64_t alloc_blocks_int(bool wait,
                      int64_t num_blocks, int64_t *start_block);
   using BitMapArea::alloc_blocks; //non-wait version
   using BitMapArea::alloc_blocks_dis; //non-wait version
@@ -459,7 +464,7 @@ public:
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock);
   void child_unlock(BitMapArea *child);
 
-  int64_t alloc_blocks_int(bool wait, bool wrap,
+  int64_t alloc_blocks_int(bool wait,
                          int64_t num_blocks, int64_t *start_block);
   int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
@@ -520,6 +525,11 @@ public:
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
   void unreserve_blocks(int64_t blocks);
 
+  int64_t alloc_blocks_int(bool wait,
+                         int64_t num_blocks, int64_t *start_block);
+
+  int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
+           int64_t hint, int64_t area_blk_off, ExtentList *block_list);
   int64_t alloc_blocks_dis(int64_t num_blocks, int64_t hint, ExtentList *block_list);
   int64_t alloc_blocks_dis_res(int64_t num_blocks, int64_t hint, ExtentList *block_list);
 

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -236,12 +236,12 @@ public:
   }
 
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
-             int64_t blk_off, ExtentList *block_list) {
+             int64_t hint, int64_t blk_off, ExtentList *block_list) {
     debug_assert(0);
     return 0;
   }
   virtual int64_t alloc_blocks_dis(int64_t num_blocks,
-             int64_t blk_off, ExtentList *block_list) {
+             int64_t hint, int64_t blk_off, ExtentList *block_list) {
     debug_assert(0);
     return 0;
   }
@@ -354,14 +354,14 @@ public:
   }
 
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
-             int64_t blk_off, int64_t *block_list) {
+             int64_t hint, int64_t blk_off, int64_t *block_list) {
     debug_assert(0);
     return 0;
   }
 
   int64_t alloc_blocks(int64_t num_blocks, int64_t *start_block);
   using BitMapArea::alloc_blocks_dis;
-  int64_t alloc_blocks_dis(int64_t num_blocks,
+  int64_t alloc_blocks_dis(int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
 
@@ -427,9 +427,9 @@ public:
   using BitMapArea::alloc_blocks; //non-wait version
   using BitMapArea::alloc_blocks_dis; //non-wait version
   virtual int64_t alloc_blocks(bool wait, int64_t num_blocks, int64_t *start_block);
-  virtual int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
+  virtual int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
-  virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
+  virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
   virtual void set_blocks_used_int(int64_t start_block, int64_t num_blocks);
   virtual void set_blocks_used(int64_t start_block, int64_t num_blocks);
@@ -461,7 +461,7 @@ public:
 
   int64_t alloc_blocks_int(bool wait, bool wrap,
                          int64_t num_blocks, int64_t *start_block);
-  int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks,
+  int64_t alloc_blocks_dis_int(bool wait, int64_t num_blocks, int64_t hint,
         int64_t blk_off, ExtentList *block_list);  
   void free_blocks_int(int64_t start_block, int64_t num_blocks);
 
@@ -501,7 +501,7 @@ private:
   bool check_input_dis(int64_t num_blocks);
   void init_check(int64_t total_blocks, int64_t zone_size_block,
                  bmap_alloc_mode_t mode, bool def, bool stats_on);
-  int64_t alloc_blocks_dis_work(int64_t num_blocks, ExtentList *block_list, bool reserved);
+  int64_t alloc_blocks_dis_work(int64_t num_blocks, int64_t hint, ExtentList *block_list, bool reserved);
 
 public:
 
@@ -520,8 +520,8 @@ public:
   void set_blocks_used(int64_t start_block, int64_t num_blocks);
   void unreserve_blocks(int64_t blocks);
 
-  int64_t alloc_blocks_dis(int64_t num_blocks, ExtentList *block_list);
-  int64_t alloc_blocks_dis_res(int64_t num_blocks, ExtentList *block_list);
+  int64_t alloc_blocks_dis(int64_t num_blocks, int64_t hint, ExtentList *block_list);
+  int64_t alloc_blocks_dis_res(int64_t num_blocks, int64_t hint, ExtentList *block_list);
 
   void free_blocks_dis(int64_t num_blocks, ExtentList *block_list);
   bool is_allocated_dis(ExtentList *blocks, int64_t num_blocks);

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -220,7 +220,7 @@ int BitMapAllocator::alloc_extents_dis(
   int64_t num = 0;
   *count = 0;
 
-  num = m_bit_alloc->alloc_blocks_dis_res(nblks, &block_list);
+  num = m_bit_alloc->alloc_blocks_dis_res(nblks, hint, &block_list);
   if (num < nblks) {
     m_bit_alloc->free_blocks_dis(num, &block_list);
     return -ENOSPC;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -133,7 +133,7 @@ int BitMapAllocator::allocate(
   *offset = 0;
   *length = 0;
 
-  count = m_bit_alloc->alloc_blocks_res(nblks, &start_blk);
+  count = m_bit_alloc->alloc_blocks_res(nblks, hint / m_block_size, &start_blk);
   if (count == 0) {
     return -ENOSPC;
   }
@@ -164,9 +164,11 @@ int BitMapAllocator::alloc_extents(
      << dendl;
 
   if (alloc_unit > (uint64_t) m_block_size) {
-    return alloc_extents_cont(want_size, alloc_unit, max_alloc_size, hint, extents, count);     
+    return alloc_extents_cont(want_size, alloc_unit, 
+                              max_alloc_size, hint / m_block_size, extents, count);     
   } else {
-    return alloc_extents_dis(want_size, alloc_unit, max_alloc_size, hint, extents, count); 
+    return alloc_extents_dis(want_size, alloc_unit,
+                             max_alloc_size, hint / m_block_size, extents, count); 
   }
 }
 
@@ -192,7 +194,7 @@ int BitMapAllocator::alloc_extents_cont(
   while (need_blks > 0) {
     int64_t count = 0;
     count = m_bit_alloc->alloc_blocks_res(
-      (max_blks && need_blks > max_blks) ? max_blks : need_blks, &start_blk);
+      (max_blks && need_blks > max_blks) ? max_blks : need_blks, hint, &start_blk);
     if (count == 0) {
       break;
     }

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -45,7 +45,7 @@ TEST_P(AllocTest, test_alloc_init)
   alloc->shutdown(); 
   blocks = BitMapZone::get_total_blocks() * 2;
   init_alloc(blocks, 1);
-  ASSERT_EQ(alloc->get_free(), 0);
+  ASSERT_EQ(alloc->get_free(), (uint64_t) 0);
 }
 
 TEST_P(AllocTest, test_alloc_min_alloc)
@@ -186,6 +186,49 @@ TEST_P(AllocTest, test_alloc_failure)
                                    block_size * 512, (int64_t) 0, &extents, &count), -ENOSPC);
   }
 }
+
+TEST_P(AllocTest, test_alloc_hint_bmap)
+{
+  if (GetParam() == std::string("stupid")) {
+    return;
+  }
+  int64_t blocks = BitMapArea::get_level_factor(2) * 4;
+  int count = 0;
+  int64_t allocated = 0;
+  int64_t zone_size = 1024;
+  g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", std::to_string(zone_size));
+
+  init_alloc(blocks, 1);
+  alloc->init_add_free(0, blocks);
+
+  auto extents = std::vector<AllocExtent>
+          (zone_size * 4, AllocExtent(-1, -1));
+  alloc->reserve(blocks);
+
+  allocated = alloc->alloc_extents(1, 1, 1, zone_size, &extents, &count);
+  ASSERT_EQ(0, allocated);
+  ASSERT_EQ(1, count);
+  ASSERT_EQ(extents[0].offset, (uint64_t) zone_size);
+
+  allocated = alloc->alloc_extents(1, 1, 1, zone_size * 2 - 1, &extents, &count);
+  EXPECT_EQ(0, allocated);
+  ASSERT_EQ(1, count);
+  EXPECT_EQ((int64_t) extents[0].offset, zone_size * 2 - 1);
+
+  /*
+   * Wrap around with hint
+   */
+  allocated = alloc->alloc_extents(zone_size * 2, 1, 1,  blocks - zone_size * 2, &extents, &count);
+  EXPECT_EQ(0, allocated);
+  EXPECT_EQ(zone_size * 2, count);
+  EXPECT_EQ((int64_t)extents[0].offset, blocks - zone_size * 2);
+
+  allocated = alloc->alloc_extents(zone_size, 1, 1, blocks - zone_size, &extents, &count);
+  EXPECT_EQ(0, allocated);
+  EXPECT_EQ(zone_size, count);
+  EXPECT_EQ(extents[0].offset, (uint64_t) 0);
+}
+
 
 INSTANTIATE_TEST_CASE_P(
   Allocator,


### PR DESCRIPTION
This pull request has following changes:
1. Hint based allocation in BitMapAllocator.
2. Unit Test cases related to that.
3. Cleanup of wrap argument that is no more in use.