### PR TITLE
libradosstriper: resolve several issues found by cppcheck

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -695,10 +695,12 @@ int libradosstriper::RadosStriperImpl::aio_generic_stat
     delete getxattr_completion;
     multi_completion->complete_request(rc);
     multi_completion->put();
+    delete multi_completion;
     return rc;
   }
   cdata->put();
   multi_completion->put();
+  delete multi_completion;
   return 0;
 }
 


### PR DESCRIPTION
[src/libradosstriper/RadosStriperImpl.cc:702]: (error) Memory leak: multi_completion

Signed-off-by: Ilya Shipitsin <chipitsine@gmail.com>