### PR TITLE
Use RCU locking to protect pg_map

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,14 @@ endif(WITH_RDMA)
 
 find_package(Backtrace)
 
+find_package(urcu REQUIRED)
+
 if(LINUX)
   find_package(udev REQUIRED)
   set(HAVE_UDEV ${UDEV_FOUND})
+
+  find_package(urcu REQUIRED)
+  set(HAVE_URCU ${URCU_FOUND})
 
   find_package(aio REQUIRED)
   set(HAVE_LIBAIO ${AIO_FOUND})
@@ -192,6 +197,8 @@ if(LINUX)
   find_package(blkid REQUIRED)
   set(HAVE_BLKID ${BLKID_FOUND})
 else()
+  set(HAVE_URCU OFF)
+  message(STATUS "Not using urcu")
   set(HAVE_UDEV OFF)
   message(STATUS "Not using udev")
   set(HAVE_LIBAIO OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,6 @@ include_directories(
   ${PROJECT_BINARY_DIR}/src/include
   ${PROJECT_SOURCE_DIR}/src)
 
-if(LEVELDB_PREFIX)
-  include_directories(${LEVELDB_PREFIX}/include)
-  link_directories(${LEVELDB_PREFIX}/lib)
-endif()
-
 if(OFED_PREFIX)
   include_directories(${OFED_PREFIX}/include)
   link_directories(${OFED_PREFIX}/lib)
@@ -240,10 +235,14 @@ option(WITH_KVS "Key value store is here" ON)
 option(WITH_RBD "Remote block storage is here" ON)
 
 option(WITH_LEVELDB "LevelDB is here" ON)
-if(${WITH_LEVELDB})
-find_package(leveldb REQUIRED)
-find_file(HAVE_LEVELDB_FILTER_POLICY leveldb/filter_policy.h PATHS ${LEVELDB_INCLUDE_DIR})
-endif(${WITH_LEVELDB})
+if(WITH_LEVELDB)
+  if(LEVELDB_PREFIX)
+    include_directories(${LEVELDB_PREFIX}/include)
+    link_directories(${LEVELDB_PREFIX}/lib)
+  endif()
+  find_package(leveldb REQUIRED)
+  find_file(HAVE_LEVELDB_FILTER_POLICY leveldb/filter_policy.h PATHS ${LEVELDB_INCLUDE_DIR})
+endif(WITH_LEVELDB)
 
 find_package(atomic_ops REQUIRED)
 message(STATUS "${ATOMIC_OPS_LIBRARIES}")

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -134,6 +134,7 @@ BuildRequires:	xfsprogs
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	yasm
+BuildRequires:	userspace-rcu
 
 #################################################################################
 # distro-conditional dependencies

--- a/cmake/modules/Findurcu.cmake
+++ b/cmake/modules/Findurcu.cmake
@@ -1,0 +1,19 @@
+# - Find URCU
+#
+# URCU_INCLUDE_DIRS - Where to find urcu.h
+# URCU_LIBRARIES - List of libraries when using URCU.
+# URCU_FOUND - True if URCU found.
+
+find_path(URCU_INCLUDE_DIR NAMES urcu/uatomic.h)
+
+find_library(URCU_LIBRARY NAMES urcu)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(urcu DEFAULT_MSG URCU_LIBRARY URCU_INCLUDE_DIR)
+
+IF(URCU_FOUND)
+  SET(URCU_LIBRARIES ${URCU_LIBRARY})
+  SET(URCU_INCLUDE_DIRS ${URCU_INCLUDE_DIR})
+ENDIF(URCU_FOUND)
+
+MARK_AS_ADVANCED(URCU_INCLUDE_DIR URCU_LIBRARY)

--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -12,7 +12,7 @@ function install() {
 function install_one() {
     case $(lsb_release -si) in
         Ubuntu|Debian|Devuan)
-            sudo apt-get install -y "$@"
+            sudo apt-get install -y --force-yes "$@"
             ;;
         CentOS|Fedora|RedHatEnterpriseServer)
             sudo yum install -y "$@"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -531,7 +531,7 @@ add_library(common STATIC ${libcommon_files}
   $<TARGET_OBJECTS:common_mountcephfs_objs>)
 target_link_libraries(common json_spirit erasure_code rt ${LIB_RESOLV}
   ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
-  ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${URCU_LIBRARIES})
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/common/version.cc

--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -21,6 +21,7 @@ from ceph_detect_init import fedora
 from ceph_detect_init import rhel
 from ceph_detect_init import suse
 from ceph_detect_init import gentoo
+from ceph_detect_init import freebsd
 import logging
 import platform
 
@@ -65,6 +66,7 @@ def _get_distro(distro, use_rhceph=False):
         'gentoo': gentoo,
         'funtoo': gentoo,
         'exherbo': gentoo,
+        'freebsd': freebsd,
     }
 
     if distro == 'redhat' and use_rhceph:
@@ -90,11 +92,22 @@ def _normalized_distro_name(distro):
 
 def platform_information():
     """detect platform information from remote host."""
