### PR TITLE
qa/workunits/rbd: simplify running nbd test under build env

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -5,24 +5,52 @@
 POOL=rbd
 IMAGE=testrbdnbd$$
 TOO_LARGE_IMAGE=${IMAGE}_large
-SUDO=sudo
 SIZE=64
 DATA=
 DEV=
 
+_sudo()
+{
+    local cmd
+
+    if [ `id -u` -eq 0 ]
+    then
+	"$@"
+	return $?
+    fi
+
+    # Look for the command in the user path. If it fails run it as is,
+    # supposing it is in sudo path.
+    cmd=`which $1 2>/dev/null` || cmd=$1
+    shift
+    sudo -nE "${cmd}" "$@"
+}
+
 setup()
 {
+    if [ -e CMakeCache.txt ]; then
+	# running under cmake build dir
+
+	CEPH_SRC=$(readlink -f $(dirname $0)/../../../src)
+	CEPH_ROOT=${PWD}
+	CEPH_BIN=${CEPH_ROOT}/bin
+
+	export LD_LIBRARY_PATH=${CEPH_ROOT}/lib:${LD_LIBRARY_PATH}
+	export PYTHONPATH=${PYTHONPATH}:${CEPH_SRC}/pybind
+	for x in ${CEPH_ROOT}/lib/cython_modules/lib* ; do
+            PYTHONPATH="${PYTHONPATH}:${x}"
+	done
+	PATH=${CEPH_BIN}:${PATH}
+    fi
+
+    _sudo echo test sudo
+
     trap cleanup INT TERM EXIT
     TEMPDIR=`mktemp -d`
     DATA=${TEMPDIR}/data
     dd if=/dev/urandom of=${DATA} bs=1M count=${SIZE}
     rbd --dest-pool ${POOL} --no-progress import ${DATA} ${IMAGE}
     rbd -p ${POOL} create ${TOO_LARGE_IMAGE} --size 3T
-
-    if [ `id -u` = 0 ]
-    then
-	SUDO=
-    fi
 }
 
 function cleanup()
@@ -31,7 +59,7 @@ function cleanup()
     rm -Rf ${TMPDIR}
     if [ -n "${DEV}" ]
     then
-	${SUDO} rbd-nbd unmap ${DEV}
+	_sudo rbd-nbd unmap ${DEV}
     fi
     if rbd -p ${POOL} status ${IMAGE} 2>/dev/null; then
 	for s in 0.5 1 2 4 8 16 32; do
@@ -61,31 +89,31 @@ if [ `id -u` -ne 0 ]
 then
     expect_false rbd-nbd map ${IMAGE}
 fi
-expect_false ${SUDO} rbd-nbd map INVALIDIMAGE
-expect_false ${SUDO} rbd-nbd --device INVALIDDEV map ${IMAGE}
-expect_false ${SUDO} rbd-nbd map ${TOO_LARGE_IMAGE}
+expect_false _sudo rbd-nbd map INVALIDIMAGE
+expect_false _sudo rbd-nbd --device INVALIDDEV map ${IMAGE}
+expect_false _sudo rbd-nbd map ${TOO_LARGE_IMAGE}
 
 # map test using the first unused device
-DEV=`${SUDO} rbd-nbd map ${POOL}/${IMAGE}`
-${SUDO} rbd-nbd list-mapped | grep "^${DEV}$"
+DEV=`_sudo rbd-nbd map ${POOL}/${IMAGE}`
+_sudo rbd-nbd list-mapped | grep "^${DEV}$"
 
 # map test specifying the device
-expect_false ${SUDO} rbd-nbd --device ${DEV} map ${POOL}/${IMAGE}
+expect_false _sudo rbd-nbd --device ${DEV} map ${POOL}/${IMAGE}
 dev1=${DEV}
-${SUDO} rbd-nbd unmap ${DEV}
-${SUDO} rbd-nbd list-mapped | expect_false grep "^${DEV}$"
+_sudo rbd-nbd unmap ${DEV}
+_sudo rbd-nbd list-mapped | expect_false grep "^${DEV}$"
 DEV=
 # XXX: race possible when the device is reused by other process
