### PR TITLE
msg/async: cleanup code.

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -328,7 +328,7 @@ void AsyncConnection::process()
 {
   ssize_t r = 0;
   int prev_state = state;
-#ifdef WITH_LTTNG
+#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
   utime_t ltt_recv_stamp = ceph_clock_now();
 #endif
   bool need_dispatch_writer = false;
@@ -432,7 +432,7 @@ void AsyncConnection::process()
 
       case STATE_OPEN_MESSAGE_HEADER:
         {
-#ifdef WITH_LTTNG
+#if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
           ltt_recv_stamp = ceph_clock_now();
 #endif
           ldout(async_msgr->cct, 20) << __func__ << " begin MSG" << dendl;


### PR DESCRIPTION
Only WITH_EVENTTRACE, it declare local paramter utime_t ltt_recv_stamp.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>