### PR TITLE
kraken: mon: peon wrongly delete routed pg stats op before receive pg stats ack

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -705,7 +705,8 @@ bool PGMonitor::preprocess_pg_stats(MonOpRequestRef op)
   // only if they've had the map for a while.
   if (stats->had_map_for > 30.0 &&
       mon->osdmon()->is_readable() &&
-      stats->epoch < mon->osdmon()->osdmap.get_epoch())
+      stats->epoch < mon->osdmon()->osdmap.get_epoch() &&
+      !session->proxy_con)
     mon->osdmon()->send_latest_now_nodelete(op, stats->epoch+1);
 
   // Always forward the PGStats to the leader, even if they are the same as


### PR DESCRIPTION
http://tracker.ceph.com/issues/18554