### PR TITLE
remove unnecessary check of collide

### DIFF
--- a/src/crush/crush_compat.h
+++ b/src/crush/crush_compat.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdbool.h>
 
 /* asm-generic/bug.h */
 


### PR DESCRIPTION
The check logic is out of choosing item. So puting the check
logic into the choosing.

Signed-off-by: tianqing <tianqing@unitedstack.com>