### PR TITLE
mon,ceph-disk: add lockbox permissions to bootstrap-osd

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1776,6 +1776,13 @@ class Prepare(object):
             default='/etc/ceph/dmcrypt-keys',
             help='directory where dm-crypt keys are stored',
         )
+        parser.add_argument(
+            '--prepare-key',
+            metavar='PATH',
+            help='bootstrap-osd keyring path template (%(default)s)',
+            default='{statedir}/bootstrap-osd/{cluster}.keyring',
+            dest='prepare_key_template',
+        )
         return parser
 
     @staticmethod
@@ -2382,9 +2389,14 @@ class Lockbox(object):
         key_size = CryptHelpers.get_dmcrypt_keysize(self.args)
         key = open('/dev/urandom', 'rb').read(key_size / 8)
         base64_key = base64.b64encode(key)
+        cluster = self.args.cluster
+        bootstrap = self.args.prepare_key_template.format(cluster=cluster,
+                                                          statedir=STATEDIR)
         command_check_call(
             [
                 'ceph',
+                '--name', 'client.bootstrap-osd',
+                '--keyring', bootstrap,
                 'config-key',
                 'put',
                 'dm-crypt/osd/' + self.args.osd_uuid + '/luks',
@@ -2394,6 +2406,8 @@ class Lockbox(object):
         keyring, stderr, ret = command(
             [
                 'ceph',
+                '--name', 'client.bootstrap-osd',
+                '--keyring', bootstrap,
                 'auth',
                 'get-or-create',
                 'client.osd-lockbox.' + self.args.osd_uuid,

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -145,10 +145,16 @@ void MonCapGrant::expand_profile(EntityName name) const
     profile_grants.push_back(MonCapGrant("config-key delete", "key", StringConstraint("", prefix)));
   }
   if (profile == "bootstrap-osd") {
+    string prefix = "dm-crypt/osd";
+    profile_grants.push_back(MonCapGrant("config-key put", "key", StringConstraint("", prefix)));
     profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));  // read monmap
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));  // read osdmap
     profile_grants.push_back(MonCapGrant("mon getmap"));
     profile_grants.push_back(MonCapGrant("osd create"));
+    profile_grants.push_back(MonCapGrant("auth get-or-create"));
+    profile_grants.back().command_args["entity"] = StringConstraint("", "client.");
+    prefix = "allow command \"config-key get\" with key=\"dm-crypt/osd/";
+    profile_grants.back().command_args["caps_mon"] = StringConstraint("", prefix);
     profile_grants.push_back(MonCapGrant("auth add"));
     profile_grants.back().command_args["entity"] = StringConstraint("", "osd.");
     profile_grants.back().command_args["caps_mon"] = StringConstraint("allow profile osd", "");


### PR DESCRIPTION
So that ceph-disk can use it to put the encryption key when initializing
an OSD with --dmcrypt.

Fixes: http://tracker.ceph.com/issues/17849

Signed-off-by: Loic Dachary <loic@dachary.org>