### PR TITLE
rbd/cls_rbd: silence compiler warnings

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1496,7 +1496,7 @@ int get_data_pool(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   CLS_LOG(20, "get_data_pool");
 
-  int64_t data_pool_id;
+  int64_t data_pool_id = -1;
   int r = read_key(hctx, "data_pool_id", &data_pool_id);
   if (r == -ENOENT) {
     data_pool_id = -1;


### PR DESCRIPTION
As below:
```
[ 15%] Building CXX object src/test/librbd/CMakeFiles/rbd_test.dir/test_fixture.cc.o
In file included from /home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc:42:0:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc: In function ‘int set_features(cls_method_context_t, ceph::bufferlist*, ceph::bufferlist*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/objclass/objclass.h:35:72: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 5 has type ‘long long unsigned int’ [-Wformat=]
   cls_log(level, "<cls> %s:%d: " fmt, __FILE__, __LINE__, ##__VA_ARGS__)
                                                                        ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/objclass/objclass.h:36:27: note: in expansion of macro ‘CLS_LOG’
 #define CLS_ERR(fmt, ...) CLS_LOG(0, fmt, ##__VA_ARGS__)
                           ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc:443:5: note: in expansion of macro ‘CLS_ERR’
     CLS_ERR("Attempting to enable immutable feature: %" PRIu64,
     ^
Linking CXX shared library ../../lib/libcls_journal.so
[ 15%] Built target cls_journal
Scanning dependencies of target rbd_test_mock

[ 15%] Building CXX object src/test/librbd/CMakeFiles/rbd_test_mock.dir/mock/MockImageCtx.cc.o
  CC       db/compaction_iterator.o
[ 15%] Building CXX object src/test/librados_test_stub/CMakeFiles/rados_test_stub.dir/TestClassHandler.cc.o
  CC       db/compaction_job.o
[ 15%] Building CXX object src/test/librados_test_stub/CMakeFiles/rados_test_stub.dir/TestIoCtxImpl.cc.o
Linking CXX static library ../../../lib/libjournal_test_mock.a
[ 15%] Built target journal_test_mock
Scanning dependencies of target rbd_api
[ 15%] Building CXX object src/librbd/CMakeFiles/rbd_api.dir/librbd.cc.o
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc: In function ‘int get_data_pool(cls_method_context_t, ceph::bufferlist*, ceph::bufferlist*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc:1499:11: warning: ‘data_pool_id’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   int64_t data_pool_id;
           ^
```
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>