### PR TITLE
os/bluestore: use std::unordered_map for SharedBlob lookup

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2187,11 +2187,6 @@ BlueStore::Collection::Collection(BlueStore *ns, Cache *c, coll_t cid)
     cid(cid),
     lock("BlueStore::Collection::lock", true, false),
     exists(true),
-    // size the shared blob hash table as a ratio of the onode cache size.
-    shared_blob_set(MAX(16,
-			g_conf->bluestore_onode_cache_size /
-			store->cache_shards.size() *
-			g_conf->bluestore_shared_blob_hash_table_size_ratio)),
     onode_map(c)
 {
 }

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -34,6 +34,7 @@ TEST(bluestore, sizeof) {
   P(std::atomic_int);
   P(BlueStore::SharedBlobRef);
   P(boost::intrusive::set_base_hook<>);
+  P(boost::intrusive::unordered_set_base_hook<>);
   P(bufferlist);
   cout << "map<uint64_t,uint64_t>\t" << sizeof(map<uint64_t,uint64_t>) << std::endl;
   cout << "map<char,char>\t" << sizeof(map<char,char>) << std::endl;


### PR DESCRIPTION
Many blobs aren't shared.  Save 8 bytes per SharedBlob by using a normal
unordered_map instead of instrusive::set.

More importantly, perhaps, it avoids us having to tune the intrusive
unordered_set size manually.  std::unordered_map does this automatically
for you, but the intrusive one does not.  And it's unclear how to
statically size it given that it's a per-collection structure and we have
no idea how many objects we'll have, how many blobs per object, and how
many objects will be cloned.

Signed-off-by: Sage Weil <sage@redhat.com>