### PR TITLE
rgw: fix for passing temporary in InitBucketSyncStatus

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1815,8 +1815,7 @@ public:
 
 RGWCoroutine *RGWRemoteBucketLog::init_sync_status_cr()
 {
-  rgw_bucket_shard_sync_info sync_status;
-  return new RGWInitBucketShardSyncStatusCoroutine(&sync_env, bs, sync_status);
+  return new RGWInitBucketShardSyncStatusCoroutine(&sync_env, bs, init_status);
 }
 
 template <class T>

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -451,6 +451,7 @@ class RGWRemoteBucketLog : public RGWCoroutinesManager {
   RGWHTTPManager *http_manager;
 
   RGWDataSyncEnv sync_env;
+  rgw_bucket_shard_sync_info init_status;
 
   RGWBucketSyncCR *sync_cr{nullptr};
 


### PR DESCRIPTION
RGWInitBucketShardSyncStatusCoroutine was recently changed to store its sync_status by reference. This works fine when called via RGWRunBucketShardSyncCoroutine, but not in RGWBucketSyncStatusManager::init_sync_status() which is used by radosgw-admin. RGWBucketSyncStatusManager::init_sync_status() returns a coroutine with a reference to a temporary local variable, leading to a crash

Fixes: http://tracker.ceph.com/issues/17661