### PR TITLE
msg/async: less verbose debug messages at debug_ms=1

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2104,7 +2104,7 @@ void AsyncConnection::_stop()
   if (delay_state)
     delay_state->flush();
 
-  ldout(async_msgr->cct, 1) << __func__ << dendl;
+  ldout(async_msgr->cct, 2) << __func__ << dendl;
   std::lock_guard<std::mutex> l(write_lock);
 
   reset_recv_state();

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -741,8 +741,9 @@ void AsyncConnection::process()
 
           // note last received message.
           in_seq.set(message->get_seq());
-	  ldout(async_msgr->cct, 1) << " == rx == " << message->get_source() << " seq "
-                                    << message->get_seq() << " " << message << " " << *message << dendl;
+	  ldout(async_msgr->cct, 5) << " rx " << message->get_source() << " seq "
+                                    << message->get_seq() << " " << message
+				    << " " << *message << dendl;
 
           ack_left.inc();
           // if send_message always send inline, it may have no

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2354,7 +2354,7 @@ void AsyncConnection::DelayedDelivery::flush() {
 
 void AsyncConnection::send_keepalive()
 {
-  ldout(async_msgr->cct, 10) << __func__ << " started." << dendl;
+  ldout(async_msgr->cct, 10) << __func__ << dendl;
   std::lock_guard<std::mutex> l(write_lock);
   if (can_write != WriteStatus::CLOSED) {
     keepalive = true;
@@ -2364,7 +2364,7 @@ void AsyncConnection::send_keepalive()
 
 void AsyncConnection::mark_down()
 {
-  ldout(async_msgr->cct, 1) << __func__ << " started." << dendl;
+  ldout(async_msgr->cct, 1) << __func__ << dendl;
   std::lock_guard<std::mutex> l(lock);
   _stop();
 }
@@ -2392,7 +2392,7 @@ void AsyncConnection::_send_keepalive_or_ack(bool ack, utime_t *tp)
 
 void AsyncConnection::handle_write()
 {
-  ldout(async_msgr->cct, 10) << __func__ << " started." << dendl;
+  ldout(async_msgr->cct, 10) << __func__ << dendl;
   ssize_t r = 0;
 
   write_lock.lock();

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1851,7 +1851,12 @@ void AsyncConnection::accept(ConnectedSocket socket, entity_addr_t &addr)
 
 int AsyncConnection::send_message(Message *m)
 {
-  ldout(async_msgr->cct, 1) << " == tx == " << m << " " << *m << dendl;
+  lgeneric_subdout(async_msgr->cct, ms,
+		   1) << "-- " << async_msgr->get_myaddr() << " --> "
+		      << get_peer_addr() << " -- "
+		      << *m << " -- " << m << " con "
+		      << m->get_connection().get()
+		      << dendl;
 
   // optimistic think it's ok to encode(actually may broken now)
   if (!m->get_priority())

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -136,7 +136,7 @@ EventCenter::~EventCenter()
 void EventCenter::set_owner()
 {
   owner = pthread_self();
-  ldout(cct, 1) << __func__ << " idx=" << idx << " owner=" << owner << dendl;
+  ldout(cct, 2) << __func__ << " idx=" << idx << " owner=" << owner << dendl;
   if (!global_centers) {
     cct->lookup_or_create_singleton_object<EventCenter::AssociatedCenters>(
         global_centers, "AsyncMessenger::EventCenter::global_center");

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -261,7 +261,7 @@ void EventCenter::delete_time_event(uint64_t id)
 
 void EventCenter::wakeup()
 {
-  ldout(cct, 1) << __func__ << dendl;
+  ldout(cct, 2) << __func__ << dendl;
 
   char buf = 'c';
   // wake up "event_wait"


### PR DESCRIPTION
<pre>2016-09-22 14:57:31.767629 7fc7de0a1180  1  Processor -- start
2016-09-22 14:57:31.767814 7fc7de0a1180  1 -- :/0 start start
2016-09-22 14:57:31.768473 7fc7de0a1180  1 -- :/1525808036 --> 127.0.0.1:6789/0 -- auth(proto 0 30 bytes epoch 0) v1 -- 0x561b0a0677a0 con 0
2016-09-22 14:57:31.768827 7fc7beffd700  1 -- 127.0.0.1:0/1525808036 learned_addr learned my addr 127.0.0.1:0/1525808036
2016-09-22 14:57:31.769723 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 1 ==== mon_map magic: 0 v1 ==== 191+0+0 (418559010 0 0) 0x7fc7ac0023a0 con 0x561b0a070c40
2016-09-22 14:57:31.769831 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 2 ==== auth_reply(proto 2 0 (0) Success) v1 ==== 33+0+0 (2556977903 0 0) 0x7fc7ac0028b0 con 0x561b0a070c40
2016-09-22 14:57:31.770028 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 --> 127.0.0.1:6789/0 -- auth(proto 2 32 bytes epoch 0) v1 -- 0x7fc79c001310 con 0
2016-09-22 14:57:31.770769 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 3 ==== auth_reply(proto 2 0 (0) Success) v1 ==== 206+0+0 (3772563336 0 0) 0x7fc7ac0026a0 con 0x561b0a070c40
2016-09-22 14:57:31.770922 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 --> 127.0.0.1:6789/0 -- auth(proto 2 165 bytes epoch 0) v1 -- 0x7fc79c002f00 con 0
2016-09-22 14:57:31.771693 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 4 ==== auth_reply(proto 2 0 (0) Success) v1 ==== 393+0+0 (383001287 0 0) 0x7fc7ac0026a0 con 0x561b0a070c40
2016-09-22 14:57:31.771844 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 --> 127.0.0.1:6789/0 -- mon_subscribe({monmap=0+}) v2 -- 0x561b0a06e880 con 0
2016-09-22 14:57:31.772013 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 --> 127.0.0.1:6789/0 -- mon_subscribe({osdmap=0}) v2 -- 0x561b0a0677a0 con 0
2016-09-22 14:57:31.772303 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 5 ==== mon_map magic: 0 v1 ==== 191+0+0 (418559010 0 0) 0x7fc7ac002270 con 0x561b0a070c40
2016-09-22 14:57:31.772587 7fc7bd7fa700  1 -- 127.0.0.1:0/1525808036 <== mon.0 127.0.0.1:6789/0 6 ==== osd_map(5..5 src has 1..5) v3 ==== 1563+0+0 (1652522744 0 0) 0x7fc7ac0028b0 con 0x561b0a070c40
2016-09-22 14:57:31.772879 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 --> 127.0.0.1:6800/22079 -- osd_op(unknown.0.0:1 0.30a98c1c rbd_directory [read 0~0] snapc 0=[] ack+read+known_if_redirected e5) v7 -- 0x561b0a079510 con 0
2016-09-22 14:57:31.774269 7fc7be7fc700  1 -- 127.0.0.1:0/1525808036 <== osd.0 127.0.0.1:6800/22079 1 ==== osd_op_reply(1 rbd_directory [read 0~0] v0'0 uv0 ack = -2 ((2) No such file or directory)) v7 ==== 133+0+0 (1715324816 0 0) 0x7fc7a8001e60 con 0x561b0a074e90
2016-09-22 14:57:31.774584 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 >> 127.0.0.1:6800/22079 conn(0x561b0a074e90 :-1 s=STATE_OPEN pgs=13 cs=1 l=1).mark_down
2016-09-22 14:57:31.774649 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 >> 127.0.0.1:6789/0 conn(0x561b0a070c40 :-1 s=STATE_OPEN pgs=16 cs=1 l=1).mark_down
2016-09-22 14:57:31.774731 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 shutdown_connections 
2016-09-22 14:57:31.774871 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 shutdown_connections 
2016-09-22 14:57:31.774897 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 wait complete.
2016-09-22 14:57:31.774907 7fc7de0a1180  1 -- 127.0.0.1:0/1525808036 >> 127.0.0.1:0/1525808036 conn(0x561b0a05d710 :-1 s=STATE_NONE pgs=0 cs=0 l=0).mark_down
</pre>