### PR TITLE
jewel: rbd: bench-write will crash if --io-size is 4G

### DIFF
--- a/src/tools/rbd/action/BenchWrite.cc
+++ b/src/tools/rbd/action/BenchWrite.cc
@@ -126,6 +126,11 @@ int do_bench_write(librbd::Image& image, uint64_t io_size,
     return -EINVAL;
   }
 
+  if (io_size > std::numeric_limits<uint32_t>::max()) {
+    std::cerr << "rbd: io-size should be less than 4G" << std::endl;
+    return -EINVAL;
+  }
+
   rbd_bencher b(&image);
 
   std::cout << "bench-write "


### PR DESCRIPTION
http://tracker.ceph.com/issues/18558