### PR TITLE
jewel: librbd: restore journal access when force disabling mirroring

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -339,6 +339,13 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
                << dendl;
   }
 
+  if (!is_primary) {
+    r = Journal<>::promote(ictx);
+    if (r < 0) {
+      lderr(cct) << "failed to promote image: " << cpp_strerror(r) << dendl;
+    }
+  }
+
   header_oid = ::journal::Journaler::header_oid(ictx->id);
 
   while(true) {


### PR DESCRIPTION
If mirroring is force disabled on a demoted image, the journal was
being left in an inconsistent ownership state.

Fixes: http://tracker.ceph.com/issues/17767
Signed-off-by: Mykola Golub <mgolub@mirantis.com>