### PR TITLE
messages/MForward: reencode forwarded message if target has differing features

### DIFF
--- a/src/messages/MForward.h
+++ b/src/messages/MForward.h
@@ -77,6 +77,9 @@ public:
     // message are changed when reencoding with more features than the
     // client had originally.  That should never happen, but we may as
     // well be defensive here.
+    if (con_features != features) {
+      msg->clear_payload();
+    }
     encode_message(msg, features & con_features, payload);
     ::encode(con_features, payload);
     ::encode(entity_name, payload);

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -190,7 +190,12 @@ void Message::encode(uint64_t features, int crcflags)
 {
   // encode and copy out of *m
   if (empty_payload()) {
+    assert(middle.length() == 0);
     encode_payload(features);
+
+    if (byte_throttler) {
+      byte_throttler->take(payload.length() + middle.length());
+    }
 
     // if the encoder didn't specify past compatibility, we assume it
     // is incompatible.

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -361,10 +361,10 @@ public:
 
   void set_middle(bufferlist& bl) {
     if (byte_throttler)
-      byte_throttler->put(payload.length());
+      byte_throttler->put(middle.length());
     middle.claim(bl, buffer::list::CLAIM_ALLOW_NONSHAREABLE);
     if (byte_throttler)
-      byte_throttler->take(payload.length());
+      byte_throttler->take(middle.length());
   }
   bufferlist& get_middle() { return middle; }
 

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -329,8 +329,9 @@ public:
    */
 
   void clear_payload() {
-    if (byte_throttler)
+    if (byte_throttler) {
       byte_throttler->put(payload.length() + middle.length());
+    }
     payload.clear();
     middle.clear();
   }


### PR DESCRIPTION
This ensures we reencode the payload with the
appropriate set of features if the client, us, or the
target do not have identical features.  Otherwise we
may forward an encoding with more features than the
target can handle.

Signed-off-by: Sage Weil <sage@redhat.com>