### PR TITLE
tools/ceph_monstore_tool: hint when caps is empty

### DIFF
--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -532,6 +532,10 @@ static int update_auth(MonitorDBStore& st, const string& keyring_path)
     KeyServerData::Incremental auth_inc;
     auth_inc.name = k.first;
     auth_inc.auth = k.second;
+    if (auth_inc.auth.caps.empty()) {
+      cerr << "no caps granted to: " << auth_inc.name << std::endl;
+      return -EINVAL;
+    }
     auth_inc.op = KeyServerData::AUTH_INC_ADD;
 
     AuthMonitor::Incremental inc;


### PR DESCRIPTION
client.admin lack of caps after rebuild,add hint it.
as follow:
caps: [mds] allow *
caps: [mon] allow *
caps: [osd] allow *

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>