### PR TITLE
crush: remove the crush_lock

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1365,9 +1365,6 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
     ::decode(bucket->items[j], blp);
   }
 
-  bucket->perm = (__u32*)calloc(1, bucket->size * sizeof(__u32));
-  bucket->perm_n = 0;
-
   switch (bucket->alg) {
   case CRUSH_BUCKET_UNIFORM:
     ::decode((reinterpret_cast<crush_bucket_uniform*>(bucket))->item_weight, blp);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1090,11 +1090,10 @@ public:
 	       const vector<__u32>& weight) const {
     Mutex::Locker l(mapper_lock);
     int rawout[maxout];
-    int scratch[maxout * 3];
-    char work[crush->working_size];
+    char work[crush_work_size(crush, maxout)];
     crush_init_workspace(crush, work);
     int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0],
-			       weight.size(), work, scratch);
+			       weight.size(), work);
     if (numrep < 0)
       numrep = 0;
     out.resize(numrep);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1091,23 +1091,25 @@ public:
     Mutex::Locker l(mapper_lock);
     int rawout[maxout];
     int scratch[maxout * 3];
-    int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0], weight.size(), scratch);
+    char work[crush->working_size];
+    crush_init_workspace(crush, work);
+    int numrep = crush_do_rule(crush, rule, x, rawout, maxout, &weight[0],
+			       weight.size(), work, scratch);
     if (numrep < 0)
       numrep = 0;
     out.resize(numrep);
     for (int i=0; i<numrep; i++)
       out[i] = rawout[i];
   }
