### PR TITLE
src/kv/CMakeLists.txt: force rocksdb/include to first include directory

### DIFF
--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -5,8 +5,8 @@ set(kv_srcs
   RocksDBStore.cc)
 add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
-target_include_directories(kv_objs PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_include_directories(kv PUBLIC ${ROCKSDB_INCLUDE_DIR})
+target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
+target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb snappy z)
 
 # rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.


### PR DESCRIPTION
 - Otherwise on FreeBSD older packages could be used for include
   this then can result to missing declared functions because
   includes and libs are out of sync

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>