### PR TITLE
rgw: remove suggestion to upgrade libcurl

### DIFF
--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -471,8 +471,7 @@ static int detect_curl_multi_wait_bug(CephContext *cct, CURLM *handle,
     curl_multi_wait_bug_present = true;
     ldout(cct, 0) << "WARNING: detected a version of libcurl which contains a "
         "bug in curl_multi_wait(). enabling a workaround that may degrade "
-        "performance slightly. please upgrade to a more recent version of "
-        "libcurl." << dendl;
+        "performance slightly." << dendl;
   }
 
   return clear_signal(read_fd);


### PR DESCRIPTION
@ktdreyer pointed out on the ceph-users list that it's a bad idea to ask users to maintain their own packages for curl