### PR TITLE
ceph_test_objectstore: smaller device

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5737,6 +5737,9 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("bluestore_buffer_cache_size", "2000000");
   g_ceph_context->_conf->set_val("bluestore_onode_cache_size", "500");
 
+  // specify device size
+  g_ceph_context->_conf->set_val("bluestore_block_size", "10240000000");
+
   g_ceph_context->_conf->set_val(
     "enable_experimental_unrecoverable_data_corrupting_features", "*");
   g_ceph_context->_conf->apply_changes(NULL);


### PR DESCRIPTION
This is faster.  The bitmap has to be scanned during
startup and fsck and that's slow.

Signed-off-by: Sage Weil <sage@redhat.com>