### PR TITLE
msg/async/AsyncMessenger.cc: use explicit reference from my_inst.

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -167,7 +167,7 @@ int Processor::rebind(const set<int>& avoid_ports)
   ldout(msgr->cct, 10) << __func__ << " new nonce " << nonce << " and inst " << msgr->my_inst << dendl;
 
   ldout(msgr->cct, 10) << __func__ << " will try " << addr << " and avoid ports " << new_avoid << dendl;
-  return bind(addr, new_avoid);
+  return bind(msgr->my_inst.addr, new_avoid);
 }
 
 void Processor::start()


### PR DESCRIPTION
Very likely Clang is being picky here, but if we do not reference the
msgr->my_inst ifor addr, then the nonce is incorrectly updated and
communication starts to fail.

And cephtool-test-rados.sh starts to fail.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>