### PR TITLE
rgw: fix rgw crash when client post object with null conditions

### DIFF
--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -276,6 +276,10 @@ int RGWPolicy::from_json(bufferlist& bl, string& err_msg)
       int i;
       for (i = 0; !citer.end() && i < 3; ++citer, ++i) {
 	JSONObj *o = *citer;
+        const string& condition_data = o->get_data();
+        if (condition_data.empty()) {
+            return -EINVAL;
+        }
         v.push_back(o->get_data());
       }
       if (i != 3 || !citer.end()) { /* we expect exactly 3 arguments here */


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17631

Signed-off-by: Feng Guo <diluga@gmail.com>
(cherry picked from commit 0cdf81a507748571b08496c19f09b9f693ee0902)