### PR TITLE
[DNM] test: use the test name as the default prefix of temp pool name

### DIFF
--- a/src/test/cls_journal/test_cls_journal.cc
+++ b/src/test/cls_journal/test_cls_journal.cc
@@ -16,7 +16,7 @@ class TestClsJournal : public ::testing::Test {
 public:
 
   static void SetUpTestCase() {
-    _pool_name = get_temp_pool_name();
+    _pool_name = get_temp_pool_name("test_cls_journal");
     ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
   }
 

--- a/src/test/cls_lua/test_cls_lua.cc
+++ b/src/test/cls_lua/test_cls_lua.cc
@@ -529,7 +529,7 @@ objclass.register(current_subop_version)
 class ClsLua : public ::testing::Test {
   protected:
     static void SetUpTestCase() {
-      pool_name = get_temp_pool_name();
+      pool_name = get_temp_pool_name("test_cls_lua");
       ASSERT_EQ("", create_one_pool_pp(pool_name, rados));
       ASSERT_EQ(0, rados.ioctx_create(pool_name.c_str(), ioctx));
     }

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -66,7 +66,7 @@ class TestClsRbd : public ::testing::Test {
 public:
 
   static void SetUpTestCase() {
-    _pool_name = get_temp_pool_name();
+    _pool_name = get_temp_pool_name("test_cls_rbd");
     ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
   }
 

--- a/src/test/journal/RadosTestFixture.cc
+++ b/src/test/journal/RadosTestFixture.cc
@@ -12,7 +12,7 @@ RadosTestFixture::RadosTestFixture()
 }
 
 void RadosTestFixture::SetUpTestCase() {
-  _pool_name = get_temp_pool_name();
+  _pool_name = get_temp_pool_name("test-journal");
   ASSERT_EQ("", create_one_pool_pp(_pool_name, _rados));
 
   CephContext* cct = reinterpret_cast<CephContext*>(_rados.cct());

--- a/src/test/librados/TestCase.cc
+++ b/src/test/librados/TestCase.cc
@@ -13,7 +13,7 @@ rados_t RadosTestNS::s_cluster = NULL;
 
 void RadosTestNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestNS");
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -64,7 +64,7 @@ Rados RadosTestPPNS::s_cluster;
 
 void RadosTestPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestPPNS");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -106,7 +106,7 @@ Rados RadosTestParamPPNS::s_cluster;
 
 void RadosTestParamPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestParamPPNS");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -187,7 +187,7 @@ rados_t RadosTestECNS::s_cluster = NULL;
 
 void RadosTestECNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestECNS");
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 
@@ -218,7 +218,7 @@ Rados RadosTestECPPNS::s_cluster;
 
 void RadosTestECPPNS::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestECPPNS");
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 
@@ -248,7 +248,7 @@ rados_t RadosTest::s_cluster = NULL;
 
 void RadosTest::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTest");
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -306,7 +306,7 @@ Rados RadosTestPP::s_cluster;
 
 void RadosTestPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestPP");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -365,7 +365,7 @@ Rados RadosTestParamPP::s_cluster;
 
 void RadosTestParamPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestParamPP");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -454,7 +454,7 @@ rados_t RadosTestEC::s_cluster = NULL;
 
 void RadosTestEC::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestEC");
   ASSERT_EQ("", create_one_ec_pool(pool_name, &s_cluster));
 }
 
@@ -488,7 +488,7 @@ Rados RadosTestECPP::s_cluster;
 
 void RadosTestECPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("RadosTestECPP");
   ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
 }
 

--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -21,6 +21,16 @@
 
 using namespace librados;
 
+std::string get_temp_pool_name()
+{
+  const auto test_info =
+    ::testing::UnitTest::GetInstance()->current_test_info();
+  assert(test_info);
+  std::ostringstream oss;
+  oss << test_info->test_case_name() << "." << test_info->name();
+  return get_temp_pool_name(oss.str());
+}
+
 std::string get_temp_pool_name(const std::string &prefix)
 {
   char hostname[80];

--- a/src/test/librados/test.h
+++ b/src/test/librados/test.h
@@ -22,7 +22,8 @@
 #include <string>
 #include <unistd.h>
 
-std::string get_temp_pool_name(const std::string &prefix = "test-rados-api-");
+std::string get_temp_pool_name();
+std::string get_temp_pool_name(const std::string &prefix);
 
 std::string create_one_pool(const std::string &pool_name, rados_t *cluster,
     uint32_t pg_num=0);

--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -2745,7 +2745,7 @@ public:
   virtual ~LibRadosTwoPoolsECPP() {};
 protected:
   static void SetUpTestCase() {
-    pool_name = get_temp_pool_name();
+    pool_name = get_temp_pool_name("LibRadosTwoPoolsECPP");
     ASSERT_EQ("", create_one_ec_pool_pp(pool_name, s_cluster));
   }
   static void TearDownTestCase() {

--- a/src/test/libradosstriper/TestCase.cc
+++ b/src/test/libradosstriper/TestCase.cc
@@ -12,7 +12,7 @@ rados_t StriperTest::s_cluster = NULL;
 
 void StriperTest::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("rados_striper_test_param");
   ASSERT_EQ("", create_one_pool(pool_name, &s_cluster));
 }
 
@@ -39,7 +39,7 @@ librados::Rados StriperTestPP::s_cluster;
 
 void StriperTestPP::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("rados_striper_test_pp");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 
@@ -63,7 +63,7 @@ librados::Rados StriperTestParam::s_cluster;
 
 void StriperTestParam::SetUpTestCase()
 {
-  pool_name = get_temp_pool_name();
+  pool_name = get_temp_pool_name("rados_striper_test_param");
   ASSERT_EQ("", create_one_pool_pp(pool_name, s_cluster));
 }
 

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -84,7 +84,7 @@ public:
     EXPECT_EQ(0, m_local_cluster->conf_set("rbd_cache", "false"));
     EXPECT_EQ(0, m_local_cluster->conf_set("rbd_mirror_journal_poll_age", "1"));
 
-    m_local_pool_name = get_temp_pool_name();
+    m_local_pool_name = get_temp_pool_name("TestImageReplayer");
     EXPECT_EQ(0, m_local_cluster->pool_create(m_local_pool_name.c_str()));
     EXPECT_EQ(0, m_local_cluster->ioctx_create(m_local_pool_name.c_str(),
 					      m_local_ioctx));


### PR DESCRIPTION
the prefix was "test-rados-api-" if not specified, but it does not help
much if multiple tests are running in parallel and all of them are using
the same prefix, also the PID used to compose the pool name is not the
one tracked by workunits/rados/test.sh. so we need something more
discriminative to name the temp pool for testing.

Signed-off-by: Kefu Chai <kchai@redhat.com>