### PR TITLE
doc: rgw: fix a typo in S3 java api example

### DIFF
--- a/doc/radosgw/s3/java.rst
+++ b/doc/radosgw/s3/java.rst
@@ -111,7 +111,7 @@ modified date.
 	do {
 		for (S3ObjectSummary objectSummary : objects.getObjectSummaries()) {
 			System.out.println(objectSummary.getKey() + "\t" +
-				ObjectSummary.getSize() + "\t" +
+				objectSummary.getSize() + "\t" +
 				StringUtils.fromDate(objectSummary.getLastModified()));
 		}
 		objects = conn.listNextBatchOfObjects(objects);


### PR DESCRIPTION
    ObjectSummary.getSize() should be objectSummary.getSize()

Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>