### PR TITLE
scripts/release-notes: allow title guesses from gh tags & description update

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -166,7 +166,18 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
+    desc = '''
+    Make ceph release notes for a given revision. Eg usage:
+
+    $ ceph-release-notes -r tags/v0.87..origin/giant $(git rev-parse --show-toplevel)
+
+    It is recommended to set the github env. token in order to avoid
+    hitting the api rate limits.
+    '''
+
+    parser = argparse.ArgumentParser(description=desc,
+                                     formatter_class=argparse.RawTextHelpFormatter)
+
     parser.add_argument("--rev", "-r",
                         help="git revision range for creating release notes")
     parser.add_argument("--text", "-t",

--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -70,8 +70,24 @@ def get_original_issue(issue, verbose):
             print ("http://tracker.ceph.com/issues/" + issue + " has no copied_to relations, do not look for the original issue")
         return issue
 
+def split_component(title,gh,number):
+    title_re = '(bluestore|build/ops|cephfs|cmake|core|common|crush|cli|doc|fs|librados|mds|mon|msgr|mgr|osd|log|librbd|rbd|objecter|pybind|rgw|tests|tools)(:.*)'
+    match = re.match(title_re, title)
+    if match:
+        return match.group(1)+match.group(2)
+    else:
+        issue = gh.repos("ceph")("ceph").issues(number).get()
+        labels = {it['name'] for it in issue['labels']}
+        if 'documentation' in labels:
+            return 'doc: '+ title
+        item = {'bluestore','build/ops','cephfs','common','core','fs','mgr','pybind','rgw','rbd'}.intersection(labels)
+        if item:
+            return ",".join(item)+': '+title
+        else:
+            return 'UNKNOWN: '+ title
 
-def make_release_notes(gh, repo, ref, plaintext, verbose, strict):
+
+def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
 
     issue2prs = {}
     pr2issues = {}
@@ -132,6 +148,8 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict):
                     print ("ERROR: http://github.com/ceph/ceph/pull/" + str(number) + " title " + title.encode("utf-8") + " does not match " + title_re)
                 else:
                     title = match.group(1) + match.group(2)
+            if use_tags:
+                title = split_component(title,gh,number)
 
             pr2info[number] = (author, title, message)
 
@@ -188,14 +206,16 @@ if __name__ == "__main__":
                         help="verbose")
     parser.add_argument("--strict",
                         action='store_true', default=None,
-                        help="strict")
+                        help="strict, recommended only for backport releases")
     parser.add_argument("repo", metavar="repo",
                         help="path to ceph git repo")
     parser.add_argument("--token", default=os.getenv("GITHUB_ACCESS_TOKEN"),
                         help="Github Access Token ($GITHUB_ACCESS_TOKEN otherwise)")
+    parser.add_argument("--use-tags", default=False,
+                        help="Use github tags to guess the component")
 
     args = parser.parse_args()
     gh = github.GitHub(
         access_token=args.token)
 
-    make_release_notes(gh, Repo(args.repo), args.rev, args.text, args.verbose, args.strict)
+    make_release_notes(gh, Repo(args.repo), args.rev, args.text, args.verbose, args.strict, args.use_tags)


### PR DESCRIPTION
basically uses github issue tags to guess the component for the pr, helpful when dealing with large changeset for a release. Also make help a little more descriptive