### PR TITLE
Small pile of random cephfs fixes and cleanup

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6842,12 +6842,10 @@ void Client::fill_statx(Inode *in, unsigned int mask, struct ceph_statx *stx)
   /* These are always considered to be available */
   stx->stx_dev = in->snapid;
   stx->stx_blksize = MAX(in->layout.stripe_unit, 4096);
-  stx->stx_mode = S_IFMT & in->mode;
 
-  if (use_faked_inos())
-   stx->stx_ino = in->faked_ino;
-  else
-    stx->stx_ino = in->ino;
+  /* Type bits are always set, even when CEPH_STATX_MODE is not */
+  stx->stx_mode = S_IFMT & in->mode;
+  stx->stx_ino = use_faked_inos() ? in->faked_ino : (ino_t)in->ino;
   stx->stx_rdev = in->rdev;
   stx->stx_mask |= (CEPH_STATX_INO|CEPH_STATX_RDEV);
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6658,7 +6658,7 @@ int Client::setattrx(const char *relpath, struct ceph_statx *stx, int mask,
 
   filepath path(relpath);
   InodeRef in;
-  int r = path_walk(path, &in, perms, flags & AT_SYMLINK_NOFOLLOW);
+  int r = path_walk(path, &in, perms, !(flags & AT_SYMLINK_NOFOLLOW));
   if (r < 0)
     return r;
   return _setattrx(in, stx, mask, perms);
@@ -6738,7 +6738,7 @@ int Client::statx(const char *relpath, struct ceph_statx *stx,
 
   unsigned mask = statx_to_mask(flags, want);
 
-  int r = path_walk(path, &in, perms, flags & AT_SYMLINK_NOFOLLOW, mask);
+  int r = path_walk(path, &in, perms, !(flags & AT_SYMLINK_NOFOLLOW), mask);
   if (r < 0)
     return r;
 

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6047,8 +6047,7 @@ int Client::get_or_create(Inode *dir, const char* name,
 }
 
 int Client::path_walk(const filepath& origpath, InodeRef *end,
-		      const UserPerm& perms, bool followsym,
-		      int mask, int uid, int gid)
+		      const UserPerm& perms, bool followsym, int mask)
 {
   filepath path = origpath;
   InodeRef cur;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9905,7 +9905,7 @@ Inode *Client::ll_get_inode(vinodeno_t vino)
   return in;
 }
 
-int Client::_ll_getattr(Inode *in, const UserPerm& perms)
+int Client::_ll_getattr(Inode *in, int caps, const UserPerm& perms)
 {
   vinodeno_t vino = _get_vino(in);
 
@@ -9916,14 +9916,14 @@ int Client::_ll_getattr(Inode *in, const UserPerm& perms)
   if (vino.snapid < CEPH_NOSNAP)
     return 0;
   else
-    return _getattr(in, CEPH_STAT_CAP_INODE_ALL, perms);
+    return _getattr(in, caps, perms);
 }
 
 int Client::ll_getattr(Inode *in, struct stat *attr, const UserPerm& perms)
 {
   Mutex::Locker lock(client_lock);
 
-  int res = _ll_getattr(in, perms);
+  int res = _ll_getattr(in, CEPH_STAT_CAP_INODE_ALL, perms);
 
   if (res == 0)
     fill_stat(in, attr);
@@ -9940,7 +9940,7 @@ int Client::ll_getattrx(Inode *in, struct ceph_statx *stx, unsigned int want,
   unsigned mask = statx_to_mask(flags, want);
 
   if (mask && !in->caps_issued_mask(mask))
-    res = _ll_getattr(in, perms);
+    res = _ll_getattr(in, mask, perms);
 
   if (res == 0)
     fill_statx(in, mask, stx);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6742,12 +6742,10 @@ int Client::statx(const char *relpath, struct ceph_statx *stx,
   if (r < 0)
     return r;
 
-  if (mask && !in->caps_issued_mask(mask)) {
-    r = _getattr(in, mask, perms);
-    if (r < 0) {
-      ldout(cct, 3) << "statx exit on error!" << dendl;
-      return r;
-    }
+  r = _getattr(in, mask, perms);
+  if (r < 0) {
+    ldout(cct, 3) << "statx exit on error!" << dendl;
+    return r;
   }
 
   fill_statx(in, mask, stx);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -516,7 +516,7 @@ protected:
   // path traversal for high-level interface
   InodeRef cwd;
   int path_walk(const filepath& fp, InodeRef *end, const UserPerm& perms,
-		bool followsym=true, int mask=0, int uid=-1, int gid=-1);
+		bool followsym=true, int mask=0);
 		
   int fill_stat(Inode *in, struct stat *st, frag_info_t *dirstat=0, nest_info_t *rstat=0);
   int fill_stat(InodeRef& in, struct stat *st, frag_info_t *dirstat=0, nest_info_t *rstat=0) {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -921,7 +921,7 @@ private:
 
   mds_rank_t _get_random_up_mds() const;
 
-  int _ll_getattr(Inode *in, const UserPerm& perms);
+  int _ll_getattr(Inode *in, int caps, const UserPerm& perms);
 
 public:
   int mount(const std::string &mount_root, const UserPerm& perms,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -809,7 +809,6 @@ private:
 	      const char *data_pool, bool *created, const UserPerm &perms);
 
   loff_t _lseek(Fh *fh, loff_t offset, int whence);
-  loff_t _lseek(Fh *fh, loff_t offset, int whence, const UserPerm& perms);
   int _read(Fh *fh, int64_t offset, uint64_t size, bufferlist *bl);
   int _write(Fh *fh, int64_t offset, uint64_t size, const char *buf,
           const struct iovec *iov, int iovcnt);
@@ -1033,7 +1032,7 @@ public:
   int lookup_parent(Inode *in, const UserPerm& perms, Inode **parent=NULL);
   int lookup_name(Inode *in, Inode *parent, const UserPerm& perms);
   int close(int fd);
-  loff_t lseek(int fd, loff_t offset, int whence, const UserPerm& perms);
+  loff_t lseek(int fd, loff_t offset, int whence);
   int read(int fd, char *buf, loff_t size, loff_t offset=-1);
   int preadv(int fd, const struct iovec *iov, int iovcnt, loff_t offset=-1);
   int write(int fd, const char *buf, loff_t size, loff_t offset=-1);
@@ -1168,7 +1167,7 @@ public:
 
   int ll_read(Fh *fh, loff_t off, loff_t len, bufferlist *bl);
   int ll_write(Fh *fh, loff_t off, loff_t len, const char *data);
-  loff_t ll_lseek(Fh *fh, loff_t offset, int whence, const UserPerm& perms);
+  loff_t ll_lseek(Fh *fh, loff_t offset, int whence);
   int ll_flush(Fh *fh);
   int ll_fsync(Fh *fh, bool syncdataonly);
   int ll_fallocate(Fh *fh, int mode, loff_t offset, loff_t length);

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -1173,7 +1173,7 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
       int fd = open_files[f];
       int64_t off = t.get_int();
       int64_t whence = t.get_int();
-      client->lseek(fd, off, whence, perms);
+      client->lseek(fd, off, whence);
     } else if (strcmp(op, "read") == 0) {
       int64_t f = t.get_int();
       int64_t size = t.get_int();

--- a/src/client/hypertable/CephBroker.cc
+++ b/src/client/hypertable/CephBroker.cc
@@ -310,11 +310,11 @@ void CephBroker::remove(ResponseCallback *cb, const char *fname) {
 
 void CephBroker::length(ResponseCallbackLength *cb, const char *fname, bool) {
   int r;
-  struct stat statbuf;
+  struct ceph_statx stx;
 
   HT_DEBUGF("length file='%s'", fname);
 
-  if ((r = ceph_lstat(cmount, fname, &statbuf)) < 0) {
+  if ((r = ceph_statx(cmount, fname, &stx, CEPH_STATX_SIZE, AT_SYMLINK_NOFOLLOW)) < 0) {
     String abspath;
     make_abs_path(fname, abspath);
     std::string errs(cpp_strerror(r));
@@ -322,7 +322,7 @@ void CephBroker::length(ResponseCallbackLength *cb, const char *fname, bool) {
     report_error(cb,- r);
     return;
   }
-  cb->response(statbuf.st_size);
+  cb->response(stx.stx_size);
 }
 
 void CephBroker::pread(ResponseCallbackRead *cb, uint32_t fd, uint64_t offset,
@@ -487,11 +487,11 @@ void CephBroker::readdir(ResponseCallbackReaddir *cb, const char *dname) {
 
 void CephBroker::exists(ResponseCallbackExists *cb, const char *fname) {
   String abspath;
-  struct stat statbuf;
+  struct ceph_statx stx;
   
   HT_DEBUGF("exists file='%s'", fname);
   make_abs_path(fname, abspath);
-  cb->response(ceph_lstat(cmount, abspath.c_str(), &statbuf) == 0);
+  cb->response(ceph_statx(cmount, abspath.c_str(), &stx, 0, AT_SYMLINK_NOFOLLOW) == 0);
 }
 
 void CephBroker::rename(ResponseCallback *cb, const char *src, const char *dst) {

--- a/src/java/native/libcephfs_jni.cc
+++ b/src/java/native/libcephfs_jni.cc
@@ -1350,7 +1350,7 @@ JNIEXPORT jint JNICALL Java_com_ceph_fs_CephMount_native_1ceph_1setattr
 	struct ceph_mount_info *cmount = get_ceph_mount(j_mntp);
 	CephContext *cct = ceph_get_mount_context(cmount);
 	const char *c_path;
-	struct stat st;
+	struct ceph_statx stx;
 	int ret, mask = fixup_attr_mask(j_mask);
 
 	CHECK_ARG_NULL(j_path, "@path is null", -1);
@@ -1363,17 +1363,17 @@ JNIEXPORT jint JNICALL Java_com_ceph_fs_CephMount_native_1ceph_1setattr
 		return -1;
 	}
 
-	memset(&st, 0, sizeof(st));
+	memset(&stx, 0, sizeof(stx));
 
-	st.st_mode = env->GetIntField(j_cephstat, cephstat_mode_fid);
-	st.st_uid = env->GetIntField(j_cephstat, cephstat_uid_fid);
-	st.st_gid = env->GetIntField(j_cephstat, cephstat_gid_fid);
-	st.st_mtime = env->GetLongField(j_cephstat, cephstat_m_time_fid);
-	st.st_atime = env->GetLongField(j_cephstat, cephstat_a_time_fid);
+	stx.stx_mode = env->GetIntField(j_cephstat, cephstat_mode_fid);
+	stx.stx_uid = env->GetIntField(j_cephstat, cephstat_uid_fid);
+	stx.stx_gid = env->GetIntField(j_cephstat, cephstat_gid_fid);
+	stx.stx_mtime.tv_sec = env->GetLongField(j_cephstat, cephstat_m_time_fid);
+	stx.stx_atime.tv_sec = env->GetLongField(j_cephstat, cephstat_a_time_fid);
 
 	ldout(cct, 10) << "jni: setattr: path " << c_path << " mask " << mask << dendl;
 
-	ret = ceph_setattr(cmount, c_path, &st, mask);
+	ret = ceph_setattrx(cmount, c_path, &stx, mask, 0);
 
 	ldout(cct, 10) << "jni: setattr: exit ret " << ret << dendl;
 

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -833,7 +833,7 @@ extern "C" int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd,
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
-  return cmount->get_client()->lseek(fd, offset, whence, cmount->default_perms);
+  return cmount->get_client()->lseek(fd, offset, whence);
 }
 
 extern "C" int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf,
@@ -1532,7 +1532,7 @@ extern "C" int ceph_ll_fsync(class ceph_mount_info *cmount,
 extern "C" off_t ceph_ll_lseek(class ceph_mount_info *cmount,
 				Fh *fh, off_t offset, int whence)
 {
-  return (cmount->get_client()->ll_lseek(fh, offset, whence, cmount->default_perms));
+  return (cmount->get_client()->ll_lseek(fh, offset, whence));
 }
 
 extern "C" int ceph_ll_write(class ceph_mount_info *cmount,

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -251,11 +251,11 @@ TEST(ACL, DefaultACL) {
   // mode and ACL are updated
   ASSERT_EQ(ceph_getxattr(cmount, test_dir2, ACL_EA_ACCESS, acl2_buf, acl_buf_size), acl_buf_size);
   {
-    struct stat stbuf;
-    ASSERT_EQ(ceph_stat(cmount, test_dir2, &stbuf), 0);
+    struct ceph_statx stx;
+    ASSERT_EQ(ceph_statx(cmount, test_dir2, &stx, CEPH_STATX_MODE, 0), 0);
     // other bits of mode &= acl other perm
-    ASSERT_EQ(stbuf.st_mode & 0777, 0750u);
-    ASSERT_EQ(check_acl_and_mode(acl2_buf, acl_buf_size, stbuf.st_mode), 0);
+    ASSERT_EQ(stx.stx_mode & 0777u, 0750u);
+    ASSERT_EQ(check_acl_and_mode(acl2_buf, acl_buf_size, stx.stx_mode), 0);
   }
 
   char test_file1[256];
@@ -269,11 +269,11 @@ TEST(ACL, DefaultACL) {
   // mode and ACL are updated
   ASSERT_EQ(ceph_fgetxattr(cmount, fd, ACL_EA_ACCESS, acl2_buf, acl_buf_size), acl_buf_size);
   {
-    struct stat stbuf;
-    ASSERT_EQ(ceph_stat(cmount, test_file1, &stbuf), 0);
+    struct ceph_statx stx;
+    ASSERT_EQ(ceph_statx(cmount, test_file1, &stx, CEPH_STATX_MODE, 0), 0);
     // other bits of mode &= acl other perm
-    ASSERT_EQ(stbuf.st_mode & 0777, 0660u);
-    ASSERT_EQ(check_acl_and_mode(acl2_buf, acl_buf_size, stbuf.st_mode), 0);
+    ASSERT_EQ(stx.stx_mode & 0777u, 0660u);
+    ASSERT_EQ(check_acl_and_mode(acl2_buf, acl_buf_size, stx.stx_mode), 0);
   }
 
   free(acl1_buf);

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -160,11 +160,11 @@ TEST(ACL, SetACL) {
   ASSERT_GT(tmpfd, 0);
   ceph_close(cmount, tmpfd);
 
-  struct stat stbuf;
-  ASSERT_EQ(ceph_fstat(cmount, fd, &stbuf), 0);
+  struct ceph_statx stx;
+  ASSERT_EQ(ceph_fstatx(cmount, fd, &stx, CEPH_STATX_MODE, 0), 0);
   // mode was modified according to ACL
-  ASSERT_EQ(stbuf.st_mode & 0777, 0770u);
-  ASSERT_EQ(check_acl_and_mode(acl_buf, acl_buf_size, stbuf.st_mode), 0);
+  ASSERT_EQ(stx.stx_mode & 0777u, 0770u);
+  ASSERT_EQ(check_acl_and_mode(acl_buf, acl_buf_size, stx.stx_mode), 0);
 
   acl_buf_size = acl_ea_size(3);
   // setting ACL that is equivalent to file mode
@@ -173,9 +173,9 @@ TEST(ACL, SetACL) {
   // ACL was deleted
   ASSERT_EQ(ceph_fgetxattr(cmount, fd, ACL_EA_ACCESS, NULL, 0), -ENODATA);
 
-  ASSERT_EQ(ceph_fstat(cmount, fd, &stbuf), 0);
+  ASSERT_EQ(ceph_fstatx(cmount, fd, &stx, CEPH_STATX_MODE, 0), 0);
   // mode was modified according to ACL
-  ASSERT_EQ(stbuf.st_mode & 0777, 0600u);
+  ASSERT_EQ(stx.stx_mode & 0777u, 0600u);
 
   free(acl_buf);
   ceph_close(cmount, fd);
@@ -200,20 +200,20 @@ TEST(ACL, Chmod) {
   ASSERT_EQ(generate_test_acl(acl_buf, acl_buf_size, 0775), 0);
   ASSERT_EQ(ceph_fsetxattr(cmount, fd, ACL_EA_ACCESS, acl_buf, acl_buf_size, 0), 0);
 
-  struct stat stbuf;
-  ASSERT_EQ(ceph_fstat(cmount, fd, &stbuf), 0);
+  struct ceph_statx stx;
+  ASSERT_EQ(ceph_fstatx(cmount, fd, &stx, CEPH_STATX_MODE, 0), 0);
   // mode was updated according to ACL
-  ASSERT_EQ(stbuf.st_mode & 0777, 0775u);
+  ASSERT_EQ(stx.stx_mode & 0777u, 0775u);
 
   // change mode
   ASSERT_EQ(ceph_fchmod(cmount, fd, 0640), 0);
 
-  ASSERT_EQ(ceph_fstat(cmount, fd, &stbuf), 0);
-  ASSERT_EQ(stbuf.st_mode & 0777, 0640u);
+  ASSERT_EQ(ceph_fstatx(cmount, fd, &stx, CEPH_STATX_MODE, 0), 0);
+  ASSERT_EQ(stx.stx_mode & 0777u, 0640u);
 
   // ACL was updated according to mode
   ASSERT_EQ(ceph_fgetxattr(cmount, fd, ACL_EA_ACCESS, acl_buf, acl_buf_size), acl_buf_size);
-  ASSERT_EQ(check_acl_and_mode(acl_buf, acl_buf_size, stbuf.st_mode), 0);
+  ASSERT_EQ(check_acl_and_mode(acl_buf, acl_buf_size, stx.stx_mode), 0);
 
   free(acl_buf);
   ceph_close(cmount, fd);

--- a/src/test/libcephfs/caps.cc
+++ b/src/test/libcephfs/caps.cc
@@ -60,8 +60,8 @@ TEST(Caps, ReadZero) {
 
     ASSERT_EQ(0, ceph_close(cmount, wfd));
 
-    struct stat st;
-    ASSERT_EQ(0, ceph_stat(cmount, c_path, &st));
+    struct ceph_statx stx;
+    ASSERT_EQ(0, ceph_statx(cmount, c_path, &stx, CEPH_STATX_MTIME, 0));
 
     caps = ceph_debug_get_file_caps(cmount, c_path);
     ASSERT_EQ(expect, caps & expect);

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -770,8 +770,8 @@ TEST(LibCephFS, FlagO_PATH) {
   // try to sync
   ASSERT_EQ(-EBADF, ceph_fsync(cmount, fd, false));
 
-  struct stat sb;
-  ASSERT_EQ(0, ceph_fstat(cmount, fd, &sb));
+  struct ceph_statx stx;
+  ASSERT_EQ(0, ceph_fstatx(cmount, fd, &stx, 0, 0));
 
   ASSERT_EQ(0, ceph_close(cmount, fd));
   ceph_shutdown(cmount);
@@ -986,8 +986,8 @@ TEST(LibCephFS, BadFileDesc) {
   ASSERT_EQ(ceph_ftruncate(cmount, -1, 0), -EBADF);
   ASSERT_EQ(ceph_fsync(cmount, -1, 0), -EBADF);
 
-  struct stat stat;
-  ASSERT_EQ(ceph_fstat(cmount, -1, &stat), -EBADF);
+  struct ceph_statx stx;
+  ASSERT_EQ(ceph_fstatx(cmount, -1, &stx, 0, 0), -EBADF);
 
   struct sockaddr_storage addr;
   ASSERT_EQ(ceph_get_file_stripe_address(cmount, -1, 0, &addr, 1), -EBADF);
@@ -1175,7 +1175,7 @@ TEST(LibCephFS, UseUnmounted) {
   EXPECT_EQ(-ENOTCONN, ceph_write(cmount, 0, NULL, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_ftruncate(cmount, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_fsync(cmount, 0, 0));
-  EXPECT_EQ(-ENOTCONN, ceph_fstat(cmount, 0, &st));
+  EXPECT_EQ(-ENOTCONN, ceph_fstatx(cmount, 0, &stx, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_sync_fs(cmount));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_stripe_unit(cmount, 0));
   EXPECT_EQ(-ENOTCONN, ceph_get_file_pool(cmount, 0));

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1148,7 +1148,7 @@ TEST(LibCephFS, UseUnmounted) {
   EXPECT_EQ(-ENOTCONN, ceph_readlink(cmount, "/path", NULL, 0));
   EXPECT_EQ(-ENOTCONN, ceph_symlink(cmount, "/path", "/path"));
   EXPECT_EQ(-ENOTCONN, ceph_statx(cmount, "/path", &stx, 0, 0));
-  EXPECT_EQ(-ENOTCONN, ceph_setattr(cmount, "/path", &st, 0));
+  EXPECT_EQ(-ENOTCONN, ceph_setattrx(cmount, "/path", &stx, 0, 0));
   EXPECT_EQ(-ENOTCONN, ceph_getxattr(cmount, "/path", "name", NULL, 0));
   EXPECT_EQ(-ENOTCONN, ceph_lgetxattr(cmount, "/path", "name", NULL, 0));
   EXPECT_EQ(-ENOTCONN, ceph_listxattr(cmount, "/path", NULL, 0));


### PR DESCRIPTION
This is a small patch pile of random bugfixes and cleanups. Most of the bugs fixed are either in the new statx handling code, though there are a couple of fixes to bugs introduced during the UserPerm conversion as well.

There is also a fix for what appears to be an inode refcount leak in the ceph_ll_link code, that I found by inspection. Please take a hard look at that one and make sure I'm not missing anythingt here.

Finally, this also converts most of the internal libcephfs callers to use the statx-based APIs. For now, I've left the java and python APIs the same, but converted them to use statx APIs internally. Eventually we may want to convert them to something more statx-like. That means fixing up their callers though and I'm a little unclear on how best to audit all of them.