### PR TITLE
test/fio: fix global CephContext life cycle

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -103,7 +103,7 @@ Engine::Engine(const thread_data* td) : ref_count(0)
   }
 
   // claim the g_ceph_context reference and release it on destruction
-  auto cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
+  cct = global_init(nullptr, args, CEPH_ENTITY_TYPE_OSD,
 			 CODE_ENVIRONMENT_UTILITY, 0);
   common_init_finish(g_ceph_context);
 


### PR DESCRIPTION
It looks like that's a bad idea to omit add_ref when returning intrusive_ptr<CephContext> from global_init. Assigning **temporary** resulting pointer to another var doesn't increment ref counter. From the boost manual - this is equivalent to swap call instead. Hence we might have either lack of CephContext release or its' premature release. The latter case I observed in fio plugin.

Consider the following code snippet:
```c++
#include <iostream>
#include <boost/intrusive_ptr.hpp>
using namespace std;
struct  A
{
  int nref = 0;
  A() { cout<<"A"<<this<<std::endl;}
  ~A() { cout<<"~A"<<this<<std::endl;}

  void put() { if (--nref == 0 ) delete this;}
  void get() { nref++;}
};

void intrusive_ptr_add_ref(A* a)
{
  a->get();
  cout<<"add "<<a<<" "<<a->nref<<std::endl;
}
void intrusive_ptr_release(A* a)
{
  cout<<"release "<<a<<" "<<a->nref-1<<std::endl;
  a->put();
}

typedef boost::intrusive_ptr<A> APtr;
 APtr createAPtr() {
  A* res = new A;
  return APtr(res, false);
}

int main()
{
  auto aptr = createAPtr();
  APtr aptr2;
  aptr2 = createAPtr();
  APtr aptr3;
  aptr3 = createAPtr();
  aptr3->get(); //OK
  APtr aptr4(createAPtr());
  APtr aptr5;
  aptr5 = createAPtr();
  aptr5->get(); //OK
  APtr aptr6;
  aptr6 = aptr5; //OK
  createAPtr();
  cout<<"-----------------------"<<std::endl;
}
```

Corresponding output:
```
A0x9d8c20
A0x9d9050
A0x9d9070
A0x9d9090
A0x9d90b0
add 0x9d90b0 2
A0x19cd0d0
release 0x19cd0d0 -1
-----------------------
release 0x9d90b0 1
release 0x9d90b0 0
~A0x9d90b0
release 0x9d9090 -1
release 0x9d9070 0
~A0x9d9070
release 0x9d9050 -1
release 0x9d8c20 -1
```
