### PR TITLE
jewel: Log path as well as ino when detecting metadata damage

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -42,6 +42,8 @@ struct ObjectOperation;
 
 ostream& operator<<(ostream& out, const class CDir& dir);
 class CDir : public MDSCacheObject {
+  friend ostream& operator<<(ostream& out, const class CDir& dir);
+
   /*
    * This class uses a boost::pool to handle allocation. This is *not*
    * thread-safe, so don't do allocations from multiple threads!
@@ -509,6 +511,8 @@ private:
    *             <parent,mds2>       subtree_root     
    */
   mds_authority_t dir_auth;
+
+  std::string get_path() const;
 
  public:
   mds_authority_t authority() const;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -52,7 +52,7 @@ void SessionMap::dump()
 	     << " state " << p->second->get_state_name()
 	     << " completed " << p->second->info.completed_requests
 	     << " prealloc_inos " << p->second->info.prealloc_inos
-	     << " used_ions " << p->second->info.used_inos
+	     << " used_inos " << p->second->info.used_inos
 	     << dendl;
 }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/17246