### PR TITLE
Cmake: cleanup the use of udev and blkid in target_link_lib()

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -107,7 +107,6 @@ target_link_libraries(librbd LINK_PRIVATE
   cls_journal_client 
   common
   pthread
-  udev
   ${CMAKE_DL_LIBS}
   ${EXTRALIBS})
 if(ENABLE_SHARED)

--- a/src/rbd_replay/CMakeLists.txt
+++ b/src/rbd_replay/CMakeLists.txt
@@ -36,7 +36,6 @@ if(${WITH_BABELTRACE})
     global
     babeltrace
     babeltrace-ctf
-    udev
     ${Boost_DATE_TIME_LIBRARY}
     )
   install(TARGETS rbd-replay-prep DESTINATION bin)

--- a/src/test/cls_rbd/CMakeLists.txt
+++ b/src/test/cls_rbd/CMakeLists.txt
@@ -14,9 +14,7 @@ target_link_libraries(ceph_test_cls_rbd
   ${CMAKE_DL_LIBS}
   ${CRYPTO_LIBS}
   ${EXTRALIBS}
-  radostest
-  blkid
-  udev)
+  radostest)
 install(TARGETS
   ceph_test_cls_rbd
   DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -132,7 +132,6 @@ target_link_libraries(ceph_test_librbd_fsx
   ${CMAKE_DL_LIBS}
   ${CRYPTO_LIBS}
   ${EXTRALIBS}
-  blkid
   )
 
 install(TARGETS


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>