### PR TITLE
os/bluestore: allow default to buffered write

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1020,6 +1020,7 @@ OPTION(bluestore_overlay_max_length, OPT_INT, 65536)
 OPTION(bluestore_overlay_max, OPT_INT, 0)
 OPTION(bluestore_clone_cow, OPT_BOOL, false)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL, true)
+OPTION(bluestore_default_buffered_write, OPT_BOOL, false)
 OPTION(bluestore_debug_misc, OPT_BOOL, false)
 OPTION(bluestore_debug_no_reuse_blocks, OPT_BOOL, false)
 OPTION(bluestore_debug_small_allocations, OPT_INT, 0)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7845,6 +7845,11 @@ int BlueStore::_do_write(
   if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
     dout(20) << __func__ << " will do buffered write" << dendl;
     wctx.buffered = true;
+  } else if (g_conf->bluestore_default_buffered_write &&
+	     (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+			       CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
+    dout(20) << __func__ << " defaulting to buffered write" << dendl;
+    wctx.buffered = true;
   }
 
   // FIXME: Using the MAX of the block_size_order and preferred_csum_order

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -4207,6 +4207,8 @@ TEST_P(StoreTest, SyntheticMatrixSharding) {
     { "bluestore_extent_map_shard_min_size", "60", 0 },
     { "bluestore_extent_map_shard_max_size", "300", 0 },
     { "bluestore_extent_map_shard_target_size", "150", 0 },
+    { "bluestore_default_buffered_read", "true", 0 },
+    { "bluestore_default_buffered_write", "true", 0 },
     { 0 },
   };
   do_matrix(m, store);
@@ -4272,6 +4274,7 @@ TEST_P(StoreTest, SyntheticMatrixCsumAlgorithm) {
     { "bluestore_min_alloc_size", "65536", 0 },
     { "bluestore_csum_type", "crc32c", "crc32c_16", "crc32c_8", "xxhash32",
       "xxhash64", "none", 0 },
+    { "bluestore_default_buffered_write", "false", 0 },
     { 0 },
   };
   do_matrix(m, store);
@@ -4290,6 +4293,7 @@ TEST_P(StoreTest, SyntheticMatrixCsumVsCompression) {
     { "bluestore_compression_algorithm", "snappy", "zlib", 0 },
     { "bluestore_csum_type", "crc32c", 0 },
     { "bluestore_default_buffered_read", "true", "false", 0 },
+    { "bluestore_default_buffered_write", "true", "false", 0 },
     { 0 },
   };
   do_matrix(m, store);
@@ -4305,6 +4309,7 @@ TEST_P(StoreTest, SyntheticMatrixCompression) {
     { "alignment", "65536", 0 },
     { "bluestore_min_alloc_size", "4096", "65536", 0 },
     { "bluestore_compression", "force", "aggressive", "passive", "none", 0},
+    { "bluestore_default_buffered_write", "false", 0 },
     { 0 },
   };
   do_matrix(m, store);
@@ -4320,6 +4325,7 @@ TEST_P(StoreTest, SyntheticMatrixCompressionAlgorithm) {
     { "alignment", "65536", 0 },
     { "bluestore_compression_algorithm", "zlib", "snappy", 0 },
     { "bluestore_compression", "force", 0 },
+    { "bluestore_default_buffered_write", "false", 0 },
     { 0 },
   };
   do_matrix(m, store);
@@ -4338,6 +4344,7 @@ TEST_P(StoreTest, SyntheticMatrixNoCsum) {
     { "bluestore_compression", "force", "none", 0},
     { "bluestore_csum_type", "none", 0},
     { "bluestore_default_buffered_read", "true", "false", 0 },
+    { "bluestore_default_buffered_write", "true", 0 },
     { 0 },
   };
   do_matrix(m, store);


### PR DESCRIPTION
This adds a tunable, but doesn't change default behavior. We need to test more first.