### PR TITLE
src: rename ReplicatedPG to PrimaryLogPG

### DIFF
--- a/doc/dev/object-store.rst
+++ b/doc/dev/object-store.rst
@@ -49,12 +49,12 @@
 
     "OSDMapTool" -> "OSDMap"
 
-    "PG" -> "ReplicatedPG"
+    "PG" -> "PrimaryLogPG"
     "PG" -> "ObjectStore"
     "PG" -> "OSDMap"
 
-    "ReplicatedPG" -> "ObjectStore"
-    "ReplicatedPG" -> "OSDMap"
+    "PrimaryLogPG" -> "ObjectStore"
+    "PrimaryLogPG" -> "OSDMap"
 
     "ObjectStore" -> "FileStore"
 

--- a/doc/dev/osd_internals/erasure_coding/ecbackend.rst
+++ b/doc/dev/osd_internals/erasure_coding/ecbackend.rst
@@ -193,7 +193,7 @@ Pipeline
 Reading src/osd/ExtentCache.h should have given a good idea of how
 operations might overlap.  There are several states involved in
 processing a write operation and an important invariant which
-isn't enforced by ReplicatedPG at a higher level which need to be
+isn't enforced by PrimaryLogPG at a higher level which need to be
 managed by ECBackend.  The important invariant is that we can't
 have uncacheable and rmw operations running at the same time
 on the same object.  For simplicity, we simply enforce that any

--- a/doc/dev/osd_internals/log_based_pg.rst
+++ b/doc/dev/osd_internals/log_based_pg.rst
@@ -5,19 +5,12 @@ Log Based PG
 Background
 ==========
 
-Why ReplicatedPG?
+Why PrimaryLogPG?
 -----------------
 
 Currently, consistency for all ceph pool types is ensured by primary
 log-based replication.  This goes for both erasure-coded and
-replicated pools.  If you ever find yourself asking "why is it that
-both replicated and erasure coded pools are implemented by
-ReplicatedPG.h/cc", that's why (though it definitely should be called
-LogBasedPG, should include peering, and PG should be an abstract
-interface defining only those things the OSD needs to know to route
-messages etc -- but we live in an imperfect world where git deals
-imperfectly with cherry-picking between branches where the file has
-different names).
+replicated pools.
 
 Primary log-based replication
 -----------------------------
