### PR TITLE
os/bluestore/BlueRocksEnv: Don't use OSBuffer for BlueRocksWritableFile.

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -159,9 +159,9 @@ class BlueRocksWritableFile : public rocksdb::WritableFile {
   }
 
   // Indicates if the class makes use of unbuffered I/O
-  /*bool UseOSBuffer() const {
-    return true;
-    }*/
+  bool UseOSBuffer() const {
+    return false;
+  }
 
   // This is needed when you want to allocate
   // AlignedBuffer for use with file I/O classes


### PR DESCRIPTION
After BlueFS::FileWriter using bufferlist::page_aligned_appender, we
copy the data from Append API to our bufferlist. So we don't need buffer
in WritableFileWriter in rocksdb.
This can reduct one memcopy.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>