### PR TITLE
src/common/ceph_context.h: Help Clang decide for the correct log() reference

### DIFF
--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -15,6 +15,11 @@
 #ifndef CEPH_CEPHCONTEXT_H
 #define CEPH_CEPHCONTEXT_H
 
+#if defined(__FreeBSD__)
+// Help Clang decide for the correct reference for log() 
+#include <math.h>
+#endif
+
 #include <iosfwd>
 #include <stdint.h>
 #include <string>


### PR DESCRIPTION

Clang is confused about selecting the correct log() function.
Including math.h helps for the time being.
(until this is fixed in Clang, or it turns out the be very tricky stuff in
the include order)

When compiling under Clang 3.8.0 it reports:
In file included from /usr/srcs/Ceph/work/ceph/src/common/AsyncOpTracker.cc:6:
In file included from /usr/srcs/Ceph/work/ceph/src/include/Context.h:19:
In file included from /usr/srcs/Ceph/work/ceph/src/common/dout.h:20:
In file included from /usr/srcs/Ceph/work/ceph/src/common/config.h:24:
In file included from /usr/srcs/Ceph/work/ceph/src/common/entity_name.h:22:
In file included from /usr/srcs/Ceph/work/ceph/src/include/encoding.h:304:
In file included from /usr/srcs/Ceph/work/ceph/src/include/unordered_map.h:6:
In file included from /usr/include/c++/v1/unordered_map:369:
In file included from /usr/include/c++/v1/__hash_table:19:
In file included from /usr/include/c++/v1/cmath:301:
/usr/include/c++/v1/math.h:845:37: error: reference to 'log' is ambiguous
log(_A1 __lcpp_x) _NOEXCEPT {return log((double)__lcpp_x);}
                                    ^
/usr/include/c++/v1/math.h:845:1: note: candidate found by name lookup is 'log'
log(_A1 __lcpp_x) _NOEXCEPT {return log((double)__lcpp_x);}
^
/usr/include/c++/v1/math.h:839:46: note: candidate found by name lookup is 'log'
inline _LIBCPP_INLINE_VISIBILITY long double log(long double __lcpp_x) _NOEXCEPT {return logl(__lcpp_x);}
                                             ^
/usr/include/c++/v1/math.h:838:46: note: candidate found by name lookup is 'log'
inline _LIBCPP_INLINE_VISIBILITY float       log(float __lcpp_x) _NOEXCEPT       {return logf(__lcpp_x);}
                                             ^
/usr/include/math.h:247:8: note: candidate found by name lookup is 'log'
double  log(double);
        ^
/usr/srcs/Ceph/work/ceph/src/common/ceph_context.h:49:13: note: candidate found by name lookup is 'ceph::log'
  namespace log {
            ^
1 error generated.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>