### PR TITLE
jewel: common: Log.cc: Assign LOG_INFO priority to syslog calls

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -329,7 +329,7 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
       }
 
       if (do_syslog) {
-        syslog(LOG_USER|LOG_DEBUG, "%s", buf);
+        syslog(LOG_USER|LOG_INFO, "%s", buf);
       }
 
       if (do_stderr) {
@@ -367,7 +367,7 @@ void Log::_log_message(const char *s, bool crash)
       cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }
   if ((crash ? m_syslog_crash : m_syslog_log) >= 0) {
-    syslog(LOG_USER|LOG_DEBUG, "%s", s);
+    syslog(LOG_USER|LOG_INFO, "%s", s);
   }
 
   if ((crash ? m_stderr_crash : m_stderr_log) >= 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/17376