### PR TITLE
nosetests: use /usr/bin/env to find nosetests

### DIFF
--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/nosetests --nocapture
+#!/usr/bin/env nosetests 
 # -*- mode:python; tab-width:4; indent-tabs-mode:t; coding:utf-8 -*-
 # vim: ts=4 sw=4 smarttab expandtab fileencoding=utf-8
 #

--- a/src/test/pybind/test_ceph_daemon.py
+++ b/src/test/pybind/test_ceph_daemon.py
@@ -1,4 +1,4 @@
-#!/usr/bin/nosetests --nocapture
+#!/usr/bin/env nosetests
 # -*- mode:python; tab-width:4; indent-tabs-mode:t -*-
 # vim: ts=4 sw=4 smarttab expandtab
 #


### PR DESCRIPTION
 - Options are not required, so do not pass them to the script.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>