### PR TITLE
  os/filestore: avoid to get the wrong hardlink number.

### DIFF
--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -790,8 +790,9 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
             *hardlink = 0;
           else
             return -errno;
-        }
-	*hardlink = st.st_nlink;
+        } else {
+	  *hardlink = st.st_nlink;
+	}
       }
       return 0;
     }


### PR DESCRIPTION
  Signed-off-by: huangjun <hjwsm1989@gmail.com>