### PR TITLE
common: assert(0) -> ceph_abort()

### DIFF
--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -192,7 +192,7 @@ int CephxClientHandler::handle_response(int ret, bufferlist::iterator& indata)
 
   default:
    ldout(cct, 0) << " unknown request_type " << header.request_type << dendl;
-   assert(0);
+   ceph_abort();
   }
   return ret;
 }

--- a/src/auth/cephx/CephxKeyServer.h
+++ b/src/auth/cephx/CephxKeyServer.h
@@ -173,7 +173,7 @@ struct KeyServerData {
       break;
 
     default:
-      assert(0);
+      ceph_abort();
     }
   }
 

--- a/src/auth/unknown/AuthUnknownServiceHandler.h
+++ b/src/auth/unknown/AuthUnknownServiceHandler.h
@@ -30,7 +30,7 @@ public:
     return CEPH_AUTH_UNKNOWN;
   }
   int handle_request(bufferlist::iterator& indata, bufferlist& result_bl, uint64_t& global_id, AuthCapsInfo& caps, uint64_t *auid = NULL) {
-    assert(0);  // shouldn't get called
+    ceph_abort();  // shouldn't get called
     return 0;
   }
   void build_cephx_response_header(int request_type, int status, bufferlist& bl) { }

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -87,7 +87,7 @@ int main(int argc, const char **argv, const char *envp[]) {
       filer_flags |= CEPH_OSD_FLAG_LOCALIZE_READS;
     } else if (ceph_argparse_flag(args, i, "-h", "--help", (char*)NULL)) {
       usage();
-      assert(0);
+      ceph_abort();
     } else {
       ++i;
     }

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2089,7 +2089,7 @@ void Client::handle_client_session(MClientSession *m)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 
   m->put();
@@ -5624,7 +5624,7 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
         wait_on_list(waiting_for_mdsmap);
       } else {
         // Unexpected value!
-        assert(0);
+        ceph_abort();
       }
     }
   }
@@ -7619,7 +7619,7 @@ int Client::readdir_r_cb(dir_result_t *d, add_dirent_cb_t cb, void *p,
     dirp->set_end();
     return 0;
   }
-  assert(0);
+  ceph_abort();
   return 0;
 }
 
@@ -8238,7 +8238,7 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 
   ldout(cct, 3) << "_lseek(" << f << ", " << offset << ", " << whence << ") = " << f->pos << dendl;
@@ -9372,7 +9372,7 @@ int Client::_do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
 	  in->flock_locks = new ceph_lock_state_t(cct, CEPH_LOCK_FLOCK);
 	lock_state = in->flock_locks;
       } else {
-	assert(0);
+	ceph_abort();
 	return -EINVAL;
       }
       _update_lock_state(fl, owner, lock_state);
@@ -9390,7 +9390,7 @@ int Client::_do_filelock(Inode *in, Fh *fh, int lock_type, int op, int sleep,
 	_update_lock_state(fl, owner, lock_state);
       }
     } else
-      assert(0);
+      ceph_abort();
   }
   return ret;
 }
@@ -9405,7 +9405,7 @@ int Client::_interrupt_filelock(MetaRequest *req)
   else if (req->head.args.filelock_change.rule == CEPH_LOCK_FCNTL)
     lock_type = CEPH_LOCK_FCNTL_INTR;
   else {
-    assert(0);
+    ceph_abort();
     return -EINVAL;
   }
 
@@ -9640,7 +9640,7 @@ int Client::test_dentry_handling(bool can_invalidate)
   } else {
     lderr(cct) << "no method to invalidate kernel dentry cache; expect issues!" << dendl;
     if (cct->_conf->client_die_on_failed_remount)
-      assert(0);
+      ceph_abort();
   }
   return r;
 }

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -244,7 +244,7 @@ void parse_syn_options(vector<const char*>& args)
 	syn_sargs.push_back(args[++i]);
       } else {
         cerr << "unknown syn arg " << args[i] << std::endl;
-        assert(0);
+        ceph_abort();
       }
     }
     else if (strcmp(args[i], "localize_reads") == 0) {
@@ -923,7 +923,7 @@ int SyntheticClient::run()
       break;
 
     default:
-      assert(0);
+      ceph_abort();
     }
   }
   dout(1) << "syn done, unmounting " << dendl;
@@ -1511,7 +1511,7 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
 
     else {
       dout(0) << (t.get_line()-1) << ": *** trace hit unrecognized symbol '" << op << "' " << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -2807,7 +2807,7 @@ int SyntheticClient::random_walk(int num_req)
            it != c.end();
            ++it) {
         //dout(DBL) << " got " << *it << dendl;
-	assert(0);
+	ceph_abort();
 	/*contents[*it] = it->second;
         if (it->second &&
 	    S_ISDIR(it->second->st_mode)) 

--- a/src/client/Trace.cc
+++ b/src/client/Trace.cc
@@ -41,7 +41,7 @@ void Trace::start()
   fs->open(filename);
   if (!fs->is_open()) {
     //generic_dout(0) << "** unable to open trace file " << filename << dendl;
-    assert(0);
+    ceph_abort();
   }
   //generic_dout(2) << "opened traced file '" << filename << "'" << dendl;
   

--- a/src/cls/lua/cls_lua.cc
+++ b/src/cls/lua/cls_lua.cc
@@ -246,7 +246,7 @@ static int clslua_opresult(lua_State *L, int ok, int ret, int nargs,
   assert(err);
   if (err->error) {
     CLS_ERR("error: cls_lua state machine: unexpected error");
-    assert(0);
+    ceph_abort();
   }
 
   /* everything is cherry */
@@ -884,7 +884,7 @@ static int clslua_eval(lua_State *L)
     default:
       CLS_ERR("error: unknown encoding type");
       ctx->ret = -EFAULT;
-      assert(0);
+      ceph_abort();
       return 0;
   }
 
@@ -989,7 +989,7 @@ static int eval_generic(cls_method_context_t hctx, bufferlist *in, bufferlist *o
       struct clslua_err *err = clslua_checkerr(L);
       if (!err) {
         CLS_ERR("error: cls_lua state machine: unexpected error");
-        assert(0);
+        ceph_abort();
       }
 
       /* Error origin a cls_cxx_* method? */

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -131,7 +131,7 @@ struct cls_rbd_snap {
       f->dump_string("protection_status", "protected");
       break;
     default:
-      assert(0);
+      ceph_abort();
     }
   }
   static void generate_test_instances(list<cls_rbd_snap*>& o) {

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -588,7 +588,7 @@ process_line(int line_no, const char *line, std::deque<std::string> *errors)
 	  comment += c;
 	break;
       default:
-	assert(0);
+	ceph_abort();
 	break;
     }
     assert(c != '\0'); // We better not go past the end of the input string.

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -54,7 +54,7 @@ int clog_type_to_syslog_level(clog_type t)
     case CLOG_SEC:
       return LOG_CRIT;
     default:
-      assert(0);
+      ceph_abort();
       return 0;
   }
 }
@@ -164,7 +164,7 @@ string clog_type_to_string(clog_type t)
     case CLOG_SEC:
       return "crit";
     default:
-      assert(0);
+      ceph_abort();
       return 0;
   }
 }

--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -309,7 +309,7 @@ inline int SubProcess::spawn() {
     }
 
     exec();
-    assert(0); // Never reached
+    ceph_abort(); // Never reached
   }
 
   ret = -errno;
@@ -391,7 +391,7 @@ inline void SubProcessTimed::exec() {
 
   if (timeout <= 0) {
     SubProcess::exec();
-    assert(0); // Never reached
+    ceph_abort(); // Never reached
   }
 
   sigset_t mask, oldmask;
@@ -440,7 +440,7 @@ inline void SubProcessTimed::exec() {
     }
     (void)setpgid(0, 0); // Become process group leader.
     SubProcess::exec();
-    assert(0); // Never reached
+    ceph_abort(); // Never reached
   }
 
   // Parent

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1890,7 +1890,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
       }
       return (*p)[n];
     }
-    assert(0);
+    ceph_abort();
   }
 
   /*

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1197,7 +1197,7 @@ bool md_config_t::expand_meta(std::string &origval,
 	    out += "$data_dir";
 	  }
 	} else
-	  assert(0); // unreachable
+	  ceph_abort(); // unreachable
 	expanded = true;
       }
 

--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -37,7 +37,7 @@ set<string> hobject_t::get_prefixes(
   else if (bits == 32)
     from.insert(mask);
   else
-    assert(0);
+    ceph_abort();
 
 
   set<uint32_t> to;

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -296,7 +296,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace)
       }
       delete bt;
       *_dout << dendl;
-      assert(0);
+      ceph_abort();
     }
     else if (!(follows[p->first][id/8] & (1 << (id % 8)))) {
       // new dependency
@@ -327,7 +327,7 @@ int lockdep_will_lock(const char *name, int id, bool force_backtrace)
 	// don't add this dependency, or we'll get aMutex. cycle in the graph, and
 	// does_follow() won't terminate.
 
-	assert(0);  // actually, we should just die here.
+	ceph_abort();  // actually, we should just die here.
       } else {
         BackTrace *bt = NULL;
         if (force_backtrace || lockdep_force_backtrace()) {

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -287,7 +287,7 @@ void PerfCounters::tset(int idx, utime_t amt)
     return;
   data.u64.set(amt.to_nsec());
   if (data.type & PERFCOUNTER_LONGRUNAVG)
-    assert(0);
+    ceph_abort();
 }
 
 utime_t PerfCounters::tget(int idx) const
@@ -372,7 +372,7 @@ void PerfCounters::dump_formatted(Formatter *f, bool schema,
 				  a.first / 1000000000ull,
 				  a.first % 1000000000ull);
 	} else {
-	  assert(0);
+	  ceph_abort();
 	}
 	f->close_section();
       } else {
@@ -384,7 +384,7 @@ void PerfCounters::dump_formatted(Formatter *f, bool schema,
 				  v / 1000000000ull,
 				  v % 1000000000ull);
 	} else {
-	  assert(0);
+	  ceph_abort();
 	}
       }
     }

--- a/src/compressor/AsyncCompressor.h
+++ b/src/compressor/AsyncCompressor.h
@@ -63,7 +63,7 @@ class AsyncCompressor {
       return true;
     }
     void _dequeue(Job *item) {
-      assert(0);
+      ceph_abort();
     }
     bool _empty() {
       return job_queue.empty();

--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -482,7 +482,7 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	}
       }
     }
-    else assert(0);
+    else ceph_abort();
   }
 
   // now do the items.
@@ -529,7 +529,7 @@ int CrushCompiler::parse_bucket(iter_t const& i)
 	else if (tag == "pos") 
 	  pos = int_node(sub->children[q]);
 	else
-	  assert(0);
+	  ceph_abort();
 
       }
       if (alg == CRUSH_BUCKET_UNIFORM) {
@@ -616,7 +616,7 @@ int CrushCompiler::parse_rule(iter_t const& i)
   else if (tname == "erasure")
     type = CEPH_PG_TYPE_ERASURE;
   else 
-    assert(0);    
+    ceph_abort();
 
   int minsize = int_node(i->children[start+4]);
   int maxsize = int_node(i->children[start+6]);
@@ -703,14 +703,14 @@ int CrushCompiler::parse_rule(iter_t const& i)
 	    crush.set_rule_step_choose_firstn(ruleno, step++, int_node(s->children[2]), type_id[type]);
 	  else if (mode == "indep")
 	    crush.set_rule_step_choose_indep(ruleno, step++, int_node(s->children[2]), type_id[type]);
-	  else assert(0);
+	  else ceph_abort();
 	} else if (choose == "chooseleaf") {
 	  if (mode == "firstn") 
 	    crush.set_rule_step_choose_leaf_firstn(ruleno, step++, int_node(s->children[2]), type_id[type]);
 	  else if (mode == "indep")
 	    crush.set_rule_step_choose_leaf_indep(ruleno, step++, int_node(s->children[2]), type_id[type]);
-	  else assert(0);
-	} else assert(0);
+	  else ceph_abort();
+	} else ceph_abort();
       }
       break;
 
@@ -765,7 +765,7 @@ int CrushCompiler::parse_crush(iter_t const& i)
       r = parse_rule(p);
       break;
     default:
-      assert(0);
+      ceph_abort();
     }
     if (r < 0) {
       return r;

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1185,7 +1185,7 @@ void CrushWrapper::encode(bufferlist& bl, bool lean) const
       break;
 
     default:
-      assert(0);
+      ceph_abort();
       break;
     }
   }
@@ -1414,7 +1414,7 @@ void CrushWrapper::decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator
 
   default:
     // We should have handled this case in the first switch statement
-    assert(0);
+    ceph_abort();
     break;
   }
 }

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -372,7 +372,7 @@ public:
     return s;
   }
   void finish(int r) {
-    assert(0);    // nobody should ever call me.
+    ceph_abort();    // nobody should ever call me.
   }
 
   inline int get_sub_existing_count() const {

--- a/src/include/Distribution.h
+++ b/src/include/Distribution.h
@@ -56,7 +56,7 @@ class Distribution {
       if (s < p[i]) return v[i];
       s -= p[i];
     }
-    assert(0);
+    ceph_abort();
     return v[p.size() - 1];  // hmm.  :/
   }
 

--- a/src/include/assert.h
+++ b/src/include/assert.h
@@ -85,7 +85,7 @@ using namespace ceph;
 /*
  * ceph_abort aborts the program with a nice backtrace.
  *
- * Currently, it's the same as assert(0), but we may one day make assert a
+ * Currently, it's the same as ceph_abort(), but we may one day make assert a
  * debug-only thing, like it is in many projects.
  */
 #define ceph_abort() abort()

