### PR TITLE
hammer: rbd: export diff should open image as read-only

### DIFF
--- a/src/rbd.cc
+++ b/src/rbd.cc
@@ -3048,7 +3048,7 @@ if (!set_conf_param(v, p1, p2, p3)) { \
        opt_cmd == OPT_STATUS)) {
 
     if (opt_cmd == OPT_INFO || opt_cmd == OPT_SNAP_LIST ||
-	opt_cmd == OPT_EXPORT || opt_cmd == OPT_EXPORT || opt_cmd == OPT_COPY ||
+	opt_cmd == OPT_EXPORT || opt_cmd == OPT_EXPORT_DIFF || opt_cmd == OPT_COPY ||
 	opt_cmd == OPT_CHILDREN || opt_cmd == OPT_LOCK_LIST ||
         opt_cmd == OPT_STATUS || opt_cmd == OPT_WATCH) {
       r = rbd.open_read_only(io_ctx, image, imgname, NULL);


### PR DESCRIPTION
http://tracker.ceph.com/issues/17671