### PR TITLE
monc: Fix memory leaks in init

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -366,10 +366,19 @@ int MonClient::init()
       method = cct->_conf->auth_cluster_required;
     else
       method = cct->_conf->auth_client_required;
+  
+  // Don't leak if called more than once
+  if (auth_supported) {
+    delete auth_supported;
+  }
   auth_supported = new AuthMethodList(cct, method);
   ldout(cct, 10) << "auth_supported " << auth_supported->get_supported_set() << " method " << method << dendl;
 
   int r = 0;
+  // Don't leak if called more than once
+  if (keyring) {
+    delete keyring;
+  }
   keyring = new KeyRing; // initializing keyring anyway
 
   if (auth_supported->is_supported_auth(CEPH_AUTH_CEPHX)) {
@@ -389,6 +398,10 @@ int MonClient::init()
     return r;
   }
 
+  // Don't leak if called more than once
+  if (rotating_secrets) {
+    delete rotating_secrets;
+  }
   rotating_secrets = new RotatingKeyRing(cct, cct->get_module_type(), keyring);
 
   initialized = true;

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -131,7 +131,7 @@ private:
 
   void send_log();
 
-  AuthMethodList *auth_supported;
+  AuthMethodList *auth_supported = nullptr;
 
   bool ms_dispatch(Message *m);
   bool ms_handle_reset(Connection *con);
@@ -286,8 +286,8 @@ public:
     return false;
   }
   
-  KeyRing *keyring;
-  RotatingKeyRing *rotating_secrets;
+  KeyRing *keyring = nullptr;
+  RotatingKeyRing *rotating_secrets = nullptr;
 
  public:
   explicit MonClient(CephContext *cct_);


### PR DESCRIPTION
If MonClient::init is called multiple times (such as if calling rados_connect
more than once) heap allocated members can leak when they are recreated.

Fixes: http://tracker.ceph.com/issues/18356
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>