### PR TITLE
librbd: add writesame API

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -638,6 +638,8 @@ CEPH_RBD_API ssize_t rbd_write(rbd_image_t image, uint64_t ofs, size_t len,
 CEPH_RBD_API ssize_t rbd_write2(rbd_image_t image, uint64_t ofs, size_t len,
                                 const char *buf, int op_flags);
 CEPH_RBD_API int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len);
+CEPH_RBD_API ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
+                                   const char *buf, size_t data_len, int op_flags);
 CEPH_RBD_API int rbd_aio_write(rbd_image_t image, uint64_t off, size_t len,
                                const char *buf, rbd_completion_t c);
 
@@ -660,6 +662,9 @@ CEPH_RBD_API int rbd_aio_readv(rbd_image_t image, const struct iovec *iov,
                                int iovcnt, uint64_t off, rbd_completion_t c);
 CEPH_RBD_API int rbd_aio_discard(rbd_image_t image, uint64_t off, uint64_t len,
                                  rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
+                                   const char *buf, size_t data_len,
+                                   rbd_completion_t c, int op_flags);
 
 CEPH_RBD_API int rbd_aio_create_completion(void *cb_arg,
                                            rbd_callback_t complete_cb,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -339,11 +339,14 @@ public:
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   ssize_t write2(uint64_t ofs, size_t len, ceph::bufferlist& bl, int op_flags);
   int discard(uint64_t ofs, uint64_t len);
+  ssize_t writesame(uint64_t ofs, size_t len, ceph::bufferlist &bl, int op_flags);
 
   int aio_write(uint64_t off, size_t len, ceph::bufferlist& bl, RBD::AioCompletion *c);
   /* @param op_flags see librados.h constants beginning with LIBRADOS_OP_FLAG */
   int aio_write2(uint64_t off, size_t len, ceph::bufferlist& bl,
 		  RBD::AioCompletion *c, int op_flags);
+  int aio_writesame(uint64_t off, size_t len, ceph::bufferlist& bl,
+                    RBD::AioCompletion *c, int op_flags);
   /**
    * read async from image
    *

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -971,7 +971,8 @@ struct C_InvalidateCache : public Context {
         "rbd_journal_max_payload_bytes", false)(
         "rbd_journal_max_concurrent_object_sets", false)(
         "rbd_mirroring_resync_after_disconnect", false)(
-        "rbd_mirroring_replay_delay", false);
+        "rbd_mirroring_replay_delay", false)(
+        "rbd_skip_partial_discard", false);
 
     md_config_t local_config_t;
     std::map<std::string, bufferlist> res;
@@ -1030,6 +1031,7 @@ struct C_InvalidateCache : public Context {
     ASSIGN_OPTION(journal_max_concurrent_object_sets);
     ASSIGN_OPTION(mirroring_resync_after_disconnect);
     ASSIGN_OPTION(mirroring_replay_delay);
+    ASSIGN_OPTION(skip_partial_discard);
   }
 
   ExclusiveLock<ImageCtx> *ImageCtx::create_exclusive_lock() {

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -369,6 +369,9 @@ struct C_InvalidateCache : public Context {
     plb.add_u64_counter(l_librbd_flush, "flush", "Flushes");
     plb.add_u64_counter(l_librbd_aio_flush, "aio_flush", "Async flushes");
     plb.add_time_avg(l_librbd_aio_flush_latency, "aio_flush_latency", "Latency of async flushes");
+    plb.add_u64_counter(l_librbd_ws, "ws", "WriteSames");
+    plb.add_u64_counter(l_librbd_ws_bytes, "ws_bytes", "WriteSame data");
+    plb.add_time_avg(l_librbd_ws_latency, "ws_latency", "WriteSame latency");
     plb.add_u64_counter(l_librbd_snap_create, "snap_create", "Snap creations");
     plb.add_u64_counter(l_librbd_snap_remove, "snap_remove", "Snap removals");
     plb.add_u64_counter(l_librbd_snap_rollback, "snap_rollback", "Snap rollbacks");

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -193,6 +193,7 @@ namespace librbd {
     int journal_max_concurrent_object_sets;
     bool mirroring_resync_after_disconnect;
     int mirroring_replay_delay;
+    bool skip_partial_discard;
 
     LibrbdAdminSocketHook *asok_hook;
 

--- a/src/librbd/cache/ImageCache.h
+++ b/src/librbd/cache/ImageCache.h
@@ -28,7 +28,7 @@ struct ImageCache {
   virtual void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
                          int fadvise_flags, Context *on_finish) = 0;
   virtual void aio_discard(uint64_t offset, uint64_t length,
-                           Context *on_finish) = 0;
+                           bool skip_partial_discard, Context *on_finish) = 0;
   virtual void aio_flush(Context *on_finish) = 0;
   virtual void aio_writesame(uint64_t offset, uint64_t length,
                              ceph::bufferlist&& bl,

--- a/src/librbd/cache/ImageCache.h
+++ b/src/librbd/cache/ImageCache.h
@@ -30,6 +30,9 @@ struct ImageCache {
   virtual void aio_discard(uint64_t offset, uint64_t length,
                            Context *on_finish) = 0;
   virtual void aio_flush(Context *on_finish) = 0;
+  virtual void aio_writesame(uint64_t offset, uint64_t length,
+                             ceph::bufferlist&& bl,
+                             int fadvise_flags, Context *on_finish) = 0;
 
   /// internal state methods
   virtual void init(Context *on_finish) = 0;

--- a/src/librbd/cache/ImageWriteback.cc
+++ b/src/librbd/cache/ImageWriteback.cc
@@ -53,7 +53,7 @@ void ImageWriteback<I>::aio_write(Extents &&image_extents,
 
 template <typename I>
 void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
-                                    Context *on_finish) {
+                                    bool skip_partial_discard, Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "offset=" << offset << ", "
                  << "length=" << length << ", "
@@ -61,7 +61,8 @@ void ImageWriteback<I>::aio_discard(uint64_t offset, uint64_t length,
 
   auto aio_comp = io::AioCompletion::create_and_start(on_finish, &m_image_ctx,
                                                       io::AIO_TYPE_DISCARD);
-  io::ImageDiscardRequest<I> req(m_image_ctx, aio_comp, offset, length);
+  io::ImageDiscardRequest<I> req(m_image_ctx, aio_comp, offset, length,
+                                 skip_partial_discard);
   req.set_bypass_image_cache();
   req.send();
 }

--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -30,7 +30,8 @@ public:
                 int fadvise_flags, Context *on_finish);
   void aio_write(Extents &&image_extents, ceph::bufferlist&& bl,
                  int fadvise_flags, Context *on_finish);
-  void aio_discard(uint64_t offset, uint64_t length, Context *on_finish);
+  void aio_discard(uint64_t offset, uint64_t length,
+                   bool skip_partial_discard, Context *on_finish);
   void aio_flush(Context *on_finish);
   void aio_writesame(uint64_t offset, uint64_t length,
                      ceph::bufferlist&& bl,

--- a/src/librbd/cache/ImageWriteback.h
+++ b/src/librbd/cache/ImageWriteback.h
@@ -32,6 +32,9 @@ public:
                  int fadvise_flags, Context *on_finish);
   void aio_discard(uint64_t offset, uint64_t length, Context *on_finish);
   void aio_flush(Context *on_finish);
+  void aio_writesame(uint64_t offset, uint64_t length,
+                     ceph::bufferlist&& bl,
+                     int fadvise_flags, Context *on_finish);
 
 private:
   ImageCtxT &m_image_ctx;

--- a/src/librbd/cache/PassthroughImageCache.cc
+++ b/src/librbd/cache/PassthroughImageCache.cc
@@ -63,6 +63,20 @@ void PassthroughImageCache<I>::aio_flush(Context *on_finish) {
 }
 
 template <typename I>
+void PassthroughImageCache<I>::aio_writesame(uint64_t offset, uint64_t length,
+                                             bufferlist&& bl, int fadvise_flags,
+                                             Context *on_finish) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 20) << "offset=" << offset << ", "
+                 << "length=" << length << ", "
+                 << "data_len=" << bl.length() << ", "
+                 << "on_finish=" << on_finish << dendl;
+
+  m_image_writeback.aio_writesame(offset, length, std::move(bl), fadvise_flags,
+                                  on_finish);
+}
+
+template <typename I>
 void PassthroughImageCache<I>::init(Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << dendl;

--- a/src/librbd/cache/PassthroughImageCache.cc
+++ b/src/librbd/cache/PassthroughImageCache.cc
@@ -45,13 +45,13 @@ void PassthroughImageCache<I>::aio_write(Extents &&image_extents,
 
 template <typename I>
 void PassthroughImageCache<I>::aio_discard(uint64_t offset, uint64_t length,
-                                           Context *on_finish) {
+                                           bool skip_partial_discard, Context *on_finish) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "offset=" << offset << ", "
                  << "length=" << length << ", "
                  << "on_finish=" << on_finish << dendl;
 
-  m_image_writeback.aio_discard(offset, length, on_finish);
+  m_image_writeback.aio_discard(offset, length, skip_partial_discard, on_finish);
 }
 
 template <typename I>

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -27,7 +27,7 @@ public:
   void aio_write(Extents&& image_extents, ceph::bufferlist&& bl,
                  int fadvise_flags, Context *on_finish) override;
   void aio_discard(uint64_t offset, uint64_t length,
-                   Context *on_finish) override;
+                   bool skip_partial_discard, Context *on_finish);
   void aio_flush(Context *on_finish) override;
   virtual void aio_writesame(uint64_t offset, uint64_t length,
                              ceph::bufferlist&& bl,

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -29,9 +29,9 @@ public:
   void aio_discard(uint64_t offset, uint64_t length,
                    bool skip_partial_discard, Context *on_finish);
   void aio_flush(Context *on_finish) override;
-  virtual void aio_writesame(uint64_t offset, uint64_t length,
-                             ceph::bufferlist&& bl,
-                             int fadvise_flags, Context *on_finish);
+  void aio_writesame(uint64_t offset, uint64_t length,
+                     ceph::bufferlist&& bl,
+                     int fadvise_flags, Context *on_finish) override;
 
   /// internal state methods
   void init(Context *on_finish) override;

--- a/src/librbd/cache/PassthroughImageCache.h
+++ b/src/librbd/cache/PassthroughImageCache.h
@@ -29,6 +29,9 @@ public:
   void aio_discard(uint64_t offset, uint64_t length,
                    Context *on_finish) override;
   void aio_flush(Context *on_finish) override;
+  virtual void aio_writesame(uint64_t offset, uint64_t length,
+                             ceph::bufferlist&& bl,
+                             int fadvise_flags, Context *on_finish);
 
   /// internal state methods
   void init(Context *on_finish) override;

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -33,6 +33,9 @@ enum {
 
   l_librbd_aio_flush,
   l_librbd_aio_flush_latency,
+  l_librbd_ws,
+  l_librbd_ws_bytes,
+  l_librbd_ws_latency,
 
   l_librbd_snap_create,
   l_librbd_snap_remove,

--- a/src/librbd/io/AioCompletion.cc
+++ b/src/librbd/io/AioCompletion.cc
@@ -70,6 +70,8 @@ void AioCompletion::complete() {
     ictx->perfcounter->tinc(l_librbd_discard_latency, elapsed); break;
   case AIO_TYPE_FLUSH:
     ictx->perfcounter->tinc(l_librbd_aio_flush_latency, elapsed); break;
+  case AIO_TYPE_WRITESAME:
+    ictx->perfcounter->tinc(l_librbd_ws_latency, elapsed); break;
   default:
     lderr(cct) << "completed invalid aio_type: " << aio_type << dendl;
     break;

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -804,8 +804,8 @@ ObjectRequestHandle *ImageWriteSameRequest<I>::create_object_request(
 template <typename I>
 void ImageWriteSameRequest<I>::update_stats(size_t length) {
   I &image_ctx = this->m_image_ctx;
-  image_ctx.perfcounter->inc(l_librbd_wr);
-  image_ctx.perfcounter->inc(l_librbd_wr_bytes, length);
+  image_ctx.perfcounter->inc(l_librbd_ws);
+  image_ctx.perfcounter->inc(l_librbd_ws_bytes, length);
 }
 
 } // namespace io

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -142,6 +142,15 @@ void ImageRequest<I>::aio_flush(I *ictx, AioCompletion *c) {
 }
 
 template <typename I>
+void ImageRequest<I>::aio_writesame(I *ictx, AioCompletion *c,
+                                    uint64_t off, uint64_t len,
+                                    bufferlist &&bl,
+                                    int op_flags) {
+  ImageWriteSameRequest<I> req(*ictx, c, off, len, std::move(bl), op_flags);
+  req.send();
+}
+
+template <typename I>
 void ImageRequest<I>::send() {
   I &image_ctx = this->m_image_ctx;
   assert(m_aio_comp->is_initialized(get_aio_type()));
@@ -654,6 +663,151 @@ void ImageFlushRequest<I>::send_image_cache_request() {
   image_ctx.image_cache->aio_flush(req_comp);
 }
 
+template <typename I>
+bool ImageWriteSameRequest<I>::assemble_writesame_extent(const ObjectExtent &object_extent,
+                                                         bufferlist *bl, bool force_write) {
+  size_t m_data_len = m_data_bl.length();
+
+  if (!force_write) {
+    bool may_writesame = true;
+
+    for (auto q = object_extent.buffer_extents.begin();
+         q != object_extent.buffer_extents.end(); ++q) {
+      if (!(q->first % m_data_len == 0 && q->second % m_data_len == 0)) {
+        may_writesame = false;
+        break;
+      }
+    }
+
+    if (may_writesame) {
+      bl->append(m_data_bl);
+      return true;
+    }
+  }
+
+  for (auto q = object_extent.buffer_extents.begin();
+       q != object_extent.buffer_extents.end(); ++q) {
+    bufferlist sub_bl;
+    uint64_t sub_off = q->first % m_data_len;
+    uint64_t sub_len = m_data_len - sub_off;
+    uint64_t extent_left = q->second;
+    while (extent_left >= sub_len) {
+      sub_bl.substr_of(m_data_bl, sub_off, sub_len);
+      bl->claim_append(sub_bl);
+      extent_left -= sub_len;
+      if (sub_off) {
+	sub_off = 0;
+	sub_len = m_data_len;
+      }
+    }
+    if (extent_left) {
+      sub_bl.substr_of(m_data_bl, sub_off, extent_left);
+      bl->claim_append(sub_bl);
+    }
+  }
+  return false;
+}
+
+template <typename I>
+uint64_t ImageWriteSameRequest<I>::append_journal_event(
+    const ObjectRequests &requests, bool synchronous) {
+  I &image_ctx = this->m_image_ctx;
+
+  uint64_t tid = 0;
+  assert(!this->m_image_extents.empty());
+  for (auto &extent : this->m_image_extents) {
+    journal::EventEntry event_entry(journal::AioWriteSameEvent(extent.first,
+                                                               extent.second,
+                                                               m_data_bl));
+    tid = image_ctx.journal->append_io_event(std::move(event_entry),
+                                             requests, extent.first,
+                                             extent.second, synchronous);
+  }
+
+  if (image_ctx.object_cacher == NULL) {
+    AioCompletion *aio_comp = this->m_aio_comp;
+    aio_comp->associate_journal_event(tid);
+  }
+  return tid;
+}
+
+template <typename I>
+void ImageWriteSameRequest<I>::send_image_cache_request() {
+  I &image_ctx = this->m_image_ctx;
+  assert(image_ctx.image_cache != nullptr);
+
+  AioCompletion *aio_comp = this->m_aio_comp;
+  aio_comp->set_request_count(this->m_image_extents.size());
+  for (auto &extent : this->m_image_extents) {
+    C_AioRequest *req_comp = new C_AioRequest(aio_comp);
+    image_ctx.image_cache->aio_writesame(extent.first, extent.second,
+                                         std::move(m_data_bl), m_op_flags,
+                                         req_comp);
+  }
+}
+
+template <typename I>
+void ImageWriteSameRequest<I>::send_object_cache_requests(
+    const ObjectExtents &object_extents, uint64_t journal_tid) {
+  I &image_ctx = this->m_image_ctx;
+  for (auto p = object_extents.begin(); p != object_extents.end(); ++p) {
+    const ObjectExtent &object_extent = *p;
+
+    bufferlist bl;
+    assemble_writesame_extent(object_extent, &bl, true);
+
+    AioCompletion *aio_comp = this->m_aio_comp;
+    C_AioRequest *req_comp = new C_AioRequest(aio_comp);
+    image_ctx.write_to_cache(object_extent.oid, bl, object_extent.length,
+                             object_extent.offset, req_comp, m_op_flags,
+                             journal_tid);
+  }
+}
+
+template <typename I>
+void ImageWriteSameRequest<I>::send_object_requests(
+    const ObjectExtents &object_extents, const ::SnapContext &snapc,
+    ObjectRequests *object_requests) {
+  I &image_ctx = this->m_image_ctx;
+
+  // cache handles creating object requests during writeback
+  if (image_ctx.object_cacher == NULL) {
+    AbstractImageWriteRequest<I>::send_object_requests(object_extents, snapc,
+                                                       object_requests);
+  }
+}
+
+template <typename I>
+ObjectRequestHandle *ImageWriteSameRequest<I>::create_object_request(
+    const ObjectExtent &object_extent, const ::SnapContext &snapc,
+    Context *on_finish) {
+  I &image_ctx = this->m_image_ctx;
+  assert(image_ctx.object_cacher == NULL);
+
+  bufferlist bl;
+  ObjectRequest<I> *req;
+
+  if (assemble_writesame_extent(object_extent, &bl, false)) {
+    req = ObjectRequest<I>::create_writesame(
+      &image_ctx, object_extent.oid.name, object_extent.objectno,
+      object_extent.offset, object_extent.length,
+      bl, snapc, on_finish, m_op_flags);
+    return req;
+  }
+  req = ObjectRequest<I>::create_write(
+    &image_ctx, object_extent.oid.name, object_extent.objectno,
+    object_extent.offset,
+    bl, snapc, on_finish, m_op_flags);
+  return req;
+}
+
+template <typename I>
+void ImageWriteSameRequest<I>::update_stats(size_t length) {
+  I &image_ctx = this->m_image_ctx;
+  image_ctx.perfcounter->inc(l_librbd_wr);
+  image_ctx.perfcounter->inc(l_librbd_wr_bytes, length);
+}
+
 } // namespace io
 } // namespace librbd
 
@@ -663,3 +817,4 @@ template class librbd::io::AbstractImageWriteRequest<librbd::ImageCtx>;
 template class librbd::io::ImageWriteRequest<librbd::ImageCtx>;
 template class librbd::io::ImageDiscardRequest<librbd::ImageCtx>;
 template class librbd::io::ImageFlushRequest<librbd::ImageCtx>;
+template class librbd::io::ImageWriteSameRequest<librbd::ImageCtx>;

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -276,31 +276,31 @@ protected:
   using typename ImageRequest<ImageCtxT>::ObjectRequests;
   using typename AbstractImageWriteRequest<ImageCtxT>::ObjectExtents;
 
-  virtual aio_type_t get_aio_type() const {
+  aio_type_t get_aio_type() const override {
     return AIO_TYPE_WRITESAME;
   }
-  virtual const char *get_request_type() const {
+  const char *get_request_type() const override {
     return "aio_writesame";
   }
 
   bool assemble_writesame_extent(const ObjectExtent &object_extent,
                                  bufferlist *bl, bool force_write);
 
-  virtual void send_image_cache_request() override;
+  void send_image_cache_request() override;
 
-  virtual void send_object_cache_requests(const ObjectExtents &object_extents,
-                                          uint64_t journal_tid);
+  void send_object_cache_requests(const ObjectExtents &object_extents,
+                                  uint64_t journal_tid) override;
 
-  virtual void send_object_requests(const ObjectExtents &object_extents,
-                                    const ::SnapContext &snapc,
-                                    ObjectRequests *object_requests);
-  virtual ObjectRequestHandle *create_object_request(
+  void send_object_requests(const ObjectExtents &object_extents,
+                            const ::SnapContext &snapc,
+                            ObjectRequests *object_requests) override;
+  ObjectRequestHandle *create_object_request(
       const ObjectExtent &object_extent, const ::SnapContext &snapc,
-      Context *on_finish);
+      Context *on_finish) override;
 
-  virtual uint64_t append_journal_event(const ObjectRequests &requests,
-                                        bool synchronous);
-  virtual void update_stats(size_t length);
+  uint64_t append_journal_event(const ObjectRequests &requests,
+                                bool synchronous) override;
+  void update_stats(size_t length) override;
 private:
   bufferlist m_data_bl;
   int m_op_flags;

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -35,7 +35,7 @@ public:
   static void aio_write(ImageCtxT *ictx, AioCompletion *c,
                         Extents &&image_extents, bufferlist &&bl, int op_flags);
   static void aio_discard(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
-                          uint64_t len);
+                          uint64_t len, bool skip_partial_discard);
   static void aio_flush(ImageCtxT *ictx, AioCompletion *c);
   static void aio_writesame(ImageCtxT *ictx, AioCompletion *c, uint64_t off,
                             uint64_t len, bufferlist &&bl, int op_flags);
@@ -199,8 +199,9 @@ template <typename ImageCtxT = ImageCtx>
 class ImageDiscardRequest : public AbstractImageWriteRequest<ImageCtxT> {
 public:
   ImageDiscardRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
-                      uint64_t off, uint64_t len)
-    : AbstractImageWriteRequest<ImageCtxT>(image_ctx, aio_comp, {{off, len}}) {
+                      uint64_t off, uint64_t len, bool skip_partial_discard)
+    : AbstractImageWriteRequest<ImageCtxT>(image_ctx, aio_comp, {{off, len}}),
+      m_skip_partial_discard(skip_partial_discard) {
   }
 
 protected:
@@ -229,6 +230,8 @@ protected:
   uint64_t append_journal_event(const ObjectRequests &requests,
                                 bool synchronous) override;
   void update_stats(size_t length) override;
+private:
+  bool m_skip_partial_discard;
 };
 
 template <typename ImageCtxT = ImageCtx>

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -28,7 +28,7 @@ public:
   ssize_t read(uint64_t off, uint64_t len, ReadResult &&read_result,
                int op_flags);
   ssize_t write(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
-  int discard(uint64_t off, uint64_t len);
+  int discard(uint64_t off, uint64_t len, bool skip_partial_discard);
   ssize_t writesame(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len,
@@ -36,7 +36,7 @@ public:
   void aio_write(AioCompletion *c, uint64_t off, uint64_t len,
                  bufferlist &&bl, int op_flags, bool native_async=true);
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
-                   bool native_async=true);
+                   bool skip_partial_discard, bool native_async=true);
   void aio_flush(AioCompletion *c, bool native_async=true);
   void aio_writesame(AioCompletion *c, uint64_t off, uint64_t len,
                      bufferlist &&bl, int op_flags, bool native_async=true);

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -29,6 +29,7 @@ public:
                int op_flags);
   ssize_t write(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
   int discard(uint64_t off, uint64_t len);
+  ssize_t writesame(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len,
                 ReadResult &&read_result, int op_flags, bool native_async=true);
@@ -37,8 +38,11 @@ public:
   void aio_discard(AioCompletion *c, uint64_t off, uint64_t len,
                    bool native_async=true);
   void aio_flush(AioCompletion *c, bool native_async=true);
+  void aio_writesame(AioCompletion *c, uint64_t off, uint64_t len,
+                     bufferlist &&bl, int op_flags, bool native_async=true);
 
   using ThreadPool::PointerWQ<ImageRequest<ImageCtx> >::drain;
+
   using ThreadPool::PointerWQ<ImageRequest<ImageCtx> >::empty;
 
   void shut_down(Context *on_shutdown);

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -68,6 +68,14 @@ public:
                                     uint64_t object_len,
                                     const ::SnapContext &snapc,
                                     Context *completion);
+  static ObjectRequest* create_writesame(ImageCtxT *ictx,
+                                         const std::string &oid,
+                                         uint64_t object_no,
+                                         uint64_t object_off,
+                                         uint64_t object_len,
+                                         const ceph::bufferlist &data,
+                                         const ::SnapContext &snapc,
+                                         Context *completion, int op_flags);
 
   ObjectRequest(ImageCtx *ictx, const std::string &oid,
                 uint64_t objectno, uint64_t off, uint64_t len,
@@ -448,6 +456,37 @@ protected:
   void add_write_ops(librados::ObjectWriteOperation *wr) override {
     wr->zero(m_object_off, m_object_len);
   }
+};
+
+class ObjectWriteSameRequest : public AbstractObjectWriteRequest {
+public:
+  ObjectWriteSameRequest(ImageCtx *ictx, const std::string &oid, uint64_t object_no,
+                         uint64_t object_off, uint64_t object_len,
+                         const ceph::bufferlist &data,
+                         const ::SnapContext &snapc, Context *completion,
+                         int op_flags)
+    : AbstractObjectWriteRequest(ictx, oid, object_no, object_off,
+                                 object_len, snapc, completion, false),
+      m_write_data(data), m_op_flags(op_flags) {
+  }
+
+  virtual const char *get_op_type() const {
+    return "writesame";
+  }
+
+  virtual bool pre_object_map_update(uint8_t *new_state) {
+    *new_state = OBJECT_EXISTS;
+    return true;
+  }
+
+protected:
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr);
+
+  virtual void send_write();
+
+private:
+  ceph::bufferlist m_write_data;
+  int m_op_flags;
 };
 
 } // namespace io

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -470,19 +470,19 @@ public:
       m_write_data(data), m_op_flags(op_flags) {
   }
 
-  virtual const char *get_op_type() const {
+  const char *get_op_type() const override {
     return "writesame";
   }
 
-  virtual bool pre_object_map_update(uint8_t *new_state) {
+  bool pre_object_map_update(uint8_t *new_state) override {
     *new_state = OBJECT_EXISTS;
     return true;
   }
 
 protected:
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr);
+  void add_write_ops(librados::ObjectWriteOperation *wr) override;
 
-  virtual void send_write();
+  void send_write() override;
 
 private:
   ceph::bufferlist m_write_data;

--- a/src/librbd/io/Types.h
+++ b/src/librbd/io/Types.h
@@ -19,6 +19,7 @@ typedef enum {
   AIO_TYPE_WRITE,
   AIO_TYPE_DISCARD,
   AIO_TYPE_FLUSH,
+  AIO_TYPE_WRITESAME,
 } aio_type_t;
 
 typedef std::vector<std::pair<uint64_t, uint64_t> > Extents;

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -315,7 +315,7 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
                                                io::AIO_TYPE_DISCARD,
                                                &flush_required);
   io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp, event.offset,
-                                   event.length);
+                                   event.length, event.skip_partial_discard);
   if (flush_required) {
     m_lock.Lock();
     auto flush_comp = create_aio_flush_completion(nullptr);

--- a/src/librbd/journal/Replay.h
+++ b/src/librbd/journal/Replay.h
@@ -133,6 +133,8 @@ private:
                     Context *on_safe);
   void handle_event(const AioWriteEvent &event, Context *on_ready,
                     Context *on_safe);
+  void handle_event(const AioWriteSameEvent &event, Context *on_ready,
+                    Context *on_safe);
   void handle_event(const AioFlushEvent &event, Context *on_ready,
                     Context *on_safe);
   void handle_event(const OpFinishEvent &event, Context *on_ready,
@@ -158,7 +160,7 @@ private:
   void handle_event(const DemoteEvent &event, Context *on_ready,
                     Context *on_safe);
   void handle_event(const SnapLimitEvent &event, Context *on_ready,
-		    Context *on_safe);
+                    Context *on_safe);
   void handle_event(const UpdateFeaturesEvent &event, Context *on_ready,
                     Context *on_safe);
   void handle_event(const MetadataSetEvent &event, Context *on_ready,

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -71,16 +71,21 @@ private:
 void AioDiscardEvent::encode(bufferlist& bl) const {
   ::encode(offset, bl);
   ::encode(length, bl);
+  ::encode(skip_partial_discard, bl);
 }
 
 void AioDiscardEvent::decode(__u8 version, bufferlist::iterator& it) {
   ::decode(offset, it);
   ::decode(length, it);
+  if (version >= 5) {
+    ::decode(skip_partial_discard, it);
+  }
 }
 
 void AioDiscardEvent::dump(Formatter *f) const {
   f->dump_unsigned("offset", offset);
   f->dump_unsigned("length", length);
+  f->dump_bool("skip_partial_discard", skip_partial_discard);
 }
 
 uint32_t AioWriteEvent::get_fixed_size() {
@@ -335,7 +340,7 @@ EventType EventEntry::get_event_type() const {
 }
 
 void EventEntry::encode(bufferlist& bl) const {
-  ENCODE_START(4, 1, bl);
+  ENCODE_START(5, 1, bl);
   boost::apply_visitor(EncodeVisitor(bl), event);
   ENCODE_FINISH(bl);
   encode_metadata(bl);
@@ -434,7 +439,7 @@ void EventEntry::decode_metadata(bufferlist::iterator& it) {
 
 void EventEntry::generate_test_instances(std::list<EventEntry *> &o) {
   o.push_back(new EventEntry(AioDiscardEvent()));
-  o.push_back(new EventEntry(AioDiscardEvent(123, 345), utime_t(1, 1)));
+  o.push_back(new EventEntry(AioDiscardEvent(123, 345, false), utime_t(1, 1)));
 
   bufferlist bl;
   bl.append(std::string(32, '1'));

--- a/src/librbd/journal/Types.cc
+++ b/src/librbd/journal/Types.cc
@@ -104,6 +104,23 @@ void AioWriteEvent::dump(Formatter *f) const {
   f->dump_unsigned("length", length);
 }
 
+void AioWriteSameEvent::encode(bufferlist& bl) const {
+  ::encode(offset, bl);
+  ::encode(length, bl);
+  ::encode(data, bl);
+}
+
+void AioWriteSameEvent::decode(__u8 version, bufferlist::iterator& it) {
+  ::decode(offset, it);
+  ::decode(length, it);
+  ::decode(data, it);
+}
+
+void AioWriteSameEvent::dump(Formatter *f) const {
+  f->dump_unsigned("offset", offset);
+  f->dump_unsigned("length", length);
+}
+
 void AioFlushEvent::encode(bufferlist& bl) const {
 }
 
@@ -382,6 +399,9 @@ void EventEntry::decode(bufferlist::iterator& it) {
     break;
   case EVENT_TYPE_METADATA_REMOVE:
     event = MetadataRemoveEvent();
+    break;
+  case EVENT_TYPE_AIO_WRITESAME:
+    event = AioWriteSameEvent();
     break;
   default:
     event = UnknownEvent();
@@ -723,6 +743,9 @@ std::ostream &operator<<(std::ostream &out, const EventType &type) {
     break;
   case EVENT_TYPE_METADATA_REMOVE:
     out << "MetadataRemove";
+    break;
+  case EVENT_TYPE_AIO_WRITESAME:
+    out << "AioWriteSame";
     break;
   default:
     out << "Unknown (" << static_cast<uint32_t>(type) << ")";

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -42,6 +42,7 @@ enum EventType {
   EVENT_TYPE_UPDATE_FEATURES = 15,
   EVENT_TYPE_METADATA_SET    = 16,
   EVENT_TYPE_METADATA_REMOVE = 17,
+  EVENT_TYPE_AIO_WRITESAME   = 18,
 };
 
 struct AioDiscardEvent {
@@ -73,6 +74,25 @@ struct AioWriteEvent {
   AioWriteEvent() : offset(0), length(0) {
   }
   AioWriteEvent(uint64_t _offset, uint64_t _length, const bufferlist &_data)
+    : offset(_offset), length(_length), data(_data) {
+  }
+
+  void encode(bufferlist& bl) const;
+  void decode(__u8 version, bufferlist::iterator& it);
+  void dump(Formatter *f) const;
+};
+
+struct AioWriteSameEvent {
+  static const EventType TYPE = EVENT_TYPE_AIO_WRITESAME;
+
+  uint64_t offset;
+  uint64_t length;
+  bufferlist data;
+
+  AioWriteSameEvent() : offset(0), length(0) {
+  }
+  AioWriteSameEvent(uint64_t _offset, uint64_t _length,
+                    const bufferlist &_data)
     : offset(_offset), length(_length), data(_data) {
   }
 
@@ -368,6 +388,7 @@ typedef boost::variant<AioDiscardEvent,
                        UpdateFeaturesEvent,
                        MetadataSetEvent,
                        MetadataRemoveEvent,
+                       AioWriteSameEvent,
                        UnknownEvent> Event;
 
 struct EventEntry {

--- a/src/librbd/journal/Types.h
+++ b/src/librbd/journal/Types.h
@@ -50,11 +50,12 @@ struct AioDiscardEvent {
 
   uint64_t offset;
   uint64_t length;
+  bool skip_partial_discard;
 
-  AioDiscardEvent() : offset(0), length(0) {
+  AioDiscardEvent() : offset(0), length(0), skip_partial_discard(false) {
   }
-  AioDiscardEvent(uint64_t _offset, uint64_t _length)
-    : offset(_offset), length(_length) {
+  AioDiscardEvent(uint64_t _offset, uint64_t _length, bool _skip_partial_discard)
+    : offset(_offset), length(_length), skip_partial_discard(_skip_partial_discard) {
   }
 
   void encode(bufferlist& bl) const;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1336,6 +1336,21 @@ namespace librbd {
     return r;
   }
 
+  ssize_t Image::writesame(uint64_t ofs, size_t len, bufferlist& bl, int op_flags)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, writesame_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
+               ictx->read_only, ofs, len, bl.length() <= 0 ? NULL : bl.c_str(), bl.length(),
+               op_flags);
+    if (bl.length() <= 0 || len % bl.length()) {
+      tracepoint(librbd, writesame_exit, -EINVAL);
+      return -EINVAL;
+    }
+    int r = ictx->io_work_queue->writesame(ofs, len, bufferlist{bl}, op_flags);
+    tracepoint(librbd, writesame_exit, r);
+    return r;
+  }
+
   int Image::aio_write(uint64_t off, size_t len, bufferlist& bl,
 		       RBD::AioCompletion *c)
   {
@@ -1420,6 +1435,24 @@ namespace librbd {
     tracepoint(librbd, aio_flush_exit, 0);
     return 0;
   }
+
+  int Image::aio_writesame(uint64_t off, size_t len, bufferlist& bl,
+                           RBD::AioCompletion *c, int op_flags)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, aio_writesame_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
+               ictx->read_only, off, len, bl.length() <= len ? NULL : bl.c_str(), bl.length(),
+               c->pc, op_flags);
+    if (bl.length() <= 0 || len % bl.length()) {
+      tracepoint(librbd, aio_writesame_exit, -EINVAL);
+      return -EINVAL;
+    }
+    ictx->io_work_queue->aio_writesame(get_aio_completion(c), off, len,
+                                       bufferlist{bl}, op_flags);
+    tracepoint(librbd, aio_writesame_exit, 0);
+    return 0;
+  }
+
 
   int Image::invalidate_cache()
   {
@@ -2902,6 +2935,25 @@ extern "C" int rbd_discard(rbd_image_t image, uint64_t ofs, uint64_t len)
   return r;
 }
 
+extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
+                                 const char *buf, size_t data_len, int op_flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  tracepoint(librbd, writesame_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
+             ictx->read_only, ofs, len, data_len <= 0 ? NULL : buf, data_len, op_flags);
+
+  if (data_len <= 0 || len % data_len) {
+    tracepoint(librbd, writesame_exit, -EINVAL);
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  bl.push_back(create_write_raw(ictx, buf, data_len));
+  int r = ictx->io_work_queue->writesame(ofs, len, std::move(bl), op_flags);
+  tracepoint(librbd, writesame_exit, r);
+  return r;
+}
+
 extern "C" int rbd_aio_create_completion(void *cb_arg,
 					 rbd_callback_t complete_cb,
 					 rbd_completion_t *c)
@@ -3068,6 +3120,29 @@ extern "C" int rbd_aio_flush(rbd_image_t image, rbd_completion_t c)
   tracepoint(librbd, aio_flush_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
   ictx->io_work_queue->aio_flush(get_aio_completion(comp));
   tracepoint(librbd, aio_flush_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
+                                 const char *buf, size_t data_len, rbd_completion_t c,
+                                 int op_flags)
+{
+  librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_writesame_enter, ictx, ictx->name.c_str(), ictx->snap_name.c_str(),
+             ictx->read_only, off, len, data_len <= 0 ? NULL : buf, data_len, comp->pc,
+             op_flags);
+
+  if (data_len <= 0 || len % data_len) {
+    tracepoint(librbd, aio_writesame_exit, -EINVAL);
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  bl.push_back(create_write_raw(ictx, buf, data_len));
+  ictx->io_work_queue->aio_writesame(get_aio_completion(comp), off, len,
+                                     std::move(bl), op_flags);
+  tracepoint(librbd, aio_writesame_exit, 0);
   return 0;
 }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1346,6 +1346,13 @@ namespace librbd {
       tracepoint(librbd, writesame_exit, -EINVAL);
       return -EINVAL;
     }
+
+    if (mem_is_zero(bl.c_str(), bl.length())) {
+      int r = ictx->io_work_queue->discard(ofs, len);
+      tracepoint(librbd, writesame_exit, r);
+      return r;
+    }
+
     int r = ictx->io_work_queue->writesame(ofs, len, bufferlist{bl}, op_flags);
     tracepoint(librbd, writesame_exit, r);
     return r;
@@ -1447,6 +1454,13 @@ namespace librbd {
       tracepoint(librbd, aio_writesame_exit, -EINVAL);
       return -EINVAL;
     }
+
+    if (mem_is_zero(bl.c_str(), bl.length())) {
+      ictx->io_work_queue->aio_discard(get_aio_completion(c), off, len);
+      tracepoint(librbd, aio_writesame_exit, 0);
+      return 0;
+    }
+
     ictx->io_work_queue->aio_writesame(get_aio_completion(c), off, len,
                                        bufferlist{bl}, op_flags);
     tracepoint(librbd, aio_writesame_exit, 0);
@@ -2947,6 +2961,12 @@ extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
     return -EINVAL;
   }
 
+  if (mem_is_zero(buf, data_len)) {
+    int r = ictx->io_work_queue->discard(ofs, len);
+    tracepoint(librbd, writesame_exit, r);
+    return r;
+  }
+
   bufferlist bl;
   bl.push_back(create_write_raw(ictx, buf, data_len));
   int r = ictx->io_work_queue->writesame(ofs, len, std::move(bl), op_flags);
@@ -3136,6 +3156,12 @@ extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
   if (data_len <= 0 || len % data_len) {
     tracepoint(librbd, aio_writesame_exit, -EINVAL);
     return -EINVAL;
+  }
+
+  if (mem_is_zero(buf, data_len)) {
+    ictx->io_work_queue->aio_discard(get_aio_completion(comp), off, len);
+    tracepoint(librbd, aio_writesame_exit, 0);
+    return 0;
   }
 
   bufferlist bl;

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -668,6 +668,14 @@ int IoCtx::write_full(const std::string& oid, bufferlist& bl) {
                      ctx->get_snap_context()));
 }
 
+int IoCtx::writesame(const std::string& oid, bufferlist& bl, size_t len,
+                     uint64_t off) {
+  TestIoCtxImpl *ctx = reinterpret_cast<TestIoCtxImpl*>(io_ctx_impl);
+  return ctx->execute_operation(
+    oid, boost::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len, off,
+                     ctx->get_snap_context()));
+}
+
 static int save_operation_result(int result, int *pval) {
   if (pval != NULL) {
     *pval = result;
@@ -838,6 +846,12 @@ void ObjectWriteOperation::write(uint64_t off, const bufferlist& bl) {
 void ObjectWriteOperation::write_full(const bufferlist& bl) {
   TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
   o->ops.push_back(boost::bind(&TestIoCtxImpl::write_full, _1, _2, bl, _4));
+}
+
+void ObjectWriteOperation::writesame(uint64_t off, uint64_t len, const bufferlist& bl) {
+  TestObjectOperationImpl *o = reinterpret_cast<TestObjectOperationImpl*>(impl);
+  o->ops.push_back(boost::bind(&TestIoCtxImpl::writesame, _1, _2, bl, len,
+			       off, _4));
 }
 
 void ObjectWriteOperation::zero(uint64_t off, uint64_t len) {

--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -143,6 +143,8 @@ public:
                     uint64_t off, const SnapContext &snapc) = 0;
   virtual int write_full(const std::string& oid, bufferlist& bl,
                          const SnapContext &snapc) = 0;
+  virtual int writesame(const std::string& oid, bufferlist& bl, size_t len,
+                        uint64_t off, const SnapContext &snapc) = 0;
   virtual int xattr_get(const std::string& oid,
                         std::map<std::string, bufferlist>* attrset) = 0;
   virtual int xattr_set(const std::string& oid, const std::string &name,

--- a/src/test/librados_test_stub/TestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestMemIoCtxImpl.h
@@ -52,6 +52,8 @@ public:
                     uint64_t off, const SnapContext &snapc);
   virtual int write_full(const std::string& oid, bufferlist& bl,
                          const SnapContext &snapc);
+  virtual int writesame(const std::string& oid, bufferlist& bl, size_t len,
+                        uint64_t off, const SnapContext &snapc);
   virtual int xattr_get(const std::string& oid,
                         std::map<std::string, bufferlist>* attrset);
   virtual int xattr_set(const std::string& oid, const std::string &name,

--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -88,6 +88,7 @@ int			logcount = 0;	/* total ops */
  * TRUNCATE:	-	4
  * FALLOCATE:	-	5
  * PUNCH HOLE:	-	6
+ * WRITESAME:	-	7
  *
  * When mapped read/writes are disabled, they are simply converted to normal
  * reads and writes. When fallocate/fpunch calls are disabled, they are
@@ -111,10 +112,11 @@ int			logcount = 0;	/* total ops */
 #define OP_TRUNCATE	4
 #define OP_FALLOCATE	5
 #define OP_PUNCH_HOLE	6
+#define OP_WRITESAME	7
 /* rbd-specific operations */
-#define OP_CLONE        7
-#define OP_FLATTEN	8
-#define OP_MAX_FULL	9
+#define OP_CLONE        8
+#define OP_FLATTEN	9
+#define OP_MAX_FULL	10
 
 /* operation modifiers */
 #define OP_CLOSEOPEN	100
@@ -518,6 +520,8 @@ struct rbd_operations {
 		     const char *dst_imagename, int *order, int stripe_unit,
 		     int stripe_count);
 	int (*flatten)(struct rbd_ctx *ctx);
+	ssize_t (*writesame)(struct rbd_ctx *ctx, uint64_t off, size_t len,
+			     const char *buf, size_t data_len);
 };
 
 char *pool;			/* name of the pool our test image is in */
