### PR TITLE
qa/tasks/cephfs: fix test_sessionmap.test_session_reject

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5628,7 +5628,7 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
   }
 
   filepath fp(CEPH_INO_ROOT);
-  if (!mount_root.empty()) {
+  if (cct->_conf->client_mountpoint != std::string("/") && !mount_root.empty()) {
     metadata["root"] = mount_root.c_str();
     fp = filepath(mount_root.c_str());
   }


### PR DESCRIPTION
commit 9f8810008c makes client set client_metadata.root according
to mount_path

Fixes: http://tracker.ceph.com/issues/18361
Signed-off-by: Yan, Zheng <zyan@redhat.com>