### PR TITLE
osd/OSDMap: get_previous_up_osd_before() may run into endless loop

### DIFF
--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -525,6 +525,8 @@ public:
   }
   
   int get_next_up_osd_after(int n) const {
+    if (get_max_osd() == 0)
+      return -1;
     for (int i = n + 1; i != n; ++i) {
       if (i >= get_max_osd())
 	i = 0;
@@ -537,6 +539,8 @@ public:
   }
 
   int get_previous_up_osd_before(int n) const {
+    if (get_max_osd() == 0)
+      return -1;
     for (int i = n - 1; i != n; --i) {
       if (i < 0)
 	i = get_max_osd() - 1;


### PR DESCRIPTION
make get prev/next up osd more efficient
what's more, in get_previous_up_osd_before(), if arg n = 0, run into endless loop

Signed-off-by: Mingxin Liu <mingxin@xsky.com>