### PR TITLE
cmake: remove unittest_memstore_clone from 'make check'

### DIFF
--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -139,5 +139,4 @@ target_link_libraries(unittest_transaction os common)
 
 # unittest_memstore_clone
 add_executable(unittest_memstore_clone test_memstore_clone.cc)
-add_ceph_unittest(unittest_memstore_clone ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_memstore_clone)
 target_link_libraries(unittest_memstore_clone os global)


### PR DESCRIPTION
unittest_memstore_clone needs an --osd-data directory to run in, and
(unlike ceph_test_objectstore) it does not create/manage one for you.
removing from 'make check' so the jenkins bot will stop failing

Signed-off-by: Casey Bodley <cbodley@redhat.com>