### PR TITLE
os/bluestore: refactor ExtentMap::update to avoid preceeding db updat…

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -675,11 +675,11 @@ public:
       return p->second;
     }
 
-    bool update(Onode *on, KeyValueDB::Transaction t, bool force);
-    void reshard(Onode *on, uint64_t min_alloc_size);
+    bool update(KeyValueDB::Transaction t, bool force);
+    void reshard(uint64_t min_alloc_size);
 
     /// initialize Shards from the onode
-    void init_shards(Onode *on, bool loaded, bool dirty);
+    void init_shards(bool loaded, bool dirty);
 
     /// return index of shard containing offset
     /// or -1 if not found


### PR DESCRIPTION
…e if reshard takes place.

update method might add some 'set' ops to the transaction prior to detection that resharding is needed.
No need to apply these ops after reshard takes place - correspoding records to be removed anyway.

Signed-off-by: Igor Fedotov <ifed@mirantis.com>