### PR TITLE
qa/test: use only raw device for osd's

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -430,6 +430,10 @@ def cluster(ctx, config):
     osds = ctx.cluster.only(teuthology.is_type('osd', cluster_name))
     for remote, roles_for_host in osds.remotes.iteritems():
         devs = teuthology.get_scratch_devices(remote)
+        need_osds = [role for role in roles_for_host if role.startswith('osd')]
+        if len(need_osds) > len(devs):
+            log.info("Need %d devices, Available %s" % (len(need_osds), str(devs)))
+            raise CephInsufficientDevError("Insufficient number of raw devices on remote host")
         roles_to_devs = {}
         roles_to_journals = {}
         if config.get('fs'):
@@ -1402,6 +1406,10 @@ def validate_config(ctx, config):
                 raise exceptions.ConfigError(msg)
             last_cluster = role_cluster
             last_role = role
+
+
+class CephInsufficientDevError(Exception):
+    pass
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
avoid running tests using osd's on directory, eventually
they fail due to osd init error(long file name) but at
much later point.

Fixes: http://tracker.ceph.com/issues/18874

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>