### PR TITLE
jewel: rgw_rest_s3:  apply missed base64 try-catch

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3953,7 +3953,13 @@ int RGW_Auth_S3::authorize_v2(RGWRados *store, struct req_state *s)
       << store->ctx()->_conf->rgw_ldap_uri
       << dendl;
 
-    RGWToken token{from_base64(auth_id)};
+    RGWToken token;
+    /* boost filters and/or string_ref may throw on invalid input */
+    try {
+      token = rgw::from_base64(auth_id);
+    } catch(...) {
+      token = std::string("");
+    }
 
     if (! token.valid())
       external_auth_result = -EACCES;


### PR DESCRIPTION
Fixes a case missed in 0a4c91e, in Jewel backport only.

Fixes: http://tracker.ceph.com/issues/17663

Resolves: rhbz#1381694

Signed-off-by: Matt Benjamin mbenjamin@redhat.com
