### PR TITLE
os/bluestore: must write onode when do truncate

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7540,6 +7540,9 @@ int BlueStore::_do_truncate(
 	   << " 0x" << std::hex << offset << std::dec << dendl;
   _dump_onode(o, 30);
 
+  o->exists = true;
+  txc->write_onode(o);
+
   if (offset == o->onode.size)
     return 0;
 
@@ -7557,8 +7560,6 @@ int BlueStore::_do_truncate(
   }
 
   o->onode.size = offset;
-
-  txc->write_onode(o);
   return 0;
 }
 


### PR DESCRIPTION
If this is a new object and offset is 0, we still need to write onode

Partial revert 420150d
And set exists = true if previous remove this obj

Signed-off-by: Haomai Wang <haomai@xsky.com>