### PR TITLE
common/module.c: do not use strerror_r the GNU way.

### DIFF
--- a/src/common/module.c
+++ b/src/common/module.c
@@ -40,8 +40,9 @@ static int run_command(const char *command)
 
 	if (status < 0) {
 		char error_buf[80];
+		strerror_r(errno, error_buf, sizeof(error_buf));
 		fprintf(stderr, "couldn't run '%s': %s\n", command,
-			strerror_r(errno, error_buf, sizeof(error_buf)));
+			error_buf);
 	} else if (WIFSIGNALED(status)) {
 		fprintf(stderr, "'%s' killed by signal %d\n", command,
 			WTERMSIG(status));


### PR DESCRIPTION
FreeBSD compile generates:
```
[  0%] Building C object src/CMakeFiles/common_mountcephfs_objs.dir/common/module.c.o
/home/jenkins/workspace/ceph-freebsd/src/common/module.c:44:4: warning: format specifies type 'char *' but the argument has type 'int' [-Wformat]
                        strerror_r(errno, error_buf, sizeof(error_buf)));
                        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 warning generated.
```

From the manpage:
```
       char *strerror(int errnum);

       int strerror_r(int errnum, char *buf, size_t buflen);
                   /* XSI-compliant */

       char *strerror_r(int errnum, char *buf, size_t buflen);
                   /* GNU-specific */
```
So changed the strerror_r() version to where the buffer is filled separately
and the result is ignored, instead of being used for printing.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>