### PR TITLE
rpm: move hdparm requirement to ceph-osd package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -227,7 +227,6 @@ Requires:      grep
 Requires:      xfsprogs
 Requires:      logrotate
 Requires:      util-linux
-Requires:      hdparm
 Requires:      cryptsetup
 Requires:      findutils
 Requires:      which
@@ -357,6 +356,7 @@ managers such as Pacemaker.
 Summary:	Ceph Object Storage Daemon
 Group:		System Environment/Base
 Requires:	ceph-base = %{epoch}:%{version}-%{release}
+Requires:	hdparm
 # for sgdisk, used by ceph-disk
 %if 0%{?fedora} || 0%{?rhel}
 Requires:	gdisk


### PR DESCRIPTION
`ceph-objectstore-tool` runs hdparm, but that only happens on OSD nodes.  Move the package requirement to the ceph-osd sub-package.

This reduces dependency bloat for other nodes, since Mon, RGW, and MDS nodes do not need hdparm.

Refs: http://tracker.ceph.com/issues/17177