@@ -665,6 +669,26 @@ librbd_discard(struct rbd_ctx *ctx, uint64_t off, uint64_t len)
 	return librbd_verify_object_map(ctx);
 }
 
+ssize_t
+librbd_writesame(struct rbd_ctx *ctx, uint64_t off, size_t len,
+                 const char *buf, size_t data_len)
+{
+	ssize_t n;
+	int ret;
+
+	n = rbd_writesame(ctx->image, off, len, buf, data_len, 0);
+	if (n < 0) {
+		prt("rbd_writesame(%llu, %zu) failed\n", off, len);
+		return n;
+	}
+
+	ret = librbd_verify_object_map(ctx);
+	if (ret < 0) {
+		return ret;
+	}
+	return n;
+}
+
 int
 librbd_get_size(struct rbd_ctx *ctx, uint64_t *size)
 {
@@ -781,7 +805,8 @@ const struct rbd_operations librbd_operations = {
 	librbd_get_size,
 	librbd_resize,
 	librbd_clone,
-	librbd_flatten
+	librbd_flatten,
+	librbd_writesame,
 };
 
 int
@@ -1034,6 +1059,7 @@ const struct rbd_operations krbd_operations = {
 	krbd_resize,
 	krbd_clone,
 	krbd_flatten,
+	NULL,
 };
 
 int
@@ -1156,6 +1182,7 @@ const struct rbd_operations nbd_operations = {
 	krbd_resize,
 	nbd_clone,
 	krbd_flatten,
+	NULL,
 };
 
 struct rbd_ctx ctx = RBD_CTX_INIT;
@@ -1281,6 +1308,14 @@ logdump(void)
 			if (badoff >= lp->args[0] && badoff <
 						     lp->args[0] + lp->args[1])
 				prt("\t******PPPP");
+			break;
+		case OP_WRITESAME:
+			prt("WRITESAME    0x%x thru 0x%x\t(0x%x bytes) data_size 0x%x",
+			    lp->args[0], lp->args[0] + lp->args[1] - 1,
+			    lp->args[1], lp->args[2]);
+			if (badoff >= lp->args[0] &&
+				badoff < lp->args[0] + lp->args[1])
+				prt("\t***WSWSWSWS");
 			break;
 		case OP_CLONE:
 			prt("CLONE");
@@ -1794,6 +1829,101 @@ do_punch_hole(unsigned offset, unsigned length)
 	memset(good_buf + max_offset, '\0', max_len);
 }
 
