### PR TITLE
mon/MonClient: fix race condition when shuting down the mon client

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -418,6 +418,8 @@ void MonClient::shutdown()
     waiting_for_session.pop_front();
   }
 
+  timer.shutdown();
+
   if (cur_con)
     cur_con->mark_down();
   cur_con.reset(NULL);
@@ -429,10 +431,6 @@ void MonClient::shutdown()
     finisher.wait_for_empty();
     finisher.stop();
   }
-  monc_lock.Lock();
-  timer.shutdown();
-
-  monc_lock.Unlock();
 }
 
 int MonClient::authenticate(double timeout)


### PR DESCRIPTION
we have to shutdown the hunting timer and reset `cur_con` at the same place, or the hunting timer may set `cur_con` before it get shutdown, which results segfault as follows:

```
  #0  0x00007fb09ffca989 in raise () from /lib64/libc.so.6
  #1  0x00007fb09ffcc098 in abort () from /lib64/libc.so.6
  #2  0x00007fb08ea52677 in ceph::__ceph_assert_fail(char const*, char const*, int, char const*) () from /lib64/librados.so.2
  #3  0x00007fb08e93144c in ceph::log::SubsystemMap::should_gather(unsigned int, int) [clone .part.120] () from /lib64/librados.so.2
  #4  0x00007fb08e97eb15 in RefCountedObject::put() () from /lib64/librados.so.2
  #5  0x00007fb08eae3f9e in MonClient::~MonClient() () from /lib64/librados.so.2
  #6  0x00007fb08e97c2d5 in librados::RadosClient::~RadosClient() () from /lib64/librados.so.2
  #7  0x00007fb08e97c319 in librados::RadosClient::~RadosClient() () from /lib64/librados.so.2
  #8  0x00007fb08e94684a in rados_shutdown () from /lib64/librados.so.2
  #9  0x00007fb098074210 in __pyx_pw_5rados_5Rados_7shutdown () from /usr/lib64/python2.7/site-packages/rados.so
  ...
```

Signed-off-by: runsisi <runsisi@zte.com.cn>