### PR TITLE
os/bluestore: avoid unnecessary memory copy, use variable reference in BlockDevice::Open

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -108,7 +108,7 @@ public:
 
   // for managing buffered readers/writers
   virtual int invalidate_cache(uint64_t off, uint64_t len) = 0;
-  virtual int open(string path) = 0;
+  virtual int open(const string& path) = 0;
   virtual void close() = 0;
 };
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -60,7 +60,7 @@ int KernelDevice::_lock()
   return 0;
 }
 
-int KernelDevice::open(string p)
+int KernelDevice::open(const string& p)
 {
   path = p;
   int r = 0;

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -95,7 +95,7 @@ public:
 
   // for managing buffered readers/writers
   int invalidate_cache(uint64_t off, uint64_t len) override;
-  int open(string path) override;
+  int open(const string& path) override;
   void close() override;
 };
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -772,7 +772,7 @@ NVMEDevice::NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
 }
 
 
-int NVMEDevice::open(string p)
+int NVMEDevice::open(const string& p)
 {
   int r = 0;
   dout(1) << __func__ << " path " << p << dendl;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -230,7 +230,7 @@ class NVMEDevice : public BlockDevice {
 
   // for managing buffered readers/writers
   int invalidate_cache(uint64_t off, uint64_t len) override;
-  int open(string path) override;
+  int open(const string& path) override;
   void close() override;
 };
 


### PR DESCRIPTION


Signed-off-by: liuchang0812 <liuchang0812@gmail.com>