### PR TITLE
cmake: Allow tests to build without NSS

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -140,7 +140,7 @@ endif (WITH_RADOSGW_ASIO_FRONTEND)
 
 add_library(radosgw_a STATIC ${radosgw_srcs}
   $<TARGET_OBJECTS:civetweb_common_objs>)
-target_link_libraries(radosgw_a rgw_a)
+target_link_libraries(radosgw_a rgw_a ${SSL_LIBRARIES})
 
 add_executable(radosgw rgw_main.cc)
 target_link_libraries(radosgw radosgw_a librados
@@ -148,7 +148,7 @@ target_link_libraries(radosgw radosgw_a librados
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
-  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${SSL_LIBRARIES} ${BLKID_LIBRARIES}
+  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   ${ALLOC_LIBS})
 # radosgw depends on cls libraries at runtime, but not as link dependencies
 add_dependencies(radosgw cls_rgw cls_lock cls_refcount

--- a/src/test/libcephd/CMakeLists.txt
+++ b/src/test/libcephd/CMakeLists.txt
@@ -16,7 +16,7 @@ add_executable(ceph_test_cephd_api_misc
 set_target_properties(ceph_test_cephd_api_misc PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 target_link_libraries(ceph_test_cephd_api_misc
-  cephd global ${UNITTEST_LIBS} cephdtest z snappy ceph_zstd)
+	cephd global ${UNITTEST_LIBS} cephdtest z snappy ceph_zstd)
 
 install(TARGETS
   ceph_test_cephd_api_misc


### PR DESCRIPTION
Without NSS, ceph_test_cephd_api_misc needs SSL libs linked in.  These
are pulled in by civetweb.

Signed-off-by: Daniel Gryniewicz <dang@redhat.com>