### PR TITLE
Context: std::move the callback param in FunctionContext's ctor

### DIFF
--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -451,8 +451,8 @@ typedef C_GatherBuilderBase<Context, C_Gather > C_GatherBuilder;
 
 class FunctionContext : public Context {
 public:
-  FunctionContext(const boost::function<void(int)> &callback)
-    : m_callback(callback)
+  FunctionContext(boost::function<void(int)> &&callback)
+    : m_callback(std::move(callback))
   {
   }
 


### PR DESCRIPTION
for better performance.

Signed-off-by: Kefu Chai <kchai@redhat.com>