### PR TITLE
[DNM] libcephfs: do not expose private symbols

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -833,14 +833,12 @@ if(WITH_LIBCEPHFS)
   target_link_libraries(cephfs LINK_PRIVATE client
     ${CRYPTO_LIBS} ${EXTRALIBS})
   if(ENABLE_SHARED)
-    foreach(name common client osdc)
-      set(CEPHFS_LINK_FLAGS "${CEPHFS_LINK_FLAGS} -Wl,--exclude-libs,lib${name}.a")
-    endforeach()
     set_target_properties(cephfs PROPERTIES
       OUTPUT_NAME cephfs
       VERSION 2.0.0
       SOVERSION 2
-      LINK_FLAGS ${CEPHFS_LINK_FLAGS})
+      COMPILE_FLAGS "-fvisibility=hidden -fvisibility-inlines-hidden"
+      LINK_FLAGS "-Wl,--exclude-libs,ALL")
   endif(ENABLE_SHARED)
   install(TARGETS cephfs DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(DIRECTORY

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -47,6 +47,12 @@ extern "C" {
 # error libceph: glibc must define __USE_FILE_OFFSET64 or readdir results will be corrupted
 #endif
 
+#if __GNUC__ < 4
+# error libceph: requires GCC 4.1 or up
+#endif
+
+#define CEPHFS_API __attribute__ ((visibility ("default")))
+
 /*
  * XXXX redeclarations from ceph_fs.h, rados.h, etc.  We need more of this
  * in the interface, but shouldn't be re-typing it (and using different
@@ -140,7 +146,7 @@ struct CephContext;
  * @param ngids number of gids in supplemental grouplist
  * @param gidlist array of gid_t's in the list of groups
  */
-UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
+CEPHFS_API UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
 
 /**
  * Destroy a UserPerm credential object.
@@ -150,7 +156,7 @@ UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids, gid_t *gidlist);
  * Currently this just frees the object. Note that the gidlist array is not
  * freed. The caller must do so if it's necessary.
  */
-void ceph_userperm_destroy(UserPerm *perm);
+CEPHFS_API void ceph_userperm_destroy(UserPerm *perm);
 
 /**
  * Get a pointer to the default UserPerm object for the mount.
@@ -162,7 +168,7 @@ void ceph_userperm_destroy(UserPerm *perm);
  *
  * Unlike with ceph_userperm_new, this object should not be freed.
  */
-struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
+CEPHFS_API struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
 
 /**
  * @defgroup libcephfs_h_init Setup and Teardown
@@ -181,7 +187,7 @@ struct UserPerm *ceph_mount_perms(struct ceph_mount_info *cmount);
  * @param minor where to store the minor version number
  * @param patch where to store the extra version number
  */
-const char *ceph_version(int *major, int *minor, int *patch);
+CEPHFS_API const char *ceph_version(int *major, int *minor, int *patch);
 
 /**
  * Create a mount handle for interacting with Ceph.  All libcephfs
@@ -193,7 +199,7 @@ const char *ceph_version(int *major, int *minor, int *patch);
  *           pass in NULL, and the id will be the process id of the client.
  * @returns 0 on success, negative error code on failure
  */
-int ceph_create(struct ceph_mount_info **cmount, const char * const id);
+CEPHFS_API int ceph_create(struct ceph_mount_info **cmount, const char * const id);
 
 /**
  * Create a mount handle from a CephContext, which holds the configuration
@@ -205,7 +211,7 @@ int ceph_create(struct ceph_mount_info **cmount, const char * const id);
  * @param conf reuse this pre-existing CephContext config
  * @returns 0 on success, negative error code on failure
  */
-int ceph_create_with_context(struct ceph_mount_info **cmount, struct CephContext *conf);
+CEPHFS_API int ceph_create_with_context(struct ceph_mount_info **cmount, struct CephContext *conf);
 
 
 typedef void *rados_t;
@@ -218,14 +224,14 @@ typedef void *rados_t;
  * @param cluster reference to already-initialized librados handle
  * @returns 0 on success, negative error code on failure
  */
-int ceph_create_from_rados(struct ceph_mount_info **cmount, rados_t cluster);
+CEPHFS_API int ceph_create_from_rados(struct ceph_mount_info **cmount, rados_t cluster);
 
 /**
  * Initialize the filesystem client (but do not mount the filesystem yet)
  *
  * @returns 0 on success, negative error code on failure
  */
-int ceph_init(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_init(struct ceph_mount_info *cmount);
 
 
 /**
@@ -240,7 +246,7 @@ int ceph_init(struct ceph_mount_info *cmount);
  * 	       be "/".  Passing in NULL is equivalent to "/".
  * @returns 0 on success, negative error code on failure
  */
-int ceph_mount(struct ceph_mount_info *cmount, const char *root);
+CEPHFS_API int ceph_mount(struct ceph_mount_info *cmount, const char *root);
 
 /**
  * Execute a management command remotely on an MDS.
@@ -260,7 +266,7 @@ int ceph_mount(struct ceph_mount_info *cmount, const char *root);
  * @return 0 on success, negative error code on failure
  *
  */
-int ceph_mds_command(struct ceph_mount_info *cmount,
+CEPHFS_API int ceph_mds_command(struct ceph_mount_info *cmount,
     const char *mds_spec,
     const char **cmd,
     size_t cmdlen,
@@ -271,7 +277,7 @@ int ceph_mds_command(struct ceph_mount_info *cmount,
 /**
  * Free a buffer, such as those used for output arrays from ceph_mds_command
  */
-void ceph_buffer_free(char *buf);
+CEPHFS_API void ceph_buffer_free(char *buf);
 
 /**
  * Unmount a mount handle.
@@ -279,7 +285,7 @@ void ceph_buffer_free(char *buf);
  * @param cmount the mount handle
  * @return 0 on success, negative error code on failure
  */
-int ceph_unmount(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_unmount(struct ceph_mount_info *cmount);
 
 /**
  * Destroy the mount handle.
@@ -290,7 +296,7 @@ int ceph_unmount(struct ceph_mount_info *cmount);
  * @param cmount the mount handle
  * @return 0 on success, negative error code on failure.
  */
-int ceph_release(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_release(struct ceph_mount_info *cmount);
 
 /**
  * Deprecated. Unmount and destroy the ceph mount handle. This should be
@@ -300,7 +306,7 @@ int ceph_release(struct ceph_mount_info *cmount);
  *
  * @param cmount the mount handle to shutdown
  */
-void ceph_shutdown(struct ceph_mount_info *cmount);
+CEPHFS_API void ceph_shutdown(struct ceph_mount_info *cmount);
 
 /**
  * Extract the CephContext from the mount point handle.
@@ -308,14 +314,14 @@ void ceph_shutdown(struct ceph_mount_info *cmount);
  * @param cmount the ceph mount handle to get the context from.
  * @returns the CephContext associated with the mount handle.
  */
-struct CephContext *ceph_get_mount_context(struct ceph_mount_info *cmount);
+CEPHFS_API struct CephContext *ceph_get_mount_context(struct ceph_mount_info *cmount);
 
 /*
  * Check mount status.
  *
  * Return non-zero value if mounted. Otherwise, zero.
  */
-int ceph_is_mounted(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_is_mounted(struct ceph_mount_info *cmount);
 
 /** @} init */
 
@@ -333,7 +339,7 @@ int ceph_is_mounted(struct ceph_mount_info *cmount);
  * @param path_list the configuration file path
  * @returns 0 on success, negative error code on failure
  */
-int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
+CEPHFS_API int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
 
 /**
  * Parse the command line arguments and load the configuration parameters.
@@ -343,7 +349,7 @@ int ceph_conf_read_file(struct ceph_mount_info *cmount, const char *path_list);
  * @param argv the argument list
  * @returns 0 on success, negative error code on failure
  */
-int ceph_conf_parse_argv(struct ceph_mount_info *cmount, int argc, const char **argv);
+CEPHFS_API int ceph_conf_parse_argv(struct ceph_mount_info *cmount, int argc, const char **argv);
 
 /**
  * Configure the cluster handle based on an environment variable
@@ -360,7 +366,8 @@ int ceph_conf_parse_argv(struct ceph_mount_info *cmount, int argc, const char **
  * @param var name of the environment variable to read
  * @returns 0 on success, negative error code on failure
  */
-int ceph_conf_parse_env(struct ceph_mount_info *cmount, const char *var);
+CEPHFS_API int ceph_conf_parse_env(struct ceph_mount_info *cmount,
+				   const char *var);
 
 /** Sets a configuration value from a string.
  *
@@ -370,7 +377,8 @@ int ceph_conf_parse_env(struct ceph_mount_info *cmount, const char *var);
  * 
  * @returns 0 on success, negative error code otherwise.
  */
-int ceph_conf_set(struct ceph_mount_info *cmount, const char *option, const char *value);
+CEPHFS_API int ceph_conf_set(struct ceph_mount_info *cmount,
+			     const char *option, const char *value);
 
 /**
  * Gets the configuration value as a string.
@@ -381,7 +389,7 @@ int ceph_conf_set(struct ceph_mount_info *cmount, const char *option, const char
  * @param len the length of the buffer.
  * @returns the size of the buffer filled in with the value, or negative error code on failure
  */
-int ceph_conf_get(struct ceph_mount_info *cmount, const char *option, char *buf, size_t len);
+CEPHFS_API int ceph_conf_get(struct ceph_mount_info *cmount, const char *option, char *buf, size_t len);
 
 /** @} config */
 
@@ -402,7 +410,8 @@ int ceph_conf_get(struct ceph_mount_info *cmount, const char *option, char *buf,
  * @param stbuf the file system statistics filled in by this function.
  * @return 0 on success, negative error code otherwise.
  */
-int ceph_statfs(struct ceph_mount_info *cmount, const char *path, struct statvfs *stbuf);
+CEPHFS_API int ceph_statfs(struct ceph_mount_info *cmount, const char *path,
+			   struct statvfs *stbuf);
 
 /**
  * Synchronize all filesystem data to persistent media.
@@ -410,7 +419,7 @@ int ceph_statfs(struct ceph_mount_info *cmount, const char *path, struct statvfs
  * @param cmount the ceph mount handle to use for performing the sync_fs.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_sync_fs(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_sync_fs(struct ceph_mount_info *cmount);
 
 /**
  * Get the current working directory.
@@ -418,7 +427,7 @@ int ceph_sync_fs(struct ceph_mount_info *cmount);
  * @param cmount the ceph mount to get the current working directory for.
  * @returns the path to the current working directory
  */
-const char* ceph_getcwd(struct ceph_mount_info *cmount);
+CEPHFS_API const char* ceph_getcwd(struct ceph_mount_info *cmount);
 
 /**
  * Change the current working directory.
@@ -427,7 +436,7 @@ const char* ceph_getcwd(struct ceph_mount_info *cmount);
  * @param path the path to the working directory to change into.
  * @returns 0 on success, negative error code otherwise.
  */
-int ceph_chdir(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_chdir(struct ceph_mount_info *cmount, const char *path);
 
 /** @} fsops */
 
@@ -447,7 +456,8 @@ int ceph_chdir(struct ceph_mount_info *cmount, const char *path);
  * @param dirpp the directory result pointer structure to fill in.
  * @returns 0 on success or negative error code otherwise.
  */
-int ceph_opendir(struct ceph_mount_info *cmount, const char *name, struct ceph_dir_result **dirpp);
+CEPHFS_API int ceph_opendir(struct ceph_mount_info *cmount, const char *name,
+			    struct ceph_dir_result **dirpp);
 
 /**
  * Close the open directory.
@@ -456,7 +466,8 @@ int ceph_opendir(struct ceph_mount_info *cmount, const char *name, struct ceph_d
  * @param dirp the directory result pointer (set by ceph_opendir) to close
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_closedir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+CEPHFS_API int ceph_closedir(struct ceph_mount_info *cmount,
+			     struct ceph_dir_result *dirp);
 
 /**
  * Get the next entry in an open directory.
@@ -468,7 +479,8 @@ int ceph_closedir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
  *          is empty.  This pointer should not be freed by the caller, and is only safe to
  *          access between return and the next call to ceph_readdir or ceph_closedir.
  */
-struct dirent * ceph_readdir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+CEPHFS_API struct dirent * ceph_readdir(struct ceph_mount_info *cmount,
+					struct ceph_dir_result *dirp);
 
 /**
  * A safe version of ceph_readdir, where the directory entry struct is allocated by the caller.
@@ -480,7 +492,8 @@ struct dirent * ceph_readdir(struct ceph_mount_info *cmount, struct ceph_dir_res
  * @returns 1 if the next entry was filled in, 0 if the end of the directory stream was reached,
  *          and a negative error code on failure.
  */
-int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de);
+CEPHFS_API int ceph_readdir_r(struct ceph_mount_info *cmount,
+			      struct ceph_dir_result *dirp, struct dirent *de);
 
 /**
  * A safe version of ceph_readdir that also returns the file statistics (readdir+stat).
@@ -497,8 +510,10 @@ int ceph_readdir_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp,
  * @returns 1 if the next entry was filled in, 0 if the end of the directory stream was reached,
  *          and a negative error code on failure.
  */
-int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, struct dirent *de,
-		       struct ceph_statx *stx, unsigned want, unsigned flags, struct Inode **out);
+CEPHFS_API int ceph_readdirplus_r(struct ceph_mount_info *cmount,
+				  struct ceph_dir_result *dirp, struct dirent *de,
+				  struct ceph_statx *stx, unsigned want,
+				  unsigned flags, struct Inode **out);
 
 /**
  * Gets multiple directory entries.
@@ -511,7 +526,8 @@ int ceph_readdirplus_r(struct ceph_mount_info *cmount, struct ceph_dir_result *d
  * @returns the length of the buffer that was filled in, will always be multiples of sizeof(struct dirent), or a
  *          negative error code.  If the buffer is not large enough for a single entry, -ERANGE is returned.
  */
-int ceph_getdents(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, char *name, int buflen);
+CEPHFS_API int ceph_getdents(struct ceph_mount_info *cmount,
+			     struct ceph_dir_result *dirp, char *name, int buflen);
 
 /**
  * Gets multiple directory names.
@@ -524,7 +540,8 @@ int ceph_getdents(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, 
  * @returns the length of the buffer filled in with entry names, or a negative error code on failure.
  *          If the buffer isn't large enough for a single entry, -ERANGE is returned.
  */
-int ceph_getdnames(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, char *name, int buflen);
+CEPHFS_API int ceph_getdnames(struct ceph_mount_info *cmount,
+			      struct ceph_dir_result *dirp, char *name, int buflen);
 
 /**
  * Rewind the directory stream to the beginning of the directory.
@@ -532,7 +549,8 @@ int ceph_getdnames(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp,
  * @param cmount the ceph mount handle to use for performing the rewinddir.
  * @param dirp the directory stream pointer to rewind.
  */
-void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+CEPHFS_API void ceph_rewinddir(struct ceph_mount_info *cmount,
+			       struct ceph_dir_result *dirp);
 
 /**
  * Get the current position of a directory stream.
@@ -543,7 +561,8 @@ void ceph_rewinddir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp
  *          by ceph_telldir do not have a particular order (cannot be compared with
  *          inequality).
  */
-int64_t ceph_telldir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp);
+CEPHFS_API int64_t ceph_telldir(struct ceph_mount_info *cmount,
+				struct ceph_dir_result *dirp);
 
 /**
  * Move the directory stream to a position specified by the given offset.
@@ -554,7 +573,8 @@ int64_t ceph_telldir(struct ceph_mount_info *cmount, struct ceph_dir_result *dir
  *        a value returned by seekdir.  Note that this value does not refer to the nth
  *        entry in a directory, and can not be manipulated with plus or minus.
  */
-void ceph_seekdir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, int64_t offset);
+CEPHFS_API void ceph_seekdir(struct ceph_mount_info *cmount,
+			     struct ceph_dir_result *dirp, int64_t offset);
 
 /**
  * Create a directory.
@@ -565,7 +585,8 @@ void ceph_seekdir(struct ceph_mount_info *cmount, struct ceph_dir_result *dirp, 
  * @param mode the permissions the directory should have once created.
  * @returns 0 on success or a negative return code on error.
  */
-int ceph_mkdir(struct ceph_mount_info *cmount, const char *path, mode_t mode);
+CEPHFS_API int ceph_mkdir(struct ceph_mount_info *cmount, const char *path,
+			  mode_t mode);
 
 /**
  * Create multiple directories at once.
@@ -576,7 +597,8 @@ int ceph_mkdir(struct ceph_mount_info *cmount, const char *path, mode_t mode);
  * @param mode the permissions the directory should have once created.
  * @returns 0 on success or a negative return code on error.
  */
-int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);
+CEPHFS_API int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path,
+			   mode_t mode);
 
 /**
  * Remove a directory.
@@ -585,7 +607,7 @@ int ceph_mkdirs(struct ceph_mount_info *cmount, const char *path, mode_t mode);
  * @param path the path of the directory to remove.
  * @returns 0 on success or a negative return code on error.
  */
-int ceph_rmdir(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_rmdir(struct ceph_mount_info *cmount, const char *path);
 
 /** @} dir */
 
@@ -604,7 +626,8 @@ int ceph_rmdir(struct ceph_mount_info *cmount, const char *path);
  * @param newname the path to the new file/directory to link from.
  * @returns 0 on success or a negative return code on error.
  */
-int ceph_link(struct ceph_mount_info *cmount, const char *existing, const char *newname);
+CEPHFS_API int ceph_link(struct ceph_mount_info *cmount, const char *existing,
+			 const char *newname);
 
 /**
  * Read a symbolic link.
@@ -615,7 +638,8 @@ int ceph_link(struct ceph_mount_info *cmount, const char *existing, const char *
  * @param size the length of the buffer
  * @returns number of bytes copied on success or negative error code on failure
  */
-int ceph_readlink(struct ceph_mount_info *cmount, const char *path, char *buf, int64_t size);
+CEPHFS_API int ceph_readlink(struct ceph_mount_info *cmount, const char *path,
+			     char *buf, int64_t size);
 
 /**
  * Creates a symbolic link.
@@ -625,7 +649,8 @@ int ceph_readlink(struct ceph_mount_info *cmount, const char *path, char *buf, i
  * @param newname the path to the new file/directory to link from.
  * @returns 0 on success or a negative return code on failure.
  */
-int ceph_symlink(struct ceph_mount_info *cmount, const char *existing, const char *newname);
+CEPHFS_API int ceph_symlink(struct ceph_mount_info *cmount,
+			    const char *existing, const char *newname);
 
 /** @} links */
 
@@ -644,7 +669,7 @@ int ceph_symlink(struct ceph_mount_info *cmount, const char *existing, const cha
  * @param path the path of the file or link to unlink.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
 
 /**
  * Rename a file or directory.
@@ -654,7 +679,8 @@ int ceph_unlink(struct ceph_mount_info *cmount, const char *path);
  * @param to the new name of the file or directory
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_rename(struct ceph_mount_info *cmount, const char *from, const char *to);
+CEPHFS_API int ceph_rename(struct ceph_mount_info *cmount, const char *from,
+			   const char *to);
 
 /**
  * Get a file's extended statistics and attributes.
@@ -666,8 +692,8 @@ int ceph_rename(struct ceph_mount_info *cmount, const char *from, const char *to
  * @param flags bitfield that can be used to set AT_* modifier flags (only AT_NO_ATTR_SYNC and AT_SYMLINK_NOFOLLOW)
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_statx(struct ceph_mount_info *cmount, const char *path, struct ceph_statx *stx,
-	       unsigned int want, unsigned int flags);
+CEPHFS_API int ceph_statx(struct ceph_mount_info *cmount, const char *path,
+			  struct ceph_statx *stx, unsigned want, unsigned flags);
 
 /**
  * Set a file's attributes.
@@ -679,7 +705,8 @@ int ceph_statx(struct ceph_mount_info *cmount, const char *path, struct ceph_sta
  * @param flags mask of AT_* flags (only AT_ATTR_NOFOLLOW is respected for now)
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath, struct ceph_statx *stx, int mask, int flags);
+CEPHFS_API int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath,
+			     struct ceph_statx *stx, int mask, int flags);
 
 /**
  * Set a file's attributes (extended version).
@@ -690,7 +717,8 @@ int ceph_setattrx(struct ceph_mount_info *cmount, const char *relpath, struct ce
  * @param mask a mask of all the stat values that have been set on the stat struct.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_fsetattrx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *stx, int mask);
+CEPHFS_API int ceph_fsetattrx(struct ceph_mount_info *cmount, int fd,
+			      struct ceph_statx *stx, int mask);
 
 /**
  * Change the mode bits (permissions) of a file/directory.
@@ -700,7 +728,8 @@ int ceph_fsetattrx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *st
  * @param mode the new permissions to set.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_chmod(struct ceph_mount_info *cmount, const char *path, mode_t mode);
+CEPHFS_API int ceph_chmod(struct ceph_mount_info *cmount, const char *path,
+			  mode_t mode);
 
 /**
  * Change the mode bits (permissions) of an open file.
@@ -710,7 +739,7 @@ int ceph_chmod(struct ceph_mount_info *cmount, const char *path, mode_t mode);
  * @param mode the new permissions to set.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode);
+CEPHFS_API int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode);
 
 /**
  * Change the ownership of a file/directory.
@@ -721,7 +750,8 @@ int ceph_fchmod(struct ceph_mount_info *cmount, int fd, mode_t mode);
  * @param gid the group id to set on the file/directory.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_chown(struct ceph_mount_info *cmount, const char *path, int uid, int gid);
+CEPHFS_API int ceph_chown(struct ceph_mount_info *cmount, const char *path,
+			  int uid, int gid);
 
 /**
  * Change the ownership of a file from an open file descriptor.
@@ -732,7 +762,8 @@ int ceph_chown(struct ceph_mount_info *cmount, const char *path, int uid, int gi
  * @param gid the group id to set on the file/directory.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
+CEPHFS_API int ceph_fchown(struct ceph_mount_info *cmount, int fd,
+			   int uid, int gid);
 
 /**
  * Change the ownership of a file/directory, don't follow symlinks.
@@ -743,7 +774,8 @@ int ceph_fchown(struct ceph_mount_info *cmount, int fd, int uid, int gid);
  * @param gid the group id to set on the file/directory.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_lchown(struct ceph_mount_info *cmount, const char *path, int uid, int gid);
+CEPHFS_API int ceph_lchown(struct ceph_mount_info *cmount, const char *path,
+			   int uid, int gid);
 
 /**
  * Change file/directory last access and modification times.
@@ -753,7 +785,8 @@ int ceph_lchown(struct ceph_mount_info *cmount, const char *path, int uid, int g
  * @param buf holding the access and modification times to set on the file.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_utime(struct ceph_mount_info *cmount, const char *path, struct utimbuf *buf);
+CEPHFS_API int ceph_utime(struct ceph_mount_info *cmount, const char *path,
+			  struct utimbuf *buf);
 
 /**
  * Apply or remove an advisory lock.
@@ -767,8 +800,8 @@ int ceph_utime(struct ceph_mount_info *cmount, const char *path, struct utimbuf 
  * @param owner the user-supplied owner identifier (an arbitrary integer)
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation,
-	       uint64_t owner);
+CEPHFS_API int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation,
+			  uint64_t owner);
 
 /**
  * Truncate the file to the given size.  If this operation causes the
@@ -779,7 +812,8 @@ int ceph_flock(struct ceph_mount_info *cmount, int fd, int operation,
  * @param size the new size of the file.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_truncate(struct ceph_mount_info *cmount, const char *path, int64_t size);
+CEPHFS_API int ceph_truncate(struct ceph_mount_info *cmount, const char *path,
+			     int64_t size);
 
 /**
  * Make a block or character special file.
@@ -793,7 +827,8 @@ int ceph_truncate(struct ceph_mount_info *cmount, const char *path, int64_t size
  *        it is ignored.
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_mknod(struct ceph_mount_info *cmount, const char *path, mode_t mode, dev_t rdev);
+CEPHFS_API int ceph_mknod(struct ceph_mount_info *cmount, const char *path,
+			  mode_t mode, dev_t rdev);
 /**
  * Create and/or open a file.
  *
@@ -805,7 +840,8 @@ int ceph_mknod(struct ceph_mount_info *cmount, const char *path, mode_t mode, de
  *        is specified in the flags.
  * @returns a non-negative file descriptor number on success or a negative error code on failure.
  */
-int ceph_open(struct ceph_mount_info *cmount, const char *path, int flags, mode_t mode);
+CEPHFS_API int ceph_open(struct ceph_mount_info *cmount, const char *path,
+			 int flags, mode_t mode);
 
 /**
  * Create and/or open a file with a specific file layout.
@@ -822,9 +858,10 @@ int ceph_open(struct ceph_mount_info *cmount, const char *path, int flags, mode_
  * @param data_pool name of target data pool name (optional, NULL or empty string for default)
  * @returns a non-negative file descriptor number on success or a negative error code on failure.
  */
-int ceph_open_layout(struct ceph_mount_info *cmount, const char *path, int flags,
- 		     mode_t mode, int stripe_unit, int stripe_count, int object_size,
- 		     const char *data_pool);
+CEPHFS_API int ceph_open_layout(struct ceph_mount_info *cmount, const char *path,
+				int flags, mode_t mode, int stripe_unit,
+				int stripe_count, int object_size,
+				const char *data_pool);
 
 /**
  * Close the open file.
@@ -833,7 +870,7 @@ int ceph_open_layout(struct ceph_mount_info *cmount, const char *path, int flags
  * @param fd the file descriptor referring to the open file.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_close(struct ceph_mount_info *cmount, int fd);
+CEPHFS_API int ceph_close(struct ceph_mount_info *cmount, int fd);
 
 /**
  * Reposition the open file stream based on the given offset.
@@ -848,7 +885,8 @@ int ceph_close(struct ceph_mount_info *cmount, int fd);
  *      SEEK_END: the offset is set to the end of the file plus @e offset bytes.
  * @returns 0 on success or a negative error code on failure.
  */
-int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int whence);
+CEPHFS_API int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd,
+			      int64_t offset, int whence);
 /**
  * Read data from the file.
  *
@@ -860,7 +898,8 @@ int64_t ceph_lseek(struct ceph_mount_info *cmount, int fd, int64_t offset, int w
  *        function reads from the current offset of the file descriptor.
  * @returns the number of bytes read into buf, or a negative error code on failure.
  */
-int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf, int64_t size, int64_t offset);
+CEPHFS_API int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf,
+			 int64_t size, int64_t offset);
 
 /**
  * Read data from the file.
@@ -872,8 +911,9 @@ int ceph_read(struct ceph_mount_info *cmount, int fd, char *buf, int64_t size, i
  *        function reads from the current offset of the file descriptor.
  * @returns the number of bytes read into buf, or a negative error code on failure.
  */
-int ceph_preadv(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
-           int64_t offset);
+CEPHFS_API int ceph_preadv(struct ceph_mount_info *cmount, int fd,
+			   const struct iovec *iov, int iovcnt,
+			   int64_t offset);
 
 /**
  * Write data to a file.
@@ -886,8 +926,8 @@ int ceph_preadv(struct ceph_mount_info *cmount, int fd, const struct iovec *iov,
  *        function writes to the current offset of the file descriptor.
  * @returns the number of bytes written, or a negative error code
  */
-int ceph_write(struct ceph_mount_info *cmount, int fd, const char *buf, int64_t size,
-	       int64_t offset);
+CEPHFS_API int ceph_write(struct ceph_mount_info *cmount, int fd,
+			  const char *buf, int64_t size, int64_t offset);
 
 /**
  * Write data to a file.
@@ -900,8 +940,9 @@ int ceph_write(struct ceph_mount_info *cmount, int fd, const char *buf, int64_t 
  *        function writes to the current offset of the file descriptor.
  * @returns the number of bytes written, or a negative error code
  */
-int ceph_pwritev(struct ceph_mount_info *cmount, int fd, const struct iovec *iov, int iovcnt,
-           int64_t offset);
+CEPHFS_API int ceph_pwritev(struct ceph_mount_info *cmount, int fd,
+			    const struct iovec *iov, int iovcnt,
+			    int64_t offset);
 
 /**
  * Truncate a file to the given size.
@@ -911,7 +952,8 @@ int ceph_pwritev(struct ceph_mount_info *cmount, int fd, const struct iovec *iov
  * @param size the new size of the file
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_ftruncate(struct ceph_mount_info *cmount, int fd, int64_t size);
+CEPHFS_API int ceph_ftruncate(struct ceph_mount_info *cmount, int fd,
+			      int64_t size);
 
 /**
  * Synchronize an open file to persistent media.
@@ -922,7 +964,8 @@ int ceph_ftruncate(struct ceph_mount_info *cmount, int fd, int64_t size);
  *        or just data (1).
  * @return 0 on success or a negative error code on failure.
  */
-int ceph_fsync(struct ceph_mount_info *cmount, int fd, int syncdataonly);
+CEPHFS_API int ceph_fsync(struct ceph_mount_info *cmount, int fd,
+			  int syncdataonly);
 
 /**
  * Preallocate or release disk space for the file for the byte range.
@@ -939,7 +982,7 @@ int ceph_fsync(struct ceph_mount_info *cmount, int fd, int syncdataonly);
  * @param length the length of the range.
  * @return 0 on success or a negative error code on failure.
  */
-int ceph_fallocate(struct ceph_mount_info *cmount, int fd, int mode,
+CEPHFS_API int ceph_fallocate(struct ceph_mount_info *cmount, int fd, int mode,
 	                      int64_t offset, int64_t length);
 
 /**
@@ -952,8 +995,9 @@ int ceph_fallocate(struct ceph_mount_info *cmount, int fd, int mode,
  * @param flags bitfield that can be used to set AT_* modifier flags (only AT_NO_ATTR_SYNC and AT_SYMLINK_NOFOLLOW)
  * @returns 0 on success or negative error code on failure.
  */
-int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *stx,
-		unsigned int want, unsigned int flags);
+CEPHFS_API int ceph_fstatx(struct ceph_mount_info *cmount, int fd,
+			   struct ceph_statx *stx,
+			   unsigned int want, unsigned int flags);
 
 /** @} file */
 
@@ -974,8 +1018,8 @@ int ceph_fstatx(struct ceph_mount_info *cmount, int fd, struct ceph_statx *stx,
  * @param size the size of the pre-allocated buffer
  * @returns the size of the value or a negative error code on failure.
  */
-int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, const char *name, 
-	void *value, size_t size);
+CEPHFS_API int ceph_getxattr(struct ceph_mount_info *cmount, const char *path,
+			     const char *name, void *value, size_t size);
 
 /**
  * Get an extended attribute.
@@ -987,8 +1031,8 @@ int ceph_getxattr(struct ceph_mount_info *cmount, const char *path, const char *
  * @param size the size of the pre-allocated buffer
  * @returns the size of the value or a negative error code on failure.
  */
-int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
-	void *value, size_t size);
+CEPHFS_API int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd,
+			      const char *name, void *value, size_t size);
 
 /**
  * Get an extended attribute wihtout following symbolic links.  This function is
@@ -1003,8 +1047,8 @@ int ceph_fgetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
  * @param size the size of the pre-allocated buffer
  * @returns the size of the value or a negative error code on failure.
  */
-int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path, const char *name, 
-	void *value, size_t size);
+CEPHFS_API int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path,
+			      const char *name, void *value, size_t size);
 
 /**
  * List the extended attribute keys on a file.
@@ -1015,7 +1059,8 @@ int ceph_lgetxattr(struct ceph_mount_info *cmount, const char *path, const char 
  * @param size the size of the list buffer.
  * @returns the size of the resulting list filled in.
  */
