### PR TITLE
jewel: add max_part and nbds_max options in rbd nbd map, in order to keep consistent with  

### DIFF
--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -973,7 +973,8 @@
   
   rbd help nbd map
   usage: rbd nbd map [--pool <pool>] [--image <image>] [--snap <snap>] 
-                     [--read-only] [--device <device>] 
+                     [--read-only] [--device <device>] [--nbds_max <nbds_max>] 
+                     [--max_part <max_part>] 
                      <image-or-snap-spec> 
   
   Map image to a nbd device.
@@ -988,6 +989,8 @@
     --snap arg            snapshot name
     --read-only           mount read-only
     --device arg          specify nbd device
+    --nbds_max arg        override module param nbds_max
+    --max_part arg        override module param max_part
   
   rbd help nbd unmap
   usage: rbd nbd unmap 

--- a/src/tools/rbd/action/Nbd.cc
+++ b/src/tools/rbd/action/Nbd.cc
@@ -100,7 +100,9 @@ void get_map_arguments(po::options_description *positional,
                                      at::ARGUMENT_MODIFIER_NONE);
   options->add_options()
     ("read-only", po::bool_switch(), "mount read-only")
-    ("device", po::value<std::string>(), "specify nbd device");
+    ("device", po::value<std::string>(), "specify nbd device")
+    ("nbds_max", po::value<std::string>(), "override module param nbds_max")
+    ("max_part", po::value<std::string>(), "override module param max_part");
 }
 
 int execute_map(const po::variables_map &vm)
@@ -136,6 +138,14 @@ int execute_map(const po::variables_map &vm)
   if (vm.count("device")) {
     args.push_back("--device");
     args.push_back(vm["device"].as<std::string>().c_str());
+  }
+  if (vm.count("nbds_max")) {
+    args.push_back("--nbds_max");
+    args.push_back(vm["nbds_max"].as<std::string>().c_str());
+  }
+  if (vm.count("max_part")) {
+    args.push_back("--max_part");
+    args.push_back(vm["max_part"].as<std::string>().c_str());
   }
 
   return call_nbd_cmd(vm, args);


### PR DESCRIPTION
http://tracker.ceph.com/issues/18214