### PR TITLE
librados,osdc: kill ack vs commit distinction

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8310,7 +8310,6 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 		   in->snaprealm->get_snap_context(),
 		   ceph::real_clock::now(),
 		   0,
-		   NULL,
 		   NULL);
 
   bufferlist inline_version_bl;
@@ -8331,7 +8330,6 @@ int Client::uninline_data(Inode *in, Context *onfinish)
 		   in->snaprealm->get_snap_context(),
 		   ceph::real_clock::now(),
 		   0,
-		   NULL,
 		   onfinish);
 
   return 0;
@@ -12888,14 +12886,14 @@ int Client::check_pool_perm(Inode *in, int need)
     rd_op.stat(NULL, (ceph::real_time*)nullptr, NULL);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), rd_op,
-		     nullsnapc, ceph::real_clock::now(), 0, &rd_cond, NULL);
+		     nullsnapc, ceph::real_clock::now(), 0, &rd_cond);
 
     C_SaferCond wr_cond;
     ObjectOperation wr_op;
     wr_op.create(true);
 
     objecter->mutate(oid, OSDMap::file_to_object_locator(in->layout), wr_op,
-		     nullsnapc, ceph::real_clock::now(), 0, &wr_cond, NULL);
+		     nullsnapc, ceph::real_clock::now(), 0, &wr_cond);
 
     client_lock.Unlock();
     int rd_ret = rd_cond.wait();

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8918,9 +8918,9 @@ int Client::_write(Fh *f, int64_t offset, uint64_t size, const char *buf,
     get_cap_ref(in, CEPH_CAP_FILE_BUFFER);  // released by onsafe callback
 
     filer->write_trunc(in->ino, &in->layout, in->snaprealm->get_snap_context(),
-			   offset, size, bl, ceph::real_clock::now(), 0,
-			   in->truncate_size, in->truncate_seq,
-		       NULL, onfinish);
+		       offset, size, bl, ceph::real_clock::now(), 0,
+		       in->truncate_size, in->truncate_seq,
+		       onfinish);
     client_lock.Unlock();
     flock.Lock();
 
@@ -12269,10 +12269,10 @@ int Client::_fallocate(Fh *fh, int mode, int64_t offset, int64_t length)
 
       _invalidate_inode_cache(in, offset, length);
       filer->zero(in->ino, &in->layout,
-		      in->snaprealm->get_snap_context(),
-		      offset, length,
-		      ceph::real_clock::now(),
-		      0, true, onfinish);
+		  in->snaprealm->get_snap_context(),
+		  offset, length,
+		  ceph::real_clock::now(),
+		  0, true, onfinish);
       in->mtime = ceph_clock_now();
       in->change_attr++;
       mark_caps_dirty(in, CEPH_CAP_FILE_WR);

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12061,7 +12061,6 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   Cond cond;
   bool done;
   int r = 0;
-  Context *onack;
   Context *onsafe;
 
   if (length == 0) {
@@ -12070,13 +12069,11 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   if (true || sync) {
     /* if write is stable, the epilogue is waiting on
      * flock */
-    onack = new C_NoopContext;
     onsafe = new C_SafeCond(&flock, &cond, &done, &r);
     done = false;
   } else {
     /* if write is unstable, we just place a barrier for
      * future commits to wait on */
-    onack = new C_NoopContext;
     /*onsafe = new C_Block_Sync(this, vino.ino,
 			      barrier_interval(offset, offset + length), &r);
     */
@@ -12105,7 +12102,6 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
 		  bl,
 		  ceph::real_clock::now(),
 		  0,
-		  onack,
 		  onsafe);
 
   client_lock.Unlock();
@@ -12117,9 +12113,9 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   }
 
   if (r < 0) {
-      return r;
+    return r;
   } else {
-      return length;
+    return length;
   }
 }
 

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -400,7 +400,7 @@ protected:
 
 public:
   entity_name_t get_myname() { return messenger->get_myname(); } 
-  void sync_write_commit(InodeRef& in);
+  void _sync_write_commit(Inode *in);
 
 protected:
   Filer                 *filer;     
@@ -498,7 +498,6 @@ protected:
   friend class C_Client_DentryInvalidate;  // calls dentry_invalidate_cb
   friend class C_Block_Sync; // Calls block map and protected helpers
   friend class C_C_Tick; // Asserts on client_lock
-  friend class C_Client_SyncCommit; // Asserts on client_lock
   friend class C_Client_RequestInterrupt;
   friend class C_Client_Remount;
   friend void intrusive_ptr_release(Inode *in);

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -55,7 +55,7 @@ class ObjecterWriteback : public WritebackHandler {
 	 ++p)
       op.write(p->first, p->second, trunc_size, trunc_seq);
 
-    return m_objecter->mutate(oid, oloc, op, snapc, mtime, 0, NULL,
+    return m_objecter->mutate(oid, oloc, op, snapc, mtime, 0,
 			      new C_OnFinisher(new C_Lock(m_lock, oncommit),
 					       m_finisher));
   }

--- a/src/client/ObjecterWriteback.h
+++ b/src/client/ObjecterWriteback.h
@@ -36,7 +36,7 @@ class ObjecterWriteback : public WritebackHandler {
 			   __u32 trunc_seq, ceph_tid_t journal_tid,
 			   Context *oncommit) {
     return m_objecter->write_trunc(oid, oloc, off, len, snapc, bl, mtime, 0,
-				   trunc_size, trunc_seq, NULL,
+				   trunc_size, trunc_seq,
 				   new C_OnFinisher(new C_Lock(m_lock,
 							       oncommit),
 						    m_finisher));

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -1045,9 +1045,6 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
   Mutex lock("synclient foo");
   Cond cond;
   bool ack;
-  bool safe;
-  C_GatherBuilder safeg(client->cct, new C_SafeCond(&lock, &cond, &safe));
-  Context *safegref = safeg.new_sub();  // take a ref
 
   while (!t.end()) {
 
@@ -1454,7 +1451,8 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
       object_locator_t oloc(SYNCLIENT_FIRST_POOL);
       uint64_t size;
       ceph::real_time mtime;
-      client->objecter->stat(oid, oloc, CEPH_NOSNAP, &size, &mtime, 0, new C_SafeCond(&lock, &cond, &ack));
+      client->objecter->stat(oid, oloc, CEPH_NOSNAP, &size, &mtime, 0,
+			     new C_SafeCond(&lock, &cond, &ack));
       while (!ack) cond.Wait(lock);
       lock.Unlock();
     }
@@ -1467,7 +1465,8 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
       object_locator_t oloc(SYNCLIENT_FIRST_POOL);
       lock.Lock();
       bufferlist bl;
-      client->objecter->read(oid, oloc, off, len, CEPH_NOSNAP, &bl, 0, new C_SafeCond(&lock, &cond, &ack));
+      client->objecter->read(oid, oloc, off, len, CEPH_NOSNAP, &bl, 0,
+			     new C_SafeCond(&lock, &cond, &ack));
       while (!ack) cond.Wait(lock);
       lock.Unlock();
     }
@@ -1485,9 +1484,7 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
       SnapContext snapc;
       client->objecter->write(oid, oloc, off, len, snapc, bl,
 			      ceph::real_clock::now(), 0,
-			      new C_SafeCond(&lock, &cond, &ack),
-			      safeg.new_sub());
-      safeg.activate();
+			      new C_SafeCond(&lock, &cond, &ack));
       while (!ack) cond.Wait(lock);
       lock.Unlock();
     }