@@ -55,7 +48,7 @@ newer cannot have completed without that log containing it) and the
 newest head remembered (clearly, all writes in the log were started,
 so it's fine for us to remember them) as the new head.  This is the
 main point of divergence between replicated pools and ec pools in
-PG/ReplicatedPG: replicated pools try to choose the newest valid
+PG/PrimaryLogPG: replicated pools try to choose the newest valid
 option to avoid the client needing to replay those operations and
 instead recover the other copies.  EC pools instead try to choose
 the *oldest* option available to them.
@@ -85,7 +78,7 @@ PGBackend
 So, the fundamental difference between replication and erasure coding
 is that replication can do destructive updates while erasure coding
 cannot.  It would be really annoying if we needed to have two entire
-implementations of ReplicatedPG, one for each of the two, if there are
+implementations of PrimaryLogPG, one for each of the two, if there are
 really only a few fundamental differences:
 
   1. How reads work -- async only, requires remote reads for ec

--- a/doc/dev/osd_internals/map_message_handling.rst
+++ b/doc/dev/osd_internals/map_message_handling.rst
@@ -97,7 +97,7 @@ If these conditions are not met, the op is either discarded or queued for later 
 CEPH_MSG_OSD_OP processing
 --------------------------
 
-ReplicatedPG::do_op handles CEPH_MSG_OSD_OP op and will queue it
+PrimaryLogPG::do_op handles CEPH_MSG_OSD_OP op and will queue it
 
   1. in wait_for_all_missing if it is a CEPH_OSD_OP_PGLS for a designated snapid and some object updates are still missing
   2. in waiting_for_active if the op may write but the scrubber is working

--- a/doc/dev/osd_internals/osd_overview.rst
+++ b/doc/dev/osd_internals/osd_overview.rst
@@ -81,7 +81,7 @@ Concepts
   See MapHandling
 
 *PG*
-  See src/osd/PG.* src/osd/ReplicatedPG.*
+  See src/osd/PG.* src/osd/PrimaryLogPG.*
 
   Objects in rados are hashed into *PGs* and *PGs* are placed via crush onto
   OSDs.  The PG structure is responsible for handling requests pertaining to

--- a/doc/dev/osd_internals/snaps.rst
+++ b/doc/dev/osd_internals/snaps.rst
@@ -65,7 +65,7 @@ order to determine which clones might need to be removed upon snap
 removal, we maintain a mapping from snap to *hobject_t* using the
 *SnapMapper*.
 
-See ReplicatedPG::SnapTrimmer, SnapMapper
+See PrimaryLogPG::SnapTrimmer, SnapMapper
 
 This trimming is performed asynchronously by the snap_trim_wq while the
 pg is clean and not scrubbing.

--- a/doc/dev/osd_internals/watch_notify.rst
+++ b/doc/dev/osd_internals/watch_notify.rst
@@ -32,7 +32,7 @@ Notify to the Watch and either:
 * if the Watch is *connected*, sends a Notify message to the client
 * if the Watch is *unconnected*, does nothing.
 
-When the Watch becomes connected (in ReplicatedPG::do_osd_op_effects),
+When the Watch becomes connected (in PrimaryLogPG::do_osd_op_effects),
 Notifies are resent to all remaining tracked Notify objects.
 
 Each Notify object tracks the set of un-notified Watchers via
@@ -53,8 +53,8 @@ A watch may be in one of 5 states:
 Case 2 occurs between when an OSD goes active and the ObjectContext
 for an object with watchers is loaded into memory due to an access.
 During Case 2, no state is registered for the watch.  Case 2
-transitions to Case 4 in ReplicatedPG::populate_obc_watchers() during
-ReplicatedPG::find_object_context.  Case 1 becomes case 3 via
+transitions to Case 4 in PrimaryLogPG::populate_obc_watchers() during
+PrimaryLogPG::find_object_context.  Case 1 becomes case 3 via
 OSD::do_osd_op_effects due to a watch operation.  Case 4,5 become case
 3 in the same way. Case 3 becomes case 4 when the connection resets
 on a watcher's session.

--- a/doc/dev/versions.rst
+++ b/doc/dev/versions.rst
@@ -10,7 +10,7 @@ to the pg log as transactions, and is incremented in all the places it
 used to be. The user_version is modified by manipulating the new
 OpContext::user_at_version and is also persisted via the pg log
 transactions.
-user_at_version is modified only in ReplicatedPG::prepare_transaction
+user_at_version is modified only in PrimaryLogPG::prepare_transaction
 when the op was a "user modify" (a non-watch write), and the durable
 user_version is updated according to the following rules:
 1) set user_at_version to the maximum of ctx->new_obs.oi.user_version+1

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -5,7 +5,7 @@
 #include "common/debug.h"
 
 #include "objclass/objclass.h"
-#include "osd/ReplicatedPG.h"
+#include "osd/PrimaryLogPG.h"
 #include "osd/osd_types.h"
 
 #include "osd/ClassHandler.h"
@@ -106,7 +106,7 @@ int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
                                  char *indata, int datalen,
                                  char **outdata, int *outdatalen)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist idata;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
