### PR TITLE
rgw: only bucket owner should be able to remove bucket

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2446,7 +2446,7 @@ void RGWCreateBucket::execute()
 
 int RGWDeleteBucket::verify_permission()
 {
-  if (!verify_bucket_permission(s, RGW_PERM_WRITE)) {
+  if (s->user->user_id.compare(s->bucket_owner.get_id()) != 0) {
     return -EACCES;
   }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18345

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>