### PR TITLE
osd: kill sortbitwise

### DIFF
--- a/src/common/hobject.cc
+++ b/src/common/hobject.cc
@@ -319,40 +319,7 @@ bool hobject_t::parse(const string &s)
   return true;
 }
 
-int cmp_nibblewise(const hobject_t& l, const hobject_t& r)
-{
-  if (l.max < r.max)
-    return -1;
-  if (l.max > r.max)
-    return 1;
-  if (l.pool < r.pool)
-    return -1;
-  if (l.pool > r.pool)
-    return 1;
-  if (l.get_nibblewise_key() < r.get_nibblewise_key())
-    return -1;
-  if (l.get_nibblewise_key() > r.get_nibblewise_key())
-    return 1;
-  if (l.nspace < r.nspace)
-    return -1;
-  if (l.nspace > r.nspace)
-    return 1;
-  if (l.get_effective_key() < r.get_effective_key())
-    return -1;
-  if (l.get_effective_key() > r.get_effective_key())
-    return 1;
-  if (l.oid < r.oid)
-    return -1;
-  if (l.oid > r.oid)
-    return 1;
-  if (l.snap < r.snap)
-    return -1;
-  if (l.snap > r.snap)
-    return 1;
-  return 0;
-}
-
-int cmp_bitwise(const hobject_t& l, const hobject_t& r)
+int cmp(const hobject_t& l, const hobject_t& r)
 {
   if (l.max < r.max)
     return -1;
@@ -606,7 +573,7 @@ bool ghobject_t::parse(const string& s)
   return true;
 }
 
