### PR TITLE
Don't loop forever when reading data from 0 sized semgment.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -715,6 +715,10 @@ int RGWGetObj::read_user_manifest_part(rgw_bucket& bucket, RGWObjEnt& ent, RGWAc
     return -EPERM;
   }
 
+  if (ent.size == 0) {
+    return 0;
+  }
+
   perfcounter->inc(l_rgw_get_b, cur_end - cur_ofs);
   while (cur_ofs <= cur_end) {
     bufferlist bl;
@@ -725,6 +729,12 @@ int RGWGetObj::read_user_manifest_part(rgw_bucket& bucket, RGWObjEnt& ent, RGWAc
     off_t len = bl.length();
     cur_ofs += len;
     ofs += len;
+    if (!len) {
+        ldout(s->cct, 0) << "ERROR: read 0 bytes; ofs=" << cur_ofs
+	    << " end=" << cur_end << " from obj=" << ent.key.name
+	    << "[" << ent.key.instance << "]" << dendl;
+        return -EIO;
+    }
     ret = 0;
     perfcounter->tinc(l_rgw_get_lat,
                       (ceph_clock_now(s->cct) - start_time));
@@ -871,6 +881,11 @@ int RGWGetObj::handle_user_manifest(const char *prefix)
   r = iterate_user_manifest_parts(s->cct, store, ofs, end, bucket, obj_prefix, bucket_policy, NULL, get_obj_user_manifest_iterate_cb, (void *)this);
   if (r < 0)
     return r;
+
+  if (!total_len) {
+    bufferlist bl;
+    send_response_data(bl, 0, 0);
+  }
 
   return 0;
 }


### PR DESCRIPTION
The 0 sized segment can arise depending on how
the client uploads the object in the first place.
The cpu loop then happens during a swift `GET'.

This version of the patch: no assert, handles DLO with only empty segments.

Signed-off-by: Marcus Watts <mwatts@redhat.com>