### PR TITLE
jewel: build/ops: allow building RGW with LDAP disabled

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1101,10 +1101,6 @@ endif(${WITH_KVS})
 
 if(${WITH_RADOSGW})
 
-  if(${HAVE_OPENLDAP})
-    set(rgw_ldap_srcs rgw/rgw_ldap.cc)
-  endif(${HAVE_OPENLDAP})
-
   set(rgw_a_srcs
     rgw/rgw_acl.cc
     rgw/rgw_acl_s3.cc
@@ -1126,7 +1122,7 @@ if(${WITH_RADOSGW})
     rgw/rgw_http_client.cc
     rgw/rgw_json_enc.cc
     rgw/rgw_keystone.cc
-    ${rgw_ldap_srcs}
+    rgw/rgw_ldap.cc
     rgw/rgw_loadgen.cc
     rgw/rgw_log.cc
     rgw/rgw_metadata.cc


### PR DESCRIPTION
http://tracker.ceph.com/issues/17312