### PR TITLE
[DNM] rgw: improve handling of error messages

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -264,6 +264,45 @@ enum RGWObjCategory {
   RGW_OBJ_CATEGORY_MULTIMETA = 3,
 };
 
+
+class rgw_ret {
+  int ret;
+  boost::optional<std::string> message;
+
+  rgw_ret(const int ret, std::string message)
+    : ret(ret),
+      message(std::move(message)) {
+  }
+
+public:
+  rgw_ret()
+    : ret(0) {
+  }
+
+  rgw_ret(const int ret)
+    : ret(ret) {
+  }
+
+  rgw_ret& operator=(const int ret) {
+    this->ret = ret;
+    return *this;
+  }
+
+  operator int() const {
+    return ret;
+  }
+
+  boost::optional<std::string> get_err_msg() const {
+    return message;
+  }
+
+  /* Make a ret value with a customized status message. */
+  static rgw_ret make_custom(const int ret, std::string message) {
+    return rgw_ret(ret, std::move(message));
+  }
+};
+
+
 /** Store error returns for output at a different point in the program */
 struct rgw_err {
   rgw_err();

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -133,7 +133,7 @@ namespace rgw {
 
     RGWUserInfo* get_user() { return user; }
 
-  virtual int postauth_init() { return 0; }
+    rgw_ret postauth_init() override { return 0; }
 
     /* descendant equivalent of *REST*::init_from_header(...):
      * prepare request for execute()--should mean, fixup URI-alikes

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1375,7 +1375,7 @@ void RGWGetObj::execute()
   if (torrent.get_flag())
   {
     torrent.init(s, store);
-    torrent.get_torrent_file(op_ret, read_op, total_len, bl, obj);
+    op_ret = torrent.get_torrent_file(read_op, total_len, bl, obj);
     if (op_ret < 0)
     {
       ldout(s->cct, 0) << "ERROR: failed to get_torrent_file ret= " << op_ret

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1589,7 +1589,7 @@ public:
 
   virtual int read_permissions(RGWOp *op) = 0;
   virtual int authorize() = 0;
-  virtual int postauth_init() = 0;
+  virtual rgw_ret postauth_init() = 0;
   virtual int error_handler(int err_no, string *error_content);
 };
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -59,7 +59,7 @@ protected:
   bool cors_exist;
   RGWQuotaInfo bucket_quota;
   RGWQuotaInfo user_quota;
-  int op_ret;
+  rgw_ret op_ret;
 
   int do_aws4_auth_completion();
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -823,7 +823,7 @@ public:
   void pre_exec();
   void execute();
 
-  virtual int get_params() = 0;
+  virtual rgw_ret get_params() = 0;
   virtual int get_data(bufferlist& bl) = 0;
   virtual void send_response() = 0;
   virtual const string name() { return "post_obj"; }

--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -116,7 +116,7 @@ int process_request(RGWRados* const store,
                     RGWRestfulIO* const client_io,
                     OpsLogSocket* const olog)
 {
-  int ret = 0;
+  rgw_ret ret = 0;
 
   client_io->init(g_ceph_context);
 
@@ -231,5 +231,5 @@ done:
 	  << " ======"
 	  << dendl;
 
-  return (ret < 0 ? ret : s->err.ret);
+  return (ret < 0 ? static_cast<int>(ret) : s->err.ret);
 } /* process_request */

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1630,7 +1630,7 @@ int RGWHandler_REST::validate_tenant_name(string const& t)
 
 // This function enforces Amazon's spec for bucket names.
 // (The requirements, not the recommendations.)
-int RGWHandler_REST::validate_bucket_name(const string& bucket)
+rgw_ret RGWHandler_REST::validate_bucket_name(const string& bucket)
 {
   int len = bucket.size();
   if (len < 3) {

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -309,20 +309,26 @@ void rgw_flush_formatter(struct req_state *s, Formatter *formatter)
 }
 
 void set_req_state_err(struct rgw_err& err,     /* out */
-                       int err_no,              /* in  */
+                       rgw_ret err_no,          /* in  */
                        const int prot_flags)    /* in  */
 {
   const struct rgw_http_errors *r;
+  const auto custom_msg = err_no.get_err_msg();
 
   if (err_no < 0)
     err_no = -err_no;
   err.ret = -err_no;
+
   if (prot_flags & RGW_REST_SWIFT) {
     r = search_err(err_no, RGW_HTTP_SWIFT_ERRORS,
 		   ARRAY_LEN(RGW_HTTP_SWIFT_ERRORS));
     if (r) {
       err.http_ret = r->http_ret;
-      err.s3_code = r->s3_code;
+      if (custom_msg) {
+        err.s3_code = *custom_msg;
+      } else {
+        err.s3_code = r->s3_code;
+      }
       return;
     }
   }
@@ -331,6 +337,9 @@ void set_req_state_err(struct rgw_err& err,     /* out */
   if (r) {
     err.http_ret = r->http_ret;
     err.s3_code = r->s3_code;
+    if (custom_msg) {
+      err.message = *custom_msg;
+    }
     return;
   }
   dout(0) << "WARNING: set_req_state_err err_no=" << err_no
@@ -340,7 +349,7 @@ void set_req_state_err(struct rgw_err& err,     /* out */
   err.s3_code = "UnknownError";
 }
 
-void set_req_state_err(struct req_state * const s, const int err_no)
+void set_req_state_err(struct req_state * const s, const rgw_ret err_no)
 {
   if (s) {
     set_req_state_err(s->err, err_no, s->prot_flags);
@@ -734,8 +743,10 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
-void abort_early(struct req_state *s, RGWOp *op, int err_no,
-		 RGWHandler* handler)
+void abort_early(struct req_state* const s,
+                 RGWOp* const op,
+                 rgw_ret err_no,
+                 RGWHandler* const handler)
 {
   string error_content("");
   if (!s->formatter) {

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -530,8 +530,8 @@ public:
 static constexpr int64_t NO_CONTENT_LENGTH = -1;
 static constexpr int64_t CHUNKED_TRANSFER_ENCODING = -2;
 
-extern void set_req_state_err(struct rgw_err &err, int err_no, int prot_flags);
-extern void set_req_state_err(struct req_state *s, int err_no);
+extern void set_req_state_err(struct rgw_err &err, rgw_ret err_no, int prot_flags);
+extern void set_req_state_err(struct req_state *s, rgw_ret err_no);
 extern void dump_errno(int http_ret, string& out);
 extern void dump_errno(const struct rgw_err &err, string& out);
 extern void dump_errno(struct req_state *s);
@@ -604,8 +604,10 @@ extern void dump_etag(struct req_state *s,
 extern void dump_epoch_header(struct req_state *s, const char *name, real_time t);
 extern void dump_time_header(struct req_state *s, const char *name, real_time t);
 extern void dump_last_modified(struct req_state *s, real_time t);
-extern void abort_early(struct req_state* s, RGWOp* op, int err,
-			RGWHandler* handler);
+extern void abort_early(struct req_state* s,
+                        RGWOp* op,
+                        rgw_ret err,
+                        RGWHandler* handler);
 extern void dump_range(struct req_state* s, uint64_t ofs, uint64_t end,
 		       uint64_t total_size);
 extern void dump_continue(struct req_state *s);

--- a/src/rgw/rgw_rest.h
+++ b/src/rgw/rgw_rest.h
@@ -422,7 +422,7 @@ public:
   virtual ~RGWHandler_REST() {}
 
   static int validate_tenant_name(const string& bucket);
-  static int validate_bucket_name(const string& bucket);
+  static rgw_ret validate_bucket_name(const string& bucket);
   static int validate_object_name(const string& object);
 
   int init_permissions(RGWOp* op);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -156,8 +156,11 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
     set_req_state_err(s, 0);
     dump_errno(s, custom_http_ret);
   } else {
-    set_req_state_err(s, (partial_content && !op_ret) ? STATUS_PARTIAL_CONTENT
-          	  : op_ret);
+    if (partial_content && !op_ret) {
+      set_req_state_err(s, STATUS_PARTIAL_CONTENT);
+    } else {
+      set_req_state_err(s, op_ret);
+    }
     dump_errno(s);
   }
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3153,7 +3153,7 @@ int RGWHandler_REST_S3::init_from_header(struct req_state* s,
   return 0;
 }
 
-int RGWHandler_REST_S3::postauth_init()
+rgw_ret RGWHandler_REST_S3::postauth_init()
 {
   struct req_init_state *t = &s->init_state;
   bool relaxed_names = s->cct->_conf->rgw_relaxed_s3_bucket_names;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1632,7 +1632,7 @@ void RGWPostObj_ObjStore_S3::rebuild_key(string& key)
   key = new_key;
 }
 
-int RGWPostObj_ObjStore_S3::get_params()
+rgw_ret RGWPostObj_ObjStore_S3::get_params()
 {
   // get the part boundary
   string req_content_type_str = s->info.env->get("CONTENT_TYPE", "");
@@ -1651,8 +1651,8 @@ int RGWPostObj_ObjStore_S3::get_params()
   parse_params(req_content_type_str, req_content_type, params);
 
   if (req_content_type.compare("multipart/form-data") != 0) {
-    err_msg = "Request Content-Type is not multipart/form-data";
-    return -EINVAL;
+    return rgw_ret::make_custom(-EINVAL,
+       "Request Content-Type is not multipart/form-data");
   }
 
   if (s->cct->_conf->subsys.should_gather(ceph_subsys_rgw, 20)) {
@@ -1672,8 +1672,8 @@ int RGWPostObj_ObjStore_S3::get_params()
 
   map<string, string>::iterator iter = params.find("boundary");
   if (iter == params.end()) {
-    err_msg = "Missing multipart boundary specification";
-    return -EINVAL;
+    return rgw_ret::make_custom(-EINVAL,
+      "Missing multipart boundary specification");
   }
 
   // create the boundary
@@ -1704,8 +1704,7 @@ int RGWPostObj_ObjStore_S3::get_params()
     }
 
     if (done) { /* unexpected here */
-      err_msg = "Malformed request";
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL, "Malformed request");
     }
 
     if (stringcasecmp(part.name, "file") == 0) { /* beginning of data transfer */
@@ -1723,8 +1722,7 @@ int RGWPostObj_ObjStore_S3::get_params()
     uint64_t chunk_size = s->cct->_conf->rgw_max_chunk_size;
     r = read_data(part.data, chunk_size, &boundary, &done);
     if (!boundary) {
-      err_msg = "Couldn't find boundary";
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL,  "Couldn't find boundary");
     }
     parts[part.name] = part;
     string part_str(part.data.c_str(), part.data.length());
@@ -1733,8 +1731,7 @@ int RGWPostObj_ObjStore_S3::get_params()
 
   string object_str;
   if (!part_str("key", &object_str)) {
-    err_msg = "Key not specified";
-    return -EINVAL;
+    return rgw_ret::make_custom(-EINVAL, "Key not specified");
   }
 
   s->object = rgw_obj_key(object_str);
@@ -1742,8 +1739,7 @@ int RGWPostObj_ObjStore_S3::get_params()
   rebuild_key(s->object.name);
 
   if (s->object.empty()) {
-    err_msg = "Empty object name";
-    return -EINVAL;
+    return rgw_ret::make_custom(-EINVAL, "Empty object name");
   }
 
   env.add_var("key", s->object.name);
@@ -1787,9 +1783,9 @@ int RGWPostObj_ObjStore_S3::get_params()
     attrs[attr_name] = attr_bl;
   }
 
-  int r = get_policy();
+  auto r = get_policy();
   if (r < 0)
-    return r;
+    return std::move(r);
 
   min_len = post_policy.min_length;
   max_len = post_policy.max_length;
@@ -1797,7 +1793,7 @@ int RGWPostObj_ObjStore_S3::get_params()
   return 0;
 }
 
-int RGWPostObj_ObjStore_S3::get_policy()
+rgw_ret RGWPostObj_ObjStore_S3::get_policy()
 {
   bufferlist encoded_policy;
 
@@ -1807,14 +1803,12 @@ int RGWPostObj_ObjStore_S3::get_policy()
     string s3_access_key;
     if (!part_str("AWSAccessKeyId", &s3_access_key)) {
       ldout(s->cct, 0) << "No S3 access key found!" << dendl;
-      err_msg = "Missing access key";
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL, "Missing access key");
     }
     string received_signature_str;
     if (!part_str("signature", &received_signature_str)) {
       ldout(s->cct, 0) << "No signature found!" << dendl;
-      err_msg = "Missing signature";
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL, "Missing signature");
     }
     RGWUserInfo user_info;
 
@@ -1840,8 +1834,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
 
 	if (external_auth_result < 0) {
 	  ldout(s->cct, 0) << "User lookup failed!" << dendl;
-	  err_msg = "Bad access key / signature";
-	  return -EACCES;
+          return rgw_ret::make_custom(-EACCES, "Bad access key / signature");
 	}
 
 	string project_id = keystone_validator.response.get_project_id();
@@ -1890,8 +1883,8 @@ int RGWPostObj_ObjStore_S3::get_policy()
       // rgw_get_user_info_by_access_key, but it doesn't hurt to check!
       if (iter == access_keys.end()) {
 	ldout(s->cct, 0) << "Secret key lookup failed!" << dendl;
-	err_msg = "No secret key for matching access key";
-	return -EACCES;
+        return rgw_ret::make_custom(-EACCES,
+                                    "No secret key for matching access key");
       }
       string s3_secret_key = (iter->second).key;
 
@@ -1915,8 +1908,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
 			 << dendl;
 	ldout(s->cct, 0) << "expected: "
 			 << expected_signature_hmac_encoded.c_str() << dendl;
-	err_msg = "Bad access key / signature";
-	return -EACCES;
+        return rgw_ret::make_custom(-EACCES, "Bad access key / signature");
       }
     }
 
@@ -1926,21 +1918,21 @@ int RGWPostObj_ObjStore_S3::get_policy()
       decoded_policy.decode_base64(encoded_policy);
     } catch (buffer::error& err) {
       ldout(s->cct, 0) << "failed to decode_base64 policy" << dendl;
-      err_msg = "Could not decode policy";
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL, "Could not decode policy");
     }
 
     decoded_policy.append('\0'); // NULL terminate
 
     ldout(s->cct, 0) << "POST policy: " << decoded_policy.c_str() << dendl;
 
+    std::string err_msg;
     int r = post_policy.from_json(decoded_policy, err_msg);
     if (r < 0) {
       if (err_msg.empty()) {
 	err_msg = "Failed to parse policy";
       }
       ldout(s->cct, 0) << "failed to parse policy" << dendl;
-      return -EINVAL;
+      return rgw_ret::make_custom(-EINVAL, std::move(err_msg));
     }
 
     post_policy.set_var_checked("AWSAccessKeyId");
@@ -1953,7 +1945,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
 	err_msg = "Policy check failed";
       }
       ldout(s->cct, 0) << "policy check failed" << dendl;
-      return r;
+      return rgw_ret::make_custom(r, std::move(err_msg));
     }
 
     // deep copy
