### PR TITLE
lttng: remove the source files created by lttng-gen-tp

### DIFF
--- a/src/tracing/librados.c
+++ b/src/tracing/librados.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "librados.h"

--- a/src/tracing/librbd.c
+++ b/src/tracing/librbd.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "librbd.h"

--- a/src/tracing/objectstore.c
+++ b/src/tracing/objectstore.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "objectstore.h"

--- a/src/tracing/oprequest.c
+++ b/src/tracing/oprequest.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "oprequest.h"

--- a/src/tracing/osd.c
+++ b/src/tracing/osd.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "osd.h"

--- a/src/tracing/pg.c
+++ b/src/tracing/pg.c
@@ -1,6 +1,0 @@
-
-#define TRACEPOINT_CREATE_PROBES
-/*
- * The header containing our TRACEPOINT_EVENTs.
- */
-#include "pg.h"


### PR DESCRIPTION
they will be created at build time in the build directory.

Signed-off-by: Kefu Chai <kchai@redhat.com>