### PR TITLE
rgw: remove unused variable "ostr" in rgw_b64.h and fix the comment

### DIFF
--- a/src/rgw/rgw_b64.h
+++ b/src/rgw/rgw_b64.h
@@ -28,8 +28,7 @@ namespace rgw {
   inline std::string to_base64(boost::string_ref sref)
   {
     using namespace boost::archive::iterators;
-    std::string ostr;
-    
+
     // output must be =padded modulo 3
     auto psize = sref.size();
     while ((psize % 3) != 0) {
@@ -52,7 +51,7 @@ namespace rgw {
     std::string outstr(b64_iter(sref.data()),
 		       b64_iter(sref.data() + sref.size()));
 
-    // pad ostr with '=' to a length that is a multiple of 3
+    // pad outstr with '=' to a length that is a multiple of 3
     for (size_t ix = 0; ix < (psize-sref.size()); ++ix)
       outstr.push_back('=');
 


### PR DESCRIPTION
ostr is no needed as outstr is used in the following code.
Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>