### PR TITLE
mon: Do not allow pools to be deleted by default

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -270,7 +270,7 @@ OPTION(mon_pg_check_down_all_threshold, OPT_FLOAT, .5) // threshold of down osds
 OPTION(mon_cache_target_full_warn_ratio, OPT_FLOAT, .66) // position between pool cache_target_full and max where we start warning
 OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full
-OPTION(mon_allow_pool_delete, OPT_BOOL, true) // allow pool deletion
+OPTION(mon_allow_pool_delete, OPT_BOOL, false) // allow pool deletion
 OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
 OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active


### PR DESCRIPTION
This prevents accidental pool removals on cluster which may contain
very valuable data.

Users can still revert this setting and allow a pool to be removed,
but that would be a deliberate action of the admin.

Signed-off-by: Wido den Hollander wido@42on.com
