### PR TITLE
common/str_list.h: fix clang warning about std::move

### DIFF
--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -96,7 +96,7 @@ static inline std::vector<std::string> get_str_vec(const std::string& str)
   std::vector<std::string> str_vec;
   const char *delims = ";,= \t";
   get_str_vec(str, delims, str_vec);
-  return std::move(str_vec);
+  return str_vec;
 }
 
 #endif


### PR DESCRIPTION
/home/jenkins/workspace/ceph-master/src/include/str_list.h:99:10: warning: moving a local object in a return statement prevents copy elision [-Wpessimizing-move]
  return std::move(str_vec);
         ^
/home/jenkins/workspace/ceph-master/src/include/str_list.h:99:10: note: remove std::move call here
  return std::move(str_vec);
         ^~~~~~~~~~       ~
1 warning generated.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>