### PR TITLE
rgw: compilation of the ASIO front-end is enabled by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -333,7 +333,7 @@ if(WITH_RADOSGW)
   find_package(fcgi REQUIRED)
 endif(WITH_RADOSGW)
 
-option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" OFF)
+option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" ON)
 
 #option for CephFS
 option(WITH_CEPHFS "CephFS is enabled" ON)


### PR DESCRIPTION
We're changing the default value because the previous one was
a makeshift solution to not fail Ceph compilation due to
the Beast's dependency on Boost >= 1.54 that wasn't available
on CentoOS 7. As we got the in-tree Boost we can compile
the ASIO front-end by default.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>

<hr>
This PR is an alternative to #12070.

CC: @cbodley, @mattbenjamin.