### PR TITLE
t/common/CMakeLists.txt: backtrace output does not match regex on FreeBSD

### DIFF
--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -218,6 +218,7 @@ target_link_libraries(unittest_dns_resolve global)
 add_ceph_unittest(unittest_dns_resolve
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_dns_resolve)
 
+if(NOT FREEBSD)
 add_executable(unittest_back_trace
   test_back_trace.cc)
 set_source_files_properties(test_back_trace.cc PROPERTIES
@@ -225,3 +226,5 @@ set_source_files_properties(test_back_trace.cc PROPERTIES
 target_link_libraries(unittest_back_trace ceph-common)
 add_ceph_unittest(unittest_back_trace
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_back_trace)
+endif()
+


### PR DESCRIPTION
 -the  output on FreeBSD/Clang looks like:
 ```ceph version Development (no_version)
 1: 0x44bfb3 <_Z3foov+0x413> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 2: 0x44c23e <_ZN20BackTrace_Basic_Test8TestBodyEv+0x1e> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 3: 0x4d068a <_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x7a> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 4: 0x4b5977 <_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x77> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 5: 0x484c25 <_ZN7testing4Test3RunEv+0xc5> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 6: 0x486108 <_ZN7testing8TestInfo3RunEv+0xd8> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 7: 0x486c87 <_ZN7testing8TestCase3RunEv+0xe7> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 8: 0x49489c <_ZN7testing8internal12UnitTestImpl11RunAllTestsEv+0x39c> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 9: 0x4d40da <_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x7a> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 10: 0x4b8207 <_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS0_12UnitTestImplEbEET0_PT_MS4_FS3_vEPKc+0x77> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 11: 0x49449b <_ZN7testing8UnitTest3RunEv+0x19b> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 12: 0x4da161 <_Z13RUN_ALL_TESTSv+0x11> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
 13: 0x4da145 <main+0x45> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>