### PR TITLE
kraken: librbd: prevent self-blacklisting during break lock

### DIFF
--- a/src/librbd/exclusive_lock/BreakRequest.cc
+++ b/src/librbd/exclusive_lock/BreakRequest.cc
@@ -112,7 +112,16 @@ void BreakRequest<I>::send_blacklist() {
   }
 
   CephContext *cct = m_image_ctx.cct;
-  ldout(cct, 10) << dendl;
+  entity_name_t entity_name = entity_name_t::CLIENT(
+    m_image_ctx.md_ctx.get_instance_id());
+  ldout(cct, 10) << "local entity=" << entity_name << ", "
+                 << "locker entity=" << m_locker.entity << dendl;
+
+  if (m_locker.entity == entity_name) {
+    lderr(cct) << "attempting to self-blacklist" << dendl;
+    finish(-EINVAL);
+    return;
+  }
 
   // TODO: need async version of RadosClient::blacklist_add
   using klass = BreakRequest<I>;

--- a/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
+++ b/src/test/librados_test_stub/MockTestMemIoCtxImpl.h
@@ -60,6 +60,11 @@ public:
                                   snapc);
   }
 
+  MOCK_CONST_METHOD0(get_instance_id, uint64_t());
+  uint64_t do_get_instance_id() const {
+    return TestMemIoCtxImpl::get_instance_id();
+  }
+
   MOCK_METHOD2(list_snaps, int(const std::string& o, snap_set_t *out_snaps));
   int do_list_snaps(const std::string& o, snap_set_t *out_snaps) {
     return TestMemIoCtxImpl::list_snaps(o, out_snaps);
@@ -148,6 +153,7 @@ public:
     ON_CALL(*this, aio_watch(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_watch));
     ON_CALL(*this, aio_unwatch(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_aio_unwatch));
     ON_CALL(*this, exec(_, _, _, _, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_exec));
+    ON_CALL(*this, get_instance_id()).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_get_instance_id));
     ON_CALL(*this, list_snaps(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_snaps));
     ON_CALL(*this, list_watchers(_, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_list_watchers));
     ON_CALL(*this, notify(_, _, _, _)).WillByDefault(Invoke(this, &MockTestMemIoCtxImpl::do_notify));


### PR DESCRIPTION
http://tracker.ceph.com/issues/18703