### PR TITLE
rbd: remove dead code from rbdmap

### DIFF
--- a/src/rbdmap
+++ b/src/rbdmap
@@ -17,8 +17,6 @@ do_map() {
 		  ""|\#*)
 			continue
 			;;
-		  */*)
-			;;
 		  *)
 			DEV=rbd/$DEV
 			;;


### PR DESCRIPTION
This may have originally been intended differently, but the actual behavior is
that everything gets mapped under /dev/rbd/...

Signed-off-by: Nathan Cutler <ncutler@suse.com>