### PR TITLE
mds: fix incorrect assertion in Server::_dir_is_nonempty()

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -6098,7 +6098,7 @@ bool Server::_dir_is_nonempty(MDRequestRef& mdr, CInode *in)
 {
   dout(10) << "dir_is_nonempty " << *in << dendl;
   assert(in->is_auth());
-  assert(in->filelock.can_read(-1));
+  assert(in->filelock.can_read(mdr->get_client()));
 
   frag_info_t dirstat;
   version_t dirstat_version = in->get_projected_inode()->dirstat.version;


### PR DESCRIPTION
when filelock is in XLOCKDONE state. client of xlocker can rdlock
the filelock. In that case, only client of xlocker can read the lock.

Signed-off-by: Yan, Zheng <zyan@redhat.com>