### PR TITLE
os/bluestore: drop inline_dirty from struct ExtentMap

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1243,7 +1243,6 @@ ostream& operator<<(ostream& out, const BlueStore::Blob& b)
 
 void BlueStore::Blob::discard_unallocated()
 {
-  size_t pos = 0;
   if (blob.is_compressed()) {
     bool discard = false;
     bool all_invalid = true;
@@ -1260,6 +1259,7 @@ void BlueStore::Blob::discard_unallocated()
       shared_blob->bc.discard(0, blob.get_compressed_payload_original_length());
     }
   } else {
+    size_t pos = 0;
     for (auto e : blob.extents) {
       if (!e.is_valid()) {
         shared_blob->bc.discard(pos, e.length);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -585,21 +585,6 @@ void BlueStore::LRUCache::_audit(const char *when)
     dout(20) << __func__ << " " << when << " buffer_size " << buffer_size
 	     << " ok" << dendl;
   }
-  if (false) {
-    uint64_t lc = 0, oc = 0;
-    set<OnodeSpace*> spaces;
-    for (auto i = onode_lru.begin(); i != onode_lru.end(); ++i) {
-      assert(i->space->onode_map.count(i->oid));
-      if (spaces.count(i->space) == 0) {
-	spaces.insert(i->space);
-	oc += i->space->onode_map.size();
-      }
-      ++lc;
-    }
-    if (lc != oc) {
-      derr << " lc " << lc << " oc " << oc << dendl;
-    }
-  }
 }
 #endif
 
@@ -876,24 +861,6 @@ void BlueStore::TwoQCache::_audit(const char *when)
 
     dout(20) << __func__ << " " << when << " buffer_bytes " << buffer_bytes
 	     << " ok" << dendl;
-  }
-
-  if (false) {
-    uint64_t lc = 0, oc = 0;
-    set<OnodeSpace*> spaces;
-
-    for (auto i = onode_lru.begin(); i != onode_lru.end(); ++i) {
-      assert(i->space->onode_map.count(i->oid));
-      if (spaces.count(i->space) == 0) {
-	spaces.insert(i->space);
-	oc += i->space->onode_map.size();
-      }
-      ++lc;
-    }
-
-    if (lc != oc) {
-      derr << " lc " << lc << " oc " << oc << dendl;
-    }
   }
 }
 #endif
@@ -1808,20 +1775,11 @@ bool BlueStore::ExtentMap::encode_some(uint32_t offset, uint32_t length,
       p->blob->encode(bl);
     }
   }
-  /*
-  derr << __func__ << ":";
-  bl.hexdump(*_dout);
-  *_dout << dendl;
-  */
   return false;
 }
 
 void BlueStore::ExtentMap::decode_some(bufferlist& bl)
 {
-/*  derr << __func__ << ":";
-  bl.hexdump(*_dout);
-  *_dout << dendl;
-  */
   bufferlist::iterator p = bl.begin();
   uint32_t num;
   small_decode_varint(num, p);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2601,6 +2601,7 @@ void BlueStore::_init_logger()
   b.add_u64(l_bluestore_txc, "bluestore_txc", "Transactions committed");
   b.add_u64(l_bluestore_onode_reshard, "bluestore_onode_reshard",
 	    "Onode extent map reshard events");
+  b.add_u64(l_bluestore_gc, "bluestore_gc", "Sum for garbage collection reads");
   b.add_u64(l_bluestore_gc_bytes, "bluestore_gc_bytes", "garbage collected bytes");
   logger = b.create_perf_counters();
   g_ceph_context->get_perfcounters_collection()->add(logger);
@@ -7882,6 +7883,7 @@ int BlueStore::_do_write(
         o->extent_map.fault_range(db, gc_start_offset, read_len);
         _do_write_data(txc, c, o, gc_start_offset, read_len, head_bl, &wctx);
       }
+      logger->inc(l_bluestore_gc);
       logger->inc(l_bluestore_gc_bytes, read_len);
     }
 
@@ -7898,6 +7900,7 @@ int BlueStore::_do_write(
         o->extent_map.fault_range(db, end, read_len);
         _do_write_data(txc, c, o, end, read_len, tail_bl, &wctx);
       }
+      logger->inc(l_bluestore_gc);
       logger->inc(l_bluestore_gc_bytes, read_len);
     }
   }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -588,7 +588,6 @@ public:
     };
     vector<Shard> shards;    ///< shards
 
-    bool inline_dirty = false;
     bufferlist inline_bl;    ///< cached encoded map, if unsharded; empty=>dirty
 
     ExtentMap(Onode *o);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -92,6 +92,7 @@ enum {
   l_bluestore_write_small_new,
   l_bluestore_txc,
   l_bluestore_onode_reshard,
+  l_bluestore_gc,
   l_bluestore_gc_bytes,
   l_bluestore_last
 };

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -296,7 +296,7 @@ struct bluestore_blob_t {
 
   int estimate_encoded_size() const {
     // conservative upper bound... fixme
-    return csum_data.length() + extents.size() * 16 + 48;
+    return csum_data.length() + extents.size() * 16 + 24;
   }
 
   bool can_split() const {


### PR DESCRIPTION
We don't need this member as we can simply clear inline_bl
to mark it as dirty.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>