### PR TITLE
doc: Document that osd_heartbeat_grace applies to MON and OSD

### DIFF
--- a/doc/rados/configuration/mon-osd-interaction.rst
+++ b/doc/rados/configuration/mon-osd-interaction.rst
@@ -31,8 +31,9 @@ or by setting the value at runtime. If a neighboring Ceph OSD Daemon doesn't
 show a heartbeat within a 20 second grace period, the Ceph OSD Daemon may
 consider the neighboring Ceph OSD Daemon ``down`` and report it back to a Ceph
 Monitor, which will update the Ceph Cluster Map. You may change this grace
-period by adding an ``osd heartbeat grace`` setting under the ``[osd]`` section
-of your Ceph configuration file, or by setting the value at runtime.
+period by adding an ``osd heartbeat grace`` setting under the ``[mon]``
+and ``[osd]`` or ``[global]`` section of your Ceph configuration file,
+or by setting the value at runtime.
 
 
 .. ditaa:: +---------+          +---------+
@@ -348,6 +349,8 @@ OSD Settings
 
 :Description: The elapsed time when a Ceph OSD Daemon hasn't shown a heartbeat
               that the Ceph Storage Cluster considers it ``down``.
+              This setting has to be set in both the [mon] and [osd] or [global]
+              section so that it is read by both the MON and OSD daemons.
  
 :Type: 32-bit Integer
 :Default: ``20``

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -764,7 +764,10 @@ OPTION(osd_command_thread_timeout, OPT_INT, 10*60)
 OPTION(osd_command_thread_suicide_timeout, OPT_INT, 15*60)
 OPTION(osd_heartbeat_addr, OPT_ADDR, entity_addr_t())
 OPTION(osd_heartbeat_interval, OPT_INT, 6)       // (seconds) how often we ping peers
-OPTION(osd_heartbeat_grace, OPT_INT, 20)         // (seconds) how long before we decide a peer has failed
+
+// (seconds) how long before we decide a peer has failed
+// This setting is read by the MONs and OSDs and has to be set to a equal value in both settings of the configuration
+OPTION(osd_heartbeat_grace, OPT_INT, 20)
 OPTION(osd_heartbeat_min_peers, OPT_INT, 10)     // minimum number of peers
 OPTION(osd_heartbeat_use_min_delay_socket, OPT_BOOL, false) // prio the heartbeat tcp socket and set dscp as CS6 on it if true
 


### PR DESCRIPTION
This value has to be set in both the [mon] and [osd] section since
both daemons read this value.

Signed-off-by: Wido den Hollander <wido@42on.com>