### PR TITLE
osd/PG: add "down" pg state (distinct from down+peering)

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2648,6 +2648,7 @@ void OSD::create_recoverystate_perf()
   rs_perf.add_time_avg(rs_getlog_latency, "getlog_latency", "Getlog recovery state latency");
   rs_perf.add_time_avg(rs_waitactingchange_latency, "waitactingchange_latency", "Waitactingchange recovery state latency");
   rs_perf.add_time_avg(rs_incomplete_latency, "incomplete_latency", "Incomplete recovery state latency");
+  rs_perf.add_time_avg(rs_down_latency, "down_latency", "Down recovery state latency");
   rs_perf.add_time_avg(rs_getmissing_latency, "getmissing_latency", "Getmissing recovery state latency");
   rs_perf.add_time_avg(rs_waitupthru_latency, "waitupthru_latency", "Waitupthru recovery state latency");
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -195,6 +195,7 @@ enum {
   rs_getlog_latency,
   rs_waitactingchange_latency,
   rs_incomplete_latency,
+  rs_down_latency,
   rs_getmissing_latency,
   rs_waitupthru_latency,
   rs_last,

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7247,7 +7247,9 @@ PG::RecoveryState::GetInfo::GetInfo(my_context ctx)
 
   pg->reset_min_peer_features();
   get_infos();
-  if (peer_info_requested.empty() && !prior_set->pg_down) {
+  if (prior_set->pg_down) {
+    post_event(IsDown());
+  } else if (peer_info_requested.empty()) {
     post_event(GotInfo());
   }
 }
@@ -7377,8 +7379,7 @@ boost::statechart::result PG::RecoveryState::GetInfo::react(const MNotifyRec& in
 	  }
 	  if (!any_up_complete_now && any_down_now) {
 	    dout(10) << " no osds up+complete from interval " << interval << dendl;
-	    pg->state_set(PG_STATE_DOWN);
-            pg->publish_stats_to_osd();
+	    post_event(IsDown());
 	    return discard_event();
 	  }
 	  break;
@@ -7619,6 +7620,36 @@ void PG::RecoveryState::WaitActingChange::exit()
   PG *pg = context< RecoveryMachine >().pg;
   utime_t dur = ceph_clock_now(pg->cct) - enter_time;
   pg->osd->recoverystate_perf->tinc(rs_waitactingchange_latency, dur);
+}
+
+/*------Down--------*/
+PG::RecoveryState::Down::Down(my_context ctx)
+  : my_base(ctx),
+    NamedState(context< RecoveryMachine >().pg->cct, "Started/Primary/Peering/Down")
+{
+  context< RecoveryMachine >().log_enter(state_name);
+  PG *pg = context< RecoveryMachine >().pg;
+
+  pg->state_clear(PG_STATE_PEERING);
+  pg->state_set(PG_STATE_DOWN);
+
+  unique_ptr<PriorSet> &prior_set = context< Peering >().prior_set;
+  assert(pg->blocked_by.empty());
+  pg->blocked_by.insert(prior_set->down.begin(), prior_set->down.end());
+  pg->publish_stats_to_osd();
+}
+
+void PG::RecoveryState::Down::exit()
+{
+  context< RecoveryMachine >().log_exit(state_name, enter_time);
+  PG *pg = context< RecoveryMachine >().pg;
+
+  pg->state_clear(PG_STATE_DOWN);
+  utime_t dur = ceph_clock_now(pg->cct) - enter_time;
+  pg->osd->recoverystate_perf->tinc(rs_down_latency, dur);
+
+  pg->blocked_by.clear();
+  pg->publish_stats_to_osd();
 }
 
 /*------Incomplete--------*/

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1643,6 +1643,10 @@ public:
     struct IsIncomplete : boost::statechart::event< IsIncomplete > {
       IsIncomplete() : boost::statechart::event< IsIncomplete >() {}
     };
+    struct Down;
+    struct IsDown : boost::statechart::event< IsDown > {
+      IsDown() : boost::statechart::event< IsDown >() {}
+    };
 
     struct Primary : boost::statechart::state< Primary, Started, Peering >, NamedState {
       explicit Primary(my_context ctx);
@@ -1928,7 +1932,8 @@ public:
       typedef boost::mpl::list <
 	boost::statechart::custom_reaction< QueryState >,
 	boost::statechart::transition< GotInfo, GetLog >,
-	boost::statechart::custom_reaction< MNotifyRec >
+	boost::statechart::custom_reaction< MNotifyRec >,
+	boost::statechart::transition< IsDown, Down >
 	> reactions;
       boost::statechart::result react(const QueryState& q);
       boost::statechart::result react(const MNotifyRec& infoevt);
@@ -1987,6 +1992,11 @@ public:
       boost::statechart::result react(const QueryState& q);
       boost::statechart::result react(const ActMap& am);
       boost::statechart::result react(const MLogRec& logrec);
+    };
+
+    struct Down : boost::statechart::state< Down, Peering>, NamedState {
+      explicit Down(my_context ctx);
+      void exit();
     };
 
     struct Incomplete : boost::statechart::state< Incomplete, Peering>, NamedState {


### PR DESCRIPTION
When we declare a PG down, move to a distinct down state
(!= down+peering) so that we know peering completed (and
concluded the PG is down).
