### PR TITLE
qa/suites/rados/basic: set low omap limit for rgw workload

### DIFF
--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -4,6 +4,8 @@ overrides:
       client:
         debug rgw: 20
         debug ms: 1
+      osd:
+        osd_max_omap_entries_per_request: 10
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
This gets *some* coverage for the omap limits in the rados suite.

Signed-off-by: Sage Weil <sage@redhat.com>