### PR TITLE
Zipkin tracing [GSOC 2016]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,12 @@ if(WITH_XIO)
 set(HAVE_XIO ${XIO_FOUND})
 endif(WITH_XIO)
 
+option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
+if(WITH_BLKIN)
+  find_package(blkin REQUIRED)
+  include_directories(${BLKIN_INCLUDE_DIR})
+endif(WITH_BLKIN)
+
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 

--- a/cmake/modules/Findblkin.cmake
+++ b/cmake/modules/Findblkin.cmake
@@ -1,0 +1,23 @@
+# - Try to find blkin
+# Once done this will define
+#  BLKIN_FOUND - System has blkin
+#  BLKIN_INCLUDE_DIR - The blkin include directories
+#  BLKIN_LIBRARIES - The libraries needed to use blkin
+
+find_package(PkgConfig)
+pkg_check_modules(PC_BLKIN QUIET libblkin)
+
+find_path(BLKIN_INCLUDE_DIR ztracer.hpp
+	HINTS ${PC_BLKIN_INCLUDEDIR} ${PC_BLKIN_INCLUDE_DIRS}
+	PATH_SUFFIXES blkin)
+find_library(BLKIN_LIBRARY NAMES blkin
+	HINTS ${PC_BLKIN_LIBDIR} ${PC_BLKIN_LIBRARY_DIRS})
+
+include(FindPackageHandleStandardArgs)
+# handle the QUIETLY and REQUIRED arguments and set BLKIN_FOUND to TRUE
+# if all listed variables are TRUE
+find_package_handle_standard_args(blkin DEFAULT_MSG
+	BLKIN_LIBRARY BLKIN_INCLUDE_DIR)
+
+set(BLKIN_LIBRARIES ${BLKIN_LIBRARY} lttng-ust)
+mark_as_advanced(BLKIN_INCLUDE_DIR BLKIN_LIBRARIES)

--- a/do_autogen.sh
+++ b/do_autogen.sh
@@ -4,6 +4,7 @@ usage() {
     cat <<EOF
 do_autogen.sh: make a ceph build by running autogen, etc.
 
+-b                               blkin tracing
 -C <parameter>                   add parameters to configure
 -c                               use cryptopp
 -d <level>                       debug build
@@ -36,9 +37,10 @@ verbose=0
 profile=0
 rocksdb=1
 CONFIGURE_FLAGS="--disable-static --with-lttng"
-while getopts  "C:cd:e:hjJLO:pPRTv" flag
+while getopts  "bC:cd:e:hjJLO:pPRTv" flag
 do
     case $flag in
+    b) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-blkin";;
     C) CONFIGURE_FLAGS="$CONFIGURE_FLAGS $OPTARG";;
     c) CONFIGURE_FLAGS="$CONFIGURE_FLAGS --with-cryptopp --without-nss";;
     d) debug_level=$OPTARG;;

--- a/doc/dev/blkin.rst
+++ b/doc/dev/blkin.rst
@@ -1,0 +1,167 @@
+=========================
+ Tracing Ceph With BlkKin
+=========================
+
+Ceph can use Blkin, a library created by Marios Kogias and others,
+which enables tracking a specific request from the time it enters
+the system at higher levels till it is finally served by RADOS.
+
+In general, Blkin implements the Dapper_ tracing semantics
+in order to show the causal relationships between the different
+processing phases that an IO request may trigger. The goal is an
+end-to-end visualisation of the request's route in the system,
+accompanied by information concerning latencies in each processing
+phase. Thanks to LTTng this can happen with a minimal overhead and
+in realtime. The LTTng traces can then be visualized with Twitter's
+Zipkin_.
+
+.. _Dapper: http://static.googleusercontent.com/media/research.google.com/el//pubs/archive/36356.pdf
+.. _Zipkin: http://twitter.github.io/zipkin/
+
+
+Installing Blkin
+================
+
+You can install Markos Kogias' upstream Blkin_ by hand.::
+
+  cd blkin/
+  make && make install
+
+or build distribution packages using DistroReadyBlkin_, which also comes with
+pkgconfig support. If you choose the latter, then you must generate the
+configure and make files first.::
+
+  cd blkin
+  autoreconf -i
+
+.. _Blkin: https://github.com/marioskogias/blkin
+.. _DistroReadyBlkin: https://github.com/agshew/blkin
+
+
+Configuring Ceph with Blkin
+===========================
+
+If you built and installed Blkin by hand, rather than building and
+installing packages, then set these variables before configuring
+Ceph.::
+
+  export BLKIN_CFLAGS=-Iblkin/
+  export BLKIN_LIBS=-lzipkin-cpp
+
+Since there are separate lttng and blkin changes to Ceph, you may
+want to configure with something like::
+
+  ./configure --with-blkin --without-lttng --with-debug
+
+
+Testing Blkin
+=============
+
+It's easy to test Ceph's Blkin tracing. Let's assume you don't have
+Ceph already running, and you compiled Ceph with Blkin support but
+you did't install it. Then launch Ceph with the ``vstart.sh`` script
+in Ceph's src directgory so you can see the possible tracepoints.::
+
+  cd src
+  OSD=3 MON=3 RGW=1 ./vstart.sh -n
+  lttng list --userspace
+
+You'll see something like the following:::
+
+  UST events:
+  -------------
+  PID: 8987 - Name: ./ceph-osd
+        zipkin:timestamp (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        zipkin:keyval (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        ust_baddr_statedump:soinfo (loglevel: TRACE_DEBUG_LINE (13)) (type: tracepoint)
+
+  PID: 8407 - Name: ./ceph-mon
+        zipkin:timestamp (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        zipkin:keyval (loglevel: TRACE_WARNING (4)) (type: tracepoint)
+        ust_baddr_statedump:soinfo (loglevel: TRACE_DEBUG_LINE (13)) (type: tracepoint)
+
+  ...
+
+Next, stop Ceph so that the tracepoints can be enabled.::
+
+  ./stop.sh
+
+Start up an LTTng session and enable the tracepoints.::
+
+  lttng create blkin-test
+  lttng enable-event --userspace zipkin:timestamp
+  lttng enable-event --userspace zipkin:keyval
+  lttng start
+
+Then start up Ceph again.::
+
+  OSD=3 MON=3 RGW=1 ./vstart.sh -n
+
+You may want to check that ceph is up.::
+
+  ./ceph status
+
+Now put something in usin rados, check that it made it, get it back, and remove it.::
+
+  ./rados mkpool test-blkin
+  ./rados put test-object-1 ./vstart.sh --pool=test-blkin
+  ./rados -p test-blkin ls
+  ./ceph osd map test-blkin test-object-1
+  ./rados get test-object-1 ./vstart-copy.sh --pool=test-blkin
+  md5sum vstart*
+  ./rados rm test-object-1 --pool=test-blkin
+
+You could also use the example in ``examples/librados/`` or ``rados bench``.
+
+Then stop the LTTng session and see what was collected.::
+
+  lttng stop
+  lttng view
+
+You'll see something like:::
+
+  [13:09:07.755054973] (+?.?????????) scruffy zipkin:timestamp: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, event = "Message allocated" }
+  [13:09:07.755071569] (+0.000016596) scruffy zipkin:keyval: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, key = "Type", val = "MOSDOp" }
+  [13:09:07.755074217] (+0.000002648) scruffy zipkin:keyval: { cpu_id = 5 }, { trace_name = "Main", service_name = "MOSDOp", port_no = 0, ip = "0.0.0.0", trace_id = 7492589359882233221, span_id = 2694140257089376129, parent_span_id = 0, key = "Reqid", val = "client.4126.0:1" }
+  ...
+
+
+Install  Zipkin
+===============
+One of the points of using Blkin is so that you can look at the traces
+using Zipkin. Users should run Zipkin as a tracepoints collector and
+also a web service, which means users need to run three services,
+zipkin-collector, zipkin-query and zipkin-web.
+
+Download Zipkin Package::
+
+  wget https://github.com/twitter/zipkin/archive/1.1.0.tar.gz
+  tar zxf 1.1.0.tar.gz
+  cd zipkin-1.1.0
+  bin/collector cassandra &
+  bin/query cassandra &
+  bin/web &
+
+Check Zipkin::
+
+  bin/test
+  Browse http://${zipkin-web-ip}:8080
+
+
+Show Ceph's Blkin Traces in Zipkin-web
+======================================
+Blkin provides a script which translates lttng result to Zipkin
+(Dapper) semantics.
+
+Send lttng data to Zipkin::
+
+  python3 babeltrace_zipkin.py ${lttng-traces-dir}/${blkin-test}/ust/uid/0/64-bit/ -p ${zipkin-collector-port(9410 by default)} -s ${zipkin-collector-ip}
+
+Example::
+
+  python3 babeltrace_zipkin.py ~/lttng-traces-dir/blkin-test-20150225-160222/ust/uid/0/64-bit/ -p 9410 -s 127.0.0.1
+
+Check Ceph traces on webpage::
+
+  Browse http://${zipkin-web-ip}:8080
+  Click "Find traces"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -488,6 +488,7 @@ endif(HAVE_ARMV8_CRC)
 
 add_library(common_utf8 STATIC common/utf8.c)
 
+target_link_libraries(common json_spirit common_utf8 erasure_code rt uuid resolv ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES} ${BLKIN_LIBRARIES})
 if(${WITH_LTTNG})
   add_subdirectory(tracing)
 endif(${WITH_LTTNG})

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -17,7 +17,8 @@ class ObjecterWriteback : public WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish) {
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        ZTracer::Trace *trace) {
     m_objecter->read_trunc(oid, oloc, off, len, snapid, pbl, 0,
 			   trunc_size, trunc_seq,
 			   new C_OnFinisher(new C_Lock(m_lock, onfinish),
@@ -34,7 +35,7 @@ class ObjecterWriteback : public WritebackHandler {
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit) {
+			   Context *oncommit, ZTracer::Trace *trace) {
     return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
 				   trunc_size, trunc_seq, NULL,
 				   new C_OnFinisher(new C_Lock(m_lock,

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -185,6 +185,8 @@ protected:
 public:
   ZTracer::Trace osd_trace;
   ZTracer::Trace pg_trace;
+  ZTracer::Trace store_trace;
+  ZTracer::Trace journal_trace;
 
   virtual ~TrackedOp() {}
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -18,6 +18,7 @@
 #include <include/utime.h>
 #include "common/Mutex.h"
 #include "common/histogram.h"
+#include "common/zipkin_trace.h"
 #include "include/xlist.h"
 #include "msg/Message.h"
 #include "include/memory.h"
@@ -182,6 +183,8 @@ protected:
   virtual void _unregistered() {};
 
 public:
+  ZTracer::Trace osd_trace;
+
   virtual ~TrackedOp() {}
 
   const utime_t& get_initiated() const {

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -184,6 +184,7 @@ protected:
 
 public:
   ZTracer::Trace osd_trace;
+  ZTracer::Trace pg_trace;
 
   virtual ~TrackedOp() {}
 

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -24,6 +24,7 @@
 #include "common/safe_io.h"
 #include "common/valgrind.h"
 #include "common/version.h"
+#include "common/zipkin_trace.h"
 #include "include/color.h"
 
 #include <errno.h>

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -123,6 +123,7 @@ void complain_about_parse_errors(CephContext *cct,
 void common_init_finish(CephContext *cct)
 {
   cct->init_crypto();
+  ZTracer::ztrace_init();
 
   int flags = cct->get_init_flags();
   if (!(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -906,6 +906,7 @@ OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64M
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
 OPTION(osd_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all osd requests
+OPTION(osdc_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all objecter requests
 
 OPTION(osd_discard_disconnected_ops, OPT_BOOL, true)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -905,6 +905,8 @@ OPTION(osd_bench_large_size_max_throughput, OPT_U64, 100 << 20) // 100 MB/s
 OPTION(osd_bench_max_block_size, OPT_U64, 64 << 20) // cap the block size at 64MB
 OPTION(osd_bench_duration, OPT_U32, 30) // duration of 'osd bench', capped at 30s to avoid triggering timeouts
 
+OPTION(osd_blkin_trace_all, OPT_BOOL, false) // create a blkin trace for all osd requests
+
 OPTION(osd_discard_disconnected_ops, OPT_BOOL, true)
 
 OPTION(memstore_device_bytes, OPT_U64, 1024*1024*1024)

--- a/src/common/zipkin_trace.h
+++ b/src/common/zipkin_trace.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef COMMON_ZIPKIN_TRACE_H
+#define COMMON_ZIPKIN_TRACE_H
+
+#include <string>
+#include "acconfig.h"
+
+#ifdef WITH_BLKIN
+
+#include <ztracer.hpp>
+
+#else // !WITH_BLKIN
+
+// add stubs for noop Trace and Endpoint
+struct blkin_trace_info {};
+
+namespace ZTracer
+{
+static inline int ztrace_init() { return 0; }
+
+class Endpoint {
+ public:
+  Endpoint(const char *name) {}
+  Endpoint(const char *ip, int port, const char *name) {}
+
+  void copy_ip(const std::string &newip) {}
+  void copy_name(const std::string &newname) {}
+  void copy_address_from(const Endpoint *endpoint) {}
+  void share_address_from(const Endpoint *endpoint) {}
+  void set_port(int p) {}
+};
+
+class Trace {
+ public:
+  Trace() {}
+  Trace(const char *name, const Endpoint *ep, const Trace *parent = NULL) {}
+  Trace(const char *name, const Endpoint *ep,
+        const blkin_trace_info *i, bool child=false) {}
+
+  bool valid() const { return false; }
+  operator bool() const { return false; }
+
+  int init(const char *name, const Endpoint *ep, const Trace *parent = NULL) {
+    return 0;
+  }
+  int init(const char *name, const Endpoint *ep,
+           const blkin_trace_info *i, bool child=false) {
+    return 0;
+  }
+
+  void copy_name(const std::string &newname) {}
+
+  const blkin_trace_info* get_info() const { return NULL; }
+  void set_info(const blkin_trace_info *i) {}
+
+  void keyval(const char *key, const char *val) const {}
+  void keyval(const char *key, int64_t val) const {}
+  void keyval(const char *key, const char *val, const Endpoint *ep) const {}
+  void keyval(const char *key, int64_t val, const Endpoint *ep) const {}
+
+  void event(const char *event) const {}
+  void event(const char *event, const Endpoint *ep) const {}
+};
+} // namespace ZTrace
+
+#endif // !WITH_BLKIN
+
+#endif // COMMON_ZIPKIN_TRACE_H

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -76,6 +76,7 @@
 #define CEPH_FEATURE_OSD_HITSET_GMT (1ULL<<54)
 #define CEPH_FEATURE_HAMMER_0_94_4 (1ULL<<55)
 #define CEPH_FEATURE_NEW_OSDOP_ENCODING   (1ULL<<56) /* New, v7 encoding */
+#define CEPH_FEATURE_BLKIN_TRACING (1ULL<<57) // enabled by ifdef, don't overlap
 #define CEPH_FEATURE_MON_STATEFUL_SUB (1ULL<<57) /* stateful mon subscription */
 #define CEPH_FEATURE_MON_ROUTE_OSDMAP (1ULL<<57) /* peon sends osdmaps */
 #define CEPH_FEATURE_OSDSUBOP_NO_SNAPCONTEXT (1ULL<<57) /* overlap, drop unused SnapContext in v12 */
@@ -112,6 +113,13 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 		return f;
 	}
 }
+
+// conditionally include blkin in CEPH_FEATURES_ALL/SUPPORTED_DEFAULT
+#ifdef WITH_BLKIN
+#define CEPH_FEATURES_BLKIN CEPH_FEATURE_BLKIN_TRACING
+#else
+#define CEPH_FEATURES_BLKIN 0
+#endif
 
 /*
  * Features supported.  Should be everything above.
@@ -176,6 +184,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
          CEPH_FEATURE_OSD_PROXY_WRITE_FEATURES |         \
 	 CEPH_FEATURE_OSD_HITSET_GMT |			 \
 	 CEPH_FEATURE_HAMMER_0_94_4 |		 \
+	 CEPH_FEATURES_BLKIN | \
 	 CEPH_FEATURE_MON_STATEFUL_SUB |	 \
 	 CEPH_FEATURE_MON_ROUTE_OSDMAP |	 \
 	 CEPH_FEATURE_CRUSH_TUNABLES5 |	    \

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -258,8 +258,8 @@
 /* Version number of package */
 #cmakedefine VERSION "@VERSION@"
 
-/* Defined if pthread_setname_np() is available */
-#cmakedefine HAVE_PTHREAD_SETNAME_NP 1
+/* Defined if blkin enabled */
+#cmakedefine WITH_BLKIN
 
 /* Defined if pthread_set_name_np() is available */
 #cmakedefine HAVE_PTHREAD_SET_NAME_NP

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -332,6 +332,12 @@ typedef void *rados_write_op_t;
 typedef void *rados_read_op_t;
 
 /**
+ * @struct blkin_trace_info
+ * blkin trace information for Zipkin tracing
+ */
+struct blkin_trace_info;
+
+/**
  * Get the version of librados.
  *
  * The version number is major.minor.extra. Note that this is

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1005,6 +1005,10 @@ namespace librados
 		    ObjectWriteOperation *op, snap_t seq,
 		    std::vector<snap_t>& snaps);
     int aio_operate(const std::string& oid, AioCompletion *c,
+        ObjectWriteOperation *op, snap_t seq,
+        std::vector<snap_t>& snaps,
+        const blkin_trace_info *trace_info);
+    int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, bufferlist *pbl);
 
     int aio_operate(const std::string& oid, AioCompletion *c,
@@ -1015,6 +1019,9 @@ namespace librados
     int aio_operate(const std::string& oid, AioCompletion *c,
 		    ObjectReadOperation *op, int flags,
 		    bufferlist *pbl);
+    int aio_operate(const std::string& oid, AioCompletion *c,
+        ObjectReadOperation *op, int flags,
+        bufferlist *pbl, const blkin_trace_info *trace_info);
 
     // watch/notify
     int watch2(const std::string& o, uint64_t *handle,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -633,6 +633,8 @@ CEPH_RBD_API int rbd_aio_read2(rbd_image_t image, uint64_t off, size_t len,
                                char *buf, rbd_completion_t c, int op_flags);
 CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
                                  rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_discard_traced(rbd_image_t image, uint64_t off, uint64_t len,
+                                 rbd_completion_t c, const struct blkin_trace_info *trace_info);
 
 CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,
                                            rbd_callback_t complete_cb,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -611,6 +611,9 @@ CEPH_RBD_API ssize_t rbd_write2(rbd_image_t image, uint64_t ofs, size_t len,
 CEPH_RBD_API int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
 CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
                                const char *buf, rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
+                               const char *buf, rbd_completion_t c,
+                               const struct blkin_trace_info *trace_info);
 
 /*
  * @param op_flags: see librados.h constants beginning with LIBRADOS_OP_FLAG
@@ -619,6 +622,10 @@ CEPH_RBD_API int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
                                 const char *buf, rbd_completion_t c, int op_flags);
 CEPH_RBD_API int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,
                               char *buf, rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
+                              char *buf, rbd_completion_t c,
+                              const struct blkin_trace_info *trace_info);
+
 /*
  * @param op_flags: see librados.h constants beginning with LIBRADOS_OP_FLAG
  */

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -363,6 +363,8 @@ public:
   int aio_read_traced(uint64_t off, size_t len, ceph::bufferlist& bl, RBD::AioCompletion *c,
 		  const struct blkin_trace_info *trace_info);
   int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
+  int aio_discard_traced(uint64_t off, uint64_t len, RBD::AioCompletion *c,
+		  const struct blkin_trace_info *trace_info);
 
   int flush();
   /**

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -337,6 +337,8 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_write2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+  int aio_write_traced(uint64_t off, size_t len, ceph::bufferlist& bl, RBD::AioCompletion *c,
+		  const struct blkin_trace_info *trace_info);
   /**
    * read async from image
    *
@@ -358,6 +360,8 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_read2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+  int aio_read_traced(uint64_t off, size_t len, ceph::bufferlist& bl, RBD::AioCompletion *c,
+		  const struct blkin_trace_info *trace_info);
   int aio_discard(uint64_t off, uint64_t len, RBD::AioCompletion *c);
 
   int flush();

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -782,7 +782,7 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
 
 int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 				  bufferlist *pbl, size_t len, uint64_t off,
-				  uint64_t snapid)
+				  uint64_t snapid, const blkin_trace_info *info)
 {
   if (len > (size_t) INT_MAX)
     return -EDOM;
@@ -793,17 +793,21 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   c->io = this;
   c->blp = pbl;
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados read", &objecter->trace_endpoint, info);
+
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
     off, len, snapid, pbl, 0,
-    onack, &c->objver);
+    onack, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
 
 int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
 				  char *buf, size_t len, uint64_t off,
-				  uint64_t snapid)
+				  uint64_t snapid, const blkin_trace_info *info)
 {
   if (len > (size_t) INT_MAX)
     return -EDOM;
@@ -817,10 +821,14 @@ int librados::IoCtxImpl::aio_read(const object_t oid, AioCompletionImpl *c,
   c->blp = &c->bl;
   c->out_buf = buf;
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados read", &objecter->trace_endpoint, info);
+
   Objecter::Op *o = objecter->prepare_read_op(
     oid, oloc,
     off, len, snapid, &c->bl, 0,
-    onack, &c->objver);
+    onack, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
   return 0;
 }
@@ -863,7 +871,7 @@ int librados::IoCtxImpl::aio_sparse_read(const object_t oid,
 
 int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 				   const bufferlist& bl, size_t len,
-				   uint64_t off)
+				   uint64_t off, const blkin_trace_info *info)
 {
   auto ut = ceph::real_clock::now(client->cct);
   ldout(client->cct, 20) << "aio_write " << oid << " " << off << "~" << len << " snapc=" << snapc << " snap_seq=" << snap_seq << dendl;
@@ -877,13 +885,17 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
   Context *onack = new C_aio_Ack(c);
   Context *onsafe = new C_aio_Safe(c);
 
+  ZTracer::Trace trace;
+  if (info)
+    trace.init("rados write", &objecter->trace_endpoint, info);
+
   c->io = this;
   queue_aio_write(c);
 
   Objecter::Op *o = objecter->prepare_write_op(
     oid, oloc,
     off, len, snapc, bl, ut, 0,
-    onack, onsafe, &c->objver);
+    onack, onsafe, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(o, &c->tid);
 
   return 0;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -743,23 +743,32 @@ int librados::IoCtxImpl::aio_operate_read(const object_t &oid,
 					  ::ObjectOperation *o,
 					  AioCompletionImpl *c,
 					  int flags,
-					  bufferlist *pbl)
+					  bufferlist *pbl,
+            const blkin_trace_info *trace_info)
 {
   Context *onack = new C_aio_Ack(c);
 
   c->is_read = true;
   c->io = this;
 
+  ZTracer::Trace trace;
+  if (trace_info)
+    trace.init("rados operate read", &objecter->trace_endpoint, trace_info);
+
+  trace.event("init root span");
   Objecter::Op *objecter_op = objecter->prepare_read_op(oid, oloc,
 		 *o, snap_seq, pbl, flags,
-		 onack, &c->objver);
+		 onack, &c->objver, nullptr, 0, &trace);
   objecter->op_submit(objecter_op, &c->tid);
+  trace.event("rados operate read submitted");
+
   return 0;
 }
 
 int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
-				     const SnapContext& snap_context, int flags)
+				     const SnapContext& snap_context, int flags,
+             const blkin_trace_info *trace_info)
 {
   auto ut = ceph::real_clock::now(client->cct);
   /* can't write to a snapshot */
@@ -772,10 +781,16 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
   c->io = this;
   queue_aio_write(c);
 
+  ZTracer::Trace trace;
+  if (trace_info)
+    trace.init("rados operate", &objecter->trace_endpoint, trace_info);
+
+  trace.event("init root span");
   Objecter::Op *op = objecter->prepare_mutate_op(
     oid, oloc, *o, snap_context, ut, flags, onack,
-    oncommit, &c->objver);
+    oncommit, &c->objver, &trace);
   objecter->op_submit(op, &c->tid);
+  trace.event("rados operate op submitted");
 
   return 0;
 }

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -18,6 +18,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/snap_types.h"
+#include "common/zipkin_trace.h"
 #include "include/atomic.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
@@ -188,14 +189,17 @@ struct librados::IoCtxImpl {
   };
 
   int aio_read(const object_t oid, AioCompletionImpl *c,
-	       bufferlist *pbl, size_t len, uint64_t off, uint64_t snapid);
+	       bufferlist *pbl, size_t len, uint64_t off, uint64_t snapid,
+	       const blkin_trace_info *info = nullptr);
   int aio_read(object_t oid, AioCompletionImpl *c,
-	       char *buf, size_t len, uint64_t off, uint64_t snapid);
+	       char *buf, size_t len, uint64_t off, uint64_t snapid,
+	       const blkin_trace_info *info = nullptr);
   int aio_sparse_read(const object_t oid, AioCompletionImpl *c,
 		      std::map<uint64_t,uint64_t> *m, bufferlist *data_bl,
 		      size_t len, uint64_t off, uint64_t snapid);
   int aio_write(const object_t &oid, AioCompletionImpl *c,
-		const bufferlist& bl, size_t len, uint64_t off);
+		const bufferlist& bl, size_t len, uint64_t off,
+		const blkin_trace_info *info = nullptr);
   int aio_append(const object_t &oid, AioCompletionImpl *c,
 		 const bufferlist& bl, size_t len);
   int aio_write_full(const object_t &oid, AioCompletionImpl *c,

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -156,9 +156,9 @@ struct librados::IoCtxImpl {
   int operate_read(const object_t& oid, ::ObjectOperation *o, bufferlist *pbl, int flags=0);
   int aio_operate(const object_t& oid, ::ObjectOperation *o,
 		  AioCompletionImpl *c, const SnapContext& snap_context,
-		  int flags);
+		  int flags, const blkin_trace_info *trace_info = nullptr);
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
-		       AioCompletionImpl *c, int flags, bufferlist *pbl);
+		       AioCompletionImpl *c, int flags, bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
 
   struct C_aio_Ack : public Context {
     librados::AioCompletionImpl *c;

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -1486,6 +1486,21 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 }
 
 int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+         librados::ObjectWriteOperation *o,
+         snap_t snap_seq, std::vector<snap_t>& snaps,
+         const blkin_trace_info *trace_info)
+{
+  object_t obj(oid);
+  vector<snapid_t> snv;
+  snv.resize(snaps.size());
+  for (size_t i = 0; i < snaps.size(); ++i)
+    snv[i] = snaps[i];
+  SnapContext snapc(snap_seq, snv);
+  return io_ctx_impl->aio_operate(obj, &o->impl->o, c->pc,
+          snapc, 0, trace_info);
+}
+
+int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				 librados::ObjectReadOperation *o,
 				 bufferlist *pbl)
 {
@@ -1522,6 +1537,14 @@ int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 				       translate_flags(flags), pbl);
 }
 
+int librados::IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+         librados::ObjectReadOperation *o,
+         int flags, bufferlist *pbl, const blkin_trace_info *trace_info)
+{
+  object_t obj(oid);
+  return io_ctx_impl->aio_operate_read(obj, &o->impl->o, c->pc,
+               translate_flags(flags), pbl, trace_info);
+}
 
 void librados::IoCtx::snap_set_read(snap_t seq)
 {

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -188,6 +188,9 @@ private:
 } // anonymous namespace
 
 template <typename I>
+const ZTracer::Endpoint AioImageRequest<I>::m_endp = ZTracer::Endpoint("librbd");
+
+template <typename I>
 void AioImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
                                   Extents &&image_extents, char *buf,
                                   bufferlist *pbl, int op_flags,

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -218,8 +218,9 @@ void AioImageRequest<I>::aio_write(I *ictx, AioCompletion *c,
 
 template <typename I>
 void AioImageRequest<I>::aio_discard(I *ictx, AioCompletion *c,
-                                     uint64_t off, uint64_t len) {
-  AioImageDiscard<I> req(*ictx, c, off, len);
+                                     uint64_t off, uint64_t len,
+                                     const blkin_trace_info *trace_info) {
+  AioImageDiscard<I> req(*ictx, c, off, len, trace_info);
   req.send();
 }
 
@@ -649,16 +650,17 @@ AioObjectRequestHandle *AioImageDiscard<I>::create_object_request(
   if (object_extent.length == image_ctx.layout.object_size) {
     req = AioObjectRequest<I>::create_remove(
       &image_ctx, object_extent.oid.name, object_extent.objectno, snapc,
-      on_finish);
+      on_finish, trace);
   } else if (object_extent.offset + object_extent.length ==
                image_ctx.layout.object_size) {
     req = AioObjectRequest<I>::create_truncate(
       &image_ctx, object_extent.oid.name, object_extent.objectno,
-      object_extent.offset, snapc, on_finish);
+      object_extent.offset, snapc, on_finish, trace);
   } else {
     req = AioObjectRequest<I>::create_zero(
       &image_ctx, object_extent.oid.name, object_extent.objectno,
-      object_extent.offset, object_extent.length, snapc, on_finish);
+      object_extent.offset, object_extent.length, snapc, on_finish,
+      trace);
   }
   return req;
 }

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -285,7 +285,7 @@ void AioImageRead<I>::send_request() {
   auto &image_extents = this->m_image_extents;
   if (image_ctx.object_cacher && image_ctx.readahead_max_bytes > 0 &&
       !(m_op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
-    readahead(get_image_ctx(&image_ctx), image_extents, &this->m_trace);
+    readahead(get_image_ctx(&image_ctx), image_extents);
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;

--- a/src/librbd/AioImageRequest.cc
+++ b/src/librbd/AioImageRequest.cc
@@ -190,15 +190,17 @@ private:
 template <typename I>
 void AioImageRequest<I>::aio_read(I *ictx, AioCompletion *c,
                                   Extents &&image_extents, char *buf,
-                                  bufferlist *pbl, int op_flags) {
-  AioImageRead<I> req(*ictx, c, std::move(image_extents), buf, pbl, op_flags);
+                                  bufferlist *pbl, int op_flags,
+                                  const blkin_trace_info *trace_info) {
+  AioImageRead<I> req(*ictx, c, std::move(image_extents), buf, pbl, op_flags, trace_info);
   req.send();
 }
 
 template <typename I>
 void AioImageRequest<I>::aio_write(I *ictx, AioCompletion *c, uint64_t off,
-                                   size_t len, const char *buf, int op_flags) {
-  AioImageWrite<I> req(*ictx, c, off, len, buf, op_flags);
+                                   size_t len, const char *buf, int op_flags,
+                                   const blkin_trace_info *trace_info) {
+  AioImageWrite<I> req(*ictx, c, off, len, buf, op_flags, trace_info);
   req.send();
 }
 
@@ -279,7 +281,7 @@ void AioImageRead<I>::send_request() {
   auto &image_extents = this->m_image_extents;
   if (image_ctx.object_cacher && image_ctx.readahead_max_bytes > 0 &&
       !(m_op_flags & LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
-    readahead(get_image_ctx(&image_ctx), image_extents);
+    readahead(get_image_ctx(&image_ctx), image_extents, &this->trace);
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;
@@ -335,7 +337,7 @@ void AioImageRead<I>::send_request() {
                                                                     req);
         image_ctx.aio_read_from_cache(extent.oid, extent.objectno,
                                       &req->data(), extent.length,
-                                      extent.offset, cache_comp, m_op_flags);
+                                      extent.offset, cache_comp, m_op_flags, &this->trace);
       } else {
         req->send();
       }
@@ -517,7 +519,7 @@ void AioImageWrite<I>::send_object_cache_requests(const ObjectExtents &object_ex
     C_AioRequest *req_comp = new C_AioRequest(aio_comp);
     image_ctx.write_to_cache(object_extent.oid, bl, object_extent.length,
                              object_extent.offset, req_comp, m_op_flags,
-                               journal_tid);
+                               journal_tid, &this->trace);
   }
 }
 

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -61,16 +61,17 @@ protected:
   AioCompletion *m_aio_comp;
   Extents m_image_extents;
   bool m_bypass_image_cache = false;
-  const ZTracer::Endpoint endp;
+  static const ZTracer::Endpoint m_endp;
   ZTracer::Trace trace;
 
   AioImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                   Extents &&image_extents,
                   const blkin_trace_info *trace_info = nullptr)
     : m_image_ctx(image_ctx), m_aio_comp(aio_comp),
-      m_image_extents(image_extents), endp("AioImageRequest") {
-        if (trace_info)
-          trace.init("AioImageRequest", &endp, trace_info);
+      m_image_extents(image_extents) {
+        if (trace_info) {
+          trace.init("AioImageRequest", &m_endp, trace_info);
+        }
 
   }
 

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -61,8 +61,8 @@ protected:
   AioCompletion *m_aio_comp;
   Extents m_image_extents;
   bool m_bypass_image_cache = false;
-  static const ZTracer::Endpoint m_endp;
-  ZTracer::Trace trace;
+  static const ZTracer::Endpoint s_endp;
+  ZTracer::Trace m_trace;
 
   AioImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                   Extents &&image_extents,
@@ -70,7 +70,7 @@ protected:
     : m_image_ctx(image_ctx), m_aio_comp(aio_comp),
       m_image_extents(image_extents) {
         if (trace_info) {
-          trace.init("AioImageRequest", &m_endp, trace_info);
+          m_trace.init("AioImageRequest", &s_endp, trace_info);
         }
 
   }

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -36,7 +36,7 @@ public:
   static void aio_write(ImageCtxT *ictx, AioCompletion *c,
                         Extents &&image_extents, bufferlist &&bl, int op_flags);
   static void aio_discard(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
-                          uint64_t len);
+                          uint64_t len, const blkin_trace_info *trace_info = nullptr);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c);
 
   virtual bool is_write_op() const {
@@ -214,8 +214,8 @@ template <typename ImageCtxT = ImageCtx>
 class AioImageDiscard : public AbstractAioImageWrite<ImageCtxT> {
 public:
   AioImageDiscard(ImageCtxT &image_ctx, AioCompletion *aio_comp, uint64_t off,
-                  uint64_t len)
-    : AbstractAioImageWrite<ImageCtxT>(image_ctx, aio_comp, {{off, len}}) {
+                  uint64_t len, const blkin_trace_info *trace_info = nullptr)
+    : AbstractAioImageWrite<ImageCtxT>(image_ctx, aio_comp, {{off, len}}, trace_info) {
   }
 
 protected:

--- a/src/librbd/AioImageRequest.h
+++ b/src/librbd/AioImageRequest.h
@@ -149,7 +149,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish) = 0;
+      Context *on_finish, ZTracer::Trace *trace = nullptr) = 0;
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous) = 0;
@@ -200,7 +200,7 @@ protected:
                                     AioObjectRequests *aio_object_requests);
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish);
+      Context *on_finish, ZTracer::Trace *trace = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);
@@ -239,7 +239,7 @@ protected:
 
   virtual AioObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish);
