### PR TITLE
rbd-mirror: concurrent access of event might result in heap corruption

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1084,7 +1084,6 @@ void ImageReplayer<I>::process_entry() {
     ImageReplayer, &ImageReplayer<I>::handle_process_entry_ready>(this);
   Context *on_commit = new C_ReplayCommitted(this, std::move(m_replay_entry));
   m_local_replay->process(m_event_entry, on_ready, on_commit);
-  m_event_entry = {};
 }
 
 template <typename I>


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17283
Signed-off-by: Jason Dillaman <dillaman@redhat.com>