### PR TITLE
common/pick_address.cc: Copy public_netw to cluster_netw if cluster empty

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,11 @@
 11.1.1
 ------
 
+ * When assigning a network to the public network and not to
+   the cluster network the network specification of the public
+   network will be used for the cluster network as well.
+   In the older version this would lead to cluster services
+   being bound to 0.0.0.0:<port>, thus actually making the
+   cluster service even more publicly available than the
+   public services. When only specifying a cluster network it
+   will still result in the public services binding to 0.0.0.0.

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -112,6 +112,7 @@ void pick_addresses(CephContext *cct, int needs)
     exit(1);
   }
 
+
   if ((needs & CEPH_PICK_ADDRESS_PUBLIC)
       && cct->_conf->public_addr.is_blank_ip()
       && !cct->_conf->public_network.empty()) {
@@ -119,9 +120,16 @@ void pick_addresses(CephContext *cct, int needs)
   }
 
   if ((needs & CEPH_PICK_ADDRESS_CLUSTER)
-      && cct->_conf->cluster_addr.is_blank_ip()
-      && !cct->_conf->cluster_network.empty()) {
-    fill_in_one_address(cct, ifa, cct->_conf->cluster_network, "cluster_addr");
+      && cct->_conf->cluster_addr.is_blank_ip()) {
+    if (!cct->_conf->cluster_network.empty()) {
+      fill_in_one_address(cct, ifa, cct->_conf->cluster_network, "cluster_addr");
+    } else {
+      if (!cct->_conf->public_network.empty()) {
+        lderr(cct) << "Public network was set, but cluster network was not set " << dendl;
+        lderr(cct) << "    Using public network also for cluster network" << dendl;
+        fill_in_one_address(cct, ifa, cct->_conf->public_network, "cluster_addr");
+      }
+    }
   }
 
   freeifaddrs(ifa);


### PR DESCRIPTION
 - When public network is set, but cluster network is not, then
   the cluster-bindings would be on 0.0.0.0 which could be unexpeted.

 In this commit we copy the public network into the cluster network
 to make sure that the cluster backend is not bound on 0.0.0.0
 Which could be consideren an insecure, or unexpected, action.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>