### PR TITLE
mds: remove unused EFragment::OP_ONESHOT

### DIFF
--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -49,8 +49,7 @@ public:
     OP_PREPARE = 1,
     OP_COMMIT = 2,
     OP_ROLLBACK = 3,
-    OP_FINISH = 4, // finish deleting orphan dirfrags
-    OP_ONESHOT = 5,  // (legacy) PREPARE+COMMIT
+    OP_FINISH = 4 // finish deleting orphan dirfrags
   };
   static const char *op_name(int o) {
     switch (o) {

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -2745,8 +2745,7 @@ void EFragment::replay(MDSRank *mds)
   switch (op) {
   case OP_PREPARE:
     mds->mdcache->add_uncommitted_fragment(dirfrag_t(ino, basefrag), bits, orig_frags, _segment, &rollback);
-    // fall-thru
-  case OP_ONESHOT:
+
     if (in)
       mds->mdcache->adjust_dir_fragments(in, basefrag, bits, resultfrags, waiters, true);
     break;
@@ -2798,8 +2797,6 @@ void EFragment::decode(bufferlist::iterator &bl) {
     ::decode(stamp, bl);
   if (struct_v >= 3)
     ::decode(op, bl);
-  else
-    op = OP_ONESHOT;
   ::decode(ino, bl);
   ::decode(basefrag, bl);
   ::decode(bits, bl);


### PR DESCRIPTION
EFragment::decode had a minimum version of 4, and
the only way you could get the ONESHOT value was if
you had a struct_v < 2.

Signed-off-by: John Spray <john.spray@redhat.com>