### PR TITLE
jewel: systemd: Restart Mon after 10s in case of failure

### DIFF
--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -24,7 +24,8 @@ PrivateTmp=true
 TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
-StartLimitBurst=3
+StartLimitBurst=5
+RestartSec=10
 
 [Install]
 WantedBy=ceph-mon.target


### PR DESCRIPTION
In some situations the IP address the Monitor wants to bind to
might not be available yet.

This might for example be a IPv6 Address which is still performing
DAD or waiting for a Router Advertisement to be send by the Router(s).

Have systemd wait for 10s before starting the Mon and increase the amount
of times it does so to 5.

This allows the system to bring up IP Addresses in the mean time while
systemd waits with restarting the Mon.

Fixes: #18635

Signed-off-by: Wido den Hollander <wido@42on.com>
(cherry picked from commit e73eb8cc1e0d45af1f0b7852c551f2ddfb82a520)