### PR TITLE
rgw_file:  fix RGWLibFS::setattr for directory objects

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -586,6 +586,10 @@ namespace rgw {
 
     string obj_name{rgw_fh->relative_object_name()};
 
+    if (rgw_fh->is_dir()) {
+      obj_name += "/";
+    }
+
     RGWSetAttrsRequest req(cct, get_user(), rgw_fh->bucket_name(), obj_name);
 
     rgw_fh->create_stat(st, mask);


### PR DESCRIPTION
Fixes:  http://tracker.ceph.com/issues/18808

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>