### PR TITLE
include/fs_types: fix unsigned integer overflow

### DIFF
--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -102,7 +102,7 @@ struct file_layout_t {
   }
 
   uint64_t get_period() const {
-    return stripe_count * object_size;
+    return static_cast<uint64_t>(stripe_count) * object_size;
   }
 
   void from_legacy(const ceph_file_layout& fl);


### PR DESCRIPTION
stats image has (`stripe_count` * `object_size`) > `UINT32_MAX` results following exception:
```  
  ...
  5: (()+0xc3391) [0x7f720e638391]
  6: (librbd::Image::stat(rbd_image_info_t&, unsigned long)+0x46) [0x7f720e5d1fd6]
  7: (rbd::action::info::execute(boost::program_options::variables_map const&)+0x194) [0x7f7218266744]
  8: (rbd::Shell::execute(std::vector<char const*, std::allocator<char const*> > const&)+0x87d) [0x7f721823c1bd]
  9: (main()+0x72) [0x7f721820b4c2]
  ...
  Floating point exception (core dumped)
```

Signed-off-by: runsisi <runsisi@zte.com.cn>