### PR TITLE
rgw: rename s3_code to err_code for swift

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -160,7 +160,7 @@ clear()
 {
   http_ret = 200;
   ret = 0;
-  s3_code.clear();
+  err_code.clear();
 }
 
 bool rgw_err::
@@ -312,20 +312,20 @@ void set_req_state_err(struct rgw_err& err,	/* out */
   bool is_website_redirect = false;
 
   if (prot_flags & RGW_REST_SWIFT) {
-    if (search_err(rgw_http_swift_errors, err_no, is_website_redirect, err.http_ret, err.s3_code))
+    if (search_err(rgw_http_swift_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
       return;
   }
 
   //Default to searching in s3 errors
   is_website_redirect |= (prot_flags & RGW_REST_WEBSITE)
 		&& err_no == ERR_WEBSITE_REDIRECT && err.is_clear();
-  if (search_err(rgw_http_s3_errors, err_no, is_website_redirect, err.http_ret, err.s3_code))
+  if (search_err(rgw_http_s3_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
       return;
   dout(0) << "WARNING: set_req_state_err err_no=" << err_no
 	<< " resorting to 500" << dendl;
 
   err.http_ret = 500;
-  err.s3_code = "UnknownError";
+  err.err_code = "UnknownError";
 }
 
 void set_req_state_err(struct req_state* s, int err_no, const string& err_msg)
@@ -347,8 +347,8 @@ void dump(struct req_state* s)
 {
   if (s->format != RGW_FORMAT_HTML)
     s->formatter->open_object_section("Error");
-  if (!s->err.s3_code.empty())
-    s->formatter->dump_string("Code", s->err.s3_code);
+  if (!s->err.err_code.empty())
+    s->formatter->dump_string("Code", s->err.err_code);
   if (!s->err.message.empty())
     s->formatter->dump_string("Message", s->err.message);
   if (!s->bucket_name.empty())	// TODO: connect to expose_bucket
@@ -431,7 +431,7 @@ void req_info::init_meta_info(bool *found_bad_meta)
 
 std::ostream& operator<<(std::ostream& oss, const rgw_err &err)
 {
-  oss << "rgw_err(http_ret=" << err.http_ret << ", s3='" << err.s3_code << "') ";
+  oss << "rgw_err(http_ret=" << err.http_ret << ", err_code='" << err.err_code << "') ";
   return oss;
 }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -272,7 +272,7 @@ struct rgw_err {
 
   int http_ret;
   int ret;
-  std::string s3_code;
+  std::string err_code;
   std::string message;
 };
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -381,7 +381,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
   } else
     entry.http_status = "200"; // default
 
-  entry.error_code = s->err.s3_code;
+  entry.error_code = s->err.err_code;
   entry.bucket_id = bucket_id;
 
   bufferlist bl;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1976,7 +1976,7 @@ void RGWFormPost::send_response()
   }
 
   set_req_state_err(s, op_ret);
-  s->err.s3_code = err_msg;
+  s->err.err_code = err_msg;
   dump_errno(s);
   if (! redirect.empty()) {
     dump_redirect(s, redirect);


### PR DESCRIPTION
The error code of Swift is named "s3_code" too, it is confusable. So correct it.    

Signed-off-by: Guo Zhandong <guozhandong@cmss.chinamobile.com>