-int ceph_listxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
+CEPHFS_API int ceph_listxattr(struct ceph_mount_info *cmount, const char *path,
+			      char *list, size_t size);
 
 /**
  * List the extended attribute keys on a file.
@@ -1026,7 +1071,8 @@ int ceph_listxattr(struct ceph_mount_info *cmount, const char *path, char *list,
  * @param size the size of the list buffer.
  * @returns the size of the resulting list filled in.
  */
-int ceph_flistxattr(struct ceph_mount_info *cmount, int fd, char *list, size_t size);
+CEPHFS_API int ceph_flistxattr(struct ceph_mount_info *cmount, int fd,
+			       char *list, size_t size);
 
 /**
  * Get the list of extended attribute keys on a file, but do not follow symbolic links.
@@ -1037,7 +1083,8 @@ int ceph_flistxattr(struct ceph_mount_info *cmount, int fd, char *list, size_t s
  * @param size the size of the list buffer.
  * @returns the size of the resulting list filled in.
  */
-int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path, char *list, size_t size);
+CEPHFS_API int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path,
+			       char *list, size_t size);
 
 /**
  * Remove an extended attribute from a file.
@@ -1047,7 +1094,8 @@ int ceph_llistxattr(struct ceph_mount_info *cmount, const char *path, char *list
  * @param name the name of the extended attribute to remove.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_removexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
+CEPHFS_API int ceph_removexattr(struct ceph_mount_info *cmount, const char *path,
+				const char *name);
 
 /**
  * Remove an extended attribute from a file.
@@ -1057,7 +1105,8 @@ int ceph_removexattr(struct ceph_mount_info *cmount, const char *path, const cha
  * @param name the name of the extended attribute to remove.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd, const char *name);
+CEPHFS_API int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd,
+				 const char *name);
 
 /**
  * Remove the extended attribute from a file, do not follow symbolic links.
@@ -1067,7 +1116,8 @@ int ceph_fremovexattr(struct ceph_mount_info *cmount, int fd, const char *name);
  * @param name the name of the extended attribute to remove.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_lremovexattr(struct ceph_mount_info *cmount, const char *path, const char *name);
+CEPHFS_API int ceph_lremovexattr(struct ceph_mount_info *cmount,
+				 const char *path, const char *name);
 
 /**
  * Set an extended attribute on a file.
@@ -1082,8 +1132,9 @@ int ceph_lremovexattr(struct ceph_mount_info *cmount, const char *path, const ch
  *      CEPH_XATTR_REPLACE: replace the extended attribute, Must already exist.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_setxattr(struct ceph_mount_info *cmount, const char *path, const char *name, 
-	const void *value, size_t size, int flags);
+CEPHFS_API int ceph_setxattr(struct ceph_mount_info *cmount, const char *path,
+			     const char *name,  const void *value, size_t size,
+			     int flags);
 
 /**
  * Set an extended attribute on a file.
@@ -1098,8 +1149,9 @@ int ceph_setxattr(struct ceph_mount_info *cmount, const char *path, const char *
  *      CEPH_XATTR_REPLACE: replace the extended attribute, Must already exist.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
-	const void *value, size_t size, int flags);
+CEPHFS_API int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd,
+			      const char *name, const void *value, size_t size,
+			      int flags);
 
 /**
  * Set an extended attribute on a file, do not follow symbolic links.
@@ -1114,8 +1166,9 @@ int ceph_fsetxattr(struct ceph_mount_info *cmount, int fd, const char *name,
  *      CEPH_XATTR_REPLACE: replace the extended attribute, Must already exist.
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char *name, 
-	const void *value, size_t size, int flags);
+CEPHFS_API int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path,
+			      const char *name, const void *value, size_t size,
+			      int flags);
 
 /** @} xattr */
 
