### PR TITLE
os/bluestore: flush before enumerating omap values

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8263,6 +8263,7 @@ int BlueStore::_do_remove(
   if (r < 0)
     return r;
   if (o->onode.has_omap()) {
+    o->flush();
     _do_omap_clear(txc, o->onode.nid);
   }
   o->exists = false;
@@ -8397,6 +8398,7 @@ int BlueStore::_omap_clear(TransContext *txc,
   dout(15) << __func__ << " " << c->cid << " " << o->oid << dendl;
   int r = 0;
   if (o->onode.has_omap()) {
+    o->flush();
     _do_omap_clear(txc, o->onode.nid);
     o->onode.clear_omap_flag();
     txc->write_onode(o);
@@ -8501,6 +8503,7 @@ int BlueStore::_omap_rmkey_range(TransContext *txc,
   if (!o->onode.has_omap()) {
     goto out;
   }
+  o->flush();
   it = db->get_iterator(PREFIX_OMAP);
   get_omap_key(o->onode.nid, first, &key_first);
   get_omap_key(o->onode.nid, last, &key_last);
@@ -8587,6 +8590,7 @@ int BlueStore::_clone(TransContext *txc,
   // clone omap
   if (newo->onode.has_omap()) {
     dout(20) << __func__ << " clearing old omap data" << dendl;
+    newo->flush();
     _do_omap_clear(txc, newo->onode.nid);
   }
   if (oldo->onode.has_omap()) {


### PR DESCRIPTION
For a few update ops we enumerate omap keys (to remove them).
Make sure we flush the pipeline before doing so or else we may
lose keys inserted by a previous transaction that hasn't yet
committed.

Fixes: http://tracker.ceph.com/issues/18140
Signed-off-by: Sage Weil <sage@redhat.com>