### PR TITLE
[DNM] safe_io: always overwrite existing file

### DIFF
--- a/src/common/safe_io.c
+++ b/src/common/safe_io.c
@@ -160,12 +160,6 @@ int safe_write_file(const char *base, const char *file,
   char tmp[PATH_MAX];
   int fd;
 
-  // does the file already have correct content?
-  char oldval[80];
-  ret = safe_read_file(base, file, oldval, sizeof(oldval));
-  if (ret == (int)vallen && memcmp(oldval, val, vallen) == 0)
-    return 0;  // yes.
-
   snprintf(fn, sizeof(fn), "%s/%s", base, file);
   snprintf(tmp, sizeof(tmp), "%s/%s.tmp", base, file);
   fd = open(tmp, O_WRONLY|O_CREAT|O_TRUNC, 0644);


### PR DESCRIPTION
even if the existing file already has correct content. this helps to
re-create the SELinux context of the file being written. if there is a
file already exists with the same content but with a different SELinux
context, prior to this change, the file will keep unchanged. and its
SELinux context is preserved. so SELinux denial will be reported if the
application tries to read/write that file later.

Fixes: http://tracker.ceph.com/issues/16800
Signed-off-by: Kefu Chai <kchai@redhat.com>