### PR TITLE
common/config_opts.h: FreeBSD timing changed due to no SO_REUSEADDR

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -191,8 +191,14 @@ OPTION(ms_dispatch_throttle_bytes, OPT_U64, 100 << 20)
 OPTION(ms_bind_ipv6, OPT_BOOL, false)
 OPTION(ms_bind_port_min, OPT_INT, 6800)
 OPTION(ms_bind_port_max, OPT_INT, 7300)
+#if !defined(__FreeBSD__)
 OPTION(ms_bind_retry_count, OPT_INT, 3) // If binding fails, how many times do we retry to bind
 OPTION(ms_bind_retry_delay, OPT_INT, 5) // Delay between attemps to bind
+#else
+// FreeBSD does not use SO_REAUSEADDR so allow for a bit more time per default
+OPTION(ms_bind_retry_count, OPT_INT, 6) // If binding fails, how many times do we retry to bind
+OPTION(ms_bind_retry_delay, OPT_INT, 6) // Delay between attemps to bind
+#endif
 OPTION(ms_rwthread_stack_bytes, OPT_U64, 1024 << 10)
 OPTION(ms_tcp_read_timeout, OPT_U64, 900)
 OPTION(ms_pq_max_tokens_per_priority, OPT_U64, 16777216)


### PR DESCRIPTION
Some tests could run into max retries if the server is seriously loaded.
So allow for more time, and tries.

One of the tests that failed was:
    test-erasure-code-plugins.sh

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>