### PR TITLE
os/bluestore: simplify blob status checking for small writes

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7265,7 +7265,8 @@ void BlueStore::_do_write_small(
   if (ep != o->extent_map.extent_map.begin()) {
     --ep;
     b = ep->blob;
-    if (ep->logical_offset - ep->blob_offset + b->get_blob().get_ondisk_length() <= offset) {
+    if (ep->logical_offset - ep->blob_offset +
+      b->get_blob().get_ondisk_length() <= offset) {
       ++ep;
     }
   }
@@ -7274,7 +7275,7 @@ void BlueStore::_do_write_small(
       break;
     }
     b = ep->blob;
-    if (!b->get_blob().is_mutable() || b->get_blob().is_compressed()) {
+    if (!b->get_blob().is_mutable()) {
       dout(20) << __func__ << " ignoring immutable " << *b << dendl;
       ++ep;
       continue;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -30,6 +30,7 @@
 #include "FreelistManager.h"
 #include "BlueFS.h"
 #include "BlueRocksEnv.h"
+#include "auth/Crypto.h"
 
 #define dout_subsys ceph_subsys_bluestore
 
@@ -3829,11 +3830,10 @@ int BlueStore::mkfs()
     unsigned n = g_conf->bluestore_precondition_bluefs /
       g_conf->bluestore_precondition_bluefs_block;
     bufferlist bl;
-    bufferptr bp(g_conf->bluestore_precondition_bluefs_block);
-    for (unsigned i=0; i < g_conf->bluestore_precondition_bluefs_block; ++i) {
-      bp[i] = rand();
-    }
-    bl.append(bp);
+    int len = g_conf->bluestore_precondition_bluefs_block;
+    char buf[len];
+    get_random_bytes(buf, len);
+    bl.append(buf, len);
     string key1("a");
     string key2("b");
     for (unsigned i=0; i < n; ++i) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -240,6 +240,7 @@ public:
       _rm_buffer(buffer_map.find(b->offset));
     }
     void _rm_buffer(map<uint64_t,std::unique_ptr<Buffer>>::iterator p) {
+      assert(p != buffer_map.end());
       cache->_audit("_rm_buffer start");
       if (p->second->is_writing()) {
         writing.erase(writing.iterator_to(*p->second));

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -321,7 +321,7 @@ public:
     std::atomic_int nref = {0}; ///< reference count
 
     // these are defined/set if the shared_blob is 'loaded'
-    bool loaded = false;        ///< whether shared_blob_t is loaded
+    bool loaded = false;        ///< whether shared_blob is loaded
     bluestore_shared_blob_t shared_blob; ///< the actual shared state
 
     // these are defined/set if the blob is marked 'shared'
@@ -515,7 +515,7 @@ public:
     uint32_t logical_offset = 0;      ///< logical offset
     uint32_t blob_offset = 0;         ///< blob offset
     uint32_t length = 0;              ///< length
-    uint8_t  blob_depth = 0;          /// blob overlapping count
+    uint8_t  blob_depth = 0;          ///< blob overlapping count
     BlobRef blob;                     ///< the blob with our data
 
     /// ctor for lookup only


### PR DESCRIPTION
If a blob is marked as compressed and still mutable, something is wrong.
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>