### PR TITLE
mon/PGMonitor: fix description for ceph pg ls, etc.

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -1112,7 +1112,7 @@ Usage::
 	deep_scrub|backfill|backfill_toofull|recovery_wait|
 	undersized...]}
 
-Subcommand ``ls-by-pool`` lists pg with pool = [poolname | poolid]
+Subcommand ``ls-by-pool`` lists pg with pool = [poolname]
 
 Usage::
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -142,7 +142,7 @@ COMMAND("pg dump_stuck " \
 COMMAND("pg ls-by-pool " \
         "name=poolstr,type=CephString " \
 	"name=states,type=CephChoices,strings=active|clean|down|replay|scrubbing|degraded|inconsistent|peering|repair|recovering|backfill_wait|incomplete|stale|remapped|deep_scrub|backfill|backfill_toofull|recovery_wait|undersized|activating|peered,n=N,req=false ", \
-	"list pg with pool = [poolname | poolid]", "pg", "r", "cli,rest")
+	"list pg with pool = [poolname]", "pg", "r", "cli,rest")
 COMMAND("pg ls-by-primary " \
         "name=osd,type=CephOsdName " \
         "name=pool,type=CephInt,req=false " \


### PR DESCRIPTION
1. `ceph pg ls-by-pool` does not support `poolid`, so modify the description for it
1. add `osdid` as an arg for `ceph pg ls`, so we can support both:
`ceph pg ls <poolid> <osdid> <states>` and
`ceph pg ls <poolid> <states>`

Signed-off-by: runsisi <runsisi@zte.com.cn>