### PR TITLE
os/bluestore: kill overlay related options

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1020,8 +1020,6 @@ OPTION(bluestore_wal_max_ops, OPT_U64, 512)
 OPTION(bluestore_wal_max_bytes, OPT_U64, 128*1024*1024)
 OPTION(bluestore_nid_prealloc, OPT_INT, 1024)
 OPTION(bluestore_blobid_prealloc, OPT_U64, 10240)
-OPTION(bluestore_overlay_max_length, OPT_INT, 65536)
-OPTION(bluestore_overlay_max, OPT_INT, 0)
 OPTION(bluestore_clone_cow, OPT_BOOL, true)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL, true)
 OPTION(bluestore_default_buffered_write, OPT_BOOL, false)


### PR DESCRIPTION
These two options are not used anymore.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>