### PR TITLE
core: set dumpable flag after setuid

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -31,6 +31,10 @@
 #include <grp.h>
 #include <errno.h>
 
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
 #define dout_subsys ceph_subsys_
 
 static void global_init_set_globals(CephContext *cct)
@@ -261,6 +265,12 @@ void global_init(std::vector < const char * > *alt_def_args,
       priv_ss << "deferred set uid:gid to " << uid << ":" << gid << " (" << uid_string << ":" << gid_string << ")";
     }
   }
+
+#if defined(HAVE_SYS_PRCTL_H)
+  if (prctl(PR_SET_DUMPABLE, 1) == -1) {
+    cerr << "warning: unable to set dumpable flag: " << cpp_strerror(errno) << std::endl;
+  }
+#endif
 
   // Expand metavariables. Invoke configuration observers. Open log file.
   g_conf->apply_changes(NULL);


### PR DESCRIPTION
When ceph-* drops drops privileges via setuid, core dumps are no longer
generated because its DUMPABLE flag is cleared. We have to manually
turn that back on.

From prctl(2):

      Normally, this flag is set to 1.  However, it is reset to the current value contained in the file /proc/sys/fs/suid_dumpable (which by default has the value 0), in the fol‐
      lowing circumstances:

      *  The process's effective user or group ID is changed.

      *  The process's filesystem user or group ID is changed (see credentials(7)).

      *  The process executes (execve(2)) a set-user-ID or set-group-ID program, or a program that has capabilities (see capabilities(7)).

Fixes: http://tracker.ceph.com/issues/17650

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>