### PR TITLE
rbd: destination pool should be source pool if it is not specified

### DIFF
--- a/qa/workunits/rbd/copy.sh
+++ b/qa/workunits/rbd/copy.sh
@@ -95,7 +95,8 @@ test_rename() {
     rbd create -p rbd2 -s 1 foo
     rbd rename rbd2/foo rbd2/bar
     rbd -p rbd2 ls | grep bar
-    ! rbd rename rbd2/bar foo
+    rbd rename rbd2/bar foo
+    rbd rename --pool rbd2 foo bar
     ! rbd rename rbd2/bar --dest-pool rbd foo
     rbd rename --pool rbd2 bar --dest-pool rbd2 foo
     rbd -p rbd2 ls | grep foo

--- a/src/tools/rbd/action/Rename.cc
+++ b/src/tools/rbd/action/Rename.cc
@@ -42,9 +42,9 @@ int execute(const po::variables_map &vm) {
     return r;
   }
 
-  std::string dst_pool_name;
   std::string dst_image_name;
   std::string dst_snap_name;
+  std::string dst_pool_name = pool_name;
   r = utils::get_pool_image_snapshot_names(
     vm, at::ARGUMENT_MODIFIER_DEST, &arg_index, &dst_pool_name, &dst_image_name,
     &dst_snap_name, utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_FULL);


### PR DESCRIPTION
Currently if user perform image rename operation and user give pool
name as a optional parameter (--pool=<pool_name>) then currently
its taking this optional pool name for source pool and making
destination pool name default pool name.
With this fix if user provide pool name as a optional pool name
parameter then it  will consider both soruce and destination pool
name as optional parameter pool name.

Fixes: http://tracker.ceph.com/issues/18326

Reported-by: МАРК КОРЕНБЕРГ <socketpair@gmail.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>