### PR TITLE
cmake: make python package optional

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,8 @@ if(WITH_CEPHFS_JAVA)
 endif()
 
 # Python stuff
+option(WITH_PYTHON "build python bindings" ON)
+if(WITH_PYTHON)
 find_package(PythonInterp 2 REQUIRED)
 find_package(PythonLibs 2 REQUIRED)
 
@@ -209,7 +211,8 @@ if(WITH_PYTHON3 MATCHES "check|CHECK")
 elseif(WITH_PYTHON3)
   find_package(Python3Interp 3 REQUIRED)
   find_package(Python3Libs 3 REQUIRED)
-endif()
+endif(WITH_PYTHON3)
+endif(WITH_PYTHON)
 
 if(HAVE_XIO)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -I${XIO_INCLUDE_DIR}")
@@ -510,7 +513,16 @@ add_subdirectory(include)
 add_subdirectory(librados)
 add_subdirectory(libradosstriper)
 
-if (WITH_MGR)
+set(librados_config_srcs
+  librados-config.cc)
+add_executable(librados-config ${librados_config_srcs})
+target_link_libraries(librados-config librados global ${BLKID_LIBRARIES}
+  ${CMAKE_DL_LIBS})
+
+install(TARGETS librados-config DESTINATION bin)
+
+if(WITH_PYTHON)
+if(WITH_MGR)
   set(mgr_srcs
       ceph_mgr.cc
       mon/PGMap.cc
@@ -531,14 +543,6 @@ if (WITH_MGR)
   install(TARGETS ceph-mgr DESTINATION bin)
 endif (WITH_MGR)
 
-set(librados_config_srcs
-  librados-config.cc)
-add_executable(librados-config ${librados_config_srcs})
-target_link_libraries(librados-config librados global ${BLKID_LIBRARIES}
-  ${CMAKE_DL_LIBS})
-
-install(TARGETS librados-config DESTINATION bin)
-
 # virtualenv base directory for ceph-disk and ceph-detect-init
 set(CEPH_BUILD_VIRTUALENV $ENV{TMPDIR})
 if(NOT CEPH_BUILD_VIRTUALENV)
@@ -548,6 +552,7 @@ endif()
 add_subdirectory(pybind)
 add_subdirectory(ceph-disk)
 add_subdirectory(ceph-detect-init)
+endif()
 
 ## dencoder
 CHECK_C_COMPILER_FLAG("-fvar-tracking-assignments" HAS_VTA)


### PR DESCRIPTION
added an option to exclude finding the python package. The default
behavior is to still look for Python2. This is option is helpful
when building in containers or other restricted environments, and
you dont want to pull in mighty python. For example, make ceph-mon
builds without python.
