### PR TITLE
ceph-detect-init: Add docker detection

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/docker/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/docker/__init__.py
@@ -1,0 +1,3 @@
+def choose_init():
+    """Returns 'none' because we are running in a container"""
+    return 'none'


### PR DESCRIPTION
if running `ceph-detect-init` from a container, the given output is the
reference from the hosting system. This patch add the capability of
detecting if the tool is being run inside a container.

Signed-off-by: Guillaume Abrioux <gabrioux@redhat.com>