### PR TITLE
rgw: rgw_rados.cc fix shard_num format for snprintf

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4863,7 +4863,7 @@ int RGWRados::time_log_trim(const string& oid, const real_time& start_time, cons
 string RGWRados::objexp_hint_get_shardname(int shard_num)
 {
   char buf[32];
-  snprintf(buf, sizeof(buf), "%010u", shard_num);
+  snprintf(buf, sizeof(buf), "%010u", (unsigned)shard_num);
 
   string objname("obj_delete_at_hint.");
   return objname + buf;


### PR DESCRIPTION
shard_num can be converted to unsigned implicitly, just make it clear to avoid complaining from compiler.
Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>