### PR TITLE
run-make-check.sh: Make DRY_RUN actually do a dry run

### DIFF
--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -67,7 +67,7 @@ function run() {
     export TMPDIR=$(mktemp -d --tmpdir ceph.XXX)
     if test -x ./do_cmake.sh ; then
         $DRY_RUN ./do_cmake.sh $@ || return 1
-        cd build
+        $DRY_RUN cd build
         $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
         $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure || return 1
     else


### PR DESCRIPTION
The "cd build" command will cause an error during a dry run if the directory
does not exist.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>