### PR TITLE
rgw/rgw_file.cc: Add compat.h to allow CLOCK_MONOTONE

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "include/rados/rgw_file.h"
 
 #include <sys/types.h>


### PR DESCRIPTION
A previous commit added the CLOCK_*_* routines without adding compat.h

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>