### PR TITLE
os/bluestore: add new garbage collector

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1037,6 +1037,19 @@ OPTION(bluestore_compression_mode, OPT_STR, "none")  // force|aggressive|passive
 OPTION(bluestore_compression_algorithm, OPT_STR, "snappy")
 OPTION(bluestore_compression_min_blob_size, OPT_U32, 128*1024)
 OPTION(bluestore_compression_max_blob_size, OPT_U32, 512*1024)
+/*
+ * Specifies minimum expected amount of saved allocation units
+ * per single blob to enable compressed blobs garbage collection
+ * 
+ */
+OPTION(bluestore_gc_enable_blob_threshold, OPT_INT, 0)  
+/*
+ * Specifies minimum expected amount of saved allocation units
+ * per all blobsb to enable compressed blobs garbage collection
+ * 
+ */
+OPTION(bluestore_gc_enable_total_threshold, OPT_INT, 0)  
+
 OPTION(bluestore_max_blob_size, OPT_U32, 512*1024)
 /*
  * Require the net gain of compression at least to be at this ratio,

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -99,8 +99,6 @@ public:
     const string& path,
     uuid_d *fsid);
 
-  Logger *logger;
-
   /**
    * Fetch Object Store statistics.
    *
@@ -1487,8 +1485,7 @@ public:
 
  public:
   ObjectStore(CephContext* cct,
-	      const std::string& path_) : path(path_), cct(cct),
-					  logger(nullptr) {}
+	      const std::string& path_) : path(path_), cct(cct) {}
   virtual ~ObjectStore() {}
 
   // no copying

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -109,6 +109,14 @@ public:
   virtual objectstore_perf_stat_t get_cur_stats() = 0;
 
   /**
+   * Fetch Object Store performance counters.
+   *
+   *
+   * This appears to be called with nothing locked.
+   */
+  virtual const PerfCounters* get_perf_counters() const = 0;
+
+  /**
    * a sequencer orders transactions
    *
    * Any transactions queued under a given sequencer will be applied in

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -532,6 +532,196 @@ ostream& operator<<(ostream& out, const BlueStore::Buffer& b)
   return out << ")";
 }
 
+// Garbage Collector
+
+void BlueStore::GarbageCollector::process_protrusive_extents(
+  const BlueStore::ExtentMap& extent_map, 
+  uint64_t start_offset,
+  uint64_t end_offset,
+  uint64_t start_touch_offset,
+  uint64_t end_touch_offset,
+  uint64_t min_alloc_size)
+{
+  assert(start_offset <= start_touch_offset && end_offset>= end_touch_offset);
+
+  uint64_t lookup_start_offset = P2ALIGN(start_offset, min_alloc_size);
+  uint64_t lookup_end_offset = ROUND_UP_TO(end_offset, min_alloc_size);
+
+  dout(30) << __func__ << " (hex): [" << std::hex
+           << lookup_start_offset << ", " << lookup_end_offset 
+           << ")" << std::dec << dendl;
+
+  for (auto it = extent_map.seek_lextent(lookup_start_offset);
+       it != extent_map.extent_map.end() &&
+         it->logical_offset < lookup_end_offset;
+       ++it) {
+    uint64_t alloc_unit_start = it->logical_offset / min_alloc_size;
+    uint64_t alloc_unit_end = (it->logical_end() - 1) / min_alloc_size;
+
+    dout(30) << __func__ << " " << *it
+             << "alloc_units: " << alloc_unit_start << ".." << alloc_unit_end
+             << dendl;
+
+    Blob* b = it->blob.get();
+
+    if (it->logical_offset >=start_touch_offset &&
+        it->logical_end() <= end_touch_offset) {
+      // Process extents within the range affected by 
+      // the current write request.
+      // Need to take into account if existing extents
+      // can be merged with them (uncompressed case)
+      if (!b->get_blob().is_compressed()) {
+        if (blob_info_counted && used_alloc_unit == alloc_unit_start) {
+	  --blob_info_counted->expected_allocations; // don't need to allocate
+                                                     // new AU for compressed
+                                                     // data since another
+                                                     // collocated uncompressed
+                                                     // blob already exists
+          dout(30) << __func__  << " --expected:"
+                   << alloc_unit_start << dendl;
+        }
+        used_alloc_unit = alloc_unit_end;
+        blob_info_counted =  nullptr;
+      }
+    } else if (b->get_blob().is_compressed()) {
+
+      // additionally we take compressed blobs that were not impacted
+      // by the write into account too
+      BlobInfo& bi =
+        affected_blobs.emplace(
+          b, BlobInfo(b->get_referenced_bytes())).first->second;
+
+      int adjust =
+       (used_alloc_unit && used_alloc_unit == alloc_unit_start) ? 0 : 1;
+      bi.expected_allocations += alloc_unit_end - alloc_unit_start + adjust;
+      dout(30) << __func__  << " expected_allocations=" 
+               << bi.expected_allocations << " end_au:"
+               << alloc_unit_end << dendl;
+
+      blob_info_counted =  &bi;
+      used_alloc_unit = alloc_unit_end;
+
+      assert(it->length <= bi.referenced_bytes);
+       bi.referenced_bytes -= it->length;
+      dout(30) << __func__ << " affected_blob:" << *b
+               << " unref 0x" << std::hex << it->length
+               << " referenced = 0x" << bi.referenced_bytes
+               << std::dec << dendl;
+      // NOTE: we can't move specific blob to resulting GC list here
+      // when reference counter == 0 since subsequent extents might
+      // decrement its expected_allocation. 
+      // Hence need to enumerate all the extents first.
+      if (!bi.collect_candidate) {
+        bi.first_lextent = it;
+        bi.collect_candidate = true;
+      }
+      bi.last_lextent = it;
+    } else {
+      if (blob_info_counted && used_alloc_unit == alloc_unit_start) {
+        // don't need to allocate new AU for compressed data since another
+        // collocated uncompressed blob already exists
+    	--blob_info_counted->expected_allocations;
+        dout(30) << __func__  << " --expected_allocations:"
+		 << alloc_unit_start << dendl;
+      }
+      used_alloc_unit = alloc_unit_end;
+      blob_info_counted = nullptr;
+    }
+  }
+
+  for (auto b_it = affected_blobs.begin();
+       b_it != affected_blobs.end();
+       ++b_it) {
+    Blob* b = b_it->first;
+    BlobInfo& bi = b_it->second;
+    if (bi.referenced_bytes == 0) {
+      uint64_t len_on_disk = b_it->first->get_blob().get_ondisk_length();
+      int64_t blob_expected_for_release =
+        ROUND_UP_TO(len_on_disk, min_alloc_size) / min_alloc_size;
+
+      dout(30) << __func__ << " " << *(b_it->first)
+               << " expected4release=" << blob_expected_for_release
+               << " expected_allocations=" << bi.expected_allocations
+               << dendl;
+      if (blob_expected_for_release >= bi.expected_allocations) {
+        if (bi.collect_candidate) {
+          auto it = bi.first_lextent;
+          bool bExit = false;
+          do {
+            if (it->blob.get() == b) {
+              extents_to_collect.emplace_back(it->logical_offset, it->length);
+            }
+            bExit = it == bi.last_lextent;
+            ++it;
+          } while(!bExit);
+        }
+        expected_for_release += blob_expected_for_release;
+        expected_allocations += bi.expected_allocations;
+      }
+    }
+  }
+}
+
+int64_t BlueStore::GarbageCollector::estimate(
+  uint64_t start_offset,
+  uint64_t length,
+  const BlueStore::ExtentMap& extent_map,
+  const BlueStore::extent_map_t& old_extents,
+  uint64_t min_alloc_size)
+{
+
+  affected_blobs.clear();
+  extents_to_collect.clear();
+  used_alloc_unit = boost::optional<uint64_t >();
+  blob_info_counted = nullptr;
+
+  gc_start_offset = start_offset;
+  gc_end_offset = start_offset + length;
+
+  uint64_t end_offset = start_offset + length;
+
+  for (auto it = old_extents.begin(); it != old_extents.end(); ++it) {
+    Blob* b = it->blob.get();
+    if (b->get_blob().is_compressed()) {
+
+      // update gc_start_offset/gc_end_offset if needed
+      gc_start_offset = min(gc_start_offset, (uint64_t)it->blob_start());
+      gc_end_offset = max(gc_end_offset, (uint64_t)it->blob_end());
+
+      auto o = it->logical_offset;
+      auto l = it->length;
+
+      uint64_t ref_bytes = b->get_referenced_bytes();
+      assert(l <= ref_bytes);
+      // micro optimization to bypass blobs that have no more references
+      if (ref_bytes != l) {
+        dout(30) << __func__ << " affected_blob:" << *b
+                 << " unref 0x" << std::hex << o << "~" << l
+                 << std::dec << dendl;
+	// emplace () call below returns previously existed entry from
+        // the map if any instead of inserting a new one. Hence we need
+        // to decrement referenced_bytes counter after such an insert.
+	BlobInfo& bi =
+          affected_blobs.emplace(b, BlobInfo(ref_bytes)).first->second;
+        bi.referenced_bytes -= l;
+      }
+    }
+  }
+  dout(30) << __func__ << " gc range(hex): [" << std::hex
+           << gc_start_offset << ", " << gc_end_offset 
+           << ")" << std::dec << dendl;
+
+  // enumerate preceeding extents to check if they reference affected blobs
+  if (gc_start_offset < start_offset || gc_end_offset > end_offset) {
+    process_protrusive_extents(extent_map,
+                               gc_start_offset,
+			       gc_end_offset,
+			       start_offset,
+			       end_offset,
+			       min_alloc_size);
+  }
+  return expected_for_release - expected_allocations;
+}
 
 // Cache
 
@@ -2330,6 +2520,20 @@ BlueStore::extent_map_t::iterator BlueStore::ExtentMap::find_lextent(
 
 BlueStore::extent_map_t::iterator BlueStore::ExtentMap::seek_lextent(
   uint64_t offset)
+{
+  Extent dummy(offset);
+  auto fp = extent_map.lower_bound(dummy);
+  if (fp != extent_map.begin()) {
+    --fp;
+    if (fp->logical_end() <= offset) {
+      ++fp;
+    }
+  }
+  return fp;
+}
+
+BlueStore::extent_map_t::const_iterator BlueStore::ExtentMap::seek_lextent(
+  uint64_t offset) const
 {
   Extent dummy(offset);
   auto fp = extent_map.lower_bound(dummy);
@@ -8509,6 +8713,34 @@ void BlueStore::_wctx_finish(
   }
 }
 
+void BlueStore::_do_garbage_collection(
+  TransContext *txc,
+  CollectionRef& c,
+  OnodeRef o,
+  uint64_t offset,
+  uint64_t length,
+  WriteContext *wctx)
+{
+  GarbageCollector gc(c->store->cct);
+  int64_t benefit = gc.estimate(offset,
+                                length,
+                                o->extent_map,
+                                wctx->old_extents, 
+                                min_alloc_size);
+  if (benefit > 0) {
+    auto& extents_to_collect = gc.get_extents_to_collect();
+    for (auto it = extents_to_collect.begin();
+         it != extents_to_collect.end();
+         ++it) {
+      bufferlist bl;
+      int r = _do_read(c.get(), o, it->offset, it->length, bl, 0);
+      assert(r == (int)it->length);
+      o->extent_map.fault_range(db, it->offset, it->length);
+      _do_write_data(txc, c, o, it->offset, it->length, bl, wctx);
+    }
+  }
+}
+
 void BlueStore::_do_write_data(
   TransContext *txc,
   CollectionRef& c,
@@ -8675,6 +8907,8 @@ int BlueStore::_do_write(
 
   o->extent_map.fault_range(db, offset, length);
   _do_write_data(txc, c, o, offset, length, bl, &wctx);
+
+  _do_garbage_collection(txc, c, o, offset, length, &wctx);
 
   r = _do_alloc_write(txc, c, &wctx);
   if (r < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8430,7 +8430,7 @@ int BlueStore::_do_alloc_write(
     // counting machinery.
     assert(!b->is_referenced());
     b->get_ref(coll.get(), wi.b_off0, wi.length0); 
-                                                   
+                                               
 
     // queue io
     if (!g_conf->bluestore_debug_omit_block_device_write) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -106,6 +106,7 @@ enum {
   l_bluestore_onode_reshard,
   l_bluestore_blob_split,
   l_bluestore_extent_compress,
+  l_bluestore_gc_merged,
   l_bluestore_last
 };
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2154,6 +2154,9 @@ public:
     perf_tracker.update_from_perfcounters(*logger);
     return perf_tracker.get_cur_stats();
   }
+  const PerfCounters* get_perf_counters() const {
+    return logger;
+  }
 
   int queue_transactions(
     Sequencer *osr,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -631,11 +631,11 @@ public:
       return a.logical_offset == b.logical_offset;
     }
 
-    uint32_t blob_start() {
+    uint32_t blob_start() const {
       return logical_offset - blob_offset;
     }
 
-    uint32_t blob_end() {
+    uint32_t blob_end() const {
       return blob_start() + blob->get_blob().get_logical_length();
     }
 
@@ -645,7 +645,7 @@ public:
 
     // return true if any piece of the blob is out of
     // the given range [o, o + l].
-    bool blob_escapes_range(uint32_t o, uint32_t l) {
+    bool blob_escapes_range(uint32_t o, uint32_t l) const {
       return blob_start() < o || blob_end() > o + l;
     }
   };
@@ -764,6 +764,7 @@ public:
 
     /// seek to the first lextent including or after offset
     extent_map_t::iterator seek_lextent(uint64_t offset);
+    extent_map_t::const_iterator seek_lextent(uint64_t offset) const;
 
     /// add a new Extent
     void add(uint32_t lo, uint32_t o, uint32_t l, BlobRef& b) {
@@ -792,6 +793,113 @@ public:
 
     /// split a blob (and referring extents)
     BlobRef split_blob(BlobRef lb, uint32_t blob_offset, uint32_t pos);
+  };
+
+  /// Compressed Blob Garbage collector
+  /*
+  The primary idea of the collector is to estimate a difference between
+  allocation units(AU) currently present for compressed blobs and new AUs
+  required to store that data uncompressed. 
+  Estimation is performed for protrusive extents within a logical range
+  determined by a concatenation of old_extents collection and specific(current)
+  write request.
+  The root cause for old_extents use is the need to handle blob ref counts
+  properly. Old extents still hold blob refs and hence we need to traverse
+  the collection to determine if blob to be released.
+  Protrusive extents are extents that fit into the blob set in action
+  (ones that are below the logical range from above) but not removed totally
+  due to the current write. 
+  E.g. for
+  extent1 <loffs = 100, boffs = 100, len  = 100> -> 
+    blob1<compressed, len_on_disk=4096, logical_len=8192>
+  extent2 <loffs = 200, boffs = 200, len  = 100> ->
+    blob2<raw, len_on_disk=4096, llen=4096>
+  extent3 <loffs = 300, boffs = 300, len  = 100> ->
+    blob1<compressed, len_on_disk=4096, llen=8192>
+  extent4 <loffs = 4096, boffs = 0, len  = 100>  ->
+    blob3<raw, len_on_disk=4096, llen=4096>
+  write(300~100)
+  protrusive extents are within the following ranges <0~300, 400~8192-400>
+  In this case existing AUs that might be removed due to GC (i.e. blob1) 
+  use 2x4K bytes.
+  And new AUs expected after GC = 0 since extent1 to be merged into blob2.
+  Hence we should do a collect.
+  */
+  class GarbageCollector
+  {
+  public:
+    /// return amount of allocation units that might be saved due to GC
+    int64_t estimate(
+      uint64_t offset,
+      uint64_t length,
+      const ExtentMap& extent_map,
+      const extent_map_t& old_extents,
+      uint64_t min_alloc_size);
+
+    /// return a collection of extents to perform GC on
+    const vector<AllocExtent>& get_extents_to_collect() const {
+      return extents_to_collect;
+    }
+    GarbageCollector(CephContext* _cct) : cct(_cct) {}
+
+  private:
+    struct BlobInfo {
+      uint64_t referenced_bytes = 0;    ///< amount of bytes referenced in blob
+      int64_t expected_allocations = 0; ///< new alloc units required 
+                                        ///< in case of gc fulfilled
+      bool collect_candidate = false;   ///< indicate if blob has any extents 
+                                        ///< eligible for GC.
+      extent_map_t::const_iterator first_lextent; ///< points to the first 
+                                                  ///< lextent referring to 
+                                                  ///< the blob if any.
+                                                  ///< collect_candidate flag 
+                                                  ///< determines the validity
+      extent_map_t::const_iterator last_lextent;  ///< points to the last 
+                                                  ///< lextent referring to 
+                                                  ///< the blob if any.
+
+      BlobInfo(uint64_t ref_bytes) :
+        referenced_bytes(ref_bytes) {
+      }
+    };
+    CephContext* cct;
+    map<Blob*, BlobInfo> affected_blobs; ///< compressed blobs and their ref_map
+                                         ///< copies that are affected by the
+                                         ///< specific write
+
+    vector<AllocExtent> extents_to_collect; ///< protrusive extents that should
+                                            ///< be collected if GC takes place
+
+    boost::optional<uint64_t > used_alloc_unit; ///< last processed allocation
+                                                ///<  unit when traversing 
+                                                ///< protrusive extents. 
+                                                ///< Other extents mapped to
+                                                ///< this AU to be ignored 
+                                                ///< (except the case where
+                                                ///< uncompressed extent follows
+                                                ///< compressed one - see below).
+    BlobInfo* blob_info_counted = nullptr; ///< set if previous allocation unit
+                                           ///< caused expected_allocations
+					   ///< counter increment at this blob.
+                                           ///< if uncompressed extent follows 
+                                           ///< a decrement for the 
+                                	   ///< expected_allocations counter 
+                                           ///< is needed
+    int64_t expected_allocations = 0;      ///< new alloc units required in case
+                                           ///< of gc fulfilled
+    int64_t expected_for_release = 0;      ///< alloc units currently used by
+                                           ///< compressed blobs that might
+                                           ///< gone after GC
+    uint64_t gc_start_offset;              ///starting offset for GC
+    uint64_t gc_end_offset;                ///ending offset for GC
+
+  protected:
+    void process_protrusive_extents(const BlueStore::ExtentMap& extent_map, 
+				    uint64_t start_offset,
+				    uint64_t end_offset,
+				    uint64_t start_touch_offset,
+				    uint64_t end_touch_offset,
+				    uint64_t min_alloc_size);
   };
 
   struct OnodeSpace;
