### PR TITLE
build: drop dryrun of autogen.sh from run-cmake-check.sh script

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -47,7 +47,6 @@ function run() {
     if test -f ./install-deps.sh ; then
 	$DRY_RUN ./install-deps.sh || return 1
     fi
-    $DRY_RUN ./autogen.sh || return 1
     $DRY_RUN mkdir build
     $DRY_RUN cd build
     $DRY_RUN cmake "$@" ../


### PR DESCRIPTION
Introduced by https://github.com/ceph/ceph/pull/11007.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>