### PR TITLE
rgw: remove duplicate flush formatter

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -806,7 +806,6 @@ void abort_early(struct req_state *s, RGWOp *op, int err_no,
     } else {
       end_header(s, op);
     }
-    rgw_flush_formatter(s, s->formatter);
   }
   perfcounter->inc(l_rgw_failed_req);
 }


### PR DESCRIPTION
The method `rgw_flush_formatter_and_reset` has been invoked in `end_header,` maybe `rgw_flush_formatter` is duplicate.

Signed-off-by: Guo Zhandong <guozhandong@cmss.chinamobile.com>