### PR TITLE
rgw: do not abort when accept a CORS request with short origin

### DIFF
--- a/src/rgw/rgw_cors.cc
+++ b/src/rgw/rgw_cors.cc
@@ -104,7 +104,8 @@ static bool is_string_in_set(set<string>& s, string h) {
         string sl = ssplit.front();
         dout(10) << "Finding " << sl << ", in " << h 
           << ", at offset not less than " << flen << dendl;
-        if (h.compare((h.size() - sl.size()), sl.size(), sl) != 0)
+        if (h.size() < sl.size() ||
+	    h.compare((h.size() - sl.size()), sl.size(), sl) != 0)
           continue;
         ssplit.pop_front();
       }


### PR DESCRIPTION
Fixed: #18187

when accept a CROS request, the request http origin shorter than the bucket's corsrule
(eg. origin: http://s.com corsrule: \<AllowedOrigin\>*.verylongdomain.com\</AllowedOrigin\>).
the rgw_cors.cc::is_string_in_set() will have a wrong index, the radosrgw server will abort.

$ curl http://test.localhost:8000/app.data -H "Origin:http://s.com"

 0> 2016-12-05 03:22:29.548138 7f6add05d700 -1 *** Caught signal(Aborted) **
 in thread 7f6add05d700 thread_name:civetweb-worker

 ceph version 11.0.2-2168-gd2f8fb4(d2f8fb4a6ba75af7e6da0f5a7f1b49ec998b1631)
 1: (()+0x50720a) [0x7f6b147c420a]
 2: (()+0xf370) [0x7f6b09a33370]
 3: (gsignal()+0x37) [0x7f6b081ca1d7]
 4: (abort()+0x148) [0x7f6b081cb8c8]
 5: (__gnu_cxx::__verbose_terminate_handler()+0x165) [0x7f6b08ace9d5]
 6: (()+0x5e946) [0x7f6b08acc946]
 7: (()+0x5e973) [0x7f6b08acc973]
 8: (()+0x5eb93) [0x7f6b08accb93]
 9: (std::__throw_out_of_range(char const*)+0x77) 0x7f6b08b21a17]
 10: (()+0xbd97a) [0x7f6b08b2b97a]
 11: (()+0x449c1e) [0x7f6b14706c1e]
 12: (RGWCORSRule::is_origin_present(char const*)+0x48) [0x7f6b147073b8]
 13: (RGWCORSConfiguration::host_name_rule(char const*)+0x37) [0x7f6b147074e7]
 14: (RGWOp::generate_cors_headers(std::string&, std::string&, std::string&, std::string&, unsigned int*)+0xa3) [0x7f6b14593e63]
 15: (dump_access_control(req_state*, RGWOp*)+0x61) [0x7f6b14653f91]

Signed-off-by: LiuYang <yippeetry@gmail.com>