### PR TITLE
client: fix potential buffer overflow

### DIFF
--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -1004,8 +1004,8 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
   UserPerm perms = client->pick_my_perms();
   t.start();
 
-  char buf[1024];
-  char buf2[1024];
+  string buf;
+  string buf2;
 
   utime_t start = ceph_clock_now(client->cct);
 

--- a/src/client/Trace.cc
+++ b/src/client/Trace.cc
@@ -52,22 +52,22 @@ void Trace::start()
   _line = 1;
 }
 
-const char *Trace::peek_string(char *buf, const char *prefix)
+const char *Trace::peek_string(string &buf, const char *prefix)
 {
   //if (prefix) cout << "prefix '" << prefix << "' line '" << line << "'" << std::endl;
   if (prefix &&
       strstr(line.c_str(), "/prefix") == line.c_str()) {
-    strcpy(buf, prefix);
-    strcpy(buf + strlen(prefix),
-	   line.c_str() + strlen("/prefix"));
+    buf.clear();
+    buf.append(prefix);
+    buf.append(line.c_str() + strlen("/prefix"));
   } else {
-    strcpy(buf, line.c_str());
+    buf = line;
   }
-  return buf;
+  return buf.c_str();
 }
 
 
-const char *Trace::get_string(char *buf, const char *prefix)
+const char *Trace::get_string(string &buf, const char *prefix)
 {
   peek_string(buf, prefix);
 
@@ -77,5 +77,5 @@ const char *Trace::get_string(char *buf, const char *prefix)
   getline(*fs, line);
   //cout << "next line is " << line << std::endl;
 
-  return buf;
+  return buf.c_str();
 }

--- a/src/client/Trace.h
+++ b/src/client/Trace.h
@@ -51,11 +51,11 @@ class Trace {
 
   void start();
 
-  const char *peek_string(char *buf, const char *prefix);
-  const char *get_string(char *buf, const char *prefix);
+  const char *peek_string(string &buf, const char *prefix);
+  const char *get_string(string &buf, const char *prefix);
 
   int64_t get_int() {
-    char buf[20];
+    string buf;
     return atoll(get_string(buf, 0));
   }
   bool end() {


### PR DESCRIPTION
Trace::peek_string try to fill char *buf without any length check.
I think string buf is the better way to handle it.

Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>