### PR TITLE
rgw: the swift container acl should support field .ref

### DIFF
--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -59,6 +59,7 @@ static bool uid_is_public(const string& uid)
     return false;
 
   return sub.compare(".r") == 0 ||
+         sub.compare(".ref") == 0 ||
          sub.compare(".referer") == 0 ||
          sub.compare(".referrer") == 0;
 }
@@ -75,6 +76,7 @@ static bool extract_referer_urlspec(const std::string& uid,
   url_spec = uid.substr(pos + 1);
 
   return sub.compare(".r") == 0 ||
+         sub.compare(".ref") == 0 ||
          sub.compare(".referer") == 0 ||
          sub.compare(".referrer") == 0;
 }


### PR DESCRIPTION
On the openstack-swift. The container acl supports .ref, which is ignored on ceph swift.

Fixes: http://tracker.ceph.com/issues/18484
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>