### PR TITLE
selinux: Allow ceph to manage tmp files

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -93,6 +93,7 @@ allow ceph_t self:tcp_socket { accept listen };
 corenet_tcp_connect_cyphesis_port(ceph_t)
 corenet_tcp_connect_generic_port(ceph_t)
 files_list_tmp(ceph_t)
+files_manage_generic_tmp_files(ceph_t)
 fstools_exec(ceph_t)
 nis_use_ypbind_uncond(ceph_t)
 storage_raw_rw_fixed_disk(ceph_t)


### PR DESCRIPTION
Two new denials showed up in testing that relate to ceph trying to
manage (rename and unlink) tmp files. This commit allows ceph to manage
the files.

Signed-off-by: Boris Ranto <branto@redhat.com>

RH bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1375898