--- a/src/include/btree_interval_set.h
+++ b/src/include/btree_interval_set.h
@@ -357,7 +357,7 @@ class btree_interval_set {
 
         if (p->first + p->second != start) {
           //cout << "p is " << p->first << "~" << p->second << ", start is " << start << ", len is " << len << endl;
-          assert(0);
+          ceph_abort();
         }
 
         p->second += len;               // append to end

--- a/src/include/elist.h
+++ b/src/include/elist.h
@@ -170,7 +170,7 @@ public:
       else if (mode == CACHE_NEXT)
 	cur = next;
       else
-	assert(0);
+	ceph_abort();
       next = cur->_next;
       return *this;
     }

--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -356,7 +356,7 @@ class interval_set {
         
         if (p->first + p->second != start) {
           //cout << "p is " << p->first << "~" << p->second << ", start is " << start << ", len is " << len << endl;
-          assert(0);
+          ceph_abort();
         }
         
         p->second += len;               // append to end

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -240,7 +240,7 @@ bool AioObjectRead<I>::should_complete(int r)
     break;
   default:
     lderr(image_ctx->cct) << "invalid request state: " << m_state << dendl;
-    assert(0);
+    ceph_abort();
   }
 
   return finished;
@@ -420,7 +420,7 @@ bool AbstractAioObjectWrite::should_complete(int r)
 
   default:
     lderr(m_ictx->cct) << "invalid request state: " << m_state << dendl;
-    assert(0);
+    ceph_abort();
   }
 
   return finished;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1769,7 +1769,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       }
       if (is_protected) {
 	lderr(ictx->cct) << "snapshot is still protected after unprotection" << dendl;
-	assert(0);
+	ceph_abort();
       }
     }
 

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -446,7 +446,7 @@ void CDentry::encode_lock_state(int type, bufferlist& bl)
   else if (linkage.is_null()) {
     // encode nothing.
   }
-  else assert(0);  
+  else ceph_abort();
 }
 
 void CDentry::decode_lock_state(int type, bufferlist& bl)
@@ -487,7 +487,7 @@ void CDentry::decode_lock_state(int type, bufferlist& bl)
     }
     break;
   default: 
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -620,6 +620,6 @@ std::string CDentry::linkage_t::get_remote_d_type_string() const
     case S_IFDIR: return "dir";
     case S_IFCHR: return "chr";
     case S_IFIFO: return "fifo";
-    default: assert(0); return "";
+    default: ceph_abort(); return "";
   }
 }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1891,7 +1891,7 @@ void CDir::go_bad_dentry(snapid_t last, const std::string &dname)
       inode->ino(), frag, last, dname);
   if (fatal) {
     cache->mds->damaged();
-    assert(0);  // unreachable, damaged() respawns us
+    ceph_abort();  // unreachable, damaged() respawns us
   }
 }
 
@@ -1900,7 +1900,7 @@ void CDir::go_bad(bool complete)
   const bool fatal = cache->mds->damage_table.notify_dirfrag(inode->ino(), frag);
   if (fatal) {
     cache->mds->damaged();
-    assert(0);  // unreachable, damaged() respawns us
+    ceph_abort();  // unreachable, damaged() respawns us
   }
 
   if (complete)
@@ -2616,7 +2616,7 @@ void CDir::verify_fragstat()
       c.nfiles != fnode.fragstat.nfiles) {
     dout(0) << "verify_fragstat failed " << fnode.fragstat << " on " << *this << dendl;
     dout(0) << "               i count " << c << dendl;
-    assert(0);
+    ceph_abort();
   } else {
     dout(0) << "verify_fragstat ok " << fnode.fragstat << " on " << *this << dendl;
   }
@@ -2736,7 +2736,7 @@ CDir *CDir::get_frozen_tree_root()
     if (dir->inode->parent)
       dir = dir->inode->parent->dir;
     else
-      assert(0);
+      ceph_abort();
   }
 }
 
@@ -2995,7 +2995,7 @@ int CDir::_next_dentry_on_set(set<dentry_key_t>& dns, bool missing_okay,
       } else {
 	dout(5) << " we lost dentry " << dnkey.name
 		<< ", bailing out because that's impossible!" << dendl;
-	assert(0);
+	ceph_abort();
       }
     }
     // okay, we got a  dentry

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1539,7 +1539,7 @@ void CInode::encode_lock_state(int type, bufferlist& bl)
     break;
   
   default:
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -1793,7 +1793,7 @@ void CInode::decode_lock_state(int type, bufferlist& bl)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -1830,7 +1830,7 @@ void CInode::clear_dirty_scattered(int type)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -1923,7 +1923,7 @@ void CInode::finish_scatter_update(ScatterLock *lock, CDir *dir,
 	ename = "lock inest accounted scatter stat update";
 	break;
       default:
-	assert(0);
+	ceph_abort();
       }
 	
       mut->add_projected_fnode(dir);
@@ -2185,7 +2185,7 @@ void CInode::finish_scatter_gather_update(int type)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -2331,7 +2331,7 @@ void CInode::unfreeze_inode(list<MDSInternalContextBase*>& finished)
     state_clear(STATE_FROZEN);
     put(PIN_FROZEN);
   } else 
-    assert(0);
+    ceph_abort();
   take_waiting(WAIT_UNFREEZE, finished);
 }
 

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -264,7 +264,7 @@ void DamageTable::erase(damage_entry_id_t damage_id)
     remotes.erase(backtrace_entry->ino);
   } else {
     derr << "Invalid type " << type << dendl;
-    assert(0);
+    ceph_abort();
   }
 
   by_id.erase(by_id_entry);

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -831,7 +831,7 @@ void Locker::eval_gather(SimpleLock *lock, bool first, bool *pneed_issue, list<M
 	  break;
 
 	default:
-	  assert(0);
+	  ceph_abort();
 	}
       }
     } else {
@@ -3535,7 +3535,7 @@ void Locker::handle_client_lease(MClientLease *m)
     break;
 
   default:
-    assert(0); // implement me
+    ceph_abort(); // implement me
     break;
   }
 }
@@ -3660,7 +3660,7 @@ SimpleLock *Locker::get_lock(int lock_type, MDSCacheObjectInfo &info)
 
   default:
     dout(7) << "get_lock don't know lock_type " << lock_type << dendl;
-    assert(0);
+    ceph_abort();
     break;
   }
 
@@ -3702,7 +3702,7 @@ void Locker::handle_lock(MLock *m)
     
   default:
     dout(7) << "handle_lock got otype " << m->get_lock_type() << dendl;
-    assert(0);
+    ceph_abort();
     break;
   }
 }
@@ -3913,7 +3913,7 @@ bool Locker::simple_sync(SimpleLock *lock, bool *need_issue)
     case LOCK_LOCK: lock->set_state(LOCK_LOCK_SYNC); break;
     case LOCK_XSYN: lock->set_state(LOCK_XSYN_SYNC); break;
     case LOCK_EXCL: lock->set_state(LOCK_EXCL_SYNC); break;
-    default: assert(0);
+    default: ceph_abort();
     }
 
     int gather = 0;
@@ -3991,7 +3991,7 @@ void Locker::simple_excl(SimpleLock *lock, bool *need_issue)
   case LOCK_LOCK: lock->set_state(LOCK_LOCK_EXCL); break;
   case LOCK_SYNC: lock->set_state(LOCK_SYNC_EXCL); break;
   case LOCK_XSYN: lock->set_state(LOCK_XSYN_EXCL); break;
-  default: assert(0);
+  default: ceph_abort();
   }
   
   int gather = 0;
@@ -4057,7 +4057,7 @@ void Locker::simple_lock(SimpleLock *lock, bool *need_issue)
     (static_cast<ScatterLock *>(lock))->clear_unscatter_wanted();
     break;
   case LOCK_TSYN: lock->set_state(LOCK_TSYN_LOCK); break;
-  default: assert(0);
+  default: ceph_abort();
   }
 
   int gather = 0;
@@ -4139,7 +4139,7 @@ void Locker::simple_xlock(SimpleLock *lock)
   switch (lock->get_state()) {
   case LOCK_LOCK: 
   case LOCK_XLOCKDONE: lock->set_state(LOCK_LOCK_XLOCK); break;
-  default: assert(0);
+  default: ceph_abort();
   }
 
   int gather = 0;
@@ -4436,7 +4436,7 @@ void Locker::scatter_nudge(ScatterLock *lock, MDSInternalContextBase *c, bool fo
 	    simple_sync(lock);
 	  break;
 	default:
-	  assert(0);
+	  ceph_abort();
 	}
 	++count;
 	if (lock->is_stable() && count == 2) {
@@ -4511,10 +4511,10 @@ void Locker::scatter_tempsync(ScatterLock *lock, bool *need_issue)
   CInode *in = static_cast<CInode *>(lock->get_parent());
 
   switch (lock->get_state()) {
-  case LOCK_SYNC: assert(0);   // this shouldn't happen
+  case LOCK_SYNC: ceph_abort();   // this shouldn't happen
   case LOCK_LOCK: lock->set_state(LOCK_LOCK_TSYN); break;
   case LOCK_MIX: lock->set_state(LOCK_MIX_TSYN); break;
-  default: assert(0);
+  default: ceph_abort();
   }
 
   int gather = 0;
@@ -4781,7 +4781,7 @@ void Locker::scatter_mix(ScatterLock *lock, bool *need_issue)
       // fall-thru
     case LOCK_EXCL: lock->set_state(LOCK_EXCL_MIX); break;
     case LOCK_TSYN: lock->set_state(LOCK_TSYN_MIX); break;
-    default: assert(0);
+    default: ceph_abort();
     }
 
     int gather = 0;
@@ -4855,7 +4855,7 @@ void Locker::file_excl(ScatterLock *lock, bool *need_issue)
   case LOCK_MIX: lock->set_state(LOCK_MIX_EXCL); break;
   case LOCK_LOCK: lock->set_state(LOCK_LOCK_EXCL); break;
   case LOCK_XSYN: lock->set_state(LOCK_XSYN_EXCL); break;
-  default: assert(0);
+  default: ceph_abort();
   }
   int gather = 0;
   
@@ -4912,7 +4912,7 @@ void Locker::file_xsyn(SimpleLock *lock, bool *need_issue)
 
   switch (lock->get_state()) {
   case LOCK_EXCL: lock->set_state(LOCK_EXCL_XSYN); break;
-  default: assert(0);
+  default: ceph_abort();
   }
   
   int gather = 0;
@@ -5027,7 +5027,7 @@ void Locker::handle_file_lock(ScatterLock *lock, MLock *m)
     switch (lock->get_state()) {
     case LOCK_SYNC: lock->set_state(LOCK_SYNC_LOCK); break;
     case LOCK_MIX: lock->set_state(LOCK_MIX_LOCK); break;
-    default: assert(0);
+    default: ceph_abort();
     }
 
     eval_gather(lock, true);
@@ -5183,7 +5183,7 @@ void Locker::handle_file_lock(ScatterLock *lock, MLock *m)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }  
   
   m->put();

--- a/src/mds/LogEvent.h
+++ b/src/mds/LogEvent.h
@@ -109,7 +109,7 @@ public:
   /*** recovery ***/
   /* replay() - replay given event.  this is idempotent.
    */
