### PR TITLE
mds: remove boost::pool usage and use tcmalloc directly

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -36,8 +36,6 @@ ostream& CDentry::print_db_line_prefix(ostream& out)
   return out << ceph_clock_now() << " mds." << dir->cache->mds->get_nodeid() << ".cache.den(" << dir->ino() << " " << name << ") ";
 }
 
-boost::pool<> CDentry::pool(sizeof(CDentry));
-
 LockType CDentry::lock_type(CEPH_LOCK_DN);
 LockType CDentry::versionlock_type(CEPH_LOCK_DVERSION);
 

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -121,16 +121,6 @@ public:
     linkage.remote_d_type = dt;
   }
 
-  static void *operator new(size_t num_bytes) {
-    void *n = pool.malloc();
-    if (!n)
-      throw std::bad_alloc();
-    return n;
-  }
-  void operator delete(void *p) {
-    pool.free(p);
-  }
-
   const char *pin_name(int p) const override {
     switch (p) {
     case PIN_INODEPIN: return "inodepin";
@@ -381,16 +371,6 @@ protected:
 
   version_t version;  // dir version when last touched.
   version_t projected_version;  // what it will be when i unlock/commit.
-
-
-private:
-  /*
-   * This class uses a boost::pool to handle allocation. This is *not*
-   * thread-safe, so don't do allocations from multiple threads!
-   *
-   * Alternatively, switch the pool to use a boost::singleton_pool.
-   */
-  static boost::pool<> pool;
 };
 
 ostream& operator<<(ostream& out, const CDentry& dn);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -74,8 +74,6 @@ public:
 // PINS
 //int cdir_pins[CDIR_NUM_PINS] = { 0,0,0,0,0,0,0,0,0,0,0,0,0,0 };
 
-boost::pool<> CDir::pool(sizeof(CDir));
-
 
 ostream& operator<<(ostream& out, const CDir& dir)
 {

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -45,25 +45,6 @@ ostream& operator<<(ostream& out, const class CDir& dir);
 class CDir : public MDSCacheObject, public Counter<CDir> {
   friend ostream& operator<<(ostream& out, const class CDir& dir);
 
-  /*
-   * This class uses a boost::pool to handle allocation. This is *not*
-   * thread-safe, so don't do allocations from multiple threads!
-   *
-   * Alternatively, switch the pool to use a boost::singleton_pool.
-   */
-private:
-  static boost::pool<> pool;
-public:
-  static void *operator new(size_t num_bytes) { 
-    void *n = pool.malloc();
-    if (!n)
-      throw std::bad_alloc();
-    return n;
-  }
-  void operator delete(void *p) {
-    pool.free(p);
-  }
-
 public:
   // -- pins --
   static const int PIN_DNWAITER =     1;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -66,9 +66,6 @@ public:
 };
 
 
-boost::pool<> CInode::pool(sizeof(CInode));
-boost::pool<> Capability::pool(sizeof(Capability));
-
 LockType CInode::versionlock_type(CEPH_LOCK_IVERSION);
 LockType CInode::authlock_type(CEPH_LOCK_IAUTH);
 LockType CInode::linklock_type(CEPH_LOCK_ILINK);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -129,27 +129,6 @@ WRITE_CLASS_ENCODER_FEATURES(InodeStore)
 
 // cached inode wrapper
 class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CInode> {
-  /*
-   * This class uses a boost::pool to handle allocation. This is *not*
-   * thread-safe, so don't do allocations from multiple threads!
-   *
-   * Alternatively, switch the pool to use a boost::singleton_pool.
-   */
-
-private:
-  static boost::pool<> pool;
-public:
-  static void *operator new(size_t num_bytes) { 
-    void *n = pool.malloc();
-    if (!n)
-      throw std::bad_alloc();
-    return n;
-  }
-  void operator delete(void *p) {
-    pool.free(p);
-  }
-
-
  public:
   // -- pins --
   static const int PIN_DIRFRAG =         -1; 

--- a/src/mds/Capability.h
+++ b/src/mds/Capability.h
@@ -128,16 +128,6 @@ public:
   }
   Capability(const Capability& other);  // no copying
 
-
-  static void *operator new(size_t num_bytes) {
-    void *n = pool.malloc();
-    if (!n)
-      throw std::bad_alloc();
-    return n;
-  }
-  void operator delete(void *p) {
-    pool.free(p);
-  }
   const Capability& operator=(const Capability& other);  // no copying
 
   int pending() { return _pending; }
@@ -336,7 +326,6 @@ public:
   xlist<Capability*>::item item_client_revoking_caps;
 
 private:
-  static boost::pool<> pool;
   CInode *inode;
   client_t client;
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -98,6 +98,8 @@
 
 #include "common/Timer.h"
 
+#include "perfglue/heap_profiler.h"
+
 using namespace std;
 
 #include "common/config.h"
@@ -7375,11 +7377,11 @@ void MDCache::check_memory_usage()
         g_conf->mds_cache_size * g_conf->mds_health_cache_threshold) {
     // Only do this once we are back in bounds: otherwise the releases would
     // slow down whatever process caused us to exceed bounds to begin with
-    dout(2) << "check_memory_usage: releasing unused space from pool allocators"
-            << dendl;
-    CInode::pool.release_memory();
-    CDir::pool.release_memory();
-    CDentry::pool.release_memory();
+    if (ceph_using_tcmalloc()) {
+      dout(2) << "check_memory_usage: releasing unused space from tcmalloc" 
+	      << dendl;
+      ceph_heap_release_free_memory();
+    }
     exceeded_size_limit = false;
   }
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18425

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>