### PR TITLE
os/bluestore: fix reclaim_blocks and clean up Allocator interface

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -35,13 +35,13 @@ public:
    * Apart from that extents can vary between these lower and higher limits according
    * to free block search algorithm and availability of contiguous space.
    */
-  virtual int allocate(uint64_t want_size, uint64_t alloc_unit,
-                       uint64_t max_alloc_size, int64_t hint,
-                       AllocExtentVector *extents, int *count, uint64_t *ret_len) = 0;
+  virtual int64_t allocate(uint64_t want_size, uint64_t alloc_unit,
+			   uint64_t max_alloc_size, int64_t hint,
+			   AllocExtentVector *extents, int *count) = 0;
 
   int allocate(uint64_t want_size, uint64_t alloc_unit,
-               int64_t hint, AllocExtentVector *extents, int *count, uint64_t *ret_len) {
-    return allocate(want_size, alloc_unit, want_size, hint, extents, count, ret_len);
+               int64_t hint, AllocExtentVector *extents, int *count) {
+    return allocate(want_size, alloc_unit, want_size, hint, extents, count);
   }
 
   virtual int release(

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -37,11 +37,11 @@ public:
    */
   virtual int64_t allocate(uint64_t want_size, uint64_t alloc_unit,
 			   uint64_t max_alloc_size, int64_t hint,
-			   AllocExtentVector *extents, int *count) = 0;
+			   AllocExtentVector *extents) = 0;
 
   int allocate(uint64_t want_size, uint64_t alloc_unit,
-               int64_t hint, AllocExtentVector *extents, int *count) {
-    return allocate(want_size, alloc_unit, want_size, hint, extents, count);
+               int64_t hint, AllocExtentVector *extents) {
+    return allocate(want_size, alloc_unit, want_size, hint, extents);
   }
 
   virtual int release(

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -47,17 +47,6 @@ public:
   virtual int release(
     uint64_t offset, uint64_t length) = 0;
 
-  virtual int release_extents(AllocExtentVector *extents, int count) {
-    int res = 0;
-      for (int i = 0; i < count; i++) {
-        res = release((*extents)[i].offset, (*extents)[i].length);
-        if (res != 0) {
-	  break;
-        }
-      }
-    return res;
-  }
-
   virtual void dump() = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -110,7 +110,7 @@ void BitMapAllocator::unreserve(uint64_t unused)
 
 int64_t BitMapAllocator::allocate(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count)
+  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents)
 {
 
   assert(!(alloc_unit % m_block_size));
@@ -125,23 +125,21 @@ int64_t BitMapAllocator::allocate(
      << dendl;
 
   return allocate_dis(want_size, alloc_unit / m_block_size,
-                      max_alloc_size, hint / m_block_size, extents, count);
+                      max_alloc_size, hint / m_block_size, extents);
 }
 
 int64_t BitMapAllocator::allocate_dis(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count)
+  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents)
 {
   ExtentList block_list = ExtentList(extents, m_block_size, max_alloc_size);
   int64_t nblks = (want_size + m_block_size - 1) / m_block_size;
   int64_t num = 0;
-  *count = 0;
 
   num = m_bit_alloc->alloc_blocks_dis_res(nblks, alloc_unit, hint, &block_list);
   if (num == 0) {
     return -ENOSPC;
   }
-  *count = block_list.get_extent_count();
 
   return num * m_block_size;
 }

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -108,9 +108,9 @@ void BitMapAllocator::unreserve(uint64_t unused)
   m_bit_alloc->unreserve_blocks(nblks);
 }
 
-int BitMapAllocator::allocate(
+int64_t BitMapAllocator::allocate(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len)
+  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count)
 {
 
   assert(!(alloc_unit % m_block_size));
@@ -125,27 +125,25 @@ int BitMapAllocator::allocate(
      << dendl;
 
   return allocate_dis(want_size, alloc_unit / m_block_size,
-                      max_alloc_size, hint / m_block_size, extents, count, ret_len); 
+                      max_alloc_size, hint / m_block_size, extents, count);
 }
 
