### PR TITLE
crush:  when osd_location_hook does not exist, we should exit error.

### DIFF
--- a/src/crush/CrushLocation.cc
+++ b/src/crush/CrushLocation.cc
@@ -42,6 +42,12 @@ int CrushLocation::update_from_hook()
 {
   if (cct->_conf->crush_location_hook.length() == 0)
     return 0;
+ 
+  if (0 != access(cct->_conf->crush_location_hook.c_str(), R_OK)) {
+    lderr(cct) << "the user define crush location hook: " << cct->_conf->crush_location_hook
+               << " may not exist or can not access it" << dendl;
+    return errno;
+  }
 
   SubProcessTimed hook(
     cct->_conf->crush_location_hook.c_str(),

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -408,6 +408,10 @@ for name in $what; do
 		case "${update_crush:-1}" in 1|[Tt][Rr][Uu][Ee])
 		    # update location in crush
 		    get_conf osd_location_hook "$BINDIR/ceph-crush-location" "osd crush location hook"
+                   if [ ! -e "$osd_location_hook" ]; then
+                       EXIT_STATUS=2
+                       continue
+                   fi
 		    osd_location=`$osd_location_hook --cluster $cluster --id $id --type osd`
 		    get_conf osd_weight "" "osd crush initial weight"
 		    defaultweight="$(df -P -k $osd_data/. | tail -1 | awk '{ print sprintf("%.4f",$2/1073741824) }')"


### PR DESCRIPTION
crush:  when osd_location_hook does not exist, we should exit error.

    If the user define "osd crush location hook" in ceph.conf, but the
    osd_location_hook tool does not exist, we should exit error.

Signed-off-by:song baisen <song.baisen@zte.com.cn>