### PR TITLE
msg/async/rdma: support RDMA in systemctl

### DIFF
--- a/systemd/ceph-fuse@.service
+++ b/systemd/ceph-fuse@.service
@@ -13,6 +13,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-fuse.target

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
-PrivateDevices=yes
+PrivateDevices=no
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
@@ -19,6 +19,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mgr@.service
+++ b/systemd/ceph-mgr@.service
@@ -25,6 +25,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-mgr.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -17,7 +17,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
-PrivateDevices=yes
+PrivateDevices=no
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
@@ -26,6 +26,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=5
 RestartSec=10
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -20,6 +20,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=30
 RestartSec=20s
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -10,7 +10,7 @@ LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
-PrivateDevices=yes
+PrivateDevices=no
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
@@ -18,6 +18,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30s
 StartLimitBurst=5
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-radosgw.target

--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -10,7 +10,7 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
 ExecStart=/usr/bin/rbd-mirror -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
-PrivateDevices=yes
+PrivateDevices=no
 ProtectHome=true
 ProtectSystem=full
 PrivateTmp=true
@@ -18,6 +18,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
 TasksMax=infinity
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=ceph-rbd-mirror.target

--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -12,6 +12,7 @@ RemainAfterExit=yes
 ExecStart=/usr/bin/rbdmap map
 ExecReload=/usr/bin/rbdmap map
 ExecStop=/usr/bin/rbdmap unmap
+LimitMEMLOCK=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
RDMA requires registering and locking memory for hardware direct access
and opening of RDMA related devices.

Change systemctl files to enable that.

Signed-off-by: Adir Lev <adirl@mellanox.com>