### PR TITLE
packaging: install libceph-common.so* not libceph-common.so.*

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1354,7 +1354,7 @@ fi
 %defattr(-,root,root,-)
 %{_libdir}/librados.so.*
 %dir %{_libdir}/ceph
-%{_libdir}/ceph/libceph-common.so.*
+%{_libdir}/ceph/libceph-common.so*
 %if %{with lttng}
 %{_libdir}/librados_tp.so.*
 %endif

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,3 +1,3 @@
 usr/lib/librados.so.*
 usr/lib/librados_tp.so.*
-usr/lib/ceph/libceph-common.so.*
+usr/lib/ceph/libceph-common.so*


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18692
Signed-off-by: Kefu Chai <kchai@redhat.com>