### PR TITLE
jewel: rgw: Do not archive metadata by default

### DIFF
--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -830,6 +830,10 @@ int RGWMetadataManager::store_in_heap(RGWMetadataHandler *handler, const string&
 
   rgw_bucket heap_pool(store->get_zone_params().metadata_heap);
 
+  if (heap_pool.name.empty()) {
+    return 0;
+  }
+
   RGWObjVersionTracker otracker;
   otracker.write_version = objv_tracker->write_version;
   string oid = heap_oid(handler, key, objv_tracker->write_version);
@@ -851,6 +855,10 @@ int RGWMetadataManager::remove_from_heap(RGWMetadataHandler *handler, const stri
   }
 
   rgw_bucket heap_pool(store->get_zone_params().metadata_heap);
+
+  if (heap_pool.name.empty()) {
+    return 0;
+  }
 
   string oid = heap_oid(handler, key, objv_tracker->write_version);
   rgw_obj obj(heap_pool, oid);
@@ -886,6 +894,7 @@ int RGWMetadataManager::put_entry(RGWMetadataHandler *handler, const string& key
   ret = rgw_put_system_obj(store, bucket, oid,
                            bl.c_str(), bl.length(), exclusive,
                            objv_tracker, mtime, pattrs);
+
   if (ret < 0) {
     int r = remove_from_heap(handler, key, objv_tracker);
     if (r < 0) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1466,7 +1466,9 @@ int RGWZoneParams::fix_pool_names()
   }
 
   domain_root = fix_zone_pool_name(pool_names, name, ".rgw.data.root", domain_root.name);
-  metadata_heap = fix_zone_pool_name(pool_names, name, ".rgw.meta", metadata_heap.name);
+  if (!metadata_heap.name.empty()) {
+    metadata_heap = fix_zone_pool_name(pool_names, name, ".rgw.meta", metadata_heap.name);
+  }
   control_pool = fix_zone_pool_name(pool_names, name, ".rgw.control", control_pool.name);
   gc_pool = fix_zone_pool_name(pool_names, name ,".rgw.gc", gc_pool.name);
   log_pool = fix_zone_pool_name(pool_names, name, ".rgw.log", log_pool.name);
@@ -3333,11 +3335,6 @@ int RGWRados::replace_region_with_zonegroup()
       ldout(cct, 0) << __func__ << ": error initializing default zone params: " << cpp_strerror(-ret) << dendl;
       return ret;
     }
-    /* default zone is missing meta_heap */
-    if (ret != -ENOENT && zoneparams.metadata_heap.name.empty()) {
-      zoneparams.metadata_heap = ".rgw.meta";
-      return zoneparams.update();
-    }
     /* update master zone */
     RGWZoneGroup default_zg(default_zonegroup_name);
     ret = default_zg.init(cct, this);
@@ -3448,9 +3445,6 @@ int RGWRados::replace_region_with_zonegroup()
       if (ret < 0) {
         ldout(cct, 0) << "failed to init zoneparams  " << iter->first <<  ": " << cpp_strerror(-ret) << dendl;
         return ret;
-      }
-      if (zoneparams.metadata_heap.name.empty()) {
-	zoneparams.metadata_heap = ".rgw.meta";
       }
       zonegroup.realm_id = realm.get_id();
       ret = zoneparams.update();


### PR DESCRIPTION
http://tracker.ceph.com/issues/17339

commit a4a9f3019022e07271cf03747a54927169a29527
Author: root <root@ceph-node1.homeoffice.wal-mart.com>
Date:   Mon Sep 12 14:30:43 2016 +0530

    rgw: Do not archive metadata by default
    
    Fixes: http://tracker.ceph.com/issues/17256
    Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>
    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
