### PR TITLE
client: trim_caps() do not dereference cap if it's removed

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -621,7 +621,7 @@ protected:
   void add_update_cap(Inode *in, MetaSession *session, uint64_t cap_id,
 		      unsigned issued, unsigned seq, unsigned mseq, inodeno_t realm,
 		      int flags, const UserPerm& perms);
-  void remove_cap(Cap *cap, bool queue_release);
+  Cap* remove_cap(Cap *cap, bool queue_release);
   void remove_all_caps(Inode *in);
   void remove_session_caps(MetaSession *session);
   void mark_caps_dirty(Inode *in, int caps);


### PR DESCRIPTION
this silences the warning of "Use of memory after it is freed" reported
by clang static analyzer.

Reported-by: Brad Hubbard <bhubbard@redhat.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>