### PR TITLE
DNM: Enforce boundedness at compile time

### DIFF
--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -33,8 +33,8 @@ struct denc_traits<inodeno_t> {
   enum { supported = 2 };
   enum { featured = false };
   enum { bounded = true };
-  static void bound_encode(const inodeno_t &o, size_t& p) {
-    denc(o.val, p);
+  static void bound_encode(bounded_t<inodeno_t>, size_t& p) {
+    denc(bounded_t<decltype(inodeno_t::val)>{}, p);
   }
   static void encode(const inodeno_t &o, buffer::list::contiguous_appender& p) {
     denc(o.val, p);

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -127,8 +127,8 @@ struct denc_traits<snapid_t> {
   enum { supported = 2 };
   enum { featured = false };
   enum { bounded = true };
-  static void bound_encode(const snapid_t& o, size_t& p) {
-    denc(o.val, p);
+  static void bound_encode(bounded_t<snapid_t>, size_t& p) {
+    denc(bounded_t<decltype(snapid_t::val)>{}, p);
   }
   static void encode(const snapid_t &o, buffer::list::contiguous_appender& p) {
     denc(o.val, p);

--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -130,7 +130,7 @@ struct denc_counter_t {
 WRITE_CLASS_DENC(denc_counter_t)
 
 struct denc_counter_bounded_t {
-  void bound_encode(size_t& p) const {
+  static void bound_encode(size_t& p) {
     ++counts.num_bound_encode;
     ++p;  // denc.h does not like 0-length objects
   }
@@ -334,10 +334,17 @@ struct foo_t {
   int32_t a = 0;
   uint64_t b = 123;
 
-  DENC(foo_t, v, p) {
+  DENC_BOUNDED(foo_t, v, p) {
     DENC_START(1, 1, p);
     ::denc(v.a, p);
     ::denc(v.b, p);
+    DENC_FINISH(p);
+  }
+
+  DENC_BOUND_ENCODE(foo_t, p) {
+    DENC_START(1, 1, p);
+    ::denc(bounded_t<decltype(foo_t::a)>{}, p);
+    ::denc(bounded_t<decltype(foo_t::b)>{}, p);
     DENC_FINISH(p);
   }
 
@@ -351,10 +358,16 @@ struct foo2_t {
   int32_t c = 0;
   uint64_t d = 123;
 
-  DENC(foo2_t, v, p) {
+  DENC_BOUNDED(foo2_t, v, p) {
     DENC_START(1, 1, p);
     ::denc(v.c, p);
     ::denc(v.d, p);
+    DENC_FINISH(p);
+  }
+  DENC_BOUND_ENCODE(foo2_t, p) {
+    DENC_START(1, 1, p);
+    ::denc(bounded_t<decltype(foo2_t::c)>{}, p);
+    ::denc(bounded_t<decltype(foo2_t::d)>{}, p);
     DENC_FINISH(p);
   }
 
@@ -369,9 +382,15 @@ struct bar_t {
   int32_t a = 0;
   uint64_t b = 123;
 
-  DENC_FEATURED(bar_t, v, p, f) {
+  DENC_FEATURED_BOUNDED(bar_t, v, p, f) {
     ::denc(v.a, p, f);
     ::denc(v.b, p, f);
+  }
+  DENC_FEATURED_BOUND_ENCODE(bar_t, p, f) {
+    DENC_START(1, 1, p);
+    ::denc(bounded_t<decltype(bar_t::a)>{}, p, f);
+    ::denc(bounded_t<decltype(bar_t::b)>{}, p, f);
+    DENC_FINISH(p);
   }
 
   friend bool operator==(const bar_t& l, const bar_t& r) {


### PR DESCRIPTION
Givne a type T, our desire is that if denc_traits<T>::bounded is true
that the function denc_traits<T>::bound_encode() execute while depending
on no particulars of the object passed to it.

This was why some bound_encode() functions enabled by a true bound trait
would pass a value of *(const T*)nullptr, causing a crash at run time if
the referenced were ever accessed in the called function. This is
undefined behavior and there is some concern it might be teriggered
spuriously at low optimization levels.

This is a requirement that can be enforced at compile-time. To do so I
have set up a template type, bounded_t<T>, that can participate in
argument deduction and which can swallow references of type T passed to
it, functioning as a 'trap door' that allows the 'bounded' functions to
be easily called from non-bounded ones but not vice-versa.

This works quite well. The main downside is that the requirement that
bound_encode() for bounded types not actually receive a reference to the
object to be encoded means that a single template function cannot serve
as bound_encode, encode, and decode in one. A separate implementation of
bound_encode must be provided. This follows from the encode and decode
being written in terms of members of the class to be encoded and
decoded.

This seems to be unavoidable in the general case, unfortunately.

But I bet I could come up with a template based solution using members
to pointer variables for the specific case of feature-conditioned
serializing a sequence of class members.

Signed-off-by: Adam C. Emerson <aemerson@redhat.com>