### PR TITLE
common/admin_socket: add config for admin socket permission bits

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -299,6 +299,18 @@ void AdminSocket::chown(uid_t uid, gid_t gid)
   }
 }
 
+void AdminSocket::chmod(mode_t mode)
+{
+  if (m_sock_fd >= 0) {
+    int r = ::chmod(m_path.c_str(), mode);
+    if (r < 0) {
+      r = -errno;
+      lderr(m_cct) << "AdminSocket: failed to chmod socket: "
+                   << cpp_strerror(r) << dendl;
+    }
+  }
+}
+
 bool AdminSocket::do_accept()
 {
   struct sockaddr_un address;

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -78,6 +78,7 @@ public:
   bool init(const std::string &path);
 
   void chown(uid_t uid, gid_t gid);
+  void chmod(mode_t mode);
 
 private:
   AdminSocket(const AdminSocket& rhs);

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -24,6 +24,7 @@
 #include "common/safe_io.h"
 #include "common/valgrind.h"
 #include "common/version.h"
+#include "common/strtol.h"
 #include "include/color.h"
 
 #include <errno.h>
@@ -131,5 +132,24 @@ void common_init_finish(CephContext *cct)
   if ((flags & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
       (cct->get_set_uid() || cct->get_set_gid())) {
     cct->get_admin_socket()->chown(cct->get_set_uid(), cct->get_set_gid());
+  }
+
+  md_config_t *conf = cct->_conf;
+
+  if (!conf->admin_socket.empty() && !conf->admin_socket_mode.empty()) {
+    int ret = 0;
+    std::string err;
+
+    ret = strict_strtol(conf->admin_socket_mode.c_str(), 8, &err);
+    if (err.empty()) {
+      if (!(ret & (~ACCESSPERMS))) {
+        cct->get_admin_socket()->chmod(static_cast<mode_t>(ret));
+      } else {
+        lderr(cct) << "Invalid octal permissions string: "
+            << conf->admin_socket_mode << dendl;
+      }
+    } else {
+      lderr(cct) << "Invalid octal string: " << err << dendl;
+    }
   }
 }

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -27,6 +27,7 @@ OPTION(lockdep, OPT_BOOL, false)
 OPTION(lockdep_force_backtrace, OPT_BOOL, false) // always gather current backtrace at every lock
 OPTION(run_dir, OPT_STR, "/var/run/ceph")       // the "/var/run/ceph" dir, created on daemon startup
 OPTION(admin_socket, OPT_STR, "$run_dir/$cluster-$name.asok") // default changed by common_preinit()
+OPTION(admin_socket_mode, OPT_STR, "") // permission bits to set for admin socket file, e.g., "0775", "0755"
 OPTION(crushtool, OPT_STR, "crushtool") // crushtool utility path
 
 OPTION(daemonize, OPT_BOOL, false) // default changed by common_preinit()


### PR DESCRIPTION
this is to fix https://github.com/influxdata/telegraf/issues/1657, so other tools, such as `telegraf`, running as non-root user can gather info from the ceph daemons.

Signed-off-by: runsisi runsisi@zte.com.cn
