### PR TITLE
cmake: produce civetweb.h, again

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -17,6 +17,13 @@ install(TARGETS
   DESTINATION bin)
 endif(WITH_TESTS)
 
+add_custom_target(civetweb_h
+  COMMAND ${CMAKE_COMMAND} -E make_directory
+  "${CMAKE_BINARY_DIR}/src/include/civetweb"
+  COMMAND ${CMAKE_COMMAND} -E copy_if_different
+  "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
+  "${CMAKE_BINARY_DIR}/src/include/civetweb"
+  COMMENT "keep civetweb.h up-to-date")
 
 set(rgw_a_srcs
   rgw_acl.cc
@@ -96,15 +103,11 @@ set(rgw_a_srcs
 
 add_library(rgw_a STATIC ${rgw_a_srcs})
 
+add_dependencies(rgw_a civetweb_h)
+
 target_include_directories(rgw_a PUBLIC
   "../Beast/include"
   ${FCGI_INCLUDE_DIR})
-
-# we want to include civetweb.h as "civetweb/civetweb.h".  Make it so.
-file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/src/include/civetweb")
-file(COPY
-  "${CMAKE_SOURCE_DIR}/src/civetweb/include/civetweb.h"
-  DESTINATION "${CMAKE_BINARY_DIR}/src/include/civetweb")
 
 target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client cls_version_client


### PR DESCRIPTION
The recent change to do this logic with file copy (and in src/rgw)
resolved the build problem, but now updates to the civetweb
submodule were not reflected in the build.

Move the copy into a custom target which will always source the
current submodule version at build time.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>