### PR TITLE
doc: Modify Configuring Cinder section

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -295,6 +295,7 @@ specify the pool name for the block device. On your OpenStack node, edit
     ...
     [ceph]
     volume_driver = cinder.volume.drivers.rbd.RBDDriver
+    volume_backend_name = ceph
     rbd_pool = volumes
     rbd_ceph_conf = /etc/ceph/ceph.conf
     rbd_flatten_volume_from_snapshot = false


### PR DESCRIPTION
doc/rbd/rbd-openstack.rst: Add ``volume_backend_name`` in description of
cinder.conf

Fixes: http://tracker.ceph.com/issues/18840
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>