### PR TITLE
librbd: fix segfault on EOPNOTSUPP returned while fetching snapshot timestamp

### DIFF
--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -474,6 +474,7 @@ Context *RefreshRequest<I>::handle_v2_get_snap_timestamps(int *result) {
     send_v2_get_mutable_metadata();
     return nullptr;
   } else if (*result == -EOPNOTSUPP) {
+    m_snap_timestamps = std::vector<utime_t>(m_snap_names.size(), utime_t());
     // Ignore it means no snap timestamps are available
   } else if (*result < 0) {
     lderr(cct) << "failed to retrieve snapshots: " << cpp_strerror(*result)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18839