### PR TITLE
librbd: bug fixes for optional data pool support

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2413,6 +2413,7 @@ int librados::Rados::ioctx_create(const char *name, IoCtx &io)
   int ret = rados_ioctx_create((rados_t)client, name, &p);
   if (ret)
     return ret;
+  io.close();
   io.io_ctx_impl = (IoCtxImpl*)p;
   return 0;
 }
@@ -2423,6 +2424,7 @@ int librados::Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
   int ret = rados_ioctx_create2((rados_t)client, pool_id, &p);
   if (ret)
     return ret;
+  io.close();
   io.io_ctx_impl = (IoCtxImpl*)p;
   return 0;
 }

--- a/src/librbd/CopyupRequest.cc
+++ b/src/librbd/CopyupRequest.cc
@@ -146,7 +146,12 @@ bool CopyupRequest::send_copyup() {
     ldout(m_ictx->cct, 20) << __func__ << " " << this << " copyup with "
                            << "empty snapshot context" << dendl;
     librados::AioCompletion *comp = util::create_rados_safe_callback(this);
-    r = m_ictx->md_ctx.aio_operate(m_oid, comp, &copyup_op, 0, snaps);
+
+    librados::Rados rados(m_ictx->data_ctx);
+    r = rados.ioctx_create2(m_ictx->data_ctx.get_id(), m_data_ctx);
+    assert(r == 0);
+
+    r = m_data_ctx.aio_operate(m_oid, comp, &copyup_op, 0, snaps);
     assert(r == 0);
     comp->release();
   }

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -74,6 +74,7 @@ private:
   AsyncOperation m_async_op;
 
   std::vector<uint64_t> m_snap_ids;
+  librados::IoCtx m_data_ctx; // for empty SnapContext
 
   void complete_requests(int r);
 

--- a/src/librbd/operation/ObjectMapIterate.cc
+++ b/src/librbd/operation/ObjectMapIterate.cc
@@ -38,7 +38,7 @@ public:
     m_handle_mismatch(handle_mismatch),
     m_invalidate(invalidate)
   {
-    m_io_ctx.dup(image_ctx->md_ctx);
+    m_io_ctx.dup(image_ctx->data_ctx);
     m_io_ctx.snap_set_read(CEPH_SNAPDIR);
   }
 

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -906,6 +906,8 @@ int Rados::ioctx_create(const char *name, IoCtx &io) {
   if (ret) {
     return ret;
   }
+
+  io.close();
   io.io_ctx_impl = reinterpret_cast<IoCtxImpl*>(p);
   return 0;
 }
@@ -917,6 +919,8 @@ int Rados::ioctx_create2(int64_t pool_id, IoCtx &io)
   if (ret) {
     return ret;
   }
+
+  io.close();
   io.io_ctx_impl = reinterpret_cast<IoCtxImpl*>(p);
   return 0;
 }

--- a/src/test/librbd/test_ObjectMap.cc
+++ b/src/test/librbd/test_ObjectMap.cc
@@ -41,7 +41,7 @@ TEST_F(TestObjectMap, RefreshInvalidatesWhenCorrupt) {
   std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
   bufferlist bl;
   bl.append("corrupt");
-  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, bl));
+  ASSERT_EQ(0, ictx->md_ctx.write_full(oid, bl));
 
   ASSERT_EQ(0, when_open_object_map(ictx));
   ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
@@ -65,7 +65,7 @@ TEST_F(TestObjectMap, RefreshInvalidatesWhenTooSmall) {
   librbd::cls_client::object_map_resize(&op, 0, OBJECT_NONEXISTENT);
 
   std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
-  ASSERT_EQ(0, ictx->data_ctx.operate(oid, &op));
+  ASSERT_EQ(0, ictx->md_ctx.operate(oid, &op));
 
   ASSERT_EQ(0, when_open_object_map(ictx));
   ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
@@ -88,7 +88,7 @@ TEST_F(TestObjectMap, InvalidateFlagOnDisk) {
   std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
   bufferlist bl;
   bl.append("corrupt");
-  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, bl));
+  ASSERT_EQ(0, ictx->md_ctx.write_full(oid, bl));
 
   ASSERT_EQ(0, when_open_object_map(ictx));
   ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
