### PR TITLE
msg/async/net_handler.cc: Do not apply SO_REUSEADDR for FreeBSD

### DIFF
--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -40,6 +40,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
     return -errno;
   }
 
+#if !defined(__FreeBSD__)
   /* Make sure connection-intensive things like the benchmark
    * will be able to close/open sockets a zillion of times */
   if (reuse_addr) {
@@ -50,6 +51,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
       return -errno;
     }
   }
+#endif
 
   return s;
 }


### PR DESCRIPTION
FreeBSD seems to work different whe SO_REUSEADDR is set on the messenger sockets.
SO_REUSEADDR was mainly used to allow for enough sockets during testing and benchmarking.
Very likely we can do without.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>