### PR TITLE
mds: use new omap get_keys/get_vals api

### DIFF
--- a/qa/suites/fs/basic/omap_limit/10.yaml
+++ b/qa/suites/fs/basic/omap_limit/10.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd_max_omap_entries_per_request: 10

--- a/qa/suites/fs/basic/omap_limit/10000.yaml
+++ b/qa/suites/fs/basic/omap_limit/10000.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd_max_omap_entries_per_request: 10000

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -487,6 +487,7 @@ OPTION(mds_cache_size, OPT_INT, 100000)
 OPTION(mds_cache_mid, OPT_FLOAT, .7)
 OPTION(mds_max_file_recover, OPT_U32, 32)
 OPTION(mds_dir_max_commit_size, OPT_INT, 10) // MB
+OPTION(mds_dir_keys_per_op, OPT_INT, 16384)
 OPTION(mds_decay_halflife, OPT_FLOAT, 5)
 OPTION(mds_beacon_interval, OPT_FLOAT, 4)
 OPTION(mds_beacon_grace, OPT_FLOAT, 15)

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1484,10 +1484,38 @@ void CDir::fetch(MDSInternalContextBase *c, const std::set<dentry_key_t>& keys)
   _omap_fetch(c, keys);
 }
 
+class C_IO_Dir_OMAP_FetchedMore : public CDirIOContext {
+  MDSInternalContextBase *fin;
+public:
+  bufferlist hdrbl;
+  bool more = false;
+  map<string, bufferlist> omap;      ///< carry-over from before
+  map<string, bufferlist> omap_more; ///< new batch
+  int ret;
+  C_IO_Dir_OMAP_FetchedMore(CDir *d, MDSInternalContextBase *f) :
+    CDirIOContext(d), fin(f), ret(0) { }
+  void finish(int r) {
+    // merge results
+    if (omap.empty()) {
+      omap.swap(omap_more);
+    } else {
+      omap.insert(omap_more.begin(), omap_more.end());
+    }
+    if (more) {
+      dir->_omap_fetch_more(hdrbl, omap, fin);
+    } else {
+      dir->_omap_fetched(hdrbl, omap, !fin, r);
+      if (fin)
+	fin->complete(r);
+    }
+  }
+};
+
 class C_IO_Dir_OMAP_Fetched : public CDirIOContext {
   MDSInternalContextBase *fin;
 public:
   bufferlist hdrbl;
+  bool more = false;
   map<string, bufferlist> omap;
   bufferlist btbl;
   int ret1, ret2, ret3;
@@ -1500,9 +1528,13 @@ public:
       dir->inode->verify_diri_backtrace(btbl, ret3);
     if (r >= 0) r = ret1;
     if (r >= 0) r = ret2;
-    dir->_omap_fetched(hdrbl, omap, !fin, r);
-    if (fin)
-      fin->complete(r);
+    if (more) {
+      dir->_omap_fetch_more(hdrbl, omap, fin);
+    } else {
+      dir->_omap_fetched(hdrbl, omap, !fin, r);
+      if (fin)
+	fin->complete(r);
+    }
   }
 };
 
