### PR TITLE
upstart: start ceph-all after static-network-up

### DIFF
--- a/src/upstart/ceph-all.conf
+++ b/src/upstart/ceph-all.conf
@@ -1,4 +1,4 @@
 description "Ceph"
 
-start on runlevel [2345]
+start on runlevel [2345] and static-network-up
 stop on runlevel [!2345]


### PR DESCRIPTION
Starting on runlevel [2345] allows the ceph services to
start before all of the networking is configured. This
introduces a race condition which allows a service to start
before the network it binds to is available.

Add the static-network-up event as a dependency for the start
on directive in order to start the ceph services after all of
the network stanzas have been processed and executed in the
/etc/network/interfaces and /etc/network/interfaces.d/*.conf
files.

Fixes: http://tracker.ceph.com/issues/17689

Signed-off-by: Billy Olsen billy.olsen@gmail.com
