### PR TITLE
auth: Let's not use the deprecated cephx option

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -528,7 +528,9 @@ EOF
 		fi
 		if [ "$cephx" -eq 1 ] ; then
 			wconf <<EOF
-        auth supported = cephx
+        auth cluster required = cephx
+        auth service required = cephx
+        auth client required = cephx
 EOF
 		else
 			wconf <<EOF


### PR DESCRIPTION
Enable cephx by setting the option of "auth supported" has been
deprecated for a long time, it's better to use the recommended
options instead.

Signed-off-by: Dave Chen <wei.d.chen@intel.com>