### PR TITLE
[DNM] jewel: rgw openssl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,10 +158,10 @@ endif(${WITH_OPENLDAP})
 option(WITH_OPENSSL "OPENSSL is here" ON)
 if(${WITH_OPENSSL})
 find_package(OpenSSL REQUIRED)
-set(HAVE_OPENSSL ON)
+set(USE_OPENSSL ON)
 #message(STATUS "${OPENSSL_LIBRARIES}")
 else(${WITH_OPENSSL})
-set(HAVE_OPENSSL OFF)
+set(USE_OPENSSL OFF)
 set(OPENSSL_LIBRARIES)
 endif(${WITH_OPENSSL})
 
@@ -287,6 +287,47 @@ endif(WITH_XIO)
 
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
+
+if (WITH_RADOSGW)
+  if (NOT DEFINED OPENSSL_FOUND)
+    message(STATUS "Looking for openssl anyways, because radosgw selected")
+    find_package(OpenSSL)
+  endif()
+  if (OPENSSL_FOUND)
+    execute_process(
+      COMMAND
+	"sh" "-c"
+	"objdump -p ${OPENSSL_SSL_LIBRARY} | sed -n 's/^  SONAME  *//p'"
+      OUTPUT_VARIABLE LIBSSL_SONAME
+      ERROR_VARIABLE OBJDUMP_ERRORS
+      RESULT_VARIABLE OBJDUMP_RESULTS
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (OBJDUMP_RESULTS)
+      message(FATAL_ERROR "can't run objdump: ${OBJDUMP_RESULTS}")
+    endif()
+    if (NOT OBJDUMP_ERRORS STREQUAL "")
+      message(WARNING "message from objdump: ${OBJDUMP_ERRORS}")
+    endif()
+    execute_process(
+      COMMAND
+	"sh" "-c"
+	"objdump -p ${OPENSSL_CRYPTO_LIBRARY} | sed -n 's/^  SONAME  *//p'"
+      OUTPUT_VARIABLE LIBCRYPTO_SONAME
+      ERROR_VARIABLE OBJDUMP_ERRORS
+      RESULT_VARIABLE OBJDUMP_RESULTS
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (OBJDUMP_RESULTS)
+      message(FATAL_ERROR "can't run objdump: ${OBJDUMP_RESULTS}")
+    endif()
+    if (NOT OBJDUMP_ERRORS STREQUAL "")
+      message(WARNING "message from objdump: ${OBJDUMP_ERRORS}")
+    endif()
+    message(STATUS "ssl soname: ${LIBSSL_SONAME}")
+    message(STATUS "crypto soname: ${LIBCRYPTO_SONAME}")
+  else()
+    message(WARNING "ssl not found: rgw civetweb may fail to dlopen libssl libcrypto")
+  endif()
+endif (WITH_RADOSGW)
 
 #option for CephFS
 option(WITH_CEPHFS "CephFS is enabled" ON)

--- a/configure.ac
+++ b/configure.ac
@@ -531,6 +531,29 @@ AS_IF([test "$RADOSGW" = "1"],
                             AC_DEFINE([HAVE_CURL_MULTI_WAIT], [1], [Define if have curl_multi_wait()]))
               ])
 
