### PR TITLE
librbd: silence the unused variable warning

### DIFF
--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -192,6 +192,11 @@ public:
   void expect_snap_namespace_list(MockRefreshImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"), StrEq("get_snapshot_namespace"), _, _, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
   }
 
   void expect_add_snap(MockRefreshImageCtx &mock_image_ctx,


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>