### PR TITLE
os/bluestore: use Best-Effort policy when evicting onode from cache

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1045,6 +1045,7 @@ OPTION(bluestore_extent_map_shard_min_size, OPT_U32, 150)
 OPTION(bluestore_extent_map_shard_target_size_slop, OPT_DOUBLE, .2)
 OPTION(bluestore_extent_map_inline_shard_prealloc_size, OPT_U32, 256)
 OPTION(bluestore_cache_trim_interval, OPT_DOUBLE, .1)
+OPTION(bluestore_cache_trim_max_skip_pinned, OPT_U32, 64) // skip this many onodes pinned in cache before we give up
 OPTION(bluestore_cache_type, OPT_STR, "2q")   // lru, 2q
 OPTION(bluestore_2q_cache_kin_ratio, OPT_DOUBLE, .5)    // kin page slot size / max page slot size
 OPTION(bluestore_2q_cache_kout_ratio, OPT_DOUBLE, .5)   // number of kout page slot / total number of page slot


### PR DESCRIPTION
We want a precise control of cache usage, and BE can achieve this goal
in a better way.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>