### PR TITLE
rgw: dump objects in RGWBucket::check_object_index()

### DIFF
--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -277,7 +277,8 @@ public:
           list<rgw_obj_key>& objs_to_unlink, std::string *err_msg = NULL);
 
   int check_object_index(RGWBucketAdminOpState& op_state,
-          map<string, RGWObjEnt> result, std::string *err_msg = NULL);
+                         RGWFormatterFlusher& flusher,
+                         std::string *err_msg = NULL);
 
   int check_index(RGWBucketAdminOpState& op_state,
           map<RGWObjCategory, RGWStorageStats>& existing_stats,


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/14589

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>