### PR TITLE
ceph-disk: do not create bluestore wal/db partitions by default

### DIFF
--- a/qa/workunits/ceph-disk/ceph-disk-test.py
+++ b/qa/workunits/ceph-disk/ceph-disk-test.py
@@ -467,10 +467,8 @@ class TestCephDisk(object):
              " " + disk)
         c.wait_for_osd_up(osd_uuid)
         device = json.loads(c.sh("ceph-disk list --format json " + disk))[0]
-        assert len(device['partitions']) == 4
+        assert len(device['partitions']) == 2
         c.check_osd_status(osd_uuid, 'block')
-        c.check_osd_status(osd_uuid, 'block.wal')
-        c.check_osd_status(osd_uuid, 'block.db')
         c.helper("pool_read_write")
         c.destroy_osd(osd_uuid)
         c.sh("ceph-disk --verbose zap " + disk)

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1813,6 +1813,44 @@ class Prepare(object):
         parser = subparsers.add_parser(
             'prepare',
             parents=parents,
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=textwrap.fill(textwrap.dedent("""\
+            If the --bluestore argument is given, a bluestore objectstore
+            will be used instead of the legacy filestore objectstore.
+
+            When an entire device is prepared for bluestore, two
+            partitions are created. The first partition is for metadata,
+            the second partition is for blocks that contain data.
+
+            Unless explicitly specified with --block.db or
+            --block.wal, the bluestore DB and WAL data is stored on
+            the main block device. For instance:
+
+                ceph-disk prepare --bluestore /dev/sdc
+
+            Will create
+
+                /dev/sdc1 for osd metadata
+                /dev/sdc2 for block, db, and wal data (the rest of the disk)
+
+
+            If either --block.db or --block.wal are specified to be
+            the same whole device, they will be created as partition
+            three and four respectively. For instance:
+
+                ceph-disk prepare --bluestore \\
+                      --block.db /dev/sdc \\
+                      --block.wal /dev/sdc \\
+                      /dev/sdc
+
+            Will create
+
+                /dev/sdc1 for osd metadata
+                /dev/sdc2 for block (the rest of the disk)
+                /dev/sdc3 for db
+                /dev/sdc4 for wal
+
+            """)),
             help='Prepare a directory or disk for a Ceph OSD',
         )
         parser.set_defaults(
@@ -1888,7 +1926,13 @@ class PrepareBluestore(Prepare):
     def prepare_locked(self):
         if self.data.args.dmcrypt:
             self.lockbox.prepare()
-        self.data.prepare(self.blockdb, self.blockwal, self.block)
+        to_prepare_list = []
+        if getattr(self.data.args, 'block.db'):
+            to_prepare_list.append(self.blockdb)
+        if getattr(self.data.args, 'block.wal'):
+            to_prepare_list.append(self.blockwal)
+        to_prepare_list.append(self.block)
+        self.data.prepare(*to_prepare_list)
 
 
 class Space(object):
@@ -2241,6 +2285,9 @@ class PrepareBluestoreBlockDB(PrepareSpace):
             num = 0
         return num
 
+    def wants_space(self):
+        return False
+
     @staticmethod
     def parser():
         parser = PrepareSpace.parser('block.db', positional=False)
@@ -2275,6 +2322,9 @@ class PrepareBluestoreBlockWAL(PrepareSpace):
         else:
             num = 0
         return num
+
+    def wants_space(self):
+        return False
 
     @staticmethod
     def parser():


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18291

Signed-off-by: Loic Dachary <loic@dachary.org>