### PR TITLE
osd: Flush Journal on shutdown

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -604,6 +604,7 @@ OPTION(osd_uuid, OPT_UUID, uuid_d())
 OPTION(osd_data, OPT_STR, "/var/lib/ceph/osd/$cluster-$id")
 OPTION(osd_journal, OPT_STR, "/var/lib/ceph/osd/$cluster-$id/journal")
 OPTION(osd_journal_size, OPT_INT, 5120)         // in mb
+OPTION(osd_journal_flush_on_shutdown, OPT_BOOL, true) // Flush journal to data store on shutdown
 // flags for specific control purpose during osd mount() process. 
 // e.g., can be 1 to skip over replaying journal
 // or 2 to skip over mounting omap or 3 to skip over both.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2752,6 +2752,12 @@ int OSD::shutdown()
 
   dout(10) << "syncing store" << dendl;
   enable_disable_fuse(true);
+
+  if (g_conf->osd_journal_flush_on_shutdown) {
+    dout(10) << "flushing journal" << dendl;
+    store->flush_journal();
+  }
+
   store->umount();
   delete store;
   store = 0;


### PR DESCRIPTION
This way a data store is consistent and hot-swappable if a OSD had
a clean shutdown.

Make this behavior configurable and enable it by default.

Signed-off-by: Wido den Hollander wido@42on.com

This is a better version of #11025
