### PR TITLE
denc: don't pass null instances into encoder fns

### DIFF
--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -33,7 +33,7 @@ struct denc_traits<inodeno_t> {
   enum { supported = 2 };
   enum { featured = false };
   enum { bounded = true };
-  static void bound_encode(const inodeno_t o, size_t& p) {
+  static void bound_encode(const inodeno_t &o, size_t& p) {
     denc(o.val, p);
   }
   static void encode(const inodeno_t &o, buffer::list::contiguous_appender& p) {


### PR DESCRIPTION
In cases like inodeno_t, the object ref passed in
is dereferenced and passing in a null reference
causes a segfault.

Clearly the constructor overhead is best avoided,
but until someone finds a way to do this better, let's
not crash!

This was causing the MDS to crash on startup after
the new encoding code was merged.

Fixes: http://tracker.ceph.com/issues/17636
Signed-off-by: John Spray <john.spray@redhat.com>