### PR TITLE
tests: fully disable build of jerasure plugin

### DIFF
--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -78,17 +78,17 @@ target_link_libraries(unittest_erasure_code
   )
 
 # unittest_erasure_code_plugin_jerasure
-add_executable(unittest_erasure_code_plugin_jerasure
-  TestErasureCodePluginJerasure.cc
-  )
+#add_executable(unittest_erasure_code_plugin_jerasure
+#  TestErasureCodePluginJerasure.cc
+#  )
 #add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
-target_link_libraries(unittest_erasure_code_plugin_jerasure
-  global
-  osd
-  ec_jerasure
-  common)
-add_dependencies(unittest_erasure_code_plugin_jerasure
-  ec_jerasure)
+#target_link_libraries(unittest_erasure_code_plugin_jerasure
+#  global
+#  osd
+#  ec_jerasure
+#  common)
+#add_dependencies(unittest_erasure_code_plugin_jerasure
+#  ec_jerasure)
 
 if(HAVE_BETTER_YASM_ELF64)
 


### PR DESCRIPTION
It was failing to build with

[100%] Building CXX object src/test/erasure-code/CMakeFiles/unittest_erasure_code_plugin_jerasure.dir/TestErasureCodePluginJerasure.cc.o
/home/sage/src/ceph/src/test/erasure-code/TestErasureCodePluginJerasure.cc:25:25: fatal error: gtest/gtest.h: No such file or directory
compilation terminated.

Signed-off-by: Sage Weil <sage@redhat.com>