### PR TITLE
os/filestore: version will be uninitialized varible if store_version doesn't exist

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -1255,8 +1255,6 @@ int FileStore::version_stamp_is_valid(uint32_t *version)
   int ret = safe_read_file(basedir.c_str(), "store_version",
       bp.c_str(), bp.length());
   if (ret < 0) {
-    if (ret == -ENOENT)
-      return 0;
     return ret;
   }
   bufferlist bl;
@@ -1286,6 +1284,11 @@ int FileStore::upgrade()
   dout(1) << "upgrade" << dendl;
   uint32_t version;
   int r = version_stamp_is_valid(&version);
+
+  if (r == -ENOENT) {
+      derr << "The store_version file doesn't exist." << dendl;
+      return -EINVAL;
+  }
   if (r < 0)
     return r;
   if (r == 1)


### PR DESCRIPTION
The logic of code is not changed.

http://people.redhat.com/bhubbard/scan-build/report-95c661.html#EndPath

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>