+      Context *on_finish, ZTracer::Trace *trace = nullptr);
 
   virtual uint64_t append_journal_event(const AioObjectRequests &requests,
                                         bool synchronous);

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -94,7 +94,7 @@ int AioImageRequestWQ::discard(uint64_t off, uint64_t len) {
 
 void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
                                  char *buf, bufferlist *pbl, int op_flags,
-                                 bool native_async) {
+                                 bool native_async, const blkin_trace_info *trace_info) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_READ);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_read: ictx=" << &m_image_ctx << ", "
@@ -121,18 +121,18 @@ void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
 
   if (m_image_ctx.non_blocking_aio || writes_blocked() || !writes_empty() ||
       lock_required) {
-    queue(new AioImageRead<>(m_image_ctx, c, {{off, len}}, buf, pbl, op_flags));
+    queue(new AioImageRead<>(m_image_ctx, c, {{off, len}}, buf, pbl, op_flags, trace_info));
   } else {
     c->start_op();
     AioImageRequest<>::aio_read(&m_image_ctx, c, {{off, len}}, buf, pbl,
-                                op_flags);
+                                op_flags, trace_info);
     finish_in_flight_op();
   }
 }
 
 void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
                                   const char *buf, int op_flags,
-                                  bool native_async) {
+                                  bool native_async, const blkin_trace_info *trace_info) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_WRITE);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_write: ictx=" << &m_image_ctx << ", "
@@ -146,13 +146,12 @@ void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
   if (!start_in_flight_op(c)) {
     return;
   }
-
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(new AioImageWrite<>(m_image_ctx, c, off, len, buf, op_flags));
+    queue(new AioImageWrite<>(m_image_ctx, c, off, len, buf, op_flags, trace_info));
   } else {
     c->start_op();
-    AioImageRequest<>::aio_write(&m_image_ctx, c, off, len, buf, op_flags);
+    AioImageRequest<>::aio_write(&m_image_ctx, c, off, len, buf, op_flags, trace_info);
     finish_in_flight_op();
   }
 }

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -39,7 +39,7 @@ ssize_t AioImageRequestWQ::read(uint64_t off, uint64_t len, char *buf,
 
   C_SaferCond cond;
   AioCompletion *c = AioCompletion::create(&cond);
-  aio_read(c, off, len, buf, NULL, op_flags, false);
+  aio_read(c, off, len, buf, NULL, op_flags, nullptr, false);
   return cond.wait();
 }
 
@@ -59,7 +59,7 @@ ssize_t AioImageRequestWQ::write(uint64_t off, uint64_t len, const char *buf,
 
   C_SaferCond cond;
   AioCompletion *c = AioCompletion::create(&cond);
-  aio_write(c, off, len, buf, op_flags, false);
+  aio_write(c, off, len, buf, op_flags, nullptr, false);
 
   r = cond.wait();
   if (r < 0) {
@@ -83,7 +83,7 @@ int AioImageRequestWQ::discard(uint64_t off, uint64_t len) {
 
   C_SaferCond cond;
   AioCompletion *c = AioCompletion::create(&cond);
-  aio_discard(c, off, len, false);
+  aio_discard(c, off, len, nullptr, false);
 
   r = cond.wait();
   if (r < 0) {
@@ -94,7 +94,7 @@ int AioImageRequestWQ::discard(uint64_t off, uint64_t len) {
 
 void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
                                  char *buf, bufferlist *pbl, int op_flags,
-                                 bool native_async, const blkin_trace_info *trace_info) {
+                                 const blkin_trace_info *trace_info, bool native_async) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_READ);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_read: ictx=" << &m_image_ctx << ", "
@@ -132,7 +132,7 @@ void AioImageRequestWQ::aio_read(AioCompletion *c, uint64_t off, uint64_t len,
 
 void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
                                   const char *buf, int op_flags,
-                                  bool native_async, const blkin_trace_info *trace_info) {
+                                  const blkin_trace_info *trace_info, bool native_async) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_WRITE);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_write: ictx=" << &m_image_ctx << ", "
@@ -157,8 +157,8 @@ void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
 }
 
 void AioImageRequestWQ::aio_discard(AioCompletion *c, uint64_t off,
-                                    uint64_t len, bool native_async,
-                                    const blkin_trace_info *trace_info) {
+                                    uint64_t len, const blkin_trace_info *trace_info,
+                                    bool native_async) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_DISCARD);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_discard: ictx=" << &m_image_ctx << ", "

