### PR TITLE
os/bluestore: narrow condition of sanity check when get_object_key()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -307,7 +307,7 @@ static void get_object_key(const ghobject_t& oid, string *key)
       derr << "key " << pretty_binary_string(*key) << dendl;
       derr << "oid " << oid << dendl;
       derr << "  t " << t << dendl;
-      assert(t == oid);
+      assert(r == 0 && t == oid);
     }
   }
 }


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>