### PR TITLE
librados: postpone cct deletion

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -65,6 +65,7 @@ bool librados::RadosClient::ms_get_authorizer(int dest_type,
 
 librados::RadosClient::RadosClient(CephContext *cct_)
   : Dispatcher(cct_->get()),
+    cct_deleter{cct_, [](CephContext *p) {p->put();}},
     conf(cct_->_conf),
     state(DISCONNECTED),
     monclient(cct_),
@@ -431,7 +432,6 @@ librados::RadosClient::~RadosClient()
     delete messenger;
   if (objecter)
     delete objecter;
-  cct->put();
   cct = NULL;
 }
 

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -37,6 +37,9 @@ class AioCompletionImpl;
 
 class librados::RadosClient : public Dispatcher
 {
+  std::unique_ptr<CephContext,
+		  std::function<void(CephContext*)> > cct_deleter;
+
 public:
   using Dispatcher::cct;
   md_config_t *conf;


### PR DESCRIPTION
when `debug refs` is enabled, RefCountedObject::put() prints log using
cct, but RadosClient relinquishes the reference to cct too early, so its
when its `RefCountedObject` member variables print log when they are
destructed, the cct is freed. so we need postpone destructure of it
after all other RefCountedObject member variables are destroyed.

Signed-off-by: Kefu Chai <kchai@redhat.com>