### PR TITLE
librados-dev: install inline_memory.h

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1341,6 +1341,7 @@ fi
 %{_includedir}/rados/librados.hpp
 %{_includedir}/rados/buffer.h
 %{_includedir}/rados/buffer_fwd.h
+%{_includedir}/rados/inline_memory.h
 %{_includedir}/rados/page.h
 %{_includedir}/rados/crc32c.h
 %{_includedir}/rados/rados_types.h

--- a/debian/librados-dev.install
+++ b/debian/librados-dev.install
@@ -4,6 +4,7 @@ usr/include/rados/buffer_fwd.h
 usr/include/rados/crc32c.h
 usr/include/rados/librados.h
 usr/include/rados/librados.hpp
+usr/include/rados/inline_memory.h
 usr/include/rados/page.h
 usr/include/rados/rados_types.h
 usr/include/rados/rados_types.hpp

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -4,6 +4,7 @@ install(FILES rados/librados.h
   rados/librados.hpp
   buffer.h
   buffer_fwd.h
+  inline_memory.h
   memory.h
   page.h
   crc32c.h

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -55,7 +55,7 @@
 # include <assert.h>
 #endif
 
-#include "include/inline_memory.h"
+#include "inline_memory.h"
 
 #if __GNUC__ >= 4
   #define CEPH_BUFFER_API  __attribute__ ((visibility ("default")))

--- a/src/include/rados/inline_memory.h
+++ b/src/include/rados/inline_memory.h
@@ -1,0 +1,1 @@
+../inline_memory.h


### PR DESCRIPTION
This is needed to compile against the c++ api since
c38869232c3c852d98fa1826632db360c5a6afd4

Fixes: http://tracker.ceph.com/issues/17654
Signed-off-by: Josh Durgin <jdurgin@redhat.com>