### PR TITLE
src/common/config_opts.h: Clean up mon_osd_report_timeout

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -308,7 +308,7 @@ OPTION(mon_osd_full_ratio, OPT_FLOAT, .95) // what % full makes an OSD "full"
 OPTION(mon_osd_nearfull_ratio, OPT_FLOAT, .85) // what % full makes an OSD near full
 OPTION(mon_allow_pool_delete, OPT_BOOL, false) // allow pool deletion
 OPTION(mon_globalid_prealloc, OPT_U32, 10000)   // how many globalids to prealloc
-OPTION(mon_osd_report_timeout, OPT_INT, 900)    // grace period before declaring unresponsive OSDs dead
+OPTION(mon_osd_report_timeout, OPT_INT, 300)    // grace period before declaring unresponsive OSDs dead
 OPTION(mon_force_standby_active, OPT_BOOL, true) // should mons force standby-replay mds to be active
 OPTION(mon_warn_on_legacy_crush_tunables, OPT_BOOL, true) // warn if crush tunables are too old (older than mon_min_crush_required_version)
 OPTION(mon_crush_min_required_version, OPT_STR, "firefly")


### PR DESCRIPTION
Current default value of mon_osd_report_timeout is 900. With this value, if the MON is considering some OSD(s) down, clients I/O could be potentially blocked for 900 seconds.

This PR is to propose lowering this default value to 300 seconds.
IMHO it is still a bit long.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>