### PR TITLE
jewel: mon: OSDMonitor: clear jewel+ feature bits when talking to Hammer OSD

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1215,7 +1215,9 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
     // determine appropriate features
     if (!tmp.test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
       dout(10) << __func__ << " encoding without feature SERVER_JEWEL" << dendl;
-      features &= ~CEPH_FEATURE_SERVER_JEWEL;
+      features &= ~(CEPH_FEATURE_SERVER_JEWEL |
+	  CEPH_FEATURE_NEW_OSDOP_ENCODING |
+	  CEPH_FEATURE_CRUSH_TUNABLES5);
     }
     dout(10) << __func__ << " encoding full map with " << features << dendl;
 


### PR DESCRIPTION
During upgrade from Hammer to Jewel, when upgrading MONs first and OSDs last, Jewel MONs send OSDMaps with components in encoding versions not encodable by Hammer OSDs, generating extra load on MONs due to requests for full OSDMap after failing the CRC check.
Fix this by not including CEPH_FEATURE_NEW_OSDOP_ENCODING (which is responsible for encoding pg_pool_t in version 24 instead of 21) and CEPH_FEATURE_CRUSH_TUNABLES5 (responsible for adding chooseleaf_stable field into encoded CRUSH map) when CEPH_OSDMAP_REQUIRE_JEWEL flag is not present.

Fixes: http://tracker.ceph.com/issues/18582

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>