### PR TITLE
rgw: remove a redundant judgement in rgw_rados.cc:delete_obj.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7849,7 +7849,6 @@ int RGWRados::Object::Delete::delete_obj()
     need_invalidate = true;
     r = 0;
   }
-  bool removed = (r >= 0);
 
   int64_t poolid = ref.ioctx.get_id();
   if (r >= 0) {
@@ -7859,18 +7858,17 @@ int RGWRados::Object::Delete::delete_obj()
       obj_tombstone_cache->add(obj, entry);
     }
     r = index_op.complete_del(poolid, ref.ioctx.get_last_version(), state->mtime, params.remove_objs);
-  } else {
-    int ret = index_op.cancel();
-    if (ret < 0) {
-      ldout(store->ctx(), 0) << "ERROR: index_op.cancel() returned ret=" << ret << dendl;
-    }
-  }
-  if (removed) {
+    
     int ret = target->complete_atomic_modification();
     if (ret < 0) {
       ldout(store->ctx(), 0) << "ERROR: complete_atomic_modification returned ret=" << ret << dendl;
     }
     /* other than that, no need to propagate error */
+  } else {
+    int ret = index_op.cancel();
+    if (ret < 0) {
+      ldout(store->ctx(), 0) << "ERROR: index_op.cancel() returned ret=" << ret << dendl;
+    }
   }
 
   if (need_invalidate) {


### PR DESCRIPTION
The value of the 'removed' is just the same as 'r>=0'. We can merge the two
judgement and remove the var 'removed'. Because the delete_obj is always called when
we delete obj from ceph, remove the judgement may gain a little improvement.

Signed-off-by: Zhang Shaowen zhangshaowen@cmss.chinamobile.com
