### PR TITLE
tests: no python3 tests for ceph-disk

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py27,py34,py35,py36
+envlist = flake8,py27
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
2.5.0 published today made it so an environment with no action fails
where it previously did not.

Fixes: http://tracker.ceph.com/issues/17923

Signed-off-by: Loic Dachary <loic@dachary.org>