### PR TITLE
client: remove dead log code

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2260,17 +2260,11 @@ void Client::handle_client_reply(MClientReply *reply)
     reply->put();
     return;
   }
+  MetaRequest *request = mds_requests.at(tid);
 
   ldout(cct, 20) << "handle_client_reply got a reply. Safe:" << is_safe
 		 << " tid " << tid << dendl;
-  MetaRequest *request = mds_requests[tid];
-  if (!request) {
-    ldout(cct, 0) << "got an unknown reply (probably duplicate) on tid " << tid << " from mds "
-      << mds_num << " safe: " << is_safe << dendl;
-    reply->put();
-    return;
-  }
-    
+
   if (request->got_unsafe && !is_safe) {
     //duplicate response
     ldout(cct, 0) << "got a duplicate reply on tid " << tid << " from mds "


### PR DESCRIPTION
The preceding if statement has always checked if mds_requests has no
request for the given tid. I don't know how the assert was ever
triggered during work on 3b520b5.

Partial revert of 3b520b5173d96db5ffc30ed31a92760f3910e733.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>