### PR TITLE
ceph: Fix rados bench seq/rand tests to work when -b op-size != -o ob…

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -228,6 +228,7 @@ int ObjBencher::aio_bench(
     return -EINVAL;
 
   int num_objects = 0;
+  int num_writes = 0;
   int r = 0;
   int prevPid = 0;
   utime_t runtime;
@@ -239,7 +240,7 @@ int ObjBencher::aio_bench(
   if (operation != OP_WRITE) {
     uint64_t prev_op_size, prev_object_size;
     r = fetch_bench_metadata(run_name_meta, &prev_op_size, &prev_object_size,
-			     &num_objects, &prevPid);
+			     &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       if (r == -ENOENT)
         cerr << "Must write data before running a read benchmark!" << std::endl;
@@ -275,17 +276,17 @@ int ObjBencher::aio_bench(
     if (r != 0) goto out;
   }
   else if (OP_SEQ_READ == operation) {
-    r = seq_read_bench(secondsToRun, num_objects, concurrentios, prevPid, no_verify);
+    r = seq_read_bench(secondsToRun, num_objects, num_writes, concurrentios, prevPid, no_verify);
     if (r != 0) goto out;
   }
   else if (OP_RAND_READ == operation) {
-    r = rand_read_bench(secondsToRun, num_objects, concurrentios, prevPid, no_verify);
+    r = rand_read_bench(secondsToRun, num_objects, num_writes, concurrentios, prevPid, no_verify);
     if (r != 0) goto out;
   }
 
   if (OP_WRITE == operation && cleanup) {
     r = fetch_bench_metadata(run_name_meta, &op_size, &object_size,
-			     &num_objects, &prevPid);
+			     &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       if (r == -ENOENT)
         cerr << "Should never happen: bench metadata missing for current run!" << std::endl;
@@ -356,12 +357,13 @@ static T vec_stddev(vector<T>& v)
 
 int ObjBencher::fetch_bench_metadata(const std::string& metadata_file,
 				     uint64_t *op_size, uint64_t* object_size,
-				     int* num_objects, int* prevPid) {
+				     int* num_objects, int* num_writes,
+				     int* prevPid) {
   int r = 0;
   bufferlist object_data;
 
   r = sync_read(metadata_file, object_data,
-		sizeof(int) * 2 + sizeof(size_t) * 2);
+		sizeof(int) * 3 + sizeof(size_t) * 2);
   if (r <= 0) {
     // treat an empty file as a file that does not exist
     if (r == 0) {
@@ -377,6 +379,11 @@ int ObjBencher::fetch_bench_metadata(const std::string& metadata_file,
     ::decode(*op_size, p);
   } else {
     *op_size = *object_size;
+  }
+  if (!p.end()) {
+    ::decode(*num_writes, p);
+  } else {
+    *num_writes = *num_objects;
   }
 
   return 0;
@@ -611,6 +618,7 @@ int ObjBencher::write_bench(int secondsToRun,
   ::encode(num_objects, b_write);
   ::encode(getpid(), b_write);
   ::encode(data.op_size, b_write);
+  ::encode(data.started, b_write);
 
   // persist meta-data for further cleanup or read
   sync_write(run_name_meta, b_write, sizeof(int)*3);
@@ -633,7 +641,7 @@ int ObjBencher::write_bench(int secondsToRun,
   return r;
 }
 
-int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid, bool no_verify) {
+int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int num_writes, int concurrentios, int pid, bool no_verify) {
   lock_cond lc(&lock);
 
   if (concurrentios <= 0) 
@@ -701,7 +709,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
 
   slot = 0;
   while ((!seconds_to_run || ceph_clock_now() < finish_time) &&
-	 num_objects > data.started) {
+	 num_writes > data.started) {
     lock.Lock();
     int old_slot = slot;
     bool found = false;
@@ -859,7 +867,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   return r;
 }
 
-int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurrentios, int pid, bool no_verify)
+int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int num_writes, int concurrentios, int pid, bool no_verify)
 {
   lock_cond lc(&lock);
 
@@ -877,6 +885,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   time_to_run.set_from_double(seconds_to_run);
   double total_latency = 0;
   int r = 0;
+  int rand_id;
   utime_t runtime;
   sanitize_object_contents(&data, data.op_size); //clean it up once; subsequent
   //changes will be safe because string length should remain the same
@@ -893,7 +902,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
 
   //set up initial reads
   for (int i = 0; i < concurrentios; ++i) {
-    name[i] = generate_object_name(i / writes_per_object, pid);
     contents[i] = new bufferlist();
   }
 
@@ -909,11 +917,13 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   utime_t finish_time = data.start_time + time_to_run;
   //start initial reads
   for (int i = 0; i < concurrentios; ++i) {
-    index[i] = i;
+    rand_id = rand() % num_writes;
+    name[i] = generate_object_name(rand_id / writes_per_object, pid);
+    index[i] = rand_id;
     start_times[i] = ceph_clock_now();
     create_completion(i, _aio_cb, (void *)&lc);
     r = aio_read(name[i], i, contents[i], data.op_size,
-		 data.op_size * (i % writes_per_object));
+		 data.op_size * (rand_id % writes_per_object));
     if (r < 0) { //naughty, doesn't clean up heap -- oh, or handle the print thread!
       cerr << "r = " << r << std::endl;
       goto ERR;
@@ -927,7 +937,6 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   //keep on adding new reads as old ones complete
   int slot;
   bufferlist *cur_contents;
-  int rand_id;
 
   slot = 0;
   while ((!seconds_to_run || ceph_clock_now() < finish_time)) {
@@ -984,7 +993,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       }
     } 
 
-    rand_id = rand() % num_objects;
+    rand_id = rand() % num_writes;
     newName = generate_object_name(rand_id / writes_per_object, pid);
     index[slot] = rand_id;
     release_completion(slot);
@@ -1095,6 +1104,7 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
   int r = 0;
   uint64_t op_size, object_size;
   int num_objects;
+  int num_writes;
   int prevPid;
 
   // default meta object if user does not specify one
@@ -1141,7 +1151,7 @@ int ObjBencher::clean_up(const std::string& orig_prefix, int concurrentios, cons
       continue;
     }
 
-    r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &prevPid);
+    r = fetch_bench_metadata(run_name_meta, &op_size, &object_size, &num_objects, &num_writes, &prevPid);
     if (r < 0) {
       return r;
     }

--- a/src/common/obj_bencher.h
+++ b/src/common/obj_bencher.h
@@ -74,11 +74,12 @@ protected:
   struct bench_data data;
 
   int fetch_bench_metadata(const std::string& metadata_file, uint64_t* op_size,
-			   uint64_t* object_size, int* num_objects, int* prevPid);
+			   uint64_t* object_size, int* num_objects,
+			   int* num_writes, int* prevPid);
 
   int write_bench(int secondsToRun, int concurrentios, const string& run_name_meta, unsigned max_objects);
-  int seq_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid, bool no_verify=false);
-  int rand_read_bench(int secondsToRun, int num_objects, int concurrentios, int writePid, bool no_verify=false);
+  int seq_read_bench(int secondsToRun, int num_objects, int num_writes, int concurrentios, int writePid, bool no_verify=false);
+  int rand_read_bench(int secondsToRun, int num_objects, int num_writes, int concurrentios, int writePid, bool no_verify=false);
 
   int clean_up(int num_objects, int prevPid, int concurrentios);
   bool more_objects_matching_prefix(const std::string& prefix, std::list<Object>* name);

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -906,7 +906,7 @@ protected:
 
   int aio_read(const std::string& oid, int slot, bufferlist *pbl, size_t len,
 	       size_t offset) override {
-    return io_ctx.aio_read(oid, completions[slot], pbl, len, 0);
+    return io_ctx.aio_read(oid, completions[slot], pbl, len, offset);
   }
 
   int aio_write(const std::string& oid, int slot, bufferlist& bl, size_t len,


### PR DESCRIPTION
…ject-size

rados bench write correctly creates objects whose object_size is a multiple of
op_size, but radios bench seq and rand cannot read them, failing with:
    benchmark_data_alpha1-p200_7856_object0 is not correct!

There are a number of issues concerning this bug, discovered one at a time.
Routine aio_read() in rados.cc is hard-coded to read an object at offset zero,
no matter what offset it is passed.

Routine seq_read_bench() in obj_bencher.cc stops reading after "num_objects"
I/Os, when it should issue "num_objects * writes_per_object" reads (but see
below), so the test run times are unexpectedly short.

In routine rand_read_bench(), the first "concurrentios" I/Os are actually
sequential reads of the first few objects, not random. Also, the routine
only generates random offsets modulo "num_objects", not
"num_objects * writes_per_object", so the I/O distribution ignores most of
the higher-numbered objects (but see next).

If a rados bench write test finishes based on time, not number of objects,
then the last object written is usually shorter than the rest. Fixing the
above issues causes the seq and rand tests to issue I/Os beyond the end of
that final shorter object.

The solution is to record the number of writes issued by rados bench write
as an additional parameter in the "bench_metadata" file (num_writes). The
seq test then issues "num_writes" reads and doesn't run off the end of the
last object. The rand test generates a random number modulo "num_writes",
then converts that to an object and offset pair, also avoiding any reads
beyond the end of the last object, and the I/O distribution across the
entire set of objects and across offsets within objects is balanced.

The code in this fix is unencumbered by any other license.
Fixes: #16385
Signed-off-by: krehm