### PR TITLE
test: do not add clang specific #pragma if not compiling with clang

### DIFF
--- a/src/test/TestSignalHandlers.cc
+++ b/src/test/TestSignalHandlers.cc
@@ -46,16 +46,19 @@ static void simple_segv_test()
 
 // Given the name of the function, we can be pretty sure this is intentional.
 
+#ifdef __clang__
 #pragma clang diagnostic push
-
 #pragma clang diagnostic ignored "-Winfinite-recursion"
+#endif
 
 static void infinite_recursion_test_impl()
 {
   infinite_recursion_test_impl();
 }
 
+#ifdef __clang__
 #pragma clang diagnostic pop
+#endif
 
 static void infinite_recursion_test()
 {


### PR DESCRIPTION
this silences the warnings like:

warning:
/srv/autobuild-ceph/gitbuilder.git/build/out~/ceph-11.0.2-1849-gcdc9f9d/src/test/TestSignalHandlers.cc:49:0:
ignoring #pragma clang diagnostic [-Wunknown-pragmas]
^

Signed-off-by: Kefu Chai <kchai@redhat.com>