### PR TITLE
common/PluginRegistry: improve error output for shared library load fa…

### DIFF
--- a/src/common/PluginRegistry.cc
+++ b/src/common/PluginRegistry.cc
@@ -142,13 +142,16 @@ int PluginRegistry::load(const std::string &type,
     + name + PLUGIN_SUFFIX;
   void *library = dlopen(fname.c_str(), RTLD_NOW);
   if (!library) {
+    string err1(dlerror());
     // fall back to plugin_dir
     std::string fname2 = cct->_conf->plugin_dir + "/" + PLUGIN_PREFIX +
       name + PLUGIN_SUFFIX;
     library = dlopen(fname2.c_str(), RTLD_NOW);
     if (!library) {
-      lderr(cct) << __func__ << " failed dlopen(" << fname << ") or dlopen("
-		 << fname2 << "): " << dlerror() << dendl;
+      lderr(cct) << __func__
+		 << " failed dlopen(): \""	<< err1.c_str() 
+		 << "\" or \"" << dlerror() << "\""
+		 << dendl;
       return -EIO;
     }
   }


### PR DESCRIPTION
…ilure. When both load attempts fail we could see  the last dlopen result only. But the first load attempt could report different issue. This patch provides both errors in the following way:

> 2016-09-14 15:25:42.528253 7fa37cb3a840 -1 load failed dlopen(): "/usr/local/lib/ceph/compressor/compressor/libceph_snappy.so:
cannot open shared object file: No such file or directory" or "/usr/local/lib/ceph/compressor/libceph_snappy.so: undefined symb
ol: _ZN4ceph14PluginRegistry3addERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_PNS_6PluginE"


Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>