### PR TITLE
rgw structures rework

### DIFF
--- a/qa/tasks/radosgw_admin.py
+++ b/qa/tasks/radosgw_admin.py
@@ -277,12 +277,6 @@ def task(ctx, config):
                 'bucket.instance:{bucket_name}:{bucket_instance}'.format(
                 bucket_name=bucket_name2,bucket_instance=dest_bucket_id)],
                 check_status=True)
-            del out1['data']['bucket_info']['bucket']['pool']
-            del out1['data']['bucket_info']['bucket']['index_pool']
-            del out1['data']['bucket_info']['bucket']['data_extra_pool']
-            del out2['data']['bucket_info']['bucket']['pool']
-            del out2['data']['bucket_info']['bucket']['index_pool']
-            del out2['data']['bucket_info']['bucket']['data_extra_pool']
             assert out1 == out2
 
         same_region = 0

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -872,7 +872,7 @@ struct cls_rgw_obj_chain {
 
   cls_rgw_obj_chain() {}
 
-  void push_obj(string& pool, cls_rgw_obj_key& key, string& loc) {
+  void push_obj(const string& pool, cls_rgw_obj_key& key, string& loc) {
     cls_rgw_obj obj;
     obj.pool = pool;
     obj.key = key;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -872,7 +872,7 @@ struct cls_rgw_obj_chain {
 
   cls_rgw_obj_chain() {}
 
-  void push_obj(const string& pool, cls_rgw_obj_key& key, string& loc) {
+  void push_obj(const string& pool, const cls_rgw_obj_key& key, const string& loc) {
     cls_rgw_obj obj;
     obj.pool = pool;
     obj.key = key;

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -239,6 +239,10 @@ struct cls_rgw_obj_key {
   cls_rgw_obj_key(const string &_name) : name(_name) {}
   cls_rgw_obj_key(const string& n, const string& i) : name(n), instance(i) {}
 
+  void set(const string& _name) {
+    name = _name;
+  }
+
   bool operator==(const cls_rgw_obj_key& k) const {
     return (name.compare(k.name) == 0) &&
            (instance.compare(k.instance) == 0);
@@ -249,6 +253,12 @@ struct cls_rgw_obj_key {
       r = instance.compare(k.instance);
     }
     return (r < 0);
+  }
+  bool operator<=(const cls_rgw_obj_key& k) const {
+    return !(k < *this);
+  }
+  bool empty() {
+    return name.empty();
   }
   void encode(bufferlist &bl) const {
     ENCODE_START(1, 1, bl);

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -11,8 +11,6 @@ void cls_user_gen_test_bucket(cls_user_bucket *bucket, int i)
   snprintf(buf, sizeof(buf), ".%d", i);
 
   bucket->name = string("buck") + buf;
-  bucket->data_pool = string(".data.pool") + buf;
-  bucket->index_pool = string(".index.pool") + buf;
   bucket->marker = string("mark") + buf;
   bucket->bucket_id = string("bucket.id") + buf;
 }
@@ -20,9 +18,6 @@ void cls_user_gen_test_bucket(cls_user_bucket *bucket, int i)
 void cls_user_bucket::dump(Formatter *f) const
 {
   encode_json("name", name, f);
-  encode_json("data_pool", data_pool,f);
-  encode_json("data_extra_pool", data_extra_pool,f);
-  encode_json("index_pool", index_pool,f);
   encode_json("marker", marker,f);
   encode_json("bucket_id", bucket_id,f);
 }

--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -14,26 +14,34 @@
  */
 struct cls_user_bucket {
   std::string name;
-  std::string data_pool;
-  std::string index_pool;
   std::string marker;
   std::string bucket_id;
-  std::string data_extra_pool;
+  std::string placement_id;
+  struct {
+    std::string data_pool;
+    std::string index_pool;
+    std::string data_extra_pool;
+  } explicit_placement;
 
   void encode(bufferlist& bl) const {
-     ENCODE_START(7, 3, bl);
+     ENCODE_START(8, 8, bl);
     ::encode(name, bl);
-    ::encode(data_pool, bl);
     ::encode(marker, bl);
     ::encode(bucket_id, bl);
-    ::encode(index_pool, bl);
-    ::encode(data_extra_pool, bl);
+    ::encode(placement_id, bl);
+    if (placement_id.empty()) {
+      ::encode(explicit_placement.data_pool, bl);
+      ::encode(explicit_placement.index_pool, bl);
+      ::encode(explicit_placement.data_extra_pool, bl);
+    }
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(7, 3, 3, bl);
+    DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
     ::decode(name, bl);
-    ::decode(data_pool, bl);
+    if (struct_v < 8) {
+      ::decode(explicit_placement.data_pool, bl);
+    }
     if (struct_v >= 2) {
       ::decode(marker, bl);
       if (struct_v <= 3) {
@@ -46,13 +54,22 @@ struct cls_user_bucket {
         ::decode(bucket_id, bl);
       }
     }
-    if (struct_v >= 5) {
-      ::decode(index_pool, bl);
+    if (struct_v < 8) {
+      if (struct_v >= 5) {
+        ::decode(explicit_placement.index_pool, bl);
+      } else {
+        explicit_placement.index_pool = explicit_placement.data_pool;
+      }
+      if (struct_v >= 7) {
+        ::decode(explicit_placement.data_extra_pool, bl);
+      }
     } else {
-      index_pool = data_pool;
-    }
-    if (struct_v >= 7) {
-      ::decode(data_extra_pool, bl);
+      ::decode(placement_id, bl);
+      if (placement_id.empty()) {
+        ::decode(explicit_placement.data_pool, bl);
+        ::decode(explicit_placement.index_pool, bl);
+        ::decode(explicit_placement.data_extra_pool, bl);
+      }
     }
     DECODE_FINISH(bl);
   }

--- a/src/cls/version/cls_version.cc
+++ b/src/cls/version/cls_version.cc
@@ -109,6 +109,7 @@ static bool check_conds(list<obj_version_cond>& conds, obj_version& objv)
   for (list<obj_version_cond>::iterator iter = conds.begin(); iter != conds.end(); ++iter) {
     obj_version_cond& cond = *iter;
     obj_version& v = cond.ver;
+    CLS_LOG(20, "cls_version: check_version %s:%d (cond=%d)", v.tag.c_str(), (int)v.ver, (int)cond.cond);
 
     switch (cond.cond) {
       case VER_COND_NONE:

--- a/src/cls/version/cls_version_types.h
+++ b/src/cls/version/cls_version_types.h
@@ -31,6 +31,11 @@ struct obj_version {
     ver++;
   }
 
+  void clear() {
+    ver = 0;
+    tag.clear();
+  }
+
   bool empty() {
     return tag.empty();
   }

--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -6,8 +6,8 @@ script_root=`dirname $0`
 script_root=`(cd $script_root;pwd)`
 if [ -e CMakeCache.txt ]; then
     script_root=$PWD
-elif [ -e $root_path/../build/CMakeCache.txt ]; then
-    cd $root_path/../build
+elif [ -e $script_root/../build/CMakeCache.txt ]; then
+    cd $script_root/../build
     script_root=$PWD
 fi
 vstart_path=`dirname $0`

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1716,12 +1716,6 @@ static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
   RGWBucketInfo bucket_info;
 
   int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
-  if (ret == -ENOENT) {
-    if (bucket_id.empty()) {
-      cerr << "ERROR: bucket id specified" << std::endl;
-      return EINVAL;
-    }
-  }
   if (ret < 0) {
     cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
     return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5541,7 +5541,7 @@ next:
     cout << "old bucket instance id: " << bucket_info.bucket.bucket_id << std::endl;
     cout << "new bucket instance id: " << new_bucket_info.bucket.bucket_id << std::endl;
 
-    ret = store->init_bucket_index(new_bucket_info.bucket, new_bucket_info.num_shards);
+    ret = store->init_bucket_index(new_bucket_info, new_bucket_info.num_shards);
     if (ret < 0) {
       cerr << "ERROR: failed to init new bucket indexes: " << cpp_strerror(-ret) << std::endl;
       return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1292,10 +1292,9 @@ int set_user_quota(int opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, in
 
 static bool bucket_object_check_filter(const string& name)
 {
-  string ns;
-  string obj;
-  string instance;
-  return rgw_obj::translate_oid_to_obj_in_ns(name, obj, instance, ns);
+  rgw_obj_key k;
+  string ns; /* empty namespace */
+  return rgw_obj_key::oid_to_key_in_ns(name, &k, ns);
 }
 
 int check_min_obj_stripe_size(RGWRados *store, RGWBucketInfo& bucket_info, rgw_obj& obj, uint64_t min_stripe_size, bool *need_rewrite)
@@ -5194,7 +5193,7 @@ next:
     }
     rgw_obj obj(bucket, object);
     if (!object_version.empty()) {
-      obj.set_instance(object_version);
+      obj.key.set_instance(object_version);
     }
 
     rgw_cls_bi_entry entry;
@@ -5367,7 +5366,7 @@ next:
     }
 
     rgw_obj obj(bucket, object);
-    obj.set_instance(object_version);
+    obj.key.set_instance(object_version);
     bool need_rewrite = true;
     if (min_rewrite_stripe_size > 0) {
       ret = check_min_obj_stripe_size(store, bucket_info, obj, min_rewrite_stripe_size, &need_rewrite);
@@ -5674,7 +5673,7 @@ next:
       return -ret;
     }
     rgw_obj obj(bucket, object);
-    obj.set_instance(object_version);
+    obj.key.set_instance(object_version);
 
     uint64_t obj_size;
     map<string, bufferlist> attrs;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1023,8 +1023,7 @@ int bucket_stats(rgw_bucket& bucket, int shard_id, Formatter *formatter)
   }
   formatter->open_object_section("stats");
   formatter->dump_string("bucket", bucket.name);
-  formatter->dump_string("pool", bucket.data_pool);
-  formatter->dump_string("index_pool", bucket.index_pool);
+  ::encode_json("placement", bucket.placement, formatter);
 
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);
@@ -1362,7 +1361,7 @@ int check_obj_locator_underscore(RGWBucketInfo& bucket_info, rgw_obj& obj, rgw_o
   string oid;
   string locator;
 
-  get_obj_bucket_and_oid_loc(obj, obj.bucket, oid, locator);
+  get_obj_bucket_and_oid_loc(obj, oid, locator);
 
   f->dump_string("oid", oid);
   f->dump_string("locator", locator);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1293,9 +1293,9 @@ int set_user_quota(int opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, in
 static bool bucket_object_check_filter(const string& name)
 {
   string ns;
-  string obj = name;
+  string obj;
   string instance;
-  return rgw_obj::translate_raw_obj_to_obj_in_ns(obj, instance, ns);
+  return rgw_obj::translate_oid_to_obj_in_ns(name, obj, instance, ns);
 }
 
 int check_min_obj_stripe_size(RGWRados *store, RGWBucketInfo& bucket_info, rgw_obj& obj, uint64_t min_stripe_size, bool *need_rewrite)

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2347,6 +2347,7 @@ int main(int argc, const char **argv)
   string tenant;
   std::string access_key, secret_key, user_email, display_name;
   std::string bucket_name, pool_name, object;
+  rgw_pool pool;
   std::string date, subuser, access, format;
   std::string start_date, end_date;
   std::string key_type_str;
@@ -2507,6 +2508,7 @@ int main(int argc, const char **argv)
       bucket_name = val;
     } else if (ceph_argparse_witharg(args, i, &val, "-p", "--pool", (char*)NULL)) {
       pool_name = val;
+      pool = rgw_pool(pool_name);
     } else if (ceph_argparse_witharg(args, i, &val, "-o", "--object", (char*)NULL)) {
       object = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--object-version", (char*)NULL)) {
@@ -5028,7 +5030,7 @@ next:
       return usage();
     }
 
-    int ret = store->add_bucket_placement(pool_name);
+    int ret = store->add_bucket_placement(pool);
     if (ret < 0)
       cerr << "failed to add bucket placement: " << cpp_strerror(-ret) << std::endl;
   }
@@ -5039,13 +5041,13 @@ next:
       return usage();
     }
 
-    int ret = store->remove_bucket_placement(pool_name);
+    int ret = store->remove_bucket_placement(pool);
     if (ret < 0)
       cerr << "failed to remove bucket placement: " << cpp_strerror(-ret) << std::endl;
   }
 
   if (opt_cmd == OPT_POOLS_LIST) {
-    set<string> pools;
+    set<rgw_pool> pools;
     int ret = store->list_placement_set(pools);
     if (ret < 0) {
       cerr << "could not list placement set: " << cpp_strerror(-ret) << std::endl;
@@ -5053,10 +5055,9 @@ next:
     }
     formatter->reset();
     formatter->open_array_section("pools");
-    set<string>::iterator siter;
-    for (siter = pools.begin(); siter != pools.end(); ++siter) {
+    for (auto siter = pools.begin(); siter != pools.end(); ++siter) {
       formatter->open_object_section("pool");
-      formatter->dump_string("name",  *siter);
+      formatter->dump_string("name",  siter->to_str());
       formatter->close_section();
     }
     formatter->close_section();
@@ -5850,7 +5851,7 @@ next:
 
     RGWOrphanSearchInfo info;
 
-    info.pool = pool_name;
+    info.pool = pool;
     info.job_name = job_id;
     info.num_shards = num_shards;
 
@@ -6721,7 +6722,7 @@ next:
         return EINVAL;
       }
 
-      RGWReplicaObjectLogger logger(store, pool_name, META_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, META_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.get_bounds(shard_id, bounds);
       if (ret < 0)
         return -ret;
@@ -6730,7 +6731,7 @@ next:
         cerr << "ERROR: shard-id must be specified for get operation" << std::endl;
         return EINVAL;
       }
-      RGWReplicaObjectLogger logger(store, pool_name, DATA_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, DATA_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.get_bounds(shard_id, bounds);
       if (ret < 0)
         return -ret;
@@ -6768,7 +6769,7 @@ next:
         cerr << "ERROR: daemon-id must be specified for delete operation" << std::endl;
         return EINVAL;
       }
-      RGWReplicaObjectLogger logger(store, pool_name, META_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, META_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.delete_bound(shard_id, daemon_id, false);
       if (ret < 0)
         return -ret;
@@ -6781,7 +6782,7 @@ next:
         cerr << "ERROR: daemon-id must be specified for delete operation" << std::endl;
         return EINVAL;
       }
-      RGWReplicaObjectLogger logger(store, pool_name, DATA_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, DATA_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.delete_bound(shard_id, daemon_id, false);
       if (ret < 0)
         return -ret;
@@ -6830,7 +6831,7 @@ next:
         return EINVAL;
       }
 
-      RGWReplicaObjectLogger logger(store, pool_name, META_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, META_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.update_bound(shard_id, daemon_id, marker, time, &entries);
       if (ret < 0) {
         cerr << "ERROR: failed to update bounds: " << cpp_strerror(-ret) << std::endl;
@@ -6841,7 +6842,7 @@ next:
         cerr << "ERROR: shard-id must be specified for get operation" << std::endl;
         return EINVAL;
       }
-      RGWReplicaObjectLogger logger(store, pool_name, DATA_REPLICA_LOG_OBJ_PREFIX);
+      RGWReplicaObjectLogger logger(store, pool, DATA_REPLICA_LOG_OBJ_PREFIX);
       int ret = logger.update_bound(shard_id, daemon_id, marker, time, &entries);
       if (ret < 0) {
         cerr << "ERROR: failed to update bounds: " << cpp_strerror(-ret) << std::endl;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -498,10 +498,9 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id,
 
 static bool bucket_object_check_filter(const string& oid)
 {
+  rgw_obj_key key;
   string ns;
-  string ver;
-  string name;
-  return rgw_obj::translate_oid_to_obj_in_ns(oid, name, ns, ver);
+  return rgw_obj_key::oid_to_key_in_ns(oid, &key, ns);
 }
 
 int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bucket& bucket, rgw_obj_key& key)
@@ -999,7 +998,6 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
   int max = 1000;
 
   map<string, bool> common_prefixes;
-  string ns = "";
 
   bool is_truncated;
   map<string, bool> meta_objs;
@@ -1033,10 +1031,10 @@ int RGWBucket::check_bad_index_multipart(RGWBucketAdminOpState& op_state,
       rgw_bucket_dir_entry& ent = *iter;
 
       rgw_obj obj(bucket, ent.key);
-      obj.set_ns(ns);
+      obj.key.ns.clear();
 
       rgw_obj_index_key key;
-      obj.get_index_key(&key);
+      obj.key.get_index_key(&key);
 
       string oid = key.name;
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -819,12 +819,11 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     return -EINVAL;
   }
 
-  std::string no_oid;
-
   std::string display_name = op_state.get_user_display_name();
   rgw_bucket bucket = op_state.get_bucket();
 
-  rgw_obj obj(bucket, no_oid);
+  const rgw_pool& root_pool = store->get_zone_params().domain_root;
+  rgw_raw_obj obj(root_pool, bucket.name);
   RGWObjVersionTracker objv_tracker;
 
   map<string, bufferlist> attrs;
@@ -886,9 +885,7 @@ int RGWBucket::link(RGWBucketAdminOpState& op_state, std::string *err_msg)
     policy_instance.encode(aclbl);
 
     string oid_bucket_instance = RGW_BUCKET_INSTANCE_MD_PREFIX + key;
-    rgw_bucket bucket_instance;
-    bucket_instance.name = oid_bucket_instance;
-    rgw_obj obj_bucket_instance(bucket_instance, no_oid);
+    rgw_raw_obj obj_bucket_instance(root_pool, oid_bucket_instance);
     r = store->system_obj_set_attr(NULL, obj_bucket_instance, RGW_ATTR_ACL, aclbl, &objv_tracker);
 
     r = rgw_link_bucket(store, user_info.user_id, bucket_info.bucket, real_time());

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -496,12 +496,12 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id,
   } while (!done);
 }
 
-static bool bucket_object_check_filter(const string& name)
+static bool bucket_object_check_filter(const string& oid)
 {
   string ns;
   string ver;
-  string obj = name;
-  return rgw_obj::translate_raw_obj_to_obj_in_ns(obj, ns, ver);
+  string name;
+  return rgw_obj::translate_oid_to_obj_in_ns(oid, name, ns, ver);
 }
 
 int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bucket& bucket, rgw_obj_key& key)
@@ -650,7 +650,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
 
       ret = store->get_obj_state(&obj_ctx, obj, &astate, false);
       if (ret == -ENOENT) {
-        dout(1) << "WARNING: cannot find obj state for obj " << obj.get_object() << dendl;
+        dout(1) << "WARNING: cannot find obj state for obj " << obj.get_oid() << dendl;
         continue;
       }
       if (ret < 0) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -647,7 +647,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
       RGWObjState *astate = NULL;
       rgw_obj obj(bucket, (*it).key);
 
-      ret = store->get_obj_state(&obj_ctx, obj, &astate, false);
+      ret = store->get_obj_state(&obj_ctx, info, obj, &astate, false);
       if (ret == -ENOENT) {
         dout(1) << "WARNING: cannot find obj state for obj " << obj.get_oid() << dendl;
         continue;
@@ -662,7 +662,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
         RGWObjManifest::obj_iterator miter = manifest.obj_begin();
         rgw_obj head_obj = manifest.get_obj();
         rgw_raw_obj raw_head_obj;
-        store->obj_to_raw(head_obj, &raw_head_obj);
+        store->obj_to_raw(info.placement_rule, head_obj, &raw_head_obj);
 
 
         for (; miter != manifest.obj_end() && max_aio--; ++miter) {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1922,7 +1922,7 @@ public:
     RGWObjectCtx obj_ctx(store);
 
     string tenant_name, bucket_name;
-    parse_bucket(entry, tenant_name, bucket_name);
+    parse_bucket(entry, &tenant_name, &bucket_name);
     int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, be, &ot, &mtime, &attrs);
     if (ret < 0)
       return ret;
@@ -1950,7 +1950,7 @@ public:
     RGWObjectCtx obj_ctx(store);
 
     string tenant_name, bucket_name;
-    parse_bucket(entry, tenant_name, bucket_name);
+    parse_bucket(entry, &tenant_name, &bucket_name);
     int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, old_be, &old_ot, &orig_mtime, &attrs);
     if (ret < 0 && ret != -ENOENT)
       return ret;
@@ -1988,7 +1988,7 @@ public:
     RGWObjectCtx obj_ctx(store);
 
     string tenant_name, bucket_name;
-    parse_bucket(entry, tenant_name, bucket_name);
+    parse_bucket(entry, &tenant_name, &bucket_name);
     int ret = store->get_bucket_entrypoint_info(obj_ctx, tenant_name, bucket_name, be, &objv_tracker, NULL, NULL);
     if (ret < 0)
       return ret;
@@ -2113,10 +2113,12 @@ public:
       rgw_bucket_instance_oid_to_key(key);
       string tenant_name;
       string bucket_name;
-      parse_bucket(key, tenant_name, bucket_name);
+      string bucket_instance;
+      parse_bucket(key, &tenant_name, &bucket_name, &bucket_instance);
 
       RGWZonePlacementInfo rule_info;
       bci.info.bucket.name = bucket_name;
+      bci.info.bucket.bucket_id = bucket_instance;
       bci.info.bucket.tenant = tenant_name;
       ret = store->select_bucket_location_by_rule(bci.info.placement_rule, bci.info.bucket, &rule_info);
       if (ret < 0) {

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -46,7 +46,7 @@ extern int rgw_bucket_delete_bucket_obj(RGWRados *store,
                                         const string& bucket_name,
                                         RGWObjVersionTracker& objv_tracker);
 
-extern int rgw_bucket_sync_user_stats(RGWRados *store, const rgw_user& user_id, rgw_bucket& bucket);
+extern int rgw_bucket_sync_user_stats(RGWRados *store, const rgw_user& user_id, const RGWBucketInfo& bucket_info);
 extern int rgw_bucket_sync_user_stats(RGWRados *store, const string& tenant_name, const string& bucket_name);
 
 extern void rgw_make_bucket_entry_name(const string& tenant_name,

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -274,7 +274,7 @@ public:
   int init(RGWRados *storage, RGWBucketAdminOpState& op_state);
 
   int check_bad_index_multipart(RGWBucketAdminOpState& op_state,
-          list<rgw_obj_key>& objs_to_unlink, std::string *err_msg = NULL);
+          list<rgw_obj_index_key>& objs_to_unlink, std::string *err_msg = NULL);
 
   int check_object_index(RGWBucketAdminOpState& op_state,
                          RGWFormatterFlusher& flusher,

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -176,7 +176,7 @@ class RGWCache  : public T
   int list_objects_raw_init(rgw_pool& pool, RGWAccessHandle *handle) {
     return T::list_objects_raw_init(pool, handle);
   }
-  int list_objects_raw_next(RGWObjEnt& obj, RGWAccessHandle *handle) {
+  int list_objects_raw_next(rgw_bucket_dir_entry& obj, RGWAccessHandle *handle) {
     return T::list_objects_raw_next(obj, handle);
   }
 

--- a/src/rgw/rgw_cache.h
+++ b/src/rgw/rgw_cache.h
@@ -94,7 +94,7 @@ WRITE_CLASS_ENCODER(ObjectCacheInfo)
 
 struct RGWCacheNotifyInfo {
   uint32_t op;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   ObjectCacheInfo obj_info;
   off_t ofs;
   string ns;
@@ -173,25 +173,25 @@ class RGWCache  : public T
 {
   ObjectCache cache;
 
-  int list_objects_raw_init(rgw_bucket& bucket, RGWAccessHandle *handle) {
-    return T::list_objects_raw_init(bucket, handle);
+  int list_objects_raw_init(rgw_pool& pool, RGWAccessHandle *handle) {
+    return T::list_objects_raw_init(pool, handle);
   }
   int list_objects_raw_next(RGWObjEnt& obj, RGWAccessHandle *handle) {
     return T::list_objects_raw_next(obj, handle);
   }
 
-  string normal_name(rgw_bucket& bucket, const std::string& oid) {
-    string& bucket_name = bucket.name;
-    char buf[bucket_name.size() + 1 + oid.size() + 1];
-    const char *bucket_str = bucket_name.c_str();
+  string normal_name(rgw_pool& pool, const std::string& oid) {
+    string& pool_name = pool.name;
+    char buf[pool_name.size() + 1 + oid.size() + 1];
+    const char *pool_str = pool_name.c_str();
     const char *oid_str = oid.c_str();
-    sprintf(buf, "%s+%s", bucket_str, oid_str);
+    sprintf(buf, "%s+%s", pool_str, oid_str);
     return string(buf);
   }
 
-  void normalize_bucket_and_obj(rgw_bucket& src_bucket, const string& src_obj, rgw_bucket& dst_bucket, string& dst_obj);
-  string normal_name(rgw_obj& obj) {
-    return normal_name(obj.bucket, obj.get_object());
+  void normalize_pool_and_obj(rgw_pool& src_pool, const string& src_obj, rgw_pool& dst_pool, string& dst_obj);
+  string normal_name(rgw_raw_obj& obj) {
+    return normal_name(obj.pool, obj.oid);
   }
 
   int init_rados() {
@@ -208,7 +208,7 @@ class RGWCache  : public T
     return true;
   }
 
-  int distribute_cache(const string& normal_name, rgw_obj& obj, ObjectCacheInfo& obj_info, int op);
+  int distribute_cache(const string& normal_name, rgw_raw_obj& obj, ObjectCacheInfo& obj_info, int op);
   int watch_cb(uint64_t notify_id,
 	       uint64_t cookie,
 	       uint64_t notifier_id,
@@ -224,27 +224,27 @@ public:
     cache.chain_cache(cc);
   }
 
-  int system_obj_set_attrs(void *ctx, rgw_obj& obj, 
+  int system_obj_set_attrs(void *ctx, rgw_raw_obj& obj, 
                 map<string, bufferlist>& attrs,
                 map<string, bufferlist>* rmattrs,
                 RGWObjVersionTracker *objv_tracker);
-  int put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mtime,
+  int put_system_obj_impl(rgw_raw_obj& obj, uint64_t size, real_time *mtime,
               map<std::string, bufferlist>& attrs, int flags,
               bufferlist& data,
               RGWObjVersionTracker *objv_tracker,
               real_time set_mtime);
-  int put_system_obj_data(void *ctx, rgw_obj& obj, bufferlist& bl, off_t ofs, bool exclusive);
+  int put_system_obj_data(void *ctx, rgw_raw_obj& obj, bufferlist& bl, off_t ofs, bool exclusive);
 
   int get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::Read::GetObjState& read_state,
-                     RGWObjVersionTracker *objv_tracker, rgw_obj& obj,
+                     RGWObjVersionTracker *objv_tracker, rgw_raw_obj& obj,
                      bufferlist& bl, off_t ofs, off_t end,
                      map<string, bufferlist> *attrs,
                      rgw_cache_entry_info *cache_info);
 
-  int raw_obj_stat(rgw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch, map<string, bufferlist> *attrs,
+  int raw_obj_stat(rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch, map<string, bufferlist> *attrs,
                    bufferlist *first_chunk, RGWObjVersionTracker *objv_tracker);
 
-  int delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker);
+  int delete_system_obj(rgw_raw_obj& obj, RGWObjVersionTracker *objv_tracker);
 
   bool chain_cache_entry(list<rgw_cache_entry_info *>& cache_info_entries, RGWChainedCache::Entry *chained_entry) {
     return cache.chain_cache_entry(cache_info_entries, chained_entry);
@@ -252,23 +252,23 @@ public:
 };
 
 template <class T>
-void RGWCache<T>::normalize_bucket_and_obj(rgw_bucket& src_bucket, const string& src_obj, rgw_bucket& dst_bucket, string& dst_obj)
+void RGWCache<T>::normalize_pool_and_obj(rgw_pool& src_pool, const string& src_obj, rgw_pool& dst_pool, string& dst_obj)
 {
   if (src_obj.size()) {
-    dst_bucket = src_bucket;
+    dst_pool = src_pool;
     dst_obj = src_obj;
   } else {
-    dst_bucket = T::get_zone_params().domain_root;
-    dst_obj = src_bucket.name;
+    dst_pool = T::get_zone_params().domain_root;
+    dst_obj = src_pool.name;
   }
 }
 
 template <class T>
-int RGWCache<T>::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker)
+int RGWCache<T>::delete_system_obj(rgw_raw_obj& obj, RGWObjVersionTracker *objv_tracker)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
 
   string name = normal_name(obj);
   cache.remove(name);
@@ -281,18 +281,18 @@ int RGWCache<T>::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_trac
 
 template <class T>
 int RGWCache<T>::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::Read::GetObjState& read_state,
-                     RGWObjVersionTracker *objv_tracker, rgw_obj& obj,
+                     RGWObjVersionTracker *objv_tracker, rgw_raw_obj& obj,
                      bufferlist& obl, off_t ofs, off_t end,
                      map<string, bufferlist> *attrs,
                      rgw_cache_entry_info *cache_info)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
   if (ofs != 0)
     return T::get_system_obj(obj_ctx, read_state, objv_tracker, obj, obl, ofs, end, attrs, cache_info);
 
-  string name = normal_name(obj.bucket, oid);
+  string name = normal_name(obj.pool, oid);
 
   ObjectCacheInfo info;
 
@@ -351,14 +351,14 @@ int RGWCache<T>::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::R
 }
 
 template <class T>
-int RGWCache<T>::system_obj_set_attrs(void *ctx, rgw_obj& obj, 
+int RGWCache<T>::system_obj_set_attrs(void *ctx, rgw_raw_obj& obj, 
                            map<string, bufferlist>& attrs,
                            map<string, bufferlist>* rmattrs,
                            RGWObjVersionTracker *objv_tracker) 
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
   ObjectCacheInfo info;
   info.xattrs = attrs;
   if (rmattrs)
@@ -370,7 +370,7 @@ int RGWCache<T>::system_obj_set_attrs(void *ctx, rgw_obj& obj,
     info.flags |= CACHE_FLAG_OBJV;
   }
   int ret = T::system_obj_set_attrs(ctx, obj, attrs, rmattrs, objv_tracker);
-  string name = normal_name(bucket, oid);
+  string name = normal_name(pool, oid);
   if (ret >= 0) {
     cache.put(name, info, NULL);
     int r = distribute_cache(name, obj, info, UPDATE_OBJ);
@@ -384,15 +384,15 @@ int RGWCache<T>::system_obj_set_attrs(void *ctx, rgw_obj& obj,
 }
 
 template <class T>
-int RGWCache<T>::put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mtime,
+int RGWCache<T>::put_system_obj_impl(rgw_raw_obj& obj, uint64_t size, real_time *mtime,
               map<std::string, bufferlist>& attrs, int flags,
               bufferlist& data,
               RGWObjVersionTracker *objv_tracker,
               real_time set_mtime)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
   ObjectCacheInfo info;
   info.xattrs = attrs;
   info.status = 0;
@@ -410,7 +410,7 @@ int RGWCache<T>::put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mti
   }
   info.meta.mtime = result_mtime;
   info.meta.size = size;
-  string name = normal_name(bucket, oid);
+  string name = normal_name(pool, oid);
   if (ret >= 0) {
     cache.put(name, info, NULL);
     int r = distribute_cache(name, obj, info, UPDATE_OBJ);
@@ -424,11 +424,11 @@ int RGWCache<T>::put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mti
 }
 
 template <class T>
-int RGWCache<T>::put_system_obj_data(void *ctx, rgw_obj& obj, bufferlist& data, off_t ofs, bool exclusive)
+int RGWCache<T>::put_system_obj_data(void *ctx, rgw_raw_obj& obj, bufferlist& data, off_t ofs, bool exclusive)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
   ObjectCacheInfo info;
   bool cacheable = false;
   if ((ofs == 0) || (ofs == -1)) {
@@ -440,7 +440,7 @@ int RGWCache<T>::put_system_obj_data(void *ctx, rgw_obj& obj, bufferlist& data, 
   }
   int ret = T::put_system_obj_data(ctx, obj, data, ofs, exclusive);
   if (cacheable) {
-    string name = normal_name(bucket, oid);
+    string name = normal_name(pool, oid);
     if (ret >= 0) {
       cache.put(name, info, NULL);
       int r = distribute_cache(name, obj, info, UPDATE_OBJ);
@@ -455,15 +455,15 @@ int RGWCache<T>::put_system_obj_data(void *ctx, rgw_obj& obj, bufferlist& data, 
 }
 
 template <class T>
-int RGWCache<T>::raw_obj_stat(rgw_obj& obj, uint64_t *psize, real_time *pmtime,
+int RGWCache<T>::raw_obj_stat(rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime,
                           uint64_t *pepoch, map<string, bufferlist> *attrs,
                           bufferlist *first_chunk, RGWObjVersionTracker *objv_tracker)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(obj.bucket, obj.get_object(), bucket, oid);
+  normalize_pool_and_obj(obj.pool, obj.oid, pool, oid);
 
-  string name = normal_name(bucket, oid);
+  string name = normal_name(pool, oid);
 
   uint64_t size;
   real_time mtime;
@@ -516,7 +516,7 @@ done:
 }
 
 template <class T>
-int RGWCache<T>::distribute_cache(const string& normal_name, rgw_obj& obj, ObjectCacheInfo& obj_info, int op)
+int RGWCache<T>::distribute_cache(const string& normal_name, rgw_raw_obj& obj, ObjectCacheInfo& obj_info, int op)
 {
   RGWCacheNotifyInfo info;
 
@@ -548,10 +548,10 @@ int RGWCache<T>::watch_cb(uint64_t notify_id,
     return -EIO;
   }
 
-  rgw_bucket bucket;
+  rgw_pool pool;
   string oid;
-  normalize_bucket_and_obj(info.obj.bucket, info.obj.get_object(), bucket, oid);
-  string name = normal_name(bucket, oid);
+  normalize_pool_and_obj(info.obj.pool, info.obj.oid, pool, oid);
+  string name = normal_name(pool, oid);
   
   switch (info.op) {
   case UPDATE_OBJ:

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -14,6 +14,7 @@
 #include "rgw_common.h"
 #include "rgw_acl.h"
 #include "rgw_string.h"
+#include "rgw_rados.h"
 
 #include "common/ceph_crypto.h"
 #include "common/armor.h"
@@ -1432,6 +1433,14 @@ bool RGWUserCaps::is_valid_cap_type(const string& tp)
   }
 
   return false;
+}
+
+void rgw_raw_obj::decode_from_rgw_obj(bufferlist::iterator& bl)
+{
+  rgw_obj old_obj;
+  ::decode(old_obj, bl);
+
+  RGWRados::obj_to_raw(old_obj, this);
 }
 
 std::string rgw_bucket::get_key(char tenant_delim, char id_delim) const

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1468,7 +1468,7 @@ static void escape_str(const string& s, char esc_char, char special_char, string
   const char *src = s.c_str();
   char dest_buf[s.size() * 2 + 1];
   char *destp = dest_buf;
-  
+
   for (size_t i = 0; i < s.size(); i++) {
     char c = src[i];
     if (c == esc_char || c == special_char) {
@@ -1482,7 +1482,7 @@ static void escape_str(const string& s, char esc_char, char special_char, string
 
 void rgw_pool::from_str(const string& s)
 {
-  ssize_t pos = unescape_str(s, 0, '\\', ':', &name);
+  size_t pos = unescape_str(s, 0, '\\', ':', &name);
   if (pos != string::npos) {
     pos = unescape_str(s, pos, '\\', ':', &ns);
     /* ignore return; if pos != string::npos it means that we had a colon

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1435,6 +1435,74 @@ bool RGWUserCaps::is_valid_cap_type(const string& tp)
   return false;
 }
 
+static ssize_t unescape_str(const string& s, ssize_t ofs, char esc_char, char special_char, string *dest)
+{
+  const char *src = s.c_str();
+  char dest_buf[s.size() + 1];
+  char *destp = dest_buf;
+  bool esc = false;
+
+  dest_buf[0] = '\0';
+
+  for (size_t i = ofs; i < s.size(); i++) {
+    char c = src[i];
+    if (!esc && c == esc_char) {
+      esc = true;
+      continue;
+    }
+    if (!esc && c == special_char) {
+      *destp = '\0';
+      *dest = dest_buf;
+      return (ssize_t)i + 1;
+    }
+    *destp++ = c;
+    esc = false;
+  }
+  *destp = '\0';
+  *dest = dest_buf;
+  return string::npos;
+}
+
+static void escape_str(const string& s, char esc_char, char special_char, string *dest)
+{
+  const char *src = s.c_str();
+  char dest_buf[s.size() * 2 + 1];
+  char *destp = dest_buf;
+  
+  for (size_t i = 0; i < s.size(); i++) {
+    char c = src[i];
+    if (c == esc_char || c == special_char) {
+      *destp++ = esc_char;
+    }
+    *destp++ = c;
+  }
+  *destp++ = '\0';
+  *dest = dest_buf;
+}
+
+void rgw_pool::from_str(const string& s)
+{
+  ssize_t pos = unescape_str(s, 0, '\\', ':', &name);
+  if (pos != string::npos) {
+    pos = unescape_str(s, pos, '\\', ':', &ns);
+    /* ignore return; if pos != string::npos it means that we had a colon
+     * in the middle of ns that wasn't escaped, we're going to stop there
+     */
+  }
+}
+
+string rgw_pool::to_str() const
+{
+  string esc_name;
+  escape_str(name, '\\', ':', &esc_name);
+  if (ns.empty()) {
+    return esc_name;
+  }
+  string esc_ns;
+  escape_str(ns, '\\', ':', &esc_ns);
+  return esc_name + ":" + esc_ns;
+}
+
 void rgw_raw_obj::decode_from_rgw_obj(bufferlist::iterator& bl)
 {
   rgw_obj old_obj;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1440,7 +1440,8 @@ void rgw_raw_obj::decode_from_rgw_obj(bufferlist::iterator& bl)
   rgw_obj old_obj;
   ::decode(old_obj, bl);
 
-  RGWRados::obj_to_raw(old_obj, this);
+  get_obj_bucket_and_oid_loc(old_obj, oid, loc);
+  pool = old_obj.get_explicit_data_pool();
 }
 
 std::string rgw_bucket::get_key(char tenant_delim, char id_delim) const

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -766,15 +766,22 @@ struct rgw_pool {
   void decode_from_bucket(bufferlist::iterator& bl);
 
   void decode(bufferlist::iterator& bl) {
-    uint64_t start_off = bl.get_off();
     DECODE_START_LEGACY_COMPAT_LEN(10, 3, 3, bl);
-    if (struct_v < 10) {
-      bl.seek(start_off);
-      decode_from_bucket(bl);
-      return;
-    }
 
     ::decode(name, bl);
+
+    if (struct_v < 10) {
+
+    /*
+     * note that rgw_pool can be used where rgw_bucket was used before
+     * therefore we inherit rgw_bucket's old versions. However, we only
+     * need the first field from rgw_bucket. unless we add more fields
+     * in which case we'll need to look at struct_v, and check the actual
+     * version. Anything older than 10 needs to be treated as old rgw_bucket
+     */
+
+    }
+
     DECODE_FINISH(bl);
   }
 
@@ -817,6 +824,7 @@ struct rgw_data_placement_target {
   };
 
   void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 };
 
 inline ostream& operator<<(ostream& out, const rgw_pool& p) {
@@ -872,6 +880,9 @@ struct rgw_raw_obj {
     }
     return (r < 0);
   }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_raw_obj)
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -861,9 +861,21 @@ struct rgw_raw_obj {
     ::encode(loc, bl);
     ENCODE_FINISH(bl);
   }
+
+  void decode_from_rgw_obj(bufferlist::iterator& bl);
+
   void decode(bufferlist::iterator& bl) {
-     DECODE_START(6, bl);
-#warning decode old rgw_obj
+    unsigned ofs = bl.get_off();
+    DECODE_START(6, bl);
+    if (struct_v < 6) {
+      /*
+       * this object was encoded as rgw_obj, prior to rgw_raw_obj been split out of it,
+       * let's decode it as rgw_obj and convert it
+       */
+      bl.seek(ofs);
+      decode_from_rgw_obj(bl);
+      return;
+    }
     ::decode(pool, bl);
     ::decode(oid, bl);
     ::decode(loc, bl);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -842,6 +842,10 @@ struct rgw_raw_obj {
     oid = _oid;
   }
 
+  bool empty() {
+    return oid.empty();
+  }
+
   void encode(bufferlist& bl) const {
      ENCODE_START(6, 6, bl);
     ::encode(pool, bl);
@@ -856,6 +860,17 @@ struct rgw_raw_obj {
     ::decode(oid, bl);
     ::decode(loc, bl);
     DECODE_FINISH(bl);
+  }
+
+  bool operator<(const rgw_raw_obj& o) const {
+    int r = pool.compare(o.pool);
+    if (r == 0) {
+      r = oid.compare(o.oid);
+      if (r == 0) {
+        r = loc.compare(o.loc);
+      }
+    }
+    return (r < 0);
   }
 };
 WRITE_CLASS_ENCODER(rgw_raw_obj)
@@ -1662,6 +1677,10 @@ public:
     if (orig_obj[0] == '_' && ns.empty()) {
       loc = orig_obj;
     }
+  }
+
+  bool empty() {
+    return object.empty();
   }
 
   bool have_null_instance() {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -850,7 +850,7 @@ struct rgw_raw_obj {
     oid = _oid;
   }
 
-  bool empty() {
+  bool empty() const {
     return oid.empty();
   }
 
@@ -891,6 +891,10 @@ struct rgw_raw_obj {
       }
     }
     return (r < 0);
+  }
+
+  bool operator==(const rgw_raw_obj& o) const {
+    return (pool == o.pool && oid == o.oid && loc == o.loc);
   }
 
   void dump(Formatter *f) const;
@@ -1702,7 +1706,7 @@ public:
     }
   }
 
-  bool empty() {
+  bool empty() const {
     return object.empty();
   }
 
@@ -1710,7 +1714,7 @@ public:
     return instance == "null";
   }
 
-  bool have_instance() {
+  bool have_instance() const {
     return !instance.empty();
   }
 
@@ -1798,7 +1802,7 @@ public:
     }
   }
 
-  string& get_hash_object() {
+  const string& get_hash_object() const {
     return index_hash_source.empty() ? orig_obj : index_hash_source;
   }
   /**
@@ -1896,6 +1900,14 @@ public:
 
   bool is_in_extra_data() const {
     return in_extra_data;
+  }
+
+  const rgw_pool& get_data_pool() const {
+    if (!in_extra_data) {
+      return bucket.placement.data_pool;
+    } else {
+      return bucket.placement.data_extra_pool;
+    }
   }
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1826,7 +1826,6 @@ WRITE_CLASS_ENCODER(RGWBucketEnt)
 struct rgw_obj {
   rgw_bucket bucket;
   rgw_obj_key key;
-  std::string placement_id;
 
   bool in_extra_data{false}; /* in-memory only member, does not serialize */
 
@@ -1883,7 +1882,7 @@ struct rgw_obj {
     ::encode(key.ns, bl);
     ::encode(key.name, bl);
     ::encode(key.instance, bl);
-    ::encode(placement_id, bl);
+//    ::encode(placement_id, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& bl) {
@@ -1918,7 +1917,7 @@ struct rgw_obj {
       ::decode(key.ns, bl);
       ::decode(key.name, bl);
       ::decode(key.instance, bl);
-      ::decode(placement_id, bl);
+//      ::decode(placement_id, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -992,6 +992,9 @@ struct rgw_bucket {
   bool operator<(const rgw_bucket& b) const {
     return name.compare(b.name) < 0;
   }
+  bool operator==(const rgw_bucket& b) const {
+    return (name == b.name) && (bucket_id == b.bucket_id);
+  }
 };
 WRITE_CLASS_ENCODER(rgw_bucket)
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -789,7 +789,7 @@ struct rgw_pool {
     return (compare(p) == 0);
   }
   bool operator!=(const rgw_pool& p) const {
-    return (*this != p);
+    return !(*this == p);
   }
 };
 WRITE_CLASS_ENCODER(rgw_pool)

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -8,7 +8,7 @@
 
 //------------RGWPutObj_Compress---------------
 
-int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_obj *pobj, bool *again)
+int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again)
 {
   bufferlist in_bl;
   if (*again) {

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -43,7 +43,7 @@ public:
                      RGWPutObjDataProcessor* next)
     : RGWPutObj_Filter(next), cct(cct_), compressor(compressor) {}
   virtual ~RGWPutObj_Compress(){}
-  virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_obj *pobj, bool *again) override;
+  virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override;
 
   bool is_compressed() { return compressed; }
   vector<compression_block>& get_compression_blocks() { return blocks; }

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -479,8 +479,7 @@ int RGWAsyncFetchRemoteObj::_send_request()
   string op_id = store->unique_id(store->get_new_req_id());
   map<string, bufferlist> attrs;
 
-  rgw_obj src_obj(bucket_info.bucket, key.name);
-  src_obj.set_instance(key.instance);
+  rgw_obj src_obj(bucket_info.bucket, key);
 
   rgw_obj dest_obj(src_obj);
 
@@ -531,8 +530,7 @@ int RGWAsyncStatRemoteObj::_send_request()
   string client_id = store->zone_id() + buf;
   string op_id = store->unique_id(store->get_new_req_id());
 
-  rgw_obj src_obj(bucket_info.bucket, key.name);
-  src_obj.set_instance(key.instance);
+  rgw_obj src_obj(bucket_info.bucket, key);
 
   rgw_obj dest_obj(src_obj);
 
@@ -566,8 +564,7 @@ int RGWAsyncRemoveObj::_send_request()
 {
   RGWObjectCtx obj_ctx(store);
 
-  rgw_obj obj(bucket_info.bucket, key.name);
-  obj.set_instance(key.instance);
+  rgw_obj obj(bucket_info.bucket, key);
 
   ldout(store->ctx(), 0) << __func__ << "(): deleting obj=" << obj << dendl;
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -228,7 +228,6 @@ RGWRadosSetOmapKeysCR::~RGWRadosSetOmapKeysCR()
 
 int RGWRadosSetOmapKeysCR::send_request()
 {
-  rgw_rados_ref ref;
   int r = store->get_raw_obj_ref(obj, &ref);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to get ref for (" << obj << ") ret=" << r << dendl;
@@ -271,7 +270,6 @@ RGWRadosGetOmapKeysCR::~RGWRadosGetOmapKeysCR()
 }
 
 int RGWRadosGetOmapKeysCR::send_request() {
-  rgw_rados_ref ref;
   int r = store->get_raw_obj_ref(obj, &ref);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to get ref for (" << obj << ") ret=" << r << dendl;
@@ -302,7 +300,6 @@ RGWRadosRemoveOmapKeysCR::~RGWRadosRemoveOmapKeysCR()
 }
 
 int RGWRadosRemoveOmapKeysCR::send_request() {
-  rgw_rados_ref ref;
   int r = store->get_raw_obj_ref(obj, &ref);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to get ref for (" << obj << ") ret=" << r << dendl;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1091,6 +1091,7 @@ class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
 
 class RGWAsyncStatObj : public RGWAsyncRadosRequest {
   RGWRados *store;
+  RGWBucketInfo bucket_info;
   rgw_obj obj;
   uint64_t *psize;
   real_time *pmtime;
@@ -1100,7 +1101,7 @@ protected:
   int _send_request() override;
 public:
   RGWAsyncStatObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *store,
-                  const rgw_obj& obj, uint64_t *psize = nullptr,
+                  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
                   real_time *pmtime = nullptr, uint64_t *pepoch = nullptr,
                   RGWObjVersionTracker *objv_tracker = nullptr)
 	  : RGWAsyncRadosRequest(caller, cn), store(store), obj(obj), psize(psize),
@@ -1110,6 +1111,7 @@ public:
 class RGWStatObjCR : public RGWSimpleCoroutine {
   RGWRados *store;
   RGWAsyncRadosProcessor *async_rados;
+  RGWBucketInfo bucket_info;
   rgw_obj obj;
   uint64_t *psize;
   real_time *pmtime;
@@ -1118,7 +1120,7 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
   RGWAsyncStatObj *req = nullptr;
  public:
   RGWStatObjCR(RGWAsyncRadosProcessor *async_rados, RGWRados *store,
-	  const rgw_obj& obj, uint64_t *psize = nullptr,
+	  const RGWBucketInfo& _bucket_info, const rgw_obj& obj, uint64_t *psize = nullptr,
 	  real_time* pmtime = nullptr, uint64_t *pepoch = nullptr,
 	  RGWObjVersionTracker *objv_tracker = nullptr);
   ~RGWStatObjCR() {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -101,7 +101,7 @@ class RGWAsyncGetSystemObj : public RGWAsyncRadosRequest {
   RGWObjectCtx *obj_ctx;
   RGWRados::SystemObject::Read::GetObjState read_state;
   RGWObjVersionTracker *objv_tracker;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   bufferlist *pbl;
   map<string, bufferlist> *pattrs;
   off_t ofs;
@@ -110,14 +110,14 @@ protected:
   int _send_request();
 public:
   RGWAsyncGetSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store, RGWObjectCtx *_obj_ctx,
-                       RGWObjVersionTracker *_objv_tracker, rgw_obj& _obj,
+                       RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                        bufferlist *_pbl, off_t _ofs, off_t _end);
   void set_read_attrs(map<string, bufferlist> *_pattrs) { pattrs = _pattrs; }
 };
 
 class RGWAsyncPutSystemObj : public RGWAsyncRadosRequest {
   RGWRados *store;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   bool exclusive;
   bufferlist bl;
 
@@ -125,27 +125,27 @@ protected:
   int _send_request();
 public:
   RGWAsyncPutSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
-                       rgw_obj& _obj, bool _exclusive,
+                       const rgw_raw_obj& _obj, bool _exclusive,
                        bufferlist& _bl);
 };
 
 class RGWAsyncPutSystemObjAttrs : public RGWAsyncRadosRequest {
   RGWRados *store;
   RGWObjVersionTracker *objv_tracker;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   map<string, bufferlist> *attrs;
 
 protected:
   int _send_request();
 public:
   RGWAsyncPutSystemObjAttrs(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
-                       RGWObjVersionTracker *_objv_tracker, rgw_obj& _obj,
+                       RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
                        map<string, bufferlist> *_attrs);
 };
 
 class RGWAsyncLockSystemObj : public RGWAsyncRadosRequest {
   RGWRados *store;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   string lock_name;
   string cookie;
   uint32_t duration_secs;
@@ -154,13 +154,13 @@ protected:
   int _send_request();
 public:
   RGWAsyncLockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
-                        RGWObjVersionTracker *_objv_tracker, rgw_obj& _obj,
+                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie, uint32_t _duration_secs);
 };
 
 class RGWAsyncUnlockSystemObj : public RGWAsyncRadosRequest {
   RGWRados *store;
-  rgw_obj obj;
+  rgw_raw_obj obj;
   string lock_name;
   string cookie;
 
@@ -168,7 +168,7 @@ protected:
   int _send_request();
 public:
   RGWAsyncUnlockSystemObj(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, RGWRados *_store,
-                        RGWObjVersionTracker *_objv_tracker, rgw_obj& _obj,
+                        RGWObjVersionTracker *_objv_tracker, const rgw_raw_obj& _obj,
 		        const string& _name, const string& _cookie);
 };
 
@@ -180,8 +180,7 @@ class RGWSimpleRadosReadCR : public RGWSimpleCoroutine {
   RGWObjectCtx obj_ctx;
   bufferlist bl;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   map<string, bufferlist> *pattrs{nullptr};
 
@@ -193,10 +192,10 @@ class RGWSimpleRadosReadCR : public RGWSimpleCoroutine {
 
 public:
   RGWSimpleRadosReadCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      T *_result, bool empty_on_enoent = true)
     : RGWSimpleCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
-      obj_ctx(store), pool(_pool), oid(_oid), result(_result),
+      obj_ctx(store), obj(_obj), result(_result),
       empty_on_enoent(empty_on_enoent) {}
   ~RGWSimpleRadosReadCR() {
     request_cleanup();
@@ -220,7 +219,6 @@ public:
 template <class T>
 int RGWSimpleRadosReadCR<T>::send_request()
 {
-  rgw_obj obj = rgw_obj(pool, oid);
   req = new RGWAsyncGetSystemObj(this, stack->create_completion_notifier(),
 			         store, &obj_ctx, NULL,
 				 obj,
@@ -268,8 +266,7 @@ class RGWSimpleRadosReadAttrsCR : public RGWSimpleCoroutine {
   RGWObjectCtx obj_ctx;
   bufferlist bl;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   map<string, bufferlist> *pattrs;
 
@@ -277,11 +274,11 @@ class RGWSimpleRadosReadAttrsCR : public RGWSimpleCoroutine {
 
 public:
   RGWSimpleRadosReadAttrsCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist> *_pattrs) : RGWSimpleCoroutine(_store->ctx()),
                                                 async_rados(_async_rados), store(_store),
                                                 obj_ctx(store),
-						pool(_pool), oid(_oid),
+						obj(_obj),
                                                 pattrs(_pattrs),
                                                 req(NULL) { }
   ~RGWSimpleRadosReadAttrsCR() {
@@ -305,18 +302,17 @@ class RGWSimpleRadosWriteCR : public RGWSimpleCoroutine {
   RGWRados *store;
   bufferlist bl;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAsyncPutSystemObj *req;
 
 public:
   RGWSimpleRadosWriteCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      const T& _data) : RGWSimpleCoroutine(_store->ctx()),
                                                 async_rados(_async_rados),
 						store(_store),
-						pool(_pool), oid(_oid),
+						obj(_obj),
                                                 req(NULL) {
     ::encode(_data, bl);
   }
@@ -333,7 +329,6 @@ public:
   }
 
   int send_request() {
-    rgw_obj obj = rgw_obj(pool, oid);
     req = new RGWAsyncPutSystemObj(this, stack->create_completion_notifier(),
 			           store, obj, false, bl);
     async_rados->queue(req);
@@ -349,8 +344,7 @@ class RGWSimpleRadosWriteAttrsCR : public RGWSimpleCoroutine {
   RGWAsyncRadosProcessor *async_rados;
   RGWRados *store;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   map<string, bufferlist> attrs;
 
@@ -358,11 +352,11 @@ class RGWSimpleRadosWriteAttrsCR : public RGWSimpleCoroutine {
 
 public:
   RGWSimpleRadosWriteAttrsCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist>& _attrs) : RGWSimpleCoroutine(_store->ctx()),
                                                 async_rados(_async_rados),
 						store(_store),
-						pool(_pool), oid(_oid),
+						obj(_obj),
                                                 attrs(_attrs), req(NULL) {
   }
   ~RGWSimpleRadosWriteAttrsCR() {
@@ -377,7 +371,6 @@ public:
   }
 
   int send_request() {
-    rgw_obj obj = rgw_obj(pool, oid);
     req = new RGWAsyncPutSystemObjAttrs(this, stack->create_completion_notifier(),
 			           store, NULL, obj, &attrs);
     async_rados->queue(req);
@@ -393,14 +386,13 @@ class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
   RGWRados *store;
   map<string, bufferlist> entries;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAioCompletionNotifier *cn;
 
 public:
   RGWRadosSetOmapKeysCR(RGWRados *_store,
-		      rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist>& _entries);
 
   ~RGWRadosSetOmapKeysCR();
@@ -419,14 +411,13 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   int rval;
   librados::IoCtx ioctx;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAioCompletionNotifier *cn;
 
 public:
   RGWRadosGetOmapKeysCR(RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      const string& _marker,
 		      map<string, bufferlist> *_entries, int _max_entries);
 
@@ -451,14 +442,13 @@ class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
 
   set<string> keys;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAioCompletionNotifier *cn;
 
 public:
   RGWRadosRemoveOmapKeysCR(RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid,
+		      const rgw_raw_obj& _obj,
 		      const set<string>& _keys);
 
   ~RGWRadosRemoveOmapKeysCR();
@@ -477,14 +467,14 @@ class RGWSimpleRadosLockCR : public RGWSimpleCoroutine {
   string cookie;
   uint32_t duration;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAsyncLockSystemObj *req;
 
 public:
   RGWSimpleRadosLockCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid, const string& _lock_name,
+		      const rgw_raw_obj& _obj,
+                      const string& _lock_name,
 		      const string& _cookie,
 		      uint32_t _duration);
   ~RGWSimpleRadosLockCR() {
@@ -509,14 +499,14 @@ class RGWSimpleRadosUnlockCR : public RGWSimpleCoroutine {
   string lock_name;
   string cookie;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   RGWAsyncUnlockSystemObj *req;
 
 public:
   RGWSimpleRadosUnlockCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-		      const rgw_bucket& _pool, const string& _oid, const string& _lock_name,
+		      const rgw_raw_obj& _obj, 
+                      const string& _lock_name,
 		      const string& _cookie);
   ~RGWSimpleRadosUnlockCR() {
     request_cleanup();
@@ -533,8 +523,7 @@ class RGWOmapAppend : public RGWConsumerCR<string> {
   RGWAsyncRadosProcessor *async_rados;
   RGWRados *store;
 
-  rgw_bucket pool;
-  string oid;
+  rgw_raw_obj obj;
 
   bool going_down;
 
@@ -546,7 +535,8 @@ class RGWOmapAppend : public RGWConsumerCR<string> {
   uint64_t window_size;
   uint64_t total_entries;
 public:
-  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store, rgw_bucket& _pool, const string& _oid,
+  RGWOmapAppend(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
+                const rgw_raw_obj& _obj,
                 uint64_t _window_size = OMAP_APPEND_MAX_ENTRIES_DEFAULT);
   int operate();
   void flush_pending();
@@ -557,12 +547,8 @@ public:
     return total_entries;
   }
 
-  const rgw_bucket& get_pool() {
-    return pool;
-  }
-
-  const string& get_oid() {
-    return oid;
+  const rgw_raw_obj& get_obj() {
+    return obj;
   }
 };
 
@@ -639,14 +625,14 @@ class RGWShardedOmapCRManager {
 
   vector<RGWOmapAppend *> shards;
 public:
-  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store, RGWCoroutine *_op, int _num_shards, rgw_bucket& pool, const string& oid_prefix)
+  RGWShardedOmapCRManager(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store, RGWCoroutine *_op, int _num_shards, const rgw_pool& pool, const string& oid_prefix)
                       : async_rados(_async_rados),
 		        store(_store), op(_op), num_shards(_num_shards) {
     shards.reserve(num_shards);
     for (int i = 0; i < num_shards; ++i) {
       char buf[oid_prefix.size() + 16];
       snprintf(buf, sizeof(buf), "%s.%d", oid_prefix.c_str(), i);
-      RGWOmapAppend *shard = new RGWOmapAppend(async_rados, store, pool, buf);
+      RGWOmapAppend *shard = new RGWOmapAppend(async_rados, store, rgw_raw_obj(pool, buf));
       shard->get();
       shards.push_back(shard);
       op->spawn(shard, false);
@@ -1018,8 +1004,7 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
   RGWAsyncRadosProcessor *async_rados;
   RGWRados *store;
 
-  const rgw_bucket& pool;
-  const string oid;
+  const rgw_raw_obj obj;
 
   const string lock_name;
   const string cookie;
@@ -1036,10 +1021,10 @@ class RGWContinuousLeaseCR : public RGWCoroutine {
 
 public:
   RGWContinuousLeaseCR(RGWAsyncRadosProcessor *_async_rados, RGWRados *_store,
-                       const rgw_bucket& _pool, const string& _oid,
+                       const rgw_raw_obj& _obj,
                        const string& _lock_name, int _interval, RGWCoroutine *_caller)
     : RGWCoroutine(_store->ctx()), async_rados(_async_rados), store(_store),
-    pool(_pool), oid(_oid), lock_name(_lock_name),
+    obj(_obj), lock_name(_lock_name),
     cookie(RGWSimpleRadosLockCR::gen_random_cookie(cct)),
     interval(_interval), lock("RGWContinuousLeaseCR"), caller(_caller)
   {}

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -386,6 +386,8 @@ class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
   RGWRados *store;
   map<string, bufferlist> entries;
 
+  rgw_rados_ref ref;
+
   rgw_raw_obj obj;
 
   RGWAioCompletionNotifier *cn;
@@ -409,7 +411,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   int max_entries;
 
   int rval;
-  librados::IoCtx ioctx;
+  rgw_rados_ref ref;
 
   rgw_raw_obj obj;
 
@@ -438,7 +440,7 @@ class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
   int max_entries;
 
   int rval;
-  librados::IoCtx ioctx;
+  rgw_rados_ref ref;
 
   set<string> keys;
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1672,7 +1672,7 @@ int RGWDataSyncStatusManager::init()
 
   error_logger = new RGWSyncErrorLogger(store, RGW_SYNC_ERROR_LOG_SHARD_PREFIX, ERROR_LOGGER_SHARDS);
 
-  int r = source_log.init(source_zone, conn, error_logger);
+  int r = source_log.init(source_zone, conn, error_logger, sync_module);
   if (r < 0) {
     lderr(store->ctx()) << "ERROR: failed to init remote log, r=" << r << dendl;
     finalize();
@@ -2670,8 +2670,8 @@ int RGWRunBucketSyncCoroutine::operate()
       set_status("acquiring sync lock");
       auto store = sync_env->store;
       lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store,
-                                          store->get_zone_params().log_pool,
-                                          status_oid, "sync_lock",
+                                          rgw_raw_obj(store->get_zone_params().log_pool, status_oid),
+                                          "sync_lock",
                                           cct->_conf->rgw_sync_lease_period,
                                           this);
       lease_stack = spawn(lease_cr.get(), false);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3083,8 +3083,8 @@ int DataLogTrimPollCR::operate()
       // prevent other gateways from attempting to trim for the duration
       set_status("acquiring trim lock");
       yield call(new RGWSimpleRadosLockCR(store->get_async_rados(), store,
-                                          store->get_zone_params().log_pool,
-                                          lock_oid, "data_trim", lock_cookie,
+                                          rgw_raw_obj(store->get_zone_params().log_pool, lock_oid),
+                                          "data_trim", lock_cookie,
                                           interval.sec()));
       if (retcode < 0) {
         // if the lock is already held, go back to sleep and try again later

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -264,7 +264,7 @@ public:
 
 class RGWDataSyncStatusManager {
   RGWRados *store;
-  librados::IoCtx ioctx;
+  rgw_rados_ref ref;
 
   string source_zone;
   RGWRESTConn *conn;
@@ -275,9 +275,8 @@ class RGWDataSyncStatusManager {
 
   string source_status_oid;
   string source_shard_status_oid_prefix;
-  rgw_obj source_status_obj;
 
-  map<int, rgw_obj> shard_objs;
+  map<int, rgw_raw_obj> shard_objs;
 
   int num_shards;
 
@@ -473,7 +472,6 @@ public:
 
 class RGWBucketSyncStatusManager {
   RGWRados *store;
-  librados::IoCtx ioctx;
 
   RGWCoroutinesManager cr_mgr;
 
@@ -490,10 +488,9 @@ class RGWBucketSyncStatusManager {
 
   string source_status_oid;
   string source_shard_status_oid_prefix;
-  rgw_obj source_status_obj;
 
   map<int, rgw_bucket_shard_sync_info> sync_status;
-  rgw_obj status_obj;
+  rgw_raw_obj status_obj;
 
   int num_shards;
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -12,12 +12,24 @@
 
 static string shadow_ns = RGW_OBJ_NS_SHADOW;
 
+static void init_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+  b->placement.data_pool = rgw_pool(dp);
+  b->placement.index_pool = rgw_pool(ip);
+}
+
 void RGWObjManifestPart::generate_test_instances(std::list<RGWObjManifestPart*>& o)
 {
   o.push_back(new RGWObjManifestPart);
 
   RGWObjManifestPart *p = new RGWObjManifestPart;
-  rgw_bucket b("tenant", "bucket", ".pool", ".index_pool", "marker_", "12", "region");
+  rgw_bucket b;
+  init_bucket(&b, "tenant", "bucket", ".pool", ".index_pool", "marker_", "12");
+
   p->loc = rgw_obj(b, "object");
   p->loc_ofs = 512 * 1024;
   p->size = 128 * 1024;
@@ -133,7 +145,8 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
   RGWObjManifest *m = new RGWObjManifest;
   for (int i = 0; i<10; i++) {
     RGWObjManifestPart p;
-    rgw_bucket b("tenant", "bucket", ".pool", ".index_pool", "marker_", "12", "region");
+    rgw_bucket b;
+    init_bucket(&b, "tenant", "bucket", ".pool", ".index_pool", "marker_", "12");
     p.loc = rgw_obj(b, "object");
     p.loc_ofs = 0;
     p.size = 512 * 1024;
@@ -408,7 +421,8 @@ void RGWUserInfo::generate_test_instances(list<RGWUserInfo*>& o)
 
 void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 {
-  rgw_bucket *b = new rgw_bucket("tenant", "name", "pool", ".index_pool", "marker", "123", "region");
+  rgw_bucket *b = new rgw_bucket;
+  init_bucket(b, "tenant", "name", "pool", ".index_pool", "marker", "123");
   o.push_back(b);
   o.push_back(new rgw_bucket);
 }
@@ -416,7 +430,7 @@ void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
 {
   RGWBucketInfo *i = new RGWBucketInfo;
-  i->bucket = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
+  init_bucket(&i->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
   i->owner = "owner";
   i->flags = BUCKET_SUSPENDED;
   o.push_back(i);
@@ -454,7 +468,7 @@ void RGWOLHInfo::generate_test_instances(list<RGWOLHInfo*> &o)
 void RGWBucketEnt::generate_test_instances(list<RGWBucketEnt*>& o)
 {
   RGWBucketEnt *e = new RGWBucketEnt;
-  e->bucket = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
+  init_bucket(&e->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
   e->size = 1024;
   e->size_rounded = 4096;
   e->count = 1;
@@ -474,7 +488,8 @@ void RGWUploadPartInfo::generate_test_instances(list<RGWUploadPartInfo*>& o)
 
 void rgw_obj::generate_test_instances(list<rgw_obj*>& o)
 {
-  rgw_bucket b = rgw_bucket("tenant", "bucket", "pool", ".index_pool", "marker", "10", "region");
+  rgw_bucket b;
+  init_bucket(&b, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
   rgw_obj *obj = new rgw_obj(b, "object");
   o.push_back(obj);
   o.push_back(new rgw_obj);

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -159,13 +159,16 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
 
 void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_stripe, uint64_t ofs, string *override_prefix, rgw_obj_select *location)
 {
-  string oid;
+  rgw_obj loc;
+
+  string& oid = loc.key.name;
+  string& ns = loc.key.ns;
+
   if (!override_prefix || override_prefix->empty()) {
     oid = prefix;
   } else {
     oid = *override_prefix;
   }
-  string ns;
 
   if (!cur_part_id) {
     if (ofs < max_head_size) {
@@ -190,21 +193,15 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
     }
   }
 
-  rgw_bucket *bucket;
-
-  rgw_obj loc;
-
   if (!tail_bucket.name.empty()) {
-    bucket = &tail_bucket;
+    loc.bucket = tail_bucket;
   } else {
-    bucket = &obj.bucket;
+    loc.bucket = obj.bucket;
   }
 
-  loc.init_ns(*bucket, oid, ns);
-  
   // Always overwrite instance with tail_instance
   // to get the right shadow object location
-  loc.set_instance(tail_instance);
+  loc.key.set_instance(tail_instance);
 
   *location = loc;
 }

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -172,6 +172,7 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
 
   if (!cur_part_id) {
     if (ofs < max_head_size) {
+      location->set_placement_rule(head_placement_rule);
       *location = obj;
       return;
     } else {
@@ -193,8 +194,8 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
     }
   }
 
-  if (!tail_bucket.name.empty()) {
-    loc.bucket = tail_bucket;
+  if (!tail_placement.bucket.name.empty()) {
+    loc.bucket = tail_placement.bucket;
   } else {
     loc.bucket = obj.bucket;
   }
@@ -203,6 +204,7 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   // to get the right shadow object location
   loc.key.set_instance(tail_instance);
 
+  location->set_placement_rule(tail_placement.placement_rule);
   *location = loc;
 }
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -112,11 +112,11 @@ void RGWObjManifest::obj_iterator::seek(uint64_t o)
 void RGWObjManifest::obj_iterator::update_location()
 {
   if (manifest->explicit_objs) {
-    location = explicit_iter->second.loc;
+    RGWRados::obj_to_raw(explicit_iter->second.loc, &location);
     return;
   }
 
-  const rgw_obj& head = manifest->get_head();
+  const rgw_raw_obj& head = manifest->get_head();
 
   if (ofs < manifest->get_head_size()) {
     location = head;
@@ -159,7 +159,7 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
   o.push_back(new RGWObjManifest);
 }
 
-void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_stripe, uint64_t ofs, string *override_prefix, rgw_obj *location)
+void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_stripe, uint64_t ofs, string *override_prefix, rgw_raw_obj *location)
 {
   string oid;
   if (!override_prefix || override_prefix->empty()) {
@@ -194,17 +194,21 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
 
   rgw_bucket *bucket;
 
+  rgw_obj loc;
+
   if (!tail_bucket.name.empty()) {
     bucket = &tail_bucket;
   } else {
-    bucket = &head_obj.bucket;
+    bucket = &obj.bucket;
   }
 
-  location->init_ns(*bucket, oid, ns);
+  loc.init_ns(*bucket, oid, ns);
   
   // Always overwrite instance with tail_instance
   // to get the right shadow object location
-  location->set_instance(tail_instance);
+  loc.set_instance(tail_instance);
+
+  RGWRados::obj_to_raw(loc, location);
 }
 
 

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -343,7 +343,7 @@ std::string RGWSwiftWebsiteListingFormatter::format_name(
   return item_name.substr(prefix.length());
 }
 
-void RGWSwiftWebsiteListingFormatter::dump_object(const RGWObjEnt& objent)
+void RGWSwiftWebsiteListingFormatter::dump_object(const rgw_bucket_dir_entry& objent)
 {
   const auto name = format_name(objent.key.name);
   ss << boost::format(R"(<tr class="item %s">)")
@@ -351,9 +351,9 @@ void RGWSwiftWebsiteListingFormatter::dump_object(const RGWObjEnt& objent)
      << boost::format(R"(<td class="colname"><a href="%s">%s</a></td>)")
                                 % url_encode(name)
                                 % HTMLHelper::escape(name)
-     << boost::format(R"(<td class="colsize">%lld</td>)") % objent.size
+     << boost::format(R"(<td class="colsize">%lld</td>)") % objent.meta.size
      << boost::format(R"(<td class="coldate">%s</td>)")
-                                % dump_time_to_str(objent.mtime)
+                                % dump_time_to_str(objent.meta.mtime)
      << R"(</tr>)";
 }
 

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -79,7 +79,7 @@ public:
   void generate_header(const std::string& dir_path,
                        const std::string& css_path);
   void generate_footer();
-  void dump_object(const RGWObjEnt& objent);
+  void dump_object(const rgw_bucket_dir_entry& objent);
   void dump_subdir(const std::string& name);
 };
 

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -197,18 +197,18 @@ int RGWGC::process(int index, int max_secs)
 
         ctx->locator_set_key(obj.loc);
         rgw_obj key_obj;
-        key_obj.set_obj(obj.key.name);
+        key_obj.set_name(obj.key.name);
         key_obj.set_instance(obj.key.instance);
 
-	dout(0) << "gc::process: removing " << obj.pool << ":" << key_obj.get_object() << dendl;
+	dout(0) << "gc::process: removing " << obj.pool << ":" << key_obj.get_oid() << dendl;
 	ObjectWriteOperation op;
 	cls_refcount_put(op, info.tag, true);
-        ret = ctx->operate(key_obj.get_object(), &op);
+        ret = ctx->operate(key_obj.get_oid(), &op);
 	if (ret == -ENOENT)
 	  ret = 0;
         if (ret < 0) {
           remove_tag = false;
-          dout(0) << "failed to remove " << obj.pool << ":" << key_obj.get_object() << "@" << obj.loc << dendl;
+          dout(0) << "failed to remove " << obj.pool << ":" << key_obj.get_oid() << "@" << obj.loc << dendl;
         }
 
         if (going_down()) // leave early, even if tag isn't removed, it's ok

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -187,7 +187,7 @@ int RGWGC::process(int index, int max_secs)
         if (obj.pool != last_pool) {
           delete ctx;
           ctx = new IoCtx;
-	  ret = store->get_rados_handle()->ioctx_create(obj.pool.c_str(), *ctx);
+	  ret = rgw_init_ioctx(store->get_rados_handle(), obj.pool, *ctx);
 	  if (ret < 0) {
 	    dout(0) << "ERROR: failed to create ioctx pool=" << obj.pool << dendl;
 	    continue;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -196,19 +196,18 @@ int RGWGC::process(int index, int max_secs)
         }
 
         ctx->locator_set_key(obj.loc);
-        rgw_obj key_obj;
-        key_obj.set_name(obj.key.name);
-        key_obj.set_instance(obj.key.instance);
 
-	dout(0) << "gc::process: removing " << obj.pool << ":" << key_obj.get_oid() << dendl;
+        const string& oid = obj.key.name; /* just stored raw oid there */
+
+	dout(0) << "gc::process: removing " << obj.pool << ":" << obj.key.name << dendl;
 	ObjectWriteOperation op;
 	cls_refcount_put(op, info.tag, true);
-        ret = ctx->operate(key_obj.get_oid(), &op);
+        ret = ctx->operate(oid, &op);
 	if (ret == -ENOENT)
 	  ret = 0;
         if (ret < 0) {
           remove_tag = false;
-          dout(0) << "failed to remove " << obj.pool << ":" << key_obj.get_oid() << "@" << obj.loc << dendl;
+          dout(0) << "failed to remove " << obj.pool << ":" << oid << "@" << obj.loc << dendl;
         }
 
         if (going_down()) // leave early, even if tag isn't removed, it's ok

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -94,7 +94,6 @@ void RGWObjManifest::dump(Formatter *f) const
   f->close_section();
   f->dump_unsigned("obj_size", obj_size);
   ::encode_json("explicit_objs", explicit_objs, f);
-  ::encode_json("head_obj", head_obj, f);
   ::encode_json("head_size", head_size, f);
   ::encode_json("max_head_size", max_head_size, f);
   ::encode_json("prefix", prefix, f);
@@ -576,7 +575,7 @@ void rgw_bucket::dump(Formatter *f) const
   encode_json("marker", marker, f);
   encode_json("bucket_id", bucket_id, f);
   encode_json("tenant", tenant, f);
-  encode_json("placement", placement, f);
+  encode_json("explicit_placement", explicit_placement, f);
 }
 
 void rgw_bucket::decode_json(JSONObj *obj) {
@@ -584,12 +583,12 @@ void rgw_bucket::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("marker", marker, obj);
   JSONDecoder::decode_json("bucket_id", bucket_id, obj);
   JSONDecoder::decode_json("tenant", tenant, obj);
-  JSONDecoder::decode_json("placement", placement, obj);
-  if (placement.data_pool.empty()) {
+  JSONDecoder::decode_json("explicit_placement", explicit_placement, obj);
+  if (explicit_placement.data_pool.empty()) {
     /* decoding old format */
-    JSONDecoder::decode_json("pool", placement.data_pool, obj);
-    JSONDecoder::decode_json("data_extra_pool", placement.data_extra_pool, obj);
-    JSONDecoder::decode_json("index_pool", placement.index_pool, obj);
+    JSONDecoder::decode_json("pool", explicit_placement.data_pool, obj);
+    JSONDecoder::decode_json("data_extra_pool", explicit_placement.data_extra_pool, obj);
+    JSONDecoder::decode_json("index_pool", explicit_placement.index_pool, obj);
   }
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -81,6 +81,12 @@ void RGWObjManifestRule::dump(Formatter *f) const
   encode_json("override_prefix", override_prefix, f);
 }
 
+void rgw_bucket_placement::dump(Formatter *f) const
+{
+  encode_json("bucket", bucket, f);
+  encode_json("placement_rule", placement_rule, f);
+}
+
 void RGWObjManifest::dump(Formatter *f) const
 {
   map<uint64_t, RGWObjManifestPart>::const_iterator iter = objs.begin();
@@ -97,9 +103,9 @@ void RGWObjManifest::dump(Formatter *f) const
   ::encode_json("head_size", head_size, f);
   ::encode_json("max_head_size", max_head_size, f);
   ::encode_json("prefix", prefix, f);
-  ::encode_json("tail_bucket", tail_bucket, f);
   ::encode_json("rules", rules, f);
   ::encode_json("tail_instance", tail_instance, f);
+  ::encode_json("tail_placement", tail_placement, f);
 }
 
 void rgw_log_entry::dump(Formatter *f) const
@@ -800,7 +806,6 @@ void rgw_obj::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
   encode_json("key", key, f);
-  encode_json("placement_id", placement_id, f);
 }
 
 void RGWDefaultSystemMetaObjInfo::dump(Formatter *f) const {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -763,22 +763,6 @@ void rgw_obj_key::dump(Formatter *f) const
   encode_json("instance", instance, f);
 }
 
-void RGWObjEnt::dump(Formatter *f) const
-{
-  encode_json("name", key.name, f);
-  encode_json("instance", key.instance, f);
-  encode_json("namespace", ns, f);
-  encode_json("owner", owner.to_str(), f);
-  encode_json("owner_display_name", owner_display_name, f);
-  encode_json("size", size, f);
-  utime_t ut(mtime);
-  encode_json("mtime", ut, f);
-  encode_json("etag", etag, f);
-  encode_json("content_type", content_type, f);
-  encode_json("tag", tag, f);
-  encode_json("flags", flags, f);
-}
-
 void RGWBucketEnt::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -761,6 +761,7 @@ void rgw_obj_key::dump(Formatter *f) const
 {
   encode_json("name", name, f);
   encode_json("instance", instance, f);
+  encode_json("ns", ns, f);
 }
 
 void RGWBucketEnt::dump(Formatter *f) const
@@ -798,9 +799,8 @@ void rgw_raw_obj::decode_json(JSONObj *obj) {
 void rgw_obj::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
-  encode_json("ns", ns, f);
-  encode_json("name", name, f);
-  encode_json("instance", instance, f);
+  encode_json("key", key, f);
+  encode_json("placement_id", placement_id, f);
 }
 
 void RGWDefaultSystemMetaObjInfo::dump(Formatter *f) const {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -42,7 +42,7 @@ void encode_json(const char *name, const RGWUserCaps& val, Formatter *f)
 
 void encode_json(const char *name, const rgw_pool& pool, Formatter *f)
 {
-  f->dump_string(name, pool.name);
+  f->dump_string(name, pool.to_str());
 }
 
 void decode_json_obj(rgw_pool& pool, JSONObj *obj)
@@ -1425,7 +1425,7 @@ void RGWOrphanSearchInfo::dump(Formatter *f) const
 {
   f->open_object_section("orphan_search_info");
   f->dump_string("job_name", job_name);
-  f->dump_string("pool", pool);
+  encode_json("pool", pool, f);
   f->dump_int("num_shards", num_shards);
   encode_json("start_time", start_time, f);
   f->close_section();

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -814,11 +814,9 @@ void rgw_raw_obj::decode_json(JSONObj *obj) {
 void rgw_obj::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
-  encode_json("key", loc, f);
   encode_json("ns", ns, f);
-  encode_json("object", object, f);
+  encode_json("name", name, f);
   encode_json("instance", instance, f);
-  encode_json("orig_obj", orig_obj, f);
 }
 
 void RGWDefaultSystemMetaObjInfo::dump(Formatter *f) const {

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -339,7 +339,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
             RGWObjectCtx rctx(store);
             rgw_obj obj(bucket_info.bucket, key);
             RGWObjState *state;
-            int ret = store->get_obj_state(&rctx, obj, &state, false);
+            int ret = store->get_obj_state(&rctx, bucket_info, obj, &state, false);
             if (ret < 0) {
               return ret;
             }

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -423,7 +423,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
               RGWObjectCtx rctx(store);
               rgw_obj obj(bucket_info.bucket, obj_iter->key);
               RGWObjState *state;
-              int ret = store->get_obj_state(&rctx, obj, &state, false);
+              int ret = store->get_obj_state(&rctx, bucket_info, obj, &state, false);
               if (ret < 0) {
                 return ret;
               }

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -400,7 +400,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
     string oid = render_log_object_name(s->cct->_conf->rgw_log_object_name, &bdt,
 				        s->bucket.bucket_id, entry.bucket);
 
-    rgw_obj obj(store->get_zone_params().log_pool, oid);
+    rgw_raw_obj obj(store->get_zone_params().log_pool, oid);
 
     ret = store->append_async(obj, bl.length(), bl);
     if (ret == -ENOENT) {

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -280,7 +280,7 @@ public:
   int put(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker,
                   real_time mtime, JSONObj *obj, sync_type_t sync_type) override { return -ENOTSUP; }
 
-  void get_pool_and_oid(RGWRados *store, const string& key, rgw_bucket& bucket, string& oid) override {}
+  void get_pool_and_oid(RGWRados *store, const string& key, rgw_pool& pool, string& oid) override {}
 
   int remove(RGWRados *store, string& entry, RGWObjVersionTracker& objv_tracker) override { return -ENOTSUP; }
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -851,7 +851,7 @@ int RGWMetadataManager::store_in_heap(RGWMetadataHandler *handler, const string&
 
   rgw_pool heap_pool(store->get_zone_params().metadata_heap);
 
-  if (heap_pool.name.empty()) {
+  if (heap_pool.empty()) {
     return 0;
   }
 
@@ -877,7 +877,7 @@ int RGWMetadataManager::remove_from_heap(RGWMetadataHandler *handler, const stri
 
   rgw_pool heap_pool(store->get_zone_params().metadata_heap);
 
-  if (heap_pool.name.empty()) {
+  if (heap_pool.empty()) {
     return 0;
   }
 

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -88,7 +88,7 @@ public:
   }
 
 protected:
-  virtual void get_pool_and_oid(RGWRados *store, const string& key, rgw_bucket& bucket, string& oid) = 0;
+  virtual void get_pool_and_oid(RGWRados *store, const string& key, rgw_pool& pool, string& oid) = 0;
   /**
    * Compare an incoming versus on-disk tag/version+mtime combo against
    * the sync mode to see if the new one should replace the on-disk one.

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -117,16 +117,27 @@ protected:
   /*
    * The tenant_name is always returned on purpose. May be empty, of course.
    */
-  static void parse_bucket(const string &bucket,
-                           string &tenant_name, string &bucket_name)
+  static void parse_bucket(const string& bucket,
+                           string *tenant_name,
+                           string *bucket_name,
+                           string *bucket_instance = nullptr /* optional */)
   {
     int pos = bucket.find('/');
     if (pos >= 0) {
-      tenant_name = bucket.substr(0, pos);
+      *tenant_name = bucket.substr(0, pos);
     } else {
-      tenant_name.clear();
+      tenant_name->clear();
     }
-    bucket_name = bucket.substr(pos + 1);
+    string bn = bucket.substr(pos + 1);
+    pos = bn.find (':');
+    if (pos < 0) {
+      *bucket_name = std::move(bn);
+      return;
+    }
+    *bucket_name = bn.substr(0, pos);
+    if (bucket_instance) {
+      *bucket_instance = bn.substr(pos + 1);
+    }
   }
 };
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4945,7 +4945,7 @@ void RGWCompleteMultipart::execute()
       }
 
       rgw_obj_index_key remove_key;
-      src_obj.get_index_key(&remove_key);
+      src_obj.key.get_index_key(&remove_key);
 
       remove_objs.push_back(remove_key);
 
@@ -5078,7 +5078,7 @@ void RGWAbortMultipart::execute()
           rgw_raw_obj_to_obj(s->bucket, raw_head, &head);
 
           rgw_obj_index_key key;
-          head.get_index_key(&key);
+          head.key.get_index_key(&key);
           remove_objs.push_back(key);
         }
       }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5503,8 +5503,7 @@ void RGWSetAttrs::execute()
   if (op_ret < 0)
     return;
 
-  rgw_obj obj(s->bucket, s->object.name);
-  obj.set_instance(s->object.instance);
+  rgw_obj obj(s->bucket, s->object);
 
   store->set_atomic(s->obj_ctx, obj);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5272,8 +5272,7 @@ void RGWDeleteMultiObj::execute()
   for (iter = multi_delete->objects.begin();
         iter != multi_delete->objects.end() && num_processed < max_to_delete;
         ++iter, num_processed++) {
-    rgw_obj obj(bucket, iter->name);
-    obj.set_instance(iter->instance);
+    rgw_obj obj(bucket, *iter);
 
     obj_ctx->obj.set_atomic(obj);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5526,9 +5526,8 @@ void RGWGetObjLayout::pre_exec()
 
 void RGWGetObjLayout::execute()
 {
-  rgw_obj obj(s->bucket, s->object.name);
-  obj.set_instance(s->object.instance);
-  target = new RGWRados::Object(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
+  rgw_obj obj(s->bucket, s->object);
+  target = new RGWRados::Object(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), rgw_obj(s->bucket, s->object));
   RGWRados::Object::Read stat_op(target);
 
   op_ret = stat_op.prepare();
@@ -5536,7 +5535,7 @@ void RGWGetObjLayout::execute()
     return;
   }
 
-  head_obj = stat_op.state.obj;
+  head_obj = stat_op.state.head_obj;
 
   op_ret = target->get_manifest(&manifest);
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -776,10 +776,10 @@ public:
   RGWPutObj_Filter(RGWPutObjDataProcessor* next) :
   next(next){}
   virtual ~RGWPutObj_Filter() {}
-  virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_obj *pobj, bool *again) override {
+  virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_raw_obj *pobj, bool *again) override {
     return next->handle_data(bl, ofs, phandle, pobj, again);
   }
-  virtual int throttle_data(void *handle, const rgw_obj& obj, uint64_t size, bool need_to_wait) override {
+  virtual int throttle_data(void *handle, const rgw_raw_obj& obj, uint64_t size, bool need_to_wait) override {
     return next->throttle_data(handle, obj, size, need_to_wait);
   }
 }; /* RGWPutObj_Filter */
@@ -1604,7 +1604,7 @@ static inline int put_data_and_throttle(RGWPutObjDataProcessor *processor,
   bool again = false;
   do {
     void *handle;
-    rgw_obj obj;
+    rgw_raw_obj obj;
 
     uint64_t size = data.length();
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1770,7 +1770,7 @@ class RGWGetObjLayout : public RGWOp {
 protected:
   RGWRados::Object *target{nullptr};
   RGWObjManifest *manifest{nullptr};
-  rgw_obj head_obj;
+  rgw_raw_obj head_obj;
 
 public:
   RGWGetObjLayout() {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -182,7 +182,7 @@ public:
   void pre_exec();
   void execute();
   int read_user_manifest_part(rgw_bucket& bucket,
-                              const RGWObjEnt& ent,
+                              const rgw_bucket_dir_entry& ent,
                               RGWAccessControlPolicy *bucket_policy,
                               off_t start_ofs,
                               off_t end_ofs);
@@ -429,7 +429,7 @@ protected:
   string encoding_type;
   bool list_versions;
   int max;
-  vector<RGWObjEnt> objs;
+  vector<rgw_bucket_dir_entry> objs;
   map<string, bool> common_prefixes;
 
   int default_max;
@@ -1429,7 +1429,7 @@ public:
 };
 
 struct RGWMultipartUploadEntry {
-  RGWObjEnt obj;
+  rgw_bucket_dir_entry obj;
   RGWMPObj mp;
 };
 

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -141,11 +141,10 @@ int RGWOrphanStore::list_jobs(map <string,RGWOrphanSearchState>& job_list)
 
 int RGWOrphanStore::init()
 {
-  const char *log_pool = store->get_zone_params().log_pool.name.c_str();
-  librados::Rados *rados = store->get_rados_handle();
-  int r = rados->ioctx_create(log_pool, ioctx);
+  rgw_pool& log_pool = store->get_zone_params().log_pool;
+  int r = rgw_init_ioctx(store->get_rados_handle(), log_pool, ioctx);
   if (r < 0) {
-    cerr << "ERROR: failed to open log pool (" << store->get_zone_params().log_pool.name << " ret=" << r << std::endl;
+    cerr << "ERROR: failed to open log pool (" << log_pool << " ret=" << r << std::endl;
     return r;
   }
 
@@ -280,13 +279,11 @@ int RGWOrphanSearch::log_oids(map<int, string>& log_shards, map<int, list<string
 
 int RGWOrphanSearch::build_all_oids_index()
 {
-  librados::Rados *rados = store->get_rados_handle();
-
   librados::IoCtx ioctx;
 
-  int ret = rados->ioctx_create(search_info.pool.c_str(), ioctx);
+  int ret = rgw_init_ioctx(store->get_rados_handle(), search_info.pool, ioctx);
   if (ret < 0) {
-    lderr(store->ctx()) << __func__ << ": ioctx_create() returned ret=" << ret << dendl;
+    lderr(store->ctx()) << __func__ << ": rgw_init_ioctx() returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -674,11 +671,9 @@ int RGWOrphanSearch::compare_oid_indexes()
 
   librados::IoCtx data_ioctx;
 
-  librados::Rados *rados = store->get_rados_handle();
-
-  int ret = rados->ioctx_create(search_info.pool.c_str(), data_ioctx);
+  int ret = rgw_init_ioctx(store->get_rados_handle(), search_info.pool, data_ioctx);
   if (ret < 0) {
-    lderr(store->ctx()) << __func__ << ": ioctx_create() returned ret=" << ret << dendl;
+    lderr(store->ctx()) << __func__ << ": rgw_init_ioctx() returned ret=" << ret << dendl;
     return ret;
   }
 

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -41,7 +41,7 @@ static string obj_fingerprint(const string& oid, const char *force_ns = NULL)
     rgw_obj new_obj(b, obj_name);
     new_obj.set_ns(force_ns);
     new_obj.set_instance(obj_instance);
-    s = obj_marker + "_" + new_obj.get_object();
+    s = obj_marker + "_" + new_obj.get_oid();
   }
 
   /* cut out suffix */
@@ -424,7 +424,7 @@ int RGWOrphanSearch::handle_stat_result(map<int, list<string> >& oids, RGWRados:
   set<string> obj_oids;
   rgw_bucket& bucket = result.obj.bucket;
   if (!result.has_manifest) { /* a very very old object, or part of a multipart upload during upload */
-    const string loc = bucket.bucket_id + "_" + result.obj.get_object();
+    const string loc = bucket.bucket_id + "_" + result.obj.get_oid();
     obj_oids.insert(obj_fingerprint(loc));
 
     /*

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -437,8 +437,8 @@ int RGWOrphanSearch::handle_stat_result(map<int, list<string> >& oids, RGWRados:
 
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(); miter != manifest.obj_end(); ++miter) {
-      const rgw_obj& loc = miter.get_location();
-      string s = bucket.bucket_id + "_" + loc.get_object();
+      const rgw_raw_obj& loc = miter.get_location();
+      string s = loc.oid;
       obj_oids.insert(obj_fingerprint(s));
     }
   }

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -437,7 +437,7 @@ int RGWOrphanSearch::handle_stat_result(map<int, list<string> >& oids, RGWRados:
 
     RGWObjManifest::obj_iterator miter;
     for (miter = manifest.obj_begin(); miter != manifest.obj_end(); ++miter) {
-      const rgw_raw_obj& loc = miter.get_location();
+      const rgw_raw_obj& loc = miter.get_location().get_raw_obj(store);
       string s = loc.oid;
       obj_oids.insert(obj_fingerprint(s));
     }

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -503,7 +503,7 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
   int count = 0;
 
   do {
-    vector<RGWObjEnt> result;
+    vector<rgw_bucket_dir_entry> result;
 
 #define MAX_LIST_OBJS_ENTRIES 100
     ret = list_op.list_objects(MAX_LIST_OBJS_ENTRIES, &result, NULL, &truncated);
@@ -512,17 +512,16 @@ int RGWOrphanSearch::build_linked_oids_for_bucket(const string& bucket_instance_
       return -ret;
     }
 
-    for (vector<RGWObjEnt>::iterator iter = result.begin(); iter != result.end(); ++iter) {
-      RGWObjEnt& entry = *iter;
+    for (vector<rgw_bucket_dir_entry>::iterator iter = result.begin(); iter != result.end(); ++iter) {
+      rgw_bucket_dir_entry& entry = *iter;
       if (entry.key.instance.empty()) {
         ldout(store->ctx(), 20) << "obj entry: " << entry.key.name << dendl;
       } else {
         ldout(store->ctx(), 20) << "obj entry: " << entry.key.name << " [" << entry.key.instance << "]" << dendl;
       }
 
-      ldout(store->ctx(), 20) << __func__ << ": entry.key.name=" << entry.key.name << " entry.key.instance=" << entry.key.instance << " entry.ns=" << entry.ns << dendl;
+      ldout(store->ctx(), 20) << __func__ << ": entry.key.name=" << entry.key.name << " entry.key.instance=" << entry.key.instance << dendl;
       rgw_obj obj(bucket_info.bucket, entry.key);
-      obj.set_ns(entry.ns);
 
       RGWRados::Object op_target(store, bucket_info, obj_ctx, obj);
 

--- a/src/rgw/rgw_orphan.h
+++ b/src/rgw/rgw_orphan.h
@@ -70,23 +70,25 @@ WRITE_CLASS_ENCODER(RGWOrphanSearchStage)
   
 struct RGWOrphanSearchInfo {
   string job_name;
-  string pool;
+  rgw_pool pool;
   uint16_t num_shards;
   utime_t start_time;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     ::encode(job_name, bl);
-    ::encode(pool, bl);
+    ::encode(pool.to_str(), bl);
     ::encode(num_shards, bl);
     ::encode(start_time, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     ::decode(job_name, bl);
-    ::decode(pool, bl);
+    string s;
+    ::decode(s, bl);
+    pool.from_str(s);
     ::decode(num_shards, bl);
     ::decode(start_time, bl);
     DECODE_FINISH(bl);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1571,21 +1571,21 @@ int RGWZoneParams::fix_pool_names()
     return r;
   }
 
-  domain_root = fix_zone_pool_dup(pools, name, ".rgw.data.root", domain_root);
+  domain_root = fix_zone_pool_dup(pools, name, ".rgw.meta:root", domain_root);
   if (!metadata_heap.name.empty()) {
-    metadata_heap = fix_zone_pool_dup(pools, name, ".rgw.meta", metadata_heap);
+    metadata_heap = fix_zone_pool_dup(pools, name, ".rgw.meta:heap", metadata_heap);
   }
   control_pool = fix_zone_pool_dup(pools, name, ".rgw.control", control_pool);
-  gc_pool = fix_zone_pool_dup(pools, name ,".rgw.gc", gc_pool);
-  lc_pool = fix_zone_pool_dup(pools, name ,".rgw.lc", lc_pool);
+  gc_pool = fix_zone_pool_dup(pools, name ,".rgw.log:gc", gc_pool);
+  lc_pool = fix_zone_pool_dup(pools, name ,".rgw.log:lc", lc_pool);
   log_pool = fix_zone_pool_dup(pools, name, ".rgw.log", log_pool);
-  intent_log_pool = fix_zone_pool_dup(pools, name, ".rgw.intent-log", intent_log_pool);
-  usage_log_pool = fix_zone_pool_dup(pools, name, ".rgw.usage", usage_log_pool);
-  user_keys_pool = fix_zone_pool_dup(pools, name, ".rgw.users.keys", user_keys_pool);
-  user_email_pool = fix_zone_pool_dup(pools, name, ".rgw.users.email", user_email_pool);
-  user_swift_pool = fix_zone_pool_dup(pools, name, ".rgw.users.swift", user_swift_pool);
-  user_uid_pool = fix_zone_pool_dup(pools, name, ".rgw.users.uid", user_uid_pool);
-  roles_pool = fix_zone_pool_dup(pools, name, ".rgw.roles", roles_pool);
+  intent_log_pool = fix_zone_pool_dup(pools, name, ".rgw.log:intent", intent_log_pool);
+  usage_log_pool = fix_zone_pool_dup(pools, name, ".rgw.log:usage", usage_log_pool);
+  user_keys_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:users.keys", user_keys_pool);
+  user_email_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:users.email", user_email_pool);
+  user_swift_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:users.swift", user_swift_pool);
+  user_uid_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:users.uid", user_uid_pool);
+  roles_pool = fix_zone_pool_dup(pools, name, ".rgw.meta:roles", roles_pool);
 
   for(auto& iter : placement_pools) {
     iter.second.index_pool = fix_zone_pool_dup(pools, name, "." + default_bucket_index_pool_suffix,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8450,6 +8450,10 @@ int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, const RGWBucketInfo& b
 
 int RGWRados::get_system_obj_state_impl(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWRawObjState **state, RGWObjVersionTracker *objv_tracker)
 {
+  if (obj.empty()) {
+    return -EINVAL;
+  }
+
   RGWRawObjState *s = rctx->raw.get_state(obj);
   ldout(cct, 20) << "get_system_obj_state: rctx=" << (void *)rctx << " obj=" << obj << " state=" << (void *)s << " s->prefetch_data=" << s->prefetch_data << dendl;
   *state = s;
@@ -8496,6 +8500,10 @@ int RGWRados::get_system_obj_state(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWRawO
 int RGWRados::get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
                                  RGWObjState **state, bool follow_olh, bool assume_noent)
 {
+  if (obj.empty()) {
+    return -EINVAL;
+  }
+
   bool need_follow_olh = follow_olh && obj.key.instance.empty();
 
   RGWObjState *s = rctx->obj.get_state(obj);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -11401,8 +11401,7 @@ int RGWRados::omap_get_all(rgw_raw_obj& obj, bufferlist& header,
 			   std::map<string, bufferlist>& m)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  int r = get_raw_obj_ref(obj, &ref);
   if (r < 0) {
     return r;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -441,9 +441,7 @@ int RGWSystemMetaObj::init(CephContext *_cct, RGWRados *_store, bool setup_obj, 
 
 int RGWSystemMetaObj::read_default(RGWDefaultSystemMetaObjInfo& default_info, const string& oid)
 {
-  string pool_name = get_pool_name(cct);
-
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   bufferlist bl;
   RGWObjectCtx obj_ctx(store);
   int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
@@ -482,10 +480,9 @@ int RGWSystemMetaObj::use_default(bool old_format)
 
 int RGWSystemMetaObj::set_as_default(bool exclusive)
 {
-  string pool_name = get_pool_name(cct);
   string oid  = get_default_oid();
 
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   bufferlist bl;
 
   RGWDefaultSystemMetaObjInfo default_info;
@@ -503,8 +500,7 @@ int RGWSystemMetaObj::set_as_default(bool exclusive)
 
 int RGWSystemMetaObj::read_id(const string& obj_name, string& object_id)
 {
-  string pool_name = get_pool_name(cct);
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   bufferlist bl;
 
   string oid = get_names_oid_prefix() + obj_name;
@@ -529,8 +525,7 @@ int RGWSystemMetaObj::read_id(const string& obj_name, string& object_id)
 
 int RGWSystemMetaObj::delete_obj(bool old_format)
 {
-  string pool_name = get_pool_name(cct);
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
 
   /* check to see if obj is the default */
   RGWDefaultSystemMetaObjInfo default_info;
@@ -539,7 +534,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
     return ret;
   if (default_info.default_id == id || (old_format && default_info.default_id == name)) {
     string oid = get_default_oid(old_format);
-    rgw_obj default_named_obj(pool, oid);
+    rgw_raw_obj default_named_obj(pool, oid);
     ret = store->delete_system_obj(default_named_obj);
     if (ret < 0) {
       ldout(cct, 0) << "Error delete default obj name  " << name << ": " << cpp_strerror(-ret) << dendl;
@@ -548,7 +543,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
   }
   if (!old_format) {
     string oid  = get_names_oid_prefix() + name;
-    rgw_obj object_name(pool, oid);
+    rgw_raw_obj object_name(pool, oid);
     ret = store->delete_system_obj(object_name);
     if (ret < 0) {
       ldout(cct, 0) << "Error delete obj name  " << name << ": " << cpp_strerror(-ret) << dendl;
@@ -563,7 +558,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
     oid += id;
   }
 
-  rgw_obj object_id(pool, oid);
+  rgw_raw_obj object_id(pool, oid);
   ret = store->delete_system_obj(object_id);
   if (ret < 0) {
     ldout(cct, 0) << "Error delete object id " << id << ": " << cpp_strerror(-ret) << dendl;
@@ -574,9 +569,7 @@ int RGWSystemMetaObj::delete_obj(bool old_format)
 
 int RGWSystemMetaObj::store_name(bool exclusive)
 {
-  string pool_name = get_pool_name(cct);
-
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   string oid = get_names_oid_prefix() + name;
 
   RGWNameToId nameToId;
@@ -611,10 +604,9 @@ int RGWSystemMetaObj::rename(const string& new_name)
     return ret;
   }
   /* delete old name */
-  string pool_name = get_pool_name(cct);
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   string oid = get_names_oid_prefix() + old_name;
-  rgw_obj old_name_obj(pool, oid);
+  rgw_raw_obj old_name_obj(pool, oid);
   ret = store->delete_system_obj(old_name_obj);
   if (ret < 0) {
     ldout(cct, 0) << "Error delete old obj name  " << old_name << ": " << cpp_strerror(-ret) << dendl;
@@ -626,9 +618,8 @@ int RGWSystemMetaObj::rename(const string& new_name)
 
 int RGWSystemMetaObj::read_info(const string& obj_id, bool old_format)
 {
-  string pool_name = get_pool_name(cct);
+  rgw_pool pool(get_pool_name(cct));
 
-  rgw_bucket pool(pool_name.c_str());
   bufferlist bl;
 
   string oid = get_info_oid_prefix(old_format) + obj_id;
@@ -695,9 +686,7 @@ int RGWSystemMetaObj::create(bool exclusive)
 
 int RGWSystemMetaObj::store_info(bool exclusive)
 {
-  string pool_name = get_pool_name(cct);
-
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
 
   string oid = get_info_oid_prefix() + id;
 
@@ -785,8 +774,7 @@ int RGWRealm::delete_obj()
 
 int RGWRealm::create_control(bool exclusive)
 {
-  auto pool_name = get_pool_name(cct);
-  auto pool = rgw_bucket{pool_name.c_str()};
+  auto pool = rgw_pool{get_pool_name(cct)};
   auto oid = get_control_oid();
   return rgw_put_system_obj(store, pool, oid, nullptr, 0, exclusive,
                             nullptr, real_time(), nullptr);
@@ -794,9 +782,8 @@ int RGWRealm::create_control(bool exclusive)
 
 int RGWRealm::delete_control()
 {
-  auto pool_name = get_pool_name(cct);
-  auto pool = rgw_bucket{pool_name.c_str()};
-  auto obj = rgw_obj{pool, get_control_oid()};
+  auto pool = rgw_pool{get_pool_name(cct)};
+  auto obj = rgw_raw_obj{pool, get_control_oid()};
   return store->delete_system_obj(obj);
 }
 
@@ -993,10 +980,9 @@ const string RGWPeriod::get_period_oid()
 
 int RGWPeriod::read_latest_epoch(RGWPeriodLatestEpochInfo& info)
 {
-  string pool_name = get_pool_name(cct);
   string oid = get_period_oid_prefix() + get_latest_epoch_oid();
 
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   bufferlist bl;
   RGWObjectCtx obj_ctx(store);
   int ret = rgw_get_system_obj(store, obj_ctx, pool, oid, bl, NULL, NULL);
@@ -1044,10 +1030,9 @@ int RGWPeriod::use_latest_epoch()
 
 int RGWPeriod::set_latest_epoch(epoch_t epoch, bool exclusive)
 {
-  string pool_name = get_pool_name(cct);
   string oid = get_period_oid_prefix() + get_latest_epoch_oid();
 
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
   bufferlist bl;
 
   RGWPeriodLatestEpochInfo info;
@@ -1061,12 +1046,12 @@ int RGWPeriod::set_latest_epoch(epoch_t epoch, bool exclusive)
 
 int RGWPeriod::delete_obj()
 {
-  rgw_bucket pool(get_pool_name(cct));
+  rgw_pool pool(get_pool_name(cct));
 
   // delete the object for each period epoch
   for (epoch_t e = 1; e <= epoch; e++) {
     RGWPeriod p{get_id(), e};
-    rgw_obj oid{pool, p.get_period_oid()};
+    rgw_raw_obj oid{pool, p.get_period_oid()};
     int ret = store->delete_system_obj(oid);
     if (ret < 0) {
       ldout(cct, 0) << "WARNING: failed to delete period object " << oid
@@ -1075,7 +1060,7 @@ int RGWPeriod::delete_obj()
   }
 
   // delete the .latest_epoch object
-  rgw_obj oid{pool, get_period_oid_prefix() + get_latest_epoch_oid()};
+  rgw_raw_obj oid{pool, get_period_oid_prefix() + get_latest_epoch_oid()};
   int ret = store->delete_system_obj(oid);
   if (ret < 0) {
     ldout(cct, 0) << "WARNING: failed to delete period object " << oid
@@ -1086,9 +1071,8 @@ int RGWPeriod::delete_obj()
 
 int RGWPeriod::read_info()
 {
-  string pool_name = get_pool_name(cct);
+  rgw_pool pool(get_pool_name(cct));
 
-  rgw_bucket pool(pool_name.c_str());
   bufferlist bl;
 
   RGWObjectCtx obj_ctx(store);
@@ -1145,9 +1129,8 @@ int RGWPeriod::store_info(bool exclusive)
     ldout(cct, 0) << "ERROR: RGWPeriod::get_latest_epoch() returned " << cpp_strerror(-ret) << dendl;
     return ret;
   }
-  string pool_name = get_pool_name(cct);
 
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(get_pool_name(cct));
 
   string oid = get_period_oid();
   bufferlist bl;
@@ -1549,7 +1532,7 @@ int RGWZoneParams::fix_pool_names()
 int RGWZoneParams::create(bool exclusive)
 {
   /* check for old pools config */
-  rgw_obj obj(domain_root, avail_pools);
+  rgw_raw_obj obj(domain_root, avail_pools);
   int r = store->raw_obj_stat(obj, NULL, NULL, NULL, NULL, NULL, NULL);
   if (r < 0) {
     ldout(store->ctx(), 10) << "couldn't find old data placement pools config, setting up new ones for the zone" << dendl;
@@ -2703,32 +2686,18 @@ RGWObjState *RGWObjectCtx::get_state(rgw_obj& obj) {
   RGWObjState *result;
   map<rgw_obj, RGWObjState>::iterator iter;
   lock.get_read();
-  if (!obj.get_object().empty()) {
-    iter = objs_state.find(obj);
-    if (iter != objs_state.end()) {
-      result = &iter->second;
-      lock.unlock();
-    } else {
-      lock.unlock();
-      lock.get_write();
-      result = &objs_state[obj];
-      lock.unlock();
-    }
-    return result;
+  assert (!obj.get_object().empty());
+  iter = objs_state.find(obj);
+  if (iter != objs_state.end()) {
+    result = &iter->second;
+    lock.unlock();
   } else {
-    rgw_obj new_obj(store->get_zone_params().domain_root, obj.bucket.name);
-    iter = objs_state.find(new_obj);
-    if (iter != objs_state.end()) {
-      result = &iter->second;
-      lock.unlock();
-    } else {
-      lock.unlock();
-      lock.get_write();
-      result = &objs_state[new_obj];
-      lock.unlock();
-    }
-    return result;
+    lock.unlock();
+    lock.get_write();
+    result = &objs_state[obj];
+    lock.unlock();
   }
+  return result;
 }
 
 void RGWObjectCtx::invalidate(rgw_obj& obj)
@@ -2750,22 +2719,14 @@ void RGWObjectCtx::invalidate(rgw_obj& obj)
 
 void RGWObjectCtx::set_atomic(rgw_obj& obj) {
   RWLock::WLocker wl(lock);
-  if (!obj.get_object().empty()) {
-    objs_state[obj].is_atomic = true;
-  } else {
-    rgw_obj new_obj(store->get_zone_params().domain_root, obj.bucket.name);
-    objs_state[new_obj].is_atomic = true;
-  }
+  assert (!obj.get_object().empty());
+  objs_state[obj].is_atomic = true;
 }
 
 void RGWObjectCtx::set_prefetch_data(rgw_obj& obj) {
   RWLock::WLocker wl(lock);
-  if (!obj.get_object().empty()) {
-    objs_state[obj].prefetch_data = true;
-  } else {
-    rgw_obj new_obj(store->get_zone_params().domain_root, obj.bucket.name);
-    objs_state[new_obj].prefetch_data = true;
-  }
+  assert (!obj.get_object().empty());
+  objs_state[obj].prefetch_data = true;
 }
 
 class RGWMetaNotifierManager : public RGWCoroutinesManager {
@@ -3164,9 +3125,9 @@ RGWDataSyncStatusManager* RGWRados::get_data_sync_manager(const std::string& sou
 int RGWRados::get_required_alignment(rgw_bucket& bucket, uint64_t *alignment)
 {
   IoCtx ioctx;
-  int r = open_bucket_data_ctx(bucket, ioctx);
+  int r = open_pool_ctx(bucket.placement.data_pool, ioctx);
   if (r < 0) {
-    ldout(cct, 0) << "ERROR: open_bucket_data_ctx() returned " << r << dendl;
+    ldout(cct, 0) << "ERROR: open_pool_ctx() returned " << r << dendl;
     return r;
   }
 
@@ -3386,7 +3347,7 @@ int RGWRados::convert_regionmap()
   }
   string oid = region_map_oid; 
 
-  rgw_bucket pool(pool_name.c_str());
+  rgw_pool pool(pool_name);
   bufferlist bl;
   RGWObjectCtx obj_ctx(this);
   int ret = rgw_get_system_obj(this, obj_ctx, pool, oid, bl, NULL, NULL);
@@ -3427,7 +3388,7 @@ int RGWRados::convert_regionmap()
   current_period.set_bucket_quota(zonegroupmap.bucket_quota);
 
   // remove the region_map so we don't try to convert again
-  rgw_obj obj(pool, oid);
+  rgw_raw_obj obj(pool, oid);
   ret = delete_system_obj(obj);
   if (ret < 0) {
     ldout(cct, 0) << "Error could not remove " << obj
@@ -4143,9 +4104,8 @@ void RGWRados::schedule_context(Context *c) {
   finisher->queue(c);
 }
 
-int RGWRados::list_raw_prefixed_objs(const string& pool_name, const string& prefix, list<string>& result)
+int RGWRados::list_raw_prefixed_objs(const rgw_pool& pool, const string& prefix, list<string>& result)
 {
-  rgw_bucket pool(pool_name.c_str());
   bool is_truncated;
   RGWListRawObjsCtx ctx;
   do {
@@ -4183,23 +4143,24 @@ int RGWRados::list_zonegroups(list<string>& zonegroups)
 int RGWRados::list_zones(list<string>& zones)
 {
   RGWZoneParams zoneparams;
-  string pool_name = zoneparams.get_pool_name(cct);
+  rgw_pool pool(zoneparams.get_pool_name(cct));
 
-  return list_raw_prefixed_objs(pool_name, zone_names_oid_prefix, zones);
+  return list_raw_prefixed_objs(pool, zone_names_oid_prefix, zones);
 }
 
 int RGWRados::list_realms(list<string>& realms)
 {
   RGWRealm realm(cct, this);
-  string pool_name = realm.get_pool_name(cct);
-  return list_raw_prefixed_objs(pool_name, realm_names_oid_prefix, realms);
+  rgw_pool pool(realm.get_pool_name(cct));
+  return list_raw_prefixed_objs(pool, realm_names_oid_prefix, realms);
 }
 
 int RGWRados::list_periods(list<string>& periods)
 {
   RGWPeriod period;
   list<string> raw_periods;
-  int ret = list_raw_prefixed_objs(period.get_pool_name(cct), period.get_info_oid_prefix(), raw_periods);
+  rgw_pool pool(period.get_pool_name(cct));
+  int ret = list_raw_prefixed_objs(pool, period.get_info_oid_prefix(), raw_periods);
   if (ret < 0) {
     return ret;
   }
@@ -4381,40 +4342,21 @@ void RGWRados::pick_control_oid(const string& key, string& notify_oid)
   notify_oid.append(buf);
 }
 
-int RGWRados::open_pool_ctx(const string& pool, librados::IoCtx&  io_ctx)
+int RGWRados::open_pool_ctx(const rgw_pool& pool, librados::IoCtx&  io_ctx)
 {
   librados::Rados *rad = get_rados_handle();
-  int r = rad->ioctx_create(pool.c_str(), io_ctx);
+  int r = rad->ioctx_create(pool.name.c_str(), io_ctx);
   if (r != -ENOENT)
     return r;
 
   if (!pools_initialized)
     return r;
 
-  r = rad->pool_create(pool.c_str());
+  r = rad->pool_create(pool.name.c_str());
   if (r < 0 && r != -EEXIST)
     return r;
 
-  return rad->ioctx_create(pool.c_str(), io_ctx);
-}
-
-int RGWRados::open_bucket_data_ctx(rgw_bucket& bucket, librados::IoCtx& data_ctx)
-{
-  int r = open_pool_ctx(bucket.data_pool, data_ctx);
-  if (r < 0)
-    return r;
-
-  return 0;
-}
-
-int RGWRados::open_bucket_data_extra_ctx(rgw_bucket& bucket, librados::IoCtx& data_ctx)
-{
-  string& pool = (!bucket.data_extra_pool.empty() ? bucket.data_extra_pool : bucket.data_pool);
-  int r = open_pool_ctx(pool, data_ctx);
-  if (r < 0)
-    return r;
-
-  return 0;
+  return rad->ioctx_create(pool.name.c_str(), io_ctx);
 }
 
 void RGWRados::build_bucket_index_marker(const string& shard_id_str, const string& shard_marker,
@@ -4428,7 +4370,7 @@ void RGWRados::build_bucket_index_marker(const string& shard_id_str, const strin
 
 int RGWRados::open_bucket_index_ctx(rgw_bucket& bucket, librados::IoCtx& index_ctx)
 {
-  int r = open_pool_ctx(bucket.index_pool, index_ctx);
+  int r = open_pool_ctx(bucket.placement.index_pool, index_ctx);
   if (r < 0)
     return r;
 
@@ -4786,7 +4728,7 @@ int RGWRados::time_log_add_init(librados::IoCtx& io_ctx)
   librados::Rados *rad = get_rados_handle();
   int r = rad->ioctx_create(log_pool, io_ctx);
   if (r == -ENOENT) {
-    rgw_bucket pool(log_pool);
+    rgw_pool pool(log_pool);
     r = create_pool(pool);
     if (r < 0)
       return r;
@@ -5049,7 +4991,7 @@ int RGWRados::objexp_hint_trim(const string& oid,
   return 0;
 }
 
-int RGWRados::lock_exclusive(rgw_bucket& pool, const string& oid, timespan& duration, 
+int RGWRados::lock_exclusive(rgw_pool& pool, const string& oid, timespan& duration, 
                              string& zone_id, string& owner_id) {
   librados::IoCtx io_ctx;
 
@@ -5071,7 +5013,7 @@ int RGWRados::lock_exclusive(rgw_bucket& pool, const string& oid, timespan& dura
   return l.lock_exclusive(&io_ctx, oid);
 }
 
-int RGWRados::unlock(rgw_bucket& pool, const string& oid, string& zone_id, string& owner_id) {
+int RGWRados::unlock(rgw_pool& pool, const string& oid, string& zone_id, string& owner_id) {
   librados::IoCtx io_ctx;
 
   const char *pool_name = pool.name.c_str();
@@ -5309,26 +5251,16 @@ done:
  * create a rados pool, associated meta info
  * returns 0 on success, -ERR# otherwise.
  */
-int RGWRados::create_pool(rgw_bucket& bucket) 
+int RGWRados::create_pool(rgw_pool& pool) 
 {
   int ret = 0;
 
-  string pool = bucket.index_pool;
-
   librados::Rados *rad = get_rados_handle();
-  ret = rad->pool_create(pool.c_str(), 0);
+  ret = rad->pool_create(pool.name.c_str(), 0);
   if (ret == -EEXIST)
     ret = 0;
   if (ret < 0)
     return ret;
-
-  if (bucket.data_pool != pool) {
-    ret = rad->pool_create(bucket.data_pool.c_str(), 0);
-    if (ret == -EEXIST)
-      ret = 0;
-    if (ret < 0)
-      return ret;
-  }
 
   return 0;
 }
@@ -5551,9 +5483,9 @@ int RGWRados::set_bucket_location_by_rule(const string& location_rule, const str
 
   RGWZonePlacementInfo& placement_info = piter->second;
 
-  bucket.data_pool = placement_info.data_pool;
-  bucket.data_extra_pool = placement_info.data_extra_pool;
-  bucket.index_pool = placement_info.index_pool;
+  bucket.placement.data_pool = placement_info.data_pool;
+  bucket.placement.data_extra_pool = placement_info.data_extra_pool;
+  bucket.placement.index_pool = placement_info.index_pool;
 
   if (rule_info) {
     *rule_info = placement_info;
@@ -5586,7 +5518,7 @@ int RGWRados::select_legacy_bucket_placement(const string& tenant_name, const st
   string pool_name;
   bool write_map = false;
 
-  rgw_obj obj(get_zone_params().domain_root, avail_pools);
+  rgw_raw_obj obj(get_zone_params().domain_root, avail_pools);
 
   RGWObjectCtx obj_ctx(this);
   int ret = rgw_get_system_obj(this, obj_ctx, get_zone_params().domain_root, avail_pools, map_bl, NULL, NULL);
@@ -5651,8 +5583,8 @@ read_omap:
     miter = m.begin();
     pool_name = miter->first;
   }
-  bucket.data_pool = pool_name;
-  bucket.index_pool = pool_name;
+  bucket.placement.data_pool = pool_name;
+  bucket.placement.index_pool = pool_name;
 
   rule_info->data_pool = pool_name;
   rule_info->data_extra_pool = pool_name;
@@ -5666,7 +5598,7 @@ int RGWRados::update_placement_map()
 {
   bufferlist header;
   map<string, bufferlist> m;
-  rgw_obj obj(get_zone_params().domain_root, avail_pools);
+  rgw_raw_obj obj(get_zone_params().domain_root, avail_pools);
   int ret = omap_get_all(obj, header, m);
   if (ret < 0)
     return ret;
@@ -5688,7 +5620,7 @@ int RGWRados::add_bucket_placement(std::string& new_pool)
   if (ret < 0) // DNE, or something
     return ret;
 
-  rgw_obj obj(get_zone_params().domain_root, avail_pools);
+  rgw_raw_obj obj(get_zone_params().domain_root, avail_pools);
   bufferlist empty_bl;
   ret = omap_set(obj, new_pool, empty_bl);
 
@@ -5700,7 +5632,7 @@ int RGWRados::add_bucket_placement(std::string& new_pool)
 
 int RGWRados::remove_bucket_placement(std::string& old_pool)
 {
-  rgw_obj obj(get_zone_params().domain_root, avail_pools);
+  rgw_raw_obj obj(get_zone_params().domain_root, avail_pools);
   int ret = omap_del(obj, old_pool);
 
   // don't care about return value
@@ -5714,7 +5646,7 @@ int RGWRados::list_placement_set(set<string>& names)
   bufferlist header;
   map<string, bufferlist> m;
 
-  rgw_obj obj(get_zone_params().domain_root, avail_pools);
+  rgw_raw_obj obj(get_zone_params().domain_root, avail_pools);
   int ret = omap_get_all(obj, header, m);
   if (ret < 0)
     return ret;
@@ -5766,16 +5698,16 @@ int RGWRados::create_pools(vector<string>& names, vector<int>& retcodes)
 
 int RGWRados::get_obj_ioctx(const rgw_obj& obj, librados::IoCtx *ioctx)
 {
-  rgw_bucket bucket;
+  const rgw_bucket& bucket = obj.bucket;
   string oid, key;
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
 
   int r;
 
   if (!obj.is_in_extra_data()) {
-    r = open_bucket_data_ctx(bucket, *ioctx);
+    r = open_pool_ctx(bucket.placement.data_pool, *ioctx);
   } else {
-    r = open_bucket_data_extra_ctx(bucket, *ioctx);
+    r = open_pool_ctx(bucket.placement.get_data_extra_pool(), *ioctx);
   }
   if (r < 0)
     return r;
@@ -5785,42 +5717,28 @@ int RGWRados::get_obj_ioctx(const rgw_obj& obj, librados::IoCtx *ioctx)
   return 0;
 }
 
-int RGWRados::get_obj_ref(const rgw_obj& obj, rgw_rados_ref *ref, rgw_bucket *bucket)
+int RGWRados::get_raw_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref, rgw_pool *pool)
 {
-  get_obj_bucket_and_oid_loc(obj, *bucket, ref->oid, ref->key);
-
-  int r;
-
-  if (!obj.is_in_extra_data()) {
-    r = open_bucket_data_ctx(*bucket, ref->ioctx);
-  } else {
-    r = open_bucket_data_extra_ctx(*bucket, ref->ioctx);
-  }
-  if (r < 0)
-    return r;
-
-  ref->ioctx.locator_set_key(ref->key);
-
-  return 0;
-}
-
-int RGWRados::get_system_obj_ref(const rgw_obj& obj, rgw_rados_ref *ref, rgw_bucket *bucket)
-{
-  get_obj_bucket_and_oid_loc(obj, *bucket, ref->oid, ref->key);
+  *pool = obj.pool;
+  ref->oid = obj.oid;
+  ref->key.clear();
 
   int r;
 
   if (ref->oid.empty()) {
-    ref->oid = bucket->name;
-    *bucket = get_zone_params().domain_root;
+    ref->oid = pool->name;
+    *pool = get_zone_params().domain_root;
   }
-  r = open_pool_ctx(bucket->name, ref->ioctx);
+  r = open_pool_ctx(pool->name, ref->ioctx);
   if (r < 0)
     return r;
 
-  ref->ioctx.locator_set_key(ref->key);
-
   return 0;
+}
+
+int RGWRados::get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref, rgw_pool *pool)
+{
+  return get_raw_obj_ref(obj, ref, pool);
 }
 
 /*
@@ -5834,7 +5752,7 @@ int RGWRados::fix_head_obj_locator(rgw_bucket& bucket, bool copy_obj, bool remov
 
   rgw_obj obj(bucket, key);
 
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, locator);
+  get_obj_bucket_and_oid_loc(obj, oid, locator);
 
   if (locator.empty()) {
     ldout(cct, 20) << "object does not have a locator, nothing to fix" << dendl;
@@ -5987,7 +5905,8 @@ int RGWRados::fix_tail_obj_locator(rgw_bucket& bucket, rgw_obj_key& key, bool fi
   }
 
   rgw_rados_ref ref;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -6011,7 +5930,7 @@ int RGWRados::fix_tail_obj_locator(rgw_bucket& bucket, rgw_obj_key& key, bool fi
 	continue;
       }
 
-      get_obj_bucket_and_oid_loc(loc, bucket, oid, locator);
+      get_obj_bucket_and_oid_loc(loc, oid, locator);
       ref.ioctx.locator_set_key(locator);
 
       ldout(cct, 20) << __func__ << ": key=" << key << " oid=" << oid << " locator=" << locator << dendl;
@@ -6337,7 +6256,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
                                            void *_index_op)
 {
   RGWRados::Bucket::UpdateIndex *index_op = static_cast<RGWRados::Bucket::UpdateIndex *>(_index_op);
-  rgw_bucket bucket;
+  rgw_pool pool;
   rgw_rados_ref ref;
   RGWRados *store = target->get_store();
 
@@ -6355,7 +6274,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     return -EIO;
   }
 
-  r = store->get_obj_ref(obj, &ref, &bucket);
+  r = store->get_obj_ref(obj, &ref, &pool);
   if (r < 0)
     return r;
 
@@ -6506,7 +6425,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
     obj.get_index_key(&obj_key);
 
     r = store->objexp_hint_add(meta.delete_at,
-            bucket.tenant, bucket.name, bucket.bucket_id, obj_key);
+            obj.bucket.tenant, obj.bucket.name, obj.bucket.bucket_id, obj_key);
     if (r < 0) {
       ldout(store->ctx(), 0) << "ERROR: objexp_hint_add() returned r=" << r << ", object will not get removed" << dendl;
       /* ignoring error, nothing we can do at this point */
@@ -6515,7 +6434,7 @@ int RGWRados::Object::Write::_do_write_meta(uint64_t size, uint64_t accounted_si
   meta.canceled = false;
 
   /* update quota cache */
-  store->quota_handler->update_stats(meta.owner, bucket, (orig_exists ? 0 : 1),
+  store->quota_handler->update_stats(meta.owner, obj.bucket, (orig_exists ? 0 : 1),
                                      accounted_size, orig_size);
   return 0;
 
@@ -6587,15 +6506,15 @@ int RGWRados::Object::Write::write_meta(uint64_t size, uint64_t accounted_size,
 }
 
 /** Write/overwrite a system object. */
-int RGWRados::put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mtime,
+int RGWRados::put_system_obj_impl(rgw_raw_obj& obj, uint64_t size, real_time *mtime,
               map<std::string, bufferlist>& attrs, int flags,
               bufferlist& data,
               RGWObjVersionTracker *objv_tracker,
               real_time set_mtime /* 0 for don't set */)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   rgw_rados_ref ref;
-  int r = get_system_obj_ref(obj, &ref, &bucket);
+  int r = get_system_obj_ref(obj, &ref, &pool);
   if (r < 0)
     return r;
 
@@ -6651,12 +6570,12 @@ int RGWRados::put_system_obj_impl(rgw_obj& obj, uint64_t size, real_time *mtime,
   return 0;
 }
 
-int RGWRados::put_system_obj_data(void *ctx, rgw_obj& obj, bufferlist& bl,
+int RGWRados::put_system_obj_data(void *ctx, rgw_raw_obj& obj, bufferlist& bl,
 			       off_t ofs, bool exclusive)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_system_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_system_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -6706,8 +6625,8 @@ int RGWRados::aio_put_obj_data(void *ctx, rgw_obj& obj, bufferlist& bl,
                                void **handle)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -7532,7 +7451,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     return ret;
   }
 
-  bool copy_data = !astate->has_manifest || (src_obj.bucket.data_pool != dest_obj.bucket.data_pool);
+  bool copy_data = !astate->has_manifest || (src_obj.bucket.placement.data_pool != dest_obj.bucket.placement.data_pool);
   bool copy_first = false;
   if (astate->has_manifest) {
     if (!astate->manifest.has_tail()) {
@@ -7570,8 +7489,8 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   }
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  ret = get_obj_ref(miter.get_location(), &ref, &bucket);
+  rgw_pool pool;
+  ret = get_obj_ref(miter.get_location(), &ref, &pool);
   if (ret < 0) {
     return ret;
   }
@@ -7615,7 +7534,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
       ObjectWriteOperation op;
       cls_refcount_get(op, tag, true);
       const rgw_obj& loc = miter.get_location();
-      get_obj_bucket_and_oid_loc(loc, bucket, oid, key);
+      get_obj_bucket_and_oid_loc(loc, oid, key);
       ref.ioctx.locator_set_key(key);
 
       ret = ref.ioctx.operate(oid, &op);
@@ -7672,7 +7591,7 @@ done_ret:
       ObjectWriteOperation op;
       cls_refcount_put(op, tag, true);
 
-      get_obj_bucket_and_oid_loc(*riter, bucket, oid, key);
+      get_obj_bucket_and_oid_loc(*riter, oid, key);
       ref.ioctx.locator_set_key(key);
 
       int r = ref.ioctx.operate(oid, &op);
@@ -7967,10 +7886,9 @@ void RGWRados::update_gc_chain(rgw_obj& head_obj, RGWObjManifest& manifest, cls_
     if (mobj == head_obj)
       continue;
     string oid, loc;
-    rgw_bucket bucket;
-    get_obj_bucket_and_oid_loc(mobj, bucket, oid, loc);
+    get_obj_bucket_and_oid_loc(mobj, oid, loc);
     cls_rgw_obj_key key(oid);
-    chain->push_obj(bucket.data_pool, key, loc);
+    chain->push_obj(mobj.bucket.placement.data_pool, key, loc);
   }
 }
 
@@ -8157,9 +8075,8 @@ int RGWRados::bucket_rebuild_index(rgw_bucket& bucket)
 int RGWRados::defer_gc(void *ctx, rgw_obj& obj)
 {
   RGWObjectCtx *rctx = static_cast<RGWObjectCtx *>(ctx);
-  rgw_bucket bucket;
   std::string oid, key;
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
   if (!rctx)
     return 0;
 
@@ -8285,8 +8202,8 @@ int RGWRados::Object::Delete::delete_obj()
   }
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = store->get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = store->get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -8396,7 +8313,7 @@ int RGWRados::Object::Delete::delete_obj()
     return r;
 
   /* update quota cache */
-  store->quota_handler->update_stats(params.bucket_owner, bucket, -1, 0, obj_size);
+  store->quota_handler->update_stats(params.bucket_owner, obj.bucket, -1, 0, obj_size);
 
   return 0;
 }
@@ -8419,7 +8336,7 @@ int RGWRados::delete_obj(RGWObjectCtx& obj_ctx,
   return del_op.delete_obj();
 }
 
-int RGWRados::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker)
+int RGWRados::delete_system_obj(rgw_raw_obj& obj, RGWObjVersionTracker *objv_tracker)
 {
   if (obj.get_object().empty()) {
     ldout(cct, 1) << "delete_system_obj got empty object name "
@@ -8427,8 +8344,8 @@ int RGWRados::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker
     return -EINVAL;
   }
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -8449,16 +8366,15 @@ int RGWRados::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker
 
 int RGWRados::delete_obj_index(rgw_obj& obj)
 {
-  rgw_bucket bucket;
   std::string oid, key;
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
 
   RGWObjectCtx obj_ctx(this);
 
   RGWBucketInfo bucket_info;
-  int ret = get_bucket_instance_info(obj_ctx, bucket, bucket_info, NULL, NULL);
+  int ret = get_bucket_instance_info(obj_ctx, obj.bucket, bucket_info, NULL, NULL);
   if (ret < 0) {
-    ldout(cct, 0) << "ERROR: " << __func__ << "() get_bucket_instance_info(bucket=" << bucket << ") returned ret=" << ret << dendl;
+    ldout(cct, 0) << "ERROR: " << __func__ << "() get_bucket_instance_info(bucket=" << obj.bucket << ") returned ret=" << ret << dendl;
     return ret;
   }
 
@@ -8533,7 +8449,7 @@ int RGWRados::get_olh_target_state(RGWObjectCtx& obj_ctx, rgw_obj& obj, RGWObjSt
   return 0;
 }
 
-int RGWRados::get_system_obj_state_impl(RGWObjectCtx *rctx, rgw_obj& obj, RGWObjState **state, RGWObjVersionTracker *objv_tracker)
+int RGWRados::get_system_obj_state_impl(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWObjState **state, RGWObjVersionTracker *objv_tracker)
 {
   RGWObjState *s = rctx->get_state(obj);
   ldout(cct, 20) << "get_system_obj_state: rctx=" << (void *)rctx << " obj=" << obj << " state=" << (void *)s << " s->prefetch_data=" << s->prefetch_data << dendl;
@@ -8567,7 +8483,7 @@ int RGWRados::get_system_obj_state_impl(RGWObjectCtx *rctx, rgw_obj& obj, RGWObj
   return 0;
 }
 
-int RGWRados::get_system_obj_state(RGWObjectCtx *rctx, rgw_obj& obj, RGWObjState **state, RGWObjVersionTracker *objv_tracker)
+int RGWRados::get_system_obj_state(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWObjState **state, RGWObjVersionTracker *objv_tracker)
 {
   int ret;
 
@@ -8783,8 +8699,7 @@ int RGWRados::Object::Stat::stat_async()
 
   string oid;
   string loc;
-  rgw_bucket bucket;
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, loc);
+  get_obj_bucket_and_oid_loc(obj, oid, loc);
 
   int r = store->get_obj_ioctx(obj, &state.io_ctx);
   if (r < 0) {
@@ -8852,11 +8767,11 @@ int RGWRados::Object::Stat::finish()
  * dest: bufferlist to store the result in
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::system_obj_get_attr(rgw_obj& obj, const char *name, bufferlist& dest)
+int RGWRados::system_obj_get_attr(rgw_raw_obj& obj, const char *name, bufferlist& dest)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_system_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_system_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -8997,7 +8912,7 @@ int RGWRados::Object::prepare_atomic_modification(ObjectWriteOperation& op, bool
   return 0;
 }
 
-int RGWRados::system_obj_set_attr(void *ctx, rgw_obj& obj, const char *name, bufferlist& bl,
+int RGWRados::system_obj_set_attr(void *ctx, rgw_raw_obj& obj, const char *name, bufferlist& bl,
 				  RGWObjVersionTracker *objv_tracker)
 {
   map<string, bufferlist> attrs;
@@ -9005,14 +8920,14 @@ int RGWRados::system_obj_set_attr(void *ctx, rgw_obj& obj, const char *name, buf
   return system_obj_set_attrs(ctx, obj, attrs, NULL, objv_tracker);
 }
 
-int RGWRados::system_obj_set_attrs(void *ctx, rgw_obj& obj,
+int RGWRados::system_obj_set_attrs(void *ctx, rgw_raw_obj& obj,
                         map<string, bufferlist>& attrs,
                         map<string, bufferlist>* rmattrs,
                         RGWObjVersionTracker *objv_tracker)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_system_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_system_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -9072,8 +8987,8 @@ int RGWRados::set_attrs(void *ctx, rgw_obj& obj,
                         map<string, bufferlist>* rmattrs)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -9093,6 +9008,8 @@ int RGWRados::set_attrs(void *ctx, rgw_obj& obj,
       op.rmxattr(name.c_str());
     }
   }
+
+  const rgw_bucket& bucket = obj.bucket;
 
   for (iter = attrs.begin(); iter != attrs.end(); ++iter) {
     const string& name = iter->first;
@@ -9327,7 +9244,7 @@ int RGWRados::SystemObject::get_state(RGWObjState **pstate, RGWObjVersionTracker
 
 int RGWRados::stat_system_obj(RGWObjectCtx& obj_ctx,
                               RGWRados::SystemObject::Read::GetObjState& state,
-                              rgw_obj& obj,
+                              rgw_raw_obj& obj,
                               map<string, bufferlist> *attrs,
                               real_time *lastmod,
                               uint64_t *obj_size,
@@ -9364,7 +9281,7 @@ int RGWRados::stat_system_obj(RGWObjectCtx& obj_ctx,
 int RGWRados::SystemObject::Read::stat(RGWObjVersionTracker *objv_tracker)
 {
   RGWRados *store = source->get_store();
-  rgw_obj& obj = source->get_obj();
+  rgw_raw_obj& obj = source->get_obj();
 
   return store->stat_system_obj(source->get_ctx(), state, obj, stat_params.attrs,
                                 stat_params.lastmod, stat_params.obj_size, objv_tracker);
@@ -9504,7 +9421,6 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   RGWRados *store = source->get_store();
   CephContext *cct = store->ctx();
 
-  rgw_bucket bucket;
   std::string oid, key;
   rgw_obj read_obj = state.obj;
   uint64_t read_ofs = ofs;
@@ -9518,7 +9434,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   uint64_t max_chunk_size;
 
 
-  get_obj_bucket_and_oid_loc(state.obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(state.obj, oid, key);
 
   RGWObjState *astate;
   int r = source->get_state(&astate, true);
@@ -9541,13 +9457,13 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
     reading_from_head = (read_obj == state.obj);
 
     if (!reading_from_head) {
-      get_obj_bucket_and_oid_loc(read_obj, bucket, oid, key);
+      get_obj_bucket_and_oid_loc(read_obj, oid, key);
     }
   }
 
-  r = store->get_max_chunk_size(bucket, &max_chunk_size);
+  r = store->get_max_chunk_size(read_obj.bucket, &max_chunk_size);
   if (r < 0) {
-    ldout(cct, 0) << "ERROR: failed to get max_chunk_size() for bucket " << bucket << dendl;
+    ldout(cct, 0) << "ERROR: failed to get max_chunk_size() for bucket " << read_obj.bucket << dendl;
     return r;
   }
 
@@ -9602,32 +9518,29 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   return bl.length();
 }
 
-int RGWRados::SystemObject::Read::GetObjState::get_ioctx(RGWRados *store, rgw_obj& obj, librados::IoCtx **ioctx)
+int RGWRados::SystemObject::Read::GetObjState::get_ref(RGWRados *store, rgw_raw_obj& obj, rgw_rados_ref **pref)
 {
-  if (!has_ioctx) {
-    int r = store->get_obj_ioctx(obj, &io_ctx);
+  if (!has_ref) {
+    rgw_pool pool;
+    int r = store->get_raw_obj_ref(obj, &ref, &pool);
     if (r < 0) {
       return r;
     }
-    has_ioctx = true;
+    has_ref = true;
   }
-  *ioctx = &io_ctx;
+  *pref = &ref;
   return 0;
 
 }
 
 int RGWRados::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::Read::GetObjState& read_state,
-                             RGWObjVersionTracker *objv_tracker, rgw_obj& obj,
+                             RGWObjVersionTracker *objv_tracker, rgw_raw_obj& obj,
                              bufferlist& bl, off_t ofs, off_t end,
                              map<string, bufferlist> *attrs,
                              rgw_cache_entry_info *cache_info)
 {
-  rgw_bucket bucket;
-  std::string oid, key;
   uint64_t len;
   ObjectReadOperation op;
-
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
 
   if (end < 0)
     len = 0;
@@ -9645,20 +9558,20 @@ int RGWRados::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::Read
     op.getxattrs(attrs, NULL);
   }
 
-  librados::IoCtx *io_ctx;
-  int r = read_state.get_ioctx(this, obj, &io_ctx);
+  rgw_rados_ref *ref;
+  int r = read_state.get_ref(this, obj, &ref);
   if (r < 0) {
-    ldout(cct, 20) << "get_ioctx() on obj=" << obj << " returned " << r << dendl;
+    ldout(cct, 20) << "read_state.get_ref() on obj=" << obj << " returned " << r << dendl;
     return r;
   }
-  r = io_ctx->operate(oid, &op, NULL);
+  r = ref->ioctx.operate(ref->oid, &op, NULL);
   if (r < 0) {
     ldout(cct, 20) << "rados->read r=" << r << " bl.length=" << bl.length() << dendl;
     return r;
   }
   ldout(cct, 20) << "rados->read r=" << r << " bl.length=" << bl.length() << dendl;
 
-  uint64_t op_ver = io_ctx->get_last_version();
+  uint64_t op_ver = ref->ioctx.get_last_version();
 
   if (read_state.last_ver > 0 &&
       read_state.last_ver != op_ver) {
@@ -9674,7 +9587,7 @@ int RGWRados::get_system_obj(RGWObjectCtx& obj_ctx, RGWRados::SystemObject::Read
 int RGWRados::SystemObject::Read::read(int64_t ofs, int64_t end, bufferlist& bl, RGWObjVersionTracker *objv_tracker)
 {
   RGWRados *store = source->get_store();
-  rgw_obj& obj = source->get_obj();
+  rgw_raw_obj& obj = source->get_obj();
 
   return store->get_system_obj(source->get_ctx(), state, objv_tracker, obj, bl, ofs, end, read_params.attrs, read_params.cache_info);
 }
@@ -9682,7 +9595,7 @@ int RGWRados::SystemObject::Read::read(int64_t ofs, int64_t end, bufferlist& bl,
 int RGWRados::SystemObject::Read::get_attr(const char *name, bufferlist& dest)
 {
   RGWRados *store = source->get_store();
-  rgw_obj& obj = source->get_obj();
+  rgw_raw_obj& obj = source->get_obj();
 
   return store->system_obj_get_attr(obj, name, dest);
 }
@@ -9969,7 +9882,6 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
   ObjectReadOperation op;
   struct get_obj_data *d = (struct get_obj_data *)arg;
   string oid, key;
-  rgw_bucket bucket;
   bufferlist *pbl;
   AioCompletion *c;
 
@@ -10003,7 +9915,7 @@ int RGWRados::get_obj_iterate_cb(RGWObjectCtx *ctx, RGWObjState *astate,
     }
   }
 
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
 
   d->throttle.get(len);
   if (d->is_cancelled()) {
@@ -10088,7 +10000,6 @@ int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx, rgw_obj& obj,
 			  int (*iterate_obj_cb)(rgw_obj&, off_t, off_t, off_t, bool, RGWObjState *, void *),
 	                  void *arg)
 {
-  rgw_bucket bucket;
   rgw_obj read_obj = obj;
   uint64_t read_ofs = ofs;
   uint64_t len;
@@ -10154,8 +10065,8 @@ int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx, rgw_obj& obj,
 int RGWRados::obj_operate(rgw_obj& obj, ObjectWriteOperation *op)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -10166,8 +10077,8 @@ int RGWRados::obj_operate(rgw_obj& obj, ObjectWriteOperation *op)
 int RGWRados::obj_operate(rgw_obj& obj, ObjectReadOperation *op)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -10295,14 +10206,14 @@ int RGWRados::bucket_index_link_olh(RGWObjState& olh_state, rgw_obj& obj_instanc
                                     real_time unmod_since, bool high_precision_time)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj_instance, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj_instance, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   BucketShard bs(this);
-  int ret = bs.init(bucket, obj_instance);
+  int ret = bs.init(obj_instance.bucket, obj_instance);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -10328,14 +10239,14 @@ void RGWRados::bucket_index_guard_olh_op(RGWObjState& olh_state, ObjectOperation
 int RGWRados::bucket_index_unlink_instance(rgw_obj& obj_instance, const string& op_tag, const string& olh_tag, uint64_t olh_epoch)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj_instance, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj_instance, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   BucketShard bs(this);
-  int ret = bs.init(bucket, obj_instance);
+  int ret = bs.init(obj_instance.bucket, obj_instance);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -10355,14 +10266,14 @@ int RGWRados::bucket_index_read_olh_log(RGWObjState& state, rgw_obj& obj_instanc
                                         bool *is_truncated)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj_instance, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj_instance, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   BucketShard bs(this);
-  int ret = bs.init(bucket, obj_instance);
+  int ret = bs.init(obj_instance.bucket, obj_instance);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -10384,14 +10295,14 @@ int RGWRados::bucket_index_read_olh_log(RGWObjState& state, rgw_obj& obj_instanc
 int RGWRados::bucket_index_trim_olh_log(RGWObjState& state, rgw_obj& obj_instance, uint64_t ver)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj_instance, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj_instance, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   BucketShard bs(this);
-  int ret = bs.init(bucket, obj_instance);
+  int ret = bs.init(obj_instance.bucket, obj_instance);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -10415,14 +10326,14 @@ int RGWRados::bucket_index_trim_olh_log(RGWObjState& state, rgw_obj& obj_instanc
 int RGWRados::bucket_index_clear_olh(RGWObjState& state, rgw_obj& obj_instance)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj_instance, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj_instance, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   BucketShard bs(this);
-  int ret = bs.init(bucket, obj_instance);
+  int ret = bs.init(obj_instance.bucket, obj_instance);
   if (ret < 0) {
     ldout(cct, 5) << "bs.init() returned ret=" << ret << dendl;
     return ret;
@@ -10498,11 +10409,13 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, RGWBucket
   }
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
+
+  const rgw_bucket& bucket = obj.bucket;
 
   if (need_to_link) {
     rgw_obj target(bucket, key);
@@ -10811,8 +10724,8 @@ int RGWRados::remove_olh_pending_entries(RGWObjState& state, rgw_obj& olh_obj, m
   }
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(olh_obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_obj_ref(olh_obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -10884,13 +10797,13 @@ int RGWRados::follow_olh(RGWObjectCtx& obj_ctx, RGWObjState *state, rgw_obj& olh
   return 0;
 }
 
-int RGWRados::raw_obj_stat(rgw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
+int RGWRados::raw_obj_stat(rgw_raw_obj& obj, uint64_t *psize, real_time *pmtime, uint64_t *epoch,
                            map<string, bufferlist> *attrs, bufferlist *first_chunk,
                            RGWObjVersionTracker *objv_tracker)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -11120,7 +11033,7 @@ void RGWRados::get_bucket_meta_oid(const rgw_bucket& bucket, string& oid)
   oid = RGW_BUCKET_INSTANCE_MD_PREFIX + bucket.get_key(':');
 }
 
-void RGWRados::get_bucket_instance_obj(const rgw_bucket& bucket, rgw_obj& obj)
+void RGWRados::get_bucket_instance_obj(const rgw_bucket& bucket, rgw_raw_obj& obj)
 {
   if (!bucket.oid.empty()) {
     obj.init(get_zone_params().domain_root, bucket.oid);
@@ -11144,7 +11057,7 @@ int RGWRados::get_bucket_instance_info(RGWObjectCtx& obj_ctx, const string& meta
   return get_bucket_instance_from_oid(obj_ctx, oid, info, pmtime, pattrs);
 }
 
-int RGWRados::get_bucket_instance_info(RGWObjectCtx& obj_ctx, rgw_bucket& bucket, RGWBucketInfo& info,
+int RGWRados::get_bucket_instance_info(RGWObjectCtx& obj_ctx, const rgw_bucket& bucket, RGWBucketInfo& info,
                                        real_time *pmtime, map<string, bufferlist> *pattrs)
 {
   string oid;
@@ -11399,11 +11312,11 @@ int RGWRados::put_linked_bucket_info(RGWBucketInfo& info, bool exclusive, real_t
   return 0;
 }
 
-int RGWRados::omap_get_vals(rgw_obj& obj, bufferlist& header, const string& marker, uint64_t count, std::map<string, bufferlist>& m)
+int RGWRados::omap_get_vals(rgw_raw_obj& obj, bufferlist& header, const string& marker, uint64_t count, std::map<string, bufferlist>& m)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -11416,7 +11329,7 @@ int RGWRados::omap_get_vals(rgw_obj& obj, bufferlist& header, const string& mark
  
 }
 
-int RGWRados::omap_get_all(rgw_obj& obj, bufferlist& header,
+int RGWRados::omap_get_all(rgw_raw_obj& obj, bufferlist& header,
 			   std::map<string, bufferlist>& m)
 {
   rgw_rados_ref ref;
@@ -11445,15 +11358,15 @@ int RGWRados::omap_get_all(rgw_obj& obj, bufferlist& header,
   return 0;
 }
 
-int RGWRados::omap_set(rgw_obj& obj, std::string& key, bufferlist& bl)
+int RGWRados::omap_set(rgw_raw_obj& obj, std::string& key, bufferlist& bl)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
-  ldout(cct, 15) << "omap_set bucket=" << bucket << " oid=" << ref.oid << " key=" << key << dendl;
+  ldout(cct, 15) << "omap_set pool=" << pool << " oid=" << ref.oid << " key=" << key << dendl;
 
   map<string, bufferlist> m;
   m[key] = bl;
@@ -11463,11 +11376,11 @@ int RGWRados::omap_set(rgw_obj& obj, std::string& key, bufferlist& bl)
   return r;
 }
 
-int RGWRados::omap_set(rgw_obj& obj, std::map<std::string, bufferlist>& m)
+int RGWRados::omap_set(rgw_raw_obj& obj, std::map<std::string, bufferlist>& m)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -11477,11 +11390,11 @@ int RGWRados::omap_set(rgw_obj& obj, std::map<std::string, bufferlist>& m)
   return r;
 }
 
-int RGWRados::omap_del(rgw_obj& obj, const std::string& key)
+int RGWRados::omap_del(rgw_raw_obj& obj, const std::string& key)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -11524,11 +11437,11 @@ int RGWRados::update_containers_stats(map<string, RGWBucketEnt>& m)
   return m.size();
 }
 
-int RGWRados::append_async(rgw_obj& obj, size_t size, bufferlist& bl)
+int RGWRados::append_async(rgw_raw_obj& obj, size_t size, bufferlist& bl)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -11557,12 +11470,12 @@ int RGWRados::distribute(const string& key, bufferlist& bl)
   return control_pool_ctx.notify2(notify_oid, bl, 0, NULL);
 }
 
-int RGWRados::pool_iterate_begin(rgw_bucket& bucket, RGWPoolIterCtx& ctx)
+int RGWRados::pool_iterate_begin(const rgw_pool& pool, RGWPoolIterCtx& ctx)
 {
   librados::IoCtx& io_ctx = ctx.io_ctx;
   librados::NObjectIterator& iter = ctx.iter;
 
-  int r = open_bucket_data_ctx(bucket, io_ctx);
+  int r = open_pool_ctx(pool, io_ctx);
   if (r < 0)
     return r;
 
@@ -11610,7 +11523,7 @@ struct RGWAccessListFilterPrefix : public RGWAccessListFilter {
   }
 };
 
-int RGWRados::list_raw_objects(rgw_bucket& pool, const string& prefix_filter,
+int RGWRados::list_raw_objects(const rgw_pool& pool, const string& prefix_filter,
 			       int max, RGWListRawObjsCtx& ctx, list<string>& oids,
 			       bool *is_truncated)
 {
@@ -11763,15 +11676,15 @@ int RGWRados::trim_bi_log_entries(rgw_bucket& bucket, int shard_id, string& star
 
 int RGWRados::bi_get_instance(rgw_obj& obj, rgw_bucket_dir_entry *dirent)
 {
-  rgw_bucket bucket;
+  rgw_pool pool;
   rgw_rados_ref ref;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  int r = get_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
 
   rgw_cls_bi_entry bi_entry;
-  r = bi_get(bucket, obj, InstanceIdx, &bi_entry);
+  r = bi_get(obj.bucket, obj, InstanceIdx, &bi_entry);
   if (r < 0 && r != -ENOENT) {
     ldout(cct, 0) << "ERROR: bi_get() returned r=" << r << dendl;
   }
@@ -12144,44 +12057,37 @@ int RGWRados::cls_bucket_list(rgw_bucket& bucket, int shard_id, rgw_obj_key& sta
 
 int RGWRados::cls_obj_usage_log_add(const string& oid, rgw_usage_log_info& info)
 {
-  librados::IoCtx io_ctx;
+  rgw_raw_obj obj(get_zone_params().usage_log_pool, oid);
 
-  const char *usage_log_pool = get_zone_params().usage_log_pool.name.c_str();
-  librados::Rados *rad = get_rados_handle();
-  int r = rad->ioctx_create(usage_log_pool, io_ctx);
-  if (r == -ENOENT) {
-    rgw_bucket pool(usage_log_pool);
-    r = create_pool(pool);
-    if (r < 0)
-      return r;
- 
-    // retry
-    r = rad->ioctx_create(usage_log_pool, io_ctx);
-  }
-  if (r < 0)
+  rgw_rados_ref ref;
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
+  if (r < 0) {
     return r;
+  }
 
   ObjectWriteOperation op;
   cls_rgw_usage_log_add(op, info);
 
-  r = io_ctx.operate(oid, &op);
+  r = ref.ioctx.operate(ref.oid, &op);
   return r;
 }
 
 int RGWRados::cls_obj_usage_log_read(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
                                      string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated)
 {
-  librados::IoCtx io_ctx;
+  rgw_raw_obj obj(get_zone_params().usage_log_pool, oid);
+
+  rgw_rados_ref ref;
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
+  if (r < 0) {
+    return r;
+  }
 
   *is_truncated = false;
 
-  const char *usage_log_pool = get_zone_params().usage_log_pool.name.c_str();
-  librados::Rados *rad = get_rados_handle();
-  int r = rad->ioctx_create(usage_log_pool, io_ctx);
-  if (r < 0)
-    return r;
-
-  r = cls_rgw_usage_log_read(io_ctx, oid, user, start_epoch, end_epoch,
+  r = cls_rgw_usage_log_read(ref.ioctx, ref.oid, user, start_epoch, end_epoch,
 			     max_entries, read_iter, usage, is_truncated);
 
   return r;
@@ -12189,18 +12095,19 @@ int RGWRados::cls_obj_usage_log_read(string& oid, string& user, uint64_t start_e
 
 int RGWRados::cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch)
 {
-  librados::IoCtx io_ctx;
+  rgw_raw_obj obj(get_zone_params().usage_log_pool, oid);
 
-  const char *usage_log_pool = get_zone_params().usage_log_pool.name.c_str();
-  librados::Rados *rad = get_rados_handle();
-  int r = rad->ioctx_create(usage_log_pool, io_ctx);
-  if (r < 0)
+  rgw_rados_ref ref;
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
+  if (r < 0) {
     return r;
+  }
 
   ObjectWriteOperation op;
   cls_rgw_usage_log_trim(op, user, start_epoch, end_epoch);
 
-  r = io_ctx.operate(oid, &op);
+  r = ref.ioctx.operate(ref.oid, &op);
   return r;
 }
 
@@ -12257,7 +12164,7 @@ int RGWRados::check_disk_state(librados::IoCtx io_ctx,
   obj.set_loc(list_state.locator);
   obj.set_ns(ns);
   obj.set_instance(key.instance);
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, loc);
+  get_obj_bucket_and_oid_loc(obj, oid, loc);
   io_ctx.locator_set_key(loc);
 
   RGWObjState *astate = NULL;
@@ -12391,11 +12298,11 @@ int RGWRados::cls_user_get_header(const string& user_id, cls_user_header *header
 {
   string buckets_obj_id;
   rgw_get_buckets_obj(user_id, buckets_obj_id);
-  rgw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
+  rgw_raw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -12417,11 +12324,11 @@ int RGWRados::cls_user_get_header_async(const string& user_id, RGWGetUserHeader_
 {
   string buckets_obj_id;
   rgw_get_buckets_obj(user_id, buckets_obj_id);
-  rgw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
+  rgw_raw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
 
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -12433,7 +12340,7 @@ int RGWRados::cls_user_get_header_async(const string& user_id, RGWGetUserHeader_
   return 0;
 }
 
-int RGWRados::cls_user_sync_bucket_stats(rgw_obj& user_obj, rgw_bucket& bucket)
+int RGWRados::cls_user_sync_bucket_stats(rgw_raw_obj& user_obj, rgw_bucket& bucket)
 {
   map<string, struct rgw_bucket_dir_header> headers;
   int r = cls_bucket_head(bucket, RGW_NO_SHARD, headers);
@@ -12482,7 +12389,7 @@ int RGWRados::update_user_bucket_stats(const string& user_id, rgw_bucket& bucket
 
   string buckets_obj_id;
   rgw_get_buckets_obj(user_id, buckets_obj_id);
-  rgw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
+  rgw_raw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
 
   int r = cls_user_update_buckets(obj, entries, false);
   if (r < 0) {
@@ -12493,7 +12400,7 @@ int RGWRados::update_user_bucket_stats(const string& user_id, rgw_bucket& bucket
   return 0;
 }
 
-int RGWRados::cls_user_list_buckets(rgw_obj& obj,
+int RGWRados::cls_user_list_buckets(rgw_raw_obj& obj,
                                     const string& in_marker,
                                     const string& end_marker,
                                     const int max_entries,
@@ -12502,8 +12409,8 @@ int RGWRados::cls_user_list_buckets(rgw_obj& obj,
                                     bool * const truncated)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -12522,11 +12429,11 @@ int RGWRados::cls_user_list_buckets(rgw_obj& obj,
   return 0;
 }
 
-int RGWRados::cls_user_update_buckets(rgw_obj& obj, list<cls_user_bucket_entry>& entries, bool add)
+int RGWRados::cls_user_update_buckets(rgw_raw_obj& obj, list<cls_user_bucket_entry>& entries, bool add)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -12544,15 +12451,15 @@ int RGWRados::complete_sync_user_stats(const rgw_user& user_id)
 {
   string buckets_obj_id;
   rgw_get_buckets_obj(user_id, buckets_obj_id);
-  rgw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
+  rgw_raw_obj obj(get_zone_params().user_uid_pool, buckets_obj_id);
   return cls_user_complete_stats_sync(obj);
 }
 
-int RGWRados::cls_user_complete_stats_sync(rgw_obj& obj)
+int RGWRados::cls_user_complete_stats_sync(rgw_raw_obj& obj)
 {
   rgw_rados_ref ref;
-  rgw_bucket bucket;
-  int r = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int r = get_raw_obj_ref(obj, &ref, &pool);
   if (r < 0) {
     return r;
   }
@@ -12566,7 +12473,7 @@ int RGWRados::cls_user_complete_stats_sync(rgw_obj& obj)
   return 0;
 }
 
-int RGWRados::cls_user_add_bucket(rgw_obj& obj, const cls_user_bucket_entry& entry)
+int RGWRados::cls_user_add_bucket(rgw_raw_obj& obj, const cls_user_bucket_entry& entry)
 {
   list<cls_user_bucket_entry> l;
   l.push_back(entry);
@@ -12574,11 +12481,11 @@ int RGWRados::cls_user_add_bucket(rgw_obj& obj, const cls_user_bucket_entry& ent
   return cls_user_update_buckets(obj, l, true);
 }
 
-int RGWRados::cls_user_remove_bucket(rgw_obj& obj, const cls_user_bucket& bucket)
+int RGWRados::cls_user_remove_bucket(rgw_raw_obj& obj, const cls_user_bucket& bucket)
 {
-  rgw_bucket b;
+  rgw_pool p;
   rgw_rados_ref ref;
-  int r = get_obj_ref(obj, &ref, &b);
+  int r = get_system_obj_ref(obj, &ref, &p);
   if (r < 0) {
     return r;
   }
@@ -13060,7 +12967,8 @@ int RGWRados::delete_obj_aio(rgw_obj& obj, rgw_bucket& bucket,
                              list<librados::AioCompletion *>& handles, bool keep_index_consistent)
 {
   rgw_rados_ref ref;
-  int ret = get_obj_ref(obj, &ref, &bucket);
+  rgw_pool pool;
+  int ret = get_obj_ref(obj, &ref, &pool);
   if (ret < 0) {
     lderr(cct) << "ERROR: failed to get obj ref with ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8907,6 +8907,11 @@ void RGWRados::Object::invalidate_state()
   ctx.obj.invalidate(obj);
 }
 
+void RGWRados::SystemObject::invalidate_state()
+{
+  ctx.raw.invalidate(obj);
+}
+
 int RGWRados::Object::prepare_atomic_modification(ObjectWriteOperation& op, bool reset_obj, const string *ptag,
                                                   const char *if_match, const char *if_nomatch, bool removal_op)
 {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2104,6 +2104,12 @@ public:
   }
 };
 
+template<>
+void RGWObjectCtxImpl<rgw_obj, RGWObjState>::invalidate(rgw_obj& obj);
+
+template<>
+void RGWObjectCtxImpl<rgw_raw_obj, RGWRawObjState>::invalidate(rgw_raw_obj& obj);
+
 struct RGWObjectCtx {
   RGWRados *store;
   void *user_ctx;
@@ -3135,7 +3141,7 @@ public:
 
   int get_system_obj_state(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWRawObjState **state, RGWObjVersionTracker *objv_tracker);
   int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
-                    bool follow_olh, assume_noent = false);
+                    bool follow_olh, bool assume_noent = false);
   int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state) {
     return get_obj_state(rctx, bucket_info, obj, state, true);
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -67,7 +67,7 @@ static inline void prepend_bucket_marker(const rgw_bucket& bucket, const string&
 static inline void get_obj_bucket_and_oid_loc(const rgw_obj& obj, string& oid, string& locator)
 {
   const rgw_bucket& bucket = obj.bucket;
-  prepend_bucket_marker(bucket, obj.get_object(), oid);
+  prepend_bucket_marker(bucket, obj.get_oid(), oid);
   const string& loc = obj.get_loc();
   if (!loc.empty()) {
     prepend_bucket_marker(bucket, loc, locator);
@@ -498,7 +498,7 @@ public:
        * when the explicit objs manifest was around, and it got copied.
        */
       rgw_obj& obj_0 = objs[0].loc;
-      if (!obj_0.get_object().empty() && obj_0.ns.empty()) {
+      if (!obj_0.get_oid().empty() && obj_0.ns.empty()) {
         objs[0].loc = obj;
         objs[0].size = head_size;
       }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2530,6 +2530,8 @@ public:
   public:
     SystemObject(RGWRados *_store, RGWObjectCtx& _ctx, rgw_raw_obj& _obj) : store(_store), ctx(_ctx), obj(_obj), state(NULL) {}
 
+    void invalidate_state();
+
     RGWRados *get_store() { return store; }
     rgw_raw_obj& get_obj() { return obj; }
     RGWObjectCtx& get_ctx() { return ctx; }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2272,7 +2272,7 @@ public:
   }
 
   int get_raw_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref, rgw_pool *pool = NULL);
-  void obj_to_raw(const rgw_obj& obj, rgw_raw_obj *raw_obj);
+  static void obj_to_raw(const rgw_obj& obj, rgw_raw_obj *raw_obj);
 
   int list_raw_objects(const rgw_pool& pool, const string& prefix_filter, int max,
                        RGWListRawObjsCtx& ctx, list<string>& oids,

--- a/src/rgw/rgw_realm_watcher.cc
+++ b/src/rgw/rgw_realm_watcher.cc
@@ -96,8 +96,8 @@ int RGWRealmWatcher::watch_start(RGWRealm& realm)
   }
 
   // open an IoCtx for the realm's pool
-  auto pool = realm.get_pool_name(cct);
-  r = rados.ioctx_create(pool.c_str(), pool_ctx);
+  rgw_pool pool(realm.get_pool(cct));
+  r = rgw_init_ioctx(&rados, pool, pool_ctx);
   if (r < 0) {
     lderr(cct) << "Failed to open pool " << pool
         << " with " << cpp_strerror(-r) << dendl;

--- a/src/rgw/rgw_replica_log.cc
+++ b/src/rgw/rgw_replica_log.cc
@@ -39,7 +39,7 @@ int RGWReplicaLogger::open_ioctx(librados::IoCtx& ctx, const string& pool)
 {
   int r = store->get_rados_handle()->ioctx_create(pool.c_str(), ctx);
   if (r == -ENOENT) {
-    rgw_bucket p(pool.c_str());
+    rgw_pool p(pool);
     r = store->create_pool(p);
     if (r < 0)
       return r;

--- a/src/rgw/rgw_replica_log.cc
+++ b/src/rgw/rgw_replica_log.cc
@@ -35,25 +35,16 @@ void RGWReplicaBounds::decode_json(JSONObj *obj) {
 RGWReplicaLogger::RGWReplicaLogger(RGWRados *_store) :
     cct(_store->cct), store(_store) {}
 
-int RGWReplicaLogger::open_ioctx(librados::IoCtx& ctx, const string& pool)
+int RGWReplicaLogger::open_ioctx(librados::IoCtx& ctx, const rgw_pool& pool)
 {
-  int r = store->get_rados_handle()->ioctx_create(pool.c_str(), ctx);
-  if (r == -ENOENT) {
-    rgw_pool p(pool);
-    r = store->create_pool(p);
-    if (r < 0)
-      return r;
-
-    // retry
-    r = store->get_rados_handle()->ioctx_create(pool.c_str(), ctx);
-  }
+  int r = rgw_init_ioctx(store->get_rados_handle(), pool, ctx, true);
   if (r < 0) {
     lderr(cct) << "ERROR: could not open rados pool " << pool << dendl;
   }
   return r;
 }
 
-int RGWReplicaLogger::update_bound(const string& oid, const string& pool,
+int RGWReplicaLogger::update_bound(const string& oid, const rgw_pool& pool,
                                    const string& daemon_id,
                                    const string& marker, const utime_t& time,
                                    const list<RGWReplicaItemMarker> *entries,
@@ -79,7 +70,7 @@ int RGWReplicaLogger::update_bound(const string& oid, const string& pool,
   return ioctx.operate(oid, &opw);
 }
 
-int RGWReplicaLogger::write_bounds(const string& oid, const string& pool,
+int RGWReplicaLogger::write_bounds(const string& oid, const rgw_pool& pool,
                                    RGWReplicaBounds& bounds)
 {
   librados::IoCtx ioctx;
@@ -103,7 +94,7 @@ int RGWReplicaLogger::write_bounds(const string& oid, const string& pool,
   return 0;
 }
 
-int RGWReplicaLogger::delete_bound(const string& oid, const string& pool,
+int RGWReplicaLogger::delete_bound(const string& oid, const rgw_pool& pool,
                                    const string& daemon_id, bool purge_all,
                                    bool need_to_exist)
 {
@@ -125,7 +116,7 @@ int RGWReplicaLogger::delete_bound(const string& oid, const string& pool,
   return ioctx.operate(oid, &opw);
 }
 
-int RGWReplicaLogger::get_bounds(const string& oid, const string& pool,
+int RGWReplicaLogger::get_bounds(const string& oid, const rgw_pool& pool,
                                  RGWReplicaBounds& bounds)
 {
   librados::IoCtx ioctx;
@@ -139,11 +130,11 @@ int RGWReplicaLogger::get_bounds(const string& oid, const string& pool,
 
 RGWReplicaObjectLogger::
 RGWReplicaObjectLogger(RGWRados *_store,
-                       const string& _pool,
+                       const rgw_pool& _pool,
                        const string& _prefix) : RGWReplicaLogger(_store),
                        pool(_pool), prefix(_prefix) {
   if (pool.empty())
-    store->get_log_pool_name(pool);
+    store->get_log_pool(pool);
 }
 
 int RGWReplicaObjectLogger::create_log_objects(int shards)
@@ -166,7 +157,7 @@ int RGWReplicaObjectLogger::create_log_objects(int shards)
 RGWReplicaBucketLogger::RGWReplicaBucketLogger(RGWRados *_store) :
   RGWReplicaLogger(_store)
 {
-  store->get_log_pool_name(pool);
+  store->get_log_pool(pool);
   prefix = _store->ctx()->_conf->rgw_replica_log_obj_prefix;
   prefix.append(".");
 }

--- a/src/rgw/rgw_replica_log.h
+++ b/src/rgw/rgw_replica_log.h
@@ -43,26 +43,26 @@ class RGWReplicaLogger {
 protected:
   CephContext *cct;
   RGWRados *store;
-  int open_ioctx(librados::IoCtx& ctx, const string& pool);
+  int open_ioctx(librados::IoCtx& ctx, const rgw_pool& pool);
 
   explicit RGWReplicaLogger(RGWRados *_store);
 
-  int update_bound(const string& oid, const string& pool,
+  int update_bound(const string& oid, const rgw_pool& pool,
                    const string& daemon_id, const string& marker,
                    const utime_t& time,
                    const list<RGWReplicaItemMarker> *entries,
                    bool need_to_exist);
-  int write_bounds(const string& oid, const string& pool,
+  int write_bounds(const string& oid, const rgw_pool& pool,
                  RGWReplicaBounds& bounds);
-  int delete_bound(const string& oid, const string& pool,
+  int delete_bound(const string& oid, const rgw_pool& pool,
                    const string& daemon_id, bool purge_all,
                    bool need_to_exist);
-  int get_bounds(const string& oid, const string& pool,
+  int get_bounds(const string& oid, const rgw_pool& pool,
                  RGWReplicaBounds& bounds);
 };
 
 class RGWReplicaObjectLogger : private RGWReplicaLogger {
-  string pool;
+  rgw_pool pool;
   string prefix;
 
   void get_shard_oid(int id, string& oid) {
@@ -73,7 +73,7 @@ class RGWReplicaObjectLogger : private RGWReplicaLogger {
 
 public:
   RGWReplicaObjectLogger(RGWRados *_store,
-                const string& _pool,
+                const rgw_pool& _pool,
                 const string& _prefix);
 
   int create_log_objects(int shards);
@@ -99,7 +99,7 @@ public:
 };
 
 class RGWReplicaBucketLogger : private RGWReplicaLogger {
-  string pool;
+  rgw_pool pool;
   string prefix;
 
   string obj_name(const rgw_bucket& bucket, int shard_id, bool index_by_instance);

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -576,7 +576,7 @@ void dump_time(struct req_state *s, const char *name, real_time *t)
   s->formatter->dump_string(name, buf);
 }
 
-void dump_owner(struct req_state *s, rgw_user& id, string& name,
+void dump_owner(struct req_state *s, const rgw_user& id, string& name,
 		const char *section)
 {
   if (!section)

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -562,7 +562,7 @@ extern void end_header(struct req_state *s,
 		       bool force_no_error = false);
 extern void dump_start(struct req_state *s);
 extern void list_all_buckets_start(struct req_state *s);
-extern void dump_owner(struct req_state *s, rgw_user& id, string& name,
+extern void dump_owner(struct req_state *s, const rgw_user& id, string& name,
 		       const char *section = NULL);
 extern void dump_header(struct req_state* s,
                         const boost::string_ref& name,

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -428,7 +428,7 @@ static void add_grants_headers(map<int, string>& grants, map<string, string, lts
 
 int RGWRESTStreamWriteRequest::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uint64_t obj_size, map<string, bufferlist>& attrs)
 {
-  string resource = obj.bucket.name + "/" + obj.get_object();
+  string resource = obj.bucket.name + "/" + obj.get_oid();
   string new_url = url;
   if (new_url[new_url.size() - 1] != '/')
     new_url.append("/");
@@ -619,7 +619,7 @@ int RGWRESTStreamRWRequest::get_obj(RGWAccessKey& key, map<string, string>& extr
 {
   string urlsafe_bucket, urlsafe_object;
   url_encode(obj.bucket.get_key(':', 0), urlsafe_bucket);
-  url_encode(obj.get_orig_obj(), urlsafe_object);
+  url_encode(obj.get_name(), urlsafe_object);
   string resource = urlsafe_bucket + "/" + urlsafe_object;
 
   return get_resource(key, extra_headers, resource);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -619,7 +619,7 @@ int RGWRESTStreamRWRequest::get_obj(RGWAccessKey& key, map<string, string>& extr
 {
   string urlsafe_bucket, urlsafe_object;
   url_encode(obj.bucket.get_key(':', 0), urlsafe_bucket);
-  url_encode(obj.get_name(), urlsafe_object);
+  url_encode(obj.key.name, urlsafe_object);
   string resource = urlsafe_bucket + "/" + urlsafe_object;
 
   return get_resource(key, extra_headers, resource);

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -144,8 +144,8 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw
   if (rgwx_stat) {
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "stat", "true"));
   }
-  if (!obj.get_instance().empty()) {
-    const string& instance = obj.get_instance();
+  if (!obj.key.instance.empty()) {
+    const string& instance = obj.key.instance;
     params.push_back(param_pair_t("versionId", instance));
   }
   if (get_op) {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -414,7 +414,7 @@ void RGWOp_BILog_List::execute() {
   send_response();
   do {
     list<rgw_bi_log_entry> entries;
-    int ret = store->list_bi_log_entries(bucket_info.bucket, shard_id,
+    int ret = store->list_bi_log_entries(bucket_info, shard_id,
                                           marker, max_entries - count, 
                                           entries, &truncated);
     if (ret < 0) {
@@ -496,7 +496,7 @@ void RGWOp_BILog_Info::execute() {
     }
   }
   map<RGWObjCategory, RGWStorageStats> stats;
-  int ret =  store->get_bucket_stats(bucket_info.bucket, shard_id, &bucket_ver, &master_ver, stats, &max_marker);
+  int ret =  store->get_bucket_stats(bucket_info, shard_id, &bucket_ver, &master_ver, stats, &max_marker);
   if (ret < 0 && ret != -ENOENT) {
     http_ret = ret;
     return;
@@ -558,7 +558,7 @@ void RGWOp_BILog_Delete::execute() {
       return;
     }
   }
-  http_ret = store->trim_bi_log_entries(bucket_info.bucket, shard_id, start_marker, end_marker);
+  http_ret = store->trim_bi_log_entries(bucket_info, shard_id, start_marker, end_marker);
   if (http_ret < 0) {
     dout(5) << "ERROR: trim_bi_log_entries() " << dendl;
   }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2921,9 +2921,9 @@ void RGWGetObjLayout_ObjStore_S3::send_response()
   f.open_array_section("data_location");
   for (auto miter = manifest->obj_begin(); miter != manifest->obj_end(); ++miter) {
     f.open_object_section("obj");
-    rgw_obj loc = miter.get_location();
+    rgw_raw_obj raw_loc = miter.get_location().get_raw_obj(store);
     ::encode_json("ofs", miter.get_ofs(), &f);
-    ::encode_json("loc", loc, &f);
+    ::encode_json("loc", raw_loc, &f);
     ::encode_json("loc_ofs", miter.location_ofs(), &f);
     ::encode_json("loc_size", miter.get_stripe_size(), &f);
     f.close_section();

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -271,7 +271,7 @@ static void dump_container_metadata(struct req_state *,
 
 void RGWListBucket_ObjStore_SWIFT::send_response()
 {
-  vector<RGWObjEnt>::iterator iter = objs.begin();
+  vector<rgw_bucket_dir_entry>::iterator iter = objs.begin();
   map<string, bool>::iterator pref_iter = common_prefixes.begin();
 
   dump_start(s);
@@ -283,7 +283,7 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
   while (iter != objs.end() || pref_iter != common_prefixes.end()) {
     bool do_pref = false;
     bool do_objs = false;
-    rgw_obj_key& key = iter->key;
+    rgw_obj_key key(iter->key);
     if (pref_iter == common_prefixes.end())
       do_objs = true;
     else if (iter == objs.end())
@@ -302,12 +302,12 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
 
       s->formatter->open_object_section("object");
       s->formatter->dump_string("name", key.name);
-      s->formatter->dump_string("hash", iter->etag);
-      s->formatter->dump_int("bytes", iter->accounted_size);
-      string single_content_type = iter->content_type;
-      if (iter->content_type.size()) {
+      s->formatter->dump_string("hash", iter->meta.etag);
+      s->formatter->dump_int("bytes", iter->meta.accounted_size);
+      string single_content_type = iter->meta.content_type;
+      if (iter->meta.content_type.size()) {
         // content type might hold multiple values, just dump the last one
-        ssize_t pos = iter->content_type.rfind(',');
+        ssize_t pos = iter->meta.content_type.rfind(',');
         if (pos > 0) {
           ++pos;
           while (single_content_type[pos] == ' ')
@@ -316,7 +316,7 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
         }
         s->formatter->dump_string("content_type", single_content_type);
       }
-      dump_time(s, "last_modified", &iter->mtime);
+      dump_time(s, "last_modified", &iter->meta.mtime);
       s->formatter->close_section();
     }
 
@@ -1775,7 +1775,7 @@ RGWOp* RGWSwiftWebsiteHandler::get_ws_listing_op()
         htmler.dump_subdir(subdir_name);
       }
 
-      for (const RGWObjEnt& obj : objs) {
+      for (const rgw_bucket_dir_entry& obj : objs) {
         if (! common_prefixes.count(obj.key.name + '/')) {
           htmler.dump_object(obj);
         }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1814,7 +1814,8 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
 
   /* First, get attrset of the object we'll try to retrieve. */
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
-  obj_ctx.set_atomic(obj);
+  obj_ctx.obj.set_atomic(obj);
+  obj_ctx.obj.set_prefetch_data(obj);
 
   RGWObjState* state = nullptr;
   if (store->get_obj_state(&obj_ctx, obj, &state, false) < 0) {
@@ -1843,7 +1844,8 @@ bool RGWSwiftWebsiteHandler::is_index_present(const std::string& index)
   rgw_obj obj(s->bucket, index);
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);
-  obj_ctx.set_atomic(obj);
+  obj_ctx.obj.set_atomic(obj);
+  obj_ctx.obj.set_prefetch_data(obj);
 
   RGWObjState* state = nullptr;
   if (store->get_obj_state(&obj_ctx, obj, &state, false) < 0) {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1818,7 +1818,7 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
   obj_ctx.obj.set_prefetch_data(obj);
 
   RGWObjState* state = nullptr;
-  if (store->get_obj_state(&obj_ctx, obj, &state, false) < 0) {
+  if (store->get_obj_state(&obj_ctx, s->bucket_info, obj, &state, false) < 0) {
     return false;
   }
 
@@ -1848,7 +1848,7 @@ bool RGWSwiftWebsiteHandler::is_index_present(const std::string& index)
   obj_ctx.obj.set_prefetch_data(obj);
 
   RGWObjState* state = nullptr;
-  if (store->get_obj_state(&obj_ctx, obj, &state, false) < 0) {
+  if (store->get_obj_state(&obj_ctx, s->bucket_info, obj, &state, false) < 0) {
     return false;
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -283,15 +283,18 @@ void RGWListBucket_ObjStore_SWIFT::send_response()
   while (iter != objs.end() || pref_iter != common_prefixes.end()) {
     bool do_pref = false;
     bool do_objs = false;
-    rgw_obj_key key(iter->key);
+    rgw_obj_key key;
+    if (iter != objs.end()) {
+      key = iter->key;
+    }
     if (pref_iter == common_prefixes.end())
       do_objs = true;
     else if (iter == objs.end())
       do_pref = true;
-    else if (key.name.compare(pref_iter->first) == 0) {
+    else if (!key.empty() && key.name.compare(pref_iter->first) == 0) {
       do_objs = true;
       ++pref_iter;
-    } else if (key.name.compare(pref_iter->first) <= 0)
+    } else if (!key.empty() && key.name.compare(pref_iter->first) <= 0)
       do_objs = true;
     else
       do_pref = true;

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -306,11 +306,9 @@ int RGWMetaSyncStatusManager::init()
     return -EIO;
   }
 
-  const char *log_pool = store->get_zone_params().log_pool.name.c_str();
-  librados::Rados *rados = store->get_rados_handle();
-  int r = rados->ioctx_create(log_pool, ioctx);
+  int r = rgw_init_ioctx(store->get_rados_handle(), store->get_zone_params().log_pool, ioctx, true);
   if (r < 0) {
-    lderr(store->ctx()) << "ERROR: failed to open log pool (" << store->get_zone_params().log_pool.name << " ret=" << r << dendl;
+    lderr(store->ctx()) << "ERROR: failed to open log pool (" << store->get_zone_params().log_pool << " ret=" << r << dendl;
     return r;
   }
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -331,7 +331,7 @@ int RGWMetaSyncStatusManager::init()
   int num_shards = master_log.get_sync_status().sync_info.num_shards;
 
   for (int i = 0; i < num_shards; i++) {
-    shard_objs[i] = rgw_obj(store->get_zone_params().log_pool, sync_env.shard_obj_name(i));
+    shard_objs[i] = rgw_raw_obj(store->get_zone_params().log_pool, sync_env.shard_obj_name(i));
   }
 
   RWLock::WLocker wl(ts_to_shard_lock);
@@ -616,7 +616,8 @@ public:
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
         RGWRados *store = sync_env->store;
-	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store, store->get_zone_params().log_pool, sync_env->status_oid(),
+	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store,
+                                            rgw_raw_obj(store->get_zone_params().log_pool, sync_env->status_oid()),
                                             lock_name, lock_duration, this);
         lease_cr->get();
         lease_stack = spawn(lease_cr, false);
@@ -633,8 +634,9 @@ public:
       yield {
         set_status("writing sync status");
         RGWRados *store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				 sync_env->status_oid(), status));
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store,
+                                                           rgw_raw_obj(store->get_zone_params().log_pool, sync_env->status_oid()),
+                                                           status));
       }
 
       if (retcode < 0) {
@@ -662,16 +664,19 @@ public:
 	  marker.next_step_marker = info.marker;
 	  marker.timestamp = info.last_update;
           RGWRados *store = sync_env->store;
-          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				                          sync_env->shard_obj_name(i), marker), true);
+          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
+                                                                store,
+                                                                rgw_raw_obj(store->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
+                                                                marker), true);
         }
       }
       yield {
         set_status("changing sync state: build full sync maps");
 	status.state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
         RGWRados *store = sync_env->store;
-        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				 sync_env->status_oid(), status));
+        call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados, store,
+                                                           rgw_raw_obj(store->get_zone_params().log_pool, sync_env->status_oid()),
+                                                           status));
       }
       set_status("drop lock lease");
       yield lease_cr->go_down();
@@ -696,8 +701,7 @@ class RGWReadSyncStatusCoroutine : public RGWSimpleRadosReadCR<rgw_meta_sync_inf
 public:
   RGWReadSyncStatusCoroutine(RGWMetaSyncEnv *_sync_env,
 		      rgw_meta_sync_status *_status) : RGWSimpleRadosReadCR(_sync_env->async_rados, _sync_env->store,
-									    _sync_env->store->get_zone_params().log_pool,
-									    _sync_env->status_oid(),
+									    rgw_raw_obj(_sync_env->store->get_zone_params().log_pool, _sync_env->status_oid()),
 									    &_status->sync_info),
                                                                             sync_env(_sync_env),
 									    sync_status(_status) {
@@ -716,8 +720,9 @@ int RGWReadSyncStatusCoroutine::handle_data(rgw_meta_sync_info& data)
   RGWRados *store = sync_env->store;
   map<uint32_t, rgw_meta_sync_marker>& markers = sync_status->sync_markers;
   for (int i = 0; i < (int)data.num_shards; i++) {
-    spawn(new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				                    sync_env->shard_obj_name(i), &markers[i]), true);
+    spawn(new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store,
+                                                         rgw_raw_obj(store->get_zone_params().log_pool, sync_env->shard_obj_name(i)),
+                                                         &markers[i]), true);
   }
   return 0;
 }
@@ -791,7 +796,9 @@ public:
         set_status(string("acquiring lock (") + sync_env->status_oid() + ")");
 	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
         string lock_name = "sync_lock";
-	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, sync_env->store, sync_env->store->get_zone_params().log_pool, sync_env->status_oid(),
+	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados,
+                                            sync_env->store,
+                                            rgw_raw_obj(sync_env->store->get_zone_params().log_pool, sync_env->status_oid()),
                                             lock_name, lock_duration, this);
         lease_cr->get();
         lease_stack = spawn(lease_cr, false);
@@ -870,8 +877,9 @@ public:
           int shard_id = (int)iter->first;
           rgw_meta_sync_marker& marker = iter->second;
           marker.total_entries = entries_index->get_total_entries(shard_id);
-          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, sync_env->store, sync_env->store->get_zone_params().log_pool,
-                                                                sync_env->shard_obj_name(shard_id), marker), true);
+          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, sync_env->store,
+                                                                rgw_raw_obj(sync_env->store->get_zone_params().log_pool, sync_env->shard_obj_name(shard_id)),
+                                                                marker), true);
         }
       }
 
@@ -1101,8 +1109,10 @@ public:
 
     ldout(sync_env->cct, 20) << __func__ << "(): updating marker marker_oid=" << marker_oid << " marker=" << new_marker << dendl;
     RGWRados *store = sync_env->store;
-    return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				 marker_oid, sync_marker);
+    return new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados,
+                                                           store,
+                                                           rgw_raw_obj(store->get_zone_params().log_pool, marker_oid),
+                                                           sync_marker);
   }
 };
 
@@ -1236,7 +1246,7 @@ public:
 class RGWMetaSyncShardCR : public RGWCoroutine {
   RGWMetaSyncEnv *sync_env;
 
-  const rgw_bucket& pool;
+  const rgw_pool& pool;
   const std::string& period; //< currently syncing period id
   RGWMetadataLog* mdlog; //< log of syncing period
   uint32_t shard_id;
@@ -1284,7 +1294,7 @@ class RGWMetaSyncShardCR : public RGWCoroutine {
   int total_entries = 0;
 
 public:
-  RGWMetaSyncShardCR(RGWMetaSyncEnv *_sync_env, const rgw_bucket& _pool,
+  RGWMetaSyncShardCR(RGWMetaSyncEnv *_sync_env, const rgw_pool& _pool,
                      const std::string& period, RGWMetadataLog* mdlog,
                      uint32_t _shard_id, rgw_meta_sync_marker& _marker,
                      const std::string& period_marker, bool *_reset_backoff)
@@ -1395,8 +1405,8 @@ public:
           lease_cr->put();
         }
         RGWRados *store = sync_env->store;
-	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store, pool,
-                                            sync_env->shard_obj_name(shard_id),
+	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store,
+                                            rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                             lock_name, lock_duration, this);
         lease_cr->get();
         lease_stack = spawn(lease_cr, false);
@@ -1430,7 +1440,8 @@ public:
           lost_lock = true;
           break;
         }
-        yield call(new RGWRadosGetOmapKeysCR(sync_env->store, pool, oid, marker, &entries, max_entries));
+        yield call(new RGWRadosGetOmapKeysCR(sync_env->store, rgw_raw_obj(pool, oid),
+                                             marker, &entries, max_entries));
         if (retcode < 0) {
           ldout(sync_env->cct, 0) << "ERROR: " << __func__ << "(): RGWRadosGetOmapKeysCR() returned ret=" << retcode << dendl;
           yield lease_cr->go_down();
@@ -1475,8 +1486,8 @@ public:
 
 	  using WriteMarkerCR = RGWSimpleRadosWriteCR<rgw_meta_sync_marker>;
 	  yield call(new WriteMarkerCR(sync_env->async_rados, sync_env->store,
-				       pool, sync_env->shard_obj_name(shard_id),
-				       *temp_marker));
+				       rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
+				       sync_marker));
         }
 
         if (retcode < 0) {
@@ -1525,8 +1536,8 @@ public:
           uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
           string lock_name = "sync_lock";
           RGWRados *store = sync_env->store;
-          lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store, pool,
-                                              sync_env->shard_obj_name(shard_id),
+          lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, store,
+                                              rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
                                               lock_name, lock_duration, this);
           lease_cr->get();
           lease_stack = spawn(lease_cr, false);
@@ -1658,7 +1669,7 @@ class RGWMetaSyncShardControlCR : public RGWBackoffControlCR
 {
   RGWMetaSyncEnv *sync_env;
 
-  const rgw_bucket& pool;
+  const rgw_pool& pool;
   const std::string& period;
   RGWMetadataLog* mdlog;
   uint32_t shard_id;
@@ -1667,7 +1678,7 @@ class RGWMetaSyncShardControlCR : public RGWBackoffControlCR
 
   static constexpr bool exit_on_error = false; // retry on all errors
 public:
-  RGWMetaSyncShardControlCR(RGWMetaSyncEnv *_sync_env, const rgw_bucket& _pool,
+  RGWMetaSyncShardControlCR(RGWMetaSyncEnv *_sync_env, const rgw_pool& _pool,
                             const std::string& period, RGWMetadataLog* mdlog,
                             uint32_t _shard_id, const rgw_meta_sync_marker& _marker,
                             std::string&& period_marker)
@@ -1682,14 +1693,15 @@ public:
 
   RGWCoroutine *alloc_finisher_cr() override {
     RGWRados *store = sync_env->store;
-    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store, pool,
-                                                               sync_env->shard_obj_name(shard_id), &sync_marker);
+    return new RGWSimpleRadosReadCR<rgw_meta_sync_marker>(sync_env->async_rados, store,
+                                                          rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
+                                                          &sync_marker);
   }
 };
 
 class RGWMetaSyncCR : public RGWCoroutine {
   RGWMetaSyncEnv *sync_env;
-  const rgw_bucket& pool;
+  const rgw_pool& pool;
   RGWPeriodHistory::Cursor cursor; //< sync position in period history
   RGWPeriodHistory::Cursor next; //< next period in history
   rgw_meta_sync_status sync_status;
@@ -1786,8 +1798,8 @@ public:
         sync_status.sync_info.period = cursor.get_period().get_id();
         sync_status.sync_info.realm_epoch = cursor.get_epoch();
         yield call(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(sync_env->async_rados,
-                                                                 sync_env->store, pool,
-                                                                 sync_env->status_oid(),
+                                                                 sync_env->store,
+                                                                 rgw_raw_obj(pool, sync_env->status_oid()),
                                                                  sync_status.sync_info));
       }
     }
@@ -1849,8 +1861,9 @@ int RGWRemoteMetaLog::init_sync_status()
 
 int RGWRemoteMetaLog::store_sync_info()
 {
-  return run(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(async_rados, store, store->get_zone_params().log_pool,
-				 sync_env.status_oid(), sync_status.sync_info));
+  return run(new RGWSimpleRadosWriteCR<rgw_meta_sync_info>(async_rados, store,
+                                                           rgw_raw_obj(store->get_zone_params().log_pool, sync_env.status_oid()),
+                                                           sync_status.sync_info));
 }
 
 // return a cursor to the period at our sync position

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -232,7 +232,7 @@ class RGWMetaSyncStatusManager {
 
   RGWRemoteMetaLog master_log;
 
-  map<int, rgw_obj> shard_objs;
+  map<int, rgw_raw_obj> shard_objs;
 
   struct utime_shard {
     real_time ts;

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -91,10 +91,10 @@ int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_pool& pool
   return 0;
 }
 
-int rgw_delete_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid,
+int rgw_delete_system_obj(RGWRados *rgwstore, rgw_pool& pool, const string& oid,
                           RGWObjVersionTracker *objv_tracker)
 {
-  rgw_obj obj(bucket, oid);
+  rgw_raw_obj obj(pool, oid);
   return rgwstore->delete_system_obj(obj, objv_tracker);
 }
 

--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -18,19 +18,19 @@
 
 static std::map<std::string, std::string>* ext_mime_map;
 
-int rgw_put_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid, const char *data, size_t size, bool exclusive,
+int rgw_put_system_obj(RGWRados *rgwstore, rgw_pool& pool, const string& oid, const char *data, size_t size, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs)
 {
   map<string,bufferlist> no_attrs;
   if (!pattrs)
     pattrs = &no_attrs;
 
-  rgw_obj obj(bucket, oid);
+  rgw_raw_obj obj(pool, oid);
 
   int ret = rgwstore->put_system_obj(NULL, obj, data, size, exclusive, NULL, *pattrs, objv_tracker, set_mtime);
 
   if (ret == -ENOENT) {
-    ret = rgwstore->create_pool(bucket);
+    ret = rgwstore->create_pool(pool);
     if (ret >= 0)
       ret = rgwstore->put_system_obj(NULL, obj, data, size, exclusive, NULL, *pattrs, objv_tracker, set_mtime);
   }
@@ -38,14 +38,14 @@ int rgw_put_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid
   return ret;
 }
 
-int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_bucket& bucket, const string& key, bufferlist& bl,
+int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_pool& pool, const string& key, bufferlist& bl,
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime, map<string, bufferlist> *pattrs,
                        rgw_cache_entry_info *cache_info)
 {
   struct rgw_err err;
   bufferlist::iterator iter;
   int request_len = READ_CHUNK_LEN;
-  rgw_obj obj(bucket, key);
+  rgw_raw_obj obj(pool, key);
 
   do {
     RGWRados::SystemObject source(rgwstore, obj_ctx, obj);

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -21,7 +21,7 @@ int rgw_put_system_obj(RGWRados *rgwstore, rgw_pool& pool, const string& oid, co
 int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_pool& pool, const string& key, bufferlist& bl,
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime, map<string, bufferlist> *pattrs = NULL,
                        rgw_cache_entry_info *cache_info = NULL);
-int rgw_delete_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid,
+int rgw_delete_system_obj(RGWRados *rgwstore, rgw_pool& pool, const string& oid,
                           RGWObjVersionTracker *objv_tracker);
 
 int rgw_tools_init(CephContext *cct);

--- a/src/rgw/rgw_tools.h
+++ b/src/rgw/rgw_tools.h
@@ -16,9 +16,9 @@ struct RGWObjVersionTracker;
 
 struct obj_version;
 
-int rgw_put_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid, const char *data, size_t size, bool exclusive,
+int rgw_put_system_obj(RGWRados *rgwstore, rgw_pool& pool, const string& oid, const char *data, size_t size, bool exclusive,
                        RGWObjVersionTracker *objv_tracker, real_time set_mtime, map<string, bufferlist> *pattrs = NULL);
-int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_bucket& bucket, const string& key, bufferlist& bl,
+int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_pool& pool, const string& key, bufferlist& bl,
                        RGWObjVersionTracker *objv_tracker, real_time *pmtime, map<string, bufferlist> *pattrs = NULL,
                        rgw_cache_entry_info *cache_info = NULL);
 int rgw_delete_system_obj(RGWRados *rgwstore, rgw_bucket& bucket, const string& oid,

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -58,10 +58,9 @@ void seed::get_torrent_file(int &op_ret, RGWRados::Object::Read &read_op, uint64
   }
 
   string oid, key;
-  rgw_bucket bucket;
   map<string, bufferlist> m;
   set<string> obj_key;
-  get_obj_bucket_and_oid_loc(obj, bucket, oid, key);
+  get_obj_bucket_and_oid_loc(obj, oid, key);
   ldout(s->cct, 0) << "NOTICE: head obj oid= " << oid << dendl;
 
   obj_key.insert(RGW_OBJ_TORRENT);
@@ -268,7 +267,10 @@ int seed::save_torrent_file()
   string key = RGW_OBJ_TORRENT;
   rgw_obj obj(s->bucket, s->object.name);    
 
-  op_ret = store->omap_set(obj, key, bl);
+  rgw_raw_obj raw_obj;
+  store->obj_to_raw(obj, &raw_obj);
+
+  op_ret = store->omap_set(raw_obj, key, bl);
   if (op_ret < 0)
   {
     ldout(s->cct, 0) << "ERROR: failed to omap_set() op_ret = " << op_ret << dendl;

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -268,7 +268,7 @@ int seed::save_torrent_file()
   rgw_obj obj(s->bucket, s->object.name);    
 
   rgw_raw_obj raw_obj;
-  store->obj_to_raw(obj, &raw_obj);
+  store->obj_to_raw(s->bucket_info.placement_rule, obj, &raw_obj);
 
   op_ret = store->omap_set(raw_obj, key, bl);
   if (op_ret < 0)

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -20,6 +20,10 @@ add_executable(unittest_http_manager test_http_manager.cc)
 add_ceph_unittest(unittest_http_manager ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_http_manager)
 target_link_libraries(unittest_http_manager rgw_a)
 
+set(test_rgw_a_src
+  test_rgw_common.cc)
+add_library(test_rgw_a STATIC ${test_rgw_a_src})
+
 # ceph_test_rgw_manifest
 set(test_rgw_manifest_srcs test_rgw_manifest.cc)
 add_executable(ceph_test_rgw_manifest
@@ -27,6 +31,7 @@ add_executable(ceph_test_rgw_manifest
   )
 target_link_libraries(ceph_test_rgw_manifest
   rgw_a
+  test_rgw_a
   cls_rgw_client
   cls_lock_client
   cls_refcount_client
@@ -55,6 +60,7 @@ add_executable(ceph_test_rgw_obj
   )
 target_link_libraries(ceph_test_rgw_obj
   rgw_a
+  test_rgw_a
   cls_rgw_client
   cls_lock_client
   cls_refcount_client

--- a/src/test/rgw/test_rgw_common.cc
+++ b/src/test/rgw/test_rgw_common.cc
@@ -1,0 +1,89 @@
+#include "test_rgw_common.h"
+
+void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params, const std::string& name, bool is_default)
+{
+  zonegroup->placement_targets[name] = { name };
+
+  RGWZonePlacementInfo& pinfo = zone_params->placement_pools[name];
+  pinfo.index_pool = rgw_pool(name + ".index").to_str();
+  pinfo.data_pool = rgw_pool(name + ".data").to_str();
+  pinfo.data_extra_pool = rgw_pool(name + ".extra").to_str();
+  
+  if (is_default) {
+    zonegroup->default_placement = name;
+  }
+}
+
+void test_rgw_init_env(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params)
+{
+  test_rgw_add_placement(zonegroup, zone_params, "default-placement", true);
+
+}
+
+void test_rgw_populate_explicit_placement_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+  b->explicit_placement.data_pool = rgw_pool(dp);
+  b->explicit_placement.index_pool = rgw_pool(ip);
+}
+
+void test_rgw_populate_old_bucket(old_rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+  b->data_pool = dp;
+  b->index_pool = ip;
+}
+
+std::string test_rgw_get_obj_oid(const rgw_obj& obj)
+{
+  std::string oid;
+  std::string loc;
+
+  get_obj_bucket_and_oid_loc(obj, oid, loc);
+  return oid;
+}
+
+void test_rgw_init_explicit_placement_bucket(rgw_bucket *bucket, const char *name)
+{
+  test_rgw_populate_explicit_placement_bucket(bucket, "", name, ".data-pool", ".index-pool", "marker", "bucket-id");
+}
+
+void test_rgw_init_old_bucket(old_rgw_bucket *bucket, const char *name)
+{
+  test_rgw_populate_old_bucket(bucket, "", name, ".data-pool", ".index-pool", "marker", "bucket-id");
+}
+
+void test_rgw_populate_bucket(rgw_bucket *b, const char *t, const char *n, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+}
+
+void test_rgw_init_bucket(rgw_bucket *bucket, const char *name)
+{
+  test_rgw_populate_bucket(bucket, "", name, "marker", "bucket-id");
+}
+
+rgw_obj test_rgw_create_obj(const rgw_bucket& bucket, const std::string& name, const std::string& instance, const std::string& ns)
+{
+  rgw_obj obj(bucket, name);
+  if (!instance.empty()) {
+    obj.key.set_instance(instance);
+  }
+  if (!ns.empty()) {
+    obj.key.ns = ns;
+  }
+  obj.bucket = bucket;
+
+  return obj;
+}
+
+

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -1,0 +1,505 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2013 eNovance SAS <licensing@enovance.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#include <iostream>
+#include "common/ceph_json.h"
+#include "common/Formatter.h"
+#include "rgw/rgw_common.h"
+#include "rgw/rgw_rados.h"
+
+#ifndef CEPH_TEST_RGW_COMMON_H
+#define CEPH_TEST_RGW_COMMON_H
+
+struct old_rgw_bucket {
+  std::string tenant;
+  std::string name;
+  std::string data_pool;
+  std::string data_extra_pool; /* if not set, then we should use data_pool instead */
+  std::string index_pool;
+  std::string marker;
+  std::string bucket_id;
+
+  std::string oid; /*
+                    * runtime in-memory only info. If not empty, points to the bucket instance object
+                    */
+
+  old_rgw_bucket() { }
+  // cppcheck-suppress noExplicitConstructor
+  old_rgw_bucket(const std::string& s) : name(s) {
+    data_pool = index_pool = s;
+    marker = "";
+  }
+  old_rgw_bucket(const char *n) : name(n) {
+    data_pool = index_pool = n;
+    marker = "";
+  }
+  old_rgw_bucket(const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id, const char *h) :
+    tenant(t), name(n), data_pool(dp), index_pool(ip), marker(m), bucket_id(id) {}
+
+  void encode(bufferlist& bl) const {
+     ENCODE_START(8, 3, bl);
+    ::encode(name, bl);
+    ::encode(data_pool, bl);
+    ::encode(marker, bl);
+    ::encode(bucket_id, bl);
+    ::encode(index_pool, bl);
+    ::encode(data_extra_pool, bl);
+    ::encode(tenant, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START_LEGACY_COMPAT_LEN(8, 3, 3, bl);
+    ::decode(name, bl);
+    ::decode(data_pool, bl);
+    if (struct_v >= 2) {
+      ::decode(marker, bl);
+      if (struct_v <= 3) {
+        uint64_t id;
+        ::decode(id, bl);
+        char buf[16];
+        snprintf(buf, sizeof(buf), "%llu", (long long)id);
+        bucket_id = buf;
+      } else {
+        ::decode(bucket_id, bl);
+      }
+    }
+    if (struct_v >= 5) {
+      ::decode(index_pool, bl);
+    } else {
+      index_pool = data_pool;
+    }
+    if (struct_v >= 7) {
+      ::decode(data_extra_pool, bl);
+    }
+    if (struct_v >= 8) {
+      ::decode(tenant, bl);
+    }
+    DECODE_FINISH(bl);
+  }
+
+  // format a key for the bucket/instance. pass delim=0 to skip a field
+  std::string get_key(char tenant_delim = '/',
+                      char id_delim = ':') const;
+
+  const std::string& get_data_extra_pool() {
+    if (data_extra_pool.empty()) {
+      return data_pool;
+    }
+    return data_extra_pool;
+  }
+
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
+  static void generate_test_instances(list<old_rgw_bucket*>& o);
+
+  bool operator<(const old_rgw_bucket& b) const {
+    return name.compare(b.name) < 0;
+  }
+};
+WRITE_CLASS_ENCODER(old_rgw_bucket)
+
+class old_rgw_obj {
+  std::string orig_obj;
+  std::string loc;
+  std::string object;
+  std::string instance;
+public:
+  const std::string& get_object() const { return object; }
+  const std::string& get_orig_obj() const { return orig_obj; }
+  const std::string& get_loc() const { return loc; }
+  const std::string& get_instance() const { return instance; }
+  old_rgw_bucket bucket;
+  std::string ns;
+
+  bool in_extra_data; /* in-memory only member, does not serialize */
+
+  // Represents the hash index source for this object once it is set (non-empty)
+  std::string index_hash_source;
+
+  old_rgw_obj() : in_extra_data(false) {}
+  old_rgw_obj(old_rgw_bucket& b, const std::string& o) : in_extra_data(false) {
+    init(b, o);
+  }
+  old_rgw_obj(old_rgw_bucket& b, const rgw_obj_key& k) : in_extra_data(false) {
+    from_index_key(b, k);
+  }
+  void init(old_rgw_bucket& b, const std::string& o) {
+    bucket = b;
+    set_obj(o);
+    reset_loc();
+  }
+  void init_ns(old_rgw_bucket& b, const std::string& o, const std::string& n) {
+    bucket = b;
+    set_ns(n);
+    set_obj(o);
+    reset_loc();
+  }
+  int set_ns(const char *n) {
+    if (!n)
+      return -EINVAL;
+    std::string ns_str(n);
+    return set_ns(ns_str);
+  }
+  int set_ns(const std::string& n) {
+    if (n[0] == '_')
+      return -EINVAL;
+    ns = n;
+    set_obj(orig_obj);
+    return 0;
+  }
+  int set_instance(const std::string& i) {
+    if (i[0] == '_')
+      return -EINVAL;
+    instance = i;
+    set_obj(orig_obj);
+    return 0;
+  }
+
+  int clear_instance() {
+    return set_instance(string());
+  }
+
+  void set_loc(const std::string& k) {
+    loc = k;
+  }
+
+  void reset_loc() {
+    loc.clear();
+    /*
+     * For backward compatibility. Older versions used to have object locator on all objects,
+     * however, the orig_obj was the effective object locator. This had the same effect as not
+     * having object locator at all for most objects but the ones that started with underscore as
+     * these were escaped.
+     */
+    if (orig_obj[0] == '_' && ns.empty()) {
+      loc = orig_obj;
+    }
+  }
+
+  bool have_null_instance() {
+    return instance == "null";
+  }
+
+  bool have_instance() {
+    return !instance.empty();
+  }
+
+  bool need_to_encode_instance() {
+    return have_instance() && !have_null_instance();
+  }
+
+  void set_obj(const std::string& o) {
+    object.reserve(128);
+
+    orig_obj = o;
+    if (ns.empty() && !need_to_encode_instance()) {
+      if (o.empty()) {
+        return;
+      }
+      if (o.size() < 1 || o[0] != '_') {
+        object = o;
+        return;
+      }
+      object = "_";
+      object.append(o);
+    } else {
+      object = "_";
+      object.append(ns);
+      if (need_to_encode_instance()) {
+        object.append(string(":") + instance);
+      }
+      object.append("_");
+      object.append(o);
+    }
+    reset_loc();
+  }
+
+  /*
+   * get the object's key name as being referred to by the bucket index.
+   */
+  std::string get_index_key_name() const {
+    if (ns.empty()) {
+      if (orig_obj.size() < 1 || orig_obj[0] != '_') {
+        return orig_obj;
+      }
+      return std::string("_") + orig_obj;
+    };
+
+    char buf[ns.size() + 16];
+    snprintf(buf, sizeof(buf), "_%s_", ns.c_str());
+    return std::string(buf) + orig_obj;
+  };
+
+  void from_index_key(old_rgw_bucket& b, const rgw_obj_key& key) {
+    if (key.name[0] != '_') {
+      init(b, key.name);
+      set_instance(key.instance);
+      return;
+    }
+    if (key.name[1] == '_') {
+      init(b, key.name.substr(1));
+      set_instance(key.instance);
+      return;
+    }
+    ssize_t pos = key.name.find('_', 1);
+    if (pos < 0) {
+      /* shouldn't happen, just use key */
+      init(b, key.name);
+      set_instance(key.instance);
+      return;
+    }
+
+    init_ns(b, key.name.substr(pos + 1), key.name.substr(1, pos -1));
+    set_instance(key.instance);
+  }
+
+  void get_index_key(rgw_obj_key *key) const {
+    key->name = get_index_key_name();
+    key->instance = instance;
+  }
+
+  static void parse_ns_field(string& ns, std::string& instance) {
+    int pos = ns.find(':');
+    if (pos >= 0) {
+      instance = ns.substr(pos + 1);
+      ns = ns.substr(0, pos);
+    } else {
+      instance.clear();
+    }
+  }
+
+  std::string& get_hash_object() {
+    return index_hash_source.empty() ? orig_obj : index_hash_source;
+  }
+  /**
+   * Translate a namespace-mangled object name to the user-facing name
+   * existing in the given namespace.
+   *
+   * If the object is part of the given namespace, it returns true
+   * and cuts down the name to the unmangled version. If it is not
+   * part of the given namespace, it returns false.
+   */
+  static bool translate_raw_obj_to_obj_in_ns(string& obj, std::string& instance, std::string& ns) {
+    if (obj[0] != '_') {
+      if (ns.empty()) {
+        return true;
+      }
+      return false;
+    }
+
+    std::string obj_ns;
+    bool ret = parse_raw_oid(obj, &obj, &instance, &obj_ns);
+    if (!ret) {
+      return ret;
+    }
+
+    return (ns == obj_ns);
+  }
+
+  static bool parse_raw_oid(const std::string& oid, std::string *obj_name, std::string *obj_instance, std::string *obj_ns) {
+    obj_instance->clear();
+    obj_ns->clear();
+    if (oid[0] != '_') {
+      *obj_name = oid;
+      return true;
+    }
+
+    if (oid.size() >= 2 && oid[1] == '_') {
+      *obj_name = oid.substr(1);
+      return true;
+    }
+
+    if (oid[0] != '_' || oid.size() < 3) // for namespace, min size would be 3: _x_
+      return false;
+
+    int pos = oid.find('_', 1);
+    if (pos <= 1) // if it starts with __, it's not in our namespace
+      return false;
+
+    *obj_ns = oid.substr(1, pos - 1);
+    parse_ns_field(*obj_ns, *obj_instance);
+
+    *obj_name = oid.substr(pos + 1);
+    return true;
+  }
+
+  /**
+   * Given a mangled object name and an empty namespace string, this
+   * function extracts the namespace into the string and sets the object
+   * name to be the unmangled version.
+   *
+   * It returns true after successfully doing so, or
+   * false if it fails.
+   */
+  static bool strip_namespace_from_object(string& obj, std::string& ns, std::string& instance) {
+    ns.clear();
+    instance.clear();
+    if (obj[0] != '_') {
+      return true;
+    }
+
+    size_t pos = obj.find('_', 1);
+    if (pos == std::string::npos) {
+      return false;
+    }
+
+    if (obj[1] == '_') {
+      obj = obj.substr(1);
+      return true;
+    }
+
+    size_t period_pos = obj.find('.');
+    if (period_pos < pos) {
+      return false;
+    }
+
+    ns = obj.substr(1, pos-1);
+    obj = obj.substr(pos+1, std::string::npos);
+
+    parse_ns_field(ns, instance);
+    return true;
+  }
+
+  void set_in_extra_data(bool val) {
+    in_extra_data = val;
+  }
+
+  bool is_in_extra_data() const {
+    return in_extra_data;
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(5, 3, bl);
+    ::encode(bucket.name, bl);
+    ::encode(loc, bl);
+    ::encode(ns, bl);
+    ::encode(object, bl);
+    ::encode(bucket, bl);
+    ::encode(instance, bl);
+    if (!ns.empty() || !instance.empty()) {
+      ::encode(orig_obj, bl);
+    }
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START_LEGACY_COMPAT_LEN(5, 3, 3, bl);
+    ::decode(bucket.name, bl);
+    ::decode(loc, bl);
+    ::decode(ns, bl);
+    ::decode(object, bl);
+    if (struct_v >= 2)
+      ::decode(bucket, bl);
+    if (struct_v >= 4)
+      ::decode(instance, bl);
+    if (ns.empty() && instance.empty()) {
+      if (object[0] != '_') {
+        orig_obj = object;
+      } else {
+	orig_obj = object.substr(1);
+      }
+    } else {
+      if (struct_v >= 5) {
+        ::decode(orig_obj, bl);
+      } else {
+        ssize_t pos = object.find('_', 1);
+        if (pos < 0) {
+          throw buffer::error();
+        }
+        orig_obj = object.substr(pos);
+      }
+    }
+    DECODE_FINISH(bl);
+  }
+
+  bool operator==(const old_rgw_obj& o) const {
+    return (object.compare(o.object) == 0) &&
+           (bucket.name.compare(o.bucket.name) == 0) &&
+           (ns.compare(o.ns) == 0) &&
+           (instance.compare(o.instance) == 0);
+  }
+  bool operator<(const old_rgw_obj& o) const {
+    int r = bucket.name.compare(o.bucket.name);
+    if (r == 0) {
+      r = bucket.bucket_id.compare(o.bucket.bucket_id);
+      if (r == 0) {
+        r = object.compare(o.object);
+        if (r == 0) {
+          r = ns.compare(o.ns);
+          if (r == 0) {
+            r = instance.compare(o.instance);
+          }
+        }
+      }
+    }
+
+    return (r < 0);
+  }
+};
+WRITE_CLASS_ENCODER(old_rgw_obj)
+
+static inline void prepend_old_bucket_marker(const old_rgw_bucket& bucket, const string& orig_oid, string& oid)
+{
+  if (bucket.marker.empty() || orig_oid.empty()) {
+    oid = orig_oid;
+  } else {
+    oid = bucket.marker;
+    oid.append("_");
+    oid.append(orig_oid);
+  }
+}
+
+void test_rgw_init_env(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params);
+
+struct test_rgw_env {
+  RGWZoneGroup zonegroup;
+  RGWZoneParams zone_params;
+  rgw_data_placement_target default_placement;
+
+  test_rgw_env() {
+    test_rgw_init_env(&zonegroup, &zone_params);
+    default_placement.data_pool = rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_pool);
+    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_extra_pool);
+  }
+
+  rgw_data_placement_target get_placement(const std::string& placement_id) {
+    const RGWZonePlacementInfo& pi = zone_params.placement_pools[placement_id];
+    rgw_data_placement_target pt;
+    pt.index_pool = pi.index_pool;
+    pt.data_pool = pi.data_pool;
+    pt.data_extra_pool = pi.data_extra_pool;
+    return pt;
+  }
+
+  rgw_raw_obj get_raw(const rgw_obj& obj) {
+    rgw_obj_select s(obj);
+    return s.get_raw_obj(zonegroup, zone_params);
+  }
+
+  rgw_raw_obj get_raw(const rgw_obj_select& os) {
+    return os.get_raw_obj(zonegroup, zone_params);
+  }
+};
+
+void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params, const std::string& name, bool is_default);
+void test_rgw_populate_explicit_placement_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id);
+void test_rgw_populate_old_bucket(old_rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id);
+
+std::string test_rgw_get_obj_oid(const rgw_obj& obj);
+void test_rgw_init_explicit_placement_bucket(rgw_bucket *bucket, const char *name);
+void test_rgw_init_old_bucket(old_rgw_bucket *bucket, const char *name);
+void test_rgw_populate_bucket(rgw_bucket *b, const char *t, const char *n, const char *m, const char *id);
+void test_rgw_init_bucket(rgw_bucket *bucket, const char *name);
+rgw_obj test_rgw_create_obj(const rgw_bucket& bucket, const std::string& name, const std::string& instance, const std::string& ns);
+
+#endif
+

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -29,9 +29,19 @@
 #endif
 using namespace std;
 
+static void populate_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+  b->placement.data_pool = rgw_pool(dp);
+  b->placement.index_pool = rgw_pool(ip);
+}
+
 static void init_bucket(rgw_bucket *bucket, const char *ten, const char *name)
 {
-  *bucket = rgw_bucket(ten, name, ".data-pool", ".index-pool", "marker.", "bucket-id", NULL);
+  populate_bucket(bucket, ten, name, ".data-pool", ".index-pool", "marker.", "bucket-id");
 }
 
 void append_head(list<rgw_obj> *objs, rgw_obj& head)

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -13,8 +13,10 @@
  */
 #include <iostream>
 #include "global/global_init.h"
+#include "common/ceph_argparse.h"
 #include "rgw/rgw_common.h"
 #include "rgw/rgw_rados.h"
+#include "test_rgw_common.h"
 #define GTEST
 #ifdef GTEST
 #include <gtest/gtest.h>
@@ -24,25 +26,84 @@
                                 else cout << "(" << #v << "==" << #s << ") PASSED\n";
 #define EXPECT_EQ(v, s) ASSERT_EQ(v, s)
 #define ASSERT_TRUE(c) if(c)cout << "Error at " << __LINE__ << "(" << #c << ")" << "\n"; \
-                          else cout << "(" << #c << ") PASSED\n";
+                          else cout << "(" << #c << ") PASSED\n";#define EXPECT_TRUE(c) ASSERT_TRUE(c) 
 #define EXPECT_TRUE(c) ASSERT_TRUE(c) 
 #endif
 using namespace std;
 
-static void populate_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
-{
-  b->tenant = t;
-  b->name = n;
-  b->marker = m;
-  b->bucket_id = id;
-  b->placement.data_pool = rgw_pool(dp);
-  b->placement.index_pool = rgw_pool(ip);
-}
+struct OldObjManifestPart {
+  old_rgw_obj loc;   /* the object where the data is located */
+  uint64_t loc_ofs;  /* the offset at that object where the data is located */
+  uint64_t size;     /* the part size */
 
-static void init_bucket(rgw_bucket *bucket, const char *ten, const char *name)
-{
-  populate_bucket(bucket, ten, name, ".data-pool", ".index-pool", "marker.", "bucket-id");
-}
+  OldObjManifestPart() : loc_ofs(0), size(0) {}
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(2, 2, bl);
+    ::encode(loc, bl);
+    ::encode(loc_ofs, bl);
+    ::encode(size, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+     DECODE_START_LEGACY_COMPAT_LEN_32(2, 2, 2, bl);
+     ::decode(loc, bl);
+     ::decode(loc_ofs, bl);
+     ::decode(size, bl);
+     DECODE_FINISH(bl);
+  }
+
+  void dump(Formatter *f) const;
+  static void generate_test_instances(list<OldObjManifestPart*>& o);
+};
+WRITE_CLASS_ENCODER(OldObjManifestPart)
+
+class OldObjManifest {
+protected:
+  map<uint64_t, OldObjManifestPart> objs;
+
+  uint64_t obj_size;
+public:
+
+  OldObjManifest() : obj_size(0) {}
+  OldObjManifest(const OldObjManifest& rhs) {
+    *this = rhs;
+  }
+  OldObjManifest& operator=(const OldObjManifest& rhs) {
+    objs = rhs.objs;
+    obj_size = rhs.obj_size;
+    return *this;
+  }
+
+  const map<uint64_t, OldObjManifestPart>& get_objs() {
+    return objs;
+  }
+
+  void append(uint64_t ofs, const OldObjManifestPart& part) {
+    objs[ofs] = part;
+    obj_size = max(obj_size, ofs + part.size);
+  }
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(2, 2, bl);
+    ::encode(obj_size, bl);
+    ::encode(objs, bl);
+    ENCODE_FINISH(bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    DECODE_START_LEGACY_COMPAT_LEN_32(6, 2, 2, bl);
+    ::decode(obj_size, bl);
+    ::decode(objs, bl);
+    DECODE_FINISH(bl);
+  }
+
+  bool empty() {
+    return objs.empty();
+  }
+};
+WRITE_CLASS_ENCODER(OldObjManifest)
 
 void append_head(list<rgw_obj> *objs, rgw_obj& head)
 {
@@ -52,7 +113,7 @@ void append_head(list<rgw_obj> *objs, rgw_obj& head)
 void append_stripes(list<rgw_obj> *objs, RGWObjManifest& manifest, uint64_t obj_size, uint64_t stripe_size)
 {
   string prefix = manifest.get_prefix();
-  rgw_bucket bucket = manifest.get_head().bucket;
+  rgw_bucket bucket = manifest.get_obj().bucket;
 
   int i = 0;
   for (uint64_t ofs = manifest.get_max_head_size(); ofs < obj_size; ofs += stripe_size) {
@@ -66,13 +127,13 @@ void append_stripes(list<rgw_obj> *objs, RGWObjManifest& manifest, uint64_t obj_
   }
 }
 
-static void gen_obj(uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_size,
+static void gen_obj(test_rgw_env& env, uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_size,
                     RGWObjManifest *manifest, rgw_bucket *bucket, rgw_obj *head, RGWObjManifest::generator *gen,
                     list<rgw_obj> *test_objs)
 {
   manifest->set_trivial_rule(head_max_size, stripe_size);
 
-  init_bucket(bucket, "", "buck");
+  test_rgw_init_bucket(bucket, "buck");
 
   *head = rgw_obj(*bucket, "oid");
   gen->create_begin(g_ceph_context, manifest, *bucket, *head);
@@ -91,9 +152,11 @@ static void gen_obj(uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_s
   list<rgw_obj>::iterator iter = test_objs->begin();
 
   while (ofs < obj_size) {
-    rgw_obj obj = gen->get_cur_obj();
+    rgw_raw_obj obj = gen->get_cur_obj(env.zonegroup, env.zone_params);
 cout << "obj=" << obj << std::endl;
-    ASSERT_TRUE(obj == *iter);
+    rgw_raw_obj test_raw;
+    rgw_obj_to_raw(env.zonegroup, env.zone_params, *iter, &test_raw);
+    ASSERT_TRUE(obj == test_raw);
 
     ofs = MIN(ofs + gen->cur_stripe_max_size(), obj_size);
     gen->create_next(ofs);
@@ -105,8 +168,10 @@ cout << "obj=" << obj << std::endl;
   }
 
   if (manifest->has_tail()) {
-    rgw_obj obj = gen->get_cur_obj();
-    ASSERT_TRUE(obj == *iter);
+    rgw_raw_obj obj = gen->get_cur_obj(env.zonegroup, env.zone_params);
+    rgw_raw_obj test_raw;
+    rgw_obj_to_raw(env.zonegroup, env.zone_params, *iter, &test_raw);
+    ASSERT_TRUE(obj == test_raw);
     ++iter;
   }
   ASSERT_TRUE(iter == test_objs->end());
@@ -115,7 +180,44 @@ cout << "obj=" << obj << std::endl;
   ASSERT_EQ(manifest->has_tail(), (obj_size > head_max_size));
 }
 
+static void gen_old_obj(test_rgw_env& env, uint64_t obj_size, uint64_t head_max_size, uint64_t stripe_size,
+                    OldObjManifest *manifest, old_rgw_bucket *bucket, old_rgw_obj *head,
+                    list<old_rgw_obj> *test_objs)
+{
+  test_rgw_init_old_bucket(bucket, "buck");
+
+  *head = old_rgw_obj(*bucket, "obj");
+
+  OldObjManifestPart part;
+  part.loc = *head;
+  part.size = head_max_size;
+  part.loc_ofs = 0;
+
+  manifest->append(0, part);
+  test_objs->push_back(part.loc);
+
+  string prefix;
+  append_rand_alpha(g_ceph_context, prefix, prefix, 16);
+
+  int i = 0;
+  for (uint64_t ofs = head_max_size; ofs < obj_size; ofs += stripe_size, i++) {
+    char buf[32];
+    snprintf(buf, sizeof(buf), "%s.%d", prefix.c_str(), i);
+    old_rgw_obj loc(*bucket, buf);
+    loc.set_ns("shadow");
+    OldObjManifestPart part;
+    part.loc = loc;
+    part.size = min(stripe_size, obj_size - ofs);
+    part.loc_ofs = 0;
+
+    manifest->append(ofs, part);
+
+    test_objs->push_back(loc);
+  }
+}
+
 TEST(TestRGWManifest, head_only_obj) {
+  test_rgw_env env;
   RGWObjManifest manifest;
   rgw_bucket bucket;
   rgw_obj head;
@@ -125,7 +227,7 @@ TEST(TestRGWManifest, head_only_obj) {
 
   list<rgw_obj> objs;
 
-  gen_obj(obj_size, 512 * 1024, 4 * 1024 * 1024, &manifest, &bucket, &head, &gen, &objs);
+  gen_obj(env, obj_size, 512 * 1024, 4 * 1024 * 1024, &manifest, &bucket, &head, &gen, &objs);
 
   cout <<  " manifest.get_obj_size()=" << manifest.get_obj_size() << std::endl;
   cout <<  " manifest.get_head_size()=" << manifest.get_head_size() << std::endl;
@@ -135,18 +237,21 @@ TEST(TestRGWManifest, head_only_obj) {
   for (iter = manifest.obj_begin(), liter = objs.begin();
        iter != manifest.obj_end() && liter != objs.end();
        ++iter, ++liter) {
-    ASSERT_TRUE(*liter == iter.get_location());
+    ASSERT_TRUE(env.get_raw(*liter) == env.get_raw(iter.get_location()));
   }
 
   ASSERT_TRUE(iter == manifest.obj_end());
   ASSERT_TRUE(liter == objs.end());
 
+  rgw_raw_obj raw_head;
+
   iter = manifest.obj_find(100 * 1024);
-  ASSERT_TRUE(iter.get_location() == head);
+  ASSERT_TRUE(env.get_raw(iter.get_location()) == env.get_raw(head));
   ASSERT_EQ((int)iter.get_stripe_size(), obj_size);
 }
 
 TEST(TestRGWManifest, obj_with_head_and_tail) {
+  test_rgw_env env;
   RGWObjManifest manifest;
   rgw_bucket bucket;
   rgw_obj head;
@@ -158,18 +263,18 @@ TEST(TestRGWManifest, obj_with_head_and_tail) {
   int stripe_size = 4 * 1024 * 1024;
   int head_size = 512 * 1024;
 
-  gen_obj(obj_size, head_size, stripe_size, &manifest, &bucket, &head, &gen, &objs);
+  gen_obj(env, obj_size, head_size, stripe_size, &manifest, &bucket, &head, &gen, &objs);
 
   list<rgw_obj>::iterator liter;
 
-  rgw_obj last_obj;
+  rgw_obj_select last_obj;
 
   RGWObjManifest::obj_iterator iter;
   for (iter = manifest.obj_begin(), liter = objs.begin();
        iter != manifest.obj_end() && liter != objs.end();
        ++iter, ++liter) {
-    cout << "*liter=" << *liter << " iter.get_location()=" << iter.get_location() << std::endl;
-    ASSERT_TRUE(*liter == iter.get_location());
+    cout << "*liter=" << *liter << " iter.get_location()=" << env.get_raw(iter.get_location()) << std::endl;
+    ASSERT_TRUE(env.get_raw(*liter) == env.get_raw(iter.get_location()));
 
     last_obj = iter.get_location();
   }
@@ -178,18 +283,19 @@ TEST(TestRGWManifest, obj_with_head_and_tail) {
   ASSERT_TRUE(liter == objs.end());
 
   iter = manifest.obj_find(100 * 1024);
-  ASSERT_TRUE(iter.get_location() == head);
+  ASSERT_TRUE(env.get_raw(iter.get_location()) == env.get_raw(head));
   ASSERT_EQ((int)iter.get_stripe_size(), head_size);
 
   uint64_t ofs = 20 * 1024 * 1024 + head_size;
   iter = manifest.obj_find(ofs + 100);
 
-  ASSERT_TRUE(iter.get_location() == last_obj);
+  ASSERT_TRUE(env.get_raw(iter.get_location()) == env.get_raw(last_obj));
   ASSERT_EQ(iter.get_stripe_ofs(), ofs);
   ASSERT_EQ(iter.get_stripe_size(), obj_size - ofs);
 }
 
 TEST(TestRGWManifest, multipart) {
+  test_rgw_env env;
   int num_parts = 16;
   vector <RGWObjManifest> pm(num_parts);
   rgw_bucket bucket;
@@ -224,14 +330,78 @@ TEST(TestRGWManifest, multipart) {
   RGWObjManifest m;
 
   for (int i = 0; i < num_parts; i++) {
-    m.append(pm[i]);
+    m.append(pm[i], env.zonegroup, env.zone_params);
   }
   RGWObjManifest::obj_iterator iter;
   for (iter = m.obj_begin(); iter != m.obj_end(); ++iter) {
     RGWObjManifest::obj_iterator fiter = m.obj_find(iter.get_ofs());
-    ASSERT_TRUE(fiter.get_location() == iter.get_location());
+    ASSERT_TRUE(env.get_raw(fiter.get_location()) == env.get_raw(iter.get_location()));
   }
 
   ASSERT_EQ(m.get_obj_size(), num_parts * part_size);
+}
+
+TEST(TestRGWManifest, old_obj_manifest) {
+  test_rgw_env env;
+  OldObjManifest old_manifest;
+  old_rgw_bucket old_bucket;
+  old_rgw_obj old_head;
+
+  int obj_size = 40 * 1024 * 1024;
+  uint64_t stripe_size = 4 * 1024 * 1024;
+  uint64_t head_size = 512 * 1024;
+
+  list<old_rgw_obj> old_objs;
+
+  gen_old_obj(env, obj_size, head_size, stripe_size, &old_manifest, &old_bucket, &old_head, &old_objs);
+
+  ASSERT_EQ(old_objs.size(), 11);
+
+
+  bufferlist bl;
+  ::encode(old_manifest , bl);
+
+  RGWObjManifest manifest;
+
+  try {
+    auto iter = bl.begin();
+    ::decode(manifest, iter);
+  } catch (buffer::error& err) {
+    ASSERT_TRUE(false);
+  }
+
+  rgw_raw_obj last_obj;
+
+  RGWObjManifest::obj_iterator iter;
+  auto liter = old_objs.begin();
+  for (iter = manifest.obj_begin();
+       iter != manifest.obj_end() && liter != old_objs.end();
+       ++iter, ++liter) {
+    rgw_pool old_pool(liter->bucket.data_pool);
+    string old_oid;
+    prepend_old_bucket_marker(old_bucket, liter->get_object(), old_oid);
+    rgw_raw_obj raw_old(old_pool, old_oid);
+    cout << "*liter=" << raw_old << " iter.get_location()=" << env.get_raw(iter.get_location()) << std::endl;
+    ASSERT_EQ(raw_old, env.get_raw(iter.get_location()));
+
+    last_obj = env.get_raw(iter.get_location());
+  }
+
+  ASSERT_TRUE(liter == old_objs.end());
+  ASSERT_TRUE(iter == manifest.obj_end());
+
+}
+
+
+int main(int argc, char **argv) {
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+  env_to_vec(args);
+
+  vector<const char*> def_args;
+  global_init(&def_args, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }
 

--- a/src/test/rgw/test_rgw_obj.cc
+++ b/src/test/rgw/test_rgw_obj.cc
@@ -30,9 +30,19 @@
 #endif
 using namespace std;
 
+static void populate_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+{
+  b->tenant = t;
+  b->name = n;
+  b->marker = m;
+  b->bucket_id = id;
+  b->placement.data_pool = rgw_pool(dp);
+  b->placement.index_pool = rgw_pool(ip);
+}
+
 static void init_bucket(rgw_bucket *bucket, const char *name)
 {
-  *bucket = rgw_bucket("", name, ".data-pool", ".index-pool", "marker", "bucket-id", NULL);
+  populate_bucket(bucket, "", name, ".data-pool", ".index-pool", "marker", "bucket-id");
 }
 
 void check_parsed_correctly(rgw_obj& obj, const string& name, const string& ns, const string& instance)


### PR DESCRIPTION
Create new types:
- rgw_pool (to represent pools instead of rgw_bucket)
- rgw_raw_obj (to represent the raw rados object instead of rgw_obj)
- rgw_obj_index_key

 Don't store placement info in rgw_bucket (if possible, still keeping explicit placement for backward compatibility when dealing with older data). head object will always reside in the bucket's default placement target pool, (from the zone config), tail depends on what's in the manifest.

Rework rgw_obj; rename some of the fields, don't refer to oid as object anymore and don't auto generate the oid. Don't encode the oid, but the name, ns, and instance. Split rgw_obj_key and rgw_obj_index_key, and rgw_obj handles both as needed.

Pools can now be defined with a namespace (<pool>[:ns]), and consolidate a few of the default pools.
