### PR TITLE
rgw: Should be able to suspend a tenant when the tenant has buckets.

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -134,7 +134,7 @@ int rgw_read_user_buckets(RGWRados * store,
 
     for (list<cls_user_bucket_entry>::iterator q = entries.begin(); q != entries.end(); ++q) {
       RGWBucketEnt e(*q);
-      e.bucket.tenant = user_id.tenant;
+      rgw_parse_url_bucket(q->bucket.name, user_id.tenant, e.bucket.tenant, e.bucket.name);
       buckets.add(e);
       total++;
     }

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -134,6 +134,7 @@ int rgw_read_user_buckets(RGWRados * store,
 
     for (list<cls_user_bucket_entry>::iterator q = entries.begin(); q != entries.end(); ++q) {
       RGWBucketEnt e(*q);
+      e.bucket.tenant = user_id.tenant;
       buckets.add(e);
       total++;
     }


### PR DESCRIPTION
The struct `cls_user_bucket` does not contain tenant of bucket, and the struct `rgw_bucket` need the tenant of bucket if it exists. So when passing the cls_user_bucket to rgw_bucket, we need to add the bucket's tenant.

Fixes: http://tracker.ceph.com/issues/17215
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>