### PR TITLE
cmake: support the case when keyutils is not found

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -638,7 +638,7 @@ if(WITH_RBD)
       $<TARGET_OBJECTS:parse_secret_objs>)
     set(DENCODER_EXTRALIBS
       ${DENCODER_EXTRALIBS}
-      keyutils
+      ${KEYUTILS_LIBRARIES}
       udev)
   endif(LINUX)
 endif(WITH_RBD)
@@ -823,8 +823,8 @@ add_subdirectory(bash_completion)
 if(KEYUTILS_FOUND)
   set(parse_secret_files
     common/secret.c)
-  add_library(parse_secret_objs OBJECT ${parse_secret_files})
 endif()
+add_library(parse_secret_objs OBJECT ${parse_secret_files})
 
 if(WITH_LIBCEPHFS)
   add_subdirectory(client)
@@ -857,7 +857,7 @@ if(WITH_LIBCEPHFS)
   add_executable(mount.ceph ${mount_ceph_srcs}
     $<TARGET_OBJECTS:parse_secret_objs>
     $<TARGET_OBJECTS:common_mountcephfs_objs>)
-  target_link_libraries(mount.ceph keyutils)
+  target_link_libraries(mount.ceph ${KEYUTILS_LIBRARIES})
 
   install(TARGETS ceph-syn DESTINATION bin)
   install(TARGETS mount.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -841,7 +841,7 @@ target_link_libraries(unittest_rbd_replay
   global
   rbd_replay
   rbd_replay_ios
-  keyutils
+  ${KEYUTILS_LIBRARIES}
   ${BLKID_LIBRARIES}
   )
 endif(WITH_RBD)

--- a/src/test/bench/CMakeLists.txt
+++ b/src/test/bench/CMakeLists.txt
@@ -31,7 +31,7 @@ if(WITH_RBD)
     udev
     ${BLKID_LIBRARIES}
     ${CMAKE_DL_LIBS}
-    keyutils
+    ${KEYUTILS_LIBRARIES}
     )
   add_dependencies(ceph_smalliobenchrbd
     cls_rbd

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -133,7 +133,7 @@ target_link_libraries(ceph_test_librbd_fsx
   ${EXTRALIBS}
   blkid
   udev
-  keyutils
+  ${KEYUTILS_LIBRARIES}
   )
 
 install(TARGETS

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(rbd librbd librados
   rbd_types
   journal
   common global
-  keyutils udev
+  ${KEYUTILS_LIBRARIES} udev
   ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 install(TARGETS rbd DESTINATION bin)


### PR DESCRIPTION
When keyutils is not found dont include secrets.cc. Also use ${KEYUTILS_LIBRARIES} instead of keyutils.

