### PR TITLE
    doc: change the osd_max_backfills default to 1

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -486,7 +486,7 @@ priority than requests to read or write data.
 
 :Description: The maximum number of backfills allowed to or from a single OSD.
 :Type: 64-bit Unsigned Integer
-:Default: ``10``
+:Default: ``1``
 
 
 ``osd backfill scan min`` 


### PR DESCRIPTION
  Fixes: http://tracker.ceph.com/issues/17701
  Signed-off-by: huangjun <hjwsm1989@gmail.com>