### PR TITLE
os/bluestore: preallocate object[extent_shard] key to avoid reallocate

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -281,6 +281,14 @@ static void get_object_key(const ghobject_t& oid, string *key)
 {
   key->clear();
 
+  size_t max_len = 1 + 8 + 4 +
+                  (oid.hobj.nspace.length() * 3 + 1) +
+                  (oid.hobj.get_key().length() * 3 + 1) +
+                   1 + // for '<', '=', or '>'
+                  (oid.hobj.oid.name.length() * 3 + 1) +
+                   8 + 8 + 1;
+  key->reserve(max_len);
+
   _key_encode_shard(oid.shard_id, key);
   _key_encode_u64(oid.hobj.pool + 0x8000000000000000ull, key);
   _key_encode_u32(oid.hobj.get_bitwise_key_u32(), key);
@@ -392,6 +400,7 @@ static void get_extent_shard_key(const string& onode_key, uint32_t offset,
 				 string *key)
 {
   key->clear();
+  key->reserve(onode_key.length() + 4 + 1);
   key->append(onode_key);
   _key_encode_u32(offset, key);
   key->push_back(EXTENT_SHARD_KEY_SUFFIX);


### PR DESCRIPTION
which is less efficient.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>