### PR TITLE
include/object: pass "snapid_t&" to bound_encode()

### DIFF
--- a/src/include/object.h
+++ b/src/include/object.h
@@ -127,7 +127,7 @@ struct denc_traits<snapid_t> {
   enum { supported = 2 };
   enum { featured = false };
   enum { bounded = true };
-  static void bound_encode(const snapid_t o, size_t& p) {
+  static void bound_encode(const snapid_t& o, size_t& p) {
     denc(o.val, p);
   }
   static void encode(const snapid_t &o, buffer::list::contiguous_appender& p) {


### PR DESCRIPTION
otherwise the STL container's encoders will segfault when trying to
figure out the element size: they use "denc(*(A*)nullptr, elem_size)"
to do the calculation.

Signed-off-by: Kefu Chai <kchai@redhat.com>