### PR TITLE
os/bluestore/BlueFS: do not start racing async compaction

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -998,10 +998,14 @@ bool BlueFS::_should_compact_log()
   float ratio = (float)current / (float)expected;
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
-	   << " ratio " << ratio << dendl;
-  if (current < g_conf->bluefs_log_compact_min_size ||
-      ratio < g_conf->bluefs_log_compact_min_ratio)
+	   << " ratio " << ratio
+	   << (log_flushing ? " (async compaction in progress)" : "")
+	   << dendl;
+  if (log_flushing ||
+      current < g_conf->bluefs_log_compact_min_size ||
+      ratio < g_conf->bluefs_log_compact_min_ratio) {
     return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
Compaction is triggred from sync_metadata.  If one compaction is
in progress and another thread also calls sync_metadata, do not
trigger a second async compaction!

Signed-off-by: Sage Weil <sage@redhat.com>