### PR TITLE
rgw multisite: move lease up to RunBucketSync instead of child crs

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1778,17 +1778,6 @@ public:
 	  return set_cr_error(retcode);
 	}
       }
-      yield call(new RGWSimpleRadosWriteCR<rgw_bucket_shard_sync_info>(sync_env->async_rados, store, store->get_zone_params().log_pool,
-				 sync_status_oid, status));
-      yield { /* take lock again, we just recreated the object */
-	uint32_t lock_duration = 30;
-	call(new RGWSimpleRadosLockCR(sync_env->async_rados, store, store->get_zone_params().log_pool, sync_status_oid,
-			             lock_name, cookie, lock_duration));
-	if (retcode < 0) {
-	  ldout(cct, 0) << "ERROR: failed to take a lock on " << sync_status_oid << dendl;
-	  return set_cr_error(retcode);
-	}
-      }
       /* fetch current position in logs */
       yield call(new RGWReadRemoteBucketIndexLogInfoCR(sync_env, bs, &info));
       if (retcode < 0 && retcode != -ENOENT) {


### PR DESCRIPTION
`RGWRunBucketSyncCoroutine` is storing a cached copy of the `rgw_bucket_shard_sync_info sync_status` between its calls to its child coroutines `RGWInitBucketShardSyncStatusCoroutine`, `RGWBucketShardFullSyncCR`, and `RGWBucketShardIncrementalSyncCR`. But each of these coroutines is acquiring and releasing a lock on the sync status, so another gateway could potentially acquire the lock and modify the sync status in between.

This patch set moves the lease from each of these child coroutines into `RGWRunBucketSyncCoroutine` itself, which it holds across all of the coroutines it spawns. Not only does this eliminate the race to read/update the sync status, but it also reduces the number of round trips to release/reacquire the lease, and simplifies the child coroutines significantly. In cases where the lock is already held by someone else, it also avoids doing a lot of work (reading the sync status, and reading bucket info/syncing it from the master) before failing with EBUSY.

`RGWBucketShardFullSyncCR` and `RGWBucketShardIncrementalSyncCR` now take a pointer to the `lease_cr` from `RGWRunBucketSyncCoroutine`, so they can check `lease_cr->is_locked()` and fail with `-ECANCELED` on a broken lease.
