### PR TITLE
cmake: support for external rocksdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -501,6 +501,12 @@ if(WITH_UBSAN)
   endif()
 endif()
 
+# Rocksdb
+option(WITH_SYSTEM_ROCKSDB "require and build with system rocksdb" OFF)
+if (WITH_SYSTEM_ROCKSDB)
+  find_package(rocksdb REQUIRED)
+endif()
+
 # Boost
 option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 

--- a/cmake/modules/Findrocksdb.cmake
+++ b/cmake/modules/Findrocksdb.cmake
@@ -1,0 +1,18 @@
+# Find the native Rocksdb includes and library
+# This module defines
+#  ROCKSDB_INCLUDE_DIR, where to find rocksdb/db.h, Set when
+#                       ROCKSDB_INCLUDE_DIR is found.
+#  ROCKSDB_LIBRARIES, libraries to link against to use Rocksdb.
+#  ROCKSDB_FOUND, If false, do not try to use Rocksdb.
+
+find_path(ROCKSDB_INCLUDE_DIR rocksdb/db.h)
+
+find_library(ROCKSDB_LIBRARIES rocksdb)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Rocksdb DEFAULT_MSG
+  ROCKSDB_LIBRARIES ROCKSDB_INCLUDE_DIR)
+
+mark_as_advanced(
+  ROCKSDB_INCLUDE_DIR
+  ROCKSDB_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -714,48 +714,52 @@ install(TARGETS ceph-mon DESTINATION bin)
 # OSD/ObjectStore
 # make rocksdb statically
 
-set(ROCKSDB_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
+if (NOT WITH_SYSTEM_ROCKSDB)
+  set(ROCKSDB_CMAKE_ARGS -DCMAKE_POSITION_INDEPENDENT_CODE=ON)
 
-if(ALLOCATOR STREQUAL "jemalloc")
-  list(APPEND ROCKSDB_CMAKE_ARGS -DWITH_JEMALLOC=ON)
-endif()
+  if(ALLOCATOR STREQUAL "jemalloc")
+    list(APPEND ROCKSDB_CMAKE_ARGS -DWITH_JEMALLOC=ON)
+  endif()
 
-if (WITH_CCACHE AND CCACHE_FOUND)
-  list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER=ccache)
-  list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER_ARG1=${CMAKE_CXX_COMPILER})
-else(WITH_CCACHE AND CCACHE_FOUND)
-  list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
-endif(WITH_CCACHE AND CCACHE_FOUND)
+  if (WITH_CCACHE AND CCACHE_FOUND)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER=ccache)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER_ARG1=${CMAKE_CXX_COMPILER})
+  else(WITH_CCACHE AND CCACHE_FOUND)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
+  endif(WITH_CCACHE AND CCACHE_FOUND)
 
-list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
-list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
+  list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
+  list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-  list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
-endif()
+  if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
+  endif()
 
-# we use an external project and copy the sources to bin directory to ensure
-# that object files are built outside of the source tree.
-include(ExternalProject)
-ExternalProject_Add(rocksdb_ext
-  SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb
-  CMAKE_ARGS ${ROCKSDB_CMAKE_ARGS}
-  BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rocksdb
-  BUILD_COMMAND $(MAKE) rocksdblib
-  INSTALL_COMMAND "true")
+  # we use an external project and copy the sources to bin directory to ensure
+  # that object files are built outside of the source tree.
+  include(ExternalProject)
+  ExternalProject_Add(rocksdb_ext
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb
+    CMAKE_ARGS ${ROCKSDB_CMAKE_ARGS}
+    BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/rocksdb
+    BUILD_COMMAND $(MAKE) rocksdblib
+    INSTALL_COMMAND "true")
 
-# force rocksdb make to be called on each time
-ExternalProject_Add_Step(rocksdb_ext forcebuild
-  DEPENDEES configure
-  DEPENDERS build
-  COMMAND "true"
-  ALWAYS 1)
+  # force rocksdb make to be called on each time
+  ExternalProject_Add_Step(rocksdb_ext forcebuild
+    DEPENDEES configure
+    DEPENDERS build
+    COMMAND "true"
+    ALWAYS 1)
 
-set(ROCKSDB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/include)
+  set(ROCKSDB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/rocksdb/include)
 
-add_library(rocksdb STATIC IMPORTED)
-add_dependencies(rocksdb rocksdb_ext)
-set_property(TARGET rocksdb PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/rocksdb/librocksdblib.a")
+  add_library(rocksdb STATIC IMPORTED)
+  add_dependencies(rocksdb rocksdb_ext)
+  set_property(TARGET rocksdb PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_BINARY_DIR}/rocksdb/librocksdblib.a")
+  set(ROCKSDB_LIBRARIES rocksdb)
+
+endif(NOT WITH_SYSTEM_ROCKSDB)
 
 add_subdirectory(kv)
 add_subdirectory(os)

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
+target_link_libraries(kv ${LEVELDB_LIBRARIES} ${ROCKSDB_LIBRARIES} ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
 
 # rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.
 find_package(BZip2 QUIET)

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -27,8 +27,11 @@ set(merge_libs
   mon
   os
   osd
-  osdc
-  rocksdb)
+  osdc)
+
+if(NOT WITH_SYSTEM_ROCKSDB)
+  list(APPEND merge_libs ${ROCKSDB_LIBRARIES})
+endif(NOT WITH_SYSTEM_ROCKSDB)
 
 if(HAVE_ARMV8_CRC)
   list(APPEND merge_libs common_crc_aarch64)


### PR DESCRIPTION
add support for building with an external rocksdb. Some distros are now starting to support rocksdb (ubuntu for example http://packages.ubuntu.com/yakkety/librocksdb-dev). For Rook scenarios we'd like to build all ceph's external dependencies separately (in a build container). It also simplifies the build process as we don't have to passthrough toolchains etc. the ExternalProject_add.

The default is still to build from the submodule.