### PR TITLE
tests: subst repo and branch in git.ceph.com URL in qa/tasks/cram.py and qa/tasks/qemu.py

### DIFF
--- a/qa/suites/krbd/unmap/tasks/unmap.yaml
+++ b/qa/suites/krbd/unmap/tasks/unmap.yaml
@@ -2,4 +2,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p=ceph.git;a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/unmap.t
+      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/unmap.t

--- a/qa/suites/rbd/maintenance/qemu/xfstests.yaml
+++ b/qa/suites/rbd/maintenance/qemu/xfstests.yaml
@@ -9,5 +9,5 @@ io_workload:
           clone: true
           type: block
           num_rbd: 2
-          test: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/run_xfstests_qemu.sh
+          test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/run_xfstests_qemu.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/#qemu_xfstests.yaml#
+++ b/qa/suites/rbd/qemu/workloads/#qemu_xfstests.yaml#
@@ -3,5 +3,5 @@ tasks:
     all:
       type: block
       num_rbd: 2
-      grtest: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/run_xfstests_qemu.sh
+      grtest: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/run_xfstests_qemu.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_bonnie.yaml
@@ -2,5 +2,5 @@ tasks:
 - qemu:
     all:
       clone: true
-      test: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/workunits/suites/bonnie.sh
+      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/workunits/suites/bonnie.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_fsstress.yaml
@@ -2,5 +2,5 @@ tasks:
 - qemu:
     all:
       clone: true
-      test: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/workunits/suites/fsstress.sh
+      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/workunits/suites/fsstress.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_iozone.yaml.disabled
+++ b/qa/suites/rbd/qemu/workloads/qemu_iozone.yaml.disabled
@@ -1,6 +1,6 @@
 tasks:
 - qemu:
     all:
-      test: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/workunits/suites/iozone.sh
+      test: http://git.ceph.com/?p={repo};a=blob_plain;h={branch};f=qa/workunits/suites/iozone.sh
       image_size: 20480
 exclude_arch: armv7l

--- a/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
+++ b/qa/suites/rbd/qemu/workloads/qemu_xfstests.yaml
@@ -4,5 +4,5 @@ tasks:
       clone: true
       type: block
       num_rbd: 2
-      test: http://git.ceph.com/?p=ceph.git;a=blob_plain;f=qa/run_xfstests_qemu.sh
+      test: http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=qa/run_xfstests_qemu.sh
 exclude_arch: armv7l

--- a/qa/suites/rbd/singleton/all/formatted-output.yaml
+++ b/qa/suites/rbd/singleton/all/formatted-output.yaml
@@ -7,4 +7,4 @@ tasks:
 - cram:
     clients:
       client.0:
-      - http://git.ceph.com/?p=ceph.git;a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/formatted-output.t
+      - http://git.ceph.com/?p={repo};a=blob_plain;hb={branch};f=src/test/cli-integration/rbd/formatted-output.t

--- a/qa/tasks/cram.py
+++ b/qa/tasks/cram.py
@@ -7,6 +7,7 @@ import os
 from teuthology import misc as teuthology
 from teuthology.parallel import parallel
 from teuthology.orchestra import run
+from teuthology.config import config as teuth_config
 
 log = logging.getLogger(__name__)
 
@@ -61,6 +62,12 @@ def task(ctx, config):
     if refspec is None:
         refspec = 'HEAD'
 
+    # hack: the git_url is always ceph-ci or ceph
+    git_url = teuth_config.get_ceph_git_url()
+    repo_name = 'ceph.git'
+    if git_url.count('ceph-ci'):
+        repo_name = 'ceph-ci.git'
+
     try:
         for client, tests in clients.iteritems():
             (remote,) = ctx.cluster.only(client).remotes.iterkeys()
@@ -76,11 +83,12 @@ def task(ctx, config):
                     ],
                 )
             for test in tests:
-                log.info('fetching test %s for %s', test, client)
+                url = test.format(repo=repo_name, branch=refspec)
+                log.info('fetching test %s for %s', url, client)
                 assert test.endswith('.t'), 'tests must end in .t'
                 remote.run(
                     args=[
-                        'wget', '-nc', '-nv', '-P', client_dir, '--', test.format(branch=refspec),
+                        'wget', '-nc', '-nv', '-P', client_dir, '--', url,
                         ],
                     )
 


### PR DESCRIPTION
Inspired by bcbe45d948f1c4da02e27b3be5f29a8b52745e28

Fixes: http://tracker.ceph.com/issues/18440
Signed-off-by: Nathan Cutler <ncutler@suse.com>