### PR TITLE
rbd: import real thin-provision image

### DIFF
--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -145,18 +145,24 @@ if ceph osd dump | grep ^pool | grep "'rbd'" | grep tier; then
 fi
 
 # create specifically sparse files
-# 1 1M block of sparse, 1 1M block of random
+# 1 1M block of sparse, 1 1M block of random, 1 1M block of zero, 1 1M block of random
 dd if=/dev/urandom bs=1M seek=1 count=1 of=${TMPDIR}/sparse1
+dd if=/dev/zero bs=1M seek=2 count=1 of=${TMPDIR}/sparse1
+dd if=/dev/urandom bs=1M seek=3 count=1 of=${TMPDIR}/sparse1
 
-# 1 1M block of random, 1 1M block of sparse
-dd if=/dev/urandom bs=1M count=1 of=${TMPDIR}/sparse2; truncate ${TMPDIR}/sparse2 -s 2M
+# 1 1M block of random, 1 1M block of sparse, 1 1M block of zero, 1 1M block of sparse
+dd if=/dev/urandom bs=1M count=1 of=${TMPDIR}/sparse2;
+dd if=/dev/zero bs=1M seek=2 count=1 of=${TMPDIR}/sparse2; truncate ${TMPDIR}/sparse2 -s 4M
 
 # 1M-block images; validate resulting blocks
 