@@ -1502,9 +1499,7 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
       SnapContext snapc;
       client->objecter->zero(oid, oloc, off, len, snapc,
 			     ceph::real_clock::now(), 0,
-			     new C_SafeCond(&lock, &cond, &ack),
-			     safeg.new_sub());
-      safeg.activate();
+			     new C_SafeCond(&lock, &cond, &ack));
       while (!ack) cond.Wait(lock);
       lock.Unlock();
     }
@@ -1517,15 +1512,6 @@ int SyntheticClient::play_trace(Trace& t, string& prefix, bool metadata_only)
   }
 
   dout(10) << "trace finished on line " << t.get_line() << dendl;
-
-  // wait for safe after an object trace
-  safegref->complete(0);
-  lock.Lock();
-  while (!safe) {
-    dout(10) << "waiting for safe" << dendl;
-    cond.Wait(lock);
-  }
-  lock.Unlock();
 
   // close open files
   for (ceph::unordered_map<int64_t, int64_t>::iterator fi = open_files.begin();
@@ -2274,7 +2260,6 @@ int SyntheticClient::create_objects(int nobj, int osize, int inflight)
   Mutex lock("create_objects lock");
   Cond cond;
   
-  int unack = 0;
   int unsafe = 0;
   
   list<utime_t> starts;
@@ -2295,13 +2280,12 @@ int SyntheticClient::create_objects(int nobj, int osize, int inflight)
     client->client_lock.Lock();
     client->objecter->write(oid, oloc, 0, osize, snapc, bl,
 			    ceph::real_clock::now(), 0,
-			    new C_Ref(lock, cond, &unack),
 			    new C_Ref(lock, cond, &unsafe));
     client->client_lock.Unlock();
 
     lock.Lock();
-    while (unack > inflight) {
-      dout(20) << "waiting for " << unack << " unack" << dendl;
+    while (unsafe > inflight) {
+      dout(20) << "waiting for " << unsafe << " unsafe" << dendl;
       cond.Wait(lock);
     }
     lock.Unlock();
@@ -2312,10 +2296,6 @@ int SyntheticClient::create_objects(int nobj, int osize, int inflight)
   }
 
   lock.Lock();
-  while (unack > 0) {
-    dout(20) << "waiting for " << unack << " unack" << dendl;
-    cond.Wait(lock);
-  }
   while (unsafe > 0) {
     dout(10) << "waiting for " << unsafe << " unsafe" << dendl;
     cond.Wait(lock);

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -2399,7 +2399,7 @@ int SyntheticClient::object_rw(int nobj, int osize, int wrpc,
       m.ops.push_back(op);
       client->objecter->mutate(oid, oloc, m, snapc,
 			       ceph::real_clock::now(), 0,
-			       NULL, new C_Ref(lock, cond, &unack));
+			       new C_Ref(lock, cond, &unack));
     } else {
       dout(10) << "read from " << oid << dendl;
       bufferlist inbl;

--- a/src/librados/AioCompletionImpl.h
+++ b/src/librados/AioCompletionImpl.h
@@ -31,7 +31,7 @@ struct librados::AioCompletionImpl {
   Cond cond;
   int ref, rval;
   bool released;
-  bool ack, safe;
+  bool complete;
   version_t objver;
   ceph_tid_t tid;
 
@@ -49,7 +49,8 @@ struct librados::AioCompletionImpl {
   xlist<AioCompletionImpl*>::item aio_write_list_item;
 
   AioCompletionImpl() : lock("AioCompletionImpl lock", false, false),
-			ref(1), rval(0), released(false), ack(false), safe(false),
+			ref(1), rval(0), released(false),
+			complete(false),
 			objver(0),
                         tid(0),
 			callback_complete(0),
@@ -58,10 +59,6 @@ struct librados::AioCompletionImpl {
 			callback_safe_arg(0),
 			is_read(false), blp(nullptr), out_buf(nullptr),
 			io(NULL), aio_write_seq(0), aio_write_list_item(this) { }
-
-  bool wants_ack() {
-    return is_read || callback_complete;
-  }
 
   int set_complete_callback(void *cb_arg, rados_callback_t cb) {
     lock.Lock();
@@ -79,55 +76,41 @@ struct librados::AioCompletionImpl {
   }
   int wait_for_complete() {
     lock.Lock();
-    while (!ack)
+    while (!complete)
       cond.Wait(lock);
     lock.Unlock();
     return 0;
   }
   int wait_for_safe() {
-    lock.Lock();
-    while (!safe)
-      cond.Wait(lock);
-    lock.Unlock();
-    return 0;
+    return wait_for_complete();
   }
   int is_complete() {
     lock.Lock();
-    int r = ack;
+    int r = complete;
     lock.Unlock();
     return r;
   }
   int is_safe() {
-    lock.Lock();
-    int r = safe;
-    lock.Unlock();
-    return r;
+    return is_complete();
   }
   int wait_for_complete_and_cb() {
     lock.Lock();
-    while (!ack || callback_complete)
+    while (!complete || callback_complete || callback_safe)
       cond.Wait(lock);
     lock.Unlock();
     return 0;
   }
   int wait_for_safe_and_cb() {
-    lock.Lock();
-    while (!safe || callback_safe)
-      cond.Wait(lock);
-    lock.Unlock();
-    return 0;
+    return wait_for_complete_and_cb();
   }
   int is_complete_and_cb() {
     lock.Lock();
-    int r = ack && !callback_complete;
+    int r = complete && !callback_complete && !callback_safe;
     lock.Unlock();
     return r;
   }
   int is_safe_and_cb() {
-    lock.Lock();
-    int r = safe && !callback_safe;
-    lock.Unlock();
-    return r;
+    return is_complete_and_cb();
   }
   int get_return_value() {
     lock.Lock();
@@ -180,30 +163,18 @@ struct C_AioComplete : public Context {
   }
 
   void finish(int r) {
-    rados_callback_t cb = c->callback_complete;
-    void *cb_arg = c->callback_complete_arg;
-    cb(c, cb_arg);
+    rados_callback_t cb_complete = c->callback_complete;
+    void *cb_complete_arg = c->callback_complete_arg;
+    if (cb_complete)
+      cb_complete(c, cb_complete_arg);
+
+    rados_callback_t cb_safe = c->callback_safe;
+    void *cb_safe_arg = c->callback_safe_arg;
+    if (cb_safe)
+      cb_safe(c, cb_safe_arg);
 
     c->lock.Lock();
     c->callback_complete = NULL;
-    c->cond.Signal();
-    c->put_unlock();
-  }
-};
-
-struct C_AioSafe : public Context {
-  AioCompletionImpl *c;
-
-  explicit C_AioSafe(AioCompletionImpl *cc) : c(cc) {
-    c->_get();
-  }
-
-  void finish(int r) {
-    rados_callback_t cb = c->callback_safe;
-    void *cb_arg = c->callback_safe_arg;
-    cb(c, cb_arg);
-
-    c->lock.Lock();
     c->callback_safe = NULL;
     c->cond.Signal();
     c->put_unlock();
@@ -228,9 +199,9 @@ struct C_AioCompleteAndSafe : public Context {
   void finish(int r) {
     c->lock.Lock();
     c->rval = r;
-    c->ack = true;
-    c->safe = true;
+    c->complete = true;
     c->lock.Unlock();
+
     rados_callback_t cb_complete = c->callback_complete;
     void *cb_complete_arg = c->callback_complete_arg;
     if (cb_complete)

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -878,7 +878,7 @@ int librados::IoCtxImpl::aio_write(const object_t &oid, AioCompletionImpl *c,
   Objecter::Op *o = objecter->prepare_write_op(
     oid, oloc,
     off, len, snapc, bl, ut, 0,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(o, &c->tid);
 
   return 0;
@@ -903,7 +903,7 @@ int librados::IoCtxImpl::aio_append(const object_t &oid, AioCompletionImpl *c,
   Objecter::Op *o = objecter->prepare_append_op(
     oid, oloc,
     len, snapc, bl, ut, 0,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(o, &c->tid);
 
   return 0;
@@ -929,7 +929,7 @@ int librados::IoCtxImpl::aio_write_full(const object_t &oid,
   Objecter::Op *o = objecter->prepare_write_full_op(
     oid, oloc,
     snapc, bl, ut, 0,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(o, &c->tid);
 
   return 0;
@@ -960,7 +960,7 @@ int librados::IoCtxImpl::aio_writesame(const object_t &oid,
     oid, oloc,
     write_len, off,
     snapc, bl, ut, 0,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(o, &c->tid);
 
   return 0;
@@ -982,7 +982,7 @@ int librados::IoCtxImpl::aio_remove(const object_t &oid, AioCompletionImpl *c, i
   Objecter::Op *o = objecter->prepare_remove_op(
     oid, oloc,
     snapc, ut, flags,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(o, &c->tid);
 
   return 0;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -406,7 +406,7 @@ int librados::IoCtxImpl::selfmanaged_snap_rollback_object(const object_t& oid,
   op.rollback(snapid);
   objecter->mutate(oid, oloc,
 		   op, snapc, ceph::real_clock::now(), 0,
-		   onack, NULL, NULL);
+		   onack, NULL);
 
   mylock.Lock();
   while (!done) cond.Wait(mylock);
@@ -686,7 +686,7 @@ int librados::IoCtxImpl::operate(const object_t& oid, ::ObjectOperation *o,
 			 << " nspace=" << oloc.nspace << dendl;
   Objecter::Op *objecter_op = objecter->prepare_mutate_op(oid, oloc,
 							  *o, snapc, ut, flags,
-							  NULL, oncommit, &ver);
+							  oncommit, &ver);
   objecter->op_submit(objecter_op);
 
   mylock.Lock();
@@ -770,7 +770,7 @@ int librados::IoCtxImpl::aio_operate(const object_t& oid,
 
   Objecter::Op *op = objecter->prepare_mutate_op(
     oid, oloc, *o, snap_context, ut, flags,
-    NULL, onack, &c->objver);
+    onack, &c->objver);
   objecter->op_submit(op, &c->tid);
 
   return 0;
@@ -1601,7 +1601,7 @@ int librados::IoCtxImpl::unwatch(uint64_t cookie)
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(), 0, NULL,
+		   snapc, ceph::real_clock::now(), 0,
 		   &onfinish, &ver);
   objecter->linger_cancel(linger_op);
 
@@ -1620,7 +1620,7 @@ int librados::IoCtxImpl::aio_unwatch(uint64_t cookie, AioCompletionImpl *c)
   prepare_assert_ops(&wr);
   wr.watch(cookie, CEPH_OSD_WATCH_OP_UNWATCH);
   objecter->mutate(linger_op->target.base_oid, oloc, wr,
-		   snapc, ceph::real_clock::now(), 0, NULL,
+		   snapc, ceph::real_clock::now(), 0,
 		   oncomplete, &c->objver);
   return 0;
 }

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -159,12 +159,6 @@ struct librados::IoCtxImpl {
   int aio_operate_read(const object_t& oid, ::ObjectOperation *o,
 		       AioCompletionImpl *c, int flags, bufferlist *pbl);
 
-  struct C_aio_Ack : public Context {
-    librados::AioCompletionImpl *c;
-    explicit C_aio_Ack(AioCompletionImpl *_c);
-    void finish(int r);
-  };
-
   struct C_aio_stat_Ack : public Context {
     librados::AioCompletionImpl *c;
     time_t *pmtime;
@@ -181,9 +175,9 @@ struct librados::IoCtxImpl {
     void finish(int r);
   };
 
-  struct C_aio_Safe : public Context {
+  struct C_aio_Complete : public Context {
     AioCompletionImpl *c;
-    explicit C_aio_Safe(AioCompletionImpl *_c);
+    explicit C_aio_Complete(AioCompletionImpl *_c);
     void finish(int r);
   };
 

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -398,15 +398,12 @@ struct C_aio_watch_flush_Complete : public Context {
   virtual void finish(int r) {
     c->lock.Lock();
     c->rval = r;
-    c->ack = true;
-    c->safe = true;
+    c->complete = true;
     c->cond.Signal();
 
-    if (c->callback_complete) {
+    if (c->callback_complete ||
+	c->callback_safe) {
       client->finisher.queue(new librados::C_AioComplete(c));
-    }
-    if (c->callback_safe) {
-      client->finisher.queue(new librados::C_AioSafe(c));
     }
     c->put_unlock();
   }

--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -125,7 +125,7 @@ libradosstriper::RadosStriperImpl::CompletionData::CompletionData
   m_striper(striper), m_soid(soid), m_lockCookie(lockCookie), m_ack(0) {
   m_striper->get();
   if (userCompletion) {
-    m_ack = new librados::IoCtxImpl::C_aio_Ack(userCompletion);
+    m_ack = new librados::IoCtxImpl::C_aio_Complete(userCompletion);
     userCompletion->io = striper->m_ioCtxImpl;
   }
 }
@@ -188,7 +188,7 @@ libradosstriper::RadosStriperImpl::WriteCompletionData::WriteCompletionData
   CompletionData(striper, soid, lockCookie, userCompletion, n), m_safe(0),
   m_unlockCompletion(0) {
   if (userCompletion) {
-    m_safe = new librados::IoCtxImpl::C_aio_Safe(userCompletion);
+    m_safe = new librados::IoCtxImpl::C_aio_Complete(userCompletion);
   }
 }
 

--- a/src/libradosstriper/RadosStriperImpl.h
+++ b/src/libradosstriper/RadosStriperImpl.h
@@ -52,7 +52,7 @@ struct libradosstriper::RadosStriperImpl {
     /// shared lock to be released at completion
     std::string m_lockCookie;
     /// completion handler
-    librados::IoCtxImpl::C_aio_Ack *m_ack;
+    librados::IoCtxImpl::C_aio_Complete *m_ack;
   };
 
   /**
@@ -93,7 +93,7 @@ struct libradosstriper::RadosStriperImpl {
    */
   struct WriteCompletionData : CompletionData {
     /// safe completion handler
-    librados::IoCtxImpl::C_aio_Safe *m_safe;
+    librados::IoCtxImpl::C_aio_Complete *m_safe;
     /// return code of write completion, to be remembered until unlocking happened
     int m_writeRc;
     /// completion object for the unlocking of the striped object at the end of the write

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -2075,7 +2075,7 @@ void CDir::_omap_commit(int op_prio)
 
       cache->mds->objecter->mutate(oid, oloc, op, snapc,
 				   ceph::real_clock::now(),
-				   0, NULL, gather.new_sub());
+				   0, gather.new_sub());
 
       write_size = 0;
       to_set.clear();
@@ -2109,7 +2109,7 @@ void CDir::_omap_commit(int op_prio)
 
   cache->mds->objecter->mutate(oid, oloc, op, snapc,
 			       ceph::real_clock::now(),
-			       0, NULL, gather.new_sub());
+			       0, gather.new_sub());
 
   gather.activate();
 }

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -982,7 +982,7 @@ void CInode::store(MDSInternalContextBase *fin)
 		     mdcache->mds->finisher);
   mdcache->mds->objecter->mutate(oid, oloc, m, snapc,
 				 ceph::real_clock::now(), 0,
-				 NULL, newfin);
+				 newfin);
 }
 
 void CInode::_stored(int r, version_t v, Context *fin)
@@ -1167,14 +1167,14 @@ void CInode::store_backtrace(MDSInternalContextBase *fin, int op_prio)
     dout(20) << __func__ << ": no dirtypool or no old pools" << dendl;
     mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 				   ceph::real_clock::now(),
-				   0, NULL, fin2);
+				   0, fin2);
     return;
   }
 
   C_GatherBuilder gather(g_ceph_context, fin2);
   mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 				 ceph::real_clock::now(),
-				 0, NULL, gather.new_sub());
+				 0, gather.new_sub());
 
   // In the case where DIRTYPOOL is set, we update all old pools backtraces
   // such that anyone reading them will see the new pool ID in
@@ -1195,7 +1195,7 @@ void CInode::store_backtrace(MDSInternalContextBase *fin, int op_prio)
     object_locator_t oloc(*p);
     mdcache->mds->objecter->mutate(oid, oloc, op, snapc,
 				   ceph::real_clock::now(),
-				   0, NULL, gather.new_sub());
+				   0, gather.new_sub());
   }
   gather.activate();
 }
@@ -3751,7 +3751,7 @@ void CInode::validate_disk_state(CInode::validated_data *results,
         SnapContext snapc;
         in->mdcache->mds->objecter->mutate(oid, object_locator_t(pool), scrub_tag, snapc,
 					   ceph::real_clock::now(),
-					   0, NULL, NULL);
+					   0, NULL);
       }
     }
 

--- a/src/mds/JournalPointer.cc
+++ b/src/mds/JournalPointer.cc
@@ -92,7 +92,7 @@ int JournalPointer::save(Objecter *objecter) const
   C_SaferCond waiter;
   objecter->write_full(object_t(object_id), object_locator_t(pool_id),
 		       SnapContext(), data,
-		       ceph::real_clock::now(), 0, NULL,
+		       ceph::real_clock::now(), 0,
 		       &waiter);
   int write_result = waiter.wait();
   if (write_result < 0) {
@@ -115,7 +115,7 @@ void JournalPointer::save(Objecter *objecter, Context *completion) const
 
   objecter->write_full(object_t(get_object_id()), object_locator_t(pool_id),
 		       SnapContext(), data,
-		       ceph::real_clock::now(), 0, NULL,
+		       ceph::real_clock::now(), 0,
 		       completion);
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6257,9 +6257,8 @@ void MDCache::_truncate_inode(CInode *in, LogSegment *ls)
   filer.truncate(in->inode.ino, &in->inode.layout, *snapc,
 		 pi->truncate_size, pi->truncate_from-pi->truncate_size,
 		 pi->truncate_seq, ceph::real_time::min(), 0,
-		 0, new C_OnFinisher(new C_IO_MDC_TruncateFinish(this, in,
-								       ls),
-					   mds->finisher));
+		 new C_OnFinisher(new C_IO_MDC_TruncateFinish(this, in, ls),
+				  mds->finisher));
 }
 
 struct C_MDC_TruncateLogged : public MDCacheLogContext {

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11324,7 +11324,7 @@ void MDCache::_fragment_committed(dirfrag_t basedirfrag, list<CDir*>& resultfrag
     }
     mds->objecter->mutate(oid, oloc, op, nullsnapc,
 			  ceph::real_clock::now(),
-			  0, NULL, gather.new_sub());
+			  0, gather.new_sub());
   }
 
   assert(gather.has_subs());

--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -83,7 +83,6 @@ void MDSTable::save(MDSInternalContextBase *onfinish, version_t v)
   mds->objecter->write_full(oid, oloc,
 			    snapc,
 			    bl, ceph::real_clock::now(), 0,
-			    NULL,
 			    new C_OnFinisher(new C_IO_MT_Save(this, version),
 					     mds->finisher));
 }

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -426,7 +426,7 @@ void SessionMap::save(MDSInternalContextBase *onsave, version_t needv)
 
   mds->objecter->mutate(oid, oloc, op, snapc,
 			ceph::real_clock::now(),
-			0, NULL,
+			0,
 			new C_OnFinisher(new C_IO_SM_Save(this, version),
 					 mds->finisher));
 }
@@ -761,7 +761,7 @@ void SessionMap::save_if_dirty(const std::set<entity_name_t> &tgt_sessions,
       MDSInternalContextBase *on_safe = gather_bld->new_sub();
       mds->objecter->mutate(oid, oloc, op, snapc,
 			    ceph::real_clock::now(),
-			    0, NULL, new C_OnFinisher(
+			    0, new C_OnFinisher(
 			      new C_IO_SM_Save_One(this, on_safe),
 			      mds->finisher));
     }

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -916,7 +916,7 @@ void StrayManager::truncate(CDentry *dn, uint32_t op_allowance)
     filer.zero(in->ino(), &in->inode.layout, *snapc,
 	       0, in->inode.layout.object_size,
 	       ceph::real_clock::now(),
-	       0, true, NULL, gather.new_sub());
+	       0, true, gather.new_sub());
   }
 
   assert(gather.has_subs());

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -120,7 +120,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
       dout(10) << __func__ << " remove dirfrag " << oid << dendl;
       mds->objecter->remove(oid, oloc, nullsnapc,
 			    ceph::real_clock::now(),
-			    0, NULL, gather.new_sub());
+			    0, gather.new_sub());
     }
     assert(gather.has_subs());
     gather.activate();
