### PR TITLE
test/encoding/readable.sh: fix shell script warning

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -69,7 +69,7 @@ test_object() {
       if [ -n "$incompat" ]; then
         if [ -z "$incompat_paths" ]; then
           echo "skipping incompat $type version $arversion, changed at $incompat < code $myversion"
-          continue
+	  return
         else
           # If we are ignoring not whole type, but objects that are in $incompat_path,
           # we don't skip here, just give info.


### PR DESCRIPTION
shell complains about:
`continue: only meaningful in a`for', `while', or`until' loop`

Signed-off-by: Willem Jan Withagen wjw@digiware.nl
