### PR TITLE
common/ceph_crypto: warn + assert if crypto shutdown fails

### DIFF
--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -59,7 +59,11 @@ void ceph::crypto::shutdown(bool shared)
   pthread_mutex_lock(&crypto_init_mutex);
   ceph_assert(crypto_refs > 0);
   if (--crypto_refs == 0) {
-    NSS_ShutdownContext(crypto_context);
+    int r = NSS_ShutdownContext(crypto_context);
+    if (r) {
+      cerr << "NSS_ShutdownContext failed; leaked objects?" << std::endl;
+      assert(0 == "NSS_ShutdownContext failed");
+    }
     if (!shared) {
       PR_Cleanup();
     }


### PR DESCRIPTION
If we fail to shutdown, subsequent attempts to init within the same
process can fail.  This can be triggered by leaked crypto objects (e.g.,
an AsyncConnection).  The symptom is asserts on crypto init like so:

common/ceph_crypto.cc: In function 'void ceph::crypto::init(CephContext*)' thread 7f8d9cd208c0 time 2016-07-14 12:17:44.515176
common/ceph_crypto.cc: 73: FAILED assert(crypto_context != __null)

which is quite confusing. See http://tracker.ceph.com/issues/14115.

Warn and assert early (on shutdown!) so we can catch bugs!

We should pass these suites:
- [x] rados
- [x] rgw
- [ ] rbd
- [ ] fs

