### PR TITLE
rgw_file:  split last argv on ws, if provided

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -647,7 +647,18 @@ int librgw_create(librgw_t* rgw, int argc, char **argv)
     std::lock_guard<std::mutex> lg(librgw_mtx);
     if (! g_ceph_context) {
       vector<const char*> args;
+      std::vector<std::string> spl_args;
+      // last non-0 argument will be split and consumed
+      if (argc > 1) {
+	const std::string spl_arg{argv[(--argc)]};
+	get_str_vec(spl_arg, " \t", spl_args);
+      }
       argv_to_vec(argc, const_cast<const char**>(argv), args);
+      // append split args, if any
+      for (const auto& elt : spl_args) {
+	args.push_back(elt.c_str());
+      }
+      env_to_vec(args);
       rc = rgwlib.init(args);
     }
   }


### PR DESCRIPTION
This is intended to allow an "extra" unparsed argument string
containing various cmdline options to be passed as the last argument
in the argv array of librgw_create(), which nfs-ganesha is
expecting to happen.

While at it, hook env_args() too.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>