### PR TITLE
unittest_chain_xattr: account for existing xattrs

### DIFF
--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -347,13 +347,14 @@ TEST(chain_xattr, fskip_chain_cleanup_and_ensure_single_attr)
   ::unlink(file);
   int fd = ::open(file, O_CREAT|O_RDWR|O_TRUNC, 0700);
 
+  std::size_t existing_xattrs = get_xattrs(fd).size();
   char buf[800];
   memset(buf, sizeof(buf), 0x1F);
   // set chunked without either
   {
     std::size_t r = chain_fsetxattr(fd, name, buf, sizeof(buf));
     ASSERT_EQ(sizeof(buf), r);
-    ASSERT_GT(get_xattrs(fd).size(), 1UL);
+    ASSERT_GT(get_xattrs(fd).size(), existing_xattrs + 1UL);
   }
 
   // verify
@@ -368,7 +369,7 @@ TEST(chain_xattr, fskip_chain_cleanup_and_ensure_single_attr)
   {
     std::size_t r = chain_fsetxattr<false, true>(fd, name, buf, sizeof(buf));
     ASSERT_EQ(sizeof(buf), r);
-    ASSERT_EQ(1UL, get_xattrs(fd).size());
+    ASSERT_EQ(existing_xattrs + 1UL, get_xattrs(fd).size());
   }
 
   // verify
@@ -389,6 +390,7 @@ TEST(chain_xattr, skip_chain_cleanup_and_ensure_single_attr)
   const char *file = FILENAME;
   ::unlink(file);
   int fd = ::open(file, O_CREAT|O_RDWR|O_TRUNC, 0700);
+  std::size_t existing_xattrs = get_xattrs(fd).size();
   ::close(fd);
 
   char buf[3000];
@@ -397,7 +399,7 @@ TEST(chain_xattr, skip_chain_cleanup_and_ensure_single_attr)
   {
     std::size_t r = chain_setxattr(file, name, buf, sizeof(buf));
     ASSERT_EQ(sizeof(buf), r);
-    ASSERT_GT(get_xattrs(file).size(), 1UL);
+    ASSERT_GT(get_xattrs(file).size(), existing_xattrs + 1UL);
   }
 
   // verify
@@ -412,7 +414,7 @@ TEST(chain_xattr, skip_chain_cleanup_and_ensure_single_attr)
   {
     std::size_t r = chain_setxattr<false, true>(file, name, buf, sizeof(buf));
     ASSERT_EQ(sizeof(buf), r);
-    ASSERT_EQ(1UL, get_xattrs(file).size());
+    ASSERT_EQ(existing_xattrs + 1UL, get_xattrs(file).size());
   }
 
   // verify


### PR DESCRIPTION
On CentOS with selinux enabled, files always have an
xattr 'security.selinux'.  Account for that when adding/
removing xattrs.

Fixes: http://tracker.ceph.com/issues/16025
Signed-off-by: Dan Mick <dan.mick@redhat.com>