### PR TITLE
compressor/zlib: switch to raw deflate

### DIFF
--- a/src/test/compressor/test_compression_zlib.cc
+++ b/src/test/compressor/test_compression_zlib.cc
@@ -93,8 +93,6 @@ TEST(ZlibCompressor, compress_decompress_chunk)
   bufferlist exp;
   exp.append("This is test text1234567890");
   EXPECT_TRUE(exp.contents_equal(after));
-
-
 }
 
 TEST(ZlibCompressor, compress_decompress_isal)
@@ -175,6 +173,92 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
   EXPECT_EQ(res, 0);
   exp.append(test);
   EXPECT_TRUE(exp.contents_equal(after));
+}
+
+void test_compress(size_t size)
+{
+  ZlibCompressor sp(false);
+  EXPECT_STREQ(sp.get_type().c_str(), "zlib");
+  char* data = (char*) malloc(size);
+  for (size_t t = 0; t < size; t++) {
+    data[t] = (t & 0xff) | (t >> 8);
+  }
+  bufferlist in;
+  in.append(data, size);
+  for (size_t t = 0; t < 100000; t++) {
+    bufferlist out;
+    int res = sp.compress(in, out);
+    EXPECT_EQ(res, 0);
+  }
+}
+
+void test_decompress(size_t size)
+{
+  ZlibCompressor sp(false);
+  EXPECT_STREQ(sp.get_type().c_str(), "zlib");
+  char* data = (char*) malloc(size);
+  for (size_t t = 0; t < size; t++) {
+    data[t] = (t & 0xff) | (t >> 8);
+  }
+  bufferlist in, out;
+  in.append(data, size);
+  int res = sp.compress(in, out);
+  EXPECT_EQ(res, 0);
+  for (size_t t = 0; t < 100000; t++) {
+    bufferlist out_dec;
+    int res = sp.decompress(out, out_dec);
+    EXPECT_EQ(res, 0);
+  }
+}
+
+TEST(ZlibCompressor, compress_1024)
+{
+  test_compress(1024);
+}
+
+TEST(ZlibCompressor, compress_2048)
+{
+  test_compress(2048);
+}
+
+TEST(ZlibCompressor, compress_4096)
+{
+  test_compress(4096);
+}
+
+TEST(ZlibCompressor, compress_8192)
+{
+  test_compress(8192);
+}
+
+TEST(ZlibCompressor, compress_16384)
+{
+  test_compress(16384);
+}
+
+TEST(Zlibdecompressor, decompress_1024)
+{
+  test_decompress(1024);
+}
+
+TEST(Zlibdecompressor, decompress_2048)
+{
+  test_decompress(2048);
+}
+
+TEST(Zlibdecompressor, decompress_4096)
+{
+  test_decompress(4096);
+}
+
+TEST(Zlibdecompressor, decompress_8192)
+{
+  test_decompress(8192);
+}
+
+TEST(Zlibdecompressor, decompress_16384)
+{
+  test_decompress(16384);
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
By using raw deflate instead of default zlib deflate, we're saving 6 bytes on each compression stream and some CPU time by not calculating Adler32 during both compression and decompression (which is waste of time as Bluestore has its own checksumming code that is *also* executed).
CPU time savings are more visible on decompression (depends on compressed stream length; from 5 to 20% cpu time saved), but compression also sees gains (up to 5% in my testing).

Signed-off-by: Piotr Dałek <git@predictor.org.pl>