### PR TITLE
mds/StrayManager: avoid reusing deleted inode in StrayManager::_purge_stray_logged

### DIFF
--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -301,11 +301,6 @@ void StrayManager::_purge_stray_logged(CDentry *dn, version_t pdv, LogSegment *l
   dn->state_clear(CDentry::STATE_PURGING | CDentry::STATE_PURGINGPINNED);
   dn->put(CDentry::PIN_PURGING);
 
-  // drop inode
-  if (in->is_dirty())
-    in->mark_clean();
-  in->mdcache->remove_inode(in);
-
   // drop dentry?
   if (dn->is_new()) {
     dout(20) << " dn is new, removing" << dendl;
@@ -314,6 +309,11 @@ void StrayManager::_purge_stray_logged(CDentry *dn, version_t pdv, LogSegment *l
   } else {
     in->mdcache->touch_dentry_bottom(dn);  // drop dn as quickly as possible.
   }
+
+  // drop inode
+  if (in->is_dirty())
+    in->mark_clean();
+  in->mdcache->remove_inode(in);
 }
 
 void StrayManager::enqueue(CDentry *dn, bool trunc)


### PR DESCRIPTION
This issue was found by testing another PR (https://github.com/ceph/ceph/pull/12792), which makes MDS directly uses TCMALLOC, not boost::pool. When the version of TCMALLOC is 4.2.6 or above, removing directory will cause MDS crash.

`assert((o->lru_list == & lru_pintail) || (o->lru_list ==&lru_top) || (o->lru_list == &lru_b))`

The root cause is that in StrayManager::_purge_stray_logged, inode will delete itself firstly, then it tries to drop dentry via this deleted inode. I think it should be the new version of TCMALLOC to expose this issue more easily and obviously.

The fix here is to reorder the dropping sequence. Tests have passed with following test cases:

1. boost::pool with TCMALLOC 4.2.6
2. only TCMALLOC 4.2.6
3. boost::pool with TCMALLOC 4.1.2
4. only TCMALLOC 4.1.2

Fixes: http://tracker.ceph.com/issues/18877

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>