### PR TITLE
librbd: keep rbd_default_features setting as bitmask

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -476,6 +476,7 @@ set(libcommon_files
   common/ceph_strings.cc
   common/ceph_frag.cc
   common/config.cc
+  common/config_validators.cc
   common/utf8.c
   common/mime.c
   common/strtol.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1299,8 +1299,25 @@ OPTION(rbd_default_format, OPT_INT, 2)
 OPTION(rbd_default_order, OPT_INT, 22)
 OPTION(rbd_default_stripe_count, OPT_U64, 0) // changing requires stripingv2 feature
 OPTION(rbd_default_stripe_unit, OPT_U64, 0) // changing to non-object size requires stripingv2 feature
-SAFE_OPTION(rbd_default_features, OPT_STR, "layering,exclusive-lock,object-map,fast-diff,deep-flatten")   // only applies to format 2 images
 OPTION(rbd_default_data_pool, OPT_STR, "") // optional default pool for storing image data blocks
+
+/**
+ * RBD features are only applicable for v2 images. This setting accepts either
+ * an integer bitmask value or comma-delimited string of RBD feature names.
+ * This setting is always internally stored as an integer bitmask value. The
+ * mapping between feature bitmask value and feature name is as follows:
+ *
+ *  +1 -> layering
+ *  +2 -> striping
+ *  +4 -> exclusive-lock
+ *  +8 -> object-map
+ *  +16 -> fast-diff
+ *  +32 -> deep-flatten
+ *  +64 -> journaling
+ *  +128 -> data-pool
+ */
+SAFE_OPTION(rbd_default_features, OPT_STR, "layering,exclusive-lock,object-map,fast-diff,deep-flatten")
+OPTION_VALIDATOR(rbd_default_features)
 
 OPTION(rbd_default_map_options, OPT_STR, "") // default rbd map -o / --options
 

--- a/src/common/config_validators.cc
+++ b/src/common/config_validators.cc
@@ -1,0 +1,70 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/config_validators.h"
+#include "include/stringify.h"
+#include "include/rbd/features.h"
+#include <map>
+#include <sstream>
+#include <vector>
+#include <boost/algorithm/string.hpp>
+#include <boost/lexical_cast.hpp>
+
+int validate(md_config_t::option_rbd_default_features_t *,
+             std::string *value, std::string *error_message) {
+  static const std::map<std::string, uint64_t> FEATURE_MAP = {
+    {RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING},
+    {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
+    {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
+    {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
+    {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
+    {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
+    {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
+    {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
+  };
+  static_assert((RBD_FEATURE_DATA_POOL << 1) > RBD_FEATURES_ALL,
+                "new RBD feature added");
+
+  // convert user-friendly comma delimited feature name list to a bitmask
+  // that is used by the librbd API
+  uint64_t features = 0;
+  error_message->clear();
+
+  try {
+    features = boost::lexical_cast<decltype(features)>(*value);
+
+    uint64_t unsupported_features = (features & ~RBD_FEATURES_ALL);
+    if (unsupported_features != 0ull) {
+      features &= RBD_FEATURES_ALL;
+
+      std::stringstream ss;
+      ss << "ignoring unknown feature mask 0x"
+         << std::hex << unsupported_features;
+      *error_message = ss.str();
+    }
+  } catch (const boost::bad_lexical_cast& ) {
+    int r = 0;
+    std::vector<std::string> feature_names;
+    boost::split(feature_names, *value, boost::is_any_of(","));
+    for (auto feature_name: feature_names) {
+      boost::trim(feature_name);
+      auto feature_it = FEATURE_MAP.find(feature_name);
+      if (feature_it != FEATURE_MAP.end()) {
+        features += feature_it->second;
+      } else {
+        if (!error_message->empty()) {
+          *error_message += ", ";
+        }
+        *error_message += "ignoring unknown feature " + feature_name;
+        r = -EINVAL;
+      }
+    }
+
+    if (features == 0 && r == -EINVAL) {
+      features = RBD_FEATURES_DEFAULT;
+    }
+  }
+  *value = stringify(features);
+  return 0;
+}
+

--- a/src/common/config_validators.h
+++ b/src/common/config_validators.h
@@ -1,0 +1,17 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_CONFIG_VALIDATORS
+#define CEPH_CONFIG_VALIDATORS
+
+#include "config.h"
+#include <string>
+
+/**
+ * Global config value validators for the Ceph project
+ */
+
+int validate(md_config_t::option_rbd_default_features_t *type,
+             std::string *value, std::string *error_message);
+
+#endif // CEPH_CONFIG_VALIDATORS

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -64,38 +64,10 @@ std::string generate_image_id(librados::IoCtx &ioctx) {
   return id;
 }
 
-uint64_t parse_rbd_default_features(CephContext* cct)
+uint64_t get_rbd_default_features(CephContext* cct)
 {
-  int ret = 0;
-  uint64_t value = 0;
   auto str_val = cct->_conf->get_val<std::string>("rbd_default_features");
-  try {
-      value = boost::lexical_cast<decltype(value)>(str_val);
-  } catch (const boost::bad_lexical_cast& ) {
-    map<std::string, int> conf_vals = {{RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING},
-                                       {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
-                                       {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
-                                       {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
-                                       {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
-                                       {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
-                                       {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
-                                       {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
-    };
-    std::vector<std::string> strs;
-    boost::split(strs, str_val, boost::is_any_of(","));
-    for (auto feature: strs) {
-    	boost::trim(feature);
-      if (conf_vals.find(feature) != conf_vals.end()) {
-        value += conf_vals[feature];
-      } else {
-        ret = -EINVAL;
-        lderr(cct) << "ignoring unknown feature " << feature << dendl;
-      }
-    }
-    if (value == 0 && ret == -EINVAL)
-      value = RBD_FEATURES_DEFAULT;
-  }
-  return value;
+  return boost::lexical_cast<uint64_t>(str_val);
 }
 
 } // namespace util

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -197,7 +197,7 @@ private:
   Context *m_on_finish = nullptr;
 };
 
-uint64_t parse_rbd_default_features(CephContext* cct);
+uint64_t get_rbd_default_features(CephContext* cct);
 
 } // namespace util
 

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -135,7 +135,7 @@ CreateRequest<I>::CreateRequest(IoCtx &ioctx, const std::string &image_name,
   m_objmap_name = ObjectMap<>::object_map_name(m_image_id, CEPH_NOSNAP);
 
   if (image_options.get(RBD_IMAGE_OPTION_FEATURES, &m_features) != 0) {
-    m_features = util::parse_rbd_default_features(m_cct);
+    m_features = util::get_rbd_default_features(m_cct);
     m_negotiate_features = true;
   }
 

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -101,7 +101,7 @@ public:
 					       m_remote_ioctx));
 
     m_image_name = get_temp_image_name();
-    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
+    uint64_t features = librbd::util::get_rbd_default_features(g_ceph_context);
     features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;
     int order = 0;
     EXPECT_EQ(0, librbd::create(m_remote_ioctx, m_image_name.c_str(), 1 << 22,

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -86,7 +86,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
 
   void create_image(const string &pool_name, bool mirrored=true,
 		    string *image_name=nullptr) {
-    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
+    uint64_t features = librbd::util::get_rbd_default_features(g_ceph_context);
     string name = "image" + stringify(++m_image_number);
     if (mirrored) {
       features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;
@@ -135,7 +135,7 @@ TestPoolWatcher() : m_lock("TestPoolWatcherLock"),
       ictx->state->close();
     }
 
-    uint64_t features = librbd::util::parse_rbd_default_features(g_ceph_context);
+    uint64_t features = librbd::util::get_rbd_default_features(g_ceph_context);
     string name = "clone" + stringify(++m_image_number);
     if (mirrored) {
       features |= RBD_FEATURE_EXCLUSIVE_LOCK | RBD_FEATURE_JOURNALING;

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -343,7 +343,7 @@ std::string get_short_features_help(bool append_suffix) {
 
     std::string suffix;
     if (append_suffix) {
-      if ((pair.first & rbd::utils::parse_rbd_default_features(g_ceph_context)) != 0) {
+      if ((pair.first & rbd::utils::get_rbd_default_features(g_ceph_context)) != 0) {
         suffix += "+";
       }
       if ((pair.first & RBD_FEATURES_MUTABLE) != 0) {

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -543,7 +543,7 @@ int get_image_options(const boost::program_options::variables_map &vm,
     features = vm[at::IMAGE_FEATURES].as<uint64_t>();
     features_specified = true;
   } else {
-    features = parse_rbd_default_features(g_ceph_context);
+    features = get_rbd_default_features(g_ceph_context);
   }
 
   if (vm.count(at::IMAGE_STRIPE_UNIT)) {
@@ -874,40 +874,9 @@ std::string timestr(time_t t) {
   return buf;
 }
 
-// FIXME (asheplyakov): use function from librbd/Utils.cc
-
-uint64_t parse_rbd_default_features(CephContext* cct) 
-{
-  int ret = 0;
-  uint64_t value = 0;
+uint64_t get_rbd_default_features(CephContext* cct) {
   auto features = cct->_conf->get_val<std::string>("rbd_default_features");
-  try {
-    value = boost::lexical_cast<decltype(value)>(features);
-  } catch (const boost::bad_lexical_cast& ) {
-    map<std::string, int> conf_vals = {{RBD_FEATURE_NAME_LAYERING, RBD_FEATURE_LAYERING}, 
-                                       {RBD_FEATURE_NAME_STRIPINGV2, RBD_FEATURE_STRIPINGV2},
-                                       {RBD_FEATURE_NAME_EXCLUSIVE_LOCK, RBD_FEATURE_EXCLUSIVE_LOCK},
-                                       {RBD_FEATURE_NAME_OBJECT_MAP, RBD_FEATURE_OBJECT_MAP},
-                                       {RBD_FEATURE_NAME_FAST_DIFF, RBD_FEATURE_FAST_DIFF},
-                                       {RBD_FEATURE_NAME_DEEP_FLATTEN, RBD_FEATURE_DEEP_FLATTEN},
-                                       {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
-                                       {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
-    };
-    std::vector<std::string> strs;
-    boost::split(strs, features, boost::is_any_of(","));
-    for (auto feature: strs) {
-      boost::trim(feature);
-      if (conf_vals.find(feature) != conf_vals.end()) {
-        value += conf_vals[feature];
-      } else {
-        ret = -EINVAL;
-        std::cerr << "Warning: unknown rbd feature " << feature << std::endl;
-      }
-    }
-    if (value == 0 && ret == -EINVAL)
-      value = RBD_FEATURES_DEFAULT;
-  }
-  return value;
+  return boost::lexical_cast<uint64_t>(features);
 }
 
 } // namespace utils

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -135,7 +135,7 @@ std::string mirror_image_status_state(librbd::mirror_image_status_t status);
 std::string timestr(time_t t);
 
 // duplicate here to not include librbd_internal lib
-uint64_t parse_rbd_default_features(CephContext* cct);
+uint64_t get_rbd_default_features(CephContext* cct);
 
 } // namespace utils
 } // namespace rbd


### PR DESCRIPTION
Support both human readable, comma delimited list of feature
names and also integer bitmask value. Attempting to read the
setting will always result in the feature bitmask integer
value.

This is required to avoid breaking backwards compatibility with
librbd clients that are dependent on the older behavior (e.g.
OpenStack).

Fixes: http://tracker.ceph.com/issues/18247
Signed-off-by: Jason Dillaman <dillaman@redhat.com>