### PR TITLE
rgw: compile the ASIO frontend uncondtionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,8 +333,6 @@ if(WITH_RADOSGW)
   find_package(fcgi REQUIRED)
 endif(WITH_RADOSGW)
 
-option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" OFF)
-
 #option for CephFS
 option(WITH_CEPHFS "CephFS is enabled" ON)
 

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -135,9 +135,6 @@
 /* define if leveldb is enabled */
 #cmakedefine WITH_LEVELDB
 
-/* define if radosgw's asio frontend enabled */
-#cmakedefine WITH_RADOSGW_ASIO_FRONTEND
-
 /* define if HAVE_THREAD_SAFE_RES_QUERY */
 #cmakedefine HAVE_THREAD_SAFE_RES_QUERY
 

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -114,19 +114,14 @@ target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS})
 
 set(radosgw_srcs
+  rgw_asio_client.cc
+  rgw_asio_frontend.cc
   rgw_fcgi_process.cc
   rgw_loadgen_process.cc
   rgw_civetweb.cc
   rgw_civetweb_frontend.cc
   rgw_civetweb_log.cc
   rgw_main.cc)
-
-if (WITH_RADOSGW_ASIO_FRONTEND)
-  list(APPEND radosgw_srcs
-    rgw_asio_client.cc
-    rgw_asio_frontend.cc)
-endif (WITH_RADOSGW_ASIO_FRONTEND)
-
 add_executable(radosgw ${radosgw_srcs}  $<TARGET_OBJECTS:civetweb_common_objs>)
 target_link_libraries(radosgw rgw_a librados
   cls_rgw_client cls_lock_client cls_refcount_client

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -53,9 +53,7 @@
 #include "rgw_request.h"
 #include "rgw_process.h"
 #include "rgw_frontend.h"
-#if defined(WITH_RADOSGW_ASIO_FRONTEND)
 #include "rgw_asio_frontend.h"
-#endif /* WITH_RADOSGW_ASIO_FRONTEND */
 
 #include <map>
 #include <string>
@@ -433,7 +431,6 @@ int main(int argc, const char **argv)
     RGWFrontendConfig *config = fiter->second;
     string framework = config->get_framework();
     RGWFrontend *fe;
-#if defined(WITH_RADOSGW_ASIO_FRONTEND)
     if ((framework == "asio") &&
 	cct->check_experimental_feature_enabled("rgw-asio-frontend")) {
       int port;
@@ -443,9 +440,6 @@ int main(int argc, const char **argv)
       RGWProcessEnv env{ store, &rest, olog, port, uri_prefix };
       fe = new RGWAsioFrontend(env);
     } else if (framework == "fastcgi" || framework == "fcgi") {
-#else
-    if (framework == "fastcgi" || framework == "fcgi") {
-#endif /* WITH_RADOSGW_ASIO_FRONTEND */
       std::string uri_prefix;
       config->get_val("prefix", "", &uri_prefix);
       RGWProcessEnv fcgi_pe = { store, &rest, olog, 0, uri_prefix };


### PR DESCRIPTION
This reverts commit 46a44646e890e4cb73085f40258a10855680270b.
We're doing that because the reverted commit was a makeshift
solution to not fail Ceph compilation because of the  Beast's
dependency on Boost >= 1.54 that wasn't available on CentoOS 7.
As we got the in-tree Boost the commit isn't necessary anymore.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>

Conflicts:
	src/include/config-h.in.cmake
          Trivial conflict around "#cmakedefine WITH_LEVELDB".

<hr>
CC: @cbodley.