### PR TITLE
osd: extend OMAP_GETKEYS and GETVALS to include a 'more' output field

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,12 +1,23 @@
 12.0.0
 ------
 
- * The omap_get_keys and omap_get_vals librados functions have been deprecated
-   in favor of omap_get_vals2 and omap_get_keys2.  The new methods include an
-   output argument indicating whether there are additional keys left to fetch.
-   Previously this had to be inferred from the requested key count vs the
-   number of keys returned, but this breaks with new OSD-side limits on the
-   number of keys or bytes that can be returned by a single omap request.  These
-   limits were introduced by kraken but were effectively disabled (by setting a
-   very large limit of 1 GB) because users of the newly deprecated interface
-   cannot tell whether they should fetch more keys or not.
+ * Some varients of the omap_get_keys and omap_get_vals librados
+   functions have been deprecated in favor of omap_get_vals2 and
+   omap_get_keys2.  The new methods include an output argument
+   indicating whether there are additional keys left to fetch.
+   Previously this had to be inferred from the requested key count vs
+   the number of keys returned, but this breaks with new OSD-side
+   limits on the number of keys or bytes that can be returned by a
+   single omap request.  These limits were introduced by kraken but
+   are effectively disabled by default (by setting a very large limit
+   of 1 GB) because users of the newly deprecated interface cannot
+   tell whether they should fetch more keys or not.  In the case of
+   the standalone calls in the C++ interface
+   (IoCtx::get_omap_{keys,vals}), librados has been updated to loop on
+   the client side to provide a correct result via multiple calls to
+   the OSD.  In the case of the methods used for building
+   multi-operation transactions, however, client-side looping is not
+   practical, and the methods have been deprecated.  Note that use of
+   either the IoCtx methods on older librados versions or the
+   deprecated methods on any version of librados will lead to
+   incomplete results if/when the new OSD limits are enabled.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,12 @@
-11.1.1
+12.0.0
 ------
 
