### PR TITLE
os/bluestore: dedup omap_head, reuse nid instead

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6526,9 +6526,9 @@ void BlueStore::_osr_reap_done(OpSequencer *osr)
       txc->log_state_latency(logger, l_bluestore_state_done_lat);
       delete txc;
       osr->qcond.notify_all();
-      if (osr->q.empty())
-        dout(20) << __func__ << " osr " << osr << " q now empty" << dendl;
     }
+    if (osr->q.empty())
+      dout(20) << __func__ << " osr " << osr << " q now empty" << dendl;
   }
 
   if (c) {

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -572,7 +572,7 @@ void bluestore_onode_t::dump(Formatter *f) const
     f->close_section();
   }
   f->close_section();
-  f->dump_unsigned("omap_head", omap_head);
+  f->dump_string("flags", get_flags_string());
   f->open_array_section("extent_map_shards");
   for (auto si : extent_map_shards) {
     f->dump_object("shard", si);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -589,18 +589,6 @@ void bluestore_onode_t::generate_test_instances(list<bluestore_onode_t*>& o)
   // FIXME
 }
 
-// FIXME: Using this to compute the ctx.csum_order can lead to poor small
-// random read performance when initial writes are large.
-size_t bluestore_onode_t::get_preferred_csum_order() const
-{
-  uint32_t t = expected_write_size;
-  if (!t) {
-    return 0;
-  }
-  return ctz(expected_write_size);
-}
-
-
 // bluestore_wal_op_t
 
 void bluestore_wal_op_t::dump(Formatter *f) const

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -667,7 +667,11 @@ struct bluestore_onode_t {
   uint64_t nid = 0;                    ///< numeric id (locally unique)
   uint64_t size = 0;                   ///< object size
   map<string, bufferptr> attrs;        ///< attrs
-  uint64_t omap_head = 0;              ///< id for omap root node
+  uint8_t flags = 0;
+
+  enum {
+    FLAG_OMAP = 1,
+  };
 
   struct shard_info {
     uint32_t offset = 0;  ///< logical offset for start of shard
@@ -686,6 +690,38 @@ struct bluestore_onode_t {
   uint32_t expected_write_size = 0;
   uint32_t alloc_hint_flags = 0;
 
+  string get_flags_string() const {
+    string s;
+    if (flags & FLAG_OMAP) {
+      s = "omap";
+    }
+    return s;
+  }
+
+  bool has_flag(unsigned f) const {
+    return flags & f;
+  }
+
+  void set_flag(unsigned f) {
+    flags |= f;
+  }
+
+  void clear_flag(unsigned f) {
+    flags &= ~f;
+  }
+
+  bool has_omap() const {
+    return has_flag(FLAG_OMAP);
+  }
+
+  void set_omap_flag() {
+    set_flag(FLAG_OMAP);
+  }
+
+  void clear_omap_flag() {
+    clear_flag(FLAG_OMAP);
+  }
+
   /// get preferred csum chunk size
   size_t get_preferred_csum_order() const;
 
@@ -694,7 +730,7 @@ struct bluestore_onode_t {
     denc(v.nid, p);
     denc(v.size, p);
     denc(v.attrs, p);
-    denc(v.omap_head, p);
+    denc(v.flags, p);
     denc(v.extent_map_shards, p);
     denc(v.expected_object_size, p);
     denc(v.expected_write_size, p);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -722,9 +722,6 @@ struct bluestore_onode_t {
     clear_flag(FLAG_OMAP);
   }
 
-  /// get preferred csum chunk size
-  size_t get_preferred_csum_order() const;
-
   DENC(bluestore_onode_t, v, p) {
     DENC_START(1, 1, p);
     denc(v.nid, p);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -314,23 +314,6 @@ TEST(bluestore_blob_t, csum_bench)
   }
 }
 
-TEST(bluestore_onode_t, get_preferred_csum_order)
-{
-  bluestore_onode_t on;
-  ASSERT_EQ(0u, on.get_preferred_csum_order());
-  on.expected_write_size = 4096;
-  ASSERT_EQ(12u, on.get_preferred_csum_order());
-  on.expected_write_size = 4096;
-  ASSERT_EQ(12u, on.get_preferred_csum_order());
-  on.expected_write_size = 8192;
-  ASSERT_EQ(13u, on.get_preferred_csum_order());
-  on.expected_write_size = 8192 + 4096;
-  ASSERT_EQ(12u, on.get_preferred_csum_order());
-  on.expected_write_size = 1048576;
-  ASSERT_EQ(20u, on.get_preferred_csum_order());
-}
-
-
 TEST(Blob, put_ref)
 {
   {


### PR DESCRIPTION
This is faster and save us some memory as well as space.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>