### PR TITLE
msg/async/rdma: release potential QueuePair when shutdown socket

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1716,6 +1716,7 @@ ssize_t AsyncConnection::handle_connect_msg(ceph_msg_connect &connect, bufferlis
             existing->delay_state->set_center(new_center);
         } else if (existing->state == STATE_CLOSED) {
           cs.close();
+          cs.reset();
           return ;
         } else {
           ceph_abort();

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -110,6 +110,7 @@ class AsyncConnection : public Connection {
       center->delete_file_event(cs.fd(), EVENT_READABLE|EVENT_WRITABLE);
       cs.shutdown();
       cs.close();
+      cs.reset();
     }
   }
   Message *_get_next_outgoing(bufferlist *bl) {


### PR DESCRIPTION
For tcp backend, shutdown_socket will close tcp fd and release associated
resources, for rdma backend, current impl only issue FIN request and beg
peer closed. If dead connection, it will let fault connection still own
QueuePair.

Signed-off-by: Haomai Wang <haomai@xsky.com>