@@ -1133,7 +1186,7 @@ int ceph_lsetxattr(struct ceph_mount_info *cmount, const char *path, const char 
  * @param fh the open file descriptor referring to the file to get the striping unit of.
  * @returns the striping unit of the file or a negative error code on failure.
  */
-int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh);
+CEPHFS_API int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh);
 
 /**
  * Get the file striping unit.
@@ -1142,7 +1195,8 @@ int ceph_get_file_stripe_unit(struct ceph_mount_info *cmount, int fh);
  * @param path the path of the file/directory get the striping unit of.
  * @returns the striping unit of the file or a negative error code on failure.
  */
-int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount,
+					 const char *path);
 
 /**
  * Get the file striping count from an open file descriptor.
@@ -1151,7 +1205,7 @@ int ceph_get_path_stripe_unit(struct ceph_mount_info *cmount, const char *path);
  * @param fh the open file descriptor referring to the file to get the striping count of.
  * @returns the striping count of the file or a negative error code on failure.
  */
-int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh);
+CEPHFS_API int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh);
 
 /**
  * Get the file striping count.
@@ -1160,7 +1214,8 @@ int ceph_get_file_stripe_count(struct ceph_mount_info *cmount, int fh);
  * @param path the path of the file/directory get the striping count of.
  * @returns the striping count of the file or a negative error code on failure.
  */
