### PR TITLE
compress: Fix compilation failure from missing header

### DIFF
--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include <random>
 #include "Compressor.h"
 #include "CompressionPlugin.h"
 #include "common/dout.h"


### PR DESCRIPTION
Compress was failing due to the random header not being included.