### PR TITLE
bluestore/BlueFS: revert direct IO for WRITER_WAL

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1380,7 +1380,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   assert(h->file->num_readers.load() == 0);
 
   bool buffered;
-  if (h->file->fnode.ino == 1 || h->writer_type == WRITER_WAL)
+  if (h->file->fnode.ino == 1)
     buffered = false;
   else
     buffered = g_conf->bluefs_buffered_io;


### PR DESCRIPTION
When writer_type is WRITER_WAL, forcing direct IO when bluefs_buffered_io = true appears to yield a 6-8% performance degradation on NVMe hardware.  Revert the change for now.  In the future we will need to understand why direct IO in general is causing performance issues on our NVMe test hardware.

Signed-off-by: Mark Nelson <mnelson@redhat.com>