### PR TITLE
[RFC]bluestore: separate kv_sync_thread to two parts.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2501,6 +2501,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
 	     &wal_tp),
     m_finisher_num(1),
     kv_sync_thread(this),
+    kv_sync_thread1(this),
     kv_stop(false),
     logger(NULL),
     debug_read_error_lock("BlueStore::debug_read_error_lock"),
@@ -4015,6 +4016,7 @@ int BlueStore::mount()
   }
   wal_tp.start();
   kv_sync_thread.create("bstore_kv_sync");
+  kv_sync_thread1.create("bstore_kv_sync1");
 
   r = _wal_replay();
   if (r < 0)
@@ -6577,6 +6579,48 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
   txc->released.clear();
 }
 
+void BlueStore::_kv_sync_thread1()
+{
+  dout(10) << __func__ << " start" << dendl;
+  std::unique_lock<std::mutex> l(kv_lock1);
+  while (true) {
+    assert(kv_committing2.empty());
+    assert(wal_cleaning2.empty());
+    if (kv_committing1.empty() && wal_cleaning1.empty()) {
+      if (kv_stop)
+	break;
+      dout(20) << __func__ << " sleep" << dendl;
+      kv_sync_cond.notify_all();
+      kv_cond1.wait(l);
+      dout(20) << __func__ << " wake" << dendl;
+    } else {
+      kv_committing2.swap(kv_committing1);
+      wal_cleaning2.swap(wal_cleaning1);
+      kv_cond1.notify_one();
+      utime_t start = ceph_clock_now(NULL);
+      l.unlock();
+
+     while (!kv_committing2.empty()) {
+	TransContext *txc = kv_committing2.front();
+	_txc_state_proc(txc);
+	kv_committing2.pop_front();
+      }
+      while (!wal_cleaning2.empty()) {
+	TransContext *txc = wal_cleaning2.front();
+	_txc_state_proc(txc);
+	wal_cleaning2.pop_front();
+      }
+
+      // this is as good a place as any ...
+      _reap_collections();
+
+      l.lock();
+    }
+  }
+  dout(10) << __func__ << " finish" << dendl;
+}
+
+
 void BlueStore::_kv_sync_thread()
 {
   dout(10) << __func__ << " start" << dendl;
@@ -6700,6 +6744,7 @@ void BlueStore::_kv_sync_thread()
       dout(20) << __func__ << " committed " << kv_committing.size()
 	       << " cleaned " << wal_cleaning.size()
 	       << " in " << dur << dendl;
+#if 0
       while (!kv_committing.empty()) {
 	TransContext *txc = kv_committing.front();
 	assert(txc->state == TransContext::STATE_KV_SUBMITTED);
@@ -6711,16 +6756,29 @@ void BlueStore::_kv_sync_thread()
 	_txc_state_proc(txc);
 	wal_cleaning.pop_front();
       }
-
+#endif
       alloc->commit_finish();
 
       // this is as good a place as any ...
-      _reap_collections();
+     // _reap_collections();
 
       if (bluefs) {
 	if (!bluefs_gift_extents.empty()) {
 	  _commit_bluefs_freespace(bluefs_gift_extents);
 	}
+      }
+
+      {
+	std::unique_lock<std::mutex> m(kv_lock1);
+	while (true) {
+	  if (!(kv_committing1.empty() && wal_cleaning1.empty()))
+	    kv_cond1.wait(m);
+	  else
+	    break;
+	}
+	kv_committing1.swap(kv_committing);
+	wal_cleaning1.swap(wal_cleaning);
+	kv_cond1.notify_one();
       }
 
       l.lock();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1480,6 +1480,14 @@ public:
       return NULL;
     }
   };
+  struct KVSyncThread1 : public Thread {
+    BlueStore *store;
+    explicit KVSyncThread1(BlueStore *s) : store(s) {}
+    void *entry() {
+      store->_kv_sync_thread1();
+      return NULL;
+    }
+  };
 
   // --------------------------------------------------------
   // members
@@ -1521,13 +1529,17 @@ private:
   vector<Finisher*> finishers;
 
   KVSyncThread kv_sync_thread;
-  std::mutex kv_lock;
-  std::condition_variable kv_cond, kv_sync_cond;
+  KVSyncThread1 kv_sync_thread1;
+  std::mutex kv_lock, kv_lock1;
+  std::condition_variable kv_cond, kv_sync_cond, kv_cond1;
   bool kv_stop;
   deque<TransContext*> kv_queue;             ///< ready, already submitted
   deque<TransContext*> kv_queue_unsubmitted; ///< ready, need submit by kv thread
   deque<TransContext*> kv_committing;        ///< currently syncing
   deque<TransContext*> wal_cleanup_queue;    ///< wal done, ready for cleanup
+  deque<TransContext*> wal_cleaning1, kv_committing1;
+  deque<TransContext*> wal_cleaning2, kv_committing2;
+
 
   PerfCounters *logger;
 
@@ -1668,13 +1680,20 @@ private:
   void _osr_reap_done(OpSequencer *osr);
 
   void _kv_sync_thread();
+  void _kv_sync_thread1();
   void _kv_stop() {
     {
       std::lock_guard<std::mutex> l(kv_lock);
       kv_stop = true;
       kv_cond.notify_all();
     }
+    {
+      std::lock_guard<std::mutex> l(kv_lock1);
+      kv_cond1.notify_all();
+    }
+
     kv_sync_thread.join();
+    kv_sync_thread1.join();
     {
       std::lock_guard<std::mutex> l(kv_lock);
       kv_stop = false;


### PR DESCRIPTION
To make performance better.

Signed-off-by: Jianpeng Ma jianpeng.ma@intel.com
