### PR TITLE
msg: seed random engine used for ms_type="random"

### DIFF
--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -20,7 +20,8 @@ Messenger *Messenger::create_client_messenger(CephContext *cct, string lname)
 			   lname, nonce, 0);
 }
 
-static std::default_random_engine random_engine;
+static std::random_device seed;
+static std::default_random_engine random_engine(seed());
 static Spinlock random_lock;
 
 Messenger *Messenger::create(CephContext *cct, const string &type,

--- a/src/msg/Messenger.cc
+++ b/src/msg/Messenger.cc
@@ -20,16 +20,16 @@ Messenger *Messenger::create_client_messenger(CephContext *cct, string lname)
 			   lname, nonce, 0);
 }
 
-static std::random_device seed;
-static std::default_random_engine random_engine(seed());
-static Spinlock random_lock;
-
 Messenger *Messenger::create(CephContext *cct, const string &type,
 			     entity_name_t name, string lname,
 			     uint64_t nonce, uint64_t cflags)
 {
   int r = -1;
   if (type == "random") {
+    static std::random_device seed;
+    static std::default_random_engine random_engine(seed());
+    static Spinlock random_lock;
+
     std::lock_guard<Spinlock> lock(random_lock);
     std::uniform_int_distribution<> dis(0, 1);
     r = dis(random_engine);


### PR DESCRIPTION
commit c80eb1b5c01a800242f17ba0d10b778123484b00 converted this logic from `rand_r()` to `std::default_random_engine`, but neglected to seed the engine. this is likely causing unintended behavior in teuthology tests that rely on `ms type = random`

ping @athanatos @liewegas @jdurgin 