### PR TITLE
mds: fix a compiler warning about unused-variable

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9087,8 +9087,6 @@ void MDCache::request_cleanup(MDRequestRef& mdr)
   // remove from session
   mdr->item_session_request.remove_myself();
 
-  bool was_replay = mdr->client_request && mdr->client_request->is_replay();
-
   // remove from map
   active_requests.erase(mdr->reqid);
 


### PR DESCRIPTION
#11078 has removed the use of this variable, so remove it should be safe.

Signed-off-by: runsisi <runsisi@zte.com.cn>