### PR TITLE
ceph-osd: --flush-journal: sporadic segfaults on exit

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -355,13 +355,15 @@ int main(int argc, const char **argv)
       derr << TEXT_RED << " ** ERROR: error flushing journal " << g_conf->osd_journal
 	   << " for object store " << g_conf->osd_data
 	   << ": " << cpp_strerror(-err) << TEXT_NORMAL << dendl;
-      exit(1);
+      goto flushjournal_out;
     }
     store->umount();
     derr << "flushed journal " << g_conf->osd_journal
 	 << " for object store " << g_conf->osd_data
 	 << dendl;
-    exit(0);
+flushjournal_out:
+    delete store;
+    exit(err < 0 ? 1 : 0);
   }
   if (dump_journal) {
     common_init_finish(g_ceph_context);


### PR DESCRIPTION
FileStore holds a number of recources like op thread pool and work
queue, key/value DB threads, etc. These should be properly stopped
(released) before exiting to avoid segfaults on exit.

Note: more code paths (mkfs, dump_journal, etc) need similar fixes,
these will be submitted as separate patches.

Fixes: http://tracker.ceph.com/issues/18820
Signed-off-by: Alexey Sheplyakov <asheplyakov@mirantis.com>