### PR TITLE
os/bluestore: fix offset bug in _do_write_small.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6964,7 +6964,7 @@ void BlueStore::_do_write_small(
   if (ep != o->extent_map.extent_map.begin()) {
     --ep;
     b = ep->blob;
-    if (ep->logical_offset + b->get_blob().get_ondisk_length() <= offset) {
+    if ((ep->logical_offset - ep->blob_offset) + b->get_blob().get_ondisk_length() <= offset) {
       ++ep;
     }
   }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6964,7 +6964,7 @@ void BlueStore::_do_write_small(
   if (ep != o->extent_map.extent_map.begin()) {
     --ep;
     b = ep->blob;
-    if ((ep->logical_offset - ep->blob_offset) + b->get_blob().get_ondisk_length() <= offset) {
+    if (ep->logical_offset - ep->blob_offset + b->get_blob().get_ondisk_length() <= offset) {
       ++ep;
     }
   }


### PR DESCRIPTION
  The statement "if (ep->logical_offset + b->get_blob().get_ondisk_length() <= offset)" which try to judge if the writing offset is in the current Blob may be wrong.

Signed-off-by: feng yu amoxic@126.com