### PR TITLE
jewel: rgw: radosgw-admin period update reverts deleted zonegroup 

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1230,6 +1230,7 @@ struct RGWPeriodMap
   void reset() {
     zonegroups.clear();
     zonegroups_by_api.clear();
+    master_zonegroup.clear();
   }
 
   uint32_t get_zone_short_id(const string& zone_id) const;


### PR DESCRIPTION
http://tracker.ceph.com/issues/18712