### PR TITLE
rgw: RGWBucketSyncStatusManager uses existing async_rados

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2762,9 +2762,6 @@ int RGWBucketSyncStatusManager::init()
     return -EINVAL;
   }
 
-  async_rados = new RGWAsyncRadosProcessor(store, store->ctx()->_conf->rgw_num_async_rados_threads);
-  async_rados->start();
-
   int ret = http_manager.set_threaded();
   if (ret < 0) {
     ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
@@ -2794,6 +2791,8 @@ int RGWBucketSyncStatusManager::init()
   sync_module.reset(new RGWDefaultSyncModuleInstance());
 
   int effective_num_shards = (num_shards ? num_shards : 1);
+
+  auto async_rados = store->get_async_rados();
 
   for (int i = 0; i < effective_num_shards; i++) {
     RGWRemoteBucketLog *l = new RGWRemoteBucketLog(store, this, async_rados, &http_manager);

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -479,7 +479,6 @@ class RGWBucketSyncStatusManager {
 
   RGWCoroutinesManager cr_mgr;
 
-  RGWAsyncRadosProcessor *async_rados;
   RGWHTTPManager http_manager;
 
   string source_zone;
@@ -504,7 +503,6 @@ public:
   RGWBucketSyncStatusManager(RGWRados *_store, const string& _source_zone,
                              const rgw_bucket& bucket) : store(_store),
                                                                                      cr_mgr(_store->ctx(), _store->get_cr_registry()),
-                                                                                     async_rados(NULL),
                                                                                      http_manager(store->ctx(), cr_mgr.get_completion_mgr()),
                                                                                      source_zone(_source_zone),
                                                                                      conn(NULL), error_logger(NULL),


### PR DESCRIPTION
RGWBucketSyncStatusManager was creating its own RGWAsyncRadosProcessor
and failing to clean it up on destruction. A recent change turned
global_init()'s return value into an intrusive_ptr to guarantee that our
CephContext is freed, and this triggered an assertion that all worker
threads were shut down

Fixes: http://tracker.ceph.com/issues/18083