@@ -1974,8 +1966,7 @@ int RGWPostObj_ObjStore_S3::get_policy()
   RGWAccessControlPolicy_S3 s3policy(s->cct);
   ldout(s->cct, 20) << "canned_acl=" << canned_acl << dendl;
   if (s3policy.create_canned(s->owner, s->bucket_owner, canned_acl) < 0) {
-    err_msg = "Bad canned ACLs";
-    return -EINVAL;
+    return rgw_ret::make_custom(-EINVAL, "Bad canned ACLs");
   }
 
   policy = s3policy;
@@ -2119,7 +2110,6 @@ done:
     s->formatter->dump_string("Key", s->object.name);
     s->formatter->close_section();
   }
-  s->err.message = err_msg;
   set_req_state_err(s, op_ret);
   dump_errno(s);
   if (op_ret >= 0) {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -197,7 +197,6 @@ class RGWPostObj_ObjStore_S3 : public RGWPostObj_ObjStore {
   map<string, post_form_part, const ltstr_nocase> parts;  
   RGWPolicyEnv env;
   RGWPolicy post_policy;
-  string err_msg;
 
   int read_with_boundary(bufferlist& bl, uint64_t max, bool check_eol,
                          bool *reached_boundary,
@@ -213,13 +212,13 @@ class RGWPostObj_ObjStore_S3 : public RGWPostObj_ObjStore {
   bool part_str(const string& name, string *val);
   bool part_bl(const string& name, bufferlist *pbl);
 
-  int get_policy();
+  rgw_ret get_policy();
   void rebuild_key(string& key);
 public:
   RGWPostObj_ObjStore_S3() {}
   ~RGWPostObj_ObjStore_S3() {}
 
-  int get_params();
+  rgw_ret get_params();
   int complete_get_params();
   void send_response();
   int get_data(bufferlist& bl);

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -473,7 +473,7 @@ public:
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
-  int postauth_init() { return 0; }
+  rgw_ret postauth_init() override { return 0; }
 };
 
 class RGWHandler_REST_S3 : public RGWHandler_REST {
@@ -490,7 +490,7 @@ public:
   virtual int authorize() {
     return RGW_Auth_S3::authorize(store, s);
   }
-  int postauth_init();
+  rgw_ret postauth_init() override;
 };
 
 class RGWHandler_REST_Service_S3 : public RGWHandler_REST_S3 {

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -467,9 +467,6 @@ public:
   RGWHandler_Auth_S3() : RGWHandler_REST() {}
   virtual ~RGWHandler_Auth_S3() {}
 
-  static int validate_bucket_name(const string& bucket);
-  static int validate_object_name(const string& bucket);
-
   virtual int init(RGWRados *store,
                    struct req_state *s,
                    rgw::io::BasicClient *cio);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/format.hpp>
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
@@ -2137,7 +2138,7 @@ int RGWHandler_REST_SWIFT::authorize()
   return -EPERM;
 }
 
-int RGWHandler_REST_SWIFT::postauth_init()
+rgw_ret RGWHandler_REST_SWIFT::postauth_init()
 {
   struct req_init_state* t = &s->init_state;
 
@@ -2151,7 +2152,7 @@ int RGWHandler_REST_SWIFT::postauth_init()
 	   << rgw_make_bucket_entry_name(s->bucket_tenant, s->bucket_name)
 	   << dendl;
 
-  int ret;
+  rgw_ret ret;
   ret = validate_tenant_name(s->bucket_tenant);
   if (ret)
     return ret;
@@ -2183,13 +2184,23 @@ int RGWHandler_REST_SWIFT::postauth_init()
   return 0;
 }
 
-int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
+rgw_ret RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
 {
-  int ret = RGWHandler_REST::validate_bucket_name(bucket);
-  if (ret < 0)
-    return ret;
+  const size_t len = bucket.size();
 
-  int len = bucket.size();
+  if (len > MAX_BUCKET_NAME_LEN) {
+    /* Bucket Name too long. Generate custom error message and bind it
+     * to an R-value reference. */
+    auto&& msg = boost::str(
+      boost::format("Container name length of %lld longer than %lld")
+        % len % int(MAX_BUCKET_NAME_LEN));
+    return rgw_ret::make_custom(-ERR_INVALID_BUCKET_NAME, msg);
+  }
+
+  const auto ret = RGWHandler_REST::validate_bucket_name(bucket);
+  if (ret < 0) {
+    return ret;
+  }
 
   if (len == 0)
     return 0;
@@ -2202,7 +2213,7 @@ int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
 
   const char *s = bucket.c_str();
 
-  for (int i = 0; i < len; ++i, ++s) {
+  for (size_t i = 0; i < len; ++i, ++s) {
     if (*(unsigned char *)s == 0xff)
       return -ERR_INVALID_BUCKET_NAME;
   }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1250,8 +1250,11 @@ int RGWGetObj_ObjStore_SWIFT::send_response_data(bufferlist& bl,
     set_req_state_err(s, 0);
     dump_errno(s, custom_http_ret);
   } else {
-    set_req_state_err(s, (partial_content && !op_ret) ? STATUS_PARTIAL_CONTENT
-		    : op_ret);
+    if (partial_content && !op_ret) {
+      set_req_state_err(s, STATUS_PARTIAL_CONTENT);
+    } else {
+      set_req_state_err(s, op_ret);
+    }
     dump_errno(s);
 
     if (s->err.is_err()) {

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -265,11 +265,11 @@ public:
   RGWHandler_REST_SWIFT() {}
   virtual ~RGWHandler_REST_SWIFT() {}
 
-  static int validate_bucket_name(const string& bucket);
+  static rgw_ret validate_bucket_name(const std::string& bucket);
 
   int init(RGWRados *store, struct req_state *s, rgw::io::BasicClient *cio);
   int authorize() override;
-  int postauth_init() override;
+  rgw_ret postauth_init() override;
 
   RGWAccessControlPolicy *alloc_policy() { return NULL; /* return new RGWAccessControlPolicy_SWIFT; */ }
   void free_policy(RGWAccessControlPolicy *policy) { delete policy; }
@@ -418,7 +418,7 @@ public:
     return 0;
   }
 
-  int postauth_init() override {
+  rgw_ret postauth_init() override {
     return 0;
   }
 
@@ -473,7 +473,7 @@ public:
     return 0;
   }
 
-  int postauth_init() override {
+  rgw_ret postauth_init() override {
     return 0;
   }
 
@@ -528,7 +528,7 @@ public:
     return 0;
   }
 
-  int postauth_init() override {
+  rgw_ret postauth_init() override {
     return 0;
   }
 

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -142,7 +142,7 @@ public:
 
   int init(RGWRados *store, struct req_state *state, rgw::io::BasicClient *cio);
   int authorize();
-  int postauth_init() { return 0; }
+  rgw_ret postauth_init() override { return 0; }
   int read_permissions(RGWOp *op) { return 0; }
 
   virtual RGWAccessControlPolicy *alloc_policy() { return NULL; }

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -38,8 +38,10 @@ void seed::init(struct req_state *p_req, RGWRados *p_store)
   store = p_store;
 }
 
-void seed::get_torrent_file(int &op_ret, RGWRados::Object::Read &read_op, uint64_t &total_len, 
-  bufferlist &bl_data, rgw_obj &obj)
+int seed::get_torrent_file(RGWRados::Object::Read &read_op,
+                           uint64_t &total_len,
+                           ceph::bufferlist &bl_data,
+                           rgw_obj &obj)
 {
   /* add other field if config is set */
   dencode.bencode_dict(bl);
@@ -65,11 +67,12 @@ void seed::get_torrent_file(int &op_ret, RGWRados::Object::Read &read_op, uint64
   ldout(s->cct, 0) << "NOTICE: head obj oid= " << oid << dendl;
 
   obj_key.insert(RGW_OBJ_TORRENT);
-  op_ret = read_op.state.io_ctx.omap_get_vals_by_keys(oid, obj_key, &m);
+  const int op_ret = read_op.state.io_ctx.omap_get_vals_by_keys(oid, obj_key, &m);
   if (op_ret < 0)
   {
-    ldout(s->cct, 0) << "ERROR: failed to omap_get_vals_by_keys op_ret = " << op_ret << dendl;
-    return;
+    ldout(s->cct, 0) << "ERROR: failed to omap_get_vals_by_keys op_ret = "
+                     << op_ret << dendl;
+    return op_ret;
   }
 
   map<string, bufferlist>::iterator iter;
@@ -83,7 +86,7 @@ void seed::get_torrent_file(int &op_ret, RGWRados::Object::Read &read_op, uint64
 
   bl_data = bl;
   total_len = bl.length();
-  return;
+  return 0;
 }
 
 bool seed::get_flag()

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -116,8 +116,10 @@ public:
 
   int get_params();
   void init(struct req_state *p_req, RGWRados *p_store);
-  void get_torrent_file(int &op_ret, RGWRados::Object::Read &read_op, 
-    uint64_t &total_len, bufferlist &bl_data, rgw_obj &obj);
+  int get_torrent_file(RGWRados::Object::Read &read_op,
+                       uint64_t &total_len,
+                       ceph::bufferlist &bl_data,
+                       rgw_obj &obj);
   
   off_t get_data_len();
   bool get_flag();


### PR DESCRIPTION
It's not unusual case when RadosGW has to provide a client with detailed, possibly on-the-fly generated error message. In such situation the approach based on static mapping between `op_ret` and a message isn't scalable. `RGWPostObj_ObjStore_S3` tries to deal with that on its own by introducing `err_msg` member and the related machinery. However, a more generic solution might be desirable as the problem seems to affect other parts of the code as well (see tickets [17938](http://tracker.ceph.com/issues/17938),  [17935](http://tracker.ceph.com/issues/17935)).