### PR TITLE
jewel: rados/upgrade test fails with git clone https://github.com/ceph/ceph.git /home/ubuntu/cephtest/clone.client.0 ; cd -- /home/ubuntu/cephtest/clone.client.0 && git checkout jewel

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -313,11 +313,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,
@@ -334,11 +338,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 alt_git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -309,21 +309,41 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
     clonedir = '{tdir}/clone.{role}'.format(tdir=testdir, role=role)
 
     git_url = teuth_config.get_ceph_git_url()
-    remote.run(
-        logger=log.getChild(role),
-        args=[
-            'git',
-            'clone',
+    try:
+        remote.run(
+            logger=log.getChild(role),
+            args=[
+                'git',
+                'clone',
+                git_url,
+                clonedir,
+                run.Raw(';'),
+                'cd', '--', clonedir,
+                run.Raw('&&'),
+                'git', 'checkout', refspec,
+            ],
+        )
+    except CommandFailedError:
+        alt_git_url = git_url.replace('ceph-ci', 'ceph')
+        log.info(
+            "failed to check out '%s' from %s; will also try in %s",
+            refspec,
             git_url,
-            clonedir,
-            run.Raw(';'),
-            'cd', '--', clonedir,
-            run.Raw('&&'),
-            'git', 'checkout', refspec,
-            run.Raw('&&'),
-            'mv', 'qa/workunits', srcdir,
-        ],
-    )
+            alt_git_url,
+        )
+        remote.run(
+            logger=log.getChild(role),
+            args=[
+                'git',
+                'clone',
+                alt_git_url,
+                clonedir,
+                run.Raw(';'),
+                'cd', '--', clonedir,
+                run.Raw('&&'),
+                'git', 'checkout', refspec,
+            ],
+        )
 
     remote.run(
         logger=log.getChild(role),


### PR DESCRIPTION
http://tracker.ceph.com/issues/18376