### PR TITLE
c_write_operations.cc: Fix trivial memory leak

### DIFF
--- a/src/test/librados/c_write_operations.cc
+++ b/src/test/librados/c_write_operations.cc
@@ -221,6 +221,7 @@ TEST(LibRadosCWriteOps, WriteSame) {
   ASSERT_TRUE(op);
   rados_write_op_remove(op);
   ASSERT_EQ(0, rados_write_op_operate(op, ioctx, "test", NULL, 0));
+  rados_release_write_op(op);
 
   rados_ioctx_destroy(ioctx);
   ASSERT_EQ(0, destroy_one_pool(pool_name, &cluster));


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>