--- a/src/librbd/AioImageRequestWQ.cc
+++ b/src/librbd/AioImageRequestWQ.cc
@@ -157,7 +157,8 @@ void AioImageRequestWQ::aio_write(AioCompletion *c, uint64_t off, uint64_t len,
 }
 
 void AioImageRequestWQ::aio_discard(AioCompletion *c, uint64_t off,
-                                    uint64_t len, bool native_async) {
+                                    uint64_t len, bool native_async,
+                                    const blkin_trace_info *trace_info) {
   c->init_time(&m_image_ctx, librbd::AIO_TYPE_DISCARD);
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "aio_discard: ictx=" << &m_image_ctx << ", "
@@ -174,10 +175,10 @@ void AioImageRequestWQ::aio_discard(AioCompletion *c, uint64_t off,
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
   if (m_image_ctx.non_blocking_aio || writes_blocked()) {
-    queue(new AioImageDiscard<>(m_image_ctx, c, off, len));
+    queue(new AioImageDiscard<>(m_image_ctx, c, off, len, trace_info));
   } else {
     c->start_op();
-    AioImageRequest<>::aio_discard(&m_image_ctx, c, off, len);
+    AioImageRequest<>::aio_discard(&m_image_ctx, c, off, len, trace_info);
     finish_in_flight_op();
   }
 }

--- a/src/librbd/AioImageRequestWQ.h
+++ b/src/librbd/AioImageRequestWQ.h
@@ -8,6 +8,7 @@
 #include "include/atomic.h"
 #include "common/RWLock.h"
 #include "common/WorkQueue.h"
+#include "common/zipkin_trace.h"
 #include <list>
 
 namespace librbd {
@@ -26,9 +27,11 @@ public:
   int discard(uint64_t off, uint64_t len);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len, char *buf,
-                bufferlist *pbl, int op_flags, bool native_async=true);
+                bufferlist *pbl, int op_flags, bool native_async=true,
+                const blkin_trace_info *trace_info = nullptr);
   void aio_write(AioCompletion *c, uint64_t off, uint64_t len, const char *buf,
-                 int op_flags, bool native_async=true);
+                 int op_flags, bool native_async=true,
+                 const blkin_trace_info *trace_info = nullptr);
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
                    bool native_async=true);
   void aio_flush(AioCompletion *c, bool native_async=true);

--- a/src/librbd/AioImageRequestWQ.h
+++ b/src/librbd/AioImageRequestWQ.h
@@ -33,7 +33,7 @@ public:
                  int op_flags, bool native_async=true,
                  const blkin_trace_info *trace_info = nullptr);
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
-                   bool native_async=true);
+                   bool native_async=true, const blkin_trace_info *trace_info = nullptr);
   void aio_flush(AioCompletion *c, bool native_async=true);
 
   using typename ThreadPool::PointerWQ<AioImageRequest<ImageCtx> >::drain;

--- a/src/librbd/AioImageRequestWQ.h
+++ b/src/librbd/AioImageRequestWQ.h
@@ -27,13 +27,13 @@ public:
   int discard(uint64_t off, uint64_t len);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len, char *buf,
-                bufferlist *pbl, int op_flags, bool native_async=true,
-                const blkin_trace_info *trace_info = nullptr);
+                bufferlist *pbl, int op_flags, const blkin_trace_info *trace_info,
+                bool native_async=true);
   void aio_write(AioCompletion *c, uint64_t off, uint64_t len, const char *buf,
-                 int op_flags, bool native_async=true,
-                 const blkin_trace_info *trace_info = nullptr);
+                 int op_flags, const blkin_trace_info *trace_info,
+                 bool native_async=true);
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
-                   bool native_async=true, const blkin_trace_info *trace_info = nullptr);
+                   const blkin_trace_info *trace_info, bool native_async=true);
   void aio_flush(AioCompletion *c, bool native_async=true);
 
   using typename ThreadPool::PointerWQ<AioImageRequest<ImageCtx> >::drain;

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -32,9 +32,10 @@ AioObjectRequest<I>*
 AioObjectRequest<I>::create_remove(I *ictx, const std::string &oid,
                                    uint64_t object_no,
                                    const ::SnapContext &snapc,
-                                   Context *completion) {
+                                   Context *completion,
+                                   ZTracer::Trace *trace) {
   return new AioObjectRemove(util::get_image_ctx(ictx), oid, object_no, snapc,
-                             completion);
+                             completion, trace);
 }
 
 template <typename I>
@@ -42,9 +43,10 @@ AioObjectRequest<I>*
 AioObjectRequest<I>::create_truncate(I *ictx, const std::string &oid,
                                      uint64_t object_no, uint64_t object_off,
                                      const ::SnapContext &snapc,
-                                     Context *completion) {
+                                     Context *completion,
+                                     ZTracer::Trace *trace) {
   return new AioObjectTruncate(util::get_image_ctx(ictx), oid, object_no,
-                               object_off, snapc, completion);
+                               object_off, snapc, completion, trace);
 }
 
 template <typename I>
@@ -65,9 +67,10 @@ AioObjectRequest<I>::create_zero(I *ictx, const std::string &oid,
                                  uint64_t object_no, uint64_t object_off,
                                  uint64_t object_len,
                                  const ::SnapContext &snapc,
-                                 Context *completion) {
+                                 Context *completion,
+                                 ZTracer::Trace *trace) {
   return new AioObjectZero(util::get_image_ctx(ictx), oid, object_no,
-                           object_off, object_len, snapc, completion);
+                           object_off, object_len, snapc, completion, trace);
 }
 
 template <typename I>

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -288,7 +288,7 @@ void AioObjectRead<I>::send() {
   librados::AioCompletion *rados_completion =
     util::create_rados_ack_callback(this);
   int r = image_ctx->data_ctx.aio_operate(this->m_oid, rados_completion, &op,
-                                          flags, nullptr, (this->m_trace) ? this->m_trace.get_info() : nullptr);
+                                          flags, nullptr, this->m_trace ? this->m_trace.get_info() : nullptr);
   assert(r == 0);
 
   rados_completion->release();
@@ -559,7 +559,7 @@ void AbstractAioObjectWrite::send_write_op(bool write_guard)
   librados::AioCompletion *rados_completion =
     util::create_rados_safe_callback(this);
   int r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
-           m_snap_seq, m_snaps, (m_trace) ? m_trace.get_info() : nullptr);
+                                       m_snap_seq, m_snaps, m_trace ? m_trace.get_info() : nullptr);
   assert(r == 0);
   rados_completion->release();
 }

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -336,7 +336,7 @@ void AioObjectRead<I>::read_from_parent(Extents&& parent_extents)
                             << dendl;
   AioImageRequest<>::aio_read(image_ctx->parent, parent_completion,
                               std::move(parent_extents), nullptr, &m_read_data,
-                              0);
+                              0, nullptr);
 }
 
 /** write **/

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -9,6 +9,7 @@
 #include <map>
 
 #include "common/snap_types.h"
+#include "common/zipkin_trace.h"
 #include "include/buffer.h"
 #include "include/rados/librados.hpp"
 #include "librbd/ObjectMap.h"
@@ -69,7 +70,8 @@ public:
   AioObjectRequest(ImageCtx *ictx, const std::string &oid,
                    uint64_t objectno, uint64_t off, uint64_t len,
                    librados::snap_t snap_id,
-                   Context *completion, bool hide_enoent);
+                   Context *completion, bool hide_enoent,
+                   ZTracer::Trace *trace = nullptr);
   virtual ~AioObjectRequest() {}
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr) {};
@@ -93,6 +95,7 @@ protected:
   Context *m_completion;
   Extents m_parent_extents;
   bool m_hide_enoent;
+  ZTracer::Trace m_trace;
 };
 
 template <typename ImageCtxT = ImageCtx>
@@ -176,7 +179,8 @@ public:
   AbstractAioObjectWrite(ImageCtx *ictx, const std::string &oid,
                          uint64_t object_no, uint64_t object_off,
                          uint64_t len, const ::SnapContext &snapc,
-                         Context *completion, bool hide_enoent);
+                         Context *completion, bool hide_enoent,
+                         ZTracer::Trace *trace = nullptr);
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr)
   {
@@ -258,9 +262,9 @@ public:
   AioObjectWrite(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                  uint64_t object_off, const ceph::bufferlist &data,
                  const ::SnapContext &snapc, Context *completion,
-                 int op_flags)
+                 int op_flags, ZTracer::Trace *trace = nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, data.length(),
-                             snapc, completion, false),
+                             snapc, completion, false, trace),
       m_write_data(data), m_op_flags(op_flags) {
   }
 

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -48,13 +48,15 @@ public:
                                          const std::string &oid,
                                          uint64_t object_no,
                                          const ::SnapContext &snapc,
-                                         Context *completion);
+                                         Context *completion,
+                                         ZTracer::Trace *trace = nullptr);
   static AioObjectRequest* create_truncate(ImageCtxT *ictx,
                                            const std::string &oid,
                                            uint64_t object_no,
                                            uint64_t object_off,
                                            const ::SnapContext &snapc,
-                                           Context *completion);
+                                           Context *completion,
+                                           ZTracer::Trace *trace = nullptr);
   static AioObjectRequest* create_write(ImageCtxT *ictx, const std::string &oid,
                                         uint64_t object_no,
                                         uint64_t object_off,
@@ -66,7 +68,8 @@ public:
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,
                                        const ::SnapContext &snapc,
-                                       Context *completion);
+                                       Context *completion,
+                                       ZTracer::Trace *trace = nullptr);
 
   AioObjectRequest(ImageCtx *ictx, const std::string &oid,
                    uint64_t objectno, uint64_t off, uint64_t len,
@@ -291,9 +294,10 @@ private:
 class AioObjectRemove : public AbstractAioObjectWrite {
 public:
   AioObjectRemove(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
-                  const ::SnapContext &snapc, Context *completion)
+                  const ::SnapContext &snapc, Context *completion,
+                  ZTracer::Trace *trace = nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, 0, 0, snapc, completion,
-                             true),
+                             true, trace),
       m_object_state(OBJECT_NONEXISTENT) {
   }
 
@@ -365,9 +369,10 @@ class AioObjectTruncate : public AbstractAioObjectWrite {
 public:
   AioObjectTruncate(ImageCtx *ictx, const std::string &oid,
                     uint64_t object_no, uint64_t object_off,
-                    const ::SnapContext &snapc, Context *completion)
+                    const ::SnapContext &snapc, Context *completion,
+                    ZTracer::Trace *trace = nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, 0, snapc,
-                             completion, true) {
+                             completion, true, trace) {
   }
 
 protected:
@@ -392,9 +397,10 @@ class AioObjectZero : public AbstractAioObjectWrite {
 public:
   AioObjectZero(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                 uint64_t object_off, uint64_t object_len,
-                const ::SnapContext &snapc, Context *completion)
+                const ::SnapContext &snapc, Context *completion,
+                ZTracer::Trace *trace = nullptr)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, object_len,
-                             snapc, completion, true) {
+                             snapc, completion, true, trace) {
   }
 
 protected:

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -60,7 +60,8 @@ public:
                                         uint64_t object_off,
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
-                                        Context *completion, int op_flags);
+                                        Context *completion, int op_flags,
+                                        ZTracer::Trace *trace = nullptr);
   static AioObjectRequest* create_zero(ImageCtxT *ictx, const std::string &oid,
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,
@@ -108,15 +109,17 @@ public:
                                uint64_t objectno, uint64_t offset,
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
-                               Context *completion, int op_flags) {
+                               Context *completion, int op_flags,
+                               ZTracer::Trace *trace = nullptr) {
     return new AioObjectRead(ictx, oid, objectno, offset, len, buffer_extents,
-                             snap_id, sparse, completion, op_flags);
+                             snap_id, sparse, completion, op_flags, trace);
   }
 
   AioObjectRead(ImageCtxT *ictx, const std::string &oid,
                 uint64_t objectno, uint64_t offset, uint64_t len,
                 Extents& buffer_extents, librados::snap_t snap_id, bool sparse,
-                Context *completion, int op_flags);
+                Context *completion, int op_flags,
+                ZTracer::Trace *trace = nullptr);
 
   virtual bool should_complete(int r);
   virtual void send();

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -49,33 +49,33 @@ public:
                                          uint64_t object_no,
                                          const ::SnapContext &snapc,
                                          Context *completion,
-                                         ZTracer::Trace *trace = nullptr);
+                                         ZTracer::Trace *trace);
   static AioObjectRequest* create_truncate(ImageCtxT *ictx,
                                            const std::string &oid,
                                            uint64_t object_no,
                                            uint64_t object_off,
                                            const ::SnapContext &snapc,
                                            Context *completion,
-                                           ZTracer::Trace *trace = nullptr);
+                                           ZTracer::Trace *trace);
   static AioObjectRequest* create_write(ImageCtxT *ictx, const std::string &oid,
                                         uint64_t object_no,
                                         uint64_t object_off,
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
                                         Context *completion, int op_flags,
-                                        ZTracer::Trace *trace = nullptr);
+                                        ZTracer::Trace *trace);
   static AioObjectRequest* create_zero(ImageCtxT *ictx, const std::string &oid,
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,
                                        const ::SnapContext &snapc,
                                        Context *completion,
-                                       ZTracer::Trace *trace = nullptr);
+                                       ZTracer::Trace *trace);
 
   AioObjectRequest(ImageCtx *ictx, const std::string &oid,
                    uint64_t objectno, uint64_t off, uint64_t len,
                    librados::snap_t snap_id,
                    Context *completion, bool hide_enoent,
-                   ZTracer::Trace *trace = nullptr);
+                   ZTracer::Trace *trace);
   virtual ~AioObjectRequest() {}
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr) {};
@@ -113,7 +113,7 @@ public:
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
                                Context *completion, int op_flags,
-                               ZTracer::Trace *trace = nullptr) {
+                               ZTracer::Trace *trace) {
     return new AioObjectRead(ictx, oid, objectno, offset, len, buffer_extents,
                              snap_id, sparse, completion, op_flags, trace);
   }
@@ -122,7 +122,7 @@ public:
                 uint64_t objectno, uint64_t offset, uint64_t len,
                 Extents& buffer_extents, librados::snap_t snap_id, bool sparse,
                 Context *completion, int op_flags,
-                ZTracer::Trace *trace = nullptr);
+                ZTracer::Trace *trace);
 
   virtual bool should_complete(int r);
   virtual void send();
@@ -186,7 +186,7 @@ public:
                          uint64_t object_no, uint64_t object_off,
                          uint64_t len, const ::SnapContext &snapc,
                          Context *completion, bool hide_enoent,
-                         ZTracer::Trace *trace = nullptr);
+                         ZTracer::Trace *trace);
 
   virtual void add_copyup_ops(librados::ObjectWriteOperation *wr)
   {
@@ -268,7 +268,7 @@ public:
   AioObjectWrite(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                  uint64_t object_off, const ceph::bufferlist &data,
                  const ::SnapContext &snapc, Context *completion,
-                 int op_flags, ZTracer::Trace *trace = nullptr)
+                 int op_flags, ZTracer::Trace *trace)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, data.length(),
                              snapc, completion, false, trace),
       m_write_data(data), m_op_flags(op_flags) {
@@ -295,7 +295,7 @@ class AioObjectRemove : public AbstractAioObjectWrite {
 public:
   AioObjectRemove(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                   const ::SnapContext &snapc, Context *completion,
-                  ZTracer::Trace *trace = nullptr)
+                  ZTracer::Trace *trace)
     : AbstractAioObjectWrite(ictx, oid, object_no, 0, 0, snapc, completion,
                              true, trace),
       m_object_state(OBJECT_NONEXISTENT) {
@@ -344,7 +344,7 @@ public:
   AioObjectTrim(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                 const ::SnapContext &snapc, Context *completion)
     : AbstractAioObjectWrite(ictx, oid, object_no, 0, 0, snapc, completion,
-                             true) {
+                             true, nullptr) {
   }
 
 protected:
@@ -370,7 +370,7 @@ public:
   AioObjectTruncate(ImageCtx *ictx, const std::string &oid,
                     uint64_t object_no, uint64_t object_off,
                     const ::SnapContext &snapc, Context *completion,
-                    ZTracer::Trace *trace = nullptr)
+                    ZTracer::Trace *trace)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, 0, snapc,
                              completion, true, trace) {
   }
