### PR TITLE
os/bluestore: fix potential memory leak

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -624,7 +624,6 @@ public:
     }
 
     void clear() {
-      extent_map.clear();
       extent_map.clear_and_dispose([&](Extent *e) { delete e; });
       shards.clear();
       inline_bl.clear();


### PR DESCRIPTION
Call to extent_map.clear_and_dispose() will be noop after extent_map.clear()
hence causing memory leak.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>