### PR TITLE
common/config_opts.h: Optimized RocksDB WAL settings.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1002,7 +1002,7 @@ OPTION(bluestore_freelist_type, OPT_STR, "bitmap") // extent | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT, 128)
 OPTION(bluestore_bitmapallocator_blocks_per_zone, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
 OPTION(bluestore_bitmapallocator_span_size, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
-OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=16,min_write_buffer_number_to_merge=3,recycle_log_file_num=16")
+OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456")
 OPTION(bluestore_fsck_on_mount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_umount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_mkfs, OPT_BOOL, true)


### PR DESCRIPTION
Increasing the total amount of WAL space improves performance of 4K randwrites on NVMe configurations.  Spreading the logs over many files does not particularly make sense.  In our test setup:

```
buffer count     buffer size    aggregate    4K randwrite (MB/s)
16               4m             64m          105.73
4                16m            64m          134.906
2                32m            64m          196.793
16               16m            256m         227.959
4                64m            256m         221.089
2                128m           256m         234.898
4                128m           512m         256.793
4                256m           1024m        265.873
4                512m           2048m        262.495
4                1024m          4096m        270.052
```

Performance increases are notable up to 4 256MB logs.  Small gains may be made by increasing the aggregate log size considerably beyond that, however the gains appear to be minimal.

Signed-off-by: Mark Nelson mnelson@redhat.com