+unsigned get_data_size(unsigned size)
+{
+	unsigned i;
+	unsigned hint;
+	unsigned max = sqrt((double)size) + 1;
+	unsigned good = 1;
+	unsigned curr = good;
+
+	hint = get_random() % max;
+
+	for (i = 1; i < max && curr < hint; i++) {
+		if (size % i == 0) {
+			good = curr;
+			curr = i;
+		}
+	}
+
+	if (curr == hint)
+		good = curr;
+
+	return good;
+}
+
+void
+dowritesame(unsigned offset, unsigned size)
+{
+	ssize_t ret;
+	off_t newsize;
+	unsigned buf_off;
+	unsigned data_size;
+	int n;
+
+	offset -= offset % writebdy;
+	if (o_direct)
+		size -= size % writebdy;
+	if (size == 0) {
+		if (!quiet && testcalls > simulatedopcount && !o_direct)
+			prt("skipping zero size writesame\n");
+		log4(OP_SKIPPED, OP_WRITESAME, offset, size);
+		return;
+	}
+
+	data_size = get_data_size(size);
+
+	log4(OP_WRITESAME, offset, size, data_size);
+
+	gendata(original_buf, good_buf, offset, data_size);
+	if (file_size < offset + size) {
+		newsize = ceil(((double)offset + size) / truncbdy) * truncbdy;
+		if (file_size < newsize)
+			memset(good_buf + file_size, '\0', newsize - file_size);
+		file_size = newsize;
+		if (lite) {
+			warn("Lite file size bug in fsx!");
+			report_failure(162);
+		}
+		ret = ops->resize(&ctx, newsize);
+		if (ret < 0) {
+			prterrcode("dowritesame: ops->resize", ret);
+			report_failure(163);
+		}
+	}
+
+	for (n = size / data_size, buf_off = data_size; n > 1; n--) {
+		memcpy(good_buf + offset + buf_off, good_buf + offset, data_size);
+		buf_off += data_size;
+	}
+
+	if (testcalls <= simulatedopcount)
+		return;
+
+	if (!quiet &&
+		((progressinterval && testcalls % progressinterval == 0) ||
+		       (debug &&
+		       (monitorstart == -1 ||
+			(static_cast<long>(offset + size) > monitorstart &&
+			 (monitorend == -1 ||
+			  static_cast<long>(offset) <= monitorend))))))
+		prt("%lu writesame\t0x%x thru\t0x%x\tdata_size\t0x%x(0x%x bytes)\n", testcalls,
+		    offset, offset + size - 1, data_size, size);
+
+	ret = ops->writesame(&ctx, offset, size, good_buf + offset, data_size);
+	if (ret != (ssize_t)size) {
+		if (ret < 0)
+			prterrcode("dowritesame: ops->writesame", ret);
+		else
+			prt("short writesame: 0x%x bytes instead of 0x%x\n",
+			    ret, size);
+		report_failure(164);
+	}
+
+	if (flush_enabled)
+		doflush(offset, size);
+}
+
 void clone_filename(char *buf, size_t len, int clones)
 {
 	snprintf(buf, len, "%s/fsx-%s-parent%d",
@@ -2165,6 +2295,12 @@ test(void)
 			goto out;
 		}
 		break;
+	case OP_WRITESAME:
+		/* writesame not implemented */
+		if (!ops->writesame) {
+			log4(OP_SKIPPED, OP_WRITESAME, offset, size);
+			goto out;
+		}
 	}
 
 	switch (op) {
@@ -2197,6 +2333,11 @@ test(void)
 	case OP_PUNCH_HOLE:
 		TRIM_OFF_LEN(offset, size, file_size);
 		do_punch_hole(offset, size);
+		break;
+
+	case OP_WRITESAME:
+		TRIM_OFF_LEN(offset, size, maxfilelen);
+		dowritesame(offset, size);
 		break;
 
 	case OP_CLONE:

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -246,7 +246,8 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
   C_SaferCond aio_comp_ctx;
   AioCompletion *aio_comp = AioCompletion::create_and_start(
     &aio_comp_ctx, ictx, AIO_TYPE_DISCARD);
-  MockImageDiscardRequest mock_aio_image_discard(mock_image_ctx, aio_comp, 0, 1);
+  MockImageDiscardRequest mock_aio_image_discard(mock_image_ctx, aio_comp,
+                                                 0, 1, ictx->skip_partial_discard);
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
     mock_aio_image_discard.send();

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -78,6 +78,19 @@ struct ObjectRequest<librbd::MockTestImageCtx> : public ObjectRequestHandle {
     return s_instance;
   }
 
+  static ObjectRequest* create_writesame(librbd::MockTestImageCtx *ictx,
+                                         const std::string &oid,
+                                         uint64_t object_no,
+                                         uint64_t object_off,
+                                         uint64_t object_len,
+                                         const ceph::bufferlist &data,
+                                         const ::SnapContext &snapc,
+                                         Context *completion, int op_flags) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = completion;
+    return s_instance;
+  }
+
   ObjectRequest() {
     assert(s_instance == nullptr);
     s_instance = this;
@@ -146,6 +159,7 @@ struct TestMockIoImageRequest : public TestMockFixture {
   typedef ImageWriteRequest<librbd::MockTestImageCtx> MockImageWriteRequest;
   typedef ImageDiscardRequest<librbd::MockTestImageCtx> MockImageDiscardRequest;
   typedef ImageFlushRequest<librbd::MockTestImageCtx> MockImageFlushRequest;
+  typedef ImageWriteSameRequest<librbd::MockTestImageCtx> MockImageWriteSameRequest;
   typedef ObjectRequest<librbd::MockTestImageCtx> MockObjectRequest;
   typedef ObjectReadRequest<librbd::MockTestImageCtx> MockObjectReadRequest;
 
@@ -262,6 +276,37 @@ TEST_F(TestMockIoImageRequest, AioFlushJournalAppendDisabled) {
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
     mock_aio_image_flush.send();
+  }
+  ASSERT_EQ(0, aio_comp_ctx.wait());
+}
+
+TEST_F(TestMockIoImageRequest, AioWriteSameJournalAppendDisabled) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockObjectRequest mock_aio_object_request;
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockJournal mock_journal;
+  mock_image_ctx.journal = &mock_journal;
+
+  InSequence seq;
+  expect_is_journal_appending(mock_journal, false);
+  expect_write_to_cache(mock_image_ctx, ictx->get_object_name(0),
+                        0, 1, 0, 0);
+
+  C_SaferCond aio_comp_ctx;
+  AioCompletion *aio_comp = AioCompletion::create_and_start(
+    &aio_comp_ctx, ictx, AIO_TYPE_WRITESAME);
+
+  bufferlist bl;
+  bl.append("1");
+  MockImageWriteSameRequest mock_aio_image_writesame(mock_image_ctx, aio_comp,
+                                                     0, 1, std::move(bl), 0);
+  {
+    RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
+    mock_aio_image_writesame.send();
   }
   ASSERT_EQ(0, aio_comp_ctx.wait());
 }