@@ -2197,6 +2305,12 @@ private:
                       uint64_t length,
                       bufferlist& bl,
                       WriteContext *wctx);
+  void _do_garbage_collection(TransContext *txc,
+			      CollectionRef& c,
+			      OnodeRef o,
+			      uint64_t offset,
+			      uint64_t length,
+			      WriteContext *wctx);
 
   int _touch(TransContext *txc,
 	     CollectionRef& c,

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -78,6 +78,9 @@ public:
   uint64_t end() const {
     return offset + length;
   }
+  bool operator==(const AllocExtent& other) const {
+    return offset == other.offset && length == other.length;
+  }
 };
 
 inline static ostream& operator<<(ostream& out, const AllocExtent& e) {

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -141,6 +141,9 @@ public:
     perf_tracker.update_from_perfcounters(*logger);
     return perf_tracker.get_cur_stats();
   }
+  const PerfCounters* get_perf_counters() const {
+    return logger;
+  }
 
 private:
   string internal_name;         ///< internal name, used to name the perfcounter instance

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -553,6 +553,10 @@ public:
   objectstore_perf_stat_t get_cur_stats() {
     return objectstore_perf_stat_t();
   }
+  const PerfCounters* get_perf_counters() const {
+    return logger;
+  }
+
 
   int queue_transactions(
     Sequencer *osr,

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -385,6 +385,11 @@ public:
 
   objectstore_perf_stat_t get_cur_stats() override;
 
+  const PerfCounters* get_perf_counters() const {
+    return nullptr;
+  }
+
+
   int queue_transactions(
     Sequencer *osr, vector<Transaction>& tls,
     TrackedOpRef op = TrackedOpRef(),

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1236,6 +1236,9 @@ TEST_P(StoreTest, BluestoreStatFSTest) {
     return;
   g_conf->set_val("bluestore_compression_mode", "force");
   g_conf->set_val("bluestore_min_alloc_size", "65536");
+ 
+ // just a big number to disble gc
+  g_conf->set_val("bluestore_gc_enable_total_threshold", "100000");
   g_ceph_context->_conf->apply_changes(NULL);
   int r = store->umount();
   ASSERT_EQ(r, 0);
@@ -1474,6 +1477,7 @@ TEST_P(StoreTest, BluestoreStatFSTest) {
     ASSERT_EQ( 0u, statfs.compressed);
     ASSERT_EQ( 0u, statfs.compressed_allocated);
   }
+  g_conf->set_val("bluestore_gc_enable_total_threshold", "0");
   g_conf->set_val("bluestore_compression_mode", "none");
   g_conf->set_val("bluestore_min_alloc_size", "0");
   g_ceph_context->_conf->apply_changes(NULL);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -20,6 +20,7 @@
 #include <sys/mount.h>
 #include "os/ObjectStore.h"
 #include "os/filestore/FileStore.h"
+#include "os/bluestore/BlueStore.h"
 #include "include/Context.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
@@ -5841,6 +5842,169 @@ TEST_P(StoreTest, KVDBStatsTest) {
   g_conf->set_val("rocksdb_collect_compaction_stats", "false");
   g_conf->set_val("rocksdb_collect_extended_stats","false");
   g_conf->set_val("rocksdb_collect_memory_stats","false");
+}
+
+TEST_P(StoreTest, garbageCollection) {
+  ObjectStore::Sequencer osr("test");
+  int r;
+  coll_t cid;
+  int buf_len = 256 * 1024;
+  int overlap_offset = 64 * 1024;
+  int write_offset = buf_len;
+  if (string(GetParam()) != "bluestore")
+    return;
+
+#define WRITE_AT(offset, _length) {\
+      ObjectStore::Transaction t;\
+      if ((uint64_t)_length != bl.length()) { \
+        buffer::ptr p(bl.c_str(), _length);\
+        bufferlist bl_tmp;\
+        bl_tmp.push_back(p);\
+        t.write(cid, hoid, offset, bl_tmp.length(), bl_tmp);\
+      } else {\
+        t.write(cid, hoid, offset, bl.length(), bl);\
+      }\
+      r = apply_transaction(store, &osr, std::move(t));\
+      ASSERT_EQ(r, 0);\
+  }
+  g_conf->set_val("bluestore_min_alloc_size", "65536");
+  g_conf->set_val("bluestore_compression_min_blob_size", "262144");
+  g_conf->set_val("bluestore_compression_mode", "force");
+  g_ceph_context->_conf->apply_changes(NULL);
+
+  ghobject_t hoid(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  {
+    bufferlist in;
+    r = store->read(cid, hoid, 0, 5, in);
+    ASSERT_EQ(-ENOENT, r);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    cerr << "Creating collection " << cid << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+
+  std::string data;
+  data.resize(buf_len);
+
+  {
+    { 
+      bool exists = store->exists(cid, hoid);
+      ASSERT_TRUE(!exists);
+
+      ObjectStore::Transaction t;
+      t.touch(cid, hoid);
+      cerr << "Creating object " << hoid << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+
+      exists = store->exists(cid, hoid);
+      ASSERT_EQ(true, exists);
+    } 
+    bufferlist bl;
+
+    for(size_t i = 0; i < data.size(); i++)
+      data[i] = i % 256;
+
+    bl.append(data);
+
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(0, buf_len);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x10000);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(write_offset - 2 * overlap_offset, buf_len);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x20000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0u);
+    }
+
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(write_offset - overlap_offset, buf_len);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x20000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x10000u);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(write_offset - 3 * overlap_offset, buf_len);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x20000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x20000u);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(write_offset + 1, overlap_offset-1);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x20000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x20000u);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(write_offset + 1, overlap_offset);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x10000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x3ffffu);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(0, buf_len-1);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x10000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x40001u);
+    }
+    g_conf->set_val("bluestore_gc_enable_total_threshold", "1"); //forbid GC when saving = 0
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(1, overlap_offset-2);
+      WRITE_AT(overlap_offset * 2 + 1, overlap_offset-2);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x10000);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x40001u);
+    }
+    {
+      struct store_statfs_t statfs;
+      WRITE_AT(overlap_offset + 1, overlap_offset-2);
+      int r = store->statfs(&statfs);
+      ASSERT_EQ(r, 0);
+      ASSERT_EQ(statfs.compressed_allocated, 0x0);
+      const PerfCounters* counters = store->get_perf_counters();
+      ASSERT_EQ(counters->get(l_bluestore_gc_merged), 0x40007u);
+    }
+    {
+      ObjectStore::Transaction t;
+      t.remove(cid, hoid);
+      cerr << "Cleaning" << std::endl;
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+    }
+  }
+  g_conf->set_val("bluestore_gc_enable_total_threshold", "0");
+  g_conf->set_val("bluestore_compression_min_blob_size", "131072");
+  g_conf->set_val("bluestore_compression_mode", "none");
+  g_conf->set_val("bluestore_min_blob_size", "0");
+  g_ceph_context->_conf->apply_changes(NULL);
 }
 
 int main(int argc, char **argv) {

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5754,7 +5754,7 @@ TEST_P(StoreTest, OnodeSizeTracking) {
     ASSERT_EQ(r, 0);
   }
   g_ceph_context->_conf->set_val("bluestore_cache_size", "4000000");
-  g_conf->set_val("bluestore_min_alloc_size", stringify(block_size));
+  g_conf->set_val("bluestore_min_alloc_size", "0");
   g_conf->set_val("bluestore_compression_mode", "none");
   g_conf->set_val("bluestore_csum_type", "crc32c");
 

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1214,6 +1214,290 @@ TEST(ExtentMap, compress_extent_map)
   ASSERT_EQ(6u, em.extent_map.size());
 }
 
