### PR TITLE
os/filestore/FileJournal: fail out if FileJournal is not block device…

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -89,13 +89,17 @@ int FileJournal::_open(bool forwrite, bool create)
 
   if (S_ISBLK(st.st_mode)) {
     ret = _open_block_device();
-  } else {
+  } else if (S_ISREG(st.st_mode)) {
     if (aio && !force_aio) {
       derr << "FileJournal::_open: disabling aio for non-block journal.  Use "
 	   << "journal_force_aio to force use of aio anyway" << dendl;
       aio = false;
     }
     ret = _open_file(st.st_size, st.st_blksize, create);
+  } else {
+    derr << "FileJournal::_open: wrong journal file type: " << st.st_mode
+	 << dendl;
+    ret = -EINVAL;
   }
 
   if (ret)
@@ -134,6 +138,7 @@ int FileJournal::_open(bool forwrite, bool create)
 
  out_fd:
   VOID_TEMP_FAILURE_RETRY(::close(fd));
+  fd = -1;
   return ret;
 }
 


### PR DESCRIPTION
… or regular file

otherwise JournalingFileStore will assert when deleting FileJournal
which still has the non block/regular file opened.

Fixes: http://tracker.ceph.com/issues/17307
Signed-off-by: Kefu Chai <kchai@redhat.com>