### PR TITLE
msg/async: no need to set the new once before binding

### DIFF
--- a/src/msg/SimplePolicyMessenger.h
+++ b/src/msg/SimplePolicyMessenger.h
@@ -31,7 +31,7 @@ private:
 public:
 
   SimplePolicyMessenger(CephContext *cct, entity_name_t name,
-			string mname, uint64_t _nonce)
+			string mname, uint32_t nonce)
     : Messenger(cct, name),
       policy_lock("SimplePolicyMessenger::policy_lock")
     {

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -166,7 +166,6 @@ int Processor::rebind(const set<int>& avoid_ports)
 
   // adjust the nonce; we want our entity_addr_t to be truly unique.
   nonce += 1000000;
-  msgr->my_inst.addr.nonce = nonce;
   ldout(msgr->cct, 10) << __func__ << " new nonce " << nonce << " and inst " << msgr->my_inst << dendl;
 
   ldout(msgr->cct, 10) << __func__ << " will try " << addr << " and avoid ports " << new_avoid << dendl;

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -265,7 +265,7 @@ class C_handle_reap : public EventCallback {
  */
 
 AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
-                               string mname, uint64_t _nonce)
+                               string mname, uint32_t _nonce)
   : SimplePolicyMessenger(cct, name,mname, _nonce),
     dispatch_queue(cct, this, mname),
     lock("AsyncMessenger::lock"),

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -49,7 +49,7 @@ class Processor {
   NetHandler net;
   Worker *worker;
   ServerSocket listen_socket;
-  uint64_t nonce;
+  uint32_t nonce;
   EventCallbackRef listen_handler;
 
   class C_processor_accept;
@@ -84,7 +84,7 @@ public:
    * be a value that will be repeated if the daemon restarts.
    */
   AsyncMessenger(CephContext *cct, entity_name_t name,
-                 string mname, uint64_t _nonce);
+                 string mname, uint32_t nonce);
 
   /**
    * Destroy the AsyncMessenger. Pretty simple since all the work is done
@@ -227,7 +227,7 @@ private:
   Mutex lock;
   // AsyncMessenger stuff
   /// approximately unique ID set by the Constructor for use in entity_addr_t
-  uint64_t nonce;
+  uint32_t nonce;
 
   /// true, specifying we haven't learned our addr; set false when we find it.
   // maybe this should be protected by the lock?

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -39,7 +39,7 @@ static ostream& _prefix(std::ostream *_dout, SimpleMessenger *msgr) {
  */
 
 SimpleMessenger::SimpleMessenger(CephContext *cct, entity_name_t name,
-				 string mname, uint64_t _nonce)
+				 string mname, uint32_t _nonce)
   : SimplePolicyMessenger(cct, name,mname, _nonce),
     accepter(this, _nonce),
     dispatch_queue(cct, this, mname),

--- a/src/msg/simple/SimpleMessenger.h
+++ b/src/msg/simple/SimpleMessenger.h
@@ -82,7 +82,7 @@ public:
    * features The local features bits for the local_connection
    */
   SimpleMessenger(CephContext *cct, entity_name_t name,
-		  string mname, uint64_t _nonce);
+		  string mname, uint32_t nonce);
 
   /**
    * Destroy the SimpleMessenger. Pretty simple since all the work is done
@@ -262,7 +262,7 @@ private:
 
   // SimpleMessenger stuff
   /// approximately unique ID set by the Constructor for use in entity_addr_t
-  uint64_t nonce;
+  uint32_t nonce;
   /// overall lock used for SimpleMessenger data structures
   Mutex lock;
   /// true, specifying we haven't learned our addr; set false when we find it.


### PR DESCRIPTION
and Processor::bind() will set the new addr to myaddr once it binds
the new listening address.

Fixes: http://tracker.ceph.com/issues/17807
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>
Signed-off-by: Kefu Chai <kchai@redhat.com>