### PR TITLE
rgw: Fix a bug that multipart upload may exceed the quota. 

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6343,9 +6343,16 @@ int RGWRados::Object::Write::write_meta(uint64_t size, uint64_t accounted_size,
   string index_tag;
   uint64_t epoch;
   int64_t poolid;
-
-  bool orig_exists = state->exists;
-  uint64_t orig_size = state->accounted_size;
+  bool orig_exists;
+  uint64_t orig_size;
+  
+  if (!reset_obj) {    //Multipart upload, it has immutable head. 
+    orig_exists = false;
+    orig_size = 0;
+  } else {
+    orig_exists = state->exists;
+    orig_size = state->accounted_size;
+  }
 
   bool versioned_target = (meta.olh_epoch > 0 || !obj.get_instance().empty());
 


### PR DESCRIPTION
Multipart upload has immutable head. After we have uploaded a part, we invoke write_meta to write the head obj of this part while the head obj actually has been written at the beginning of uploading. The orig_exists is always true and orig_size is the size of the first chunk. But these information is not in quota cache. So we update the quota stats with incorrect data. 

Fixes: http://tracker.ceph.com/issues/19602

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>