### PR TITLE
common/ceph_context: Show clear message if all features are enabled

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -304,9 +304,14 @@ public:
 	conf->enable_experimental_unrecoverable_data_corrupting_features,
 	cct->_experimental_features);
       ceph_spin_unlock(&cct->_feature_lock);
-      if (!cct->_experimental_features.empty())
-	lderr(cct) << "WARNING: the following dangerous and experimental features are enabled: "
-		   << cct->_experimental_features << dendl;
+      if (!cct->_experimental_features.empty()) {
+        if (cct->_experimental_features.count("*")) {
+          lderr(cct) << "WARNING: all dangerous and experimental features are enabled." << dendl;
+        } else {
+          lderr(cct) << "WARNING: the following dangerous and experimental features are enabled: "
+	    << cct->_experimental_features << dendl;
+        }
+      }
     }
     if (changed.count("crush_location")) {
       cct->crush_location.update_from_conf();


### PR DESCRIPTION
It's saying the following dangerous and experimental featuresare enabled
while the value is "\*", it's not quite clear what's "\*" stands for.

The patch update the message so that it's more clear when "\*" is used in
place.

Signed-off-by: Dave Chen <wei.d.chen@intel.com>