### PR TITLE
rgw: clear data_sync_cr if RGWDataSyncControlCR fails

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1581,11 +1581,13 @@ int RGWRemoteDataLog::run_sync(int num_shards)
 {
   lock.get_write();
   data_sync_cr = new RGWDataSyncControlCR(&sync_env, num_shards);
+  data_sync_cr->get(); // run() will drop a ref, so take another
   lock.unlock();
 
   int r = run(data_sync_cr);
 
   lock.get_write();
+  data_sync_cr->put();
   data_sync_cr = NULL;
   lock.unlock();
 

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1582,16 +1582,17 @@ int RGWRemoteDataLog::run_sync(int num_shards)
   lock.get_write();
   data_sync_cr = new RGWDataSyncControlCR(&sync_env, num_shards);
   lock.unlock();
+
   int r = run(data_sync_cr);
-  if (r < 0) {
-    ldout(store->ctx(), 0) << "ERROR: failed to run sync" << dendl;
-    return r;
-  }
 
   lock.get_write();
   data_sync_cr = NULL;
   lock.unlock();
 
+  if (r < 0) {
+    ldout(store->ctx(), 0) << "ERROR: failed to run sync" << dendl;
+    return r;
+  }
   return 0;
 }
 


### PR DESCRIPTION
async notifications will still try to call wakeup() on RGWDataSyncControlCR if it fails, leading to segfault

Fixes: http://tracker.ceph.com/issues/17569
