### PR TITLE
os/bluestore: reap collection after all pending ios done

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4175,8 +4175,6 @@ int BlueStore::umount()
   dout(1) << __func__ << dendl;
 
   _sync();
-  _reap_collections();
-  coll_map.clear();
 
   mempool_thread.shutdown();
 
@@ -4192,6 +4190,8 @@ int BlueStore::umount()
     dout(20) << __func__ << " stopping finisher" << dendl;
     f->stop();
   }
+  _reap_collections();
+  coll_map.clear();
   dout(20) << __func__ << " closing" << dendl;
 
   mounted = false;


### PR DESCRIPTION
Otherwise when umount finish reap and wait for pending io done, the last
pending io may aim to remove collection and make removed_collection not
empty. So the leaked collection ref will result in BlueStore deconstruction
segment failt

Signed-off-by: Haomai Wang <haomai@xsky.com>