### PR TITLE
rgw: LCWorker's worktime is not the same as config rgw_lifecycle_work_time.

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -529,7 +529,7 @@ bool RGWLC::LCWorker::should_work(utime_t& now)
   if (cct->_conf->rgw_lc_debug_interval > 0) {
 	  /* We're debugging, so say we can run */
 	  return true;
-  } else if ((bdt.tm_hour*60 + bdt.tm_min >= start_hour*60 + start_minute) ||
+  } else if ((bdt.tm_hour*60 + bdt.tm_min >= start_hour*60 + start_minute) &&
 		     (bdt.tm_hour*60 + bdt.tm_min <= end_hour*60 + end_minute)) {
 	  return true;
   } else {


### PR DESCRIPTION
The judgement in should_work is not correctly. The worktime should between start time and end time.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>