### PR TITLE
librbd: don't continue to remove an image w/ incompatible features

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1502,6 +1502,9 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     if (r < 0) {
       ldout(cct, 2) << "error opening image: " << cpp_strerror(-r) << dendl;
       delete ictx;
+      if (r != -ENOENT) {
+	return r;
+      }
     } else {
       string header_oid = ictx->header_oid;
       old_format = ictx->old_format;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18315
Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>