### PR TITLE
mount: do not print "unknown" option to kclient

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -201,8 +201,10 @@ static char *parse_options(const char *data, int *filesys_flags)
 			skip = 0;
 		} else {
 			skip = 0;
-			if (verboseflag)
-				printf("ceph: Unknown mount option %s\n",data);
+			if (verboseflag) {
+			  fprintf(stderr, "mount.ceph: unrecognized mount option \"%s\", "
+			                  "passing to kernel.\n", data);
+            }
 		}
 
 		/* Copy (possibly modified) option to out */


### PR DESCRIPTION
If these options were really unknown to the kernel client,
we would quickly find out when it returned an error.  No need
to mention them in the output of the userspace tool.

Fixes: http://tracker.ceph.com/issues/18159
Signed-off-by: John Spray <john.spray@redhat.com>