### PR TITLE
cmake: add RGW and MDS to libcephd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -337,12 +337,15 @@ endif(WITH_DPDK)
 
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
+option(WITH_RADOSGW_FCGI_FRONTEND "Rados Gateway's FCGI frontend is enabled" ON)
+option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" ON)
 if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)
-  find_package(fcgi REQUIRED)
+  if(WITH_RADOSGW_FCGI_FRONTEND)
+    find_package(fcgi REQUIRED)
+  endif()
 endif(WITH_RADOSGW)
 
-option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" ON)
 
 if (WITH_RADOSGW)
   if (NOT DEFINED OPENSSL_FOUND)

--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -49,7 +49,7 @@ using namespace std;
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
 
-void usage()
+static void usage()
 {
   cout << "usage: ceph-mds -i name [flags] [[--hot-standby][rank]]\n"
        << "  -m monitorip:port\n"
@@ -86,7 +86,11 @@ static void handle_mds_signal(int signum)
     mds->handle_signal(signum);
 }
 
-int main(int argc, const char **argv) 
+#ifdef BUILDING_FOR_EMBEDDED
+extern "C" int cephd_mds(int argc, const char **argv)
+#else
+int main(int argc, const char **argv)
+#endif
 {
   vector<const char*> args;
   argv_to_vec(argc, argv, args);

--- a/src/include/cephd/libcephd.h
+++ b/src/include/cephd/libcephd.h
@@ -85,6 +85,24 @@ CEPH_LIBCEPHD_API int cephd_run_osd(int argc, const char **argv);
  */
 CEPH_LIBCEPHD_API int cephd_run_mds(int argc, const char **argv);
 
+/**
+ * Runs ceph-rgw passing in command line args
+ *
+ * @param argc number of parameters
+ * @param argv array of string arguments
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_LIBCEPHD_API int cephd_run_rgw(int argc, const char **argv);
+
+/**
+ * Runs radosgw-admin passing in command line args
+ *
+ * @param argc number of parameters
+ * @param argv array of string arguments
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_LIBCEPHD_API int cephd_run_rgw_admin(int argc, const char **argv);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/cephd/libcephd.h
+++ b/src/include/cephd/libcephd.h
@@ -76,6 +76,15 @@ CEPH_LIBCEPHD_API int cephd_run_mon(int argc, const char **argv);
  */
 CEPH_LIBCEPHD_API int cephd_run_osd(int argc, const char **argv);
 
+/**
+ * Runs ceph-mds passing in command line args
+ *
+ * @param argc number of parameters
+ * @param argv array of string arguments
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_LIBCEPHD_API int cephd_run_mds(int argc, const char **argv);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -145,6 +145,9 @@
 /* define if radosgw enabled */
 #cmakedefine WITH_RADOSGW
 
+/* define if radosgw enabled */
+#cmakedefine WITH_RADOSGW_FCGI_FRONTEND
+
 /* define if leveldb is enabled */
 #cmakedefine WITH_LEVELDB
 

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -3,7 +3,8 @@ include(MergeStaticLibraries)
 add_library(cephd_base STATIC
   libcephd.cc
   ../ceph_mon.cc
-  ../ceph_osd.cc)
+  ../ceph_osd.cc
+  ../ceph_mds.cc)
 
 set_target_properties(cephd_base PROPERTIES COMPILE_DEFINITIONS BUILDING_FOR_EMBEDDED)
 
