### PR TITLE
workunits: build kernel in unique temporary dir

### DIFF
--- a/qa/workunits/kernel_untar_build.sh
+++ b/qa/workunits/kernel_untar_build.sh
@@ -2,19 +2,22 @@
 
 set -e
 
-wget -q http://download.ceph.com/qa/linux-4.0.5.tar.xz
+T=$(mktemp -d tmp.XXXXXX)
 
-mkdir t
-cd t
-tar Jxvf ../linux*.xz
-cd linux*
-make defconfig
-make -j`grep -c processor /proc/cpuinfo`
-cd ..
-if ! rm -rv linux* ; then
-    echo "uh oh rm -r failed, it left behind:"
-    find .
-    exit 1
-fi
-cd ..
-rm -rv t linux*
+(
+    cd "$T"
+    wget -q http://download.ceph.com/qa/linux-4.0.5.tar.xz
+
+    tar Jxvf linux*.xz
+    cd linux*
+    make defconfig
+    make -j`grep -c processor /proc/cpuinfo`
+    cd ..
+    if ! rm -rv linux* ; then
+        echo "uh oh rm -r failed, it left behind:"
+        find .
+        exit 1
+    fi
+)
+
+rm -rf "$T"


### PR DESCRIPTION
This allows multiple instances of the workunit to be run in parallel in
the same directory. I'm using this change for performance testing.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>