### PR TITLE
cli: retry when the mon is not configured

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -214,7 +214,7 @@ function test_kill_daemon() {
         # kill the mon and verify it cannot be reached
         #
         kill_daemon $pidfile TERM || return 1
-        ! ceph --connect-timeout 60 status || return 1
+        ! timeout 60 ceph --connect-timeout 60 status || return 1
     done
 
     teardown $dir || return 1
@@ -290,7 +290,7 @@ function test_kill_daemons() {
     # kill the mon and verify it cannot be reached
     #
     kill_daemons $dir TERM || return 1
-    ! ceph --connect-timeout 60 status || return 1
+    ! timeout 60 ceph --connect-timeout 60 status || return 1
     teardown $dir || return 1
 }
 

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1191,6 +1191,17 @@ def run_in_thread(target, *args, **kwargs):
     return t.retval
 
 
+def send_command_retry(*args, **kwargs):
+    while True:
+        try:
+            return send_command(*args, **kwargs)
+        except Exception as e:
+            if ('get_command_descriptions' in str(e) and
+                'object in state configuring' in str(e)):
+                continue
+            else:
+                raise
+
 def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
                  verbose=False):
     """
@@ -1304,8 +1315,9 @@ def json_command(cluster, target=('mon', ''), prefix=None, argdict=None,
                 # use the target we were originally given
                 pass
 
-        ret, outbuf, outs = send_command(cluster, target, [json.dumps(cmddict)],
-                                         inbuf, timeout, verbose)
+        ret, outbuf, outs = send_command_retry(cluster,
+                                               target, [json.dumps(cmddict)],
+                                               inbuf, timeout, verbose)
 
     except Exception as e:
         if not isinstance(e, ArgumentError):


### PR DESCRIPTION
The mon may return on error if a command is sent to it while it is
still in configuring state.

Fixes: http://tracker.ceph.com/issues/16477

Signed-off-by: Loic Dachary <loic@dachary.org>