### PR TITLE
test_bloom_filter.cc: Fix a mismatch for the random_seed parameter

### DIFF
--- a/src/test/common/test_bloom_filter.cc
+++ b/src/test/common/test_bloom_filter.cc
@@ -291,7 +291,7 @@ TEST(BloomFilter, SequenceDouble) {
 #endif
 
 TEST(BloomFilter, Assignement) {
-  bloom_filter bf1(10, .1, .1), bf2;
+  bloom_filter bf1(10, .1, 1), bf2;
 
   bf1.insert("foo");
   bf2 = bf1;


### PR DESCRIPTION
random_seed is integer and used to select seeding with either a random or a preset value.
All tests are run with random_seed == 1.
And 0.1 is converted/rounded to 0 by Clang

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>