-int cmp_nibblewise(const ghobject_t& l, const ghobject_t& r)
+int cmp(const ghobject_t& l, const ghobject_t& r)
 {
   if (l.max < r.max)
     return -1;
@@ -616,27 +583,7 @@ int cmp_nibblewise(const ghobject_t& l, const ghobject_t& r)
     return -1;
   if (l.shard_id > r.shard_id)
     return 1;
-  int ret = cmp_nibblewise(l.hobj, r.hobj);
-  if (ret != 0)
-    return ret;
-  if (l.generation < r.generation)
-    return -1;
-  if (l.generation > r.generation)
-    return 1;
-  return 0;
-}
-
-int cmp_bitwise(const ghobject_t& l, const ghobject_t& r)
-{
-  if (l.max < r.max)
-    return -1;
-  if (l.max > r.max)
-    return 1;
-  if (l.shard_id < r.shard_id)
-    return -1;
-  if (l.shard_id > r.shard_id)
-    return 1;
-  int ret = cmp_bitwise(l.hobj, r.hobj);
+  int ret = cmp(l.hobj, r.hobj);
   if (ret != 0)
     return ret;
   if (l.generation < r.generation)

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -305,37 +305,6 @@ public:
   friend bool operator==(const hobject_t&, const hobject_t&);
   friend bool operator!=(const hobject_t&, const hobject_t&);
   friend struct ghobject_t;
-
-  struct NibblewiseComparator {
-    bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-
-  struct BitwiseComparator {
-    bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-
-  struct Comparator {
-    bool bitwise;
-    explicit Comparator(bool b) : bitwise(b) {}
-    bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-  struct ComparatorWithDefault {
-    bool bitwise;
-    explicit ComparatorWithDefault(bool b=true) : bitwise(b) {}
-    bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-  template <typename T>
-  using bitwisemap = std::map<hobject_t, T, BitwiseComparator>;
-
-  using bitwiseset = std::set<hobject_t, BitwiseComparator>;
 };
 WRITE_CLASS_ENCODER(hobject_t)
 
@@ -509,25 +478,6 @@ public:
   friend bool operator==(const ghobject_t&, const ghobject_t&);
   friend bool operator!=(const ghobject_t&, const ghobject_t&);
 
-  struct NibblewiseComparator {
-    bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-
-  struct BitwiseComparator {
-    bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
-
-  struct Comparator {
-    bool bitwise;
-    explicit Comparator(bool b) : bitwise(b) {}
-    bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-      return cmp(l, r) < 0;
-    }
-  };
 };
 WRITE_CLASS_ENCODER(ghobject_t)
 

--- a/src/common/hobject.h
+++ b/src/common/hobject.h
@@ -289,21 +289,32 @@ public:
   void decode(json_spirit::Value& v);
   void dump(Formatter *f) const;
   static void generate_test_instances(list<hobject_t*>& o);
-  friend int cmp_nibblewise(const hobject_t& l, const hobject_t& r);
-  friend int cmp_bitwise(const hobject_t& l, const hobject_t& r);
+  friend int cmp(const hobject_t& l, const hobject_t& r);
+  friend bool operator>(const hobject_t& l, const hobject_t& r) {
+    return cmp(l, r) > 0;
+  }
+  friend bool operator>=(const hobject_t& l, const hobject_t& r) {
+    return cmp(l, r) >= 0;
+  }
+  friend bool operator<(const hobject_t& l, const hobject_t& r) {
+    return cmp(l, r) < 0;
+  }
+  friend bool operator<=(const hobject_t& l, const hobject_t& r) {
+    return cmp(l, r) <= 0;
+  }
   friend bool operator==(const hobject_t&, const hobject_t&);
   friend bool operator!=(const hobject_t&, const hobject_t&);
   friend struct ghobject_t;
 
   struct NibblewiseComparator {
     bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp_nibblewise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
 
   struct BitwiseComparator {
     bool operator()(const hobject_t& l, const hobject_t& r) const {
-      return cmp_bitwise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
 
@@ -311,20 +322,14 @@ public:
     bool bitwise;
     explicit Comparator(bool b) : bitwise(b) {}
     bool operator()(const hobject_t& l, const hobject_t& r) const {
-      if (bitwise)
-	return cmp_bitwise(l, r) < 0;
-      else
-	return cmp_nibblewise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
   struct ComparatorWithDefault {
     bool bitwise;
     explicit ComparatorWithDefault(bool b=true) : bitwise(b) {}
     bool operator()(const hobject_t& l, const hobject_t& r) const {
-      if (bitwise)
-	return cmp_bitwise(l, r) < 0;
-      else
-	return cmp_nibblewise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
   template <typename T>
@@ -373,61 +378,19 @@ inline bool operator!=(const T&, const hobject_t &rhs) {
   return !rhs.is_max();
 }
 
-extern int cmp_nibblewise(const hobject_t& l, const hobject_t& r);
-extern int cmp_bitwise(const hobject_t& l, const hobject_t& r);
-static inline int cmp(const hobject_t& l, const hobject_t& r, bool sort_bitwise) {
-  if (sort_bitwise)
-    return cmp_bitwise(l, r);
-  else
-    return cmp_nibblewise(l, r);
-}
+extern int cmp(const hobject_t& l, const hobject_t& r);
 template <typename T>
-static inline int cmp(const hobject_t &l, const T&, bool sort_bitwise) {
+static inline int cmp(const hobject_t &l, const T&) {
   static_assert(always_false<T>::value::value, "Do not compare to get_max()");
   return l.is_max() ? 0 : -1;
 }
 template <typename T>
-static inline int cmp(const T&, const hobject_t&r, bool sort_bitwise) {
-  static_assert(always_false<T>::value::value, "Do not compare to get_max()");
-  return r.is_max() ? 0 : 1;
-}
-template <typename T>
-static inline int cmp_nibblewise(const hobject_t &l, const T&, bool sort_bitwise) {
-  static_assert(always_false<T>::value::value, "Do not compare to get_max()");
-  return l.is_max() ? 0 : -1;
-}
-template <typename T>
-static inline int cmp_nibblewise(const T&, const hobject_t&r, bool sort_bitwise) {
-  static_assert(always_false<T>::value::value, "Do not compare to get_max()");
-  return r.is_max() ? 0 : 1;
-}
-template <typename T>
-static inline int cmp_bitwise(const hobject_t &l, const T&, bool sort_bitwise) {
-  static_assert(always_false<T>::value::value, "Do not compare to get_max()");
-  return l.is_max() ? 0 : -1;
-}
-template <typename T>
-static inline int cmp_bitwise(const T&, const hobject_t&r, bool sort_bitwise) {
+static inline int cmp(const T&, const hobject_t&r) {
   static_assert(always_false<T>::value::value, "Do not compare to get_max()");
   return r.is_max() ? 0 : 1;
 }
 
 
-
-// these are convenient
-static inline hobject_t MAX_HOBJ(const hobject_t& l, const hobject_t& r, bool bitwise) {
-  if (cmp(l, r, bitwise) >= 0)
-    return l;
-  else
-    return r;
-}
-
-static inline hobject_t MIN_HOBJ(const hobject_t& l, const hobject_t& r, bool bitwise) {
-  if (cmp(l, r, bitwise) <= 0)
-    return l;
-  else
-    return r;
-}
 
 typedef version_t gen_t;
 
@@ -530,20 +493,31 @@ public:
   size_t encoded_size() const;
   void dump(Formatter *f) const;
   static void generate_test_instances(list<ghobject_t*>& o);
-  friend int cmp_nibblewise(const ghobject_t& l, const ghobject_t& r);
-  friend int cmp_bitwise(const ghobject_t& l, const ghobject_t& r);
+  friend int cmp(const ghobject_t& l, const ghobject_t& r);
+  friend bool operator>(const ghobject_t& l, const ghobject_t& r) {
+    return cmp(l, r) > 0;
+  }
+  friend bool operator>=(const ghobject_t& l, const ghobject_t& r) {
+    return cmp(l, r) >= 0;
+  }
+  friend bool operator<(const ghobject_t& l, const ghobject_t& r) {
+    return cmp(l, r) < 0;
+  }
+  friend bool operator<=(const ghobject_t& l, const ghobject_t& r) {
+    return cmp(l, r) <= 0;
+  }
   friend bool operator==(const ghobject_t&, const ghobject_t&);
   friend bool operator!=(const ghobject_t&, const ghobject_t&);
 
   struct NibblewiseComparator {
     bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-      return cmp_nibblewise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
 
   struct BitwiseComparator {
     bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-      return cmp_bitwise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
 
@@ -551,10 +525,7 @@ public:
     bool bitwise;
     explicit Comparator(bool b) : bitwise(b) {}
     bool operator()(const ghobject_t& l, const ghobject_t& r) const {
-         if (bitwise)
-	return cmp_bitwise(l, r) < 0;
-      else
-	return cmp_nibblewise(l, r) < 0;
+      return cmp(l, r) < 0;
     }
   };
 };
@@ -573,31 +544,7 @@ ostream& operator<<(ostream& out, const ghobject_t& o);
 
 WRITE_EQ_OPERATORS_4(ghobject_t, max, shard_id, hobj, generation)
 
-extern int cmp_nibblewise(const ghobject_t& l, const ghobject_t& r);
-extern int cmp_bitwise(const ghobject_t& l, const ghobject_t& r);
-static inline int cmp(const ghobject_t& l, const ghobject_t& r,
-		      bool sort_bitwise) {
-  if (sort_bitwise)
-    return cmp_bitwise(l, r);
-  else
-    return cmp_nibblewise(l, r);
-}
+extern int cmp(const ghobject_t& l, const ghobject_t& r);
 
-// these are convenient
-static inline ghobject_t MAX_GHOBJ(const ghobject_t& l, const ghobject_t& r,
-				   bool bitwise) {
-  if (cmp(l, r, bitwise) >= 0)
-    return l;
-  else
-    return r;
-}
-
-static inline ghobject_t MIN_GHOBJ(const ghobject_t& l, const ghobject_t& r,
-				   bool bitwise) {
-  if (cmp(l, r, bitwise) <= 0)
-    return l;
-  else
-    return r;
-}
 
 #endif

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -4205,7 +4205,7 @@ extern "C" int rados_object_list_cursor_cmp(
 {
   hobject_t *lhs = (hobject_t*)lhs_cur;
   hobject_t *rhs = (hobject_t*)rhs_cur;
-  return cmp_bitwise(*lhs, *rhs);
+  return cmp(*lhs, *rhs);
 }
 
 extern "C" int rados_object_list(rados_ioctx_t io,
@@ -6073,7 +6073,7 @@ bool librados::ObjectCursor::operator<(const librados::ObjectCursor &rhs)
 {
   const hobject_t lhs_hobj = (c_cursor == nullptr) ? hobject_t() : *((hobject_t*)c_cursor);
   const hobject_t rhs_hobj = (rhs.c_cursor == nullptr) ? hobject_t() : *((hobject_t*)(rhs.c_cursor));
-  return cmp_bitwise(lhs_hobj, rhs_hobj) == -1;
+  return lhs_hobj < rhs_hobj;
 }
 
 librados::ObjectCursor::ObjectCursor(const librados::ObjectCursor &rhs)

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -70,7 +70,7 @@ public:
   map<string,bufferlist> attrset;
 
   interval_set<uint64_t> data_subset;
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator> clone_subsets;
+  map<hobject_t, interval_set<uint64_t>> clone_subsets;
 
   bool first, complete;
 

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -475,7 +475,7 @@ static int os_readdir(const char *path,
       while (true) {
 	vector<ghobject_t> ls;
 	int r = fs->store->collection_list(
-	  cid, next, last, true, 1000, &ls, &next);
+	  cid, next, last, 1000, &ls, &next);
 	if (r < 0)
 	  return r;
 	for (auto p : ls) {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1833,7 +1833,6 @@ public:
    * @param c collection
    * @param start list object that sort >= this value
    * @param end list objects that sort < this value
-   * @param sort_bitwise sort bitwise (instead of legacy nibblewise)
    * @param max return no more than this many results
    * @param seq return no objects with snap < seq
    * @param ls [out] result
@@ -1842,13 +1841,13 @@ public:
    */
   virtual int collection_list(const coll_t& c,
 			      const ghobject_t& start, const ghobject_t& end,
-			      bool sort_bitwise, int max,
+			      int max,
 			      vector<ghobject_t> *ls, ghobject_t *next) = 0;
   virtual int collection_list(CollectionHandle &c,
 			      const ghobject_t& start, const ghobject_t& end,
-			      bool sort_bitwise, int max,
+			      int max,
 			      vector<ghobject_t> *ls, ghobject_t *next) {
-    return collection_list(c->get_cid(), start, end, sort_bitwise, max, ls, next);
+    return collection_list(c->get_cid(), start, end, max, ls, next);
   }
 
 

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -475,7 +475,7 @@ public:
     void *osr {nullptr}; // NULL on replay
 
     map<coll_t, __le32> coll_index;
-    map<ghobject_t, __le32, ghobject_t::BitwiseComparator> object_index;
+    map<ghobject_t, __le32> object_index;
 
     __le32 coll_id {0};
     __le32 object_id {0};
@@ -748,7 +748,7 @@ public:
       }
 
       vector<__le32> om(other.object_index.size());
-      map<ghobject_t, __le32, ghobject_t::BitwiseComparator>::iterator object_index_p;
+      map<ghobject_t, __le32>::iterator object_index_p;
       for (object_index_p = other.object_index.begin();
            object_index_p != other.object_index.end();
            ++object_index_p) {
@@ -894,7 +894,7 @@ public:
           colls[coll_index_p->second] = coll_index_p->first;
         }
 
-        map<ghobject_t, __le32, ghobject_t::BitwiseComparator>::iterator object_index_p;
+        map<ghobject_t, __le32>::iterator object_index_p;
         for (object_index_p = t->object_index.begin();
              object_index_p != t->object_index.end();
              ++object_index_p) {
@@ -996,7 +996,7 @@ private:
       return index_id;
     }
     __le32 _get_object_id(const ghobject_t& oid) {
-      map<ghobject_t, __le32, ghobject_t::BitwiseComparator>::iterator o = object_index.find(oid);
+      map<ghobject_t, __le32>::iterator o = object_index.find(oid);
       if (o != object_index.end())
         return o->second;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1810,7 +1810,7 @@ private:
 
   int _collection_list(
     Collection *c, const ghobject_t& start, const ghobject_t& end,
-    bool sort_bitwise, int max, vector<ghobject_t> *ls, ghobject_t *next);
+    int max, vector<ghobject_t> *ls, ghobject_t *next);
 
   template <typename T, typename F>
   T select_option(const std::string& opt_name, T val1, F f) {
@@ -1949,12 +1949,12 @@ public:
   int collection_list(const coll_t& cid,
 		      const ghobject_t& start,
 		      const ghobject_t& end,
-		      bool sort_bitwise, int max,
+		      int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override;
   int collection_list(CollectionHandle &c,
 		      const ghobject_t& start,
 		      const ghobject_t& end,
-		      bool sort_bitwise, int max,
+		      int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override;
 
   int omap_get(

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1640,8 +1640,8 @@ private:
   list<CollectionRef> removed_collections;
 
   RWLock debug_read_error_lock;
-  set<ghobject_t, ghobject_t::BitwiseComparator> debug_data_error_objects;
-  set<ghobject_t, ghobject_t::BitwiseComparator> debug_mdata_error_objects;
+  set<ghobject_t> debug_data_error_objects;
+  set<ghobject_t> debug_mdata_error_objects;
 
   std::atomic<int> csum_type;
 

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -168,7 +168,6 @@ protected:
   virtual int collection_list_partial(
     const ghobject_t &start, ///< [in] object at which to start
     const ghobject_t &end,    ///< [in] list only objects < end
-    bool sort_bitwise,      ///< [in] use bitwise sort
     int max_count,          ///< [in] return at most max_count objects
     vector<ghobject_t> *ls,  ///< [out] Listed objects
     ghobject_t *next         ///< [out] Next object to list

--- a/src/os/filestore/DBObjectMap.cc
+++ b/src/os/filestore/DBObjectMap.cc
@@ -889,10 +889,10 @@ int DBObjectMap::clone(const ghobject_t &oid,
   if (oid == target)
     return 0;
 
-  MapHeaderLock _l1(this, MIN_GHOBJ(oid, target, true));
-  MapHeaderLock _l2(this, MAX_GHOBJ(oid, target, true));
+  MapHeaderLock _l1(this, std::min(oid, target));
+  MapHeaderLock _l2(this, std::max(oid, target));
   MapHeaderLock *lsource, *ltarget;
-  if (cmp_bitwise(oid, target) > 0) {
+  if (oid > target) {
     lsource = &_l2;
     ltarget= &_l1;
   } else {

--- a/src/os/filestore/DBObjectMap.h
+++ b/src/os/filestore/DBObjectMap.h
@@ -70,7 +70,7 @@ public:
    * Set of headers currently in use
    */
   set<uint64_t> in_use;
-  set<ghobject_t, ghobject_t::BitwiseComparator> map_header_in_use;
+  set<ghobject_t> map_header_in_use;
 
   /**
    * Takes the map_header_in_use entry in constructor, releases in
@@ -331,7 +331,7 @@ private:
   /// Implicit lock on Header->seq
   typedef ceph::shared_ptr<_Header> Header;
   Mutex cache_lock;
-  SimpleLRU<ghobject_t, _Header, ghobject_t::BitwiseComparator> caches;
+  SimpleLRU<ghobject_t, _Header> caches;
 
   string map_header_key(const ghobject_t &oid);
   string header_key(uint64_t seq);

--- a/src/os/filestore/FDCache.h
+++ b/src/os/filestore/FDCache.h
@@ -52,14 +52,14 @@ public:
 private:
   CephContext *cct;
   const int registry_shards;
-  SharedLRU<ghobject_t, FD, ghobject_t::BitwiseComparator> *registry;
+  SharedLRU<ghobject_t, FD> *registry;
 
 public:
   explicit FDCache(CephContext *cct) : cct(cct),
   registry_shards(MAX(cct->_conf->filestore_fd_cache_shards, 1)) {
     assert(cct);
     cct->_conf->add_observer(this);
-    registry = new SharedLRU<ghobject_t, FD, ghobject_t::BitwiseComparator>[registry_shards];
+    registry = new SharedLRU<ghobject_t, FD>[registry_shards];
     for (int i = 0; i < registry_shards; ++i) {
       registry[i].set_cct(cct);
       registry[i].set_size(

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4801,7 +4801,7 @@ int FileStore::collection_list(const coll_t& c,
   sep.hobj.pool = -1;
   sep.set_shard(shard);
   if (!c.is_temp() && !c.is_meta()) {
-    if (cmp_bitwise(start, sep) < 0) { // bitwise vs nibble doesn't matter here
+    if (start < sep) {
       dout(10) << __func__ << " first checking temp pool" << dendl;
       coll_t temp = c.get_temp();
       int r = collection_list(temp, start, end, max, ls, next);

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4617,7 +4617,7 @@ int FileStore::_collection_remove_recursive(const coll_t &cid,
   vector<ghobject_t> objects;
   ghobject_t max;
   while (!max.is_max()) {
-    r = collection_list(cid, max, ghobject_t::get_max(), true,
+    r = collection_list(cid, max, ghobject_t::get_max(),
 			300, &objects, &max);
     if (r < 0)
       return r;
@@ -4748,7 +4748,7 @@ int FileStore::collection_empty(const coll_t& c, bool *empty)
   RWLock::RLocker l((index.index)->access_lock);
 
   vector<ghobject_t> ls;
-  r = index->collection_list_partial(ghobject_t(), ghobject_t::get_max(), true,
+  r = index->collection_list_partial(ghobject_t(), ghobject_t::get_max(),
 				     1, &ls, NULL);
   if (r < 0) {
     derr << __func__ << " collection_list_partial returned: "
@@ -4763,7 +4763,7 @@ int FileStore::collection_empty(const coll_t& c, bool *empty)
 int FileStore::collection_list(const coll_t& c,
 			       const ghobject_t& orig_start,
 			       const ghobject_t& end,
-			       bool sort_bitwise, int max,
+			       int max,
 			       vector<ghobject_t> *ls, ghobject_t *next)
 {
   ghobject_t start = orig_start;
@@ -4804,7 +4804,7 @@ int FileStore::collection_list(const coll_t& c,
     if (cmp_bitwise(start, sep) < 0) { // bitwise vs nibble doesn't matter here
       dout(10) << __func__ << " first checking temp pool" << dendl;
       coll_t temp = c.get_temp();
-      int r = collection_list(temp, start, end, sort_bitwise, max, ls, next);
+      int r = collection_list(temp, start, end, max, ls, next);
       if (r < 0)
 	return r;
       if (*next != ghobject_t::get_max())
@@ -4825,7 +4825,7 @@ int FileStore::collection_list(const coll_t& c,
   assert(NULL != index.index);
   RWLock::RLocker l((index.index)->access_lock);
 
-  r = index->collection_list_partial(start, end, sort_bitwise, max, ls, next);
+  r = index->collection_list_partial(start, end, max, ls, next);
 
   if (r < 0) {
     assert(!m_filestore_fail_eio || r != -EIO);
@@ -5459,7 +5459,6 @@ int FileStore::_split_collection(const coll_t& cid,
       collection_list(
 	cid,
 	next, ghobject_t::get_max(),
-	true,
 	get_ideal_list_max(),
 	&objects,
 	&next);
@@ -5479,7 +5478,6 @@ int FileStore::_split_collection(const coll_t& cid,
       collection_list(
 	dest,
 	next, ghobject_t::get_max(),
-	true,
 	get_ideal_list_max(),
 	&objects,
 	&next);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -656,8 +656,7 @@ public:
   // collections
   using ObjectStore::collection_list;
   int collection_list(const coll_t& c,
-		      const ghobject_t& start, const ghobject_t& end,
-		      bool sort_bitwise, int max,
+		      const ghobject_t& start, const ghobject_t& end, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next);
   int list_collections(vector<coll_t>& ls);
   int list_collections(vector<coll_t>& ls, bool include_temp);

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -627,8 +627,8 @@ public:
 
   // DEBUG read error injection, an object is removed from both on delete()
   Mutex read_error_lock;
-  set<ghobject_t, ghobject_t::BitwiseComparator> data_error_set; // read() will return -EIO
-  set<ghobject_t, ghobject_t::BitwiseComparator> mdata_error_set; // getattr(),stat() will return -EIO
+  set<ghobject_t> data_error_set; // read() will return -EIO
+  set<ghobject_t> mdata_error_set; // getattr(),stat() will return -EIO
   void inject_data_error(const ghobject_t &oid);
   void inject_mdata_error(const ghobject_t &oid);
   void debug_obj_on_delete(const ghobject_t &oid);

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -903,7 +903,7 @@ int HashIndex::get_path_contents_by_hash_bitwise(
   for (map<string, ghobject_t>::iterator i = rev_objects.begin();
        i != rev_objects.end();
        ++i) {
-    if (next_object && cmp_bitwise(i->second, *next_object) < 0)
+    if (next_object && i->second < *next_object)
       continue;
     string hash_prefix = get_path_str(i->second);
     hash_prefixes->insert(hash_prefix);
@@ -1004,12 +1004,12 @@ int HashIndex::list_by_hash_bitwise(
 	    *next = j->second;
 	  return 0;
 	}
-	if (cmp_bitwise(j->second, end) >= 0) {
+	if (j->second >= end) {
 	  if (next)
 	    *next = j->second;
 	  return 0;
 	}
-	if (!next || cmp_bitwise(j->second, *next) >= 0) {
+	if (!next || j->second >= *next) {
 	  dout(20) << __func__ << " prefix " << *i << " ob " << j->second << dendl;
 	  out->push_back(j->second);
 	}

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -440,7 +440,6 @@ int HashIndex::_lookup(const ghobject_t &oid,
 
 int HashIndex::_collection_list_partial(const ghobject_t &start,
 					const ghobject_t &end,
-					bool sort_bitwise,
 					int max_count,
 					vector<ghobject_t> *ls,
 					ghobject_t *next) {
@@ -450,7 +449,7 @@ int HashIndex::_collection_list_partial(const ghobject_t &start,
     next = &_next;
   *next = start;
   dout(20) << __func__ << " start:" << start << " end:" << end << "-" << max_count << " ls.size " << ls->size() << dendl;
-  return list_by_hash(path, end, sort_bitwise, max_count, next, ls);
+  return list_by_hash(path, end, max_count, next, ls);
 }
 
 int HashIndex::prep_delete() {
@@ -947,73 +946,14 @@ int HashIndex::get_path_contents_by_hash_bitwise(
   return 0;
 }
 
-int HashIndex::get_path_contents_by_hash_nibblewise(
-  const vector<string> &path,
-  const ghobject_t *next_object,
-  set<string> *hash_prefixes,
-  set<pair<string, ghobject_t>, CmpPairNibblewise > *objects)
-{
-  map<string, ghobject_t> rev_objects;
-  int r;
-  r = list_objects(path, 0, 0, &rev_objects);
-  if (r < 0)
-    return r;
-
-  for (map<string, ghobject_t>::iterator i = rev_objects.begin();
-       i != rev_objects.end();
-       ++i) {
-    string hash_prefix = get_path_str(i->second);
-    if (next_object && cmp_nibblewise(i->second, *next_object) < 0)
-      continue;
-    hash_prefixes->insert(hash_prefix);
-    objects->insert(pair<string, ghobject_t>(hash_prefix, i->second));
-  }
-
-  vector<string> subdirs;
-  r = list_subdirs(path, &subdirs);
-  if (r < 0)
-    return r;
-
-  // sort nibblewise (string sort of (reversed) hex digits)
-  std::sort(subdirs.begin(), subdirs.end());
-
-  string cur_prefix;
-  for (vector<string>::const_iterator i = path.begin();
-       i != path.end();
-       ++i) {
-    cur_prefix.append(*i);
-  }
-  string next_object_string;
-  if (next_object)
-    next_object_string = get_path_str(*next_object);
-
-  for (vector<string>::iterator i = subdirs.begin();
-       i != subdirs.end();
-       ++i) {
-    string candidate = cur_prefix + *i;
-    if (next_object) {
-      if (next_object->is_max())
-	continue;
-      if (candidate < next_object_string.substr(0, candidate.size()))
-	continue;
-    }
-    hash_prefixes->insert(cur_prefix + *i);
-  }
-  return 0;
-}
-
 int HashIndex::list_by_hash(const vector<string> &path,
 			    const ghobject_t &end,
-			    bool sort_bitwise,
 			    int max_count,
 			    ghobject_t *next,
 			    vector<ghobject_t> *out)
 {
   assert(out);
-  if (sort_bitwise)
-    return list_by_hash_bitwise(path, end, max_count, next, out);
-  else
-    return list_by_hash_nibblewise(path, end, max_count, next, out);
+  return list_by_hash_bitwise(path, end, max_count, next, out);
 }
 
 int HashIndex::list_by_hash_bitwise(
@@ -1082,67 +1022,4 @@ int HashIndex::list_by_hash_bitwise(
   return 0;
 }
 
-int HashIndex::list_by_hash_nibblewise(
-  const vector<string> &path,
-  const ghobject_t& end,
-  int max_count,
-  ghobject_t *next,
-  vector<ghobject_t> *out)
-{
-  vector<string> next_path = path;
-  next_path.push_back("");
-  set<string> hash_prefixes;
-  set<pair<string, ghobject_t>, CmpPairNibblewise> objects;
-  int r = get_path_contents_by_hash_nibblewise(path,
-					       next,
-					       &hash_prefixes,
-					       &objects);
-  if (r < 0)
-    return r;
-  for (set<string>::iterator i = hash_prefixes.begin();
-       i != hash_prefixes.end();
-       ++i) {
-    dout(20) << __func__ << " prefix " << *i << dendl;
-    set<pair<string, ghobject_t>, CmpPairNibblewise >::iterator j =
-      objects.lower_bound(make_pair(*i, ghobject_t()));
-    if (j == objects.end() || j->first != *i) {
-      *(next_path.rbegin()) = *(i->rbegin());
-      ghobject_t next_recurse;
-      if (next)
-	next_recurse = *next;
-      r = list_by_hash_nibblewise(next_path,
-				  end,
-				  max_count,
-				  &next_recurse,
-				  out);
 
-      if (r < 0)
-	return r;
-      if (!next_recurse.is_max()) {
-	if (next)
-	  *next = next_recurse;
-	return 0;
-      }
-    } else {
-      while (j != objects.end() && j->first == *i) {
-	if (max_count > 0 && out->size() == (unsigned)max_count) {
-	  if (next)
-	    *next = j->second;
-	  return 0;
-	}
-	if (cmp_nibblewise(j->second, end) >= 0) {
-	  if (next)
-	    *next = j->second;
-	  return 0;
-	}
-	if (!next || cmp_nibblewise(j->second, *next) >= 0) {
-	  out->push_back(j->second);
-	}
-	++j;
-      }
-    }
-  }
-  if (next)
-    *next = ghobject_t::get_max();
-  return 0;
-}

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -359,20 +359,6 @@ private:
     return str;
   }
 
-  struct CmpPairNibblewise {
-    bool operator()(const pair<string, ghobject_t>& l,
-		    const pair<string, ghobject_t>& r)
-    {
-      if (l.first < r.first)
-	return true;
-      if (l.first > r.first)
-	return false;
-      if (cmp_nibblewise(l.second, r.second) < 0)
-	return true;
-      return false;
-    }
-  };
-
   struct CmpPairBitwise {
     bool operator()(const pair<string, ghobject_t>& l,
 		    const pair<string, ghobject_t>& r)
@@ -381,7 +367,7 @@ private:
 	return true;
       if (l.first > r.first)
 	return false;
-      if (cmp_bitwise(l.second, r.second) < 0)
+      if (cmp(l.second, r.second) < 0)
 	return true;
       return false;
     }

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -196,7 +196,6 @@ protected:
   int _collection_list_partial(
     const ghobject_t &start,
     const ghobject_t &end,
-    bool sort_bitwise,
     int max_count,
     vector<ghobject_t> *ls,
     ghobject_t *next
@@ -401,31 +400,17 @@ private:
     set<string, CmpHexdigitStringBitwise> *hash_prefixes, /// [out] prefixes in dir
     set<pair<string, ghobject_t>, CmpPairBitwise> *objects /// [out] objects
     );
-  int get_path_contents_by_hash_nibblewise(
-    const vector<string> &path,             /// [in] Path to list
-    const ghobject_t *next_object,          /// [in] list > *next_object
-    set<string> *hash_prefixes,             /// [out] prefixes in dir
-    set<pair<string, ghobject_t>, CmpPairNibblewise> *objects /// [out] objects
-    );
 
   /// List objects in collection in ghobject_t order
   int list_by_hash(
     const vector<string> &path, /// [in] Path to list
     const ghobject_t &end,      /// [in] List only objects < end
-    bool sort_bitwise,          /// [in] sort bitwise
     int max_count,              /// [in] List at most max_count
     ghobject_t *next,            /// [in,out] List objects >= *next
     vector<ghobject_t> *out      /// [out] Listed objects
     ); ///< @return Error Code, 0 on success
   /// List objects in collection in ghobject_t order
   int list_by_hash_bitwise(
-    const vector<string> &path, /// [in] Path to list
-    const ghobject_t &end,      /// [in] List only objects < end
-    int max_count,              /// [in] List at most max_count
-    ghobject_t *next,            /// [in,out] List objects >= *next
-    vector<ghobject_t> *out      /// [out] Listed objects
-    ); ///< @return Error Code, 0 on success
-  int list_by_hash_nibblewise(
     const vector<string> &path, /// [in] Path to list
     const ghobject_t &end,      /// [in] List only objects < end
     int max_count,              /// [in] List at most max_count

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -157,12 +157,11 @@ int LFNIndex::pre_hash_collection(uint32_t pg_num, uint64_t expected_num_objs)
 
 int LFNIndex::collection_list_partial(const ghobject_t &start,
 				      const ghobject_t &end,
-				      bool sort_bitwise,
 				      int max_count,
 				      vector<ghobject_t> *ls,
 				      ghobject_t *next)
 {
-  return _collection_list_partial(start, end, sort_bitwise, max_count, ls, next);
+  return _collection_list_partial(start, end, max_count, ls, next);
 }
 
 /* Derived class utility methods */

--- a/src/os/filestore/LFNIndex.h
+++ b/src/os/filestore/LFNIndex.h
@@ -189,7 +189,6 @@ public:
   int collection_list_partial(
     const ghobject_t &start,
     const ghobject_t &end,
-    bool sort_bitwise,
     int max_count,
     vector<ghobject_t> *ls,
     ghobject_t *next
@@ -255,7 +254,6 @@ protected:
   virtual int _collection_list_partial(
     const ghobject_t &start,
     const ghobject_t &end,
-    bool sort_bitwise,
     int max_count,
     vector<ghobject_t> *ls,
     ghobject_t *next

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1388,7 +1388,7 @@ int KStore::collection_empty(const coll_t& cid, bool *empty)
   dout(15) << __func__ << " " << cid << dendl;
   vector<ghobject_t> ls;
   ghobject_t next;
-  int r = collection_list(cid, ghobject_t(), ghobject_t::get_max(), true, 1,
+  int r = collection_list(cid, ghobject_t(), ghobject_t::get_max(), 1,
 			  &ls, &next);
   if (r < 0) {
     derr << __func__ << " collection_list returned: " << cpp_strerror(r)
@@ -1401,19 +1401,17 @@ int KStore::collection_empty(const coll_t& cid, bool *empty)
 }
 
 int KStore::collection_list(
-  const coll_t& cid, const ghobject_t& start, const ghobject_t& end,
-  bool sort_bitwise, int max,
+  const coll_t& cid, const ghobject_t& start, const ghobject_t& end, int max,
   vector<ghobject_t> *ls, ghobject_t *pnext)
 {
   CollectionHandle c = _get_collection(cid);
   if (!c)
     return -ENOENT;
-  return collection_list(c, start, end, sort_bitwise, max, ls, pnext);
+  return collection_list(c, start, end, max, ls, pnext);
 }
 
 int KStore::collection_list(
-  CollectionHandle &c_, const ghobject_t& start, const ghobject_t& end,
-  bool sort_bitwise, int max,
+  CollectionHandle &c_, const ghobject_t& start, const ghobject_t& end, int max,
   vector<ghobject_t> *ls, ghobject_t *pnext)
 
 {
@@ -1423,7 +1421,7 @@ int KStore::collection_list(
   int r;
   {
     RWLock::RLocker l(c->lock);
-    r = _collection_list(c, start, end, sort_bitwise, max, ls, pnext);
+    r = _collection_list(c, start, end, max, ls, pnext);
   }
 
   dout(10) << __func__ << " " << c->cid
@@ -1434,13 +1432,9 @@ int KStore::collection_list(
 }
 
 int KStore::_collection_list(
-  Collection* c, const ghobject_t& start, const ghobject_t& end,
-  bool sort_bitwise, int max,
+  Collection* c, const ghobject_t& start, const ghobject_t& end, int max,
   vector<ghobject_t> *ls, ghobject_t *pnext)
 {
-  if (!sort_bitwise)
-    return -EOPNOTSUPP;
-
   int r = 0;
   KeyValueDB::Iterator it;
   string temp_start_key, temp_end_key;
@@ -3293,7 +3287,7 @@ int KStore::_remove_collection(TransContext *txc, coll_t cid,
     // Enumerate onodes in db, up to nonexistent_count + 1
     // then check if all of them are marked as non-existent.
     // Bypass the check if returned number is greater than nonexistent_count
-    r = _collection_list(c->get(), ghobject_t(), ghobject_t::get_max(), true,
+    r = _collection_list(c->get(), ghobject_t(), ghobject_t::get_max(),
                          nonexistent_count + 1, &ls, &next);
     if (r >= 0) {
       bool exists = false; //ls.size() > nonexistent_count;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -399,7 +399,7 @@ private:
 
   int _collection_list(
     Collection *c, const ghobject_t& start, const ghobject_t& end,
-    bool sort_bitwise, int max, vector<ghobject_t> *ls, ghobject_t *next);
+    int max, vector<ghobject_t> *ls, ghobject_t *next);
 
 public:
   KStore(CephContext *cct, const string& path);
@@ -483,11 +483,11 @@ public:
 
   int collection_list(
     const coll_t& cid, const ghobject_t& start, const ghobject_t& end,
-    bool sort_bitwise, int max,
+    int max,
     vector<ghobject_t> *ls, ghobject_t *next) override;
   int collection_list(
     CollectionHandle &c, const ghobject_t& start, const ghobject_t& end,
-    bool sort_bitwise, int max,
+    int max,
     vector<ghobject_t> *ls, ghobject_t *next) override;
 
   using ObjectStore::omap_get;

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -120,7 +120,7 @@ void MemStore::dump(Formatter *f)
     f->close_section();
 
     f->open_array_section("objects");
-    for (map<ghobject_t,ObjectRef,ghobject_t::BitwiseComparator>::iterator q = p->second->object_map.begin();
+    for (map<ghobject_t,ObjectRef>::iterator q = p->second->object_map.begin();
 	 q != p->second->object_map.end();
 	 ++q) {
       f->open_object_section("object");
@@ -473,7 +473,7 @@ int MemStore::collection_list(const coll_t& cid,
 
   dout(10) << __func__ << " cid " << cid << " start " << start
 	   << " end " << end << dendl;
-  map<ghobject_t,ObjectRef,ghobject_t::BitwiseComparator>::iterator p = c->object_map.lower_bound(start);
+  map<ghobject_t,ObjectRef>::iterator p = c->object_map.lower_bound(start);
   while (p != c->object_map.end() &&
 	 ls->size() < (unsigned)max &&
 	 p->first < end) {
@@ -1445,7 +1445,7 @@ int MemStore::_split_collection(const coll_t& cid, uint32_t bits, uint32_t match
   RWLock::WLocker l1(MIN(&(*sc), &(*dc))->lock);
   RWLock::WLocker l2(MAX(&(*sc), &(*dc))->lock);
 
-  map<ghobject_t,ObjectRef,ghobject_t::BitwiseComparator>::iterator p = sc->object_map.begin();
+  map<ghobject_t,ObjectRef>::iterator p = sc->object_map.begin();
   while (p != sc->object_map.end()) {
     if (p->first.match(bits, match)) {
       dout(20) << " moving " << p->first << dendl;

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -476,7 +476,7 @@ int MemStore::collection_list(const coll_t& cid,
   map<ghobject_t,ObjectRef,ghobject_t::BitwiseComparator>::iterator p = c->object_map.lower_bound(start);
   while (p != c->object_map.end() &&
 	 ls->size() < (unsigned)max &&
-	 cmp_bitwise(p->first, end) < 0) {
+	 p->first < end) {
     ls->push_back(p->first);
     ++p;
   }

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -463,11 +463,9 @@ int MemStore::collection_empty(const coll_t& cid, bool *empty)
 int MemStore::collection_list(const coll_t& cid,
 			      const ghobject_t& start,
 			      const ghobject_t& end,
-			      bool sort_bitwise, int max,
+			      int max,
 			      vector<ghobject_t> *ls, ghobject_t *next)
 {
-  if (!sort_bitwise)
-    return -EOPNOTSUPP;
   CollectionRef c = get_collection(cid);
   if (!c)
     return -ENOENT;

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -327,8 +327,7 @@ public:
   int collection_empty(const coll_t& c, bool *empty) override;
   using ObjectStore::collection_list;
   int collection_list(const coll_t& cid,
-		      const ghobject_t& start, const ghobject_t& end,
-		      bool sort_bitwise, int max,
+		      const ghobject_t& start, const ghobject_t& end, int max,
 		      vector<ghobject_t> *ls, ghobject_t *next) override;
 
   using ObjectStore::omap_get;

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -99,7 +99,7 @@ public:
     CephContext *cct;
     bool use_page_set;
     ceph::unordered_map<ghobject_t, ObjectRef> object_hash;  ///< for lookup
-    map<ghobject_t, ObjectRef,ghobject_t::BitwiseComparator> object_map;        ///< for iteration
+    map<ghobject_t, ObjectRef> object_map;        ///< for iteration
     map<string,bufferptr> xattr;
     RWLock lock;   ///< for object_{map,hash}
     bool exists;
@@ -141,7 +141,7 @@ public:
       ::encode(use_page_set, bl);
       uint32_t s = object_map.size();
       ::encode(s, bl);
-      for (map<ghobject_t, ObjectRef,ghobject_t::BitwiseComparator>::const_iterator p = object_map.begin();
+      for (map<ghobject_t, ObjectRef>::const_iterator p = object_map.begin();
 	   p != object_map.end();
 	   ++p) {
 	::encode(p->first, bl);
@@ -168,7 +168,7 @@ public:
 
     uint64_t used_bytes() const {
       uint64_t result = 0;
-      for (map<ghobject_t, ObjectRef,ghobject_t::BitwiseComparator>::const_iterator p = object_map.begin();
+      for (map<ghobject_t, ObjectRef>::const_iterator p = object_map.begin();
 	   p != object_map.end();
 	   ++p) {
         result += p->second->get_size();

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1475,7 +1475,7 @@ int ECBackend::get_min_avail_to_read_shards(
       assert(!shards.count(i->shard));
       const pg_info_t &info = get_parent()->get_shard_info(*i);
       const pg_missing_t &missing = get_parent()->get_shard_missing(*i);
-      if (cmp(hoid, info.last_backfill, get_parent()->sort_bitwise()) < 0 &&
+      if (hoid < info.last_backfill &&
 	  !missing.is_missing(hoid)) {
 	have.insert(i->shard);
 	shards.insert(make_pair(i->shard, *i));

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -251,7 +251,7 @@ struct OnRecoveryReadComplete :
 
 struct RecoveryMessages {
   map<hobject_t,
-      ECBackend::read_request_t, hobject_t::BitwiseComparator> reads;
+      ECBackend::read_request_t> reads;
   void read(
     ECBackend *ec,
     const hobject_t &hoid, uint64_t off, uint64_t len,
@@ -888,7 +888,7 @@ void ECBackend::handle_sub_write(
     add_temp_objs(op.temp_added);
   }
   if (op.backfill) {
-    for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = op.temp_removed.begin();
+    for (set<hobject_t>::iterator i = op.temp_removed.begin();
 	 i != op.temp_removed.end();
 	 ++i) {
       dout(10) << __func__ << ": removing object " << *i
@@ -941,7 +941,7 @@ void ECBackend::handle_sub_read(
   ECSubReadReply *reply)
 {
   shard_id_t shard = get_parent()->whoami_shard().shard;
-  for(map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator>::iterator i =
+  for(map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >>::iterator i =
         op.to_read.begin();
       i != op.to_read.end();
       ++i) {
@@ -1012,7 +1012,7 @@ error:
     reply->buffers_read.erase(i->first);
     reply->errors[i->first] = r;
   }
-  for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = op.attrs_to_read.begin();
+  for (set<hobject_t>::iterator i = op.attrs_to_read.begin();
        i != op.attrs_to_read.end();
        ++i) {
     dout(10) << __func__ << ": fulfilling attr request on "
@@ -1077,7 +1077,7 @@ void ECBackend::handle_sub_read_reply(
     return;
   }
   ReadOp &rop = iter->second;
-  for (map<hobject_t, list<pair<uint64_t, bufferlist> >, hobject_t::BitwiseComparator>::iterator i =
+  for (map<hobject_t, list<pair<uint64_t, bufferlist> >>::iterator i =
 	 op.buffers_read.begin();
        i != op.buffers_read.end();
        ++i) {
@@ -1105,7 +1105,7 @@ void ECBackend::handle_sub_read_reply(
       riter->get<2>()[from].claim(j->second);
     }
   }
-  for (map<hobject_t, map<string, bufferlist>, hobject_t::BitwiseComparator>::iterator i = op.attrs_read.begin();
+  for (map<hobject_t, map<string, bufferlist>>::iterator i = op.attrs_read.begin();
        i != op.attrs_read.end();
        ++i) {
     assert(!op.errors.count(i->first));	// if read error better not have sent an attribute
@@ -1117,7 +1117,7 @@ void ECBackend::handle_sub_read_reply(
     rop.complete[i->first].attrs = map<string, bufferlist>();
     (*(rop.complete[i->first].attrs)).swap(i->second);
   }
-  for (map<hobject_t, int, hobject_t::BitwiseComparator>::iterator i = op.errors.begin();
+  for (map<hobject_t, int>::iterator i = op.errors.begin();
        i != op.errors.end();
        ++i) {
     rop.complete[i->first].errors.insert(
@@ -1207,9 +1207,9 @@ void ECBackend::handle_sub_read_reply(
 
 void ECBackend::complete_read_op(ReadOp &rop, RecoveryMessages *m)
 {
-  map<hobject_t, read_request_t, hobject_t::BitwiseComparator>::iterator reqiter =
+  map<hobject_t, read_request_t>::iterator reqiter =
     rop.to_read.begin();
-  map<hobject_t, read_result_t, hobject_t::BitwiseComparator>::iterator resiter =
+  map<hobject_t, read_result_t>::iterator resiter =
     rop.complete.begin();
   assert(rop.to_read.size() == rop.complete.size());
   for (; reqiter != rop.to_read.end(); ++reqiter, ++resiter) {
@@ -1241,8 +1241,8 @@ void ECBackend::filter_read_op(
   const OSDMapRef& osdmap,
   ReadOp &op)
 {
-  set<hobject_t, hobject_t::BitwiseComparator> to_cancel;
-  for (map<pg_shard_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator i = op.source_to_obj.begin();
+  set<hobject_t> to_cancel;
+  for (map<pg_shard_t, set<hobject_t> >::iterator i = op.source_to_obj.begin();
        i != op.source_to_obj.end();
        ++i) {
     if (osdmap->is_down(i->first.osd)) {
@@ -1255,10 +1255,10 @@ void ECBackend::filter_read_op(
   if (to_cancel.empty())
     return;
 
-  for (map<pg_shard_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator i = op.source_to_obj.begin();
+  for (map<pg_shard_t, set<hobject_t> >::iterator i = op.source_to_obj.begin();
        i != op.source_to_obj.end();
        ) {
-    for (set<hobject_t, hobject_t::BitwiseComparator>::iterator j = i->second.begin();
+    for (set<hobject_t>::iterator j = i->second.begin();
 	 j != i->second.end();
 	 ) {
       if (to_cancel.count(*j))
@@ -1274,7 +1274,7 @@ void ECBackend::filter_read_op(
     }
   }
 
-  for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = to_cancel.begin();
+  for (set<hobject_t>::iterator i = to_cancel.begin();
        i != to_cancel.end();
        ++i) {
     get_parent()->cancel_pull(*i);
@@ -1341,7 +1341,7 @@ void ECBackend::on_change()
        i != tid_to_read_map.end();
        ++i) {
     dout(10) << __func__ << ": cancelling " << i->second << dendl;
-    for (map<hobject_t, read_request_t, hobject_t::BitwiseComparator>::iterator j =
+    for (map<hobject_t, read_request_t>::iterator j =
 	   i->second.to_read.begin();
 	 j != i->second.to_read.end();
 	 ++j) {
@@ -1367,7 +1367,7 @@ void ECBackend::on_flushed()
 void ECBackend::dump_recovery_info(Formatter *f) const
 {
   f->open_array_section("recovery_ops");
-  for (map<hobject_t, RecoveryOp, hobject_t::BitwiseComparator>::const_iterator i = recovery_ops.begin();
+  for (map<hobject_t, RecoveryOp>::const_iterator i = recovery_ops.begin();
        i != recovery_ops.end();
        ++i) {
     f->open_object_section("op");
@@ -1482,7 +1482,7 @@ int ECBackend::get_min_avail_to_read_shards(
       }
     }
 
-    map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator>::const_iterator miter =
+    map<hobject_t, set<pg_shard_t>>::const_iterator miter =
       get_parent()->get_missing_loc_shards().find(hoid);
     if (miter != get_parent()->get_missing_loc_shards().end()) {
       for (set<pg_shard_t>::iterator i = miter->second.begin();
@@ -1557,7 +1557,7 @@ int ECBackend::get_remaining_shards(
 
 void ECBackend::start_read_op(
   int priority,
-  map<hobject_t, read_request_t, hobject_t::BitwiseComparator> &to_read,
+  map<hobject_t, read_request_t> &to_read,
   OpRequestRef _op,
   bool do_redundant_reads,
   bool for_recovery)
@@ -1586,8 +1586,7 @@ void ECBackend::do_read_op(ReadOp &op)
   dout(10) << __func__ << ": starting read " << op << dendl;
 
   map<pg_shard_t, ECSubRead> messages;
-  for (map<hobject_t, read_request_t,
-           hobject_t::BitwiseComparator>::iterator i = op.to_read.begin();
+  for (map<hobject_t, read_request_t>::iterator i = op.to_read.begin();
        i != op.to_read.end();
        ++i) {
     bool need_attrs = i->second.want_attrs;
@@ -1785,7 +1784,7 @@ bool ECBackend::try_state_to_reads()
     assert(get_parent()->get_pool().is_hacky_ecoverwrites());
     objects_read_async_no_cache(
       op->remote_read,
-      [this, op](hobject_t::bitwisemap<pair<int, extent_map> > &&results) {
+      [this, op](map<hobject_t,pair<int, extent_map> > &&results) {
 	for (auto &&i: results) {
 	  op->remote_read_result.emplace(i.first, i.second.second);
 	}
@@ -1834,7 +1833,7 @@ bool ECBackend::try_reads_to_commit()
     trans[i->shard];
   }
 
-  hobject_t::bitwisemap<extent_map> written;
+  map<hobject_t,extent_map> written;
   if (op->plan.t) {
     ECTransaction::generate_transactions(
       op->plan,
@@ -1865,7 +1864,7 @@ bool ECBackend::try_reads_to_commit()
     }
   }
 
-  hobject_t::bitwisemap<extent_set> written_set;
+  map<hobject_t,extent_set> written_set;
   for (auto &&i: written) {
     written_set[i.first] = i.second.get_interval_set();
   }
@@ -2016,7 +2015,7 @@ void ECBackend::objects_read_async(
   Context *on_complete,
   bool fast_read)
 {
-  hobject_t::bitwisemap<std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > >
+  map<hobject_t,std::list<boost::tuple<uint64_t, uint64_t, uint32_t> > >
     reads;
 
   uint32_t flags = 0;
@@ -2066,7 +2065,7 @@ void ECBackend::objects_read_async(
 	hoid(hoid),
 	to_read(to_read),
 	on_complete(on_complete) {}
-    void operator()(hobject_t::bitwisemap<pair<int, extent_map> > &&results) {
+    void operator()(map<hobject_t,pair<int, extent_map> > &&results) {
       auto dpp = ec->get_parent()->get_dpp();
       ldpp_dout(dpp, 20) << "objects_read_async_cb: got: " << results
 			 << dendl;
@@ -2119,7 +2118,7 @@ void ECBackend::objects_read_async(
     reads,
     fast_read,
     make_gen_lambda_context<
-      hobject_t::bitwisemap<pair<int, extent_map> > &&, cb>(
+      map<hobject_t,pair<int, extent_map> > &&, cb>(
 	cb(this,
 	   hoid,
 	   to_read,
@@ -2186,11 +2185,11 @@ out:
 };
 
 void ECBackend::objects_read_and_reconstruct(
-  const hobject_t::bitwisemap<
+  const map<hobject_t,
     std::list<boost::tuple<uint64_t, uint64_t, uint32_t> >
   > &reads,
   bool fast_read,
-  GenContextURef<hobject_t::bitwisemap<pair<int, extent_map> > &&> &&func)
+  GenContextURef<map<hobject_t,pair<int, extent_map> > &&> &&func)
 {
   in_progress_client_reads.emplace_back(
     reads.size(), std::move(func));
@@ -2202,7 +2201,7 @@ void ECBackend::objects_read_and_reconstruct(
   set<int> want_to_read;
   get_want_to_read_shards(&want_to_read);
     
-  map<hobject_t, read_request_t, hobject_t::BitwiseComparator> for_read_op;
+  map<hobject_t, read_request_t> for_read_op;
   for (auto &&to_read: reads) {
     set<pg_shard_t> shards;
     int r = get_min_avail_to_read_shards(
@@ -2261,7 +2260,7 @@ int ECBackend::send_all_remaining_reads(
   GenContext<pair<RecoveryMessages *, read_result_t& > &> *c =
     rop.to_read.find(hoid)->second.cb;
 
-  map<hobject_t, read_request_t, hobject_t::BitwiseComparator> for_read_op;
+  map<hobject_t, read_request_t> for_read_op;
   for_read_op.insert(
     make_pair(
       hoid,

--- a/src/osd/ECMsgTypes.cc
+++ b/src/osd/ECMsgTypes.cc
@@ -169,8 +169,8 @@ void ECSubRead::encode(bufferlist &bl, uint64_t features) const
     ENCODE_START(1, 1, bl);
     ::encode(from, bl);
     ::encode(tid, bl);
-    map<hobject_t, list<pair<uint64_t, uint64_t> >, hobject_t::BitwiseComparator> tmp;
-    for (map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator>::const_iterator m = to_read.begin();
+    map<hobject_t, list<pair<uint64_t, uint64_t> >> tmp;
+    for (map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >>::const_iterator m = to_read.begin();
 	  m != to_read.end(); ++m) {
       list<pair<uint64_t, uint64_t> > tlist;
       for (list<boost::tuple<uint64_t, uint64_t, uint32_t> >::const_iterator l = m->second.begin();
@@ -199,9 +199,9 @@ void ECSubRead::decode(bufferlist::iterator &bl)
   ::decode(from, bl);
   ::decode(tid, bl);
   if (struct_v == 1) {
-    map<hobject_t, list<pair<uint64_t, uint64_t> >, hobject_t::BitwiseComparator>tmp;
+    map<hobject_t, list<pair<uint64_t, uint64_t> >>tmp;
     ::decode(tmp, bl);
-    for (map<hobject_t, list<pair<uint64_t, uint64_t> >, hobject_t::BitwiseComparator>::const_iterator m = tmp.begin();
+    for (map<hobject_t, list<pair<uint64_t, uint64_t> >>::const_iterator m = tmp.begin();
 	  m != tmp.end(); ++m) {
       list<boost::tuple<uint64_t, uint64_t, uint32_t> > tlist;
       for (list<pair<uint64_t, uint64_t> > ::const_iterator l = m->second.begin();
@@ -231,7 +231,7 @@ void ECSubRead::dump(Formatter *f) const
   f->dump_stream("from") << from;
   f->dump_unsigned("tid", tid);
   f->open_array_section("objects");
-  for (map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator>::const_iterator i =
+  for (map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >>::const_iterator i =
 	 to_read.begin();
        i != to_read.end();
        ++i) {
@@ -254,7 +254,7 @@ void ECSubRead::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("object_attrs_requested");
-  for (set<hobject_t,hobject_t::BitwiseComparator>::const_iterator i = attrs_to_read.begin();
+  for (set<hobject_t>::const_iterator i = attrs_to_read.begin();
        i != attrs_to_read.end();
        ++i) {
     f->open_object_section("object");
@@ -320,7 +320,7 @@ void ECSubReadReply::dump(Formatter *f) const
   f->dump_stream("from") << from;
   f->dump_unsigned("tid", tid);
   f->open_array_section("buffers_read");
-  for (map<hobject_t, list<pair<uint64_t, bufferlist> >, hobject_t::BitwiseComparator>::const_iterator i =
+  for (map<hobject_t, list<pair<uint64_t, bufferlist> >>::const_iterator i =
 	 buffers_read.begin();
        i != buffers_read.end();
        ++i) {
@@ -342,7 +342,7 @@ void ECSubReadReply::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("attrs_returned");
-  for (map<hobject_t, map<string, bufferlist>, hobject_t::BitwiseComparator>::const_iterator i =
+  for (map<hobject_t, map<string, bufferlist>>::const_iterator i =
 	 attrs_read.begin();
        i != attrs_read.end();
        ++i) {
@@ -363,7 +363,7 @@ void ECSubReadReply::dump(Formatter *f) const
   f->close_section();
 
   f->open_array_section("errors");
-  for (map<hobject_t, int, hobject_t::BitwiseComparator>::const_iterator i = errors.begin();
+  for (map<hobject_t, int>::const_iterator i = errors.begin();
        i != errors.end();
        ++i) {
     f->open_object_section("error_pair");

--- a/src/osd/ECMsgTypes.h
+++ b/src/osd/ECMsgTypes.h
@@ -31,8 +31,8 @@ struct ECSubWrite {
   eversion_t trim_to;
   eversion_t roll_forward_to;
   vector<pg_log_entry_t> log_entries;
-  set<hobject_t, hobject_t::BitwiseComparator> temp_added;
-  set<hobject_t, hobject_t::BitwiseComparator> temp_removed;
+  set<hobject_t> temp_added;
+  set<hobject_t> temp_removed;
   boost::optional<pg_hit_set_history_t> updated_hit_set_history;
   bool backfill = false;
   ECSubWrite() : tid(0) {}
@@ -48,8 +48,8 @@ struct ECSubWrite {
     eversion_t roll_forward_to,
     vector<pg_log_entry_t> log_entries,
     boost::optional<pg_hit_set_history_t> updated_hit_set_history,
-    const set<hobject_t, hobject_t::BitwiseComparator> &temp_added,
-    const set<hobject_t, hobject_t::BitwiseComparator> &temp_removed,
+    const set<hobject_t> &temp_added,
+    const set<hobject_t> &temp_removed,
     bool backfill)
     : from(from), tid(tid), reqid(reqid),
       soid(soid), stats(stats), t(t),
@@ -105,8 +105,8 @@ WRITE_CLASS_ENCODER(ECSubWriteReply)
 struct ECSubRead {
   pg_shard_t from;
   ceph_tid_t tid;
-  map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >, hobject_t::BitwiseComparator> to_read;
-  set<hobject_t, hobject_t::BitwiseComparator> attrs_to_read;
+  map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >> to_read;
+  set<hobject_t> attrs_to_read;
   void encode(bufferlist &bl, uint64_t features) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;
@@ -117,9 +117,9 @@ WRITE_CLASS_ENCODER_FEATURES(ECSubRead)
 struct ECSubReadReply {
   pg_shard_t from;
   ceph_tid_t tid;
-  map<hobject_t, list<pair<uint64_t, bufferlist> >, hobject_t::BitwiseComparator> buffers_read;
-  map<hobject_t, map<string, bufferlist>, hobject_t::BitwiseComparator> attrs_read;
-  map<hobject_t, int, hobject_t::BitwiseComparator> errors;
+  map<hobject_t, list<pair<uint64_t, bufferlist> >> buffers_read;
+  map<hobject_t, map<string, bufferlist>> attrs_read;
+  map<hobject_t, int> errors;
   void encode(bufferlist &bl) const;
   void decode(bufferlist::iterator &bl);
   void dump(Formatter *f) const;

--- a/src/osd/ECTransaction.cc
+++ b/src/osd/ECTransaction.cc
@@ -101,12 +101,12 @@ void ECTransaction::generate_transactions(
   pg_t pgid,
   bool legacy_log_entries,
   const ECUtil::stripe_info_t &sinfo,
-  const hobject_t::bitwisemap<extent_map> &partial_extents,
+  const map<hobject_t,extent_map> &partial_extents,
   vector<pg_log_entry_t> &entries,
-  hobject_t::bitwisemap<extent_map> *written_map,
+  map<hobject_t,extent_map> *written_map,
   map<shard_id_t, ObjectStore::Transaction> *transactions,
-  set<hobject_t, hobject_t::BitwiseComparator> *temp_added,
-  set<hobject_t, hobject_t::BitwiseComparator> *temp_removed,
+  set<hobject_t> *temp_added,
+  set<hobject_t> *temp_removed,
   DoutPrefixProvider *dpp)
 {
   assert(written_map);
@@ -122,7 +122,7 @@ void ECTransaction::generate_transactions(
   assert(temp_added);
   assert(temp_removed);
 
-  map<hobject_t, pg_log_entry_t*, hobject_t::BitwiseComparator> obj_to_log;
+  map<hobject_t, pg_log_entry_t*> obj_to_log;
   for (auto &&i: entries) {
     obj_to_log.insert(make_pair(i.soid, &i));
   }

--- a/src/osd/ECTransaction.h
+++ b/src/osd/ECTransaction.h
@@ -26,10 +26,10 @@ namespace ECTransaction {
   struct WritePlan {
     PGTransactionUPtr t;
     bool invalidates_cache = false; // Yes, both are possible
-    hobject_t::bitwisemap<extent_set> to_read;
-    hobject_t::bitwisemap<extent_set> will_write; // superset of to_read
+    map<hobject_t,extent_set> to_read;
+    map<hobject_t,extent_set> will_write; // superset of to_read
 
-    hobject_t::bitwisemap<ECUtil::HashInfoRef> hash_infos;
+    map<hobject_t,ECUtil::HashInfoRef> hash_infos;
   };
 
   bool requires_overwrite(
@@ -182,12 +182,12 @@ namespace ECTransaction {
     pg_t pgid,
     bool legacy_log_entries,
     const ECUtil::stripe_info_t &sinfo,
-    const hobject_t::bitwisemap<extent_map> &partial_extents,
+    const map<hobject_t,extent_map> &partial_extents,
     vector<pg_log_entry_t> &entries,
-    hobject_t::bitwisemap<extent_map> *written,
+    map<hobject_t,extent_map> *written,
     map<shard_id_t, ObjectStore::Transaction> *transactions,
-    set<hobject_t, hobject_t::BitwiseComparator> *temp_added,
-    set<hobject_t, hobject_t::BitwiseComparator> *temp_removed,
+    set<hobject_t> *temp_added,
+    set<hobject_t> *temp_removed,
     DoutPrefixProvider *dpp);
 };
 

--- a/src/osd/ExtentCache.h
+++ b/src/osd/ExtentCache.h
@@ -182,7 +182,7 @@ private:
     set extent_set;
 
     bool operator<(const object_extent_set &rhs) const {
-      return cmp_bitwise(oid, rhs.oid) < 0;
+      return oid < rhs.oid;
     }
 
     struct uint_cmp {
@@ -330,10 +330,10 @@ private:
   };
   struct Cmp {
     bool operator()(const hobject_t &oid, const object_extent_set &rhs) const {
-      return cmp_bitwise(oid, rhs.oid) < 0;
+      return oid < rhs.oid;
     }
     bool operator()(const object_extent_set &lhs, const hobject_t &oid) const {
-      return cmp_bitwise(lhs.oid, oid) < 0;
+      return lhs.oid < oid;
     }
   };
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8415,7 +8415,7 @@ void OSD::handle_pg_query(OpRequestRef op)
      * before the pg is recreated, we'll just start it off backfilling
      * instead of just empty */
     if (service.deleting_pgs.lookup(pgid))
-      empty.set_last_backfill(hobject_t(), true);
+      empty.set_last_backfill(hobject_t());
     if (it->second.type == pg_query_t::LOG ||
 	it->second.type == pg_query_t::FULLLOG) {
       ConnectionRef con = service.get_con_osd_cluster(from, osdmap->get_epoch());

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3039,7 +3039,7 @@ void OSD::clear_temp_objects()
     ghobject_t next;
     while (1) {
       vector<ghobject_t> objects;
-      store->collection_list(*p, next, ghobject_t::get_max(), true,
+      store->collection_list(*p, next, ghobject_t::get_max(),
 			     store->get_ideal_list_max(),
 			     &objects, &next);
       if (objects.empty())
@@ -3092,7 +3092,7 @@ void OSD::recursive_remove_collection(CephContext* cct,
   SnapMapper mapper(cct, &driver, 0, 0, 0, pgid.shard);
 
   vector<ghobject_t> objects;
-  store->collection_list(tmp, ghobject_t(), ghobject_t::get_max(), true,
+  store->collection_list(tmp, ghobject_t(), ghobject_t::get_max(),
 			 INT_MAX, &objects, 0);
 
   // delete them.
@@ -4763,7 +4763,6 @@ bool remove_dir(
     coll,
     next,
     ghobject_t::get_max(),
-    true,
     store->get_ideal_list_max(),
     &olist,
     &next);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5905,9 +5905,9 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       pg->lock();
 
       fout << *pg << std::endl;
-      std::map<hobject_t, pg_missing_item, hobject_t::BitwiseComparator>::const_iterator mend =
+      std::map<hobject_t, pg_missing_item>::const_iterator mend =
 	pg->pg_log.get_missing().get_items().end();
-      std::map<hobject_t, pg_missing_item, hobject_t::BitwiseComparator>::const_iterator mi =
+      std::map<hobject_t, pg_missing_item>::const_iterator mi =
 	pg->pg_log.get_missing().get_items().begin();
       for (; mi != mend; ++mi) {
 	fout << mi->first << " -> " << mi->second << std::endl;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7572,6 +7572,11 @@ void OSD::activate_map()
 
   dout(7) << "activate_map version " << osdmap->get_epoch() << dendl;
 
+  if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
+    derr << __func__ << " SORTBITWISE flag is not set" << dendl;
+    ceph_abort();
+  }
+
   if (osdmap->test_flag(CEPH_OSDMAP_FULL)) {
     dout(10) << " osdmap flagged full, doing onetime osdmap subscribe" << dendl;
     osdmap_subscribe(osdmap->get_epoch() + 1, false);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8903,7 +8903,7 @@ void OSD::handle_backoff(OpRequestRef& op, OSDMapRef& osdmap)
     // advance
     pos = _pgid.get_hobj_end(osdmap->get_pg_pool(pos.pool)->get_pg_num());
     dout(20) << __func__ << "  next pg " << pos << dendl;
-  } while (cmp_bitwise(pos, m->end) < 0);
+  } while (pos < m->end);
 }
 
 template<typename T, int MSGTYPE>

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -727,7 +727,7 @@ private:
   bool agent_valid_iterator;
   int agent_ops;
   int flush_mode_high_count; //once have one pg with FLUSH_MODE_HIGH then flush objects with high speed
-  set<hobject_t, hobject_t::BitwiseComparator> agent_oids;
+  set<hobject_t> agent_oids;
   bool agent_active;
   struct AgentThread : public Thread {
     OSDService *osd;
@@ -934,7 +934,7 @@ private:
   uint64_t recovery_ops_reserved;
   bool recovery_paused;
 #ifdef DEBUG_RECOVERY_OIDS
-  map<spg_t, set<hobject_t, hobject_t::BitwiseComparator> > recovery_oids;
+  map<spg_t, set<hobject_t> > recovery_oids;
 #endif
   bool _recover_now(uint64_t *available_pushes);
   void _maybe_queue_recovery();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -476,7 +476,7 @@ bool PG::search_for_missing(
 {
   unsigned num_unfound_before = missing_loc.num_unfound();
   bool found_missing = missing_loc.add_source_info(
-    from, oinfo, omissing, get_sort_bitwise(), ctx->handle);
+    from, oinfo, omissing, ctx->handle);
   if (found_missing && num_unfound_before != missing_loc.num_unfound())
     publish_stats_to_osd();
   if (found_missing &&
@@ -536,7 +536,6 @@ bool PG::MissingLoc::add_source_info(
   pg_shard_t fromosd,
   const pg_info_t &oinfo,
   const pg_missing_t &omissing,
-  bool sort_bitwise,
   ThreadPool::TPHandle* handle)
 {
   bool found_missing = false;
@@ -559,7 +558,7 @@ bool PG::MissingLoc::add_source_info(
       continue;
     }
     if (!oinfo.last_backfill.is_max() &&
-	oinfo.last_backfill_bitwise != sort_bitwise) {
+	!oinfo.last_backfill_bitwise) {
       ldout(pg->cct, 10) << "search_for_missing " << soid << " " << need
 			 << " also missing on osd." << fromosd
 			 << " (last_backfill " << oinfo.last_backfill
@@ -1795,7 +1794,7 @@ void PG::activate(ObjectStore::Transaction& t,
         missing_loc.add_batch_sources_info(complete_shards, ctx->handle);
       } else {
         missing_loc.add_source_info(pg_whoami, info, pg_log.get_missing(),
-				    get_sort_bitwise(), ctx->handle);
+				    ctx->handle);
         for (set<pg_shard_t>::iterator i = actingbackfill.begin();
 	     i != actingbackfill.end();
 	     ++i) {
@@ -1807,7 +1806,6 @@ void PG::activate(ObjectStore::Transaction& t,
 	    *i,
 	    peer_info[*i],
 	    peer_missing[*i],
-	    get_sort_bitwise(),
             ctx->handle);
         }
       }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -259,7 +259,6 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   peer_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
   acting_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
   upacting_features(CEPH_FEATURES_SUPPORTED_DEFAULT),
-  do_sort_bitwise(false),
   last_epoch(0)
 {
 #ifdef PG_DEBUG_REFS
@@ -5325,7 +5324,7 @@ void PG::on_new_interval()
     upacting_features &= osdmap->get_xinfo(*p).features;
   }
 
-  do_sort_bitwise = osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE);
+  assert(osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE));
 
   _on_new_interval();
 }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -354,7 +354,7 @@ void PG::proc_replica_log(
   dout(10) << " peer osd." << from << " now " << oinfo << " " << omissing << dendl;
   might_have_unfound.insert(from);
 
-  for (map<hobject_t, pg_missing_item, hobject_t::ComparatorWithDefault>::const_iterator i =
+  for (map<hobject_t, pg_missing_item>::const_iterator i =
 	 omissing.get_items().begin();
        i != omissing.get_items().end();
        ++i) {
@@ -520,7 +520,7 @@ void PG::MissingLoc::add_batch_sources_info(
   ldout(pg->cct, 10) << __func__ << ": adding sources in batch "
 		     << sources.size() << dendl;
   unsigned loop = 0;
-  for (map<hobject_t, pg_missing_item, hobject_t::ComparatorWithDefault>::const_iterator i = needs_recovery_map.begin();
+  for (map<hobject_t, pg_missing_item>::const_iterator i = needs_recovery_map.begin();
       i != needs_recovery_map.end();
       ++i) {
     if (handle && ++loop >= pg->cct->_conf->osd_loop_before_reset_tphandle) {
@@ -542,7 +542,7 @@ bool PG::MissingLoc::add_source_info(
   bool found_missing = false;
   unsigned loop = 0;
   // found items?
-  for (map<hobject_t,pg_missing_item, hobject_t::ComparatorWithDefault>::const_iterator p = needs_recovery_map.begin();
+  for (map<hobject_t,pg_missing_item>::const_iterator p = needs_recovery_map.begin();
        p != needs_recovery_map.end();
        ++p) {
     const hobject_t &soid(p->first);
@@ -2487,7 +2487,7 @@ void PG::split_backoffs(PG *child, unsigned split_bits)
 void PG::clear_backoffs()
 {
   dout(10) << __func__ << " " << dendl;
-  map<hobject_t,set<BackoffRef>,hobject_t::BitwiseComparator> ls;
+  map<hobject_t,set<BackoffRef>> ls;
   {
     Mutex::Locker l(backoff_lock);
     ls.swap(backoffs);
@@ -3517,9 +3517,9 @@ void PG::filter_snapc(vector<snapid_t> &snaps)
   }
 }
 
-void PG::requeue_object_waiters(map<hobject_t, list<OpRequestRef>, hobject_t::BitwiseComparator>& m)
+void PG::requeue_object_waiters(map<hobject_t, list<OpRequestRef>>& m)
 {
-  for (map<hobject_t, list<OpRequestRef>, hobject_t::BitwiseComparator>::iterator it = m.begin();
+  for (map<hobject_t, list<OpRequestRef>>::iterator it = m.begin();
        it != m.end();
        ++it)
     requeue_ops(it->second);
@@ -3938,7 +3938,7 @@ void PG::_scan_rollback_obs(
 
 void PG::_scan_snaps(ScrubMap &smap) 
 {
-  for (map<hobject_t, ScrubMap::object, hobject_t::BitwiseComparator>::iterator i = smap.objects.begin();
+  for (map<hobject_t, ScrubMap::object>::iterator i = smap.objects.begin();
        i != smap.objects.end();
        ++i) {
     const hobject_t &hoid = i->first;
@@ -4598,7 +4598,7 @@ void PG::scrub_compare_maps()
 
   // construct authoritative scrub map for type specific scrubbing
   scrubber.cleaned_meta_map.insert(scrubber.primary_scrubmap);
-  map<hobject_t, pair<uint32_t, uint32_t>, hobject_t::BitwiseComparator> missing_digest;
+  map<hobject_t, pair<uint32_t, uint32_t>> missing_digest;
 
   if (acting.size() > 1) {
     dout(10) << __func__ << "  comparing replica scrub maps" << dendl;
@@ -4606,7 +4606,7 @@ void PG::scrub_compare_maps()
     stringstream ss;
 
     // Map from object with errors to good peer
-    map<hobject_t, list<pg_shard_t>, hobject_t::BitwiseComparator> authoritative;
+    map<hobject_t, list<pg_shard_t>> authoritative;
     map<pg_shard_t, ScrubMap *> maps;
 
     dout(2) << __func__ << "   osd." << acting[0] << " has "
@@ -4641,7 +4641,7 @@ void PG::scrub_compare_maps()
       osd->clog->error(ss);
     }
 
-    for (map<hobject_t, list<pg_shard_t>, hobject_t::BitwiseComparator>::iterator i = authoritative.begin();
+    for (map<hobject_t, list<pg_shard_t>>::iterator i = authoritative.begin();
 	 i != authoritative.end();
 	 ++i) {
       list<pair<ScrubMap::object, pg_shard_t> > good_peers;
@@ -4656,7 +4656,7 @@ void PG::scrub_compare_maps()
 	  good_peers));
     }
 
-    for (map<hobject_t, list<pg_shard_t>, hobject_t::BitwiseComparator>::iterator i = authoritative.begin();
+    for (map<hobject_t, list<pg_shard_t>>::iterator i = authoritative.begin();
 	 i != authoritative.end();
 	 ++i) {
       scrubber.cleaned_meta_map.objects.erase(i->first);
@@ -4717,7 +4717,7 @@ bool PG::scrub_process_inconsistent()
     osd->clog->error(ss);
     if (repair) {
       state_clear(PG_STATE_CLEAN);
-      for (map<hobject_t, list<pair<ScrubMap::object, pg_shard_t> >, hobject_t::BitwiseComparator>::iterator i =
+      for (map<hobject_t, list<pair<ScrubMap::object, pg_shard_t> >>::iterator i =
 	     scrubber.authoritative.begin();
 	   i != scrubber.authoritative.end();
 	   ++i) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1701,7 +1701,7 @@ void PG::activate(ObjectStore::Transaction& t,
 
 	pi.last_update = info.last_update;
 	pi.last_complete = info.last_update;
-	pi.set_last_backfill(hobject_t(), get_sort_bitwise());
+	pi.set_last_backfill(hobject_t());
 	pi.last_epoch_started = info.last_epoch_started;
 	pi.history = info.history;
 	pi.hit_set = info.hit_set;
@@ -2262,15 +2262,14 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
   child->info.purged_snaps = info.purged_snaps;
 
   if (info.last_backfill.is_max()) {
-    child->info.set_last_backfill(hobject_t::get_max(),
-				  info.last_backfill_bitwise);
+    child->info.set_last_backfill(hobject_t::get_max());
   } else {
     // restart backfill on parent and child to be safe.  we could
     // probably do better in the bitwise sort case, but it's more
     // fragile (there may be special work to do on backfill completion
     // in the future).
-    info.set_last_backfill(hobject_t(), info.last_backfill_bitwise);
-    child->info.set_last_backfill(hobject_t(), info.last_backfill_bitwise);
+    info.set_last_backfill(hobject_t());
+    child->info.set_last_backfill(hobject_t());
   }
 
   child->info.stats = info.stats;
@@ -2921,7 +2920,7 @@ void PG::init(
 
   if (backfill) {
     dout(10) << __func__ << ": Setting backfill" << dendl;
-    info.set_last_backfill(hobject_t(), get_sort_bitwise());
+    info.set_last_backfill(hobject_t());
     info.last_complete = info.last_update;
     pg_log.mark_log_for_rewrite();
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4323,8 +4323,6 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
       case PG::Scrubber::INACTIVE:
         dout(10) << "scrub start" << dendl;
 
-	scrubber.cleaned_meta_map.reset_bitwise(get_sort_bitwise());
-
         publish_stats_to_osd();
         scrubber.epoch_start = info.history.same_interval_since;
         scrubber.active = true;
@@ -4666,7 +4664,7 @@ void PG::scrub_compare_maps()
     }
   }
 
-  ScrubMap for_meta_scrub(get_sort_bitwise());
+  ScrubMap for_meta_scrub;
   if (scrubber.end.is_max() ||
       scrubber.cleaned_meta_map.objects.empty()) {
     scrubber.cleaned_meta_map.swap(for_meta_scrub);

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1655,7 +1655,7 @@ void PG::activate(ObjectStore::Transaction& t,
        */
       bool force_restart_backfill =
 	!pi.last_backfill.is_max() &&
-	pi.last_backfill_bitwise != get_sort_bitwise();
+	!pi.last_backfill_bitwise;
 
       if (pi.last_update == info.last_update && !force_restart_backfill) {
         // empty log
@@ -5436,9 +5436,6 @@ ostream& operator<<(ostream& out, const PG& pg)
     out << " MUST_DEEP_SCRUB";
   if (pg.scrubber.must_scrub)
     out << " MUST_SCRUB";
-
-  if (!pg.get_sort_bitwise())
-    out << " NIBBLEWISE";
 
   //out << " (" << pg.pg_log.get_tail() << "," << pg.pg_log.get_head() << "]";
   if (pg.pg_log.get_missing().num_missing()) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4941,7 +4941,6 @@ void PG::merge_new_log_entries(
   for (auto &&i: entries) {
     missing_loc.rebuild(
       i.soid,
-      get_sort_bitwise(),
       pg_whoami,
       actingbackfill,
       info,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -488,7 +488,7 @@ public:
 	auto pinfoiter = pinfo.find(i.first);
 	assert(pinfoiter != pinfo.end());
 	if (item->need <= pinfoiter->second.last_update &&
-	    cmp(hoid, pinfoiter->second.last_backfill, sort_bitwise) <= 0 &&
+	    hoid <= pinfoiter->second.last_backfill &&
 	    !i.second.is_missing(hoid))
 	  mliter->second.insert(i.first);
       }
@@ -768,7 +768,7 @@ public:
     void trim_to(const hobject_t &soid) {
       trim();
       while (!objects.empty() &&
-	     cmp(objects.begin()->first, soid, sort_bitwise) <= 0) {
+	     objects.begin()->first <= soid) {
 	pop_front();
       }
     }
@@ -1209,8 +1209,8 @@ public:
     // classic (non chunk) scrubs block all writes
     // chunky scrubs only block writes to a range
     bool write_blocked_by_scrub(const hobject_t &soid, bool sort_bitwise) {
-      if (cmp(soid, start, sort_bitwise) >= 0 &&
-	  cmp(soid, end, sort_bitwise) < 0)
+      if (soid >= start &&
+	  soid < end)
 	return true;
 
       return false;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2082,7 +2082,6 @@ public:
   uint64_t acting_features;
   uint64_t upacting_features;
 
-  bool do_sort_bitwise;
   epoch_t last_epoch;
 
  public:
@@ -2096,11 +2095,6 @@ public:
 
   uint64_t get_min_acting_features() const { return acting_features; }
   uint64_t get_min_upacting_features() const { return upacting_features; }
-
-  /// true if we will sort hobjects bitwise for this pg interval
-  bool get_sort_bitwise() const {
-    return do_sort_bitwise;
-  }
 
   void init_primary_up_acting(
     const vector<int> &newup,

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -726,17 +726,12 @@ public:
     // info about a backfill interval on a peer
     eversion_t version; /// version at which the scan occurred
     map<hobject_t,eversion_t> objects;
-    bool sort_bitwise;
     hobject_t begin;
     hobject_t end;
 
-    explicit BackfillInterval(bool bitwise=true)
-      : sort_bitwise(bitwise)
-    {}
-    
     /// clear content
-    void clear(bool bitwise=true) {
-      *this = BackfillInterval(bitwise);
+    void clear() {
+      *this = BackfillInterval();
     }
 
     /// clear objects list only
@@ -745,8 +740,8 @@ public:
     }
 
     /// reinstantiate with a new start+end position and sort order
-    void reset(hobject_t start, bool bitwise) {
-      clear(bitwise);
+    void reset(hobject_t start) {
+      clear();
       begin = end = start;
     }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -427,7 +427,6 @@ public:
       pg_shard_t source,           ///< [in] source
       const pg_info_t &oinfo,      ///< [in] info
       const pg_missing_t &omissing, ///< [in] (optional) missing
-      bool sort_bitwise,            ///< [in] local sort bitwise (vs nibblewise)
       ThreadPool::TPHandle* handle  ///< [in] ThreadPool handle
       ); ///< @return whether a new object location was discovered
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1197,12 +1197,8 @@ public:
 
     // classic (non chunk) scrubs block all writes
     // chunky scrubs only block writes to a range
-    bool write_blocked_by_scrub(const hobject_t &soid, bool sort_bitwise) {
-      if (soid >= start &&
-	  soid < end)
-	return true;
-
-      return false;
+    bool write_blocked_by_scrub(const hobject_t &soid) {
+      return (soid >= start && soid < end);
     }
 
     // clear all state

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -448,7 +448,6 @@ public:
     /// Call to update structures for hoid after a change
     void rebuild(
       const hobject_t &hoid,
-      bool sort_bitwise,
       pg_shard_t self,
       const set<pg_shard_t> to_recover,
       const pg_info_t &info,

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -212,7 +212,6 @@ int PGBackend::objects_list_partial(
       ch,
       _next,
       ghobject_t::get_max(),
-      parent->sort_bitwise(),
       max - ls->size(),
       &objects,
       &_next);
@@ -249,7 +248,6 @@ int PGBackend::objects_list_range(
     ch,
     ghobject_t(start, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
     ghobject_t(end, ghobject_t::NO_GEN, get_parent()->whoami_shard().shard),
-    parent->sort_bitwise(),
     INT_MAX,
     &objects,
     NULL);

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -174,7 +174,7 @@ void PGBackend::on_change_cleanup(ObjectStore::Transaction *t)
 {
   dout(10) << __func__ << dendl;
   // clear temp
-  for (set<hobject_t, hobject_t::BitwiseComparator>::iterator i = temp_contents.begin();
+  for (set<hobject_t>::iterator i = temp_contents.begin();
        i != temp_contents.end();
        ++i) {
     dout(10) << __func__ << ": Removing oid "
@@ -624,7 +624,7 @@ map<pg_shard_t, ScrubMap *>::const_iterator
   for (map<pg_shard_t, ScrubMap *>::const_iterator j = maps.begin();
        j != maps.end();
        ++j) {
-    map<hobject_t, ScrubMap::object, hobject_t::BitwiseComparator>::iterator i =
+    map<hobject_t, ScrubMap::object>::iterator i =
       j->second->objects.find(obj);
     if (i == j->second->objects.end()) {
       continue;
@@ -715,19 +715,19 @@ out:
 void PGBackend::be_compare_scrubmaps(
   const map<pg_shard_t,ScrubMap*> &maps,
   bool repair,
-  map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &missing,
-  map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &inconsistent,
-  map<hobject_t, list<pg_shard_t>, hobject_t::BitwiseComparator> &authoritative,
-  map<hobject_t, pair<uint32_t,uint32_t>, hobject_t::BitwiseComparator> &missing_digest,
+  map<hobject_t, set<pg_shard_t>> &missing,
+  map<hobject_t, set<pg_shard_t>> &inconsistent,
+  map<hobject_t, list<pg_shard_t>> &authoritative,
+  map<hobject_t, pair<uint32_t,uint32_t>> &missing_digest,
   int &shallow_errors, int &deep_errors,
   Scrub::Store *store,
   const spg_t& pgid,
   const vector<int> &acting,
   ostream &errorstream)
 {
-  map<hobject_t,ScrubMap::object, hobject_t::BitwiseComparator>::const_iterator i;
-  map<pg_shard_t, ScrubMap *, hobject_t::BitwiseComparator>::const_iterator j;
-  set<hobject_t, hobject_t::BitwiseComparator> master_set;
+  map<hobject_t,ScrubMap::object>::const_iterator i;
+  map<pg_shard_t, ScrubMap *>::const_iterator j;
+  set<hobject_t> master_set;
   utime_t now = ceph_clock_now();
 
   // Construct master set
@@ -738,7 +738,7 @@ void PGBackend::be_compare_scrubmaps(
   }
 
   // Check maps against master set and each other
-  for (set<hobject_t, hobject_t::BitwiseComparator>::const_iterator k = master_set.begin();
+  for (set<hobject_t>::const_iterator k = master_set.begin();
        k != master_set.end();
        ++k) {
     object_info_t auth_oi;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -140,7 +140,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual std::string gen_dbg_prefix() const = 0;
 
-     virtual const map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &get_missing_loc_shards()
+     virtual const map<hobject_t, set<pg_shard_t>> &get_missing_loc_shards()
        const = 0;
 
      virtual const pg_missing_tracker_t &get_local_missing() const = 0;
@@ -369,20 +369,20 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    virtual void dump_recovery_info(Formatter *f) const = 0;
 
  private:
-   set<hobject_t, hobject_t::BitwiseComparator> temp_contents;
+   set<hobject_t> temp_contents;
  public:
    // Track contents of temp collection, clear on reset
    void add_temp_obj(const hobject_t &oid) {
      temp_contents.insert(oid);
    }
-   void add_temp_objs(const set<hobject_t, hobject_t::BitwiseComparator> &oids) {
+   void add_temp_objs(const set<hobject_t> &oids) {
      temp_contents.insert(oids.begin(), oids.end());
    }
    void clear_temp_obj(const hobject_t &oid) {
      temp_contents.erase(oid);
    }
-   void clear_temp_objs(const set<hobject_t, hobject_t::BitwiseComparator> &oids) {
-     for (set<hobject_t, hobject_t::BitwiseComparator>::const_iterator i = oids.begin();
+   void clear_temp_objs(const set<hobject_t> &oids) {
+     for (set<hobject_t>::const_iterator i = oids.begin();
 	  i != oids.end();
 	  ++i) {
        temp_contents.erase(*i);
@@ -540,10 +540,10 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
    void be_compare_scrubmaps(
      const map<pg_shard_t,ScrubMap*> &maps,
      bool repair,
-     map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &missing,
-     map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &inconsistent,
-     map<hobject_t, list<pg_shard_t>, hobject_t::BitwiseComparator> &authoritative,
-     map<hobject_t, pair<uint32_t,uint32_t>, hobject_t::BitwiseComparator> &missing_digest,
+     map<hobject_t, set<pg_shard_t>> &missing,
+     map<hobject_t, set<pg_shard_t>> &inconsistent,
+     map<hobject_t, list<pg_shard_t>> &authoritative,
+     map<hobject_t, pair<uint32_t,uint32_t>> &missing_digest,
      int &shallow_errors, int &deep_errors,
      Scrub::Store *store,
      const spg_t& pgid,

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -243,7 +243,6 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual pg_shard_t primary_shard() const = 0;
 
      virtual uint64_t min_peer_features() const = 0;
-     virtual bool sort_bitwise() const = 0;
 
      virtual hobject_t get_temp_recovery_object(eversion_t version,
 						snapid_t snap) = 0;

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -157,7 +157,7 @@ void PGLog::proc_replica_log(
     we will send the peer enough log to arrive at the same state.
   */
 
-  for (map<hobject_t, pg_missing_item, hobject_t::BitwiseComparator>::const_iterator i = omissing.get_items().begin();
+  for (map<hobject_t, pg_missing_item>::const_iterator i = omissing.get_items().begin();
        i != omissing.get_items().end();
        ++i) {
     dout(20) << " before missing " << i->first << " need " << i->second.need
@@ -285,7 +285,7 @@ void PGLog::merge_log(ObjectStore::Transaction& t,
   // The logs must overlap.
   assert(log.head >= olog.tail && olog.head >= log.tail);
 
-  for (map<hobject_t, pg_missing_item, hobject_t::BitwiseComparator>::const_iterator i = missing.get_items().begin();
+  for (map<hobject_t, pg_missing_item>::const_iterator i = missing.get_items().begin();
        i != missing.get_items().end();
        ++i) {
     dout(20) << "pg_missing_t sobject: " << i->first << dendl;

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -753,7 +753,7 @@ protected:
     ldpp_dout(dpp, 20) << __func__ << ": merging hoid " << hoid
 		       << " entries: " << entries << dendl;
 
-    if (cmp(hoid, info.last_backfill, info.last_backfill_bitwise) > 0) {
+    if (hoid > info.last_backfill) {
       ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid << " after last_backfill"
 			 << dendl;
       return;
@@ -1002,7 +1002,7 @@ public:
 	ldpp_dout(dpp, 20) << "update missing, append " << *p << dendl;
 	log->add(*p);
       }
-      if (cmp(p->soid, last_backfill, last_backfill_bitwise) <= 0 &&
+      if (p->soid <= last_backfill &&
 	  !p->is_error()) {
 	missing.add_next_event(*p);
 	if (rollbacker) {
@@ -1192,7 +1192,7 @@ public:
 	     i != log.log.rend();
 	     ++i) {
 	  if (!debug_verify_stored_missing && i->version <= info.last_complete) break;
-	  if (cmp(i->soid, info.last_backfill, info.last_backfill_bitwise) > 0)
+	  if (i->soid > info.last_backfill)
 	    continue;
 	  if (i->is_error())
 	    continue;
@@ -1240,7 +1240,7 @@ public:
 	    if (checked.count(i.first))
 	      continue;
 	    if (i.second.need > log.tail ||
-	      cmp(i.first, info.last_backfill, info.last_backfill_bitwise) > 0) {
+	      i.first > info.last_backfill) {
 	      lderr(dpp->get_cct()) << __func__ << ": invalid missing set entry found "
 				    << i.first
 				    << dendl;
@@ -1266,7 +1266,7 @@ public:
 	       i != divergent_priors.rend();
 	       ++i) {
 	    if (i->first <= info.last_complete) break;
-	    if (cmp(i->second, info.last_backfill, info.last_backfill_bitwise) > 0)
+	    if (i->second > info.last_backfill)
 	      continue;
 	    if (did.count(i->second)) continue;
 	    did.insert(i->second);

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -573,10 +573,6 @@ public:
   //////////////////// get or set missing ////////////////////
 
   const pg_missing_tracker_t& get_missing() const { return missing; }
-  void resort_missing(bool sort_bitwise) {
-    missing.resort(sort_bitwise);
-  }
-
   void revise_have(hobject_t oid, eversion_t have) {
     missing.revise_have(oid, have);
   }
@@ -712,7 +708,7 @@ public:
 protected:
   static void split_by_object(
     mempool::osd::list<pg_log_entry_t> &entries,
-    map<hobject_t, mempool::osd::list<pg_log_entry_t>, hobject_t::BitwiseComparator> *out_entries) {
+    map<hobject_t, mempool::osd::list<pg_log_entry_t>> *out_entries) {
     while (!entries.empty()) {
       mempool::osd::list<pg_log_entry_t> &out_list = (*out_entries)[entries.front().soid];
       out_list.splice(out_list.end(), entries, entries.begin());
@@ -932,9 +928,9 @@ protected:
     LogEntryHandler *rollbacker,         ///< [in] optional rollbacker object
     const DoutPrefixProvider *dpp        ///< [in] logging provider
     ) {
-    map<hobject_t, mempool::osd::list<pg_log_entry_t>, hobject_t::BitwiseComparator > split;
+    map<hobject_t, mempool::osd::list<pg_log_entry_t> > split;
     split_by_object(entries, &split);
-    for (map<hobject_t, mempool::osd::list<pg_log_entry_t>, hobject_t::BitwiseComparator>::iterator i = split.begin();
+    for (map<hobject_t, mempool::osd::list<pg_log_entry_t>>::iterator i = split.begin();
 	 i != split.end();
 	 ++i) {
       _merge_object_divergent_entries(
@@ -1185,9 +1181,9 @@ public:
 			   << info.last_complete
 			   << "," << info.last_update << "]" << dendl;
 
-	set<hobject_t, hobject_t::BitwiseComparator> did;
-	set<hobject_t, hobject_t::BitwiseComparator> checked;
-	set<hobject_t, hobject_t::BitwiseComparator> skipped;
+	set<hobject_t> did;
+	set<hobject_t> checked;
+	set<hobject_t> skipped;
 	for (list<pg_log_entry_t>::reverse_iterator i = log.log.rbegin();
 	     i != log.log.rend();
 	     ++i) {

--- a/src/osd/PGTransaction.h
+++ b/src/osd/PGTransaction.h
@@ -36,7 +36,7 @@
  */
 class PGTransaction {
 public:
-  map<hobject_t, ObjectContextRef, hobject_t::BitwiseComparator> obc_map;
+  map<hobject_t, ObjectContextRef> obc_map;
 
   class ObjectOperation {
   public:
@@ -245,7 +245,7 @@ public:
 
     friend class PGTransaction;
   };
-  map<hobject_t, ObjectOperation, hobject_t::BitwiseComparator> op_map;
+  map<hobject_t, ObjectOperation> op_map;
 private:
   ObjectOperation &get_object_op_for_modify(const hobject_t &hoid) {
     auto &op = op_map[hoid];
@@ -523,7 +523,7 @@ public:
    */
   template <typename T>
   void safe_create_traverse(T &&t) {
-    map<hobject_t, list<hobject_t>, hobject_t::BitwiseComparator> dgraph;
+    map<hobject_t, list<hobject_t>> dgraph;
     list<hobject_t> stack;
 
     // Populate stack with roots, dgraph with edges

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3467,7 +3467,7 @@ void PrimaryLogPG::do_backfill(OpRequestRef op)
     {
       assert(cct->_conf->osd_kill_backfill_at != 2);
 
-      info.set_last_backfill(m->last_backfill, get_sort_bitwise());
+      info.set_last_backfill(m->last_backfill);
       if (m->compat_stat_sum) {
 	info.stats.stats = m->stats.stats; // Previously, we only sent sum
       } else {
@@ -9986,7 +9986,7 @@ void PrimaryLogPG::on_removal(ObjectStore::Transaction *t)
   dout(10) << "on_removal" << dendl;
 
   // adjust info to backfill
-  info.set_last_backfill(hobject_t(), true);
+  info.set_last_backfill(hobject_t());
   pg_log.reset_backfill();
   dirty_info = true;
 
@@ -11216,7 +11216,7 @@ uint64_t PrimaryLogPG::recover_backfill(
     pg_info_t& pinfo = peer_info[bt];
 
     if (new_last_backfill > pinfo.last_backfill) {
-      pinfo.set_last_backfill(new_last_backfill, get_sort_bitwise());
+      pinfo.set_last_backfill(new_last_backfill);
       epoch_t e = get_osdmap()->get_epoch();
       MOSDPGBackfill *m = NULL;
       if (pinfo.last_backfill.is_max()) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10882,27 +10882,16 @@ uint64_t PrimaryLogPG::recover_backfill(
     assert(last_backfill_started == earliest_backfill());
     new_backfill = false;
 
-    // initialize BackfillIntervals (with proper sort order)
+    // initialize BackfillIntervals
     for (set<pg_shard_t>::iterator i = backfill_targets.begin();
 	 i != backfill_targets.end();
 	 ++i) {
-      peer_backfill_info[*i].reset(peer_info[*i].last_backfill,
-				   get_sort_bitwise());
+      peer_backfill_info[*i].reset(peer_info[*i].last_backfill);
     }
-    backfill_info.reset(last_backfill_started,
-			get_sort_bitwise());
+    backfill_info.reset(last_backfill_started);
 
     backfills_in_flight.clear();
     pending_backfill_updates.clear();
-  }
-
-  // sanity check sort orders
-  assert(backfill_info.sort_bitwise == get_sort_bitwise());
-  for (map<pg_shard_t, BackfillInterval>::iterator i =
-	 peer_backfill_info.begin();
-       i != peer_backfill_info.end();
-       ++i) {
-    assert(i->second.sort_bitwise == get_sort_bitwise());
   }
 
   for (set<pg_shard_t>::iterator i = backfill_targets.begin();
@@ -10938,7 +10927,7 @@ uint64_t PrimaryLogPG::recover_backfill(
     if (backfill_info.begin <= earliest_peer_backfill() &&
 	!backfill_info.extends_to_end() && backfill_info.empty()) {
       hobject_t next = backfill_info.end;
-      backfill_info.reset(next, get_sort_bitwise());
+      backfill_info.reset(next);
       backfill_info.end = hobject_t::get_max();
       update_range(&backfill_info, handle);
       backfill_info.trim();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1235,15 +1235,9 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	    ls_iter == sentries.end()) {
 	  result = 1;
 
-	  if (get_osdmap()->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
-	    // Set response.handle to the start of the next PG
-	    // according to the object sort order.  Only do this if
-	    // the cluster is in bitwise mode; with legacy nibblewise
-	    // sort PGs don't always cover contiguous ranges of the
-	    // hash order.
-	    response.handle = info.pgid.pgid.get_hobj_end(
-	      pool.info.get_pg_num());
-	  }
+	  // Set response.handle to the start of the next PG according
+	  // to the object sort order.
+	  response.handle = info.pgid.pgid.get_hobj_end(pool.info.get_pg_num());
 	} else {
           response.handle = next;
         }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1964,7 +1964,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   }
 
   if (write_ordered &&
-      scrubber.write_blocked_by_scrub(head, get_sort_bitwise())) {
+      scrubber.write_blocked_by_scrub(head)) {
     dout(20) << __func__ << ": waiting for scrub" << dendl;
     waiting_for_scrub.push_back(op);
     op->mark_delayed("waiting for scrub");
@@ -2972,7 +2972,7 @@ void PrimaryLogPG::promote_object(ObjectContextRef obc,
 {
   hobject_t hoid = obc ? obc->obs.oi.soid : missing_oid;
   assert(hoid != hobject_t());
-  if (scrubber.write_blocked_by_scrub(hoid, get_sort_bitwise())) {
+  if (scrubber.write_blocked_by_scrub(hoid)) {
     dout(10) << __func__ << " " << hoid
 	     << " blocked by scrub" << dendl;
     if (op) {
@@ -8174,7 +8174,7 @@ int PrimaryLogPG::try_flush_mark_clean(FlushOpRef fop)
   }
 
   if (!fop->blocking &&
-      scrubber.write_blocked_by_scrub(oid, get_sort_bitwise())) {
+      scrubber.write_blocked_by_scrub(oid)) {
     if (fop->op) {
       dout(10) << __func__ << " blocked by scrub" << dendl;
       requeue_op(fop->op);
@@ -8889,7 +8889,7 @@ void PrimaryLogPG::handle_watch_timeout(WatchRef watch)
     return;
   }
 
-  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid, get_sort_bitwise())) {
+  if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
     dout(10) << "handle_watch_timeout waiting for scrub on obj "
 	     << obc->obs.oi.soid
 	     << dendl;
@@ -11529,7 +11529,7 @@ void PrimaryLogPG::hit_set_remove_all()
     // Once we hit a degraded object just skip
     if (is_degraded_or_backfilling_object(aoid))
       return;
-    if (scrubber.write_blocked_by_scrub(aoid, get_sort_bitwise()))
+    if (scrubber.write_blocked_by_scrub(aoid))
       return;
   }
 
@@ -11648,7 +11648,7 @@ void PrimaryLogPG::hit_set_persist()
     // Once we hit a degraded object just skip further trim
     if (is_degraded_or_backfilling_object(aoid))
       return;
-    if (scrubber.write_blocked_by_scrub(aoid, get_sort_bitwise()))
+    if (scrubber.write_blocked_by_scrub(aoid))
       return;
   }
 
@@ -11682,7 +11682,7 @@ void PrimaryLogPG::hit_set_persist()
     new_hset.using_gmt);
 
   // If the current object is degraded we skip this persist request
-  if (scrubber.write_blocked_by_scrub(oid, get_sort_bitwise()))
+  if (scrubber.write_blocked_by_scrub(oid))
     return;
 
   hit_set->seal();
@@ -11926,7 +11926,7 @@ bool PrimaryLogPG::agent_work(int start_max, int agent_flush_quota)
       osd->logger->inc(l_osd_agent_skip);
       continue;
     }
-    if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid, get_sort_bitwise())) {
+    if (scrubber.write_blocked_by_scrub(obc->obs.oi.soid)) {
       dout(20) << __func__ << " skip (scrubbing) " << obc->obs.oi << dendl;
       osd->logger->inc(l_osd_agent_skip);
       continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1108,8 +1108,7 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	hobject_t pg_end = info.pgid.pgid.get_hobj_end(pool.info.get_pg_num());
         dout(10) << " pgnls lower_bound " << lower_bound
 		 << " pg_end " << pg_end << dendl;
-	if (get_sort_bitwise() &&
-	    ((!lower_bound.is_max() && lower_bound >= pg_end) ||
+	if (((!lower_bound.is_max() && lower_bound >= pg_end) ||
 	     (lower_bound != hobject_t() && lower_bound < pg_start))) {
 	  // this should only happen with a buggy client.
 	  dout(10) << "outside of PG bounds " << pg_start << " .. "
@@ -10871,7 +10870,6 @@ uint64_t PrimaryLogPG::recover_backfill(
   dout(10) << "recover_backfill (" << max << ")"
            << " bft=" << backfill_targets
 	   << " last_backfill_started " << last_backfill_started
-	   << " sort " << (get_sort_bitwise() ? "bitwise" : "nibblewise")
 	   << (new_backfill ? " new_backfill":"")
 	   << dendl;
   assert(!backfill_targets.empty());

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -305,7 +305,7 @@ public:
 
   std::string gen_dbg_prefix() const override { return gen_prefix(); }
   
-  const map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator>
+  const map<hobject_t, set<pg_shard_t>>
     &get_missing_loc_shards() const override {
     return missing_loc.get_missing_locs();
   }
@@ -937,13 +937,13 @@ protected:
   bool already_ack(eversion_t v);
 
   // projected object info
-  SharedLRU<hobject_t, ObjectContext, hobject_t::ComparatorWithDefault> object_contexts;
+  SharedLRU<hobject_t, ObjectContext> object_contexts;
   // map from oid.snapdir() to SnapSetContext *
-  map<hobject_t, SnapSetContext*, hobject_t::BitwiseComparator> snapset_contexts;
+  map<hobject_t, SnapSetContext*> snapset_contexts;
   Mutex snapset_contexts_lock;
 
   // debug order that client ops are applied
-  map<hobject_t, map<client_t, ceph_tid_t>, hobject_t::BitwiseComparator> debug_op_order;
+  map<hobject_t, map<client_t, ceph_tid_t>> debug_op_order;
 
   void populate_obc_watchers(ObjectContextRef obc);
   void check_blacklisted_obc_watchers(ObjectContextRef obc);
@@ -995,7 +995,7 @@ protected:
   }
   void put_snapset_context(SnapSetContext *ssc);
 
-  map<hobject_t, ObjectContextRef, hobject_t::BitwiseComparator> recovering;
+  map<hobject_t, ObjectContextRef> recovering;
 
   /*
    * Backfill
@@ -1011,8 +1011,8 @@ protected:
    *   - are not included in pg stats (yet)
    *   - have their stats in pending_backfill_updates on the primary
    */
-  set<hobject_t, hobject_t::Comparator> backfills_in_flight;
-  map<hobject_t, pg_stat_t, hobject_t::Comparator> pending_backfill_updates;
+  set<hobject_t> backfills_in_flight;
+  map<hobject_t, pg_stat_t> pending_backfill_updates;
 
   void dump_recovery_info(Formatter *f) const override {
     f->open_array_section("backfill_targets");
@@ -1045,7 +1045,7 @@ protected:
     }
     {
       f->open_array_section("backfills_in_flight");
-      for (set<hobject_t, hobject_t::BitwiseComparator>::const_iterator i = backfills_in_flight.begin();
+      for (set<hobject_t>::const_iterator i = backfills_in_flight.begin();
 	   i != backfills_in_flight.end();
 	   ++i) {
 	f->dump_stream("object") << *i;
@@ -1054,7 +1054,7 @@ protected:
     }
     {
       f->open_array_section("recovering");
-      for (map<hobject_t, ObjectContextRef, hobject_t::BitwiseComparator>::const_iterator i = recovering.begin();
+      for (map<hobject_t, ObjectContextRef>::const_iterator i = recovering.begin();
 	   i != recovering.end();
 	   ++i) {
 	f->dump_stream("object") << i->first;
@@ -1233,7 +1233,7 @@ protected:
   void recover_got(hobject_t oid, eversion_t v);
 
   // -- copyfrom --
-  map<hobject_t, CopyOpRef, hobject_t::BitwiseComparator> copy_ops;
+  map<hobject_t, CopyOpRef> copy_ops;
 
   int fill_in_copy_get(
     OpContext *ctx,
@@ -1278,7 +1278,7 @@ protected:
   friend struct C_Copyfrom;
 
   // -- flush --
-  map<hobject_t, FlushOpRef, hobject_t::BitwiseComparator> flush_ops;
+  map<hobject_t, FlushOpRef> flush_ops;
 
   /// start_flush takes ownership of on_flush iff ret == -EINPROGRESS
   int start_flush(
@@ -1300,8 +1300,7 @@ protected:
     const hobject_t &begin, const hobject_t &end) override;
   virtual void scrub_snapshot_metadata(
     ScrubMap &map,
-    const std::map<hobject_t, pair<uint32_t, uint32_t>,
-    hobject_t::BitwiseComparator> &missing_digest) override;
+    const std::map<hobject_t, pair<uint32_t, uint32_t>> &missing_digest) override;
   virtual void _scrub_clear_state() override;
   virtual void _scrub_finish() override;
   object_stat_collection_t scrub_cstat;
@@ -1319,7 +1318,7 @@ protected:
   bool pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& outdata);
   int get_pgls_filter(bufferlist::iterator& iter, PGLSFilter **pfilter);
 
-  map<hobject_t, list<OpRequestRef>, hobject_t::BitwiseComparator> in_progress_proxy_ops;
+  map<hobject_t, list<OpRequestRef>> in_progress_proxy_ops;
   void kick_proxy_ops_blocked(hobject_t& soid);
   void cancel_proxy_ops(bool requeue);
 
@@ -1456,7 +1455,7 @@ private:
   };
   struct SnapTrimmer : public boost::statechart::state_machine< SnapTrimmer, NotTrimming > {
     PrimaryLogPG *pg;
-    set<hobject_t, hobject_t::BitwiseComparator> in_flight;
+    set<hobject_t> in_flight;
     snapid_t snap_to_trim;
     explicit SnapTrimmer(PrimaryLogPG *pg) : pg(pg) {}
     ~SnapTrimmer();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -821,9 +821,7 @@ protected:
     if (!to_req.empty()) {
       // requeue at front of scrub blocking queue if we are blocked by scrub
       for (auto &&p: to_req) {
-	if (scrubber.write_blocked_by_scrub(
-	      p.first.get_head(),
-	      get_sort_bitwise())) {
+	if (scrubber.write_blocked_by_scrub(p.first.get_head())) {
 	  waiting_for_scrub.splice(
 	    waiting_for_scrub.begin(),
 	    p.second,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -433,9 +433,6 @@ public:
   uint64_t min_peer_features() const override {
     return get_min_peer_features();
   }
-  bool sort_bitwise() const override {
-    return get_sort_bitwise();
-  }
 
   void send_message_osd_cluster(
     int peer, Message *m, epoch_t from_epoch) override;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -395,8 +395,8 @@ public:
     assert(peer_info.count(peer));
     bool should_send =
       hoid.pool != (int64_t)info.pgid.pool() ||
-      cmp(hoid, last_backfill_started, get_sort_bitwise()) <= 0 ||
-      cmp(hoid, peer_info[peer].last_backfill, get_sort_bitwise()) <= 0;
+      hoid <= last_backfill_started ||
+      hoid <= peer_info[peer].last_backfill;
     if (!should_send)
       assert(is_backfill_targets(peer));
     return should_send;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1292,7 +1292,7 @@ void ReplicatedBackend::calc_head_subsets(
     c.snap = snapset.clones[j];
     prev.intersection_of(snapset.clone_overlap[snapset.clones[j]]);
     if (!missing.is_missing(c) &&
-	cmp(c, last_backfill, get_parent()->sort_bitwise()) < 0 &&
+	c < last_backfill &&
 	get_parent()->try_lock_for_read(c, manager)) {
       dout(10) << "calc_head_subsets " << head << " has prev " << c
 	       << " overlap " << prev << dendl;
@@ -1360,7 +1360,7 @@ void ReplicatedBackend::calc_clone_subsets(
     c.snap = snapset.clones[j];
     prev.intersection_of(snapset.clone_overlap[snapset.clones[j]]);
     if (!missing.is_missing(c) &&
-	cmp(c, last_backfill, get_parent()->sort_bitwise()) < 0 &&
+	c < last_backfill &&
 	get_parent()->try_lock_for_read(c, manager)) {
       dout(10) << "calc_clone_subsets " << soid << " has prev " << c
 	       << " overlap " << prev << dendl;
@@ -1381,7 +1381,7 @@ void ReplicatedBackend::calc_clone_subsets(
     c.snap = snapset.clones[j];
     next.intersection_of(snapset.clone_overlap[snapset.clones[j-1]]);
     if (!missing.is_missing(c) &&
-	cmp(c, last_backfill, get_parent()->sort_bitwise()) < 0 &&
+	c < last_backfill &&
 	get_parent()->try_lock_for_read(c, manager)) {
       dout(10) << "calc_clone_subsets " << soid << " has next " << c
 	       << " overlap " << next << dendl;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -158,13 +158,13 @@ void ReplicatedBackend::recover_object(
 
 void ReplicatedBackend::check_recovery_sources(const OSDMapRef& osdmap)
 {
-  for(map<pg_shard_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator i = pull_from_peer.begin();
+  for(map<pg_shard_t, set<hobject_t> >::iterator i = pull_from_peer.begin();
       i != pull_from_peer.end();
       ) {
     if (osdmap->is_down(i->first.osd)) {
       dout(10) << "check_recovery_sources resetting pulls from osd." << i->first
 	       << ", osdmap has it marked down" << dendl;
-      for (set<hobject_t, hobject_t::BitwiseComparator>::iterator j = i->second.begin();
+      for (set<hobject_t>::iterator j = i->second.begin();
 	   j != i->second.end();
 	   ++j) {
 	get_parent()->cancel_pull(*j);
@@ -388,8 +388,8 @@ void generate_transaction(
   bool legacy_log_entries,
   vector<pg_log_entry_t> &log_entries,
   ObjectStore::Transaction *t,
-  set<hobject_t, hobject_t::BitwiseComparator> *added,
-  set<hobject_t, hobject_t::BitwiseComparator> *removed)
+  set<hobject_t> *added,
+  set<hobject_t> *removed)
 {
   assert(t);
   assert(added);
@@ -551,7 +551,7 @@ void ReplicatedBackend::submit_transaction(
   vector<pg_log_entry_t> log_entries(_log_entries);
   ObjectStore::Transaction op_t;
   PGTransactionUPtr t(std::move(_t));
-  set<hobject_t, hobject_t::BitwiseComparator> added, removed;
+  set<hobject_t> added, removed;
   generate_transaction(
     t,
     coll,
@@ -1261,7 +1261,7 @@ void ReplicatedBackend::calc_head_subsets(
   const pg_missing_t& missing,
   const hobject_t &last_backfill,
   interval_set<uint64_t>& data_subset,
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+  map<hobject_t, interval_set<uint64_t>>& clone_subsets,
   ObcLockManager &manager)
 {
   dout(10) << "calc_head_subsets " << head
@@ -1325,7 +1325,7 @@ void ReplicatedBackend::calc_clone_subsets(
   const pg_missing_t& missing,
   const hobject_t &last_backfill,
   interval_set<uint64_t>& data_subset,
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+  map<hobject_t, interval_set<uint64_t>>& clone_subsets,
   ObcLockManager &manager)
 {
   dout(10) << "calc_clone_subsets " << soid
@@ -1419,11 +1419,11 @@ void ReplicatedBackend::prepare_pull(
   eversion_t _v = get_parent()->get_local_missing().get_items().find(
     soid)->second.need;
   assert(_v == v);
-  const map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator> &missing_loc(
+  const map<hobject_t, set<pg_shard_t>> &missing_loc(
     get_parent()->get_missing_loc_shards());
   const map<pg_shard_t, pg_missing_t > &peer_missing(
     get_parent()->get_shard_missing());
-  map<hobject_t, set<pg_shard_t>, hobject_t::BitwiseComparator>::const_iterator q = missing_loc.find(soid);
+  map<hobject_t, set<pg_shard_t>>::const_iterator q = missing_loc.find(soid);
   assert(q != missing_loc.end());
   assert(!q->second.empty());
 
@@ -1525,7 +1525,7 @@ void ReplicatedBackend::prep_push_to_replica(
   dout(10) << __func__ << ": " << soid << " v" << oi.version
 	   << " size " << size << " to osd." << peer << dendl;
 
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator> clone_subsets;
+  map<hobject_t, interval_set<uint64_t>> clone_subsets;
   interval_set<uint64_t> data_subset;
 
   ObcLockManager lock_manager;
@@ -1596,7 +1596,7 @@ void ReplicatedBackend::prep_push(ObjectContextRef obc,
   interval_set<uint64_t> data_subset;
   if (obc->obs.oi.size)
     data_subset.insert(0, obc->obs.oi.size);
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator> clone_subsets;
+  map<hobject_t, interval_set<uint64_t>> clone_subsets;
 
   prep_push(obc, soid, peer,
 	    obc->obs.oi.version, data_subset, clone_subsets,
@@ -1608,7 +1608,7 @@ void ReplicatedBackend::prep_push(
   const hobject_t& soid, pg_shard_t peer,
   eversion_t version,
   interval_set<uint64_t> &data_subset,
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+  map<hobject_t, interval_set<uint64_t>>& clone_subsets,
   PushOp *pop,
   bool cache_dont_need,
   ObcLockManager &&lock_manager)
@@ -1749,7 +1749,7 @@ void ReplicatedBackend::submit_push_data(
 void ReplicatedBackend::submit_push_complete(ObjectRecoveryInfo &recovery_info,
 					     ObjectStore::Transaction *t)
 {
-  for (map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>::const_iterator p =
+  for (map<hobject_t, interval_set<uint64_t>>::const_iterator p =
 	 recovery_info.clone_subset.begin();
        p != recovery_info.clone_subset.end();
        ++p) {
@@ -2414,7 +2414,7 @@ void ReplicatedBackend::_failed_push(pg_shard_t from, const hobject_t &soid)
 }
 
 void ReplicatedBackend::clear_pull(
-  map<hobject_t, PullInfo, hobject_t::BitwiseComparator>::iterator piter,
+  map<hobject_t, PullInfo>::iterator piter,
   bool clear_pull_from_peer)
 {
   auto from = piter->second.from;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -95,14 +95,14 @@ public:
   virtual void dump_recovery_info(Formatter *f) const {
     {
       f->open_array_section("pull_from_peer");
-      for (map<pg_shard_t, set<hobject_t, hobject_t::BitwiseComparator> >::const_iterator i = pull_from_peer.begin();
+      for (map<pg_shard_t, set<hobject_t> >::const_iterator i = pull_from_peer.begin();
 	   i != pull_from_peer.end();
 	   ++i) {
 	f->open_object_section("pulling_from");
 	f->dump_stream("pull_from") << i->first;
 	{
 	  f->open_array_section("pulls");
-	  for (set<hobject_t, hobject_t::BitwiseComparator>::const_iterator j = i->second.begin();
+	  for (set<hobject_t>::const_iterator j = i->second.begin();
 	       j != i->second.end();
 	       ++j) {
 	    f->open_object_section("pull_info");
@@ -118,7 +118,7 @@ public:
     }
     {
       f->open_array_section("pushing");
-      for (map<hobject_t, map<pg_shard_t, PushInfo>, hobject_t::BitwiseComparator>::const_iterator i =
+      for (map<hobject_t, map<pg_shard_t, PushInfo>>::const_iterator i =
 	     pushing.begin();
 	   i != pushing.end();
 	   ++i) {
@@ -182,7 +182,7 @@ private:
       }
     }
   };
-  map<hobject_t, map<pg_shard_t, PushInfo>, hobject_t::BitwiseComparator> pushing;
+  map<hobject_t, map<pg_shard_t, PushInfo>> pushing;
 
   // pull
   struct PullInfo {
@@ -214,12 +214,12 @@ private:
     }
   };
 
-  map<hobject_t, PullInfo, hobject_t::BitwiseComparator> pulling;
+  map<hobject_t, PullInfo> pulling;
 
   // Reverse mapping from osd peer to objects beging pulled from that peer
-  map<pg_shard_t, set<hobject_t, hobject_t::BitwiseComparator> > pull_from_peer;
+  map<pg_shard_t, set<hobject_t> > pull_from_peer;
   void clear_pull(
-    map<hobject_t, PullInfo, hobject_t::BitwiseComparator>::iterator piter,
+    map<hobject_t, PullInfo>::iterator piter,
     bool clear_pull_from_peer = true);
 
   void sub_op_push(OpRequestRef op);
@@ -294,7 +294,7 @@ private:
     SnapSet& snapset, const hobject_t& poid, const pg_missing_t& missing,
     const hobject_t &last_backfill,
     interval_set<uint64_t>& data_subset,
-    map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+    map<hobject_t, interval_set<uint64_t>>& clone_subsets,
     ObcLockManager &lock_manager);
   void prepare_pull(
     eversion_t v,
@@ -318,7 +318,7 @@ private:
     const hobject_t& soid, pg_shard_t peer,
     eversion_t version,
     interval_set<uint64_t> &data_subset,
-    map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+    map<hobject_t, interval_set<uint64_t>>& clone_subsets,
     PushOp *op,
     bool cache,
     ObcLockManager &&lock_manager);
@@ -327,7 +327,7 @@ private:
     const pg_missing_t& missing,
     const hobject_t &last_backfill,
     interval_set<uint64_t>& data_subset,
-    map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>& clone_subsets,
+    map<hobject_t, interval_set<uint64_t>>& clone_subsets,
     ObcLockManager &lock_manager);
   ObjectRecoveryInfo recalc_subsets(
     const ObjectRecoveryInfo& recovery_info,

--- a/src/osd/Session.cc
+++ b/src/osd/Session.cc
@@ -47,8 +47,8 @@ void Session::ack_backoff(
   auto p = backoffs.lower_bound(begin);
   while (p != backoffs.end()) {
     // note: must still examine begin=end=p->first case
-    int r = cmp_bitwise(p->first, end);
-    if (r > 0 || (r == 0 && cmp_bitwise(begin, end) < 0)) {
+    int r = cmp(p->first, end);
+    if (r > 0 || (r == 0 && begin < end)) {
       break;
     }
     auto q = p->second.begin();

--- a/src/osd/Session.cc
+++ b/src/osd/Session.cc
@@ -11,7 +11,7 @@
 
 void Session::clear_backoffs()
 {
-  map<hobject_t,set<BackoffRef>,hobject_t::BitwiseComparator> ls;
+  map<hobject_t,set<BackoffRef>> ls;
   {
     Mutex::Locker l(backoff_lock);
     ls.swap(backoffs);

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -169,14 +169,14 @@ struct Session : public RefCountedObject {
       assert(backoff_count == (int)backoffs.size());
       auto p = backoffs.lower_bound(oid);
       if (p != backoffs.begin() &&
-	  cmp_bitwise(p->first, oid) > 0) {
+	  p->first > oid) {
 	--p;
       }
       if (p != backoffs.end()) {
-	int r = cmp_bitwise(oid, p->first);
+	int r = cmp(oid, p->first);
 	if (r == 0 || r > 0) {
 	  for (auto& q : p->second) {
-	    if (r == 0 || cmp_bitwise(oid, q->end) < 0) {
+	    if (r == 0 || oid < q->end) {
 	      return &(*q);
 	    }
 	  }

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -139,7 +139,7 @@ struct Session : public RefCountedObject {
   /// protects backoffs; orders inside Backoff::lock *and* PG::backoff_lock
   Mutex backoff_lock;
   std::atomic_int backoff_count= {0};  ///< simple count of backoffs
-  map<hobject_t,set<BackoffRef>, hobject_t::BitwiseComparator> backoffs;
+  map<hobject_t,set<BackoffRef>> backoffs;
 
   std::atomic<uint64_t> backoff_seq = {0};
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4853,9 +4853,9 @@ void ObjectRecoveryInfo::decode(bufferlist::iterator &bl,
   if (struct_v < 2) {
     if (!soid.is_max() && soid.pool == -1)
       soid.pool = pool;
-    map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator> tmp;
+    map<hobject_t, interval_set<uint64_t>> tmp;
     tmp.swap(clone_subset);
-    for (map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator>::iterator i = tmp.begin();
+    for (map<hobject_t, interval_set<uint64_t>>::iterator i = tmp.begin();
 	 i != tmp.end();
 	 ++i) {
       hobject_t first(i->first);
@@ -5134,11 +5134,11 @@ void ScrubMap::merge_incr(const ScrubMap &l)
   assert(valid_through == l.incr_since);
   valid_through = l.valid_through;
 
-  for (map<hobject_t,object, hobject_t::BitwiseComparator>::const_iterator p = l.objects.begin();
+  for (map<hobject_t,object>::const_iterator p = l.objects.begin();
        p != l.objects.end();
        ++p){
     if (p->second.negative) {
-      map<hobject_t,object, hobject_t::BitwiseComparator>::iterator q = objects.find(p->first);
+      map<hobject_t,object>::iterator q = objects.find(p->first);
       if (q != objects.end()) {
 	objects.erase(q);
       }
@@ -5176,9 +5176,9 @@ void ScrubMap::decode(bufferlist::iterator& bl, int64_t pool)
 
   // handle hobject_t upgrade
   if (struct_v < 3) {
-    map<hobject_t, object, hobject_t::ComparatorWithDefault> tmp;
+    map<hobject_t, object> tmp;
     tmp.swap(objects);
-    for (map<hobject_t, object, hobject_t::ComparatorWithDefault>::iterator i = tmp.begin();
+    for (map<hobject_t, object>::iterator i = tmp.begin();
 	 i != tmp.end();
 	 ++i) {
       hobject_t first(i->first);
@@ -5194,7 +5194,7 @@ void ScrubMap::dump(Formatter *f) const
   f->dump_stream("valid_through") << valid_through;
   f->dump_stream("incremental_since") << incr_since;
   f->open_array_section("objects");
-  for (map<hobject_t,object, hobject_t::ComparatorWithDefault>::const_iterator p = objects.begin(); p != objects.end(); ++p) {
+  for (map<hobject_t,object>::const_iterator p = objects.begin(); p != objects.end(); ++p) {
     f->open_object_section("object");
     f->dump_string("name", p->first.oid.name);
     f->dump_unsigned("hash", p->first.get_hash());

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4735,14 +4735,9 @@ struct ScrubMap {
   };
   WRITE_CLASS_ENCODER(object)
 
-  bool bitwise; // ephemeral, not encoded
   map<hobject_t,object> objects;
   eversion_t valid_through;
   eversion_t incr_since;
-
-  ScrubMap() : bitwise(true) {}
-  ScrubMap(bool bitwise)
-    : bitwise(bitwise) {}
 
   void merge_incr(const ScrubMap &l);
   void insert(const ScrubMap &r) {
@@ -4757,15 +4752,6 @@ struct ScrubMap {
   void encode(bufferlist& bl) const;
   void decode(bufferlist::iterator& bl, int64_t pool=-1);
   void dump(Formatter *f) const;
-  void reset_bitwise(bool new_bitwise) {
-    if (bitwise == new_bitwise)
-      return;
-    map<hobject_t, object> new_objects(
-      objects.begin(),
-      objects.end());
-    ::swap(new_objects, objects);
-    bitwise = new_bitwise;
-  }
   static void generate_test_instances(list<ScrubMap*>& o);
 };
 WRITE_CLASS_ENCODER(ScrubMap::object)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2210,9 +2210,9 @@ struct pg_info_t {
       last_backfill_bitwise(false)
   { }
   
-  void set_last_backfill(hobject_t pos, bool sort) {
+  void set_last_backfill(hobject_t pos) {
     last_backfill = pos;
-    last_backfill_bitwise = sort;
+    last_backfill_bitwise = true;
   }
 
   bool is_empty() const { return last_update.version == 0; }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3120,7 +3120,7 @@ ostream& operator<<(ostream& out, const pg_missing_item &item);
 
 class pg_missing_const_i {
 public:
-  virtual const map<hobject_t, pg_missing_item, hobject_t::ComparatorWithDefault> &
+  virtual const map<hobject_t, pg_missing_item> &
     get_items() const = 0;
   virtual const map<version_t, hobject_t> &get_rmissing() const = 0;
   virtual unsigned int num_missing() const = 0;
@@ -3145,7 +3145,7 @@ public:
 };
 template <>
 class ChangeTracker<true> {
-  set<hobject_t, hobject_t::BitwiseComparator> _changed;
+  set<hobject_t> _changed;
 public:
   void changed(const hobject_t &obj) {
     _changed.insert(obj);
@@ -3167,7 +3167,7 @@ public:
 template <bool TrackChanges>
 class pg_missing_set : public pg_missing_const_i {
   using item = pg_missing_item;
-  map<hobject_t, item, hobject_t::ComparatorWithDefault> missing;  // oid -> (need v, have v)
+  map<hobject_t, item> missing;  // oid -> (need v, have v)
   map<version_t, hobject_t> rmissing;  // v -> oid
   ChangeTracker<TrackChanges> tracker;
 
@@ -3184,7 +3184,7 @@ public:
       tracker.changed(i.first);
   }
 
-  const map<hobject_t, item, hobject_t::ComparatorWithDefault> &get_items() const override {
+  const map<hobject_t, item> &get_items() const override {
     return missing;
   }
   const map<version_t, hobject_t> &get_rmissing() const override {
@@ -3205,7 +3205,7 @@ public:
     return true;
   }
   bool is_missing(const hobject_t& oid, eversion_t v) const override {
-    map<hobject_t, item, hobject_t::ComparatorWithDefault>::const_iterator m =
+    map<hobject_t, item>::const_iterator m =
       missing.find(oid);
     if (m == missing.end())
       return false;
@@ -3215,7 +3215,7 @@ public:
     return true;
   }
   eversion_t have_old(const hobject_t& oid) const override {
-    map<hobject_t, item, hobject_t::ComparatorWithDefault>::const_iterator m =
+    map<hobject_t, item>::const_iterator m =
       missing.find(oid);
     if (m == missing.end())
       return eversion_t();
@@ -3235,7 +3235,7 @@ public:
    */
   void add_next_event(const pg_log_entry_t& e) {
     if (e.is_update()) {
-      map<hobject_t, item, hobject_t::ComparatorWithDefault>::iterator missing_it;
+      map<hobject_t, item>::iterator missing_it;
       missing_it = missing.find(e.soid);
       bool is_missing_divergent_item = missing_it != missing.end();
       if (e.prior_version == eversion_t() || e.is_clone()) {
@@ -3291,25 +3291,25 @@ public:
   }
 
   void rm(const hobject_t& oid, eversion_t v) {
-    std::map<hobject_t, item, hobject_t::ComparatorWithDefault>::iterator p = missing.find(oid);
+    std::map<hobject_t, item>::iterator p = missing.find(oid);
     if (p != missing.end() && p->second.need <= v)
       rm(p);
   }
 
-  void rm(std::map<hobject_t, item, hobject_t::ComparatorWithDefault>::const_iterator m) {
+  void rm(std::map<hobject_t, item>::const_iterator m) {
     tracker.changed(m->first);
     rmissing.erase(m->second.need.version);
     missing.erase(m);
   }
 
   void got(const hobject_t& oid, eversion_t v) {
-    std::map<hobject_t, item, hobject_t::ComparatorWithDefault>::iterator p = missing.find(oid);
+    std::map<hobject_t, item>::iterator p = missing.find(oid);
     assert(p != missing.end());
     assert(p->second.need <= v);
     got(p);
   }
 
-  void got(std::map<hobject_t, item, hobject_t::ComparatorWithDefault>::const_iterator m) {
+  void got(std::map<hobject_t, item>::const_iterator m) {
     tracker.changed(m->first);
     rmissing.erase(m->second.need.version);
     missing.erase(m);
@@ -3320,7 +3320,7 @@ public:
     unsigned split_bits,
     pg_missing_set *omissing) {
     unsigned mask = ~((~0)<<split_bits);
-    for (map<hobject_t, item, hobject_t::ComparatorWithDefault>::iterator i = missing.begin();
+    for (map<hobject_t, item>::iterator i = missing.begin();
 	 i != missing.end();
       ) {
       if ((i->first.get_hash() & mask) == child_pgid.m_seed) {
@@ -3339,16 +3339,6 @@ public:
     rmissing.clear();
   }
 
-  void resort(bool sort_bitwise) {
-    if (missing.key_comp().bitwise != sort_bitwise) {
-      map<hobject_t, item, hobject_t::ComparatorWithDefault> tmp;
-      tmp.swap(missing);
-      missing = map<hobject_t, item, hobject_t::ComparatorWithDefault>(
-	hobject_t::ComparatorWithDefault(sort_bitwise));
-      missing.insert(tmp.begin(), tmp.end());
-    }
-  }
-
   void encode(bufferlist &bl) const {
     ENCODE_START(3, 2, bl);
     ::encode(missing, bl);
@@ -3363,8 +3353,8 @@ public:
 
     if (struct_v < 3) {
       // Handle hobject_t upgrade
-      map<hobject_t, item, hobject_t::ComparatorWithDefault> tmp;
-      for (map<hobject_t, item, hobject_t::ComparatorWithDefault>::iterator i =
+      map<hobject_t, item> tmp;
+      for (map<hobject_t, item>::iterator i =
 	     missing.begin();
 	   i != missing.end();
 	) {
@@ -3380,7 +3370,7 @@ public:
       missing.insert(tmp.begin(), tmp.end());
     }
 
-    for (map<hobject_t,item, hobject_t::ComparatorWithDefault>::iterator it =
+    for (map<hobject_t,item>::iterator it =
 	   missing.begin();
 	 it != missing.end();
 	 ++it)
@@ -3390,7 +3380,7 @@ public:
   }
   void dump(Formatter *f) const {
     f->open_array_section("missing");
-    for (map<hobject_t,item, hobject_t::ComparatorWithDefault>::const_iterator p =
+    for (map<hobject_t,item>::const_iterator p =
 	   missing.begin(); p != missing.end(); ++p) {
       f->open_object_section("item");
       f->dump_stream("object") << p->first;
@@ -3462,7 +3452,7 @@ public:
     }
     if (oss && !ok) {
       *oss << "check_missing: " << check_missing << "\n";
-      set<hobject_t, hobject_t::BitwiseComparator> changed;
+      set<hobject_t> changed;
       tracker.get_changed([&](const hobject_t &hoid) { changed.insert(hoid); });
       *oss << "changed: " << changed << "\n";
     }
@@ -4498,7 +4488,7 @@ class ObcLockManager {
       ObjectContext::RWState::State type)
       : obc(obc), type(type) {}
   };
-  map<hobject_t, ObjectLockState, hobject_t::BitwiseComparator> locks;
+  map<hobject_t, ObjectLockState> locks;
 public:
   ObcLockManager() = default;
   ObcLockManager(ObcLockManager &&) = default;
@@ -4616,7 +4606,7 @@ struct ObjectRecoveryInfo {
   object_info_t oi;
   SnapSet ss;
   interval_set<uint64_t> copy_subset;
-  map<hobject_t, interval_set<uint64_t>, hobject_t::BitwiseComparator> clone_subset;
+  map<hobject_t, interval_set<uint64_t>> clone_subset;
 
   ObjectRecoveryInfo() : size(0) { }
 
@@ -4746,13 +4736,13 @@ struct ScrubMap {
   WRITE_CLASS_ENCODER(object)
 
   bool bitwise; // ephemeral, not encoded
-  map<hobject_t,object, hobject_t::ComparatorWithDefault> objects;
+  map<hobject_t,object> objects;
   eversion_t valid_through;
   eversion_t incr_since;
 
   ScrubMap() : bitwise(true) {}
   ScrubMap(bool bitwise)
-    : bitwise(bitwise), objects(hobject_t::ComparatorWithDefault(bitwise)) {}
+    : bitwise(bitwise) {}
 
   void merge_incr(const ScrubMap &l);
   void insert(const ScrubMap &r) {
@@ -4770,10 +4760,9 @@ struct ScrubMap {
   void reset_bitwise(bool new_bitwise) {
     if (bitwise == new_bitwise)
       return;
-    map<hobject_t, object, hobject_t::ComparatorWithDefault> new_objects(
+    map<hobject_t, object> new_objects(
       objects.begin(),
-      objects.end(),
-      hobject_t::ComparatorWithDefault(new_bitwise));
+      objects.end());
     ::swap(new_objects, objects);
     bitwise = new_bitwise;
   }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1236,8 +1236,8 @@ public:
 
     bool contained_by(const hobject_t& begin, const hobject_t& end) {
       hobject_t h = get_hobj();
-      int r = cmp_bitwise(h, begin);
-      return r == 0 || (r > 0 && cmp_bitwise(h, end) < 0);
+      int r = cmp(h, begin);
+      return r == 0 || (r > 0 && h < end);
     }
 
     void dump(Formatter *f) const;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1807,7 +1807,7 @@ public:
     map<ceph_tid_t,CommandOp*> command_ops;
 
     // backoffs
-    map<hobject_t,OSDBackoff,hobject_t::BitwiseComparator> backoffs;
+    map<hobject_t,OSDBackoff> backoffs;
     multimap<uint64_t,OSDBackoff*> backoffs_by_id;
 
     int osd;

--- a/src/test/objectstore/FileStoreDiff.cc
+++ b/src/test/objectstore/FileStoreDiff.cc
@@ -134,14 +134,14 @@ bool FileStoreDiff::diff_objects(FileStore *a_store, FileStore *b_store, coll_t 
   int err;
   std::vector<ghobject_t> b_objects, a_objects;
   err = b_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
-				 true, INT_MAX, &b_objects, NULL);
+				 INT_MAX, &b_objects, NULL);
   if (err < 0) {
     dout(0) << "diff_objects list on verify coll " << coll.to_str()
 	    << " returns " << err << dendl;
     return true;
   }
   err = a_store->collection_list(coll, ghobject_t(), ghobject_t::get_max(),
-				 true, INT_MAX, &a_objects, NULL);
+				 INT_MAX, &a_objects, NULL);
   if (err < 0) {
     dout(0) << "diff_objects list on store coll " << coll.to_str()
               << " returns " << err << dendl;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2218,7 +2218,7 @@ TEST_P(StoreTest, SimpleListTest) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  set<ghobject_t, ghobject_t::BitwiseComparator> all;
+  set<ghobject_t> all;
   {
     ObjectStore::Transaction t;
     for (int i=0; i<200; ++i) {
@@ -2235,7 +2235,7 @@ TEST_P(StoreTest, SimpleListTest) {
     ASSERT_EQ(r, 0);
   }
   {
-    set<ghobject_t, ghobject_t::BitwiseComparator> saw;
+    set<ghobject_t> saw;
     vector<ghobject_t> objects;
     ghobject_t next, current;
     while (!next.is_max()) {
@@ -2262,7 +2262,7 @@ TEST_P(StoreTest, SimpleListTest) {
   }
   {
     ObjectStore::Transaction t;
-    for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator p = all.begin(); p != all.end(); ++p)
+    for (set<ghobject_t>::iterator p = all.begin(); p != all.end(); ++p)
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
@@ -2282,7 +2282,7 @@ TEST_P(StoreTest, ListEndTest) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  set<ghobject_t, ghobject_t::BitwiseComparator> all;
+  set<ghobject_t> all;
   {
     ObjectStore::Transaction t;
     for (int i=0; i<200; ++i) {
@@ -2313,7 +2313,7 @@ TEST_P(StoreTest, ListEndTest) {
   }
   {
     ObjectStore::Transaction t;
-    for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator p = all.begin(); p != all.end(); ++p)
+    for (set<ghobject_t>::iterator p = all.begin(); p != all.end(); ++p)
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
@@ -2362,7 +2362,7 @@ TEST_P(StoreTest, MultipoolListTest) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  set<ghobject_t, ghobject_t::BitwiseComparator> all, saw;
+  set<ghobject_t> all, saw;
   {
     ObjectStore::Transaction t;
     for (int i=0; i<200; ++i) {
@@ -2399,7 +2399,7 @@ TEST_P(StoreTest, MultipoolListTest) {
   }
   {
     ObjectStore::Transaction t;
-    for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator p = all.begin(); p != all.end(); ++p)
+    for (set<ghobject_t>::iterator p = all.begin(); p != all.end(); ++p)
       t.remove(cid, *p);
     t.remove_collection(cid);
     cerr << "Cleaning" << std::endl;
@@ -3013,7 +3013,7 @@ TEST_P(StoreTest, ManyObjectTest) {
   coll_t cid;
   string base = "";
   for (int i = 0; i < 100; ++i) base.append("aaaaa");
-  set<ghobject_t, ghobject_t::BitwiseComparator> created;
+  set<ghobject_t> created;
   {
     ObjectStore::Transaction t;
     t.create_collection(cid, 0);
@@ -3034,14 +3034,14 @@ TEST_P(StoreTest, ManyObjectTest) {
     ASSERT_EQ(r, 0);
   }
 
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = created.begin();
+  for (set<ghobject_t>::iterator i = created.begin();
        i != created.end();
        ++i) {
     struct stat buf;
     ASSERT_TRUE(!store->stat(cid, *i, &buf));
   }
 
-  set<ghobject_t, ghobject_t::BitwiseComparator> listed, listed2;
+  set<ghobject_t> listed, listed2;
   vector<ghobject_t> objects;
   r = store->collection_list(cid, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
   ASSERT_EQ(r, 0);
@@ -3091,13 +3091,13 @@ TEST_P(StoreTest, ManyObjectTest) {
   ASSERT_TRUE(listed.size() == created.size());
   if (listed2.size())
     ASSERT_EQ(listed.size(), listed2.size());
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = listed.begin();
+  for (set<ghobject_t>::iterator i = listed.begin();
        i != listed.end();
        ++i) {
     ASSERT_TRUE(created.count(*i));
   }
 
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = created.begin();
+  for (set<ghobject_t>::iterator i = created.begin();
        i != created.end();
        ++i) {
     ObjectStore::Transaction t;
@@ -3160,9 +3160,9 @@ public:
   unsigned write_alignment;
   unsigned max_object_len, max_write_len;
   unsigned in_flight;
-  map<ghobject_t, Object, ghobject_t::BitwiseComparator> contents;
-  set<ghobject_t, ghobject_t::BitwiseComparator> available_objects;
-  set<ghobject_t, ghobject_t::BitwiseComparator> in_flight_objects;
+  map<ghobject_t, Object> contents;
+  set<ghobject_t> available_objects;
+  set<ghobject_t> in_flight_objects;
   ObjectGenerator *object_gen;
   gen_type *rng;
   ObjectStore *store;
@@ -3323,7 +3323,7 @@ public:
       cond.Wait(lock);
     boost::uniform_int<> choose(0, available_objects.size() - 1);
     int index = choose(*rng);
-    set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = available_objects.begin();
+    set<ghobject_t>::iterator i = available_objects.begin();
     for ( ; index > 0; --index, ++i) ;
     ghobject_t ret = *i;
     return ret;
@@ -3869,7 +3869,7 @@ public:
     while (in_flight)
       cond.Wait(lock);
     vector<ghobject_t> objects;
-    set<ghobject_t, ghobject_t::BitwiseComparator> objects_set, objects_set2;
+    set<ghobject_t> objects_set, objects_set2;
     ghobject_t next, current;
     while (1) {
       //cerr << "scanning..." << std::endl;
@@ -3901,7 +3901,7 @@ public:
     }
 
     ASSERT_EQ(objects_set.size(), available_objects.size());
-    for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = objects_set.begin();
+    for (set<ghobject_t>::iterator i = objects_set.begin();
 	 i != objects_set.end();
 	 ++i) {
       ASSERT_GT(available_objects.count(*i), (unsigned)0);
@@ -3912,7 +3912,7 @@ public:
     ASSERT_EQ(r, 0);
     objects_set2.insert(objects.begin(), objects.end());
     ASSERT_EQ(objects_set2.size(), available_objects.size());
-    for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = objects_set2.begin();
+    for (set<ghobject_t>::iterator i = objects_set2.begin();
 	 i != objects_set2.end();
 	 ++i) {
       ASSERT_GT(available_objects.count(*i), (unsigned)0);
@@ -4368,7 +4368,7 @@ TEST_P(StoreTest, HashCollisionTest) {
   }
   string base = "";
   for (int i = 0; i < 100; ++i) base.append("aaaaa");
-  set<ghobject_t, ghobject_t::BitwiseComparator> created;
+  set<ghobject_t> created;
   for (int n = 0; n < 10; ++n) {
     char nbuf[100];
     sprintf(nbuf, "n%d", n);
@@ -4391,7 +4391,7 @@ TEST_P(StoreTest, HashCollisionTest) {
   vector<ghobject_t> objects;
   r = store->collection_list(cid, ghobject_t(), ghobject_t::get_max(), INT_MAX, &objects, 0);
   ASSERT_EQ(r, 0);
-  set<ghobject_t, ghobject_t::BitwiseComparator> listed(objects.begin(), objects.end());
+  set<ghobject_t> listed(objects.begin(), objects.end());
   cerr << "listed.size() is " << listed.size() << " and created.size() is " << created.size() << std::endl;
   ASSERT_TRUE(listed.size() == created.size());
   objects.clear();
@@ -4418,13 +4418,13 @@ TEST_P(StoreTest, HashCollisionTest) {
   }
   cerr << "listed.size() is " << listed.size() << std::endl;
   ASSERT_TRUE(listed.size() == created.size());
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = listed.begin();
+  for (set<ghobject_t>::iterator i = listed.begin();
        i != listed.end();
        ++i) {
     ASSERT_TRUE(created.count(*i));
   }
 
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = created.begin();
+  for (set<ghobject_t>::iterator i = created.begin();
        i != created.end();
        ++i) {
     ObjectStore::Transaction t;
@@ -4450,7 +4450,7 @@ TEST_P(StoreTest, ScrubTest) {
     ASSERT_EQ(r, 0);
   }
   string base = "aaaaa";
-  set<ghobject_t, ghobject_t::BitwiseComparator> created;
+  set<ghobject_t> created;
   for (int i = 0; i < 1000; ++i) {
     char buf[100];
     sprintf(buf, "%d", i);
@@ -4490,7 +4490,7 @@ TEST_P(StoreTest, ScrubTest) {
   r = store->collection_list(cid, ghobject_t(), ghobject_t::get_max(),
 			     INT_MAX, &objects, 0);
   ASSERT_EQ(r, 0);
-  set<ghobject_t, ghobject_t::BitwiseComparator> listed(objects.begin(), objects.end());
+  set<ghobject_t> listed(objects.begin(), objects.end());
   cerr << "listed.size() is " << listed.size() << " and created.size() is " << created.size() << std::endl;
   ASSERT_TRUE(listed.size() == created.size());
   objects.clear();
@@ -4516,13 +4516,13 @@ TEST_P(StoreTest, ScrubTest) {
   }
   cerr << "listed.size() is " << listed.size() << std::endl;
   ASSERT_TRUE(listed.size() == created.size());
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = listed.begin();
+  for (set<ghobject_t>::iterator i = listed.begin();
        i != listed.end();
        ++i) {
     ASSERT_TRUE(created.count(*i));
   }
 
-  for (set<ghobject_t, ghobject_t::BitwiseComparator>::iterator i = created.begin();
+  for (set<ghobject_t>::iterator i = created.begin();
        i != created.end();
        ++i) {
     ObjectStore::Transaction t;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -91,7 +91,7 @@ bool sorted(const vector<ghobject_t> &in) {
   for (vector<ghobject_t>::const_iterator i = in.begin();
        i != in.end();
        ++i) {
-    if (cmp(start, *i, true) > 0) {
+    if (start > *i) {
       cout << start << " should follow " << *i << std::endl;
       return false;
     }
@@ -2329,24 +2329,24 @@ TEST_P(StoreTest, Sort) {
     ASSERT_EQ(a, b);
     b.oid.name = "b";
     ASSERT_NE(a, b);
-    ASSERT_TRUE(cmp_bitwise(a, b) < 0);
+    ASSERT_TRUE(a < b);
     a.pool = 1;
     b.pool = 2;
-    ASSERT_TRUE(cmp_bitwise(a, b) < 0);
+    ASSERT_TRUE(a < b);
     a.pool = 3;
-    ASSERT_TRUE(cmp_bitwise(a, b) > 0);
+    ASSERT_TRUE(a > b);
   }
   {
     ghobject_t a(hobject_t(sobject_t("a", CEPH_NOSNAP)));
     ghobject_t b(hobject_t(sobject_t("b", CEPH_NOSNAP)));
     a.hobj.pool = 1;
     b.hobj.pool = 1;
-    ASSERT_TRUE(cmp_bitwise(a, b) < 0);
+    ASSERT_TRUE(a < b);
     a.hobj.pool = -3;
-    ASSERT_TRUE(cmp_bitwise(a, b) < 0);
+    ASSERT_TRUE(a < b);
     a.hobj.pool = 1;
     b.hobj.pool = -3;
-    ASSERT_TRUE(cmp_bitwise(a, b) > 0);
+    ASSERT_TRUE(a > b);
   }
 }
 

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -356,7 +356,7 @@ void WorkloadGenerator::do_destroy_collection(ObjectStore::Transaction *t,
   entry->m_osr.flush();
   vector<ghobject_t> ls;
   m_store->collection_list(entry->m_coll, ghobject_t(), ghobject_t::get_max(),
-			   true, INT_MAX, &ls, NULL);
+			   INT_MAX, &ls, NULL);
   dout(2) << __func__ << " coll " << entry->m_coll
       << " (" << ls.size() << " objects)" << dendl;
 

--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -80,7 +80,6 @@ protected:
   virtual int _collection_list_partial(
 				       const ghobject_t &start,
 				       const ghobject_t &end,
-				       bool sort_bitwise,
 				       int max_count,
 				       vector<ghobject_t> *ls,
 				       ghobject_t *next

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -92,7 +92,7 @@ public:
     pg_missing_t init;
     pg_missing_t final;
 
-    set<hobject_t, hobject_t::BitwiseComparator> toremove;
+    set<hobject_t> toremove;
     list<pg_log_entry_t> torollback;
 
   private:
@@ -153,7 +153,7 @@ public:
   };
 
   struct LogHandler : public PGLog::LogEntryHandler {
-    set<hobject_t, hobject_t::BitwiseComparator> removed;
+    set<hobject_t> removed;
     list<pg_log_entry_t> rolledback;
     
     void rollback(
@@ -204,8 +204,8 @@ public:
     }
 
     {
-      set<hobject_t, hobject_t::BitwiseComparator>::const_iterator titer = tcase.toremove.begin();
-      set<hobject_t, hobject_t::BitwiseComparator>::const_iterator hiter = handler.removed.begin();
+      set<hobject_t>::const_iterator titer = tcase.toremove.begin();
+      set<hobject_t>::const_iterator hiter = handler.removed.begin();
       for (; titer != tcase.toremove.end(); ++titer, ++hiter) {
 	EXPECT_EQ(*titer, *hiter);
       }

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -490,8 +490,9 @@ TEST_F(PGLogTest, merge_old_entry) {
     list<hobject_t> remove_snap;
 
     info.last_backfill = hobject_t();
-    info.last_backfill.set_hash(1);
+    info.last_backfill.set_hash(100);
     oe.soid.set_hash(2);
+    ASSERT_GT(oe.soid, info.last_backfill);
 
     EXPECT_FALSE(is_dirty());
     EXPECT_TRUE(remove_snap.empty());

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1442,14 +1442,14 @@ TEST(ghobject_t, cmp) {
   sep.set_shard(shard_id_t(1));
   sep.hobj.pool = -1;
   cout << min << " < " << sep << std::endl;
-  ASSERT_TRUE(cmp_bitwise(min, sep) < 0);
+  ASSERT_TRUE(min < sep);
 
   sep.set_shard(shard_id_t::NO_SHARD);
   cout << "sep shard " << sep.shard_id << std::endl;
   ghobject_t o(hobject_t(object_t(), string(), CEPH_NOSNAP, 0x42,
 			 1, string()));
   cout << "o " << o << std::endl;
-  ASSERT_TRUE(cmp_bitwise(o, sep) > 0);
+  ASSERT_TRUE(o > sep);
 }
 
 TEST(ghobject_t, parse) {

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -438,8 +438,8 @@ TEST_F(MapCacherTest, Random)
 class MapperVerifier {
   PausyAsyncMap *driver;
   boost::scoped_ptr< SnapMapper > mapper;
-  map<snapid_t, set<hobject_t, hobject_t::BitwiseComparator> > snap_to_hobject;
-  map<hobject_t, set<snapid_t>, hobject_t::BitwiseComparator> hobject_to_snap;
+  map<snapid_t, set<hobject_t> > snap_to_hobject;
+  map<hobject_t, set<snapid_t>> hobject_to_snap;
   snapid_t next;
   uint32_t mask;
   uint32_t bits;
@@ -491,7 +491,7 @@ public:
     for (set<snapid_t>::iterator i = snaps.begin();
 	 i != snaps.end();
 	 ++i) {
-      map<snapid_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator j = snap_to_hobject.find(*i);
+      map<snapid_t, set<hobject_t> >::iterator j = snap_to_hobject.find(*i);
       assert(j != snap_to_hobject.end());
       j->second.insert(obj);
     }
@@ -506,9 +506,9 @@ public:
     Mutex::Locker l(lock);
     if (snap_to_hobject.empty())
       return;
-    map<snapid_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator snap =
+    map<snapid_t, set<hobject_t> >::iterator snap =
       rand_choose(snap_to_hobject);
-    set<hobject_t, hobject_t::BitwiseComparator> hobjects = snap->second;
+    set<hobject_t> hobjects = snap->second;
 
     vector<hobject_t> hoids;
     while (mapper->get_next_objects_to_trim(
@@ -518,7 +518,7 @@ public:
 	assert(hobjects.count(hoid));
 	hobjects.erase(hoid);
 
-	map<hobject_t, set<snapid_t>, hobject_t::BitwiseComparator>::iterator j =
+	map<hobject_t, set<snapid_t>>::iterator j =
 	  hobject_to_snap.find(hoid);
 	assert(j->second.count(snap->first));
 	set<snapid_t> old_snaps(j->second);
@@ -548,12 +548,12 @@ public:
     Mutex::Locker l(lock);
     if (hobject_to_snap.empty())
       return;
-    map<hobject_t, set<snapid_t>, hobject_t::BitwiseComparator>::iterator obj =
+    map<hobject_t, set<snapid_t>>::iterator obj =
       rand_choose(hobject_to_snap);
     for (set<snapid_t>::iterator i = obj->second.begin();
 	 i != obj->second.end();
 	 ++i) {
-      map<snapid_t, set<hobject_t, hobject_t::BitwiseComparator> >::iterator j =
+      map<snapid_t, set<hobject_t> >::iterator j =
 	snap_to_hobject.find(*i);
       assert(j->second.count(obj->first));
       j->second.erase(obj->first);
@@ -572,7 +572,7 @@ public:
     Mutex::Locker l(lock);
     if (hobject_to_snap.empty())
       return;
-    map<hobject_t, set<snapid_t>, hobject_t::BitwiseComparator>::iterator obj =
+    map<hobject_t, set<snapid_t>>::iterator obj =
       rand_choose(hobject_to_snap);
     set<snapid_t> snaps;
     int r = mapper->get_snaps(obj->first, &snaps);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -90,7 +90,6 @@ int _action_on_all_objects_in_pg(ObjectStore *store, coll_t coll, action_on_obje
 				   coll,
 				   next,
 				   ghobject_t::get_max(),
-				   true,
 				   LIST_AT_A_TIME,
 				   &list,
 				   &next);
@@ -621,7 +620,7 @@ int ObjectStoreTool::export_files(ObjectStore *store, coll_t coll)
 
   while (!next.is_max()) {
     vector<ghobject_t> objects;
-    int r = store->collection_list(coll, next, ghobject_t::get_max(), true, 300,
+    int r = store->collection_list(coll, next, ghobject_t::get_max(), 300,
       &objects, &next);
     if (r < 0)
       return r;


### PR DESCRIPTION
This rips out all of the bitwise vs nibblewise nastyness in the code. The only remaining bits are in the interval checks (which need to be correct for past osdmap intervals and any period where sortbitwise gets unset), and in the last_backfill_bitwise field in pg_info_t, which might still be populated by old osds that haven't gone clean since before the bitwise flag was set.

The big win here is we're back to operator< and friends for hobject_t and ghobject_t, yay!