### PR TITLE
rgw: multisite: fix master disk file del error caused by versioning delete marker

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8734,6 +8734,13 @@ int RGWRados::Object::Delete::delete_obj()
 
   if (params.versioning_status & BUCKET_VERSIONED || explicit_marker_version) {
     if (instance.empty() || explicit_marker_version) {
+      if (!instance.empty() && explicit_marker_version) {
+        rgw_bucket_dir_entry dirent;
+        int r = store->bi_get_instance(target->get_bucket_info(), obj, &dirent);
+        if (r == 0) {
+          return 0;  //return when the delete marker is existed
+        }
+      }
       rgw_obj marker = obj;
 
       if (!params.marker_version_id.empty()) {


### PR DESCRIPTION
Usually，delete(simple) a versioned object under multisite environment including these steps:
1、master zone  run delete(simple)
2、slave zone run delete(simple)
3、master zone deal with the sync process triggered by slave zone delete(simple) op
During the third step, master zone enter into _RGWRados::Object::Delete::delete_obj_ again, the process do not stop opportunely, that cause unexpected behaviours were produced. As a result, a extra entry was inserted in olh data entry, that cause the disk file and item in XX.rgw.buckets.data(related with delete marker) remaining after deleting all version of this object. 