### PR TITLE
doc/man: avoid file builtin to solve build error

### DIFF
--- a/man/conf.py
+++ b/man/conf.py
@@ -9,7 +9,7 @@ exclude_patterns = ['**/.#*', '**/*~']
 
 
 def _get_description(fname, base):
-    with file(fname) as f:
+    with open(fname) as f:
         one = None
         while True:
             line = f.readline().rstrip('\n')


### PR DESCRIPTION
Sphinx running with Python 3.X fails:

    # Sphinx version: 1.4.8
    # Python version: 3.5.2 (CPython)
    # Docutils version: 0.12 release
    # Jinja2 version: 2.8
    # Last messages:

    # Loaded extensions:
    Traceback (most recent call last):
      File "/usr/lib/python3.5/site-packages/sphinx/cmdline.py", line 243, in main
        opts.warningiserror, opts.tags, opts.verbosity, opts.jobs)
      File "/usr/lib/python3.5/site-packages/sphinx/application.py", line 137, in __init__
        confoverrides or {}, self.tags)
      File "/usr/lib/python3.5/site-packages/sphinx/config.py", line 287, in __init__
        execfile_(filename, config)
      File "/usr/lib/python3.5/site-packages/sphinx/util/pycompat.py", line 130, in execfile_
        exec_(code, _globals)
      File "conf.py", line 56, in <module>
      File "conf.py", line 47, in _get_manpages
      File "conf.py", line 12, in _get_description
    NameError: name 'file' is not defined

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>