### PR TITLE
http://tracker.ceph.com/issues/18644

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -308,7 +308,7 @@ OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full
 OPTION(mon_allow_pool_delete, OPT_BOOL, false) // allow pool deletion
 OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
-OPTION(mon_osd_report_timeout, OPT_INT, 300)    // grace period before declaring unresponsive OSDs dead
+OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active
 OPTION(mon_warn_on_legacy_crush_tunables, OPT_BOOL, true) // warn if crush tunables are too old (older than mon_min_crush_required_version)
 OPTION(mon_crush_min_required_version, OPT_STR, "firefly")

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -308,7 +308,7 @@ OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full
 OPTION(mon_allow_pool_delete, OPT_BOOL, false) // allow pool deletion
 OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
-OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
+OPTION(mon_osd_report_timeout, OPT_INT, 300)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active
 OPTION(mon_warn_on_legacy_crush_tunables, OPT_BOOL, true) // warn if crush tunables are too old (older than mon_min_crush_required_version)
 OPTION(mon_crush_min_required_version, OPT_STR, "firefly")

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1094,6 +1094,7 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
   }
   mask |= CEPH_FEATURE_OSD_PRIMARY_AFFINITY;
 
+<<<<<<< HEAD
   if (entity_type == CEPH_ENTITY_TYPE_OSD) {
     const uint64_t jewel_features = CEPH_FEATURE_SERVER_JEWEL;
     if (test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
@@ -1108,6 +1109,20 @@ uint64_t OSDMap::get_features(int entity_type, uint64_t *pmask) const
     }
     mask |= kraken_features;
   }
+=======
+  const uint64_t jewel_features = CEPH_FEATURE_SERVER_JEWEL;
+  if (test_flag(CEPH_OSDMAP_REQUIRE_JEWEL)) {
+    features |= jewel_features;
+  }
+  mask |= jewel_features;
+
+  const uint64_t kraken_features = CEPH_FEATURE_SERVER_KRAKEN
+    | CEPH_FEATURE_MSG_ADDR2;
+  if (test_flag(CEPH_OSDMAP_REQUIRE_KRAKEN)) {
+    features |= kraken_features;
+  }
+  mask |= kraken_features;
+>>>>>>> 1a5cc32... osd/OSDMap: reflect REQUIRE_*_OSDS flag in required features
 
   if (pmask)
     *pmask = mask;


### PR DESCRIPTION
 osd/OSDMap: reflect REQUIRE_*_OSDS flag in required features

Callers should be mindful of the mask output; this isn't necessary
an exhaustive list of features that e.g. a kraken OSD would/should
have--just certain interesting ones.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 1a5cc32f0a3bf5ef06642402e930e3786700ab7d)