### PR TITLE
mon/paxos: use dynamic cast instead of static cast

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -506,7 +506,8 @@ void Paxos::_sanity_check_store()
 void Paxos::handle_last(MonOpRequestRef op)
 {
   op->mark_paxos_event("handle_last");
-  MMonPaxos *last = static_cast<MMonPaxos*>(op->get_req());
+  MMonPaxos *last = dynamic_cast<MMonPaxos*>(op->get_req());
+  assert(last);
   bool need_refresh = false;
   int from = last->get_source().num();
 


### PR DESCRIPTION
Using static_cast for downcast (Message* to MMonPaxos*) is not safe when the Message*  pointer point to  base(Message) object. So using a run-time checking dynamic_cast instead should be more safe.

Signed-off-by: jinweiyi <jinweiyi@cmss.chinamobile.com>