-  virtual void replay(MDSRank *m) { assert(0); }
+  virtual void replay(MDSRank *m) { ceph_abort(); }
 
   /**
    * If the subclass embeds a MetaBlob, return it here so that

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -137,7 +137,7 @@ double mds_load_t::mds_load()
     return cpu_load_avg;
 
   }
-  assert(0);
+  ceph_abort();
   return 0;
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -584,7 +584,7 @@ struct C_MDS_RetryOpenRoot : public MDSInternalContext {
       // it is not okay to call suicide() here because we are in
       // a Finisher callback.
       cache->mds->damaged();
-      assert(0);  // damaged should never return
+      ceph_abort();  // damaged should never return
     } else {
       cache->open_root();
     }
@@ -3401,7 +3401,7 @@ void MDCache::handle_resolve_ack(MMDSResolveAck *ack)
 	mds->server->do_rmdir_rollback(su->rollback, from, null_ref);
 	break;
       default:
-	assert(0);
+	ceph_abort();
       }
     } else {
       MDRequestRef mdr = request_get(*p);
@@ -4253,7 +4253,7 @@ void MDCache::handle_cache_rejoin(MMDSCacheRejoin *m)
     break;
 
   default: 
-    assert(0);
+    ceph_abort();
   }
   m->put();
 }
@@ -7774,7 +7774,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, Message *req, MDSInternalContextBa
     if (MDS_INO_IS_MDSDIR(path.get_ino())) 
       open_foreign_mdsdir(path.get_ino(), _get_waiter(mdr, req, fin));
     else {
-      //assert(0);  // hrm.. broken
+      //ceph_abort();  // hrm.. broken
       return -ESTALE;
     }
     return 1;
@@ -7981,7 +7981,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, Message *req, MDSInternalContextBa
 	    dout(20) << " didn't traverse full path; not returning pdnvec" << dendl;
 	    dn = NULL;
 	  } else if (dn) {
-	    assert(0); // should have fallen out in ->is_null() check above
+	    ceph_abort(); // should have fallen out in ->is_null() check above
 	  } else if (curdir->is_frozen()) {
 	    dout(20) << " not adding null to frozen dir " << dendl;
 	  } else if (snapid < CEPH_MAXSNAP) {
@@ -8058,7 +8058,7 @@ int MDCache::path_traverse(MDRequestRef& mdr, Message *req, MDSInternalContextBa
       }    
     }
     
-    assert(0);  // i shouldn't get here
+    ceph_abort();  // i shouldn't get here
   }
   
   // success.
@@ -8195,7 +8195,7 @@ void MDCache::_open_remote_dentry_finish(CDentry *dn, inodeno_t ino, MDSInternal
           dn->get_projected_linkage()->get_remote_ino());
       if (fatal) {
         mds->damaged();
-        assert(0);  // unreachable, damaged() respawns us
+        ceph_abort();  // unreachable, damaged() respawns us
       }
   }
   fin->complete(r < 0 ? r : 0);
@@ -8999,7 +8999,7 @@ void MDCache::dispatch_request(MDRequestRef& mdr)
       repair_inode_stats_work(mdr);
       break;
     default:
-      assert(0);
+      ceph_abort();
     }
   }
 }
@@ -9310,7 +9310,7 @@ void MDCache::_snaprealm_create_finish(MDRequestRef& mdr, MutationRef& mut, CIno
   /*
   static int count = 5;
   if (--count == 0)
-    assert(0);  // hack test test **********
+    ceph_abort();  // hack test test **********
   */
 
   // done.
@@ -10290,7 +10290,7 @@ void MDCache::send_dentry_link(CDentry *dn, MDRequestRef& mdr)
       ::encode(ino, m->bl);
       ::encode(d_type, m->bl);
     } else
-      assert(0);   // aie, bad caller!
+      ceph_abort();   // aie, bad caller!
     mds->send_message_mds(m, p->first);
   }
 }
@@ -10331,7 +10331,7 @@ void MDCache::handle_dentry_link(MDentryLink *m)
       dir->link_remote_inode(dn, ino, d_type);
     }
   } else {
-    assert(0);
+    ceph_abort();
   }
 
   if (!finished.empty())
@@ -10904,7 +10904,7 @@ bool MDCache::fragment_are_all_frozen(CDir *dir)
     if (p->first.frag.contains(dir->get_frag()))
       return p->second.all_frozen;
   }
-  assert(0);
+  ceph_abort();
   return false;
 }
 
@@ -10919,7 +10919,7 @@ void MDCache::fragment_freeze_inc_num_waiters(CDir *dir)
       return;
     }
   }
-  assert(0);
+  ceph_abort();
 }
 
 void MDCache::find_stale_fragment_freeze()
@@ -11334,7 +11334,7 @@ void MDCache::handle_fragment_notify(MMDSFragmentNotify *notify)
 
     mds->queue_waiters(waiters);
   } else {
-    assert(0);
+    ceph_abort();
   }
 
   notify->put();

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -107,7 +107,7 @@ class C_MDL_WriteError : public MDSIOContextBase {
       mds->clog->error() << "Unhandled journal write error on MDS rank " <<
         mds->get_nodeid() << ": " << cpp_strerror(r) << ", shutting down.";
       mds->damaged();
-      assert(0);  // damaged should never return
+      ceph_abort();  // damaged should never return
     }
   }
 
@@ -910,7 +910,7 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
       // Oh dear, something unreadable in the store for this rank: require
       // operator intervention.
       mds->damaged();
-      assert(0);  // damaged should not return
+      ceph_abort();  // damaged should not return
   }
 
   // First, read the pointer object.
@@ -927,12 +927,12 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
   } else if (read_result == -EBLACKLISTED) {
     derr << "Blacklisted during JournalPointer read!  Respawning..." << dendl;
     mds->respawn();
-    assert(0); // Should be unreachable because respawn calls execv
+    ceph_abort(); // Should be unreachable because respawn calls execv
   } else if (read_result != 0) {
     mds->clog->error() << "failed to read JournalPointer: " << read_result
                        << " (" << cpp_strerror(read_result) << ")";
     mds->damaged_unlocked();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 
   // If the back pointer is non-null, that means that a journal
@@ -961,7 +961,7 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
     if (recovery_result == -EBLACKLISTED) {
       derr << "Blacklisted during journal recovery!  Respawning..." << dendl;
       mds->respawn();
-      assert(0); // Should be unreachable because respawn calls execv
+      ceph_abort(); // Should be unreachable because respawn calls execv
     } else if (recovery_result != 0) {
       // Journaler.recover succeeds if no journal objects are present: an error
       // means something worse like a corrupt header, which we can't handle here.
@@ -1008,7 +1008,7 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
   if (recovery_result == -EBLACKLISTED) {
     derr << "Blacklisted during journal recovery!  Respawning..." << dendl;
     mds->respawn();
-    assert(0); // Should be unreachable because respawn calls execv
+    ceph_abort(); // Should be unreachable because respawn calls execv
   } else if (recovery_result != 0) {
     mds->clog->error() << "Error recovering journal " << jp.front << ": "
       << cpp_strerror(recovery_result);
@@ -1279,7 +1279,7 @@ void MDLog::_replay_thread()
         } else {
           mds->clog->error() << "missing journal object";
           mds->damaged_unlocked();
-          assert(0);  // Should be unreachable because damaged() calls respawn()
+          ceph_abort();  // Should be unreachable because damaged() calls respawn()
         }
       } else if (r == -EINVAL) {
         if (journaler->get_read_pos() < journaler->get_expire_pos()) {
@@ -1290,7 +1290,7 @@ void MDLog::_replay_thread()
           } else {
             mds->clog->error() << "invalid journaler offsets";
             mds->damaged_unlocked();
-            assert(0);  // Should be unreachable because damaged() calls respawn()
+            ceph_abort();  // Should be unreachable because damaged() calls respawn()
           }
         } else {
           /* re-read head and check it
@@ -1313,7 +1313,7 @@ void MDLog::_replay_thread()
 
                 mds->clog->error() << "error reading journal header";
                 mds->damaged_unlocked();
-                assert(0);  // Should be unreachable because damaged() calls
+                ceph_abort();  // Should be unreachable because damaged() calls
                             // respawn()
             }
           }
@@ -1357,7 +1357,7 @@ void MDLog::_replay_thread()
         continue;
       } else {
         mds->damaged_unlocked();
-        assert(0);  // Should be unreachable because damaged() calls
+        ceph_abort();  // Should be unreachable because damaged() calls
                     // respawn()
       }
 

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -79,7 +79,7 @@ class MDSCacheObject {
     case PIN_PTRWAITER: return "ptrwaiter";
     case PIN_TEMPEXPORTING: return "tempexporting";
     case PIN_CLIENTLEASE: return "clientlease";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 
@@ -195,7 +195,7 @@ protected:
 #ifdef MDS_REF_SET
     assert(by < 0 || ref_map[by] == 0);
 #endif
-    assert(0);
+    ceph_abort();
   }
   void get(int by) {
     if (ref == 0)
@@ -378,15 +378,15 @@ protected:
   // ---------------------------------------------
   // locking
   // noop unless overloaded.
-  virtual SimpleLock* get_lock(int type) { assert(0); return 0; }
-  virtual void set_object_info(MDSCacheObjectInfo &info) { assert(0); }
-  virtual void encode_lock_state(int type, bufferlist& bl) { assert(0); }
-  virtual void decode_lock_state(int type, bufferlist& bl) { assert(0); }
-  virtual void finish_lock_waiters(int type, uint64_t mask, int r=0) { assert(0); }
-  virtual void add_lock_waiter(int type, uint64_t mask, MDSInternalContextBase *c) { assert(0); }
-  virtual bool is_lock_waiting(int type, uint64_t mask) { assert(0); return false; }
+  virtual SimpleLock* get_lock(int type) { ceph_abort(); return 0; }
+  virtual void set_object_info(MDSCacheObjectInfo &info) { ceph_abort(); }
+  virtual void encode_lock_state(int type, bufferlist& bl) { ceph_abort(); }
+  virtual void decode_lock_state(int type, bufferlist& bl) { ceph_abort(); }
+  virtual void finish_lock_waiters(int type, uint64_t mask, int r=0) { ceph_abort(); }
+  virtual void add_lock_waiter(int type, uint64_t mask, MDSInternalContextBase *c) { ceph_abort(); }
+  virtual bool is_lock_waiting(int type, uint64_t mask) { ceph_abort(); return false; }
 
-  virtual void clear_dirty_scattered(int type) { assert(0); }
+  virtual void clear_dirty_scattered(int type) { ceph_abort(); }
 
   // ---------------------------------------------
   // ordering

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -100,6 +100,6 @@ void C_IO_Wrapper::complete(int r)
 MDSRank *MDSInternalContextGather::get_mds()
 {
   derr << "Forbidden call to MDSInternalContextGather::get_mds by " << typeid(*this).name() << dendl;
-  assert(0);
+  ceph_abort();
 }
 

--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -133,7 +133,7 @@ public:
  */
 class C_MDSInternalNoop : public MDSInternalContextBase
 {
-  virtual MDSRank* get_mds() {assert(0);}
+  virtual MDSRank* get_mds() {ceph_abort();}
 public:
   void finish(int r) {}
   void complete(int r) {}

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1141,7 +1141,7 @@ void MDSDaemon::respawn()
 
   // We have to assert out here, because suicide() returns, and callers
   // to respawn expect it never to return.
-  assert(0);
+  ceph_abort();
 }
 
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -299,7 +299,7 @@ MDSTableClient *MDSRank::get_table_client(int t)
   switch (t) {
   case TABLE_ANCHOR: return NULL;
   case TABLE_SNAP: return snapclient;
-  default: assert(0);
+  default: ceph_abort();
   }
 }
 
@@ -308,7 +308,7 @@ MDSTableServer *MDSRank::get_table_server(int t)
   switch (t) {
   case TABLE_ANCHOR: return NULL;
   case TABLE_SNAP: return snapserver;
-  default: assert(0);
+  default: ceph_abort();
   }
 }
 

--- a/src/mds/MDSTableServer.h
+++ b/src/mds/MDSTableServer.h
@@ -42,7 +42,7 @@ private:
   virtual void _prepare(bufferlist &bl, uint64_t reqid, mds_rank_t bymds) = 0;
   virtual bool _commit(version_t tid, MMDSTableRequest *req=NULL) = 0;
   virtual void _rollback(version_t tid) = 0;
