### PR TITLE
osd: resend boot messages

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1566,6 +1566,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   debug_drop_pg_create_left(-1),
   outstanding_pg_stats(false),
   timeout_mon_on_pg_stats(true),
+  send_boot_count(0),
   up_thru_wanted(0), up_thru_pending(0),
   pg_stat_queue_lock("OSD::pg_stat_queue_lock"),
   osd_stat_updated(false),
@@ -3996,7 +3997,13 @@ void OSD::tick()
       start_boot();
     }
   }
-
+  // mon didn't respond to reply , the osd become state_booting, it need resend boot message 
+  if (is_booting()) {
+    if(send_boot_count++ >= 5){
+      start_boot();
+      send_boot_count = 0;
+    }
+  }
   if (is_active()) {
     // periodically kick recovery work queue
     recovery_tp.wake();

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1708,6 +1708,8 @@ protected:
   map<spg_t, list<PG::CephPeeringEvtRef> > peering_wait_for_split;
   PGRecoveryStats pg_recovery_stats;
 
+  int send_boot_count;
+  
   PGPool _get_pool(int id, OSDMapRef createmap);
 
   PG *get_pg_or_queue_for_pg(const spg_t& pgid, OpRequestRef& op);


### PR DESCRIPTION
Fixes:http://tracker.ceph.com/issues/16336
Osd sent the boot messages are lost or mon didn't respond, osd in booting condition, so need to resend the boot messages

Signed-off-by: lizhong <lizhong@szsandstone.com>