### PR TITLE
osd/PrimaryLogPG: optimal pick_newest_available

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9803,9 +9803,10 @@ void PrimaryLogPG::sub_op_remove(OpRequestRef op)
 eversion_t PrimaryLogPG::pick_newest_available(const hobject_t& oid)
 {
   eversion_t v;
-
-  assert(pg_log.get_missing().is_missing(oid));
-  v = pg_log.get_missing().get_items().find(oid)->second.have;
+  pg_missing_item pmi;
+  bool is_missing = pg_log.get_missing().is_missing(oid, &pmi);
+  assert(is_missing);
+  v = pmi.have;
   dout(10) << "pick_newest_available " << oid << " " << v << " on osd." << osd->whoami << " (local)" << dendl;
 
   assert(!actingbackfill.empty());


### PR DESCRIPTION
  we can get pg_missing_item from is_missing(), no need to find it again.

  Signed-off-by: huangjun <hjwsm1989@gmail.com>