### PR TITLE
msg: Fix calls to Messenger::create with new parameter

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -46,7 +46,8 @@ DaemonServer::~DaemonServer() {
 int DaemonServer::init(uint64_t gid, entity_addr_t client_addr)
 {
   // Initialize Messenger
-  msgr = Messenger::create(g_ceph_context, g_conf->ms_type,
+  std::string public_msgr_type = g_conf->ms_public_type.empty() ? g_conf->ms_type : g_conf->ms_public_type;
+  msgr = Messenger::create(g_ceph_context, public_msgr_type,
 			   entity_name_t::MGR(gid), "server", getpid(), 0);
   int r = msgr->bind(g_conf->public_addr);
   if (r < 0) {

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -79,7 +79,8 @@ public:
   int init_messenger() {
     dout(1) << __func__ << dendl;
 
-    msg = Messenger::create(cct, cct->_conf->ms_type, entity_name_t::CLIENT(-1),
+    std::string public_msgr_type = cct->_conf->ms_public_type.empty() ? cct->_conf->ms_type : cct->_conf->ms_public_type;
+    msg = Messenger::create(cct, public_msgr_type, entity_name_t::CLIENT(-1),
                             "test-mon-msg", 0, 0);
     assert(msg != NULL);
     msg->set_default_policy(Messenger::Policy::lossy_client(0,0));

--- a/src/test/mon/test_mon_workloadgen.cc
+++ b/src/test/mon/test_mon_workloadgen.cc
@@ -361,7 +361,8 @@ class OSDStub : public TestStub
 	     << cct->_conf->auth_supported << dendl;
     stringstream ss;
     ss << "client-osd" << whoami;
-    messenger.reset(Messenger::create(cct, cct->_conf->ms_type, entity_name_t::OSD(whoami),
+    std::string public_msgr_type = cct->_conf->ms_public_type.empty() ? cct->_conf->ms_type : cct->_conf->ms_public_type;
+    messenger.reset(Messenger::create(cct, public_msgr_type, entity_name_t::OSD(whoami),
 				      ss.str().c_str(), getpid(), 0));
 
     Throttle throttler(g_ceph_context, "osd_client_bytes",

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -189,14 +189,18 @@ int main(int argc, char **argv)
   int think_time = atoi(args[4]);
   int len = atoi(args[5]);
 
-  cerr << " using ms-type " << g_ceph_context->_conf->ms_type << std::endl;
+  std::string public_msgr_type = g_ceph_context->_conf->ms_public_type.empty() ? g_ceph_context->_conf->ms_type : g_ceph_context->_conf->ms_public_type;
+
+  cerr << " using ms-public-type " << public_msgr_type << std::endl;
   cerr << "       server ip:port " << args[0] << std::endl;
   cerr << "       numjobs " << numjobs << std::endl;
   cerr << "       concurrency " << concurrent << std::endl;
   cerr << "       ios " << ios << std::endl;
   cerr << "       thinktime(us) " << think_time << std::endl;
   cerr << "       message data bytes " << len << std::endl;
-  MessengerClient client(g_ceph_context->_conf->ms_type, args[0], think_time);
+
+  MessengerClient client(public_msgr_type, args[0], think_time);
+
   client.ready(concurrent, numjobs, ios, len);
   Cycles::init();
   uint64_t start = Cycles::rdtsc();

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -157,15 +157,17 @@ int main(int argc, char **argv)
 
   int worker_threads = atoi(args[1]);
   int think_time = atoi(args[2]);
+  std::string public_msgr_type = g_ceph_context->_conf->ms_public_type.empty() ? g_ceph_context->_conf->ms_type : g_ceph_context->_conf->ms_public_type;
+
   cerr << " This tool won't handle connection error alike things, " << std::endl;
   cerr << "please ensure the proper network environment to test." << std::endl;
   cerr << " Or ctrl+c when meeting error and restart tests" << std::endl;
-  cerr << " using ms-type " << g_ceph_context->_conf->ms_type << std::endl;
+  cerr << " using ms-public-type " << public_msgr_type << std::endl;
   cerr << "       bind ip:port " << args[0] << std::endl;
   cerr << "       worker threads " << worker_threads << std::endl;
   cerr << "       thinktime(us) " << think_time << std::endl;
 
-  MessengerServer server(g_ceph_context->_conf->ms_type, args[0], worker_threads, think_time);
+  MessengerServer server(public_msgr_type, args[0], worker_threads, think_time);
   server.start();
 
   return 0;

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -1498,7 +1498,7 @@ INSTANTIATE_TEST_CASE_P(
   Messenger,
   MessengerTest,
   ::testing::Values(
-    "async",
+    "async+posix",
     "simple"
   )
 );

--- a/src/test/osd/TestOSDScrub.cc
+++ b/src/test/osd/TestOSDScrub.cc
@@ -56,7 +56,8 @@ TEST(TestOSDScrub, scrub_time_permit) {
              g_conf->osd_objectstore,
              g_conf->osd_data,
              g_conf->osd_journal);
-  Messenger *ms = Messenger::create(g_ceph_context, g_conf->ms_type,
+  std::string cluster_msgr_type = g_conf->ms_cluster_type.empty() ? g_conf->ms_type : g_conf->ms_cluster_type;
+  Messenger *ms = Messenger::create(g_ceph_context, cluster_msgr_type,
 				    entity_name_t::OSD(0), "make_checker",
 				    getpid(), 0);
   ms->set_cluster_protocol(CEPH_OSD_PROTOCOL);

--- a/src/test/testmsgr.cc
+++ b/src/test/testmsgr.cc
@@ -92,8 +92,9 @@ int main(int argc, const char **argv, const char *envp[]) {
   std::string sss(ss.str());
   g_ceph_context->_conf->set_val("public_addr", sss.c_str());
   g_ceph_context->_conf->apply_changes(NULL);
+  std::string public_msgr_type = g_conf->ms_public_type.empty() ? g_conf->ms_type : g_conf->ms_public_type;
   Messenger *rank = Messenger::create(g_ceph_context,
-				      g_conf->ms_type,
+				      public_msgr_type,
 				      entity_name_t::MON(whoami), "tester",
 				      getpid());
   int err = rank->bind(g_ceph_context->_conf->public_addr);


### PR DESCRIPTION
Update all calls to Messenger::create()
take 'ms_public_type' or 'ms_cluster_type' instead of 'ms_type'

Signed-off-by: Sarit Zubakov <saritz@mellanox.com>