### PR TITLE
client: simplify remove_cap interface

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3858,7 +3858,7 @@ void Client::add_update_cap(Inode *in, MetaSession *mds_session, uint64_t cap_id
     signal_cond_list(in->waitfor_caps);
 }
 
-Cap* Client::remove_cap(Cap *cap, bool queue_release)
+void Client::remove_cap(Cap *cap, bool queue_release)
 {
   Inode *in = cap->inode;
   MetaSession *session = cap->session;
@@ -3890,7 +3890,6 @@ Cap* Client::remove_cap(Cap *cap, bool queue_release)
   } else {
     cap->cap_item.remove_myself();
     delete cap;
-    cap = nullptr;
   }
 
   if (!in->is_any_caps()) {
@@ -3899,7 +3898,6 @@ Cap* Client::remove_cap(Cap *cap, bool queue_release)
     put_snap_realm(in->snaprealm);
     in->snaprealm = 0;
   }
-  return cap;
 }
 
 void Client::remove_all_caps(Inode *in)
@@ -3996,7 +3994,7 @@ void Client::trim_caps(MetaSession *s, int max)
       // disposable non-auth cap
       if (!(get_caps_used(in) & ~oissued & mine)) {
 	ldout(cct, 20) << " removing unused, unneeded non-auth cap on " << *in << dendl;
-	cap = remove_cap(cap, true);
+	remove_cap(cap, true);
 	trimmed++;
       }
     } else {
@@ -4027,7 +4025,7 @@ void Client::trim_caps(MetaSession *s, int max)
     }
 
     ++p;
-    if (cap && !cap->inode) {
+    if (!cap->inode) {
       cap->cap_item.remove_myself();
       delete cap;
     }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -621,7 +621,7 @@ protected:
   void add_update_cap(Inode *in, MetaSession *session, uint64_t cap_id,
 		      unsigned issued, unsigned seq, unsigned mseq, inodeno_t realm,
 		      int flags, const UserPerm& perms);
-  Cap* remove_cap(Cap *cap, bool queue_release);
+  void remove_cap(Cap *cap, bool queue_release);
   void remove_all_caps(Inode *in);
   void remove_session_caps(MetaSession *session);
   void mark_caps_dirty(Inode *in, int caps);

--- a/src/client/MetaSession.h
+++ b/src/client/MetaSession.h
@@ -47,15 +47,13 @@ struct MetaSession {
   std::set<ceph_tid_t> flushing_caps_tids;
   std::set<Inode*> early_flushing_caps;
 
-  Cap *s_cap_iterator;
-
   MClientCapRelease *release;
   
   MetaSession()
     : mds_num(-1), con(NULL),
       seq(0), cap_gen(0), cap_renew_seq(0), num_caps(0),
       state(STATE_NEW), mds_state(0), readonly(false),
-      s_cap_iterator(NULL), release(NULL)
+      release(NULL)
   {}
   ~MetaSession();
 


### PR DESCRIPTION
All this complexity only existed to handle the
case where trim wanted to iterate over an xlist
without getting disturbed by a deletion.  We
can simply increment the iterator before
maybe-deleting the Cap.

Signed-off-by: John Spray <john.spray@redhat.com>