### PR TITLE
osd: fix fiemap inconsistency during scrub

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -823,6 +823,8 @@ OPTION(osd_deep_scrub_interval, OPT_FLOAT, 60*60*24*7) // once a week
 OPTION(osd_deep_scrub_randomize_ratio, OPT_FLOAT, 0.15) // scrubs will randomly become deep scrubs at this rate (0.15 -> 15% of scrubs are deep)
 OPTION(osd_deep_scrub_stride, OPT_INT, 524288)
 OPTION(osd_deep_scrub_update_digest_min_age, OPT_INT, 2*60*60)   // objects must be this old (seconds) before we update the whole-object digest on scrub
+OPTION(osd_deep_scrub_allocation_fix, OPT_BOOL, false) // fix object allocation diff among the replicas
+OPTION(osd_deep_scrub_allocation_fix_threshold, OPT_FLOAT, 0.20) // the imbalance thereshold for us to fix the allocation
 OPTION(osd_scan_list_ping_tp_interval, OPT_U64, 100)
 OPTION(osd_class_dir, OPT_STR, CEPH_LIBDIR "/rados-classes") // where rados plugins are stored
 OPTION(osd_open_classes_on_start, OPT_BOOL, true)

--- a/src/common/scrub_types.h
+++ b/src/common/scrub_types.h
@@ -115,6 +115,9 @@ struct inconsistent_obj_wrapper : librados::inconsistent_obj_t {
   void set_attr_name_mismatch() {
     errors |= obj_err_t::ATTR_NAME_MISMATCH;
   }
+  void set_object_fiemap_inconsistency() {
+    errors |= obj_err_t::OBJECT_FIEMAP_INCONSISTENCY;
+  }
   void add_shard(const pg_shard_t& pgs, const shard_info_wrapper& shard);
   void set_auth_missing(const hobject_t& hoid,
                         const map<pg_shard_t, ScrubMap*>&,

--- a/src/include/rados/rados_types.hpp
+++ b/src/include/rados/rados_types.hpp
@@ -146,10 +146,11 @@ struct obj_err_t {
     SIZE_MISMATCH        = 1 << 6,
     ATTR_VALUE_MISMATCH  = 1 << 7,
     ATTR_NAME_MISMATCH    = 1 << 8,
+    OBJECT_FIEMAP_INCONSISTENCY = 1 << 9,
     // When adding more here add to either SHALLOW_ERRORS or DEEP_ERRORS
   };
   uint64_t errors = 0;
-  static constexpr uint64_t SHALLOW_ERRORS = OBJECT_INFO_INCONSISTENCY|SIZE_MISMATCH|ATTR_VALUE_MISMATCH|ATTR_NAME_MISMATCH;
+  static constexpr uint64_t SHALLOW_ERRORS = OBJECT_INFO_INCONSISTENCY|SIZE_MISMATCH|ATTR_VALUE_MISMATCH|ATTR_NAME_MISMATCH|OBJECT_FIEMAP_INCONSISTENCY;
   static constexpr uint64_t DEEP_ERRORS = DATA_DIGEST_MISMATCH|OMAP_DIGEST_MISMATCH;
   bool has_object_info_inconsistency() const {
     return errors & OBJECT_INFO_INCONSISTENCY;
@@ -168,6 +169,9 @@ struct obj_err_t {
   }
   bool has_attr_name_mismatch() const {
     return errors & ATTR_NAME_MISMATCH;
+  }
+  bool has_object_fiemap_inconsistency() const {
+    return errors & OBJECT_FIEMAP_INCONSISTENCY;
   }
   bool has_shallow_errors() const {
     return errors & SHALLOW_ERRORS;

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5215,7 +5215,7 @@ void ScrubMap::generate_test_instances(list<ScrubMap*>& o)
 void ScrubMap::object::encode(bufferlist& bl) const
 {
   bool compat_read_error = read_error || ec_hash_mismatch || ec_size_mismatch;
-  ENCODE_START(8, 2, bl);
+  ENCODE_START(9, 2, bl);
   ::encode(size, bl);
   ::encode(negative, bl);
   ::encode(attrs, bl);
@@ -5230,12 +5230,13 @@ void ScrubMap::object::encode(bufferlist& bl) const
   ::encode(read_error, bl);
   ::encode(ec_hash_mismatch, bl);
   ::encode(ec_size_mismatch, bl);
+  ::encode(object_fiemap, bl);
   ENCODE_FINISH(bl);
 }
 
 void ScrubMap::object::decode(bufferlist::iterator& bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(8, 2, 2, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(9, 2, 2, bl);
   ::decode(size, bl);
   bool tmp, compat_read_error = false;
   ::decode(tmp, bl);
@@ -5274,6 +5275,9 @@ void ScrubMap::object::decode(bufferlist::iterator& bl)
     ::decode(tmp, bl);
     ec_size_mismatch = tmp;
   }
+  if (struct_v >= 9) {
+    ::decode(object_fiemap, bl);
+  }
   // If older encoder found a read_error, set read_error
   if (compat_read_error && !read_error && !ec_hash_mismatch && !ec_size_mismatch)
     read_error = true;
@@ -5291,6 +5295,14 @@ void ScrubMap::object::dump(Formatter *f) const
     f->dump_int("length", p->second.length());
     f->close_section();
   }
+  f->open_array_section("object_fiemap");
+  for (map<uint64_t,uint64_t>::const_iterator p = object_fiemap.begin();
+        p != object_fiemap.end(); ++p) {
+    f->open_object_section("extent");
+    f->dump_unsigned("offset", p->first);
+    f->dump_unsigned("length", p->second);
+    f->close_section();
+  }
   f->close_section();
 }
 
@@ -5303,6 +5315,8 @@ void ScrubMap::object::generate_test_instances(list<object*>& o)
   o.back()->size = 123;
   o.back()->attrs["foo"] = buffer::copy("foo", 3);
   o.back()->attrs["bar"] = buffer::copy("barval", 6);
+  o.back()->object_fiemap[4096] = 4096;
+  o.back()->object_fiemap[16384] = 8192;
 }
 
 // -- OSDOp --

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4248,6 +4248,7 @@ ostream& operator<<(ostream& out, const PushOp &op);
 struct ScrubMap {
   struct object {
     map<string,bufferptr> attrs;
+    map<uint64_t, uint64_t> object_fiemap;
     set<snapid_t> snapcolls;
     uint64_t size;
     __u32 omap_digest;         ///< omap crc32c


### PR DESCRIPTION
    Currently, because of some reasons, Although the content in object is consistent,
    the allocation blocks on filesystem may be inconsistent,
    which lead to different filesystem space usage for a same object.
    
    Different space usage for same objects may cause huge inbalance based on current crush alg.
    Therefore, we have enough confidence to consider this case as an inconsistency and report
    a scrub error and repair it.