### PR TITLE
librados: Memory leaks in object_list_begin and object_list_end

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -5941,7 +5941,7 @@ librados::ObjectCursor librados::IoCtx::object_list_begin()
 {
   hobject_t *h = new hobject_t(io_ctx_impl->objecter->enumerate_objects_begin());
   ObjectCursor oc;
-  oc.c_cursor = (rados_object_list_cursor)h;
+  oc.set((rados_object_list_cursor)h);
   return oc;
 }
 
@@ -5950,7 +5950,7 @@ librados::ObjectCursor librados::IoCtx::object_list_end()
 {
   hobject_t *h = new hobject_t(io_ctx_impl->objecter->enumerate_objects_end());
   librados::ObjectCursor oc;
-  oc.c_cursor = (rados_object_list_cursor)h;
+  oc.set((rados_object_list_cursor)h);
   return oc;
 }
 


### PR DESCRIPTION
We allocate a cursor in the constructor but simply reassign it in these
functions without cleaning up the original. We have a utility setter that
handles this exact case so we should use it.

Fixes: http://tracker.ceph.com/issues/18252

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>