### PR TITLE
build scripts: Enable dnf for Fedora >= 22

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -32,9 +32,16 @@ BUILD_MAKEOPTS=${BUILD_MAKEOPTS:-$DEFAULT_MAKEOPTS}
 CHECK_MAKEOPTS=${CHECK_MAKEOPTS:-$DEFAULT_MAKEOPTS}
 
 function run() {
-    # Same logic as install-deps.sh for finding package installer
     local install_cmd
-    test -f /etc/redhat-release && install_cmd="yum install -y"
+    if test -f /etc/redhat-release ; then
+        source /etc/os-release
+        if test "$(echo "$VERSION_ID >= 22" | bc)" -ne 0; then
+            install_cmd="dnf -y install"
+        else
+            install_cmd="yum install -y"
+        fi
+    fi
+
     type apt-get > /dev/null 2>&1 && install_cmd="apt-get install -y"
     type zypper > /dev/null 2>&1 && install_cmd="zypper --gpg-auto-import-keys --non-interactive install"
     if [ -n "$install_cmd" ]; then

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -50,9 +50,16 @@ else
 fi
 
 function run() {
-    # Same logic as install-deps.sh for finding package installer
     local install_cmd
-    test -f /etc/redhat-release && install_cmd="yum install -y"
+    if test -f /etc/redhat-release ; then
+        source /etc/os-release
+        if test "$(echo "$VERSION_ID >= 22" | bc)" -ne 0; then
+            install_cmd="dnf -y install"
+        else
+            install_cmd="yum install -y"
+        fi
+    fi
+
     type apt-get > /dev/null 2>&1 && install_cmd="apt-get install -y"
     type zypper > /dev/null 2>&1 && install_cmd="zypper --gpg-auto-import-keys --non-interactive install"
     if [ -n "$install_cmd" ]; then


### PR DESCRIPTION
The use of yum triggers a warning and reference to yum2dnf on Fedora >= 22.
Use either yum or dnf based on the Fedora version.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>