### PR TITLE
librbd: corrected use-after-free in ImageWatcher

### DIFF
--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -62,9 +62,10 @@ struct C_UnwatchAndFlush : public Context {
     // to completing the callback to avoid racing an explicit
     // librados shutdown
     Context *ctx = on_finish;
+    r = ret_val;
     delete this;
 
-    ctx->complete(ret_val);
+    ctx->complete(r);
   }
 
   virtual void finish(int r) override {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17289
Signed-off-by: Jason Dillaman <dillaman@redhat.com>