-int BitMapAllocator::allocate_dis(
+int64_t BitMapAllocator::allocate_dis(
   uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len)
+  int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count)
 {
   ExtentList block_list = ExtentList(extents, m_block_size, max_alloc_size);
   int64_t nblks = (want_size + m_block_size - 1) / m_block_size;
   int64_t num = 0;
   *count = 0;
-  *ret_len = 0;
 
   num = m_bit_alloc->alloc_blocks_dis_res(nblks, alloc_unit, hint, &block_list);
   if (num == 0) {
     return -ENOSPC;
   }
   *count = block_list.get_extent_count();
-  *ret_len = num * m_block_size;
 
-  return 0;
+  return num * m_block_size;
 }
 
 int BitMapAllocator::release(

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -23,8 +23,7 @@ class BitMapAllocator : public Allocator {
 
   int64_t allocate_dis(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
-    int *count);
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents);
 
 public:
   BitMapAllocator(CephContext* cct, int64_t device_size, int64_t block_size);
@@ -35,8 +34,7 @@ public:
 
   int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
-    int *count);
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents);
 
   int release(
     uint64_t offset, uint64_t length);

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -21,8 +21,10 @@ class BitMapAllocator : public Allocator {
 
   void insert_free(uint64_t offset, uint64_t len);
 
-  int allocate_dis(uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-                        int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len);
+  int64_t allocate_dis(
+    uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
+    int *count);
 
 public:
   BitMapAllocator(CephContext* cct, int64_t device_size, int64_t block_size);
@@ -31,9 +33,10 @@ public:
   int reserve(uint64_t need);
   void unreserve(uint64_t unused);
 
-  int allocate(
+  int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len);
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
+    int *count);
 
   int release(
     uint64_t offset, uint64_t length);

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1769,8 +1769,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
 
   int count = 0;
   uint64_t alloc_len = 0;
-  AllocExtentVector extents = AllocExtentVector(left / min_alloc_size);
-
+  AllocExtentVector extents;
   r = alloc[id]->allocate(left, min_alloc_size, hint,
                           &extents, &count, &alloc_len);
   if (r < 0 || alloc_len < left) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -180,12 +180,10 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   int r = alloc[id]->reserve(want);
   assert(r == 0); // caller shouldn't ask for more than they can get
   int count = 0;
-  uint64_t got = 0;
-  r = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
-                          extents, &count, &got);
-
-  assert(r >= 0);
-  if (got < want)
+  int64_t got = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
+				    extents, &count);
+  assert(got > 0);
+  if (got < (int64_t)want)
     alloc[id]->unreserve(want - got);
 
   for (int i = 0; i < count; i++) {
@@ -1768,16 +1766,15 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   }
 
   int count = 0;
-  uint64_t alloc_len = 0;
   AllocExtentVector extents;
-  r = alloc[id]->allocate(left, min_alloc_size, hint,
-                          &extents, &count, &alloc_len);
-  if (r < 0 || alloc_len < left) {
+  int64_t alloc_len = alloc[id]->allocate(left, min_alloc_size, hint,
+                          &extents, &count);
+  if (alloc_len < (int64_t)left) {
     derr << __func__ << " allocate failed on 0x" << std::hex << left
 	 << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
     alloc[id]->dump();
     assert(0 == "allocate failed... wtf");
-    return r;
+    return -ENOSPC;
   }
 
   for (int i = 0; i < count; i++) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1765,6 +1765,7 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
   }
 
   AllocExtentVector extents;
+  extents.reserve(4);  // 4 should be (more than) enough for most allocations
   int64_t alloc_len = alloc[id]->allocate(left, min_alloc_size, hint,
                           &extents);
   if (alloc_len < (int64_t)left) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -179,17 +179,16 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   assert(alloc[id]);
   int r = alloc[id]->reserve(want);
   assert(r == 0); // caller shouldn't ask for more than they can get
-  int count = 0;
   int64_t got = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
-				    extents, &count);
+				    extents);
   assert(got > 0);
   if (got < (int64_t)want)
     alloc[id]->unreserve(want - got);
 
