### PR TITLE
Log: Replace namespace log with logging

### DIFF
--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -15,7 +15,7 @@
 #include "include/uuid.h"
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 Graylog::Graylog(const SubsystemMap * const s, std::string logger)
     : m_subs(s),
@@ -167,5 +167,5 @@ void Graylog::log_log_entry(LogEntry const * const e)
   }
 }
 
-} // ceph::log::
+} // ceph::logging::
 } // ceph::

--- a/src/common/Graylog.h
+++ b/src/common/Graylog.h
@@ -21,7 +21,7 @@ namespace ceph {
 
 class Formatter;
 
-namespace log {
+namespace logging {
 
 struct Entry;
 class SubsystemMap;

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -197,7 +197,7 @@ void LogChannel::update_config(map<string,string> &log_to_monitors,
   set_log_prio(prio);
 
   if (to_graylog && !graylog) { /* should but isn't */
-    graylog = ceph::log::Graylog::Ref(new ceph::log::Graylog("clog"));
+    graylog = ceph::logging::Graylog::Ref(new ceph::logging::Graylog("clog"));
   } else if (!to_graylog && graylog) { /* shouldn't but is */
     graylog.reset();
   }

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -33,7 +33,7 @@ struct Connection;
 class LogChannel;
 
 namespace ceph {
-namespace log {
+namespace logging {
   class Graylog;
 }
 }
@@ -182,7 +182,7 @@ private:
   std::string syslog_facility;
   bool log_to_syslog;
   bool log_to_monitors;
-  shared_ptr<ceph::log::Graylog> graylog;
+  shared_ptr<ceph::logging::Graylog> graylog;
 
 
   friend class LogClientTemp;

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -147,10 +147,10 @@ private:
  * logging-related config changes to the log.
  */
 class LogObs : public md_config_obs_t {
-  ceph::log::Log *log;
+  ceph::logging::Log *log;
 
 public:
-  explicit LogObs(ceph::log::Log *l) : log(l) {}
+  explicit LogObs(ceph::logging::Log *l) : log(l) {}
 
   const char** get_tracked_conf_keys() const {
     static const char *KEYS[] = {
@@ -476,7 +476,7 @@ CephContext::CephContext(uint32_t module_type_, int init_flags_)
   ceph_spin_init(&_feature_lock);
   ceph_spin_init(&_cct_perf_lock);
 
-  _log = new ceph::log::Log(&_conf->subsys);
+  _log = new ceph::logging::Log(&_conf->subsys);
   _log->start();
 
   _log_obs = new LogObs(_log);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -41,7 +41,7 @@ class CryptoHandler;
 namespace ceph {
   class PluginRegistry;
   class HeartbeatMap;
-  namespace log {
+  namespace logging {
     class Log;
   }
 }
@@ -71,7 +71,7 @@ public:
   void put();
 
   md_config_t *_conf;
-  ceph::log::Log *_log;
+  ceph::logging::Log *_log;
 
   /* init ceph::crypto */
   void init_crypto();

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -210,7 +210,7 @@ private:
   changed_set_t changed;
 
 public:
-  ceph::log::SubsystemMap subsys;
+  ceph::logging::SubsystemMap subsys;
 
   EntityName name;
   string data_dir_option;  ///< data_dir config option, if any

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -57,7 +57,7 @@ public:
       char __array[((v >= -1) && (v <= 200)) ? 0 : -1] __attribute__((unused)); \
     }									\
     static size_t _log_exp_length=80; \
-    ceph::log::Entry *_dout_e = cct->_log->create_entry(v, sub, &_log_exp_length);	\
+    ceph::logging::Entry *_dout_e = cct->_log->create_entry(v, sub, &_log_exp_length);	\
     ostream _dout_os(&_dout_e->m_streambuf);				\
     CephContext *_dout_cct = cct;					\
     std::ostream* _dout = &_dout_os;

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -11,7 +11,7 @@
 
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 struct Entry {
   utime_t m_stamp;

--- a/src/log/EntryQueue.h
+++ b/src/log/EntryQueue.h
@@ -7,7 +7,7 @@
 #include "Entry.h"
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 struct EntryQueue {
   int m_len;

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -34,7 +34,7 @@
 
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 static OnExitManager exit_callbacks;
 
@@ -476,5 +476,5 @@ void Log::inject_segv()
   m_inject_segv = true;
 }
 
-} // ceph::log::
+} // ceph::logging::
 } // ceph::

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -11,7 +11,7 @@
 #include "EntryQueue.h"
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 class Graylog;
 class SubsystemMap;

--- a/src/log/SubsystemMap.cc
+++ b/src/log/SubsystemMap.cc
@@ -2,7 +2,7 @@
 #include "SubsystemMap.h"
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 void SubsystemMap::add(unsigned subsys, std::string name, int log, int gather)
 {

--- a/src/log/SubsystemMap.h
+++ b/src/log/SubsystemMap.h
@@ -10,7 +10,7 @@
 #include "include/assert.h"
 
 namespace ceph {
-namespace log {
+namespace logging {
 
 struct Subsystem {
   int log_level, gather_level;

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -5,7 +5,7 @@
 #include "common/PrebufferedStreambuf.h"
 #include "SubsystemMap.h"
 
-using namespace ceph::log;
+using namespace ceph::logging;
 
 TEST(Log, Simple)
 {

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -131,7 +131,7 @@ void LogMonitor::update_from_paxos(bool *need_bootstrap)
       }
 
       if (channels.do_log_to_graylog(channel)) {
-	ceph::log::Graylog::Ref graylog = channels.get_graylog(channel);
+	ceph::logging::Graylog::Ref graylog = channels.get_graylog(channel);
 	if (graylog) {
 	  graylog->log_log_entry(&le);
 	}
@@ -725,14 +725,14 @@ bool LogMonitor::log_channel_info::do_log_to_syslog(const string &channel) {
   return ret;
 }
 
-ceph::log::Graylog::Ref LogMonitor::log_channel_info::get_graylog(
+ceph::logging::Graylog::Ref LogMonitor::log_channel_info::get_graylog(
     const string &channel)
 {
   generic_dout(25) << __func__ << " for channel '"
 		   << channel << "'" << dendl;
 
   if (graylogs.count(channel) == 0) {
-    ceph::log::Graylog::Ref graylog = ceph::log::Graylog::Ref(new ceph::log::Graylog("mon"));
+    ceph::logging::Graylog::Ref graylog = ceph::logging::Graylog::Ref(new ceph::logging::Graylog("mon"));
 
     graylog->set_fsid(g_conf->fsid);
     graylog->set_hostname(g_conf->host);

--- a/src/mon/LogMonitor.h
+++ b/src/mon/LogMonitor.h
@@ -31,7 +31,7 @@ class MLog;
 static const string LOG_META_CHANNEL = "$channel";
 
 namespace ceph {
-namespace log {
+namespace logging {
   class Graylog;
 }
 }
@@ -54,7 +54,7 @@ private:
     map<string,string> log_to_graylog_host;
     map<string,string> log_to_graylog_port;
 
-    map<string, shared_ptr<ceph::log::Graylog>> graylogs;
+    map<string, shared_ptr<ceph::logging::Graylog>> graylogs;
     uuid_d fsid;
     string host;
 
@@ -125,7 +125,7 @@ private:
 			      &CLOG_CONFIG_DEFAULT_KEY) == "true");
     }
 
-    shared_ptr<ceph::log::Graylog> get_graylog(const string &channel);
+    shared_ptr<ceph::logging::Graylog> get_graylog(const string &channel);
   } channels;
 
   void update_log_channels();


### PR DESCRIPTION
 - This to avoid a naming conflict that Clang finds with
   std::log from cmath

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>