### PR TITLE
rgw: make RGWLocalAuthApplier::is_admin_of() aware about system users.

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -220,7 +220,7 @@ uint32_t RGWLocalAuthApplier::get_perms_from_aclspec(const aclspec_t& aclspec) c
 
 bool RGWLocalAuthApplier::is_admin_of(const rgw_user& uid) const
 {
-  return user_info.admin;
+  return user_info.admin || user_info.system;
 }
 
 bool RGWLocalAuthApplier::is_owner_of(const rgw_user& uid) const


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18106

Undergoes testing at the moment.

CC: @cbodley.