### PR TITLE
Stop hiding errors from run-tox.sh

### DIFF
--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -33,7 +33,4 @@ else
 fi
 
 source ${CEPH_DETECT_INIT_VIRTUALENV}/bin/activate
-tox -c ${TOX_PATH} > ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out 2>&1
-status=$?
-grep -v InterpreterNotFound < ${CEPH_DETECT_INIT_VIRTUALENV}/tox.out
-exit $status
+tox -c ${TOX_PATH}

--- a/src/ceph-disk/run-tox.sh
+++ b/src/ceph-disk/run-tox.sh
@@ -30,7 +30,4 @@ if [ -z $CEPH_BUILD_DIR ]; then
 fi
 
 source ${CEPH_DISK_VIRTUALENV}/bin/activate
-tox -c ${TOX_PATH} > ${CEPH_DISK_VIRTUALENV}/tox.out 2>&1
-status=$?
-grep -v InterpreterNotFound < ${CEPH_DISK_VIRTUALENV}/tox.out
-exit $status
+tox -c ${TOX_PATH}


### PR DESCRIPTION
The grep -v should have been grep, but, why even bother?
Tox doesn't output that much; just dump it, and exit with
tox's error code.

Fixes: http://tracker.ceph.com/issues/17267
Signed-off-by: Dan Mick <dan.mick@redhat.com>