### PR TITLE
osd/PG: simplify the logic of backfill_targets checking

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1447,20 +1447,13 @@ bool PG::choose_acting(pg_shard_t &auth_log_shard_id, bool *history_les_bound)
   if (backfill_targets.empty()) {
     // Caller is GetInfo
     backfill_targets = want_backfill;
-    for (set<pg_shard_t>::iterator i = backfill_targets.begin();
-	 i != backfill_targets.end();
-	 ++i) {
-      assert(!stray_set.count(*i));
-    }
-  } else {
-    // Will not change if already set because up would have had to change
-    assert(backfill_targets == want_backfill);
-    // Verify that nothing in backfill is in stray_set
-    for (set<pg_shard_t>::iterator i = want_backfill.begin();
-	 i != want_backfill.end();
-	 ++i) {
-      assert(stray_set.find(*i) == stray_set.end());
-    }
+  }
+  // Will not change if already set because up would have had to change
+  // Verify that nothing in backfill is in stray_set
+  for (set<pg_shard_t>::iterator i = want_backfill.begin();
+      i != want_backfill.end();
+      ++i) {
+    assert(stray_set.find(*i) == stray_set.end());
   }
   dout(10) << "choose_acting want " << want << " (== acting) backfill_targets " 
 	   << want_backfill << dendl;


### PR DESCRIPTION
  the final state is backfill_targets equals want_backfill,
  and backfill shards should not included in stray_set.
  Signed-off-by: huangjun <hjwsm1989@gmail.com>