### PR TITLE
allow read caps for mds when authorizing a fs volume

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1028,7 +1028,7 @@ class CephFSVolumeClient(object):
         # permissions to access the share
         client_entity = "client.{0}".format(auth_id)
         want_access_level = 'r' if readonly else 'rw'
-        want_mds_cap = 'allow {0} path={1}'.format(want_access_level, path)
+        want_mds_cap = 'allow r,allow {0} path={1}'.format(want_access_level, path)
         want_osd_cap = 'allow {0} pool={1} namespace={2}'.format(
             want_access_level, pool_name, namespace)
 


### PR DESCRIPTION
This is to fix http://tracker.ceph.com/issues/18589

@jcsp 