### PR TITLE
osd/pg: bound the portion of the log we request in GetLog::GetLog()

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7474,7 +7474,8 @@ PG::RecoveryState::GetLog::GetLog(my_context ctx)
        ++p) {
     if (*p == pg->pg_whoami) continue;
     pg_info_t& ri = pg->peer_info[*p];
-    if (ri.last_update >= best.log_tail && ri.last_update < request_log_from)
+    if (ri.last_update < pg->info.log_tail && ri.last_update >= best.log_tail &&
+        ri.last_update < request_log_from)
       request_log_from = ri.last_update;
   }
 


### PR DESCRIPTION
osd/PG: bound the portion of the log we request in PG::RecoveryState::GetLog::GetLog

Signed-off-by: Jie Wang <jie.wang@kylin-cloud.com>