### PR TITLE
rgw: 0lenfix1

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -84,6 +84,8 @@ static int parse_range(const char *range, off_t& ofs, off_t& end, bool *partial_
   string s(range);
   string ofs_str;
   string end_str;
+  char *eop;
+  int il;
 
   *partial_content = false;
 
@@ -110,23 +112,47 @@ static int parse_range(const char *range, off_t& ofs, off_t& end, bool *partial_
     goto done;
 
   *partial_content = true;
+  end = -2;
 
+  if (pos == 0 && s.length() == 1)
+    goto done;
   ofs_str = s.substr(0, pos);
   end_str = s.substr(pos + 1);
+  for (il = ofs_str.length(); il > 0; --il)
+    if (!isspace(ofs_str[il-1])) break;
+  if (il < ofs_str.length())
+    ofs_str.erase(il);
+  for (il = end_str.length(); il > 0; --il)
+    if (!isspace(end_str[il-1])) break;
+  if (il < end_str.length())
+    end_str.erase(il);
+
   if (end_str.length()) {
-    end = atoll(end_str.c_str());
-    if (end < 0)
+    end = strtoll(end_str.c_str(), &eop, 10);
+    if (end < 0 || eop - end_str.c_str() != end_str.length())
       goto done;
   }
 
   if (ofs_str.length()) {
-    ofs = atoll(ofs_str.c_str());
+    ofs = strtoll(ofs_str.c_str(), &eop, 10);
+    if (eop - ofs_str.c_str() != ofs_str.length())
+	goto done;
+    ++end;
   } else { // RFC2616 suffix-byte-range-spec
     ofs = -end;
     end = -1;
+    if (!ofs) {
+/* this is case "-0".  We *should* probably return 416
+ * but that will fail teuthology.  See
+ *  https://bugs.launchpad.net/swift/+bug/1047658
+ * so for now, do "nothing" = pretend no range was specified.
+ * That's also allowable by the RFC...
+ */
+       *partial_content = false;
+    }
   }
 
-  if (end >= 0 && end < ofs)
+  if (end > 0 && end <= ofs)
     goto done;
 
   r = 0;
@@ -830,7 +856,7 @@ int RGWGetObj::read_user_manifest_part(rgw_bucket& bucket,
   }
 
   perfcounter->inc(l_rgw_get_b, cur_end - cur_ofs);
-  while (cur_ofs <= cur_end) {
+  while (cur_ofs < cur_end) {
     bufferlist bl;
     op_ret = read_op.read(cur_ofs, cur_end, bl);
     if (op_ret < 0)
@@ -911,8 +937,8 @@ static int iterate_user_manifest_parts(CephContext * const cct,
                         ent.etag.length());
       }
 
-      if (!found_end && obj_ofs > (uint64_t)end) {
-	end_ofs = end - cur_total_len + 1;
+      if (!found_end && obj_ofs >= (uint64_t)end) {
+	end_ofs = end - cur_total_len;
 	found_end = true;
       }
 
@@ -1004,8 +1030,8 @@ static int iterate_slo_parts(CephContext *cct,
 
     obj_ofs += ent.size;
 
-    if (!found_end && obj_ofs > (uint64_t)end) {
-      end_ofs = end - cur_total_len + 1;
+    if (!found_end && obj_ofs >= (uint64_t)end) {
+      end_ofs = end - cur_total_len;
       found_end = true;
     }
 
@@ -1236,10 +1262,10 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl)
   }
 
   if (end < 0 || end >= static_cast<off_t>(total_len)) {
-    end = total_len - 1;
+    end = total_len;
   }
 
-  total_len = end - ofs + 1;
+  total_len = end - ofs;
 
   int r = iterate_slo_parts(s->cct, store, ofs, end, slo_parts,
         get_obj_user_manifest_iterate_cb, (void *)this);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7212,7 +7212,7 @@ int RGWRados::copy_obj_to_remote_dest(RGWObjState *astate,
     return ret;
   }
 
-  ret = read_op.iterate(0, astate->size - 1, out_stream_req->get_out_cb());
+  ret = read_op.iterate(0, astate->size, out_stream_req->get_out_cb());
   if (ret < 0)
     return ret;
 
@@ -7472,7 +7472,7 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
   write_op.meta.olh_epoch = olh_epoch;
   write_op.meta.delete_at = delete_at;
 
-  ret = write_op.write_meta(end + 1, attrs);
+  ret = write_op.write_meta(end, attrs);
   if (ret < 0) {
     goto done_ret;
   }
@@ -7560,7 +7560,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
     } while (again);
 
     ofs += read_len;
-  } while (ofs <= end);
+  } while (ofs < end);
 
   string etag;
   map<string, bufferlist>::iterator iter = attrs.find(RGW_ATTR_ETAG);
@@ -9048,9 +9048,9 @@ int RGWRados::Object::Read::prepare(int64_t *pofs, int64_t *pend)
     ofs += astate->size;
     if (ofs < 0)
       ofs = 0;
-    end = astate->size - 1;
+    end = astate->size;
   } else if (end < 0) {
-    end = astate->size - 1;
+    end = astate->size;
   }
 
   if (astate->size > 0) {
@@ -9058,7 +9058,7 @@ int RGWRados::Object::Read::prepare(int64_t *pofs, int64_t *pend)
       return -ERANGE;
     }
     if (end >= (off_t)astate->size) {
-      end = astate->size - 1;
+      end = astate->size;
     }
   }
 
