### PR TITLE
rgw: AbortMultipart request returns NoSuchUpload error if the meta obj doesn't exist

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5100,7 +5100,7 @@ void RGWAbortMultipart::execute()
   // and also remove the metadata obj
   op_ret = del_op.delete_obj();
   if (op_ret == -ENOENT) {
-    op_ret = -ERR_NO_SUCH_BUCKET;
+    op_ret = -ERR_NO_SUCH_UPLOAD;
   }
 }
 


### PR DESCRIPTION
In abort multipart request, we delete the meta obj after we delete all uploaded parts. If the meta obj doesn't exist, we return `NoSuchUpload`. 

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>