### PR TITLE
mgr/MgrClient: fix ms_handle_reset

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -166,7 +166,7 @@ bool MgrClient::ms_handle_reset(Connection *con)
   }
   return false;
 #else
-  return true;
+  return false;
 #endif
 }
 


### PR DESCRIPTION
Return false because we don't handle the reset.

Signed-off-by: Sage Weil <sage@redhat.com>