### PR TITLE
os/bluestore: Record correctly wal_bytes for TransContext.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6390,7 +6390,7 @@ void BlueStore::_txc_finish(TransContext *txc)
   }
 
   throttle_wal_ops.put(txc->ops);
-  throttle_wal_bytes.put(txc->bytes);
+  throttle_wal_bytes.put(txc->wal_bytes);
 
   OpSequencerRef osr = txc->osr;
   {
@@ -6782,6 +6782,7 @@ int BlueStore::queue_transactions(
     _txc_add_transaction(txc, &(*p));
   }
 
+  txc->wal_bytes = txc->bytes;
   _txc_write_nodes(txc, txc->t);
   // journal wal items
   if (txc->wal_txn) {
@@ -6792,6 +6793,7 @@ int BlueStore::queue_transactions(
     txc->wal_txn->seq = ++wal_seq;
     bufferlist bl;
     ::encode(*txc->wal_txn, bl);
+    txc->wal_bytes += bl.length();
     string key;
     get_wal_key(txc->wal_txn->seq, &key);
     txc->t->set(PREFIX_WAL, key, bl);
@@ -6803,7 +6805,7 @@ int BlueStore::queue_transactions(
   throttle_ops.get(txc->ops);
   throttle_bytes.get(txc->bytes);
   throttle_wal_ops.get(txc->ops);
-  throttle_wal_bytes.get(txc->bytes);
+  throttle_wal_bytes.get(txc->wal_bytes);
 
   if (handle)
     handle->reset_tp_timeout();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1142,7 +1142,7 @@ public:
     OpSequencerRef osr;
     boost::intrusive::list_member_hook<> sequencer_item;
 
-    uint64_t ops, bytes;
+    uint64_t ops, bytes, wal_bytes;
 
     set<OnodeRef> onodes;     ///< these need to be updated/written
     set<SharedBlobRef> shared_blobs;  ///< these need to be updated/written
@@ -1227,6 +1227,7 @@ public:
 	osr(o),
 	ops(0),
 	bytes(0),
+	wal_bytes(0),
 	oncommit(NULL),
 	onreadable(NULL),
 	onreadable_sync(NULL),


### PR DESCRIPTION
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>