### PR TITLE
qa/tasks/workunit: clear clone dir before retrying checkout

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -313,11 +313,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,
@@ -334,11 +338,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 alt_git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,


### PR DESCRIPTION
If we checkout ceph-ci.git, and don't find a branch,
we'll try again from ceph.git. But the checkout will
already exist and the clone will fail, so we'll still
fail to find the branch.

The same can happen if a previous workunit task already
checked out the repo.

Fix by removing the repo before checkout (the first and
second times).  Note that this may break if there are
multiple workunit tasks running in parallel on the same
role.  That is already racy, so if it's happening, we'll
want to switch to using a truly unique clonedir for each
instantiation.

Fixes: http://tracker.ceph.com/issues/18336
Signed-off-by: Sage Weil <sage@redhat.com>