### PR TITLE
osd/command tell: check pgid at the right time

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5540,11 +5540,10 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
   // 'tell <pgid>' (which comes in without any of that prefix)?
 
   else if (prefix == "pg" ||
-	   (cmd_getval(cct, cmdmap, "pgid", pgidstr) &&
-	     (prefix == "query" ||
-	      prefix == "mark_unfound_lost" ||
-	      prefix == "list_missing")
-	   )) {
+	    prefix == "query" ||
+	    prefix == "mark_unfound_lost" ||
+	    prefix == "list_missing"
+	   ) {
     pg_t pgid;
 
     if (!cmd_getval(cct, cmdmap, "pgid", pgidstr)) {


### PR DESCRIPTION
Run a command: "ceph tell osd.0 query", and it outputs the following error message:
  Error EINVAL: unrecognized command! [{"prefix": "query"}]

In fact, the command "query" exists, but it requires one more input parameter "pgid", therefore the following error information will be more appropriate:
  Error EINVAL: no pgid specified

In this patch, we check the parameter pgid after recognizing a command (like "query" or "list_missing"), rather than before it. Just getting and checking pgid [here (Line 5550)](https://github.com/ceph/ceph/pull/11547/commits/3f6736613c830613a1f9bfad6e3c37a1eadeb2f3#diff-fa6c2eba8356ae1442d1bf749beacfdfL5550)  is more appropriate.

Signed-off-by: Javeme javaloveme@gmail.com
