### PR TITLE
os/bluestore: simplify allocator release flow

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -62,9 +62,6 @@ public:
     return res;
   }
 
-  virtual void commit_start() = 0;
-  virtual void commit_finish() = 0;
-
   virtual void dump() = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -239,8 +239,7 @@ int BitMapAllocator::release(
   dout(10) << __func__ << " 0x"
            << std::hex << offset << "~" << length << std::dec
            << dendl;
-  m_uncommitted.insert(offset, length);
-  m_num_uncommitted += length;
+  insert_free(offset, length);
   return 0;
 }
 

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -13,13 +13,9 @@
 class BitMapAllocator : public Allocator {
   std::mutex m_lock;
 
-  int64_t m_num_uncommitted;
-  int64_t m_num_committing;
   int64_t m_block_size;
   int64_t m_num_reserved;
 
-  btree_interval_set<uint64_t> m_uncommitted; ///< released but not yet usable
-  btree_interval_set<uint64_t> m_committing;  ///< released but not yet usable
   BitAllocator *m_bit_alloc; // Bit allocator instance
 
   void insert_free(uint64_t offset, uint64_t len);
@@ -48,9 +44,6 @@ public:
 
   int release(
     uint64_t offset, uint64_t length);
-
-  void commit_start();
-  void commit_finish();
 
   uint64_t get_free();
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1817,17 +1817,7 @@ void BlueFS::sync_metadata()
   utime_t start = ceph_clock_now(NULL);
   vector<interval_set<uint64_t>> to_release(pending_release.size());
   to_release.swap(pending_release);
-  for (auto p : alloc) {
-    if (p) {
-      p->commit_start();
-    }
-  }
   _flush_and_sync_log(l);
-  for (auto p : alloc) {
-    if (p) {
-      p->commit_finish();
-    }
-  }
   for (unsigned i = 0; i < to_release.size(); ++i) {
     for (auto p = to_release[i].begin(); p != to_release[i].end(); ++p) {
       alloc[i]->release(p.get_start(), p.get_len());

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -251,6 +251,7 @@ private:
   vector<interval_set<uint64_t> > block_all;  ///< extents in bdev we own
   vector<uint64_t> block_total;               ///< sum of block_all
   vector<Allocator*> alloc;                   ///< allocators for bdevs
+  vector<interval_set<uint64_t>> pending_release; ///< extents to release
 
   void _init_logger();
   void _shutdown_logger();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8751,17 +8751,19 @@ int BlueStore::_clone_range(TransContext *txc,
   newo->exists = true;
   _assign_nid(txc, newo);
 
-  if (g_conf->bluestore_clone_cow) {
-    _do_zero(txc, c, newo, dstoff, length);
-    _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
-  } else {
-    bufferlist bl;
-    r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
-    if (r < 0)
-      goto out;
-    r = _do_write(txc, c, newo, dstoff, bl.length(), bl, 0);
-    if (r < 0)
-      goto out;
+  if (length > 0) {
+    if (g_conf->bluestore_clone_cow) {
+      _do_zero(txc, c, newo, dstoff, length);
+      _do_clone_range(txc, c, oldo, newo, srcoff, length, dstoff);
+    } else {
+      bufferlist bl;
+      r = _do_read(c.get(), oldo, srcoff, length, bl, 0);
+      if (r < 0)
+	goto out;
+      r = _do_write(txc, c, newo, dstoff, bl.length(), bl, 0);
+      if (r < 0)
+	goto out;
+    }
   }
 
   txc->write_onode(newo);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6666,7 +6666,6 @@ void BlueStore::_kv_sync_thread()
 	txc->state = TransContext::STATE_KV_SUBMITTED;
       }
       for (auto txc : kv_committing) {
-	_txc_release_alloc(txc);
 	if (txc->had_ios) {
 	  --txc->osr->txc_with_unstable_io;
 	}
@@ -6722,6 +6721,7 @@ void BlueStore::_kv_sync_thread()
       while (!kv_committing.empty()) {
 	TransContext *txc = kv_committing.front();
 	assert(txc->state == TransContext::STATE_KV_SUBMITTED);
+	_txc_release_alloc(txc);
 	_txc_state_proc(txc);
 	kv_committing.pop_front();
       }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6624,8 +6624,6 @@ void BlueStore::_kv_sync_thread()
       dout(30) << __func__ << " submitting txc " << kv_submitting << dendl;
       dout(30) << __func__ << " wal_cleaning txc " << wal_cleaning << dendl;
 
-      alloc->commit_start();
-
       // flush/barrier on block device
       bdev->flush();
 
@@ -6729,8 +6727,6 @@ void BlueStore::_kv_sync_thread()
 	_txc_state_proc(txc);
 	wal_cleaning.pop_front();
       }
-
-      alloc->commit_finish();
 
       // this is as good a place as any ...
       _reap_collections();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1512,6 +1512,7 @@ private:
   Throttle throttle_wal_ops, throttle_wal_bytes;  ///< submit to wal complete
 
   interval_set<uint64_t> bluefs_extents;  ///< block extents owned by bluefs
+  interval_set<uint64_t> bluefs_extents_reclaiming; ///< currently reclaiming
 
   std::mutex wal_lock;
   std::atomic<uint64_t> wal_seq = {0};

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -250,8 +250,8 @@ int StupidAllocator::release(
   std::lock_guard<std::mutex> l(lock);
   dout(10) << __func__ << " 0x" << std::hex << offset << "~" << length
 	   << std::dec << dendl;
-  uncommitted.insert(offset, length);
-  num_uncommitted += length;
+  _insert_free(offset, length);
+  num_free += length;
   return 0;
 }
 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -11,8 +11,6 @@
 
 StupidAllocator::StupidAllocator()
   : num_free(0),
-    num_uncommitted(0),
-    num_committing(0),
     num_reserved(0),
     free(10),
     last_alloc(0)
@@ -274,22 +272,6 @@ void StupidAllocator::dump()
 	      << p.get_len() << std::dec << dendl;
     }
   }
-  dout(0) << __func__ << " committing: "
-	  << committing.num_intervals() << " extents" << dendl;
-  for (auto p = committing.begin();
-       p != committing.end();
-       ++p) {
-    dout(0) << __func__ << "  0x" << std::hex << p.get_start() << "~"
-	    << p.get_len() << std::dec << dendl;
-  }
-  dout(0) << __func__ << " uncommitted: "
-	  << uncommitted.num_intervals() << " extents" << dendl;
-  for (auto p = uncommitted.begin();
-       p != uncommitted.end();
-       ++p) {
-    dout(0) << __func__ << "  0x" << std::hex << p.get_start() << "~"
-	    << p.get_len() << std::dec << dendl;
-  }
 }
 
 void StupidAllocator::init_add_free(uint64_t offset, uint64_t length)
@@ -329,28 +311,3 @@ void StupidAllocator::shutdown()
   dout(1) << __func__ << dendl;
 }
 
