### PR TITLE
[RFC] librados: support copy-less writes in librados C API

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1997,6 +1997,29 @@ CEPH_RADOS_API int rados_aio_write(rados_ioctx_t io, const char *oid,
 		                   const char *buf, size_t len, uint64_t off);
 
 /**
+ * Write data to an object asynchronously
+ *
+ * Queues the write and returns. The return value of the completion
+ * will be 0 on success, negative error code on failure.
+ * 
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior. 
+ *
+ * @param io the context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the write is safe and complete
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_write2(rados_ioctx_t io, const char *oid,
+		                   rados_completion_t completion,
+		                   char *buf, size_t len, uint64_t off);
+
+/**
  * Asychronously append data to an object
  *
  * Queues the append and returns.
@@ -2015,6 +2038,30 @@ CEPH_RADOS_API int rados_aio_write(rados_ioctx_t io, const char *oid,
 CEPH_RADOS_API int rados_aio_append(rados_ioctx_t io, const char *oid,
 		                    rados_completion_t completion,
 		                    const char *buf, size_t len);
+
+/**
+ * Asychronously append data to an object
+ *
+ * Queues the append and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ * 
+ * buf is assumed to not change before entire append is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the context to operate in
+ * @param oid the name of the object
+ * @param completion what to do when the append is safe and complete
+ * @param buf the data to append
+ * @param len length of buf (in bytes)
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_append2(rados_ioctx_t io, const char *oid,
+		                    rados_completion_t completion,
+		                    char *buf, size_t len);
 
 /**
  * Asychronously write an entire object
@@ -2039,6 +2086,32 @@ CEPH_RADOS_API int rados_aio_write_full(rados_ioctx_t io, const char *oid,
 			                const char *buf, size_t len);
 
 /**
+ * Asychronously write an entire object
+ *
+ * The object is filled with the provided data. If the object exists,
+ * it is atomically truncated and then written.
+ * Queues the write_full and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ *
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the write_full is safe and complete
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_write_full2(rados_ioctx_t io, const char *oid,
+			                rados_completion_t completion,
+			                char *buf, size_t len);
+
+/**
  * Asychronously write the same buffer multiple times
  *
  * Queues the writesame and returns.
@@ -2059,6 +2132,33 @@ CEPH_RADOS_API int rados_aio_write_full(rados_ioctx_t io, const char *oid,
 CEPH_RADOS_API int rados_aio_writesame(rados_ioctx_t io, const char *oid,
 			               rados_completion_t completion,
 			               const char *buf, size_t data_len,
+				       size_t write_len, uint64_t off);
+
+/**
+ * Asychronously write the same buffer multiple times
+ *
+ * Queues the writesame and returns.
+ *
+ * The return value of the completion will be 0 on success, negative
+ * error code on failure.
+ *
+ * buf is assumed to not change before entire write is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param completion what to do when the writesame is safe and complete
+ * @param buf data to write
+ * @param data_len length of the data, in bytes
+ * @param write_len the total number of bytes to write
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, -EROFS if the io context specifies a snap_seq
+ * other than LIBRADOS_SNAP_HEAD
+ */
+CEPH_RADOS_API int rados_aio_writesame2(rados_ioctx_t io, const char *oid,
+			               rados_completion_t completion,
+			               char *buf, size_t data_len,
 				       size_t write_len, uint64_t off);
 
 /**
@@ -2218,6 +2318,26 @@ CEPH_RADOS_API int rados_aio_getxattr(rados_ioctx_t io, const char *o,
 CEPH_RADOS_API int rados_aio_setxattr(rados_ioctx_t io, const char *o,
 				      rados_completion_t completion,
 				      const char *name, const char *buf,
+				      size_t len);
+
+/**
+ * Asynchronously set an extended attribute on an object.
+ *
+ * buf is assumed to not change before entire operation is complete,
+ * in other words, attempts to modify/free buf before operation is
+ * complete will result in undefined behavior.
+ *
+ * @param io the context in which xattr is set
+ * @param o name of the object
+ * @param completion what to do when the setxattr completes
+ * @param name which extended attribute to set
+ * @param buf what to store in the xattr
+ * @param len the number of bytes in buf
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_aio_setxattr2(rados_ioctx_t io, const char *o,
+				      rados_completion_t completion,
+				      const char *name, char *buf,
 				      size_t len);
 
 /**

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1342,6 +1342,24 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
                                const char *buf, size_t len, uint64_t off);
 
 /**
+ * Write *len* bytes from *buf* into the *oid* object, starting at
+ * offset *off*. The value of *len* must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @note This will never return a positive value not equal to len.
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_write2(rados_ioctx_t io, const char *oid,
+                                char *buf, size_t len, uint64_t off);
+
+/**
  * Write *len* bytes from *buf* into the *oid* object. The value of
  * *len* must be <= UINT_MAX/2.
  *
@@ -1356,6 +1374,25 @@ CEPH_RADOS_API int rados_write(rados_ioctx_t io, const char *oid,
  */
 CEPH_RADOS_API int rados_write_full(rados_ioctx_t io, const char *oid,
                                     const char *buf, size_t len);
