### PR TITLE
ceph-create-keys: Add connection timeouts.

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -103,6 +103,7 @@ def get_key(cluster, mon_id):
 
                 args_prefix = [
                         "ceph",
+                        '--connect-timeout=20',
                         '--cluster={cluster}'.format(cluster=cluster),
                         '--name=mon.',
                         '--keyring=/var/lib/ceph/mon/{cluster}-{mon_id}/keyring'.format(
@@ -175,6 +176,7 @@ def bootstrap_key(cluster, type_):
 
     args = [
         'ceph',
+        '--connect-timeout=20',
         '--cluster={cluster}'.format(cluster=cluster),
         'auth',
         'get-or-create',


### PR DESCRIPTION
ceph commands will hang indefinitely if called without a parameter:

    --connect-timeout

Signed-off-by: Owen Synge <osynge@suse.com>