-    linux_distro = platform.linux_distribution(
-        supported_dists=platform._supported_dists + ('alpine',))
-    logging.debug('platform_information: linux_distribution = ' +
-                  str(linux_distro))
-    distro, release, codename = linux_distro
+    if platform.system() == 'Linux':
+        linux_distro = platform.linux_distribution(
+            supported_dists=platform._supported_dists + ('alpine',))
+        logging.debug('platform_information: linux_distribution = ' +
+                      str(linux_distro))
+        distro, release, codename = linux_distro
+    elif platform.system() == 'FreeBSD':
+        distro = 'freebsd'
+        release = platform.release()
+        codename = platform.version().split(' ')[3].split(':')[0]
+        logging.debug(
+            'platform_information: release = {}, version = {}'.format(
+                platform.release(), platform.version()))
+    else:
+        raise exc.UnsupportedPlatform(platform.system(), '', '')
+
     # this could be an empty string in Debian
     if not codename and 'debian' in distro.lower():
         debian_codenames = {

--- a/src/ceph-detect-init/ceph_detect_init/freebsd/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/freebsd/__init__.py
@@ -1,0 +1,11 @@
+distro = None
+release = None
+codename = None
+
+
+def choose_init():
+    """Select a init system
+
+     Returns the name of a init system (upstart, sysvinit ...).
+     """
+    return 'bsdrc'

--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -17,11 +17,6 @@
 # GNU Library Public License for more details.
 #
 
-if [ x"`uname`"x = xFreeBSDx ]; then
-    echo FreeBSD init system has not been integrated.
-    exit 0
-fi
-
 # run from the ceph-detect-init directory or from its parent
 : ${CEPH_DETECT_INIT_VIRTUALENV:=/tmp/ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -140,7 +140,8 @@ int check_mon_data_empty()
   errno = 0;
   while ((de = ::readdir(dir))) {
     if (string(".") != de->d_name &&
-	string("..") != de->d_name) {
+	string("..") != de->d_name &&
+	string("kv_backend") != de->d_name) {
       code = -ENOTEMPTY;
       break;
     }

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -238,11 +238,10 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
   int lvl = (prio == CLOG_ERROR ? -1 : 0);
   ldout(cct,lvl) << "log " << prio << " : " << s << dendl;
   LogEntry e;
-  // who will be set when we queue the entry on LogClient
-  //e.who = messenger->get_myinst();
   e.stamp = ceph_clock_now(cct);
-  // seq will be set when we queue the entry on LogClient
-  // e.seq = ++last_log;
+  // seq and who should be set for syslog/graylog/log_to_mon
+  e.who = parent->get_myinst();
+  e.seq = parent->get_next_seq();
   e.prio = prio;
   e.msg = s;
   e.channel = get_log_channel();
@@ -342,8 +341,6 @@ void LogClient::_send_to_mon()
 version_t LogClient::queue(LogEntry &entry)
 {
   Mutex::Locker l(log_lock);
-  entry.seq = ++last_log;
-  entry.who = messenger->get_myinst();
   log_queue.push_back(entry);
 
   if (is_mon) {
@@ -351,6 +348,16 @@ version_t LogClient::queue(LogEntry &entry)
   }
 
   return entry.seq;
+}
+
+uint64_t LogClient::get_next_seq()
+{
+  return ++last_log;
+}
+
+const entity_inst_t& LogClient::get_myinst()
+{
+  return messenger->get_myinst();
 }
 
 bool LogClient::handle_log_ack(MLogAck *m)

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -20,6 +20,7 @@
 
 #include <iosfwd>
 #include <sstream>
+#include <atomic>
 
 class LogClient;
 class MLog;
@@ -233,6 +234,8 @@ public:
     channels.clear();
   }
 
+  uint64_t get_next_seq();
+  const entity_inst_t& get_myinst();
   version_t queue(LogEntry &entry);
 
 private:
@@ -245,7 +248,7 @@ private:
   bool is_mon;
   Mutex log_lock;
   version_t last_log_sent;
-  version_t last_log;
+  std::atomic<uint64_t> last_log;
   std::deque<LogEntry> log_queue;
 
   std::map<std::string, LogChannelRef> channels;

--- a/src/common/RCU.h
+++ b/src/common/RCU.h
@@ -1,0 +1,63 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2011 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include <urcu.h>
+#include <pthread.h>
+
+#ifndef CEPH_RCU_H
+#define CEPH_RCU_H
+
+namespace ceph {
+
+template <class A=int> class RCU {
+public:
+  static void RCU_online() {
+    rcu_thread_online();
+  }
+  static void RCU_offline() {
+    rcu_thread_offline();
+  }
+  static void RCU_quiescent_state() {
+    rcu_quiescent_state();
+  }
+  static void RCU_syncrhonize() {
+    synchronize_rcu();
+  }
+  static void RCU_read_lock() {
+    rcu_read_lock();
+  }
+  static void RCU_read_unlock() {
+    rcu_read_unlock();
+  }
+  static void RCU_quiescent() {
+    rcu_quiescent_state();
+  }
+  RCU(pthread_key_t key, const void *value) {
+    rcu_register_thread();
+    pthread_setspecific(key,value);
+  }
+  ~RCU() {
+    rcu_unregister_thread();
+  }
+  inline static A *RCU_dereference(A *ptr) {
+    return rcu_dereference(ptr);
+  }
+  inline static void RCU_xchg_and_sync(A **ptr1, A *ptr2) {
+    rcu_xchg_pointer(ptr1, ptr2);
+    synchronize_rcu();
+  }
+};
+}
+
+#endif

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -64,8 +64,6 @@ int get_block_device_base(const char *dev, char *out, size_t out_len)
 {
   struct stat st;
   int r = 0;
-  char buf[PATH_MAX*2];
-  struct dirent *de;
   DIR *dir;
   char devname[PATH_MAX], fn[PATH_MAX];
   char *p;
@@ -100,14 +98,8 @@ int get_block_device_base(const char *dev, char *out, size_t out_len)
   if (!dir)
     return -errno;
 
-  while (!::readdir_r(dir, reinterpret_cast<struct dirent*>(buf), &de)) {
-    if (!de) {
-      if (errno) {
-	r = -errno;
-	goto out;
-      }
-      break;
-    }
+  struct dirent *de = nullptr;
+  while ((de = ::readdir(dir))) {
     if (de->d_name[0] == '.')
       continue;
     snprintf(fn, sizeof(fn), "%s/sys/block/%s/%s", sandbox_dir, de->d_name,

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -1,3 +1,4 @@
+
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
@@ -562,6 +563,8 @@ CephContext::CephContext(uint32_t module_type_, int init_flags_)
   _admin_socket->register_command("log flush", "log flush", _admin_hook, "flush log entries to log file");
   _admin_socket->register_command("log dump", "log dump", _admin_hook, "dump recent log entries to log file");
   _admin_socket->register_command("log reopen", "log reopen", _admin_hook, "reopen log file");
+
+  pthread_key_create(&registered, 0);
 
   _crypto_none = CryptoHandler::create(CEPH_CRYPTO_NONE);
   _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -146,6 +146,8 @@ public:
    */
   CryptoHandler *get_crypto_handler(int type);
 
+  pthread_key_t registered;
+
   /// check if experimental feature is enable, and emit appropriate warnings
   bool check_experimental_feature_enabled(const std::string& feature);
   bool check_experimental_feature_enabled(const std::string& feature,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -712,6 +712,7 @@ OPTION(osd_map_message_max, OPT_INT, 100)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send to peers, clients
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
+OPTION(osd_inject_pg_lock_longhold, OPT_BOOL, false)
 // shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds
 OPTION(osd_max_markdown_period , OPT_INT, 600)
 OPTION(osd_max_markdown_count, OPT_INT, 5)

--- a/src/common/fd.cc
+++ b/src/common/fd.cc
@@ -30,16 +30,14 @@ void dump_open_fds(CephContext *cct)
     lderr(cct) << "dump_open_fds unable to open " << fn << dendl;
     return;
   }
-  struct dirent de, *pde = 0;
+  struct dirent *de = nullptr;
 
   int n = 0;
-  while (readdir_r(d, &de, &pde) >= 0) {
-    if (pde == NULL)
-      break;
-    if (de.d_name[0] == '.')
+  while ((de = ::readdir(d))) {
+    if (de->d_name[0] == '.')
       continue;
     char path[PATH_MAX];
-    snprintf(path, sizeof(path), "%s/%s", fn, de.d_name);
+    snprintf(path, sizeof(path), "%s/%s", fn, de->d_name);
     char target[PATH_MAX];
     ssize_t r = readlink(path, target, sizeof(target) - 1);
     if (r < 0) {
@@ -48,7 +46,7 @@ void dump_open_fds(CephContext *cct)
       continue;
     }
     target[r] = 0;
-    lderr(cct) << "dump_open_fds " << de.d_name << " -> " << target << dendl;
+    lderr(cct) << "dump_open_fds " << de->d_name << " -> " << target << dendl;
     n++;
   }
   lderr(cct) << "dump_open_fds dumped " << n << " open files" << dendl;

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -132,6 +132,9 @@
 /* define if radosgw enabled */
 #cmakedefine WITH_RADOSGW
 
+/* define if leveldb is enabled */
+#cmakedefine WITH_LEVELDB
+
 /* define if radosgw's asio frontend enabled */
 #cmakedefine WITH_RADOSGW_ASIO_FRONTEND
 

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -517,6 +517,7 @@ struct ceph_osd_op {
 			__le64 ver;     /* no longer used */
 			__u8 op;	/* CEPH_OSD_WATCH_OP_* */
 			__u32 gen;      /* registration generation */
+			__u32 timeout; /* connection timeout */
 		} __attribute__ ((packed)) watch;
 		struct {
 			__le64 cookie;

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -562,6 +562,18 @@ struct ceph_osd_op {
 	__le32 payload_len;
 } __attribute__ ((packed));
 
+/*
+ * Check the compatibility of struct ceph_osd_op
+ *  (2+4+(2*8+8+4)+4) = (sizeof(ceph_osd_op::op) +
+ *                     sizeof(ceph_osd_op::flags) +
+ *                     sizeof(ceph_osd_op::extent) +
+ *                     sizeof(ceph_osd_op::payload_len))
+ */
+#ifdef __cplusplus
+static_assert(sizeof(ceph_osd_op) == (2+4+(2*8+8+4)+4),
+              "sizeof(ceph_osd_op) breaks the compatibility");
+#endif
+
 struct ceph_osd_reply_head {
 	__le32 client_inc;                /* client incarnation */
 	__le32 flags;

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -2207,7 +2207,6 @@ typedef void (*rados_watchcb2_t)(void *arg,
  * after 30 seconds. Watches are automatically reestablished when a new
  * connection is made, or a placement group switches OSDs.
  *
- * @note BUG: watch timeout should be configurable
  * @note BUG: librados should provide a way for watchers to notice connection resets
  * @note BUG: the ver parameter does not work, and -ERANGE will never be returned
  *            (See URL tracker.ceph.com/issues/2592)
@@ -2233,12 +2232,11 @@ CEPH_RADOS_API int rados_watch(rados_ioctx_t io, const char *o, uint64_t ver,
  * A watch operation registers the client as being interested in
  * notifications on an object. OSDs keep track of watches on
  * persistent storage, so they are preserved across cluster changes by
- * the normal recovery process. If the client loses its connection to
- * the primary OSD for a watched object, the watch will be removed
- * after 30 seconds. Watches are automatically reestablished when a new
+ * the normal recovery process. If the client loses its connection to the
+ * primary OSD for a watched object, the watch will be removed after
+ * a timeout configured with osd_client_watch_timeout.
+ * Watches are automatically reestablished when a new
  * connection is made, or a placement group switches OSDs.
- *
- * @note BUG: watch timeout should be configurable
  *
  * @param io the pool the object is in
  * @param o the object to watch
@@ -2254,6 +2252,30 @@ CEPH_RADOS_API int rados_watch2(rados_ioctx_t io, const char *o, uint64_t *cooki
 				void *arg);
 
 /**
+ * Register an interest in an object
+ *
+ * A watch operation registers the client as being interested in
+ * notifications on an object. OSDs keep track of watches on
+ * persistent storage, so they are preserved across cluster changes by
+ * the normal recovery process. Watches are automatically reestablished when a new
+ * connection is made, or a placement group switches OSDs.
+ *
+ * @param io the pool the object is in
+ * @param o the object to watch
+ * @param cookie where to store the internal id assigned to this watch
+ * @param watchcb what to do when a notify is received on this object
+ * @param watcherrcb what to do when the watch session encounters an error
+ * @param timeout how many seconds the connection will keep after disconnection
+ * @param arg opaque value to pass to the callback
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_watch3(rados_ioctx_t io, const char *o, uint64_t *cookie,
+        rados_watchcb2_t watchcb,
+        rados_watcherrcb_t watcherrcb,
+        uint32_t timeout,
+        void *arg);
+
+/**
  * Asynchronous register an interest in an object
  *
  * A watch operation registers the client as being interested in
@@ -2263,8 +2285,6 @@ CEPH_RADOS_API int rados_watch2(rados_ioctx_t io, const char *o, uint64_t *cooki
  * the primary OSD for a watched object, the watch will be removed
  * after 30 seconds. Watches are automatically reestablished when a new
  * connection is made, or a placement group switches OSDs.
- *
- * @note BUG: watch timeout should be configurable
  *
  * @param io the pool the object is in
  * @param o the object to watch
@@ -2280,6 +2300,35 @@ CEPH_RADOS_API int rados_aio_watch(rados_ioctx_t io, const char *o,
 				   rados_watchcb2_t watchcb,
 				   rados_watcherrcb_t watcherrcb,
 				   void *arg);
+
+/**
+ * Asynchronous register an interest in an object
+ *
+ * A watch operation registers the client as being interested in
+ * notifications on an object. OSDs keep track of watches on
+ * persistent storage, so they are preserved across cluster changes by
+ * the normal recovery process. If the client loses its connection to
+ * the primary OSD for a watched object, the watch will be removed
+ * after the number of seconds that configured in timeout parameter.
+ * Watches are automatically reestablished when a new
+ * connection is made, or a placement group switches OSDs.
+ *
+ * @param io the pool the object is in
+ * @param o the object to watch
+ * @param completion what to do when operation has been attempted
+ * @param handle where to store the internal id assigned to this watch
+ * @param watchcb what to do when a notify is received on this object
+ * @param watcherrcb what to do when the watch session encounters an error
+ * @param timeout how many seconds the connection will keep after disconnection
+ * @param arg opaque value to pass to the callback
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_aio_watch2(rados_ioctx_t io, const char *o,
+           rados_completion_t completion, uint64_t *handle,
+           rados_watchcb2_t watchcb,
+           rados_watcherrcb_t watcherrcb,
+           uint32_t timeout,
+           void *arg);
 
 /**
  * Check on the status of a watch

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -1029,8 +1029,12 @@ namespace librados
     // watch/notify
     int watch2(const std::string& o, uint64_t *handle,
 	       librados::WatchCtx2 *ctx);
+    int watch3(const std::string& o, uint64_t *handle,
+	       librados::WatchCtx2 *ctx, uint32_t timeout);
     int aio_watch(const std::string& o, AioCompletion *c, uint64_t *handle,
 	       librados::WatchCtx2 *ctx);
+    int aio_watch2(const std::string& o, AioCompletion *c, uint64_t *handle,
+	       librados::WatchCtx2 *ctx, uint32_t timeout);
     int unwatch2(uint64_t handle);
     int aio_unwatch(uint64_t handle, AioCompletion *c);
     /**

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -1,8 +1,12 @@
 set(kv_srcs
   KeyValueDB.cc
-  LevelDBStore.cc
   MemDB.cc
   RocksDBStore.cc)
+
+if (WITH_LEVELDB)
+  list(APPEND kv_srcs LevelDBStore.cc)
+endif (WITH_LEVELDB)
+
 add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -2,7 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "KeyValueDB.h"
+#ifdef WITH_LEVELDB
 #include "LevelDBStore.h"
+#endif
 #include "MemDB.h"
 #ifdef HAVE_LIBROCKSDB
 #include "RocksDBStore.h"
@@ -15,9 +17,11 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
 			       void *p)
 {
+#ifdef WITH_LEVELDB
   if (type == "leveldb") {
     return new LevelDBStore(cct, dir);
   }
+#endif
 #ifdef HAVE_KINETIC
   if (type == "kinetic" &&
       cct->check_experimental_feature_enabled("kinetic")) {
@@ -39,9 +43,11 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 
 int KeyValueDB::test_init(const string& type, const string& dir)
 {
+#ifdef WITH_LEVELDB
   if (type == "leveldb") {
     return LevelDBStore::_test_init(dir);
   }
+#endif
 #ifdef HAVE_KINETIC
   if (type == "kinetic") {
     return KineticStore::_test_init(g_ceph_context);

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1485,6 +1485,15 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
                                librados::WatchCtx2 *ctx2,
                                bool internal)
 {
+  return watch(oid, handle, ctx, ctx2, 0, internal);
+}
+
+int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
+                               librados::WatchCtx *ctx,
+                               librados::WatchCtx2 *ctx2,
+                               uint32_t timeout,
+                               bool internal)
+{
   ::ObjectOperation wr;
   version_t objver;
   C_SaferCond onfinish;
@@ -1495,7 +1504,7 @@ int librados::IoCtxImpl::watch(const object_t& oid, uint64_t *handle,
 					   oid, ctx, ctx2, internal);
 
   prepare_assert_ops(&wr);
-  wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH);
+  wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
   objecter->linger_watch(linger_op, wr,
 			 snapc, ceph::real_clock::now(), bl,
@@ -1519,6 +1528,16 @@ int librados::IoCtxImpl::aio_watch(const object_t& oid,
                                    uint64_t *handle,
                                    librados::WatchCtx *ctx,
                                    librados::WatchCtx2 *ctx2,
+                                   bool internal) {
+  return aio_watch(oid, c, handle, ctx, ctx2, 0, internal);
+}
+
+int librados::IoCtxImpl::aio_watch(const object_t& oid,
+                                   AioCompletionImpl *c,
+                                   uint64_t *handle,
+                                   librados::WatchCtx *ctx,
+                                   librados::WatchCtx2 *ctx2,
+                                   uint32_t timeout,
                                    bool internal)
 {
   Objecter::LingerOp *linger_op = objecter->linger_register(oid, oloc, 0);
@@ -1530,7 +1549,7 @@ int librados::IoCtxImpl::aio_watch(const object_t& oid,
   linger_op->watch_context = new WatchInfo(this, oid, ctx, ctx2, internal);
 
   prepare_assert_ops(&wr);
-  wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH);
+  wr.watch(*handle, CEPH_OSD_WATCH_OP_WATCH, timeout);
   bufferlist bl;
   objecter->linger_watch(linger_op, wr,
                          snapc, ceph::real_clock::now(), bl,

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -242,9 +242,14 @@ struct librados::IoCtxImpl {
   void set_sync_op_version(version_t ver);
   int watch(const object_t& oid, uint64_t *cookie, librados::WatchCtx *ctx,
 	    librados::WatchCtx2 *ctx2, bool internal = false);
+  int watch(const object_t& oid, uint64_t *cookie, librados::WatchCtx *ctx,
+	    librados::WatchCtx2 *ctx2, uint32_t timeout, bool internal = false);
   int aio_watch(const object_t& oid, AioCompletionImpl *c, uint64_t *cookie,
                 librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2,
                 bool internal = false);
+  int aio_watch(const object_t& oid, AioCompletionImpl *c, uint64_t *cookie,
+                librados::WatchCtx *ctx, librados::WatchCtx2 *ctx2,
+                uint32_t timeout, bool internal = false);
   int watch_check(uint64_t cookie);
   int unwatch(uint64_t cookie);
   int aio_unwatch(uint64_t cookie, AioCompletionImpl *c);

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -82,7 +82,8 @@ set(librbd_internal_srcs
   operation/SnapshotRollbackRequest.cc
   operation/SnapshotUnprotectRequest.cc
   operation/SnapshotLimitRequest.cc
-  operation/TrimRequest.cc)
+  operation/TrimRequest.cc
+  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
 
 add_library(rbd_api STATIC librbd.cc)
 add_library(rbd_internal STATIC
@@ -93,9 +94,6 @@ if(WITH_LTTNG)
 endif()
 
 add_library(librbd ${CEPH_SHARED}
-  $<TARGET_OBJECTS:osdc_rbd_objs>
-  $<TARGET_OBJECTS:common_util_obj>
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   librbd.cc)
 if(LINUX)
   list(APPEND librbd 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -89,7 +89,7 @@ add_library(rbd_internal STATIC
   ${librbd_internal_srcs}
   $<TARGET_OBJECTS:rados_snap_set_diff_obj>)
 if(WITH_LTTNG)
-  add_dependencies(rbd_api librbd-tp)
+  add_dependencies(rbd_internal librbd-tp)
 endif()
 
 add_library(librbd ${CEPH_SHARED}

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -95,26 +95,19 @@ endif()
 
 add_library(librbd ${CEPH_SHARED}
   librbd.cc)
-if(LINUX)
-  list(APPEND librbd 
-    $<TARGET_OBJECTS:parse_secret_objs>  
-    $<TARGET_OBJECTS:krbd_objs>
-    )
-endif(LINUX)
 
 target_link_libraries(librbd LINK_PRIVATE 
   rbd_internal
   rbd_types
   journal
   librados 
-  common 
   osdc
   cls_rbd_client 
   cls_lock_client 
   cls_journal_client 
+  common
   pthread
   udev
-  keyutils
   ${CMAKE_DL_LIBS}
   ${EXTRALIBS})
 if(ENABLE_SHARED)

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -43,7 +43,6 @@
 #include "librbd/exclusive_lock/AutomaticPolicy.h"
 #include "librbd/exclusive_lock/StandardPolicy.h"
 #include "librbd/operation/TrimRequest.h"
-#include "include/util.h"
 
 #include "journal/Journaler.h"
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -141,21 +141,21 @@ COMMAND("pg dump_stuck " \
 	"pg", "r", "cli,rest")
 COMMAND("pg ls-by-pool " \
         "name=poolstr,type=CephString " \
-	"name=states,type=CephChoices,strings=active|clean|down|replay|splitting|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
+	"name=states,type=CephChoices,strings=active|clean|down|replay|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
 	"list pg with pool = [poolname | poolid]", "pg", "r", "cli,rest")
 COMMAND("pg ls-by-primary " \
         "name=osd,type=CephOsdName " \
         "name=pool,type=CephInt,req=false " \
-	"name=states,type=CephChoices,strings=active|clean|down|replay|splitting|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
+	"name=states,type=CephChoices,strings=active|clean|down|replay|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
 	"list pg with primary = [osd]", "pg", "r", "cli,rest")
 COMMAND("pg ls-by-osd " \
         "name=osd,type=CephOsdName " \
         "name=pool,type=CephInt,req=false " \
-	"name=states,type=CephChoices,strings=active|clean|down|replay|splitting|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
+	"name=states,type=CephChoices,strings=active|clean|down|replay|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
 	"list pg on osd [osd]", "pg", "r", "cli,rest")
 COMMAND("pg ls " \
         "name=pool,type=CephInt,req=false " \
-	"name=states,type=CephChoices,strings=active|clean|down|replay|splitting|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
+	"name=states,type=CephChoices,strings=active|clean|down|replay|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
 	"list pg with specific pool, osd, state", "pg", "r", "cli,rest")
 COMMAND("pg map name=pgid,type=CephPgid", "show mapping of pg to osds", \
 	"pg", "r", "cli,rest")

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -288,12 +288,19 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
   }
 
   for (int o = 0; o < osdmap.get_max_osd(); o++) {
+    if (osdmap.is_out(o))
+      continue;
+    auto found = down_pending_out.find(o);
     if (osdmap.is_down(o)) {
       // populate down -> out map
-      if (osdmap.is_in(o) &&
-	  down_pending_out.count(o) == 0) {
-	dout(10) << " adding osd." << o << " to down_pending_out map" << dendl;
-	down_pending_out[o] = ceph_clock_now(g_ceph_context);
+      if (found == down_pending_out.end()) {
+        dout(10) << " adding osd." << o << " to down_pending_out map" << dendl;
+        down_pending_out[o] = ceph_clock_now(g_ceph_context);
+      }
+    } else {
+      if (found != down_pending_out.end()) {
+        dout(10) << " removing osd." << o << " from down_pending_out map" << dendl;
+        down_pending_out.erase(found);
       }
     }
   }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1678,8 +1678,6 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
       note["peering"] += p->second;
     if (p->first & PG_STATE_REPAIR)
       note["repair"] += p->second;
-    if (p->first & PG_STATE_SPLITTING)
-      note["splitting"] += p->second;
     if (p->first & PG_STATE_RECOVERING)
       note["recovering"] += p->second;
     if (p->first & PG_STATE_RECOVERY_WAIT)
@@ -1777,7 +1775,6 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
 	                        PG_STATE_INCONSISTENT |
 	                        PG_STATE_PEERING |
 	                        PG_STATE_REPAIR |
-	                        PG_STATE_SPLITTING |
 	                        PG_STATE_RECOVERING |
 	                        PG_STATE_RECOVERY_WAIT |
 	                        PG_STATE_INCOMPLETE |

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -13,11 +13,12 @@
  * Foundation.  See file COPYING.
  *
  */
-
+#include <urcu.h>
 #include <unistd.h>
 
 #include "include/Context.h"
 #include "common/errno.h"
+#include "common/RCU.h"
 #include "AsyncMessenger.h"
 #include "AsyncConnection.h"
 
@@ -327,6 +328,8 @@ void AsyncConnection::process()
   bool need_dispatch_writer = false;
   std::lock_guard<std::mutex> l(lock);
   last_active = ceph::coarse_mono_clock::now();
+
+  RCU<>::RCU_quiescent();
   do {
     ldout(async_msgr->cct, 20) << __func__ << " prev state is " << get_state_name(prev_state) << dendl;
     prev_state = state;

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -14,8 +14,10 @@
  *
  */
 
+#include <urcu.h>
 #include "common/Cond.h"
 #include "common/errno.h"
+#include "common/RCU.h"
 #include "PosixStack.h"
 #ifdef HAVE_RDMA
 #include "rdma/RDMAStack.h"
@@ -41,6 +43,7 @@ void NetworkStack::add_thread(unsigned i, std::function<void ()> &thread)
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();
       w->init_done();
+      RCU<> rcu(w->cct->registered, this);
       while (!w->done) {
         ldout(cct, 30) << __func__ << " calling event process" << dendl;
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -203,7 +203,6 @@ class Worker {
 
  public:
   bool done = false;
-
   CephContext *cct;
   PerfCounters *perf_logger;
   unsigned id;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6517,13 +6517,13 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
     txc->onreadable_sync = NULL;
   }
   unsigned n = txc->osr->parent->shard_hint.hash_to_shard(m_finisher_num);
-  if (txc->onreadable) {
-    finishers[n]->queue(txc->onreadable);
-    txc->onreadable = NULL;
-  }
   if (txc->oncommit) {
     finishers[n]->queue(txc->oncommit);
     txc->oncommit = NULL;
+  }
+  if (txc->onreadable) {
+    finishers[n]->queue(txc->onreadable);
+    txc->onreadable = NULL;
   }
   while (!txc->oncommits.empty()) {
     auto f = txc->oncommits.front();

--- a/src/os/filestore/BtrfsFileStoreBackend.cc
+++ b/src/os/filestore/BtrfsFileStoreBackend.cc
@@ -320,12 +320,8 @@ int BtrfsFileStoreBackend::list_checkpoints(list<string>& ls)
 
   list<string> snaps;
   char path[PATH_MAX];
-  char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
   struct dirent *de;
-  while (::readdir_r(dir, (struct dirent *)&buf, &de) == 0) {
-    if (!de)
-      break;
-
+  while ((de = ::readdir(dir))) {
     snprintf(path, sizeof(path), "%s/%s", get_basedir_path().c_str(), de->d_name);
 
     struct stat st;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4633,11 +4633,8 @@ int FileStore::list_collections(vector<coll_t>& ls, bool include_temp)
     return r;
   }
 
-  char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
-  struct dirent *de;
-  while ((r = ::readdir_r(dir, (struct dirent *)&buf, &de)) == 0) {
-    if (!de)
-      break;
+  struct dirent *de = nullptr;
+  while ((de = ::readdir(dir))) {
     if (de->d_type == DT_UNKNOWN) {
       // d_type not supported (non-ext[234], btrfs), must stat
       struct stat sb;
@@ -4675,7 +4672,7 @@ int FileStore::list_collections(vector<coll_t>& ls, bool include_temp)
   }
 
   if (r > 0) {
-    derr << "trying readdir_r " << fn << ": " << cpp_strerror(r) << dendl;
+    derr << "trying readdir " << fn << ": " << cpp_strerror(r) << dendl;
     r = -r;
   }
 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(osd STATIC ${osd_srcs}
   $<TARGET_OBJECTS:global_common_objs>
   $<TARGET_OBJECTS:heap_profiler_objs>
   $<TARGET_OBJECTS:common_util_obj>)
+target_include_directories(osd BEFORE PUBLIC ${URCU_INCLUDE_DIRS})
 target_link_libraries(osd ${LEVELDB_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 if(WITH_LTTNG)
   add_dependencies(osd oprequest-tp osd-tp pg-tp)

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -48,10 +48,9 @@ int ClassHandler::open_all_classes()
   if (!dir)
     return -errno;
 
-  char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
-  struct dirent *pde;
+  struct dirent *pde = nullptr;
   int r = 0;
-  while ((r = ::readdir_r(dir, (dirent *)&buf, &pde)) == 0 && pde) {
+  while ((pde = ::readdir(dir))) {
     if (pde->d_name[0] == '.')
       continue;
     if (strlen(pde->d_name) > sizeof(CLS_PREFIX) - 1 + sizeof(CLS_SUFFIX) - 1 &&

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -20,6 +20,7 @@
 #include <signal.h>
 #include <ctype.h>
 #include <boost/scoped_ptr.hpp>
+#include <urcu.h>
 
 #ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
@@ -110,6 +111,7 @@
 #include "messages/MOSDPGPushReply.h"
 #include "messages/MOSDPGPull.h"
 
+#include "common/RCU.h"
 #include "common/perf_counters.h"
 #include "common/Timer.h"
 #include "common/LogClient.h"
@@ -173,6 +175,40 @@ void PGQueueable::RunVis::operator()(const PGScrub &op) {
 
 void PGQueueable::RunVis::operator()(const PGRecovery &op) {
   return osd->do_recovery(pg.get(), op.epoch_queued, op.reserved_pushes, handle);
+}
+
+OSD::PG_map_subscriber::PG_map_subscriber(OSD *o) {
+  assert(pthread_getspecific(o->cct->registered) > 0);
+  RCU<>::RCU_read_lock();
+  subscribed_pg_map = RCU<ceph::unordered_map<spg_t, PG*>>::RCU_dereference(o->pg_map_ptr);
+}
+
+bool OSD::PG_map_subscriber::is_pg_map_end(unordered_map<spg_t, PG*>::iterator &i) {
+  return i == subscribed_pg_map->end();
+}
+
+unordered_map<spg_t, PG*>::iterator OSD::PG_map_subscriber::pg_map_find(const spg_t &pgid) {
+  return subscribed_pg_map->find(pgid);
+}
+
+OSD::PG_map_subscriber::~PG_map_subscriber() {
+  RCU<>::RCU_read_unlock();
+}
+
+// Take write lock and swap pg_map_ptr to a shadow copy of the pg_map.
+// Readers will see the shadow copy until the write completes so need not
+// block. When the write completes swap pg_map_ptr to modified pg_map.
+OSD::WLocker_and_pg_map_publish::WLocker_and_pg_map_publish(OSD *o) :
+  osd_ptr(o),
+  l(o->pg_map_lock) {
+  osd_ptr->pg_map_shadow = osd_ptr->pg_map;
+  RCU<ceph::unordered_map<spg_t, PG*>>::RCU_xchg_and_sync(
+    &osd_ptr->pg_map_ptr, &osd_ptr->pg_map_shadow);
+}
+
+OSD::WLocker_and_pg_map_publish::~WLocker_and_pg_map_publish() {
+  RCU<ceph::unordered_map<spg_t, PG*>>::RCU_xchg_and_sync(
+    &osd_ptr->pg_map_ptr, &osd_ptr->pg_map);
 }
 
 //Initial features in new superblock.
@@ -1689,6 +1725,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
     &osd_tp),
   map_lock("OSD::map_lock"),
   pg_map_lock("OSD::pg_map_lock"),
+  pg_map_ptr(&pg_map),
   last_pg_create_epoch(0),
   mon_report_lock("OSD::mon_report_lock"),
   stats_ack_timeout(cct->_conf->osd_mon_ack_timeout),
@@ -3065,7 +3102,11 @@ PG *OSD::_open_lock_pg(
 
   PG* pg = _make_pg(createmap, pgid);
   {
-    RWLock::WLocker l(pg_map_lock);
+    WLocker_and_pg_map_publish l(this);
+    if (g_conf->osd_inject_pg_lock_longhold) {
+      usleep(5000);
+    }
+
     pg->lock(no_lockdep_check);
     pg_map[pgid] = pg;
     pg->get("PGMap");  // because it's in pg_map
@@ -3220,10 +3261,10 @@ PGRef OSD::get_pg_or_queue_for_pg(const spg_t& pgid, OpRequestRef& op)
   // get_pg_or_queue_for_pg is only called from the fast_dispatch path where
   // the session_dispatch_lock must already be held.
   assert(session->session_dispatch_lock.is_locked());
-  RWLock::RLocker l(pg_map_lock);
 
-  ceph::unordered_map<spg_t, PG*>::iterator i = pg_map.find(pgid);
-  if (i == pg_map.end())
+  PG_map_subscriber l(this);
+  ceph::unordered_map<spg_t, PG*>::iterator i = l.pg_map_find(pgid);
+  if (l.is_pg_map_end(i))
     session->waiting_for_pg[pgid];
 
   map<spg_t, list<OpRequestRef> >::iterator wlistiter =
@@ -7355,7 +7396,7 @@ void OSD::consume_map()
   for (list<PGRef>::iterator i = to_remove.begin();
        i != to_remove.end();
        to_remove.erase(i++)) {
-    RWLock::WLocker locker(pg_map_lock);
+    WLocker_and_pg_map_publish l(this);
     (*i)->lock();
     _remove_pg(&**i);
     (*i)->unlock();
@@ -8306,7 +8347,8 @@ void OSD::handle_pg_remove(OpRequestRef op)
       continue;
     }
 
-    RWLock::WLocker l(pg_map_lock);
+    WLocker_and_pg_map_publish l(this);
+
     if (pg_map.count(pgid) == 0) {
       dout(10) << " don't have pg " << pgid << dendl;
       continue;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1437,10 +1437,8 @@ int OSDMap::apply_incremental(const Incremental &inc)
   }
 
   // blacklist
-  for (map<entity_addr_t,utime_t>::const_iterator p = inc.new_blacklist.begin();
-       p != inc.new_blacklist.end();
-       ++p) {
-    blacklist[p->first] = p->second;
+  if (!inc.new_blacklist.empty()) {
+    blacklist.insert(inc.new_blacklist.begin(),inc.new_blacklist.end());
     new_blacklist_entries = true;
   }
   for (vector<entity_addr_t>::const_iterator p = inc.old_blacklist.begin();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -2052,6 +2052,7 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
     ObjectMap::ObjectMapIterator iter =
       store->get_omap_iterator(coll,
 			       ghobject_t(recovery_info.soid));
+    assert(iter);
     for (iter->lower_bound(progress.omap_recovered_to);
 	 iter->valid();
 	 iter->next(false)) {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -5506,7 +5506,12 @@ int ReplicatedPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	dout(10) << "watch: peer_addr="
 	  << ctx->op->get_req()->get_connection()->get_peer_addr() << dendl;
 
-	watch_info_t w(cookie, cct->_conf->osd_client_watch_timeout,
+	uint32_t timeout = cct->_conf->osd_client_watch_timeout;
+	if (op.watch.timeout != 0) {
+	  timeout = op.watch.timeout;
+	}
+
+	watch_info_t w(cookie, timeout,
 	  ctx->op->get_req()->get_connection()->get_peer_addr());
 	if (op.watch.op == CEPH_OSD_WATCH_OP_WATCH ||
 	    op.watch.op == CEPH_OSD_WATCH_OP_LEGACY_WATCH) {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -801,8 +801,6 @@ std::string pg_state_string(int state)
     oss << "down+";
   if (state & PG_STATE_REPLAY)
     oss << "replay+";
-  if (state & PG_STATE_SPLITTING)
-    oss << "splitting+";
   if (state & PG_STATE_UNDERSIZED)
     oss << "undersized+";
   if (state & PG_STATE_DEGRADED)
@@ -849,8 +847,6 @@ int pg_string_state(const std::string& state)
     type = PG_STATE_DOWN;
   else if (state == "replay")
     type = PG_STATE_REPLAY;
-  else if (state == "splitting")
-    type = PG_STATE_SPLITTING;
   else if (state == "scrubbing")
     type = PG_STATE_SCRUBBING;
   else if (state == "degraded")

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -917,7 +917,7 @@ inline ostream& operator<<(ostream& out, const osd_stat_t& s) {
 #define PG_STATE_DOWN         (1<<4)  // a needed replica is down, PG offline
 #define PG_STATE_REPLAY       (1<<5)  // crashed, waiting for replay
 //#define PG_STATE_STRAY      (1<<6)  // i must notify the primary i exist.
-#define PG_STATE_SPLITTING    (1<<7)  // i am splitting
+//#define PG_STATE_SPLITTING    (1<<7)  // i am splitting
 #define PG_STATE_SCRUBBING    (1<<8)  // scrubbing
 //#define PG_STATE_SCRUBQ       (1<<9)  // queued for scrub
 #define PG_STATE_DEGRADED     (1<<10) // pg contains objects with reduced redundancy

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -922,10 +922,11 @@ struct ObjectOperation {
   }
 
   // watch/notify
-  void watch(uint64_t cookie, __u8 op) {
+  void watch(uint64_t cookie, __u8 op, uint32_t timeout = 0) {
     OSDOp& osd_op = add_op(CEPH_OSD_OP_WATCH);
     osd_op.op.watch.cookie = cookie;
     osd_op.op.watch.op = op;
+    osd_op.op.watch.timeout = timeout;
   }
 
   void notify(uint64_t cookie, uint32_t prot_ver, uint32_t timeout,

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(get_command_descriptions
 target_link_libraries(get_command_descriptions
   mon
   global
-  leveldb
+  ${LEVELDB_LIBRARIES}
   ${EXTRALIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}

--- a/src/test/common/test_blkdev.cc
+++ b/src/test/common/test_blkdev.cc
@@ -13,9 +13,7 @@
 
 TEST(blkdev, get_block_device_base) {
   char buf[PATH_MAX*2];
-  char buf2[PATH_MAX*2];
   char buf3[PATH_MAX*2];
-  struct dirent *de, *de2;
 
   ASSERT_EQ(-EINVAL, get_block_device_base("/etc/notindev", buf, 100));
 
@@ -32,9 +30,8 @@ TEST(blkdev, get_block_device_base) {
     sprintf(buf, "%s/sys/block", root.c_str());
     DIR *dir = opendir(buf);
     ASSERT_NE(dir, nullptr);
-    while (!::readdir_r(dir, reinterpret_cast<struct dirent*>(buf), &de)) {
-      if (!de)
-	break;
+    struct dirent *de = nullptr;
+    while ((de = ::readdir(dir))) {
       if (de->d_name[0] == '.')
 	continue;
 
@@ -57,9 +54,8 @@ TEST(blkdev, get_block_device_base) {
       sprintf(subdirfn, "%s/sys/block/%s", root.c_str(), de->d_name);
       DIR *subdir = opendir(subdirfn);
       ASSERT_TRUE(subdir);
-      while (!::readdir_r(subdir, reinterpret_cast<struct dirent*>(buf2), &de2)) {
-	if (!de2)
-	  break;
+      struct dirent *de2 = nullptr;
+      while ((de2 = ::readdir(subdir))) {
 	if (de2->d_name[0] == '.')
 	  continue;
 	// partiions will be prefixed with the base name

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -52,10 +52,8 @@ void TestClassHandler::open_all_classes() {
     assert(false);;
   }
 
-  char buf[offsetof(struct dirent, d_name) + PATH_MAX + 1];
-  struct dirent *pde;
-  int r = 0;
-  while ((r = ::readdir_r(dir, (dirent *)&buf, &pde)) == 0 && pde) {
+  struct dirent *pde = nullptr;
+  while ((pde = ::readdir(dir))) {
     std::string name(pde->d_name);
     if (!boost::algorithm::starts_with(name, "libcls_") ||
         !boost::algorithm::ends_with(name, ".so")) {

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -60,7 +60,6 @@ set(unittest_librbd_srcs
   )
 add_executable(unittest_librbd
   ${unittest_librbd_srcs}
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   $<TARGET_OBJECTS:common_texttable_obj>)
 target_compile_definitions(unittest_librbd PUBLIC "-DTEST_LIBRBD_INTERNALS")
 set_target_properties(unittest_librbd PROPERTIES COMPILE_FLAGS
@@ -88,7 +87,6 @@ target_link_libraries(unittest_librbd
 
 add_executable(ceph_test_librbd
   test_main.cc
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   $<TARGET_OBJECTS:common_texttable_obj>)
 target_link_libraries(ceph_test_librbd
   rbd_test

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -54,7 +54,7 @@ add_executable(unittest_osdscrub
   TestOSDScrub.cc
   )
 add_ceph_unittest(unittest_osdscrub ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osdscrub)
-target_link_libraries(unittest_osdscrub osd global ${CMAKE_DL_LIBS} os mon ${BLKID_LIBRARIES})
+target_link_libraries(unittest_osdscrub osd global ${CMAKE_DL_LIBS} os mon ${BLKID_LIBRARIES} ${URCU_LIBRARIES})
 
 # unittest_pglog
 add_executable(unittest_pglog

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -25,7 +25,6 @@ add_executable(unittest_rbd_mirror
   image_sync/test_mock_SnapshotCreateRequest.cc
   image_sync/test_mock_SyncPointCreateRequest.cc
   image_sync/test_mock_SyncPointPruneRequest.cc
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   )
 add_ceph_unittest(unittest_rbd_mirror ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rbd_mirror)
 set_target_properties(unittest_rbd_mirror PROPERTIES COMPILE_FLAGS
@@ -55,7 +54,6 @@ target_link_libraries(unittest_rbd_mirror
 
 add_executable(ceph_test_rbd_mirror
   test_main.cc
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc
   )
 set_target_properties(ceph_test_rbd_mirror PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})

--- a/src/test/test_stress_watch.cc
+++ b/src/test/test_stress_watch.cc
@@ -52,9 +52,8 @@ struct WatcherUnwatcher : public Thread {
       uint64_t handle;
       WatchNotifyTestCtx watch_ctx;
       int r = ioctx.watch("foo", 0, &handle, &watch_ctx);
-      bufferlist bl;
       if (r == 0)
-	ioctx.unwatch("foo", handle);
+        ioctx.unwatch("foo", handle);
       ioctx.close();
     }
     return NULL;

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc
   rebuild_mondb.cc
   RadosDump.cc)
-target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS})
+target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS} ${URCU_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-objectstore-tool fuse)
 endif(WITH_FUSE)

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -26,8 +26,7 @@ add_library(rbd_mirror_internal STATIC
   ${rbd_mirror_internal})
 
 add_executable(rbd-mirror
-  main.cc
-  ${CMAKE_SOURCE_DIR}/src/common/ContextCompletion.cc)
+  main.cc)
 target_link_libraries(rbd-mirror
   rbd_mirror_internal
   rbd_api

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -2433,23 +2433,25 @@ TRACEPOINT_EVENT(librados, rados_watch_exit,
     )
 )
 
-TRACEPOINT_EVENT(librados, rados_watch2_enter,
+TRACEPOINT_EVENT(librados, rados_watch3_enter,
     TP_ARGS(
         rados_ioctx_t, ioctx,
         const char*, oid,
         uint64_t*, phandle,
         rados_watchcb2_t, callback,
+        uint32_t, timeout,
         void*, arg),
     TP_FIELDS(
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
         ctf_string(oid, oid)
         ctf_integer_hex(uint64_t, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
+        ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)
     )
 )
 
-TRACEPOINT_EVENT(librados, rados_watch2_exit,
+TRACEPOINT_EVENT(librados, rados_watch3_exit,
     TP_ARGS(
         int, retval,
         uint64_t, handle),
@@ -2459,13 +2461,14 @@ TRACEPOINT_EVENT(librados, rados_watch2_exit,
     )
 )
 
-TRACEPOINT_EVENT(librados, rados_aio_watch_enter,
+TRACEPOINT_EVENT(librados, rados_aio_watch2_enter,
     TP_ARGS(
         rados_ioctx_t, ioctx,
         const char*, oid,
         rados_completion_t, completion,
         uint64_t*, phandle,
         rados_watchcb2_t, callback,
+        uint32_t, timeout,
         void*, arg),
     TP_FIELDS(
         ctf_integer_hex(rados_ioctx_t, ioctx, ioctx)
@@ -2473,11 +2476,12 @@ TRACEPOINT_EVENT(librados, rados_aio_watch_enter,
         ctf_integer_hex(rados_completion_t, completion, completion)
         ctf_integer_hex(uint64_t, phandle, phandle)
         ctf_integer_hex(rados_watchcb2_t, callback, callback)
+        ctf_integer(uint32_t, timeout, timeout)
         ctf_integer_hex(void*, arg, arg)
     )
 )
 
-TRACEPOINT_EVENT(librados, rados_aio_watch_exit,
+TRACEPOINT_EVENT(librados, rados_aio_watch2_exit,
     TP_ARGS(
         int, retval,
         uint64_t, handle),


### PR DESCRIPTION
Add userspace rcu library to list of ceph build requirements.
Use rcu publish/subscribe model for pg_map access in fast path.
RCU information is at [www.liburcu.org](www.liburcu.org)

Signed-off-by: Dan Lambright dlambrig@gmail.com
