### PR TITLE
rgw: move compression config into zone

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1558,7 +1558,6 @@ OPTION(mon_mgr_beacon_grace, OPT_INT, 30)  // How long to wait to failover
 OPTION(rgw_list_bucket_min_readahead, OPT_INT, 1000) // minimum number of entries to read from rados for bucket listing
 
 OPTION(rgw_rest_getusage_op_compat, OPT_BOOL, false) // dump description of total stats for s3 GetUsage API
-OPTION(rgw_compression_type, OPT_STR, "none") // type of compressor, none to not use
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -64,8 +64,7 @@ RGWGetObj_Decompress::RGWGetObj_Decompress(CephContext* cct_,
 {
   compressor = Compressor::create(cct, cs_info->compression_type);
   if (!compressor.get())
-    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type 
-                     << " for rgw, check rgw_compression_type config option" << dendl;
+    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type << dendl;
 }
 
 int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
@@ -74,8 +73,7 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
 
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return decompressed data?
-    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type 
-                     << " for rgw, check rgw_compression_type config option" << dendl;
+    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type << dendl;
     return -EIO;
   }
   bufferlist out_bl, in_bl;

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -865,6 +865,7 @@ void RGWZoneParams::dump(Formatter *f) const
   encode_json("placement_pools", placement_pools, f);
   encode_json("metadata_heap", metadata_heap.data_pool, f);
   encode_json("tier_config", tier_config, f);
+  encode_json("compression_type", compression_type, f);
   encode_json("realm_id", realm_id, f);
 }
 
@@ -911,6 +912,7 @@ void RGWZoneParams::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("placement_pools", placement_pools, obj);
   ::decode_json("metadata_heap", metadata_heap, obj);
   JSONDecoder::decode_json("tier_config", tier_config, obj);
+  JSONDecoder::decode_json("compression_type", compression_type, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
 
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7109,11 +7109,11 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   RGWPutObjDataProcessor *filter = &processor;
 
-  const auto& compression_type = cct->_conf->rgw_compression_type;
+  const auto& compression_type = zone_params.get_compression_type();
   if (compression_type != "none") {
     plugin = Compressor::create(cct, compression_type);
     if (!plugin) {
-      ldout(cct, 1) << "Cannot load plugin for rgw_compression_type "
+      ldout(cct, 1) << "Cannot load plugin for compression type "
           << compression_type << dendl;
     } else {
       compressor = boost::in_place(cct, plugin, filter);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1612,6 +1612,12 @@ const string& RGWZoneParams::get_predefined_name(CephContext *cct) {
   return cct->_conf->rgw_zone;
 }
 
+const string& RGWZoneParams::get_compression_type() const
+{
+  static const std::string NONE{"none"};
+  return !compression_type.empty() ? compression_type : NONE;
+}
+
 int RGWZoneParams::init(CephContext *cct, RGWRados *store, bool setup_obj, bool old_format)
 {
   if (name.empty()) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -992,6 +992,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   string realm_id;
 
   map<string, string> tier_config;
+  std::string compression_type{"none"};
 
   RGWZoneParams() : RGWSystemMetaObj() {}
   RGWZoneParams(const string& name) : RGWSystemMetaObj(name){}
@@ -1004,6 +1005,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   const string& get_names_oid_prefix();
   const string& get_info_oid_prefix(bool old_format = false);
   const string& get_predefined_name(CephContext *cct);
+  const string& get_compression_type() const;
 
   int init(CephContext *_cct, RGWRados *_store, bool setup_obj = true,
 	   bool old_format = false);
@@ -1015,7 +1017,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   int fix_pool_names();
   
   void encode(bufferlist& bl) const {
-    ENCODE_START(8, 1, bl);
+    ENCODE_START(9, 1, bl);
     ::encode(domain_root, bl);
     ::encode(control_pool, bl);
     ::encode(gc_pool, bl);
@@ -1033,11 +1035,12 @@ struct RGWZoneParams : RGWSystemMetaObj {
     ::encode(realm_id, bl);
     ::encode(lc_pool, bl);
     ::encode(tier_config, bl);
+    ::encode(compression_type, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(8, bl);
+    DECODE_START(9, bl);
     ::decode(domain_root, bl);
     ::decode(control_pool, bl);
     ::decode(gc_pool, bl);
@@ -1070,6 +1073,9 @@ struct RGWZoneParams : RGWSystemMetaObj {
     }
     if (struct_v >= 8) {
       ::decode(tier_config, bl);
+    }
+    if (struct_v >= 9) {
+      ::decode(compression_type, bl);
     }
     DECODE_FINISH(bl);
   }

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -175,6 +175,7 @@
                                set list of zones to sync from
      --sync-from-rm=[zone-name][,...]
                                remove zones from list of zones to sync from
+     --compression=<type>      zone compression type ('none' or plugin name)
      --fix                     besides checking bucket index, will also fix it
      --check-objects           bucket check: rebuilds bucket index according to
                                actual objects state


### PR DESCRIPTION
This replaces the `rgw_compression_type` config option with an entry in the zone configuration, which can be set with the `--compression=` option to `radosgw-admin zone create` or `zone modify`.

Also adds some new documentation.