### PR TITLE
common/WorkQueue: Add a function in treadpool for draining a given work queue

### DIFF
--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -530,11 +530,6 @@ public:
    * If it is not NULL, blocks until the given work queue does not have
    * any items left to process. */
   void drain(WorkQueue_* wq = 0);
-  /** @brief Wait until work completes, extend for drain.
-   * If the parameter is NULL, blocks until all threads are idle.
-   * If it is not NULL, blocks until the given work queue has all
-   * the items completely processed. */
-  void drain2(WorkQueue_* wq = 0);
 
   /// set io priority
   void set_ioprio(int cls, int priority);

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -435,6 +435,7 @@ public:
 private:
   vector<WorkQueue_*> work_queues;
   int last_work_queue;
+  map<WorkQueue_*, int> _wq_processing; ///Store processing count for each wq
  
 
   // threads
@@ -470,6 +471,7 @@ public:
   void add_work_queue(WorkQueue_* wq) {
     Mutex::Locker l(_lock);
     work_queues.push_back(wq);
+    _wq_processing[wq] = 0;
   }
   /// remove a work queue from this thread pool
   void remove_work_queue(WorkQueue_* wq) {
@@ -481,6 +483,9 @@ public:
       work_queues[i-1] = work_queues[i];
     assert(i == work_queues.size());
     work_queues.resize(i-1);
+    auto ret = _wq_processing.find(wq);
+    if (ret != _wq_processing.end())
+      _wq_processing.erase(ret);
   }
 
   /// take thread pool lock
@@ -525,6 +530,11 @@ public:
    * If it is not NULL, blocks until the given work queue does not have
    * any items left to process. */
   void drain(WorkQueue_* wq = 0);
+  /** @brief Wait until work completes, extend for drain.
+   * If the parameter is NULL, blocks until all threads are idle.
+   * If it is not NULL, blocks until the given work queue has all
+   * the items completely processed. */
+  void drain2(WorkQueue_* wq = 0);
 
   /// set io priority
   void set_ioprio(int cls, int priority);


### PR DESCRIPTION
The function threadpool::drain(wq) drains work queues. As the code comments say: If the parameter(wq) is not NULL, blocks until the given work queue does not have any items left to process. The threadpool , however,  blocks until all threads are idle, even if the given wq is empty. A new function -drain2(wq)- added in threadpool can drain a given wq. It implements the same action with drain(wq) when wq is NULL.

Signed-off-by: jinweiyi <jinweiyi@cmss.chinamobile.com>