### PR TITLE
OSD: avoid FileStore finisher deadlock in osd_lock when shutdown OSD

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6833,11 +6833,11 @@ void OSD::handle_osd_map(MOSDMap *m)
 void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 {
   dout(10) << __func__ << " " << first << ".." << last << dendl;
-  Mutex::Locker l(osd_lock);
   if (is_stopping()) {
     dout(10) << __func__ << " bailing, we are shutting down" << dendl;
     return;
   }
+  Mutex::Locker l(osd_lock);
   map_lock.get_write();
 
   bool do_shutdown = false;


### PR DESCRIPTION
When OSD receive signal to shutdown, it will try to call ObjectStore->flush
to make sure all pending IO done. But previous OSDMap committing IO may
complete Context in OSD::_committed_osd_maps which need to acquire osd_lock
firstly. So OSD shutdown thread need to wait for finisher done, and finisher
is acquiring osd_lock. dead lock happended

Signed-off-by: Haomai Wang <haomai@xsky.com>