### PR TITLE
doc: Added osd_agent_max_low_ops, osd_agent_max_ops config reference

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -505,6 +505,22 @@ recovery operations to ensure optimal performance during recovery.
 :Type: 32-bit Integer
 :Default: ``5``
 
+
+``osd agent max ops``
+
+:Description: The maximum number of agent flush ops for tiering flushing.
+:Type: 32-bit Integer
+:Default: ``4``
+
+
+``osd agent max low ops``
+
+:Description: The maximum number of low speed agent flush ops for tiering flushing.
+:Type: 32-bit Integer
+:Default: ``2``
+
+
+
 .. index:: OSD; backfilling
 
 Backfilling


### PR DESCRIPTION
Describes 'osd agent max low ops' and 'osd agent max ops', which were
added to config_opts.h, but no any desciption.

Signed-off-by: Zhong Jiajia <zhong2plus@gmail.com>