### PR TITLE
radosgw: Remove the newline from swift errors.

### DIFF
--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -28,6 +28,7 @@ RGWFormatter_Plain::RGWFormatter_Plain(const bool ukv)
   : buf(NULL),
     len(0),
     max_len(0),
+    wrote_something(false),
     min_stack_level(0),
     use_kv(ukv)
 {
@@ -44,7 +45,7 @@ void RGWFormatter_Plain::flush(ostream& os)
     return;
 
   if (len) {
-    os << buf << "\n";
+    os << buf;
     os.flush();
   }
 
@@ -159,13 +160,14 @@ void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool q
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
 
   const char *eol;
-  if (len) {
+  if (wrote_something) {
     if (use_kv && entry.is_array && entry.size > 1)
       eol = ", ";
     else
       eol = "\n";
   } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);
@@ -271,10 +273,11 @@ void RGWFormatter_Plain::dump_value_int(const char *name, const char *fmt, ...)
   va_end(ap);
 
   const char *eol;
-  if (len)
+  if (wrote_something) {
     eol = "\n";
-  else
+  } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -57,6 +57,7 @@ private:
   std::list<struct plain_stack_entry> stack;
   size_t min_stack_level;
   bool use_kv;
+  bool wrote_something;
 };
 
 


### PR DESCRIPTION
The current code emits a newline after swift errors, but fails
to account for it when it calculates 'content-length'.  This results in
some clients (go github.com/ncw/swift) producing complaints about the
unsolicited newline such as this,
	Unsolicited response received on idle HTTP channel starting with "\n"; err=<nil>

This patch removes the newline, but only after get_len() was called,
which happens at the end of the request while calculating content-length.
There are other parts of the swift wire protocol that depend on the
newline being emitted, but all that happens before get_len() is called.

Fixes: http://tracker.ceph.com/issues/18473
Signed-off-by: Marcus Watts <mwatts@redhat.com>