### PR TITLE
doc: fix description for rsize and rasize

### DIFF
--- a/doc/man/8/mount.ceph.rst
+++ b/doc/man/8/mount.ceph.rst
@@ -46,12 +46,15 @@ Options
 =======
 
 :command:`wsize`
-  int, max write size. Default: none (writeback uses smaller of wsize
+  int (bytes), max write size. Default: none (writeback uses smaller of wsize
   and stripe unit)
 
 :command:`rsize`
-  int (bytes), max readahead, multiple of 1024, Default: 524288
-  (512*1024)
+  int (bytes), max read size. Default: none
+
+:command:`rasize`
+  int (bytes), max readahead, multiple of 1024, Default: 8388608
+  (8192*1024)
 
 :command:`osdtimeout`
   int (seconds), Default: 60


### PR DESCRIPTION
looks like a typo happened when documenting the `rsize`/`rasize` option in the Ceph kernel module documentation (see https://github.com/ceph/ceph-client/pull/15)
I also updated the default readahead value to match the code: https://github.com/ceph/ceph-client/blob/for-linus/fs/ceph/super.h#L48