### PR TITLE
mon: send updated monmap to its subscribers

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4332,7 +4332,7 @@ void Monitor::handle_subscribe(MonOpRequestRef op)
 	pgmon()->check_sub(s->sub_map["osd_pg_creates"]);
       }
     } else if (p->first == "monmap") {
-      check_sub(s->sub_map["monmap"]);
+      monmon()->check_sub(s->sub_map[p->first]);
     } else if (logmon()->sub_name_to_id(p->first) >= 0) {
       logmon()->check_sub(s->sub_map[p->first]);
     } else if (p->first == "mgrmap" || p->first == "mgrdigest") {
@@ -4429,32 +4429,6 @@ bool Monitor::ms_handle_refused(Connection *con)
   dout(10) << "ms_handle_refused " << con << " " << con->get_peer_addr() << dendl;
   return false;
 }
-
-void Monitor::check_subs()
-{
-  string type = "monmap";
-  if (session_map.subs.count(type) == 0)
-    return;
-  xlist<Subscription*>::iterator p = session_map.subs[type]->begin();
-  while (!p.end()) {
-    Subscription *sub = *p;
-    ++p;
-    check_sub(sub);
-  }
-}
-
-void Monitor::check_sub(Subscription *sub)
-{
-  dout(10) << "check_sub monmap next " << sub->next << " have " << monmap->get_epoch() << dendl;
-  if (sub->next <= monmap->get_epoch()) {
-    send_latest_monmap(sub->session->con.get());
-    if (sub->onetime)
-      session_map.remove_sub(sub);
-    else
-      sub->next = monmap->get_epoch() + 1;
-  }
-}
-
 
 // -----
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -667,9 +667,6 @@ public:
   MonSessionMap session_map;
   AdminSocketHook *admin_hook;
 
-  void check_subs();
-  void check_sub(Subscription *sub);
-
   void send_latest_monmap(Connection *con);
 
   // messages

--- a/src/mon/MonmapMonitor.h
+++ b/src/mon/MonmapMonitor.h
@@ -81,7 +81,12 @@ class MonmapMonitor : public PaxosService {
 
   void tick();
 
- private:
+  void check_sub(Subscription *sub);
+
+private:
+  void check_subs();
+
+private:
   bufferlist monmap_bl;
 };
 


### PR DESCRIPTION
prior to this change, we send monmap when serving the subscription
requests, but the updates are not sent to the subscribers anymore.
so we need to send latest monmap to subscribers and update the
subscription status accordingly when the monmap is updated.

http://tracker.ceph.com/issues/17558
Signed-off-by: Kefu Chai <kchai@redhat.com>