+
+/**
+ * Write *len* bytes from *buf* into the *oid* object. The value of
+ * *len* must be <= UINT_MAX/2.
+ *
+ * The object is filled with the provided data. If the object exists,
+ * it is atomically truncated and then written.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param len length of the data, in bytes
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_write_full2(rados_ioctx_t io, const char *oid,
+                                     char *buf, size_t len);
 
 /**
  * Write the same *data_len* bytes from *buf* multiple times into the
@@ -1374,6 +1411,27 @@ CEPH_RADOS_API int rados_write_full(rados_ioctx_t io, const char *oid,
 CEPH_RADOS_API int rados_writesame(rados_ioctx_t io, const char *oid,
                                    const char *buf, size_t data_len,
                                    size_t write_len, uint64_t off);
+
+/**
+ * Write the same *data_len* bytes from *buf* multiple times into the
+ * *oid* object. *write_len* bytes are written in total, which must be
+ * a multiple of *data_len*. The value of *write_len* and *data_len*
+ * must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the io context in which the write will occur
+ * @param oid name of the object
+ * @param buf data to write
+ * @param data_len length of the data, in bytes
+ * @param write_len the total number of bytes to write
+ * @param off byte offset in the object to begin writing at
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_writesame2(rados_ioctx_t io, const char *oid,
+                                    char *buf, size_t data_len,
+                                    size_t write_len, uint64_t off);
 
 /**
  * Efficiently copy a portion of one object to another
@@ -1409,6 +1467,22 @@ CEPH_RADOS_API int rados_clone_range(rados_ioctx_t io, const char *dst,
  */
 CEPH_RADOS_API int rados_append(rados_ioctx_t io, const char *oid,
                                 const char *buf, size_t len);
