### PR TITLE
src/test/CMakeLists.txt: Exclude test on HAVE_BLKID

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -492,16 +492,18 @@ if(${WITH_CEPHFS})
     )
 endif(${WITH_CEPHFS})
 
-add_executable(ceph_test_get_blkdev_size
-  test_get_blkdev_size.cc
-  )
-target_link_libraries(ceph_test_get_blkdev_size
-  common
-  pthread
-  ${EXTRALIBS}
-  ${BLKID_LIBRARIES}
-  ${CMAKE_DL_LIBS}
-  )
+if(HAVE_BLKID)
+  add_executable(ceph_test_get_blkdev_size
+    test_get_blkdev_size.cc
+    )
+  target_link_libraries(ceph_test_get_blkdev_size
+    common
+    pthread
+    ${EXTRALIBS}
+    ${BLKID_LIBRARIES}
+    ${CMAKE_DL_LIBS}
+    )
+endif(HAVE_BLKID)
 
 #make check starts here
 


### PR DESCRIPTION
 - Since ceph_test_get_blkdev_size really depends on blkid stuff.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>