### PR TITLE
mon/OSDMonitor: make 'osd crush move ...' work on osds

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -74,11 +74,16 @@ ceph osd crush rm foo
 ceph osd crush rm osd.$o2 host2
 ceph osd crush rm host2
 
+ceph osd crush add-bucket foo host
+ceph osd crush move foo root=default rack=localrack
+
+ceph osd crush create-or-move osd.$o1 1.0 root=default
+ceph osd crush move osd.$o1 host=foo
+ceph osd find osd.$o1 | grep host | grep foo
+
 ceph osd crush rm osd.$o1
 ceph osd crush rm osd.$o2
 
-ceph osd crush add-bucket foo host
-ceph osd crush move foo root=default rack=localrack
 ceph osd crush rm foo
 
 # test reweight

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5933,7 +5933,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       int id = newcrush.get_item_id(name);
 
       if (!newcrush.check_item_loc(g_ceph_context, id, loc, (int *)NULL)) {
-	err = newcrush.move_bucket(g_ceph_context, id, loc);
+	if (id >= 0) {
+	  err = newcrush.create_or_move_item(g_ceph_context, id, 0, name, loc);
+	} else {
+	  err = newcrush.move_bucket(g_ceph_context, id, loc);
+	}
 	if (err >= 0) {
 	  ss << "moved item id " << id << " name '" << name << "' to location " << loc << " in crush map";
 	  pending_inc.crush.clear();


### PR DESCRIPTION
Currently it only allows you to move buckets, which is annoying and much
less useful.  To move an OSD you need to use create-or-move, which is
harder to use.

http://tracker.ceph.com/issues/18587