### PR TITLE
client: add pid to metadata

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1941,6 +1941,8 @@ void Client::populate_metadata()
     ldout(cct, 1) << __func__ << " failed to read hostname (" << cpp_strerror(r) << ")" << dendl;
   }
 
+  metadata["pid"] = stringify(getpid());
+
   // Ceph entity id (the '0' in "client.0")
   metadata["entity_id"] = cct->_conf->name.get_id();
 


### PR DESCRIPTION
This allows us to distinguish multiple clients on a machine.

Fixes: http://tracker.ceph.com/issues/17276

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>