### PR TITLE
  osd/PGLog: add the missed case if there is only one divergent entry

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -795,7 +795,7 @@ protected:
       ldpp_dout(dpp, 10) << __func__ << ": more recent entry found: "
 			 << *objiter->second << ", already merged" << dendl;
 
-      assert(objiter->second->version > last_divergent_update);
+      assert(objiter->second->version >= last_divergent_update);
 
       // ensure missing has been updated appropriately
       if (objiter->second->is_update()) {


### PR DESCRIPTION
  Fixes: http://tracker.ceph.com/issues/16279

  Signed-off-by: huangjun <hjwsm1989@gmail.com>