-  virtual void _server_update(bufferlist& bl) { assert(0); }
+  virtual void _server_update(bufferlist& bl) { ceph_abort(); }
 
   void _note_prepare(mds_rank_t mds, uint64_t reqid) {
     pending_for_mds[version].mds = mds;

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -340,7 +340,7 @@ void Migrator::export_try_cancel(CDir *dir, bool notify_peer)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 
   // finish clean-up?
@@ -753,7 +753,7 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   }
   if (dir->inode->is_system()) {
     dout(7) << "i won't export system dirs (root, mdsdirs, stray, /.ceph, etc.)" << dendl;
-    //assert(0);
+    //ceph_abort();
     return;
   }
 
@@ -1923,10 +1923,10 @@ void Migrator::handle_export_discover(MExportDirDiscover *m)
     if (r > 0) return;
     if (r < 0) {
       dout(7) << "handle_export_discover_2 failed to discover or not dir " << m->get_path() << ", NAK" << dendl;
-      assert(0);    // this shouldn't happen if the auth pins its path properly!!!!
+      ceph_abort();    // this shouldn't happen if the auth pins its path properly!!!!
     }
 
-    assert(0); // this shouldn't happen; the get_inode above would have succeeded.
+    ceph_abort(); // this shouldn't happen; the get_inode above would have succeeded.
   }
 
   // yay

--- a/src/mds/Migrator.h
+++ b/src/mds/Migrator.h
@@ -76,7 +76,7 @@ public:
     case EXPORT_EXPORTING: return "exporting";
     case EXPORT_LOGGINGFINISH: return "loggingfinish";
     case EXPORT_NOTIFYING: return "notifying";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 
@@ -125,7 +125,7 @@ public:
     case IMPORT_ACKING: return "acking";
     case IMPORT_FINISHING: return "finishing";
     case IMPORT_ABORTING: return "aborting";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -390,7 +390,7 @@ void Server::handle_client_session(MClientSession *m)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
   m->put();
 }
@@ -492,10 +492,10 @@ void Server::_session_logged(Session *session, uint64_t state_seq, bool open, ve
       }
       mds->sessionmap.remove_session(session);
     } else {
-      assert(0);
+      ceph_abort();
     }
   } else {
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -1802,7 +1802,7 @@ void Server::handle_slave_request_reply(MMDSSlaveRequest *m)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
   
   // done with reply.
@@ -1833,7 +1833,7 @@ void Server::dispatch_slave_request(MDRequestRef& mdr)
 
       if (!lock) {
 	dout(10) << "don't have object, dropping" << dendl;
-	assert(0); // can this happen, if we auth pinned properly.
+	ceph_abort(); // can this happen, if we auth pinned properly.
       }
       if (op == MMDSSlaveRequest::OP_XLOCK && !lock->get_parent()->is_auth()) {
 	dout(10) << "not auth for remote xlock attempt, dropping on " 
@@ -1928,7 +1928,7 @@ void Server::dispatch_slave_request(MDRequestRef& mdr)
     break;
 
   default: 
-    assert(0);
+    ceph_abort();
   }
 }
 
@@ -1996,7 +1996,7 @@ void Server::handle_slave_auth_pin(MDRequestRef& mdr)
 	} else if (CDentry *dn = dynamic_cast<CDentry*>(*p)) {
 	  dir = dn->get_dir();
 	} else {
-	  assert(0);
+	  ceph_abort();
 	}
 	if (dir) {
 	  if (dir->is_freezing_dir())
@@ -2309,7 +2309,7 @@ CInode* Server::prepare_new_inode(MDRequestRef& mdr, CDir *dir, inodeno_t useino
     mds->clog->error() << mdr->client_request->get_source()
        << " specified ino " << useino
        << " but mds." << mds->get_nodeid() << " allocated " << in->inode.ino << "\n";
-    //assert(0); // just for now.
+    //ceph_abort(); // just for now.
   }
     
   int got = g_conf->mds_client_prealloc_inos - mdr->session->get_num_projected_prealloc_inos();
@@ -5175,7 +5175,7 @@ void Server::handle_slave_link_prep(MDRequestRef& mdr)
 
   mdr->auth_pin(targeti);
 
-  //assert(0);  // test hack: make sure master can handle a slave that fails to prepare...
+  //ceph_abort();  // test hack: make sure master can handle a slave that fails to prepare...
   assert(g_conf->mds_kill_link_at != 5);
 
   // journal it

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -162,7 +162,7 @@ void SessionMap::_load_finish(
                        << "' " << operation_r << " ("
                        << cpp_strerror(operation_r) << ")";
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 
   // Decode header
@@ -172,7 +172,7 @@ void SessionMap::_load_finish(
       mds->clog->error() << "error reading sessionmap header "
                          << header_r << " (" << cpp_strerror(header_r) << ")";
       mds->damaged();
-      assert(0);  // Should be unreachable because damaged() calls respawn()
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
     }
 
     if(header_bl.length() == 0) {
@@ -186,7 +186,7 @@ void SessionMap::_load_finish(
     } catch (buffer::error &e) {
       mds->clog->error() << "corrupt sessionmap header: " << e.what();
       mds->damaged();
-      assert(0);  // Should be unreachable because damaged() calls respawn()
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
     }
     dout(10) << __func__ << " loaded version " << version << dendl;
   }
@@ -197,7 +197,7 @@ void SessionMap::_load_finish(
     mds->clog->error() << "error reading sessionmap values: " 
                        << values_r << " (" << cpp_strerror(values_r) << ")";
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 
   // Decode session_vals
@@ -206,7 +206,7 @@ void SessionMap::_load_finish(
   } catch (buffer::error &e) {
     mds->clog->error() << "corrupt sessionmap values: " << e.what();
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 
   if (session_vals.size() == g_conf->mds_sessionmap_keys_per_op) {

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -37,7 +37,7 @@ inline const char *get_lock_type_name(int t) {
   case CEPH_LOCK_INO: return "ino";
   case CEPH_LOCK_IFLOCK: return "iflock";
   case CEPH_LOCK_IPOLICY: return "ipolicy";
-  default: assert(0); return 0;
+  default: ceph_abort(); return 0;
   }
 }
 
@@ -140,7 +140,7 @@ public:
 
     case LOCK_SNAP_SYNC: return "snap->sync";
 
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 
@@ -257,7 +257,7 @@ public:
     case CEPH_LOCK_IFLOCK:   return 8 +10*SimpleLock::WAIT_BITS;
     case CEPH_LOCK_IPOLICY:  return 8 +11*SimpleLock::WAIT_BITS;
     default:
-      assert(0);
+      ceph_abort();
     }
   }
 

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -131,7 +131,7 @@ void SnapServer::_prepare(bufferlist &bl, uint64_t reqid, mds_rank_t bymds)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
   //dump();
 }
@@ -179,7 +179,7 @@ bool SnapServer::_commit(version_t tid, MMDSTableRequest *req)
     pending_noop.erase(tid);
   }
   else
-    assert(0);
+    ceph_abort();
 
   // bump version.
   version++;
@@ -211,7 +211,7 @@ void SnapServer::_rollback(version_t tid)
   }    
 
   else
-    assert(0);
+    ceph_abort();
 
   // bump version.
   version++;

--- a/src/mds/flock.cc
+++ b/src/mds/flock.cc
@@ -442,12 +442,12 @@ void ceph_lock_state_t::adjust_locks(list<multimap<uint64_t, ceph_filelock>::ite
       if (0 == new_lock.length) {
         if (old_lock->start + old_lock->length == new_lock.start) {
           new_lock.start = old_lock->start;
-        } else assert(0); /* if there's no end to new_lock, the neighbor
+        } else ceph_abort(); /* if there's no end to new_lock, the neighbor
                              HAS TO be to left side */
       } else if (0 == old_lock->length) {
         if (new_lock.start + new_lock.length == old_lock->start) {
           new_lock.length = 0;
-        } else assert(0); //same as before, but reversed
+        } else ceph_abort(); //same as before, but reversed
       } else {
         if (old_lock->start + old_lock->length == new_lock.start) {
           new_lock.start = old_lock->start;

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -599,7 +599,7 @@ void EMetaBlob::fullbit::update_inode(MDSRank *mds, CInode *in)
           << std::dec << " in journal";
       mds->clog->error() << oss.str();
       mds->damaged();
-      assert(0);  // Should be unreachable because damaged() calls respawn()
+      ceph_abort();  // Should be unreachable because damaged() calls respawn()
     }
   }
 }
@@ -1215,7 +1215,7 @@ void EMetaBlob::replay(MDSRank *mds, LogSegment *logseg, MDSlaveUpdate *slaveup)
 	  dout(0) << "EMetaBlob.replay missing dir ino  " << (*lp).ino << dendl;
           mds->clog->error() << "failure replaying journal (EMetaBlob)";
           mds->damaged();
-          assert(0);  // Should be unreachable because damaged() calls respawn()
+          ceph_abort();  // Should be unreachable because damaged() calls respawn()
 	}
       }
 
@@ -1961,7 +1961,7 @@ void ETableServer::replay(MDSRank *mds)
   default:
     mds->clog->error() << "invalid tableserver op in ETableServer";
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
   
   assert(version == server->get_version());
@@ -2527,7 +2527,7 @@ void ESlaveUpdate::replay(MDSRank *mds)
   default:
     mds->clog->error() << "invalid op in ESlaveUpdate";
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 }
 
@@ -2770,7 +2770,7 @@ void EFragment::replay(MDSRank *mds)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
   }
 
   metablob.replay(mds, _segment);
@@ -3031,7 +3031,7 @@ void EImportFinish::replay(MDSRank *mds)
 	     << dendl;
     mds->clog->error() << "failure replaying journal (EImportFinish)";
     mds->damaged();
-    assert(0);  // Should be unreachable because damaged() calls respawn()
+    ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 }
 

--- a/src/mds/mds_table_types.h
+++ b/src/mds/mds_table_types.h
@@ -26,7 +26,7 @@ inline const char *get_mdstable_name(int t) {
   switch (t) {
   case TABLE_ANCHOR: return "anchortable";
   case TABLE_SNAP: return "snaptable";
-  default: assert(0);
+  default: ceph_abort();
   }
 }
 
@@ -53,7 +53,7 @@ inline const char *get_mdstableserver_opname(int op) {
   case TABLESERVER_OP_ROLLBACK: return "rollback";
   case TABLESERVER_OP_SERVER_UPDATE: return "server_update";
   case TABLESERVER_OP_SERVER_READY: return "server_ready";
-  default: assert(0); return 0;
+  default: ceph_abort(); return 0;
   }
 }
 
@@ -68,7 +68,7 @@ inline const char *get_mdstable_opname(int op) {
   case TABLE_OP_CREATE: return "create";
   case TABLE_OP_UPDATE: return "update";
   case TABLE_OP_DESTROY: return "destroy";
-  default: assert(0); return 0;
+  default: ceph_abort(); return 0;
   }
 }
 

