### PR TITLE
kraken: qa/workunits/rbd/test_lock_fence.sh fails (regression)

### DIFF
--- a/qa/workunits/rbd/test_lock_fence.sh
+++ b/qa/workunits/rbd/test_lock_fence.sh
@@ -3,7 +3,7 @@
 
 IMAGE=rbdrw-image
 LOCKID=rbdrw
-RELPATH=$(dirname $0)/../../../src/test/pybind
+RELPATH=$(dirname $0)/../../../src/test/librbd
 RBDRW=$RELPATH/rbdrw.py
 
 rbd create $IMAGE --size 10 --image-format 2 --image-shared || exit 1


### PR DESCRIPTION
http://tracker.ceph.com/issues/18392