### PR TITLE
cmake: link ceph-{mgr,mon,mds,osd} against libcommon statically

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1354,7 +1354,7 @@ fi
 %defattr(-,root,root,-)
 %{_libdir}/librados.so.*
 %dir %{_libdir}/ceph
-%{_libdir}/ceph/libceph-common.so
+%{_libdir}/ceph/libceph-common.so.*
 %if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif

--- a/debian/control
+++ b/debian/control
@@ -632,7 +632,7 @@ Description: debugging symbols for radosgw
 
 Package: ceph-test
 Architecture: linux-any
-Depends: ceph-common, curl, xml2, xmlstarlet, ${misc:Depends}, ${shlibs:Depends}
+Depends: ceph-common, curl, xmlstarlet, ${misc:Depends}, ${shlibs:Depends}
 Description: Ceph test and benchmarking tools
  This package contains tools for testing and benchmarking Ceph.
 
@@ -641,7 +641,7 @@ Architecture: linux-any
 Section: debug
 Priority: extra
 Depends: ceph-test (= ${binary:Version}), ceph-common (= ${binary:Version}),
-         curl, xml2,
+         curl,
          ${misc:Depends}
 Description: Ceph test and benchmarking tools
  .

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,3 +1,3 @@
 usr/lib/librados.so.*
 usr/lib/librados_tp.so.*
