### PR TITLE
os/bluestore: Add bluestore pextent vector to mempool

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -471,7 +471,7 @@ public:
     void get_ref(uint64_t offset, uint64_t length);
     /// put logical references, and get back any released extents
     bool put_ref(Collection *coll, uint64_t offset, uint64_t length,
-		 vector<bluestore_pextent_t> *r);
+		 PExtentVector *r);
     /// pass references for specific range to other blob
     void pass_ref(Blob* other, uint64_t src_offset, uint64_t length, uint64_t dest_offset);
 
@@ -1640,8 +1640,8 @@ private:
   int _open_super_meta();
 
   int _reconcile_bluefs_freespace();
-  int _balance_bluefs_freespace(vector<bluestore_pextent_t> *extents);
-  void _commit_bluefs_freespace(const vector<bluestore_pextent_t>& extents);
+  int _balance_bluefs_freespace(PExtentVector *extents);
+  void _commit_bluefs_freespace(const PExtentVector& extents);
 
   CollectionRef _get_collection(const coll_t& cid);
   void _queue_reap_collection(CollectionRef& c);
@@ -1696,7 +1696,7 @@ private:
 
   int _fsck_check_extents(
     const ghobject_t& oid,
-    const vector<bluestore_pextent_t>& extents,
+    const PExtentVector& extents,
     bool compressed,
     boost::dynamic_bitset<> &used_blocks,
     store_statfs_t& expected_statfs);

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -200,7 +200,7 @@ void bluestore_extent_ref_map_t::get(uint64_t offset, uint32_t length)
 
 void bluestore_extent_ref_map_t::put(
   uint64_t offset, uint32_t length,
-  vector<bluestore_pextent_t> *release)
+  PExtentVector *release)
 {
   auto p = ref_map.lower_bound(offset);
   if (p == ref_map.end() || p->first > offset) {

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -29,6 +29,7 @@ TEST(bluestore, sizeof) {
   P(BlueStore::Buffer);
   P(bluestore_onode_t);
   P(bluestore_blob_t);
+  P(bluestore_blob_t::extents);
   P(bluestore_extent_ref_map_t);
   P(bluestore_extent_ref_map_t::record_t);
   P(std::atomic_int);
@@ -36,6 +37,7 @@ TEST(bluestore, sizeof) {
   P(boost::intrusive::set_base_hook<>);
   P(boost::intrusive::unordered_set_base_hook<>);
   P(bufferlist);
+  P(bufferptr);
   cout << "map<uint64_t,uint64_t>\t" << sizeof(map<uint64_t,uint64_t>) << std::endl;
   cout << "map<char,char>\t" << sizeof(map<char,char>) << std::endl;
 }

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -117,7 +117,7 @@ TEST(bluestore_extent_ref_map_t, get)
 TEST(bluestore_extent_ref_map_t, put)
 {
   bluestore_extent_ref_map_t m;
-  vector<bluestore_pextent_t> r;
+  PExtentVector r;
   m.get(10, 30);
   m.put(10, 30, &r);
   cout << m << " " << r << std::endl;
@@ -333,7 +333,7 @@ TEST(Blob, put_ref)
     b.get_ref(0, 0x1200);
     b.get_ref(0xae00, 0x4200);
     cout << b << std::endl;
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
 
     b.put_ref(&coll, 0, 0x1200, &r);
     cout << " r " << r << std::endl;
@@ -356,7 +356,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(0, mas*2));
     B.get_ref(0, mas*2);
     ASSERT_TRUE(b.is_allocated(0, mas*2));
@@ -376,7 +376,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(123, mas*2));
     B.get_ref(0, mas*2);
     B.put_ref(&coll, 0, mas, &r);
@@ -397,7 +397,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas));
     b.extents.push_back(bluestore_pextent_t(2, mas));
     b.extents.push_back(bluestore_pextent_t(3, mas));
@@ -432,7 +432,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas));
     b.extents.push_back(bluestore_pextent_t(2, mas));
     b.extents.push_back(bluestore_pextent_t(3, mas));
@@ -470,7 +470,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 6));
     B.get_ref(0, mas*6);
     B.put_ref(&coll, mas, mas, &r);
@@ -499,7 +499,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
@@ -534,7 +534,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
@@ -584,7 +584,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
@@ -634,7 +634,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 8));
     B.get_ref(0, mas*8);
     B.put_ref(&coll, 0, mas, &r);
@@ -672,7 +672,7 @@ TEST(Blob, put_ref)
     B.shared_blob = new BlueStore::SharedBlob(nullptr);
     B.shared_blob->get();  // hack to avoid dtor from running
     bluestore_blob_t& b = B.dirty_blob();
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(0, mas*4));
     b.init_csum(Checksummer::CSUM_CRC32C, 14, mas * 4);
     B.get_ref(0, mas*4);
@@ -699,7 +699,7 @@ TEST(Blob, put_ref)
     b.init_csum(Checksummer::CSUM_CRC32C, 12, 0x1e000);
 
     cout << "before: " << B << std::endl;
-    vector<bluestore_pextent_t> r;
+    PExtentVector r;
     B.put_ref(&coll, 0x1800, 0x2000, &r);
     cout << "after: " << B << std::endl;
     cout << "r " << r << std::endl;


### PR DESCRIPTION
This adds 32K to our reference 4M object Onode :(

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>