### PR TITLE
os/filestore: Fix erroneous WARNING: max attr too small

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -5519,8 +5519,10 @@ void FileStore::handle_conf_change(const struct md_config_t *conf,
       changed.count("filestore_max_xattr_value_size_xfs") ||
       changed.count("filestore_max_xattr_value_size_btrfs") ||
       changed.count("filestore_max_xattr_value_size_other")) {
-    Mutex::Locker l(lock);
-    set_xattr_limits_via_conf();
+    if (backend) {
+      Mutex::Locker l(lock);
+      set_xattr_limits_via_conf();
+    }
   }
 
   if (changed.count("filestore_queue_max_bytes") ||


### PR DESCRIPTION
When we read the conf values from the conf file we call handle_conf_change which
calls set_xattr_limits_via_conf but this is before m_fs_type is initialised so
we fall through to the default comaprison with
filestore_max_xattr_value_size_other (1024) and erroneously issue the warning.
This happens at every startup but subsequent calls once the filestore is mounted
proceed as expected. Don't call set_xattr_limits_via_conf unless the filestore
is mounted.

Fixes: http://tracker.ceph.com/issues/17420
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>