@@ -106,16 +106,16 @@ TEST_F(TestObjectMap, InvalidateFlagInMemoryOnly) {
 
   std::string oid = librbd::ObjectMap::object_map_name(ictx->id, CEPH_NOSNAP);
   bufferlist valid_bl;
-  ASSERT_LT(0, ictx->data_ctx.read(oid, valid_bl, 0, 0));
+  ASSERT_LT(0, ictx->md_ctx.read(oid, valid_bl, 0, 0));
 
   bufferlist corrupt_bl;
   corrupt_bl.append("corrupt");
-  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, corrupt_bl));
+  ASSERT_EQ(0, ictx->md_ctx.write_full(oid, corrupt_bl));
 
   ASSERT_EQ(0, when_open_object_map(ictx));
   ASSERT_TRUE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
 
-  ASSERT_EQ(0, ictx->data_ctx.write_full(oid, valid_bl));
+  ASSERT_EQ(0, ictx->md_ctx.write_full(oid, valid_bl));
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
   ASSERT_FALSE(ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID));
 }

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -20,6 +20,7 @@
 std::string TestFixture::_pool_name;
 librados::Rados TestFixture::_rados;
 uint64_t TestFixture::_image_number = 0;
+std::string TestFixture::_data_pool;
 
 TestFixture::TestFixture() : m_image_size(0) {
 }