-int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_get_path_stripe_count(struct ceph_mount_info *cmount,
+					  const char *path);
 
 /**
  * Get the file object size from an open file descriptor.
@@ -1169,7 +1224,7 @@ int ceph_get_path_stripe_count(struct ceph_mount_info *cmount, const char *path)
  * @param fh the open file descriptor referring to the file to get the object size of.
  * @returns the object size of the file or a negative error code on failure.
  */
-int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh);
+CEPHFS_API int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh);
 
 /**
  * Get the file object size.
@@ -1178,7 +1233,8 @@ int ceph_get_file_object_size(struct ceph_mount_info *cmount, int fh);
  * @param path the path of the file/directory get the object size of.
  * @returns the object size of the file or a negative error code on failure.
  */
-int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_get_path_object_size(struct ceph_mount_info *cmount,
+					 const char *path);
 
 /**
  * Get the file pool information from an open file descriptor.
@@ -1187,7 +1243,7 @@ int ceph_get_path_object_size(struct ceph_mount_info *cmount, const char *path);
  * @param fh the open file descriptor referring to the file to get the pool information of.
  * @returns the ceph pool id that the file is in
  */
-int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh);
+CEPHFS_API int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh);
 
 /**
  * Get the file pool information.
@@ -1196,7 +1252,8 @@ int ceph_get_file_pool(struct ceph_mount_info *cmount, int fh);
  * @param path the path of the file/directory get the pool information of.
  * @returns the ceph pool id that the file is in
  */
