### PR TITLE
mon: no delay for single message MSG_ALIVE and MSG_PGTEMP

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -80,6 +80,7 @@ OSDMonitor::OSDMonitor(CephContext *cct, Monitor *mn, Paxos *p, const string& se
    cct(cct),
    inc_osd_cache(g_conf->mon_osd_cache_size),
    full_osd_cache(g_conf->mon_osd_cache_size),
+   last_attempted_minwait_time(utime_t()),
    op_tracker(cct, true, 1)
 {}
 
@@ -1362,6 +1363,22 @@ bool OSDMonitor::should_propose(double& delay)
     delay = 0.0;
     osd_weight.clear();
     return true;
+  }
+
+  // propose as fast as possible if updating up_thru or pg_temp
+  // want to merge OSDMap changes as much as possible
+  if ((pending_inc.new_primary_temp.size() == 1
+      || pending_inc.new_up_thru.size() == 1)
+      && pending_inc.new_state.size() < 2) {
+    dout(15) << " propose as fast as possible for up_thru/pg_temp" << dendl;
+
+    utime_t now = ceph_clock_now();
+    if (now - last_attempted_minwait_time > g_conf->paxos_propose_interval
+	&& now - paxos->get_last_commit_time() > g_conf->paxos_min_wait) {
+      delay = g_conf->paxos_min_wait;
+      last_attempted_minwait_time = now;
+      return true;
+    }
   }
 
   return PaxosService::should_propose(delay);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -131,6 +131,9 @@ private:
   bool check_failure(utime_t now, int target_osd, failure_info_t& fi);
   void force_failure(utime_t now, int target_osd);
 
+  // the time of last msg(MSG_ALIVE and MSG_PGTEMP) proposed without delay
+  utime_t last_attempted_minwait_time;
+
   bool _have_pending_crush();
   CrushWrapper &_get_stable_crush();
   void _get_pending_crush(CrushWrapper& newcrush);

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -1212,6 +1212,14 @@ public:
    * @return the first committed version
    */
   version_t get_first_committed() { return first_committed; }
+  /** 
+   * Get the last commit time
+   *
+   * @returns Our last commit time
+  */
+  utime_t get_last_commit_time() const{
+    return last_commit_time;
+  }
   /**
    * Check if a given version is readable.
    *


### PR DESCRIPTION
Currently, monitor may wait  'paxos_propose_interval' before propose_pending
However, we don't want this long wait for message MSG_ALIVE and MSG_PGTEMP since it will block the peering process so that all IO will block a long time when adding or removing osd in the cluster.
Thus, wait paxos_min_wait(default = 0.05) for those messages. Even through, we can set paxos_min_wait = 0 to make the propose_pending immediately if we want.

Signed-off-by: yaoning <yaoning@unitedstack.com>