### PR TITLE
mds: check and get latest current logsegment to avoid trimming logsegment crashing

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -1933,6 +1933,8 @@ void CInode::finish_scatter_update(ScatterLock *lock, CDir *dir,
 void CInode::_finish_frag_update(CDir *dir, MutationRef& mut)
 {
   dout(10) << "_finish_frag_update on " << *dir << dendl;
+  if (!mut->ls || mdcache->mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mdcache->mds->mdlog->get_current_segment();
   mut->apply();
   mut->cleanup();
 }

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1725,6 +1725,8 @@ void Locker::file_update_finish(CInode *in, MutationRef& mut, bool share, client
 				Capability *cap, MClientCaps *ack)
 {
   dout(10) << "file_update_finish on " << *in << dendl;
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   in->pop_and_dirty_projected_inode(mut->ls);
   in->put(CInode::PIN_PTRWAITER);
 
@@ -4255,6 +4257,8 @@ void Locker::scatter_writebehind_finish(ScatterLock *lock, MutationRef& mut)
 {
   CInode *in = static_cast<CInode*>(lock->get_parent());
   dout(10) << "scatter_writebehind_finish on " << *lock << " on " << *in << dendl;
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   in->pop_and_dirty_projected_inode(mut->ls);
 
   lock->finish_flush();

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -538,7 +538,8 @@ void MDCache::_create_system_file(CDir *dir, const char *name, CInode *in, MDSIn
 void MDCache::_create_system_file_finish(MutationRef& mut, CDentry *dn, version_t dpv, MDSInternalContextBase *fin)
 {
   dout(10) << "_create_system_file_finish " << *dn << dendl;
-  
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   dn->pop_projected_linkage();
   dn->mark_dirty(dpv, mut->ls);
 
@@ -976,6 +977,8 @@ void MDCache::try_subtree_merge_at(CDir *dir, bool do_eval)
 void MDCache::subtree_merge_writebehind_finish(CInode *in, MutationRef& mut)
 {
   dout(10) << "subtree_merge_writebehind_finish on " << in << dendl;
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   in->pop_and_dirty_projected_inode(mut->ls);
 
   mut->apply();
@@ -6302,6 +6305,8 @@ void MDCache::truncate_inode_finish(CInode *in, LogSegment *ls)
 void MDCache::truncate_inode_logged(CInode *in, MutationRef& mut)
 {
   dout(10) << "truncate_inode_logged " << *in << dendl;
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   mut->apply();
   mds->locker->drop_locks(mut.get());
   mut->cleanup();
@@ -9314,6 +9319,8 @@ void MDCache::_snaprealm_create_finish(MDRequestRef& mdr, MutationRef& mut, CIno
   dout(10) << "_snaprealm_create_finish " << *in << dendl;
 
   // apply
+  if (!mut->ls || mds->mdlog->segment_is_expired(mut->ls))
+    mut->ls = mds->mdlog->get_current_segment();
   in->pop_and_dirty_projected_inode(mut->ls);
   mut->apply();
   mds->locker->drop_locks(mut.get());
@@ -11174,6 +11181,8 @@ void MDCache::_fragment_logged(MDRequestRef& mdr)
   assert(it != fragments.end());
   fragment_info_t &info = it->second;
   CInode *diri = info.resultfrags.front()->get_inode();
+  if (!mdr->ls || mds->mdlog->segment_is_expired(mdr->ls))
+    mdr->ls = mds->mdlog->get_current_segment();
 
   dout(10) << "fragment_logged " << basedirfrag << " bits " << info.bits
 	   << " on " << *diri << dendl;

--- a/src/mds/MDLog.h
+++ b/src/mds/MDLog.h
@@ -163,6 +163,10 @@ public:
   {
     return expiring_segments;
   }
+
+  bool segment_is_expired(LogSegment* ls) {
+    return expired_segments.count(ls);
+  }
 protected:
 
   // -- subtreemaps --


### PR DESCRIPTION
This PR is trying to fix follow trimming logsegment crashing on MDS. Please see tracker in details.

```
2016-10-25 15:30:38.836972 7f5dea451700 -1 ./include/elist.h: In function 'elist<T>::~elist() [with T = CDentry*]' thread 7f5dea451700 time 2016-10-25 15:30:38.834810
./include/elist.h: 92: FAILED assert(_head.empty())

 ceph version 0.94.9-166-gbe32c81 (be32c819f9fa44b1abe168595a7b57b5833fe6d3)
 1: (ceph::__ceph_assert_fail(char const*, char const*, int, char const*)+0x85) [0x970ac5]
 2: (LogSegment::~LogSegment()+0x29a) [0x7f0a1a]
 3: (MDLog::_trim_expired_segments()+0x158) [0x7e8558]
 4: (MDLog::trim(int)+0x1e8) [0x7e8b18]
 5: (MDS::tick()+0x63c) [0x5a434c]
 6: (MDSInternalContextBase::complete(int)+0x16b) [0x7dd30b]
 7: (SafeTimer::timer_thread()+0x104) [0x961584]
 8: (SafeTimerThread::entry()+0xd) [0x96253d]
 9: (()+0x7df3) [0x7f5df122ddf3]
 10: (clone()+0x6d) [0x7f5deff141bd]
```

Fixes: #18119

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>