### PR TITLE
osd: recover broken maps automatically

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -688,6 +688,7 @@ OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send 
 // force recovery of broken osdmaps from the monitors
 OPTION(osd_map_recover_broken, OPT_BOOL, false)
 OPTION(osd_map_recover_broken_timeout, OPT_FLOAT, 30.0)
+OPTION(osd_map_recover_broken_shutdown_after, OPT_BOOL, true)
 // debug osd map recovery at (does not necessarily kill the osd)
 OPTION(osd_map_recover_broken_debug_at, OPT_INT, 0)
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -688,6 +688,8 @@ OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send 
 // force recovery of broken osdmaps from the monitors
 OPTION(osd_map_recover_broken, OPT_BOOL, false)
 OPTION(osd_map_recover_broken_timeout, OPT_FLOAT, 30.0)
+// debug osd map recovery at (does not necessarily kill the osd)
+OPTION(osd_map_recover_broken_debug_at, OPT_INT, 0)
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
 // shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -687,6 +687,7 @@ OPTION(osd_map_message_max, OPT_INT, 100)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send to peers, clients
 // force recovery of broken osdmaps from the monitors
 OPTION(osd_map_recover_broken, OPT_BOOL, false)
+OPTION(osd_map_recover_broken_timeout, OPT_FLOAT, 30.0)
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
 // shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -685,6 +685,8 @@ OPTION(osd_map_max_advance, OPT_INT, 150) // make this < cache_size!
 OPTION(osd_map_cache_size, OPT_INT, 200)
 OPTION(osd_map_message_max, OPT_INT, 100)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send to peers, clients
+// force recovery of broken osdmaps from the monitors
+OPTION(osd_map_recover_broken, OPT_BOOL, false)
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
 // shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds

--- a/src/messages/MMonGetOSDMap.h
+++ b/src/messages/MMonGetOSDMap.h
@@ -16,7 +16,7 @@
 #define CEPH_MMONGETOSDMAP_H
 
 #include "msg/Message.h"
