### PR TITLE
qa/tasks: force umount during kclient teardown

### DIFF
--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -5,7 +5,9 @@ import contextlib
 import logging
 
 from teuthology.misc import deep_merge
+from teuthology.orchestra.run import CommandFailedError
 from teuthology import misc
+from teuthology.contextutil import MaxWhileTries
 from cephfs.kernel_mount import KernelMount
 
 log = logging.getLogger(__name__)
@@ -113,7 +115,7 @@ def task(ctx, config):
             if mount.is_mounted():
                 try:
                     mount.umount()
-                except CommandFailedError:
+                except (CommandFailedError, MaxWhileTries):
                     log.warn("Ordinary umount failed, forcing...")
                     forced = True
                     mount.umount_wait(force=True)

--- a/qa/tasks/kclient.py
+++ b/qa/tasks/kclient.py
@@ -104,11 +104,32 @@ def task(ctx, config):
 
         kernel_mount.mount()
 
+
+    def umount_all():
+        log.info('Unmounting kernel clients...')
+
+        forced = False
+        for mount in mounts.values():
+            if mount.is_mounted():
+                try:
+                    mount.umount()
+                except CommandFailedError:
+                    log.warn("Ordinary umount failed, forcing...")
+                    forced = True
+                    mount.umount_wait(force=True)
+
+        return forced
+
     ctx.mounts = mounts
     try:
         yield mounts
+    except:
+        umount_all()  # ignore forced retval, we are already in error handling
     finally:
-        log.info('Unmounting kernel clients...')
-        for mount in mounts.values():
-            if mount.is_mounted():
-                mount.umount()
+
+        forced = umount_all()
+        if forced:
+            # The context managers within the kclient manager worked (i.e.
+            # the test workload passed) but for some reason we couldn't
+            # umount, so turn this into a test failure.
+            raise RuntimeError("Kernel mounts did not umount cleanly")


### PR DESCRIPTION
Previously we could readily end up hanging on teardown
when something had gone wrong with umount.  Forcing
is a big hammer (umount_wait will power cycle the node
if umount isn't working), so if we had to do that
then raise an exception to indicate that something
was wrong with the test.

Fixes: http://tracker.ceph.com/issues/18663
Signed-off-by: John Spray <john.spray@redhat.com>