### PR TITLE
FileStore::_do_fiemap: do not reference fiemap after it is freed

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3212,13 +3212,14 @@ more:
     last = extent++;
   }
   const bool is_last = last->fe_flags & FIEMAP_EXTENT_LAST;
-  free(fiemap);
   if (!is_last) {
     uint64_t xoffset = last->fe_logical + last->fe_length - offset;
     offset = last->fe_logical + last->fe_length;
     len -= xoffset;
+    free(fiemap);
     goto more;
   }
+  free(fiemap);
 
   return r;
 }


### PR DESCRIPTION
It looks like c3748fa7 tried to fix this but didn't go far enough. We still
access last (which is derived from fiemap::fm_extends) if is_last is false.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>