### PR TITLE
cleanup: resolve compiler warnings

### DIFF
--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -208,7 +208,10 @@ int ceph_create(struct ceph_mount_info **cmount, const char * const id);
 int ceph_create_with_context(struct ceph_mount_info **cmount, struct CephContext *conf);
 
 
+#ifndef VOIDPTR_RADOS_T
+#define VOIDPTR_RADOS_T
 typedef void *rados_t;
+#endif // VOIDPTR_RADOS_T
 
 /**
  * Create a mount handle from a rados_t, for using libcephfs in the

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -166,7 +166,10 @@ enum {
  * -- or to the same cluster with different users -- requires
  * different cluster handles.
  */
+#ifndef VOIDPTR_RADOS_T
+#define VOIDPTR_RADOS_T
 typedef void *rados_t;
+#endif //VOIDPTR_RADOS_T
 
 /**
  * @typedef rados_config_t

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -318,7 +318,6 @@ public:
   };
 
   struct SharedBlobSet;
-  struct Collection;
 
   /// in-memory shared blob state (incl cached buffers)
   struct SharedBlob {

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -285,7 +285,7 @@ int RGWRadosGetOmapKeysCR::send_request() {
   set_status() << "send request";
 
   librados::ObjectReadOperation op;
-  op.omap_get_vals(marker, max_entries, entries, &rval);
+  op.omap_get_vals2(marker, max_entries, entries, nullptr, &rval);
 
   cn = stack->create_completion_notifier();
   return ioctx.aio_operate(oid, cn->completion(), &op, NULL);

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -25,12 +25,7 @@
 #define dout_subsys ceph_subsys_rgw
 
 RGWFormatter_Plain::RGWFormatter_Plain(const bool ukv)
-  : buf(NULL),
-    len(0),
-    max_len(0),
-    wrote_something(false),
-    min_stack_level(0),
-    use_kv(ukv)
+  : use_kv(ukv)
 {
 }
 

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -50,14 +50,14 @@ private:
   void write_data(const char *fmt, ...);
   void dump_value_int(const char *name, const char *fmt, ...);
 
-  char *buf;
-  int len;
-  int max_len;
+  char *buf = nullptr;
+  int len = 0;
+  int max_len = 0;
 
   std::list<struct plain_stack_entry> stack;
-  size_t min_stack_level;
+  size_t min_stack_level = 0;
   bool use_kv;
-  bool wrote_something;
+  bool wrote_something = 0;
 };
 
 

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1050,7 +1050,7 @@ TEST_F(TestClsRbd, snapshots_timestamps)
   ASSERT_EQ(0, get_snapcontext(&ioctx, oid, &snapc));
   ASSERT_EQ(1u, snapc.snaps.size());
   ASSERT_EQ(0, snapshot_timestamp_list(&ioctx, oid, snapc.snaps, &snap_timestamps));
-  ASSERT_LT(0, snap_timestamps[0].tv.tv_sec);
+  ASSERT_LT(0U, snap_timestamps[0].tv.tv_sec);
   ioctx.close();
 }
 

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -77,7 +77,7 @@ std::unique_ptr<CrushWrapper> build_indep_map(CephContext *cct, int num_rack,
     delete f;
   }
 
-  return std::move(c);
+  return c;
 }
 
 int get_num_dups(const vector<int>& v)

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -43,6 +43,8 @@ struct ManagedLock<MockExclusiveLockImageCtx> {
     : m_lock("ManagedLock::m_lock") {
   }
 
+  virtual ~ManagedLock() = default;
+
   mutable Mutex m_lock;
 
   virtual void shutdown_handler(int r, Context *) = 0;

--- a/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
@@ -56,6 +56,8 @@ struct ManagedLock<MockTestImageCtx> {
     : m_lock("ManagedLock::m_lock") {
   }
 
+  virtual ~ManagedLock() = default;
+
   mutable Mutex m_lock;
 
   bool is_lock_owner() const {


### PR DESCRIPTION
There are 2×10¹⁴ metres of DNA in all the cells of my body. If every run of four base-pairs encoded the word 'hate'…okay that's a bit overboard. Sure, I don't *like* warnings, but there are a lot of things that deserve to have hate lavished upon them more than compiler diagnostics do.