### PR TITLE
client: fix clang warn of "argument is an uninitialized value"

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7130,7 +7130,9 @@ int Client::opendir(const char *relpath, dir_result_t **dirpp, const UserPerm& p
       return r;
   }
   r = _opendir(in.get(), dirpp, perms);
-  tout(cct) << (unsigned long)*dirpp << std::endl;
+  /* if ENOTDIR, dirpp will be an uninitialized point and it's very dangerous to access its value */
+  if (r != -ENOTDIR)
+      tout(cct) << (unsigned long)*dirpp << std::endl;
   return r;
 }
 


### PR DESCRIPTION
http://people.redhat.com/bhubbard/scan-build/report-faad49.html#EndPath

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>