### PR TITLE
msg/simple/Pipe: avoid returning 0 on poll timeout

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2500,8 +2500,11 @@ int Pipe::tcp_read_wait()
   if (has_pending_data())
     return 0;
 
-  if (poll(&pfd, 1, msgr->timeout) <= 0)
+  int r = poll(&pfd, 1, msgr->timeout);
+  if (r < 0)
     return -errno;
+  if (r == 0)
+    return -EAGAIN;
 
   evmask = POLLERR | POLLHUP | POLLNVAL;
 #if defined(__linux__)


### PR DESCRIPTION
If poll times out it will return 0 (no data to read on socket).  In
165e5abdbf6311974d4001e43982b83d06f9e0cc we changed tcp_read_wait from
returning -1 to returning -errno, which means we return 0 instead of -1
in this case.

This makes tcp_read() get into an infinite loop by repeatedly trying to
read from the socket and getting EAGAIN.

Fix by explicitly checking for a 0 return from poll(2) and returning
EAGAIN in that case.

Signed-off-by: Sage Weil <sage@redhat.com>