### PR TITLE
cmake: Determine ceph-osd-prestart.sh path in upstart/systemd configs at build time

### DIFF
--- a/systemd/CMakeLists.txt
+++ b/systemd/CMakeLists.txt
@@ -1,3 +1,12 @@
+include(GNUInstallDirs)
+
+configure_file(${CMAKE_SOURCE_DIR}/systemd/ceph-osd@.service.in
+  ${CMAKE_CURRENT_BINARY_DIR}/ceph-osd@.service @ONLY)
+
+install(FILES
+  ${CMAKE_BINARY_DIR}/systemd/ceph-osd@.service
+  DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/systemd/system)
+
 install(FILES
   ceph.target
   ceph-fuse.target
@@ -11,7 +20,6 @@ install(FILES
   ceph-mds@.service
   ceph-mgr@.service
   ceph-mon@.service
-  ceph-osd@.service
   ceph-radosgw@.service
   ceph-rbd-mirror@.service
   ceph-disk@.service

--- a/systemd/ceph-osd@.service.in
+++ b/systemd/ceph-osd@.service.in
@@ -10,7 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
-ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
+ExecStartPre=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
 ProtectHome=true
 ProtectSystem=full


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18825
Signed-off-by: John Lin <johnlinp@gmail.com>