### PR TITLE
cmake: replace civetweb symlink w/file copy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,12 +387,6 @@ option(DEBUG_GATHER "C_Gather debugging is enabled" ON)
 option(HAVE_LIBZFS "LibZFS is enabled" OFF)
 option(ENABLE_COVERAGE "Coverage is enabled" OFF)
 option(PG_DEBUG_REFS "PG Ref debugging is enabled" OFF)
-# we want to include civetweb.h as "civetweb/civetweb.h".  Make it so.
-execute_process(
-COMMAND rm -f "${CMAKE_BINARY_DIR}/src/include/civetweb"
-COMMAND mkdir -p "${CMAKE_BINARY_DIR}/src/include"
-COMMAND ln -s "${CMAKE_SOURCE_DIR}/src/civetweb/include"
-        "${CMAKE_BINARY_DIR}/src/include/civetweb")
 
 option(WITH_TESTS "enable the build of ceph-test package scripts/binaries" ON)
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -100,6 +100,12 @@ target_include_directories(rgw_a PUBLIC
   "../Beast/include"
   ${FCGI_INCLUDE_DIR})
 
+# we want to include civetweb.h as "civetweb/civetweb.h".  Make it so.
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/src/include/civetweb")
+file(COPY
+  "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
+  DESTINATION "${CMAKE_BINARY_DIR}/src/include/civetweb")
+
 target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
   cls_replica_log_client cls_user_client common common_utf8 global


### PR DESCRIPTION
Intended to remove an apparent race.  The two effects are
1. replace top-level command callouts w/file builtins
2. do them in the src/rgw sub-cmake

This is cleaner, and ideally avoids the race.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>