### PR TITLE
osd: correct epoch setting of osd boot msg

### DIFF
--- a/src/messages/MOSDBoot.h
+++ b/src/messages/MOSDBoot.h
@@ -37,12 +37,12 @@ class MOSDBoot : public PaxosServiceMessage {
     : PaxosServiceMessage(MSG_OSD_BOOT, 0, HEAD_VERSION, COMPAT_VERSION),
       boot_epoch(0), osd_features(0)
   { }
-  MOSDBoot(OSDSuperblock& s, epoch_t be,
+  MOSDBoot(OSDSuperblock& s, epoch_t e, epoch_t be,
 	   const entity_addr_t& hb_back_addr_ref,
 	   const entity_addr_t& hb_front_addr_ref,
            const entity_addr_t& cluster_addr_ref,
 	   uint64_t feat)
-    : PaxosServiceMessage(MSG_OSD_BOOT, s.current_epoch, HEAD_VERSION, COMPAT_VERSION),
+    : PaxosServiceMessage(MSG_OSD_BOOT, e, HEAD_VERSION, COMPAT_VERSION),
       sb(s),
       hb_back_addr(hb_back_addr_ref),
       hb_front_addr(hb_front_addr_ref),

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5084,7 +5084,7 @@ void OSD::_send_boot()
       hb_front_server_messenger->ms_deliver_handle_fast_connect(local_connection);
   }
 
-  MOSDBoot *mboot = new MOSDBoot(superblock, service.get_boot_epoch(),
+  MOSDBoot *mboot = new MOSDBoot(superblock, get_osdmap_epoch(), service.get_boot_epoch(),
                                  hb_back_addr, hb_front_addr, cluster_addr,
 				 CEPH_FEATURES_ALL);
   dout(10) << " client_addr " << client_messenger->get_myaddr()


### PR DESCRIPTION
use get_osdmap_epoch() maybe better than superblock's current_epoch, because
_send_boot() might happen when committing new osdmap, superblock.current_epoch
prior to osdmap.epoch, _committed_osd_map() may modify some osd metadata thereafter,
thus, break the consistency between epoch and metadata in boot msg.

Signed-off-by: Mingxin Liu <mingxin@xsky.com>