### PR TITLE
rgw: revert a commit that broke s3 signature validation

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1826,7 +1826,7 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO* cio)
     if (subdomain.empty()
         && (domain.empty() || domain != info.host)
         && !looks_like_ip_address(info.host.c_str())
-        && RGWHandler_REST::validate_bucket_name(info.host) == 0) {
+        && RGWHandler_REST::validate_bucket_name(info.host)) {
       subdomain.append(info.host);
       in_hosted_domain = 1;
     }


### PR DESCRIPTION
This reverts commit 0e0a4bc3dcb61c2e8dfe65daefe207c62b36306c.

this commit, while logically correct, causes us to add a / to the end of
the request_uri. this breaks signature verification, because the initial
signature was generated without the /

Fixes: http://tracker.ceph.com/issues/17279