### PR TITLE
log: use one write system call per message

### DIFF
--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -354,9 +354,12 @@ void Log::_flush(EntryQueue *t, EntryQueue *requeue, bool crash)
 void Log::_log_message(const char *s, bool crash)
 {
   if (m_fd >= 0) {
-    int r = safe_write(m_fd, s, strlen(s));
-    if (r >= 0)
-      r = safe_write(m_fd, "\n", 1);
+    size_t len = strlen(s);
+    std::string b;
+    b.reserve(len + 1);
+    b.append(s, len);
+    b += '\n';
+    int r = safe_write(m_fd, b.c_str(), b.size());
     if (r < 0)
       cerr << "problem writing to " << m_log_file << ": " << cpp_strerror(r) << std::endl;
   }


### PR DESCRIPTION
Two separate safe_write calls would result in having two write syscalls
like so:

    25098 write(2, "2016-10-04 11:33:46.357326 7fb025968f00 10 client.4143 did not get mds through better means, so chos"..., 114) = 114
    25098 write(2, "\n", 1)                 = 1
    25098 write(2, "2016-10-04 11:33:46.357333 7fb025968f00 20 client.4143 mds is 0", 63) = 63
    25098 write(2, "\n", 1)                 = 1
    25098 write(2, "2016-10-04 11:33:46.357336 7fb025968f00 10 client.4143 send_request rebuilding request 1 for mds.0", 98) = 98
    25098 write(2, "\n", 1)                 = 1
    25098 write(2, "2016-10-04 11:33:46.357341 7fb025968f00 20 client.4143 encode_cap_releases enter (req: 0x7fb02e7502c"..., 110) = 110
    25098 write(2, "\n", 1)                 = 1

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>