### PR TITLE
global: we need to handle the init_on_startup return value when global_init.

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -326,7 +326,10 @@ global_init(std::vector < const char * > *alt_def_args,
   if (code_env == CODE_ENVIRONMENT_DAEMON && !(flags & CINIT_FLAG_NO_DAEMON_ACTIONS))
     output_ceph_version();
 
-  g_ceph_context->crush_location.init_on_startup();
+  if (g_ceph_context->crush_location.init_on_startup()) {
+    cerr << " failed to init_on_startup : " << cpp_strerror(errno) << std::endl;
+    exit(1);
+  }
 
   return boost::intrusive_ptr<CephContext>{g_ceph_context, false};
 }


### PR DESCRIPTION
global: we need to handle the init_on_startup return value when global_init.

Signed-off-by:song baisen <song.baisen@zte.com.cn>