### PR TITLE
API cleanup for libcephfs interfaces

### DIFF
--- a/src/include/cephfs/ceph_statx.h
+++ b/src/include/cephfs/ceph_statx.h
@@ -62,10 +62,18 @@ struct ceph_statx {
 #define CEPH_STATX_VERSION	0x00001000U     /* Want/got stx_version */
 #define CEPH_STATX_ALL_STATS	0x00001fffU     /* All supported stats */
 
-/* statx request flags. Callers can set these in the "flags" field */
+/*
+ * Compatability macros until these defines make their way into glibc
+ */
 #ifndef AT_NO_ATTR_SYNC
 #define AT_NO_ATTR_SYNC		0x4000 /* Don't sync attributes with the server */
 #endif
+
+/*
+ * The statx interfaces only allow these flags. In order to allow us to add
+ * others in the future, we disallow setting any that aren't recognized.
+ */
+#define CEPH_REQ_FLAG_MASK		(AT_SYMLINK_NOFOLLOW|AT_NO_ATTR_SYNC)
 
 #ifdef __cplusplus
 }

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -153,6 +153,18 @@ UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
 void ceph_userperm_destroy(UserPerm *perm);
 
 /**
+ * Get a pointer to the default UserPerm object for the mount.
+ *
+ * @param cmount the mount info handle
+ *
+ * Every cmount has a default set of credentials. This returns a pointer to
+ * that object.
+ *
+ * Unlike with ceph_userperm_new, this object should not be freed.
+ */
+struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
+
+/**
  * @defgroup libcephfs_h_init Setup and Teardown
  * These are the first and last functions that should be called
  * when using libcephfs.
@@ -229,9 +241,6 @@ int ceph_init(struct ceph_mount_info *cmount);
  * @returns 0 on success, negative error code on failure
  */
 int ceph_mount(struct ceph_mount_info *cmount, const char *root);
-
-
-struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
 
 /**
  * Execute a management command remotely on an MDS.

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -33,7 +33,6 @@
 
 #include "include/cephfs/libcephfs.h"
 
-
 struct ceph_mount_info
 {
 public:
@@ -522,6 +521,8 @@ extern "C" int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_di
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return cmount->get_client()->readdirplus_r(reinterpret_cast<dir_result_t*>(dirp), de, stx, want, flags, out);
 }
 
@@ -629,6 +630,8 @@ extern "C" int ceph_statx(struct ceph_mount_info *cmount, const char *path,
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return cmount->get_client()->statx(path, stx, cmount->default_perms,
 				     want, flags);
 }
@@ -646,6 +649,8 @@ extern "C" int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return cmount->get_client()->setattrx(relpath, stx, mask,
 					cmount->default_perms, flags);
 }
@@ -898,6 +903,8 @@ extern "C" int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_s
 {
   if (!cmount->is_mounted())
     return -ENOTCONN;
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return cmount->get_client()->fstatx(fd, stx, cmount->default_perms,
 				      want, flags);
 }
@@ -1408,6 +1415,8 @@ extern "C" int ceph_ll_lookup(struct ceph_mount_info *cmount,
 			      struct ceph_statx *stx, unsigned want,
 			      unsigned flags, const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return (cmount->get_client())->ll_lookupx(parent, name, out, stx, want,
 					    flags, *perms);
 }
@@ -1427,6 +1436,8 @@ int ceph_ll_walk(struct ceph_mount_info *cmount, const char* name, Inode **i,
 		 struct ceph_statx *stx, unsigned int want, unsigned int flags,
 		 const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return(cmount->get_client()->ll_walk(name, i, stx, want, flags, *perms));
 }
 
@@ -1435,6 +1446,8 @@ extern "C" int ceph_ll_getattr(class ceph_mount_info *cmount,
 			       unsigned int want, unsigned int flags,
 			       const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return (cmount->get_client()->ll_getattrx(in, stx, want, flags, *perms));
 }
 
@@ -1544,6 +1557,8 @@ extern "C" int ceph_ll_create(class ceph_mount_info *cmount,
 			      struct ceph_statx *stx, unsigned want,
 			      unsigned lflags, const UserPerm *perms)
 {
+  if (lflags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return (cmount->get_client())->ll_createx(parent, name, mode, oflags, outp,
 					    fhp, stx, want, lflags, *perms);
 }
@@ -1554,6 +1569,8 @@ extern "C" int ceph_ll_mknod(class ceph_mount_info *cmount, Inode *parent,
 			     unsigned want, unsigned flags,
 			     const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return (cmount->get_client())->ll_mknodx(parent, name, mode, rdev,
 					   out, stx, want, flags, *perms);
 }
@@ -1563,6 +1580,8 @@ extern "C" int ceph_ll_mkdir(class ceph_mount_info *cmount, Inode *parent,
 			     struct ceph_statx *stx, unsigned want,
 			     unsigned flags, const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return cmount->get_client()->ll_mkdirx(parent, name, mode, out, stx, want,
 					 flags, *perms);
 }
@@ -1624,6 +1643,8 @@ extern "C" int ceph_ll_symlink(class ceph_mount_info *cmount,
 			       struct ceph_statx *stx, unsigned want,
 			       unsigned flags, const UserPerm *perms)
 {
+  if (flags & ~CEPH_REQ_FLAG_MASK)
+    return -EINVAL;
   return (cmount->get_client()->ll_symlinkx(in, name, value, out, stx, want,
 					    flags, *perms));
 }


### PR DESCRIPTION
Just a couple of patches to do some cleanup of the statx-based APIs. The main thing we need to ensure is that no callers are setting flags that we don't currently recognize, as that would prevent us from being able to add new flags in the future.

I tried to run tests over the weekend but a bunch died, so I'm rerunning them now:

http://pulpito.ceph.com/jlayton-2016-11-21_14:46:06-fs-wip-jlayton-libcephfs---basic-mira/

Still, this patchset is pretty trivial, so I'll be surprised if it breaks anything.