### PR TITLE
crush: ruleset is out of scope in CrushTester::test_with_crushtool

### DIFF
--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -371,10 +371,11 @@ int CrushTester::test_with_crushtool(const char *crushtool_cmd,
     "--min-x", "1",
     "--max-x", "50",
     NULL);
+  string opt_ruleset = stringify(ruleset);
   if (ruleset >= 0) {
     crushtool.add_cmd_args(
       "--ruleset",
-      stringify(ruleset).c_str(),
+      opt_ruleset.c_str(),
       NULL);
   }
   int ret = crushtool.spawn();


### PR DESCRIPTION
Fix: http://tracker.ceph.com/issues/18890
Signed-off-by: choury chouryzhou@tencent.com