### PR TITLE
rgw/swift: remove redundant assignment operation

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -387,9 +387,7 @@ static int encode_token(CephContext *cct, string& swift_user, string& key,
   utime_t expiration = ceph_clock_now(cct);
   expiration += cct->_conf->rgw_swift_token_expiration;
 
-  ret = build_token(swift_user, key, nonce, expiration, bl);
-
-  return ret;
+  return build_token(swift_user, key, nonce, expiration, bl);
 }
 
 


### PR DESCRIPTION
This is the clean-up commit extracted from #10411.