### PR TITLE
Revert "msg/simple/Pipe: avoid infinite loop in Pipe::do_recv()"

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -205,6 +205,7 @@ OPTION(ms_inject_delay_probability, OPT_DOUBLE, 0) // range [0, 1]
 OPTION(ms_inject_internal_delays, OPT_DOUBLE, 0)   // seconds
 OPTION(ms_dump_on_send, OPT_BOOL, false)           // hexdump msg to log on send
 OPTION(ms_dump_corrupt_message_level, OPT_INT, 1)  // debug level to hexdump undecodeable messages at
+OPTION(ms_socket_retry_on_eagain, OPT_INT, 2) // # of pipe retries on EAGAIN from ::recv
 OPTION(ms_async_transport_type, OPT_STR, "posix")
 OPTION(ms_async_op_threads, OPT_U64, 3)            // number of worker processing threads for async messenger created on init
 OPTION(ms_async_max_op_threads, OPT_U64, 5)        // max number of worker processing threads for async messenger

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -170,6 +170,9 @@ ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
   nread = cs.read(buf, len);
   if (nread < 0) {
     if (nread == -EAGAIN) {
+      // FIXME: I think this needs to get changed to look like
+      // SimpleMessenger's Pipe::do_recv() EAGAIN handling with
+      // ms_socket_retry_on_eagain
       nread = 0;
     } else if (nread == -EINTR) {
       goto again;

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2604,7 +2604,7 @@ ssize_t Pipe::do_recv(char *buf, size_t len, int flags)
 again:
   ssize_t got = ::recv( sd, buf, len, flags );
   if (got < 0) {
-    if (errno == EINTR) {
+    if (errno == EAGAIN || errno == EINTR) {
       goto again;
     }
     ldout(msgr->cct, 10) << __func__ << " socket " << sd << " returned "

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -2601,10 +2601,21 @@ int Pipe::tcp_read_wait()
 
 ssize_t Pipe::do_recv(char *buf, size_t len, int flags)
 {
+  int retries = 0;
 again:
   ssize_t got = ::recv( sd, buf, len, flags );
   if (got < 0) {
-    if (errno == EAGAIN || errno == EINTR) {
+    if (errno == EINTR) {
+      goto again;
+    } else if (errno == EAGAIN &&
+	       msgr->cct->_conf->ms_socket_retry_on_eagain > retries) {
+      ++retries;
+      ldout(msgr->cct, 1) << __func__ << " socket " << sd
+			  << " unexpectedly got EAGAIN! Retrying again for "
+			  << retries << '/'
+			  << msgr->cct->_conf->ms_socket_retry_on_eagain
+			  << " time (ms_socket_retry_on_eagain config)"
+			  << dendl;
       goto again;
     }
     ldout(msgr->cct, 10) << __func__ << " socket " << sd << " returned "


### PR DESCRIPTION
Reverts ceph/ceph#6971

The original patch was a band-aid to fix http://tracker.ceph.com/issues/18184, and
http://tracker.ceph.com/issues/14120#note-6 discusses why we don't want to keep it.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>