### PR TITLE
jewel: osd crashes when radosgw-admin bi list --max-entries=1 command runing

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2388,7 +2388,7 @@ static int rgw_bi_list_op(cls_method_context_t hctx, bufferlist *in, bufferlist 
 
   string filter = op.name;
 #define MAX_BI_LIST_ENTRIES 1000
-  int32_t max = (op.max < MAX_BI_LIST_ENTRIES ? op.max : MAX_BI_LIST_ENTRIES);
+  int32_t max = (op.max < MAX_BI_LIST_ENTRIES ? op.max : MAX_BI_LIST_ENTRIES) + 1; /* one extra entry for identifying truncation */
   string start_key = op.marker;
   int ret = list_plain_entries(hctx, op.name, op.marker, max, &op_ret.entries);
   if (ret < 0) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/17784