### PR TITLE
librbd: remove unused local variable

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -910,7 +910,6 @@ struct C_InvalidateCache : public Context {
                                         map<string, bufferlist> *res) {
     size_t conf_prefix_len = prefix.size();
 
-    string start = prefix;
     for (auto it : pairs) {
       if (it.first.compare(0, MIN(conf_prefix_len, it.first.size()), prefix) > 0)
         return false;


### PR DESCRIPTION
Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>