### PR TITLE
doc: add "--orphan-stale-secs" to radosgw-admin(8)

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -414,6 +414,11 @@ Orphans Search Options
 
 	Number of shards to use for keeping the temporary scan info
 
+.. option:: --orphan-stale-secs
+
+        Number of seconds to wait before declaring an object to be an orphan.
+        Default is 86400 (24 hours).
+
 
 Examples
 ========


### PR DESCRIPTION
The radosgw-admin(8) manual page did not include the description of the `--orphan-stale-secs` option of the `orphans find` command. The option sets the number of seconds to wait before declaring an object to be an orphan.

Fixes: http://tracker.ceph.com/issues/17280