+
+/**
+ * Append *len* bytes from *buf* into the *oid* object. The value of
+ * *len* must be <= UINT_MAX/2.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the context to operate in
+ * @param oid the name of the object
+ * @param buf the data to append
+ * @param len length of buf (in bytes)
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_append2(rados_ioctx_t io, const char *oid,
+                                 char *buf, size_t len);
 
 /**
  * Read data from an object
@@ -1488,6 +1562,23 @@ CEPH_RADOS_API int rados_getxattr(rados_ioctx_t io, const char *o,
 CEPH_RADOS_API int rados_setxattr(rados_ioctx_t io, const char *o,
                                   const char *name, const char *buf,
                                   size_t len);
+
+/**
+ * Set an extended attribute on an object.
+ *
+ * This function is not thread-safe, i.e. contents of buf must remain
+ * the same during entire function call.
+ *
+ * @param io the context in which xattr is set
+ * @param o name of the object
+ * @param name which extended attribute to set
+ * @param buf what to store in the xattr
+ * @param len the number of bytes in buf
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_setxattr2(rados_ioctx_t io, const char *o,
+                                   const char *name, char *buf,
+                                   size_t len);
 
 /**
  * Delete an extended attribute from an object.

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -3443,6 +3443,21 @@ extern "C" int rados_write(rados_ioctx_t io, const char *o, const char *buf, siz
   return retval;
 }
 
+extern "C" int rados_write2(rados_ioctx_t io, const char *o, char *buf, size_t len, uint64_t off)
+{
+  tracepoint(librados, rados_write_enter, io, o, buf, len, off);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
+  int retval = ctx->write(oid, bl, len, off);
+  tracepoint(librados, rados_write_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_append(rados_ioctx_t io, const char *o, const char *buf, size_t len)
 {
   tracepoint(librados, rados_append_enter, io, o, buf, len);
@@ -3452,6 +3467,21 @@ extern "C" int rados_append(rados_ioctx_t io, const char *o, const char *buf, si
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->append(oid, bl, len);
+  tracepoint(librados, rados_append_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_append2(rados_ioctx_t io, const char *o, char *buf, size_t len)
+{
+  tracepoint(librados, rados_append_enter, io, o, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
   int retval = ctx->append(oid, bl, len);
   tracepoint(librados, rados_append_exit, retval);
   return retval;
@@ -3471,6 +3501,21 @@ extern "C" int rados_write_full(rados_ioctx_t io, const char *o, const char *buf
   return retval;
 }
 
+extern "C" int rados_write_full2(rados_ioctx_t io, const char *o, char *buf, size_t len)
+{
+  tracepoint(librados, rados_write_full_enter, io, o, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
+  int retval = ctx->write_full(oid, bl);
+  tracepoint(librados, rados_write_full_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_writesame(rados_ioctx_t io,
 				const char *o,
 				const char *buf,
@@ -3483,6 +3528,24 @@ extern "C" int rados_writesame(rados_ioctx_t io,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, data_len);
+  int retval = ctx->writesame(oid, bl, write_len, off);
+  tracepoint(librados, rados_writesame_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_writesame2(rados_ioctx_t io,
+				const char *o,
+				char *buf,
+				size_t data_len,
+				size_t write_len,
+				uint64_t off)
+{
+  tracepoint(librados, rados_writesame_enter, io, o, buf, data_len, write_len, off);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(data_len, buf);
+  bl.push_back(bp);
   int retval = ctx->writesame(oid, bl, write_len, off);
   tracepoint(librados, rados_writesame_exit, retval);
   return retval;
@@ -3971,6 +4034,19 @@ extern "C" int rados_setxattr(rados_ioctx_t io, const char *o, const char *name,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->setxattr(oid, name, bl);
+  tracepoint(librados, rados_setxattr_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_setxattr2(rados_ioctx_t io, const char *o, const char *name, char *buf, size_t len)
+{
+  tracepoint(librados, rados_setxattr_enter, io, o, name, buf, len);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);
   int retval = ctx->setxattr(oid, name, bl);
   tracepoint(librados, rados_setxattr_exit, retval);
   return retval;

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4590,6 +4590,24 @@ extern "C" int rados_aio_write(rados_ioctx_t io, const char *o,
   return retval;
 }
 
+extern "C" int rados_aio_write2(rados_ioctx_t io, const char *o,
+				rados_completion_t completion,
+				char *buf, size_t len, uint64_t off)
+{
+  tracepoint(librados, rados_aio_write_enter, io, o, completion, buf, len, off);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
+  int retval = ctx->aio_write(oid, (librados::AioCompletionImpl*)completion,
+			bl, len, off);
+  tracepoint(librados, rados_aio_write_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_aio_append(rados_ioctx_t io, const char *o,
 				rados_completion_t completion,
 				const char *buf, size_t len)
@@ -4601,6 +4619,24 @@ extern "C" int rados_aio_append(rados_ioctx_t io, const char *o,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->aio_append(oid, (librados::AioCompletionImpl*)completion,
+			 bl, len);
+  tracepoint(librados, rados_aio_append_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_aio_append2(rados_ioctx_t io, const char *o,
+				rados_completion_t completion,
+				char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_append_enter, io, o, completion, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
   int retval = ctx->aio_append(oid, (librados::AioCompletionImpl*)completion,
 			 bl, len);
   tracepoint(librados, rados_aio_append_exit, retval);
@@ -4623,6 +4659,23 @@ extern "C" int rados_aio_write_full(rados_ioctx_t io, const char *o,
   return retval;
 }
 
+extern "C" int rados_aio_write_full2(rados_ioctx_t io, const char *o,
+				    rados_completion_t completion,
+				    char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_write_full_enter, io, o, completion, buf, len);
+  if (len > UINT_MAX/2)
+    return -E2BIG;
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
+  int retval = ctx->aio_write_full(oid, (librados::AioCompletionImpl*)completion, bl);
+  tracepoint(librados, rados_aio_write_full_exit, retval);
+  return retval;
+}
+
 extern "C" int rados_aio_writesame(rados_ioctx_t io, const char *o,
 				   rados_completion_t completion,
 				   const char *buf, size_t data_len,
@@ -4634,6 +4687,24 @@ extern "C" int rados_aio_writesame(rados_ioctx_t io, const char *o,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, data_len);
+  int retval = ctx->aio_writesame(o, (librados::AioCompletionImpl*)completion,
+				  bl, write_len, off);
+  tracepoint(librados, rados_aio_writesame_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_aio_writesame2(rados_ioctx_t io, const char *o,
+				   rados_completion_t completion,
+				   char *buf, size_t data_len,
+				   size_t write_len, uint64_t off)
+{
+  tracepoint(librados, rados_aio_writesame_enter, io, o, completion, buf,
+						data_len, write_len, off);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(data_len, buf);
+  bl.push_back(bp);  
   int retval = ctx->aio_writesame(o, (librados::AioCompletionImpl*)completion,
 				  bl, write_len, off);
   tracepoint(librados, rados_aio_writesame_exit, retval);
@@ -4776,6 +4847,21 @@ extern "C" int rados_aio_setxattr(rados_ioctx_t io, const char *o,
   object_t oid(o);
   bufferlist bl;
   bl.append(buf, len);
+  int retval = ctx->aio_setxattr(oid, (librados::AioCompletionImpl*)completion, name, bl);
+  tracepoint(librados, rados_aio_setxattr_exit, retval);
+  return retval;
+}
+
+extern "C" int rados_aio_setxattr2(rados_ioctx_t io, const char *o,
+				  rados_completion_t completion,
+				  const char *name, char *buf, size_t len)
+{
+  tracepoint(librados, rados_aio_setxattr_enter, io, o, completion, name, buf, len);
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  object_t oid(o);
+  bufferlist bl;
+  bufferptr bp = buffer::create_static(len, buf);
+  bl.push_back(bp);  
   int retval = ctx->aio_setxattr(oid, (librados::AioCompletionImpl*)completion, name, bl);
   tracepoint(librados, rados_aio_setxattr_exit, retval);
   return retval;


### PR DESCRIPTION
These commits introduce rados_write2(), rados_write_full2(), rados_writesame2(), rados_append2() and rados_setxattr2(), rados_aio_write2(), rados_aio_write_full2(), rados_aio_writesame2(), rados_aio_append2() and rados_aio_setxattr2() which do not copy user buffers into temporary bufferptrs, reducing memory and CPU usage, at expense of requiring that provided buffers don't change through entire write/append. Otherwise these "2" function perform exactly like their non-"2" equivalents.

Signed-off-by: Piotr Dałek <git@predictor.org.pl>