### PR TITLE
build/ops: run ceph-osd-prestart.sh with bash

### DIFF
--- a/src/ceph-osd-prestart.sh
+++ b/src/ceph-osd-prestart.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 eval set -- "$(getopt -o i: --long id:,cluster: -- $@)"
 


### PR DESCRIPTION
Newer Debian and Ubuntu systems have /bin/sh linked to "dash" and scripts
containing bashisms (like this one) will fail.

Fixes: http://tracker.ceph.com/issues/17637
Signed-off-by: Nathan Cutler <ncutler@suse.com>