### PR TITLE
test: librbd: fix compile warning for unused variable

### DIFF
--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -190,8 +190,8 @@ public:
   }
 
   void expect_snap_namespace_list(MockRefreshImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                               exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapshot_namespace"), _, _, _));
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                  exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapshot_namespace"), _, _, _));
   }
 
   void expect_add_snap(MockRefreshImageCtx &mock_image_ctx,


### PR DESCRIPTION
    src/test/librbd/image/test_mock_RefreshRequest.cc:193:11: warning: unused variable ‘expect’ [-Wunused-variable]
         auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
               ^

Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>