### PR TITLE
jewel: client: fix stale entries in command table

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5509,6 +5509,8 @@ void Client::handle_command_reply(MCommandReply *m)
     op.on_finish->complete(m->r);
   }
 
+  commands.erase(opiter);
+
   m->put();
 }
 


### PR DESCRIPTION
This patch is Jewel-specific because in Kraken
this code was already refactored for CommandTable
and got fixed in the process.

Fixes: http://tracker.ceph.com/issues/17974
Signed-off-by: John Spray <john.spray@redhat.com>