### PR TITLE
test/cli/crushtool: fix the test of compile-decompile-recompile.t

### DIFF
--- a/src/test/cli/crushtool/compile-decompile-recompile.t
+++ b/src/test/cli/crushtool/compile-decompile-recompile.t
@@ -10,6 +10,6 @@
   $ cmp need_tree_order.crush nto.conf
   $ cmp nto.compiled nto.recompiled
 
-  $ crushtool -c missing-bucket.crushmap.txt
+  $ crushtool -c "$TESTDIR/missing-bucket.crushmap.txt"
   in rule 'rule-bad' item 'root-404' not defined
   [1]


### PR DESCRIPTION
should read the map from $TESTDIR,
it's a regression introduced by b2c0a07

Fixes: http://tracker.ceph.com/issues/17306
Signed-off-by: Kefu Chai <kchai@redhat.com>