### PR TITLE
init-ceph: Make init-ceph work under FreeBSD for init-system

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -159,7 +159,8 @@ do_root_cmd_okfail() {
 get_local_daemon_list() {
     type=$1
     if [ -d "/var/lib/ceph/$type" ]; then
-	for i in `find -L /var/lib/ceph/$type -mindepth 1 -maxdepth 1 -type d -printf '%f\n'`; do
+	for p in `find -L /var/lib/ceph/$type -mindepth 1 -maxdepth 1 -type d'`; do
+	    i=`basename $p` 
 	    if [ -e "/var/lib/ceph/$type/$i/sysvinit" ]; then
 		id=`echo $i | sed 's/[^-]*-//'`
 		local="$local $type.$id"

--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -50,6 +50,16 @@ if [ -n "$CEPH_BIN" ] && [ -n "$CEPH_ROOT" ] && [ -n "$CEPH_BUILD_DIR" ]; then
   ASSUME_DEV=1
 fi
 
+if [ `uname` = FreeBSD ]; then
+  GETOPT=/usr/local/bin/getopt
+else
+  GETOPT=getopt
+fi
+
+if id ceph > /dev/null 2>&1; then
+  SET_CEPHUSER_ARGS=" --setuser ceph --setgroup ceph"
+fi
+
 usage_exit() {
     echo "usage: $0 [options] {start|stop|restart|condrestart} [mon|osd|mds]..."
     printf "Core options:\n"
@@ -137,7 +147,7 @@ stop_daemon() {
 ## command line options
 options=
 
-OPTS=$(getopt -n 'init-ceph' -o 'hvam:c:' -l 'help,verbose,valgrind,novalgrind,allhosts,restart,norestart,btrfs,nobtrfs,fsmount,nofsmount,btrfsumount,fsumount,conf:,cluster:,hostname:' -- "$@")
+OPTS=$(${GETOPT} -n 'init-ceph' -o 'hvam:c:' -l 'help,verbose,valgrind,novalgrind,allhosts,restart,norestart,btrfs,nobtrfs,fsmount,nofsmount,btrfsumount,fsumount,conf:,cluster:,hostname:' -- "$@")
 if [ $? != 0 ]
 then
     exit 1
@@ -352,7 +362,7 @@ for name in $what; do
 
 	    [ -n "$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES" ] && tcmalloc="TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=$TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 
-	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster --setuser ceph --setgroup ceph $runmode"
+	    cmd="$files $tcmalloc $wrap $cmd --cluster $cluster ${SET_CEPHUSER_ARGS} ceph $runmode"
 
 	    if [ $dofsmount -eq 1 ] && [ -n "$fs_devs" ]; then
 		get_conf pre_mount "true" "pre mount command"


### PR DESCRIPTION
 - FreeBSD find does not have printf option
 - ulimit has different grammar
 - use the packaged getopt in /usr/local
 - Only apply user-facts when user ceph is available

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>