### PR TITLE
os/bluestore: optimize intrusive sets for size.

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -405,7 +405,7 @@ public:
   };
 
   /// in-memory blob metadata and associated cached buffers (if any)
-  struct Blob : public boost::intrusive::set_base_hook<> {
+  struct Blob : public boost::intrusive::set_base_hook<boost::intrusive::optimize_size<true>> {
     std::atomic_int nref = {0};     ///< reference count
     int id = -1;                    ///< id, for spanning blobs only, >= 0
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
@@ -514,7 +514,7 @@ public:
   typedef boost::intrusive::set<Blob> blob_map_t;
 
   /// a logical extent, pointing to (some portion of) a blob
-  struct Extent : public boost::intrusive::set_base_hook<> {
+  struct Extent : public boost::intrusive::set_base_hook<boost::intrusive::optimize_size<true>> {
     uint32_t logical_offset = 0;      ///< logical offset
     uint32_t blob_offset = 0;         ///< blob offset
     uint32_t length = 0;              ///< length


### PR DESCRIPTION
This saves us 8 bytes per structure that uses set_base_hook.  Performance may be lower or higher depending on memory locality, the cost of masking operations, and memory saved potentially allowing for more cached onodes.

Signed-off-by: Mark Nelson <mnelson@redhat.com>