### PR TITLE
rbd: add error prompt when input command 'snap set limit' is incomplete

### DIFF
--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -474,6 +474,7 @@ int execute_set_limit(const po::variables_map &vm) {
   if (vm.count(at::LIMIT)) {
     limit = vm[at::LIMIT].as<uint64_t>();
   } else {
+    std::cerr << "rbd: must specify --limit <num>" << std::endl;
     return -ERANGE;
   }
 


### PR DESCRIPTION
Signed-off-by: Tang Jin <tang.jin@istuary.com> 

When to execute command such as 'rbd snap set limit 1', there are no output at all. But in fact it failed. So I add this error prompt to tell user to input complete command.