### PR TITLE
qa/tasks/admin_socket: subst in repo name

### DIFF
--- a/qa/suites/powercycle/osd/tasks/admin_socket_objecter_requests.yaml
+++ b/qa/suites/powercycle/osd/tasks/admin_socket_objecter_requests.yaml
@@ -10,4 +10,4 @@ tasks:
 - admin_socket:
     client.0:
       objecter_requests:
-        test: "http://git.ceph.com/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"
+        test: "http://git.ceph.com/?p={repo};a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"

--- a/qa/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
+++ b/qa/suites/rados/thrash/workloads/admin_socket_objecter_requests.yaml
@@ -10,4 +10,4 @@ tasks:
 - admin_socket:
     client.0:
       objecter_requests:
-        test: "http://git.ceph.com/?p=ceph.git;a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"
+        test: "http://git.ceph.com/?p={repo};a=blob_plain;f=src/test/admin_socket/objecter_requests;hb={branch}"

--- a/qa/tasks/admin_socket.py
+++ b/qa/tasks/admin_socket.py
@@ -11,6 +11,7 @@ import time
 from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from teuthology.parallel import parallel
+from teuthology.config import config as teuth_config
 
 log = logging.getLogger(__name__)
 
@@ -152,8 +153,14 @@ def _run_tests(ctx, client, tests):
 
             test_path = None
             if 'test' in config:
+                # hack: the git_url is always ceph-ci or ceph
+                git_url = teuth_config.get_ceph_git_url()
+                repo_name = 'ceph.git'
+                if git_url.count('ceph-ci'):
+                    repo_name = 'ceph-ci.git'
                 url = config['test'].format(
-                    branch=config.get('branch', 'master')
+                    branch=config.get('branch', 'master'),
+                    repo=repo_name,
                     )
                 test_path = os.path.join(tmp_dir, command)
                 remote.run(


### PR DESCRIPTION
It is either ceph.git or ceph-ci.git.

Signed-off-by: Sage Weil <sage@redhat.com>