### PR TITLE
os/bluestore: No garbage collection for uncompressed blobs

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -41,6 +41,7 @@ if [ x`uname`x = xFreeBSDx ]; then
         archivers/snappy \
         ftp/curl \
         misc/e2fsprogs-libuuid \
+        misc/getopt \
         textproc/expat2 \
         textproc/libxml2 \
         textproc/xmlstarlet \

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2209,18 +2209,20 @@ bool BlueStore::ExtentMap::do_write_check_depth(
   auto hp = seek_lextent(start_offset);
   if (hp != extent_map.end() &&
     hp->logical_offset < start_offset &&
-    start_offset < hp->logical_offset + hp->length) {
-    depth = hp->blob_depth;
-    head_overlap = true;
+    start_offset < (hp->logical_offset + hp->length) &&
+    hp->blob->get_blob().is_compressed()) {
+      depth = hp->blob_depth;
+      head_overlap = true;
   }
 
   auto tp = seek_lextent(end_offset);
   if (tp != extent_map.end() &&
     tp->logical_offset < end_offset &&
-    end_offset < tp->logical_offset + tp->length) {
-    tail_overlap = true;
-    if (depth < tp->blob_depth) {
-      depth = tp->blob_depth;
+    end_offset < (tp->logical_offset + tp->length) &&
+    tp->blob->get_blob().is_compressed()) {
+      tail_overlap = true;
+      if (depth < tp->blob_depth) {
+        depth = tp->blob_depth;
     }
   }
 

--- a/src/tools/ceph-monstore-update-crush.sh
+++ b/src/tools/ceph-monstore-update-crush.sh
@@ -28,6 +28,12 @@ else
     exit 1
 fi
 
+if [ `uname` = FreeBSD ]; then
+    GETOPT=/usr/local/bin/getopt
+else
+    GETOPT=getopt
+fi
+
 function osdmap_get() {
     local store_path=$1
     local query=$2
@@ -90,7 +96,7 @@ EOF
 
 function main() {
     local temp
-    temp=$(getopt -o h --long verbose,help,mon-store:,out:,rewrite -n $0 -- "$@") || return 1
+    temp=$($GETOPT -o h --long verbose,help,mon-store:,out:,rewrite -n $0 -- "$@") || return 1
 
     eval set -- "$temp"
     local rewrite


### PR DESCRIPTION
This is a bug fix.  As part of the change, we skip garbage collection of uncompressed blobs. Also, if overlapping blob is compressed, then blob_depth for newly created blob is set to minimum(1).  