### PR TITLE
doc: Remove duplicate command for Ubuntu

### DIFF
--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -241,7 +241,7 @@ configuration file, restart your gateway. On Red Hat Enteprise Linux execute::
 
 On Ubuntu execute::
 
- sudo service radosgw restart id=rgw.<short-hostname>sudo service radosgw restart id=rgw.<short-hostname>
+ sudo service radosgw restart id=rgw.<short-hostname>
 
 For federated configurations, each zone may have a different ``index_pool``
 setting for failover. To make the value consistent for a region's zones, you


### PR DESCRIPTION
Remove duplicate "sudo service radosgw restart id=rgw.<short-hostname>" command for Ubuntu in Configure Bucket Sharding.