### PR TITLE
osd: Return correct osd_objectstore in OSD metadata

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5115,7 +5115,7 @@ void OSD::_collect_metadata(map<string,string> *pm)
   (*pm)["hb_back_addr"] = stringify(hb_back_server_messenger->get_myaddr());
 
   // backend
-  (*pm)["osd_objectstore"] = cct->_conf->osd_objectstore;
+  (*pm)["osd_objectstore"] = store->get_type();
   store->collect_metadata(pm);
 
   collect_sys_info(pm, cct);


### PR DESCRIPTION
Do not simply read the configuration value as it might have changed
during OSD startup by reading the type from disk.

Fixes: #18638
Signed-off-by: Wido den Hollander <wido@42on.com>