### PR TITLE
client: fix the cross-quota rename boundary check conditions

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -11524,11 +11524,14 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
       return -EROFS;
   }
   if (cct->_conf->client_quota &&
-      fromdir != todir &&
-      (fromdir->quota.is_enable() ||
-       todir->quota.is_enable() ||
-       get_quota_root(fromdir, perm) != get_quota_root(todir, perm))) {
-    return -EXDEV;
+      fromdir != todir) {
+    Inode *fromdir_root =
+      fromdir->quota.is_enable() ? fromdir : get_quota_root(fromdir, perm);
+    Inode *todir_root =
+      todir->quota.is_enable() ? todir : get_quota_root(todir, perm);
+    if (fromdir_root != todir_root) {
+      return -EXDEV;
+    }
   }
 
   InodeRef target;


### PR DESCRIPTION
We were previously rejecting a rename if either of the involved directories
was a quota root, even if the other directory was part of the same quota
"tree". What we really want to do is identify the correct quota root
(whether local or ancestral) for each directory and compare them. So
now we do.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>