### PR TITLE
doc: Update filestore xattr config documentation.

### DIFF
--- a/doc/rados/configuration/filestore-config-ref.rst
+++ b/doc/rados/configuration/filestore-config-ref.rst
@@ -32,7 +32,37 @@ xattrs`` threshold is reached.
 
 ``filestore max inline xattr size``
 
-:Description: The maximimum size of an XATTR stored in the filesystem (i.e., XFS, btrfs, ext4, etc.) per object. Should not be larger than the filesytem can handle.
+:Description: The maximimum size of an XATTR stored in the filesystem (i.e., XFS,
+              btrfs, ext4, etc.) per object. Should not be larger than the
+              filesytem can handle. Default value of 0 means to use the value
+              specific to the underlying filesystem.
+:Type: Unsigned 32-bit Integer
+:Required: No
+:Default: ``0``
+
+
+``filestore max inline xattr size xfs``
+
+:Description: The maximimum size of an XATTR stored in the XFS filesystem.
+              Only used if ``filestore max inline xattr size`` == 0.
+:Type: Unsigned 32-bit Integer
+:Required: No
+:Default: ``65536``
+
+
+``filestore max inline xattr size btrfs``
+
+:Description: The maximimum size of an XATTR stored in the btrfs filesystem.
+              Only used if ``filestore max inline xattr size`` == 0.
+:Type: Unsigned 32-bit Integer
+:Required: No
+:Default: ``2048``
+
+
+``filestore max inline xattr size other``
+
+:Description: The maximimum size of an XATTR stored in other filesystems.
+              Only used if ``filestore max inline xattr size`` == 0.
 :Type: Unsigned 32-bit Integer
 :Required: No
 :Default: ``512``
@@ -40,7 +70,36 @@ xattrs`` threshold is reached.
 
 ``filestore max inline xattrs``
 
-:Description: The maximum number of XATTRs stored in the fileystem per object.
+:Description: The maximum number of XATTRs stored in the filesystem per object.
+              Default value of 0 means to use the value specific to the
+              underlying filesystem.
+:Type: 32-bit Integer
+:Required: No
+:Default: ``0``
+
+
+``filestore max inline xattrs xfs``
+
+:Description: The maximum number of XATTRs stored in the XFS filesystem per object.
+              Only used if ``filestore max inline xattrs`` == 0.
+:Type: 32-bit Integer
+:Required: No
+:Default: ``10``
+
+
+``filestore max inline xattrs btrfs``
+
+:Description: The maximum number of XATTRs stored in the btrfs filesystem per object.
+              Only used if ``filestore max inline xattrs`` == 0.
+:Type: 32-bit Integer
+:Required: No
+:Default: ``10``
+
+
+``filestore max inline xattrs other``
+
+:Description: The maximum number of XATTRs stored in other filesystems per object.
+              Only used if ``filestore max inline xattrs`` == 0.
 :Type: 32-bit Integer
 :Required: No
 :Default: ``2``


### PR DESCRIPTION
Current documentation of filestore xattr settings is not precise enough and does provide incorrect default values in case of xfs or btrfs. This PR clarifies configuration options and default values.

Signed-off-by: Bartłomiej Święcki <bartlomiej.swiecki@corp.ovh.com>