--- a/src/test/librbd/io/test_mock_ImageRequest.cc
+++ b/src/test/librbd/io/test_mock_ImageRequest.cc
@@ -241,7 +241,9 @@ TEST_F(TestMockIoImageRequest, AioDiscardJournalAppendDisabled) {
 
   InSequence seq;
   expect_is_journal_appending(mock_journal, false);
-  expect_object_request_send(mock_image_ctx, mock_aio_object_request, 0);
+  if (!ictx->skip_partial_discard) {
+    expect_object_request_send(mock_image_ctx, mock_aio_object_request, 0);
+  }
 
   C_SaferCond aio_comp_ctx;
   AioCompletion *aio_comp = AioCompletion::create_and_start(

--- a/src/test/librbd/journal/test_Entries.cc
+++ b/src/test/librbd/journal/test_Entries.cc
@@ -175,7 +175,7 @@ TEST_F(TestJournalEntries, AioDiscard) {
   C_SaferCond cond_ctx;
   auto c = librbd::io::AioCompletion::create(&cond_ctx);
   c->get();
-  ictx->io_work_queue->aio_discard(c, 123, 234);
+  ictx->io_work_queue->aio_discard(c, 123, 234, cct->_conf->rbd_skip_partial_discard);
   ASSERT_EQ(0, c->wait_for_complete());
   c->put();
 

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -143,7 +143,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
 
   // inject a discard operation into the journal
   inject_into_journal(ictx,
-                      librbd::journal::AioDiscardEvent(0, payload.size()));
+                      librbd::journal::AioDiscardEvent(0, payload.size(), ictx->skip_partial_discard));
   close_image(ictx);
 
   // re-open the journal so that it replays the new entry
@@ -170,9 +170,9 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
 
   // replay several envents and check the commit position
   inject_into_journal(ictx,
-                      librbd::journal::AioDiscardEvent(0, payload.size()));
+                      librbd::journal::AioDiscardEvent(0, payload.size(), ictx->cct->_conf->rbd_skip_partial_discard));
   inject_into_journal(ictx,
-                      librbd::journal::AioDiscardEvent(0, payload.size()));
+                      librbd::journal::AioDiscardEvent(0, payload.size(), ictx->cct->_conf->rbd_skip_partial_discard));
   close_image(ictx);
 
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
@@ -183,7 +183,7 @@ TEST_F(TestJournalReplay, AioDiscardEvent) {
 
   // verify lock ordering constraints
   aio_comp = new librbd::io::AioCompletion();
-  ictx->io_work_queue->aio_discard(aio_comp, 0, read_payload.size());
+  ictx->io_work_queue->aio_discard(aio_comp, 0, read_payload.size(), ictx->cct->_conf->rbd_skip_partial_discard);
   ASSERT_EQ(0, aio_comp->wait_for_complete());
   aio_comp->release();
 }

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -50,6 +50,15 @@ struct ImageRequest<MockReplayImageCtx> {
     s_instance->aio_flush(c);
   }
 
