### PR TITLE
os/bluestore: remove build warning in a better way

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1782,7 +1782,7 @@ void BlueStore::ExtentMap::reshard(Onode *o, uint64_t min_alloc_size)
 bool BlueStore::ExtentMap::encode_some(uint32_t offset, uint32_t length,
 				       bufferlist& bl, unsigned *pn)
 {
-  dummy.logical_offset = offset;
+  Extent dummy(offset);
   auto start = extent_map.lower_bound(dummy);
   uint32_t end = offset + length;
 
@@ -2069,7 +2069,7 @@ void BlueStore::ExtentMap::dirty_range(
 BlueStore::extent_map_t::iterator BlueStore::ExtentMap::find(
   uint64_t offset)
 {
-  dummy.logical_offset = offset;
+  Extent dummy(offset);
   return extent_map.find(dummy);
 }
 
@@ -2085,7 +2085,7 @@ BlueStore::extent_map_t::iterator BlueStore::ExtentMap::find_lextent(
 BlueStore::extent_map_t::iterator BlueStore::ExtentMap::seek_lextent(
   uint64_t offset)
 {
-  dummy.logical_offset = offset;
+  Extent dummy(offset);
   auto fp = extent_map.lower_bound(dummy);
   if (fp != extent_map.begin()) {
     --fp;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -557,7 +557,8 @@ public:
   typedef mempool::bluestore_meta_other::map<int,BlobRef> blob_map_t;
 
   /// a logical extent, pointing to (some portion of) a blob
-  struct Extent : public boost::intrusive::set_base_hook<boost::intrusive::optimize_size<true>> {
+  typedef boost::intrusive::set_base_hook<boost::intrusive::optimize_size<true> > ExtentBase; //making an alias to avoid build warnings
+  struct Extent : public ExtentBase {
     MEMPOOL_CLASS_HELPERS();
 
     uint32_t logical_offset = 0;      ///< logical offset
@@ -567,13 +568,14 @@ public:
     BlobRef  blob;                    ///< the blob with our data
 
     /// ctor for lookup only
-    explicit Extent(uint32_t lo) : logical_offset(lo) { }
+    explicit Extent(uint32_t lo) : ExtentBase(), logical_offset(lo) { }
     /// ctor for delayed initialization (see decode_some())
-    explicit Extent() {
+    explicit Extent() : ExtentBase() {
     }
     /// ctor for general usage
     Extent(uint32_t lo, uint32_t o, uint32_t l, uint8_t bd, BlobRef& b)
-      : logical_offset(lo), blob_offset(o), length(l), blob_depth(bd) {
+      : ExtentBase(),
+        logical_offset(lo), blob_offset(o), length(l), blob_depth(bd) {
       assign_blob(b);
     }
     ~Extent() {
@@ -628,7 +630,6 @@ public:
   struct ExtentMap {
     Onode *onode;
     extent_map_t extent_map;        ///< map of Extents to Blobs
-    Extent dummy;                   ///< dummy extent for lookups
     blob_map_t spanning_blob_map;   ///< blobs that span shards
 
     struct Shard {


### PR DESCRIPTION
This is yet another fix for build warning about uninitialized Extent instance. Seems more preferable since it doesn't increase ExtentMap memory footprint.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>