### PR TITLE
mds: don't access mdsmap from log submit thread

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -297,6 +297,7 @@ void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase *c)
   le->update_segment();
   le->set_stamp(ceph_clock_now(g_ceph_context));
 
+  mdsmap_up_features = mds->mdsmap->get_up_features();
   pending_events[ls->seq].push_back(PendingEvent(le, c));
   num_events++;
 
@@ -376,6 +377,7 @@ void MDLog::_submit_thread()
       continue;
     }
 
+    int64_t features = mdsmap_up_features;
     PendingEvent data = it->second.front();
     it->second.pop_front();
 
@@ -386,7 +388,7 @@ void MDLog::_submit_thread()
       LogSegment *ls = le->_segment;
       // encode it, with event type
       bufferlist bl;
-      le->encode_with_header(bl, mds->mdsmap->get_up_features());
+      le->encode_with_header(bl, features);
 
       uint64_t write_pos = journaler->get_write_pos();
 

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -134,6 +134,7 @@ protected:
     PendingEvent(LogEvent *e, MDSContext *c, bool f=false) : le(e), fin(c), flush(f) {}
   };
 
+  int64_t mdsmap_up_features;
   map<uint64_t,list<PendingEvent> > pending_events; // log segment -> event list
   Mutex submit_mutex;
   Cond submit_cond;
@@ -202,6 +203,7 @@ public:
                       already_replayed(false),
                       recovery_thread(this),
                       event_seq(0), expiring_events(0), expired_events(0),
+		      mdsmap_up_features(0),
                       submit_mutex("MDLog::submit_mutex"),
                       submit_thread(this),
                       cur_event(NULL) { }		  


### PR DESCRIPTION
the log submit thread does not hold the big mds_lock.

Fixes: http://tracker.ceph.com/issues/18047
Signed-off-by: Yan, Zheng <zyan@redhat.com>