### PR TITLE
rgw: move compression config into zone placement

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1561,7 +1561,6 @@ OPTION(mon_mgr_beacon_grace, OPT_INT, 30)  // How long to wait to failover
 OPTION(rgw_list_bucket_min_readahead, OPT_INT, 1000) // minimum number of entries to read from rados for bucket listing
 
 OPTION(rgw_rest_getusage_op_compat, OPT_BOOL, false) // dump description of total stats for s3 GetUsage API
-OPTION(rgw_compression_type, OPT_STR, "none") // type of compressor, none to not use
 
 OPTION(mutex_perf_counter, OPT_BOOL, false) // enable/disable mutex perf counter
 OPTION(throttler_perf_counter, OPT_BOOL, true) // enable/disable throttler perf counter

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -64,8 +64,7 @@ RGWGetObj_Decompress::RGWGetObj_Decompress(CephContext* cct_,
 {
   compressor = Compressor::create(cct, cs_info->compression_type);
   if (!compressor.get())
-    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type 
-                     << " for rgw, check rgw_compression_type config option" << dendl;
+    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type << dendl;
 }
 
 int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
@@ -74,8 +73,7 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
 
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return decompressed data?
-    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type 
-                     << " for rgw, check rgw_compression_type config option" << dendl;
+    lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type << dendl;
     return -EIO;
   }
   bufferlist out_bl, in_bl;

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -881,6 +881,7 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
   encode_json("data_pool", data_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
   encode_json("index_type", (uint32_t)index_type, f);
+  encode_json("compression", compression_type, f);
 }
 
 void RGWZonePlacementInfo::decode_json(JSONObj *obj)
@@ -891,6 +892,7 @@ void RGWZonePlacementInfo::decode_json(JSONObj *obj)
   uint32_t it;
   JSONDecoder::decode_json("index_type", it, obj);
   index_type = (RGWBucketIndexType)it;
+  JSONDecoder::decode_json("compression", compression_type, obj);
 }
 
 void RGWZoneParams::decode_json(JSONObj *obj)

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2807,10 +2807,10 @@ int RGWPutObj::get_data(const off_t fst, const off_t lst, bufferlist& bl)
   return ret;
 }
 
