### PR TITLE
rgw: add lifecycle validation according to S3.

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -83,14 +83,8 @@ bool RGWLifecycleConfiguration::validate()
   while (next_iter != prefix_map.end()) {
     string c_pre = cur_iter->first;
     string n_pre = next_iter->first;
-    if (c_pre.length() > n_pre.length()) {
-      if (c_pre.compare(0, n_pre.length(), n_pre) == 0) {
-        return false;
-      }
-    } else {
-      if (n_pre.compare(0, c_pre.length(), c_pre) == 0) {
-        return false;
-      }
+    if (n_pre.compare(0, c_pre.length(), c_pre) == 0) {
+      return false;
     }
     ++next_iter;
     ++cur_iter;

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -33,12 +33,12 @@ using namespace librados;
 
 bool LCRule::validate()
 {
-  if (id.length() > MAX_ID_LEN)
+  if (id.length() > MAX_ID_LEN) {
     return false;
-  else if (status.compare("Enabled") != 0 && status.compare("Disabled") != 0)
+  }
+  else if (expiration.get_days() <= 0) {
     return false;
-  else if (expiration.get_days() <= 0)
-    return false;
+  }
   return true;
 }
 
@@ -55,29 +55,33 @@ void RGWLifecycleConfiguration::_add_rule(LCRule *rule)
   prefix_map[rule->get_prefix()] = rule->get_expiration().get_days();
 }
 
-bool RGWLifecycleConfiguration::check_and_add_rule(LCRule *rule)
+int RGWLifecycleConfiguration::check_and_add_rule(LCRule *rule)
 {
-  if (!rule->validate())
-    return false;
+  if (!rule->validate()) {
+    return -EINVAL;
+  }
   string id;
   rule->get_id(id);
-  if (rule_map.find(id) != rule_map.end())  //id shouldn't be the same 
-    return false;
+  if (rule_map.find(id) != rule_map.end()) {  //id shouldn't be the same 
+    return -EINVAL;
+  }
   rule_map.insert(pair<string, LCRule>(id, *rule));
 
   auto ret = prefix_map.insert(pair<string, int>(rule->get_prefix(), rule->get_expiration().get_days()));
   //Now prefix shouldn't be the same. When we add noncurrent expiration or other action, prefix may be same.
-  if (!ret.second)
-    return false;
-  return true;
+  if (!ret.second) {
+    return -ERR_INVALID_REQUEST;
+  }
+  return 0;
 }
 
 //Rules are conflicted: if one rule's prefix starts with other rule's prefix, and these two rules
 //define same action(now only support expiration days). 
 bool RGWLifecycleConfiguration::validate() 
 {
-  if (prefix_map.size() < 2)
+  if (prefix_map.size() < 2) {
     return true;
+  }
   auto next_iter = prefix_map.begin();
   auto cur_iter = next_iter++;
   while (next_iter != prefix_map.end()) {

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -165,7 +165,7 @@ public:
 
   void add_rule(LCRule* rule);
 
-  bool check_and_add_rule(LCRule* rule);
+  int check_and_add_rule(LCRule* rule);
 
   bool validate();
 

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -20,6 +20,7 @@
 
 using namespace std;
 #define HASH_PRIME 7877
+#define MAX_ID_LEN 255
 static string lc_oid_prefix = "lc";
 static string lc_index_lock_name = "lc_process";
 
@@ -102,6 +103,8 @@ public:
   void set_expiration(LCExpiration*_expiration) {
     expiration = *_expiration;
   }
+
+  bool validate();
   
   void encode(bufferlist& bl) const {
      ENCODE_START(1, 1, bl);
@@ -161,6 +164,10 @@ public:
 //  static void generate_test_instances(list<RGWAccessControlList*>& o);
 
   void add_rule(LCRule* rule);
+
+  bool check_and_add_rule(LCRule* rule);
+
+  bool validate();
 
   multimap<string, LCRule>& get_rule_map() { return rule_map; }
   map<string, int>& get_prefix_map() { return prefix_map; }

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -57,6 +57,8 @@ bool LCRule_S3::xml_end(const char *el) {
   if (!lc_status)
     return false;
   status = lc_status->get_data();
+  if (status.compare("Enabled") != 0 && status.compare("Disabled") != 0)
+    return false;
 
   lc_expiration = static_cast<LCExpiration_S3 *>(find_first("Expiration"));
   if (!lc_expiration)
@@ -78,15 +80,18 @@ void LCRule_S3::to_xml(CephContext *cct, ostream& out) {
 
 int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfiguration& dest)
 {
+  int ret = 0;
   multimap<string, LCRule>::iterator iter;
   for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
     LCRule& src_rule = iter->second;
-    if (!dest.check_and_add_rule(&src_rule))
-      return -EINVAL;
+    ret = dest.check_and_add_rule(&src_rule);
+    if (ret < 0)
+      return ret;
   }
-  if (!dest.validate())
-    return -EINVAL;
-  return 0;
+  if (!dest.validate()) {
+    ret = -ERR_INVALID_REQUEST;
+  }
+  return ret;
 }
 
 void RGWLifecycleConfiguration_S3::dump_xml(Formatter *f) const

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -81,13 +81,11 @@ int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfigura
   multimap<string, LCRule>::iterator iter;
   for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
     LCRule& src_rule = iter->second;
-    bool rule_ok = true;
-
-    if (rule_ok) {
-      dest.add_rule(&src_rule);
-    }
+    if (!dest.check_and_add_rule(&src_rule))
+      return -EINVAL;
   }
-
+  if (!dest.validate())
+    return -EINVAL;
   return 0;
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4236,7 +4236,7 @@ void RGWPutLC::execute()
   ldout(s->cct, 15) << "read len=" << len << " data=" << (data ? data : "") << dendl;
 
   if (!parser.parse(data, len, 1)) {
-    op_ret = -EACCES;
+    op_ret = -EINVAL;
     return;
   }
   config = static_cast<RGWLifecycleConfiguration_S3 *>(parser.find_first("LifecycleConfiguration"));

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4236,12 +4236,12 @@ void RGWPutLC::execute()
   ldout(s->cct, 15) << "read len=" << len << " data=" << (data ? data : "") << dendl;
 
   if (!parser.parse(data, len, 1)) {
-    op_ret = -EINVAL;
+    op_ret = -ERR_MALFORMED_XML;
     return;
   }
   config = static_cast<RGWLifecycleConfiguration_S3 *>(parser.find_first("LifecycleConfiguration"));
   if (!config) {
-    op_ret = -EINVAL;
+    op_ret = -ERR_MALFORMED_XML;
     return;
   }
 


### PR DESCRIPTION
According to S3, every S3 lifecycle rule has some restrictions and shouldn't be conflicted with other lifecycle rule.

Fixes: http://tracker.ceph.com/issues/18394

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>