### PR TITLE
rgw: error_code in error log is not right when data sync fails.

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2249,7 +2249,7 @@ public:
         sync_status = retcode;
       }
       if (!error_ss.str().empty()) {
-        yield call(sync_env->error_logger->log_error_cr(sync_env->conn->get_remote_id(), "data", error_ss.str(), retcode, "failed to sync object"));
+        yield call(sync_env->error_logger->log_error_cr(sync_env->conn->get_remote_id(), "data", error_ss.str(), -retcode, "failed to sync object"));
       }
 done:
       if (sync_status == 0) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18437

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>