@@ -9067,7 +9067,7 @@ int RGWRados::Object::Read::prepare(int64_t *pofs, int64_t *pend)
   if (pend)
     *pend = end;
   if (params.read_size)
-    *params.read_size = (ofs <= end ? end + 1 - ofs : 0);
+    *params.read_size = (ofs < end ? end - ofs : 0);
   if (params.obj_size)
     *params.obj_size = astate->size;
   if (params.lastmod)
@@ -9274,7 +9274,7 @@ int RGWRados::Object::Read::read(int64_t ofs, int64_t end, bufferlist& bl)
   if (end < 0)
     len = 0;
   else
-    len = end - ofs + 1;
+    len = end - ofs;
 
   if (astate->has_manifest && astate->manifest.has_tail()) {
     /* now get the relevant object part */
@@ -9849,7 +9849,7 @@ int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx, rgw_obj& obj,
   if (end < 0)
     len = 0;
   else
-    len = end - ofs + 1;
+    len = end - ofs;
 
   if (astate->has_manifest) {
     /* now get the relevant object stripe */
@@ -9857,11 +9857,11 @@ int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx, rgw_obj& obj,
 
     RGWObjManifest::obj_iterator obj_end = astate->manifest.obj_end();
 
-    for (; iter != obj_end && ofs <= end; ++iter) {
+    for (; iter != obj_end && ofs < end; ++iter) {
       off_t stripe_ofs = iter.get_stripe_ofs();
       off_t next_stripe_ofs = stripe_ofs + iter.get_stripe_size();
 
-      while (ofs < next_stripe_ofs && ofs <= end) {
+      while (ofs < next_stripe_ofs && ofs < end) {
         read_obj = iter.get_location();
         uint64_t read_len = min(len, iter.get_stripe_size() - (ofs - stripe_ofs));
         read_ofs = iter.location_ofs() + (ofs - stripe_ofs);
@@ -9881,7 +9881,7 @@ int RGWRados::iterate_obj(RGWObjectCtx& obj_ctx, rgw_obj& obj,
       }
     }
   } else {
-    while (ofs <= end) {
+    while (ofs < end) {
       uint64_t read_len = min(len, max_chunk_size);
 
       r = iterate_obj_cb(obj, ofs, ofs, read_len, reading_from_head, astate, arg);


### PR DESCRIPTION
The first commit is to fix http://tracker.ceph.com/issues/17572.  It also turns out that somebody broke byte ranges on SLO/DLO, so this patch removes the code that broke that.

The 2nd commit redoes "end" counts to get rid of a bunch of +1/-1 stuff, hopefully to make bugs like the first commit less likely.  It also fixes the range parse logic to be a bit more strict (ie, less likely to return wrong results for bad ranges.)

I found the swift test logic in teuthology and ran it directly on my test setup, seems to work.
