### PR TITLE
msg/async/rdma: Fix memory leak of OSD

### DIFF
--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -122,7 +122,7 @@ void RDMADispatcher::polling()
           dead_queue_pairs.pop_back();
         }
       }
-      // handle_async_event();
+      handle_async_event();
       if (done)
         break;
 


### PR DESCRIPTION
We can delete qp only in RDMADispatcher::handle_async_event() which call
"erase_qpn" to enable deletion.

Signed-off-by: Sarit Zubakov <saritz@mellanox.com>