### PR TITLE
dmclock: The integration of client service tracker & distributed environment factor Delta, Rho into the LibRADOS and OSD

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -487,7 +487,8 @@ int main(int argc, const char **argv)
     CEPH_FEATURE_NOSRCADDR |
     CEPH_FEATURE_PGID64 |
     CEPH_FEATURE_MSG_AUTH |
-    CEPH_FEATURE_OSD_ERASURE_CODES;
+    CEPH_FEATURE_OSD_ERASURE_CODES |
+    CEPH_FEATURE_QOS_DMC;
 
   // All feature bits 0 - 34 should be present from dumpling v0.67 forward
   uint64_t osd_required =

--- a/src/common/mClockCommon.h
+++ b/src/common/mClockCommon.h
@@ -1,0 +1,26 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2016 SK Telecom
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#pragma once
+
+#include "dmclock/src/dmclock_recs.h"
+
+// the following is done to unclobber _ASSERT_H so it returns to the
+// way ceph likes it
+#include "include/assert.h"
+
+
+namespace ceph {
+  namespace dmc = crimson::dmclock;
+}

--- a/src/common/mClockCommon.h
+++ b/src/common/mClockCommon.h
@@ -24,3 +24,17 @@
 namespace ceph {
   namespace dmc = crimson::dmclock;
 }
