### PR TITLE
Fix long stalls when calling ceph_fsync()

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9033,7 +9033,7 @@ int Client::_fsync(Inode *in, bool syncdataonly)
     ldout(cct, 15) << "using return-valued form of _fsync" << dendl;
   }
   
-  if (!syncdataonly && (in->dirty_caps & ~CEPH_CAP_ANY_FILE_WR)) {
+  if (!syncdataonly && in->dirty_caps) {
     check_caps(in, true);
     if (in->flushing_caps)
       flush_tid = last_flush_tid;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4118,18 +4118,26 @@ void Client::flush_caps()
   ldout(cct, 10) << "flush_caps" << dendl;
   xlist<Inode*>::iterator p = delayed_caps.begin();
   while (!p.end()) {
+    unsigned flags = CHECK_CAPS_NODELAY;
     Inode *in = *p;
+
     ++p;
     delayed_caps.pop_front();
-    check_caps(in, CHECK_CAPS_NODELAY);
+    if (p.end() && cap_list.empty())
+      flags |= CHECK_CAPS_SYNCHRONOUS;
+    check_caps(in, flags);
   }
 
   // other caps, too
   p = cap_list.begin();
   while (!p.end()) {
+    unsigned flags = CHECK_CAPS_NODELAY;
     Inode *in = *p;
+
     ++p;
-    check_caps(in, CHECK_CAPS_NODELAY);
+    if (p.end())
+      flags |= CHECK_CAPS_SYNCHRONOUS;
+    check_caps(in, flags);
   }
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -648,7 +648,7 @@ protected:
   void handle_cap_flushsnap_ack(MetaSession *session, Inode *in, class MClientCaps *m);
   void handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, class MClientCaps *m);
   void cap_delay_requeue(Inode *in);
-  void send_cap(Inode *in, MetaSession *session, Cap *cap,
+  void send_cap(Inode *in, MetaSession *session, Cap *cap, bool sync,
 		int used, int want, int retain, int flush,
 		ceph_tid_t flush_tid);
   void check_caps(Inode *in, bool immediate);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -651,7 +651,7 @@ protected:
   void send_cap(Inode *in, MetaSession *session, Cap *cap,
 		int used, int want, int retain, int flush,
 		ceph_tid_t flush_tid);
-  void check_caps(Inode *in, bool is_delayed);
+  void check_caps(Inode *in, bool immediate);
   void get_cap_ref(Inode *in, int cap);
   void put_cap_ref(Inode *in, int cap);
   void flush_snaps(Inode *in, bool all_again=false);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -651,7 +651,11 @@ protected:
   void send_cap(Inode *in, MetaSession *session, Cap *cap, bool sync,
 		int used, int want, int retain, int flush,
 		ceph_tid_t flush_tid);
-  void check_caps(Inode *in, bool immediate);
+
+  /* Flags for check_caps() */
+#define CHECK_CAPS_NODELAY	(0x1)
+
+  void check_caps(Inode *in, unsigned flags);
   void get_cap_ref(Inode *in, int cap);
   void put_cap_ref(Inode *in, int cap);
   void flush_snaps(Inode *in, bool all_again=false);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -628,7 +628,7 @@ protected:
   int mark_caps_flushing(Inode *in, ceph_tid_t *ptid);
   void adjust_session_flushing_caps(Inode *in, MetaSession *old_s, MetaSession *new_s);
   void flush_caps();
-  void flush_caps(Inode *in, MetaSession *session);
+  void flush_caps(Inode *in, MetaSession *session, bool sync=false);
   void kick_flushing_caps(MetaSession *session);
   void early_kick_flushing_caps(MetaSession *session);
   void kick_maxsize_requests(MetaSession *session);
@@ -654,6 +654,7 @@ protected:
 
   /* Flags for check_caps() */
 #define CHECK_CAPS_NODELAY	(0x1)
+#define CHECK_CAPS_SYNCHRONOUS	(0x2)
 
   void check_caps(Inode *in, unsigned flags);
   void get_cap_ref(Inode *in, int cap);

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -627,7 +627,7 @@ protected:
   void mark_caps_dirty(Inode *in, int caps);
   int mark_caps_flushing(Inode *in, ceph_tid_t *ptid);
   void adjust_session_flushing_caps(Inode *in, MetaSession *old_s, MetaSession *new_s);
-  void flush_caps();
+  void flush_caps_sync();
   void flush_caps(Inode *in, MetaSession *session, bool sync=false);
   void kick_flushing_caps(MetaSession *session);
   void early_kick_flushing_caps(MetaSession *session);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -2487,7 +2487,9 @@ void Locker::handle_client_caps(MClientCaps *m)
   client_t client = m->get_source().num();
 
   snapid_t follows = m->get_snap_follows();
-  dout(7) << "handle_client_caps on " << m->get_ino()
+  dout(7) << "handle_client_caps "
+	  << ((m->flags & CLIENT_CAPS_SYNC) ? "sync" : "async")
+	  << " on " << m->get_ino()
 	  << " tid " << m->get_client_tid() << " follows " << follows
 	  << " op " << ceph_cap_op_name(m->get_op()) << dendl;
 
@@ -2706,10 +2708,10 @@ void Locker::handle_client_caps(MClientCaps *m)
     }
 
     // filter wanted based on what we could ever give out (given auth/replica status)
-    bool need_flush = false;
+    bool need_flush = m->flags & CLIENT_CAPS_SYNC;
     int new_wanted = m->get_wanted() & head_in->get_caps_allowed_ever();
     if (new_wanted != cap->wanted()) {
-      if (new_wanted & ~cap->pending()) {
+      if (!need_flush && (new_wanted & ~cap->pending())) {
 	// exapnding caps.  make sure we aren't waiting for a log flush
 	need_flush = _need_flush_mdlog(head_in, new_wanted & ~cap->pending());
       }


### PR DESCRIPTION
This PR should fix [tracker bug 17563](http://tracker.ceph.com/issues/17563)

The userland client fsync codepath is quite slow in some (rather common) workloads. I have a libcephfs test program that creates a file, writes 16k to it, calls ceph_fsync on it and then ceph_close. This is done in a loop 256 times.

Without this patchset when I run this program vs a vstart cluster under "time":
```
real    21m19.619s
user    0m0.431s
sys     0m0.364s
```

With this patchset:
```
real    0m11.491s
user    0m0.247s
sys     0m0.127s
```

Roughly 100x speedup. I first noticed this when testing with ganesha, backed by ceph, so this should help its workload as well.
