### PR TITLE
doc: Add documentation about mon_allow_pool_delete before pool remove

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -56,6 +56,11 @@
 OSD: change the prefix from fs_* to os_*, because commit_latency and …
 …apply_latency will be used not only for filestore.
 
+* Monitors will no longer allow pools to be removed by default.
+  The setting mon_allow_pool_delete has to be set to true (defaults to false)
+  before they allow pools to be removed.
+  This is a additional safeguard against pools being removed by accident.
+
 11.0.0
 ------
 

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -175,6 +175,13 @@ To delete a pool, execute::
 
 	ceph osd pool delete {pool-name} [{pool-name} --yes-i-really-really-mean-it]
 
+
+To remove a pool the mon_allow_pool_delete flag must be set to true in the Monitor's
+configuration. Otherwise they will refuse to remove a pool.
+
+See `Monitor Configuration`_ for more information.
+
+.. _Monitor Configuration: ../../configuration/mon-config-ref
 	
 If you created your own rulesets and rules for a pool you created,  you should
 consider removing them when you no longer need your pool::


### PR DESCRIPTION
Tell users they need to set this to true before Monitors will allow
pools to be removed.

Also update the Pending Release Notes so that users can find this change
there.

This was changed with commit 5d7f4ea

Signed-off-by: Wido den Hollander <wido@42on.com>