### PR TITLE
mds/CInode: fix build failing due to duplicate var definitions

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3819,8 +3819,6 @@ void CInode::validate_disk_state(CInode::validated_data *results,
       // Ignore rval because it's the result of a FAILOK operation
       // from fetch_backtrace_and_tag: the real result is in
       // backtrace.ondisk_read_retval
-      MDCache *mdcache = in->mdcache;
-      const inode_t& inode = in->inode;
       dout(20) << "ondisk_read_retval: " << results->backtrace.ondisk_read_retval << dendl;
       if (results->backtrace.ondisk_read_retval != 0) {
         results->backtrace.error_str << "failed to read off disk; see retval";


### PR DESCRIPTION
Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>