### PR TITLE
libcephfs: fix cct refcount constructing from rados

### DIFF
--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -320,7 +320,6 @@ extern "C" int ceph_create_from_rados(struct ceph_mount_info **cmount,
 {
   auto rados = (librados::RadosClient *) cluster;
   auto cct = rados->cct;
-  cct->get();
   return ceph_create_with_context(cmount, cct);
 }
 


### PR DESCRIPTION
This get() made sense before ceph_mount_info did its
own reference acquisition on the context object.

Follow up to:
a567fa66 libcephfs.cc: fix memory leak

Signed-off-by: John Spray <john.spray@redhat.com>