+  MOCK_METHOD5(aio_writesame, void(AioCompletion *c, uint64_t off, uint64_t len,
+                                   const bufferlist &bl, int op_flags));
+  static void aio_writesame(MockReplayImageCtx *ictx, AioCompletion *c,
+                            uint64_t off, uint64_t len, bufferlist &&bl,
+                            int op_flags) {
+    assert(s_instance != nullptr);
+    s_instance->aio_writesame(c, off, len, bl, op_flags);
+  }
+
   ImageRequest() {
     s_instance = this;
   }
@@ -139,6 +148,14 @@ public:
                         uint64_t len, const char *data) {
     EXPECT_CALL(mock_io_image_request,
                 aio_write(_, io::Extents{{off, len}}, BufferlistEqual(data), _))
+                  .WillOnce(SaveArg<0>(aio_comp));
+  }
+
+  void expect_aio_writesame(MockIoImageRequest &mock_io_image_request,
+                            io::AioCompletion **aio_comp, uint64_t off,
+                            uint64_t len, const char *data) {
+    EXPECT_CALL(mock_io_image_request,
+                aio_writesame(_, off, len, BufferlistEqual(data), _))
                   .WillOnce(SaveArg<0>(aio_comp));
   }
 
@@ -385,6 +402,34 @@ TEST_F(TestMockJournalReplay, AioFlush) {
 
   ASSERT_EQ(0, when_shut_down(mock_journal_replay, false));
   ASSERT_EQ(0, on_ready.wait());
+}
+
+TEST_F(TestMockJournalReplay, AioWriteSame) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockReplayImageCtx mock_image_ctx(*ictx);
+  MockJournalReplay mock_journal_replay(mock_image_ctx);
+  MockIoImageRequest mock_io_image_request;
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  io::AioCompletion *aio_comp;
+  C_SaferCond on_ready;
+  C_SaferCond on_safe;
+  expect_aio_writesame(mock_io_image_request, &aio_comp, 123, 456, "333");
+  when_process(mock_journal_replay,
+               EventEntry{AioWriteSameEvent(123, 456, to_bl("333"))},
+               &on_ready, &on_safe);
+
+  when_complete(mock_image_ctx, aio_comp, 0);
+  ASSERT_EQ(0, on_ready.wait());
+
+  expect_aio_flush(mock_image_ctx, mock_io_image_request, 0);
+  ASSERT_EQ(0, when_shut_down(mock_journal_replay, false));
+  ASSERT_EQ(0, on_safe.wait());
 }
 
 TEST_F(TestMockJournalReplay, IOError) {

--- a/src/test/librbd/mock/cache/MockImageCache.h
+++ b/src/test/librbd/mock/cache/MockImageCache.h
@@ -28,7 +28,7 @@ struct MockImageCache {
     aio_write_mock(image_extents, bl, fadvise_flags, on_finish);
   }
 
-  MOCK_METHOD3(aio_discard, void(uint64_t, uint64_t, Context *));
+  MOCK_METHOD4(aio_discard, void(uint64_t, uint64_t, bool, Context *));
   MOCK_METHOD1(aio_flush, void(Context *));
   MOCK_METHOD5(aio_writesame_mock, void(uint64_t, uint64_t, ceph::bufferlist& bl,
                                         int, Context *));

--- a/src/test/librbd/mock/cache/MockImageCache.h
+++ b/src/test/librbd/mock/cache/MockImageCache.h
@@ -30,6 +30,12 @@ struct MockImageCache {
 
   MOCK_METHOD3(aio_discard, void(uint64_t, uint64_t, Context *));
   MOCK_METHOD1(aio_flush, void(Context *));
+  MOCK_METHOD5(aio_writesame_mock, void(uint64_t, uint64_t, ceph::bufferlist& bl,
+                                        int, Context *));
+  void aio_writesame(uint64_t off, uint64_t len, ceph::bufferlist&& bl,
+                     int fadvise_flags, Context *on_finish) {
+    aio_writesame_mock(off, len, bl, fadvise_flags, on_finish);
+  }
 };
 
 } // namespace cache

