### PR TITLE
qa/suites/ceph-ansible: removing fs workunit

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/3-tasks/cfuse_workunit_suites_blogbench.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/3-tasks/cfuse_workunit_suites_blogbench.yaml
@@ -1,9 +1,0 @@
-meta:
-- desc: "Run the cephfs blogbench tests"
-
-tasks:
-- ceph-fuse:
-- workunit:
-    clients:
-      client.0:
-        - suites/blogbench.sh


### PR DESCRIPTION
removing fs workunit for now until tracker issue 18528 is resolved.

Signed-off-by: Tamil Muthamizhan <tmuthami@redhat.com>