### PR TITLE
build/rdma: fix unittest_libcephfs_config link problem under ubuntu

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -809,7 +809,7 @@ add_executable(unittest_libcephfs_config
   libcephfs_config.cc
   )
 add_ceph_unittest(unittest_libcephfs_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_libcephfs_config)
-target_link_libraries(unittest_libcephfs_config cephfs)
+target_link_libraries(unittest_libcephfs_config cephfs ${EXTRALIBS})
 endif(WITH_LIBCEPHFS)
 
 if(WITH_RBD)


### PR DESCRIPTION
Signed-off-by: Haomai Wang <haomai@xsky.com>