### PR TITLE
tests: disable the echo when running get_timeout_delays()

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1082,6 +1082,8 @@ function test_is_clean() {
 # @return a list of sleep delays
 #
 function get_timeout_delays() {
+    local saved_state=$(set +o)
+    set +x
     local timeout=$1
     local first_step=${2:-1}
 
@@ -1096,6 +1098,7 @@ function get_timeout_delays() {
     if test "$(echo $total \< $timeout | bc -l)" = "1"; then
         echo -n $(echo $timeout - $total | bc -l)
     fi
+    eval "$saved_state"
 }
 
 function test_get_timeout_delays() {


### PR DESCRIPTION
this function is very distracting when one is looking at the log

Signed-off-by: Kefu Chai <kchai@redhat.com>