-  
+
   bool check_crush_rule(int ruleset, int type, int size,  ostream& ss) {
-   
-    assert(crush);    
+    assert(crush);
 
     __u32 i;
     for (i = 0; i < crush->max_rules; i++) {
       if (crush->rules[i] &&
-          crush->rules[i]->mask.ruleset == ruleset &&
-          crush->rules[i]->mask.type == type) {
+	  crush->rules[i]->mask.ruleset == ruleset &&
+	  crush->rules[i]->mask.type == type) {
 
         if (crush->rules[i]->mask.min_size <= size &&
             crush->rules[i]->mask.max_size >= size) {

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -50,7 +50,6 @@ inline static void decode(crush_rule_step &s, bufferlist::iterator &p)
 
 using namespace std;
 class CrushWrapper {
-  mutable Mutex mapper_lock;
 public:
   std::map<int32_t, string> type_map; /* bucket/device type names */
   std::map<int32_t, string> name_map; /* bucket/device names */
@@ -78,8 +77,7 @@ public:
   CrushWrapper(const CrushWrapper& other);
   const CrushWrapper& operator=(const CrushWrapper& other);
 
-  CrushWrapper() : mapper_lock("CrushWrapper::mapper_lock"),
-		   crush(0), have_rmaps(false) {
+  CrushWrapper() : crush(0), have_rmaps(false) {
     create();
   }
   ~CrushWrapper() {
@@ -1088,7 +1086,6 @@ public:
 
   void do_rule(int rule, int x, vector<int>& out, int maxout,
 	       const vector<__u32>& weight) const {
-    Mutex::Locker l(mapper_lock);
     int rawout[maxout];
     char work[crush_work_size(crush, maxout)];
     crush_init_workspace(crush, work);

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -45,6 +45,13 @@ void crush_finalize(struct crush_map *map)
 	int b;
 	__u32 i;
 
+	/* Calculate the needed working space while we do other
+	   finalization tasks. */
+	map->working_size = sizeof(struct crush_work);
+	/* Space for the array of pointers to per-bucket workspace */
+	map->working_size += map->max_buckets *
+		sizeof(struct crush_work_bucket *);
+
 	/* calc max_devices */
 	map->max_devices = 0;
 	for (b=0; b<map->max_buckets; b++) {
@@ -53,10 +60,18 @@ void crush_finalize(struct crush_map *map)
 		for (i=0; i<map->buckets[b]->size; i++)
 			if (map->buckets[b]->items[i] >= map->max_devices)
 				map->max_devices = map->buckets[b]->items[i] + 1;
+
+		switch (map->buckets[b]->alg) {
+		default:
+			/* The base case, permutation variables and
+			   the pointer to the permutation array. */
+			map->working_size += sizeof(struct crush_work_bucket);
+			break;
+		}
+		/* Every bucket has a permutation array. */
+		map->working_size += map->buckets[b]->size * sizeof(__u32);
 	}
 }
-
-
 
 
 
@@ -212,16 +227,11 @@ crush_make_uniform_bucket(int hash, int type, int size,
         if (!bucket->h.items)
                 goto err;
 
-        bucket->h.perm = malloc(sizeof(__u32)*size);
-
-        if (!bucket->h.perm)
-                goto err;
 	for (i=0; i<size; i++)
 		bucket->h.items[i] = items[i];
 
 	return bucket;
 err:
-        free(bucket->h.perm);
         free(bucket->h.items);
         free(bucket);
         return NULL;
@@ -251,9 +261,6 @@ crush_make_list_bucket(int hash, int type, int size,
 	bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)
                 goto err;
-	bucket->h.perm = malloc(sizeof(__u32)*size);
-        if (!bucket->h.perm)
-                goto err;
 
 
         bucket->item_weights = malloc(sizeof(__u32)*size);
@@ -282,7 +289,6 @@ crush_make_list_bucket(int hash, int type, int size,
 err:
         free(bucket->sum_weights);
         free(bucket->item_weights);
-        free(bucket->h.perm);
         free(bucket->h.items);
         free(bucket);
         return NULL;
@@ -347,7 +353,6 @@ crush_make_tree_bucket(int hash, int type, int size,
 
 	if (size == 0) {
 		bucket->h.items = NULL;
-		bucket->h.perm = NULL;
 		bucket->h.weight = 0;
 		bucket->node_weights = NULL;
 		bucket->num_nodes = 0;
@@ -357,9 +362,6 @@ crush_make_tree_bucket(int hash, int type, int size,
 
 	bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)
-                goto err;
-	bucket->h.perm = malloc(sizeof(__u32)*size);
-        if (!bucket->h.perm)
                 goto err;
 
 	/* calc tree depth */
@@ -399,7 +401,6 @@ crush_make_tree_bucket(int hash, int type, int size,
 	return bucket;
 err:
         free(bucket->node_weights);
-        free(bucket->h.perm);
         free(bucket->h.items);
         free(bucket);
         return NULL;
@@ -577,9 +578,6 @@ crush_make_straw_bucket(struct crush_map *map,
         bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)
                 goto err;
-	bucket->h.perm = malloc(sizeof(__u32)*size);
-        if (!bucket->h.perm)
-                goto err;
 	bucket->item_weights = malloc(sizeof(__u32)*size);
         if (!bucket->item_weights)
                 goto err;
@@ -601,7 +599,6 @@ crush_make_straw_bucket(struct crush_map *map,
 err:
         free(bucket->straws);
         free(bucket->item_weights);
-        free(bucket->h.perm);
         free(bucket->h.items);
         free(bucket);
         return NULL;
@@ -630,9 +627,6 @@ crush_make_straw2_bucket(struct crush_map *map,
         bucket->h.items = malloc(sizeof(__s32)*size);
         if (!bucket->h.items)
                 goto err;
-	bucket->h.perm = malloc(sizeof(__u32)*size);
-        if (!bucket->h.perm)
-                goto err;
 	bucket->item_weights = malloc(sizeof(__u32)*size);
         if (!bucket->item_weights)
                 goto err;
@@ -647,7 +641,6 @@ crush_make_straw2_bucket(struct crush_map *map,
 	return bucket;
 err:
         free(bucket->item_weights);
-        free(bucket->h.perm);
         free(bucket->h.items);
         free(bucket);
         return NULL;
@@ -698,11 +691,6 @@ int crush_add_uniform_bucket_item(struct crush_bucket_uniform *bucket, int item,
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 
 	bucket->h.items[newsize-1] = item;
 
@@ -724,11 +712,6 @@ int crush_add_list_bucket_item(struct crush_bucket_list *bucket, int item, int w
 		return -ENOMEM;
 	} else {
 		bucket->h.items = _realloc;
-	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
 	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
@@ -775,17 +758,12 @@ int crush_add_tree_bucket_item(struct crush_bucket_tree *bucket, int item, int w
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 	if ((_realloc = realloc(bucket->node_weights, sizeof(__u32)*bucket->num_nodes)) == NULL) {
 		return -ENOMEM;
 	} else {
 		bucket->node_weights = _realloc;
 	}
-	
+
 	node = crush_calc_tree_node(newsize-1);
 	bucket->node_weights[node] = weight;
 
@@ -824,18 +802,13 @@ int crush_add_straw_bucket_item(struct crush_map *map,
 				int item, int weight)
 {
 	int newsize = bucket->h.size + 1;
-	
+
 	void *_realloc = NULL;
 
 	if ((_realloc = realloc(bucket->h.items, sizeof(__s32)*newsize)) == NULL) {
 		return -ENOMEM;
 	} else {
 		bucket->h.items = _realloc;
-	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
 	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
@@ -873,11 +846,6 @@ int crush_add_straw2_bucket_item(struct crush_map *map,
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
 	} else {
@@ -899,9 +867,6 @@ int crush_add_straw2_bucket_item(struct crush_map *map,
 int crush_bucket_add_item(struct crush_map *map,
 			  struct crush_bucket *b, int item, int weight)
 {
-	/* invalidate perm cache */
-	b->perm_n = 0;
-
 	switch (b->alg) {
 	case CRUSH_BUCKET_UNIFORM:
 		return crush_add_uniform_bucket_item((struct crush_bucket_uniform *)b, item, weight);
@@ -945,11 +910,6 @@ int crush_remove_uniform_bucket_item(struct crush_bucket_uniform *bucket, int it
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 	return 0;
 }
 
@@ -983,11 +943,6 @@ int crush_remove_list_bucket_item(struct crush_bucket_list *bucket, int item)
 		return -ENOMEM;
 	} else {
 		bucket->h.items = _realloc;
-	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
 	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
@@ -1053,11 +1008,6 @@ int crush_remove_tree_bucket_item(struct crush_bucket_tree *bucket, int item)
 		} else {
 			bucket->h.items = _realloc;
 		}
-		if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-			return -ENOMEM;
-		} else {
-			bucket->h.perm = _realloc;
-		}
 
 		olddepth = calc_depth(bucket->h.size);
 		newdepth = calc_depth(newsize);
@@ -1106,11 +1056,6 @@ int crush_remove_straw_bucket_item(struct crush_map *map,
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
 	} else {
@@ -1155,11 +1100,6 @@ int crush_remove_straw2_bucket_item(struct crush_map *map,
 	} else {
 		bucket->h.items = _realloc;
 	}
-	if ((_realloc = realloc(bucket->h.perm, sizeof(__u32)*newsize)) == NULL) {
-		return -ENOMEM;
-	} else {
-		bucket->h.perm = _realloc;
-	}
 	if ((_realloc = realloc(bucket->item_weights, sizeof(__u32)*newsize)) == NULL) {
 		return -ENOMEM;
 	} else {
@@ -1171,9 +1111,6 @@ int crush_remove_straw2_bucket_item(struct crush_map *map,
 
 int crush_bucket_remove_item(struct crush_map *map, struct crush_bucket *b, int item)
 {
-	/* invalidate perm cache */
-	b->perm_n = 0;
-
 	switch (b->alg) {
 	case CRUSH_BUCKET_UNIFORM:
 		return crush_remove_uniform_bucket_item((struct crush_bucket_uniform *)b, item);

--- a/src/crush/crush.c
+++ b/src/crush/crush.c
@@ -45,7 +45,6 @@ int crush_get_bucket_item_weight(const struct crush_bucket *b, int p)
 
 void crush_destroy_bucket_uniform(struct crush_bucket_uniform *b)
 {
-	kfree(b->h.perm);
 	kfree(b->h.items);
 	kfree(b);
 }
@@ -54,14 +53,12 @@ void crush_destroy_bucket_list(struct crush_bucket_list *b)
 {
 	kfree(b->item_weights);
 	kfree(b->sum_weights);
-	kfree(b->h.perm);
 	kfree(b->h.items);
 	kfree(b);
 }
 
 void crush_destroy_bucket_tree(struct crush_bucket_tree *b)
 {
-	kfree(b->h.perm);
 	kfree(b->h.items);
 	kfree(b->node_weights);
 	kfree(b);
@@ -71,7 +68,6 @@ void crush_destroy_bucket_straw(struct crush_bucket_straw *b)
 {
 	kfree(b->straws);
 	kfree(b->item_weights);
-	kfree(b->h.perm);
 	kfree(b->h.items);
 	kfree(b);
 }
@@ -79,7 +75,6 @@ void crush_destroy_bucket_straw(struct crush_bucket_straw *b)
 void crush_destroy_bucket_straw2(struct crush_bucket_straw2 *b)
 {
 	kfree(b->item_weights);
-	kfree(b->h.perm);
 	kfree(b->h.items);
 	kfree(b);
 }

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -135,13 +135,6 @@ struct crush_bucket {
 	__u32 size;      /* num items */
 	__s32 *items;
 
-	/*
-	 * cached random permutation: used for uniform bucket and for
-	 * the linear search fallback for the other bucket types.
-	 */
-	__u32 perm_x;  /* @x for which *perm is defined */
-	__u32 perm_n;  /* num elements of *perm that are permuted/defined */
-	__u32 *perm;
 };
 
 struct crush_bucket_uniform {
@@ -211,6 +204,19 @@ struct crush_map {
 	 * device fails. */
 	__u8 chooseleaf_stable;
 
+	/* This value is calculated after decode or construction by
+	   the builder. It is exposed here (rather than having a
+	   'build CRUSH working space' function) so that callers can
+	   reserve a static buffer, allocate space on the stack, or
+	   otherwise avoid calling into the heap allocator if they
+	   want to. The size of the working space depends on the map,
+	   while the size of the scratch vector passed to the mapper
+	   depends on the size of the desired result set.
+
+	   Nothing stops the caller from allocating both in one swell
+	   foop and passing in two points, though. */
+	size_t working_size;
+
 #ifndef __KERNEL__
 	/*
 	 * version 0 (original) of straw_calc has various flaws.  version 1
@@ -247,5 +253,27 @@ static inline int crush_calc_tree_node(int i)
 {
 	return ((i+1) << 1)-1;
 }
+
+/* ---------------------------------------------------------------------
+			       Private
+   --------------------------------------------------------------------- */
+
+/* These data structures are private to the CRUSH implementation. They
+   are exposed in this header file because builder needs their
+   definitions to calculate the total working size.
+
+   Moving this out of the crush map allow us to treat the CRUSH map as
+   immutable within the mapper and removes the requirement for a CRUSH
+   map lock. */
+
+struct crush_work_bucket {
+	__u32 perm_x; /* @x for which *perm is defined */
+	__u32 perm_n; /* num elements of *perm that are permuted/defined */
+	__u32 *perm;  /* Permutation of the bucket's items */
+};
+
+struct crush_work {
+	struct crush_work_bucket **work; /* Per-bucket working store */
+};
 
 #endif

--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -23,6 +23,7 @@
 # include "hash.h"
 #endif
 #include "crush_ln_table.h"
+#include "mapper.h"
 
 #define dprintk(args...) /* printf(args) */
 
@@ -851,22 +852,21 @@ void crush_init_workspace(const struct crush_map *m, void *v) {
  * @weight: weight vector (for map leaves)
  * @weight_max: size of weight vector
  * @cwin: Pointer to at least map->working_size bytes of memory or NULL.
- * @scratch: scratch vector for private use; must be >= 3 * result_max
  */
 int crush_do_rule(const struct crush_map *map,
 		  int ruleno, int x, int *result, int result_max,
 		  const __u32 *weight, int weight_max,
-		  void *cwin, int *scratch)
+		  void *cwin)
 {
 	int result_len;
 	struct crush_work *cw = cwin;
-	int *a = scratch;
-	int *b = scratch + result_max;
-	int *c = scratch + result_max*2;
+	int *a = (int *)((char *)cw + map->working_size);
+	int *b = a + result_max;
+	int *c = b + result_max;
+	int *w = a;
+	int *o = b;
 	int recurse_to_leaf;
-	int *w;
 	int wsize = 0;
-	int *o;
 	int osize;
 	int *tmp;
 	const struct crush_rule *rule;
@@ -897,9 +897,6 @@ int crush_do_rule(const struct crush_map *map,
 
 	rule = map->rules[ruleno];
 	result_len = 0;
-	w = a;
-	o = b;
-
 
 	for (step = 0; step < rule->len; step++) {
 		int firstn = 0;

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -15,6 +15,8 @@ extern int crush_do_rule(const struct crush_map *map,
 			 int ruleno,
 			 int x, int *result, int result_max,
 			 const __u32 *weights, int weight_max,
-			 int *scratch);
+			 void *cwin, int *scratch);
+
+extern void crush_init_workspace(const struct crush_map *m, void *v);
 
 #endif

--- a/src/crush/mapper.h
+++ b/src/crush/mapper.h
@@ -15,7 +15,17 @@ extern int crush_do_rule(const struct crush_map *map,
 			 int ruleno,
 			 int x, int *result, int result_max,
 			 const __u32 *weights, int weight_max,
-			 void *cwin, int *scratch);
+			 void *cwin);
+
+/* Returns the exact amount of workspace that will need to be used
+   for a given combination of crush_map and result_max. The caller can
+   then allocate this much on its own, either on the stack, in a
+   per-thread long-lived buffer, or however it likes. */
+
+static inline size_t crush_work_size(const struct crush_map *map,
+				     int result_max) {
+	return map->working_size + result_max * 3 * sizeof(__u32);
+}
 
 extern void crush_init_workspace(const struct crush_map *m, void *v);
 

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -68,6 +68,8 @@ CrushWrapper *build_indep_map(CephContext *cct, int num_rack, int num_host,
   assert(ret == 0);
   c->set_rule_name(ruleno, "data");
 
+  c->finalize();
+
   if (false) {
     Formatter *f = Formatter::create("json-pretty");
     f->open_object_section("crush_map");
@@ -291,6 +293,8 @@ TEST(CRUSH, straw_zero) {
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(1, ruleset1);
 
+  c->finalize();
+
   vector<unsigned> reweight(n, 0x10000);
   for (int i=0; i<10000; ++i) {
     vector<int> out0, out1;
@@ -382,6 +386,8 @@ TEST(CRUSH, straw_same) {
     jf.flush(cout);
   }
 
+  c->finalize();
+
   vector<int> sum0(n, 0), sum1(n, 0);
   vector<unsigned> reweight(n, 0x10000);
   int different = 0;
@@ -450,6 +456,8 @@ double calc_straw2_stddev(int *weights, int n, bool verbose)
   }
   totalweight /= (double)0x10000;
   double avgweight = totalweight / n;
+
+  c->finalize();
 
   int total = 1000000;
   for (int i=0; i<total; ++i) {
@@ -590,6 +598,8 @@ TEST(CRUSH, straw2_reweight) {
   }
   totalweight /= (double)0x10000;
   double avgweight = totalweight / n;
+
+  c->finalize();
 
   int total = 1000000;
   for (int i=0; i<total; ++i) {

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -905,6 +905,8 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     }
   }
 
+  c->finalize();
+
   {
     stringstream ss;
     ErasureCodeIsaDefault isa(tcache);

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -307,6 +307,8 @@ TEST(ErasureCodeTest, create_ruleset)
     }
   }
 
+  c->finalize();
+
   {
     stringstream ss;
     ErasureCodeJerasureReedSolomonVandermonde jerasure;

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -130,6 +130,8 @@ TEST(ErasureCodeTest, create_ruleset)
     }
   }
 
+  c->finalize();
+
   ErasureCodeLrc lrc(g_conf->erasure_code_dir);
   EXPECT_EQ(0, lrc.create_ruleset("rule1", *c, &cerr));
 


### PR DESCRIPTION
Do not keep mutable state around in the CRUSH map, move it out into a separate workspace that gets passed in. Making the CRUSH map read-only allows concurrency.