### PR TITLE
build/ops: fix /etc/os-release parsing in install-deps.sh

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -55,8 +55,8 @@ if [ x`uname`x = xFreeBSDx ]; then
 
     exit
 else
-    DISTRO=$(grep  "^ID=" /etc/os-release | sed "s/ID=//")
-    case $DISTRO in
+    source /etc/os-release
+    case $ID in
     debian|ubuntu|devuan)
         echo "Using apt-get to install dependencies"
         $SUDO apt-get install -y lsb-release devscripts equivs
@@ -118,7 +118,7 @@ else
         $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;
     *)
-        echo "$DISTRO is unknown, dependencies will have to be installed manually."
+        echo "$ID is unknown, dependencies will have to be installed manually."
         ;;
     esac
 fi


### PR DESCRIPTION
85a370e35fc42031a7f7e24dea9e50a649c0f309 introduced the DISTRO variable whose
value was obtained by parsing /etc/os-release like this:

DISTRO=$(grep  "^ID=" /etc/os-release | sed "s/ID=//")

This unfortunately picks up the double-quotes, so on a CentOS system DISTRO
will be equal to '"centos"'.

Signed-off-by: Nathan Cutler <ncutler@suse.com>