### PR TITLE
mon: make MDSMonitor tolerant of slow mon elections

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -109,7 +109,7 @@ void FSMap::print(ostream& out) const
 
 
 
-void FSMap::print_summary(Formatter *f, ostream *out)
+void FSMap::print_summary(Formatter *f, ostream *out) const
 {
   map<mds_role_t,string> by_rank;
   map<string,int> by_state;

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -444,14 +444,14 @@ public:
   }
 
   void print(ostream& out) const;
-  void print_summary(Formatter *f, ostream *out);
+  void print_summary(Formatter *f, ostream *out) const;
 
   void dump(Formatter *f) const;
   static void generate_test_instances(list<FSMap*>& ls);
 };
 WRITE_CLASS_ENCODER_FEATURES(FSMap)
 
-inline ostream& operator<<(ostream& out, FSMap& m) {
+inline ostream& operator<<(ostream& out, const FSMap& m) {
   m.print_summary(NULL, &out);
   return out;
 }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -480,26 +480,6 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
   return true;
 }
 
-
-namespace {
-class C_Updated : public Context {
-  MDSMonitor *mm;
-  MonOpRequestRef op;
-public:
-  C_Updated(MDSMonitor *a, MonOpRequestRef c) :
-    mm(a), op(c) {}
-  void finish(int r) {
-    if (r >= 0)
-      mm->_updated(op);   // success
-    else if (r == -ECANCELED) {
-      mm->mon->no_reply(op);
-    } else {
-      mm->dispatch(op);        // try again
-    }
-  }
-};
-}
-
 bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
 {
   op->mark_mdsmon_event(__func__);
@@ -699,7 +679,15 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
   dout(7) << "prepare_beacon pending map now:" << dendl;
   print_map(pending_fsmap);
   
-  wait_for_finished_proposal(op, new C_Updated(this, op));
+  wait_for_finished_proposal(op, new FunctionContext([op, this](int r){
+    if (r >= 0)
+      _updated(op);   // success
+    else if (r == -ECANCELED) {
+      mon->no_reply(op);
+    } else {
+      dispatch(op);        // try again
+    }
+  }));
 
   return true;
 }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2965,8 +2965,25 @@ void MDSMonitor::tick()
     do_propose |= maybe_expand_cluster(i.second);
   }
 
+  const auto now = ceph_clock_now(g_ceph_context);
+  if (last_tick.is_zero()) {
+    last_tick = now;
+  }
+
+  if (now - last_tick > (g_conf->mds_beacon_grace - g_conf->mds_beacon_interval)) {
+    // This case handles either local slowness (calls being delayed
+    // for whatever reason) or cluster election slowness (a long gap
+    // between calls while an election happened)
+    dout(4) << __func__ << ": resetting beacon timeouts due to mon delay "
+            "(slow election?) of " << now - last_tick << " seconds" << dendl;
+    for (auto &i : last_beacon) {
+      i.second.stamp = now;
+    }
+  }
+
+  last_tick = now;
+
   // check beacon timestamps
-  utime_t now = ceph_clock_now(g_ceph_context);
   utime_t cutoff = now;
   cutoff -= g_conf->mds_beacon_grace;
 
@@ -2974,7 +2991,7 @@ void MDSMonitor::tick()
   for (const auto &p : pending_fsmap.mds_roles) {
     auto &gid = p.first;
     if (last_beacon.count(gid) == 0) {
-      last_beacon[gid].stamp = ceph_clock_now(g_ceph_context);
+      last_beacon[gid].stamp = now;
       last_beacon[gid].seq = 0;
     }
   }
@@ -3054,5 +3071,12 @@ MDSMonitor::MDSMonitor(Monitor *mn, Paxos *p, string service_name)
         "mds remove_data_pool"));
   handlers.push_back(std::make_shared<LegacyHandler<RemoveDataPoolHandler> >(
         "mds rm_data_pool"));
