### PR TITLE
os/bluestore: fix global commit latency

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1204,7 +1204,6 @@ public:
       utime_t lat, now = ceph_clock_now(g_ceph_context);
       lat = now - last_stamp;
       logger->tinc(state, lat);
-      start = now;
       last_stamp = now;
     }
 


### PR DESCRIPTION
"start" is used to calculate the global bluestore commit latency
and hence shall not be updated at each internal state enter/exit.

Otherwise the l_bluestore_commit_lat counter won't reflect the
real commit latency precisely.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>