### PR TITLE
cmake: search for nspr include files for both suffixes: nspr4 and nspr

### DIFF
--- a/cmake/modules/FindNSPR.cmake
+++ b/cmake/modules/FindNSPR.cmake
@@ -34,6 +34,7 @@ else (NSPR_LIBRARIES AND NSPR_INCLUDE_DIRS)
       /sw/include
     PATH_SUFFIXES
       nspr4
+      nspr
   )
 
   find_library(PLDS4_LIBRARY


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18535
Signed-off-by: John Lin <johnlinp@gmail.com>