### PR TITLE
msg/async/rdma: Remove compilation warning

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -880,10 +880,7 @@ int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
     ldout(cct, 1) << __func__ << " got bad length (" << r << "): " << cpp_strerror(errno) << dendl;
     r = -EINVAL;
   } else { // valid message
-    int tmp;
-
-    sscanf(msg, "%x:%x:%x:%x:%s", &tmp, &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
-    im.lid = tmp;
+    sscanf(msg, "%hu:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
     wire_gid_to_gid(gid, &(im.gid));
     ldout(cct, 5) << __func__ << " recevd: " << im.lid << ", " << im.qpn << ", " << im.psn << ", " << im.peer_qpn << ", " << gid  << dendl;
   }


### PR DESCRIPTION
Fixed warning - of sending unsigned short int to %x

Signed-off-by: Sarit Zubakov <saritz@mellanox.com>