### PR TITLE
rgw: swift: fix a bug object owner should not be able to handle the obj without container permission

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1416,6 +1416,8 @@ OPTION(rgw_swift_auth_entry, OPT_STR, "auth")  // entry point for which a url is
 OPTION(rgw_swift_tenant_name, OPT_STR, "")  // tenant name to use for swift access
 OPTION(rgw_swift_account_in_url, OPT_BOOL, false)  // assume that URL always contain the account (aka tenant) part
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL, false)  // enforce generation of Content-Length even in cost of performance or scalability
+OPTION(rgw_swift_verify_object_acl, OPT_BOOL, true)  // if you want to be consistent with SWIFT, set false to skip and propose to handle
+                                                     // the same object with SWIFT and S3 separately
 OPTION(rgw_keystone_url, OPT_STR, "")  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR, "")  // keystone admin token (shared secret)
 OPTION(rgw_keystone_admin_user, OPT_STR, "")  // keystone admin user name


### PR DESCRIPTION
When user2 upload the object in user1's container with container write permission, then user1 remove the user2's write permission on the container. At last user2 can still download the uploaded object without container read permission, which is not consistent with the openstack swift.

Fixes: http://tracker.ceph.com/issues/18596
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>