### PR TITLE
jewel: tests: upgrade:hammer-x: install firefly only on Ubuntu 14.04

### DIFF
--- a/qa/suites/upgrade/hammer-x/f-h-x-offline/distros
+++ b/qa/suites/upgrade/hammer-x/f-h-x-offline/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/hammer-x/f-h-x-offline/ubuntu_14.04.yaml
+++ b/qa/suites/upgrade/hammer-x/f-h-x-offline/ubuntu_14.04.yaml
@@ -1,0 +1,1 @@
+../../../../distros/all/ubuntu_14.04.yaml


### PR DESCRIPTION
The upgrade:hammer-x/f-h-x-offline test installs firefly, but firefly does not
build on CentOS anymore, just Ubuntu 14.04.

References: http://tracker.ceph.com/issues/18089
Signed-off-by: Nathan Cutler <ncutler@suse.com>