### PR TITLE
mon: fix wrongly delete routed pgstats op

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -705,7 +705,8 @@ bool PGMonitor::preprocess_pg_stats(MonOpRequestRef op)
   // only if they've had the map for a while.
   if (stats->had_map_for > 30.0 &&
       mon->osdmon()->is_readable() &&
-      stats->epoch < mon->osdmon()->osdmap.get_epoch())
+      stats->epoch < mon->osdmon()->osdmap.get_epoch() &&
+      !session->proxy_con)
     mon->osdmon()->send_latest_now_nodelete(op, stats->epoch+1);
 
   // Always forward the PGStats to the leader, even if they are the same as


### PR DESCRIPTION
a peon may forward the pgstats to leader, and record it locally, but leader will check if
osd has the latest map before process, if not, will use a route op to indicate poen to send it,
then poen will delete routed op when fininaly send out which make poen cannot send pgstatack
when leader has processed the pgstat update. so osd will always track this op until reach a
threshold block pgstats sending, at worst, reopen mon session.

Signed-off-by: Mingxin Liu <mingxin@xsky.com>