@@ -164,7 +164,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
 	     << " pool " << oloc.pool << " snapc " << snapc << dendl;
     mds->objecter->remove(oid, oloc, *snapc,
 			  ceph::real_clock::now(), 0,
-			  NULL, gather.new_sub());
+			  gather.new_sub());
   }
   // remove old backtrace objects
   for (compact_set<int64_t>::iterator p = pi->old_pools.begin();
@@ -175,7 +175,7 @@ void StrayManager::purge(CDentry *dn, uint32_t op_allowance)
 	     << " old pool " << *p << " snapc " << snapc << dendl;
     mds->objecter->remove(oid, oloc, *snapc,
 			  ceph::real_clock::now(), 0,
-			  NULL, gather.new_sub());
+			  gather.new_sub());
   }
   assert(gather.has_subs());
   gather.activate();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2904,7 +2904,7 @@ void PrimaryLogPG::do_proxy_write(OpRequestRef op, const hobject_t& missing_oid)
   ceph_tid_t tid = osd->objecter->mutate(
     soid.oid, oloc, obj_op, snapc,
     ceph::real_clock::from_ceph_timespec(pwop->mtime),
-    flags, NULL, new C_OnFinisher(fin, &osd->objecter_finisher),
+    flags, new C_OnFinisher(fin, &osd->objecter_finisher),
     &pwop->user_version, pwop->reqid);
   fin->tid = tid;
   pwop->objecter_tid = tid;
