### PR TITLE
os/bluestore: remove 'extents' from shard_info

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1661,7 +1661,6 @@ bool BlueStore::ExtentMap::update(Onode *o, KeyValueDB::Transaction t,
         }
 	assert(p->shard_info->offset == p->offset);
 	p->shard_info->bytes = len;
-	p->shard_info->extents = nn;
 	t->set(PREFIX_OBJ, p->key, bl);
 	p->dirty = false;
       }

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -546,13 +546,12 @@ void bluestore_onode_t::shard_info::dump(Formatter *f) const
 {
   f->dump_unsigned("offset", offset);
   f->dump_unsigned("bytes", bytes);
-  f->dump_unsigned("extents", extents);
 }
 
 ostream& operator<<(ostream& out, const bluestore_onode_t::shard_info& si)
 {
-  return out << std::hex << "0x" << si.offset << "(0x" << si.bytes << " bytes, "
-	     << std::dec << si.extents << " extents)";
+  return out << std::hex << "0x" << si.offset << "(0x" << si.bytes << " bytes"
+	     << std::dec << ")";
 }
 
 void bluestore_onode_t::dump(Formatter *f) const

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -673,11 +673,9 @@ struct bluestore_onode_t {
   struct shard_info {
     uint32_t offset = 0;  ///< logical offset for start of shard
     uint32_t bytes = 0;   ///< encoded bytes
-    uint32_t extents = 0; ///< extents
     DENC(shard_info, v, p) {
       denc_varint(v.offset, p);
       denc_varint(v.bytes, p);
-      denc_varint(v.extents, p);
     }
     void dump(Formatter *f) const;
   };


### PR DESCRIPTION
We don't use this field; no need to consume the space
on disk.

Signed-off-by: Sage Weil <sage@redhat.com>