### PR TITLE
ceph-create-keys: add missing argument comma

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -109,7 +109,7 @@ def get_key(cluster, mon_id):
                 returncode = subprocess.call(
                     args=args_prefix + [
                         'auth',
-                        'get'
+                        'get',
                         'client.admin',
                         ],
                     stdout=f,


### PR DESCRIPTION
The arguments "get" and "client.admin" were being concatenated into
"getclient.admin".

Found using ceph-ansible + strace:

    13031 execve("/usr/bin/ceph", ["ceph", "--cluster=ceph", "--name=mon.", "--keyring=/var/lib/ceph/mon/ceph-ceph-mon0/keyring", "auth", "getclient.admin"], ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin", "LANG=en_US.UTF-8", "CLUSTER=ceph", "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728", "CEPH_AUTO_RESTART_ON_UPGRADE=no"] <unfinished ...>

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>