### PR TITLE
test/rgw: fixes for test_multi_period_incremental_sync()

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -323,6 +323,8 @@ def set_master_zone(zone):
     zonegroup = zone.zonegroup
     zonegroup.period.update(zone, commit=True)
     zonegroup.master_zone = zone
+    # wait for reconfiguration, so that later metadata requests go to the new master
+    time.sleep(5)
 
 def gen_bucket_name():
     global num_buckets


### PR DESCRIPTION
test was only creating objects in subsequent periods, which wasn't adding any entries to the mdlog. this wasn't correctly testing incremental metadata sync across periods