### PR TITLE
crush: do is_out test only if we do not collide

### DIFF
--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -548,17 +548,15 @@ parent_r %d stable %d\n",
 					} else {
 						/* we already have a leaf! */
 						out2[outpos] = item;
-		}
+		                        }
 				}
 
-				if (!reject) {
+				if (!reject && !collide) {
 					/* out? */
 					if (itemtype == 0)
 						reject = is_out(map, weight,
 								weight_max,
 								item, x);
-					else
-						reject = 0;
 				}
 
 reject:


### PR DESCRIPTION
The is_out() test could requires additional hash, so we shall
skip it whenever it is possible.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>