@@ -27,9 +28,22 @@ TestFixture::TestFixture() : m_image_size(0) {
 void TestFixture::SetUpTestCase() {
   _pool_name = get_temp_pool_name("test-librbd-");
   ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
+
+  bool created = false;
+  ASSERT_EQ(0, create_image_data_pool(_rados, _data_pool, &created));
+  if (!_data_pool.empty()) {
+    printf("using image data pool: %s\n", _data_pool.c_str());
+    if (!created) {
+      _data_pool.clear();
+    }
+  }
 }
 
 void TestFixture::TearDownTestCase() {
+  if (!_data_pool.empty()) {
+    ASSERT_EQ(0, _rados.pool_delete(_data_pool.c_str()));
+  }
+
   ASSERT_EQ(0, destroy_one_pool_pp(_pool_name, _rados));
 }
 

--- a/src/test/librbd/test_fixture.h
+++ b/src/test/librbd/test_fixture.h
@@ -40,6 +40,7 @@ public:
   static std::string _pool_name;
   static librados::Rados _rados;
   static uint64_t _image_number;
+  static std::string _data_pool;
 
   librados::IoCtx m_ioctx;
   librbd::RBD m_rbd;

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -515,7 +515,7 @@ TEST_F(TestInternal, SnapshotCopyup)
   ASSERT_EQ(256, ictx2->aio_work_queue->write(256, bl.length(), bl.c_str(), 0));
 
   librados::IoCtx snap_ctx;
-  snap_ctx.dup(m_ioctx);
+  snap_ctx.dup(ictx2->data_ctx);
   snap_ctx.snap_set_read(CEPH_SNAPDIR);
 
   librados::snap_set_t snap_set;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -161,6 +161,8 @@ public:
     _image_number = 0;
     ASSERT_EQ("", connect_cluster(&_cluster));
     ASSERT_EQ("", connect_cluster_pp(_rados));
+
+    create_optional_data_pool();
   }
 
   static void TearDownTestCase() {
@@ -195,6 +197,18 @@ public:
   std::string get_temp_image_name() {
     ++_image_number;
     return "image" + stringify(_image_number);
+  }
+
+  static void create_optional_data_pool() {
+    bool created = false;
+    std::string data_pool;
+    ASSERT_EQ(0, create_image_data_pool(_rados, data_pool, &created));
+    if (!data_pool.empty()) {
+      printf("using image data pool: %s\n", data_pool.c_str());
+      if (created) {
+        _unique_pool_names.push_back(data_pool);
+      }
+    }
   }
 
   std::string create_pool(bool unique = false) {

--- a/src/test/librbd/test_support.cc
+++ b/src/test/librbd/test_support.cc
@@ -48,3 +48,21 @@ int get_image_id(librbd::Image &image, std::string *image_id)
   return 0;
 }
 
+int create_image_data_pool(librados::Rados &rados, std::string &data_pool, bool *created) {
+  std::string pool;
+  int r = rados.conf_get("rbd_default_data_pool", pool);
+  if (r != 0) {
+    return r;
+  } else if (pool.empty()) {
+    return 0;
+  }
+
+  r = rados.pool_create(pool.c_str());
+  if ((r == 0) || (r == -EEXIST)) {
+    data_pool = pool;
+    *created = (r == 0);
+    return 0;
+  }
+
+  return r;
+}

--- a/src/test/librbd/test_support.h
+++ b/src/test/librbd/test_support.h
@@ -10,6 +10,7 @@ bool is_feature_enabled(uint64_t feature);
 int create_image_pp(librbd::RBD &rbd, librados::IoCtx &ioctx,
                     const std::string &name, uint64_t size);
 int get_image_id(librbd::Image &image, std::string *image_id);
+int create_image_data_pool(librados::Rados &rados, std::string &data_pool, bool *created);
 
 #define REQUIRE(x) {			  \
   if (!(x)) {				  \

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -133,6 +133,10 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
             rados.conf_set('rbd_default_stripe_count', str(stripe_count or 0))
         if stripe_unit is not None:
             rados.conf_set('rbd_default_stripe_unit', str(stripe_unit or 0))
+        feature_data_pool = 0
+        datapool = rados.conf_get('rbd_default_data_pool')
+        if not len(datapool) == 0:
+            feature_data_pool = 128
         image_name = get_temp_image_name()
         if exception is None:
             RBD().create(ioctx, image_name, IMG_SIZE)
@@ -145,8 +149,12 @@ def check_default_params(format, order=None, features=None, stripe_count=None,
                     eq(expected_order, actual_order)
 
                     expected_features = features
-                    if expected_features is None or format == 1:
-                        expected_features = 0 if format == 1 else 61
+                    if format == 1:
+                        expected_features = 0
+                    elif expected_features is None:
+                        expected_features = 61 | feature_data_pool
+                    else:
+                        expected_features |= feature_data_pool
                     eq(expected_features, image.features())
 
                     expected_stripe_count = stripe_count

--- a/src/test/rbd_mirror/test_ClusterWatcher.cc
+++ b/src/test/rbd_mirror/test_ClusterWatcher.cc
@@ -7,6 +7,7 @@
 #include "librbd/internal.h"
 #include "tools/rbd_mirror/ClusterWatcher.h"
 #include "tools/rbd_mirror/types.h"
+#include "test/rbd_mirror/test_fixture.h"
 #include "test/librados/test.h"
 #include "gtest/gtest.h"
 #include <boost/scope_exit.hpp>
@@ -25,7 +26,7 @@ using std::string;
 void register_test_cluster_watcher() {
 }
 
-class TestClusterWatcher : public ::testing::Test {
+class TestClusterWatcher : public ::rbd::mirror::TestFixture {
 public:
 
   TestClusterWatcher() : m_lock("TestClusterWatcherLock")

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -17,6 +17,7 @@
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "include/stringify.h"
+#include "test/rbd_mirror/test_fixture.h"
 #include "cls/journal/cls_journal_types.h"
 #include "cls/journal/cls_journal_client.h"
 #include "cls/rbd/cls_rbd_types.h"
@@ -48,7 +49,7 @@ void register_test_rbd_mirror() {
 #define TEST_IO_SIZE 512
 #define TEST_IO_COUNT 11
 
-class TestImageReplayer : public ::testing::Test {
+class TestImageReplayer : public ::rbd::mirror::TestFixture {
 public:
   struct C_WatchCtx : public librados::WatchCtx2 {
     TestImageReplayer *test;

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -3,6 +3,7 @@
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "include/stringify.h"
+#include "test/rbd_mirror/test_fixture.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "cls/rbd/cls_rbd_client.h"
 #include "include/rbd_types.h"
@@ -35,7 +36,7 @@ using std::string;
 void register_test_pool_watcher() {
 }
 
-class TestPoolWatcher : public ::testing::Test {
+class TestPoolWatcher : public ::rbd::mirror::TestFixture {
 public:
 
 TestPoolWatcher() : m_lock("TestPoolWatcherLock"),

--- a/src/test/rbd_mirror/test_fixture.h
+++ b/src/test/rbd_mirror/test_fixture.h
@@ -39,6 +39,7 @@ public:
 
   Threads *m_threads = nullptr;
 
+
   int create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
                    const std::string &name, uint64_t size);
   int open_image(librados::IoCtx &io_ctx, const std::string &image_name,
@@ -48,11 +49,13 @@ public:
                   librados::snap_t *snap_id = nullptr);
 
   static std::string get_temp_image_name();
+  static int create_image_data_pool(std::string &data_pool);
 
   static std::string _local_pool_name;
   static std::string _remote_pool_name;
   static std::shared_ptr<librados::Rados> _rados;
   static uint64_t _image_number;
+  static std::string _data_pool;
 };
 
 } // namespace mirror


### PR DESCRIPTION
This PR enables running librbd with an optional data pool. Relevant support was already added a while ago in the form of an additional "--datapool" option while creating RBD images, but there were places in librbd that were not fully functional to fully support using optional data pool. Furthermore, running teuthology tests revealed a bunch of failed tests which this PR aims to resolve.

NOTE: teuthology runs are being scheduled with this PR on top of Sam's ec-partial-overwrite branch.