### PR TITLE
msg/async/rdma: check if exp verbs avail

### DIFF
--- a/cmake/modules/Findrdma.cmake
+++ b/cmake/modules/Findrdma.cmake
@@ -20,6 +20,17 @@ endif ()
 
 if (RDMA_FOUND)
   message(STATUS "Found libibverbs: ${RDMA_LIBRARY}")
+
+  include(CheckCXXSourceCompiles)
+  CHECK_CXX_SOURCE_COMPILES("
+    #include <infiniband/verbs.h>
+    int main() {
+      struct ibv_context* ctxt;
+      struct ibv_exp_gid_attr gid_attr;
+      ibv_exp_query_gid_attr(ctxt, 1, 0, &gid_attr);
+      return 0;
+    } " HAVE_IBV_EXP)
+
 else ()
   message(STATUS "Not Found libibverbs: ${RDMA_LIBRARY}")
   if (RDMA_FIND_REQUIRED)

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -130,6 +130,9 @@
 /* AsyncMessenger RDMA conditional compilation */
 #cmakedefine HAVE_RDMA
 
+/* ibverbs experimental conditional compilation */
+#cmakedefine HAVE_IBV_EXP
+
 /* define if embedded enabled */
 #cmakedefine WITH_EMBEDDED
 


### PR DESCRIPTION
Insure Ceph RDMA compiles on native OS with libibverbs

Signed-off-by: Adir Lev <adirl@mellanox.com>
Signed-off-by: Oren Duer <oren@mellanox.com>