### PR TITLE
rgw: fix put_acls for objects starting and ending with underscore

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3984,7 +3984,8 @@ void RGWPutACLs::execute()
   }
 
   new_policy.encode(bl);
-  obj = rgw_obj(s->bucket, s->object);
+  obj = rgw_obj(s->bucket, s->object.name);
+  obj.set_instance(s->object.instance);
   map<string, bufferlist> attrs;
 
   store->set_atomic(s->obj_ctx, obj);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17625
Signed-off-by: Orit Wasserman <owasserm@redhat.com>
