### PR TITLE
tools/ceph-monstore-update-crush.sh: FreeBSD getopt is not compatible…

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -41,6 +41,7 @@ if [ x`uname`x = xFreeBSDx ]; then
         archivers/snappy \
         ftp/curl \
         misc/e2fsprogs-libuuid \
+        misc/getopt \
         textproc/expat2 \
         textproc/libxml2 \
         textproc/xmlstarlet \

--- a/src/tools/ceph-monstore-update-crush.sh
+++ b/src/tools/ceph-monstore-update-crush.sh
@@ -28,6 +28,12 @@ else
     exit 1
 fi
 
+if [ `uname` = FreeBSD ]; then
+    GETOPT=/usr/local/bin/getopt
+else
+    GETOPT=getopt
+fi
+
 function osdmap_get() {
     local store_path=$1
     local query=$2
@@ -90,7 +96,7 @@ EOF
 
 function main() {
     local temp
-    temp=$(getopt -o h --long verbose,help,mon-store:,out:,rewrite -n $0 -- "$@") || return 1
+    temp=$($GETOPT -o h --long verbose,help,mon-store:,out:,rewrite -n $0 -- "$@") || return 1
 
     eval set -- "$temp"
     local rewrite


### PR DESCRIPTION
…, use the one from packages

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>