### PR TITLE
osd/PG.h: move shared ptr instead of copying it

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -226,7 +226,7 @@ protected:
   void update_osdmap_ref(OSDMapRef newmap) {
     assert(_lock.is_locked_by_me());
     Mutex::Locker l(map_lock);
-    osdmap_ref = newmap;
+    osdmap_ref = std::move(newmap);
   }
 
   OSDMapRef get_osdmap_with_maplock() const {


### PR DESCRIPTION
When we move newmap into osdmap_ref we prevent unnecessary increase
and decrease of reference count when newmap goes out of scope.

Signed-off-by: Michal Jarzabek stiopa@gmail.com
