### PR TITLE
mon: preserve osd weight when marking osd out, then in

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -43,6 +43,10 @@
   If you had manually configured the mon to use rocksdb, this file should
   be created and filled with the string "rocksdb" (newline optional).
 
+* The 'osd out ...' and 'osd in ...' commands now preserve the OSD
+  weight.  Previously the mons would only preserve the weight if the
+  mon automatically marked and OSD out and then in, but not when an
+  admin did so explicitly.
 
 11.0.0
 ------

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1145,6 +1145,13 @@ function test_mon_osd()
   ceph osd dump | grep 'osd.0.*in'
   ceph osd find 0
 
+  # make sure mark out preserves weight
+  ceph osd reweight osd.0 .5
+  ceph osd dump | grep ^osd.0 | grep 'weight 0.5'
+  ceph osd out 0
+  ceph osd in 0
+  ceph osd dump | grep ^osd.0 | grep 'weight 0.5'
+
   f=$TEMP_DIR/map.$$
   ceph osd getcrushmap -o $f
   [ -s $f ]

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2171,7 +2171,6 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
     }
     wait_for_finished_proposal(op, new C_RetryMessage(this, op));
   } else if (pending_inc.new_up_client.count(from)) {
-    //FIXME: should this be using new_up_client?
     // already prepared, just wait
     dout(7) << __func__ << " already prepared, waiting on "
 	    << m->get_orig_source_addr() << dendl;


### PR DESCRIPTION
We already did this when the mon automatically marked an osd out and
then back in.  Do the same when the admin does it explicitly.
