### PR TITLE
[DNM] radosgw: Remove the newline from swift errors.

### DIFF
--- a/qa/config/rados.yaml
+++ b/qa/config/rados.yaml
@@ -4,3 +4,4 @@ overrides:
       osd:
         osd op queue: debug_random
         osd op queue cut off: debug_random
+        osd debug verify cached snaps: true

--- a/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
+++ b/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
@@ -1,12 +1,3 @@
-overrides:
-  ceph-deploy:
-    conf:
-      global:
-        debug ms: 1
-      osd:
-        debug osd: 10
-      mon:
-        debug mon: 10
 roles:
 - - mon.a
   - mds.0

--- a/qa/suites/rados/thrash/thrashers/mapgap.yaml
+++ b/qa/suites/rados/thrash/thrashers/mapgap.yaml
@@ -16,6 +16,6 @@ tasks:
     - osd_map_cache_size
 - thrashosds:
     timeout: 1800
-    chance_pgnum_grow: 1
-    chance_pgpnum_fix: 1
-    chance_test_map_discontinuity: 0.5
+    chance_pgnum_grow: 0.25
+    chance_pgpnum_fix: 0.25
+    chance_test_map_discontinuity: 2

--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,5 +4,5 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-jewel
       rgw_server: client.0

--- a/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -8,5 +8,5 @@ tasks:
       valgrind: [--tool=memcheck]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-jewel
       rgw_server: client.0

--- a/qa/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_s3tests_multiregion.yaml
@@ -58,6 +58,6 @@ tasks:
       metadata-only: true
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-jewel
       idle_timeout: 300
       rgw_server: client.0

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -373,9 +373,7 @@ def build_ceph_cluster(ctx, config):
 
             if mds_nodes:
                 log.info('Configuring CephFS...')
-                ceph_fs = Filesystem(ctx)
-                if not ceph_fs.legacy_configured():
-                    ceph_fs.create()
+                ceph_fs = Filesystem(ctx, create=True)
         elif not config.get('only_mon'):
             raise RuntimeError(
                 "The cluster is NOT operational due to insufficient OSDs")

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -262,17 +262,14 @@ def build_ceph_cluster(ctx, config):
         # try the next block which will wait up to 15 minutes to gatherkeys.
         execute_ceph_deploy(mon_create_nodes)
 
-        estatus_gather = execute_ceph_deploy(gather_keys)
-        max_gather_tries = 90
-        gather_tries = 0
-        while (estatus_gather != 0):
-            gather_tries += 1
-            if gather_tries >= max_gather_tries:
-                msg = 'ceph-deploy was not able to gatherkeys after 15 minutes'
-                raise RuntimeError(msg)
-            estatus_gather = execute_ceph_deploy(gather_keys)
-            time.sleep(10)
+        # create-keys is explicit now
+        # http://tracker.ceph.com/issues/16036
+        mons = ctx.cluster.only(teuthology.is_type('mon'))
+        for remote in mons.remotes.iterkeys():
+            remote.run(args=['sudo', 'ceph-create-keys', '--cluster', 'ceph',
+                             '--id', remote.shortname])
 
+        estatus_gather = execute_ceph_deploy(gather_keys)
         if mds_nodes:
             estatus_mds = execute_ceph_deploy(deploy_mds)
             if estatus_mds != 0:

--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -15,7 +15,7 @@ from teuthology.orchestra import run
 log = logging.getLogger(__name__)
 
 DEFAULT_NUM_RBD = 1
-DEFAULT_IMAGE_URL = 'http://ceph.com/qa/ubuntu-12.04.qcow2'
+DEFAULT_IMAGE_URL = 'http://download.ceph.com/qa/ubuntu-12.04.qcow2'
 DEFAULT_MEM = 4096 # in megabytes
 
 def create_images(ctx, config, managers):

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -313,11 +313,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,
@@ -334,11 +338,15 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
+                'rm',
+                '-rf',
+                clonedir,
+                run.Raw('&&'),
                 'git',
                 'clone',
                 alt_git_url,
                 clonedir,
-                run.Raw(';'),
+                run.Raw('&&'),
                 'cd', '--', clonedir,
                 run.Raw('&&'),
                 'git', 'checkout', refspec,

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -359,7 +359,8 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
                     run.Raw('TESTDIR="{tdir}"'.format(tdir=testdir)),
                     run.Raw('CEPH_ARGS="--cluster {0}"'.format(cluster)),
                     run.Raw('CEPH_ID="{id}"'.format(id=id_)),
