### PR TITLE
osd: use append(bufferlist &) to avoid unnecessary copy

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3801,7 +3801,7 @@ int PrimaryLogPG::do_writesame(OpContext *ctx, OSDOp& osd_op)
   }
 
   while (write_length) {
-    write_op.indata.append(osd_op.indata.c_str(), op.writesame.data_length);
+    write_op.indata.append(osd_op.indata);
     write_length -= op.writesame.data_length;
   }
 


### PR DESCRIPTION
buffer::list::c_str() will rebuild itself if it isn't
contiguous, and append(char *) will do copy from the ptr.

Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>