### PR TITLE
mon: move case CEPH_MSG_POOLOP to OSDs group

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3851,6 +3851,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
 
     // OSDs
     case CEPH_MSG_MON_GET_OSDMAP:
+    case CEPH_MSG_POOLOP:
     case MSG_OSD_MARK_ME_DOWN:
     case MSG_OSD_FAILURE:
     case MSG_OSD_BOOT:
@@ -3876,10 +3877,6 @@ void Monitor::dispatch_op(MonOpRequestRef op)
     case MSG_PGSTATS:
     case MSG_GETPOOLSTATS:
       paxos_service[PAXOS_PGMAP]->dispatch(op);
-      break;
-
-    case CEPH_MSG_POOLOP:
-      paxos_service[PAXOS_OSDMAP]->dispatch(op);
       break;
 
     // log


### PR DESCRIPTION
The message CEPH_MSG_POOLOP is processed by class OSDMonitor, it's processed in the same way as other OSD messages in Monitor::dispatch_op(), such as the following messages:
  CEPH_MSG_MON_GET_OSDMAP, MSG_OSD_BOOT, MSG_OSD_ALIVE...

This patch moves case CEPH_MSG_POOLOP to cases of OSDs group.

Signed-off-by: Javeme <javaloveme@gmail.com>