### PR TITLE
Enhancement for raw::clone() if CEPH_HAVE_SPLICE enabled.

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -190,6 +190,12 @@ static simple_spinlock_t buffer_debug_lock = SIMPLE_SPINLOCK_INITIALIZER;
     virtual raw* clone_empty() = 0;
     raw *clone() {
       raw *c = clone_empty();
+#ifdef CEPH_HAVE_SPLICE
+      // raw_pipe::clone_empty() returns NULL
+      if (!c) {
+        return NULL;
+      }
+#endif
       memcpy(c->data, data, len);
       return c;
     }


### PR DESCRIPTION
When `CEPH_HAVE_SPLICE` is enabled, `raw_pipe::clone_empty()` returns `NULL`. raw::clone() does not check the return value of `clone_empty()` for this case.

```Cpp
    raw *clone() {
      raw *c = clone_empty();
      memcpy(c->data, data, len);
      return c;
    }
```

So, add the check when `CEPH_HAVE_SPLICE` is enabled.

Signed-off-by: You Ji <youji@ebay.com>