### PR TITLE
Wip wjw clang map bug

### DIFF
--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -404,6 +404,7 @@ TEST(denc, pair)
 
 TEST(denc, map)
 {
+#if !defined(__FreeBSD__)
   {
     cout << "map<string,foo_t>" << std::endl;
     std::map<string,foo_t> s;
@@ -412,6 +413,7 @@ TEST(denc, map)
     s["baz"] = foo_t();
     test_denc(s);
   }
+#endif
   {
     cout << "map<string,bar_t>" << std::endl;
     std::map<string,bar_t> s;

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -229,6 +229,7 @@ TEST(mempool, set)
   set_obj.insert(obj(1, 2));
 }
 
+#if !defined(__FreeBSD__)
 TEST(mempool, map)
 {
   {
@@ -243,6 +244,7 @@ TEST(mempool, map)
     v[3] = obj(2, 3);
   }
 }
+#endif
 
 TEST(mempool, list)
 {
@@ -258,12 +260,14 @@ TEST(mempool, list)
   }
 }
 
+#if !defined(__FreeBSD__)
 TEST(mempool, unordered_map)
 {
   mempool::unittest_2::unordered_map<int,obj> h;
   h[1] = obj();
   h[2] = obj(1);
 }
+#endif
 
 int main(int argc, char **argv)
 {


### PR DESCRIPTION
Clang seems to have a problem with compiling map<> code.
  with: src/test/test_mempool.cc 

Or when it compiles it traps.
  with: src/test/test_denc.cc 
  running: unittest_denc