### PR TITLE
os/bluestore: fix compiler warnings

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1776,7 +1776,7 @@ void BlueStore::ExtentMap::reshard(Onode *o, uint64_t min_alloc_size)
 bool BlueStore::ExtentMap::encode_some(uint32_t offset, uint32_t length,
 				       bufferlist& bl, unsigned *pn)
 {
-  Extent dummy(offset);
+  dummy.logical_offset = offset;
   auto start = extent_map.lower_bound(dummy);
   uint32_t end = offset + length;
 
@@ -2066,7 +2066,7 @@ void BlueStore::ExtentMap::dirty_range(
 BlueStore::extent_map_t::iterator BlueStore::ExtentMap::find(
   uint64_t offset)
 {
-  Extent dummy(offset);
+  dummy.logical_offset = offset;
   return extent_map.find(dummy);
 }
 
@@ -2082,7 +2082,7 @@ BlueStore::extent_map_t::iterator BlueStore::ExtentMap::find_lextent(
 BlueStore::extent_map_t::iterator BlueStore::ExtentMap::seek_lextent(
   uint64_t offset)
 {
-  Extent dummy(offset);
+  dummy.logical_offset = offset;
   auto fp = extent_map.lower_bound(dummy);
   if (fp != extent_map.begin()) {
     --fp;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -606,6 +606,7 @@ public:
   struct ExtentMap {
     Onode *onode;
     extent_map_t extent_map;        ///< map of Extents to Blobs
+    Extent dummy;                   ///< dummy extent for lookups
     blob_map_t spanning_blob_map;   ///< blobs that span shards
 
     struct Shard {


### PR DESCRIPTION
As follows:

/home/jenkins-build/build/workspace/ceph-pull-requests/build/boost/include/boost/intrusive/pointer_plus_bits.hpp: In member function ‘bool BlueStore::ExtentMap::encode_some(uint32_t, uint32_t, ceph::bufferlist&, unsigned int*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/build/boost/include/boost/intrusive/pointer_plus_bits.hpp:76:7: warning: ‘dummy’ is used uninitialized in this function [-Wuninitialized]
       n = pointer(uintptr_t(p) | (uintptr_t(n) & Mask));
       ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/os/bluestore/BlueStore.cc:1779:10: note: ‘dummy’ was declared here
   Extent dummy(offset);

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>