### PR TITLE
jewel: build/ops: fixed the issue when --disable-server, compilation fails.

### DIFF
--- a/src/common/Makefile.am
+++ b/src/common/Makefile.am
@@ -82,12 +82,14 @@ libcommon_internal_la_SOURCES = \
 
 common/PluginRegistry.cc: ./ceph_ver.h
 
+libcommon_internal_la_SOURCES += \
+	common/ceph_json.cc \
+	common/util.cc
+
 if ENABLE_SERVER
 libcommon_internal_la_SOURCES += \
 	common/xattr.c \
 	common/ipaddr.cc \
-	common/ceph_json.cc \
-	common/util.cc \
 	common/pick_address.cc
 endif
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/18120

If cannot disable-server, the user has to always compile backend storage part,
even only want to compile the client. Cherry-pick cannot be done because ceph
master doesn't have Makefile.am any more.

Signed-off-by: Pan Liu <pan.liu@istuary.com>