### PR TITLE
osd: fix typo in PG::clear_primary_state

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -948,7 +948,7 @@ void PG::clear_primary_state()
 
   snap_trimq.clear();
 
-  finish_sync_event = 0;  // so that _finish_recvoery doesn't go off in another thread
+  finish_sync_event = 0;  // so that _finish_recovery doesn't go off in another thread
 
   missing_loc.clear();
 


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>