### PR TITLE
os/bluestore: kill BufferSpace.empty()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7514,12 +7514,10 @@ void BlueStore::_dump_extent_map(ExtentMap &em, int log_level)
 		      << dendl;
     }
     std::lock_guard<std::recursive_mutex> l(e.blob->shared_blob->bc.cache->lock);
-    if (!e.blob->shared_blob->bc.empty()) {
-      for (auto& i : e.blob->shared_blob->bc.buffer_map) {
-	dout(log_level) << __func__ << "       0x" << std::hex << i.first
-			<< "~" << i.second->length << std::dec
-			<< " " << *i.second << dendl;
-      }
+    for (auto& i : e.blob->shared_blob->bc.buffer_map) {
+      dout(log_level) << __func__ << "       0x" << std::hex << i.first
+                      << "~" << i.second->length << std::dec
+                      << " " << *i.second << dendl;
     }
   }
 }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -273,10 +273,6 @@ public:
       return i;
     }
 
-    bool empty() const {
-      return buffer_map.empty();
-    }
-
     // must be called under protection of the Cache lock
     void _clear();
 


### PR DESCRIPTION
Because:
1. All other public methods are called under the protection of cache->lock,
which makes the usage of this method is weird.

2. The only caller is _dump_extent_map(), and we can do it without this
in a simpler way.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>