### PR TITLE
cmake: add support for debug mode compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules/")
 
+if(${CMAKE_BUILD_TYPE} MATCHES "Debug")
+  add_definitions(-DDEBUG)
+endif()
+
 if(CMAKE_SYSTEM_NAME MATCHES "Linux")
   set(LINUX ON)
   FIND_PACKAGE(Threads)


### PR DESCRIPTION
Signed-off-by: Pan Liu <pan.liu@istuary.com>

Debug mode compile is needed, and the user could get a debug version which supports gdb well, by changing one line in do_cmake.sh:
orig: cmake -DBOOST_J=$(nproc) "$@" .. 
new: cmake -DBOOST_J=$(nproc) "$@" .. -DCMAKE_BUILD_TYPE=Debug
