### PR TITLE
osd/PrimaryLogPG::try_lock_for_read: give up if missing

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -345,6 +345,8 @@ public:
   bool try_lock_for_read(
     const hobject_t &hoid,
     ObcLockManager &manager) override {
+    if (is_missing_object(hoid))
+      return false;
     auto obc = get_object_context(hoid, false, nullptr);
     if (!obc)
       return false;


### PR DESCRIPTION
The only users calc_*_subsets might try to read_lock an object which is
missing on the primary.  Returning false in those cases is perfectly
reasonable and avoids the problem.

Fixes: http://tracker.ceph.com/issues/18583
Signed-off-by: Samuel Just <sjust@redhat.com>