### PR TITLE
ceph-disk: fix flake8 errors

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -204,6 +204,7 @@ class Ptype(object):
                 return True
         return False
 
+
 DEFAULT_FS_TYPE = 'xfs'
 SYSFS = '/sys'
 
@@ -5140,6 +5141,7 @@ def main_catch(func, args):
 
 def run():
     main(sys.argv[1:])
+
 
 if __name__ == '__main__':
     main(sys.argv[1:])


### PR DESCRIPTION
flake8 3.1.1 surfaces the following issues:

```
ceph_disk/main.py:173:1: E305 expected 2 blank lines after class or
function definition, found 1
ceph_disk/main.py:5011:1: E305 expected 2 blank lines after class or
function definition, found 1
```

Fixes: http://tracker.ceph.com/issues/17898

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>