### PR TITLE
qa: do not mention ceph branch explicitly

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/2-config/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-config/ceph_ansible.yaml
@@ -9,7 +9,6 @@ overrides:
             osd default pool size: 2                                                                                                                                                                        
             mon pg warn min per osd: 2                                                                                                                                                                      
         ceph_dev: true                                                                                                                                                                                      
-        ceph_dev_branch: jewel                                                                                                                                                                              
         ceph_dev_key: https://download.ceph.com/keys/autobuild.asc                                                                                                                                          
         ceph_origin: upstream                                                                                                                                                                               
         ceph_test: true                                                                                                                                                                                     


### PR DESCRIPTION
no need to mention ceph_dev_branch explicitly. it will be taken from the
ceph branch value mentioned in the teuthology-suite command

Signed-off-by: Tamil Muthamizhan <tmuthami@redhat.com>