### PR TITLE
librbd: exclusive lock incorrectly initialized when switching to head revision

### DIFF
--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -56,7 +56,8 @@ void SetSnapRequest<I>::send_init_exclusive_lock() {
     }
   }
 
-  if (!m_image_ctx.test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
+  if (m_image_ctx.read_only ||
+      !m_image_ctx.test_features(RBD_FEATURE_EXCLUSIVE_LOCK)) {
     int r = 0;
     if (send_refresh_parent(&r) != nullptr) {
       send_complete();


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17618
Signed-off-by: Jason Dillaman dillaman@redhat.com
