### PR TITLE
hammer: tests: populate mnt_point in qa/tasks/ceph.py

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -580,6 +580,7 @@ def cluster(ctx, config):
 
                 log.info('mount %s on %s -o %s' % (dev, remote,
                                                    ','.join(mount_options)))
+                mnt_point = '/var/lib/ceph/osd/ceph-{id}'.format(id=id_)
                 remote.run(
                     args=[
                         'sudo',
@@ -587,7 +588,7 @@ def cluster(ctx, config):
                         '-t', fs,
                         '-o', ','.join(mount_options),
                         dev,
-                        os.path.join('/var/lib/ceph/osd', 'ceph-{id}'.format(id=id_)),
+                        mnt_point,
                     ]
                 )
                 remote.run(


### PR DESCRIPTION
In hammer, there is no "mnt_point" variable, yet 53225d5 was cherry-picked to
hammer - see 87e0299448908775600c62130617bad503027768 and https://github.com/ceph/ceph/pull/12455

This caused lots of "NameError: global name 'mnt_point' is not defined" errors
in hammer integration testing.

This is not a cherry-pick, because the mnt_point variable was introduced by
a54ff597faa379c8fd369352fb924651be269f95 ("tasks/ceph: convert cluster creation
to work with multiple clusters") which was not backported to hammer.

Fixes: http://tracker.ceph.com/issues/18383
Signed-off-by: Nathan Cutler <ncutler@suse.com>