### PR TITLE
rgw: set a default bucket quota of 100000

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1466,7 +1466,7 @@ OPTION(rgw_replica_log_obj_prefix, OPT_STR, "replica_log") //
 OPTION(rgw_bucket_quota_ttl, OPT_INT, 600) // time for cached bucket stats to be cached within rgw instance
 OPTION(rgw_bucket_quota_soft_threshold, OPT_DOUBLE, 0.95) // threshold from which we don't rely on cached info for quota decisions
 OPTION(rgw_bucket_quota_cache_size, OPT_INT, 10000) // number of entries in bucket quota cache
-OPTION(rgw_bucket_default_quota_max_objects, OPT_INT, -1) // number of objects allowed
+OPTION(rgw_bucket_default_quota_max_objects, OPT_INT, 100000) // number of objects allowed--avoid exceeding a safe number of entries in a single index shard
 OPTION(rgw_bucket_default_quota_max_size, OPT_LONGLONG, -1) // Max size of object in bytes
 
 OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header


### PR DESCRIPTION
The new default value is chosen is a known-safe maximum value
for bucket entries in one bucket index shard.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>