@@ -135,7 +135,7 @@ int cls_call(cls_method_context_t hctx, const char *cls, const char *method,
 int cls_getxattr(cls_method_context_t hctx, const char *name,
                                  char **outdata, int *outdatalen)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist name_data;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
@@ -160,7 +160,7 @@ int cls_getxattr(cls_method_context_t hctx, const char *name,
 int cls_setxattr(cls_method_context_t hctx, const char *name,
                                  const char *value, int val_len)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist name_data;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
@@ -179,7 +179,7 @@ int cls_setxattr(cls_method_context_t hctx, const char *name,
 int cls_read(cls_method_context_t hctx, int ofs, int len,
                                  char **outdata, int *outdatalen)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_SYNC_READ;
   ops[0].op.extent.offset = ofs;
@@ -199,14 +199,14 @@ int cls_read(cls_method_context_t hctx, int ofs, int len,
 
 int cls_get_request_origin(cls_method_context_t hctx, entity_inst_t *origin)
 {
-  ReplicatedPG::OpContext **pctx = static_cast<ReplicatedPG::OpContext **>(hctx);
+  PrimaryLogPG::OpContext **pctx = static_cast<PrimaryLogPG::OpContext **>(hctx);
   *origin = (*pctx)->op->get_req()->get_orig_source_inst();
   return 0;
 }
 
 int cls_cxx_create(cls_method_context_t hctx, bool exclusive)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_CREATE;
   ops[0].op.flags = (exclusive ? CEPH_OSD_OP_FLAG_EXCL : 0);
@@ -215,7 +215,7 @@ int cls_cxx_create(cls_method_context_t hctx, bool exclusive)
 
 int cls_cxx_remove(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_DELETE;
   return (*pctx)->pg->do_osd_ops(*pctx, ops);
@@ -223,7 +223,7 @@ int cls_cxx_remove(cls_method_context_t hctx)
 
 int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   int ret;
   ops[0].op.op = CEPH_OSD_OP_STAT;
@@ -248,7 +248,7 @@ int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime)
 
 int cls_cxx_stat2(cls_method_context_t hctx, uint64_t *size, ceph::real_time *mtime)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   int ret;
   ops[0].op.op = CEPH_OSD_OP_STAT;
@@ -279,7 +279,7 @@ int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, bufferlist *outbl)
 int cls_cxx_read2(cls_method_context_t hctx, int ofs, int len,
                   bufferlist *outbl, uint32_t op_flags)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   int ret;
   ops[0].op.op = CEPH_OSD_OP_SYNC_READ;
@@ -301,7 +301,7 @@ int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, bufferlist *inbl)
 int cls_cxx_write2(cls_method_context_t hctx, int ofs, int len,
                    bufferlist *inbl, uint32_t op_flags)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_WRITE;
   ops[0].op.extent.offset = ofs;
@@ -313,7 +313,7 @@ int cls_cxx_write2(cls_method_context_t hctx, int ofs, int len,
 
 int cls_cxx_write_full(cls_method_context_t hctx, bufferlist *inbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_WRITEFULL;
   ops[0].op.extent.offset = 0;
@@ -324,7 +324,7 @@ int cls_cxx_write_full(cls_method_context_t hctx, bufferlist *inbl)
 
 int cls_cxx_replace(cls_method_context_t hctx, int ofs, int len, bufferlist *inbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(2);
   ops[0].op.op = CEPH_OSD_OP_TRUNCATE;
   ops[0].op.extent.offset = 0;
@@ -339,7 +339,7 @@ int cls_cxx_replace(cls_method_context_t hctx, int ofs, int len, bufferlist *inb
 int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
                      bufferlist *outbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist name_data;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
@@ -358,7 +358,7 @@ int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
 
 int cls_cxx_getxattrs(cls_method_context_t hctx, map<string, bufferlist> *attrset)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
   int r;
@@ -380,7 +380,7 @@ int cls_cxx_getxattrs(cls_method_context_t hctx, map<string, bufferlist> *attrse
 int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
                      bufferlist *inbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   bufferlist name_data;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
@@ -398,7 +398,7 @@ int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
 
 int cls_cxx_snap_revert(cls_method_context_t hctx, snapid_t snapid)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   ops[0].op.op = CEPH_OSD_OP_ROLLBACK;
   ops[0].op.snap.snapid = snapid;
@@ -407,7 +407,7 @@ int cls_cxx_snap_revert(cls_method_context_t hctx, snapid_t snapid)
 
 int cls_cxx_map_get_all_vals(cls_method_context_t hctx, map<string, bufferlist>* vals)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   int ret;
@@ -438,7 +438,7 @@ int cls_cxx_map_get_all_vals(cls_method_context_t hctx, map<string, bufferlist>*
 int cls_cxx_map_get_keys(cls_method_context_t hctx, const string &start_obj,
 			 uint64_t max_to_get, set<string> *keys)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   int ret;
@@ -465,7 +465,7 @@ int cls_cxx_map_get_vals(cls_method_context_t hctx, const string &start_obj,
 			 const string &filter_prefix, uint64_t max_to_get,
 			 map<string, bufferlist> *vals)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   int ret;
@@ -491,7 +491,7 @@ int cls_cxx_map_get_vals(cls_method_context_t hctx, const string &start_obj,
 
 int cls_cxx_map_read_header(cls_method_context_t hctx, bufferlist *outbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   int ret;
@@ -508,7 +508,7 @@ int cls_cxx_map_read_header(cls_method_context_t hctx, bufferlist *outbl)
 int cls_cxx_map_get_val(cls_method_context_t hctx, const string &key,
 			bufferlist *outbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   int ret;
@@ -541,7 +541,7 @@ int cls_cxx_map_get_val(cls_method_context_t hctx, const string &key,
 int cls_cxx_map_set_val(cls_method_context_t hctx, const string &key,
 			bufferlist *inbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   bufferlist& update_bl = op.indata;
@@ -557,7 +557,7 @@ int cls_cxx_map_set_val(cls_method_context_t hctx, const string &key,
 int cls_cxx_map_set_vals(cls_method_context_t hctx,
 			 const std::map<string, bufferlist> *map)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   bufferlist& update_bl = op.indata;
@@ -570,7 +570,7 @@ int cls_cxx_map_set_vals(cls_method_context_t hctx,
 
 int cls_cxx_map_clear(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
 
@@ -581,7 +581,7 @@ int cls_cxx_map_clear(cls_method_context_t hctx)
 
 int cls_cxx_map_write_header(cls_method_context_t hctx, bufferlist *inbl)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   op.indata.claim(*inbl);
@@ -593,7 +593,7 @@ int cls_cxx_map_write_header(cls_method_context_t hctx, bufferlist *inbl)
 
 int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> ops(1);
   OSDOp& op = ops[0];
   bufferlist& update_bl = op.indata;
@@ -610,7 +610,7 @@ int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)
 int cls_cxx_list_watchers(cls_method_context_t hctx,
 			  obj_list_watch_response_t *watchers)
 {
-  ReplicatedPG::OpContext **pctx = (ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
   vector<OSDOp> nops(1);
   OSDOp& op = nops[0];
   int r;
@@ -661,7 +661,7 @@ int cls_gen_rand_base64(char *dest, int size) /* size should be the required str
 
 uint64_t cls_current_version(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext *ctx = *(ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
 
   return ctx->pg->info.last_user_version;
 }
@@ -669,20 +669,20 @@ uint64_t cls_current_version(cls_method_context_t hctx)
 
 int cls_current_subop_num(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext *ctx = *(ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
 
   return ctx->current_osd_subop_num;
 }
 
 uint64_t cls_get_features(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext *ctx = *(ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
   return ctx->pg->get_osdmap()->get_up_osd_features();
 }
 
 uint64_t cls_get_client_features(cls_method_context_t hctx)
 {
-  ReplicatedPG::OpContext *ctx = *(ReplicatedPG::OpContext **)hctx;
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
   return ctx->op->get_req()->get_connection()->get_features();
 }
 

--- a/src/osd/CMakeLists.txt
+++ b/src/osd/CMakeLists.txt
@@ -9,7 +9,7 @@ set(osd_srcs
   OpRequest.cc
   PG.cc
   PGLog.cc
-  ReplicatedPG.cc
+  PrimaryLogPG.cc
   ReplicatedBackend.cc
   ECBackend.cc
   ECTransaction.cc

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -24,7 +24,7 @@
 #include "messages/MOSDECSubOpReadReply.h"
 #include "ECMsgTypes.h"
 
-#include "ReplicatedPG.h"
+#include "PrimaryLogPG.h"
 
 #define dout_subsys ceph_subsys_osd
 #define DOUT_PREFIX_ARGS this
@@ -910,7 +910,7 @@ void ECBackend::handle_sub_write(
     !op.backfill,
     localt);
 
-  ReplicatedPG *_rPG = dynamic_cast<ReplicatedPG *>(get_parent());
+  PrimaryLogPG *_rPG = dynamic_cast<PrimaryLogPG *>(get_parent());
   if (_rPG && !_rPG->is_undersized() &&
       (unsigned)get_parent()->whoami_shard().shard >= ec_impl->get_data_chunk_count())
     op.t.set_fadvise_flag(CEPH_OSD_OP_FLAG_FADVISE_DONTNEED);

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -520,7 +520,7 @@ public:
    * if you recall that a temp object created for object head foo will
    * only ever be referenced by other transactions on foo and aren't
    * reused).  Next, factor this part into a class and maintain one per
-   * ordering token.  Next, fixup ReplicatedPG's repop queue to be
+   * ordering token.  Next, fixup PrimaryLogPG's repop queue to be
    * partitioned by ordering token.  Finally, refactor the op pipeline
    * so that the log entries passed into submit_tranaction aren't
    * versioned.  We can't assign versions to them until we actually

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -48,7 +48,7 @@
 #include "os/FuseStore.h"
 #endif
 
-#include "ReplicatedPG.h"
+#include "PrimaryLogPG.h"
 
 
 #include "msg/Messenger.h"
@@ -3104,7 +3104,7 @@ PG* OSD::_make_pg(
   PG *pg;
   if (createmap->get_pg_type(pgid.pgid) == pg_pool_t::TYPE_REPLICATED ||
       createmap->get_pg_type(pgid.pgid) == pg_pool_t::TYPE_ERASURE)
-    pg = new ReplicatedPG(&service, createmap, pool, pgid);
+    pg = new PrimaryLogPG(&service, createmap, pool, pgid);
   else
     ceph_abort();
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -215,7 +215,7 @@ class Objecter;
 
 class Watch;
 class Notification;
-class ReplicatedPG;
+class PrimaryLogPG;
 
 class AuthAuthorizeHandlerRegistry;
 
@@ -1962,7 +1962,7 @@ private:
     ThreadPool::TPHandle &handle);
 
   friend class PG;
-  friend class ReplicatedPG;
+  friend class PrimaryLogPG;
 
 
  protected:

--- a/src/osd/PGTransaction.h
+++ b/src/osd/PGTransaction.h
@@ -509,7 +509,7 @@ public:
    * object clone from source case (make_writeable made a clone).
    *
    * This structure only requires that the source->sink graph be acyclic.
-   * This is much more general than is actually required by ReplicatedPG.
+   * This is much more general than is actually required by PrimaryLogPG.
    * Only 4 flavors of multi-object transactions actually happen:
    * 1) rename temp -> object for copyfrom
    * 2) clone head -> clone, modify head for make_writeable on normal head write

--- a/src/osd/Watch.cc
+++ b/src/osd/Watch.cc
@@ -7,7 +7,7 @@
 #include <map>
 
 #include "OSD.h"
-#include "ReplicatedPG.h"
+#include "PrimaryLogPG.h"
 #include "Watch.h"
 
 #include "common/config.h"
@@ -107,7 +107,7 @@ void Notify::do_timeout()
   for (set<WatchRef>::iterator i = _watchers.begin();
        i != _watchers.end();
        ++i) {
-    boost::intrusive_ptr<ReplicatedPG> pg((*i)->get_pg());
+    boost::intrusive_ptr<PrimaryLogPG> pg((*i)->get_pg());
     pg->lock();
     if (!(*i)->is_discarded()) {
       (*i)->cancel_notify(self.lock());
@@ -241,7 +241,7 @@ public:
   void finish(int) { ceph_abort(); /* not used */ }
   void complete(int) {
     dout(10) << "HandleWatchTimeout" << dendl;
-    boost::intrusive_ptr<ReplicatedPG> pg(watch->pg);
+    boost::intrusive_ptr<PrimaryLogPG> pg(watch->pg);
     OSDService *osd(watch->osd);
     osd->watch_lock.Unlock();
     pg->lock();
@@ -283,7 +283,7 @@ string Watch::gen_dbg_prefix() {
 }
 
 Watch::Watch(
-  ReplicatedPG *pg,
+  PrimaryLogPG *pg,
   OSDService *osd,
   ObjectContextRef obc,
   uint32_t timeout,
@@ -493,7 +493,7 @@ void Watch::notify_ack(uint64_t notify_id, bufferlist& reply_bl)
 }
 
 WatchRef Watch::makeWatchRef(
-  ReplicatedPG *pg, OSDService *osd,
+  PrimaryLogPG *pg, OSDService *osd,
   ObjectContextRef obc, uint32_t timeout, uint64_t cookie, entity_name_t entity, const entity_addr_t& addr)
 {
   WatchRef ret(new Watch(pg, osd, obc, timeout, cookie, entity, addr));
@@ -523,7 +523,7 @@ void WatchConState::reset(Connection *con)
   for (set<WatchRef>::iterator i = _watches.begin();
        i != _watches.end();
        ++i) {
-    boost::intrusive_ptr<ReplicatedPG> pg((*i)->get_pg());
+    boost::intrusive_ptr<PrimaryLogPG> pg((*i)->get_pg());
     pg->lock();
     if (!(*i)->is_discarded()) {
       if ((*i)->is_connected(con)) {

--- a/src/osd/Watch.h
+++ b/src/osd/Watch.h
@@ -26,9 +26,9 @@ enum WatcherState {
 };
 
 class OSDService;
-class ReplicatedPG;
-void intrusive_ptr_add_ref(ReplicatedPG *pg);
-void intrusive_ptr_release(ReplicatedPG *pg);
+class PrimaryLogPG;
+void intrusive_ptr_add_ref(PrimaryLogPG *pg);
+void intrusive_ptr_release(PrimaryLogPG *pg);
 struct ObjectContext;
 class MWatchNotify;
 
@@ -156,7 +156,7 @@ class Watch {
   CancelableContext *cb;
 
   OSDService *osd;
-  boost::intrusive_ptr<ReplicatedPG> pg;
+  boost::intrusive_ptr<PrimaryLogPG> pg;
   ceph::shared_ptr<ObjectContext> obc;
 
   std::map<uint64_t, NotifyRef> in_progress_notifies;
@@ -173,7 +173,7 @@ class Watch {
   bool discarded;
 
   Watch(
-    ReplicatedPG *pg, OSDService *osd,
+    PrimaryLogPG *pg, OSDService *osd,
     ceph::shared_ptr<ObjectContext> obc, uint32_t timeout,
     uint64_t cookie, entity_name_t entity,
     const entity_addr_t& addr);
@@ -212,14 +212,14 @@ public:
 
   string gen_dbg_prefix();
   static WatchRef makeWatchRef(
-    ReplicatedPG *pg, OSDService *osd,
+    PrimaryLogPG *pg, OSDService *osd,
     ceph::shared_ptr<ObjectContext> obc, uint32_t timeout, uint64_t cookie, entity_name_t entity, const entity_addr_t &addr);
   void set_self(WatchRef _self) {
     self = _self;
   }
 
   /// Does not grant a ref count!
-  boost::intrusive_ptr<ReplicatedPG> get_pg() { return pg; }
+  boost::intrusive_ptr<PrimaryLogPG> get_pg() { return pg; }
 
   ceph::shared_ptr<ObjectContext> get_obc() { return obc; }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4401,7 +4401,7 @@ public:
   ObjectContext()
     : ssc(NULL),
       destructor_callback(0),
-      lock("ReplicatedPG::ObjectContext::lock"),
+      lock("PrimaryLogPG::ObjectContext::lock"),
       unstable_writes(0), readers(0), writers_waiting(0), readers_waiting(0),
       blocked(false), requeue_scrub_on_unblock(false) {}
 


### PR DESCRIPTION
It's been confusing for a long time that EC pools are implemented by
ReplicatedPG.  What PG/ReplicatedPG really implement is the concept
of a PG where consistency is managed by the primary via a log.

Signed-off-by: Samuel Just <sjust@redhat.com>