### PR TITLE
rgw: print is_admin as int instead of __u8

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -234,7 +234,7 @@ void RGWLocalAuthApplier::to_str(std::ostream& out) const
       << ", acct_name=" << user_info.display_name
       << ", subuser=" << subuser
       << ", perm_mask=" << get_perm_mask()
-      << ", is_admin=" << user_info.admin << ")";
+      << ", is_admin=" << static_cast<int>(user_info.admin) << ")";
 }
 
 uint32_t RGWLocalAuthApplier::get_perm_mask(const std::string& subuser_name,


### PR DESCRIPTION
`RGWUserInfo::admin` is a `__u8`, so printing it directly results in output
like `\00`. this causes some tools to interpret the radosgw log as a
binary file