### PR TITLE
ceph-disk: prevent unnecessary tracebacks from subprocess.check_call

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1575,7 +1575,8 @@ class Device(object):
                 '--mbrtogpt',
                 '--',
                 self.path,
-            ]
+            ],
+            exit=True
         )
         update_partition(self.path, 'created')
         return num
@@ -2727,12 +2728,9 @@ class PrepareData(object):
                 '--',
                 partition.get_dev(),
             ])
-            try:
-                LOG.debug('Creating %s fs on %s',
-                          self.args.fs_type, partition.get_dev())
-                command_check_call(args)
-            except subprocess.CalledProcessError as e:
-                raise Error(e)
+            LOG.debug('Creating %s fs on %s',
+                      self.args.fs_type, partition.get_dev())
+            command_check_call(args, exit=True)
 
             path = mount(dev=partition.get_dev(),
                          fstype=self.args.fs_type,
@@ -2748,18 +2746,16 @@ class PrepareData(object):
                 partition.unmap()
 
         if not is_partition(self.args.data):
-            try:
-                command_check_call(
-                    [
-                        'sgdisk',
-                        '--typecode=%d:%s' % (partition.get_partition_number(),
-                                              partition.ptype_for_name('osd')),
-                        '--',
-                        self.args.data,
-                    ],
-                )
-            except subprocess.CalledProcessError as e:
-                raise Error(e)
+            command_check_call(
+                [
+                    'sgdisk',
+                    '--typecode=%d:%s' % (partition.get_partition_number(),
+                                          partition.ptype_for_name('osd')),
+                    '--',
+                    self.args.data,
+                ],
+                exit=True,
+            )
             update_partition(self.args.data, 'prepared')
             command_check_call(['udevadm', 'trigger',
                                 '--action=add',

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -154,7 +154,7 @@ class TestDevice(Base):
                        partition_number,
                        main.PTYPE['regular']['journal']['ready']),
                    '--mbrtogpt', '--', path]
-        m_command_check_call.assert_called_with(command)
+        m_command_check_call.assert_called_with(command, exit=True)
         m_update_partition.assert_called_with(path, 'created')
 
         actual_partition_number = device.create_partition(
@@ -167,7 +167,7 @@ class TestDevice(Base):
                        partition_number,
                        main.PTYPE['regular']['journal']['ready']),
                    '--mbrtogpt', '--', path]
-        m_command_check_call.assert_called_with(command)
+        m_command_check_call.assert_called_with(command, exit=True)
 
 
 class TestDevicePartition(Base):


### PR DESCRIPTION
This new PR makes a few changes to remove a commit that adapted the 'Authors' line, while still addressing the problem of unnecessary tracebacks from ceph-disk.

Original PR is at https://github.com/ceph/ceph/pull/9485

See http://tracker.ceph.com/issues/16125