### PR TITLE
rgw: avoid dynamic memory allocations in rgw_swift_auth.cc by using static_vector

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -4,13 +4,7 @@
 #include <array>
 
 #include <boost/utility/string_ref.hpp>
-/* TODO(rzarzynski): we want to use static_vector when it will be available
- * also on RHEL/Centos 7. At the moment std::vetor is being used instead. */
-#if 0
-#  include <boost/container/static_vector.hpp>
-#else
-#  include <vector>
-#endif
+#include <boost/container/static_vector.hpp>
 
 #include "rgw_swift_auth.h"
 #include "rgw_rest.h"
@@ -229,12 +223,7 @@ RGWAuthApplier::aplptr_t RGWTempURLAuthEngine::authenticate() const
   };
 
   /* Account owner calculates the signature also against a HTTP method. */
-  /* TODO(rzarzynski): switch to static_vector when possible. */
-#if 0
   boost::container::static_vector<boost::string_ref, 3> allowed_methods;
-#else
-  std::vector<boost::string_ref> allowed_methods;
-#endif
   if (strcmp("HEAD", s->info.method) == 0) {
     /* HEAD requests are specially handled. */
     /* TODO: after getting a newer boost (with static_vector supporting


### PR DESCRIPTION
This reverts commit bc23e0f7fa8491c44fa938eeb954197f6aad2367.
We're doing that because the reverted commit was a makeshift
solution to not fail Ceph compilation on platforms lacking
Boost modern enough to ship the container/static_vector.hpp.
As we got the in-tree Boost the commit isn't necessary anymore.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>
<hr>
CC: @cbodley, @mattbenjamin.