### PR TITLE
os/bluestore: make 2q cache kin/kout size tunable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -996,6 +996,8 @@ OPTION(bluestore_extent_map_shard_min_size, OPT_U32, 150)
 OPTION(bluestore_extent_map_shard_target_size_slop, OPT_DOUBLE, .2)
 OPTION(bluestore_extent_map_inline_shard_prealloc_size, OPT_U32, 256)
 OPTION(bluestore_cache_type, OPT_STR, "2q")   // lru, 2q
+OPTION(bluestore_2q_cache_kin_ratio, OPT_DOUBLE, .5)    // kin page slot size / max page slot size
+OPTION(bluestore_2q_cache_kout_ratio, OPT_DOUBLE, .5)   // number of kout page slot / total number of page slot
 OPTION(bluestore_onode_cache_size, OPT_U32, 4*1024)
 OPTION(bluestore_buffer_cache_size, OPT_U32, 512*1024*1024)
 OPTION(bluestore_kvbackend, OPT_STR, "rocksdb")

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -710,8 +710,8 @@ void BlueStore::TwoQCache::trim(uint64_t onode_max, uint64_t buffer_max)
 
   // buffers
   if (buffer_bytes > buffer_max) {
-    uint64_t kin = buffer_max / 2;
-    uint64_t khot = kin;
+    uint64_t kin = buffer_max * g_conf->bluestore_2q_cache_kin_ratio;
+    uint64_t khot = buffer_max - kin;
 
     // pre-calculate kout based on average buffer size too,
     // which is typical(the warm_in and hot lists may change later)
@@ -720,7 +720,8 @@ void BlueStore::TwoQCache::trim(uint64_t onode_max, uint64_t buffer_max)
     if (buffer_num) {
       uint64_t buffer_avg_size = buffer_bytes / buffer_num;
       assert(buffer_avg_size);
-      kout = buffer_max / buffer_avg_size;
+      uint64_t caculated_buffer_num = buffer_max / buffer_avg_size;
+      kout = caculated_buffer_num * g_conf->bluestore_2q_cache_kout_ratio;
     }
 
     if (buffer_list_bytes[BUFFER_HOT] < khot) {


### PR DESCRIPTION
default kin/hot queue size is 50% of max buffer size.
50% is a better choice for the number of page slot in kout.
we make it tunable.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>