-                    run.Raw('PATH=$PATH:/usr/sbin')
+                    run.Raw('PATH=$PATH:/usr/sbin'),
+                    run.Raw('CEPH_BASE={dir}'.format(dir=clonedir)),
                 ]
                 if env is not None:
                     for var, val in env.iteritems():

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -305,8 +305,8 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         scratch_tmp = os.path.join(mnt, 'client.{id}'.format(id=id_), 'tmp')
     else:
         scratch_tmp = os.path.join(mnt, subdir)
-    srcdir = '{tdir}/workunit.{role}'.format(tdir=testdir, role=role)
     clonedir = '{tdir}/clone.{role}'.format(tdir=testdir, role=role)
+    srcdir = '{cdir}/qa/workunits'.format(cdir=clonedir)
 
     git_url = teuth_config.get_ceph_git_url()
     remote.run(
@@ -320,8 +320,6 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
             'cd', '--', clonedir,
             run.Raw('&&'),
             'git', 'checkout', refspec,
-            run.Raw('&&'),
-            'mv', 'qa/workunits', srcdir,
         ],
     )
 
@@ -394,6 +392,6 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(
             logger=log.getChild(role),
             args=[
-                'rm', '-rf', '--', workunits_file, srcdir, clonedir,
+                'rm', '-rf', '--', workunits_file, clonedir,
             ],
         )

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2897,10 +2897,19 @@ def start_daemon(
                 ],
             )
         elif os.path.exists(os.path.join(path, 'systemd')):
+            # ensure there is no duplicate ceph-osd@.service
+            command_check_call(
+                [
+                    'systemctl',
+                    'disable',
+                    'ceph-osd@{osd_id}'.format(osd_id=osd_id),
+                ],
+            )
             command_check_call(
                 [
                     'systemctl',
                     'enable',
+                    '--runtime',
                     'ceph-osd@{osd_id}'.format(osd_id=osd_id),
                 ],
             )
@@ -2958,6 +2967,7 @@ def stop_daemon(
                 [
                     'systemctl',
                     'disable',
+                    '--runtime',
                     'ceph-osd@{osd_id}'.format(osd_id=osd_id),
                 ],
             )

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4317,6 +4317,8 @@ def main_trigger(args):
         )
         return
 
+    if get_ceph_user() == 'ceph':
+        command_check_call(['chown', 'ceph:ceph', args.dev])
     parttype = get_partition_type(args.dev)
     partid = get_partition_uuid(args.dev)
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -801,6 +801,7 @@ OPTION(osd_debug_skip_full_check_in_backfill_reservation, OPT_BOOL, false)
 OPTION(osd_debug_reject_backfill_probability, OPT_DOUBLE, 0)
 OPTION(osd_debug_inject_copyfrom_error, OPT_BOOL, false)  // inject failure during copyfrom completion
 OPTION(osd_debug_randomize_hobject_sort_order, OPT_BOOL, false)
+OPTION(osd_debug_verify_cached_snaps, OPT_BOOL, false)
 OPTION(osd_enable_op_tracker, OPT_BOOL, true) // enable/disable OSD op tracking
 OPTION(osd_num_op_tracker_shard, OPT_U32, 32) // The number of shards for holding the ops
 OPTION(osd_op_history_size, OPT_U32, 20)    // Max number of completed ops to track

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -28,7 +28,6 @@
 
 #define CEPH_INO_ROOT   1
 #define CEPH_INO_CEPH   2       /* hidden .ceph dir */
-#define CEPH_INO_DOTDOT 3	/* used by ceph fuse for parent (..) */
 #define CEPH_INO_LOST_AND_FOUND 4	/* reserved ino for use in recovery */
 
 /* arbitrary limit on max # of monitors (cluster of 3 is typical) */

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -158,7 +158,7 @@ void PGPool::update(OSDMapRef map)
   auid = pi->auid;
   name = map->get_pool_name(id);
   bool updated = false;
