### PR TITLE
qa/tasks/ceph-deploy: create-keys explicitly

### DIFF
--- a/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
+++ b/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
@@ -1,12 +1,3 @@
-overrides:
-  ceph-deploy:
-    conf:
-      global:
-        debug ms: 1
-      osd:
-        debug osd: 10
-      mon:
-        debug mon: 10
 roles:
 - - mon.a
   - mds.0

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -295,17 +295,14 @@ def build_ceph_cluster(ctx, config):
         # try the next block which will wait up to 15 minutes to gatherkeys.
         execute_ceph_deploy(mon_create_nodes)
 
-        estatus_gather = execute_ceph_deploy(gather_keys)
-        max_gather_tries = 90
-        gather_tries = 0
-        while (estatus_gather != 0):
-            gather_tries += 1
-            if gather_tries >= max_gather_tries:
-                msg = 'ceph-deploy was not able to gatherkeys after 15 minutes'
-                raise RuntimeError(msg)
-            estatus_gather = execute_ceph_deploy(gather_keys)
-            time.sleep(10)
+        # create-keys is explicit now
+        # http://tracker.ceph.com/issues/16036
+        mons = ctx.cluster.only(teuthology.is_type('mon'))
+        for remote in mons.remotes.iterkeys():
+            remote.run(args=['sudo', 'ceph-create-keys', '--cluster', 'ceph',
+                             '--id', remote.shortname])
 
+        estatus_gather = execute_ceph_deploy(gather_keys)
         if mds_nodes:
             estatus_mds = execute_ceph_deploy(deploy_mds)
             if estatus_mds != 0:


### PR DESCRIPTION
Due to https://github.com/ceph/ceph/pull/9345 we need to create-keys explicitly, should be also back ported to kraken.

Failures here are due to different issue: http://pulpito.ceph.com/vasu-2017-01-10_18:07:13-ceph-deploy-kraken---basic-vps/