### PR TITLE
jewel: mds: finish clientreplay requests before requesting active state

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1240,7 +1240,7 @@ void MDSRank::clientreplay_start()
 bool MDSRank::queue_one_replay()
 {
   if (replay_queue.empty()) {
-    clientreplay_done();
+    mdlog->wait_for_safe(new C_MDS_VoidFn(this, &MDSRank::clientreplay_done));
     return false;
   }
   queue_waiter(replay_queue.front());


### PR DESCRIPTION
http://tracker.ceph.com/issues/18679

All clientreplay requests' finish contexts should be executed
before MDCache::export_remaining_imported_caps(). Otherwise
MDCache::try_reconnect_cap() may fail to reconnect client caps.

Fixes: http://tracker.ceph.com/issues/18461
Signed-off-by: Yan, Zheng <zyan@redhat.com>
(cherry picked from commit 80dae314ee90e79d60e2cfee301e43a435c10801)