### PR TITLE
rgw: eradicate dynamic memory allocation in RGWPostObj.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2894,22 +2894,6 @@ int RGWPostObj::verify_permission()
   return 0;
 }
 
-RGWPutObjProcessor *RGWPostObj::select_processor(RGWObjectCtx& obj_ctx)
-{
-  RGWPutObjProcessor *processor;
-
-  uint64_t part_size = s->cct->_conf->rgw_obj_stripe_size;
-
-  processor = new RGWPutObjProcessor_Atomic(obj_ctx, s->bucket_info, s->bucket, s->object.name, part_size, s->req_id, s->bucket_info.versioning_enabled());
-
-  return processor;
-}
-
-void RGWPostObj::dispose_processor(RGWPutObjProcessor *processor)
-{
-  delete processor;
-}
-
 void RGWPostObj::pre_exec()
 {
   rgw_bucket_object_pre_exec(s);
@@ -2917,7 +2901,6 @@ void RGWPostObj::pre_exec()
 
 void RGWPostObj::execute()
 {
-  RGWPutObjProcessor *processor = NULL;
   char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
   unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
   MD5 hash;
@@ -2926,29 +2909,39 @@ void RGWPostObj::execute()
 
   // read in the data from the POST form
   op_ret = get_params();
-  if (op_ret < 0)
-    goto done;
+  if (op_ret < 0) {
+    return;
+  }
 
   op_ret = verify_params();
-  if (op_ret < 0)
-    goto done;
+  if (op_ret < 0) {
+    return;
+  }
 
   if (!verify_bucket_permission(s, RGW_PERM_WRITE)) {
     op_ret = -EACCES;
-    goto done;
+    return;
   }
 
   op_ret = store->check_quota(s->bucket_owner.get_id(), s->bucket,
 			      user_quota, bucket_quota, s->content_length);
   if (op_ret < 0) {
-    goto done;
+    return;
   }
 
-  processor = select_processor(*static_cast<RGWObjectCtx *>(s->obj_ctx));
+  RGWPutObjProcessor_Atomic processor(*static_cast<RGWObjectCtx *>(s->obj_ctx),
+                                      s->bucket_info,
+                                      s->bucket,
+                                      s->object.name,
+                                      /* part size */
+                                      s->cct->_conf->rgw_obj_stripe_size,
+                                      s->req_id,
+                                      s->bucket_info.versioning_enabled());
 
-  op_ret = processor->prepare(store, NULL);
-  if (op_ret < 0)
-    goto done;
+  op_ret = processor.prepare(store, nullptr);
+  if (op_ret < 0) {
+    return;
+  }
 
   while (data_pending) {
      bufferlist data;
@@ -2956,25 +2949,25 @@ void RGWPostObj::execute()
 
      if (len < 0) {
        op_ret = len;
-       goto done;
+       return;
      }
 
      if (!len)
        break;
 
-     op_ret = put_data_and_throttle(processor, data, ofs, &hash, false);
+     op_ret = put_data_and_throttle(&processor, data, ofs, &hash, false);
 
      ofs += len;
 
      if (ofs > max_len) {
        op_ret = -ERR_TOO_LARGE;
-       goto done;
+       return;
      }
    }
 
   if (len < min_len) {
     op_ret = -ERR_TOO_SMALL;
-    goto done;
+    return;
   }
 
   s->obj_size = ofs;
@@ -2982,10 +2975,10 @@ void RGWPostObj::execute()
   op_ret = store->check_quota(s->bucket_owner.get_id(), s->bucket,
 			      user_quota, bucket_quota, s->obj_size);
   if (op_ret < 0) {
-    goto done;
+    return;
   }
 
-  processor->complete_hash(&hash);
+  processor.complete_hash(&hash);
   hash.Final(m);
   buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);
 
@@ -3002,10 +2995,7 @@ void RGWPostObj::execute()
     emplace_attr(RGW_ATTR_CONTENT_TYPE, std::move(ct_bl));
   }
 
-  op_ret = processor->complete(etag, NULL, real_time(), attrs, delete_at);
-
-done:
-  dispose_processor(processor);
+  op_ret = processor.complete(etag, NULL, real_time(), attrs, delete_at);
 }
 
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -705,9 +705,6 @@ public:
 };
 
 class RGWPostObj : public RGWOp {
-
-  friend class RGWPutObjProcessor;
-
 protected:
   off_t min_len;
   off_t max_len;
@@ -724,9 +721,14 @@ protected:
   ceph::real_time delete_at;
 
 public:
-  RGWPostObj() : min_len(0), max_len(LLONG_MAX), len(0), ofs(0),
-		 supplied_md5_b64(NULL), supplied_etag(NULL),
-		 data_pending(false) {}
+  RGWPostObj() : min_len(0),
+                 max_len(LLONG_MAX),
+                 len(0),
+                 ofs(0),
+                 supplied_md5_b64(nullptr),
+                 supplied_etag(nullptr),
+                 data_pending(false) {
+  }
 
   void emplace_attr(std::string&& key, buffer::list&& bl) {
     attrs.emplace(std::move(key), std::move(bl)); /* key and bl are r-value refs */
@@ -740,9 +742,6 @@ public:
   int verify_permission();
   void pre_exec();
   void execute();
-
-  RGWPutObjProcessor *select_processor(RGWObjectCtx& obj_ctx);
-  void dispose_processor(RGWPutObjProcessor *processor);
 
   virtual int get_params() = 0;
   virtual int get_data(bufferlist& bl) = 0;


### PR DESCRIPTION
s3-tests hasn't found any regression here.

CC: @mattbenjamin, @cbodley.