### PR TITLE
rgw: swift: fix anonymous user's error code of getting object

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1222,6 +1222,20 @@ void RGWCopyObj_ObjStore_SWIFT::send_response()
   }
 }
 
+int RGWGetObj_ObjStore_SWIFT::verify_permission()
+{
+  op_ret = RGWGetObj_ObjStore::verify_permission();
+
+  /* We have to differentiate error codes depending on whether user is
+   * anonymous (401 Unauthorized) or he doesn't have necessary permissions
+   * (403 Forbidden). */
+  if (s->auth_identity->is_anonymous() && op_ret == -EACCES) {
+    return -EPERM;
+  } else {
+    return op_ret;
+  }
+}
+
 int RGWGetObj_ObjStore_SWIFT::get_params()
 {
   const string& mm = s->info.args.get("multipart-manifest");

--- a/src/rgw/rgw_rest_swift.h
+++ b/src/rgw/rgw_rest_swift.h
@@ -17,6 +17,7 @@ public:
   RGWGetObj_ObjStore_SWIFT() {}
   ~RGWGetObj_ObjStore_SWIFT() {}
 
+  int verify_permission() override;
   int get_params();
   int send_response_data_error();
   int send_response_data(bufferlist& bl, off_t ofs, off_t len);


### PR DESCRIPTION
The openstack swift will return 401 rather than 403 when the anon user has no permission to get objects.

Fixes: http://tracker.ceph.com/issues/18806
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>