### PR TITLE
rgw_file: fix bug of kill nfs-ganesha with fsal rgw

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -461,7 +461,7 @@ namespace rgw {
 
     cct = global_init(&def_args, args,
 		      CEPH_ENTITY_TYPE_CLIENT,
-		      CODE_ENVIRONMENT_DAEMON,
+		      CODE_ENVIRONMENT_LIBRARY,
 		      CINIT_FLAG_UNPRIVILEGED_DAEMON_DEFAULTS);
 
     Mutex mutex("main");
@@ -542,6 +542,7 @@ namespace rgw {
     }
 
     fe->run();
+    fe->detach();
 
     return 0;
   } /* RGWLib::init() */
@@ -551,8 +552,6 @@ namespace rgw {
     derr << "shutting down" << dendl;
 
     fe->stop();
-
-    fe->join();
 
     delete fe;
     delete fec;

--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -160,6 +160,10 @@ public:
     return 0;
   }
 
+  void detach() {
+    thread->detach();
+  }
+
   void stop();
 
   void join() {


### PR DESCRIPTION
RGWLib change CODE_ENVIRONMENT_DAEMON to CODE_ENVIRONMENT_LIBRARY

fix bug of kill nfs-ganesha failed
http://tracker.ceph.com/issues/18505

Signed-off-by: Min Chen <chenmin@xsky.com>