-usr/lib/ceph/libceph-common.so
+usr/lib/ceph/libceph-common.so.*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -566,6 +566,9 @@ target_link_libraries(ceph-common json_spirit erasure_code rt ${LIB_RESOLV}
 if(NOT WITH_SYSTEM_BOOST)
   target_link_libraries(ceph-common ${ZLIB_LIBRARIES})
 endif()
+# appease dpkg-shlibdeps
+set_target_properties(ceph-common PROPERTIES
+  SOVERSION 0)
 install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
 if(WITH_EMBEDDED)
   add_library(cephd_common STATIC

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -544,16 +544,15 @@ else()
 endif()
 
 add_library(common-objs OBJECT ${libcommon_files})
-add_library(ceph-common SHARED
+set(ceph_common_objs
   $<TARGET_OBJECTS:common_buffer_obj>
   $<TARGET_OBJECTS:common_texttable_obj>
   $<TARGET_OBJECTS:compressor_objs>
   $<TARGET_OBJECTS:common-objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:global_common_objs>)
-set_target_properties(ceph-common PROPERTIES
-  INSTALL_RPATH "")
-target_link_libraries(ceph-common json_spirit erasure_code rt ${LIB_RESOLV}
+set(ceph_common_deps
+  json_spirit erasure_code rt ${LIB_RESOLV}
   ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
   ${Boost_REGEX_LIBRARY}
@@ -564,19 +563,7 @@ target_link_libraries(ceph-common json_spirit erasure_code rt ${LIB_RESOLV}
   ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
   ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 if(NOT WITH_SYSTEM_BOOST)
-  target_link_libraries(ceph-common ${ZLIB_LIBRARIES})
-endif()
-# appease dpkg-shlibdeps
-set_target_properties(ceph-common PROPERTIES
-  SOVERSION 0)
-install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
-if(WITH_EMBEDDED)
-  add_library(cephd_common STATIC
-    $<TARGET_OBJECTS:common_buffer_obj>
-    $<TARGET_OBJECTS:common_texttable_obj>
-    $<TARGET_OBJECTS:compressor_objs>
-    $<TARGET_OBJECTS:common-objs>
-    $<TARGET_OBJECTS:common_mountcephfs_objs>)
+  list(APPEND ceph_common_deps ${ZLIB_LIBRARIES})
 endif()
 
 set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
@@ -587,8 +574,19 @@ set_source_files_properties(${CMAKE_SOURCE_DIR}/src/ceph_ver.c
 include(SIMDExt)
 if(HAVE_ARMV8_CRC)
   add_library(common_crc_aarch64 STATIC common/crc32c_aarch64.c)
-  target_link_libraries(ceph-common common_crc_aarch64)
+  list(APPEND ceph_common_deps common_crc_aarch64)
 endif(HAVE_ARMV8_CRC)
+
+add_library(common STATIC ${ceph_common_objs})
+target_link_libraries(common ${ceph_common_deps})
+
+add_library(ceph-common SHARED ${ceph_common_objs})
+target_link_libraries(ceph-common ${ceph_common_deps})
+# appease dpkg-shlibdeps
+set_target_properties(ceph-common PROPERTIES
+  SOVERSION 0
+  INSTALL_RPATH "")
+install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
 
 add_library(common_utf8 STATIC common/utf8.c)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -626,7 +626,7 @@ if (WITH_MGR)
   add_executable(ceph-mgr ${mgr_srcs}
                  $<TARGET_OBJECTS:heap_profiler_objs>)
   target_include_directories(ceph-mgr PRIVATE "${PYTHON_INCLUDE_DIRS}")
-  target_link_libraries(ceph-mgr mds osdc global
+  target_link_libraries(ceph-mgr mds osdc global-static common
       ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
   install(TARGETS ceph-mgr DESTINATION bin)
 endif (WITH_MGR)
@@ -716,7 +716,8 @@ set(ceph_mon_srcs
 add_executable(ceph-mon ${ceph_mon_srcs}
   $<TARGET_OBJECTS:common_texttable_obj>)
 add_dependencies(ceph-mon erasure_code_plugins)
-      target_link_libraries(ceph-mon mon ceph-common os global ${EXTRALIBS}
+target_link_libraries(ceph-mon mon common os global-static common
+  ${EXTRALIBS}
   ${CMAKE_DL_LIBS})
 install(TARGETS ceph-mon DESTINATION bin)
 
@@ -782,7 +783,8 @@ set(ceph_osd_srcs
 add_executable(ceph-osd ${ceph_osd_srcs}
   $<TARGET_OBJECTS:common_util_obj>)
 add_dependencies(ceph-osd erasure_code_plugins)
-target_link_libraries(ceph-osd osd os global ${BLKID_LIBRARIES} ${RDMA_LIBRARIES})
+target_link_libraries(ceph-osd osd os global-static common
+  ${BLKID_LIBRARIES} ${RDMA_LIBRARIES})
 if(WITH_FUSE)
   target_link_libraries(ceph-osd ${FUSE_LIBRARIES})
 endif()
@@ -793,7 +795,7 @@ set(ceph_mds_srcs
   ceph_mds.cc)
 add_executable(ceph-mds ${ceph_mds_srcs}
   $<TARGET_OBJECTS:common_util_obj>)
-target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global
+target_link_libraries(ceph-mds mds ${CMAKE_DL_LIBS} global-static common
   ${Boost_THREAD_LIBRARY})
 install(TARGETS ceph-mds DESTINATION bin)
 
@@ -897,7 +899,7 @@ if(WITH_LIBCEPHFS)
     ceph_syn.cc
     client/SyntheticClient.cc)
   add_executable(ceph-syn ${ceph_syn_srcs})
-  target_link_libraries(ceph-syn client global)
+  target_link_libraries(ceph-syn client global-static)
 
   set(mount_ceph_srcs
     mount/mount.ceph.c)
@@ -916,7 +918,8 @@ if(WITH_LIBCEPHFS)
       ceph_fuse.cc
       client/fuse_ll.cc)
     add_executable(ceph-fuse ${ceph_fuse_srcs})
-    target_link_libraries(ceph-fuse ${ALLOC_LIBS} ${FUSE_LIBRARIES} client global)
+    target_link_libraries(ceph-fuse ${ALLOC_LIBS} ${FUSE_LIBRARIES}
+      client global-static)
     set_target_properties(ceph-fuse PROPERTIES COMPILE_FLAGS "-I${FUSE_INCLUDE_DIRS}")
     install(TARGETS ceph-fuse DESTINATION bin)
     install(PROGRAMS mount.fuse.ceph DESTINATION ${CMAKE_INSTALL_SBINDIR})

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -5,6 +5,13 @@ set(libglobal_srcs
 set(global_common_files
   global_context.cc)
 add_library(global_common_objs OBJECT ${global_common_files})
-add_library(global STATIC ${libglobal_srcs}
+add_library(libglobal_objs OBJECT ${libglobal_srcs})
+
+add_library(global-static STATIC
+  $<TARGET_OBJECTS:libglobal_objs>
+  $<TARGET_OBJECTS:global_common_objs>)
+
+add_library(global STATIC
+  $<TARGET_OBJECTS:libglobal_objs>
   $<TARGET_OBJECTS:global_common_objs>)
 target_link_libraries(global ceph-common ${DPDK_LIBRARIES} ${EXTRALIBS})

--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -18,7 +18,6 @@
 #include "/usr/include/asm-generic/errno.h"
 #include "/usr/include/asm-generic/errno-base.h"
 #include "common/ceph_context.h"
-#include "global/global_context.h"
 #include "common/Clock.h"
 #include "include/types.h"
 

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -17,7 +17,7 @@ set(merge_libs
   cephd_rados
   cephd_rbd
   cephd_rgw
-  cephd_common
+  common
   common_utf8
   erasure_code
   global

--- a/src/mds/CMakeLists.txt
+++ b/src/mds/CMakeLists.txt
@@ -40,4 +40,4 @@ set(mds_srcs
 add_library(mds STATIC ${mds_srcs}
   $<TARGET_OBJECTS:heap_profiler_objs>
   $<TARGET_OBJECTS:common_util_obj>)
-target_link_libraries(mds ${ALLOC_LIBS} osdc ceph-common liblua)
+target_link_libraries(mds ${ALLOC_LIBS} osdc liblua)

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -98,7 +98,7 @@ target_link_libraries(test_build_libcommon ceph-common pthread ${CRYPTO_LIBS} ${
 
 if(WITH_RADOSGW)
   add_executable(test_build_librgw buildtest_skeleton.cc)
-  target_link_libraries(test_build_librgw rgw_a global pthread ${CRYPTO_LIBS} ${EXTRALIBS})
+  target_link_libraries(test_build_librgw rgw_a pthread ${CRYPTO_LIBS} ${EXTRALIBS})
 endif(WITH_RADOSGW)
 
 if(WITH_LIBCEPHFS)
@@ -459,7 +459,6 @@ set_target_properties(ceph_test_stress_watch PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_stress_watch
   librados
-  global
   ${UNITTEST_LIBS}
   radostest
   ${EXTRALIBS}
@@ -474,12 +473,6 @@ if(WITH_FUSE)
   add_executable(ceph_test_cfuse_cache_invalidate
     test_cfuse_cache_invalidate.cc
     )
-  target_link_libraries(ceph_test_cfuse_cache_invalidate
-    global
-    os
-    ${EXTRALIBS}
-    ${CMAKE_DL_LIBS}
-    )
 endif(WITH_FUSE)
 
 if(${WITH_CEPHFS})
@@ -488,11 +481,7 @@ if(${WITH_CEPHFS})
     )
   target_link_libraries(test_c_headers
     librados
-    cephfs
-    ${EXTRALIBS}
-    ${BLKID_LIBRARIES}
-    ${CMAKE_DL_LIBS}
-    )
+    cephfs)
 endif(${WITH_CEPHFS})
 
 if(HAVE_BLKID)


### PR DESCRIPTION
when packaging debian packages, dpkg-shlibdeps analyzes the linked
shared libraries of the binaries in given package by looking at their
names. but if the name does not include any useful versioning
information, it complains. we have no intention of versioning
libceph-common, as it is merely an internal shared library used by ceph
packages only. but there is no simple way to disable dpkg-shlibdeps'
warning of

  dpkg-shlibdeps: warning: can't extract name and version from library
  name 'libceph-common.so'

other than skipping the dpkg-shlibdeps for the whole package. so let's
just version it anyway.

Signed-off-by: Kefu Chai <kchai@redhat.com>