### PR TITLE
src/tools/rados/rados.cc: Clean up unnecessary return statement initialization

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -381,7 +381,6 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
 {
   string oid(objname);
   bool stdio = (strcmp(infile, "-") == 0);
-  int ret = 0;
   int fd = STDIN_FILENO;
   if (!stdio)
     fd = open(infile, O_RDONLY);
@@ -389,6 +388,8 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
     cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
     return 1;
   }
+
+  int ret = 0;
   int count = op_size;
   uint64_t offset = obj_offset;
   while (count != 0) {
@@ -441,7 +442,7 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
     }
     offset += count;
   }
-  ret = 0;
+
  out:
   if (fd != STDOUT_FILENO)
     VOID_TEMP_FAILURE_RETRY(close(fd));
@@ -481,7 +482,7 @@ static int do_append(IoCtx& io_ctx, RadosStriper& striper,
       goto out;
     }
   }
-  ret = 0;
+ 
 out:
   if (fd != STDOUT_FILENO)
     VOID_TEMP_FAILURE_RETRY(close(fd));


### PR DESCRIPTION
Do not initialize return statement two times unnecessarily.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>