### PR TITLE
os/bluestore/bluefs: make bluefs_preextend_wal_files default is false.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -987,7 +987,7 @@ OPTION(bluefs_min_flush_size, OPT_U64, 65536)  // ignore flush until its this bi
 OPTION(bluefs_compact_log_sync, OPT_BOOL, false)  // sync or async log compaction?
 OPTION(bluefs_buffered_io, OPT_BOOL, false)
 OPTION(bluefs_allocator, OPT_STR, "bitmap")     // stupid | bitmap
-OPTION(bluefs_preextend_wal_files, OPT_BOOL, true)  // this *requires* that rocksdb has recycling enabled
+OPTION(bluefs_preextend_wal_files, OPT_BOOL, false)  // this *requires* that rocksdb has recycling enabled
 
 OPTION(bluestore_bluefs, OPT_BOOL, true)
 OPTION(bluestore_bluefs_env_mirror, OPT_BOOL, false) // mirror to normal Env for debug


### PR DESCRIPTION
This make rocksdb log corruption. Before fix, disable this function.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>