### PR TITLE
librbd/ImageCtx: no need for virtual dtor

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -73,7 +73,7 @@ public:
         lock("librbd::Journal::SafeTimerSingleton::lock") {
     init();
   }
-  virtual ~SafeTimerSingleton() {
+  ~SafeTimerSingleton() {
     Mutex::Locker locker(lock);
     shutdown();
   }


### PR DESCRIPTION
CID 1396232 (#1 of 1): Non-virtual destructor (VIRTUAL_DTOR)
1. nonvirtual_dtor: Class librbd::<unnamed>::SafeTimerSingleton has a destructor and a pointer to it is upcast to class SafeTimer which doesn't have a virtual destructor.

The SafeTimerSingleton is not polymorphic; no need for
a virtual dtor.

Signed-off-by: Sage Weil <sage@redhat.com>