### PR TITLE
osd/PG: fix the unreadable log in choose_acting

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1136,7 +1136,7 @@ void PG::calc_ec_acting(
 	}
       }
       if (want[i] == CRUSH_ITEM_NONE)
-	ss << " failed to fill position " << i << std::endl;
+	ss << " failed to fill position " << (int)i << std::endl;
     }
   }
 


### PR DESCRIPTION
To avoid the log like: failed to fill position ^B