### PR TITLE
osd: should not look up an empty pg

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1167,7 +1167,7 @@ function pg_scrub() {
     wait_for_scrub $pgid "$last_scrub"
 }
 
-function DISABLED_test_pg_scrub() {
+function test_pg_scrub() {
     local dir=$1
 
     setup $dir || return 1

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6377,10 +6377,12 @@ void OSD::handle_scrub(MOSDScrub *m)
 	 p != m->scrub_pgs.end();
 	 ++p) {
       spg_t pcand;
-      auto pg_map_entry = pg_map.find(pcand);
-      if (osdmap->get_primary_shard(*p, &pcand) &&
-	  pg_map_entry != pg_map.end())
-	handle_pg_scrub(m, pg_map_entry->second);
+      if (osdmap->get_primary_shard(*p, &pcand)) {
+	auto pg_map_entry = pg_map.find(pcand);
+	if (pg_map_entry != pg_map.end()) {
+	  handle_pg_scrub(m, pg_map_entry->second);
+	}
+      }
     }
   }
 


### PR DESCRIPTION
this fixes the "pg scrub/repair/deep-scrub"