### PR TITLE
jewel: TestLibRBD.DiscardAfterWrite doesn't handle rbd_skip_partial_discard = true

### DIFF
--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -4360,6 +4360,9 @@ TEST_F(TestLibRBD, FlushCacheWithCopyupOnExternalSnapshot) {
 
 TEST_F(TestLibRBD, DiscardAfterWrite)
 {
+  CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
+  REQUIRE(!cct->_conf->rbd_skip_partial_discard);
+
   librados::IoCtx ioctx;
   ASSERT_EQ(0, _rados.ioctx_create(m_pool_name.c_str(), ioctx));
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/17763