### PR TITLE
common/BackTrace: demangle on FreeBSD also

### DIFF
--- a/src/test/common/test_back_trace.cc
+++ b/src/test/common/test_back_trace.cc
@@ -33,9 +33,14 @@ TEST(BackTrace, Basic) {
   boost::split(lines, bt, boost::is_any_of("\n"));
   const unsigned lineno = 1;
   ASSERT_GT(lines.size(), lineno);
-  ASSERT_EQ(lines[0].find(pretty_version_to_str()), 1);
+  ASSERT_EQ(lines[0].find(pretty_version_to_str()), 1U);
   boost::regex e{"^ 1: "
+#ifdef __FreeBSD__
+		 "<foo.*>\\s"
+		 "at\\s.*$"};
+#else
 		 "\\(foo.*\\)\\s"
 		 "\\[0x[[:xdigit:]]+\\]$"};
+#endif
   EXPECT_TRUE(boost::regex_match(lines[lineno], e));
 }


### PR DESCRIPTION
the output on FreeBSD/clang looks like:

1: 0x44bfb3 <_Z3foov+0x413> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
2: 0x44c23e <_ZN20BackTrace_Basic_Test8TestBodyEv+0x1e> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
3: 0x4d068a <_ZN7testing8internal38HandleSehExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x7a> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
4: 0x4b5977 <_ZN7testing8internal35HandleExceptionsInMethodIfSupportedINS_4TestEvEET0_PT_MS4_FS3_vEPKc+0x77> at /usr/srcs/Ceph/work/ceph/build/bin/unittest_back_trace
...

and update the test accordingly, as FreeBSD/clang uses '<>' to enclose
the mangled function and offset.

Signed-off-by: Kefu Chai <kchai@redhat.com>