### PR TITLE
librbd: Include WorkQueue.h since we use it

### DIFF
--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -11,6 +11,7 @@
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/Cond.h"
+#include "common/WorkQueue.h"
 #include "journal/Future.h"
 #include "journal/JournalMetadataListener.h"
 #include "journal/ReplayEntry.h"
@@ -23,7 +24,6 @@
 #include <string>
 #include <unordered_map>
 
-class ContextWQ;
 class SafeTimer;
 namespace journal {
 class Journaler;


### PR DESCRIPTION
We use m_work_queue of type ContextWQ in handle_update function but we
do not include common/WorkQueue.h that defines ContextWQ. This results
in dereference of an incomplete type and causes build error in latest
Fedora rawhide (future 26).

Signed-off-by: Boris Ranto <branto@redhat.com>