### PR TITLE
librbd: assert failure when using data pool

### DIFF
--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -190,6 +190,7 @@ CreateRequest<I>::CreateRequest(IoCtx &ioctx, const std::string &image_name,
   if (!m_data_pool.empty() && m_data_pool != ioctx.get_pool_name()) {
     m_features |= RBD_FEATURE_DATA_POOL;
   } else {
+    m_data_pool.clear();
     m_features &= ~RBD_FEATURE_DATA_POOL;
   }
 


### PR DESCRIPTION
This fixes a silly assert that's hit during image creation
(cli/api) when the data pool specified is same as the pool
specified by -p/--pool option (or the default).

Signed-off-by: Venky Shankar <vshankar@redhat.com>