### PR TITLE
init-ceph: print trailing n in "status" output

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -462,7 +462,8 @@ for name in $what; do
 	status)
 	    if daemon_is_running $name ceph-$type $id $pid_file; then
 		printf "$name: running "
-		do_cmd "$BINDIR/ceph --admin-daemon $asok version 2>/dev/null" || echo unknown
+		do_cmd "$BINDIR/ceph daemon $name version 2>/dev/null" || printf unknown
+		printf "\n"
             elif [ -e "$pid_file" ]; then
                 # daemon is dead, but pid file still exists
                 echo "$name: dead."


### PR DESCRIPTION
the version command is handled by HelpHook, which does not print newline
at the end of the returned JSON. so the output of "status" subcommand
looks like:

=== osd.1 ===
osd.1: running {"version":"Development"}=== osd.2 ===
osd.2: not running.

with this change, a newline is added to the end of version.

Signed-off-by: Kefu Chai <kchai@redhat.com>