### PR TITLE
os/bluestore/bluestore_types: uint64_t for ref_map

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -151,7 +151,7 @@ struct bluestore_extent_ref_map_t {
   struct record_t {
     uint32_t length;
     uint32_t refs;
-    record_t(uint32_t l=0, uint32_t r=0) : length(l), refs(r) {}
+    record_t(uint64_t l=0, uint32_t r=0) : length(l), refs(r) {}
     void encode(bufferlist& bl) const {
       small_encode_varint_lowz(length, bl);
       small_encode_varint(refs, bl);
@@ -163,10 +163,10 @@ struct bluestore_extent_ref_map_t {
   };
   WRITE_CLASS_ENCODER(record_t)
 
-  map<uint32_t,record_t> ref_map;
+  map<uint64_t,record_t> ref_map;
 
   void _check() const;
-  void _maybe_merge_left(map<uint32_t,record_t>::iterator& p);
+  void _maybe_merge_left(map<uint64_t,record_t>::iterator& p);
 
   void clear() {
     ref_map.clear();
@@ -175,11 +175,11 @@ struct bluestore_extent_ref_map_t {
     return ref_map.empty();
   }
 
-  void get(uint32_t offset, uint32_t len);
-  void put(uint32_t offset, uint32_t len, vector<bluestore_pextent_t> *release);
+  void get(uint64_t offset, uint32_t len);
+  void put(uint64_t offset, uint32_t len, vector<bluestore_pextent_t> *release);
 
-  bool contains(uint32_t offset, uint32_t len) const;
-  bool intersects(uint32_t offset, uint32_t len) const;
+  bool contains(uint64_t offset, uint32_t len) const;
+  bool intersects(uint64_t offset, uint32_t len) const;
 
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& p);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5297,6 +5297,9 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("bluestore_buffer_cache_size", "2000000");
   g_ceph_context->_conf->set_val("bluestore_onode_cache_size", "500");
 
+  // use a large enough block device that we'll exceed 32 bit LBAs
+  g_ceph_context->_conf->set_val("bluestore_block_size", "1024000000000");
+
   g_ceph_context->_conf->set_val(
     "enable_experimental_unrecoverable_data_corrupting_features", "*");
   g_ceph_context->_conf->apply_changes(NULL);


### PR DESCRIPTION
We use this to track raw extents on disk for SharedBlob.  We
also use it for the in-memory Blob with the blob namespace, but
using uint64_t intead of uint32_t doesn't hurt us there.

Signed-off-by: Sage Weil <sage@redhat.com>