### PR TITLE
librados: use cursor for nobjects listing

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,22 @@
+>= 12.0.0
+------
+* The original librados rados_objects_list_open (C) and objects_begin
+  (C++) object listing API, deprecated in Hammer, has finally been
+  removed.  Users of this interface must update their software to use
+  either the rados_nobjects_list_open (C) and nobjects_begin (C++) API or
+  the new rados_object_list_begin (C) and object_list_begin (C++) API
+  before updating the client-side librados library to Luminous.
+
+  Object enumeration (via any API) with the latest librados version
+  and pre-Hammer OSDs is no longer supported.  Note that no in-tree
+  Ceph services rely on object enumeration via the deprecated APIs, so
+  only external librados users might be affected.
+
+  The newest (and recommended) rados_object_list_begin (C) and
+  object_list_begin (C++) API is only usable on clusters with the
+  SORTBITWISE flag enabled (Jewel and later).  (Note that this flag is
+  required to be set before upgrading beyond Jewel.)
+
 12.0.0
 ------
 

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -1000,6 +1000,28 @@ CEPH_RADOS_API uint32_t rados_nobjects_list_seek(rados_list_ctx_t ctx,
                                                  uint32_t pos);
 
 /**
+ * Reposition object iterator to a different position
+ *
+ * @param ctx iterator marking where you are in the listing
+ * @param cursor position to move to
+ * @returns rounded position we moved to
+ */
+CEPH_RADOS_API uint32_t rados_nobjects_list_seek_cursor(rados_list_ctx_t ctx,
+                                                        rados_object_list_cursor cursor);
+
+/**
+ * Reposition object iterator to a different position
+ *
+ * The returned handle must be released with rados_object_list_cursor_free().
+ *
+ * @param ctx iterator marking where you are in the listing
+ * @param cursor where to store cursor
+ * @returns 0 on success, negative error code on failure
+ */
+CEPH_RADOS_API int rados_nobjects_list_get_cursor(rados_list_ctx_t ctx,
+                                                  rados_object_list_cursor *cursor);
+
+/**
  * Get the next object name and locator in the pool
  *
  * *entry and *key are valid until next call to rados_nobjects_list_*

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -72,6 +72,32 @@ namespace librados
   };
   CEPH_RADOS_API std::ostream& operator<<(std::ostream& out, const librados::ListObject& lop);
 
+  class CEPH_RADOS_API NObjectIterator;
+
+  class CEPH_RADOS_API ObjectCursor
+  {
+    public:
+    ObjectCursor();
+    ObjectCursor(const ObjectCursor &rhs);
+    explicit ObjectCursor(rados_object_list_cursor c);
+    ~ObjectCursor();
+    ObjectCursor& operator=(const ObjectCursor& rhs);
+    bool operator<(const ObjectCursor &rhs) const;
+    bool operator==(const ObjectCursor &rhs) const;
+    void set(rados_object_list_cursor c);
+
+    friend class IoCtx;
+    friend class NObjectIteratorImpl;
+    friend std::ostream& operator<<(std::ostream& os, const librados::ObjectCursor& oc);
+
+    std::string to_str() const;
+    bool from_str(const std::string& s);
+
+    protected:
+    rados_object_list_cursor c_cursor;
+  };
+  CEPH_RADOS_API std::ostream& operator<<(std::ostream& os, const librados::ObjectCursor& oc);
+
   class CEPH_RADOS_API NObjectIterator : public std::iterator <std::forward_iterator_tag, ListObject> {
   public:
     static const NObjectIterator __EndObjectIterator;
@@ -105,21 +131,6 @@ namespace librados
     NObjectIterator(ObjListCtx *ctx_);
     void get_next();
     NObjectIteratorImpl *impl;
-  };
-
-  class CEPH_RADOS_API ObjectCursor
-  {
-    public:
-    ObjectCursor();
-    ObjectCursor(const ObjectCursor &rhs);
-    ~ObjectCursor();
-    bool operator<(const ObjectCursor &rhs);
-    void set(rados_object_list_cursor c);
-
-    friend class IoCtx;
-
-    protected:
-    rados_object_list_cursor c_cursor;
   };
 
   class CEPH_RADOS_API ObjectItem

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -121,6 +121,12 @@ namespace librados
     /// move the iterator to a given hash position.  this may (will!) be rounded to the nearest pg.
     uint32_t seek(uint32_t pos);
 
+    /// move the iterator to a given cursor position
+    uint32_t seek(const ObjectCursor& cursor);
+
+    /// get current cursor position
+    ObjectCursor get_cursor();
+
     /**
      * Configure PGLS filter to be applied OSD-side (requires caller
      * to know/understand the format expected by the OSD)
@@ -872,6 +878,10 @@ namespace librados
     /// Start enumerating objects for a pool starting from a hash position
     NObjectIterator nobjects_begin(uint32_t start_hash_position);
     NObjectIterator nobjects_begin(uint32_t start_hash_position,
+                                   const bufferlist &filter);
+    /// Start enumerating objects for a pool starting from cursor
+    NObjectIterator nobjects_begin(const librados::ObjectCursor& cursor);
+    NObjectIterator nobjects_begin(const librados::ObjectCursor& cursor,
                                    const bufferlist &filter);
     /// Iterator indicating the end of a pool
     const NObjectIterator& nobjects_end() const;

--- a/src/librados/IoCtxImpl.cc
+++ b/src/librados/IoCtxImpl.cc
@@ -595,6 +595,21 @@ uint32_t librados::IoCtxImpl::nlist_seek(Objecter::NListContext *context,
   return objecter->list_nobjects_seek(context, pos);
 }
 
+uint32_t librados::IoCtxImpl::nlist_seek(Objecter::NListContext *context,
+                                    const rados_object_list_cursor& cursor)
+{
+  context->list.clear();
+  return objecter->list_nobjects_seek(context, *(const hobject_t *)cursor);
+}
+
+rados_object_list_cursor librados::IoCtxImpl::nlist_get_cursor(Objecter::NListContext *context)
+{
+  hobject_t *c = new hobject_t;
+
+  objecter->list_nobjects_get_cursor(context, c);
+  return (rados_object_list_cursor)c;
+}
+
 int librados::IoCtxImpl::create(const object_t& oid, bool exclusive)
 {
   ::ObjectOperation op;

--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -110,6 +110,8 @@ struct librados::IoCtxImpl {
   // io
   int nlist(Objecter::NListContext *context, int max_entries);
   uint32_t nlist_seek(Objecter::NListContext *context, uint32_t pos);
+  uint32_t nlist_seek(Objecter::NListContext *context, const rados_object_list_cursor& cursor);
+  rados_object_list_cursor nlist_get_cursor(Objecter::NListContext *context);
   void object_list_slice(
     const hobject_t start,
     const hobject_t finish,

--- a/src/librados/ListObjectImpl.h
+++ b/src/librados/ListObjectImpl.h
@@ -67,6 +67,12 @@ class NObjectIteratorImpl {
     /// move the iterator to a given hash position.  this may (will!) be rounded to the nearest pg.
     uint32_t seek(uint32_t pos);
 
+    /// move the iterator to a given cursor position
+    uint32_t seek(const librados::ObjectCursor& cursor);
+
+    /// get current cursor position
+    librados::ObjectCursor get_cursor();
+
     void set_filter(const bufferlist &bl);
 
   private:

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3626,7 +3626,7 @@ void Objecter::_nlist_reply(NListContext *list_context, int r,
 		 << ", tentative new pos " << list_context->pos << dendl;
   list_context->extra_info.append(extra_info);
   if (response_size) {
-    list_context->list.merge(response.entries);
+    list_context->list.splice(list_context->list.end(), response.entries);
   }
 
   if (list_context->list.size() >= list_context->max_entries) {

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2731,6 +2731,8 @@ public:
 
   void list_nobjects(NListContext *p, Context *onfinish);
   uint32_t list_nobjects_seek(NListContext *p, uint32_t pos);
+  uint32_t list_nobjects_seek(NListContext *list_context, const hobject_t& c);
+  void list_nobjects_get_cursor(NListContext *list_context, hobject_t *c);
 
   hobject_t enumerate_objects_begin();
   hobject_t enumerate_objects_end();

--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -390,6 +390,224 @@ TEST_F(LibRadosListPP, ListObjectsStartPP) {
   }
 }
 
+TEST_F(LibRadosListPP, ListObjectsCursorNSPP) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  const int max_objs = 16;
+
+  map<string, string> oid_to_ns;
+
+  for (int i=0; i<max_objs; ++i) {
+    stringstream ss;
+    ss << "ns" << i / 4;
+    ioctx.set_namespace(ss.str());
+    string oid = stringify(i);
+    ASSERT_EQ(0, ioctx.write(oid, bl, bl.length(), 0));
+
+    oid_to_ns[oid] = ss.str();
+  }
+
+  ioctx.set_namespace(all_nspaces);
+
+  librados::NObjectIterator it = ioctx.nobjects_begin();
+  std::map<librados::ObjectCursor, string> cursor_to_obj;
+
+  int count = 0;
+
+  librados::ObjectCursor seek_cursor;
+
+  map<string, list<librados::ObjectCursor> > ns_to_cursors;
+
+  for (it = ioctx.nobjects_begin(); it != ioctx.nobjects_end(); ++it) {
+    librados::ObjectCursor cursor = it.get_cursor();
+    string oid = it->get_oid();
+    cout << "> oid=" << oid << " cursor=" << it.get_cursor() << std::endl;
+  }
+
+  vector<string> objs_order;
+
+  for (it = ioctx.nobjects_begin(); it != ioctx.nobjects_end(); ++it, ++count) {
+    librados::ObjectCursor cursor = it.get_cursor();
+    string oid = it->get_oid();
+    std::cout << oid << " " << it.get_pg_hash_position() << std::endl;
+    cout << ": oid=" << oid << " cursor=" << it.get_cursor() << std::endl;
+    cursor_to_obj[cursor] = oid;
+
+    ASSERT_EQ(oid_to_ns[oid], it->get_nspace());
+
+    it.seek(cursor);
+    cout << ": seek to " << cursor << " it.cursor=" << it.get_cursor() << std::endl;
+    ASSERT_EQ(oid, it->get_oid());
+    ASSERT_LT(count, max_objs); /* avoid infinite loops due to bad seek */
+
+    ns_to_cursors[it->get_nspace()].push_back(cursor);
+
+    if (count == max_objs/2) {
+      seek_cursor = cursor;
+    }
+    objs_order.push_back(it->get_oid());
+  }
+
+  ASSERT_EQ(count, max_objs);
+
+  /* check that reading past seek also works */
+  cout << "seek_cursor=" << seek_cursor << std::endl;
+  it.seek(seek_cursor);
+  for (count = max_objs/2; count < max_objs; ++count, ++it) {
+    ASSERT_EQ(objs_order[count], it->get_oid());
+  }
+
+  /* seek to all cursors, check that we get expected obj */
+  for (auto& niter : ns_to_cursors) {
+    const string& ns = niter.first;
+    list<librados::ObjectCursor>& cursors = niter.second;
+
+    for (auto& cursor : cursors) {
+      cout << ": seek to " << cursor << std::endl;
+      it.seek(cursor);
+      ASSERT_EQ(cursor, it.get_cursor());
+      string& expected_oid = cursor_to_obj[cursor];
+      cout << ": it->get_cursor()=" << it.get_cursor() << " expected=" << cursor << std::endl;
+      cout << ": it->get_oid()=" << it->get_oid() << " expected=" << expected_oid << std::endl;
+      cout << ": it->get_nspace()=" << it->get_oid() << " expected=" << ns << std::endl;
+      ASSERT_EQ(expected_oid, it->get_oid());
+      ASSERT_EQ(it->get_nspace(), ns);
+    }
+  }
+}
+
+TEST_F(LibRadosListPP, ListObjectsCursorPP) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+  bufferlist bl;
+  bl.append(buf, sizeof(buf));
+
+  const int max_objs = 16;
+
+  for (int i=0; i<max_objs; ++i) {
+    stringstream ss;
+    ss << "ns" << i / 4;
+    ioctx.set_namespace(ss.str());
+    ASSERT_EQ(0, ioctx.write(stringify(i), bl, bl.length(), 0));
+  }
+
+  ioctx.set_namespace(all_nspaces);
+
+  librados::NObjectIterator it = ioctx.nobjects_begin();
+  std::map<librados::ObjectCursor, string> cursor_to_obj;
+
+  int count = 0;
+
+  for (; it != ioctx.nobjects_end(); ++it, ++count) {
+    librados::ObjectCursor cursor = it.get_cursor();
+    string oid = it->get_oid();
+    std::cout << oid << " " << it.get_pg_hash_position() << std::endl;
+    cout << ": oid=" << oid << " cursor=" << it.get_cursor() << std::endl;
+    cursor_to_obj[cursor] = oid;
+
+    it.seek(cursor);
+    cout << ": seek to " << cursor << std::endl;
+    ASSERT_EQ(oid, it->get_oid());
+    ASSERT_LT(count, max_objs); /* avoid infinite loops due to bad seek */
+  }
+
+  ASSERT_EQ(count, max_objs);
+
+  auto p = cursor_to_obj.rbegin();
+  it = ioctx.nobjects_begin();
+  while (p != cursor_to_obj.rend()) {
+    cout << ": seek to " << p->first << std::endl;
+    it.seek(p->first);
+    ASSERT_EQ(p->first, it.get_cursor());
+    cout << ": it->get_cursor()=" << it.get_cursor() << " expected=" << p->first << std::endl;
+    cout << ": it->get_oid()=" << it->get_oid() << " expected=" << p->second << std::endl;
+    ASSERT_EQ(p->second, it->get_oid());
+
+    librados::NObjectIterator it2 = ioctx.nobjects_begin(it.get_cursor());
+    ASSERT_EQ(it2->get_oid(), it->get_oid());
+
+    ++p;
+  }
+}
+
+TEST_F(LibRadosList, ListObjectsCursor) {
+  char buf[128];
+  memset(buf, 0xcc, sizeof(buf));
+
+  const int max_objs = 16;
+
+  for (int i=0; i<max_objs; ++i) {
+    string n = stringify(i);
+    ASSERT_EQ(0, rados_write(ioctx, n.c_str(), buf, sizeof(buf), 0));
+  }
+
+  {
+    rados_list_ctx_t ctx;
+    const char *entry;
+    rados_object_list_cursor cursor;
+    ASSERT_EQ(0, rados_nobjects_list_open(ioctx, &ctx));
+    ASSERT_EQ(rados_nobjects_list_get_cursor(ctx, &cursor), 0);
+    rados_object_list_cursor first_cursor = cursor;
+    cout << "x cursor=" << ObjectCursor(cursor) << std::endl;
+    while (rados_nobjects_list_next(ctx, &entry, NULL, NULL) == 0) {
+      string oid = entry;
+      ASSERT_EQ(rados_nobjects_list_get_cursor(ctx, &cursor), 0);
+      cout << "> oid=" << oid << " cursor=" << ObjectCursor(cursor) << std::endl;
+    }
+    rados_nobjects_list_seek_cursor(ctx, first_cursor);
+    ASSERT_EQ(rados_nobjects_list_next(ctx, &entry, NULL, NULL), 0);
+    cout << "FIRST> seek to " << ObjectCursor(first_cursor) << " oid=" << string(entry) << std::endl;
+  }
+  rados_list_ctx_t ctx;
+  ASSERT_EQ(0, rados_nobjects_list_open(ioctx, &ctx));
+
+  std::map<rados_object_list_cursor, string> cursor_to_obj;
+  int count = 0;
+
+  const char *entry;
+  while (rados_nobjects_list_next(ctx, &entry, NULL, NULL) == 0) {
+    rados_object_list_cursor cursor;
+    ASSERT_EQ(rados_nobjects_list_get_cursor(ctx, &cursor), 0);
+    string oid = entry;
+    cout << ": oid=" << oid << " cursor=" << ObjectCursor(cursor) << std::endl;
+    cursor_to_obj[cursor] = oid;
+
+    rados_nobjects_list_seek_cursor(ctx, cursor);
+    cout << ": seek to " << ObjectCursor(cursor) << std::endl;
+    ASSERT_EQ(rados_nobjects_list_next(ctx, &entry, NULL, NULL), 0);
+    cout << "> " << ObjectCursor(cursor) << " -> " << entry << std::endl;
+    ASSERT_EQ(string(entry), oid);
+    ASSERT_LT(count, max_objs); /* avoid infinite loops due to bad seek */
+
+    ++count;
+  }
+
+  ASSERT_EQ(count, max_objs);
+
+  auto p = cursor_to_obj.rbegin();
+  ASSERT_EQ(0, rados_nobjects_list_open(ioctx, &ctx));
+  while (p != cursor_to_obj.rend()) {
+    cout << ": seek to " << ObjectCursor(p->first) << std::endl;
+    rados_object_list_cursor cursor;
+    rados_object_list_cursor oid(p->first);
+    rados_nobjects_list_seek_cursor(ctx, oid);
+    ASSERT_EQ(rados_nobjects_list_get_cursor(ctx, &cursor), 0);
+    cout << ": cursor()=" << ObjectCursor(cursor) << " expected=" << oid << std::endl;
+    // ASSERT_EQ(ObjectCursor(oid), ObjectCursor(cursor));
+    ASSERT_EQ(rados_nobjects_list_next(ctx, &entry, NULL, NULL), 0);
+    cout << "> " << ObjectCursor(cursor) << " -> " << entry << std::endl;
+    cout << ": entry=" << entry << " expected=" << p->second << std::endl;
+    ASSERT_EQ(p->second, string(entry));
+
+    ++p;
+
+    rados_object_list_cursor_free(ctx, cursor);
+  }
+}
+
 TEST_F(LibRadosListEC, ListObjects) {
   char buf[128];
   memset(buf, 0xcc, sizeof(buf));

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -1766,6 +1766,38 @@ TRACEPOINT_EVENT(librados, rados_nobjects_list_seek_exit,
     )
 )
 
+TRACEPOINT_EVENT(librados, rados_nobjects_list_seek_cursor_enter,
+    TP_ARGS(
+        rados_list_ctx_t, listctx),
+    TP_FIELDS(
+        ctf_integer_hex(rados_list_ctx_t, listctx, listctx)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_nobjects_list_seek_cursor_exit,
+    TP_ARGS(
+        uint32_t, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_nobjects_list_get_cursor_enter,
+    TP_ARGS(
+        rados_list_ctx_t, listctx),
+    TP_FIELDS(
+        ctf_integer_hex(rados_list_ctx_t, listctx, listctx)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_nobjects_list_get_cursor_exit,
+    TP_ARGS(
+        uint32_t, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librados, rados_nobjects_list_get_pg_hash_position_enter,
     TP_ARGS(
         rados_list_ctx_t, listctx),


### PR DESCRIPTION
This includes also the changes that are in #13149, and replaces #12399. Unlike the older PR that it replaces, it leverages the ObjectCursor type that has been added for a new pool listing api (aka v3).