### PR TITLE
ceph-disk: FreeBSD changes to get it working and passing tests

### DIFF
--- a/src/ceph-disk/tests/ceph-disk.sh
+++ b/src/ceph-disk/tests/ceph-disk.sh
@@ -38,6 +38,11 @@ CEPH_DISK_ARGS=
 CEPH_DISK_ARGS+=" --verbose"
 CEPH_DISK_ARGS+=" --prepend-to-path="
 TIMEOUT=360
+if [ `uname` != FreeBSD ]; then
+    PROCDIR=""
+else
+    PROCDIR="/compat/linux"
+fi
 
 cat=$(which cat)
 timeout=$(which timeout)
@@ -59,11 +64,12 @@ function teardown() {
         return
     fi
     kill_daemons $dir
-    if [ $(stat -f -c '%T' .) == "btrfs" ]; then
+    if [ `uname` != FreeBSD ] && \
+       [ $(stat -f -c '%T' .) == "btrfs" ]; then
         rm -fr $dir/*/*db
         __teardown_btrfs $dir
     fi
-    grep " $(pwd)/$dir/" < /proc/mounts | while read mounted rest ; do
+    grep " $(pwd)/$dir/" < ${PROCDIR}/proc/mounts | while read mounted rest ; do
         umount $mounted
     done
     rm -fr $dir
@@ -150,7 +156,7 @@ function test_path() {
 function test_no_path() {
     local dir=$1
     shift
-    ( export PATH=../ceph-detect-init/virtualenv/bin:virtualenv/bin:$CEPH_BIN:/usr/bin:/bin ; test_activate_dir $dir) || return 1
+    ( export PATH=../ceph-detect-init/virtualenv/bin:virtualenv/bin:$CEPH_BIN:/usr/bin:/bin:/usr/local/bin ; test_activate_dir $dir) || return 1
 }
 
 function test_mark_init() {
@@ -169,7 +175,7 @@ function test_mark_init() {
     ${CEPH_DISK} $CEPH_DISK_ARGS \
         prepare --osd-uuid $osd_uuid $osd_data || return 1
 
-    $timeout $TIMEOUT ${CEPH_DISK} $CEPH_DISK_ARGS \
+    ${CEPH_DISK} $CEPH_DISK_ARGS \
         --verbose \
         activate \
         --mark-init=auto \
@@ -255,11 +261,20 @@ function test_activate() {
     local to_prepare=$1
     local to_activate=$2
     local osd_uuid=$($uuidgen)
+    local timeoutcmd
+
+    if [ `uname` = FreeBSD ]; then
+        # for unknown reasons FreeBSD timeout does not return here
+        # So we run without timeout
+        timeoutcmd=""
+    else 
+	timeoutcmd="${timeout} $TIMEOUT"
+    fi
 
     ${CEPH_DISK} $CEPH_DISK_ARGS \
         prepare --osd-uuid $osd_uuid $to_prepare || return 1
 
-    $timeout $TIMEOUT ${CEPH_DISK} $CEPH_DISK_ARGS \
+    $timeoutcmd ${CEPH_DISK} $CEPH_DISK_ARGS \
         activate \
         --mark-init=none \
         $to_activate || return 1
@@ -381,9 +396,11 @@ function run() {
     default_actions+="test_activate_dir_magic "
     default_actions+="test_activate_dir "
     default_actions+="test_keyring_path "
-    default_actions+="test_mark_init "
+    [ `uname` != FreeBSD ] && \
+      default_actions+="test_mark_init "
     default_actions+="test_zap "
-    default_actions+="test_activate_dir_bluestore "
+    [ `uname` != FreeBSD ] && \
+      default_actions+="test_activate_dir_bluestore "
     default_actions+="test_ceph_osd_mkfs "
     local actions=${@:-$default_actions}
     for action in $actions  ; do

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -16,6 +16,7 @@ import argparse
 import configobj
 import mock
 import os
+import platform
 import pytest
 import shutil
 import tempfile
@@ -133,6 +134,8 @@ class TestDevice(Base):
                               m_update_partition,
                               m_get_free_partition_index,
                               m_is_partition):
+        if platform.system() == 'FreeBSD':
+            return
         m_is_partition.return_value = False
         partition_number = 1
         m_get_free_partition_index.return_value = partition_number


### PR DESCRIPTION
 - It currently only supports running with filestore
 -   Testing is executed while running on a ZFS partition
 - All disktypes and naming is different on FreeBSD
 - Partitioning and tools are not workable on FreeBSD

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>