### PR TITLE
doc: Remove "splitting" state

### DIFF
--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -22,9 +22,6 @@ map is ``active + clean``.
 *Replay*
   The placement group is waiting for clients to replay operations after an OSD crashed.
 
-*Splitting*
-  Ceph is splitting the placement group into multiple placement groups. (functional?)
-
 *Scrubbing*
   Ceph is checking the placement group for inconsistencies.
 


### PR DESCRIPTION
There is no splitting state so remove it from pg-states.rst

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>