### PR TITLE
kraken: osd: os/bluestore: fix statfs to not include DB partition in free space

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4717,7 +4717,6 @@ int BlueStore::statfs(struct store_statfs_t *buf)
 
     // include dedicated db, too, if that isn't the shared device.
     if (bluefs_shared_bdev != BlueFS::BDEV_DB) {
-      buf->available += bluefs->get_free(BlueFS::BDEV_DB);
       buf->total += bluefs->get_total(BlueFS::BDEV_DB);
     }
   }


### PR DESCRIPTION
If we report the DB space as vailable, ceph thinks the OSD can store more
data and will not mark the cluster as full as easily.  And in reality, we
can't actually store data in this space--only metadata.  Avoid the problem
by not reporting it as available.

Backport: kraken
Fixes: http://tracker.ceph.com/issues/18599
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit c66d5babb1e283869ba0f1f59029bead5ca5f37d)