### PR TITLE
mds: revert "mds/Mutation: remove redundant _dump method"

### DIFF
--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -315,6 +315,11 @@ void MDRequestImpl::print(ostream &out) const
 
 void MDRequestImpl::dump(Formatter *f) const
 {
+  _dump(ceph_clock_now(g_ceph_context), f);
+}
+
+void MDRequestImpl::_dump(utime_t now, Formatter *f) const
+{
   f->dump_string("flag_point", state_string());
   f->dump_stream("reqid") << reqid;
   {

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -333,6 +333,7 @@ struct MDRequestImpl : public MutationImpl, public TrackedOp {
   // TrackedOp stuff
   typedef ceph::shared_ptr<MDRequestImpl> Ref;
 protected:
+  void _dump(utime_t now, Formatter *f) const;
   void _dump_op_descriptor_unlocked(ostream& stream) const;
 };
 


### PR DESCRIPTION
This reverts commit 93d0fc9d937186861b41b054235955475c65b5c1.

This commit had the unintentional side-effect of preventing TrackedOp
dumps from including MDS specific events.

Fixes: http://tracker.ceph.com/issues/17906

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>