### PR TITLE
librbd: ensure consistency groups will gracefully fail on older OSDs

### DIFF
--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -35,8 +35,7 @@ namespace librbd {
                                     std::map<rados::cls::lock::locker_id_t,
                                              rados::cls::lock::locker_info_t> *lockers,
                                     bool *exclusive_lock, std::string *lock_tag,
-				    ::SnapContext *snapc, parent_info *parent,
-				    cls::rbd::GroupSpec *uplink);
+				    ::SnapContext *snapc, parent_info *parent);
     int get_mutable_metadata(librados::IoCtx *ioctx, const std::string &oid,
 			     bool read_only, uint64_t *size, uint64_t *features,
 			     uint64_t *incompatible_features,
@@ -45,8 +44,7 @@ namespace librbd {
 			     bool *exclusive_lock,
 			     std::string *lock_tag,
 			     ::SnapContext *snapc,
-			     parent_info *parent,
-			     cls::rbd::GroupSpec *uplink);
+			     parent_info *parent);
 
     // low-level interface (mainly for testing)
     void create_image(librados::ObjectWriteOperation *op, uint64_t size,
@@ -346,15 +344,18 @@ namespace librbd {
     int group_image_list(librados::IoCtx *ioctx, const std::string &oid,
 			 const cls::rbd::GroupImageSpec &start,
 			 uint64_t max_return,
-			 std::vector<cls::rbd::GroupImageStatus>& images);
+			 std::vector<cls::rbd::GroupImageStatus> *images);
     int group_image_set(librados::IoCtx *ioctx, const std::string &oid,
 			const cls::rbd::GroupImageStatus &st);
     int image_add_group(librados::IoCtx *ioctx, const std::string &oid,
 	                const cls::rbd::GroupSpec &group_spec);
     int image_remove_group(librados::IoCtx *ioctx, const std::string &oid,
 			   const cls::rbd::GroupSpec &group_spec);
+    void image_get_group_start(librados::ObjectReadOperation *op);
+    int image_get_group_finish(bufferlist::iterator *iter,
+                               cls::rbd::GroupSpec *group_spec);
     int image_get_group(librados::IoCtx *ioctx, const std::string &oid,
-			cls::rbd::GroupSpec &s);
+			cls::rbd::GroupSpec *group_spec);
 
   } // namespace cls_client
 } // namespace librbd

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -164,14 +164,14 @@ public:
   // RBD consistency groups support functions
   int group_create(IoCtx& io_ctx, const char *group_name);
   int group_remove(IoCtx& io_ctx, const char *group_name);
-  int group_list(IoCtx& io_ctx, std::vector<std::string>& names);
+  int group_list(IoCtx& io_ctx, std::vector<std::string> *names);
 
   int group_image_add(IoCtx& io_ctx, const char *group_name,
 		      IoCtx& image_io_ctx, const char *image_name);
   int group_image_remove(IoCtx& io_ctx, const char *group_name,
 			 IoCtx& image_io_ctx, const char *image_name);
   int group_image_list(IoCtx& io_ctx, const char *group_name,
-		       std::vector<group_image_status_t>& images);
+		       std::vector<group_image_status_t> *images);
 
 private:
   /* We don't allow assignment or copying */

--- a/src/librbd/Group.h
+++ b/src/librbd/Group.h
@@ -8,13 +8,14 @@ namespace librbd {
 // Consistency groups functions
 int group_create(librados::IoCtx& io_ctx, const char *imgname);
 int group_remove(librados::IoCtx& io_ctx, const char *group_name);
-int group_list(librados::IoCtx& io_ctx, std::vector<std::string>& names);
+int group_list(librados::IoCtx& io_ctx, std::vector<std::string> *names);
 int group_image_add(librados::IoCtx& group_ioctx, const char *group_name,
 		    librados::IoCtx& image_ioctx, const char *image_name);
 int group_image_remove(librados::IoCtx& group_ioctx, const char *group_name,
 		       librados::IoCtx& image_ioctx, const char *image_name);
 int group_image_list(librados::IoCtx& group_ioctx, const char *group_name,
-		     std::vector<group_image_status_t>& images);
+		     std::vector<group_image_status_t> *images);
 int image_get_group(ImageCtx *ictx, group_spec_t *group_spec);
 }
+
 #endif // CEPH_LIBRBD_GROUP_H

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -256,8 +256,7 @@ Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
                                                       &m_lockers,
                                                       &m_exclusive_locked,
                                                       &m_lock_tag, &m_snapc,
