### PR TITLE
DNM: jewel: rgw: for the create_bucket api, if the input creation_time is zero, w…

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5156,10 +5156,11 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.num_shards = bucket_index_max_shards;
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;
-    if (real_clock::is_zero(creation_time))
-      creation_time = ceph::real_clock::now(cct);
-    else
+    if (real_clock::is_zero(creation_time)) {
+      info.creation_time = ceph::real_clock::now(cct);
+    } else {
       info.creation_time = creation_time;
+    }
     ret = put_linked_bucket_info(info, exclusive, ceph::real_time(), pep_objv, &attrs, true);
     if (ret == -EEXIST) {
        /* we need to reread the info and return it, caller will have a use for it */


### PR DESCRIPTION
…e should set it to 'now"

Fixes: http://tracker.ceph.com/issues/16597

Signed-off-by: weiqiaomiao wei.qiaomiao@zte.com.cn
