### PR TITLE
src/CMakeLists.txt: disable -Werror on rocksdb

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -700,6 +700,10 @@ endif(WITH_CCACHE AND CCACHE_FOUND)
 list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
 list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+  list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
+endif()
+
 # we use an external project and copy the sources to bin directory to ensure
 # that object files are built outside of the source tree.
 include(ExternalProject)


### PR DESCRIPTION
The Rocksdb code under Clang complains about:
/home/jenkins/workspace/ceph-master/src/rocksdb/util/thread_local.h:205:5:
  error: macro expansion producing 'defined' has undefined behavior
  [-Werror,-Wexpansion-to-defined]
    ^
/home/jenkins/workspace/ceph-master/src/rocksdb/util/thread_local.h:22:4:
  note: expanded from macro 'ROCKSDB_SUPPORT_THREAD_LOCAL'
  !defined(OS_WIN) && !defined(OS_MACOSX) && !defined(IOS_CROSS_COMPILE)
   ^`
So under Clang disable -Werror

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>