### PR TITLE
qa/distros: make centos_latest 7.3

### DIFF
--- a/qa/distros/supported/centos_latest.yaml
+++ b/qa/distros/supported/centos_latest.yaml
@@ -1,1 +1,1 @@
-../all/centos_7.2.yaml
+../all/centos_7.3.yaml


### PR DESCRIPTION
This will fix smithi runs and break vps runs until we get a 7.3 cloud-init
image ready.

Signed-off-by: Sage Weil <sage@redhat.com>