### PR TITLE
librados: do not expose non-public symbols

### DIFF
--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -1133,6 +1133,7 @@ int librados::IoCtxImpl::aio_setxattr(const object_t& oid, AioCompletionImpl *c,
   return aio_operate(oid, &op, c, snapc, 0);
 }
 
+namespace {
 struct AioGetxattrsData {
   AioGetxattrsData(librados::AioCompletionImpl *c, map<string, bufferlist>* attrset,
 		   librados::RadosClient *_client) :
@@ -1142,6 +1143,7 @@ struct AioGetxattrsData {
   map<std::string, bufferlist>* user_attrset;
   librados::RadosClient *client;
 };
+}
 
 static void aio_getxattrs_complete(rados_completion_t c, void *arg) {
   AioGetxattrsData *cdata = reinterpret_cast<AioGetxattrsData*>(arg);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4735,6 +4735,7 @@ extern "C" int rados_aio_getxattr(rados_ioctx_t io, const char *o,
   return ret;
 }
 
+namespace {
 struct AioGetxattrsData {
   AioGetxattrsData(rados_completion_t c, rados_xattrs_iter_t *_iter) :
     iter(_iter), user_completion((librados::AioCompletionImpl*)c) {
@@ -4747,6 +4748,7 @@ struct AioGetxattrsData {
   rados_xattrs_iter_t *iter;
   struct librados::C_AioCompleteAndSafe user_completion;
 };
+}
 
 static void rados_aio_getxattrs_complete(rados_completion_t c, void *arg) {
   AioGetxattrsData *cdata = reinterpret_cast<AioGetxattrsData*>(arg);


### PR DESCRIPTION
librados could be referencing the wrong symbol when calling the
destructor. for example, a variable of type AioGetxattrsData in
IoCtxImpl.cc) could be destructed using the destructor defined in
librados.cc. this is reproduciable using

ceph_test_rados_api_aio --gtest_filter=LibRadosAio.XattrIter

Signed-off-by: Kefu Chai <kchai@redhat.com>