### PR TITLE
client: Clear setuid bits when writing or truncating

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6586,6 +6586,10 @@ force_request:
     req->inode_drop |= CEPH_CAP_AUTH_SHARED;
     ldout(cct,10) << "changing gid to " << stx->stx_gid << dendl;
   }
+  if (mask & CEPH_SETATTR_BTIME) {
+    req->head.args.setattr.btime = utime_t(stx->stx_btime);
+    req->inode_drop |= CEPH_CAP_AUTH_SHARED;
+  }
   if (mask & CEPH_SETATTR_MTIME) {
     req->head.args.setattr.mtime = utime_t(stx->stx_mtime);
     req->inode_drop |= CEPH_CAP_AUTH_SHARED | CEPH_CAP_FILE_RD |
@@ -6593,11 +6597,6 @@ force_request:
   }
   if (mask & CEPH_SETATTR_ATIME) {
     req->head.args.setattr.atime = utime_t(stx->stx_atime);
-    req->inode_drop |= CEPH_CAP_FILE_CACHE | CEPH_CAP_FILE_RD |
-      CEPH_CAP_FILE_WR;
-  }
-  if (mask & CEPH_SETATTR_BTIME) {
-    req->head.args.setattr.btime = utime_t(stx->stx_btime);
     req->inode_drop |= CEPH_CAP_FILE_CACHE | CEPH_CAP_FILE_RD |
       CEPH_CAP_FILE_WR;
   }

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -380,6 +380,7 @@ extern const char *ceph_mds_op_name(int op);
 #endif
 #define CEPH_SETATTR_MTIME_NOW	(1 << 7)
 #define CEPH_SETATTR_ATIME_NOW	(1 << 8)
+#define CEPH_SETATTR_KILL_SGUID	(1 << 10)
 
 /*
  * Ceph setxattr request flags.

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3740,7 +3740,7 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
   __u32 access_mask = MAY_WRITE;
 
   // xlock inode
-  if (mask & (CEPH_SETATTR_MODE|CEPH_SETATTR_UID|CEPH_SETATTR_GID|CEPH_SETATTR_BTIME))
+  if (mask & (CEPH_SETATTR_MODE|CEPH_SETATTR_UID|CEPH_SETATTR_GID|CEPH_SETATTR_BTIME|CEPH_SETATTR_KILL_SGUID))
     xlocks.insert(&cur->authlock);
   if (mask & (CEPH_SETATTR_MTIME|CEPH_SETATTR_ATIME|CEPH_SETATTR_SIZE))
     xlocks.insert(&cur->filelock);
@@ -3800,7 +3800,7 @@ void Server::handle_client_setattr(MDRequestRef& mdr)
 
   if (mask & CEPH_SETATTR_MODE)
     pi->mode = (pi->mode & ~07777) | (req->head.args.setattr.mode & 07777);
-  else if ((mask & (CEPH_SETATTR_UID|CEPH_SETATTR_GID)) &&
+  else if ((mask & (CEPH_SETATTR_UID|CEPH_SETATTR_GID|CEPH_SETATTR_KILL_SGUID)) &&
 	    S_ISREG(pi->mode)) {
     pi->mode &= ~S_ISUID;
     if ((pi->mode & (S_ISGID|S_IXGRP)) == (S_ISGID|S_IXGRP))

--- a/src/test/libcephfs/recordlock.cc
+++ b/src/test/libcephfs/recordlock.cc
@@ -355,6 +355,8 @@ static void thread_ConcurrentRecordLocking(str_ConcurrentRecordLocking& s) {
   lock1.l_pid = getpid();
   ASSERT_EQ(0, ceph_ll_setlk(cmount, fh, &lock1, pthread_self(), false));
   PING_MAIN(7); // (7)
+
+  ASSERT_EQ(0, ceph_ll_close(cmount, fh));
 }
 
 // Used by ConcurrentRecordLocking test
@@ -746,6 +748,7 @@ static void process_ConcurrentRecordLocking(str_ConcurrentRecordLocking& s) {
   ASSERT_EQ(0, ceph_ll_setlk(cmount, fh, &lock1, mypid, false));
   PING_MAIN(7); // (7)
 
+  ASSERT_EQ(0, ceph_ll_close(cmount, fh));
   CLEANUP_CEPH();
 
   s.sem_destroy();

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1402,6 +1402,7 @@ TEST(LibCephFS, Nlink) {
   ASSERT_EQ(ceph_ll_mkdir(cmount, root, dirname, 0755, &dir, &stx, 0, 0, perms), 0);
   ASSERT_EQ(ceph_ll_create(cmount, dir, filename, 0666, O_RDWR|O_CREAT|O_EXCL,
 			   &file, &fh, &stx, CEPH_STATX_NLINK, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
   ASSERT_EQ(stx.stx_nlink, (nlink_t)1);
 
   ASSERT_EQ(ceph_ll_link(cmount, file, dir, linkname, perms), 0);
@@ -1573,6 +1574,7 @@ TEST(LibCephFS, LazyStatx) {
   ceph_ll_unlink(cmount1, root1, filename, perms1);
   ASSERT_EQ(ceph_ll_create(cmount1, root1, filename, 0666, O_RDWR|O_CREAT|O_EXCL,
 			   &file1, &fh, &stx, 0, 0, perms1), 0);
+  ASSERT_EQ(ceph_ll_close(cmount1, fh), 0);
 
   ASSERT_EQ(ceph_ll_lookup_root(cmount2, &root2), 0);
 
@@ -1737,5 +1739,6 @@ TEST(LibCephFS, ClearSetuid) {
   ASSERT_TRUE(stx.stx_mask & CEPH_STATX_MODE);
   ASSERT_FALSE(stx.stx_mode & (S_ISUID|S_ISGID));
 
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
   ceph_shutdown(cmount);
 }


### PR DESCRIPTION
This is the remainder of the fix for this tracker bug:

http://tracker.ceph.com/issues/18131

The basic idea is to declare a new CEPH_SETATTR_KILL_SGUID flag. When this is set in a setattr request, the MDS will clear those bits out of the mode. This should allow us to fix the mode properly without relying on a read/modify/write cycle of the mode (which would be racy).

Truncates always go to the server so there we just set the KILL_SGUID flag if we don't have Ax caps.

Writes will now take As caps along with Fw in order to check whether to issue a setattr. I think that should be mostly harmless since we'll already have them in most cases, but there could be some small performance impact there. I'm open to suggestions if anyone sees a better way to do this.

Also, there are a couple of bugfixes in here for problems that I noticed by inspection, and I beefed up the new ClearSetuid test to test truncate and write behavior.

Once this is in, we should be set to change ceph-fuse over to handling setuid clearing itself, which will close some races that can occur now.