### PR TITLE
doc: clarify "ceph quorum" syntax

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1189,12 +1189,16 @@ Usage::
 quorum
 ------
 
-Enter or exit quorum.
+Cause MON to enter or exit quorum.
 
 Usage::
 
 	ceph quorum enter|exit
 
+Note: this only works on the MON to which the ``ceph`` command is connected.
+If you want a specific MON to enter or exit quorum, use this syntax::
+
+	ceph tell mon.<id> quorum enter|exit
 
 quorum_status
 -------------


### PR DESCRIPTION
The man page did not prepare the user for the fact that "ceph quorum exit" will
cause a random monitor to leave quorum, nor did it say explicitly how to make
the command work on a specific monitor.

Fixes: http://tracker.ceph.com/issues/17802
Signed-off-by: Nathan Cutler <ncutler@suse.com>