### PR TITLE
client: remove redundant initialization

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -279,9 +279,6 @@ Client::Client(Messenger *m, MonClient *mc)
   // file handles
   free_fd_set.insert(10, 1<<30);
 
-  // set up messengers
-  messenger = m;
-
   // osd interfaces
   mdsmap.reset(new MDSMap);
   objecter = new Objecter(cct, messenger, monclient, NULL,


### PR DESCRIPTION
messenger is already initialized in the constructor member
initialization list.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>