+AS_IF([test "$RADOSGW" = "1"],  [
+    AX_CHECK_OPENSSL([],
+        [AC_MSG_FAILURE([radosgw selected but OpenSSL not found])])
+AC_MSG_NOTICE([radosgw: openssl INCLUDES $OPENSSL_INCLUDES LIBS $OPENSSL_LIBS])
+AC_MSG_CHECKING(for radosgw/civetweb: sonames for openssl libraries)
+  saved_LIBS="${LIBS}"
+  LIBS="$OPENSSL_LIBS"
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([[]], [[]])],
+      [AC_MSG_RESULT([linked])
+eval `$OBJDUMP -p ./conftest$ac_exeext | sed -n 's/^  NEEDED  *libssl/LIBSSL_SONAME=libssl/p;
+s/^  NEEDED  *libcrypto/LIBCRYPTO_SONAME=libcrypto/p'`],
+      AC_MSG_RESULT([problem looking up sonames]))
+  LIBS="${saved_LIBS}"
+AC_MSG_NOTICE([radosgw: openssl sonames $LIBSSL_SONAME $LIBCRYPTO_SONAME])])
+SONAME_DEFINES=""
+AS_IF([test "x$LIBSSL_SONAME" != x], [
+SONAME_DEFINES="$SONAME_DEFINES -DSSL_LIB=\\"'"'"$LIBSSL_SONAME\\"'"'""
+])
+AS_IF([test "x$LIBCRYPTO_SONAME" != x], [
+SONAME_DEFINES="$SONAME_DEFINES -DCRYPTO_LIB=\\"'"'"$LIBCRYPTO_SONAME\\"'"'""
+])
+AC_SUBST(SONAME_DEFINES)
+
 # fuse?
 AC_ARG_WITH([fuse],
             [AS_HELP_STRING([--without-fuse], [disable FUSE userspace client])],

--- a/doc/install/install-ceph-gateway.rst
+++ b/doc/install/install-ceph-gateway.rst
@@ -10,9 +10,8 @@ simplifies the Ceph Object Gateway installation and configuration.
           Ceph storage cluster, and the gateway host should have access to the 
           public network.
 
-.. note:: In version 0.80, the Ceph Object Gateway does not support SSL. You
-          may setup a reverse proxy server with SSL to dispatch HTTPS requests 
-          as HTTP requests to CivetWeb.
+.. note:: As of version 10.2.6, the Ceph Object Gateway **does** support SSL.
+          See `Using SSL with Civetweb`_ for information on how to set that up.
 
 Execute the Pre-Installation Procedure
 --------------------------------------
@@ -83,10 +82,6 @@ your administration server. Add a section entitled
 ``[client.rgw.<gateway-node>]``, replacing ``<gateway-node>`` with the short
 node name of your Ceph Object Gateway node (i.e., ``hostname -s``).
 
-.. note:: In version 0.94, the Ceph Object Gateway does not support SSL. You
-          may setup a reverse proxy web server with SSL to dispatch HTTPS 
-          requests as HTTP requests to CivetWeb.
-
 For example, if your node name is ``gateway-node1``, add a section like this
 after the ``[global]`` section::
 
@@ -144,6 +139,28 @@ If you add a new ``IPv4`` iptables rule after installing
 execute the following as the ``root`` user::
 
  iptables-save > /etc/iptables/rules.v4
+
+Using SSL with Civetweb
+-----------------------
+.. _Using SSL with Civetweb:
+
+Before using SSL with civetweb, you will need a certificate that will match
+the host name that that will be used to access the Ceph Object Gateway.
+You may wish to obtain one that has `subject alternate name` fields for
+more flexibility.  If you intend to use S3-style subdomains
+(`Add Wildcard to DNS`_), you will need a `wildcard` certificate.
+
+Civetweb requires that the server key, server certificate, and any other
+CA or intermediate certificates be supplied in one file.  Each of these
+items must be in `pem` form.  Because the combined file contains the
+secret key, it should be protected from unauthorized access.
+
+To configure ssl operation, append ``s`` to the port number.  Currently
+it is not possible to configure the radosgw to listen on both
+http and https, you must pick only one.  So::
+
+ [client.rgw.gateway-node1]
+ rgw_frontends = civetweb port=443s ssl_certificate=/etc/ceph/private/keyandcert.pem
 
 Migrating from Apache to Civetweb
 ---------------------------------
@@ -267,6 +284,7 @@ Where ``client.rgw.ceph-client`` is the name of the gateway user.
 
 Add Wildcard to DNS
 -------------------
+.. _Add Wildcard to DNS:
 
 To use Ceph with S3-style subdomains (e.g., bucket-name.domain-name.com), you
 need to add a wildcard to the DNS record of the DNS server you use with the

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -1,0 +1,124 @@
+# ===========================================================================
+#     http://www.gnu.org/software/autoconf-archive/ax_check_openssl.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_OPENSSL([action-if-found[, action-if-not-found]])
+#
+# DESCRIPTION
+#
+#   Look for OpenSSL in a number of default spots, or in a user-selected
+#   spot (via --with-openssl).  Sets
+#
+#     OPENSSL_INCLUDES to the include directives required
+#     OPENSSL_LIBS to the -l directives required
+#     OPENSSL_LDFLAGS to the -L or -R flags required
+#
+#   and calls ACTION-IF-FOUND or ACTION-IF-NOT-FOUND appropriately
+#
+#   This macro sets OPENSSL_INCLUDES such that source files should use the
+#   openssl/ directory in include directives:
+#
+#     #include <openssl/hmac.h>
+#
+# LICENSE
+#
+#   Copyright (c) 2009,2010 Zmanda Inc. <http://www.zmanda.com/>
+#   Copyright (c) 2009,2010 Dustin J. Mitchell <dustin@zmanda.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 8
+
+AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
+AC_DEFUN([AX_CHECK_OPENSSL], [
+    found=false
+    AC_ARG_WITH([openssl],
+        [AS_HELP_STRING([--with-openssl=DIR],
+            [root of the OpenSSL directory])],
+        [
+            case "$withval" in
+            "" | y | ye | yes | n | no)
+            AC_MSG_ERROR([Invalid --with-openssl value])
+              ;;
+            *) ssldirs="$withval"
+              ;;
+            esac
+        ], [
+            # if pkg-config is installed and openssl has installed a .pc file,
+            # then use that information and don't search ssldirs
+            AC_PATH_PROG([PKG_CONFIG], [pkg-config])
+            if test x"$PKG_CONFIG" != x""; then
+                OPENSSL_LDFLAGS=`$PKG_CONFIG openssl --libs-only-L 2>/dev/null`
+                if test $? = 0; then
+                    OPENSSL_LIBS=`$PKG_CONFIG openssl --libs-only-l 2>/dev/null`
+                    OPENSSL_INCLUDES=`$PKG_CONFIG openssl --cflags-only-I 2>/dev/null`
+                    found=true
+                fi
+            fi
+
+            # no such luck; use some default ssldirs
+            if ! $found; then
+                ssldirs="/usr/local/ssl /usr/lib/ssl /usr/ssl /usr/pkg /usr/local /usr"
+            fi
+        ]
+        )
+
+
+    # note that we #include <openssl/foo.h>, so the OpenSSL headers have to be in
+    # an 'openssl' subdirectory
+
+    if ! $found; then
+        OPENSSL_INCLUDES=
+        for ssldir in $ssldirs; do
+            AC_MSG_CHECKING([for openssl/ssl.h in $ssldir])
+            if test -f "$ssldir/include/openssl/ssl.h"; then
+                OPENSSL_INCLUDES="-I$ssldir/include"
+                OPENSSL_LDFLAGS="-L$ssldir/lib"
+                OPENSSL_LIBS="-lssl -lcrypto"
+                found=true
+                AC_MSG_RESULT([yes])
+                break
+            else
+                AC_MSG_RESULT([no])
+            fi
+        done
+
+        # if the file wasn't found, well, go ahead and try the link anyway -- maybe
+        # it will just work!
+    fi
+
+    # try the preprocessor and linker with our new flags,
+    # being careful not to pollute the global LIBS, LDFLAGS, and CPPFLAGS
+
+    AC_MSG_CHECKING([whether compiling and linking against OpenSSL works])
+    echo "Trying link with OPENSSL_LDFLAGS=$OPENSSL_LDFLAGS;" \
+        "OPENSSL_LIBS=$OPENSSL_LIBS; OPENSSL_INCLUDES=$OPENSSL_INCLUDES" >&AS_MESSAGE_LOG_FD
+
+    save_LIBS="$LIBS"
+    save_LDFLAGS="$LDFLAGS"
+    save_CPPFLAGS="$CPPFLAGS"
+    LDFLAGS="$LDFLAGS $OPENSSL_LDFLAGS"
+    LIBS="$OPENSSL_LIBS $LIBS"
+    CPPFLAGS="$OPENSSL_INCLUDES $CPPFLAGS"
+    AC_LINK_IFELSE(
+        [AC_LANG_PROGRAM([#include <openssl/ssl.h>], [SSL_new(NULL)])],
+        [
+            AC_MSG_RESULT([yes])
+            $1
+        ], [
+            AC_MSG_RESULT([no])
+            $2
+        ])
+    CPPFLAGS="$save_CPPFLAGS"
+    LDFLAGS="$save_LDFLAGS"
+    LIBS="$save_LIBS"
+
+    AC_SUBST([OPENSSL_INCLUDES])
+    AC_SUBST([OPENSSL_LIBS])
+    AC_SUBST([OPENSSL_LDFLAGS])
+])

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1177,13 +1177,20 @@ if(${WITH_RADOSGW})
   add_library(civetweb_common_objs OBJECT ${civetweb_common_files})
   target_include_directories(civetweb_common_objs PRIVATE
 	"${CMAKE_SOURCE_DIR}/src/civetweb/include")
-  if(HAVE_OPENSSL)
   set_property(TARGET civetweb_common_objs
-	       APPEND PROPERTY COMPILE_DEFINITIONS NO_SSL_DL=1)
-  target_include_directories(civetweb_common_objs PUBLIC
-	"${OPENSSL_INCLUDE_DIR}")
-  else(HAVE_OPENSSL)
-  endif(HAVE_OPENSSL)
+    APPEND PROPERTY COMPILE_DEFINITIONS USE_IPV6=1)
+  if(USE_OPENSSL)
+    set_property(TARGET civetweb_common_objs
+      APPEND PROPERTY COMPILE_DEFINITIONS NO_SSL_DL=1)
+    target_include_directories(civetweb_common_objs PRIVATE
+      "${SSL_INCLUDE_DIR}")
+  endif(USE_OPENSSL)
+  if (LIBSSL_SONAME)
+    set_property(TARGET civetweb_common_objs
+      APPEND PROPERTY COMPILE_DEFINITIONS SSL_LIB="${LIBSSL_SONAME}")
+    set_property(TARGET civetweb_common_objs
+      APPEND PROPERTY COMPILE_DEFINITIONS CRYPTO_LIB="${LIBCRYPTO_SONAME}")
+  endif()
 
   add_library(rgw_a STATIC ${rgw_a_srcs})
   target_link_libraries(rgw_a librados cls_rgw_client cls_refcount_client

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1175,7 +1175,7 @@ if(${WITH_RADOSGW})
 
   set(civetweb_common_files civetweb/src/civetweb.c)
   add_library(civetweb_common_objs OBJECT ${civetweb_common_files})
-  target_include_directories(civetweb_common_objs PUBLIC
+  target_include_directories(civetweb_common_objs PRIVATE
 	"${CMAKE_SOURCE_DIR}/src/civetweb/include")
   if(HAVE_OPENSSL)
   set_property(TARGET civetweb_common_objs

--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -133,8 +133,7 @@ libcivetweb_la_SOURCES =  \
 
 libcivetweb_la_CXXFLAGS = ${CIVETWEB_INCLUDE} -fPIC -Woverloaded-virtual \
 	${AM_CXXFLAGS}
-libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE} -fPIC -DNO_SSL_DL
-LIBCIVETWEB_DEPS += -lssl -lcrypto
+libcivetweb_la_CFLAGS = -I$(srcdir)/civetweb/include ${CIVETWEB_INCLUDE} -fPIC $(SONAME_DEFINES)
 
 noinst_LTLIBRARIES += libcivetweb.la
 
@@ -147,7 +146,7 @@ radosgw_SOURCES = \
 	civetweb/src/civetweb.c \
 	rgw/rgw_main.cc
 
-radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE}
+radosgw_CFLAGS = -I$(srcdir)/civetweb/include -fPIC -I$(srcdir)/xxHash ${CIVETWEB_INCLUDE} $(SONAME_DEFINES)
 radosgw_LDADD = $(LIBRGW) $(LIBCIVETWEB) $(LIBCIVETWEB_DEPS) $(LIBRGW_DEPS) $(RESOLV_LIBS) \
 	$(CEPH_GLOBAL)
 bin_PROGRAMS += radosgw

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -27,11 +27,22 @@ int RGWMongoose::write_data(const char *buf, int len)
   return r;
 }
 
-RGWMongoose::RGWMongoose(mg_connection *_conn, int _port)
-  : conn(_conn), port(_port), status_num(0), header_done(false),
+RGWMongoose::RGWMongoose(mg_connection *_conn)
+  : conn(_conn), status_num(0), header_done(false),
     sent_header(false), has_content_length(false),
     explicit_keepalive(false), explicit_conn_close(false)
 {
+    sockaddr *lsa = mg_get_local_addr(conn);
+    switch(lsa->sa_family) {
+    case AF_INET:
+	port = ntohs(((struct sockaddr_in*)lsa)->sin_port);
+	break;
+    case AF_INET6:
+	port = ntohs(((struct sockaddr_in6*)lsa)->sin6_port);
+	break;
+    default:
+	port = -1;
+    }
 }
 
 int RGWMongoose::read_data(char *buf, int len)
@@ -141,14 +152,12 @@ void RGWMongoose::init_env(CephContext *cct)
   env.set("REMOTE_USER", info->remote_user);
   env.set("SCRIPT_URI", info->uri); /* FIXME */
 
+  if (port <= 0)
+    lderr(cct) << "init_env: bug: invalid port number" << dendl;
   char port_buf[16];
   snprintf(port_buf, sizeof(port_buf), "%d", port);
   env.set("SERVER_PORT", port_buf);
-
   if (info->is_ssl) {
-    if (port == 0) {
-      strcpy(port_buf,"443");
-    }
     env.set("SERVER_PORT_SECURE", port_buf);
   }
 }

