### PR TITLE
jewel: Crash in Client::_invalidate_kernel_dcache when reconnecting during unmount

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3923,6 +3923,8 @@ public:
 
 void Client::_invalidate_kernel_dcache()
 {
+  if (unmounting)
+    return;
   if (can_invalidate_dentries && dentry_invalidate_cb && root->dir) {
     for (ceph::unordered_map<string, Dentry*>::iterator p = root->dir->dentries.begin();
 	 p != root->dir->dentries.end();


### PR DESCRIPTION
http://tracker.ceph.com/issues/17477