### PR TITLE
auth: Enhancement for the supported auth methods

### DIFF
--- a/src/auth/AuthMethodList.cc
+++ b/src/auth/AuthMethodList.cc
@@ -35,10 +35,12 @@ AuthMethodList::AuthMethodList(CephContext *cct, string str)
     } else if (iter->compare("none") == 0) {
       auth_supported.push_back(CEPH_AUTH_NONE);
     } else {
+      auth_supported.push_back(CEPH_AUTH_UNKNOWN);
       lderr(cct) << "WARNING: unknown auth protocol defined: " << *iter << dendl;
     }
   }
   if (auth_supported.empty()) {
+    lderr(cct) << "WARNING: no auth protocol defined, use 'cephx' by default" << dendl;
     auth_supported.push_back(CEPH_AUTH_CEPHX);
   }
 }


### PR DESCRIPTION
- If no auth protocol defined, `cephx` is used by default, it's debatable if
  ceph should abort here or use `cephx` by default, but if `cephx` is used
  in this case it's better to give some warning message.
- ceph has CEPH_AUTH_UNKNOWN auth protocol defined, change to use this
  protocol if the auth method is unknown.

Signed-off-by: Dave Chen <wei.d.chen@intel.com>