### PR TITLE
Changed config parameter "rgw keystone make new tenants" in radosgw multitenancy

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -16,7 +16,7 @@ The following configuration options are available for Keystone integration::
 	rgw keystone accepted roles = {accepted user roles}
 	rgw keystone token cache size = {number of tokens to cache}
 	rgw keystone revocation interval = {number of seconds before checking revoked tickets}
-	rgw keystone make new tenants = {true for private tenant for each new user}
+	rgw keystone implicit tenants = {true for private tenant for each new user}
 	rgw s3 auth use keystone = true
 	nss db path = {path to nss db}
 

--- a/doc/radosgw/multitenancy.rst
+++ b/doc/radosgw/multitenancy.rst
@@ -88,7 +88,7 @@ Swift with Keystone
 -------------------
 
 TBD -- don't forget to explain the function of
-       rgw keystone make new tenants = true
+       rgw keystone implicit tenants = true
        in commit e9259486decab52a362443d3fd3dec33b0ec654f
 
 Notes and known issues


### PR DESCRIPTION
Fixes bug: http://tracker.ceph.com/issues/17293

Modified the configuration parameter in two files
mentioned below from "rgw keystone make new tenants"
to "rgw keystone implicit tenants"