### PR TITLE
doc: Update install-ceph-gateway.rst

### DIFF
--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -510,24 +510,24 @@ Execute the following steps:
 
 #. Add the following contents to the file::
 
-    import boto
     import boto.s3.connection
 
     access_key = 'I0PJDPCIYZ665MW88W9R'
     secret_key = 'dxaXZ8U90SXydYzyS5ivamEP20hkLSUViiaR+ZDA'
     conn = boto.connect_s3(
-            aws_access_key_id = access_key,
-            aws_secret_access_key = secret_key,
-            host = '{hostname}', port = {port},
-            is_secure=False, calling_format = boto.s3.connection.OrdinaryCallingFormat(),
-            )
+            aws_access_key_id=access_key,
+            aws_secret_access_key=secret_key,
+            host='{hostname}', port={port},
+            is_secure=False, calling_format=boto.s3.connection.OrdinaryCallingFormat(),
+           )
 
     bucket = conn.create_bucket('my-new-bucket')
-        for bucket in conn.get_all_buckets():
-                print "{name} {created}".format(
-                        name = bucket.name,
-                        created = bucket.creation_date,
-     )
+    for bucket in conn.get_all_buckets():
+        print "{name} {created}".format(
+            name=bucket.name,
+            created=bucket.creation_date,
+        )
+
 
    Replace ``{hostname}`` with the hostname of the host where you have
    configured the gateway service i.e., the ``gateway host``. Replace {port}


### PR DESCRIPTION
Make the s3test.py script PIP-8 compliant, and more importantly it no longer fails because of the wrong indentation on the line of the for-loop