@@ -8149,7 +8149,6 @@ int PrimaryLogPG::start_flush(
       (CEPH_OSD_FLAG_IGNORE_OVERLAY |
        CEPH_OSD_FLAG_ORDERSNAP |
        CEPH_OSD_FLAG_ENFORCE_SNAPC),
-      NULL,
       NULL /* no callback, we'll rely on the ordering w.r.t the next op */);
   }
 
@@ -8165,7 +8164,6 @@ int PrimaryLogPG::start_flush(
       (CEPH_OSD_FLAG_IGNORE_OVERLAY |
        CEPH_OSD_FLAG_ORDERSNAP |
        CEPH_OSD_FLAG_ENFORCE_SNAPC),
-      NULL,
       NULL /* no callback, we'll rely on the ordering w.r.t the next op */);
   }
 
@@ -8199,8 +8197,8 @@ int PrimaryLogPG::start_flush(
     soid.oid, base_oloc, o, snapc,
     ceph::real_clock::from_ceph_timespec(oi.mtime),
     CEPH_OSD_FLAG_IGNORE_OVERLAY | CEPH_OSD_FLAG_ENFORCE_SNAPC,
-    NULL, new C_OnFinisher(fin,
-			   &osd->objecter_finisher));
+    new C_OnFinisher(fin,
+		     &osd->objecter_finisher));
   /* we're under the pg lock and fin->finish() is grabbing that */
   fin->tid = tid;
   fop->objecter_tid = tid;

