### PR TITLE
common/TrackedOp: remove unused 'now' in _dump()

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -369,7 +369,7 @@ void TrackedOp::dump(utime_t now, Formatter *f) const
   f->dump_float("duration", get_duration());
   {
     f->open_array_section("type_data");
-    _dump(now, f);
+    _dump(f);
     f->close_section();
   }
 }

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -150,7 +150,7 @@ protected:
   { }
 
   /// output any type-specific data you want to get when dump() is called
-  virtual void _dump(utime_t now, Formatter *f) const {}
+  virtual void _dump(Formatter *f) const {}
   /// if you want something else to happen when events are marked, implement
   virtual void _event_marked() {}
   /// return a unique descriptor of the Op; eg the message it's attached to

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -315,10 +315,10 @@ void MDRequestImpl::print(ostream &out) const
 
 void MDRequestImpl::dump(Formatter *f) const
 {
-  _dump(ceph_clock_now(g_ceph_context), f);
+  _dump(f);
 }
 
-void MDRequestImpl::_dump(utime_t now, Formatter *f) const
+void MDRequestImpl::_dump(Formatter *f) const
 {
   f->dump_string("flag_point", state_string());
   f->dump_stream("reqid") << reqid;

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -333,7 +333,7 @@ struct MDRequestImpl : public MutationImpl, public TrackedOp {
   // TrackedOp stuff
   typedef ceph::shared_ptr<MDRequestImpl> Ref;
 protected:
-  void _dump(utime_t now, Formatter *f) const;
+  void _dump(Formatter *f) const;
   void _dump_op_descriptor_unlocked(ostream& stream) const;
 };
 

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -46,7 +46,7 @@ OpRequest::OpRequest(Message *req, OpTracker *tracker) :
   tracker->mark_event(this, "dispatched", request->get_dispatch_stamp());
 }
 
-void OpRequest::_dump(utime_t now, Formatter *f) const
+void OpRequest::_dump(Formatter *f) const
 {
   Message *m = request;
   f->dump_string("flag_point", state_string());

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -99,7 +99,7 @@ struct OpRequest : public TrackedOp {
     return classes_;
   }
 
-  void _dump(utime_t now, Formatter *f) const;
+  void _dump(Formatter *f) const;
 
   bool has_feature(uint64_t f) const {
     return request->get_connection()->has_feature(f);


### PR DESCRIPTION
Greg pointed this out in PR #11985

Signed-off-by: John Spray <john.spray@redhat.com>