### PR TITLE
mon/PGMap: PGs can be stuck more than one thing

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1046,20 +1046,23 @@ bool PGMap::get_stuck_counts(const utime_t cutoff, map<string, int>& note) const
   for (ceph::unordered_map<pg_t, pg_stat_t>::const_iterator i = pg_stat.begin();
        i != pg_stat.end();
        ++i) {
-
     if (! (i->second.state & PG_STATE_ACTIVE)) {
       if (i->second.last_active < cutoff)
         ++inactive;
-    } else if (! (i->second.state & PG_STATE_CLEAN)) {
+    }
+    if (! (i->second.state & PG_STATE_CLEAN)) {
       if (i->second.last_clean < cutoff)
         ++unclean;
-    } else if (i->second.state & PG_STATE_DEGRADED) {
+    }
+    if (i->second.state & PG_STATE_DEGRADED) {
       if (i->second.last_undegraded < cutoff)
         ++degraded;
-    } else if (i->second.state & PG_STATE_UNDERSIZED) {
+    }
+    if (i->second.state & PG_STATE_UNDERSIZED) {
       if (i->second.last_fullsized < cutoff)
         ++undersized;
-    } else if (i->second.state & PG_STATE_STALE) {
+    }
+    if (i->second.state & PG_STATE_STALE) {
       if (i->second.last_unstale < cutoff)
         ++stale;
     }


### PR DESCRIPTION
This was inadvertantly changed waaay back in
9c95bb0454dbad781b6655f4c7116620005101f7.

This fixes the health warnings so that they are
complete and (most importantly) consistent with the
results of 'pg dump_stuck ...'.

Signed-off-by: Sage Weil <sage@redhat.com>