### PR TITLE
tests: use shorter directories for tests

### DIFF
--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -395,7 +395,7 @@ if not CEPH_BUILD_DIR:
     CEPH_LIB=os.path.join(CEPH_BIN, '.libs')
     os.putenv('CEPH_LIB', CEPH_LIB)
 
-CEPH_DIR = CEPH_BUILD_DIR + "/ceph_objectstore_tool_dir"
+CEPH_DIR = CEPH_BUILD_DIR + "/cot_dir"
 CEPH_CONF = os.path.join(CEPH_DIR, 'ceph.conf')
 
 def kill_daemons():


### PR DESCRIPTION
So that jenkins can use longer directories. We can't have both otherwise
the limit UNIX domain socket path length limit triggers errors such as:

... client.admin.12750.asok is too long! The maximum length on this system is 107

Fixes: http://tracker.ceph.com/issues/16014

Signed-off-by: Loic Dachary <loic@dachary.org>