### PR TITLE
Small interface cleanups for struct ceph_statx 

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6852,6 +6852,7 @@ void Client::fill_statx(Inode *in, unsigned int mask, struct ceph_statx *stx)
   /* These are always considered to be available */
   stx->stx_dev = in->snapid;
   stx->stx_blksize = MAX(in->layout.stripe_unit, 4096);
+  stx->stx_mode = S_IFMT & in->mode;
 
   if (use_faked_inos())
    stx->stx_ino = in->faked_ino;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6850,16 +6850,14 @@ void Client::fill_statx(Inode *in, unsigned int mask, struct ceph_statx *stx)
     mask = ~0;
 
   /* These are always considered to be available */
-  stx->stx_dev_major = in->snapid >> 32;
-  stx->stx_dev_minor = (uint32_t)in->snapid;
+  stx->stx_dev = in->snapid;
   stx->stx_blksize = MAX(in->layout.stripe_unit, 4096);
 
   if (use_faked_inos())
    stx->stx_ino = in->faked_ino;
   else
     stx->stx_ino = in->ino;
-  stx->stx_rdev_minor = MINOR(in->rdev);
-  stx->stx_rdev_major = MAJOR(in->rdev);
+  stx->stx_rdev = in->rdev;
   stx->stx_mask |= (CEPH_STATX_INO|CEPH_STATX_RDEV);
 
   if (mask & CEPH_CAP_AUTH_SHARED) {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -93,14 +93,6 @@ struct CommandOp
   std::string  *outs;
 };
 
-/* Device bit shift handling */
-#define MINORBITS	20
-#define MINORMASK	((1U << MINORBITS) - 1)
-
-#define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
-#define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
-#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
-
 /* error code for ceph_fuse */
 #define CEPH_FUSE_NO_MDS_UP    -(1<<2) /* no mds up deteced in ceph_fuse */
 

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -41,6 +41,13 @@
 #define FINO_STAG(x) ((x) >> 48)
 #define MAKE_FINO(i,s) ((i) | ((s) << 48))
 
+#define MINORBITS	20
+#define MINORMASK	((1U << MINORBITS) - 1)
+
+#define MAJOR(dev)	((unsigned int) ((dev) >> MINORBITS))
+#define MINOR(dev)	((unsigned int) ((dev) & MINORMASK))
+#define MKDEV(ma,mi)	(((ma) << MINORBITS) | (mi))
+
 static uint32_t new_encode_dev(dev_t dev)
 {
 	unsigned major = MAJOR(dev);

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -658,7 +658,7 @@ static void fuse_ll_create(fuse_req_t req, fuse_ino_t parent, const char *name,
   const struct fuse_ctx *ctx = fuse_req_ctx(req);
   Inode *i1 = cfuse->iget(parent), *i2;
   struct fuse_entry_param fe;
-  Fh *fh = NULL;
+  Fh *fh;
 
   memset(&fe, 0, sizeof(fe));
 

--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -40,14 +40,10 @@ struct ceph_statx {
 	uint64_t	stx_size;
 	uint64_t	stx_blocks;
 	uint64_t	stx_version;
-	int64_t		stx_atime;
-	int64_t		stx_btime;
-	int64_t		stx_ctime;
-	int64_t		stx_mtime;
-	int32_t		stx_atime_ns;
-	int32_t		stx_btime_ns;
-	int32_t		stx_ctime_ns;
-	int32_t		stx_mtime_ns;
+	struct timespec	stx_atime;
+	struct timespec	stx_btime;
+	struct timespec	stx_ctime;
+	struct timespec	stx_mtime;
 	uint32_t	stx_rdev_major;
 	uint32_t	stx_rdev_minor;
 	uint32_t	stx_dev_major;

--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -36,7 +36,6 @@ struct ceph_statx {
 	uint32_t	stx_uid;
 	uint32_t	stx_gid;
 	uint16_t	stx_mode;
-	uint16_t	__spare0[1];
 	uint64_t	stx_ino;
 	uint64_t	stx_size;
 	uint64_t	stx_blocks;
@@ -53,7 +52,6 @@ struct ceph_statx {
 	uint32_t	stx_rdev_minor;
 	uint32_t	stx_dev_major;
 	uint32_t	stx_dev_minor;
-	uint64_t	__spare1[16];
 };
 
 #define CEPH_STATX_MODE		0x00000001U     /* Want/got stx_mode */

--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -40,14 +40,12 @@ struct ceph_statx {
 	uint64_t	stx_size;
 	uint64_t	stx_blocks;
 	uint64_t	stx_version;
+	dev_t		stx_dev;
+	dev_t		stx_rdev;
 	struct timespec	stx_atime;
 	struct timespec	stx_btime;
 	struct timespec	stx_ctime;
 	struct timespec	stx_mtime;
-	uint32_t	stx_rdev_major;
-	uint32_t	stx_rdev_minor;
-	uint32_t	stx_dev_major;
-	uint32_t	stx_dev_minor;
 };
 
 #define CEPH_STATX_MODE		0x00000001U     /* Want/got stx_mode */

--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -29,23 +29,21 @@ extern "C" {
  */
 struct ceph_statx {
 	uint32_t	stx_mask;
-	uint32_t	stx_information;
 	uint32_t	stx_blksize;
 	uint32_t	stx_nlink;
-	uint32_t	stx_gen;
 	uint32_t	stx_uid;
 	uint32_t	stx_gid;
 	uint16_t	stx_mode;
 	uint64_t	stx_ino;
 	uint64_t	stx_size;
 	uint64_t	stx_blocks;
-	uint64_t	stx_version;
 	dev_t		stx_dev;
 	dev_t		stx_rdev;
 	struct timespec	stx_atime;
-	struct timespec	stx_btime;
 	struct timespec	stx_ctime;
 	struct timespec	stx_mtime;
+	struct timespec	stx_btime;
+	uint64_t	stx_version;
 };
 
 #define CEPH_STATX_MODE		0x00000001U     /* Want/got stx_mode */
@@ -62,8 +60,7 @@ struct ceph_statx {
 #define CEPH_STATX_BASIC_STATS	0x000007ffU     /* The stuff in the normal stat struct */
 #define CEPH_STATX_BTIME	0x00000800U     /* Want/got stx_btime */
 #define CEPH_STATX_VERSION	0x00001000U     /* Want/got stx_version */
-#define CEPH_STATX_GEN		0x00002000U     /* Want/got stx_gen */
-#define CEPH_STATX_ALL_STATS	0x00003fffU     /* All supported stats */
+#define CEPH_STATX_ALL_STATS	0x00001fffU     /* All supported stats */
 
 /* statx request flags. Callers can set these in the "flags" field */
 #ifndef AT_NO_ATTR_SYNC


### PR DESCRIPTION
When I originally copied the proposed statx interface for ceph, I think I took it a bit too far and left a lot of the fields as fixed-length when that wasn't really necessary. So, as I mentioned in standup yesterday, this is a set of changes to struct ceph_statx to give the interface a bit more of a userland flavor. The main changes are to keep a dev_t in the structure for the stx_dev and stx_rdev fields, and to convert all of the timestamps to use struct timespec instead of separate fields for the secs and nsecs.

There's also a small bugfix for ll_create, which had a broken caller in the (unused) SyntheticClient code.