### PR TITLE
os/bluestore: clear extent map on object removal

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8122,6 +8122,7 @@ int BlueStore::_do_remove(
     txc->t->rmkey(PREFIX_OBJ, s.key);
   }
   txc->t->rmkey(PREFIX_OBJ, o->key);
+  o->extent_map.clear();
   _debug_obj_on_delete(o->oid);
   return 0;
 }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -604,6 +604,14 @@ public:
       extent_map.clear_and_dispose([&](Extent *e) { delete e; });
     }
 
+    void clear() {
+      extent_map.clear();
+      extent_map.clear_and_dispose([&](Extent *e) { delete e; });
+      shards.clear();
+      inline_bl.clear();
+      needs_reshard = false;
+    }
+
     bool encode_some(uint32_t offset, uint32_t length, bufferlist& bl,
 		     unsigned *pn);
     void decode_some(bufferlist& bl);


### PR DESCRIPTION
Clear ExtentMap (esp shards, etc.) when an object is removed.  Otherwise
if we recreate it we will have stale state (like the shards vector or
inline_bl) that are bogus.

Signed-off-by: Sage Weil <sage@redhat.com>