### PR TITLE
osd: fix the setting of soid in sub_op_push

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -2353,7 +2353,7 @@ void ReplicatedBackend::sub_op_push(OpRequestRef op)
   MOSDSubOp *m = static_cast<MOSDSubOp *>(op->get_req());
 
   PushOp pop;
-  pop.soid = m->recovery_info.soid;
+  pop.soid = m->poid;
   pop.version = m->version;
   m->claim_data(pop.data);
   pop.data_included.swap(m->data_included);


### PR DESCRIPTION
In the case of recovery pull using sub op, and if the prep push on
remote peers fail for some reasons, recovery_info.soid is not set
in prep_push_op_blank. Use it on the primary would lead to an
assertion failure.

Signed-off-by: Zhiqiang Wang <zhiqiang@xsky.com>