--- a/src/osdc/Filer.cc
+++ b/src/osdc/Filer.cc
@@ -323,7 +323,7 @@ int Filer::purge_range(inodeno_t ino,
   if (num_obj == 1) {
     object_t oid = file_object_t(ino, first_obj);
     object_locator_t oloc = OSDMap::file_to_object_locator(*layout);
-    objecter->remove(oid, oloc, snapc, mtime, flags, NULL, oncommit);
+    objecter->remove(oid, oloc, snapc, mtime, flags, oncommit);
     return 0;
   }
 
@@ -373,7 +373,7 @@ void Filer::_do_purge_range(PurgeRange *pr, int fin)
   // Issue objecter ops outside pr->lock to avoid lock dependency loop
   for (const auto& oid : remove_oids) {
     object_locator_t oloc = OSDMap::file_to_object_locator(pr->layout);
-    objecter->remove(oid, oloc, pr->snapc, pr->mtime, pr->flags, NULL,
+    objecter->remove(oid, oloc, pr->snapc, pr->mtime, pr->flags,
 		     new C_OnFinisher(new C_PurgeRange(this, pr), finisher));
   }
 }

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -203,7 +203,7 @@ class Filer {
       ops[0].op.extent.truncate_seq = truncate_seq;
       ops[0].op.extent.truncate_size = extents[0].offset;
       objecter->_modify(extents[0].oid, extents[0].oloc, ops, mtime, snapc,
-			flags, NULL, oncommit);
+			flags, oncommit);
     } else {
       C_GatherBuilder gcom(cct, oncommit);
       for (vector<ObjectExtent>::iterator p = extents.begin();
@@ -214,7 +214,6 @@ class Filer {
 	ops[0].op.extent.truncate_size = p->offset;
 	ops[0].op.extent.truncate_seq = truncate_seq;
 	objecter->_modify(p->oid, p->oloc, ops, mtime, snapc, flags,
-			  NULL,
 			  oncommit ? gcom.new_sub():0);
       }
       gcom.activate();

--- a/src/osdc/Filer.h
+++ b/src/osdc/Filer.h
@@ -163,8 +163,7 @@ class Filer {
 	    int op_flags = 0) {
     vector<ObjectExtent> extents;
     Striper::file_to_extents(cct, ino, layout, offset, len, 0, extents);
-    objecter->sg_write(extents, snapc, bl, mtime, flags, NULL, oncommit,
-		       op_flags);
+    objecter->sg_write(extents, snapc, bl, mtime, flags, oncommit, op_flags);
   }
 
   void write_trunc(inodeno_t ino,
@@ -183,7 +182,7 @@ class Filer {
     Striper::file_to_extents(cct, ino, layout, offset, len, truncate_size,
 			     extents);
     objecter->sg_write_trunc(extents, snapc, bl, mtime, flags,
-		       truncate_size, truncate_seq, NULL, oncommit, op_flags);
+		       truncate_size, truncate_seq, oncommit, op_flags);
   }
 
   void truncate(inodeno_t ino,
@@ -235,11 +234,10 @@ class Filer {
       if (extents[0].offset == 0 && extents[0].length == layout->object_size
 	  && (!keep_first || extents[0].objectno != 0))
 	objecter->remove(extents[0].oid, extents[0].oloc,
-			 snapc, mtime, flags, NULL, oncommit);
+			 snapc, mtime, flags, oncommit);
       else
 	objecter->zero(extents[0].oid, extents[0].oloc, extents[0].offset,
-		       extents[0].length, snapc, mtime, flags, NULL,
-		       oncommit);
+		       extents[0].length, snapc, mtime, flags, oncommit);
     } else {
       C_GatherBuilder gcom(cct, oncommit);
       for (vector<ObjectExtent>::iterator p = extents.begin();
@@ -249,12 +247,10 @@ class Filer {
 	    (!keep_first || p->objectno != 0))
 	  objecter->remove(p->oid, p->oloc,
 			   snapc, mtime, flags,
-			   NULL,
 			   oncommit ? gcom.new_sub():0);
 	else
 	  objecter->zero(p->oid, p->oloc, p->offset, p->length,
 			 snapc, mtime, flags,
-			 NULL,
 			 oncommit ? gcom.new_sub():0);
       }
       gcom.activate();

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -650,7 +650,7 @@ void Journaler::_do_flush(unsigned amount)
   filer.write(ino, &layout, snapc,
 	      flush_pos, len, write_bl, ceph::real_clock::now(),
 	      0,
-	      NULL, wrap_finisher(onsafe), write_iohint);
+	      wrap_finisher(onsafe), write_iohint);
 
   flush_pos += len;
   assert(write_buf.length() == write_pos - flush_pos);
@@ -791,7 +791,7 @@ void Journaler::_issue_prezero()
     Context *c = wrap_finisher(new C_Journaler_Prezero(this, prezeroing_pos,
 						       len));
     filer.zero(ino, &layout, snapc, prezeroing_pos, len,
-	       ceph::real_clock::now(), 0, NULL, c);
+	       ceph::real_clock::now(), 0, c);
     prezeroing_pos += len;
   }
 }

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -448,7 +448,7 @@ void Journaler::_write_head(Context *oncommit)
   object_t oid = file_object_t(ino, 0);
   object_locator_t oloc(pg_pool);
   objecter->write_full(oid, oloc, snapc, bl, ceph::real_clock::now(), 0,
-		       NULL, wrap_finisher(new C_WriteHead(
+		       wrap_finisher(new C_WriteHead(
 					     this, last_written,
 					     wrap_finisher(oncommit))),
 		       0, 0, write_iohint);

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -70,8 +70,7 @@ enum {
   l_osdc_op_send,
   l_osdc_op_send_bytes,
   l_osdc_op_resend,
-  l_osdc_op_ack,
-  l_osdc_op_commit,
+  l_osdc_op_reply,
 
   l_osdc_op,
   l_osdc_op_r,
@@ -247,8 +246,7 @@ void Objecter::init()
     pcb.add_u64_counter(l_osdc_op_send, "op_send", "Sent operations");
     pcb.add_u64_counter(l_osdc_op_send_bytes, "op_send_bytes", "Sent data");
     pcb.add_u64_counter(l_osdc_op_resend, "op_resend", "Resent operations");
-    pcb.add_u64_counter(l_osdc_op_ack, "op_ack", "Commit callbacks");
-    pcb.add_u64_counter(l_osdc_op_commit, "op_commit", "Operation commits");
+    pcb.add_u64_counter(l_osdc_op_reply, "op_reply", "Operation reply");
 
     pcb.add_u64_counter(l_osdc_op, "op", "Operations");
     pcb.add_u64_counter(l_osdc_op_r, "op_r",
@@ -555,7 +553,7 @@ void Objecter::_send_linger(LingerOp *info,
   watchl.unlock();
   Op *o = new Op(info->target.base_oid, info->target.base_oloc,
 		 opv, info->target.flags | CEPH_OSD_FLAG_READ,
-		 NULL, NULL,
+		 NULL,
 		 info->pobjver);
   o->oncommit_sync = oncommit;
   o->outbl = poutbl;
@@ -1457,11 +1455,8 @@ void Objecter::_check_op_pool_dne(Op *op, unique_lock& sl)
       ldout(cct, 10) << "check_op_pool_dne tid " << op->tid
 		     << " concluding pool " << op->target.base_pgid.pool()
 		     << " dne" << dendl;
-      if (op->onack) {
-	op->onack->complete(-ENOENT);
-      }
-      if (op->oncommit) {
-	op->oncommit->complete(-ENOENT);
+      if (op->onfinish) {
+	op->onfinish->complete(-ENOENT);
       }
       if (op->oncommit_sync) {
 	op->oncommit_sync->complete(-ENOENT);
@@ -2211,15 +2206,10 @@ void Objecter::_send_op_account(Op *op)
   inflight_ops.inc();
 
   // add to gather set(s)
-  if (op->onack) {
-    num_unacked.inc();
+  if (op->onfinish || op->oncommit_sync) {
+    num_in_flight.inc();
   } else {
-    ldout(cct, 20) << " note: not requesting ack" << dendl;
-  }
-  if (op->oncommit || op->oncommit_sync) {
-    num_uncommitted.inc();
-  } else {
-    ldout(cct, 20) << " note: not requesting commit" << dendl;
+    ldout(cct, 20) << " note: not requesting reply" << dendl;
   }
 
   logger->inc(l_osdc_op_active);
@@ -2398,8 +2388,7 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
   sl.unlock();
   put_session(s);
 
-  ldout(cct, 5) << num_unacked.read() << " unacked, " << num_uncommitted.read()
-		<< " uncommitted" << dendl;
+  ldout(cct, 5) << num_in_flight.read() << " in flight" << dendl;
 }
 
 int Objecter::op_cancel(OSDSession *s, ceph_tid_t tid, int r)
@@ -2424,16 +2413,11 @@ int Objecter::op_cancel(OSDSession *s, ceph_tid_t tid, int r)
   ldout(cct, 10) << __func__ << " tid " << tid << " in session " << s->osd
 		 << dendl;
   Op *op = p->second;
-  if (op->onack) {
-    op->onack->complete(r);
-    op->onack = NULL;
-    num_unacked.dec();
-  }
-  if (op->oncommit || op->oncommit_sync)
-    num_uncommitted.dec();
-  if (op->oncommit) {
-    op->oncommit->complete(r);
-    op->oncommit = NULL;
+  if (op->onfinish || op->oncommit_sync)
+    num_in_flight.dec();
+  if (op->onfinish) {
+    op->onfinish->complete(r);
+    op->onfinish = NULL;
   }
   if (op->oncommit_sync) {
     op->oncommit_sync->complete(r);
@@ -2986,14 +2970,10 @@ void Objecter::_cancel_linger_op(Op *op)
   ldout(cct, 15) << "cancel_op " << op->tid << dendl;
 
   assert(!op->should_resend);
-  if (op->onack) {
-    delete op->onack;
-    num_unacked.dec();
-  }
-  if (op->oncommit || op->oncommit_sync) {
-    delete op->oncommit;
+  if (op->onfinish || op->oncommit_sync) {
+    delete op->onfinish;
     delete op->oncommit_sync;
-    num_uncommitted.dec();
+    num_in_flight.dec();
   }
 
   _finish_op(op, 0);
@@ -3044,10 +3024,8 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
 
   int flags = op->target.flags;
   flags |= CEPH_OSD_FLAG_KNOWN_REDIR;
-  if (op->oncommit || op->oncommit_sync)
+  if (op->onfinish || op->oncommit_sync)
     flags |= CEPH_OSD_FLAG_ONDISK;
-  if (op->onack)
-    flags |= CEPH_OSD_FLAG_ACK;
 
   if (!honor_osdmap_full)
     flags |= CEPH_OSD_FLAG_FULL_FORCE;
@@ -3239,11 +3217,8 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   if (retry_writes_after_first_reply && op->attempts == 1 &&
       (op->target.flags & CEPH_OSD_FLAG_WRITE)) {
     ldout(cct, 7) << "retrying write after first reply: " << tid << dendl;
-    if (op->onack) {
-      num_unacked.dec();
-    }
-    if (op->oncommit || op->oncommit_sync) {
-      num_uncommitted.dec();
+    if (op->onfinish || op->oncommit_sync) {
+      num_in_flight.dec();
     }
     _session_op_remove(s, op);
     sl.unlock();
@@ -3272,17 +3247,14 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     // have, but that is better than doing callbacks out of order.
   }
 
-  Context *onack = 0;
-  Context *oncommit = 0;
+  Context *onfinish = 0;
 
   int rc = m->get_result();
 
   if (m->is_redirect_reply()) {
     ldout(cct, 5) << " got redirect reply; redirecting" << dendl;
-    if (op->onack)
-      num_unacked.dec();
-    if (op->oncommit || op->oncommit_sync)
-      num_uncommitted.dec();
+    if (op->onfinish || op->oncommit_sync)
+      num_in_flight.dec();
     _session_op_remove(s, op);
     sl.unlock();
     put_session(s);
@@ -3362,43 +3334,34 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
     }
   }
 
-  // ack|commit -> ack
-  if (op->onack) {
-    ldout(cct, 15) << "handle_osd_op_reply ack" << dendl;
-    op->replay_version = m->get_replay_version();
-    onack = op->onack;
-    op->onack = 0;  // only do callback once
-    num_unacked.dec();
-    logger->inc(l_osdc_op_ack);
+  // NOTE: we assume that since we only request ONDISK ever we will
+  // only ever get back one (type of) ack ever.
+
+  if (op->onfinish || op->oncommit_sync) {
+    num_in_flight.dec();
   }
-  if (m->is_ondisk() || rc) {
-    if (op->oncommit) {
-      ldout(cct, 15) << "handle_osd_op_reply safe" << dendl;
-      oncommit = op->oncommit;
-      op->oncommit = NULL;
-      num_uncommitted.dec();
-      logger->inc(l_osdc_op_commit);
-    }
-    if (op->oncommit_sync) {
-      ldout(cct, 15) << "handle_osd_op_reply safe (sync)" << dendl;
-      op->oncommit_sync->complete(rc);
-      op->oncommit_sync = NULL;
-      num_uncommitted.dec();
-      logger->inc(l_osdc_op_commit);
-    }
+  if (op->onfinish) {
+    ldout(cct, 15) << "handle_osd_op_reply finish" << dendl;
+    onfinish = op->onfinish;
+    op->onfinish = NULL;
   }
+  if (op->oncommit_sync) {
+    ldout(cct, 15) << "handle_osd_op_reply finish (sync)" << dendl;
+    op->oncommit_sync->complete(rc);
+    op->oncommit_sync = NULL;
+  }
+  logger->inc(l_osdc_op_reply);
 
   /* get it before we call _finish_op() */
   auto completion_lock = s->get_lock(op->target.base_oid);
 
   // done with this tid?
-  if (!op->onack && !op->oncommit && !op->oncommit_sync) {
+  if (!op->onfinish && !op->oncommit_sync) {
     ldout(cct, 15) << "handle_osd_op_reply completed tid " << tid << dendl;
     _finish_op(op, 0);
   }
 
-  ldout(cct, 5) << num_unacked.read() << " unacked, " << num_uncommitted.read()
-		<< " uncommitted" << dendl;
+  ldout(cct, 5) << num_in_flight.read() << " in flight" << dendl;
 
   // serialize completions
   if (completion_lock.mutex()) {
@@ -3407,11 +3370,8 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   sl.unlock();
 
   // do callbacks
-  if (onack) {
-    onack->complete(rc);
-  }
-  if (oncommit) {
-    oncommit->complete(rc);
+  if (onfinish) {
+    onfinish->complete(rc);
   }
   if (completion_lock.mutex()) {
     completion_lock.unlock();

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2459,7 +2459,7 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t off, uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit, version_t *objver = NULL,
+    Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
@@ -2471,7 +2471,7 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;
@@ -2480,10 +2480,10 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t off, uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit, version_t *objver = NULL,
+    Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
     Op *o = prepare_write_op(oid, oloc, off, len, snapc, bl, mtime, flags,
-			     onack, oncommit, objver, extra_ops, op_flags);
+			     oncommit, objver, extra_ops, op_flags);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;
@@ -2492,7 +2492,7 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit,
+    Context *oncommit,
     version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
@@ -2504,7 +2504,7 @@ public:
     ops[i].op.extent.truncate_seq = 0;
     ops[i].indata = bl;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;
@@ -2513,11 +2513,11 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t len, const SnapContext& snapc,
     const bufferlist &bl, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit,
+    Context *oncommit,
     version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL) {
     Op *o = prepare_append_op(oid, oloc, len, snapc, bl, mtime, flags,
-			      onack, oncommit, objver, extra_ops);
+			      oncommit, objver, extra_ops);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;
@@ -2526,7 +2526,7 @@ public:
 			 uint64_t off, uint64_t len, const SnapContext& snapc,
 			 const bufferlist &bl, ceph::real_time mtime, int flags,
 			 uint64_t trunc_size, __u32 trunc_seq,
-			 Context *onack, Context *oncommit,
+			 Context *oncommit,
 			 version_t *objver = NULL,
 			 ObjectOperation *extra_ops = NULL, int op_flags = 0) {
     vector<OSDOp> ops;
@@ -2539,7 +2539,7 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2549,7 +2549,7 @@ public:
   Op *prepare_write_full_op(
     const object_t& oid, const object_locator_t& oloc,
     const SnapContext& snapc, const bufferlist &bl,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
     vector<OSDOp> ops;
@@ -2560,7 +2560,7 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;
@@ -2568,11 +2568,11 @@ public:
   ceph_tid_t write_full(
     const object_t& oid, const object_locator_t& oloc,
     const SnapContext& snapc, const bufferlist &bl,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
     Op *o = prepare_write_full_op(oid, oloc, snapc, bl, mtime, flags,
-				  onack, oncommit, objver, extra_ops, op_flags);
+				  oncommit, objver, extra_ops, op_flags);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;
@@ -2581,7 +2581,7 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t write_len, uint64_t off,
     const SnapContext& snapc, const bufferlist &bl,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
 
@@ -2594,7 +2594,7 @@ public:
     ops[i].indata = bl;
     ops[i].op.flags = op_flags;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;
@@ -2603,12 +2603,12 @@ public:
     const object_t& oid, const object_locator_t& oloc,
     uint64_t write_len, uint64_t off,
     const SnapContext& snapc, const bufferlist &bl,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     ObjectOperation *extra_ops = NULL, int op_flags = 0) {
 
     Op *o = prepare_writesame_op(oid, oloc, write_len, off, snapc, bl,
-				 mtime, flags, onack, oncommit, objver,
+				 mtime, flags, oncommit, objver,
 				 extra_ops, op_flags);
 
     ceph_tid_t tid;
@@ -2617,7 +2617,7 @@ public:
   }
   ceph_tid_t trunc(const object_t& oid, const object_locator_t& oloc,
 		   const SnapContext& snapc, ceph::real_time mtime, int flags,
-		   uint64_t trunc_size, __u32 trunc_seq, Context *onack,
+		   uint64_t trunc_size, __u32 trunc_seq,
 		   Context *oncommit, version_t *objver = NULL,
 		   ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
@@ -2627,7 +2627,7 @@ public:
     ops[i].op.extent.truncate_size = trunc_size;
     ops[i].op.extent.truncate_seq = trunc_seq;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2636,7 +2636,7 @@ public:
   }
   ceph_tid_t zero(const object_t& oid, const object_locator_t& oloc,
 		  uint64_t off, uint64_t len, const SnapContext& snapc,
-		  ceph::real_time mtime, int flags, Context *onack, Context *oncommit,
+		  ceph::real_time mtime, int flags, Context *oncommit,
 	     version_t *objver = NULL, ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
@@ -2644,7 +2644,7 @@ public:
     ops[i].op.extent.offset = off;
     ops[i].op.extent.length = len;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2653,14 +2653,14 @@ public:
   }
   ceph_tid_t rollback_object(const object_t& oid, const object_locator_t& oloc,
 			     const SnapContext& snapc, snapid_t snapid,
-			     ceph::real_time mtime, Context *onack, Context *oncommit,
+			     ceph::real_time mtime, Context *oncommit,
 			     version_t *objver = NULL,
 			     ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_ROLLBACK;
     ops[i].op.snap.snapid = snapid;
-    Op *o = new Op(oid, oloc, ops, CEPH_OSD_FLAG_WRITE, onack, oncommit,
+    Op *o = new Op(oid, oloc, ops, CEPH_OSD_FLAG_WRITE, NULL, oncommit,
 		   objver);
     o->mtime = mtime;
     o->snapc = snapc;
@@ -2670,7 +2670,7 @@ public:
   }
   ceph_tid_t create(const object_t& oid, const object_locator_t& oloc,
 		    const SnapContext& snapc, ceph::real_time mtime, int global_flags,
-		    int create_flags, Context *onack, Context *oncommit,
+		    int create_flags, Context *oncommit,
 		    version_t *objver = NULL,
 		    ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
@@ -2678,7 +2678,7 @@ public:
     ops[i].op.op = CEPH_OSD_OP_CREATE;
     ops[i].op.flags = create_flags;
     Op *o = new Op(oid, oloc, ops, global_flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2688,13 +2688,13 @@ public:
   Op *prepare_remove_op(
     const object_t& oid, const object_locator_t& oloc,
     const SnapContext& snapc, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit,
+    Context *oncommit,
     version_t *objver = NULL, ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
     ops[i].op.op = CEPH_OSD_OP_DELETE;
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     return o;
@@ -2702,10 +2702,10 @@ public:
   ceph_tid_t remove(
     const object_t& oid, const object_locator_t& oloc,
     const SnapContext& snapc, ceph::real_time mtime, int flags,
-    Context *onack, Context *oncommit,
+    Context *oncommit,
     version_t *objver = NULL, ObjectOperation *extra_ops = NULL) {
     Op *o = prepare_remove_op(oid, oloc, snapc, mtime, flags,
-			      onack, oncommit, objver, extra_ops);
+			      oncommit, objver, extra_ops);
     ceph_tid_t tid;
     op_submit(o, &tid);
     return tid;
@@ -2714,7 +2714,7 @@ public:
   ceph_tid_t setxattr(const object_t& oid, const object_locator_t& oloc,
 	      const char *name, const SnapContext& snapc, const bufferlist &bl,
 	      ceph::real_time mtime, int flags,
-	      Context *onack, Context *oncommit,
+	      Context *oncommit,
 	      version_t *objver = NULL, ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
@@ -2725,7 +2725,7 @@ public:
       ops[i].indata.append(name);
     ops[i].indata.append(bl);
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2735,7 +2735,7 @@ public:
   ceph_tid_t removexattr(const object_t& oid, const object_locator_t& oloc,
 	      const char *name, const SnapContext& snapc,
 	      ceph::real_time mtime, int flags,
-	      Context *onack, Context *oncommit,
+	      Context *oncommit,
 	      version_t *objver = NULL, ObjectOperation *extra_ops = NULL) {
     vector<OSDOp> ops;
     int i = init_ops(ops, 1, extra_ops);
@@ -2745,7 +2745,7 @@ public:
     if (name)
       ops[i].indata.append(name);
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;
@@ -2883,15 +2883,14 @@ public:
 
   void sg_write_trunc(vector<ObjectExtent>& extents, const SnapContext& snapc,
 		      const bufferlist& bl, ceph::real_time mtime, int flags,
-		      uint64_t trunc_size, __u32 trunc_seq, Context *onack,
+		      uint64_t trunc_size, __u32 trunc_seq,
 		      Context *oncommit, int op_flags = 0) {
     if (extents.size() == 1) {
       write_trunc(extents[0].oid, extents[0].oloc, extents[0].offset,
 		  extents[0].length, snapc, bl, mtime, flags,
-		  extents[0].truncate_size, trunc_seq, onack, oncommit,
+		  extents[0].truncate_size, trunc_seq, oncommit,
 		  0, 0, op_flags);
     } else {
-      C_GatherBuilder gack(cct, onack);
       C_GatherBuilder gcom(cct, oncommit);
       for (vector<ObjectExtent>::iterator p = extents.begin();
 	   p != extents.end();
@@ -2905,19 +2904,17 @@ public:
 	assert(cur.length() == p->length);
 	write_trunc(p->oid, p->oloc, p->offset, p->length,
 	      snapc, cur, mtime, flags, p->truncate_size, trunc_seq,
-	      onack ? gack.new_sub():0,
 	      oncommit ? gcom.new_sub():0,
 	      0, 0, op_flags);
       }
-      gack.activate();
       gcom.activate();
     }
   }
 
   void sg_write(vector<ObjectExtent>& extents, const SnapContext& snapc,
 		const bufferlist& bl, ceph::real_time mtime, int flags,
-		Context *onack, Context *oncommit, int op_flags = 0) {
-    sg_write_trunc(extents, snapc, bl, mtime, flags, 0, 0, onack, oncommit,
+		Context *oncommit, int op_flags = 0) {
+    sg_write_trunc(extents, snapc, bl, mtime, flags, 0, 0, oncommit,
 		   op_flags);
   }
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2154,11 +2154,11 @@ public:
   Op *prepare_mutate_op(
     const object_t& oid, const object_locator_t& oloc,
     ObjectOperation& op, const SnapContext& snapc,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     osd_reqid_t reqid = osd_reqid_t()) {
     Op *o = new Op(oid, oloc, op.ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->priority = op.priority;
     o->mtime = mtime;
     o->snapc = snapc;
@@ -2169,10 +2169,10 @@ public:
   ceph_tid_t mutate(
     const object_t& oid, const object_locator_t& oloc,
     ObjectOperation& op, const SnapContext& snapc,
-    ceph::real_time mtime, int flags, Context *onack,
+    ceph::real_time mtime, int flags,
     Context *oncommit, version_t *objver = NULL,
     osd_reqid_t reqid = osd_reqid_t()) {
-    Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags, onack,
+    Op *o = prepare_mutate_op(oid, oloc, op, snapc, mtime, flags,
 			      oncommit, objver, reqid);
     ceph_tid_t tid;
     op_submit(o, &tid);

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1234,7 +1234,6 @@ public:
     int priority;
     Context *onfinish;
     uint64_t ontimeout;
-    Context *oncommit_sync; // used internally by watch/notify
 
     ceph_tid_t tid;
     eversion_t replay_version; // for op replay
@@ -1275,7 +1274,6 @@ public:
       priority(0),
       onfinish(fin),
       ontimeout(0),
-      oncommit_sync(NULL),
       tid(0),
       attempts(0),
       objver(ov),

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2445,10 +2445,10 @@ public:
   ceph_tid_t _modify(const object_t& oid, const object_locator_t& oloc,
 		     vector<OSDOp>& ops, ceph::real_time mtime,
 		     const SnapContext& snapc, int flags,
-		     Context *onack, Context *oncommit,
+		     Context *oncommit,
 		     version_t *objver = NULL) {
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags.read() |
-		   CEPH_OSD_FLAG_WRITE, onack, oncommit, objver);
+		   CEPH_OSD_FLAG_WRITE, NULL, oncommit, objver);
     o->mtime = mtime;
     o->snapc = snapc;
     ceph_tid_t tid;

--- a/src/test/librados_test_stub/TestRadosClient.cc
+++ b/src/test/librados_test_stub/TestRadosClient.cc
@@ -30,8 +30,7 @@ namespace librados {
 
 static void finish_aio_completion(AioCompletionImpl *c, int r) {
   c->lock.Lock();
-  c->ack = true;
-  c->safe = true;
+  c->complete = true;
   c->rval = r;
   c->lock.Unlock();
 

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -260,7 +260,7 @@ int Dumper::undump(const char *dump_file)
   lock.Lock();
   objecter->write_full(oid, oloc, snapc, hbl,
 		       ceph::real_clock::now(), 0,
-		       NULL, &header_cond);
+		       &header_cond);
   lock.Unlock();
 
   r = header_cond.wait();

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -306,7 +306,7 @@ int Dumper::undump(const char *dump_file)
     C_SaferCond write_cond;
     lock.Lock();
     filer.write(ino, &h.layout, snapc, pos, l, j,
-		ceph::real_clock::now(), 0, NULL, &write_cond);
+		ceph::real_clock::now(), 0, &write_cond);
     lock.Unlock();
 
     r = write_cond.wait();


### PR DESCRIPTION
Remove duplicate callbacks.  Simplify code.