### PR TITLE
buffer: add copy(unsigned, ptr) back

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1176,6 +1176,12 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   }
 
   template<bool is_const>
+  void buffer::list::iterator_impl<is_const>::copy(unsigned len, ptr &dest)
+  {
+    copy_deep(len, dest);
+  }
+
+  template<bool is_const>
   void buffer::list::iterator_impl<is_const>::copy_deep(unsigned len, ptr &dest)
   {
     if (!len) {
@@ -1348,6 +1354,11 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
   void buffer::list::iterator::copy(unsigned len, char *dest)
   {
     return buffer::list::iterator_impl<false>::copy(len, dest);
+  }
+
+  void buffer::list::iterator::copy(unsigned len, ptr &dest)
+  {
+    return buffer::list::iterator_impl<false>::copy_deep(len, dest);
   }
 
   void buffer::list::iterator::copy_deep(unsigned len, ptr &dest)

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -401,6 +401,8 @@ namespace buffer CEPH_BUFFER_API {
       // copy data out.
       // note that these all _append_ to dest!
       void copy(unsigned len, char *dest);
+      // deprecated, use copy_deep()
+      void copy(unsigned len, ptr &dest) __attribute__((deprecated));
       void copy_deep(unsigned len, ptr &dest);
       void copy_shallow(unsigned len, ptr &dest);
       void copy(unsigned len, list &dest);
@@ -442,6 +444,8 @@ namespace buffer CEPH_BUFFER_API {
 
       // copy data out
       void copy(unsigned len, char *dest);
+      // deprecated, use copy_deep()
+      void copy(unsigned len, ptr &dest) __attribute__((deprecated));
       void copy_deep(unsigned len, ptr &dest);
       void copy_shallow(unsigned len, ptr &dest);
       void copy(unsigned len, list &dest);


### PR DESCRIPTION
to be ABI-compatible with prior versions.

copy(unsigned, ptr) was renamed to copy_deep() in 6d7f748

Fixes: http://tracker.ceph.com/issues/17809
Signed-off-by: Kefu Chai <kchai@redhat.com>