### PR TITLE
doc/rados/configuration/osd-config-ref.rst: document the fast mark down

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -716,6 +716,17 @@ Miscellaneous
 :Default: ``false``
 
 
+``osd fast fail on connection refused``
+
+:Description: If this option is enabled, crashed OSDs are marked down
+              immediately by connected peers and MONs (assuming that the
+              crashed OSD host survives). Disable it to restore old
+              behavior, at the expense of possible long I/O stalls when
+              OSDs crash in the middle of I/O operations.
+:Type: Boolean
+:Default: ``true``
+
+
 
 .. _pool: ../../operations/pools
 .. _Configuring Monitor/OSD Interaction: ../mon-osd-interaction


### PR DESCRIPTION
Document the "osd fast fail on connection refused" option.

Signed-off-by: Piotr Dałek <git@predictor.org.pl>