### PR TITLE
osd: clarify REQUIRE_LUMINOUS error message

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5035,7 +5035,8 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
 	    << dendl;
   } else if (!monc->monmap.get_required_features().contains_all(
 	       ceph::features::mon::FEATURE_LUMINOUS)) {
-    dout(1) << "monmap REQUIRE_LUMINOUS is NOT set; upgrade mons first" << dendl;
+    derr << "monmap REQUIRE_LUMINOUS is NOT set; must upgrade all monitors to "
+	 << "Luminous or later before Luminous OSDs will boot" << dendl;
   } else if (osdmap->get_epoch() >= oldest - 1 &&
 	     osdmap->get_epoch() + cct->_conf->osd_map_message_max > newest) {
     _send_boot();


### PR DESCRIPTION
This should be visible at the default log level, so users have some
hope of figuring out the problem.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>