### PR TITLE
global: start removing g_ceph_context

### DIFF
--- a/qa/suites/rados/multimon/clusters/3.yaml
+++ b/qa/suites/rados/multimon/clusters/3.yaml
@@ -1,5 +1,6 @@
 roles:
-- [mon.a, mon.b, mon.c, osd.0, osd.1]
+- [mon.a, mon.c, osd.0]
+- [mon.b, osd.1]
 openstack:
 - volumes: # attached to each instance
     count: 2

--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -1,10 +1,8 @@
-overrides:
-  ceph:
-    conf:
-      mon.b:
-        clock offset: 10
 tasks:
 - install:
+- exec:
+    mon.b:
+    - date -u -s @$(expr $(date -u +%s) + 10)
 - ceph:
     wait-for-healthy: false
     log-whitelist:

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -446,7 +446,7 @@ int CryptoKey::create(CephContext *cct, int t)
   r = _set_secret(t, s);
   if (r < 0)
     return r;
-  created = ceph_clock_now(cct);
+  created = ceph_clock_now();
   return r;
 }
 

--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -179,7 +179,7 @@ bool CephXTicketHandler::verify_service_ticket_reply(CryptoKey& secret,
            << " validity=" << msg_a.validity << dendl;
   session_key = msg_a.session_key;
   if (!msg_a.validity.is_zero()) {
-    expires = ceph_clock_now(cct);
+    expires = ceph_clock_now();
     expires += msg_a.validity;
     renew_after = expires;
     renew_after -= ((double)msg_a.validity.sec() / 4);
@@ -193,7 +193,7 @@ bool CephXTicketHandler::verify_service_ticket_reply(CryptoKey& secret,
 bool CephXTicketHandler::have_key()
 {
   if (have_key_flag) {
-    have_key_flag = ceph_clock_now(cct) < expires;
+    have_key_flag = ceph_clock_now() < expires;
   }
 
   return have_key_flag;
@@ -202,7 +202,7 @@ bool CephXTicketHandler::have_key()
 bool CephXTicketHandler::need_key() const
 {
   if (have_key_flag) {
-    return (!expires.is_zero()) && (ceph_clock_now(cct) >= renew_after);
+    return (!expires.is_zero()) && (ceph_clock_now() >= renew_after);
   }
 
   return true;

--- a/src/auth/cephx/CephxServiceHandler.cc
+++ b/src/auth/cephx/CephxServiceHandler.cc
@@ -106,7 +106,7 @@ int CephxServiceHandler::handle_request(bufferlist::iterator& indata, bufferlist
         should_enc_ticket = true;
       }
 
-      info.ticket.init_timestamps(ceph_clock_now(cct), cct->_conf->auth_mon_ticket_ttl);
+      info.ticket.init_timestamps(ceph_clock_now(), cct->_conf->auth_mon_ticket_ttl);
       info.ticket.name = entity_name;
       info.ticket.global_id = global_id;
       info.ticket.auid = eauth.auid;

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include <sys/stat.h>
@@ -37,11 +37,13 @@ using namespace std;
 #include "global/signal_handler.h"
 #include "common/Preforker.h"
 #include "common/safe_io.h"
-       
+
 #include <sys/types.h>
 #include <fcntl.h>
 
 #include <fuse.h>
+
+#define dout_context g_ceph_context
 
 static void fuse_usage()
 {

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -46,6 +46,7 @@ using namespace std;
 
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 void usage()

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -47,6 +47,7 @@ using namespace std;
 
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 
 namespace {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -1630,7 +1630,7 @@ int Client::make_request(MetaRequest *request,
   request->set_tid(tid);
 
   // and timestamp
-  request->op_stamp = ceph_clock_now(NULL);
+  request->op_stamp = ceph_clock_now();
 
   // make note
   mds_requests[tid] = request->get();
@@ -1747,7 +1747,7 @@ int Client::make_request(MetaRequest *request,
     pdirbl->claim(reply->get_extra_bl());
 
   // -- log times --
-  utime_t lat = ceph_clock_now(cct);
+  utime_t lat = ceph_clock_now();
   lat -= request->sent_stamp;
   ldout(cct, 20) << "lat " << lat << dendl;
   logger->tinc(l_c_lat, lat);
@@ -2138,7 +2138,7 @@ void Client::send_request(MetaRequest *request, MetaSession *session,
   }
 
   if (request->mds == -1) {
-    request->sent_stamp = ceph_clock_now(cct);
+    request->sent_stamp = ceph_clock_now();
     ldout(cct, 20) << "send_request set sent_stamp to " << request->sent_stamp << dendl;
   }
   request->mds = mds;
@@ -3158,7 +3158,7 @@ int Client::get_caps_used(Inode *in)
 void Client::cap_delay_requeue(Inode *in)
 {
   ldout(cct, 10) << "cap_delay_requeue on " << *in << dendl;
-  in->hold_caps_until = ceph_clock_now(cct);
+  in->hold_caps_until = ceph_clock_now();
   in->hold_caps_until += cct->_conf->client_caps_release_delay;
   delayed_caps.push_back(&in->cap_item);
 }
@@ -3334,7 +3334,7 @@ void Client::check_caps(Inode *in, unsigned flags)
   else
     cap_delay_requeue(in);
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   map<mds_rank_t, Cap*>::iterator it = in->caps.begin();
   while (it != in->caps.end()) {
@@ -5776,13 +5776,13 @@ void Client::unmount()
   lru.lru_set_max(0);
   trim_cache();
 
-  while (lru.lru_get_size() > 0 || 
+  while (lru.lru_get_size() > 0 ||
          !inode_map.empty()) {
-    ldout(cct, 2) << "cache still has " << lru.lru_get_size() 
-            << "+" << inode_map.size() << " items" 
+    ldout(cct, 2) << "cache still has " << lru.lru_get_size()
+            << "+" << inode_map.size() << " items"
 	    << ", waiting (for caps to release?)"
             << dendl;
-    utime_t until = ceph_clock_now(cct) + utime_t(5, 0);
+    utime_t until = ceph_clock_now() + utime_t(5, 0);
     int r = mount_cond.WaitUntil(client_lock, until);
     if (r == ETIMEDOUT) {
       dump_cache(NULL);
@@ -5848,7 +5848,7 @@ void Client::tick()
   tick_event = new C_C_Tick(this);
   timer.add_event_after(cct->_conf->client_tick_interval, tick_event);
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   if (!mounted && !mds_requests.empty()) {
     MetaRequest *req = mds_requests.begin()->second;
@@ -5893,8 +5893,8 @@ void Client::tick()
 void Client::renew_caps()
 {
   ldout(cct, 10) << "renew_caps()" << dendl;
-  last_cap_renew = ceph_clock_now(cct);
-  
+  last_cap_renew = ceph_clock_now();
+
   for (map<mds_rank_t,MetaSession*>::iterator p = mds_sessions.begin();
        p != mds_sessions.end();
        ++p) {
@@ -5907,7 +5907,7 @@ void Client::renew_caps()
 void Client::renew_caps(MetaSession *session)
 {
   ldout(cct, 10) << "renew_caps mds." << session->mds_num << dendl;
-  session->last_cap_renew_request = ceph_clock_now(cct);
+  session->last_cap_renew_request = ceph_clock_now();
   uint64_t seq = ++session->cap_renew_seq;
   session->con->send_message(new MClientSession(CEPH_SESSION_REQUEST_RENEWCAPS, seq));
 }
@@ -5982,7 +5982,7 @@ int Client::_lookup(Inode *dir, const string& dname, int mask, InodeRef *target,
 
     if (!dn->inode || dn->inode->caps_issued_mask(mask)) {
       // is dn lease valid?
-      utime_t now = ceph_clock_now(cct);
+      utime_t now = ceph_clock_now();
       if (dn->lease_mds >= 0 &&
 	  dn->lease_ttl > now &&
 	  mds_sessions.count(dn->lease_mds)) {
@@ -6049,9 +6049,9 @@ int Client::get_or_create(Inode *dir, const char* name,
     Dentry *dn = dir->dir->dentries[name];
     
     // is dn lease valid?
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     if (dn->inode &&
-	dn->lease_mds >= 0 && 
+	dn->lease_mds >= 0 &&
 	dn->lease_ttl > now &&
 	mds_sessions.count(dn->lease_mds)) {
       MetaSession *s = mds_sessions[dn->lease_mds];
@@ -6482,7 +6482,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
 
   if (!mask) {
     // caller just needs us to bump the ctime
-    in->ctime = ceph_clock_now(cct);
+    in->ctime = ceph_clock_now();
     in->cap_dirtier_uid = perms.uid();
     in->cap_dirtier_gid = perms.gid();
     if (issued & CEPH_CAP_AUTH_EXCL)
@@ -6501,7 +6501,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     mask &= ~CEPH_SETATTR_KILL_SGUID;
 
     if (mask & CEPH_SETATTR_UID) {
-      in->ctime = ceph_clock_now(cct);
+      in->ctime = ceph_clock_now();
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->uid = stx->stx_uid;
@@ -6511,7 +6511,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
       ldout(cct,10) << "changing uid to " << stx->stx_uid << dendl;
     }
     if (mask & CEPH_SETATTR_GID) {
-      in->ctime = ceph_clock_now(cct);
+      in->ctime = ceph_clock_now();
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->gid = stx->stx_gid;
@@ -6522,7 +6522,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     }
 
     if (mask & CEPH_SETATTR_MODE) {
-      in->ctime = ceph_clock_now(cct);
+      in->ctime = ceph_clock_now();
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->mode = (in->mode & ~07777) | (stx->stx_mode & 07777);
@@ -6538,7 +6538,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
     }
 
     if (mask & CEPH_SETATTR_BTIME) {
-      in->ctime = ceph_clock_now(cct);
+      in->ctime = ceph_clock_now();
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->btime = utime_t(stx->stx_btime);
@@ -6557,7 +6557,7 @@ int Client::_do_setattr(Inode *in, struct ceph_statx *stx, int mask,
         in->mtime = utime_t(stx->stx_mtime);
       if (mask & CEPH_SETATTR_ATIME)
         in->atime = utime_t(stx->stx_atime);
-      in->ctime = ceph_clock_now(cct);
+      in->ctime = ceph_clock_now();
       in->cap_dirtier_uid = perms.uid();
       in->cap_dirtier_gid = perms.gid();
       in->time_warp_seq++;
@@ -8308,7 +8308,7 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 		   OSDMap::file_to_object_locator(in->layout),
 		   create_ops,
 		   in->snaprealm->get_snap_context(),
-		   ceph::real_clock::now(cct),
+		   ceph::real_clock::now(),
 		   0,
 		   NULL,
 		   NULL);
@@ -8329,7 +8329,7 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 		   OSDMap::file_to_object_locator(in->layout),
 		   uninline_ops,
 		   in->snaprealm->get_snap_context(),
-		   ceph::real_clock::now(cct),
+		   ceph::real_clock::now(),
 		   0,
 		   NULL,
 		   onfinish);
@@ -8814,7 +8814,7 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
   ldout(cct, 10) << "cur file size is " << in->size << dendl;
 
   // time it.
-  utime_t start = ceph_clock_now(cct);
+  utime_t start = ceph_clock_now();
 
   if (in->inline_version == 0) {
     int r = _getattr(in, CEPH_STAT_CAP_INLINE_DATA, f->actor_perms, true);
@@ -8909,7 +8909,7 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     // async, caching, non-blocking.
     r = objectcacher->file_write(&in->oset, &in->layout,
 				 in->snaprealm->get_snap_context(),
-				 offset, size, bl, ceph::real_clock::now(cct),
+				 offset, size, bl, ceph::real_clock::now(),
 				 0);
     put_cap_ref(in, CEPH_CAP_FILE_BUFFER);
 
@@ -8937,7 +8937,7 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     get_cap_ref(in, CEPH_CAP_FILE_BUFFER);  // released by onsafe callback
 
     filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
-			   offset, size, bl, ceph::real_clock::now(cct), 0,
+			   offset, size, bl, ceph::real_clock::now(), 0,
 			   in->truncate_size, in->truncate_seq,
 			   onfinish, new C_OnFinisher(onsafe, &objecter_finisher));
     client_lock.Unlock();
@@ -8952,7 +8952,7 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
   // if we get here, write was successful, update client metadata
 success:
   // time
-  lat = ceph_clock_now(cct);
+  lat = ceph_clock_now();
   lat -= start;
   logger->tinc(l_c_wrlat, lat);
 
@@ -8978,7 +8978,7 @@ success:
   }
 
   // mtime
-  in->mtime = ceph_clock_now(cct);
+  in->mtime = ceph_clock_now();
   in->change_attr++;
   mark_caps_dirty(in, CEPH_CAP_FILE_WR);
 
@@ -12121,7 +12121,7 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
 		  length,
 		  fakesnap,
 		  bl,
-		  ceph::real_clock::now(cct),
+		  ceph::real_clock::now(),
 		  0,
 		  onack,
 		  onsafe);
@@ -12265,7 +12265,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
         in->inline_data = bl;
         in->inline_version++;
       }
-      in->mtime = ceph_clock_now(cct);
+      in->mtime = ceph_clock_now();
       in->change_attr++;
       mark_caps_dirty(in, CEPH_CAP_FILE_WR);
     } else {
@@ -12290,10 +12290,10 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
       filer->zero(in->ino, &in->layout,
 		      in->snaprealm->get_snap_context(),
 		      offset, length,
-		      ceph::real_clock::now(cct),
+		      ceph::real_clock::now(),
 		      0, true, onfinish,
 		      new C_OnFinisher(onsafe, &objecter_finisher));
-      in->mtime = ceph_clock_now(cct);
+      in->mtime = ceph_clock_now();
       in->change_attr++;
       mark_caps_dirty(in, CEPH_CAP_FILE_WR);
 
@@ -12308,7 +12308,7 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
     uint64_t size = offset + length;
     if (size > in->size) {
       in->size = size;
-      in->mtime = ceph_clock_now(cct);
+      in->mtime = ceph_clock_now();
       in->change_attr++;
       mark_caps_dirty(in, CEPH_CAP_FILE_WR);
 
@@ -12726,7 +12726,7 @@ Inode *Client::get_quota_root(Inode *in, const UserPerm& perms)
     return NULL;
 
   Inode *cur = in;
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   while (cur) {
     if (cur != in && cur->quota.is_enable())
@@ -12778,7 +12778,7 @@ Inode *Client::get_quota_root(Inode *in, const UserPerm& perms)
       break;
     }
 
-    now = ceph_clock_now(cct);
+    now = ceph_clock_now();
     if (cur == in)
       cur = parent_ref.get();
     else
@@ -12905,14 +12905,14 @@ int Client::check_pool_perm(Inode *in, int need)
     rd_op.stat(NULL, (ceph::real_time*)nullptr, NULL);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), rd_op,
-		     nullsnapc, ceph::real_clock::now(cct), 0, &rd_cond, NULL);
+		     nullsnapc, ceph::real_clock::now(), 0, &rd_cond, NULL);
 
     C_SaferCond wr_cond;
     ObjectOperation wr_op;
     wr_op.create(true);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), wr_op,
-		     nullsnapc, ceph::real_clock::now(cct), 0, &wr_cond, NULL);
+		     nullsnapc, ceph::real_clock::now(), 0, &wr_cond, NULL);
 
     client_lock.Unlock();
     int rd_ret = rd_cond.wait();

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -175,7 +175,7 @@ bool Inode::cap_is_valid(Cap* cap) const
     << "cap expire  " << cap->session->cap_ttl << std::endl
     << "cur time    " << ceph_clock_now(cct) << std::endl;*/
   if ((cap->session->cap_gen <= cap->gen)
-      && (ceph_clock_now(client->cct) < cap->session->cap_ttl)) {
+      && (ceph_clock_now() < cap->session->cap_ttl)) {
     return true;
   }
   return false;

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -39,6 +39,7 @@ using namespace std;
 #include "include/assert.h"
 #include "include/cephfs/ceph_statx.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_client
 #undef dout_prefix
 #define dout_prefix *_dout << "client." << (whoami >= 0 ? whoami:client->get_nodeid()) << " "

--- a/src/client/SyntheticClient.h
+++ b/src/client/SyntheticClient.h
@@ -207,12 +207,12 @@ class SyntheticClient {
   }
 
   bool time_to_stop() {
-    utime_t now = ceph_clock_now(client->cct);
-    if (0) cout << "time_to_stop .. now " << now 
-		<< " until " << run_until 
-		<< " start " << run_start 
+    utime_t now = ceph_clock_now();
+    if (0) cout << "time_to_stop .. now " << now
+		<< " until " << run_until
+		<< " start " << run_start
 		<< std::endl;
-    if (run_until.sec() && now > run_until) 
+    if (run_until.sec() && now > run_until)
       return true;
     else
       return false;

--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include <sys/file.h>
@@ -37,6 +37,8 @@
 #include "fuse_ll.h"
 #include <fuse.h>
 #include <fuse_lowlevel.h>
+
+#define dout_context g_ceph_context
 
 #define FINO_INO(x) ((x) & ((1ull<<48)-1ull))
 #define FINO_STAG(x) ((x) >> 48)

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -96,7 +96,7 @@ static int read_lock(cls_method_context_t hctx, const string& name, lock_info_t 
 
   /* now trim expired locks */
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
 
   map<locker_id_t, locker_info_t>::iterator iter = lock->lockers.begin();
 
@@ -217,7 +217,7 @@ static int lock_obj(cls_method_context_t hctx,
   linfo.tag = tag;
   utime_t expiration;
   if (!duration.is_zero()) {
-    expiration = ceph_clock_now(g_ceph_context);
+    expiration = ceph_clock_now();
     expiration += duration;
 
   }

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3318,7 +3318,7 @@ int image_status_set(cls_method_context_t hctx, const string &global_image_id,
 		     const cls::rbd::MirrorImageStatus &status) {
   MirrorImageStatusOnDisk ondisk_status(status);
   ondisk_status.up = false;
-  ondisk_status.last_update = ceph_clock_now(g_ceph_context);
+  ondisk_status.last_update = ceph_clock_now();
 
   int r = cls_get_request_origin(hctx, &ondisk_status.origin);
   assert(r == 0);

--- a/src/common/Clock.cc
+++ b/src/common/Clock.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 
@@ -20,7 +20,7 @@
 
 #include <time.h>
 
-utime_t ceph_clock_now(CephContext *cct)
+utime_t ceph_clock_now()
 {
 #if defined(__linux__)
   struct timespec tp;
@@ -31,15 +31,10 @@ utime_t ceph_clock_now(CephContext *cct)
   gettimeofday(&tv, NULL);
   utime_t n(&tv);
 #endif
-  if (cct)
-    n += cct->_conf->clock_offset;
   return n;
 }
 
-time_t ceph_clock_gettime(CephContext *cct)
+time_t ceph_clock_gettime()
 {
-  time_t ret = time(NULL);
-  if (cct)
-    ret += ((time_t)cct->_conf->clock_offset);
-  return ret;
+  return time(NULL);
 }

--- a/src/common/Clock.h
+++ b/src/common/Clock.h
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #ifndef CEPH_CLOCK_H
@@ -19,9 +19,7 @@
 
 #include <time.h>
 
-class CephContext;
-
-extern utime_t ceph_clock_now(CephContext *cct);
-extern time_t ceph_clock_gettime(CephContext *cct);
+extern utime_t ceph_clock_now();
+extern time_t ceph_clock_gettime();
 
 #endif

--- a/src/common/Cond.h
+++ b/src/common/Cond.h
@@ -75,15 +75,15 @@ class Cond {
     return r;
   }
 
-  int WaitInterval(CephContext *cct, Mutex &mutex, utime_t interval) {
-    utime_t when = ceph_clock_now(cct);
+  int WaitInterval(Mutex &mutex, utime_t interval) {
+    utime_t when = ceph_clock_now();
     when += interval;
     return WaitUntil(mutex, when);
   }
 
   template<typename Duration>
-  int WaitInterval(CephContext *cct, Mutex &mutex, Duration interval) {
-    ceph::real_time when(ceph::real_clock::now(cct));
+  int WaitInterval(Mutex &mutex, Duration interval) {
+    ceph::real_time when(ceph::real_clock::now());
     when += interval;
 
     struct timespec ts = ceph::real_clock::to_timespec(when);

--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -59,7 +59,7 @@ void *Finisher::finisher_thread_entry()
       ldout(cct, 10) << "finisher_thread doing " << ls << dendl;
 
       if (logger)
-        start = ceph_clock_now(cct);
+	start = ceph_clock_now();
 
       // Now actually process the contexts.
       for (vector<Context*>::iterator p = ls.begin();
@@ -79,7 +79,7 @@ void *Finisher::finisher_thread_entry()
 	}
 	if (logger) {
 	  logger->dec(l_finisher_queue_len);
-          end = ceph_clock_now(cct);
+	  end = ceph_clock_now();
 	  logger->tinc(l_finisher_complete_lat, end - start);
 	  start = end;
         }

--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -238,7 +238,7 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
   int lvl = (prio == CLOG_ERROR ? -1 : 0);
   ldout(cct,lvl) << "log " << prio << " : " << s << dendl;
   LogEntry e;
-  e.stamp = ceph_clock_now(cct);
+  e.stamp = ceph_clock_now();
   // seq and who should be set for syslog/graylog/log_to_mon
   e.who = parent->get_myinst();
   e.seq = parent->get_next_seq();

--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -97,7 +97,7 @@ void Mutex::Lock(bool no_lockdep) {
   if (logger && cct && cct->_conf->mutex_perf_counter) {
     utime_t start;
     // instrumented mutex enabled
-    start = ceph_clock_now(cct);
+    start = ceph_clock_now();
     if (TryLock()) {
       goto out;
     }
@@ -105,7 +105,7 @@ void Mutex::Lock(bool no_lockdep) {
     r = pthread_mutex_lock(&_m);
 
     logger->tinc(l_mutex_wait,
-		 ceph_clock_now(cct) - start);
+		 ceph_clock_now() - start);
   } else {
     r = pthread_mutex_lock(&_m);
   }

--- a/src/common/Throttle.cc
+++ b/src/common/Throttle.cc
@@ -102,7 +102,7 @@ bool Throttle::_wait(int64_t c)
     waited = true;
     ldout(cct, 2) << "_wait waiting..." << dendl;
     if (logger)
-      start = ceph_clock_now(cct);
+      start = ceph_clock_now();
 
     do {
       cv->Wait(lock);
@@ -110,7 +110,7 @@ bool Throttle::_wait(int64_t c)
 
     ldout(cct, 2) << "_wait finished waiting" << dendl;
     if (logger) {
-      utime_t dur = ceph_clock_now(cct) - start;
+      utime_t dur = ceph_clock_now() - start;
       logger->tinc(l_throttle_wait, dur);
     }
 

--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -86,8 +86,8 @@ void SafeTimer::timer_thread()
   lock.Lock();
   ldout(cct,10) << "timer_thread starting" << dendl;
   while (!stopping) {
-    utime_t now = ceph_clock_now(cct);
-    
+    utime_t now = ceph_clock_now();
+
     while (!schedule.empty()) {
       scheduled_map_t::iterator p = schedule.begin();
 
@@ -126,7 +126,7 @@ void SafeTimer::add_event_after(double seconds, Context *callback)
 {
   assert(lock.is_locked());
 
-  utime_t when = ceph_clock_now(cct);
+  utime_t when = ceph_clock_now();
   when += seconds;
   add_event_at(when, callback);
 }

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -122,7 +122,7 @@ bool OpTracker::dump_historic_ops(Formatter *f)
   if (!tracking_enabled)
     return false;
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   history.dump_ops(now, f);
   return true;
 }
@@ -136,7 +136,7 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked)
   f->open_object_section("ops_in_flight"); // overall dump
   uint64_t total_ops_in_flight = 0;
   f->open_array_section("ops"); // list of TrackedOps
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   for (uint32_t i = 0; i < num_optracker_shards; i++) {
     ShardedTrackingData* sdata = sharded_in_flight_list[i];
     assert(NULL != sdata); 
@@ -197,7 +197,7 @@ void OpTracker::unregister_inflight_op(TrackedOp *i)
   if (!tracking_enabled)
     delete i;
   else {
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     history.insert(now, TrackedOpRef(i));
   }
 }
@@ -208,7 +208,7 @@ bool OpTracker::check_ops_in_flight(std::vector<string> &warning_vector, int *sl
   if (!tracking_enabled)
     return false;
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   utime_t too_old = now;
   too_old -= complaint_time;
   utime_t oldest_op = now;
@@ -296,7 +296,7 @@ bool OpTracker::check_ops_in_flight(std::vector<string> &warning_vector, int *sl
 void OpTracker::get_age_ms_histogram(pow2_hist_t *h)
 {
   h->clear();
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
 
   for (uint32_t iter = 0; iter < num_optracker_shards; iter++) {
     ShardedTrackingData* sdata = sharded_in_flight_list[iter];
@@ -347,7 +347,7 @@ void TrackedOp::mark_event(const string &event)
   if (!is_tracked)
     return;
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   {
     Mutex::Locker l(lock);
     events.push_back(make_pair(now, event));

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -19,6 +19,7 @@
 #include "msg/Message.h"
 #include "include/assert.h"
 
+#define dout_context cct
 #define dout_subsys ceph_subsys_optracker
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)
@@ -223,10 +224,10 @@ bool OpTracker::check_ops_in_flight(std::vector<string> &warning_vector, int *sl
       if (oldest_op_tmp < oldest_op) {
         oldest_op = oldest_op_tmp;
       }
-    } 
+    }
     total_ops_in_flight += sdata->ops_in_flight_sharded.size();
   }
-      
+
   if (0 == total_ops_in_flight)
     return false;
 

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -104,7 +104,7 @@ public:
    */
   bool check_ops_in_flight(std::vector<string> &warning_strings, int *slow = NULL);
   void mark_event(TrackedOp *op, const string &evt,
-                          utime_t time = ceph_clock_now(g_ceph_context));
+		  utime_t time = ceph_clock_now());
 
   void on_shutdown() {
     history.on_shutdown();
@@ -169,7 +169,7 @@ public:
     if (!events.empty() && events.rbegin()->second.compare("done") == 0)
       return events.rbegin()->first - get_initiated();
     else
-      return ceph_clock_now(NULL) - get_initiated();
+      return ceph_clock_now() - get_initiated();
   }
 
   void mark_event(const string &event);

--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -150,7 +150,7 @@ void ThreadPool::worker(WorkThread *wt)
       hb,
       cct->_conf->threadpool_default_timeout,
       0);
-    _cond.WaitInterval(cct, _lock,
+    _cond.WaitInterval(_lock,
       utime_t(
 	cct->_conf->threadpool_empty_queue_max_wait, 0));
   }
@@ -325,7 +325,7 @@ void ShardedThreadPool::shardedthreadpool_worker(uint32_t thread_index)
        cct->get_heartbeat_map()->reset_timeout(
 	 hb,
 	 wq->timeout_interval, wq->suicide_interval);
-       shardedpool_cond.WaitInterval(cct, shardedpool_lock,
+       shardedpool_cond.WaitInterval(shardedpool_lock,
 	 utime_t(
 	   cct->_conf->threadpool_empty_queue_max_wait, 0));
       }
@@ -341,7 +341,7 @@ void ShardedThreadPool::shardedthreadpool_worker(uint32_t thread_index)
 	  cct->get_heartbeat_map()->reset_timeout(
 	    hb,
 	    wq->timeout_interval, wq->suicide_interval);
-          shardedpool_cond.WaitInterval(cct, shardedpool_lock,
+          shardedpool_cond.WaitInterval(shardedpool_lock,
 	    utime_t(
 	      cct->_conf->threadpool_empty_queue_max_wait, 0));
         }

--- a/src/common/assert.cc
+++ b/src/common/assert.cc
@@ -47,7 +47,7 @@ namespace ceph {
 			  const char *func)
   {
     ostringstream tss;
-    tss << ceph_clock_now(g_assert_context);
+    tss << ceph_clock_now();
 
     char buf[8096];
     BackTrace *bt = new BackTrace(1);
@@ -82,7 +82,7 @@ namespace ceph {
 			   const char *func, const char* msg, ...)
   {
     ostringstream tss;
-    tss << ceph_clock_now(g_assert_context);
+    tss << ceph_clock_now();
 
     class BufAppender {
     public:

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -146,7 +146,7 @@ public:
 
       if (_cct->_conf->heartbeat_interval) {
         utime_t interval(_cct->_conf->heartbeat_interval, 0);
-        _cond.WaitInterval(_cct, _lock, interval);
+        _cond.WaitInterval(_lock, interval);
       } else
         _cond.Wait(_lock);
 

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -14,8 +14,6 @@
 
 // For ceph_timespec
 #include "include/types.h"
-
-#include "ceph_context.h"
 #include "ceph_time.h"
 #include "config.h"
 
@@ -47,13 +45,6 @@ int clock_gettime(int clk_id, struct timespec *tp)
 
 namespace ceph {
   namespace time_detail {
-    real_clock::time_point real_clock::now(const CephContext* cct) noexcept {
-      auto t = now();
-      if (cct)
-	t += make_timespan(cct->_conf->clock_offset);
-      return t;
-    }
-
     void real_clock::to_ceph_timespec(const time_point& t,
 				      struct ceph_timespec& ts) {
       ts.tv_sec = to_time_t(t);
@@ -67,14 +58,6 @@ namespace ceph {
     real_clock::time_point real_clock::from_ceph_timespec(
       const struct ceph_timespec& ts) {
       return time_point(seconds(ts.tv_sec) + nanoseconds(ts.tv_nsec));
-    }
-
-    coarse_real_clock::time_point coarse_real_clock::now(
-      const CephContext* cct) noexcept {
-      auto t = now();
-      if (cct)
-	t += make_timespan(cct->_conf->clock_offset);
-      return t;
     }
 
     void coarse_real_clock::to_ceph_timespec(const time_point& t,
@@ -92,7 +75,7 @@ namespace ceph {
       const struct ceph_timespec& ts) {
       return time_point(seconds(ts.tv_sec) + nanoseconds(ts.tv_nsec));
     }
-  };
+  }
 
   using std::chrono::duration_cast;
   using std::chrono::seconds;

--- a/src/common/ceph_time.h
+++ b/src/common/ceph_time.h
@@ -33,7 +33,6 @@
 int clock_gettime(int clk_id, struct timespec *tp);
 #endif
 
-class CephContext;
 struct ceph_timespec;
 
 namespace ceph {
@@ -84,12 +83,9 @@ namespace ceph {
 	clock_gettime(CLOCK_REALTIME, &ts);
 	return from_timespec(ts);
       }
-      // We need a version of 'now' that can take a CephContext for
-      // introducing configurable clock skew.
-      static time_point now(const CephContext* cct) noexcept;
 
       static bool is_zero(const time_point& t) {
-        return (t == time_point::min());
+	return (t == time_point::min());
       }
 
       // Allow conversion to/from any clock with the same interface as
@@ -182,7 +178,6 @@ namespace ceph {
 #endif
 	return from_timespec(ts);
       }
-      static time_point now(const CephContext* cct) noexcept;
 
       static time_t to_time_t(const time_point& t) noexcept {
 	return duration_cast<seconds>(t.time_since_epoch()).count();

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -379,7 +379,6 @@ OPTION(paxos_trim_max, OPT_INT, 500) // max number of extra proposals to trim at
 OPTION(paxos_service_trim_min, OPT_INT, 250) // minimum amount of versions to trigger a trim (0 disables it)
 OPTION(paxos_service_trim_max, OPT_INT, 500) // maximum amount of versions to trim during a single proposal (0 disables it)
 OPTION(paxos_kill_at, OPT_INT, 0)
-OPTION(clock_offset, OPT_DOUBLE, 0) // how much to offset the system clock in Clock.cc
 OPTION(auth_cluster_required, OPT_STR, "cephx")   // required of mon, mds, osd daemons
 OPTION(auth_service_required, OPT_STR, "cephx")   // required by daemons of clients
 OPTION(auth_client_required, OPT_STR, "cephx, none")     // what clients require of daemons

--- a/src/common/debug.h
+++ b/src/common/debug.h
@@ -20,16 +20,16 @@
 /* Global version of the stuff in common/dout.h
  */
 
-#define dout(v) ldout((g_ceph_context), v)
+#define dout(v) ldout((dout_context), v)
 
-#define pdout(v, p) lpdout((g_ceph_context), v, p)
+#define pdout(v, p) lpdout((dout_context), v, p)
 
-#define dlog_p(sub, v) ldlog_p1((g_ceph_context), sub, v)
+#define dlog_p(sub, v) ldlog_p1((dout_context), sub, v)
 
-#define generic_dout(v) lgeneric_dout((g_ceph_context), v)
+#define generic_dout(v) lgeneric_dout((dout_context), v)
 
-#define derr lderr((g_ceph_context))
+#define derr lderr((dout_context))
 
-#define generic_derr lgeneric_derr((g_ceph_context))
+#define generic_derr lgeneric_derr((dout_context))
 
 #endif

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -78,7 +78,7 @@ ostream& ObjBencher::out(ostream& os, utime_t& t)
 
 ostream& ObjBencher::out(ostream& os)
 {
-  utime_t cur_time = ceph_clock_now(cct);
+  utime_t cur_time = ceph_clock_now();
   return out(os, cur_time);
 }
 
@@ -99,7 +99,7 @@ void *ObjBencher::status_printer(void *_bencher) {
   if (formatter)
     formatter->open_array_section("datas");
   while(!data.done) {
-    utime_t cur_time = ceph_clock_now(bencher->cct);
+    utime_t cur_time = ceph_clock_now();
 
     if (i % 20 == 0 && !formatter) {
       if (i > 0)
@@ -208,7 +208,7 @@ void *ObjBencher::status_printer(void *_bencher) {
     }
     ++i;
     ++cycleSinceChange;
-    cond.WaitInterval(bencher->cct, bencher->lock, ONE_SECOND);
+    cond.WaitInterval(bencher->lock, ONE_SECOND);
   }
   if (formatter)
     formatter->close_section(); //datas
@@ -292,13 +292,13 @@ int ObjBencher::aio_bench(
       goto out;
     }
 
-    data.start_time = ceph_clock_now(cct);
+    data.start_time = ceph_clock_now();
     out(cout) << "Cleaning up (deleting benchmark objects)" << std::endl;
 
     r = clean_up(num_objects, prevPid, concurrentios);
     if (r != 0) goto out;
 
-    runtime = ceph_clock_now(cct) - data.start_time;
+    runtime = ceph_clock_now() - data.start_time;
     out(cout) << "Clean up completed and total clean up time :" << runtime << std::endl;
 
     // lastrun file
@@ -442,10 +442,10 @@ int ObjBencher::write_bench(int secondsToRun,
   ceph_pthread_setname(print_thread, "write_stat");
   lock.Lock();
   data.finished = 0;
-  data.start_time = ceph_clock_now(cct);
+  data.start_time = ceph_clock_now();
   lock.Unlock();
   for (int i = 0; i<concurrentios; ++i) {
-    start_times[i] = ceph_clock_now(cct);
+    start_times[i] = ceph_clock_now();
     r = create_completion(i, _aio_cb, (void *)&lc);
     if (r < 0)
       goto ERR;
@@ -470,7 +470,7 @@ int ObjBencher::write_bench(int secondsToRun,
   stopTime = data.start_time + runtime;
   slot = 0;
   lock.Lock();
-  while (!secondsToRun || ceph_clock_now(cct) < stopTime) {
+  while (!secondsToRun || ceph_clock_now() < stopTime) {
     bool found = false;
     while (1) {
       int old_slot = slot;
@@ -503,7 +503,7 @@ int ObjBencher::write_bench(int secondsToRun,
       lock.Unlock();
       goto ERR;
     }
-    data.cur_latency = ceph_clock_now(cct) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
     data.history.latency.push_back(data.cur_latency);
     total_latency += data.cur_latency;
     if( data.cur_latency > data.max_latency) data.max_latency = data.cur_latency;
@@ -513,10 +513,10 @@ int ObjBencher::write_bench(int secondsToRun,
     --data.in_flight;
     lock.Unlock();
     release_completion(slot);
-    timePassed = ceph_clock_now(cct) - data.start_time;
+    timePassed = ceph_clock_now() - data.start_time;
 
     //write new stuff to backend
-    start_times[slot] = ceph_clock_now(cct);
+    start_times[slot] = ceph_clock_now();
     r = create_completion(slot, _aio_cb, &lc);
     if (r < 0)
       goto ERR;
@@ -545,7 +545,7 @@ int ObjBencher::write_bench(int secondsToRun,
       lock.Unlock();
       goto ERR;
     }
-    data.cur_latency = ceph_clock_now(cct) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
     data.history.latency.push_back(data.cur_latency);
     total_latency += data.cur_latency;
     if (data.cur_latency > data.max_latency) data.max_latency = data.cur_latency;
@@ -559,7 +559,7 @@ int ObjBencher::write_bench(int secondsToRun,
     contents[slot] = 0;
   }
 
-  timePassed = ceph_clock_now(cct) - data.start_time;
+  timePassed = ceph_clock_now() - data.start_time;
   lock.Lock();
   data.done = true;
   lock.Unlock();
@@ -670,7 +670,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
 
   lock.Lock();
   data.finished = 0;
-  data.start_time = ceph_clock_now(cct);
+  data.start_time = ceph_clock_now();
   lock.Unlock();
 
   pthread_t print_thread;
@@ -681,7 +681,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   //start initial reads
   for (int i = 0; i < concurrentios; ++i) {
     index[i] = i;
-    start_times[i] = ceph_clock_now(cct);
+    start_times[i] = ceph_clock_now();
     create_completion(i, _aio_cb, (void *)&lc);
     r = aio_read(name[i], i, contents[i], data.op_size,
 		 data.op_size * (i % writes_per_object));
@@ -700,7 +700,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   bufferlist *cur_contents;
 
   slot = 0;
-  while ((!seconds_to_run || ceph_clock_now(cct) < finish_time) &&
+  while ((!seconds_to_run || ceph_clock_now() < finish_time) &&
 	 num_objects > data.started) {
     lock.Lock();
     int old_slot = slot;
@@ -723,7 +723,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     }
 
     // calculate latency here, so memcmp doesn't inflate it
-    data.cur_latency = ceph_clock_now(cct) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
 
     cur_contents = contents[slot];
     int current_index = index[slot];
@@ -761,7 +761,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     release_completion(slot);
 
     //start new read and check data if requested
-    start_times[slot] = ceph_clock_now(cct);
+    start_times[slot] = ceph_clock_now();
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.op_size,
 		 data.op_size * (data.started % writes_per_object));
@@ -786,7 +786,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
       lock.Unlock();
       goto ERR;
     }
-    data.cur_latency = ceph_clock_now(cct) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
     total_latency += data.cur_latency;
     if (data.cur_latency > data.max_latency) data.max_latency = data.cur_latency;
     if (data.cur_latency < data.min_latency) data.min_latency = data.cur_latency;
@@ -808,7 +808,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
     delete contents[slot];
   }
 
-  runtime = ceph_clock_now(cct) - data.start_time;
+  runtime = ceph_clock_now() - data.start_time;
   lock.Lock();
   data.done = true;
   lock.Unlock();
@@ -899,7 +899,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
 
   lock.Lock();
   data.finished = 0;
-  data.start_time = ceph_clock_now(g_ceph_context);
+  data.start_time = ceph_clock_now();
   lock.Unlock();
 
   pthread_t print_thread;
@@ -910,7 +910,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   //start initial reads
   for (int i = 0; i < concurrentios; ++i) {
     index[i] = i;
-    start_times[i] = ceph_clock_now(g_ceph_context);
+    start_times[i] = ceph_clock_now();
     create_completion(i, _aio_cb, (void *)&lc);
     r = aio_read(name[i], i, contents[i], data.op_size,
 		 data.op_size * (i % writes_per_object));
@@ -930,7 +930,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   int rand_id;
 
   slot = 0;
-  while ((!seconds_to_run || ceph_clock_now(g_ceph_context) < finish_time)) {
+  while ((!seconds_to_run || ceph_clock_now() < finish_time)) {
     lock.Lock();
     int old_slot = slot;
     bool found = false;
@@ -952,7 +952,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
     }
 
     // calculate latency here, so memcmp doesn't inflate it
-    data.cur_latency = ceph_clock_now(cct) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
 
     lock.Unlock();
 
@@ -993,7 +993,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
     cur_contents->invalidate_crc();
 
     //start new read and check data if requested
-    start_times[slot] = ceph_clock_now(g_ceph_context);
+    start_times[slot] = ceph_clock_now();
     create_completion(slot, _aio_cb, (void *)&lc);
     r = aio_read(newName, slot, contents[slot], data.op_size,
 		 data.op_size * (rand_id % writes_per_object));
@@ -1019,7 +1019,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       lock.Unlock();
       goto ERR;
     }
-    data.cur_latency = ceph_clock_now(g_ceph_context) - start_times[slot];
+    data.cur_latency = ceph_clock_now() - start_times[slot];
     total_latency += data.cur_latency;
     if (data.cur_latency > data.max_latency) data.max_latency = data.cur_latency;
     if (data.cur_latency < data.min_latency) data.min_latency = data.cur_latency;
@@ -1041,7 +1041,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
     delete contents[slot];
   }
 
-  runtime = ceph_clock_now(g_ceph_context) - data.start_time;
+  runtime = ceph_clock_now() - data.start_time;
   lock.Lock();
   data.done = true;
   lock.Unlock();

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -22,6 +22,7 @@
 #include <zlib.h>
 
 // -----------------------------------------------------------------------------
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_compressor
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -27,6 +27,7 @@ extern "C" {
 #include "isa-l/include/erasure_code.h"
 }
 // -----------------------------------------------------------------------------
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
+++ b/src/erasure-code/isa/ErasureCodeIsaTableCache.cc
@@ -30,6 +30,7 @@
 // -----------------------------------------------------------------------------
 
 // -----------------------------------------------------------------------------
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _tc_prefix(_dout)

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -29,6 +29,7 @@ extern "C" {
 
 #define LARGEST_VECTOR_WORDSIZE 16
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodePluginJerasure.cc
@@ -21,6 +21,7 @@
 #include "ErasureCodePluginJerasure.h"
 #include "jerasure_init.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/jerasure/jerasure_init.cc
+++ b/src/erasure-code/jerasure/jerasure_init.cc
@@ -22,6 +22,8 @@ extern "C" {
 #include "galois.h"
 }
 
+#define dout_context g_ceph_context
+
 extern "C" int jerasure_init(int count, int *words)
 {
   for(int i = 0; i < count; i++) {

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -31,6 +31,7 @@
 // re-include our assert to clobber boost's
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/shec/ErasureCodePluginShec.cc
+++ b/src/erasure-code/shec/ErasureCodePluginShec.cc
@@ -25,6 +25,8 @@
 #include "ErasureCodeShec.h"
 #include "jerasure_init.h"
 
+#define dout_context g_ceph_context
+
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -35,6 +35,7 @@ extern int calc_determinant(int *matrix, int dim);
 extern int* reed_sol_vandermonde_coding_matrix(int k, int m, int w);
 }
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)

--- a/src/erasure-code/shec/ErasureCodeShecTableCache.cc
+++ b/src/erasure-code/shec/ErasureCodeShecTableCache.cc
@@ -24,6 +24,7 @@
 // -----------------------------------------------------------------------------
 
 // -----------------------------------------------------------------------------
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _tc_prefix(_dout)

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -36,6 +36,7 @@
 #include <sys/prctl.h>
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
 
 static void global_init_set_globals(CephContext *cct)

--- a/src/global/pidfile.cc
+++ b/src/global/pidfile.cc
@@ -36,6 +36,7 @@
 // logging is not functional when it is called. cerr output is lost
 // when the caller is daemonized but it will show if not (-f)
 //
+#define dout_context g_ceph_context
 #define dout_prefix *_dout
 #define dout_subsys ceph_subsys_
 

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -31,6 +31,8 @@
 extern char *sys_siglist[]; 
 #endif 
 
+#define dout_context g_ceph_context
+
 void install_sighandler(int signum, signal_handler_t handler, int flags)
 {
   int ret;

--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -61,7 +61,7 @@ void IndexCache::push(const string &key, const index_data &idata) {
     utime_t old_time = new_it->second.second;
     t2kmap.erase(old_time);
   }
-  utime_t time = ceph_clock_now(g_ceph_context);
+  utime_t time = ceph_clock_now();
   k2itmap[idata.kdata] = make_pair(idata, time);
   t2kmap[time] = idata.kdata;
   if ((int)k2itmap.size() > cache_size) {
@@ -79,7 +79,7 @@ void IndexCache::push(const index_data &idata) {
     t2kmap.erase(old_time);
     k2itmap.erase(idata.kdata);
   }
-  utime_t time = ceph_clock_now(g_ceph_context);
+  utime_t time = ceph_clock_now();
   k2itmap[idata.kdata] = make_pair(idata, time);
   t2kmap[time] = idata.kdata;
   if ((int)k2itmap.size() > cache_size) {
@@ -190,7 +190,7 @@ int KvFlatBtreeAsync::next(const index_data &idata, index_data * out_data)
     out_data->kdata.parse(kvs.begin()->first);
     bufferlist::iterator b = kvs.begin()->second.begin();
     out_data->decode(b);
-    if (idata.is_timed_out(ceph_clock_now(g_ceph_context),timeout)) {
+    if (idata.is_timed_out(ceph_clock_now(), timeout)) {
       if (verbose) cout << client_name << " THINKS THE OTHER CLIENT DIED."
 	  << std::endl;
       //the client died after deleting the object. clean up.
@@ -217,7 +217,7 @@ int KvFlatBtreeAsync::prev(const index_data &idata, index_data * out_data)
     if (verbose) cout << "\t\t\t" << client_name
 	<< "-prev: getting index failed with error "
 	<< err << std::endl;
-    if (idata.is_timed_out(ceph_clock_now(g_ceph_context),timeout)) {
+    if (idata.is_timed_out(ceph_clock_now(), timeout)) {
       if (verbose) cout << client_name << " THINKS THE OTHER CLIENT DIED."
 	  << std::endl;
       //the client died after deleting the object. clean up.
@@ -276,7 +276,7 @@ int KvFlatBtreeAsync::read_index(const string &key, index_data * idata,
       (cache_size / cache_refresh >= 2? cache_size / cache_refresh: 2),
       &kvmap,&err);
   err = io_ctx.operate(index_name, &oro, NULL);
-  utime_t mytime = ceph_clock_now(g_ceph_context);
+  utime_t mytime = ceph_clock_now();
   if (err < 0){
     cerr << "\t" << client_name
 	<< "-read_index: getting keys failed with "
@@ -711,7 +711,7 @@ void KvFlatBtreeAsync::set_up_prefix_index(
   std::map<std::string, pair<bufferlist, int> > assertions;
   map<string, bufferlist> to_insert;
   idata->prefix = "1";
-  idata->ts = ceph_clock_now(g_ceph_context);
+  idata->ts = ceph_clock_now();
   for(vector<object_data>::const_iterator it = to_create.begin();
       it != to_create.end();
       ++it) {
@@ -1682,7 +1682,7 @@ int KvFlatBtreeAsync::get(const string &key, bufferlist *val) {
     return -ESUICIDE;
   }
   err = read_index(key, &idata, NULL, false);
-  mytime = ceph_clock_now(g_ceph_context);
+  mytime = ceph_clock_now();
   if (err < 0) {
     if (verbose) cout << "getting oid failed with code " << err << std::endl;
     return err;
@@ -2081,7 +2081,7 @@ bool KvFlatBtreeAsync::is_consistent() {
 	  io_ctx.aio_operate(dit->obj, aioc, &oro, NULL);
 	  aioc->wait_for_safe();
 	  err = aioc->get_return_value();
-	  if (ceph_clock_now(g_ceph_context) - idata.ts > timeout) {
+	  if (ceph_clock_now() - idata.ts > timeout) {
 	    if (err < 0) {
 	      aioc->release();
 	      if (err == -ENOENT) {

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -168,11 +168,11 @@ void LevelDBStore::close()
 
 int LevelDBStore::submit_transaction(KeyValueDB::Transaction t)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   LevelDBTransactionImpl * _t =
     static_cast<LevelDBTransactionImpl *>(t.get());
   leveldb::Status s = db->Write(leveldb::WriteOptions(), &(_t->bat));
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_leveldb_txns);
   logger->tinc(l_leveldb_submit_latency, lat);
   return s.ok() ? 0 : -1;
@@ -180,13 +180,13 @@ int LevelDBStore::submit_transaction(KeyValueDB::Transaction t)
 
 int LevelDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   LevelDBTransactionImpl * _t =
     static_cast<LevelDBTransactionImpl *>(t.get());
   leveldb::WriteOptions options;
   options.sync = true;
   leveldb::Status s = db->Write(options, &(_t->bat));
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_leveldb_txns);
   logger->tinc(l_leveldb_submit_sync_latency, lat);
   return s.ok() ? 0 : -1;
@@ -246,7 +246,7 @@ int LevelDBStore::get(
     const std::set<string> &keys,
     std::map<string, bufferlist> *out)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   for (std::set<string>::const_iterator i = keys.begin();
        i != keys.end(); ++i) {
     std::string value;
@@ -255,7 +255,7 @@ int LevelDBStore::get(
     if (status.ok())
       (*out)[*i].append(value);
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_leveldb_gets);
   logger->tinc(l_leveldb_get_latency, lat);
   return 0;
@@ -266,7 +266,7 @@ int LevelDBStore::get(const string &prefix,
       bufferlist *out)
 {
   assert(out && (out->length() == 0));
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   int r = 0;
   string value, k;
   leveldb::Status s;
@@ -277,7 +277,7 @@ int LevelDBStore::get(const string &prefix,
   } else {
     r = -ENOENT;
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_leveldb_gets);
   logger->tinc(l_leveldb_get_latency, lat);
   return r;

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -11,6 +11,7 @@ using std::string;
 #include "common/debug.h"
 #include "common/perf_counters.h"
 
+#define dout_context cct
 #define dout_subsys ceph_subsys_leveldb
 #undef dout_prefix
 #define dout_prefix *_dout << "leveldb: "

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -27,6 +27,7 @@
 #include "common/errno.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_memdb
 #undef dout_prefix
 #define dout_prefix *_dout << "memdb: "

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -412,7 +412,7 @@ void RocksDBStore::get_statistics(Formatter *f)
 
 int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   // enable rocksdb breakdown
   // considering performance overhead, default is disabled
   if (g_conf->rocksdb_perf) {
@@ -436,7 +436,7 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
          << " Rocksdb transaction: " << rocks_txc.seen << dendl;
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
 
   if (g_conf->rocksdb_perf) {
     utime_t write_memtable_time;
@@ -465,7 +465,7 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
 
 int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   // enable rocksdb breakdown
   // considering performance overhead, default is disabled
   if (g_conf->rocksdb_perf) {
@@ -490,7 +490,7 @@ int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
          << " Rocksdb transaction: " << rocks_txc.seen << dendl;
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
 
   if (g_conf->rocksdb_perf) {
     utime_t write_memtable_time;
@@ -590,7 +590,7 @@ int RocksDBStore::get(
     const std::set<string> &keys,
     std::map<string, bufferlist> *out)
 {
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   for (std::set<string>::const_iterator i = keys.begin();
        i != keys.end(); ++i) {
     std::string value;
@@ -599,7 +599,7 @@ int RocksDBStore::get(
     if (status.ok())
       (*out)[*i].append(value);
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_rocksdb_gets);
   logger->tinc(l_rocksdb_get_latency, lat);
   return 0;
@@ -611,7 +611,7 @@ int RocksDBStore::get(
     bufferlist *out)
 {
   assert(out && (out->length() == 0));
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   int r = 0;
   string value, k;
   rocksdb::Status s;
@@ -622,7 +622,7 @@ int RocksDBStore::get(
   } else {
     r = -ENOENT;
   }
-  utime_t lat = ceph_clock_now(g_ceph_context) - start;
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_rocksdb_gets);
   logger->tinc(l_rocksdb_get_latency, lat);
   return r;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -29,6 +29,7 @@ using std::string;
 
 #include "common/debug.h"
 
+#define dout_context cct
 #define dout_subsys ceph_subsys_rocksdb
 #undef dout_prefix
 #define dout_prefix *_dout << "rocksdb: "

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -408,7 +408,7 @@ int librados::IoCtxImpl::selfmanaged_snap_rollback_object(const object_t& oid,
   prepare_assert_ops(&op);
   op.rollback(snapid);
   objecter->mutate(oid, oloc,
-		   op, snapc, ceph::real_clock::now(client->cct), 0,
+		   op, snapc, ceph::real_clock::now(), 0,
 		   onack, NULL, NULL);
 
   mylock.Lock();
@@ -667,7 +667,7 @@ int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
 				 ceph::real_time *pmtime, int flags)
 {
   ceph::real_time ut = (pmtime ? *pmtime :
-    ceph::real_clock::now(client->cct));
+    ceph::real_clock::now());
 
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
@@ -761,7 +761,7 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
 				     ::ObjectOperation *o, AioCompletionImpl *c,
 				     const SnapContext& snap_context, int flags)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
     return -EROFS;
@@ -865,7 +865,7 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 				   const bufferlist& bl, size_t len,
 				   uint64_t off)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
   ldout(client->cct, 20) << "aio_write " << oid << " " << off << "~" << len << " snapc=" << snapc << " snap_seq=" << snap_seq << dendl;
 
   if (len > UINT_MAX/2)
@@ -892,7 +892,7 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
 int librados::IoCtxImpl::aio_append(const object_t &oid, AioCompletionImpl *c,
 				    const bufferlist& bl, size_t len)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
 
   if (len > UINT_MAX/2)
     return -E2BIG;
@@ -919,7 +919,7 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
 					AioCompletionImpl *c,
 					const bufferlist& bl)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
 
   if (bl.length() > UINT_MAX/2)
     return -E2BIG;
@@ -948,7 +948,7 @@ int librados::IoCtxImpl::aio_writesame(const object_t &oid,
 				       size_t write_len,
 				       uint64_t off)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
 
   if ((bl.length() > UINT_MAX/2) || (write_len > UINT_MAX/2))
     return -E2BIG;
@@ -976,7 +976,7 @@ int librados::IoCtxImpl::aio_writesame(const object_t &oid,
 
 int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c, int flags)
 {
-  auto ut = ceph::real_clock::now(client->cct);
+  auto ut = ceph::real_clock::now();
 
   /* can't write to a snapshot */
   if (snap_seq != CEPH_NOSNAP)
@@ -1610,7 +1610,7 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(client->cct), 0, NULL,
+		   snapc, ceph::real_clock::now(), 0, NULL,
 		   &onfinish, &ver);
   objecter->linger_cancel(linger_op);
 
@@ -1629,7 +1629,7 @@ int librados::IoCtxImpl::aio_unwatch(uint64_t cookie, AioCompletionImpl *c)
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(client->cct), 0, NULL,
+		   snapc, ceph::real_clock::now(), 0, NULL,
 		   oncomplete, &c->objver);
   return 0;
 }

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -543,13 +543,13 @@ int librados::RadosClient::wait_for_osdmap()
 
     if (objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch)) == 0) {
       ldout(cct, 10) << __func__ << " waiting" << dendl;
-      utime_t start = ceph_clock_now(cct);
+      utime_t start = ceph_clock_now();
       while (objecter->with_osdmap(std::mem_fn(&OSDMap::get_epoch)) == 0) {
         if (timeout.is_zero()) {
           cond.Wait(lock);
         } else {
-          cond.WaitInterval(cct, lock, timeout);
-          utime_t elapsed = ceph_clock_now(cct) - start;
+          cond.WaitInterval(lock, timeout);
+          utime_t elapsed = ceph_clock_now() - start;
           if (elapsed > timeout) {
             lderr(cct) << "timed out waiting for first osdmap from monitors"
                        << dendl;

--- a/src/librbd/AioCompletion.cc
+++ b/src/librbd/AioCompletion.cc
@@ -77,7 +77,7 @@ void AioCompletion::complete() {
 
   tracepoint(librbd, aio_complete_enter, this, rval);
   utime_t elapsed;
-  elapsed = ceph_clock_now(cct) - start_time;
+  elapsed = ceph_clock_now() - start_time;
   switch (aio_type) {
   case AIO_TYPE_OPEN:
   case AIO_TYPE_CLOSE:
@@ -130,7 +130,7 @@ void AioCompletion::init_time(ImageCtx *i, aio_type_t t) {
   if (ictx == nullptr) {
     ictx = i;
     aio_type = t;
-    start_time = ceph_clock_now(ictx->cct);
+    start_time = ceph_clock_now();
   }
 }
 

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -2179,7 +2179,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     uint64_t left = mylen;
 
     RWLock::RLocker owner_locker(ictx->owner_lock);
-    start_time = ceph_clock_now(ictx->cct);
+    start_time = ceph_clock_now();
     while (left > 0) {
       uint64_t period_off = off - (off % period);
       uint64_t read_len = min(period_off + period - off, left);
@@ -2206,7 +2206,7 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
       off += ret;
     }
 
-    elapsed = ceph_clock_now(ictx->cct) - start_time;
+    elapsed = ceph_clock_now() - start_time;
     ictx->perfcounter->tinc(l_librbd_rd_latency, elapsed);
     ictx->perfcounter->inc(l_librbd_rd);
     ictx->perfcounter->inc(l_librbd_rd_bytes, mylen);

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -225,13 +225,13 @@ void Log::submit_entry(Entry *e)
 Entry *Log::create_entry(int level, int subsys)
 {
   if (true) {
-    return new Entry(ceph_clock_now(NULL),
-		   pthread_self(),
-		   level, subsys);
+    return new Entry(ceph_clock_now(),
+		     pthread_self(),
+		     level, subsys);
   } else {
     // kludge for perf testing
     Entry *e = m_recent.dequeue();
-    e->m_stamp = ceph_clock_now(NULL);
+    e->m_stamp = ceph_clock_now();
     e->m_thread = pthread_self();
     e->m_prio = level;
     e->m_subsys = subsys;
@@ -246,13 +246,13 @@ Entry *Log::create_entry(int level, int subsys, size_t* expected_size)
                                "Log hint");
     size_t size = __atomic_load_n(expected_size, __ATOMIC_RELAXED);
     void *ptr = ::operator new(sizeof(Entry) + size);
-    return new(ptr) Entry(ceph_clock_now(NULL),
+    return new(ptr) Entry(ceph_clock_now(),
        pthread_self(), level, subsys,
        reinterpret_cast<char*>(ptr) + sizeof(Entry), size, expected_size);
   } else {
     // kludge for perf testing
     Entry *e = m_recent.dequeue();
-    e->m_stamp = ceph_clock_now(NULL);
+    e->m_stamp = ceph_clock_now();
     e->m_thread = pthread_self();
     e->m_prio = level;
     e->m_subsys = subsys;

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -28,7 +28,7 @@ TEST(Log, Simple)
     int sys = i % 4;
     int l = 5 + (i%4);
     if (subs.should_gather(sys, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL),
+      Entry *e = new Entry(ceph_clock_now(),
 			   pthread_self(),
 			   l,
 			   sys,
@@ -57,7 +57,7 @@ TEST(Log, ManyNoGather)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1));
+      log.submit_entry(new Entry(ceph_clock_now(), pthread_self(), l, 1));
   }
   log.flush();
   log.stop();
@@ -75,7 +75,7 @@ TEST(Log, ManyGatherLog)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1,
+      log.submit_entry(new Entry(ceph_clock_now(), pthread_self(), l, 1,
 				 "this is a long string asdf asdf asdf asdf asdf asdf asd fasd fasdf "));
   }
   log.flush();
@@ -93,7 +93,7 @@ TEST(Log, ManyGatherLogStringAssign)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph_clock_now(), pthread_self(), l, 1);
       ostringstream oss;
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
       e->set_str(oss.str());
@@ -114,7 +114,7 @@ TEST(Log, ManyGatherLogStringAssignWithReserve)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph_clock_now(), pthread_self(), l, 1);
       ostringstream oss;
       oss.str().reserve(80);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
@@ -137,7 +137,7 @@ TEST(Log, ManyGatherLogPrebuf)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph_clock_now(), pthread_self(), l, 1);
       PrebufferedStreambuf psb(e->m_static_buf, sizeof(e->m_static_buf));
       ostream oss(&psb);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd";
@@ -160,7 +160,7 @@ TEST(Log, ManyGatherLogPrebufOverflow)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l)) {
-      Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+      Entry *e = new Entry(ceph_clock_now(), pthread_self(), l, 1);
       PrebufferedStreambuf psb(e->m_static_buf, sizeof(e->m_static_buf));
       ostream oss(&psb);
       oss << "this i a long stream asdf asdf asdf asdf asdf asdf asdf asdf asdf as fd"
@@ -184,7 +184,7 @@ TEST(Log, ManyGather)
   for (int i=0; i<many; i++) {
     int l = 10;
     if (subs.should_gather(1, l))
-      log.submit_entry(new Entry(ceph_clock_now(NULL), pthread_self(), l, 1));
+      log.submit_entry(new Entry(ceph_clock_now(), pthread_self(), l, 1));
   }
   log.flush();
   log.stop();
@@ -200,7 +200,7 @@ void do_segv()
   log.reopen_log_file();
 
   log.inject_segv();
-  Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), 10, 1);
+  Entry *e = new Entry(ceph_clock_now(), pthread_self(), 10, 1);
   log.submit_entry(e);  // this should segv
 
   log.flush();
@@ -221,7 +221,7 @@ TEST(Log, LargeLog)
   log.set_log_file("/tmp/big");
   log.reopen_log_file();
   int l = 10;
-  Entry *e = new Entry(ceph_clock_now(NULL), pthread_self(), l, 1);
+  Entry *e = new Entry(ceph_clock_now(), pthread_self(), l, 1);
 
   std::string msg(10000000, 0);
   e->set_str(msg);

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -118,7 +118,7 @@ void Beacon::handle_mds_beacon(MMDSBeacon *m)
 
   // update lab
   if (seq_stamp.count(seq)) {
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     if (seq_stamp[seq] > last_acked_stamp) {
       last_acked_stamp = seq_stamp[seq];
       utime_t rtt = now - last_acked_stamp;
@@ -172,9 +172,9 @@ void Beacon::send_and_wait(const double duration)
            << " for up to " << duration << "s" << dendl;
 
   utime_t timeout;
-  timeout.set_from_double(ceph_clock_now(cct) + duration);
+  timeout.set_from_double(ceph_clock_now() + duration);
   while ((!seq_stamp.empty() && seq_stamp.begin()->first <= awaiting_seq)
-         && ceph_clock_now(cct) < timeout) {
+         && ceph_clock_now() < timeout) {
     waiting_cond.WaitUntil(lock, timeout);
   }
 
@@ -205,7 +205,7 @@ void Beacon::_send()
 	   << " seq " << last_seq
 	   << dendl;
 
-  seq_stamp[last_seq] = ceph_clock_now(g_ceph_context);
+  seq_stamp[last_seq] = ceph_clock_now();
 
   assert(want_state != MDSMap::STATE_NULL);
   
@@ -264,7 +264,7 @@ bool Beacon::is_laggy()
   if (last_acked_stamp == utime_t())
     return false;
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t since = now - last_acked_stamp;
   if (since > g_conf->mds_beacon_grace) {
     dout(5) << "is_laggy " << since << " > " << g_conf->mds_beacon_grace
@@ -398,7 +398,7 @@ void Beacon::notify_health(MDSRank const *mds)
     set<Session*> sessions;
     mds->sessionmap.get_client_session_set(sessions);
 
-    utime_t cutoff = ceph_clock_now(g_ceph_context);
+    utime_t cutoff = ceph_clock_now();
     cutoff -= g_conf->mds_recall_state_timeout;
     utime_t last_recall = mds->mdcache->last_recall_state;
 

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -27,6 +27,7 @@
 
 #include "Beacon.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds.beacon." << name << ' '

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -32,7 +32,7 @@
 
 ostream& CDentry::print_db_line_prefix(ostream& out) 
 {
-  return out << ceph_clock_now(g_ceph_context) << " mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
+  return out << ceph_clock_now() << " mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
 }
 
 boost::pool<> CDentry::pool(sizeof(CDentry));

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -25,12 +25,13 @@
 
 #include "messages/MLock.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->dirfrag() << " " << name << ") "
 
 
-ostream& CDentry::print_db_line_prefix(ostream& out) 
+ostream& CDentry::print_db_line_prefix(ostream& out)
 {
   return out << ceph_clock_now() << " mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
 }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -171,7 +171,7 @@ void CDir::print(ostream& out)
 
 ostream& CDir::print_db_line_prefix(ostream& out) 
 {
-  return out << ceph_clock_now(g_ceph_context) << " mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") ";
+  return out << ceph_clock_now() << " mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") ";
 }
 
 
@@ -189,10 +189,10 @@ CDir::CDir(CInode *in, frag_t fg, MDCache *mdcache, bool auth) :
   num_dirty(0), committing_version(0), committed_version(0),
   dir_auth_pins(0), request_pins(0),
   dir_rep(REP_NONE),
-  pop_me(ceph_clock_now(g_ceph_context)),
-  pop_nested(ceph_clock_now(g_ceph_context)),
-  pop_auth_subtree(ceph_clock_now(g_ceph_context)),
-  pop_auth_subtree_nested(ceph_clock_now(g_ceph_context)),
+  pop_me(ceph_clock_now()),
+  pop_nested(ceph_clock_now()),
+  pop_auth_subtree(ceph_clock_now()),
+  pop_auth_subtree_nested(ceph_clock_now()),
   num_dentries_nested(0), num_dentries_auth_subtree(0),
   num_dentries_auth_subtree_nested(0),
   dir_auth(CDIR_AUTH_DEFAULT)
@@ -1686,7 +1686,7 @@ CDentry *CDir::_load_dentry(
         }
 
         //in->hack_accessed = false;
-        //in->hack_load_stamp = ceph_clock_now(g_ceph_context);
+        //in->hack_load_stamp = ceph_clock_now();
         //num_new_inodes_loaded++;
       } else {
         dout(0) << "_fetched  badness: got (but i already had) " << *in
@@ -2073,7 +2073,7 @@ void CDir::_omap_commit(int op_prio)
 	op.omap_rm_keys(to_remove);
 
       cache->mds->objecter->mutate(oid, oloc, op, snapc,
-				   ceph::real_clock::now(g_ceph_context),
+				   ceph::real_clock::now(),
 				   0, NULL, gather.new_sub());
 
       write_size = 0;
@@ -2107,7 +2107,7 @@ void CDir::_omap_commit(int op_prio)
     op.omap_rm_keys(to_remove);
 
   cache->mds->objecter->mutate(oid, oloc, op, snapc,
-			       ceph::real_clock::now(g_ceph_context),
+			       ceph::real_clock::now(),
 			       0, NULL, gather.new_sub());
 
   gather.activate();
@@ -2940,7 +2940,7 @@ void CDir::scrub_initialize(const ScrubHeaderRefConst& header)
   assert(scrub_infop && !scrub_infop->directory_scrubbing);
 
   scrub_infop->recursive_start.version = get_projected_version();
-  scrub_infop->recursive_start.time = ceph_clock_now(g_ceph_context);
+  scrub_infop->recursive_start.time = ceph_clock_now();
 
   scrub_infop->directories_to_scrub.clear();
   scrub_infop->directories_scrubbing.clear();
@@ -3118,7 +3118,7 @@ bool CDir::scrub_local()
 
   scrub_info();
   if (rval) {
-    scrub_infop->last_local.time = ceph_clock_now(g_ceph_context);
+    scrub_infop->last_local.time = ceph_clock_now();
     scrub_infop->last_local.version = get_projected_version();
     scrub_infop->pending_scrub_error = false;
     scrub_infop->last_scrub_dirty = true;

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -37,6 +37,7 @@
 #include "include/assert.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << cache->mds->get_nodeid() << ".cache.dir(" << this->dirfrag() << ") "

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -82,7 +82,7 @@ LockType CInode::policylock_type(CEPH_LOCK_IPOLICY);
 //int cinode_pins[CINODE_NUM_PINS];  // counts
 ostream& CInode::print_db_line_prefix(ostream& out)
 {
-  return out << ceph_clock_now(g_ceph_context) << " mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << inode.ino << ") ";
+  return out << ceph_clock_now() << " mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << inode.ino << ") ";
 }
 
 /*
@@ -980,7 +980,7 @@ void CInode::store(MDSInternalContextBase *fin)
     new C_OnFinisher(new C_IO_Inode_Stored(this, get_version(), fin),
 		     mdcache->mds->finisher);
   mdcache->mds->objecter->mutate(oid, oloc, m, snapc,
-				 ceph::real_clock::now(g_ceph_context), 0,
+				 ceph::real_clock::now(), 0,
 				 NULL, newfin);
 }
 
@@ -1165,14 +1165,14 @@ void CInode::store_backtrace(MDSInternalContextBase *fin, int op_prio)
   if (!state_test(STATE_DIRTYPOOL) || inode.old_pools.empty()) {
     dout(20) << __func__ << ": no dirtypool or no old pools" << dendl;
     mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
-				   ceph::real_clock::now(g_ceph_context),
+				   ceph::real_clock::now(),
 				   0, NULL, fin2);
     return;
   }
 
   C_GatherBuilder gather(g_ceph_context, fin2);
   mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
-				 ceph::real_clock::now(g_ceph_context),
+				 ceph::real_clock::now(),
 				 0, NULL, gather.new_sub());
 
   // In the case where DIRTYPOOL is set, we update all old pools backtraces
@@ -1193,7 +1193,7 @@ void CInode::store_backtrace(MDSInternalContextBase *fin, int op_prio)
 
     object_locator_t oloc(*p);
     mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
-				   ceph::real_clock::now(g_ceph_context),
+				   ceph::real_clock::now(),
 				   0, NULL, gather.new_sub());
   }
   gather.activate();
@@ -2842,7 +2842,7 @@ Capability *CInode::reconnect_cap(client_t client, const cap_reconnect_t& icr, S
     cap->issue_norevoke(icr.capinfo.issued);
     cap->reset_seq();
   }
-  cap->set_last_issue_stamp(ceph_clock_now(g_ceph_context));
+  cap->set_last_issue_stamp(ceph_clock_now());
   return cap;
 }
 
@@ -3241,7 +3241,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
       cap->issue_norevoke(issue);
       issue = cap->pending();
       cap->set_last_issue();
-      cap->set_last_issue_stamp(ceph_clock_now(g_ceph_context));
+      cap->set_last_issue_stamp(ceph_clock_now());
       cap->clear_new();
       ecap.caps = issue;
       ecap.wanted = cap->wanted();
@@ -3604,7 +3604,7 @@ void CInode::decode_import(bufferlist::iterator& p,
     _mark_dirty_parent(ls);
   }
 
-  ::decode(pop, ceph_clock_now(g_ceph_context), p);
+  ::decode(pop, ceph_clock_now(), p);
 
   ::decode(replica_map, p);
   if (!replica_map.empty())
@@ -3749,7 +3749,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
         scrub_tag.setxattr("scrub_tag", tag_bl);
         SnapContext snapc;
         in->mdcache->mds->objecter->mutate(oid, object_locator_t(pool), scrub_tag, snapc,
-					   ceph::real_clock::now(g_ceph_context),
+					   ceph::real_clock::now(),
 					   0, NULL, NULL);
       }
     }
@@ -4242,7 +4242,7 @@ void CInode::scrub_initialize(CDentry *scrub_parent,
   scrub_infop->header = header;
 
   scrub_infop->scrub_start_version = get_version();
-  scrub_infop->scrub_start_stamp = ceph_clock_now(g_ceph_context);
+  scrub_infop->scrub_start_stamp = ceph_clock_now();
   // right now we don't handle remote inodes
 }
 
@@ -4261,7 +4261,7 @@ int CInode::scrub_dirfrag_next(frag_t* out_dirfrag)
   while (i != scrub_infop->dirfrag_stamps.end()) {
     if (i->second.scrub_start_version < scrub_infop->scrub_start_version) {
       i->second.scrub_start_version = get_projected_version();
-      i->second.scrub_start_stamp = ceph_clock_now(g_ceph_context);
+      i->second.scrub_start_stamp = ceph_clock_now();
       *out_dirfrag = i->first;
       dout(20) << " return frag " << *out_dirfrag << dendl;
       return 0;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -48,6 +48,7 @@
 #include "mds/MDSContinuation.h"
 #include "mds/InoTable.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mdcache->mds->get_nodeid() << ".cache.ino(" << inode.ino << ") "

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -666,7 +666,7 @@ public:
     item_dirty_dirfrag_nest(this), 
     item_dirty_dirfrag_dirfragtree(this), 
     auth_pin_freeze_allowance(0),
-    pop(ceph_clock_now(g_ceph_context)),
+    pop(ceph_clock_now()),
     versionlock(this, &versionlock_type),
     authlock(this, &authlock_type),
     linklock(this, &linklock_type),

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -37,6 +37,8 @@
 #include <set>
 #include <map>
 
+#define dout_context g_ceph_context
+
 class Context;
 class CDentry;
 class CDir;
@@ -1161,4 +1163,5 @@ private:
 
 ostream& operator<<(ostream& out, const CInode::scrub_stamp_info_t& si);
 
+#undef dout_context
 #endif

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "common/debug.h"
@@ -18,6 +18,7 @@
 
 #include "DamageTable.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << ".damage " << __func__ << " "

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -40,7 +40,7 @@ class DamageEntry
   DamageEntry()
   {
     id = get_random(0, 0xffffffff);
-    reported_at = ceph_clock_now(g_ceph_context);
+    reported_at = ceph_clock_now();
   }
 
   virtual damage_entry_type_t get_type() const = 0;

--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -19,6 +19,7 @@
 
 #include "common/config.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << "." << table_name << ": "

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -91,7 +91,7 @@ int JournalPointer::save(Objecter *objecter) const
   C_SaferCond waiter;
   objecter->write_full(object_t(object_id), object_locator_t(pool_id),
 		       SnapContext(), data,
-		       ceph::real_clock::now(g_ceph_context), 0, NULL,
+		       ceph::real_clock::now(), 0, NULL,
 		       &waiter);
   int write_result = waiter.wait();
   if (write_result < 0) {
@@ -114,7 +114,7 @@ void JournalPointer::save(Objecter *objecter, Context *completion) const
 
   objecter->write_full(object_t(get_object_id()), object_locator_t(pool_id),
 		       SnapContext(), data,
-		       ceph::real_clock::now(g_ceph_context), 0, NULL,
+		       ceph::real_clock::now(), 0, NULL,
 		       completion);
 }
 

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -22,6 +22,7 @@
 #include "mds/JournalPointer.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_journaler
 #undef dout_prefix
 #define dout_prefix *_dout << objecter->messenger->get_myname() << ".journalpointer "

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -564,7 +564,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
   }
 
   mdr->done_locking = true;
-  mdr->set_mds_stamp(ceph_clock_now(NULL));
+  mdr->set_mds_stamp(ceph_clock_now());
   result = true;
   marker.message = "acquired locks";
 
@@ -1957,7 +1957,7 @@ bool Locker::issue_caps(CInode *in, Capability *only_cap)
 	if (op == CEPH_CAP_OP_REVOKE) {
 		revoking_caps.push_back(&cap->item_revoking_caps);
 		revoking_caps_by_client[cap->get_client()].push_back(&cap->item_client_revoking_caps);
-		cap->set_last_revoke_stamp(ceph_clock_now(g_ceph_context));
+		cap->set_last_revoke_stamp(ceph_clock_now());
 		cap->reset_num_revoke_warnings();
 	}
 
@@ -3395,7 +3395,7 @@ bool Locker::any_late_revoking_caps(xlist<Capability*> const &revoking) const
       // No revoking caps at the moment
       return false;
     } else {
-      utime_t now = ceph_clock_now(g_ceph_context);
+      utime_t now = ceph_clock_now();
       utime_t age = now - (*p)->get_last_revoke_stamp();
       if (age <= g_conf->mds_revoke_cap_timeout) {
           return false;
@@ -3432,7 +3432,7 @@ void Locker::get_late_revoking_clients(std::list<client_t> *result) const
 
 void Locker::caps_tick()
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
 
   dout(20) << __func__ << " " << revoking_caps.size() << " revoking caps" << dendl;
 
@@ -3526,7 +3526,7 @@ void Locker::handle_client_lease(MClientLease *m)
 	m->h.seq = ++l->seq;
 	m->clear_payload();
 
-	utime_t now = ceph_clock_now(g_ceph_context);
+	utime_t now = ceph_clock_now();
 	now += mdcache->client_lease_durations[pool];
 	mdcache->touch_client_lease(l, pool, now);
 
@@ -4347,7 +4347,7 @@ void Locker::mark_updated_scatterlock(ScatterLock *lock)
 	     << " - already on list since " << lock->get_update_stamp() << dendl;
   } else {
     updated_scatterlocks.push_back(lock->get_updated_item());
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     lock->set_update_stamp(now);
     dout(10) << "mark_updated_scatterlock " << *lock
 	     << " - added at " << now << dendl;
@@ -4478,7 +4478,7 @@ void Locker::scatter_tick()
   dout(10) << "scatter_tick" << dendl;
   
   // updated
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   int n = updated_scatterlocks.size();
   while (!updated_scatterlocks.empty()) {
     ScatterLock *lock = updated_scatterlocks.front();

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -49,6 +49,7 @@
 #undef dout_prefix
 #undef DOUT_COND
 #define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_locker
+#define dout_context g_ceph_context
 #define dout_prefix _prefix(_dout, mds)
 static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {
   return *_dout << "mds." << mds->get_nodeid() << ".locker ";
@@ -5180,7 +5181,7 @@ void Locker::handle_file_lock(ScatterLock *lock, MLock *m)
 	      << " on " << *lock->get_parent() << dendl;
       scatter_nudge(lock, 0, true);
       mds->mdlog->flush();
-    }    
+    }
     break;
 
   default:

--- a/src/mds/LogEvent.cc
+++ b/src/mds/LogEvent.cc
@@ -38,6 +38,8 @@
 
 #include "events/ENoOp.h"
 
+#define dout_context g_ceph_context
+
 
 LogEvent *LogEvent::decode(bufferlist& bl)
 {

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -73,8 +73,8 @@ int MDBalancer::proc_message(Message *m)
 void MDBalancer::tick()
 {
   static int num_bal_times = g_conf->mds_bal_max;
-  static utime_t first = ceph_clock_now(g_ceph_context);
-  utime_t now = ceph_clock_now(g_ceph_context);
+  static utime_t first = ceph_clock_now();
+  utime_t now = ceph_clock_now();
   utime_t elapsed = now;
   elapsed -= first;
 
@@ -186,7 +186,7 @@ int MDBalancer::localize_balancer()
            << " oid=" << oid << " oloc=" << oloc << dendl;
 
   /* timeout: if we waste half our time waiting for RADOS, then abort! */
-  double t = ceph_clock_now(g_ceph_context) + g_conf->mds_bal_interval/2;
+  double t = ceph_clock_now() + g_conf->mds_bal_interval/2;
   utime_t timeout;
   timeout.set_from_double(t);
   lock.Lock();
@@ -208,7 +208,7 @@ int MDBalancer::localize_balancer()
 
 void MDBalancer::send_heartbeat()
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   
   if (mds->mdsmap->is_degraded()) {
     dout(10) << "send_heartbeat degraded" << dendl;
@@ -506,7 +506,7 @@ void MDBalancer::prep_rebalance(int beat)
   } else {
     int cluster_size = mds->get_mds_map()->get_num_in_mds();
     mds_rank_t whoami = mds->get_nodeid();
-    rebalance_time = ceph_clock_now(g_ceph_context);
+    rebalance_time = ceph_clock_now();
 
     // reset
     my_targets.clear();
@@ -533,7 +533,7 @@ void MDBalancer::prep_rebalance(int beat)
     double total_load = 0.0;
     multimap<double,mds_rank_t> load_map;
     for (mds_rank_t i=mds_rank_t(0); i < mds_rank_t(cluster_size); i++) {
-      map<mds_rank_t, mds_load_t>::value_type val(i, mds_load_t(ceph_clock_now(g_ceph_context)));
+      map<mds_rank_t, mds_load_t>::value_type val(i, mds_load_t(ceph_clock_now()));
       std::pair < map<mds_rank_t, mds_load_t>::iterator, bool > r(mds_load.insert(val));
       mds_load_t &load(r.first->second);
 
@@ -679,7 +679,7 @@ int MDBalancer::mantle_prep_rebalance()
 
   /* prepare for balancing */
   int cluster_size = mds->get_mds_map()->get_num_in_mds();
-  rebalance_time = ceph_clock_now(g_ceph_context);
+  rebalance_time = ceph_clock_now();
   my_targets.clear();
   imported.clear();
   exported.clear();
@@ -690,7 +690,7 @@ int MDBalancer::mantle_prep_rebalance()
   for (mds_rank_t i=mds_rank_t(0);
        i < mds_rank_t(cluster_size);
        i++) {
-    map<mds_rank_t, mds_load_t>::value_type val(i, mds_load_t(ceph_clock_now(g_ceph_context)));
+    map<mds_rank_t, mds_load_t>::value_type val(i, mds_load_t(ceph_clock_now()));
     std::pair < map<mds_rank_t, mds_load_t>::iterator, bool > r(mds_load.insert(val));
     mds_load_t &load(r.first->second);
 

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -39,6 +39,7 @@ using std::vector;
 #include "common/config.h"
 #include "common/errno.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND
 #define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_balancer

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -364,7 +364,7 @@ void MDCache::create_unlinked_system_inode(CInode *in, inodeno_t ino,
   in->inode.size = 0;
   in->inode.ctime = 
     in->inode.mtime =
-    in->inode.btime = ceph_clock_now(g_ceph_context);
+    in->inode.btime = ceph_clock_now();
   in->inode.nlink = 1;
   in->inode.truncate_size = -1ull;
   in->inode.change_attr = 0;
@@ -859,7 +859,7 @@ void MDCache::adjust_subtree_auth(CDir *dir, mds_authority_t auth, bool do_eval)
 
     // adjust recursive pop counters
     if (dir->is_auth()) {
-      utime_t now = ceph_clock_now(g_ceph_context);
+      utime_t now = ceph_clock_now();
       CDir *p = dir->get_parent_dir();
       while (p) {
 	p->pop_auth_subtree.sub(now, decayrate, dir->pop_auth_subtree);
@@ -936,7 +936,7 @@ void MDCache::try_subtree_merge_at(CDir *dir, bool do_eval)
 
     // adjust popularity?
     if (dir->is_auth()) {
-      utime_t now = ceph_clock_now(g_ceph_context);
+      utime_t now = ceph_clock_now();
       CDir *p = dir->get_parent_dir();
       while (p) {
 	p->pop_auth_subtree.add(now, decayrate, dir->pop_auth_subtree);
@@ -2107,7 +2107,7 @@ void MDCache::predirty_journal_parents(MutationRef mut, EMetaBlob *blob,
 
   // make sure stamp is set
   if (mut->get_mds_stamp() == utime_t())
-    mut->set_mds_stamp(ceph_clock_now(g_ceph_context));
+    mut->set_mds_stamp(ceph_clock_now());
 
   if (in->is_base())
     return;
@@ -5677,7 +5677,7 @@ void MDCache::do_cap_import(Session *session, CInode *in, Capability *cap,
     if (cap->get_last_seq() == 0) // reconnected cap
       cap->inc_last_seq();
     cap->set_last_issue();
-    cap->set_last_issue_stamp(ceph_clock_now(g_ceph_context));
+    cap->set_last_issue_stamp(ceph_clock_now());
     cap->clear_new();
     MClientCaps *reap = new MClientCaps(CEPH_CAP_OP_IMPORT,
 					in->ino(),
@@ -6745,7 +6745,7 @@ bool MDCache::trim_inode(CDentry *dn, CInode *in, CDir *con, map<mds_rank_t, MCa
       mds->logger->inc("outt");
     else {
       mds->logger->inc("outut");
-      mds->logger->fset("oututl", ceph_clock_now(g_ceph_context) - in->hack_load_stamp);
+      mds->logger->fset("oututl", ceph_clock_now() - in->hack_load_stamp);
     }
   }
   */
@@ -7326,7 +7326,7 @@ void MDCache::dentry_remove_replica(CDentry *dn, mds_rank_t from, set<SimpleLock
 
 void MDCache::trim_client_leases()
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   
   dout(10) << "trim_client_leases" << dendl;
 
@@ -7380,7 +7380,7 @@ void MDCache::check_memory_usage()
   if (num_inodes_with_caps > g_conf->mds_cache_size) {
     float ratio = (float)g_conf->mds_cache_size * .9 / (float)num_inodes_with_caps;
     if (ratio < 1.0) {
-      last_recall_state = ceph_clock_now(g_ceph_context);
+      last_recall_state = ceph_clock_now();
       mds->server->recall_client_state(ratio);
     }
   }
@@ -7417,7 +7417,7 @@ public:
 
 void MDCache::shutdown_check()
 {
-  dout(0) << "shutdown_check at " << ceph_clock_now(g_ceph_context) << dendl;
+  dout(0) << "shutdown_check at " << ceph_clock_now() << dendl;
 
   // cache
   char old_val[32] = { 0 };
@@ -8960,7 +8960,7 @@ MDRequestRef MDCache::request_start_internal(int op)
   MDRequestImpl::Params params;
   params.reqid.name = entity_name_t::MDS(mds->get_nodeid());
   params.reqid.tid = mds->issue_tid();
-  params.initiated = ceph_clock_now(g_ceph_context);
+  params.initiated = ceph_clock_now();
   params.internal_op = op;
   MDRequestRef mdr =
       mds->op_tracker.create_request<MDRequestImpl,MDRequestImpl::Params>(params);
@@ -10771,7 +10771,7 @@ void MDCache::split_dir(CDir *dir, int bits)
   info.mdr = mdr;
   info.dirs.push_back(dir);
   info.bits = bits;
-  info.last_cum_auth_pins_change = ceph_clock_now(g_ceph_context);
+  info.last_cum_auth_pins_change = ceph_clock_now();
 
   fragment_freeze_dirs(dirs);
   // initial mark+complete pass
@@ -10809,7 +10809,7 @@ void MDCache::merge_dir(CInode *diri, frag_t frag)
   info.mdr = mdr;
   info.dirs = dirs;
   info.bits = -bits;
-  info.last_cum_auth_pins_change = ceph_clock_now(g_ceph_context);
+  info.last_cum_auth_pins_change = ceph_clock_now();
 
   fragment_freeze_dirs(dirs);
   // initial mark+complete pass
@@ -10983,7 +10983,7 @@ void MDCache::find_stale_fragment_freeze()
 {
   dout(10) << "find_stale_fragment_freeze" << dendl;
   // see comment in Migrator::find_stale_export_freeze()
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t cutoff = now;
   cutoff -= g_conf->mds_freeze_tree_timeout;
 
@@ -11322,7 +11322,7 @@ void MDCache::_fragment_committed(dirfrag_t basedirfrag, list<CDir*>& resultfrag
       op.remove();
     }
     mds->objecter->mutate(oid, oloc, op, nullsnapc,
-			  ceph::real_clock::now(g_ceph_context),
+			  ceph::real_clock::now(),
 			  0, NULL, gather.new_sub());
   }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -103,6 +103,7 @@ using namespace std;
 #include "common/config.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mds)
@@ -245,7 +246,7 @@ void MDCache::log_stat()
 }
 
 
-// 
+//
 
 bool MDCache::shutdown()
 {

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -31,6 +31,7 @@
 #include "common/errno.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND
 #define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_log

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -295,7 +295,7 @@ void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase *c)
 
   le->_segment = ls;
   le->update_segment();
-  le->set_stamp(ceph_clock_now(g_ceph_context));
+  le->set_stamp(ceph_clock_now());
 
   mdsmap_up_features = mds->mdsmap->get_up_features();
   pending_events[ls->seq].push_back(PendingEvent(le, c));
@@ -615,7 +615,7 @@ void MDLog::trim(int m)
   }
 
   // hack: only trim for a few seconds at a time
-  utime_t stop = ceph_clock_now(g_ceph_context);
+  utime_t stop = ceph_clock_now();
   stop += 2.0;
 
   map<uint64_t,LogSegment*>::iterator p = segments.begin();
@@ -624,7 +624,7 @@ void MDLog::trim(int m)
 	   num_events - expiring_events - expired_events > max_events) ||
 	  (segments.size() - expiring_segments.size() - expired_segments.size() > max_segments))) {
     
-    if (stop < ceph_clock_now(g_ceph_context))
+    if (stop < ceph_clock_now())
       break;
 
     int num_expiring_segments = (int)expiring_segments.size();

--- a/src/mds/MDSContext.cc
+++ b/src/mds/MDSContext.cc
@@ -18,8 +18,8 @@
 #include "MDSContext.h"
 
 #include "common/dout.h"
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
-
 
 void MDSInternalContextBase::complete(int r) {
   MDSRank *mds = get_mds();

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -63,7 +63,7 @@
 #include "perfglue/cpu_profiler.h"
 #include "perfglue/heap_profiler.h"
 
-
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << name << ' '

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -187,7 +187,7 @@ void MDSRankDispatcher::tick()
   }
 
   // log
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   mds_load_t load = balancer->get_load(now);
 
   if (logger) {
@@ -465,7 +465,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
 
   // hack: thrash exports
   static utime_t start;
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   if (start == utime_t())
     start = now;
   /*double el = now - start;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -36,6 +36,7 @@
 
 #include "MDSRank.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << whoami << '.' << incarnation << ' '

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -81,7 +81,7 @@ void MDSTable::save(MDSInternalContextBase *onfinish, version_t v)
   object_locator_t oloc(mds->mdsmap->get_metadata_pool());
   mds->objecter->write_full(oid, oloc,
 			    snapc,
-			    bl, ceph::real_clock::now(g_ceph_context), 0,
+			    bl, ceph::real_clock::now(), 0,
 			    NULL,
 			    new C_OnFinisher(new C_IO_MT_Save(this, version),
 					     mds->finisher));

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -28,6 +28,7 @@
 #include "include/assert.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << "." << table_name << ": "

--- a/src/mds/MDSTableClient.cc
+++ b/src/mds/MDSTableClient.cc
@@ -30,6 +30,7 @@
 
 #include "common/config.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".tableclient(" << get_mdstable_name(table) << ") "

--- a/src/mds/MDSTableServer.cc
+++ b/src/mds/MDSTableServer.cc
@@ -20,6 +20,7 @@
 #include "messages/MMDSTableRequest.h"
 #include "events/ETableServer.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << ".tableserver(" << get_mdstable_name(table) << ") "

--- a/src/mds/Mantle.cc
+++ b/src/mds/Mantle.cc
@@ -19,6 +19,7 @@
 
 #include <fstream>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds_balancer
 #undef DOUT_COND
 #define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_balancer

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -211,7 +211,7 @@ void Migrator::export_empty_import(CDir *dir)
 
 void Migrator::find_stale_export_freeze()
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t cutoff = now;
   cutoff -= g_conf->mds_freeze_tree_timeout;
 
@@ -845,7 +845,7 @@ void Migrator::dispatch_export_dir(MDRequestRef& mdr)
   mds->send_message_mds(discover, it->second.peer);
   assert(g_conf->mds_kill_export_at != 2);
 
-  it->second.last_cum_auth_pins_change = ceph_clock_now(g_ceph_context);
+  it->second.last_cum_auth_pins_change = ceph_clock_now();
 
   // start the freeze, but hold it up with an auth_pin.
   dir->freeze_tree();
@@ -1236,7 +1236,7 @@ void Migrator::export_go_synced(CDir *dir, uint64_t tid)
   cache->adjust_subtree_auth(dir, mds->get_nodeid(), it->second.peer);
 
   // take away the popularity we're sending.
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   mds->balancer->subtract_export(dir, now);
   
   // fill export message with cache data
@@ -1807,7 +1807,7 @@ void Migrator::export_finish(CDir *dir)
   // finish export (adjust local cache state)
   int num_dentries = 0;
   C_ContextsBase<MDSInternalContextBase, MDSInternalContextGather> *fin = new C_ContextsBase<MDSInternalContextBase, MDSInternalContextGather>(g_ceph_context);
-  finish_export_dir(dir, ceph_clock_now(g_ceph_context), it->second.peer,
+  finish_export_dir(dir, ceph_clock_now(), it->second.peer,
 		    it->second.peer_imported, fin->contexts, &num_dentries);
   dir->add_waiter(CDir::WAIT_UNFREEZE, fin);
 
@@ -2225,7 +2225,7 @@ void Migrator::handle_export_dir(MExportDir *m)
   assert(it->second.state == IMPORT_PREPPED);
   assert(it->second.tid == m->get_tid());
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   mds_rank_t oldauth = mds_rank_t(m->get_source().num());
   dout(7) << "handle_export_dir importing " << *dir << " from " << oldauth << dendl;
   assert(dir->is_auth() == false);

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -76,6 +76,7 @@
 #include "common/config.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND
 #define DOUT_COND(cct, l) (l <= cct->_conf->debug_mds || l <= cct->_conf->debug_mds_migrator)

--- a/src/mds/RecoveryQueue.cc
+++ b/src/mds/RecoveryQueue.cc
@@ -21,6 +21,7 @@
 #include "RecoveryQueue.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << " RecoveryQueue::" << __func__ << " "

--- a/src/mds/ScrubStack.cc
+++ b/src/mds/ScrubStack.cc
@@ -20,6 +20,7 @@
 #include "mds/MDCache.h"
 #include "mds/MDSContinuation.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, scrubstack->mdcache->mds)

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -66,6 +66,7 @@ using namespace std;
 
 #include "common/config.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".server "
@@ -144,7 +145,7 @@ void Server::dispatch(Message *m)
   }
 
   // active?
-  if (!mds->is_active() && 
+  if (!mds->is_active() &&
       !(mds->is_stopping() && m->get_source().is_mds())) {
     if (m->get_type() == CEPH_MSG_CLIENT_REQUEST &&
 	(mds->is_reconnect() || mds->get_want_state() == CEPH_MDS_STATE_RECONNECT)) {

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -618,7 +618,7 @@ void Server::find_idle_sessions()
   
   // timeout/stale
   //  (caps go stale, lease die)
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t cutoff = now;
   cutoff -= g_conf->mds_session_timeout;  
   while (1) {
@@ -746,7 +746,7 @@ void Server::reconnect_clients(MDSInternalContext *reconnect_done_)
 
   // clients will get the mdsmap and discover we're reconnecting via the monitor.
   
-  reconnect_start = ceph_clock_now(g_ceph_context);
+  reconnect_start = ceph_clock_now();
   dout(1) << "reconnect_clients -- " << client_reconnect_gather.size() << " sessions" << dendl;
   mds->sessionmap.dump();
 }
@@ -765,7 +765,7 @@ void Server::handle_client_reconnect(MClientReconnect *m)
     return;
   }
 
-  utime_t delay = ceph_clock_now(g_ceph_context);
+  utime_t delay = ceph_clock_now();
   delay -= reconnect_start;
   dout(10) << " reconnect_start " << reconnect_start << " delay " << delay << dendl;
 
@@ -881,7 +881,7 @@ void Server::reconnect_tick()
 {
   utime_t reconnect_end = reconnect_start;
   reconnect_end += g_conf->mds_reconnect_timeout;
-  if (ceph_clock_now(g_ceph_context) >= reconnect_end &&
+  if (ceph_clock_now() >= reconnect_end &&
       !client_reconnect_gather.empty()) {
     dout(10) << "reconnect timed out" << dendl;
     for (set<client_t>::iterator p = client_reconnect_gather.begin();
@@ -1096,7 +1096,7 @@ void Server::early_reply(MDRequestRef& mdr, CInode *tracei, CDentry *tracedn)
   mdr->did_early_reply = true;
 
   mds->logger->inc(l_mds_reply);
-  utime_t lat = ceph_clock_now(g_ceph_context) - req->get_recv_stamp();
+  utime_t lat = ceph_clock_now() - req->get_recv_stamp();
   mds->logger->tinc(l_mds_reply_latency, lat);
   dout(20) << "lat " << lat << dendl;
 
@@ -1151,7 +1151,7 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
   if (!did_early_reply && !is_replay) {
 
     mds->logger->inc(l_mds_reply);
-    utime_t lat = ceph_clock_now(g_ceph_context) - mdr->client_request->get_recv_stamp();
+    utime_t lat = ceph_clock_now() - mdr->client_request->get_recv_stamp();
     mds->logger->tinc(l_mds_reply_latency, lat);
     dout(20) << "lat " << lat << dendl;
     
@@ -1263,7 +1263,7 @@ void Server::set_trace_dist(Session *session, MClientReply *reply,
   bufferlist bl;
   mds_rank_t whoami = mds->get_nodeid();
   client_t client = session->get_client();
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
 
   dout(20) << "set_trace_dist snapid " << snapid << dendl;
 
@@ -2754,7 +2754,7 @@ void Server::handle_client_getattr(MDRequestRef& mdr, bool is_lookup)
   // value for them.  (currently this matters for xattrs and inline data)
   mdr->getattr_caps = mask;
 
-  mds->balancer->hit_inode(ceph_clock_now(g_ceph_context), ref, META_POP_IRD,
+  mds->balancer->hit_inode(ceph_clock_now(), ref, META_POP_IRD,
 			   req->get_source().num());
 
   // reply
@@ -3373,7 +3373,7 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   dir->verify_fragstat();
 #endif
 
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   mdr->set_mds_stamp(now);
 
   snapid_t snapid = mdr->snapid;
@@ -5071,7 +5071,7 @@ void Server::_link_remote(MDRequestRef& mdr, bool inc, CDentry *dn, CInode *targ
 
   assert(g_conf->mds_kill_link_at != 2);
 
-  mdr->set_mds_stamp(ceph_clock_now(NULL));
+  mdr->set_mds_stamp(ceph_clock_now());
 
   // add to event
   mdr->ls = mdlog->get_current_segment();
@@ -6493,7 +6493,7 @@ void Server::handle_client_rename(MDRequestRef& mdr)
     assert(g_conf->mds_kill_rename_at != 4);
 
   // -- declare now --
-  mdr->set_mds_stamp(ceph_clock_now(g_ceph_context));
+  mdr->set_mds_stamp(ceph_clock_now());
 
   // -- prepare journal entry --
   mdr->ls = mdlog->get_current_segment();

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -424,9 +424,10 @@ void SessionMap::save(MDSInternalContextBase *onsave, version_t needv)
   null_sessions.clear();
 
   mds->objecter->mutate(oid, oloc, op, snapc,
-			ceph::real_clock::now(g_ceph_context),
-      0, NULL, new C_OnFinisher(new C_IO_SM_Save(this, version),
-				mds->finisher));
+			ceph::real_clock::now(),
+			0, NULL,
+			new C_OnFinisher(new C_IO_SM_Save(this, version),
+					 mds->finisher));
 }
 
 void SessionMap::_save_finish(version_t v)
@@ -472,7 +473,7 @@ uint64_t SessionMap::set_state(Session *session, int s) {
 
 void SessionMapStore::decode_legacy(bufferlist::iterator& p)
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   uint64_t pre;
   ::decode(pre, p);
   if (pre == (uint64_t)-1) {
@@ -615,7 +616,7 @@ void SessionMap::touch_session(Session *session)
 				      new xlist<Session*>).first;
   by_state_entry->second->push_back(&session->item_session_list);
 
-  session->last_cap_renew = ceph_clock_now(g_ceph_context);
+  session->last_cap_renew = ceph_clock_now();
 }
 
 void SessionMap::_mark_dirty(Session *s)
@@ -758,7 +759,7 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
       object_locator_t oloc(mds->mdsmap->get_metadata_pool());
       MDSInternalContextBase *on_safe = gather_bld->new_sub();
       mds->objecter->mutate(oid, oloc, op, snapc,
-			    ceph::real_clock::now(g_ceph_context),
+			    ceph::real_clock::now(),
 			    0, NULL, new C_OnFinisher(
 			      new C_IO_SM_Save_One(this, on_safe),
 			      mds->finisher));
@@ -819,12 +820,12 @@ void Session::notify_recall_sent(int const new_limit)
   if (recalled_at.is_zero()) {
     // Entering recall phase, set up counters so we can later
     // judge whether the client has respected the recall request
-    recalled_at = last_recall_sent = ceph_clock_now(g_ceph_context);
+    recalled_at = last_recall_sent = ceph_clock_now();
     assert (new_limit < caps.size());  // Behaviour of Server::recall_client_state
     recall_count = caps.size() - new_limit;
     recall_release_count = 0;
   } else {
-    last_recall_sent = ceph_clock_now(g_ceph_context);
+    last_recall_sent = ceph_clock_now();
   }
 }
 

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -24,6 +24,7 @@
 #include "include/assert.h"
 #include "include/stringify.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << ".sessionmap "

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -413,7 +413,7 @@ public:
     } else {
       s = session_map[i.name] = new Session;
       s->info.inst = i;
-      s->last_cap_renew = ceph_clock_now(g_ceph_context);
+      s->last_cap_renew = ceph_clock_now();
       if (logger) {
         logger->set(l_mdssm_session_count, session_map.size());
         logger->inc(l_mdssm_session_add);

--- a/src/mds/SnapRealm.cc
+++ b/src/mds/SnapRealm.cc
@@ -23,6 +23,7 @@
  * SnapRealm
  */
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mdcache->mds->get_nodeid(), inode, srnode.seq, this)

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -27,6 +27,7 @@
 #include "common/config.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << rank << ".snap "

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -118,7 +118,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
       object_t oid = CInode::get_object_name(in->inode.ino, *p, "");
       dout(10) << __func__ << " remove dirfrag " << oid << dendl;
       mds->objecter->remove(oid, oloc, nullsnapc,
-			    ceph::real_clock::now(g_ceph_context),
+			    ceph::real_clock::now(),
 			    0, NULL, gather.new_sub());
     }
     assert(gather.has_subs());
@@ -149,7 +149,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
       dout(10) << __func__ << " 0~" << to << " objects 0~" << num
 	       << " snapc " << snapc << " on " << *in << dendl;
       filer.purge_range(in->inode.ino, &in->inode.layout, *snapc,
-			0, num, ceph::real_clock::now(g_ceph_context), 0,
+			0, num, ceph::real_clock::now(), 0,
 			gather.new_sub());
     }
   }
@@ -162,7 +162,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
     dout(10) << __func__ << " remove backtrace object " << oid
 	     << " pool " << oloc.pool << " snapc " << snapc << dendl;
     mds->objecter->remove(oid, oloc, *snapc,
-			  ceph::real_clock::now(g_ceph_context), 0,
+			  ceph::real_clock::now(), 0,
 			  NULL, gather.new_sub());
   }
   // remove old backtrace objects
@@ -173,7 +173,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
     dout(10) << __func__ << " remove backtrace object " << oid
 	     << " old pool " << *p << " snapc " << snapc << dendl;
     mds->objecter->remove(oid, oloc, *snapc,
-			  ceph::real_clock::now(g_ceph_context), 0,
+			  ceph::real_clock::now(), 0,
 			  NULL, gather.new_sub());
   }
   assert(gather.has_subs());
@@ -909,12 +909,12 @@ void StrayManager::truncate(CDentry *dn, uint32_t op_allowance)
     // keep backtrace object
     if (num > 1) {
       filer.purge_range(in->ino(), &in->inode.layout, *snapc,
-			1, num - 1, ceph::real_clock::now(g_ceph_context),
+			1, num - 1, ceph::real_clock::now(),
 			0, gather.new_sub());
     }
     filer.zero(in->ino(), &in->inode.layout, *snapc,
 	       0, in->inode.layout.object_size,
-	       ceph::real_clock::now(g_ceph_context),
+	       ceph::real_clock::now(),
 	       0, true, NULL, gather.new_sub());
   }
 

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -27,6 +27,7 @@
 
 #include "StrayManager.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mds)

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -52,6 +52,7 @@
 
 #include "Locker.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef DOUT_COND
 #define DOUT_COND(cct, l) (l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_log \

--- a/src/mds/mdstypes.h
+++ b/src/mds/mdstypes.h
@@ -1158,7 +1158,7 @@ inline void decode(dirfrag_load_vec_t& c, bufferlist::iterator &p) {
 inline std::ostream& operator<<(std::ostream& out, dirfrag_load_vec_t& dl)
 {
   // ugliness!
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   DecayRate rate(g_conf->mds_decay_halflife);
   return out << "[" << dl.vec[0].get(now, rate) << "," << dl.vec[1].get(now, rate) 
 	     << " " << dl.meta_load(now, rate)
@@ -1230,7 +1230,7 @@ public:
   DecayCounter count;
 
 public:
-  load_spread_t() : p(0), n(0), count(ceph_clock_now(g_ceph_context))
+  load_spread_t() : p(0), n(0), count(ceph_clock_now())
   {
     for (int i=0; i<MAX; i++)
       last[i] = -1;

--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -52,7 +52,7 @@ public:
   }
   void decode_payload() {
     bufferlist::iterator p = payload.begin();
-    utime_t now(ceph_clock_now(NULL));
+    utime_t now(ceph_clock_now());
     ::decode(load, now, p);
     ::decode(beat, p);
     ::decode(import_map, p);

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -16,6 +16,7 @@
 
 #include "mgr/ClusterState.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -19,6 +19,7 @@
 #include "messages/MCommandReply.h"
 #include "messages/MPGStats.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr.server " << __func__ << " "

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -117,7 +117,7 @@ void DaemonPerfCounters::update(MMgrReport *report)
     declared_types.insert(t.path);
   }
 
-  const auto now = ceph_clock_now(g_ceph_context);
+  const auto now = ceph_clock_now();
 
   // Parse packed data according to declared set of types
   bufferlist::iterator p = report->packed.begin();

--- a/src/mgr/DaemonState.cc
+++ b/src/mgr/DaemonState.cc
@@ -13,6 +13,7 @@
 
 #include "DaemonState.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -31,6 +31,7 @@
 
 #include "Mgr.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/MgrPyModule.cc
+++ b/src/mgr/MgrPyModule.cc
@@ -19,6 +19,7 @@
 #include "MgrPyModule.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -27,6 +27,7 @@
 
 #include "MgrStandby.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -27,6 +27,7 @@
 
 #include "PyModules.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -22,6 +22,8 @@
 
 #include "PyState.h"
 
+#define dout_context g_ceph_context
+
 PyModules *global_handle = NULL;
 
 

--- a/src/mon/DataHealthService.cc
+++ b/src/mon/DataHealthService.cc
@@ -139,7 +139,7 @@ int DataHealthService::update_store_stats(DataStats &ours)
   ours.store_stats.bytes_sst = extra["sst"];
   ours.store_stats.bytes_log = extra["log"];
   ours.store_stats.bytes_misc = extra["misc"];
-  ours.last_update = ceph_clock_now(g_ceph_context);
+  ours.last_update = ceph_clock_now();
 
   return 0;
 }
@@ -159,7 +159,7 @@ int DataHealthService::update_stats()
           << " total " << prettybyte_t(ours.fs_stats.byte_total)
           << ", used " << prettybyte_t(ours.fs_stats.byte_used)
           << ", avail " << prettybyte_t(ours.fs_stats.byte_avail) << dendl;
-  ours.last_update = ceph_clock_now(g_ceph_context);
+  ours.last_update = ceph_clock_now();
 
   return update_store_stats(ours);
 }

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -86,7 +86,7 @@ void Elector::start()
     int r = mon->store->apply_transaction(t);
     assert(r >= 0);
   }
-  start_stamp = ceph_clock_now(g_ceph_context);
+  start_stamp = ceph_clock_now();
   electing_me = true;
   acked_me[mon->rank].cluster_features = CEPH_FEATURES_ALL;
   acked_me[mon->rank].mon_features = ceph::features::mon::get_supported();
@@ -117,7 +117,7 @@ void Elector::defer(int who)
 
   // ack them
   leader_acked = who;
-  ack_stamp = ceph_clock_now(g_ceph_context);
+  ack_stamp = ceph_clock_now();
   MMonElection *m = new MMonElection(MMonElection::OP_ACK, epoch, mon->monmap);
   m->mon_features = ceph::features::mon::get_supported();
   m->sharing_bl = mon->get_supported_commands_bl();

--- a/src/mon/LogMonitor.cc
+++ b/src/mon/LogMonitor.cc
@@ -63,7 +63,7 @@ void LogMonitor::create_initial()
   dout(10) << "create_initial -- creating initial map" << dendl;
   LogEntry e;
   memset(&e.who, 0, sizeof(e.who));
-  e.stamp = ceph_clock_now(g_ceph_context);
+  e.stamp = ceph_clock_now();
   e.prio = CLOG_INFO;
   std::stringstream ss;
   ss << "mkfs " << mon->monmap->get_fsid();
@@ -553,7 +553,7 @@ void LogMonitor::_create_sub_incremental(MLog *mlog, int level, version_t sv)
     dout(10) << __func__ << " skipped from " << sv
 	     << " to first_committed " << get_first_committed() << dendl;
     LogEntry le;
-    le.stamp = ceph_clock_now(NULL);
+    le.stamp = ceph_clock_now();
     le.prio = CLOG_WARN;
     ostringstream ss;
     ss << "skipped log messages from " << sv << " to " << get_first_committed();

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -96,8 +96,8 @@ void MDSMonitor::create_new_fs(FSMap &fsm, const std::string &name,
   fs->mds_map.cas_pool = -1;
   fs->mds_map.max_file_size = g_conf->mds_max_file_size;
   fs->mds_map.compat = fsm.compat;
-  fs->mds_map.created = ceph_clock_now(g_ceph_context);
-  fs->mds_map.modified = ceph_clock_now(g_ceph_context);
+  fs->mds_map.created = ceph_clock_now();
+  fs->mds_map.modified = ceph_clock_now();
   fs->mds_map.session_timeout = g_conf->mds_session_timeout;
   fs->mds_map.session_autoclose = g_conf->mds_session_autoclose;
   fs->mds_map.enabled = true;
@@ -189,7 +189,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   // Set 'modified' on maps modified this epoch
   for (auto &i : fsmap.filesystems) {
     if (i.second->mds_map.epoch == fsmap.epoch) {
-      i.second->mds_map.modified = ceph_clock_now(g_ceph_context);
+      i.second->mds_map.modified = ceph_clock_now();
     }
   }
 
@@ -285,7 +285,7 @@ void MDSMonitor::_note_beacon(MMDSBeacon *m)
   version_t seq = m->get_seq();
 
   dout(15) << "_note_beacon " << *m << " noting time" << dendl;
-  last_beacon[gid].stamp = ceph_clock_now(g_ceph_context);  
+  last_beacon[gid].stamp = ceph_clock_now();
   last_beacon[gid].seq = seq;
 }
 
@@ -549,7 +549,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
     }
 
     // initialize the beacon timer
-    last_beacon[gid].stamp = ceph_clock_now(g_ceph_context);
+    last_beacon[gid].stamp = ceph_clock_now();
     last_beacon[gid].seq = seq;
 
     // new incompat?
@@ -621,7 +621,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
       dout(4) << __func__ << ": marking rank "
               << info.rank << " damaged" << dendl;
 
-      utime_t until = ceph_clock_now(g_ceph_context);
+      utime_t until = ceph_clock_now();
       until += g_conf->mds_blacklist_interval;
       const auto blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
       request_proposal(mon->osdmon());
@@ -1262,7 +1262,7 @@ bool MDSMonitor::fail_mds_gid(mds_gid_t gid)
 
   epoch_t blacklist_epoch = 0;
   if (info.rank >= 0 && info.state != MDSMap::STATE_STANDBY_REPLAY) {
-    utime_t until = ceph_clock_now(g_ceph_context);
+    utime_t until = ceph_clock_now();
     until += g_conf->mds_blacklist_interval;
     blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
   }
@@ -1749,8 +1749,8 @@ int MDSMonitor::management_command(
     new_fs->mds_map.fs_name = fs->mds_map.fs_name;
     new_fs->mds_map.max_file_size = g_conf->mds_max_file_size;
     new_fs->mds_map.compat = fsmap.compat;
-    new_fs->mds_map.created = ceph_clock_now(g_ceph_context);
-    new_fs->mds_map.modified = ceph_clock_now(g_ceph_context);
+    new_fs->mds_map.created = ceph_clock_now();
+    new_fs->mds_map.modified = ceph_clock_now();
     new_fs->mds_map.session_timeout = g_conf->mds_session_timeout;
     new_fs->mds_map.session_autoclose = g_conf->mds_session_autoclose;
     new_fs->mds_map.enabled = true;
@@ -2843,7 +2843,7 @@ void MDSMonitor::maybe_replace_gid(mds_gid_t gid,
         << " " << ceph_mds_state_name(info.state)
         << " laggy" << dendl;
       pending_fsmap.modify_daemon(info.global_id, [](MDSMap::mds_info_t *info) {
-          info->laggy_since = ceph_clock_now(g_ceph_context);
+          info->laggy_since = ceph_clock_now();
       });
       *mds_propose = true;
   }
@@ -2973,7 +2973,7 @@ void MDSMonitor::tick()
     do_propose |= maybe_expand_cluster(i.second);
   }
 
-  const auto now = ceph_clock_now(g_ceph_context);
+  const auto now = ceph_clock_now();
   if (last_tick.is_zero()) {
     last_tick = now;
   }

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -122,7 +122,7 @@ bool MgrMonitor::preprocess_beacon(MonOpRequestRef op)
   MMgrBeacon *m = static_cast<MMgrBeacon*>(op->get_req());
   dout(4) << "beacon from " << m->get_gid() << dendl;
 
-  last_beacon[m->get_gid()] = ceph_clock_now(g_ceph_context);
+  last_beacon[m->get_gid()] = ceph_clock_now();
 
   if (pending_map.active_gid == m->get_gid()
       && pending_map.active_addr == m->get_server_addr()
@@ -163,7 +163,7 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
     }
   }
 
-  last_beacon[m->get_gid()] = ceph_clock_now(g_ceph_context);
+  last_beacon[m->get_gid()] = ceph_clock_now();
 
   // Track whether we modified pending_map
   bool updated = false;
@@ -276,7 +276,7 @@ void MgrMonitor::send_digests()
 
 void MgrMonitor::tick()
 {
-  const utime_t now = ceph_clock_now(g_ceph_context);
+  const utime_t now = ceph_clock_now();
   utime_t cutoff = now;
   cutoff -= g_conf->mon_mgr_beacon_grace;
 

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -135,7 +135,7 @@ int MonClient::get_monmap_privately()
 
     utime_t interval;
     interval.set_from_double(cct->_conf->mon_client_hunt_interval);
-    map_cond.WaitInterval(cct, monc_lock, interval);
+    map_cond.WaitInterval(monc_lock, interval);
 
     if (monmap.fsid.is_zero() && cur_con) {
       cur_con->mark_down();  // nope, clean that connection up
@@ -448,7 +448,7 @@ int MonClient::authenticate(double timeout)
   if (cur_mon.empty())
     _reopen_session();
 
-  utime_t until = ceph_clock_now(cct);
+  utime_t until = ceph_clock_now();
   until += timeout;
   if (timeout > 0.0)
     ldout(cct, 10) << "authenticate will time out at " << until << dendl;
@@ -723,7 +723,7 @@ void MonClient::tick()
     _reopen_session();
   } else if (!cur_mon.empty()) {
     // just renew as needed
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     if (!cur_con->has_feature(CEPH_FEATURE_MON_STATEFUL_SUB)) {
       ldout(cct, 10) << "renew subs? (now: " << now
 		     << "; renew after: " << sub_renew_after << ") -- "
@@ -786,7 +786,7 @@ void MonClient::_renew_subs()
     _reopen_session();
   else {
     if (sub_renew_sent == utime_t())
-      sub_renew_sent = ceph_clock_now(cct);
+      sub_renew_sent = ceph_clock_now();
 
     MMonSubscribe *m = new MMonSubscribe;
     m->what = sub_new;
@@ -847,7 +847,7 @@ int MonClient::_check_auth_rotating()
     return 0;
   }
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   utime_t cutoff = now;
   cutoff -= MIN(30.0, cct->_conf->auth_service_ticket_ttl / 4.0);
   utime_t issued_at_lower_bound = now;
@@ -885,7 +885,7 @@ int MonClient::_check_auth_rotating()
 int MonClient::wait_auth_rotating(double timeout)
 {
   Mutex::Locker l(monc_lock);
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   utime_t until = now;
   until += timeout;
 
@@ -903,7 +903,7 @@ int MonClient::wait_auth_rotating(double timeout)
     }
     ldout(cct, 10) << "wait_auth_rotating waiting (until " << until << ")" << dendl;
     auth_cond.WaitUntil(monc_lock, until);
-    now = ceph_clock_now(cct);
+    now = ceph_clock_now();
   }
   ldout(cct, 10) << "wait_auth_rotating done" << dendl;
   return 0;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -62,7 +62,7 @@ struct MonClientPinger : public Dispatcher {
   { }
 
   int wait_for_reply(double timeout = 0.0) {
-    utime_t until = ceph_clock_now(cct);
+    utime_t until = ceph_clock_now();
     until += (timeout > 0 ? timeout : cct->_conf->client_mount_timeout);
     done = false;
 

--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -462,7 +462,7 @@ int MonMap::build_initial(CephContext *cct, ostream& errout)
              << std::endl;
       return r;
     }
-    created = ceph_clock_now(cct);
+    created = ceph_clock_now();
     last_changed = created;
     return 0;
   }
@@ -548,7 +548,7 @@ int MonMap::build_initial(CephContext *cct, ostream& errout)
     errout << "no monitors specified to connect to." << std::endl;
     return -ENOENT;
   }
-  created = ceph_clock_now(cct);
+  created = ceph_clock_now();
   last_changed = created;
   return 0;
 }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -217,7 +217,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   bool r = mon_caps->parse("allow *", NULL);
   assert(r);
 
-  exited_quorum = ceph_clock_now(g_ceph_context);
+  exited_quorum = ceph_clock_now();
 
   // assume our commands until we have an election.  this only means
   // we won't reply with EINVAL before the election; any command that
@@ -1218,7 +1218,7 @@ void Monitor::_reset()
 
   leader_since = utime_t();
   if (!quorum.empty()) {
-    exited_quorum = ceph_clock_now(g_ceph_context);
+    exited_quorum = ceph_clock_now();
   }
   quorum.clear();
   outside_quorum.clear();
@@ -1702,7 +1702,7 @@ void Monitor::sync_trim_providers()
 {
   dout(20) << __func__ << dendl;
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   map<uint64_t,SyncProvider>::iterator p = sync_providers.begin();
   while (p != sync_providers.end()) {
     if (now > p->second.timeout) {
@@ -2053,7 +2053,7 @@ void Monitor::win_election(epoch_t epoch, set<int>& active, uint64_t features,
            << dendl;
   assert(is_electing());
   state = STATE_LEADER;
-  leader_since = ceph_clock_now(g_ceph_context);
+  leader_since = ceph_clock_now();
   leader = rank;
   quorum = active;
   quorum_con_features = features;
@@ -2398,7 +2398,7 @@ void Monitor::health_tick_stop()
 
 utime_t Monitor::health_interval_calc_next_update()
 {
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   time_t secs = now.sec();
   int remainder = secs % cct->_conf->mon_health_to_clog_interval;
@@ -3068,9 +3068,9 @@ void Monitor::handle_command(MonOpRequestRef op)
 
   if (prefix == "compact" || prefix == "mon compact") {
     dout(1) << "triggering manual compaction" << dendl;
-    utime_t start = ceph_clock_now(g_ceph_context);
+    utime_t start = ceph_clock_now();
     store->compact();
-    utime_t end = ceph_clock_now(g_ceph_context);
+    utime_t end = ceph_clock_now();
     end -= start;
     dout(1) << "finished manual compaction in " << end << " seconds" << dendl;
     ostringstream oss;
@@ -3159,7 +3159,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     f->dump_stream("cluster_fingerprint") << fingerprint;
     f->dump_string("version", ceph_version_to_str());
     f->dump_string("commit", git_version_to_str());
-    f->dump_stream("timestamp") << ceph_clock_now(NULL);
+    f->dump_stream("timestamp") << ceph_clock_now();
 
     vector<string> tagsvec;
     cmd_getval(g_ceph_context, cmdmap, "tags", tagsvec);
@@ -3706,7 +3706,7 @@ void Monitor::waitlist_or_zap_client(MonOpRequestRef op)
   Message *m = op->get_req();
   MonSession *s = op->get_session();
   ConnectionRef con = op->get_connection();
-  utime_t too_old = ceph_clock_now(g_ceph_context);
+  utime_t too_old = ceph_clock_now();
   too_old -= g_ceph_context->_conf->mon_lease;
   if (m->get_recv_stamp() > too_old &&
       con->is_connected()) {
@@ -3776,7 +3776,7 @@ void Monitor::_ms_dispatch(Message *m)
 
   assert(s);
 
-  s->session_timeout = ceph_clock_now(NULL);
+  s->session_timeout = ceph_clock_now();
   s->session_timeout += g_conf->mon_session_timeout;
 
   if (s->auth_handler) {
@@ -4091,7 +4091,7 @@ void Monitor::timecheck_start_round()
 
   if (timecheck_round % 2) {
     dout(10) << __func__ << " there's a timecheck going on" << dendl;
-    utime_t curr_time = ceph_clock_now(g_ceph_context);
+    utime_t curr_time = ceph_clock_now();
     double max = g_conf->mon_timecheck_interval*3;
     if (curr_time - timecheck_round_start < max) {
       dout(10) << __func__ << " keep current round going" << dendl;
@@ -4106,7 +4106,7 @@ void Monitor::timecheck_start_round()
   assert(timecheck_round % 2 == 0);
   timecheck_acks = 0;
   timecheck_round ++;
-  timecheck_round_start = ceph_clock_now(g_ceph_context);
+  timecheck_round_start = ceph_clock_now();
   dout(10) << __func__ << " new " << timecheck_round << dendl;
 
   timecheck();
@@ -4290,7 +4290,7 @@ void Monitor::timecheck()
       continue;
 
     entity_inst_t inst = monmap->get_inst(*it);
-    utime_t curr_time = ceph_clock_now(g_ceph_context);
+    utime_t curr_time = ceph_clock_now();
     timecheck_waiting[inst] = curr_time;
     MTimeCheck *m = new MTimeCheck(MTimeCheck::OP_PING);
     m->epoch = get_epoch();
@@ -4341,7 +4341,7 @@ void Monitor::handle_timecheck_leader(MonOpRequestRef op)
     return;
   }
 
-  utime_t curr_time = ceph_clock_now(g_ceph_context);
+  utime_t curr_time = ceph_clock_now();
 
   assert(timecheck_waiting.count(other) > 0);
   utime_t timecheck_sent = timecheck_waiting[other];
@@ -4469,7 +4469,7 @@ void Monitor::handle_timecheck_peon(MonOpRequestRef op)
 
   assert((timecheck_round % 2) != 0);
   MTimeCheck *reply = new MTimeCheck(MTimeCheck::OP_PONG);
-  utime_t curr_time = ceph_clock_now(g_ceph_context);
+  utime_t curr_time = ceph_clock_now();
   reply->timestamp = curr_time;
   reply->epoch = m->epoch;
   reply->round = m->round;
@@ -5085,7 +5085,7 @@ void Monitor::tick()
   }
   
   // trim sessions
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   xlist<MonSession*>::iterator p = session_map.sessions.begin();
 
   bool out_for_too_long = (!exited_quorum.is_zero()

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -287,7 +287,7 @@ private:
     SyncProvider() : cookie(0), last_committed(0), full(false) {}
 
     void reset_timeout(CephContext *cct, int grace) {
-      timeout = ceph_clock_now(cct);
+      timeout = ceph_clock_now();
       timeout += grace;
     }
   };

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -30,6 +30,8 @@
 #include "common/debug.h"
 #include "common/safe_io.h"
 
+#define dout_context g_ceph_context
+
 class MonitorDBStore
 {
   string path;

--- a/src/mon/MonmapMonitor.cc
+++ b/src/mon/MonmapMonitor.cc
@@ -78,7 +78,7 @@ void MonmapMonitor::create_pending()
 {
   pending_map = *mon->monmap;
   pending_map.epoch++;
-  pending_map.last_changed = ceph_clock_now(g_ceph_context);
+  pending_map.last_changed = ceph_clock_now();
   dout(10) << "create_pending monmap epoch " << pending_map.epoch << dendl;
 }
 
@@ -455,7 +455,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
      */
 
     pending_map.add(name, addr);
-    pending_map.last_changed = ceph_clock_now(g_ceph_context);
+    pending_map.last_changed = ceph_clock_now();
     ss << "adding mon." << name << " at " << addr;
     propose = true;
     dout(0) << __func__ << " proposing new mon." << name << dendl;
@@ -507,7 +507,7 @@ bool MonmapMonitor::prepare_command(MonOpRequestRef op)
 
     entity_addr_t addr = pending_map.get_addr(name);
     pending_map.remove(name);
-    pending_map.last_changed = ceph_clock_now(g_ceph_context);
+    pending_map.last_changed = ceph_clock_now();
     ss << "removing mon." << name << " at " << addr
        << ", there will be " << pending_map.size() << " monitors" ;
     propose = true;
@@ -556,7 +556,7 @@ bool MonmapMonitor::prepare_join(MonOpRequestRef op)
   if (pending_map.contains(join->addr))
     pending_map.remove(pending_map.get_name(join->addr));
   pending_map.add(join->name, join->addr);
-  pending_map.last_changed = ceph_clock_now(g_ceph_context);
+  pending_map.last_changed = ceph_clock_now();
   return true;
 }
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -123,7 +123,7 @@ void OSDMonitor::create_initial()
 			g_conf->osd_pg_bits, g_conf->osd_pgp_bits);
   }
   newmap.set_epoch(1);
-  newmap.created = newmap.modified = ceph_clock_now(g_ceph_context);
+  newmap.created = newmap.modified = ceph_clock_now();
 
   // new clusters should sort bitwise by default.
   newmap.set_flag(CEPH_OSDMAP_SORTBITWISE);
@@ -296,7 +296,7 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
       // populate down -> out map
       if (found == down_pending_out.end()) {
         dout(10) << " adding osd." << o << " to down_pending_out map" << dendl;
-        down_pending_out[o] = ceph_clock_now(g_ceph_context);
+        down_pending_out[o] = ceph_clock_now();
       }
     } else {
       if (found != down_pending_out.end()) {
@@ -1092,7 +1092,7 @@ void OSDMonitor::maybe_prime_pg_temp()
 
   PGMap *pg_map = &mon->pgmon()->pg_map;
 
-  utime_t stop = ceph_clock_now(NULL);
+  utime_t stop = ceph_clock_now();
   stop += g_conf->mon_osd_prime_pg_temp_max_time;
   int chunk = 1000;
   int n = chunk;
@@ -1105,7 +1105,7 @@ void OSDMonitor::maybe_prime_pg_temp()
       prime_pg_temp(next, pp);
       if (--n <= 0) {
 	n = chunk;
-	if (ceph_clock_now(NULL) > stop) {
+	if (ceph_clock_now() > stop) {
 	  dout(10) << __func__ << " consumed more than "
 		   << g_conf->mon_osd_prime_pg_temp_max_time
 		   << " seconds, stopping"
@@ -1120,7 +1120,7 @@ void OSDMonitor::maybe_prime_pg_temp()
       n -= prime_pg_temp(next, pg_map, *p);
       if (n <= 0) {
 	n = chunk;
-	if (ceph_clock_now(NULL) > stop) {
+	if (ceph_clock_now() > stop) {
 	  dout(10) << __func__ << " consumed more than "
 		   << g_conf->mon_osd_prime_pg_temp_max_time
 		   << " seconds, stopping"
@@ -1193,7 +1193,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	   << dendl;
 
   // finalize up pending_inc
-  pending_inc.modified = ceph_clock_now(g_ceph_context);
+  pending_inc.modified = ceph_clock_now();
 
   int r = pending_inc.propagate_snaps_to_tiers(g_ceph_context, osdmap);
   assert(r == 0);
@@ -1877,7 +1877,7 @@ bool OSDMonitor::prepare_failure(MonOpRequestRef op)
   assert(osdmap.get_addr(target_osd) == m->get_target().addr);
 
   // calculate failure time
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t failed_since =
     m->get_recv_stamp() -
     utime_t(m->failed_for ? m->failed_for : g_conf->osd_heartbeat_grace, 0);
@@ -2245,7 +2245,7 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
       dout(10) << " not laggy, new xi " << xi << dendl;
     } else {
       if (xi.down_stamp.sec()) {
-        int interval = ceph_clock_now(g_ceph_context).sec() -
+        int interval = ceph_clock_now().sec() -
 	  xi.down_stamp.sec();
         if (g_conf->mon_osd_laggy_max_interval &&
 	    (interval > g_conf->mon_osd_laggy_max_interval)) {
@@ -2810,7 +2810,7 @@ void OSDMonitor::tick()
   if (!mon->is_leader()) return;
 
   bool do_propose = false;
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
 
   // mark osds down?
   if (check_failures(now))
@@ -7047,7 +7047,7 @@ done:
       string blacklistop;
       cmd_getval(g_ceph_context, cmdmap, "blacklistop", blacklistop);
       if (blacklistop == "add") {
-	utime_t expires = ceph_clock_now(g_ceph_context);
+	utime_t expires = ceph_clock_now();
 	double d;
 	// default one hour
 	cmd_getval(g_ceph_context, cmdmap, "expire", d, double(60*60));
@@ -7108,7 +7108,7 @@ done:
     if (pp->snap_exists(snapname.c_str())) {
       ss << "pool " << poolstr << " snap " << snapname << " already exists";
     } else {
-      pp->add_snap(snapname.c_str(), ceph_clock_now(g_ceph_context));
+      pp->add_snap(snapname.c_str(), ceph_clock_now());
       pp->set_snap_epoch(pending_inc.epoch);
       ss << "created pool " << poolstr << " snap " << snapname;
     }
@@ -8161,7 +8161,7 @@ bool OSDMonitor::prepare_pool_op(MonOpRequestRef op)
   switch (m->op) {
   case POOL_OP_CREATE_SNAP:
     if (!pp.snap_exists(m->name.c_str())) {
-      pp.add_snap(m->name.c_str(), ceph_clock_now(g_ceph_context));
+      pp.add_snap(m->name.c_str(), ceph_clock_now());
       dout(10) << "create snap in pool " << m->pool << " " << m->name << " seq " << pp.get_snap_epoch() << dendl;
       changed = true;
     }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2171,7 +2171,7 @@ void PGMapUpdater::register_pg(
     stats.last_deep_scrub_stamp = ps.last_deep_scrub_stamp;
     stats.last_clean_scrub_stamp = ps.last_clean_scrub_stamp;
   } else {
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     stats.last_fresh = now;
     stats.last_active = now;
     stats.last_change = now;

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -12,6 +12,8 @@
 #include "osd/osd_types.h"
 #include "osd/OSDMap.h"
 
+#define dout_context g_ceph_context
+
 // --
 
 void PGMap::Incremental::encode(bufferlist &bl, uint64_t features) const

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -120,7 +120,7 @@ void PGMonitor::tick()
   handle_osd_timeouts();
 
   if (!pg_map.pg_sum_deltas.empty()) {
-    utime_t age = ceph_clock_now(g_ceph_context) - pg_map.stamp;
+    utime_t age = ceph_clock_now() - pg_map.stamp;
     if (age > 2 * g_conf->mon_delta_reset_interval) {
       dout(10) << " clearing pg_map delta (" << age << " > " << g_conf->mon_delta_reset_interval << " seconds old)" << dendl;
       pg_map.clear_delta();
@@ -138,7 +138,7 @@ void PGMonitor::tick()
     ceph::unordered_map<uint64_t,pair<pool_stat_t,utime_t> >::iterator it;
     for (it = pg_map.per_pool_sum_delta.begin();
          it != pg_map.per_pool_sum_delta.end(); ) {
-      utime_t age = ceph_clock_now(g_ceph_context) - it->second.second;
+      utime_t age = ceph_clock_now() - it->second.second;
       if (age > 2*g_conf->mon_delta_reset_interval) {
 	dout(10) << " clearing pg_map delta for pool " << it->first
 	         << " (" << age << " > " << g_conf->mon_delta_reset_interval
@@ -296,7 +296,7 @@ void PGMonitor::handle_osd_timeouts()
   if (!mon->is_leader())
     return;
 
-  utime_t now(ceph_clock_now(g_ceph_context));
+  utime_t now(ceph_clock_now());
   utime_t timeo(g_conf->mon_osd_report_timeout, 0);
   if (now - mon->get_leader_since() < timeo) {
     // We haven't been the leader for long enough to consider OSD timeouts
@@ -477,7 +477,7 @@ void PGMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   version_t version = pending_inc.version;
   dout(10) << __func__ << " v " << version << dendl;
   assert(get_last_committed() + 1 == version);
-  pending_inc.stamp = ceph_clock_now(g_ceph_context);
+  pending_inc.stamp = ceph_clock_now();
 
   uint64_t features = mon->get_quorum_con_features();
 
@@ -772,7 +772,7 @@ bool PGMonitor::prepare_pg_stats(MonOpRequestRef op)
     return false;
   }
 
-  last_osd_report[from] = ceph_clock_now(g_ceph_context);
+  last_osd_report[from] = ceph_clock_now();
 
   if (!stats->get_orig_source().is_osd() ||
       !mon->osdmon()->osdmap.is_up(from) ||
@@ -946,7 +946,7 @@ void PGMonitor::send_pg_creates()
   dout(10) << "send_pg_creates to " << pg_map.creating_pgs.size()
            << " pgs" << dendl;
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   for (map<int, map<epoch_t, set<pg_t> > >::iterator p =
          pg_map.creating_pgs_by_osd_epoch.begin();
        p != pg_map.creating_pgs_by_osd_epoch.end();
@@ -1006,7 +1006,7 @@ epoch_t PGMonitor::send_pg_creates(int osd, Connection *con, epoch_t next)
     assert(mon->osdmon()->osdmap.is_up(osd));
     mon->messenger->send_message(m, mon->osdmon()->osdmap.get_inst(osd));
   }
-  last_sent_pg_create[osd] = ceph_clock_now(g_ceph_context);
+  last_sent_pg_create[osd] = ceph_clock_now();
 
   // sub is current through last + 1
   return last + 1;
@@ -1032,7 +1032,7 @@ void PGMonitor::_try_mark_pg_stale(
     dout(10) << " marking pg " << pgid << " stale (acting_primary "
 	     << stat->acting_primary << ")" << dendl;
     stat->state |= PG_STATE_STALE;  
-    stat->last_unstale = ceph_clock_now(g_ceph_context);
+    stat->last_unstale = ceph_clock_now();
   }
 }
 
@@ -1469,7 +1469,7 @@ bool PGMonitor::prepare_command(MonOpRequestRef op)
       pg_stat_t& s = pending_inc.pg_stat_updates[pgid];
       s.state = PG_STATE_CREATING;
       s.created = epoch;
-      s.last_change = ceph_clock_now(g_ceph_context);
+      s.last_change = ceph_clock_now();
     }
     ss << "pg " << pgidstr << " now creating, ok";
     goto update;
@@ -1546,7 +1546,7 @@ static void note_stuck_detail(int what,
     if (since == utime_t()) {
       ss << " since forever";
     } else {
-      utime_t dur = ceph_clock_now(g_ceph_context) - since;
+      utime_t dur = ceph_clock_now() - since;
       ss << " for " << dur;
     }
     ss << ", current state " << pg_state_string(p->second.state)
@@ -1612,7 +1612,7 @@ namespace {
       return;
 
     int pgs_count = 0;
-    const utime_t now = ceph_clock_now(nullptr);
+    const utime_t now = ceph_clock_now();
     for (const auto& pg_entry : pg_stats) {
       const auto& pg_stat(pg_entry.second);
       const utime_t time_since_ls = now - pg_stat.last_scrub_stamp;
@@ -1693,7 +1693,7 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
   }
 
   ceph::unordered_map<pg_t, pg_stat_t> stuck_pgs;
-  utime_t now(ceph_clock_now(g_ceph_context));
+  utime_t now(ceph_clock_now());
   utime_t cutoff = now - utime_t(g_conf->mon_pg_stuck_threshold, 0);
   uint64_t num_inactive_pgs = 0;
   
@@ -2006,7 +2006,7 @@ int PGMonitor::dump_stuck_pg_stats(stringstream &ds,
     }
   }
 
-  utime_t now(ceph_clock_now(g_ceph_context));
+  utime_t now(ceph_clock_now());
   utime_t cutoff = now - utime_t(threshold, 0);
 
   if (!f) {

--- a/src/mon/Paxos.h
+++ b/src/mon/Paxos.h
@@ -657,8 +657,8 @@ public:
     C_Proposal(Context *c, bufferlist& proposal_bl) :
 	proposer_context(c),
 	bl(proposal_bl),
-        proposed(false),
-	proposal_time(ceph_clock_now(NULL))
+	proposed(false),
+	proposal_time(ceph_clock_now())
       { }
 
     void finish(int r) {
@@ -1357,7 +1357,7 @@ inline ostream& operator<<(ostream& out, Paxos::C_Proposal& p)
 {
   string proposed = (p.proposed ? "proposed" : "unproposed");
   out << " " << proposed
-      << " queued " << (ceph_clock_now(NULL) - p.proposal_time)
+      << " queued " << (ceph_clock_now() - p.proposal_time)
       << " tx dump:\n";
   MonitorDBStore::TransactionRef t(new MonitorDBStore::Transaction);
   bufferlist::iterator p_it = p.bl.begin();

--- a/src/mon/PaxosService.cc
+++ b/src/mon/PaxosService.cc
@@ -164,7 +164,7 @@ bool PaxosService::should_propose(double& delay)
   if (get_last_committed() <= 1)
     delay = 0.0;
   else {
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     if ((now - paxos->last_commit_time) > g_conf->paxos_propose_interval)
       delay = (double)g_conf->paxos_min_wait;
     else

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -66,7 +66,7 @@ struct MonSession : public RefCountedObject {
     osd_epoch(0),
     auth_handler(NULL),
     proxy_con(NULL), proxy_tid(0) {
-    time_established = ceph_clock_now(g_ceph_context);
+    time_established = ceph_clock_now();
   }
   ~MonSession() {
     //generic_dout(0) << "~MonSession " << this << dendl;

--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -95,7 +95,7 @@ void DispatchQueue::enqueue(Message *m, int priority, uint64_t id)
 
 void DispatchQueue::local_delivery(Message *m, int priority)
 {
-  m->set_recv_stamp(ceph_clock_now(msgr->cct));
+  m->set_recv_stamp(ceph_clock_now());
   Mutex::Locker l(local_delivery_lock);
   if (local_messages.empty())
     local_delivery_cond.Signal();

--- a/src/msg/Messenger.h
+++ b/src/msg/Messenger.h
@@ -556,7 +556,7 @@ public:
    * of one reference to it.
    */
   void ms_fast_dispatch(Message *m) {
-    m->set_dispatch_stamp(ceph_clock_now(cct));
+    m->set_dispatch_stamp(ceph_clock_now());
     for (list<Dispatcher*>::iterator p = fast_dispatchers.begin();
 	 p != fast_dispatchers.end();
 	 ++p) {
@@ -586,7 +586,7 @@ public:
    *  one reference to it.
    */
   void ms_deliver_dispatch(Message *m) {
-    m->set_dispatch_stamp(ceph_clock_now(cct));
+    m->set_dispatch_stamp(ceph_clock_now());
     for (list<Dispatcher*>::iterator p = dispatchers.begin();
 	 p != dispatchers.end();
 	 ++p) {

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -344,7 +344,7 @@ void AsyncConnection::process()
 
           if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
             ldout(async_msgr->cct, 20) << __func__ << " got KEEPALIVE" << dendl;
-	    set_last_keepalive(ceph_clock_now(NULL));
+	    set_last_keepalive(ceph_clock_now());
           } else if (tag == CEPH_MSGR_TAG_KEEPALIVE2) {
             state = STATE_OPEN_KEEPALIVE2;
           } else if (tag == CEPH_MSGR_TAG_KEEPALIVE2_ACK) {
@@ -381,7 +381,7 @@ void AsyncConnection::process()
           _append_keepalive_or_ack(true, &kp_t);
 	  write_lock.unlock();
           ldout(async_msgr->cct, 20) << __func__ << " got KEEPALIVE2 " << kp_t << dendl;
-	  set_last_keepalive(ceph_clock_now(NULL));
+	  set_last_keepalive(ceph_clock_now());
           need_dispatch_writer = true;
           state = STATE_OPEN;
           break;
@@ -480,7 +480,7 @@ void AsyncConnection::process()
           front.clear();
           middle.clear();
           data.clear();
-          recv_stamp = ceph_clock_now(async_msgr->cct);
+          recv_stamp = ceph_clock_now();
           current_header = header;
           state = STATE_OPEN_MESSAGE_THROTTLE_MESSAGE;
           break;
@@ -548,7 +548,7 @@ void AsyncConnection::process()
             }
           }
 
-          throttle_stamp = ceph_clock_now(msgr->cct);
+          throttle_stamp = ceph_clock_now();
           state = STATE_OPEN_MESSAGE_READ_FRONT;
           break;
         }
@@ -714,7 +714,7 @@ void AsyncConnection::process()
 
           message->set_recv_stamp(recv_stamp);
           message->set_throttle_stamp(throttle_stamp);
-          message->set_recv_complete_stamp(ceph_clock_now(async_msgr->cct));
+          message->set_recv_complete_stamp(ceph_clock_now());
 
           // check received seq#.  if it is old, drop the message.  
           // note that incoming messages may skip ahead.  this is convenient for the client
@@ -2314,7 +2314,7 @@ void AsyncConnection::DelayedDelivery::do_request(int id)
     utime_t release = delay_queue.front().first;
     m = delay_queue.front().second;
     string delay_msg_type = msgr->cct->_conf->ms_inject_delay_msg_type;
-    utime_t now = ceph_clock_now(msgr->cct);
+    utime_t now = ceph_clock_now();
     if ((release > now &&
         (delay_msg_type.empty() || m->get_type_name() == delay_msg_type))) {
       utime_t t = release - now;
@@ -2378,7 +2378,7 @@ void AsyncConnection::_append_keepalive_or_ack(bool ack, utime_t *tp)
     outcoming_bl.append((char*)&ts, sizeof(ts));
   } else if (has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
     struct ceph_timespec ts;
-    utime_t t = ceph_clock_now(async_msgr->cct);
+    utime_t t = ceph_clock_now();
     t.encode_timeval(&ts);
     outcoming_bl.append(CEPH_MSGR_TAG_KEEPALIVE2);
     outcoming_bl.append((char*)&ts, sizeof(ts));

--- a/src/msg/async/dpdk/IP.cc
+++ b/src/msg/async/dpdk/IP.cc
@@ -191,7 +191,7 @@ int ipv4::handle_received_packet(Packet p, ethernet_address from)
     // This is a newly created frag_id
     if (frag.mem_size == 0) {
       _frags_age.push_back(frag_id);
-      frag.rx_time = ceph_clock_now(cct);
+      frag.rx_time = ceph_clock_now();
     }
     auto added_size = frag.merge(h, offset, std::move(p));
     _frag_mem += added_size;
@@ -374,7 +374,7 @@ void ipv4::frag_timeout() {
   if (_frags.empty()) {
     return;
   }
-  auto now = ceph_clock_now(cct);
+  auto now = ceph_clock_now();
   for (auto it = _frags_age.begin(); it != _frags_age.end();) {
     auto frag_id = *it;
     auto& frag = _frags[frag_id];

--- a/src/msg/async/dpdk/IP.h
+++ b/src/msg/async/dpdk/IP.h
@@ -289,7 +289,7 @@ class ipv4 {
     frag_timefd.construct(center->create_time_event(tp.to_nsec() / 1000, frag_handler));
   }
   void frag_arm() {
-    auto now = ceph_clock_now(cct);
+    auto now = ceph_clock_now();
     frag_timefd.construct(center->create_time_event(now.to_nsec() / 1000, frag_handler));
   }
 

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -271,7 +271,7 @@ void *Pipe::DelayedDelivery::entry()
     Message *m = delay_queue.front().second;
     string delay_msg_type = pipe->msgr->cct->_conf->ms_inject_delay_msg_type;
     if (!flush_count &&
-        (release > ceph_clock_now(pipe->msgr->cct) &&
+        (release > ceph_clock_now() &&
          (delay_msg_type.empty() || m->get_type_name() == delay_msg_type))) {
       lgeneric_subdout(pipe->msgr->cct, ms, 10) << *pipe << "DelayedDelivery::entry sleeping on delay_cond until " << release << dendl;
       delay_cond.WaitUntil(delay_lock, release);
@@ -1510,7 +1510,7 @@ void Pipe::fault(bool onread)
     backoff.set_from_double(conf->ms_initial_backoff);
   } else {
     ldout(msgr->cct,10) << "fault waiting " << backoff << dendl;
-    cond.WaitInterval(msgr->cct, pipe_lock, backoff);
+    cond.WaitInterval(pipe_lock, backoff);
     backoff += backoff;
     if (backoff > conf->ms_max_backoff)
       backoff.set_from_double(conf->ms_max_backoff);
@@ -1630,7 +1630,7 @@ void Pipe::reader()
     if (tag == CEPH_MSGR_TAG_KEEPALIVE) {
       ldout(msgr->cct,2) << "reader got KEEPALIVE" << dendl;
       pipe_lock.Lock();
-      connection_state->set_last_keepalive(ceph_clock_now(NULL));
+      connection_state->set_last_keepalive(ceph_clock_now());
       continue;
     }
     if (tag == CEPH_MSGR_TAG_KEEPALIVE2) {
@@ -1647,7 +1647,7 @@ void Pipe::reader()
 	keepalive_ack_stamp = utime_t(t);
 	ldout(msgr->cct,2) << "reader got KEEPALIVE2 " << keepalive_ack_stamp
 			   << dendl;
-	connection_state->set_last_keepalive(ceph_clock_now(NULL));
+	connection_state->set_last_keepalive(ceph_clock_now());
 	cond.Signal();
       }
       continue;
@@ -1835,7 +1835,7 @@ void Pipe::writer()
 	if (connection_state->has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
 	  pipe_lock.Unlock();
 	  rc = write_keepalive2(CEPH_MSGR_TAG_KEEPALIVE2,
-				ceph_clock_now(msgr->cct));
+				ceph_clock_now());
 	} else {
 	  pipe_lock.Unlock();
 	  rc = write_keepalive();
@@ -2038,7 +2038,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
   unsigned data_len, data_off;
   int aborted;
   Message *message;
-  utime_t recv_stamp = ceph_clock_now(msgr->cct);
+  utime_t recv_stamp = ceph_clock_now();
 
   if (policy.throttler_messages) {
     ldout(msgr->cct,10) << "reader wants " << 1 << " message from policy throttler "
@@ -2066,7 +2066,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
     in_q->dispatch_throttler.get(message_size);
   }
 
-  utime_t throttle_stamp = ceph_clock_now(msgr->cct);
+  utime_t throttle_stamp = ceph_clock_now();
 
   // read front
   front_len = header.front_len;
@@ -2202,7 +2202,7 @@ int Pipe::read_message(Message **pm, AuthSessionHandler* auth_handler)
 
   message->set_recv_stamp(recv_stamp);
   message->set_throttle_stamp(throttle_stamp);
-  message->set_recv_complete_stamp(ceph_clock_now(msgr->cct));
+  message->set_recv_complete_stamp(ceph_clock_now());
 
   *pm = message;
   return 0;

--- a/src/msg/xio/XioConnection.cc
+++ b/src/msg/xio/XioConnection.cc
@@ -193,7 +193,7 @@ void XioConnection::send_keepalive_or_ack_internal(bool ack, const utime_t *tp)
     xcmd->get_bl_ref().append(CEPH_MSGR_TAG_KEEPALIVE2_ACK);
     xcmd->get_bl_ref().append((char*)&ts, sizeof(ts));
   } else if (has_feature(CEPH_FEATURE_MSGR_KEEPALIVE2)) {
-    utime_t t = ceph_clock_now(msgr->cct);
+    utime_t t = ceph_clock_now();
     t.encode_timeval(&ts);
     xcmd->get_bl_ref().append(CEPH_MSGR_TAG_KEEPALIVE2);
     xcmd->get_bl_ref().append((char*)&ts, sizeof(ts));
@@ -311,7 +311,7 @@ int XioConnection::handle_data_msg(struct xio_session *session,
   ceph_msg_footer footer;
   buffer::list payload, middle, data;
 
-  const utime_t recv_stamp = ceph_clock_now(msgr->cct);
+  const utime_t recv_stamp = ceph_clock_now();
 
   ldout(msgr->cct,4) << __func__ << " " << "msg_seq.size()="  << msg_seq.size() <<
     dendl;
@@ -452,7 +452,7 @@ int XioConnection::handle_data_msg(struct xio_session *session,
 
     /* update timestamps */
     m->set_recv_stamp(recv_stamp);
-    m->set_recv_complete_stamp(ceph_clock_now(msgr->cct));
+    m->set_recv_complete_stamp(ceph_clock_now());
     m->set_seq(header.seq);
 
     /* MP-SAFE */
@@ -511,7 +511,7 @@ int XioConnection::on_msg(struct xio_session *session,
 
   case CEPH_MSGR_TAG_KEEPALIVE:
     ldout(msgr->cct, 20) << __func__ << " got KEEPALIVE" << dendl;
-    set_last_keepalive(ceph_clock_now(nullptr));
+    set_last_keepalive(ceph_clock_now());
     break;
 
   case CEPH_MSGR_TAG_KEEPALIVE2:
@@ -524,7 +524,7 @@ int XioConnection::on_msg(struct xio_session *session,
       utime_t kp_t = utime_t(*t);
       ldout(msgr->cct, 20) << __func__ << " got KEEPALIVE2 with timestamp" << kp_t << dendl;
       send_keepalive_or_ack(true, &kp_t);
-      set_last_keepalive(ceph_clock_now(nullptr));
+      set_last_keepalive(ceph_clock_now());
     }
 
     break;
@@ -855,7 +855,7 @@ int XioLoopbackConnection::send_message(Message *m)
 
 void XioLoopbackConnection::send_keepalive()
 {
-  utime_t t = ceph_clock_now(nullptr);
+  utime_t t = ceph_clock_now();
   set_last_keepalive(t);
   set_last_keepalive_ack(t);
 }

--- a/src/msg/xio/XioMessenger.cc
+++ b/src/msg/xio/XioMessenger.cc
@@ -52,8 +52,6 @@ static const level_pair LEVELS[] = {
   make_pair("trace", 20)
 };
 
-// maintain our own global context, we can't rely on g_ceph_context
-// for things like librados
 static CephContext *context;
 
 int get_level()

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -15,6 +15,7 @@
 
 static ClassHandler *ch;
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_objclass
 
 void cls_initialize(ClassHandler *h)

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -13,10 +13,9 @@
 #include "auth/Crypto.h"
 #include "common/armor.h"
 
-static ClassHandler *ch;
+static constexpr int dout_subsys = ceph_subsys_objclass;
 
-#define dout_context g_ceph_context
-#define dout_subsys ceph_subsys_objclass
+static ClassHandler *ch;
 
 void cls_initialize(ClassHandler *h)
 {
@@ -643,14 +642,14 @@ int cls_gen_rand_base64(char *dest, int size) /* size should be the required str
 
   ret = cls_gen_random_bytes(buf, sizeof(buf));
   if (ret < 0) {
-    generic_derr << "cannot get random bytes: " << ret << dendl;
+    lgeneric_derr(ch->cct) << "cannot get random bytes: " << ret << dendl;
     return -1;
   }
 
   ret = ceph_armor(tmp_dest, &tmp_dest[sizeof(tmp_dest)],
 		   (const char *)buf, ((const char *)buf) + ((size - 1) * 3 + 4 - 1) / 4);
   if (ret < 0) {
-    generic_derr << "ceph_armor failed" << dendl;
+    lgeneric_derr(ch->cct) << "ceph_armor failed" << dendl;
     return -1;
   }
   tmp_dest[ret] = '\0';
@@ -711,7 +710,7 @@ int cls_log(int level, const char *format, ...)
      va_end(ap);
 #define MAX_SIZE 8196
      if ((n > -1 && n < size) || size > MAX_SIZE) {
-       dout(level) << buf << dendl;
+       ldout(ch->cct, level) << buf << dendl;
        return n;
      }
      size *= 2;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -117,6 +117,7 @@ typedef int (*cls_method_cxx_call_t)(cls_method_context_t ctx,
 				     class buffer::list *inbl, class buffer::list *outbl);
 
 class PGLSFilter {
+  CephContext* cct;
 protected:
   string xattr;
 public:

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -20,6 +20,7 @@
 #include <sys/mount.h>
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_fuse
 #include "common/debug.h"
 #undef dout_prefix

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -20,7 +20,7 @@
 #include <sys/mount.h>
 #endif
 
-#define dout_context g_ceph_context
+#define dout_context store->cct
 #define dout_subsys ceph_subsys_fuse
 #include "common/debug.h"
 #undef dout_prefix
@@ -106,7 +106,8 @@ enum {
   FN_HASH_VAL,
 };
 
-static int parse_fn(const char *path, coll_t *cid, ghobject_t *oid, string *key,
+static int parse_fn(CephContext* cct, const char *path, coll_t *cid,
+		    ghobject_t *oid, string *key,
 		    uint32_t *hash, uint32_t *hash_bits)
 {
   list<string> v;
@@ -121,7 +122,7 @@ static int parse_fn(const char *path, coll_t *cid, ghobject_t *oid, string *key,
     if (!*p)
       break;
   }
-  dout(10) << __func__ << " path " << path << " -> " << v << dendl;
+  ldout(cct, 10) << __func__ << " path " << path << " -> " << v << dendl;
 
   if (v.empty())
     return FN_ROOT;
@@ -229,17 +230,18 @@ static int parse_fn(const char *path, coll_t *cid, ghobject_t *oid, string *key,
 
 static int os_getattr(const char *path, struct stat *stbuf)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int t = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int t = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (t < 0)
     return t;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   stbuf->st_size = 0;
@@ -380,17 +382,19 @@ static int os_readdir(const char *path,
 		      off_t offset,
 		      struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << " offset " << offset << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << " offset " << offset
+		     << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int t = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int t = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (t < 0)
     return t;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   // we can't shift 32 bits or else off_t will go negative
@@ -461,13 +465,13 @@ static int os_readdir(const char *path,
       } else {
 	last = ghobject_t::get_max();
       }
-      dout(10) << __func__ << std::hex
-	       << " offset " << offset << " hash "
-	       << hobject_t::_reverse_bits(hash_value)
-	       << std::dec
-	       << "/" << hash_bits
-	       << " first " << next << " last " << last
-	       << dendl;
+      ldout(fs->store->cct, 10) << __func__ << std::hex
+			 << " offset " << offset << " hash "
+			 << hobject_t::_reverse_bits(hash_value)
+			 << std::dec
+			 << "/" << hash_bits
+			 << " first " << next << " last " << last
+			 << dendl;
       while (true) {
 	vector<ghobject_t> ls;
 	int r = fs->store->collection_list(
@@ -541,17 +545,18 @@ static int os_readdir(const char *path,
 
 static int os_open(const char *path, struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int t = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int t = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (t < 0)
     return t;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   bufferlist *pbl = 0;
@@ -695,17 +700,18 @@ static int os_open(const char *path, struct fuse_file_info *fi)
 
 static int os_mkdir(const char *path, mode_t mode)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int f = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int f = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (f < 0)
     return f;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   ObjectStore::Transaction t;
@@ -755,23 +761,26 @@ static int os_mkdir(const char *path, mode_t mode)
 
 static int os_chmod(const char *path, mode_t mode)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   return 0;
 }
 
 static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int f = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int f = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (f < 0)
     return f;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   ObjectStore::Transaction t;
@@ -835,13 +844,13 @@ static int os_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 
 static int os_release(const char *path, struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << dendl;
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   std::lock_guard<std::mutex> l(fs->lock);
   FuseStore::OpenFile *o = reinterpret_cast<FuseStore::OpenFile*>(fi->fh);
   if (--o->ref == 0) {
-    dout(10) << __func__ << " closing last " << o->path << dendl;
+    ldout(fs->store->cct, 10) << __func__ << " closing last " << o->path << dendl;
     fs->open_files.erase(o->path);
     delete o;
   }
@@ -851,10 +860,10 @@ static int os_release(const char *path, struct fuse_file_info *fi)
 static int os_read(const char *path, char *buf, size_t size, off_t offset,
 		   struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << " offset " << offset
-	   << " size " << size << dendl;
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << " offset " << offset
+		     << " size " << size << dendl;
   std::lock_guard<std::mutex> l(fs->lock);
   FuseStore::OpenFile *o = reinterpret_cast<FuseStore::OpenFile*>(fi->fh);
   if (!o)
@@ -872,10 +881,10 @@ static int os_read(const char *path, char *buf, size_t size, off_t offset,
 static int os_write(const char *path, const char *buf, size_t size,
 		    off_t offset, struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << " offset " << offset
-	   << " size " << size << dendl;
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << " offset " << offset
+		     << " size " << size << dendl;
   std::lock_guard<std::mutex> l(fs->lock);
   FuseStore::OpenFile *o = reinterpret_cast<FuseStore::OpenFile*>(fi->fh);
   if (!o)
@@ -904,17 +913,18 @@ static int os_write(const char *path, const char *buf, size_t size,
 
 int os_flush(const char *path, struct fuse_file_info *fi)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int f = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int f = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (f < 0)
     return f;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   FuseStore::OpenFile *o = reinterpret_cast<FuseStore::OpenFile*>(fi->fh);
@@ -962,17 +972,18 @@ int os_flush(const char *path, struct fuse_file_info *fi)
 
 static int os_unlink(const char *path)
 {
-  dout(10) << __func__ << " " << path << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int f = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int f = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (f < 0)
     return f;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   ObjectStore::Transaction t;
@@ -1033,12 +1044,15 @@ static int os_unlink(const char *path)
 
 static int os_truncate(const char *path, off_t size)
 {
-  dout(10) << __func__ << " " << path << " size " << size << dendl;
+  fuse_context *fc = fuse_get_context();
+  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << " size " << size << dendl;
   coll_t cid;
   ghobject_t oid;
   string key;
   uint32_t hash_value, hash_bits;
-  int f = parse_fn(path, &cid, &oid, &key, &hash_value, &hash_bits);
+  int f = parse_fn(fs->store->cct, path, &cid, &oid, &key, &hash_value,
+		   &hash_bits);
   if (f < 0)
     return f;
 
@@ -1052,8 +1066,6 @@ static int os_truncate(const char *path, off_t size)
   if (f != FN_OBJECT_DATA)
     return -EPERM;
 
-  fuse_context *fc = fuse_get_context();
-  FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
   std::lock_guard<std::mutex> l(fs->lock);
 
   if (fs->open_files.count(path)) {
@@ -1078,9 +1090,9 @@ static int os_truncate(const char *path, off_t size)
 
 static int os_statfs(const char *path, struct statvfs *stbuf)
 {
-  dout(10) << __func__ << " " << path << dendl;
   fuse_context *fc = fuse_get_context();
   FuseStore *fs = static_cast<FuseStore*>(fc->private_data);
+  ldout(fs->store->cct, 10) << __func__ << " " << path << dendl;
   std::lock_guard<std::mutex> l(fs->lock);
 
   struct store_statfs_t s;
@@ -1139,7 +1151,7 @@ int FuseStore::main()
     "-d", // debug
   };
   int c = 3;
-  if (g_conf->fuse_debug)
+  if (store->cct->_conf->fuse_debug)
     ++c;
   return fuse_main(c, (char**)v, &fs_oper, (void*)this);
 }
@@ -1156,7 +1168,7 @@ int FuseStore::start()
     "-d", // debug
   };
   int c = 3;
-  if (g_conf->fuse_debug)
+  if (store->cct->_conf->fuse_debug)
     ++c;
   fuse_args a = FUSE_ARGS_INIT(c, (char**)v);
   info->args = a;

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -30,6 +30,7 @@ class SequencerPosition;
  */
 class ObjectMap {
 public:
+  CephContext* cct;
   /// Set keys and values from specified map
   virtual int set_keys(
     const ghobject_t &oid,              ///< [in] object containing map
@@ -146,6 +147,7 @@ public:
   }
 
 
+  ObjectMap(CephContext* cct) : cct(cct) {}
   virtual ~ObjectMap() {}
 };
 

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -67,7 +67,7 @@ ObjectStore *ObjectStore::create(CephContext *cct,
 			         osflagbits_t flags)
 {
   if (type == "filestore") {
-    return new FileStore(data, journal, flags);
+    return new FileStore(cct, data, journal, flags);
   }
   if (type == "memstore") {
     return new MemStore(cct, data);

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -104,7 +104,7 @@ int ObjectStore::probe_block_device_fsid(
 #endif
 
   // okay, try FileStore (journal).
-  r = FileStore::get_block_device_fsid(path, fsid);
+  r = FileStore::get_block_device_fsid(cct, path, fsid);
   if (r == 0) {
     lgeneric_dout(cct, 0) << __func__ << " " << path << " is filestore, "
 			  << *fsid << dendl;

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -95,7 +95,7 @@ int ObjectStore::probe_block_device_fsid(
 #if defined(HAVE_LIBAIO)
   // first try bluestore -- it has a crc on its header and will fail
   // reliably.
-  r = BlueStore::get_block_device_fsid(path, fsid);
+  r = BlueStore::get_block_device_fsid(cct, path, fsid);
   if (r == 0) {
     lgeneric_dout(cct, 0) << __func__ << " " << path << " is bluestore, "
 			  << *fsid << dendl;

--- a/src/os/ObjectStore.cc
+++ b/src/os/ObjectStore.cc
@@ -64,7 +64,7 @@ ObjectStore *ObjectStore::create(CephContext *cct,
 				 const string& type,
 				 const string& data,
 				 const string& journal,
-			         osflagbits_t flags)
+				 osflagbits_t flags)
 {
   if (type == "filestore") {
     return new FileStore(cct, data, journal, flags);

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -70,6 +70,7 @@ protected:
   string path;
 
 public:
+  CephContext* cct;
   /**
    * create - create an ObjectStore instance.
    *
@@ -126,6 +127,7 @@ public:
    * created in ...::queue_transaction(s)
    */
   struct Sequencer_impl : public RefCountedObject {
+    CephContext* cct;
     virtual void flush() = 0;
 
     /**
@@ -143,7 +145,7 @@ public:
       Context *c ///< [in] context to call upon flush/commit
       ) = 0; ///< @return true if idle, false otherwise
 
-    Sequencer_impl() : RefCountedObject(NULL, 0) {}
+    Sequencer_impl(CephContext* cct) : RefCountedObject(NULL, 0), cct(cct)  {}
     virtual ~Sequencer_impl() {}
   };
   typedef boost::intrusive_ptr<Sequencer_impl> Sequencer_implRef;
@@ -1484,12 +1486,14 @@ public:
   }
 
  public:
-  explicit ObjectStore(const std::string& path_) : path(path_), logger(NULL) {}
+  ObjectStore(CephContext* cct,
+	      const std::string& path_) : path(path_), cct(cct),
+					  logger(nullptr) {}
   virtual ~ObjectStore() {}
 
   // no copying
-  explicit ObjectStore(const ObjectStore& o);
-  const ObjectStore& operator=(const ObjectStore& o);
+  explicit ObjectStore(const ObjectStore& o) = delete;
+  const ObjectStore& operator=(const ObjectStore& o) = delete;
 
   // versioning
   virtual int upgrade() {

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -6,6 +6,7 @@
 #include "BitMapAllocator.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 
 Allocator *Allocator::create(string type,

--- a/src/os/bluestore/Allocator.cc
+++ b/src/os/bluestore/Allocator.cc
@@ -6,17 +6,17 @@
 #include "BitMapAllocator.h"
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 
-Allocator *Allocator::create(string type,
+Allocator *Allocator::create(CephContext* cct, string type,
                              int64_t size, int64_t block_size)
 {
   if (type == "stupid") {
-    return new StupidAllocator;
+    return new StupidAllocator(cct);
   } else if (type == "bitmap") {
-    return new BitMapAllocator(size, block_size);
+    return new BitMapAllocator(cct, size, block_size);
   }
-  derr << "Allocator::" << __func__ << " unknown alloc type " << type << dendl;
-  return NULL;
+  lderr(cct) << "Allocator::" << __func__ << " unknown alloc type "
+	     << type << dendl;
+  return nullptr;
 }

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -66,7 +66,8 @@ public:
   virtual uint64_t get_free() = 0;
 
   virtual void shutdown() = 0;
-  static Allocator *create(string type, int64_t size, int64_t block_size);
+  static Allocator *create(CephContext* cct, string type, int64_t size,
+			   int64_t block_size);
 };
 
 #endif

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -25,6 +25,7 @@
 #include "common/debug.h"
 #include <math.h>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "bitalloc:"

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -25,7 +25,7 @@
 #include "common/debug.h"
 #include <math.h>
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "bitalloc:"
@@ -113,7 +113,6 @@ void BmapEntityListIter::decr_idx()
 /*
  * Bitmap Entry functions.
  */
-
 void BmapEntry::_init_bit_mask()
 {
 
@@ -125,12 +124,13 @@ void BmapEntry::_init_bit_mask()
 
   uint64_t bmask = ((bmap_t) 0x1 << (BmapEntry::size() - 1));
   for (int i = 0; i < BmapEntry::size(); i++) {
-    m_bit_to_mask[i] = bmask >> i; 
+    m_bit_to_mask[i] = bmask >> i;
   }
   BmapEntry::m_bit_mask_init = true;
 }
 
-BmapEntry::BmapEntry(bool full)
+BmapEntry::BmapEntry(CephContext* cct, bool full)
+  : cct(cct)
 {
 
   BmapEntry::_init_bit_mask();
@@ -394,7 +394,7 @@ void BitMapZone::init(int64_t zone_num, int64_t total_blocks, bool def)
   alloc_assert(total_blocks < std::numeric_limits<int32_t>::max());
   alloc_assert(!(total_blocks % BmapEntry::size()));
 
-  BmapEntryVector *bmaps = new BmapEntryVector(num_bmaps, BmapEntry(def));
+  BmapEntryVector *bmaps = new BmapEntryVector(num_bmaps, BmapEntry(cct, def));
   m_bmap_list = bmaps;
   incr_count();
 }
@@ -431,12 +431,16 @@ int64_t BitMapZone::get_reserved_blocks()
   return 0;
 }
 
-BitMapZone::BitMapZone(int64_t total_blocks, int64_t zone_num)
+BitMapZone::BitMapZone(CephContext* cct, int64_t total_blocks,
+		       int64_t zone_num)
+  : BitMapArea(cct)
 {
   init(zone_num, total_blocks, false);
 }
 
-BitMapZone::BitMapZone(int64_t total_blocks, int64_t zone_num, bool def)
+BitMapZone::BitMapZone(CephContext* cct, int64_t total_blocks,
+		       int64_t zone_num, bool def)
+  : BitMapArea(cct)
 {
   init(zone_num, total_blocks, def);
 }
@@ -670,14 +674,14 @@ void BitMapZone::dump_state(int& count)
 /*
  * BitMapArea Leaf and non-Leaf functions.
  */
-int64_t BitMapArea::get_zone_size()
+int64_t BitMapArea::get_zone_size(CephContext* cct)
 {
-  return g_conf->bluestore_bitmapallocator_blocks_per_zone;
+  return cct->_conf->bluestore_bitmapallocator_blocks_per_zone;
 }
 
-int64_t BitMapArea::get_span_size()
+int64_t BitMapArea::get_span_size(CephContext* cct)
 {
-  return g_conf->bluestore_bitmapallocator_span_size;
+  return cct->_conf->bluestore_bitmapallocator_span_size;
 }
 
 bmap_area_type_t BitMapArea::level_to_type(int level)
@@ -691,11 +695,11 @@ bmap_area_type_t BitMapArea::level_to_type(int level)
   }
 }
 
-int BitMapArea::get_level(int64_t total_blocks)
+int BitMapArea::get_level(CephContext* cct, int64_t total_blocks)
 {
   int level = 1;
-  int64_t zone_size_block = get_zone_size();
-  int64_t span_size = get_span_size();
+  int64_t zone_size_block = get_zone_size(cct);
+  int64_t span_size = get_span_size(cct);
   int64_t spans = zone_size_block * span_size;
   while (spans < total_blocks) {
     spans *= span_size;
@@ -704,17 +708,17 @@ int BitMapArea::get_level(int64_t total_blocks)
   return level;
 }
 
-int64_t BitMapArea::get_level_factor(int level)
+int64_t BitMapArea::get_level_factor(CephContext* cct, int level)
 {
   alloc_assert(level > 0);
 
-  int64_t zone_size = get_zone_size();
+  int64_t zone_size = get_zone_size(cct);
   if (level == 1) {
     return zone_size;
   }
 
   int64_t level_factor = zone_size;
-  int64_t span_size = get_span_size();
+  int64_t span_size = get_span_size(cct);
   while (--level) {
     level_factor *= span_size;
   }
@@ -735,7 +739,8 @@ bmap_area_type_t BitMapArea::get_type()
 /*
  * BitMapArea Leaf and Internal
  */
-BitMapAreaIN::BitMapAreaIN()
+BitMapAreaIN::BitMapAreaIN(CephContext* cct)
+  : BitMapArea(cct)
 {
   // nothing
 }
@@ -744,7 +749,7 @@ void BitMapAreaIN::init_common(int64_t total_blocks, int64_t area_idx, bool def)
 {
   m_area_index = area_idx;
   m_total_blocks = total_blocks;
-  m_level = BitMapArea::get_level(total_blocks);
+  m_level = BitMapArea::get_level(cct, total_blocks);
   m_type = BitMapArea::level_to_type(m_level);
   m_reserved_blocks = 0;
 
@@ -757,7 +762,7 @@ void BitMapAreaIN::init(int64_t total_blocks, int64_t area_idx, bool def)
   alloc_assert(!(total_blocks % BmapEntry::size()));
 
   init_common(total_blocks, area_idx, def);
-  int64_t level_factor = BitMapArea::get_level_factor(m_level);
+  int64_t level_factor = BitMapArea::get_level_factor(cct, m_level);
 
   num_child = (total_blocks + level_factor - 1) / level_factor;
   alloc_assert(num_child < std::numeric_limits<int16_t>::max());
@@ -768,30 +773,34 @@ void BitMapAreaIN::init(int64_t total_blocks, int64_t area_idx, bool def)
   int i = 0;
   for (i = 0; i < num_child - 1; i++) {
     if (m_level <= 2) {
-      children[i] = new BitMapAreaLeaf(m_child_size_blocks, i, def);
+      children[i] = new BitMapAreaLeaf(cct, m_child_size_blocks, i, def);
     } else {
-      children[i] = new BitMapAreaIN(m_child_size_blocks, i, def);
+      children[i] = new BitMapAreaIN(cct, m_child_size_blocks, i, def);
     }
     total_blocks -= m_child_size_blocks;
   }
 
-  int last_level = BitMapArea::get_level(total_blocks);
+  int last_level = BitMapArea::get_level(cct, total_blocks);
   if (last_level == 1) {
-    children[i] = new BitMapAreaLeaf(total_blocks, i, def);
+    children[i] = new BitMapAreaLeaf(cct, total_blocks, i, def);
   } else {
-    children[i] = new BitMapAreaIN(total_blocks, i, def);
+    children[i] = new BitMapAreaIN(cct, total_blocks, i, def);
   }
   BitMapAreaList *list = new BitMapAreaList(children, num_child);
   m_child_list = list;
   m_num_child = num_child;
 }
 
-BitMapAreaIN::BitMapAreaIN(int64_t total_blocks, int64_t area_idx)
+BitMapAreaIN::BitMapAreaIN(CephContext* cct,int64_t total_blocks,
+			   int64_t area_idx)
+  : BitMapArea(cct)
 {
   init(total_blocks, area_idx, false);
 }
 
-BitMapAreaIN::BitMapAreaIN(int64_t total_blocks, int64_t area_idx, bool def)
+BitMapAreaIN::BitMapAreaIN(CephContext* cct, int64_t total_blocks,
+			   int64_t area_idx, bool def)
+  : BitMapArea(cct)
 {
   init(total_blocks, area_idx, def);
 }
@@ -1052,25 +1061,29 @@ void BitMapAreaIN::dump_state(int& count)
 /*
  * BitMapArea Leaf
  */
-BitMapAreaLeaf::BitMapAreaLeaf(int64_t total_blocks, int64_t area_idx)
+BitMapAreaLeaf::BitMapAreaLeaf(CephContext* cct, int64_t total_blocks,
+			       int64_t area_idx)
+  : BitMapAreaIN(cct)
 {
   init(total_blocks, area_idx, false);
 }
 
-BitMapAreaLeaf::BitMapAreaLeaf(int64_t total_blocks, int64_t area_idx, bool def)
+BitMapAreaLeaf::BitMapAreaLeaf(CephContext* cct, int64_t total_blocks,
+			       int64_t area_idx, bool def)
+  : BitMapAreaIN(cct)
 {
   init(total_blocks, area_idx, def);
 }
 
 void BitMapAreaLeaf::init(int64_t total_blocks, int64_t area_idx,
-          bool def)
+			  bool def)
 {
   int64_t num_child = 0;
   alloc_assert(!(total_blocks % BmapEntry::size()));
 
   init_common(total_blocks, area_idx, def);
   alloc_assert(m_level == 1);
-  int zone_size_block = get_zone_size();
+  int zone_size_block = get_zone_size(cct);
   alloc_assert(zone_size_block > 0);
   num_child = (total_blocks + zone_size_block - 1) / zone_size_block;
   alloc_assert(num_child);
@@ -1079,7 +1092,7 @@ void BitMapAreaLeaf::init(int64_t total_blocks, int64_t area_idx,
   alloc_assert(m_level == 1);
   BitMapArea **children = new BitMapArea*[num_child];
   for (int i = 0; i < num_child; i++) {
-      children[i] = new BitMapZone(m_child_size_blocks, i, def);
+    children[i] = new BitMapZone(cct, m_child_size_blocks, i, def);
   }
 
   BitMapAreaList *list = new BitMapAreaList(children, num_child);
@@ -1197,19 +1210,25 @@ BitMapAreaList::BitMapAreaList(BitMapArea **list, int64_t len)
 /*
  * Main allocator functions.
  */
-BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block, bmap_alloc_mode_t mode)
+BitAllocator::BitAllocator(CephContext* cct, int64_t total_blocks,
+			   int64_t zone_size_block, bmap_alloc_mode_t mode)
+  : BitMapAreaIN(cct)
 {
   init_check(total_blocks, zone_size_block, mode, false, false);
 }
 
-BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block,
-         bmap_alloc_mode_t mode, bool def)
+BitAllocator::BitAllocator(CephContext* cct, int64_t total_blocks,
+			   int64_t zone_size_block, bmap_alloc_mode_t mode,
+			   bool def)
+  : BitMapAreaIN(cct)
 {
   init_check(total_blocks, zone_size_block, mode, def, false);
 }
 
-BitAllocator::BitAllocator(int64_t total_blocks, int64_t zone_size_block,
-         bmap_alloc_mode_t mode, bool def, bool stats_on)
+BitAllocator::BitAllocator(CephContext* cct, int64_t total_blocks,
+			   int64_t zone_size_block, bmap_alloc_mode_t mode,
+			   bool def, bool stats_on)
+  : BitMapAreaIN(cct)
 {
   init_check(total_blocks, zone_size_block, mode, def, stats_on);
 }
@@ -1350,7 +1369,7 @@ bool BitAllocator::check_input(int64_t num_blocks)
     return false;
   }
 
-  if (num_blocks > get_zone_size()) {
+  if (num_blocks > get_zone_size(cct)) {
     return false;
   }
   return true;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -12,6 +12,7 @@
 #include "bluestore_types.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "bitmapalloc:"

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -12,13 +12,15 @@
 #include "bluestore_types.h"
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "bitmapalloc:"
 
 
-BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
+BitMapAllocator::BitMapAllocator(CephContext* cct, int64_t device_size,
+				 int64_t block_size)
+  : cct(cct)
 {
   assert(ISP2(block_size));
   if (!ISP2(block_size)) {
@@ -28,7 +30,7 @@ BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
     return;
   }
 
-  int64_t zone_size_blks = g_conf->bluestore_bitmapallocator_blocks_per_zone;
+  int64_t zone_size_blks = cct->_conf->bluestore_bitmapallocator_blocks_per_zone;
   assert(ISP2(zone_size_blks));
   if (!ISP2(zone_size_blks)) {
     derr << __func__ << " zone_size " << zone_size_blks
@@ -37,7 +39,7 @@ BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
     return;
   }
 
-  int64_t span_size = g_conf->bluestore_bitmapallocator_span_size;
+  int64_t span_size = cct->_conf->bluestore_bitmapallocator_span_size;
   assert(ISP2(span_size));
   if (!ISP2(span_size)) {
     derr << __func__ << " span_size " << span_size
@@ -47,8 +49,8 @@ BitMapAllocator::BitMapAllocator(int64_t device_size, int64_t block_size)
   }
 
   m_block_size = block_size;
-  m_bit_alloc = new BitAllocator(device_size / block_size,
-        zone_size_blks, CONCURRENT, true);
+  m_bit_alloc = new BitAllocator(cct, device_size / block_size,
+				 zone_size_blks, CONCURRENT, true);
   assert(m_bit_alloc);
   if (!m_bit_alloc) {
     derr << __func__ << " Unable to intialize Bit Allocator" << dendl;

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -11,6 +11,7 @@
 #include "include/btree_interval_set.h"
 
 class BitMapAllocator : public Allocator {
+  CephContext* cct;
   std::mutex m_lock;
 
   int64_t m_block_size;
@@ -24,8 +25,7 @@ class BitMapAllocator : public Allocator {
                         int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len);
 
 public:
-  BitMapAllocator();
-  BitMapAllocator(int64_t device_size, int64_t block_size);
+  BitMapAllocator(CephContext* cct, int64_t device_size, int64_t block_size);
   ~BitMapAllocator();
 
   int reserve(uint64_t need);

--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -7,6 +7,7 @@
 
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "

--- a/src/os/bluestore/BitmapFreelistManager.h
+++ b/src/os/bluestore/BitmapFreelistManager.h
@@ -46,7 +46,7 @@ class BitmapFreelistManager : public FreelistManager {
     KeyValueDB::Transaction txn);
 
 public:
-  BitmapFreelistManager(KeyValueDB *db, string meta_prefix,
+  BitmapFreelistManager(CephContext* cct, KeyValueDB *db, string meta_prefix,
 			string bitmap_prefix);
 
   static void setup_merge_operator(KeyValueDB *db, string prefix);

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -24,6 +24,7 @@
 
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev "

--- a/src/os/bluestore/BlockDevice.cc
+++ b/src/os/bluestore/BlockDevice.cc
@@ -24,7 +24,7 @@
 
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev "
@@ -44,7 +44,8 @@ void IOContext::aio_wait()
   dout(20) << __func__ << " " << this << " done" << dendl;
 }
 
-BlockDevice *BlockDevice::create(const string& path, aio_callback_t cb, void *cbpriv)
+BlockDevice *BlockDevice::create(CephContext* cct, const string& path,
+				 aio_callback_t cb, void *cbpriv)
 {
   string type = "kernel";
   char buf[PATH_MAX + 1];
@@ -58,11 +59,11 @@ BlockDevice *BlockDevice::create(const string& path, aio_callback_t cb, void *cb
   dout(1) << __func__ << " path " << path << " type " << type << dendl;
 
   if (type == "kernel") {
-    return new KernelDevice(cb, cbpriv);
+    return new KernelDevice(cct, cb, cbpriv);
   }
 #if defined(HAVE_SPDK)
   if (type == "ust-nvme") {
-    return new NVMEDevice(cb, cbpriv);
+    return new NVMEDevice(cct, cb, cbpriv);
   }
 #endif
 

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -28,6 +28,7 @@
 
 /// track in-flight io
 struct IOContext {
+  CephContext* cct;
   void *priv;
 #ifdef HAVE_SPDK
   void *nvme_task_first = nullptr;
@@ -44,13 +45,13 @@ struct IOContext {
   std::atomic_int num_reading = {0};
   std::atomic_int num_waiting = {0};
 
-  explicit IOContext(void *p)
-    : priv(p)
+  explicit IOContext(CephContext* cct, void *p)
+    : cct(cct), priv(p)
     {}
 
   // no copying
-  IOContext(const IOContext& other);
-  IOContext &operator=(const IOContext& other);
+  IOContext(const IOContext& other) = delete;
+  IOContext &operator=(const IOContext& other) = delete;
 
   bool has_pending_aios() {
     return num_pending.load();
@@ -68,6 +69,9 @@ struct IOContext {
 
 
 class BlockDevice {
+public:
+  CephContext* cct;
+private:
   std::mutex ioc_reap_lock;
   vector<IOContext*> ioc_reap_queue;
   std::atomic_int ioc_reap_count = {0};
@@ -76,12 +80,12 @@ protected:
   bool rotational = true;
 
 public:
-  BlockDevice() = default;
+  BlockDevice(CephContext* cct) : cct(cct) {}
   virtual ~BlockDevice() = default;
   typedef void (*aio_callback_t)(void *handle, void *aio);
 
   static BlockDevice *create(
-      const string& path, aio_callback_t cb, void *cbpriv);
+    CephContext* cct, const string& path, aio_callback_t cb, void *cbpriv);
   virtual bool supported_bdev_label() { return true; }
   virtual bool is_rotational() { return rotational; }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -9,6 +9,7 @@
 #include "BlockDevice.h"
 #include "Allocator.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluefs
 #undef dout_prefix
 #define dout_prefix *_dout << "bluefs "

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1476,7 +1476,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     }
   }
   if (must_dirty) {
-    h->file->fnode.mtime = ceph_clock_now(NULL);
+    h->file->fnode.mtime = ceph_clock_now();
     assert(h->file->fnode.ino >= 1);
     if (h->file->dirty_seq == 0) {
       h->file->dirty_seq = log_seq + 1;
@@ -1619,13 +1619,13 @@ void BlueFS::wait_for_aio(FileWriter *h)
   // NOTE: this is safe to call without a lock, as long as our reference is
   // stable.
   dout(10) << __func__ << " " << h << dendl;
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   for (auto p : h->iocv) {
     if (p) {
       p->aio_wait();
     }
   }
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   dout(10) << __func__ << " " << h << " done in " << dur << dendl;
 }
@@ -1824,7 +1824,7 @@ void BlueFS::sync_metadata()
     return;
   }
   dout(10) << __func__ << dendl;
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
   _flush_and_sync_log(l);
@@ -1842,7 +1842,7 @@ void BlueFS::sync_metadata()
     }
   }
 
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   dout(10) << __func__ << " done in " << dur << dendl;
 }
@@ -1902,7 +1902,7 @@ int BlueFS::open_for_write(
   }
   assert(file->fnode.ino > 1);
 
-  file->fnode.mtime = ceph_clock_now(NULL);
+  file->fnode.mtime = ceph_clock_now();
   file->fnode.prefer_bdev = BlueFS::BDEV_DB;
   if (dirname.length() > 5) {
     // the "db.slow" and "db.wal" directory names are hard-coded at
@@ -2135,7 +2135,7 @@ int BlueFS::lock_file(const string& dirname, const string& filename,
 	     << " not found, creating" << dendl;
     file = new File;
     file->fnode.ino = ++ino_last;
-    file->fnode.mtime = ceph_clock_now(NULL);
+    file->fnode.mtime = ceph_clock_now();
     file_map[ino_last] = file;
     dir->file_map[filename] = file;
     ++file->refs;

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -40,6 +40,7 @@ enum {
 
 class BlueFS {
 public:
+  CephContext* cct;
   static constexpr unsigned MAX_BDEV = 3;
   static constexpr unsigned BDEV_WAL = 0;
   static constexpr unsigned BDEV_DB = 1;
@@ -322,7 +323,7 @@ private:
   }
 
 public:
-  BlueFS();
+  BlueFS(CephContext* cct);
   ~BlueFS();
 
   // the super is always stored on bdev 0

--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -133,7 +133,7 @@ class BlueRocksRandomAccessFile : public rocksdb::RandomAccessFile {
     if (pattern == RANDOM)
       h->buf.max_prefetch = 4096;
     else if (pattern == SEQUENTIAL)
-      h->buf.max_prefetch = g_conf->bluefs_max_prefetch;
+      h->buf.max_prefetch = fs->cct->_conf->bluefs_max_prefetch;
   }
 
   // Remove any kind of caching of data from the offset to offset+length

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -31,6 +31,7 @@
 #include "BlueRocksEnv.h"
 #include "auth/Crypto.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 
 // bluestore_meta_onode

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2534,7 +2534,7 @@ void *BlueStore::MempoolThread::entry()
     ++store->mempool_seq;
     utime_t wait;
     wait += g_conf->bluestore_cache_trim_interval;
-    cond.WaitInterval(g_ceph_context, lock, wait);
+    cond.WaitInterval(lock, wait);
   }
   stop = false;
   return NULL;
@@ -2944,7 +2944,7 @@ int BlueStore::_check_or_set_bdev_label(
   if (create) {
     label.osd_uuid = fsid;
     label.size = size;
-    label.btime = ceph_clock_now(NULL);
+    label.btime = ceph_clock_now();
     label.description = desc;
     int r = _write_bdev_label(path, label);
     if (r < 0)
@@ -4268,7 +4268,7 @@ int BlueStore::fsck(bool deep)
   uint64_t num_sharded_objects = 0;
   uint64_t num_object_shards = 0;
 
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
 
   int r = _open_path();
   if (r < 0)
@@ -4721,7 +4721,7 @@ int BlueStore::fsck(bool deep)
 	  << num_shared_blobs << " shared."
 	  << dendl;
 
-  utime_t duration = ceph_clock_now(NULL) - start;
+  utime_t duration = ceph_clock_now() - start;
   dout(1) << __func__ << " finish with " << errors << " errors in "
 	  << duration << " seconds" << dendl;
   return errors;
@@ -5265,7 +5265,7 @@ int BlueStore::_verify_csum(OnodeRef& o,
 {
   int bad;
   uint64_t bad_csum;
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   int r = blob->verify_csum(blob_xoffset, bl, &bad, &bad_csum);
   if (r < 0) {
     if (r == -1) {
@@ -5289,14 +5289,14 @@ int BlueStore::_verify_csum(OnodeRef& o,
       derr << __func__ << " failed with exit code: " << cpp_strerror(r) << dendl;
     }
   }
-  logger->tinc(l_bluestore_csum_lat, ceph_clock_now(g_ceph_context) - start);
+  logger->tinc(l_bluestore_csum_lat, ceph_clock_now() - start);
   return r;
 }
 
 int BlueStore::_decompress(bufferlist& source, bufferlist* result)
 {
   int r = 0;
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   bufferlist::iterator i = source.begin();
   bluestore_compression_header_t chdr;
   ::decode(chdr, i);
@@ -5318,7 +5318,7 @@ int BlueStore::_decompress(bufferlist& source, bufferlist* result)
       r = -EIO;
     }
   }
-  logger->tinc(l_bluestore_decompress_lat, ceph_clock_now(g_ceph_context) - start);
+  logger->tinc(l_bluestore_decompress_lat, ceph_clock_now() - start);
   return r;
 }
 
@@ -6520,7 +6520,7 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
   }
   unsigned n = txc->osr->parent->shard_hint.hash_to_shard(m_finisher_num);
   if (txc->oncommit) {
-    logger->tinc(l_bluestore_commit_lat, ceph_clock_now(g_ceph_context) - txc->start);
+    logger->tinc(l_bluestore_commit_lat, ceph_clock_now() - txc->start);
     finishers[n]->queue(txc->oncommit);
     txc->oncommit = NULL;
   }
@@ -6701,7 +6701,7 @@ void BlueStore::_kv_sync_thread()
       kv_committing.swap(kv_queue);
       kv_submitting.swap(kv_queue_unsubmitted);
       wal_cleaning.swap(wal_cleanup_queue);
-      utime_t start = ceph_clock_now(NULL);
+      utime_t start = ceph_clock_now();
       l.unlock();
 
       dout(30) << __func__ << " committing txc " << kv_committing << dendl;
@@ -6794,7 +6794,7 @@ void BlueStore::_kv_sync_thread()
 	dout(10) << __func__ << " blobid_max now " << blobid_max << dendl;
       }
 
-      utime_t finish = ceph_clock_now(NULL);
+      utime_t finish = ceph_clock_now();
       utime_t dur = finish - start;
       dout(20) << __func__ << " committed " << kv_committing.size()
 	       << " cleaned " << wal_cleaning.size()
@@ -7884,7 +7884,7 @@ int BlueStore::_do_alloc_write(
     bool compressed = false;
     if(c && wi.blob_length > min_alloc_size) {
 
-      utime_t start = ceph_clock_now(g_ceph_context);
+      utime_t start = ceph_clock_now();
 
       // compress
       assert(b_off == 0);
@@ -7934,7 +7934,7 @@ int BlueStore::_do_alloc_write(
         logger->inc(l_bluestore_compress_rejected_count);
       }
       logger->tinc(l_bluestore_compress_lat,
-		   ceph_clock_now(g_ceph_context) - start);
+		   ceph_clock_now() - start);
     }
     if (!compressed) {
       dblob.set_flag(bluestore_blob_t::FLAG_MUTABLE);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -31,7 +31,7 @@
 #include "BlueRocksEnv.h"
 #include "auth/Crypto.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 
 // bluestore_meta_onode
@@ -278,7 +278,8 @@ static int get_key_shared_blob(const string& key, uint64_t *sbid)
 
 static int get_key_object(const string& key, ghobject_t *oid);
 
-static void get_object_key(const ghobject_t& oid, string *key)
+static void get_object_key(CephContext* cct, const ghobject_t& oid,
+			   string *key)
 {
   key->clear();
 
@@ -506,14 +507,15 @@ ostream& operator<<(ostream& out, const BlueStore::Buffer& b)
 
 // Cache
 
-BlueStore::Cache *BlueStore::Cache::create(string type, PerfCounters *logger)
+BlueStore::Cache *BlueStore::Cache::create(CephContext* cct, string type,
+					   PerfCounters *logger)
 {
   Cache *c = nullptr;
 
   if (type == "lru")
-    c = new LRUCache;
+    c = new LRUCache(cct);
   else if (type == "2q")
-    c = new TwoQCache;
+    c = new TwoQCache(cct);
   else
     assert(0 == "unrecognized cache type");
 
@@ -787,7 +789,7 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
 
   // buffers
   if (buffer_bytes > buffer_max) {
-    uint64_t kin = buffer_max * g_conf->bluestore_2q_cache_kin_ratio;
+    uint64_t kin = buffer_max * cct->_conf->bluestore_2q_cache_kin_ratio;
     uint64_t khot = buffer_max - kin;
 
     // pre-calculate kout based on average buffer size too,
@@ -798,7 +800,7 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
       uint64_t buffer_avg_size = buffer_bytes / buffer_num;
       assert(buffer_avg_size);
       uint64_t calculated_buffer_num = buffer_max / buffer_avg_size;
-      kout = calculated_buffer_num * g_conf->bluestore_2q_cache_kout_ratio;
+      kout = calculated_buffer_num * cct->_conf->bluestore_2q_cache_kout_ratio;
     }
 
     if (buffer_list_bytes[BUFFER_HOT] < khot) {
@@ -958,7 +960,7 @@ void BlueStore::TwoQCache::_audit(const char *when)
 void BlueStore::BufferSpace::_clear()
 {
   // note: we already hold cache->lock
-  dout(10) << __func__ << dendl;
+  ldout(cache->cct, 10) << __func__ << dendl;
   while (!buffer_map.empty()) {
     _rm_buffer(buffer_map.begin());
   }
@@ -967,7 +969,7 @@ void BlueStore::BufferSpace::_clear()
 int BlueStore::BufferSpace::_discard(uint64_t offset, uint64_t length)
 {
   // note: we already hold cache->lock
-  dout(20) << __func__ << std::hex << " 0x" << offset << "~" << length
+  ldout(cache->cct, 20) << __func__ << std::hex << " 0x" << offset << "~" << length
            << std::dec << dendl;
   int cache_private = 0;
   cache->_audit("discard start");
@@ -1106,7 +1108,7 @@ void BlueStore::BufferSpace::finish_write(uint64_t seq)
     }
 
     Buffer *b = &*i;
-    dout(20) << __func__ << " " << *b << dendl;
+    ldout(cache->cct, 20) << __func__ << " " << *b << dendl;
     assert(b->is_writing());
 
     if (b->flags & Buffer::FLAG_NOCACHE) {
@@ -1135,7 +1137,7 @@ void BlueStore::BufferSpace::split(size_t pos, BlueStore::BufferSpace &r)
       break;
 
     if (p->second->offset < pos) {
-      dout(30) << __func__ << " cut " << *p->second << dendl;
+      ldout(cache->cct, 30) << __func__ << " cut " << *p->second << dendl;
       size_t left = pos - p->second->offset;
       size_t right = p->second->length - left;
       if (p->second->data.length()) {
@@ -1153,7 +1155,7 @@ void BlueStore::BufferSpace::split(size_t pos, BlueStore::BufferSpace &r)
     }
 
     assert(p->second->end() > pos);
-    dout(30) << __func__ << " move " << *p->second << dendl;
+    ldout(cache->cct, 30) << __func__ << " move " << *p->second << dendl;
     if (p->second->data.length()) {
       r._add_buffer(new Buffer(&r, p->second->state, p->second->seq,
                                p->second->offset - pos, p->second->data),
@@ -1183,11 +1185,12 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::add(const ghobject_t& oid, OnodeRef o
   std::lock_guard<std::recursive_mutex> l(cache->lock);
   auto p = onode_map.find(oid);
   if (p != onode_map.end()) {
-    dout(30) << __func__ << " " << oid << " " << o
-	     << " raced, returning existing " << p->second << dendl;
+    ldout(cache->cct, 30) << __func__ << " " << oid << " " << o
+			  << " raced, returning existing " << p->second
+			  << dendl;
     return p->second;
   }
-  dout(30) << __func__ << " " << oid << " " << o << dendl;
+  ldout(cache->cct, 30) << __func__ << " " << oid << " " << o << dendl;
   onode_map[oid] = o;
   cache->_add_onode(o, 1);
   return o;
@@ -1196,14 +1199,15 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::add(const ghobject_t& oid, OnodeRef o
 BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
 {
   std::lock_guard<std::recursive_mutex> l(cache->lock);
-  dout(30) << __func__ << dendl;
+  ldout(cache->cct, 30) << __func__ << dendl;
   ceph::unordered_map<ghobject_t,OnodeRef>::iterator p = onode_map.find(oid);
   if (p == onode_map.end()) {
-    dout(30) << __func__ << " " << oid << " miss" << dendl;
+    ldout(cache->cct, 30) << __func__ << " " << oid << " miss" << dendl;
     cache->logger->inc(l_bluestore_onode_misses);
     return OnodeRef();
   }
-  dout(30) << __func__ << " " << oid << " hit " << p->second << dendl;
+  ldout(cache->cct, 30) << __func__ << " " << oid << " hit " << p->second
+			<< dendl;
   cache->_touch_onode(p->second);
   cache->logger->inc(l_bluestore_onode_hits);
   return p->second;
@@ -1212,7 +1216,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
 void BlueStore::OnodeSpace::clear()
 {
   std::lock_guard<std::recursive_mutex> l(cache->lock);
-  dout(10) << __func__ << dendl;
+  ldout(cache->cct, 10) << __func__ << dendl;
   for (auto &p : onode_map) {
     cache->_rm_onode(p.second);
   }
@@ -1223,7 +1227,7 @@ void BlueStore::OnodeSpace::clear_pre_split(SharedBlobSet& sbset,
 					    uint32_t ps, int bits)
 {
   std::lock_guard<std::recursive_mutex> l(cache->lock);
-  dout(10) << __func__ << dendl;
+  ldout(cache->cct, 10) << __func__ << dendl;
 
   auto p = onode_map.begin();
   while (p != onode_map.end()) {
@@ -1259,7 +1263,8 @@ void BlueStore::OnodeSpace::rename(OnodeRef& oldo,
 				     const string& new_okey)
 {
   std::lock_guard<std::recursive_mutex> l(cache->lock);
-  dout(30) << __func__ << " " << old_oid << " -> " << new_oid << dendl;
+  ldout(cache->cct, 30) << __func__ << " " << old_oid << " -> " << new_oid
+			<< dendl;
   ceph::unordered_map<ghobject_t,OnodeRef>::iterator po, pn;
   po = onode_map.find(old_oid);
   pn = onode_map.find(new_oid);
@@ -1267,7 +1272,8 @@ void BlueStore::OnodeSpace::rename(OnodeRef& oldo,
 
   assert(po != onode_map.end());
   if (pn != onode_map.end()) {
-    dout(30) << __func__ << "  removing target " << pn->second << dendl;
+    ldout(cache->cct, 30) << __func__ << "  removing target " << pn->second
+			  << dendl;
     cache->_rm_onode(pn->second);
     onode_map.erase(pn);
   }
@@ -1288,7 +1294,7 @@ void BlueStore::OnodeSpace::rename(OnodeRef& oldo,
 bool BlueStore::OnodeSpace::map_any(std::function<bool(OnodeRef)> f)
 {
   std::lock_guard<std::recursive_mutex> l(cache->lock);
-  dout(20) << __func__ << dendl;
+  ldout(cache->cct, 20) << __func__ << dendl;
   for (auto& i : onode_map) {
     if (f(i.second)) {
       return true;
@@ -1333,14 +1339,16 @@ BlueStore::SharedBlob::~SharedBlob()
 void BlueStore::SharedBlob::put()
 {
   if (--nref == 0) {
-    dout(20) << __func__ << " " << this
-	     << " removing self from set " << parent_set << dendl;
+    ldout(bc.cache->cct, 20) << __func__ << " " << this
+			       << " removing self from set " << parent_set
+			       << dendl;
     if (parent_set) {
       if (parent_set->remove(this)) {
 	delete this;
       } else {
-	dout(20) << __func__ << " " << this
-		 << " lost race to remove myself from set" << dendl;
+	ldout(bc.cache->cct, 20)
+	  << __func__ << " " << this << " lost race to remove myself from set"
+	  << dendl;
       }
     } else {
       delete this;
@@ -1604,9 +1612,9 @@ ostream& operator<<(ostream& out, const BlueStore::Extent& e)
 #undef dout_prefix
 #define dout_prefix *_dout << "bluestore.extentmap(" << this << ") "
 
-BlueStore::ExtentMap::ExtentMap(Onode *o)
-  : onode(o),
-    inline_bl(g_conf->bluestore_extent_map_inline_shard_prealloc_size) {
+BlueStore::ExtentMap::ExtentMap(CephContext* cct, Onode *o)
+  : cct(cct), onode(o),
+    inline_bl(cct->_conf->bluestore_extent_map_inline_shard_prealloc_size) {
 }
 
 bool BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
@@ -1620,9 +1628,8 @@ bool BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
       bool never_happen = encode_some(0, OBJECT_MAX_SIZE, inline_bl, &n);
       assert(!never_happen);
       size_t len = inline_bl.length();
-      dout(20) << __func__ << " inline shard "
-	       << len << " bytes from " << n << " extents" << dendl;
-      if (!force && len > g_conf->bluestore_extent_map_shard_max_size) {
+      dout(20) << __func__ << " inline shard " << len << " bytes from " << n<< " extents" << dendl;
+      if (!force && len > cct->_conf->bluestore_extent_map_shard_max_size) {
 	return true;
       }
     }
@@ -1667,16 +1674,17 @@ bool BlueStore::ExtentMap::update(KeyValueDB::Transaction t,
 	  return true;
 	}
         size_t len = bl.length();
+
 	dout(20) << __func__ << " shard 0x" << std::hex
 		 << p->offset << std::dec << " is " << len
 		 << " bytes (was " << p->shard_info->bytes << ") from " << nn
 		 << " extents" << dendl;
 
         //indicate need for reshard if force mode selected, len > shard_max size OR
-        //non-last shard size is below the min threshold. The last check is to avoid potential 
+        //non-last shard size is below the min threshold. The last check is to avoid potential
         //unneeded reshardings since this might happen permanently.
         if (!force &&
-             (len > g_conf->bluestore_extent_map_shard_max_size ||
+             (len > cct->_conf->bluestore_extent_map_shard_max_size ||
                (n != shards.end() && len < g_conf->bluestore_extent_map_shard_min_size))) {
           return true;
         }
@@ -1728,11 +1736,12 @@ void BlueStore::ExtentMap::reshard(uint64_t min_alloc_size)
       bytes += s.bytes;
     }
   }
-  unsigned target = g_conf->bluestore_extent_map_shard_target_size;
-  unsigned slop = target * g_conf->bluestore_extent_map_shard_target_size_slop;
+  unsigned target = cct->_conf->bluestore_extent_map_shard_target_size;
+  unsigned slop = target *
+    cct->_conf->bluestore_extent_map_shard_target_size_slop;
   unsigned extent_avg = bytes / extent_map.size();
-  dout(20) << __func__ << " extent_avg " << extent_avg
-	   << " target " << target << " slop " << slop << dendl;
+  dout(20) << __func__ << " extent_avg " << extent_avg << " target " << target
+	   << " slop " << slop << dendl;
 
   // reshard
   unsigned estimate = 0;
@@ -1756,8 +1765,8 @@ void BlueStore::ExtentMap::reshard(uint64_t min_alloc_size)
       offset = e.logical_offset;
       new_shard_info.emplace_back(bluestore_onode_t::shard_info());
       new_shard_info.back().offset = offset;
-      dout(20) << __func__ << "  new shard 0x" << std::hex << offset << std::dec
-	       << dendl;
+      dout(20) << __func__ << "  new shard 0x" << std::hex << offset
+	       << std::dec << dendl;
       estimate = 0;
     }
     estimate += extent_avg;
@@ -1818,9 +1827,8 @@ void BlueStore::ExtentMap::reshard(uint64_t min_alloc_size)
 	      if (b->get_blob().can_split_at(blob_offset) &&
 		  blob_offset % min_alloc_size == 0) {
 		dout(20) << __func__ << "    splitting blob, bstart 0x"
-			 << std::hex << bstart
-			 << " blob_offset 0x" << blob_offset
-			 << std::dec << " " << *b << dendl;
+			 << std::hex << bstart << " blob_offset 0x"
+			 << blob_offset << std::dec << " " << *b << dendl;
 		b = split_blob(b, blob_offset, sh.offset);
 		// switch b to the new right-hand side, in case it
 		// *also* has to get split.
@@ -1983,7 +1991,7 @@ void BlueStore::ExtentMap::decode_some(bufferlist& bl)
 	le->assign_blob(blobs[blobid - 1]);
 	assert(le->blob);
       } else {
-	Blob *b = new Blob();
+	Blob *b = new Blob(cct);
         uint64_t sbid = 0;
 	b->decode(p, struct_v, &sbid, false);
 	blobs[n] = b;
@@ -2036,7 +2044,7 @@ void BlueStore::ExtentMap::decode_spanning_blobs(
   unsigned n;
   denc_varint(n, p);
   while (n--) {
-    BlobRef b(new Blob());
+    BlobRef b(new Blob(c->store->cct));
     denc_varint(b->id, p);
     spanning_blob_map[b->id] = b;
     uint64_t sbid = 0;
@@ -2125,7 +2133,7 @@ void BlueStore::ExtentMap::dirty_range(
     auto p = &shards[start];
     if (!p->loaded) {
       dout(20) << __func__ << " shard 0x" << std::hex << p->offset << std::dec
-               << " is not loaded, can't mark dirty" << dendl;
+	       << " is not loaded, can't mark dirty" << dendl;
       assert(0 == "can't mark unloaded shard dirty");
     }
     if (!p->dirty) {
@@ -2310,8 +2318,8 @@ BlueStore::BlobRef BlueStore::ExtentMap::split_blob(
 {
   uint32_t end_pos = pos + lb->get_blob().get_logical_length() - blob_offset;
   dout(20) << __func__ << " 0x" << std::hex << pos << " end 0x" << end_pos
-	   << " blob_offset 0x" << blob_offset << std::dec
-	   << " " << *lb << dendl;
+	   << " blob_offset 0x" << blob_offset << std::dec << " " << *lb
+	   << dendl;
   BlobRef rb = onode->c->new_blob();
   lb->split(blob_offset, rb.get());
 
@@ -2350,10 +2358,10 @@ BlueStore::BlobRef BlueStore::ExtentMap::split_blob(
 void BlueStore::Onode::flush()
 {
   std::unique_lock<std::mutex> l(flush_lock);
-  dout(20) << __func__ << " " << flush_txns << dendl;
+  ldout(c->store->cct, 20) << __func__ << " " << flush_txns << dendl;
   while (!flush_txns.empty())
     flush_cond.wait(l);
-  dout(20) << __func__ << " done" << dendl;
+  ldout(c->store->cct, 20) << __func__ << " done" << dendl;
 }
 
 // =======================================================
@@ -2384,13 +2392,14 @@ void BlueStore::Collection::open_shared_blob(uint64_t sbid, BlobRef b)
 
   b->shared_blob = shared_blob_set.lookup(sbid);
   if (b->shared_blob) {
-    dout(10) << __func__ << " sbid 0x" << std::hex << sbid << std::dec
-	     << " had " << *b->shared_blob << dendl;
+    ldout(store->cct, 10) << __func__ << " sbid 0x" << std::hex << sbid
+			  << std::dec << " had " << *b->shared_blob << dendl;
   } else {
     b->shared_blob = new SharedBlob(sbid, cache);
     shared_blob_set.add(b->shared_blob.get());
-    dout(10) << __func__ << " sbid 0x" << std::hex << sbid << std::dec
-	     << " opened " << *b->shared_blob << dendl;
+    ldout(store->cct, 10) << __func__ << " sbid 0x" << std::hex << sbid
+			  << std::dec << " opened " << *b->shared_blob
+			  << dendl;
   }
 }
 
@@ -2402,21 +2411,22 @@ void BlueStore::Collection::load_shared_blob(SharedBlobRef sb)
   get_shared_blob_key(sb->sbid, &key);
   int r = store->db->get(PREFIX_SHARED_BLOB, key, &v);
   if (r < 0) {
-    derr << __func__ << " sbid 0x" << std::hex << sb->sbid << std::dec
-	 << " not found at key " << pretty_binary_string(key) << dendl;
+      lderr(store->cct) << __func__ << " sbid 0x" << std::hex << sb->sbid
+			<< std::dec << " not found at key "
+			<< pretty_binary_string(key) << dendl;
     assert(0 == "uh oh, missing shared_blob");
   }
 
   bufferlist::iterator p = v.begin();
   ::decode(sb->shared_blob, p);
-  dout(10) << __func__ << " sbid 0x" << std::hex << sb->sbid << std::dec
-	   << " loaded shared_blob " << *sb << dendl;
+  ldout(store->cct, 10) << __func__ << " sbid 0x" << std::hex << sb->sbid
+			<< std::dec << " loaded shared_blob " << *sb << dendl;
   sb->loaded = true;
 }
 
 void BlueStore::Collection::make_blob_shared(uint64_t sbid, BlobRef b)
 {
-  dout(10) << __func__ << " " << *b << dendl;
+  ldout(store->cct, 10) << __func__ << " " << *b << dendl;
   bluestore_blob_t& blob = b->dirty_blob();
 
   // update blob
@@ -2432,7 +2442,7 @@ void BlueStore::Collection::make_blob_shared(uint64_t sbid, BlobRef b)
       b->shared_blob->shared_blob.ref_map.get(p.offset, p.length);
     }
   }
-  dout(20) << __func__ << " now " << *b << dendl;
+  ldout(store->cct, 20) << __func__ << " now " << *b << dendl;
 }
 
 BlueStore::OnodeRef BlueStore::Collection::get_onode(
@@ -2444,8 +2454,8 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
   spg_t pgid;
   if (cid.is_pg(&pgid)) {
     if (!oid.match(cnode.bits, pgid.ps())) {
-      derr << __func__ << " oid " << oid << " not part of " << pgid
-	   << " bits " << cnode.bits << dendl;
+      lderr(store->cct) << __func__ << " oid " << oid << " not part of "
+			<< pgid << " bits " << cnode.bits << dendl;
       ceph_abort();
     }
   }
@@ -2455,18 +2465,18 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
     return o;
 
   string key;
-  get_object_key(oid, &key);
+  get_object_key(store->cct, oid, &key);
 
-  dout(20) << __func__ << " oid " << oid << " key "
-	   << pretty_binary_string(key) << dendl;
+  ldout(store->cct, 20) << __func__ << " oid " << oid << " key "
+			<< pretty_binary_string(key) << dendl;
 
   bufferlist v;
   int r = store->db->get(PREFIX_OBJ, key, &v);
-  dout(20) << " r " << r << " v.len " << v.length() << dendl;
+  ldout(store->cct, 20) << " r " << r << " v.len " << v.length() << dendl;
   Onode *on;
   if (v.length() == 0) {
     assert(r == -ENOENT);
-    if (!g_conf->bluestore_debug_misc &&
+    if (!store->cct->_conf->bluestore_debug_misc &&
 	!create)
       return OnodeRef();
 
@@ -2501,7 +2511,8 @@ void BlueStore::Collection::trim_cache()
   size_t seq;
   store->get_mempool_stats(&seq, &total_bytes, &total_onodes);
   if (seq == cache->last_trim_seq) {
-    dout(30) << __func__ << " no new mempool stats; nothing to do" << dendl;
+    ldout(store->cct, 30) << __func__ << " no new mempool stats; nothing to do"
+			  << dendl;
     return;
   }
   cache->last_trim_seq = seq;
@@ -2512,13 +2523,14 @@ void BlueStore::Collection::trim_cache()
   }
   float bytes_per_onode = (float)total_bytes / (float)total_onodes;
   size_t num_shards = store->cache_shards.size();
-  uint64_t shard_target = g_conf->bluestore_cache_size / num_shards;
-  dout(30) << __func__
-	   << " total meta bytes " << total_bytes
-	   << ", total onodes " << total_onodes
-	   << ", bytes_per_onode " << bytes_per_onode
+  uint64_t shard_target = store->cct->_conf->bluestore_cache_size / num_shards;
+  ldout(store->cct, 30) << __func__
+			<< " total meta bytes " << total_bytes
+			<< ", total onodes " << total_onodes
+			<< ", bytes_per_onode " << bytes_per_onode
 	   << dendl;
-  cache->trim(shard_target, g_conf->bluestore_cache_meta_ratio, bytes_per_onode);
+  cache->trim(shard_target, store->cct->_conf->bluestore_cache_meta_ratio,
+	      bytes_per_onode);
 
   store->_update_cache_logger();
 }
@@ -2534,7 +2546,7 @@ void *BlueStore::MempoolThread::entry()
     store->mempool_onodes = mempool::bluestore_meta_onode::allocated_items();
     ++store->mempool_seq;
     utime_t wait;
-    wait += g_conf->bluestore_cache_trim_interval;
+    wait += store->cct->_conf->bluestore_cache_trim_interval;
     cond.WaitInterval(lock, wait);
   }
   stop = false;
@@ -2592,7 +2604,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
     mempool_thread(this)
 {
   _init_logger();
-  g_ceph_context->_conf->add_observer(this);
+  cct->_conf->add_observer(this);
   set_cache_shards(1);
 
   if (cct->_conf->bluestore_shard_finishers) {
@@ -2614,7 +2626,7 @@ BlueStore::~BlueStore()
   }
   finishers.clear();
 
-  g_ceph_context->_conf->remove_observer(this);
+  cct->_conf->remove_observer(this);
   _shutdown_logger();
   assert(!mounted);
   assert(db == NULL);
@@ -2656,15 +2668,15 @@ void BlueStore::handle_conf_change(const struct md_config_t *conf,
 
 void BlueStore::_set_compression()
 {
-  comp_min_blob_size = g_conf->bluestore_compression_min_blob_size;
-  comp_max_blob_size = g_conf->bluestore_compression_max_blob_size;
+  comp_min_blob_size = cct->_conf->bluestore_compression_min_blob_size;
+  comp_max_blob_size = cct->_conf->bluestore_compression_max_blob_size;
 
-  auto m = Compressor::get_comp_mode_type(g_conf->bluestore_compression_mode);
+  auto m = Compressor::get_comp_mode_type(cct->_conf->bluestore_compression_mode);
   if (m) {
     comp_mode = *m;
   } else {
     derr << __func__ << " unrecognized value '"
-         << g_conf->bluestore_compression_mode
+         << cct->_conf->bluestore_compression_mode
          << "' for bluestore_compression_mode, reverting to 'none'"
          << dendl;
     comp_mode = Compressor::COMP_NONE;
@@ -2672,7 +2684,7 @@ void BlueStore::_set_compression()
 
   compressor = nullptr;
 
-  auto& alg_name = g_conf->bluestore_compression_algorithm;
+  auto& alg_name = cct->_conf->bluestore_compression_algorithm;
   if (!alg_name.empty()) {
     compressor = Compressor::create(cct, alg_name);
     if (!compressor) {
@@ -2689,7 +2701,7 @@ void BlueStore::_set_compression()
 void BlueStore::_set_csum()
 {
   csum_type = Checksummer::CSUM_NONE;
-  int t = Checksummer::get_csum_string_type(g_conf->bluestore_csum_type);
+  int t = Checksummer::get_csum_string_type(cct->_conf->bluestore_csum_type);
   if (t > Checksummer::CSUM_NONE)
     csum_type = t;
 
@@ -2700,7 +2712,7 @@ void BlueStore::_set_csum()
 
 void BlueStore::_init_logger()
 {
-  PerfCountersBuilder b(g_ceph_context, "BlueStore",
+  PerfCountersBuilder b(cct, "BlueStore",
                         l_bluestore_first, l_bluestore_last);
   b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
     "Average prepare state latency");
@@ -2813,7 +2825,7 @@ void BlueStore::_init_logger()
   b.add_u64(l_bluestore_extent_compress, "bluestore_extent_compress",
             "Sum for extents that have been removed due to compression");
   logger = b.create_perf_counters();
-  g_ceph_context->get_perfcounters_collection()->add(logger);
+  cct->get_perfcounters_collection()->add(logger);
 }
 
 int BlueStore::_reload_logger()
@@ -2833,14 +2845,15 @@ int BlueStore::_reload_logger()
 
 void BlueStore::_shutdown_logger()
 {
-  g_ceph_context->get_perfcounters_collection()->remove(logger);
+  cct->get_perfcounters_collection()->remove(logger);
   delete logger;
 }
 
-int BlueStore::get_block_device_fsid(const string& path, uuid_d *fsid)
+int BlueStore::get_block_device_fsid(CephContext* cct, const string& path,
+				     uuid_d *fsid)
 {
   bluestore_bdev_label_t label;
-  int r = _read_bdev_label(path, &label);
+  int r = _read_bdev_label(cct, path, &label);
   if (r < 0)
     return r;
   *fsid = label.osd_uuid;
@@ -2894,7 +2907,8 @@ int BlueStore::_write_bdev_label(string path, bluestore_bdev_label_t label)
   return r;
 }
 
-int BlueStore::_read_bdev_label(string path, bluestore_bdev_label_t *label)
+int BlueStore::_read_bdev_label(CephContext* cct, string path,
+				bluestore_bdev_label_t *label)
 {
   dout(10) << __func__ << dendl;
   int fd = ::open(path.c_str(), O_RDONLY);
@@ -2950,7 +2964,7 @@ int BlueStore::_check_or_set_bdev_label(
     if (r < 0)
       return r;
   } else {
-    int r = _read_bdev_label(path, &label);
+    int r = _read_bdev_label(cct, path, &label);
     if (r < 0)
       return r;
     if (label.osd_uuid != fsid) {
@@ -2967,20 +2981,20 @@ void BlueStore::_set_alloc_sizes(void)
   /*
    * Set device block size according to its media
    */
-  if (g_conf->bluestore_min_alloc_size) {
-    min_alloc_size = g_conf->bluestore_min_alloc_size;
+  if (cct->_conf->bluestore_min_alloc_size) {
+    min_alloc_size = cct->_conf->bluestore_min_alloc_size;
   } else {
     assert(bdev);
     if (bdev->is_rotational()) {
-      min_alloc_size = g_conf->bluestore_min_alloc_size_hdd;
+      min_alloc_size = cct->_conf->bluestore_min_alloc_size_hdd;
     } else {
-      min_alloc_size = g_conf->bluestore_min_alloc_size_ssd;
+      min_alloc_size = cct->_conf->bluestore_min_alloc_size_ssd;
     }
   }
   min_alloc_size_order = ctz(min_alloc_size);
   assert(min_alloc_size == 1u << min_alloc_size_order);
 
-  max_alloc_size = g_conf->bluestore_max_alloc_size;
+  max_alloc_size = cct->_conf->bluestore_max_alloc_size;
 
   dout(10) << __func__ << " min_alloc_size 0x" << std::hex << min_alloc_size
 	   << std::dec << " order " << min_alloc_size_order
@@ -2993,7 +3007,7 @@ int BlueStore::_open_bdev(bool create)
   bluestore_bdev_label_t label;
   assert(bdev == NULL);
   string p = path + "/block";
-  bdev = BlockDevice::create(p, aio_cb, static_cast<void*>(this));
+  bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this));
   int r = bdev->open(p);
   if (r < 0)
     goto fail;
@@ -3032,7 +3046,7 @@ void BlueStore::_close_bdev()
 int BlueStore::_open_fm(bool create)
 {
   assert(fm == NULL);
-  fm = FreelistManager::create(freelist_type, db, PREFIX_ALLOC);
+  fm = FreelistManager::create(cct, freelist_type, db, PREFIX_ALLOC);
 
   if (create) {
     // initialize freespace
@@ -3046,7 +3060,7 @@ int BlueStore::_open_fm(bool create)
     fm->create(bdev->get_size(), t);
 
     uint64_t reserved = 0;
-    if (g_conf->bluestore_bluefs) {
+    if (cct->_conf->bluestore_bluefs) {
       assert(bluefs_extents.num_intervals() == 1);
       interval_set<uint64_t>::iterator p = bluefs_extents.begin();
       reserved = p.get_start() + p.get_len();
@@ -3065,14 +3079,14 @@ int BlueStore::_open_fm(bool create)
     // instead rely on bluefs_extents.
     fm->allocate(0, BLUEFS_START, t);
 
-    if (g_conf->bluestore_debug_prefill > 0) {
+    if (cct->_conf->bluestore_debug_prefill > 0) {
       uint64_t end = bdev->get_size() - reserved;
       dout(1) << __func__ << " pre-fragmenting freespace, using "
-	      << g_conf->bluestore_debug_prefill << " with max free extent "
-	      << g_conf->bluestore_debug_prefragment_max << dendl;
+	      << cct->_conf->bluestore_debug_prefill << " with max free extent "
+	      << cct->_conf->bluestore_debug_prefragment_max << dendl;
       uint64_t start = P2ROUNDUP(reserved, min_alloc_size);
-      uint64_t max_b = g_conf->bluestore_debug_prefragment_max / min_alloc_size;
-      float r = g_conf->bluestore_debug_prefill;
+      uint64_t max_b = cct->_conf->bluestore_debug_prefragment_max / min_alloc_size;
+      float r = cct->_conf->bluestore_debug_prefill;
       r /= 1.0 - r;
       bool stop = false;
 
@@ -3132,7 +3146,7 @@ int BlueStore::_open_alloc()
 {
   assert(alloc == NULL);
   assert(bdev->get_size());
-  alloc = Allocator::create(g_conf->bluestore_allocator,
+  alloc = Allocator::create(cct, cct->_conf->bluestore_allocator,
                             bdev->get_size(),
                             min_min_alloc_size);
   uint64_t num = 0, bytes = 0;
@@ -3280,7 +3294,7 @@ int BlueStore::_open_db(bool create)
 
   string kv_backend;
   if (create) {
-    kv_backend = g_conf->bluestore_kvbackend;
+    kv_backend = cct->_conf->bluestore_kvbackend;
   } else {
     r = read_meta("kv_backend", &kv_backend);
     if (r < 0) {
@@ -3292,7 +3306,7 @@ int BlueStore::_open_db(bool create)
 
   bool do_bluefs;
   if (create) {
-    do_bluefs = g_conf->bluestore_bluefs;
+    do_bluefs = cct->_conf->bluestore_bluefs;
   } else {
     string s;
     r = read_meta("bluefs", &s);
@@ -3319,7 +3333,7 @@ int BlueStore::_open_db(bool create)
       derr << " backend must be rocksdb to use bluefs" << dendl;
       return -EINVAL;
     }
-    bluefs = new BlueFS;
+    bluefs = new BlueFS(cct);
 
     string bfn;
     struct stat st;
@@ -3368,12 +3382,12 @@ int BlueStore::_open_db(bool create)
       // note: we might waste a 4k block here if block.db is used, but it's
       // simpler.
       uint64_t initial =
-	bdev->get_size() * (g_conf->bluestore_bluefs_min_ratio +
-			    g_conf->bluestore_bluefs_gift_ratio);
-      initial = MAX(initial, g_conf->bluestore_bluefs_min);
+	bdev->get_size() * (cct->_conf->bluestore_bluefs_min_ratio +
+			    cct->_conf->bluestore_bluefs_gift_ratio);
+      initial = MAX(initial, cct->_conf->bluestore_bluefs_min);
       // align to bluefs's alloc_size
-      initial = P2ROUNDUP(initial, g_conf->bluefs_alloc_size);
-      initial += g_conf->bluefs_alloc_size - BLUEFS_START;
+      initial = P2ROUNDUP(initial, cct->_conf->bluefs_alloc_size);
+      initial += cct->_conf->bluefs_alloc_size - BLUEFS_START;
       bluefs->add_block_extent(bluefs_shared_bdev, BLUEFS_START, initial);
       bluefs_extents.insert(BLUEFS_START, initial);
     }
@@ -3405,9 +3419,9 @@ int BlueStore::_open_db(bool create)
 	  bluefs->get_block_device_size(BlueFS::BDEV_WAL) -
 	   BDEV_LABEL_BLOCK_SIZE);
       }
-      g_conf->set_val("rocksdb_separate_wal_dir", "true");
+      cct->_conf->set_val("rocksdb_separate_wal_dir", "true");
     } else {
-      g_conf->set_val("rocksdb_separate_wal_dir", "false");
+      cct->_conf->set_val("rocksdb_separate_wal_dir", "false");
     }
 
     if (create) {
@@ -3418,7 +3432,7 @@ int BlueStore::_open_db(bool create)
       derr << __func__ << " failed bluefs mount: " << cpp_strerror(r) << dendl;
       goto free_bluefs;
     }
-    if (g_conf->bluestore_bluefs_env_mirror) {
+    if (cct->_conf->bluestore_bluefs_env_mirror) {
       rocksdb::Env *a = new BlueRocksEnv(bluefs);
       unique_ptr<rocksdb::Directory> dir;
       rocksdb::Env *b = rocksdb::Env::Default();
@@ -3447,16 +3461,16 @@ int BlueStore::_open_db(bool create)
                << (uint64_t)(db_size * 95 / 100) << " "
                << fn + ".slow" << ","
                << (uint64_t)(slow_size * 95 / 100);
-      g_conf->set_val("rocksdb_db_paths", db_paths.str(), false, false);
+      cct->_conf->set_val("rocksdb_db_paths", db_paths.str(), false, false);
       dout(10) << __func__ << " set rocksdb_db_paths to "
-	       << g_conf->rocksdb_db_paths << dendl;
+	       << cct->_conf->rocksdb_db_paths << dendl;
     }
 
     if (create) {
       env->CreateDir(fn);
-      if (g_conf->rocksdb_separate_wal_dir)
+      if (cct->_conf->rocksdb_separate_wal_dir)
 	env->CreateDir(fn + ".wal");
-      if (g_conf->rocksdb_db_paths.length())
+      if (cct->_conf->rocksdb_db_paths.length())
 	env->CreateDir(fn + ".slow");
     }
   } else if (create) {
@@ -3470,7 +3484,7 @@ int BlueStore::_open_db(bool create)
     }
 
     // wal_dir, too!
-    if (g_conf->rocksdb_separate_wal_dir) {
+    if (cct->_conf->rocksdb_separate_wal_dir) {
       string walfn = path + "/db.wal";
       r = ::mkdir(walfn.c_str(), 0755);
       if (r < 0)
@@ -3484,7 +3498,7 @@ int BlueStore::_open_db(bool create)
     }
   }
 
-  db = KeyValueDB::create(g_ceph_context,
+  db = KeyValueDB::create(cct,
 			  kv_backend,
 			  fn,
 			  static_cast<void*>(env));
@@ -3506,7 +3520,7 @@ int BlueStore::_open_db(bool create)
   db->set_merge_operator(PREFIX_STAT, merge_op);
 
   if (kv_backend == "rocksdb")
-    options = g_conf->bluestore_rocksdb_options;
+    options = cct->_conf->bluestore_rocksdb_options;
   db->init(options);
   if (create)
     r = db->create_and_open(err);
@@ -3621,25 +3635,25 @@ int BlueStore::_balance_bluefs_freespace(vector<bluestore_pextent_t> *extents)
 
   uint64_t gift = 0;
   uint64_t reclaim = 0;
-  if (bluefs_ratio < g_conf->bluestore_bluefs_min_ratio) {
-    gift = g_conf->bluestore_bluefs_gift_ratio * total_free;
+  if (bluefs_ratio < cct->_conf->bluestore_bluefs_min_ratio) {
+    gift = cct->_conf->bluestore_bluefs_gift_ratio * total_free;
     dout(10) << __func__ << " bluefs_ratio " << bluefs_ratio
-	     << " < min_ratio " << g_conf->bluestore_bluefs_min_ratio
+	     << " < min_ratio " << cct->_conf->bluestore_bluefs_min_ratio
 	     << ", should gift " << pretty_si_t(gift) << dendl;
-  } else if (bluefs_ratio > g_conf->bluestore_bluefs_max_ratio) {
-    reclaim = g_conf->bluestore_bluefs_reclaim_ratio * total_free;
-    if (bluefs_total - reclaim < g_conf->bluestore_bluefs_min)
-      reclaim = bluefs_total - g_conf->bluestore_bluefs_min;
+  } else if (bluefs_ratio > cct->_conf->bluestore_bluefs_max_ratio) {
+    reclaim = cct->_conf->bluestore_bluefs_reclaim_ratio * total_free;
+    if (bluefs_total - reclaim < cct->_conf->bluestore_bluefs_min)
+      reclaim = bluefs_total - cct->_conf->bluestore_bluefs_min;
     dout(10) << __func__ << " bluefs_ratio " << bluefs_ratio
-	     << " > max_ratio " << g_conf->bluestore_bluefs_max_ratio
+	     << " > max_ratio " << cct->_conf->bluestore_bluefs_max_ratio
 	     << ", should reclaim " << pretty_si_t(reclaim) << dendl;
   }
-  if (bluefs_total < g_conf->bluestore_bluefs_min &&
-    g_conf->bluestore_bluefs_min <
-      (uint64_t)(g_conf->bluestore_bluefs_max_ratio * total_free)) {
-    uint64_t g = g_conf->bluestore_bluefs_min - bluefs_total;
+  if (bluefs_total < cct->_conf->bluestore_bluefs_min &&
+    cct->_conf->bluestore_bluefs_min <
+      (uint64_t)(cct->_conf->bluestore_bluefs_max_ratio * total_free)) {
+    uint64_t g = cct->_conf->bluestore_bluefs_min - bluefs_total;
     dout(10) << __func__ << " bluefs_total " << bluefs_total
-	     << " < min " << g_conf->bluestore_bluefs_min
+	     << " < min " << cct->_conf->bluestore_bluefs_min
 	     << ", should gift " << pretty_si_t(g) << dendl;
     if (g > gift)
       gift = g;
@@ -3662,7 +3676,7 @@ int BlueStore::_balance_bluefs_freespace(vector<bluestore_pextent_t> *extents)
     int count = 0;
     uint64_t alloc_len = 0;
     AllocExtentVector exts = AllocExtentVector(gift / min_alloc_size);
-    r = alloc->allocate(gift, g_conf->bluefs_alloc_size, 0, 0, &exts, &count, &alloc_len);
+    r = alloc->allocate(gift, cct->_conf->bluefs_alloc_size, 0, 0, &exts, &count, &alloc_len);
 
     if (r < 0 || alloc_len < gift) {
       derr << __func__ << " allocate failed on 0x" << std::hex << gift
@@ -3812,7 +3826,7 @@ int BlueStore::_setup_block_symlink_or_file(
 	  return r;
 	}
 
-	if (g_conf->bluestore_block_preallocate_file) {
+	if (cct->_conf->bluestore_block_preallocate_file) {
 #ifdef HAVE_POSIX_FALLOCATE
 	  r = ::posix_fallocate(fd, 0, size);
 	  if (r) {
@@ -3865,8 +3879,8 @@ int BlueStore::mkfs()
     r = read_meta("mkfs_done", &done);
     if (r == 0) {
       dout(1) << __func__ << " already created" << dendl;
-      if (g_conf->bluestore_fsck_on_mkfs) {
-        r = fsck(g_conf->bluestore_fsck_on_mkfs_deep);
+      if (cct->_conf->bluestore_fsck_on_mkfs) {
+        r = fsck(cct->_conf->bluestore_fsck_on_mkfs_deep);
         if (r < 0) {
           derr << __func__ << " fsck found fatal error: " << cpp_strerror(r)
                << dendl;
@@ -3896,7 +3910,7 @@ int BlueStore::mkfs()
     }
   }
 
-  freelist_type = g_conf->bluestore_freelist_type;
+  freelist_type = cct->_conf->bluestore_freelist_type;
 
   r = _open_path();
   if (r < 0)
@@ -3929,20 +3943,20 @@ int BlueStore::mkfs()
     fsid = old_fsid;
   }
 
-  r = _setup_block_symlink_or_file("block", g_conf->bluestore_block_path,
-				   g_conf->bluestore_block_size,
-				   g_conf->bluestore_block_create);
+  r = _setup_block_symlink_or_file("block", cct->_conf->bluestore_block_path,
+				   cct->_conf->bluestore_block_size,
+				   cct->_conf->bluestore_block_create);
   if (r < 0)
     goto out_close_fsid;
-  if (g_conf->bluestore_bluefs) {
-    r = _setup_block_symlink_or_file("block.wal", g_conf->bluestore_block_wal_path,
-	g_conf->bluestore_block_wal_size,
-	g_conf->bluestore_block_wal_create);
+  if (cct->_conf->bluestore_bluefs) {
+    r = _setup_block_symlink_or_file("block.wal", cct->_conf->bluestore_block_wal_path,
+	cct->_conf->bluestore_block_wal_size,
+	cct->_conf->bluestore_block_wal_create);
     if (r < 0)
       goto out_close_fsid;
-    r = _setup_block_symlink_or_file("block.db", g_conf->bluestore_block_db_path,
-	g_conf->bluestore_block_db_size,
-	g_conf->bluestore_block_db_create);
+    r = _setup_block_symlink_or_file("block.db", cct->_conf->bluestore_block_db_path,
+	cct->_conf->bluestore_block_db_size,
+	cct->_conf->bluestore_block_db_create);
     if (r < 0)
       goto out_close_fsid;
   }
@@ -3965,10 +3979,10 @@ int BlueStore::mkfs()
   if (r < 0)
     goto out_close_fm;
 
-  r = write_meta("kv_backend", g_conf->bluestore_kvbackend);
+  r = write_meta("kv_backend", cct->_conf->bluestore_kvbackend);
   if (r < 0)
     goto out_close_alloc;
-  r = write_meta("bluefs", stringify((int)g_conf->bluestore_bluefs));
+  r = write_meta("bluefs", stringify((int)cct->_conf->bluestore_bluefs));
   if (r < 0)
     goto out_close_alloc;
 
@@ -4000,8 +4014,8 @@ int BlueStore::mkfs()
   _close_path();
 
   if (r == 0 &&
-      g_conf->bluestore_fsck_on_mkfs) {
-    int rc = fsck(g_conf->bluestore_fsck_on_mkfs_deep);
+      cct->_conf->bluestore_fsck_on_mkfs) {
+    int rc = fsck(cct->_conf->bluestore_fsck_on_mkfs_deep);
     if (rc < 0)
       return rc;
     if (rc > 0) {
@@ -4019,7 +4033,8 @@ void BlueStore::set_cache_shards(unsigned num)
   assert(num >= old);
   cache_shards.resize(num);
   for (unsigned i = old; i < num; ++i) {
-    cache_shards[i] = Cache::create(g_conf->bluestore_cache_type, logger);
+    cache_shards[i] = Cache::create(cct, cct->_conf->bluestore_cache_type,
+				    logger);
   }
 }
 
@@ -4042,8 +4057,8 @@ int BlueStore::mount()
     }
   }
 
-  if (g_conf->bluestore_fsck_on_mount) {
-    int rc = fsck(g_conf->bluestore_fsck_on_mount_deep);
+  if (cct->_conf->bluestore_fsck_on_mount) {
+    int rc = fsck(cct->_conf->bluestore_fsck_on_mount_deep);
     if (rc < 0)
       return rc;
     if (rc > 0) {
@@ -4177,8 +4192,8 @@ int BlueStore::umount()
   _close_fsid();
   _close_path();
 
-  if (g_conf->bluestore_fsck_on_umount) {
-    int rc = fsck(g_conf->bluestore_fsck_on_umount_deep);
+  if (cct->_conf->bluestore_fsck_on_umount) {
+    int rc = fsck(cct->_conf->bluestore_fsck_on_umount_deep);
     if (rc < 0)
       return rc;
     if (rc > 0) {
@@ -5066,7 +5081,7 @@ int BlueStore::_do_read(
   if (op_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
     dout(20) << __func__ << " will do buffered read" << dendl;
     buffered = true;
-  } else if (g_conf->bluestore_default_buffered_read &&
+  } else if (cct->_conf->bluestore_default_buffered_read &&
 	     (op_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
 			  CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
     dout(20) << __func__ << " defaulting to buffered read" << dendl;
@@ -5149,7 +5164,7 @@ int BlueStore::_do_read(
 	     << " need 0x" << b2r_it->second << std::dec << dendl;
     if (bptr->get_blob().has_flag(bluestore_blob_t::FLAG_COMPRESSED)) {
       bufferlist compressed_bl, raw_bl;
-      IOContext ioc(NULL);   // FIXME?
+      IOContext ioc(cct, NULL);   // FIXME?
       r = bptr->get_blob().map(
 	0, bptr->get_blob().get_ondisk_length(),
 	[&](uint64_t offset, uint64_t length) {
@@ -5198,7 +5213,7 @@ int BlueStore::_do_read(
 		 << dendl;
 
 	// read it
-	IOContext ioc(NULL);  // FIXME?
+	IOContext ioc(cct, NULL);  // FIXME?
 	bufferlist bl;
 	r = bptr->get_blob().map(r_off, r_len,
 			     [&](uint64_t offset, uint64_t length) {
@@ -5625,7 +5640,7 @@ int BlueStore::_collection_list(
     temp = true;
   } else {
     string k;
-    get_object_key(start, &k);
+    get_object_key(cct, start, &k);
     if (start.hobj.is_temp()) {
       temp = true;
       assert(k >= temp_start_key && k < temp_end_key);
@@ -5640,7 +5655,7 @@ int BlueStore::_collection_list(
   if (end.hobj.is_max()) {
     pend = temp ? temp_end_key : end_key;
   } else {
-    get_object_key(end, &end_key);
+    get_object_key(cct, end, &end_key);
     if (end.hobj.is_temp()) {
       if (temp)
 	pend = end_key;
@@ -6233,7 +6248,7 @@ void BlueStore::get_db_statistics(Formatter *f)
 
 BlueStore::TransContext *BlueStore::_txc_create(OpSequencer *osr)
 {
-  TransContext *txc = new TransContext(osr);
+  TransContext *txc = new TransContext(cct, osr);
   txc->t = db->get_transaction();
   osr->queue_new(txc);
   dout(20) << __func__ << " osr " << osr << " = " << txc
@@ -6291,7 +6306,7 @@ void BlueStore::_txc_state_proc(TransContext *txc)
         sb->bc.finish_write(txc->seq);
       }
       txc->shared_blobs_written.clear();
-      if (g_conf->bluestore_sync_submit_transaction &&
+      if (cct->_conf->bluestore_sync_submit_transaction &&
 	  fm->supports_parallel_transactions()) {
 	if (txc->last_nid >= nid_max ||
 	    txc->last_blobid >= blobid_max) {
@@ -6308,8 +6323,8 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	} else if (txc->osr->txc_with_unstable_io) {
 	  dout(20) << __func__ << " prior txc(s) with unstable ios "
 		   << txc->osr->txc_with_unstable_io.load() << dendl;
-	} else if (g_conf->bluestore_debug_randomize_serial_transaction &&
-		   rand() % g_conf->bluestore_debug_randomize_serial_transaction
+	} else if (cct->_conf->bluestore_debug_randomize_serial_transaction &&
+		   rand() % cct->_conf->bluestore_debug_randomize_serial_transaction
 		   == 0) {
 	  dout(20) << __func__ << " DEBUG randomly forcing submit via kv thread"
 		   << dendl;
@@ -6667,7 +6682,7 @@ void BlueStore::_txc_finalize_kv(TransContext *txc, KeyValueDB::Transaction t)
 void BlueStore::_txc_release_alloc(TransContext *txc)
 {
   // update allocator with full released set
-  if (!g_conf->bluestore_debug_no_reuse_blocks) {
+  if (!cct->_conf->bluestore_debug_no_reuse_blocks) {
     for (interval_set<uint64_t>::iterator p = txc->released.begin();
 	 p != txc->released.end();
 	 ++p) {
@@ -6719,19 +6734,19 @@ void BlueStore::_kv_sync_thread()
       // it.  in either case, we increase the max in the earlier txn
       // we submit.
       uint64_t new_nid_max = 0, new_blobid_max = 0;
-      if (nid_last + g_conf->bluestore_nid_prealloc/2 > nid_max) {
+      if (nid_last + cct->_conf->bluestore_nid_prealloc/2 > nid_max) {
 	KeyValueDB::Transaction t =
 	  kv_submitting.empty() ? synct : kv_submitting.front()->t;
-	new_nid_max = nid_last + g_conf->bluestore_nid_prealloc;
+	new_nid_max = nid_last + cct->_conf->bluestore_nid_prealloc;
 	bufferlist bl;
 	::encode(new_nid_max, bl);
 	t->set(PREFIX_SUPER, "nid_max", bl);
 	dout(10) << __func__ << " new_nid_max " << new_nid_max << dendl;
       }
-      if (blobid_last + g_conf->bluestore_blobid_prealloc/2 > blobid_max) {
+      if (blobid_last + cct->_conf->bluestore_blobid_prealloc/2 > blobid_max) {
 	KeyValueDB::Transaction t =
 	  kv_submitting.empty() ? synct : kv_submitting.front()->t;
-	new_blobid_max = blobid_last + g_conf->bluestore_blobid_prealloc;
+	new_blobid_max = blobid_last + cct->_conf->bluestore_blobid_prealloc;
 	bufferlist bl;
 	::encode(new_blobid_max, bl);
 	t->set(PREFIX_SUPER, "blobid_max", bl);
@@ -6852,12 +6867,12 @@ int BlueStore::_wal_apply(TransContext *txc)
   txc->log_state_latency(logger, l_bluestore_state_wal_queued_lat);
   txc->state = TransContext::STATE_WAL_APPLYING;
 
-  if (g_conf->bluestore_inject_wal_apply_delay) {
+  if (cct->_conf->bluestore_inject_wal_apply_delay) {
     dout(20) << __func__ << " bluestore_inject_wal_apply_delay "
-	     << g_conf->bluestore_inject_wal_apply_delay
+	     << cct->_conf->bluestore_inject_wal_apply_delay
 	     << dendl;
     utime_t t;
-    t.set_from_double(g_conf->bluestore_inject_wal_apply_delay);
+    t.set_from_double(cct->_conf->bluestore_inject_wal_apply_delay);
     t.sleep();
     dout(20) << __func__ << " finished sleep" << dendl;
   }
@@ -6965,7 +6980,7 @@ int BlueStore::queue_transactions(
   ObjectStore::Transaction::collect_contexts(
     tls, &onreadable, &ondisk, &onreadable_sync);
 
-  if (g_conf->objectstore_blackhole) {
+  if (cct->_conf->objectstore_blackhole) {
     dout(0) << __func__ << " objectstore_blackhole = TRUE, dropping transaction"
 	    << dendl;
     delete ondisk;
@@ -7445,7 +7460,7 @@ int BlueStore::_touch(TransContext *txc,
 
 void BlueStore::_dump_onode(OnodeRef o, int log_level)
 {
-  if (!g_conf->subsys.should_gather(ceph_subsys_bluestore, log_level))
+  if (!cct->_conf->subsys.should_gather(ceph_subsys_bluestore, log_level))
     return;
   dout(log_level) << __func__ << " " << o << " " << o->oid
 		  << " nid " << o->onode.nid
@@ -7848,7 +7863,7 @@ int BlueStore::_do_alloc_write(
 
   auto crr = select_option(
     "compression_required_ratio",
-    g_conf->bluestore_compression_required_ratio,
+    cct->_conf->bluestore_compression_required_ratio,
     [&]() {
       double val;
       if(coll->pool_opts.get(pool_opts_t::COMPRESSION_REQUIRED_RATIO, &val)) {
@@ -8144,7 +8159,7 @@ int BlueStore::_do_write(
   if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
     dout(20) << __func__ << " will do buffered write" << dendl;
     wctx.buffered = true;
-  } else if (g_conf->bluestore_default_buffered_write &&
+  } else if (cct->_conf->bluestore_default_buffered_write &&
 	     (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
 			       CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
     dout(20) << __func__ << " defaulting to buffered write" << dendl;
@@ -8218,8 +8233,8 @@ int BlueStore::_do_write(
     }
   }
   if (wctx.target_blob_size == 0 ||
-      wctx.target_blob_size > g_conf->bluestore_max_blob_size) {
-    wctx.target_blob_size = g_conf->bluestore_max_blob_size;
+      wctx.target_blob_size > cct->_conf->bluestore_max_blob_size) {
+    wctx.target_blob_size = cct->_conf->bluestore_max_blob_size;
   }
   // set the min blob size floor at 2x the min_alloc_size, or else we
   // won't be able to allocate a smaller extent for the compressed
@@ -8701,7 +8716,7 @@ int BlueStore::_clone(TransContext *txc,
   r = _do_truncate(txc, c, newo, 0);
   if (r < 0)
     goto out;
-  if (g_conf->bluestore_clone_cow) {
+  if (cct->_conf->bluestore_clone_cow) {
     _do_clone_range(txc, c, oldo, newo, 0, oldo->onode.size, 0);
   } else {
     bufferlist bl;
@@ -8806,7 +8821,7 @@ int BlueStore::_do_clone_range(
       } else if (!e.blob->shared_blob->loaded) {
 	c->load_shared_blob(e.blob->shared_blob);
       }
-      cb = new Blob;
+      cb = new Blob(cct);
       e.blob->last_encoded_id = n;
       id_to_blob[n] = cb;
       e.blob->dup(*cb);
@@ -8884,7 +8899,7 @@ int BlueStore::_clone_range(TransContext *txc,
   _assign_nid(txc, newo);
 
   if (length > 0) {
-    if (g_conf->bluestore_clone_cow) {
+    if (cct->_conf->bluestore_clone_cow) {
       _do_zero(txc, c, newo, dstoff, length);
       _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
     } else {
@@ -8933,7 +8948,7 @@ int BlueStore::_rename(TransContext *txc,
 
   // rewrite shards
   oldo->extent_map.fault_range(db, 0, oldo->onode.size);
-  get_object_key(new_oid, &new_okey);
+  get_object_key(cct, new_oid, &new_okey);
   for (auto &s : oldo->extent_map.shards) {
     txc->t->rmkey(PREFIX_OBJ, s.key);
     get_extent_shard_key(new_okey, s.offset, &s.key);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2554,8 +2554,7 @@ static void aio_cb(void *priv, void *priv2)
 }
 
 BlueStore::BlueStore(CephContext *cct, const string& path)
-  : ObjectStore(path),
-    cct(cct),
+  : ObjectStore(cct, path),
     bluefs(NULL),
     bluefs_shared_bdev(0),
     db(NULL),
@@ -6923,7 +6922,7 @@ int BlueStore::_do_wal_op(TransContext *txc, bluestore_wal_op_t& wo)
 int BlueStore::_wal_replay()
 {
   dout(10) << __func__ << " start" << dendl;
-  OpSequencerRef osr = new OpSequencer;
+  OpSequencerRef osr = new OpSequencer(cct);
   int count = 0;
   KeyValueDB::Iterator it = db->get_iterator(PREFIX_WAL);
   for (it->lower_bound(string()); it->valid(); it->next(), ++count) {
@@ -6982,7 +6981,7 @@ int BlueStore::queue_transactions(
     osr = static_cast<OpSequencer *>(posr->p.get());
     dout(10) << __func__ << " existing " << osr << " " << *osr << dendl;
   } else {
-    osr = new OpSequencer;
+    osr = new OpSequencer(cct);
     osr->parent = posr;
     posr->p = osr;
     dout(10) << __func__ << " new " << osr << " " << *osr << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1,4 +1,3 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1370,9 +1370,10 @@ public:
 
     std::atomic_int kv_committing_serially = {0};
 
-    OpSequencer()
+    OpSequencer(CephContext* cct)
 	//set the qlock to PTHREAD_MUTEX_RECURSIVE mode
-      : parent(NULL) {
+      : Sequencer_impl(cct),
+	parent(NULL) {
     }
     ~OpSequencer() {
       assert(q.empty());
@@ -1505,7 +1506,6 @@ public:
   // --------------------------------------------------------
   // members
 private:
-  CephContext *cct;
   BlueFS *bluefs;
   unsigned bluefs_shared_bdev;  ///< which bluefs bdev we are sharing
   KeyValueDB *db;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1213,7 +1213,7 @@ public:
     }
 
     void log_state_latency(PerfCounters *logger, int state) {
-      utime_t lat, now = ceph_clock_now(g_ceph_context);
+      utime_t lat, now = ceph_clock_now();
       lat = now - last_stamp;
       logger->tinc(state, lat);
       last_stamp = now;
@@ -1314,7 +1314,7 @@ public:
 	onreadable_sync(NULL),
 	wal_txn(NULL),
 	ioc(this),
-	start(ceph_clock_now(g_ceph_context)) {
+	start(ceph_clock_now()) {
         last_stamp = start;
     }
     ~TransContext() {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -110,7 +110,6 @@ class BlueStore : public ObjectStore,
   // -----------------------------------------------------
   // types
 public:
-
   // config observer
   virtual const char** get_tracked_conf_keys() const override;
   virtual void handle_conf_change(const struct md_config_t *conf,
@@ -420,6 +419,7 @@ public:
   /// in-memory blob metadata and associated cached buffers (if any)
   struct Blob {
     MEMPOOL_CLASS_HELPERS();
+    CephContext* cct;
 
     std::atomic_int nref = {0};     ///< reference count
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
@@ -435,7 +435,7 @@ public:
     bluestore_extent_ref_map_t ref_map;
 
   public:
-    Blob() {}
+    Blob(CephContext* cct) : cct(cct) {}
     ~Blob() {
     }
 
@@ -639,6 +639,7 @@ public:
 
   /// a sharded extent map, mapping offsets to lextents to blobs
   struct ExtentMap {
+    CephContext* cct;
     Onode *onode;
     extent_map_t extent_map;        ///< map of Extents to Blobs
     blob_map_t spanning_blob_map;   ///< blobs that span shards
@@ -660,7 +661,7 @@ public:
       void operator()(Extent *e) { delete e; }
     };
 
-    ExtentMap(Onode *o);
+    ExtentMap(CephContext* cct, Onode *o);
     ~ExtentMap() {
       extent_map.clear_and_dispose(DeleteDisposer());
     }
@@ -814,7 +815,7 @@ public:
 	oid(o),
 	key(k),
 	exists(false),
-	extent_map(this) {
+	extent_map(c->store->cct, this) {
     }
 
     void flush();
@@ -831,6 +832,7 @@ public:
 
   /// a cache (shard) of onodes and buffers
   struct Cache {
+    CephContext* cct;
     PerfCounters *logger;
     std::recursive_mutex lock;          ///< protect lru and other structures
 
@@ -839,8 +841,9 @@ public:
 
     size_t last_trim_seq = 0;
 
-    static Cache *create(string type, PerfCounters *logger);
+    static Cache *create(CephContext* cct, string type, PerfCounters *logger);
 
+    Cache(CephContext* cct) : cct(cct) {}
     virtual ~Cache() {}
 
     virtual void _add_onode(OnodeRef& o, int level) = 0;
@@ -908,6 +911,7 @@ public:
     uint64_t buffer_size = 0;
 
   public:
+    LRUCache(CephContext* cct) : Cache(cct) {}
     uint64_t _get_num_onodes() override {
       return onode_lru.size();
     }
@@ -1008,6 +1012,7 @@ public:
     uint64_t buffer_list_bytes[BUFFER_TYPE_MAX] = {0}; ///< bytes per type
 
   public:
+    TwoQCache(CephContext* cct) : Cache(cct) {}
     uint64_t _get_num_onodes() override {
       return onode_lru.size();
     }
@@ -1126,7 +1131,7 @@ public:
     void make_blob_shared(uint64_t sbid, BlobRef b);
 
     BlobRef new_blob() {
-      BlobRef b = new Blob;
+      BlobRef b = new Blob(store->cct);
       b->shared_blob = new SharedBlob(cache);
       return b;
     }
@@ -1304,7 +1309,7 @@ public:
     uint64_t last_nid = 0;     ///< if non-zero, highest new nid we allocated
     uint64_t last_blobid = 0;  ///< if non-zero, highest new blobid we allocated
 
-    explicit TransContext(OpSequencer *o)
+    explicit TransContext(CephContext* cct, OpSequencer *o)
       : state(STATE_PREPARE),
 	osr(o),
 	ops(0),
@@ -1313,7 +1318,7 @@ public:
 	onreadable(NULL),
 	onreadable_sync(NULL),
 	wal_txn(NULL),
-	ioc(this),
+	ioc(cct, this),
 	start(ceph_clock_now()) {
         last_stamp = start;
     }
@@ -1647,7 +1652,8 @@ private:
 				   bool create);
 
   int _write_bdev_label(string path, bluestore_bdev_label_t label);
-  static int _read_bdev_label(string path, bluestore_bdev_label_t *label);
+  static int _read_bdev_label(CephContext* cct, string path,
+			      bluestore_bdev_label_t *label);
   int _check_or_set_bdev_label(string path, uint64_t size, string desc,
 			       bool create);
 
@@ -1751,7 +1757,8 @@ public:
   bool wants_journal() override { return false; };
   bool allows_journal() override { return false; };
 
-  static int get_block_device_fsid(const string& path, uuid_d *fsid);
+  static int get_block_device_fsid(CephContext* cct, const string& path,
+				   uuid_d *fsid);
 
   bool test_mount_in_use() override;
 
@@ -1976,21 +1983,21 @@ public:
   }
 private:
   bool _debug_data_eio(const ghobject_t& o) {
-    if (!g_conf->bluestore_debug_inject_read_err) {
+    if (!cct->_conf->bluestore_debug_inject_read_err) {
       return false;
     }
     RWLock::RLocker l(debug_read_error_lock);
     return debug_data_error_objects.count(o);
   }
   bool _debug_mdata_eio(const ghobject_t& o) {
-    if (!g_conf->bluestore_debug_inject_read_err) {
+    if (!cct->_conf->bluestore_debug_inject_read_err) {
       return false;
     }
     RWLock::RLocker l(debug_read_error_lock);
     return debug_mdata_error_objects.count(o);
   }
   void _debug_obj_on_delete(const ghobject_t& o) {
-    if (g_conf->bluestore_debug_inject_read_err) {
+    if (cct->_conf->bluestore_debug_inject_read_err) {
       RWLock::WLocker l(debug_read_error_lock);
       debug_data_error_objects.erase(o);
       debug_mdata_error_objects.erase(o);

--- a/src/os/bluestore/ExtentFreelistManager.cc
+++ b/src/os/bluestore/ExtentFreelistManager.cc
@@ -7,6 +7,7 @@
 
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "

--- a/src/os/bluestore/ExtentFreelistManager.cc
+++ b/src/os/bluestore/ExtentFreelistManager.cc
@@ -7,7 +7,7 @@
 
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "freelist "
@@ -208,7 +208,7 @@ void ExtentFreelistManager::allocate(
       p->second = newlen;
     }
   }
-  if (g_conf->bluestore_debug_freelist)
+  if (cct->_conf->bluestore_debug_freelist)
     _audit();
 }
 
@@ -279,6 +279,6 @@ void ExtentFreelistManager::release(
 
   kv_free[offset] = length;
 
-  if (g_conf->bluestore_debug_freelist)
+  if (cct->_conf->bluestore_debug_freelist)
     _audit();
 }

--- a/src/os/bluestore/ExtentFreelistManager.h
+++ b/src/os/bluestore/ExtentFreelistManager.h
@@ -29,7 +29,9 @@ class ExtentFreelistManager : public FreelistManager {
   void _dump();
 
 public:
-  ExtentFreelistManager(KeyValueDB *kvdb, std::string prefix) :
+  ExtentFreelistManager(CephContext* cct, KeyValueDB *kvdb,
+			std::string prefix) :
+    FreelistManager(cct),
     kvdb(kvdb),
     prefix(prefix),
     total_free(0) {

--- a/src/os/bluestore/FreelistManager.cc
+++ b/src/os/bluestore/FreelistManager.cc
@@ -6,6 +6,7 @@
 #include "BitmapFreelistManager.h"
 
 FreelistManager *FreelistManager::create(
+  CephContext* cct,
   string type,
   KeyValueDB *kvdb,
   string prefix)
@@ -16,9 +17,9 @@ FreelistManager *FreelistManager::create(
   // freelist type until after we open the db.
   assert(prefix == "B");
   if (type == "extent")
-    return new ExtentFreelistManager(kvdb, "B");
+    return new ExtentFreelistManager(cct, kvdb, "B");
   if (type == "bitmap")
-    return new BitmapFreelistManager(kvdb, "B", "b");
+    return new BitmapFreelistManager(cct, kvdb, "B", "b");
   return NULL;
 }
 

--- a/src/os/bluestore/FreelistManager.h
+++ b/src/os/bluestore/FreelistManager.h
@@ -12,10 +12,12 @@
 
 class FreelistManager {
 public:
-  FreelistManager() {}
+  CephContext* cct;
+  FreelistManager(CephContext* cct) : cct(cct) {}
   virtual ~FreelistManager() {}
 
   static FreelistManager *create(
+    CephContext* cct,
     string type,
     KeyValueDB *db,
     string prefix);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -26,6 +26,7 @@
 #include "common/blkdev.h"
 #include "common/align.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev(" << path << ") "

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -201,9 +201,9 @@ int KernelDevice::flush()
     g_ceph_context->_log->flush();
     _exit(1);
   }
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   int r = ::fdatasync(fd_direct);
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   if (r < 0) {
     r = -errno;
@@ -280,7 +280,7 @@ void KernelDevice::_aio_thread()
       }
     }
     if (g_conf->bdev_debug_aio) {
-      utime_t now = ceph_clock_now(NULL);
+      utime_t now = ceph_clock_now();
       std::lock_guard<std::mutex> l(debug_queue_lock);
       if (debug_oldest) {
 	if (debug_stall_since == utime_t()) {

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -26,19 +26,20 @@
 #include "common/blkdev.h"
 #include "common/align.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_bdev
 #undef dout_prefix
 #define dout_prefix *_dout << "bdev(" << path << ") "
 
-KernelDevice::KernelDevice(aio_callback_t cb, void *cbpriv)
-  : fd_direct(-1),
+KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
+  : BlockDevice(cct),
+    fd_direct(-1),
     fd_buffered(-1),
     size(0), block_size(0),
     fs(NULL), aio(false), dio(false),
     debug_lock("KernelDevice::debug_lock"),
     flush_lock("KernelDevice::flush_lock"),
-    aio_queue(g_conf->bdev_aio_max_queue_depth),
+    aio_queue(cct->_conf->bdev_aio_max_queue_depth),
     aio_callback(cb),
     aio_callback_priv(cbpriv),
     aio_stop(false),
@@ -82,7 +83,7 @@ int KernelDevice::open(string p)
     goto out_direct;
   }
   dio = true;
-  aio = g_conf->bdev_aio;
+  aio = cct->_conf->bdev_aio;
   if (!aio) {
     assert(0 == "non-aio not supported");
   }
@@ -129,7 +130,7 @@ int KernelDevice::open(string p)
   // blksize doesn't strictly matter except that some file systems may
   // require a read/modify/write if we write something smaller than
   // it.
-  block_size = g_conf->bdev_block_size;
+  block_size = cct->_conf->bdev_block_size;
   if (block_size != (unsigned)st.st_blksize) {
     dout(1) << __func__ << " backing device/file reports st_blksize "
 	    << st.st_blksize << ", using bdev_block_size "
@@ -192,14 +193,14 @@ int KernelDevice::flush()
     return 0;
   }
   dout(10) << __func__ << " start" << dendl;
-  if (g_conf->bdev_inject_crash) {
+  if (cct->_conf->bdev_inject_crash) {
     ++injecting_crash;
     // sleep for a moment to give other threads a chance to submit or
     // wait on io that races with a flush.
     derr << __func__ << " injecting crash. first we sleep..." << dendl;
-    sleep(g_conf->bdev_inject_crash_flush_delay);
+    sleep(cct->_conf->bdev_inject_crash_flush_delay);
     derr << __func__ << " and now we die" << dendl;
-    g_ceph_context->_log->flush();
+    cct->_log->flush();
     _exit(1);
   }
   utime_t start = ceph_clock_now();
@@ -248,7 +249,7 @@ void KernelDevice::_aio_thread()
     dout(40) << __func__ << " polling" << dendl;
     int max = 16;
     FS::aio_t *aio[max];
-    int r = aio_queue.get_next_completed(g_conf->bdev_aio_poll_ms,
+    int r = aio_queue.get_next_completed(cct->_conf->bdev_aio_poll_ms,
 					 aio, max);
     if (r < 0) {
       derr << __func__ << " got " << cpp_strerror(r) << dendl;
@@ -280,7 +281,7 @@ void KernelDevice::_aio_thread()
 	}
       }
     }
-    if (g_conf->bdev_debug_aio) {
+    if (cct->_conf->bdev_debug_aio) {
       utime_t now = ceph_clock_now();
       std::lock_guard<std::mutex> l(debug_queue_lock);
       if (debug_oldest) {
@@ -288,11 +289,11 @@ void KernelDevice::_aio_thread()
 	  debug_stall_since = now;
 	} else {
 	  utime_t cutoff = now;
-	  cutoff -= g_conf->bdev_debug_aio_suicide_timeout;
+	  cutoff -= cct->_conf->bdev_debug_aio_suicide_timeout;
 	  if (debug_stall_since < cutoff) {
 	    derr << __func__ << " stalled aio " << debug_oldest
 		 << " since " << debug_stall_since << ", timeout is "
-		 << g_conf->bdev_debug_aio_suicide_timeout
+		 << cct->_conf->bdev_debug_aio_suicide_timeout
 		 << "s, suicide" << dendl;
 	    assert(0 == "stalled aio... buggy kernel or bad device?");
 	  }
@@ -300,13 +301,13 @@ void KernelDevice::_aio_thread()
       }
     }
     reap_ioc();
-    if (g_conf->bdev_inject_crash) {
+    if (cct->_conf->bdev_inject_crash) {
       ++inject_crash_count;
-      if (inject_crash_count * g_conf->bdev_aio_poll_ms / 1000 >
-	  g_conf->bdev_inject_crash + g_conf->bdev_inject_crash_flush_delay) {
+      if (inject_crash_count * cct->_conf->bdev_aio_poll_ms / 1000 >
+	  cct->_conf->bdev_inject_crash + cct->_conf->bdev_inject_crash_flush_delay) {
 	derr << __func__ << " bdev_inject_crash trigger from aio thread"
 	     << dendl;
-	g_ceph_context->_log->flush();
+	cct->_log->flush();
 	_exit(1);
       }
     }
@@ -322,7 +323,7 @@ void KernelDevice::_aio_log_start(
 {
   dout(20) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
-  if (g_conf->bdev_debug_inflight_ios) {
+  if (cct->_conf->bdev_debug_inflight_ios) {
     Mutex::Locker l(debug_lock);
     if (debug_inflight.intersects(offset, length)) {
       derr << __func__ << " inflight overlap of 0x"
@@ -365,7 +366,7 @@ void KernelDevice::_aio_log_finish(
 {
   dout(20) << __func__ << " " << aio << " 0x"
 	   << std::hex << offset << "~" << length << std::dec << dendl;
-  if (g_conf->bdev_debug_inflight_ios) {
+  if (cct->_conf->bdev_debug_inflight_ios) {
     Mutex::Locker l(debug_lock);
     debug_inflight.erase(offset, length);
   }
@@ -413,7 +414,7 @@ void KernelDevice::aio_submit(IOContext *ioc)
     // do not dereference txc (or it's contents) after we submit (if
     // done == true and we don't loop)
     int retries = 0;
-    if (g_conf->bdev_debug_aio) {
+    if (cct->_conf->bdev_debug_aio) {
       std::lock_guard<std::mutex> l(debug_queue_lock);
       debug_aio_link(*cur);
     }
@@ -458,8 +459,8 @@ int KernelDevice::aio_write(
     ioc->pending_aios.push_back(FS::aio_t(ioc, fd_direct));
     ++ioc->num_pending;
     FS::aio_t& aio = ioc->pending_aios.back();
-    if (g_conf->bdev_inject_crash &&
-	rand() % g_conf->bdev_inject_crash == 0) {
+    if (cct->_conf->bdev_inject_crash &&
+	rand() % cct->_conf->bdev_inject_crash == 0) {
       derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	   << off << "~" << len << std::dec
 	   << dendl;
@@ -483,8 +484,8 @@ int KernelDevice::aio_write(
   {
     dout(5) << __func__ << " 0x" << std::hex << off << "~" << len
 	    << std::dec << " buffered" << dendl;
-    if (g_conf->bdev_inject_crash &&
-	rand() % g_conf->bdev_inject_crash == 0) {
+    if (cct->_conf->bdev_inject_crash &&
+	rand() % cct->_conf->bdev_inject_crash == 0) {
       derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	   << off << "~" << len << std::dec << dendl;
       ++injecting_crash;

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -73,7 +73,7 @@ class KernelDevice : public BlockDevice {
   void debug_aio_unlink(FS::aio_t& aio);
 
 public:
-  KernelDevice(aio_callback_t cb, void *cbpriv);
+  KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   void aio_submit(IOContext *ioc) override;
 

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -207,7 +207,7 @@ class NVMEDevice : public BlockDevice {
   aio_callback_t aio_callback;
   void *aio_callback_priv;
 
-  NVMEDevice(aio_callback_t cb, void *cbpriv);
+  NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   bool supported_bdev_label() override { return false; }
 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -5,6 +5,7 @@
 #include "bluestore_types.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_bluestore
 #undef dout_prefix
 #define dout_prefix *_dout << "stupidalloc "

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -11,6 +11,7 @@
 #include "os/bluestore/bluestore_types.h"
 
 class StupidAllocator : public Allocator {
+  CephContext* cct;
   std::mutex lock;
 
   int64_t num_free;     ///< total bytes in freelist
@@ -24,7 +25,7 @@ class StupidAllocator : public Allocator {
   void _insert_free(uint64_t offset, uint64_t len);
 
 public:
-  StupidAllocator();
+  StupidAllocator(CephContext* cct);
   ~StupidAllocator();
 
   int reserve(uint64_t need);

--- a/src/os/bluestore/bluefs_tool.cc
+++ b/src/os/bluestore/bluefs_tool.cc
@@ -27,13 +27,13 @@ int main(int argc, char **argv)
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_UTILITY, 0);
-  common_init_finish(g_ceph_context);
-  g_ceph_context->_conf->set_val(
+  common_init_finish(cct.get());
+  cct->_conf->set_val(
     "enable_experimental_unrecoverable_data_corrupting_features",
     "*");
-  g_ceph_context->_conf->apply_changes(NULL);
+  cct->_conf->apply_changes(NULL);
 
-  BlueFS fs;
+  BlueFS fs(&(*cct));
 
   if (args.size() != 4) {
     usage(argv);

--- a/src/os/filestore/BtrfsFileStoreBackend.cc
+++ b/src/os/filestore/BtrfsFileStoreBackend.cc
@@ -43,6 +43,7 @@
 
 #if defined(__linux__)
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "btrfsfilestorebackend(" << get_basedir_path() << ") "

--- a/src/os/filestore/BtrfsFileStoreBackend.cc
+++ b/src/os/filestore/BtrfsFileStoreBackend.cc
@@ -43,7 +43,7 @@
 
 #if defined(__linux__)
 
-#define dout_context g_ceph_context
+#define dout_context cct()
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "btrfsfilestorebackend(" << get_basedir_path() << ") "
@@ -56,8 +56,8 @@ BtrfsFileStoreBackend::BtrfsFileStoreBackend(FileStore *fs):
     GenericFileStoreBackend(fs), has_clone_range(false),
     has_snap_create(false), has_snap_destroy(false),
     has_snap_create_v2(false), has_wait_sync(false), stable_commits(false),
-    m_filestore_btrfs_clone_range(g_conf->filestore_btrfs_clone_range),
-    m_filestore_btrfs_snap (g_conf->filestore_btrfs_snap) { }
+    m_filestore_btrfs_clone_range(cct()->_conf->filestore_btrfs_clone_range),
+    m_filestore_btrfs_snap (cct()->_conf->filestore_btrfs_snap) { }
 
 int BtrfsFileStoreBackend::detect_features()
 {

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -24,9 +24,11 @@
 #include "common/RWLock.h"
 
 /**
- * CollectionIndex provides an interface for manipulating indexed collections
+  CollectionIndex provides an interface for manipulating indexed collections
  */
 class CollectionIndex {
+public:
+  CephContext* cct;
 protected:
   /**
    * Object encapsulating a returned path.
@@ -175,8 +177,8 @@ protected:
   /// Call prior to removing directory
   virtual int prep_delete() { return 0; }
 
-  explicit CollectionIndex(const coll_t& collection):
-    access_lock("CollectionIndex::access_lock", true, false) {}
+  CollectionIndex(CephContext* cct, const coll_t& collection)
+    : cct(cct), access_lock("CollectionIndex::access_lock", true, false) {}
 
   /*
    * Pre-hash the collection, this collection should map to a PG folder.

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -19,6 +19,7 @@
 #include "common/config.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore "

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -19,7 +19,7 @@
 #include "common/config.h"
 #include "include/assert.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore "
@@ -149,7 +149,8 @@ string DBObjectMap::ghobject_key(const ghobject_t &oid)
 //   bad: plana8923501-10...4c.3.ffffffffffffffff.2
 // fixed: plana8923501-10...4c.3.CB767F2D.ffffffffffffffff.2
 // returns 0 for false, 1 for true, negative for error
-int DBObjectMap::is_buggy_ghobject_key_v1(const string &in)
+int DBObjectMap::is_buggy_ghobject_key_v1(CephContext* cct,
+					  const string &in)
 {
   int dots = 5;  // skip 5 .'s
   const char *s = in.c_str();
@@ -951,7 +952,7 @@ int DBObjectMap::upgrade_to_v2()
         iter->valid() && count < 300;
         iter->next()) {
       dout(20) << __func__ << " key is " << iter->key() << dendl;
-      int r = is_buggy_ghobject_key_v1(iter->key());
+      int r = is_buggy_ghobject_key_v1(cct, iter->key());
       if (r < 0) {
 	derr << __func__ << " bad key '" << iter->key() << "'" << dendl;
 	return r;

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -115,9 +115,10 @@ public:
     }
   };
 
-  explicit DBObjectMap(KeyValueDB *db) : db(db), header_lock("DBOBjectMap"),
-           	                         cache_lock("DBObjectMap::CacheLock"),
-      	                                 caches(g_conf->filestore_omap_header_cache_size)
+  DBObjectMap(CephContext* cct, KeyValueDB *db)
+    : ObjectMap(cct), db(db), header_lock("DBOBjectMap"),
+      cache_lock("DBObjectMap::CacheLock"),
+      caches(cct->_conf->filestore_omap_header_cache_size)
     {}
 
   int set_keys(

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -325,7 +325,8 @@ public:
   /// String munging (public for testing)
   static string ghobject_key(const ghobject_t &oid);
   static string ghobject_key_v0(coll_t c, const ghobject_t &oid);
-  static int is_buggy_ghobject_key_v1(const string &in);
+  static int is_buggy_ghobject_key_v1(CephContext* cct,
+				      const string &in);
 private:
   /// Implicit lock on Header->seq
   typedef ceph::shared_ptr<_Header> Header;

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -908,7 +908,7 @@ void FileJournal::queue_write_fin(uint64_t seq, Context *fin)
 void FileJournal::queue_completions_thru(uint64_t seq)
 {
   assert(finisher_lock.is_locked());
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   list<completion_item> items;
   batch_pop_completions(items);
   list<completion_item>::iterator it = items.begin();
@@ -1039,7 +1039,7 @@ void FileJournal::do_write(bufferlist& bl)
 	   << (hbp.length() ? " + header":"")
 	   << dendl;
 
-  utime_t from = ceph_clock_now(g_ceph_context);
+  utime_t from = ceph_clock_now();
 
   // entry
   off64_t pos = write_pos;
@@ -1142,7 +1142,7 @@ void FileJournal::do_write(bufferlist& bl)
 #endif
   }
 
-  utime_t lat = ceph_clock_now(g_ceph_context) - from;
+  utime_t lat = ceph_clock_now() - from;
   dout(20) << "do_write latency " << lat << dendl;
 
   write_lock.Lock();
@@ -1621,7 +1621,7 @@ void FileJournal::submit_entry(uint64_t seq, bufferlist& e, uint32_t orig_len,
 
     completions.push_back(
       completion_item(
-	seq, oncommit, ceph_clock_now(g_ceph_context), osd_op));
+	seq, oncommit, ceph_clock_now(), osd_op));
     if (writeq.empty())
       writeq_cond.Signal();
     writeq.push_back(write_item(seq, e, orig_len, osd_op));

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -41,6 +41,7 @@
 #define O_DSYNC O_SYNC
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -41,7 +41,7 @@
 #define O_DSYNC O_SYNC
 #endif
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "
@@ -164,9 +164,9 @@ int FileJournal::_open_block_device()
 	   << dendl;
   max_size = bdev_sz;
 
-  block_size = g_conf->journal_block_size;
+  block_size = cct->_conf->journal_block_size;
 
-  if (g_conf->journal_discard) {
+  if (cct->_conf->journal_discard) {
     discard = block_device_support_discard(fn.c_str());
     dout(10) << fn << " support discard: " << (int)discard << dendl;
   }
@@ -178,10 +178,10 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
 			    bool create)
 {
   int ret;
-  int64_t conf_journal_sz(g_conf->osd_journal_size);
+  int64_t conf_journal_sz(cct->_conf->osd_journal_size);
   conf_journal_sz <<= 20;
 
-  if ((g_conf->osd_journal_size == 0) && (oldsize < ONE_MEG)) {
+  if ((cct->_conf->osd_journal_size == 0) && (oldsize < ONE_MEG)) {
     derr << "I'm sorry, I don't know how large of a journal to create."
 	 << "Please specify a block device to use as the journal OR "
 	 << "set osd_journal_size in your ceph.conf" << dendl;
@@ -189,7 +189,7 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
   }
 
   if (create && (oldsize < conf_journal_sz)) {
-    uint64_t newsize(g_conf->osd_journal_size);
+    uint64_t newsize(cct->_conf->osd_journal_size);
     newsize <<= 20;
     dout(10) << "_open extending to " << newsize << " bytes" << dendl;
     ret = ::ftruncate(fd, newsize);
@@ -229,9 +229,9 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
   else {
     max_size = oldsize;
   }
-  block_size = g_conf->journal_block_size;
+  block_size = cct->_conf->journal_block_size;
 
-  if (create && g_conf->journal_zero_on_create) {
+  if (create && cct->_conf->journal_zero_on_create) {
     derr << "FileJournal::_open_file : zeroing journal" << dendl;
     uint64_t write_size = 1 << 20;
     char *buf;
@@ -313,7 +313,7 @@ int FileJournal::create()
   header.fsid = fsid;
   header.max_size = max_size;
   header.block_size = block_size;
-  if (g_conf->journal_block_align || directio)
+  if (cct->_conf->journal_block_align || directio)
     header.alignment = block_size;
   else
     header.alignment = 16;  // at least stay word aligned on 64bit machines...
@@ -352,7 +352,7 @@ int FileJournal::create()
     goto free_buf;
   }
 
-  needed_space = ((int64_t)g_conf->osd_max_write_size) << 20;
+  needed_space = ((int64_t)cct->_conf->osd_max_write_size) << 20;
   needed_space += (2 * sizeof(entry_header_t)) + get_top();
   if (header.max_size - header.start < needed_space) {
     derr << "FileJournal::create: OSD journal is not large enough to hold "
@@ -813,8 +813,8 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
   // gather queued writes
   off64_t queue_pos = write_pos;
 
-  int eleft = g_conf->journal_max_write_entries;
-  unsigned bmax = g_conf->journal_max_write_bytes;
+  int eleft = cct->_conf->journal_max_write_entries;
+  unsigned bmax = cct->_conf->journal_max_write_bytes;
 
   if (full_state != FULL_NOTFULL)
     return -ENOSPC;
@@ -865,14 +865,16 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
       }
       if (eleft) {
         if (--eleft == 0) {
-          dout(20) << "prepare_multi_write hit max events per write " << g_conf->journal_max_write_entries << dendl;
+          dout(20) << "prepare_multi_write hit max events per write "
+		   << cct->_conf->journal_max_write_entries << dendl;
           batch_unpop_write(items);
           goto out;
         }
       }
       if (bmax) {
         if (bl.length() >= bmax) {
-          dout(20) << "prepare_multi_write hit max write size " << g_conf->journal_max_write_bytes << dendl;
+          dout(20) << "prepare_multi_write hit max write size "
+		   << cct->_conf->journal_max_write_bytes << dendl;
           batch_unpop_write(items);
           goto out;
         }
@@ -1025,9 +1027,9 @@ void FileJournal::do_write(bufferlist& bl)
     return;
 
   buffer::ptr hbp;
-  if (g_conf->journal_write_header_frequency &&
+  if (cct->_conf->journal_write_header_frequency &&
       (((++journaled_since_start) %
-	g_conf->journal_write_header_frequency) == 0)) {
+	cct->_conf->journal_write_header_frequency) == 0)) {
     must_write_header = true;
   }
 
@@ -1138,7 +1140,7 @@ void FileJournal::do_write(bufferlist& bl)
       ceph_abort();
     }
 #ifdef HAVE_POSIX_FADVISE
-    if (g_conf->filestore_fadvise)
+    if (cct->_conf->filestore_fadvise)
       posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED);
 #endif
   }
@@ -1283,9 +1285,9 @@ void FileJournal::write_thread_entry()
 void FileJournal::do_aio_write(bufferlist& bl)
 {
 
-  if (g_conf->journal_write_header_frequency &&
+  if (cct->_conf->journal_write_header_frequency &&
       (((++journaled_since_start) %
-	g_conf->journal_write_header_frequency) == 0)) {
+	cct->_conf->journal_write_header_frequency) == 0)) {
     must_write_header = true;
   }
 
@@ -1535,7 +1537,7 @@ void FileJournal::check_aio_completion()
 
 int FileJournal::prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist* tbl) {
   dout(10) << "prepare_entry " << tls << dendl;
-  int data_len = g_conf->journal_align_min_size - 1;
+  int data_len = cct->_conf->journal_align_min_size - 1;
   int data_align = -1; // -1 indicates that we don't care about the alignment
   bufferlist bl;
   for (vector<ObjectStore::Transaction>::iterator p = tls.begin();
@@ -1839,11 +1841,11 @@ int FileJournal::set_throttle_params()
 {
   stringstream ss;
   bool valid = throttle.set_params(
-    g_conf->journal_throttle_low_threshhold,
-    g_conf->journal_throttle_high_threshhold,
-    g_conf->filestore_expected_throughput_bytes,
-    g_conf->journal_throttle_high_multiple,
-    g_conf->journal_throttle_max_multiple,
+    cct->_conf->journal_throttle_low_threshhold,
+    cct->_conf->journal_throttle_high_threshhold,
+    cct->_conf->filestore_expected_throughput_bytes,
+    cct->_conf->journal_throttle_high_multiple,
+    cct->_conf->journal_throttle_max_multiple,
     header.max_size - get_top(),
     &ss);
 
@@ -1954,7 +1956,7 @@ bool FileJournal::read_entry(
     derr << "Unable to read past sequence " << seq
 	 << " but header indicates the journal has committed up through "
 	 << header.committed_up_to << ", journal is corrupt" << dendl;
-    if (g_conf->journal_ignore_corruption) {
+    if (cct->_conf->journal_ignore_corruption) {
       if (corrupt)
 	*corrupt = true;
       return false;

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -31,6 +31,9 @@ using std::deque;
 # include <libaio.h>
 #endif
 
+#define dout_context g_ceph_context
+
+
 /**
  * Implements journaling on top of block device or file.
  *
@@ -536,4 +539,5 @@ private:
 
 WRITE_CLASS_ENCODER(FileJournal::header_t)
 
+#undef dout_context
 #endif

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -31,9 +31,6 @@ using std::deque;
 # include <libaio.h>
 #endif
 
-#define dout_context g_ceph_context
-
-
 /**
  * Implements journaling on top of block device or file.
  *
@@ -391,14 +388,15 @@ private:
   }
 
  public:
-  FileJournal(uuid_d fsid, Finisher *fin, Cond *sync_cond, const char *f, bool dio=false, bool ai=true, bool faio=false) :
-    Journal(fsid, fin, sync_cond),
-    finisher_lock("FileJournal::finisher_lock", false, true, false, g_ceph_context),
+  FileJournal(CephContext* cct, uuid_d fsid, Finisher *fin, Cond *sync_cond,
+	      const char *f, bool dio=false, bool ai=true, bool faio=false) :
+    Journal(cct, fsid, fin, sync_cond),
+    finisher_lock("FileJournal::finisher_lock", false, true, false, cct),
     journaled_seq(0),
     plug_journal_completions(false),
-    writeq_lock("FileJournal::writeq_lock", false, true, false, g_ceph_context),
+    writeq_lock("FileJournal::writeq_lock", false, true, false, cct),
     completions_lock(
-      "FileJournal::completions_lock", false, true, false, g_ceph_context),
+      "FileJournal::completions_lock", false, true, false, cct),
     fn(f),
     zero_buf(NULL),
     max_size(0), block_size(0),
@@ -418,30 +416,30 @@ private:
     full_state(FULL_NOTFULL),
     fd(-1),
     writing_seq(0),
-    throttle(g_conf->filestore_caller_concurrency),
-    write_lock("FileJournal::write_lock", false, true, false, g_ceph_context),
+    throttle(cct->_conf->filestore_caller_concurrency),
+    write_lock("FileJournal::write_lock", false, true, false, cct),
     write_stop(true),
     aio_stop(true),
     write_thread(this),
     write_finish_thread(this) {
 
       if (aio && !directio) {
-        derr << "FileJournal::_open_any: aio not supported without directio; disabling aio" << dendl;
+	lderr(cct) << "FileJournal::_open_any: aio not supported without directio; disabling aio" << dendl;
         aio = false;
       }
 #ifndef HAVE_LIBAIO
       if (aio) {
-        derr << "FileJournal::_open_any: libaio not compiled in; disabling aio" << dendl;
+	lderr(cct) << "FileJournal::_open_any: libaio not compiled in; disabling aio" << dendl;
         aio = false;
       }
 #endif
 
-      g_conf->add_observer(this);
+      cct->_conf->add_observer(this);
   }
   ~FileJournal() {
     assert(fd == -1);
     delete[] zero_buf;
-    g_conf->remove_observer(this);
+    cct->_conf->remove_observer(this);
   }
 
   int check();
@@ -539,5 +537,4 @@ private:
 
 WRITE_CLASS_ENCODER(FileJournal::header_t)
 
-#undef dout_context
 #endif

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1927,7 +1927,7 @@ FileStore::Op *FileStore::build_op(vector<Transaction>& tls,
   }
 
   Op *o = new Op;
-  o->start = ceph_clock_now(g_ceph_context);
+  o->start = ceph_clock_now();
   o->tls = std::move(tls);
   o->onreadable = onreadable;
   o->onreadable_sync = onreadable_sync;
@@ -2008,7 +2008,7 @@ void FileStore::_finish_op(OpSequencer *osr)
   list<Context*> to_queue;
   Op *o = osr->dequeue(&to_queue);
 
-  utime_t lat = ceph_clock_now(g_ceph_context);
+  utime_t lat = ceph_clock_now();
   lat -= o->start;
 
   dout(10) << "_finish_op " << o << " seq " << o->op << " " << *osr << "/" << osr->parent << " lat " << lat << dendl;
@@ -2064,7 +2064,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     return 0;
   }
 
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   // set up the sequencer
   OpSequencer *osr;
   assert(posr);
@@ -2125,7 +2125,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
       ceph_abort();
     }
     submit_manager.op_submit_finish(op_num);
-    utime_t end = ceph_clock_now(g_ceph_context);
+    utime_t end = ceph_clock_now();
     logger->tinc(l_filestore_queue_transaction_latency_avg, end - start);
     return 0;
   }
@@ -2153,7 +2153,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     if (ondisk)
       apply_manager.add_waiter(op_num, ondisk);
     submit_manager.op_submit_finish(op_num);
-    utime_t end = ceph_clock_now(g_ceph_context);
+    utime_t end = ceph_clock_now();
     logger->tinc(l_filestore_queue_transaction_latency_avg, end - start);
     return 0;
   }
@@ -2190,7 +2190,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   submit_manager.op_submit_finish(op);
   apply_manager.op_apply_finish(op);
 
-  utime_t end = ceph_clock_now(g_ceph_context);
+  utime_t end = ceph_clock_now();
   logger->tinc(l_filestore_queue_transaction_latency_avg, end - start);
   return r;
 }
@@ -3816,10 +3816,10 @@ void FileStore::sync_entry()
     utime_t min_interval;
     min_interval.set_from_double(m_filestore_min_sync_interval);
 
-    utime_t startwait = ceph_clock_now(g_ceph_context);
+    utime_t startwait = ceph_clock_now();
     if (!force_sync) {
       dout(20) << "sync_entry waiting for max_interval " << max_interval << dendl;
-      sync_cond.WaitInterval(g_ceph_context, lock, max_interval);
+      sync_cond.WaitInterval(lock, max_interval);
     } else {
       dout(20) << "sync_entry not waiting, force_sync set" << dendl;
     }
@@ -3832,7 +3832,7 @@ void FileStore::sync_entry()
       break;
     } else {
       // wait for at least the min interval
-      utime_t woke = ceph_clock_now(g_ceph_context);
+      utime_t woke = ceph_clock_now();
       woke -= startwait;
       dout(20) << "sync_entry woke after " << woke << dendl;
       if (woke < min_interval) {
@@ -3840,7 +3840,7 @@ void FileStore::sync_entry()
 	t -= woke;
 	dout(20) << "sync_entry waiting for another " << t
 		 << " to reach min interval " << min_interval << dendl;
-	sync_cond.WaitInterval(g_ceph_context, lock, t);
+	sync_cond.WaitInterval(lock, t);
       }
     }
 
@@ -3851,7 +3851,7 @@ void FileStore::sync_entry()
 
     op_tp.pause();
     if (apply_manager.commit_start()) {
-      utime_t start = ceph_clock_now(g_ceph_context);
+      utime_t start = ceph_clock_now();
       uint64_t cp = apply_manager.get_committing_seq();
 
       sync_entry_timeo_lock.Lock();
@@ -3928,7 +3928,7 @@ void FileStore::sync_entry()
 	}
       }
 
-      utime_t done = ceph_clock_now(g_ceph_context);
+      utime_t done = ceph_clock_now();
       utime_t lat = done - start;
       utime_t dur = done - startwait;
       dout(10) << "sync_entry commit took " << lat << ", interval was " << dur << dendl;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -90,6 +90,7 @@ using ceph::crypto::SHA1;
 #define tracepoint(...)
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore(" << basedir << ") "

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -516,8 +516,10 @@ int FileStore::lfn_unlink(const coll_t& cid, const ghobject_t& o,
   return 0;
 }
 
-FileStore::FileStore(const std::string &base, const std::string &jdev, osflagbits_t flags, const char *name, bool do_update) :
-  JournalingObjectStore(base),
+FileStore::FileStore(CephContext* cct, const std::string &base,
+		     const std::string &jdev, osflagbits_t flags,
+		     const char *name, bool do_update) :
+  JournalingObjectStore(cct, base),
   internal_name(name),
   basedir(base), journalpath(jdev),
   generic_flags(flags),
@@ -1644,7 +1646,7 @@ int FileStore::mount()
       goto close_current_fd;
     }
 
-    DBObjectMap *dbomap = new DBObjectMap(omap_store);
+    DBObjectMap *dbomap = new DBObjectMap(cct, omap_store);
     ret = dbomap->init(do_update);
     if (ret < 0) {
       delete dbomap;
@@ -2073,7 +2075,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     osr = static_cast<OpSequencer *>(posr->p.get());
     dout(5) << "queue_transactions existing " << osr << " " << *osr << dendl;
   } else {
-    osr = new OpSequencer(next_osr_id.inc());
+    osr = new OpSequencer(cct, next_osr_id.inc());
     osr->set_cct(g_ceph_context);
     osr->parent = posr;
     posr->p = osr;

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -90,7 +90,7 @@ using ceph::crypto::SHA1;
 #define tracepoint(...)
 #endif
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore(" << basedir << ") "
@@ -131,12 +131,13 @@ int FileStore::validate_hobject_key(const hobject_t &obj) const
   return len > m_filestore_max_xattr_value_size ? -ENAMETOOLONG : 0;
 }
 
-int FileStore::get_block_device_fsid(const string& path, uuid_d *fsid)
+int FileStore::get_block_device_fsid(CephContext* cct, const string& path,
+				     uuid_d *fsid)
 {
   // make sure we don't try to use aio or direct_io (and get annoying
   // error messages from failing to do so); performance implications
   // should be irrelevant for this use
-  FileJournal j(*fsid, 0, 0, path.c_str(), false, false);
+  FileJournal j(cct, *fsid, 0, 0, path.c_str(), false, false);
   return j.peek_fsid(*fsid);
 }
 
@@ -247,7 +248,7 @@ int FileStore::lfn_open(const coll_t& cid,
 
   if (create)
     flags |= O_CREAT;
-  if (g_conf->filestore_odsync_write) {
+  if (cct->_conf->filestore_odsync_write) {
     flags |= O_DSYNC;
   }
 
@@ -487,7 +488,7 @@ int FileStore::lfn_unlink(const coll_t& cid, const ghobject_t& o,
 	assert(!m_filestore_fail_eio || r != -EIO);
 	return r;
       }
-      if (g_conf->filestore_debug_inject_read_err) {
+      if (cct->_conf->filestore_debug_inject_read_err) {
 	debug_obj_on_delete(o);
       }
       if (!m_disable_wbthrottle) {
@@ -527,62 +528,62 @@ FileStore::FileStore(CephContext* cct, const std::string &base,
   fsid_fd(-1), op_fd(-1),
   basedir_fd(-1), current_fd(-1),
   backend(NULL),
-  index_manager(do_update),
+  index_manager(cct, do_update),
   lock("FileStore::lock"),
   force_sync(false),
   sync_entry_timeo_lock("FileStore::sync_entry_timeo_lock"),
-  timer(g_ceph_context, sync_entry_timeo_lock),
+  timer(cct, sync_entry_timeo_lock),
   stop(false), sync_thread(this),
-  fdcache(g_ceph_context),
-  wbthrottle(g_ceph_context),
+  fdcache(cct),
+  wbthrottle(cct),
   next_osr_id(0),
-  m_disable_wbthrottle(g_conf->filestore_odsync_write || 
-                      !g_conf->filestore_wbthrottle_enable),
-  throttle_ops(g_conf->filestore_caller_concurrency),
-  throttle_bytes(g_conf->filestore_caller_concurrency),
-  m_ondisk_finisher_num(g_conf->filestore_ondisk_finisher_threads),
-  m_apply_finisher_num(g_conf->filestore_apply_finisher_threads),
-  op_tp(g_ceph_context, "FileStore::op_tp", "tp_fstore_op", g_conf->filestore_op_threads, "filestore_op_threads"),
-  op_wq(this, g_conf->filestore_op_thread_timeout,
-	g_conf->filestore_op_thread_suicide_timeout, &op_tp),
+  m_disable_wbthrottle(cct->_conf->filestore_odsync_write ||
+                      !cct->_conf->filestore_wbthrottle_enable),
+  throttle_ops(cct->_conf->filestore_caller_concurrency),
+  throttle_bytes(cct->_conf->filestore_caller_concurrency),
+  m_ondisk_finisher_num(cct->_conf->filestore_ondisk_finisher_threads),
+  m_apply_finisher_num(cct->_conf->filestore_apply_finisher_threads),
+  op_tp(cct, "FileStore::op_tp", "tp_fstore_op", cct->_conf->filestore_op_threads, "filestore_op_threads"),
+  op_wq(this, cct->_conf->filestore_op_thread_timeout,
+	cct->_conf->filestore_op_thread_suicide_timeout, &op_tp),
   logger(NULL),
   read_error_lock("FileStore::read_error_lock"),
-  m_filestore_commit_timeout(g_conf->filestore_commit_timeout),
-  m_filestore_journal_parallel(g_conf->filestore_journal_parallel ),
-  m_filestore_journal_trailing(g_conf->filestore_journal_trailing),
-  m_filestore_journal_writeahead(g_conf->filestore_journal_writeahead),
-  m_filestore_fiemap_threshold(g_conf->filestore_fiemap_threshold),
-  m_filestore_max_sync_interval(g_conf->filestore_max_sync_interval),
-  m_filestore_min_sync_interval(g_conf->filestore_min_sync_interval),
-  m_filestore_fail_eio(g_conf->filestore_fail_eio),
-  m_filestore_fadvise(g_conf->filestore_fadvise),
+  m_filestore_commit_timeout(cct->_conf->filestore_commit_timeout),
+  m_filestore_journal_parallel(cct->_conf->filestore_journal_parallel ),
+  m_filestore_journal_trailing(cct->_conf->filestore_journal_trailing),
+  m_filestore_journal_writeahead(cct->_conf->filestore_journal_writeahead),
+  m_filestore_fiemap_threshold(cct->_conf->filestore_fiemap_threshold),
+  m_filestore_max_sync_interval(cct->_conf->filestore_max_sync_interval),
+  m_filestore_min_sync_interval(cct->_conf->filestore_min_sync_interval),
+  m_filestore_fail_eio(cct->_conf->filestore_fail_eio),
+  m_filestore_fadvise(cct->_conf->filestore_fadvise),
   do_update(do_update),
-  m_journal_dio(g_conf->journal_dio),
-  m_journal_aio(g_conf->journal_aio),
-  m_journal_force_aio(g_conf->journal_force_aio),
-  m_osd_rollback_to_cluster_snap(g_conf->osd_rollback_to_cluster_snap),
-  m_osd_use_stale_snap(g_conf->osd_use_stale_snap),
+  m_journal_dio(cct->_conf->journal_dio),
+  m_journal_aio(cct->_conf->journal_aio),
+  m_journal_force_aio(cct->_conf->journal_force_aio),
+  m_osd_rollback_to_cluster_snap(cct->_conf->osd_rollback_to_cluster_snap),
+  m_osd_use_stale_snap(cct->_conf->osd_use_stale_snap),
   m_filestore_do_dump(false),
   m_filestore_dump_fmt(true),
-  m_filestore_sloppy_crc(g_conf->filestore_sloppy_crc),
-  m_filestore_sloppy_crc_block_size(g_conf->filestore_sloppy_crc_block_size),
-  m_filestore_max_alloc_hint_size(g_conf->filestore_max_alloc_hint_size),
+  m_filestore_sloppy_crc(cct->_conf->filestore_sloppy_crc),
+  m_filestore_sloppy_crc_block_size(cct->_conf->filestore_sloppy_crc_block_size),
+  m_filestore_max_alloc_hint_size(cct->_conf->filestore_max_alloc_hint_size),
   m_fs_type(0),
   m_filestore_max_inline_xattr_size(0),
   m_filestore_max_inline_xattrs(0),
   m_filestore_max_xattr_value_size(0)
 {
-  m_filestore_kill_at.set(g_conf->filestore_kill_at);
+  m_filestore_kill_at.set(cct->_conf->filestore_kill_at);
   for (int i = 0; i < m_ondisk_finisher_num; ++i) {
     ostringstream oss;
     oss << "filestore-ondisk-" << i;
-    Finisher *f = new Finisher(g_ceph_context, oss.str(), "fn_odsk_fstore");
+    Finisher *f = new Finisher(cct, oss.str(), "fn_odsk_fstore");
     ondisk_finishers.push_back(f);
   }
   for (int i = 0; i < m_apply_finisher_num; ++i) {
     ostringstream oss;
     oss << "filestore-apply-" << i;
-    Finisher *f = new Finisher(g_ceph_context, oss.str(), "fn_appl_fstore");
+    Finisher *f = new Finisher(cct, oss.str(), "fn_appl_fstore");
     apply_finishers.push_back(f);
   }
 
@@ -595,15 +596,15 @@ FileStore::FileStore(CephContext* cct, const std::string &base,
   current_op_seq_fn = sss.str();
 
   ostringstream omss;
-  if (g_conf->filestore_omap_backend_path != "") {
-      omap_dir = g_conf->filestore_omap_backend_path;
+  if (cct->_conf->filestore_omap_backend_path != "") {
+      omap_dir = cct->_conf->filestore_omap_backend_path;
   } else {
       omss << basedir << "/current/omap";
       omap_dir = omss.str();
   }
 
   // initialize logger
-  PerfCountersBuilder plb(g_ceph_context, internal_name, l_filestore_first, l_filestore_last);
+  PerfCountersBuilder plb(cct, internal_name, l_filestore_first, l_filestore_last);
 
   plb.add_u64(l_filestore_journal_queue_ops, "journal_queue_ops", "Operations in journal queue");
   plb.add_u64(l_filestore_journal_ops, "journal_ops", "Active journal entries to be applied");
@@ -629,8 +630,8 @@ FileStore::FileStore(CephContext* cct, const std::string &base,
 
   logger = plb.create_perf_counters();
 
-  g_ceph_context->get_perfcounters_collection()->add(logger);
-  g_ceph_context->_conf->add_observer(this);
+  cct->get_perfcounters_collection()->add(logger);
+  cct->_conf->add_observer(this);
 
   superblock.compat_features = get_fs_initial_compat_set();
 }
@@ -645,8 +646,8 @@ FileStore::~FileStore()
     delete *it;
     *it = NULL;
   }
-  g_ceph_context->_conf->remove_observer(this);
-  g_ceph_context->get_perfcounters_collection()->remove(logger);
+  cct->_conf->remove_observer(this);
+  cct->get_perfcounters_collection()->remove(logger);
 
   if (journal)
     journal->logger = NULL;
@@ -682,7 +683,7 @@ void FileStore::collect_metadata(map<string,string> *pm)
   ss << "0x" << std::hex << m_fs_type << std::dec;
   (*pm)["filestore_f_type"] = ss.str();
 
-  if (g_conf->filestore_collect_device_partition_information) {
+  if (cct->_conf->filestore_collect_device_partition_information) {
     rc = get_device_by_uuid(get_fsid(), "PARTUUID", partition_path,
           dev_node);
   } else {
@@ -725,8 +726,10 @@ void FileStore::new_journal()
 {
   if (journalpath.length()) {
     dout(10) << "open_journal at " << journalpath << dendl;
-    journal = new FileJournal(fsid, &finisher, &sync_cond, journalpath.c_str(),
-			      m_journal_dio, m_journal_aio, m_journal_force_aio);
+    journal = new FileJournal(cct, fsid, &finisher, &sync_cond,
+			      journalpath.c_str(),
+			      m_journal_dio, m_journal_aio,
+			      m_journal_force_aio);
     if (journal)
       journal->logger = logger;
   }
@@ -740,7 +743,7 @@ int FileStore::dump_journal(ostream& out)
   if (!journalpath.length())
     return -EINVAL;
 
-  FileJournal *journal = new FileJournal(fsid, &finisher, &sync_cond, journalpath.c_str(), m_journal_dio);
+  FileJournal *journal = new FileJournal(cct, fsid, &finisher, &sync_cond, journalpath.c_str(), m_journal_dio);
   r = journal->dump(out);
   delete journal;
   return r;
@@ -873,7 +876,7 @@ int FileStore::mkfs()
   }
 
   // superblock
-  superblock.omap_backend = g_conf->filestore_omap_backend;
+  superblock.omap_backend = cct->_conf->filestore_omap_backend;
   ret = write_superblock();
   if (ret < 0) {
     derr << "mkfs: write_superblock() failed: "
@@ -936,7 +939,7 @@ int FileStore::mkfs()
   }
   ret = KeyValueDB::test_init(superblock.omap_backend, omap_dir);
   if (ret < 0) {
-    derr << "mkfs failed to create " << g_conf->filestore_omap_backend << dendl;
+    derr << "mkfs failed to create " << cct->_conf->filestore_omap_backend << dendl;
     goto close_fsid_fd;
   }
   // create fsid under omap
@@ -988,7 +991,7 @@ int FileStore::mkfs()
     dout(1) << "FileStore::mkfs: omap fsid is already set to " << fsid << dendl;
   }
 
-  dout(1) << g_conf->filestore_omap_backend << " db exists/created" << dendl;
+  dout(1) << cct->_conf->filestore_omap_backend << " db exists/created" << dendl;
 
   // journal?
   ret = mkjournal();
@@ -1394,7 +1397,7 @@ int FileStore::mount()
 	 << cpp_strerror(ret) << dendl;
     goto close_fsid_fd;
   } else if (ret == 0) {
-    if (do_update || (int)version_stamp < g_conf->filestore_update_to) {
+    if (do_update || (int)version_stamp < cct->_conf->filestore_update_to) {
       derr << "FileStore::mount: stale version stamp detected: "
 	   << version_stamp
 	   << ". Proceeding, do_update "
@@ -1406,7 +1409,7 @@ int FileStore::mount()
       derr << "FileStore::mount: stale version stamp " << version_stamp
 	   << ". Please run the FileStore update script before starting the "
 	   << "OSD, or set filestore_update_to to " << target_version
-	   << " (currently " << g_conf->filestore_update_to << ")"
+	   << " (currently " << cct->_conf->filestore_update_to << ")"
 	   << dendl;
       goto close_fsid_fd;
     }
@@ -1617,7 +1620,7 @@ int FileStore::mount()
 
   dout(0) << "start omap initiation" << dendl;
   if (!(generic_flags & SKIP_MOUNT_OMAP)) {
-    KeyValueDB * omap_store = KeyValueDB::create(g_ceph_context,
+    KeyValueDB * omap_store = KeyValueDB::create(cct,
 						 superblock.omap_backend,
 						 omap_dir);
     if (omap_store == NULL)
@@ -1628,7 +1631,7 @@ int FileStore::mount()
     }
 
     if (superblock.omap_backend == "rocksdb")
-      ret = omap_store->init(g_conf->filestore_rocksdb_options);
+      ret = omap_store->init(cct->_conf->filestore_rocksdb_options);
     else
       ret = omap_store->init();
 
@@ -1655,7 +1658,7 @@ int FileStore::mount()
     }
     stringstream err2;
 
-    if (g_conf->filestore_debug_omap_check && !dbomap->check(err2)) {
+    if (cct->_conf->filestore_debug_omap_check && !dbomap->check(err2)) {
       derr << err2.str() << dendl;
       delete dbomap;
       ret = -EINVAL;
@@ -1728,7 +1731,7 @@ int FileStore::mount()
     wbthrottle.start();
   } else {
     dout(0) << "mount INFO: WbThrottle is disabled" << dendl;
-    if (g_conf->filestore_odsync_write) {
+    if (cct->_conf->filestore_odsync_write) {
       dout(0) << "mount INFO: O_DSYNC write is enabled" << dendl;
     }
   }
@@ -1749,7 +1752,7 @@ int FileStore::mount()
 
   {
     stringstream err2;
-    if (g_conf->filestore_debug_omap_check && !object_map->check(err2)) {
+    if (cct->_conf->filestore_debug_omap_check && !object_map->check(err2)) {
       derr << err2.str() << dendl;
       ret = -EINVAL;
       goto stop_sync;
@@ -1771,7 +1774,7 @@ int FileStore::mount()
   timer.init();
 
   // upgrade?
-  if (g_conf->filestore_update_to >= (int)get_target_version()) {
+  if (cct->_conf->filestore_update_to >= (int)get_target_version()) {
     int err = upgrade();
     if (err < 0) {
       derr << "error converting store" << dendl;
@@ -1984,12 +1987,12 @@ void FileStore::_do_op(OpSequencer *osr, ThreadPool::TPHandle &handle)
     wbthrottle.throttle();
   }
   // inject a stall?
-  if (g_conf->filestore_inject_stall) {
-    int orig = g_conf->filestore_inject_stall;
+  if (cct->_conf->filestore_inject_stall) {
+    int orig = cct->_conf->filestore_inject_stall;
     dout(5) << "_do_op filestore_inject_stall " << orig << ", sleeping" << dendl;
-    for (int n = 0; n < g_conf->filestore_inject_stall; n++)
+    for (int n = 0; n < cct->_conf->filestore_inject_stall; n++)
       sleep(1);
-    g_conf->set_val("filestore_inject_stall", "0");
+    cct->_conf->set_val("filestore_inject_stall", "0");
     dout(5) << "_do_op done stalling" << dendl;
   }
 
@@ -2058,7 +2061,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
   ObjectStore::Transaction::collect_contexts(
     tls, &onreadable, &ondisk, &onreadable_sync);
 
-  if (g_conf->objectstore_blackhole) {
+  if (cct->_conf->objectstore_blackhole) {
     dout(0) << __func__ << " objectstore_blackhole = TRUE, dropping transaction"
 	    << dendl;
     delete ondisk;
@@ -2076,7 +2079,7 @@ int FileStore::queue_transactions(Sequencer *posr, vector<Transaction>& tls,
     dout(5) << "queue_transactions existing " << osr << " " << *osr << dendl;
   } else {
     osr = new OpSequencer(cct, next_osr_id.inc());
-    osr->set_cct(g_ceph_context);
+    osr->set_cct(cct);
     osr->parent = posr;
     posr->p = osr;
     dout(5) << "queue_transactions new " << osr << " " << *osr << dendl;
@@ -3019,7 +3022,7 @@ void FileStore::_do_transaction(
 	*_dout << dendl;
 
 	if (r == -EMFILE) {
-	  dump_open_fds(g_ceph_context);
+	  dump_open_fds(cct);
 	}
 
 	assert(0 == "unexpected error");
@@ -3064,7 +3067,7 @@ int FileStore::stat(
 	     << " = " << r
 	     << " (size " << st->st_size << ")" << dendl;
   }
-  if (g_conf->filestore_debug_inject_read_err &&
+  if (cct->_conf->filestore_debug_inject_read_err &&
       debug_mdata_eio(oid)) {
     return -EIO;
   } else {
@@ -3154,7 +3157,7 @@ int FileStore::read(
 
   dout(10) << "FileStore::read " << cid << "/" << oid << " " << offset << "~"
 	   << got << "/" << len << dendl;
-  if (g_conf->filestore_debug_inject_read_err &&
+  if (cct->_conf->filestore_debug_inject_read_err &&
       debug_data_eio(oid)) {
     return -EIO;
   } else {
@@ -3407,7 +3410,7 @@ int FileStore::_zero(const coll_t& cid, const ghobject_t& oid, uint64_t offset, 
   dout(15) << "zero " << cid << "/" << oid << " " << offset << "~" << len << dendl;
   int ret = 0;
 
-  if (g_conf->filestore_punch_hole) {
+  if (cct->_conf->filestore_punch_hole) {
 #ifdef CEPH_HAVE_FALLOCATE
 # if !defined(DARWIN) && !defined(__FreeBSD__)
 #    ifdef FALLOC_FL_KEEP_SIZE
@@ -3792,8 +3795,9 @@ int FileStore::_clone_range(const coll_t& oldcid, const ghobject_t& oldoid, cons
 
 class SyncEntryTimeout : public Context {
 public:
-  explicit SyncEntryTimeout(int commit_timeo)
-    : m_commit_timeo(commit_timeo)
+  CephContext* cct;
+  explicit SyncEntryTimeout(CephContext* cct, int commit_timeo)
+    : cct(cct), m_commit_timeo(commit_timeo)
   {
   }
 
@@ -3859,7 +3863,7 @@ void FileStore::sync_entry()
 
       sync_entry_timeo_lock.Lock();
       SyncEntryTimeout *sync_entry_timeo =
-	new SyncEntryTimeout(m_filestore_commit_timeout);
+	new SyncEntryTimeout(cct, m_filestore_commit_timeout);
       timer.add_event_after(m_filestore_commit_timeout, sync_entry_timeo);
       sync_entry_timeo_lock.Unlock();
 
@@ -3867,7 +3871,7 @@ void FileStore::sync_entry()
 
       dout(15) << "sync_entry committing " << cp << dendl;
       stringstream errstream;
-      if (g_conf->filestore_debug_omap_check && !object_map->check(errstream)) {
+      if (cct->_conf->filestore_debug_omap_check && !object_map->check(errstream)) {
 	derr << errstream.str() << dendl;
 	ceph_abort();
       }
@@ -3972,7 +3976,7 @@ void FileStore::sync_entry()
     }
 
     lock.Lock();
-    finish_contexts(g_ceph_context, fin, 0);
+    finish_contexts(cct, fin, 0);
     fin.clear();
     if (!sync_waiters.empty()) {
       dout(10) << "sync_entry more waiters, committing again" << dendl;
@@ -4049,7 +4053,7 @@ void FileStore::flush()
 {
   dout(10) << "flush" << dendl;
 
-  if (g_conf->filestore_blackhole) {
+  if (cct->_conf->filestore_blackhole) {
     // wait forever
     Mutex lock("FileStore::flush::lock");
     Cond cond;
@@ -4293,7 +4297,7 @@ int FileStore::getattr(const coll_t& _cid, const ghobject_t& oid, const char *na
  out:
   dout(10) << "getattr " << cid << "/" << oid << " '" << name << "' = " << r << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
-  if (g_conf->filestore_debug_inject_read_err &&
+  if (cct->_conf->filestore_debug_inject_read_err &&
       debug_mdata_eio(oid)) {
     return -EIO;
   } else {
@@ -4367,7 +4371,7 @@ int FileStore::getattrs(const coll_t& _cid, const ghobject_t& oid, map<string,bu
   dout(10) << "getattrs " << cid << "/" << oid << " = " << r << dendl;
   assert(!m_filestore_fail_eio || r != -EIO);
 
-  if (g_conf->filestore_debug_inject_read_err &&
+  if (cct->_conf->filestore_debug_inject_read_err &&
       debug_mdata_eio(oid)) {
     return -EIO;
   } else {
@@ -5271,7 +5275,7 @@ void FileStore::_inject_failure()
     dout(5) << "_inject_failure " << (final+1) << " -> " << final << dendl;
     if (final == 0) {
       derr << "_inject_failure KILLING" << dendl;
-      g_ceph_context->_log->flush();
+      cct->_log->flush();
       _exit(1);
     }
   }
@@ -5442,7 +5446,7 @@ int FileStore::_split_collection(const coll_t& cid,
     _close_replay_guard(cid, spos);
     _close_replay_guard(dest, spos);
   }
-  if (!r && g_conf->filestore_debug_verify_split) {
+  if (!r && cct->_conf->filestore_debug_verify_split) {
     vector<ghobject_t> objects;
     ghobject_t next;
     while (1) {
@@ -5626,21 +5630,21 @@ int FileStore::set_throttle_params()
 {
   stringstream ss;
   bool valid = throttle_bytes.set_params(
-    g_conf->filestore_queue_low_threshhold,
-    g_conf->filestore_queue_high_threshhold,
-    g_conf->filestore_expected_throughput_bytes,
-    g_conf->filestore_queue_high_delay_multiple,
-    g_conf->filestore_queue_max_delay_multiple,
-    g_conf->filestore_queue_max_bytes,
+    cct->_conf->filestore_queue_low_threshhold,
+    cct->_conf->filestore_queue_high_threshhold,
+    cct->_conf->filestore_expected_throughput_bytes,
+    cct->_conf->filestore_queue_high_delay_multiple,
+    cct->_conf->filestore_queue_max_delay_multiple,
+    cct->_conf->filestore_queue_max_bytes,
     &ss);
 
   valid &= throttle_ops.set_params(
-    g_conf->filestore_queue_low_threshhold,
-    g_conf->filestore_queue_high_threshhold,
-    g_conf->filestore_expected_throughput_ops,
-    g_conf->filestore_queue_high_delay_multiple,
-    g_conf->filestore_queue_max_delay_multiple,
-    g_conf->filestore_queue_max_ops,
+    cct->_conf->filestore_queue_low_threshhold,
+    cct->_conf->filestore_queue_high_threshhold,
+    cct->_conf->filestore_expected_throughput_ops,
+    cct->_conf->filestore_queue_high_delay_multiple,
+    cct->_conf->filestore_queue_max_delay_multiple,
+    cct->_conf->filestore_queue_max_ops,
     &ss);
 
   logger->set(l_filestore_op_queue_max_ops, throttle_ops.get_max());
@@ -5704,46 +5708,46 @@ void FileStore::set_xattr_limits_via_conf()
   switch (m_fs_type) {
 #if defined(__linux__)
   case XFS_SUPER_MAGIC:
-    fs_xattr_size = g_conf->filestore_max_inline_xattr_size_xfs;
-    fs_xattrs = g_conf->filestore_max_inline_xattrs_xfs;
-    fs_xattr_max_value_size = g_conf->filestore_max_xattr_value_size_xfs;
+    fs_xattr_size = cct->_conf->filestore_max_inline_xattr_size_xfs;
+    fs_xattrs = cct->_conf->filestore_max_inline_xattrs_xfs;
+    fs_xattr_max_value_size = cct->_conf->filestore_max_xattr_value_size_xfs;
     break;
   case BTRFS_SUPER_MAGIC:
-    fs_xattr_size = g_conf->filestore_max_inline_xattr_size_btrfs;
-    fs_xattrs = g_conf->filestore_max_inline_xattrs_btrfs;
-    fs_xattr_max_value_size = g_conf->filestore_max_xattr_value_size_btrfs;
+    fs_xattr_size = cct->_conf->filestore_max_inline_xattr_size_btrfs;
+    fs_xattrs = cct->_conf->filestore_max_inline_xattrs_btrfs;
+    fs_xattr_max_value_size = cct->_conf->filestore_max_xattr_value_size_btrfs;
     break;
 #endif
   default:
-    fs_xattr_size = g_conf->filestore_max_inline_xattr_size_other;
-    fs_xattrs = g_conf->filestore_max_inline_xattrs_other;
-    fs_xattr_max_value_size = g_conf->filestore_max_xattr_value_size_other;
+    fs_xattr_size = cct->_conf->filestore_max_inline_xattr_size_other;
+    fs_xattrs = cct->_conf->filestore_max_inline_xattrs_other;
+    fs_xattr_max_value_size = cct->_conf->filestore_max_xattr_value_size_other;
     break;
   }
 
   // Use override value if set
-  if (g_conf->filestore_max_inline_xattr_size)
-    m_filestore_max_inline_xattr_size = g_conf->filestore_max_inline_xattr_size;
+  if (cct->_conf->filestore_max_inline_xattr_size)
+    m_filestore_max_inline_xattr_size = cct->_conf->filestore_max_inline_xattr_size;
   else
     m_filestore_max_inline_xattr_size = fs_xattr_size;
 
   // Use override value if set
-  if (g_conf->filestore_max_inline_xattrs)
-    m_filestore_max_inline_xattrs = g_conf->filestore_max_inline_xattrs;
+  if (cct->_conf->filestore_max_inline_xattrs)
+    m_filestore_max_inline_xattrs = cct->_conf->filestore_max_inline_xattrs;
   else
     m_filestore_max_inline_xattrs = fs_xattrs;
 
   // Use override value if set
-  if (g_conf->filestore_max_xattr_value_size)
-    m_filestore_max_xattr_value_size = g_conf->filestore_max_xattr_value_size;
+  if (cct->_conf->filestore_max_xattr_value_size)
+    m_filestore_max_xattr_value_size = cct->_conf->filestore_max_xattr_value_size;
   else
     m_filestore_max_xattr_value_size = fs_xattr_max_value_size;
 
-  if (m_filestore_max_xattr_value_size < g_conf->osd_max_object_name_len) {
+  if (m_filestore_max_xattr_value_size < cct->_conf->osd_max_object_name_len) {
     derr << "WARNING: max attr value size ("
 	 << m_filestore_max_xattr_value_size
 	 << ") is smaller than osd_max_object_name_len ("
-	 << g_conf->osd_max_object_name_len
+	 << cct->_conf->osd_max_object_name_len
 	 << ").  Your backend filesystem appears to not support attrs large "
 	 << "enough to handle the configured max rados name size.  You may get "
 	 << "unexpected ENAMETOOLONG errors on rados operations or buggy "

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -343,8 +343,9 @@ private:
       }
     }
 
-    explicit OpSequencer(int i)
-      : qlock("FileStore::OpSequencer::qlock", false, false),
+    OpSequencer(CephContext* cct, int i)
+      : Sequencer_impl(cct),
+	qlock("FileStore::OpSequencer::qlock", false, false),
 	parent(0),
 	apply_lock("FileStore::OpSequencer::apply_lock", false, false),
         id(i) {}
@@ -438,8 +439,8 @@ public:
 		 bool force_clear_omap=false);
 
 public:
-  FileStore(const std::string &base, const std::string &jdev,
-    osflagbits_t flags = 0,
+  FileStore(CephContext* cct, const std::string &base, const std::string &jdev,
+	    osflagbits_t flags = 0,
     const char *internal_name = "filestore", bool update_to=false);
   ~FileStore();
 

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -121,8 +121,8 @@ public:
     return target_version;
   }
 
-  static int get_block_device_fsid(const string& path, uuid_d *fsid);
-
+  static int get_block_device_fsid(CephContext* cct, const string& path,
+				   uuid_d *fsid);
   struct FSPerfTracker {
     PerfCounters::avg_tracker<uint64_t> os_commit_latency;
     PerfCounters::avg_tracker<uint64_t> os_apply_latency;
@@ -314,7 +314,7 @@ private:
     void flush() {
       Mutex::Locker l(qlock);
 
-      while (g_conf->filestore_blackhole)
+      while (cct->_conf->filestore_blackhole)
 	cond.Wait(qlock);  // wait forever
 
 
@@ -830,6 +830,10 @@ protected:
 public:
   explicit FileStoreBackend(FileStore *fs) : filestore(fs) {}
   virtual ~FileStoreBackend() {}
+
+  CephContext* cct() const {
+    return filestore->cct;
+  }
 
   static FileStoreBackend *create(long f_type, FileStore *fs);
 

--- a/src/os/filestore/GenericFileStoreBackend.cc
+++ b/src/os/filestore/GenericFileStoreBackend.cc
@@ -46,6 +46,7 @@
 #define SLOPPY_CRC_XATTR "user.cephos.scrc"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "genericfilestorebackend(" << get_basedir_path() << ") "

--- a/src/os/filestore/GenericFileStoreBackend.cc
+++ b/src/os/filestore/GenericFileStoreBackend.cc
@@ -46,7 +46,7 @@
 #define SLOPPY_CRC_XATTR "user.cephos.scrc"
 
 
-#define dout_context g_ceph_context
+#define dout_context cct()
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "genericfilestorebackend(" << get_basedir_path() << ") "
@@ -60,10 +60,10 @@ GenericFileStoreBackend::GenericFileStoreBackend(FileStore *fs):
   ioctl_fiemap(false),
   seek_data_hole(false),
   use_splice(false),
-  m_filestore_fiemap(g_conf->filestore_fiemap),
-  m_filestore_seek_data_hole(g_conf->filestore_seek_data_hole),
-  m_filestore_fsync_flushes_journal_data(g_conf->filestore_fsync_flushes_journal_data),
-  m_filestore_splice(g_conf->filestore_splice) {}
+  m_filestore_fiemap(cct()->_conf->filestore_fiemap),
+  m_filestore_seek_data_hole(cct()->_conf->filestore_seek_data_hole),
+  m_filestore_fsync_flushes_journal_data(cct()->_conf->filestore_fsync_flushes_journal_data),
+  m_filestore_splice(cct()->_conf->filestore_splice) {}
 
 int GenericFileStoreBackend::detect_features()
 {

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -21,6 +21,7 @@
 
 #include "common/errno.h"
 #include "common/debug.h"
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 
 const string HashIndex::SUBDIR_ATTR = "contents";

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -21,7 +21,7 @@
 
 #include "common/errno.h"
 #include "common/debug.h"
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 
 const string HashIndex::SUBDIR_ATTR = "contents";

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -134,13 +134,14 @@ private:
 public:
   /// Constructor.
   HashIndex(
+    CephContext* cct,
     coll_t collection,     ///< [in] Collection
     const char *base_path, ///< [in] Path to the index root.
     int merge_at,          ///< [in] Merge threshhold.
     int split_multiple,	   ///< [in] Split threshhold.
     uint32_t index_version,///< [in] Index version
     double retry_probability=0) ///< [in] retry probability
-    : LFNIndex(collection, base_path, index_version, retry_probability),
+    : LFNIndex(cct, collection, base_path, index_version, retry_probability),
       merge_threshold(merge_at),
       split_multiplier(split_multiple) {}
 

--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -78,10 +78,10 @@ int IndexManager::init_index(coll_t c, const char *path, uint32_t version) {
   int r = set_version(path, version);
   if (r < 0)
     return r;
-  HashIndex index(c, path, g_conf->filestore_merge_threshold,
-		  g_conf->filestore_split_multiple,
+  HashIndex index(cct, c, path, cct->_conf->filestore_merge_threshold,
+		  cct->_conf->filestore_split_multiple,
 		  version,
-		  g_conf->filestore_index_retry_probability);
+		  cct->_conf->filestore_index_retry_probability);
   return index.init();
 }
 
@@ -100,8 +100,9 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
     case CollectionIndex::HASH_INDEX_TAG_2: // fall through
     case CollectionIndex::HOBJECT_WITH_POOL: {
       // Must be a HashIndex
-      *index = new HashIndex(c, path, g_conf->filestore_merge_threshold,
-				   g_conf->filestore_split_multiple, version);
+      *index = new HashIndex(cct, c, path,
+			     cct->_conf->filestore_merge_threshold,
+			     cct->_conf->filestore_split_multiple, version);
       return 0;
     }
     default: ceph_abort();
@@ -109,10 +110,10 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
 
   } else {
     // No need to check
-    *index = new HashIndex(c, path, g_conf->filestore_merge_threshold,
-				 g_conf->filestore_split_multiple,
-				 CollectionIndex::HOBJECT_WITH_POOL,
-				 g_conf->filestore_index_retry_probability);
+    *index = new HashIndex(cct, c, path, cct->_conf->filestore_merge_threshold,
+			   cct->_conf->filestore_split_multiple,
+			   CollectionIndex::HOBJECT_WITH_POOL,
+			   cct->_conf->filestore_index_retry_probability);
     return 0;
   }
 }

--- a/src/os/filestore/IndexManager.h
+++ b/src/os/filestore/IndexManager.h
@@ -49,6 +49,7 @@ struct Index {
  * This is enforced by using CollectionIndex::access_lock
  */
 class IndexManager {
+  CephContext* cct;
   RWLock lock; ///< Lock for Index Manager
   bool upgrade;
   ceph::unordered_map<coll_t, CollectionIndex* > col_indices;
@@ -68,8 +69,10 @@ class IndexManager {
   bool get_index_optimistic(coll_t c, Index *index);
 public:
   /// Constructor
-  explicit IndexManager(bool upgrade) : lock("IndexManager lock"),
-		    		        upgrade(upgrade) {}
+  explicit IndexManager(CephContext* cct,
+			bool upgrade) : cct(cct),
+					lock("IndexManager lock"),
+					upgrade(upgrade) {}
 
   ~IndexManager();
 

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -31,14 +31,15 @@ protected:
   uuid_d fsid;
   Finisher *finisher;
 public:
+  CephContext* cct;
   PerfCounters *logger;
 protected:
   Cond *do_sync_cond;
   bool wait_on_full;
 
 public:
-  Journal(uuid_d f, Finisher *fin, Cond *c=0) :
-    fsid(f), finisher(fin), logger(NULL),
+  Journal(CephContext* cct, uuid_d f, Finisher *fin, Cond *c=0) :
+    fsid(f), finisher(fin), cct(cct), logger(NULL),
     do_sync_cond(c),
     wait_on_full(false) { }
   virtual ~Journal() { }

--- a/src/os/filestore/JournalingObjectStore.cc
+++ b/src/os/filestore/JournalingObjectStore.cc
@@ -5,6 +5,7 @@
 #include "common/errno.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "

--- a/src/os/filestore/JournalingObjectStore.cc
+++ b/src/os/filestore/JournalingObjectStore.cc
@@ -5,7 +5,7 @@
 #include "common/errno.h"
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_journal
 #undef dout_prefix
 #define dout_prefix *_dout << "journal "
@@ -40,11 +40,12 @@ int JournalingObjectStore::journal_replay(uint64_t fs_op_seq)
 {
   dout(10) << "journal_replay fs op_seq " << fs_op_seq << dendl;
 
-  if (g_conf->journal_replay_from) {
-    dout(0) << "journal_replay forcing replay from " << g_conf->journal_replay_from
+  if (cct->_conf->journal_replay_from) {
+    dout(0) << "journal_replay forcing replay from "
+	    << cct->_conf->journal_replay_from
 	    << " instead of " << fs_op_seq << dendl;
     // the previous op is the last one committed
-    fs_op_seq = g_conf->journal_replay_from - 1;
+    fs_op_seq = cct->_conf->journal_replay_from - 1;
   }
 
   uint64_t op_seq = fs_op_seq;
@@ -124,7 +125,8 @@ uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
     dout(10) << "op_apply_start blocked, waiting" << dendl;
     blocked_cond.Wait(apply_lock);
   }
-  dout(10) << "op_apply_start " << op << " open_ops " << open_ops << " -> " << (open_ops+1) << dendl;
+  dout(10) << "op_apply_start " << op << " open_ops " << open_ops << " -> "
+	   << (open_ops+1) << dendl;
   assert(!blocked);
   assert(op > committed_seq);
   open_ops++;
@@ -134,10 +136,9 @@ uint64_t JournalingObjectStore::ApplyManager::op_apply_start(uint64_t op)
 void JournalingObjectStore::ApplyManager::op_apply_finish(uint64_t op)
 {
   Mutex::Locker l(apply_lock);
-  dout(10) << "op_apply_finish " << op << " open_ops " << open_ops
-	   << " -> " << (open_ops-1)
-	   << ", max_applied_seq " << max_applied_seq << " -> " << MAX(op, max_applied_seq)
-	   << dendl;
+  dout(10) << "op_apply_finish " << op << " open_ops " << open_ops << " -> "
+	   << (open_ops-1) << ", max_applied_seq " << max_applied_seq << " -> "
+	   << MAX(op, max_applied_seq) << dendl;
   --open_ops;
   assert(open_ops >= 0);
 
@@ -191,11 +192,11 @@ bool JournalingObjectStore::ApplyManager::commit_start()
   {
     Mutex::Locker l(apply_lock);
     dout(10) << "commit_start max_applied_seq " << max_applied_seq
-	     << ", open_ops " << open_ops
-	     << dendl;
+	     << ", open_ops " << open_ops << dendl;
     blocked = true;
     while (open_ops > 0) {
-      dout(10) << "commit_start waiting for " << open_ops << " open ops to drain" << dendl;
+      dout(10) << "commit_start waiting for " << open_ops
+	       << " open ops to drain" << dendl;
       blocked_cond.Wait(apply_lock);
     }
     assert(open_ops == 0);
@@ -227,7 +228,8 @@ void JournalingObjectStore::ApplyManager::commit_started()
 {
   Mutex::Locker l(apply_lock);
   // allow new ops. (underlying fs should now be committing all prior ops)
-  dout(10) << "commit_started committing " << committing_seq << ", unblocking" << dendl;
+  dout(10) << "commit_started committing " << committing_seq << ", unblocking"
+	   << dendl;
   blocked = false;
   blocked_cond.Signal();
 }

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -27,12 +27,13 @@ protected:
 
 
   class SubmitManager {
+    CephContext* cct;
     Mutex lock;
     uint64_t op_seq;
     uint64_t op_submitted;
   public:
-    SubmitManager() :
-      lock("JOS::SubmitManager::lock", false, true, false, g_ceph_context),
+    SubmitManager(CephContext* cct) :
+      cct(cct), lock("JOS::SubmitManager::lock", false, true, false, cct),
       op_seq(0), op_submitted(0)
     {}
     uint64_t op_submit_start();
@@ -47,6 +48,7 @@ protected:
   } submit_manager;
 
   class ApplyManager {
+    CephContext* cct;
     Journal *&journal;
     Finisher &finisher;
 
@@ -61,13 +63,13 @@ protected:
     uint64_t committing_seq, committed_seq;
 
   public:
-    ApplyManager(Journal *&j, Finisher &f) :
-      journal(j), finisher(f),
-      apply_lock("JOS::ApplyManager::apply_lock", false, true, false, g_ceph_context),
+    ApplyManager(CephContext* cct, Journal *&j, Finisher &f) :
+      cct(cct), journal(j), finisher(f),
+      apply_lock("JOS::ApplyManager::apply_lock", false, true, false, cct),
       blocked(false),
       open_ops(0),
       max_applied_seq(0),
-      com_lock("JOS::ApplyManager::com_lock", false, true, false, g_ceph_context),
+      com_lock("JOS::ApplyManager::com_lock", false, true, false, cct),
       committing_seq(0), committed_seq(0) {}
     void reset() {
       assert(open_ops == 0);
@@ -133,7 +135,8 @@ public:
     : ObjectStore(cct, path),
       journal(NULL),
       finisher(cct, "JournalObjectStore", "fn_jrn_objstore"),
-      apply_manager(journal, finisher),
+      submit_manager(cct),
+      apply_manager(cct, journal, finisher),
       replaying(false) {}
 
   ~JournalingObjectStore() {

--- a/src/os/filestore/JournalingObjectStore.h
+++ b/src/os/filestore/JournalingObjectStore.h
@@ -129,10 +129,10 @@ public:
   }
 
 public:
-  explicit JournalingObjectStore(const std::string& path)
-    : ObjectStore(path),
+  JournalingObjectStore(CephContext* cct, const std::string& path)
+    : ObjectStore(cct, path),
       journal(NULL),
-      finisher(g_ceph_context, "JournalObjectStore", "fn_jrn_objstore"),
+      finisher(cct, "JournalObjectStore", "fn_jrn_objstore"),
       apply_manager(journal, finisher),
       replaying(false) {}
 

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -35,6 +35,7 @@
 #include "LFNIndex.h"
 using ceph::crypto::SHA1;
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "LFNIndex(" << get_base_path() << ") "

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -35,7 +35,7 @@
 #include "LFNIndex.h"
 using ceph::crypto::SHA1;
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "LFNIndex(" << get_base_path() << ") "

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -127,11 +127,12 @@ private:
 public:
   /// Constructor
   LFNIndex(
+    CephContext* cct,
     coll_t collection,
     const char *base_path, ///< [in] path to Index root
     uint32_t index_version,
     double _error_injection_probability=0)
-    : CollectionIndex(collection),
+    : CollectionIndex(cct, collection),
       base_path(base_path),
       index_version(index_version),
       error_injection_enabled(false),

--- a/src/os/filestore/WBThrottle.cc
+++ b/src/os/filestore/WBThrottle.cc
@@ -171,7 +171,7 @@ void *WBThrottle::entry()
     ::fsync(**wb.get<1>());
 #endif
 #ifdef HAVE_POSIX_FADVISE
-    if (g_conf->filestore_fadvise && wb.get<2>().nocache) {
+    if (cct->_conf->filestore_fadvise && wb.get<2>().nocache) {
       int fa_r = posix_fadvise(**wb.get<1>(), 0, 0, POSIX_FADV_DONTNEED);
       assert(fa_r == 0);
     }
@@ -221,7 +221,7 @@ void WBThrottle::clear()
        i != pending_wbs.end();
        ++i) {
 #ifdef HAVE_POSIX_FADVISE
-    if (g_conf->filestore_fadvise && i->second.first.nocache) {
+    if (cct->_conf->filestore_fadvise && i->second.first.nocache) {
       int fa_r = posix_fadvise(**i->second.second, 0, 0, POSIX_FADV_DONTNEED);
       assert(fa_r == 0);
     }

--- a/src/os/filestore/XfsFileStoreBackend.cc
+++ b/src/os/filestore/XfsFileStoreBackend.cc
@@ -28,6 +28,7 @@
 #include "include/assert.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "xfsfilestorebackend(" << get_basedir_path() << ") "

--- a/src/os/filestore/XfsFileStoreBackend.cc
+++ b/src/os/filestore/XfsFileStoreBackend.cc
@@ -28,7 +28,7 @@
 #include "include/assert.h"
 #include "include/compat.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct()
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "xfsfilestorebackend(" << get_basedir_path() << ") "
@@ -106,7 +106,7 @@ int XfsFileStoreBackend::detect_features()
     goto out_close;
   }
 
-  if (g_conf->filestore_xfs_extsize) {
+  if (cct()->_conf->filestore_xfs_extsize) {
     ret = set_extsize(fd, 1U << 15); // a few pages
     if (ret) {
       ret = 0;

--- a/src/os/filestore/ZFSFileStoreBackend.cc
+++ b/src/os/filestore/ZFSFileStoreBackend.cc
@@ -36,7 +36,7 @@
 
 ZFSFileStoreBackend::ZFSFileStoreBackend(FileStore *fs) :
   GenericFileStoreBackend(fs), base_zh(NULL), current_zh(NULL),
-  m_filestore_zfs_snap(g_conf->filestore_zfs_snap)
+  m_filestore_zfs_snap(cct->_conf->filestore_zfs_snap)
 {
   int ret = zfs.init();
   if (ret < 0) {

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2075,7 +2075,7 @@ void KStore::_kv_sync_thread()
     } else {
       dout(20) << __func__ << " committing " << kv_queue.size() << dendl;
       kv_committing.swap(kv_queue);
-      utime_t start = ceph_clock_now(NULL);
+      utime_t start = ceph_clock_now();
       l.unlock();
 
       dout(30) << __func__ << " committing txc " << kv_committing << dendl;
@@ -2092,7 +2092,7 @@ void KStore::_kv_sync_thread()
       }
       int r = db->submit_transaction_sync(t);
       assert(r == 0);
-      utime_t finish = ceph_clock_now(NULL);
+      utime_t finish = ceph_clock_now();
       utime_t dur = finish - start;
       dout(20) << __func__ << " committed " << kv_committing.size()
 	       << " in " << dur << dendl;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -29,6 +29,7 @@
 #include "common/Formatter.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_kstore
 
 /*

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -29,7 +29,7 @@
 #include "common/Formatter.h"
 
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_kstore
 
 /*
@@ -249,7 +249,8 @@ static void get_coll_key_range(const coll_t& cid, int bits,
 
 static int get_key_object(const string& key, ghobject_t *oid);
 
-static void get_object_key(const ghobject_t& oid, string *key)
+static void get_object_key(CephContext* cct, const ghobject_t& oid,
+			   string *key)
 {
   key->clear();
 
@@ -458,7 +459,7 @@ void KStore::OnodeHashLRU::clear()
 }
 
 void KStore::OnodeHashLRU::rename(const ghobject_t& old_oid,
-				    const ghobject_t& new_oid)
+				  const ghobject_t& new_oid)
 {
   std::lock_guard<std::mutex> l(lock);
   dout(30) << __func__ << " " << old_oid << " -> " << new_oid << dendl;
@@ -475,14 +476,14 @@ void KStore::OnodeHashLRU::rename(const ghobject_t& old_oid,
   OnodeRef o = po->second;
 
   // install a non-existent onode it its place
-  po->second.reset(new Onode(old_oid, o->key));
+  po->second.reset(new Onode(cct, old_oid, o->key));
   lru.push_back(*po->second);
 
   // fix oid, key
   onode_map.insert(make_pair(new_oid, o));
   _touch(o);
   o->oid = new_oid;
-  get_object_key(new_oid, &o->key);
+  get_object_key(cct, new_oid, &o->key);
 }
 
 bool KStore::OnodeHashLRU::get_next(
@@ -563,7 +564,7 @@ KStore::Collection::Collection(KStore *ns, coll_t c)
   : store(ns),
     cid(c),
     lock("KStore::Collection::lock", true, false),
-    onode_map()
+    onode_map(store->cct)
 {
 }
 
@@ -576,8 +577,8 @@ KStore::OnodeRef KStore::Collection::get_onode(
   spg_t pgid;
   if (cid.is_pg(&pgid)) {
     if (!oid.match(cnode.bits, pgid.ps())) {
-      derr << __func__ << " oid " << oid << " not part of " << pgid
-	   << " bits " << cnode.bits << dendl;
+      lderr(store->cct) << __func__ << " oid " << oid << " not part of "
+			<< pgid << " bits " << cnode.bits << dendl;
       ceph_abort();
     }
   }
@@ -587,14 +588,14 @@ KStore::OnodeRef KStore::Collection::get_onode(
     return o;
 
   string key;
-  get_object_key(oid, &key);
+  get_object_key(store->cct, oid, &key);
 
-  dout(20) << __func__ << " oid " << oid << " key "
-	   << pretty_binary_string(key) << dendl;
+  ldout(store->cct, 20) << __func__ << " oid " << oid << " key "
+			<< pretty_binary_string(key) << dendl;
 
   bufferlist v;
   int r = store->db->get(PREFIX_OBJ, key, &v);
-  dout(20) << " r " << r << " v.len " << v.length() << dendl;
+  ldout(store->cct, 20) << " r " << r << " v.len " << v.length() << dendl;
   Onode *on;
   if (v.length() == 0) {
     assert(r == -ENOENT);
@@ -602,12 +603,12 @@ KStore::OnodeRef KStore::Collection::get_onode(
       return OnodeRef();
 
     // new
-    on = new Onode(oid, key);
+    on = new Onode(store->cct, oid, key);
     on->dirty = true;
   } else {
     // loaded
     assert(r >=0);
-    on = new Onode(oid, key);
+    on = new Onode(store->cct, oid, key);
     on->exists = true;
     bufferlist::iterator p = v.begin();
     ::decode(on->onode, p);
@@ -654,7 +655,7 @@ KStore::~KStore()
 void KStore::_init_logger()
 {
   // XXX
-  PerfCountersBuilder b(g_ceph_context, "KStore",
+  PerfCountersBuilder b(cct, "KStore",
                         l_kstore_first, l_kstore_last);
   b.add_time_avg(l_kstore_state_prepare_lat, "state_prepare_lat", "Average prepare state latency");
   b.add_time_avg(l_kstore_state_kv_queued_lat, "state_kv_queued_lat", "Average kv_queued state latency");
@@ -662,13 +663,13 @@ void KStore::_init_logger()
   b.add_time_avg(l_kstore_state_finishing_lat, "state_finishing_lat", "Average finishing state latency");
   b.add_time_avg(l_kstore_state_done_lat, "state_done_lat", "Average done state latency");
   logger = b.create_perf_counters();
-  g_ceph_context->get_perfcounters_collection()->add(logger);
+  cct->get_perfcounters_collection()->add(logger);
 }
 
 void KStore::_shutdown_logger()
 {
   // XXX
-  g_ceph_context->get_perfcounters_collection()->remove(logger);
+  cct->get_perfcounters_collection()->remove(logger);
   delete logger;
 }
 
@@ -804,7 +805,7 @@ int KStore::_open_db(bool create)
 
   string kv_backend;
   if (create) {
-    kv_backend = g_conf->kstore_backend;
+    kv_backend = cct->_conf->kstore_backend;
   } else {
     r = read_meta("kv_backend", &kv_backend);
     if (r < 0) {
@@ -838,16 +839,14 @@ int KStore::_open_db(bool create)
     }
   }
 
-  db = KeyValueDB::create(g_ceph_context,
-			  kv_backend,
-			  fn);
+  db = KeyValueDB::create(cct, kv_backend, fn);
   if (!db) {
     derr << __func__ << " error creating db" << dendl;
     return -EIO;
   }
   string options;
   if (kv_backend == "rocksdb")
-    options = g_conf->kstore_rocksdb_options;
+    options = cct->_conf->kstore_rocksdb_options;
   db->init(options);
   stringstream err;
   if (create)
@@ -945,7 +944,7 @@ int KStore::mkfs()
   if (r < 0)
     goto out_close_fsid;
 
-  r = write_meta("kv_backend", g_conf->kstore_backend);
+  r = write_meta("kv_backend", cct->_conf->kstore_backend);
   if (r < 0)
     goto out_close_db;
 
@@ -973,8 +972,8 @@ int KStore::mount()
 {
   dout(1) << __func__ << " path " << path << dendl;
 
-  if (g_conf->kstore_fsck_on_mount) {
-    int rc = fsck(g_conf->kstore_fsck_on_mount_deep);
+  if (cct->_conf->kstore_fsck_on_mount) {
+    int rc = fsck(cct->_conf->kstore_fsck_on_mount_deep);
     if (rc < 0)
       return rc;
   }
@@ -1472,7 +1471,7 @@ int KStore::_collection_list(
     temp = true;
   } else {
     string k;
-    get_object_key(start, &k);
+    get_object_key(cct, start, &k);
     if (start.hobj.is_temp()) {
       temp = true;
       assert(k >= temp_start_key && k < temp_end_key);
@@ -1487,7 +1486,7 @@ int KStore::_collection_list(
   if (end.hobj.is_max()) {
     pend = temp ? temp_end_key : end_key;
   } else {
-    get_object_key(end, &end_key);
+    get_object_key(cct, end, &end_key);
     if (end.hobj.is_temp()) {
       if (temp)
 	pend = end_key;
@@ -1886,7 +1885,7 @@ void KStore::_assign_nid(TransContext *txc, OnodeRef o)
   o->onode.nid = ++nid_last;
   dout(20) << __func__ << " " << o->oid << " nid " << o->onode.nid << dendl;
   if (nid_last > nid_max) {
-    nid_max += g_conf->kstore_nid_prealloc;
+    nid_max += cct->_conf->kstore_nid_prealloc;
     bufferlist bl;
     ::encode(nid_max, bl);
     txc->t->set(PREFIX_SUPER, "nid_max", bl);
@@ -1912,9 +1911,9 @@ void KStore::_txc_state_proc(TransContext *txc)
     case TransContext::STATE_PREPARE:
       txc->log_state_latency(logger, l_kstore_state_prepare_lat);
       txc->state = TransContext::STATE_KV_QUEUED;
-      if (!g_conf->kstore_sync_transaction) {
+      if (!cct->_conf->kstore_sync_transaction) {
 	std::lock_guard<std::mutex> l(kv_lock);
-	if (g_conf->kstore_sync_submit_transaction) {
+	if (cct->_conf->kstore_sync_submit_transaction) {
           int r = db->submit_transaction(txc->t);
 	  assert(r == 0);
 	}
@@ -2047,7 +2046,7 @@ void KStore::_osr_reap_done(OpSequencer *osr)
     }
 
     if (txc->first_collection) {
-      txc->first_collection->onode_map.trim(g_conf->kstore_onode_map_size);
+      txc->first_collection->onode_map.trim(cct->_conf->kstore_onode_map_size);
     }
 
     osr->q.pop_front();
@@ -2082,7 +2081,7 @@ void KStore::_kv_sync_thread()
 
       // one transaction to force a sync
       KeyValueDB::Transaction t = db->get_transaction();
-      if (!g_conf->kstore_sync_submit_transaction) {
+      if (!cct->_conf->kstore_sync_submit_transaction) {
 	for (std::deque<TransContext *>::iterator it = kv_committing.begin();
 	     it != kv_committing.end();
 	     ++it) {
@@ -2614,7 +2613,7 @@ int KStore::_do_write(TransContext *txc,
 
   uint64_t stripe_size = o->onode.stripe_size;
   if (!stripe_size) {
-    o->onode.stripe_size = g_conf->kstore_default_stripe_size;
+    o->onode.stripe_size = cct->_conf->kstore_default_stripe_size;
     stripe_size = o->onode.stripe_size;
   }
 
@@ -2844,7 +2843,7 @@ int KStore::_do_remove(TransContext *txc,
   o->exists = false;
   o->onode = kstore_onode_t();
   txc->onodes.erase(o);
-  get_object_key(o->oid, &key);
+  get_object_key(cct, o->oid, &key);
   txc->t->rmkey(PREFIX_OBJ, key);
   return 0;
 }

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -625,8 +625,7 @@ KStore::OnodeRef KStore::Collection::get_onode(
 #define dout_prefix *_dout << "kstore(" << path << ") "
 
 KStore::KStore(CephContext *cct, const string& path)
-  : ObjectStore(path),
-    cct(cct),
+  : ObjectStore(cct, path),
     db(NULL),
     path_fd(-1),
     fsid_fd(-1),
@@ -2135,7 +2134,7 @@ int KStore::queue_transactions(
     osr = static_cast<OpSequencer *>(posr->p.get());
     dout(10) << __func__ << " existing " << osr << " " << *osr << dendl;
   } else {
-    osr = new OpSequencer;
+    osr = new OpSequencer(cct);
     osr->parent = posr;
     posr->p = osr;
     dout(10) << __func__ << " new " << osr << " " << *osr << dendl;

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -638,7 +638,7 @@ KStore::KStore(CephContext *cct, const string& path)
     finisher(cct),
     kv_sync_thread(this),
     kv_stop(false),
-    logger(NULL)
+    logger(nullptr)
 {
   _init_logger();
 }

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -207,8 +207,8 @@ public:
       return "???";
     }
 
-    void log_state_latency(PerfCounters *logger, int state) {      
-        utime_t lat, now = ceph_clock_now(g_ceph_context);
+    void log_state_latency(PerfCounters *logger, int state) {
+        utime_t lat, now = ceph_clock_now();
         lat = now - start;
         logger->tinc(state, lat);
         start = now;
@@ -237,7 +237,7 @@ public:
 	oncommit(NULL),
 	onreadable(NULL),
 	onreadable_sync(NULL),
-        start(ceph_clock_now(g_ceph_context)){
+        start(ceph_clock_now()){
       //cout << "txc new " << this << std::endl;
     }
     ~TransContext() {

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -57,6 +57,7 @@ public:
 
   /// an in-memory object
   struct Onode {
+    CephContext* cct;
     std::atomic_int nref;  ///< reference count
 
     ghobject_t oid;
@@ -76,8 +77,9 @@ public:
 
     map<uint64_t,bufferlist> pending_stripes;  ///< unwritten stripes
 
-    Onode(const ghobject_t& o, const string& k)
-      : nref(0),
+    Onode(CephContext* cct, const ghobject_t& o, const string& k)
+      : cct(cct),
+	nref(0),
 	oid(o),
 	key(k),
 	dirty(false),
@@ -104,6 +106,7 @@ public:
   typedef boost::intrusive_ptr<Onode> OnodeRef;
 
   struct OnodeHashLRU {
+    CephContext* cct;
     typedef boost::intrusive::list<
       Onode,
       boost::intrusive::member_hook<
@@ -115,7 +118,7 @@ public:
     ceph::unordered_map<ghobject_t,OnodeRef> onode_map;  ///< forward lookups
     lru_list_t lru;                                      ///< lru
 
-    OnodeHashLRU() {}
+    OnodeHashLRU(CephContext* cct) : cct(cct) {}
 
     void add(const ghobject_t& oid, OnodeRef o);
     void _touch(OnodeRef o);

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -263,9 +263,10 @@ public:
 
     Sequencer *parent;
 
-    OpSequencer()
+    OpSequencer(CephContext* cct)
 	//set the qlock to PTHREAD_MUTEX_RECURSIVE mode
-      : parent(NULL) {
+      : Sequencer_impl(cct),
+	parent(NULL) {
     }
     ~OpSequencer() {
       assert(q.empty());
@@ -309,7 +310,6 @@ public:
   // --------------------------------------------------------
   // members
 private:
-  CephContext *cct;
   KeyValueDB *db;
   uuid_d fsid;
   int path_fd;  ///< open handle to $path

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -29,6 +29,7 @@
 #include "MemStore.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "memstore(" << path << ") "

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -679,6 +679,8 @@ int MemStore::queue_transactions(Sequencer *osr,
   // Sequencer with a mutex. this guarantees ordering on a given sequencer,
   // while allowing operations on different sequencers to happen in parallel
   struct OpSequencer : public Sequencer_impl {
+    OpSequencer(CephContext* cct) :
+      Sequencer_impl(cct) {}
     std::mutex mutex;
     void flush() override {}
     bool flush_commit(Context*) override { return true; }
@@ -687,7 +689,7 @@ int MemStore::queue_transactions(Sequencer *osr,
   std::unique_lock<std::mutex> lock;
   if (osr) {
     if (!osr->p) {
-      osr->p = new OpSequencer();
+      osr->p = new OpSequencer(cct);
     }
     auto seq = static_cast<OpSequencer*>(osr->p.get());
     lock = std::unique_lock<std::mutex>(seq->mutex);

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -29,7 +29,7 @@
 #include "MemStore.h"
 #include "include/compat.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "memstore(" << path << ") "
@@ -225,10 +225,10 @@ int MemStore::statfs(struct store_statfs_t *st)
 {
    dout(10) << __func__ << dendl;
   st->reset();
-  st->total = g_conf->memstore_device_bytes;
+  st->total = cct->_conf->memstore_device_bytes;
   st->available = MAX(int64_t(st->total) - int64_t(used_bytes), 0ll);
   dout(10) << __func__ << ": used_bytes: " << used_bytes
-	   << "/" << g_conf->memstore_device_bytes << dendl;
+	   << "/" << cct->_conf->memstore_device_bytes << dendl;
   return 0;
 }
 

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -30,9 +30,6 @@
 #include "include/assert.h"
 
 class MemStore : public ObjectStore {
-private:
-  CephContext *const cct;
-
 public:
   struct Object : public RefCountedObject {
     std::mutex xattr_mutex;
@@ -241,8 +238,7 @@ private:
 
 public:
   MemStore(CephContext *cct, const string& path)
-    : ObjectStore(path),
-      cct(cct),
+    : ObjectStore(cct, path),
       coll_lock("MemStore::coll_lock"),
       finisher(cct),
       used_bytes(0) {}

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -17,6 +17,7 @@
 #include "common/config.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix *_dout

--- a/src/osd/ClassHandler.cc
+++ b/src/osd/ClassHandler.cc
@@ -17,7 +17,6 @@
 #include "common/config.h"
 #include "common/debug.h"
 
-#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix *_dout
@@ -52,7 +51,7 @@ int ClassHandler::open_class(const string& cname, ClassData **pcls)
 
 int ClassHandler::open_all_classes()
 {
-  dout(10) << __func__ << dendl;
+  ldout(cct, 10) << __func__ << dendl;
   DIR *dir = ::opendir(cct->_conf->osd_class_dir.c_str());
   if (!dir)
     return -errno;
@@ -68,7 +67,7 @@ int ClassHandler::open_all_classes()
       char cname[PATH_MAX + 1];
       strncpy(cname, pde->d_name + sizeof(CLS_PREFIX) - 1, sizeof(cname) -1);
       cname[strlen(cname) - (sizeof(CLS_SUFFIX) - 1)] = '\0';
-      dout(10) << __func__ << " found " << cname << dendl;
+      ldout(cct, 10) << __func__ << " found " << cname << dendl;
       ClassData *cls;
       // skip classes that aren't in 'osd class load list'
       r = open_class(cname, &cls);
@@ -123,11 +122,11 @@ ClassHandler::ClassData *ClassHandler::_get_class(const string& cname,
     cls = &iter->second;
   } else {
     if (check_allowed && !in_class_list(cname, cct->_conf->osd_class_load_list)) {
-      dout(0) << "_get_class not permitted to load " << cname << dendl;
+      ldout(cct, 0) << "_get_class not permitted to load " << cname << dendl;
       return NULL;
     }
     cls = &classes[cname];
-    dout(10) << "_get_class adding new class name " << cname << " " << cls << dendl;
+    ldout(cct, 10) << "_get_class adding new class name " << cname << " " << cls << dendl;
     cls->name = cname;
     cls->handler = this;
     cls->whitelisted = in_class_list(cname, cct->_conf->osd_class_default_list);
@@ -147,7 +146,7 @@ int ClassHandler::_load_class(ClassData *cls)
     snprintf(fname, sizeof(fname), "%s/" CLS_PREFIX "%s" CLS_SUFFIX,
 	     cct->_conf->osd_class_dir.c_str(),
 	     cls->name.c_str());
-    dout(10) << "_load_class " << cls->name << " from " << fname << dendl;
+    ldout(cct, 10) << "_load_class " << cls->name << " from " << fname << dendl;
 
     cls->handle = dlopen(fname, RTLD_NOW);
     if (!cls->handle) {
@@ -155,12 +154,12 @@ int ClassHandler::_load_class(ClassData *cls)
       int r = ::stat(fname, &st);
       if (r < 0) {
         r = -errno;
-        dout(0) << __func__ << " could not stat class " << fname
-                << ": " << cpp_strerror(r) << dendl;
+	ldout(cct, 0) << __func__ << " could not stat class " << fname
+		      << ": " << cpp_strerror(r) << dendl;
       } else {
-	dout(0) << "_load_class could not open class " << fname
-      	        << " (dlopen failed): " << dlerror() << dendl;
-      	r = -EIO;
+	ldout(cct, 0) << "_load_class could not open class " << fname
+		      << " (dlopen failed): " << dlerror() << dendl;
+	r = -EIO;
       }
       cls->status = ClassData::CLASS_MISSING;
       return r;
@@ -191,19 +190,19 @@ int ClassHandler::_load_class(ClassData *cls)
       cls->status = ClassData::CLASS_MISSING_DEPS;
       return r;
     }
-    
-    dout(10) << "_load_class " << cls->name << " satisfied dependency " << dc->name << dendl;
+
+    ldout(cct, 10) << "_load_class " << cls->name << " satisfied dependency " << dc->name << dendl;
     cls->missing_dependencies.erase(p++);
   }
-  
+
   // initialize
   void (*cls_init)() = (void (*)())dlsym(cls->handle, "__cls_init");
   if (cls_init) {
     cls->status = ClassData::CLASS_INITIALIZING;
     cls_init();
   }
-  
-  dout(10) << "_load_class " << cls->name << " success" << dendl;
+
+  ldout(cct, 10) << "_load_class " << cls->name << " success" << dendl;
   cls->status = ClassData::CLASS_OPEN;
   return 0;
 }
@@ -215,10 +214,10 @@ ClassHandler::ClassData *ClassHandler::register_class(const char *cname)
   assert(mutex.is_locked());
 
   ClassData *cls = _get_class(cname, false);
-  dout(10) << "register_class " << cname << " status " << cls->status << dendl;
+  ldout(cct, 10) << "register_class " << cname << " status " << cls->status << dendl;
 
   if (cls->status != ClassData::CLASS_INITIALIZING) {
-    dout(0) << "class " << cname << " isn't loaded; is the class registering under the wrong name?" << dendl;
+    ldout(cct, 0) << "class " << cname << " isn't loaded; is the class registering under the wrong name?" << dendl;
     return NULL;
   }
   return cls;
@@ -235,11 +234,12 @@ ClassHandler::ClassMethod *ClassHandler::ClassData::register_method(const char *
 {
   /* no need for locking, called under the class_init mutex */
   if (!flags) {
-    derr << "register_method " << name << "." << mname << " flags " << flags << " " << (void*)func
-	 << " FAILED -- flags must be non-zero" << dendl;
+    lderr(handler->cct) << "register_method " << name << "." << mname
+			<< " flags " << flags << " " << (void*)func
+			<< " FAILED -- flags must be non-zero" << dendl;
     return NULL;
   }
-  dout(10) << "register_method " << name << "." << mname << " flags " << flags << " " << (void*)func << dendl;
+  ldout(handler->cct, 10) << "register_method " << name << "." << mname << " flags " << flags << " " << (void*)func << dendl;
   ClassMethod& method = methods_map[mname];
   method.func = func;
   method.name = mname;
@@ -253,7 +253,7 @@ ClassHandler::ClassMethod *ClassHandler::ClassData::register_cxx_method(const ch
 									cls_method_cxx_call_t func)
 {
   /* no need for locking, called under the class_init mutex */
-  dout(10) << "register_cxx_method " << name << "." << mname << " flags " << flags << " " << (void*)func << dendl;
+  ldout(handler->cct, 10) << "register_cxx_method " << name << "." << mname << " flags " << flags << " " << (void*)func << dendl;
   ClassMethod& method = methods_map[mname];
   method.cxx_func = func;
   method.name = mname;

--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -1,3 +1,5 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
 #ifndef CEPH_CLASSHANDLER_H
 #define CEPH_CLASSHANDLER_H
 

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -26,6 +26,7 @@
 
 #include "PrimaryLogPG.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -26,7 +26,7 @@
 
 #include "PrimaryLogPG.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix
@@ -197,8 +197,7 @@ ECBackend::ECBackend(
   CephContext *cct,
   ErasureCodeInterfaceRef ec_impl,
   uint64_t stripe_width)
-  : PGBackend(pg, store, coll, ch),
-    cct(cct),
+  : PGBackend(cct, pg, store, coll, ch),
     ec_impl(ec_impl),
     sinfo(ec_impl->get_data_chunk_count(), stripe_width) {
   assert((ec_impl->get_data_chunk_count() *

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -559,7 +559,6 @@ public:
   bool try_finish_rmw();
   void check_ops();
 
-  CephContext *cct;
   ErasureCodeInterfaceRef ec_impl;
 
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -149,6 +149,7 @@
 #define tracepoint(...)
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, whoami, get_osdmap_epoch())

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -241,7 +241,7 @@ OSDService::OSDService(OSD *osd) :
   agent_stop_flag(false),
   agent_timer_lock("OSDService::agent_timer_lock"),
   agent_timer(osd->client_messenger->cct, agent_timer_lock),
-  last_recalibrate(ceph_clock_now(NULL)),
+  last_recalibrate(ceph_clock_now()),
   promote_max_objects(0),
   promote_max_bytes(0),
   objecter(new Objecter(osd->client_messenger->cct, osd->objecter_messenger, osd->monc, NULL, 0, 0)),
@@ -612,7 +612,7 @@ void OSDService::agent_stop()
 
 void OSDService::promote_throttle_recalibrate()
 {
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   double dur = now - last_recalibrate;
   last_recalibrate = now;
   unsigned prob = promote_probability_millis;
@@ -702,7 +702,7 @@ void OSDService::check_nearfull_warning(const osd_stat_t &osd_stat)
   Mutex::Locker l(full_status_lock);
   enum s_names new_state;
 
-  time_t now = ceph_clock_gettime(NULL);
+  time_t now = ceph_clock_gettime();
 
   // We base ratio on kb_avail rather than kb_used because they can
   // differ significantly e.g. on btrfs volumes with a large number of
@@ -1164,10 +1164,10 @@ bool OSDService::prepare_to_stop()
 					      osdmap->get_epoch(),
 					      true  // request ack
 					      ));
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     utime_t timeout;
     timeout.set_from_double(now + cct->_conf->osd_mon_shutdown_timeout);
-    while ((ceph_clock_now(cct) < timeout) &&
+    while ((ceph_clock_now() < timeout) &&
        (get_state() != STOPPING)) {
       is_stopping_cond.WaitUntil(is_stopping_lock, timeout);
     }
@@ -1462,7 +1462,7 @@ void OSDService::queue_for_snap_trim(PG *pg) {
 	PGSnapTrim(pg->get_osdmap()->get_epoch()),
 	cct->_conf->osd_snap_trim_cost,
 	cct->_conf->osd_snap_trim_priority,
-	ceph_clock_now(cct),
+	ceph_clock_now(),
 	entity_inst_t())));
 }
 
@@ -2207,7 +2207,7 @@ int OSD::init()
   mgrc.set_pgstats_cb([this](){
       RWLock::RLocker l(map_lock);
       
-      utime_t had_for = ceph_clock_now(cct) - had_map_since;
+      utime_t had_for = ceph_clock_now() - had_map_since;
       osd_stat_t cur_stat = service.get_osd_stat();
       cur_stat.os_perf_stat = store->get_cur_stats();
 
@@ -3926,7 +3926,7 @@ void OSD::maybe_update_heartbeat_peers()
   assert(osd_lock.is_locked());
 
   if (is_waiting_for_healthy()) {
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     if (last_heartbeat_resample == utime_t()) {
       last_heartbeat_resample = now;
       heartbeat_set_peers_need_update();
@@ -4151,7 +4151,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	  i->second.last_rx_front = m->stamp;
 	}
 
-        utime_t cutoff = ceph_clock_now(cct);
+        utime_t cutoff = ceph_clock_now();
         cutoff -= cct->_conf->osd_heartbeat_grace;
         if (i->second.is_healthy(cutoff)) {
           // Cancel false reports
@@ -4209,7 +4209,7 @@ void OSD::heartbeat_entry()
     utime_t w;
     w.set_from_double(wait);
     dout(30) << "heartbeat_entry sleeping for " << wait << dendl;
-    heartbeat_cond.WaitInterval(cct, heartbeat_lock, w);
+    heartbeat_cond.WaitInterval(heartbeat_lock, w);
     if (is_stopping())
       return;
     dout(30) << "heartbeat_entry woke up" << dendl;
@@ -4219,7 +4219,7 @@ void OSD::heartbeat_entry()
 void OSD::heartbeat_check()
 {
   assert(heartbeat_lock.is_locked());
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   // check for heartbeat replies (move me elsewhere?)
   utime_t cutoff = now;
@@ -4285,7 +4285,7 @@ void OSD::heartbeat()
 
   dout(5) << "heartbeat: " << service.get_osd_stat() << dendl;
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   // send heartbeats
   for (map<int,HeartbeatInfo>::iterator i = heartbeat_peers.begin();
@@ -4419,7 +4419,7 @@ void OSD::tick_without_osd_lock()
     // mon report?
     bool reset = false;
     bool report = false;
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     pg_stat_queue_lock.Lock();
     double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
     double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;
@@ -4676,7 +4676,7 @@ void TestOpsSocketHook::test_ops(OSDService *service, ObjectStore *store,
       double scrub_max_interval = pool_scrub_max_interval > 0 ?
         pool_scrub_max_interval : g_conf->osd_scrub_max_interval;
       // Instead of marking must_scrub force a schedule scrub
-      utime_t stamp = ceph_clock_now(service->cct);
+      utime_t stamp = ceph_clock_now();
       stamp -= scrub_max_interval;
       stamp -=  100.0;  // push back last scrub more for good measure
       pg->info.history.last_scrub_stamp = stamp;
@@ -4825,7 +4825,7 @@ void OSD::ms_handle_connect(Connection *con)
       map_lock.get_read();
       Mutex::Locker l2(mon_report_lock);
 
-      utime_t now = ceph_clock_now(NULL);
+      utime_t now = ceph_clock_now();
       last_mon_report = now;
 
       // resend everything, it's a new session
@@ -5013,7 +5013,7 @@ bool OSD::_is_healthy()
 
   if (is_waiting_for_healthy()) {
     Mutex::Locker l(heartbeat_lock);
-    utime_t cutoff = ceph_clock_now(cct);
+    utime_t cutoff = ceph_clock_now();
     cutoff -= cct->_conf->osd_heartbeat_grace;
     int num = 0, up = 0;
     for (map<int,HeartbeatInfo>::iterator p = heartbeat_peers.begin();
@@ -5222,7 +5222,7 @@ void OSD::send_failures()
   assert(map_lock.is_locked());
   assert(mon_report_lock.is_locked());
   Mutex::Locker l(heartbeat_lock);
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   while (!failure_queue.empty()) {
     int osd = failure_queue.begin()->first;
     entity_inst_t i = osdmap->get_inst(osd);
@@ -5289,7 +5289,7 @@ void OSD::send_pg_stats(const utime_t &now)
     }
 
     if (last_pg_stats_ack == utime_t() || !outstanding_pg_stats.empty()) {
-      last_pg_stats_ack = ceph_clock_now(cct);
+      last_pg_stats_ack = ceph_clock_now();
     }
     outstanding_pg_stats.insert(tid);
     dout(20) << __func__ << "  updates pending: " << outstanding_pg_stats << dendl;
@@ -5314,7 +5314,7 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
 
   pg_stat_queue_lock.Lock();
 
-  last_pg_stats_ack = ceph_clock_now(cct);
+  last_pg_stats_ack = ceph_clock_now();
 
   // decay timeout slowly (analogous to TCP)
   stats_ack_timeout =
@@ -5366,7 +5366,7 @@ void OSD::flush_pg_stats()
 {
   dout(10) << "flush_pg_stats" << dendl;
   osd_lock.Unlock();
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   map_lock.get_read();
   mon_report_lock.Lock();
   send_pg_stats(now);
@@ -5763,7 +5763,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       }
     }
 
-    utime_t start = ceph_clock_now(cct);
+    utime_t start = ceph_clock_now();
     for (int64_t pos = 0; pos < count; pos += bsize) {
       char nm[30];
       unsigned offset = 0;
@@ -5788,7 +5788,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
 	waiter.wait();
       }
     }
-    utime_t end = ceph_clock_now(cct);
+    utime_t end = ceph_clock_now();
 
     // clean up
     store->queue_transaction(osr.get(), std::move(cleanupt), NULL);
@@ -6620,7 +6620,7 @@ void OSD::sched_scrub()
     return;
   }
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   bool time_permit = scrub_time_permit(now);
   bool load_is_low = scrub_load_below_threshold();
   dout(20) << "sched_scrub load_is_low=" << (int)load_is_low << dendl;
@@ -7076,7 +7076,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
     }
   }
 
-  had_map_since = ceph_clock_now(cct);
+  had_map_since = ceph_clock_now();
 
   epoch_t _bind_epoch = service.get_bind_epoch();
   if (osdmap->is_up(whoami) &&
@@ -7151,7 +7151,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	do_restart = true;
 
 	//add markdown log
-	utime_t now = ceph_clock_now(g_ceph_context);
+	utime_t now = ceph_clock_now();
 	utime_t grace = utime_t(g_conf->osd_max_markdown_period, 0);
 	osd_markdown_log.push_back(now);
 	//clear all out-of-date log
@@ -8454,7 +8454,7 @@ void OSD::check_replay_queue()
 {
   assert(osd_lock.is_locked());
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   list< pair<spg_t,utime_t> > pgids;
   replay_queue_lock.Lock();
   while (!replay_queue.empty() &&
@@ -8514,7 +8514,7 @@ bool OSDService::_recover_now(uint64_t *available_pushes)
   if (available_pushes)
     *available_pushes = max - recovery_ops_active - recovery_ops_reserved;
 
-  if (ceph_clock_now(cct) < defer_recovery_until) {
+  if (ceph_clock_now() < defer_recovery_until) {
     dout(15) << "_recover_now defer until " << defer_recovery_until << dendl;
     return false;
   }
@@ -8870,7 +8870,7 @@ bool OSD::op_is_discardable(MOSDOp *op)
 
 void OSD::enqueue_op(PGRef pg, OpRequestRef& op)
 {
-  utime_t latency = ceph_clock_now(cct) - op->get_req()->get_recv_stamp();
+  utime_t latency = ceph_clock_now() - op->get_req()->get_recv_stamp();
   dout(15) << "enqueue_op " << op << " prio " << op->get_req()->get_priority()
 	   << " cost " << op->get_req()->get_cost()
 	   << " latency " << latency
@@ -8890,7 +8890,7 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
     osd->cct->get_heartbeat_map()->reset_timeout(hb,
       osd->cct->_conf->threadpool_default_timeout, 0);
     sdata->sdata_lock.Lock();
-    sdata->sdata_cond.WaitInterval(osd->cct, sdata->sdata_lock,
+    sdata->sdata_cond.WaitInterval(sdata->sdata_lock,
       utime_t(osd->cct->_conf->threadpool_empty_queue_max_wait, 0));
     sdata->sdata_lock.Unlock();
     sdata->sdata_op_ordering_lock.Lock();
@@ -9022,7 +9022,7 @@ void OSD::dequeue_op(
   PGRef pg, OpRequestRef op,
   ThreadPool::TPHandle &handle)
 {
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   op->set_dequeued_time(now);
   utime_t latency = now - op->get_req()->get_recv_stamp();
   dout(10) << "dequeue_op " << op << " prio " << op->get_req()->get_priority()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -149,7 +149,7 @@
 #define tracepoint(...)
 #endif
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, whoami, get_osdmap_epoch())
@@ -549,14 +549,14 @@ void OSDService::agent_entry()
 	     << ", top is " << level
 	     << " with pgs " << top.size()
 	     << ", ops " << agent_ops << "/"
-	     << g_conf->osd_agent_max_ops
+	     << cct->_conf->osd_agent_max_ops
 	     << (agent_active ? " active" : " NOT ACTIVE")
 	     << dendl;
     dout(20) << __func__ << " oids " << agent_oids << dendl;
-    int max = g_conf->osd_agent_max_ops - agent_ops;
+    int max = cct->_conf->osd_agent_max_ops - agent_ops;
     int agent_flush_quota = max;
     if (!flush_mode_high_count)
-      agent_flush_quota = g_conf->osd_agent_max_low_ops - agent_ops;
+      agent_flush_quota = cct->_conf->osd_agent_max_low_ops - agent_ops;
     if (agent_flush_quota <= 0 || top.empty() || !agent_active) {
       agent_cond.Wait(agent_lock);
       continue;
@@ -573,14 +573,14 @@ void OSDService::agent_entry()
     agent_lock.Unlock();
     if (!pg->agent_work(max, agent_flush_quota)) {
       dout(10) << __func__ << " " << pg->get_pgid()
-	<< " no agent_work, delay for " << g_conf->osd_agent_delay_time
+	<< " no agent_work, delay for " << cct->_conf->osd_agent_delay_time
 	<< " seconds" << dendl;
 
       osd->logger->inc(l_osd_tier_delay);
       // Queue a timer to call agent_choose_mode for this pg in 5 seconds
       agent_timer_lock.Lock();
       Context *cb = new AgentTimeoutCB(pg);
-      agent_timer.add_event_after(g_conf->osd_agent_delay_time, cb);
+      agent_timer.add_event_after(cct->_conf->osd_agent_delay_time, cb);
       agent_timer_lock.Unlock();
     }
     agent_lock.Lock();
@@ -618,8 +618,8 @@ void OSDService::promote_throttle_recalibrate()
   last_recalibrate = now;
   unsigned prob = promote_probability_millis;
 
-  uint64_t target_obj_sec = g_conf->osd_tier_promote_max_objects_sec;
-  uint64_t target_bytes_sec = g_conf->osd_tier_promote_max_bytes_sec;
+  uint64_t target_obj_sec = cct->_conf->osd_tier_promote_max_objects_sec;
+  uint64_t target_bytes_sec = cct->_conf->osd_tier_promote_max_bytes_sec;
 
   unsigned min_prob = 1;
 
@@ -1494,7 +1494,7 @@ int OSD::mkfs(CephContext *cct, ObjectStore *store, const string &dev,
     goto free_store;
   }
 
-  store->set_cache_shards(g_conf->osd_op_num_shards);
+  store->set_cache_shards(cct->_conf->osd_op_num_shards);
 
   ret = store->mount();
   if (ret) {
@@ -1718,6 +1718,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
     &command_tp),
   replay_queue_lock("OSD::replay_queue_lock"),
   remove_wq(
+    cct,
     store,
     cct->_conf->osd_remove_thread_timeout,
     cct->_conf->osd_remove_thread_suicide_timeout,
@@ -1984,8 +1985,8 @@ int OSD::enable_disable_fuse(bool stop)
 {
 #ifdef HAVE_LIBFUSE
   int r;
-  string mntpath = g_conf->osd_data + "/fuse";
-  if (fuse_store && (stop || !g_conf->osd_objectstore_fuse)) {
+  string mntpath = cct->_conf->osd_data + "/fuse";
+  if (fuse_store && (stop || !cct->_conf->osd_objectstore_fuse)) {
     dout(1) << __func__ << " disabling" << dendl;
     fuse_store->stop();
     delete fuse_store;
@@ -1999,7 +2000,7 @@ int OSD::enable_disable_fuse(bool stop)
     }
     return 0;
   }
-  if (!fuse_store && g_conf->osd_objectstore_fuse) {
+  if (!fuse_store && cct->_conf->osd_objectstore_fuse) {
     dout(1) << __func__ << " enabling" << dendl;
     r = ::mkdir(mntpath.c_str(), 0700);
     if (r < 0)
@@ -2038,7 +2039,7 @@ int OSD::init()
 	  << (journal_path.empty() ? "(no journal)" : journal_path) << dendl;
   assert(store);  // call pre_init() first!
 
-  store->set_cache_shards(g_conf->osd_op_num_shards);
+  store->set_cache_shards(cct->_conf->osd_op_num_shards);
 
   int r = store->mount();
   if (r < 0) {
@@ -2065,19 +2066,19 @@ int OSD::init()
   // sanity check long object name handling
   {
     hobject_t l;
-    l.oid.name = string(g_conf->osd_max_object_name_len, 'n');
-    l.set_key(string(g_conf->osd_max_object_name_len, 'k'));
-    l.nspace = string(g_conf->osd_max_object_namespace_len, 's');
+    l.oid.name = string(cct->_conf->osd_max_object_name_len, 'n');
+    l.set_key(string(cct->_conf->osd_max_object_name_len, 'k'));
+    l.nspace = string(cct->_conf->osd_max_object_namespace_len, 's');
     r = store->validate_hobject_key(l);
     if (r < 0) {
       derr << "backend (" << store->get_type() << ") is unable to support max "
 	   << "object name[space] len" << dendl;
       derr << "   osd max object name len = "
-	   << g_conf->osd_max_object_name_len << dendl;
+	   << cct->_conf->osd_max_object_name_len << dendl;
       derr << "   osd max object namespace len = "
-	   << g_conf->osd_max_object_namespace_len << dendl;
+	   << cct->_conf->osd_max_object_namespace_len << dendl;
       derr << cpp_strerror(r) << dendl;
-      if (g_conf->osd_check_max_object_name_len_on_startup) {
+      if (cct->_conf->osd_check_max_object_name_len_on_startup) {
 	goto out;
       }
       derr << "osd_check_max_object_name_len_on_startup = false, starting anyway"
@@ -2832,7 +2833,7 @@ int OSD::shutdown()
   dout(10) << "syncing store" << dendl;
   enable_disable_fuse(true);
 
-  if (g_conf->osd_journal_flush_on_shutdown) {
+  if (cct->_conf->osd_journal_flush_on_shutdown) {
     dout(10) << "flushing journal" << dendl;
     store->flush_journal();
   }
@@ -2865,14 +2866,14 @@ int OSD::shutdown()
 
 int OSD::update_crush_location()
 {
-  if (!g_conf->osd_crush_update_on_start) {
+  if (!cct->_conf->osd_crush_update_on_start) {
     dout(10) << __func__ << " osd_crush_update_on_start = false" << dendl;
     return 0;
   }
 
   char weight[32];
-  if (g_conf->osd_crush_initial_weight >= 0) {
-    snprintf(weight, sizeof(weight), "%.4lf", g_conf->osd_crush_initial_weight);
+  if (cct->_conf->osd_crush_initial_weight >= 0) {
+    snprintf(weight, sizeof(weight), "%.4lf", cct->_conf->osd_crush_initial_weight);
   } else {
     struct store_statfs_t st;
     int r = store->statfs(&st);
@@ -3023,7 +3024,9 @@ void OSD::clear_temp_objects()
   }
 }
 
-void OSD::recursive_remove_collection(ObjectStore *store, spg_t pgid, coll_t tmp)
+void OSD::recursive_remove_collection(CephContext* cct,
+				      ObjectStore *store, spg_t pgid,
+				      coll_t tmp)
 {
   OSDriver driver(
     store,
@@ -3033,7 +3036,7 @@ void OSD::recursive_remove_collection(ObjectStore *store, spg_t pgid, coll_t tmp
   ceph::shared_ptr<ObjectStore::Sequencer> osr (std::make_shared<
                                       ObjectStore::Sequencer>("rm"));
   ObjectStore::Transaction t;
-  SnapMapper mapper(&driver, 0, 0, 0, pgid.shard);
+  SnapMapper mapper(cct, &driver, 0, 0, 0, pgid.shard);
 
   vector<ghobject_t> objects;
   store->collection_list(tmp, ghobject_t(), ghobject_t::get_max(), true,
@@ -3049,7 +3052,7 @@ void OSD::recursive_remove_collection(ObjectStore *store, spg_t pgid, coll_t tmp
     if (r != 0 && r != -ENOENT)
       ceph_abort();
     t.remove(tmp, *p);
-    if (removed > g_conf->osd_target_transaction_size) {
+    if (removed > cct->_conf->osd_target_transaction_size) {
       int r = store->apply_transaction(osr.get(), std::move(t));
       assert(r == 0);
       t = ObjectStore::Transaction();
@@ -3078,7 +3081,7 @@ PGPool OSD::_get_pool(int id, OSDMapRef createmap)
     ceph_abort();
   }
 
-  PGPool p = PGPool(createmap, id);
+  PGPool p = PGPool(cct, createmap, id);
 
   dout(10) << "_get_pool " << p.id << dendl;
   return p;
@@ -3310,7 +3313,7 @@ void OSD::load_pgs()
     if (it->is_temp(&pgid) ||
        (it->is_pg(&pgid) && PG::_has_removal_flag(store, pgid))) {
       dout(10) << "load_pgs " << *it << " clearing temp" << dendl;
-      recursive_remove_collection(store, pgid, *it);
+      recursive_remove_collection(cct, store, pgid, *it);
       continue;
     }
 
@@ -4422,7 +4425,7 @@ void OSD::tick_without_osd_lock()
     bool report = false;
     utime_t now = ceph_clock_now();
     pg_stat_queue_lock.Lock();
-    double backoff = stats_ack_timeout / g_conf->osd_mon_ack_timeout;
+    double backoff = stats_ack_timeout / cct->_conf->osd_mon_ack_timeout;
     double adjusted_min = cct->_conf->osd_mon_report_interval_min * backoff;
     // note: we shouldn't adjust max because it must remain < the
     // mon's mon_osd_report_timeout (which defaults to 1.5x our
@@ -4437,8 +4440,8 @@ void OSD::tick_without_osd_lock()
       last_pg_stats_ack = now;  // reset clock
       last_pg_stats_sent = utime_t();
       stats_ack_timeout =
-	MAX(g_conf->osd_mon_ack_timeout,
-	    stats_ack_timeout * g_conf->osd_stats_ack_timeout_factor);
+	MAX(cct->_conf->osd_mon_ack_timeout,
+	    stats_ack_timeout * cct->_conf->osd_stats_ack_timeout_factor);
       outstanding_pg_stats.clear();
     }
     if (now - last_pg_stats_sent > max) {
@@ -4790,7 +4793,7 @@ void OSD::RemoveWQ::_process(
   ObjectStore::Transaction t;
   PGLog::clear_info_log(pg->info.pgid, &t);
 
-  if (g_conf->osd_inject_failure_on_pg_removal) {
+  if (cct->_conf->osd_inject_failure_on_pg_removal) {
     generic_derr << "osd_inject_failure_on_pg_removal" << dendl;
     exit(1);
   }
@@ -5109,10 +5112,10 @@ void OSD::_collect_metadata(map<string,string> *pm)
   (*pm)["hb_back_addr"] = stringify(hb_back_server_messenger->get_myaddr());
 
   // backend
-  (*pm)["osd_objectstore"] = g_conf->osd_objectstore;
+  (*pm)["osd_objectstore"] = cct->_conf->osd_objectstore;
   store->collect_metadata(pm);
 
-  collect_sys_info(pm, g_ceph_context);
+  collect_sys_info(pm, cct);
 
   dout(10) << __func__ << " " << *pm << dendl;
 }
@@ -5319,8 +5322,8 @@ void OSD::handle_pg_stats_ack(MPGStatsAck *ack)
 
   // decay timeout slowly (analogous to TCP)
   stats_ack_timeout =
-    MAX(g_conf->osd_mon_ack_timeout,
-	stats_ack_timeout * g_conf->osd_stats_ack_timeout_decay);
+    MAX(cct->_conf->osd_mon_ack_timeout,
+	stats_ack_timeout * cct->_conf->osd_stats_ack_timeout_decay);
   dout(20) << __func__ << "  timeout now " << stats_ack_timeout << dendl;
 
   if (ack->get_tid() > pg_stat_tid_flushed) {
@@ -5671,14 +5674,14 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
     ceph::shared_ptr<ObjectStore::Sequencer> osr (std::make_shared<
                                         ObjectStore::Sequencer>("bench"));
 
-    uint32_t duration = g_conf->osd_bench_duration;
+    uint32_t duration = cct->_conf->osd_bench_duration;
 
-    if (bsize > (int64_t) g_conf->osd_bench_max_block_size) {
+    if (bsize > (int64_t) cct->_conf->osd_bench_max_block_size) {
       // let us limit the block size because the next checks rely on it
       // having a sane value.  If we allow any block size to be set things
       // can still go sideways.
       ss << "block 'size' values are capped at "
-         << prettybyte_t(g_conf->osd_bench_max_block_size) << ". If you wish to use"
+         << prettybyte_t(cct->_conf->osd_bench_max_block_size) << ". If you wish to use"
          << " a higher value, please adjust 'osd_bench_max_block_size'";
       r = -EINVAL;
       goto out;
@@ -5688,11 +5691,11 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       // IOPS and duration, so that the OSD doesn't get hung up on this,
       // preventing timeouts from going off
       int64_t max_count =
-        bsize * duration * g_conf->osd_bench_small_size_max_iops;
+        bsize * duration * cct->_conf->osd_bench_small_size_max_iops;
       if (count > max_count) {
         ss << "'count' values greater than " << max_count
            << " for a block size of " << prettybyte_t(bsize) << ", assuming "
-           << g_conf->osd_bench_small_size_max_iops << " IOPS,"
+           << cct->_conf->osd_bench_small_size_max_iops << " IOPS,"
            << " for " << duration << " seconds,"
            << " can cause ill effects on osd. "
            << " Please adjust 'osd_bench_small_size_max_iops' with a higher"
@@ -5711,11 +5714,11 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       //       way too big.  Given we already check how big the block size
       //       is, it's safe to assume everything will check out.
       int64_t max_count =
-        g_conf->osd_bench_large_size_max_throughput * duration;
+        cct->_conf->osd_bench_large_size_max_throughput * duration;
       if (count > max_count) {
         ss << "'count' values greater than " << max_count
            << " for a block size of " << prettybyte_t(bsize) << ", assuming "
-           << prettybyte_t(g_conf->osd_bench_large_size_max_throughput) << "/s,"
+           << prettybyte_t(cct->_conf->osd_bench_large_size_max_throughput) << "/s,"
            << " for " << duration << " seconds,"
            << " can cause ill effects on osd. "
            << " Please adjust 'osd_bench_large_size_max_throughput'"
@@ -6524,24 +6527,26 @@ bool OSD::scrub_random_backoff()
   return false;
 }
 
-OSDService::ScrubJob::ScrubJob(const spg_t& pg, const utime_t& timestamp,
+OSDService::ScrubJob::ScrubJob(CephContext* cct,
+			       const spg_t& pg, const utime_t& timestamp,
 			       double pool_scrub_min_interval,
 			       double pool_scrub_max_interval, bool must)
-  : pgid(pg),
+  : cct(cct),
+    pgid(pg),
     sched_time(timestamp),
     deadline(timestamp)
 {
   // if not explicitly requested, postpone the scrub with a random delay
   if (!must) {
     double scrub_min_interval = pool_scrub_min_interval > 0 ?
-      pool_scrub_min_interval : g_conf->osd_scrub_min_interval;
+      pool_scrub_min_interval : cct->_conf->osd_scrub_min_interval;
     double scrub_max_interval = pool_scrub_max_interval > 0 ?
-      pool_scrub_max_interval : g_conf->osd_scrub_max_interval;
+      pool_scrub_max_interval : cct->_conf->osd_scrub_max_interval;
 
     sched_time += scrub_min_interval;
     double r = rand() / (double)RAND_MAX;
     sched_time +=
-      scrub_min_interval * g_conf->osd_scrub_interval_randomize_ratio * r;
+      scrub_min_interval * cct->_conf->osd_scrub_interval_randomize_ratio * r;
     deadline += scrub_max_interval;
   }
 }
@@ -6925,8 +6930,8 @@ void OSD::handle_osd_map(MOSDMap *m)
       o->encode(fbl, inc.encode_features | CEPH_FEATURE_RESERVED);
 
       bool injected_failure = false;
-      if (g_conf->osd_inject_bad_map_crc_probability > 0 &&
-	  (rand() % 10000) < g_conf->osd_inject_bad_map_crc_probability*10000.0) {
+      if (cct->_conf->osd_inject_bad_map_crc_probability > 0 &&
+	  (rand() % 10000) < cct->_conf->osd_inject_bad_map_crc_probability*10000.0) {
 	derr << __func__ << " injecting map crc failure" << dendl;
 	injected_failure = true;
       }
@@ -7153,17 +7158,17 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 
 	//add markdown log
 	utime_t now = ceph_clock_now();
-	utime_t grace = utime_t(g_conf->osd_max_markdown_period, 0);
+	utime_t grace = utime_t(cct->_conf->osd_max_markdown_period, 0);
 	osd_markdown_log.push_back(now);
 	//clear all out-of-date log
 	while (!osd_markdown_log.empty() &&
 	       osd_markdown_log.front() + grace < now)
 	  osd_markdown_log.pop_front();
-	if ((int)osd_markdown_log.size() > g_conf->osd_max_markdown_count) {
+	if ((int)osd_markdown_log.size() > cct->_conf->osd_max_markdown_count) {
 	  dout(0) << __func__ << " marked down "
 		  << osd_markdown_log.size()
 		  << " > osd_max_markdown_count "
-		  << g_conf->osd_max_markdown_count
+		  << cct->_conf->osd_max_markdown_count
 		  << " in last " << grace << " seconds, shutting down"
 		  << dendl;
 	  do_restart = false;
@@ -7339,9 +7344,9 @@ bool OSD::advance_pg(
   epoch_t min_epoch = service.get_min_pg_epoch();
   epoch_t max;
   if (min_epoch) {
-    max = min_epoch + g_conf->osd_map_max_advance;
+    max = min_epoch + cct->_conf->osd_map_max_advance;
   } else {
-    max = next_epoch + g_conf->osd_map_max_advance;
+    max = next_epoch + cct->_conf->osd_map_max_advance;
   }
 
   for (;
@@ -7352,7 +7357,7 @@ bool OSD::advance_pg(
       dout(20) << __func__ << " missing map " << next_epoch << dendl;
       // make sure max is bumped up so that we can get past any
       // gap in maps
-      max = MAX(max, next_epoch + g_conf->osd_map_max_advance);
+      max = MAX(max, next_epoch + cct->_conf->osd_map_max_advance);
       continue;
     }
 
@@ -8532,11 +8537,11 @@ void OSD::do_recovery(
   ThreadPool::TPHandle &handle)
 {
   uint64_t started = 0;
-  if (g_conf->osd_recovery_sleep > 0) {
+  if (cct->_conf->osd_recovery_sleep > 0) {
     handle.suspend_tp_timeout();
     pg->unlock();
     utime_t t;
-    t.set_from_double(g_conf->osd_recovery_sleep);
+    t.set_from_double(cct->_conf->osd_recovery_sleep);
     t.sleep();
     dout(20) << __func__ << " slept for " << t << dendl;
     pg->lock();
@@ -8762,7 +8767,7 @@ void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
   }
 
   // ok, we didn't have the PG.
-  if (!g_conf->osd_debug_misdirected_ops) {
+  if (!cct->_conf->osd_debug_misdirected_ops) {
     return;
   }
   // let's see if it's our fault or the client's.  note that this might
@@ -9255,7 +9260,7 @@ void OSD::update_log_config()
   uuid_d fsid;
   string host;
 
-  if (parse_log_client_options(g_ceph_context, log_to_monitors, log_to_syslog,
+  if (parse_log_client_options(cct, log_to_monitors, log_to_syslog,
 			       log_channel, log_prio, log_to_graylog,
 			       log_to_graylog_host, log_to_graylog_port,
 			       fsid, host) == 0)
@@ -9269,15 +9274,15 @@ void OSD::update_log_config()
 void OSD::check_config()
 {
   // some sanity checks
-  if (g_conf->osd_map_cache_size <= g_conf->osd_map_max_advance + 2) {
-    clog->warn() << "osd_map_cache_size (" << g_conf->osd_map_cache_size << ")"
+  if (cct->_conf->osd_map_cache_size <= cct->_conf->osd_map_max_advance + 2) {
+    clog->warn() << "osd_map_cache_size (" << cct->_conf->osd_map_cache_size << ")"
 		<< " is not > osd_map_max_advance ("
-		<< g_conf->osd_map_max_advance << ")";
+		<< cct->_conf->osd_map_max_advance << ")";
   }
-  if (g_conf->osd_map_cache_size <= (int)g_conf->osd_pg_epoch_persisted_max_stale + 2) {
-    clog->warn() << "osd_map_cache_size (" << g_conf->osd_map_cache_size << ")"
-		<< " is not > osd_pg_epoch_persisted_max_stale ("
-		<< g_conf->osd_pg_epoch_persisted_max_stale << ")";
+  if (cct->_conf->osd_map_cache_size <= (int)cct->_conf->osd_pg_epoch_persisted_max_stale + 2) {
+    clog->warn() << "osd_map_cache_size (" << cct->_conf->osd_map_cache_size << ")"
+		 << " is not > osd_pg_epoch_persisted_max_stale ("
+		 << cct->_conf->osd_pg_epoch_persisted_max_stale << ")";
   }
 }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -898,7 +898,7 @@ public:
 	  PGScrub(pg->get_osdmap()->get_epoch()),
 	  cct->_conf->osd_scrub_cost,
 	  pg->get_scrub_priority(),
-	  ceph_clock_now(cct),
+	  ceph_clock_now(),
 	  entity_inst_t())));
   }
 
@@ -925,7 +925,7 @@ private:
 	PGRecovery(p.first, reserved_pushes),
 	cct->_conf->osd_recovery_cost,
 	cct->_conf->osd_recovery_priority,
-	ceph_clock_now(cct),
+	ceph_clock_now(),
 	entity_inst_t()));
     op_wq.queue(to_queue);
   }
@@ -940,7 +940,7 @@ public:
     _maybe_queue_recovery();
   }
   void defer_recovery(float defer_for) {
-    defer_recovery_until = ceph_clock_now(cct);
+    defer_recovery_until = ceph_clock_now();
     defer_recovery_until += defer_for;
   }
   void pause_recovery() {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -632,6 +632,7 @@ private:
 
 public:
   struct ScrubJob {
+    CephContext* cct;
     /// pg to be scrubbed
     spg_t pgid;
     /// a time scheduled for scrub. but the scrub could be delayed if system
@@ -640,7 +641,8 @@ public:
     /// the hard upper bound of scrub time
     utime_t deadline;
     ScrubJob() {}
-    explicit ScrubJob(const spg_t& pg, const utime_t& timestamp,
+    explicit ScrubJob(CephContext* cct, const spg_t& pg,
+		      const utime_t& timestamp,
 		      double pool_scrub_min_interval = 0,
 		      double pool_scrub_max_interval = 0, bool must = true);
     /// order the jobs by sched_time
@@ -651,7 +653,7 @@ public:
   /// @returns the scrub_reg_stamp used for unregister the scrub job
   utime_t reg_pg_scrub(spg_t pgid, utime_t t, double pool_scrub_min_interval,
 		       double pool_scrub_max_interval, bool must) {
-    ScrubJob scrub(pgid, t, pool_scrub_min_interval, pool_scrub_max_interval,
+    ScrubJob scrub(cct, pgid, t, pool_scrub_min_interval, pool_scrub_max_interval,
 		   must);
     Mutex::Locker l(sched_scrub_lock);
     sched_scrub_pg.insert(scrub);
@@ -659,7 +661,7 @@ public:
   }
   void unreg_pg_scrub(spg_t pgid, utime_t t) {
     Mutex::Locker l(sched_scrub_lock);
-    size_t removed = sched_scrub_pg.erase(ScrubJob(pgid, t));
+    size_t removed = sched_scrub_pg.erase(ScrubJob(cct, pgid, t));
     assert(removed);
   }
   bool first_scrub_stamp(ScrubJob *out) {
@@ -1273,7 +1275,8 @@ public:
     hobject_t oid(sobject_t("infos", CEPH_NOSNAP));
     return ghobject_t(oid);
   }
-  static void recursive_remove_collection(ObjectStore *store,
+  static void recursive_remove_collection(CephContext* cct,
+					  ObjectStore *store,
 					  spg_t pgid,
 					  coll_t tmp);
 
@@ -1425,7 +1428,7 @@ public:
 
     explicit Session(CephContext *cct) :
       RefCountedObject(cct),
-      auid(-1), con(0),
+      auid(-1), con(0), wstate(cct),
       session_dispatch_lock("Session::session_dispatch_lock"), 
       last_sent_epoch(0), received_map_epoch(0)
     {}
@@ -2324,12 +2327,13 @@ protected:
   // -- removing --
   struct RemoveWQ :
     public ThreadPool::WorkQueueVal<pair<PGRef, DeletingStateRef> > {
+    CephContext* cct;
     ObjectStore *&store;
     list<pair<PGRef, DeletingStateRef> > remove_queue;
-    RemoveWQ(ObjectStore *&o, time_t ti, time_t si, ThreadPool *tp)
+    RemoveWQ(CephContext* cct, ObjectStore *&o, time_t ti, time_t si,
+	     ThreadPool *tp)
       : ThreadPool::WorkQueueVal<pair<PGRef, DeletingStateRef> >(
-	"OSD::RemoveWQ", ti, si, tp),
-	store(o) {}
+	"OSD::RemoveWQ", ti, si, tp), cct(cct), store(o) {}
 
     bool _empty() override {
       return remove_queue.empty();

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2649,7 +2649,7 @@ int OSDMap::build_simple(CephContext *cct, epoch_t e, uuid_d &fsid,
 		 << dendl;
   epoch = e;
   set_fsid(fsid);
-  created = modified = ceph_clock_now(cct);
+  created = modified = ceph_clock_now();
 
   if (nosd >=  0) {
     set_max_osd(nosd);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -7,9 +7,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "PG.h"
@@ -65,6 +65,7 @@
 
 #include <sstream>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1558,7 +1558,7 @@ void PG::activate(ObjectStore::Transaction& t,
       is_primary() &&
       pool.info.crash_replay_interval > 0 &&
       may_need_replay(get_osdmap())) {
-    replay_until = ceph_clock_now(cct);
+    replay_until = ceph_clock_now();
     replay_until += pool.info.crash_replay_interval;
     dout(10) << "activate starting replay interval for " << pool.info.crash_replay_interval
 	     << " until " << replay_until << dendl;
@@ -2654,7 +2654,7 @@ void PG::publish_stats_to_osd()
   else
     state_clear(PG_STATE_INCONSISTENT);
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   if (info.stats.state != state) {
     info.stats.last_change = now;
     if ((state & PG_STATE_ACTIVE) &&
@@ -3424,7 +3424,7 @@ bool PG::sched_scrub()
   if (deep_scrub_interval <= 0) {
     deep_scrub_interval = cct->_conf->osd_deep_scrub_interval;
   }
-  bool time_for_deep = ceph_clock_now(cct) >=
+  bool time_for_deep = ceph_clock_now() >=
     info.history.last_deep_scrub_stamp + deep_scrub_interval;
 
   bool deep_coin_flip = false;
@@ -3535,7 +3535,7 @@ void PG::reg_next_scrub()
   utime_t reg_stamp;
   if (scrubber.must_scrub ||
       (info.stats.stats_invalid && g_conf->osd_scrub_invalid_stats)) {
-    reg_stamp = ceph_clock_now(cct);
+    reg_stamp = ceph_clock_now();
   } else {
     reg_stamp = info.history.last_scrub_stamp;
   }
@@ -4635,7 +4635,7 @@ void PG::scrub_finish()
 
   // finish up
   unreg_next_scrub();
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   info.history.last_scrub = info.last_update;
   info.history.last_scrub_stamp = now;
   if (scrubber.deep) {
@@ -5847,7 +5847,7 @@ void PG::RecoveryState::Initial::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_initial_latency, dur);
 }
 
@@ -5910,7 +5910,7 @@ void PG::RecoveryState::Started::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_started_latency, dur);
 }
 
@@ -6005,7 +6005,7 @@ void PG::RecoveryState::Reset::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_reset_latency, dur);
 }
 
@@ -6030,7 +6030,7 @@ void PG::RecoveryState::Start::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_start_latency, dur);
 }
 
@@ -6092,7 +6092,7 @@ void PG::RecoveryState::Primary::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   pg->want_acting.clear();
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_primary_latency, dur);
   pg->clear_primary_state();
   pg->state_clear(PG_STATE_CREATING);
@@ -6195,7 +6195,7 @@ void PG::RecoveryState::Peering::exit()
   pg->state_clear(PG_STATE_PEERING);
   pg->clear_probe_targets();
 
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_peering_latency, dur);
 }
 
@@ -6251,7 +6251,7 @@ void PG::RecoveryState::Backfilling::exit()
   pg->backfill_reserved = false;
   pg->backfill_reserving = false;
   pg->state_clear(PG_STATE_BACKFILL);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_backfilling_latency, dur);
 }
 
@@ -6298,7 +6298,7 @@ void PG::RecoveryState::WaitRemoteBackfillReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitremotebackfillreserved_latency, dur);
 }
 
@@ -6356,7 +6356,7 @@ void PG::RecoveryState::WaitLocalBackfillReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitlocalbackfillreserved_latency, dur);
 }
 
@@ -6384,7 +6384,7 @@ void PG::RecoveryState::NotBackfilling::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_notbackfilling_latency, dur);
 }
 
@@ -6400,7 +6400,7 @@ void PG::RecoveryState::RepNotRecovering::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_repnotrecovering_latency, dur);
 }
 
@@ -6438,7 +6438,7 @@ void PG::RecoveryState::RepWaitRecoveryReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_repwaitrecoveryreserved_latency, dur);
 }
 
@@ -6480,7 +6480,7 @@ void PG::RecoveryState::RepWaitBackfillReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_repwaitbackfillreserved_latency, dur);
 }
 
@@ -6546,7 +6546,7 @@ void PG::RecoveryState::RepRecovering::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   pg->osd->remote_reserver.cancel_reservation(pg->info.pgid);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_reprecovering_latency, dur);
 }
 
@@ -6562,7 +6562,7 @@ void PG::RecoveryState::Activating::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_activating_latency, dur);
 }
 
@@ -6585,7 +6585,7 @@ void PG::RecoveryState::WaitLocalRecoveryReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitlocalrecoveryreserved_latency, dur);
 }
 
@@ -6625,7 +6625,7 @@ void PG::RecoveryState::WaitRemoteRecoveryReserved::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitremoterecoveryreserved_latency, dur);
 }
 
@@ -6688,7 +6688,7 @@ void PG::RecoveryState::Recovering::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_recovering_latency, dur);
 }
 
@@ -6728,7 +6728,7 @@ void PG::RecoveryState::Recovered::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_recovered_latency, dur);
 }
 
@@ -6756,7 +6756,7 @@ void PG::RecoveryState::Clean::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   pg->state_clear(PG_STATE_CLEAN);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_clean_latency, dur);
 }
 
@@ -7086,7 +7086,7 @@ void PG::RecoveryState::Active::exit()
   pg->state_clear(PG_STATE_BACKFILL_WAIT);
   pg->state_clear(PG_STATE_RECOVERY_WAIT);
   pg->state_clear(PG_STATE_REPLAY);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_active_latency, dur);
   pg->agent_stop();
 }
@@ -7179,7 +7179,7 @@ void PG::RecoveryState::ReplicaActive::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   pg->osd->remote_reserver.cancel_reservation(pg->info.pgid);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_replicaactive_latency, dur);
 }
 
@@ -7291,7 +7291,7 @@ void PG::RecoveryState::Stray::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_stray_latency, dur);
 }
 
@@ -7490,7 +7490,7 @@ void PG::RecoveryState::GetInfo::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_getinfo_latency, dur);
   pg->blocked_by.clear();
   pg->publish_stats_to_osd();
@@ -7622,7 +7622,7 @@ void PG::RecoveryState::GetLog::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_getlog_latency, dur);
   pg->blocked_by.clear();
   pg->publish_stats_to_osd();
@@ -7684,7 +7684,7 @@ void PG::RecoveryState::WaitActingChange::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitactingchange_latency, dur);
 }
 
@@ -7711,7 +7711,7 @@ void PG::RecoveryState::Down::exit()
   PG *pg = context< RecoveryMachine >().pg;
 
   pg->state_clear(PG_STATE_DOWN);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_down_latency, dur);
 
   pg->blocked_by.clear();
@@ -7771,7 +7771,7 @@ void PG::RecoveryState::Incomplete::exit()
   PG *pg = context< RecoveryMachine >().pg;
 
   pg->state_clear(PG_STATE_INCOMPLETE);
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_incomplete_latency, dur);
 
   pg->blocked_by.clear();
@@ -7910,7 +7910,7 @@ void PG::RecoveryState::GetMissing::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_getmissing_latency, dur);
   pg->blocked_by.clear();
   pg->publish_stats_to_osd();
@@ -7956,7 +7956,7 @@ void PG::RecoveryState::WaitUpThru::exit()
 {
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitupthru_latency, dur);
 }
 
@@ -7972,9 +7972,9 @@ void PG::RecoveryState::RecoveryMachine::log_enter(const char *state_name)
 
 void PG::RecoveryState::RecoveryMachine::log_exit(const char *state_name, utime_t enter_time)
 {
-  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  utime_t dur = ceph_clock_now() - enter_time;
   dout(5) << "exit " << state_name << " " << dur << " " << event_count << " " << event_time << dendl;
-  pg->osd->pg_recovery_stats.log_exit(state_name, ceph_clock_now(pg->cct) - enter_time,
+  pg->osd->pg_recovery_stats.log_exit(state_name, ceph_clock_now() - enter_time,
 				      event_count, event_time);
   event_count = 0;
   event_time = utime_t();
@@ -8199,7 +8199,7 @@ void PG::RecoveryState::start_handle(RecoveryCtx *new_ctx) {
     } else {
       rctx = *new_ctx;
     }
-    rctx->start_time = ceph_clock_now(pg->cct);
+    rctx->start_time = ceph_clock_now();
   }
 }
 
@@ -8229,7 +8229,7 @@ void PG::RecoveryState::end_block_outgoing() {
 
 void PG::RecoveryState::end_handle() {
   if (rctx) {
-    utime_t dur = ceph_clock_now(pg->cct) - rctx->start_time;
+    utime_t dur = ceph_clock_now() - rctx->start_time;
     machine.event_time += dur;
   }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -664,7 +664,7 @@ public:
     const char *get_state_name() { return state_name; }
     NamedState(CephContext *cct_, const char *state_name_)
       : state_name(state_name_),
-        enter_time(ceph_clock_now(cct_)) {}
+	enter_time(ceph_clock_now()) {}
     virtual ~NamedState() {}
   };
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -729,7 +729,7 @@ void PGBackend::be_compare_scrubmaps(
   map<hobject_t,ScrubMap::object, hobject_t::BitwiseComparator>::const_iterator i;
   map<pg_shard_t, ScrubMap *, hobject_t::BitwiseComparator>::const_iterator j;
   set<hobject_t, hobject_t::BitwiseComparator> master_set;
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
 
   // Construct master set
   for (j = maps.begin(); j != maps.end(); ++j) {

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -28,6 +28,7 @@
 #include "PGLog.h"
 #include "common/LogClient.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -28,7 +28,7 @@
 #include "PGLog.h"
 #include "common/LogClient.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix
@@ -410,7 +410,7 @@ PGBackend *PGBackend::build_pg_backend(
     stringstream ss;
     ceph::ErasureCodePluginRegistry::instance().factory(
       profile.find("plugin")->second,
-      g_conf->erasure_code_dir,
+      cct->_conf->erasure_code_dir,
       profile,
       &ec_impl,
       &ss);
@@ -837,9 +837,9 @@ void PGBackend::be_compare_scrubmaps(
 	update = MAYBE;
       }
       if (auth_object.digest_present && auth_object.omap_digest_present &&
-	  g_conf->osd_debug_scrub_chance_rewrite_digest &&
+	  cct->_conf->osd_debug_scrub_chance_rewrite_digest &&
 	  (((unsigned)rand() % 100) >
-	   g_conf->osd_debug_scrub_chance_rewrite_digest)) {
+	   cct->_conf->osd_debug_scrub_chance_rewrite_digest)) {
 	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
 	update = MAYBE;
       }
@@ -869,13 +869,13 @@ void PGBackend::be_compare_scrubmaps(
       if (update != NO) {
 	utime_t age = now - auth_oi.local_mtime;
 	if (update == FORCE ||
-	    age > g_conf->osd_deep_scrub_update_digest_min_age) {
+	    age > cct->_conf->osd_deep_scrub_update_digest_min_age) {
 	  dout(20) << __func__ << " will update digest on " << *k << dendl;
 	  missing_digest[*k] = make_pair(auth_object.digest,
 					 auth_object.omap_digest);
 	} else {
 	  dout(20) << __func__ << " missing digest but age " << age
-		   << " < " << g_conf->osd_deep_scrub_update_digest_min_age
+		   << " < " << cct->_conf->osd_deep_scrub_update_digest_min_age
 		   << " on " << *k << dendl;
 	}
       }

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -50,6 +50,8 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
   * 4) Handling scrub, deep-scrub, repair
   */
  class PGBackend {
+ public:
+   CephContext* cct;
  protected:
    ObjectStore *store;
    const coll_t coll;
@@ -259,8 +261,9 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    };
    Listener *parent;
    Listener *get_parent() const { return parent; }
-   PGBackend(Listener *l, ObjectStore *store, coll_t coll,
+   PGBackend(CephContext* cct, Listener *l, ObjectStore *store, coll_t coll,
 	     ObjectStore::CollectionHandle &ch) :
+     cct(cct),
      store(store),
      coll(coll),
      ch(ch),

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -19,6 +19,7 @@
 #include "include/unordered_map.h"
 #include "common/ceph_context.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -19,7 +19,7 @@
 #include "include/unordered_map.h"
 #include "common/ceph_context.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)
@@ -42,6 +42,7 @@ PGLog::IndexedLog PGLog::IndexedLog::split_out_child(
 }
 
 void PGLog::IndexedLog::trim(
+  CephContext* cct,
   eversion_t s,
   set<eversion_t> *trimmed)
 {
@@ -121,7 +122,7 @@ void PGLog::trim(
     assert(trim_to <= info.last_complete);
 
     dout(10) << "trim " << log << " to " << trim_to << dendl;
-    log.trim(trim_to, &trimmed);
+    log.trim(cct, trim_to, &trimmed);
     info.log_tail = log.tail;
   }
 }

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -29,6 +29,8 @@ using namespace std;
 #define PGLOG_INDEXED_EXTRA_CALLER_OPS (1 << 2)
 #define PGLOG_INDEXED_ALL              (PGLOG_INDEXED_OBJECTS | PGLOG_INDEXED_CALLER_OPS | PGLOG_INDEXED_EXTRA_CALLER_OPS)
 
+#define dout_context g_ceph_context
+
 class CephContext;
 
 struct PGLog : DoutPrefixProvider {
@@ -558,8 +560,8 @@ public:
   PGLog(CephContext *cct, DoutPrefixProvider *dpp = 0) :
     prefix_provider(dpp),
     dirty_from(eversion_t::max()),
-    writeout_from(eversion_t::max()), 
-    cct(cct), 
+    writeout_from(eversion_t::max()),
+    cct(cct),
     pg_log_debug(!(cct && !(cct->_conf->osd_debug_pg_log_writeout))),
     touched_log(false),
     clear_divergent_priors(false) {}
@@ -1308,5 +1310,7 @@ public:
     ldpp_dout(dpp, 10) << "read_log_and_missing done" << dendl;
   }
 };
-  
+
+#undef dout_context
+
 #endif // CEPH_PG_LOG_H

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -29,8 +29,6 @@ using namespace std;
 #define PGLOG_INDEXED_EXTRA_CALLER_OPS (1 << 2)
 #define PGLOG_INDEXED_ALL              (PGLOG_INDEXED_OBJECTS | PGLOG_INDEXED_CALLER_OPS | PGLOG_INDEXED_EXTRA_CALLER_OPS)
 
-#define dout_context g_ceph_context
-
 class CephContext;
 
 struct PGLog : DoutPrefixProvider {
@@ -477,6 +475,7 @@ public:
     }
 
     void trim(
+      CephContext* cct,
       eversion_t s,
       set<eversion_t> *trimmed);
 
@@ -1242,9 +1241,9 @@ public:
 	      continue;
 	    if (i.second.need > log.tail ||
 	      cmp(i.first, info.last_backfill, info.last_backfill_bitwise) > 0) {
-	      derr << __func__ << ": invalid missing set entry found "
-		   << i.first
-		   << dendl;
+	      lderr(dpp->get_cct()) << __func__ << ": invalid missing set entry found "
+				    << i.first
+				    << dendl;
 	      assert(0 == "invalid missing set entry found");
 	    }
 	    bufferlist bv;
@@ -1310,7 +1309,5 @@ public:
     ldpp_dout(dpp, 10) << "read_log_and_missing done" << dendl;
   }
 };
-
-#undef dout_context
 
 #endif // CEPH_PG_LOG_H

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2307,7 +2307,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   ctx->src_obc.swap(src_obc);
 
   execute_ctx(ctx);
-  utime_t prepare_latency = ceph_clock_now(cct);
+  utime_t prepare_latency = ceph_clock_now();
   prepare_latency -= op->get_dequeued_time();
   osd->logger->tinc(l_osd_op_prepare_lat, prepare_latency);
   if (op->may_read() && op->may_write()) {
@@ -2661,7 +2661,7 @@ struct C_ProxyRead : public Context {
   C_ProxyRead(PrimaryLogPG *p, hobject_t o, epoch_t lpr,
 	     const PrimaryLogPG::ProxyReadOpRef& prd)
     : pg(p), oid(o), last_peering_reset(lpr),
-      tid(0), prdop(prd), start(ceph_clock_now(NULL))
+      tid(0), prdop(prd), start(ceph_clock_now())
   {}
   void finish(int r) {
     if (prdop->canceled)
@@ -2673,7 +2673,7 @@ struct C_ProxyRead : public Context {
     }
     if (last_peering_reset == pg->get_last_peering_reset()) {
       pg->finish_proxy_read(oid, tid, r);
-      pg->osd->logger->tinc(l_osd_tier_r_lat, ceph_clock_now(NULL) - start);
+      pg->osd->logger->tinc(l_osd_tier_r_lat, ceph_clock_now() - start);
     }
     pg->unlock();
   }
@@ -3004,13 +3004,13 @@ public:
   PromoteCallback(ObjectContextRef obc_, PrimaryLogPG *pg_)
     : obc(obc_),
       pg(pg_),
-      start(ceph_clock_now(NULL)) {}
+      start(ceph_clock_now()) {}
 
   virtual void finish(PrimaryLogPG::CopyCallbackResults results) {
     PrimaryLogPG::CopyResults *results_data = results.get<1>();
     int r = results.get<0>();
     pg->finish_promote(r, results_data, obc);
-    pg->osd->logger->tinc(l_osd_tier_promote_lat, ceph_clock_now(NULL) - start);
+    pg->osd->logger->tinc(l_osd_tier_promote_lat, ceph_clock_now() - start);
   }
 };
 
@@ -3282,7 +3282,7 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
       // _prior_ to being committed; it will not get set with
       // writeahead journaling, for instance.
       if (ctx->readable_stamp == utime_t())
-	ctx->readable_stamp = ceph_clock_now(cct);
+	ctx->readable_stamp = ceph_clock_now();
     });
   ctx->register_on_commit(
     [m, ctx, this](){
@@ -3348,7 +3348,7 @@ void PrimaryLogPG::log_op_stats(OpContext *ctx)
   OpRequestRef op = ctx->op;
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   utime_t latency = now;
   latency -= ctx->op->get_req()->get_recv_stamp();
   utime_t process_latency = now;
@@ -5540,7 +5540,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	    break;
 	  }
 	  dout(10) << " found existing watch " << w << " by " << entity << dendl;
-	  p->second->got_ping(ceph_clock_now(NULL));
+	  p->second->got_ping(ceph_clock_now());
 	  result = 0;
         } else if (op.watch.op == CEPH_OSD_WATCH_OP_UNWATCH) {
 	  map<pair<uint64_t, entity_name_t>, watch_info_t>::iterator oi_iter =
@@ -6833,7 +6833,7 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
   dout(20) << __func__ << " " << soid << " " << ctx
 	   << " op " << pg_log_entry_t::get_op_name(log_op_type)
 	   << dendl;
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
 
   // snapset
   bufferlist bss;
@@ -7991,7 +7991,7 @@ struct C_Flush : public Context {
   utime_t start;
   C_Flush(PrimaryLogPG *p, hobject_t o, epoch_t lpr)
     : pg(p), oid(o), last_peering_reset(lpr),
-      tid(0), start(ceph_clock_now(NULL))
+      tid(0), start(ceph_clock_now())
   {}
   void finish(int r) {
     if (r == -ECANCELED)
@@ -7999,7 +7999,7 @@ struct C_Flush : public Context {
     pg->lock();
     if (last_peering_reset == pg->get_last_peering_reset()) {
       pg->finish_flush(oid, tid, r);
-      pg->osd->logger->tinc(l_osd_tier_flush_lat, ceph_clock_now(NULL) - start);
+      pg->osd->logger->tinc(l_osd_tier_flush_lat, ceph_clock_now() - start);
     }
     pg->unlock();
   }
@@ -8674,7 +8674,7 @@ PrimaryLogPG::RepGather *PrimaryLogPG::new_repop(
   RepGather *repop = new RepGather(
     ctx, rep_tid, info.last_complete, false);
 
-  repop->start = ceph_clock_now(cct);
+  repop->start = ceph_clock_now();
 
   repop_queue.push_back(&repop->queue_item);
   repop->get();
@@ -8702,7 +8702,7 @@ boost::intrusive_ptr<PrimaryLogPG::RepGather> PrimaryLogPG::new_repop(
     r);
   repop->v = version;
 
-  repop->start = ceph_clock_now(cct);
+  repop->start = ceph_clock_now();
 
   repop_queue.push_back(&repop->queue_item);
 
@@ -8737,7 +8737,7 @@ PrimaryLogPG::OpContextUPtr PrimaryLogPG::simple_opc_create(ObjectContextRef obc
   osd_reqid_t reqid(osd->get_cluster_msgr_name(), 0, rep_tid);
   OpContextUPtr ctx(new OpContext(OpRequestRef(), reqid, ops, obc, this));
   ctx->op_t.reset(new PGTransaction());
-  ctx->mtime = ceph_clock_now(g_ceph_context);
+  ctx->mtime = ceph_clock_now();
   return ctx;
 }
 
@@ -9919,7 +9919,7 @@ void PrimaryLogPG::mark_all_unfound_lost(
 
   mempool::osd::list<pg_log_entry_t> log_entries;
 
-  utime_t mtime = ceph_clock_now(cct);
+  utime_t mtime = ceph_clock_now();
   map<hobject_t, pg_missing_item, hobject_t::ComparatorWithDefault>::const_iterator m =
     missing_loc.get_needs_recovery().begin();
   map<hobject_t, pg_missing_item, hobject_t::ComparatorWithDefault>::const_iterator mend =
@@ -11677,7 +11677,7 @@ void PrimaryLogPG::hit_set_remove_all()
     OpContextUPtr ctx = simple_opc_create(obc);
     ctx->at_version = get_next_version();
     ctx->updated_hset_history = info.hit_set;
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     ctx->mtime = now;
     hit_set_trim(ctx, 0);
     simple_opc_submit(std::move(ctx));
@@ -11691,7 +11691,7 @@ void PrimaryLogPG::hit_set_remove_all()
 
 void PrimaryLogPG::hit_set_create()
 {
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   // make a copy of the params to modify
   HitSet::Params params(pool.info.hit_set_params);
 
@@ -11766,7 +11766,7 @@ void PrimaryLogPG::hit_set_persist()
   bufferlist bl;
   unsigned max = pool.info.hit_set_count;
 
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   hobject_t oid;
   time_t flush_time = 0;
 
@@ -12222,7 +12222,7 @@ bool PrimaryLogPG::agent_maybe_flush(ObjectContextRef& obc)
     return false;
   }
 
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   utime_t ob_local_mtime;
   if (obc->obs.oi.local_mtime != utime_t()) {
     ob_local_mtime = obc->obs.oi.local_mtime;
@@ -12302,7 +12302,7 @@ bool PrimaryLogPG::agent_maybe_evict(ObjectContextRef& obc, bool after_flush)
 
   if (agent_state->evict_mode != TierAgentState::EVICT_MODE_FULL) {
     // is this object old than cache_min_evict_age?
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     utime_t ob_local_mtime;
     if (obc->obs.oi.local_mtime != utime_t()) {
       ob_local_mtime = obc->obs.oi.local_mtime;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -10,9 +10,9 @@
  *
  * This is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
- * License version 2.1, as published by the Free Software 
+ * License version 2.1, as published by the Free Software
  * Foundation.  See file COPYING.
- * 
+ *
  */
 
 #include "boost/tuple/tuple.hpp"
@@ -55,6 +55,7 @@
 #define tracepoint(...)
 #endif
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this, osd->whoami, get_osdmap()
 #undef dout_prefix

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -82,7 +82,7 @@ static void log_subop_stats(
   PerfCounters *logger,
   OpRequestRef op, int subop)
 {
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
   utime_t latency = now;
   latency -= op->get_req()->get_recv_stamp();
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -22,6 +22,7 @@
 #include "messages/MOSDPGPull.h"
 #include "messages/MOSDPGPushReply.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -22,7 +22,7 @@
 #include "messages/MOSDPGPull.h"
 #include "messages/MOSDPGPushReply.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
 #undef dout_prefix
@@ -114,8 +114,7 @@ ReplicatedBackend::ReplicatedBackend(
   ObjectStore::CollectionHandle &c,
   ObjectStore *store,
   CephContext *cct) :
-  PGBackend(pg, store, coll, c),
-  cct(cct) {}
+  PGBackend(cct, pg, store, coll, c) {}
 
 void ReplicatedBackend::run_recovery_op(
   PGBackend::RecoveryHandle *_h,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -27,8 +27,6 @@ class ReplicatedBackend : public PGBackend {
   };
   friend struct C_ReplicatedBackend_OnPullComplete;
 public:
-  CephContext *cct;
-
   ReplicatedBackend(
     PGBackend::Listener *pg,
     coll_t coll,

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -14,6 +14,7 @@
 
 #include "SnapMapper.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix *_dout << "snap_mapper."

--- a/src/osd/SnapMapper.cc
+++ b/src/osd/SnapMapper.cc
@@ -14,7 +14,7 @@
 
 #include "SnapMapper.h"
 
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix *_dout << "snap_mapper."

--- a/src/osd/SnapMapper.h
+++ b/src/osd/SnapMapper.h
@@ -97,6 +97,7 @@ public:
  */
 class SnapMapper {
 public:
+  CephContext* cct;
   struct object_snaps {
     hobject_t oid;
     std::set<snapid_t> snaps;
@@ -165,13 +166,14 @@ public:
   const shard_id_t shard;
   const string shard_prefix;
   SnapMapper(
+    CephContext* cct,
     MapCacher::StoreDriver<std::string, bufferlist> *driver,
     uint32_t match,  ///< [in] pgid
     uint32_t bits,   ///< [in] current split bits
     int64_t pool,    ///< [in] pool
     shard_id_t shard ///< [in] shard
     )
-    : backend(driver), mask_bits(bits), match(match), pool(pool),
+    : cct(cct), backend(driver), mask_bits(bits), match(match), pool(pool),
       shard(shard), shard_prefix(make_shard_prefix(shard)) {
     update_bits(mask_bits);
   }

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -377,7 +377,7 @@ void Watch::connect(ConnectionRef con, bool _will_ping)
     }
   }
   if (will_ping) {
-    last_ping = ceph_clock_now(NULL);
+    last_ping = ceph_clock_now();
     register_cb();
   } else {
     unregister_cb();
@@ -449,7 +449,7 @@ void Watch::start_notify(NotifyRef notif)
   assert(in_progress_notifies.find(notif->notify_id) ==
 	 in_progress_notifies.end());
   if (will_ping) {
-    utime_t cutoff = ceph_clock_now(NULL);
+    utime_t cutoff = ceph_clock_now();
     cutoff.sec_ref() -= timeout;
     if (last_ping < cutoff) {
       dout(10) << __func__ << " " << notif->notify_id

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -16,6 +16,7 @@ struct CancelableContext : public Context {
   virtual void cancel() = 0;
 };
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_osd
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, this)

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -277,7 +277,8 @@ class WatchConState {
   Mutex lock;
   std::set<WatchRef> watches;
 public:
-  WatchConState() : lock("WatchConState") {}
+  CephContext* cct;
+  WatchConState(CephContext* cct) : lock("WatchConState"), cct(cct) {}
 
   /// Add a watch
   void addWatch(

--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1850,7 +1850,7 @@ void ObjectCacher::flusher_entry()
     if (flusher_stop)
       break;
 
-    flusher_cond.WaitInterval(cct, lock, seconds(1));
+    flusher_cond.WaitInterval(lock, seconds(1));
   }
 
   /* Wait for reads to finish. This is only possible if handling

--- a/src/osdc/ObjectCacher.h
+++ b/src/osdc/ObjectCacher.h
@@ -512,7 +512,7 @@ class ObjectCacher {
   void mark_dirty(BufferHead *bh) {
     bh_set_state(bh, BufferHead::STATE_DIRTY);
     bh_lru_dirty.lru_touch(bh);
-    //bh->set_dirty_stamp(ceph_clock_now(g_ceph_context));
+    //bh->set_dirty_stamp(ceph_clock_now());
   }
 
   void bh_add(Object *ob, BufferHead *bh);

--- a/src/perfglue/heap_profiler.cc
+++ b/src/perfglue/heap_profiler.cc
@@ -26,6 +26,8 @@
 #include "global/global_context.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
+
 bool ceph_using_tcmalloc()
 {
   return true;

--- a/src/rbd_replay/PendingIO.cc
+++ b/src/rbd_replay/PendingIO.cc
@@ -15,6 +15,7 @@
 #include "PendingIO.hpp"
 #include "rbd_replay_debug.hpp"
 
+#define dout_context g_ceph_context
 
 using namespace std;
 using namespace rbd_replay;

--- a/src/rbd_replay/Replayer.cc
+++ b/src/rbd_replay/Replayer.cc
@@ -23,6 +23,7 @@
 #include "global/global_context.h"
 #include "rbd_replay_debug.hpp"
 
+#define dout_context g_ceph_context
 
 using namespace std;
 using namespace rbd_replay;

--- a/src/rbd_replay/actions.cc
+++ b/src/rbd_replay/actions.cc
@@ -18,6 +18,7 @@
 #include "PendingIO.hpp"
 #include "rbd_replay_debug.hpp"
 
+#define dout_context g_ceph_context
 
 using namespace rbd_replay;
 using namespace std;

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -120,7 +120,7 @@ namespace rgw {
     // XXX move RGWLibIO and timing setup into process_request
 
 #if 0 /* XXX */
-    utime_t tm = ceph_clock_now(NULL);
+    utime_t tm = ceph_clock_now();
 #endif
 
     RGWLibIO io_ctx;
@@ -139,7 +139,7 @@ namespace rgw {
     // XXX move RGWLibIO and timing setup into process_request
 
 #if 0 /* XXX */
-    utime_t tm = ceph_clock_now(NULL);
+    utime_t tm = ceph_clock_now();
 #endif
 
     RGWLibIO io_ctx;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6487,7 +6487,7 @@ next:
       cerr << "ERROR: marker was not specified" <<std::endl;
       return EINVAL;
     }
-    utime_t time = ceph_clock_now(NULL);
+    utime_t time = ceph_clock_now();
     if (!date.empty()) {
       ret = parse_date_str(date, time);
       if (ret < 0) {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -42,6 +42,7 @@
 
 using namespace std;
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 #define SECRET_KEY_LEN 40

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -6,6 +6,7 @@
 
 #include "rgw_asio_client.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 #undef dout_prefix

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -11,6 +11,7 @@
 
 #include "include/str_list.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 

--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -7,6 +7,7 @@
 #include "rgw_client_io.h"
 #include "rgw_rest.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 static const char *signed_subresources[] = {

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1873,7 +1873,7 @@ void *RGWDataChangesLog::ChangesRenewThread::entry() {
 
     int interval = cct->_conf->rgw_data_log_window * 3 / 4;
     lock.Lock();
-    cond.WaitInterval(cct, lock, utime_t(interval, 0));
+    cond.WaitInterval(lock, utime_t(interval, 0));
     lock.Unlock();
   } while (!log->going_down());
 

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -25,6 +25,7 @@
 
 #include "cls/user/cls_user_types.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 #define BUCKET_TAG_TIMEOUT 30

--- a/src/rgw/rgw_civetweb_log.cc
+++ b/src/rgw/rgw_civetweb_log.cc
@@ -6,6 +6,7 @@
 #define dout_subsys ceph_subsys_civetweb
 
 
+#define dout_context g_ceph_context
 int rgw_civetweb_log_callback(const struct mg_connection *conn, const char *buf) {
   dout(0) << "civetweb: " << (void *)conn << ": " << buf << dendl;
   return 0;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -193,7 +193,7 @@ req_state::req_state(CephContext* _cct, RGWEnv* e, RGWUserInfo* u)
 
   system_request = false;
 
-  time = ceph_clock_now(cct);
+  time = ceph_clock_now();
   perm_mask = 0;
   bucket_instance_shard_id = -1;
   content_length = 0;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -23,6 +23,7 @@
 
 #include <sstream>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 PerfCounters *perfcounter = NULL;

--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -160,7 +160,7 @@ stringstream& RGWCoroutine::Status::set_status()
   if (history.size() > (size_t)max_history) {
     history.pop_front();
   }
-  timestamp = ceph_clock_now(cct);
+  timestamp = ceph_clock_now();
 
   return status;
 }

--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -1,4 +1,4 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -16,7 +16,7 @@
 #include <iostream>
 #include <map>
 
-#include <boost/algorithm/string.hpp> 
+#include <boost/algorithm/string.hpp>
 
 #include "include/types.h"
 #include "common/debug.h"
@@ -25,6 +25,7 @@
 
 #include "rgw_cors.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 using namespace std;
 

--- a/src/rgw/rgw_cors_s3.cc
+++ b/src/rgw/rgw_cors_s3.cc
@@ -22,6 +22,7 @@
 #include "rgw_cors_s3.h"
 #include "rgw_user.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -5,6 +5,7 @@
 
 #include "cls/lock/cls_lock_client.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 bool RGWAsyncRadosProcessor::RGWWQ::_enqueue(RGWAsyncRadosRequest *req) {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -570,7 +570,7 @@ class RGWAsyncWait : public RGWAsyncRadosRequest {
 protected:
   int _send_request() {
     Mutex::Locker l(*lock);
-    return cond->WaitInterval(cct, *lock, interval);
+    return cond->WaitInterval(*lock, interval);
   }
 public:
   RGWAsyncWait(RGWCoroutine *caller, RGWAioCompletionNotifier *cn, CephContext *_cct,

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -6,9 +6,9 @@
 
 #include <string>
 #include <map>
-
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 void RGWEnv::init(CephContext *cct)

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1080,7 +1080,7 @@ namespace rgw {
   done:
     dispose_processor(processor);
     perfcounter->tinc(l_rgw_put_lat,
-		      (ceph_clock_now(s->cct) - s->time));
+		      (ceph_clock_now() - s->time));
     return op_ret;
   } /* exec_finish */
 

--- a/src/rgw/rgw_frontend.cc
+++ b/src/rgw/rgw_frontend.cc
@@ -9,6 +9,7 @@
 #include "include/assert.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 int RGWFrontendConfig::parse_config(const string& config,

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -15,6 +15,7 @@
 #include "rgw_civetweb_log.h"
 #include "civetweb/civetweb.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 class RGWFrontendConfig {

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -131,7 +131,7 @@ int RGWGC::list(int *index, string& marker, uint32_t max, bool expired_only, std
 int RGWGC::process(int index, int max_secs)
 {
   rados::cls::lock::Lock l(gc_index_lock_name);
-  utime_t end = ceph_clock_now(g_ceph_context);
+  utime_t end = ceph_clock_now();
   std::list<string> remove_tags;
 
   /* max_secs should be greater than zero. We don't want a zero max_secs
@@ -175,7 +175,7 @@ int RGWGC::process(int index, int max_secs)
       std::list<cls_rgw_obj>::iterator liter;
       cls_rgw_obj_chain& chain = info.chain;
 
-      utime_t now = ceph_clock_now(g_ceph_context);
+      utime_t now = ceph_clock_now();
       if (now >= end)
         goto done;
 
@@ -275,7 +275,7 @@ void RGWGC::stop_processor()
 
 void *RGWGC::GCWorker::entry() {
   do {
-    utime_t start = ceph_clock_now(cct);
+    utime_t start = ceph_clock_now();
     dout(2) << "garbage collection: start" << dendl;
     int r = gc->process();
     if (r < 0) {
@@ -286,7 +286,7 @@ void *RGWGC::GCWorker::entry() {
     if (gc->going_down())
       break;
 
-    utime_t end = ceph_clock_now(cct);
+    utime_t end = ceph_clock_now();
     end -= start;
     int secs = cct->_conf->rgw_gc_processor_period;
 
@@ -296,7 +296,7 @@ void *RGWGC::GCWorker::entry() {
     secs -= end.sec();
 
     lock.Lock();
-    cond.WaitInterval(cct, lock, utime_t(secs, 0));
+    cond.WaitInterval(lock, utime_t(secs, 0));
     lock.Unlock();
   } while (!gc->going_down());
 

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -10,6 +10,7 @@
 
 #include <list>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;

--- a/src/rgw/rgw_http_client.cc
+++ b/src/rgw/rgw_http_client.cc
@@ -16,6 +16,7 @@
 
 #include "rgw_coroutine.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 struct rgw_http_req_data : public RefCountedObject {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -17,6 +17,7 @@
 #include "common/ceph_json.h"
 #include "common/Formatter.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 void encode_json(const char *name, const obj_version& v, Formatter *f)

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -508,8 +508,8 @@ void * RGWKeystoneTokenCache::RevokeThread::entry()
     }
 
     lock.Lock();
-    cond.WaitInterval(cct, lock,
-                      utime_t(cct->_conf->rgw_keystone_revocation_interval, 0));
+    cond.WaitInterval(lock,
+		      utime_t(cct->_conf->rgw_keystone_revocation_interval, 0));
     lock.Unlock();
   } while (!cache->going_down());
 

--- a/src/rgw/rgw_keystone.cc
+++ b/src/rgw/rgw_keystone.cc
@@ -15,6 +15,7 @@
 #include "common/armor.h"
 #include "common/Cond.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 int rgw_open_cms_envelope(CephContext * const cct,

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -123,7 +123,7 @@ public:
   const std::string& get_user_name() const {return user.name;};
   bool has_role(const string& r) const;
   bool expired() {
-    uint64_t now = ceph_clock_now(NULL).sec();
+    uint64_t now = ceph_clock_now().sec();
     return (now >= (uint64_t)get_expires());
   }
   int parse(CephContext *cct,

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -45,7 +45,7 @@ void RGWLifecycleConfiguration::_add_rule(LCRule *rule)
 
 void *RGWLC::LCWorker::entry() {
   do {
-    utime_t start = ceph_clock_now(cct);
+    utime_t start = ceph_clock_now();
     if (should_work(start)) {
       dout(5) << "life cycle: start" << dendl;
       int r = lc->process();
@@ -57,7 +57,7 @@ void *RGWLC::LCWorker::entry() {
     if (lc->going_down())
       break;
 
-    utime_t end = ceph_clock_now(cct);
+    utime_t end = ceph_clock_now();
     int secs = schedule_next_start_time(start, end);
     time_t next_time = end + secs;
     char buf[30];
@@ -65,7 +65,7 @@ void *RGWLC::LCWorker::entry() {
     dout(5) << "schedule life cycle next start time: " << nt <<dendl;
 
     lock.Lock();
-    cond.WaitInterval(cct, lock, utime_t(secs, 0));
+    cond.WaitInterval(lock, utime_t(secs, 0));
     lock.Unlock();
   } while (!lc->going_down());
 
@@ -103,7 +103,7 @@ bool RGWLC::if_already_run_today(time_t& start_date)
 {
   struct tm bdt;
   time_t begin_of_day;
-  utime_t now = ceph_clock_now(cct);
+  utime_t now = ceph_clock_now();
   localtime_r(&start_date, &bdt);
 
   if (cct->_conf->rgw_lc_debug_interval > 0) {
@@ -244,7 +244,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
 
       vector<RGWObjEnt>::iterator obj_iter;
       int pos = 0;
-      utime_t now = ceph_clock_now(cct);
+      utime_t now = ceph_clock_now();
       for (obj_iter = objs.begin(); obj_iter != objs.end(); obj_iter++) {
         bool prefix_match = false;
         int match_days = 0;
@@ -311,7 +311,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
 
         vector<RGWObjEnt>::iterator obj_iter;
         int days = prefix_iter->second;
-        utime_t now = ceph_clock_now(cct);
+        utime_t now = ceph_clock_now();
 
         for (obj_iter = objs.begin(); obj_iter != objs.end(); obj_iter++) {
           if (obj_has_expired(now - ceph::real_clock::to_time_t((*obj_iter).mtime), days)) {
@@ -421,7 +421,7 @@ int RGWLC::process(int index, int max_lock_secs)
 {
   rados::cls::lock::Lock l(lc_index_lock_name);
   do {
-    utime_t now = ceph_clock_now(cct);
+    utime_t now = ceph_clock_now();
     pair<string, int > entry;//string = bucket_name:bucket_id ,int = LC_BUCKET_STATUS
     if (max_lock_secs <= 0)
       return -EAGAIN;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -18,7 +18,7 @@
 #include "rgw_lc_s3.h"
 
 
-
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 const char* LC_STATUS[] = {

--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -118,7 +118,7 @@ void RGWLoadGenProcess::handle_request(RGWRequest* r)
 
   RGWLoadGenRequestEnv env;
 
-  utime_t tm = ceph_clock_now(NULL);
+  utime_t tm = ceph_clock_now();
 
   env.port = 80;
   env.content_length = req->content_length;

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -113,7 +113,7 @@ public:
     timer.init();
     Mutex::Locker l(timer_lock);
     set_timer();
-    utime_t ts = ceph_clock_now(cct);
+    utime_t ts = ceph_clock_now();
     recalc_round_timestamp(ts);
   }
 
@@ -223,7 +223,7 @@ static void log_usage(struct req_state *s, const string& op_name)
 
   entry.add(op_name, data);
 
-  utime_t ts = ceph_clock_now(s->cct);
+  utime_t ts = ceph_clock_now();
 
   usage_logger->insert(ts, entry);
 }
@@ -371,7 +371,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
   uint64_t bytes_received = ACCOUNTING_IO(s)->get_bytes_received();
 
   entry.time = s->time;
-  entry.total_time = ceph_clock_now(s->cct) - s->time;
+  entry.total_time = ceph_clock_now() - s->time;
   entry.bytes_sent = bytes_sent;
   entry.bytes_received = bytes_received;
   if (s->err.http_ret) {

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -157,7 +157,7 @@ bool RGWObjectExpirer::process_single_shard(const string& shard,
   int num_entries = cct->_conf->rgw_objexp_chunk_size;
 
   int max_secs = cct->_conf->rgw_objexp_gc_interval;
-  utime_t end = ceph_clock_now(cct);
+  utime_t end = ceph_clock_now();
   end += max_secs;
 
   rados::cls::lock::Lock l(objexp_lock_name);
@@ -192,7 +192,7 @@ bool RGWObjectExpirer::process_single_shard(const string& shard,
       trim_chunk(shard, last_run, round_start, marker, out_marker);
     }
 
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     if (now >= end) {
       done = false;
       break;
@@ -252,7 +252,7 @@ void RGWObjectExpirer::stop_processor()
 void *RGWObjectExpirer::OEWorker::entry() {
   utime_t last_run;
   do {
-    utime_t start = ceph_clock_now(cct);
+    utime_t start = ceph_clock_now();
     ldout(cct, 2) << "object expiration: start" << dendl;
     if (oe->inspect_all_shards(last_run, start)) {
       /* All shards have been processed properly. Next time we can start
@@ -265,7 +265,7 @@ void *RGWObjectExpirer::OEWorker::entry() {
     if (oe->going_down())
       break;
 
-    utime_t end = ceph_clock_now(cct);
+    utime_t end = ceph_clock_now();
     end -= start;
     int secs = cct->_conf->rgw_objexp_gc_interval;
 
@@ -275,7 +275,7 @@ void *RGWObjectExpirer::OEWorker::entry() {
     secs -= end.sec();
 
     lock.Lock();
-    cond.WaitInterval(cct, lock, utime_t(secs, 0));
+    cond.WaitInterval(lock, utime_t(secs, 0));
     lock.Unlock();
   } while (!oe->going_down());
 

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -35,6 +35,7 @@ using namespace std;
 
 #include "cls/lock/cls_lock_client.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 static string objexp_lock_name = "gc_process";

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -890,7 +890,7 @@ static int iterate_user_manifest_parts(CephContext * const cct,
   bool is_truncated;
   vector<RGWObjEnt> objs;
 
-  utime_t start_time = ceph_clock_now(cct);
+  utime_t start_time = ceph_clock_now();
 
   RGWRados::Bucket target(store, *pbucket_info);
   RGWRados::Bucket::List list_op(&target);
@@ -927,7 +927,7 @@ static int iterate_user_manifest_parts(CephContext * const cct,
       }
 
       perfcounter->tinc(l_rgw_get_lat,
-                       (ceph_clock_now(cct) - start_time));
+			(ceph_clock_now() - start_time));
 
       if (found_start && !handled_end) {
         len_count += end_ofs - start_ofs;
@@ -941,7 +941,7 @@ static int iterate_user_manifest_parts(CephContext * const cct,
       }
 
       handled_end = found_end;
-      start_time = ceph_clock_now(cct);
+      start_time = ceph_clock_now();
     }
   } while (is_truncated);
 
@@ -987,7 +987,7 @@ static int iterate_slo_parts(CephContext *cct,
     return 0;
   }
 
-  utime_t start_time = ceph_clock_now(cct);
+  utime_t start_time = ceph_clock_now();
 
   map<uint64_t, rgw_slo_part>::iterator iter = slo_parts.upper_bound(ofs);
   if (iter != slo_parts.begin()) {
@@ -1020,7 +1020,7 @@ static int iterate_slo_parts(CephContext *cct,
     }
 
     perfcounter->tinc(l_rgw_get_lat,
-                      (ceph_clock_now(cct) - start_time));
+		      (ceph_clock_now() - start_time));
 
     if (found_start) {
       if (cb) {
@@ -1030,7 +1030,7 @@ static int iterate_slo_parts(CephContext *cct,
       }
     }
 
-    start_time = ceph_clock_now(cct);
+    start_time = ceph_clock_now();
   }
 
   return 0;
@@ -1263,7 +1263,7 @@ int RGWGetObj::handle_slo_manifest(bufferlist& bl)
 int RGWGetObj::get_data_cb(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   /* garbage collection related handling */
-  utime_t start_time = ceph_clock_now(s->cct);
+  utime_t start_time = ceph_clock_now();
   if (start_time > gc_invalidate_time) {
     int r = store->defer_gc(s->obj_ctx, obj);
     if (r < 0) {
@@ -1318,7 +1318,7 @@ static bool object_is_expired(map<string, bufferlist>& attrs) {
       return false;
     }
 
-    if (delete_at <= ceph_clock_now(g_ceph_context)) {
+    if (delete_at <= ceph_clock_now()) {
       return true;
     }
   }
@@ -1330,7 +1330,7 @@ void RGWGetObj::execute()
 {
   utime_t start_time = s->time;
   bufferlist bl;
-  gc_invalidate_time = ceph_clock_now(s->cct);
+  gc_invalidate_time = ceph_clock_now();
   gc_invalidate_time += (s->cct->_conf->rgw_gc_obj_min_wait / 2);
 
   bool need_decompress;
@@ -1467,7 +1467,7 @@ void RGWGetObj::execute()
     op_ret = filter->flush();
 
   perfcounter->tinc(l_rgw_get_lat,
-                   (ceph_clock_now(s->cct) - start_time));
+		    (ceph_clock_now() - start_time));
   if (op_ret < 0) {
     goto done_err;
   }
@@ -3188,7 +3188,7 @@ void RGWPutObj::execute()
 done:
   dispose_processor(processor);
   perfcounter->tinc(l_rgw_put_lat,
-                   (ceph_clock_now(s->cct) - s->time));
+		    (ceph_clock_now() - s->time));
 }
 
 int RGWPostObj::verify_permission()

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -42,6 +42,7 @@
 #include "compressor/Compressor.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;

--- a/src/rgw/rgw_orphan.cc
+++ b/src/rgw/rgw_orphan.cc
@@ -206,7 +206,7 @@ int RGWOrphanSearch::init(const string& job_name, RGWOrphanSearchInfo *info) {
     search_info = *info;
     search_info.job_name = job_name;
     search_info.num_shards = (info->num_shards ? info->num_shards : DEFAULT_NUM_SHARDS);
-    search_info.start_time = ceph_clock_now(store->ctx());
+    search_info.start_time = ceph_clock_now();
     search_stage = RGWOrphanSearchStage(ORPHAN_SEARCH_STAGE_INIT);
 
     r = save_state();

--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -182,7 +182,7 @@ int RGWPolicy::add_condition(const string& op, const string& first, const string
 
 int RGWPolicy::check(RGWPolicyEnv *env, string& err_msg)
 {
-  uint64_t now = ceph_clock_now(NULL).sec();
+  uint64_t now = ceph_clock_now().sec();
   if (expires <= now) {
     dout(0) << "NOTICE: policy calculated as expired: " << expiration_str << dendl;
     err_msg = "Policy expired";

--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -8,6 +8,7 @@
 #include "rgw_common.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 class RGWPolicyCondition {

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -21,6 +21,7 @@
 #define def_dout_subsys
 #endif
 
+#define dout_context g_ceph_context
 
 extern void signal_shutdown();
 
@@ -198,5 +199,6 @@ extern int rgw_process_authenticated(RGWHandler_REST* handler,
 #undef def_dout_subsys
 #undef dout_subsys
 #endif
+#undef dout_context
 
 #endif /* RGW_PROCESS_H */

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -26,6 +26,7 @@
 #include "rgw_bucket.h"
 #include "rgw_user.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -73,6 +73,7 @@ using namespace librados;
 
 #include "compressor/Compressor.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2856,7 +2856,7 @@ void *RGWRadosThread::Worker::entry() {
   utime_t interval = utime_t(msec / 1000, (msec % 1000) * 1000000);
 
   do {
-    utime_t start = ceph_clock_now(cct);
+    utime_t start = ceph_clock_now();
     int r = processor->process();
     if (r < 0) {
       dout(0) << "ERROR: processor->process() returned error r=" << r << dendl;
@@ -2865,7 +2865,7 @@ void *RGWRadosThread::Worker::entry() {
     if (processor->going_down())
       break;
 
-    utime_t end = ceph_clock_now(cct);
+    utime_t end = ceph_clock_now();
     end -= start;
 
     uint64_t cur_msec = processor->interval_msec();
@@ -2882,7 +2882,7 @@ void *RGWRadosThread::Worker::entry() {
       wait_time -= end;
 
       lock.Lock();
-      cond.WaitInterval(cct, lock, wait_time);
+      cond.WaitInterval(lock, wait_time);
       lock.Unlock();
     } else {
       lock.Lock();
@@ -5361,7 +5361,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.bucket_index_shard_hash_type = RGWBucketInfo::MOD;
     info.requester_pays = false;
     if (real_clock::is_zero(creation_time)) {
-      info.creation_time = ceph::real_clock::now(cct);
+      info.creation_time = ceph::real_clock::now();
     } else {
       info.creation_time = creation_time;
     }
@@ -11804,7 +11804,7 @@ int RGWRados::process_lc()
 
 int RGWRados::process_expire_objects()
 {
-  obj_expirer->inspect_all_shards(utime_t(), ceph_clock_now(cct));
+  obj_expirer->inspect_all_shards(utime_t(), ceph_clock_now());
   return 0;
 }
 
@@ -12640,7 +12640,7 @@ int RGWStateLog::store_entry(const string& client_id, const string& op_id, const
   if (check_state) {
     cls_statelog_check_state(op, client_id, op_id, object, *check_state);
   }
-  utime_t ts = ceph_clock_now(store->ctx());
+  utime_t ts = ceph_clock_now();
   bufferlist nobl;
   cls_statelog_add(op, client_id, op_id, object, ts, state, (bl ? *bl : nobl));
   r = ioctx.operate(oid, &op);

--- a/src/rgw/rgw_request.cc
+++ b/src/rgw/rgw_request.cc
@@ -21,7 +21,7 @@ void RGWRequest::log_format(struct req_state *s, const char *fmt, ...)
 } /* RGWRequest::log_format */
 
 void RGWRequest::log_init() {
-  ts = ceph_clock_now(g_ceph_context);
+  ts = ceph_clock_now();
 }
 
 void RGWRequest::log(struct req_state *s, const char *msg) {
@@ -30,7 +30,7 @@ void RGWRequest::log(struct req_state *s, const char *msg) {
     req_str.append(" ");
     req_str.append(s->info.request_uri);
   }
-  utime_t t = ceph_clock_now(g_ceph_context) - ts;
+  utime_t t = ceph_clock_now() - ts;
   dout(2) << "req " << id << ":" << t << ":" << s->dialect << ":"
 	  << req_str << ":" << (op ? op->name() : "") << ":" << msg
 	  << dendl;

--- a/src/rgw/rgw_request.cc
+++ b/src/rgw/rgw_request.cc
@@ -4,6 +4,7 @@
 #include "rgw_op.h"
 #include "rgw_request.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 /* XXX */

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -95,9 +95,9 @@ int RGWRESTSimpleRequest::receive_header(void *ptr, size_t len)
   return 0;
 }
 
-static void get_new_date_str(CephContext *cct, string& date_str)
+static void get_new_date_str(string& date_str)
 {
-  utime_t tm = ceph_clock_now(cct);
+  utime_t tm = ceph_clock_now();
   stringstream s;
   tm.asctime(s);
   date_str = s.str();
@@ -117,7 +117,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const c
   new_url.append(new_resource);
 
   string date_str;
-  get_new_date_str(cct, date_str);
+  get_new_date_str(date_str);
   headers.push_back(pair<string, string>("HTTP_DATE", date_str));
 
   string canonical_header;
@@ -248,7 +248,7 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
 {
 
   string date_str;
-  get_new_date_str(cct, date_str);
+  get_new_date_str(date_str);
 
   RGWEnv new_env;
   req_info new_info(cct, &new_env);
@@ -433,7 +433,7 @@ int RGWRESTStreamWriteRequest::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uin
     new_url.append("/");
 
   string date_str;
-  get_new_date_str(cct, date_str);
+  get_new_date_str(date_str);
 
   RGWEnv new_env;
   req_info new_info(cct, &new_env);
@@ -631,7 +631,7 @@ int RGWRESTStreamRWRequest::get_resource(RGWAccessKey& key, map<string, string>&
     new_url.append("/");
 
   string date_str;
-  get_new_date_str(cct, date_str);
+  get_new_date_str(date_str);
 
   RGWEnv new_env;
   req_info new_info(cct, &new_env);

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -12,6 +12,7 @@
 #include "common/strtol.h"
 #include "include/str_list.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 int RGWRESTSimpleRequest::get_status()

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -22,6 +22,7 @@
 #include "common/errno.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 void RGWOp_ZoneGroupMap_Get::execute() {

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -23,6 +23,7 @@
 #include "common/errno.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define LOG_CLASS_LIST_MAX_ENTRIES (1000)
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rest_metadata.cc
+++ b/src/rgw/rgw_rest_metadata.cc
@@ -22,6 +22,7 @@
 #include "common/strtol.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 const string RGWOp_Metadata_Get::name() {

--- a/src/rgw/rgw_rest_opstate.cc
+++ b/src/rgw/rgw_rest_opstate.cc
@@ -21,6 +21,7 @@
 #include "common/errno.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define OPSTATE_LIST_MAX_ENTRIES 1000
 #define dout_subsys ceph_subsys_rgw
 

--- a/src/rgw/rgw_rest_replica_log.cc
+++ b/src/rgw/rgw_rest_replica_log.cc
@@ -24,6 +24,7 @@
 #include "common/errno.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 #define REPLICA_INPUT_MAX_LEN (512*1024)
 

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -33,6 +33,7 @@
 #include "rgw_token.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 using namespace rgw;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3526,7 +3526,7 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s, bool force_b
   bool using_qs;
 
   uint64_t now_req = 0;
-  uint64_t now = ceph_clock_now(s->cct);
+  uint64_t now = ceph_clock_now();
 
   /* v4 requires rados auth */
   if (!store->ctx()->_conf->rgw_s3_auth_use_rados) {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -80,7 +80,7 @@ static void dump_account_metadata(struct req_state * const s,
                                   const RGWAccessControlPolicy_SWIFTAcct &policy)
 {
   /* Adding X-Timestamp to keep align with Swift API */
-  dump_header(s, "X-Timestamp", ceph_clock_now(g_ceph_context));
+  dump_header(s, "X-Timestamp", ceph_clock_now());
 
   dump_header(s, "X-Account-Container-Count", buckets_count);
   dump_header(s, "X-Account-Object-Count", buckets_object_count);
@@ -1545,7 +1545,7 @@ void RGWInfo_ObjStore_SWIFT::list_slo_data(Formatter& formatter,
 bool RGWInfo_ObjStore_SWIFT::is_expired(const std::string& expires, CephContext* cct)
 {
   string err;
-  const utime_t now = ceph_clock_now(cct);
+  const utime_t now = ceph_clock_now();
   const uint64_t expiration = (uint64_t)strict_strtoll(expires.c_str(),
                                                        10, &err);
   if (!err.empty()) {

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -31,6 +31,7 @@
 
 #include <boost/utility/string_ref.hpp>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 int RGWListBuckets_ObjStore_SWIFT::get_params()

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -116,7 +116,7 @@ void RGWTempURLAuthEngine::get_owner_info(RGWUserInfo& owner_info) const
 bool RGWTempURLAuthEngine::is_expired(const std::string& expires) const
 {
   string err;
-  const utime_t now = ceph_clock_now(g_ceph_context);
+  const utime_t now = ceph_clock_now();
   const uint64_t expiration = (uint64_t)strict_strtoll(expires.c_str(),
                                                        10, &err);
   if (!err.empty()) {
@@ -373,7 +373,7 @@ static int encode_token(CephContext *cct, string& swift_user, string& key,
   if (ret < 0)
     return ret;
 
-  utime_t expiration = ceph_clock_now(cct);
+  utime_t expiration = ceph_clock_now();
   expiration += cct->_conf->rgw_swift_token_expiration;
 
   return build_token(swift_user, key, nonce, expiration, bl);
@@ -426,7 +426,7 @@ RGWAuthApplier::aplptr_t RGWSignedTokenAuthEngine::authenticate() const
     throw -EINVAL;
   }
 
-  const utime_t now = ceph_clock_now(cct);
+  const utime_t now = ceph_clock_now();
   if (expiration < now) {
     ldout(cct, 0) << "NOTICE: old timed out token was used now=" << now
 	          << " token.expiration=" << expiration

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -18,6 +18,7 @@
 #include "rgw_http_client.h"
 #include "include/str_list.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 #define DEFAULT_SWIFT_PREFIX "/swift"

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -525,7 +525,7 @@ public:
   virtual void SetUp() {
     char *path = getenv("OBJECT_MAP_PATH");
     if (!path) {
-      db.reset(new DBObjectMap(new KeyValueDBMemory()));
+      db.reset(new DBObjectMap(g_ceph_context, new KeyValueDBMemory()));
       tester.db = db.get();
       return;
     }
@@ -536,7 +536,7 @@ public:
     KeyValueDB *store = KeyValueDB::create(g_ceph_context, "leveldb", strpath);
     assert(!store->create_and_open(cerr));
 
-    db.reset(new DBObjectMap(store));
+    db.reset(new DBObjectMap(g_ceph_context, store));
     tester.db = db.get();
   }
 

--- a/src/test/TestSignalHandlers.cc
+++ b/src/test/TestSignalHandlers.cc
@@ -28,6 +28,7 @@
 #include <sstream>
 #include <string>
 
+#define dout_context g_ceph_context
 using std::string;
 
 // avoid compiler warning about dereferencing NULL pointer

--- a/src/test/TestTimers.cc
+++ b/src/test/TestTimers.cc
@@ -94,7 +94,7 @@ static int basic_timer_test(T &timer, Mutex *lock)
     if (lock)
       lock->Lock();
     utime_t inc(2 * i, 0);
-    utime_t t = ceph_clock_now(g_ceph_context) + inc;
+    utime_t t = ceph_clock_now() + inc;
     timer.add_event_at(t, test_contexts[i]);
     if (lock)
       lock->Unlock();
@@ -133,7 +133,7 @@ static int test_out_of_order_insertion(SafeTimer &timer, Mutex *lock)
 
   {
     utime_t inc(100, 0);
-    utime_t t = ceph_clock_now(g_ceph_context) + inc;
+    utime_t t = ceph_clock_now() + inc;
     lock->Lock();
     timer.add_event_at(t, test_contexts[0]);
     lock->Unlock();
@@ -141,7 +141,7 @@ static int test_out_of_order_insertion(SafeTimer &timer, Mutex *lock)
 
   {
     utime_t inc(2, 0);
-    utime_t t = ceph_clock_now(g_ceph_context) + inc;
+    utime_t t = ceph_clock_now() + inc;
     lock->Lock();
     timer.add_event_at(t, test_contexts[1]);
     lock->Unlock();
@@ -182,7 +182,7 @@ static int safe_timer_cancel_all_test(SafeTimer &safe_timer, Mutex& safe_timer_l
   safe_timer_lock.Lock();
   for (int i = 0; i < MAX_TEST_CONTEXTS; ++i) {
     utime_t inc(4 * i, 0);
-    utime_t t = ceph_clock_now(g_ceph_context) + inc;
+    utime_t t = ceph_clock_now() + inc;
     safe_timer.add_event_at(t, test_contexts[i]);
   }
   safe_timer_lock.Unlock();
@@ -220,7 +220,7 @@ static int safe_timer_cancellation_test(SafeTimer &safe_timer, Mutex& safe_timer
   safe_timer_lock.Lock();
   for (int i = 0; i < MAX_TEST_CONTEXTS; ++i) {
     utime_t inc(4 * i, 0);
-    utime_t t = ceph_clock_now(g_ceph_context) + inc;
+    utime_t t = ceph_clock_now() + inc;
     safe_timer.add_event_at(t, test_contexts[i]);
   }
   safe_timer_lock.Unlock();

--- a/src/test/bench/small_io_bench_fs.cc
+++ b/src/test/bench/small_io_bench_fs.cc
@@ -132,7 +132,7 @@ int main(int argc, char **argv)
   ops.insert(make_pair(vm["write-ratio"].as<double>(), Bencher::WRITE));
   ops.insert(make_pair(1-vm["write-ratio"].as<double>(), Bencher::READ));
 
-  FileStore fs(vm["filestore-path"].as<string>(),
+  FileStore fs(g_ceph_context, vm["filestore-path"].as<string>(),
 	       vm["journal-path"].as<string>());
   ObjectStore::Sequencer osr(__func__);
 

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -42,7 +42,7 @@ int main(int argc, const char **argv)
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_OSD,
 			 CODE_ENVIRONMENT_UTILITY, 0);
 
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
 
   list<T*> ls;
   for (int i=0; i<threads; i++) {
@@ -58,13 +58,13 @@ int main(int argc, const char **argv)
     delete t;
   }
 
-  utime_t t = ceph_clock_now(NULL);
+  utime_t t = ceph_clock_now();
   t -= start;
   cout << " flushing.. " << t << " so far ..." << std::endl;
 
   g_ceph_context->_log->flush();
 
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
 
   cout << dur << std::endl;

--- a/src/test/bench_log.cc
+++ b/src/test/bench_log.cc
@@ -9,6 +9,8 @@
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
 
+#define dout_context g_ceph_context
+
 struct T : public Thread {
   int num;
   set<int> myset;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -219,12 +219,12 @@ TEST(Buffer, constructors) {
 
 void bench_buffer_alloc(int size, int num)
 {
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   for (int i=0; i<num; ++i) {
     bufferptr p = buffer::create(size);
     p.zero();
   }
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   cout << num << " alloc of size " << size
        << " in " << (end - start) << std::endl;
 }
@@ -751,7 +751,7 @@ TEST(BufferPtr, copy_out) {
 
 TEST(BufferPtr, copy_out_bench) {
   for (int s=1; s<=8; s*=2) {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     int buflen = 1048576;
     int count = 1000;
     uint64_t v;
@@ -761,7 +761,7 @@ TEST(BufferPtr, copy_out_bench) {
 	bp.copy_out(j, s, (char *)&v);
       }
     }
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     cout << count << " fills of buffer len " << buflen
 	 << " with " << s << " byte copy_out in"
 	 << (end - start) << std::endl;
@@ -786,7 +786,7 @@ TEST(BufferPtr, copy_in) {
 
 TEST(BufferPtr, copy_in_bench) {
   for (int s=1; s<=8; s*=2) {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     int buflen = 1048576;
     int count = 1000;
     for (int i=0; i<count; ++i) {
@@ -795,7 +795,7 @@ TEST(BufferPtr, copy_in_bench) {
 	bp.copy_in(j, s, (char *)&j, false);
       }
     }
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     cout << count << " fills of buffer len " << buflen
 	 << " with " << s << " byte copy_in in "
 	 << (end - start) << std::endl;
@@ -826,7 +826,7 @@ TEST(BufferPtr, append_bench) {
   char src[1048576];
   memset(src, 0, sizeof(src));
   for (int s=4; s<=16384; s*=4) {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     int buflen = 1048576;
     int count = 4000;
     for (int i=0; i<count; ++i) {
@@ -836,7 +836,7 @@ TEST(BufferPtr, append_bench) {
 	bp.append(src, s);
       }
     }
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     cout << count << " fills of buffer len " << buflen
 	 << " with " << s << " byte appends in "
 	 << (end - start) << std::endl;
@@ -1397,13 +1397,13 @@ TEST(BufferList, constructors) {
 
 void bench_bufferlist_alloc(int size, int num, int per)
 {
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   for (int i=0; i<num; ++i) {
     bufferlist bl;
     for (int j=0; j<per; ++j)
       bl.append(buffer::create(size));
   }
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   cout << num << " alloc of size " << size
        << " in " << (end - start) << std::endl;
 }
@@ -2534,18 +2534,18 @@ TEST(BufferList, crc32c_append_perf) {
   bufferlist blb;
   blb.push_back(b);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = bla.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "a.crc32c(0) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 1138817026u);
   }
   assert(buffer::get_cached_crc() == 0 + base_cached);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = bla.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "a.crc32c(0) (again) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 1138817026u);
@@ -2553,9 +2553,9 @@ TEST(BufferList, crc32c_append_perf) {
   assert(buffer::get_cached_crc() == 1 + base_cached);
 
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = bla.crc32c(5);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "a.crc32c(5) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 3239494520u);
@@ -2563,9 +2563,9 @@ TEST(BufferList, crc32c_append_perf) {
   assert(buffer::get_cached_crc() == 1 + base_cached);
   assert(buffer::get_cached_crc_adjusted() == 1 + base_cached_adjusted);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = bla.crc32c(5);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "a.crc32c(5) (again) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 3239494520u);
@@ -2574,18 +2574,18 @@ TEST(BufferList, crc32c_append_perf) {
   assert(buffer::get_cached_crc_adjusted() == 2 + base_cached_adjusted);
 
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = blb.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "b.crc32c(0) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 2481791210u);
   }
   assert(buffer::get_cached_crc() == 1 + base_cached);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = blb.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "b.crc32c(0) (again)= " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 2481791210u);
@@ -2596,9 +2596,9 @@ TEST(BufferList, crc32c_append_perf) {
   ab.push_back(a);
   ab.push_back(b);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = ab.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)ab.length() / (float)(1024*1024) / (float)(end - start);
     std::cout << "ab.crc32c(0) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 2988268779u);
@@ -2609,9 +2609,9 @@ TEST(BufferList, crc32c_append_perf) {
   ac.push_back(a);
   ac.push_back(c);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = ac.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)ac.length() / (float)(1024*1024) / (float)(end - start);
     std::cout << "ac.crc32c(0) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 2988268779u);
@@ -2623,9 +2623,9 @@ TEST(BufferList, crc32c_append_perf) {
   ba.push_back(b);
   ba.push_back(a);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = ba.crc32c(0);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)ba.length() / (float)(1024*1024) / (float)(end - start);
     std::cout << "ba.crc32c(0) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 169240695u);
@@ -2633,9 +2633,9 @@ TEST(BufferList, crc32c_append_perf) {
   assert(buffer::get_cached_crc() == 5 + base_cached);
   assert(buffer::get_cached_crc_adjusted() == 4 + base_cached_adjusted);
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     uint32_t r = ba.crc32c(5);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)ba.length() / (float)(1024*1024) / (float)(end - start);
     std::cout << "ba.crc32c(5) = " << r << " at " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(r, 1265464778u);

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -283,12 +283,12 @@ TEST(ClsLock, TestLockDuration) {
   Lock l("lock");
   utime_t dur(5, 0);
   l.set_duration(dur);
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   ASSERT_EQ(0, l.lock_exclusive(&ioctx, oid));
   int r = l.lock_exclusive(&ioctx, oid);
   if (r == 0) {
     // it's possible to get success if we were just really slow...
-    ASSERT_TRUE(ceph_clock_now(NULL) > start + dur);
+    ASSERT_TRUE(ceph_clock_now() > start + dur);
   } else {
     ASSERT_EQ(-EEXIST, r);
   }

--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -122,7 +122,7 @@ TEST(cls_rgw, test_log_add_same_time)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now(g_ceph_context);
+  utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, false);
 
   librados::ObjectReadOperation *rop = new_rop();
@@ -209,7 +209,7 @@ TEST(cls_rgw, test_log_add_different_time)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now(g_ceph_context);
+  utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
   librados::ObjectReadOperation *rop = new_rop();
@@ -305,7 +305,7 @@ TEST(cls_rgw, test_log_trim)
   ASSERT_EQ(0, ioctx.create(oid, true));
 
   /* generate log */
-  utime_t start_time = ceph_clock_now(g_ceph_context);
+  utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
   librados::ObjectReadOperation *rop = new_rop();

--- a/src/test/cls_statelog/test_cls_statelog.cc
+++ b/src/test/cls_statelog/test_cls_statelog.cc
@@ -38,7 +38,7 @@ void add_log(librados::ObjectWriteOperation *op, const string& client_id, const 
   bufferlist bl;
   ::encode(state, bl);
 
-  utime_t ts = ceph_clock_now(g_ceph_context);
+  utime_t ts = ceph_clock_now();
 
   cls_statelog_add(*op, client_id, op_id, obj, ts, state, bl);
 }

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -50,42 +50,42 @@ TEST(Crc32c, Performance) {
   std::cout << "calculating crc" << std::endl;
 
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     unsigned val = ceph_crc32c(0, (unsigned char *)a, len);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "best choice = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);
   }
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     unsigned val = ceph_crc32c(0xffffffff, (unsigned char *)a, len);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "best choice 0xffffffff = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(3895876243u, val);
   }
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     unsigned val = ceph_crc32c_sctp(0, (unsigned char *)a, len);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "sctp = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);
   }
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     unsigned val = ceph_crc32c_intel_baseline(0, (unsigned char *)a, len);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "intel baseline = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);
   }
   if (ceph_arch_aarch64_crc32) // Skip if CRC32C instructions are not defined.
   {
-    utime_t start = ceph_clock_now(NULL);
+    utime_t start = ceph_clock_now();
     unsigned val = ceph_crc32c_aarch64(0, (unsigned char *)a, len);
-    utime_t end = ceph_clock_now(NULL);
+    utime_t end = ceph_clock_now();
     float rate = (float)len / (float)(1024*1024) / (float)(end - start);
     std::cout << "aarch64 = " << rate << " MB/sec" << std::endl;
     ASSERT_EQ(261108528u, val);

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -158,14 +158,14 @@ TEST(AES, Loop) {
 TEST(AES, LoopKey) {
   bufferptr k(16);
   get_random_bytes(k.c_str(), k.length());
-  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(NULL), k);
+  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(), k);
 
   bufferlist data;
   bufferptr r(128);
   get_random_bytes(r.c_str(), r.length());
   data.append(r);
 
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   int n = 100000;
 
   for (int i=0; i<n; ++i) {
@@ -175,7 +175,7 @@ TEST(AES, LoopKey) {
     ASSERT_EQ(r, 0);
   }
 
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   cout << n << " encoded in " << dur << std::endl;
 }

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -176,14 +176,14 @@ int ErasureCodeBench::encode()
   for (int i = 0; i < k + m; i++) {
     want_to_encode.insert(i);
   }
-  utime_t begin_time = ceph_clock_now(g_ceph_context);
+  utime_t begin_time = ceph_clock_now();
   for (int i = 0; i < max_iterations; i++) {
     map<int,bufferlist> encoded;
     code = erasure_code->encode(want_to_encode, in, &encoded);
     if (code)
       return code;
   }
-  utime_t end_time = ceph_clock_now(g_ceph_context);
+  utime_t end_time = ceph_clock_now();
   cout << (end_time - begin_time) << "\t" << (max_iterations * (in_size / 1024)) << endl;
   return 0;
 }
@@ -295,7 +295,7 @@ int ErasureCodeBench::decode()
     display_chunks(encoded, erasure_code->get_chunk_count());
   }
 
-  utime_t begin_time = ceph_clock_now(g_ceph_context);
+  utime_t begin_time = ceph_clock_now();
   for (int i = 0; i < max_iterations; i++) {
     if (exhaustive_erasures) {
       code = decode_erasures(encoded, encoded, 0, erasures, erasure_code);
@@ -321,7 +321,7 @@ int ErasureCodeBench::decode()
 	return code;
     }
   }
-  utime_t end_time = ceph_clock_now(g_ceph_context);
+  utime_t end_time = ceph_clock_now();
   cout << (end_time - begin_time) << "\t" << (max_iterations * (in_size / 1024)) << endl;
   return 0;
 }

--- a/src/test/filestore/TestFileStore.cc
+++ b/src/test/filestore/TestFileStore.cc
@@ -30,7 +30,7 @@ TEST(FileStore, create)
 {
   {
     map<string,string> pm;
-    FileStore fs("a", "b");
+    FileStore fs(g_ceph_context, "a", "b");
     TestFileStore::create_backend(fs, 0);
     fs.collect_metadata(&pm);
     ASSERT_EQ(pm["filestore_backend"], "generic");
@@ -38,7 +38,7 @@ TEST(FileStore, create)
 #if defined(__linux__)
   {
     map<string,string> pm;
-    FileStore fs("a", "b");
+    FileStore fs(g_ceph_context, "a", "b");
     TestFileStore::create_backend(fs, BTRFS_SUPER_MAGIC);
     fs.collect_metadata(&pm);
     ASSERT_EQ(pm["filestore_backend"], "btrfs");
@@ -46,7 +46,7 @@ TEST(FileStore, create)
 # ifdef HAVE_LIBXFS
   {
     map<string,string> pm;
-    FileStore fs("a", "b");
+    FileStore fs(g_ceph_context, "a", "b");
     TestFileStore::create_backend(fs, XFS_SUPER_MAGIC);
     fs.collect_metadata(&pm);
     ASSERT_EQ(pm["filestore_backend"], "xfs");

--- a/src/test/journal/RadosTestFixture.cc
+++ b/src/test/journal/RadosTestFixture.cc
@@ -119,8 +119,7 @@ bool RadosTestFixture::wait_for_update(journal::JournalMetadataPtr metadata) {
   Mutex::Locker locker(m_listener.mutex);
   while (m_listener.updates[metadata.get()] == 0) {
     if (m_listener.cond.WaitInterval(
-          reinterpret_cast<CephContext*>(m_ioctx.cct()),
-          m_listener.mutex, utime_t(10, 0)) != 0) {
+	  m_listener.mutex, utime_t(10, 0)) != 0) {
       return false;
     }
   }

--- a/src/test/journal/test_JournalPlayer.cc
+++ b/src/test/journal/test_JournalPlayer.cc
@@ -101,7 +101,6 @@ public:
       if (m_replay_hander.entries_available) {
         m_replay_hander.entries_available = false;
       } else if (m_replay_hander.cond.WaitInterval(
-          reinterpret_cast<CephContext*>(m_ioctx.cct()),
           m_replay_hander.lock, utime_t(10, 0)) != 0) {
         break;
       }
@@ -117,7 +116,6 @@ public:
       player->try_pop_front(&entry, &commit_tid);
 
       if (m_replay_hander.cond.WaitInterval(
-            reinterpret_cast<CephContext*>(m_ioctx.cct()),
             m_replay_hander.lock, utime_t(10, 0)) != 0) {
         return false;
       }

--- a/src/test/journal/test_ObjectRecorder.cc
+++ b/src/test/journal/test_ObjectRecorder.cc
@@ -372,7 +372,6 @@ TEST_F(TestObjectRecorder, Close) {
     Mutex::Locker locker(m_handler.lock);
     while (!m_handler.is_closed) {
       if (m_handler.cond.WaitInterval(
-            reinterpret_cast<CephContext*>(m_ioctx.cct()),
             m_handler.lock, utime_t(10, 0)) != 0) {
         break;
       }
@@ -423,7 +422,6 @@ TEST_F(TestObjectRecorder, Overflow) {
     Mutex::Locker locker(m_handler.lock);
     while (m_handler.overflows == 0) {
       if (m_handler.cond.WaitInterval(
-            reinterpret_cast<CephContext*>(m_ioctx.cct()),
             m_handler.lock, utime_t(10, 0)) != 0) {
         break;
       }

--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -326,7 +326,7 @@ void KvStoreBench::aio_callback_timed(int * err, void *arg) {
   //throughput
   args->kvsb->data.throughput_jf.open_object_section("throughput");
   args->kvsb->data.throughput_jf.dump_unsigned(string(1, args->op).c_str(),
-      ceph_clock_now(g_ceph_context));
+      ceph_clock_now());
   args->kvsb->data.throughput_jf.close_section();
 
   data_lock->Unlock();

--- a/src/test/kv_store_bench.h
+++ b/src/test/kv_store_bench.h
@@ -50,10 +50,10 @@ struct StopWatch {
   utime_t end_time;
 
   void start_time() {
-    begin_time = ceph_clock_now(g_ceph_context);
+    begin_time = ceph_clock_now();
   }
   void stop_time() {
-    end_time = ceph_clock_now(g_ceph_context);
+    end_time = ceph_clock_now();
   }
   double get_time() {
     return (end_time - begin_time) * 1000;

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -2162,11 +2162,11 @@ TEST_F(LibRadosTwoPoolsPP, HitSetRead) {
   cache_ioctx.set_namespace("");
 
   // keep reading until we see our object appear in the HitSet
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   utime_t hard_stop = start + utime_t(600, 0);
 
   while (true) {
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     ASSERT_TRUE(now < hard_stop);
 
     string name = "foo";
@@ -2345,7 +2345,7 @@ TEST_F(LibRadosTwoPoolsPP, HitSetTrim) {
   cache_ioctx.set_namespace("");
 
   // do a bunch of writes and make sure the hitsets rotate
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   utime_t hard_stop = start + utime_t(count * period * 50, 0);
 
   time_t first = 0;
@@ -2378,7 +2378,7 @@ TEST_F(LibRadosTwoPoolsPP, HitSetTrim) {
       }
     }
 
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     ASSERT_TRUE(now < hard_stop);
 
     sleep(1);
@@ -4828,11 +4828,11 @@ TEST_F(LibRadosTwoPoolsECPP, HitSetRead) {
   cache_ioctx.set_namespace("");
 
   // keep reading until we see our object appear in the HitSet
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   utime_t hard_stop = start + utime_t(600, 0);
 
   while (true) {
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     ASSERT_TRUE(now < hard_stop);
 
     string name = "foo";
@@ -4971,7 +4971,7 @@ TEST_F(LibRadosTwoPoolsECPP, HitSetTrim) {
   cache_ioctx.set_namespace("");
 
   // do a bunch of writes and make sure the hitsets rotate
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   utime_t hard_stop = start + utime_t(count * period * 50, 0);
 
   time_t first = 0;
@@ -5008,7 +5008,7 @@ TEST_F(LibRadosTwoPoolsECPP, HitSetTrim) {
       }
     }
 
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     ASSERT_TRUE(now < hard_stop);
 
     sleep(1);

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -24,6 +24,7 @@
 #include "include/assert.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rados
 
 namespace {

--- a/src/test/librados_test_stub/TestClassHandler.cc
+++ b/src/test/librados_test_stub/TestClassHandler.cc
@@ -11,6 +11,7 @@
 #include "common/debug.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rados
 
 namespace librados {

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.cc
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.cc
@@ -614,7 +614,7 @@ TestMemRadosClient::SharedFile TestMemIoCtxImpl::get_file(
 
     if (new_version) {
       file->snap_id = snapc.seq;
-      file->mtime = ceph_clock_now(m_client->cct()).sec();
+      file->mtime = ceph_clock_now().sec();
       m_pool->files[oid].push_back(file);
     }
     return file;

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -93,9 +93,9 @@ public:
   bool wait_for_entries_available(librbd::ImageCtx *ictx) {
     Mutex::Locker locker(m_replay_handler.lock);
     while (!m_replay_handler.entries_available) {
-      if (m_replay_handler.cond.WaitInterval(ictx->cct, m_replay_handler.lock,
-                                             utime_t(10, 0)) != 0) {
-        return false;
+      if (m_replay_handler.cond.WaitInterval(m_replay_handler.lock,
+					     utime_t(10, 0)) != 0) {
+	return false;
       }
     }
     m_replay_handler.entries_available = false;

--- a/src/test/librbd/test_ImageWatcher.cc
+++ b/src/test/librbd/test_ImageWatcher.cc
@@ -135,8 +135,8 @@ public:
   bool wait_for_notifies(librbd::ImageCtx &ictx) {
     Mutex::Locker l(m_callback_lock);
     while (m_notifies.size() < m_notify_acks.size()) {
-      int r = m_callback_cond.WaitInterval(ictx.cct, m_callback_lock,
-					 utime_t(10, 0));
+      int r = m_callback_cond.WaitInterval(m_callback_lock,
+					   utime_t(10, 0));
       if (r != 0) {
 	break;
       }
@@ -238,7 +238,7 @@ struct ProgressContext : public librbd::ProgressContext {
   bool wait(librbd::ImageCtx *ictx, uint64_t offset_, uint64_t total_) {
     Mutex::Locker l(mutex);
     while (!received) {
-      int r = cond.WaitInterval(ictx->cct, mutex, utime_t(10, 0));
+      int r = cond.WaitInterval(mutex, utime_t(10, 0));
       if (r != 0) {
 	break;
       }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -633,8 +633,7 @@ TEST_F(TestLibRBD, UpdateWatchAndResize)
     void wait_for_size(size_t size) {
       Mutex::Locker locker(m_lock);
       while (m_size != size) {
-	CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
-	ASSERT_EQ(0, m_cond.WaitInterval(cct, m_lock, seconds(5)));
+	ASSERT_EQ(0, m_cond.WaitInterval(m_lock, seconds(5)));
       }
     }
     rbd_image_t &m_image;
@@ -685,8 +684,7 @@ TEST_F(TestLibRBD, UpdateWatchAndResizePP)
       void wait_for_size(size_t size) {
 	Mutex::Locker locker(m_lock);
 	while (m_size != size) {
-	  CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());
-	  ASSERT_EQ(0, m_cond.WaitInterval(cct, m_lock, seconds(5)));
+	  ASSERT_EQ(0, m_cond.WaitInterval(m_lock, seconds(5)));
 	}
       }
       librbd::Image &m_image;

--- a/src/test/librbd/test_mock_AioImageRequest.cc
+++ b/src/test/librbd/test_mock_AioImageRequest.cc
@@ -128,6 +128,7 @@ AioObjectRead<librbd::MockTestImageCtx>* AioObjectRead<librbd::MockTestImageCtx>
 } // namespace librbd
 
 #include "librbd/AioImageRequest.cc"
+
 template class librbd::AioImageRequest<librbd::MockTestImageCtx>;
 
 namespace librbd {

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include "test/librbd/test_mock_fixture.h"
@@ -26,6 +26,7 @@
 #include <list>
 #include <boost/scope_exit.hpp>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd
 
 namespace librbd {

--- a/src/test/librbd/test_mock_ObjectWatcher.cc
+++ b/src/test/librbd/test_mock_ObjectWatcher.cc
@@ -153,8 +153,7 @@ public:
   bool wait_for_watch(MockImageCtx &mock_image_ctx, size_t count) {
     Mutex::Locker locker(m_lock);
     while (m_watch_count < count) {
-      if (m_cond.WaitInterval(mock_image_ctx.cct, m_lock,
-                              utime_t(10, 0)) != 0) {
+      if (m_cond.WaitInterval(m_lock, utime_t(10, 0)) != 0) {
         return false;
       }
     }

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -28,6 +28,7 @@
 #include "common/debug.h"
 #include "global/global_init.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 namespace {

--- a/src/test/librgw_file_gp.cc
+++ b/src/test/librgw_file_gp.cc
@@ -28,6 +28,7 @@
 #include "common/debug.h"
 #include "global/global_init.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
 namespace {

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -262,9 +262,9 @@ public:
     if (timeout > 0) {
       utime_t cond_timeout;
       cond_timeout.set_from_double(timeout);
-      utime_t s = ceph_clock_now(g_ceph_context);
-      err = cond.WaitInterval(g_ceph_context, lock, cond_timeout);
-      utime_t e = ceph_clock_now(g_ceph_context);
+      utime_t s = ceph_clock_now();
+      err = cond.WaitInterval(lock, cond_timeout);
+      utime_t e = ceph_clock_now();
       dout(20) << __func__ << " took " << (e-s) << " seconds" << dendl;
     } else {
       err = cond.Wait(lock);

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -42,6 +42,7 @@
 #include "messages/MGenericMessage.h"
 #include "messages/MMonJoin.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
 #undef dout_prefix
 #define dout_prefix *_dout << "test-mon-msg "

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -449,7 +449,7 @@ class OSDStub : public TestStub
   void boot() {
     dout(1) << __func__ << " boot?" << dendl;
 
-    utime_t now = ceph_clock_now(messenger->cct);
+    utime_t now = ceph_clock_now();
     if ((last_boot_attempt > 0.0)
 	&& ((now - last_boot_attempt)) <= STUB_BOOT_INTERVAL) {
       dout(1) << __func__ << " backoff and try again later." << dendl;
@@ -465,7 +465,7 @@ class OSDStub : public TestStub
 
   void add_pg(pg_t pgid, epoch_t epoch, pg_t parent) {
 
-    utime_t now = ceph_clock_now(messenger->cct);
+    utime_t now = ceph_clock_now();
 
     pg_stat_t s;
     s.created = epoch;
@@ -543,7 +543,7 @@ class OSDStub : public TestStub
   void send_pg_stats() {
     dout(10) << __func__
 	     << " pgs " << pgs.size() << " osdmap " << osdmap << dendl;
-    utime_t now = ceph_clock_now(messenger->cct);
+    utime_t now = ceph_clock_now();
     MPGStats *mstats = new MPGStats(monc.get_fsid(), osdmap.get_epoch(), now);
 
     mstats->set_tid(1);
@@ -577,7 +577,7 @@ class OSDStub : public TestStub
     assert(pgs.count(pgid) > 0);
 
     pg_stat_t &s = pgs[pgid];
-    utime_t now = ceph_clock_now(messenger->cct);
+    utime_t now = ceph_clock_now();
 
     if (now - s.last_change < 10.0) {
       dout(10) << __func__
@@ -702,7 +702,7 @@ class OSDStub : public TestStub
     dout(10) << __func__
 	     << " send " << num_entries << " log messages" << dendl;
 
-    utime_t now = ceph_clock_now(messenger->cct);
+    utime_t now = ceph_clock_now();
     int seq = 0;
     for (; num_entries > 0; --num_entries) {
       LogEntry e;

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -63,6 +63,7 @@
 
 using namespace std;
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, get_name())

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -124,12 +124,12 @@ class C_poll : public EventCallback {
     woken = true;
   }
   bool poll(int milliseconds) {
-    auto start = ceph::coarse_real_clock::now(g_ceph_context);
+    auto start = ceph::coarse_real_clock::now();
     while (!woken) {
       center->process_events(sleepus);
       usleep(sleepus);
       auto r = std::chrono::duration_cast<std::chrono::milliseconds>(
-              ceph::coarse_real_clock::now(g_ceph_context) - start);
+              ceph::coarse_real_clock::now() - start);
       if (r >= std::chrono::milliseconds(milliseconds))
         break;
     }

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -738,7 +738,7 @@ TEST_P(MessengerTest, MessageTest) {
     t += 1000*1000*500;
     Mutex::Locker l(cli_dispatcher.lock);
     while (!cli_dispatcher.got_new)
-      cli_dispatcher.cond.WaitInterval(g_ceph_context, cli_dispatcher.lock, t);
+      cli_dispatcher.cond.WaitInterval(cli_dispatcher.lock, t);
     ASSERT_TRUE(cli_dispatcher.got_new);
     cli_dispatcher.got_new = false;
   }
@@ -756,7 +756,7 @@ TEST_P(MessengerTest, MessageTest) {
     t += 1000*1000*500;
     Mutex::Locker l(cli_dispatcher.lock);
     while (!cli_dispatcher.got_new)
-      cli_dispatcher.cond.WaitInterval(g_ceph_context, cli_dispatcher.lock, t);
+      cli_dispatcher.cond.WaitInterval(cli_dispatcher.lock, t);
     ASSERT_TRUE(cli_dispatcher.got_new);
     cli_dispatcher.got_new = false;
   }

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -24,7 +24,8 @@ public:
     AllocTest(): alloc(0) { }
     void init_alloc(int64_t size, uint64_t min_alloc_size) {
       std::cout << "Creating alloc type " << string(GetParam()) << " \n";
-      alloc.reset(Allocator::create(string(GetParam()), size, min_alloc_size));
+      alloc.reset(Allocator::create(g_ceph_context, string(GetParam()), size,
+				    min_alloc_size));
     }
 
     void init_close() {
@@ -224,7 +225,7 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
   if (GetParam() == std::string("stupid")) {
     return;
   }
-  int64_t blocks = BitMapArea::get_level_factor(2) * 4;
+  int64_t blocks = BitMapArea::get_level_factor(g_ceph_context, 2) * 4;
   int count = 0;
   int64_t allocated = 0;
   int64_t zone_size = 1024;

--- a/src/test/objectstore/DeterministicOpSequence.cc
+++ b/src/test/objectstore/DeterministicOpSequence.cc
@@ -29,6 +29,7 @@
 #include "common/config.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "deterministic_seq "

--- a/src/test/objectstore/FileStoreDiff.cc
+++ b/src/test/objectstore/FileStoreDiff.cc
@@ -20,6 +20,7 @@
 
 #include "FileStoreDiff.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "filestore_diff "

--- a/src/test/objectstore/TestObjectStoreState.cc
+++ b/src/test/objectstore/TestObjectStoreState.cc
@@ -25,6 +25,7 @@
 #include "TestObjectStoreState.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout << "ceph_test_objectstore_state "

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -47,7 +47,7 @@ TEST(BlueFS, mkfs) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
   uuid_d fsid;
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   fs.add_block_device(BlueFS::BDEV_DB, fn);
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   fs.mkfs(fsid);
@@ -57,7 +57,7 @@ TEST(BlueFS, mkfs) {
 TEST(BlueFS, mkfs_mount) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -72,7 +72,7 @@ TEST(BlueFS, mkfs_mount) {
 TEST(BlueFS, write_read) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -104,7 +104,7 @@ TEST(BlueFS, write_read) {
 TEST(BlueFS, small_appends) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -255,7 +255,7 @@ TEST(BlueFS, test_flush_1) {
     "65536");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -290,7 +290,7 @@ TEST(BlueFS, test_flush_2) {
     "65536");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -318,7 +318,7 @@ TEST(BlueFS, test_flush_3) {
     "65536");
   g_ceph_context->_conf->apply_changes(NULL);
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -352,7 +352,7 @@ TEST(BlueFS, test_simple_compaction_sync) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -405,7 +405,7 @@ TEST(BlueFS, test_simple_compaction_async) {
   uint64_t size = 1048576 * 128;
   string fn = get_temp_bdev(size);
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -461,7 +461,7 @@ TEST(BlueFS, test_compaction_sync) {
     "bluefs_compact_log_sync",
     "true");
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -499,7 +499,7 @@ TEST(BlueFS, test_compaction_async) {
     "bluefs_compact_log_sync",
     "false");
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;
@@ -537,7 +537,7 @@ TEST(BlueFS, test_replay) {
     "bluefs_compact_log_sync",
     "false");
 
-  BlueFS fs;
+  BlueFS fs(g_ceph_context);
   ASSERT_EQ(0, fs.add_block_device(BlueFS::BDEV_DB, fn));
   fs.add_block_extent(BlueFS::BDEV_DB, 1048576, size - 1048576);
   uuid_d fsid;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1,4 +1,4 @@
-// -*- mode:C; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
@@ -317,7 +317,7 @@ TEST(bluestore_blob_t, csum_bench)
 TEST(Blob, put_ref)
 {
   {
-    BlueStore::Blob b;
+    BlueStore::Blob b(g_ceph_context);
     b.shared_blob = new BlueStore::SharedBlob(nullptr);
     b.shared_blob->get();  // hack to avoid dtor from running
     b.dirty_blob().extents.push_back(bluestore_pextent_t(0x40715000, 0x2000));
@@ -336,14 +336,14 @@ TEST(Blob, put_ref)
     r.clear();
     b.put_ref(0xae00, 0x4200, 0x1000, &r);
     cout << " r " << r << std::endl;
-    cout << b << std::endl;  
+    cout << b << std::endl;
   }
 
   unsigned mas = 4096;
   unsigned mrs = 8192;
 
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -363,7 +363,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*2, b.extents[0].length);
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -384,7 +384,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*2, b.extents[0].length);
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -419,7 +419,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(3u, b.extents.size());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -457,7 +457,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.extents[4].is_valid());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -486,7 +486,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.extents[2].is_valid());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -521,7 +521,7 @@ TEST(Blob, put_ref)
     ASSERT_TRUE(b.extents[2].is_valid());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -571,7 +571,7 @@ TEST(Blob, put_ref)
     ASSERT_FALSE(b.extents[0].is_valid());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -621,7 +621,7 @@ TEST(Blob, put_ref)
     ASSERT_FALSE(b.extents[0].is_valid());
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -659,7 +659,7 @@ TEST(Blob, put_ref)
   }
   // verify csum chunk size if factored in properly
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -676,7 +676,7 @@ TEST(Blob, put_ref)
     ASSERT_EQ(mas*4, b.extents[0].length);
   }
   {
-    BlueStore::Blob B;
+    BlueStore::Blob B(g_ceph_context);
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
@@ -759,9 +759,10 @@ TEST(bluestore_blob_t, prune_tail)
 
 TEST(Blob, split)
 {
-  BlueStore::Cache *cache = BlueStore::Cache::create("lru", NULL);
+  BlueStore::Cache *cache = BlueStore::Cache::create(
+    g_ceph_context, "lru", NULL);
   {
-    BlueStore::Blob L, R;
+    BlueStore::Blob L(g_ceph_context), R(g_ceph_context);
     L.shared_blob = new BlueStore::SharedBlob(cache);
     L.shared_blob->get();  // hack to avoid dtor from running
     R.shared_blob = new BlueStore::SharedBlob(cache);
@@ -781,7 +782,7 @@ TEST(Blob, split)
     ASSERT_EQ(0x1000u, R.get_blob().extents.front().length);
   }
   {
-    BlueStore::Blob L, R;
+    BlueStore::Blob L(g_ceph_context), R(g_ceph_context);
     L.shared_blob = new BlueStore::SharedBlob(cache);
     L.shared_blob->get();  // hack to avoid dtor from running
     R.shared_blob = new BlueStore::SharedBlob(cache);
@@ -805,9 +806,9 @@ TEST(Blob, split)
 
 TEST(ExtentMap, find_lextent)
 {
-  BlueStore::LRUCache cache;
-  BlueStore::ExtentMap em(nullptr);
-  BlueStore::BlobRef br(new BlueStore::Blob);
+  BlueStore::LRUCache cache(g_ceph_context);
+  BlueStore::ExtentMap em(g_ceph_context, nullptr);
+  BlueStore::BlobRef br(new BlueStore::Blob(g_ceph_context));
   br->shared_blob = new BlueStore::SharedBlob(&cache);
 
   ASSERT_EQ(em.extent_map.end(), em.find_lextent(0));
@@ -851,9 +852,9 @@ TEST(ExtentMap, find_lextent)
 
 TEST(ExtentMap, seek_lextent)
 {
-  BlueStore::LRUCache cache;
-  BlueStore::ExtentMap em(nullptr);
-  BlueStore::BlobRef br(new BlueStore::Blob);
+  BlueStore::LRUCache cache(g_ceph_context);
+  BlueStore::ExtentMap em(g_ceph_context, nullptr);
+  BlueStore::BlobRef br(new BlueStore::Blob(g_ceph_context));
   br->shared_blob = new BlueStore::SharedBlob(&cache);
 
   ASSERT_EQ(em.extent_map.end(), em.seek_lextent(0));
@@ -897,9 +898,9 @@ TEST(ExtentMap, seek_lextent)
 
 TEST(ExtentMap, has_any_lextents)
 {
-  BlueStore::LRUCache cache;
-  BlueStore::ExtentMap em(nullptr);
-  BlueStore::BlobRef b(new BlueStore::Blob);
+  BlueStore::LRUCache cache(g_ceph_context);
+  BlueStore::ExtentMap em(g_ceph_context, nullptr);
+  BlueStore::BlobRef b(new BlueStore::Blob(g_ceph_context));
   b->shared_blob = new BlueStore::SharedBlob(&cache);
 
   ASSERT_FALSE(em.has_any_lextents(0, 0));
@@ -941,11 +942,11 @@ TEST(ExtentMap, has_any_lextents)
 
 TEST(ExtentMap, compress_extent_map)
 {
-  BlueStore::LRUCache cache;
-  BlueStore::ExtentMap em(nullptr);
-  BlueStore::BlobRef b1(new BlueStore::Blob);
-  BlueStore::BlobRef b2(new BlueStore::Blob);
-  BlueStore::BlobRef b3(new BlueStore::Blob);
+  BlueStore::LRUCache cache(g_ceph_context);
+  BlueStore::ExtentMap em(g_ceph_context, nullptr);
+  BlueStore::BlobRef b1(new BlueStore::Blob(g_ceph_context));
+  BlueStore::BlobRef b2(new BlueStore::Blob(g_ceph_context));
+  BlueStore::BlobRef b3(new BlueStore::Blob(g_ceph_context));
   b1->shared_blob = new BlueStore::SharedBlob(&cache);
   b2->shared_blob = new BlueStore::SharedBlob(&cache);
   b3->shared_blob = new BlueStore::SharedBlob(&cache);

--- a/src/test/objectstore/test_idempotent.cc
+++ b/src/test/objectstore/test_idempotent.cc
@@ -66,7 +66,8 @@ int main(int argc, char **argv) {
   KeyValueDB *_db = KeyValueDB::create(g_ceph_context, "leveldb", db_path);
   assert(!_db->create_and_open(std::cerr));
   boost::scoped_ptr<KeyValueDB> db(_db);
-  boost::scoped_ptr<ObjectStore> store(new FileStore(store_path, store_dev));
+  boost::scoped_ptr<ObjectStore> store(new FileStore(cct.get(), store_path,
+						     store_dev));
 
   ObjectStore::Sequencer osr(__func__);
   coll_t coll(spg_t(pg_t(0,12),shard_id_t::NO_SHARD));

--- a/src/test/objectstore/test_idempotent_sequence.cc
+++ b/src/test/objectstore/test_idempotent_sequence.cc
@@ -27,6 +27,7 @@
 #include "common/config.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_
 #undef dout_prefix
 #define dout_prefix *_dout << "test_idempotent_sequence "

--- a/src/test/objectstore/test_idempotent_sequence.cc
+++ b/src/test/objectstore/test_idempotent_sequence.cc
@@ -78,10 +78,10 @@ int verify_at = 0;
 std::string status_file;
 
 int run_diff(std::string& a_path, std::string& a_journal,
-	      std::string& b_path, std::string& b_journal)
+	     std::string& b_path, std::string& b_journal)
 {
-  FileStore *a = new FileStore(a_path, a_journal, 0, "a");
-  FileStore *b = new FileStore(b_path, b_journal, 0, "b");
+  FileStore *a = new FileStore(g_ceph_context, a_path, a_journal, 0, "a");
+  FileStore *b = new FileStore(g_ceph_context, b_path, b_journal, 0, "b");
 
   int ret = 0;
   {
@@ -101,7 +101,8 @@ int run_diff(std::string& a_path, std::string& a_journal,
 
 int run_get_last_op(std::string& filestore_path, std::string& journal_path)
 {
-  FileStore *store = new FileStore(filestore_path, journal_path);
+  FileStore *store = new FileStore(g_ceph_context, filestore_path,
+				   journal_path);
 
   int err = store->mount();
   if (err) {
@@ -135,7 +136,8 @@ int run_sequence_to(int val, std::string& filestore_path,
   if (!is_seed_set)
     seed = (int) time(NULL);
 
-  FileStore *store = new FileStore(filestore_path, journal_path);
+  FileStore *store = new FileStore(g_ceph_context, filestore_path,
+				   journal_path);
 
   int err;
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -159,7 +159,7 @@ TEST_P(KVTest, PutReopen) {
 TEST_P(KVTest, BenchCommit) {
   int n = 1024;
   ASSERT_EQ(0, db->create_and_open(cout));
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   {
     cout << "priming" << std::endl;
     // prime
@@ -183,7 +183,7 @@ TEST_P(KVTest, BenchCommit) {
     t->set("prefix", "key" + stringify(i), data);
     db->submit_transaction_sync(t);
   }
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   utime_t dur = end - start;
   cout << n << " commits in " << dur << ", avg latency " << (dur / (double)n)
        << std::endl;

--- a/src/test/objectstore/test_memstore_clone.cc
+++ b/src/test/objectstore/test_memstore_clone.cc
@@ -20,6 +20,8 @@
 #include "common/errno.h"
 #include "store_test_fixture.h"
 
+#define dout_context g_ceph_context
+
 namespace {
 
 const coll_t cid;

--- a/src/test/objectstore/test_transaction.cc
+++ b/src/test/objectstore/test_transaction.cc
@@ -186,7 +186,7 @@ void bench_num_bytes(bool legacy)
     cout << "get_encoded_bytes: ";
   }
 
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   if (legacy) {
     for (int i = 0; i < max; ++i) {
       a.get_encoded_bytes_test();
@@ -197,7 +197,7 @@ void bench_num_bytes(bool legacy)
     }
   }
 
-  utime_t end = ceph_clock_now(NULL);
+  utime_t end = ceph_clock_now();
   cout << max << " encodes in " << (end - start) << std::endl;
 
 }

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -387,7 +387,7 @@ TestObjectStoreState::coll_entry_t
 
 void WorkloadGenerator::do_stats()
 {
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   m_stats_lock.Lock();
 
   utime_t duration = (now - m_stats_begin);
@@ -412,7 +412,7 @@ void WorkloadGenerator::run()
   int ops_run = 0;
 
   utime_t stats_interval(m_stats_show_secs, 0);
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   utime_t stats_time = now;
   m_stats_begin = now;
 
@@ -441,7 +441,7 @@ void WorkloadGenerator::run()
 
 
     if (m_do_stats) {
-      utime_t now = ceph_clock_now(NULL);
+      utime_t now = ceph_clock_now();
       utime_t elapsed = now - stats_time;
       if (elapsed >= stats_interval) {
 	do_stats();

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -31,6 +31,8 @@
 
 #include "TestObjectStoreState.h"
 
+#define dout_context g_ceph_context
+
 static const char *our_name = NULL;
 void usage();
 

--- a/src/test/objectstore_bench.cc
+++ b/src/test/objectstore_bench.cc
@@ -15,6 +15,7 @@
 #include "common/strtol.h"
 #include "common/ceph_argparse.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 
 static void usage()

--- a/src/test/old/test_disk_bw.cc
+++ b/src/test/old/test_disk_bw.cc
@@ -39,7 +39,7 @@ int main(int argc, char **argv)
   }
   
  
-  utime_t start = ceph_clock_now(g_ceph_context);
+  utime_t start = ceph_clock_now();
   while (loop++ < count) {
     int ret = safe_write(fd, buf, bsize);
     if (ret)
@@ -49,7 +49,7 @@ int main(int argc, char **argv)
   }
   ::fsync(fd);
   ::close(fd);
-  utime_t end = ceph_clock_now(g_ceph_context);
+  utime_t end = ceph_clock_now();
   end -= start;
 
 

--- a/src/test/old/test_seek_read.c
+++ b/src/test/old/test_seek_read.c
@@ -36,7 +36,7 @@ int main(int argc, char **argv)
     
     int s = blocks*4096;
 
-    utime_t start = ceph_clock_now(g_ceph_context);
+    utime_t start = ceph_clock_now();
     for (int i=0; i<count; i++) {
       off64_t o = (lrand48() % numblocks) * 4096;
       //cout << "s = " << s << " o = " << o << endl;
@@ -47,7 +47,7 @@ int main(int argc, char **argv)
       //int r = ::read(fd, buf, s);
       if (r < 0) cout << "r = " << r << " " << strerror(errno) << endl;
     }
-    utime_t end = ceph_clock_now(g_ceph_context);
+    utime_t end = ceph_clock_now();
     
     double timeper = end - start;
     timeper /= count;

--- a/src/test/old/test_short_seek_read.c
+++ b/src/test/old/test_short_seek_read.c
@@ -50,10 +50,10 @@ int main(int argc, char **argv)
       so = o + 4096*((rand() % range) );//- range/2);
       //cout << o << " " << so << " " << (so-o) << endl;
 
-      utime_t start = ceph_clock_now(g_ceph_context);
+      utime_t start = ceph_clock_now();
       lseek64(fd, so, SEEK_SET);
       r = ::read(fd, buf, blocks*4096);
-      utime_t end = ceph_clock_now(g_ceph_context);
+      utime_t end = ceph_clock_now();
       timeper += (end-start);
     }
     

--- a/src/test/old/testcounter.cc
+++ b/src/test/old/testcounter.cc
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
   DecayCounter dc(hl);
   RealCounter rc;
 
-  utime_t now = ceph_clock_now(g_ceph_context);
+  utime_t now = ceph_clock_now();
 
   for (int ms=0; ms < 300*1000; ms++) {
 	if (ms % 30000 == 0) {

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -133,10 +133,10 @@ Writer::Writer(OmapBench *omap_bench) : ob(omap_bench) {
   oid = name.str();
 }
 void Writer::start_time() {
-  begin_time = ceph_clock_now(g_ceph_context);
+  begin_time = ceph_clock_now();
 }
 void Writer::stop_time() {
-  end_time = ceph_clock_now(g_ceph_context);
+  end_time = ceph_clock_now();
 }
 double Writer::get_time() {
   return (end_time - begin_time) * 1000;

--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -29,9 +29,11 @@
 
 class TestWrapLFNIndex : public LFNIndex {
 public:
-  TestWrapLFNIndex(coll_t collection,
+  TestWrapLFNIndex(CephContext* cct,
+		   coll_t collection,
 		   const char *base_path,
-		   uint32_t index_version) : LFNIndex(collection, base_path, index_version) {}
+		   uint32_t index_version)
+    : LFNIndex(cct, collection, base_path, index_version) {}
 
   virtual uint32_t collection_version() {
     return index_version;
@@ -92,7 +94,9 @@ protected:
 
 class TestHASH_INDEX_TAG : public TestWrapLFNIndex, public ::testing::Test {
 public:
-  TestHASH_INDEX_TAG() : TestWrapLFNIndex(coll_t(), "PATH_1", CollectionIndex::HASH_INDEX_TAG) {
+  TestHASH_INDEX_TAG()
+    : TestWrapLFNIndex(g_ceph_context, coll_t(), "PATH_1",
+		       CollectionIndex::HASH_INDEX_TAG) {
   }
 };
 
@@ -110,7 +114,9 @@ TEST_F(TestHASH_INDEX_TAG, generate_and_parse_name) {
 
 class TestHASH_INDEX_TAG_2 : public TestWrapLFNIndex, public ::testing::Test {
 public:
-  TestHASH_INDEX_TAG_2() : TestWrapLFNIndex(coll_t(), "PATH_1", CollectionIndex::HASH_INDEX_TAG_2) {
+  TestHASH_INDEX_TAG_2()
+    : TestWrapLFNIndex(g_ceph_context,
+		       coll_t(), "PATH_1", CollectionIndex::HASH_INDEX_TAG_2) {
   }
 };
 
@@ -133,7 +139,9 @@ TEST_F(TestHASH_INDEX_TAG_2, generate_and_parse_name) {
 
 class TestHOBJECT_WITH_POOL : public TestWrapLFNIndex, public ::testing::Test {
 public:
-  TestHOBJECT_WITH_POOL() : TestWrapLFNIndex(coll_t(), "PATH_1", CollectionIndex::HOBJECT_WITH_POOL) {
+  TestHOBJECT_WITH_POOL()
+    : TestWrapLFNIndex(g_ceph_context, coll_t(),
+		       "PATH_1", CollectionIndex::HOBJECT_WITH_POOL) {
   }
 };
 
@@ -177,7 +185,9 @@ TEST_F(TestHOBJECT_WITH_POOL, generate_and_parse_name) {
 
 class TestLFNIndex : public TestWrapLFNIndex, public ::testing::Test {
 public:
-  TestLFNIndex() : TestWrapLFNIndex(coll_t(), "PATH_1", CollectionIndex::HOBJECT_WITH_POOL) {
+  TestLFNIndex()
+    : TestWrapLFNIndex(g_ceph_context, coll_t(), "PATH_1",
+		       CollectionIndex::HOBJECT_WITH_POOL) {
   }
 
   virtual void SetUp() {

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -14,6 +14,7 @@
 
 #include "MemWriteback.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_objectcacher
 #undef dout_prefix
 #define dout_prefix *_dout << "MemWriteback(" << this << ") "

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -889,7 +889,7 @@ double perf_ceph_clock_now()
   int count = 100000;
   uint64_t start = Cycles::rdtsc();
   for (int i = 0; i < count; i++) {
-    ceph_clock_now(g_ceph_context);
+    ceph_clock_now();
   }
   uint64_t stop = Cycles::rdtsc();
   return Cycles::to_seconds(stop - start)/count;

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -134,8 +134,7 @@ public:
                                std::function<void()> fn = []() {}) {
     Mutex::Locker locker(mock_object_copy_request.lock);
     while (mock_object_copy_request.object_contexts.count(object_num) == 0) {
-      if (mock_object_copy_request.cond.WaitInterval(m_local_image_ctx->cct,
-                                                     mock_object_copy_request.lock,
+      if (mock_object_copy_request.cond.WaitInterval(mock_object_copy_request.lock,
                                                      utime_t(10, 0)) != 0) {
         return false;
       }
@@ -153,8 +152,7 @@ public:
   MockImageCopyRequest::SnapMap wait_for_snap_map(MockObjectCopyRequest &mock_object_copy_request) {
     Mutex::Locker locker(mock_object_copy_request.lock);
     while (mock_object_copy_request.snap_map == nullptr) {
-      if (mock_object_copy_request.cond.WaitInterval(m_local_image_ctx->cct,
-                                                     mock_object_copy_request.lock,
+      if (mock_object_copy_request.cond.WaitInterval(mock_object_copy_request.lock,
                                                      utime_t(10, 0)) != 0) {
         return MockImageCopyRequest::SnapMap();
       }

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -71,7 +71,7 @@ struct rbd_bencher {
     while (in_flight > max) {
       utime_t dur;
       dur.set_from_double(.2);
-      cond.WaitInterval(g_ceph_context, lock, dur);
+      cond.WaitInterval(lock, dur);
     }
   }
 

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -12,6 +12,7 @@
 #include <string>
 #include <vector>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "random-write: "

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -262,7 +262,7 @@ public:
 
     Mutex::Locker locker(m_watch_ctx->lock);
     while (!m_watch_ctx->notified) {
-      if (m_watch_ctx->cond.WaitInterval(g_ceph_context, m_watch_ctx->lock,
+      if (m_watch_ctx->cond.WaitInterval(m_watch_ctx->lock,
 					 utime_t(seconds, 0)) != 0) {
         return false;
       }

--- a/src/test/signals.cc
+++ b/src/test/signals.cc
@@ -12,6 +12,7 @@
 
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 static volatile sig_atomic_t got_sigusr1 = 0;
 
 static void handle_sigusr1(int signo)

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -120,8 +120,8 @@ TEST(TestFileJournal, Create) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
   }
 }
@@ -134,8 +134,8 @@ TEST(TestFileJournal, WriteSmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -159,8 +159,8 @@ TEST(TestFileJournal, WriteBig) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -187,8 +187,8 @@ TEST(TestFileJournal, WriteMany) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -220,8 +220,8 @@ TEST(TestFileJournal, WriteManyVecs) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -272,8 +272,8 @@ TEST(TestFileJournal, ReplaySmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -332,8 +332,8 @@ TEST(TestFileJournal, ReplayCorrupt) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -417,8 +417,8 @@ TEST(TestFileJournal, WriteTrim) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -469,8 +469,8 @@ TEST(TestFileJournal, WriteTrimSmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -519,8 +519,8 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -578,8 +578,8 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 
@@ -637,8 +637,8 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(fsid, finisher, &sync_cond, path, subtests[i].directio,
-		  subtests[i].aio, subtests[i].faio);
+    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
     ASSERT_EQ(0, j.create());
     j.make_writeable();
 

--- a/src/test/test_rewrite_latency.cc
+++ b/src/test/test_rewrite_latency.cc
@@ -23,10 +23,10 @@ int main(int argc, const char **argv)
   }
 
   while (true) {
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     int r = ::pwrite(fd, fn, strlen(fn), 0);
     assert(r >= 0);
-    utime_t lat = ceph_clock_now(NULL);
+    utime_t lat = ceph_clock_now();
     lat -= now;
     utime_t oldmin;
     if (!latency.empty())

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -451,7 +451,7 @@ public:
     uint32_t mask,
     uint32_t bits)
     : driver(driver),
-      mapper(new SnapMapper(driver, mask, bits, 0, shard_id_t(1))),
+      mapper(new SnapMapper(g_ceph_context, driver, mask, bits, 0, shard_id_t(1))),
              mask(mask), bits(bits),
       lock("lock") {}
 

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -19,6 +19,7 @@
 #include "global/global_init.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_filestore
 #undef dout_prefix
 #define dout_prefix *_dout

--- a/src/test/test_trans.cc
+++ b/src/test/test_trans.cc
@@ -51,7 +51,7 @@ int main(int argc, const char **argv)
   cout << "#dev " << filename << std::endl;
   cout << "#mb " << mb << std::endl;
 
-  ObjectStore *fs = new FileStore(filename, NULL);
+  ObjectStore *fs = new FileStore(cct.get(), filename, NULL);
   if (fs->mount() < 0) {
     cout << "mount failed" << std::endl;
     return -1;

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -13,7 +13,7 @@ int main(int argc, char *argv[])
   char aes_key[AES_KEY_LEN];
   memset(aes_key, 0x77, sizeof(aes_key));
   bufferptr keybuf(aes_key, sizeof(aes_key));
-  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(g_ceph_context), keybuf);
+  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(), keybuf);
 
   const char *msg="hello! this is a message\n";
   char pad[16];

--- a/src/test/testcrypto.cc
+++ b/src/test/testcrypto.cc
@@ -8,6 +8,8 @@
 
 #define AES_KEY_LEN	16
 
+#define dout_context g_ceph_context
+
 int main(int argc, char *argv[])
 {
   char aes_key[AES_KEY_LEN];

--- a/src/test/testkeys.cc
+++ b/src/test/testkeys.cc
@@ -4,6 +4,8 @@
 #include "common/config.h"
 #include "common/debug.h"
 
+#define dout_context g_ceph_context
+
 #define AES_KEY_LEN	16
 
 int main(int argc, const char **argv)

--- a/src/test/testkeys.cc
+++ b/src/test/testkeys.cc
@@ -26,7 +26,7 @@ int main(int argc, const char **argv)
   char aes_key[AES_KEY_LEN];
   memset(aes_key, 0x77, sizeof(aes_key));
   bufferptr keybuf(aes_key, sizeof(aes_key));
-  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(g_ceph_context), keybuf);
+  CryptoKey key(CEPH_CRYPTO_AES, ceph_clock_now(), keybuf);
 
   const char *msg="hello! this is a message\n";
   char pad[16];

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -165,7 +165,8 @@ int main(int argc, char **argv) {
   string store_path(args[1]);
   string store_dev(args[2]);
 
-  boost::scoped_ptr<ObjectStore> store(new FileStore(store_path, store_dev));
+  boost::scoped_ptr<ObjectStore> store(new FileStore(cct.get(), store_path,
+						     store_dev));
 
   std::cerr << "mkfs starting" << std::endl;
   assert(!store->mkfs());

--- a/src/tools/ceph-client-debug.cc
+++ b/src/tools/ceph-client-debug.cc
@@ -23,6 +23,7 @@
 #include "client/Dir.h"
 #include "include/cephfs/libcephfs.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_client
 
 void usage()

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -161,7 +161,7 @@ class StoreTool
     uint64_t total_size = 0;
     uint64_t total_txs = 0;
 
-    utime_t started_at = ceph_clock_now(g_ceph_context);
+    utime_t started_at = ceph_clock_now();
 
     do {
       int num_keys = 0;
@@ -186,14 +186,14 @@ class StoreTool
       if (num_keys > 0)
         other->submit_transaction_sync(tx);
 
-      utime_t cur_duration = ceph_clock_now(g_ceph_context) - started_at;
+      utime_t cur_duration = ceph_clock_now() - started_at;
       std::cout << "ts = " << cur_duration << "s, copied " << total_keys
                 << " keys so far (" << stringify(si_t(total_size)) << ")"
                 << std::endl;
 
     } while (it->valid());
 
-    utime_t time_taken = ceph_clock_now(g_ceph_context) - started_at;
+    utime_t time_taken = ceph_clock_now() - started_at;
 
     std::cout << "summary:" << std::endl;
     std::cout << "  copied " << total_keys << " keys" << std::endl;

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -494,7 +494,7 @@ int inflate_pgmap(MonitorDBStore& st, unsigned n, bool can_be_trimmed) {
       }
       ::encode(ps->second, dirty_pgs);
     }
-    utime_t inc_stamp = ceph_clock_now(NULL);
+    utime_t inc_stamp = ceph_clock_now();
     ::encode(inc_stamp, trans_bl);
     ::encode_destructively(dirty_pgs, trans_bl);
     bufferlist dirty_osds;
@@ -635,7 +635,7 @@ static int update_pgmap_meta(MonitorDBStore& st)
   // the first pgmap_meta
   t->put(prefix, "version", 1);
   {
-    auto stamp = ceph_clock_now(g_ceph_context);
+    auto stamp = ceph_clock_now();
     bufferlist bl;
     ::encode(stamp, bl);
     t->put(prefix, "stamp", bl);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -377,7 +377,7 @@ int finish_remove_pgs(ObjectStore *store)
     if (it->is_temp(&pgid) ||
        (it->is_pg(&pgid) && PG::_has_removal_flag(store, pgid))) {
       cout << "finish_remove_pgs " << *it << " removing " << pgid << std::endl;
-      OSD::recursive_remove_collection(store, pgid, *it);
+      OSD::recursive_remove_collection(g_ceph_context, store, pgid, *it);
       continue;
     }
 
@@ -450,6 +450,7 @@ int write_info(ObjectStore::Transaction &t, epoch_t epoch, pg_info_t &info,
   map<string,bufferlist> km;
   pg_info_t last_written_info;
   int ret = PG::_prepare_write_info(
+    g_ceph_context,
     &km, epoch,
     info,
     last_written_info,
@@ -890,7 +891,7 @@ int ObjectStoreTool::get_object(ObjectStore *store, coll_t coll,
     OSD::make_snapmapper_oid());
   spg_t pg;
   coll.is_pg_prefix(&pg);
-  SnapMapper mapper(&driver, 0, 0, 0, pg.shard);
+  SnapMapper mapper(g_ceph_context, &driver, 0, 0, 0, pg.shard);
 
   if (ob.hoid.hobj.is_temp()) {
     cerr << "ERROR: Export contains temporary object '" << ob.hoid << "'" << std::endl;
@@ -1445,7 +1446,7 @@ int do_remove_object(ObjectStore *store, coll_t coll,
     store,
     coll_t(),
     OSD::make_snapmapper_oid());
-  SnapMapper mapper(&driver, 0, 0, 0, pg.shard);
+  SnapMapper mapper(g_ceph_context, &driver, 0, 0, 0, pg.shard);
   struct stat st;
 
   int r = store->stat(coll, ghobj, &st);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2228,7 +2228,8 @@ int mydump_journal(Formatter *f, string journalpath, bool m_journal_dio)
   if (!journalpath.length())
     return -EINVAL;
 
-  FileJournal *journal = new FileJournal(uuid_d(), NULL, NULL, journalpath.c_str(), m_journal_dio);
+  FileJournal *journal = new FileJournal(g_ceph_context, uuid_d(), NULL, NULL,
+					 journalpath.c_str(), m_journal_dio);
   r = journal->_fdump(*f, false);
   delete journal;
   return r;

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
     std::cerr << "Enabling paranoid checks" << std::endl;
     store->options.paranoid_checks = true;
     }*/
-  DBObjectMap omap(store);
+  DBObjectMap omap(cct.get(), store);
   stringstream out;
   int r = store->open(out);
   if (r < 0) {

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -342,8 +342,8 @@ int MetadataDriver::inject_unlinked_inode(
   // (we won't actually give the *correct* dirstat here though)
   inode.inode.dirstat.nfiles = 1;
 
-  inode.inode.ctime = 
-    inode.inode.mtime = ceph_clock_now(g_ceph_context);
+  inode.inode.ctime =
+    inode.inode.mtime = ceph_clock_now();
   inode.inode.nlink = 1;
   inode.inode.truncate_size = -1ull;
   inode.inode.truncate_seq = 1;

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -24,6 +24,7 @@
 #include "DataScan.h"
 #include "include/compat.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "datascan." << __func__ << ": "

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -258,7 +258,7 @@ int Dumper::undump(const char *dump_file)
   C_SaferCond header_cond;
   lock.Lock();
   objecter->write_full(oid, oloc, snapc, hbl,
-		       ceph::real_clock::now(g_ceph_context), 0,
+		       ceph::real_clock::now(), 0,
 		       NULL, &header_cond);
   lock.Unlock();
 
@@ -285,7 +285,7 @@ int Dumper::undump(const char *dump_file)
     cout << "Purging " << purge_count << " objects from " << last_obj << std::endl;
     lock.Lock();
     filer.purge_range(ino, &h.layout, snapc, last_obj, purge_count,
-		      ceph::real_clock::now(g_ceph_context), 0, &purge_cond);
+		      ceph::real_clock::now(), 0, &purge_cond);
     lock.Unlock();
     purge_cond.wait();
   }
@@ -305,7 +305,7 @@ int Dumper::undump(const char *dump_file)
     C_SaferCond write_cond;
     lock.Lock();
     filer.write(ino, &h.layout, snapc, pos, l, j,
-		ceph::real_clock::now(g_ceph_context), 0, NULL, &write_cond);
+		ceph::real_clock::now(), 0, NULL, &write_cond);
     lock.Unlock();
 
     r = write_cond.wait();

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -28,6 +28,7 @@
 
 #include "Dumper.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 #define HEADER_LEN 4096

--- a/src/tools/cephfs/JournalFilter.cc
+++ b/src/tools/cephfs/JournalFilter.cc
@@ -19,6 +19,7 @@
 #include "mds/events/ESession.h"
 #include "mds/events/EUpdate.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 

--- a/src/tools/cephfs/JournalScanner.cc
+++ b/src/tools/cephfs/JournalScanner.cc
@@ -19,6 +19,7 @@
 
 #include "JournalScanner.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 /**

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -32,6 +32,7 @@
 #include "JournalTool.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << __func__ << ": "

--- a/src/tools/cephfs/MDSUtility.cc
+++ b/src/tools/cephfs/MDSUtility.cc
@@ -14,6 +14,7 @@
 #include "MDSUtility.h"
 #include "mon/MonClient.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 

--- a/src/tools/cephfs/PgFiles.cc
+++ b/src/tools/cephfs/PgFiles.cc
@@ -18,6 +18,7 @@
 #include "PgFiles.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << "pgeffects." << __func__ << ": "

--- a/src/tools/cephfs/Resetter.cc
+++ b/src/tools/cephfs/Resetter.cc
@@ -23,6 +23,7 @@
 
 #include "Resetter.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
 int Resetter::reset(mds_role_t role)

--- a/src/tools/cephfs/TableTool.cc
+++ b/src/tools/cephfs/TableTool.cc
@@ -22,6 +22,7 @@
 #include "TableTool.h"
 
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
 #define dout_prefix *_dout << __func__ << ": "

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -36,6 +36,7 @@
 #include "crush/CrushTester.h"
 #include "include/assert.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_crush
 
 using namespace std;

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -307,7 +307,7 @@ int main(int argc, const char **argv)
 
   if (create) {
     monmap.epoch = 0;
-    monmap.created = ceph_clock_now(g_ceph_context);
+    monmap.created = ceph_clock_now();
     monmap.last_changed = monmap.created;
     srand(getpid() + time(0));
     if (g_conf->fsid.is_zero()) {

--- a/src/tools/rados/PoolDump.cc
+++ b/src/tools/rados/PoolDump.cc
@@ -19,6 +19,7 @@
 
 using namespace librados;
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rados
 
 /**

--- a/src/tools/rados/RadosImport.cc
+++ b/src/tools/rados/RadosImport.cc
@@ -18,6 +18,7 @@
 #include "osd/PGLog.h"
 #include "RadosImport.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rados
 
 int RadosImport::import(std::string pool, bool no_overwrite)

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -612,7 +612,7 @@ public:
   }
 
   float time_passed() {
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
     now -= start_time;
     uint64_t ns = now.nsec();
     float total = (float) ns / 1000000000.0;
@@ -805,7 +805,7 @@ uint64_t LoadGen::gen_next_op()
 
 int LoadGen::run()
 {
-  start_time = ceph_clock_now(g_ceph_context);
+  start_time = ceph_clock_now();
   utime_t end_time = start_time;
   end_time += run_length;
   utime_t stamp_time = start_time;
@@ -814,14 +814,14 @@ int LoadGen::run()
   while (1) {
     lock.Lock();
     utime_t one_second(1, 0);
-    cond.WaitInterval(g_ceph_context, lock, one_second);
+    cond.WaitInterval(lock, one_second);
     lock.Unlock();
-    utime_t now = ceph_clock_now(g_ceph_context);
+    utime_t now = ceph_clock_now();
 
     if (now > end_time)
       break;
 
-    uint64_t expected = total_expected();  
+    uint64_t expected = total_expected();
     lock.Lock();
     uint64_t sent = total_sent;
     uint64_t completed = total_completed;

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -156,7 +156,7 @@ struct rbd_bencher {
     while (in_flight > max) {
       utime_t dur;
       dur.set_from_double(.2);
-      cond.WaitInterval(g_ceph_context, lock, dur);
+      cond.WaitInterval(lock, dur);
     }
   }
 
@@ -208,7 +208,7 @@ int do_bench(librbd::Image& image, io_type_t io_type,
 
   srand(time(NULL) % (unsigned long) -1);
 
-  utime_t start = ceph_clock_now(NULL);
+  utime_t start = ceph_clock_now();
   utime_t last;
   unsigned ios = 0;
 
@@ -268,7 +268,7 @@ int do_bench(librbd::Image& image, io_type_t io_type,
       cur_off += io_size;
     }
 
-    utime_t now = ceph_clock_now(NULL);
+    utime_t now = ceph_clock_now();
     utime_t elapsed = now - start;
     if (last.is_zero()) {
       last = elapsed;
@@ -295,7 +295,7 @@ int do_bench(librbd::Image& image, io_type_t io_type,
               << std::endl;
   }
 
-  utime_t now = ceph_clock_now(NULL);
+  utime_t now = ceph_clock_now();
   double elapsed = now - start;
 
   printf("elapsed: %5d  ops: %8d  ops/sec: %8.2lf  bytes/sec: %8.2lf\n",

--- a/src/tools/rbd/action/ImportDiff.cc
+++ b/src/tools/rbd/action/ImportDiff.cc
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <boost/program_options.hpp>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd
 
 namespace rbd {

--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -15,6 +15,7 @@
 #include <iostream>
 #include <boost/program_options.hpp>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd
 
 namespace rbd {

--- a/src/tools/rbd_mirror/ClusterWatcher.cc
+++ b/src/tools/rbd_mirror/ClusterWatcher.cc
@@ -8,6 +8,7 @@
 
 #include "ClusterWatcher.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::ClusterWatcher:" << this << " " \

--- a/src/tools/rbd_mirror/ImageDeleter.cc
+++ b/src/tools/rbd_mirror/ImageDeleter.cc
@@ -34,6 +34,7 @@
 #include "librbd/Utils.h"
 #include "ImageDeleter.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::ImageDeleter: " << this << " " \

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -28,6 +28,7 @@
 #include "tools/rbd_mirror/image_replayer/EventPreprocessor.h"
 #include "tools/rbd_mirror/image_replayer/ReplayStatusFormatter.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::" << *this << " " \

--- a/src/tools/rbd_mirror/ImageSync.cc
+++ b/src/tools/rbd_mirror/ImageSync.cc
@@ -14,6 +14,7 @@
 #include "tools/rbd_mirror/image_sync/SyncPointCreateRequest.h"
 #include "tools/rbd_mirror/image_sync/SyncPointPruneRequest.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::ImageSync: " \

--- a/src/tools/rbd_mirror/ImageSyncThrottler.cc
+++ b/src/tools/rbd_mirror/ImageSyncThrottler.cc
@@ -16,6 +16,7 @@
 #include "ImageSync.h"
 #include "common/ceph_context.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::ImageSyncThrottler:: " << this \

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -234,8 +234,9 @@ void Mirror::run()
     if (!m_manual_stop) {
       update_replayers(m_local_cluster_watcher->get_pool_peers());
     }
-    m_cond.WaitInterval(g_ceph_context, m_lock,
-	utime_t(m_cct->_conf->rbd_mirror_pool_replayers_refresh_interval, 0));
+    m_cond.WaitInterval(
+      m_lock,
+      utime_t(m_cct->_conf->rbd_mirror_pool_replayers_refresh_interval, 0));
   }
 
   // stop all replayers in parallel

--- a/src/tools/rbd_mirror/Mirror.cc
+++ b/src/tools/rbd_mirror/Mirror.cc
@@ -11,6 +11,7 @@
 #include "Threads.h"
 #include "ImageSync.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::Mirror: " << this << " " \

--- a/src/tools/rbd_mirror/PoolWatcher.cc
+++ b/src/tools/rbd_mirror/PoolWatcher.cc
@@ -12,6 +12,7 @@
 
 #include "PoolWatcher.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::PoolWatcher: " << this << " " \

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -457,8 +457,9 @@ void Replayer::run()
     if (m_blacklisted) {
       break;
     }
-    m_cond.WaitInterval(g_ceph_context, m_lock,
-	utime_t(g_ceph_context->_conf->rbd_mirror_image_state_check_interval, 0));
+    m_cond.WaitInterval(m_lock,
+			utime_t(g_ceph_context->_conf
+				->rbd_mirror_image_state_check_interval, 0));
   }
 
   ImageIds empty_sources;
@@ -468,7 +469,7 @@ void Replayer::run()
     if (m_image_replayers.empty()) {
       break;
     }
-    m_cond.WaitInterval(g_ceph_context, m_lock, seconds(1));
+    m_cond.WaitInterval(m_lock, seconds(1));
   }
 }
 

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -18,6 +18,7 @@
 #include "Replayer.h"
 #include "Threads.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::Replayer: " \

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -23,6 +23,7 @@
 #include "tools/rbd_mirror/ProgressContext.h"
 #include "tools/rbd_mirror/ImageSyncThrottler.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::BootstrapRequest: " \

--- a/src/tools/rbd_mirror/image_replayer/CloseImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CloseImageRequest.cc
@@ -9,6 +9,7 @@
 #include "librbd/ImageState.h"
 #include "librbd/Utils.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::CloseImageRequest: " \

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -14,6 +14,7 @@
 #include "librbd/Utils.h"
 #include "librbd/image/CreateRequest.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::CreateImageRequest: " \

--- a/src/tools/rbd_mirror/image_replayer/EventPreprocessor.cc
+++ b/src/tools/rbd_mirror/image_replayer/EventPreprocessor.cc
@@ -13,6 +13,7 @@
 #include "librbd/journal/Types.h"
 #include <boost/variant.hpp>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 
 #undef dout_prefix

--- a/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Utils.h"
 #include <type_traits>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::OpenImageRequest: " \

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -15,6 +15,7 @@
 #include "librbd/journal/Policy.h"
 #include <type_traits>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::OpenLocalImageRequest: " \

--- a/src/tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
+++ b/src/tools/rbd_mirror/image_replayer/ReplayStatusFormatter.cc
@@ -10,6 +10,7 @@
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_replayer::ReplayStatusFormatter: " \

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Utils.h"
 #include "tools/rbd_mirror/ProgressContext.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::ImageCopyRequest: " \

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
@@ -7,6 +7,7 @@
 #include "librbd/Utils.h"
 #include "common/errno.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::ObjectCopyRequest: " \

--- a/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Utils.h"
 #include "librbd/journal/Types.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::SnapshotCopyRequest: " \

--- a/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Utils.h"
 #include "osdc/Striper.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::SnapshotCreateRequest: " \

--- a/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SyncPointCreateRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Operations.h"
 #include "librbd/Utils.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::SyncPointCreateRequest: " \

--- a/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SyncPointPruneRequest.cc
@@ -10,6 +10,7 @@
 #include "librbd/Utils.h"
 #include <set>
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd::mirror::image_sync::SyncPointPruneRequest: " \

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -51,6 +51,7 @@
 #include "include/rbd/librbd.hpp"
 #include "include/xlist.h"
 
+#define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
 #define dout_prefix *_dout << "rbd-nbd: "


### PR DESCRIPTION
Unskew the clock,
Add a `dout_context` macro to simplify handling `dout` without rewriting too much code
Remove uses of g_ceph_context from the OSD, ObjectStore, and object class code.

More to come!

Stay tuned kids for our next exciting commit.
Same squid time
Same squid repo!

🦑