### PR TITLE
os/bluestore: fix leak of result-checking of _fsck_check_extents

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4145,7 +4145,7 @@ int BlueStore::fsck()
 	for (auto &r : shared_blob.ref_map.ref_map) {
 	  extents.emplace_back(bluestore_pextent_t(r.first, r.second.length));
 	}
-	_fsck_check_extents(p->second.oids.front(),
+	errors += _fsck_check_extents(p->second.oids.front(),
 			    extents,
 			    p->second.compressed,
 			    used_blocks, expected_statfs);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1702,6 +1702,8 @@ void BlueStore::ExtentMap::decode_some(bufferlist& bl)
     ++n;
     extent_map.insert(*le);
   }
+
+  assert(n == num);
 }
 
 void BlueStore::ExtentMap::encode_spanning_blobs(bufferlist& bl)

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -175,15 +175,6 @@ struct bluestore_extent_ref_map_t {
     return ref_map.empty();
   }
 
-  // raw reference insertion that assumes no conflicts/interference
-  // with the existing references
-  void fill(uint32_t offset, uint32_t len, int refs = 1) {
-    auto p = ref_map.insert(
-        map<uint32_t,record_t>::value_type(offset,
-                                           record_t(len, refs))).first;
-    _maybe_merge_left(p);
-  }
-
   void get(uint32_t offset, uint32_t len);
   void put(uint32_t offset, uint32_t len, vector<bluestore_pextent_t> *release);
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -590,12 +590,6 @@ WRITE_CLASS_ENCODER(bluestore_shared_blob_t)
 
 ostream& operator<<(ostream& out, const bluestore_shared_blob_t& o);
 
-
-
-/// blob id: positive = local, negative = shared bnode
-typedef int64_t bluestore_blob_id_t;
-
-
 /// onode: per-object metadata
 struct bluestore_onode_t {
   uint64_t nid = 0;                    ///< numeric id (locally unique)


### PR DESCRIPTION
We shall not ignore the result of _fsck_check_extents() durint fsck().

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>