### PR TITLE
systemd: Start OSDs after MONs

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ceph object storage daemon osd.%i
-After=network-online.target local-fs.target time-sync.target
+After=network-online.target local-fs.target time-sync.target ceph-mon.target
 Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-osd.target
 


### PR DESCRIPTION
Currently, we start/stop OSDs and MONs simultaneously. This may cause
problems especially when we are shutting down the system. Once the mon
goes down it causes a re-election and the MONs can miss the message
from the OSD that is going down.

Resolves: http://tracker.ceph.com/issues/18516

Signed-off-by: Boris Ranto <branto@redhat.com>