### PR TITLE
mon: clear duplicated logic in MDSMonitor

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2833,22 +2833,14 @@ void MDSMonitor::maybe_replace_gid(mds_gid_t gid,
     pending_fsmap.promote(sgid, fs, info.rank);
 
     *mds_propose = true;
-  } else if (info.state == MDSMap::STATE_STANDBY_REPLAY) {
-    dout(10) << " failing " << gid << " " << info.addr << " mds." << info.rank << "." << info.inc
-      << " " << ceph_mds_state_name(info.state)
+  } else if (info.state == MDSMap::STATE_STANDBY_REPLAY || 
+             info.state == MDSMap::STATE_STANDBY) {
+    dout(10) << " failing and removing " << gid << " " << info.addr << " mds." << info.rank 
+      << "." << info.inc << " " << ceph_mds_state_name(info.state)
       << dendl;
     fail_mds_gid(gid);
     *mds_propose = true;
-  } else {
-    if (info.state == MDSMap::STATE_STANDBY ||
-        info.state == MDSMap::STATE_STANDBY_REPLAY) {
-      // remove it
-      dout(10) << " removing " << gid << " " << info.addr << " mds." << info.rank << "." << info.inc
-        << " " << ceph_mds_state_name(info.state)
-        << " (laggy)" << dendl;
-      fail_mds_gid(gid);
-      *mds_propose = true;
-    } else if (!info.laggy()) {
+  } else if (!info.laggy()) {
       dout(10) << " marking " << gid << " " << info.addr << " mds." << info.rank << "." << info.inc
         << " " << ceph_mds_state_name(info.state)
         << " laggy" << dendl;
@@ -2856,8 +2848,6 @@ void MDSMonitor::maybe_replace_gid(mds_gid_t gid,
           info->laggy_since = ceph_clock_now(g_ceph_context);
       });
       *mds_propose = true;
-    }
-    last_beacon.erase(gid);
   }
 }
 


### PR DESCRIPTION
Clear some duplicated logic in MDSMonitor when checking replacement for a failed MDS. It will make this part of logic more clear and readable.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>