### PR TITLE
tests: ceph-disk: force debug monc = 0

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -235,6 +235,10 @@ class TestCephDisk(object):
             c.helper("install multipath-tools device-mapper-multipath")
         c.conf['global']['pid file'] = '/var/run/ceph/$cluster-$name.pid'
         #
+        # Avoid json parsing interference
+        #
+        c.conf['global']['debug monc'] = 0
+        #
         # objecstore
         #
         c.conf['global']['osd journal size'] = 100


### PR DESCRIPTION
The sh function will collect both stderr and stdout and debug
will mess the json parsing.

Fixes: http://tracker.ceph.com/issues/17607

Signed-off-by: Loic Dachary <ldachary@redhat.com>