### PR TITLE
mon: MonMap: clear 'mon_info' during decode

### DIFF
--- a/src/mon/MonMap.cc
+++ b/src/mon/MonMap.cc
@@ -209,6 +209,11 @@ void MonMap::decode(bufferlist::iterator &p)
   }
   if (struct_v >= 5) {
     ::decode(mon_info, p);
+  } else {
+    // we may be decoding to an existing monmap; if we do not
+    // clear the mon_info map now, we will likely incur in problems
+    // later on MonMap::sanitize_mons()
+    mon_info.clear();
   }
   DECODE_FINISH(p);
   sanitize_mons(mon_addr);


### PR DESCRIPTION
It so happens that it's not safe to assume the monmap will be in an
empty state upon decoding.

Turns out the MonClient will reuse the MonMap instance when decoding
the just received map from the monitors. Should the monitors be on an
older version that do not support 'mon_info', this field will not be
decoded (after all, there's no field to decode from); but by this time,
the MonClient would already have a built monmap, which could have
populated 'mon_info' with temporary mon names from 'mon initial
members'.

Given the existing entries in 'mon_info', and the conflicting entries in
'mon_addr', we would end up asserting in 'sanitize_mons()'. This becomes
a non-issue if 'mon_info' is empty, as was unfortunately presumed.

Fixes: http://tracker.ceph.com/issues/18265
Signed-off-by: Joao Eduardo Luis <joao@suse.de>