### PR TITLE
os/bluestore: fix spanning blob leak from ~ExtentMap

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -554,6 +554,7 @@ public:
 
     ExtentMap(Onode *o);
     ~ExtentMap() {
+      spanning_blob_map.clear_and_dispose([&](Blob *b) { b->put(); });
       extent_map.clear_and_dispose([&](Extent *e) { delete e; });
     }
 


### PR DESCRIPTION
If a Blob is spanning is not getting deleted as spanning_blob_map
is holding one ref.Explicitly decreasing Blob ref from ExtentMap
destructor and erasing from spanning_blob_map is fixing the leak.

Signed-off-by: Somnath Roy <somnath.roy@sandisk.com>