### PR TITLE
tests: TestErasureCodePluginJerasure must stop the log thread

### DIFF
--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -81,7 +81,7 @@ target_link_libraries(unittest_erasure_code
 add_executable(unittest_erasure_code_plugin_jerasure
   TestErasureCodePluginJerasure.cc
   )
-#add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
+add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
 target_link_libraries(unittest_erasure_code_plugin_jerasure
   global
   osd

--- a/src/test/erasure-code/TestErasureCodePluginJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodePluginJerasure.cc
@@ -20,6 +20,7 @@
 #include "global/global_init.h"
 #include "erasure-code/ErasureCodePlugin.h"
 #include "common/ceph_argparse.h"
+#include "log/Log.h"
 #include "global/global_context.h"
 #include "common/config.h"
 #include "gtest/gtest.h"
@@ -73,7 +74,9 @@ int main(int argc, char **argv)
   g_conf->set_val("erasure_code_dir", directory, false, false);
 
   ::testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  int status = RUN_ALL_TESTS();
+  g_ceph_context->_log->stop();
+  return status;
 }
 
 /*


### PR DESCRIPTION
When a log entry is created in dout.h, it holds a pointer to the

   static size_t _log_exp_length

variable. When OnExitManager::~OnExitManager from Log.cc is called
during global destruction, it may happen after the static variables
referenced by some entries have been deallocated. The flush() function
will try to access these deallocated variables via the hint_size()
method and core dump.

To prevent this race, the Log::stop() method must be called explicitly
to ensure no entries are left when the global destructors are called.

Fixes: http://tracker.ceph.com/issues/17561

Signed-off-by: Loic Dachary <ldachary@redhat.com>