### PR TITLE
os/bluestore: remove intermediate key var to avoid string copy

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4608,9 +4608,8 @@ int BlueStore::fsck(bool deep)
   it = db->get_iterator(PREFIX_OMAP);
   if (it) {
     for (it->lower_bound(string()); it->valid(); it->next()) {
-      string key = it->key();
       uint64_t omap_head;
-      _key_decode_u64(key.c_str(), &omap_head);
+      _key_decode_u64(it->key().c_str(), &omap_head);
       if (used_omap_head.count(omap_head) == 0) {
 	derr << __func__ << " found stray omap data on omap_head " << omap_head
 	     << dendl;


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>

@ifed01  In favor of comment at https://github.com/ceph/ceph/pull/12618