### PR TITLE
lttng: build the tracepoint provider lib from .c files in repo

### DIFF
--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -2,22 +2,20 @@
 # the source files include the tracing headers like
 # #include "tracing/oprequest.h". so better put them into
 # ${PROJECT_BINARY_DIR}/include, where acconfig.h is also located
-set(header_dir ${CMAKE_BINARY_DIR}/include/tracing)
+set(working_dir ${CMAKE_BINARY_DIR}/include)
+set(header_dir ${working_dir}/tracing)
 file(MAKE_DIRECTORY ${header_dir})
 
 file(GLOB tps "*.tp")
 foreach(tp ${tps})
   get_filename_component(name ${tp} NAME_WE)
   set(header ${header_dir}/${name}.h)
-  set(src ${header_dir}/${name}.c)
   add_custom_command(
-    OUTPUT ${header} ${src}
-    COMMAND ${LTTNG_GEN_TP} ${tp} -o tracing/${name}.h -o tracing/${name}.c
+    OUTPUT ${header}
+    COMMAND ${LTTNG_GEN_TP} ${tp} -o tracing/${name}.h
     DEPENDS ${tp}
-    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/include
-    COMMENT "generating ${header} ${src}")
-  set_source_files_properties(${header} ${src}
-    PROPERTIES GENERATED TRUE)
+    WORKING_DIRECTORY ${working_dir}
+    COMMENT "generating ${header}")
   add_custom_target(
     ${name}-tp
     DEPENDS ${header})
@@ -28,11 +26,8 @@ function(add_tracing_library name tracings version)
     get_filename_component(tp ${tp_file} NAME_WE)
     list(APPEND hdrs
       ${header_dir}/${tp}.h)
-    list(APPEND srcs
-      ${header_dir}/${tp}.h
-      ${header_dir}/${tp}.c)
   endforeach()
-  add_library(${name} SHARED ${srcs})
+  add_library(${name} SHARED ${hdrs} ${tp}.c)
   target_link_libraries(${name} ${LTTNGUST_LIBRARIES} ${CMAKE_DL_LIBS})
   string(REGEX MATCH "^[0-9]+" soversion ${version})
   set_target_properties(${name} PROPERTIES

--- a/src/tracing/README.md
+++ b/src/tracing/README.md
@@ -13,12 +13,17 @@ Then install as normal
     apt-get install lttng-tools liblttng-ust-dev
 
 Add/Update Provider
-================
+===================
 
 ## Create tracepoint definition file
 
 Add tracepoint definitions for the provider into a `.tp` file. Documentation
 on defining a tracepoint can be found in `man lttng-ust`. By convention files
 are named according to the logical sub-system they correspond to (e.g.
-`mutex.tp`, `pg.tp`). Place the `.tp` file into the `src/tracing` directory
+`mutex.tp`, `pg.tp`). And add a C source file to be compiled into the tracepoint
+provider shared object, in which `TRACEPOINT_DEFINE` should be defined. See
+[LTTng document](http://lttng.org/docs/#doc-dynamic-linking) for details.
+Place the `.tp` and the `.c` files into the `src/tracing` directory
 and modify the CMake file `src/tracing/CMakeLists.txt` accordingly.
+
+

--- a/src/tracing/librados.c
+++ b/src/tracing/librados.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "librados.h"
+#include "tracing/librados.h"

--- a/src/tracing/librbd.c
+++ b/src/tracing/librbd.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "librbd.h"
+#include "tracing/librbd.h"

--- a/src/tracing/objectstore.c
+++ b/src/tracing/objectstore.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "objectstore.h"
+#include "tracing/objectstore.h"

--- a/src/tracing/oprequest.c
+++ b/src/tracing/oprequest.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "oprequest.h"
+#include "tracing/oprequest.h"

--- a/src/tracing/osd.c
+++ b/src/tracing/osd.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "osd.h"
+#include "tracing/osd.h"

--- a/src/tracing/pg.c
+++ b/src/tracing/pg.c
@@ -3,4 +3,4 @@
 /*
  * The header containing our TRACEPOINT_EVENTs.
  */
-#include "pg.h"
+#include "tracing/pg.h"


### PR DESCRIPTION
we should not have `TRACEPOINT_DEFINE` deinfed in both the application
we are tracing and the tracing provider library.

* tracing/*.c: reference the header file with path
* README.md: add instructions to add .c file
* CMakeLists.c:
  - compile the .c file in repo, not the one generated by
    lttng-gen-tp
  - no need to mark the generated header file as GENEREATED,
    they are marked so by default (they are listed in OUTPUT)
  - do not generate .c file anymore, they are not used.

Signed-off-by: Kefu Chai <kchai@redhat.com>