### PR TITLE
CMakeLists.txt/Boost: Reduce the version requirement for FreeBSD.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -470,7 +470,11 @@ if(WITH_MGR)
 endif()
 
 # require minimally the bundled version
-find_package(Boost 1.61 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+if (FREEBSD)
+  find_package(Boost 1.55 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+else()
+  find_package(Boost 1.61 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
+endif()
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/include)
 


### PR DESCRIPTION
 - Even though we have 1.62. available on FreeBSD, the CMake detection code
   does the wrong thing during linking with 1.62
   This is due to incomplete code in the FindPython{Libs}.cmake.
   Linking will result in missing a lot of python symbols.
 - requesting 1.55 does the right thing, even if 1.62 is the actual version
   to bind.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>