### PR TITLE
rgw: fix a bug the owner should delete objects in the container

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -538,6 +538,11 @@ int RGWGetObj::verify_permission()
   }
 
   if (!verify_object_permission(s, RGW_PERM_READ)) {
+    /* swift container owner doesn't have SWIFT_PERM_READ perm by default,
+     * so here we should consider it separately*/
+    if (s->prot_flags & RGW_REST_SWIFT && s->auth_identity->is_owner_of(s->bucket_owner.get_id())) {
+      return 0;
+    }
     return -EACCES;
   }
 


### PR DESCRIPTION
The owner should has right to delete the object in his container by default

Fixes: http://tracker.ceph.com/issues/18517
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>