### PR TITLE
jewel: Missing comma in ceph-create-keys causes concatenation of arguments

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -109,7 +109,7 @@ def get_key(cluster, mon_id):
                 returncode = subprocess.call(
                     args=args_prefix + [
                         'auth',
-                        'get'
+                        'get',
                         'client.admin',
                         ],
                     stdout=f,


### PR DESCRIPTION
http://tracker.ceph.com/issues/17816