### PR TITLE
librbd: possible deadlock if cluster connection closed after image

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -55,13 +55,19 @@ struct C_UnwatchAndFlush : public Context {
       r = rados.aio_watch_flush(aio_comp);
       assert(r == 0);
       aio_comp->release();
-    } else {
-      Context::complete(ret_val);
+      return;
     }
+
+    // ensure our reference to the RadosClient is released prior
+    // to completing the callback to avoid racing an explicit
+    // librados shutdown
+    Context *ctx = on_finish;
+    delete this;
+
+    ctx->complete(ret_val);
   }
 
   virtual void finish(int r) override {
-    on_finish->complete(r);
   }
 };
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17254
Signed-off-by: Jason Dillaman <dillaman@redhat.com>