### PR TITLE
kv: Rocksdb stats

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -886,7 +886,10 @@ OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default rocksdb cache size
 OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
-OPTION(rocksdb_perf, OPT_BOOL, false) // rocksdb breakdown
+OPTION(rocksdb_perf, OPT_BOOL, false) // Enabling this will have 5-10% impact on performance for the stats collection
+OPTION(rocksdb_collect_compaction_stats, OPT_BOOL, false) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
+OPTION(rocksdb_collect_extended_stats, OPT_BOOL, false) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
+OPTION(rocksdb_collect_memory_stats, OPT_BOOL, false) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
 
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -11,6 +11,7 @@
 #include "include/memory.h"
 #include <boost/scoped_ptr.hpp>
 #include "include/encoding.h"
+#include "common/Formatter.h"
 
 using std::string;
 /**
@@ -312,6 +313,12 @@ public:
     return -EOPNOTSUPP;
   }
 
+  virtual bool support_statistics() {
+    return false;
+  }
+  virtual void get_statistics(Formatter *f) {
+    return ;
+  }
 protected:
   /// List of matching prefixes and merge operators
   std::vector<std::pair<std::string,

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -313,11 +313,11 @@ public:
     return -EOPNOTSUPP;
   }
 
-  virtual bool support_statistics() {
+  virtual bool can_dump_stats() {
     return false;
   }
   virtual void get_statistics(Formatter *f) {
-    return ;
+    return;
   }
 protected:
   /// List of matching prefixes and merge operators

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -68,6 +68,7 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::DB *db;
   rocksdb::Env *env;
   string options_str;
+
   int do_open(ostream &out, bool create_if_missing);
 
   // manage async compactions
@@ -141,6 +142,13 @@ public:
   int create_and_open(ostream &out);
 
   void close();
+
+  bool support_statistics() {
+    return true;
+  }
+
+  void get_statistics(Formatter *f);
+
   struct  RocksWBHandler: public rocksdb::WriteBatch::Handler {
     std::string seen ;
     int num_seen = 0;

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -13,6 +13,9 @@
 #include <boost/scoped_ptr.hpp>
 #include "rocksdb/write_batch.h"
 #include "rocksdb/perf_context.h"
+#include "rocksdb/iostats_context.h"
+#include "rocksdb/statistics.h"
+#include "rocksdb/table.h"
 #include <errno.h>
 #include "common/errno.h"
 #include "common/dout.h"
@@ -53,6 +56,7 @@ namespace rocksdb{
   class Iterator;
   class Logger;
   struct Options;
+  struct BlockBasedTableOptions;
 }
 
 extern rocksdb::Logger *create_rocksdb_ceph_logger();
@@ -67,6 +71,8 @@ class RocksDBStore : public KeyValueDB {
   void *priv;
   rocksdb::DB *db;
   rocksdb::Env *env;
+  std::shared_ptr<rocksdb::Statistics> dbstats;
+  rocksdb::BlockBasedTableOptions bbt_opts;
   string options_str;
 
   int do_open(ostream &out, bool create_if_missing);
@@ -124,6 +130,7 @@ public:
     priv(p),
     db(NULL),
     env(static_cast<rocksdb::Env*>(p)),
+    dbstats(NULL),
     compact_queue_lock("RocksDBStore::compact_thread_lock"),
     compact_queue_stop(false),
     compact_thread(this),
@@ -143,7 +150,7 @@ public:
 
   void close();
 
-  bool support_statistics() {
+  bool can_dump_stats() {
     return true;
   }
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1493,6 +1493,8 @@ public:
     return 0;
   }
 
+  virtual void get_db_statistics(Formatter *f) { }
+
   virtual string get_type() = 0;
 
   // mgmt

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6162,6 +6162,10 @@ uint64_t BlueStore::_assign_blobid(TransContext *txc)
   return bid;
 }
 
+void BlueStore::get_db_statistics(Formatter *f) {
+  if (db->can_dump_stats())
+    db->get_statistics(f);
+}
 
 BlueStore::TransContext *BlueStore::_txc_create(OpSequencer *osr)
 {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1751,10 +1751,7 @@ public:
     return 0;
   }
 
-  void get_db_statistics(Formatter *f) {
-    if (db->support_statistics())
-      db->get_statistics(f);
-  }
+  void get_db_statistics(Formatter *f);
 
 public:
   int statfs(struct store_statfs_t *buf) override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1751,6 +1751,11 @@ public:
     return 0;
   }
 
+  void get_db_statistics(Formatter *f) {
+    if (db->support_statistics())
+      db->get_statistics(f);
+  }
+
 public:
   int statfs(struct store_statfs_t *buf) override;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1935,6 +1935,9 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     f->dump_bool("success", success);
     f->dump_int("value", value);
     f->close_section();
+  } else if (command == "bluestore_db_statistics") {
+    if (store->get_type() == "bluestore")
+      store->get_db_statistics(f);
   } else {
     assert(0 == "broken asok registration");
   }
@@ -2394,6 +2397,9 @@ void OSD::final_init()
 				     "get malloc extension heap property");
   assert(r == 0);
 
+  r = admin_socket->register_command("bluestore_db_statistics", "bluestore_db_statistics", asok_hook,
+					 "print statistics of kvdb which used by bluestore");
+  assert(r == 0);
 
   test_ops_hook = new TestOpsSocketHook(&(this->service), this->store);
   // Note: pools are CephString instead of CephPoolname because
@@ -2715,6 +2721,7 @@ int OSD::shutdown()
   cct->get_admin_socket()->unregister_command("get_latest_osdmap");
   cct->get_admin_socket()->unregister_command("set_heap_property");
   cct->get_admin_socket()->unregister_command("get_heap_property");
+  cct->get_admin_socket()->unregister_command("bluestore_db_statistics");
   delete asok_hook;
   asok_hook = NULL;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1935,9 +1935,8 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     f->dump_bool("success", success);
     f->dump_int("value", value);
     f->close_section();
-  } else if (command == "bluestore_db_statistics") {
-    if (store->get_type() == "bluestore")
-      store->get_db_statistics(f);
+  } else if (command == "dump_objectstore_kv_stats") {
+    store->get_db_statistics(f);
   } else {
     assert(0 == "broken asok registration");
   }
@@ -2397,7 +2396,7 @@ void OSD::final_init()
 				     "get malloc extension heap property");
   assert(r == 0);
 
-  r = admin_socket->register_command("bluestore_db_statistics", "bluestore_db_statistics", asok_hook,
+  r = admin_socket->register_command("dump_objectstore_kv_stats", "dump_objectstore_kv_stats", asok_hook,
 					 "print statistics of kvdb which used by bluestore");
   assert(r == 0);
 
@@ -2721,7 +2720,7 @@ int OSD::shutdown()
   cct->get_admin_socket()->unregister_command("get_latest_osdmap");
   cct->get_admin_socket()->unregister_command("set_heap_property");
   cct->get_admin_socket()->unregister_command("get_heap_property");
-  cct->get_admin_socket()->unregister_command("bluestore_db_statistics");
+  cct->get_admin_socket()->unregister_command("dump_objectstore_kv_stats");
   delete asok_hook;
   asok_hook = NULL;
 


### PR DESCRIPTION
This is PR is an extension to #11729 

Added extended stats from Rocksdb and collecting the stats only when rocksdb_perf is enabled.
rocksdb_perf should be enabled while initializing the store to collect all the stats.