### PR TITLE
ceph-disk: ability to use a different cluster name with dmcrypt

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2466,7 +2466,7 @@ class Lockbox(object):
                       self.args.lockbox)
             self.partition = self.create_partition()
 
-    def create_key(self, cluster):
+    def create_key(self):
         key_size = CryptHelpers.get_dmcrypt_keysize(self.args)
         key = open('/dev/urandom', 'rb').read(key_size / 8)
         base64_key = base64.b64encode(key)
@@ -2528,7 +2528,7 @@ class Lockbox(object):
         LOG.debug('Mounting lockbox ' + str(" ".join(args)))
         command_check_call(args)
         write_one_line(path, 'osd-uuid', self.args.osd_uuid)
-        self.create_key(self.args.cluster)
+        self.create_key()
         self.symlink_spaces(path)
         write_one_line(path, 'magic', CEPH_LOCKBOX_ONDISK_MAGIC)
         if self.device is not None:

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -316,7 +316,7 @@ class TestDevicePartitionCrypt(Base):
             partition.map()
             assert m['_dmcrypt_map'].called
             m['get_dmcrypt_key'].assert_called_with(
-                uuid, '/etc/ceph/dmcrypt-keys', True)
+                uuid, '/etc/ceph/dmcrypt-keys', True, 'ceph')
 
 
 class TestCryptHelpers(Base):


### PR DESCRIPTION
Prior to this commit we were not able to configure an OSD using dmcrypt
on a cluster with a different name than 'ceph'. Adding the command line
option to --cluster <cluster name> to fix this.

Signed-off-by: Sébastien Han <seb@redhat.com>