### PR TITLE
osd: fix CEPH_OSD_FLAG_RWORDERED

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9322,6 +9322,10 @@ int OSD::init_op_flags(OpRequestRef& op)
   // client flags have no bearing on whether an op is a read, write, etc.
   op->rmw_flags = 0;
 
+  if (m->has_flag(CEPH_OSD_FLAG_RWORDERED)) {
+    op->set_force_rwordered();
+  }
+
   // set bits based on op codes, called methods.
   for (iter = m->ops.begin(); iter != m->ops.end(); ++iter) {
     if ((iter->op.op == CEPH_OSD_OP_WATCH &&

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -96,7 +96,9 @@ bool OpRequest::may_write() {
   return need_write_cap() || check_rmw(CEPH_OSD_RMW_FLAG_CLASS_WRITE);
 }
 bool OpRequest::may_cache() { return check_rmw(CEPH_OSD_RMW_FLAG_CACHE); }
-bool OpRequest::rwordered_forced() { return check_rmw(CEPH_OSD_RMW_FLAG_CACHE); }
+bool OpRequest::rwordered_forced() {
+  return check_rmw(CEPH_OSD_RMW_FLAG_RWORDERED);
+}
 bool OpRequest::rwordered() {
   return may_write() || may_cache() || rwordered_forced();
 }


### PR DESCRIPTION
Broke this in 3a2ed3b136de68192f661b6992cbb96ce6aafd20.

Signed-off-by: Sage Weil <sage@redhat.com>