### PR TITLE
[DNM] Fix rgw crash when client post object with  null condition

### DIFF
--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -276,6 +276,10 @@ int RGWPolicy::from_json(bufferlist& bl, string& err_msg)
       int i;
       for (i = 0; !citer.end() && i < 3; ++citer, ++i) {
 	JSONObj *o = *citer;
+        const string& condition_data = o->get_data();
+        if (condition_data.empty()) {
+            return -EINVAL;
+        }
         v.push_back(o->get_data());
       }
       if (i != 3 || !citer.end()) { /* we expect exactly 3 arguments here */


### PR DESCRIPTION
http://tracker.ceph.com/issues/17631

when i used boto3 to post object with null conditions,rgw will crash(hammer 0.94.5~0.94.9),and return http-status-code=502,so i make a patch to fix this problem!

test_script.py
```
import boto3
from botocore.client import Config
import requests


session = boto3.session.Session()
s3client = session.client('s3', use_ssl=False,
                            endpoint_url='http://s3.x.abc.com',
                            aws_access_key_id='',
                            aws_secret_access_key='',
                            config=Config(s3={'addressing_style': 'virtual'}))


post = s3client.generate_presigned_post(
    Bucket='cn-demo1',
    Key='testsign',
    Fields={
        # "acl": "public_read",
        # "Content-Type": "text/plain",
    },
    Conditions=[
        # {
        #     "acl": "public_read",
        #     "Content-Type": "text/plain",
        # }
    ]
)

files = {"file": '/tmp/testsign'}
response = requests.post(post["url"], post['fields'], files=files)
print response.content
```

radosgw.log

```
-122> 2016-10-19 16:26:10.277642 7fa2adffb700  1 ====== starting new request req=0x7fa2c4012b90 =====
  -121> 2016-10-19 16:26:10.277669 7fa2adffb700  2 req 1:0.000027::POST /::initializing for trans_id = tx000000000000000000001-0058072e22-196a7-cn-zone1
  -120> 2016-10-19 16:26:10.277676 7fa2adffb700 10 host=cn-demo1.s3.x.abc.com
  -119> 2016-10-19 16:26:10.277682 7fa2adffb700 20 subdomain=cn-demo1 domain=s3.x.abc.com in_hosted_domain=1
  -118> 2016-10-19 16:26:10.277733 7fa2adffb700 10 s->object=<NULL> s->bucket=cn-demo1
  -117> 2016-10-19 16:26:10.277745 7fa2adffb700  2 req 1:0.000103:s3:POST /::getting op
  -116> 2016-10-19 16:26:10.277750 7fa2adffb700  2 req 1:0.000108:s3:POST /:post_obj:authorizing
  -115> 2016-10-19 16:26:10.277755 7fa2adffb700  2 req 1:0.000113:s3:POST /:post_obj:reading permissions
  -114> 2016-10-19 16:26:10.277779 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adffa260 obj=.cn-zone1.rgw.domain:cn-demo1 state=0x7fa2dc011ae0 s->prefetch_data=0
  -113> 2016-10-19 16:26:10.277789 7fa2adffb700 10 cache get: name=.cn-zone1.rgw.domain+cn-demo1 : miss
  -112> 2016-10-19 16:26:10.277879 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6800/10050 -- osd_op(client.104103.0:221 cn-demo1 [call version.read,getxattrs,stat] 3.ee3a42a9 ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc014010 con 0x340b1a0
  -111> 2016-10-19 16:26:10.278218 7fa2cd7fa700 10 allocated request req=0x7fa2c4018b40
  -110> 2016-10-19 16:26:10.280368 7fa2f44f5700  1 -- 10.63.48.8:0/76403620 <== osd.0 10.63.48.8:6800/10050 74 ==== osd_op_reply(221 cn-demo1 [call,getxattrs,stat] v0'0 uv10 ondisk = 0) v6 ==== 259+0+139 (4142662963 0 2341838577) 0x7fa2d400b600 con 0x340b1a0
  -109> 2016-10-19 16:26:10.280444 7fa2adffb700 10 cache put: name=.cn-zone1.rgw.domain+cn-demo1
  -108> 2016-10-19 16:26:10.280452 7fa2adffb700 10 adding .cn-zone1.rgw.domain+cn-demo1 to cache LRU end
  -107> 2016-10-19 16:26:10.280460 7fa2adffb700 20 get_obj_state: s->obj_tag was set empty
  -106> 2016-10-19 16:26:10.280463 7fa2adffb700 20 Read xattr: user.rgw.idtag
  -105> 2016-10-19 16:26:10.280464 7fa2adffb700 20 Read xattr: user.rgw.manifest
  -104> 2016-10-19 16:26:10.280468 7fa2adffb700 10 cache get: name=.cn-zone1.rgw.domain+cn-demo1 : type miss (requested=17, cached=22)
  -103> 2016-10-19 16:26:10.280472 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adffa260 obj=.cn-zone1.rgw.domain:cn-demo1 state=0x7fa2dc011ae0 s->prefetch_data=0
  -102> 2016-10-19 16:26:10.280507 7fa2adffb700 20 rados->read ofs=0 len=524288
  -101> 2016-10-19 16:26:10.280526 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6800/10050 -- osd_op(client.104103.0:222 cn-demo1 [call version.check_conds,call version.read,read 0~524288] 3.ee3a42a9 ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc018550 con 0x340b1a0
  -100> 2016-10-19 16:26:10.281563 7fa2f44f5700  1 -- 10.63.48.8:0/76403620 <== osd.0 10.63.48.8:6800/10050 75 ==== osd_op_reply(222 cn-demo1 [call,call,read 0~173] v0'0 uv10 ondisk = 0) v6 ==== 259+0+221 (4231957603 0 3060218431) 0x7fa2d400bd90 con 0x340b1a0
   -99> 2016-10-19 16:26:10.281606 7fa2adffb700 20 rados->read r=0 bl.length=173
   -98> 2016-10-19 16:26:10.281616 7fa2adffb700 10 cache put: name=.cn-zone1.rgw.domain+cn-demo1
   -97> 2016-10-19 16:26:10.281618 7fa2adffb700 10 moving .cn-zone1.rgw.domain+cn-demo1 to cache LRU end
   -96> 2016-10-19 16:26:10.281630 7fa2adffb700 20 rgw_get_bucket_info: bucket instance: cn-demo1(@{i=.cn-zone1.rgw.buckets.index,e=.cn-zone1.rgw.bucketa.extra}.cn-zone1.rgw.buckets[cn-zone1.94121.1])
   -95> 2016-10-19 16:26:10.281637 7fa2adffb700 20 reading from .cn-zone1.rgw.domain:.bucket.meta.cn-demo1:cn-zone1.94121.1
   -94> 2016-10-19 16:26:10.281644 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adffa260 obj=.cn-zone1.rgw.domain:.bucket.meta.cn-demo1:cn-zone1.94121.1 state=0x7fa2dc0183c0 s->prefetch_data=0
   -93> 2016-10-19 16:26:10.281649 7fa2adffb700 10 cache get: name=.cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1 : miss
   -92> 2016-10-19 16:26:10.281673 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6808/10402 -- osd_op(client.104103.0:223 .bucket.meta.cn-demo1:cn-zone1.94121.1 [call version.read,getxattrs,stat] 3.56b61b9e ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc013410 con 0x3416390
   -91> 2016-10-19 16:26:10.282689 7fa2f42f3700  1 -- 10.63.48.8:0/76403620 <== osd.2 10.63.48.8:6808/10402 52 ==== osd_op_reply(223 .bucket.meta.cn-demo1:cn-zone1.94121.1 [call,getxattrs,stat] v0'0 uv8 ondisk = 0) v6 ==== 289+0+310 (1921822369 0 1226983775) 0x7fa2c00092b0 con 0x3416390
   -90> 2016-10-19 16:26:10.282740 7fa2adffb700 10 cache put: name=.cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1
   -89> 2016-10-19 16:26:10.282747 7fa2adffb700 10 adding .cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1 to cache LRU end
   -88> 2016-10-19 16:26:10.282749 7fa2adffb700 10 updating xattr: name=user.rgw.acl bl.length()=151
   -87> 2016-10-19 16:26:10.282754 7fa2adffb700 20 get_obj_state: s->obj_tag was set empty
   -86> 2016-10-19 16:26:10.282757 7fa2adffb700 20 Read xattr: user.rgw.acl
   -85> 2016-10-19 16:26:10.282758 7fa2adffb700 20 Read xattr: user.rgw.idtag
   -84> 2016-10-19 16:26:10.282758 7fa2adffb700 20 Read xattr: user.rgw.manifest
   -83> 2016-10-19 16:26:10.282761 7fa2adffb700 10 cache get: name=.cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1 : type miss (requested=17, cached=22)
   -82> 2016-10-19 16:26:10.282765 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adffa260 obj=.cn-zone1.rgw.domain:.bucket.meta.cn-demo1:cn-zone1.94121.1 state=0x7fa2dc0183c0 s->prefetch_data=0
   -81> 2016-10-19 16:26:10.282791 7fa2adffb700 20 rados->read ofs=0 len=524288
   -80> 2016-10-19 16:26:10.282810 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6808/10402 -- osd_op(client.104103.0:224 .bucket.meta.cn-demo1:cn-zone1.94121.1 [call version.check_conds,call version.read,read 0~524288] 3.56b61b9e ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc01c270 con 0x3416390
   -79> 2016-10-19 16:26:10.283751 7fa2f42f3700  1 -- 10.63.48.8:0/76403620 <== osd.2 10.63.48.8:6808/10402 53 ==== osd_op_reply(224 .bucket.meta.cn-demo1:cn-zone1.94121.1 [call,call,read 0~232] v0'0 uv8 ondisk = 0) v6 ==== 289+0+280 (4210773805 0 3645179015) 0x7fa2c0009410 con 0x3416390
   -78> 2016-10-19 16:26:10.283793 7fa2adffb700 20 rados->read r=0 bl.length=232
   -77> 2016-10-19 16:26:10.283802 7fa2adffb700 10 cache put: name=.cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1
   -76> 2016-10-19 16:26:10.283805 7fa2adffb700 10 moving .cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1 to cache LRU end
   -75> 2016-10-19 16:26:10.283816 7fa2adffb700 10 chain_cache_entry: cache_locator=.cn-zone1.rgw.domain+cn-demo1
   -74> 2016-10-19 16:26:10.283817 7fa2adffb700 10 chain_cache_entry: cache_locator=.cn-zone1.rgw.domain+.bucket.meta.cn-demo1:cn-zone1.94121.1
   -73> 2016-10-19 16:26:10.283847 7fa2adffb700 15 Read AccessControlPolicy<AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>u-gfn2636</ID><DisplayName>u-gfn2636</DisplayName></Owner><AccessControlList><Grant><Grantee xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="CanonicalUser"><ID>u-gfn2636</ID><DisplayName>u-gfn2636</DisplayName></Grantee><Permission>FULL_CONTROL</Permission></Grant></AccessControlList></AccessControlPolicy>
   -72> 2016-10-19 16:26:10.283856 7fa2adffb700  2 req 1:0.006213:s3:POST /:post_obj:init op
   -71> 2016-10-19 16:26:10.283859 7fa2adffb700  2 req 1:0.006217:s3:POST /:post_obj:verifying op mask
   -70> 2016-10-19 16:26:10.283861 7fa2adffb700 20 required_mask= 2 user.op_mask=7
   -69> 2016-10-19 16:26:10.283862 7fa2adffb700  2 req 1:0.006220:s3:POST /:post_obj:verifying op permissions
   -68> 2016-10-19 16:26:10.283864 7fa2adffb700  2 req 1:0.006222:s3:POST /:post_obj:verifying op params
   -67> 2016-10-19 16:26:10.283866 7fa2adffb700  2 req 1:0.006224:s3:POST /:post_obj:executing
   -66> 2016-10-19 16:26:10.283902 7fa2adffb700 20 request content_type_str=multipart/form-data; boundary=d7e20d5d07bd4ee183e3ab79bf11cdec
   -65> 2016-10-19 16:26:10.283904 7fa2adffb700 20 request content_type params:
   -64> 2016-10-19 16:26:10.283905 7fa2adffb700 20  boundary -> d7e20d5d07bd4ee183e3ab79bf11cdec
   -63> 2016-10-19 16:26:10.283906 7fa2adffb700 20 adding bucket to policy env: cn-demo1
   -62> 2016-10-19 16:26:10.284019 7fa2adffb700 20 read part header: name=policy content_type=
   -61> 2016-10-19 16:26:10.284022 7fa2adffb700 20 name=Content-Disposition
   -60> 2016-10-19 16:26:10.284023 7fa2adffb700 20 val=form-data
   -59> 2016-10-19 16:26:10.284024 7fa2adffb700 20 params:
   -58> 2016-10-19 16:26:10.284025 7fa2adffb700 20  name -> policy
   -57> 2016-10-19 16:26:10.284054 7fa2adffb700 20 read part header: name=AWSAccessKeyId content_type=
   -56> 2016-10-19 16:26:10.284057 7fa2adffb700 20 name=Content-Disposition
   -55> 2016-10-19 16:26:10.284057 7fa2adffb700 20 val=form-data
   -54> 2016-10-19 16:26:10.284058 7fa2adffb700 20 params:
   -53> 2016-10-19 16:26:10.284059 7fa2adffb700 20  name -> AWSAccessKeyId
   -52> 2016-10-19 16:26:10.284083 7fa2adffb700 20 read part header: name=key content_type=
   -51> 2016-10-19 16:26:10.284085 7fa2adffb700 20 name=Content-Disposition
   -50> 2016-10-19 16:26:10.284086 7fa2adffb700 20 val=form-data
   -49> 2016-10-19 16:26:10.284087 7fa2adffb700 20 params:
   -48> 2016-10-19 16:26:10.284087 7fa2adffb700 20  name -> key
   -47> 2016-10-19 16:26:10.284137 7fa2adffb700 20 read part header: name=signature content_type=
   -46> 2016-10-19 16:26:10.284140 7fa2adffb700 20 name=Content-Disposition
   -45> 2016-10-19 16:26:10.284141 7fa2adffb700 20 val=form-data
   -44> 2016-10-19 16:26:10.284142 7fa2adffb700 20 params:
   -43> 2016-10-19 16:26:10.284142 7fa2adffb700 20  name -> signature
   -42> 2016-10-19 16:26:10.284168 7fa2adffb700 20 read part header: name=file content_type=
   -41> 2016-10-19 16:26:10.284170 7fa2adffb700 20 name=Content-Disposition
   -40> 2016-10-19 16:26:10.284171 7fa2adffb700 20 val=form-data
   -39> 2016-10-19 16:26:10.284172 7fa2adffb700 20 params:
   -38> 2016-10-19 16:26:10.284172 7fa2adffb700 20  filename -> file
   -37> 2016-10-19 16:26:10.284173 7fa2adffb700 20  name -> file
   -36> 2016-10-19 16:26:10.284205 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adff9340 obj=.cn-zone1.users:KFIH2I8PDAU38KNAV3VB state=0x7fa2dc0170c0 s->prefetch_data=0
   -35> 2016-10-19 16:26:10.284212 7fa2adffb700 10 cache get: name=.cn-zone1.users+KFIH2I8PDAU38KNAV3VB : miss
   -34> 2016-10-19 16:26:10.284233 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6808/10402 -- osd_op(client.104103.0:225 KFIH2I8PDAU38KNAV3VB [getxattrs,stat] 11.7a4e43db ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc01ce30 con 0x3416390
   -33> 2016-10-19 16:26:10.286137 7fa2f42f3700  1 -- 10.63.48.8:0/76403620 <== osd.2 10.63.48.8:6808/10402 54 ==== osd_op_reply(225 KFIH2I8PDAU38KNAV3VB [getxattrs,stat] v0'0 uv1 ondisk = 0) v6 ==== 229+0+20 (574316515 0 407760374) 0x7fa2c00098e0 con 0x3416390
   -32> 2016-10-19 16:26:10.286200 7fa2adffb700 10 cache put: name=.cn-zone1.users+KFIH2I8PDAU38KNAV3VB
   -31> 2016-10-19 16:26:10.286211 7fa2adffb700 10 adding .cn-zone1.users+KFIH2I8PDAU38KNAV3VB to cache LRU end
   -30> 2016-10-19 16:26:10.286216 7fa2adffb700 20 get_obj_state: s->obj_tag was set empty
   -29> 2016-10-19 16:26:10.286222 7fa2adffb700 10 cache get: name=.cn-zone1.users+KFIH2I8PDAU38KNAV3VB : type miss (requested=1, cached=6)
   -28> 2016-10-19 16:26:10.286226 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adff9340 obj=.cn-zone1.users:KFIH2I8PDAU38KNAV3VB state=0x7fa2dc0170c0 s->prefetch_data=0
   -27> 2016-10-19 16:26:10.286229 7fa2adffb700 20 rados->read ofs=0 len=524288
   -26> 2016-10-19 16:26:10.286250 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6808/10402 -- osd_op(client.104103.0:226 KFIH2I8PDAU38KNAV3VB [read 0~524288] 11.7a4e43db ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc01d660 con 0x3416390
   -25> 2016-10-19 16:26:10.287013 7fa2f42f3700  1 -- 10.63.48.8:0/76403620 <== osd.2 10.63.48.8:6808/10402 55 ==== osd_op_reply(226 KFIH2I8PDAU38KNAV3VB [read 0~13] v0'0 uv1 ondisk = 0) v6 ==== 187+0+13 (320362715 0 2457416643) 0x7fa2c00098e0 con 0x3416390
   -24> 2016-10-19 16:26:10.287070 7fa2adffb700 20 rados->read r=0 bl.length=13
   -23> 2016-10-19 16:26:10.287092 7fa2adffb700 10 cache put: name=.cn-zone1.users+KFIH2I8PDAU38KNAV3VB
   -22> 2016-10-19 16:26:10.287095 7fa2adffb700 10 moving .cn-zone1.users+KFIH2I8PDAU38KNAV3VB to cache LRU end
   -21> 2016-10-19 16:26:10.287109 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adff90b0 obj=.cn-zone1.users.uid:u-gfn2636 state=0x7fa2dc01db00 s->prefetch_data=0
   -20> 2016-10-19 16:26:10.287115 7fa2adffb700 10 cache get: name=.cn-zone1.users.uid+u-gfn2636 : miss
   -19> 2016-10-19 16:26:10.287149 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6804/10226 -- osd_op(client.104103.0:227 u-gfn2636 [call version.read,getxattrs,stat] 14.e6852273 ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc01f850 con 0x33f1010
   -18> 2016-10-19 16:26:10.288130 7fa2f46f7700  1 -- 10.63.48.8:0/76403620 <== osd.1 10.63.48.8:6804/10226 97 ==== osd_op_reply(227 u-gfn2636 [call,getxattrs,stat] v0'0 uv2 ondisk = 0) v6 ==== 260+0+139 (358932637 0 2785148612) 0x7fa2dc021010 con 0x33f1010
   -17> 2016-10-19 16:26:10.288172 7fa2adffb700 10 cache put: name=.cn-zone1.users.uid+u-gfn2636
   -16> 2016-10-19 16:26:10.288178 7fa2adffb700 10 adding .cn-zone1.users.uid+u-gfn2636 to cache LRU end
   -15> 2016-10-19 16:26:10.288182 7fa2adffb700 20 get_obj_state: s->obj_tag was set empty
   -14> 2016-10-19 16:26:10.288187 7fa2adffb700 10 cache get: name=.cn-zone1.users.uid+u-gfn2636 : type miss (requested=17, cached=22)
   -13> 2016-10-19 16:26:10.288191 7fa2adffb700 20 get_obj_state: rctx=0x7fa2adff90b0 obj=.cn-zone1.users.uid:u-gfn2636 state=0x7fa2dc01db00 s->prefetch_data=0
   -12> 2016-10-19 16:26:10.288220 7fa2adffb700 20 rados->read ofs=0 len=524288
   -11> 2016-10-19 16:26:10.288238 7fa2adffb700  1 -- 10.63.48.8:0/76403620 --> 10.63.48.8:6804/10226 -- osd_op(client.104103.0:228 u-gfn2636 [call version.check_conds,call version.read,read 0~524288] 14.e6852273 ack+read+known_if_redirected e141) v5 -- ?+0 0x7fa2dc0254f0 con 0x33f1010
   -10> 2016-10-19 16:26:10.289151 7fa2f46f7700  1 -- 10.63.48.8:0/76403620 <== osd.1 10.63.48.8:6804/10226 98 ==== osd_op_reply(228 u-gfn2636 [call,call,read 0~325] v0'0 uv2 ondisk = 0) v6 ==== 260+0+373 (1489435925 0 1384514980) 0x7fa2dc025d20 con 0x33f1010
    -9> 2016-10-19 16:26:10.289187 7fa2adffb700 20 rados->read r=0 bl.length=325
    -8> 2016-10-19 16:26:10.289196 7fa2adffb700 10 cache put: name=.cn-zone1.users.uid+u-gfn2636
    -7> 2016-10-19 16:26:10.289198 7fa2adffb700 10 moving .cn-zone1.users.uid+u-gfn2636 to cache LRU end
    -6> 2016-10-19 16:26:10.289214 7fa2adffb700 10 chain_cache_entry: cache_locator=.cn-zone1.users.uid+u-gfn2636
    -5> 2016-10-19 16:26:10.289303 7fa2adffb700  0 Successful Signature Verification!
    -4> 2016-10-19 16:26:10.289311 7fa2adffb700  0 POST policy: {"conditions": [{}, {"bucket": "cn-demo1"}, {"key": "testsign"}], "expiration": "2016-10-19T09:26:10Z"}
    -3> 2016-10-19 16:26:10.289518 7fa2adffb700 20 data={}
    -2> 2016-10-19 16:26:10.289520 7fa2adffb700 20 is_object=1
    -1> 2016-10-19 16:26:10.289521 7fa2adffb700 20 is_array=0
     0> 2016-10-19 16:26:10.290832 7fa2adffb700 -1 *** Caught signal (Segmentation fault) **
 in thread 7fa2adffb700

 ceph version 0.94.9 (fe6d859066244b97b24f09d46552afc2071e6f90)
 1: /usr/bin/radosgw() [0x6fb0d3]
 2: (()+0xf8d0) [0x7fa30571c8d0]
 3: (RGWPolicy::from_json(ceph::buffer::list&, std::string&)+0xba9) [0x686669]
 4: (RGWPostObj_ObjStore_S3::get_policy()+0x11a3) [0x53ec83]
 5: (RGWPostObj_ObjStore_S3::get_params()+0x12e3) [0x540bf3]
 6: (RGWPostObj::execute()+0x162) [0x656ba2]
 7: /usr/bin/radosgw() [0x598543]
 8: (RGWFCGXProcess::handle_request(RGWRequest*)+0x71) [0x598c51]
 9: (ThreadPool::WorkQueue<RGWRequest>::_void_process(void*, ThreadPool::TPHandle&)+0x4b) [0x59bb7b]
 10: (ThreadPool::worker(ThreadPool::WorkThread*)+0xa77) [0x7241d7]
 11: (ThreadPool::WorkThread::entry()+0x10) [0x7252b0]
 12: (()+0x80a4) [0x7fa3057150a4]
 13: (clone()+0x6d) [0x7fa303e6204d]
 NOTE: a copy of the executable, or `objdump -rdS <executable>` is needed to interpret this.

--- logging levels ---
   0/ 5 none
   0/ 1 lockdep
   0/ 1 context
   1/ 1 crush
   1/ 5 mds
   1/ 5 mds_balancer
   1/ 5 mds_locker
   1/ 5 mds_log
   1/ 5 mds_log_expire
   1/ 5 mds_migrator
   0/ 1 buffer
   0/ 1 timer
   0/ 1 filer
   0/ 1 striper
   0/ 1 objecter
   0/ 5 rados
   0/ 5 rbd
   0/ 5 rbd_replay
   0/ 5 journaler
   0/ 5 objectcacher
   0/ 5 client
   0/ 5 osd
   0/ 5 optracker
   0/ 5 objclass
   1/ 3 filestore
   1/ 3 keyvaluestore
   1/ 3 journal
   0/ 5 ms
   1/ 5 mon
   0/10 monc
   1/ 5 paxos
   0/ 5 tp
   1/ 5 auth
   1/ 5 crypto
   1/ 1 finisher
   1/ 5 heartbeatmap
   1/ 5 perfcounter
  20/20 rgw
   1/10 civetweb
   1/ 5 javaclient
   1/ 5 asok
   1/ 1 throttle
   0/ 0 refs
   1/ 5 xio
  -2/-2 (syslog threshold)
  -1/-1 (stderr threshold)
  max_recent     10000
  max_new         1000
  log_file /home/ceph/log/radosgw.cn-zone1.log
--- end dump of recent events ---

```


Signed-off-by: Feng Guo <diluga@gmail.com>