### PR TITLE
osd/osd_types: print notify-ack op properly

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5313,6 +5313,7 @@ ostream& operator<<(ostream& out, const OSDOp& op)
 	out << " gen " << op.op.watch.gen;
       break;
     case CEPH_OSD_OP_NOTIFY:
+    case CEPH_OSD_OP_NOTIFY_ACK:
       out << " cookie " << op.op.notify.cookie;
       break;
     case CEPH_OSD_OP_COPY_GET:


### PR DESCRIPTION
Not like "[notify-ack 0~0]"!

Signed-off-by: Sage Weil <sage@redhat.com>