@@ -398,7 +398,7 @@ public:
   AioObjectZero(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
                 uint64_t object_off, uint64_t object_len,
                 const ::SnapContext &snapc, Context *completion,
-                ZTracer::Trace *trace = nullptr)
+                ZTracer::Trace *trace)
     : AbstractAioObjectWrite(ictx, oid, object_no, object_off, object_len,
                              snapc, completion, true, trace) {
   }

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -188,7 +188,7 @@ void CopyupRequest::send()
                          << ", extents " << m_image_extents
                          << dendl;
   AioImageRequest<>::aio_read(m_ictx->parent, comp, std::move(m_image_extents),
-                              nullptr, &m_copyup_data, 0);
+                              nullptr, &m_copyup_data, 0, nullptr);
 }
 
 void CopyupRequest::complete(int r)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -684,7 +684,7 @@ struct C_InvalidateCache : public Context {
   void ImageCtx::aio_read_from_cache(object_t o, uint64_t object_no,
 				     bufferlist *bl, size_t len,
 				     uint64_t off, Context *onfinish,
-				     int fadvise_flags) {
+				     int fadvise_flags, ZTracer::Trace *trace) {
     snap_lock.get_read();
     ObjectCacher::OSDRead *rd = object_cacher->prepare_read(snap_id, bl, fadvise_flags);
     snap_lock.put_read();
@@ -693,7 +693,7 @@ struct C_InvalidateCache : public Context {
     extent.buffer_extents.push_back(make_pair(0, len));
     rd->extents.push_back(extent);
     cache_lock.Lock();
-    int r = object_cacher->readx(rd, object_set, onfinish);
+    int r = object_cacher->readx(rd, object_set, onfinish, trace);
     cache_lock.Unlock();
     if (r != 0)
       onfinish->complete(r);
@@ -701,7 +701,7 @@ struct C_InvalidateCache : public Context {
 
   void ImageCtx::write_to_cache(object_t o, const bufferlist& bl, size_t len,
 				uint64_t off, Context *onfinish,
-				int fadvise_flags, uint64_t journal_tid) {
+				int fadvise_flags, uint64_t journal_tid, ZTracer::Trace *trace) {
     snap_lock.get_read();
     ObjectCacher::OSDWrite *wr = object_cacher->prepare_write(
       snapc, bl, ceph::real_time::min(), fadvise_flags, journal_tid);
@@ -714,7 +714,7 @@ struct C_InvalidateCache : public Context {
     wr->extents.push_back(extent);
     {
       Mutex::Locker l(cache_lock);
-      object_cacher->writex(wr, object_set, onfinish);
+      object_cacher->writex(wr, object_set, onfinish, trace);
     }
   }
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -266,10 +266,11 @@ namespace librbd {
 			   uint64_t *overlap) const;
     void aio_read_from_cache(object_t o, uint64_t object_no, bufferlist *bl,
 			     size_t len, uint64_t off, Context *onfinish,
-			     int fadvise_flags);
+			     int fadvise_flags, ZTracer::Trace *trace = nullptr);
     void write_to_cache(object_t o, const bufferlist& bl, size_t len,
 			uint64_t off, Context *onfinish, int fadvise_flags,
-                        uint64_t journal_tid);
+                        uint64_t journal_tid,
+                        ZTracer::Trace *trace = nullptr);
     void user_flushed();
     void flush_cache(Context *onfinish);
     void shut_down_cache(Context *on_finish);

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -215,7 +215,7 @@ namespace librbd {
     librados::AioCompletion *rados_completion =
       util::create_rados_ack_callback(req);
     int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
-					 flags, NULL, (trace) ? trace->get_info() : nullptr);
+					 flags, NULL, trace ? trace->get_info() : nullptr);
     rados_completion->release();
     assert(r >= 0);
   }

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -157,7 +157,7 @@ namespace librbd {
 
       request_sent = true;
       AioObjectWrite *req = new AioObjectWrite(image_ctx, oid, object_no, off,
-                                               bl, snapc, this, 0);
+                                               bl, snapc, this, 0, nullptr);
       req->send();
     }
   };

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -25,7 +25,7 @@ namespace librbd {
 		      const object_locator_t& oloc, uint64_t off, uint64_t len,
 		      snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
 		      __u32 trunc_seq, int op_flags, Context *onfinish,
-          ZTracer::Trace *trace);
+		      ZTracer::Trace *trace);
 
     // Determine whether a read to this extent could be affected by a
     // write-triggered copy-on-write

--- a/src/librbd/LibrbdWriteback.h
+++ b/src/librbd/LibrbdWriteback.h
@@ -24,7 +24,8 @@ namespace librbd {
     virtual void read(const object_t& oid, uint64_t object_no,
 		      const object_locator_t& oloc, uint64_t off, uint64_t len,
 		      snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		      __u32 trunc_seq, int op_flags, Context *onfinish);
+		      __u32 trunc_seq, int op_flags, Context *onfinish,
+          ZTracer::Trace *trace);
 
     // Determine whether a read to this extent could be affected by a
     // write-triggered copy-on-write
@@ -37,7 +38,7 @@ namespace librbd {
 			     const SnapContext& snapc, const bufferlist &bl,
 			     ceph::real_time mtime, uint64_t trunc_size,
 			     __u32 trunc_seq, ceph_tid_t journal_tid,
-			     Context *oncommit);
+			     Context *oncommit, ZTracer::Trace *trace);
     using WritebackHandler::write;
 
     virtual void overwrite_extent(const object_t& oid, uint64_t off,

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -30,7 +30,7 @@ void ImageWriteback<I>::aio_read(Extents &&image_extents, bufferlist *bl,
                                                             &m_image_ctx,
                                                             AIO_TYPE_READ);
   AioImageRead<I> req(m_image_ctx, aio_comp, std::move(image_extents), nullptr,
-                      bl, fadvise_flags);
+                      bl, fadvise_flags, nullptr);
   req.set_bypass_image_cache();
   req.send();
 }
@@ -63,7 +63,7 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
   AioCompletion *aio_comp = AioCompletion::create_and_start(on_finish,
                                                             &m_image_ctx,
                                                             AIO_TYPE_DISCARD);
-  AioImageDiscard<I> req(m_image_ctx, aio_comp, offset, length);
+  AioImageDiscard<I> req(m_image_ctx, aio_comp, offset, length, nullptr);
   req.set_bypass_image_cache();
   req.send();
 }

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3762,7 +3762,8 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   };
 
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents)
+                 const vector<pair<uint64_t,uint64_t> >& image_extents,
+                 ZTracer::Trace *trace)
   {
     uint64_t total_bytes = 0;
     for (vector<pair<uint64_t,uint64_t> >::const_iterator p = image_extents.begin();
@@ -3801,7 +3802,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 	  ictx->readahead.inc_pending();
 	  ictx->aio_read_from_cache(q->oid, q->objectno, NULL,
 				    q->length, q->offset,
-				    req_comp, 0);
+				    req_comp, 0, trace);
 	}
       }
       ictx->perfcounter->inc(l_librbd_readahead);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2483,7 +2483,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       // coordinate through AIO WQ to ensure lock is acquired if needed
       m_dest->aio_work_queue->aio_write(comp, m_offset, m_bl->length(),
                                         m_bl->c_str(),
-                                        LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
+                                        LIBRADOS_OP_FLAG_FADVISE_DONTNEED, nullptr);
     }
 
   private:
@@ -2539,7 +2539,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       AioCompletion *comp = AioCompletion::create_and_start(ctx, src,
                                                             AIO_TYPE_READ);
       AioImageRequest<>::aio_read(src, comp, {{offset, len}}, nullptr, bl,
-                                  fadvise_flags);
+                                  fadvise_flags, nullptr);
       prog_ctx.update_progress(offset, src_size);
     }
 
@@ -2764,7 +2764,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       C_SaferCond ctx;
       AioCompletion *c = AioCompletion::create_and_start(&ctx, ictx,
                                                          AIO_TYPE_READ);
-      AioImageRequest<>::aio_read(ictx, c, {{off, read_len}}, nullptr, &bl, 0);
+      AioImageRequest<>::aio_read(ictx, c, {{off, read_len}}, nullptr, &bl, 0, nullptr);
 
       int ret = ctx.wait();
       if (ret < 0) {
@@ -3801,7 +3801,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 	  ictx->readahead.inc_pending();
 	  ictx->aio_read_from_cache(q->oid, q->objectno, NULL,
 				    q->length, q->offset,
-				    req_comp, 0);
+				    req_comp, 0, nullptr);
 	}
       }
       ictx->perfcounter->inc(l_librbd_readahead);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -3762,8 +3762,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   };
 
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents,
-                 ZTracer::Trace *trace)
+                 const vector<pair<uint64_t,uint64_t> >& image_extents)
   {
     uint64_t total_bytes = 0;
     for (vector<pair<uint64_t,uint64_t> >::const_iterator p = image_extents.begin();
@@ -3802,7 +3801,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
 	  ictx->readahead.inc_pending();
 	  ictx->aio_read_from_cache(q->oid, q->objectno, NULL,
 				    q->length, q->offset,
-				    req_comp, 0, trace);
+				    req_comp, 0);
 	}
       }
       ictx->perfcounter->inc(l_librbd_readahead);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -190,8 +190,7 @@ namespace librbd {
 		   int (*cb)(uint64_t, size_t, int, void *),
 		   void *arg);
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents,
-                 ZTracer::Trace *trace = nullptr);
+                 const vector<pair<uint64_t,uint64_t> >& image_extents);
 
   int flush(ImageCtx *ictx);
   int invalidate_cache(ImageCtx *ictx);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -15,6 +15,7 @@
 #include "include/rbd_types.h"
 #include "librbd/parent_types.h"
 #include "common/WorkQueue.h"
+#include "common/zipkin_trace.h"
 
 enum {
   l_librbd_first = 26000,
@@ -189,7 +190,8 @@ namespace librbd {
 		   int (*cb)(uint64_t, size_t, int, void *),
 		   void *arg);
   void readahead(ImageCtx *ictx,
-                 const vector<pair<uint64_t,uint64_t> >& image_extents);
+                 const vector<pair<uint64_t,uint64_t> >& image_extents,
+                 ZTracer::Trace *trace = nullptr);
 
   int flush(ImageCtx *ictx);
   int invalidate_cache(ImageCtx *ictx);

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -300,7 +300,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
                                                          AIO_TYPE_DISCARD,
                                                          &flush_required);
   AioImageRequest<I>::aio_discard(&m_image_ctx, aio_comp, event.offset,
-                                  event.length);
+                                  event.length, nullptr);
   if (flush_required) {
     m_lock.Lock();
     AioCompletion *flush_comp = create_aio_flush_completion(nullptr);
@@ -322,7 +322,7 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
                                                          AIO_TYPE_WRITE,
                                                          &flush_required);
   AioImageRequest<I>::aio_write(&m_image_ctx, aio_comp, event.offset,
-                                event.length, data.c_str(), 0);
+                                event.length, data.c_str(), 0, nullptr);
   if (flush_required) {
     m_lock.Lock();
     AioCompletion *flush_comp = create_aio_flush_completion(nullptr);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1283,7 +1283,7 @@ namespace librbd {
       return -EINVAL;
     }
     ictx->aio_work_queue->aio_write(get_aio_completion(c), off, len, bl.c_str(),
-                                    0);
+                                    0, nullptr);
     tracepoint(librbd, aio_write_exit, 0);
     return 0;
   }
@@ -1299,7 +1299,7 @@ namespace librbd {
       return -EINVAL;
     }
     ictx->aio_work_queue->aio_write(get_aio_completion(c), off, len, bl.c_str(),
-                                    op_flags);
+                                    op_flags, nullptr);
     tracepoint(librbd, aio_write_exit, 0);
     return 0;
   }
@@ -1314,7 +1314,7 @@ namespace librbd {
       return -EINVAL;
     }
     ictx->aio_work_queue->aio_write(get_aio_completion(c), off, len, bl.c_str(),
-                                    0, true, trace_info);
+                                    0, trace_info);
     tracepoint(librbd, aio_write_traced_exit, 0);
     return 0;
   }
@@ -1323,7 +1323,7 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, aio_discard_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, c->pc);
-    ictx->aio_work_queue->aio_discard(get_aio_completion(c), off, len);
+    ictx->aio_work_queue->aio_discard(get_aio_completion(c), off, len, nullptr);
     tracepoint(librbd, aio_discard_exit, 0);
     return 0;
   }
@@ -1333,7 +1333,7 @@ namespace librbd {
   {
     ImageCtx *ictx = (ImageCtx *)ctx;
     tracepoint(librbd, aio_discard__traced_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, c->pc);
-    ictx->aio_work_queue->aio_discard(get_aio_completion(c), off, len, true, trace_info);
+    ictx->aio_work_queue->aio_discard(get_aio_completion(c), off, len, trace_info);
     tracepoint(librbd, aio_discard_traced_exit, 0);
     return 0;
   }
@@ -1346,7 +1346,7 @@ namespace librbd {
     ldout(ictx->cct, 10) << "Image::aio_read() buf=" << (void *)bl.c_str() << "~"
 			 << (void *)(bl.c_str() + len - 1) << dendl;
     ictx->aio_work_queue->aio_read(get_aio_completion(c), off, len, NULL, &bl,
-                                   0);
+                                   0, nullptr);
     tracepoint(librbd, aio_read_exit, 0);
     return 0;
   }
@@ -1360,7 +1360,7 @@ namespace librbd {
     ldout(ictx->cct, 10) << "Image::aio_read() buf=" << (void *)bl.c_str() << "~"
 			 << (void *)(bl.c_str() + len - 1) << dendl;
     ictx->aio_work_queue->aio_read(get_aio_completion(c), off, len, NULL, &bl,
-                                   op_flags);
+                                   op_flags, nullptr);
     tracepoint(librbd, aio_read_exit, 0);
     return 0;
   }
@@ -2797,7 +2797,7 @@ extern "C" int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_write_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
-  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0);
+  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, nullptr);
   tracepoint(librbd, aio_write_exit, 0);
   return 0;
 }
@@ -2808,7 +2808,7 @@ extern "C" int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_write_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
-  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, true, trace_info);
+  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, trace_info, true);
   tracepoint(librbd, aio_write_exit, 0);
   return 0;
 }
@@ -2821,7 +2821,7 @@ extern "C" int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
   tracepoint(librbd, aio_write2_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
 	      ictx->read_only, off, len, buf, comp->pc, op_flags);
   ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf,
-                                  op_flags);
+                                  op_flags, nullptr);
   tracepoint(librbd, aio_write_exit, 0);
   return 0;
 }
@@ -2833,7 +2833,7 @@ extern "C" int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_discard_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, comp->pc);
-  ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len);
+  ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len, nullptr);
   tracepoint(librbd, aio_discard_exit, 0);
   return 0;
 }
@@ -2844,7 +2844,7 @@ extern "C" int rbd_aio_discard_traced(rbd_image_t image, uint64_t off, uint64_t 
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_discard_traced_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, comp->pc);
-  ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len, true, trace_info);
+  ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len, trace_info);
   tracepoint(librbd, aio_discard_traced_exit, 0);
   return 0;
 }
@@ -2856,7 +2856,7 @@ extern "C" int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
   ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
-                                 0);
+                                 0, nullptr);
   tracepoint(librbd, aio_read_exit, 0);
   return 0;
 }
@@ -2868,7 +2868,7 @@ extern "C" int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
   ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
-                                 0, true, trace_info);
+                                 0, trace_info);
   tracepoint(librbd, aio_read_exit, 0);
   return 0;
 }
@@ -2881,7 +2881,7 @@ extern "C" int rbd_aio_read2(rbd_image_t image, uint64_t off, size_t len,
   tracepoint(librbd, aio_read2_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
 	      ictx->read_only, off, len, buf, comp->pc, op_flags);
   ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
-                                 op_flags);
+                                 op_flags, nullptr);
   tracepoint(librbd, aio_read_exit, 0);
   return 0;
 }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2770,7 +2770,7 @@ extern "C" int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_write_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
-  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, trace_info);
+  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, true, trace_info);
   tracepoint(librbd, aio_write_exit, 0);
   return 0;
 }
@@ -2819,7 +2819,7 @@ extern "C" int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
   ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
-                                 0, trace_info);
+                                 0, true, trace_info);
   tracepoint(librbd, aio_read_exit, 0);
   return 0;
 }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1328,6 +1328,16 @@ namespace librbd {
     return 0;
   }
 
+  int Image::aio_discard_traced(uint64_t off, uint64_t len, RBD::AioCompletion *c,
+        const struct blkin_trace_info *trace_info)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, aio_discard__traced_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, c->pc);
+    ictx->aio_work_queue->aio_discard(get_aio_completion(c), off, len, true, trace_info);
+    tracepoint(librbd, aio_discard_traced_exit, 0);
+    return 0;
+  }
+
   int Image::aio_read(uint64_t off, size_t len, bufferlist& bl,
 		      RBD::AioCompletion *c)
   {
@@ -2825,6 +2835,17 @@ extern "C" int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
   tracepoint(librbd, aio_discard_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, comp->pc);
   ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len);
   tracepoint(librbd, aio_discard_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_discard_traced(rbd_image_t image, uint64_t off, uint64_t len,
+             rbd_completion_t c, const struct blkin_trace_info *trace_info)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_discard_traced_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, comp->pc);
+  ictx->aio_work_queue->aio_discard(get_aio_completion(comp), off, len, true, trace_info);
+  tracepoint(librbd, aio_discard_traced_exit, 0);
   return 0;
 }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -2764,6 +2764,17 @@ extern "C" int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
   return 0;
 }
 
+extern "C" int rbd_aio_write_traced(rbd_image_t image, uint64_t off, size_t len,
+           const char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_write_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
+  ictx->aio_work_queue->aio_write(get_aio_completion(comp), off, len, buf, 0, trace_info);
+  tracepoint(librbd, aio_write_exit, 0);
+  return 0;
+}
+
 extern "C" int rbd_aio_write2(rbd_image_t image, uint64_t off, size_t len,
 			      const char *buf, rbd_completion_t c, int op_flags)
 {
@@ -2797,6 +2808,18 @@ extern "C" int rbd_aio_read(rbd_image_t image, uint64_t off, size_t len,
   tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
   ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
                                  0);
+  tracepoint(librbd, aio_read_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_read_traced(rbd_image_t image, uint64_t off, size_t len,
+          char *buf, rbd_completion_t c, const struct blkin_trace_info *trace_info)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_read_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, off, len, buf, comp->pc);
+  ictx->aio_work_queue->aio_read(get_aio_completion(comp), off, len, buf, NULL,
+                                 0, trace_info);
   tracepoint(librbd, aio_read_exit, 0);
   return 0;
 }

--- a/src/librbd/operation/FlattenRequest.cc
+++ b/src/librbd/operation/FlattenRequest.cc
@@ -42,7 +42,7 @@ public:
     bufferlist bl;
     string oid = image_ctx.get_object_name(m_object_no);
     AioObjectWrite *req = new AioObjectWrite(&image_ctx, oid, m_object_no, 0,
-                                             bl, m_snapc, this, 0);
+                                             bl, m_snapc, this, 0, nullptr);
     if (!req->has_parent()) {
       // stop early if the parent went away - it just means
       // another flatten finished first or the image was resized

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -367,7 +367,7 @@ void TrimRequest<I>::send_clean_boundary() {
                               req_comp);
     } else {
       req = new AioObjectTruncate(&image_ctx, p->oid.name, p->objectno,
-                                  p->offset, snapc, req_comp);
+                                  p->offset, snapc, req_comp, nullptr);
     }
     req->send();
   }

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpRead : public Message {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 3) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload, features);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpRead"; }

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpReadReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpReadReply"; }

--- a/src/messages/MOSDECSubOpWrite.h
+++ b/src/messages/MOSDECSubOpWrite.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpWrite : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -45,12 +45,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpWrite"; }

--- a/src/messages/MOSDECSubOpWriteReply.h
+++ b/src/messages/MOSDECSubOpWriteReply.h
@@ -20,7 +20,7 @@
 #include "osd/ECMsgTypes.h"
 
 class MOSDECSubOpWriteReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -41,12 +41,16 @@ public:
     ::decode(pgid, p);
     ::decode(map_epoch, p);
     ::decode(op, p);
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
     ::encode(pgid, payload);
     ::encode(map_epoch, payload);
     ::encode(op, payload);
+    encode_trace(payload, features);
   }
 
   const char *get_type_name() const { return "MOSDECSubOpWriteReply"; }

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -33,7 +33,7 @@ class OSD;
 
 class MOSDOp : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 3;
 
 private:
@@ -349,6 +349,8 @@ struct ceph_osd_request_head {
 
       ::encode(retry_attempt, payload);
       ::encode(features, payload);
+
+      encode_trace(payload, features);
     }
   }
 
@@ -494,6 +496,10 @@ struct ceph_osd_request_head {
     ::decode(retry_attempt, p);
 
     ::decode(features, p);
+
+    if (header.version >= 8) {
+      decode_trace(p);
+    }
 
     OSDOp::split_osd_op_vector_in_data(ops, data);
 

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -32,7 +32,7 @@
 
 class MOSDOpReply : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 2;
 
   object_t oid;
@@ -203,6 +203,7 @@ public:
           ::encode(redirect, payload);
         }
       }
