### PR TITLE
jewel: rbd-nbd: disallow mapping images >2TB in size

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -4,6 +4,7 @@
 
 POOL=rbd
 IMAGE=testrbdnbd$$
+TOO_LARGE_IMAGE=${IMAGE}_large
 SUDO=sudo
 SIZE=64
 DATA=
@@ -16,6 +17,7 @@ setup()
     DATA=${TEMPDIR}/data
     dd if=/dev/urandom of=${DATA} bs=1M count=${SIZE}
     rbd --dest-pool ${POOL} --no-progress import ${DATA} ${IMAGE}
+    rbd -p ${POOL} create ${TOO_LARGE_IMAGE} --size 3T
 
     if [ `id -u` = 0 ]
     then
@@ -38,6 +40,7 @@ function cleanup()
 	done
 	rbd -p ${POOL} remove ${IMAGE}
     fi
+    rbd -p ${POOL} remove ${TOO_LARGE_IMAGE}
 }
 
 function expect_false()
@@ -60,6 +63,7 @@ then
 fi
 expect_false ${SUDO} rbd-nbd map INVALIDIMAGE
 expect_false ${SUDO} rbd-nbd --device INVALIDDEV map ${IMAGE}
+expect_false ${SUDO} rbd-nbd map ${TOO_LARGE_IMAGE}
 
 # map test using the first unused device
 DEV=`${SUDO} rbd-nbd map ${POOL}/${IMAGE}`

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -582,6 +582,14 @@ static int do_map()
   }
 
   size = info.size;
+
+  if (size > (1UL << 32) * 512) {
+    r = -EFBIG;
+    cerr << "rbd-nbd: image is too large (" << prettybyte_t(size) << ", max is "
+         << prettybyte_t((1UL << 32) * 512) << ")" << std::endl;
+    goto close_nbd;
+  }
+
   r = ioctl(nbd, NBD_SET_SIZE, size);
   if (r < 0) {
     r = -errno;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17844