### PR TITLE
Cython/pybind: Hardcode ENODATA until FreeBSD has this define

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -197,17 +197,18 @@ class WouldBlock(Error):
 class OutOfRange(Error):
     pass
 
+# FreeBSD does not have ENODATA
 cdef errno_to_exception =  {
     errno.EPERM      : PermissionError,
     errno.ENOENT     : ObjectNotFound,
     errno.EIO        : IOError,
     errno.ENOSPC     : NoSpace,
     errno.EEXIST     : ObjectExists,
-    errno.ENODATA    : NoData,
     errno.EINVAL     : InvalidValue,
     errno.EOPNOTSUPP : OperationNotSupported,
     errno.ERANGE     : OutOfRange,
     errno.EWOULDBLOCK: WouldBlock,
+    87		     : NoData,
 }
 
 

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -375,7 +375,7 @@ class TimedOut(Error):
     pass
 
 
-
+# FreeBSD does not have ENODATA
 cdef errno_to_exception = {
     errno.EPERM     : PermissionError,
     errno.ENOENT    : ObjectNotFound,
@@ -383,10 +383,10 @@ cdef errno_to_exception = {
     errno.ENOSPC    : NoSpace,
     errno.EEXIST    : ObjectExists,
     errno.EBUSY     : ObjectBusy,
-    errno.ENODATA   : NoData,
     errno.EINTR     : InterruptedOrTimeoutError,
     errno.ETIMEDOUT : TimedOut,
-    errno.EACCES    : PermissionDeniedError
+    errno.EACCES    : PermissionDeniedError,
+    87              : NoData
 }
 
 

--- a/src/pybind/rgw/rgw.pyx
+++ b/src/pybind/rgw/rgw.pyx
@@ -228,17 +228,18 @@ class WouldBlock(Error):
 class OutOfRange(Error):
     pass
 
+# FreeBSD does not have ENODATA
 cdef errno_to_exception =  {
     errno.EPERM      : PermissionError,
     errno.ENOENT     : ObjectNotFound,
     errno.EIO        : IOError,
     errno.ENOSPC     : NoSpace,
     errno.EEXIST     : ObjectExists,
-    errno.ENODATA    : NoData,
     errno.EINVAL     : InvalidValue,
     errno.EOPNOTSUPP : OperationNotSupported,
     errno.ERANGE     : OutOfRange,
     errno.EWOULDBLOCK: WouldBlock,
+    87               : NoData,
 }
 
 


### PR DESCRIPTION
Problem:
 - several pyx files use errno.ENODATA for error catching
 - This generates errors when the cython out is actually compiled
   bij the FreeBSD/Clang compiler.
   This due to '#define ENODATA 87' is missing
 - FreeBSD uses the ENOATTR define for this and cython is actually
   the only part that trips over it and is not proven to be repairable
   in tree. Have had several attempts with @tchaikov, but no success.

Fix:
 - So replace the enum value with a hardcode value.
   It is a value that is carved in stone in the include file, so there is
   little chance that this will ever change.
 - Patches have been submitted both with FreeBSD and cython to
   get FreeBSD:ENODATA and cython:ENOATTR
 - Once all fixes have been upstreamed this should go back to a regular
   define.

Current alternative:
 - For the time being I have fixed /usr/include/errno.h.
   But that will prevent FreeBSD to build packages, and everybody that will
   want to manually build will also have to fix this sytem file.
   Not a very nice prospective

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>