### PR TITLE
make-srpm.sh: A simple script to make the srpm for ceph.

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+./make-dist
+rpmbuild -D"_sourcedir `pwd`" -D"_specdir `pwd`" -D"_srcrpmdir `pwd`" -bs ceph.spec


### PR DESCRIPTION
This is a simple script to make the srpm for ceph based
on make-dist.

Yes, it is short, but it will stop many people from
having to solve the same problem.

Signed-off-by: Ira Cooper <ira@redhat.com>