### PR TITLE
rgw/rgw_main.cc: fix parenteses and function result

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -196,7 +196,7 @@ int main(int argc, const char **argv)
   // dout() messages will be sent to stderr, but FCGX wants messages on stdout
   // Redirect stderr to stdout.
   TEMP_FAILURE_RETRY(close(STDERR_FILENO));
-  if (TEMP_FAILURE_RETRY(dup2(STDOUT_FILENO, STDERR_FILENO) < 0)) {
+  if (TEMP_FAILURE_RETRY(dup2(STDOUT_FILENO, STDERR_FILENO)) < 0) {
     int err = errno;
     cout << "failed to redirect stderr to stdout: " << cpp_strerror(err)
          << std::endl;


### PR DESCRIPTION
 - The function in the macro parameter is expected to return -1 i
   on error and not type(bool).
   So reorganize the parenteses and just pass dup2() to the macro.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>