-int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_get_path_pool(struct ceph_mount_info *cmount,
+				  const char *path);
 
 /**
  * Get the name of the pool a opened file is stored in,
@@ -1210,7 +1267,8 @@ int ceph_get_path_pool(struct ceph_mount_info *cmount, const char *path);
  * @param buflen size of the buffer
  * @returns length in bytes of the pool name, or -ERANGE if the buffer is not large enough.
  */
-int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, char *buf, size_t buflen);
+CEPHFS_API int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh,
+				       char *buf, size_t buflen);
 
 /**
  * get the name of a pool by id
@@ -1223,7 +1281,8 @@ int ceph_get_file_pool_name(struct ceph_mount_info *cmount, int fh, char *buf, s
  * @param buflen size of the buffer
  * @returns length in bytes of the pool name, or -ERANGE if the buffer is not large enough
  */
-int ceph_get_pool_name(struct ceph_mount_info *cmount, int pool, char *buf, size_t buflen);
+CEPHFS_API int ceph_get_pool_name(struct ceph_mount_info *cmount, int pool,
+				  char *buf, size_t buflen);
 
 /**
  * Get the name of the pool a file is stored in
@@ -1237,7 +1296,8 @@ int ceph_get_pool_name(struct ceph_mount_info *cmount, int pool, char *buf, size
  * @param buflen size of the buffer
  * @returns length in bytes of the pool name, or -ERANGE if the buffer is not large enough.
  */
-int ceph_get_path_pool_name(struct ceph_mount_info *cmount, const char *path, char *buf, size_t buflen);
+CEPHFS_API int ceph_get_path_pool_name(struct ceph_mount_info *cmount,
+				       const char *path, char *buf, size_t buflen);
 
 /**
  * Get the file layout from an open file descriptor.
@@ -1250,7 +1310,9 @@ int ceph_get_path_pool_name(struct ceph_mount_info *cmount, const char *path, ch
  * @param pg_pool where to store the ceph pool id that the file is in
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_get_file_layout(struct ceph_mount_info *cmount, int fh, int *stripe_unit, int *stripe_count, int *object_size, int *pg_pool);
+CEPHFS_API int ceph_get_file_layout(struct ceph_mount_info *cmount, int fh,
+				    int *stripe_unit, int *stripe_count,
+				    int *object_size, int *pg_pool);
 
 /**
  * Get the file layout.
@@ -1263,7 +1325,10 @@ int ceph_get_file_layout(struct ceph_mount_info *cmount, int fh, int *stripe_uni
  * @param pg_pool where to store the ceph pool id that the file is in
  * @returns 0 on success or a negative error code on failure.
  */
