### PR TITLE
ceph-create-keys should not try forever to do things

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -74,7 +74,7 @@ def wait_for_quorum(cluster, mon_id):
         break
 
     if wait_count == 0:
-        LOG.error("ceph-mon was not able to join quorum within ten minutes")
+        LOG.error("ceph-mon was not able to join quorum within 10 minutes")
 
 
 def get_key(cluster, mon_id):
@@ -93,7 +93,8 @@ def get_key(cluster, mon_id):
         os.makedirs(pathdir)
         os.chmod(pathdir, 0770)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
-    while True:
+    wait_count = 600  # 10 minutes
+    while wait_count > 0:
         try:
             with file(tmp, 'w') as f:
                 os.fchmod(f.fileno(), 0600)
@@ -141,6 +142,7 @@ def get_key(cluster, mon_id):
                 else:
                     LOG.info('Cannot get or create admin key')
                     time.sleep(1)
+                    wait_count -= 1
                     continue
 
             os.rename(tmp, path)
@@ -153,6 +155,10 @@ def get_key(cluster, mon_id):
                     pass
                 else:
                     raise
+
+    if wait_count == 0:
+        raise SystemExit("Could not get or create the admin key after 10 minutes")
+
 
 def bootstrap_key(cluster, type_):
     path = '/var/lib/ceph/bootstrap-{type}/{cluster}.keyring'.format(

--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -30,7 +30,8 @@ def get_ceph_gid():
     return gid
 
 def wait_for_quorum(cluster, mon_id):
-    while True:
+    wait_count = 600  # 10 minutes
+    while wait_count > 0:
         p = subprocess.Popen(
             args=[
                 'ceph',
@@ -48,11 +49,13 @@ def wait_for_quorum(cluster, mon_id):
         if returncode != 0:
             LOG.info('ceph-mon admin socket not ready yet.')
             time.sleep(1)
+            wait_count -= 1
             continue
 
         if out == '':
             LOG.info('ceph-mon admin socket returned no data')
             time.sleep(1)
+            wait_count -= 1
             continue
 
         try:
@@ -65,9 +68,13 @@ def wait_for_quorum(cluster, mon_id):
         if state not in QUORUM_STATES:
             LOG.info('ceph-mon is not in quorum: %r', state)
             time.sleep(1)
+            wait_count -= 1
             continue
 
         break
+
+    if wait_count == 0:
+        LOG.error("ceph-mon was not able to join quorum within ten minutes")
 
 
 def get_key(cluster, mon_id):

--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -74,7 +74,7 @@ def wait_for_quorum(cluster, mon_id):
         break
 
     if wait_count == 0:
-        LOG.error("ceph-mon was not able to join quorum within 10 minutes")
+        raise SystemExit("ceph-mon was not able to join quorum within 10 minutes")
 
 
 def get_key(cluster, mon_id):
@@ -189,7 +189,8 @@ def bootstrap_key(cluster, type_):
         os.chmod(pathdir, 0770)
         os.chown(pathdir, get_ceph_uid(), get_ceph_gid())
 
-    while True:
+    wait_count = 600  # 10 minutes
+    while wait_count > 0:
         try:
             with file(tmp, 'w') as f:
                 os.fchmod(f.fileno(), 0600)
@@ -206,6 +207,7 @@ def bootstrap_key(cluster, type_):
                 else:
                     LOG.info('Cannot get or create bootstrap key for %s', type_)
                     time.sleep(1)
+                    wait_count -= 1
                     continue
 
             os.rename(tmp, path)
@@ -218,6 +220,8 @@ def bootstrap_key(cluster, type_):
                     pass
                 else:
                     raise
+    if wait_count == 0:
+        raise SystemExit("Could not get or create %s bootstrap key after 10 minutes" % type_)
 
 
 def parse_args():


### PR DESCRIPTION
These `while` loops continue to cause issues when monitors can't form quorum or keys can't be created (or bootstrap).

Not only related to tracker issue 17753 but a wealth of other ceph-deploy, ceph-ansible, and ceph-installer issues:

http://tracker.ceph.com/issues/17753
http://tracker.ceph.com/issues/12649
http://tracker.ceph.com/issues/16255
https://bugzilla.redhat.com/show_bug.cgi?id=1329008
https://bugzilla.redhat.com/show_bug.cgi?id=1327983
https://bugzilla.redhat.com/show_bug.cgi?id=1332920
https://bugzilla.redhat.com/show_bug.cgi?id=1335211
https://bugzilla.redhat.com/show_bug.cgi?id=1384052

This PR waits for 10 minutes. *I* feel like that is a reasonable value, but I am OK with raising it even more if that is considered too low.