### PR TITLE
doc: standardize EPEL instructions

### DIFF
--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -409,7 +409,7 @@ RPM Packages
 Ceph requires additional additional third party libraries.
 To add the EPEL repository, execute the following::
 
-   su -c 'rpm -Uvh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm'
+   sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 Ceph requires the following packages:
 

--- a/doc/start/documenting-ceph.rst
+++ b/doc/start/documenting-ceph.rst
@@ -306,8 +306,7 @@ Packages for Enterprise Linux) repository as it provides some extra packages
 which are not available in the default repository. To install ``epel``, execute
 the following::
 
-	wget http://ftp.riken.jp/Linux/fedora/epel/7/x86_64/e/epel-release-7-2.noarch.rpm
-	sudo yum install epel-release-7-2.noarch.rpm
+        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
 For CentOS/RHEL distributions, execute the following::
 

--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -57,11 +57,12 @@ For CentOS 7, perform the following steps:
         sudo subscription-manager repos --enable=rhel-7-server-extras-rpms
 
 #. Install and enable the Extra Packages for Enterprise Linux (EPEL)
-   repository. Please see the `EPEL wiki`_ page for more information.
+   repository::
 
-#. On CentOS, you can execute the following command chain::
+        sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 
-        sudo yum install -y yum-utils && sudo yum-config-manager --add-repo https://dl.fedoraproject.org/pub/epel/7/x86_64/ && sudo yum install --nogpgcheck -y epel-release && sudo rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-7 && sudo rm /etc/yum.repos.d/dl.fedoraproject.org*
+   Please see the `EPEL wiki`_ page for more information.
+
 
 #. Add the package to your repository. Open a text editor and create a
    Yellowdog Updater, Modified (YUM) entry. Use the file path


### PR DESCRIPTION
Prior to this change, the documentation pages contained different ways to enable EPEL. Pick a simple, secure (https) way and standardize on that.

