### PR TITLE
mds: check if down mds is known

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1548,7 +1548,7 @@ void MDSRankDispatcher::handle_mds_map(
     oldmap->get_down_mds_set(&olddown);
     mdsmap->get_down_mds_set(&down);
     for (set<mds_rank_t>::iterator p = down.begin(); p != down.end(); ++p) {
-      if (olddown.count(*p) == 0) {
+      if (oldmap->have_inst(*p) && olddown.count(*p) == 0) {
         messenger->mark_down(oldmap->get_inst(*p).addr);
         handle_mds_failure(*p);
       }


### PR DESCRIPTION
This avoids an assertion failure where an MDS receives an mdsmap that
causes it to enter up:replay and also see another MDS go down.

Fixes: http://tracker.ceph.com/issues/17670

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>