### PR TITLE
osd: Include OSD ID in metadata data

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4945,6 +4945,7 @@ void OSD::_collect_metadata(map<string,string> *pm)
   (*pm)["ceph_version"] = pretty_version_to_str();
 
   // config info
+  (*pm)["osd_id"] = std::to_string(whoami);
   (*pm)["osd_data"] = dev_path;
   (*pm)["osd_journal"] = journal_path;
   (*pm)["front_addr"] = stringify(client_messenger->get_myaddr());


### PR DESCRIPTION
This way the output returned can be easily JSON parsed and includes
the OSD's ID in the JSON.

Signed-off-by: Wido den Hollander <wido@42on.com>