### PR TITLE
os/bluestore: RTC programming model has been applied

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1068,6 +1068,7 @@ OPTION(bluestore_debug_randomize_serial_transaction, OPT_INT, 0)
 OPTION(bluestore_inject_wal_apply_delay, OPT_FLOAT, 0)
 OPTION(bluestore_shard_finishers, OPT_BOOL, false)
 OPTION(bluestore_rtc, OPT_BOOL, false)
+OPTION(bluestore_rtc_sync_completions, OPT_BOOL, false)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1067,6 +1067,7 @@ OPTION(bluestore_debug_inject_read_err, OPT_BOOL, false)
 OPTION(bluestore_debug_randomize_serial_transaction, OPT_INT, 0)
 OPTION(bluestore_inject_wal_apply_delay, OPT_FLOAT, 0)
 OPTION(bluestore_shard_finishers, OPT_BOOL, false)
+OPTION(bluestore_rtc, OPT_BOOL, false)
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -64,6 +64,7 @@ class Context {
   virtual void finish(int r) = 0;
 
  public:
+  static const int FLAG_SYNC = 256;
   Context() {}
   virtual ~Context() {}       // we want a virtual destructor!!!
   virtual void complete(int r) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6199,6 +6199,7 @@ void BlueStore::_txc_state_proc(TransContext *txc)
     case TransContext::STATE_PREPARE:
       txc->log_state_latency(logger, l_bluestore_state_prepare_lat);
       if (txc->ioc.has_pending_aios()) {
+	txc->is_pipelined_io = true;
 	txc->state = TransContext::STATE_AIO_WAIT;
 	_txc_aio_submit(txc);
 	return;
@@ -6214,6 +6215,8 @@ void BlueStore::_txc_state_proc(TransContext *txc)
       //assert(txc->osr->qlock.is_locked());  // see _txc_finish_io
       txc->log_state_latency(logger, l_bluestore_state_io_done_lat);
       txc->state = TransContext::STATE_KV_QUEUED;
+      ++txc->osr->kv_finisher_submitting;
+
       for (auto& sb : txc->shared_blobs_written) {
         sb->bc.finish_write(txc->seq);
       }
@@ -6240,10 +6243,18 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	} else {
 	  _txc_finalize_kv(txc, txc->t);
 	  txc->kv_submitted = true;
+	  if (g_conf->bluestore_rtc && !txc->is_pipelined_io &&
+	    txc->osr->kv_finisher_submitting == 1) {
+	    txc->kv_submitted_sync = true;
+	    db->submit_transaction_sync(txc->t);
+	    _txc_state_proc(txc);
+	    return;
+	  }
 	  int r = db->submit_transaction(txc->t);
 	  assert(r == 0);
 	}
       }
+      txc->is_pipelined_io = true;
       {
 	std::lock_guard<std::mutex> l(kv_lock);
 	kv_queue.push_back(txc);
@@ -6316,6 +6327,7 @@ void BlueStore::_txc_finish_io(TransContext *txc)
    * even though aio will complete in any order.
    */
 
+  TransContext *cursor;
   OpSequencer *osr = txc->osr.get();
   std::lock_guard<std::mutex> l(osr->qlock);
   txc->state = TransContext::STATE_IO_DONE;
@@ -6326,6 +6338,7 @@ void BlueStore::_txc_finish_io(TransContext *txc)
     if (p->state < TransContext::STATE_IO_DONE) {
       dout(20) << __func__ << " " << txc << " blocked by " << &*p << " "
 	       << p->get_state_name() << dendl;
+      txc->is_pipelined_io = true;
       return;
     }
     if (p->state > TransContext::STATE_IO_DONE) {
@@ -6334,7 +6347,8 @@ void BlueStore::_txc_finish_io(TransContext *txc)
     }
   }
   do {
-    _txc_state_proc(&*p++);
+    cursor = &*p++;
+    _txc_state_proc(cursor);
   } while (p != osr->q.end() &&
 	   p->state == TransContext::STATE_IO_DONE);
 }
