### PR TITLE
rgw: fix failed to create bucket if a non-master zonegroup has a single zone

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3794,9 +3794,9 @@ int RGWRados::init_complete()
     obj_expirer->start_processor();
   }
 
-  /* not point of running sync thread if there is a single zone or
-     we don't have a master zone configured or there is no rest_master_conn */
-  if (get_zonegroup().zones.size() < 2 || get_zonegroup().master_zone.empty() || !rest_master_conn) {
+  /* not point of running sync thread if  we don't have a master zone configured 
+    or there is no rest_master_conn */
+  if (get_zonegroup().master_zone.empty() || !rest_master_conn) {
     run_sync_thread = false;
   }
 


### PR DESCRIPTION
If a non-master zonegroup has a single zone, the metadata sync thread not running and
the non-master zonegroup can't sync user from master zonegroup,
so we can't create bucket(or other metadata update) in it
because the authenticated user not found in the zone of non-master zonegroup.

Signed-off-by: weiqiaomiao <wei.qiaomiao@zte.com.cn>