### PR TITLE
ceph_test_objectstore: fix Rename test

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5066,7 +5066,6 @@ TEST_P(StoreTest, Rename) {
     ObjectStore::Transaction t;
     t.remove(cid, dstoid);
     t.collection_move_rename(cid, srcoid, cid, dstoid);
-    t.setattr(cid, srcoid, "attr", a);  // note: this is a no-op
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }


### PR DESCRIPTION
We were doing a no-op setattr here, even though the intenral
ENOENT used to be ignored, because it previously triggered a
bug in bluestore.  We're no longer ignoring that internal
error, though, as of 6ecb44f0c6216f3fb29b384a2d10c7d33bf1d19c,
so remove this part of the test.

The original bluestore bug we used to trigger was fixed by
0210f1fde6f8e17affdd0c49055a71a01f109447.

Signed-off-by: Sage Weil <sage@redhat.com>