+
+WRITE_RAW_ENCODER(dmc::ReqParams)
+
+inline void encode(const dmc::PhaseType &phase, bufferlist& bl,
+                   uint64_t features=0)
+{
+  ::encode(static_cast<uint8_t>(phase), bl);
+}
+inline void decode(dmc::PhaseType &phase, bufferlist::iterator& p)
+{
+  uint8_t int_phase;
+  ::decode((uint8_t&)int_phase, p);
+  phase = static_cast<dmc::PhaseType>(int_phase);
+}

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -34,7 +34,7 @@ namespace ceph {
 
   namespace dmc = crimson::dmclock;
 
-  template <typename T, typename K>
+  template <typename T, typename K, typename ReqPm = dmc::ReqParams, typename RespPm = dmc::PhaseType>
   class mClockQueue : public OpQueue <T, K> {
 
     using priority_t = unsigned;
@@ -301,6 +301,12 @@ namespace ceph {
     void enqueue(K cl, unsigned priority, unsigned cost, T item) override final {
       // priority is ignored
       queue.add_request(item, cl, cost);
+    }
+
+    void _enqueue(K cl, unsigned priority, unsigned cost, T item,
+		  const ReqPm& req_params) {
+      // priority is ignored
+      queue.add_request(item, cl, req_params, cost);
     }
 
     void enqueue_front(K cl,

--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -39,6 +39,7 @@ namespace ceph {
 
     using priority_t = unsigned;
     using cost_t = unsigned;
+    using Retn = std::pair<T, RespPm>;
 
     typedef std::list<std::pair<cost_t, T> > ListPairs;
 
@@ -342,6 +343,32 @@ namespace ceph {
       assert(pr.is_retn());
       auto& retn = pr.get_retn();
       return *(retn.request);
+    }
+
+    Retn _dequeue() {
+      assert(!empty());
+      RespPm resp_params = RespPm();
+
+      if (!(high_queue.empty())) {
+	T ret = high_queue.rbegin()->second.front().second;
+	high_queue.rbegin()->second.pop_front();
+	if (high_queue.rbegin()->second.empty()) {
+	  high_queue.erase(high_queue.rbegin()->first);
+	}
+	return std::make_pair(ret, resp_params);
+      }
+
+      if (!queue_front.empty()) {
+	T ret = queue_front.front().second;
+	queue_front.pop_front();
+	return std::make_pair(ret, resp_params);
+      }
+
+      auto pr = queue.pull_request();
+      assert(pr.is_retn());
+      auto& retn = pr.get_retn();
+      resp_params = retn.phase;
+      return std::make_pair(*(retn.request), resp_params);
     }
 
     void dump(ceph::Formatter *f) const override final {

--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -88,6 +88,7 @@
 #define CEPH_FEATURE_FS_CHANGE_ATTR          (1ULL<<59) /* change_attr */
 
 #define CEPH_FEATURE_MSG_ADDR2 (1ULL<<59)  /* ADDR2 feature */
+#define CEPH_FEATURE_QOS_DMC          (1ULL<<60) /* dmclock QoS */
 
 #define CEPH_FEATURE_RESERVED2 (1ULL<<61)  /* slow down, we are almost out... */
 #define CEPH_FEATURE_RESERVED  (1ULL<<62)  /* DO NOT USE THIS ... last bit! */
@@ -187,6 +188,7 @@ static inline unsigned long long ceph_sanitize_features(unsigned long long f) {
 	 CEPH_FEATURE_FS_BTIME |			 \
 	 CEPH_FEATURE_FS_CHANGE_ATTR |			 \
 	 CEPH_FEATURE_MSG_ADDR2 | \
+	 CEPH_FEATURE_QOS_DMC |			 \
 	 0ULL)
 
 #define CEPH_FEATURES_SUPPORTED_DEFAULT  CEPH_FEATURES_ALL

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -20,7 +20,7 @@
 #include "osd/osd_types.h"
 #include "include/ceph_features.h"
 #include <atomic>
-
+#include "common/mClockCommon.h"
 /*
  * OSD op
  *
@@ -65,6 +65,7 @@ private:
   uint64_t features;
 
   osd_reqid_t reqid; // reqid explicitly set by sender
+  dmc::ReqParams qos_params;
 
 public:
   friend class MOSDOpReply;
@@ -78,6 +79,7 @@ public:
   void set_reqid(const osd_reqid_t rid) {
     reqid = rid;
   }
+  void set_qos_params(const dmc::ReqParams& p) { qos_params = p; }
 
   // Fields decoded in partial decoding
   const pg_t& get_pg() const {
@@ -107,6 +109,10 @@ public:
                          reqid.inc,
 			 header.tid);
     }
+  }
+  const dmc::ReqParams& get_qos_params() const {
+    assert(!partial_decode_needed);
+    return qos_params;
   }
 
   // Fields decoded in final decoding

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -21,6 +21,7 @@
 #include "MOSDOp.h"
 #include "os/ObjectStore.h"
 #include "common/errno.h"
+#include "common/mClockCommon.h"
 
 /*
  * OSD op reply
@@ -32,7 +33,7 @@
 
 class MOSDOpReply : public Message {
 
-  static const int HEAD_VERSION = 7;
+  static const int HEAD_VERSION = 8;
   static const int COMPAT_VERSION = 2;
 
   object_t oid;
@@ -47,6 +48,7 @@ class MOSDOpReply : public Message {
   int32_t retry_attempt;
   bool do_redirect;
   request_redirect_t redirect;
+  dmc::PhaseType qos_resp;
 
 public:
   const object_t& get_oid() const { return oid; }
@@ -93,6 +95,8 @@ public:
   void set_redirect(const request_redirect_t& redir) { redirect = redir; }
   const request_redirect_t& get_redirect() const { return redirect; }
   bool is_redirect_reply() const { return do_redirect; }
+  void set_qos_resp(const dmc::PhaseType qresp) { qos_resp = qresp; }
+  dmc::PhaseType get_qos_resp() const { return qos_resp; }
 
   void add_flags(int f) { flags |= f; }
 
@@ -128,10 +132,10 @@ public:
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION) {
     do_redirect = false;
   }
-  MOSDOpReply(MOSDOp *req, int r, epoch_t e, int acktype, bool ignore_out_data)
+  MOSDOpReply(MOSDOp *req, int r, epoch_t e, int acktype, bool ignore_out_data,
+              dmc::PhaseType qresp = dmc::PhaseType::reservation)
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION),
-      oid(req->oid), pgid(req->pgid), ops(req->ops) {
-
+      oid(req->oid), pgid(req->pgid), ops(req->ops), qos_resp(qresp) {
     set_tid(req->get_tid());
     result = r;
     flags =
@@ -202,6 +206,11 @@ public:
         if (do_redirect) {
           ::encode(redirect, payload);
         }
+        if ((features & CEPH_FEATURE_QOS_DMC) == 0) {
+          header.version = 7;
+        } else {
+          ::encode(qos_resp, payload);
+        }
       }
     }
   }
@@ -234,6 +243,7 @@ public:
       ::decode(do_redirect, p);
       if (do_redirect)
 	::decode(redirect, p);
+      ::decode(qos_resp, p);
     } else if (header.version < 2) {
       ceph_osd_reply_head head;
       ::decode(head, p);
@@ -292,6 +302,10 @@ public:
         if (do_redirect) {
 	  ::decode(redirect, p);
         }
+      }
+
+      if (header.version >=8 ) {
+        ::decode(qos_resp, p);
       }
     }
   }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -28,7 +28,7 @@ OpRequest::OpRequest(Message *req, OpTracker *tracker) :
   rmw_flags(0), request(req),
   hit_flag_points(0), latest_flag_point(0),
   send_map_update(false), sent_epoch(0),
-  hitset_inserted(false) {
+  hitset_inserted(false), qos_resp(dmc::PhaseType::reservation) {
   if (req->get_priority() < tracker->cct->_conf->osd_client_op_priority) {
     // don't warn as quickly for low priority ops
     warn_interval_multiplier = tracker->cct->_conf->osd_recovery_op_warn_multiple;

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -23,6 +23,7 @@
 #include "msg/Message.h"
 #include "include/memory.h"
 #include "common/TrackedOp.h"
+#include "common/mClockCommon.h"
 
 /**
  * osd request identifier
@@ -133,6 +134,7 @@ public:
   bool send_map_update;
   epoch_t sent_epoch;
   bool hitset_inserted;
+  dmc::PhaseType qos_resp;
   Message *get_req() const { return request; }
   bool been_queued_for_pg() { return hit_flag_points & flag_queued_for_pg; }
   bool been_reached_pg() { return hit_flag_points & flag_reached_pg; }

--- a/src/osd/PGQueueable.h
+++ b/src/osd/PGQueueable.h
@@ -69,6 +69,7 @@ class PGQueueable {
   utime_t start_time;
   entity_inst_t owner;
   dmc::ReqParams qos_params;
+  dmc::PhaseType qos_resp;
 
   struct RunVis : public boost::static_visitor<> {
     OSD *osd;
@@ -98,7 +99,8 @@ public:
     : qvariant(op), cost(op->get_req()->get_cost()),
       priority(op->get_req()->get_priority()),
       start_time(op->get_req()->get_recv_stamp()),
-      owner(op->get_req()->get_source_inst())
+      owner(op->get_req()->get_source_inst()),
+      qos_resp(dmc::PhaseType::reservation)
   {
     if (op->get_req()->get_type() == CEPH_MSG_OSD_OP) {
       MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
@@ -109,17 +111,17 @@ public:
     const PGSnapTrim &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
   PGQueueable(
     const PGScrub &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
   PGQueueable(
     const PGRecovery &op, int cost, unsigned priority, utime_t start_time,
     const entity_inst_t &owner)
     : qvariant(op), cost(cost), priority(priority), start_time(start_time),
-      owner(owner) {}
+      owner(owner), qos_resp(dmc::PhaseType::reservation) {}
 
   friend std::ostream& operator<<(std::ostream&, const PGQueueable&);
 
@@ -141,6 +143,8 @@ public:
   entity_inst_t get_owner() const { return owner; }
   const QVariant& get_variant() const { return qvariant; }
   dmc::ReqParams get_qos_params() const { return qos_params; }
+  dmc::PhaseType get_qos_resp() const { return qos_resp; }
+  void set_qos_resp(dmc::PhaseType qresp) { qos_resp = qresp; }
 }; // class PGQueueable
 
 

--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -146,7 +146,8 @@ namespace ceph {
 					 unsigned priority,
 					 unsigned cost,
 					 Request item) {
-    queue.enqueue(get_inner_client(cl, item), priority, cost, item);
+    queue._enqueue(get_inner_client(cl, item), priority, cost, item,
+		   item.second.get_qos_params());
   }
 
   // Enqueue the op in the front of the regular queue

--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -160,7 +160,9 @@ namespace ceph {
 
   // Return an op to be dispatch
   inline Request mClockClientQueue::dequeue() {
-    return queue.dequeue();
+    std::pair<Request, dmc::PhaseType> retn = queue._dequeue();
+    retn.first.second.set_qos_resp(retn.second);
+    return retn.first;
   }
 
   std::ostream& operator<<(std::ostream& out, const Request& req) {

--- a/src/osdc/CMakeLists.txt
+++ b/src/osdc/CMakeLists.txt
@@ -6,3 +6,4 @@ set(osdc_rbd_files
   Striper.cc)
 add_library(osdc_rbd_objs OBJECT ${osdc_rbd_files})
 add_library(osdc STATIC ${osdc_files} $<TARGET_OBJECTS:osdc_rbd_objs>)
+target_link_libraries(osdc dmclock)

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3399,6 +3399,8 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
 
   // done with this tid?
   if (!op->onack && !op->oncommit && !op->oncommit_sync) {
+    uint32_t shard_index = op->target.pgid.ps() % num_shards;
+    qos_trk->track_resp(OsdID(op->target.osd, shard_index), m->get_qos_resp());
     ldout(cct, 15) << "handle_osd_op_reply completed tid " << tid << dendl;
     _finish_op(op, 0);
   }

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3081,6 +3081,12 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
     m->set_reqid(op->reqid);
   }
 
+  uint32_t shard_index = op->target.pgid.ps() % num_shards;
+  dmc::ReqParams rp = qos_trk->get_req_params(OsdID(op->target.osd,
+                                                    shard_index));
+
+  m->set_qos_params(rp);
+
   logger->inc(l_osdc_op_send);
   logger->inc(l_osdc_op_send_bytes, m->get_data().length());
 
@@ -4876,6 +4882,7 @@ Objecter::OSDSession::~OSDSession()
 
 Objecter::~Objecter()
 {
+  delete qos_trk;
   delete osdmap;
 
   assert(homeless_session->get_nref() == 1);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -25,6 +25,8 @@
 
 #include <boost/thread/shared_mutex.hpp>
 
+#include "dmclock/src/dmclock_client.h"
+
 #include "include/assert.h"
 #include "include/buffer.h"
 #include "include/types.h"
@@ -1111,6 +1113,11 @@ public:
   Messenger *messenger;
   MonClient *monc;
   Finisher *finisher;
+
+  using OsdID = std::pair<int, uint32_t>;
+  dmc::ServiceTracker<OsdID> *qos_trk;
+  uint32_t num_shards;
+
 private:
   OSDMap    *osdmap;
 public:
@@ -1934,6 +1941,7 @@ private:
 	   double mon_timeout,
 	   double osd_timeout) :
     Dispatcher(cct_), messenger(m), monc(mc), finisher(fin),
+    num_shards(cct->_conf->osd_op_num_shards),
     osdmap(new OSDMap), initialized(0), last_tid(0), client_inc(-1),
     max_linger_id(0), num_unacked(0), num_uncommitted(0), global_op_flags(0),
     keep_balanced_budget(false), honor_osdmap_full(true),
@@ -1948,7 +1956,9 @@ private:
     op_throttle_ops(cct, "objecter_ops", cct->_conf->objecter_inflight_ops),
     epoch_barrier(0),
     retry_writes_after_first_reply(cct->_conf->objecter_retry_writes_after_first_reply)
-  { }
+  {
+    qos_trk = new dmc::ServiceTracker<OsdID>();
+  }
   ~Objecter();
 
   void init();

--- a/src/test/common/test_mclock_priority_queue.cc
+++ b/src/test/common/test_mclock_priority_queue.cc
@@ -43,7 +43,7 @@ bool operator==(const Client& r1, const Client& r2) {
 
 TEST(mClockPriorityQueue, Create)
 {
-  ceph::mClockQueue<Request,Client> q;
+  ceph::mClockQueue<Request,Client> q(nullptr);
 }
 
 


### PR DESCRIPTION
This patch is the integration of client service tracker & distributed environment factor Delta, Rho into the client LibRADOS and OSD.
First, we have handled client_op (CEPH_MSG_OSD_OP (MOSDOp & MOSDOpReply)) to guarantee QoS between Ceph clients in the distributed environment.
