### PR TITLE
rgw: blanket apply NO_SSL_DL to civetweb sections

### DIFF
--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -132,7 +132,7 @@ libcivetweb_la_SOURCES =  \
 	civetweb/src/civetweb.c
 
 libcivetweb_la_CXXFLAGS = ${CIVETWEB_INCLUDE} -fPIC -Woverloaded-virtual \
-	${AM_CXXFLAGS}
+	${AM_CXXFLAGS} -DNO_SSL_DL
 libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE} -fPIC -DNO_SSL_DL
 LIBCIVETWEB_DEPS += -lssl -lcrypto
 
@@ -147,7 +147,7 @@ radosgw_SOURCES = \
 	civetweb/src/civetweb.c \
 	rgw/rgw_main.cc
 
-radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE}
+radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE} -DNO_SSL_DL
 radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) $(RESOLV_LIBS) \
 	$(CEPH_GLOBAL)
 bin_PROGRAMS += radosgw


### PR DESCRIPTION
Since civetweb.c is compiled directly into the radosgw executable,
NO_SSL_DL needs to also be applied to the radosgw binary. For
completeness, also apply it to libcivetweb cxxflags.

Fixes: http://tracker.ceph.com/issues/16957

Signed-off-by: Karol Mroz kmroz@suse.de
