### PR TITLE
hammer: Cannot reserve CentOS 7.2 smithi machines

### DIFF
--- a/qa/distros/all/centos.yaml
+++ b/qa/distros/all/centos.yaml
@@ -1,0 +1,1 @@
+os_type: centos

--- a/qa/distros/supported/centos.yaml
+++ b/qa/distros/supported/centos.yaml
@@ -1,0 +1,1 @@
+../all/centos.yaml

--- a/qa/distros/supported/centos_7.2.yaml
+++ b/qa/distros/supported/centos_7.2.yaml
@@ -1,1 +1,0 @@
-../all/centos_7.2.yaml


### PR DESCRIPTION
http://tracker.ceph.com/issues/18405