### PR TITLE
common/xmlformatter: turn on underscored and add unittest

### DIFF
--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -136,7 +136,7 @@ namespace ceph {
   class XMLFormatter : public Formatter {
   public:
     static const char *XML_1_DTD;
-    XMLFormatter(bool pretty = false, bool lowercased_underscored = false);
+    XMLFormatter(bool pretty = false, bool lowercased = false, bool underscored = true);
 
     virtual void set_status(int status, const char* status_name) {}
     virtual void output_header();
@@ -163,17 +163,20 @@ namespace ceph {
     void open_array_section_with_attrs(const char *name, const FormatterAttrs& attrs);
     void open_object_section_with_attrs(const char *name, const FormatterAttrs& attrs);
     void dump_string_with_attrs(const char *name, const std::string& s, const FormatterAttrs& attrs);
+
   protected:
     void open_section_in_ns(const char *name, const char *ns, const FormatterAttrs *attrs);
     void finish_pending_string();
     void print_spaces();
     static std::string escape_xml_str(const char *str);
     void get_attrs_str(const FormatterAttrs *attrs, std::string& attrs_str);
+    char to_lower_underscore(char c) const;
 
     std::stringstream m_ss, m_pending_string;
     std::deque<std::string> m_sections;
-    bool m_pretty;
-    bool m_lowercased_underscored;
+    const bool m_pretty;
+    const bool m_lowercased;
+    const bool m_underscored;
     std::string m_pending_string_name;
     bool m_header_done;
   };

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -152,6 +152,12 @@ add_executable(unittest_tableformatter
 add_ceph_unittest(unittest_tableformatter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_tableformatter)
 target_link_libraries(unittest_tableformatter global)
 
+add_executable(unittest_xmlformatter
+    test_xmlformatter.cc
+    )
+add_ceph_unittest(unittest_xmlformatter ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_xmlformatter)
+target_link_libraries(unittest_xmlformatter ceph-common)
+
 # unittest_bit_vector
 add_executable(unittest_bit_vector
   test_bit_vector.cc

--- a/src/test/common/test_xmlformatter.cc
+++ b/src/test/common/test_xmlformatter.cc
@@ -1,0 +1,165 @@
+#include "gtest/gtest.h"
+
+#include "common/Formatter.h"
+#include <sstream>
+#include <string>
+
+using namespace ceph;
+
+
+TEST(xmlformatter, oneline)
+{
+
+  std::stringstream sout;
+  XMLFormatter formatter;
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
+  formatter.flush(sout);
+  std::string cmp = "<integer>10</integer><float>10</float><string>string</string>";
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, multiline)
+{
+  std::stringstream sout;
+  XMLFormatter formatter;
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
+
+  std::string cmp = ""
+    "<integer>10</integer><float>10</float><string>string</string>"
+    "<integer>20</integer><float>20</float><string>string</string>";
+
+  formatter.flush(sout);
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, multiflush)
+{
+  std::stringstream sout1;
+  std::stringstream sout2;
+  XMLFormatter formatter;
+  formatter.dump_int("integer", 10);
+  formatter.dump_float("float", 10.0);
+  formatter.dump_string("string", "string");
+  formatter.flush(sout1);
+
+  std::string cmp = ""
+    "<integer>10</integer>"
+    "<float>10</float>"
+    "<string>string</string>";
+
+  EXPECT_EQ(cmp, sout1.str());
+
+  formatter.dump_int("integer", 20);
+  formatter.dump_float("float", 20.0);
+  formatter.dump_string("string", "string");
+  formatter.flush(sout2);
+
+  cmp = ""
+    "<integer>20</integer>"
+    "<float>20</float>"
+    "<string>string</string>";
+
+  EXPECT_EQ(cmp, sout2.str());
+}
+
+TEST(xmlformatter, pretty)
+{
+  std::stringstream sout;
+  XMLFormatter formatter(
+      true,   // pretty
+      false,   // lowercased
+      false); // underscored
+  formatter.open_object_section("xml");
+  formatter.dump_int("Integer", 10);
+  formatter.dump_float("Float", 10.0);
+  formatter.dump_string("String", "String");
+  formatter.close_section();
+  formatter.flush(sout);
+  std::string cmp = ""
+    "<xml>\n"
+    " <Integer>10</Integer>\n"
+    " <Float>10</Float>\n"
+    " <String>String</String>\n"
+    "</xml>\n\n";
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, lowercased)
+{
+  std::stringstream sout;
+  XMLFormatter formatter(
+      false,  // pretty
+      true,   // lowercased
+      false); // underscored
+  formatter.dump_int("Integer", 10);
+  formatter.dump_float("Float", 10.0);
+  formatter.dump_string("String", "String");
+  formatter.flush(sout);
+  std::string cmp = ""
+    "<integer>10</integer>"
+    "<float>10</float>"
+    "<string>String</string>";
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, underscored)
+{
+  std::stringstream sout;
+  XMLFormatter formatter(
+      false,  // pretty
+      false,   // lowercased
+      true); // underscored
+  formatter.dump_int("Integer Item", 10);
+  formatter.dump_float("Float Item", 10.0);
+  formatter.dump_string("String Item", "String");
+  formatter.flush(sout);
+  std::string cmp = ""
+    "<Integer_Item>10</Integer_Item>"
+    "<Float_Item>10</Float_Item>"
+    "<String_Item>String</String_Item>";
+
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, lowercased_underscored)
+{
+  std::stringstream sout;
+  XMLFormatter formatter(
+      false,  // pretty
+      true,   // lowercased
+      true); // underscored
+  formatter.dump_int("Integer Item", 10);
+  formatter.dump_float("Float Item", 10.0);
+  formatter.dump_string("String Item", "String");
+  formatter.flush(sout);
+  std::string cmp = ""
+    "<integer_item>10</integer_item>"
+    "<float_item>10</float_item>"
+    "<string_item>String</string_item>";
+  EXPECT_EQ(cmp, sout.str());
+}
+
+TEST(xmlformatter, pretty_lowercased_underscored)
+{
+  std::stringstream sout;
+  XMLFormatter formatter(
+      true,  // pretty
+      true,   // lowercased
+      true); // underscored
+  formatter.dump_int("Integer Item", 10);
+  formatter.dump_float("Float Item", 10.0);
+  formatter.dump_string("String Item", "String");
+  formatter.flush(sout);
+  std::string cmp = ""
+    "<integer_item>10</integer_item>\n"
+    "<float_item>10</float_item>\n"
+    "<string_item>String</string_item>\n\n";
+  EXPECT_EQ(cmp, sout.str());
+}


### PR DESCRIPTION

As discussed in Dev-maillist, turn on `underscored` by default.

@tchaikov @liewegas @jcsp 

Please take a look, thanks