### PR TITLE
rgw: remove circular reference in RGWAsyncRadosRequest

### DIFF
--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -22,11 +22,9 @@ public:
   RGWAsyncRadosRequest(RGWCoroutine *_caller, RGWAioCompletionNotifier *_cn) : caller(_caller), notifier(_cn), retcode(0),
                                                                                done(false), lock("RGWAsyncRadosRequest::lock") {
     notifier->get();
-    caller->get();
   }
   virtual ~RGWAsyncRadosRequest() {
     notifier->put();
-    caller->put();
   }
 
   void send_request() {


### PR DESCRIPTION
RGWAsyncRadosRequest does not need a reference to its calling coroutine,
it only needs the completion notifier. this eliminates a circular
reference between RGWAsyncRadosRequest and the coroutines that create
them

Fixes: http://tracker.ceph.com/issues/17792
Fixes: http://tracker.ceph.com/issues/17793