### PR TITLE
os/bluestore/BlueFS: prevent concurrent async compaction

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1188,6 +1188,7 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
   uint64_t discarded = 0;
   vector<bluefs_extent_t> old_extents;
   while (discarded < old_log_jump_to) {
+    assert(!log_file->fnode.extents.empty());
     bluefs_extent_t& e = log_file->fnode.extents.front();
     bluefs_extent_t temp = e;
     if (discarded + e.length <= old_log_jump_to) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -999,9 +999,9 @@ bool BlueFS::_should_compact_log()
   dout(10) << __func__ << " current 0x" << std::hex << current
 	   << " expected " << expected << std::dec
 	   << " ratio " << ratio
-	   << (log_flushing ? " (async compaction in progress)" : "")
+	   << (new_log ? " (async compaction in progress)" : "")
 	   << dendl;
-  if (log_flushing ||
+  if (new_log ||
       current < g_conf->bluefs_log_compact_min_size ||
       ratio < g_conf->bluefs_log_compact_min_ratio) {
     return false;
@@ -1122,6 +1122,8 @@ void BlueFS::_compact_log_async(std::unique_lock<std::mutex>& l)
 {
   dout(10) << __func__ << dendl;
   File *log_file = log_writer->file.get();
+  assert(!new_log);
+  assert(!new_log_writer);
 
   // 1. allocate new log space and jump to it.
   old_log_jump_to = log_file->fnode.get_allocated();


### PR DESCRIPTION
Tried to fix this in dbe23c94c0074358380a40d47a417f7999920696
but got the condition wrong (log_flushing is for
normal fsync).

Signed-off-by: Sage Weil <sage@redhat.com>