-  for (int i = 0; i < count; i++) {
-    block_all[id].erase((*extents)[i].offset, (*extents)[i].length);
-    block_total[id] -= (*extents)[i].length;
-    log_t.op_alloc_rm(id, (*extents)[i].offset, (*extents)[i].length);
+  for (auto& p : *extents) {
+    block_all[id].erase(p.offset, p.length);
+    block_total[id] -= p.length;
+    log_t.op_alloc_rm(id, p.offset, p.length);
   }
 
   r = _flush_and_sync_log(l);
@@ -1765,10 +1764,9 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     hint = ev->back().end();
   }
 
-  int count = 0;
   AllocExtentVector extents;
   int64_t alloc_len = alloc[id]->allocate(left, min_alloc_size, hint,
-                          &extents, &count);
+                          &extents);
   if (alloc_len < (int64_t)left) {
     derr << __func__ << " allocate failed on 0x" << std::hex << left
 	 << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
@@ -1777,8 +1775,8 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
     return -ENOSPC;
   }
 
-  for (int i = 0; i < count; i++) {
-    bluefs_extent_t e = bluefs_extent_t(id, extents[i].offset, extents[i].length);
+  for (auto& p : extents) {
+    bluefs_extent_t e = bluefs_extent_t(id, p.offset, p.length);
     if (!ev->empty() &&
 	ev->back().bdev == e.bdev &&
 	ev->back().end() == (uint64_t) e.offset) {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -187,6 +187,7 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   if (got <= 0) {
     derr << __func__ << " failed to allocate space to return to bluestore"
 	 << dendl;
+    alloc[id]->dump();
     return got;
   }
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -181,9 +181,14 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   assert(r == 0); // caller shouldn't ask for more than they can get
   int64_t got = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
 				    extents);
-  assert(got > 0);
-  if (got < (int64_t)want)
-    alloc[id]->unreserve(want - got);
+  if (got < (int64_t)want) {
+    alloc[id]->unreserve(want - MAX(0, got));
+  }
+  if (got <= 0) {
+    derr << __func__ << " failed to allocate space to return to bluestore"
+	 << dendl;
+    return got;
+  }
 
   for (auto& p : *extents) {
     block_all[id].erase(p.offset, p.length);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3810,8 +3810,9 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
 
     int count = 0;
     uint64_t alloc_len = 0;
-    AllocExtentVector exts = AllocExtentVector(gift / min_alloc_size);
-    r = alloc->allocate(gift, cct->_conf->bluefs_alloc_size, 0, 0, &exts, &count, &alloc_len);
+    AllocExtentVector exts;
+    r = alloc->allocate(gift, cct->_conf->bluefs_alloc_size, 0, 0, &exts,
+			&count, &alloc_len);
 
     if (r < 0 || alloc_len < gift) {
       derr << __func__ << " allocate failed on 0x" << std::hex << gift
@@ -8109,8 +8110,7 @@ int BlueStore::_do_alloc_write(
 
     int count = 0;
     uint64_t alloc_len = 0;
-    AllocExtentVector extents = AllocExtentVector(final_length / min_alloc_size);
-
+    AllocExtentVector extents;
     int r = alloc->allocate(final_length, min_alloc_size, max_alloc_size,
                             hint, &extents, &count, &alloc_len);
     assert(r == 0 && alloc_len == final_length);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3844,8 +3844,11 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
       AllocExtentVector extents;
       int r = bluefs->reclaim_blocks(bluefs_shared_bdev, reclaim,
 				     &extents);
-      assert(r >= 0);
-
+      if (r < 0) {
+	derr << __func__ << " failed to reclaim space from bluefs"
+	     << dendl;
+	break;
+      }
       for (auto e : extents) {
 	bluefs_extents.erase(e.offset, e.length);
 	bluefs_extents_reclaiming.insert(e.offset, e.length);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8105,6 +8105,7 @@ int BlueStore::_do_alloc_write(
     }
 
     AllocExtentVector extents;
+    extents.reserve(4);  // 4 should be (more than) enough for most allocations
     int64_t got = alloc->allocate(final_length, min_alloc_size, max_alloc_size,
                             hint, &extents);
     assert(got == (int64_t)final_length);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3808,10 +3808,9 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
     int r = alloc->reserve(gift);
     assert(r == 0);
 
-    int count = 0;
     AllocExtentVector exts;
     int64_t alloc_len = alloc->allocate(gift, cct->_conf->bluefs_alloc_size,
-					0, 0, &exts, &count);
+					0, 0, &exts);
 
     if (alloc_len < (int64_t)gift) {
       derr << __func__ << " allocate failed on 0x" << std::hex << gift
@@ -3820,10 +3819,8 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
       assert(0 == "allocate failed, wtf");
       return -ENOSPC;
     }
-    assert(count > 0);
-    
-    for (int i = 0; i < count; i++) {
-      bluestore_pextent_t e = bluestore_pextent_t(exts[i]);
+    for (auto& p : exts) {
+      bluestore_pextent_t e = bluestore_pextent_t(p);
       dout(1) << __func__ << " gifting " << e << " to bluefs" << dendl;
       extents->push_back(e);
     }
@@ -8107,10 +8104,9 @@ int BlueStore::_do_alloc_write(
       }
     }
 
-    int count = 0;
     AllocExtentVector extents;
     int64_t got = alloc->allocate(final_length, min_alloc_size, max_alloc_size,
-                            hint, &extents, &count);
+                            hint, &extents);
     assert(got == (int64_t)final_length);
     need -= got;
     txc->statfs_delta.allocated() += got;

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -83,7 +83,7 @@ static uint64_t aligned_len(btree_interval_set<uint64_t>::iterator p,
     return p.get_len() - skew;
 }
 
-int StupidAllocator::allocate_int(
+int64_t StupidAllocator::allocate_int(
   uint64_t want_size, uint64_t alloc_unit, int64_t hint,
   uint64_t *offset, uint32_t *length)
 {
@@ -201,14 +201,13 @@ int StupidAllocator::allocate_int(
   return 0;
 }
 
-int StupidAllocator::allocate(
+int64_t StupidAllocator::allocate(
   uint64_t want_size,
   uint64_t alloc_unit,
   uint64_t max_alloc_size,
   int64_t hint,
   mempool::bluestore_alloc::vector<AllocExtent> *extents,
-  int *count,
-  uint64_t *ret_len)
+  int *count)
 {
   uint64_t allocated_size = 0;
   uint64_t offset = 0;
@@ -219,7 +218,6 @@ int StupidAllocator::allocate(
     max_alloc_size = want_size;
   }
   *count = 0;
-  *ret_len = 0;
 
   ExtentList block_list = ExtentList(extents, 1, max_alloc_size);
 
@@ -238,12 +236,10 @@ int StupidAllocator::allocate(
   }
 
   *count = block_list.get_extent_count();
-  *ret_len = allocated_size;
   if (allocated_size == 0) {
     return -ENOSPC;
   }
-
-  return 0;
+  return allocated_size;
 }
 
 int StupidAllocator::release(

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -206,8 +206,7 @@ int64_t StupidAllocator::allocate(
   uint64_t alloc_unit,
   uint64_t max_alloc_size,
   int64_t hint,
-  mempool::bluestore_alloc::vector<AllocExtent> *extents,
-  int *count)
+  mempool::bluestore_alloc::vector<AllocExtent> *extents)
 {
   uint64_t allocated_size = 0;
   uint64_t offset = 0;
@@ -217,7 +216,6 @@ int64_t StupidAllocator::allocate(
   if (max_alloc_size == 0) {
     max_alloc_size = want_size;
   }
-  *count = 0;
 
   ExtentList block_list = ExtentList(extents, 1, max_alloc_size);
 
@@ -235,7 +233,6 @@ int64_t StupidAllocator::allocate(
     hint = offset + length;
   }
 
-  *count = block_list.get_extent_count();
   if (allocated_size == 0) {
     return -ENOSPC;
   }

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -33,8 +33,7 @@ public:
 
   int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
-    int *count);
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents);
 
   int64_t allocate_int(
     uint64_t want_size, uint64_t alloc_unit, int64_t hint,

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -31,11 +31,12 @@ public:
   int reserve(uint64_t need);
   void unreserve(uint64_t unused);
 
-  int allocate(
+  int64_t allocate(
     uint64_t want_size, uint64_t alloc_unit, uint64_t max_alloc_size,
-    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents, int *count, uint64_t *ret_len);
+    int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents,
+    int *count);
 
-  int allocate_int(
+  int64_t allocate_int(
     uint64_t want_size, uint64_t alloc_unit, int64_t hint,
     uint64_t *offset, uint32_t *length);
 

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -21,8 +21,8 @@ void ExtentList::add_extents(int64_t start, int64_t count) {
   AllocExtent *last_extent = NULL;
   bool can_merge = false;
 
-  if (m_num_extents > 0) {
-    last_extent = &((*m_extents)[m_num_extents - 1]);
+  if (!m_extents->empty()) {
+    last_extent = &(m_extents->back());
     uint64_t last_offset = last_extent->end() / m_block_size;
     uint32_t last_length = last_extent->length / m_block_size;
     if ((last_offset == (uint64_t) start) &&
@@ -34,11 +34,9 @@ void ExtentList::add_extents(int64_t start, int64_t count) {
   if (can_merge) {
     last_extent->length += (count * m_block_size);
   } else {
-    (*m_extents)[m_num_extents].offset = start * m_block_size;
-    (*m_extents)[m_num_extents].length = count * m_block_size;
-    m_num_extents++;
+    m_extents->emplace_back(AllocExtent(start * m_block_size,
+					count * m_block_size));
   }
-  assert((int64_t) m_extents->size() >= m_num_extents);
 }
 
 // bluestore_bdev_label_t

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -86,28 +86,29 @@ inline static ostream& operator<<(ostream& out, const AllocExtent& e) {
 
 class ExtentList {
   AllocExtentVector *m_extents;
-  int64_t m_num_extents;
   int64_t m_block_size;
   int64_t m_max_blocks;
 
 public:
-  void init(AllocExtentVector *extents, int64_t block_size, uint64_t max_alloc_size) {
+  void init(AllocExtentVector *extents, int64_t block_size,
+	    uint64_t max_alloc_size) {
     m_extents = extents;
-    m_num_extents = 0;
     m_block_size = block_size;
     m_max_blocks = max_alloc_size / block_size;
+    assert(m_extents->empty());
   }
 
   ExtentList(AllocExtentVector *extents, int64_t block_size) {
     init(extents, block_size, 0);
   }
 
-  ExtentList(AllocExtentVector *extents, int64_t block_size, uint64_t max_alloc_size) {
+  ExtentList(AllocExtentVector *extents, int64_t block_size,
+	     uint64_t max_alloc_size) {
     init(extents, block_size, max_alloc_size);
   }
 
   void reset() {
-    m_num_extents = 0;
+    m_extents->clear();
   }
 
   void add_extents(int64_t start, int64_t count);
@@ -123,7 +124,7 @@ public:
   }
 
   int64_t get_extent_count() {
-    return m_num_extents;
+    return m_extents->size();
   }
 };
 

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -52,18 +52,14 @@ TEST_P(AllocTest, test_alloc_min_alloc)
 {
   int64_t block_size = 1024;
   int64_t blocks = BitMapZone::get_total_blocks() * 2 * block_size;
-  int count = 0;
-  uint64_t alloc_len = 0;
 
   {
     init_alloc(blocks, block_size);
     alloc->init_add_free(block_size, block_size);
     EXPECT_EQ(alloc->reserve(block_size), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (1, AllocExtent(0, 0));
-    EXPECT_EQ(alloc->allocate(block_size, block_size, 
-                                   0, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(alloc_len, (uint64_t) block_size);
+    AllocExtentVector extents;
+    EXPECT_EQ(block_size, alloc->allocate(block_size, block_size,
+					  0, (int64_t) 0, &extents));
   }
 
   /*
@@ -72,15 +68,12 @@ TEST_P(AllocTest, test_alloc_min_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (4, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size, 
-                                   0, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(alloc_len, 4 * (uint64_t) block_size);
+    AllocExtentVector extents;
+    EXPECT_EQ(4*block_size,
+	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
+			      0, (int64_t) 0, &extents));
+    EXPECT_EQ(1u, extents.size());
     EXPECT_EQ(extents[0].length, 4 * block_size);
-    EXPECT_EQ(0U, extents[1].length);
-    EXPECT_EQ(count, 1);
   }
 
   /*
@@ -90,16 +83,14 @@ TEST_P(AllocTest, test_alloc_min_alloc)
     alloc->init_add_free(0, block_size * 2);
     alloc->init_add_free(3 * block_size, block_size * 2);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (4, AllocExtent(0, 0));
+    AllocExtentVector extents;
   
-    EXPECT_EQ(alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size, 
-                                   0, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(alloc_len, 4 * (uint64_t) block_size);
+    EXPECT_EQ(4*block_size,
+	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
+			      0, (int64_t) 0, &extents));
+    EXPECT_EQ(2u, extents.size());
     EXPECT_EQ(extents[0].length, 2 * block_size);
     EXPECT_EQ(extents[1].length, 2 * block_size);
-    EXPECT_EQ(0U, extents[2].length);
-    EXPECT_EQ(count, 2);
   }
   alloc->shutdown();
 }
@@ -108,8 +99,6 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
 {
   int64_t block_size = 1024;
   int64_t blocks = BitMapZone::get_total_blocks() * 2 * block_size;
-  int count = 0;
-  uint64_t alloc_len = 0;
 
   init_alloc(blocks, block_size);
 
@@ -120,16 +109,14 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (4, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size, 
-                                   block_size, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(alloc_len, 4 * (uint64_t) block_size);
-    for (int i = 0; i < 4; i++) {
-      EXPECT_EQ(extents[i].length, block_size);
+    AllocExtentVector extents;
+    EXPECT_EQ(4*block_size,
+	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
+			      block_size, (int64_t) 0, &extents));
+    for (auto e : extents) {
+      EXPECT_EQ(e.length, block_size);
     }
-    EXPECT_EQ(count, 4);
+    EXPECT_EQ(4u, extents.size());
   }
 
 
@@ -140,16 +127,14 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 4);
     EXPECT_EQ(alloc->reserve(block_size * 4), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (2, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size, 
-                                   2 * block_size, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(alloc_len, 4 * (uint64_t) block_size);
-    for (int i = 0; i < 2; i++) {
-      EXPECT_EQ(extents[i].length, block_size * 2);
+    AllocExtentVector extents;
+    EXPECT_EQ(4*block_size,
+	      alloc->allocate(4 * (uint64_t)block_size, (uint64_t) block_size,
+			      2 * block_size, (int64_t) 0, &extents));
+    EXPECT_EQ(2u, extents.size());
+    for (auto& e : extents) {
+      EXPECT_EQ(e.length, block_size * 2);
     }
-    EXPECT_EQ(count, 2);
   }
 
   /*
@@ -158,17 +143,15 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 1024);
     EXPECT_EQ(alloc->reserve(block_size * 1024), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (1024, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(1024 * (uint64_t)block_size, (uint64_t) block_size * 4, 
-                                   block_size * 4, (int64_t) 0, &extents, &count, &alloc_len), 0);
- 
-    EXPECT_EQ(alloc_len, 1024 * (uint64_t) block_size);
-    for (int i = 0; i < count; i++) {
-      EXPECT_EQ(extents[i].length, block_size * 4);
+    AllocExtentVector extents;
+    EXPECT_EQ(1024 * block_size,
+	      alloc->allocate(1024 * (uint64_t)block_size,
+			      (uint64_t) block_size * 4,
+			      block_size * 4, (int64_t) 0, &extents));
+    for (auto& e : extents) {
+      EXPECT_EQ(e.length, block_size * 4);
     }
-    EXPECT_EQ(count, 1024 / 4);
+    EXPECT_EQ(1024u/4, extents.size());
   }
 
   /*
@@ -177,16 +160,14 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
   {
     alloc->init_add_free(0, block_size * 16);
     EXPECT_EQ(alloc->reserve(block_size * 16), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (8, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(16 * (uint64_t)block_size, (uint64_t) block_size, 
-                                   2 * block_size, (int64_t) 0, &extents, &count, &alloc_len), 0);
+    AllocExtentVector extents;
+    EXPECT_EQ(16 * block_size,
+	      alloc->allocate(16 * (uint64_t)block_size, (uint64_t) block_size,
+			      2 * block_size, (int64_t) 0, &extents));
 
-    EXPECT_EQ(count, 8);
-    EXPECT_EQ(alloc_len, 16 * (uint64_t) block_size);
-    for (int i = 0; i < 8; i++) {
-      EXPECT_EQ(extents[i].length, 2 * block_size);
+    EXPECT_EQ(extents.size(), 8u);
+    for (auto& e : extents) {
+      EXPECT_EQ(e.length, 2 * block_size);
     }
     EXPECT_EQ(alloc->release_extents(&extents, count), 0);
   }
@@ -196,8 +177,6 @@ TEST_P(AllocTest, test_alloc_failure)
 {
   int64_t block_size = 1024;
   int64_t blocks = BitMapZone::get_total_blocks() * block_size;
-  int count = 0;
-  uint64_t alloc_len = 0;
 
   init_alloc(blocks, block_size);
   {
@@ -205,18 +184,18 @@ TEST_P(AllocTest, test_alloc_failure)
     alloc->init_add_free(block_size * 512, block_size * 256);
 
     EXPECT_EQ(alloc->reserve(block_size * 512), 0);
-    AllocExtentVector extents = AllocExtentVector 
-                        (4, AllocExtent(0, 0));
-  
-    EXPECT_EQ(alloc->allocate(512 * (uint64_t)block_size, (uint64_t) block_size * 256, 
-                                   block_size * 256, (int64_t) 0, &extents, &count, &alloc_len), 0);
-    EXPECT_EQ(512 * (uint64_t)block_size, alloc_len);
+    AllocExtentVector extents;
+    EXPECT_EQ(512 * block_size,
+	      alloc->allocate(512 * (uint64_t)block_size,
+			      (uint64_t) block_size * 256,
+			      block_size * 256, (int64_t) 0, &extents));
     alloc->init_add_free(0, block_size * 256);
     alloc->init_add_free(block_size * 512, block_size * 256);
     EXPECT_EQ(alloc->reserve(block_size * 512), 0);
-    EXPECT_EQ(alloc->allocate(512 * (uint64_t)block_size, (uint64_t) block_size * 512,
-                                   block_size * 512, (int64_t) 0, &extents, &count, &alloc_len), -ENOSPC);
-    EXPECT_EQ(alloc_len, (uint64_t) 0);
+    EXPECT_EQ(-ENOSPC,
+	      alloc->allocate(512 * (uint64_t)block_size,
+			      (uint64_t) block_size * 512,
+			      block_size * 512, (int64_t) 0, &extents));
   }
 }
 
@@ -226,44 +205,39 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
     return;
   }
   int64_t blocks = BitMapArea::get_level_factor(g_ceph_context, 2) * 4;
-  int count = 0;
   int64_t allocated = 0;
   int64_t zone_size = 1024;
-  uint64_t alloc_len = 0;
-  g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", std::to_string(zone_size));
+  g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone",
+		  std::to_string(zone_size));
 
   init_alloc(blocks, 1);
   alloc->init_add_free(0, blocks);
 
-  auto extents = AllocExtentVector
-          (zone_size * 4, AllocExtent(-1, -1));
+  AllocExtentVector extents;
   alloc->reserve(blocks);
 
-  allocated = alloc->allocate(1, 1, 1, zone_size, &extents, &count, &alloc_len);
-  ASSERT_EQ(0, allocated);
-  ASSERT_EQ((uint64_t) 1, alloc_len);
-  ASSERT_EQ(1, count);
+  allocated = alloc->allocate(1, 1, 1, zone_size, &extents);
+  ASSERT_EQ(1, allocated);
+  ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(extents[0].offset, (uint64_t) zone_size);
 
-  allocated = alloc->allocate(1, 1, 1, zone_size * 2 - 1, &extents, &count, &alloc_len);
-  ASSERT_EQ((uint64_t) 1, alloc_len);
-  EXPECT_EQ(0, allocated);
-  ASSERT_EQ(1, count);
+  allocated = alloc->allocate(1, 1, 1, zone_size * 2 - 1, &extents);
+  EXPECT_EQ(1, allocated);
+  ASSERT_EQ(1u, extents.size());
   EXPECT_EQ((int64_t) extents[0].offset, zone_size * 2 - 1);
 
   /*
    * Wrap around with hint
    */
-  allocated = alloc->allocate(zone_size * 2, 1, 1,  blocks - zone_size * 2, &extents, &count, &alloc_len);
-  EXPECT_EQ(0, allocated);
-  ASSERT_EQ((uint64_t) zone_size * 2, alloc_len);
-  EXPECT_EQ(zone_size * 2, count);
+  allocated = alloc->allocate(zone_size * 2, 1, 1,  blocks - zone_size * 2,
+			      &extents);
+  ASSERT_EQ(zone_size * 2, allocated);
+  EXPECT_EQ(zone_size * 2, (int)extents.size());
   EXPECT_EQ((int64_t)extents[0].offset, blocks - zone_size * 2);
 
-  allocated = alloc->allocate(zone_size, 1, 1, blocks - zone_size, &extents, &count, &alloc_len);
-  EXPECT_EQ(0, allocated);
-  ASSERT_EQ((uint64_t) zone_size, alloc_len);
-  EXPECT_EQ(zone_size, count);
+  allocated = alloc->allocate(zone_size, 1, 1, blocks - zone_size, &extents);
+  ASSERT_EQ(zone_size, allocated);
+  EXPECT_EQ(zone_size, (int)extents.size());
   EXPECT_EQ(extents[0].offset, (uint64_t) 0);
 }
 

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -169,7 +169,6 @@ TEST_P(AllocTest, test_alloc_min_max_alloc)
     for (auto& e : extents) {
       EXPECT_EQ(e.length, 2 * block_size);
     }
-    EXPECT_EQ(alloc->release_extents(&extents, count), 0);
   }
 }
 

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -190,6 +190,7 @@ TEST_P(AllocTest, test_alloc_failure)
 			      block_size * 256, (int64_t) 0, &extents));
     alloc->init_add_free(0, block_size * 256);
     alloc->init_add_free(block_size * 512, block_size * 256);
+    extents.clear();
     EXPECT_EQ(alloc->reserve(block_size * 512), 0);
     EXPECT_EQ(-ENOSPC,
 	      alloc->allocate(512 * (uint64_t)block_size,
@@ -220,6 +221,7 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
   ASSERT_EQ(1u, extents.size());
   ASSERT_EQ(extents[0].offset, (uint64_t) zone_size);
 
+  extents.clear();
   allocated = alloc->allocate(1, 1, 1, zone_size * 2 - 1, &extents);
   EXPECT_EQ(1, allocated);
   ASSERT_EQ(1u, extents.size());
@@ -228,12 +230,14 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
   /*
    * Wrap around with hint
    */
+  extents.clear();
   allocated = alloc->allocate(zone_size * 2, 1, 1,  blocks - zone_size * 2,
 			      &extents);
   ASSERT_EQ(zone_size * 2, allocated);
   EXPECT_EQ(zone_size * 2, (int)extents.size());
   EXPECT_EQ((int64_t)extents[0].offset, blocks - zone_size * 2);
 
+  extents.clear();
   allocated = alloc->allocate(zone_size, 1, 1, blocks - zone_size, &extents);
   ASSERT_EQ(zone_size, allocated);
   EXPECT_EQ(zone_size, (int)extents.size());


### PR DESCRIPTION
This evolved into something truly ugly, and reclaim_blocks managed to misuse
it.  Fix and clean.