### PR TITLE
test/rados/list.cc: Memory leak in ceph_test_rados_api_list

### DIFF
--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -692,9 +692,10 @@ TEST_F(LibRadosList, EnumerateObjects) {
   {
     rados_object_list_item results[12];
     memset(results, 0, sizeof(rados_object_list_item) * 12);
-    int r = rados_object_list(ioctx,
-            c, rados_object_list_end(ioctx),
+    rados_object_list_cursor temp_end = rados_object_list_end(ioctx);
+    int r = rados_object_list(ioctx, c, temp_end,
             12, NULL, 0, results, &c);
+    rados_object_list_cursor_free(ioctx, temp_end);
     ASSERT_GE(r, 0);
     for (int i = 0; i < r; ++i) {
       std::string oid(results[i].oid, results[i].oid_length);


### PR DESCRIPTION
Valgrind flags a memory leak when we create a temporary from
rados_object_list_end()

Fixes: http://tracker.ceph.com/issues/18250

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>