### PR TITLE
hammer: RWLock.h: 124: FAILED assert(r == 0) in rados-jewel-distro-basic-smithi

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -606,7 +606,7 @@ public:
 
       case OP_SPLIT_COLLECTION2:
         assert(op->cid < cm.size());
-        op->dest_cid = cm[op->dest_oid];
+	assert(op->dest_cid < cm.size());
         op->cid = cm[op->cid];
         op->dest_cid = cm[op->dest_cid];
         break;


### PR DESCRIPTION
http://tracker.ceph.com/issues/17957