### PR TITLE
tool/cephfs: displaying "list" in journal event mode

### DIFF
--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -57,7 +57,7 @@ void JournalTool::usage()
     << "      --frag=<ino>.<frag> [--dname=<dentry string>]\n"
     << "      --client=<session id integer>\n"
     << "    <effect>: [get|apply|recover_dentries|splice]\n"
-    << "    <output>: [summary|binary|json] [--path <path>]\n"
+    << "    <output>: [summary|list|binary|json] [--path <path>]\n"
     << "\n"
     << "Options:\n"
     << "  --rank=<str>  Journal rank (default 0)\n";


### PR DESCRIPTION
lack of displaying "list" when use the journal event mode of cephfs-journal-tool 

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>