### PR TITLE
osd: encode pg_pool_t like hammer when CEPH_FEATURE_JEWEL_OSD is unset

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1483,7 +1483,8 @@ void pg_pool_t::encode(bufferlist& bl, uint64_t features) const
   }
 
   uint8_t v = 24;
-  if (!(features & CEPH_FEATURE_NEW_OSDOP_ENCODING)) {
+  if (!(features & CEPH_FEATURE_NEW_OSDOP_ENCODING) ||
+      !(features & CEPH_FEATURE_SERVER_JEWEL)) {
     // this was the first post-hammer thing we added; if it's missing, encode
     // like hammer.
     v = 21;


### PR DESCRIPTION
OSDMonitor::encode_pending() clears CEPH_FEATURE_SERVER_JEWEL in order
to encode the map in a way compatible with hammer. However
pg_pool_t::encode() uses CEPH_FEATURE_NEW_OSDOP_ENCODING to determine
the encoding version, and picks v24 anyway. The result is full_crc
mismatch, so OSDs start requesting full maps instead of incremental ones
(which can saturate monitors and break the upgrade).

Fixes: http://tracker.ceph.com/issues/18582

Signed-off-by: Alexey Sheplyakov <asheplyakov@mirantis.com>