+}
+
+void MDSMonitor::on_restart()
+{
+  // Clear out the leader-specific state.
+  last_tick = utime_t();
+  last_beacon.clear();
 }
 

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -38,15 +38,7 @@ class FileSystemCommandHandler;
 
 class MDSMonitor : public PaxosService {
  public:
-  // mds maps
-  FSMap fsmap;           // current
-  FSMap pending_fsmap;  // current + pending updates
-
-  // my helpers
-  void print_map(FSMap &m, int dbl=7);
-  void create_new_fs(FSMap &m, const std::string &name, int metadata_pool, int data_pool);
-
-  version_t get_trim_to();
+  MDSMonitor(Monitor *mn, Paxos *p, string service_name);
 
   // service methods
   void create_initial();
@@ -56,16 +48,33 @@ class MDSMonitor : public PaxosService {
   void encode_pending(MonitorDBStore::TransactionRef t);
   // we don't require full versions; don't encode any.
   virtual void encode_full(MonitorDBStore::TransactionRef t) { }
+  version_t get_trim_to();
 
-  void update_logger();
-
-  void _updated(MonOpRequestRef op);
- 
   bool preprocess_query(MonOpRequestRef op);  // true if processed.
   bool prepare_update(MonOpRequestRef op);
   bool should_propose(double& delay);
 
   void on_active();
+
+  void check_subs();
+  void check_sub(Subscription *sub);
+
+  const FSMap &get_pending() const { return pending_fsmap; }
+  const FSMap &get_fsmap() const { return fsmap; }
+  void dump_info(Formatter *f);
+  int print_nodes(Formatter *f);
+
+ protected:
+  // mds maps
+  FSMap fsmap;           // current
+  FSMap pending_fsmap;  // current + pending updates
+
+  // my helpers
+  void print_map(FSMap &m, int dbl=7);
+  void create_new_fs(FSMap &m, const std::string &name, int metadata_pool, int data_pool);
+  void update_logger();
+
+  void _updated(MonOpRequestRef op);
 
   void _note_beacon(class MMDSBeacon *m);
   bool preprocess_beacon(MonOpRequestRef op);
@@ -123,23 +132,14 @@ class MDSMonitor : public PaxosService {
 
   std::list<std::shared_ptr<FileSystemCommandHandler> > handlers;
 
-public:
-  MDSMonitor(Monitor *mn, Paxos *p, string service_name);
-
   bool maybe_promote_standby(std::shared_ptr<Filesystem> fs);
   bool maybe_expand_cluster(std::shared_ptr<Filesystem> fs);
   void maybe_replace_gid(mds_gid_t gid, const beacon_info_t &beacon,
       bool *mds_propose, bool *osd_propose);
   void tick();     // check state, take actions
 
-  void dump_info(Formatter *f);
   int dump_metadata(const string& who, Formatter *f, ostream& err);
-  int print_nodes(Formatter *f);
 
-  void check_subs();
-  void check_sub(Subscription *sub);
-
-private:
   MDSMap *generate_mds_map(fs_cluster_id_t fscid);
   void update_metadata(mds_gid_t gid, const Metadata& metadata);
   void remove_from_metadata(MonitorDBStore::TransactionRef t);

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -55,6 +55,7 @@ class MDSMonitor : public PaxosService {
   bool should_propose(double& delay);
 
   void on_active();
+  void on_restart();
 
   void check_subs();
   void check_sub(Subscription *sub);
@@ -153,6 +154,11 @@ class MDSMonitor : public PaxosService {
 
   int _check_pool(const int64_t pool_id, std::stringstream *ss) const;
   mds_gid_t gid_from_arg(const std::string& arg, std::ostream& err);
+
+  // When did the mon last call into our tick() method?  Used for detecting
+  // when the mon was not updating us for some period (e.g. during slow
+  // election) to reset last_beacon timeouts
+  utime_t last_tick;
 };
 
 #endif

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2688,7 +2688,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     pgmon()->pg_map.print_summary(f, NULL);
     f->close_section();
     f->open_object_section("fsmap");
-    mdsmon()->fsmap.print_summary(f, NULL);
+    mdsmon()->get_fsmap().print_summary(f, NULL);
     f->close_section();
 
     f->open_object_section("mgrmap");
@@ -2702,8 +2702,8 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     ss << "     monmap " << *monmap << "\n";
     ss << "            election epoch " << get_epoch()
        << ", quorum " << get_quorum() << " " << get_quorum_names() << "\n";
-    if (mdsmon()->fsmap.filesystem_count() > 0) {
-      ss << "      fsmap " << mdsmon()->fsmap << "\n";
+    if (mdsmon()->get_fsmap().filesystem_count() > 0) {
+      ss << "      fsmap " << mdsmon()->get_fsmap() << "\n";
     }
     if (mgrmon()->in_use()) {
       ss << "        mgr ";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8210,7 +8210,7 @@ int OSDMonitor::_check_remove_pool(int64_t pool, const pg_pool_t *p,
   const string& poolstr = osdmap.get_pool_name(pool);
 
   // If the Pool is in use by CephFS, refuse to delete it
-  FSMap const &pending_fsmap = mon->mdsmon()->pending_fsmap;
+  FSMap const &pending_fsmap = mon->mdsmon()->get_pending();
   if (pending_fsmap.pool_in_use(pool)) {
     *ss << "pool '" << poolstr << "' is in use by CephFS";
     return -EBUSY;
@@ -8259,7 +8259,7 @@ bool OSDMonitor::_check_become_tier(
   const std::string &tier_pool_name = osdmap.get_pool_name(tier_pool_id);
   const std::string &base_pool_name = osdmap.get_pool_name(base_pool_id);
 
-  const FSMap &pending_fsmap = mon->mdsmon()->pending_fsmap;
+  const FSMap &pending_fsmap = mon->mdsmon()->get_pending();
   if (pending_fsmap.pool_in_use(tier_pool_id)) {
     *ss << "pool '" << tier_pool_name << "' is in use by CephFS";
     *err = -EBUSY;
@@ -8319,7 +8319,7 @@ bool OSDMonitor::_check_remove_tier(
   const std::string &base_pool_name = osdmap.get_pool_name(base_pool_id);
 
   // Apply CephFS-specific checks
-  const FSMap &pending_fsmap = mon->mdsmon()->pending_fsmap;
+  const FSMap &pending_fsmap = mon->mdsmon()->get_pending();
   if (pending_fsmap.pool_in_use(base_pool_id)) {
     if (base_pool->type != pg_pool_t::TYPE_REPLICATED) {
       // If the underlying pool is erasure coded, we can't permit the


### PR DESCRIPTION
Previously MDS daemons would get failed incorrectly
when they appeared to have timed out due to
delays in calling into MDSMonitor that were
actually caused by e.g. slow leveldb writes leading
to slow mon elections.

Fixes: http://tracker.ceph.com/issues/17308
Signed-off-by: John Spray john.spray@redhat.com
