### PR TITLE
cmake: explictly call find_package(PythonInterp) first to fix build err

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -348,6 +348,7 @@ option(WITH_CEPHFS "CephFS is enabled" ON)
 option(WITH_MGR "ceph-mgr is enabled" ON)
 if(WITH_MGR)
     set(Python_ADDITIONAL_VERSIONS 2.7)
+    find_package(PythonInterp 2.7 REQUIRED)
     find_package(PythonLibs 2.7 REQUIRED)
     # Boost dependency check deferred to Boost section
 endif(WITH_MGR)


### PR DESCRIPTION
this is an un-modified message from dev-util/cmake-3.7.1
/usr/share/cmake/Modules/FindPythonLibs.cmake

call ``find_package(PythonInterp)`` first to
 get the currently active Python version by default with a consistent
version  of PYTHON_LIBRARIES.

Signed-off-by: Yixun Lan <dlan@gentoo.org>

---
the detail error message we've met here

Found PythonInterp: python (found suitable version "2.7.12", minimum required is "2")
CMake Error at /usr/share/cmake/Modules/FindPythonLibs.cmake:54 (get_filename_component):
  get_filename_component called with incorrect number of arguments
Call Stack (most recent call first):
  src/CMakeLists.txt:209 (find_package)