### PR TITLE
jewel: rgw: multisite: memory leak in RGWCloneMetaLogCoroutine::state_store_mdlog_entries()

### DIFF
--- a/src/rgw/rgw_coroutine.cc
+++ b/src/rgw/rgw_coroutine.cc
@@ -33,7 +33,6 @@ void RGWCompletionManager::register_completion_notifier(RGWAioCompletionNotifier
   Mutex::Locker l(lock);
   if (cn) {
     cns.insert(cn);
-    cn->get();
   }
 }
 
@@ -42,7 +41,6 @@ void RGWCompletionManager::unregister_completion_notifier(RGWAioCompletionNotifi
   Mutex::Locker l(lock);
   if (cn) {
     cns.erase(cn);
-    cn->put();
   }
 }
 
@@ -50,7 +48,6 @@ void RGWCompletionManager::_complete(RGWAioCompletionNotifier *cn, void *user_in
 {
   if (cn) {
     cns.erase(cn);
-    cn->put();
   }
   complete_reqs.push_back(user_info);
   cond.Signal();

--- a/src/rgw/rgw_coroutine.h
+++ b/src/rgw/rgw_coroutine.h
@@ -7,6 +7,7 @@
 #endif
 
 #include <boost/asio.hpp>
+#include <boost/intrusive_ptr.hpp>
 
 #ifdef NEED_ASSERT_H
 #pragma pop_macro("_ASSERT_H")
@@ -30,7 +31,8 @@ class RGWAioCompletionNotifier;
 class RGWCompletionManager : public RefCountedObject {
   CephContext *cct;
   list<void *> complete_reqs;
-  set<RGWAioCompletionNotifier *> cns;
+  using NotifierRef = boost::intrusive_ptr<RGWAioCompletionNotifier>;
+  set<NotifierRef> cns;
 
   Mutex lock;
   Cond cond;

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -21,11 +21,9 @@ public:
   RGWAsyncRadosRequest(RGWCoroutine *_caller, RGWAioCompletionNotifier *_cn) : caller(_caller), notifier(_cn), retcode(0),
                                                                                done(false), lock("RGWAsyncRadosRequest::lock") {
     notifier->get();
-    caller->get();
   }
   virtual ~RGWAsyncRadosRequest() {
     notifier->put();
-    caller->put();
   }
 
   void send_request() {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -11,19 +11,18 @@ class RGWAsyncRadosRequest : public RefCountedObject {
 
   int retcode;
 
-  bool done;
-
   Mutex lock;
 
 protected:
   virtual int _send_request() = 0;
 public:
   RGWAsyncRadosRequest(RGWCoroutine *_caller, RGWAioCompletionNotifier *_cn) : caller(_caller), notifier(_cn), retcode(0),
-                                                                               done(false), lock("RGWAsyncRadosRequest::lock") {
-    notifier->get();
+                                                                               lock("RGWAsyncRadosRequest::lock") {
   }
   virtual ~RGWAsyncRadosRequest() {
-    notifier->put();
+    if (notifier) {
+      notifier->put();
+    }
   }
 
   void send_request() {
@@ -31,8 +30,9 @@ public:
     retcode = _send_request();
     {
       Mutex::Locker l(lock);
-      if (!done) {
-        notifier->cb();
+      if (notifier) {
+        notifier->cb(); // drops its own ref
+        notifier = nullptr;
       }
     }
     put();
@@ -43,7 +43,11 @@ public:
   void finish() {
     {
       Mutex::Locker l(lock);
-      done = true;
+      if (notifier) {
+        // we won't call notifier->cb() to drop its ref, so drop it here
+        notifier->put();
+        notifier = nullptr;
+      }
     }
     put();
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/18559
http://tracker.ceph.com/issues/18560