### PR TITLE
osd:  add is_split check before _start_split

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -353,11 +353,12 @@ void OSDService::_maybe_split_pgid(OSDMapRef old_map,
 				  spg_t pgid)
 {
   assert(old_map->have_pg_pool(pgid.pool()));
-  if (pgid.ps() < static_cast<unsigned>(old_map->get_pg_num(pgid.pool()))) {
+  int old_pgnum = old_map->get_pg_num(pgid.pool());
+  if (pgid.ps() < static_cast<unsigned>(old_pgnum)) {
     set<spg_t> children;
-    pgid.is_split(old_map->get_pg_num(pgid.pool()),
-		  new_map->get_pg_num(pgid.pool()), &children);
-    _start_split(pgid, children);
+    if (pgid.is_split(old_pgnum,
+		  new_map->get_pg_num(pgid.pool()), &children)) { 
+      _start_split(pgid, children); }
   } else {
     assert(pgid.ps() < static_cast<unsigned>(new_map->get_pg_num(pgid.pool())));
   }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -608,6 +608,7 @@ public:
   int get_pg_num(int pg_pool) const
   {
     const pg_pool_t *pool = get_pg_pool(pg_pool);
+    assert(NULL != pool);
     return pool->get_pg_num();
   }
 


### PR DESCRIPTION
osd:  add is_split check before _start_split

Signed-off-by: song baisen <song.baisen@zte.com.cn>