### PR TITLE
cmake: fix rpath on shared libraries and binaries targets

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -545,6 +545,8 @@ add_library(ceph-common SHARED
   $<TARGET_OBJECTS:common-objs>
   $<TARGET_OBJECTS:common_mountcephfs_objs>
   $<TARGET_OBJECTS:global_common_objs>)
+set_target_properties(ceph-common PROPERTIES
+  INSTALL_RPATH "")
 target_link_libraries(ceph-common json_spirit erasure_code rt ${LIB_RESOLV}
   ${Boost_THREAD_LIBRARY}
   ${Boost_SYSTEM_LIBRARY}
@@ -891,6 +893,8 @@ if(WITH_LIBCEPHFS)
   add_executable(mount.ceph ${mount_ceph_srcs}
     $<TARGET_OBJECTS:parse_secret_objs>
     $<TARGET_OBJECTS:common_mountcephfs_objs>)
+  set_target_properties(mount.ceph PROPERTIES
+    INSTALL_RPATH "")
   target_link_libraries(mount.ceph ${KEYUTILS_LIBRARIES})
 
   install(TARGETS ceph-syn DESTINATION bin)

--- a/src/cls/CMakeLists.txt
+++ b/src/cls/CMakeLists.txt
@@ -6,14 +6,20 @@ set(cls_embedded_srcs)
 # cls_hello
 set(cls_hello_srcs hello/cls_hello.cc)
 add_library(cls_hello SHARED ${cls_hello_srcs})
-set_target_properties(cls_hello PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_hello PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_hello DESTINATION ${cls_dir})
 list(APPEND cls_embedded_srcs ${cls_hello_srcs})
 
 # cls_numops
 set(cls_numops_srcs numops/cls_numops.cc)
 add_library(cls_numops SHARED ${cls_numops_srcs})
-set_target_properties(cls_numops PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_numops PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_numops DESTINATION ${cls_dir})
 
 set(cls_numops_client_srcs numops/cls_numops_client.cc)
@@ -25,7 +31,10 @@ list(APPEND cls_embedded_srcs ${cls_numops_srcs} ${cls_numops_client_srcs})
 if (WITH_RBD)
   set(cls_rbd_srcs rbd/cls_rbd.cc rbd/cls_rbd_types.cc)
   add_library(cls_rbd SHARED ${cls_rbd_srcs})
-  set_target_properties(cls_rbd PROPERTIES VERSION "1.0.0" SOVERSION "1")
+  set_target_properties(cls_rbd PROPERTIES
+    VERSION "1.0.0"
+    SOVERSION "1"
+    INSTALL_RPATH "")
   install(TARGETS cls_rbd DESTINATION ${cls_dir})
 
   set(cls_rbd_client_srcs rbd/cls_rbd_client.cc rbd/cls_rbd_types.cc)
@@ -38,7 +47,10 @@ endif (WITH_RBD)
 # cls_lock
 set(cls_lock_srcs lock/cls_lock.cc)
 add_library(cls_lock SHARED ${cls_lock_srcs})
-set_target_properties(cls_lock PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_lock PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_lock DESTINATION ${cls_dir})
 
 set(cls_lock_client_srcs
@@ -56,7 +68,10 @@ set(cls_refcount_srcs
   ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
 add_library(cls_refcount SHARED ${cls_refcount_srcs})
 target_link_libraries(cls_refcount json_spirit)
-set_target_properties(cls_refcount PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_refcount PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_refcount DESTINATION ${cls_dir})
 
 set(cls_refcount_client_srcs
@@ -69,7 +84,10 @@ list(APPEND cls_embedded_srcs ${cls_refcount_srcs} ${cls_refcount_client_srcs})
 # cls_version
 set(cls_version_srcs version/cls_version.cc)
 add_library(cls_version SHARED ${cls_version_srcs})
-set_target_properties(cls_version PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_version PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_version DESTINATION ${cls_dir})
 
 set(cls_version_client_srcs
@@ -82,7 +100,10 @@ list(APPEND cls_embedded_srcs ${cls_version_srcs} ${cls_version_client_srcs})
 # cls_log
 set(cls_log_srcs log/cls_log.cc)
 add_library(cls_log SHARED ${cls_log_srcs})
-set_target_properties(cls_log PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_log PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_log DESTINATION ${cls_dir})
 
 set(cls_log_client_srcs log/cls_log_client.cc)
@@ -93,7 +114,10 @@ list(APPEND cls_embedded_srcs ${cls_log_srcs} ${cls_log_client_srcs})
 # cls_statelog
 set(cls_statelog_srcs statelog/cls_statelog.cc)
 add_library(cls_statelog SHARED ${cls_statelog_srcs})
-set_target_properties(cls_statelog PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_statelog PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_statelog DESTINATION ${cls_dir})
 
 set(cls_statelog_client_srcs statelog/cls_statelog_client.cc)
@@ -104,7 +128,10 @@ list(APPEND cls_embedded_srcs ${cls_statelog_srcs} ${cls_statelog_client_srcs})
 # cls_timeindex
 set(cls_timeindex_srcs timeindex/cls_timeindex.cc)
 add_library(cls_timeindex SHARED ${cls_timeindex_srcs})
-set_target_properties(cls_timeindex PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_timeindex PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_timeindex DESTINATION ${cls_dir})
 
 set(cls_timeindex_client_srcs timeindex/cls_timeindex_client.cc)
@@ -115,7 +142,10 @@ list(APPEND cls_embedded_srcs ${cls_timeindex_srcs} ${cls_timeindex_client_srcs}
 # cls_replica_log
 set(cls_replica_log_srcs replica_log/cls_replica_log.cc)
 add_library(cls_replica_log SHARED ${cls_replica_log_srcs})
-set_target_properties(cls_replica_log PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_replica_log PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_replica_log DESTINATION ${cls_dir})
 
 set(cls_replica_log_client_srcs
@@ -129,7 +159,10 @@ list(APPEND cls_embedded_srcs ${cls_replica_log_srcs} ${cls_replica_log_client_s
 # cls_user
 set(cls_user_srcs user/cls_user.cc)
 add_library(cls_user SHARED ${cls_user_srcs})
-set_target_properties(cls_user PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_user PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_user DESTINATION ${cls_dir})
 
 set(cls_user_client_srcs
@@ -145,7 +178,10 @@ set(cls_journal_srcs
   journal/cls_journal.cc
   journal/cls_journal_types.cc)
 add_library(cls_journal SHARED ${cls_journal_srcs})
-set_target_properties(cls_journal PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_journal PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_journal DESTINATION ${cls_dir})
 
 set(cls_journal_client_srcs
@@ -164,7 +200,10 @@ if (WITH_RADOSGW)
     ${CMAKE_SOURCE_DIR}/src/common/ceph_json.cc)
   add_library(cls_rgw SHARED ${cls_rgw_srcs})
   target_link_libraries(cls_rgw json_spirit)
-  set_target_properties(cls_rgw PROPERTIES VERSION "1.0.0" SOVERSION "1")
+  set_target_properties(cls_rgw PROPERTIES
+    VERSION "1.0.0"
+    SOVERSION "1"
+    INSTALL_RPATH "")
   install(TARGETS cls_rgw DESTINATION ${cls_dir})
 
   set(cls_rgw_client_srcs
@@ -181,7 +220,10 @@ if (WITH_CEPHFS)
   set(cls_cephfs_srcs
     cephfs/cls_cephfs.cc)
   add_library(cls_cephfs SHARED ${cls_cephfs_srcs})
-  set_target_properties(cls_cephfs PROPERTIES VERSION "1.0.0" SOVERSION "1")
+  set_target_properties(cls_cephfs PROPERTIES
+    VERSION "1.0.0"
+    SOVERSION "1"
+    INSTALL_RPATH "")
   install(TARGETS cls_cephfs DESTINATION ${cls_dir})
 
   set(cls_cephfs_client_srcs
@@ -196,7 +238,10 @@ set(cls_lua_srcs
     lua/cls_lua.cc
     lua/lua_bufferlist.cc)
 add_library(cls_lua SHARED ${cls_lua_srcs})
-set_target_properties(cls_lua PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_lua PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_lua DESTINATION ${cls_dir})
 target_link_libraries(cls_lua
     liblua

--- a/src/compressor/snappy/CMakeLists.txt
+++ b/src/compressor/snappy/CMakeLists.txt
@@ -7,7 +7,10 @@ set(snappy_sources
 add_library(ceph_snappy SHARED ${snappy_sources})
 add_dependencies(ceph_snappy ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ceph_snappy ${SNAPPY_LIBRARIES})
-set_target_properties(ceph_snappy PROPERTIES VERSION 2.0.0 SOVERSION 2)
+set_target_properties(ceph_snappy PROPERTIES
+  VERSION 2.0.0
+  SOVERSION 2
+  INSTALL_RPATH "")
 install(TARGETS ceph_snappy DESTINATION ${compressor_plugin_dir})
 
 if(WITH_EMBEDDED)

--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -31,7 +31,10 @@ add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ceph_zlib ${ZLIB_LIBRARIES})
 target_include_directories(ceph_zlib PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
-set_target_properties(ceph_zlib PROPERTIES VERSION 2.0.0 SOVERSION 2)
+set_target_properties(ceph_zlib PROPERTIES
+  VERSION 2.0.0
+  SOVERSION 2
+  INSTALL_RPATH "")
 install(TARGETS ceph_zlib DESTINATION ${compressor_plugin_dir})
 
 if(WITH_EMBEDDED)

--- a/src/erasure-code/isa/CMakeLists.txt
+++ b/src/erasure-code/isa/CMakeLists.txt
@@ -55,7 +55,10 @@ add_library(ec_isa SHARED
   $<TARGET_OBJECTS:erasure_code_objs>)
 add_dependencies(ec_isa ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_isa ${EXTRALIBS})
-set_target_properties(ec_isa PROPERTIES VERSION 2.14.0 SOVERSION 2)
+set_target_properties(ec_isa PROPERTIES
+  VERSION 2.14.0
+  SOVERSION 2
+  INSTALL_RPATH "")
 install(TARGETS ec_isa DESTINATION ${erasure_plugin_dir})
 
 if(WITH_EMBEDDED)

--- a/src/erasure-code/jerasure/CMakeLists.txt
+++ b/src/erasure-code/jerasure/CMakeLists.txt
@@ -88,6 +88,8 @@ set(ec_jerasure_objs
   $<TARGET_OBJECTS:erasure_code_objs>)
 
 add_library(ec_jerasure SHARED ${ec_jerasure_objs})
+set_target_properties(ec_jerasure PROPERTIES
+  INSTALL_RPATH "")
 target_link_libraries(ec_jerasure ${EXTRALIBS})
 install(TARGETS ec_jerasure DESTINATION ${erasure_plugin_dir})
 
@@ -95,6 +97,8 @@ install(TARGETS ec_jerasure DESTINATION ${erasure_plugin_dir})
 foreach(flavor ${jerasure_legacy_flavors})
   set(plugin_name "ec_jerasure_${flavor}")
   add_library(${plugin_name} SHARED ${ec_jerasure_objs})
+  set_target_properties(${plugin_name} PROPERTIES
+    INSTALL_RPATH "")
   install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})
   add_dependencies(ec_jerasure ${plugin_name})
 endforeach()

--- a/src/erasure-code/lrc/CMakeLists.txt
+++ b/src/erasure-code/lrc/CMakeLists.txt
@@ -9,6 +9,8 @@ set(lrc_srcs
 
 add_library(ec_lrc SHARED ${lrc_srcs})
 add_dependencies(ec_lrc ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
+set_target_properties(ec_lrc PROPERTIES
+  INSTALL_RPATH "")
 target_link_libraries(ec_lrc crush json_spirit)
 install(TARGETS ec_lrc DESTINATION ${erasure_plugin_dir})
 

--- a/src/erasure-code/shec/CMakeLists.txt
+++ b/src/erasure-code/shec/CMakeLists.txt
@@ -19,6 +19,8 @@ set(ec_shec_objs
 
 add_library(ec_shec SHARED ${ec_shec_objs})
 add_dependencies(ec_shec ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
+set_target_properties(ec_shec PROPERTIES
+  INSTALL_RPATH "")
 target_link_libraries(ec_shec ${EXTRALIBS})
 install(TARGETS ec_shec DESTINATION ${erasure_plugin_dir})
 
@@ -26,6 +28,8 @@ install(TARGETS ec_shec DESTINATION ${erasure_plugin_dir})
 foreach(flavor ${jerasure_legacy_flavors})
   set(plugin_name "ec_shec_${flavor}")
   add_library(${plugin_name} SHARED ${ec_shec_objs})
+  set_target_properties(${plugin_name} PROPERTIES
+    INSTALL_RPATH "")
   install(TARGETS ${plugin_name} DESTINATION ${erasure_plugin_dir})
   add_dependencies(ec_shec ${plugin_name})
 endforeach()

--- a/src/key_value_store/CMakeLists.txt
+++ b/src/key_value_store/CMakeLists.txt
@@ -1,6 +1,9 @@
 set(kvs_srcs cls_kvs.cc)
 add_library(cls_kvs SHARED ${kvs_srcs})
-set_target_properties(cls_kvs PROPERTIES VERSION "1.0.0" SOVERSION "1")
+set_target_properties(cls_kvs PROPERTIES
+  VERSION "1.0.0"
+  SOVERSION "1"
+  INSTALL_RPATH "")
 install(TARGETS cls_kvs DESTINATION ${CMAKE_INSTALL_LIBDIR}/rados-classes)
 
 if(WITH_EMBEDDED)

--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -34,7 +34,8 @@ function(add_tracing_library name tracings version)
   set_target_properties(${name} PROPERTIES
     OUTPUT_NAME ${name}
     VERSION ${version}
-    SOVERSION ${soversion})
+    SOVERSION ${soversion}
+    INSTALL_RPATH "")
 endfunction()
 
 set(osd_traces oprequest.tp osd.tp pg.tp)


### PR DESCRIPTION
While building the Ceph RPMs in opensuse build system, we got several errors as mention in the end of the discussion in #12840 

The problem was due to the attempt of CMake to rewrite the RPATH of the binaries, or shared libraries, that didn't have any RPATH linked during the building phase.

Signed-off-by: Ricardo Dias <rdias@suse.com>