### PR TITLE
test: temporarily remove fork()ing flock tests

### DIFF
--- a/src/test/libcephfs/flock.cc
+++ b/src/test/libcephfs/flock.cc
@@ -70,7 +70,6 @@ static const struct timespec* abstime(struct timespec &ts, long ms) {
 }
 
 /* Basic locking */
-
 TEST(LibCephFS, BasicLocking) {
   struct ceph_mount_info *cmount = NULL;
   STARTUP_CEPH();
@@ -427,7 +426,8 @@ static void process_ConcurrentLocking(str_ConcurrentLocking& s) {
   exit(EXIT_SUCCESS);
 }
 
-TEST(LibCephFS, InterProcessLocking) {
+// Disabled because of fork() issues (http://tracker.ceph.com/issues/16556)
+TEST(LibCephFS, DISABLED_InterProcessLocking) {
   PROCESS_SLOW_MS();
   // Process synchronization
   char c_file[1024];
@@ -526,7 +526,8 @@ TEST(LibCephFS, InterProcessLocking) {
   CLEANUP_CEPH();
 }
 
-TEST(LibCephFS, ThreesomeInterProcessLocking) {
+// Disabled because of fork() issues (http://tracker.ceph.com/issues/16556)
+TEST(LibCephFS, DISABLED_ThreesomeInterProcessLocking) {
   PROCESS_SLOW_MS();
   // Process synchronization
   char c_file[1024];

--- a/src/test/libcephfs/recordlock.cc
+++ b/src/test/libcephfs/recordlock.cc
@@ -749,7 +749,8 @@ static void process_ConcurrentRecordLocking(str_ConcurrentRecordLocking& s) {
   exit(EXIT_SUCCESS);
 }
 
-TEST(LibCephFS, InterProcessRecordLocking) {
+// Disabled because of fork() issues (http://tracker.ceph.com/issues/16556)
+TEST(LibCephFS, DISABLED_InterProcessRecordLocking) {
   PROCESS_SLOW_MS();
   // Process synchronization
   char c_file[1024];
@@ -909,7 +910,8 @@ TEST(LibCephFS, InterProcessRecordLocking) {
   CLEANUP_CEPH();
 }
 
-TEST(LibCephFS, ThreesomeInterProcessRecordLocking) {
+// Disabled because of fork() issues (http://tracker.ceph.com/issues/16556)
+TEST(LibCephFS, DISABLED_ThreesomeInterProcessRecordLocking) {
   PROCESS_SLOW_MS();
   // Process synchronization
   char c_file[1024];


### PR DESCRIPTION
Usually we fix tests instead of disabling them but in this instance the failure is potentially masking anything else going wrong during the libcephfs tests, and the fix is probably going to be to re-engineer how the tests are written.

http://tracker.ceph.com/issues/16556