### PR TITLE
os/filestore/chain_xattr.h:uses ENODATA, so include compat.h

### DIFF
--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -4,6 +4,7 @@
 #ifndef __CEPH_OSD_CHAIN_XATTR_H
 #define __CEPH_OSD_CHAIN_XATTR_H
 
+#include "include/compat.h"
 #include "common/xattr.h"
 #include "include/assert.h"
 #include "include/buffer.h"


### PR DESCRIPTION
 - Trying to be able to build without ENODATA in /usr/include/errno.h
   And here we use ENODATA for testing attributes.
   Include it here, otherwise it will be require in plenty other files.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>