### PR TITLE
librados: AioCompletion + RGW

### DIFF
--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -212,7 +212,12 @@ namespace librados
     int get_return_value();
     int get_version() __attribute__ ((deprecated));
     uint64_t get_version64();
+    void get();
+    void put();
     void release();
+	void operator delete(void* ptr) {
+		static_cast<AioCompletion*>(ptr)->put();
+	}
     AioCompletionImpl *pc;
   };
 

--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -27,6 +27,7 @@
 class IoCtxImpl;
 
 struct librados::AioCompletionImpl {
+  AioCompletion c;
   Mutex lock;
   Cond cond;
   int ref, rval;
@@ -48,7 +49,8 @@ struct librados::AioCompletionImpl {
   ceph_tid_t aio_write_seq;
   xlist<AioCompletionImpl*>::item aio_write_list_item;
 
-  AioCompletionImpl() : lock("AioCompletionImpl lock", false, false),
+  AioCompletionImpl() : c(this),
+ 			lock("AioCompletionImpl lock", false, false),
 			ref(1), rval(0), released(false), ack(false), safe(false),
 			objver(0),
                         tid(0),
@@ -166,8 +168,9 @@ struct librados::AioCompletionImpl {
     assert(ref > 0);
     int n = --ref;
     lock.Unlock();
-    if (!n)
+    if (!n) {
       delete this;
+    }
   }
 };
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -9610,7 +9610,9 @@ struct get_obj_data : public RefCountedObject {
       total_read(0), lock("get_obj_data"), data_lock("get_obj_data::data_lock"),
       client_cb(NULL),
       throttle(cct, "get_obj_data", cct->_conf->rgw_get_obj_window_size, false) {}
-  virtual ~get_obj_data() { } 
+
+  virtual ~get_obj_data() {}
+
   void set_cancelled(int r) {
     cancelled.set(1);
     err_code.set(r);
@@ -9638,6 +9640,7 @@ struct get_obj_data : public RefCountedObject {
 
     c->wait_for_safe_and_cb();
     int r = c->get_return_value();
+    c->put();
 
     lock.Lock();
     completion_map.erase(cur_ofs);
@@ -9668,6 +9671,7 @@ struct get_obj_data : public RefCountedObject {
     struct get_obj_aio_data *paio_data =  &aio_data.back(); /* last element */
 
     librados::AioCompletion *c = librados::Rados::aio_create_completion((void *)paio_data, NULL, _get_obj_aio_completion_cb);
+    c->get(); /* take "extra" ref so completion_map can't outlive c */
     completion_map[ofs] = c;
 
     *pc = c;


### PR DESCRIPTION
    Allow AioCompletion to forward get() and put() refcounting
    operators.  Use these to take an extra ref on mapped completions
    in RGW's read i/o path.
    
    Of more interest, while here, remove the confusing split lifecycle
    of AioCompletion and AioCompletionImpl--removing heap allocation
    of AioCompletion as a side effect.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>