### PR TITLE
osd: may trim log on some peers

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1565,6 +1565,15 @@ void PrimaryLogPG::calc_trim_to()
     pg_trim_to = new_trim_to;
     assert(pg_trim_to <= pg_log.get_head());
     assert(pg_trim_to <= min_last_complete_ondisk);
+  } else if (pg_trim_to == eversion_t()) {
+    // may trim log on peers
+    eversion_t new_trim_to = MIN(
+      pg_log.get_log().log.begin()->version,
+      limit);
+    dout(10) << "calc_trim_to " << pg_trim_to << " -> " << new_trim_to << dendl;
+    pg_trim_to = new_trim_to;
+    assert(pg_trim_to <= pg_log.get_head());
+    assert(pg_trim_to <= min_last_complete_ondisk);
   }
 }
 


### PR DESCRIPTION
pg_trim_to is set to eversion_t() after peering. Primary won't
initiate pg log trim until reaching max pg log entries if the
pg is under recovering. But the number of log entries on some
peers may exceeds the specified max number of log entries a lot.
This becomes severe when the peers continuously go down/up.
Trim the logs on those peers to either min_last_complete_on_disk
or the log_tail version on primary in this case.

Signed-off-by: Zhiqiang Wang <zhiqiang@xsky.com>