### PR TITLE
osd: fix memory leak from EC write workload

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -349,14 +349,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     raw_posix_aligned(unsigned l, unsigned _align) : raw(l) {
       align = _align;
       assert((align >= sizeof(void *)) && (align & (align - 1)) == 0);
-#ifdef DARWIN
-      data = (char *) valloc (len);
-#else
-      data = 0;
-      int r = ::posix_memalign((void**)(void*)&data, align, len);
-      if (r)
-	throw bad_alloc();
-#endif /* DARWIN */
+      data = mempool::buffer_data::alloc_char.allocate_aligned(len, align);
       if (!data)
 	throw bad_alloc();
       inc_total_alloc(len);
@@ -364,7 +357,7 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
       bdout << "raw_posix_aligned " << this << " alloc " << (void *)data << " l=" << l << ", align=" << align << " total_alloc=" << buffer::get_total_alloc() << bendl;
     }
     ~raw_posix_aligned() {
-      ::free((void*)data);
+      mempool::buffer_data::alloc_char.deallocate_aligned(data, len);
       dec_total_alloc(len);
       bdout << "raw_posix_aligned " << this << " free " << (void *)data << " " << buffer::get_total_alloc() << bendl;
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8005,6 +8005,7 @@ int BlueStore::_do_write(
 	   << " - have 0x" << o->onode.size
 	   << " (" << std::dec << o->onode.size << ")"
 	   << " bytes"
+	   << " fadvise_flags 0x" << std::hex << fadvise_flags << std::dec
 	   << dendl;
   _dump_onode(o);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8289,7 +8289,10 @@ int BlueStore::_setattr(TransContext *txc,
 	   << " " << name << " (" << val.length() << " bytes)"
 	   << dendl;
   int r = 0;
-  o->onode.attrs[name] = val;
+  if (val.is_partial())
+    o->onode.attrs[name] = bufferptr(val.c_str(), val.length());
+  else
+    o->onode.attrs[name] = val;
   txc->write_onode(o);
   dout(10) << __func__ << " " << c->cid << " " << o->oid
 	   << " " << name << " (" << val.length() << " bytes)"

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3432,6 +3432,8 @@ void ObjectModDesc::decode(bufferlist::iterator &_bl)
   ::decode(can_local_rollback, _bl);
   ::decode(rollback_info_completed, _bl);
   ::decode(bl, _bl);
+  // ensure bl does not pin a larger buffer in memory
+  bl.rebuild();
   DECODE_FINISH(_bl);
 }
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3535,6 +3535,8 @@ void pg_log_entry_t::decode(bufferlist::iterator &bl)
   if (struct_v >= 7 ||  // for v >= 7, this is for all ops.
       op == CLONE) {    // for v < 7, it's only present for CLONE.
     ::decode(snaps, bl);
+    // ensure snaps does not pin a larger buffer in memory
+    snaps.rebuild();
   }
 
   if (struct_v >= 8)

--- a/src/test/test_mempool.cc
+++ b/src/test/test_mempool.cc
@@ -265,6 +265,18 @@ TEST(mempool, unordered_map)
   h[2] = obj(1);
 }
 
+TEST(mempool, bufferlist)
+{
+  bufferlist bl;
+  int len = 1048576;
+  size_t before = mempool::buffer_data::allocated_bytes();
+  cout << "before " << before << std::endl;
+  bl.append(buffer::create_aligned(len, 4096));
+  size_t after = mempool::buffer_data::allocated_bytes();
+  cout << "after " << after << std::endl;
+  ASSERT_GE(after, before + len);
+}
+
 int main(int argc, char **argv)
 {
   vector<const char*> args;


### PR DESCRIPTION
This appears to only manifest when BlueStore is the backend, although the
final fix appeared to be related to the pg_log_entry_t bufferlists; not
quite sure why FileStore wasn't affected as well.