### PR TITLE
ceph-detect-init: FreeBSD introduction of bsdrc

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -21,6 +21,7 @@ from ceph_detect_init import fedora
 from ceph_detect_init import rhel
 from ceph_detect_init import suse
 from ceph_detect_init import gentoo
+from ceph_detect_init import freebsd
 import logging
 import platform
 
@@ -65,6 +66,7 @@ def _get_distro(distro, use_rhceph=False):
         'gentoo': gentoo,
         'funtoo': gentoo,
         'exherbo': gentoo,
+        'freebsd': freebsd,
     }
 
     if distro == 'redhat' and use_rhceph:
@@ -90,11 +92,19 @@ def _normalized_distro_name(distro):
 
 def platform_information():
     """detect platform information from remote host."""
-    linux_distro = platform.linux_distribution(
-        supported_dists=platform._supported_dists + ('alpine',))
-    logging.debug('platform_information: linux_distribution = ' +
-                  str(linux_distro))
-    distro, release, codename = linux_distro
+    if platform.system() == 'Linux' and platform.linux_distribution()[0] != '':
+        linux_distro = platform.linux_distribution(
+            supported_dists=platform._supported_dists + ('alpine',))
+        logging.debug('platform_information: linux_distribution = ' +
+                      str(linux_distro))
+        distro, release, codename = linux_distro
+    elif platform.system() == 'FreeBSD':
+        distro = 'freebsd'
+        release = platform.release()
+        codename = platform.version().split(' ')[3].split(':')[0]
+    else:
+        raise exc.UnsupportedPlatform(platform.system(), '', '')
+
     # this could be an empty string in Debian
     if not codename and 'debian' in distro.lower():
         debian_codenames = {

--- a/src/ceph-detect-init/ceph_detect_init/freebsd/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/freebsd/__init__.py
@@ -1,0 +1,11 @@
+distro = None
+release = None
+codename = None
+
+
+def choose_init():
+    """Select a init system
+
+     Returns the name of a init system (upstart, sysvinit ...).
+     """
+    return 'bsdrc'

--- a/src/ceph-detect-init/run-tox.sh
+++ b/src/ceph-detect-init/run-tox.sh
@@ -17,11 +17,6 @@
 # GNU Library Public License for more details.
 #
 
-if [ x"`uname`"x = xFreeBSDx ]; then
-    echo FreeBSD init system has not been integrated.
-    exit 0
-fi
-
 # run from the ceph-detect-init directory or from its parent
 : ${CEPH_DETECT_INIT_VIRTUALENV:=/tmp/ceph-detect-init-virtualenv}
 test -d ceph-detect-init && cd ceph-detect-init

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -32,6 +32,7 @@ from ceph_detect_init import main
 from ceph_detect_init import rhel
 from ceph_detect_init import suse
 from ceph_detect_init import gentoo
+from ceph_detect_init import freebsd
 
 logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
                     level=logging.DEBUG)
@@ -41,6 +42,9 @@ class TestCephDetectInit(testtools.TestCase):
 
     def test_alpine(self):
         self.assertEqual('openrc', alpine.choose_init())
