### PR TITLE
messages/MOSDSubOp: Make encode_payload can be reentrant

### DIFF
--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -181,6 +181,7 @@ public:
   void finish_decode() { }
 
   virtual void encode_payload(uint64_t features) {
+    header.version = HEAD_VERSION;
     ::encode(map_epoch, payload);
     ::encode(reqid, payload);
     ::encode(pgid.pgid, payload);


### PR DESCRIPTION
Otherwise, AsyncConnection will use uninitialized feature to encode
message. The caller side will set a old version header but encode with newest
feature since passing feature is ok. It will let receiver side got a old
header version but newest payload decode result.

Signed-off-by: Haomai Wang <haomai@xsky.com>