### PR TITLE
client: Fix lookup of "/.." in jewel

### DIFF
--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -28,7 +28,6 @@
 
 #define CEPH_INO_ROOT   1
 #define CEPH_INO_CEPH   2       /* hidden .ceph dir */
-#define CEPH_INO_DOTDOT 3	/* used by ceph fuse for parent (..) */
 #define CEPH_INO_LOST_AND_FOUND 4	/* reserved ino for use in recovery */
 
 /* arbitrary limit on max # of monitors (cluster of 3 is typical) */


### PR DESCRIPTION
This should fix a problem for nfs-ganesha when built against libcephfs. Currently with the jewel client, doing a lookup of ".." at the root directory ends up returning -ENOENT. This converts it to consider the parent of the root to be the root itself (similarly to how /.. works in Linux).

Only lightly tested so far but it is building now and I'll run the whole fs suite over it once it's done.