### PR TITLE
do_freebsd.sh: Set options for debug building.

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -6,7 +6,7 @@ if test -e build; then
 fi
 mkdir build
 cd build
-cmake $@ ..
+cmake "$@" ..
 
 # minimal config to find plugins
 cat <<EOF > ceph.conf

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -27,6 +27,6 @@ rm -rf build && ./do_cmake.sh "$*" \
 	2>&1 | tee cmake.log
 
 cd build
-gmake -j$NPROC V=1 VERBOSE=1 | tee build.log 2>&1
-gmake -j$NPROC check CEPH_BUFFER_NO_BENCH=yes | tee check.log 2>&1
+gmake -j$NPROC V=1 VERBOSE=1 
+gmake -j$NPROC check CEPH_BUFFER_NO_BENCH=yes 
 

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -13,6 +13,7 @@ fi
 rm -rf build && ./do_cmake.sh "$*" \
 	-D CMAKE_BUILD_TYPE=Debug \
 	-D CMAKE_CXX_FLAGS_DEBUG="-O0 -g" \
+	-D CMAKE_C_FLAGS_DEBUG="-O0 -g" \
 	-D ENABLE_GIT_VERSION=OFF \
 	-D WITH_BLKID=OFF \
 	-D WITH_FUSE=OFF \


### PR DESCRIPTION
And that requires that the options need to be passed on completely
to the cmake program as well. Thus adding """'s around the option
argument with do_cmake.sh as well

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>