### PR TITLE
ceph-fuse: start up log on parent process before shutdown

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -295,6 +295,8 @@ int main(int argc, const char **argv, const char *envp[]) {
     //cout << "child done" << std::endl;
     return r;
   } else {
+    if (restart_log)
+      g_ceph_context->_log->start();
     // i am the parent
     //cout << "parent, waiting for signal" << std::endl;
     ::close(fd[1]);


### PR DESCRIPTION
Otherwise, we hit an assert in the Ceph context and logging teardown.

Fixes: http://tracker.ceph.com/issues/18157

Signed-off-by: Greg Farnum <gfarnum@redhat.com>