### PR TITLE
build: dump env during build

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -701,6 +701,8 @@ export CPPFLAGS="$java_inc"
 export CFLAGS="$RPM_OPT_FLAGS"
 export CXXFLAGS="$RPM_OPT_FLAGS"
 
+env | sort
+
 mkdir build
 cd build
 cmake .. \

--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,7 @@ endif
 	dh $@ --buildsystem=cmake --with javahelper,python2,python3,systemd --parallel
 
 override_dh_auto_configure:
+	env | sort
 	dh_auto_configure --buildsystem=cmake -- $(extraopts) $(CEPH_EXTRA_CMAKE_ARGS)
 
 override_dh_auto_build:


### PR DESCRIPTION
This isn't needed now since http://tracker.ceph.com/issues/18084 jsut got fixed, but it'll help us next time.