### PR TITLE
qa/workunits/rados/test_envlibrados_for_rocksdb: force librados-dev install

### DIFF
--- a/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
+++ b/qa/workunits/rados/test_envlibrados_for_rocksdb.sh
@@ -12,7 +12,7 @@ function install() {
 function install_one() {
     case $(lsb_release -si) in
         Ubuntu|Debian|Devuan)
-            sudo apt-get install -y "$@"
+            sudo apt-get install -y --force-yes "$@"
             ;;
         CentOS|Fedora|RedHatEnterpriseServer)
             sudo yum install -y "$@"


### PR DESCRIPTION
On trusty we see

 WARNING: The following packages cannot be authenticated!
   librados-dev
 E: There are problems and -y was used without --force-yes

Signed-off-by: Sage Weil <sage@redhat.com>