### PR TITLE
rgw: Add --zonegroup-new-name  in usage

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -207,6 +207,8 @@ void _usage()
   cout << "   --realm-new-name=<name>   realm new name\n";
   cout << "   --rgw-zonegroup=<name>    zonegroup name\n";
   cout << "   --zonegroup-id=<id>       zonegroup id\n";
+  cout << "   --zonegroup-new-name=<name>\n";
+  cout << "                             zonegroup new name\n";
   cout << "   --rgw-zone=<name>         name of zone in which radosgw is running\n";
   cout << "   --zone-id=<id>            zone id\n";
   cout << "   --zone-new-name=<name>    zone new name\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -157,6 +157,8 @@
      --realm-new-name=<name>   realm new name
      --rgw-zonegroup=<name>    zonegroup name
      --zonegroup-id=<id>       zonegroup id
+     --zonegroup-new-name=<name>
+                               zonegroup new name
      --rgw-zone=<name>         name of zone in which radosgw is running
      --zone-id=<id>            zone id
      --zone-new-name=<name>    zone new name


### PR DESCRIPTION
add `--zonegroup-new-name`  to the usage overview.

Signed-off-by: Hans van den Bogert <hansbogert@gmail.com>