### PR TITLE
os/bluestore: nullptr in OmapIteratorImpl::valid

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5774,7 +5774,7 @@ int BlueStore::OmapIteratorImpl::lower_bound(const string& to)
 bool BlueStore::OmapIteratorImpl::valid()
 {
   RWLock::RLocker l(c->lock);
-  return o->onode.has_omap() && it->valid() && it->raw_key().second <= tail;
+  return o->onode.has_omap() && it && it->valid() && it->raw_key().second <= tail;
 }
 
 int BlueStore::OmapIteratorImpl::next(bool validate)


### PR DESCRIPTION
call stack:
SnapMapper::get_next_object_to_trim -> MapCacher::get_next ->
OSDriver::get_next-> BlueStore::OmapIteratorImpl::valid()

In OSDriver::get_next, it call iter->upper_bound(key); // this may reset it to nullptr

Signed-off-by: Xinze Chi <xinze@xsky.com>