### PR TITLE
hammer: rgw: fix crash when client posts object with null condition

### DIFF
--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -286,11 +286,13 @@ int RGWPolicy::from_json(bufferlist& bl, string& err_msg)
       int r = add_condition(v[0], v[1], v[2], err_msg);
       if (r < 0)
         return r;
-    } else {
+    } else if (!citer.end()) {
       JSONObj *c = *citer;
       dout(0) << "adding simple_check: " << c->get_name() << " : " << c->get_data() << dendl;
 
       add_simple_check(c->get_name(), c->get_data());
+    } else {
+      return -EINVAL;
     }
   }
   return 0;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17631