-
+#include "messages/PaxosServiceMessage.h"
 #include "include/types.h"
 
 class MMonGetOSDMap : public PaxosServiceMessage {

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -21,6 +21,7 @@ set(osd_srcs
   ScrubStore.cc
   osd_types.cc
   ECUtil.cc
+  OSDMapRecovery.cc
   ${CMAKE_SOURCE_DIR}/src/common/TrackedOp.cc
   ${osdc_osd_srcs})
 if(HAS_VTA)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1253,19 +1253,19 @@ void OSDService::send_incremental_map(epoch_t since, Connection *con,
   send_map(m, con);
 }
 
-bool OSDService::_get_map_bl(epoch_t e, bufferlist& bl)
+bool OSDService::_get_map_bl(epoch_t e, bufferlist& bl, bool cache)
 {
   bool found = map_bl_cache.lookup(e, &bl);
   if (found)
     return true;
   found = store->read(coll_t::meta(),
 		      OSD::get_osdmap_pobject_name(e), 0, 0, bl) >= 0;
-  if (found)
+  if (found && cache)
     _add_map_bl(e, bl);
   return found;
 }
 
-bool OSDService::get_inc_map_bl(epoch_t e, bufferlist& bl)
+bool OSDService::get_inc_map_bl(epoch_t e, bufferlist& bl, bool cache)
 {
   Mutex::Locker l(map_cache_lock);
   bool found = map_bl_inc_cache.lookup(e, &bl);
@@ -1273,7 +1273,7 @@ bool OSDService::get_inc_map_bl(epoch_t e, bufferlist& bl)
     return true;
   found = store->read(coll_t::meta(),
 		      OSD::get_inc_osdmap_pobject_name(e), 0, 0, bl) >= 0;
-  if (found)
+  if (found && cache)
     _add_map_inc_bl(e, bl);
   return found;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2161,9 +2161,12 @@ int OSD::init()
     r = _recover_broken_maps();
     if (r < 0) {
       derr << "OSD::init: error attempting broken maps recovery -- dying!" << dendl;
-      return r;
+      goto out;
     } else {
-      dout(0) << "OSD::init: recovered broken maps -- continuing!" << dendl;
+      dout(0) << "OSD::init: recovered broken maps -- shutdown." << dendl;
+      // force the user to restart the osd without '--osd-map-recover-broken'
+      r = -EAGAIN;
+      goto out;
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2157,6 +2157,22 @@ int OSD::init()
       goto out;
   }
 
+  if (g_conf->osd_map_recover_broken) {
+    if (!cct->check_experimental_feature_enabled("osd_map_recover_broken")) {
+      derr << "OSD::init: unable to attempt recovery of broken maps; "
+           << "requires experimental feature 'osd_map_recover_broken' enabled"
+           << dendl;
+      return -EINVAL;
+    }
+    r = _recover_broken_maps();
+    if (r < 0) {
+      derr << "OSD::init: error attempting broken maps recovery -- dying!" << dendl;
+      return r;
+    } else {
+      dout(0) << "OSD::init: recovered broken maps -- continuing!" << dendl;
+    }
+  }
+
   class_handler = new ClassHandler(cct);
   cls_initialize(class_handler);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2163,10 +2163,14 @@ int OSD::init()
       derr << "OSD::init: error attempting broken maps recovery -- dying!" << dendl;
       goto out;
     } else {
-      dout(0) << "OSD::init: recovered broken maps -- shutdown." << dendl;
-      // force the user to restart the osd without '--osd-map-recover-broken'
-      r = -EAGAIN;
-      goto out;
+      if (g_conf->osd_map_recover_broken_shutdown_after) {
+        dout(0) << "OSD::init: recovered broken maps -- shutdown." << dendl;
+        // force the user to restart the osd without '--osd-map-recover-broken'
+        r = -EAGAIN;
+        goto out;
+      } else {
+        dout(0) << "OSD::init: recovered broken maps -- continue." << dendl;
+      }
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1617,17 +1617,11 @@ int OSD::_recover_broken_maps()
 {
   dout(0) << __func__ << " attempt to recover broken maps" << dendl;
 
-  OSDMapRecovery omr(cct, this);
-  list<pair<epoch_t, epoch_t> > ranges;
-
   epoch_t max = MAX(superblock.newest_map, superblock.current_epoch);
   dout(0) << __func__ << " looking at epochs [" << superblock.oldest_map
           << " .. " << max << "]" << dendl;
 
-  if (!omr.find_broken_ranges(superblock.oldest_map, max, ranges)) {
-    dout(0) << "no broken maps were found" << dendl;
-    return 0;
-  }
+  OSDMapRecovery omr(cct, this);
 
   int r = omr.init();
   if (r < 0) {
@@ -1635,11 +1629,11 @@ int OSD::_recover_broken_maps()
     return r;
   }
 
-  r = omr.recover(superblock.oldest_map, superblock.newest_map);
+  r = omr.recover(superblock.oldest_map, max);
   if (r < 0) {
     derr << "unable to recover maps" << dendl;
   } 
-  return 0;
+  return r;
 }
 
 #undef dout_prefix

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2499,9 +2499,9 @@ public:
   friend class OSDService;
 
   struct corrupt_map : public std::exception {
-    epoch_t epoch;
+    const epoch_t epoch;
     explicit corrupt_map(epoch_t e) : epoch(e) { }
-    const char *what() const throw();
+    const char *what() const override noexcept;
   };
 };
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1016,11 +1016,11 @@ public:
   }
   void pin_map_bl(epoch_t e, bufferlist &bl);
   void _add_map_bl(epoch_t e, bufferlist& bl);
