### PR TITLE
mds,mon: Clean issues detected by cppcheck

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1168,9 +1168,9 @@ void MDLog::_reformat_journal(JournalPointer const &jp_in, Journaler *old_journa
       if (le->get_type() == EVENT_SUBTREEMAP
           || le->get_type() == EVENT_SUBTREEMAP_TEST) {
         ESubtreeMap *sle = dynamic_cast<ESubtreeMap*>(le);
+        assert(sle != NULL);
         dout(20) << __func__ << " zeroing expire_pos in subtreemap event at "
           << le_pos << " seq=" << sle->event_seq << dendl;
-        assert(sle != NULL);
         sle->expire_pos = 0;
         modified = true;
       }

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -2618,11 +2618,11 @@ void MDSMonitor::check_sub(Subscription *sub)
       mds_map = &(fsmap.filesystems.at(fscid)->mds_map);
     }
 
+    assert(mds_map != nullptr);
     dout(10) << __func__ << " selected MDS map epoch " <<
       mds_map->epoch << " for namespace " << fscid << " for subscriber "
       << sub->session->inst.name << " who wants epoch " << sub->next << dendl;
 
-    assert(mds_map != nullptr);
     if (sub->next > mds_map->epoch) {
       return;
     }


### PR DESCRIPTION
[src/mds/MDLog.cc:1172] -> [src/mds/MDLog.cc:1173]: (warning) Either the condition 'sle!=NULL' is redundant or there is possible null pointer dereference: sle.
[src/mon/MDSMonitor.cc:2622] -> [src/mon/MDSMonitor.cc:2625]: (warning) Either the condition 'mds_map!=nullptr' is redundant or there is possible null pointer dereference: mds_map.