### PR TITLE
jewel: rgw：bucket check remove _multipart_ prefix

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -839,7 +839,7 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
   int max = 1000;
 
   map<string, bool> common_prefixes;
-  string ns = "multipart";
+  string ns = "";
 
   bool is_truncated;
   map<string, bool> meta_objs;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17514