-  bool get_map_bl(epoch_t e, bufferlist& bl) {
+  bool get_map_bl(epoch_t e, bufferlist& bl, bool cache = true) {
     Mutex::Locker l(map_cache_lock);
-    return _get_map_bl(e, bl);
+    return _get_map_bl(e, bl, cache);
   }
-  bool _get_map_bl(epoch_t e, bufferlist& bl);
+  bool _get_map_bl(epoch_t e, bufferlist& bl, bool cache = true);
 
   void add_map_inc_bl(epoch_t e, bufferlist& bl) {
     Mutex::Locker l(map_cache_lock);
@@ -1028,7 +1028,7 @@ public:
   }
   void pin_map_inc_bl(epoch_t e, bufferlist &bl);
   void _add_map_inc_bl(epoch_t e, bufferlist& bl);
-  bool get_inc_map_bl(epoch_t e, bufferlist& bl);
+  bool get_inc_map_bl(epoch_t e, bufferlist& bl, bool cache = true);
 
   void clear_map_bl_cache_pins(epoch_t e);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2472,6 +2472,8 @@ private:
 
   int init_op_flags(OpRequestRef& op);
 
+  int _recover_broken_maps();
+
 public:
   static int peek_meta(ObjectStore *store, string& magic,
 		       uuid_d& cluster_fsid, uuid_d& osd_fsid, int& whoami);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2495,6 +2495,12 @@ public:
 public:
   OSDService service;
   friend class OSDService;
+
+  struct corrupt_map : public std::exception {
+    epoch_t epoch;
+    explicit corrupt_map(epoch_t e) : epoch(e) { }
+    const char *what() const throw();
+  };
 };
 
 //compatibility of the executable

