### PR TITLE
AArch64: Detect crc32 extension support from assembler

### DIFF
--- a/cmake/modules/SIMDExt.cmake
+++ b/cmake/modules/SIMDExt.cmake
@@ -16,9 +16,20 @@
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
   set(HAVE_ARM 1) 
-  CHECK_C_COMPILER_FLAG(-march=armv8-a+crc HAVE_ARMV8_CRC)
+  set(save_quiet ${CMAKE_REQUIRED_QUIET})
+  set(CMAKE_REQUIRED_QUIET true)
+  include(CheckCXXSourceCompiles)
+  check_cxx_source_compiles("
+    #define CRC32CX(crc, value) __asm__(\"crc32cx %w[c], %w[c], %x[v]\":[c]\"+r\"(crc):[v]\"r\"(value))
+    asm(\".arch_extension crc\");
+    unsigned int foo(unsigned int ret) {
+      CRC32CX(ret, 0);
+      return ret;
+    }
+    int main() { foo(0); }" HAVE_ARMV8_CRC)
+  set(CMAKE_REQUIRED_QUIET ${save_quiet})
   if(HAVE_ARMV8_CRC)
-    set(ARM_CRC_FLAGS "-march=armv8-a+crc")
+    message(STATUS " aarch64 crc extensions supported")
   endif()
   CHECK_C_COMPILER_FLAG(-march=armv8-a+simd HAVE_ARMV8_SIMD)
   if(HAVE_ARMV8_SIMD)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -488,7 +488,6 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
 include(SIMDExt)
 if(HAVE_ARMV8_CRC)
   add_library(common_crc_aarch64 STATIC common/crc32c_aarch64.c)
-  set_target_properties(common_crc_aarch64 PROPERTIES COMPILE_FLAGS "${CMAKE_C_FLAGS} ${ARM_CRC_FLAGS}")
   target_link_libraries(common common_crc_aarch64)
 endif(HAVE_ARMV8_CRC)
 

--- a/src/common/crc32c_aarch64.c
+++ b/src/common/crc32c_aarch64.c
@@ -2,6 +2,9 @@
 #include "include/int_types.h"
 #include "common/crc32c_aarch64.h"
 
+/* Request crc extension capabilities from the assembler */
+asm(".arch_extension crc");
+
 #define CRC32CX(crc, value) __asm__("crc32cx %w[c], %w[c], %x[v]":[c]"+r"(crc):[v]"r"(value))
 #define CRC32CW(crc, value) __asm__("crc32cw %w[c], %w[c], %w[v]":[c]"+r"(crc):[v]"r"(value))
 #define CRC32CH(crc, value) __asm__("crc32ch %w[c], %w[c], %w[v]":[c]"+r"(crc):[v]"r"(value))


### PR DESCRIPTION
The used compiler may or may not be recent enough to recognize the
crc32 extended cpu type. However, it does not really have to know about
them either, since all we do is pass inline assembly instructions to
the assembler.

This patch moves the crc cpu extension detection from compiler based
to assembler based, so that we can build optimized code even when the
compiler does not know about the cpu type yet.

Fixes: http://tracker.ceph.com/issues/17516
Signed-off-by: Alexander Graf <agraf@suse.de>