### PR TITLE
rgw: fix http referer acl conflict with public read in swift api

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -120,7 +120,7 @@ uint32_t RGWAccessControlPolicy::get_perm(const RGWIdentityApplier& auth_identit
 
   /* Should we continue looking up even deeper? */
   if (nullptr != http_referer && (perm & perm_mask) != perm_mask) {
-    perm |= acl.get_referer_perm(http_referer, perm_mask);
+    perm = acl.get_referer_perm(http_referer, perm_mask);
   }
 
   ldout(cct, 5) << "Getting permissions identity=" << auth_identity

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -218,6 +218,10 @@ struct ACLReferer {
   }
 
   bool is_match(boost::string_ref http_referer) const {
+    if ("*" == url_spec){
+      return true;
+    }
+
     const auto http_host = get_http_host(http_referer);
     if (!http_host || http_host->length() < url_spec.length()) {
       return false;


### PR DESCRIPTION
when the read acl of container is '.r:*,.r:-.example.com', the www.example.com should not
has the perm to read the object of container.

Fixes: http://tracker.ceph.com/issues/18841
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>