--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -39,7 +39,7 @@ class MMDSCacheRejoin : public Message {
     case OP_WEAK: return "weak";
     case OP_STRONG: return "strong";
     case OP_ACK: return "ack";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/messages/MMDSSlaveRequest.h
+++ b/src/messages/MMDSSlaveRequest.h
@@ -86,7 +86,7 @@ class MMDSSlaveRequest : public Message {
     case OP_ABORT: return "abort";
       //case OP_COMMIT: return "commit";
 
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/messages/MMonElection.h
+++ b/src/messages/MMonElection.h
@@ -36,7 +36,7 @@ public:
     case OP_ACK: return "ack";
     case OP_NAK: return "nak";
     case OP_VICTORY: return "victory";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
   

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -43,7 +43,7 @@ class MMonPaxos : public Message {
     case OP_COMMIT: return "commit";
     case OP_LEASE: return "lease";
     case OP_LEASE_ACK: return "lease_ack";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
 

--- a/src/messages/MMonProbe.h
+++ b/src/messages/MMonProbe.h
@@ -42,7 +42,7 @@ public:
     case OP_SLURP_LATEST: return "slurp_latest";
     case OP_DATA: return "data";
     case OP_MISSING_FEATURES: return "missing_features";
-    default: assert(0); return 0;
+    default: ceph_abort(); return 0;
     }
   }
   

--- a/src/messages/PaxosServiceMessage.h
+++ b/src/messages/PaxosServiceMessage.h
@@ -39,12 +39,12 @@ class PaxosServiceMessage : public Message {
   }
 
   void encode_payload(uint64_t features) {
-    assert(0);
+    ceph_abort();
     paxos_encode();
   }
 
   void decode_payload() {
-    assert(0);
+    ceph_abort();
     bufferlist::iterator p = payload.begin();
     paxos_decode(p);
   }

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -79,7 +79,7 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
   auto handler = auth_registry.get_handler(protocol);
   if (!handler) {
     dout(0) << "No AuthAuthorizeHandler found for protocol " << protocol << dendl;
-    assert(0);
+    ceph_abort();
     is_valid = false;
     return true;
   }

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -116,7 +116,7 @@ public:
         }
       } else if (key.first == CEPH_ENTITY_TYPE_OSD) {
       } else {
-        assert(0);
+        ceph_abort();
       }
     } else {
       dout(1) << "mon failed to return metadata for "
@@ -435,7 +435,7 @@ bool Mgr::ms_dispatch(Message *m)
       // from monclient anyway), but we don't see notifications.  Hook
       // into MonClient to get notifications instead of messing
       // with message delivery to achieve it?
-      assert(0);
+      ceph_abort();
 
       py_modules.notify_all("mon_map", "");
       break;

--- a/src/mgr/PyFormatter.cc
+++ b/src/mgr/PyFormatter.cc
@@ -86,7 +86,7 @@ std::ostream& PyFormatter::dump_stream(const char *name)
 void PyFormatter::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)
 {
   // TODO
-  assert(0);
+  ceph_abort();
 }
 
 /**
@@ -103,7 +103,7 @@ void PyFormatter::dump_pyobject(const char *name, PyObject *p)
     Py_DECREF(key);
     Py_DECREF(p);
   } else {
-    assert(0);
+    ceph_abort();
   }
 }
 

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -31,6 +31,7 @@
 #include <list>
 
 #include "common/Formatter.h"
+#include "include/assert.h"
 
 class PyFormatter : public ceph::Formatter
 {
@@ -54,9 +55,9 @@ public:
 
   // Obscure, don't care.
   void open_array_section_in_ns(const char *name, const char *ns)
-  {assert(0);}
+  {ceph_abort();}
   void open_object_section_in_ns(const char *name, const char *ns)
-  {assert(0);}
+  {ceph_abort();}
 
   void reset()
   {
@@ -94,20 +95,20 @@ public:
   void flush(std::ostream& os)
   {
       // This class is not a serializer: this doens't make sense
-      assert(0);
+      ceph_abort();
   }
 
   int get_len() const
   {
       // This class is not a serializer: this doens't make sense
-      assert(0);
+      ceph_abort();
       return 0;
   }
 
   void write_raw_data(const char *data)
   {
       // This class is not a serializer: this doens't make sense
-      assert(0);
+      ceph_abort();
   }
 
   PyObject *get()

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -89,7 +89,7 @@ ceph_send_command(PyObject *self, PyObject *args)
 
   auto set_fn = PyObject_GetAttrString(completion, "complete");
   if (set_fn == nullptr) {
-    assert(0);  // TODO raise python exception instead
+    ceph_abort();  // TODO raise python exception instead
   } else {
     assert(PyCallable_Check(set_fn));
   }

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -291,7 +291,7 @@ bool AuthMonitor::preprocess_query(MonOpRequestRef op)
     return false;
 
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -308,7 +308,7 @@ bool AuthMonitor::prepare_update(MonOpRequestRef op)
   case CEPH_MSG_AUTH:
     return prep_auth(op, true);
   default:
-    assert(0);
+    ceph_abort();
     return false;
   }
 }

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -549,13 +549,13 @@ void Elector::dispatch(MonOpRequestRef op)
 	handle_nak(op);
 	return;
       default:
-	assert(0);
+	ceph_abort();
       }
     }
     break;
     
   default: 
-    assert(0);
+    ceph_abort();
   }
 }
 

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -259,7 +259,7 @@ bool LogMonitor::preprocess_query(MonOpRequestRef op)
     return preprocess_log(op);
 
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -275,7 +275,7 @@ bool LogMonitor::prepare_update(MonOpRequestRef op)
   case MSG_LOG:
     return prepare_log(op);
   default:
-    assert(0);
+    ceph_abort();
     return false;
   }
 }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -274,7 +274,7 @@ bool MDSMonitor::preprocess_query(MonOpRequestRef op)
     return preprocess_offload_targets(op);
 
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -474,7 +474,7 @@ bool MDSMonitor::prepare_update(MonOpRequestRef op)
     return prepare_offload_targets(op);
   
   default:
-    assert(0);
+    ceph_abort();
   }
 
   return true;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -290,7 +290,7 @@ class MonitorDBStore
 	break;
       default:
 	derr << __func__ << " unknown op type " << op.type << dendl;
-	ceph_assert(0);
+	ceph_abort();
 	break;
       }
     }

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -183,7 +183,7 @@ bool MonmapMonitor::preprocess_query(MonOpRequestRef op)
   case MSG_MON_JOIN:
     return preprocess_join(op);
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -311,7 +311,7 @@ bool MonmapMonitor::prepare_update(MonOpRequestRef op)
   case MSG_MON_JOIN:
     return prepare_join(op);
   default:
-    assert(0);
+    ceph_abort();
   }
 
   return false;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1423,7 +1423,7 @@ bool OSDMonitor::preprocess_query(MonOpRequestRef op)
     return preprocess_remove_snaps(op);
 
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -1457,7 +1457,7 @@ bool OSDMonitor::prepare_update(MonOpRequestRef op)
     return prepare_remove_snaps(op);
 
   default:
-    assert(0);
+    ceph_abort();
   }
 
   return false;
@@ -2641,7 +2641,7 @@ MOSDMap *OSDMonitor::build_incremental(epoch_t from, epoch_t to)
 	       << bl.length() << " bytes" << dendl;
       m->maps[e] = bl;
       } else {
-	assert(0);  // we should have all maps.
+	ceph_abort();  // we should have all maps.
       }
     }
   }
@@ -8041,7 +8041,7 @@ bool OSDMonitor::preprocess_pool_op(MonOpRequestRef op)
   case POOL_OP_AUID_CHANGE:
     return false;
   default:
-    assert(0);
+    ceph_abort();
     break;
   }
 
@@ -8199,7 +8199,7 @@ bool OSDMonitor::prepare_pool_op(MonOpRequestRef op)
     break;
 
   default:
-    assert(0);
+    ceph_abort();
     break;
   }
 

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -583,7 +583,7 @@ bool PGMonitor::preprocess_query(MonOpRequestRef op)
 
 
   default:
-    assert(0);
+    ceph_abort();
     return true;
   }
 }
@@ -601,7 +601,7 @@ bool PGMonitor::prepare_update(MonOpRequestRef op)
     return prepare_command(op);
 
   default:
-    assert(0);
+    ceph_abort();
     return false;
   }
 }
@@ -1540,7 +1540,7 @@ static void note_stuck_detail(int what,
       whatname = "stale";
       break;
     default:
-      assert(0);
+      ceph_abort();
     }
     ss << "pg " << p->first << " is stuck " << whatname;
     if (since == utime_t()) {

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -900,7 +900,7 @@ void Paxos::commit_start()
   else if (is_updating())
     state = STATE_WRITING;
   else
-    assert(0);
+    ceph_abort();
 
   if (mon->get_quorum().size() > 1) {
     // cancel timeout event
@@ -982,7 +982,7 @@ void Paxos::handle_commit(MonOpRequestRef op)
 
   if (!mon->is_peon()) {
     dout(10) << "not a peon, dropping" << dendl;
-    assert(0);
+    ceph_abort();
     return;
   }
 
@@ -1465,13 +1465,13 @@ void Paxos::dispatch(MonOpRequestRef op)
 	handle_lease_ack(op);
 	break;
       default:
-	assert(0);
+	ceph_abort();
       }
     }
     break;
     
   default:
-    assert(0);
+    ceph_abort();
   }
 }
 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -40,7 +40,7 @@ inline const char *get_paxos_name(int p) {
   case PAXOS_LOG: return "logm";
   case PAXOS_AUTH: return "auth";
   case PAXOS_MGR: return "mgr";
-  default: assert(0); return 0;
+  default: ceph_abort(); return 0;
   }
 }
 

--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -185,7 +185,7 @@ void DispatchQueue::entry()
 	  msgr->ms_deliver_handle_refused(qitem.get_connection());
 	  break;
 	default:
-	  assert(0);
+	  ceph_abort();
 	}
       } else {
 	Message *m = qitem.get_message();

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -73,7 +73,7 @@ public:
    *
    * @param m The Message to fast dispatch.
    */
