### PR TITLE
os: remove move_ranges_destroy_src

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -385,7 +385,6 @@ public:
       OP_COLL_HINT = 40, // cid, type, bl
 
       OP_TRY_RENAME = 41,   // oldcid, oldoid, newoid
-      OP_MERGE_DELETE = 42, //move tempobj to base object. cid, oid, newoid, vector of tuple <src offset, dest offset, len>
     };
 
     // Transaction hint type
@@ -646,7 +645,6 @@ public:
 
       case OP_CLONERANGE2:
       case OP_CLONE:
-      case OP_MERGE_DELETE:
         assert(op->cid < cm.size());
         assert(op->oid < om.size());
         assert(op->dest_oid < om.size());
@@ -934,9 +932,6 @@ public:
       void decode_attrset(map<string,bufferlist>& aset) {
         ::decode(aset, data_bl_p);
       }
-      void decode_move_info(vector<std::pair<uint64_t, uint64_t >>& move_info) {
-        ::decode(move_info, data_bl_p);
-      }
       void decode_attrset_bl(bufferlist *pbl) {
 	decode_str_str_map_to_bl(data_bl_p, pbl);
       }
@@ -1190,27 +1185,6 @@ public:
       _op->off = srcoff;
       _op->len = srclen;
       _op->dest_off = dstoff;
-      data.ops++;
-    }
-
-    /*
-     * Move source object to base object.
-     * Data portion is only copied from source object to base object.
-     * The copy is done according to the move_info vector of tuple, which
-     * has information of offset and length.
-     * Finally, the source object is deleted.
-     */
-    void move_ranges_destroy_src(
-      const coll_t& cid,
-      const ghobject_t& src_oid,
-      ghobject_t oid,
-      const vector<std::pair<uint64_t, uint64_t>>& move_info) {
-      Op* _op = _get_next_op();
-      _op->op = OP_MERGE_DELETE;
-      _op->cid = _get_coll_id(cid);
-      _op->oid = _get_object_id(src_oid);
-      _op->dest_oid = _get_object_id(oid);
-      ::encode(move_info, data_bl);
       data.ops++;
     }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2096,12 +2096,6 @@ private:
 		   OnodeRef& oldo,
 		   OnodeRef& newo,
 		   uint64_t srcoff, uint64_t length, uint64_t dstoff);
-  int _move_ranges_destroy_src(
-    TransContext *txc,
-    CollectionRef& c,
-    OnodeRef& oldo,
-    OnodeRef& newo,
-    const vector<std::pair<uint64_t,uint64_t>> move_info);
   int _rename(TransContext *txc,
 	      CollectionRef& c,
 	      OnodeRef& oldo,

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -590,11 +590,6 @@ public:
   int _clone_range(const coll_t& oldcid, const ghobject_t& oldoid, const coll_t& newcid, const ghobject_t& newoid,
 		   uint64_t srcoff, uint64_t len, uint64_t dstoff,
 		   const SequencerPosition& spos);
-  int _move_ranges_destroy_src(
-    const coll_t& temp_cid, const ghobject_t& temp_oid,
-    const coll_t& cid, const ghobject_t& oid,
-    const vector<std::pair<uint64_t, uint64_t> > move_info,
-    const SequencerPosition& spos);
   int _do_clone_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff);
   int _do_sparse_copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff);
   int _do_copy_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff, bool skip_sloppycrc=false);

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -637,13 +637,6 @@ private:
 		   OnodeRef& oldo,
 		   OnodeRef& newo,
 		   uint64_t srcoff, uint64_t length, uint64_t dstoff);
-  int _move_ranges_destroy_src(
-    TransContext *txc,
-    CollectionRef& c,
-    OnodeRef& oldo,
-    CollectionRef& bc,
-    OnodeRef& newo,
-    vector<std::pair<uint64_t, uint64_t>> move_info);
   int _rename(TransContext *txc,
 	      CollectionRef& c,
 	      OnodeRef& oldo,

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -847,17 +847,6 @@ void MemStore::_do_transaction(Transaction& t)
       }
       break;
 
