### PR TITLE
jewel: monitor cannot start because of FAILED assert(info.state == MDSMap::STATE_STANDBY)

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2789,9 +2789,17 @@ bool MDSMonitor::maybe_promote_standby(std::shared_ptr<Filesystem> fs)
   } else {
     // There were no failures to replace, so try using any available standbys
     // as standby-replay daemons.
+
+    // Take a copy of the standby GIDs so that we can iterate over
+    // them while perhaps-modifying standby_daemons during the loop
+    // (if we promote anyone they are removed from standby_daemons)
+    std::vector<mds_gid_t> standby_gids;
     for (const auto &j : pending_fsmap.standby_daemons) {
-      const auto &gid = j.first;
-      const auto &info = j.second;
+      standby_gids.push_back(j.first);
+    }
+
+    for (const auto &gid : standby_gids) {
+      const auto &info = pending_fsmap.standby_daemons.at(gid);
       assert(info.state == MDSMap::STATE_STANDBY);
 
       if (!info.standby_replay) {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2786,11 +2786,9 @@ bool MDSMonitor::maybe_promote_standby(std::shared_ptr<Filesystem> fs)
 	do_propose = true;
       }
     }
-  }
-
-  // There were no failures to replace, so try using any available standbys
-  // as standby-replay daemons.
-  if (failed.empty()) {
+  } else {
+    // There were no failures to replace, so try using any available standbys
+    // as standby-replay daemons.
     for (const auto &j : pending_fsmap.standby_daemons) {
       const auto &gid = j.first;
       const auto &info = j.second;


### PR DESCRIPTION
http://tracker.ceph.com/issues/18282