-# 1M sparse, 1M data
-rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse1
-rbd ls -l | grep sparse1 | grep -i '2048k'
-[ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
+# 1M sparse, 1M data, 1M zero, 1M data, with 4K sparse-size
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 4K ${TMPDIR}/sparse1
+rbd ls -l | grep sparse1 | grep -i '4096k'
+rbd du sparse1 | grep '4096k 4096k'
+rbd diff sparse1 | grep '1048576 1048576 data'
+rbd diff sparse1 | grep '3145728 1048576 data'
+[ $tiered -eq 1 -o "$(objects sparse1)" = '1 3' ]
 
 # export, compare contents and on-disk size
 rbd export sparse1 ${TMPDIR}/sparse1.out
@@ -164,9 +170,36 @@ compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
 rm ${TMPDIR}/sparse1.out
 rbd rm sparse1
 
-# 1M data, 1M sparse
-rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -i '2048k'
+# 1M sparse, 1M data, 1M zero, 1M data, with 2M sparse-size
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 2M ${TMPDIR}/sparse1
+rbd ls -l | grep sparse1 | grep -i '4096k'
+rbd du sparse1 | grep '4096k 4096k'
+rbd diff sparse1 | grep '0       2097152 data'
+rbd diff sparse1 | grep '2097152 2097152 data'
+[ $tiered -eq 1 -o "$(objects sparse1)" = '1 3' ]
+
+# export, compare contents and on-disk size
+rbd export sparse1 ${TMPDIR}/sparse1.out
+compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
+rm ${TMPDIR}/sparse1.out
+rbd rm sparse1
+
+# 1M data, 1M sparse, 1M zero, 1M sparse, with 4K sparse-size
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 4K ${TMPDIR}/sparse2
+rbd ls -l | grep sparse2 | grep -i '4096k'
+rbd du sparse2 | grep '4096k 2048k'
+rbd diff sparse2 | grep '0       1048576 data'
+[ $tiered -eq 1 -o "$(objects sparse2)" = '0' ]
+rbd export sparse2 ${TMPDIR}/sparse2.out
+compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
+rm ${TMPDIR}/sparse2.out
+rbd rm sparse2
+
+# 1M data, 1M sparse, 1M zero, 1M sparse, with 2M sparse-size
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 2M ${TMPDIR}/sparse2
+rbd ls -l | grep sparse2 | grep -i '4096k'
+rbd du sparse2 | grep '4096k 2048k'
+rbd diff sparse2 | grep '0       2097152 data'
 [ $tiered -eq 1 -o "$(objects sparse2)" = '0' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
@@ -176,20 +209,48 @@ rbd rm sparse2
 # extend sparse1 to 10 1M blocks, sparse at the end
 truncate ${TMPDIR}/sparse1 -s 10M
 # import from stdin just for fun, verify still sparse
-rbd import $RBD_CREATE_ARGS --order 20 - sparse1 < ${TMPDIR}/sparse1
+rbd import $RBD_CREATE_ARGS --order 21 - sparse1 < ${TMPDIR}/sparse1
 rbd ls -l | grep sparse1 | grep -i '10240k'
-[ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
+rbd du sparse1 | grep '10240k 4096k'
+rbd diff sparse1 | grep '1048576 1048576 data'
+rbd diff sparse1 | grep '3145728 1048576 data'
+[ $tiered -eq 1 -o "$(objects sparse1)" = '1 3' ]
+rbd export sparse1 ${TMPDIR}/sparse1.out
+compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
+rm ${TMPDIR}/sparse1.out
+rbd rm sparse1
+# import from stdin just for fun, verify still sparse
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 2M - sparse1 < ${TMPDIR}/sparse1
+rbd ls -l | grep sparse1 | grep -i '10240k'
+rbd du sparse1 | grep '10240k 4096k'
+rbd diff sparse1 | grep '0       2097152 data'
+rbd diff sparse1 | grep '2097152 2097152 data'
+[ $tiered -eq 1 -o "$(objects sparse1)" = '1 3' ]
 rbd export sparse1 ${TMPDIR}/sparse1.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
 rm ${TMPDIR}/sparse1.out
 rbd rm sparse1
 
-# extend sparse2 to 4M total with two more nonsparse megs
+# extend sparse2 to 6M total with two more nonsparse megs
 dd if=/dev/urandom bs=2M count=1 of=${TMPDIR}/sparse2 oflag=append conv=notrunc
 # again from stding
-rbd import $RBD_CREATE_ARGS --order 20 - sparse2 < ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -i '4096k'
-[ $tiered -eq 1 -o "$(objects sparse2)" = '0 2 3' ]
+rbd import $RBD_CREATE_ARGS --order 21 - sparse2 < ${TMPDIR}/sparse2
+rbd ls -l | grep sparse2 | grep -i '6144k'
+rbd du sparse2 | grep '6144k 4096k'
+rbd diff sparse2 | grep '0       1048576 data'
+rbd diff sparse2 | grep '4194304 2097152 data'
+[ $tiered -eq 1 -o "$(objects sparse2)" = '0 4 5' ]
+rbd export sparse2 ${TMPDIR}/sparse2.out
+compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
+rm ${TMPDIR}/sparse2.out
+rbd rm sparse2
+# again from stding
+rbd import $RBD_CREATE_ARGS --order 21 --sparse-size 2M - sparse2 < ${TMPDIR}/sparse2
+rbd ls -l | grep sparse2 | grep -i '6144k'
+rbd du sparse2 | grep '6144k 4096k'
+rbd diff sparse2 | grep '0       2097152 data'
+rbd diff sparse2 | grep '4194304 2097152 data'
+[ $tiered -eq 1 -o "$(objects sparse2)" = '0 4 5' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
 rm ${TMPDIR}/sparse2.out
@@ -201,7 +262,7 @@ rbd rm sparse2
 
 echo "partially-sparse file imports to partially-sparse image"
 rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse1 sparse
-[ $tiered -eq 1 -o "$(objects sparse)" = '1' ]
+[ $tiered -eq 1 -o "$(objects sparse)" = '1 3' ]
 rbd rm sparse
 
 echo "zeros import through stdin to sparse image"
@@ -221,7 +282,7 @@ dd if=/dev/zero bs=4M count=1 | rados -p $(get_image_data_pool sparse) \
 # 1 object full of zeros; export should still create 0-disk-usage file
 rm ${TMPDIR}/sparse || true
 rbd export sparse ${TMPDIR}/sparse
-[ $(stat ${TMPDIR}/sparse --format=%b) = '0' ] 
+[ $(stat ${TMPDIR}/sparse --format=%b) = '0' ]
 rbd rm sparse
 
 rm ${TMPDIR}/sparse ${TMPDIR}/sparse1 ${TMPDIR}/sparse2 ${TMPDIR}/sparse3 || true

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -358,6 +358,9 @@ CEPH_RBD_API int rbd_copy(rbd_image_t image, rados_ioctx_t dest_io_ctx,
 CEPH_RBD_API int rbd_copy2(rbd_image_t src, rbd_image_t dest);
 CEPH_RBD_API int rbd_copy3(rbd_image_t src, rados_ioctx_t dest_io_ctx,
 			   const char *destname, rbd_image_options_t dest_opts);
+CEPH_RBD_API int rbd_copy4(rbd_image_t src, rados_ioctx_t dest_io_ctx,
+			   const char *destname, rbd_image_options_t dest_opts,
+			   size_t sparse_size);
 CEPH_RBD_API int rbd_copy_with_progress(rbd_image_t image, rados_ioctx_t dest_p,
                                         const char *destname,
                                         librbd_progress_fn_t cb, void *cbdata);
@@ -368,6 +371,12 @@ CEPH_RBD_API int rbd_copy_with_progress3(rbd_image_t image,
 					 const char *destname,
 					 rbd_image_options_t dest_opts,
 					 librbd_progress_fn_t cb, void *cbdata);
+CEPH_RBD_API int rbd_copy_with_progress4(rbd_image_t image,
+					 rados_ioctx_t dest_p,
+					 const char *destname,
+					 rbd_image_options_t dest_opts,
+					 librbd_progress_fn_t cb, void *cbdata,
+					 size_t sparse_size);
 
 /* snapshots */
 CEPH_RBD_API int rbd_snap_list(rbd_image_t image, rbd_snap_info_t *snaps,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -254,11 +254,16 @@ public:
   int copy(IoCtx& dest_io_ctx, const char *destname);
   int copy2(Image& dest);
   int copy3(IoCtx& dest_io_ctx, const char *destname, ImageOptions& opts);
+  int copy4(IoCtx& dest_io_ctx, const char *destname, ImageOptions& opts,
+	    size_t sparse_size);
   int copy_with_progress(IoCtx& dest_io_ctx, const char *destname,
 			 ProgressContext &prog_ctx);
   int copy_with_progress2(Image& dest, ProgressContext &prog_ctx);
   int copy_with_progress3(IoCtx& dest_io_ctx, const char *destname,
 			  ImageOptions& opts, ProgressContext &prog_ctx);
+  int copy_with_progress4(IoCtx& dest_io_ctx, const char *destname,
+			  ImageOptions& opts, ProgressContext &prog_ctx,
+			  size_t sparse_size);
 
   /* striping */
   uint64_t get_stripe_unit() const;

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -69,6 +69,35 @@ uint64_t get_rbd_default_features(CephContext* cct)
   return boost::lexical_cast<uint64_t>(str_val);
 }
 
+bool calc_sparse_extent(const bufferptr &bp,
+                        size_t sparse_size,
+                        uint64_t length,
+                        size_t *write_offset,
+                        size_t *write_length,
+                        size_t *offset) {
+  size_t extent_size;
+  if (*offset + sparse_size > length) {
+    extent_size = length - *offset;
+  } else {
+    extent_size = sparse_size;
+  }
+
+  bufferptr extent(bp, *offset, extent_size);
+  *offset += extent_size;
+
+  bool extent_is_zero = extent.is_zero();
+  if (!extent_is_zero) {
+    *write_length += extent_size;
+  }
+  if (extent_is_zero && *write_length == 0) {
+    *write_offset += extent_size;
+  }
+
+  if ((extent_is_zero || *offset == length) && *write_length != 0) {
+    return true;
+  }
+  return false;
+}
 } // namespace util
 
 } // namespace librbd

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -187,6 +187,12 @@ private:
 
 uint64_t get_rbd_default_features(CephContext* cct);
 
+bool calc_sparse_extent(const bufferptr &bp,
+                        size_t sparse_size,
+                        uint64_t length,
+                        size_t *write_offset,
+                        size_t *write_length,
+                        size_t *offset);
 } // namespace util
 
 } // namespace librbd

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -152,8 +152,8 @@ namespace librbd {
   int snap_is_protected(ImageCtx *ictx, const char *snap_name,
 			bool *is_protected);
   int copy(ImageCtx *ictx, IoCtx& dest_md_ctx, const char *destname,
-	   ImageOptions& opts, ProgressContext &prog_ctx);
-  int copy(ImageCtx *src, ImageCtx *dest, ProgressContext &prog_ctx);
+	   ImageOptions& opts, ProgressContext &prog_ctx, size_t sparse_size);
+  int copy(ImageCtx *src, ImageCtx *dest, ProgressContext &prog_ctx, size_t sparse_size);
 
   /* cooperative locking */
   int list_lockers(ImageCtx *ictx,

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -196,7 +196,8 @@
                   [--data-pool <data-pool>] 
                   [--journal-splay-width <journal-splay-width>] 
                   [--journal-object-size <journal-object-size>] 
-                  [--journal-pool <journal-pool>] [--no-progress] 
+                  [--journal-pool <journal-pool>] [--sparse-size <sparse-size>] 
+                  [--no-progress] 
                   <source-image-or-snap-spec> <dest-image-spec> 
   
   Copy src image to dest.
@@ -227,6 +228,7 @@
     --journal-splay-width arg    number of active journal objects
     --journal-object-size arg    size of journal objects
     --journal-pool arg           pool for journal objects
+    --sparse-size arg            sparse size in B/K/M [default: 4K]
     --no-progress                disable progress output
   
   Image Features:
@@ -588,7 +590,8 @@
                     [--stripe-count <stripe-count>] [--data-pool <data-pool>] 
                     [--journal-splay-width <journal-splay-width>] 
                     [--journal-object-size <journal-object-size>] 
-                    [--journal-pool <journal-pool>] [--no-progress] 
+                    [--journal-pool <journal-pool>] 
+                    [--sparse-size <sparse-size>] [--no-progress] 
                     [--export-format <export-format>] [--pool <pool>] 
                     [--image <image>] 
                     <path-name> <dest-image-spec> 
@@ -620,6 +623,7 @@
     --journal-splay-width arg number of active journal objects
     --journal-object-size arg size of journal objects
     --journal-pool arg        pool for journal objects
+    --sparse-size arg         sparse size in B/K/M [default: 4K]
     --no-progress             disable progress output
     --export-format arg       format of image file
     -p [ --pool ] arg         pool name (deprecated)
@@ -632,7 +636,7 @@
   
   rbd help import-diff
   usage: rbd import-diff [--path <path>] [--pool <pool>] [--image <image>] 
-                         [--no-progress] 
+                         [--sparse-size <sparse-size>] [--no-progress] 
                          <path-name> <image-spec> 
   
   Import an incremental diff.
@@ -646,6 +650,7 @@
     --path arg           import file (or '-' for stdin)
     -p [ --pool ] arg    pool name
     --image arg          image name
+    --sparse-size arg    sparse size in B/K/M [default: 4K]
     --no-progress        disable progress output
   
   rbd help info

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -293,6 +293,12 @@ void add_size_option(boost::program_options::options_description *opt) {
      "image size (in M/G/T)");
 }
 
+void add_sparse_size_option(boost::program_options::options_description *opt) {
+  opt->add_options()
+    (IMAGE_SPARSE_SIZE.c_str(), po::value<ImageObjectSize>(),
+    "sparse size in B/K/M [default: 4K]");
+}
+
 void add_path_options(boost::program_options::options_description *pos,
                       boost::program_options::options_description *opt,
                       const std::string &description) {

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -70,6 +70,7 @@ static const std::string IMAGE_SIZE("size");
 static const std::string IMAGE_STRIPE_UNIT("stripe-unit");
 static const std::string IMAGE_STRIPE_COUNT("stripe-count");
 static const std::string IMAGE_DATA_POOL("data-pool");
+static const std::string IMAGE_SPARSE_SIZE("sparse-size");
 
 static const std::string JOURNAL_OBJECT_SIZE("journal-object-size");
 static const std::string JOURNAL_SPLAY_WIDTH("journal-splay-width");
@@ -178,6 +179,8 @@ void add_create_journal_options(
   boost::program_options::options_description *opt);
 
 void add_size_option(boost::program_options::options_description *opt);
+
+void add_sparse_size_option(boost::program_options::options_description *opt);
 
 void add_path_options(boost::program_options::options_description *pos,
                       boost::program_options::options_description *opt,

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -33,6 +33,7 @@ void aio_completion_callback(librbd::completion_t completion,
 } // namespace detail
 
 static const std::string RBD_DIFF_BANNER ("rbd diff v1\n");
+static const size_t RBD_DEFAULT_SPARSE_SIZE = 4096;
 
 static const std::string RBD_IMAGE_BANNER_V2 ("rbd image v2\n");
 static const std::string RBD_IMAGE_DIFFS_BANNER_V2 ("rbd image diffss v2\n");
@@ -166,6 +167,13 @@ int init_and_open_image(const std::string &pool_name,
                         librbd::Image *image);
 
 int snap_set(librbd::Image &image, const std::string &snap_name);
+
+bool calc_sparse_extent(const bufferptr &bp,
+                        size_t sparse_size,
+                        uint64_t length,
+                        size_t *write_offset,
+                        size_t *write_length,
+                        size_t *offset);
 
 std::string image_id(librbd::Image& image);
 

--- a/src/tools/rbd/action/Copy.cc
+++ b/src/tools/rbd/action/Copy.cc
@@ -17,10 +17,11 @@ namespace po = boost::program_options;
 
 static int do_copy(librbd::Image &src, librados::IoCtx& dest_pp,
 		   const char *destname, librbd::ImageOptions& opts,
-		   bool no_progress)
+		   bool no_progress,
+		   size_t sparse_size)
 {
   utils::ProgressContext pc("Image copy", no_progress);
-  int r = src.copy_with_progress3(dest_pp, destname, opts, pc);
+  int r = src.copy_with_progress4(dest_pp, destname, opts, pc, sparse_size);
   if (r < 0){
     pc.fail();
     return r;
@@ -35,6 +36,7 @@ void get_arguments(po::options_description *positional,
                                      at::ARGUMENT_MODIFIER_SOURCE);
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST);
   at::add_create_image_options(options, false);
+  at::add_sparse_size_option(options);
   at::add_no_progress_option(options);
 }
 
@@ -82,8 +84,12 @@ int execute(const po::variables_map &vm) {
     return r;
   }
 
+  size_t sparse_size = utils::RBD_DEFAULT_SPARSE_SIZE;
+  if (vm.count(at::IMAGE_SPARSE_SIZE)) {
+    sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
+  }
   r = do_copy(image, dst_io_ctx, dst_image_name.c_str(), opts,
-              vm[at::NO_PROGRESS].as<bool>());
+              vm[at::NO_PROGRESS].as<bool>(), sparse_size);
   if (r < 0) {
     std::cerr << "rbd: copy failed: " << cpp_strerror(r) << std::endl;
     return r;

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -203,7 +203,7 @@ static int do_image_resize(ImportDiffContext *idiffctx)
   return 0;
 }
 
-static int do_image_io(ImportDiffContext *idiffctx, bool discard)
+static int do_image_io(ImportDiffContext *idiffctx, bool discard, size_t sparse_size)
 {
   int r;
   char buf[16];
@@ -227,11 +227,37 @@ static int do_image_io(ImportDiffContext *idiffctx, bool discard)
     if (r < 0) {
       return r;
     }
-    data.append(bp);
-  }
 
-  C_ImportDiff *ctx = new C_ImportDiff(idiffctx, data, off, len, discard);
-  return ctx->send();
+    // skip writing zeros
+    size_t write_offset = 0;
+    size_t write_length = 0;
+    size_t offset = 0;
+    while (offset < len) {
+      if (utils::calc_sparse_extent(bp,
+                                    sparse_size,
+                                    len,
+                                    &write_offset,
+                                    &write_length,
+                                    &offset)) {
+	bufferptr write_ptr(bp, write_offset, write_length);
+        bufferlist write_bl;
+        write_bl.push_back(write_ptr);
+	C_ImportDiff *ctx = new C_ImportDiff(idiffctx, data, off, len, discard);
+	r = ctx->send();
+
+	if (r < 0) {
+	  return r;
+	}
+        // Reset write offset and write length after current write submitted
+        write_offset = offset;
+        write_length = 0;
+      }
+    }
+  } else {
+    C_ImportDiff *ctx = new C_ImportDiff(idiffctx, data, off, len, discard);
+    return ctx->send();
+  }
+  return r;
 }
 
 static int validate_banner(int fd, std::string banner)