+      encode_trace(payload, features);
     }
   }
   virtual void decode_payload() {
@@ -292,6 +293,9 @@ public:
         if (do_redirect) {
 	  ::decode(redirect, p);
         }
+      }
+      if (header.version >= 8) {
+        decode_trace(p);
       }
     }
   }

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -25,7 +25,7 @@
 
 class MOSDRepOp : public Message {
 
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
@@ -95,6 +95,9 @@ public:
     ::decode(updated_hit_set_history, p);
     ::decode(pg_trim_rollback_to, p);
     final_decode_needed = false;
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
 
   virtual void encode_payload(uint64_t features) {
@@ -113,6 +116,7 @@ public:
     ::encode(from, payload);
     ::encode(updated_hit_set_history, payload);
     ::encode(pg_trim_rollback_to, payload);
+    encode_trace(payload, features);
   }
 
   MOSDRepOp()

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -29,7 +29,7 @@
  */
 
 class MOSDRepOpReply : public Message {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 public:
   epoch_t map_epoch;
@@ -66,6 +66,9 @@ public:
 
     ::decode(from, p);
     final_decode_needed = false;
+    if (header.version >= 2) {
+      decode_trace(p);
+    }
   }
   virtual void encode_payload(uint64_t features) {
     ::encode(map_epoch, payload);
@@ -75,6 +78,7 @@ public:
     ::encode(result, payload);
     ::encode(last_complete_ondisk, payload);
     ::encode(from, payload);
+    encode_trace(payload, features);
   }
 
   epoch_t get_map_epoch() { return map_epoch; }

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -27,7 +27,7 @@
 
 class MOSDSubOp : public Message {
 
-  static const int HEAD_VERSION = 12;
+  static const int HEAD_VERSION = 13;
   static const int COMPAT_VERSION = 7;
 
 public:
@@ -176,6 +176,9 @@ public:
     } else {
       pg_trim_rollback_to = pg_trim_to;
     }
+    if (header.version >= 13) {
+      decode_trace(p);
+    }
   }
 
   void finish_decode() { }
@@ -235,6 +238,7 @@ public:
     ::encode(pgid.shard, payload);
     ::encode(updated_hit_set_history, payload);
     ::encode(pg_trim_rollback_to, payload);
+    encode_trace(payload, features);
   }
 
   MOSDSubOp()

--- a/src/messages/MOSDSubOpReply.h
+++ b/src/messages/MOSDSubOpReply.h
@@ -30,7 +30,7 @@
  */
 
 class MOSDSubOpReply : public Message {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 1;
 public:
   epoch_t map_epoch;
@@ -84,6 +84,9 @@ public:
 	shard_id_t::NO_SHARD);
       pgid.shard = shard_id_t::NO_SHARD;
     }
+    if (header.version >= 3) {
+      decode_trace(p);
+    }
   }
 
   void finish_decode() { }
@@ -105,6 +108,7 @@ public:
     ::encode(attrset, payload);
     ::encode(from, payload);
     ::encode(pgid.shard, payload);
+    encode_trace(payload, features);
   }
 
   epoch_t get_map_epoch() { return map_epoch; }

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -258,7 +258,7 @@ Message *decode_message(CephContext *cct, int crcflags,
 			ceph_msg_header& header,
 			ceph_msg_footer& footer,
 			bufferlist& front, bufferlist& middle,
-			bufferlist& data)
+			bufferlist& data, Connection* conn)
 {
   // verify crc
   if (crcflags & MSG_CRC_HEADER) {
@@ -752,6 +752,7 @@ Message *decode_message(CephContext *cct, int crcflags,
     return 0;
   }
 
+  m->set_connection(conn);
   m->set_header(header);
   m->set_footer(footer);
   m->set_payload(front);
@@ -830,6 +831,6 @@ Message *decode_message(CephContext *cct, int crcflags, bufferlist::iterator& p)
   ::decode(fr, p);
   ::decode(mi, p);
   ::decode(da, p);
-  return decode_message(cct, crcflags, h, f, fr, mi, da);
+  return decode_message(cct, crcflags, h, f, fr, mi, da, nullptr);
 }
 

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -782,6 +782,43 @@ Message *decode_message(CephContext *cct, int crcflags,
 }
 
 
+WRITE_RAW_ENCODER(blkin_trace_info)
+
+void Message::encode_trace(bufferlist &bl, uint64_t features) const
+{
+#ifdef WITH_BLKIN
+  if (features & CEPH_FEATURE_BLKIN_TRACING)
+    ::encode(*trace.get_info(), bl);
+#endif
+}
+
+void Message::decode_trace(bufferlist::iterator &p, bool create)
+{
+#ifdef WITH_BLKIN
+  if (!connection)
+    return;
+
+  const auto endpoint = connection->get_messenger()->get_trace_endpoint();
+  blkin_trace_info info = {};
+
+  // only decode a trace if both sides of the connection agree
+  if (connection->has_feature(CEPH_FEATURE_BLKIN_TRACING))
+    ::decode(info, p);
+
+  if (info.trace_id) {
+    trace.init(get_type_name(), endpoint, &info, true);
+    trace.event("decoded trace");
+  } else if (create) { // create a trace even if we didn't get one on the wire
+    trace.init(get_type_name(), endpoint);
+    trace.event("created trace");
+  }
+  trace.keyval("tid", get_tid());
+  trace.keyval("entity type", get_source().type_str());
+  trace.keyval("entity num", get_source().num());
+#endif
+}
+
+
 // This routine is not used for ordinary messages, but only when encapsulating a message
 // for forwarding and routing.  It's also used in a backward compatibility test, which only
 // effectively tests backward compability for those functions.  To avoid backward compatibility

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -449,8 +449,9 @@ typedef boost::intrusive_ptr<Message> MessageRef;
 extern Message *decode_message(CephContext *cct, int crcflags,
 			       ceph_msg_header &header,
 			       ceph_msg_footer& footer, bufferlist& front,
-			       bufferlist& middle, bufferlist& data);
-inline ostream& operator<<(ostream &out, const Message &m) {
+			       bufferlist& middle, bufferlist& data,
+			       Connection* conn);
+inline ostream& operator<<(ostream& out, const Message& m) {
   m.print(out);
   if (m.get_header().version)
     out << " v" << m.get_header().version;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -26,6 +26,7 @@
 #include "include/types.h"
 #include "include/buffer.h"
 #include "common/Throttle.h"
+#include "common/zipkin_trace.h"
 #include "msg_types.h"
 
 #include "common/RefCountedObj.h"
@@ -220,6 +221,11 @@ protected:
   bi::list_member_hook<> dispatch_q;
 
 public:
+  // zipkin tracing
+  ZTracer::Trace trace;
+  void encode_trace(bufferlist &bl, uint64_t features) const;
+  void decode_trace(bufferlist::iterator &p, bool create = false);
+
   class CompletionHook : public Context {
   protected:
     Message *m;
@@ -277,6 +283,7 @@ protected:
     if (byte_throttler)
       byte_throttler->put(payload.length() + middle.length() + data.length());
     release_message_throttle();
+    trace.event("message destructed");
     /* call completion hooks (if any) */
     if (completion_hook)
       completion_hook->complete(0);

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <random>
+#include <netdb.h>
 #include "include/Spinlock.h"
 
 #include "include/types.h"

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -3,6 +3,7 @@
 
 #include <random>
 #include "include/Spinlock.h"
+
 #include "include/types.h"
 #include "Messenger.h"
 
@@ -44,6 +45,27 @@ Messenger *Messenger::create(CephContext *cct, const string &type,
 #endif
   lderr(cct) << "unrecognized ms_type '" << type << "'" << dendl;
   return nullptr;
+}
+
+void Messenger::set_endpoint_addr(const entity_addr_t& a, 
+                                  const entity_name_t &name)
+{
+  size_t hostlen;
+  if (a.get_family() == AF_INET)
+    hostlen = sizeof(struct sockaddr_in);
+  else if (a.get_family() == AF_INET6)
+    hostlen = sizeof(struct sockaddr_in6);
+  else
+    hostlen = 0;
+
+  if (hostlen) {
+    char buf[NI_MAXHOST] = { 0 };
+    getnameinfo(a.get_sockaddr(), hostlen, buf, sizeof(buf),
+                NULL, 0, NI_NUMERICHOST);
+
+    trace_endpoint.copy_ip(buf);
+  }
+  trace_endpoint.set_port(a.get_port());
 }
 
 /*

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -41,6 +41,10 @@ class Messenger {
 private:
   list<Dispatcher*> dispatchers;
   list <Dispatcher*> fast_dispatchers;
+  ZTracer::Endpoint trace_endpoint;
+
+  void set_endpoint_addr(const entity_addr_t& a,
+                         const entity_name_t &name);
 
 protected:
   /// the "name" of the local daemon. eg client.99
@@ -136,7 +140,8 @@ public:
    * or use the create() function.
    */
   Messenger(CephContext *cct_, entity_name_t w)
-    : my_inst(),
+    : trace_endpoint("0.0.0.0", 0, "Messenger"),
+      my_inst(),
       default_send_priority(CEPH_MSG_PRIO_DEFAULT), started(false),
       magic(0),
       socket_priority(-1),
@@ -214,8 +219,18 @@ protected:
   /**
    * set messenger's address
    */
-  virtual void set_myaddr(const entity_addr_t& a) { my_inst.addr = a; }
+  virtual void set_myaddr(const entity_addr_t& a) {
+    my_inst.addr = a;
+    set_endpoint_addr(a, my_inst.name);
+  }
 public:
+  /**
+   * @return the zipkin trace endpoint
+   */
+  const ZTracer::Endpoint* get_trace_endpoint() const {
+    return &trace_endpoint;
+  }
+
   /**
    * Retrieve the Messenger's name.
    *

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1907,6 +1907,7 @@ int AsyncConnection::send_message(Message *m)
                                << " Drop message " << m << dendl;
     m->put();
   } else {
+    m->trace.event("async enqueueing message");
     out_q[m->get_priority()].emplace_back(std::move(bl), m);
     ldout(async_msgr->cct, 15) << __func__ << " inline write is denied, reschedule m=" << m << dendl;
     if (can_write != WriteStatus::REPLACING)
@@ -2224,6 +2225,7 @@ ssize_t AsyncConnection::write_message(Message *m, bufferlist& bl, bool more)
     outcoming_bl.append((char*)&old_footer, sizeof(old_footer));
   }
 
+  m->trace.event("async writing message");
   logger->inc(l_msgr_send_bytes, outcoming_bl.length() - original_bl_len);
   ldout(async_msgr->cct, 20) << __func__ << " sending " << m->get_seq()
                              << " " << m << dendl;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -686,7 +686,8 @@ void AsyncConnection::process()
 
           ldout(async_msgr->cct, 20) << __func__ << " got " << front.length() << " + " << middle.length()
                               << " + " << data.length() << " byte message" << dendl;
-          Message *message = decode_message(async_msgr->cct, async_msgr->crcflags, current_header, footer, front, middle, data);
+          Message *message = decode_message(async_msgr->cct, async_msgr->crcflags, current_header, footer,
+                                            front, middle, data, this);
           if (!message) {
             ldout(async_msgr->cct, 1) << __func__ << " decode message failed " << dendl;
             goto fail;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1613,6 +1613,8 @@ void Pipe::reader()
 	continue;
       }
 
+      m->trace.event("pipe read message");
+
       if (state == STATE_CLOSED ||
 	  state == STATE_CONNECTING) {
 	in_q->dispatch_throttle_release(m->get_dispatch_throttle_size());
@@ -1846,6 +1848,8 @@ void Pipe::writer()
 	blist.append(m->get_data());
 
         pipe_lock.Unlock();
+
+        m->trace.event("pipe writing message");
 
         ldout(msgr->cct,20) << "writer sending " << m->get_seq() << " " << m << dendl;
 	int rc = write_message(header, footer, blist);

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2091,7 +2091,8 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
 
   ldout(msgr->cct,20) << "reader got " << front.length() << " + " << middle.length() << " + " << data.length()
 	   << " byte message" << dendl;
-  message = decode_message(msgr->cct, msgr->crcflags, header, footer, front, middle, data);
+  message = decode_message(msgr->cct, msgr->crcflags, header, footer,
+                           front, middle, data, connection_state.get());
   if (!message) {
     ret = -EINVAL;
     goto out_dethrottle;

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -425,6 +425,7 @@ void SimpleMessenger::submit_message(Message *m, PipeConnection *con,
 				     const entity_addr_t& dest_addr, int dest_type,
 				     bool already_locked)
 {
+  m->trace.event("simple submitting message");
   if (cct->_conf->ms_dump_on_send) {
     m->encode(-1, true);
     ldout(cct, 0) << "submit_message " << *m << "\n";

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -429,9 +429,8 @@ int XioConnection::handle_data_msg(struct xio_session *session,
   /* update connection timestamp */
   recv.set(tmsg->timestamp);
 
-  Message *m =
-    decode_message(msgr->cct, msgr->crcflags, header, footer, payload, middle,
-		   data);
+  Message *m = decode_message(msgr->cct, msgr->crcflags, header, footer,
+                              payload, middle, data, this);
 
   if (m) {
     /* completion */

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -938,7 +938,10 @@ assert(req->out.pdata_iov.nents || !nbuffers);
      }
     tail->next = NULL;
   }
-  xcon->portal->enqueue(xcon, xmsg);
+  xmsg->trace = m->trace;
+  m->trace.event("xio portal enqueue for send");
+  m->trace.keyval("xio message segments", xmsg->hdr.msg_cnt);
+  xcon->portal->enqueue_for_send(xcon, xmsg);
 
   return code;
 } /* send_message(Message *, Connection *) */

--- a/src/msg/xio/XioMsg.cc
+++ b/src/msg/xio/XioMsg.cc
@@ -27,6 +27,7 @@ int XioDispatchHook::release_msgs()
   /* queue for release */
   xcmp = static_cast<XioCompletion *>(rsp_pool.alloc(sizeof(XioCompletion)));
   new (xcmp) XioCompletion(xcon, this);
+  xcmp->trace = m->trace;
 
   /* merge with portal traffic */
   xcon->portal->enqueue(xcon, xcmp);

--- a/src/msg/xio/XioPortal.h
+++ b/src/msg/xio/XioPortal.h
@@ -170,6 +170,7 @@ public:
 	xcmp->xcon->msg_release_fail(msg, code);
       msg = next_msg;
     }
+    xcmp->trace.event("xio_release_msg");
     xcmp->finalize(); /* unconditional finalize */
   }
 
@@ -273,6 +274,7 @@ public:
 		  goto restart;
 		}
 
+		xs->trace.event("xio_send_msg");
 		msg = xsend->get_xio_msg();
 		code = xio_send_msg(xcon->conn, msg);
 		/* header trace moved here to capture xio serial# */

--- a/src/msg/xio/XioSubmit.h
+++ b/src/msg/xio/XioSubmit.h
@@ -40,6 +40,7 @@ public:
   enum submit_type type;
   bi::list_member_hook<> submit_list;
   XioConnection *xcon;
+  ZTracer::Trace trace;
 
   XioSubmit(enum submit_type _type, XioConnection *_xcon) :
     type(_type), xcon(_xcon)

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1689,9 +1689,11 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 
   if (osd_op) {
     osd_op->mark_event("commit_queued_for_journal_write");
-    osd_op->journal_trace.init("journal", &trace_endpoint, &osd_op->store_trace);
-    osd_op->journal_trace.event("submit_entry");
-    osd_op->journal_trace.keyval("seq", seq);
+    if (osd_op->store_trace) {
+      osd_op->journal_trace.init("journal", &trace_endpoint, &osd_op->store_trace);
+      osd_op->journal_trace.event("submit_entry");
+      osd_op->journal_trace.keyval("seq", seq);
+    }
   }
   {
     Mutex::Locker l1(writeq_lock);

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1003,8 +1003,11 @@ void FileJournal::queue_completions_thru(uint64_t seq)
     }
     if (next.finish)
       finisher->queue(next.finish);
-    if (next.tracked_op)
+    if (next.tracked_op) {
       next.tracked_op->mark_event("journaled_completion_queued");
+      next.tracked_op->journal_trace.event("queued completion");
+      next.tracked_op->journal_trace.keyval("completed through", seq);
+    }
     items.erase(it++);
   }
   batch_unpop_completions(items);
@@ -1049,8 +1052,10 @@ int FileJournal::prepare_single_write(write_item &next_write, bufferlist& bl, of
   footerptr.copy_in(post_offset + magic2_offset, sizeof(uint64_t), (char *)&magic2);
 
   bl.claim_append(ebl);
-  if (next_write.tracked_op)
+  if (next_write.tracked_op) {
     next_write.tracked_op->mark_event("write_thread_in_journal_buffer");
+    next_write.tracked_op->journal_trace.event("prepare_single_write");
+  }
 
   journalq.push_back(pair<uint64_t,off64_t>(seq, queue_pos));
   writing_seq = seq;
@@ -1682,6 +1687,12 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
     logger->inc(l_os_j_bytes, e.length());
   }
 
+  if (osd_op) {
+    osd_op->mark_event("commit_queued_for_journal_write");
+    osd_op->journal_trace.init("journal", &trace_endpoint, &osd_op->store_trace);
+    osd_op->journal_trace.event("submit_entry");
+    osd_op->journal_trace.keyval("seq", seq);
+  }
   {
     Mutex::Locker l1(writeq_lock);
 #ifdef HAVE_LIBAIO
@@ -1701,6 +1712,8 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
     if (writeq.empty())
       writeq_cond.Signal();
     writeq.push_back(write_item(seq, e, orig_len, osd_op));
+    if (osd_op)
+      osd_op->journal_trace.keyval("queue depth", writeq.size());
   }
 }
 

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -542,6 +542,7 @@ FileStore::FileStore(const std::string &base, const std::string &jdev, osflagbit
   op_wq(this, g_conf->filestore_op_thread_timeout,
 	g_conf->filestore_op_thread_suicide_timeout, &op_tp),
   logger(NULL),
+  trace_endpoint("0.0.0.0", 0, "FileStore"),
   read_error_lock("FileStore::read_error_lock"),
   m_filestore_commit_timeout(g_conf->filestore_commit_timeout),
   m_filestore_journal_parallel(g_conf->filestore_journal_parallel ),
@@ -1945,6 +1946,7 @@ void FileStore::queue_op(OpSequencer *osr, Op *o)
   // sequencer, the op order will be preserved.
 
   osr->queue(o);
+  o->trace.event("queued");
 
   logger->inc(l_os_ops);
   logger->inc(l_os_bytes, o->bytes);
@@ -1991,9 +1993,12 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
 
   osr->apply_lock.Lock();
   Op *o = osr->peek_queue();
+  o->trace.event("op_apply_start");
   apply_manager.op_apply_start(o->op);
   dout(5) << "_do_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " start" << dendl;
+  o->trace.event("_do_transactions start");
   int r = _do_transactions(o->tls, o->op, &handle);
+  o->trace.event("op_apply_finish");
   apply_manager.op_apply_finish(o->op);
   dout(10) << "_do_op " << o << " seq " << o->op << " r = " << r
 	   << ", finisher " << o->onreadable << " " << o->onreadable_sync << dendl;
@@ -2012,6 +2017,7 @@ void FileStore::_finish_op(OpSequencer *osr)
 
   dout(10) << "_finish_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " lat " << lat << dendl;
   osr->apply_lock.Unlock();  // locked in _do_op
+  o->trace.event("_finish_op");
 
   // called with tp lock held
   op_queue_release_throttle(o);
@@ -2081,6 +2087,12 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     (*i).set_osr(osr);
   }
 
