### PR TITLE
mon: optracker's initiated_at timestamp should not be NULL

### DIFF
--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -86,7 +86,9 @@ private:
   op_type_t op_type;
 
   MonOpRequest(Message *req, OpTracker *tracker) :
-    TrackedOp(tracker, req->get_recv_stamp()),
+    TrackedOp(tracker,
+      req->get_recv_stamp().is_zero() ?
+      req->get_recv_stamp() : ceph_clock_now()),
     request(req),
     session(NULL),
     con(NULL),


### PR DESCRIPTION
mon may track a self-initiated message, recv_stamp remains unset
so using ceph_clock_now() instead to make optracker happy

Signed-off-by: Mingxin Liu <mingxin@xsky.com>