### PR TITLE
rgw: Anonymous users shouldn't be able to access requester pays buckets.

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -899,6 +899,10 @@ bool verify_requester_payer_permission(struct req_state *s)
 
   if (s->auth_identity->is_owner_of(s->bucket_info.owner))
     return true;
+  
+  if (s->auth_identity->is_anonymous()) {
+    return false;
+  }
 
   const char *request_payer = s->info.env->get("HTTP_X_AMZ_REQUEST_PAYER");
   if (!request_payer) {


### PR DESCRIPTION
Anonymous users can't access requester pays buckets in S3.
We can find that in http://docs.aws.amazon.com/AmazonS3/latest/dev/RequesterPaysBuckets.html.

Fixes: http://tracker.ceph.com/issues/17175

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>