### PR TITLE
mon/OSDMonitor: remove duplicate jewel/kraken flag warning

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3100,26 +3100,6 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
       }
     }
 
-    // warn about upgrade flags that can be set but are not.
-    if ((osdmap.get_up_osd_features() & CEPH_FEATURE_SERVER_JEWEL) &&
-	!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
-      string msg = "all OSDs are running jewel or later but the"
-	" 'require_jewel_osds' osdmap flag is not set";
-      summary.push_back(make_pair(HEALTH_WARN, msg));
-      if (detail) {
-	detail->push_back(make_pair(HEALTH_WARN, msg));
-      }
-    }
-    if ((osdmap.get_up_osd_features() & CEPH_FEATURE_SERVER_KRAKEN) &&
-	!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_KRAKEN)) {
-      string msg = "all OSDs are running kraken or later but the"
-	" 'require_kraken_osds' osdmap flag is not set";
-      summary.push_back(make_pair(HEALTH_WARN, msg));
-      if (detail) {
-	detail->push_back(make_pair(HEALTH_WARN, msg));
-      }
-    }
-
     get_pools_health(summary, detail);
   }
 }


### PR DESCRIPTION
Since 6244755a7051abe2e89d9f1ff75a10c4b76ee3b5 and
12e508313dbd5d1d38c76859cb7de2ce22404e12, the original check added in
ae0d6eb1c01aa74a2c44c017c0c5b06697348d2d (perhaps by a bad
rebase/merge?)  is duplicated and doubles the warning messages.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>