### PR TITLE
jewel: osd: allow client throttler to be adjusted on-fly, without restart

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8940,6 +8940,8 @@ const char** OSD::get_tracked_conf_keys() const
     "clog_to_graylog_port",
     "host",
     "fsid",
+    "osd_client_message_size_cap",
+    "osd_client_message_cap",
     NULL
   };
   return KEYS;
@@ -8996,6 +8998,22 @@ void OSD::handle_conf_change(const struct md_config_t *conf,
     }
   }
 #endif
+
+  if (changed.count("osd_client_message_cap")) {
+    uint64_t newval = cct->_conf->osd_client_message_cap;
+    Messenger::Policy pol = client_messenger->get_policy(entity_name_t::TYPE_CLIENT);
+    if (pol.throttler_messages && newval > 0) {
+      pol.throttler_messages->reset_max(newval);
+    }
+  }
+  if (changed.count("osd_client_message_size_cap")) {
+    uint64_t newval = cct->_conf->osd_client_message_size_cap;
+    Messenger::Policy pol = client_messenger->get_policy(entity_name_t::TYPE_CLIENT);
+    if (pol.throttler_bytes && newval > 0) {
+      pol.throttler_bytes->reset_max(newval);
+    }
+  }
+
   check_config();
 }
 


### PR DESCRIPTION
This patch allows the osd_client_message_cap and
osd_client_message_size_cap to be adjusted on-fly, using admin socket
functionality. 
This particular PR is a backport of https://github.com/ceph/ceph/pull/13213 into jewel.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>

Conflicts:
	src/osd/OSD.cc (suppress new fields added post-jewel)