### PR TITLE
jewel: rpm: /etc/ceph/rbdmap is packaged with executable access rights

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -700,7 +700,7 @@ make %{?_smp_mflags} check
 make DESTDIR=%{buildroot} install
 find %{buildroot} -type f -name "*.la" -exec rm -f {} ';'
 find %{buildroot} -type f -name "*.a" -exec rm -f {} ';'
-install -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
+install -m 0644 -D src/etc-rbdmap %{buildroot}%{_sysconfdir}/ceph/rbdmap
 %if 0%{?fedora} || 0%{?rhel}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 %endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/17472