### PR TITLE
do_freebsd.sh: Do not use LTTNG on FreeBSD

### DIFF
--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -16,6 +16,7 @@ rm -rf build && ./do_cmake.sh "$*" \
 	-D CMAKE_C_FLAGS_DEBUG="-O0 -g" \
 	-D ENABLE_GIT_VERSION=OFF \
 	-D WITH_BLKID=OFF \
+	-D WITH_LTTNG=OFF \
 	-D WITH_FUSE=OFF \
 	-D WITH_RBD=OFF \
 	-D WITH_XFS=OFF \


### PR DESCRIPTION
  FreeBSD has Dtrace

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>