### PR TITLE
mds: skip fragment space check for replayed request

### DIFF
--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -146,6 +146,10 @@ public:
     stray_index = (stray_index+1)%NUM_STRAY;
   }
 
+  void activate_stray_manager() {
+    stray_manager.activate();
+  }
+
   /**
    * Call this when you know that a CDentry is ready to be passed
    * on to StrayManager (i.e. this is a stray you've just created)

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1285,6 +1285,7 @@ void MDSRank::active_start()
   mdcache->start_files_to_recover();
 
   mdcache->reissue_all_caps();
+  mdcache->activate_stray_manager();
 
   finish_contexts(g_ceph_context, waiting_for_active);  // kick waiters
 }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2289,7 +2289,8 @@ CDentry* Server::prepare_stray_dentry(MDRequestRef& mdr, CInode *in)
 
   CDir *straydir = mdcache->get_stray_dir(in);
 
-  if (!check_fragment_space(mdr, straydir))
+  if (!mdr->client_request->is_replay() &&
+      !check_fragment_space(mdr, straydir))
     return NULL;
 
   straydn = mdcache->get_or_create_stray_dentry(in);

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -433,6 +433,11 @@ bool StrayManager::_consume(CDentry *dn, bool trunc, uint32_t ops_required)
 {
   const int files_avail = g_conf->mds_max_purge_files - files_purging;
 
+  if (!started) {
+    dout(20) << __func__ << ": haven't started purging yet" << dendl;
+    return false;
+  }
+
   if (files_avail <= 0) {
     dout(20) << __func__ << ": throttling on max files" << dendl;
     return false;
@@ -732,6 +737,13 @@ bool StrayManager::__eval_stray(CDentry *dn, bool delay)
   }
 }
 
+void StrayManager::activate()
+{
+  dout(10) << __func__ << dendl;
+  started = true;
+  _advance();
+}
+
 bool StrayManager::eval_stray(CDentry *dn, bool delay)
 {
   // avoid nested eval_stray
@@ -838,7 +850,7 @@ void StrayManager::migrate_stray(CDentry *dn, mds_rank_t to)
 
 StrayManager::StrayManager(MDSRank *mds)
   : delayed_eval_stray(member_offset(CDentry, item_stray)),
-    mds(mds), logger(NULL),
+    mds(mds), logger(NULL), started(false),
     ops_in_flight(0), files_purging(0),
     max_purge_ops(0), 
     num_strays(0), num_strays_purging(0), num_strays_delayed(0),

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -55,6 +55,8 @@ class StrayManager
   MDSRank *mds;
   PerfCounters *logger;
 
+  bool started;
+
   // Throttled allowances
   uint64_t ops_in_flight;
   uint64_t files_purging;
@@ -168,6 +170,7 @@ class StrayManager
   public:
   explicit StrayManager(MDSRank *mds);
   void set_logger(PerfCounters *l) {logger = l;}
+  void activate();
 
   bool eval_stray(CDentry *dn, bool delay=false);
 


### PR DESCRIPTION
when handling replayed request, stray directory can be different
from the stray directory used by the original request. The fragment
space check for stray directory can fail.

Fixes: http://tracker.ceph.com/issues/18660
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>