### PR TITLE
common/compressor: add libcommon as a dependency for zlib and snappy p…

### DIFF
--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -6,6 +6,6 @@ set(snappy_sources
 
 add_library(ceph_snappy SHARED ${snappy_sources})
 add_dependencies(ceph_snappy ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_snappy snappy)
+target_link_libraries(ceph_snappy snappy common)
 set_target_properties(ceph_snappy PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_snappy DESTINATION ${compressor_plugin_dir})

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zlib z)
+target_link_libraries(ceph_zlib z common)
 target_include_directories(ceph_zlib PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_zlib DESTINATION ${compressor_plugin_dir})


### PR DESCRIPTION
…lugins to ensure PluginRegistry access for them.

Without this fix compression plugins failed to load if libcommon wasn't resolved by some other lib/app dependencies. E.g. one could observe the issue with fio objectstore plugin. See PR #10267

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>