### PR TITLE
FreeBSD: snprintf and setting _XOPEN_SOURCE generate warning

### DIFF
--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -12,7 +12,9 @@
  *
  */
 
+#if !defined(__FreeBSD__)
 #define _XOPEN_SOURCE 500
+#endif
 
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
 - With XOPEN_SOURCE 500 snprintf is not defined, and clang complains about
   a missing declaration

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>