### PR TITLE
mon/OSDMonitor: newly created osd should not be wrongly marked in

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6933,8 +6933,10 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       if (!osdmap.exists(i) &&
 	  pending_inc.new_up_client.count(i) == 0 &&
 	  (pending_inc.new_state.count(i) == 0 ||
-	   (pending_inc.new_state[i] & CEPH_OSD_EXISTS) == 0))
+	   (pending_inc.new_state[i] & CEPH_OSD_EXISTS) == 0)) {
+        pending_inc.new_weight[i] = CEPH_OSD_OUT;
 	goto done;
+      }
     }
 
     // raise max_osd


### PR DESCRIPTION
if we are creating an osd which has the same id as a previously removed `in` osd, we should not mark this newly created osd as `in`, otherwise it would be confusing for user who has set the `noin` flag and then tries to create new osds

steps to reproduce:
```
[root@c49 ~]# ceph osd tree  
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 0.25400 root default                                    
-2 0.25400     host c49                                    
 0 0.12700         osd.0      up  1.00000          1.00000 
 1 0.12700         osd.1      up  1.00000          1.00000 
 2       0 osd.2            down  1.00000          1.00000 
 3       0 osd.3            down        0          1.00000 
 4       0 osd.4            down        0          1.00000 
[root@c49 ~]# 
[root@c49 ~]# ceph osd in 4
marked in osd.4. 
[root@c49 ~]# ceph osd rm 4
removed osd.4
[root@c49 ~]# ceph osd create
4
[root@c49 ~]# ceph osd tree
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 0.25400 root default                                    
-2 0.25400     host c49                                    
 0 0.12700         osd.0      up  1.00000          1.00000 
 1 0.12700         osd.1      up  1.00000          1.00000 
 2       0 osd.2            down  1.00000          1.00000 
 3       0 osd.3            down        0          1.00000 
 4       0 osd.4            down  1.00000          1.00000
```

Signed-off-by: runsisi <runsisi@zte.com.cn>