### PR TITLE
safe_io: rename safe_io.c to safe_io.cc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -508,7 +508,7 @@ set(mon_common_files
 add_library(mon_common_objs OBJECT ${mon_common_files})
 set(common_mountcephfs_files
   common/armor.c
-  common/safe_io.c
+  common/safe_io.cc
   common/module.c
   common/addr_parsing.c)
 add_library(common_mountcephfs_objs OBJECT

--- a/src/common/safe_io.cc
+++ b/src/common/safe_io.cc
@@ -12,9 +12,7 @@
  *
  */
 
-#define _XOPEN_SOURCE 500
-
-#include <stdio.h>
+#include <cstdio>
 #include <string.h>
 #include <unistd.h>
 #include <errno.h>


### PR DESCRIPTION
as snprintf() confirms to C99 and C++11, and is part of XPG 5. but
FreeBSD does not expose it with _XOPEN_SOURCE=500. let's just move this
source file to the C++ land.

Signed-off-by: Kefu Chai <kchai@redhat.com>