### PR TITLE
osd: Add config option to disable new scrubs during recovery

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -771,6 +771,7 @@ OPTION(osd_max_push_cost, OPT_U64, 8<<20)  // max size of push message
 OPTION(osd_max_push_objects, OPT_U64, 10)  // max objects in single push op
 OPTION(osd_recovery_forget_lost_objects, OPT_BOOL, false)   // off for now
 OPTION(osd_max_scrubs, OPT_INT, 1)
+OPTION(osd_scrub_during_recovery, OPT_BOOL, true) // Allow new scrubs to start while recovery is active on the OSD
 OPTION(osd_scrub_begin_hour, OPT_INT, 0)
 OPTION(osd_scrub_end_hour, OPT_INT, 24)
 OPTION(osd_scrub_load_threshold, OPT_FLOAT, 0.5)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6576,6 +6576,11 @@ void OSD::sched_scrub()
 	break;
       }
 
+      if (!cct->_conf->osd_scrub_during_recovery && service.is_recovery_active()) {
+        dout(10) << __func__ << "not scheduling scrub of " << scrub.pgid << " due to active recovery ops" << dendl;
+        break;
+      }
+
       PG *pg = _lookup_lock_pg(scrub.pgid);
       if (!pg)
 	continue;
@@ -8550,6 +8555,14 @@ void OSDService::finish_recovery_op(PG *pg, const hobject_t& soid, bool dequeue)
 #endif
 
   _maybe_queue_recovery();
+}
+
+bool OSDService::is_recovery_active()
+{
+  if (recovery_ops_active > 0)
+    return true;
+
+  return false;
 }
 
 // =========================================================

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -944,6 +944,7 @@ private:
 public:
   void start_recovery_op(PG *pg, const hobject_t& soid);
   void finish_recovery_op(PG *pg, const hobject_t& soid, bool dequeue);
+  bool is_recovery_active();
   void release_reserved_pushes(uint64_t pushes) {
     Mutex::Locker l(recovery_lock);
     assert(recovery_ops_reserved >= pushes);


### PR DESCRIPTION
A new config option allows for configuring if the OSD will schedule
a new scrub while recovery is active.

When set to false no new scrubs will be initiated by the OSD while
there are recovery threads active on that OSD.

Fixes: http://tracker.ceph.com/issues/17866
Signed-off-by: Wido den Hollander <wido@42on.com>