### PR TITLE
tracing: Fix error in including all files in osd_tp

### DIFF
--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -26,8 +26,9 @@ function(add_tracing_library name tracings version)
     get_filename_component(tp ${tp_file} NAME_WE)
     list(APPEND hdrs
       ${header_dir}/${tp}.h)
+    list(APPEND tpfiles ${tp}.c)
   endforeach()
-  add_library(${name} SHARED ${hdrs} ${tp}.c)
+  add_library(${name} SHARED ${hdrs} ${tpfiles})
   target_link_libraries(${name} ${LTTNGUST_LIBRARIES} ${CMAKE_DL_LIBS})
   string(REGEX MATCH "^[0-9]+" soversion ${version})
   set_target_properties(${name} PROPERTIES


### PR DESCRIPTION
osd_tp is the only variable that is a list and with current logic only
the last file of the list will be included in the tracing library. This
patch is to address that issue

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>