### PR TITLE
when call the multiparts upload API TransferManager.upload() by s3 ja…

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -4179,7 +4179,7 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(struct req_state* const s,
       handler = new RGWHandler_REST_Obj_S3;
     }
   }
-
+ 
   ldout(s->cct, 20) << __func__ << " handler=" << typeid(*handler).name()
 		    << dendl;
   return handler;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3730,18 +3730,12 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s, bool force_b
         if (key != "X-Amz-Credential") {
           string key_decoded;
           url_decode(key, key_decoded);
-          if (key.length() != key_decoded.length()) {
-            encoded_key = key;
-          } else {
-            aws4_uri_encode(key, encoded_key);
-          }
+	  aws4_uri_encode(key_decoded, encoded_key);
+          
           string val_decoded;
           url_decode(val, val_decoded);
-          if (val.length() != val_decoded.length()) {
-            encoded_val = val;
-          } else {
-            aws4_uri_encode(val, encoded_val);
-          }
+          aws4_uri_encode(val_decoded, encoded_val);
+
         } else {
           encoded_key = key;
           encoded_val = val;


### PR DESCRIPTION
when call the multiparts upload API TransferManager.upload() by s3 java API , i got a excepiton 'AmazonS3Exception'

I fount that when the parameter in the URL incloudes  characters '-,_.~', got excepiton 'AmazonS3Exception' , I looked at the s3 doc and thought the rgw's implement might be wrong.

the example code : http://docs.aws.amazon.com/AmazonS3/latest/dev/HLuploadFileJava.html

the s3 doc:

http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
URI-encode each parameter name and value according to the following rules:

Do not URI-encode any of the unreserved characters that RFC 3986 defines: A-Z, a-z, 0-9, hyphen ( - ), underscore ( _ ), period ( . ), and tilde ( ~ ).
Percent-encode all other characters with %XY, where X and Y are hexadecimal characters (0-9 and uppercase A-F). For example, the space character must be encoded as %20 (not using '+', as some encoding schemes do) and extended UTF-8 characters must be in the form %XY%ZA%BC.

Signed-off-by: qiyu cn-qiyu@qq.com