### PR TITLE
jewel: build/ops: fixed compilation error when --with-radowsgw=no

### DIFF
--- a/src/cls/Makefile-client.am
+++ b/src/cls/Makefile-client.am
@@ -34,12 +34,14 @@ libcls_replica_log_client_la_SOURCES = \
 noinst_LTLIBRARIES += libcls_replica_log_client.la
 DENCODER_DEPS += libcls_replica_log_client.la
 
+if WITH_RADOSGW
 libcls_rgw_client_la_SOURCES = \
 	cls/rgw/cls_rgw_client.cc \
 	cls/rgw/cls_rgw_types.cc \
 	cls/rgw/cls_rgw_ops.cc
 noinst_LTLIBRARIES += libcls_rgw_client.la
 DENCODER_DEPS += libcls_rgw_client.la
+endif
 
 libcls_rbd_client_la_SOURCES = \
 	cls/rbd/cls_rbd_client.cc \
@@ -92,9 +94,6 @@ noinst_HEADERS += \
 	cls/replica_log/cls_replica_log_types.h \
 	cls/replica_log/cls_replica_log_ops.h \
 	cls/replica_log/cls_replica_log_client.h \
-	cls/rgw/cls_rgw_client.h \
-	cls/rgw/cls_rgw_ops.h \
-	cls/rgw/cls_rgw_types.h \
 	cls/user/cls_user_client.h \
 	cls/user/cls_user_ops.h \
 	cls/user/cls_user_types.h \
@@ -102,3 +101,10 @@ noinst_HEADERS += \
 	cls/cephfs/cls_cephfs_client.h \
 	cls/journal/cls_journal_client.h \
 	cls/journal/cls_journal_types.h
+
+if WITH_RADOSGW
+noinst_HEADERS += \
+	cls/rgw/cls_rgw_client.h \
+	cls/rgw/cls_rgw_ops.h \
+	cls/rgw/cls_rgw_types.h
+endif

--- a/src/cls/Makefile-server.am
+++ b/src/cls/Makefile-server.am
@@ -60,6 +60,7 @@ libcls_user_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)
 libcls_user_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'
 radoslib_LTLIBRARIES += libcls_user.la
 
+if WITH_RADOSGW
 libcls_rgw_la_SOURCES = \
 	cls/rgw/cls_rgw.cc \
 	cls/rgw/cls_rgw_ops.cc \
@@ -68,6 +69,8 @@ libcls_rgw_la_SOURCES = \
 libcls_rgw_la_LIBADD = libjson_spirit.la $(PTHREAD_LIBS) $(EXTRALIBS)
 libcls_rgw_la_LDFLAGS = ${AM_LDFLAGS} -module -avoid-version -shared -export-symbols-regex '.*__cls_.*'
 radoslib_LTLIBRARIES += libcls_rgw.la
+endif
+
 
 libcls_cephfs_la_SOURCES = cls/cephfs/cls_cephfs.cc
 libcls_cephfs_la_LIBADD = $(PTHREAD_LIBS) $(EXTRALIBS)

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -1,5 +1,6 @@
 if ENABLE_CLIENT
-
+if WITH_RADOS
+if WITH_RADOSGW
 # inject rgw stuff in the decoder testcase
 DENCODER_SOURCES += \
 	rgw/rgw_dencoder.cc \
@@ -17,9 +18,6 @@ DENCODER_DEPS += -lcurl -lexpat \
 	libcls_user_client.la \
 	libcls_timeindex_client.la \
 	libcls_statelog_client.la
-
-if WITH_RADOS
-if WITH_RADOSGW
 
 librgw_la_SOURCES = \
 	rgw/rgw_acl.cc \

--- a/src/test/Makefile-client.am
+++ b/src/test/Makefile-client.am
@@ -3,7 +3,6 @@ ceph_dencoder_SOURCES = \
 	test/encoding/ceph_dencoder.cc \
 	$(DENCODER_SOURCES)
 ceph_dencoder_LDADD = \
-	$(LIBRGW) \
 	$(LIBRADOS) \
 	$(LIBRBD_TYPES) \
 	$(LIBOSD_TYPES) \
@@ -26,6 +25,9 @@ ceph_dencoder_CXXFLAGS += -DWITH_RBD
 endif
 if WITH_RADOSGW
 ceph_dencoder_CXXFLAGS += -DWITH_RADOSGW
+ceph_dencoder_LDADD += \
+	$(LIBRGW) \
+	$(LIBRGW_DEPS) 
 endif
 
 


### PR DESCRIPTION
If cannot disable radosgw, the user has to always compile radosgw part, even only want to use block device or file storage. Cherry-pick cannot be done because ceph master doesn't have Makefile.am any more.

http://tracker.ceph.com/issues/18512