### PR TITLE
os/bluestore: optimize blob usage when doing appends/overwrites

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2708,7 +2708,9 @@ BlueStore::Extent *BlueStore::ExtentMap::set_lextent(
   uint64_t blob_offset, uint64_t length, BlobRef b,
   extent_map_t *old_extents)
 {
-  punch_hole(logical_offset, length, old_extents);
+  if (old_extents) {
+    punch_hole(logical_offset, length, old_extents);
+  }
 
   // We need to have completely initialized Blob to increment its ref counters.
   // But that's not true for newly created blob and we defer the increment until

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5841,7 +5841,7 @@ int BlueStore::_do_read(
   for (auto& p : blobs2read) {
     BlobRef bptr = p.first;
     dout(20) << __func__ << "  blob " << *bptr << std::hex
-	     << " need 0x" << p.second << std::dec << dendl;
+	     << " need " << p.second << std::dec << dendl;
     if (bptr->get_blob().is_compressed()) {
       // read the whole thing
       if (compressed_blob_bls.empty()) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1668,7 +1668,7 @@ void BlueStore::Blob::discard_unallocated(Collection *coll)
     assert(discard == all_invalid); // in case of compressed blob all
 				    // or none pextents are invalid.
     if (discard) {
-      shared_blob->bc.discard(shared_blob->get_cache(), 0, blob.get_compressed_payload_original_length());
+      shared_blob->bc.discard(shared_blob->get_cache(), 0, blob.get_logical_length());
     }
   } else {
     size_t pos = 0;
@@ -1777,6 +1777,7 @@ bool BlueStore::Blob::put_ref(
       }
       pos += e.length;
     }
+    assert(b.is_compressed() || b.get_logical_length() == pos);
     b.extents.resize(1);
     b.extents[0].offset = bluestore_pextent_t::INVALID_OFFSET;
     b.extents[0].length = pos;
@@ -1861,9 +1862,12 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
     blob_offset,
     &(r->used_in_blob));
 
+  uint32_t llen_lb = 0;
+  uint32_t llen_rb = 0;
   for (auto p = lb.extents.begin(); p != lb.extents.end(); ++p, ++i) {
     if (p->length <= left) {
       left -= p->length;
+      llen_lb += p->length;
       continue;
     }
     if (left) {
@@ -1875,14 +1879,19 @@ void BlueStore::Blob::split(Collection *coll, uint32_t blob_offset, Blob *r)
 				  bluestore_pextent_t::INVALID_OFFSET,
 				  p->length - left));
       }
+      llen_rb += p->length - left;
+      llen_lb += left;
       p->length = left;
       ++i;
       ++p;
     }
     while (p != lb.extents.end()) {
+      llen_rb += p->length;
       rb.extents.push_back(*p++);
     }
     lb.extents.resize(i);
+    lb.logical_length = llen_lb;
+    rb.logical_length = llen_rb;
     break;
   }
   rb.flags = lb.flags;
