### PR TITLE
cmake: fix librados compiling error

### DIFF
--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -43,9 +43,9 @@ endfunction()
 
 set(osd_traces oprequest.tp osd.tp pg.tp)
 add_tracing_library(osd_tp "${osd_traces}" 1.0.0)
-add_tracing_library(rados_tp librados.tp 2.0.0)
+add_tracing_library(librados_tp librados.tp 2.0.0)
 add_tracing_library(rbd_tp librbd.tp 1.0.0)
 add_tracing_library(os_tp objectstore.tp 1.0.0)
 
-install(TARGETS rados_tp osd_tp rbd_tp os_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(TARGETS librados_tp osd_tp rbd_tp os_tp DESTINATION ${CMAKE_INSTALL_LIBDIR})
 


### PR DESCRIPTION
The build error happened with the following message:
    ```
    /var/ceph/ceph/src/librados/librados.cc:47:30: fatal error:
    tracing/librados.h: No such file or directory
     #include "tracing/librados.h"
                                  ^
    compilation terminated.
    ```
Actually, this issue was fixed by commit: 5e03ff098166 (
"cmake: fix the tracing header dependencies"). However,
it comes up again becuase of this commit: 0a717593c0c3 (
"cmake: let librados_api_obj depend on librados-tp"), which
forgets to replace "rados-tp" with "librados-tp". So, complete
this change accordingly.

Signed-off-by: Eric Ren <zren@suse.com>