### PR TITLE
doc: clarify that "ms bind ipv6" disables IPv4

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -150,9 +150,9 @@ The procedure is as follows:
 
 	mon host = 192.168.0.1
 
-   **Note:** You may use IPv6 addresses too, but you must set ``ms bind ipv6`` 
-   to ``true``. See `Network Configuration Reference`_ for details about 
-   network configuration.
+   **Note:** You may use IPv6 addresses instead of IPv4 addresses, but
+   you must set ``ms bind ipv6`` to ``true``. See `Network Configuration
+   Reference`_ for details about network configuration.
 
 #. Create a keyring for your cluster and generate a monitor secret key. ::
 

--- a/doc/rados/configuration/network-config-ref.rst
+++ b/doc/rados/configuration/network-config-ref.rst
@@ -347,7 +347,8 @@ Bind settings set the default port ranges Ceph OSD and MDS daemons use. The
 default range is ``6800:7300``. Ensure that your `IP Tables`_ configuration
 allows you to use the configured port range.
 
-You may also enable Ceph daemons to bind to IPv6 addresses.
+You may also enable Ceph daemons to bind to IPv6 addresses instead of IPv4
+addresses.
 
 
 ``ms bind port min``
@@ -368,7 +369,8 @@ You may also enable Ceph daemons to bind to IPv6 addresses.
 
 ``ms bind ipv6``
 
-:Description: Enables Ceph daemons to bind to IPv6 addresses.
+:Description: Enables Ceph daemons to bind to IPv6 addresses. Currently the
+messenger *either* uses IPv4 or IPv6, but it can't do both.
 :Type: Boolean
 :Default: ``false``
 :Required: No


### PR DESCRIPTION
This was sort of described in `doc/rados/configuration/ms-ref.rst` already. Add the same information to the other areas where we talk about the ms bind ipv6 setting.