### PR TITLE
kraken: performance: os/bluestore: use aio for reads

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -90,13 +90,28 @@ public:
   virtual uint64_t get_size() const = 0;
   virtual uint64_t get_block_size() const = 0;
 
-  virtual int read(uint64_t off, uint64_t len, bufferlist *pbl,
-	   IOContext *ioc, bool buffered) = 0;
-  virtual int read_random(uint64_t off, uint64_t len, char *buf,
-           bool buffered) = 0;
+  virtual int read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc,
+    bool buffered) = 0;
+  virtual int read_random(
+    uint64_t off,
+    uint64_t len,
+    char *buf,
+    bool buffered) = 0;
 
-  virtual int aio_write(uint64_t off, bufferlist& bl,
-		IOContext *ioc, bool buffered) = 0;
+  virtual int aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc) = 0;
+  virtual int aio_write(
+    uint64_t off,
+    bufferlist& bl,
+    IOContext *ioc,
+    bool buffered) = 0;
   virtual int flush() = 0;
 
   void queue_reap_ioc(IOContext *ioc);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4982,6 +4982,11 @@ struct region_t {
   uint64_t logical_offset;
   uint64_t blob_xoffset;   //region offset within the blob
   uint64_t length;
+  bufferlist bl;
+
+  // used later in read process
+  uint64_t front = 0;
+  uint64_t r_off = 0;
 
   region_t(uint64_t offset, uint64_t b_offs, uint64_t len)
     : logical_offset(offset),
@@ -5102,31 +5107,82 @@ int BlueStore::_do_read(
     ++lp;
   }
 
-  // enumerate and read/decompress desired blobs
+  // read raw blob data
+  vector<bufferlist> compressed_blob_bls;
+  IOContext ioc(cct);
+  for (auto& p : blobs2read) {
+    BlobRef bptr = p.first;
+    dout(20) << __func__ << "  blob " << *bptr << std::hex
+	     << " need 0x" << p.second << std::dec << dendl;
+    if (bptr->get_blob().is_compressed()) {
+      // read the whole thing
+      if (compressed_blob_bls.empty()) {
+	// ensure we avoid any reallocation on subsequent blobs
+	compressed_blob_bls.reserve(blobs2read.size());
+      }
+      compressed_blob_bls.push_back(bufferlist());
+      bufferlist& bl = compressed_blob_bls.back();
+      r = bptr->get_blob().map(
+	0, bptr->get_blob().get_ondisk_length(),
+	[&](uint64_t offset, uint64_t length) {
+	  int r = bdev->aio_read(offset, length, &bl, &ioc);
+	  if (r < 0)
+            return r;
+          return 0;
+	});
+    } else {
+      // read the pieces
+      for (auto& reg : p.second) {
+	// determine how much of the blob to read
+	uint64_t chunk_size = bptr->get_blob().get_chunk_size(block_size);
+	reg.r_off = reg.blob_xoffset;
+	uint64_t r_len = reg.length;
+	reg.front = reg.r_off % chunk_size;
+	if (reg.front) {
+	  reg.r_off -= reg.front;
+	  r_len += reg.front;
+	}
+	unsigned tail = r_len % chunk_size;
+	if (tail) {
+	  r_len += chunk_size - tail;
+	}
+	dout(20) << __func__ << "    region 0x" << std::hex
+		 << reg.logical_offset
+		 << ": 0x" << reg.blob_xoffset << "~" << reg.length
+		 << " reading 0x" << reg.r_off << "~" << r_len << std::dec
+		 << dendl;
+
+	// read it
+	r = bptr->get_blob().map(
+	  reg.r_off, r_len,
+	  [&](uint64_t offset, uint64_t length) {
+	    int r = bdev->aio_read(offset, length, &reg.bl, &ioc);
+	    if (r < 0)
+              return r;
+            return 0;
+	  });
+        if (r < 0)
+          return r;
+      }
+    }
+  }
+  bdev->aio_submit(&ioc);
+  ioc.aio_wait();
+
+  // enumerate and decompress desired blobs
+  auto p = compressed_blob_bls.begin();
   blobs2read_t::iterator b2r_it = blobs2read.begin();
   while (b2r_it != blobs2read.end()) {
     BlobRef bptr = b2r_it->first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
 	     << " need 0x" << b2r_it->second << std::dec << dendl;
-    if (bptr->get_blob().has_flag(bluestore_blob_t::FLAG_COMPRESSED)) {
-      bufferlist compressed_bl, raw_bl;
-      IOContext ioc(NULL);   // FIXME?
-      r = bptr->get_blob().map(
-	0, bptr->get_blob().get_ondisk_length(),
-	[&](uint64_t offset, uint64_t length) {
-	  bufferlist t;
-	  int r = bdev->read(offset, length, &t, &ioc, false);
-	  if (r < 0)
-            return r;
-	  compressed_bl.claim_append(t);
-          return 0;
-	});
-      if (r < 0)
-        return r;
-
+    if (bptr->get_blob().is_compressed()) {
+      assert(p != compressed_blob_bls.end());
+      bufferlist& compressed_bl = *p++;
       if (_verify_csum(o, &bptr->get_blob(), 0, compressed_bl) < 0) {
 	return -EIO;
       }
+      bufferlist raw_bl;
       r = _decompress(compressed_bl, &raw_bl);
       if (r < 0)
 	return r;
@@ -5138,51 +5194,18 @@ int BlueStore::_do_read(
 	  raw_bl, i.blob_xoffset, i.length);
       }
     } else {
-      for (auto reg : b2r_it->second) {
-	// determine how much of the blob to read
-	uint64_t chunk_size = bptr->get_blob().get_chunk_size(block_size);
-	uint64_t r_off = reg.blob_xoffset;
-	uint64_t r_len = reg.length;
-	unsigned front = r_off % chunk_size;
-	if (front) {
-	  r_off -= front;
-	  r_len += front;
-	}
-	unsigned tail = r_len % chunk_size;
-	if (tail) {
-	  r_len += chunk_size - tail;
-	}
-	dout(20) << __func__ << "    region 0x" << std::hex
-		 << reg.logical_offset
-		 << ": 0x" << reg.blob_xoffset << "~" << reg.length
-		 << " reading 0x" << r_off << "~" << r_len << std::dec
-		 << dendl;
-
-	// read it
-	IOContext ioc(NULL);  // FIXME?
-	bufferlist bl;
-	r = bptr->get_blob().map(r_off, r_len,
-			     [&](uint64_t offset, uint64_t length) {
-	    bufferlist t;
-	    int r = bdev->read(offset, length, &t, &ioc, false);
-	    if (r < 0)
-              return r;
-	    bl.claim_append(t);
-            return 0;
-	  });
-        if (r < 0)
-          return r;
-
-	r = _verify_csum(o, &bptr->get_blob(), r_off, bl);
+      for (auto& reg : b2r_it->second) {
+	r = _verify_csum(o, &bptr->get_blob(), reg.r_off, reg.bl);
 	if (r < 0) {
 	  return -EIO;
 	}
 	if (buffered) {
-	  bptr->shared_blob->bc.did_read(r_off, bl);
+	  bptr->shared_blob->bc.did_read(reg.r_off, reg.bl);
 	}
 
 	// prune and keep result
-	ready_regions[reg.logical_offset].substr_of(bl, front, reg.length);
+	ready_regions[reg.logical_offset].substr_of(
+	  reg.bl, reg.front, reg.length);
       }
     }
     ++b2r_it;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -553,6 +553,39 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   return r < 0 ? r : 0;
 }
 
+int KernelDevice::aio_read(
+  uint64_t off,
+  uint64_t len,
+  bufferlist *pbl,
+  IOContext *ioc)
+{
+  dout(5) << __func__ << " 0x" << std::hex << off << "~" << len << std::dec
+	  << dendl;
+
+  int r = 0;
+#ifdef HAVE_LIBAIO
+  if (aio && dio) {
+    _aio_log_start(ioc, off, len);
+    ioc->pending_aios.push_back(FS::aio_t(ioc, fd_direct));
+    ++ioc->num_pending;
+    FS::aio_t& aio = ioc->pending_aios.back();
+    aio.pread(off, len);
+    for (unsigned i=0; i<aio.iov.size(); ++i) {
+      dout(30) << "aio " << i << " " << aio.iov[i].iov_base
+	       << " " << aio.iov[i].iov_len << dendl;
+    }
+    pbl->append(aio.bl);
+    dout(5) << __func__ << " 0x" << std::hex << off << "~" << len
+	    << std::dec << " aio " << &aio << dendl;
+  } else
+#endif
+  {
+    r = read(off, len, pbl, ioc, false);
+  }
+
+  return r;
+}
+
 int KernelDevice::direct_read_unaligned(uint64_t off, uint64_t len, char *buf)
 {
   uint64_t aligned_off = align_down(off, block_size);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -271,10 +271,12 @@ void KernelDevice::_aio_thread()
 	// trust aio[] values; they my be freed (e.g., by BlueFS::_fsync)
 	if (left == 0) {
 	  // check waiting count before doing callback (which may
-	  // destroy this ioc).
+	  // destroy this ioc).  and avoid ref to ioc after aio_wake()
+	  // in case that triggers destruction.
+	  void *priv = ioc->priv;
 	  ioc->aio_wake();
-	  if (ioc->priv) {
-	    aio_callback(aio_callback_priv, ioc->priv);
+	  if (priv) {
+	    aio_callback(aio_callback_priv, priv);
 	  }
 	}
       }

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -541,7 +541,6 @@ int KernelDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
     goto out;
   }
   assert((uint64_t)r == len);
-  pbl->clear();
   pbl->push_back(std::move(p));
 
   dout(40) << "data: ";

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -87,6 +87,8 @@ public:
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,
 	   bool buffered) override;
+  int aio_read(uint64_t off, uint64_t len, bufferlist *pbl,
+	       IOContext *ioc) override;
   int read_random(uint64_t off, uint64_t len, char *buf, bool buffered) override;
 
   int aio_write(uint64_t off, bufferlist& bl,

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -948,6 +948,45 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
   return r;
 }
 
+int NVMEDevice::aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc)
+{
+  uint64_t len = bl.length();
+  dout(20) << __func__ << " " << off << "~" << len << " ioc " << ioc << dendl;
+  assert(off % block_size == 0);
+  assert(len % block_size == 0);
+  assert(len > 0);
+  assert(off < size);
+  assert(off + len <= size);
+
+  Task *t = new Task(this, IOCommand::READ_COMMAND, off, len);
+
+  bufferptr p = buffer::create_page_aligned(len);
+  pbl->append(p);
+  int r = 0;
+  t->ctx = ioc;
+  char *buf = p.c_str();
+  t->fill_cb = [buf, t]() {
+    t->copy_to_buf(buf, 0, t->len);
+  };
+
+  Task *first = static_cast<Task*>(ioc->nvme_task_first);
+  Task *last = static_cast<Task*>(ioc->nvme_task_last);
+  if (last)
+    last->next = t;
+  if (!first)
+    ioc->nvme_task_first = t;
+  ioc->nvme_task_last = t;
+  ++ioc->num_pending;
+
+  return 0;
+}
+
+
+
 int NVMEDevice::read_random(uint64_t off, uint64_t len, char *buf, bool buffered)
 {
   assert(len > 0);

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -936,7 +936,6 @@ int NVMEDevice::read(uint64_t off, uint64_t len, bufferlist *pbl,
     while (t->return_code > 0)
       ioc->cond.wait(l);
   }
-  pbl->clear();
   pbl->push_back(std::move(p));
   r = t->return_code;
   delete t;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -223,7 +223,13 @@ class NVMEDevice : public BlockDevice {
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
            IOContext *ioc,
            bool buffered) override;
-
+  int aio_read(
+    uint64_t off,
+    uint64_t len,
+    bufferlist *pbl,
+    IOContext *ioc) override {
+    assert(0 == "implement me");
+  }
   int aio_write(uint64_t off, bufferlist& bl,
                 IOContext *ioc,
                 bool buffered) override;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -227,9 +227,7 @@ class NVMEDevice : public BlockDevice {
     uint64_t off,
     uint64_t len,
     bufferlist *pbl,
-    IOContext *ioc) override {
-    assert(0 == "implement me");
-  }
+    IOContext *ioc) override;
   int aio_write(uint64_t off, bufferlist& bl,
                 IOContext *ioc,
                 bool buffered) override;


### PR DESCRIPTION
http://tracker.ceph.com/issues/19031

Backport #13066 to kraken.

