### PR TITLE
rgw: avoid infinite loop when ECANCELED for rgw_get_system_obj

### DIFF
--- a/src/rgw/rgw_tools.cc
+++ b/src/rgw/rgw_tools.cc
@@ -47,6 +47,9 @@ int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_bucket& bu
   int request_len = READ_CHUNK_LEN;
   rgw_obj obj(bucket, key);
 
+#define RGW_GET_SYSEM_OBJ_RETRIES 10
+
+  int retry_count = RGW_GET_SYSEM_OBJ_RETRIES;
   do {
     RGWRados::SystemObject source(rgwstore, obj_ctx, obj);
     RGWRados::SystemObject::Read rop(&source);
@@ -73,7 +76,7 @@ int rgw_get_system_obj(RGWRados *rgwstore, RGWObjectCtx& obj_ctx, rgw_bucket& bu
       break;
     bl.clear();
     request_len *= 2;
-  } while (true);
+  } while ( --retry_count > 0);
 
   return 0;
 }


### PR DESCRIPTION
Do retries upto RGW_GET_SYSTEM_OBJ_RETRIES (currently 10) instead of an
infinite retry loop

Fixes: http://tracker.ceph.com/issues/17996
