### PR TITLE
PG: check snapset attr when selecting auth shard of objects

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -674,6 +674,28 @@ map<pg_shard_t, ScrubMap *>::const_iterator
       error_string += " oi_attr_corrupted";
       goto out;
     }
+    if (obj.has_snapset()) {
+      bufferlist b;
+      map<string, bufferptr>::iterator m;
+      SnapSet ss;
+      m = i->second.attrs.find(SS_ATTR);
+      if (m == i->second.attrs.end()) {
+        // no snapset on object, probably corrupt
+        shard_info.set_ss_attr_missing();
+        error_string += " ss_attr_missing";
+        goto out;
+      }
+      b.push_back(m->second);
+      try {
+        bufferlist::iterator miter = b.begin();
+        ::decode(ss, miter);
+      } catch (...) {
+        // invalid SnapSet, probably corrupt
+        shard_info.set_ss_attr_corrupted();
+        error_string += " ss_attr_corrupted";
+        goto out;
+      }
+    }
 
     if (auth_version != eversion_t()) {
       if (!object_error.has_object_info_inconsistency() && !(bl == auth_bl)) {


### PR DESCRIPTION
this patch can fix the error that object cannot be repaired
when primary copy misses snapset attr

Signed-off-by: xinxin shu <shuxinxin@chinac.com>