--- a/src/test/librbd/test_internal.cc
+++ b/src/test/librbd/test_internal.cc
@@ -299,7 +299,7 @@ TEST_F(TestInternal, AioDiscardRequestsLock) {
   Context *ctx = new DummyContext();
   auto c = librbd::io::AioCompletion::create(ctx);
   c->get();
-  ictx->io_work_queue->aio_discard(c, 0, 256);
+  ictx->io_work_queue->aio_discard(c, 0, 256, false);
 
   bool is_owner;
   ASSERT_EQ(0, librbd::is_exclusive_lock_owner(ictx, &is_owner));
@@ -686,7 +686,7 @@ TEST_F(TestInternal, DiscardCopyup)
   read_bl.push_back(read_ptr);
 
   ASSERT_EQ(static_cast<int>(m_image_size - 64),
-            ictx2->io_work_queue->discard(32, m_image_size - 64));
+            ictx2->io_work_queue->discard(32, m_image_size - 64, false));
   ASSERT_EQ(0, librbd::snap_set(ictx2, "snap1"));
 
   {

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -487,7 +487,7 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Trim) {
   // trim the object
   uint64_t trim_offset = rand() % one.range_end();
   ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(
-    trim_offset, one.range_end() - trim_offset));
+    trim_offset, one.range_end() - trim_offset, m_remote_image_ctx->skip_partial_discard));
   ASSERT_EQ(0, create_snap("sync"));
 
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
@@ -530,7 +530,7 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Remove) {
 
   // remove the object
   uint64_t object_size = 1 << m_remote_image_ctx->order;
-  ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(0, object_size));
+  ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(0, object_size, m_remote_image_ctx->skip_partial_discard));
   ASSERT_EQ(0, create_snap("sync"));
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
   librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -33,7 +33,7 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size)
     uint64_t len = 1 + rand() % max_size;
 
     if (rand() % 4 == 0) {
-      ASSERT_EQ((int)len, image_ctx->io_work_queue->discard(off, len));
+      ASSERT_EQ((int)len, image_ctx->io_work_queue->discard(off, len, image_ctx->skip_partial_discard));
     } else {
       bufferlist bl;
       bl.append(std::string(len, '1'));
@@ -202,7 +202,7 @@ TEST_F(TestImageSync, Discard) {
   ASSERT_EQ(0, create_snap(m_remote_image_ctx, "snap", nullptr));
 
   ASSERT_EQ((int)len - 2, m_remote_image_ctx->io_work_queue->discard(off + 1,
-                                                                     len - 2));
+                                                                     len - 2, m_remote_image_ctx->skip_partial_discard));
   {
     RWLock::RLocker owner_locker(m_remote_image_ctx->owner_lock);
     ASSERT_EQ(0, m_remote_image_ctx->flush());

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -847,7 +847,7 @@ TEST_F(TestMockImageReplayer, DelayedReplay) {
   // process with delay
   EXPECT_CALL(mock_replay_entry, get_data());
   librbd::journal::EventEntry event_entry(
-    librbd::journal::AioDiscardEvent(123, 345), ceph_clock_now());
+    librbd::journal::AioDiscardEvent(123, 345, false), ceph_clock_now());
   EXPECT_CALL(mock_local_replay, decode(_, _))
     .WillOnce(DoAll(SetArgPointee<1>(event_entry),
                     Return(0)));

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -172,6 +172,38 @@ TRACEPOINT_EVENT(librbd, open_image_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, writesame_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, name,
+        const char*, snap_name,
+        char, read_only,
+        uint64_t, off,
+        size_t, len,
+        const char*, buf,
+	size_t, data_len,
+	int, op_flags),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(name, name)
+        ctf_string(snap_name, snap_name)
+        ctf_integer(char, read_only, read_only)
+        ctf_integer(uint64_t, off, off)
+        ctf_integer(size_t, len, len)
+        ctf_integer(size_t, data_len, data_len)
+        ceph_ctf_sequence(unsigned char, buf, buf, size_t, data_len)
+        ctf_integer(int, op_flags, op_flags)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, writesame_exit,
+    TP_ARGS(
+        ssize_t, retval),
+    TP_FIELDS(
+        ctf_integer(ssize_t, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, aio_open_image_enter,
     TP_ARGS(
         void*, imagectx,
@@ -921,6 +953,40 @@ TRACEPOINT_EVENT(librbd, aio_complete_enter,
 TRACEPOINT_EVENT(librbd, aio_complete_exit,
     TP_ARGS(),
     TP_FIELDS()
+)
+
+TRACEPOINT_EVENT(librbd, aio_writesame_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, name,
+        const char*, snap_name,
+        char, read_only,
+        uint64_t, off,
+        size_t, len,
+        const char*, buf,
+        size_t, data_len,
+        const void*, completion,
+	int, op_flags),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(name, name)
+        ctf_string(snap_name, snap_name)
+        ctf_integer(char, read_only, read_only)
+        ctf_integer(uint64_t, off, off)
+        ctf_integer(size_t, len, len)
+        ctf_integer(size_t, data_len, data_len)
+        ceph_ctf_sequence(unsigned char, buf, buf, size_t, data_len)
+        ctf_integer_hex(const void*, completion, completion)
+        ctf_integer(int, op_flags, op_flags)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, aio_writesame_exit,
+    TP_ARGS(
+        ssize_t, retval),
+    TP_FIELDS(
+        ctf_integer(ssize_t, retval, retval)
+    )
 )
 
 TRACEPOINT_EVENT(librbd, clone_enter,


### PR DESCRIPTION
The writesame support for librbd base on LiumxNL's pr: https://github.com/ceph/ceph/pull/10019

I rebased the code on the current master branch and drive it to work.
Changes:
1. drop writesame2 as suggested
2. keep "writesame" semantics on image request level
    (use librados::write instead of librados::writesame, I think normal write is just fine since librados::writesame also has the limit that write_len % data_len == 0 for an object request, which may not be statisfied when we split our image request into object requests.)
3. make it workable under the current code base, because there are many changes after the original pr.

ToDo:
1. add more tests: fsx etc.
2. make writesame passthrough the cache, as suggested by jason