### PR TITLE
DNM: tests: stabilize TestPGLog

### DIFF
--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -60,7 +60,6 @@ target_link_libraries(unittest_osdscrub osd global ${CMAKE_DL_LIBS} os mon ${BLK
 # unittest_pglog
 add_executable(unittest_pglog
   TestPGLog.cc
-  $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_pglog ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_pglog)
 target_link_libraries(unittest_pglog osd global ${CMAKE_DL_LIBS} ${BLKID_LIBRARIES})


### PR DESCRIPTION
Do not use EXPECT_DEATH because it is unsafe when there are threads and
lead to intermittent failures.

Fixes: http://tracker.ceph.com/issues/18030

Signed-off-by: Loic Dachary <loic@dachary.org>