### PR TITLE
librbd: create fewer empty objects during copyup

### DIFF
--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -359,7 +359,7 @@ void AbstractAioObjectWrite::guard_write()
 
 bool AbstractAioObjectWrite::should_complete(int r)
 {
-  ldout(m_ictx->cct, 20) << get_write_type() << " " << this << " " << m_oid
+  ldout(m_ictx->cct, 20) << get_op_type() << " " << this << " " << m_oid
                          << " " << m_object_off << "~" << m_object_len
                          << " should_complete: r = " << r << dendl;
 
@@ -371,7 +371,7 @@ bool AbstractAioObjectWrite::should_complete(int r)
       return true;
     }
 
-    send_write();
+    send_write_op();
     finished = false;
     break;
 
@@ -395,7 +395,7 @@ bool AbstractAioObjectWrite::should_complete(int r)
       break;
     }
 
-    finished = send_post();
+    finished = send_post_object_map_update();
     break;
 
   case LIBRBD_AIO_WRITE_COPYUP:
@@ -405,14 +405,14 @@ bool AbstractAioObjectWrite::should_complete(int r)
       complete(r);
       finished = false;
     } else {
-      finished = send_post();
+      finished = send_post_object_map_update();
     }
     break;
 
   case LIBRBD_AIO_WRITE_FLAT:
     ldout(m_ictx->cct, 20) << "WRITE_FLAT" << dendl;
 
-    finished = send_post();
+    finished = send_post_object_map_update();
     break;
 
   case LIBRBD_AIO_WRITE_ERROR:
