### PR TITLE
deb: update python-rgw dependencies to librgw2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -728,7 +728,7 @@ Description: Python 3 libraries for the Ceph librbd library
 Package: python-rgw
 Architecture: linux-any
 Section: python
-Depends: librgw1 (>= ${binary:Version}),
+Depends: librgw2 (>= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
          ${python:Depends}
@@ -745,7 +745,7 @@ Description: Python 2 libraries for the Ceph librgw library
 Package: python3-rgw
 Architecture: linux-any
 Section: python
-Depends: librgw1 (>= ${binary:Version}),
+Depends: librgw2 (>= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
          ${python3:Depends}


### PR DESCRIPTION
From teuthology failures:
```
The following packages have unmet dependencies:
ceph-common : Depends: python-rgw (= 11.0.2-1319-gff1425e-1trusty) but it is not going to be installed
python-ceph : Depends: python-rgw (= 11.0.2-1319-gff1425e-1trusty) but it is not going to be installed
```
It won't install python-rgw because it has a dependency on librgw1, which should instead be librgw2.

Thanks to @dmick for root-causing.