### PR TITLE
osdc: cache should ignore error bhs during trim

### DIFF
--- a/src/osdc/ObjectCacher.cc
+++ b/src/osdc/ObjectCacher.cc
@@ -1234,7 +1234,7 @@ void ObjectCacher::trim()
       break;
 
     ldout(cct, 10) << "trim trimming " << *bh << dendl;
-    assert(bh->is_clean() || bh->is_zero());
+    assert(bh->is_clean() || bh->is_zero() || bh->is_error());
 
     Object *ob = bh->ob;
     bh_remove(ob, bh);


### PR DESCRIPTION
A read error (such as injecting a timeout into an OSD op) might result
in a bh in an error state. These should be trimable by the cache.

Fixes: http://tracker.ceph.com/issues/18436
Signed-off-by: Jason Dillaman <dillaman@redhat.com>