### PR TITLE
rbd: cleanup: fix the typo in namespace comment

### DIFF
--- a/src/tools/rbd/action/ImportDiff.cc
+++ b/src/tools/rbd/action/ImportDiff.cc
@@ -230,6 +230,6 @@ Shell::Action action(
   {"import-diff"}, {}, "Import an incremental diff.", "", &get_arguments,
   &execute);
 
-} // namespace list
+} // namespace import_diff
 } // namespace action
 } // namespace rbd

--- a/src/tools/rbd/action/Rename.cc
+++ b/src/tools/rbd/action/Rename.cc
@@ -79,6 +79,6 @@ Shell::Action action(
   {"rename"}, {"mv"}, "Rename image within pool.", "", &get_arguments,
   &execute);
 
-} // namespace list
+} // namespace rename
 } // namespace action
 } // namespace rbd

--- a/src/tools/rbd/action/Resize.cc
+++ b/src/tools/rbd/action/Resize.cc
@@ -88,6 +88,6 @@ Shell::Action action(
   {"resize"}, {}, "Resize (expand or shrink) image.", "", &get_arguments,
   &execute);
 
-} // namespace list
+} // namespace resize
 } // namespace action
 } // namespace rbd


### PR DESCRIPTION
Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>