### PR TITLE
doc: fix mgr literal block rST syntax

### DIFF
--- a/doc/mgr/administrator.rst
+++ b/doc/mgr/administrator.rst
@@ -5,23 +5,20 @@ ceph-mgr administrator's guide
 Setup
 -----
 
-Create an authentication key for your daemon:
+Create an authentication key for your daemon::
 
-::
     ceph auth get-or-create mgr.$name mon 'allow *'
 
 Place that key into ``mgr data`` path, which for a cluster "ceph"
 and mgr $name "foo" would be ``/var/lib/ceph/mgr/ceph-foo``.
 
-Start the ceph-mgr daemon:
+Start the ceph-mgr daemon::
 
-::
     ceph-mgr -i $name
 
 Check that the mgr has come up by looking at the output
-of ``ceph status``, which should now include a mgr status line:
+of ``ceph status``, which should now include a mgr status line::
 
-::
     mgr active: $name
 
 High availability
@@ -45,9 +42,7 @@ Calling module commands
 -----------------------
 
 Where a module implements command line hooks, using the Ceph CLI's
-``tell`` command to call them like this:
-
-::
+``tell`` command to call them like this::
 
     ceph tell mgr <command | help>
 

--- a/doc/mgr/plugins.rst
+++ b/doc/mgr/plugins.rst
@@ -48,9 +48,8 @@ Exposing commands
 -----------------
 
 Set the ``COMMANDS`` class attribute of your plugin to a list of dicts
-like this:
+like this::
 
-::
     COMMANDS = [
         {
             "cmd": "foobar name=myarg,type=CephString",


### PR DESCRIPTION
Prior to this change, there were double-colon (`::`) characters in the HTML docs to indicate literal blocks.

The proceeding paragraphs were not pre-formatted because there was no newline between the double-colon and the to-be-pre-formatted paragraph.

Move the `::` characters inline to simplify the syntax and make Sphinx properly interpret these texts as literal blocks.