### PR TITLE
[DNM] Make PG::queue_op lockless for common case

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,9 +182,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ${ENABLE_SHARED})
 
 find_package(Backtrace)
 
+find_package(urcu REQUIRED)
+
 if(LINUX)
   find_package(udev REQUIRED)
   set(HAVE_UDEV ${UDEV_FOUND})
+
+  find_package(urcu REQUIRED)
+  set(HAVE_URCU ${URCU_FOUND})
 
   find_package(aio REQUIRED)
   set(HAVE_LIBAIO ${AIO_FOUND})
@@ -192,6 +197,8 @@ if(LINUX)
   find_package(blkid REQUIRED)
   set(HAVE_BLKID ${BLKID_FOUND})
 else()
+  set(HAVE_URCU OFF)
+  message(STATUS "Not using urcu")
   set(HAVE_UDEV OFF)
   message(STATUS "Not using udev")
   set(HAVE_LIBAIO OFF)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -130,6 +130,7 @@ BuildRequires:	xfsprogs
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	yasm
+BuildRequires:	userspace-rcu
 
 #################################################################################
 # distro-conditional dependencies

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,6 +220,8 @@ if(HAVE_XIO)
   list(APPEND EXTRALIBS ${XIO_LIBRARY} pthread rt)
 endif(HAVE_XIO)
 
+set(RCU_LIBS ${GPERFTOOLS_TCMALLOC_LIBRARY})
+
 # sort out which allocator to use
 if(ALLOCATOR STREQUAL "tcmalloc")
   set(ALLOC_LIBS ${GPERFTOOLS_TCMALLOC_LIBRARY})
@@ -476,7 +478,7 @@ add_library(common STATIC ${libcommon_files}
   $<TARGET_OBJECTS:common_mountcephfs_objs>)
 target_link_libraries(common json_spirit erasure_code rt ${LIB_RESOLV}
   ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
-  ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS} ${URCU_LIBRARIES})
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/common/version.cc
@@ -643,7 +645,7 @@ set(ceph_osd_srcs
 add_executable(ceph-osd ${ceph_osd_srcs}
   $<TARGET_OBJECTS:common_util_obj>)
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global ${BLKID_LIBRARIES})
+target_link_libraries(ceph-osd osd os global ${URCU_LIBRARIES} ${BLKID_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})
 endif()

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -1,3 +1,4 @@
+
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
@@ -512,6 +513,8 @@ CephContext::CephContext(uint32_t module_type_, int init_flags_)
   _admin_socket->register_command("log flush", "log flush", _admin_hook, "flush log entries to log file");
   _admin_socket->register_command("log dump", "log dump", _admin_hook, "dump recent log entries to log file");
   _admin_socket->register_command("log reopen", "log reopen", _admin_hook, "reopen log file");
+
+  pthread_key_create(&registered, 0);
 
   _crypto_none = CryptoHandler::create(CEPH_CRYPTO_NONE);
   _crypto_aes = CryptoHandler::create(CEPH_CRYPTO_AES);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -146,6 +146,8 @@ public:
    */
   CryptoHandler *get_crypto_handler(int type);
 
