### PR TITLE
script: ceph-release-notes check orig. issue only for backports

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -154,7 +154,8 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
             pr2info[number] = (author, title, message)
 
             for issue in set(issues):
-                issue = get_original_issue(issue, verbose)
+                if strict:
+                    issue = get_original_issue(issue, verbose)
                 issue2prs.setdefault(issue, set([])).add(number)
                 pr2issues.setdefault(number, set([])).add(issue)
             sys.stdout.write('.')


### PR DESCRIPTION
Avoid querying the redmine api which can be expensive for calls not
passing --strict parameter, this is useful for backport projects not
necessary for normal releases, and saves significant time

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>