### PR TITLE
yasm-wrapper: translate "-isystem $1" to "-i $1"

### DIFF
--- a/src/yasm-wrapper
+++ b/src/yasm-wrapper
@@ -15,7 +15,7 @@ while [ -n "$*" ]; do
 	-g* | -f* | -W* | -MD | -MP | -fPIC | -c | -D* | --param* | -O* | -m* | -pipe | ggc-min* )
 	    shift
 	    ;;
-	-I )
+	-I | -isystem )
 	    shift
 	    new="$new -i $1"
 	    shift


### PR DESCRIPTION
this silences the warning of:

yasm: warning: can open only one input file, only the last file will be
processed

as yasm does not understand -isystem as gcc does.

Signed-off-by: Kefu Chai <kchai@redhat.com>