### PR TITLE
test/ceph_crypto: do not read ceph.conf in global_init()

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -751,7 +751,6 @@ target_link_libraries(unittest_perf_counters global)
 # unittest_ceph_crypto
 add_executable(unittest_ceph_crypto
   ceph_crypto.cc
-  $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_ceph_crypto ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_ceph_crypto)
 target_link_libraries(unittest_ceph_crypto global)

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -1,5 +1,8 @@
 #include "gtest/gtest.h"
+#include "common/ceph_argparse.h"
 #include "common/ceph_crypto.h"
+#include "common/common_init.h"
+#include "global/global_init.h"
 #include "global/global_context.h"
 
 class CryptoEnvironment: public ::testing::Environment {
@@ -138,3 +141,15 @@ TEST_F(ForkDeathTest, MD5) {
   ASSERT_EXIT(do_simple_crypto(), ::testing::ExitedWithCode(0), "^$");
 }
 #endif //GTEST_HAS_DEATH_TEST
+
+int main(int argc, char **argv) {
+  std::vector<const char*> args(argv, argv + argc);
+  env_to_vec(args);
+  auto cct = global_init(NULL, args,
+                         CEPH_ENTITY_TYPE_CLIENT,
+                         CODE_ENVIRONMENT_UTILITY,
+                         CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
ForkDeathTest.MD5 expect an empty output while global_init() complains
if ceph.conf is missing if 0 is passed in as the `flags`. this test
passes if ceph.conf is in current working directory, but jenkins does
not prepare this file for this test.

Fixes: http://tracker.ceph.com/issues/18128
Signed-off-by: Kefu Chai <kchai@redhat.com>