### PR TITLE
librados: remove unused bufferlist from rados_write_op_rmxattr

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4941,7 +4941,6 @@ extern "C" void rados_write_op_rmxattr(rados_write_op_t write_op,
                                        const char *name)
 {
   tracepoint(librados, rados_write_op_rmxattr_enter, write_op, name);
-  bufferlist bl;
   ((::ObjectOperation *)write_op)->rmxattr(name);
   tracepoint(librados, rados_write_op_rmxattr_exit);
 }


### PR DESCRIPTION
rados_write_op_rmxattr declares the bl bufferlist variable, then doesn't make
any use of it. Get rid of it, as it's probably an effect of copy+paste.

Signed-off-by: Piotr Dałek <git@predictor.org.pl>