-                                                      &m_parent_md,
-						      &m_group_spec);
+                                                      &m_parent_md);
   }
   if (*result < 0) {
     lderr(cct) << "failed to retrieve mutable metadata: "
@@ -334,6 +333,48 @@ Context *RefreshRequest<I>::handle_v2_get_flags(int *result) {
     return nullptr;
   } else if (*result < 0) {
     lderr(cct) << "failed to retrieve flags: " << cpp_strerror(*result)
+               << dendl;
+    return m_on_finish;
+  }
+
+  send_v2_get_group();
+  return nullptr;
+}
+
+template <typename I>
+void RefreshRequest<I>::send_v2_get_group() {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::image_get_group_start(&op);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp = create_rados_ack_callback<
+    klass, &klass::handle_v2_get_group>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                         &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_v2_get_group(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": "
+                 << "r=" << *result << dendl;
+
+  if (*result == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    cls_client::image_get_group_finish(&it, &m_group_spec);
+  }
+  if (*result == -EOPNOTSUPP) {
+    // Older OSD doesn't support RBD groups
+    *result = 0;
+    ldout(cct, 10) << "OSD does not support consistency groups" << dendl;
+  } else if (*result < 0) {
+    lderr(cct) << "failed to retrieve group: " << cpp_strerror(*result)
                << dendl;
     return m_on_finish;
   }
@@ -931,10 +972,9 @@ void RefreshRequest<I>::apply() {
     } else {
       m_image_ctx.features = m_features;
       m_image_ctx.flags = m_flags;
+      m_image_ctx.group_spec = m_group_spec;
       m_image_ctx.parent_md = m_parent_md;
     }
-
-     m_image_ctx.group_spec = m_group_spec;
 
     for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
       std::vector<librados::snap_t>::const_iterator it = std::find(

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -52,6 +52,9 @@ private:
    *            V2_GET_FLAGS                                  |
    *                |                                         |
    *                v                                         |
+   *            V2_GET_GROUP                                  |
+   *                |                                         |
+   *                v                                         |
    *            V2_GET_SNAPSHOTS (skip if no snaps)           |
    *                |                                         |
    *                v                                         |
@@ -154,6 +157,9 @@ private:
 
   void send_v2_get_flags();
   Context *handle_v2_get_flags(int *result);
+
+  void send_v2_get_group();
+  Context *handle_v2_get_group(int *result);
 
   void send_v2_get_snapshots();
   Context *handle_v2_get_snapshots(int *result);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -483,7 +483,7 @@ namespace librbd {
     return r;
   }
 
-  int RBD::group_list(IoCtx& io_ctx, vector<string>& names)
+  int RBD::group_list(IoCtx& io_ctx, vector<string> *names)
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, group_list_enter, io_ctx.get_pool_name().c_str(),
@@ -491,7 +491,7 @@ namespace librbd {
 
     int r = librbd::group_list(io_ctx, names);
     if (r >= 0) {
-      for (auto itr : names) {
+      for (auto itr : *names) {
 	tracepoint(librbd, group_list_entry, itr.c_str());
       }
     }
@@ -524,7 +524,7 @@ namespace librbd {
   }
 
   int RBD::group_image_list(IoCtx& group_ioctx, const char *group_name,
-                            std::vector<group_image_status_t>& images)
+                            std::vector<group_image_status_t> *images)
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
     tracepoint(librbd, group_image_list_enter, group_ioctx.get_pool_name().c_str(),
@@ -3237,7 +3237,7 @@ extern "C" int rbd_group_image_list(rados_ioctx_t group_p,
 	     group_ioctx.get_id(), group_name);
 
   std::vector<librbd::group_image_status_t> cpp_images;
-  int r = librbd::group_image_list(group_ioctx, group_name, cpp_images);
+  int r = librbd::group_image_list(group_ioctx, group_name, &cpp_images);
 
   if (r == -ENOENT) {
     tracepoint(librbd, group_image_list_exit, 0);

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1057,19 +1057,18 @@ TEST_F(TestClsRbd, get_mutable_metadata_features)
   std::string lock_tag;
   ::SnapContext snapc;
   parent_info parent;
-  cls::rbd::GroupSpec group_spec;
 
   ASSERT_EQ(0, get_mutable_metadata(&ioctx, oid, true, &size, &features,
 				    &incompatible_features, &lockers,
 				    &exclusive_lock, &lock_tag, &snapc,
-                                    &parent, &group_spec));
+                                    &parent));
   ASSERT_EQ(static_cast<uint64_t>(RBD_FEATURE_EXCLUSIVE_LOCK), features);
   ASSERT_EQ(0U, incompatible_features);
 
   ASSERT_EQ(0, get_mutable_metadata(&ioctx, oid, false, &size, &features,
                                     &incompatible_features, &lockers,
                                     &exclusive_lock, &lock_tag, &snapc,
-				    &parent, &group_spec));
+				    &parent));
   ASSERT_EQ(static_cast<uint64_t>(RBD_FEATURE_EXCLUSIVE_LOCK), features);
   ASSERT_EQ(static_cast<uint64_t>(RBD_FEATURE_EXCLUSIVE_LOCK),
 	    incompatible_features);
@@ -2004,14 +2003,16 @@ TEST_F(TestClsRbd, group_image_list) {
 
   vector<cls::rbd::GroupImageStatus> images;
   cls::rbd::GroupImageSpec empty_image_spec = cls::rbd::GroupImageSpec();
-  ASSERT_EQ(0, group_image_list(&ioctx, group_id, empty_image_spec, 1024, images));
+  ASSERT_EQ(0, group_image_list(&ioctx, group_id, empty_image_spec, 1024,
+                                &images));
   ASSERT_EQ(1U, images.size());
   ASSERT_EQ(image_id, images[0].spec.image_id);
   ASSERT_EQ(pool_id, images[0].spec.pool_id);
   ASSERT_EQ(cls::rbd::GROUP_IMAGE_LINK_STATE_INCOMPLETE, images[0].state);
 
   cls::rbd::GroupImageStatus last_image = *images.rbegin();
-  ASSERT_EQ(0, group_image_list(&ioctx, group_id, last_image.spec, 1024, images));
+  ASSERT_EQ(0, group_image_list(&ioctx, group_id, last_image.spec, 1024,
+                                &images));
   ASSERT_EQ(0U, images.size());
 }
 
@@ -2113,7 +2114,7 @@ TEST_F(TestClsRbd, image_get_group) {
   ASSERT_EQ(0, image_add_group(&ioctx, image_id, spec_add));
 
   cls::rbd::GroupSpec spec;
-  ASSERT_EQ(0, image_get_group(&ioctx, image_id, spec));
+  ASSERT_EQ(0, image_get_group(&ioctx, image_id, &spec));
 
   ASSERT_EQ(group_id, spec.group_id);
   ASSERT_EQ(pool_id, spec.pool_id);

--- a/src/test/librbd/test_ConsistencyGroups.cc
+++ b/src/test/librbd/test_ConsistencyGroups.cc
@@ -51,14 +51,14 @@ TEST_F(TestLibCG, group_create)
   ASSERT_EQ(0, rbd.group_create(ioctx, "mygroup"));
 
   vector<string> groups;
-  ASSERT_EQ(0, rbd.group_list(ioctx, groups));
+  ASSERT_EQ(0, rbd.group_list(ioctx, &groups));
   ASSERT_EQ(1U, groups.size());
   ASSERT_EQ("mygroup", groups[0]);
 
   ASSERT_EQ(0, rbd.group_remove(ioctx, "mygroup"));
 
   groups.clear();
-  ASSERT_EQ(0, rbd.group_list(ioctx, groups));
+  ASSERT_EQ(0, rbd.group_list(ioctx, &groups));
   ASSERT_EQ(0U, groups.size());
 }
 
@@ -78,7 +78,7 @@ TEST_F(TestLibCG, add_image)
   ASSERT_EQ(0, rbd.group_image_add(ioctx, group_name, ioctx, image_name));
 
   vector<librbd::group_image_status_t> images;
-  ASSERT_EQ(0, rbd.group_image_list(ioctx, group_name, images));
+  ASSERT_EQ(0, rbd.group_image_list(ioctx, group_name, &images));
   ASSERT_EQ(1U, images.size());
   ASSERT_EQ("myimage", images[0].name);
   ASSERT_EQ(ioctx.get_id(), images[0].pool);
@@ -86,6 +86,6 @@ TEST_F(TestLibCG, add_image)
   ASSERT_EQ(0, rbd.group_image_remove(ioctx, group_name, ioctx, image_name));
 
   images.clear();
-  ASSERT_EQ(0, rbd.group_image_list(ioctx, group_name, images));
+  ASSERT_EQ(0, rbd.group_image_list(ioctx, group_name, &images));
   ASSERT_EQ(0U, images.size());
 }

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -68,7 +68,7 @@ int execute_list(const po::variables_map &vm) {
 
   librbd::RBD rbd;
   std::vector<std::string> names;
-  r = rbd.group_list(io_ctx, names);
+  r = rbd.group_list(io_ctx, &names);
 
   if (r == -ENOENT)
     r = 0;
@@ -257,7 +257,7 @@ int execute_list_images(const po::variables_map &vm) {
   librbd::RBD rbd;
   std::vector<librbd::group_image_status_t> images;
 
-  r = rbd.group_image_list(io_ctx, group_name.c_str(), images);
+  r = rbd.group_image_list(io_ctx, group_name.c_str(), &images);
 
   if (r == -ENOENT)
     r = 0;


### PR DESCRIPTION
Attempting to retrieve the group spec will fail on older OSDs, so it
must be executed as an individual step in the refresh state machine.
Also fixed code style issues for out parameters.

Signed-off-by: Jason Dillaman dillaman@redhat.com
