### PR TITLE
os/filestore/HashIndex: fix list_by_hash_* termination on reaching end

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -1065,7 +1065,7 @@ int HashIndex::list_by_hash_bitwise(
 	}
 	if (cmp_bitwise(j->second, end) >= 0) {
 	  if (next)
-	    *next = ghobject_t::get_max();
+	    *next = j->second;
 	  return 0;
 	}
 	if (!next || cmp_bitwise(j->second, *next) >= 0) {
@@ -1131,7 +1131,7 @@ int HashIndex::list_by_hash_nibblewise(
 	}
 	if (cmp_nibblewise(j->second, end) >= 0) {
 	  if (next)
-	    *next = ghobject_t::get_max();
+	    *next = j->second;
 	  return 0;
 	}
 	if (!next || cmp_nibblewise(j->second, *next) >= 0) {


### PR DESCRIPTION
If we set *next to max, then the caller (a few lines up) doesn't terminate
the loop and will keep trying to list objects in every following hash
dir until it reaches the end of the collection.  In fact, if we have an
end bound we will never to an efficient listing unless we hit the max
first.

For one user, this was causing OSD suicides when scrub ran because it
wasn't able to list all objects before the timeout.  In general, this would
cause scrub to stall a PG for a long time and slow down requests.

Signed-off-by: Sage Weil <sage@redhat.com>