### PR TITLE
jewel: rgw: multisite doesn't retry RGWFetchAllMetaCR on failed lease

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -574,8 +574,6 @@ int RGWCoroutinesManager::run(list<RGWCoroutinesStack *>& stacks)
     if (iter == scheduled_stacks.end()) {
       iter = scheduled_stacks.begin();
     }
-
-    ret = 0;
   }
 
   lock.get_write();


### PR DESCRIPTION
http://tracker.ceph.com/issues/17162
