### PR TITLE
cmake: turn libcommon into a shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,15 +518,6 @@ find_package(Boost 1.61 COMPONENTS ${BOOST_COMPONENTS} REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 include_directories(SYSTEM ${PROJECT_BINARY_DIR}/include)
 
-if (WITH_SYSTEM_BOOST)
-  if(FREEBSD)
-    # if boost_python is used then also link with libpython*
-    LIST(APPEND Boost_LIBRARIES ${PYTHON_LIBRARIES})
-  endif()
-else()
-  LIST(APPEND Boost_LIBRARIES "-lz")
-endif()
-
 CHECK_INCLUDE_FILE_CXX("boost/asio/coroutine.hpp" HAVE_BOOST_ASIO_COROUTINE)
 
 find_package(Threads REQUIRED)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1353,6 +1353,8 @@ fi
 %files -n librados2
 %defattr(-,root,root,-)
 %{_libdir}/librados.so.*
+%dir %{_libdir}/ceph
+%{_libdir}/ceph/libceph-common.so
 %if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,2 +1,3 @@
 usr/lib/librados.so.*
 usr/lib/librados_tp.so.*
+usr/lib/ceph/libceph-common.so

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,12 @@ include(GNUInstallDirs)
 # for erasure and compressor plugins
 set(CMAKE_INSTALL_PKGLIBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})
 set(CMAKE_INSTALL_FULL_PKGLIBDIR ${CMAKE_INSTALL_FULL_LIBDIR}/${PROJECT_NAME})
+# so libceph-common can be found
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+if(NOT CMAKE_INSTALL_RPATH)
+  set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_FULL_PKGLIBDIR}")
+endif()
+
 # to be compatible with configure_files shared with autoconfig
 set(bindir ${CMAKE_INSTALL_FULL_BINDIR})
 set(sbindir ${CMAKE_INSTALL_FULL_SBINDIR})
@@ -424,8 +430,6 @@ set(libcommon_files
   common/TrackedOp.cc
   common/SloppyCRCMap.cc
   common/types.cc
-  $<TARGET_OBJECTS:common_buffer_obj>
-  $<TARGET_OBJECTS:common_texttable_obj>
   log/Log.cc
   log/SubsystemMap.cc
   mon/MonCap.cc
@@ -503,7 +507,6 @@ set(libcommon_files
   common/dns_resolve.cc
   ${arch_files}
   ${auth_files}
-  $<TARGET_OBJECTS:compressor_objs>
   ${mds_files})
 if(LINUX)
   list(APPEND libcommon_files msg/async/EventEpoll.cc)
@@ -534,17 +537,36 @@ else()
     perfglue/disabled_stubs.cc)
 endif()
 