--- a/src/osd/OSDMapRecovery.cc
+++ b/src/osd/OSDMapRecovery.cc
@@ -1,0 +1,389 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <iostream>
+#include <errno.h>
+
+#include "osd/OSD.h"
+#include "osd/OSDMap.h"
+#include "osd/OSDMapRecovery.h"
+
+#include "os/ObjectStore.h"
+
+#include "msg/Messenger.h"
+#include "msg/Message.h"
+#include "mon/MonClient.h"
+
+#include "messages/MOSDMap.h"
+#include "messages/MMonGetOSDMap.h"
+
+#include "common/ceph_context.h"
+#include "common/errno.h"
+#include "include/assert.h"
+#include "common/config.h"
+
+#define dout_subsys ceph_subsys_osd
+#undef dout_prefix
+#define dout_prefix _prefix(_dout, this)
+
+static ostream& _prefix(std::ostream* _dout, OSDMapRecovery *osdmr) {
+  return *_dout << "osd." << osdmr->osd->get_nodeid()
+                << " osdmr(" << osdmr->get_state() << ") ";
+}
+
+/* OSDMapRecovery attempts to recover broken osd maps by asking them from
+ * the monitors. Recovering osd maps may mask other corruptions. This should
+ * be considered solely as a last resort.
+ *
+ * This is how it goes:
+ *
+ * 'init' gets basic requirements set up
+ *
+ *  - a dedicated messenger, so we don't mess with the OSDs own client ms
+ *  - a mon client, dully authenticated
+ *
+ */
+int OSDMapRecovery::init()
+{
+  int auth_attempts = 0;
+  int max_auth_attempts = 10;
+
+  int ret = monc.build_initial_monmap();
+  if (ret < 0)
+    return ret;
+
+  ms = Messenger::create_client_messenger(cct, "recover_mon_client");
+  if (!ms) {
+    return -EINVAL;
+  }
+  monc.set_messenger(ms);
+  ret = monc.init();
+  if (ret < 0) {
+    derr << __func__ << " error initiating monclient" << dendl;
+    goto err_out;
+  }
+  ret = monc.authenticate();
+  if (ret < 0) {
+    derr << __func__ << " unable to authenticate with monitors" << dendl;
+    goto err_out;
+  }
+
+  while (monc.wait_auth_rotating(30.0) < 0) {
+    if (++auth_attempts > max_auth_attempts) {
+      derr << __func__ << " unable to get rotating auth keys" << dendl;
+      ret = -EINVAL;
+      goto err_monout;
+    }
+  }
+
+  ms->add_dispatcher_head(this);
+  state = STATE_INIT;
+
+  return 0;
+
+ err_monout:
+  monc.shutdown();
+ err_out:
+  ms->shutdown();
+  delete ms;
+  return ret;
+}
+
+void OSDMapRecovery::clear() {
+  dout(0) << __func__ << dendl;
+
+  Mutex::Locker l(lock);
+  wanted.first = wanted.second = 0;
+  wanted_available.first = wanted_available.second = 0;
+  remote_available.first = remote_available.second = 0;
+
+  maps.clear();
+  incremental_maps.clear();
+}
+
+bool OSDMapRecovery::ms_dispatch(Message *m)
+{
+  Mutex::Locker l(lock);
+
+  dout(20) << __func__ << " " << m << " " << *m << dendl;
+
+  if (m->get_type() != CEPH_MSG_OSD_MAP) {
+    dout(10) << __func__ << " unhandled message" << dendl;
+    return false;
+  }
+
+  if (state != STATE_WAIT_MON) {
+    dout(0) << __func__ << " unexpected message -- drop!" << dendl;
+    m->put();
+    return true;
+  }
+
+  MOSDMap *mm = static_cast<MOSDMap*>(m);
+
+  dout(0) << __func__ << " got maps ["
+          << mm->get_first() << " .. " << mm->get_last()
+          << "], wanted [" << wanted.first
+          << " .. " << wanted.second << "]"
+          << ", remote has [ " << mm->oldest_map
+          << " .. " << mm->newest_map << "]"
+          << dendl;
+
+  remote_available = make_pair(mm->oldest_map, mm->newest_map);
+
+  if (mm->get_first() == 0 &&
+      mm->get_last() == 0 &&
+      wanted.first != 0 &&
+      wanted.second != 0) {
+    m->put();
+    return true;
+  }
+
+  wanted_available.first = wanted_available.second = 0;
+  pair<epoch_t,epoch_t> &war = wanted_available; // wanted available range
+
+  // check if received values are within wanted range
+  if (wanted.first >= mm->get_first()) {
+    if (wanted.second <= mm->get_last()) {
+      war = wanted;
+    } else {
+      war.first = wanted.first;
+      war.second = mm->get_last();
+    }
+  } else if (wanted.second >= mm->get_first()) {
+    war.first = mm->get_first();
+    if (wanted.second <= mm->get_last()) {
+      war.second = wanted.second;
+    } else {
+      war.second = mm->get_last();
+    }
+  }
+
+  dout(0) << __func__ << " wanted available range ["
+          << war.first << " .. " << war.second << "]" << dendl;
+  if (war.first == 0 && war.second == 0) {
+    // there's nothing we want. drop it.
+    dout(0) << __func__ << " nothing we want -- drop!" << dendl;
+    m->put();
+    return true;
+  }
+
+  for (auto e : mm->maps) {
+    if (e.first < war.first || e.first > war.second)
+      continue;
+    maps[e.first] = e.second;
+  }
+
+  for (auto e : mm->incremental_maps) {
+    if (e.first < war.first || e.first > war.second)
+      continue;
+    incremental_maps[e.first] = e.second;
+  }
+
+  dout(0) << __func__ << " have " << maps.size()
+          << " maps and " << incremental_maps.size()
+          << " incremental maps" << dendl;
+
+  wanted_cond.SignalAll();
+
+  return true;
+}
+
+int OSDMapRecovery::recover_range(
+    const pair<epoch_t,epoch_t> &r,
+    list<pair<epoch_t,epoch_t> >& missing)
+{
+  dout(10) << __func__ << " [" << r.first << " .. "
+           << r.second << "]" << dendl;
+
+  clear();
+
+  lock.Lock();
+  wanted = r;
+  MMonGetOSDMap *req = new MMonGetOSDMap;
+  req->request_full(r.first, r.second);
+  monc.send_mon_message(req);
+
+  state = STATE_WAIT_MON;
+  wanted_cond.Wait(lock);
+
+  state = STATE_WORKING;
+  dout(0) << __func__ << " got available range ["
+          << wanted_available.first << " .. "
+          << wanted_available.second << "]" << dendl;
+
+  int err = 0;
+  if (!_contained_in(wanted, wanted_available)) {
+    dout(0) << __func__ << " didn't get a valid range" << dendl;
+    if (!_contained_in(wanted, remote_available)) {
+      dout(0) << __func__
+              << " monitor does not have available the requested maps"
+              << " (available [" << remote_available.first
+              << " .. " << remote_available.second << "]"
+              << dendl;
+      err = -ENOENT;
+    } else {
+      err = -ERANGE;
+    }
+    lock.Unlock();
+    return err;
+  }
+
+  if (wanted.first < wanted_available.first) {
+    pair<epoch_t,epoch_t> p;
+    p.first = wanted.first;
+    p.second = wanted_available.first - 1;
+    missing.push_back(p);
+  }
+
+  if (wanted.second > wanted_available.second) {
+    pair<epoch_t,epoch_t> p;
+    p.first = wanted_available.second + 1;
+    p.second = wanted.second;
+    missing.push_back(p);
+  }
+
+  if (!missing.empty()) {
+    dout(0) << __func__ << " missing ranges " << missing << dendl;
+  }
+
+  ObjectStore::Transaction t;
+  for (epoch_t e = wanted_available.first;
+       e <= wanted_available.second;
+       ++e) {
+
+    auto i = maps.find(e);
+    if (i != maps.end()) {
+      dout(10) << __func__ << " full map epoch " << e << dendl;
+      OSDMap *o = new OSDMap;
+      bufferlist& bl = i->second;
+      o->decode(bl);
+      dout(0) << *o << dendl;
+      assert(bl.length() > 0);
+      ghobject_t fulloid = osd->get_osdmap_pobject_name(e);
+      t.write(coll_t::meta(), fulloid, 0, bl.length(), bl);
+      //maps.erase(e);
+    }
+
+    i = incremental_maps.find(e);
+    if (i != incremental_maps.end()) {
+      dout(10) << __func__ << " inc map epoch " << e << dendl;
+      bufferlist& bl = i->second;
+      ghobject_t incoid = osd->get_inc_osdmap_pobject_name(e);
+      t.write(coll_t::meta(), incoid, 0, bl.length(), bl);
+      // incremental_maps.erase(e);
+    }
+  }
+  err = osd->service.store->apply_transaction(
+      osd->service.meta_osr.get(),
+      std::move(t));
+  if (err < 0) {
+    derr << __func__ << " unable to apply transaction" << dendl;
+  }
+
+  lock.Unlock();
+  return err;
+}
+
+int OSDMapRecovery::recover_single(epoch_t e)
+{
+  state = STATE_RECOVERING;
+  dout(0) << __func__ << " epoch " << e << dendl;
+
+  pair<epoch_t,epoch_t> p = make_pair(e, e);
+  list<pair<epoch_t,epoch_t> > missing;
+  int r = recover_range(p, missing);
+  if (r < 0) {
+    derr << __func__ << " unable to recover epoch " << e << dendl;
+    return r;
+  }
+  assert(missing.empty());
+
+  state = STATE_DONE;
+  return 0;
+}
+
+int OSDMapRecovery::recover(const epoch_t first, const epoch_t last)
+{
+  state = STATE_RECOVERING;
+  dout(10) << __func__ << " epochs from " << first
+           << " to " << last << dendl;
+
+  list<pair<epoch_t,epoch_t> > ranges;
+  if (!find_broken_ranges(first, last, ranges)) {
+    dout(0) << __func__ << " no broken ranges found" << dendl;
+    return 0;
+  }
+
+  while (!ranges.empty()) {
+    pair<epoch_t,epoch_t> r = ranges.front();
+    ranges.pop_front();
+
+    list<pair<epoch_t,epoch_t> > missing;
+    int ret = recover_range(r, missing);
+    if (ret < 0) {
+      derr << __func__ << " error recovering range ["
+        << r.first << " .. " << r.second << "]" << dendl;
+      return ret;
+    }
+    if (!missing.empty()) {
+      ranges.splice(ranges.begin(), missing);
+    }
+  }
+
+  state = STATE_DONE;
+  return 0;
+}
+
+
+bool OSDMapRecovery::find_broken_ranges(
+    epoch_t first,
+    epoch_t last,
+    list<pair<epoch_t,epoch_t> >& ranges) {
+
+  dout(10) << __func__ << " [" << first << " .. " << last << "]" << dendl;
+
+  for (auto e = first; e <= last; e ++) {
+
+    bool broken = false;
+    try {
+      bufferlist bl;
+
+      if (!osd->service.get_map_bl(e, bl, false) || bl.length() == 0) {
+        throw ceph::buffer::end_of_buffer();
+      }
+
+      OSDMap m;
+      m.decode(bl);
+
+    } catch (ceph::buffer::end_of_buffer e) {
+      broken = true;
+    } catch (ceph::buffer::malformed_input e) {
+      broken = true;
+    }
+
+    if (broken) {
+      dout(0) << __func__ << " epoch " << e << " broken" << dendl;
+
+      auto &l = ranges.back();
+      if (l.second == (e - 1)) {
+        l.second = e;
+      } else {
+        ranges.push_back(std::make_pair(e, e));
+      }
+    }
+  }
+
+  return !ranges.empty();
+}
+

