### PR TITLE
tool: add some ceph relate processes to ps-ceph.pl

### DIFF
--- a/src/ps-ceph.pl
+++ b/src/ps-ceph.pl
@@ -23,6 +23,10 @@ sub is_ceph_proc {
         return 1 if $cmdline =~ /\bceph-mds\b/;
         return 1 if $cmdline =~ /\bceph-mon\b/;
         return 1 if $cmdline =~ /\bceph-osd\b/;
+        return 1 if $cmdline =~ /\bceph-mgr\b/;
+        return 1 if $cmdline =~ /\bceph-disk\b/;
+        return 1 if $cmdline =~ /\brbd-mirror\b/;
+        return 1 if $cmdline =~ /\bradosgw\b/;
         return 1 if $cmdline =~ /\bosdmaptool\b/;
         return 1 if $cmdline =~ /\brados\b/;
         return 1 if $cmdline =~ /test_/;


### PR DESCRIPTION

 add ceph-mgr,ceph-disk,rbd-mirror,radosgw to ps-ceph.pl,because

 these processes may run long time.so we need to know whether they are

 running in our machine.

Signed-off-by:song baisen <song.baisen@zte.com.cn>