### PR TITLE
test/rgw: unit tests for RGWFetchAllMetaCR

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1775,6 +1775,15 @@ public:
   }
 };
 
+RGWRemoteMetaLog::RGWRemoteMetaLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
+                                   RGWMetaSyncStatusManager *_sm)
+  : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
+    store(_store), conn(NULL), async_rados(async_rados),
+    http_manager(store->ctx(), completion_mgr),
+    status_manager(_sm), error_logger(NULL), meta_sync_cr(NULL)
+{
+}
+
 void RGWRemoteMetaLog::init_sync_env(RGWMetaSyncEnv *env) {
   env->cct = store->ctx();
   env->store = store;

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -735,7 +735,7 @@ class RGWFetchAllMetaCR : public RGWCoroutine {
   list<string> result;
   list<string>::iterator iter;
 
-  RGWShardedOmapCRManager *entries_index;
+  std::unique_ptr<RGWBaseShardedOmapCRManager> entries_index;
 
   boost::intrusive_ptr<RGWBaseContinuousLeaseCR> lease_cr;
   RGWCoroutinesStack *lease_stack;
@@ -748,7 +748,7 @@ public:
   RGWFetchAllMetaCR(RGWMetaSyncEnv *_sync_env, int _num_shards,
                     map<uint32_t, rgw_meta_sync_marker>& _markers) : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
 						      num_shards(_num_shards),
-						      ret_status(0), entries_index(NULL), lease_stack(nullptr),
+						      ret_status(0), lease_stack(nullptr),
                                                       lost_lock(false), failed(false), markers(_markers) {
   }
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -722,13 +722,65 @@ int RGWReadSyncStatusCoroutine::handle_data(rgw_meta_sync_info& data)
   return 0;
 }
 
-class RGWFetchAllMetaCR : public RGWCoroutine {
+class DefaultFetchAllMetaEnv : public RGWFetchAllMetaEnv {
   RGWMetaSyncEnv *sync_env;
+  rgw_bucket& pool;
+  using ReadCR = RGWReadRESTResourceCR<std::list<std::string>>;
+
+ public:
+  DefaultFetchAllMetaEnv(RGWMetaSyncEnv *sync_env)
+    : sync_env(sync_env),
+      pool(sync_env->store->get_zone_params().log_pool)
+  {}
+
+  RGWBaseContinuousLeaseCR* create_lease(RGWCoroutine *parent) override
+  {
+    auto cct = sync_env->store->ctx();
+    uint32_t duration = cct->_conf->rgw_sync_lease_period;
+    return new RGWContinuousLeaseCR(sync_env->async_rados, sync_env->store,
+                                    pool, sync_env->status_oid(),
+                                    "sync_lock", duration, parent);
+  }
+  RGWBaseShardedOmapCRManager* create_omap_mgr(RGWCoroutine *parent,
+                                               int num_shards) override
+  {
+    return new RGWShardedOmapCRManager(sync_env->async_rados, sync_env->store,
+                                       parent, num_shards, pool,
+                                       mdlog_sync_full_sync_index_prefix);
+  }
+  RGWCoroutine* create_read_sections(std::list<std::string> *result) override
+  {
+    auto cct = sync_env->store->ctx();
+    return new ReadCR(cct, sync_env->conn, sync_env->http_manager,
+                      "/admin/metadata", nullptr, result);
+  }
+  RGWCoroutine* create_read_keys(const std::string& section,
+                                      std::list<std::string> *result) override
+  {
+    auto cct = sync_env->store->ctx();
+    return new ReadCR(cct, sync_env->conn, sync_env->http_manager,
+                      string("/admin/metadata/") + section, nullptr, result);
+  }
+  RGWCoroutine* create_write_marker(int shard_id,
+                                    const rgw_meta_sync_marker& marker) override
+  {
+    using WriteCR = RGWSimpleRadosWriteCR<rgw_meta_sync_marker>;
+    return new WriteCR(sync_env->async_rados, sync_env->store, pool,
+                       sync_env->shard_obj_name(shard_id), marker);
+  }
+
+  int get_log_shard_id(const std::string& section, const std::string& key,
+                       int *shard_id) override
+  {
+    return sync_env->store->meta_mgr->get_log_shard_id(section, key, shard_id);
+  }
+};
+
+class RGWFetchAllMetaCR : public RGWCoroutine {
+  RGWFetchAllMetaEnv *env;
 
   int num_shards;
-
-
-  int ret_status;
+  int ret_status{0};
 
   list<string> sections;
   list<string>::iterator sections_iter;
@@ -738,19 +790,17 @@ class RGWFetchAllMetaCR : public RGWCoroutine {
   std::unique_ptr<RGWBaseShardedOmapCRManager> entries_index;
 
   boost::intrusive_ptr<RGWBaseContinuousLeaseCR> lease_cr;
-  RGWCoroutinesStack *lease_stack;
-  bool lost_lock;
-  bool failed;
+  RGWCoroutinesStack *lease_stack{nullptr};
+  bool lost_lock{false};
+  bool failed{false};
 
   map<uint32_t, rgw_meta_sync_marker>& markers;
 
 public:
-  RGWFetchAllMetaCR(RGWMetaSyncEnv *_sync_env, int _num_shards,
-                    map<uint32_t, rgw_meta_sync_marker>& _markers) : RGWCoroutine(_sync_env->cct), sync_env(_sync_env),
-						      num_shards(_num_shards),
-						      ret_status(0), lease_stack(nullptr),
-                                                      lost_lock(false), failed(false), markers(_markers) {
-  }
+  RGWFetchAllMetaCR(CephContext *cct, RGWFetchAllMetaEnv *env,
+                    int num_shards, map<uint32_t, rgw_meta_sync_marker>& markers)
+    : RGWCoroutine(cct), env(env), num_shards(num_shards), markers(markers)
+  {}
 
   void append_section_from_set(set<string>& all_sections, const string& name) {
     set<string>::iterator iter = all_sections.find(name);
@@ -778,16 +828,11 @@ public:
   }
 
   int operate() {
-    RGWRESTConn *conn = sync_env->conn;
-
     reenter(this) {
       yield {
-        set_status(string("acquiring lock (") + sync_env->status_oid() + ")");
-	uint32_t lock_duration = cct->_conf->rgw_sync_lease_period;
-        string lock_name = "sync_lock";
-	lease_cr = new RGWContinuousLeaseCR(sync_env->async_rados, sync_env->store, sync_env->store->get_zone_params().log_pool, sync_env->status_oid(),
-                                            lock_name, lock_duration, this);
-        lease_stack = spawn(lease_cr, false);
+        set_status("acquiring lock");
+	lease_cr = env->create_lease(this);
+        lease_stack = spawn(lease_cr.get(), false);
       }
       while (!lease_cr->is_locked()) {
         if (lease_cr->is_done()) {
@@ -798,13 +843,10 @@ public:
         set_sleeping(true);
         yield;
       }
-      entries_index = new RGWShardedOmapCRManager(sync_env->async_rados, sync_env->store, this, num_shards,
-						  sync_env->store->get_zone_params().log_pool,
-                                                  mdlog_sync_full_sync_index_prefix);
-      yield {
-	call(new RGWReadRESTResourceCR<list<string> >(cct, conn, sync_env->http_manager,
-				       "/admin/metadata", NULL, &sections));
-      }
+      entries_index.reset(env->create_omap_mgr(this, num_shards));
+
+      // read the list of metadata sections
+      yield call(env->create_read_sections(&sections));
       if (get_ret_status() < 0) {
         ldout(cct, 0) << "ERROR: failed to fetch metadata sections" << dendl;
         yield lease_cr->go_down();
@@ -814,12 +856,9 @@ public:
       rearrange_sections();
       sections_iter = sections.begin();
       for (; sections_iter != sections.end(); ++sections_iter) {
-        yield {
-	  string entrypoint = string("/admin/metadata/") + *sections_iter;
-          /* FIXME: need a better scaling solution here, requires streaming output */
-	  call(new RGWReadRESTResourceCR<list<string> >(cct, conn, sync_env->http_manager,
-				       entrypoint, NULL, &result));
-	}
+        // read the metadata keys for this section
+        /* FIXME: need a better scaling solution here, requires streaming output */
+        yield call(env->create_read_keys(*sections_iter, &result));
         if (get_ret_status() < 0) {
           ldout(cct, 0) << "ERROR: failed to fetch metadata section: " << *sections_iter << dendl;
           yield lease_cr->go_down();
@@ -828,23 +867,20 @@ public:
         }
         iter = result.begin();
         for (; iter != result.end(); ++iter) {
-          RGWRados *store;
-          int ret;
           yield {
             if (!lease_cr->is_locked()) {
               lost_lock = true;
               break;
             }
 	    ldout(cct, 20) << "list metadata: section=" << *sections_iter << " key=" << *iter << dendl;
-	    string s = *sections_iter + ":" + *iter;
             int shard_id;
-            store = sync_env->store;
-            ret = store->meta_mgr->get_log_shard_id(*sections_iter, *iter, &shard_id);
+            int ret = env->get_log_shard_id(*sections_iter, *iter, &shard_id);
             if (ret < 0) {
               ldout(cct, 0) << "ERROR: could not determine shard id for " << *sections_iter << ":" << *iter << dendl;
               ret_status = ret;
               break;
             }
+	    string s = *sections_iter + ":" + *iter;
 	    if (!entries_index->append(s, shard_id)) {
               break;
             }
@@ -857,12 +893,11 @@ public:
         }
       }
       if (!failed) {
-        for (map<uint32_t, rgw_meta_sync_marker>::iterator iter = markers.begin(); iter != markers.end(); ++iter) {
+        for (auto iter = markers.begin(); iter != markers.end(); ++iter) {
           int shard_id = (int)iter->first;
           rgw_meta_sync_marker& marker = iter->second;
           marker.total_entries = entries_index->get_total_entries(shard_id);
-          spawn(new RGWSimpleRadosWriteCR<rgw_meta_sync_marker>(sync_env->async_rados, sync_env->store, sync_env->store->get_zone_params().log_pool,
-                                                                sync_env->shard_obj_name(shard_id), marker), true);
+          spawn(env->create_write_marker(shard_id, marker), true);
         }
       }
 
@@ -894,6 +929,12 @@ public:
     return 0;
   }
 };
+
+RGWCoroutine* create_fetch_all_meta_cr(CephContext *cct, RGWFetchAllMetaEnv *env,
+                                       int num_shards, std::map<uint32_t, rgw_meta_sync_marker>& markers)
+{
+  return new RGWFetchAllMetaCR(cct, env, num_shards, markers);
+}
 
 static string full_sync_index_shard_oid(int shard_id)
 {
@@ -1967,7 +2008,11 @@ int RGWRemoteMetaLog::run_sync()
     switch ((rgw_meta_sync_info::SyncState)sync_status.sync_info.state) {
       case rgw_meta_sync_info::StateBuildingFullSyncMaps:
         ldout(store->ctx(), 20) << __func__ << "(): building full sync maps" << dendl;
-        r = run(new RGWFetchAllMetaCR(&sync_env, num_shards, sync_status.sync_markers));
+        {
+          DefaultFetchAllMetaEnv fetch_env(&sync_env);
+          r = run(create_fetch_all_meta_cr(store->ctx(), &fetch_env, num_shards,
+                                           sync_status.sync_markers));
+        }
         if (r == -EBUSY || r == -EAGAIN) {
           backoff.backoff_sleep();
           continue;

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -451,5 +451,31 @@ public:
   int operate();
 };
 
+class RGWBaseContinuousLeaseCR;
+class RGWBaseShardedOmapCRManager;
+
+class RGWFetchAllMetaEnv {
+ public:
+  virtual ~RGWFetchAllMetaEnv() = default;
+
+  // child cr factories to support unit testing
+  virtual RGWBaseContinuousLeaseCR* create_lease(RGWCoroutine *parent) = 0;
+  virtual RGWBaseShardedOmapCRManager* create_omap_mgr(RGWCoroutine *parent,
+                                                       int num_shards) = 0;
+  virtual RGWCoroutine* create_read_sections(std::list<std::string> *res) = 0;
+  virtual RGWCoroutine* create_read_keys(const std::string& section,
+                                         std::list<std::string> *res) = 0;
+  virtual RGWCoroutine* create_write_marker(int shard_id,
+                                            const rgw_meta_sync_marker& m) = 0;
+
+  virtual int get_log_shard_id(const std::string& section,
+                               const std::string& key, int *shard_id) = 0;
+};
+
+// create a coroutine to build the full sync maps for metadata
+extern RGWCoroutine* create_fetch_all_meta_cr(CephContext *cct,
+                                              RGWFetchAllMetaEnv *env,
+                                              int num_shards,
+                                              std::map<uint32_t, rgw_meta_sync_marker>& markers);
 
 #endif

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -3,6 +3,7 @@
 
 #include "rgw_coroutine.h"
 #include "rgw_http_client.h"
+#include "rgw_metadata.h"
 #include "rgw_meta_sync_status.h"
 
 #include "include/stringify.h"
@@ -200,12 +201,7 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
 
 public:
   RGWRemoteMetaLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                   RGWMetaSyncStatusManager *_sm)
-    : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
-      store(_store), conn(NULL), async_rados(async_rados),
-      http_manager(store->ctx(), completion_mgr),
-      status_manager(_sm), error_logger(NULL), meta_sync_cr(NULL) {}
-
+                   RGWMetaSyncStatusManager *_sm);
   ~RGWRemoteMetaLog();
 
   int init();

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -3,6 +3,11 @@ add_executable(unittest_rgw_bencode test_rgw_bencode.cc)
 add_ceph_unittest(unittest_rgw_bencode ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_bencode)
 target_link_libraries(unittest_rgw_bencode rgw_a)
 
+#unittest_rgw_sync_crs
+add_executable(unittest_rgw_sync_crs test_rgw_sync_crs.cc)
+add_ceph_unittest(unittest_rgw_sync_crs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_sync_crs)
+target_link_libraries(unittest_rgw_sync_crs rgw_a)
+
 #unitttest_rgw_period_history
 add_executable(unittest_rgw_period_history test_rgw_period_history.cc)
 add_ceph_unittest(unittest_rgw_period_history ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_period_history)

--- a/src/test/rgw/test_rgw_sync_crs.cc
+++ b/src/test/rgw/test_rgw_sync_crs.cc
@@ -1,0 +1,357 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "gtest/gtest.h"
+
+#include <boost/intrusive_ptr.hpp>
+
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+
+#include "rgw/rgw_sync.h"
+#include "rgw/rgw_cr_rados.h"
+#include "rgw/rgw_boost_asio_yield.h"
+
+
+// coroutine to call the given function object
+class MockCR : public RGWCoroutine {
+  std::function<int()> func;
+ public:
+  MockCR(std::function<int()>&& func)
+    : RGWCoroutine(g_ceph_context), func(std::move(func))
+  {}
+  int operate() override {
+    reenter(this) {
+      int ret = func();
+      if (ret < 0) {
+        return set_cr_error(ret);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+
+// mock lease cr to start locked and sleep until unlocked
+class MockLeaseCR : public RGWBaseContinuousLeaseCR {
+  bool locked{true};
+ public:
+  MockLeaseCR() : RGWBaseContinuousLeaseCR(g_ceph_context) {}
+
+  bool is_locked() override { return locked; }
+  void set_locked(bool l) override { locked = l; set_sleeping(false); }
+  void go_down() override { set_locked(false); }
+  void abort() override { set_locked(false); }
+
+  int operate() override {
+    reenter(this) {
+      while (locked) {
+        yield set_sleeping(true);
+      }
+      return set_cr_done();
+    }
+    return 0;
+  }
+};
+
+// mock omap mgr stores entries in memory
+class MockShardedOmapManager : public RGWBaseShardedOmapCRManager {
+  // store the entries for each shard
+  using Shard = std::vector<std::string>;
+  std::vector<Shard> shards;
+  boost::intrusive_ptr<RGWBaseContinuousLeaseCR> cr;
+
+ public:
+  MockShardedOmapManager(RGWCoroutine *parent, int num_shards)
+    : shards(num_shards)
+  {
+    // spawn a coroutine that will remain running until finish(). this
+    // simulates the RGWOmapAppend crs, to make sure we clean up properly on
+    // error paths - failure to call finish() will lead to a coroutine deadlock
+    cr = new MockLeaseCR();
+    parent->spawn(cr.get(), false);
+  }
+  bool append(const string& entry, int shard_id) override {
+    shards[shard_id].push_back(entry);
+    return true;
+  }
+  bool finish() override {
+    cr->go_down();
+    return true;
+  }
+  uint64_t get_total_entries(int shard_id) override {
+    return shards[shard_id].size();
+  }
+};
+
+// default no-op mock for RGWFetchAllMetaEnv
+class MockFetchAllMetaEnv : public RGWFetchAllMetaEnv {
+ public:
+  RGWBaseContinuousLeaseCR* create_lease(RGWCoroutine *parent) override {
+    return new MockLeaseCR();
+  }
+  RGWBaseShardedOmapCRManager* create_omap_mgr(RGWCoroutine *parent,
+                                               int num_shards) override {
+    return new MockShardedOmapManager(parent, num_shards);
+  }
+  RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+    return new MockCR([] { return 0; });
+  }
+  RGWCoroutine* create_read_keys(const std::string& section,
+                                 std::list<std::string> *res) override {
+    return new MockCR([] { return 0; });
+  }
+  RGWCoroutine* create_write_marker(int shard_id,
+                                    const rgw_meta_sync_marker& m) override {
+    return new MockCR([] { return 0; });
+  }
+  int get_log_shard_id(const std::string& section,
+                       const std::string& key, int *shard_id) override {
+    *shard_id = 0; // map everything to the first shard
+    return 0;
+  }
+};
+
+using Markers = std::map<uint32_t, rgw_meta_sync_marker>;
+
+
+// test lease failure
+
+// mock lease that injects the given error
+class FailedLeaseCR : public RGWBaseContinuousLeaseCR {
+  const int err;
+ public:
+  FailedLeaseCR(int err) : RGWBaseContinuousLeaseCR(g_ceph_context), err(err) {}
+  bool is_locked() override { return false; }
+  void set_locked(bool status) override {}
+  void go_down() override {}
+  void abort() override {}
+  int operate() override { return set_cr_error(retcode = err); }
+};
+
+TEST(FetchAllMeta, LeaseBusy)
+{
+  struct MockEnv : public MockFetchAllMetaEnv {
+    RGWBaseContinuousLeaseCR* create_lease(RGWCoroutine *parent) override {
+      return new FailedLeaseCR(-EBUSY);
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-EBUSY, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                     markers.size(), markers)));
+}
+
+TEST(FetchAllMeta, LeaseLost)
+{
+  class MockEnv : public MockFetchAllMetaEnv {
+    boost::intrusive_ptr<RGWBaseContinuousLeaseCR> lease;
+   public:
+    RGWBaseContinuousLeaseCR* create_lease(RGWCoroutine *parent) override {
+      lease = new MockLeaseCR();
+      return lease.get();
+    }
+    RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+      return new MockCR([res] { res->emplace_back("section"); return 0; });
+    }
+    RGWCoroutine* create_read_keys(const std::string& section,
+                                   std::list<std::string> *res) override {
+      lease->set_locked(false);
+      return new MockCR([res] { res->emplace_back("key"); return 0; });
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-EBUSY, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                     markers.size(), markers)));
+}
+
+
+// test omap append failures
+
+TEST(FetchAllMeta, OmapAppendErr)
+{
+  // test that append() failures are non-fatal, as long as finish() succeeds
+  struct MockEnv : public MockFetchAllMetaEnv {
+    RGWBaseShardedOmapCRManager* create_omap_mgr(RGWCoroutine *parent,
+                                                 int num_shards) override {
+      class MockOmapMgr : public RGWBaseShardedOmapCRManager {
+       public:
+        bool append(const string&, int) override { return false; }
+        bool finish() override { return true; }
+        uint64_t get_total_entries(int) override { return 0; }
+      };
+      return new MockOmapMgr();
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(0, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                markers.size(), markers)));
+}
+
+TEST(FetchAllMeta, OmapFinishErr)
+{
+  // test that finish() failures lead to -EIO
+  struct MockEnv : public MockFetchAllMetaEnv {
+    RGWBaseShardedOmapCRManager* create_omap_mgr(RGWCoroutine *parent,
+                                                 int num_shards) override {
+      class MockOmapMgr : public RGWBaseShardedOmapCRManager {
+       public:
+        bool append(const string&, int) override { return true; }
+        bool finish() override { return false; }
+        uint64_t get_total_entries(int) override { return 0; }
+      };
+      return new MockOmapMgr();
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-EIO, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                   markers.size(), markers)));
+}
+
+
+// test get_log_shard_id errors
+
+TEST(FetchAllMeta, LogShardErr)
+{
+  struct MockEnv : public MockFetchAllMetaEnv {
+    // return an obscure error code
+    int get_log_shard_id(const std::string&, const std::string&, int*) override {
+      return -EXDEV;
+    }
+    // return a section/key so we have something to call get_log_shard_id() on
+    RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+      return new MockCR([res] { res->emplace_back("section"); return 0; });
+    }
+    RGWCoroutine* create_read_keys(const std::string& section,
+                                   std::list<std::string> *res) override {
+      return new MockCR([res] { res->emplace_back("key"); return 0; });
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-EXDEV, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                     markers.size(), markers)));
+}
+
+
+// test successful crs with varying section data
+
+// in-memory representation of the full sync map
+using AllMetaMap = std::map<std::string, std::list<std::string>>;
+
+// mock that satisfies reads from the given sync map
+class Readable_FetchAllMetaEnv : public MockFetchAllMetaEnv {
+  AllMetaMap sections;
+ public:
+  Readable_FetchAllMetaEnv() = default;
+  Readable_FetchAllMetaEnv(AllMetaMap&& sections)
+    : sections(std::move(sections)) {}
+
+  RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+    return new MockCR([this, res] {
+                            for (auto& s : sections) {
+                              res->push_back(s.first);
+                            }
+                            return 0;
+                          });
+  }
+  RGWCoroutine* create_read_keys(const std::string& section,
+                                 std::list<std::string> *res) override {
+    return new MockCR([this, &section, res] {
+                            auto i = sections.find(section);
+                            if (i == sections.end()) {
+                              return -ENOENT;
+                            }
+                            *res = i->second; // return a copy
+                            return 0;
+                          });
+  }
+};
+
+TEST(FetchAllMeta, ReadNoSections)
+{
+  Readable_FetchAllMetaEnv env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(0, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                markers.size(), markers)));
+  ASSERT_EQ(0u, markers[0].total_entries);
+}
+
+TEST(FetchAllMeta, ReadEmptySection)
+{
+  AllMetaMap sections{
+    {"bucket", {}},
+  };
+  Readable_FetchAllMetaEnv env(std::move(sections));
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(0, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                markers.size(), markers)));
+  ASSERT_EQ(0u, markers[0].total_entries);
+}
+
+TEST(FetchAllMeta, ReadTwoSections)
+{
+  AllMetaMap sections{
+    {"bucket", {"a","b","c"}},
+    {"user", {"d", "e", "f"}},
+  };
+  // TODO: test for rearrange_sections()
+  Readable_FetchAllMetaEnv env(std::move(sections));
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(0, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                markers.size(), markers)));
+  ASSERT_EQ(6u, markers[0].total_entries);
+}
+
+
+// test read failures
+
+TEST(FetchAllMeta, ReadSectionsEIO)
+{
+  struct MockEnv : public MockFetchAllMetaEnv {
+    RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+      return new MockCR([] { return -EIO; });
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-EIO, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                   markers.size(), markers)));
+}
+
+TEST(FetchAllMeta, ReadKeysENOENT)
+{
+  // return a single section "foo", and fail to read that section with ENOENT
+  struct MockEnv : public MockFetchAllMetaEnv {
+    RGWCoroutine* create_read_sections(std::list<std::string> *res) override {
+      return new MockCR([res] { res->emplace_back("foo"); return 0; });
+    }
+    RGWCoroutine* create_read_keys(const std::string& section,
+                                   std::list<std::string> *res) override {
+      return new MockCR([] { return -ENOENT; });
+    }
+  } env;
+  RGWCoroutinesManager crs(g_ceph_context, nullptr);
+  Markers markers{{0, {}}};
+  ASSERT_EQ(-ENOENT, crs.run(create_fetch_all_meta_cr(g_ceph_context, &env,
+                                                      markers.size(), markers)));
+}
+
+
+// global context init
+int main(int argc, char** argv)
+{
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
this is an experiment to build up unit tests for rgw sync coroutines. RGWFetchAllMetaCR is a convenient place to start, because it doesn't have a deep call stack - this means the factory interface is small

note that the tests for `ReadSectionsEIO` and `ReadKeysENOENT` will deadlock without https://github.com/ceph/ceph/pull/11505
