### PR TITLE
[DNM] batched ObjectMap updates

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1265,6 +1265,9 @@ OPTION(rbd_default_data_pool, OPT_STR, "") // optional default pool for storing 
 
 OPTION(rbd_default_map_options, OPT_STR, "") // default rbd map -o / --options
 
+// batch size for batched object map updations (whenever appropriate)
+OPTION(rbd_object_map_batch_size, OPT_INT, 16384)
+
 /**
  * RBD journal options.
  */

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -64,6 +64,9 @@ class Context {
     finish(r);
     delete this;
   }
+  virtual bool is_last_request() {
+    return true;
+  }
 };
 
 /**

--- a/src/include/rbd/object_map_types.h
+++ b/src/include/rbd/object_map_types.h
@@ -10,4 +10,12 @@ static const uint8_t OBJECT_EXISTS       = 1;
 static const uint8_t OBJECT_PENDING      = 2;
 static const uint8_t OBJECT_EXISTS_CLEAN = 3;
 
+enum {
+  OBJECT_MAP_BATCH_LEVEL0 = 0,
+  OBJECT_MAP_BATCH_LEVEL1,
+  OBJECT_MAP_BATCH_MAX,
+};
+
+static const uint8_t OBJECT_MAP_VIEW_LEVELS = OBJECT_MAP_BATCH_MAX;
+
 #endif // CEPH_RBD_OBJECT_MAP_TYPES_H

--- a/src/librbd/AioCompletion.cc
+++ b/src/librbd/AioCompletion.cc
@@ -201,6 +201,14 @@ void AioCompletion::associate_journal_event(uint64_t tid) {
   journal_tid = tid;
 }
 
+bool AioCompletion::is_last_request() {
+  CephContext *cct = ictx->cct;
+
+  Mutex::Locker locker(lock);
+  ldout(cct, 20) << this << " pending=" << pending_count << dendl;
+  return (pending_count == 1);
+}
+
 bool AioCompletion::is_complete() {
   tracepoint(librbd, aio_is_complete_enter, this);
   bool done;

--- a/src/librbd/AioCompletion.h
+++ b/src/librbd/AioCompletion.h
@@ -156,6 +156,7 @@ struct AioCompletion {
 
   void associate_journal_event(uint64_t tid);
 
+  bool is_last_request();
   bool is_complete();
 
   ssize_t get_return_value();
@@ -228,6 +229,9 @@ public:
   virtual ~C_AioRequest() {}
   virtual void finish(int r) {
     m_completion->complete_request(r);
+  }
+  bool is_last_request() {
+    return m_completion->is_last_request();
   }
 protected:
   AioCompletion *m_completion;

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -246,10 +246,10 @@ protected:
   virtual void send_write();
   virtual void send_write_op(bool write_guard);
   virtual void handle_write_guard();
+  virtual void send_pre();
+  virtual bool send_post();
 
 private:
-  void send_pre();
-  bool send_post();
   void send_copyup();
 };
 
@@ -323,6 +323,8 @@ protected:
 
   virtual void guard_write();
   virtual void send_write();
+  virtual void send_pre();
+  virtual bool send_post();
 
 private:
   uint8_t m_object_state;

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -61,6 +61,7 @@ set(librbd_internal_srcs
   object_map/SnapshotRollbackRequest.cc
   object_map/UnlockRequest.cc
   object_map/UpdateRequest.cc
+  object_map/BatchUpdateRequest.cc
   object_watcher/Notifier.cc
   operation/DisableFeaturesRequest.cc
   operation/EnableFeaturesRequest.cc

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -381,6 +381,8 @@ bool ObjectMap::aio_update(uint64_t start_object_no, uint64_t end_object_no,
          m_image_ctx.exclusive_lock->is_lock_owner());
   assert(m_image_ctx.object_map_lock.is_wlocked());
   assert(start_object_no < end_object_no);
+  assert(!m_object_map.in_batch_mode(start_object_no));
+  assert(!m_object_map.in_batch_mode(end_object_no));
 
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << &m_image_ctx << " aio_update: start=" << start_object_no

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -103,6 +103,12 @@ public:
                   const boost::optional<uint8_t> &current_state,
                   Context *on_finish);
 
+  // batch updations
+  bool aio_batch(uint64_t object_no, uint8_t new_state,
+                 const boost::optional<uint8_t> &current_state, uint8_t view_idx);
+  void aio_update_batch(Context *on_finish);
+  uint32_t batch_size();
+
   void rollback(uint64_t snap_id, Context *on_finish);
   void snapshot_add(uint64_t snap_id, Context *on_finish);
   void snapshot_remove(uint64_t snap_id, Context *on_finish);

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -19,6 +19,52 @@ namespace librbd {
 
 class ImageCtx;
 
+class ObjectMapView {
+public:
+  ObjectMapView() {}
+
+  inline uint64_t size() const {
+    return m_level0_view.size();
+  }
+
+  ceph::BitVector<2> *level0_map() {
+    return &m_level0_view;
+  }
+
+  bool in_batch_mode(uint64_t object_no);
+  void resize(uint64_t new_size, uint8_t object_state);
+  uint32_t batch_size();
+
+  ceph::BitVector<2u>::Reference operator[](uint64_t object_no);
+  uint8_t operator[](uint64_t object_no) const;
+
+  void sync_view(ImageCtx &image_ctx, uint64_t snap_id, uint8_t view_idx,
+                 Context *on_finish);
+  void update_view(uint64_t object_no, const boost::optional<uint8_t> &current_state,
+                   uint8_t new_state, uint8_t view_idx);
+  void apply_view();
+private:
+  struct View {
+    View() : m_tracked(0) {}
+
+    ceph::BitVector<1> m_lookup;
+    ceph::BitVector<2> m_map_track;
+
+    boost::optional<uint64_t> m_object_start;
+    uint64_t m_object_end;
+
+    boost::optional<uint8_t> m_current_state;
+    uint8_t m_new_state;
+
+    uint32_t m_tracked;
+  };
+
+  ceph::BitVector<2> m_level0_view;
+  View m_level_view[OBJECT_MAP_VIEW_LEVELS];
+
+  void reset_view(uint8_t view_idx);
+};
+
 class ObjectMap {
 public:
   ObjectMap(ImageCtx &image_ctx, uint64_t snap_id);
@@ -66,6 +112,7 @@ private:
   ceph::BitVector<2> m_object_map;
   uint64_t m_snap_id;
 
+  ObjectMapView m_object_map_view;
 };
 
 } // namespace librbd

--- a/src/librbd/ObjectMap.h
+++ b/src/librbd/ObjectMap.h
@@ -109,10 +109,13 @@ public:
 
 private:
   ImageCtx &m_image_ctx;
-  ceph::BitVector<2> m_object_map;
   uint64_t m_snap_id;
 
-  ObjectMapView m_object_map_view;
+  ObjectMapView m_object_map;
+
+  ceph::BitVector<2> *level0_map() {
+    return m_object_map.level0_map();
+  }
 };
 
 } // namespace librbd

--- a/src/librbd/object_map/BatchUpdateRequest.cc
+++ b/src/librbd/object_map/BatchUpdateRequest.cc
@@ -1,0 +1,106 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/object_map/UpdateRequest.h"
+#include "librbd/object_map/BatchUpdateRequest.h"
+#include "common/dout.h"
+#include "common/WorkQueue.h"
+#include "librbd/Utils.h"
+#include "librbd/ImageCtx.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::object_map::BatchUpdateRequest: " \
+                           << this << " " << __func__
+
+using librbd::ObjectMapView;
+
+namespace librbd {
+
+using util::create_context_callback;
+
+namespace object_map {
+
+template<typename I>
+BatchUpdateRequest<I>::BatchUpdateRequest(I &image_ctx, ObjectMapView *object_map,
+                                          uint64_t snap_id, Context *on_finish)
+  : m_image_ctx(image_ctx), m_object_map(object_map), m_snap_id(snap_id),
+    m_on_finish(on_finish) {
+  m_cct = m_image_ctx.cct;
+}
+
+template<typename I>
+void BatchUpdateRequest<I>::send() {
+  ldout(m_cct, 20) << dendl;
+
+  // get a copy which we can mod
+  m_object_map_dup = *m_object_map;
+  // apply views to the master ObjectMap
+  m_object_map->apply_view();
+
+  // switch thread context to acquire locks
+  switch_thread_context();
+}
+
+template<typename I>
+void BatchUpdateRequest<I>::switch_thread_context() {
+  ldout(m_cct, 20) << dendl;
+
+  using klass = BatchUpdateRequest<I>;
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_swtich_thread_context>(this);
+
+  m_image_ctx.op_work_queue->queue(ctx, 0);
+}
+
+template<typename I>
+void BatchUpdateRequest<I>::handle_swtich_thread_context(int r) {
+  ldout(m_cct, 20) << ": r=" << r << dendl;
+
+  update_object_map();
+}
+
+template<typename I>
+void BatchUpdateRequest<I>::update_object_map() {
+  ldout(m_cct, 20) << dendl;
+
+  if (m_view_idx == OBJECT_MAP_VIEW_LEVELS) {
+    finish();
+    return;
+  }
+
+  ldout(m_cct, 20) << ": flushing object map view (idx: "
+                   << static_cast<uint32_t>(m_view_idx) << ")" << dendl;
+
+  using klass = BatchUpdateRequest<I>;
+  Context *ctx = create_context_callback<klass, &klass::handle_update_object_map>(this);
+
+  m_object_map_dup.sync_view(m_image_ctx, m_snap_id, m_view_idx, ctx);
+}
+
+template<typename I>
+Context *BatchUpdateRequest<I>::handle_update_object_map(int *result) {
+  ldout(m_cct, 20) << ": r=" << *result << dendl;
+
+  if (*result < 0) {
+    return m_on_finish; // object map invalidation is taken care by UpdateRequest
+  }
+
+  // update object map for next view
+  ++m_view_idx;
+  update_object_map();
+  return nullptr;
+}
+
+template<typename I>
+void BatchUpdateRequest<I>::finish() {
+  ldout(m_cct, 20) << dendl;
+
+  m_on_finish->complete(0);
+  delete this;
+}
+
+} // namespace object_map
+} // namespace librbd
+
+template class librbd::object_map::BatchUpdateRequest<librbd::ImageCtx>;

--- a/src/librbd/object_map/BatchUpdateRequest.h
+++ b/src/librbd/object_map/BatchUpdateRequest.h
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_OBJECT_MAP_BATCH_UPDATE_REQUEST_H
+#define CEPH_LIBRBD_OBJECT_MAP_BATCH_UPDATE_REQUEST_H
+
+#include "include/int_types.h"
+#include "librbd/object_map/Request.h"
+#include "common/bit_vector.hpp"
+#include <boost/optional.hpp>
+#include "librbd/ObjectMap.h"
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+class ObjectMapView;
+
+namespace object_map {
+
+template<typename ImageCtxT = ImageCtx>
+class BatchUpdateRequest {
+public:
+  BatchUpdateRequest(ImageCtxT &image_ctx, ObjectMapView *object_map,
+                     uint64_t snap_id, Context *on_finish);
+
+  void send();
+
+private:
+  ImageCtx &m_image_ctx;
+  ObjectMapView *m_object_map;
+  uint64_t m_snap_id;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+  uint8_t m_view_idx = 0;
+  ObjectMapView m_object_map_dup;
+
+  void switch_thread_context();
+  void handle_swtich_thread_context(int r);
+
+  void update_object_map();
+  Context *handle_update_object_map(int *result);
+
+  void finish();
+};
+
+} // namespace object_map
+} // namespace librbd
+
+extern template class librbd::object_map::BatchUpdateRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OBJECT_MAP_BATCH_UPDATE_REQUEST_H


### PR DESCRIPTION
[Sending this out for early comments on the approach. Below are the implementation details in brief]

The idea is to track ObjectMap updates (in-memory) in an ordered set of views or levels. This is represented by the newly introduced `ObjectMapView` class. This class provides public methods to manage (track/query/synchronize) batch updates to the ObjectMap. Since updates are tracked in memory (until a flush operation is requested), querying the ObjectMap needs to return the latest update made to the map (for a given object number). This is done by scanning the ObjectMap view in reverse order (views are indexed by update order). `ObjectMapView` class also maintains a master copy of the `ObjectMap` on which views are applied (in order) when flushing out to disk.

NOTE: It looks entirely possible that just updating the master copy of the `ObjectMap` and tracking enough information (new/current state, start/end object number) to update the on-disk copy should suffice given the conditional logic used everywhere (librbd and rados class) while updating the in-memory/on-disk map, which is much simpler to implement (and in fact it's how I had implemented it in the first place), but I feel that the above implementation has flexibility in some ways.