@@ -21,6 +22,7 @@ set(merge_libs
   global
   json_spirit
   kv
+  mds
   mon
   os
   osd

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -16,6 +16,7 @@ set(merge_libs
   cephd_cls_kvs
   cephd_rados
   cephd_rbd
+  cephd_rgw
   cephd_common
   common_utf8
   erasure_code

--- a/src/libcephd/libcephd.cc
+++ b/src/libcephd/libcephd.cc
@@ -224,6 +224,8 @@ void cephd_preload_rados_classes(OSD *osd)
 extern "C" int cephd_mon(int argc, const char **argv);
 extern "C" int cephd_osd(int argc, const char **argv);
 extern "C" int cephd_mds(int argc, const char **argv);
+extern "C" int cephd_rgw(int argc, const char **argv);
+extern "C" int cephd_rgw_admin(int argc, const char **argv);
 
 int cephd_run_mon(int argc, const char **argv)
 {
@@ -238,4 +240,15 @@ int cephd_run_osd(int argc, const char **argv)
 int cephd_run_mds(int argc, const char **argv)
 {
     return cephd_mds(argc, argv);
+}
+
+
+int cephd_run_rgw(int argc, const char **argv)
+{
+    return cephd_rgw(argc, argv);
+}
+
+int cephd_run_rgw_admin(int argc, const char **argv)
+{
+    return cephd_rgw_admin(argc, argv);
 }

--- a/src/libcephd/libcephd.cc
+++ b/src/libcephd/libcephd.cc
@@ -223,6 +223,7 @@ void cephd_preload_rados_classes(OSD *osd)
 
 extern "C" int cephd_mon(int argc, const char **argv);
 extern "C" int cephd_osd(int argc, const char **argv);
+extern "C" int cephd_mds(int argc, const char **argv);
 
 int cephd_run_mon(int argc, const char **argv)
 {
@@ -232,4 +233,9 @@ int cephd_run_mon(int argc, const char **argv)
 int cephd_run_osd(int argc, const char **argv)
 {
     return cephd_osd(argc, argv);
+}
+
+int cephd_run_mds(int argc, const char **argv)
+{
+    return cephd_mds(argc, argv);
 }

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -41,7 +41,6 @@ set(rgw_a_srcs
   rgw_cors_s3.cc
   rgw_dencoder.cc
   rgw_env.cc
-  rgw_fcgi.cc
   rgw_formats.cc
   rgw_frontend.cc
   rgw_gc.cc
@@ -101,6 +100,10 @@ set(rgw_a_srcs
   rgw_xml_enc.cc
   rgw_torrent.cc)
 
+if (WITH_RADOSGW_FCGI_FRONTEND)
+  list(APPEND rgw_a_srcs rgw_fcgi.cc)
+endif()
+
 add_library(rgw_a STATIC ${rgw_a_srcs})
 
 add_dependencies(rgw_a civetweb_h)
@@ -117,11 +120,14 @@ target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS})
 
 set(radosgw_srcs
-  rgw_fcgi_process.cc
   rgw_loadgen_process.cc
   rgw_civetweb.cc
   rgw_civetweb_frontend.cc
   rgw_civetweb_log.cc)
+
+if (WITH_RADOSGW_FCGI_FRONTEND)
+  list(APPEND radosgw_srcs rgw_fcgi_process.cc)
+endif()
 
 if (WITH_RADOSGW_ASIO_FRONTEND)
   list(APPEND radosgw_srcs
@@ -138,7 +144,7 @@ target_link_libraries(radosgw radosgw_a librados
   cls_rgw_client cls_lock_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
-  global fcgi ${LIB_RESOLV}
+  global ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${SSL_LIBRARIES} ${BLKID_LIBRARIES}
   ${ALLOC_LIBS})
 # radosgw depends on cls libraries at runtime, but not as link dependencies
@@ -155,7 +161,7 @@ target_link_libraries(radosgw-admin rgw_a librados
   cls_rgw_client cls_lock_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
-  global fcgi ${LIB_RESOLV}
+  global ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${SSL_LIBRARIES} ${BLKID_LIBRARIES})
 install(TARGETS radosgw-admin DESTINATION bin)
 
@@ -173,7 +179,7 @@ target_link_libraries(radosgw-object-expirer rgw_a librados
   cls_rgw_client cls_lock_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
-  global fcgi ${LIB_RESOLV}
+  global ${FCGI_LIBRARY} ${LIB_RESOLV}
   ${CURL_LIBRARIES} ${EXPAT_LIBRARIES})
 install(TARGETS radosgw-object-expirer DESTINATION bin)
 
@@ -206,5 +212,5 @@ if(WITH_EMBEDDED)
   add_library(cephd_rgw_base STATIC rgw_main.cc ${radosgw_admin_srcs})
   set_target_properties(cephd_rgw_base PROPERTIES COMPILE_DEFINITIONS BUILDING_FOR_EMBEDDED)
   merge_static_libraries(cephd_rgw cephd_rgw_base rgw_a radosgw_a)
-  target_link_libraries(cephd_rgw fcgi)
+  target_link_libraries(cephd_rgw ${FCGI_LIBRARY})
 endif()

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -121,8 +121,7 @@ set(radosgw_srcs
   rgw_loadgen_process.cc
   rgw_civetweb.cc
   rgw_civetweb_frontend.cc
-  rgw_civetweb_log.cc
-  rgw_main.cc)
+  rgw_civetweb_log.cc)
 
 if (WITH_RADOSGW_ASIO_FRONTEND)
   list(APPEND radosgw_srcs
@@ -130,8 +129,12 @@ if (WITH_RADOSGW_ASIO_FRONTEND)
     rgw_asio_frontend.cc)
 endif (WITH_RADOSGW_ASIO_FRONTEND)
 
-add_executable(radosgw ${radosgw_srcs}  $<TARGET_OBJECTS:civetweb_common_objs>)
-target_link_libraries(radosgw rgw_a librados
+add_library(radosgw_a STATIC ${radosgw_srcs}
+  $<TARGET_OBJECTS:civetweb_common_objs>)
+target_link_libraries(radosgw_a rgw_a)
+
+add_executable(radosgw rgw_main.cc)
+target_link_libraries(radosgw radosgw_a librados
   cls_rgw_client cls_lock_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
@@ -197,3 +200,11 @@ target_link_libraries(rgw LINK_PRIVATE
 set_target_properties(rgw PROPERTIES OUTPUT_NAME rgw VERSION 2.0.0
   SOVERSION 2)
 install(TARGETS rgw DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+if(WITH_EMBEDDED)
+  include(MergeStaticLibraries)
+  add_library(cephd_rgw_base STATIC rgw_main.cc ${radosgw_admin_srcs})
+  set_target_properties(cephd_rgw_base PROPERTIES COMPILE_DEFINITIONS BUILDING_FOR_EMBEDDED)
+  merge_static_libraries(cephd_rgw cephd_rgw_base rgw_a radosgw_a)
+  target_link_libraries(cephd_rgw fcgi)
+endif()

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -2238,7 +2238,11 @@ public:
   }
 };
 
-int main(int argc, char **argv)
+#ifdef BUILDING_FOR_EMBEDDED
+extern "C" int cephd_rgw_admin(int argc, const char **argv)
+#else
+int main(int argc, const char **argv)
+#endif
 {
   vector<const char*> args;
   argv_to_vec(argc, (const char **)argv, args);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -96,7 +96,7 @@ static void wait_shutdown()
   }
 }
 
-int signal_fd_init()
+static int signal_fd_init()
 {
   return socketpair(AF_UNIX, SOCK_STREAM, 0, signal_fd);
 }
@@ -153,7 +153,7 @@ public:
   }
 };
 
-int usage()
+static int usage()
 {
   cerr << "usage: radosgw [options...]" << std::endl;
   cerr << "options:\n";
@@ -190,7 +190,11 @@ static void reloader_handler(int signum)
 /*
  * start up the RADOS connection and then handle HTTP messages as they come in
  */
+#ifdef BUILDING_FOR_EMBEDDED
+extern "C" int cephd_rgw(int argc, const char **argv)
+#else
 int main(int argc, const char **argv)
+#endif
 {
   // dout() messages will be sent to stderr, but FCGX wants messages on stdout
   // Redirect stderr to stdout.

--- a/src/rgw/rgw_request.h
+++ b/src/rgw/rgw_request.h
@@ -9,8 +9,9 @@
 #include "rgw_acl.h"
 #include "rgw_user.h"
 #include "rgw_op.h"
+#if defined(WITH_RADOSGW_FCGI_FRONTEND)
 #include "rgw_fcgi.h"
-
+#endif
 #include "common/QueueRing.h"
 
 struct RGWRequest
@@ -34,6 +35,7 @@ struct RGWRequest
   void log(struct req_state *s, const char *msg);
 }; /* RGWRequest */
 
+#if defined(WITH_RADOSGW_FCGI_FRONTEND)
 struct RGWFCGXRequest : public RGWRequest {
   FCGX_Request *fcgx;
   QueueRing<FCGX_Request *> *qr;
@@ -48,6 +50,7 @@ struct RGWFCGXRequest : public RGWRequest {
     qr->enqueue(fcgx);
   }
 };
+#endif
 
 struct RGWLoadGenRequest : public RGWRequest {
 	string method;


### PR DESCRIPTION
This PR adds RGW and MDS to embedded Ceph. The approach is similar to the work to add MON and OSD keeping the changes to a minimum. Also in here is a commit to make the FCGI dependency optional