### PR TITLE
osd: mark queued flag for op

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1898,6 +1898,7 @@ void PG::take_op_map_waiters()
     if (op_must_wait_for_map(get_osdmap_with_maplock()->get_epoch(), *i)) {
       break;
     } else {
+      (*i)->mark_queued_for_pg();
       osd->op_wq.queue(make_pair(PGRef(this), *i));
       waiting_for_map.erase(i++);
     }


### PR DESCRIPTION
queue_op will check the op epoch with current osdmap epoch,
and then, the op will be push into waiting_for_map or mark
queued flag.
but when the op pop from waiting_for_map, take_op_map_waiters
forget to mark queued flag before handle it.

Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>