### PR TITLE
ceph.spec.in, debian/control: Add bc to build dependencies

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -95,6 +95,7 @@ BuildRequires:	checkpolicy
 BuildRequires:	selinux-policy-devel
 BuildRequires:	/usr/share/selinux/devel/policyhelp
 %endif
+BuildRequires:	bc
 BuildRequires:	boost-devel
 %if ! 0%{?suse_version}
 BuildRequires:	boost-python

--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,8 @@ Vcs-Browser: https://github.com/ceph/ceph
 Maintainer: Ceph Maintainers <ceph-maintainers@lists.ceph.com>
 Uploaders: Ken Dreyer <kdreyer@redhat.com>,
            Alfredo Deza <adeza@redhat.com>
-Build-Depends: btrfs-tools,
+Build-Depends: bc,
+               btrfs-tools,
 	       cmake,
                cpio,
 	       cryptsetup-bin | cryptsetup,


### PR DESCRIPTION
The bc is missing for ceph-helpers.sh

Fixes: http://tracker.ceph.com/issues/18876
Signed-off-by: Kyr Shatskyy <kyrylo.shatskyy@gmail.com>