### PR TITLE
libcephfs: add ceph_fsetattr&&ceph_lchmod&&ceph_lutime

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -656,6 +656,17 @@ int ceph_lstat(struct ceph_mount_info *cmount, const char *path, struct stat *st
 int ceph_setattr(struct ceph_mount_info *cmount, const char *relpath, struct stat *attr, int mask);
 
 /**
+ * Set a file's attributes.
+ * 
+ * @param cmount the ceph mount handle to use for performing the setattr.
+ * @param fd the fd of the open file/directory to set the attributes of.
+ * @param attr the stat struct that must include attribute values to set on the file.
+ * @param mask a mask of all the stat values that have been set on the stat struct.
+ * @returns 0 on success or negative error code on failure.
+ */
+int ceph_fsetattr(struct ceph_mount_info *cmount, int fd, struct stat *attr, int mask);
+
+/**
  * Set a file's attributes (extended version).
  *
  * @param cmount the ceph mount handle to use for performing the setattr.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -634,6 +634,14 @@ extern "C" int ceph_setattr(struct ceph_mount_info *cmount, const char *relpath,
   return cmount->get_client()->setattr(relpath, attr, mask);
 }
 
+extern "C" int ceph_fsetattr(struct ceph_mount_info *cmount, int fd,
+	            struct stat *attr, int mask)
+{
+  if (!cmount->is_mounted())
+    return -ENOTCONN;
+  return cmount->get_client()->fsetattr(fd, attr, mask, cmount->default_perms);
+}
+
 extern "C" int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath,
 			    struct ceph_statx *stx, int mask, int flags)
 {

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1158,6 +1158,7 @@ TEST(LibCephFS, UseUnmounted) {
   EXPECT_EQ(-ENOTCONN, ceph_lremovexattr(cmount, "/path", "name"));
   EXPECT_EQ(-ENOTCONN, ceph_setxattr(cmount, "/path", "name", NULL, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_lsetxattr(cmount, "/path", "name", NULL, 0, 0));
+  EXPECT_EQ(-ENOTCONN, ceph_fsetattr(cmount, 0, &st, 0));
   EXPECT_EQ(-ENOTCONN, ceph_chmod(cmount, "/path", 0));
   EXPECT_EQ(-ENOTCONN, ceph_fchmod(cmount, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_chown(cmount, "/path", 0, 0));
@@ -1668,5 +1669,32 @@ TEST(LibCephFS, DirChangeAttr) {
   ASSERT_TRUE(stx.stx_mask & CEPH_STATX_VERSION);
   ASSERT_NE(stx.stx_version, old_change_attr);
 
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, SetSize) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  char filename[32];
+  sprintf(filename, "/setsize%x", getpid());
+
+  ceph_unlink(cmount, filename);
+  int fd = ceph_open(cmount, filename, O_RDWR|O_CREAT|O_EXCL, 0666);
+  ASSERT_LT(0, fd);
+
+  struct stat st;
+  uint64_t size = 8388608;
+  st.st_size = (off_t)size;
+  ASSERT_EQ(ceph_fsetattr(cmount, fd, &st, CEPH_SETATTR_SIZE), 0);
+
+  struct stat stbuf;
+  ASSERT_EQ(ceph_fstat(cmount, fd, &stbuf), 0);
+  ASSERT_EQ(stbuf.st_size, (off_t)size);
+
+  ceph_close(cmount, fd);
   ceph_shutdown(cmount);
 }


### PR DESCRIPTION
export ceph_fsetattr() && ceph_lchmod() && ceph_lutime()

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>