### PR TITLE
msg/MOSDOp: add for forward compatibility

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -358,11 +358,11 @@ struct ceph_osd_request_head {
 
     // Always keep here the newest version of decoding order/rule
     if (header.version == HEAD_VERSION) {
-	  ::decode(pgid, p);
-	  ::decode(osdmap_epoch, p);
-	  ::decode(flags, p);
-	  ::decode(reassert_version, p);
-	  ::decode(reqid, p);
+      ::decode(pgid, p);
+      ::decode(osdmap_epoch, p);
+      ::decode(flags, p);
+      ::decode(reassert_version, p);
+      ::decode(reqid, p);
     } else if (header.version < 2) {
       // old decode
       ::decode(client_inc, p);
@@ -465,6 +465,12 @@ struct ceph_osd_request_head {
       // put client_inc in reqid.inc for get_reqid()'s benefit
       if (reqid.name == entity_name_t() && reqid.tid == 0)
 	reqid.inc = client_inc;
+    } else {
+      ::decode(pgid, p);
+      ::decode(osdmap_epoch, p);
+      ::decode(flags, p);
+      ::decode(reassert_version, p);
+      ::decode(reqid, p);
     }
 
     partial_decode_needed = false;


### PR DESCRIPTION
if we inc HEAD_VERSION from 7 to greater on the client, the server will go into
non-branch and decoded nothing, resulting in version incompatibility. A better choice is to
add these code to decode the old version fields just as the MOSDOpReply does.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>