### PR TITLE
rgw: fixes for virtual hosting of buckets

### DIFF
--- a/doc/radosgw/s3/commons.rst
+++ b/doc/radosgw/s3/commons.rst
@@ -18,6 +18,8 @@ The second method identifies the bucket via a virtual bucket host name. For exam
 	GET / HTTP/1.1
 	Host: mybucket.cname.domain.com
 
+To configure virtual hosted buckets, you can either set ``rgw_dns_name = cname.domain.com`` in ceph.conf, or add ``cname.domain.com`` to the list of ``hostnames`` in your zonegroup configuration. See `Ceph Object Gateway - Multisite Configuration`_ for more on zonegroups.
+
 .. tip:: We prefer the first method, because the second method requires expensive domain certification and DNS wild cards.
 
 Common Request Headers
@@ -105,3 +107,5 @@ Common Response Status
 +---------------+-----------------------------------+
 | ``500``       | InternalError                     |
 +---------------+-----------------------------------+
+
+.. _`Ceph Object Gateway - Multisite Configuration`: ../../multisite

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -208,8 +208,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, RGWZoneGroup& zone_group)
   hostnames_set.insert(cct->_conf->rgw_dns_name);
   hostnames_set.insert(zone_group.hostnames.begin(), zone_group.hostnames.end());
   hostnames_set.erase(""); // filter out empty hostnames
-  string s;
-  ldout(cct, 20) << "RGW hostnames: " << std::accumulate(hostnames_set.begin(), hostnames_set.end(), s) << dendl;
+  ldout(cct, 20) << "RGW hostnames: " << hostnames_set << dendl;
   /* TODO: We should have a sanity check that no hostname matches the end of
    * any other hostname, otherwise we will get ambigious results from
    * rgw_find_host_in_domains.
@@ -223,8 +222,7 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, RGWZoneGroup& zone_group)
   hostnames_s3website_set.insert(cct->_conf->rgw_dns_s3website_name);
   hostnames_s3website_set.insert(zone_group.hostnames_s3website.begin(), zone_group.hostnames_s3website.end());
   hostnames_s3website_set.erase(""); // filter out empty hostnames
-  s.clear();
-  ldout(cct, 20) << "RGW S3website hostnames: " << std::accumulate(hostnames_s3website_set.begin(), hostnames_s3website_set.end(), s) << dendl;
+  ldout(cct, 20) << "RGW S3website hostnames: " << hostnames_s3website_set << dendl;
   /* TODO: we should repeat the hostnames_set sanity check here
    * and ALSO decide about overlap, if any
    */

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -205,10 +205,9 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, RGWZoneGroup& zone_group)
     http_status_names[h->code] = h->name;
   }
 
-  if (!cct->_conf->rgw_dns_name.empty()) {
-    hostnames_set.insert(cct->_conf->rgw_dns_name);
-  }
-  hostnames_set.insert(zone_group.hostnames.begin(),  zone_group.hostnames.end());
+  hostnames_set.insert(cct->_conf->rgw_dns_name);
+  hostnames_set.insert(zone_group.hostnames.begin(), zone_group.hostnames.end());
+  hostnames_set.erase(""); // filter out empty hostnames
   string s;
   ldout(cct, 20) << "RGW hostnames: " << std::accumulate(hostnames_set.begin(), hostnames_set.end(), s) << dendl;
   /* TODO: We should have a sanity check that no hostname matches the end of
@@ -221,10 +220,9 @@ void rgw_rest_init(CephContext *cct, RGWRados *store, RGWZoneGroup& zone_group)
    * X.B.A ambigously splits to both {X, B.A} and {X.B, A}
    */
 
-  if (!cct->_conf->rgw_dns_s3website_name.empty()) {
-    hostnames_s3website_set.insert(cct->_conf->rgw_dns_s3website_name);
-  }
+  hostnames_s3website_set.insert(cct->_conf->rgw_dns_s3website_name);
   hostnames_s3website_set.insert(zone_group.hostnames_s3website.begin(), zone_group.hostnames_s3website.end());
+  hostnames_s3website_set.erase(""); // filter out empty hostnames
   s.clear();
   ldout(cct, 20) << "RGW S3website hostnames: " << std::accumulate(hostnames_s3website_set.begin(), hostnames_s3website_set.end(), s) << dendl;
   /* TODO: we should repeat the hostnames_set sanity check here

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1849,7 +1849,7 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO* cio)
     if (subdomain.empty()
         && (domain.empty() || domain != info.host)
         && !looks_like_ip_address(info.host.c_str())
-        && RGWHandler_REST::validate_bucket_name(info.host)) {
+        && RGWHandler_REST::validate_bucket_name(info.host) == 0) {
       subdomain.append(info.host);
       in_hosted_domain = 1;
     }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1846,10 +1846,12 @@ int RGWREST::preprocess(struct req_state *s, RGWClientIO* cio)
     // As additional checks:
     // - if the Host header is an IP, we're using path-style access without DNS
     // - Also check that the Host header is a valid bucket name before using it.
+    // - Don't enable virtual hosting if no hostnames are configured
     if (subdomain.empty()
         && (domain.empty() || domain != info.host)
         && !looks_like_ip_address(info.host.c_str())
-        && RGWHandler_REST::validate_bucket_name(info.host) == 0) {
+        && RGWHandler_REST::validate_bucket_name(info.host) == 0
+        && !(hostnames_set.empty() && hostnames_s3website_set.empty())) {
       subdomain.append(info.host);
       in_hosted_domain = 1;
     }


### PR DESCRIPTION
this brings back the fix from @robbat2 that was reverted in https://github.com/ceph/ceph/pull/10873, with an additional check that disables the virtual hosting feature if no hostnames were configured. this prevents default configurations (such as teuthology) from treating all requests as virtual hosted buckets

also updated the docs - a preview should eventually be available at http://docs.ceph.com/docs/wip-17440/radosgw/s3/commons/
