### PR TITLE
osd/PrimaryLogPG: don't truncate if we don't have to for WRITEFULL

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5312,7 +5312,11 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  op.flags = op.flags | CEPH_OSD_OP_FLAG_FADVISE_DONTNEED;
 
 	maybe_create_new_object(ctx);
-	t->truncate(soid, 0);
+	if (pool.info.require_rollback()) {
+	  t->truncate(soid, 0);
+	} else if (obs.exists && op.extent.length < oi.size) {
+	  t->truncate(soid, op.extent.length);
+	}
 	if (op.extent.length) {
 	  t->write(soid, 0, op.extent.length, osd_op.indata, op.flags);
 	}


### PR DESCRIPTION
Signed-off-by: Samuel Just <sjust@redhat.com>