### PR TITLE
rgw: fix handling RGWUserInfo::system in RGWHandler_REST_SWIFT.

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2115,7 +2115,7 @@ int RGWHandler_REST_SWIFT::authorize()
     }
 
     /* FIXME(rzarzynski): move into separated RGWAuthApplier decorator. */
-    if (s->user->system) {
+    if (s->user->system && s->auth_identity->is_owner_of(s->user->user_id)) {
       s->system_request = true;
       ldout(s->cct, 20) << "system request over Swift API" << dendl;
 


### PR DESCRIPTION
Before this patch the flag was wrongly handled in the Swift API
implementation. In rare conditions this might result in setting
`req_state::system_request`.

This may happen only if both of those conditions are fulfilled:
 * RadosGW is running in a multi-site configuration (at least
   one user with the system flag turned on is present),
 * the `rgw_swift_account_in_url` configurable has been switched
   to `true`. The value is `false` by default and our documentation
   doesn't actually mention about the option.

The issue doesn't affect Jewel nor any previous release.

Fixes: http://tracker.ceph.com/issues/18476
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>

<hr>
CC: @yehudasa, @cbodley.