### PR TITLE
Link allocation libraries to test binaries when rocksdb is built with jemalloc

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -101,7 +101,7 @@ if(WITH_LIBCEPHFS)
 endif(WITH_LIBCEPHFS)
 
 add_executable(test_build_librados buildtest_skeleton.cc)
-target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os common cls_lock_client ${BLKID_LIBRARIES})
+target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os common cls_lock_client ${BLKID_LIBRARIES} ${ALLOC_LIBS})
 
 # bench_log
 set(bench_log_srcs
@@ -123,7 +123,7 @@ target_link_libraries(ceph_test_mutate global librados ${BLKID_LIBRARIES}
 add_executable(test_trans
   test_trans.cc
   )
-target_link_libraries(test_trans os global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(test_trans os global ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 
 ## Benchmarks
 
@@ -156,7 +156,7 @@ endif(WITH_KVS)
 
 # ceph_objectstore_bench
 add_executable(ceph_objectstore_bench objectstore_bench.cc)
-target_link_libraries(ceph_objectstore_bench global ${BLKID_LIBRARIES} os)
+target_link_libraries(ceph_objectstore_bench global ${BLKID_LIBRARIES} os ${ALLOC_LIBS})
 
 if(${WITH_RADOSGW})
   # test_cors
@@ -340,6 +340,7 @@ target_link_libraries(ceph_test_rgw_token
   global
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   )
 
 # librgw_file_gp (just the rgw_file get-put bucket ops)
@@ -380,7 +381,7 @@ if(PERF_LOCAL_FLAGS)
   set_target_properties(ceph_perf_local PROPERTIES COMPILE_FLAGS
     ${PERF_LOCAL_FLAGS})
 endif()
-target_link_libraries(ceph_perf_local os global ${UNITTEST_LIBS})
+target_link_libraries(ceph_perf_local os global ${UNITTEST_LIBS} ${ALLOC_LIBS})
 
 # ceph_xattr_bench
 add_executable(ceph_xattr_bench
@@ -396,6 +397,7 @@ target_link_libraries(ceph_xattr_bench
   ${EXTRALIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
+  ${ALLOC_LIBS}
   )
 
 install(TARGETS
@@ -422,6 +424,7 @@ target_link_libraries(ceph_test_filejournal
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   )
 install(TARGETS
   ceph_test_filejournal
@@ -467,6 +470,7 @@ if(WITH_FUSE)
     os
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
+    ${ALLOC_LIBS}
     )
 endif(WITH_FUSE)
 

--- a/src/test/ObjectMap/CMakeLists.txt
+++ b/src/test/ObjectMap/CMakeLists.txt
@@ -11,6 +11,7 @@ target_link_libraries(ceph_test_object_map
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${CMAKE_DL_LIBS}
   )
 
@@ -26,6 +27,7 @@ target_link_libraries(ceph_test_keyvaluedb_atomicity
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${CMAKE_DL_LIBS}
   )
 
@@ -42,6 +44,7 @@ target_link_libraries(ceph_test_keyvaluedb_iterators
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${CMAKE_DL_LIBS}
   )
 

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -31,6 +31,7 @@ if(WITH_RBD)
     udev
     ${BLKID_LIBRARIES}
     ${CMAKE_DL_LIBS}
+    ${ALLOC_LIBS}
     keyutils
     )
   add_dependencies(ceph_smalliobenchrbd
@@ -53,7 +54,7 @@ add_executable(ceph_smalliobenchfs
   ${ceph_smalliobenchfs_srcs}
   )
 target_link_libraries(ceph_smalliobenchfs librados ${Boost_PROGRAM_OPTIONS_LIBRARY} os global
-  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
+  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 
 # ceph_smalliobenchdumb
 set(smalliobenchdumb_srcs
@@ -66,7 +67,7 @@ add_executable(ceph_smalliobenchdumb
   ${smalliobenchdumb_srcs}
   )
 target_link_libraries(ceph_smalliobenchdumb librados ${Boost_PROGRAM_OPTIONS_LIBRARY} os global
-  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS}) 
+  ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 
 # ceph_tpbench
 set(tpbench_srcs

--- a/src/test/filestore/CMakeLists.txt
+++ b/src/test/filestore/CMakeLists.txt
@@ -3,6 +3,6 @@ add_executable(ceph_test_filestore
   TestFileStore.cc)
 set_target_properties(ceph_test_filestore PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
-target_link_libraries(ceph_test_filestore os global ${UNITTEST_LIBS})
+target_link_libraries(ceph_test_filestore os global ${UNITTEST_LIBS} ${ALLOC_LIBS})
 
 

--- a/src/test/mon/CMakeLists.txt
+++ b/src/test/mon/CMakeLists.txt
@@ -16,7 +16,7 @@ install(TARGETS ceph_test_mon_workloadgen
 add_executable(ceph_test_mon_msg 
   test-mon-msg.cc
   )
-target_link_libraries(ceph_test_mon_msg os osdc global ${UNITTEST_LIBS})
+target_link_libraries(ceph_test_mon_msg os osdc global ${UNITTEST_LIBS} ${ALLOC_LIBS})
 set_target_properties(ceph_test_mon_msg PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -4,7 +4,7 @@ add_executable(ceph_perf_objectstore
   )
 set_target_properties(ceph_perf_objectstore PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
-target_link_libraries(ceph_perf_objectstore os osdc global ${UNITTEST_LIBS})
+target_link_libraries(ceph_perf_objectstore os osdc global ${UNITTEST_LIBS} ${ALLOC_LIBS})
 install(TARGETS ceph_perf_objectstore
   DESTINATION bin)
 
@@ -24,6 +24,7 @@ target_link_libraries(ceph_test_objectstore
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
@@ -42,6 +43,7 @@ target_link_libraries(ceph_test_keyvaluedb
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
@@ -57,6 +59,7 @@ target_link_libraries(ceph_test_objectstore_workloadgen
   os
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
@@ -71,6 +74,7 @@ target_link_libraries(ceph_test_filestore_idempotent
   os
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
@@ -86,6 +90,7 @@ target_link_libraries(ceph_test_filestore_idempotent_sequence
   os
   global
   ${EXTRALIBS}
+  ${ALLOC_LIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}
   )
@@ -97,14 +102,14 @@ add_executable(unittest_chain_xattr
   chain_xattr.cc
   )
 add_ceph_unittest(unittest_chain_xattr ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_chain_xattr)
-target_link_libraries(unittest_chain_xattr os global)
+target_link_libraries(unittest_chain_xattr os global ${ALLOC_LIBS})
 
 # unittest_rocksdb_option
 add_executable(unittest_rocksdb_option
   TestRocksdbOptionParse.cc
   )
 add_ceph_unittest(unittest_rocksdb_option ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rocksdb_option)
-target_link_libraries(unittest_rocksdb_option global os ${BLKID_LIBRARIES})
+target_link_libraries(unittest_rocksdb_option global os ${BLKID_LIBRARIES} ${ALLOC_LIBS})
 
 if(HAVE_LIBAIO)
   # unittest_bit_alloc
@@ -112,38 +117,38 @@ if(HAVE_LIBAIO)
     BitAllocator_test.cc
     )
   add_ceph_unittest(unittest_bit_alloc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bit_alloc)
-  target_link_libraries(unittest_bit_alloc os global)
+  target_link_libraries(unittest_bit_alloc os global ${ALLOC_LIBS})
 
   add_executable(unittest_alloc
     Allocator_test.cc
     )
   add_ceph_unittest(unittest_alloc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_alloc)
-  target_link_libraries(unittest_alloc os global)
+  target_link_libraries(unittest_alloc os global ${ALLOC_LIBS})
 
   # unittest_bluefs
   add_executable(unittest_bluefs
     test_bluefs.cc
     )
   add_ceph_unittest(unittest_bluefs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bluefs)
-  target_link_libraries(unittest_bluefs os global)
+  target_link_libraries(unittest_bluefs os global ${ALLOC_LIBS})
 
   # unittest_bluestore_types
   add_executable(unittest_bluestore_types
     test_bluestore_types.cc
     )
   add_ceph_unittest(unittest_bluestore_types ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_bluestore_types)
-  target_link_libraries(unittest_bluestore_types os global)
+  target_link_libraries(unittest_bluestore_types os global ${ALLOC_LIBS})
 endif(HAVE_LIBAIO)
 
 # unittest_transaction
 add_executable(unittest_transaction
   test_transaction.cc)
 add_ceph_unittest(unittest_transaction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_transaction)
-target_link_libraries(unittest_transaction os common)
+target_link_libraries(unittest_transaction os common ${ALLOC_LIBS})
 
 # unittest_memstore_clone
 add_executable(unittest_memstore_clone
   test_memstore_clone.cc
   $<TARGET_OBJECTS:store_test_fixture>)
 add_ceph_unittest(unittest_memstore_clone ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_memstore_clone)
-target_link_libraries(unittest_memstore_clone os global)
+target_link_libraries(unittest_memstore_clone os global ${ALLOC_LIBS})

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -22,11 +22,11 @@ target_link_libraries(ceph_radosacl librados global)
 install(TARGETS ceph_radosacl DESTINATION bin)
 
 add_executable(ceph-osdomap-tool ceph_osdomap_tool.cc)
-target_link_libraries(ceph-osdomap-tool os global ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(ceph-osdomap-tool os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${ALLOC_LIBS})
 install(TARGETS ceph-osdomap-tool DESTINATION bin)
 
 add_executable(ceph-monstore-tool ceph_monstore_tool.cc)
-target_link_libraries(ceph-monstore-tool os global ${Boost_PROGRAM_OPTIONS_LIBRARY})
+target_link_libraries(ceph-monstore-tool os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${ALLOC_LIBS})
 install(TARGETS ceph-monstore-tool DESTINATION bin)
 install(PROGRAMS
   ceph-monstore-update-crush.sh
@@ -37,7 +37,7 @@ add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc
   rebuild_mondb.cc
   RadosDump.cc)
-target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS})
+target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 if(WITH_FUSE)
   target_link_libraries(ceph-objectstore-tool fuse)
 endif(WITH_FUSE)
@@ -53,7 +53,7 @@ endif(WITH_LIBCEPHFS)
 
 if(WITH_TESTS)
 add_executable(ceph-kvstore-tool ceph_kvstore_tool.cc)
-target_link_libraries(ceph-kvstore-tool os global)
+target_link_libraries(ceph-kvstore-tool os global ${ALLOC_LIBS})
 install(TARGETS ceph-kvstore-tool DESTINATION bin)
 endif(WITH_TESTS)
 


### PR DESCRIPTION
Link allocation libraries to test binaries when rocksdb is built with jemalloc.

Signed-off-by: Varada Kari varada.kari@sandisk.com
