### PR TITLE
osd: fix stat sum update of recovery pushing

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -635,8 +635,7 @@ void ECBackend::continue_recovery_op(
 	      get_parent()->on_peer_recover(
 		*i,
 		op.hoid,
-		op.recovery_info,
-		object_stat_sum_t());
+		op.recovery_info);
 	    }
 	  }
 	  object_stat_sum_t stat;

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -96,8 +96,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
      virtual void on_peer_recover(
        pg_shard_t peer,
        const hobject_t &oid,
-       const ObjectRecoveryInfo &recovery_info,
-       const object_stat_sum_t &stat
+       const ObjectRecoveryInfo &recovery_info
        ) = 0;
 
      virtual void begin_peer_recover(

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -466,10 +466,8 @@ void PrimaryLogPG::on_global_recover(
 void PrimaryLogPG::on_peer_recover(
   pg_shard_t peer,
   const hobject_t &soid,
-  const ObjectRecoveryInfo &recovery_info,
-  const object_stat_sum_t &stat)
+  const ObjectRecoveryInfo &recovery_info)
 {
-  info.stats.stats.sum.add(stat);
   publish_stats_to_osd();
   // done!
   peer_missing[peer].got(soid, recovery_info.version);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -257,8 +257,7 @@ public:
   void on_peer_recover(
     pg_shard_t peer,
     const hobject_t &oid,
-    const ObjectRecoveryInfo &recovery_info,
-    const object_stat_sum_t &stat
+    const ObjectRecoveryInfo &recovery_info
     ) override;
   void begin_peer_recover(
     pg_shard_t peer,

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -2213,18 +2213,12 @@ bool ReplicatedBackend::handle_push_reply(pg_shard_t peer, PushReplyOp &op, Push
     } else {
       // done!
       get_parent()->on_peer_recover(
-	peer, soid, pi->recovery_info,
-	pi->stat);
-
-      object_stat_sum_t stat;
-      stat.num_bytes_recovered = pi->recovery_info.size;
-      stat.num_keys_recovered = reply->omap_entries.size();
-      stat.num_objects_recovered = 1;
+	peer, soid, pi->recovery_info);
 
       get_parent()->release_locks(pi->lock_manager);
+      object_stat_sum_t stat = pi->stat;
       pushing[soid].erase(peer);
       pi = NULL;
-
 
       if (pushing[soid].empty()) {
 	get_parent()->on_global_recover(soid, stat);


### PR DESCRIPTION
Use the stat field of PushInfo to do the stat update, which is
more accurate, especially in the case of sparse file. Also,
remove the stat sum update in on_peer_recover, which is done in
on_global_recover.

Signed-off-by: Zhiqiang Wang <zhiqiang@xsky.com>