### PR TITLE
osd: Remove unused '_lsb_release_' declarations

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2133,8 +2133,6 @@ protected:
   void _preboot(epoch_t oldest, epoch_t newest);
   void _send_boot();
   void _collect_metadata(map<string,string> *pmeta);
-  bool _lsb_release_set(char *buf, const char *str, map<string,string> *pm, const char *key);
-  void _lsb_release_parse (map<string,string> *pm);
 
   void start_waiting_for_healthy();
   bool _is_healthy();


### PR DESCRIPTION
_lsb_release_set and _lsb_release_parse declarations still exist despite their
definitions being removed some time ago.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>