### PR TITLE
common: fix that $host always expands to localhost instead of actual hostname

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -505,6 +505,7 @@ set(libcommon_files
   common/Graylog.cc
   common/fs_types.cc
   common/dns_resolve.cc
+  common/hostname.cc
   ${arch_files}
   ${auth_files}
   ${mds_files})

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -27,6 +27,7 @@
 #include "msg/msg_types.h"
 #include "osd/osd_types.h"
 #include "common/errno.h"
+#include "common/hostname.h"
 
 #include "include/assert.h"
 
@@ -1267,9 +1268,14 @@ bool md_config_t::expand_meta(std::string &origval,
 	else if (var == "cluster")
 	  out += cluster;
 	else if (var == "name")
-	  out += name.to_cstr();
+          out += name.to_cstr();
 	else if (var == "host")
-	  out += host;
+        {
+          if (host == "")
+            out += ceph_get_short_hostname();
+          else
+	    out += host;
+        }
 	else if (var == "num")
 	  out += name.get_id().c_str();
 	else if (var == "id")

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -13,7 +13,7 @@
  */
 
 /* note: no header guard */
-OPTION(host, OPT_STR, "localhost")
+OPTION(host, OPT_STR, "") // "" means that ceph will use short hostname
 OPTION(fsid, OPT_UUID, uuid_d())
 OPTION(public_addr, OPT_ADDR, entity_addr_t())
 OPTION(cluster_addr, OPT_ADDR, entity_addr_t())

--- a/src/common/hostname.cc
+++ b/src/common/hostname.cc
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/hostname.h"
+
+#include <string>
+#include <unistd.h>
+
+std::string ceph_get_hostname()
+{
+  char buf[1024];
+  gethostname(buf, 1024);
+  return std::string(buf);
+}
+
+std::string ceph_get_short_hostname()
+{
+  std::string hostname = ceph_get_hostname();
+  size_t pos = hostname.find('.');
+  if (pos == std::string::npos)
+  {
+    return hostname;
+  }
+  else
+  {
+    return hostname.substr(0, pos);
+  }
+}

--- a/src/common/hostname.h
+++ b/src/common/hostname.h
@@ -1,0 +1,22 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_COMMON_HOSTNAME_H
+#define CEPH_COMMON_HOSTNAME_H
+
+#include <string>
+
+extern std::string ceph_get_hostname();
+extern std::string ceph_get_short_hostname();
+#endif

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -120,6 +120,7 @@ target_link_libraries(unittest_crc32c global)
 # unittest_config
 add_executable(unittest_config
   test_config.cc
+  test_hostname.cc
   )
 add_ceph_unittest(unittest_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_config)
 target_link_libraries(unittest_config global)
@@ -225,3 +226,9 @@ set_source_files_properties(test_back_trace.cc PROPERTIES
 target_link_libraries(unittest_back_trace ceph-common)
 add_ceph_unittest(unittest_back_trace
   ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_back_trace)
+
+add_executable(unittest_hostname
+    test_hostname.cc)
+target_link_libraries(unittest_hostname ceph-common)
+add_ceph_unittest(unittest_hostname
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_hostname)

--- a/src/test/common/test_hostname.cc
+++ b/src/test/common/test_hostname.cc
@@ -1,0 +1,55 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "gtest/gtest.h"
+#include "common/hostname.h"
+#include "common/SubProcess.h"
+#include "stdio.h"
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#include "unistd.h"
+
+#include <string>
+#include <iostream>
+#include <stdexcept>
+#include <stdio.h>
+#include <string>
+#include <memory>
+
+std::string exec(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) throw std::runtime_error("popen() failed!");
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != NULL)
+            result += buffer.data();
+    }
+    // remove \n
+    return result.substr(0, result.size()-1);;
+}
+
+TEST(Hostname, full) {
+  std::string hn = ceph_get_hostname();
+  ASSERT_EQ(hn, exec("hostname")) ;
+
+	
+}
+
+TEST(Hostname, short) {
+  std::string shn = ceph_get_short_hostname();
+  ASSERT_EQ(shn, exec("hostname -s")) ;
+}


### PR DESCRIPTION

* add function : ceph_get_hostname, ceph_get_short_hostname
* add unittest for hostname function
* expand $host in config.cc

TODO: update documentation about this feature

Fixes: http://tracker.ceph.com/issues/11081

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>