### PR TITLE
build/ops: run make with PORTABLE=1 on aarch64

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -748,18 +748,20 @@ cmake .. \
 %endif
 %endif
 
+# set PORTABLE=1 on aarch64 so rocksdb doesn't use -march=native
+# http://tracker.ceph.com/issues/18065
+%ifarch aarch64
+PORTABLE=1 make %{?_smp_mflags}
+%else
 make %{?_smp_mflags}
-
+%endif
 
 %if 0%{with make_check}
 %check
 # run in-tree unittests
 cd build
 ctest %{?_smp_mflags}
-
 %endif
-
-
 
 %install
 pushd build


### PR DESCRIPTION
rocksdb was refusing to build for aarch64 because the compiler we were using
did not support -march=native. The rocksdb documentation suggests that this can
be disabled by running make in this way.

Fixes: http://tracker.ceph.com/issues/18065
Signed-off-by: smithfarm <ncutler@suse.com>