### PR TITLE
os/bluestore: remove deferred_csum machinery

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1089,8 +1089,6 @@ public:
 	: blob(b), b_off(bo), data(bl) {}
     };
 
-    list<DeferredCsum> deferred_csum;
-
     explicit TransContext(OpSequencer *o)
       : state(STATE_PREPARE),
 	osr(o),
@@ -1114,10 +1112,6 @@ public:
     }
     void write_shared_blob(SharedBlobRef &sb) {
       shared_blobs.insert(sb);
-    }
-
-    void add_deferred_csum(BlobRef& b, uint64_t bo, bufferlist& bl) {
-      deferred_csum.emplace_back(TransContext::DeferredCsum(b, bo, bl));
     }
   };
 


### PR DESCRIPTION
When we added this way back in d4f4fa0312d943dd0ce3c27f5fc56c7a753bb471,
we did not have our own buffer cache, and were relying
on the cache at the BlockDevice layer.  In that case,
we would have the problem of a partial wal overwrite
followed by another partial write that needed to read
the rest of the chunk.

However, now we have our own cache, and any data we write
in the _do_write_small() wal path will go into the cache,
which means we will never read the old data off of
disk and need the old csum values.

Remove this now-unnecessary kludge!

Signed-off-by: Sage Weil <sage@redhat.com>