-int ceph_get_path_layout(struct ceph_mount_info *cmount, const char *path, int *stripe_unit, int *stripe_count, int *object_size, int *pg_pool);
+CEPHFS_API int ceph_get_path_layout(struct ceph_mount_info *cmount,
+				    const char *path,
+				    int *stripe_unit, int *stripe_count,
+				    int *object_size, int *pg_pool);
 
 /**
  * Get the file replication information from an open file descriptor.
@@ -1272,7 +1337,7 @@ int ceph_get_path_layout(struct ceph_mount_info *cmount, const char *path, int *
  * @param fh the open file descriptor referring to the file to get the replication information of.
  * @returns the replication factor of the file.
  */
-int ceph_get_file_replication(struct ceph_mount_info *cmount, int fh);
+CEPHFS_API int ceph_get_file_replication(struct ceph_mount_info *cmount, int fh);
 
 /**
  * Get the file replication information.
@@ -1281,7 +1346,8 @@ int ceph_get_file_replication(struct ceph_mount_info *cmount, int fh);
  * @param path the path of the file/directory get the replication information of.
  * @returns the replication factor of the file.
  */
-int ceph_get_path_replication(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_get_path_replication(struct ceph_mount_info *cmount,
+					 const char *path);
 
 /**
  * Get the id of the named pool.
@@ -1290,7 +1356,8 @@ int ceph_get_path_replication(struct ceph_mount_info *cmount, const char *path);
  * @param pool_name the name of the pool.
  * @returns the pool id, or a negative error code on failure.
  */
-int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name);
+CEPHFS_API int ceph_get_pool_id(struct ceph_mount_info *cmount,
+				const char *pool_name);
 
 /**
  * Get the pool replication factor.
@@ -1299,7 +1366,8 @@ int ceph_get_pool_id(struct ceph_mount_info *cmount, const char *pool_name);
  * @param pool_id the pool id to look up
  * @returns the replication factor, or a negative error code on failure.
  */
-int ceph_get_pool_replication(struct ceph_mount_info *cmount, int pool_id);
+CEPHFS_API int ceph_get_pool_replication(struct ceph_mount_info *cmount,
+					 int pool_id);
 
 /**
  * Get the OSD address where the primary copy of a file stripe is located.
@@ -1313,8 +1381,10 @@ int ceph_get_pool_replication(struct ceph_mount_info *cmount, int pool_id);
  * @returns the size of the addressed filled into the @e addr parameter, or a negative
  *	error code on failure.
  */
-int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int fd, int64_t offset,
-				 struct sockaddr_storage *addr, int naddr);
+CEPHFS_API int ceph_get_file_stripe_address(struct ceph_mount_info *cmount,
+					    int fd, int64_t offset,
+					    struct sockaddr_storage *addr,
+					    int naddr);
 
 /**
  * Get the list of OSDs where the objects containing a file offset are located.
@@ -1329,8 +1399,9 @@ int ceph_get_file_stripe_address(struct ceph_mount_info *cmount, int fd, int64_t
  * @returns the number of items stored in the output array, or -ERANGE if the
  * array is not large enough.
  */
-int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fd,
-                              int64_t offset, int64_t *length, int *osds, int nosds);
+CEPHFS_API int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fd,
+					 int64_t offset, int64_t *length,
+					 int *osds, int nosds);
 
 /**
  * Get the fully qualified CRUSH location of an OSD.
@@ -1346,8 +1417,8 @@ int ceph_get_file_extent_osds(struct ceph_mount_info *cmount, int fd,
  * @returns the amount of bytes written into the buffer, or -ERANGE if the
  * array is not large enough.
  */
-int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
-    int osd, char *path, size_t len);
+CEPHFS_API int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
+					   int osd, char *path, size_t len);
 
 /**
  * Get the network address of an OSD.
@@ -1357,15 +1428,15 @@ int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
  * @param addr the OSD network address.
  * @returns zero on success, other returns a negative error code.
  */
-int ceph_get_osd_addr(struct ceph_mount_info *cmount, int osd,
-    struct sockaddr_storage *addr);
+CEPHFS_API int ceph_get_osd_addr(struct ceph_mount_info *cmount, int osd,
+				 struct sockaddr_storage *addr);
 
 /**
  * Get the file layout stripe unit granularity.
  * @param cmount the ceph mount handle.
  * @returns the stripe unit granularity or a negative error code on failure.
  */
-int ceph_get_stripe_unit_granularity(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_get_stripe_unit_granularity(struct ceph_mount_info *cmount);
 
 /** @} filelayout */
 
@@ -1373,11 +1444,11 @@ int ceph_get_stripe_unit_granularity(struct ceph_mount_info *cmount);
  * No longer available.  Do not use.
  * These functions will return -EOPNOTSUPP.
  */
-int ceph_set_default_file_stripe_unit(struct ceph_mount_info *cmount, int stripe);
-int ceph_set_default_file_stripe_count(struct ceph_mount_info *cmount, int count);
-int ceph_set_default_object_size(struct ceph_mount_info *cmount, int size);
-int ceph_set_default_preferred_pg(struct ceph_mount_info *cmount, int osd);
-int ceph_set_default_file_replication(struct ceph_mount_info *cmount, int replication);
+CEPHFS_API int ceph_set_default_file_stripe_unit(struct ceph_mount_info *cmount, int stripe);
+CEPHFS_API int ceph_set_default_file_stripe_count(struct ceph_mount_info *cmount, int count);
+CEPHFS_API int ceph_set_default_object_size(struct ceph_mount_info *cmount, int size);
+CEPHFS_API int ceph_set_default_preferred_pg(struct ceph_mount_info *cmount, int osd);
+CEPHFS_API int ceph_set_default_file_replication(struct ceph_mount_info *cmount, int replication);
 
 /**
  * Read from local replicas when possible.
@@ -1387,7 +1458,7 @@ int ceph_set_default_file_replication(struct ceph_mount_info *cmount, int replic
  *     for reads.
  * @returns 0
  */
-int ceph_localize_reads(struct ceph_mount_info *cmount, int val);
+CEPHFS_API int ceph_localize_reads(struct ceph_mount_info *cmount, int val);
 
 /**
  * Get the osd id of the local osd (if any)
@@ -1396,7 +1467,7 @@ int ceph_localize_reads(struct ceph_mount_info *cmount, int val);
  * @returns the osd (if any) local to the node where this call is made, otherwise
  *	-1 is returned.
  */
-int ceph_get_local_osd(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_get_local_osd(struct ceph_mount_info *cmount);
 
 /** @} default_filelayout */
 
@@ -1408,7 +1479,7 @@ int ceph_get_local_osd(struct ceph_mount_info *cmount);
  * @returns the current capabilities issued to this client
  *       for the open file
  */
-int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd);
+CEPHFS_API int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd);
 
 /**
  * Get the capabilities currently issued to the client.
@@ -1418,15 +1489,14 @@ int ceph_debug_get_fd_caps(struct ceph_mount_info *cmount, int fd);
  * @returns the current capabilities issued to this client
  *       for the file
  */
-int ceph_debug_get_file_caps(struct ceph_mount_info *cmount, const char *path);
+CEPHFS_API int ceph_debug_get_file_caps(struct ceph_mount_info *cmount, const char *path);
 
 /* Low Level */
-struct Inode *ceph_ll_get_inode(struct ceph_mount_info *cmount,
-				vinodeno_t vino);
-int ceph_ll_lookup_inode(
-    struct ceph_mount_info *cmount,
-    struct inodeno_t ino,
-    Inode **inode);
+CEPHFS_API struct Inode *ceph_ll_get_inode(struct ceph_mount_info *cmount,
+					   vinodeno_t vino);
+CEPHFS_API int ceph_ll_lookup_inode(struct ceph_mount_info *cmount,
+				    struct inodeno_t ino,
+				    Inode **inode);
 
 /**
  * Get the root inode of FS. Increase counter of references for root Inode. You must call ceph_ll_forget for it!
@@ -1435,38 +1505,46 @@ int ceph_ll_lookup_inode(
  * @param parent pointer to pointer to Inode struct. Pointer to root inode will be returned
  * @returns 0 if all good
  */
