### PR TITLE
rbd: set rbd_default_features config option as a string

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -36,6 +36,10 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
+#include <utility>
+#include <boost/type_traits.hpp>
+#include <boost/utility/enable_if.hpp>
+
 /* Don't use standard Ceph logging in this file.
  * We can't use logging until it's initialized, and a lot of the necessary
  * initialization happens here.
@@ -60,32 +64,6 @@ const char *CEPH_CONF_FILE_DEFAULT = "$data_dir/config, /etc/ceph/$cluster.conf,
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)
-
-
-void *config_option::conf_ptr(md_config_t *conf) const
-{
-  void *v = (void*)(((char*)conf) + md_conf_off);
-  return v;
-}
-
-const void *config_option::conf_ptr(const md_config_t *conf) const
-{
-  const void *v = (const void*)(((const char*)conf) + md_conf_off);
-  return v;
-}
-
-struct config_option config_optionsp[] = {
-#define OPTION(name, type, def_val) \
-       { STRINGIFY(name), type, offsetof(struct md_config_t, name) },
-#define SUBSYS(name, log, gather)
-#define DEFAULT_SUBSYS(log, gather)
-#include "common/config_opts.h"
-#undef OPTION
-#undef SUBSYS
-#undef DEFAULT_SUBSYS
-};
-
-const int NUM_CONFIG_OPTIONS = sizeof(config_optionsp) / sizeof(config_option);
 
 int ceph_resolve_file_search(const std::string& filename_list,
 			     std::string& result)
@@ -123,6 +101,7 @@ md_config_t::md_config_t()
 #define OPTION_OPT_U64(name, def_val) name(((uint64_t)1) * def_val),
 #define OPTION_OPT_UUID(name, def_val) name(def_val),
 #define OPTION(name, type, def_val) OPTION_##type(name, def_val)
+#define SAFE_OPTION(name, type, def_val) OPTION(name, type, def_val)
 #define SUBSYS(name, log, gather)
 #define DEFAULT_SUBSYS(log, gather)
 #include "common/config_opts.h"
@@ -137,10 +116,28 @@ md_config_t::md_config_t()
 #undef OPTION_OPT_U64
 #undef OPTION_OPT_UUID
 #undef OPTION
+#undef SAFE_OPTION
 #undef SUBSYS
 #undef DEFAULT_SUBSYS
   lock("md_config_t", true, false)
 {
+  static const std::vector<md_config_t::config_option> s_config_options = {
+#define OPTION4(name, type, def_val, safe) \
+        config_option{ STRINGIFY(name), type, &md_config_t::name, safe },
+#define OPTION(name, type, def_val) OPTION4(name, type, def_val, false)
+#define SAFE_OPTION(name, type, def_val) OPTION4(name, type, def_val, true)
+#define SUBSYS(name, log, gather)
+#define DEFAULT_SUBSYS(log, gather)
+#include "common/config_opts.h"
+#undef OPTION
+#undef SAFE_OPTION
+#undef SUBSYS
+#undef DEFAULT_SUBSYS
+  };
+  static std::shared_ptr<decltype(s_config_options)>
+    s_tbl(new std::vector<md_config_t::config_option>(std::move(s_config_options)));
+  config_options = s_tbl;
+
   init_subsys();
 }
 
@@ -151,8 +148,10 @@ void md_config_t::init_subsys()
 #define DEFAULT_SUBSYS(log, gather) \
   subsys.add(ceph_subsys_, "none", log, gather);
 #define OPTION(a, b, c)
+#define SAFE_OPTION(a, b, c)
 #include "common/config_opts.h"
 #undef OPTION
+#undef SAFE_OPTION
 #undef SUBSYS
 #undef DEFAULT_SUBSYS
 }
@@ -225,7 +224,7 @@ int md_config_t::parse_config_files(const char *conf_files,
     string &s = *p;
     if (s.find("$data_dir") != string::npos) {
       if (data_dir_option.length()) {
-	list<config_option*> stack;
+	list<config_option const *> stack;
 	expand_meta(s, NULL, stack, warnings);
 	p++;
       } else {
@@ -279,12 +278,11 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
 
   std::vector <std::string> my_sections;
   _get_my_sections(my_sections);
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {
-    config_option *opt = &config_optionsp[i];
+  for (auto& opt: *config_options) {
     std::string val;
-    int ret = _get_val_from_conf_file(my_sections, opt->name, val, false);
+    int ret = _get_val_from_conf_file(my_sections, opt.name, val, false);
     if (ret == 0) {
-      set_val_impl(val.c_str(), opt);
+      set_val_impl(val.c_str(), &opt);
     }
   }
   
@@ -377,14 +375,13 @@ void md_config_t::_show_config(std::ostream *out, Formatter *f)
       f->dump_string(debug_name.c_str(), ss.str());
     }
   }
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {
-    config_option *opt = config_optionsp + i;
+  for (auto& opt: *config_options) {
     char *buf;
-    _get_val(opt->name, &buf, -1);
+    _get_val(opt.name, &buf, -1);
     if (out)
-      *out << opt->name << " = " << buf << std::endl;
+      *out << opt.name << " = " << buf << std::endl;
     if (f)
-      f->dump_string(opt->name, buf);
+      f->dump_string(opt.name, buf);
     free(buf);
   }
 }
@@ -518,9 +515,10 @@ int md_config_t::parse_option(std::vector<const char*>& args,
     return ret;
   }
 
-  for (o = 0; o < NUM_CONFIG_OPTIONS; ++o) {
+  o = 0;
+  for (auto& opt_ref: *config_options) {
     ostringstream err;
-    const config_option *opt = config_optionsp + o;
+    config_option const *opt = &opt_ref;
     std::string as_option("--");
     as_option += opt->name;
     if (opt->type == OPT_BOOL) {
@@ -550,9 +548,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
 	ret = -EINVAL;
 	break;
       }
-      if (oss && (
-		  ((opt->type == OPT_STR) || (opt->type == OPT_ADDR) ||
-		   (opt->type == OPT_UUID)) &&
+      if (oss && ((!opt->is_safe()) &&
 		  (observers.find(opt->name) == observers.end()))) {
 	*oss << "You cannot change " << opt->name << " using injectargs.\n";
 	ret = -ENOSYS;
@@ -572,8 +568,9 @@ int md_config_t::parse_option(std::vector<const char*>& args,
       }
       break;
     }
+    ++o;
   }
-  if (o == NUM_CONFIG_OPTIONS) {
+  if (o == (int)config_options->size()) {
     // ignore
     ++i;
   }
@@ -712,6 +709,49 @@ void md_config_t::set_val_or_die(const char *key, const char *val)
   assert(ret == 0);
 }
 
+struct is_integer_member : public boost::static_visitor<bool> {
+  template<typename T,
+           typename boost::enable_if<boost::is_integral<T>, int>::type = 0>
+  bool operator()(const T md_config_t::* /* member_ptr */) const {
+    return true;
+  }
+  template<typename T,
+           typename boost::enable_if_c<!boost::is_integral<T>::value, int>::type = 0>
+  bool operator()(const T md_config_t::* /* member_ptr */) const {
+    return false;
+  }
+};
+
+struct is_float_member : public boost::static_visitor<bool> {
+  template<typename T,
+           typename boost::enable_if<boost::is_float<T>, int>::type = 0>
+  bool operator()(const T md_config_t::* /* member_ptr */) const {
+    return true;
+  }
+  template<typename T,
+           typename boost::enable_if_c<!boost::is_float<T>::value, int>::type = 0>
+  bool operator()(const T md_config_t::* /* member_ptr */) const {
+    return false;
+  }
+};
+
+bool md_config_t::config_option::is_safe() const {
+  // for now integer and floating point options considered thread safe
+  return safe ||
+    boost::apply_visitor(is_integer_member(), md_member_ptr) ||
+    boost::apply_visitor(is_float_member(), md_member_ptr);
+}
+
+md_config_t::config_option const *md_config_t::find_config_option(const std::string &normalized_key) const
+{
+  auto opt_it = std::find_if(config_options->begin(),
+                             config_options->end(),
+			     [normalized_key](const config_option &opt) -> bool {
+			       return strcmp(normalized_key.c_str(), opt.name) == 0;
+			     });
+  return config_options->end() == opt_it ? nullptr : &(*opt_it);
+}
+
 int md_config_t::set_val(const char *key, const char *val, bool meta, bool safe)
 {
   Mutex::Locker l(lock);
@@ -746,23 +786,17 @@ int md_config_t::set_val(const char *key, const char *val, bool meta, bool safe)
     }	
   }
 
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; ++i) {
-    config_option *opt = &config_optionsp[i];
-    if (strcmp(opt->name, k.c_str()) == 0) {
-      if (safe && internal_safe_to_start_threads) {
-	// If threads have been started...
-	if ((opt->type == OPT_STR) || (opt->type == OPT_ADDR) ||
-	    (opt->type == OPT_UUID)) {
-	  // And this is NOT an integer valued variable....
-	  if (observers.find(opt->name) == observers.end()) {
-	    // And there is no observer to safely change it...
-	    // You lose.
-	    return -ENOSYS;
-	  }
-	}
+  config_option const *opt = find_config_option(k);
+  if (opt) {
+    if ((!opt->is_safe()) && safe && internal_safe_to_start_threads) {
+      // If threads have been started and the option is not thread safe
+      if (observers.find(opt->name) == observers.end()) {
+        // And there is no observer to safely change it...
+        // You lose.
+        return -ENOSYS;
       }
-      return set_val_impl(v.c_str(), opt);
     }
+    return set_val_impl(v.c_str(), opt);
   }
 
   // couldn't find a configuration option with key 'key'
@@ -776,6 +810,39 @@ int md_config_t::get_val(const char *key, char **buf, int len) const
   return _get_val(key, buf,len);
 }
 
+md_config_t::config_value_t md_config_t::get_val_generic(const char *key) const
+{
+  Mutex::Locker l(lock);
+  return _get_val(key);
+}
+
+class get_value_generic_visitor : public boost::static_visitor<md_config_t::config_value_t> {
+  md_config_t const *conf;
+public:
+  explicit get_value_generic_visitor(md_config_t const *conf_) : conf(conf_) { }
+  template<typename T> md_config_t::config_value_t operator()(const T md_config_t::* member_ptr) {
+    return md_config_t::config_value_t(conf->*member_ptr);
+  }
+};
+
+md_config_t::config_value_t md_config_t::_get_val(const char *key) const
+{
+  assert(lock.is_locked());
+
+  if (!key)
+    return config_value_t(invalid_config_value_t());
+
+  // In key names, leading and trailing whitespace are not significant.
+  string k(ConfFile::normalize_key_name(key));
+
+  config_option const *opt = find_config_option(k);
+  if (!opt) {
+      return config_value_t(invalid_config_value_t());
+  }
+  get_value_generic_visitor gvv(this);
+  return boost::apply_visitor(gvv, opt->md_member_ptr);
+}
+
 int md_config_t::_get_val(const char *key, char **buf, int len) const
 {
   assert(lock.is_locked());
@@ -783,48 +850,15 @@ int md_config_t::_get_val(const char *key, char **buf, int len) const
   if (!key)
     return -EINVAL;
 
-  // In key names, leading and trailing whitespace are not significant.
   string k(ConfFile::normalize_key_name(key));
 
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; ++i) {
-    const config_option *opt = &config_optionsp[i];
-    if (strcmp(opt->name, k.c_str()))
-      continue;
-
+  config_value_t cval = _get_val(k.c_str());
+  if (!boost::get<invalid_config_value_t>(&cval)) {
     ostringstream oss;
-    switch (opt->type) {
-      case OPT_INT:
-        oss << *(int*)opt->conf_ptr(this);
-        break;
-      case OPT_LONGLONG:
-        oss << *(long long*)opt->conf_ptr(this);
-        break;
-      case OPT_STR:
-	oss << *((std::string*)opt->conf_ptr(this));
-	break;
-      case OPT_FLOAT:
-        oss << *(float*)opt->conf_ptr(this);
-        break;
-      case OPT_DOUBLE:
-        oss << *(double*)opt->conf_ptr(this);
-        break;
-      case OPT_BOOL: {
-	  bool b = *(bool*)opt->conf_ptr(this);
-	  oss << (b ? "true" : "false");
-	}
-        break;
-      case OPT_U32:
-        oss << *(uint32_t*)opt->conf_ptr(this);
-        break;
-      case OPT_U64:
-        oss << *(uint64_t*)opt->conf_ptr(this);
-        break;
-      case OPT_ADDR:
-        oss << *(entity_addr_t*)opt->conf_ptr(this);
-        break;
-      case OPT_UUID:
-	oss << *(uuid_d*)opt->conf_ptr(this);
-        break;
+    if (bool *flagp = boost::get<bool>(&cval)) {
+      oss << (*flagp ? "true" : "false");
+    } else {
+      oss << cval;
     }
     string str(oss.str());
     int l = strlen(str.c_str()) + 1;
@@ -860,11 +894,11 @@ void md_config_t::get_all_keys(std::vector<std::string> *keys) const {
   const std::string negative_flag_prefix("no_");
 
   keys->clear();
-  keys->reserve(NUM_CONFIG_OPTIONS);
-  for (size_t i = 0; i < NUM_CONFIG_OPTIONS; ++i) {
-    keys->push_back(config_optionsp[i].name);
-    if (config_optionsp[i].type == OPT_BOOL) {
-      keys->push_back(negative_flag_prefix + config_optionsp[i].name);
+  keys->reserve(config_options->size());
+  for (auto& opt: *config_options) {
+    keys->push_back(opt.name);
+    if (opt.type == OPT_BOOL) {
+      keys->push_back(negative_flag_prefix + opt.name);
     }
   }
   for (int i = 0; i < subsys.get_num(); ++i) {
@@ -930,7 +964,7 @@ int md_config_t::_get_val_from_conf_file(const std::vector <std::string> &sectio
   return -ENOENT;
 }
 
-int md_config_t::set_val_impl(const char *val, const config_option *opt)
+int md_config_t::set_val_impl(const char *val, config_option const *opt)
 {
   assert(lock.is_locked());
   int ret = set_val_raw(val, opt);
@@ -940,89 +974,96 @@ int md_config_t::set_val_impl(const char *val, const config_option *opt)
   return 0;
 }
 
-int md_config_t::set_val_raw(const char *val, const config_option *opt)
+template<typename T> struct strtox_helper;
+
+template<> struct strtox_helper<float> {
+  static inline void apply(const char *val, float &x, std::string &err) {
+    x = strict_strtof(val, &err);
+  }
+};
+
+template<> struct strtox_helper<double> {
+  static inline void apply(const char *val, double &x, std::string &err) {
+    x = strict_strtod(val, &err);
+  }
+};
+
+template<typename T> static inline int strict_strtox(const char *val, T &x) {
+  std::string err;
+  strtox_helper<T>::apply(val, x, err);
+  return err.empty() ? 0 : -EINVAL;
+}
+
+class set_value_visitor : public boost::static_visitor<int> {
+  md_config_t const *conf;
+  const char *val;
+public:
+  explicit set_value_visitor(md_config_t const *conf_, const char *val_) :
+    conf(conf_), val(val_) { }
+
+  int operator()(const std::string md_config_t::* member_ptr) {
+    auto *ptr = const_cast<std::string *>(&(conf->*member_ptr));
+    *ptr = val ? val : "";
+    return 0;
+  }
+
+  int operator()(const bool md_config_t::* member_ptr) {
+    bool *ptr = const_cast<bool *>(&(conf->*member_ptr));
+    if (strcasecmp(val, "false") == 0) {
+      *ptr = false;
+    } else if (strcasecmp(val, "true") == 0) {
+      *ptr = true;
+    } else {
+      std::string err;
+      int b = strict_strtol(val, 10, &err);
+      if (!err.empty()) {
+	return -EINVAL;
+      }
+      *ptr = !!b;
+    }
+    return 0;
+  }
+    
+  // type has parse() member function
+  template<typename T,
+    typename boost::enable_if<boost::is_member_function_pointer<decltype(&T::parse)>, int>::type = 0>
+      int operator()(const T md_config_t::* member_ptr) {
+	T *obj = const_cast<T *>(&(conf->*member_ptr));
+	if (!obj->parse(val)) {
+	  return -EINVAL;
+	}
+	return 0;
+      }
+
+  // float, double
+  template<typename T,
+    typename boost::enable_if<boost::is_floating_point<T>, int>::type = 0>
+      int operator()(const T md_config_t::* member_ptr) {
+	T* ptr = const_cast<T *>(&(conf->*member_ptr));
+	return strict_strtox(val, *ptr);
+      }
+
+  // integers
+  template<typename T,
+    typename boost::enable_if_c<boost::is_integral<T>::value &&
+      !boost::is_same<T, bool>::value, int>::type = 0>
+      int operator()(const T md_config_t::* member_ptr) {
+	std::string err;
+	T f = strict_si_cast<T>(val, &err);
+	if (!err.empty()) {
+	  return -EINVAL;
+	}
+	T *ptr = const_cast<T *>(&(conf->*member_ptr));
+	*ptr = f;
+	return 0;
+  }
+};
+
+int md_config_t::set_val_raw(const char *val, config_option const *opt)
 {
   assert(lock.is_locked());
-  switch (opt->type) {
-    case OPT_INT: {
-      std::string err;
-      int f = strict_si_cast<int>(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(int*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_LONGLONG: {
-      std::string err;
-      long long f = strict_si_cast<long long>(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(long long*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_STR:
-      *(std::string*)opt->conf_ptr(this) = val ? val : "";
-      return 0;
-    case OPT_FLOAT: {
-      std::string err;
-      float f = strict_strtof(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(float*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_DOUBLE: {
-      std::string err;
-      double f = strict_strtod(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(double*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_BOOL:
-      if (strcasecmp(val, "false") == 0)
-	*(bool*)opt->conf_ptr(this) = false;
-      else if (strcasecmp(val, "true") == 0)
-	*(bool*)opt->conf_ptr(this) = true;
-      else {
-	std::string err;
-	int b = strict_strtol(val, 10, &err);
-	if (!err.empty())
-	  return -EINVAL;
-	*(bool*)opt->conf_ptr(this) = !!b;
-      }
-      return 0;
-    case OPT_U32: {
-      std::string err;
-      int f = strict_si_cast<uint32_t>(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(uint32_t*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_U64: {
-      std::string err;
-      uint64_t f = strict_si_cast<uint64_t>(val, &err);
-      if (!err.empty())
-	return -EINVAL;
-      *(uint64_t*)opt->conf_ptr(this) = f;
-      return 0;
-    }
-    case OPT_ADDR: {
-      entity_addr_t *addr = (entity_addr_t*)opt->conf_ptr(this);
-      if (!addr->parse(val)) {
-	return -EINVAL;
-      }
-      return 0;
-    }
-    case OPT_UUID: {
-      uuid_d *u = (uuid_d*)opt->conf_ptr(this);
-      if (!u->parse(val))
-	return -EINVAL;
-      return 0;
-    }
-  }
-  return -ENOSYS;
+  set_value_visitor svv(this, val);
+  return boost::apply_visitor(svv, opt->md_member_ptr);
 }
 
 static const char *CONF_METAVARIABLES[] = {
@@ -1036,12 +1077,12 @@ void md_config_t::expand_all_meta()
 {
   // Expand all metavariables
   ostringstream oss;
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {
-    config_option *opt = config_optionsp + i;
-    if (opt->type == OPT_STR) {
-      std::string *str = (std::string *)opt->conf_ptr(this);
-      list<config_option *> stack;
-      expand_meta(*str, opt, stack, &oss);
+  for (auto& opt: *config_options) {
+    std::string *str;
+    opt.conf_ptr(str, this);
+    if (str) {
+      list<config_option const *> stack;
+      expand_meta(*str, &opt, stack, &oss);
     }
   }
   cerr << oss.str();
@@ -1050,13 +1091,13 @@ void md_config_t::expand_all_meta()
 bool md_config_t::expand_meta(std::string &origval,
 			      std::ostream *oss) const
 {
-  list<config_option *> stack;
+  list<config_option const *> stack;
   return expand_meta(origval, NULL, stack, oss);
 }
 
 bool md_config_t::expand_meta(std::string &origval,
-			      config_option *opt,
-			      std::list<config_option *> stack,
+			      config_option const *opt,
+			      std::list<config_option const *> stack,
 			      std::ostream *oss) const
 {
   assert(lock.is_locked());
@@ -1068,17 +1109,17 @@ bool md_config_t::expand_meta(std::string &origval,
   // ignore an expansion loop and create a human readable
   // message about it
   if (opt) {
-    for (list<config_option *>::iterator i = stack.begin();
+    for (list<config_option const *>::iterator i = stack.begin();
 	 i != stack.end();
 	 ++i) {
       if (strcmp(opt->name, (*i)->name) == 0) {
 	*oss << "variable expansion loop at "
 	     << opt->name << "=" << origval << std::endl;
 	*oss << "expansion stack: " << std::endl;
-	for (list<config_option *>::iterator j = stack.begin();
+	for (list<config_option const *>::iterator j = stack.begin();
 	     j != stack.end();
 	     ++j) {
-	  *oss << (*j)->name << "=" << *(string *)(*j)->conf_ptr(this) << std::endl;
+	  *oss << (*j)->name << "=" << *((*j)->conf_ptr<std::string>(this)) << std::endl;
 	}
 	return false;
       }
@@ -1162,16 +1203,16 @@ bool md_config_t::expand_meta(std::string &origval,
 
       if (!expanded) {
 	// config option?
-	for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {
-	  config_option *opt = &config_optionsp[i];
-	  if (var == opt->name) {
-	    if (opt->type == OPT_STR) {
-	      string *origval = (string *)opt->conf_ptr(this);
-	      expand_meta(*origval, opt, stack, oss);
+        for (auto& opt: *config_options) {
+	  if (var == opt.name) {
+	    string *origval;
+	    opt.conf_ptr(origval, const_cast<md_config_t *>(this));
+	    if (origval) {
+	      expand_meta(*origval, &opt, stack, oss);
 	      out += *origval;
 	    } else {
 	      char *vv = NULL;
-	      _get_val(opt->name, &vv, -1);
+	      _get_val(opt.name, &vv, -1);
 	      out += vv;
 	      free(vv);
 	    }
@@ -1203,27 +1244,26 @@ void md_config_t::diff(
 
   char local_buf[4096];
   char other_buf[4096];
-  for (int i = 0; i < NUM_CONFIG_OPTIONS; i++) {
-    config_option *opt = &config_optionsp[i];
+  for (auto& opt: *config_options) {
     memset(local_buf, 0, sizeof(local_buf));
     memset(other_buf, 0, sizeof(other_buf));
 
     char *other_val = other_buf;
-    int err = other->get_val(opt->name, &other_val, sizeof(other_buf));
+    int err = other->get_val(opt.name, &other_val, sizeof(other_buf));
     if (err < 0) {
       if (err == -ENOENT) {
-        unknown->insert(opt->name);
+        unknown->insert(opt.name);
       }
       continue;
     }
 
     char *local_val = local_buf;
-    err = _get_val(opt->name, &local_val, sizeof(local_buf));
+    err = _get_val(opt.name, &local_val, sizeof(local_buf));
     if (err != 0)
       continue;
 
     if (strcmp(local_val, other_val))
-      diff->insert(make_pair(opt->name, make_pair(local_val, other_val)));
+      diff->insert(make_pair(opt.name, make_pair(local_val, other_val)));
   }
 }
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1256,11 +1256,7 @@ OPTION(rbd_default_format, OPT_INT, 2)
 OPTION(rbd_default_order, OPT_INT, 22)
 OPTION(rbd_default_stripe_count, OPT_U64, 0) // changing requires stripingv2 feature
 OPTION(rbd_default_stripe_unit, OPT_U64, 0) // changing to non-object size requires stripingv2 feature
-OPTION(rbd_default_features, OPT_INT, 61)   // only applies to format 2 images
-					    // +1 for layering, +2 for stripingv2,
-					    // +4 for exclusive lock, +8 for object map
-					    // +16 for fast-diff, +32 for deep-flatten,
-					    // +64 for journaling, +128 for data pool
+SAFE_OPTION(rbd_default_features, OPT_STR, "layering,exclusive-lock,object-map,fast-diff,deep-flatten")   // only applies to format 2 images
 OPTION(rbd_default_data_pool, OPT_STR, "") // optional default pool for storing image data blocks
 
 OPTION(rbd_default_map_options, OPT_STR, "") // default rbd map -o / --options

--- a/src/include/rbd/features.h
+++ b/src/include/rbd/features.h
@@ -10,6 +10,21 @@
 #define RBD_FEATURE_JOURNALING          (1ULL<<6)
 #define RBD_FEATURE_DATA_POOL           (1ULL<<7)
 
+#define RBD_FEATURES_DEFAULT             (RBD_FEATURE_LAYERING | \
+                                         RBD_FEATURE_EXCLUSIVE_LOCK | \
+                                         RBD_FEATURE_OBJECT_MAP | \
+                                         RBD_FEATURE_FAST_DIFF | \
+                                         RBD_FEATURE_DEEP_FLATTEN)
+
+#define RBD_FEATURE_NAME_LAYERING        "layering"
+#define RBD_FEATURE_NAME_STRIPINGV2      "striping"
+#define RBD_FEATURE_NAME_EXCLUSIVE_LOCK  "exclusive-lock"
+#define RBD_FEATURE_NAME_OBJECT_MAP      "object-map"
+#define RBD_FEATURE_NAME_FAST_DIFF       "fast-diff"
+#define RBD_FEATURE_NAME_DEEP_FLATTEN    "deep-flatten"
+#define RBD_FEATURE_NAME_JOURNALING      "journaling"
+#define RBD_FEATURE_NAME_DATA_POOL       "data-pool"
+
 /// features that make an image inaccessible for read or write by
 /// clients that don't understand them
 #define RBD_FEATURES_INCOMPATIBLE 	(RBD_FEATURE_LAYERING       | \

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -1,9 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include "librbd/Utils.h"
 #include "include/rbd_types.h"
 #include "include/stringify.h"
+#include "include/rbd/features.h"
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd: "
 
 namespace librbd {
 namespace util {
@@ -55,5 +64,40 @@ std::string generate_image_id(librados::IoCtx &ioctx) {
   return id;
 }
 
+uint64_t parse_rbd_default_features(CephContext* cct) 
+{
+  int ret = 0;
+  uint64_t value = 0;
+  auto str_val = cct->_conf->get_val<std::string>("rbd_default_features");
+  try {
+      value = boost::lexical_cast<decltype(value)>(str_val);
+  } catch (const boost::bad_lexical_cast& ) {
+    map<std::string, int> conf_vals = {{RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING}, 
+                                       {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
+                                       {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
+                                       {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
+                                       {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
+                                       {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
+                                       {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
+                                       {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
+    };
+    std::vector<std::string> strs;
+    boost::split(strs, str_val, boost::is_any_of(","));
+    for (auto feature: strs) {
+    	boost::trim(feature);
+      if (conf_vals.find(feature) != conf_vals.end()) {
+        value += conf_vals[feature];
+      } else {
+        ret = -EINVAL;
+        ldout(cct, 1) << "Warning: unknown rbd feature " << feature << dendl;
+      }
+    }
+    if (value == 0 && ret == -EINVAL)
+      value = RBD_FEATURES_DEFAULT;
+  }
+  return value;
+}
+
 } // namespace util
+
 } // namespace librbd

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -197,7 +197,10 @@ private:
   Context *m_on_finish = nullptr;
 };
 
+uint64_t parse_rbd_default_features(CephContext* cct);
+
 } // namespace util
+
 } // namespace librbd
 
 #endif // CEPH_LIBRBD_UTILS_H

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -135,7 +135,7 @@ CreateRequest<I>::CreateRequest(IoCtx &ioctx, const std::string &image_name,
   m_objmap_name = ObjectMap::object_map_name(m_image_id, CEPH_NOSNAP);
 
   if (image_options.get(RBD_IMAGE_OPTION_FEATURES, &m_features) != 0) {
-    m_features = m_cct->_conf->rbd_default_features;
+    m_features = util::parse_rbd_default_features(m_cct);
   }
 
   uint64_t features_clear = 0;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -884,7 +884,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
   {
     CephContext *cct = (CephContext *)io_ctx.cct();
     bool old_format = cct->_conf->rbd_default_format == 1;
-    uint64_t features = old_format ? 0 : cct->_conf->rbd_default_features;
+    uint64_t features = old_format ? 0 : librbd::util::parse_rbd_default_features(cct);
     return create(io_ctx, imgname, size, old_format, features, order, 0, 0);
   }
 

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -171,7 +171,7 @@
     --image-feature arg       image features
                               [layering(+), striping, exclusive-lock(+*),
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
-                              journaling(*)]
+                              journaling(*), data-pool]
     --image-shared            shared image
     --stripe-unit arg         stripe unit
     --stripe-count arg        stripe count
@@ -217,7 +217,7 @@
     --image-feature arg          image features
                                  [layering(+), striping, exclusive-lock(+*),
                                  object-map(+*), fast-diff(+*), deep-flatten(+-),
-                                 journaling(*)]
+                                 journaling(*), data-pool]
     --image-shared               shared image
     --stripe-unit arg            stripe unit
     --stripe-count arg           stripe count
@@ -261,7 +261,7 @@
     --image-feature arg       image features
                               [layering(+), striping, exclusive-lock(+*),
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
-                              journaling(*)]
+                              journaling(*), data-pool]
     --image-shared            shared image
     --stripe-unit arg         stripe unit
     --stripe-count arg        stripe count
@@ -371,7 +371,7 @@
                          (example: [<pool-name>/]<image-name>)
     <features>           image features
                          [layering, striping, exclusive-lock, object-map,
-                         fast-diff, deep-flatten, journaling]
+                         fast-diff, deep-flatten, journaling, data-pool]
   
   Optional arguments
     -p [ --pool ] arg    pool name
@@ -391,7 +391,7 @@
                               (example: [<pool-name>/]<image-name>)
     <features>                image features
                               [layering, striping, exclusive-lock, object-map,
-                              fast-diff, deep-flatten, journaling]
+                              fast-diff, deep-flatten, journaling, data-pool]
   
   Optional arguments
     -p [ --pool ] arg         pool name
@@ -607,7 +607,7 @@
     --image-feature arg       image features
                               [layering(+), striping, exclusive-lock(+*),
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
-                              journaling(*)]
+                              journaling(*), data-pool]
     --image-shared            shared image
     --stripe-unit arg         stripe unit
     --stripe-count arg        stripe count

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -99,7 +99,7 @@ public:
 					       m_remote_ioctx));
 
     m_image_name = get_temp_image_name();
-    uint64_t features = g_ceph_context->_conf->rbd_default_features;
+    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
     features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;
     int order = 0;
     EXPECT_EQ(0, librbd::create(m_remote_ioctx, m_image_name.c_str(), 1 << 22,

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -84,7 +84,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
 
   void create_image(const string &pool_name, bool mirrored=true,
 		    string *image_name=nullptr) {
-    uint64_t features = g_ceph_context->_conf->rbd_default_features;
+    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
     string name = "image" + stringify(++m_image_number);
     if (mirrored) {
       features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;
@@ -132,7 +132,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
       ictx->state->close();
     }
 
-    uint64_t features = g_ceph_context->_conf->rbd_default_features;
+    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
     string name = "clone" + stringify(++m_image_number);
     if (mirrored) {
       features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -3,6 +3,7 @@
 
 #include "tools/rbd/ArgumentTypes.h"
 #include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
 #include "include/rbd/features.h"
 #include "common/config.h"
 #include "common/strtol.h"
@@ -17,13 +18,15 @@ namespace argument_types {
 namespace po = boost::program_options;
 
 const std::map<uint64_t, std::string> ImageFeatures::FEATURE_MAPPING = {
-  {RBD_FEATURE_LAYERING, "layering"},
-  {RBD_FEATURE_STRIPINGV2, "striping"},
-  {RBD_FEATURE_EXCLUSIVE_LOCK, "exclusive-lock"},
-  {RBD_FEATURE_OBJECT_MAP, "object-map"},
-  {RBD_FEATURE_FAST_DIFF, "fast-diff"},
-  {RBD_FEATURE_DEEP_FLATTEN, "deep-flatten"},
-  {RBD_FEATURE_JOURNALING, "journaling"}};
+  {RBD_FEATURE_LAYERING, RBD_FEATURE_NAME_LAYERING},
+  {RBD_FEATURE_STRIPINGV2, RBD_FEATURE_NAME_STRIPINGV2},
+  {RBD_FEATURE_EXCLUSIVE_LOCK, RBD_FEATURE_NAME_EXCLUSIVE_LOCK},
+  {RBD_FEATURE_OBJECT_MAP, RBD_FEATURE_NAME_OBJECT_MAP},
+  {RBD_FEATURE_FAST_DIFF, RBD_FEATURE_NAME_FAST_DIFF},
+  {RBD_FEATURE_DEEP_FLATTEN, RBD_FEATURE_NAME_DEEP_FLATTEN},
+  {RBD_FEATURE_JOURNALING, RBD_FEATURE_NAME_JOURNALING},
+  {RBD_FEATURE_DATA_POOL, RBD_FEATURE_NAME_DATA_POOL},
+};
 
 Format::Formatter Format::create_formatter(bool pretty) const {
   if (value == "json") {
@@ -340,7 +343,7 @@ std::string get_short_features_help(bool append_suffix) {
 
     std::string suffix;
     if (append_suffix) {
-      if ((pair.first & g_conf->rbd_default_features) != 0) {
+      if ((pair.first & rbd::utils::parse_rbd_default_features(g_ceph_context)) != 0) {
         suffix += "+";
       }
       if ((pair.first & RBD_FEATURES_MUTABLE) != 0) {

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -134,6 +134,9 @@ std::string mirror_image_status_state(librbd::mirror_image_status_t status);
 
 std::string timestr(time_t t);
 
+// duplicate here to not include librbd_internal lib
+uint64_t parse_rbd_default_features(CephContext* cct);
+
 } // namespace utils
 } // namespace rbd
 


### PR DESCRIPTION
Now one can use human readable feature names instead of grepping the code for 
the magic numbers
