### PR TITLE
rgw: pass authentication domain to civetweb

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -111,7 +111,7 @@ void RGWCivetWeb::init_env(CephContext *cct)
   }
 
   env.set("REQUEST_METHOD", info->request_method);
-  env.set("REQUEST_URI", info->uri);
+  env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later
   env.set("SCRIPT_URI", info->uri); /* FIXME */
   if (info->query_string) {
     env.set("QUERY_STRING", info->query_string);

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -53,6 +53,7 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "enable_keep_alive", "yes");
   set_conf_default(conf_map, "validate_http_method", "no");
   set_conf_default(conf_map, "canonicalize_url_path", "no");
+  set_conf_default(conf_map, "enable_auth_domain_check", "no");
   conf->get_val("port", "80", &port_str);
   std::replace(port_str.begin(), port_str.end(), '+', ',');
   conf_map["listening_ports"] = port_str;


### PR DESCRIPTION
This is needed to support absolute uris, as civetweb further cross
checks whether the request is made to the same domain or not, otherwise
civetweb ends up sending NULL response back to the client. Also set the
REQUEST_URI to the full request uri, since the old uri parameter is
deprecated.

This needs https://github.com/ceph/civetweb/pull/16 also merged for full support of subdomain style requests

Fixes: http://tracker.ceph.com/issues/17657
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>