### PR TITLE
os/bluestore: fix latency calculation

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -48,6 +48,14 @@
   mon automatically marked and OSD out and then in, but not when an
   admin did so explicitly.
 
+* The 'ceph osd perf' command will display 'commit_latency(ms)' and 
+  'apply_latency(ms)'. Previously, the names of these two columns are 
+  'fs_commit_latency(ms)' and 'fs_apply_latency(ms)'. We remove the prefix 
+  'fs_', because they are not filestore specific. 
+
+OSD: change the prefix from fs_* to os_*, because commit_latency and …
+…apply_latency will be used not only for filestore.
+
 11.0.0
 ------
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1120,7 +1120,7 @@ void PGMap::dump_osd_perf_stats(Formatter *f) const
     f->dump_int("id", i->first);
     {
       f->open_object_section("perf_stats");
-      i->second.fs_perf_stat.dump(f);
+      i->second.os_perf_stat.dump(f);
       f->close_section();
     }
     f->close_section();
@@ -1131,14 +1131,14 @@ void PGMap::print_osd_perf_stats(std::ostream *ss) const
 {
   TextTable tab;
   tab.define_column("osd", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("fs_commit_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("fs_apply_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("commit_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("apply_latency(ms)", TextTable::LEFT, TextTable::RIGHT);
   for (ceph::unordered_map<int32_t, osd_stat_t>::const_iterator i = osd_stat.begin();
        i != osd_stat.end();
        ++i) {
     tab << i->first;
-    tab << i->second.fs_perf_stat.filestore_commit_latency;
-    tab << i->second.fs_perf_stat.filestore_apply_latency;
+    tab << i->second.os_perf_stat.os_commit_latency;
+    tab << i->second.os_perf_stat.os_apply_latency;
     tab << TextTable::endrow;
   }
   (*ss) << tab;

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -129,8 +129,8 @@ public:
 
     objectstore_perf_stat_t get_cur_stats() const {
       objectstore_perf_stat_t ret;
-      ret.filestore_commit_latency = os_commit_latency.avg();
-      ret.filestore_apply_latency = os_apply_latency.avg();
+      ret.os_commit_latency = os_commit_latency.avg();
+      ret.os_apply_latency = os_apply_latency.avg();
       return ret;
     }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2208,7 +2208,7 @@ int OSD::init()
       
       utime_t had_for = ceph_clock_now(cct) - had_map_since;
       osd_stat_t cur_stat = service.get_osd_stat();
-      cur_stat.fs_perf_stat = store->get_cur_stats();
+      cur_stat.os_perf_stat = store->get_cur_stats();
 
       MPGStats *m = new MPGStats(monc->get_fsid(), osdmap->get_epoch(), had_for);
       m->osd_stat = cur_stat;
@@ -5202,7 +5202,7 @@ void OSD::send_pg_stats(const utime_t &now)
 
   osd_stat_t cur_stat = service.get_osd_stat();
 
-  cur_stat.fs_perf_stat = store->get_cur_stats();
+  cur_stat.os_perf_stat = store->get_cur_stats();
 
   pg_stat_queue_lock.Lock();
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -275,23 +275,23 @@ void request_redirect_t::generate_test_instances(list<request_redirect_t*>& o)
 
 void objectstore_perf_stat_t::dump(Formatter *f) const
 {
-  f->dump_unsigned("commit_latency_ms", filestore_commit_latency);
-  f->dump_unsigned("apply_latency_ms", filestore_apply_latency);
+  f->dump_unsigned("commit_latency_ms", os_commit_latency);
+  f->dump_unsigned("apply_latency_ms", os_apply_latency);
 }
 
 void objectstore_perf_stat_t::encode(bufferlist &bl) const
 {
   ENCODE_START(1, 1, bl);
-  ::encode(filestore_commit_latency, bl);
-  ::encode(filestore_apply_latency, bl);
+  ::encode(os_commit_latency, bl);
+  ::encode(os_apply_latency, bl);
   ENCODE_FINISH(bl);
 }
 
 void objectstore_perf_stat_t::decode(bufferlist::iterator &bl)
 {
   DECODE_START(1, bl);
-  ::decode(filestore_commit_latency, bl);
-  ::decode(filestore_apply_latency, bl);
+  ::decode(os_commit_latency, bl);
+  ::decode(os_apply_latency, bl);
   DECODE_FINISH(bl);
 }
 
@@ -299,8 +299,8 @@ void objectstore_perf_stat_t::generate_test_instances(std::list<objectstore_perf
 {
   o.push_back(new objectstore_perf_stat_t());
   o.push_back(new objectstore_perf_stat_t());
-  o.back()->filestore_commit_latency = 20;
-  o.back()->filestore_apply_latency = 30;
+  o.back()->os_commit_latency = 20;
+  o.back()->os_apply_latency = 30;
 }
 
 // -- osd_stat_t --
@@ -322,8 +322,8 @@ void osd_stat_t::dump(Formatter *f) const
   f->open_object_section("op_queue_age_hist");
   op_queue_age_hist.dump(f);
   f->close_section();
-  f->open_object_section("fs_perf_stat");
-  fs_perf_stat.dump(f);
+  f->open_object_section("perf_stat");
+  os_perf_stat.dump(f);
   f->close_section();
 }
 
@@ -338,7 +338,7 @@ void osd_stat_t::encode(bufferlist &bl) const
   ::encode(hb_in, bl);
   ::encode(hb_out, bl);
   ::encode(op_queue_age_hist, bl);
-  ::encode(fs_perf_stat, bl);
+  ::encode(os_perf_stat, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -355,7 +355,7 @@ void osd_stat_t::decode(bufferlist::iterator &bl)
   if (struct_v >= 3)
     ::decode(op_queue_age_hist, bl);
   if (struct_v >= 4)
-    ::decode(fs_perf_stat, bl);
+    ::decode(os_perf_stat, bl);
   DECODE_FINISH(bl);
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -814,24 +814,24 @@ inline ostream& operator<<(ostream& out, const eversion_t& e) {
  */
 struct objectstore_perf_stat_t {
   // cur_op_latency is in ms since double add/sub are not associative
-  uint32_t filestore_commit_latency;
-  uint32_t filestore_apply_latency;
+  uint32_t os_commit_latency;
+  uint32_t os_apply_latency;
 
   objectstore_perf_stat_t() :
-    filestore_commit_latency(0), filestore_apply_latency(0) {}
+    os_commit_latency(0), os_apply_latency(0) {}
 
   bool operator==(const objectstore_perf_stat_t &r) const {
-    return filestore_commit_latency == r.filestore_commit_latency &&
-      filestore_apply_latency == r.filestore_apply_latency;
+    return os_commit_latency == r.os_commit_latency &&
+      os_apply_latency == r.os_apply_latency;
   }
 
   void add(const objectstore_perf_stat_t &o) {
-    filestore_commit_latency += o.filestore_commit_latency;
-    filestore_apply_latency += o.filestore_apply_latency;
+    os_commit_latency += o.os_commit_latency;
+    os_apply_latency += o.os_apply_latency;
   }
   void sub(const objectstore_perf_stat_t &o) {
-    filestore_commit_latency -= o.filestore_commit_latency;
-    filestore_apply_latency -= o.filestore_apply_latency;
+    os_commit_latency -= o.os_commit_latency;
+    os_apply_latency -= o.os_apply_latency;
   }
   void dump(Formatter *f) const;
   void encode(bufferlist &bl) const;
@@ -850,7 +850,7 @@ struct osd_stat_t {
 
   pow2_hist_t op_queue_age_hist;
 
-  objectstore_perf_stat_t fs_perf_stat;
+  objectstore_perf_stat_t os_perf_stat;
 
   osd_stat_t() : kb(0), kb_used(0), kb_avail(0),
 		 snap_trim_queue_len(0), num_snap_trimming(0) {}
@@ -862,7 +862,7 @@ struct osd_stat_t {
     snap_trim_queue_len += o.snap_trim_queue_len;
     num_snap_trimming += o.num_snap_trimming;
     op_queue_age_hist.add(o.op_queue_age_hist);
-    fs_perf_stat.add(o.fs_perf_stat);
+    os_perf_stat.add(o.os_perf_stat);
   }
   void sub(const osd_stat_t& o) {
     kb -= o.kb;
@@ -871,7 +871,7 @@ struct osd_stat_t {
     snap_trim_queue_len -= o.snap_trim_queue_len;
     num_snap_trimming -= o.num_snap_trimming;
     op_queue_age_hist.sub(o.op_queue_age_hist);
-    fs_perf_stat.sub(o.fs_perf_stat);
+    os_perf_stat.sub(o.os_perf_stat);
   }
 
   void dump(Formatter *f) const;
@@ -890,7 +890,7 @@ inline bool operator==(const osd_stat_t& l, const osd_stat_t& r) {
     l.hb_in == r.hb_in &&
     l.hb_out == r.hb_out &&
     l.op_queue_age_hist == r.op_queue_age_hist &&
-    l.fs_perf_stat == r.fs_perf_stat;
+    l.os_perf_stat == r.os_perf_stat;
 }
 inline bool operator!=(const osd_stat_t& l, const osd_stat_t& r) {
   return !(l == r);


### PR DESCRIPTION
add two statistic variables in bluestore to cal commit latency and apply latency.

Signed-off-by: Pan Liu <pan.liu@istuary.com>