### PR TITLE
rgw_file: fix spurious mount entries w/Linux NFS client

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -781,9 +781,12 @@ namespace rgw {
 	       cct->_conf->rgw_nfs_lru_lane_hiwat),
 	uid(_uid), key(_user_id, _key) {
 
+      /* fixup fs_inst */
+      root_fh.state.dev = ++fs_inst;
+
       /* no bucket may be named rgw_fs_inst-(.*) */
       fsid = RGWFileHandle::root_name + "rgw_fs_inst-" +
-	std::to_string(++(fs_inst));
+	std::to_string(fs_inst);
 
       root_fh.init_rootfs(fsid /* bucket */, RGWFileHandle::root_name);
 


### PR DESCRIPTION
This change fixes the initialization of root file handles to have
their correct fs instance.  Previously, the root file handle had
fs_inst-1.  The apparent change in fsid in a subordinate directory
triggers the client's behavior for new filesystem mounts, which
we don't want.

Fixes: http://tracker.ceph.com/issues/17850

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>