### PR TITLE
os/bluestore: garbage collect partially overlapped blobs

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -972,6 +972,8 @@ OPTION(bluestore_compression, OPT_STR, "none")  // force|aggressive|passive|none
 OPTION(bluestore_compression_algorithm, OPT_STR, "snappy")
 OPTION(bluestore_compression_min_blob_size, OPT_U32, 256*1024)
 OPTION(bluestore_compression_max_blob_size, OPT_U32, 4*1024*1024)
+OPTION(bluestore_gc_max_blob_depth, OPT_U32, 3)
+OPTION(bluestore_gc_merge_data, OPT_BOOL, true)
 /*
  * Require the net gain of compression at least to be at this ratio,
  * otherwise we don't compress.

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -85,6 +85,7 @@ enum {
   l_bluestore_write_small_new,
   l_bluestore_txc,
   l_bluestore_onode_reshard,
+  l_bluestore_gc_bytes,
   l_bluestore_last
 };
 
@@ -495,12 +496,13 @@ public:
     uint32_t logical_offset = 0;      ///< logical offset
     uint32_t blob_offset = 0;         ///< blob offset
     uint32_t length = 0;              ///< length
+    uint8_t  blob_depth;              /// blob overlapping count
     BlobRef blob;                     ///< the blob with our data
 
     explicit Extent() {}
     explicit Extent(uint32_t lo) : logical_offset(lo) {}
-    Extent(uint32_t lo, uint32_t o, uint32_t l, BlobRef& b)
-      : logical_offset(lo), blob_offset(o), length(l), blob(b) {}
+    Extent(uint32_t lo, uint32_t o, uint32_t l, uint8_t bd, BlobRef& b)
+      : logical_offset(lo), blob_offset(o), length(l), blob_depth(bd), blob(b){}
 
     // comparators for intrusive_set
     friend bool operator<(const Extent &a, const Extent &b) {
@@ -598,8 +600,8 @@ public:
     extent_map_t::iterator seek_lextent(uint64_t offset);
 
     /// add a new Extent
-    void add(uint32_t lo, uint32_t o, uint32_t l, BlobRef& b) {
-      extent_map.insert(*new Extent(lo, o, l, b));
+    void add(uint32_t lo, uint32_t o, uint32_t l, uint8_t bd, BlobRef& b) {
+      extent_map.insert(*new Extent(lo, o, l, bd, b));
     }
 
     /// remove (and delete) an Extent
@@ -621,8 +623,8 @@ public:
     /// put new lextent into lextent_map overwriting existing ones if
     /// any and update references accordingly
     Extent *set_lextent(uint64_t logical_offset,
-			uint64_t offset, uint64_t length, BlobRef b,
-			extent_map_t *old_extents);
+			uint64_t offset, uint64_t length, uint8_t blob_depth,
+                        BlobRef b, extent_map_t *old_extents);
 
   };
 
@@ -1682,6 +1684,7 @@ private:
     bool buffered = false;       ///< buffered write
     bool compress = false;       ///< compressed write
     uint64_t comp_blob_size = 0; ///< target compressed blob size
+    uint8_t blob_depth = 0;       ///< depth of the logical extent
     unsigned csum_order = 0;     ///< target checksum chunk order
 
     extent_map_t old_extents;       ///< must deref these blobs
@@ -1738,12 +1741,28 @@ private:
 	     uint32_t fadvise_flags);
   void _pad_zeros(bufferlist *bl, uint64_t *offset,
 		  uint64_t chunk_size);
+
+  bool _blobs_need_garbage_collection(OnodeRef o,
+                          uint64_t start_offset,
+                          uint64_t end_offset,
+                          uint8_t  *blob_depth,
+                          uint64_t *gc_start_offset,
+                          uint64_t *gc_end_offset);
+
   int _do_write(TransContext *txc,
 		CollectionRef &c,
 		OnodeRef o,
 		uint64_t offset, uint64_t length,
 		bufferlist& bl,
 		uint32_t fadvise_flags);
+  void _do_write_data(TransContext *txc,
+                      CollectionRef& c,
+                      OnodeRef o,
+                      uint64_t offset,
+                      uint64_t length,
+                      bufferlist& bl,
+                      WriteContext *wctx);
+
   int _touch(TransContext *txc,
 	     CollectionRef& c,
 	     OnodeRef& o);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -931,6 +931,243 @@ TEST_P(StoreTest, CompressionTest) {
   g_ceph_context->_conf->apply_changes(NULL);
 }
 
+TEST_P(StoreTest, garbageCollection) {
+  ObjectStore::Sequencer osr("test");
+  int r;
+  int64_t waste1, waste2;
+  coll_t cid;
+  int buf_len = 256 * 1024;
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  g_conf->set_val("bluestore_compression", "force");
+  g_conf->set_val("bluestore_merge_gc_data", "true"); 
+  g_ceph_context->_conf->apply_changes(NULL);
+
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  {
+    bufferlist in;
+    r = store->read(cid, hoid, 0, 5, in);
+    ASSERT_EQ(-ENOENT, r);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+
+  std::string data;
+  data.resize(buf_len);
+
+  {
+    { 
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = 'R';
+
+    bl.append(data);
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 0, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 2 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+  }
+  {
+    {
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = i  % 256;
+    bl.append(data);
+
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 2 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 50 * 1024, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+     }
+  }
+  {
+    {
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = i  % 256;
+    bl.append(data);
+
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 5 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 4 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 3 * (buf_len - 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, buf_len - 4096, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 40 * 1024, bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste1 = statfs.allocated - statfs.stored;
+    }
+    {
+      ObjectStore::Transaction t;
+      t.write(cid, hoid, 5 * (buf_len - 3 * 4096), bl.length(), bl);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+    {
+      struct store_statfs_t statfs;
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      waste2 = statfs.allocated - statfs.stored;
+      ASSERT_GE(waste1, waste2);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      t.remove_collection(cid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+     }
+  }
+  g_conf->set_val("bluestore_compression", "none");
+  g_ceph_context->_conf->apply_changes(NULL);
+}
+
 TEST_P(StoreTest, SimpleObjectTest) {
   ObjectStore::Sequencer osr("test");
   int r;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -672,7 +672,7 @@ TEST(ExtentMap, find_lextent)
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(100));
 
-  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, br));
   auto a = em.find(100);
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(99));
@@ -681,7 +681,7 @@ TEST(ExtentMap, find_lextent)
   ASSERT_EQ(a, em.find_lextent(199));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(200));
 
-  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, 1, br));
   auto b = em.find(200);
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(99));
@@ -692,7 +692,7 @@ TEST(ExtentMap, find_lextent)
   ASSERT_EQ(b, em.find_lextent(299));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(300));
 
-  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, 1, br));
   auto d = em.find(400);
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(99));
@@ -716,7 +716,7 @@ TEST(ExtentMap, seek_lextent)
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(100));
 
-  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, br));
   auto a = em.find(100);
   ASSERT_EQ(a, em.seek_lextent(0));
   ASSERT_EQ(a, em.seek_lextent(99));
@@ -725,7 +725,7 @@ TEST(ExtentMap, seek_lextent)
   ASSERT_EQ(a, em.seek_lextent(199));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(200));
 
-  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, 1, br));
   auto b = em.find(200);
   ASSERT_EQ(a, em.seek_lextent(0));
   ASSERT_EQ(a, em.seek_lextent(99));
@@ -736,7 +736,7 @@ TEST(ExtentMap, seek_lextent)
   ASSERT_EQ(b, em.seek_lextent(299));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(300));
 
-  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, br));
+  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, 1, br));
   auto d = em.find(400);
   ASSERT_EQ(a, em.seek_lextent(0));
   ASSERT_EQ(a, em.seek_lextent(99));
@@ -761,7 +761,7 @@ TEST(ExtentMap, has_any_lextents)
   ASSERT_FALSE(em.has_any_lextents(0, 1000));
   ASSERT_FALSE(em.has_any_lextents(1000, 1000));
 
-  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, b));
+  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, b));
   ASSERT_FALSE(em.has_any_lextents(0, 50));
   ASSERT_FALSE(em.has_any_lextents(0, 100));
   ASSERT_FALSE(em.has_any_lextents(50, 50));
@@ -773,7 +773,7 @@ TEST(ExtentMap, has_any_lextents)
   ASSERT_TRUE(em.has_any_lextents(199, 2));
   ASSERT_FALSE(em.has_any_lextents(200, 2));
 
-  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, b));
+  em.extent_map.insert(*new BlueStore::Extent(200, 0, 100, 1, b));
   ASSERT_TRUE(em.has_any_lextents(199, 1));
   ASSERT_TRUE(em.has_any_lextents(199, 2));
   ASSERT_TRUE(em.has_any_lextents(200, 2));
@@ -781,7 +781,7 @@ TEST(ExtentMap, has_any_lextents)
   ASSERT_TRUE(em.has_any_lextents(299, 1));
   ASSERT_FALSE(em.has_any_lextents(300, 1));
 
-  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, b));
+  em.extent_map.insert(*new BlueStore::Extent(400, 0, 100, 1, b));
   ASSERT_TRUE(em.has_any_lextents(0, 10000));
   ASSERT_TRUE(em.has_any_lextents(199, 1));
   ASSERT_FALSE(em.has_any_lextents(300, 1));
@@ -801,31 +801,31 @@ TEST(ExtentMap, compress_extent_map)
   BlueStore::BlobRef b2(new BlueStore::Blob);
   BlueStore::BlobRef b3(new BlueStore::Blob);
 
-  em.extent_map.insert(*new BlueStore::Extent(0, 0, 100, b1));
-  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, b2));
+  em.extent_map.insert(*new BlueStore::Extent(0, 0, 100, 1, b1));
+  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, b2));
   ASSERT_EQ(0, em.compress_extent_map(0, 10000));
   ASSERT_EQ(2u, em.extent_map.size());
 
-  em.extent_map.insert(*new BlueStore::Extent(200, 100, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(300, 200, 100, b2));
+  em.extent_map.insert(*new BlueStore::Extent(200, 100, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(300, 200, 100, 1, b2));
   ASSERT_EQ(0, em.compress_extent_map(0, 0));
   ASSERT_EQ(0, em.compress_extent_map(100000, 1000));
   ASSERT_EQ(2, em.compress_extent_map(0, 100000));
   ASSERT_EQ(2u, em.extent_map.size());
 
   em.extent_map.erase(em.find(100));
-  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(200, 100, 100, b3));
-  em.extent_map.insert(*new BlueStore::Extent(300, 200, 100, b2));
+  em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(200, 100, 100, 1, b3));
+  em.extent_map.insert(*new BlueStore::Extent(300, 200, 100, 1, b2));
   ASSERT_EQ(0, em.compress_extent_map(0, 1));
   ASSERT_EQ(0, em.compress_extent_map(0, 100000));
   ASSERT_EQ(4u, em.extent_map.size());
 
-  em.extent_map.insert(*new BlueStore::Extent(400, 300, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(500, 500, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(600, 600, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(700, 0, 100, b1));
-  em.extent_map.insert(*new BlueStore::Extent(800, 0, 100, b3));
+  em.extent_map.insert(*new BlueStore::Extent(400, 300, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(500, 500, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(600, 600, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(700, 0, 100, 1, b1));
+  em.extent_map.insert(*new BlueStore::Extent(800, 0, 100, 1, b3));
   ASSERT_EQ(0, em.compress_extent_map(0, 99));
   ASSERT_EQ(0, em.compress_extent_map(800, 1000));
   ASSERT_EQ(2, em.compress_extent_map(100, 500));
@@ -833,9 +833,9 @@ TEST(ExtentMap, compress_extent_map)
   em.extent_map.erase(em.find(300));
   em.extent_map.erase(em.find(500));  
   em.extent_map.erase(em.find(700));
-  em.extent_map.insert(*new BlueStore::Extent(400, 300, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(500, 400, 100, b2));
-  em.extent_map.insert(*new BlueStore::Extent(700, 500, 100, b2));
+  em.extent_map.insert(*new BlueStore::Extent(400, 300, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(500, 400, 100, 1, b2));
+  em.extent_map.insert(*new BlueStore::Extent(700, 500, 100, 1, b2));
   ASSERT_EQ(1, em.compress_extent_map(0, 1000));
   ASSERT_EQ(6u, em.extent_map.size());
 }


### PR DESCRIPTION


Because of overwrite operation, a new blob is created instead of merging data with the old blob. This leads to overlapping of blobs(example given below).
...................
......................
......................
Because of overlapping blobs, space is wasted and read-performance can degrade. As part of this code change, we try to garbage collect the overlapping blobs. If the new write request results in overlapping count of more than 3, we extent the write request so that it completely overwrite the blobs adjacent to the new write request.

To keep track of the overlapping count, a new persistent field "blob_depth" is added to lextent. Whenever we add a new lextent, the "blob_depth" is set to the max of all the overlapping lextents + 1 (In fact we need not check all the overlapping lextents, we just need to check only two lextents covering the two ends of the new lextents) . This will not always give the correct depth. It may over count in certain scenarios but will never undercount. Note: if lextents are splitted at the blobs boundary, it may be possible to correctly keep track of the depth, but that will increase the lextent counts and make "depth" update operation complicated.

This pr is based on #10406 , rebased to latest code and fixed the review comments