--- a/src/rgw/rgw_civetweb.h
+++ b/src/rgw/rgw_civetweb.h
@@ -38,7 +38,7 @@ public:
   int complete_request();
   int send_content_length(uint64_t len);
 
-  RGWMongoose(mg_connection *_conn, int _port);
+  RGWMongoose(mg_connection *_conn);
   void flush();
 };
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -18,7 +18,7 @@ static int civetweb_callback(struct mg_connection* conn) {
     OpsLogSocket* olog = pe->olog;
 
     RGWRequest req(store->get_new_req_id());
-    RGWMongoose client_io(conn, pe->port);
+    RGWMongoose client_io(conn);
 
     int ret = process_request(pe->store, rest, &req, &client_io, olog);
     if (ret < 0) {
@@ -39,6 +39,7 @@ int RGWMongooseFrontend::run() {
   map<string, string> conf_map = conf->get_config_map();
   conf->get_val("port", "80", &port_str);
   conf_map.erase("port");
+  std::replace(port_str.begin(), port_str.end(), '+', ',');
   conf_map["listening_ports"] = port_str;
   set_conf_default(conf_map, "enable_keep_alive", "yes");
   set_conf_default(conf_map, "num_threads", thread_pool_buf);

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -388,10 +388,7 @@ int main(int argc, const char **argv)
 
       fe = new RGWFCGXFrontend(fcgi_pe, config);
     } else if (framework == "civetweb" || framework == "mongoose") {
-      int port;
-      config->get_val("port", 80, &port);
-
-      RGWProcessEnv env = { store, &rest, olog, port };
+      RGWProcessEnv env = { store, &rest, olog, 0 };
 
       fe = new RGWMongooseFrontend(env, config);
     } else if (framework == "loadgen") {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3674,10 +3674,12 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s)
     }
     string token_value = string(t);
     if (using_qs && (token == "host")) {
-      if (!port.empty() && port != "80" && port != "0") {
-        token_value = token_value + ":" + port;
-      } else if (!secure_port.empty() && secure_port != "443") {
-        token_value = token_value + ":" + secure_port;
+      if (!secure_port.empty()) {
+	if (secure_port != "443")
+	  token_value = token_value + ":" + secure_port;
+      } else if (!port.empty()) {
+	if (port != "80")
+	  token_value = token_value + ":" + port;
       }
     }
     canonical_hdrs_map[token] = rgw_trim_whitespace(token_value);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19003

This will update jewel to have the same ssl functionality as master.

commits: 3866408 0455514 update cmake stuff.  Last I checked, cmake didn't work well in jewel so this may not be useful.
commit e3f80c9 is not in master: it's the autoconf equivalent to the last 2.  Note that this changes jewel to load libssl.so libcrypto.so by soname as shared objects rather than using dynamic loading.
commit 28f2841 uses civetweb wip-listen3.  This is almost the civetweb that was previously in jewel.  It adds mg_get_local_addr, which is required by this patch set.  It includes a few other minor patches that I think are harmless.