### PR TITLE
ceph.in: Fix couple of minor issues on the messages

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -458,7 +458,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                     if parsed_args.output_format:
                         valid_dict['format'] = parsed_args.output_format
                     if verbose:
-                        print("Submitting command ", valid_dict, file=sys.stderr)
+                        print("Submitting command: ", valid_dict, file=sys.stderr)
                     ret, outbuf, outs = json_command(cluster_handle,
                                                      target=target,
                                                      argdict=valid_dict)
@@ -474,7 +474,7 @@ def new_style_command(parsed_args, cmdargs, target, sigdict, inbuf, verbose):
                     print("Invalid command", file=sys.stderr)
 
     if verbose:
-        print("Submitting command ", valid_dict, file=sys.stderr)
+        print("Submitting command: ", valid_dict, file=sys.stderr)
     return json_command(cluster_handle, target=target, argdict=valid_dict,
                         inbuf=inbuf)
 
@@ -641,7 +641,6 @@ def main():
         try:
             raw_write(admin_socket(sockpath, childargs, format))
         except Exception as e:
-            print('admin_socket: {0}'.format(e))
             print('admin_socket: {0}'.format(e), file=sys.stderr)
             return errno.EINVAL
         return 0
@@ -687,7 +686,7 @@ def main():
                                        conffile=conffile)
         retargs = run_in_thread(cluster_handle.conf_parse_argv, childargs)
     except rados.Error as e:
-        print('Error initializing cluster client: {0}'.format(repr(e)), file=sys.stderr)
+        print('Error initializing cluster client: {0}'.format(e), file=sys.stderr)
         return 1
 
     childargs = retargs
@@ -732,10 +731,10 @@ def main():
         print('Cluster connection aborted', file=sys.stderr)
         return 1
     except rados.PermissionDeniedError as e:
-        print('Error connecting to cluster: {0}'.format(e.__class__.__name__), file=sys.stderr)
+        print(str(e), file=sys.stderr)
         return errno.EACCES
     except Exception as e:
-        print('Error connecting to cluster: {0}'.format(e.__class__.__name__), file=sys.stderr)
+        print(str(e), file=sys.stderr)
         return 1
 
     if parsed_args.help:


### PR DESCRIPTION
- e.__class__.name is the name of class, use the error message assembled
by function: make_ex instead.
- repr(e) will also print the name of class, end use needn't care about
the class name but the useful error message.
- General clean up.

Signed-off-by: Dave Chen <wei.d.chen@intel.com>