### PR TITLE
tests: unittest_throttle avoid ASSERT_DEATH

### DIFF
--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -61,10 +61,6 @@ protected:
 };
 
 TEST_F(ThrottleTest, Throttle) {
-  ASSERT_DEATH({
-      Throttle throttle(g_ceph_context, "throttle", -1);
-    }, "");
-
   int64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
   ASSERT_EQ(throttle.get_max(), throttle_max);
@@ -74,7 +70,6 @@ TEST_F(ThrottleTest, Throttle) {
 TEST_F(ThrottleTest, take) {
   int64_t throttle_max = 10;
   Throttle throttle(g_ceph_context, "throttle", throttle_max);
-  ASSERT_DEATH(throttle.take(-1), "");
   ASSERT_EQ(throttle.take(throttle_max), throttle_max);
   ASSERT_EQ(throttle.take(throttle_max), throttle_max * 2);
 }
@@ -90,7 +85,6 @@ TEST_F(ThrottleTest, get) {
     ASSERT_EQ(throttle.put(throttle_max), 0);
   }
 
-  ASSERT_DEATH(throttle.get(-1), "");
   ASSERT_FALSE(throttle.get(5));
   ASSERT_EQ(throttle.put(5), 0);
 


### PR DESCRIPTION
Combined with threads it may cause intermittent failures.

Fixes: http://tracker.ceph.com/issues/18036

Signed-off-by: Loic Dachary <loic@dachary.org>