### PR TITLE
os/bluestore: drop member "space" from Onode

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -637,7 +637,7 @@ void BlueStore::LRUCache::_trim(uint64_t onode_max, uint64_t buffer_max)
       assert(num == 1);
     }
     o->get();  // paranoia
-    o->space->onode_map.erase(o->oid);
+    o->c->onode_map.onode_map.erase(o->oid);
     o->put();
     --num;
   }
@@ -892,7 +892,7 @@ void BlueStore::TwoQCache::_trim(uint64_t onode_max, uint64_t buffer_max)
       assert(num == 1);
     }
     o->get();  // paranoia
-    o->space->onode_map.erase(o->oid);
+    o->c->onode_map.onode_map.erase(o->oid);
     o->put();
     --num;
   }
@@ -1239,7 +1239,7 @@ void BlueStore::OnodeSpace::rename(OnodeRef& oldo,
   OnodeRef o = po->second;
 
   // install a non-existent onode at old location
-  oldo.reset(new Onode(this, o->c, old_oid, o->key));
+  oldo.reset(new Onode(o->c, old_oid, o->key));
   po->second = oldo;
   cache->_add_onode(po->second, 1);
 
@@ -2387,11 +2387,11 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
       return OnodeRef();
 
     // new object, new onode
-    on = new Onode(&onode_map, this, oid, key);
+    on = new Onode(this, oid, key);
   } else {
     // loaded
     assert(r >= 0);
-    on = new Onode(&onode_map, this, oid, key);
+    on = new Onode(this, oid, key);
     on->exists = true;
     bufferptr::iterator p = v.front().begin();
     on->onode.decode(p);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -786,7 +786,6 @@ public:
     ghobject_t oid;
     string key;     ///< key under PREFIX_OBJ where we are stored
 
-    OnodeSpace *space;    ///< containing OnodeSpace
     boost::intrusive::list_member_hook<> lru_item;
 
     bluestore_onode_t onode;  ///< metadata stored as value in kv store
@@ -798,12 +797,11 @@ public:
     std::condition_variable flush_cond;   ///< wait here for unapplied txns
     set<TransContext*> flush_txns;   ///< committing or wal txns
 
-    Onode(OnodeSpace *s, Collection *c, const ghobject_t& o, const string& k)
+    Onode(Collection *c, const ghobject_t& o, const string& k)
       : nref(0),
 	c(c),
 	oid(o),
 	key(k),
-	space(s),
 	exists(false),
 	extent_map(this) {
     }


### PR DESCRIPTION
We can assess it through collection instead, which can therefore
save us some memory.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>