+  pthread_key_t registered;
+
   /// check if experimental feature is enable, and emit appropriate warnings
   bool check_experimental_feature_enabled(const std::string& feature);
   bool check_experimental_feature_enabled(const std::string& feature,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -682,6 +682,7 @@ OPTION(osd_map_message_max, OPT_INT, 100)  // max maps per MOSDMap message
 OPTION(osd_map_share_max_epochs, OPT_INT, 100)  // cap on # of inc maps we send to peers, clients
 OPTION(osd_inject_bad_map_crc_probability, OPT_FLOAT, 0)
 OPTION(osd_inject_failure_on_pg_removal, OPT_BOOL, false)
+OPTION(osd_inject_pg_lock_longhold, OPT_BOOL, false)
 // shutdown the OSD if stuatus flipping more than max_markdown_count times in recent max_markdown_period seconds
 OPTION(osd_max_markdown_period , OPT_INT, 600)
 OPTION(osd_max_markdown_count, OPT_INT, 5)

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -68,7 +68,7 @@ void PGMonitor::on_restart()
 void PGMonitor::on_active()
 {
   if (mon->is_leader()) {
-    check_osd_map(mon->osdmon()->osdmap.epoch);
+    check_osd_map(mon->osdmon()->osdmap.get_epoch());
     need_check_down_pgs = true;
   }
 

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -13,7 +13,7 @@
  * Foundation.  See file COPYING.
  *
  */
-
+#include <urcu.h>
 #include <unistd.h>
 
 #include "include/Context.h"
@@ -327,6 +327,8 @@ void AsyncConnection::process()
   bool already_dispatch_writer = false;
   std::lock_guard<std::mutex> l(lock);
   last_active = ceph::coarse_mono_clock::now();
+
+  rcu_quiescent_state();
   do {
     ldout(async_msgr->cct, 20) << __func__ << " prev state is " << get_state_name(prev_state) << dendl;
     prev_state = state;

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -14,6 +14,7 @@
  *
  */
 
+#include <urcu.h>
 #include "common/Cond.h"
 #include "common/errno.h"
 #include "PosixStack.h"
@@ -35,6 +36,8 @@ void NetworkStack::add_thread(unsigned i, std::function<void ()> &thread)
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();
       w->init_done();
+      pthread_setspecific(w->cct->registered, this);
+      rcu_register_thread();
       while (!w->done) {
         ldout(cct, 30) << __func__ << " calling event process" << dendl;
 
@@ -45,6 +48,7 @@ void NetworkStack::add_thread(unsigned i, std::function<void ()> &thread)
           // TODO do something?
         }
       }
+      rcu_unregister_thread();
       w->reset();
     }
   );

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -202,7 +202,6 @@ class Worker {
 
  public:
   bool done = false;
-
   CephContext *cct;
   PerfCounters *perf_logger;
   unsigned id;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include <urcu.h>
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <netinet/in.h>
@@ -88,6 +89,7 @@ Pipe::Pipe(SimpleMessenger *r, int st, PipeConnection *con)
   ANNOTATE_BENIGN_RACE_SIZED(&state, sizeof(state), "Pipe state");
   ANNOTATE_BENIGN_RACE_SIZED(&recv_len, sizeof(recv_len), "Pipe recv_len");
   ANNOTATE_BENIGN_RACE_SIZED(&recv_ofs, sizeof(recv_ofs), "Pipe recv_ofs");
+
   if (con) {
     connection_state = con;
     connection_state->reset_pipe(this);
@@ -99,7 +101,6 @@ Pipe::Pipe(SimpleMessenger *r, int st, PipeConnection *con)
   if (randomize_out_seq()) {
     lsubdout(msgr->cct,ms,15) << "Pipe(): Could not get random bytes to set seq number for session reset; set seq number to " << out_seq << dendl;
   }
-    
 
   msgr->timeout = msgr->cct->_conf->ms_tcp_read_timeout * 1000; //convert to ms
   if (msgr->timeout == 0)
@@ -1518,16 +1519,21 @@ void Pipe::stop_and_wait()
 void Pipe::reader()
 {
   pipe_lock.Lock();
-
+  
   if (state == STATE_ACCEPTING) {
     accept();
     assert(pipe_lock.is_locked());
   }
 
+  rcu_register_thread();
+  pthread_setspecific(msgr->cct->registered, this);
+
   // loop.
   while (state != STATE_CLOSED &&
 	 state != STATE_CONNECTING) {
     assert(pipe_lock.is_locked());
+
+    rcu_quiescent_state();
 
     // sleep if (re)connecting
     if (state == STATE_STANDBY) {
@@ -1542,6 +1548,9 @@ void Pipe::reader()
     pipe_lock.Unlock();
 
     char tag = -1;
+
+    rcu_thread_offline();
+
     ldout(msgr->cct,20) << "reader reading tag..." << dendl;
     if (tcp_read((char*)&tag, 1) < 0) {
       pipe_lock.Lock();
@@ -1549,6 +1558,8 @@ void Pipe::reader()
       fault(true);
       continue;
     }
+
+    rcu_thread_online();
 
     if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
       ldout(msgr->cct,2) << "reader got KEEPALIVE" << dendl;
@@ -1704,7 +1715,8 @@ void Pipe::reader()
     }
   }
 
- 
+  rcu_unregister_thread();
+
   // reap?
   reader_running = false;
   reader_needs_join = true;

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(osd STATIC ${osd_srcs}
   $<TARGET_OBJECTS:global_common_objs>
   $<TARGET_OBJECTS:heap_profiler_objs>
   $<TARGET_OBJECTS:common_util_obj>)
+target_include_directories(osd BEFORE PUBLIC ${URCU_INCLUDE_DIRS})
 target_link_libraries(osd ${LEVELDB_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
 if(WITH_LTTNG)
   add_dependencies(osd oprequest-tp osd-tp pg-tp)

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -28,6 +28,7 @@
 #include "osd_types.h"
 
 //#include "include/ceph_features.h"
+#include <atomic>
 #include "crush/CrushWrapper.h"
 #include <vector>
 #include <list>
@@ -199,7 +200,34 @@ public:
   
 private:
   uuid_d fsid;
-  epoch_t epoch;        // what epoch of the osd cluster descriptor is this
+
+  class atomic_epoch {
+    std::atomic<epoch_t> value;
+  public:
+    atomic_epoch() {
+      value.store(0);
+    }
+    atomic_epoch(epoch_t init_epoch) {
+      value.store(init_epoch);
+    }
+    atomic_epoch(const atomic_epoch& other) {
+      value=other.value.load();
+    }
+    atomic_epoch& operator=(const atomic_epoch& other) {
+      value=other.value.load();
+      return *this;
+    }
+    epoch_t get() const {
+      return value.load();
+    }
+    void set(epoch_t new_epoch) {
+      value.store(new_epoch);
+    }
+    void inc() {
+      value++;
+    }
+  } epoch;
+
   utime_t created, modified; // epoch start time
   int32_t pool_max;     // the largest pool num, ever
 
@@ -258,7 +286,7 @@ private:
   friend class PGMonitor;
 
  public:
-  OSDMap() : epoch(0), 
+  OSDMap() : epoch(0),
 	     pool_max(-1),
 	     flags(0),
 	     num_osd(0), num_up_osd(0), num_in_osd(0),
@@ -303,9 +331,8 @@ public:
   const uuid_d& get_fsid() const { return fsid; }
   void set_fsid(uuid_d& f) { fsid = f; }
 
-  epoch_t get_epoch() const { return epoch; }
-  void inc_epoch() { epoch++; }
-
+  epoch_t get_epoch() const { return epoch.get(); }
+  void inc_epoch() { epoch.inc(); }
   void set_epoch(epoch_t e);
 
   /* stamps etc */
@@ -316,7 +343,7 @@ public:
   void get_blacklist(list<pair<entity_addr_t,utime_t > > *bl) const;
 
   string get_cluster_snapshot() const {
-    if (cluster_snapshot_epoch == epoch)
+    if (cluster_snapshot_epoch == epoch.get())
       return cluster_snapshot;
     return string();
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include <urcu.h>
 #include "PG.h"
 // #include "msg/Messenger.h"
 #include "messages/MOSDRepScrub.h"
@@ -204,6 +205,8 @@ PG::PG(OSDService *o, OSDMapRef curmap,
     _pool.id,
     p.shard),
   map_lock("PG::map_lock"),
+  waiting_for_map_empty(true),
+  osdmap_ptr_rcu(&osdmap_ref),
   osdmap_ref(curmap), last_persisted_osdmap_ref(curmap), pool(_pool),
   _lock("PG::_lock"),
   #ifdef PG_DEBUG_REFS
@@ -1894,18 +1897,43 @@ void PG::take_op_map_waiters()
       waiting_for_map.erase(i++);
     }
   }
+  if (waiting_for_map.empty())
+    waiting_for_map_empty.store(true);
+}
+
+void PG::update_osdmap_ref(OSDMapRef newmap) {
+  assert(_lock.is_locked_by_me());
+  Mutex::Locker l(map_lock);
+
+  // Take extra reference of old osdmap so it is not deleted
+  // until function exits after synchronize_rcu().
+  OSDMapRef extra_ref = osdmap_ref;
+
+  osdmap_ref = newmap;
+  rcu_xchg_pointer(&osdmap_ptr_rcu, &osdmap_ref);
+  synchronize_rcu();
+}
+
+epoch_t PG::get_osdmap_epoch_rcu() {
+  rcu_read_lock();
+  OSDMapRef *osdmap_ptr = rcu_dereference(osdmap_ptr_rcu);
+  epoch_t ret_epoch = (*osdmap_ptr)->get_epoch();
+  rcu_read_unlock();
+  return ret_epoch;
 }
 
 void PG::queue_op(OpRequestRef& op)
 {
-  Mutex::Locker l(map_lock);
-  if (!waiting_for_map.empty()) {
+  if (waiting_for_map_empty.load() == false) {
+    Mutex::Locker l(map_lock);
     // preserve ordering
     waiting_for_map.push_back(op);
     op->mark_delayed("waiting_for_map not empty");
     return;
   }
-  if (op_must_wait_for_map(get_osdmap_with_maplock()->get_epoch(), op)) {
+  if (op_must_wait_for_map(get_osdmap_epoch_rcu(), op)) {
+    Mutex::Locker l(map_lock);
+    waiting_for_map_empty.store(false);
     waiting_for_map.push_back(op);
     op->mark_delayed("op must wait for map");
     return;
@@ -2264,6 +2292,10 @@ void PG::split_ops(PG *child, unsigned split_bits) {
     Mutex::Locker l(map_lock); // to avoid a race with the osd dispatch
     OSD::split_list(
       &waiting_for_map, &(child->waiting_for_map), match, split_bits);
+    if (waiting_for_map.empty())
+      waiting_for_map_empty.store(true);
+    if (child->waiting_for_map.empty())
+      child->waiting_for_map_empty.store(true);
   }
 }
 

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -53,7 +53,7 @@ add_executable(unittest_osdscrub
   TestOSDScrub.cc
   )
 add_ceph_unittest(unittest_osdscrub ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_osdscrub)
-target_link_libraries(unittest_osdscrub osd global ${CMAKE_DL_LIBS} os mon ${BLKID_LIBRARIES})
+target_link_libraries(unittest_osdscrub osd global ${CMAKE_DL_LIBS} os mon ${BLKID_LIBRARIES} ${URCU_LIBRARIES})
 
 # unittest_pglog
 add_executable(unittest_pglog

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -37,7 +37,7 @@ add_executable(ceph-objectstore-tool
   ceph_objectstore_tool.cc
   rebuild_mondb.cc
   RadosDump.cc)
-target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS})
+target_link_libraries(ceph-objectstore-tool osd os global ${Boost_PROGRAM_OPTIONS_LIBRARY} ${CMAKE_DL_LIBS} ${URCU_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-objectstore-tool fuse)
 endif(WITH_FUSE)


### PR DESCRIPTION
PG::queue_op won't queue a request if the epoch is newer
than the one in the request. This patch changes that check
to be done in a lockless manner.

This is a  WIP patch, uploaded so other's could take a peek. 
more testing / analysis needed.

(1) obtain osdmap using an RCU managed pointer
(2) manage the osdmap's epoch using an atomic counter
(3) maintain request ordering for the session

Signed-off-by: Dan Lambright <dlambrig@gmail.com>