### PR TITLE
ceph-objectstore-tool: Handle object names that are also valid json

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2666,7 +2666,8 @@ int main(int argc, char **argv)
     } else {
     json_spirit::Value v;
     try {
-      if (!json_spirit::read(object, v)) {
+      if (!json_spirit::read(object, v) ||
+          (v.type() != json_spirit::array_type && v.type() != json_spirit::obj_type)) {
         // Special: Need head/snapdir so set even if user didn't specify
         if (vm.count("objcmd") && (objcmd == "remove-clone-metadata"))
 	  head = true;


### PR DESCRIPTION
Treat an argument that happens to be json but doesn't conform to our requirements
as an object name.

Signed-off-by: David Zafman <dzafman@redhat.com>