### PR TITLE
client: set metadata["root"] from mount method when it's called with …

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5628,8 +5628,10 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
   }
 
   filepath fp(CEPH_INO_ROOT);
-  if (!mount_root.empty())
+  if (!mount_root.empty()) {
+    metadata["root"] = mount_root.c_str();
     fp = filepath(mount_root.c_str());
+  }
   while (true) {
     MetaRequest *req = new MetaRequest(CEPH_MDS_OP_GETATTR);
     req->set_filepath(fp);


### PR DESCRIPTION
…a pathname

Currently, we only set the root properly in the config file or the
--client_metadata command line option. If a userland client program
tries to call ceph_mount with a pathname, it's not being properly
set.

Since we already hold the mutex, we can just update it directly.

Signed-off-by: Jeff Layton <jlayton@redhat.com>