### PR TITLE
rgw: lock is not released when set sync marker is failed.

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1475,6 +1475,8 @@ public:
 
         if (retcode < 0) {
           ldout(sync_env->cct, 0) << "ERROR: failed to set sync marker: retcode=" << retcode << dendl;
+          yield lease_cr->go_down();
+          drain_all();
           return retcode;
         }
       }


### PR DESCRIPTION
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>