### PR TITLE
rgw: don't fail if lost race when setting acls

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3905,6 +3905,9 @@ void RGWPutACLs::execute()
     attrs[RGW_ATTR_ACL] = bl;
     op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);
   }
+  if (op_ret == -ECANCELED) {
+    op_ret = 0; /* lost a race, but it's ok because acls are immutable */
+  }
 }
 
 static void get_lc_oid(struct req_state *s, string& oid)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16930

When concurrently setting acls on object/bucket, we could lose in a race.
Instead of retry, just return success (same effect as if we won and then
other writer overwrote us).

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>