### PR TITLE
mds/MDSRank.h: make destructor protected

### DIFF
--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -280,7 +280,11 @@ class MDSRank {
         MonClient *monc_,
         Context *respawn_hook_,
         Context *suicide_hook_);
+
+  protected:
     ~MDSRank();
+
+  public:
 
     // Daemon lifetime functions: these guys break the abstraction
     // and call up into the parent MDSDaemon instance.  It's kind


### PR DESCRIPTION
MDSRank class is inherited from, but doesn't have virtual destructor.
Making destructor protected prevents possibility of deleting derived
classes using base class pointer.

Signed-off-by: Michal Jarzabek stiopa@gmail.com
