### PR TITLE
librbd: enabling/disabling rbd feature should report missing dependency

### DIFF
--- a/src/librbd/operation/DisableFeaturesRequest.cc
+++ b/src/librbd/operation/DisableFeaturesRequest.cc
@@ -178,7 +178,9 @@ Context *DisableFeaturesRequest<I>::handle_acquire_exclusive_lock(int *result) {
     if ((m_features & RBD_FEATURE_EXCLUSIVE_LOCK) != 0) {
       if ((m_new_features & RBD_FEATURE_OBJECT_MAP) != 0 ||
           (m_new_features & RBD_FEATURE_JOURNALING) != 0) {
-        lderr(cct) << "cannot disable exclusive lock" << dendl;
+        lderr(cct) << "cannot disable exclusive-lock. object-map "
+                      "or journaling must be disabled before "
+                      "disabling exclusive-lock." << dendl;
         *result = -EINVAL;
         break;
       }
@@ -190,7 +192,8 @@ Context *DisableFeaturesRequest<I>::handle_acquire_exclusive_lock(int *result) {
     }
     if ((m_features & RBD_FEATURE_OBJECT_MAP) != 0) {
       if ((m_new_features & RBD_FEATURE_FAST_DIFF) != 0) {
-        lderr(cct) << "cannot disable object map" << dendl;
+        lderr(cct) << "cannot disable object-map. fast-diff must be "
+                      "disabled before disabling object-map." << dendl;
         *result = -EINVAL;
         break;
       }

--- a/src/librbd/operation/EnableFeaturesRequest.cc
+++ b/src/librbd/operation/EnableFeaturesRequest.cc
@@ -180,7 +180,8 @@ Context *EnableFeaturesRequest<I>::handle_get_mirror_mode(int *result) {
 
     if ((m_features & RBD_FEATURE_OBJECT_MAP) != 0) {
       if ((m_new_features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
-	lderr(cct) << "cannot enable object map" << dendl;
+	lderr(cct) << "cannot enable object-map. exclusive-lock must be "
+                      "enabled before enabling object-map." << dendl;
 	*result = -EINVAL;
 	break;
       }
@@ -189,7 +190,8 @@ Context *EnableFeaturesRequest<I>::handle_get_mirror_mode(int *result) {
     }
     if ((m_features & RBD_FEATURE_FAST_DIFF) != 0) {
       if ((m_new_features & RBD_FEATURE_OBJECT_MAP) == 0) {
-	lderr(cct) << "cannot enable fast diff" << dendl;
+	lderr(cct) << "cannot enable fast-diff. object-map must be "
+                      "enabled before enabling fast-diff." << dendl;
 	*result = -EINVAL;
 	break;
       }
@@ -198,7 +200,8 @@ Context *EnableFeaturesRequest<I>::handle_get_mirror_mode(int *result) {
     }
     if ((m_features & RBD_FEATURE_JOURNALING) != 0) {
       if ((m_new_features & RBD_FEATURE_EXCLUSIVE_LOCK) == 0) {
-	lderr(cct) << "cannot enable journaling" << dendl;
+	lderr(cct) << "cannot enable journaling. exclusive-lock must be "
+                      "enabled before enabling journaling." << dendl;
 	*result = -EINVAL;
 	break;
       }


### PR DESCRIPTION
Currently while enabling or disabling rbd feature command does not
give missing dependency for eg: attempting to enable the journaling
feature on an image that doesn't have the exclusive-lock feature
enabled should give missing dependency error message.

Fixes: http://tracker.ceph.com/issues/16985

Reported-by:  Jason Dillaman <dillaman@redhat.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>