+  ZTracer::Trace trace;
+  if (osd_op && osd_op->pg_trace) {
+    osd_op->store_trace.init("filestore op", &trace_endpoint, &osd_op->pg_trace);
+    trace = osd_op->store_trace;
+  }
+
   if (journal && journal->is_writeable() && !m_filestore_journal_trailing) {
     Op *o = build_op(tls, onreadable, onreadable_sync, osd_op);
 
@@ -2099,6 +2111,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
 
     uint64_t op_num = submit_manager.op_submit_start();
     o->op = op_num;
+    trace.keyval("opnum", op_num);
 
     if (m_filestore_do_dump)
       dump_transactions(o->tls, o->op, osr);
@@ -2106,15 +2119,20 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     if (m_filestore_journal_parallel) {
       dout(5) << "queue_transactions (parallel) " << o->op << " " << o->tls << dendl;
 
+      trace.keyval("journal mode", "parallel");
+      trace.event("journal started");
       _op_journal_transactions(tbl, orig_len, o->op, ondisk, osd_op);
 
       // queue inside submit_manager op submission lock
       queue_op(osr, o);
+      trace.event("op queued");
     } else if (m_filestore_journal_writeahead) {
       dout(5) << "queue_transactions (writeahead) " << o->op << " " << o->tls << dendl;
 
       osr->queue_journal(o->op);
 
+      trace.keyval("journal mode", "writeahead");
+      trace.event("journal started");
       _op_journal_transactions(tbl, orig_len, o->op,
 			       new C_JournaledAhead(this, osr, o, ondisk),
 			       osd_op);
@@ -2146,6 +2164,9 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
       dump_transactions(o->tls, o->op, osr);
 
     queue_op(osr, o);
+    trace.keyval("opnum", op_num);
+    trace.keyval("journal mode", "none");
+    trace.event("op queued");
 
     if (ondisk)
       apply_manager.add_waiter(op_num, ondisk);
@@ -2168,10 +2189,15 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   if (m_filestore_do_dump)
     dump_transactions(tls, op, osr);
 
+  trace.event("op_apply_start");
+  trace.keyval("opnum", op);
+  trace.keyval("journal mode", "trailing");
   apply_manager.op_apply_start(op);
+  trace.event("do_transactions");
   int r = do_transactions(tls, op);
 
   if (r >= 0) {
+    trace.event("journal started");
     _op_journal_transactions(tbl, orig_len, op, ondisk, osd_op);
   } else {
     delete ondisk;
@@ -2185,6 +2211,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   apply_finishers[osr->id % m_apply_finisher_num]->queue(onreadable, r);
 
   submit_manager.op_submit_finish(op);
+  trace.event("op_apply_finish");
   apply_manager.op_apply_finish(op);
 
   utime_t end = ceph_clock_now(g_ceph_context);
@@ -2195,6 +2222,8 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
 void FileStore::_journaled_ahead(OpSequencer *osr, Op *o, Context *ondisk)
 {
   dout(5) << "_journaled_ahead " << o << " seq " << o->op << " " << *osr << " " << o->tls << dendl;
+
+  o->trace.event("writeahead journal finished");
 
   // this should queue in order because the journal does it's completions in order.
   queue_op(osr, o);

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -23,6 +23,7 @@
 #include "common/Finisher.h"
 #include "common/TrackedOp.h"
 #include "os/ObjectStore.h"
+#include "common/zipkin_trace.h"
 
 class PerfCounters;
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -680,14 +680,14 @@ bool ECBackend::handle_message(
   switch (_op->get_req()->get_type()) {
   case MSG_OSD_EC_WRITE: {
     MOSDECSubOpWrite *op = static_cast<MOSDECSubOpWrite*>(_op->get_req());
-    handle_sub_write(op->op.from, _op, op->op);
+    handle_sub_write(op->op.from, _op, op->op, _op->pg_trace);
     return true;
   }
   case MSG_OSD_EC_WRITE_REPLY: {
     MOSDECSubOpWriteReply *op = static_cast<MOSDECSubOpWriteReply*>(
       _op->get_req());
     op->set_priority(priority);
-    handle_sub_write_reply(op->op.from, op->op);
+    handle_sub_write_reply(op->op.from, op->op, _op->pg_trace);
     return true;
   }
   case MSG_OSD_EC_READ: {
@@ -695,8 +695,9 @@ bool ECBackend::handle_message(
     MOSDECSubOpReadReply *reply = new MOSDECSubOpReadReply;
     reply->pgid = get_parent()->primary_spg_t();
     reply->map_epoch = get_parent()->get_epoch();
-    handle_sub_read(op->op.from, op->op, &(reply->op));
+    handle_sub_read(op->op.from, op->op, &(reply->op), _op->pg_trace);
     op->set_priority(priority);
+    reply->trace = _op->pg_trace;
     get_parent()->send_message_osd_cluster(
       op->op.from.osd, reply, get_parent()->get_epoch());
     return true;
@@ -705,7 +706,7 @@ bool ECBackend::handle_message(
     MOSDECSubOpReadReply *op = static_cast<MOSDECSubOpReadReply*>(
       _op->get_req());
     RecoveryMessages rm;
-    handle_sub_read_reply(op->op.from, op->op, &rm);
+    handle_sub_read_reply(op->op.from, op->op, &rm, _op->pg_trace);
     dispatch_recovery_messages(rm, priority);
     return true;
   }
@@ -743,22 +744,25 @@ struct SubWriteCommitted : public Context {
   ceph_tid_t tid;
   eversion_t version;
   eversion_t last_complete;
+  const ZTracer::Trace trace;
   SubWriteCommitted(
     ECBackend *pg,
     OpRequestRef msg,
     ceph_tid_t tid,
     eversion_t version,
-    eversion_t last_complete)
+    eversion_t last_complete,
+    const ZTracer::Trace &trace)
     : pg(pg), msg(msg), tid(tid),
-      version(version), last_complete(last_complete) {}
+      version(version), last_complete(last_complete), trace(trace) {}
   void finish(int) {
     if (msg)
       msg->mark_event("sub_op_committed");
-    pg->sub_write_committed(tid, version, last_complete);
+    pg->sub_write_committed(tid, version, last_complete, trace);
   }
 };
 void ECBackend::sub_write_committed(
-  ceph_tid_t tid, eversion_t version, eversion_t last_complete) {
+  ceph_tid_t tid, eversion_t version, eversion_t last_complete,
+  const ZTracer::Trace &trace) {
   if (get_parent()->pgb_is_primary()) {
     ECSubWriteReply reply;
     reply.tid = tid;
@@ -767,7 +771,7 @@ void ECBackend::sub_write_committed(
     reply.from = get_parent()->whoami_shard();
     handle_sub_write_reply(
       get_parent()->whoami_shard(),
-      reply);
+      reply, trace);
   } else {
     get_parent()->update_last_complete_ondisk(last_complete);
     MOSDECSubOpWriteReply *r = new MOSDECSubOpWriteReply;
@@ -778,6 +782,8 @@ void ECBackend::sub_write_committed(
     r->op.committed = true;
     r->op.from = get_parent()->whoami_shard();
     r->set_priority(CEPH_MSG_PRIO_HIGH);
+    r->trace = trace;
+    r->trace.event("sending sub op commit");
     get_parent()->send_message_osd_cluster(
       get_parent()->primary_shard().osd, r, get_parent()->get_epoch());
   }
@@ -788,20 +794,23 @@ struct SubWriteApplied : public Context {
   OpRequestRef msg;
   ceph_tid_t tid;
   eversion_t version;
+  const ZTracer::Trace trace;
   SubWriteApplied(
     ECBackend *pg,
     OpRequestRef msg,
     ceph_tid_t tid,
-    eversion_t version)
-    : pg(pg), msg(msg), tid(tid), version(version) {}
+    eversion_t version,
+    const ZTracer::Trace &trace)
+    : pg(pg), msg(msg), tid(tid), version(version), trace(trace) {}
   void finish(int) {
     if (msg)
       msg->mark_event("sub_op_applied");
-    pg->sub_write_applied(tid, version);
+    pg->sub_write_applied(tid, version, trace);
   }
 };
 void ECBackend::sub_write_applied(
-  ceph_tid_t tid, eversion_t version) {
+  ceph_tid_t tid, eversion_t version,
+  const ZTracer::Trace &trace) {
   parent->op_applied(version);
   if (get_parent()->pgb_is_primary()) {
     ECSubWriteReply reply;
@@ -810,7 +819,7 @@ void ECBackend::sub_write_applied(
     reply.applied = true;
     handle_sub_write_reply(
       get_parent()->whoami_shard(),
-      reply);
+      reply, trace);
   } else {
     MOSDECSubOpWriteReply *r = new MOSDECSubOpWriteReply;
     r->pgid = get_parent()->primary_spg_t();
@@ -819,6 +828,8 @@ void ECBackend::sub_write_applied(
     r->op.tid = tid;
     r->op.applied = true;
     r->set_priority(CEPH_MSG_PRIO_HIGH);
+    r->trace = trace;
+    r->trace.event("sending sub op apply");
     get_parent()->send_message_osd_cluster(
       get_parent()->primary_shard().osd, r, get_parent()->get_epoch());
   }
@@ -828,10 +839,12 @@ void ECBackend::handle_sub_write(
   pg_shard_t from,
   OpRequestRef msg,
   ECSubWrite &op,
+  const ZTracer::Trace &trace,
   Context *on_local_applied_sync)
 {
   if (msg)
     msg->mark_started();
+  trace.event("handle_sub_write");
   assert(!get_parent()->get_log().get_missing().is_missing(op.soid));
   if (!get_parent()->pgb_is_primary())
     get_parent()->update_stats(op.stats);
@@ -876,10 +889,10 @@ void ECBackend::handle_sub_write(
       new SubWriteCommitted(
 	this, msg, op.tid,
 	op.at_version,
-	get_parent()->get_info().last_complete)));
+	get_parent()->get_info().last_complete, trace)));
   localt.register_on_applied(
     get_parent()->bless_context(
-      new SubWriteApplied(this, msg, op.tid, op.at_version)));
+      new SubWriteApplied(this, msg, op.tid, op.at_version, trace)));
   vector<ObjectStore::Transaction> tls;
   tls.reserve(2);
   tls.push_back(std::move(localt));
@@ -890,9 +903,11 @@ void ECBackend::handle_sub_write(
 void ECBackend::handle_sub_read(
   pg_shard_t from,
   ECSubRead &op,
-  ECSubReadReply *reply)
+  ECSubReadReply *reply,
+  const ZTracer::Trace &trace)
 {
   shard_id_t shard = get_parent()->whoami_shard().shard;
+  trace.event("handle sub read");
   for(map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator>::iterator i =
         op.to_read.begin();
       i != op.to_read.end();
@@ -981,11 +996,13 @@ error:
 
 void ECBackend::handle_sub_write_reply(
   pg_shard_t from,
-  ECSubWriteReply &op)
+  ECSubWriteReply &op,
+  const ZTracer::Trace &trace)
 {
   map<ceph_tid_t, Op>::iterator i = tid_to_op_map.find(op.tid);
   assert(i != tid_to_op_map.end());
   if (op.committed) {
+    trace.event("sub write committed");
     assert(i->second.pending_commit.count(from));
     i->second.pending_commit.erase(from);
     if (from != get_parent()->whoami_shard()) {
@@ -993,6 +1010,7 @@ void ECBackend::handle_sub_write_reply(
     }
   }
   if (op.applied) {
+    trace.event("sub write applied");
     assert(i->second.pending_apply.count(from));
     i->second.pending_apply.erase(from);
   }
@@ -1002,8 +1020,10 @@ void ECBackend::handle_sub_write_reply(
 void ECBackend::handle_sub_read_reply(
   pg_shard_t from,
   ECSubReadReply &op,
-  RecoveryMessages *m)
+  RecoveryMessages *m,
+  const ZTracer::Trace &trace)
 {
+  trace.event("ec sub read reply");
   dout(10) << __func__ << ": reply " << op << dendl;
   map<ceph_tid_t, ReadOp>::iterator iter = tid_to_read_map.find(op.tid);
   if (iter == tid_to_read_map.end()) {
@@ -1133,6 +1153,7 @@ void ECBackend::handle_sub_read_reply(
   }
   if (rop.in_progress.empty() || is_complete == rop.complete.size()) {
     dout(20) << __func__ << " Complete: " << rop << dendl;
+    rop.trace.event("ec read complete");
     complete_read_op(rop, m);
   } else {
     dout(10) << __func__ << " readop not complete: " << rop << dendl;
@@ -1371,6 +1392,8 @@ void ECBackend::submit_transaction(
   op->tid = tid;
   op->reqid = reqid;
   op->client_op = client_op;
+  if (client_op)
+    op->trace = client_op->pg_trace;
   
   op->t.reset(static_cast<ECTransaction*>(_t.release()));
 
@@ -1560,6 +1583,10 @@ void ECBackend::start_read_op(
   op.op = _op;
   op.do_redundant_reads = do_redundant_reads;
   op.for_recovery = for_recovery;
+  if (_op) {
+    op.trace = _op->pg_trace;
+    op.trace.event("start ec read");
+  }
   dout(10) << __func__ << ": starting " << op << dendl;
 
   map<pg_shard_t, ECSubRead> messages;
@@ -1617,6 +1644,11 @@ void ECBackend::start_read_op(
     msg->op = i->second;
     msg->op.from = get_parent()->whoami_shard();
     msg->op.tid = tid;
+    if (op.trace) {
+      // initialize a child span for this shard
+      msg->trace.init("ec sub read", nullptr, &op.trace);
+      msg->trace.keyval("shard", i->first.shard.id);
+    }
     get_parent()->send_message_osd_cluster(
       i->first.osd,
       msg,
@@ -1750,11 +1782,13 @@ void ECBackend::check_op(Op *op)
     dout(10) << __func__ << " Calling on_all_applied on " << *op << dendl;
     op->on_all_applied->complete(0);
     op->on_all_applied = 0;
+    op->trace.event("ec write all applied");
   }
   if (op->pending_commit.empty() && op->on_all_commit) {
     dout(10) << __func__ << " Calling on_all_commit on " << *op << dendl;
     op->on_all_commit->complete(0);
     op->on_all_commit = 0;
+    op->trace.event("ec write all committed");
   }
   if (op->pending_apply.empty() && op->pending_commit.empty()) {
     // done!
@@ -1762,6 +1796,7 @@ void ECBackend::check_op(Op *op)
     dout(10) << __func__ << " Completing " << *op << dendl;
     writing.pop_front();
     tid_to_op_map.erase(op->tid);
+    op->trace.event("ec write complete");
   }
   for (map<ceph_tid_t, Op>::iterator i = tid_to_op_map.begin();
        i != tid_to_op_map.end();
@@ -1780,6 +1815,7 @@ void ECBackend::start_write(Op *op) {
   }
   ObjectStore::Transaction empty;
 
+  op->trace.event("start ec write");
   op->t->generate_transactions(
     op->unstable_hash_infos,
     ec_impl,
@@ -1820,17 +1856,27 @@ void ECBackend::start_write(Op *op) {
       op->updated_hit_set_history,
       op->temp_added,
       op->temp_cleared);
+
+    ZTracer::Trace trace;
+    if (op->trace) {
+      // initialize a child span for this shard
+      trace.init("ec sub write", nullptr, &op->trace);
+      trace.keyval("shard", i->shard.id);
+    }
+
     if (*i == get_parent()->whoami_shard()) {
       handle_sub_write(
 	get_parent()->whoami_shard(),
 	op->client_op,
 	sop,
+	trace,
 	op->on_local_applied_sync);
       op->on_local_applied_sync = 0;
     } else {
       MOSDECSubOpWrite *r = new MOSDECSubOpWrite(sop);
       r->pgid = spg_t(get_parent()->primary_spg_t().pgid, i->shard);
       r->map_epoch = get_parent()->get_epoch();
+      r->trace = trace;
       get_parent()->send_message_osd_cluster(
 	i->osd, r, get_parent()->get_epoch());
     }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -55,28 +55,37 @@ public:
   friend struct SubWriteApplied;
   friend struct SubWriteCommitted;
   void sub_write_applied(
-    ceph_tid_t tid, eversion_t version);
+    ceph_tid_t tid,
+    eversion_t version,
+    const ZTracer::Trace &trace);
   void sub_write_committed(
-    ceph_tid_t tid, eversion_t version, eversion_t last_complete);
+    ceph_tid_t tid,
+    eversion_t version,
+    eversion_t last_complete,
+    const ZTracer::Trace &trace);
   void handle_sub_write(
     pg_shard_t from,
     OpRequestRef msg,
     ECSubWrite &op,
+    const ZTracer::Trace &trace,
     Context *on_local_applied_sync = 0
     );
   void handle_sub_read(
     pg_shard_t from,
     ECSubRead &op,
-    ECSubReadReply *reply
+    ECSubReadReply *reply,
+    const ZTracer::Trace &trace
     );
   void handle_sub_write_reply(
     pg_shard_t from,
-    ECSubWriteReply &op
+    ECSubWriteReply &op,
+    const ZTracer::Trace &trace
     );
   void handle_sub_read_reply(
     pg_shard_t from,
     ECSubReadReply &op,
-    RecoveryMessages *m
+    RecoveryMessages *m,
+    const ZTracer::Trace &trace
     );
 
   /// @see ReadOp below
@@ -301,6 +310,8 @@ public:
     // of the available shards.
     bool for_recovery;
 
+    ZTracer::Trace trace;
+
     map<hobject_t, read_request_t, hobject_t::BitwiseComparator> to_read;
     map<hobject_t, read_result_t, hobject_t::BitwiseComparator> complete;
 
@@ -358,6 +369,7 @@ public:
     ceph_tid_t tid;
     osd_reqid_t reqid;
     OpRequestRef client_op;
+    ZTracer::Trace trace;
 
     std::unique_ptr<ECTransaction> t;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1652,6 +1652,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   clog(log_client.create_channel()),
   whoami(id),
   dev_path(dev), journal_path(jdev),
+  trace_endpoint("0.0.0.0", 0, "osd"),
   asok_hook(NULL),
   osd_compat(get_osd_compat_set()),
   osd_tp(cct, "OSD::osd_tp", "tp_osd", cct->_conf->osd_op_threads, "osd_op_threads"),
@@ -1713,6 +1714,11 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
                                          cct->_conf->osd_op_log_threshold);
   op_tracker.set_history_size_and_duration(cct->_conf->osd_op_history_size,
                                            cct->_conf->osd_op_history_duration);
+#ifdef WITH_BLKIN
+  std::stringstream ss;
+  ss << "osd." << whoami;
+  trace_endpoint.copy_name(ss.str());
+#endif
 }
 
 OSD::~OSD()
@@ -5936,6 +5942,8 @@ void OSD::ms_fast_dispatch(Message *m)
     tracepoint(osd, ms_fast_dispatch, reqid.name._type,
         reqid.name._num, reqid.tid, reqid.inc);
   }
+  if (m->trace)
+    op->osd_trace.init("osd op", &trace_endpoint, &m->trace);
   OSDMapRef nextmap = service.get_nextmap_reserved();
   Session *session = static_cast<Session*>(m->get_connection()->get_priv());
   if (session) {
@@ -6292,6 +6300,8 @@ void OSD::_dispatch(Message *m)
   default:
     {
       OpRequestRef op = op_tracker.create_request<OpRequest, Message*>(m);
+      if (m->trace)
+        op->osd_trace.init("osd op", &trace_endpoint, &m->trace);
       // no map?  starting up?
       if (!osdmap) {
         dout(7) << "no OSDMap, not booted" << dendl;
@@ -8675,10 +8685,16 @@ bool OSD::op_is_discardable(MOSDOp *op)
 void OSD::enqueue_op(PGRef pg, OpRequestRef& op)
 {
   utime_t latency = ceph_clock_now(cct) - op->get_req()->get_recv_stamp();
-  dout(15) << "enqueue_op " << op << " prio " << op->get_req()->get_priority()
-	   << " cost " << op->get_req()->get_cost()
-	   << " latency " << latency
+  auto priority = op->get_req()->get_priority();
+  auto cost = op->get_req()->get_cost();
+
+  dout(15) << "enqueue_op " << op << " prio " << priority
+	   << " cost " << cost << " latency " << latency
 	   << " " << *(op->get_req()) << dendl;
+  op->osd_trace.event("enqueue op");
+  op->osd_trace.keyval("priority", priority);
+  op->osd_trace.keyval("cost", cost);
+
   pg->queue_op(op);
 }
 
@@ -8865,6 +8881,7 @@ void OSD::dequeue_op(
     return;
 
   op->mark_reached_pg();
+  op->osd_trace.event("dequeue_op");
 
   pg->do_request(op, handle);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -24,6 +24,9 @@
 #include "common/Timer.h"
 #include "common/WorkQueue.h"
 #include "common/AsyncReserver.h"
+#include "common/ceph_context.h"
+#include "common/zipkin_trace.h"
+
 #include "os/ObjectStore.h"
 #include "OSDCap.h" 
  
@@ -1218,6 +1221,7 @@ protected:
   int whoami;
   std::string dev_path, journal_path;
 
+  ZTracer::Endpoint trace_endpoint;
   void create_logger();
   void create_recoverystate_perf();
   void tick();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -211,7 +211,9 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   #ifdef PG_DEBUG_REFS
   _ref_id_lock("PG::_ref_id_lock"), _ref_id(0),
   #endif
-  deleting(false), dirty_info(false), dirty_big_info(false),
+  deleting(false),
+  trace_endpoint("0.0.0.0", 0, "PG"),
+  dirty_info(false), dirty_big_info(false),
   info(p),
   info_struct_v(0),
   coll(p), pg_log(cct),
@@ -248,6 +250,11 @@ PG::PG(OSDService *o, OSDMapRef curmap,
 {
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
+#endif
+#ifdef WITH_BLKIN
+  std::stringstream ss;
+  ss << "PG " << info.pgid;
+  trace_endpoint.copy_name(ss.str());
 #endif
   osr->shard_hint = p;
 }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -263,6 +263,7 @@ protected:
 public:
   bool deleting;  // true while in removing or OSD is shutting down
 
+  ZTracer::Endpoint trace_endpoint;
 
   void lock_suspend_timeout(ThreadPool::TPHandle &handle);
   void lock(bool no_lockdep = false) const;

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1559,6 +1559,10 @@ void ReplicatedPG::do_request(
   OpRequestRef& op,
   ThreadPool::TPHandle &handle)
 {
+  if (op->osd_trace) {
+    op->pg_trace.init("pg op", &trace_endpoint, &op->osd_trace);
+    op->pg_trace.event("do request");
+  }
   assert(!op_must_wait_for_map(get_osdmap()->get_epoch(), op));
   if (can_discard_request(op)) {
     return;

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -65,16 +65,21 @@ class ObjectCacher::C_RetryRead : public Context {
   OSDRead *rd;
   ObjectSet *oset;
   Context *onfinish;
+  ZTracer::Trace r_trace;
 public:
-  C_RetryRead(ObjectCacher *_oc, OSDRead *r, ObjectSet *os, Context *c)
-    : oc(_oc), rd(r), oset(os), onfinish(c) {}
+  C_RetryRead(ObjectCacher *_oc, OSDRead *r, ObjectSet *os, Context *c, ZTracer::Trace *trace = nullptr)
+    : oc(_oc), rd(r), oset(os), onfinish(c) {
+      if (trace) {
+        r_trace = *trace;
+      }
+    }
   void finish(int r) {
     if (r < 0) {
       if (onfinish)
         onfinish->complete(r);
       return;
     }
-    int ret = oc->_readx(rd, oset, onfinish, false);
+    int ret = oc->_readx(rd, oset, onfinish, false, &r_trace);
     if (ret != 0 && onfinish) {
       onfinish->complete(ret);
     }
@@ -271,7 +276,8 @@ int ObjectCacher::Object::map_read(ObjectExtent &ex,
                                    map<loff_t, BufferHead*>& hits,
                                    map<loff_t, BufferHead*>& missing,
                                    map<loff_t, BufferHead*>& rx,
-				   map<loff_t, BufferHead*>& errors)
+				   map<loff_t, BufferHead*>& errors,
+           ZTracer::Trace *trace)
 {
   assert(oc->lock.is_locked());
   ldout(oc->cct, 10) << "map_read " << ex.oid 
@@ -286,7 +292,7 @@ int ObjectCacher::Object::map_read(ObjectExtent &ex,
     // at end?
     if (p == data.end()) {
       // rest is a miss.
-      BufferHead *n = new BufferHead(this);
+      BufferHead *n = new BufferHead(this, trace);
       n->set_start(cur);
       n->set_length(left);
       oc->bh_add(this, n);
@@ -332,7 +338,7 @@ int ObjectCacher::Object::map_read(ObjectExtent &ex,
     } else if (p->first > cur) {
       // gap.. miss
       loff_t next = p->first;
-      BufferHead *n = new BufferHead(this);
+      BufferHead *n = new BufferHead(this, trace);
       loff_t len = MIN(next - cur, left);
       n->set_start(cur);
       n->set_length(len);
@@ -396,7 +402,7 @@ void ObjectCacher::Object::audit_buffers()
  * other dirty data to left and/or right.
  */
 ObjectCacher::BufferHead *ObjectCacher::Object::map_write(ObjectExtent &ex,
-    ceph_tid_t tid)
+    ceph_tid_t tid, ZTracer::Trace *trace)
 {
   assert(oc->lock.is_locked());
   BufferHead *final = 0;
@@ -414,7 +420,7 @@ ObjectCacher::BufferHead *ObjectCacher::Object::map_write(ObjectExtent &ex,
     // at end ?
     if (p == data.end()) {
       if (final == NULL) {
-        final = new BufferHead(this);
+        final = new BufferHead(this, trace);
         replace_journal_tid(final, tid);
         final->set_start( cur );
         final->set_length( max );
@@ -490,7 +496,7 @@ ObjectCacher::BufferHead *ObjectCacher::Object::map_write(ObjectExtent &ex,
         final->set_length(final->length() + glen);
         oc->bh_stat_add(final);
       } else {
-        final = new BufferHead(this);
+        final = new BufferHead(this, trace);
 	replace_journal_tid(final, tid);
         final->set_start( cur );
         final->set_length( glen );
@@ -741,7 +747,8 @@ void ObjectCacher::bh_read(BufferHead *bh, int op_flags)
 			 bh->ob->get_oloc(), bh->start(), bh->length(),
 			 bh->ob->get_snap(), &onfinish->bl,
 			 bh->ob->truncate_size, bh->ob->truncate_seq,
-			 op_flags, onfinish);
+			 op_flags, onfinish,
+       &bh->b_trace);
 
   ++reads_outstanding;
 }
@@ -1066,7 +1073,8 @@ void ObjectCacher::bh_write(BufferHead *bh)
 					   bh->snapc, bh->bl, bh->last_write,
 					   bh->ob->truncate_size,
 					   bh->ob->truncate_seq,
-					   bh->journal_tid, oncommit);
+					   bh->journal_tid, oncommit,
+             &bh->b_trace);
   ldout(cct, 20) << " tid " << tid << " on " << bh->ob->get_oid() << dendl;
 
   // set bh last_write_tid
@@ -1291,13 +1299,13 @@ bool ObjectCacher::is_cached(ObjectSet *oset, vector<ObjectExtent>& extents,
  *           must delete it)
  * returns 0 if doing async read
  */
-int ObjectCacher::readx(OSDRead *rd, ObjectSet *oset, Context *onfinish)
+int ObjectCacher::readx(OSDRead *rd, ObjectSet *oset, Context *onfinish, ZTracer::Trace *trace)
 {
-  return _readx(rd, oset, onfinish, true);
+  return _readx(rd, oset, onfinish, true, trace);
 }
 
 int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
-			 bool external_call)
+			 bool external_call, ZTracer::Trace *trace)
 {
   assert(lock.is_locked());
   bool success = true;
@@ -1361,7 +1369,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  ldout(cct, 10) << "readx  waiting on tid " << o->last_write_tid
 			 << " on " << *o << dendl;
 	  o->waitfor_commit[o->last_write_tid].push_back(
-	    new C_RetryRead(this,rd, oset, onfinish));
+	    new C_RetryRead(this,rd, oset, onfinish, trace));
 	  // FIXME: perfcounter!
 	  return 0;
 	}
@@ -1390,7 +1398,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 
     // map extent into bufferheads
     map<loff_t, BufferHead*> hits, missing, rx, errors;
-    o->map_read(*ex_it, hits, missing, rx, errors);
+    o->map_read(*ex_it, hits, missing, rx, errors, trace);
     if (external_call) {
       // retry reading error buffers
       missing.insert(errors.begin(), errors.end());
@@ -1418,7 +1426,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 			   << waitfor_read.size() << " blocked reads, "
 			   << (MAX(rx_bytes, max_size) - max_size)
 			   << " read bytes" << dendl;
-	    waitfor_read.push_back(new C_RetryRead(this, rd, oset, onfinish));
+	    waitfor_read.push_back(new C_RetryRead(this, rd, oset, onfinish, trace));
 	  }
 
 	  bh_remove(o, bh_it->second);
@@ -1437,7 +1445,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	ldout(cct, 10) << "readx missed, waiting on " << *last->second
 	  << " off " << last->first << dendl;
 	last->second->waitfor_read[last->first].push_back(
-	  new C_RetryRead(this, rd, oset, onfinish) );
+	  new C_RetryRead(this, rd, oset, onfinish, trace) );
 
       }
 
@@ -1450,7 +1458,7 @@ int ObjectCacher::_readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
 	  ldout(cct, 10) << "readx missed, waiting on " << *bh_it->second
 			 << " off " << bh_it->first << dendl;
 	  bh_it->second->waitfor_read[bh_it->first].push_back(
-	    new C_RetryRead(this, rd, oset, onfinish) );
+	    new C_RetryRead(this, rd, oset, onfinish, trace) );
 	}
 	bytes_not_in_cache += bh_it->second->length();
 	success = false;
@@ -1617,7 +1625,7 @@ void ObjectCacher::retry_waiting_reads()
   waitfor_read.splice(waitfor_read.end(), ls);
 }
 
-int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace)
+int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace, ZTracer::Trace *trace)
 {
   assert(lock.is_locked());
   ceph::real_time now = ceph::real_clock::now();
@@ -1635,7 +1643,7 @@ int ObjectCacher::writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace)
 			   ex_it->truncate_size, oset->truncate_seq);
 
     // map it all into a single bufferhead.
-    BufferHead *bh = o->map_write(*ex_it, wr->journal_tid);
+    BufferHead *bh = o->map_write(*ex_it, wr->journal_tid, trace);
     bool missing = bh->is_missing();
     bh->snapc = wr->snapc;
     

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -354,7 +354,7 @@ class ObjectCacher {
       ZTracer::Trace *trace);
     BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid, ZTracer::Trace *trace);
     
-    void replace_journal_tid(BufferHead *bh, ceph_tid_t tid);
+    void replace_journal_tid(BufferHead *bh, ceph_tid_t tid, ZTracer::Trace *trace);
     void truncate(loff_t s);
     void discard(loff_t off, loff_t len);
 

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -11,6 +11,7 @@
 #include "common/Cond.h"
 #include "common/Finisher.h"
 #include "common/Thread.h"
+#include "common/zipkin_trace.h"
 
 #include "Objecter.h"
 #include "Striper.h"
@@ -127,9 +128,10 @@ class ObjectCacher {
     int error; // holds return value for failed reads
 
     map<loff_t, list<Context*> > waitfor_read;
+    ZTracer::Trace b_trace;
 
     // cons
-    explicit BufferHead(Object *o) :
+    explicit BufferHead(Object *o, ZTracer::Trace *trace = nullptr) :
       state(STATE_MISSING),
       ref(0),
       dontneed(false),
@@ -140,6 +142,9 @@ class ObjectCacher {
       journal_tid(0),
       error(0) {
       ex.start = ex.length = 0;
+      if (trace) {
+        b_trace = *trace;
+      }
     }
 
     // extent
@@ -345,8 +350,9 @@ class ObjectCacher {
                  map<loff_t, BufferHead*>& hits,
                  map<loff_t, BufferHead*>& missing,
                  map<loff_t, BufferHead*>& rx,
-		 map<loff_t, BufferHead*>& errors);
-    BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid);
+		 map<loff_t, BufferHead*>& errors,
+      ZTracer::Trace *trace);
+    BufferHead *map_write(ObjectExtent &ex, ceph_tid_t tid, ZTracer::Trace *trace);
     
     void replace_journal_tid(BufferHead *bh, ceph_tid_t tid);
     void truncate(loff_t s);
@@ -544,7 +550,7 @@ class ObjectCacher {
   Cond read_cond;
 
   int _readx(OSDRead *rd, ObjectSet *oset, Context *onfinish,
-	     bool external_call);
+	     bool external_call, ZTracer::Trace *trace = nullptr);
   void retry_waiting_reads();
 
  public:
@@ -594,8 +600,8 @@ class ObjectCacher {
    * @note total read size must be <= INT_MAX, since
    * the return value is total bytes read
    */
-  int readx(OSDRead *rd, ObjectSet *oset, Context *onfinish);
-  int writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace);
+  int readx(OSDRead *rd, ObjectSet *oset, Context *onfinish, ZTracer::Trace *trace = nullptr);
+  int writex(OSDWrite *wr, ObjectSet *oset, Context *onfreespace, ZTracer::Trace *trace = nullptr);
   bool is_cached(ObjectSet *oset, vector<ObjectExtent>& extents,
 		 snapid_t snapid);
 

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3049,6 +3049,7 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   m->ops = op->ops;
   m->set_mtime(op->mtime);
   m->set_retry_attempt(op->attempts++);
+  m->trace = op->trace;
 
   if (op->replay_version != eversion_t())
     m->set_version(op->replay_version);  // we're replaying this op!

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3050,6 +3050,8 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   m->set_mtime(op->mtime);
   m->set_retry_attempt(op->attempts++);
   m->trace = op->trace;
+  if (!m->trace && cct->_conf->osdc_blkin_trace_all)
+    m->trace.init("objecter op", &trace_endpoint);
 
   if (op->replay_version != eversion_t())
     m->set_version(op->replay_version);  // we're replaying this op!

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2168,9 +2168,10 @@ public:
     ObjectOperation& op, const SnapContext& snapc,
     ceph::real_time mtime, int flags, Context *onack,
     Context *oncommit, version_t *objver = NULL,
+    ZTracer::Trace *trace = nullptr,
     osd_reqid_t reqid = osd_reqid_t()) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver, nullptr, trace);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
@@ -2185,7 +2186,7 @@ public:
     Context *oncommit, version_t *objver = NULL,
     osd_reqid_t reqid = osd_reqid_t()) {
     Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags, onack,
-			      oncommit, objver, reqid);
+			      oncommit, objver, nullptr, reqid);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;
@@ -2196,9 +2197,10 @@ public:
     snapid_t snapid, bufferlist *pbl, int flags,
     Context *onack, version_t *objver = NULL,
     int *data_offset = NULL,
-    uint64_t features = 0) {
+    uint64_t features = 0,
+    ZTracer::Trace *trace = nullptr) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_READ, onack, NULL, objver, data_offset);
+		   CEPH_OSD_FLAG_READ, onack, NULL, objver, data_offset, trace);
     o->priority = op.priority;
     o->snapid = snapid;
     o->outbl = pbl;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -35,10 +35,10 @@
 #include "common/ceph_timer.h"
 #include "common/Finisher.h"
 #include "common/shunique_lock.h"
+#include "common/zipkin_trace.h"
 
 #include "messages/MOSDOp.h"
 #include "osd/OSDMap.h"
-
 
 using namespace std;
 
@@ -1110,6 +1110,7 @@ public:
   Messenger *messenger;
   MonClient *monc;
   Finisher *finisher;
+  ZTracer::Endpoint trace_endpoint;
 private:
   OSDMap    *osdmap;
 public:
@@ -1269,9 +1270,11 @@ public:
     epoch_t last_force_resend;
 
     osd_reqid_t reqid; // explicitly setting reqid
+    ZTracer::Trace trace;
 
     Op(const object_t& o, const object_locator_t& ol, vector<OSDOp>& op,
-       int f, Context *ac, Context *co, version_t *ov, int *offset = NULL) :
+       int f, Context *ac, Context *co, version_t *ov, int *offset = NULL,
+       ZTracer::Trace *parent_trace = nullptr) :
       session(NULL), incarnation(0),
       target(o, ol, f),
       con(NULL),
@@ -1307,6 +1310,9 @@ public:
 
       if (target.base_oloc.key == o)
 	target.base_oloc.key.clear();
+
+      if (parent_trace && parent_trace->valid())
+        trace.init("op", nullptr, parent_trace);
     }
 
     bool operator<(const Op& other) const {
@@ -1939,6 +1945,7 @@ private:
 	   double mon_timeout,
 	   double osd_timeout) :
     Dispatcher(cct_), messenger(m), monc(mc), finisher(fin),
+    trace_endpoint("0.0.0.0", 0, "Objecter"),
     osdmap(new OSDMap), initialized(0), last_tid(0), client_inc(-1),
     max_linger_id(0), num_unacked(0), num_uncommitted(0), global_op_flags(0),
     keep_balanced_budget(false), honor_osdmap_full(true),
@@ -2332,7 +2339,8 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t off, uint64_t len, snapid_t snap, bufferlist *pbl,
     int flags, Context *onfinish, version_t *objver = NULL,
-    ObjectOperation *extra_ops = NULL, int op_flags = 0) {
+    ObjectOperation *extra_ops = NULL, int op_flags = 0,
+    ZTracer::Trace *parent_trace = nullptr) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_READ;
@@ -2342,7 +2350,8 @@ public:
     ops[i].op.extent.truncate_seq = 0;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_READ, onfinish, 0, objver);
