### PR TITLE
jewel: build/ops: add ldap lib to rgw lib deps based on build config

### DIFF
--- a/src/rgw/Makefile.am
+++ b/src/rgw/Makefile.am
@@ -116,6 +116,11 @@ LIBRGW_DEPS += \
 	-lfcgi \
 	-ldl
 
+if WITH_OPENLDAP
+LIBRGW_DEPS += \
+        -lldap
+endif
+
 librgw_la_LIBADD = $(LIBRGW_DEPS) \
 	$(PTHREAD_LIBS) $(RESOLV_LIBS) libglobal.la \
 	$(EXTRALIBS)


### PR DESCRIPTION
http://tracker.ceph.com/issues/17313