### PR TITLE
run-cmake-check.sh: Remove redundant calls

### DIFF
--- a/run-cmake-check.sh
+++ b/run-cmake-check.sh
@@ -42,12 +42,10 @@ function run() {
     else
         echo "WARNING: Don't know how to install packages" >&2
     fi
-    sudo /sbin/modprobe rbd
 
     if test -f ./install-deps.sh ; then
 	$DRY_RUN ./install-deps.sh || return 1
     fi
-    git submodule update --init --recursive
     $DRY_RUN ./do_cmake.sh $@ || return 1
     $DRY_RUN cd build
     $DRY_RUN make $BUILD_MAKEOPTS tests || return 1


### PR DESCRIPTION
Calling "git submodule init" is redundant since it is called in do_cmake.sh and
there's no reason to do a modprobe of rbd.ko here either.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>