-  virtual void ms_fast_dispatch(Message *m) { assert(0); }
+  virtual void ms_fast_dispatch(Message *m) { ceph_abort(); }
   /**
    * Let the Dispatcher preview a Message before it is dispatched. This
    * function is called on *every* Message, prior to the fast/regular dispatch

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -764,7 +764,7 @@ Message *decode_message(CephContext *cct, int crcflags,
     if (cct) {
       ldout(cct, 0) << "can't decode unknown message type " << type << " MSG_AUTH=" << CEPH_MSG_AUTH << dendl;
       if (cct->_conf->ms_die_on_bad_msg)
-	assert(0);
+	ceph_abort();
     }
     return 0;
   }
@@ -782,7 +782,7 @@ Message *decode_message(CephContext *cct, int crcflags,
 		    << " because compat_version " << header.compat_version
 		    << " > supported version " << m->get_header().version << dendl;
       if (cct->_conf->ms_die_on_bad_msg)
-	assert(0);
+	ceph_abort();
     }
     m->put();
     return 0;
@@ -806,7 +806,7 @@ Message *decode_message(CephContext *cct, int crcflags,
       m->get_payload().hexdump(*_dout);
       *_dout << dendl;
       if (cct->_conf->ms_die_on_bad_msg)
-	assert(0);
+	ceph_abort();
     }
     m->put();
     return 0;

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -565,7 +565,7 @@ public:
 	return;
       }
     }
-    assert(0);
+    ceph_abort();
   }
   /**
    *
@@ -580,7 +580,7 @@ public:
   /**
    *  Deliver a single Message. Send it to each Dispatcher
    *  in sequence until one of them handles it.
-   *  If none of our Dispatchers can handle it, assert(0).
+   *  If none of our Dispatchers can handle it, ceph_abort().
    *
    *  @param m The Message to deliver. We take ownership of
    *  one reference to it.

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1348,7 +1348,7 @@ ssize_t AsyncConnection::_process_connection()
     default:
       {
         lderr(async_msgr->cct) << __func__ << " bad state: " << state << dendl;
-        assert(0);
+        ceph_abort();
       }
   }
 
@@ -1624,7 +1624,7 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
     existing = NULL;
     goto open;
   }
-  assert(0);
+  ceph_abort();
 
  replace:
   ldout(async_msgr->cct, 10) << __func__ << " accept replacing " << existing << dendl;
@@ -1695,7 +1695,7 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
           cs.close();
           return ;
         } else {
-          assert(0);
+          ceph_abort();
         }
       }
 

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -323,7 +323,7 @@ void EventCenter::wakeup()
   int n = write(notify_send_fd, &buf, sizeof(buf));
   if (n < 0) {
     ldout(cct, 1) << __func__ << " write notify pipe failed: " << cpp_strerror(errno) << dendl;
-    assert(0);
+    ceph_abort();
   }
 }
 

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -313,7 +313,7 @@ struct entity_addr_t {
       u.sin6.sin6_port = htons(port);
       break;
     default:
-      assert(0);
+      ceph_abort();
     }
   }
   int get_port() const {

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -677,7 +677,7 @@ int Pipe::accept()
       existing = NULL;
       goto open;
     }
-    assert(0);
+    ceph_abort();
 
   retry_session:
     assert(existing->pipe_lock.is_locked());

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -379,18 +379,18 @@ int64_t BitMapZone::get_used_blocks()
 
 bool BitMapZone::reserve_blocks(int64_t num_blocks)
 {
-  alloc_assert(0);
+  ceph_abort();
   return false;
 }
 
 void BitMapZone::unreserve(int64_t num_blocks, int64_t allocated)
 {
-  alloc_assert(0);
+  ceph_abort();
 }
 
 int64_t BitMapZone::get_reserved_blocks()
 {
-  alloc_assert(0);
+  ceph_abort();
   return 0;
 }
 
@@ -1264,16 +1264,16 @@ void BitAllocator::init_check(int64_t total_blocks, int64_t zone_size_block,
   int64_t unaligned_blocks = 0;
 
   if (mode != SERIAL && mode != CONCURRENT) {
-    alloc_assert(0);
+    ceph_abort();
   }
 
   if (total_blocks <= 0) {
-    alloc_assert(0);
+    ceph_abort();
   }
 
   if (zone_size_block == 0 ||
     zone_size_block < BmapEntry::size()) {
-    alloc_assert(0);
+    ceph_abort();
   }
 
   zone_size_block = (zone_size_block / BmapEntry::size()) *
@@ -1462,7 +1462,7 @@ int64_t BitAllocator::alloc_blocks(int64_t num_blocks, int64_t hint, int64_t *st
 
   *start_block = 0;
   if (!check_input(num_blocks)) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
 

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -206,24 +206,24 @@ public:
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks) = 0;
   virtual bool is_exhausted() = 0;
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required) {
-      alloc_assert(0);
+      ceph_abort();
       return true;
   }
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock) {
-      alloc_assert(0);
+      ceph_abort();
       return true;
   }
   virtual void child_unlock(BitMapArea *child) {
-    alloc_assert(0);
+    ceph_abort();
   }
 
   virtual void lock_excl() = 0;
   virtual bool lock_excl_try() {
-    alloc_assert(0);
+    ceph_abort();
     return false;
   }
   virtual void lock_shared() {
-    alloc_assert(0);
+    ceph_abort();
     return;
   }
   virtual void unlock() = 0;
@@ -238,22 +238,22 @@ public:
   virtual void shutdown() = 0;
   virtual int64_t alloc_blocks(bool wait, int64_t num_blocks,
                                int64_t hint, int64_t *start_block) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
   virtual int64_t alloc_blocks(int64_t num_blocks, int64_t hint, int64_t *start_block) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
 
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
              int64_t hint, int64_t blk_off, ExtentList *block_list) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
   virtual int64_t alloc_blocks_dis(int64_t num_blocks,
              int64_t hint, int64_t blk_off, ExtentList *block_list) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
   virtual void set_blocks_used(int64_t start_block, int64_t num_blocks) = 0;
@@ -364,13 +364,13 @@ public:
 
   virtual int64_t alloc_blocks(bool wait, int64_t num_blocks,
                                int64_t hint, int64_t *start_block) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
 
   virtual int64_t alloc_blocks_dis(bool wait, int64_t num_blocks,
              int64_t hint, int64_t blk_off, int64_t *block_list) {
-    alloc_assert(0);
+    ceph_abort();
     return 0;
   }
 
@@ -400,7 +400,7 @@ protected:
   virtual bool is_exhausted();
   
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock) {
-    alloc_assert(0);
+    ceph_abort();
     return false;
   }
 
@@ -474,7 +474,7 @@ public:
   BitMapAreaLeaf(int64_t zone_num, int64_t total_blocks, bool def);
 
   bool child_check_n_lock(BitMapArea *child, int64_t required) {
-    alloc_assert(0);
+    ceph_abort();
     return false;
   }
 

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -66,7 +66,7 @@ BlockDevice *BlockDevice::create(const string& path, aio_callback_t cb, void *cb
 #endif
 
   derr << __func__ << " unknown backend " << type << dendl;
-  assert(0);
+  ceph_abort();
   return NULL;
 }
 

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -501,7 +501,7 @@ rocksdb::Status BlueRocksEnv::LinkFile(
   const std::string& src,
   const std::string& target)
 {
-  assert(0);
+  ceph_abort();
 }
 
 rocksdb::Status BlueRocksEnv::LockFile(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2362,7 +2362,7 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
     if (!oid.match(cnode.bits, pgid.ps())) {
       derr << __func__ << " oid " << oid << " not part of " << pgid
 	   << " bits " << cnode.bits << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -7235,7 +7235,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 
     default:
       derr << __func__ << "bad op " << op->op << dendl;
-      assert(0);
+      ceph_abort();
     }
 
   endop:

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -209,7 +209,7 @@ int KernelDevice::flush()
   if (r < 0) {
     r = -errno;
     derr << __func__ << " fdatasync got: " << cpp_strerror(r) << dendl;
-    assert(0);
+    ceph_abort();
   }
   dout(5) << __func__ << " in " << dur << dendl;;
   return r;
@@ -327,7 +327,7 @@ void KernelDevice::_aio_log_start(
 	   << std::hex
 	   << offset << "~" << length << std::dec
 	   << " with " << debug_inflight << dendl;
-      assert(0);
+      ceph_abort();
     }
     debug_inflight.insert(offset, length);
   }

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -370,7 +370,7 @@ void SharedDriverData::_aio_thread()
 {
   dout(1) << __func__ << " start" << dendl;
   if (spdk_nvme_register_io_thread() != 0) {
-    assert(0);
+    ceph_abort();
   }
 
   if (data_buf_mempool.empty()) {
@@ -421,7 +421,7 @@ void SharedDriverData::_aio_thread()
             t->ctx->nvme_task_first = t->ctx->nvme_task_last = nullptr;
             delete t;
             derr << __func__ << " failed to do write command" << dendl;
-            assert(0);
+            ceph_abort();
           }
           cur = ceph::coarse_real_clock::now(g_ceph_context);
           auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);
@@ -550,7 +550,7 @@ class NVMEManager {
     ns = spdk_nvme_ctrlr_get_ns(c, 1);
     if (!ns) {
       derr << __func__ << " failed to get namespace at 1" << dendl;
-      assert(0);
+      ceph_abort();
     }
     dout(1) << __func__ << " successfully attach nvme device at" << name
             << " " << spdk_pci_device_get_bus(pci_dev) << ":" << spdk_pci_device_get_dev(pci_dev) << ":" << spdk_pci_device_get_func(pci_dev) << dendl;
@@ -652,7 +652,7 @@ int NVMEManager::try_get(const string &sn_tag, SharedDriverData **driver)
         int r = rte_eal_init(sizeof(ealargs) / sizeof(ealargs[0]), (char **)(void *)(uintptr_t)ealargs);
         if (r < 0) {
           derr << __func__ << " failed to do rte_eal_init" << dendl;
-          assert(0);
+          ceph_abort();
         }
 
         request_mempool = rte_mempool_create("nvme_request", 512,
@@ -661,7 +661,7 @@ int NVMEManager::try_get(const string &sn_tag, SharedDriverData **driver)
                                              SOCKET_ID_ANY, 0);
         if (request_mempool == NULL) {
           derr << __func__ << " failed to create memory pool for nvme requests" << dendl;
-          assert(0);
+          ceph_abort();
         }
 
         pci_system_init();

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -159,7 +159,7 @@ protected:
     uint32_t match,                             //< [in] value to match
     uint32_t bits,                              //< [in] bits to check
     CollectionIndex* dest  //< [in] destination index
-    ) { assert(0); return 0; }
+    ) { ceph_abort(); return 0; }
 
 
   /// List contents of collection by hash
@@ -188,9 +188,9 @@ protected:
   virtual int pre_hash_collection(
       uint32_t pg_num,            ///< [in] pg number of the pool this collection belongs to
       uint64_t expected_num_objs  ///< [in] expected number of objects this collection has
-      ) { assert(0); return 0; }
+      ) { ceph_abort(); return 0; }
 
-  virtual int apply_layout_settings() { assert(0); return 0; }
+  virtual int apply_layout_settings() { ceph_abort(); return 0; }
 
   /// Virtual destructor
   virtual ~CollectionIndex() {}

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -234,7 +234,7 @@ int DBObjectMap::DBObjectMapIteratorImpl::init()
   if (header->parent) {
     Header parent = map->lookup_parent(header);
     if (!parent) {
-      assert(0);
+      ceph_abort();
       return -EINVAL;
     }
     parent_iter = std::make_shared<DBObjectMapIteratorImpl>(map, parent);
@@ -1141,11 +1141,11 @@ DBObjectMap::Header DBObjectMap::lookup_parent(Header input)
        << " for seq " << input->seq << dendl;
   int r = db->get(sys_parent_prefix(input), keys, &out);
   if (r < 0) {
-    assert(0);
+    ceph_abort();
     return Header();
   }
   if (out.empty()) {
-    assert(0);
+    ceph_abort();
     return Header();
   }
 

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -349,9 +349,9 @@ private:
     int upper_bound(const string &after) { return 0; }
     int lower_bound(const string &to) { return 0; }
     bool valid() { return false; }
-    int next(bool validate=true) { assert(0); return 0; }
-    string key() { assert(0); return ""; }
-    bufferlist value() { assert(0); return bufferlist(); }
+    int next(bool validate=true) { ceph_abort(); return 0; }
+    string key() { ceph_abort(); return ""; }
+    bufferlist value() { ceph_abort(); return bufferlist(); }
     int status() { return 0; }
   };
 

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1958,7 +1958,7 @@ bool FileJournal::read_entry(
 	*corrupt = true;
       return false;
     } else {
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -2081,14 +2081,14 @@ void FileJournal::get_header(
       0,
       h);
     if (result == FAILURE || result == MAYBE_CORRUPT)
-      assert(0);
+      ceph_abort();
     if (seq == wanted_seq) {
       if (_pos)
 	*_pos = pos;
       return;
     }
   }
-  assert(0); // not reachable
+  ceph_abort(); // not reachable
 }
 
 void FileJournal::corrupt(

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2122,7 +2122,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
 			       new C_JournaledAhead(this, osr, o, ondisk),
 			       osd_op);
     } else {
-      assert(0);
+      ceph_abort();
     }
     submit_manager.op_submit_finish(op_num);
     utime_t end = ceph_clock_now(g_ceph_context);
@@ -2933,7 +2933,7 @@ void FileStore::_do_transaction(
 
     default:
       derr << "bad op " << op->op << dendl;
-      assert(0);
+      ceph_abort();
     }
 
     if (r < 0) {
@@ -3858,7 +3858,7 @@ void FileStore::sync_entry()
       stringstream errstream;
       if (g_conf->filestore_debug_omap_check && !object_map->check(errstream)) {
 	derr << errstream.str() << dendl;
-	assert(0);
+	ceph_abort();
       }
 
       if (backend->can_checkpoint()) {
@@ -4045,7 +4045,7 @@ void FileStore::flush()
     lock.Lock();
     while (true)
       cond.Wait(lock);
-    assert(0);
+    ceph_abort();
   }
 
   if (m_filestore_journal_writeahead) {

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -382,7 +382,7 @@ private:
       return true;
     }
     void _dequeue(OpSequencer *o) {
-      assert(0);
+      ceph_abort();
     }
     bool _empty() {
       return store->op_queue.empty();

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -33,7 +33,7 @@ int hex_to_int(char c)
     return c - '0';
   if (c >= 'A' && c <= 'F')
     return c - 'A' + 10;
-  assert(0);
+  ceph_abort();
 }
 
 /// int value to hex digit

--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -104,7 +104,7 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
 				   g_conf->filestore_split_multiple, version);
       return 0;
     }
-    default: assert(0);
+    default: ceph_abort();
     }
 
   } else {

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -823,7 +823,7 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
       }
     }
   }
-  assert(0); // Unreachable
+  ceph_abort(); // Unreachable
   return 0;
 }
 
@@ -1009,7 +1009,7 @@ static int parse_object(const char *s, ghobject_t& o)
 	  *t++ = '_';
 	  break;
 	}
-	default: assert(0);
+	default: ceph_abort();
 	}
       } else {
 	*t++ = *i;

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -66,7 +66,7 @@
     } catch (RetryException) {			\
       failed = true;				\
     } catch (...) {				\
-      assert(0);				\
+      ceph_abort();				\
     }						\
   }						\
   return -1;					\

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -577,7 +577,7 @@ KStore::OnodeRef KStore::Collection::get_onode(
     if (!oid.match(cnode.bits, pgid.ps())) {
       derr << __func__ << " oid " << oid << " not part of " << pgid
 	   << " bits " << cnode.bits << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -2480,7 +2480,7 @@ void KStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 
     default:
       derr << "bad op " << op->op << dendl;
-      assert(0);
+      ceph_abort();
     }
 
   endop:

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -1008,7 +1008,7 @@ void MemStore::_do_transaction(Transaction& t)
 
     default:
       derr << "bad op " << op->op << dendl;
-      assert(0);
+      ceph_abort();
     }
 
     if (r < 0) {

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -658,7 +658,7 @@ void ECBackend::continue_recovery_op(
     // should never be called once complete
     case RecoveryOp::COMPLETE:
     default: {
-      assert(0);
+      ceph_abort();
     };
     }
   }
@@ -1716,7 +1716,7 @@ void ECBackend::start_rmw(Op *op, PGTransactionUPtr &&t)
 	     << " returned a null pointer and there is no "
 	     << " way to recover from such an error in this "
 	     << " context" << dendl;
-	assert(0);
+	ceph_abort();
       }
       return ref;
     },
@@ -1860,7 +1860,7 @@ bool ECBackend::try_reads_to_commit()
       if (i.requires_kraken()) {
 	derr << __func__ << ": log entry " << i << " requires kraken"
 	     << " but overwrites are not enabled!" << dendl;
-	assert(0);
+	ceph_abort();
       }
     }
   }

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -272,7 +272,7 @@ private:
 	return "COMPLETE";
 	break;
       default:
-	assert(0);
+	ceph_abort();
 	return "";
       }
     }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2803,7 +2803,7 @@ int OSD::shutdown()
 #ifdef PG_DEBUG_REFS
 	p->second->dump_live_ids();
 #endif
-        assert(0);
+        ceph_abort();
       }
       p->second->unlock();
       p->second->put("PGMap");
@@ -3033,7 +3033,7 @@ void OSD::recursive_remove_collection(ObjectStore *store, spg_t pgid, coll_t tmp
     OSDriver::OSTransaction _t(driver.get_transaction(&t));
     int r = mapper.remove_oid(p->hobj, &_t);
     if (r != 0 && r != -ENOENT)
-      assert(0);
+      ceph_abort();
     t.remove(tmp, *p);
     if (removed > g_conf->osd_target_transaction_size) {
       int r = store->apply_transaction(osr.get(), std::move(t));
@@ -3061,7 +3061,7 @@ PGPool OSD::_get_pool(int id, OSDMapRef createmap)
   if (!createmap->have_pg_pool(id)) {
     dout(5) << __func__ << ": the OSDmap does not contain a PG pool with id = "
 	    << id << dendl;
-    assert(0);
+    ceph_abort();
   }
 
   PGPool p = PGPool(createmap, id);
@@ -3100,7 +3100,7 @@ PG* OSD::_make_pg(
       createmap->get_pg_type(pgid.pgid) == pg_pool_t::TYPE_ERASURE)
     pg = new ReplicatedPG(&service, createmap, pool, pgid);
   else
-    assert(0);
+    ceph_abort();
 
   return pg;
 }
@@ -3411,7 +3411,7 @@ void OSD::load_pgs()
     if (r != 0) {
       derr << __func__ << ": apply_transaction returned "
 	   << cpp_strerror(r) << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -3619,7 +3619,7 @@ void OSD::handle_pg_peering_evt(
     }
 
     if (service.splitting(pgid)) {
-      assert(0);
+      ceph_abort();
     }
 
     // do we need to resurrect a deleting pg?
@@ -4678,7 +4678,7 @@ bool remove_dir(
     OSDriver::OSTransaction _t(osdriver->get_transaction(&t));
     int r = mapper->remove_oid(i->hobj, &_t);
     if (r != 0 && r != -ENOENT) {
-      assert(0);
+      ceph_abort();
     }
     t.remove(coll, *i);
     if (++num >= cct->_conf->osd_target_transaction_size) {
@@ -6232,7 +6232,7 @@ epoch_t op_required_epoch(OpRequestRef op)
       MOSDPGUpdateLogMissingReply, MSG_OSD_PG_UPDATE_LOG_MISSING_REPLY>(
       op);
   default:
-    assert(0);
+    ceph_abort();
     return 0;
   }
 }
@@ -6357,7 +6357,7 @@ bool OSD::dispatch_op_fast(OpRequestRef& op, OSDMapRef& osdmap)
       op, osdmap);
     break;
   default:
-    assert(0);
+    ceph_abort();
   }
   return true;
 }
@@ -8115,7 +8115,7 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 	m->query_epoch,
 	PG::RemoteReservationRejected()));
   } else {
-    assert(0);
+    ceph_abort();
   }
 
   if (service.splitting(m->pgid)) {
@@ -8163,7 +8163,7 @@ void OSD::handle_pg_recovery_reserve(OpRequestRef op)
 	m->query_epoch,
 	PG::RecoveryDone()));
   } else {
-    assert(0);
+    ceph_abort();
   }
 
   if (service.splitting(m->pgid)) {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2278,7 +2278,7 @@ protected:
       return true;
     }
     void _dequeue(Command *pg) override {
-      assert(0);
+      ceph_abort();
     }
     Command *_dequeue() override {
       if (osd->command_queue.empty())
@@ -2346,7 +2346,7 @@ protected:
       remove_queue.push_front(item);
     }
     bool _dequeue(pair<PGRef, DeletingStateRef> item) {
-      assert(0);
+      ceph_abort();
     }
     pair<PGRef, DeletingStateRef> _dequeue() override {
       assert(!remove_queue.empty());

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -408,7 +408,7 @@ void PG::clear_object_snap_mapping(
       &_t);
     if (!(r == 0 || r == -ENOENT)) {
       derr << __func__ << ": remove_oid returned " << cpp_strerror(r) << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 }
@@ -423,7 +423,7 @@ void PG::update_object_snap_mapping(
     &_t);
   if (!(r == 0 || r == -ENOENT)) {
     derr << __func__ << ": remove_oid returned " << cpp_strerror(r) << dendl;
-    assert(0);
+    ceph_abort();
   }
   snap_mapper.add_oid(
     soid,
@@ -2785,7 +2785,7 @@ void PG::upgrade(ObjectStore *store)
   if (r != 0) {
     derr << __func__ << ": apply_transaction returned "
 	 << cpp_strerror(r) << dendl;
-    assert(0);
+    ceph_abort();
   }
   assert(r == 0);
 
@@ -3763,7 +3763,7 @@ void PG::_scan_snaps(ScrubMap &smap)
       int r = snap_mapper.get_snaps(hoid, &cur_snaps);
       if (r != 0 && r != -ENOENT) {
 	derr << __func__ << ": get_snaps returned " << cpp_strerror(r) << dendl;
-	assert(0);
+	ceph_abort();
       }
       if (r == -ENOENT || cur_snaps != oi_snaps) {
 	ObjectStore::Transaction t;
@@ -3773,7 +3773,7 @@ void PG::_scan_snaps(ScrubMap &smap)
 	  if (r != 0) {
 	    derr << __func__ << ": remove_oid returned " << cpp_strerror(r)
 		 << dendl;
-	    assert(0);
+	    ceph_abort();
 	  }
 	  osd->clog->error() << "osd." << osd->whoami
 			    << " found snap mapper error on pg "
@@ -4349,7 +4349,7 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
         break;
 
       default:
-        assert(0);
+        ceph_abort();
     }
   }
 }
@@ -5252,14 +5252,14 @@ void PG::proc_primary_info(ObjectStore::Transaction &t, const pg_info_t &oinfo)
 	    if (r != 0 && r != -ENOENT) {
 	      derr << __func__ << ": snap_mapper get_next_object_to_trim returned "
 		   << cpp_strerror(r) << dendl;
-	      assert(0);
+	      ceph_abort();
 	    } else if (r != -ENOENT) {
 	      assert(!hoids.empty());
 	      derr << __func__ << ": snap_mapper get_next_object_to_trim returned "
 		   << cpp_strerror(r) << " for object "
 		   << hoids[0] << " on snap " << snap
 		   << " which should have been fully trimmed " << dendl;
-	      assert(0);
+	      ceph_abort();
 	    }
 	  }
 	}
@@ -5571,7 +5571,7 @@ bool PG::op_must_wait_for_map(epoch_t cur_epoch, OpRequestRef& op)
       cur_epoch,
       static_cast<MOSDPGUpdateLogMissingReply*>(op->get_req())->map_epoch);
   }
-  assert(0);
+  ceph_abort();
   return false;
 }
 
@@ -6675,7 +6675,7 @@ PG::RecoveryState::Clean::Clean(my_context ctx)
   PG *pg = context< RecoveryMachine >().pg;
 
   if (pg->info.last_complete != pg->info.last_update) {
-    assert(0);
+    ceph_abort();
   }
   pg->finish_recovery(*context< RecoveryMachine >().get_on_safe_context_list());
   pg->mark_clean();

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -424,7 +424,7 @@ PGBackend *PGBackend::build_pg_backend(
       pool.stripe_width);
   }
   default:
-    assert(0);
+    ceph_abort();
     return NULL;
   }
 }
@@ -478,7 +478,7 @@ void PGBackend::be_scan_list(
       o.stat_error = true;
     } else {
       derr << __func__ << " got: " << cpp_strerror(r) << dendl;
-      assert(0);
+      ceph_abort();
     }
   }
 }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1192,7 +1192,7 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
 	static_cast<MOSDRepOp*>(m), parent->whoami_shard(),
 	0, get_osdmap()->get_epoch(), CEPH_OSD_FLAG_ACK);
   } else {
-    assert(0);
+    ceph_abort();
   }
 
   // send ack to acker only if we haven't sent a commit already
@@ -1237,7 +1237,7 @@ void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
     commit = reply;
   }
   else {
-    assert(0);
+    ceph_abort();
   }
 
   commit->set_priority(CEPH_MSG_PRIO_HIGH); // this better match ack priority!

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2219,7 +2219,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 	  src_obc[clone_oid] = sobc;
 	  continue;
 	}
-	assert(0); // unreachable
+	ceph_abort(); // unreachable
       } else {
 	continue;
       }
@@ -3373,7 +3373,7 @@ void ReplicatedPG::log_op_stats(OpContext *ctx)
     if (rlatency != utime_t())
       osd->logger->tinc(l_osd_op_w_rlat, rlatency);
   } else
-    assert(0);
+    ceph_abort();
 
   dout(15) << "log_op_stats " << *m
 	   << " inb " << inb
@@ -3572,7 +3572,7 @@ ReplicatedPG::OpContextUPtr ReplicatedPG::trim_object(bool first, const hobject_
   ObjectContextRef obc = get_object_context(coid, false, NULL);
   if (!obc) {
     derr << __func__ << " could not find coid " << coid << dendl;
-    assert(0);
+    ceph_abort();
   }
   assert(obc->ssc);
 
@@ -9270,7 +9270,7 @@ int ReplicatedPG::find_object_context(const hobject_t& oid,
       put_snapset_context(ssc);
       return 0;
     }
-    assert(0); //unreachable
+    ceph_abort(); //unreachable
   }
 
   dout(10) << "find_object_context " << oid << " @" << oid.snap
@@ -9926,7 +9926,7 @@ void ReplicatedPG::mark_all_unfound_lost(
       break;
 
     default:
-      assert(0);
+      ceph_abort();
     }
   }
 
@@ -10707,7 +10707,7 @@ uint64_t ReplicatedPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 	  ++skipped;
 	  break;
 	default:
-	  assert(0);
+	  ceph_abort();
 	}
 	if (started >= max)
 	  break;
@@ -10822,7 +10822,7 @@ uint64_t ReplicatedPG::recover_replicas(uint64_t max, ThreadPool::TPHandle &hand
 	if (!recovering.count(soid)) {
 	  derr << __func__ << ": object added to missing set for backfill, but "
 	       << "is not in recovering, error!" << dendl;
-	  assert(0);
+	  ceph_abort();
 	}
 	continue;
       }

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -37,7 +37,7 @@ int OSDriver::get_next(
   ObjectMap::ObjectMapIterator iter =
     os->get_omap_iterator(cid, hoid);
   if (!iter) {
-    assert(0);
+    ceph_abort();
     return -EINVAL;
   }
   iter->upper_bound(key);

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -238,7 +238,7 @@ public:
   void cancel() {
     canceled = true;
   }
-  void finish(int) { assert(0); /* not used */ }
+  void finish(int) { ceph_abort(); /* not used */ }
   void complete(int) {
     dout(10) << "HandleWatchTimeout" << dendl;
     boost::intrusive_ptr<ReplicatedPG> pg(watch->pg);

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -354,7 +354,7 @@ void Journaler::_finish_probe_end(int r, uint64_t end)
     end = write_pos;
     ldout(cct, 1) << "_finish_probe_end write_pos = " << end << " (header had "
 		  << write_pos << "). log was empty. recovered." << dendl;
-    assert(0); // hrm.
+    ceph_abort(); // hrm.
   } else {
     assert(end >= write_pos);
     ldout(cct, 1) << "_finish_probe_end write_pos = " << end

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -241,7 +241,7 @@ bool ObjectCacher::Object::is_cached(loff_t cur, loff_t left) const
       // gap
       return false;
     } else
