### PR TITLE
osd/OSDMap: Uncomment code to enable private default constructors

### DIFF
--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -214,7 +214,7 @@ PyObject *PyModules::get_python(const std::string &what)
 
     cluster_state.with_osdmap([this, &f](const OSDMap &osd_map){
       cluster_state.with_pgmap(
-          [osd_map, &f](const PGMap &pg_map) {
+          [&osd_map, &f](const PGMap &pg_map) {
         pg_map.dump_fs_stats(nullptr, &f, true);
         pg_map.dump_pool_stats(osd_map, nullptr, &f, true);
       });

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -275,12 +275,10 @@ private:
   }
 
   // no copying
-  /* oh, how i long for c++11...
 private:
   OSDMap(const OSDMap& other) = default;
-  const OSDMap& operator=(const OSDMap& other) = default;
+  OSDMap& operator=(const OSDMap& other) = default;
 public:
-  */
 
   void deepish_copy_from(const OSDMap& o) {
     *this = o;

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -41,7 +41,7 @@ TYPE_FEATUREFUL(entity_inst_t)
 #include "osd/OSDMap.h"
 TYPE(osd_info_t)
 TYPE(osd_xinfo_t)
-TYPE_FEATUREFUL_STRAYDATA(OSDMap)
+TYPE_FEATUREFUL_NOCOPY(OSDMap)
 TYPE_FEATUREFUL_STRAYDATA(OSDMap::Incremental)
 
 #include "crush/CrushWrapper.h"

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1044,7 +1044,7 @@ int get_pg_metadata(ObjectStore *store, bufferlist &bl, metadata_section &ms,
     bufferlist findmap_bl;
     int ret = get_osdmap(store, ms.map_epoch, findmap, findmap_bl);
     if (ret == 0) {
-      ms.osdmap = findmap;
+      ms.osdmap.deepish_copy_from(findmap);
     } else {
       cerr << "WARNING: No OSDMap in old export,"
            " some objects may be ignored due to a split" << std::endl;


### PR DESCRIPTION
C++11 is here so let's enable this code.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>