### PR TITLE
doc: update cinder key permissions for mitaka

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -124,9 +124,17 @@ Setup Ceph Client Authentication
 If you have `cephx authentication`_ enabled, create a new user for Nova/Cinder
 and Glance. Execute the following::
 
-    ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
     ceph auth get-or-create client.glance mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=images'
     ceph auth get-or-create client.cinder-backup mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=backups'
+
+If you run an OpenStack version before Mitaka, create the following ``client.cinder`` key::
+
+    ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
+
+Since Mitaka introduced the support of RBD snapshots while doing a snapshot of a Nova instance,
+we need to allow the ``client.cinder`` key write access to the ``images`` pool; therefore, create the following key::
+
+    ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'
 
 Add the keyrings for ``client.cinder``, ``client.glance``, and
 ``client.cinder-backup`` to the appropriate nodes and change their ownership::


### PR DESCRIPTION
OpenStack Mitaka introduced the support of RBD snapshots while taking a
snapshot of a Nova instance. For this to work we need to grant write
access to the Glance pool to the Cinder key.

Signed-off-by: Sébastien Han <seb@redhat.com>