### PR TITLE
ceph: do not throw TypeError on connection failure

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -541,7 +541,10 @@ def ping_monitor(cluster_handle, name, timeout):
         run_in_thread(cluster_handle.connect, timeout=timeout)
         for m in monids() :
             s = run_in_thread(cluster_handle.ping_monitor, m)
-            print("mon.{0}".format(m) + '\n' + s)
+            if s is None:
+                print("mon.{0}".format(m) + '\n' + "Error connecting to monitor.")
+            else:
+                print("mon.{0}".format(m) + '\n' + s)
     else :
             s = run_in_thread(cluster_handle.ping_monitor, mon_id)
             print(s)


### PR DESCRIPTION
otherwise we could concat None with a string on connection problem.
which will result in TypeError. and the caller will print misleading
error like

Error connecting to cluster: TypeError

see also #12934

Signed-off-by: Kefu Chai <kchai@redhat.com>