-DEV=`${SUDO} rbd-nbd --device ${dev1} map ${POOL}/${IMAGE}`
+DEV=`_sudo rbd-nbd --device ${dev1} map ${POOL}/${IMAGE}`
 [ "${DEV}" = "${dev1}" ]
-${SUDO} rbd-nbd list-mapped | grep "^${DEV}$"
+_sudo rbd-nbd list-mapped | grep "^${DEV}$"
 
 # read test
-[ "`dd if=${DATA} bs=1M | md5sum`" = "`${SUDO} dd if=${DEV} bs=1M | md5sum`" ]
+[ "`dd if=${DATA} bs=1M | md5sum`" = "`_sudo dd if=${DEV} bs=1M | md5sum`" ]
 
 # write test
 dd if=/dev/urandom of=${DATA} bs=1M count=${SIZE}
-${SUDO} dd if=${DATA} of=${DEV} bs=1M oflag=direct
+_sudo dd if=${DATA} of=${DEV} bs=1M oflag=direct
 [ "`dd if=${DATA} bs=1M | md5sum`" = "`rbd -p ${POOL} --no-progress export ${IMAGE} - | md5sum`" ]
 
 # trim test
@@ -94,7 +122,7 @@ provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
 used=`rbd -p ${POOL} --format xml du ${IMAGE} |
   $XMLSTARLET sel -t -m "//stats/images/image/used_size" -v .`
 [ "${used}" -eq "${provisioned}" ]
-${SUDO} mkfs.ext4 -E discard ${DEV} # better idea?
+_sudo mkfs.ext4 -E discard ${DEV} # better idea?
 sync
 provisioned=`rbd -p ${POOL} --format xml du ${IMAGE} |
   $XMLSTARLET sel -t -m "//stats/images/image/provisioned_size" -v .`
@@ -117,20 +145,20 @@ test -n "${blocks2}"
 test ${blocks2} -eq ${blocks}
 
 # read-only option test
-${SUDO} rbd-nbd unmap ${DEV}
-DEV=`${SUDO} rbd-nbd map --read-only ${POOL}/${IMAGE}`
-${SUDO} rbd-nbd list-mapped | grep "^${DEV}$"
-${SUDO} dd if=${DEV} of=/dev/null bs=1M
-expect_false ${SUDO} dd if=${DATA} of=${DEV} bs=1M oflag=direct
-${SUDO} rbd-nbd unmap ${DEV}
+_sudo rbd-nbd unmap ${DEV}
+DEV=`_sudo rbd-nbd map --read-only ${POOL}/${IMAGE}`
+_sudo rbd-nbd list-mapped | grep "^${DEV}$"
+_sudo dd if=${DEV} of=/dev/null bs=1M
+expect_false _sudo dd if=${DATA} of=${DEV} bs=1M oflag=direct
+_sudo rbd-nbd unmap ${DEV}
 
 # exclusive option test
-DEV=`${SUDO} rbd-nbd map --exclusive ${POOL}/${IMAGE}`
-${SUDO} rbd-nbd list-mapped | grep "^${DEV}$"
-${SUDO} dd if=${DATA} of=${DEV} bs=1M oflag=direct
+DEV=`_sudo rbd-nbd map --exclusive ${POOL}/${IMAGE}`
+_sudo rbd-nbd list-mapped | grep "^${DEV}$"
+_sudo dd if=${DATA} of=${DEV} bs=1M oflag=direct
 expect_false timeout 10 \
 	rbd bench ${IMAGE} --io-type write --io-size=1024 --io-total=1024
-${SUDO} rbd-nbd unmap ${DEV}
+_sudo rbd-nbd unmap ${DEV}
 DEV=
 rbd bench ${IMAGE} --io-type write --io-size=1024 --io-total=1024
 


### PR DESCRIPTION
Previously running the script as unprivileged user was not very useful
due to difficulty to change path sudo was looking for a command to
execute.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>