+
+    def test_freebsd(self):
+        self.assertEqual('bsdrc', freebsd.choose_init())
 
     def test_centos(self):
         with mock.patch('ceph_detect_init.centos.release',
@@ -146,25 +150,45 @@ class TestCephDetectInit(testtools.TestCase):
 
     def test_get(self):
         g = ceph_detect_init.get
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('unknown', '', ''))):
-            self.assertRaises(exc.UnsupportedPlatform, g)
-            try:
-                g()
-            except exc.UnsupportedPlatform as e:
-                self.assertIn('Platform is not supported', str(e))
+        with mock.patch('platform.system', lambda: 'Linux'):
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('unknown', '', ''))):
+                self.assertRaises(exc.UnsupportedPlatform, g)
+                try:
+                    g()
+                except exc.UnsupportedPlatform as e:
+                    self.assertIn('Platform is not supported', str(e))
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '6.0', ''))):
-            distro = ceph_detect_init.get()
-            self.assertEqual(debian, distro)
-            self.assertEqual('debian', distro.name)
-            self.assertEqual('debian', distro.normalized_name)
-            self.assertEqual('debian', distro.distro)
-            self.assertEqual(False, distro.is_el)
-            self.assertEqual('6.0', distro.release)
-            self.assertEqual('squeeze', distro.codename)
-            self.assertEqual('sysvinit', distro.init)
+        with mock.patch('platform.system', lambda: 'Linux'):
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', '6.0', ''))):
+                distro = ceph_detect_init.get()
+                self.assertEqual(debian, distro)
+                self.assertEqual('debian', distro.name)
+                self.assertEqual('debian', distro.normalized_name)
+                self.assertEqual('debian', distro.distro)
+                self.assertEqual(False, distro.is_el)
+                self.assertEqual('6.0', distro.release)
+                self.assertEqual('squeeze', distro.codename)
+                self.assertEqual('sysvinit', distro.init)
+
+        with mock.patch('platform.system', lambda: 'FreeBSD'):
+            with mock.patch.multiple('platform',
+                                     release=lambda: '12.0-CURRENT',
+                                     version=lambda: 'FreeBSD 12 1 r306554M:'):
+                distro = ceph_detect_init.get()
+                self.assertEqual(freebsd, distro)
+                self.assertEqual('freebsd', distro.name)
+                self.assertEqual('freebsd', distro.normalized_name)
+                self.assertEqual('freebsd', distro.distro)
+                self.assertFalse(distro.is_el)
+                self.assertEqual('12.0-CURRENT', distro.release)
+                self.assertEqual('r306554M', distro.codename)
+                self.assertEqual('bsdrc', distro.init)
+
+        with mock.patch('platform.system',
+                        lambda: 'cephix'):
+            self.assertRaises(exc.UnsupportedPlatform, ceph_detect_init.get)
 
     def test_get_distro(self):
         g = ceph_detect_init._get_distro
@@ -206,39 +230,41 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('gentoo', n('exherbo'))
 
     def test_platform_information(self):
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '6.0', ''))):
-            self.assertEqual(('debian', '6.0', 'squeeze'),
-                             ceph_detect_init.platform_information())
+        with mock.patch('platform.system', lambda: 'Linux'):
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', '6.0', ''))):
+                self.assertEqual(('debian', '6.0', 'squeeze'),
+                                 ceph_detect_init.platform_information())
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '7.0', ''))):
-            self.assertEqual(('debian', '7.0', 'wheezy'),
-                             ceph_detect_init.platform_information())
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', '7.0', ''))):
+                self.assertEqual(('debian', '7.0', 'wheezy'),
+                                 ceph_detect_init.platform_information())
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '8.0', ''))):
-            self.assertEqual(('debian', '8.0', 'jessie'),
-                             ceph_detect_init.platform_information())
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', '8.0', ''))):
+                self.assertEqual(('debian', '8.0', 'jessie'),
+                                 ceph_detect_init.platform_information())
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', 'jessie/sid', ''))):
-            self.assertEqual(('debian', 'jessie/sid', 'sid'),
-                             ceph_detect_init.platform_information())
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', 'jessie/sid', ''))):
+                self.assertEqual(('debian', 'jessie/sid', 'sid'),
+                                 ceph_detect_init.platform_information())
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', 'sid/jessie', ''))):
-            self.assertEqual(('debian', 'sid/jessie', 'sid'),
-                             ceph_detect_init.platform_information())
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('debian', 'sid/jessie', ''))):
+                self.assertEqual(('debian', 'sid/jessie', 'sid'),
+                                 ceph_detect_init.platform_information())
 
     def test_run(self):
         argv = ['--use-rhceph', '--verbose']
         self.assertEqual(0, main.run(argv))
 
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('unknown', '', ''))):
-            self.assertRaises(exc.UnsupportedPlatform, main.run, argv)
-            self.assertEqual(0, main.run(argv + ['--default=sysvinit']))
+        with mock.patch('platform.system', lambda: 'Linux'):
+            with mock.patch('platform.linux_distribution',
+                            lambda **kwargs: (('unknown', '', ''))):
+                self.assertRaises(exc.UnsupportedPlatform, main.run, argv)
+                self.assertEqual(0, main.run(argv + ['--default=sysvinit']))
 
 # Local Variables:
 # compile-command: "cd .. ; .tox/py27/bin/py.test tests/test_all.py"


### PR DESCRIPTION
Get detect-init to return bsdrc when running on FreeBSD.

distro is freebsd
release is 12.0-RELEASE (or something of that nature)
codename is the actual svn commit value

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>