@@ -9000,6 +9009,7 @@ int BlueStore::_do_alloc_write(
     }
     if (!compressed) {
       dblob.set_flag(bluestore_blob_t::FLAG_MUTABLE);
+      dblob.logical_length = final_length;
       if (l->length() != wi.blob_length) {
 	// hrm, maybe we could do better here, but let's not bother.
 	dout(20) << __func__ << " forcing csum_order to block_size_order "

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2273,6 +2273,13 @@ private:
     };
     vector<write_item> writes;                 ///< blobs we're writing
 
+    /// partial clone of the context
+    void fork(const WriteContext& other) {
+      buffered = other.buffered;
+      compress = other.compress;
+      target_blob_size = other.target_blob_size;
+      csum_order = other.csum_order;
+    }
     void write(
       BlobRef b,
       uint64_t blob_len,
@@ -2335,12 +2342,6 @@ private:
                       uint64_t length,
                       bufferlist& bl,
                       WriteContext *wctx);
-  void _do_garbage_collection(TransContext *txc,
-			      CollectionRef& c,
-			      OnodeRef o,
-			      uint64_t offset,
-			      uint64_t length,
-			      WriteContext *wctx);
 
   int _touch(TransContext *txc,
 	     CollectionRef& c,

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -626,30 +626,26 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.push_back(new bluestore_blob_t);
   ls.push_back(new bluestore_blob_t(0));
   ls.push_back(new bluestore_blob_t);
-  ls.back()->extents.push_back(bluestore_pextent_t(111, 222));
-  ls.back()->logical_length += 222;
+  ls.back()->allocated_test(bluestore_pextent_t(111, 222));
   ls.push_back(new bluestore_blob_t);
   ls.back()->init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
   ls.back()->csum_data = buffer::claim_malloc(4, strdup("abcd"));
-  ls.back()->extents.emplace_back(bluestore_pextent_t(0x40100000, 0x10000));
-  ls.back()->logical_length += 0x10000;
-  ls.back()->extents.emplace_back(
-    bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));
-  ls.back()->logical_length += 0x1000;
-  ls.back()->extents.emplace_back(bluestore_pextent_t(0x40120000, 0x10000));
   ls.back()->add_unused(0, 3);
   ls.back()->add_unused(8, 8);
-  ls.back()->logical_length += 0x10000;
+  ls.back()->allocated_test(bluestore_pextent_t(0x40100000, 0x10000));
+  ls.back()->allocated_test(
+    bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));
+  ls.back()->allocated_test(bluestore_pextent_t(0x40120000, 0x10000));
 }
 
 ostream& operator<<(ostream& out, const bluestore_blob_t& o)
 {
-  out << "blob(" << o.extents;
+  out << "blob(" << o.get_extents();
   if (o.is_compressed()) {
     out << " clen 0x" << std::hex
-	<< o.logical_length
+	<< o.get_logical_length()
 	<< " -> 0x"
-	<< o.compressed_length
+	<< o.get_compressed_payload_length()
 	<< std::dec;
   }
   if (o.flags) {
@@ -731,6 +727,194 @@ int bluestore_blob_t::verify_csum(uint64_t b_off, const bufferlist& bl,
     return -1; // bad checksum
   else
     return 0;
+}
+
+void bluestore_blob_t::allocated(const AllocExtentVector& allocs)
+{
+  assert(extents.size() == 0);
+  
+  // if blob is compressed then logical length to be already configured
+  // otherwise - to be unset.
+  assert( (is_compressed() && logical_length != 0) ||
+          (!is_compressed() && logical_length == 0));
+  extents.reserve(allocs.size());
+  for (auto& a : allocs) {
+    extents.emplace_back(a.offset, a.length);
+    if (!is_compressed()) {
+      logical_length += a.length;
+    }
+  }
+}
+
+// cut it out of extents
+struct vecbuilder {
+  PExtentVector v;
+  uint64_t invalid = 0;
+
+  void add_invalid(uint64_t length) {
+    invalid += length;
+  }
+  void flush() {
+    if (invalid) {
+      v.emplace_back(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
+	invalid));
+      invalid = 0;
+    }
+  }
+  void add(uint64_t offset, uint64_t length) {
+    if (offset == bluestore_pextent_t::INVALID_OFFSET) {
+      add_invalid(length);
+    }
+    else {
+      flush();
+      v.emplace_back(bluestore_pextent_t(offset, length));
+    }
+  }
+};
+
+void bluestore_blob_t::allocated_test(const bluestore_pextent_t& alloc)
+{
+  extents.emplace_back(alloc);
+  if (!is_compressed()) {
+    logical_length += alloc.length;
+  }
+}
+
+bool bluestore_blob_t::release_extents(bool all,
+				       const PExtentVector& logical,
+				       PExtentVector* r)
+{
+  // common case: all of it?
+  if (all) {
+    uint64_t pos = 0;
+    for (auto& e : extents) {
+      if (e.is_valid()) {
+	r->push_back(e);
+      }
+      pos += e.length;
+    }
+    assert(is_compressed() || get_logical_length() == pos);
+    extents.resize(1);
+    extents[0].offset = bluestore_pextent_t::INVALID_OFFSET;
+    extents[0].length = pos;
+    return true;
+  }
+  // remove from pextents according to logical release list
+  vecbuilder vb;
+  auto loffs_it = logical.begin();
+  auto lend = logical.end();
+  uint32_t pext_loffs_start = 0; //starting loffset of the current pextent
+  uint32_t pext_loffs = 0; //current loffset
+  auto pext_it = extents.begin();
+  auto pext_end = extents.end();
+  while (pext_it != pext_end) {
+    if (loffs_it == lend ||
+        pext_loffs_start + pext_it->length <= loffs_it->offset) {
+      int delta0 = pext_loffs - pext_loffs_start;
+      assert(delta0 >= 0);
+      if ((uint32_t)delta0 < pext_it->length) {
+	vb.add(pext_it->offset + delta0, pext_it->length - delta0);
+      }
+      pext_loffs_start += pext_it->length;
+      pext_loffs = pext_loffs_start;
+      ++pext_it;
+    }
+    else {
+      //assert(pext_loffs == pext_loffs_start);
+      int delta0 = pext_loffs - pext_loffs_start;
+      assert(delta0 >= 0);
+
+      int delta = loffs_it->offset - pext_loffs;
+      assert(delta >= 0);
+      if (delta > 0) {
+	vb.add(pext_it->offset + delta0, delta);
+	pext_loffs += delta;
+      }
+
+      PExtentVector::iterator last_r = r->end();
+      if (r->begin() != last_r) {
+	--last_r;
+      }
+      uint32_t to_release = loffs_it->length;
+      do {
+	uint32_t to_release_part =
+	  MIN(pext_it->length - delta0 - delta, to_release);
+	auto o = pext_it->offset + delta0 + delta;
+	if (last_r != r->end() && last_r->offset + last_r->length == o) {
+	  last_r->length += to_release_part;
+	}
+	else {
+	  last_r = r->emplace(r->end(), o, to_release_part);
+	}
+	to_release -= to_release_part;
+	pext_loffs += to_release_part;
+	if (pext_loffs == pext_loffs_start + pext_it->length) {
+	  pext_loffs_start += pext_it->length;
+	  pext_loffs = pext_loffs_start;
+	  pext_it++;
+	  delta0 = delta = 0;
+	}
+      } while (to_release > 0 && pext_it != pext_end);
+      vb.add_invalid(loffs_it->length - to_release);
+      ++loffs_it;
+    }
+  }
+  vb.flush();
+  extents.swap(vb.v);
+  return false;
+}
+
+void bluestore_blob_t::split(uint32_t blob_offset, bluestore_blob_t& rb)
+{
+  size_t left = blob_offset;
+  uint32_t llen_lb = 0;
+  uint32_t llen_rb = 0;
+  unsigned i = 0;
+  for (auto p = extents.begin(); p != extents.end(); ++p, ++i) {
+    if (p->length <= left) {
+      left -= p->length;
+      llen_lb += p->length;
+      continue;
+    }
+    if (left) {
+      if (p->is_valid()) {
+	rb.extents.emplace_back(bluestore_pextent_t(p->offset + left,
+	  p->length - left));
+      }
+      else {
+	rb.extents.emplace_back(bluestore_pextent_t(
+	  bluestore_pextent_t::INVALID_OFFSET,
+	  p->length - left));
+      }
+      llen_rb += p->length - left;
+      llen_lb += left;
+      p->length = left;
+      ++i;
+      ++p;
+    }
+    while (p != extents.end()) {
+      llen_rb += p->length;
+      rb.extents.push_back(*p++);
+    }
+    extents.resize(i);
+    logical_length = llen_lb;
+    rb.logical_length = llen_rb;
+    break;
+  }
+  rb.flags = flags;
+
+  if (has_csum()) {
+    rb.csum_type = csum_type;
+    rb.csum_chunk_order = csum_chunk_order;
+    size_t csum_order = get_csum_chunk_size();
+    assert(blob_offset % csum_order == 0);
+    size_t pos = (blob_offset / csum_order) * get_csum_value_size();
+    // deep copy csum data
+    bufferptr old;
+    old.swap(csum_data);
+    rb.csum_data = bufferptr(old.c_str() + pos, old.length() - pos);
+    csum_data = bufferptr(old.c_str(), pos);
+  }
 }
 
 // bluestore_shared_blob_t

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -608,7 +608,7 @@ void bluestore_blob_t::dump(Formatter *f) const
     f->dump_object("extent", p);
   }
   f->close_section();
