### PR TITLE
qa/workunits/rbd: use more recent qemu-iotests that support Xenial

### DIFF
--- a/qa/workunits/rbd/qemu-iotests.sh
+++ b/qa/workunits/rbd/qemu-iotests.sh
@@ -5,15 +5,18 @@
 # require the admin ceph user, as there's no way to pass the ceph user
 # to qemu-iotests currently.
 
-# This will only work with particular qemu versions, like 1.0. Later
-# versions of qemu include qemu-iotests directly in the qemu
-# repository.
 testlist='001 002 003 004 005 008 009 010 011 021 025 032 033 055'
 
 git clone https://github.com/qemu/qemu.git
-# use v2.2.0-rc3 (last released version that handles all the tests
 cd qemu
-git checkout 2528043f1f299e0e88cb026f1ca7c40bbb4e1f80
+if lsb_release -da | grep -iq xenial; then
+    # Xenial requires a recent test harness
+    git checkout v2.3.0
+else
+    # use v2.2.0-rc3 (last released version that handles all the tests
+    git checkout 2528043f1f299e0e88cb026f1ca7c40bbb4e1f80
+
+fi
 
 cd tests/qemu-iotests
 mkdir bin


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18149
Signed-off-by: Jason Dillaman <dillaman@redhat.com>