### PR TITLE
os/bluestore: add perf variable for throttle info in bluestore

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -92,6 +92,12 @@ enum {
   l_bluestore_write_small_wal,
   l_bluestore_write_small_pre_read,
   l_bluestore_write_small_new,
+
+  l_bluestore_cur_ops_in_queue,
+  l_bluestore_cur_bytes_in_queue,
+  l_bluestore_cur_ops_in_wal_queue,
+  l_bluestore_cur_bytes_in_wal_queue,
+
   l_bluestore_txc,
   l_bluestore_onode_reshard,
   l_bluestore_blob_split,
@@ -2175,6 +2181,10 @@ private:
 			CollectionRef& d,
 			unsigned bits, int rem);
 
+  void op_queue_reserve_throttle(TransContext *txc);
+  void op_queue_release_throttle(TransContext *txc);
+  void op_queue_reserve_wal_throttle(TransContext *txc);
+  void op_queue_release_wal_throttle(TransContext *txc);
 };
 
 inline ostream& operator<<(ostream& out, const BlueStore::OpSequencer& s) {


### PR DESCRIPTION
Signed-off-by: Pan Liu <pan.liu@istuary.com>

FileStore already has these info. But not in bluestore yet.