-    case Transaction::OP_MERGE_DELETE:
-      {
-        coll_t cid = i.get_cid(op->cid);
-        ghobject_t oid = i.get_oid(op->oid);
-        ghobject_t noid = i.get_oid(op->dest_oid);
-        vector<std::pair<uint64_t, uint64_t>> move_info;
-        i.decode_move_info(move_info);
-        r = _move_ranges_destroy_src(cid, oid, noid, move_info);
-      }
-      break;
-
     case Transaction::OP_MKCOLL:
       {
         coll_t cid = i.get_cid(op->cid);
@@ -1253,42 +1242,6 @@ int MemStore::_clone_range(const coll_t& cid, const ghobject_t& oldoid,
   used_bytes += (no->get_size() - old_size);
 
   return len;
-}
-
-/* Move contents of src object according to move_info to base object.
- * Once the move_info is traversed completely, delete the src object.
- */
-int MemStore::_move_ranges_destroy_src(
-  const coll_t& cid, const ghobject_t& srcoid,
-  const ghobject_t& baseoid,
-  const vector<std::pair<uint64_t, uint64_t> > move_info)
-{
-  dout(10) << __func__ << " " << cid << " "  << srcoid << " -> "
-	   << baseoid << dendl;
-  CollectionRef c = get_collection(cid);
-  if (!c)
-    return -ENOENT;
-
-  ObjectRef oo = c->get_object(srcoid);
-  if (!oo)
-    return -ENOENT;
-  ObjectRef no = c->get_or_create_object(baseoid);
-
-  for (unsigned i = 0; i < move_info.size(); ++i) {
-    uint64_t off = move_info[i].first;
-    uint64_t len = move_info[i].second;
-    if (off >= oo->get_size())
-      return 0;
-    if (off + len >= oo->get_size())
-      len = oo->get_size() - off;
-    const ssize_t old_size = no->get_size();
-    no->clone(oo.get(), off, len, off);
-    used_bytes += (no->get_size() - old_size);
-  }
-
-  // delete the src object
-  _remove(cid, srcoid);
-  return 0;
 }
 
 int MemStore::_omap_clear(const coll_t& cid, const ghobject_t &oid)

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -216,9 +216,6 @@ private:
   int _clone_range(const coll_t& cid, const ghobject_t& oldoid,
 		   const ghobject_t& newoid,
 		   uint64_t srcoff, uint64_t len, uint64_t dstoff);
-  int _move_ranges_destroy_src(const coll_t& cid, const ghobject_t& oldoid,
-			       const ghobject_t& newoid,
-			       const vector<pair<uint64_t, uint64_t> > move_info);
   int _omap_clear(const coll_t& cid, const ghobject_t &oid);
   int _omap_setkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& aset_bl);
   int _omap_rmkeys(const coll_t& cid, const ghobject_t &oid, bufferlist& keys_bl);

--- a/src/test/objectstore/DeterministicOpSequence.h
+++ b/src/test/objectstore/DeterministicOpSequence.h
@@ -39,13 +39,12 @@ class DeterministicOpSequence : public TestObjectStoreState {
     DSOP_CLONE = 2,
     DSOP_CLONE_RANGE = 3,
     DSOP_OBJ_REMOVE = 4,
-    DSOP_COLL_MOVE = 5,
-    DSOP_SET_ATTRS = 6,
-    DSOP_COLL_CREATE = 7,
-    DSOP_MERGE_DELETE = 8,
+    DSOP_COLL_MOVE = 6,
+    DSOP_SET_ATTRS = 7,
+    DSOP_COLL_CREATE = 8,
 
     DSOP_FIRST = DSOP_TOUCH,
-    DSOP_LAST = DSOP_MERGE_DELETE,
+    DSOP_LAST = DSOP_COLL_CREATE,
   };
 
   int32_t txn;
