### PR TITLE
common: get rid of "warning: ignoring return value of ‘strerror_r’"

### DIFF
--- a/src/common/module.c
+++ b/src/common/module.c
@@ -10,6 +10,7 @@
  *
  */
 
+#include "acconfig.h"
 #include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -40,7 +41,12 @@ static int run_command(const char *command)
 
 	if (status < 0) {
 		char error_buf[80];
+#ifdef STRERROR_R_CHAR_P
+		char* dummy = strerror_r(errno, error_buf, sizeof(error_buf));
+		(void)dummy;
+#else
 		strerror_r(errno, error_buf, sizeof(error_buf));
+#endif
 		fprintf(stderr, "couldn't run '%s': %s\n", command,
 			error_buf);
 	} else if (WIFSIGNALED(status)) {


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>