### PR TITLE
jewel: rbd-mirror: snap protect of non-layered image results in split-brain

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -951,6 +951,11 @@ int Operations<I>::snap_protect(const char *snap_name) {
     return -EROFS;
   }
 
+  if (!m_image_ctx.test_features(RBD_FEATURE_LAYERING)) {
+    lderr(cct) << "image must support layering" << dendl;
+    return -ENOSYS;
+  }
+
   int r = m_image_ctx.state->refresh_if_required();
   if (r < 0) {
     return r;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17845