### PR TITLE
rpm: no @TARBALL_BASENAME@ on SUSE, add appropriate conditionals

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -65,7 +65,12 @@ License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-auto
 Group:         System/Filesystems
 %endif
 URL:		http://ceph.com/
+%if 0%{?rhel}
 Source0:	http://ceph.com/download/@TARBALL_BASENAME@.tar.bz2
+%endif
+%if ! 0%{?rhel}
+Source0:	%{name}-%{version}.tar.bz2
+%endif
 %if 0%{?suse_version}
 %if 0%{?is_opensuse}
 ExclusiveArch:  x86_64 aarch64 ppc64 ppc64le

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -642,7 +642,12 @@ python-cephfs instead.
 # common
 #################################################################################
 %prep
+%if 0%{?rhel}
 %autosetup -p1 -n @TARBALL_BASENAME@
+%endif
+%if ! 0%{?rhel}
+%autosetup -p1
+%endif
 
 %build
 %if 0%{with cephfs_java}


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>