### PR TITLE
test: Thrasher: update pgp_num of all expanded pools if not yet

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -138,7 +138,13 @@ class Thrasher:
             self.config = dict()
         # prevent monitor from auto-marking things out while thrasher runs
         # try both old and new tell syntax, in case we are testing old code
-        self._set_config('mon', '*', 'mon-osd-down-out-interval', 0)
+        self.saved_options = {}
+        first_mon = teuthology.get_first_mon(manager.ctx, self.config).split('.')
+        opt_name = 'mon_osd_down_out_interval'
+        self.saved_options[opt_name] = manager.get_config(first_mon[0],
+                                                          first_mon[1],
+                                                          opt_name)
+        self._set_config('mon', '*', opt_name, 0)
         # initialize ceph_objectstore_tool property - must be done before
         # do_thrash is spawned - http://tracker.ceph.com/issues/18799
         if (self.config.get('powercycle') or
@@ -857,6 +863,9 @@ class Thrasher:
             if self.ceph_manager.get_pool_pg_num(pool) > 0:
                 self.fix_pgp_num(pool)
         self.pools_to_fix_pgp_num.clear()
+        for opt, value in self.saved_options.iteritems():
+            self._set_config('mon', '*', opt, value)
+        self.saved_options.clear()
         self.all_up()
 
 

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1246,7 +1246,7 @@ class CephManager:
             proc = self.admin_socket(service_type, service_id,
                                      args, check_status=False, stdout=stdout)
             if proc.exitstatus is 0:
-                break
+                return proc
             else:
                 tries += 1
                 if (tries * 5) > timeout:
@@ -1269,6 +1269,16 @@ class CephManager:
             if i['pool_name'] == pool:
                 return i
         assert False
+
+    def get_config(self, service_type, service_id, name):
+        """
+        :param node: like 'mon.a'
+        :param name: the option name
+        """
+        proc = self.wait_run_admin_socket(service_type, service_id,
+                                          ['config', 'show'])
+        j = json.loads(proc.stdout.getvalue())
+        return j[name]
 
     def set_config(self, osdnum, **argdict):
         """

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -112,6 +112,7 @@ class Thrasher:
         self.logger = logger
         self.config = config
         self.revive_timeout = self.config.get("revive_timeout", 150)
+        self.pools_to_fix_pgp_num = set()
         if self.config.get('powercycle'):
             self.revive_timeout += 120
         self.clean_wait = self.config.get('clean_wait', 0)
@@ -515,18 +516,24 @@ class Thrasher:
         Increase the size of the pool
         """
         pool = self.ceph_manager.get_pool()
+        orig_pg_num = self.ceph_manager.get_pool_pg_num(pool)
         self.log("Growing pool %s" % (pool,))
         self.ceph_manager.expand_pool(pool,
                                       self.config.get('pool_grow_by', 10),
                                       self.max_pgs)
+        if orig_pg_num < self.ceph_manager.get_pool_pg_num(pool):
+            self.pools_to_fix_pgp_num.add(pool)
 
-    def fix_pgp_num(self):
+    def fix_pgp_num(self, pool=None):
         """
         Fix number of pgs in pool.
         """
-        pool = self.ceph_manager.get_pool()
+        if pool is None:
+            pool = self.ceph_manager.get_pool()
         self.log("fixing pg num pool %s" % (pool,))
         self.ceph_manager.set_pool_pgpnum(pool)
+        if pool in self.pools_to_fix_pgp_num:
+            self.pools_to_fix_pgp_num.remove(pool)
 
     def test_pool_min_size(self):
         """
@@ -839,6 +846,10 @@ class Thrasher:
                         Scrubber(self.ceph_manager, self.config)
             self.choose_action()()
             time.sleep(delay)
+        for pool in list(self.pools_to_fix_pgp_num):
+            if self.ceph_manager.get_pool_pg_num(pool) > 0:
+                self.fix_pgp_num(pool)
+        self.pools_to_fix_pgp_num.clear()
         self.all_up()
 
 


### PR DESCRIPTION
…fore waiting for healthy

otherwise, the "ceph health" complains with:

 all OSDs are running luminous or later but the 'require_luminous_osds'
osdmap flag is not set

"ceph.restart" task will timeout and fail at seeing this warning.

so we need to set the osdmap flag, after upgrading all OSDs. and call
"ceph.restart" again to see if the cluster is healthy or not.

Signed-off-by: Kefu Chai <kchai@redhat.com>