### PR TITLE
Revert "osdc: After write try merge bh."

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1114,7 +1114,6 @@ void ObjectCacher::bh_write_commit(int64_t poolid, sobject_t oid,
       }
     }
 
-    list <BufferHead*> hit;
     // apply to bh's!
     for (map<loff_t, BufferHead*>::const_iterator p = ob->data_lower_bound(start);
 	 p != ob->data.end();
@@ -1149,7 +1148,6 @@ void ObjectCacher::bh_write_commit(int64_t poolid, sobject_t oid,
 	bh->set_journal_tid(0);
 	if (bh->get_nocache())
 	  bh_lru_rest.lru_bottouch(bh);
-	hit.push_back(bh);
 	ldout(cct, 10) << "bh_write_commit clean " << *bh << dendl;
       } else {
 	mark_dirty(bh);
@@ -1157,13 +1155,6 @@ void ObjectCacher::bh_write_commit(int64_t poolid, sobject_t oid,
 		       << *bh << " r = " << r << " " << cpp_strerror(-r)
 		       << dendl;
       }
-    }
-
-    for (list<BufferHead*>::iterator bh = hit.begin();
-	bh != hit.end();
-	++bh) {
-      assert(*bh);
-      ob->try_merge_bh(*bh);
     }
   }
 


### PR DESCRIPTION
This reverts commit 1a48a8a2b222e41236341cb1241f0885a1b0b9d8.

Fixes: http://tracker.ceph.com/issues/17270
Signed-off-by: John Spray <john.spray@redhat.com>