### PR TITLE
librbd: use proper snapshot when computing diff parent overlap

### DIFF
--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -264,7 +264,7 @@ int DiffIterate::execute() {
     RWLock::RLocker l(m_image_ctx.snap_lock);
     RWLock::RLocker l2(m_image_ctx.parent_lock);
     uint64_t overlap = end_size;
-    m_image_ctx.get_parent_overlap(from_snap_id, &overlap);
+    m_image_ctx.get_parent_overlap(m_image_ctx.snap_id, &overlap);
     r = 0;
     if (m_image_ctx.parent && overlap > 0) {
       ldout(cct, 10) << " first getting parent diff" << dendl;


### PR DESCRIPTION
If no snapshot has been made, we will use CEPH_NOSNAP instead of 0,
to query the parent overlap.

Fixes bug http://tracker.ceph.com/issues/18200

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>