-// special handling for rgw_compression_type = "random" with multipart uploads
-static CompressorRef get_compressor_plugin(const req_state *s)
+// special handling for compression type = "random" with multipart uploads
+static CompressorRef get_compressor_plugin(const req_state *s,
+                                           const std::string& compression_type)
 {
-  const auto& compression_type = s->cct->_conf->rgw_compression_type;
   if (compression_type != "random") {
     return Compressor::create(s->cct, compression_type);
   }
@@ -2846,6 +2846,8 @@ void RGWPutObj::execute()
   
   off_t fst;
   off_t lst;
+  const auto& compression_type = store->get_zone_params().get_compression_type(
+      s->bucket_info.placement_rule);
   CompressorRef plugin;
   boost::optional<RGWPutObj_Compress> compressor;
 
@@ -2932,11 +2934,11 @@ void RGWPutObj::execute()
 
   fst = copy_source_range_fst;
   lst = copy_source_range_lst;
-  if (s->cct->_conf->rgw_compression_type != "none") {
-    plugin = get_compressor_plugin(s);
+  if (compression_type != "none") {
+    plugin = get_compressor_plugin(s, compression_type);
     if (!plugin) {
-      ldout(s->cct, 1) << "Cannot load plugin for rgw_compression_type "
-          << s->cct->_conf->rgw_compression_type << dendl;
+      ldout(s->cct, 1) << "Cannot load plugin for compression type "
+          << compression_type << dendl;
     } else {
       compressor.emplace(s->cct, plugin, filter);
       filter = &*compressor;
@@ -3239,12 +3241,13 @@ void RGWPostObj::execute()
   if (op_ret < 0)
     return;
 
-  const auto& compression_type = s->cct->_conf->rgw_compression_type;
+  const auto& compression_type = store->get_zone_params().get_compression_type(
+      s->bucket_info.placement_rule);
   CompressorRef plugin;
   if (compression_type != "none") {
     plugin = Compressor::create(s->cct, compression_type);
     if (!plugin) {
-      ldout(s->cct, 1) << "Cannot load plugin for rgw_compression_type "
+      ldout(s->cct, 1) << "Cannot load plugin for compression type "
           << compression_type << dendl;
     } else {
       compressor.emplace(s->cct, plugin, filter);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1654,6 +1654,17 @@ int RGWZoneParams::set_as_default(bool exclusive)
   return RGWSystemMetaObj::set_as_default(exclusive);
 }
 
+const string& RGWZoneParams::get_compression_type(const string& placement_rule) const
+{
+  static const std::string NONE{"none"};
+  auto p = placement_pools.find(placement_rule);
+  if (p == placement_pools.end()) {
+    return NONE;
+  }
+  const auto& type = p->second.compression_type;
+  return !type.empty() ? type : NONE;
+}
+
 void RGWPeriodMap::encode(bufferlist& bl) const {
   ENCODE_START(2, 1, bl);
   ::encode(id, bl);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7115,11 +7115,12 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
 
   RGWPutObjDataProcessor *filter = &processor;
 
-  const auto& compression_type = cct->_conf->rgw_compression_type;
+  const auto& compression_type = zone_params.get_compression_type(
+      dest_bucket_info.placement_rule);
   if (compression_type != "none") {
     plugin = Compressor::create(cct, compression_type);
     if (!plugin) {
-      ldout(cct, 1) << "Cannot load plugin for rgw_compression_type "
+      ldout(cct, 1) << "Cannot load plugin for compression type "
           << compression_type << dendl;
     } else {
       compressor = boost::in_place(cct, plugin, filter);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -933,20 +933,22 @@ struct RGWZonePlacementInfo {
   string data_pool;
   string data_extra_pool; /* if not set we should use data_pool */
   RGWBucketIndexType index_type;
+  std::string compression_type;
 
   RGWZonePlacementInfo() : index_type(RGWBIType_Normal) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(5, 1, bl);
+    ENCODE_START(6, 1, bl);
     ::encode(index_pool, bl);
     ::encode(data_pool, bl);
     ::encode(data_extra_pool, bl);
     ::encode((uint32_t)index_type, bl);
+    ::encode(compression_type, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(5, bl);
+    DECODE_START(6, bl);
     ::decode(index_pool, bl);
     ::decode(data_pool, bl);
     if (struct_v >= 4) {
@@ -956,6 +958,9 @@ struct RGWZonePlacementInfo {
       uint32_t it;
       ::decode(it, bl);
       index_type = (RGWBucketIndexType)it;
+    }
+    if (struct_v >= 6) {
+      ::decode(compression_type, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -1013,6 +1018,8 @@ struct RGWZoneParams : RGWSystemMetaObj {
   int create_default(bool old_format = false);
   int create(bool exclusive = true);
   int fix_pool_names();
+
+  const string& get_compression_type(const string& placement_rule) const;
   
   void encode(bufferlist& bl) const {
     ENCODE_START(8, 1, bl);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -182,6 +182,7 @@
      --data_extra_pool=<pool>  placement target data extra (non-ec) pool
      --placement-index-type=<type>
                                placement target index type (normal, indexless, or #id)
+     --compression=<type>      placement target compression type (plugin name or empty/none)
      --tier-type=<type>        zone tier type
      --tier-config=<k>=<v>[,...]
                                set zone tier config keys, values


### PR DESCRIPTION
This replaces the `rgw_compression_type` config option with an entry in the zone configuration, which can be set with the `--compression=` option to `radosgw-admin zone create` or `zone modify`.

Also adds some new documentation.