+		   CEPH_OSD_FLAG_READ, onfinish, 0, objver,
+                   nullptr, parent_trace);
     o->snapid = snap;
     o->outbl = pbl;
     return o;
@@ -2465,7 +2474,8 @@ public:
     uint64_t off, uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
     Context *onack, Context *oncommit, version_t *objver = NULL,
-    ObjectOperation *extra_ops = NULL, int op_flags = 0) {
+    ObjectOperation *extra_ops = NULL, int op_flags = 0,
+    ZTracer::Trace *parent_trace = nullptr) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_WRITE;
@@ -2476,7 +2486,8 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver,
+                   nullptr, parent_trace);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;

--- a/src/osdc/WritebackHandler.h
+++ b/src/osdc/WritebackHandler.h
@@ -15,7 +15,8 @@ class WritebackHandler {
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish) = 0;
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        ZTracer::Trace *trace = nullptr) = 0;
   /**
    * check if a given extent read result may change due to a write
    *
@@ -34,7 +35,8 @@ class WritebackHandler {
 			   const SnapContext& snapc,
 			   const bufferlist &bl, ceph::real_time mtime,
 			   uint64_t trunc_size, __u32 trunc_seq,
-                           ceph_tid_t journal_tid, Context *oncommit) = 0;
+                           ceph_tid_t journal_tid, Context *oncommit,
+                           ZTracer::Trace *trace = nullptr) = 0;
 
   virtual void overwrite_extent(const object_t& oid, uint64_t off, uint64_t len,
                                 ceph_tid_t original_journal_tid,

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -388,6 +388,14 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 }
 
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+                       ObjectReadOperation *op, int flags,
+                       bufferlist *pbl, const blkin_trace_info *trace_info) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+  return ctx->aio_operate_read(oid, *ops, c->pc, flags, pbl);
+}
+
+int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
@@ -397,6 +405,21 @@ int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
 int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
                        ObjectWriteOperation *op, snap_t seq,
                        std::vector<snap_t>& snaps) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
+
+  std::vector<snapid_t> snv;
+  snv.resize(snaps.size());
+  for (size_t i = 0; i < snaps.size(); ++i)
+    snv[i] = snaps[i];
+  SnapContext snapc(seq, snv);
+
+  return ctx->aio_operate(oid, *ops, c->pc, &snapc, 0);
+}
+
+int IoCtx::aio_operate(const std::string& oid, AioCompletion *c,
+                       ObjectWriteOperation *op, snap_t seq,
+                       std::vector<snap_t>& snaps, const blkin_trace_info *trace_info) {
   TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
   TestObjectOperationImpl *ops = reinterpret_cast<TestObjectOperationImpl*>(op->impl);
 

--- a/src/test/librados_test_stub/TestIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestIoCtxImpl.cc
@@ -102,7 +102,7 @@ void TestIoCtxImpl::aio_notify(const std::string& oid, AioCompletionImpl *c,
 
 int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, SnapContext *snap_context,
-                               int flags) {
+                               int flags, const blkin_trace_info *trace_info) {
   // TODO flags for now
   ops.get();
   m_pending_ops.inc();
@@ -116,7 +116,7 @@ int TestIoCtxImpl::aio_operate(const std::string& oid, TestObjectOperationImpl &
 int TestIoCtxImpl::aio_operate_read(const std::string& oid,
                                     TestObjectOperationImpl &ops,
                                     AioCompletionImpl *c, int flags,
-                                    bufferlist *pbl) {
+                                    bufferlist *pbl, const blkin_trace_info *trace_info) {
   // TODO ignoring flags for now
   ops.get();
   m_pending_ops.inc();

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -76,10 +76,10 @@ public:
                           bufferlist& bl, uint64_t timeout_ms, bufferlist *pbl);
   virtual int aio_operate(const std::string& oid, TestObjectOperationImpl &ops,
                           AioCompletionImpl *c, SnapContext *snap_context,
-                          int flags);
+                          int flags, const blkin_trace_info *trace_info = nullptr);
   virtual int aio_operate_read(const std::string& oid, TestObjectOperationImpl &ops,
                                AioCompletionImpl *c, int flags,
-                               bufferlist *pbl);
+                               bufferlist *pbl, const blkin_trace_info *trace_info = nullptr);
   virtual int aio_remove(const std::string& oid, AioCompletionImpl *c) = 0;
   virtual int aio_watch(const std::string& o, AioCompletionImpl *c,
                         uint64_t *handle, librados::WatchCtx2 *ctx);

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -129,7 +129,7 @@ TEST_F(TestJournalEntries, AioWrite) {
   C_SaferCond cond_ctx;
   librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
-  ictx->aio_work_queue->aio_write(c, 123, buffer.size(), buffer.c_str(), 0);
+  ictx->aio_work_queue->aio_write(c, 123, buffer.size(), buffer.c_str(), 0, nullptr);
   ASSERT_EQ(0, c->wait_for_complete());
   c->put();
 
@@ -172,7 +172,7 @@ TEST_F(TestJournalEntries, AioDiscard) {
   C_SaferCond cond_ctx;
   librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
-  ictx->aio_work_queue->aio_discard(c, 123, 234);
+  ictx->aio_work_queue->aio_discard(c, 123, 234, nullptr);
   ASSERT_EQ(0, c->wait_for_complete());
   c->put();
 

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -107,7 +107,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
   std::string payload(4096, '1');
   librbd::AioCompletion *aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_write(aio_comp, 0, payload.size(), payload.c_str(),
-                                  0);
+                                  0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 
@@ -119,7 +119,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
   std::string read_payload(4096, '\0');
   aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_read(aio_comp, 0, read_payload.size(),
-                                 &read_payload[0], NULL, 0);
+                                 &read_payload[0], NULL, 0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
   ASSERT_EQ(payload, read_payload);
@@ -144,7 +144,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
 
   aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_read(aio_comp, 0, read_payload.size(),
-                                 &read_payload[0], NULL, 0);
+                                 &read_payload[0], NULL, 0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
   if (ictx->cct->_conf->rbd_skip_partial_discard) {
@@ -175,7 +175,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
 
   // verify lock ordering constraints
   aio_comp = new librbd::AioCompletion();
-  ictx->aio_work_queue->aio_discard(aio_comp, 0, read_payload.size());
+  ictx->aio_work_queue->aio_discard(aio_comp, 0, read_payload.size(), nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 }
@@ -207,7 +207,7 @@ TEST_F(TestJournalReplay, AioWriteEvent) {
   std::string read_payload(4096, '\0');
   librbd::AioCompletion *aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_read(aio_comp, 0, read_payload.size(),
-                                 &read_payload[0], NULL, 0);
+                                 &read_payload[0], NULL, 0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
   ASSERT_EQ(payload, read_payload);
@@ -235,7 +235,7 @@ TEST_F(TestJournalReplay, AioWriteEvent) {
   // verify lock ordering constraints
   aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_write(aio_comp, 0, payload.size(), payload.c_str(),
-                                  0);
+                                  0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 }
@@ -658,7 +658,7 @@ TEST_F(TestJournalReplay, ObjectPosition) {
   std::string payload(4096, '1');
   librbd::AioCompletion *aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_write(aio_comp, 0, payload.size(), payload.c_str(),
-                                  0);
+                                  0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 
@@ -678,7 +678,7 @@ TEST_F(TestJournalReplay, ObjectPosition) {
 
   aio_comp = new librbd::AioCompletion();
   ictx->aio_work_queue->aio_write(aio_comp, 0, payload.size(), payload.c_str(),
-                                  0);
+                                  0, nullptr);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -26,19 +26,20 @@ template <>
 struct AioImageRequest<MockReplayImageCtx> {
   static AioImageRequest *s_instance;
 
-  MOCK_METHOD5(aio_write, void(AioCompletion *c, uint64_t off, size_t len,
-                               const char *buf, int op_flags));
+  MOCK_METHOD6(aio_write, void(AioCompletion *c, uint64_t off, size_t len,
+                               const char *buf, int op_flags, const blkin_trace_info *trace_info));
   static void aio_write(MockReplayImageCtx *ictx, AioCompletion *c, uint64_t off,
-                        size_t len, const char *buf, int op_flags) {
+                        size_t len, const char *buf, int op_flags, const blkin_trace_info *trace_info) {
     assert(s_instance != nullptr);
-    s_instance->aio_write(c, off, len, buf, op_flags);
+    s_instance->aio_write(c, off, len, buf, op_flags, nullptr);
   }
 
-  MOCK_METHOD3(aio_discard, void(AioCompletion *c, uint64_t off, uint64_t len));
+  MOCK_METHOD4(aio_discard, void(AioCompletion *c, uint64_t off, uint64_t len,
+                                const blkin_trace_info *trace_info));
   static void aio_discard(MockReplayImageCtx *ictx, AioCompletion *c, uint64_t off,
-                          uint64_t len) {
+                          uint64_t len, const blkin_trace_info *trace_info) {
     assert(s_instance != nullptr);
-    s_instance->aio_discard(c, off, len);
+    s_instance->aio_discard(c, off, len, nullptr);
   }
 
   MOCK_METHOD1(aio_flush, void(AioCompletion *c));
@@ -108,7 +109,7 @@ public:
   void expect_aio_discard(MockAioImageRequest &mock_aio_image_request,
                           AioCompletion **aio_comp, uint64_t off,
                           uint64_t len) {
-    EXPECT_CALL(mock_aio_image_request, aio_discard(_, off, len))
+    EXPECT_CALL(mock_aio_image_request, aio_discard(_, off, len, nullptr))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 
@@ -128,7 +129,7 @@ public:
                         AioCompletion **aio_comp, uint64_t off,
                         uint64_t len, const char *data) {
     EXPECT_CALL(mock_aio_image_request,
-                aio_write(_, off, len, CStrEq(data), _))
+                aio_write(_, off, len, CStrEq(data), _, nullptr))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -16,6 +16,7 @@
 #include "test/librbd/mock/MockReadahead.h"
 #include "common/RWLock.h"
 #include "common/WorkQueue.h"
+#include "common/zipkin_trace.h"
 #include "librbd/ImageCtx.h"
 #include "gmock/gmock.h"
 #include <string>
@@ -177,10 +178,10 @@ struct MockImageCtx {
 
   MOCK_CONST_METHOD0(get_journal_policy, journal::Policy*());
 
-  MOCK_METHOD7(aio_read_from_cache, void(object_t, uint64_t, bufferlist *,
-                                         size_t, uint64_t, Context *, int));
-  MOCK_METHOD7(write_to_cache, void(object_t, const bufferlist&, size_t,
-                                    uint64_t, Context *, int, uint64_t));
+  MOCK_METHOD8(aio_read_from_cache, void(object_t, uint64_t, bufferlist *,
+                                         size_t, uint64_t, Context *, int, ZTracer::Trace *));
+  MOCK_METHOD8(write_to_cache, void(object_t, const bufferlist&, size_t,
+                                    uint64_t, Context *, int, uint64_t, ZTracer::Trace *));
 
   ImageCtx *image_ctx;
   CephContext *cct;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -273,7 +273,7 @@ TEST_F(TestInternal, AioWriteRequestsLock) {
   Context *ctx = new DummyContext();
   librbd::AioCompletion *c = librbd::AioCompletion::create(ctx);
   c->get();
-  ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0);
+  ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0, nullptr);
 
   bool is_owner;
   ASSERT_EQ(0, librbd::is_exclusive_lock_owner(ictx, &is_owner));
@@ -295,7 +295,7 @@ TEST_F(TestInternal, AioDiscardRequestsLock) {
   Context *ctx = new DummyContext();
   librbd::AioCompletion *c = librbd::AioCompletion::create(ctx);
   c->get();
-  ictx->aio_work_queue->aio_discard(c, 0, 256);
+  ictx->aio_work_queue->aio_discard(c, 0, 256, nullptr);
 
   bool is_owner;
   ASSERT_EQ(0, librbd::is_exclusive_lock_owner(ictx, &is_owner));
@@ -699,7 +699,7 @@ TEST_F(TestInternal, ShrinkFlushesCache) {
   C_SaferCond cond_ctx;
   librbd::AioCompletion *c = librbd::AioCompletion::create(&cond_ctx);
   c->get();
-  ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0);
+  ictx->aio_work_queue->aio_write(c, 0, buffer.size(), buffer.c_str(), 0, nullptr);
 
   librbd::NoOpProgressContext no_op;
   ASSERT_EQ(0, ictx->operations->resize(m_image_size >> 1, true, no_op));

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -59,7 +59,8 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                         uint64_t object_off,
                                         const ceph::bufferlist &data,
                                         const ::SnapContext &snapc,
-                                        Context *completion, int op_flags) {
+                                        Context *completion, int op_flags,
+                                        ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;
@@ -100,7 +101,8 @@ struct AioObjectRead<librbd::MockTestImageCtx> : public AioObjectRequest<librbd:
                                uint64_t objectno, uint64_t offset,
                                uint64_t len, Extents &buffer_extents,
                                librados::snap_t snap_id, bool sparse,
-                               Context *completion, int op_flags) {
+                               Context *completion, int op_flags,
+                               ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -36,7 +36,8 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                          const std::string &oid,
                                          uint64_t object_no,
                                          const ::SnapContext &snapc,
-                                         Context *completion) {
+                                         Context *completion,
+                                         ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;
@@ -47,7 +48,8 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                            uint64_t object_no,
                                            uint64_t object_off,
                                            const ::SnapContext &snapc,
-                                           Context *completion) {
+                                           Context *completion,
+                                           ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;
@@ -71,7 +73,8 @@ struct AioObjectRequest<librbd::MockTestImageCtx> : public AioObjectRequestHandl
                                        uint64_t object_no, uint64_t object_off,
                                        uint64_t object_len,
                                        const ::SnapContext &snapc,
-                                       Context *completion) {
+                                       Context *completion,
+                                       ZTracer::Trace *trace) {
     assert(s_instance != nullptr);
     s_instance->on_finish = completion;
     return s_instance;

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -206,7 +206,7 @@ TEST_F(TestMockAioImageRequest, AioWriteJournalAppendDisabled) {
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_WRITE);
   MockAioImageWrite mock_aio_image_write(mock_image_ctx, aio_comp, 0, 1, "1",
-                                         0);
+                                         0, nullptr);
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
     mock_aio_image_write.send();
@@ -232,7 +232,7 @@ TEST_F(TestMockAioImageRequest, AioDiscardJournalAppendDisabled) {
   C_SaferCond aio_comp_ctx;
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
-  MockAioImageDiscard mock_aio_image_discard(mock_image_ctx, aio_comp, 0, 1);
+  MockAioImageDiscard mock_aio_image_discard(mock_image_ctx, aio_comp, 0, 1, nullptr);
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
     mock_aio_image_discard.send();

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -154,9 +154,10 @@ struct TestMockAioImageRequest : public TestMockFixture {
   void expect_write_to_cache(MockImageCtx &mock_image_ctx,
                              const object_t &object,
                              uint64_t offset, uint64_t length,
-                             uint64_t journal_tid, int r) {
+                             uint64_t journal_tid, int r,
+                             ZTracer::Trace *trace = nullptr) {
     EXPECT_CALL(mock_image_ctx, write_to_cache(object, _, length, offset, _, _,
-                journal_tid))
+                journal_tid, _))
       .WillOnce(WithArg<4>(CompleteContext(r, mock_image_ctx.image_ctx->op_work_queue)));
   }
 

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -1016,7 +1016,7 @@ TEST_F(TestMockJournal, EventCommitError) {
 
   C_SaferCond object_request_ctx;
   AioObjectRemove *object_request = new AioObjectRemove(
-    ictx, "oid", 0, {}, &object_request_ctx);
+    ictx, "oid", 0, {}, &object_request_ctx, nullptr);
 
   ::journal::MockFuture mock_future;
   Context *on_journal_safe;
@@ -1055,7 +1055,7 @@ TEST_F(TestMockJournal, EventCommitErrorWithPendingWriteback) {
 
   C_SaferCond object_request_ctx;
   AioObjectRemove *object_request = new AioObjectRemove(
-    ictx, "oid", 0, {}, &object_request_ctx);
+    ictx, "oid", 0, {}, &object_request_ctx, nullptr);
 
   ::journal::MockFuture mock_future;
   Context *on_journal_safe;

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -62,7 +62,8 @@ void FakeWriteback::read(const object_t& oid, uint64_t object_no,
 			 const object_locator_t& oloc,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
-			 __u32 trunc_seq, int op_flags, Context *onfinish)
+			 __u32 trunc_seq, int op_flags, Context *onfinish,
+       ZTracer::Trace *trace)
 {
   C_Delay *wrapper = new C_Delay(m_cct, onfinish, m_lock, off, pbl,
 				 m_delay_ns);
@@ -75,7 +76,8 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
 				const SnapContext& snapc,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
-				ceph_tid_t journal_tid, Context *oncommit)
+				ceph_tid_t journal_tid, Context *oncommit,
+        ZTracer::Trace *trace)
 {
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,
 				 m_delay_ns);

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -20,14 +20,15 @@ public:
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish);
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        ZTracer::Trace *trace);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit);
+			   Context *oncommit, ZTracer::Trace *trace);
 
   using WritebackHandler::write;
 

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -91,7 +91,8 @@ void MemWriteback::read(const object_t& oid, uint64_t object_no,
 			 const object_locator_t& oloc,
 			 uint64_t off, uint64_t len, snapid_t snapid,
 			 bufferlist *pbl, uint64_t trunc_size,
-			 __u32 trunc_seq, int op_flags, Context *onfinish)
+			 __u32 trunc_seq, int op_flags, Context *onfinish,
+       ZTracer::Trace *trace)
 {
   assert(snapid == CEPH_NOSNAP);
   C_DelayRead *wrapper = new C_DelayRead(this, m_cct, onfinish, m_lock, oid,
@@ -105,7 +106,8 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
 				const SnapContext& snapc,
 				const bufferlist &bl, ceph::real_time mtime,
 				uint64_t trunc_size, __u32 trunc_seq,
-				ceph_tid_t journal_tid, Context *oncommit)
+				ceph_tid_t journal_tid, Context *oncommit,
+        ZTracer::Trace *trace)
 {
   assert(snapc.seq == 0);
   C_DelayWrite *wrapper = new C_DelayWrite(this, m_cct, oncommit, m_lock, oid,

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -20,14 +20,15 @@ public:
   virtual void read(const object_t& oid, uint64_t object_no,
 		    const object_locator_t& oloc, uint64_t off, uint64_t len,
 		    snapid_t snapid, bufferlist *pbl, uint64_t trunc_size,
-		    __u32 trunc_seq, int op_flags, Context *onfinish);
+		    __u32 trunc_seq, int op_flags, Context *onfinish,
+        ZTracer::Trace *trace);
 
   virtual ceph_tid_t write(const object_t& oid, const object_locator_t& oloc,
 			   uint64_t off, uint64_t len,
 			   const SnapContext& snapc, const bufferlist &bl,
 			   ceph::real_time mtime, uint64_t trunc_size,
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
-			   Context *oncommit);
+			   Context *oncommit, ZTracer::Trace *trace);
 
   using WritebackHandler::write;
 


### PR DESCRIPTION
Cleaned up from https://github.com/ceph/ceph/pull/10637 and rebased to include recent changes in librbd.

Pass trace information from librbd to librados. This is part of the end-to-end performance visualization Google Summer of Code project, to initialize traces in fio rbd engine and pass them to librados. It is based on the wip-blkin-osdc branch that added Zipkin tracing support to Messenger and Objecter.

Trace information is passed to librbd through new rbd_aio_write_traced and rbd_aio_read_traced functions, that take trace information as one of the parameters.

Signed-off-by: Victor Araujo ve.ar91@gmail.com
