### PR TITLE
mds/server: skip unwanted dn in handle_client_readdir

### DIFF
--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -428,6 +428,7 @@ protected:
 
   map_t::iterator begin() { return items.begin(); }
   map_t::iterator end() { return items.end(); }
+  map_t::iterator lower_bound(dentry_key_t key) { return items.lower_bound(key); }
 
   unsigned get_num_head_items() const { return num_head_items; }
   unsigned get_num_head_null() const { return num_head_null; }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3416,7 +3416,9 @@ void Server::handle_client_readdir(MDRequestRef& mdr)
   bufferlist dnbl;
   __u32 numfiles = 0;
   bool end = (dir->begin() == dir->end());
-  for (CDir::map_t::iterator it = dir->begin();
+  // skip all dns < dentry_key_t(snapid, offset_str, offset_hash)
+  dentry_key_t skip_key(snapid, offset_str.c_str(), offset_hash);
+  for (CDir::map_t::iterator it = offset_str.empty() ? dir->begin() : dir->lower_bound(skip_key);
        !end && numfiles < max;
        end = (it == dir->end())) {
     CDentry *dn = it->second;


### PR DESCRIPTION
We can skip unwanted dn which  < (offset_key, snap) via map.lower_bound, rather than
iterate across them.

Previously we iterate and skip dn which < (offset_key, dn->last), as dn->last >= snap
 means (offset_key, dn->last) >= (offset_key, snap), and such iterate_and_skip logic
still keep, so this commit doesnt change code logic but an optimization.

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>