@@ -67,7 +66,6 @@ class DeterministicOpSequence : public TestObjectStoreState {
   bool do_coll_move(rngen_t& gen);
   bool do_set_attrs(rngen_t& gen);
   bool do_coll_create(rngen_t& gen);
-  bool do_move_ranges_delete_srcobj(rngen_t& gen);
 
   virtual void _do_touch(coll_t coll, hobject_t& obj);
   virtual void _do_remove(coll_t coll, hobject_t& obj);
@@ -82,10 +80,6 @@ class DeterministicOpSequence : public TestObjectStoreState {
   virtual void _do_write_and_clone_range(coll_t coll, hobject_t& orig_obj,
       hobject_t& new_obj, uint64_t srcoff, uint64_t srclen,
       uint64_t dstoff, bufferlist& bl);
-  virtual void _do_write_and_merge_delete(
-    coll_t coll, hobject_t& orig_obj,
-    hobject_t& new_obj, vector<std::pair<uint64_t, uint64_t>> move_info,
-    bufferlist& bl);
   virtual void _do_coll_move(coll_t orig_coll, coll_t new_coll, hobject_t& obj);
   virtual void _do_coll_create(coll_t cid, uint32_t pg_num, uint64_t num_objs);
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2833,71 +2833,6 @@ TEST_P(StoreTest, SimpleCloneTest) {
   }
 }
 
-TEST_P(StoreTest, SimpleMoveRangeDelSrcTest) {
-  ObjectStore::Sequencer osr("test");
-  int r;
-  coll_t cid;
-  {
-    ObjectStore::Transaction t;
-    t.create_collection(cid, 0);
-    cerr << "Creating collection " << cid << std::endl;
-    r = apply_transaction(store, &osr, std::move(t));
-    ASSERT_EQ(r, 0);
-  }
-
-  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
-  hoid.hobj.pool = -1;
-  ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
-  hoid2.hobj.pool = -1;
-
-  bufferlist small, newdata;
-  small.append("small");
-  {
-    ObjectStore::Transaction t;
-    t.write(cid, hoid2, 0, 5, small);
-    cerr << "Creating object2 and write bl " << hoid << std::endl;
-    r = apply_transaction(store, &osr, std::move(t));
-    ASSERT_EQ(r, 0);
-  }
-  {
-    ObjectStore::Transaction t;
-    t.write(cid, hoid2, 10, 5, small);
-    cerr << "Writing object2 again " << hoid << std::endl;
-    r = apply_transaction(store, &osr, std::move(t));
-    ASSERT_EQ(r, 0);
-
-  }
-  {
-    vector<std::pair<uint64_t, uint64_t>> move_info = {
-      make_pair(0, 5),
-      make_pair(10, 5)
-    };
-
-    ObjectStore::Transaction t;
-    t.move_ranges_destroy_src(cid, hoid2, hoid, move_info);
-    cerr << "move temp object" << std::endl;
-    r = apply_transaction(store, &osr, std::move(t));
-    ASSERT_EQ(r, 0);
-
-    r = store->read(cid, hoid, 0, 5, newdata);
-    ASSERT_EQ(r, 5);
-    ASSERT_TRUE(newdata.contents_equal(small));
-
-    r = store->read(cid, hoid, 10, 5, newdata);
-    ASSERT_EQ(r, 5);
-    ASSERT_TRUE(newdata.contents_equal(small));
-
-  }
-  {
-    ObjectStore::Transaction t;
-    t.remove(cid, hoid);
-    t.remove_collection(cid);
-    cerr << "Cleaning" << std::endl;
-    r = apply_transaction(store, &osr, std::move(t));
-    ASSERT_EQ(r, 0);
-  }
-}
-
 TEST_P(StoreTest, OmapSimple) {
   ObjectStore::Sequencer osr("test");
   int r;
@@ -3764,95 +3699,6 @@ public:
     return status;
   }
 
-  int move_ranges_destroy_src() {
-    Mutex::Locker locker(lock);
-    EnterExit ee("move_ranges_destroy_src");
-    if (!can_unlink())
-      return -ENOENT;
-    if (!can_create())
-      return -ENOSPC;
-    wait_for_ready();
-
-    ghobject_t old_obj;
-    int max = 20;
-    do {
-      old_obj = get_uniform_random_object();
-    } while (--max && !contents[old_obj].data.length());
-    bufferlist &srcdata = contents[old_obj].data;
-    if (srcdata.length() == 0) {
-      return 0;
-    }
-    available_objects.erase(old_obj);
-    ghobject_t new_obj = get_uniform_random_object();
-    available_objects.erase(new_obj);
-
-    boost::uniform_int<> u1(0, max_object_len - max_write_len);
-    boost::uniform_int<> u2(0, max_write_len);
-    uint64_t off = u1(*rng);
-    uint64_t len = u2(*rng);
-    if (write_alignment) {
-      off = ROUND_UP_TO(off, write_alignment);
-      len = ROUND_UP_TO(len, write_alignment);
-    }
-
-    if (off > srcdata.length() - 1) {
-      off = srcdata.length() - 1;
-    }
-    if (off + len > srcdata.length()) {
-      len = srcdata.length() - off;
-    }
-    if (0)
-      cout << __func__ << " " << off << "~" << len
-	   << " (size " << srcdata.length() << ")" << std::endl;
-
-    ObjectStore::Transaction t;
-    vector<std::pair<uint64_t,uint64_t>> extents;
-    extents.emplace_back(
-      std::pair<uint64_t,uint64_t>(off, len));
-    t.move_ranges_destroy_src(cid, old_obj, new_obj, extents);
-    ++in_flight;
-    in_flight_objects.insert(old_obj);
-
-    bufferlist bl;
-    if (off < srcdata.length()) {
-      if (off + len > srcdata.length()) {
-	bl.substr_of(srcdata, off, srcdata.length() - off);
-      } else {
-	bl.substr_of(srcdata, off, len);
-      }
-    }
-
-    // *copy* the data buffer, since we may modify it later.
-    {
-      bufferlist t;
-      t.append(bl.c_str(), bl.length());
-      t.swap(bl);
-    }
-
-    bufferlist& dstdata = contents[new_obj].data;
-    if (dstdata.length() <= off) {
-      if (bl.length() > 0) {
-        dstdata.append_zero(off - dstdata.length());
-        dstdata.append(bl);
-      }
-    } else {
-      bufferlist value;
-      assert(dstdata.length() > off);
-      dstdata.copy(0, off, value);
-      value.append(bl);
-      if (value.length() < dstdata.length())
-        dstdata.copy(value.length(),
-		     dstdata.length() - value.length(), value);
-      value.swap(dstdata);
-    }
-
-    // remove source
-    contents.erase(old_obj);
-
-    int status = store->queue_transaction(osr, std::move(t), new C_SyntheticOnClone(this, old_obj, new_obj));
-    return status;
-  }
-
   int setattrs() {
     Mutex::Locker locker(lock);
     EnterExit ee("setattrs");
@@ -4320,8 +4166,6 @@ void doSyntheticTest(boost::scoped_ptr<ObjectStore>& store,
       test_obj.write();
     } else if (val > 500) {
       test_obj.clone();
-    } else if (val > 475) {
-      test_obj.move_ranges_destroy_src();
     } else if (val > 450) {
       test_obj.clone_range();
     } else if (val > 300) {

--- a/src/test/objectstore/test_transaction.cc
+++ b/src/test/objectstore/test_transaction.cc
@@ -135,8 +135,6 @@ TEST(Transaction, MoveRangesDelSrcObj)
   t.clone(c, o1, o2);
   bl.append("some other data");
   t.write(c, o2, 1, bl.length(), bl);
-
-  t.move_ranges_destroy_src(c, o1, o2, move_info);
 }
 
 TEST(Transaction, GetNumBytes)


### PR DESCRIPTION
We are going to take a different path (rollback support in ObjectStore
instead of roll-forward via splicing data from a temp object).

Signed-off-by: Sage Weil <sage@redhat.com>