### PR TITLE
hammer: cephfs test failures (ceph.com/qa is broken, should be download.ceph.com/qa)

### DIFF
--- a/qa/suites/fs/multiclient/tasks/fsx-mpi.yaml.disabled
+++ b/qa/suites/fs/multiclient/tasks/fsx-mpi.yaml.disabled
@@ -6,7 +6,7 @@ tasks:
 - pexec:
     clients:
       - cd $TESTDIR
-      - wget http://ceph.com/qa/fsx-mpi.c
+      - wget http://download.ceph.com/qa/fsx-mpi.c
       - mpicc fsx-mpi.c -o fsx-mpi
       - rm fsx-mpi.c
       - ln -s $TESTDIR/mnt.* $TESTDIR/gmnt

--- a/qa/suites/fs/multiclient/tasks/ior-shared-file.yaml
+++ b/qa/suites/fs/multiclient/tasks/ior-shared-file.yaml
@@ -6,7 +6,7 @@ tasks:
 - pexec:
     clients:
       - cd $TESTDIR
-      - wget http://ceph.com/qa/ior.tbz2
+      - wget http://download.ceph.com/qa/ior.tbz2
       - tar xvfj ior.tbz2
       - cd ior
       - ./configure

--- a/qa/suites/fs/multiclient/tasks/mdtest.yaml
+++ b/qa/suites/fs/multiclient/tasks/mdtest.yaml
@@ -6,7 +6,7 @@ tasks:
 - pexec:
     clients:
       - cd $TESTDIR
-      - wget http://ceph.com/qa/mdtest-1.9.3.tgz
+      - wget http://download.ceph.com/qa/mdtest-1.9.3.tgz
       - mkdir mdtest-1.9.3
       - cd mdtest-1.9.3
       - tar xvfz $TESTDIR/mdtest-1.9.3.tgz

--- a/qa/tasks/cram.py
+++ b/qa/tasks/cram.py
@@ -27,9 +27,9 @@ def task(ctx, config):
         - cram:
             clients:
               client.0:
-              - http://ceph.com/qa/test.t
-              - http://ceph.com/qa/test2.t]
-              client.1: [http://ceph.com/qa/test.t]
+              - http://download.ceph.com/qa/test.t
+              - http://download.ceph.com/qa/test2.t]
+              client.1: [http://download.ceph.com/qa/test.t]
             branch: foo
 
     You can also run a list of cram tests on all clients::
@@ -38,7 +38,7 @@ def task(ctx, config):
         - ceph:
         - cram:
             clients:
-              all: [http://ceph.com/qa/test.t]
+              all: [http://download.ceph.com/qa/test.t]
 
     :param ctx: Context
     :param config: Configuration

--- a/qa/tasks/qemu.py
+++ b/qa/tasks/qemu.py
@@ -396,9 +396,9 @@ def task(ctx, config):
         - ceph:
         - qemu:
             client.0:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
             client.1:
-              test: http://ceph.com/qa/test2.sh
+              test: http://download.ceph.com/qa/test2.sh
 
     Or use the same settings on all clients:
 
@@ -406,7 +406,7 @@ def task(ctx, config):
         - ceph:
         - qemu:
             all:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
 
     For tests that don't need a filesystem, set type to block::
 
@@ -414,7 +414,7 @@ def task(ctx, config):
         - ceph:
         - qemu:
             client.0:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
               type: block
 
     The test should be configured to run on /dev/vdb and later
@@ -427,7 +427,7 @@ def task(ctx, config):
         - ceph:
         - qemu:
             client.0:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
               type: block
               num_rbd: 2
 
@@ -437,7 +437,7 @@ def task(ctx, config):
         - ceph:
         - qemu:
             client.0:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
               memory: 512 # megabytes
 
     If you want to run a test against a cloned rbd image, set clone to true::
@@ -446,7 +446,7 @@ def task(ctx, config):
         - ceph:
         - qemu:
             client.0:
-              test: http://ceph.com/qa/test.sh
+              test: http://download.ceph.com/qa/test.sh
               clone: true
     """
     assert isinstance(config, dict), \

--- a/qa/workunits/suites/pjd.sh
+++ b/qa/workunits/suites/pjd.sh
@@ -2,7 +2,6 @@
 
 set -e
 
-#wget http://ceph.com/qa/pjd-fstest-20090130-RC-open24.tgz
 wget http://download.ceph.com/qa/pjd-fstest-20090130-RC-aclfixes.tgz
 tar zxvf pjd*.tgz
 cd pjd*


### PR DESCRIPTION
http://tracker.ceph.com/issues/18602