### PR TITLE
qa: unpin knfs from ubuntu

### DIFF
--- a/qa/suites/knfs/basic/ceph/base.yaml
+++ b/qa/suites/knfs/basic/ceph/base.yaml
@@ -1,6 +1,4 @@
 
-os_type: ubuntu
-
 overrides:
   ceph:
     conf:


### PR DESCRIPTION
We have an updated nfs-utils that is no longer
generating spurious selinux warnings on CentOS.

Fixes: http://tracker.ceph.com/issues/16397
Signed-off-by: John Spray <john.spray@redhat.com>