### PR TITLE
rados:  we need to get the latest osdmap when pool does not exists

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -88,8 +88,18 @@ int64_t librados::RadosClient::lookup_pool(const char *name)
     return r;
   }
 
-  return objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name),
-			       name);
+  int64_t ret = objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name),
+                                 name);
+  if (-ENOENT == ret) {
+    // Make sure we have the latest map
+    int r = wait_for_latest_osdmap();
+    if (r < 0)
+      return r;
+    ret = objecter->with_osdmap(std::mem_fn(&OSDMap::lookup_pg_pool_name),
+                                 name);
+  }
+
+  return ret;
 }
 
 bool librados::RadosClient::pool_requires_alignment(int64_t pool_id)
@@ -439,15 +449,7 @@ int librados::RadosClient::create_ioctx(const char *name, IoCtxImpl **io)
 {
   int64_t poolid = lookup_pool(name);
   if (poolid < 0) {
-    // Make sure we have the latest map
-    int r = wait_for_latest_osdmap();
-    if (r < 0)
-      return r;
-
-    poolid = lookup_pool(name);
-    if (poolid < 0) {
-      return (int)poolid;
-    }
+    return (int)poolid;
   }
 
   *io = new librados::IoCtxImpl(this, objecter, poolid, CEPH_NOSNAP);


### PR DESCRIPTION
rados:  we need to get the latest osdmap when pool does not exists     

     sometimes when we rename a pool use the rados api,but the osdmap
     does not update when we use pool_exists api. so we need to get the
     latest osdmap when the pool does not exists, it may exists in the
     newer osdmap.

Signed-off-by: song baisen <song.baisen@zte.com.cn>