### PR TITLE
[DNM]os/bluestore: using rm_range instead of iterating key ranges

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -103,6 +103,12 @@ public:
       const std::string &prefix ///< [in] Prefix by which to remove keys
       ) = 0;
 
+    virtual void rm_range_keys(
+      const string &prefix,    ///< [in] Prefix by which to remove keys
+      const string &start,     ///< [in] The start bound of remove keys
+      const string &end        ///< [in] The start bound of remove keys
+      ) { assert(0 == "Not implemented"); }
+
     /// Merge value into key
     virtual void merge(
       const std::string &prefix,   ///< [in] Prefix ==> MUST match some established merge operator

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -472,6 +472,13 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
   }
 }
 
+void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
+                                                         const string &start,
+                                                         const string &end)
+{
+  bat.DeleteRange(combine_strings(prefix, start), combine_strings(prefix, end));
+}
+
 void RocksDBStore::RocksDBTransactionImpl::merge(
   const string &prefix,
   const string &k,

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -248,6 +248,10 @@ public:
     void rmkeys_by_prefix(
       const string &prefix
       ) override;
+    void rm_range_keys(
+      const string &prefix,
+      const string &start,
+      const string &end) override;
     void merge(
       const string& prefix,
       const string& k,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7841,21 +7841,11 @@ int BlueStore::_rmattrs(TransContext *txc,
 
 void BlueStore::_do_omap_clear(TransContext *txc, uint64_t id)
 {
-  KeyValueDB::Iterator it = db->get_iterator(PREFIX_OMAP);
   string prefix, tail;
   get_omap_header(id, &prefix);
   get_omap_tail(id, &tail);
-  it->lower_bound(prefix);
-  while (it->valid()) {
-    if (it->key() >= tail) {
-      dout(30) << __func__ << "  stop at " << pretty_binary_string(tail)
-	       << dendl;
-      break;
-    }
-    txc->t->rmkey(PREFIX_OMAP, it->key());
-    dout(30) << __func__ << "  rm " << pretty_binary_string(it->key()) << dendl;
-    it->next();
-  }
+
+  txc->t->rm_range_keys(PREFIX_OMAP, prefix, tail);
 }
 
 int BlueStore::_omap_clear(TransContext *txc,
@@ -7957,26 +7947,14 @@ int BlueStore::_omap_rmkey_range(TransContext *txc,
 				 const string& first, const string& last)
 {
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
-  KeyValueDB::Iterator it;
   string key_first, key_last;
   int r = 0;
   if (!o->onode.omap_head) {
     goto out;
   }
-  it = db->get_iterator(PREFIX_OMAP);
   get_omap_key(o->onode.omap_head, first, &key_first);
   get_omap_key(o->onode.omap_head, last, &key_last);
-  it->lower_bound(key_first);
-  while (it->valid()) {
-    if (it->key() >= key_last) {
-      dout(30) << __func__ << "  stop at " << pretty_binary_string(key_last)
-	       << dendl;
-      break;
-    }
-    txc->t->rmkey(PREFIX_OMAP, it->key());
-    dout(30) << __func__ << "  rm " << pretty_binary_string(it->key()) << dendl;
-    it->next();
-  }
+  txc->t->rm_range_keys(PREFIX_OMAP, key_first, key_last);
 
  out:
   dout(10) << __func__ << " " << c->cid << " " << o->oid << " = " << r << dendl;

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -255,6 +255,57 @@ TEST_P(KVTest, Merge) {
   fini();
 }
 
+TEST_P(KVTest, RMRange) {
+  ASSERT_EQ(0, db->create_and_open(cout));
+  bufferlist value;
+  value.append("value");
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->set("prefix", "key1", value);
+    t->set("prefix", "key2", value);
+    t->set("prefix", "key3", value);
+    t->set("prefix", "key4", value);
+    t->set("prefix", "key45", value);
+    t->set("prefix", "key5", value);
+    t->set("prefix", "key6", value);
+    db->submit_transaction_sync(t);
+  }
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->set("prefix", "key7", value);
+    t->set("prefix", "key8", value);
+    t->rm_range_keys("prefix", "key2", "key7");
+    db->submit_transaction_sync(t);
+    bufferlist v1, v2;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key1", &v1));
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key45", &v1));
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key8", &v1));
+    ASSERT_EQ(0, db->get("prefix", "key2", &v1));
+    ASSERT_EQ(0, db->get("prefix", "key7", &v2));
+  }
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rm_range_keys("prefix", "key", "key");
+    db->submit_transaction_sync(t);
+    bufferlist v1, v2;
+    ASSERT_EQ(0, db->get("prefix", "key1", &v1));
+    ASSERT_EQ(0, db->get("prefix", "key8", &v2));
+  }
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rm_range_keys("prefix", "key-", "key~");
+    db->submit_transaction_sync(t);
+    bufferlist v1, v2;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key1", &v1));
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key8", &v2));
+  }
+
+  fini();
+}
+
 
 INSTANTIATE_TEST_CASE_P(
   KeyValueDB,


### PR DESCRIPTION
Iterating key ranges introduces ineffective scan which iterate from level1 to levelN. And it won't get benefit from Bloomfilter. In bluestore heavy usage case, iterating is really stupid