### PR TITLE
os/filestore: disable use of splice by default

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1104,6 +1104,7 @@ OPTION(filestore_fsync_flushes_journal_data, OPT_BOOL, false)
 OPTION(filestore_fiemap, OPT_BOOL, false)     // (try to) use fiemap
 OPTION(filestore_punch_hole, OPT_BOOL, false)
 OPTION(filestore_seek_data_hole, OPT_BOOL, false)     // (try to) use seek_data/hole
+OPTION(filestore_splice, OPT_BOOL, false)
 OPTION(filestore_fadvise, OPT_BOOL, true)
 //collect device partition information for management application to use
 OPTION(filestore_collect_device_partition_information, OPT_BOOL, true)

--- a/src/os/filestore/GenericFileStoreBackend.cc
+++ b/src/os/filestore/GenericFileStoreBackend.cc
@@ -58,10 +58,11 @@ GenericFileStoreBackend::GenericFileStoreBackend(FileStore *fs):
   FileStoreBackend(fs),
   ioctl_fiemap(false),
   seek_data_hole(false),
+  use_splice(false),
   m_filestore_fiemap(g_conf->filestore_fiemap),
   m_filestore_seek_data_hole(g_conf->filestore_seek_data_hole),
   m_filestore_fsync_flushes_journal_data(g_conf->filestore_fsync_flushes_journal_data),
-  m_filestore_splice(false) {}
+  m_filestore_splice(g_conf->filestore_splice) {}
 
 int GenericFileStoreBackend::detect_features()
 {
@@ -165,6 +166,9 @@ int GenericFileStoreBackend::detect_features()
   //splice detection
 #ifdef CEPH_HAVE_SPLICE
   if (!m_filestore_splice) {
+    dout(0) << __func__ << ": splice() is disabled via 'filestore splice' config option" << dendl;
+    use_splice = false;
+  } else {
     int pipefd[2];
     loff_t off_in = 0;
     int r;
@@ -174,7 +178,7 @@ int GenericFileStoreBackend::detect_features()
       lseek(fd, 0, SEEK_SET);
       r = splice(fd, &off_in, pipefd[1], NULL, 10, 0);
       if (!(r < 0 && errno == EINVAL)) {
-	m_filestore_splice = true;
+	use_splice = true;
 	dout(0) << "detect_features: splice is supported" << dendl;
       } else
 	dout(0) << "detect_features: splice is NOT supported" << dendl;

--- a/src/os/filestore/GenericFileStoreBackend.h
+++ b/src/os/filestore/GenericFileStoreBackend.h
@@ -23,6 +23,7 @@ class GenericFileStoreBackend : public FileStoreBackend {
 private:
   bool ioctl_fiemap;
   bool seek_data_hole;
+  bool use_splice;
   bool m_filestore_fiemap;
   bool m_filestore_seek_data_hole;
   bool m_filestore_fsync_flushes_journal_data;
@@ -50,7 +51,7 @@ public:
     return _copy_range(from, to, srcoff, len, dstoff);
   }
   virtual int set_alloc_hint(int fd, uint64_t hint) { return -EOPNOTSUPP; }
-  virtual bool has_splice() const { return m_filestore_splice; }
+  virtual bool has_splice() const { return use_splice; }
 private:
   int _crc_load_or_init(int fd, SloppyCRCMap *cm);
   int _crc_save(int fd, SloppyCRCMap *cm);


### PR DESCRIPTION
1. currently splice is actually buggy whatever enabling or not fiemap/seek_data feature
2. like bluestore's clone_range(https://github.com/ceph/ceph/pull/11106/commits/a931dd3e0067de58c83dc41e5adb0578cc5fa2c1) we need to zero target file when source file exist hole, but filestore's zero op maybe heavy which not equal to bluestore's zero. So I'd like pick up full copy strategy instead of fine grain handle. Since clone_range overwrite target object case is rare, I don't think this will be a problem in current clone_range users.