### PR TITLE
osd/PrimaryLogPG::failed_push: update missing as well

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -424,6 +424,12 @@ public:
       ThreadPool::TPHandle* handle  ///< [in] ThreadPool handle
       );
 
+    /// Returns version needed
+    eversion_t get_version_needed(const hobject_t &hoid) const {
+      assert(needs_recovery_map.count(hoid));
+      return needs_recovery_map.at(hoid).need;
+    }
+
     /// Uses osdmap to update structures for now down sources
     void check_recovery_sources(const OSDMapRef& osdmap);
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9775,8 +9775,12 @@ void PrimaryLogPG::failed_push(const list<pg_shard_t> &from, const hobject_t &so
     requeue_ops(blocked_ops);
   }
   recovering.erase(soid);
-  for (auto&& i : from)
+  for (auto&& i : from) {
     missing_loc.remove_location(soid, i);
+    auto miter = peer_missing.find(i);
+    assert(miter != peer_missing.end());
+    miter->second.add(soid, missing_loc.get_version_needed(soid), eversion_t());
+  }
   dout(0) << __func__ << " " << soid << " from shard " << from
 	  << ", reps on " << missing_loc.get_locations(soid)
 	  << " unfound? " << missing_loc.is_unfound(soid) << dendl;


### PR DESCRIPTION
This way, pick_newest_available should do the right thing.

Fixes: http://tracker.ceph.com/issues/18165
Signed-off-by: Samuel Just <sjust@redhat.com>