### PR TITLE
common/admin-socket: fix potential buffer overflow

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -315,7 +315,7 @@ bool AdminSocket::do_accept()
   }
 
   char cmd[1024];
-  int pos = 0;
+  unsigned pos = 0;
   string c;
   while (1) {
     int ret = safe_read(connection_fd, &cmd[pos], 1);
@@ -353,7 +353,11 @@ bool AdminSocket::do_accept()
 	break;
       }
     }
-    pos++;
+    if (++pos >= sizeof(cmd)) {
+      lderr(m_cct) << "AdminSocket: error reading request too long" << dendl;
+      VOID_TEMP_FAILURE_RETRY(close(connection_fd));
+      return false;
+    }
   }
 
   bool rval = false;

--- a/src/test/admin_socket.cc
+++ b/src/test/admin_socket.cc
@@ -105,6 +105,20 @@ TEST(AdminSocket, SendNoOp) {
   ASSERT_EQ(true, asoct.shutdown());
 }
 
+TEST(AdminSocket, SendTooLongRequest) {
+  std::unique_ptr<AdminSocket>
+      asokc(new AdminSocket(g_ceph_context));
+  AdminSocketTest asoct(asokc.get());
+  ASSERT_EQ(true, asoct.shutdown());
+  ASSERT_EQ(true, asoct.init(get_rand_socket_path()));
+  AdminSocketClient client(get_rand_socket_path());
+  string version;
+  string request(16384, 'a');
+  //if admin_socket cannot handle it, segfault will happened.
+  ASSERT_NE("", client.do_request(request, &version));
+  ASSERT_EQ(true, asoct.shutdown());
+}
+
 class MyTest : public AdminSocketHook {
   bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& result) {
     std::vector<std::string> args;


### PR DESCRIPTION
Add code to ensure cmd[pos] is valid memory.

Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>