### PR TITLE
clean up correct bucket index entry in mp-upload

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4886,6 +4886,11 @@ void RGWCompleteMultipart::execute()
         op_ret = -ERR_INVALID_PART;
         return;
       } else {
+        // mp.get_part() always produce the oid like <obj-name>.<upload-id>.<num>
+        // However, when a part is uploaded more than once, the oid may be like
+        // <obj-name>.<random-alpha-numeric>.<num>
+        const string adjusted_oid = obj_part.manifest.obj_begin().get_location().get_orig_obj();
+        src_obj.init_ns(s->bucket, adjusted_oid, mp_ns);
         manifest.append(obj_part.manifest);
       }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -604,7 +604,7 @@ public:
     bool operator!=(const obj_iterator& rhs) {
       return (ofs != rhs.ofs);
     }
-    const rgw_obj& get_location() {
+    const rgw_obj& get_location() const {
       return location;
     }
 


### PR DESCRIPTION
When completing an multipart upload, RGW will remove the bucket
index keys corresponding to the component parts. Originally, the
component parts' index keys were always like
_multipart_obj-name.**upload-id**.num. But after the
commit bd8e026f88b812cc70caf6232c247844df5d99bf is merged, the key
may be either _multipart_obj-name.**upload-id**.num or
_multipart_obj-name.**random-alpha-numeric**.num. Original
RGWCompleteMultipart::execute() did not take this into consideration.
As a result, some keys like
_multipart_obj-name.**random-alpha-numeric**.num will not be
cleaned up and will be leaked.
This commit is just fix this issue.

Fixes: http://tracker.ceph.com/issues/17987
Signed-off-by: WangSu OS Dev <wangsu-os@chinanetcenter.com>