### PR TITLE
rgw: fix a bug in rgw cache in delete_system_obj and get_system_obj.

### DIFF
--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -188,9 +188,6 @@ class RGWCache  : public T
   }
 
   void normalize_pool_and_obj(rgw_pool& src_pool, const string& src_obj, rgw_pool& dst_pool, string& dst_obj);
-  string normal_name(rgw_raw_obj& obj) {
-    return normal_name(obj.pool, obj.oid);
-  }
 
   int init_rados() override {
     int ret;
@@ -268,7 +265,7 @@ int RGWCache<T>::delete_system_obj(rgw_raw_obj& obj, RGWObjVersionTracker *objv_
   string oid;
   normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
 
-  string name = normal_name(obj);
+  string name = normal_name(pool, oid);
   cache.remove(name);
 
   ObjectCacheInfo info;
@@ -290,7 +287,7 @@ int RGWCache<T>::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::R
   if (ofs != 0)
     return T::get_system_obj(obj_ctx, read_state, objv_tracker, obj, obl, ofs, end, attrs, cache_info);
 
-  string name = normal_name(obj.pool, oid);
+  string name = normal_name(pool, oid);
 
   ObjectCacheInfo info;
 


### PR DESCRIPTION
Cache's key is generated by function normal_name(bucket,oid), and these
two parameters are generated by function normalize_bucket_and_obj. But in
delete_system_obj and get_system_obj it doesn't work like that. In other
place ,like put_system_obj_impl, keys are always generated in that way.
Signed-off-by: Zhang Shaowen zhangshaowen@cmss.chinamobile.com
