### PR TITLE
jewel: rgw: fix a bug in quota check. 

### DIFF
--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -737,9 +737,7 @@ public:
       ret = check_quota("bucket", bucket_quota, bucket_stats, num_objs, size_kb);
       if (ret < 0)
         return ret;
-    }
-
-    if (def_bucket_quota.enabled) {
+    } else if (def_bucket_quota.enabled) {
       ret = check_quota("def_bucket", def_bucket_quota, bucket_stats, num_objs, size_kb);
       if (ret < 0)
         return ret;


### PR DESCRIPTION
Default bucket quota shouldn't be checked if user's bucket quota is enabled. If checked, and default bucket quota's value is less than user's bucket quota's value, the quota check
may fail, which is not right.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>