### PR TITLE
rgw: clear master_zonegroup when reseting RGWPeriodMap

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1349,6 +1349,7 @@ struct RGWPeriodMap
   void reset() {
     zonegroups.clear();
     zonegroups_by_api.clear();
+    master_zonegroup.clear();
   }
 
   uint32_t get_zone_short_id(const string& zone_id) const;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17239
Signed-off-by: Orit Wasserman <owasserm@redhat.com>