@@ -305,7 +331,7 @@ static int read_tag(int fd, __u8 end_tag, int format, __u8 *tag, uint64_t *readl
   return 0;
 }
 
-int do_import_diff_fd(librbd::Image &image, int fd, bool no_progress, int format)
+int do_import_diff_fd(librbd::Image &image, int fd, bool no_progress, int format, size_t sparse_size)
 {
   int r;
 
@@ -345,7 +371,7 @@ int do_import_diff_fd(librbd::Image &image, int fd, bool no_progress, int format
     } else if (tag == RBD_DIFF_IMAGE_SIZE) {
       r = do_image_resize(&idiffctx);
     } else if (tag == RBD_DIFF_WRITE || tag == RBD_DIFF_ZERO) {
-      r = do_image_io(&idiffctx, (tag == RBD_DIFF_ZERO));
+      r = do_image_io(&idiffctx, (tag == RBD_DIFF_ZERO), sparse_size);
     } else {
       std::cerr << "unrecognized tag byte " << (int)tag << " in stream; skipping"
                 << std::endl;
@@ -364,7 +390,7 @@ int do_import_diff_fd(librbd::Image &image, int fd, bool no_progress, int format
 }
 
 int do_import_diff(librbd::Image &image, const char *path,
-                bool no_progress)
+                bool no_progress, size_t sparse_size)
 {
   int r;
   int fd;
@@ -379,7 +405,7 @@ int do_import_diff(librbd::Image &image, const char *path,
       return r;
     }
   }
-  r = do_import_diff_fd(image, fd, no_progress, 1);
+  r = do_import_diff_fd(image, fd, no_progress, 1, sparse_size);
 
   if (fd != 0)
     close(fd);
@@ -394,6 +420,7 @@ void get_arguments_diff(po::options_description *positional,
   at::add_path_options(positional, options,
                        "import file (or '-' for stdin)");
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_sparse_size_option(options);
   at::add_no_progress_option(options);
 }
 
@@ -415,6 +442,11 @@ int execute_diff(const po::variables_map &vm) {
     return r;
   }
 
+  size_t sparse_size = utils::RBD_DEFAULT_SPARSE_SIZE;
+  if (vm.count(at::IMAGE_SPARSE_SIZE)) {
+    sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
+  }
+
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
@@ -424,7 +456,7 @@ int execute_diff(const po::variables_map &vm) {
     return r;
   }
 
-  r = do_import_diff(image, path.c_str(), vm[at::NO_PROGRESS].as<bool>());
+  r = do_import_diff(image, path.c_str(), vm[at::NO_PROGRESS].as<bool>(), sparse_size);
   if (r < 0) {
     cerr << "rbd: import-diff failed: " << cpp_strerror(r) << std::endl;
     return r;
@@ -555,7 +587,8 @@ static int do_import_header(int fd, int import_format, uint64_t &size, librbd::I
 }
 
 static int do_import_v2(int fd, librbd::Image &image, uint64_t size,
-                        size_t imgblklen, utils::ProgressContext &pc)
+                        size_t imgblklen, utils::ProgressContext &pc,
+			size_t sparse_size)
 {
   int r = 0;
   r = validate_banner(fd, utils::RBD_IMAGE_DIFFS_BANNER_V2);
@@ -575,7 +608,7 @@ static int do_import_v2(int fd, librbd::Image &image, uint64_t size,
   ::decode(diff_num, p);
 
   for (size_t i = 0; i < diff_num; i++) {
-    r = do_import_diff_fd(image, fd, true, 2);
+    r = do_import_diff_fd(image, fd, true, 2, sparse_size);
     if (r < 0) {
       pc.fail();
       std::cerr << "rbd: import-diff failed: " << cpp_strerror(r) << std::endl;
@@ -588,7 +621,8 @@ static int do_import_v2(int fd, librbd::Image &image, uint64_t size,
 }
 
 static int do_import_v1(int fd, librbd::Image &image, uint64_t size,
-                        size_t imgblklen, utils::ProgressContext &pc)
+                        size_t imgblklen, utils::ProgressContext &pc
+			size_t sparse_size)
 {
   int r = 0;
   size_t reqlen = imgblklen;    // amount requested from read
@@ -622,8 +656,7 @@ static int do_import_v1(int fd, librbd::Image &image, uint64_t size,
     if (!from_stdin)
       pc.update_progress(image_pos, size);
 
-    bufferlist bl(blklen);
-    bl.append(p, blklen);
+    bufferptr blkptr(p, blklen); 
     // resize output image by binary expansion as we go for stdin
     if (from_stdin && (image_pos + (size_t)blklen) > size) {
       size *= 2;
@@ -636,9 +669,26 @@ static int do_import_v1(int fd, librbd::Image &image, uint64_t size,
 
     // write as much as we got; perhaps less than imgblklen
     // but skip writing zeros to create sparse images
-    if (!bl.is_zero()) {
-      C_Import *ctx = new C_Import(*throttle, image, bl, image_pos);
-      ctx->send();
+    size_t write_offset = 0;
+    size_t write_length = 0;
+    size_t offset = 0;
+    while (offset < blklen) {
+      if (utils::calc_sparse_extent(blkptr,
+                                    sparse_size,
+                                    blklen,
+                                    &write_offset,
+                                    &write_length,
+                                    &offset)) {
+        bufferptr write_ptr(blkptr, write_offset, write_length);
+        bufferlist write_bl;
+        write_bl.push_back(write_ptr);
+        C_Import *ctx = new C_Import(*throttle, image, write_bl, image_pos + write_offset);
+        ctx->send();
+
+        // Reset write offset and write length after current write submitted
+        write_offset = offset;
+        write_length = 0;
+      }
     }
 
     // done with whole block, whether written or not
@@ -671,7 +721,7 @@ out:
 static int do_import(librbd::RBD &rbd, librados::IoCtx& io_ctx,
                      const char *imgname, const char *path,
 		     librbd::ImageOptions& opts, bool no_progress,
-		     int import_format)
+		     int import_format, size_t sparse_size)
 {
   int fd, r;
   struct stat stat_buf;
@@ -748,9 +798,9 @@ static int do_import(librbd::RBD &rbd, librados::IoCtx& io_ctx,
   }
 
   if (import_format == 1) {
-    r = do_import_v1(fd, image, size, imgblklen, pc);
+    r = do_import_v1(fd, image, size, imgblklen, pc, sparse_size);
   } else {
-    r = do_import_v2(fd, image, size, imgblklen, pc);
+    r = do_import_v2(fd, image, size, imgblklen, pc, sparse_size);
   }
 
   r = image.close();
@@ -774,6 +824,7 @@ void get_arguments(po::options_description *positional,
                        "import file (or '-' for stdin)");
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST);
   at::add_create_image_options(options, true);
+  at::add_sparse_size_option(options);
   at::add_no_progress_option(options);
   at::add_export_format_option(options);
 
@@ -807,6 +858,11 @@ int execute(const po::variables_map &vm) {
               << std::endl;
   } else {
     deprecated_image_name = path.substr(path.find_last_of("/") + 1);
+  }
+
+  size_t sparse_size = utils::RBD_DEFAULT_SPARSE_SIZE;
+  if (vm.count(at::IMAGE_SPARSE_SIZE)) {
+    sparse_size = vm[at::IMAGE_SPARSE_SIZE].as<size_t>();
   }
 
   size_t arg_index = 1;
@@ -844,7 +900,7 @@ int execute(const po::variables_map &vm) {
 
   librbd::RBD rbd;
   r = do_import(rbd, io_ctx, image_name.c_str(), path.c_str(),
-                opts, vm[at::NO_PROGRESS].as<bool>(), format);
+                opts, vm[at::NO_PROGRESS].as<bool>(), format, sparse_size);
   if (r < 0) {
     std::cerr << "rbd: import failed: " << cpp_strerror(r) << std::endl;
     return r;

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -621,7 +621,7 @@ static int do_import_v2(int fd, librbd::Image &image, uint64_t size,
 }
 
 static int do_import_v1(int fd, librbd::Image &image, uint64_t size,
-                        size_t imgblklen, utils::ProgressContext &pc
+                        size_t imgblklen, utils::ProgressContext &pc,
 			size_t sparse_size)
 {
   int r = 0;

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -820,6 +820,38 @@ TRACEPOINT_EVENT(librbd, copy3_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, copy4_enter,
+    TP_ARGS(
+        void*, src_imagectx,
+        const char*, src_name,
+        const char*, src_snap_name,
+        char, src_read_only,
+        const char*, dst_pool_name,
+        uint64_t, dst_id,
+        const char*, dst_name,
+        void*, opts,
+        size_t, sparse_size),
+    TP_FIELDS(
+        ctf_integer_hex(void*, src_imagectx, src_imagectx)
+        ctf_string(src_name, src_name)
+        ctf_string(src_snap_name, src_snap_name)
+        ctf_integer(char, src_read_only, src_read_only)
+        ctf_string(dst_pool_name, dst_pool_name)
+        ctf_integer(uint64_t, dst_id, dst_id)
+        ctf_string(dst_name, dst_name)
+        ctf_integer_hex(void*, opts, opts)
+        ctf_integer(size_t, sparse_size, sparse_size)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, copy4_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, resize_enter,
     TP_ARGS(
         void*, imagectx,


### PR DESCRIPTION
currently, import check whether object is zero based on the image order (object size)
therefore, holes inside object will be filled with zero and hence waste spaces for the cluster.