### PR TITLE
kraken: build/ops: systemd restarts Ceph Mon to quickly after failing to start

### DIFF
--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -24,7 +24,8 @@ PrivateTmp=true
 TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
-StartLimitBurst=3
+StartLimitBurst=5
+RestartSec=10
 
 [Install]
 WantedBy=ceph-mon.target


### PR DESCRIPTION
http://tracker.ceph.com/issues/18721