### PR TITLE
qa/workunits/rest: use unique pool names for cephfs test

### DIFF
--- a/qa/workunits/rest/test.py
+++ b/qa/workunits/rest/test.py
@@ -171,9 +171,9 @@ if __name__ == '__main__':
     assert(r.tree.find('output/mdsmap/created') is not None)
 
     expect('fs/flag/set?flag_name=enable_multiple&val=true', 'PUT', 200, '')
-    expect('osd/pool/create?pg_num=1&pool=cephfs_metadata', 'PUT', 200, '')
-    expect('osd/pool/create?pg_num=1&pool=cephfs_data', 'PUT', 200, '')
-    expect('fs/new?fs_name=cephfs&metadata=cephfs_metadata&data=cephfs_data', 'PUT', 200, '')
+    expect('osd/pool/create?pg_num=1&pool=my_cephfs_metadata', 'PUT', 200, '')
+    expect('osd/pool/create?pg_num=1&pool=my_cephfs_data', 'PUT', 200, '')
+    expect('fs/new?fs_name=mycephfs&metadata=my_cephfs_metadata&data=my_cephfs_data', 'PUT', 200, '')
     expect('osd/pool/create?pool=data2&pg_num=10', 'PUT', 200, '')
     r = expect('osd/dump', 'GET', 200, 'json', JSONHDR)
     pools = r.myjson['output']['pools']


### PR DESCRIPTION
Using cephfs_[meta]data collides with the pools that teuthology
already creates if an mds is defined.

This became a (noticeable) problem with 052c3d3f681017d56b5b0ee5cf6f65bffc952a4c

Signed-off-by: Sage Weil <sage@redhat.com>