### PR TITLE
mds: don't modify inode that is not projected

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -350,7 +350,7 @@ public:
   void project_rstat_inode_to_frag(CInode *cur, CDir *parent, snapid_t first,
 				   int linkunlink, SnapRealm *prealm);
   void _project_rstat_inode_to_frag(inode_t& inode, snapid_t ofirst, snapid_t last,
-				    CDir *parent, int linkunlink=0);
+				    CDir *parent, int linkunlink, bool update_inode);
   void project_rstat_frag_to_inode(nest_info_t& rstat, nest_info_t& accounted_rstat,
 				   snapid_t ofirst, snapid_t last, 
 				   CInode *pin, bool cow_head);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7723,7 +7723,7 @@ void Server::do_rename_rollback(bufferlist &rbl, mds_rank_t master, MDRequestRef
   if (srcdn && srcdn->authority().first == whoami) {
     nest_info_t blah;
     _rollback_repair_dir(mut, srcdir, rollback.orig_src, rollback.ctime,
-			 in ? in->is_dir() : false, 1, pi ? pi->rstat : blah);
+			 in ? in->is_dir() : false, 1, pi ? pi->accounted_rstat : blah);
   }
 
   // repair dest


### PR DESCRIPTION
In the slave rename prep case (rename inode to different auth mds), the
rename inode is not projected. CDir::check_rstat() gets confused if
MDCache::_project_rstat_inode_to_frag() updates inode's accounted rstat
in that case.

Fixes: http://tracker.ceph.com/issues/16768
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>