--- a/src/osd/OSDMapRecovery.cc
+++ b/src/osd/OSDMapRecovery.cc
@@ -149,6 +149,12 @@ bool OSDMapRecovery::ms_dispatch(Message *m)
     return true;
   }
 
+  if (g_conf->osd_map_recover_broken_debug_at == 1) {
+    dout(0) << __func__ << " [debug] drop message" << dendl;
+    m->put();
+    return true;
+  }
+
   wanted_available.first = wanted_available.second = 0;
   pair<epoch_t,epoch_t> &war = wanted_available; // wanted available range
 

--- a/src/osd/OSDMapRecovery.h
+++ b/src/osd/OSDMapRecovery.h
@@ -1,0 +1,132 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <iostream>
+#include <errno.h>
+
+#include "osd/OSD.h"
+#include "osd/OSDMap.h"
+
+#include "msg/Messenger.h"
+#include "msg/Message.h"
+#include "mon/MonClient.h"
+
+#include "common/ceph_context.h"
+#include "common/errno.h"
+#include "include/assert.h"
+#include "include/types.h"
+#include "common/config.h"
+
+struct OSDMapRecovery : public Dispatcher {
+
+  OSD *osd;
+  epoch_t broken_epoch;
+  bool single_epoch;
+
+  MonClient monc;
+  Messenger *ms;
+
+  Mutex lock;
+  Cond wanted_cond;
+  pair<epoch_t, epoch_t> wanted;
+  pair<epoch_t, epoch_t> wanted_available;
+  pair<epoch_t,epoch_t> remote_available;
+  // received from the monitors
+  map<epoch_t, bufferlist> maps;
+  map<epoch_t, bufferlist> incremental_maps;
+
+  enum state_t {
+    STATE_NONE,
+    STATE_INIT,
+    STATE_RECOVERING,
+    STATE_WAIT_MON,
+    STATE_WORKING,
+    STATE_DONE,
+    STATE_NOT_AVAILABLE
+  } state;
+
+  const char *get_state() {
+    switch (state) {
+      case STATE_NONE:
+        return "none";
+      case STATE_INIT:
+        return "init";
+      case STATE_RECOVERING:
+        return "recovering";
+      case STATE_WAIT_MON:
+        return "wait_mon";
+      case STATE_WORKING:
+        return "working";
+      case STATE_DONE:
+        return "done";
+      case STATE_NOT_AVAILABLE:
+        return "n/a";
+    }
+    return "unknown";
+  }
+
+
+  explicit OSDMapRecovery(CephContext *_cct, OSD *_osd) :
+    Dispatcher(_cct),
+    osd(_osd),
+    single_epoch(false),
+    monc(_cct),
+    ms(nullptr),
+    lock("OSDMR::lock"),
+    state(STATE_NONE)
+  { }
+  explicit OSDMapRecovery(CephContext *_cct, OSD *_osd, epoch_t e) :
+    Dispatcher(_cct),
+    osd(_osd),
+    broken_epoch(e),
+    single_epoch(true),
+    monc(_cct),
+    ms(nullptr),
+    lock("OSDMR::lock"),
+    state(STATE_NONE)
+  { }
+
+  virtual ~OSDMapRecovery() {
+    Mutex::Locker l(lock);
+
+    state = STATE_NONE;
+    monc.shutdown();
+    if (ms) {
+      ms->shutdown();
+      delete ms;
+    }
+  }
+
+  int init();
+  void clear();
+  bool ms_dispatch(Message *m);
+
+  bool ms_handle_reset(Connection *con) { return false; }
+  void ms_handle_remote_reset(Connection *con) { }
+
+  bool _contained_in(const pair<epoch_t,epoch_t>& a,
+                     const pair<epoch_t,epoch_t>& b) const {
+    return (b.first >= a.first && b.second <= a.second);
+  }
+
+  int recover_range(const pair<epoch_t,epoch_t> &r,
+                    list<pair<epoch_t,epoch_t> >& missing);
+  int recover_single(epoch_t e);
+  int recover(const epoch_t first, const epoch_t last);
+
+  bool find_broken_ranges(epoch_t first,
+                          epoch_t last,
+                          list<pair<epoch_t,epoch_t> >& ranges);
+};
+

