### PR TITLE
install-deps.sh: allow building on SLES systems

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -121,7 +121,7 @@ else
         $SUDO $builddepcmd $DIR/ceph.spec 2>&1 | tee $DIR/yum-builddep.out
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
-    opensuse|suse)
+    opensuse|suse|sles)
         echo "Using zypper to install dependencies"
         $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release systemd-rpm-macros
         sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec


### PR DESCRIPTION
Avoids this error on SLES systems:

> ./install-deps.sh
sles is unknown, dependencies will have to be installed manually.

Signed-off-by: Nitin A Kamble <Nitin.Kamble@Teradata.com>