### PR TITLE
msg/async: remove useless close function

### DIFF
--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -345,7 +345,6 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
   }
 
   if (sd < 0) {
-    ::close(sd);
     return -errno;
   }
 


### PR DESCRIPTION
fix coverity cid 1395314: it's invalid to pass a negative value to close function, and we have closed socket in net.connect/nonblock_connect in error cases indeed

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>


@yuyuyu101 Please take a look, thanks