### PR TITLE
common/ceph_string: add ceph string constants for CEPH_SESSION_FORCE_RO

### DIFF
--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -126,6 +126,7 @@ const char *ceph_session_op_name(int op)
 	case CEPH_SESSION_RECALL_STATE: return "recall_state";
 	case CEPH_SESSION_FLUSHMSG: return "flushmsg";
 	case CEPH_SESSION_FLUSHMSG_ACK: return "flushmsg_ack";
+	case CEPH_SESSION_FORCE_RO: return "force_ro";
 	case CEPH_SESSION_REJECT: return "reject";
 	}
 	return "???";


### PR DESCRIPTION
Add ceph string constants for CEPH_SESSION_FORCE_RO to keep consistent with kernel cephfs.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>