### PR TITLE
rgw: be aware abount tenants on cls_user_bucket -> rgw_bucket conversion

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -133,9 +133,8 @@ int rgw_read_user_buckets(RGWRados * store,
     if (ret < 0)
       return ret;
 
-    for (list<cls_user_bucket_entry>::iterator q = entries.begin(); q != entries.end(); ++q) {
-      RGWBucketEnt e(*q);
-      buckets.add(e);
+    for (const auto& entry : entries) {
+      buckets.add(RGWBucketEnt(user_id, entry));
       total++;
     }
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -126,7 +126,7 @@ public:
   /**
    * Add a (created) bucket to the user's bucket list.
    */
-  void add(RGWBucketEnt& bucket) {
+  void add(const RGWBucketEnt& bucket) {
     buckets[bucket.bucket.name] = bucket;
   }
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -737,10 +737,15 @@ struct rgw_bucket {
 
   rgw_bucket() { }
   // cppcheck-suppress noExplicitConstructor
-  rgw_bucket(const cls_user_bucket& b) : name(b.name), data_pool(b.data_pool),
-					 data_extra_pool(b.data_extra_pool),
-					 index_pool(b.index_pool), marker(b.marker),
-					 bucket_id(b.bucket_id) {}
+  explicit rgw_bucket(const rgw_user& u, const cls_user_bucket& b)
+    : tenant(u.tenant),
+      name(b.name),
+      data_pool(b.data_pool),
+      data_extra_pool(b.data_extra_pool),
+      index_pool(b.index_pool),
+      marker(b.marker),
+      bucket_id(b.bucket_id) {
+  }
   rgw_bucket(const string& s) : name(s) {
     data_pool = index_pool = s;
     marker = "";
@@ -1414,11 +1419,13 @@ struct RGWBucketEnt {
 
   RGWBucketEnt() : size(0), size_rounded(0), count(0) {}
 
-  explicit RGWBucketEnt(const cls_user_bucket_entry& e) : bucket(e.bucket),
-		  					  size(e.size), 
-			  				  size_rounded(e.size_rounded),
-							  creation_time(e.creation_time),
-							  count(e.count) {}
+  explicit RGWBucketEnt(const rgw_user& u, const cls_user_bucket_entry& e)
+    : bucket(u, e.bucket),
+      size(e.size),
+      size_rounded(e.size_rounded),
+      creation_time(e.creation_time),
+      count(e.count) {
+  }
 
   void convert(cls_user_bucket_entry *b) {
     bucket.convert(&b->bucket);


### PR DESCRIPTION
This is a simplified fix for [issue 18364](http://tracker.ceph.com/issues/18364). It bases on the assumption that links between user and buckets can't cross the tenant boundary. There is no change to the underlying Ceph classes. Thus, the fix should easily portable to Jewel and Kraken and I don't expect any upgrade-related issues.

Accounting became operational for tenanted users:
```
$ bin/radosgw-admin user stats --uid 2987047fc47840058e89e6182e0d96c3\$2987047fc47840058e89e6182e0d96c3 --sync-stats
...
{
    "stats": {
        "total_entries": 8,
        "total_bytes": 642,
        "total_bytes_rounded": 32768
    },
    "last_stats_sync": "2017-02-01 18:51:19.471956Z",
    "last_stats_update": "2017-02-01 18:51:19.467099Z"
}
```

Tempest nor s3-tests hasn't found any regression here. 

Fixes: http://tracker.ceph.com/issues/18364
Derogates: #12710
Is-Related-To: #12709
CC: @yehudasa, @oritwas, @cbodley.
