### PR TITLE
rgw: add rgw_compression_type=random for teuthology testing

### DIFF
--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -59,6 +59,24 @@ boost::optional<Compressor::CompressionMode> Compressor::get_comp_mode_type(cons
 
 CompressorRef Compressor::create(CephContext *cct, const std::string &type)
 {
+  // support "random" for teuthology testing
+  if (type == "random") {
+    static std::random_device seed;
+    static std::default_random_engine engine(seed());
+    static Spinlock mutex;
+
+    int alg = COMP_ALG_NONE;
+    std::uniform_int_distribution<> dist(0, COMP_ALG_LAST - 1);
+    {
+      std::lock_guard<Spinlock> lock(mutex);
+      alg = dist(engine);
+    }
+    if (alg == COMP_ALG_NONE) {
+      return nullptr;
+    }
+    return create(cct, alg);
+  }
+
   CompressorRef cs_impl = NULL;
   std::stringstream ss;
   PluginRegistry *reg = cct->get_plugin_registry();

--- a/src/rgw/rgw_compression.h
+++ b/src/rgw/rgw_compression.h
@@ -35,12 +35,13 @@ public:
 class RGWPutObj_Compress : public RGWPutObj_Filter
 {
   CephContext* cct;
-  bool compressed;
+  bool compressed{false};
+  CompressorRef compressor;
   std::vector<compression_block> blocks;
 public:
-  RGWPutObj_Compress(CephContext* cct_, RGWPutObjDataProcessor* next) :  RGWPutObj_Filter(next),
-                                                                         cct(cct_),
-                                                                         compressed(false) {}
+  RGWPutObj_Compress(CephContext* cct_, CompressorRef compressor,
+                     RGWPutObjDataProcessor* next)
+    : RGWPutObj_Filter(next), cct(cct_), compressor(compressor) {}
   virtual ~RGWPutObj_Compress(){}
   virtual int handle_data(bufferlist& bl, off_t ofs, void **phandle, rgw_obj *pobj, bool *again) override;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3086,6 +3086,10 @@ void RGWPutObj::execute()
     cs_info.blocks = move(compressor->get_compression_blocks());
     ::encode(cs_info, tmp);
     attrs[RGW_ATTR_COMPRESSION] = tmp;
+    ldout(s->cct, 20) << "storing " << RGW_ATTR_COMPRESSION
+        << " with type=" << cs_info.compression_type
+        << ", orig_size=" << cs_info.orig_size
+        << ", blocks=" << cs_info.blocks.size() << dendl;
   }
 
   buf_to_hex(m, CEPH_CRYPTO_MD5_DIGESTSIZE, calc_md5);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2808,6 +2808,29 @@ int RGWPutObj::get_data(const off_t fst, const off_t lst, bufferlist& bl)
   return ret;
 }
 
+// special handling for rgw_compression_type = "random" with multipart uploads
+static CompressorRef get_compressor_plugin(const req_state *s)
+{
+  const auto& compression_type = s->cct->_conf->rgw_compression_type;
+  if (compression_type != "random") {
+    return Compressor::create(s->cct, compression_type);
+  }
+
+  bool is_multipart{false};
+  const auto& upload_id = s->info.args.get("uploadId", &is_multipart);
+
+  if (!is_multipart) {
+    return Compressor::create(s->cct, compression_type);
+  }
+
+  // use a hash of the multipart upload id so all parts use the same plugin
+  const auto alg = std::hash<std::string>{}(upload_id) % Compressor::COMP_ALG_LAST;
+  if (alg == Compressor::COMP_ALG_NONE) {
+    return nullptr;
+  }
+  return Compressor::create(s->cct, alg);
+}
+
 void RGWPutObj::execute()
 {
   RGWPutObjProcessor *processor = NULL;
@@ -2824,7 +2847,6 @@ void RGWPutObj::execute()
   
   off_t fst;
   off_t lst;
-  const auto& compression_type = s->cct->_conf->rgw_compression_type;
   CompressorRef plugin;
   boost::optional<RGWPutObj_Compress> compressor;
 
@@ -2911,11 +2933,11 @@ void RGWPutObj::execute()
 
   fst = copy_source_range_fst;
   lst = copy_source_range_lst;
-  if (compression_type != "none") {
-    plugin = Compressor::create(s->cct, compression_type);
+  if (s->cct->_conf->rgw_compression_type != "none") {
+    plugin = get_compressor_plugin(s);
     if (!plugin) {
       ldout(s->cct, 1) << "Cannot load plugin for rgw_compression_type "
-          << compression_type << dendl;
+          << s->cct->_conf->rgw_compression_type << dendl;
     } else {
       compressor = boost::in_place(s->cct, plugin, filter);
       filter = &*compressor;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7070,12 +7070,20 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   }
 
   boost::optional<RGWPutObj_Compress> compressor;
+  CompressorRef plugin;
 
   RGWPutObjDataProcessor *filter = &processor;
-  bool compression_enabled = cct->_conf->rgw_compression_type != "none";
-  if (compression_enabled) {
-    compressor = boost::in_place(cct, filter);
-    filter = &*compressor;
+
+  const auto& compression_type = cct->_conf->rgw_compression_type;
+  if (compression_type != "none") {
+    plugin = Compressor::create(cct, compression_type);
+    if (!plugin) {
+      ldout(cct, 1) << "Cannot load plugin for rgw_compression_type "
+          << compression_type << dendl;
+    } else {
+      compressor = boost::in_place(cct, plugin, filter);
+      filter = &*compressor;
+    }
   }
 
   RGWRadosPutObj cb(cct, filter, &processor, opstate, progress_cb, progress_data);
@@ -7142,10 +7150,10 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 	}
       }
     }
-    if (compression_enabled && compressor->is_compressed()) {
+    if (compressor && compressor->is_compressed()) {
       bufferlist tmp;
       RGWCompressionInfo cs_info;
-      cs_info.compression_type = cct->_conf->rgw_compression_type;
+      cs_info.compression_type = plugin->get_type_name();
       cs_info.orig_size = cb.get_data_len();
       cs_info.blocks = move(compressor->get_compression_blocks());
       ::encode(cs_info, tmp);


### PR DESCRIPTION
adds support for compression type "random" to the `Compressor::create()` factory, similar to the strategy for ms_type=random in the `Messenger::create()` factory

rgw uses this, along with some extra logic to make sure that:
* all buffers in an upload are compressed with the same plugin, and
* all parts of a multipart upload use the same plugin

this will be used in the rgw/verify suite of ceph-qa-suite (see https://github.com/ceph/ceph-qa-suite/pull/977)