### PR TITLE
rgw: metadata sync info should be shown at master zone of slave zoneg…

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1975,7 +1975,7 @@ static void sync_status(Formatter *formatter)
 
   list<string> md_status;
 
-  if (zone.id == zonegroup.master_zone) {
+  if (store->is_meta_master()) {
     md_status.push_back("no sync (zone is master)");
   } else {
     get_md_sync_status(md_status);


### PR DESCRIPTION
…roup

When executing 'radosgw-admin sync status', the metadata sync info should be shown on the srceen at master zone of slave zonegroup.

Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>