### PR TITLE
run-cmake-check.sh: Init submodules

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -47,6 +47,7 @@ function run() {
     if test -f ./install-deps.sh ; then
 	$DRY_RUN ./install-deps.sh || return 1
     fi
+    git submodule update --init --recursive
     $DRY_RUN mkdir build
     $DRY_RUN cd build
     $DRY_RUN cmake "$@" ../


### PR DESCRIPTION
If submodules are not initialised run-cmake-check.sh can fail.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>