### PR TITLE
msg/async: assert if compiled code doesn't support the configured ms_…

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -68,6 +68,9 @@ std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string 
     return std::make_shared<DPDKStack>(c, t);
 #endif
 
+  lderr(c) << __func__ << " ms_async_transport_type " << t <<
+    " is not supported! " << dendl;
+  ceph_abort();
   return nullptr;
 }
 
@@ -83,6 +86,10 @@ Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned
   else if (type == "dpdk")
     return new DPDKWorker(c, i);
 #endif
+
+  lderr(c) << __func__ << " ms_async_transport_type " << type <<
+    " is not supported! " << dendl;
+  ceph_abort();
   return nullptr;
 }
 


### PR DESCRIPTION
…async_transport_type

for example, currently there is a crash when using the async stack (access of null pointer)
in case the user configured rdma for a code that was not compiled with RDMA

Signed-off-by: Avner BenHanoch <avnerb@mellanox.com>