### PR TITLE
os/bluestore: sloppy reshard boundaries to avoid spanning blobs

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -982,6 +982,7 @@ OPTION(bluestore_compression_required_ratio, OPT_DOUBLE, .875)
 OPTION(bluestore_extent_map_shard_max_size, OPT_U32, 1200)
 OPTION(bluestore_extent_map_shard_target_size, OPT_U32, 500)
 OPTION(bluestore_extent_map_shard_min_size, OPT_U32, 150)
+OPTION(bluestore_extent_map_shard_target_size_slop, OPT_DOUBLE, .2)
 OPTION(bluestore_extent_map_inline_shard_prealloc_size, OPT_U32, 256)
 OPTION(bluestore_cache_type, OPT_STR, "2q")   // lru, 2q
 OPTION(bluestore_onode_cache_size, OPT_U32, 16*1024)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -523,6 +523,11 @@ public:
       return a.logical_offset == b.logical_offset;
     }
 
+    uint32_t blob_end() {
+      return logical_offset + blob->get_blob().get_logical_length() -
+	blob_offset;
+    }
+
     bool blob_escapes_range(uint32_t o, uint32_t l) {
       uint32_t bstart = logical_offset - blob_offset;
       return (bstart < o ||


### PR DESCRIPTION
Make the extent map shard target size sloppy so that we can try to avoid
sharding boundaries that create spanning blobs.

Signed-off-by: Sage Weil <sage@redhat.com>