### PR TITLE
Update version of civetweb to 1.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,12 @@ option(DEBUG_GATHER "C_Gather debugging is enabled" ON)
 option(HAVE_LIBZFS "LibZFS is enabled" OFF)
 option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
+# we want to include civetweb.h as "civetweb/civetweb.h".  Make it so.
+execute_process(
+COMMAND rm -f "${CMAKE_BINARY_DIR}/src/include/civetweb"
+COMMAND mkdir -p "${CMAKE_BINARY_DIR}/src/include"
+COMMAND ln -s "${CMAKE_SOURCE_DIR}/src/civetweb/include"
+        "${CMAKE_BINARY_DIR}/src/include/civetweb")
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -855,6 +855,8 @@ if(WITH_RADOSGW)
   add_library(civetweb_common_objs OBJECT ${civetweb_common_files})
   target_include_directories(civetweb_common_objs PUBLIC
 	"${CMAKE_SOURCE_DIR}/src/civetweb/include")
+  set_property(TARGET civetweb_common_objs
+    APPEND PROPERTY COMPILE_DEFINITIONS USE_IPV6=1)
   if(HAVE_SSL)
     set_property(TARGET civetweb_common_objs
       APPEND PROPERTY COMPILE_DEFINITIONS NO_SSL_DL=1)

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -60,14 +60,14 @@ size_t RGWCivetWeb::complete_request()
 void RGWCivetWeb::init_env(CephContext *cct)
 {
   env.init(cct);
-  struct mg_request_info* const info = mg_get_request_info(conn);
+  const struct mg_request_info* info = mg_get_request_info(conn);
 
   if (! info) {
     return;
   }
 
   for (int i = 0; i < info->num_headers; i++) {
-    struct mg_request_info::mg_header* const header = &info->http_headers[i];
+    const struct mg_request_info::mg_header* header = &info->http_headers[i];
     const boost::string_ref name(header->name);
     const auto& value = header->value;
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -13,7 +13,7 @@
 
 static int civetweb_callback(struct mg_connection* conn)
 {
-  struct mg_request_info* const req_info = mg_get_request_info(conn);
+  const struct mg_request_info* const req_info = mg_get_request_info(conn);
   return static_cast<RGWCivetWebFrontend *>(req_info->user_data)->process(conn);
 }
 
@@ -51,6 +51,8 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "decode_url", "no");
   set_conf_default(conf_map, "enable_keep_alive", "yes");
   conf_map["listening_ports"] = conf->get_val("port", "80");
+  set_conf_default(conf_map, "validate_http_method", "no");
+  set_conf_default(conf_map, "canonicalize_url_path", "no");
 
   /* Set run_as_user. This will cause civetweb to invoke setuid() and setgid()
    * based on pw_uid and pw_gid obtained from pw_name. */


### PR DESCRIPTION
a simpler, less intusive change than the one in the other two PRs. This one only deals with:
- change the submodule to the version created by Pritha that is based on civetweb 1.8 + rgw related changes broken down to multiple commits
- update rgw code to support the previous change
- add USE_IPV6=1 when compiling civetweb

IMO all other changes if needed can be done on a separate commit.
