### PR TITLE
krbd: kernel client expects ip[:port], not an entity_addr_t

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -125,7 +125,7 @@ static int build_map_buf(CephContext *cct, const char *pool, const char *image,
     if (oss.tellp() > 0) {
       oss << ",";
     }
-    oss << p;
+    oss << p.get_sockaddr();
   }
 
   oss << " name=" << cct->_conf->name.get_id();


### PR DESCRIPTION
Commit 2ee1b9a4084f ("krbd.cc: don't rely on MonMap internal members")
inadvertently dropped .get_sockaddr() call, breaking rbd map.  Fix it.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>