### PR TITLE
os/bluestore: make cache settings process-wide

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -8,9 +8,13 @@ mkdir build
 cd build
 cmake $@ ..
 
+# minimal config to find plugins
 cat <<EOF > ceph.conf
 plugin dir = lib
 erasure code dir = lib
 EOF
+
+# give vstart a (hopefully) unique mon port to start with
+echo $(( RANDOM % 1000 + 40000 )) > .ceph_port
 
 echo done.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -990,7 +990,7 @@ OPTION(bluestore_extent_map_shard_min_size, OPT_U32, 150)
 OPTION(bluestore_extent_map_shard_target_size_slop, OPT_DOUBLE, .2)
 OPTION(bluestore_extent_map_inline_shard_prealloc_size, OPT_U32, 256)
 OPTION(bluestore_cache_type, OPT_STR, "2q")   // lru, 2q
-OPTION(bluestore_onode_cache_size, OPT_U32, 16*1024)
+OPTION(bluestore_onode_cache_size, OPT_U32, 4*1024)
 OPTION(bluestore_buffer_cache_size, OPT_U32, 512*1024*1024)
 OPTION(bluestore_shared_blob_hash_table_size_ratio, OPT_FLOAT, 2)  // multiple of onode_cache_size
 OPTION(bluestore_kvbackend, OPT_STR, "rocksdb")

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1695,7 +1695,7 @@ void BlueStore::ExtentMap::decode_some(bufferlist& bl)
   uint64_t prev_len = 0;
   unsigned n = 0;
   while (!p.end()) {
-    Extent *le = new Extent();
+    Extent *le = new Extent(onode->c->cache);
     uint64_t blobid;
     small_decode_varint(blobid, p);
     if ((blobid & BLOBID_FLAG_CONTIGUOUS) == 0) {
@@ -2441,6 +2441,10 @@ void BlueStore::_init_logger()
     "Sum for onode-lookups hit in the cache");
   b.add_u64(l_bluestore_onode_misses, "bluestore_onode_misses",
     "Sum for onode-lookups missed in the cache");
+  b.add_u64(l_bluestore_extents, "bluestore_extents",
+	    "Number of extents in cache");
+  b.add_u64(l_bluestore_blobs, "bluestore_blobs",
+	    "Number of blobs in cache");
   b.add_u64(l_bluestore_buffers, "bluestore_buffers",
 	    "Number of buffers in cache");
   b.add_u64(l_bluestore_buffer_bytes, "bluestore_buffer_bytes",
@@ -4525,12 +4529,17 @@ void BlueStore::_reap_collections()
 void BlueStore::_update_cache_logger()
 {
   uint64_t num_onodes = 0;
+  uint64_t num_extents = 0;
+  uint64_t num_blobs = 0;
   uint64_t num_buffers = 0;
   uint64_t num_buffer_bytes = 0;
   for (auto c : cache_shards) {
-    c->add_stats(&num_onodes, &num_buffers, &num_buffer_bytes);
+    c->add_stats(&num_onodes, &num_extents, &num_blobs,
+		 &num_buffers, &num_buffer_bytes);
   }
   logger->set(l_bluestore_onodes, num_onodes);
+  logger->set(l_bluestore_extents, num_extents);
+  logger->set(l_bluestore_blobs, num_blobs);
   logger->set(l_bluestore_buffers, num_buffers);
   logger->set(l_bluestore_buffer_bytes, num_buffer_bytes);
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1172,7 +1172,6 @@ ostream& operator<<(ostream& out, const BlueStore::SharedBlob& sb)
   out << "SharedBlob(" << &sb;
   if (sb.sbid) {
     out << " sbid 0x" << std::hex << sb.sbid << std::dec;
-    assert(sb.parent_set);
   }
   if (sb.loaded) {
     out << " loaded " << sb.shared_blob;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2422,7 +2422,7 @@ void BlueStore::_init_logger()
     "Sum for wal write op");
   b.add_u64(l_bluestore_wal_write_bytes, "wal_write_bytes",
     "Sum for wal write bytes");
-  b.add_u64(l_bluestore_write_penalty_read_ops, " write_penalty_read_ops",
+  b.add_u64(l_bluestore_write_penalty_read_ops, "write_penalty_read_ops",
     "Sum for write penalty read ops");
   b.add_u64(l_bluestore_allocated, "bluestore_allocated",
     "Sum for allocated bytes");

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1694,7 +1694,7 @@ void BlueStore::ExtentMap::decode_some(bufferlist& bl)
   uint64_t prev_len = 0;
   unsigned n = 0;
   while (!p.end()) {
-    Extent *le = new Extent(onode->c->cache);
+    Extent *le = new Extent();
     uint64_t blobid;
     small_decode_varint(blobid, p);
     if ((blobid & BLOBID_FLAG_CONTIGUOUS) == 0) {
@@ -1719,14 +1719,14 @@ void BlueStore::ExtentMap::decode_some(bufferlist& bl)
       le->blob_depth = 1;
     }
     if (blobid & BLOBID_FLAG_SPANNING) {
-      le->blob = get_spanning_blob(blobid >> BLOBID_SHIFT_BITS);
+      le->assign_blob(get_spanning_blob(blobid >> BLOBID_SHIFT_BITS));
     } else {
       blobid >>= BLOBID_SHIFT_BITS;
       if (blobid) {
-	le->blob = blobs[blobid - 1];
+	le->assign_blob(blobs[blobid - 1]);
 	assert(le->blob);
       } else {
-	le->blob = new Blob();
+	le->assign_blob(new Blob());
 	le->blob->decode(p);
 	blobs[n] = le->blob;
 	onode->c->open_shared_blob(le->blob);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -524,20 +524,23 @@ public:
     /// ctor for lookup only
     explicit Extent(uint32_t lo) : logical_offset(lo) { }
     /// ctor for delayed intitialization (see decode_some())
-    explicit Extent(Cache *cache) {
-      cache->add_extent();
+    explicit Extent() {
     }
     /// ctor for general usage
     Extent(uint32_t lo, uint32_t o, uint32_t l, uint8_t bd, BlobRef& b)
-      : logical_offset(lo), blob_offset(o), length(l), blob_depth(bd), blob(b) {
-      if (blob) {
-	blob->shared_blob->bc.cache->add_extent();
-      }
+      : logical_offset(lo), blob_offset(o), length(l), blob_depth(bd) {
+      assign_blob(b);
     }
     ~Extent() {
       if (blob) {
 	blob->shared_blob->bc.cache->rm_extent();
       }
+    }
+
+    void assign_blob(const BlobRef& b) {
+      assert(!blob);
+      blob = b;
+      blob->shared_blob->bc.cache->add_extent();
     }
 
     // comparators for intrusive_set

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -940,6 +940,8 @@ public:
       return false;
     }
 
+    void trim_cache();
+
     Collection(BlueStore *ns, Cache *ca, coll_t c);
   };
   typedef boost::intrusive_ptr<Collection> CollectionRef;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -13,6 +13,19 @@
 
 #include <sstream>
 
+#define _STR(x) #x
+#define STRINGIFY(x) _STR(x)
+
+TEST(bluestore, sizeof) {
+#define P(t) cout << STRINGIFY(t) << "\t" << sizeof(t) << std::endl
+  P(BlueStore::Onode);
+  P(BlueStore::Extent);
+  P(BlueStore::Blob);
+  P(BlueStore::SharedBlob);
+  P(bluestore_extent_ref_map_t);
+  P(bluestore_extent_ref_map_t::record_t);
+}
+
 TEST(bluestore_extent_ref_map_t, add)
 {
   bluestore_extent_ref_map_t m;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -669,8 +669,10 @@ TEST(Blob, put_ref)
 
 TEST(ExtentMap, find_lextent)
 {
+  BlueStore::LRUCache cache;
   BlueStore::ExtentMap em(nullptr);
   BlueStore::BlobRef br(new BlueStore::Blob);
+  br->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
 
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(100));
@@ -713,8 +715,10 @@ TEST(ExtentMap, find_lextent)
 
 TEST(ExtentMap, seek_lextent)
 {
+  BlueStore::LRUCache cache;
   BlueStore::ExtentMap em(nullptr);
   BlueStore::BlobRef br(new BlueStore::Blob);
+  br->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
 
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(100));
@@ -757,8 +761,10 @@ TEST(ExtentMap, seek_lextent)
 
 TEST(ExtentMap, has_any_lextents)
 {
+  BlueStore::LRUCache cache;
   BlueStore::ExtentMap em(nullptr);
   BlueStore::BlobRef b(new BlueStore::Blob);
+  b->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
 
   ASSERT_FALSE(em.has_any_lextents(0, 0));
   ASSERT_FALSE(em.has_any_lextents(0, 1000));
@@ -799,10 +805,14 @@ TEST(ExtentMap, has_any_lextents)
 
 TEST(ExtentMap, compress_extent_map)
 {
+  BlueStore::LRUCache cache;
   BlueStore::ExtentMap em(nullptr);
   BlueStore::BlobRef b1(new BlueStore::Blob);
   BlueStore::BlobRef b2(new BlueStore::Blob);
   BlueStore::BlobRef b3(new BlueStore::Blob);
+  b1->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
+  b2->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
+  b3->shared_blob = new BlueStore::SharedBlob(-1, string(), &cache);
 
   em.extent_map.insert(*new BlueStore::Extent(0, 0, 100, 1, b1));
   em.extent_map.insert(*new BlueStore::Extent(100, 0, 100, 1, b2));


### PR DESCRIPTION
...and a bunch of other stuff, including instrumenting cache onodes, extents, blobs, buffers, bytes.
