### PR TITLE
buffer: add advance(unsigned) back

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -781,20 +781,6 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     return new raw_unshareable(len);
   }
 
-  class dummy_raw : public buffer::raw {
-  public:
-    dummy_raw()
-      : raw(UINT_MAX)
-    {}
-    virtual raw* clone_empty() override {
-      return new dummy_raw();
-    }
-  };
-
-  buffer::raw* buffer::create_dummy() {
-    return new dummy_raw();
-  }
-
   buffer::ptr::ptr(raw *r) : _raw(r), _off(0), _len(r->len)   // no lock needed; this is an unref raw.
   {
     r->nref.inc();

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1082,7 +1082,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     : iterator_impl<is_const>(i.bl, i.off, i.p, i.p_off) {}
 
   template<bool is_const>
-  void buffer::list::iterator_impl<is_const>::advance(ssize_t o)
+  void buffer::list::iterator_impl<is_const>::advance(int o)
   {
     //cout << this << " advance " << o << " from " << off << " (p_off " << p_off << " in " << p->length() << ")" << std::endl;
     if (o > 0) {
@@ -1121,7 +1121,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   }
 
   template<bool is_const>
-  void buffer::list::iterator_impl<is_const>::seek(size_t o)
+  void buffer::list::iterator_impl<is_const>::seek(unsigned o)
   {
     p = ls->begin();
     off = p_off = 0;
@@ -1313,12 +1313,12 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     : iterator_impl(l, o, ip, po)
   {}
 
-  void buffer::list::iterator::advance(ssize_t o)
+  void buffer::list::iterator::advance(int o)
   {
     buffer::list::iterator_impl<false>::advance(o);
   }
 
-  void buffer::list::iterator::seek(size_t o)
+  void buffer::list::iterator::seek(unsigned o)
   {
     buffer::list::iterator_impl<false>::seek(o);
   }

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -390,8 +390,8 @@ namespace buffer CEPH_BUFFER_API {
 	//return off == bl->length();
       }
 
-      void advance(ssize_t o);
-      void seek(size_t o);
+      void advance(int o);
+      void seek(unsigned o);
       char operator*() const;
       iterator_impl& operator++();
       ptr get_current_ptr() const;
@@ -434,8 +434,8 @@ namespace buffer CEPH_BUFFER_API {
       iterator(bl_t *l, unsigned o=0);
       iterator(bl_t *l, unsigned o, list_iter_t ip, unsigned po);
 
-      void advance(ssize_t o);
-      void seek(size_t o);
+      void advance(int o);
+      void seek(unsigned o);
       char operator*();
       iterator& operator++();
       ptr get_current_ptr();

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -155,7 +155,6 @@ namespace buffer CEPH_BUFFER_API {
   raw* create_page_aligned(unsigned len);
   raw* create_zero_copy(unsigned len, int fd, int64_t *offset);
   raw* create_unshareable(unsigned len);
-  raw* create_dummy();
   raw* create_static(unsigned len, char *buf);
   raw* claim_buffer(unsigned len, char *buf, deleter del);
 

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1297,21 +1297,6 @@ TEST(BufferListIterator, copy) {
   }
 }
 
-TEST(BufferListIterator, copy_huge) {
-  constexpr unsigned len = 2268888894U;
-  static_assert(int(len) < 0,
-		"should be a number underflows when being casted to int.");
-  bufferptr ptr(buffer::create_dummy());
-  ptr.set_length(len);
-
-  bufferlist src, dest;
-  src.append(ptr);
-  auto bp = src.begin();
-  bp.copy(len, dest);
-  // contents_equal() is not for this test
-  EXPECT_EQ(len, dest.length());
-}
-
 TEST(BufferListIterator, copy_in) {
   bufferlist bl;
   const char *existing = "XXX";


### PR DESCRIPTION
advance(unsigned) and seek(int) were replaced with advance(size_t> and
seek(ssize_t) in 053bfa6. this change broke the backward compatibility
of librados/librbd's ABI.

- deprecates advance(unsigned) and seek(int)
- update the callers to use the prefered versions.

Fixes: http://tracker.ceph.com/issues/17809
Signed-off-by: Kefu Chai <kchai@redhat.com>