### PR TITLE
[DNM] rgw: add rgwrados init_barrier() (PARTIAL, PROPOSAL)

### DIFF
--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -95,7 +95,6 @@ public:
   }
 };
 
-
 class RGWAsyncGetSystemObj : public RGWAsyncRadosRequest {
   RGWRados *store;
   RGWObjectCtx *obj_ctx;

--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -275,6 +275,13 @@ void RGWGC::stop_processor()
 }
 
 void *RGWGC::GCWorker::entry() {
+
+  /* startup barrier */
+  RGWRados::init_result ires = gc->store->init_barrier();
+  if (ires != RGWRados::init_result::INIT_SUCCESS) {
+    return NULL;
+  }
+
   do {
     utime_t start = ceph_clock_now();
     dout(2) << "garbage collection: start" << dendl;

--- a/src/rgw/rgw_object_expirer_core.cc
+++ b/src/rgw/rgw_object_expirer_core.cc
@@ -251,6 +251,13 @@ void RGWObjectExpirer::stop_processor()
 }
 
 void *RGWObjectExpirer::OEWorker::entry() {
+
+  /* startup barrier */
+  RGWRados::init_result ires = oe->store->init_barrier();
+  if (ires != RGWRados::init_result::INIT_SUCCESS) {
+    return NULL;
+  }
+
   utime_t last_run;
   do {
     utime_t start = ceph_clock_now();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <thread>
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -4061,11 +4062,38 @@ int RGWRados::initialize()
 {
   int ret;
 
-  ret = init_rados();
-  if (ret < 0)
-    return ret;
+  struct Guard {
+    init_result& i_result;
+    std::unique_lock<std::mutex> ul;
+    std::condition_variable& cond;
+    Guard(init_result& _i_result,
+	  std::mutex& mtx,
+	  std::condition_variable& _cond)
+      : i_result(_i_result), ul(mtx), cond(_cond) {}
+    ~Guard() {
+      cond.notify_all();
+      /* minimize the temporal window for threads to finish
+       * executing init_barrier() */
+      if (i_result != init_result::INIT_SUCCESS) {
+	std::this_thread::sleep_for(std::chrono::seconds(120));
+      }
+    }
+  } guard(i_result, init_mtx, init_cond);
 
-  return init_complete();
+  ret = init_rados();
+  if (ret < 0) {
+    i_result = init_result::INIT_FAIL;
+    return ret;
+  }
+
+  ret = init_complete();
+  if (ret < 0) {
+    i_result = init_result::INIT_FAIL;
+    return ret;
+  }
+
+  i_result = init_result::INIT_SUCCESS;
+  return ret;
 }
 
 void RGWRados::finalize_watch()
@@ -4078,6 +4106,15 @@ void RGWRados::finalize_watch()
 
   delete[] notify_oids;
   delete[] watchers;
+}
+
+RGWRados::init_result RGWRados::init_barrier(void)
+{
+  std::unique_lock<std::mutex> guard(init_mtx);
+  while (i_result == init_result::INIT_WAIT) {
+    init_cond.wait(guard);
+  }
+  return i_result;
 }
 
 void RGWRados::schedule_context(Context *c) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -5,6 +5,7 @@
 #define CEPH_RGWRADOS_H
 
 #include <functional>
+#include <condition_variable>
 
 #include "include/rados/librados.hpp"
 #include "include/Context.h"
@@ -1951,6 +1952,16 @@ class RGWRados
   librados::IoCtx control_pool_ctx;   // .rgw.control
   bool watch_initialized;
 
+  std::mutex init_mtx;
+  std::condition_variable init_cond;
+  enum class init_result : uint32_t {
+    INIT_SUCCESS = 0,
+    INIT_WAIT,
+    INIT_FAIL,
+  };
+  init_result i_result;
+  init_result init_barrier();
+
   friend class RGWWatcher;
 
   Mutex bucket_id_lock;
@@ -2024,6 +2035,7 @@ public:
                meta_sync_thread_lock("meta_sync_thread_lock"), data_sync_thread_lock("data_sync_thread_lock"),
                num_watchers(0), watchers(NULL),
                watch_initialized(false),
+	       i_result(init_result::INIT_WAIT),
                bucket_id_lock("rados_bucket_id"),
                bucket_index_max_shards(0),
                max_bucket_id(0), cct(NULL),


### PR DESCRIPTION
To avoid faults in threads spawned by RGWRados::initialize() and
it's friend init_complete(), force the thread instances to execute
a barrier on RGWRados that can prevent any further accesses.

An assumption here is that if the integration for simpler cases
such as RGWGC and RGWObjectExpirer looks good, then it will be only
a bit more work to deal with cases such as WorkQueue descendants
(which currently lack a place to hook RGWRados::init_barrier()).

Another assumption is that the slow path is the main path, which
includes the call that completes all barriers.  On this assumption,
we can avoid the requirement to track and complete waits by callers
of RGWRados::init_barrier(), and just wait for a short period if
initialization has failed.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>