### PR TITLE
rgw: don't leak S3 LDAPHelper

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -568,7 +568,7 @@ int main(int argc, const char **argv)
   delete olog;
 
   RGWStoreManager::close_storage(store);
-
+  rgw::auth::s3::LDAPEngine::shutdown();
   rgw_tools_cleanup();
   rgw_shutdown_resolver();
   curl_global_cleanup();

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4137,8 +4137,14 @@ rgw::auth::s3::LDAPEngine::authenticate(
   auto apl = apl_factory->create_apl_remote(cct, s, get_acl_strategy(),
                                             get_creds_info(base64_token));
   return result_t::grant(std::move(apl), completer_factory(boost::none));
-}
+} /* rgw::auth::s3::LDAPEngine::authenticate */
 
+void rgw::auth::s3::LDAPEngine::shutdown() {
+  if (ldh) {
+    delete ldh;
+    ldh = nullptr;
+  }
+}
 
 /* LocalEndgine */
 rgw::auth::Engine::result_t

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -850,6 +850,8 @@ public:
   const char* get_name() const noexcept override {
     return "rgw::auth::s3::LDAPEngine";
   }
+
+  static void shutdown();
 };
 
 


### PR DESCRIPTION
Adds a static shutdown() method to RGWLDAPAuthEngine, and calls
it from main.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>