### PR TITLE
hammer: osd: filestore: FALLOC_FL_PUNCH_HOLE must be used with FALLOC_FL_KEEP_SIZE

### DIFF
--- a/src/os/FileStore.cc
+++ b/src/os/FileStore.cc
@@ -3076,6 +3076,7 @@ int FileStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t 
 
 #ifdef CEPH_HAVE_FALLOCATE
 # if !defined(DARWIN) && !defined(__FreeBSD__)
+#    ifdef FALLOC_FL_KEEP_SIZE
   // first try to punch a hole.
   FDRef fd;
   ret = lfn_open(cid, oid, false, &fd);
@@ -3084,7 +3085,7 @@ int FileStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t 
   }
 
   // first try fallocate
-  ret = fallocate(**fd, FALLOC_FL_PUNCH_HOLE, offset, len);
+  ret = fallocate(**fd, FALLOC_FL_KEEP_SIZE | FALLOC_FL_PUNCH_HOLE, offset, len);
   if (ret < 0)
     ret = -errno;
   lfn_close(fd);
@@ -3098,6 +3099,7 @@ int FileStore::_zero(coll_t cid, const ghobject_t& oid, uint64_t offset, size_t 
     goto out;  // yay!
   if (ret != -EOPNOTSUPP)
     goto out;  // some other error
+#    endif
 # endif
 #endif
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/18448