### PR TITLE
mon: support for building without leveldb + mon mkfs bug fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,11 +65,6 @@ include_directories(
   ${PROJECT_BINARY_DIR}/src/include
   ${PROJECT_SOURCE_DIR}/src)
 
-if(LEVELDB_PREFIX)
-  include_directories(${LEVELDB_PREFIX}/include)
-  link_directories(${LEVELDB_PREFIX}/lib)
-endif()
-
 if(OFED_PREFIX)
   include_directories(${OFED_PREFIX}/include)
   link_directories(${OFED_PREFIX}/lib)
@@ -240,10 +235,14 @@ option(WITH_KVS "Key value store is here" ON)
 option(WITH_RBD "Remote block storage is here" ON)
 
 option(WITH_LEVELDB "LevelDB is here" ON)
-if(${WITH_LEVELDB})
-find_package(leveldb REQUIRED)
-find_file(HAVE_LEVELDB_FILTER_POLICY leveldb/filter_policy.h PATHS ${LEVELDB_INCLUDE_DIR})
-endif(${WITH_LEVELDB})
+if(WITH_LEVELDB)
+  if(LEVELDB_PREFIX)
+    include_directories(${LEVELDB_PREFIX}/include)
+    link_directories(${LEVELDB_PREFIX}/lib)
+  endif()
+  find_package(leveldb REQUIRED)
+  find_file(HAVE_LEVELDB_FILTER_POLICY leveldb/filter_policy.h PATHS ${LEVELDB_INCLUDE_DIR})
+endif(WITH_LEVELDB)
 
 find_package(atomic_ops REQUIRED)
 message(STATUS "${ATOMIC_OPS_LIBRARIES}")

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -140,7 +140,8 @@ int check_mon_data_empty()
   errno = 0;
   while ((de = ::readdir(dir))) {
     if (string(".") != de->d_name &&
-	string("..") != de->d_name) {
+	string("..") != de->d_name &&
+	string("kv_backend") != de->d_name) {
       code = -ENOTEMPTY;
       break;
     }

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -132,6 +132,9 @@
 /* define if radosgw enabled */
 #cmakedefine WITH_RADOSGW
 
+/* define if leveldb is enabled */
+#cmakedefine WITH_LEVELDB
+
 /* define if radosgw's asio frontend enabled */
 #cmakedefine WITH_RADOSGW_ASIO_FRONTEND
 

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -1,8 +1,12 @@
 set(kv_srcs
   KeyValueDB.cc
-  LevelDBStore.cc
   MemDB.cc
   RocksDBStore.cc)
+
+if (WITH_LEVELDB)
+  list(APPEND kv_srcs LevelDBStore.cc)
+endif (WITH_LEVELDB)
+
 add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -2,7 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "KeyValueDB.h"
+#ifdef WITH_LEVELDB
 #include "LevelDBStore.h"
+#endif
 #include "MemDB.h"
 #ifdef HAVE_LIBROCKSDB
 #include "RocksDBStore.h"
@@ -15,9 +17,11 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
 			       void *p)
 {
+#ifdef WITH_LEVELDB
   if (type == "leveldb") {
     return new LevelDBStore(cct, dir);
   }
+#endif
 #ifdef HAVE_KINETIC
   if (type == "kinetic" &&
       cct->check_experimental_feature_enabled("kinetic")) {
@@ -39,9 +43,11 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 
 int KeyValueDB::test_init(const string& type, const string& dir)
 {
+#ifdef WITH_LEVELDB
   if (type == "leveldb") {
     return LevelDBStore::_test_init(dir);
   }
+#endif
 #ifdef HAVE_KINETIC
   if (type == "kinetic") {
     return KineticStore::_test_init(g_ceph_context);

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -6,7 +6,7 @@ add_executable(get_command_descriptions
 target_link_libraries(get_command_descriptions
   mon
   global
-  leveldb
+  ${LEVELDB_LIBRARIES}
   ${EXTRALIBS}
   ${BLKID_LIBRARIES}
   ${CMAKE_DL_LIBS}


### PR DESCRIPTION
WITH_LEVELDB=OFF is now fully supported and we will not link leveldb anywhere.

Also fixed an issue that prevented mon mkfs from creating a rocksdb store.