### PR TITLE
FreeBSD: update require packages

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -23,9 +23,10 @@ if [ x`uname`x = xFreeBSDx ]; then
     $SUDO pkg install -yq \
         devel/git \
         devel/gmake \
-        devel/automake \
+        devel/cmake \
         devel/yasm \
         devel/boost-all \
+        devel/boost-python-libs \
         devel/valgrind \
         devel/pkgconf \
         devel/libatomic_ops \


### PR DESCRIPTION
Leftover from the Cmake move,
and ceph-mgr requires boost-python

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>