### PR TITLE
rgw: Let the object stat command be shown in the usage

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -82,6 +82,7 @@ void _usage()
   cout << "  bi put                     store bucket index object entries\n";
   cout << "  bi list                    list raw bucket index entries\n";
   cout << "  object rm                  remove object\n";
+  cout << "  object stat                stat an object for its metadata\n";
   cout << "  object unlink              unlink object from bucket index\n";
   cout << "  objects expire             run expired objects cleanup\n";
   cout << "  period delete              delete a period\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -28,6 +28,7 @@
     bi put                     store bucket index object entries
     bi list                    list raw bucket index entries
     object rm                  remove object
+    object stat                stat an object for its metadata
     object unlink              unlink object from bucket index
     objects expire             run expired objects cleanup
     period delete              delete a period


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19013
Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>