### PR TITLE
ceph-disk: use correct user in check_journal_req

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1425,16 +1425,22 @@ def check_journal_reqs(args):
         'ceph-osd', '--check-allows-journal',
         '-i', '0',
         '--cluster', args.cluster,
+        '--setuser', get_ceph_user(),
+        '--setgroup', get_ceph_group(),
     ])
     _, _, wants_journal = command([
         'ceph-osd', '--check-wants-journal',
         '-i', '0',
         '--cluster', args.cluster,
+        '--setuser', get_ceph_user(),
+        '--setgroup', get_ceph_group(),
     ])
     _, _, needs_journal = command([
         'ceph-osd', '--check-needs-journal',
         '-i', '0',
         '--cluster', args.cluster,
+        '--setuser', get_ceph_user(),
+        '--setgroup', get_ceph_group(),
     ])
     return (not allows_journal, not wants_journal, not needs_journal)
 


### PR DESCRIPTION
The ceph-disk tool calls ceph-osd to check the journal requirements
using OSD id 0. This creates a log file for osd-0 on the system
using the current user/group for file permissions.  When ceph-disk
is run as root this makes the file owned by root which makes
the osd daemon for osd.0 unable to write to its own log file.

This commit changes the journal reqs calls of ceph-osd to pass
the ceph user and group so ceph-osd creates the log file with the
appropriate permissions.

Fixes: http://tracker.ceph.com/issues/18538

Signed-off-by: Samuel Matzek <smatzek@us.ibm.com>