### PR TITLE
messages: fix out of range assertion

### DIFF
--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -32,7 +32,7 @@ class CephContext;
 class PerfCountersBuilder;
 class PerfCountersCollectionTest;
 
-enum perfcounter_type_d
+enum perfcounter_type_d : uint8_t
 {
   PERFCOUNTER_NONE = 0,
   PERFCOUNTER_TIME = 0x1,

--- a/src/messages/MMgrReport.h
+++ b/src/messages/MMgrReport.h
@@ -36,7 +36,7 @@ public:
     ::encode(path, bl);
     ::encode(description, bl);
     ::encode(nick, bl);
-    assert(type < 256);
+    static_assert(sizeof(type) == 1, "perfcounter_type_d must be one byte");
     ::encode((uint8_t)type, bl);
     ENCODE_FINISH(bl);
   }


### PR DESCRIPTION
clang detects that this is invalid (presumably
using an 8 bit type for the enum)

Signed-off-by: John Spray <john.spray@redhat.com>