### PR TITLE
bluestore: fix NVMEDevice::open failure if serial number ends with a …

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -798,7 +798,7 @@ int NVMEDevice::open(string p)
     derr << __func__ << " unable to read " << p << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  while (r > 0 && !isalpha(buf[r-1])) {
+  while (r > 0 && !isxdigit(buf[r-1])) {
     --r;
   }
   serial_number = string(buf, r);


### PR DESCRIPTION
…number

The serial number consists of 16 hexadecimal characters.
If the serial number ends with a number, manager.try_get()
will deliver the truncated serial number.

Signed-off-by: Hongtong Liu <hongtong.liu@istuary.com>