### PR TITLE
common/blkdev: use realpath instead of readlink to resolve the recurs…

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -65,21 +65,23 @@ int get_block_device_base(const char *dev, char *out, size_t out_len)
   struct stat st;
   int r = 0;
   DIR *dir;
-  char devname[PATH_MAX], fn[PATH_MAX];
+  char devname[PATH_MAX] = {0}, fn[PATH_MAX] = {0};
   char *p;
   char realname[PATH_MAX] = {0};
 
   if (strncmp(dev, "/dev/", 5) != 0) {
-    if ((readlink(dev, realname, sizeof(realname)) == -1) || (strncmp(realname, "/dev/", 5) != 0))
+    if (realpath(dev, realname) == NULL || (strncmp(realname, "/dev/", 5) != 0)) {
       return -EINVAL;
+    }
   }
 
   if (strlen(realname))
-    strncpy(devname, realname + 5, PATH_MAX -1);
+    strncpy(devname, realname + 5, PATH_MAX - 5);
   else
-    strncpy(devname, dev + 5, PATH_MAX-1);
+    strncpy(devname, dev + 5, strlen(dev) - 5);
 
-  devname[PATH_MAX-1] = '\0';
+  devname[PATH_MAX - 1] = '\0';
+
   for (p = devname; *p; ++p)
     if (*p == '/')
       *p = '!';


### PR DESCRIPTION
…ion symbol link

This patch fix the below case:
block -> /dev/disk/by-partuuid/413c40b8-8df2-4351-a046-c44d09489396
/dev/disk/by-partuuid/413c40b8-8df2-4351-a046-c44d09489396 -> ../../sdj2

Signed-off-by: Xinze Chi <xinze@xsky.com>