### PR TITLE
rbd: remove direct linking to static boost libraries

### DIFF
--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -45,7 +45,6 @@ target_link_libraries(rbd librbd librados
   rbd_types
   journal
   ceph-common global
-  ${Boost_REGEX_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY}
   ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS})
 if(WITH_KRBD)
   target_link_libraries(rbd 

--- a/src/tools/rbd_nbd/CMakeLists.txt
+++ b/src/tools/rbd_nbd/CMakeLists.txt
@@ -1,4 +1,3 @@
 add_executable(rbd-nbd rbd-nbd.cc)
-target_link_libraries(rbd-nbd librbd librados global
-  ${Boost_REGEX_LIBRARY})
+target_link_libraries(rbd-nbd librbd librados global)
 install(TARGETS rbd-nbd DESTINATION bin)


### PR DESCRIPTION
The boost libraries are included in libceph-common. If linked
directly, boost::regex will abort during shutdown since it uses
a global static variable and it will be destructed twice.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>