### PR TITLE
rgw: extract host name from host:port string

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1846,6 +1846,10 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   bool s3website_enabled = api_priority_s3website >= 0;
 
   if (info.host.size()) {
+    ssize_t pos = info.host.find(':');
+    if (pos >= 0) {
+      info.host = info.host.substr(0, pos);
+    }
     ldout(s->cct, 10) << "host=" << info.host << dendl;
     string domain;
     string subdomain;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17788

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>