### PR TITLE
common: implement flag to control whether global_init_*() writes pidfile

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -80,7 +80,7 @@ int main(int argc, const char **argv, const char *envp[]) {
 
   auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
 			 CODE_ENVIRONMENT_DAEMON,
-			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
+			 CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS | CINIT_FLAG_NO_PIDFILES);
   for (std::vector<const char*>::iterator i = args.begin(); i != args.end(); ) {
     if (ceph_argparse_double_dash(args, i)) {
       break;

--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -40,6 +40,9 @@ enum common_init_flags_t {
 
   // don't drop privileges
   CINIT_FLAG_DEFER_DROP_PRIVILEGES = 0x10,
+
+  // don't do pidfiles
+  CINIT_FLAG_NO_PIDFILES = 0x20,
 };
 
 /*

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -353,8 +353,9 @@ int global_init_prefork(CephContext *cct)
   const md_config_t *conf = cct->_conf;
   if (!conf->daemonize) {
 
-    if (pidfile_write(conf) < 0)
-      exit(1);
+    if (!(cct->get_init_flags() & CINIT_FLAG_NO_PIDFILES))
+      if (pidfile_write(conf) < 0)
+        exit(1);
 
     if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
 	(cct->get_set_uid() || cct->get_set_gid())) {
@@ -423,8 +424,9 @@ void global_init_postfork_start(CephContext *cct)
   }
 
   const md_config_t *conf = cct->_conf;
-  if (pidfile_write(conf) < 0)
-    exit(1);
+  if (!(cct->get_init_flags() & CINIT_FLAG_NO_PIDFILES))
+    if (pidfile_write(conf) < 0)
+      exit(1);
 
   if ((cct->get_init_flags() & CINIT_FLAG_DEFER_DROP_PRIVILEGES) &&
       (cct->get_set_uid() || cct->get_set_gid())) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18309
Signed-off-by: Nathan Cutler <ncutler@suse.com>