### PR TITLE
kv/CMakeLists: partially revert jemalloc fix

### DIFF
--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb ${ALLOC_LIBS} snappy z)
+target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb snappy z)
 
 # rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.
 find_package(BZip2 QUIET)


### PR DESCRIPTION
Make 'valgrind bin/unittest_denc' stop throwing a zillion errors.