### PR TITLE
os/bluestore: drop old bluestore preconditioning; replace with wal preextension of file size

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -982,6 +982,7 @@ OPTION(bluefs_min_flush_size, OPT_U64, 65536)  // ignore flush until its this bi
 OPTION(bluefs_compact_log_sync, OPT_BOOL, false)  // sync or async log compaction?
 OPTION(bluefs_buffered_io, OPT_BOOL, false)
 OPTION(bluefs_allocator, OPT_STR, "bitmap")     // stupid | bitmap
+OPTION(bluefs_preextend_wal_files, OPT_BOOL, true)  // this *requires* that rocksdb has recycling enabled
 
 OPTION(bluestore_bluefs, OPT_BOOL, true)
 OPTION(bluestore_bluefs_env_mirror, OPT_BOOL, false) // mirror to normal Env for debug

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1006,8 +1006,6 @@ OPTION(bluestore_block_wal_path, OPT_STR, "")
 OPTION(bluestore_block_wal_size, OPT_U64, 96 * 1024*1024) // rocksdb wal
 OPTION(bluestore_block_wal_create, OPT_BOOL, false)
 OPTION(bluestore_block_preallocate_file, OPT_BOOL, false) //whether preallocate space if block/db_path/wal_path is file rather that block device.
-OPTION(bluestore_precondition_bluefs, OPT_U64, 512*1024*1024)  // write this much data at mkfs
-OPTION(bluestore_precondition_bluefs_block, OPT_U64, 1048576)
 OPTION(bluestore_csum_type, OPT_STR, "crc32c") // none|xxhash32|xxhash64|crc32c|crc32c_16|crc32c_8
 OPTION(bluestore_csum_min_block, OPT_U32, 4096)
 OPTION(bluestore_csum_max_block, OPT_U32, 64*1024)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3895,35 +3895,6 @@ int BlueStore::mkfs()
     goto out_close_alloc;
   dout(10) << __func__ << " success" << dendl;
 
-  if (bluefs &&
-      g_conf->bluestore_precondition_bluefs > 0) {
-    dout(10) << __func__ << " preconditioning with "
-	     << pretty_si_t(g_conf->bluestore_precondition_bluefs)
-	     << " in blocks of "
-	     << pretty_si_t(g_conf->bluestore_precondition_bluefs_block)
-	     << dendl;
-    unsigned n = g_conf->bluestore_precondition_bluefs /
-      g_conf->bluestore_precondition_bluefs_block;
-    bufferlist bl;
-    int len = g_conf->bluestore_precondition_bluefs_block;
-    char buf[len];
-    get_random_bytes(buf, len);
-    bl.append(buf, len);
-    string key1("a");
-    string key2("b");
-    for (unsigned i=0; i < n; ++i) {
-      KeyValueDB::Transaction t = db->get_transaction();
-      t->set(PREFIX_SUPER, (i & 1) ? key1 : key2, bl);
-      t->rmkey(PREFIX_SUPER, (i & 1) ? key2 : key1);
-      db->submit_transaction_sync(t);
-    }
-    KeyValueDB::Transaction t = db->get_transaction();
-    t->rmkey(PREFIX_SUPER, key1);
-    t->rmkey(PREFIX_SUPER, key2);
-    db->submit_transaction_sync(t);
-    dout(10) << __func__ << " done preconditioning" << dendl;
-  }
-
  out_close_alloc:
   _close_alloc();
  out_close_fm:


### PR DESCRIPTION
This drops the slwo preconditioning that didn't work.

Instead, we pre-extend rocksdb log files.  This is faster, simpler, but fragile in that disabling log recycling in rocksdb will break it.