### PR TITLE
auth: Make UNKNOWN protocol really needed and used

### DIFF
--- a/src/auth/AuthAuthorizeHandler.cc
+++ b/src/auth/AuthAuthorizeHandler.cc
@@ -15,6 +15,7 @@
 #include "AuthAuthorizeHandler.h"
 #include "cephx/CephxAuthorizeHandler.h"
 #include "none/AuthNoneAuthorizeHandler.h"
+#include "unknown/AuthUnknownAuthorizeHandler.h"
 #include "common/Mutex.h"
 
 AuthAuthorizeHandler *AuthAuthorizeHandlerRegistry::get_handler(int protocol)
@@ -35,6 +36,10 @@ AuthAuthorizeHandler *AuthAuthorizeHandlerRegistry::get_handler(int protocol)
     
   case CEPH_AUTH_CEPHX:
     m_authorizers[protocol] = new CephxAuthorizeHandler();
+    return m_authorizers[protocol];
+
+  case CEPH_AUTH_UNKNOWN:
+    m_authorizers[protocol] = new AuthUnknownAuthorizeHandler();
     return m_authorizers[protocol];
   }
   return NULL;

--- a/src/auth/AuthClientHandler.cc
+++ b/src/auth/AuthClientHandler.cc
@@ -18,6 +18,7 @@
 #include "AuthClientHandler.h"
 #include "cephx/CephxClientHandler.h"
 #include "none/AuthNoneClientHandler.h"
+#include "unknown/AuthUnknownClientHandler.h"
 
 AuthClientHandler *get_auth_client_handler(CephContext *cct, int proto,
 					   RotatingKeyRing *rkeys)
@@ -27,6 +28,8 @@ AuthClientHandler *get_auth_client_handler(CephContext *cct, int proto,
     return new CephxClientHandler(cct, rkeys);
   case CEPH_AUTH_NONE:
     return new AuthNoneClientHandler(cct, rkeys);
+  case CEPH_AUTH_UNKNOWN:
+    return new AuthUnknownClientHandler(cct, rkeys);
   default:
     return NULL;
   }

--- a/src/auth/AuthServiceHandler.cc
+++ b/src/auth/AuthServiceHandler.cc
@@ -15,6 +15,7 @@
 #include "AuthServiceHandler.h"
 #include "cephx/CephxServiceHandler.h"
 #include "none/AuthNoneServiceHandler.h"
+#include "unknown/AuthUnknownServiceHandler.h"
 
 #define dout_subsys ceph_subsys_auth
 
@@ -26,6 +27,8 @@ AuthServiceHandler *get_auth_service_handler(int type, CephContext *cct, KeyServ
     return new CephxServiceHandler(cct, ks);
   case CEPH_AUTH_NONE:
     return new AuthNoneServiceHandler(cct);
+  case CEPH_AUTH_UNKNOWN:
+    return new AuthUnknownServiceHandler(cct);
   }
   return NULL;
 }

--- a/src/auth/none/AuthNoneAuthorizeHandler.cc
+++ b/src/auth/none/AuthNoneAuthorizeHandler.cc
@@ -25,7 +25,7 @@ uint64_t *auid)
   bufferlist::iterator iter = authorizer_data.begin();
 
   try {
-    __u8 struct_v = 1;
+    __u8 struct_v;
     ::decode(struct_v, iter);
     ::decode(entity_name, iter);
     ::decode(global_id, iter);

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -888,8 +888,8 @@ int MonClient::wait_auth_rotating(double timeout)
   utime_t now = ceph_clock_now();
   utime_t until = now;
   until += timeout;
-
-  if (auth->get_protocol() == CEPH_AUTH_NONE)
+  int protocol = auth->get_protocol();
+  if (protocol == CEPH_AUTH_NONE || protocol == CEPH_AUTH_UNKNOWN)
     return 0;
   
   if (!rotating_secrets)


### PR DESCRIPTION
ceph defined `UNKNOWN` auth protocol but the protocol is
never really used anywhere, this patch pick it up where
the protocol could be applied.

Signed-off-by: Dave Chen <wei.d.chen@intel.com>