### PR TITLE
crush: ruleset is out of scope in CrushTester::test_with_crushtool

### DIFF
--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -364,6 +364,7 @@ int CrushTester::test_with_crushtool(const string& crushtool,
 {
   string timeout_string = stringify(timeout);
   string opt_max_id = stringify(max_id);
+  string opt_ruleset = stringify(ruleset);
   vector<const char *> cmd_args;
   cmd_args.push_back("timeout");
   cmd_args.push_back(timeout_string.c_str());
@@ -379,7 +380,7 @@ int CrushTester::test_with_crushtool(const string& crushtool,
   cmd_args.push_back("50");
   if (ruleset >= 0) {
     cmd_args.push_back("--ruleset");
-    cmd_args.push_back(stringify(ruleset).c_str());
+    cmd_args.push_back(opt_ruleset.c_str());
   }
   cmd_args.push_back(NULL);
 


### PR DESCRIPTION
I got the orgin params with strace like this:
 ["timeout", "5", "crushtool", "-i", "-", "--test", "--check", "49", "--min-x", "1", "--max-x", "50", "--ruleset", ""]

This will cause  creating  pool fail:
Error EINVAL: error running crushmap through crushtool: (1) Operation not permitted