### PR TITLE
osd: cleanup C_CompleteSplits::finish()

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9015,7 +9015,6 @@ struct C_CompleteSplits : public Context {
     if (osd->is_stopping())
       return;
     PG::RecoveryCtx rctx = osd->create_context();
-    set<spg_t> to_complete;
     for (set<boost::intrusive_ptr<PG> >::iterator i = pgs.begin();
 	 i != pgs.end();
 	 ++i) {
@@ -9023,15 +9022,14 @@ struct C_CompleteSplits : public Context {
       (*i)->lock();
       osd->add_newly_split_pg(&**i, &rctx);
       if (!((*i)->deleting)) {
+        set<spg_t> to_complete;
         to_complete.insert((*i)->info.pgid);
         osd->service.complete_split(to_complete);
       }
       osd->pg_map_lock.put_write();
       osd->dispatch_context_transaction(rctx, &**i);
-	to_complete.insert((*i)->info.pgid);
       (*i)->unlock();
       osd->wake_pg_waiters((*i)->info.pgid);
-      to_complete.clear();
     }
 
     osd->dispatch_context(rctx, 0, osd->service.get_osdmap());


### PR DESCRIPTION
    osd/OSD: cleanup on C_CompleteSplits::finish(), delete useless codes

    Signed-off-by: Jie Wang <jie.wang@kylin-cloud.com>