### PR TITLE
ceph_test_objectstore: tolerate fsck EOPNOTSUPP too

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -3883,7 +3883,7 @@ public:
       cond.Wait(lock);
     store->umount();
     int r = store->fsck(deep);
-    assert(r == 0);
+    assert(r == 0 || r == -EOPNOTSUPP);
     store->mount();
   }
 


### PR DESCRIPTION
44c3ec81e9a638150b7d4aa5afb38e73ed92078f is problematic for filestore etc.

Signed-off-by: Sage Weil <sage@redhat.com>