### PR TITLE
ceph_test_objectstore: test clone_range and fix a few bugs

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1338,6 +1338,11 @@ public:
      * The data portion of the destination object receives a copy of a
      * portion of the data from the source object. None of the other
      * three parts of an object is copied from the source.
+     *
+     * The destination object size may be extended to the dstoff + len.
+     *
+     * The source range *must* overlap with the source object data. If it does
+     * not the result is undefined.
      */
     void clone_range(const coll_t& cid, const ghobject_t& oid, ghobject_t noid,
 		     uint64_t srcoff, uint64_t srclen, uint64_t dstoff) {

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -1496,8 +1496,10 @@ int BufferlistObject::write(uint64_t offset, const bufferlist &src)
   if (get_size() >= offset) {
     newdata.substr_of(data, 0, offset);
   } else {
-    newdata.substr_of(data, 0, get_size());
-    newdata.append(offset - get_size());
+    if (get_size()) {
+      newdata.substr_of(data, 0, get_size());
+    }
+    newdata.append_zero(offset - get_size());
   }
 
   newdata.append(src);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5291,7 +5291,7 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("filestore_op_thread_timeout", "1000");
   g_ceph_context->_conf->set_val("filestore_op_thread_suicide_timeout", "10000");
   g_ceph_context->_conf->set_val("filestore_debug_disable_sharded_check", "true");
-  g_ceph_context->_conf->set_val("filestore_fiemap", "true");
+  //g_ceph_context->_conf->set_val("filestore_fiemap", "true");
   g_ceph_context->_conf->set_val("bluestore_fsck_on_mount", "true");
   g_ceph_context->_conf->set_val("bluestore_fsck_on_umount", "true");
   g_ceph_context->_conf->set_val("bluestore_debug_misc", "true");


### PR DESCRIPTION
* ceph_test_objectstore now tests clone_range.
* filestore_fiemap is bad bad bad.  ceph_test_objectstore no longer tries to test it.  it already defaults to off, thankfully.
* memstore pageset object clone is still buggy.