-  f->dump_unsigned("compressed_length_original", compressed_length_orig);
+  f->dump_unsigned("logical_length", logical_length);
   f->dump_unsigned("compressed_length", compressed_length);
   f->dump_unsigned("flags", flags);
   f->dump_unsigned("csum_type", csum_type);
@@ -627,15 +627,19 @@ void bluestore_blob_t::generate_test_instances(list<bluestore_blob_t*>& ls)
   ls.push_back(new bluestore_blob_t(0));
   ls.push_back(new bluestore_blob_t);
   ls.back()->extents.push_back(bluestore_pextent_t(111, 222));
+  ls.back()->logical_length += 222;
   ls.push_back(new bluestore_blob_t);
   ls.back()->init_csum(Checksummer::CSUM_XXHASH32, 16, 65536);
   ls.back()->csum_data = buffer::claim_malloc(4, strdup("abcd"));
   ls.back()->extents.emplace_back(bluestore_pextent_t(0x40100000, 0x10000));
+  ls.back()->logical_length += 0x10000;
   ls.back()->extents.emplace_back(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x1000));
+  ls.back()->logical_length += 0x1000;
   ls.back()->extents.emplace_back(bluestore_pextent_t(0x40120000, 0x10000));
   ls.back()->add_unused(0, 3);
   ls.back()->add_unused(8, 8);
