### PR TITLE
client: fix readdir vs fragmentation race

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1129,7 +1129,7 @@ void Client::insert_readdir_results(MetaRequest *request, MetaSession *session, 
 		   << ", readdir_start " << readdir_start << dendl;
 
     if (diri->snapid != CEPH_SNAPDIR &&
-	fg.is_leftmost() && readdir_offset == 2) {
+	fg.is_leftmost() && readdir_offset == 2 && readdir_start.empty()) {
       dirp->release_count = diri->dir_release_count;
       dirp->ordered_count = diri->dir_ordered_count;
       dirp->start_shared_gen = diri->shared_gen;


### PR DESCRIPTION
following sequence of events tigger the race

client readdir frag 0* -> got item 'A'
MDS merges frag 0* and frag 1*
client send readdir request (frag 1*, offset 2, readdir_start 'A')
MDS reply items (that are after item 'A') in frag *

Fixes: http://tracker.ceph.com/issues/17286
Signed-off-by: Yan, Zheng <zyan@redhat.com>