### PR TITLE
librados: remove new setxattr overload to avoid breaking the C++ ABI

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -395,7 +395,6 @@ namespace librados
     void zero(uint64_t off, uint64_t len);
     void rmxattr(const char *name);
     void setxattr(const char *name, const bufferlist& bl);
-    void setxattr(const char *name, const bufferlist&& bl);
     void tmap_update(const bufferlist& cmdbl);
     void tmap_put(const bufferlist& bl);
     void clone_range(uint64_t dst_off,

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -445,14 +445,6 @@ void librados::ObjectWriteOperation::setxattr(const char *name, const bufferlist
   o->setxattr(name, v);
 }
 
-void librados::ObjectWriteOperation::setxattr(const char *name,
-					      const buffer::list&& v)
-{
-  ::ObjectOperation *o = &impl->o;
-  o->setxattr(name, std::move(v));
-}
-
-
 void librados::ObjectWriteOperation::omap_set(
   const map<string, bufferlist> &map)
 {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18058
Signed-off-by: Josh Durgin <jdurgin@redhat.com>