### PR TITLE
osd: drop support for listing objects at a given snap

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1022,21 +1022,6 @@ int PrimaryLogPG::do_command(
 
 // ==========================================================
 
-bool PrimaryLogPG::pg_op_must_wait(MOSDOp *op)
-{
-  if (pg_log.get_missing().get_items().empty())
-    return false;
-  for (vector<OSDOp>::iterator p = op->ops.begin(); p != op->ops.end(); ++p) {
-    if (p->op.op == CEPH_OSD_OP_PGLS || p->op.op == CEPH_OSD_OP_PGNLS ||
-	p->op.op == CEPH_OSD_OP_PGLS_FILTER || p->op.op == CEPH_OSD_OP_PGNLS_FILTER) {
-      if (op->get_snapid() != CEPH_NOSNAP) {
-	return true;
-      }
-    }
-  }
-  return false;
-}
-
 void PrimaryLogPG::do_pg_op(OpRequestRef op)
 {
   MOSDOp *m = static_cast<MOSDOp *>(op->get_req());
@@ -1825,10 +1810,6 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   }
 
   if (op->includes_pg_op()) {
-    if (pg_op_must_wait(m)) {
-      wait_for_all_missing(op);
-      return;
-    }
     return do_pg_op(op);
   }
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1354,7 +1354,6 @@ public:
   void do_op(OpRequestRef& op) override;
   void record_write_error(OpRequestRef op, const hobject_t &soid,
 			  MOSDOpReply *orig_reply, int r);
-  bool pg_op_must_wait(MOSDOp *op);
   void do_pg_op(OpRequestRef op);
   void do_sub_op(OpRequestRef op) override;
   void do_sub_op_reply(OpRequestRef op) override;


### PR DESCRIPTION
This was never used (Objecter is hard-coded to CEPH_NOSNAP for pg ops), is inefficient,
and a bad API for getting this info out of the OSD.