### PR TITLE
rgw_file: fix set_attrs operation

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -604,6 +604,7 @@ namespace rgw {
     rgw_fh->encode_attrs(ux_key, ux_attrs);
 
     /* save attrs */
+    req.emplace_attr(RGW_ATTR_UNIX_KEY1, std::move(ux_key));
     req.emplace_attr(RGW_ATTR_UNIX1, std::move(ux_attrs));
 
     rc = rgwlib.get_fe()->execute_req(&req);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5178,7 +5178,7 @@ void RGWSetAttrs::execute()
   store->set_atomic(s->obj_ctx, obj);
 
   if (!s->object.empty()) {
-    op_ret = store->set_attrs(s->obj_ctx, obj, attrs, &attrs);
+    op_ret = store->set_attrs(s->obj_ctx, obj, attrs, nullptr);
   } else {
     for (auto& iter : attrs) {
       s->bucket_attrs[iter.first] = std::move(iter.second);


### PR DESCRIPTION
The effective part of this change is to always set a value
for RGW_ATTR_UNIX_KEY1 (because it is expected later).

Secondarily, do not pass the address of the to-set attributes
buffer::list as remove attrs--this is confusing.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>