### PR TITLE
tests: ceph-helpers.sh reduce get_timeout_delays() verbosity

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1085,8 +1085,8 @@ function test_is_clean() {
 # @return a list of sleep delays
 #
 function get_timeout_delays() {
-    local saved_state=$(set +o)
-    set +x
+    local trace=$(shopt -q -o xtrace && echo true || echo false)
+    $trace && shopt -u -o xtrace
     local timeout=$1
     local first_step=${2:-1}
 
@@ -1101,7 +1101,7 @@ function get_timeout_delays() {
     if test "$(echo $total \< $timeout | bc -l)" = "1"; then
         echo -n $(echo $timeout - $total | bc -l)
     fi
-    eval "$saved_state"
+    $trace && shopt -s -o xtrace
 }
 
 function test_get_timeout_delays() {


### PR DESCRIPTION
`set +o` prints out the full command line which is echoed if "xtrace" is
enabled. this increases the verbosity of get_timeout_delays().
in this change, we follow the way of kill_daemons() to kill the extra
output. see aefcf6d.

Signed-off-by: Kefu Chai <kchai@redhat.com>