### PR TITLE
rbd : make option --stripe-unit w/ B/K/M work.

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -173,7 +173,7 @@
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
                               journaling(*), data-pool]
     --image-shared            shared image
-    --stripe-unit arg         stripe unit
+    --stripe-unit arg         stripe unit in B/K/M
     --stripe-count arg        stripe count
     --data-pool arg           data pool
     --journal-splay-width arg number of active journal objects
@@ -219,7 +219,7 @@
                                  object-map(+*), fast-diff(+*), deep-flatten(+-),
                                  journaling(*), data-pool]
     --image-shared               shared image
-    --stripe-unit arg            stripe unit
+    --stripe-unit arg            stripe unit in B/K/M
     --stripe-count arg           stripe count
     --data-pool arg              data pool
     --journal-splay-width arg    number of active journal objects
@@ -263,7 +263,7 @@
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
                               journaling(*), data-pool]
     --image-shared            shared image
-    --stripe-unit arg         stripe unit
+    --stripe-unit arg         stripe unit in B/K/M
     --stripe-count arg        stripe count
     --data-pool arg           data pool
     --journal-splay-width arg number of active journal objects
@@ -609,7 +609,7 @@
                               object-map(+*), fast-diff(+*), deep-flatten(+-),
                               journaling(*), data-pool]
     --image-shared            shared image
-    --stripe-unit arg         stripe unit
+    --stripe-unit arg         stripe unit in B/K/M
     --stripe-count arg        stripe count
     --data-pool arg           data pool
     --journal-splay-width arg number of active journal objects

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -270,7 +270,7 @@ void add_create_image_options(po::options_description *opt,
     (IMAGE_FEATURES.c_str(), po::value<ImageFeatures>()->composing(),
      ("image features\n" + get_short_features_help(true)).c_str())
     (IMAGE_SHARED.c_str(), po::bool_switch(), "shared image")
-    (IMAGE_STRIPE_UNIT.c_str(), po::value<uint64_t>(), "stripe unit")
+    (IMAGE_STRIPE_UNIT.c_str(), po::value<ImageObjectSize>(), "stripe unit in B/K/M")
     (IMAGE_STRIPE_COUNT.c_str(), po::value<uint64_t>(), "stripe count")
     (IMAGE_DATA_POOL.c_str(), po::value<std::string>(), "data pool");
 


### PR DESCRIPTION
As 'man rbd' said:  --stripe-unit size-in-B/K/M. But w/ B/K/M, the
command failed and said invalid options. So fix it.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>