### PR TITLE
librbd: ignore notify errors on missing image header

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -56,6 +56,10 @@ struct C_NotifyUpdate : public Context {
         // don't fail the op if a peer fails to get the update notification
         lderr(cct) << "update notification timed-out" << dendl;
         r = 0;
+      } else if (r == -ENOENT) {
+        // don't fail if header is missing (e.g. v1 image rename)
+        ldout(cct, 5) << "update notification on missing header" << dendl;
+        r = 0;
       } else if (r < 0) {
         lderr(cct) << "update notification failed: " << cpp_strerror(r)
                    << dendl;


### PR DESCRIPTION
The rename op on v1 images fails since the header no longer exists. In
the general case, the removal of the header object will also fail the
watcher which has its own recovery path.

Fixes: http://tracker.ceph.com/issues/17549
Signed-off-by: Jason Dillaman <dillaman@redhat.com>