### PR TITLE
os/bluestore: fix Allocator::allocate() int truncation

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -39,8 +39,8 @@ public:
 			   uint64_t max_alloc_size, int64_t hint,
 			   AllocExtentVector *extents) = 0;
 
-  int allocate(uint64_t want_size, uint64_t alloc_unit,
-               int64_t hint, AllocExtentVector *extents) {
+  int64_t allocate(uint64_t want_size, uint64_t alloc_unit,
+		   int64_t hint, AllocExtentVector *extents) {
     return allocate(want_size, alloc_unit, want_size, hint, extents);
   }
 


### PR DESCRIPTION
Introduced in 5ab034345d7320fbc86a2133c0c29ec1aca4b71a.

Fixes: http://tracker.ceph.com/issues/18595
Signed-off-by: Sage Weil <sage@redhat.com>