### PR TITLE
os/bluestore: default bluestore_clone_cow=true

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1020,7 +1020,7 @@ OPTION(bluestore_nid_prealloc, OPT_INT, 1024)
 OPTION(bluestore_blobid_prealloc, OPT_U64, 10240)
 OPTION(bluestore_overlay_max_length, OPT_INT, 65536)
 OPTION(bluestore_overlay_max, OPT_INT, 0)
-OPTION(bluestore_clone_cow, OPT_BOOL, false)  // do copy-on-write for clones
+OPTION(bluestore_clone_cow, OPT_BOOL, true)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL, true)
 OPTION(bluestore_default_buffered_write, OPT_BOOL, false)
 OPTION(bluestore_debug_misc, OPT_BOOL, false)


### PR DESCRIPTION
This has been stable for a long time.

Signed-off-by: Sage Weil <sage@redhat.com>