### PR TITLE
rgw_file:  pre-assign times

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -59,6 +59,7 @@ namespace rgw {
 		      RGWFileHandle::FLAG_BUCKET);
       if (get<0>(fhr)) {
 	RGWFileHandle* rgw_fh = get<0>(fhr);
+	rgw_fh->set_times(req.get_ctime());
 	/* restore attributes */
 	auto ux_key = req.get_attr(RGW_ATTR_UNIX_KEY1);
 	auto ux_attrs = req.get_attr(RGW_ATTR_UNIX1);
@@ -122,7 +123,7 @@ namespace rgw {
 	  if (get<0>(fhr)) {
 	    RGWFileHandle* rgw_fh = get<0>(fhr);
 	    rgw_fh->set_size(req.get_size());
-	    rgw_fh->set_mtime(real_clock::to_timespec(req.get_mtime()));
+	    rgw_fh->set_times(req.get_mtime());
 	    /* restore attributes */
 	    auto ux_key = req.get_attr(RGW_ATTR_UNIX_KEY1);
 	    auto ux_attrs = req.get_attr(RGW_ATTR_UNIX1);
@@ -148,7 +149,7 @@ namespace rgw {
 	  if (get<0>(fhr)) {
 	    RGWFileHandle* rgw_fh = get<0>(fhr);
 	    rgw_fh->set_size(req.get_size());
-	    rgw_fh->set_mtime(real_clock::to_timespec(req.get_mtime()));
+	    rgw_fh->set_times(req.get_mtime());
 	    /* restore attributes */
 	    auto ux_key = req.get_attr(RGW_ATTR_UNIX_KEY1);
 	    auto ux_attrs = req.get_attr(RGW_ATTR_UNIX1);

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1812,6 +1812,10 @@ public:
     return (iter != attrs.end()) ? &(iter->second) : nullptr;
   }
 
+  real_time get_ctime() const {
+    return bucket.creation_time;
+  }
+
   virtual bool only_bucket() { return false; }
 
   virtual int op_init() {
@@ -1842,10 +1846,6 @@ public:
     s->user = user;
 
     return 0;
-  }
-
-  real_time get_ctime() const {
-    return bucket.creation_time;
   }
 
   virtual int get_params() {


### PR DESCRIPTION
Set unix timestamps based on RGW values for creation, modification
time for buckets, objects in stat requests.  Regard any saved
value of these in unix attributes as an overlay.

Fixes: http://tracker.ceph.com/issues/17367

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>