### PR TITLE
osd: when the osd pre_init we should also consider conf change

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1757,8 +1757,10 @@ void OSD::handle_signal(int signum)
 int OSD::pre_init()
 {
   Mutex::Locker lock(osd_lock);
-  if (is_stopping())
+  if (is_stopping()) {
+    cct->_conf->add_observer(this);
     return 0;
+  }
 
   if (store->test_mount_in_use()) {
     derr << "OSD::pre_init: object store '" << dev_path << "' is "


### PR DESCRIPTION
osd:  when the osd pre_init we should also consider conf change
  
  when the osd pre_init, if the osd do not exit when osd in the state
  stoping. we should also consider the conf change.

Signed-off-by: song baisen <song.baisen@zte.com.cn>