### PR TITLE
tests: osd-scrub-repair.sh disable scrub backoff in test 

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -808,6 +808,7 @@ OPTION(osd_scrub_load_threshold, OPT_FLOAT, 0.5)
 OPTION(osd_scrub_min_interval, OPT_FLOAT, 60*60*24)    // if load is low
 OPTION(osd_scrub_max_interval, OPT_FLOAT, 7*60*60*24)  // regardless of load
 OPTION(osd_scrub_interval_randomize_ratio, OPT_FLOAT, 0.5) // randomize the scheduled scrub in the span of [min,min*(1+randomize_ratio))
+OPTION(osd_scrub_backoff_ratio, OPT_DOUBLE, .66)   // the probability to back off the scheduled scrub
 OPTION(osd_scrub_chunk_min, OPT_INT, 5)
 OPTION(osd_scrub_chunk_max, OPT_INT, 25)
 OPTION(osd_scrub_sleep, OPT_FLOAT, 0)   // sleep between [deep]scrub ops

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6582,7 +6582,8 @@ void OSD::handle_scrub(MOSDScrub *m)
 
 bool OSD::scrub_random_backoff()
 {
-  bool coin_flip = (rand() % 3) == whoami % 3;
+  bool coin_flip = (rand() / (double)RAND_MAX >=
+		    cct->_conf->osd_scrub_backoff_ratio);
   if (!coin_flip) {
     dout(20) << "scrub_random_backoff lost coin flip, randomly backing off" << dendl;
     return true;

--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -2227,7 +2227,11 @@ function TEST_periodic_scrub_replicated() {
     rados list-inconsistent-obj $pg | jq '.' | grep -q $objname || return 1
 
     # Request a regular scrub and it will be done
+    local scrub_backoff_ratio=$(get_config osd ${primary} osd_scrub_backoff_ratio)
+    set_config osd ${primary} osd_scrub_backoff_ratio 0
     pg_scrub $pg
+    sleep 1
+    set_config osd ${primary} osd_scrub_backoff_ratio $scrub_backoff_ratio
     grep -q "Regular scrub request, losing deep-scrub details" $dir/osd.${primary}.log || return 1
 
     # deep-scrub error is no longer present


### PR DESCRIPTION
there is good chance that the newly scheduled scrub fail to pass the
flip-coin check: the probability of scheduling a new scrub 1/3 every
time we flip the coin. so, let's be more patient.

Signed-off-by: Kefu Chai <kchai@redhat.com>