@@ -429,13 +429,9 @@ bool AbstractAioObjectWrite::should_complete(int r)
 }
 
 void AbstractAioObjectWrite::send() {
-  ldout(m_ictx->cct, 20) << "send " << get_write_type() << " " << this <<" "
+  ldout(m_ictx->cct, 20) << "send " << get_op_type() << " " << this <<" "
                          << m_oid << " " << m_object_off << "~"
                          << m_object_len << dendl;
-  send_pre();
-}
-
-void AbstractAioObjectWrite::send_pre() {
   {
     RWLock::RLocker snap_lock(m_ictx->snap_lock);
     if (m_ictx->object_map == nullptr) {
@@ -444,12 +440,22 @@ void AbstractAioObjectWrite::send_pre() {
       // should have been flushed prior to releasing lock
       assert(m_ictx->exclusive_lock->is_lock_owner());
       m_object_exist = m_ictx->object_map->object_may_exist(m_object_no);
+    }
+  }
 
+  send_write();
+}
+
+void AbstractAioObjectWrite::send_pre_object_map_update() {
+  ldout(m_ictx->cct, 20) << __func__ << dendl;
+
+  {
+    RWLock::RLocker snap_lock(m_ictx->snap_lock);
+    if (m_ictx->object_map != nullptr) {
       uint8_t new_state;
       pre_object_map_update(&new_state);
-
       RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
-      ldout(m_ictx->cct, 20) << "send_pre " << this << " " << m_oid << " "
+      ldout(m_ictx->cct, 20) << __func__ << this << " " << m_oid << " "
                              << m_object_off << "~" << m_object_len
                              << dendl;
       m_state = LIBRBD_AIO_WRITE_PRE;
@@ -461,11 +467,10 @@ void AbstractAioObjectWrite::send_pre() {
     }
   }
 
-  // no object map update required
-  send_write();
+  send_write_op();
 }
 
-bool AbstractAioObjectWrite::send_post() {
+bool AbstractAioObjectWrite::send_post_object_map_update() {
   RWLock::RLocker snap_locker(m_ictx->snap_lock);
   if (m_ictx->object_map == nullptr || !post_object_map_update()) {
     return true;
@@ -475,7 +480,7 @@ bool AbstractAioObjectWrite::send_post() {
   assert(m_ictx->exclusive_lock->is_lock_owner());
 
   RWLock::WLocker object_map_locker(m_ictx->object_map_lock);
-  ldout(m_ictx->cct, 20) << "send_post " << this << " " << m_oid << " "
+  ldout(m_ictx->cct, 20) << __func__ << this << " " << m_oid << " "
                          << m_object_off << "~" << m_object_len << dendl;
   m_state = LIBRBD_AIO_WRITE_POST;
 
@@ -496,7 +501,7 @@ void AbstractAioObjectWrite::send_write() {
     m_state = LIBRBD_AIO_WRITE_GUARD;
     handle_write_guard();
   } else {
-    send_write_op(true);
+    send_pre_object_map_update();
   }
 }
 
@@ -526,11 +531,13 @@ void AbstractAioObjectWrite::send_copyup()
     m_ictx->copyup_list_lock.Unlock();
   }
 }
-void AbstractAioObjectWrite::send_write_op(bool write_guard)
+void AbstractAioObjectWrite::send_write_op()
 {
   m_state = LIBRBD_AIO_WRITE_FLAT;
-  if (write_guard)
+  if (m_guard) {
     guard_write();
+  }
+
   add_write_ops(&m_write);
   assert(m_write.size() != 0);
 
@@ -582,10 +589,10 @@ void AioObjectWrite::send_write() {
                          << " object exist " << m_object_exist
                          << " write_full " << write_full << dendl;
   if (write_full && !has_parent()) {
-    send_write_op(false);
-  } else {
-    AbstractAioObjectWrite::send_write();
+    m_guard = false;
   }
+
+  AbstractAioObjectWrite::send_write();
 }
 
 void AioObjectRemove::guard_write() {
@@ -598,8 +605,9 @@ void AioObjectRemove::guard_write() {
 void AioObjectRemove::send_write() {
   ldout(m_ictx->cct, 20) << "send_write " << this << " " << m_oid << " "
                          << m_object_off << "~" << m_object_len << dendl;
-  send_write_op(true);
+  send_pre_object_map_update();
 }
+
 void AioObjectTruncate::send_write() {
   ldout(m_ictx->cct, 20) << "send_write " << this << " " << m_oid
                          << " truncate " << m_object_off << dendl;

--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -112,6 +112,7 @@ bool AioObjectRequest<I>::compute_parent_extents() {
     lderr(m_ictx->cct) << this << " compute_parent_extents: failed to "
                        << "retrieve parent overlap: " << cpp_strerror(r)
                        << dendl;
+    m_has_parent = false;
     m_parent_extents.clear();
     return false;
   }
@@ -122,6 +123,7 @@ bool AioObjectRequest<I>::compute_parent_extents() {
     ldout(m_ictx->cct, 20) << this << " compute_parent_extents: "
                            << "overlap " << parent_overlap << " "
                            << "extents " << m_parent_extents << dendl;
+    m_has_parent = !m_parent_extents.empty();
     return true;
   }
   return false;

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -80,7 +80,7 @@ public:
   virtual void send() = 0;
 
   bool has_parent() const {
-    return !m_parent_extents.empty();
+    return m_has_parent;
   }
 
 protected:
@@ -93,6 +93,9 @@ protected:
   Context *m_completion;
   Extents m_parent_extents;
   bool m_hide_enoent;
+
+private:
+  bool m_has_parent = false;
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/AioObjectRequest.h
+++ b/src/librbd/AioObjectRequest.h
@@ -83,6 +83,13 @@ public:
     return m_has_parent;
   }
 
+  virtual bool is_op_payload_empty() const {
+    return false;
+  }
+
+  virtual const char *get_op_type() const = 0;
+  virtual bool pre_object_map_update(uint8_t *new_state) = 0;
+
 protected:
   bool compute_parent_extents();
 
@@ -137,6 +144,15 @@ public:
   ExtentMap &get_extent_map() {
     return m_ext_map;
   }
+
+  const char *get_op_type() const {
+    return "read";
+  }
+
+  bool pre_object_map_update(uint8_t *new_state) {
+    return false;
+  }
+
 private:
   Extents m_buffer_extents;
   bool m_tried_parent;
@@ -193,17 +209,19 @@ public:
    * Writes go through the following state machine to deal with
    * layering and the object map:
    *
-   * <start>
-   *  .  |
-   *  .  |
-   *  .  \---> LIBRBD_AIO_WRITE_PRE
-   *  .           |         |
-   *  . . . . . . | . . . . | . . . . . . . . . . .
-   *      .       |   -or-  |                     .
-   *      .       |         |                     v
-   *      .       |         \----------------> LIBRBD_AIO_WRITE_FLAT . . .
-   *      .       |                                               |      .
-   *      v       v         need copyup                           |      .
+   *   <start>
+   *      |
+   *      |\
+   *      | \       -or-
+   *      |  ---------------------------------> LIBRBD_AIO_WRITE_PRE
+   *      |                          .                            |
+   *      |                          .                            |
+   *      |                          .                            v
+   *      |                          . . .  . > LIBRBD_AIO_WRITE_FLAT. . .
+   *      |                                                       |      .
+   *      |                                                       |      .
+   *      |                                                       |      .
+   *      v                need copyup   (copyup performs pre)    |      .
    * LIBRBD_AIO_WRITE_GUARD -----------> LIBRBD_AIO_WRITE_COPYUP  |      .
    *  .       |                               |        .          |      .
    *  .       |                               |        .          |      .
@@ -238,21 +256,21 @@ protected:
   uint64_t m_snap_seq;
   std::vector<librados::snap_t> m_snaps;
   bool m_object_exist;
+  bool m_guard = true;
 
   virtual void add_write_ops(librados::ObjectWriteOperation *wr) = 0;
-  virtual const char* get_write_type() const = 0;
   virtual void guard_write();
-  virtual void pre_object_map_update(uint8_t *new_state) = 0;
   virtual bool post_object_map_update() {
     return false;
   }
   virtual void send_write();
-  virtual void send_write_op(bool write_guard);
+  virtual void send_write_op();
   virtual void handle_write_guard();
 
+  void send_pre_object_map_update();
+
 private:
-  void send_pre();
-  bool send_post();
+  bool send_post_object_map_update();
   void send_copyup();
 };
 
@@ -267,16 +285,22 @@ public:
       m_write_data(data), m_op_flags(op_flags) {
   }
 
-protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr);
+  bool is_op_payload_empty() const {
+    return (m_write_data.length() == 0);
+  }
 
-  virtual const char* get_write_type() const {
+  virtual const char *get_op_type() const {
     return "write";
   }
 
-  virtual void pre_object_map_update(uint8_t *new_state) {
+  virtual bool pre_object_map_update(uint8_t *new_state) {
     *new_state = OBJECT_EXISTS;
+    return true;
   }
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr);
+
   virtual void send_write();
 
 private:
@@ -293,28 +317,21 @@ public:
       m_object_state(OBJECT_NONEXISTENT) {
   }
 
-protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
-    if (has_parent()) {
-      wr->truncate(0);
-    } else {
-      wr->remove();
-    }
-  }
-
-  virtual const char* get_write_type() const {
+  virtual const char* get_op_type() const {
     if (has_parent()) {
       return "remove (trunc)";
     }
     return "remove";
   }
-  virtual void pre_object_map_update(uint8_t *new_state) {
+
+  virtual bool pre_object_map_update(uint8_t *new_state) {
     if (has_parent()) {
       m_object_state = OBJECT_EXISTS;
     } else {
       m_object_state = OBJECT_PENDING;
     }
     *new_state = m_object_state;
+    return true;
   }
 
   virtual bool post_object_map_update() {
@@ -326,6 +343,15 @@ protected:
 
   virtual void guard_write();
   virtual void send_write();
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
+    if (has_parent()) {
+      wr->truncate(0);
+    } else {
+      wr->remove();
+    }
+  }
 
 private:
   uint8_t m_object_state;
@@ -342,21 +368,22 @@ public:
     : AbstractAioObjectWrite(ictx, oid, object_no, 0, 0, snapc, completion,
                              true), m_post_object_map_update(post_object_map_update) { }
 
-protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
-    wr->remove();
-  }
-
-  virtual const char* get_write_type() const {
+  virtual const char* get_op_type() const {
     return "remove (trim)";
   }
 
-  virtual void pre_object_map_update(uint8_t *new_state) {
+  virtual bool pre_object_map_update(uint8_t *new_state) {
     *new_state = OBJECT_PENDING;
+    return true;
   }
 
   virtual bool post_object_map_update() {
     return m_post_object_map_update;
+  }
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
+    wr->remove();
   }
 
 private:
@@ -372,22 +399,24 @@ public:
                              completion, true) {
   }
 
-protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
-    wr->truncate(m_object_off);
-  }
-
-  virtual const char* get_write_type() const {
+  virtual const char* get_op_type() const {
     return "truncate";
   }
 
-  virtual void pre_object_map_update(uint8_t *new_state) {
+  virtual bool pre_object_map_update(uint8_t *new_state) {
     if (!m_object_exist && !has_parent())
       *new_state = OBJECT_NONEXISTENT;
     else
       *new_state = OBJECT_EXISTS;
+    return true;
   }
+
   virtual void send_write();
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
+    wr->truncate(m_object_off);
+  }
 };
 
 class AioObjectZero : public AbstractAioObjectWrite {
@@ -399,17 +428,18 @@ public:
                              snapc, completion, true) {
   }
 
-protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
-    wr->zero(m_object_off, m_object_len);
-  }
-
-  virtual const char* get_write_type() const {
+  virtual const char* get_op_type() const {
     return "zero";
   }
 
-  virtual void pre_object_map_update(uint8_t *new_state) {
+  virtual bool pre_object_map_update(uint8_t *new_state) {
     *new_state = OBJECT_EXISTS;
+    return true;
+  }
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr) {
+    wr->zero(m_object_off, m_object_len);
   }
 };
 

--- a/src/librbd/CopyupRequest.h
+++ b/src/librbd/CopyupRequest.h
@@ -36,19 +36,22 @@ private:
    *
    * @verbatim
    *
-   * <start>
-   *    |
-   *    v
-   *  STATE_READ_FROM_PARENT
-   *    .   .        |
-   *    .   .        v
-   *    .   .     STATE_OBJECT_MAP . .
-   *    .   .        |               .
-   *    .   .        v               .
-   *    .   . . > STATE_COPYUP       .
-   *    .            |               .
-   *    .            v               .
-   *    . . . . > <finish> < . . . . .
+   *              <start>
+   *                 |
+   *                 v
+   *    . . .STATE_READ_FROM_PARENT. . .
+   *    . .          |                 .
+   *    . .          v                 .
+   *    . .  STATE_OBJECT_MAP_HEAD     v (copy on read /
+   *    . .          |                 .  no HEAD rev. update)
+   *    v v          v                 .
+   *    . .    STATE_OBJECT_MAP. . . . .
+   *    . .          |
+   *    . .          v
+   *    . . . . > STATE_COPYUP
+   *    .            |
+   *    .            v
+   *    . . . . > <finish>
    *
    * @endverbatim
    *
@@ -58,7 +61,8 @@ private:
    */
   enum State {
     STATE_READ_FROM_PARENT,
-    STATE_OBJECT_MAP,
+    STATE_OBJECT_MAP_HEAD, // only update the HEAD revision
+    STATE_OBJECT_MAP,      // update HEAD+snaps (if any)
     STATE_COPYUP
   };
 
@@ -82,8 +86,10 @@ private:
 
   void remove_from_list();
 
+  bool send_object_map_head();
   bool send_object_map();
   bool send_copyup();
+  bool is_copyup_required();
 };
 
 } // namespace librbd

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -852,13 +852,13 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
       <size>536870912</size>
     </snapshot>
   </snapshots>
-  $ rbd disk-usage --pool rbd_other
+  $ rbd disk-usage --pool rbd_other 2>/dev/null
   NAME                    PROVISIONED  USED 
-  child@snap                     512M  512M 
-  child                          512M  512M 
-  deep-flatten-child@snap        512M  512M 
-  deep-flatten-child             512M  512M 
-  <TOTAL>                       1024M 2048M 
+  child@snap                     512M     0 
+  child                          512M 4096k 
+  deep-flatten-child@snap        512M     0 
+  deep-flatten-child             512M     0 
+  <TOTAL>                       1024M 4096k 
   $ rbd disk-usage --pool rbd_other --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "images": [
@@ -866,27 +866,27 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
               "name": "child", 
               "provisioned_size": 536870912, 
               "snapshot": "snap", 
-              "used_size": 536870912
+              "used_size": 0
           }, 
           {
               "name": "child", 
               "provisioned_size": 536870912, 
-              "used_size": 536870912
+              "used_size": 4194304
           }, 
           {
               "name": "deep-flatten-child", 
               "provisioned_size": 536870912, 
               "snapshot": "snap", 
-              "used_size": 536870912
+              "used_size": 0
           }, 
           {
               "name": "deep-flatten-child", 
               "provisioned_size": 536870912, 
-              "used_size": 536870912
+              "used_size": 0
           }
       ], 
       "total_provisioned_size": 1073741824, 