-if(ENABLE_SHARED)
-  list(APPEND libcommon_files
-    $<TARGET_OBJECTS:global_common_objs>)
-endif(ENABLE_SHARED)
-
-add_library(common STATIC ${libcommon_files}
-  $<TARGET_OBJECTS:mon_common_objs>
-  $<TARGET_OBJECTS:common_mountcephfs_objs>)
-target_link_libraries(common json_spirit erasure_code rt ${LIB_RESOLV}
-  ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
+add_library(common-objs OBJECT ${libcommon_files})
+add_library(ceph-common SHARED
+  $<TARGET_OBJECTS:common_buffer_obj>
+  $<TARGET_OBJECTS:common_texttable_obj>
+  $<TARGET_OBJECTS:compressor_objs>
+  $<TARGET_OBJECTS:common-objs>
+  $<TARGET_OBJECTS:common_mountcephfs_objs>
+  $<TARGET_OBJECTS:global_common_objs>)
+target_link_libraries(ceph-common json_spirit erasure_code rt ${LIB_RESOLV}
+  ${Boost_THREAD_LIBRARY}
+  ${Boost_SYSTEM_LIBRARY}
+  ${Boost_REGEX_LIBRARY}
+  ${Boost_RANDOM_LIBRARY}
+  ${Boost_PROGRAM_OPTIONS_LIBRARY}
+  ${Boost_DATE_TIME_LIBRARY}
+  ${Boost_IOSTREAMS_LIBRARY}
+  ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
   ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+if(NOT WITH_SYSTEM_BOOST)
+  target_link_libraries(ceph-common ${ZLIB_LIBRARIES})
+endif()
+install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
+if(WITH_EMBEDDED)
+  add_library(cephd_common STATIC
+    $<TARGET_OBJECTS:common_buffer_obj>
+    $<TARGET_OBJECTS:common_texttable_obj>
+    $<TARGET_OBJECTS:compressor_objs>
+    $<TARGET_OBJECTS:common-objs>
+    $<TARGET_OBJECTS:common_mountcephfs_objs>)
+endif()
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
   ${CMAKE_SOURCE_DIR}/src/common/version.cc
@@ -554,7 +576,7 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
 include(SIMDExt)
 if(HAVE_ARMV8_CRC)
   add_library(common_crc_aarch64 STATIC common/crc32c_aarch64.c)
-  target_link_libraries(common common_crc_aarch64)
+  target_link_libraries(ceph-common common_crc_aarch64)
 endif(HAVE_ARMV8_CRC)
 
 add_library(common_utf8 STATIC common/utf8.c)
@@ -681,7 +703,7 @@ set(ceph_mon_srcs
 add_executable(ceph-mon ${ceph_mon_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 add_dependencies(ceph-mon erasure_code_plugins)
-      target_link_libraries(ceph-mon mon common os global ${EXTRALIBS}
+      target_link_libraries(ceph-mon mon ceph-common os global ${EXTRALIBS}
   ${CMAKE_DL_LIBS})
 install(TARGETS ceph-mon DESTINATION bin)
 
@@ -841,7 +863,7 @@ if(WITH_LIBCEPHFS)
   target_link_libraries(cephfs LINK_PRIVATE client
     ${CRYPTO_LIBS} ${EXTRALIBS})
   if(ENABLE_SHARED)
-    foreach(name common client osdc)
+    foreach(name ceph-common client osdc)
       set(CEPHFS_LINK_FLAGS "${CEPHFS_LINK_FLAGS} -Wl,--exclude-libs,lib${name}.a")
     endforeach()
     set_target_properties(cephfs PROPERTIES

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -8,4 +8,4 @@ set(libclient_srcs
   Trace.cc
   posix_acl.cc)
 add_library(client STATIC ${libclient_srcs})
-target_link_libraries(client common osdc)
+target_link_libraries(client ceph-common osdc)

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -6,7 +6,7 @@ set(snappy_sources
 
 add_library(ceph_snappy SHARED ${snappy_sources})
 add_dependencies(ceph_snappy ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_snappy snappy)
+target_link_libraries(ceph_snappy ${SNAPPY_LIBRARIES})
 set_target_properties(ceph_snappy PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_snappy DESTINATION ${compressor_plugin_dir})
 

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -6,7 +6,7 @@ set(snappy_sources
 
 add_library(ceph_snappy SHARED ${snappy_sources})
 add_dependencies(ceph_snappy ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_snappy snappy common)
+target_link_libraries(ceph_snappy snappy)
 set_target_properties(ceph_snappy PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_snappy DESTINATION ${compressor_plugin_dir})
 

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zlib z common)
+target_link_libraries(ceph_zlib z)
 target_include_directories(ceph_zlib PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_zlib DESTINATION ${compressor_plugin_dir})

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -29,7 +29,7 @@ endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zlib z)
+target_link_libraries(ceph_zlib ${ZLIB_LIBRARIES})
 target_include_directories(ceph_zlib PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_zlib DESTINATION ${compressor_plugin_dir})

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -7,4 +7,4 @@ set(global_common_files
 add_library(global_common_objs OBJECT ${global_common_files})
 add_library(global STATIC ${libglobal_srcs}
   $<TARGET_OBJECTS:global_common_objs>)
-target_link_libraries(global common ${DPDK_LIBRARIES} ${EXTRALIBS})
+target_link_libraries(global ceph-common ${DPDK_LIBRARIES} ${EXTRALIBS})

--- a/src/java/native/CMakeLists.txt
+++ b/src/java/native/CMakeLists.txt
@@ -8,6 +8,7 @@ set_target_properties(cephfs_jni PROPERTIES
   SOVERSION 1)
 add_dependencies(cephfs_jni jni-header)
 include_directories(${JNI_INCLUDE_DIRS} ${CMAKE_CURRENT_BINARY_DIR})
-target_link_libraries(cephfs_jni LINK_PRIVATE cephfs common ${EXTRALIBS} ${JNI_LIBRARIES})
+target_link_libraries(cephfs_jni LINK_PRIVATE cephfs ceph-common
+  ${EXTRALIBS} ${JNI_LIBRARIES})
 install(TARGETS cephfs_jni
   DESTINATION ${CMAKE_INSTALL_LIBDIR})

--- a/src/json_spirit/CMakeLists.txt
+++ b/src/json_spirit/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_library(json_spirit STATIC
   json_spirit_reader.cpp
   json_spirit_writer.cpp)
-target_link_libraries(json_spirit ${Boost_LIBRARIES} common_utf8)
+target_link_libraries(json_spirit common_utf8)

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
 target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
 target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb ${ALLOC_LIBS} snappy z)
+target_link_libraries(kv ${LEVELDB_LIBRARIES} rocksdb ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
 
 # rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.
 find_package(BZip2 QUIET)

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -15,7 +15,7 @@ set(merge_libs
   cephd_cls_kvs
   cephd_rados
   cephd_rbd
-  common
+  cephd_common
   common_utf8
   erasure_code
   global

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -8,7 +8,7 @@ add_library(rados_a STATIC
   $<TARGET_OBJECTS:librados_api_obj>
   $<TARGET_OBJECTS:librados_objs>
   $<TARGET_OBJECTS:common_buffer_obj>)
-target_link_libraries(rados_a osdc common cls_lock_client
+target_link_libraries(rados_a osdc ceph-common cls_lock_client
     ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
 if(WITH_LTTNG)
   add_dependencies(librados_api_obj librados-tp)
@@ -19,7 +19,7 @@ if(ENABLE_SHARED)
     $<TARGET_OBJECTS:librados_objs>
     $<TARGET_OBJECTS:common_buffer_obj>)
   # LINK_PRIVATE instead of PRIVATE is used to backward compatibility with cmake 2.8.11
-  target_link_libraries(librados LINK_PRIVATE osdc common cls_lock_client
+  target_link_libraries(librados LINK_PRIVATE osdc ceph-common cls_lock_client
     ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
   set_target_properties(librados PROPERTIES
     OUTPUT_NAME rados

--- a/src/libradosstriper/CMakeLists.txt
+++ b/src/libradosstriper/CMakeLists.txt
@@ -5,7 +5,7 @@ set(libradosstriper_srcs
 add_library(radosstriper ${CEPH_SHARED}
   ${libradosstriper_srcs}
   $<TARGET_OBJECTS:librados_objs>)
-target_link_libraries(radosstriper librados cls_lock_client osdc common pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+target_link_libraries(radosstriper librados cls_lock_client osdc ceph-common pthread ${CRYPTO_LIBS} ${EXTRALIBS})
 set_target_properties(radosstriper PROPERTIES
   OUPUT_NAME radosstriper
   VERSION 1.0.0

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -107,7 +107,7 @@ target_link_libraries(librbd LINK_PRIVATE
   cls_rbd_client 
   cls_lock_client 
   cls_journal_client 
-  common
+  ceph-common
   pthread
   ${CMAKE_DL_LIBS}
   ${EXTRALIBS})

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -40,4 +40,4 @@ set(mds_srcs
 add_library(mds STATIC ${mds_srcs}
   $<TARGET_OBJECTS:heap_profiler_objs>
   $<TARGET_OBJECTS:common_util_obj>)
-target_link_libraries(mds ${ALLOC_LIBS} osdc common liblua)
+target_link_libraries(mds ${ALLOC_LIBS} osdc ceph-common liblua)

--- a/src/rbd_fuse/CMakeLists.txt
+++ b/src/rbd_fuse/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_executable(rbd-fuse
   rbd-fuse.cc)
 target_link_libraries(rbd-fuse
-  librbd librados common ${FUSE_LIBRARIES})
+  ceph-common librbd librados ${FUSE_LIBRARIES})
 install(TARGETS rbd-fuse DESTINATION bin)

--- a/src/rbd_replay/CMakeLists.txt
+++ b/src/rbd_replay/CMakeLists.txt
@@ -15,7 +15,7 @@ target_link_libraries(rbd_replay LINK_PRIVATE librbd librados global)
 add_executable(rbd-replay
   rbd-replay.cc)
 target_link_libraries(rbd-replay
-  librbd librados global rbd_replay rbd_replay_types common)
+  librbd librados global rbd_replay rbd_replay_types ceph-common)
 install(TARGETS rbd-replay DESTINATION bin)
 
 set(librbd_replay_ios_srcs
@@ -32,7 +32,7 @@ if(${WITH_BABELTRACE})
     rbd_replay_types
     librbd
     librados
-    common
+    ceph-common
     global
     babeltrace
     babeltrace-ctf

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -111,7 +111,7 @@ target_include_directories(rgw_a PUBLIC
 
 target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
-  cls_replica_log_client cls_user_client common common_utf8 global
+  cls_replica_log_client cls_user_client ceph-common common_utf8 global
   ${CURL_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS})

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -76,7 +76,7 @@ target_link_libraries(ceph_test_signal_handlers global ${BLKID_LIBRARIES} ${CMAK
 add_executable(ceph_test_rewrite_latency
   test_rewrite_latency.cc
   )
-target_link_libraries(ceph_test_rewrite_latency common
+target_link_libraries(ceph_test_rewrite_latency ceph-common
   ${CMAKE_DL_LIBS}
   ${CMAKE_THREAD_LIBS_INIT} ${CRYPTO_LIBS} m ${EXTRALIBS})
 
@@ -94,7 +94,7 @@ target_link_libraries(test_crypto
   )
 
 add_executable(test_build_libcommon buildtest_skeleton.cc)
-target_link_libraries(test_build_libcommon common pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+target_link_libraries(test_build_libcommon ceph-common pthread ${CRYPTO_LIBS} ${EXTRALIBS})
 
 if(WITH_RADOSGW)
   add_executable(test_build_librgw buildtest_skeleton.cc)
@@ -108,7 +108,7 @@ if(WITH_LIBCEPHFS)
 endif(WITH_LIBCEPHFS)
 
 add_executable(test_build_librados buildtest_skeleton.cc)
-target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os common cls_lock_client ${BLKID_LIBRARIES})
+target_link_libraries(test_build_librados librados pthread ${CRYPTO_LIBS} ${EXTRALIBS} osdc osd os ceph-common cls_lock_client ${BLKID_LIBRARIES})
 
 # bench_log
 set(bench_log_srcs
@@ -278,6 +278,7 @@ target_include_directories(ceph_test_librgw_file PRIVATE ${FCGI_INCLUDE_DIR})
 target_link_libraries(ceph_test_librgw_file
   rgw
   librados
+  ceph-common
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
@@ -291,6 +292,7 @@ set_target_properties(ceph_test_librgw_file_cd PROPERTIES COMPILE_FLAGS
 target_link_libraries(ceph_test_librgw_file_cd
   rgw
   librados
+  ceph-common
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
@@ -304,6 +306,7 @@ set_target_properties(ceph_test_librgw_file_gp PROPERTIES COMPILE_FLAGS
 target_link_libraries(ceph_test_librgw_file_gp
   rgw
   librados
+  ceph-common
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
@@ -318,7 +321,7 @@ target_include_directories(ceph_test_librgw_file_nfsns PRIVATE ${FCGI_INCLUDE_DI
 target_link_libraries(ceph_test_librgw_file_nfsns
   rgw
   librados
-  boost_system
+  ceph-common
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
@@ -332,6 +335,7 @@ set_target_properties(ceph_test_librgw_file_aw PROPERTIES COMPILE_FLAGS
 target_link_libraries(ceph_test_librgw_file_aw
   rgw
   librados
+  ceph-common
   ${UNITTEST_LIBS}
   ${EXTRALIBS}
   )
@@ -359,9 +363,8 @@ set_target_properties(test_rgw_ldap PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(test_rgw_ldap
   librados
-  common
+  ceph-common
   ${OPENLDAP_LIBRARIES}
-  ${Boost_LIBRARIES}
   ${UNITTEST_LIBS}
   )
 
@@ -398,7 +401,7 @@ set_target_properties(ceph_xattr_bench PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_xattr_bench
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -423,7 +426,7 @@ set_target_properties(ceph_test_filejournal PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_filejournal
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -497,7 +500,7 @@ if(HAVE_BLKID)
     test_get_blkdev_size.cc
     )
   target_link_libraries(ceph_test_get_blkdev_size
-    common
+    ceph-common
     pthread
     ${EXTRALIBS}
     ${BLKID_LIBRARIES}
@@ -595,14 +598,14 @@ add_executable(unittest_encoding
   encoding.cc
   )
 add_ceph_unittest(unittest_encoding ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_encoding)
-target_link_libraries(unittest_encoding common librados ${XIO_LIBRARY} pthread rt m ${BLKID_LIBRARIES})
+target_link_libraries(unittest_encoding ceph-common librados ${XIO_LIBRARY} pthread rt m ${BLKID_LIBRARIES})
 
 # unittest_addrs
 add_executable(unittest_addrs
   test_addrs.cc
   )
 add_ceph_unittest(unittest_addrs ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_addrs)
-target_link_libraries(unittest_addrs common librados ${XIO_LIBRARY} pthread rt m ${BLKID_LIBRARIES})
+target_link_libraries(unittest_addrs ceph-common librados ${XIO_LIBRARY} pthread rt m ${BLKID_LIBRARIES})
 
 # unittest_workqueue
 add_executable(unittest_workqueue
@@ -704,7 +707,7 @@ add_executable(unittest_xlist
   test_xlist.cc
   )
 add_ceph_unittest(unittest_xlist ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_xlist)
-target_link_libraries(unittest_xlist common ${XIO_LIBRARY})
+target_link_libraries(unittest_xlist ceph-common ${XIO_LIBRARY})
 
 # unittest_arch
 add_executable(unittest_arch
@@ -798,7 +801,7 @@ add_executable(unittest_heartbeatmap
   $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_heartbeatmap ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_heartbeatmap)
-target_link_libraries(unittest_heartbeatmap common global)
+target_link_libraries(unittest_heartbeatmap global ceph-common)
 
 if(${WITH_RADOSGW})
   # unittest_formatter
@@ -817,7 +820,7 @@ add_executable(unittest_daemon_config
   )
 add_ceph_unittest(unittest_daemon_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_daemon_config)
 target_link_libraries(unittest_daemon_config
-  common
+  ceph-common
   global
   ${BLKID_LIBRARIES}
   ${EXTRALIBS}

--- a/src/test/ObjectMap/CMakeLists.txt
+++ b/src/test/ObjectMap/CMakeLists.txt
@@ -7,7 +7,7 @@ set_target_properties(ceph_test_object_map PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_object_map
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -22,7 +22,7 @@ set_target_properties(ceph_test_keyvaluedb_atomicity PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_keyvaluedb_atomicity
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -38,7 +38,7 @@ set_target_properties(ceph_test_keyvaluedb_iterators PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_keyvaluedb_iterators
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -47,7 +47,7 @@ add_executable(unittest_str_map
   test_str_map.cc
   )
 add_ceph_unittest(unittest_str_map ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_str_map)
-target_link_libraries(unittest_str_map common global ${BLKID_LIBRARIES})
+target_link_libraries(unittest_str_map ceph-common global ${BLKID_LIBRARIES})
 
 # unittest_sharedptr_registry
 add_executable(unittest_sharedptr_registry

--- a/src/test/erasure-code/CMakeLists.txt
+++ b/src/test/erasure-code/CMakeLists.txt
@@ -6,15 +6,15 @@ add_ceph_test(test-erasure-code.sh ${CMAKE_CURRENT_SOURCE_DIR}/test-erasure-code
 add_executable(ceph_erasure_code_benchmark 
   ${CMAKE_SOURCE_DIR}/src/erasure-code/ErasureCode.cc
   ceph_erasure_code_benchmark.cc)
-target_link_libraries(ceph_erasure_code_benchmark common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code_benchmark ceph-common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 install(TARGETS ceph_erasure_code_benchmark
   DESTINATION bin)
 
 add_executable(ceph_erasure_code_non_regression ceph_erasure_code_non_regression.cc)
-target_link_libraries(ceph_erasure_code_non_regression common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code_non_regression ceph-common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 
 add_executable(ceph_erasure_code ceph_erasure_code.cc)
-target_link_libraries(ceph_erasure_code common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
+target_link_libraries(ceph_erasure_code ceph-common ${Boost_PROGRAM_OPTIONS_LIBRARY} global ${CMAKE_DL_LIBS})
 install(TARGETS ceph_erasure_code
   DESTINATION bin)
 
@@ -55,7 +55,7 @@ target_link_libraries(unittest_erasure_code_plugin
   global
   ${CMAKE_DL_LIBS}
   ec_example
-  common
+  ceph-common
   )
 add_dependencies(unittest_erasure_code_plugin
   ec_example
@@ -74,7 +74,7 @@ add_executable(unittest_erasure_code
 add_ceph_unittest(unittest_erasure_code ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code)
 target_link_libraries(unittest_erasure_code
   global
-  common
+  ceph-common
   )
 
 # unittest_erasure_code_plugin_jerasure
@@ -85,7 +85,7 @@ add_executable(unittest_erasure_code_plugin_jerasure
 add_ceph_unittest(unittest_erasure_code_plugin_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_jerasure)
 target_link_libraries(unittest_erasure_code_plugin_jerasure
   global
-  common)
+  ceph-common)
 add_dependencies(unittest_erasure_code_plugin_jerasure
   ec_jerasure)
 
@@ -100,7 +100,7 @@ add_executable(unittest_erasure_code_isa
 add_ceph_unittest(unittest_erasure_code_isa ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_isa)
 target_link_libraries(unittest_erasure_code_isa
   global
-  common
+  ceph-common
   ec_isa
   erasure_code
   )
@@ -114,7 +114,7 @@ add_executable(unittest_erasure_code_plugin_isa
 add_ceph_unittest(unittest_erasure_code_plugin_isa ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_plugin_isa)
 target_link_libraries(unittest_erasure_code_plugin_isa
   global
-  common
+  ceph-common
   crush
   ${CMAKE_DL_LIBS}
   erasure_code
@@ -132,7 +132,7 @@ target_link_libraries(unittest_erasure_code_lrc
   global
   ${CMAKE_DL_LIBS}
   ec_lrc
-  common
+  ceph-common
   )
 
 # unittest_erasure_code_plugin_lrc
@@ -147,7 +147,7 @@ add_dependencies(unittest_erasure_code_plugin_lrc
 target_link_libraries(unittest_erasure_code_plugin_lrc
   global
   ${CMAKE_DL_LIBS}
-  common)
+  ceph-common)
 
 # unittest_erasure_code_plugin_shec
 add_executable(unittest_erasure_code_plugin_shec
@@ -158,7 +158,7 @@ add_ceph_unittest(unittest_erasure_code_plugin_shec ${CMAKE_RUNTIME_OUTPUT_DIREC
 target_link_libraries(unittest_erasure_code_plugin_shec
   global
   ${CMAKE_DL_LIBS}
-  common)
+  ceph-common)
 add_dependencies(unittest_erasure_code_plugin_shec 
   ec_shec)
 
@@ -172,7 +172,7 @@ add_ceph_unittest(unittest_erasure_code_example ${CMAKE_RUNTIME_OUTPUT_DIRECTORY
 target_link_libraries(unittest_erasure_code_example
   global
   ${CMAKE_DL_LIBS}
-  common
+  ceph-common
   erasure_code
   ${UNITTEST_LIBS}
   )
@@ -189,7 +189,7 @@ add_executable(unittest_erasure_code_jerasure
 add_ceph_unittest(unittest_erasure_code_jerasure ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_erasure_code_jerasure)
 target_link_libraries(unittest_erasure_code_jerasure
   global
-  common
+  ceph-common
   ec_jerasure
   )
 
@@ -205,7 +205,7 @@ add_ceph_unittest(unittest_erasure_code_shec ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/u
 target_link_libraries(unittest_erasure_code_shec
   global
   ${CMAKE_DL_LIBS}
-  common
+  ceph-common
   ec_shec
   )
 
@@ -217,7 +217,7 @@ add_ceph_unittest(unittest_erasure_code_shec_all ${CMAKE_RUNTIME_OUTPUT_DIRECTOR
 target_link_libraries(unittest_erasure_code_shec_all
   global
   ${CMAKE_DL_LIBS}
-  common
+  ceph-common
   ec_shec
   )
 
@@ -230,7 +230,7 @@ add_ceph_unittest(unittest_erasure_code_shec_thread ${CMAKE_RUNTIME_OUTPUT_DIREC
 target_link_libraries(unittest_erasure_code_shec_thread
   global
   ${CMAKE_DL_LIBS}
-  common
+  ceph-common
   ec_shec
   )
 
@@ -243,6 +243,6 @@ add_ceph_unittest(unittest_erasure_code_shec_arguments ${CMAKE_RUNTIME_OUTPUT_DI
 target_link_libraries(unittest_erasure_code_shec_arguments
   global
   ${CMAKE_DL_LIBS}
-  common
+  ceph-common
   ec_shec
   )

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -27,6 +27,7 @@ if(${WITH_CEPHFS})
   set_target_properties(ceph_test_libcephfs_access PROPERTIES COMPILE_FLAGS
     ${UNITTEST_CXX_FLAGS})
   target_link_libraries(ceph_test_libcephfs_access
+    ceph-common
     cephfs
     librados
     ${UNITTEST_LIBS}

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -3,7 +3,7 @@ set(libradostest_srcs
   test.cc 
   TestCase.cc)
 add_library(radostest STATIC ${libradostest_srcs})
-target_link_libraries(radostest common json_spirit ${EXTRALIBS})
+target_link_libraries(radostest ceph-common json_spirit ${EXTRALIBS})
 set_target_properties(radostest PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
 # ceph_test_rados_api_cmd

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -114,7 +114,7 @@ add_executable(ceph_test_librbd_api
 target_link_libraries(ceph_test_librbd_api
   librbd
   librados
-  common
+  ceph-common
   radostest
   ${UNITTEST_LIBS})
 set_target_properties(ceph_test_librbd_api PROPERTIES COMPILE_FLAGS

--- a/src/test/mds/CMakeLists.txt
+++ b/src/test/mds/CMakeLists.txt
@@ -13,5 +13,5 @@ add_executable(unittest_mds_sessionfilter
   $<TARGET_OBJECTS:unit-main>
   )
 add_ceph_unittest(unittest_mds_sessionfilter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mds_sessionfilter)
-target_link_libraries(unittest_mds_sessionfilter mds osdc common global ${BLKID_LIBRARIES})
+target_link_libraries(unittest_mds_sessionfilter mds osdc ceph-common global ${BLKID_LIBRARIES})
 

--- a/src/test/messenger/CMakeLists.txt
+++ b/src/test/messenger/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(simple_server
   simple_dispatcher.cc
   )
 target_link_libraries(simple_server
-  os global common ${Boost_REGEX_LIBRARY}
+  os global ceph-common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -13,7 +13,7 @@ add_executable(simple_client
   simple_dispatcher.cc
   )
 target_link_libraries(simple_client
-  os global common ${Boost_REGEX_LIBRARY}
+  os global ceph-common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -24,7 +24,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_server
-    os global common ${Boost_REGEX_LIBRARY}
+    os global ceph-common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
@@ -35,7 +35,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_client
-    os global common ${Boost_REGEX_LIBRARY}
+    os global ceph-common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}

--- a/src/test/objectstore/CMakeLists.txt
+++ b/src/test/objectstore/CMakeLists.txt
@@ -20,7 +20,7 @@ set_target_properties(ceph_test_objectstore PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_objectstore
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -38,7 +38,7 @@ set_target_properties(ceph_test_keyvaluedb PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_keyvaluedb
   os
-  common
+  ceph-common
   ${UNITTEST_LIBS}
   global
   ${EXTRALIBS}
@@ -142,7 +142,7 @@ endif(HAVE_LIBAIO)
 add_executable(unittest_transaction
   test_transaction.cc)
 add_ceph_unittest(unittest_transaction ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_transaction)
-target_link_libraries(unittest_transaction os common ${XIO_LIBRARY})
+target_link_libraries(unittest_transaction os ceph-common ${XIO_LIBRARY})
 
 # unittest_memstore_clone
 add_executable(unittest_memstore_clone

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(rbd librbd librados
   krbd
   rbd_types
   journal
-  common global
+  ceph-common global
   ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 install(TARGETS rbd DESTINATION bin)


### PR DESCRIPTION
prior to this change, libcommon is a convenient library which gets
linked into librados, librbd and libcephfs and all ceph executables.
this incurs some problems:
 - double dose of libcommon in memory space and HDD: waste of memory
   and disk space.
 - if an application links to two libraries including libcommon at the
   same time. take librados and libcephfs as an example, they could
   interfere with each other by changing the other guy's status.
after this change, libcommon is tuned into a shared library and
renamed to libceph-common. it will be installed into $prefix/lib/ceph,
and packaged in librados2.

ceph.spec.in,debian/librados2.install: package libceph-common in
  librados2.
CMakeLists.txt:
  - do not link against libboost-* if not necessary.
  - s/common/ceph-common/g
  - install libceph-common into $prefix/lib/ceph
  - set rpath to $prefix/lib/ceph
  - link against ceph-common if an executable needs access to non public
    symbols in ceph.

Signed-off-by: Kefu Chai <kchai@redhat.com>