### PR TITLE
doc: drop --journal-check from ceph-mds man page

### DIFF
--- a/doc/man/8/ceph-mds.rst
+++ b/doc/man/8/ceph-mds.rst
@@ -9,7 +9,7 @@
 Synopsis
 ========
 
-| **ceph-mds** -i *name* [[ --hot-standby [*rank*] ]|[--journal_check *rank*]]
+| **ceph-mds** -i *name* [ --hot-standby [*rank*] ]
 
 
 Description
@@ -27,11 +27,10 @@ it a logical rank, or put it in a standby pool to take over for
 another daemon that crashes. Some of the specified options can cause
 other behaviors.
 
-If you specify hot-standby or journal-check, you must either specify
-the rank on the command line, or specify one of the
-mds_standby_for_[rank|name] parameters in the config.  The command
-line specification overrides the config, and specifying the rank
-overrides specifying the name.
+If you specify hot-standby, you must either specify the rank on the command
+line, or specify one of the mds_standby_for_[rank|name] parameters in the
+config.  The command line specification overrides the config, and specifying
+the rank overrides specifying the name.
 
 
 Options
@@ -68,10 +67,6 @@ Options
 
    Connect to specified monitor (instead of looking through
    ``ceph.conf``).
-
-.. option:: --journal-check <rank>
-
-    Attempt to replay the journal for MDS <rank>, then exit.
 
 .. option:: --hot-standby <rank>
 


### PR DESCRIPTION
References: http://tracker.ceph.com/issues/17747

Looking at #11739 I noticed that I neglected to clean up the ceph-mds manpage, hence this follow-up PR.