### PR TITLE
rgw: change loglevel to 20 for 'System already converted' message

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3462,7 +3462,7 @@ int RGWRados::replace_region_with_zonegroup()
 		  << dendl;
     return ret;
   } else if (ret != -ENOENT) {
-    ldout(cct, 0) << "System already converted " << dendl;
+    ldout(cct, 20) << "System already converted " << dendl;
     return 0;
   }
 


### PR DESCRIPTION
rgw: change log level to 20 for 'System already converted' message

Fixes: http://tracker.ceph.com/issues/18919

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>