### PR TITLE
ceph-disk tests: Let missing python interpreters be non-fatal

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = flake8,py27,py34
+envlist = flake8,py27,py34,py35,py36
+skip_missing_interpreters = True
 
 [testenv]
 setenv =


### PR DESCRIPTION
Let tox ignore missing interpreters, and add py35 and py36 as well.
This lets tests work on Xenial, for example, which only has py35.

Signed-off-by: Dan Mick <dan.mick@redhat.com>