### PR TITLE
rgw multisite: fix the increamtal bucket sync init

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1747,13 +1747,14 @@ class RGWInitBucketShardSyncStatusCoroutine : public RGWCoroutine {
 
   string lock_name;
   string cookie;
-  rgw_bucket_shard_sync_info status;
+  rgw_bucket_shard_sync_info& status;
 
   bucket_index_marker_info info;
 public:
   RGWInitBucketShardSyncStatusCoroutine(RGWDataSyncEnv *_sync_env,
-                                        const rgw_bucket_shard& bs)
-    : RGWCoroutine(_sync_env->cct), sync_env(_sync_env), bs(bs) {
+                                        const rgw_bucket_shard& bs,
+                                        rgw_bucket_shard_sync_info& _status)
+    : RGWCoroutine(_sync_env->cct), sync_env(_sync_env), bs(bs), status(_status) {
     store = sync_env->store;
     lock_name = "sync_lock";
 
@@ -1814,7 +1815,8 @@ public:
 
 RGWCoroutine *RGWRemoteBucketLog::init_sync_status_cr()
 {
-  return new RGWInitBucketShardSyncStatusCoroutine(&sync_env, bs);
+  rgw_bucket_shard_sync_info sync_status;
+  return new RGWInitBucketShardSyncStatusCoroutine(&sync_env, bs, sync_status);
 }
 
 template <class T>
@@ -2747,8 +2749,7 @@ int RGWRunBucketSyncCoroutine::operate()
 
     yield {
       if ((rgw_bucket_shard_sync_info::SyncState)sync_status.state == rgw_bucket_shard_sync_info::StateInit) {
-        call(new RGWInitBucketShardSyncStatusCoroutine(sync_env, bs));
-        sync_status.state = rgw_bucket_shard_sync_info::StateFullSync;
+        call(new RGWInitBucketShardSyncStatusCoroutine(sync_env, bs, sync_status));
       }
     }
 


### PR DESCRIPTION
in the `RGWBucketShardFullSyncCR::operate`, inc_marker will assigned with remote bilog's max_marker.
but the sync_status's inc_marker cant be assigned.so the next step inc sync will always sync
from null log,which means at beginning log.

Signed-off-by: Zengran Zhang <zhangzengran@h3c.com>