### PR TITLE
osd: add a pg _fastinfo attribute to reduce per-io metadata updates

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -826,6 +826,8 @@ OPTION(osd_fast_fail_on_connection_refused, OPT_BOOL, true) // immediately mark 
 OPTION(osd_pg_object_context_cache_count, OPT_INT, 64)
 OPTION(osd_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 
+OPTION(osd_fast_info, OPT_BOOL, true) // use fast info attr, if we can
+
 // determines whether PGLog::check() compares written out log to stored log
 OPTION(osd_debug_pg_log_writeout, OPT_BOOL, false)
 OPTION(osd_loop_before_reset_tphandle, OPT_U32, 64) // Max number of loop before we reset thread-pool's handle

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -194,6 +194,7 @@ CompatSet OSD::get_osd_initial_compat_set() {
   ceph_osd_feature_incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_HINTS);
   ceph_osd_feature_incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_PGMETA);
   ceph_osd_feature_incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_MISSING);
+  ceph_osd_feature_incompat.insert(CEPH_OSD_FEATURE_INCOMPAT_FASTINFO);
   return CompatSet(ceph_osd_feature_compat, ceph_osd_feature_ro_compat,
 		   ceph_osd_feature_incompat);
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2591,6 +2591,13 @@ void OSD::create_logger()
   osd_plb.add_time_avg(l_osd_tier_promote_lat, "osd_tier_promote_lat", "Object promote latency");
   osd_plb.add_time_avg(l_osd_tier_r_lat, "osd_tier_r_lat", "Object proxy read latency");
 
+  osd_plb.add_u64_counter(l_osd_pg_info, "osd_pg_info",
+			  "PG updated its info (using any method)");
+  osd_plb.add_u64_counter(l_osd_pg_fastinfo, "osd_pg_fastinfo",
+			  "PG updated its info using fastinfo attr");
+  osd_plb.add_u64_counter(l_osd_pg_biginfo, "osd_pg_biginfo",
+			  "PG updated its biginfo attr");
+
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -158,6 +158,10 @@ enum {
   l_osd_tier_promote_lat,
   l_osd_tier_r_lat,
 
+  l_osd_pg_info,
+  l_osd_pg_fastinfo,
+  l_osd_pg_biginfo,
+
   l_osd_last,
 };
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2484,8 +2484,7 @@ void PG::_update_calc_stats()
   info.stats.last_epoch_clean = info.history.last_epoch_clean;
 
   info.stats.log_size = pg_log.get_head().version - pg_log.get_tail().version;
-  info.stats.ondisk_log_size =
-    pg_log.get_head().version - pg_log.get_tail().version;
+  info.stats.ondisk_log_size = info.stats.log_size;
   info.stats.log_start = pg_log.get_tail();
   info.stats.ondisk_log_start = pg_log.get_tail();
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2782,7 +2782,7 @@ void PG::upgrade(ObjectStore *store)
 
 int PG::_prepare_write_info(map<string,bufferlist> *km,
 			    epoch_t epoch,
-			    pg_info_t &info,
+			    pg_info_t &info, pg_info_t &last_written_info,
 			    map<epoch_t,pg_interval_t> &past_intervals,
 			    bool dirty_big_info,
 			    bool dirty_epoch)
@@ -2841,7 +2841,9 @@ void PG::prepare_write_info(map<string,bufferlist> *km)
   unstable_stats.clear();
 
   bool need_update_epoch = last_epoch < get_osdmap()->get_epoch();
