### PR TITLE
tests: fix NULL references to be acceptable by Clang

### DIFF
--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -93,7 +93,7 @@ public:
                                int r) {
     if (mock_image_ctx.object_cacher != nullptr) {
       EXPECT_CALL(mock_image_ctx, invalidate_cache(purge, _))
-                    .WillOnce(WithArg<1>(CompleteContext(r, NULL)));
+                    .WillOnce(WithArg<1>(CompleteContext(r, static_cast<ContextWQ*>(NULL)))); 
     }
   }
 

--- a/src/test/librbd/journal/test_mock_OpenRequest.cc
+++ b/src/test/librbd/journal/test_mock_OpenRequest.cc
@@ -54,7 +54,7 @@ public:
 
   void expect_init_journaler(::journal::MockJournaler &mock_journaler, int r) {
     EXPECT_CALL(mock_journaler, init(_))
-                  .WillOnce(CompleteContext(r, NULL));
+                  .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
   }
 
   void expect_get_journaler_cached_client(::journal::MockJournaler &mock_journaler,

--- a/src/test/librbd/journal/test_mock_PromoteRequest.cc
+++ b/src/test/librbd/journal/test_mock_PromoteRequest.cc
@@ -92,13 +92,13 @@ public:
 
     EXPECT_CALL(mock_journaler, allocate_tag(456, ContentsEqual(tag_data_bl),
                                              _, _))
-      .WillOnce(WithArg<3>(CompleteContext(r, NULL)));
+      .WillOnce(WithArg<3>(CompleteContext(r, static_cast<ContextWQ*>(NULL))));
   }
 
   void expect_shut_down_journaler(::journal::MockJournaler &mock_journaler,
                                   int r) {
     EXPECT_CALL(mock_journaler, shut_down(_))
-      .WillOnce(CompleteContext(r, NULL));
+      .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
   }
 
 };

--- a/src/test/librbd/operation/test_mock_ResizeRequest.cc
+++ b/src/test/librbd/operation/test_mock_ResizeRequest.cc
@@ -114,13 +114,14 @@ public:
   }
 
   void expect_flush_cache(MockImageCtx &mock_image_ctx, int r) {
-    EXPECT_CALL(mock_image_ctx, flush_cache(_)).WillOnce(CompleteContext(r, NULL));
+    EXPECT_CALL(mock_image_ctx, flush_cache(_))
+                  .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
     expect_op_work_queue(mock_image_ctx);
   }
 
   void expect_invalidate_cache(MockImageCtx &mock_image_ctx, int r) {
     EXPECT_CALL(mock_image_ctx, invalidate_cache(false, _))
-                  .WillOnce(WithArg<1>(CompleteContext(r, NULL)));
+                   .WillOnce(WithArg<1>(CompleteContext(r, static_cast<ContextWQ*>(NULL))));
     expect_op_work_queue(mock_image_ctx);
   }
 

--- a/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRollbackRequest.cc
@@ -166,7 +166,7 @@ public:
   void expect_invalidate_cache(MockOperationImageCtx &mock_image_ctx, int r) {
     if (mock_image_ctx.object_cacher != nullptr) {
       EXPECT_CALL(mock_image_ctx, invalidate_cache(true, _))
-                    .WillOnce(WithArg<1>(CompleteContext(r, NULL)));
+                    .WillOnce(WithArg<1>(CompleteContext(r, static_cast<ContextWQ*>(NULL))));
     }
   }
 

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -280,7 +280,7 @@ public:
   void expect_shut_down_journaler(::journal::MockJournaler &mock_journaler) {
     EXPECT_CALL(mock_journaler, remove_listener(_));
     EXPECT_CALL(mock_journaler, shut_down(_))
-                  .WillOnce(CompleteContext(0, NULL));
+                  .WillOnce(CompleteContext(0, static_cast<ContextWQ*>(NULL)));
   }
 
   void expect_get_max_append_size(::journal::MockJournaler &mock_journaler,
@@ -324,7 +324,7 @@ public:
 
   void expect_stop_replay(::journal::MockJournaler &mock_journaler) {
     EXPECT_CALL(mock_journaler, stop_replay(_))
-                  .WillOnce(CompleteContext(0, NULL));
+                  .WillOnce(CompleteContext(0, static_cast<ContextWQ*>(NULL)));
   }
 
   void expect_shut_down_replay(MockJournalImageCtx &mock_image_ctx,
@@ -360,7 +360,7 @@ public:
     EXPECT_CALL(mock_journal_replay, decode(_, _))
                   .WillOnce(Return(0));
     EXPECT_CALL(mock_journal_replay, process(_, _, _))
-                  .WillOnce(DoAll(WithArg<1>(CompleteContext(0, NULL)),
+                  .WillOnce(DoAll(WithArg<1>(CompleteContext(0, static_cast<ContextWQ*>(NULL))),
                                   WithArg<2>(Invoke(this, &TestMockJournal::save_commit_context))));
   }
 
@@ -370,7 +370,7 @@ public:
 
   void expect_stop_append(::journal::MockJournaler &mock_journaler, int r) {
     EXPECT_CALL(mock_journaler, stop_append(_))
-                  .WillOnce(CompleteContext(r, NULL));
+                  .WillOnce(CompleteContext(r, static_cast<ContextWQ*>(NULL)));
   }
 
   void expect_committed(::journal::MockJournaler &mock_journaler,
@@ -400,7 +400,7 @@ public:
 
   void expect_flush_commit_position(::journal::MockJournaler &mock_journaler) {
     EXPECT_CALL(mock_journaler, flush_commit_position(_))
-                  .WillOnce(CompleteContext(0, NULL));
+                  .WillOnce(CompleteContext(0, static_cast<ContextWQ*>(NULL)));
   }
 
   int when_open(MockJournal &mock_journal) {


### PR DESCRIPTION
 - On some platforms NULL evaluates to nullptr, which will require a
   cast to the right type to be able to compile.
      error: reinterpret_cast from 'nullptr_t' to 'ContextWQ *'

 - It is a delicate change since otherwise GCC will start complaining
   about the reverse:
      error: invalid static_cast from type 'const long int' to type 'ContextWQ*'

 By casting right at the instance of NULL both compilers are happy.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>