### PR TITLE
rgw_file:  apply missed base64 try-catch

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -834,7 +834,13 @@ namespace rgw {
       } else {
 	/* try external authenticators (ldap for now) */
 	rgw::LDAPHelper* ldh = rgwlib.get_ldh(); /* !nullptr */
-	RGWToken token{from_base64(key.id)};
+	RGWToken token;
+	/* boost filters and/or string_ref may throw on invalid input */
+	try {
+	  token = rgw::from_base64(key.id);
+	} catch(...) {
+	  token = std::string("");
+	}
 	if (token.valid() && (ldh->auth(token.id, token.key) == 0)) {
 	  /* try to store user if it doesn't already exist */
 	  if (rgw_get_user_info_by_uid(store, token.id, user) < 0) {


### PR DESCRIPTION
Fixes a case missed in 0a4c91ec.  Affects only librgw/rgw_file
(i.e., RGW-NFS).

Fixes: http://tracker.ceph.com/issues/17663

Signed-off-by: Matt Benjamin mbenjamin@redhat.com
