### PR TITLE
librbd: block name prefix might overflow fixed size C-string

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -475,9 +475,10 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     info.obj_size = 1ULL << obj_order;
     info.num_objs = Striper::get_num_objects(ictx->layout, info.size);
     info.order = obj_order;
-    memcpy(&info.block_name_prefix, ictx->object_prefix.c_str(),
-	   min((size_t)RBD_MAX_BLOCK_NAME_SIZE,
-	       ictx->object_prefix.length() + 1));
+    strncpy(info.block_name_prefix, ictx->object_prefix.c_str(),
+            RBD_MAX_BLOCK_NAME_SIZE);
+    info.block_name_prefix[RBD_MAX_BLOCK_NAME_SIZE - 1] = '\0';
+
     // clear deprecated fields
     info.parent_pool = -1L;
     info.parent_name[0] = '\0';


### PR DESCRIPTION
The issue which resulted in too large v2 image ids was fixed
under #16887.

Fixes: http://tracker.ceph.com/issues/17310
Signed-off-by: Jason Dillaman <dillaman@redhat.com>