### PR TITLE
os/bluestore: use aio for reads

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -94,13 +94,28 @@ public:
   virtual uint64_t get_size() const = 0;
   virtual uint64_t get_block_size() const = 0;
 
-  virtual int read(uint64_t off, uint64_t len, bufferlist *pbl,
-	   IOContext *ioc, bool buffered) = 0;
-  virtual int read_random(uint64_t off, uint64_t len, char *buf,
-           bool buffered) = 0;
+  virtual int read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc,
+    bool buffered) = 0;
+  virtual int read_random(
+    uint64_t off,
+    uint64_t len,
+    char *buf,
+    bool buffered) = 0;
 
-  virtual int aio_write(uint64_t off, bufferlist& bl,
-		IOContext *ioc, bool buffered) = 0;
+  virtual int aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc) = 0;
+  virtual int aio_write(
+    uint64_t off,
+    bufferlist& bl,
+    IOContext *ioc,
+    bool buffered) = 0;
   virtual int flush() = 0;
 
   void queue_reap_ioc(IOContext *ioc);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5171,6 +5171,11 @@ struct region_t {
   uint64_t logical_offset;
   uint64_t blob_xoffset;   //region offset within the blob
   uint64_t length;
+  bufferlist bl;
+
+  // used later in read process
+  uint64_t front = 0;
+  uint64_t r_off = 0;
 
   region_t(uint64_t offset, uint64_t b_offs, uint64_t len)
     : logical_offset(offset),
@@ -5258,7 +5263,8 @@ int BlueStore::_do_read(
 
     ready_regions_t cache_res;
     interval_set<uint32_t> cache_interval;
-    bptr->shared_blob->bc.read(bptr->shared_blob->get_cache(), b_off, b_len, cache_res, cache_interval);
+    bptr->shared_blob->bc.read(
+      bptr->shared_blob->get_cache(), b_off, b_len, cache_res, cache_interval);
     dout(20) << __func__ << "  blob " << *bptr << std::hex
 	     << " need 0x" << b_off << "~" << b_len
 	     << " cache has 0x" << cache_interval
@@ -5292,52 +5298,40 @@ int BlueStore::_do_read(
     ++lp;
   }
 
-  // enumerate and read/decompress desired blobs
-  blobs2read_t::iterator b2r_it = blobs2read.begin();
-  while (b2r_it != blobs2read.end()) {
-    BlobRef bptr = b2r_it->first;
+  // read raw blob data
+  vector<bufferlist> compressed_blob_bls;
+  IOContext ioc(cct, NULL);
+  for (auto& p : blobs2read) {
+    BlobRef bptr = p.first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
-	     << " need 0x" << b2r_it->second << std::dec << dendl;
-    if (bptr->get_blob().has_flag(bluestore_blob_t::FLAG_COMPRESSED)) {
-      bufferlist compressed_bl, raw_bl;
-      IOContext ioc(cct, NULL);   // FIXME?
+	     << " need 0x" << p.second << std::dec << dendl;
+    if (bptr->get_blob().is_compressed()) {
+      // read the whole thing
+      if (compressed_blob_bls.empty()) {
+	// ensure we avoid any reallocation on subsequent blobs
+	compressed_blob_bls.reserve(blobs2read.size());
+      }
+      compressed_blob_bls.push_back(bufferlist());
+      bufferlist& bl = compressed_blob_bls.back();
       r = bptr->get_blob().map(
 	0, bptr->get_blob().get_ondisk_length(),
 	[&](uint64_t offset, uint64_t length) {
-	  bufferlist t;
-	  int r = bdev->read(offset, length, &t, &ioc, false);
+	  int r = bdev->aio_read(offset, length, &bl, &ioc);
 	  if (r < 0)
             return r;
-	  compressed_bl.claim_append(t);
           return 0;
 	});
-      if (r < 0)
-        return r;
-
-      if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl,
-		       b2r_it->second.front().logical_offset) < 0) {
-	return -EIO;
-      }
-      r = _decompress(compressed_bl, &raw_bl);
-      if (r < 0)
-	return r;
-      if (buffered) {
-	bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(), 0, raw_bl);
-      }
-      for (auto& i : b2r_it->second) {
-	ready_regions[i.logical_offset].substr_of(
-	  raw_bl, i.blob_xoffset, i.length);
-      }
     } else {
-      for (auto reg : b2r_it->second) {
+      // read the pieces
+      for (auto& reg : p.second) {
 	// determine how much of the blob to read
 	uint64_t chunk_size = bptr->get_blob().get_chunk_size(block_size);
-	uint64_t r_off = reg.blob_xoffset;
+	reg.r_off = reg.blob_xoffset;
 	uint64_t r_len = reg.length;
-	unsigned front = r_off % chunk_size;
-	if (front) {
-	  r_off -= front;
-	  r_len += front;
+	reg.front = reg.r_off % chunk_size;
+	if (reg.front) {
+	  reg.r_off -= reg.front;
+	  r_len += reg.front;
 	}
 	unsigned tail = r_len % chunk_size;
 	if (tail) {
@@ -5346,34 +5340,67 @@ int BlueStore::_do_read(
 	dout(20) << __func__ << "    region 0x" << std::hex
 		 << reg.logical_offset
 		 << ": 0x" << reg.blob_xoffset << "~" << reg.length
-		 << " reading 0x" << r_off << "~" << r_len << std::dec
+		 << " reading 0x" << reg.r_off << "~" << r_len << std::dec
 		 << dendl;
 
 	// read it
-	IOContext ioc(cct, NULL);  // FIXME?
-	bufferlist bl;
-	r = bptr->get_blob().map(r_off, r_len,
-			     [&](uint64_t offset, uint64_t length) {
-	    bufferlist t;
-	    int r = bdev->read(offset, length, &t, &ioc, false);
+	r = bptr->get_blob().map(
+	  reg.r_off, r_len,
+	  [&](uint64_t offset, uint64_t length) {
+	    int r = bdev->aio_read(offset, length, &reg.bl, &ioc);
 	    if (r < 0)
               return r;
-	    bl.claim_append(t);
             return 0;
 	  });
         if (r < 0)
           return r;
+      }
+    }
+  }
+  bdev->aio_submit(&ioc);
+  ioc.aio_wait();
 
-	r = _verify_csum(o, &bptr->get_blob(), r_off, bl, reg.logical_offset);
+  // enumerate and decompress desired blobs
+  auto p = compressed_blob_bls.begin();
+  blobs2read_t::iterator b2r_it = blobs2read.begin();
+  while (b2r_it != blobs2read.end()) {
+    BlobRef bptr = b2r_it->first;
+    dout(20) << __func__ << "  blob " << *bptr << std::hex
+	     << " need 0x" << b2r_it->second << std::dec << dendl;
+    if (bptr->get_blob().is_compressed()) {
+      assert(p != compressed_blob_bls.end());
+      bufferlist& compressed_bl = *p++;
+      if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl,
+		       b2r_it->second.front().logical_offset) < 0) {
+	return -EIO;
+      }
+      bufferlist raw_bl;
+      r = _decompress(compressed_bl, &raw_bl);
+      if (r < 0)
+	return r;
+      if (buffered) {
+	bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(), 0,
+				       raw_bl);
+      }
+      for (auto& i : b2r_it->second) {
+	ready_regions[i.logical_offset].substr_of(
+	  raw_bl, i.blob_xoffset, i.length);
+      }
+    } else {
+      for (auto& reg : b2r_it->second) {
+	r = _verify_csum(o, &bptr->get_blob(), reg.r_off, reg.bl,
+			 reg.logical_offset);
 	if (r < 0) {
 	  return -EIO;
 	}
 	if (buffered) {
-	  bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(), r_off, bl);
+	  bptr->shared_blob->bc.did_read(bptr->shared_blob->get_cache(),
+					 reg.r_off, reg.bl);
 	}
 
 	// prune and keep result
-	ready_regions[reg.logical_offset].substr_of(bl, front, reg.length);
+	ready_regions[reg.logical_offset].substr_of(
+	  reg.bl, reg.front, reg.length);
       }
     }
     ++b2r_it;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5244,6 +5244,7 @@ int BlueStore::_do_read(
   blobs2read_t blobs2read;
   unsigned left = length;
   uint64_t pos = offset;
+  unsigned num_regions = 0;
   auto lp = o->extent_map.seek_lextent(offset);
   while (left > 0 && lp != o->extent_map.extent_map.end()) {
     if (pos < lp->logical_offset) {
@@ -5289,6 +5290,7 @@ int BlueStore::_do_read(
 	dout(30) << __func__ << "    will read 0x" << std::hex << pos << ": 0x"
 		 << b_off << "~" << l << std::dec << dendl;
 	blobs2read[bptr].emplace_back(region_t(pos, b_off, l));
+	++num_regions;
       }
       pos += l;
       b_off += l;
@@ -5298,7 +5300,7 @@ int BlueStore::_do_read(
     ++lp;
   }
 
-  // read raw blob data
+  // read raw blob data.  use aio if we have >1 blobs to read.
   vector<bufferlist> compressed_blob_bls;
   IOContext ioc(cct, NULL);
   for (auto& p : blobs2read) {
@@ -5316,7 +5318,13 @@ int BlueStore::_do_read(
       r = bptr->get_blob().map(
 	0, bptr->get_blob().get_ondisk_length(),
 	[&](uint64_t offset, uint64_t length) {
-	  int r = bdev->aio_read(offset, length, &bl, &ioc);
+	  int r;
+	  // use aio if there are more regions to read than those in this blob
+	  if (num_regions > p.second.size()) {
+	    r = bdev->aio_read(offset, length, &bl, &ioc);
+	  } else {
+	    r = bdev->read(offset, length, &bl, &ioc, false);
+	  }
 	  if (r < 0)
             return r;
           return 0;
@@ -5347,18 +5355,28 @@ int BlueStore::_do_read(
 	r = bptr->get_blob().map(
 	  reg.r_off, r_len,
 	  [&](uint64_t offset, uint64_t length) {
-	    int r = bdev->aio_read(offset, length, &reg.bl, &ioc);
+	    int r;
+	    // use aio if there is more than one region to read
+	    if (num_regions > 1) {
+	      r = bdev->aio_read(offset, length, &reg.bl, &ioc);
+	    } else {
+	      r = bdev->read(offset, length, &reg.bl, &ioc, false);
+	    }
 	    if (r < 0)
               return r;
             return 0;
 	  });
         if (r < 0)
           return r;
+	assert(reg.bl.length() == r_len);
       }
     }
   }
-  bdev->aio_submit(&ioc);
-  ioc.aio_wait();
+  if (ioc.has_pending_aios()) {
+    bdev->aio_submit(&ioc);
+    dout(20) << __func__ << " waiting for aio" << dendl;
+    ioc.aio_wait();
+  }
 
   // enumerate and decompress desired blobs
   auto p = compressed_blob_bls.begin();

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -539,7 +539,6 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
     goto out;
   }
   assert((uint64_t)r == len);
-  pbl->clear();
   pbl->push_back(std::move(p));
 
   dout(40) << "data: ";

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -269,10 +269,12 @@ void KernelDevice::_aio_thread()
 	// trust aio[] values; they my be freed (e.g., by BlueFS::_fsync)
 	if (left == 0) {
 	  // check waiting count before doing callback (which may
-	  // destroy this ioc).
+	  // destroy this ioc).  and avoid ref to ioc after aio_wake()
+	  // in case that triggers destruction.
+	  void *priv = ioc->priv;
 	  ioc->aio_wake();
-	  if (ioc->priv) {
-	    aio_callback(aio_callback_priv, ioc->priv);
+	  if (priv) {
+	    aio_callback(aio_callback_priv, priv);
 	  }
 	}
       }

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -86,6 +86,8 @@ public:
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,
 	   bool buffered) override;
+  int aio_read(uint64_t off, uint64_t len, bufferlist *pbl,
+	       IOContext *ioc) override;
   int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
   int aio_write(uint64_t off, bufferlist& bl,

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -942,6 +942,45 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   return r;
 }
 
+int NVMEDevice::aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc)
+{
+  uint64_t len = bl.length();
+  dout(20) << __func__ << " " << off << "~" << len << " ioc " << ioc << dendl;
+  assert(off % block_size == 0);
+  assert(len % block_size == 0);
+  assert(len > 0);
+  assert(off < size);
+  assert(off + len <= size);
+
+  Task *t = new Task(this, IOCommand::READ_COMMAND, off, len);
+
+  bufferptr p = buffer::create_page_aligned(len);
+  pbl->append(p);
+  int r = 0;
+  t->ctx = ioc;
+  char *buf = p.c_str();
+  t->fill_cb = [buf, t]() {
+    t->copy_to_buf(buf, 0, t->len);
+  };
+
+  Task *first = static_cast<Task*>(ioc->nvme_task_first);
+  Task *last = static_cast<Task*>(ioc->nvme_task_last);
+  if (last)
+    last->next = t;
+  if (!first)
+    ioc->nvme_task_first = t;
+  ioc->nvme_task_last = t;
+  ++ioc->num_pending;
+
+  return 0;
+}
+
+
+
 int NVMEDevice::read_random(uint64_t off, uint64_t len, char *buf, bool buffered)
 {
   assert(len > 0);

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -934,7 +934,6 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
     while (t->return_code > 0)
       ioc->cond.wait(l);
   }
-  pbl->clear();
   pbl->push_back(std::move(p));
   r = t->return_code;
   delete t;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -221,7 +221,13 @@ class NVMEDevice : public BlockDevice {
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
            IOContext *ioc,
            bool buffered) override;
-
+  int aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc) override {
+    assert(0 == "implement me");
+  }
   int aio_write(uint64_t off, bufferlist& bl,
                 IOContext *ioc,
                 bool buffered) override;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -225,9 +225,7 @@ class NVMEDevice : public BlockDevice {
     uint64_t off,
     uint64_t len,
     bufferlist *pbl,
-    IOContext *ioc) override {
-    assert(0 == "implement me");
-  }
+    IOContext *ioc) override;
   int aio_write(uint64_t off, bufferlist& bl,
                 IOContext *ioc,
                 bool buffered) override;


### PR DESCRIPTION
Dispatch all raw blob reads via aio, in parallel.  This should accellerate
reads on fragmented objects (incl compressed objects) significantly.