### PR TITLE
mon: smooth io/recovery stats over longer period

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -282,7 +282,7 @@ OPTION(mon_osd_allow_primary_affinity, OPT_BOOL, false)  // allow primary_affini
 OPTION(mon_osd_prime_pg_temp, OPT_BOOL, true)  // prime osdmap with pg mapping changes
 OPTION(mon_osd_prime_pg_temp_max_time, OPT_FLOAT, .5)  // max time to spend priming
 OPTION(mon_osd_pool_ec_fast_read, OPT_BOOL, false) // whether turn on fast read on the pool or not
-OPTION(mon_stat_smooth_intervals, OPT_INT, 2)  // smooth stats over last N PGMap maps
+OPTION(mon_stat_smooth_intervals, OPT_INT, 6)  // smooth stats over last N PGMap maps
 OPTION(mon_election_timeout, OPT_FLOAT, 5)  // on election proposer, max waiting time for all ACKs
 OPTION(mon_lease, OPT_FLOAT, 5)       // lease interval
 OPTION(mon_lease_renew_interval_factor, OPT_FLOAT, .6) // on leader, to renew the lease


### PR DESCRIPTION
On a busy cluster, the PGMap will turn over every 1-2 seconds and
OSDs will report PG stats every 5-10 seconds.  Averaging over only
two PGMap versions (2-4 seconds) will lead to erratic and spikey
delta values.  Move to 6 versions (6-12 seconds) to better match
the reporting interval while still keeping the values somewhat
responsive.

Signed-off-by: Sage Weil <sage@redhat.com>