### PR TITLE
[DNM] rgw_file: prevent unlink of non-empty directories

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -270,9 +270,19 @@ namespace rgw {
 	rgw_fh->mtx.lock(); /* LOCKED */
       }
 
+      /* to preserve attributes, avoid deleting the directory vnode
+       * if children exist */
+      if (rgw_fh->has_children(RGWFileHandle::HC_FLAG_SKIP_BUCKETS)) {
+	rgw_fh->mtx.unlock();
+	unref(rgw_fh);
+	return -ENOTEMPTY;
+      }
+
       std::string oname = rgw_fh->relative_object_name();
-      if (rgw_fh->is_dir())
+      if (rgw_fh->is_dir()) {
 	oname += "/";
+      }
+
       RGWDeleteObjRequest req(cct, get_user(), parent->bucket_name(),
 			      oname);
       rc = rgwlib.get_fe()->execute_req(&req);
@@ -724,6 +734,41 @@ namespace rgw {
     return true;
   } /* RGWFileHandle::reclaim */
 
+  static bool has_children_cb(const char *name, void *arg, uint64_t off)
+  {
+    bool& cb_result = *(static_cast<bool*>(arg));
+    cb_result = true;
+    return true;
+  }
+
+  bool RGWFileHandle::has_children(uint32_t flags) const
+  {
+    if (! is_dir())
+      return false;
+
+    int rc = 0;
+    bool cb_result = false;
+    uint64_t offset = 0;
+
+    if (is_root() &&
+	(flags & HC_FLAG_SKIP_BUCKETS)) {
+      return false;
+
+      RGWListBucketsRequest req(fs->get_context(), fs->get_user(),
+				const_cast<RGWFileHandle*>(this),
+				has_children_cb, &cb_result, &offset);
+      rc = rgwlib.get_fe()->execute_req(&req);
+    } else {
+      RGWReaddirRequest req(fs->get_context(), fs->get_user(),
+			    const_cast<RGWFileHandle*>(this), has_children_cb,
+			    &cb_result, &offset);
+      req.set_default_max(1);
+      rc = rgwlib.get_fe()->execute_req(&req);
+    }
+
+    return rc;
+  } /* RGWFileHandle::has_children*/
+
   int RGWFileHandle::readdir(rgw_readdir_cb rcb, void *cb_arg, uint64_t *offset,
 			     bool *eof, uint32_t flags)
   {
@@ -753,7 +798,7 @@ namespace rgw {
 	fs->state.push_event(ev);
       }
     } else {
-      rgw_obj_key marker{"", ""};
+      //rgw_obj_key marker{"", ""};
       RGWReaddirRequest req(cct, fs->get_user(), this, rcb, cb_arg, offset);
       rc = rgwlib.get_fe()->execute_req(&req);
       if (! rc) {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -502,6 +502,11 @@ namespace rgw {
     bool deleted() const { return flags & FLAG_DELETED; }
     bool stateless_open() const { return flags & FLAG_STATELESS_OPEN; }
 
+    static constexpr uint32_t HC_FLAG_NONE = 0x0000;
+    static constexpr uint32_t HC_FLAG_SKIP_BUCKETS = 0x0001;
+
+    bool has_children(uint32_t flags = HC_FLAG_NONE) const;
+
     uint32_t open(uint32_t gsh_flags) {
       lock_guard guard(mtx);
       if (! (flags & FLAG_OPEN)) {
@@ -1177,8 +1182,8 @@ public:
   read directory content (bucket objects)
 */
 
-  class RGWReaddirRequest : public RGWLibRequest,
-			    public RGWListBucket /* RGWOp */
+class RGWReaddirRequest : public RGWLibRequest,
+			  public RGWListBucket /* RGWOp */
 {
 public:
   RGWFileHandle* rgw_fh;
@@ -1201,6 +1206,10 @@ public:
     }
     default_max = 1000; // XXX was being omitted
     op = this;
+  }
+
+  void set_default_max(uint32_t _default_max) {
+    default_max = _default_max;
   }
 
   virtual bool only_bucket() { return false; }


### PR DESCRIPTION
Now that directory name objects can have attributes, we need to
avoid deleting them if they have children.

Note that this guard has the same atomicity guarantee as other
cross-object namespace operations, so races with other endpoints
to add or delete children are tolerated.

Signed-off-by: Matt Benjamin mbenjamin@redhat.com
