### PR TITLE
mon: restructure prime_pg_temp around a full pg mapping calculated on multiple CPUs

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -460,6 +460,7 @@ set(libcommon_files
   msg/msg_types.cc
   common/hobject.cc
   osd/OSDMap.cc
+  osd/OSDMapMapping.cc
   common/histogram.cc
   osd/osd_types.cc
   osd/OpRequest.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -260,6 +260,7 @@ OPTION(mon_compact_on_bootstrap, OPT_BOOL, false)  // trigger leveldb compaction
 OPTION(mon_compact_on_trim, OPT_BOOL, true)       // compact (a prefix) when we trim old states
 OPTION(mon_osd_cache_size, OPT_INT, 10)  // the size of osdmaps cache, not to rely on underlying store's cache
 
+OPTION(mon_cpu_threads, OPT_INT, 4)
 OPTION(mon_tick_interval, OPT_INT, 5)
 OPTION(mon_session_timeout, OPT_INT, 300)    // must send keepalive or subscribe
 OPTION(mon_subscribe_interval, OPT_DOUBLE, 24*3600)  // for legacy clients only

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -261,6 +261,7 @@ OPTION(mon_compact_on_trim, OPT_BOOL, true)       // compact (a prefix) when we 
 OPTION(mon_osd_cache_size, OPT_INT, 10)  // the size of osdmaps cache, not to rely on underlying store's cache
 
 OPTION(mon_cpu_threads, OPT_INT, 4)
+OPTION(mon_osd_mapping_pgs_per_chunk, OPT_INT, 4096)
 OPTION(mon_tick_interval, OPT_INT, 5)
 OPTION(mon_session_timeout, OPT_INT, 300)    // must send keepalive or subscribe
 OPTION(mon_subscribe_interval, OPT_DOUBLE, 24*3600)  // for legacy clients only

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -284,6 +284,7 @@ OPTION(mon_osd_allow_primary_temp, OPT_BOOL, false)  // allow primary_temp to be
 OPTION(mon_osd_allow_primary_affinity, OPT_BOOL, false)  // allow primary_affinity to be set in the osdmap
 OPTION(mon_osd_prime_pg_temp, OPT_BOOL, true)  // prime osdmap with pg mapping changes
 OPTION(mon_osd_prime_pg_temp_max_time, OPT_FLOAT, .5)  // max time to spend priming
+OPTION(mon_osd_prime_pg_temp_max_estimate, OPT_FLOAT, .25) // max estimate of pg total before we do all pgs in parallel
 OPTION(mon_osd_pool_ec_fast_read, OPT_BOOL, false) // whether turn on fast read on the pool or not
 OPTION(mon_stat_smooth_intervals, OPT_INT, 6)  // smooth stats over last N PGMap maps
 OPTION(mon_election_timeout, OPT_FLOAT, 5)  // on election proposer, max waiting time for all ACKs

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -148,6 +148,7 @@ namespace mempool {
   f(buffer_meta)		      \
   f(buffer_data)		      \
   f(osd)			      \
+  f(osdmap_mapping)		      \
   f(unittest_1)			      \
   f(unittest_2)
 

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -103,6 +103,12 @@ void ClusterState::notify_osdmap(const OSDMap &osd_map)
   PGMapUpdater::update_creating_pgs(osd_map, &pg_map, &pending_inc);
   PGMapUpdater::register_new_pgs(osd_map, &pg_map, &pending_inc);
 
+  // brute force this for now (don't bother being clever by only
+  // checking osds that went up/down)
+  set<int> need_check_down_pg_osds;
+  PGMapUpdater::check_down_pgs(osd_map, &pg_map, true,
+			       need_check_down_pg_osds, &pending_inc);
+
   pg_map.apply_incremental(g_ceph_context, pending_inc);
 
   // TODO: Complete the separation of PG state handling so

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -44,6 +44,7 @@
 #include <cmath>
 
 #include "mon/MonOpRequest.h"
+#include "common/WorkQueue.h"
 
 
 #define CEPH_MON_PROTOCOL     13 /* cluster internal */
@@ -121,6 +122,7 @@ public:
   ConnectionRef con_self;
   Mutex lock;
   SafeTimer timer;
+  ThreadPool cpu_tp;  ///< threadpool for CPU intensive work
   
   /// true if we have ever joined a quorum.  if false, we are either a
   /// new cluster, a newly joining monitor, or a just-upgraded

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1051,10 +1051,14 @@ void OSDMonitor::maybe_prime_pg_temp()
     }
   } else {
     dout(10) << __func__ << " " << osds.size() << " interesting osds" << dendl;
+    std::unordered_set<pg_t> did_pgs;
     for (auto osd : osds) {
       const vector<pg_t>& pgs = mapping->get_osd_acting_pgs(osd);
       dout(20) << __func__ << " osd." << osd << " " << pgs << dendl;
       for (auto pgid : pgs) {
+	if (!did_pgs.insert(pgid).second) {
+	  continue;
+	}
 	if (!pg_map->creating_pgs.count(pgid)) {
 	  prime_pg_temp(next, pgid);
 	}

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -382,8 +382,8 @@ void OSDMonitor::on_active()
   }
   C_PrintTime *fin = new C_PrintTime(osdmap.get_epoch());
   mapping.reset(new OSDMapMapping);
-  mapping_job = mapper.queue(osdmap, mapping.get(),
-			     g_conf->mon_osd_mapping_pgs_per_chunk);
+  mapping_job = mapping->start_update(osdmap, mapper,
+				      g_conf->mon_osd_mapping_pgs_per_chunk);
   dout(10) << __func__ << " started mapping job " << mapping_job.get()
 	   << " at " << fin->start << dendl;
   mapping_job->set_finish_event(fin);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1014,6 +1014,23 @@ void OSDMonitor::maybe_prime_pg_temp()
   if (!all && osds.empty())
     return;
 
+  if (!all) {
+    unsigned estimate =
+      mapping->get_osd_acting_pgs(*osds.begin()).size() * osds.size();
+    if (estimate > mapping->get_num_pgs() *
+	g_conf->mon_osd_prime_pg_temp_max_estimate) {
+      dout(10) << __func__ << " estimate " << estimate << " pgs on "
+	       << osds.size() << " osds >= "
+	       << g_conf->mon_osd_prime_pg_temp_max_estimate << " of total "
+	       << mapping->get_num_pgs() << " pgs, all"
+	       << dendl;
+      all = true;
+    } else {
+      dout(10) << __func__ << " estimate " << estimate << " pgs on "
+	       << osds.size() << " osds" << dendl;
+    }
+  }
+
   OSDMap next;
   next.deepish_copy_from(osdmap);
   next.apply_incremental(pending_inc);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1054,7 +1054,7 @@ void OSDMonitor::maybe_prime_pg_temp()
     int n = chunk;
     std::unordered_set<pg_t> did_pgs;
     for (auto osd : osds) {
-      const vector<pg_t>& pgs = mapping->get_osd_acting_pgs(osd);
+      auto& pgs = mapping->get_osd_acting_pgs(osd);
       dout(20) << __func__ << " osd." << osd << " " << pgs << dendl;
       for (auto pgid : pgs) {
 	if (!did_pgs.insert(pgid).second) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -354,6 +354,12 @@ void OSDMonitor::on_active()
       ls.pop_front();
     }
   }
+
+  // FIXME: hacky synchronous blocking mapping update
+  utime_t start = ceph_clock_now();
+  mapping.update(osdmap);
+  utime_t end = ceph_clock_now();
+  dout(10) << __func__ << " updated mapping in " << (end - start) << dendl;
 }
 
 void OSDMonitor::on_shutdown()

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -194,8 +194,21 @@ private:
 
   void share_map_with_random_osd();
 
+  Mutex prime_pg_temp_lock = {"OSDMonitor::prime_pg_temp_lock"};
+  struct PrimeTempJob : public ParallelPGMapper::Job {
+    OSDMonitor *osdmon;
+    PrimeTempJob(const OSDMap& om, OSDMonitor *m)
+      : ParallelPGMapper::Job(&om), osdmon(m) {}
+    void process(int64_t pool, unsigned ps_begin, unsigned ps_end) override {
+      for (unsigned ps = ps_begin; ps < ps_end; ++ps) {
+	pg_t pgid(ps, pool);
+	osdmon->prime_pg_temp(*osdmap, pgid);
+      }
+    }
+    void complete() override {}
+  };
   void maybe_prime_pg_temp();
-  void prime_pg_temp(OSDMap& next, pg_t pgid);
+  void prime_pg_temp(const OSDMap& next, pg_t pgid);
 
   void update_logger();
 

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -30,6 +30,7 @@ using namespace std;
 #include "msg/Messenger.h"
 
 #include "osd/OSDMap.h"
+#include "osd/OSDMapMapping.h"
 
 #include "PaxosService.h"
 
@@ -113,6 +114,7 @@ class OSDMonitor : public PaxosService {
   CephContext *cct;
 public:
   OSDMap osdmap;
+  OSDMapMapping mapping;
 
 private:
   // [leader]

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -115,6 +115,7 @@ class OSDMonitor : public PaxosService {
 public:
   OSDMap osdmap;
   unique_ptr<OSDMapMapping> mapping;
+  unique_ptr<ParallelOSDMapper::Job> mapping_job;
 
 private:
   ParallelOSDMapper mapper;
@@ -147,8 +148,6 @@ private:
     FAST_READ_ON,
     FAST_READ_DEFAULT
   };
-
-  void _calc_mapping(const OSDMap& osdmap, OSDMapMapping *mapping);
 
   // svc
 public:  

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -112,13 +112,13 @@ struct failure_info_t {
 
 class OSDMonitor : public PaxosService {
   CephContext *cct;
+
+  ParallelPGMapper mapper;                        ///< for background pg work
+  unique_ptr<OSDMapMapping> mapping;              ///< pg <-> osd mappings
+  unique_ptr<ParallelPGMapper::Job> mapping_job;  ///< background mapping job
+
 public:
   OSDMap osdmap;
-  unique_ptr<OSDMapMapping> mapping;
-  unique_ptr<ParallelOSDMapper::Job> mapping_job;
-
-private:
-  ParallelOSDMapper mapper;
 
   // [leader]
   OSDMap::Incremental pending_inc;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -114,9 +114,11 @@ class OSDMonitor : public PaxosService {
   CephContext *cct;
 public:
   OSDMap osdmap;
-  OSDMapMapping mapping;
+  unique_ptr<OSDMapMapping> mapping;
 
 private:
+  ParallelOSDMapper mapper;
+
   // [leader]
   OSDMap::Incremental pending_inc;
   map<int, bufferlist> pending_metadata;
@@ -145,6 +147,8 @@ private:
     FAST_READ_ON,
     FAST_READ_DEFAULT
   };
+
+  void _calc_mapping(const OSDMap& osdmap, OSDMapMapping *mapping);
 
   // svc
 public:  

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -192,9 +192,7 @@ private:
   void share_map_with_random_osd();
 
   void maybe_prime_pg_temp();
-  void prime_pg_temp(OSDMap& next,
-		     ceph::unordered_map<pg_t, pg_stat_t>::iterator pp);
-  int prime_pg_temp(OSDMap& next, PGMap *pg_map, int osd);
+  void prime_pg_temp(OSDMap& next, pg_t pgid);
 
   void update_logger();
 

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2367,3 +2367,70 @@ void PGMapUpdater::update_creating_pgs(
   }
 }
 
+static void _try_mark_pg_stale(
+  const OSDMap& osdmap,
+  pg_t pgid,
+  const pg_stat_t& cur,
+  PGMap::Incremental *pending_inc)
+{
+  if ((cur.state & PG_STATE_STALE) == 0 &&
+      cur.acting_primary != -1 &&
+      osdmap.is_down(cur.acting_primary)) {
+    pg_stat_t *newstat;
+    auto q = pending_inc->pg_stat_updates.find(pgid);
+    if (q != pending_inc->pg_stat_updates.end()) {
+      if ((q->second.acting_primary == cur.acting_primary) ||
+	  ((q->second.state & PG_STATE_STALE) == 0 &&
+	   q->second.acting_primary != -1 &&
+	   osdmap.is_down(q->second.acting_primary))) {
+	newstat = &q->second;
+      } else {
+	// pending update is no longer down or already stale
+	return;
+      }
+    } else {
+      newstat = &pending_inc->pg_stat_updates[pgid];
+      *newstat = cur;
+    }
+    dout(10) << __func__ << " marking pg " << pgid
+	     << " stale (acting_primary " << newstat->acting_primary
+	     << ")" << dendl;
+    newstat->state |= PG_STATE_STALE;
+    newstat->last_unstale = ceph_clock_now();
+  }
+}
+
+void PGMapUpdater::check_down_pgs(
+    const OSDMap &osdmap,
+    const PGMap *pg_map,
+    bool check_all,
+    const set<int>& need_check_down_pg_osds,
+    PGMap::Incremental *pending_inc)
+{
+  // if a large number of osds changed state, just iterate over the whole
+  // pg map.
+  if (need_check_down_pg_osds.size() > (unsigned)osdmap.get_num_osds() *
+      g_conf->mon_pg_check_down_all_threshold) {
+    check_all = true;
+  }
+
+  if (check_all) {
+    for (const auto& p : pg_map->pg_stat) {
+      _try_mark_pg_stale(osdmap, p.first, p.second, pending_inc);
+    }
+  } else {
+    for (auto osd : need_check_down_pg_osds) {
+      if (osdmap.is_down(osd)) {
+	auto p = pg_map->pg_by_osd.find(osd);
+	if (p == pg_map->pg_by_osd.end()) {
+	  continue;
+	}
+	for (auto pgid : p->second) {
+	  const pg_stat_t &stat = pg_map->pg_stat.at(pgid);
+	  assert(stat.acting_primary == osd);
+	  _try_mark_pg_stale(osdmap, pgid, stat, pending_inc);
+	}
+      }
+    }
+  }
+}

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -418,6 +418,13 @@ public:
       bool new_pool,
       PGMap *pg_map,
       PGMap::Incremental *pending_inc);
+
+  static void check_down_pgs(
+      const OSDMap &osd_map,
+      const PGMap *pg_map,
+      bool check_all,
+      const set<int>& need_check_down_pg_osds,
+      PGMap::Incremental *pending_inc);
 };
 
 #endif

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -67,8 +67,8 @@ void PGMonitor::on_restart()
 void PGMonitor::on_active()
 {
   if (mon->is_leader()) {
+    check_all_pgs = true;
     check_osd_map(mon->osdmon()->osdmap.get_epoch());
-    need_check_down_pgs = true;
   }
 
   update_logger();
@@ -861,6 +861,9 @@ void PGMonitor::check_osd_map(epoch_t epoch)
     return;
   }
 
+  // osds that went up or down
+  set<int> need_check_down_pg_osds;
+
   // apply latest map(s)
   for (epoch_t e = pg_map.last_osdmap_epoch+1;
        e <= epoch;
@@ -877,14 +880,15 @@ void PGMonitor::check_osd_map(epoch_t epoch)
                                 &last_osd_report, &pg_map, &pending_inc);
   }
 
