### PR TITLE
common: include/ceph_features.h uses uint64_t, which is in sys/types.h

### DIFF
--- a/src/include/ceph_features.h
+++ b/src/include/ceph_features.h
@@ -1,6 +1,7 @@
 #ifndef __CEPH_FEATURES
 #define __CEPH_FEATURES
 
+#include "sys/types.h"
 
 /*
  * Each time we reclaim bits for reuse we need to specify another bit


### PR DESCRIPTION
When compiling with Clang on FreeBSD there are lots of errors about
missing uint64_t:
In file included from /home/jenkins/workspace/ceph-master/src/msg/msg_types.cc:2:
In file included from /home/jenkins/workspace/ceph-master/src/msg/msg_types.h:20:
/home/jenkins/workspace/ceph-master/src/include/ceph_features.h:71:1: error: unknown type name 'uint64_t'
DEFINE_CEPH_FEATURE( 0, 1, UID)
^
/home/jenkins/workspace/ceph-master/src/include/ceph_features.h:14:15: note: expanded from macro 'DEFINE_CEPH_FEATURE'
        const static uint64_t CEPH_FEATURE_##name = (1ULL<<bit);                \

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>