### PR TITLE
client: remove request from session->requests when handling forward

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2224,6 +2224,7 @@ void Client::handle_client_request_forward(MClientRequestForward *fwd)
 	   << dendl;
   
   request->mds = -1;
+  request->item.remove_myself();
   request->num_fwd = fwd->get_num_fwd();
   request->resend_mds = fwd->get_dest_mds();
   request->caller_cond->Signal();


### PR DESCRIPTION
Client::handle_client_request_forward() reset request->mds to -1,
it should also remove request from session->requests. Otherwise
Client::kick_requests_closed() get confused.

Fixes: http://tracker.ceph.com/issues/18675
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>