### PR TITLE
os/bluestore/BitMapAllocator: fix reservations vs min_alloc_size

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -211,7 +211,7 @@ public:
   static int get_level(CephContext* cct, int64_t total_blocks);
   static int64_t get_level_factor(CephContext* cct, int level);
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks) = 0;
-  virtual bool is_exhausted() = 0;
+  virtual bool is_exhausted(int64_t required) = 0;
   virtual bool child_check_n_lock(BitMapArea *child, int64_t required) {
       ceph_abort();
       return true;
@@ -364,7 +364,7 @@ public:
   static void incr_count() { count++;}
   static int64_t get_total_blocks() {return total_blocks;}
   bool is_allocated(int64_t start_block, int64_t num_blocks);
-  bool is_exhausted();
+  bool is_exhausted(int64_t required);
   void reset_marker();
 
   int64_t sub_used_blocks(int64_t num_blocks);
@@ -412,8 +412,8 @@ protected:
   BitMapAreaList *m_child_list;
 
   virtual bool is_allocated(int64_t start_block, int64_t num_blocks);
-  virtual bool is_exhausted();
-
+  virtual bool is_exhausted(int64_t required);
+  
   bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock) {
     ceph_abort();
     return false;

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -362,6 +362,7 @@ public:
   static void incr_count() { count++;}
   static int64_t get_total_blocks() {return total_blocks;}
   bool is_allocated(int64_t start_block, int64_t num_blocks);
+  bool is_exhausted();
   bool reserve_blks(int64_t required);
   void unreserve_blks(int64_t allocated, int64_t reserve);
   void reset_marker();

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -115,6 +115,7 @@ int64_t BitMapAllocator::allocate(
 
   assert(!(alloc_unit % m_block_size));
   assert(alloc_unit);
+  assert((want_size % alloc_unit) == 0);
 
   assert(!max_alloc_size || max_alloc_size >= alloc_unit);
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4289,7 +4289,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
 
   if (gift) {
     // round up to alloc size
-    gift = P2ROUNDUP(gift, min_alloc_size);
+    gift = P2ROUNDUP(gift, cct->_conf->bluefs_alloc_size);
 
     // hard cap to fit into 32 bits
     gift = MIN(gift, 1ull<<31);
@@ -4324,7 +4324,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
   // reclaim from bluefs?
   if (reclaim) {
     // round up to alloc size
-    reclaim = P2ROUNDUP(reclaim, min_alloc_size);
+    reclaim = P2ROUNDUP(reclaim, cct->_conf->bluefs_alloc_size);
 
     // hard cap to fit into 32 bits
     reclaim = MIN(reclaim, 1ull<<31);

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -299,6 +299,9 @@ TEST(BitAllocator, test_zone_alloc)
     bmap_test_assert(lock);
     for (int i = 0; i < zone->size(); i += 4) {
       block_list->reset();
+      if (zone->reserve_blks(1)) {
+        assert(0);
+      }
       allocated = zone->alloc_blocks_dis(1, 1, i, 0, block_list);
       bmap_test_assert(allocated == 1);
       EXPECT_EQ(extents[0].offset, (uint64_t) i * blk_size);
@@ -318,13 +321,16 @@ TEST(BitAllocator, test_zone_alloc)
 
     for (int i = 1; i <= total_blocks - BmapEntry::size(); i = i << 1) {
       for (int64_t j = 0; j <= BmapEntry::size(); j = 1 << j) {
-	extents.clear();
+        extents.clear();
         ExtentList *block_list = new ExtentList(&extents, blk_size);
-	zone = new BitMapZone(g_ceph_context, total_blocks, 0);
+        zone = new BitMapZone(g_ceph_context, total_blocks, 0);
         lock = zone->lock_excl_try();
         bmap_test_assert(lock);
 
         block_list->reset();
+        if (zone->reserve_blks(i)) {
+          assert(0);
+        }
         int64_t need_blks = (((total_blocks - j) / i) * i);
         allocated = zone->alloc_blocks_dis(need_blks, i, j, 0, block_list);
         bmap_test_assert(allocated == need_blks);
@@ -347,14 +353,18 @@ TEST(BitAllocator, test_zone_alloc)
             bmap_test_assert(lock);
             block_list->reset();
             int64_t need_blks = i;
+            if (zone->reserve_blks(i)) {
+              assert(0);
+            }
             allocated = zone->alloc_blocks_dis(need_blks, i, 0, 0, block_list);
             bmap_test_assert(allocated == need_blks);
             bmap_test_assert(extents[0].offset ==  (uint64_t) j);
             block_list->reset();
           }
           {
-            allocated = zone->alloc_blocks_dis(1, 1, 0, 0, block_list);
-            bmap_test_assert(allocated == 0);
+          if (!zone->reserve_blks(1)) {
+            bmap_test_assert(0);
+          }
             block_list->reset();
           }
          
@@ -369,20 +379,28 @@ TEST(BitAllocator, test_zone_alloc)
 
     {
       extents.clear();
+
       ExtentList *block_list = new ExtentList(&extents, blk_size);
       zone = new BitMapZone(g_ceph_context, total_blocks, 0);
       lock = zone->lock_excl_try();
       bmap_test_assert(lock);
 
       block_list->reset();
-      allocated = zone->alloc_blocks_dis(total_blocks + 1, total_blocks + 1, 0, 1024, block_list);
-      bmap_test_assert(allocated == 0);
+      if (!zone->reserve_blks(total_blocks + 1)) {
+        bmap_test_assert(0);
+      }
 
       block_list->reset();
+      if (zone->reserve_blks(total_blocks)) {
+        bmap_test_assert(0);
+      }
       allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 1, 1024, block_list);
-      bmap_test_assert(allocated == 0);
+      bmap_test_assert(allocated == 0);  
 
       block_list->reset();
+      if (zone->reserve_blks(total_blocks)) {
+        bmap_test_assert(0);
+      }
       allocated = zone->alloc_blocks_dis(total_blocks, total_blocks, 0, 0, block_list);
       bmap_test_assert(allocated == total_blocks);
       bmap_test_assert(extents[0].offset == 0);
@@ -390,12 +408,17 @@ TEST(BitAllocator, test_zone_alloc)
       zone->free_blocks(extents[0].offset, allocated);
         
       delete block_list;
+
       extents.clear();
       block_list = new ExtentList(&extents, blk_size, total_blocks / 4 * blk_size);
+      block_list->reset();
+      if (zone->reserve_blks(total_blocks/ 4)) {
+        bmap_test_assert(0);
+      }
       allocated = zone->alloc_blocks_dis(total_blocks, total_blocks / 4, 0, 0, block_list);
       bmap_test_assert(allocated == total_blocks);
       for (int i = 0; i < 4; i++) {
-	bmap_test_assert(extents[i].offset == (uint64_t) i * (total_blocks / 4));
+        bmap_test_assert(extents[i].offset == (uint64_t) i * (total_blocks / 4));
       }
     }
   }
@@ -423,7 +446,7 @@ TEST(BitAllocator, test_bmap_alloc)
     int64_t allocated = 0;
 
     BitAllocator *alloc = new BitAllocator(g_ceph_context, total_blocks,
-					   zone_size, CONCURRENT);
+             zone_size, CONCURRENT);
     int64_t alloc_size = 2;
     for (int64_t iter = 0; iter < max_iter; iter++) {
       for (int64_t j = 0; alloc_size <= total_blocks; j++) {
@@ -519,7 +542,7 @@ TEST(BitAllocator, test_bmap_alloc2)
   int64_t total_blocks = 1024 * 4;
   int64_t zone_size = 1024;
   BitAllocator *alloc = new BitAllocator(g_ceph_context, total_blocks,
-					 zone_size, CONCURRENT);
+           zone_size, CONCURRENT);
 
   alloc_extents_max_block(alloc, 1, 16);
   alloc_extents_max_block(alloc, 4, 16);
@@ -573,7 +596,7 @@ TEST(BitAllocator, test_bmap_alloc_concurrent)
   bmap_test_assert(total_blocks <= MAX_BLOCKS);
 
   BitAllocator *alloc = new BitAllocator(g_ceph_context, total_blocks,
-					 zone_size, CONCURRENT);
+           zone_size, CONCURRENT);
 
   for (int k = 0; k < 2; k++) {
     cont = k;


### PR DESCRIPTION
Fixed race condition in getting used blocks from allocator by putting it under single lock.
Signed-off-by: Ramesh Chander <Ramesh.Chander@sandisk.com>