### PR TITLE
client: fix segment fault in Client::_invalidate_kernel_dcache().

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3938,6 +3938,8 @@ public:
 
 void Client::_invalidate_kernel_dcache()
 {
+  if (unmounting)
+    return;
   if (can_invalidate_dentries && dentry_invalidate_cb && root->dir) {
     for (ceph::unordered_map<string, Dentry*>::iterator p = root->dir->dentries.begin();
 	 p != root->dir->dentries.end();


### PR DESCRIPTION
when umounting, root can be NULL

Fixes: http://tracker.ceph.com/issues/17253
Signed-off-by: Yan, Zheng <zyan@redhat.com>