### PR TITLE
osd: do not open pgs when the pg is not in pg_map

### DIFF
--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -222,6 +222,7 @@ class OpsFlightSocketHook;
 class HistoricOpsSocketHook;
 class TestOpsSocketHook;
 struct C_CompleteSplits;
+struct C_OpenPGs;
 class LogChannel;
 class CephContext;
 typedef ceph::shared_ptr<ObjectStore::Sequencer> SequencerRef;
@@ -1740,6 +1741,7 @@ private:
   friend class TestOpsSocketHook;
   TestOpsSocketHook *test_ops_hook;
   friend struct C_CompleteSplits;
+  friend struct C_OpenPGs;
 
   // -- op queue --
   enum io_queue {


### PR DESCRIPTION
the pg may be removed before the C_OpenPGs callbacked by finisher

Fixes: http://tracker.ceph.com/issues/17806
Signed-off-by: Xinze Chi <xinze@xsky.com>