### PR TITLE
mgr: init() return when connection daemons failed && add some err info

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -48,8 +48,10 @@ int DaemonServer::init(uint64_t gid, entity_addr_t client_addr)
   msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
       entity_name_t::MGR(gid), "server", getpid());
   int r = msgr->bind(g_conf->public_addr);
-  if (r < 0)
+  if (r < 0) {
+    derr << "unable to bind mgr to " << g_conf->public_addr << dendl;
     return r;
+  }
 
   msgr->set_myname(entity_name_t::MGR(gid));
   msgr->set_addr_unknowns(client_addr);

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -148,7 +148,11 @@ void Mgr::init()
   assert(!initialized);
 
   // Start communicating with daemons to learn statistics etc
-  server.init(monc->get_global_id(), client_messenger->get_myaddr());
+  int r = server.init(monc->get_global_id(), client_messenger->get_myaddr());
+  if (r < 0) {
+    derr << "Initialize server fail"<< dendl;
+    return;
+  }
   dout(4) << "Initialized server at " << server.get_myaddr() << dendl;
 
   // Preload all daemon metadata (will subsequently keep this

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -124,6 +124,7 @@ void MgrStandby::handle_signal(int signum)
 {
   Mutex::Locker l(lock);
   assert(signum == SIGINT || signum == SIGTERM);
+  derr << "*** Got signal " << sig_str(signum) << " ***" << dendl;
   shutdown();
 }
 


### PR DESCRIPTION
 mgr: mgr::init() return when connection daemons failed 
 mgr/mgrstandby: display signal info 

Signed-off-by: huanwen ren ren.huanwen@zte.com.cn
