### PR TITLE
make-dist: set rpm_release correctly for release builds

### DIFF
--- a/make-dist
+++ b/make-dist
@@ -35,8 +35,13 @@ bin/git-archive-all.sh --prefix ceph-$version/ \
 echo "including src/.git_version, src/ceph_ver.h, ceph.spec"
 src/make_version -g src/.git_version -c src/ceph_ver.h
 
-rpm_version=`echo $version | cut -d - -f 1-1`
-rpm_release=`echo $version | cut -d - -f 2- | sed 's/-/./'`
+if expr index $version '-' > /dev/null; then
+	rpm_version=`echo $version | cut -d - -f 1-1`
+	rpm_release=`echo $version | cut -d - -f 2- | sed 's/-/./'`
+else
+	rpm_version=$version
+	rpm_release=0
+fi
 
 cat ceph.spec.in | \
     sed "s/@VERSION@/$rpm_version/g" | \


### PR DESCRIPTION
Similar to autobuild-ceph 17591db, only try to set rpm_release if there
is a release part to the git describe output (i.e. if it's not at a
version tag)

Signed-off-by: Dan Mick <dan.mick@redhat.com>