+  ls.back()->logical_length += 0x10000;
 }
 
 ostream& operator<<(ostream& out, const bluestore_blob_t& o)
@@ -643,7 +647,7 @@ ostream& operator<<(ostream& out, const bluestore_blob_t& o)
   out << "blob(" << o.extents;
   if (o.is_compressed()) {
     out << " clen 0x" << std::hex
-	<< o.compressed_length_orig
+	<< o.logical_length
 	<< " -> 0x"
 	<< o.compressed_length
 	<< std::dec;

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5744,6 +5744,13 @@ TEST_P(StoreTestSpecificAUSize, OnodeSizeTracking) {
   ASSERT_NE(total_bytes, 0u);
   ASSERT_EQ(total_onodes, 1u);
 
+  {
+    ObjectStore::Transaction t;
+    t.truncate(cid, hoid, 0);
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+ 
   for(size_t i = 0; i < 1; ++i) {
     bufferlist bl;
     bl.append(std::string(block_size * (i+1), 'a'));

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5844,8 +5844,6 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
     bufferlist bl;
 
     bl.append(std::string(block_size, 'b'));
-    t.zero(cid, hoid, 0, bl.length()); // Currently we are unable to reuse blob
-                                       // when overwriting  in a single step
     t.write(cid, hoid, 0, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
@@ -5891,7 +5889,6 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
     bl.append(std::string(block_size * 2, 'e'));
 
     // Currently we are unable to reuse blob when overwriting in a single step
-    t.zero(cid, hoid, block_size * 6, bl.length());
     t.write(cid, hoid, block_size * 6, bl.length(), bl, CEPH_OSD_OP_FLAG_FADVISE_WILLNEED);
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1224,7 +1224,7 @@ TEST(GarbageCollector, BasicTest)
   BlueStore::Onode onode(coll.get(), ghobject_t(), "");
   BlueStore::ExtentMap em(&onode);
 
-  BlueStore::extent_map_t old_extents;
+  BlueStore::old_extent_map_t old_extents;
 
 
  /*
@@ -1273,8 +1273,7 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(4096, 0, 10, b3));
     b3->get_ref(coll.get(), 0, 10);
 
-    old_extents.push_back(*new BlueStore::Extent(300, 300, 10, b1)); 
-    b1->get_ref(coll.get(), 300, 10);
+    old_extents.push_back(*new BlueStore::OldExtent(300, 300, 10, b1)); 
 
     saving = gc.estimate(300, 100, em, old_extents, 4096);
     ASSERT_EQ(saving, 1);
@@ -1310,7 +1309,7 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
     BlueStore::ExtentMap em(&onode);
 
-    BlueStore::extent_map_t old_extents;
+    BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
     BlueStore::BlobRef b1(new BlueStore::Blob);
@@ -1341,13 +1340,10 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x3f000, 0x1000, b1));
     b1->get_ref(coll.get(), 0x3f000, 0x1000);
 
-    old_extents.push_back(*new BlueStore::Extent(0x8000, 0x8000, 0x8000, b1)); 
-    b1->get_ref(coll.get(), 0x8000, 0x8000);
+    old_extents.push_back(*new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b1)); 
     old_extents.push_back(
-      *new BlueStore::Extent(0x10000, 0x10000, 0x20000, b1));
-    b1->get_ref(coll.get(), 0x10000, 0x20000);
-    old_extents.push_back(*new BlueStore::Extent(0x30000, 0x30000, 0xf000, b1)); 
-    b1->get_ref(coll.get(), 0x30000, 0xf000);
+      *new BlueStore::OldExtent(0x10000, 0x10000, 0x20000, b1));
+    old_extents.push_back(*new BlueStore::OldExtent(0x30000, 0x30000, 0xf000, b1)); 
 
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);
@@ -1393,8 +1389,7 @@ TEST(GarbageCollector, BasicTest)
       *new BlueStore::Extent(0x3000, 0, 0x4000, b2)); // new extent
     b2->get_ref(coll.get(), 0, 0x4000);
 
-    old_extents.push_back(*new BlueStore::Extent(0x3000, 0x3000, 0x1000, b1)); 
-    b1->get_ref(coll.get(), 0x3000, 0x1000);
+    old_extents.push_back(*new BlueStore::OldExtent(0x3000, 0x3000, 0x1000, b1)); 
 
     saving = gc.estimate(0x3000, 0x4000, em, old_extents, 0x1000);
     ASSERT_EQ(saving, 0);
@@ -1430,7 +1425,7 @@ TEST(GarbageCollector, BasicTest)
     BlueStore::Onode onode(coll.get(), ghobject_t(), "");
     BlueStore::ExtentMap em(&onode);
 
-    BlueStore::extent_map_t old_extents;
+    BlueStore::old_extent_map_t old_extents;
     BlueStore::GarbageCollector gc(g_ceph_context);
     int64_t saving;
     BlueStore::BlobRef b0(new BlueStore::Blob);
@@ -1465,14 +1460,11 @@ TEST(GarbageCollector, BasicTest)
     em.extent_map.insert(*new BlueStore::Extent(0x3f000, 0x1f000, 0x1000, b1));
     b1->get_ref(coll.get(), 0x1f000, 0x1000);
 
-    old_extents.push_back(*new BlueStore::Extent(0x8000, 0x8000, 0x8000, b0)); 
-    b0->get_ref(coll.get(), 0x8000, 0x8000);
+    old_extents.push_back(*new BlueStore::OldExtent(0x8000, 0x8000, 0x8000, b0)); 
     old_extents.push_back(
-      *new BlueStore::Extent(0x10000, 0x10000, 0x10000, b0)); 
-    b0->get_ref(coll.get(), 0x10000, 0x10000);
+      *new BlueStore::OldExtent(0x10000, 0x10000, 0x10000, b0)); 
     old_extents.push_back(
-      *new BlueStore::Extent(0x20000, 0x00000, 0x1f000, b1)); 
-    b1->get_ref(coll.get(), 0x0, 0x1f000);
+      *new BlueStore::OldExtent(0x20000, 0x00000, 0x1f000, b1)); 
 
     saving = gc.estimate(0x30000, 0xf000, em, old_extents, 0x10000);
     ASSERT_EQ(saving, 2);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -332,6 +332,7 @@ TEST(Blob, put_ref)
     b.dirty_blob().extents.push_back(
       bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x8000));
     b.dirty_blob().extents.push_back(bluestore_pextent_t(0x4071f000, 0x5000));
+    b.dirty_blob().logical_length = b.get_blob().get_ondisk_length();
     b.get_ref(&coll, 0, 0x1200);
     b.get_ref(&coll, 0xae00, 0x4200);
     ASSERT_EQ(0x5400u, b.get_referenced_bytes());
@@ -363,6 +364,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(0, mas*2));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*2);
     ASSERT_EQ(mas * 2, B.get_referenced_bytes());
     ASSERT_TRUE(b.is_allocated(0, mas*2));
@@ -385,6 +387,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(123, mas*2));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*2);
     ASSERT_EQ(mas * 2, B.get_referenced_bytes());
     B.put_ref(coll.get(), 0, mas, &r);
@@ -413,6 +416,7 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(2, mas));
     b.extents.push_back(bluestore_pextent_t(3, mas));
     b.extents.push_back(bluestore_pextent_t(4, mas));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*4);
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -454,6 +458,7 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(4, mas));
     b.extents.push_back(bluestore_pextent_t(5, mas));
     b.extents.push_back(bluestore_pextent_t(6, mas));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*6);
     ASSERT_EQ(mas * 6, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -491,6 +496,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 6));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*6);
     ASSERT_EQ(mas * 6, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -526,6 +532,7 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -565,6 +572,7 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -621,6 +629,7 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(1, mas * 4));
     b.extents.push_back(bluestore_pextent_t(2, mas * 4));
     b.extents.push_back(bluestore_pextent_t(3, mas * 4));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*12);
     ASSERT_EQ(mas * 12, B.get_referenced_bytes());
     B.put_ref(coll.get(), mas, mas, &r);
@@ -675,6 +684,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(1, mas * 8));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0, mas*8);
     ASSERT_EQ(mas * 8, B.get_referenced_bytes());
     B.put_ref(coll.get(), 0, mas, &r);
@@ -719,6 +729,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     PExtentVector r;
     b.extents.push_back(bluestore_pextent_t(0, mas*4));
+    b.logical_length = b.get_ondisk_length();
     b.init_csum(Checksummer::CSUM_CRC32C, 14, mas * 4);
     B.get_ref(coll.get(), 0, mas*4);
     ASSERT_EQ(mas * 4, B.get_referenced_bytes());
@@ -740,7 +751,8 @@ TEST(Blob, put_ref)
     b.extents.push_back(bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET,
 					    0x13000));
     b.extents.push_back(bluestore_pextent_t(0x40118000, 0x7000));
-    B.get_ref(coll.get(), 0x0, 0x3800);
+    b.logical_length = b.get_ondisk_length();
+    B.get_ref(coll.get(0, 0x0, 0x3800);
     B.get_ref(coll.get(), 0x17c00, 0x6400);
     ASSERT_EQ(0x3800u + 0x6400u, B.get_referenced_bytes());
     b.set_flag(bluestore_blob_t::FLAG_SHARED);
@@ -760,7 +772,8 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     b.extents.push_back(bluestore_pextent_t(1, 0x5000));
     b.extents.push_back(bluestore_pextent_t(2, 0x5000));
-    B.get_ref(coll.get(), 0x0, 0xa000);
+    b.logical_length = b.get_ondisk_length();
+    B.get_ref(coll.get(0, 0x0, 0xa000);
     ASSERT_EQ(0xa000u, B.get_referenced_bytes());
     cout << "before: " << B << std::endl;
     PExtentVector r;
@@ -779,6 +792,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     b.extents.push_back(bluestore_pextent_t(1, 0x7000));
     b.extents.push_back(bluestore_pextent_t(2, 0x7000));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0x0, 0xe000);
     ASSERT_EQ(0xe000u, B.get_referenced_bytes());
     cout << "before: " << B << std::endl;
@@ -806,6 +820,7 @@ TEST(Blob, put_ref)
     bluestore_blob_t& b = B.dirty_blob();
     b.extents.push_back(bluestore_pextent_t(1, 0x5000));
     b.extents.push_back(bluestore_pextent_t(2, 0x7000));
+    b.logical_length = b.get_ondisk_length();
     B.get_ref(coll.get(), 0x0, 0xc000);
     ASSERT_EQ(0xc000u, B.get_referenced_bytes());
     cout << "before: " << B << std::endl;
@@ -861,6 +876,7 @@ TEST(bluestore_blob_t, prune_tail)
   ASSERT_FALSE(a.can_prune_tail());
   a.extents.emplace_back(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+  a.logical_length = 0x2000 * 3;
   ASSERT_TRUE(a.can_prune_tail());
   a.prune_tail();
   ASSERT_FALSE(a.can_prune_tail());
@@ -869,6 +885,7 @@ TEST(bluestore_blob_t, prune_tail)
 
   a.extents.emplace_back(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+  a.logical_length += 0x2000;
   a.init_csum(Checksummer::CSUM_CRC32C_8, 12, 0x6000);
   ASSERT_EQ(6u, a.csum_data.length());
   ASSERT_TRUE(a.can_prune_tail());
@@ -881,6 +898,7 @@ TEST(bluestore_blob_t, prune_tail)
   bluestore_blob_t b;
   b.extents.emplace_back(
     bluestore_pextent_t(bluestore_pextent_t::INVALID_OFFSET, 0x2000));
+  a.logical_length += 0x2000;
   ASSERT_FALSE(a.can_prune_tail());
 }
 
@@ -897,6 +915,7 @@ TEST(Blob, split)
     R.shared_blob = new BlueStore::SharedBlob(coll.get());
     R.shared_blob->get();  // hack to avoid dtor from running
     L.dirty_blob().extents.emplace_back(bluestore_pextent_t(0x2000, 0x2000));
+    L.dirty_blob().logical_length = L.get_blob().get_ondisk_length();
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     L.get_ref(coll.get(), 0, 0x2000);
     L.split(coll.get(), 0x1000, &R);
@@ -921,6 +940,7 @@ TEST(Blob, split)
     R.shared_blob->get();  // hack to avoid dtor from running
     L.dirty_blob().extents.emplace_back(bluestore_pextent_t(0x2000, 0x1000));
     L.dirty_blob().extents.emplace_back(bluestore_pextent_t(0x12000, 0x1000));
+    L.dirty_blob().logical_length = L.get_blob().get_ondisk_length();
     L.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
     L.get_ref(coll.get(), 0, 0x1000);
     L.get_ref(coll.get(), 0x1000, 0x1000);
@@ -952,6 +972,7 @@ TEST(Blob, legacy_decode)
     B.shared_blob = new BlueStore::SharedBlob(coll.get());
     B.dirty_blob().extents.emplace_back(bluestore_pextent_t(0x1, 0x2000));
     B.dirty_blob().init_csum(Checksummer::CSUM_CRC32C, 12, 0x2000);
+    B.dirty_blob().logical_length = B.get_blob().get_ondisk_length();
     B.get_ref(coll.get(), 0, 0xff0);
     B.get_ref(coll.get(), 0x1fff, 1);
 
@@ -1258,12 +1279,15 @@ TEST(GarbageCollector, BasicTest)
     b3->shared_blob = new BlueStore::SharedBlob(coll.get());
     b4->shared_blob = new BlueStore::SharedBlob(coll.get());
     b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
-    b1->dirty_blob().compressed_length_orig = 0x2000;
+    b1->dirty_blob().logical_length = 0x2000;
     b1->dirty_blob().compressed_length = 0x1000;
     b1->dirty_blob().extents.emplace_back(0, 0x1000);
     b2->dirty_blob().extents.emplace_back(1, 0x1000);
+    b2->dirty_blob().logical_length = b2->get_blob().get_ondisk_length();
     b3->dirty_blob().extents.emplace_back(2, 0x1000);
+    b3->dirty_blob().logical_length = b3->get_blob().get_ondisk_length();
     b4->dirty_blob().extents.emplace_back(3, 0x1000);
+    b4->dirty_blob().logical_length = b4->get_blob().get_ondisk_length();
     em.extent_map.insert(*new BlueStore::Extent(100, 100, 10, b1));
     b1->get_ref(coll.get(), 100, 10);
     em.extent_map.insert(*new BlueStore::Extent(200, 200, 10, b2));
@@ -1324,10 +1348,13 @@ TEST(GarbageCollector, BasicTest)
     b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
     b1->dirty_blob().extents.emplace_back(0, 0x20000);
     b1->dirty_blob().compressed_length = 0x20000;
-    b1->dirty_blob().compressed_length_orig = 0x40000;
+    b1->dirty_blob().logical_length = 0x40000;
     b2->dirty_blob().extents.emplace_back(1, 0x10000);
+    b2->dirty_blob().logical_length = b2->get_blob().get_ondisk_length();
     b3->dirty_blob().extents.emplace_back(2, 0x20000);
+    b3->dirty_blob().logical_length = b3->get_blob().get_ondisk_length();
     b4->dirty_blob().extents.emplace_back(3, 0x10000);
+    b4->dirty_blob().logical_length = b4->get_blob().get_ondisk_length();
 
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b1));
     b1->get_ref(coll.get(), 0, 0x8000);
@@ -1386,11 +1413,11 @@ TEST(GarbageCollector, BasicTest)
     b2->shared_blob = new BlueStore::SharedBlob(coll.get());
     b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
     b1->dirty_blob().extents.emplace_back(0, 0x2000);
-    b1->dirty_blob().compressed_length_orig = 0x4000;
+    b1->dirty_blob().logical_length = 0x4000;
     b1->dirty_blob().compressed_length = 0x2000;
     b2->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
     b2->dirty_blob().extents.emplace_back(0, 0x2000);
-    b2->dirty_blob().compressed_length_orig = 0x4000;
+    b2->dirty_blob().logical_length = 0x4000;
     b2->dirty_blob().compressed_length = 0x2000;
 
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x3000, b1));
@@ -1451,15 +1478,18 @@ TEST(GarbageCollector, BasicTest)
     b4->shared_blob = new BlueStore::SharedBlob(coll.get());
     b0->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
     b0->dirty_blob().extents.emplace_back(0, 0x10000);
-    b0->dirty_blob().compressed_length_orig = 0x20000;
+    b0->dirty_blob().logical_length = 0x20000;
     b0->dirty_blob().compressed_length = 0x10000;
     b1->dirty_blob().set_flag(bluestore_blob_t::FLAG_COMPRESSED);
     b1->dirty_blob().extents.emplace_back(0, 0x10000);
-    b1->dirty_blob().compressed_length_orig = 0x20000;
+    b1->dirty_blob().logical_length = 0x20000;
     b1->dirty_blob().compressed_length = 0x10000;
     b2->dirty_blob().extents.emplace_back(1, 0x10000);
+    b2->dirty_blob().logical_length = b2->get_blob().get_ondisk_length();
     b3->dirty_blob().extents.emplace_back(2, 0x20000);
+    b3->dirty_blob().logical_length = b3->get_blob().get_ondisk_length();
     b4->dirty_blob().extents.emplace_back(3, 0x1000);
+    b4->dirty_blob().logical_length = b4->get_blob().get_ondisk_length();
 
     em.extent_map.insert(*new BlueStore::Extent(0, 0, 0x8000, b0));
     b0->get_ref(coll.get(), 0, 0x8000);


### PR DESCRIPTION
We can reuse blob when appending/overwriting some extent instead of allocating another one.
This reduces reference Onode (4Mb total /4K AU) mem usage from 280K to ~32K (max_blob_size=64K and min_alloc_size = 4K)
Read performance is greatly improved too.
