### PR TITLE
mon: if crushtool config is empty use internal crush test

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4943,10 +4943,15 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   _get_pending_crush(newcrush);
   ostringstream err;
   CrushTester tester(newcrush, err);
-  r = tester.test_with_crushtool(g_conf->crushtool.c_str(),
+  // use the internal crush tester if crushtool config is empty
+  if (g_conf->crushtool.empty()) {
+    r = tester.test();
+  } else {
+    r = tester.test_with_crushtool(g_conf->crushtool.c_str(),
 				 osdmap.get_max_osd(),
 				 g_conf->mon_lease,
 				 crush_ruleset);
+  }
   if (r) {
     dout(10) << " tester.test_with_crushtool returns " << r
 	     << ": " << err.str() << dendl;


### PR DESCRIPTION
currently we expect the tool ```crushtool``` to be installed and available for crush map testing. This is not always the case. The change here will use the internal crush tester if the ```crushtool```
config is empty.