+TEST(GarbageCollector, BasicTest)
+{
+  BlueStore::LRUCache cache(g_ceph_context);
+  BlueStore store(g_ceph_context, "", 4096);
+  BlueStore::Collection coll(&store, &cache, coll_t());
+  BlueStore::Onode onode(&coll, ghobject_t(), "");
+  BlueStore::ExtentMap em(&onode);
+
+  BlueStore::extent_map_t old_extents;
+
+
+ /*
+  min_alloc_size = 4096
+  original disposition
+  extent1 <loffs = 100, boffs = 100, len  = 10>
+    -> blob1<compressed, len_on_disk=4096, logical_len=8192>
+  extent2 <loffs = 200, boffs = 200, len  = 10>
+    -> blob2<raw, len_on_disk=4096, llen=4096>
+  extent3 <loffs = 300, boffs = 300, len  = 10>
+    -> blob1<compressed, len_on_disk=4096, llen=8192>
+  extent4 <loffs = 4096, boffs = 0, len  = 10>
+    -> blob3<raw, len_on_disk=4096, llen=4096>
+  on write(300~100) resulted in
+  extent1 <loffs = 100, boffs = 100, len  = 10>
+    -> blob1<compressed, len_on_disk=4096, logical_len=8192>
+  extent2 <loffs = 200, boffs = 200, len  = 10>
+    -> blob2<raw, len_on_disk=4096, llen=4096>
+  extent3 <loffs = 300, boffs = 300, len  = 100>
+    -> blob4<raw, len_on_disk=4096, llen=4096>
+  extent4 <loffs = 4096, boffs = 0, len  = 10>
+    -> blob3<raw, len_on_disk=4096, llen=4096>
+  */  
+  {
+    BlueStore::GarbageCollector gc(g_ceph_context);
+    int64_t saving;
+    BlueStore::BlobRef b1(new BlueStore::Blob);
+    BlueStore::BlobRef b2(new BlueStore::Blob);
+    BlueStore::BlobRef b3(new BlueStore::Blob);
+    BlueStore::BlobRef b4(new BlueStore::Blob);
+    b1->shared_blob = new BlueStore::SharedBlob(&coll);
+    b2->shared_blob = new BlueStore::SharedBlob(&coll);
+    b3->shared_blob = new BlueStore::SharedBlob(&coll);
+    b4->shared_blob = new BlueStore::SharedBlob(&coll);
+    b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b1->dirty_blob().compressed_length_orig = 0x2000;
+    b1->dirty_blob().compressed_length = 0x1000;
+    b1->dirty_blob().extents.emplace_back(0, 0x1000);
+    b2->dirty_blob().extents.emplace_back(1, 0x1000);
+    b3->dirty_blob().extents.emplace_back(2, 0x1000);
+    b4->dirty_blob().extents.emplace_back(3, 0x1000);
+    em.extent_map.insert(*new BlueStore::Extent(100, 100, 10, b1));
+    b1->get_ref(&coll, 100, 10);
+    em.extent_map.insert(*new BlueStore::Extent(200, 200, 10, b2));
+    b2->get_ref(&coll, 200, 10);
+    em.extent_map.insert(*new BlueStore::Extent(300, 300, 100, b4));
+    b4->get_ref(&coll, 300, 100);
+    em.extent_map.insert(*new BlueStore::Extent(4096, 0, 10, b3));
+    b3->get_ref(&coll, 0, 10);
+
+    old_extents.push_back(*new BlueStore::Extent(300, 300, 10, b1)); 
+    b1->get_ref(&coll, 300, 10);
+
+    saving = gc.estimate(300, 100, em, old_extents, 4096);
+    ASSERT_EQ(saving, 1);
+    auto& to_collect = gc.get_extents_to_collect();
+    ASSERT_EQ(to_collect.size(), 1u);
+    ASSERT_EQ(to_collect[0], AllocExtent(100,10) );
+
+    em.clear();
+    old_extents.clear();
+  }
+ /*
+  original disposition
+  min_alloc_size = 0x10000
+  extent1 <loffs = 0, boffs = 0, len  = 0x40000>
+    -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
+  Write 0x8000~37000 resulted in the following extent map prior to GC
+  for the last write_small(0x30000~0xf000):
+
+  extent1 <loffs = 0, boffs = 0, len  = 0x8000>
+    -> blob1<compressed, len_on_disk=0x20000, logical_len=0x40000>
+  extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
+    -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
+  extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
+    -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
+  extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
+    -> blob4<raw, len_on_disk=0x10000, llen=0x10000>
+  extent5 <loffs = 0x3f000, boffs = 0x3f000, len  = 0x1000>
+    -> blob1<compressed, len_on_disk=0x20000, llen=0x40000>
+  */  
+  {
+    BlueStore store(g_ceph_context, "", 0x10000);
+    BlueStore::Collection coll(&store, &cache, coll_t());
+    BlueStore::Onode onode(&coll, ghobject_t(), "");
+    BlueStore::ExtentMap em(&onode);
+
+    BlueStore::extent_map_t old_extents;
+    BlueStore::GarbageCollector gc(g_ceph_context);
+    int64_t saving;
+    BlueStore::BlobRef b1(new BlueStore::Blob);
+    BlueStore::BlobRef b2(new BlueStore::Blob);
+    BlueStore::BlobRef b3(new BlueStore::Blob);
+    BlueStore::BlobRef b4(new BlueStore::Blob);
+    b1->shared_blob = new BlueStore::SharedBlob(&coll);
+    b2->shared_blob = new BlueStore::SharedBlob(&coll);
+    b3->shared_blob = new BlueStore::SharedBlob(&coll);
+    b4->shared_blob = new BlueStore::SharedBlob(&coll);
+    b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b1->dirty_blob().extents.emplace_back(0, 0x20000);
+    b1->dirty_blob().compressed_length = 0x20000;
+    b1->dirty_blob().compressed_length_orig = 0x40000;
+    b2->dirty_blob().extents.emplace_back(1, 0x10000);
+    b3->dirty_blob().extents.emplace_back(2, 0x20000);
+    b4->dirty_blob().extents.emplace_back(3, 0x10000);
+
+    em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b1));
+    b1->get_ref(&coll, 0, 0x8000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
+    b2->get_ref(&coll, 0x8000, 0x8000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
+    b3->get_ref(&coll, 0, 0x20000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
+    b4->get_ref(&coll, 0, 0xf000);
+    em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x3f000, 0x1000, b1));
+    b1->get_ref(&coll, 0x3f000, 0x1000);
+
+    old_extents.push_back(*new BlueStore::Extent(0x8000, 0x8000, 0x8000, b1)); 
+    b1->get_ref(&coll, 0x8000, 0x8000);
+    old_extents.push_back(
+      *new BlueStore::Extent(0x10000, 0x10000, 0x20000, b1));
+    b1->get_ref(&coll, 0x10000, 0x20000);
+    old_extents.push_back(*new BlueStore::Extent(0x30000, 0x30000, 0xf000, b1)); 
+    b1->get_ref(&coll, 0x30000, 0xf000);
+
+    saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
+    ASSERT_EQ(saving, 2);
+    auto& to_collect = gc.get_extents_to_collect();
+    ASSERT_EQ(to_collect.size(), 2u);
+    ASSERT_TRUE(to_collect[0] == AllocExtent(0x0,0x8000) ||
+		  to_collect[1] == AllocExtent(0x0,0x8000));
+    ASSERT_TRUE(to_collect[0] == AllocExtent(0x3f000,0x1000) ||
+		  to_collect[1] == AllocExtent(0x3f000,0x1000));
+
+    em.clear();
+    old_extents.clear();
+  }
+ /*
+  original disposition
+  min_alloc_size = 0x1000
+  extent1 <loffs = 0, boffs = 0, len  = 0x4000>
+    -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
+  write 0x3000~4000 resulted in the following extent map
+  (future feature - suppose we can compress incoming write prior to
+  GC invocation)
+
+  extent1 <loffs = 0, boffs = 0, len  = 0x4000>
+    -> blob1<compressed, len_on_disk=0x2000, logical_len=0x4000>
+  extent2 <loffs = 0x3000, boffs = 0, len  = 0x4000>
+    -> blob2<compressed, len_on_disk=0x2000, llen=0x4000>
+  */  
+  {
+    BlueStore::GarbageCollector gc(g_ceph_context);
+    int64_t saving;
+    BlueStore::BlobRef b1(new BlueStore::Blob);
+    BlueStore::BlobRef b2(new BlueStore::Blob);
+    b1->shared_blob = new BlueStore::SharedBlob(&coll);
+    b2->shared_blob = new BlueStore::SharedBlob(&coll);
+    b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b1->dirty_blob().extents.emplace_back(0, 0x2000);
+    b1->dirty_blob().compressed_length_orig = 0x4000;
+    b1->dirty_blob().compressed_length = 0x2000;
+    b2->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b2->dirty_blob().extents.emplace_back(0, 0x2000);
+    b2->dirty_blob().compressed_length_orig = 0x4000;
+    b2->dirty_blob().compressed_length = 0x2000;
+
+    em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x3000, b1));
+    b1->get_ref(&coll, 0, 0x3000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x3000, 0, 0x4000, b2)); // new extent
+    b2->get_ref(&coll, 0, 0x4000);
+
+    old_extents.push_back(*new BlueStore::Extent(0x3000, 0x3000, 0x1000, b1)); 
+    b1->get_ref(&coll, 0x3000, 0x1000);
+
+    saving = gc.estimate(0x3000, 0x4000, em, old_extents, 0x1000);
+    ASSERT_EQ(saving, 0);
+    auto& to_collect = gc.get_extents_to_collect();
+    ASSERT_EQ(to_collect.size(), 0u);
+    em.clear();
+    old_extents.clear();
+  }
+ /*
+  original disposition
+  min_alloc_size = 0x10000
+  extent0 <loffs = 0, boffs = 0, len  = 0x20000>
+    -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
+  extent1 <loffs = 0x20000, boffs = 0, len  = 0x20000>
+     -> blob1<compressed, len_on_disk=0x10000, logical_len=0x20000>
+  write 0x8000~37000 resulted in the following extent map prior
+  to GC for the last write_small(0x30000~0xf000)
+
+  extent0 <loffs = 0, boffs = 0, len  = 0x8000>
+    -> blob0<compressed, len_on_disk=0x10000, logical_len=0x20000>
+  extent2 <loffs = 0x8000, boffs = 0x8000, len  = 0x8000>
+    -> blob2<raw, len_on_disk=0x10000, llen=0x10000>
+  extent3 <loffs = 0x10000, boffs = 0, len  = 0x20000>
+    -> blob3<raw, len_on_disk=0x20000, llen=0x20000>
+  extent4 <loffs = 0x30000, boffs = 0, len  = 0xf000>
+    -> blob4<raw, len_on_disk=0x1000, llen=0x1000>
+  extent5 <loffs = 0x3f000, boffs = 0x1f000, len  = 0x1000>
+   -> blob1<compressed, len_on_disk=0x10000, llen=0x20000>
+  */  
+  {
+    BlueStore store(g_ceph_context, "", 0x10000);
+    BlueStore::Collection coll(&store, &cache, coll_t());
+    BlueStore::Onode onode(&coll, ghobject_t(), "");
+    BlueStore::ExtentMap em(&onode);
+
+    BlueStore::extent_map_t old_extents;
+    BlueStore::GarbageCollector gc(g_ceph_context);
+    int64_t saving;
+    BlueStore::BlobRef b0(new BlueStore::Blob);
+    BlueStore::BlobRef b1(new BlueStore::Blob);
+    BlueStore::BlobRef b2(new BlueStore::Blob);
+    BlueStore::BlobRef b3(new BlueStore::Blob);
+    BlueStore::BlobRef b4(new BlueStore::Blob);
+    b0->shared_blob = new BlueStore::SharedBlob(&coll);
+    b1->shared_blob = new BlueStore::SharedBlob(&coll);
+    b2->shared_blob = new BlueStore::SharedBlob(&coll);
+    b3->shared_blob = new BlueStore::SharedBlob(&coll);
+    b4->shared_blob = new BlueStore::SharedBlob(&coll);
+    b0->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b0->dirty_blob().extents.emplace_back(0, 0x10000);
+    b0->dirty_blob().compressed_length_orig = 0x20000;
+    b0->dirty_blob().compressed_length = 0x10000;
+    b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
+    b1->dirty_blob().extents.emplace_back(0, 0x10000);
+    b1->dirty_blob().compressed_length_orig = 0x20000;
+    b1->dirty_blob().compressed_length = 0x10000;
+    b2->dirty_blob().extents.emplace_back(1, 0x10000);
+    b3->dirty_blob().extents.emplace_back(2, 0x20000);
+    b4->dirty_blob().extents.emplace_back(3, 0x1000);
+
+    em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b0));
+    b0->get_ref(&coll, 0, 0x8000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x8000, 0x8000, 0x8000, b2)); // new extent
+    b2->get_ref(&coll, 0x8000, 0x8000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x10000, 0, 0x20000, b3)); // new extent
+    b3->get_ref(&coll, 0, 0x20000);
+    em.extent_map.insert(
+      *new BlueStore::Extent(0x30000, 0, 0xf000, b4)); // new extent
+    b4->get_ref(&coll, 0, 0xf000);
+    em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x1f000, 0x1000, b1));
+    b1->get_ref(&coll, 0x1f000, 0x1000);
+
+    old_extents.push_back(*new BlueStore::Extent(0x8000, 0x8000, 0x8000, b0)); 
+    b0->get_ref(&coll, 0x8000, 0x8000);
+    old_extents.push_back(
+      *new BlueStore::Extent(0x10000, 0x10000, 0x10000, b0)); 
+    b0->get_ref(&coll, 0x10000, 0x10000);
+    old_extents.push_back(
+      *new BlueStore::Extent(0x20000, 0x00000, 0x1f000, b1)); 
+    b1->get_ref(&coll, 0x0, 0x1f000);
+
+    saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
+    ASSERT_EQ(saving, 2);
+    auto& to_collect = gc.get_extents_to_collect();
+    ASSERT_EQ(to_collect.size(), 2u);
+    ASSERT_TRUE(to_collect[0] == AllocExtent(0x0,0x8000) ||
+		  to_collect[1] == AllocExtent(0x0,0x8000));
+    ASSERT_TRUE(to_collect[0] == AllocExtent(0x3f000,0x1000) ||
+		  to_collect[1] == AllocExtent(0x3f000,0x1000));
+
+    em.clear();
+    old_extents.clear();
+  }
+ }
+
 int main(int argc, char **argv) {
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -996,7 +996,7 @@ TEST(Blob, legacy_decode)
     BlueStore::Blob Bres, Bres2;
     Bres.shared_blob = new BlueStore::SharedBlob(&coll);
     Bres2.shared_blob = new BlueStore::SharedBlob(&coll);
-   
+
     uint64_t sbid, sbid2;
     Bres.decode(
       &coll,


### PR DESCRIPTION
This is a final version version that estimates how many allocation units one can save if uncompress overlapped blob(s) and save them in raw format.
Rebased on top of PR #12904 