@@ -1515,8 +1547,7 @@ void CDir::_omap_fetch(MDSInternalContextBase *c, const std::set<dentry_key_t>& 
   rd.omap_get_header(&fin->hdrbl, &fin->ret1);
   if (keys.empty()) {
     assert(!c);
-#warning use the pmore arg
-    rd.omap_get_vals("", "", (uint64_t)-1, &fin->omap, nullptr, &fin->ret2);
+    rd.omap_get_vals("", "", (uint64_t)-1, &fin->omap, &fin->more, &fin->ret2);
   } else {
     assert(c);
     std::set<std::string> str_keys;
@@ -1535,6 +1566,28 @@ void CDir::_omap_fetch(MDSInternalContextBase *c, const std::set<dentry_key_t>& 
     fin->ret3 = -ECANCELED;
   }
 
+  cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
+			     new C_OnFinisher(fin, cache->mds->finisher));
+}
+
+void CDir::_omap_fetch_more(
+  bufferlist& hdrbl,
+  map<string, bufferlist>& omap,
+  MDSInternalContextBase *c)
+{
+  // we have more omap keys to fetch!
+  object_t oid = get_ondisk_object();
+  object_locator_t oloc(cache->mds->mdsmap->get_metadata_pool());
+  C_IO_Dir_OMAP_FetchedMore *fin = new C_IO_Dir_OMAP_FetchedMore(this, c);
+  fin->hdrbl.claim(hdrbl);
+  fin->omap.swap(omap);
+  ObjectOperation rd;
+  rd.omap_get_vals(fin->omap.rbegin()->first,
+		   "", /* filter prefix */
+		   (uint64_t)-1,
+		   &fin->omap_more,
+		   &fin->more,
+		   &fin->ret);
   cache->mds->objecter->read(oid, oloc, rd, CEPH_NOSNAP, NULL, 0,
 			     new C_OnFinisher(fin, cache->mds->finisher));
 }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1547,7 +1547,8 @@ void CDir::_omap_fetch(MDSInternalContextBase *c, const std::set<dentry_key_t>& 
   rd.omap_get_header(&fin->hdrbl, &fin->ret1);
   if (keys.empty()) {
     assert(!c);
-    rd.omap_get_vals("", "", (uint64_t)-1, &fin->omap, &fin->more, &fin->ret2);
+    rd.omap_get_vals("", "", g_conf->mds_dir_keys_per_op,
+		     &fin->omap, &fin->more, &fin->ret2);
   } else {
     assert(c);
     std::set<std::string> str_keys;
@@ -1584,7 +1585,7 @@ void CDir::_omap_fetch_more(
   ObjectOperation rd;
   rd.omap_get_vals(fin->omap.rbegin()->first,
 		   "", /* filter prefix */
-		   (uint64_t)-1,
+		   g_conf->mds_dir_keys_per_op,
 		   &fin->omap_more,
 		   &fin->more,
 		   &fin->ret);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -396,6 +396,7 @@ protected:
   friend class CDirExport;
   friend class C_IO_Dir_TMAP_Fetched;
   friend class C_IO_Dir_OMAP_Fetched;
+  friend class C_IO_Dir_OMAP_FetchedMore;
   friend class C_IO_Dir_Committed;
 
   std::unique_ptr<bloom_filter> bloom;
@@ -616,6 +617,9 @@ protected:
   compact_set<string> wanted_items;
 
   void _omap_fetch(MDSInternalContextBase *fin, const std::set<dentry_key_t>& keys);
+  void _omap_fetch_more(
+    bufferlist& hdrbl, std::map<std::string, bufferlist>& omap,
+    MDSInternalContextBase *fin);
   CDentry *_load_dentry(
       const std::string &key,
       const std::string &dname,

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -90,12 +90,14 @@ public:
   int values_r;  //< Return value from OMAP value read
   bufferlist header_bl;
   std::map<std::string, bufferlist> session_vals;
+  bool more_session_vals = false;
 
   C_IO_SM_Load(SessionMap *cm, const bool f)
     : SessionMapIOContext(cm), first(f), header_r(0), values_r(0) {}
 
   void finish(int r) {
-    sessionmap->_load_finish(r, header_r, values_r, first, header_bl, session_vals);
+    sessionmap->_load_finish(r, header_r, values_r, first, header_bl, session_vals,
+      more_session_vals);
   }
 };
 }
@@ -155,7 +157,8 @@ void SessionMap::_load_finish(
     int values_r,
     bool first,
     bufferlist &header_bl,
-    std::map<std::string, bufferlist> &session_vals)
+    std::map<std::string, bufferlist> &session_vals,
+    bool more_session_vals)
 {
   if (operation_r < 0) {
     derr << "_load_finish got " << cpp_strerror(operation_r) << dendl;
@@ -210,7 +213,7 @@ void SessionMap::_load_finish(
     ceph_abort();  // Should be unreachable because damaged() calls respawn()
   }
 
-  if (session_vals.size() == g_conf->mds_sessionmap_keys_per_op) {
+  if (more_session_vals) {
     // Issue another read if we're not at the end of the omap
     const std::string last_key = session_vals.rbegin()->first;
     dout(10) << __func__ << ": continue omap load from '"
@@ -219,9 +222,8 @@ void SessionMap::_load_finish(
     object_locator_t oloc(mds->mdsmap->get_metadata_pool());
     C_IO_SM_Load *c = new C_IO_SM_Load(this, false);
     ObjectOperation op;
-#warning fixme use the pmore arg
     op.omap_get_vals(last_key, "", g_conf->mds_sessionmap_keys_per_op,
-		     &c->session_vals, nullptr, &c->values_r);
+		     &c->session_vals, &c->more_session_vals, &c->values_r);
     mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0,
         new C_OnFinisher(c, mds->finisher));
   } else {
@@ -263,9 +265,8 @@ void SessionMap::load(MDSInternalContextBase *onload)
 
   ObjectOperation op;
   op.omap_get_header(&c->header_bl, &c->header_r);
-#warning use the pmore arg
   op.omap_get_vals("", "", g_conf->mds_sessionmap_keys_per_op,
-		   &c->session_vals, nullptr, &c->values_r);
+		   &c->session_vals, &c->more_session_vals, &c->values_r);
 
   mds->objecter->read(oid, oloc, op, CEPH_NOSNAP, NULL, 0, new C_OnFinisher(c, mds->finisher));
 }

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -604,7 +604,8 @@ public:
       int values_r,
       bool first,
       bufferlist &header_bl,
-      std::map<std::string, bufferlist> &session_vals);
+      std::map<std::string, bufferlist> &session_vals,
+      bool more_session_vals);
 
   void load_legacy();
   void _load_legacy_finish(int r, bufferlist &bl);


### PR DESCRIPTION
The updated API has a "more" output argument so that we can tell if there
are more keys to fetch.

This should merge after https://github.com/ceph/ceph/pull/12950 ... only the last 2 patches are unique to this PR.