-  if ((map->get_epoch() == cached_epoch + 1) &&
+  if ((map->get_epoch() != cached_epoch + 1) ||
       (pi->get_snap_epoch() == map->get_epoch())) {
     updated = true;
     pi->build_removed_snaps(newly_removed_snaps);
@@ -176,6 +176,16 @@ void PGPool::update(OSDMapRef map)
     }
     snapc = pi->get_snap_context();
   } else {
+    /* 1) map->get_epoch() == cached_epoch + 1 &&
+     * 2) pi->get_snap_epoch() != map->get_epoch()
+     *
+     * From the if branch, 1 && 2 must be true.  From 2, we know that
+     * this map didn't change the set of removed snaps.  From 1, we
+     * know that our cached_removed_snaps matches the previous map.
+     * Thus, from 1 && 2, cached_removed snaps matches the current
+     * set of removed snaps and all we have to do is clear
+     * newly_removed_snaps.
+     */
     newly_removed_snaps.clear();
   }
   cached_epoch = map->get_epoch();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5586,6 +5586,19 @@ void PG::handle_advance_map(
 	   << dendl;
   update_osdmap_ref(osdmap);
   pool.update(osdmap);
+  if (cct->_conf->osd_debug_verify_cached_snaps) {
+    interval_set<snapid_t> actual_removed_snaps;
+    const pg_pool_t *pi = osdmap->get_pg_pool(info.pgid.pool());
+    assert(pi);
+    pi->build_removed_snaps(actual_removed_snaps);
+    if (!(actual_removed_snaps == pool.cached_removed_snaps)) {
+      derr << __func__ << ": mismatch between the actual removed snaps "
+	   << actual_removed_snaps << " and pool.cached_removed_snaps "
+	   << " pool.cached_removed_snaps " << pool.cached_removed_snaps
+	   << dendl;
+    }
+    assert(actual_removed_snaps == pool.cached_removed_snaps);
+  }
   AdvMap evt(
     osdmap, lastmap, newup, up_primary,
     newacting, acting_primary);

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -25,6 +25,7 @@ RGWFormatter_Plain::RGWFormatter_Plain(const bool ukv)
   : buf(NULL),
     len(0),
     max_len(0),
+    wrote_something(false),
     min_stack_level(0),
     use_kv(ukv)
 {
@@ -41,7 +42,7 @@ void RGWFormatter_Plain::flush(ostream& os)
     return;
 
   if (len) {
-    os << buf << "\n";
+    os << buf;
     os.flush();
   }
 
@@ -156,13 +157,14 @@ void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool q
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
 
   const char *eol;
-  if (len) {
+  if (wrote_something) {
     if (use_kv && entry.is_array && entry.size > 1)
       eol = ", ";
     else
       eol = "\n";
   } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);
@@ -268,10 +270,11 @@ void RGWFormatter_Plain::dump_value_int(const char *name, const char *fmt, ...)
   va_end(ap);
 
   const char *eol;
-  if (len)
+  if (wrote_something) {
     eol = "\n";
-  else
+  } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -56,6 +56,7 @@ private:
   std::list<struct plain_stack_entry> stack;
   size_t min_stack_level;
   bool use_kv;
+  bool wrote_something;
 };
 
 class RGWFormatterFlusher {

--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -1,5 +1,7 @@
 [Unit]
 Description=Ceph disk activation: %f
+After=local-fs.target
+Wants=local-fs.target
 
 [Service]
 Type=oneshot

--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -4,5 +4,5 @@ Description=Ceph disk activation: %f
 [Service]
 Type=oneshot
 KillMode=none
-ExecStart=/bin/sh -c 'timeout 120 flock /var/lock/ceph-disk /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
+ExecStart=/bin/sh -c 'timeout 120 flock /var/lock/ceph-disk-$(basename %f) /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
 TimeoutSec=0

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -18,7 +18,8 @@ PrivateTmp=true
 TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
-StartLimitBurst=3
+StartLimitBurst=30
+RestartSec=20s
 
 [Install]
 WantedBy=ceph-osd.target


### PR DESCRIPTION
The current code emits a newline after swift errors, but fails
to account for it when it calculates 'content-length'.  This results in
some clients (go github.com/ncw/swift) producing complaints about the
unsolicited newline such as this,
	Unsolicited response received on idle HTTP channel starting with "\n"; err=<nil>

This patch removes the newline, but only after get_len() was called,
which happens at the end of the request while calculating content-length.
There are other parts of the swift wire protocol that depend on the
newline being emitted, but all that happens before get_len() is called.

Fixes: http://tracker.ceph.com/issues/18473
Signed-off-by: Marcus Watts <mwatts@redhat.com>