### PR TITLE
jewel: build/ops: backport 'logrotate: Run as root/ceph'

### DIFF
--- a/src/logrotate.conf
+++ b/src/logrotate.conf
@@ -8,5 +8,5 @@
     endscript
     missingok
     notifempty
-    su ceph ceph
+    su root ceph
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/17382

Currently, we run the logrotate scripts as ceph/ceph but that way we
cannot rotate the scripts created by qemu (they are root/ceph and 644).
The original su line was introduced in commit 73d7bed9 because logrotate
complained that the directory was writable by a non-root group and it
needed a su line to supress that error. This way, we keep the group
settings and we can access and rotate the qemu logs as well.

Signed-off-by: Boris Ranto <branto@redhat.com>