### PR TITLE
rbd: 'rbd du' of missing image should return error

### DIFF
--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -209,7 +209,8 @@ static int do_disk_usage(librbd::RBD &rbd, librados::IoCtx &io_ctx,
     }
   }
   if (!found) {
-    std::cerr << "specified image " << imgname << " is not found." << std::endl;
+    std::cerr << "rbd: specified image " << imgname << " is not found" << ": "
+              << cpp_strerror (ENOENT) << std::endl;
     return -ENOENT;
   }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/16987

Reported-by: Jason Dillaman <dillaman@redhat.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>