### PR TITLE
[DNM] osd/PG: Remove redundant advmap reaction

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7592,20 +7592,6 @@ PG::RecoveryState::Incomplete::Incomplete(my_context ctx)
   pg->publish_stats_to_osd();
 }
 
-boost::statechart::result PG::RecoveryState::Incomplete::react(const AdvMap &advmap) {
-  PG *pg = context< RecoveryMachine >().pg;
-  int64_t poolnum = pg->info.pgid.pool();
-
-  // Reset if min_size turn smaller than previous value, pg might now be able to go active
-  if (advmap.lastmap->get_pools().find(poolnum)->second.min_size >
-      advmap.osdmap->get_pools().find(poolnum)->second.min_size) {
-    post_event(advmap);
-    return transit< Reset >();
-  }
-
-  return forward_event();
-}
-
 boost::statechart::result PG::RecoveryState::Incomplete::react(const MNotifyRec& notevt) {
   PG *pg = context< RecoveryMachine >().pg;
   ldout(pg->cct, 7) << "handle_pg_notify from osd." << notevt.from << dendl;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2019,12 +2019,10 @@ public:
 
     struct Incomplete : boost::statechart::state< Incomplete, Peering>, NamedState {
       typedef boost::mpl::list <
-	boost::statechart::custom_reaction< AdvMap >,
 	boost::statechart::custom_reaction< MNotifyRec >,
 	boost::statechart::custom_reaction< QueryState >
 	> reactions;
       explicit Incomplete(my_context ctx);
-      boost::statechart::result react(const AdvMap &advmap);
       boost::statechart::result react(const MNotifyRec& infoevt);
       boost::statechart::result react(const QueryState& infoevt);
       void exit();


### PR DESCRIPTION
In the Incomplete state there is no longer any reason to check for a
min_size reduction in an advancing map as a reduction in min_size has no
bearing on whether we can recover from Incomplete.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>