### PR TITLE
rbd: rbd CLI should validate snap name optionals

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -492,6 +492,7 @@ int get_pool_journal_names(const po::variables_map &vm,
 int validate_snapshot_name(at::ArgumentModifier mod,
                            const std::string &snap_name,
                            SnapshotPresence snapshot_presence) {
+  boost::regex pattern;
   std::string prefix = at::get_description_prefix(mod);
   switch (snapshot_presence) {
   case SNAPSHOT_PRESENCE_PERMITTED:
@@ -510,6 +511,12 @@ int validate_snapshot_name(at::ArgumentModifier mod,
       std::cerr << "rbd: "
                 << (mod == at::ARGUMENT_MODIFIER_DEST ? prefix : std::string())
                 << "snap name was not specified" << std::endl;
+      return -EINVAL;
+    }
+    // disallow "/" and "@" in snap name
+    pattern = "^[^@/]*?$";
+    if (!boost::regex_match (snap_name, pattern)) {
+      std::cerr << "rbd: invalid spec '" << snap_name << "'" << std::endl;
       return -EINVAL;
     }
     break;


### PR DESCRIPTION
Currently when user create snapshot by providing --snap argument
in command line than rbd CLI does not validating snapshot name
to ensure that it should not contain "@" or "/" character.

Fix is to add validation logic for validating "@" or "/" character.

Fixes: http://tracker.ceph.com/issues/14535

Reported-by:  Jason Dillaman <dillaman@redhat.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>