### PR TITLE
rbd: bench-write should return error if io-size >= 4G

### DIFF
--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -196,6 +196,11 @@ int do_bench(librbd::Image& image, io_type_t io_type,
     return -EINVAL;
   }
 
+  if (io_size > std::numeric_limits<uint32_t>::max()) {
+    std::cerr << "rbd: io-size should be less than 4G" << std::endl;
+    return -EINVAL;
+  }
+
   rbd_bencher b(&image, io_type, io_size);
 
   std::cout << "bench "


### PR DESCRIPTION
Currently if user perform bench-write with io-size > 4G
then its crashing because currently during memory allocation
bufferptr taking size of buffer as a unsigned and io-size > 4G
will overflow with unsigned. so during memset operation it will
try to set io_size size of memory area pointed by bufferptr,
(bufferptr area is:  (4G - io_size)), so it will cause
segmentation fault.

Fix is to return error if io-size >= 4G

Fixes: http://tracker.ceph.com/issues/18422

Reported-by:  Jason Dillaman <dillaman@redhat.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>