### PR TITLE
ceph-disk: missing return when a file is used for journal

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1927,6 +1927,7 @@ class PrepareSpace(object):
                 raise Error('%s is not a block device' % name.capitalize,
                             getattr(args, name))
             self.type = self.FILE
+            return
 
         raise Error('%s %s is neither a block device nor regular file' %
                     (name.capitalize, getattr(args, name)))


### PR DESCRIPTION
http://tracker.ceph.com/issues/17662

ceps-disk is missing a return statement when preparing the journal space when it is regular file. 