### PR TITLE
osd: _exit() intead of exit() for failure injection

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4785,7 +4785,7 @@ void OSD::RemoveWQ::_process(
 
   if (cct->_conf->osd_inject_failure_on_pg_removal) {
     generic_derr << "osd_inject_failure_on_pg_removal" << dendl;
-    exit(1);
+    _exit(1);
   }
   t.remove_collection(coll);
 


### PR DESCRIPTION
This avoids a segv from code that doesn't easily shut
down (e.g., bluestore).

Fixes: http://tracker.ceph.com/issues/18372
Signed-off-by: Sage Weil <sage@redhat.com>