### PR TITLE
mon: add warn info for osd remove from osdmap but still keep in crushmap

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -454,6 +454,20 @@ public:
    */
   bool subtree_contains(int root, int item) const;
 
+  /**
+   *  get the all device osd in crush map
+   *
+   * @para osds put all crush map osds in it
+   *
+   */ 
+  void get_all_osds_in_crush(set<int> &osds) {
+    for (const auto &p : name_map) {
+        if (p.first >= 0) {
+          osds.insert(p.first); 
+        }
+    } 
+  }
+
 private:
   /**
    * search for an item in any bucket


### PR DESCRIPTION
if the osd remove from osdmap but still keep in crushmap.This will result in

the pg can not change to active+clean.So we should provide a warn info to the user

let they known.

Signed-off-by:song baisen <song.baisen@zte.com.cn>