### PR TITLE
os/bluestore: speedup the performance of multi-replication flow by switc…

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6511,13 +6511,13 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
     txc->onreadable_sync = NULL;
   }
   unsigned n = txc->osr->parent->shard_hint.hash_to_shard(m_finisher_num);
-  if (txc->onreadable) {
-    finishers[n]->queue(txc->onreadable);
-    txc->onreadable = NULL;
-  }
   if (txc->oncommit) {
     finishers[n]->queue(txc->oncommit);
     txc->oncommit = NULL;
+  }
+  if (txc->onreadable) {
+    finishers[n]->queue(txc->onreadable);
+    txc->onreadable = NULL;
   }
   while (!txc->oncommits.empty()) {
     auto f = txc->oncommits.front();


### PR DESCRIPTION
…hing the callback order in bluestore.

In Bluestore ack callback and commit callback are queued one by one in the function "BlueStore;:_txc_finish_kv". Therefore, just only one callback is needed to call, in order to improve performance. We do this by switching the callback order in bluestore, and the callback work can be done in sub_op_modify_commit and doesn't need to do it again in sub_op_modify_applied.

Signed-off-by: Pan Liu <pan.liu@istuary.com>