### PR TITLE
tests: rbd/test_lock_fence.sh: fix rbdrw.py relative path

### DIFF
--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -3,7 +3,7 @@
 
 IMAGE=rbdrw-image
 LOCKID=rbdrw
-RELPATH=$(dirname $0)/../../../src/test/pybind
+RELPATH=$(dirname $0)/../../../src/test/librbd
 RBDRW=$RELPATH/rbdrw.py
 
 rbd create $IMAGE --size 10 --image-format 2 --image-shared || exit 1


### PR DESCRIPTION
This commit fixes a regression introduced by cf29477

Fixes: http://tracker.ceph.com/issues/18388
Signed-off-by: Nathan Cutler <ncutler@suse.com>