### PR TITLE
osd: change the conditional in _update_calc_stats

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2510,15 +2510,12 @@ void PG::_update_calc_stats()
 	 i != actingbackfill.end();
 	 ++i) {
       const pg_shard_t &p = *i;
-
       bool in_up = (upset.find(p) != upset.end());
-      bool in_acting = (actingset.find(p) != actingset.end());
-      assert(in_up || in_acting);
 
-      // in acting                  Compute total objects excluding num_missing
-      // in acting and not in up    Compute misplaced objects excluding num_missing
-      // in up and not in acting    Compute total objects already backfilled
-      if (in_acting) {
+      // recovery       Compute total objects excluding num_missing
+      //   - not in up  Compute misplaced objects excluding num_missing
+      // backfill       Compute total objects already backfilled
+      if (!is_backfill_targets(p)) {
         unsigned osd_missing;
         // primary handling
         if (p == pg_whoami) {
@@ -2536,8 +2533,6 @@ void PG::_update_calc_stats()
         if (!in_up && num_objects > osd_missing)
 	  misplaced += num_objects - osd_missing;
       } else {
-        assert(in_up && !in_acting);
-
         // If this peer has more objects then it should, ignore them
         backfilled += MIN(num_objects, peer_info[p].stats.stats.sum.num_objects);
       }


### PR DESCRIPTION
'in_up' and 'in_acting' exposes the internal logic of choose_acting.
The code to calculate missing/misplaced objects needs to be changed
as well when there is a change in choosing acting. Change to use
'is_backfill_targets' to avoid this.

Signed-off-by: Zhiqiang Wang <zhiqiang@xsky.com>