### PR TITLE
mds: ignore 'session evict' when mds is replaying log

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -800,11 +800,9 @@ int MDSDaemon::_handle_command(
     int64_t session_id = 0;
     bool got = cmd_getval(cct, cmdmap, "session_id", session_id);
     assert(got);
-    const bool killed = mds_rank->kill_session(session_id);
-    if (!killed) {
+    bool killed = mds_rank->kill_session(session_id, false, ss);
+    if (!killed)
       r = -ENOENT;
-      ss << "session '" << session_id << "' not found";
-    }
   } else if (prefix == "heap") {
     if (!ceph_using_tcmalloc()) {
       r = -EOPNOTSUPP;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1698,18 +1698,11 @@ bool MDSRankDispatcher::handle_asok_command(
     assert(got_arg == true);
 
     mds_lock.Lock();
-    Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT,
-                                                            strtol(client_id.c_str(), 0, 10)));
-    if (session) {
-      C_SaferCond on_safe;
-      server->kill_session(session, &on_safe);
-
-      mds_lock.Unlock();
-      on_safe.wait();
-    } else {
-      dout(15) << "session " << session << " not in sessionmap!" << dendl;
-      mds_lock.Unlock();
-    }
+    std::stringstream ss;
+    bool killed = kill_session(strtol(client_id.c_str(), 0, 10), true, ss);
+    if (!killed)
+      dout(15) << ss.str() << dendl;
+    mds_lock.Unlock();
   } else if (command == "scrub_path") {
     string path;
     vector<string> scrubop_vec;
@@ -1783,13 +1776,13 @@ protected:
 public:
   C_MDS_Send_Command_Reply(MDSRank *_mds, MCommand *_m) :
     MDSInternalContext(_mds), m(_m) { m->get(); }
-  void send (int r) {
+  void send (int r, const std::string& out_str) {
     bufferlist bl;
-    MDSDaemon::send_command_reply(m, mds, r, bl, "");
+    MDSDaemon::send_command_reply(m, mds, r, bl, out_str);
     m->put();
   }
   void finish (int r) {
-    send(r);
+    send(r, "");
   }
 };
 
@@ -1800,9 +1793,15 @@ public:
  */
 void MDSRankDispatcher::evict_sessions(const SessionFilter &filter, MCommand *m)
 {
-  std::list<Session*> victims;
   C_MDS_Send_Command_Reply *reply = new C_MDS_Send_Command_Reply(this, m);
 
+  if (is_any_replay()) {
+    reply->send(-EAGAIN, "MDS is replaying log");
+    delete reply;
+    return;
+  }
+
+  std::list<Session*> victims;
   const auto sessions = sessionmap.get_sessions();
   for (const auto p : sessions)  {
     if (!p.first.is_client()) {
@@ -1819,7 +1818,7 @@ void MDSRankDispatcher::evict_sessions(const SessionFilter &filter, MCommand *m)
   dout(20) << __func__ << " matched " << victims.size() << " sessions" << dendl;
 
   if (victims.empty()) {
-    reply->send(0);
+    reply->send(0, "");
     delete reply;
     return;
   }
@@ -2425,16 +2424,29 @@ void MDSRankDispatcher::handle_osd_map()
   objecter->maybe_request_map();
 }
 
-bool MDSRankDispatcher::kill_session(int64_t session_id)
+bool MDSRankDispatcher::kill_session(int64_t session_id, bool wait, std::stringstream& err_ss)
 {
-  Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT, session_id));
-
-  if (session) {
-    server->kill_session(session, NULL);
-    return true;
-  } else {
+  if (is_any_replay()) {
+    err_ss << "MDS is replaying log";
     return false;
   }
+
+  Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT, session_id));
+  if (!session) {
+    err_ss << "session " << session_id << " not in sessionmap!";
+    return false;
+  }
+  if (wait) {
+    C_SaferCond on_safe;
+    server->kill_session(session, &on_safe);
+
+    mds_lock.Unlock();
+    on_safe.wait();
+    mds_lock.Lock();
+  } else {
+    server->kill_session(session, NULL);
+  }
+  return true;
 }
 
 void MDSRank::bcast_mds_map()
@@ -2461,12 +2473,11 @@ bool MDSRankDispatcher::handle_command_legacy(std::vector<std::string> args)
       mdcache->dump_cache();
   }
   else if (args[0] == "session" && args[1] == "kill") {
-    Session *session = sessionmap.get_session(entity_name_t(CEPH_ENTITY_TYPE_CLIENT,
-							    strtol(args[2].c_str(), 0, 10)));
-    if (session)
-      server->kill_session(session, NULL);
-    else
-      dout(15) << "session " << session << " not in sessionmap!" << dendl;
+    std::stringstream ss;
+    bool killed = kill_session(strtol(args[2].c_str(), 0, 10), false, ss);
+    if (!killed)
+      dout(15) << ss.str() << dendl;
+
   } else if (args[0] == "issue_caps") {
     long inum = strtol(args[1].c_str(), 0, 10);
     CInode *in = mdcache->get_inode(inodeno_t(inum));

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -492,7 +492,7 @@ public:
                            Formatter *f, std::ostream& ss);
   void handle_mds_map(MMDSMap *m, MDSMap *oldmap);
   void handle_osd_map();
-  bool kill_session(int64_t session_id);
+  bool kill_session(int64_t session_id, bool wait, std::stringstream& ss);
   void update_log_config();
   bool handle_command_legacy(std::vector<std::string> args);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17801
Signed-off-by: Yan, Zheng <zyan@redhat.com>