-  int ret = _prepare_write_info(km, get_osdmap()->get_epoch(), info,
+  int ret = _prepare_write_info(km, get_osdmap()->get_epoch(),
+				info,
+				last_written_info,
 				past_intervals,
 				dirty_big_info, need_update_epoch);
   assert(ret == 0);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2782,9 +2782,8 @@ void PG::upgrade(ObjectStore *store)
 
 int PG::_prepare_write_info(map<string,bufferlist> *km,
 			    epoch_t epoch,
-			    pg_info_t &info, coll_t coll,
+			    pg_info_t &info,
 			    map<epoch_t,pg_interval_t> &past_intervals,
-			    ghobject_t &pgmeta_oid,
 			    bool dirty_big_info,
 			    bool dirty_epoch)
 {
@@ -2842,8 +2841,8 @@ void PG::prepare_write_info(map<string,bufferlist> *km)
   unstable_stats.clear();
 
   bool need_update_epoch = last_epoch < get_osdmap()->get_epoch();
-  int ret = _prepare_write_info(km, get_osdmap()->get_epoch(), info, coll,
-				past_intervals, pgmeta_oid,
+  int ret = _prepare_write_info(km, get_osdmap()->get_epoch(), info,
+				past_intervals,
 				dirty_big_info, need_update_epoch);
   assert(ret == 0);
   if (need_update_epoch)

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2234,9 +2234,8 @@ private:
 public:
   static int _prepare_write_info(map<string,bufferlist> *km,
     epoch_t epoch,
-    pg_info_t &info, coll_t coll,
+    pg_info_t &info,
     map<epoch_t,pg_interval_t> &past_intervals,
-    ghobject_t &pgmeta_oid,
     bool dirty_big_info,
     bool dirty_epoch);
   void write_if_dirty(ObjectStore::Transaction& t);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -295,7 +295,9 @@ public:
   pg_info_t info;               ///< current pg info
   pg_info_t last_written_info;  ///< last written info
   __u8 info_struct_v;
-  static const __u8 cur_struct_v = 8;
+  static const __u8 cur_struct_v = 9;
+  // v9 was fastinfo_key addition
+  // v8 was the move to a per-pg pgmeta object
   // v7 was SnapMapper addition in 86658392516d5175b2756659ef7ffaaf95b0f8ad
   // (first appeared in cuttlefish).
   static const __u8 compat_struct_v = 7;
@@ -2233,13 +2235,15 @@ private:
   void prepare_write_info(map<string,bufferlist> *km);
 
 public:
-  static int _prepare_write_info(map<string,bufferlist> *km,
+  static int _prepare_write_info(
+    map<string,bufferlist> *km,
     epoch_t epoch,
     pg_info_t &info,
     pg_info_t &last_written_info,
     map<epoch_t,pg_interval_t> &past_intervals,
     bool dirty_big_info,
-    bool dirty_epoch);
+    bool dirty_epoch,
+    bool try_fast_info);
   void write_if_dirty(ObjectStore::Transaction& t);
 
   eversion_t get_next_version() const {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -292,7 +292,8 @@ public:
     return pool.info.ec_pool();
   }
   // pg state
-  pg_info_t        info;
+  pg_info_t info;               ///< current pg info
+  pg_info_t last_written_info;  ///< last written info
   __u8 info_struct_v;
   static const __u8 cur_struct_v = 8;
   // v7 was SnapMapper addition in 86658392516d5175b2756659ef7ffaaf95b0f8ad
@@ -2235,6 +2236,7 @@ public:
   static int _prepare_write_info(map<string,bufferlist> *km,
     epoch_t epoch,
     pg_info_t &info,
+    pg_info_t &last_written_info,
     map<epoch_t,pg_interval_t> &past_intervals,
     bool dirty_big_info,
     bool dirty_epoch);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2243,7 +2243,8 @@ public:
     map<epoch_t,pg_interval_t> &past_intervals,
     bool dirty_big_info,
     bool dirty_epoch,
-    bool try_fast_info);
+    bool try_fast_info,
+    PerfCounters *logger = NULL);
   void write_if_dirty(ObjectStore::Transaction& t);
 
   eversion_t get_next_version() const {

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1967,6 +1967,16 @@ struct pg_hit_set_info_t {
   utime_t begin, end;   ///< time interval
   eversion_t version;   ///< version this HitSet object was written
   bool using_gmt;	///< use gmt for creating the hit_set archive object name
+
+  friend bool operator==(const pg_hit_set_info_t& l,
+			 const pg_hit_set_info_t& r) {
+    return
+      l.begin == r.begin &&
+      l.end == r.end &&
+      l.version == r.version &&
+      l.using_gmt == r.using_gmt;
+  }
+
   explicit pg_hit_set_info_t(bool using_gmt = true)
     : using_gmt(using_gmt) {}
 
@@ -1986,6 +1996,13 @@ WRITE_CLASS_ENCODER(pg_hit_set_info_t)
 struct pg_hit_set_history_t {
   eversion_t current_last_update;  ///< last version inserted into current set
   list<pg_hit_set_info_t> history; ///< archived sets, sorted oldest -> newest
+
+  friend bool operator==(const pg_hit_set_history_t& l,
+			 const pg_hit_set_history_t& r) {
+    return
+      l.current_last_update == r.current_last_update &&
+      l.history == r.history;
+  }
 
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
@@ -2026,6 +2043,23 @@ struct pg_history_t {
   utime_t last_scrub_stamp;
   utime_t last_deep_scrub_stamp;
   utime_t last_clean_scrub_stamp;
+
+  friend bool operator==(const pg_history_t& l, const pg_history_t& r) {
+    return
+      l.epoch_created == r.epoch_created &&
+      l.last_epoch_started == r.last_epoch_started &&
+      l.last_epoch_clean == r.last_epoch_clean &&
+      l.last_epoch_split == r.last_epoch_split &&
+      l.last_epoch_marked_full == r.last_epoch_marked_full &&
+      l.same_up_since == r.same_up_since &&
+      l.same_interval_since == r.same_interval_since &&
+      l.same_primary_since == r.same_primary_since &&
+      l.last_scrub == r.last_scrub &&
+      l.last_deep_scrub == r.last_deep_scrub &&
+      l.last_scrub_stamp == r.last_scrub_stamp &&
+      l.last_deep_scrub_stamp == r.last_deep_scrub_stamp &&
+      l.last_clean_scrub_stamp == r.last_clean_scrub_stamp;
+  }
 
   pg_history_t()
     : epoch_created(0),
@@ -2122,6 +2156,22 @@ struct pg_info_t {
 
   pg_history_t history;
   pg_hit_set_history_t hit_set;
+
+  friend bool operator==(const pg_info_t& l, const pg_info_t& r) {
+    return
+      l.pgid == r.pgid &&
+      l.last_update == r.last_update &&
+      l.last_complete == r.last_complete &&
+      l.last_epoch_started == r.last_epoch_started &&
+      l.last_user_version == r.last_user_version &&
+      l.log_tail == r.log_tail &&
+      l.last_backfill == r.last_backfill &&
+      l.last_backfill_bitwise == r.last_backfill_bitwise &&
+      l.purged_snaps == r.purged_snaps &&
+      l.stats == r.stats &&
+      l.history == r.history &&
+      l.hit_set == r.hit_set;
+  }
 
   pg_info_t()
     : last_epoch_started(0), last_user_version(0),

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2297,7 +2297,9 @@ struct pg_fast_info_t {
     stats.stats.sum.num_objects_dirty = info.stats.stats.sum.num_objects_dirty;
   }
 
-  void apply_to(pg_info_t* info) {
+  bool try_apply_to(pg_info_t* info) {
+    if (last_update <= info->last_update)
+      return false;
     info->last_update = last_update;
     info->last_complete = last_complete;
     info->last_user_version = last_user_version;
@@ -2320,6 +2322,7 @@ struct pg_fast_info_t {
     info->stats.stats.sum.num_wr = stats.stats.sum.num_wr;
     info->stats.stats.sum.num_wr_kb = stats.stats.sum.num_wr_kb;
     info->stats.stats.sum.num_objects_dirty = stats.stats.sum.num_objects_dirty;
+    return true;
   }
 
   void encode(bufferlist& bl) const {

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -479,9 +479,8 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
   map<string,bufferlist> km;
   int ret = PG::_prepare_write_info(
     &km, epoch,
-    info, coll,
+    info,
     past_intervals,
-    pgmeta_oid,
     true, true);
   if (ret) cerr << "Failed to write info" << std::endl;
   t.omap_setkeys(coll, pgmeta_oid, km);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -477,9 +477,11 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
   coll_t coll(info.pgid);
   ghobject_t pgmeta_oid(info.pgid.make_pgmeta_oid());
   map<string,bufferlist> km;
+  pg_info_t last_written_info;
   int ret = PG::_prepare_write_info(
     &km, epoch,
     info,
+    last_written_info,
     past_intervals,
     true, true);
   if (ret) cerr << "Failed to write info" << std::endl;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -3273,9 +3273,9 @@ int main(int argc, char **argv)
       ObjectStore::Transaction tran;
       ObjectStore::Transaction *t = &tran;
 
-      if (struct_ver != PG::cur_struct_v) {
+      if (struct_ver < PG::compat_struct_v) {
         cerr << "Can't remove past-intervals, version mismatch " << (int)struct_ver
-          << " (pg)  != " << (int)PG::cur_struct_v << " (tool)"
+          << " (pg)  < compat " << (int)PG::compat_struct_v << " (tool)"
           << std::endl;
         ret = -EFAULT;
         goto out;
@@ -3298,9 +3298,9 @@ int main(int argc, char **argv)
       ObjectStore::Transaction tran;
       ObjectStore::Transaction *t = &tran;
 
-      if (struct_ver != PG::cur_struct_v) {
-	cerr << "Can't mark-complete, version mismatch " << (int)struct_ver
-	     << " (pg)  != " << (int)PG::cur_struct_v << " (tool)"
+      if (struct_ver < PG::compat_struct_v) {
+        cerr << "Can't mark-complete, version mismatch " << (int)struct_ver
+	     << " (pg)  < compat " << (int)PG::compat_struct_v << " (tool)"
 	     << std::endl;
 	ret = 1;
 	goto out;

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -483,7 +483,7 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
     info,
     last_written_info,
     past_intervals,
-    true, true);
+    true, true, false);
   if (ret) cerr << "Failed to write info" << std::endl;
   t.omap_setkeys(coll, pgmeta_oid, km);
   return ret;


### PR DESCRIPTION
For most IO operations we only update a handful of fields in the pg_info_t structure.  However, the full struct, when encoded, is on the order of 800 bytes.

This adds a new attribute, _fastinfo, which contains only the most commonly updated fields.  When present, the fastinfo fields should be overlayed on top of the full info struct contained in the existing info attr.  If a field outside of the "fast" set is updated, we clear the fastinfo attribute and update the full info attr.

This takes the approach of speculatively trying to do a fast diff at the lowest level helper function and then comparing whether the result is correct.  That comparison is probably the slow part.  A much harder and more fragile approach would be to make all the call sites that update pg info (and set dirty_info = true) indicate whether they are updating a fast or non-fast field.  I'm not sure that's really practical, so I think this is the way to go (at least for now).

pg_fast_info_t encodes to 178 bytes, vs 847 for pg_info_t.  That could probably be improved given the high correlation between the last_* fields.