### PR TITLE
systemd: Flush OSD Journal after stop

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -11,6 +11,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
+ExecStopPost=/usr/bin/ceph-osd -f --cluster ${CLUSTERD} --id %i --setuser ceph --setgroup ceph --flush-journal
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
After stopping a OSD flush its journal to the data store. This makes sure
the data store holds a full copy of the OSD's data without a need of the journal
device.

When using external journals this makes the OSD disks more hot-pluggable between
different nodes.

On a different node one can simply create a blank journal for the OSD and run the
OSD again.

Signed-off-by: Wido den Hollander <wido@42on.com>