### PR TITLE
rgw/file: fix unlink leaf directory which can't catch correct obj name

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -235,11 +235,8 @@ namespace rgw {
       /* LOCKED */
       parent = rgw_fh->get_parent();
     } else {
-      /* atomicity */
       parent = rgw_fh;
-      LookupFHResult fhr = lookup_fh(parent, name, RGWFileHandle::FLAG_LOCK);
-      rgw_fh = get<0>(fhr);
-      /* LOCKED */
+      rgw_fh = nullptr;
     }
 
     if (parent->is_root()) {


### PR DESCRIPTION
when unlink a leaf directory without FLAG_UNLINK_THIS, it will use lookup_fh
to get FileHandle. This lookup won't carry with FLAG_DIRECTORY, it will
cause DeleteObjRequest failed with -ENOENT because rgw_fh->is_dir() is false.

Signed-off-by: Haomai Wang <haomai@xsky.com>