### PR TITLE
ceph_volume_client: set an existing auth ID's default mon caps 

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1084,7 +1084,7 @@ class CephFSVolumeClient(object):
                     'caps': [
                         'mds', mds_cap_str,
                         'osd', osd_cap_str,
-                        'mon', cap['caps'].get('mon')]
+                        'mon', cap['caps'].get('mon', 'allow r')]
                 })
             caps = self._rados_command(
                 'auth get',
@@ -1218,7 +1218,7 @@ class CephFSVolumeClient(object):
                         'caps': [
                             'mds', mds_cap_str,
                             'osd', osd_cap_str,
-                            'mon', cap['caps'].get('mon')]
+                            'mon', cap['caps'].get('mon', 'allow r')]
                     })
 
         # FIXME: rados raising Error instead of ObjectNotFound in auth get failure


### PR DESCRIPTION
... as 'allow r' (the minimum mon caps required to access a share)
when:

* authorizing the auth ID to access a volume.

* deauthorizing the auth ID to access a volume, but the auth ID is
  authorized to access other volumes.

In both the above cases, the ceph_volume_client previously tried to
set the mon caps of the auth ID to an invalid value, None.

Fixes: http://tracker.ceph.com/issues/17800