### PR TITLE
os/bluestore: remove no used parameter in bluestore_blob_t::map_bl

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7691,7 +7691,7 @@ void BlueStore::_do_write_small(
       if (!g_conf->bluestore_debug_omit_block_device_write) {
         b->get_blob().map_bl(
 	  b_off, padded,
-	  [&](uint64_t offset, uint64_t length, bufferlist& t) {
+	  [&](uint64_t offset, bufferlist& t) {
 	    bdev->aio_write(offset, t,
 			    &txc->ioc, wctx->buffered);
 	  });
@@ -8017,7 +8017,7 @@ int BlueStore::_do_alloc_write(
     if (!g_conf->bluestore_debug_omit_block_device_write) {
       b->get_blob().map_bl(
         b_off, *l,
-        [&](uint64_t offset, uint64_t length, bufferlist& t) {
+        [&](uint64_t offset, bufferlist& t) {
   	  bdev->aio_write(offset, t, &txc->ioc, false);
         });
     }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -527,7 +527,7 @@ struct bluestore_blob_t {
   }
   void map_bl(uint64_t x_off,
 	      bufferlist& bl,
-	      std::function<void(uint64_t,uint64_t,bufferlist&)> f) const {
+	      std::function<void(uint64_t,bufferlist&)> f) const {
     auto p = extents.begin();
     assert(p != extents.end());
     while (x_off >= p->length) {
@@ -542,7 +542,7 @@ struct bluestore_blob_t {
       uint64_t l = MIN(p->length - x_off, x_len);
       bufferlist t;
       it.copy(l, t);
-      f(p->offset + x_off, l, t);
+      f(p->offset + x_off, t);
       x_off = 0;
       x_len -= l;
       ++p;


### PR DESCRIPTION
the parameter  uint64_t length is not  used in   bluestore_blob_t::map_bl