### PR TITLE
jewel: crushtool --compile is create output despite of missing item

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -746,8 +746,8 @@ int CrushCompiler::parse_crush(iter_t const& i)
 { 
   find_used_bucket_ids(i);
 
-  int r = 0;
   for (iter_t p = i->children.begin(); p != i->children.end(); p++) {
+    int r = 0;
     switch (p->value.id().to_long()) {
     case crush_grammar::_tunable:
       r = parse_tunable(p);
@@ -767,10 +767,10 @@ int CrushCompiler::parse_crush(iter_t const& i)
     default:
       assert(0);
     }
+    if (r < 0) {
+      return r;
+    }
   }
-
-  if (r < 0)
-    return r;
 
   //err << "max_devices " << crush.get_max_devices() << std::endl;
   crush.finalize();

--- a/src/test/cli/crushtool/compile-decompile-recompile.t
+++ b/src/test/cli/crushtool/compile-decompile-recompile.t
@@ -9,3 +9,7 @@
 # worked
   $ cmp need_tree_order.crush nto.conf
   $ cmp nto.compiled nto.recompiled
+
+  $ crushtool -c missing-bucket.crushmap.txt
+  in rule 'rule-bad' item 'root-404' not defined
+  [1]

--- a/src/test/cli/crushtool/compile-decompile-recompile.t
+++ b/src/test/cli/crushtool/compile-decompile-recompile.t
@@ -10,6 +10,6 @@
   $ cmp need_tree_order.crush nto.conf
   $ cmp nto.compiled nto.recompiled
 
-  $ crushtool -c missing-bucket.crushmap.txt
+  $ crushtool -c "$TESTDIR/missing-bucket.crushmap.txt"
   in rule 'rule-bad' item 'root-404' not defined
   [1]

--- a/src/test/cli/crushtool/missing-bucket.crushmap.txt
+++ b/src/test/cli/crushtool/missing-bucket.crushmap.txt
@@ -1,0 +1,39 @@
+device 0 device0
+device 1 device1
+device 2 device2
+device 3 device3
+device 4 device4
+
+type 0 osd
+type 1 domain
+
+domain root {
+	id -1
+	alg straw
+	hash 0
+	item device0 weight 1.000
+	item device1 weight 1.000
+	item device2 weight 1.000
+	item device3 weight 1.000
+	item device4 weight 1.000
+}
+
+rule rule-bad {
+	ruleset 0
+	type replicated
+	min_size 1
+	max_size 10
+	step take root-404
+	step choose firstn 0 type osd
+	step emit
+}
+
+rule rule-good {
+	ruleset 1
+	type erasure
+	min_size 1
+	max_size 10
+	step take root
+	step choose indep 0 type osd
+	step emit
+}


### PR DESCRIPTION
http://tracker.ceph.com/issues/17334
