### PR TITLE
os/bluestore: avoid unnecessary call to init_csum()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7906,7 +7906,7 @@ int BlueStore::_do_alloc_write(
 	     << " csum_length 0x" << std::hex << csum_length << std::dec
 	     << dendl;
 
-    if (csum) {
+    if (csum != Checksummer::CSUM_NONE) {
       dblob.init_csum(csum, csum_order, csum_length);
       dblob.calc_csum(b_off, *l);
     }


### PR DESCRIPTION
We have to initiate CSumType from 1, which represents CSUM_NONE,
to be aligned with OSDMnitor's pool_opts_t handling.

So we have to explicitly check against CSUM_NONE to skip init_csum(),
which will set FLAG_CSUM and alloc memory for csum_data and thus
shall be avoided whenever it is possible.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>