-int ceph_ll_lookup_root(struct ceph_mount_info *cmount,
-                  Inode **parent);
-int ceph_ll_lookup(struct ceph_mount_info *cmount, Inode *parent,
-		   const char *name, Inode **out, struct ceph_statx *stx,
-		   unsigned want, unsigned flags, const UserPerm *perms);
-int ceph_ll_put(struct ceph_mount_info *cmount, struct Inode *in);
-int ceph_ll_forget(struct ceph_mount_info *cmount, struct Inode *in,
-		   int count);
-int ceph_ll_walk(struct ceph_mount_info *cmount, const char* name, Inode **i,
-		 struct ceph_statx *stx, unsigned int want, unsigned int flags,
-		 const UserPerm *perms);
-int ceph_ll_getattr(struct ceph_mount_info *cmount, struct Inode *in,
-		    struct ceph_statx *stx, unsigned int want, unsigned int flags,
-		    const UserPerm *perms);
-int ceph_ll_setattr(struct ceph_mount_info *cmount, struct Inode *in,
-		    struct ceph_statx *stx, int mask, const UserPerm *perms);
-int ceph_ll_open(struct ceph_mount_info *cmount, struct Inode *in, int flags,
-		 struct Fh **fh, const UserPerm *perms);
-off_t ceph_ll_lseek(struct ceph_mount_info *cmount, struct Fh* filehandle,
-		     off_t offset, int whence);
-int ceph_ll_read(struct ceph_mount_info *cmount, struct Fh* filehandle,
-		 int64_t off, uint64_t len, char* buf);
-int ceph_ll_fsync(struct ceph_mount_info *cmount, struct Fh *fh,
-		  int syncdataonly);
-int ceph_ll_write(struct ceph_mount_info *cmount, struct Fh* filehandle,
-		  int64_t off, uint64_t len, const char *data);
-int64_t ceph_ll_readv(struct ceph_mount_info *cmount, struct Fh *fh,
-		      const struct iovec *iov, int iovcnt, int64_t off);
-int64_t ceph_ll_writev(struct ceph_mount_info *cmount, struct Fh *fh,
-		       const struct iovec *iov, int iovcnt, int64_t off);
-int ceph_ll_close(struct ceph_mount_info *cmount, struct Fh* filehandle);
-int ceph_ll_iclose(struct ceph_mount_info *cmount, struct Inode *in, int mode);
+CEPHFS_API int ceph_ll_lookup_root(struct ceph_mount_info *cmount,
+				   Inode **parent);
+CEPHFS_API int ceph_ll_lookup(struct ceph_mount_info *cmount, Inode *parent,
+			      const char *name, Inode **out,
+			      struct ceph_statx *stx, unsigned want,
+			      unsigned flags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_put(struct ceph_mount_info *cmount, struct Inode *in);
+CEPHFS_API int ceph_ll_forget(struct ceph_mount_info *cmount, struct Inode *in,
+			      int count);
+CEPHFS_API int ceph_ll_walk(struct ceph_mount_info *cmount, const char* name,
+			    Inode **i,
+			    struct ceph_statx *stx, unsigned int want,
+			    unsigned int flags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_getattr(struct ceph_mount_info *cmount, struct Inode *in,
+			       struct ceph_statx *stx, unsigned int want,
+			       unsigned int flags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_setattr(struct ceph_mount_info *cmount, struct Inode *in,
+			       struct ceph_statx *stx, int mask,
+			       const UserPerm *perms);
+CEPHFS_API int ceph_ll_open(struct ceph_mount_info *cmount, struct Inode *in,
+			    int flags, struct Fh **fh, const UserPerm *perms);
+CEPHFS_API off_t ceph_ll_lseek(struct ceph_mount_info *cmount,
+			       struct Fh* filehandle, off_t offset, int whence);
+CEPHFS_API int ceph_ll_read(struct ceph_mount_info *cmount,
+			    struct Fh* filehandle,
+			    int64_t off, uint64_t len, char* buf);
+CEPHFS_API int ceph_ll_fsync(struct ceph_mount_info *cmount, struct Fh *fh,
+			     int syncdataonly);
+CEPHFS_API int ceph_ll_write(struct ceph_mount_info *cmount, struct Fh* filehandle,
+			     int64_t off, uint64_t len, const char *data);
+CEPHFS_API int64_t ceph_ll_readv(struct ceph_mount_info *cmount, struct Fh *fh,
+				 const struct iovec *iov, int iovcnt,
+				 int64_t off);
+CEPHFS_API int64_t ceph_ll_writev(struct ceph_mount_info *cmount, struct Fh *fh,
+				  const struct iovec *iov, int iovcnt,
+				  int64_t off);
+CEPHFS_API int ceph_ll_close(struct ceph_mount_info *cmount,
+			     struct Fh* filehandle);
+CEPHFS_API int ceph_ll_iclose(struct ceph_mount_info *cmount, struct Inode *in,
+			      int mode);
 /**
  * Get xattr value by xattr name.
  *
@@ -1478,85 +1556,90 @@ int ceph_ll_iclose(struct ceph_mount_info *cmount, struct Inode *in, int mode);
  * @param perms pointer to UserPerms object
  * @returns size of returned buffer. Negative number in error case
  */
-int ceph_ll_getxattr(struct ceph_mount_info *cmount, struct Inode *in,
-		     const char *name, void *value, size_t size,
-		     const UserPerm *perms);
-int ceph_ll_setxattr(struct ceph_mount_info *cmount, struct Inode *in,
-		     const char *name, const void *value, size_t size,
-		     int flags, const UserPerm *perms);
-int ceph_ll_listxattr(struct ceph_mount_info *cmount, struct Inode *in,
-                      char *list, size_t buf_size, size_t *list_size,
-		      const UserPerm *perms);
-int ceph_ll_removexattr(struct ceph_mount_info *cmount, struct Inode *in,
-			const char *name, const UserPerm *perms);
-int ceph_ll_create(struct ceph_mount_info *cmount, Inode *parent,
-		   const char *name, mode_t mode, int oflags, Inode **outp,
-		   Fh **fhp, struct ceph_statx *stx, unsigned want,
-		   unsigned lflags, const UserPerm *perms);
-int ceph_ll_mknod(struct ceph_mount_info *cmount, Inode *parent,
-		  const char *name, mode_t mode, dev_t rdev, Inode **out,
-		  struct ceph_statx *stx, unsigned want, unsigned flags,
-		  const UserPerm *perms);
-int ceph_ll_mkdir(struct ceph_mount_info *cmount, Inode *parent,
-		  const char *name, mode_t mode, Inode **out,
-		  struct ceph_statx *stx, unsigned want,
-		  unsigned flags, const UserPerm *perms);
-int ceph_ll_link(struct ceph_mount_info *cmount, struct Inode *in,
-		 struct Inode *newparent, const char *name,
-		 const UserPerm *perms);
-int ceph_ll_opendir(struct ceph_mount_info *cmount, struct Inode *in,
-		    struct ceph_dir_result **dirpp, const UserPerm *perms);
-int ceph_ll_releasedir(struct ceph_mount_info *cmount,
+CEPHFS_API int ceph_ll_getxattr(struct ceph_mount_info *cmount, struct Inode *in,
+				const char *name, void *value, size_t size,
+				const UserPerm *perms);
+CEPHFS_API int ceph_ll_setxattr(struct ceph_mount_info *cmount, struct Inode *in,
+				const char *name, const void *value, size_t size,
+				int flags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_listxattr(struct ceph_mount_info *cmount, struct Inode *in,
+				 char *list, size_t buf_size, size_t *list_size,
+				 const UserPerm *perms);
+CEPHFS_API int ceph_ll_removexattr(struct ceph_mount_info *cmount, struct Inode *in,
+				   const char *name, const UserPerm *perms);
+CEPHFS_API int ceph_ll_create(struct ceph_mount_info *cmount, Inode *parent,
+			      const char *name, mode_t mode, int oflags, Inode **outp,
+			      Fh **fhp, struct ceph_statx *stx, unsigned want,
+			      unsigned lflags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_mknod(struct ceph_mount_info *cmount, Inode *parent,
+			     const char *name, mode_t mode, dev_t rdev, Inode **out,
+			     struct ceph_statx *stx, unsigned want, unsigned flags,
+			     const UserPerm *perms);
+CEPHFS_API int ceph_ll_mkdir(struct ceph_mount_info *cmount, Inode *parent,
+			     const char *name, mode_t mode, Inode **out,
+			     struct ceph_statx *stx, unsigned want,
+			     unsigned flags, const UserPerm *perms);
+CEPHFS_API int ceph_ll_link(struct ceph_mount_info *cmount, struct Inode *in,
+			    struct Inode *newparent, const char *name,
+			    const UserPerm *perms);
+CEPHFS_API int ceph_ll_opendir(struct ceph_mount_info *cmount, struct Inode *in,
+			       struct ceph_dir_result **dirpp,
+			       const UserPerm *perms);
+CEPHFS_API int ceph_ll_releasedir(struct ceph_mount_info *cmount,
 		       struct ceph_dir_result* dir);
-int ceph_ll_rename(struct ceph_mount_info *cmount, struct Inode *parent,
-		   const char *name, struct Inode *newparent,
-		   const char *newname, const UserPerm *perms);
-int ceph_ll_unlink(struct ceph_mount_info *cmount, struct Inode *in,
-		   const char *name, const UserPerm *perms);
-int ceph_ll_statfs(struct ceph_mount_info *cmount, struct Inode *in,
-		   struct statvfs *stbuf);
-int ceph_ll_readlink(struct ceph_mount_info *cmount, struct Inode *in,
-		     char *buf, size_t bufsize, const UserPerm *perms);
-int ceph_ll_symlink(struct ceph_mount_info *cmount,
-		    Inode *in, const char *name, const char *value,
-		    Inode **out, struct ceph_statx *stx,
-		    unsigned want, unsigned flags,
-		    const UserPerm *perms);
-int ceph_ll_rmdir(struct ceph_mount_info *cmount, struct Inode *in,
-		  const char *name, const UserPerm *perms);
-uint32_t ceph_ll_stripe_unit(struct ceph_mount_info *cmount,
-			     struct Inode *in);
-uint32_t ceph_ll_file_layout(struct ceph_mount_info *cmount,
-			     struct Inode *in,
-			     struct ceph_file_layout *layout);
-uint64_t ceph_ll_snap_seq(struct ceph_mount_info *cmount,
-			  struct Inode *in);
-int ceph_ll_get_stripe_osd(struct ceph_mount_info *cmount,
-			   struct Inode *in,
-			   uint64_t blockno,
-			   struct ceph_file_layout* layout);
-int ceph_ll_num_osds(struct ceph_mount_info *cmount);
-int ceph_ll_osdaddr(struct ceph_mount_info *cmount,
-		    int osd, uint32_t *addr);
-uint64_t ceph_ll_get_internal_offset(struct ceph_mount_info *cmount,
-				     struct Inode *in, uint64_t blockno);
-int ceph_ll_read_block(struct ceph_mount_info *cmount,
-		       struct Inode *in, uint64_t blockid,
-		       char* bl, uint64_t offset, uint64_t length,
-		       struct ceph_file_layout* layout);
-int ceph_ll_write_block(struct ceph_mount_info *cmount,
-			struct Inode *in, uint64_t blockid,
-			char* buf, uint64_t offset,
-			uint64_t length, struct ceph_file_layout* layout,
-			uint64_t snapseq, uint32_t sync);
-int ceph_ll_commit_blocks(struct ceph_mount_info *cmount,
-			  struct Inode *in, uint64_t offset, uint64_t range);
+CEPHFS_API int ceph_ll_rename(struct ceph_mount_info *cmount,
+			      struct Inode *parent, const char *name,
+			      struct Inode *newparent, const char *newname,
+			      const UserPerm *perms);
+CEPHFS_API int ceph_ll_unlink(struct ceph_mount_info *cmount, struct Inode *in,
+			      const char *name, const UserPerm *perms);
+CEPHFS_API int ceph_ll_statfs(struct ceph_mount_info *cmount, struct Inode *in,
+			      struct statvfs *stbuf);
+CEPHFS_API int ceph_ll_readlink(struct ceph_mount_info *cmount,
+				struct Inode *in, char *buf, size_t bufsize,
+				const UserPerm *perms);
+CEPHFS_API int ceph_ll_symlink(struct ceph_mount_info *cmount,
+			       Inode *in, const char *name, const char *value,
+			       Inode **out, struct ceph_statx *stx,
+			       unsigned want, unsigned flags,
+			       const UserPerm *perms);
+CEPHFS_API int ceph_ll_rmdir(struct ceph_mount_info *cmount, struct Inode *in,
+			     const char *name, const UserPerm *perms);
+CEPHFS_API uint32_t ceph_ll_stripe_unit(struct ceph_mount_info *cmount,
+					struct Inode *in);
+CEPHFS_API uint32_t ceph_ll_file_layout(struct ceph_mount_info *cmount,
+					struct Inode *in,
+					struct ceph_file_layout *layout);
+CEPHFS_API uint64_t ceph_ll_snap_seq(struct ceph_mount_info *cmount,
+				     struct Inode *in);
+CEPHFS_API int ceph_ll_get_stripe_osd(struct ceph_mount_info *cmount,
+				      struct Inode *in,
+				      uint64_t blockno,
+				      struct ceph_file_layout* layout);
+CEPHFS_API int ceph_ll_num_osds(struct ceph_mount_info *cmount);
+CEPHFS_API int ceph_ll_osdaddr(struct ceph_mount_info *cmount,
+			       int osd, uint32_t *addr);
+CEPHFS_API uint64_t ceph_ll_get_internal_offset(struct ceph_mount_info *cmount,
+						struct Inode *in, uint64_t blockno);
+CEPHFS_API int ceph_ll_read_block(struct ceph_mount_info *cmount,
+				  struct Inode *in, uint64_t blockid,
+				  char* bl, uint64_t offset, uint64_t length,
+				  struct ceph_file_layout* layout);
+CEPHFS_API int ceph_ll_write_block(struct ceph_mount_info *cmount,
+				   struct Inode *in, uint64_t blockid,
+				   char* buf, uint64_t offset, uint64_t length,
+				   struct ceph_file_layout* layout,
+				   uint64_t snapseq, uint32_t sync);
+CEPHFS_API int ceph_ll_commit_blocks(struct ceph_mount_info *cmount,
+				     struct Inode *in, uint64_t offset,
+				     uint64_t range);
 
 
-int ceph_ll_getlk(struct ceph_mount_info *cmount,
-		  Fh *fh, struct flock *fl, uint64_t owner);
-int ceph_ll_setlk(struct ceph_mount_info *cmount,
-		  Fh *fh, struct flock *fl, uint64_t owner, int sleep);
+CEPHFS_API int ceph_ll_getlk(struct ceph_mount_info *cmount,
+			     Fh *fh, struct flock *fl, uint64_t owner);
+CEPHFS_API int ceph_ll_setlk(struct ceph_mount_info *cmount,
+			     Fh *fh, struct flock *fl, uint64_t owner,
+			     int sleep);
 
 #ifdef __cplusplus
 }

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -26,6 +26,7 @@ if(${WITH_CEPHFS})
   set_target_properties(ceph_test_libcephfs_access PROPERTIES COMPILE_FLAGS
     ${UNITTEST_CXX_FLAGS})
   target_link_libraries(ceph_test_libcephfs_access
+    json_spirit
     cephfs
     librados
     ${UNITTEST_LIBS}


### PR DESCRIPTION
otherwise the librados could be using the symbols leaked from libcephfs.
so a non-recursive lock could be still acquired when a thread is trying
to acquire it. actually it has already been relinquished by this thread.
because lockdep.cc was reoving the lock record from another instance of
`held`, and when it is acquired again, the `held` map still thinks that
the thread is holding the lock.

* CMakeLists.txt: hide all symbols from linked libs
* libcephfs.h: only expose public symbols

Signed-off-by: Kefu Chai <kchai@redhat.com>