### PR TITLE
mds: remove fail-safe queueing replay request

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9073,12 +9073,6 @@ void MDCache::request_cleanup(MDRequestRef& mdr)
   // remove from map
   active_requests.erase(mdr->reqid);
 
-  // fail-safe!
-  if (was_replay && active_requests.empty()) {
-    dout(10) << " fail-safe queueing next replay op" << dendl;
-    mds->queue_one_replay();
-  }
-
   if (mds->logger)
     log_stat();
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1253,9 +1253,7 @@ void MDSRank::clientreplay_start()
 bool MDSRank::queue_one_replay()
 {
   if (replay_queue.empty()) {
-    if (mdcache->get_num_client_requests() == 0) {
-      clientreplay_done();
-    }
+    clientreplay_done();
     return false;
   }
   queue_waiter(replay_queue.front());

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -963,6 +963,7 @@ void Server::force_clients_readonly()
 void Server::journal_and_reply(MDRequestRef& mdr, CInode *in, CDentry *dn, LogEvent *le, MDSInternalContextBase *fin)
 {
   dout(10) << "journal_and_reply tracei " << in << " tracedn " << dn << dendl;
+  assert(!mdr->has_completed);
 
   // note trace items for eventual reply.
   mdr->tracei = in;


### PR DESCRIPTION
MDSRank::queue_one_replay() does not create active request
immediately, it just queues corresponding C_MDS_RetryMessage
for execution. So the fail-safe code can queue an extra replay
request. This can cause replay requests be processed out-of-order

Fixes: http://tracker.ceph.com/issues/17271
Signed-off-by: Yan, Zheng <zyan@redhat.com>