### PR TITLE
rgw:bugfix for deleting objects name beginning and ending with underscores of one bucket using POST method of AWS's js sdk.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5202,7 +5202,8 @@ void RGWDeleteMultiObj::execute()
   for (iter = multi_delete->objects.begin();
         iter != multi_delete->objects.end() && num_processed < max_to_delete;
         ++iter, num_processed++) {
-    rgw_obj obj(bucket, *iter);
+    rgw_obj obj(bucket, (*iter.name));
+    obj.set_instance(s->object.instance);
 
     obj_ctx->set_atomic(obj);
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5202,7 +5202,7 @@ void RGWDeleteMultiObj::execute()
   for (iter = multi_delete->objects.begin();
         iter != multi_delete->objects.end() && num_processed < max_to_delete;
         ++iter, num_processed++) {
-    rgw_obj obj(bucket, (*iter.name));
+    rgw_obj obj(bucket, (*iter).name);
     obj.set_instance(s->object.instance);
 
     obj_ctx->set_atomic(obj);


### PR DESCRIPTION
rgw:bugfix for deleting objects name beginning and ending with underscores of one bucket using POST method of AWS's js sdk.
Fixes: http://tracker.ceph.com/issues/17888