### PR TITLE
os/bluestore: reap ioc when stopping aio_thread.

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -287,6 +287,7 @@ void KernelDevice::_aio_thread()
       }
     }
   }
+  reap_ioc();
   dout(10) << __func__ << " end" << dendl;
 }
 


### PR DESCRIPTION
there is possibillity that reap_ioc don't excute when stopping
aio_thread. so add reap_ioc after aio_thread is stopped.

Signed-off-by: Haodong Tang <haodong.tang@intel.com>