### PR TITLE
ceph-disk: systemd unit must run after local-fs.target

### DIFF
--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ceph disk activation: %f
+After=local-fs.target
+Wants=local-fs.target
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>