### PR TITLE
mon: MonmapMonitor: return success when monitor will be removed

### DIFF
--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -408,7 +408,6 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     ss << "adding mon." << name << " at " << addr;
     propose = true;
     dout(0) << __func__ << " proposing new mon." << name << dendl;
-    goto reply;
 
   } else if (prefix == "mon remove" ||
              prefix == "mon rm") {
@@ -462,7 +461,6 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
        << ", there will be " << pending_map.size() << " monitors" ;
     propose = true;
     err = 0;
-    goto reply;
 
   } else {
     ss << "unknown command " << prefix;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -461,6 +461,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
     ss << "removing mon." << name << " at " << addr
        << ", there will be " << pending_map.size() << " monitors" ;
     propose = true;
+    err = 0;
     goto reply;
 
   } else {


### PR DESCRIPTION
We were cascading without changing the return value to success. This was incorrect, obviously.

`Signed-off-by: Joao Eduardo Luis <joao@suse.de>`