-      assert(0);
+      ceph_abort();
   }
 
   return true;
@@ -320,7 +320,7 @@ int ObjectCacher::Object::map_read(ObjectExtent &ex,
         errors[cur] = e;
         ldout(oc->cct, 20) << "map_read error " << *e << dendl;
       } else {
-        assert(0);
+        ceph_abort();
       }
       
       loff_t lenfromcur = MIN(e->end() - cur, left);
@@ -349,7 +349,7 @@ int ObjectCacher::Object::map_read(ObjectExtent &ex,
       left -= MIN(left, n->length());
       continue;    // more?
     } else {
-      assert(0);
+      ceph_abort();
     }
   }
   return 0;
@@ -2435,7 +2435,7 @@ void ObjectCacher::verify_stats() const
 	  error += bh->length();
 	  break;
 	default:
-	  assert(0);
+	  ceph_abort();
 	}
       }
     }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1838,7 +1838,7 @@ struct C_Objecter_GetVersion : public Context {
       objecter->wait_for_latest_osdmap(fin);
     } else {
       // it doesn't return any other error codes!
-      assert(0);
+      ceph_abort();
     }
   }
 };

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -831,7 +831,7 @@ void dump_bi_entry(bufferlist& bl, BIIndexType index_type, Formatter *formatter)
       }
       break;
     default:
