### PR TITLE
qa: fix race in Mount.open_background

### DIFF
--- a/qa/tasks/cephfs/mount.py
+++ b/qa/tasks/cephfs/mount.py
@@ -157,7 +157,10 @@ class CephFSMount(object):
     def open_background(self, basename="background_file"):
         """
         Open a file for writing, then block such that the client
-        will hold a capability
+        will hold a capability.
+
+        Don't return until the remote process has got as far as opening
+        the file, then return the RemoteProcess instance.
         """
         assert(self.is_mounted())
 
@@ -176,6 +179,12 @@ class CephFSMount(object):
 
         rproc = self._run_python(pyscript)
         self.background_procs.append(rproc)
+
+        # This wait would not be sufficient if the file had already
+        # existed, but it's simple and in practice users of open_background
+        # are not using it on existing files.
+        self.wait_for_visible(basename)
+
         return rproc
 
     def wait_for_visible(self, basename="background_file", timeout=30):

--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -236,11 +236,11 @@ class TestStrays(CephFSTestCase):
 
         # Write some bytes to a file
         size_mb = 8
-        self.mount_a.write_n_mb("open_file", size_mb)
-        open_file_ino = self.mount_a.path_to_ino("open_file")
 
         # Hold the file open
         p = self.mount_a.open_background("open_file")
+        self.mount_a.write_n_mb("open_file", size_mb)
+        open_file_ino = self.mount_a.path_to_ino("open_file")
 
         self.assertEqual(self.get_session(mount_a_client_id)['num_caps'], 2)
 


### PR DESCRIPTION
Previously a later remote call could end up executing
before the remote python program in open_background
had actually got as far as opening the file.

Fixes: http://tracker.ceph.com/issues/18661
Signed-off-by: John Spray <john.spray@redhat.com>