### PR TITLE
hammer: librbd: ceph 10.2.2 rbd status on image format 2 returns "(2) No such file or directory"

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1029,6 +1029,14 @@ reprotect_and_return_err:
     extra = rand() % 0xFFFFFFFF;
     bid_ss << std::hex << bid << std::hex << extra;
     id = bid_ss.str();
+
+    // ensure the image id won't overflow the fixed block name size
+    const size_t max_id_length = RBD_MAX_BLOCK_NAME_SIZE -
+                                 strlen(RBD_DATA_PREFIX) - 1;
+    if (id.length() > max_id_length) {
+      id = id.substr(id.length() - max_id_length);
+    }
+
     r = cls_client::set_id(&io_ctx, id_obj, id);
     if (r < 0) {
       lderr(cct) << "error setting image id: " << cpp_strerror(r) << dendl;


### PR DESCRIPTION
http://tracker.ceph.com/issues/16952
