### PR TITLE
jewel: journal: do not prematurely flag object recorder as closed

### DIFF
--- a/src/journal/ObjectRecorder.cc
+++ b/src/journal/ObjectRecorder.cc
@@ -173,7 +173,7 @@ bool ObjectRecorder::close() {
 
   assert(!m_object_closed);
   m_object_closed = true;
-  return m_in_flight_tids.empty() && !m_aio_scheduled;
+  return (m_in_flight_tids.empty() && !m_in_flight_flushes && !m_aio_scheduled);
 }
 
 void ObjectRecorder::handle_append_task() {


### PR DESCRIPTION
http://tracker.ceph.com/issues/17616