### PR TITLE
test/fio_ceph_objectstore: fix fio plugin build failure caused by rec…

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -23,6 +23,8 @@
 
 #include "include/assert.h" // fio.h clobbers our assert.h
 
+#define dout_context g_ceph_context
+
 namespace {
 
 /// fio configuration options read from the job file


### PR DESCRIPTION
…ent g_ceph_context removal

>>commit a03c5be452994eb63153677bf84bd218df7a5c0a
>>Merge: 6251ff6 4e95986
>>Author: Sage Weil <sage@redhat.com>
>>Date:   Fri Dec 23 08:40:48 2016 -0600

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>