### PR TITLE
rgw: skip empty http args in method parse() to avoid extra effort

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -733,7 +733,12 @@ int RGWHTTPArgs::parse()
 {
   int pos = 0;
   bool end = false;
-  if (str[pos] == '?') pos++;
+
+  if (str.empty())
+    return 0;
+
+  if (str[pos] == '?')
+    pos++;
 
   while (!end) {
     int fpos = str.find('&', pos);


### PR DESCRIPTION
This patch can avoid the inoke of method url_decode and RGWHTTPArgs::append for the requests without http args. It will save some time.

Signed-off-by: Guo Zhandong <guozhandong@cmss.chinamobile.com>