+  const OSDMap& osdmap = mon->osdmon()->osdmap;
   assert(pg_map.last_osdmap_epoch < epoch);
   pending_inc.osdmap_epoch = epoch;
-  PGMapUpdater::update_creating_pgs(mon->osdmon()->osdmap,
-                                    &pg_map, &pending_inc);
-  PGMapUpdater::register_new_pgs(mon->osdmon()->osdmap, &pg_map, &pending_inc);
+  PGMapUpdater::update_creating_pgs(osdmap, &pg_map, &pending_inc);
+  PGMapUpdater::register_new_pgs(osdmap, &pg_map, &pending_inc);
 
-  if (need_check_down_pgs || !need_check_down_pg_osds.empty())
-    check_down_pgs();
+  PGMapUpdater::check_down_pgs(osdmap, &pg_map, check_all_pgs,
+			       need_check_down_pg_osds, &pending_inc);
+  check_all_pgs = false;
 
   propose_pending();
 }
@@ -931,76 +935,6 @@ epoch_t PGMonitor::send_pg_creates(int osd, Connection *con, epoch_t next)
 
   // sub is current through last + 1
   return last + 1;
-}
-
-void PGMonitor::_try_mark_pg_stale(
-  const OSDMap *osdmap,
-  pg_t pgid,
-  const pg_stat_t& cur_stat)
-{
-  map<pg_t,pg_stat_t>::iterator q = pending_inc.pg_stat_updates.find(pgid);
-  pg_stat_t *stat;
-  if (q == pending_inc.pg_stat_updates.end()) {
-    stat = &pending_inc.pg_stat_updates[pgid];
-    *stat = cur_stat;
-  } else {
-    stat = &q->second;
-  }
-  if ((stat->acting_primary == cur_stat.acting_primary) ||
-      ((stat->state & PG_STATE_STALE) == 0 &&
-       stat->acting_primary != -1 &&
-       osdmap->is_down(stat->acting_primary))) {
-    dout(10) << " marking pg " << pgid << " stale (acting_primary "
-	     << stat->acting_primary << ")" << dendl;
-    stat->state |= PG_STATE_STALE;  
-    stat->last_unstale = ceph_clock_now();
-  }
-}
-
-void PGMonitor::check_down_pgs()
-{
-  dout(10) << "check_down_pgs last_osdmap_epoch "
-	   << pg_map.last_osdmap_epoch << dendl;
-  if (pg_map.last_osdmap_epoch == 0)
-    return;
-
-  // use the OSDMap that matches the one pg_map has consumed.
-  std::unique_ptr<OSDMap> osdmap;
-  bufferlist bl;
-  int err = mon->osdmon()->get_version_full(pg_map.last_osdmap_epoch, bl);
-  assert(err == 0);
-  osdmap.reset(new OSDMap);
-  osdmap->decode(bl);
-
-  // if a large number of osds changed state, just iterate over the whole
-  // pg map.
-  if (need_check_down_pg_osds.size() > (unsigned)osdmap->get_num_osds() *
-      g_conf->mon_pg_check_down_all_threshold)
-    need_check_down_pgs = true;
-
-  if (need_check_down_pgs) {
-    for (auto p : pg_map.pg_stat) {
-      if ((p.second.state & PG_STATE_STALE) == 0 &&
-          p.second.acting_primary != -1 &&
-          osdmap->is_down(p.second.acting_primary)) {
-	_try_mark_pg_stale(osdmap.get(), p.first, p.second);
-      }
-    }
-  } else {
-    for (auto osd : need_check_down_pg_osds) {
-      if (osdmap->is_down(osd)) {
-	for (auto pgid : pg_map.pg_by_osd[osd]) {
-	  const pg_stat_t &stat = pg_map.pg_stat[pgid];
-	  assert(stat.acting_primary == osd);
-	  if ((stat.state & PG_STATE_STALE) == 0) {
-	    _try_mark_pg_stale(osdmap.get(), pgid, stat);
-	  }
-	}
-      }
-    }
-  }
-  need_check_down_pgs = false;
-  need_check_down_pg_osds.clear();
 }
 
 void PGMonitor::dump_info(Formatter *f) const

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -43,11 +43,10 @@ class PGMonitor : public PaxosService {
 public:
   PGMap pg_map;
 
-  bool need_check_down_pgs;
-  set<int> need_check_down_pg_osds;
-
 private:
   PGMap::Incremental pending_inc;
+
+  bool check_all_pgs = false;
 
   const char *pgmap_meta_prefix;
   const char *pgmap_pg_prefix;
@@ -95,18 +94,6 @@ private:
   epoch_t send_pg_creates(int osd, Connection *con, epoch_t next);
 
   /**
-   * check pgs for down primary osds
-   *
-   * clears need_check_down_pgs
-   * clears need_check_down_pg_osds
-   *
-   */
-  void check_down_pgs();
-  void _try_mark_pg_stale(const OSDMap *osdmap, pg_t pgid,
-			  const pg_stat_t& cur_stat);
-
-
-  /**
    * Dump stats from pgs stuck in specified states.
    *
    * @return 0 on success, negative error code on failure
@@ -118,7 +105,6 @@ private:
 public:
   PGMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name),
-      need_check_down_pgs(false),
       pgmap_meta_prefix("pgmap_meta"),
       pgmap_pg_prefix("pgmap_pg"),
       pgmap_osd_prefix("pgmap_osd")

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -36,9 +36,11 @@
 #include "include/memory.h"
 using namespace std;
 
-//forward declaration
+// forward declaration
 class CephContext;
 class CrushWrapper;
+
+
 /*
  * we track up to two intervals during which the osd was alive and
  * healthy.  the most recent is [up_from,up_thru), where up_thru is

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -8,6 +8,9 @@
 
 #include "common/debug.h"
 
+MEMPOOL_DEFINE_OBJECT_FACTORY(OSDMapMapping, osdmapmapping,
+			      osdmap_mapping);
+
 // ensure that we have a PoolMappings for each pool and that
 // the dimensions (pg_num and size) match up.
 void OSDMapMapping::_init_mappings(const OSDMap& osdmap)

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -12,8 +12,10 @@
 // the dimensions (pg_num and size) match up.
 void OSDMapMapping::_init_mappings(const OSDMap& osdmap)
 {
+  num_pgs = 0;
   auto q = pools.begin();
   for (auto& p : osdmap.get_pools()) {
+    num_pgs += p.second.get_pg_num();
     // drop unneeded pools
     while (q != pools.end() && q->first < p.first) {
       q = pools.erase(q);

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -54,13 +54,13 @@ void OSDMapMapping::update(const OSDMap& osdmap, pg_t pgid)
 void OSDMapMapping::_build_rmap(const OSDMap& osdmap)
 {
   acting_rmap.resize(osdmap.get_max_osd());
-  up_rmap.resize(osdmap.get_max_osd());
+  //up_rmap.resize(osdmap.get_max_osd());
   for (auto& v : acting_rmap) {
     v.resize(0);
   }
-  for (auto& v : up_rmap) {
-    v.resize(0);
-  }
+  //for (auto& v : up_rmap) {
+  //  v.resize(0);
+  //}
   for (auto& p : pools) {
     pg_t pgid(0, p.first);
     for (unsigned ps = 0; ps < p.second.pg_num; ++ps) {
@@ -71,9 +71,9 @@ void OSDMapMapping::_build_rmap(const OSDMap& osdmap)
 	  acting_rmap[row[4 + i]].push_back(pgid);
 	}
       }
-      for (int i = 0; i < row[3]; ++i) {
-	up_rmap[row[4 + p.second.size + i]].push_back(pgid);
-      }
+      //for (int i = 0; i < row[3]; ++i) {
+      //up_rmap[row[4 + p.second.size + i]].push_back(pgid);
+      //}
     }
   }
 }

--- a/src/osd/OSDMapMapping.cc
+++ b/src/osd/OSDMapMapping.cc
@@ -1,0 +1,103 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "OSDMapMapping.h"
+#include "OSDMap.h"
+
+// ensure that we have a PoolMappings for each pool and that
+// the dimensions (pg_num and size) match up.
+void OSDMapMapping::_init_mappings(const OSDMap& osdmap)
+{
+  auto q = pools.begin();
+  for (auto& p : osdmap.get_pools()) {
+    // drop unneeded pools
+    while (q != pools.end() && q->first < p.first) {
+      q = pools.erase(q);
+    }
+    if (q != pools.end() && q->first == p.first) {
+      if (q->second.pg_num != p.second.get_pg_num() ||
+	  q->second.size != p.second.get_size()) {
+	// pg_num changed
+	q = pools.erase(q);
+      } else {
+	// keep it
+	++q;
+	continue;
+      }
+    }
+    pools.emplace(p.first, PoolMapping(p.second.get_size(),
+				       p.second.get_pg_num()));
+  }
+  pools.erase(q, pools.end());
+  assert(pools.size() == osdmap.get_pools().size());
+}
+
+void OSDMapMapping::update(const OSDMap& osdmap)
+{
+  _init_mappings(osdmap);
+  for (auto& p : osdmap.get_pools()) {
+    _update_range(osdmap, p.first, 0, p.second.get_pg_num());
+  }
+  _build_rmap(osdmap);
+  //_dump();  // for debugging
+}
+
+void OSDMapMapping::_build_rmap(const OSDMap& osdmap)
+{
+  acting_rmap.resize(osdmap.get_max_osd());
+  up_rmap.resize(osdmap.get_max_osd());
+  for (auto& v : acting_rmap) {
+    v.resize(0);
+  }
+  for (auto& v : up_rmap) {
+    v.resize(0);
+  }
+  for (auto& p : pools) {
+    pg_t pgid(0, p.first);
+    for (unsigned ps = 0; ps < p.second.pg_num; ++ps) {
+      pgid.set_ps(ps);
+      int32_t *row = &p.second.table[p.second.row_size() * ps];
+      for (int i = 0; i < row[2]; ++i) {
+	if (row[4 + i] != CRUSH_ITEM_NONE) {
+	  acting_rmap[row[4 + i]].push_back(pgid);
+	}
+      }
+      for (int i = 0; i < row[3]; ++i) {
+	up_rmap[row[4 + p.second.size + i]].push_back(pgid);
+      }
+    }
+  }
+}
+
+void OSDMapMapping::_dump()
+{
+  for (auto& p : pools) {
+    cout << "pool " << p.first << std::endl;
+    for (unsigned i = 0; i < p.second.table.size(); ++i) {
+      cout << " " << p.second.table[i];
+      if (i % p.second.row_size() == p.second.row_size() - 1)
+	cout << std::endl;
+    }
+  }
+}
+
+void OSDMapMapping::_update_range(
+  const OSDMap& osdmap,
+  int64_t pool,
+  unsigned pg_begin,
+  unsigned pg_end)
+{
+  auto i = pools.find(pool);
+  assert(i != pools.end());
+  assert(pg_begin <= pg_end);
+  assert(pg_end <= i->second.pg_num);
+  for (unsigned ps = pg_begin; ps < pg_end; ++ps) {
+    vector<int> up, acting;
+    int up_primary, acting_primary;
+    osdmap.pg_to_up_acting_osds(
+      pg_t(ps, pool),
+      &up, &up_primary, &acting, &acting_primary);
+    i->second.set(ps, std::move(up), up_primary,
+		  std::move(acting), acting_primary);
+  }
+}

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -83,7 +83,7 @@ class OSDMapMapping {
 
   std::map<int64_t,PoolMapping> pools;
   std::vector<std::vector<pg_t>> acting_rmap;  // osd -> pg
-  std::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
+  //unused: std::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
   epoch_t epoch;
 
   void _init_mappings(const OSDMap& osdmap);
@@ -118,10 +118,12 @@ public:
     assert(osd < acting_rmap.size());
     return acting_rmap[osd];
   }
+  /* unsued
   const std::vector<pg_t>& get_osd_up_pgs(unsigned osd) {
     assert(osd < up_rmap.size());
     return up_rmap[osd];
   }
+  */
 
   void update(const OSDMap& map);
   void update(const OSDMap& map, pg_t pgid);

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -85,6 +85,7 @@ class OSDMapMapping {
   std::vector<std::vector<pg_t>> acting_rmap;  // osd -> pg
   //unused: std::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
   epoch_t epoch;
+  uint64_t num_pgs = 0;
 
   void _init_mappings(const OSDMap& osdmap);
   void _update_range(
@@ -130,6 +131,10 @@ public:
 
   epoch_t get_epoch() const {
     return epoch;
+  }
+
+  uint64_t get_num_pgs() const {
+    return num_pgs;
   }
 };
 

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -1,0 +1,121 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+
+#ifndef CEPH_OSDMAPMAPPING_H
+#define CEPH_OSDMAPMAPPING_H
+
+#include <vector>
+#include <map>
+
+#include "osd/osd_types.h"
+
+class OSDMap;
+
+/// a precalculated mapping of every PG for a given OSDMap
+class OSDMapMapping {
+  struct PoolMapping {
+    unsigned size = 0;
+    unsigned pg_num = 0;
+    std::vector<int32_t> table;
+
+    size_t row_size() const {
+      return
+	1 + // acting_primary
+	1 + // up_primary
+	1 + // num acting
+	1 + // num up
+	size + // acting
+	size;  // up
+    }
+
+    PoolMapping(int s, int p)
+      : size(s),
+	pg_num(p),
+	table(pg_num * row_size()) {
+    }
+
+    void get(size_t ps,
+	     std::vector<int> *up,
+	     int *up_primary,
+	     std::vector<int> *acting,
+	     int *acting_primary) {
+      int32_t *row = &table[row_size() * ps];
+      if (acting_primary) {
+	*acting_primary = row[0];
+      }
+      if (up_primary) {
+	*up_primary = row[1];
+      }
+      if (acting) {
+	acting->resize(row[2]);
+	for (int i = 0; i < row[2]; ++i) {
+	  (*acting)[i] = row[4 + i];
+	}
+      }
+      if (up) {
+	up->resize(row[3]);
+	for (int i = 0; i < row[3]; ++i) {
+	  (*up)[i] = row[4 + size + i];
+	}
+      }
+    }
+
+    void set(size_t ps,
+	     const std::vector<int>& up,
+	     int up_primary,
+	     const std::vector<int>& acting,
+	     int acting_primary) {
+      int32_t *row = &table[row_size() * ps];
+      row[0] = acting_primary;
+      row[1] = up_primary;
+      row[2] = acting.size();
+      row[3] = up.size();
+      for (int i = 0; i < row[2]; ++i) {
+	row[4 + i] = acting[i];
+      }
+      for (int i = 0; i < row[3]; ++i) {
+	row[4 + size + i] = up[i];
+      }
+    }
+  };
+
+  std::map<int64_t,PoolMapping> pools;
+  std::vector<std::vector<pg_t>> acting_rmap;  // osd -> pg
+  std::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
+
+  void _init_mappings(const OSDMap& osdmap);
+  void _update_range(
+    const OSDMap& map,
+    int64_t pool,
+    unsigned pg_begin, unsigned pg_end);
+
+  void _build_rmap(const OSDMap& osdmap);
+
+  void _dump();
+
+public:
+  void get(pg_t pgid,
+	   std::vector<int> *up,
+	   int *up_primary,
+	   std::vector<int> *acting,
+	   int *acting_primary) {
+    auto p = pools.find(pgid.pool());
+    assert(p != pools.end());
+    p->second.get(pgid.ps(), up, up_primary, acting, acting_primary);
+  }
+
+  const std::vector<pg_t>& get_osd_acting_pgs(unsigned osd) {
+    assert(osd < acting_rmap.size());
+    return acting_rmap[osd];
+  }
+  const std::vector<pg_t>& get_osd_up_pgs(unsigned osd) {
+    assert(osd < up_rmap.size());
+    return up_rmap[osd];
+  }
+
+  void update(const OSDMap& map);
+};
+
+
+#endif

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -167,10 +167,16 @@ public:
 
 /// a precalculated mapping of every PG for a given OSDMap
 class OSDMapMapping {
+public:
+  MEMPOOL_CLASS_HELPERS();
+private:
+
   struct PoolMapping {
+    MEMPOOL_CLASS_HELPERS();
+
     unsigned size = 0;
     unsigned pg_num = 0;
-    std::vector<int32_t> table;
+    mempool::osdmap_mapping::vector<int32_t> table;
 
     size_t row_size() const {
       return
@@ -233,9 +239,10 @@ class OSDMapMapping {
     }
   };
 
-  std::map<int64_t,PoolMapping> pools;
-  std::vector<std::vector<pg_t>> acting_rmap;  // osd -> pg
-  //unused: std::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
+  mempool::osdmap_mapping::map<int64_t,PoolMapping> pools;
+  mempool::osdmap_mapping::vector<
+    mempool::osdmap_mapping::vector<pg_t>> acting_rmap;  // osd -> pg
+  //unused: mempool::osdmap_mapping::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
   epoch_t epoch;
   uint64_t num_pgs = 0;
 
@@ -281,7 +288,7 @@ public:
     p->second.get(pgid.ps(), up, up_primary, acting, acting_primary);
   }
 
-  const std::vector<pg_t>& get_osd_acting_pgs(unsigned osd) {
+  const mempool::osdmap_mapping::vector<pg_t>& get_osd_acting_pgs(unsigned osd) {
     assert(osd < acting_rmap.size());
     return acting_rmap[osd];
   }

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 #include "gtest/gtest.h"
 #include "osd/OSDMap.h"
+#include "osd/OSDMapMapping.h"
 
 #include "global/global_context.h"
 #include "global/global_init.h"
@@ -28,6 +29,8 @@ class OSDMapTest : public testing::Test {
   const static int num_osds = 6;
 public:
   OSDMap osdmap;
+  OSDMapMapping mapping;
+
   OSDMapTest() {}
 
   void set_up_map() {
@@ -76,17 +79,29 @@ public:
 		     vector<int> *any,
 		     vector<int> *first,
 		     vector<int> *primary) {
+    mapping.update(osdmap);
     for (int i=0; i<num; ++i) {
-      vector<int> o;
-      int p;
+      vector<int> up, acting;
+      int up_primary, acting_primary;
       pg_t pgid(i, pool);
-      osdmap.pg_to_acting_osds(pgid, &o, &p);
-      for (unsigned j=0; j<o.size(); ++j)
-	(*any)[o[j]]++;
-      if (!o.empty())
-	(*first)[o[0]]++;
-      if (p >= 0)
-	(*primary)[p]++;
+      osdmap.pg_to_up_acting_osds(pgid,
+				  &up, &up_primary, &acting, &acting_primary);
+      for (unsigned j=0; j<acting.size(); ++j)
+	(*any)[acting[j]]++;
+      if (!acting.empty())
+	(*first)[acting[0]]++;
+      if (acting_primary >= 0)
+	(*primary)[acting_primary]++;
+
+      // compare to precalc mapping
+      vector<int> up2, acting2;
+      int up_primary2, acting_primary2;
+      pgid = osdmap.raw_pg_to_pg(pgid);
+      mapping.get(pgid, &up2, &up_primary2, &acting2, &acting_primary2);
+      ASSERT_EQ(up, up2);
+      ASSERT_EQ(up_primary, up_primary2);
+      ASSERT_EQ(acting, acting2);
+      ASSERT_EQ(acting_primary, acting_primary2);
     }
   }
 };


### PR DESCRIPTION
This is removing prime_pg_temps dependency on pg_map, with teh small exception of
checking for creating_pgs (which is being removed in a separate PR).

It also moves processing for calculating PG mappings *and* checking for needed pg_temp
values to a parallel work queue that runs on multiple cores.

Both work efforts (pg mapping calcs and prime_pg_temp) are time boxed with a graceful fallback.