### PR TITLE
debian: apply dh_python to python-rgw also

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -139,8 +139,8 @@ override_dh_shlibdeps:
 	dh_shlibdeps -a --exclude=erasure-code --exclude=rados-classes --exclude=compressor
 
 override_dh_python2:
-	for binding in rados cephfs rbd; do                                \
-	  dh_python2 -p python-$$binding; \
+	for binding in rados cephfs rbd rgw; do \
+	  dh_python2 -p python-$$binding;       \
 	done
 	dh_python2 -p ceph-common
 	dh_python2 -p ceph-base
@@ -148,8 +148,8 @@ override_dh_python2:
 	dh_python2 -p ceph-mgr
 
 override_dh_python3:
-	for binding in rados cephfs rbd; do                                \
-	  dh_python3 -p python3-$$binding; \
+	for binding in rados cephfs rbd rgw; do \
+	  dh_python3 -p python3-$$binding;      \
 	done
 	dh_python3 -p python3-ceph-argparse
 


### PR DESCRIPTION
so the subvar of ${python:Depends} and ${python3:Depends} can be set
properly. also this silences the warnings like
```
    warning: dpkg-gencontrol: Depends field of package python3-rgw:
unknown substitution variable ${python3:Depends}
```

Signed-off-by: Kefu Chai <kchai@redhat.com>