### PR TITLE
librados: Fix deadlock in watch_flush

### DIFF
--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -62,6 +62,7 @@ private:
   Objecter *objecter;
 
   Mutex lock;
+  Mutex shutdown_lock;
   Cond cond;
   SafeTimer timer;
   int refcnt;


### PR DESCRIPTION
In previous code, in the watch_flush, it is waiting on conditon
with holding the "lock". The condition will only be signal by
finisher thread, but sadly, in some cases,when finisher queue
is not empty, some context need to take the "lock", thus deadlock.

Fixes:http://tracker.ceph.com/issues/17252

Signed-off-by: Xiaoxi Chen xiaoxchen@ebay.com
