### PR TITLE
workunits/ceph-helpers.sh: Fixes for FreeBSD

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -117,7 +117,8 @@ function test_setup() {
 function teardown() {
     local dir=$1
     kill_daemons $dir KILL
-    if [ $(stat -f -c '%T' .) == "btrfs" ]; then
+    if [ `uname` != FreeBSD ] \
+        && [ $(stat -f -c '%T' .) == "btrfs" ]; then
         __teardown_btrfs $dir
     fi
     rm -fr $dir


### PR DESCRIPTION
 - stat(1) does not have '%T'
 - test compares numeric with -ne
 - Need a bit of delay to get 'osd down' visible

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>