### PR TITLE
cmake: do not link erasure tests again libosd

### DIFF
--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -6,15 +6,15 @@ add_ceph_test(test-erasure-code.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-erasure-code
 add_executable(ceph_erasure_code_benchmark 
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   ceph_erasure_code_benchmark.cc)
-target_link_libraries(ceph_erasure_code_benchmark osd common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code_benchmark common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 install(TARGETS ceph_erasure_code_benchmark
   DESTINATION bin)
 
 add_executable(ceph_erasure_code_non_regression ceph_erasure_code_non_regression.cc)
-target_link_libraries(ceph_erasure_code_non_regression osd common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code_non_regression common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 
 add_executable(ceph_erasure_code ceph_erasure_code.cc)
-target_link_libraries(ceph_erasure_code osd common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 install(TARGETS ceph_erasure_code
   DESTINATION bin)
 
@@ -52,7 +52,6 @@ add_executable(unittest_erasure_code_plugin
 add_ceph_unittest(unittest_erasure_code_plugin ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin)
 target_link_libraries(unittest_erasure_code_plugin
   global
-  osd
   ${CMAKE_DL_LIBS}
   ec_example
   common
@@ -73,7 +72,6 @@ add_executable(unittest_erasure_code
 add_ceph_unittest(unittest_erasure_code ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code)
 target_link_libraries(unittest_erasure_code
   global
-  osd
   common
   )
 
@@ -84,8 +82,6 @@ add_executable(unittest_erasure_code_plugin_jerasure
 add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
 target_link_libraries(unittest_erasure_code_plugin_jerasure
   global
-  osd
-  ec_jerasure
   common)
 add_dependencies(unittest_erasure_code_plugin_jerasure
   ec_jerasure)
@@ -100,7 +96,6 @@ add_executable(unittest_erasure_code_isa
 add_ceph_unittest(unittest_erasure_code_isa ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_isa)
 target_link_libraries(unittest_erasure_code_isa
   global
-  osd
   common
   ec_isa
   erasure_code
@@ -114,13 +109,13 @@ add_executable(unittest_erasure_code_plugin_isa
 add_ceph_unittest(unittest_erasure_code_plugin_isa ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_isa)
 target_link_libraries(unittest_erasure_code_plugin_isa
   global
-  osd
   common
-  ec_isa
   crush
   ${CMAKE_DL_LIBS}
   erasure_code
   )
+add_dependencies(unittest_erasure_code_plugin_isa
+  ec_isa)
 endif(HAVE_BETTER_YASM_ELF64)
 
 # unittest_erasure_code_lrc
@@ -129,7 +124,6 @@ add_executable(unittest_erasure_code_lrc
 add_ceph_unittest(unittest_erasure_code_lrc ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_lrc)
 target_link_libraries(unittest_erasure_code_lrc
   global
-  osd
   ${CMAKE_DL_LIBS}
   ec_lrc
   common
@@ -145,10 +139,7 @@ add_dependencies(unittest_erasure_code_plugin_lrc
   ec_jerasure)
 target_link_libraries(unittest_erasure_code_plugin_lrc
   global
-  osd
   ${CMAKE_DL_LIBS}
-  ec_lrc
-  ec_jerasure
   common)
 
 # unittest_erasure_code_plugin_shec
@@ -158,10 +149,8 @@ add_executable(unittest_erasure_code_plugin_shec
 add_ceph_unittest(unittest_erasure_code_plugin_shec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_shec)
 target_link_libraries(unittest_erasure_code_plugin_shec
   global
-  osd
   ${CMAKE_DL_LIBS}
-  common
-  ec_shec)
+  common)
 add_dependencies(unittest_erasure_code_plugin_shec 
   ec_shec)
 
@@ -173,7 +162,6 @@ add_executable(unittest_erasure_code_example
 add_ceph_unittest(unittest_erasure_code_example ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_example)
 target_link_libraries(unittest_erasure_code_example
   global
-  osd
   ${CMAKE_DL_LIBS}
   common
   erasure_code
@@ -191,7 +179,6 @@ add_executable(unittest_erasure_code_jerasure
 add_ceph_unittest(unittest_erasure_code_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_jerasure)
 target_link_libraries(unittest_erasure_code_jerasure
   global
-  osd
   common
   ec_jerasure
   )
@@ -206,7 +193,6 @@ add_executable(unittest_erasure_code_shec
 add_ceph_unittest(unittest_erasure_code_shec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec)
 target_link_libraries(unittest_erasure_code_shec
   global
-  osd
   ${CMAKE_DL_LIBS}
   common
   ec_shec
@@ -219,7 +205,6 @@ add_executable(unittest_erasure_code_shec_all
 add_ceph_unittest(unittest_erasure_code_shec_all ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_all)
 target_link_libraries(unittest_erasure_code_shec_all
   global
-  osd
   ${CMAKE_DL_LIBS}
   common
   ec_shec
@@ -232,7 +217,6 @@ add_executable(unittest_erasure_code_shec_thread
 add_ceph_unittest(unittest_erasure_code_shec_thread ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_thread)
 target_link_libraries(unittest_erasure_code_shec_thread
   global
-  osd
   ${CMAKE_DL_LIBS}
   common
   ec_shec
@@ -246,7 +230,6 @@ add_executable(unittest_erasure_code_shec_arguments
 add_ceph_unittest(unittest_erasure_code_shec_arguments ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_shec_arguments)
 target_link_libraries(unittest_erasure_code_shec_arguments
   global
-  osd
   ${CMAKE_DL_LIBS}
   common
   ec_shec


### PR DESCRIPTION
they are not referencing any symbols from it. and also the tests testing
plugins are not linked against the ec plugins, they *depend* on them.

Signed-off-by: Kefu Chai <kchai@redhat.com>