### PR TITLE
rbdmap: consider /etc/ceph/rbdmap when unmapping images

### DIFF
--- a/doc/man/8/rbdmap.rst
+++ b/doc/man/8/rbdmap.rst
@@ -25,7 +25,7 @@ at shutdown), as triggered by the init system (a systemd unit file,
 
 The script takes a single argument, which can be either "map" or "unmap".
 In either case, the script parses a configuration file (defaults to ``/etc/ceph/rbdmap``,
-but can be overrided via an  environment variable ``RBDMAPFILE``). Each line
+but can be overridden via an environment variable ``RBDMAPFILE``). Each line
 of the configuration file corresponds to an RBD image which is to be mapped, or
 unmapped.
 
@@ -51,8 +51,12 @@ When run as ``rbdmap map``, the script parses the configuration file, and for
 each RBD image specified attempts to first map the image (using the ``rbd map``
 command) and, second, to mount the image.
 
-When run as ``rbd unmap``, the script parses the configuration file, and
-attempts to first unmount, and then unmap, each image specified.
+When run as ``rbdmap unmap``, images listed in the configuration file will
+be unmounted and unmapped.
+
+``rbdmap unmap-all`` attempts to unmount and subsequently unmap all currently
+mapped RBD images, regardless of whether or not they're listed in the
+configuration file.
 
 If successful, the ``rbd map`` operation maps the image to a ``/dev/rbdX``
 device, at which point a udev rule is triggered to create a friendly device

--- a/src/rbdmap
+++ b/src/rbdmap
@@ -1,15 +1,6 @@
 #!/bin/bash
 
 do_map() {
-
-        # default to reasonable value if RBDMAPFILE not set in environment
-        printenv RBDMAPFILE >/dev/null || local RBDMAPFILE=/etc/ceph/rbdmap
-
-	if [ ! -f "$RBDMAPFILE" ]; then
-		logger -p "daemon.warning" -t rbdmap "No $RBDMAPFILE found."
-		exit 0
-	fi
-
 	# Read /etc/rbdtab to create non-existant mapping
 	RET=0
 	while read DEV PARAMS; do
@@ -65,7 +56,33 @@ do_map() {
 
 }
 
-do_unmap() {
+unmount_unmap() {
+	local rbd_dev=$1
+	local mnt=$(findmnt --mtab --source ${rbd_dev} --noheadings \
+							| awk '{print $1'})
+
+	logger -p "daemon.debug" -t rbdmap "Unmapping '${rbd_dev}'"
+	if [ -n "${mnt}" ]; then
+	    logger -p "daemon.debug" -t rbdmap "Unmounting '${mnt}'"
+	    umount "${mnt}" >>/dev/null 2>&1
+	fi
+	if mountpoint -q "${mnt}"; then
+	    ## Un-mounting failed.
+	    logger -p "daemon.warning" -t rbdmap "Failed to unmount '${mnt}'"
+	    return 1
+	fi
+	## Un-mapping.
+	rbd unmap $rbd_dev >>/dev/null 2>&1
+	if [ $? -ne 0 ]; then
+	    logger -p "daemon.warning" -t rbdmap "Failed to unmap '${mnt}'"
+	    return 1
+	fi
+	logger -p "daemon.debug" -t rbdmap "Unmapped '${rbd_dev}'"
+
+	return 0
+}
+
+do_unmap_all() {
 	RET=0
 	## Unmount and unmap all rbd devices
 	if ls /dev/rbd[0-9]* >/dev/null 2>&1; then
@@ -81,30 +98,56 @@ do_unmap() {
 			    fi
 			done
 
-			logger -p "daemon.debug" -t rbdmap "Unmapping '${DEV}'"
-			MNT=$(findmnt --mtab --source ${DEV} --noheadings | awk '{print $1'})
-			if [ -n "${MNT}" ]; then
-			    logger -p "daemon.debug" -t rbdmap "Unmounting '${MNT}'"
-			    umount "${MNT}" >>/dev/null 2>&1
-			fi
-			if mountpoint -q "${MNT}"; then
-			    ## Un-mounting failed.
-			    logger -p "daemon.warning" -t rbdmap "Failed to unmount '${MNT}'"
-			    RET=$((${RET}+1))
-			    continue
-			fi
-			## Un-mapping.
-			rbd unmap $DEV >>/dev/null 2>&1
-			if [ $? -ne 0 ]; then
-			    logger -p "daemon.warning" -t rbdmap "Failed to unmap '${MNT}'"
-			    RET=$((${RET}+$?))
-			    continue
-			fi
-			logger -p "daemon.debug" -t rbdmap "Unmapped '${DEV}'"
+			unmount_unmap "$DEV" || RET=$((${RET}+$?))
+
 		done
 	fi
 	exit ${RET}
 }
+
+do_unmap() {
+	RET=0
+	## skip if nothing is mapped
+	ls /dev/rbd[0-9]* >/dev/null 2>&1 || exit ${RET}
+
+	# Read /etc/rbdtab to create non-existant mapping
+	while read DEV PARAMS; do
+		case "$DEV" in
+		  ""|\#*)
+			continue
+			;;
+		  */*)
+			;;
+		  *)
+			DEV=rbd/$DEV
+			;;
+		esac
+
+		MAP_RV="$(readlink -f /dev/rbd/$DEV)"
+		if [ ! -b $MAP_RV ]; then
+			logger -p "daemon.debug" -t rbdmap "$DEV not mapped, skipping unmap"
+			continue
+		fi
+
+		## pre-unmapping
+		if [ -x "/etc/ceph/rbd.d/${DEV}" ]; then
+			logger -p "daemon.debug" -t rbdmap "Running pre-unmap hook '/etc/ceph/rbd.d/${DEV}'"
+			/etc/ceph/rbd.d/${DEV} unmap "/dev/rbd/${DEV}"
+		fi
+
+		unmount_unmap "$MAP_RV" || RET=$((${RET}+$?))
+
+	done < $RBDMAPFILE
+	exit ${RET}
+}
+
+# default to reasonable value if RBDMAPFILE not set in environment
+RBDMAPFILE="${RBDMAPFILE:-/etc/ceph/rbdmap}"
+
+if [ ! -f "$RBDMAPFILE" ]; then
+	logger -p "daemon.warning" -t rbdmap "No $RBDMAPFILE found."
+	exit 0
+fi
 
 case "$1" in
   map)
@@ -114,6 +157,11 @@ case "$1" in
   unmap)
 	do_unmap
 	;;
+
+  unmap-all)
+	do_unmap_all
+	;;
+
   *)
-	echo "Usage: rbdmap map | unmap"
+	echo "Usage: rbdmap map | unmap | unmap-all"
 esac

--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -11,7 +11,7 @@ Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/bin/rbdmap map
 ExecReload=/usr/bin/rbdmap map
-ExecStop=/usr/bin/rbdmap unmap
+ExecStop=/usr/bin/rbdmap unmap-all
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
As reported at http://tracker.ceph.com/issues/18884 , "rbdmap unmap" currently unmounts / unmaps all mapped RBD images, rather than just the images listed in RBDMAPFILE (/etc/ceph/rbdmap).

I'm unsure whether I should keep the existing behaviour and add the RBDMAP_UNMAP_ALL=no parameter, or just drop the old behaviour all together, given that it wasn't documented.
Feedback here would be very much appreciated.