### PR TITLE
mds/MDCache: kill a comipler warning

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9087,8 +9087,6 @@ void MDCache::request_cleanup(MDRequestRef& mdr)
   // remove from session
   mdr->item_session_request.remove_myself();
 
-  bool was_replay = mdr->client_request && mdr->client_request->is_replay();
-
   // remove from map
   active_requests.erase(mdr->reqid);
 


### PR DESCRIPTION
/home/jenkins-build/build/workspace/ceph-pull-requests/src/mds/MDCache.cc: In member function ‘void MDCache::request_cleanup(MDRequestRef&)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/mds/MDCache.cc:9090:8: warning: unused variable ‘was_replay’ [-Wunused-variable]
   bool was_replay = mdr->client_request && mdr->client_request->is_replay();

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>