### PR TITLE
Removed reference about pool ownership based on BZ#1368528

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -26,8 +26,6 @@ pools for storing data. A pool provides you with:
 - **Snapshots**: When you create snapshots with ``ceph osd pool mksnap``, 
   you effectively take a snapshot of a particular pool.
   
-- **Set Ownership**: You can set a user ID as the owner of a pool. 
-
 To organize data into pools, you can list, create, and remove pools. 
 You can also view the utilization statistics for each pool.
 


### PR DESCRIPTION
Signed-off-by: Bara Ancincova <bara@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1368528

From email conversation with Sage and Sam:

I don't think it is used at all, and at a minimum it is
untested and undocumented and the implementation is alomst
certainly incomplete.

I definitely support removing any trace of it from the docs.

sage