### PR TITLE
osd/: don't leak context for Blessed*Context or RecoveryQueueAsync

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -47,13 +47,13 @@ class PG_SendMessageOnConn: public Context {
 
 class PG_RecoveryQueueAsync : public Context {
   PGBackend::Listener *pg;
-  GenContext<ThreadPool::TPHandle&> *c;
+  unique_ptr<GenContext<ThreadPool::TPHandle&>> c;
   public:
   PG_RecoveryQueueAsync(
     PGBackend::Listener *pg,
     GenContext<ThreadPool::TPHandle&> *c) : pg(pg), c(c) {}
   void finish(int) {
-    pg->schedule_recovery_work(c);
+    pg->schedule_recovery_work(c.release());
   }
 };
 }


### PR DESCRIPTION
This has always been a bug, but until
68defc2b0561414711d4dd0a76bc5d0f46f8a3f8, nothing deleted those contexts
without calling complete().

Fixes: http://tracker.ceph.com/issues/18809
Bug shadowed until: 68defc2b0561414711d4dd0a76bc5d0f46f8a3f8
Signed-off-by: Samuel Just <sjust@redhat.com>