### PR TITLE
msg/async: remove fd output in log prefix

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -28,9 +28,8 @@
 #undef dout_prefix
 #define dout_prefix _conn_prefix(_dout)
 ostream& AsyncConnection::_conn_prefix(std::ostream *_dout) {
-  int fd = (cs && state != STATE_CLOSED) ? cs.fd() : -1;
   return *_dout << "-- " << async_msgr->get_myinst().addr << " >> " << peer_addr << " conn(" << this
-                << " sd=" << fd << " :" << port
+                << " :" << port
                 << " s=" << get_state_name(state)
                 << " pgs=" << peer_global_seq
                 << " cs=" << connect_seq


### PR DESCRIPTION
it's tricky to prevent fd racing in logs, otherwise we need to provide with
lock to totally avoid this. But I don't think it deserve lock

Signed-off-by: Haomai Wang <haomai@xsky.com>