### PR TITLE
auth: tolerate missing mgr keys

### DIFF
--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -74,7 +74,11 @@ int CephxClientHandler::build_request(bufferlist& bl) const
     return 0;
   }
 
-  if (need) {
+  // do not bother (re)requesting tickets if we *only* need the MGR
+  // ticket; that can happen during an upgrade and we want to avoid a
+  // loop.  we'll end up re-requesting it later when the secrets
+  // rotating.
+  if (need && need != CEPH_ENTITY_TYPE_MGR) {
     /* get service tickets */
     ldout(cct, 10) << "get service keys: want=" << want << " need=" << need << " have=" << have << dendl;
 

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -163,18 +163,31 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
 
       ret = 0;
       vector<CephXSessionAuthInfo> info_vec;
-      for (uint32_t service_id = 1; service_id <= ticket_req.keys; service_id <<= 1) {
+      int found_services = 0;
+      int service_err = 0;
+      for (uint32_t service_id = 1; service_id <= ticket_req.keys;
+	   service_id <<= 1) {
         if (ticket_req.keys & service_id) {
-	  ldout(cct, 10) << " adding key for service " << ceph_entity_type_name(service_id) << dendl;
+	  ldout(cct, 10) << " adding key for service "
+			 << ceph_entity_type_name(service_id) << dendl;
           CephXSessionAuthInfo info;
-          int r = key_server->build_session_auth_info(service_id, auth_ticket_info, info);
+          int r = key_server->build_session_auth_info(service_id,
+						      auth_ticket_info, info);
+	  // tolerate missing MGR rotating key for the purposes of upgrades.
           if (r < 0) {
-            ret = r;
-            break;
-          }
+	    ldout(cct, 10) << "   missing key for service "
+			   << ceph_entity_type_name(service_id) << dendl;
+	    service_err = r;
+	    continue;
+	  }
           info.validity += cct->_conf->auth_service_ticket_ttl;
           info_vec.push_back(info);
+	  ++found_services;
         }
+      }
+      if (!found_services && service_err) {
+	ldout(cct, 10) << __func__ << " did not find any service keys" << dendl;
+	ret = service_err;
       }
       CryptoKey no_key;
       build_cephx_response_header(cephx_header.request_type, ret, result_bl);


### PR DESCRIPTION
During upgrade we won't (yet) have mgr keys.  Tolerate this case
and let the client stumble along without them.

This is imperfect (the auth client sends an additional key request and gets EINVAL; not sure why) but the client behaves fine despite it, and it makes the upgrade tests pass.