--- a/src/osd/OSDMapRecovery.h
+++ b/src/osd/OSDMapRecovery.h
@@ -134,6 +134,12 @@ struct OSDMapRecovery : public Dispatcher {
 
   bool ms_handle_reset(Connection *con) { return false; }
   void ms_handle_remote_reset(Connection *con) { }
+  bool ms_handle_refused(Connection *con) {
+    /* if the connection is being refused by the current monitor, we presume
+     * the monclient will figure it out.
+     */
+    return false;
+  }
 
   bool _contained_in(const pair<epoch_t,epoch_t>& a,
                      const pair<epoch_t,epoch_t>& b) const {

--- a/src/osd/OSDMapRecovery.h
+++ b/src/osd/OSDMapRecovery.h
@@ -28,6 +28,37 @@
 #include "include/types.h"
 #include "common/config.h"
 
+
+/**
+ * Recover broken osd maps automatically by requesting the broken maps
+ * from the monitors.
+ *
+ * This class will create its own messenger and monclient, keeping itself
+ * separated from the OSD's so as to be as unobtrusive as possible during
+ * the OSD's init process.
+ *
+ * The recover workflow starts with the `recover()` function, which will
+ * first init the class - setup messenger and monclient -, and then proceed
+ * to finding all the broken maps and recover any broken ranges that may be
+ * found.
+ *
+ * Finding broken maps, may they be full or incremental, relies on reading
+ * map epochs from disk and decoding them. Maps with zero length are
+ * considered somehow corrupt, as well as any maps which throw exceptions
+ * during decode.
+ *
+ * Ranges will be asked from the monitors, and replies will be handled by
+ * `ms_dispatch()`. The process is blocking, with the recovery function
+ * `recover_range()` blocking while waiting for an adequate reply to be
+ * handled by `ms_dispatch()`. If `osd_map_recover_broken_timeout` is
+ * greater than zero, a timeout will be triggered if we don't get an
+ * adequate reply in the mean time.
+ *
+ * Given a reply with the wanted range, those maps will then be written
+ * off to disk. Once all the broken maps have been written to disk, the
+ * recovery will finish successfuly.
+ *
+ */
 struct OSDMapRecovery : public Dispatcher {
 
   OSD *osd;


### PR DESCRIPTION
We've seen situations in which the osdmaps or incremental maps happen to be completely zeroed out or end up getting corrupt after a series of server failures.

In some of these situations, the osds were unable to boot, dying horrible deaths on init. Recovering from these failures were just a matter of copying the right maps from a healthy osd to the affected osds, but this still had to be a manual task.

This series of patches solves the issue by automating the map recovery, by requesting the broken maps from the monitors and writing them to disk.

Recovery is not enabled by default and depends on an experimental feature ("osd_map_recover_broken") to be enabled, thus delegating to the administrator the responsibility of opting to use the automated recovery. Furthermore, we also add the possibility of proceeding with normal osd init after recovering the maps, although, again, this is not enabled by default.

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`
