### PR TITLE
ceph.in: allow 'flags' to not be present in cmddescs

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -342,7 +342,9 @@ def format_help(cmddict, partial=None):
 
         if not cmd['help']:
             continue
-        if cmd['flags'] is not None and ((cmd['flags'] & (FLAG_OBSOLETE | FLAG_DEPRECATED)) != 0):
+        flags = cmd.get('flags')
+        if (flags is not None and
+            (flags & (FLAG_OBSOLETE | FLAG_DEPRECATED)) != 0):
             continue
         concise = concise_sig(cmd['sig'])
         if partial and not concise.startswith(partial):


### PR DESCRIPTION
the 'flags' key in the command description dict may not be
present on older monitors.  Check for existence before
using it.

Introduced in 61d63433dfdcc08ecc21ba4f645794da5e01823c

Fixes: http://tracker.ceph.com/issues/18297
Signed-off-by: Dan Mick <dan.mick@redhat.com>