### PR TITLE
doc: explain rgw_fcgi_socket_backlog in rgw/config-ref.rst

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -47,6 +47,11 @@ Ceph configuration file, the default value will be set automatically.
 :Type: String
 :Default: N/A
 
+``rgw fcgi socket backlog``
+
+:Description: The socket backlog for fcgi.
+:Type: Integer
+:Default: ``1024``
 
 ``rgw host``
 


### PR DESCRIPTION
It's a useful configure. User need to increase backlog limit if their services have lot of concurrently requests.

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>