@@ -6443,6 +6457,7 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
     txc->oncommits.pop_front();
   }
 
+  --txc->osr->kv_finisher_submitting;
   throttle_ops.put(txc->ops);
   throttle_bytes.put(txc->bytes);
 }
@@ -6487,41 +6502,45 @@ void BlueStore::_txc_finish(TransContext *txc)
   throttle_wal_bytes.put(txc->bytes);
 
   OpSequencerRef osr = txc->osr;
-  {
-    std::lock_guard<std::mutex> l(osr->qlock);
-    txc->state = TransContext::STATE_DONE;
-  }
+  bool need_qlock = !txc->kv_submitted_sync || txc->wal_txn;
 
-  _osr_reap_done(osr.get());
+  std::unique_lock<std::mutex> l(osr->qlock, std::defer_lock);
+  if (need_qlock)
+    l.lock();
+  txc->state = TransContext::STATE_DONE;
+  if (need_qlock)
+    l.unlock();
+
+  _osr_reap_done(osr.get(), need_qlock);
 }
 
-void BlueStore::_osr_reap_done(OpSequencer *osr)
+void BlueStore::_osr_reap_done(OpSequencer *osr, bool need_qlock)
 {
   CollectionRef c;
-
-  {
-    std::lock_guard<std::mutex> l(osr->qlock);
-    dout(20) << __func__ << " osr " << osr << dendl;
-    while (!osr->q.empty()) {
-      TransContext *txc = &osr->q.front();
-      dout(20) << __func__ << "  txc " << txc << " " << txc->get_state_name()
-	       << dendl;
-      if (txc->state != TransContext::STATE_DONE) {
-        break;
-      }
-
-      if (!c && txc->first_collection) {
-        c = txc->first_collection;
-      }
-
-      osr->q.pop_front();
-      txc->log_state_latency(logger, l_bluestore_state_done_lat);
-      delete txc;
-      osr->qcond.notify_all();
-      if (osr->q.empty())
-        dout(20) << __func__ << " osr " << osr << " q now empty" << dendl;
+  std::unique_lock<std::mutex> l(osr->qlock, std::defer_lock);
+  if (need_qlock)
+    l.lock();
+  dout(20) << __func__ << " osr " << osr << dendl;
+  while (!osr->q.empty()) {
+    TransContext *txc = &osr->q.front();
+    dout(20) << __func__ << "  txc " << txc << " " << txc->get_state_name()
+	     << dendl;
+    if (txc->state != TransContext::STATE_DONE) {
+      break;
     }
+
+    if (!c && txc->first_collection) {
+      c = txc->first_collection;
+    }
+    osr->q.pop_front();
+    txc->log_state_latency(logger, l_bluestore_state_done_lat);
+    delete txc;
+    osr->qcond.notify_all();
+    if (osr->q.empty())
+      dout(20) << __func__ << " osr " << osr << " q now empty" << dendl;
   }
+  if(need_qlock)
+    l.unlock();
 
   if (c) {
     c->trim_cache();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1164,6 +1164,27 @@ public:
   class OpSequencer;
   typedef boost::intrusive_ptr<OpSequencer> OpSequencerRef;
 
+  class BlueStoreContext : public Context {
+    Context *context;
+    std::atomic_int *counter;
+
+    BlueStoreContext(Context *ctx, std::atomic_int *cnt) {
+      context = ctx;
+      counter = cnt;
+      ++(*counter);
+    }
+
+    void finish(int r) override {
+      if (context != NULL)
+	context->complete(r);
+      --(*counter);
+    }
+  public:
+    static BlueStoreContext *create(Context *ctx, std::atomic_int *cnt) {
+      return new BlueStoreContext(ctx, cnt);
+    }
+  };
+
   struct TransContext {
     typedef enum {
       STATE_PREPARE,
@@ -1353,6 +1374,7 @@ public:
     std::atomic_int kv_committing_serially = {0};
 
     std::atomic_int kv_finisher_submitting = {0};
+    std::atomic_int kv_doing_oncommit = {0};
 
     OpSequencer()
 	//set the qlock to PTHREAD_MUTEX_RECURSIVE mode
@@ -1360,6 +1382,13 @@ public:
     }
     ~OpSequencer() {
       assert(q.empty());
+    }
+
+    bool is_finisher_done(void) {
+      if (kv_doing_oncommit == 1) {
+	return true;
+      }
+      return false;
     }
 
     void queue_new(TransContext *txc) {

--- a/src/osd/ReplicatedPG.h
+++ b/src/osd/ReplicatedPG.h
@@ -1235,7 +1235,7 @@ protected:
 
   void _applied_recovered_object(ObjectContextRef obc);
   void _applied_recovered_object_replica();
-  void _committed_pushed_object(epoch_t epoch, eversion_t lc);
+  void _committed_pushed_object(epoch_t epoch, eversion_t lc, int r);
   void recover_got(hobject_t oid, eversion_t v);
 
   // -- copyfrom --

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -80,7 +80,7 @@ class Notify {
   void maybe_complete_notify();
 
   /// Called on Notify timeout
-  void do_timeout();
+  void do_timeout(int r);
 
   Notify(
     ConnectionRef client,


### PR DESCRIPTION
Decouple Block Device I/O from WAL/DB Device I/O
When NVDIMM is used as WAL & DB device, RTC model is better than pipeline model

bluestore_rtc option was added
- ShardedOpWQ calls submit_transaction_sync and queues txc to finishers when WAL is used
- Consistency problem has been solved, using sequencer and its member variables

bluestore_no_finisher option was added
- It must be used with bluestore_rtc option
- Context::NO_PGLOCK constant was added to do context callbacks, without pg lock
- It's desirable to use this option with machine that has small number of cores
- It's desirable to use this option with replication mode


## **Current WAL Path**
  ShardedOpWQ -> kv_sync_thread -> finishers -> Pipe:Writer
   I/O sequence: 
  submit_transaction(NVDIMM) -> **[1]bdev->flush(SSD, bottleneck)** 
  -> submit_transaction_sync(NVDIMM) -> txc_finish_kv(reply)
================= Above Path is the Critical Path of Client ===============
   -> wal_apply(SSD) -> bdev->flush(SSD) -> rm_single_key(NVDIMM) 
   -> submit_transaction_sync(NVDIMM)
======================= End of Transaction ======================
The above **[1] bdev->flush** isn't for the transaction, but for previous transaction
So, it can be bypassed

##  **WAL Path w/ bluestore_rtc on**
  ShardedOpWQ -> finishers -> Pipe:Writer
- I/O sequence: submit_transaction(NVDIMM) ->  
  -> submit_transaction_sync(NVDIMM) -> txc_finish_kv(reply)
================= Above Path is the Critical Path of Client ===============
   -> wal_apply(SSD) -> bdev->flush(SSD) -> rm_single_key(NVDIMM) 
   -> submit_transaction_sync(NVDIMM)
======================= End of Transaction ======================
In the above path, bdev->flush has been removed


##  **WAL Path w/ bluestore_rtc & bluestore_no_finisher on** 
  ShardedOpWQ -> Pipe:Writer
- I/O sequence: submit_transaction(NVDIMM) ->  
  -> submit_transaction_sync(NVDIMM) -> txc_finish_kv(reply)
================= Above Path is the Critical Path of Client ===============
   -> wal_apply(SSD) -> bdev->flush(SSD) -> rm_single_key(NVDIMM) 
   -> submit_transaction_sync(NVDIMM)
======================= End of Transaction ======================
In the above path, finishers wasn't used


Signed-off-by: Taeksang Kim <voidbag@gmail.com>