### PR TITLE
osd/osdmap: fix divide by zero error

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2992,8 +2992,11 @@ int OSDMap::summarize_mapping_stats(
       f->dump_unsigned("moved_pgs", moved_pg);
       f->dump_unsigned("total_pgs", total_pg);
     } else {
+      float percent = 0;
+      if (total_pg)
+        percent = (float)moved_pg * 100.0 / (float)total_pg;
       ss << "moved " << moved_pg << " / " << total_pg
-	 << " (" << ((float)moved_pg * 100.0 / (float)total_pg) << "%)\n";
+	 << " (" << percent << "%)\n";
     }
   }
   if (f) {


### PR DESCRIPTION
*** CID 1397255:  Incorrect expression  (DIVIDE_BY_ZERO)
/home/brad/working/src/ceph/src/osd/OSDMap.cc: 2995 in
OSDMap::summarize_mapping_stats(OSDMap*, const std::set<long,
std::less<long>, std::allocator<long>> *,
std::__cxx11::basic_string<char, std::char_traits<char>,
std::allocator<char>> *, ceph::Formatter *) const()
2989         f->open_object_section("utilization");
2990       if (newmap) {
2991         if (f) {
2992           f->dump_unsigned("moved_pgs", moved_pg);
2993           f->dump_unsigned("total_pgs", total_pg);
2994         } else {
>>>     CID 1397255:  Incorrect expression  (DIVIDE_BY_ZERO)
>>>     In expression "(float)moved_pg * 100. / (float)total_pg",
division by expression "total_pg" which may be zero has undefined
behavior.
2995           ss << "moved " << moved_pg << " / " << total_pg
2996       << " (" << ((float)moved_pg * 100.0 / (float)total_pg) <<
"%)\n";
2997         }
2998       }
2999       if (f) {
3000         f->dump_float("avg_pgs", avg_pg);

Signed-off-by: Yunchuan Wen <yunchuan.wen@kylin-cloud.com>