### PR TITLE
fix Unknown lvalue 'TasksMax' in section 'Service'

### DIFF
--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -21,7 +21,6 @@ PrivateDevices=yes
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -15,7 +15,6 @@ ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
-TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3


### PR DESCRIPTION
When I run systemctl restart ceph-osd@0, I got some mgs from 'systemctl status ceph-osd@0'
```
Sep 20 01:11:51 ceph1 systemd[1]: [/usr/lib/systemd/system/ceph-osd@.service:17] Unknown lvalue 'TasksMax' in section 'Service'
```

Signed-off-by: LeoZhang <nguzcf@gmail.com>