### PR TITLE
os/filestore/HashIndex: be loud about splits

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -315,6 +315,8 @@ int HashIndex::split_dirs(const vector<string> &path) {
   }
 
   if (must_split(info)) {
+    dout(1) << __func__ << " " << path << " has " << info.objs
+            << " objects, starting split." << dendl;
     r = initiate_split(path, info);
     if (r < 0) {
       dout(10) << "error initiating split on " << path << ": "
@@ -323,6 +325,8 @@ int HashIndex::split_dirs(const vector<string> &path) {
     }
 
     r = complete_split(path, info);
+    dout(1) << __func__ << " " << path << " split completed."
+            << dendl;
     if (r < 0) {
       dout(10) << "error completing split on " << path << ": "
 	       << cpp_strerror(r) << dendl;
@@ -378,10 +382,15 @@ int HashIndex::_created(const vector<string> &path,
     return r;
 
   if (must_split(info)) {
+    dout(1) << __func__ << " " << path << " has " << info.objs
+            << " objects, starting split." << dendl;
     int r = initiate_split(path, info);
     if (r < 0)
       return r;
-    return complete_split(path, info);
+    r = complete_split(path, info);
+    dout(1) << __func__ << " " << path << " split completed."
+            << dendl;
+    return r;
   } else {
     return 0;
   }


### PR DESCRIPTION
This ML thread "[ceph-users] filestore_split_multiple hardcoded maximum" has coincided with ~1 week of slow requests on one of our clusters. After much debugging we finally tracked it down to filestore splitting. 

It would have been much easier to understand the root cause if filestore splitting was verbose. Splitting is a rare but rather important event -- the OSD should be super verbose when it happens. (Otherwise, it simply looks like a filestore write is taking many 10s of seconds, which seems absurd).

So I'm sending this patch for comments. I'm not sure if the dout is needed in the _create function, and I didn't make the merges verbose yet (which I guess is also needed?)

If this makes it to master, I'd appreciate a backport to jewel. (filestore will lose relevance anyway in L and beyond).