### PR TITLE
src/CMakeLists.txt: Move parse_secret_objs setting within definition …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -827,8 +827,8 @@ add_subdirectory(bash_completion)
 if(WITH_LIBCEPHFS OR WITH_RBD)
   set(parse_secret_files
     common/secret.c)
+  add_library(parse_secret_objs OBJECT ${parse_secret_files})
 endif()
-add_library(parse_secret_objs OBJECT ${parse_secret_files})
 
 if(WITH_LIBCEPHFS)
   add_subdirectory(client)


### PR DESCRIPTION
…block

 - parse_secret_objs is only used when secret.c is actually used
   and that is with CEPHFS or RBD

This removes a Cmake warning on FreeBSD

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>