-      assert(0);
+      ceph_abort();
       break;
   }
 }
@@ -6155,7 +6155,7 @@ next:
       if (ret < 0)
         return -ret;
     } else { // shouldn't get here
-      assert(0);
+      ceph_abort();
     }
     encode_json("bounds", bounds, formatter);
     formatter->flush(cout);

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -68,7 +68,7 @@ protected:
 
     bool _enqueue(RGWAsyncRadosRequest *req);
     void _dequeue(RGWAsyncRadosRequest *req) {
-      assert(0);
+      ceph_abort();
     }
     bool _empty();
     RGWAsyncRadosRequest *_dequeue();

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -137,7 +137,7 @@ void RGWFormatter_Plain::dump_string(const char *name, const std::string& s)
 std::ostream& RGWFormatter_Plain::dump_stream(const char *name)
 {
   // TODO: implement this!
-  assert(0);
+  ceph_abort();
 }
 
 void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool quoted, const char *fmt, va_list ap)

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -820,7 +820,7 @@ int RGWOrphanSearch::run()
       break;
 
     default:
-      assert(0);
+      ceph_abort();
   };
 
   return 0;

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -62,7 +62,7 @@ protected:
     }
 
     void _dequeue(RGWRequest* req) {
-      assert(0);
+      ceph_abort();
     }
 
     bool _empty() {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -439,7 +439,7 @@ public:
     try {
       tx_buffer_it.advance(l);
     } catch (buffer::end_of_buffer &e) {
-      assert(0);
+      ceph_abort();
     }
 
     return l;

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -491,7 +491,7 @@ public:
     string header;
     int r = get_header(*object, &header);
     if (r < 0) {
-      assert(0);
+      ceph_abort();
     }
     if (header.size() == 0) {
       if (hmap.count(*object)) {

--- a/src/test/bench/bencher.cc
+++ b/src/test/bench/bencher.cc
@@ -193,7 +193,7 @@ void Bencher::run_bench()
 	break;
       }
       default: {
-	assert(0);
+	ceph_abort();
       }
     } 
     ops++;

--- a/src/test/bench/dumb_backend.cc
+++ b/src/test/bench/dumb_backend.cc
@@ -22,7 +22,7 @@ void DumbBackend::_write(
     full_path.c_str(), O_CREAT|O_WRONLY, 0777);
   if (fd < 0) {
     std::cout << full_path << ": errno is " << errno << std::endl;
-    assert(0);
+    ceph_abort();
   }
 
   int r =  ::lseek(fd, offset, SEEK_SET);

--- a/src/test/bench/dumb_backend.h
+++ b/src/test/bench/dumb_backend.h
@@ -73,7 +73,7 @@ class DumbBackend : public Backend {
       item_queue.push_back(item);
       return true;
     }
-    void _dequeue(write_item*) { assert(0); }
+    void _dequeue(write_item*) { ceph_abort(); }
     write_item *_dequeue() {
       if (item_queue.empty())
 	return 0;

--- a/src/test/bench/tp_bench.cc
+++ b/src/test/bench/tp_bench.cc
@@ -85,7 +85,7 @@ class PassAlong : public ThreadPool::WorkQueue<unsigned> {
     q.push_back(item);
     return true;
   }
-  void _dequeue(unsigned *item) { assert(0); }
+  void _dequeue(unsigned *item) { ceph_abort(); }
   unsigned *_dequeue() {
     if (q.empty())
       return 0;

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -140,7 +140,7 @@ public:
 
   virtual int encode_chunks(const set<int> &want_to_encode,
 			    map<int, bufferlist> *encoded) {
-    assert(0);
+    ceph_abort();
     return 0;
   }
 
@@ -189,7 +189,7 @@ public:
   virtual int decode_chunks(const set<int> &want_to_read,
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded) {
-    assert(0);
+    ceph_abort();
     return 0;
   }
 

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -45,7 +45,7 @@ class ServerDispatcher : public Dispatcher {
       return true;
     }
     void _dequeue(Message *m) {
-      assert(0);
+      ceph_abort();
     }
     bool _empty() {
       return messages.empty();

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -844,7 +844,7 @@ class SyntheticDispatcher : public Dispatcher {
     cond.Signal();
   }
   bool ms_dispatch(Message *m) {
-    assert(0);
+    ceph_abort();
   }
   bool ms_handle_reset(Connection *con);
   void ms_handle_remote_reset(Connection *con) {
@@ -1432,7 +1432,7 @@ class MarkdownDispatcher : public Dispatcher {
     return false;
   }
   void ms_fast_dispatch(Message *m) {
-    assert(0);
+    ceph_abort();
   }
   bool ms_verify_authorizer(Connection *con, int peer_type, int protocol,
                             bufferlist& authorizer, bufferlist& authorizer_reply,

--- a/src/test/objectstore/FileStoreTracker.cc
+++ b/src/test/objectstore/FileStoreTracker.cc
@@ -327,7 +327,7 @@ void FileStoreTracker::verify(const coll_t &coll, const string &obj,
     }
   }
   std::cerr << "Verifying " << make_pair(coll, obj) << " failed " << std::endl;
-  assert(0);
+  ceph_abort();
 }
 
 ObjectContents FileStoreTracker::get_current_content(

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -3830,7 +3830,7 @@ public:
 	   ++p)
 	if (available_objects.count(*p) == 0) {
 	  cerr << "+ " << *p << std::endl;
-	  assert(0);
+	  ceph_abort();
 	}
       for (set<ghobject_t>::iterator p = available_objects.begin();
 	   p != available_objects.end();

--- a/src/test/on_exit.cc
+++ b/src/test/on_exit.cc
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include "include/on_exit.h"
+#include "include/assert.h"
 
 #ifndef MAP_ANONYMOUS
 # ifdef MAP_ANON
@@ -106,7 +107,7 @@ int main(int argc, char **argv)
     *new_val = EXIT_FUNC_VAL;
     exit_func_mgr.add_callback(exit_func_cb, new_val);
     call_exit();
-    assert(0);
+    ceph_abort();
   }
 
   return 0;

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -402,7 +402,7 @@ public:
 
     void seek(uint64_t _pos) {
       if (_pos < pos) {
-	assert(0);
+	ceph_abort();
       }
       while (pos < _pos) {
 	assert(cur_valid_till >= pos);

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -693,7 +693,7 @@ public:
     int r;
     if ((r = comp->get_return_value())) {
       cerr << "err " << r << std::endl;
-      assert(0);
+      ceph_abort();
     }
     done = true;
     context->update_object_version(oid, comp->get_version64());
@@ -866,7 +866,7 @@ public:
     if (tid <= last_acked_tid) {
       cerr << "Error: finished tid " << tid
 	   << " when last_acked_tid was " << last_acked_tid << std::endl;
-      assert(0);
+      ceph_abort();
     }
     last_acked_tid = tid;
 
@@ -1043,7 +1043,7 @@ public:
     if (tid <= last_acked_tid) {
       cerr << "Error: finished tid " << tid
 	   << " when last_acked_tid was " << last_acked_tid << std::endl;
-      assert(0);
+      ceph_abort();
     }
     last_acked_tid = tid;
 
@@ -1147,7 +1147,7 @@ public:
     }
     if (r && !(r == -ENOENT && !present)) {
       cerr << "r is " << r << " while deleting " << oid << " and present is " << present << std::endl;
-      assert(0);
+      ceph_abort();
     }
 
     context->state_lock.Lock();
@@ -1264,7 +1264,7 @@ public:
       int r = context->io_ctx.notify2(context->prefix+oid, bl, 0, NULL);
       if (r < 0) {
 	std::cerr << "r is " << r << std::endl;
-	assert(0);
+	ceph_abort();
       }
       std::cerr << num << ":  notified, waiting" << std::endl;
       ctx->wait();
@@ -1336,13 +1336,13 @@ public:
       if (err != retval) {
         cerr << num << ": Error: oid " << oid << " read returned different error codes: "
              << retval << " and " << err << std::endl;
-	assert(0);
+	ceph_abort();
       }
       if (err) {
         if (!(err == -ENOENT && old_value.deleted())) {
           cerr << num << ": Error: oid " << oid << " read returned error code "
                << err << std::endl;
-          assert(0);
+          ceph_abort();
         }
       } else if (version != old_value.version) {
 	cerr << num << ": oid " << oid << " version is " << version
@@ -1392,7 +1392,7 @@ public:
 	    }
 	  }
 	}
-	if (context->errors) assert(0);
+	if (context->errors) ceph_abort();
       }
 
       // Attributes
@@ -1505,7 +1505,7 @@ public:
       int ret = context->io_ctx.snap_create(snapname.c_str());
       if (ret) {
 	cerr << "snap_create returned " << ret << std::endl;
-	assert(0);
+	ceph_abort();
       }
       assert(!context->io_ctx.snap_lookup(snapname.c_str(), &snap));
 
@@ -1533,7 +1533,7 @@ public:
       int r = context->io_ctx.selfmanaged_snap_set_write_ctx(context->seq, snapset);
       if (r) {
 	cerr << "r is " << r << " snapset is " << snapset << " seq is " << context->seq << std::endl;
-	assert(0);
+	ceph_abort();
       }
     }
   }
@@ -1580,7 +1580,7 @@ public:
       int r = context->io_ctx.selfmanaged_snap_set_write_ctx(context->seq, snapset);
       if (r) {
 	cerr << "r is " << r << " snapset is " << snapset << " seq is " << context->seq << std::endl;
-	assert(0);
+	ceph_abort();
       }
     }
     context->state_lock.Unlock();
@@ -1638,7 +1638,7 @@ public:
 
     if (r) {
       cerr << "r is " << r << std::endl;
-      assert(0);
+      ceph_abort();
     }
 
     {
@@ -1767,7 +1767,7 @@ public:
     int r;
     if ((r = comps[last_finished]->get_return_value()) != 0) {
       cerr << "err " << r << std::endl;
-      assert(0);
+      ceph_abort();
     }
     if (--outstanding == 0) {
       done = true;
@@ -1878,7 +1878,7 @@ public:
 	} else {
 	  cerr << "Error: oid " << oid << " copy_from " << oid_src << " returned error code "
 	       << r << std::endl;
-	  assert(0);
+	  ceph_abort();
 	}
       } else {
 	assert(!version || comp->get_version64() == version);

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -236,7 +236,7 @@ private:
 
     default:
       cerr << m_op << ": Invalid op type " << type << std::endl;
-      assert(0);
+      ceph_abort();
       return nullptr;
     }
   }

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -28,7 +28,7 @@ struct Foo : public Thread {
     dout(0) << "foo started" << dendl;
     sleep(1);
     dout(0) << "foo asserting 0" << dendl;
-    assert(0);
+    ceph_abort();
   }
 } foo;
 

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -457,7 +457,7 @@ int main(int argc, const char **argv)
 	    if (m.count(pgid)) {
 	      if (m[pgid] != r) {
 		cout << pgid << " had " << m[pgid] << " now " << r << std::endl;
-		assert(0);
+		ceph_abort();
 	      }
 	    } else
 	      m[pgid] = r;

--- a/src/tools/rebuild_mondb.cc
+++ b/src/tools/rebuild_mondb.cc
@@ -187,7 +187,7 @@ int update_monitor(const OSDSuperblock& sb, MonitorDBStore& ms)
   case 0:
     return 0;
   default:
-    assert(0);
+    ceph_abort();
   }
   string uuid = stringify(sb.cluster_fsid) + "\n";
   bufferlist bl;


### PR DESCRIPTION
This converts all assert(0) instances. We still need to fix assert(0 == "something") callers.