### PR TITLE
mds: add authority check for delay dirfrag split

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -400,6 +400,10 @@ void MDBalancer::queue_split(const CDir *dir, bool fast)
       dout(10) << "drop split on " << frag << " because not in cache" << dendl;
       return;
     }
+    if (!split_dir->is_auth()) {
+      dout(10) << "drop split on " << frag << " because non-auth" << dendl;
+      return;
+    }
 
     // Pass on to MDCache: note that the split might still not
     // happen if the checks in MDCache::can_fragment fail.


### PR DESCRIPTION
the dirfrag can be migareted to other mds while waiting in the
timer.

Fixes: http://tracker.ceph.com/issues/18487
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>