### PR TITLE
qa/workunits: include extension for nose tests

### DIFF
--- a/qa/workunits/fs/test_python.sh
+++ b/qa/workunits/fs/test_python.sh
@@ -2,5 +2,5 @@
 
 # Running as root because the filesystem root directory will be
 # owned by uid 0, and that's where we're writing.
-sudo nosetests -v $(dirname $0)/../../../src/test/pybind/test_cephfs
+sudo nosetests -v $(dirname $0)/../../../src/test/pybind/test_cephfs.py
 exit 0

--- a/qa/workunits/rados/test_python.sh
+++ b/qa/workunits/rados/test_python.sh
@@ -1,4 +1,4 @@
 #!/bin/sh -ex
 
-${PYTHON:-python} -m nose -v $(dirname $0)/../../../src/test/pybind/test_rados
+${PYTHON:-python} -m nose -v $(dirname $0)/../../../src/test/pybind/test_rados.py
 exit 0

--- a/qa/workunits/rbd/test_librbd_python.sh
+++ b/qa/workunits/rbd/test_librbd_python.sh
@@ -4,8 +4,8 @@ relpath=$(dirname $0)/../../../src/test/pybind
 
 if [ -n "${VALGRIND}" ]; then
   valgrind --tool=${VALGRIND} --suppressions=${TESTDIR}/valgrind.supp \
-    nosetests -v $relpath/test_rbd
+    nosetests -v $relpath/test_rbd.py
 else
-  nosetests -v $relpath/test_rbd
+  nosetests -v $relpath/test_rbd.py
 fi
 exit 0


### PR DESCRIPTION
When you have a relative path you have to include the extension.
Weird.

Signed-off-by: Sage Weil <sage@redhat.com>