### PR TITLE
osdc/ObjectCacher: wake up dirty stat waiters after removing buffers

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -2592,5 +2592,7 @@ void ObjectCacher::bh_remove(Object *ob, BufferHead *bh)
     dirty_or_tx_bh.erase(bh);
   }
   bh_stat_sub(bh);
+  if (get_stat_dirty_waiting() > 0)
+    stat_cond.Signal();
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17275
Signed-off-by: Yan, Zheng <zyan@redhat.com>