### PR TITLE
os/bluestore: fix NVMEDevice::open failure if serial number ends with a …

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -417,6 +417,7 @@ void SharedDriverData::_aio_thread()
               data_buf_reset_sgl, data_buf_next_sge);
           if (r < 0) {
             t->ctx->nvme_task_first = t->ctx->nvme_task_last = nullptr;
+            t->release_segs();
             delete t;
             derr << __func__ << " failed to do write command" << dendl;
             ceph_abort();

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -798,10 +798,12 @@ int NVMEDevice::open(string p)
     derr << __func__ << " unable to read " << p << ": " << cpp_strerror(r) << dendl;
     return r;
   }
-  while (r > 0 && !isalpha(buf[r-1])) {
-    --r;
+  /* scan buf from the beginning with isxdigit. */
+  int i = 0;
+  while (i < r && isxdigit(buf[i])) {
+    i++;
   }
-  serial_number = string(buf, r);
+  serial_number = string(buf, i);
   r = manager.try_get(serial_number, &driver);
   if (r < 0) {
     derr << __func__ << " failed to get nvme device with sn " << serial_number << dendl;


### PR DESCRIPTION
…number

The serial number consists of 16 hexadecimal characters.
If the serial number ends with a number, manager.try_get()
will deliver the truncated serial number.

Signed-off-by: Hongtong Liu <hongtong.liu@istuary.com>