### PR TITLE
os/bluestore: fix onode cache addition race

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -874,7 +874,7 @@ public:
       clear();
     }
 
-    void add(const ghobject_t& oid, OnodeRef o);
+    OnodeRef add(const ghobject_t& oid, OnodeRef o);
     OnodeRef lookup(const ghobject_t& o);
     void rename(OnodeRef& o, const ghobject_t& old_oid,
 		const ghobject_t& new_oid,


### PR DESCRIPTION
Two threads may try to add the same onode to the cache.
This is rare, but allowed (in the case of the meta
collection).  If that happens, one of them will just
back off and use the winning onode ref.

Signed-off-by: Sage Weil <sage@redhat.com>