### PR TITLE
test_subman.sh: Don't use --tmpdir

### DIFF
--- a/src/test/test_subman.sh
+++ b/src/test/test_subman.sh
@@ -2,7 +2,7 @@
 
 source $(dirname $0)/detect-build-env-vars.sh
 
-TMP=$(mktemp --tmpdir -d)
+TMP=$(mktemp -d)
 trap "rm -fr $TMP" EXIT
 
 export PATH=$TMP:$PATH


### PR DESCRIPTION
test_subman.sh: Don't use --tmpdir since on most Linux-is it is consideren default
when creating a directory:
`If TEMPLATE is not specified, use tmp.XXXXXXXXXX, and --tmpdir is implied.`

And on FreeBSD --tmpdir is not available anyways.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>
