### PR TITLE
ceph_test_rados_api_tier: dump hitset that we fail to decode

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -2286,12 +2286,16 @@ TEST_F(LibRadosTwoPoolsPP, HitSetWrite) {
     c->wait_for_complete();
     c->release();
 
-    //std::cout << "bl len is " << bl.length() << "\n";
-    //bl.hexdump(std::cout);
-    //std::cout << std::endl;
-
-    bufferlist::iterator p = bl.begin();
-    ::decode(hitsets[i], p);
+    try {
+      bufferlist::iterator p = bl.begin();
+      ::decode(hitsets[i], p);
+    }
+    catch (buffer::error& e) {
+      std::cout << "failed to decode hit set; bl len is " << bl.length() << "\n";
+      bl.hexdump(std::cout);
+      std::cout << std::endl;
+      throw e;
+    }
 
     // cope with racing splits by refreshing pg_num
     if (i == num_pg - 1)


### PR DESCRIPTION
See http://tracker.ceph.com/issues/17945

Signed-off-by: Sage Weil <sage@redhat.com>