### PR TITLE
rgw: get_zonegroup() uses "default" zonegroup if empty

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -923,7 +923,12 @@ int RGWPeriod::init(CephContext *_cct, RGWRados *_store, bool setup_obj)
 
 
 int RGWPeriod::get_zonegroup(RGWZoneGroup& zonegroup, const string& zonegroup_id) {
-  map<string, RGWZoneGroup>::const_iterator iter = period_map.zonegroups.find(zonegroup_id);
+  map<string, RGWZoneGroup>::const_iterator iter;
+  if (!zonegroup_id.empty()) {
+    iter = period_map.zonegroups.find(zonegroup_id);
+  } else {
+    iter = period_map.zonegroups.find("default");
+  }
   if (iter != period_map.zonegroups.end()) {
     zonegroup = iter->second;
     return 0;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17372

An empty zonegroup should be replaced with the "default" zonegroup.
This is needed when dealing with zonegroup set in old bucket info,
that predated setting the buckets' region.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>