-      "total_used_size": 2147483648
+      "total_used_size": 4194304
   }
   $ rbd disk-usage --pool rbd_other --format xml | xml_pp 2>&1 | grep -v '^new version at /usr/bin/xml_pp'
   <stats>
@@ -895,27 +895,27 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
         <name>child</name>
         <snapshot>snap</snapshot>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
       <image>
         <name>child</name>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>4194304</used_size>
       </image>
       <image>
         <name>deep-flatten-child</name>
         <snapshot>snap</snapshot>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
       <image>
         <name>deep-flatten-child</name>
         <provisioned_size>536870912</provisioned_size>
-        <used_size>536870912</used_size>
+        <used_size>0</used_size>
       </image>
     </images>
     <total_provisioned_size>1073741824</total_provisioned_size>
-    <total_used_size>2147483648</total_used_size>
+    <total_used_size>4194304</total_used_size>
   </stats>
 
 # cleanup

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3369,6 +3369,138 @@ TEST_F(TestLibRBD, Flatten)
   ASSERT_PASSED(validate_object_map, clone_image);
 }
 
+TEST_F(TestLibRBD, FlattenNoEmptyObjects)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  rados_ioctx_t ioctx;
+  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
+
+  librbd::RBD rbd;
+  std::string parent_name = get_temp_image_name();
+  uint64_t size = 4 << 20;
+  int order = 12; // smallest object size is 4K
+
+  bool old_format;
+  uint64_t features;
+  ASSERT_EQ(0, get_features(&old_format, &features));
+  ASSERT_FALSE(old_format);
+
+  // make a parent to clone from
+  ASSERT_EQ(0, create_image_full(ioctx, parent_name.c_str(), size, &order,
+                                 false, features));
+
+  rbd_image_t parent;
+  const int object_size = 1 << order;
+  const int object_num = size / object_size;
+  ASSERT_EQ(0, rbd_open(ioctx, parent_name.c_str(), &parent, NULL));
+  printf("made parent image \"%s\": %ldK (%d * %dK)\n", parent_name.c_str(),
+         (unsigned long)size, object_num, object_size/1024);
+
+  // write something into parent
+  char test_data[TEST_IO_SIZE + 1];
+  char zero_data[TEST_IO_SIZE + 1];
+  int i;
+  for (i = 0; i < TEST_IO_SIZE; ++i)
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
+  test_data[TEST_IO_SIZE] = '\0';
+  memset(zero_data, 0, sizeof(zero_data));
+
+  // generate a random map which covers every objects with random
+  // offset
+  int count = 0;
+  map<uint64_t, uint64_t> write_tracker;
+  while (count < 10) {
+    uint64_t ono = rand() % object_num;
+    if (write_tracker.find(ono) == write_tracker.end()) {
+      uint64_t offset = rand() % (object_size - TEST_IO_SIZE);
+      write_tracker.insert(pair<uint64_t, uint64_t>(ono, offset));
+      count++;
+    }
+  }
+
+  printf("generated random write map:\n");
+  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
+       itr != write_tracker.end(); ++itr)
+    printf("\t [%-8ld, %-8ld]\n",
+	   (unsigned long)itr->first, (unsigned long)itr->second);
+
+  printf("write data based on random map\n");
+  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
+       itr != write_tracker.end(); ++itr) {
+    printf("\twrite object-%-4ld\t", (unsigned long)itr->first);
+    ASSERT_PASSED(write_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
+  }
+
+  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
+         itr != write_tracker.end(); ++itr) {
+    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
+    ASSERT_PASSED(read_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
+  }
+
+  // find out what objects the parent image has generated
+  rbd_image_info_t p_info;
+  ASSERT_EQ(0, rbd_stat(parent, &p_info, sizeof(p_info)));
+
+  int64_t data_pool_id = rbd_get_data_pool_id(parent);
+  rados_ioctx_t d_ioctx;
+  rados_ioctx_create2(_cluster, data_pool_id, &d_ioctx);
+
+  const char *entry;
+  set<string> obj_checker;
+  rados_list_ctx_t list_ctx;
+  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
+  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
+    if (strstr(entry, p_info.block_name_prefix)) {
+      const char *block_name_suffix = entry + strlen(p_info.block_name_prefix) + 1;
+      obj_checker.insert(block_name_suffix);
+    }
+  }
+  rados_nobjects_list_close(list_ctx);
+  ASSERT_EQ(obj_checker.size(), write_tracker.size());
+
+  // create a snapshot, reopen as the parent we're interested in and protect it
+  ASSERT_EQ(0, rbd_snap_create(parent, "parent_snap"));
+  ASSERT_EQ(0, rbd_close(parent));
+  ASSERT_EQ(0, rbd_open(ioctx, parent_name.c_str(), &parent, "parent_snap"));
+  ASSERT_EQ(0, rbd_snap_protect(parent, "parent_snap"));
+  ASSERT_PASSED(validate_object_map, parent);
+  ASSERT_EQ(0, rbd_close(parent));
+  printf("made snapshot and protected: \"%s@parent_snap\"\n", parent_name.c_str());
+
+  std::string child_name = get_temp_image_name();
+  // create a copy-on-read clone and open it
+  ASSERT_EQ(0, rbd_clone(ioctx, parent_name.c_str(), "parent_snap", ioctx,
+                         child_name.c_str(), features, &order));
+
+  rbd_image_t child;
+  ASSERT_EQ(0, rbd_open(ioctx, child_name.c_str(), &child, NULL));
+  printf("made and opened clone \"%s\"\n", child_name.c_str());
+
+  printf("flattening clone: \"%s\"\n", child_name.c_str());
+  ASSERT_EQ(0, rbd_flatten(child));
+
+  printf("check whether child image has the same set of objects as parent\n");
+  rbd_image_info_t c_info;
+  ASSERT_EQ(0, rbd_stat(child, &c_info, sizeof(c_info)));
+  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
+  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
+    if (strstr(entry, c_info.block_name_prefix)) {
+      const char *block_name_suffix = entry + strlen(c_info.block_name_prefix) + 1;
+      set<string>::iterator it = obj_checker.find(block_name_suffix);
+      ASSERT_TRUE(it != obj_checker.end());
+      obj_checker.erase(it);
+    }
+  }
+  rados_nobjects_list_close(list_ctx);
+  ASSERT_TRUE(obj_checker.empty());
+  ASSERT_PASSED(validate_object_map, child);
+  ASSERT_EQ(0, rbd_close(child));
+
+  rados_ioctx_destroy(ioctx);
+  rados_ioctx_destroy(d_ioctx);
+}
+
 TEST_F(TestLibRBD, SnapshotLimit)
 {
   rados_ioctx_t ioctx;


### PR DESCRIPTION
This is based out of Doug's (@fullerdj) work (PR #9329)
as an attempt to avoid creating empty objects when
flattening an image and otherwise whenever unnecessary.

This gives good optimization benefit when a parent image
is sparsely populated. Moreover, this change is required
for correct behavior when checking disk usage of a clone
(which used to report fully allocated image due to all,
including empty objects being created during flatten).