-void StupidAllocator::commit_start()
-{
-  std::lock_guard<std::mutex> l(lock);
-  dout(10) << __func__ << " releasing " << num_uncommitted
-	   << " in extents " << uncommitted.num_intervals() << dendl;
-  assert(committing.empty());
-  committing.swap(uncommitted);
-  num_committing = num_uncommitted;
-  num_uncommitted = 0;
-}
-
-void StupidAllocator::commit_finish()
-{
-  std::lock_guard<std::mutex> l(lock);
-  dout(10) << __func__ << " released " << num_committing
-	   << " in extents " << committing.num_intervals() << dendl;
-  for (auto p = committing.begin();
-       p != committing.end();
-       ++p) {
-    _insert_free(p.get_start(), p.get_len());
-  }
-  committing.clear();
-  num_free += num_committing;
-  num_committing = 0;
-}

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -14,13 +14,9 @@ class StupidAllocator : public Allocator {
   std::mutex lock;
 
   int64_t num_free;     ///< total bytes in freelist
-  int64_t num_uncommitted;
-  int64_t num_committing;
   int64_t num_reserved; ///< reserved bytes
 
   std::vector<btree_interval_set<uint64_t> > free;        ///< leading-edge copy
-  btree_interval_set<uint64_t> uncommitted; ///< released but not yet usable
-  btree_interval_set<uint64_t> committing;  ///< released but not yet usable
 
   uint64_t last_alloc;
 
@@ -44,9 +40,6 @@ public:
 
   int release(
     uint64_t offset, uint64_t length);
-
-  void commit_start();
-  void commit_finish();
 
   uint64_t get_free();
 


### PR DESCRIPTION
No need for the allocator to coordinate with the kv commit cycle.  Instead,
make it hte caller's responsibility to not release extents until their dereference
has been committed.