### PR TITLE
osd/OSDMap: require OSD features only of OSDs

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1094,18 +1094,20 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
   }
   mask |= CEPH_FEATURE_OSD_PRIMARY_AFFINITY;
 
-  const uint64_t jewel_features = CEPH_FEATURE_SERVER_JEWEL;
-  if (test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
-    features |= jewel_features;
-  }
-  mask |= jewel_features;
+  if (entity_type == CEPH_ENTITY_TYPE_OSD) {
+    const uint64_t jewel_features = CEPH_FEATURE_SERVER_JEWEL;
+    if (test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
+      features |= jewel_features;
+    }
+    mask |= jewel_features;
 
-  const uint64_t kraken_features = CEPH_FEATURE_SERVER_KRAKEN
-    | CEPH_FEATURE_MSG_ADDR2;
-  if (test_flag(CEPH_OSDMAP_REQUIRE_KRAKEN)) {
-    features |= kraken_features;
+    const uint64_t kraken_features = CEPH_FEATURE_SERVER_KRAKEN
+      | CEPH_FEATURE_MSG_ADDR2;
+    if (test_flag(CEPH_OSDMAP_REQUIRE_KRAKEN)) {
+      features |= kraken_features;
+    }
+    mask |= kraken_features;
   }
-  mask |= kraken_features;
 
   if (pmask)
     *pmask = mask;


### PR DESCRIPTION
Fix up commit 1a5cc32f0a3b ("osd/OSDMap: reflect REQUIRE_*_OSDS flag in
required features") -- require_*_osds shouldn't affect older clients.

Fixes: http://tracker.ceph.com/issues/18831
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>