### PR TITLE
pybind: avoid "exception 'int' object is not iterable"

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1191,7 +1191,7 @@ def run_in_thread(target, *args, **kwargs):
         interrupt = True
 
     if interrupt:
-        t.retval = -errno.EINTR
+        t.retval = -errno.EINTR, None, 'Interrupted!'
     if t.exception:
         raise t.exception
     return t.retval


### PR DESCRIPTION
Run a command: ceph tell osd.0 pg 1.0 list_missing
If it's interrupted by CTRL+C, it would output a strange error message:
"exception 'int' object is not iterable".

The reason is the caller expects run_in_thread() to return a tuple, but
it returns an int. this patch we fix the bug, then it would just output
a message like: "Error EINTR: Interrupted!"
```
Detailed error message:
Traceback (most recent call last):
  File "./bin/ceph", line 949, in <module>
    retval = main()
  File "./bin/ceph", line 882, in main
    sigdict, inbuf, verbose)
  File "./bin/ceph", line 480, in new_style_command
    inbuf=inbuf)
  File "ceph/src/pybind/ceph_argparse.py", line 1334, in
json_command
    raise RuntimeError('"{0}": exception {1}'.format(argdict, e))
RuntimeError: "{'prefix': u'pg', u'cmd': u'list_missing', u'pgid':
u'1.0'}": exception "['{"prefix": "pg", "cmd": "list_missing", "pgid":
"1.0"}']": exception 'int' object is not iterable
```
Signed-off-by: Javeme <javaloveme@gmail.com>