### PR TITLE
rgw: use new omap_get_vals2 interface

### DIFF
--- a/qa/suites/rgw/multifs/omap_limit/10.yaml
+++ b/qa/suites/rgw/multifs/omap_limit/10.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd_max_omap_entries_per_request: 10

--- a/qa/suites/rgw/multifs/omap_limit/10000.yaml
+++ b/qa/suites/rgw/multifs/omap_limit/10000.yaml
@@ -1,0 +1,5 @@
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd_max_omap_entries_per_request: 10000

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -256,10 +256,12 @@ int RGWRadosSetOmapKeysCR::request_complete()
 RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(RGWRados *_store,
                       const rgw_raw_obj& _obj,
                       const string& _marker,
-                      map<string, bufferlist> *_entries, int _max_entries) : RGWSimpleCoroutine(_store->ctx()),
+                      map<string, bufferlist> *_entries,
+                      int _max_entries, bool *_pmore) : RGWSimpleCoroutine(_store->ctx()),
                                                 store(_store),
                                                 marker(_marker),
-                                                entries(_entries), max_entries(_max_entries), rval(0),
+                                                entries(_entries), max_entries(_max_entries),
+                                                pmore(_pmore), rval(0),
                                                 obj(_obj), cn(NULL)
 {
   set_description() << "set omap keys dest=" << obj << " marker=" << marker;
@@ -279,7 +281,7 @@ int RGWRadosGetOmapKeysCR::send_request() {
   set_status() << "send request";
 
   librados::ObjectReadOperation op;
-  op.omap_get_vals2(marker, max_entries, entries, nullptr, &rval);
+  op.omap_get_vals2(marker, max_entries, entries, pmore, &rval);
 
   cn = stack->create_completion_notifier();
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op, NULL);

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -409,6 +409,7 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
   string marker;
   map<string, bufferlist> *entries;
   int max_entries;
+  bool *pmore;
 
   int rval;
   rgw_rados_ref ref;
@@ -419,9 +420,10 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
 
 public:
   RGWRadosGetOmapKeysCR(RGWRados *_store,
-		      const rgw_raw_obj& _obj,
-		      const string& _marker,
-		      map<string, bufferlist> *_entries, int _max_entries);
+		        const rgw_raw_obj& _obj,
+		        const string& _marker,
+		        map<string, bufferlist> *_entries,
+                        int _max_entries, bool *pm);
 
   ~RGWRadosGetOmapKeysCR() override;
 


### PR DESCRIPTION
This is necessary to detect partial results from the OSD on both old and new
OSDs.