### PR TITLE
jewel: rgw: slave zonegroup cannot enable the bucket versioning

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1578,8 +1578,8 @@ void RGWSetBucketVersioning::execute()
     op_ret = forward_request_to_master(s, NULL, store, in_data, nullptr);
     if (op_ret < 0) {
       ldout(s->cct, 20) << __func__ << "forward_request_to_master returned ret=" << op_ret << dendl;
+      return;
     }
-    return;
   }
 
   if (enable_versioning) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/18710