+ * The omap_get_keys and omap_get_vals librados functions have been deprecated
+   in favor of omap_get_vals2 and omap_get_keys2.  The new methods include an
+   output argument indicating whether there are additional keys left to fetch.
+   Previously this had to be inferred from the requested key count vs the
+   number of keys returned, but this breaks with new OSD-side limits on the
+   number of keys or bytes that can be returned by a single omap request.  These
+   limits were introduced by kraken but were effectively disabled (by setting a
+   very large limit of 1 GB) because users of the newly deprecated interface
+   cannot tell whether they should fetch more keys or not.

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3124,7 +3124,29 @@ CEPH_RADOS_API void rados_read_op_omap_get_vals(rados_read_op_t read_op,
 				                const char *filter_prefix,
 				                uint64_t max_return,
 				                rados_omap_iter_t *iter,
-				                int *prval);
+				                int *prval)
+  __attribute__((deprecated)); /* use v2 below */
+
+/**
+ * Start iterating over key/value pairs on an object.
+ *
+ * They will be returned sorted by key.
+ *
+ * @param read_op operation to add this action to
+ * @param start_after list keys starting after start_after
+ * @param filter_prefix list only keys beginning with filter_prefix
+ * @param max_return list no more than max_return key/value pairs
+ * @param iter where to store the iterator
+ * @param pmore flag indicating whether there are more keys to fetch
+ * @param prval where to store the return value from this action
+ */
+CEPH_RADOS_API void rados_read_op_omap_get_vals2(rados_read_op_t read_op,
+						 const char *start_after,
+						 const char *filter_prefix,
+						 uint64_t max_return,
+						 rados_omap_iter_t *iter,
+						 unsigned char *pmore,
+						 int *prval);
 
 /**
  * Start iterating over keys on an object.
@@ -3142,7 +3164,28 @@ CEPH_RADOS_API void rados_read_op_omap_get_keys(rados_read_op_t read_op,
 				                const char *start_after,
 				                uint64_t max_return,
 				                rados_omap_iter_t *iter,
-				                int *prval);
+				                int *prval)
+  __attribute__((deprecated)); /* use v2 below */
+
+/**
+ * Start iterating over keys on an object.
+ *
+ * They will be returned sorted by key, and the iterator
+ * will fill in NULL for all values if specified.
+ *
+ * @param read_op operation to add this action to
+ * @param start_after list keys starting after start_after
+ * @param max_return list no more than max_return keys
+ * @param iter where to store the iterator
+ * @param pmore flag indicating whether there are more keys to fetch
+ * @param prval where to store the return value from this action
+ */
+CEPH_RADOS_API void rados_read_op_omap_get_keys2(rados_read_op_t read_op,
+						 const char *start_after,
+						 uint64_t max_return,
+						 rados_omap_iter_t *iter,
+						 unsigned char *pmore,
+						 int *prval);
 
 /**
  * Start iterating over specific key/value pairs

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -522,6 +522,23 @@ namespace librados
       const std::string &start_after,
       uint64_t max_return,
       std::map<std::string, bufferlist> *out_vals,
+      int *prval) __attribute__ ((deprecated));  // use v2
+
+    /**
+     * omap_get_vals: keys and values from the object omap
+     *
+     * Get up to max_return keys and values beginning after start_after
+     *
+     * @param start_after [in] list no keys smaller than start_after
+     * @param max_return [in] list no more than max_return key/value pairs
+     * @param out_vals [out] place returned values in out_vals on completion
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_vals2(
+      const std::string &start_after,
+      uint64_t max_return,
+      std::map<std::string, bufferlist> *out_vals,
+      bool *pmore,
       int *prval);
 
     /**
@@ -540,6 +557,26 @@ namespace librados
       const std::string &filter_prefix,
       uint64_t max_return,
       std::map<std::string, bufferlist> *out_vals,
+      int *prval) __attribute__ ((deprecated));  // use v2
+
+    /**
+     * omap_get_vals2: keys and values from the object omap
+     *
+     * Get up to max_return keys and values beginning after start_after
+     *
+     * @param start_after [in] list keys starting after start_after
+     * @param filter_prefix [in] list only keys beginning with filter_prefix
+     * @param max_return [in] list no more than max_return key/value pairs
+     * @param out_vals [out] place returned values in out_vals on completion
+     * @param pmore [out] pointer to bool indicating whether there are more keys
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_vals2(
+      const std::string &start_after,
+      const std::string &filter_prefix,
+      uint64_t max_return,
+      std::map<std::string, bufferlist> *out_vals,
+      bool *pmore,
       int *prval);
 
 
@@ -556,7 +593,24 @@ namespace librados
     void omap_get_keys(const std::string &start_after,
                        uint64_t max_return,
                        std::set<std::string> *out_keys,
-                       int *prval);
+                       int *prval) __attribute__ ((deprecated)); // use v2
+
+    /**
+     * omap_get_keys2: keys from the object omap
+     *
+     * Get up to max_return keys beginning after start_after
+     *
+     * @param start_after [in] list keys starting after start_after
+     * @param max_return [in] list no more than max_return keys
+     * @param out_keys [out] place returned values in out_keys on completion
+     * @param pmore [out] pointer to bool indicating whether there are more keys
+     * @param prval [out] place error code in prval upon completion
+     */
+    void omap_get_keys2(const std::string &start_after,
+			uint64_t max_return,
+			std::set<std::string> *out_keys,
+			bool *pmore,
+			int *prval);
 
     /**
      * omap_get_header: get header from object omap
@@ -745,15 +799,31 @@ namespace librados
                       const std::string& start_after,
                       uint64_t max_return,
                       std::map<std::string, bufferlist> *out_vals);
+    int omap_get_vals2(const std::string& oid,
+		       const std::string& start_after,
+		       uint64_t max_return,
+		       std::map<std::string, bufferlist> *out_vals,
+		       bool *pmore);
     int omap_get_vals(const std::string& oid,
                       const std::string& start_after,
                       const std::string& filter_prefix,
                       uint64_t max_return,
                       std::map<std::string, bufferlist> *out_vals);
+    int omap_get_vals2(const std::string& oid,
+		       const std::string& start_after,
+		       const std::string& filter_prefix,
+		       uint64_t max_return,
+		       std::map<std::string, bufferlist> *out_vals,
+		       bool *pmore);
     int omap_get_keys(const std::string& oid,
                       const std::string& start_after,
                       uint64_t max_return,
                       std::set<std::string> *out_keys);
+    int omap_get_keys2(const std::string& oid,
+		       const std::string& start_after,
+		       uint64_t max_return,
+		       std::set<std::string> *out_keys,
+		       bool *pmore);
     int omap_get_header(const std::string& oid,
                         bufferlist *bl);
     int omap_get_vals_by_keys(const std::string& oid,

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -266,7 +266,8 @@ void librados::ObjectReadOperation::omap_get_vals(
   int *prval)
 {
   ::ObjectOperation *o = &impl->o;
-  o->omap_get_vals(start_after, filter_prefix, max_return, out_vals, prval);
+  o->omap_get_vals(start_after, filter_prefix, max_return, out_vals, nullptr,
+		   prval);
 }
 
 void librados::ObjectReadOperation::omap_get_vals(
@@ -276,7 +277,7 @@ void librados::ObjectReadOperation::omap_get_vals(
   int *prval)
 {
   ::ObjectOperation *o = &impl->o;
-  o->omap_get_vals(start_after, "", max_return, out_vals, prval);
+  o->omap_get_vals(start_after, "", max_return, out_vals, nullptr, prval);
 }
 
 void librados::ObjectReadOperation::omap_get_keys(
@@ -286,7 +287,7 @@ void librados::ObjectReadOperation::omap_get_keys(
   int *prval)
 {
   ::ObjectOperation *o = &impl->o;
-  o->omap_get_keys(start_after, max_return, out_keys, prval);
+  o->omap_get_keys(start_after, max_return, out_keys, nullptr, prval);
 }
 
 void librados::ObjectReadOperation::omap_get_header(bufferlist *bl, int *prval)
@@ -5714,11 +5715,13 @@ extern "C" void rados_read_op_omap_get_vals(rados_read_op_t read_op,
   RadosOmapIter *omap_iter = new RadosOmapIter;
   const char *start = start_after ? start_after : "";
   const char *filter = filter_prefix ? filter_prefix : "";
-  ((::ObjectOperation *)read_op)->omap_get_vals(start,
-						filter,
-						max_return,
-						&omap_iter->values,
-						prval);
+  ((::ObjectOperation *)read_op)->omap_get_vals(
+    start,
+    filter,
+    max_return,
+    &omap_iter->values,
+    nullptr,
+    prval);
   ((::ObjectOperation *)read_op)->add_handler(new C_OmapIter(omap_iter));
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_vals_exit, *iter);
@@ -5747,8 +5750,9 @@ extern "C" void rados_read_op_omap_get_keys(rados_read_op_t read_op,
   tracepoint(librados, rados_read_op_omap_get_keys_enter, read_op, start_after, max_return, prval);
   RadosOmapIter *omap_iter = new RadosOmapIter;
   C_OmapKeysIter *ctx = new C_OmapKeysIter(omap_iter);
-  ((::ObjectOperation *)read_op)->omap_get_keys(start_after ? start_after : "",
-						max_return, &ctx->keys, prval);
+  ((::ObjectOperation *)read_op)->omap_get_keys(
+    start_after ? start_after : "",
+    max_return, &ctx->keys, nullptr, prval);
   ((::ObjectOperation *)read_op)->add_handler(ctx);
   *iter = omap_iter;
   tracepoint(librados, rados_read_op_omap_get_keys_exit, *iter);

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1515,7 +1515,8 @@ void CDir::_omap_fetch(MDSInternalContextBase *c, const std::set<dentry_key_t>& 
   rd.omap_get_header(&fin->hdrbl, &fin->ret1);
   if (keys.empty()) {
     assert(!c);
-    rd.omap_get_vals("", "", (uint64_t)-1, &fin->omap, &fin->ret2);
+#warning use the pmore arg
+    rd.omap_get_vals("", "", (uint64_t)-1, &fin->omap, nullptr, &fin->ret2);
   } else {
     assert(c);
     std::set<std::string> str_keys;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -219,8 +219,9 @@ void SessionMap::_load_finish(
     object_locator_t oloc(mds->mdsmap->get_metadata_pool());
     C_IO_SM_Load *c = new C_IO_SM_Load(this, false);
     ObjectOperation op;
+#warning fixme use the pmore arg
     op.omap_get_vals(last_key, "", g_conf->mds_sessionmap_keys_per_op,
-        &c->session_vals, &c->values_r);
+		     &c->session_vals, nullptr, &c->values_r);
     mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0,
         new C_OnFinisher(c, mds->finisher));
   } else {
@@ -262,8 +263,9 @@ void SessionMap::load(MDSInternalContextBase *onload)
 
   ObjectOperation op;
   op.omap_get_header(&c->header_bl, &c->header_r);
+#warning use the pmore arg
   op.omap_get_vals("", "", g_conf->mds_sessionmap_keys_per_op,
-      &c->session_vals, &c->values_r);
+		   &c->session_vals, nullptr, &c->values_r);
 
   mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0, new C_OnFinisher(c, mds->finisher));
 }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5747,22 +5747,25 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
 	bufferlist bl;
 	uint32_t num = 0;
+	bool truncated = false;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
 	    coll, ghobject_t(soid)
 	    );
 	  assert(iter);
 	  iter->upper_bound(start_after);
-	  for (num = 0;
-	       num < max_return &&
-		 bl.length() < cct->_conf->osd_max_omap_bytes_per_request &&
-		 iter->valid();
-	       ++num, iter->next(false)) {
+	  for (num = 0; iter->valid(); ++num, iter->next(false)) {
+	    if (num >= max_return ||
+		bl.length() >= cct->_conf->osd_max_omap_bytes_per_request) {
+	      truncated = true;
+	      break;
+	    }
 	    ::encode(iter->key(), bl);
 	  }
 	} // else return empty out_set
 	::encode(num, osd_op.outdata);
 	osd_op.outdata.claim_append(bl);
+	::encode(truncated, osd_op.outdata);
 	ctx->delta_stats.num_rd_kb += SHIFT_ROUND_UP(osd_op.outdata.length(), 10);
 	ctx->delta_stats.num_rd++;
       }
@@ -5790,6 +5793,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	tracepoint(osd, do_osd_op_pre_omapgetvals, soid.oid.name.c_str(), soid.snap.val, start_after.c_str(), max_return, filter_prefix.c_str());
 
 	uint32_t num = 0;
+	bool truncated = false;
 	bufferlist bl;
 	if (oi.is_omap()) {
 	  ObjectMap::ObjectMapIterator iter = osd->store->get_omap_iterator(
@@ -5802,18 +5806,22 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  iter->upper_bound(start_after);
 	  if (filter_prefix > start_after) iter->lower_bound(filter_prefix);
 	  for (num = 0;
-	       num < max_return &&
-		 bl.length() < cct->_conf->osd_max_omap_bytes_per_request &&
-		 iter->valid() &&
+	       iter->valid() &&
 		 iter->key().substr(0, filter_prefix.size()) == filter_prefix;
 	       ++num, iter->next(false)) {
 	    dout(20) << "Found key " << iter->key() << dendl;
+	    if (num >= max_return ||
+		bl.length() >= cct->_conf->osd_max_omap_bytes_per_request) {
+	      truncated = true;
+	      break;
+	    }
 	    ::encode(iter->key(), bl);
 	    ::encode(iter->value(), bl);
 	  }
 	} // else return empty out_set
 	::encode(num, osd_op.outdata);
 	osd_op.outdata.claim_append(bl);
+	::encode(truncated, osd_op.outdata);
 	ctx->delta_stats.num_rd_kb += SHIFT_ROUND_UP(osd_op.outdata.length(), 10);
 	ctx->delta_stats.num_rd++;
       }

--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -2117,8 +2117,8 @@ TEST(LibRadosAio, OmapPP) {
 
     bufferlist header;
 
-    op.omap_get_keys("", 1, &set_got, 0);
-    op.omap_get_vals("foo", 1, &map_got, 0);
+    op.omap_get_keys2("", 1, &set_got, nullptr, 0);
+    op.omap_get_vals2("foo", 1, &map_got, nullptr, 0);
 
     to_get.insert("foo");
     to_get.insert("qfoo3");
@@ -2126,7 +2126,7 @@ TEST(LibRadosAio, OmapPP) {
 
     op.omap_get_header(&header, 0);
 
-    op.omap_get_vals("foo2", "q", 1, &got4, 0);
+    op.omap_get_vals2("foo2", "q", 1, &got4, nullptr, 0);
 
     ioctx.aio_operate("test_obj", my_completion.get(), &op, 0);
     {
@@ -2166,7 +2166,7 @@ TEST(LibRadosAio, OmapPP) {
     ObjectReadOperation op;
 
     set<string> set_got;
-    op.omap_get_keys("", -1, &set_got, 0);
+    op.omap_get_keys2("", -1, &set_got, nullptr, 0);
     ioctx.aio_operate("test_obj", my_completion.get(), &op, 0);
     {
       TestAlarm alarm;
@@ -2193,7 +2193,7 @@ TEST(LibRadosAio, OmapPP) {
     ObjectReadOperation op;
 
     set<string> set_got;
-    op.omap_get_keys("", -1, &set_got, 0);
+    op.omap_get_keys2("", -1, &set_got, nullptr, 0);
     ioctx.aio_operate("test_obj", my_completion.get(), &op, 0);
     {
       TestAlarm alarm;
@@ -2238,7 +2238,7 @@ TEST(LibRadosAio, OmapPP) {
     ObjectReadOperation op;
     set<string> set_got;
     bufferlist hdr;
-    op.omap_get_keys("", -1, &set_got, 0);
+    op.omap_get_keys2("", -1, &set_got, nullptr, 0);
     op.omap_get_header(&hdr, NULL);
     ioctx.aio_operate("foo3", my_completion.get(), &op, 0);
     {

--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -39,8 +39,8 @@ protected:
     rados_omap_iter_t iter_vals, iter_keys, iter_vals_by_key;
     int r_vals, r_keys, r_vals_by_key;
     rados_read_op_t op = rados_create_read_op();
-    rados_read_op_omap_get_vals(op, NULL, NULL, 100, &iter_vals, &r_vals);
-    rados_read_op_omap_get_keys(op, NULL, 100, &iter_keys, &r_keys);
+    rados_read_op_omap_get_vals2(op, NULL, NULL, 100, &iter_vals, NULL, &r_vals);
+    rados_read_op_omap_get_keys2(op, NULL, 100, &iter_keys, NULL, &r_keys);
     rados_read_op_omap_get_vals_by_keys(op, keys, len,
 					&iter_vals_by_key, &r_vals_by_key);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
@@ -490,7 +490,7 @@ TEST_F(CReadOpsTest, Omap) {
   // with no omap entries
   rados_omap_iter_t iter_vals;
   rados_read_op_t rop = rados_create_read_op();
-  rados_read_op_omap_get_vals(rop, "", "", 10, &iter_vals, NULL);
+  rados_read_op_omap_get_vals2(rop, "", "", 10, &iter_vals, NULL, NULL);
   ASSERT_EQ(-ENOENT, rados_read_op_operate(rop, ioctx, obj, 0));
   rados_release_read_op(rop);
   compare_omap_vals(NULL, NULL, NULL, 0, iter_vals);
@@ -510,8 +510,8 @@ TEST_F(CReadOpsTest, Omap) {
   rados_omap_iter_t iter_keys;
   int r_vals = -1, r_keys = -1;
   rop = rados_create_read_op();
-  rados_read_op_omap_get_vals(rop, "", "test", 1, &iter_vals, &r_vals);
-  rados_read_op_omap_get_keys(rop, "test", 1, &iter_keys, &r_keys);
+  rados_read_op_omap_get_vals2(rop, "", "test", 1, &iter_vals, NULL, &r_vals);
+  rados_read_op_omap_get_keys2(rop, "test", 1, &iter_keys, NULL, &r_keys);
   ASSERT_EQ(0, rados_read_op_operate(rop, ioctx, obj, 0));
   rados_release_read_op(rop);
   EXPECT_EQ(0, r_vals);

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -464,7 +464,7 @@ TEST_F(LibRadosMiscPP, Tmap2OmapPP) {
     map<string, bufferlist> m;
     ObjectReadOperation o;
     o.omap_get_header(&got, NULL);
-    o.omap_get_vals("", 1024, &m, NULL);
+    o.omap_get_vals2("", 1024, &m, nullptr, nullptr);
     ASSERT_EQ(0, ioctx.operate("foo", &o, NULL));
 
     // compare header

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -232,7 +232,9 @@ int OmapBench::print_written_omap() {
     objstrm << prefix;
     objstrm << i;
     cout << "\nPrinting omap for "<<objstrm.str() << std::endl;
-    key_read.omap_get_keys("", LONG_MAX, &out_keys, &err);
+    // FIXME: we ignore pmore here.  this shouldn't happen for benchmark
+    // keys, though, unless the OSD limit is *really* low.
+    key_read.omap_get_keys2("", LONG_MAX, &out_keys, nullptr, &err);
     io_ctx.operate(objstrm.str(), &key_read, NULL);
     if (err < 0) {
       cout << "error " << err;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1286,9 +1286,10 @@ public:
     }
     if (!context->no_omap) {
       op.omap_get_vals_by_keys(omap_requested_keys, &omap_returned_values, 0);
-
-      op.omap_get_keys("", -1, &omap_keys, 0);
-      op.omap_get_vals("", -1, &omap, 0);
+      // NOTE: we're ignore pmore here, which assumes the OSD limit is high
+      // enough for us.
+      op.omap_get_keys2("", -1, &omap_keys, nullptr, nullptr);
+      op.omap_get_vals2("", -1, &omap, nullptr, nullptr);
       op.omap_get_header(&header, 0);
     }
     op.getxattrs(&xattrs, 0);

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -3196,10 +3196,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     if (!pool_name || nargs.size() < 2)
       usage_exit();
 
-    librados::ObjectReadOperation read;
     set<string> out_keys;
-    read.omap_get_keys("", LONG_MAX, &out_keys, &ret);
-    io_ctx.operate(nargs[1], &read, NULL);
+    ret = io_ctx.omap_get_keys(nargs[1], "", LONG_MAX, &out_keys);
     if (ret < 0) {
       cerr << "error getting omap key set " << pool_name << "/"
 	   << nargs[1] << ": "  << cpp_strerror(ret) << std::endl;


### PR DESCRIPTION
The current omap get methods cannot communicate to the client that their
results were truncated due to hitting a limit on the number of keys or
bytes, making those server-side limits extremely dangerous to
enforce.

Extend the API to implement a new set of methods that explicitly expose a
"more" flag.

The old interfaces are marked deprecated.

Open question: should we change the old implementations to loop on the client
side?