### PR TITLE
rpm: fix permissions for /etc/ceph/rbdmap

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -731,7 +731,7 @@ make DESTDIR=%{buildroot} install
 # we have dropped sysvinit bits
 rm -f %{buildroot}/%{_sysconfdir}/init.d/ceph
 popd
-install -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
+install -m 0644 -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
 %if 0%{?fedora} || 0%{?rhel}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 %endif


### PR DESCRIPTION
Prior to this change, the RPM packaging would install /etc/ceph/rbdmap with exectuable permissions. The execute bit is not necessary and does not match what the Debian packaging does. Remove the execute bit in this case.

Fixes: http://tracker.ceph.com/issues/17395