### PR TITLE
denc: fix segment fault

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -156,7 +156,8 @@ struct denc_traits<vector<bluestore_pextent_t>> {
   static void bound_encode(const vector<bluestore_pextent_t>& v, size_t& p) {
     p += sizeof(uint32_t);
     size_t per = 0;
-    denc(*(bluestore_pextent_t*)nullptr, per);
+    bluestore_pextent_t tmp;
+    denc(tmp, per);
     p += per * v.size();
   }
   static void encode(const vector<bluestore_pextent_t>& v,


### PR DESCRIPTION
* Use a temporary object instead of a null pointer in denc, so that later
* the access to the object's fields doesn't raise segment fault.

Fixes: http://tracker.ceph.com/issues/18427
Signed-off-by: Lisa Li <xiaoyan.li@intel.com>