### PR TITLE
doc: improve firewalld instructions

### DIFF
--- a/doc/start/quick-start-preflight.rst
+++ b/doc/start/quick-start-preflight.rst
@@ -284,11 +284,21 @@ On some distributions (e.g., RHEL), the default firewall configuration is fairly
 strict. You may need to adjust your firewall settings allow inbound requests so
 that clients in your network can communicate with daemons on your Ceph nodes.
 
-For ``firewalld`` on RHEL 7, add port ``6789`` for Ceph Monitor nodes and ports
-``6800:7300`` for Ceph OSDs to the public zone and ensure that you make the
-setting permanent so that it is enabled on reboot. For example::
+For ``firewalld`` on RHEL 7, add the ``ceph-mon`` service for Ceph Monitor
+nodes and the ``ceph`` service for Ceph OSDs and MDSs to the public zone and
+ensure that you make the settings permanent so that they are enabled on reboot.
 
-	sudo firewall-cmd --zone=public --add-port=6789/tcp --permanent
+For example, on monitors::
+
+	sudo firewall-cmd --zone=public --add-service=ceph-mon --permanent
+
+and on OSDs and MDSs::
+
+	sudo firewall-cmd --zone=public --add-service=ceph --permanent
+
+Once you have finished configuring firewalld with the ``--permanent`` flag, you can make the changes live immediately without rebooting::
+
+	sudo firewall-cmd --reload
 
 For ``iptables``, add port ``6789`` for Ceph Monitors and ports ``6800:7300``
 for Ceph OSDs. For example::


### PR DESCRIPTION
firewalld in RHEL 7.3 contains service definitions for ceph's ports, so we can simply use `--add-service=ceph-mon` or `--add-service=ceph` rather than having to remember specific port numbers.

Break out two examples for both MONs and OSDs/MDSs.

Add the `firewall-cmd --reload` step to ensure the `--permanent` configs take effect immediately.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>