### PR TITLE
rgw: clean up RGWShardedOmapCRManager on early return

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -814,6 +814,7 @@ public:
       }
       if (get_ret_status() < 0) {
         ldout(cct, 0) << "ERROR: failed to fetch metadata sections" << dendl;
+        yield entries_index->finish();
         yield lease_cr->go_down();
         drain_all();
 	return set_cr_error(get_ret_status());
@@ -829,6 +830,7 @@ public:
 	}
         if (get_ret_status() < 0) {
           ldout(cct, 0) << "ERROR: failed to fetch metadata section: " << *sections_iter << dendl;
+          yield entries_index->finish();
           yield lease_cr->go_down();
           drain_all();
           return set_cr_error(get_ret_status());


### PR DESCRIPTION
ShardedOmapCRManager is spawning coroutines that sleep. if we don't
finish them before trying to drain_all(), they'll lead to deadlock

Fixes: http://tracker.ceph.com/issues/17571