### PR TITLE
os/bluestore: don't implicitly create the source object for clone

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7038,8 +7038,7 @@ void BlueStore::_txc_add_transaction(TransContext *txc, Transaction *t)
     bool create = false;
     if (op->op == Transaction::OP_TOUCH ||
 	op->op == Transaction::OP_WRITE ||
-	op->op == Transaction::OP_ZERO ||
-	op->op == Transaction::OP_CLONE) {
+	op->op == Transaction::OP_ZERO) {
       create = true;
     }
 


### PR DESCRIPTION
We shall implicitly create the destination object instead and
missing source object usually indicates an error.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>