### PR TITLE
osd/ReplicatedBackend: do not set omap header if it is empty

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1669,7 +1669,8 @@ void ReplicatedBackend::submit_push_data(
     t->remove(coll, ghobject_t(target_oid));
     t->touch(coll, ghobject_t(target_oid));
     t->truncate(coll, ghobject_t(target_oid), recovery_info.size);
-    t->omap_setheader(coll, ghobject_t(target_oid), omap_header);
+    if (omap_header.length()) 
+      t->omap_setheader(coll, ghobject_t(target_oid), omap_header);
 
     bufferlist bv = attrs[OI_ATTR];
     object_info_t oi(bv);


### PR DESCRIPTION
In replicatedpg backfill, objects have no omap header or keys previously, but an empty omap header will be inserted when they are pushed to replica, which leads leveldb performance degrade seriously when cluster has huge number of objects.
so my opinion is that we does't insert omap header if is size is zero when handle PushOp in recovery.
Signed-off-by:  fangyuxiang <fang.yuxiang@eisoo.com>
