### PR TITLE
rgw: fix error code of inexistence of versions location in swift api

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6129,11 +6129,14 @@ int RGWRados::swift_versioning_copy(RGWObjectCtx& obj_ctx,
   r = get_bucket_info(obj_ctx, bucket_info.bucket.tenant, bucket_info.swift_ver_location, dest_bucket_info, NULL, NULL);
   if (r < 0) {
     ldout(cct, 10) << "failed to read dest bucket info: r=" << r << dendl;
+    if (r == -ENOENT) {
+      return -ERR_PRECONDITION_FAILED;
+    }
     return r;
   }
 
   if (dest_bucket_info.owner != bucket_info.owner) {
-    return -EPERM;
+    return -ERR_PRECONDITION_FAILED;
   }
 
   rgw_obj dest_obj(dest_bucket_info.bucket, buf);


### PR DESCRIPTION
when the versions location of container does not exist and uploading the same object two more times to the container, it will return 412 rather than 404 in openstack swift.

http://tracker.ceph.com/issues/18880
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>