### PR TITLE
DNM: Fix libcephfs_jni

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -370,13 +370,27 @@ enum {
 extern const char *ceph_mds_op_name(int op);
 
 
-#define CEPH_SETATTR_MODE	(1 << 0)
-#define CEPH_SETATTR_UID	(1 << 1)
-#define CEPH_SETATTR_GID	(1 << 2)
-#define CEPH_SETATTR_MTIME	(1 << 3)
-#define CEPH_SETATTR_ATIME	(1 << 4)
-#define CEPH_SETATTR_SIZE	(1 << 5)
-#define CEPH_SETATTR_CTIME	(1 << 6)
+#ifndef CEPH_SETATTR_MODE
+# define CEPH_SETATTR_MODE	(1 << 0)
+#endif
+#ifndef CEPH_SETATTR_UID
+# define CEPH_SETATTR_UID	(1 << 1)
+#endif
+#ifndef CEPH_SETATTR_GID
+# define CEPH_SETATTR_GID	(1 << 2)
+#endif
+#ifndef CEPH_SETATTR_MTIME
+# define CEPH_SETATTR_MTIME	(1 << 3)
+#endif
+#ifndef CEPH_SETATTR_ATIME
+# define CEPH_SETATTR_ATIME	(1 << 4)
+#endif
+#ifndef CEPH_SETATTR_SIZE
+# define CEPH_SETATTR_SIZE	(1 << 5)
+#endif
+#ifndef CEPH_SETATTR_CTIME
+# define CEPH_SETATTR_CTIME	(1 << 6)
+#endif
 #define CEPH_SETATTR_MTIME_NOW	(1 << 7)
 #define CEPH_SETATTR_ATIME_NOW	(1 << 8)
 

--- a/src/java/java/com/ceph/fs/CephStat.java
+++ b/src/java/java/com/ceph/fs/CephStat.java
@@ -37,6 +37,7 @@ public class CephStat {
   public long blocks;
   public long a_time;
   public long m_time;
+  public long inode;
 
   public boolean isFile() {
     return is_file;

--- a/src/java/native/libcephfs_jni.cc
+++ b/src/java/native/libcephfs_jni.cc
@@ -146,6 +146,7 @@ static jfieldID cephstat_gid_fid;
 static jfieldID cephstat_size_fid;
 static jfieldID cephstat_blksize_fid;
 static jfieldID cephstat_blocks_fid;
+static jfieldID cephstat_inode_fid;
 static jfieldID cephstat_a_time_fid;
 static jfieldID cephstat_m_time_fid;
 static jfieldID cephstat_is_file_fid;
@@ -312,6 +313,7 @@ static void setup_field_ids(JNIEnv *env, jclass clz)
 	GETFID(cephstat, size, J);
 	GETFID(cephstat, blksize, J);
 	GETFID(cephstat, blocks, J);
+	GETFID(cephstat, inode, J);
 	GETFID(cephstat, a_time, J);
 	GETFID(cephstat, m_time, J);
 	GETFID(cephstat, is_file, Z);
@@ -1231,6 +1233,7 @@ static void fill_cephstat(JNIEnv *env, jobject j_cephstat, struct stat *st)
 	env->SetLongField(j_cephstat, cephstat_size_fid, st->st_size);
 	env->SetLongField(j_cephstat, cephstat_blksize_fid, st->st_blksize);
 	env->SetLongField(j_cephstat, cephstat_blocks_fid, st->st_blocks);
+	env->SetLongField(j_cephstat, cephstat_inode_fid, st->st_ino);
 
 	long long time = st->st_mtim.tv_sec;
 	time *= 1000;


### PR DESCRIPTION
1. Fix redefined warning during compiling

2. Can get inode by CephMount.stat