### PR TITLE
client: don't take extra target inode reference in ll_link

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11441,7 +11441,6 @@ int Client::ll_link(Inode *in, Inode *newparent, const char *newname,
   if (r == 0) {
     assert(target);
     fill_stat(target, attr);
-    _ll_get(target.get());
   }
 out:
   return r;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -522,9 +522,16 @@ static void fuse_ll_link(fuse_req_t req, fuse_ino_t ino, fuse_ino_t newparent,
     fuse_reply_entry(req, &fe);
   } else {
     fuse_reply_err(req, -r);
+
+    /*
+     * Many ll operations in libcephfs return an extra inode reference, but
+     * ll_link currently does not. Still, FUSE needs one for the new dentry,
+     * so we commandeer the reference taken earlier when ll_link is successful.
+     * On error however, we must put that reference.
+     */
+    cfuse->iput(in);
   }
 
-  cfuse->iput(in); // iputs required
   cfuse->iput(nin);
 }
 


### PR DESCRIPTION
@gregsfortytwo asked that I break out this patch separately from the other PR I have. He also mentioned that he thought it didn't look quite right. Greg, can you elaborate on what you see as wrong here?

----------------------8<---------------------------------

For the life of me, I can't figure out where this reference is ever put.
We usually take a reference like this when there is an Inode **
parameter that we'll return to the caller. ll_link doesn't have one of
those, so as best I can tell this reference is just leaked.

Zheng however says that FUSE will eventually put this reference via
ll_forget. I still don't quite get how that works, but the other callers
clearly do not handle this correctly. Change the code to only make the
fuse code take this extra reference.

Signed-off-by: Jeff Layton <jlayton@redhat.com>