### PR TITLE
librbd: ignore error when object map is already locked by current client

### DIFF
--- a/src/librbd/object_map/LockRequest.cc
+++ b/src/librbd/object_map/LockRequest.cc
@@ -54,6 +54,10 @@ Context *LockRequest<I>::handle_lock(int *ret_val) {
 
   if (*ret_val == 0) {
     return m_on_finish;
+  } else if (*ret_val == -EEXIST) {
+    // already locked by myself
+    *ret_val = 0;
+    return m_on_finish;
   } else if (m_broke_lock || *ret_val != -EBUSY) {
     lderr(cct) << "failed to lock object map: " << cpp_strerror(*ret_val)
                << dendl;


### PR DESCRIPTION
otherwise when using `rbd` cli to rollback image with object-map feature enabled, the following error message will be printed out on the screen, which is confusing to users:
```
  librbd::object_map::LockRequest: failed to lock object map: (17) File exists
```
Signed-off-by: runsisi <runsisi@zte.com.cn>