### PR TITLE
rgw: multisite: fix error when deleting null instance

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -666,6 +666,9 @@ int RGWAsyncRemoveObj::_send_request()
   }
   if (versioned) {
     del_op.params.versioning_status = BUCKET_VERSIONED;
+    if ((bucket_info.flags & BUCKET_VERSIONS_SUSPENDED) != 0 ) {
+      del_op.params.versioning_status |= BUCKET_VERSIONS_SUSPENDED;
+    }
   }
   del_op.params.olh_epoch = versioned_epoch;
   del_op.params.marker_version_id = marker_version_id;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2396,6 +2396,9 @@ public:
             set_status("removing obj");
             if (op == CLS_RGW_OP_UNLINK_INSTANCE) {
               versioned = true;
+              if (key.instance == "") {
+                key.instance = "null";
+              }
             }
             logger.log("remove");
             call(data_sync_module->remove_object(sync_env, *bucket_info, key, timestamp, versioned, versioned_epoch, &zones_trace));
@@ -2769,7 +2772,7 @@ int RGWBucketShardIncrementalSyncCR::operate()
           set_status() << "squashed operation, skipping";
           tn->log(20, SSTR("skipping object: "
               << bucket_shard_str{bs} << "/" << key << ": squashed operation"));
-          /* not updating high marker though */
+          marker_tracker.try_update_high_marker(cur_id, 0, entry->timestamp);
           continue;
         }
         tn->set_flag(RGW_SNS_FLAG_ACTIVE);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8740,7 +8740,7 @@ int RGWRados::Object::Delete::delete_obj()
         if (params.marker_version_id != "null") {
           marker.key.set_instance(params.marker_version_id);
         }
-      } else if ((params.versioning_status & BUCKET_VERSIONS_SUSPENDED) == 0) {
+      } else if (instance != "null" && (params.versioning_status & BUCKET_VERSIONS_SUSPENDED) == 0) {
         store->gen_rand_obj_instance_name(&marker);
       }
 
@@ -8766,7 +8766,7 @@ int RGWRados::Object::Delete::delete_obj()
       rgw_bucket_dir_entry dirent;
 
       int r = store->bi_get_instance(target->get_bucket_info(), obj, &dirent);
-      if (r < 0) {
+      if (r < 0 || (obj.key.instance.empty() && !dirent.is_delete_marker() && !dirent.exists)) {
         return r;
       }
       result.delete_marker = dirent.is_delete_marker();


### PR DESCRIPTION

This modification separate deleting null version obj from deleting(simple) obj to make the meaning of two operations clear in all bucket versioning states(disable、enable、suspended).


fix http://tracker.ceph.com/issues/18534

Signed-off-by: lvshuhua <lvshuhua@cmss.chinamobile.com>