### PR TITLE
rgw: Class member cookie is not initialized correctly in some coroutine's constructor.

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -477,7 +477,7 @@ public:
     char buf[COOKIE_LEN + 1];
 
     gen_rand_alphanumeric(cct, buf, sizeof(buf) - 1);
-    string cookie = buf;
+    cookie = buf;
 
     sync_status_oid = RGWDataSyncStatusManager::sync_status_oid(sync_env->source_zone);
   }


### PR DESCRIPTION
Cookie has been defined as a class member,  and is not initialized correctly because we define a local variable named cookie, which is not not expected.

Signed-off-by: Zhang Shaowen zhangshaowen@cmss.chinamobile.com
