### PR TITLE
test/librbd: in test_notify set object-map and fast-diff features by default

### DIFF
--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -205,11 +205,12 @@ CreateRequest<I>::CreateRequest(IoCtx &ioctx, const std::string &image_name,
                    << "id=" << m_image_id << ", "
                    << "size=" << m_size << ", "
                    << "features=" << m_features << ", "
-                   << "order=" << m_order << ", "
+                   << "order=" << (uint64_t)m_order << ", "
                    << "stripe_unit=" << m_stripe_unit << ", "
                    << "stripe_count=" << m_stripe_count << ", "
-                   << "journal_order=" << m_journal_order << ", "
-                   << "journal_splay_width=" << m_journal_splay_width << ", "
+                   << "journal_order=" << (uint64_t)m_journal_order << ", "
+                   << "journal_splay_width="
+                   << (uint64_t)m_journal_splay_width << ", "
                    << "journal_pool=" << m_journal_pool << ", "
                    << "data_pool=" << m_data_pool << dendl;
 }

--- a/src/test/librbd/test_notify.py
+++ b/src/test/librbd/test_notify.py
@@ -43,9 +43,12 @@ def get_features():
     if features is not None:
         features = int(features)
     else:
-        features = int(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_LAYERING)
+        features = int(RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_LAYERING |
+                       RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF)
     assert((features & RBD_FEATURE_EXCLUSIVE_LOCK) != 0)
     assert((features & RBD_FEATURE_LAYERING) != 0)
+    assert((features & RBD_FEATURE_OBJECT_MAP) != 0)
+    assert((features & RBD_FEATURE_FAST_DIFF) != 0)
     return features
 
 def master(ioctx):


### PR DESCRIPTION
The test uses these features and fails if they are not set. Also, check
the features are provided by the user.

Signed-off-by: Mykola Golub <mgolub@mirantis.com>