### PR TITLE
don't start ceph-osd at udev rules

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2869,13 +2869,6 @@ def start_daemon(
                     'ceph-osd@{osd_id}'.format(osd_id=osd_id),
                 ],
             )
-            command_check_call(
-                [
-                    'systemctl',
-                    'start',
-                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
-                ],
-            )
         elif os.path.exists(os.path.join(path, 'openrc')):
             base_script = '/etc/init.d/ceph-osd'
             osd_script = '{base}.{osd_id}'.format(


### PR DESCRIPTION
When I use cgroup to limit the ceph-osd and ceph-mon resource, I missed a problem. I write some cgroup  rules, and it works fine. But when I reboot the system, I found it doesn't work, because the cgroup will start after udev rules.
Finally, I know when the system reboot, ceph osd daemons will start by udev rules, not the ceph-osd@.serivce. So I want udev rules only mount disk to osd path, and ceph-osd@.service start the osd daemons. It works fine.
Signed-off-by: zealoussnow nguzcf@gmail.com