### PR TITLE
osd: kill all remaining MOSDSubOp users

### DIFF
--- a/src/messages/MOSDPGBackfillRemove.h
+++ b/src/messages/MOSDPGBackfillRemove.h
@@ -1,0 +1,75 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Sage Weil <sage@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MOSDPGBACKFILLREMOVE_H
+#define CEPH_MOSDPGBACKFILLREMOVE_H
+
+#include "MOSDFastDispatchOp.h"
+
+/*
+ * instruct non-primary to remove some objects during backfill
+ */
+
+struct MOSDPGBackfillRemove : public MOSDFastDispatchOp {
+
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  spg_t pgid;            ///< target spg_t
+  epoch_t map_epoch = 0;
+  list<pair<hobject_t,eversion_t>> ls;    ///< objects to remove
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  MOSDPGBackfillRemove()
+    : MOSDFastDispatchOp(MSG_OSD_PG_BACKFILL_REMOVE, HEAD_VERSION,
+			COMPAT_VERSION) {}
+
+  MOSDPGBackfillRemove(spg_t pgid, epoch_t map_epoch)
+    : MOSDFastDispatchOp(MSG_OSD_PG_BACKFILL_REMOVE, HEAD_VERSION,
+			 COMPAT_VERSION),
+      pgid(pgid),
+      map_epoch(map_epoch) {}
+
+private:
+  ~MOSDPGBackfillRemove() {}
+
+public:
+  const char *get_type_name() const { return "backfill_remove"; }
+  void print(ostream& out) const {
+    out << "backfill_remove(" << pgid << " e" << map_epoch
+	<< " " << ls << ")";
+  }
+
+  void encode_payload(uint64_t features) {
+    ::encode(pgid, payload);
+    ::encode(map_epoch, payload);
+    ::encode(ls, payload);
+  }
+  void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(pgid, p);
+    ::decode(map_epoch, p);
+    ::decode(ls, p);
+  }
+};
+
+
+
+#endif

--- a/src/messages/MOSDRepScrubMap.h
+++ b/src/messages/MOSDRepScrubMap.h
@@ -1,0 +1,74 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Sage Weil <sage@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MOSDREPSCRUBMAP_H
+#define CEPH_MOSDREPSCRUBMAP_H
+
+#include "MOSDFastDispatchOp.h"
+
+/*
+ * pass a ScrubMap from a shard back to the primary
+ */
+
+struct MOSDRepScrubMap : public MOSDFastDispatchOp {
+
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+  spg_t pgid;            // primary spg_t
+  epoch_t map_epoch = 0;
+  pg_shard_t from;   // whose scrubmap this is
+  bufferlist scrub_map_bl;
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  MOSDRepScrubMap()
+    : MOSDFastDispatchOp(MSG_OSD_REP_SCRUBMAP, HEAD_VERSION, COMPAT_VERSION) {}
+
+  MOSDRepScrubMap(spg_t pgid, epoch_t map_epoch, pg_shard_t from)
+    : MOSDFastDispatchOp(MSG_OSD_REP_SCRUBMAP, HEAD_VERSION, COMPAT_VERSION),
+      pgid(pgid),
+      map_epoch(map_epoch),
+      from(from) {}
+
+private:
+  ~MOSDRepScrubMap() {}
+
+public:
+  const char *get_type_name() const { return "rep_scrubmap"; }
+  void print(ostream& out) const {
+    out << "rep_scrubmap(" << pgid << " e" << map_epoch
+	<< " from shard " << from << ")";
+  }
+
+  void encode_payload(uint64_t features) {
+    ::encode(pgid, payload);
+    ::encode(map_epoch, payload);
+    ::encode(from, payload);
+  }
+  void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(pgid, p);
+    ::decode(map_epoch, p);
+    ::decode(from, p);
+  }
+};
+
+
+#endif

--- a/src/messages/MOSDScrubReserve.h
+++ b/src/messages/MOSDScrubReserve.h
@@ -1,0 +1,93 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_MOSDSCRUBRESERVE_H
+#define CEPH_MOSDSCRUBRESERVE_H
+
+#include "MOSDFastDispatchOp.h"
+
+class MOSDScrubReserve : public MOSDFastDispatchOp {
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+public:
+  spg_t pgid;
+  epoch_t map_epoch;
+  enum {
+    REQUEST = 0,
+    GRANT = 1,
+    RELEASE = 2,
+    REJECT = 3,
+  };
+  int32_t type;
+  pg_shard_t from;
+
+  epoch_t get_map_epoch() const override {
+    return map_epoch;
+  }
+  spg_t get_spg() const override {
+    return pgid;
+  }
+
+  MOSDScrubReserve()
+    : MOSDFastDispatchOp(MSG_OSD_SCRUB_RESERVE, HEAD_VERSION, COMPAT_VERSION),
+      map_epoch(0), type(-1) {}
+  MOSDScrubReserve(spg_t pgid,
+		   epoch_t map_epoch,
+		   int type,
+		   pg_shard_t from)
+    : MOSDFastDispatchOp(MSG_OSD_SCRUB_RESERVE, HEAD_VERSION, COMPAT_VERSION),
+      pgid(pgid), map_epoch(map_epoch),
+      type(type), from(from) {}
+
+  const char *get_type_name() const {
+    return "MOSDScrubReserve";
+  }
+
+  void print(ostream& out) const {
+    out << "MOSDScrubReserve(" << pgid << " ";
+    switch (type) {
+    case REQUEST:
+      out << "REQUEST ";
+      break;
+    case GRANT:
+      out << "GRANT ";
+      break;
+    case REJECT:
+      out << "REJECT ";
+      break;
+    case RELEASE:
+      out << "RELEASE ";
+      break;
+    }
+    out << "e" << map_epoch << ")";
+    return;
+  }
+
+  void decode_payload() {
+    bufferlist::iterator p = payload.begin();
+    ::decode(pgid, p);
+    ::decode(map_epoch, p);
+    ::decode(type, p);
+    ::decode(from, p);
+  }
+
+  void encode_payload(uint64_t features) {
+    ::encode(pgid, payload);
+    ::encode(map_epoch, payload);
+    ::encode(type, payload);
+    ::encode(from, payload);
+  }
+};
+
+#endif

--- a/src/messages/MRecoveryReserve.h
+++ b/src/messages/MRecoveryReserve.h
@@ -45,19 +45,19 @@ public:
   }
 
   void print(ostream& out) const override {
-    out << "MRecoveryReserve ";
+    out << "MRecoveryReserve(" << pgid;
     switch (type) {
     case REQUEST:
-      out << "REQUEST ";
+      out << " REQUEST";
       break;
     case GRANT:
-      out << "GRANT ";
+      out << " GRANT";
       break;
     case RELEASE:
-      out << "RELEASE ";
+      out << " RELEASE";
       break;
     }
-    out << " pgid: " << pgid << ", query_epoch: " << query_epoch;
+    out << " e" << query_epoch << ")";
     return;
   }
 

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -81,6 +81,7 @@ using namespace std;
 #include "messages/MOSDPGCreate.h"
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDScrub.h"
+#include "messages/MOSDScrubReserve.h"
 #include "messages/MOSDRepScrub.h"
 #include "messages/MOSDRepScrubMap.h"
 #include "messages/MOSDPGScan.h"
@@ -510,6 +511,9 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_OSD_SCRUB:
     m = new MOSDScrub;
+    break;
+  case MSG_OSD_SCRUB_RESERVE:
+    m = new MOSDScrubReserve;
     break;
   case MSG_REMOVE_SNAPS:
     m = new MRemoveSnaps;

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -85,6 +85,7 @@ using namespace std;
 #include "messages/MOSDPGScan.h"
 #include "messages/MOSDPGBackfill.h"
 #include "messages/MOSDBackoff.h"
+#include "messages/MOSDPGBackfillRemove.h"
 
 #include "messages/MRemoveSnaps.h"
 
@@ -520,6 +521,9 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case MSG_OSD_PG_BACKFILL:
     m = new MOSDPGBackfill;
+    break;
+  case MSG_OSD_PG_BACKFILL_REMOVE:
+    m = new MOSDPGBackfillRemove;
     break;
   case MSG_OSD_PG_PUSH:
     m = new MOSDPGPush;

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -82,6 +82,7 @@ using namespace std;
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDScrub.h"
 #include "messages/MOSDRepScrub.h"
+#include "messages/MOSDRepScrubMap.h"
 #include "messages/MOSDPGScan.h"
 #include "messages/MOSDPGBackfill.h"
 #include "messages/MOSDBackoff.h"
@@ -515,6 +516,9 @@ Message *decode_message(CephContext *cct, int crcflags,
     break;
   case MSG_OSD_REP_SCRUB:
     m = new MOSDRepScrub;
+    break;
+  case MSG_OSD_REP_SCRUBMAP:
+    m = new MOSDRepScrubMap;
     break;
   case MSG_OSD_PG_SCAN:
     m = new MOSDPGScan;

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -93,6 +93,7 @@
 
 #define MSG_OSD_PG_SCAN        94
 #define MSG_OSD_PG_BACKFILL    95
+#define MSG_OSD_PG_BACKFILL_REMOVE 96
 
 #define MSG_COMMAND            97
 #define MSG_COMMAND_REPLY      98

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -88,7 +88,7 @@
 #define MSG_REMOVE_SNAPS       90
 
 #define MSG_OSD_SCRUB          91
-//#define MSG_OSD_PG_MISSING     92  // obsolete
+#define MSG_OSD_SCRUB_RESERVE  92  // previous PG_MISSING
 #define MSG_OSD_REP_SCRUB      93
 
 #define MSG_OSD_PG_SCAN        94

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -116,6 +116,7 @@
 #define MSG_OSD_PG_UPDATE_LOG_MISSING_REPLY  115
 
 #define MSG_OSD_PG_CREATED      116
+#define MSG_OSD_REP_SCRUBMAP    117
 
 // *** MDS ***
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -71,8 +71,6 @@
 #include "messages/MOSDBeacon.h"
 #include "messages/MOSDRepOp.h"
 #include "messages/MOSDRepOpReply.h"
-#include "messages/MOSDSubOp.h"
-#include "messages/MOSDSubOpReply.h"
 #include "messages/MOSDBoot.h"
 #include "messages/MOSDPGTemp.h"
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -100,6 +100,7 @@
 #include "messages/MOSDAlive.h"
 
 #include "messages/MOSDScrub.h"
+#include "messages/MOSDScrubReserve.h"
 #include "messages/MOSDRepScrub.h"
 
 #include "messages/MMonCommand.h"

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2331,6 +2331,7 @@ protected:
     case MSG_OSD_PG_PUSH_REPLY:
     case MSG_OSD_PG_SCAN:
     case MSG_OSD_PG_BACKFILL:
+    case MSG_OSD_PG_BACKFILL_REMOVE:
     case MSG_OSD_EC_WRITE:
     case MSG_OSD_EC_WRITE_REPLY:
     case MSG_OSD_EC_READ:

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2336,6 +2336,7 @@ protected:
     case MSG_OSD_EC_WRITE_REPLY:
     case MSG_OSD_EC_READ:
     case MSG_OSD_EC_READ_REPLY:
+    case MSG_OSD_SCRUB_RESERVE:
     case MSG_OSD_REP_SCRUB:
     case MSG_OSD_REP_SCRUBMAP:
     case MSG_OSD_PG_UPDATE_LOG_MISSING:

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2337,6 +2337,7 @@ protected:
     case MSG_OSD_EC_READ:
     case MSG_OSD_EC_READ_REPLY:
     case MSG_OSD_REP_SCRUB:
+    case MSG_OSD_REP_SCRUBMAP:
     case MSG_OSD_PG_UPDATE_LOG_MISSING:
     case MSG_OSD_PG_UPDATE_LOG_MISSING_REPLY:
       return true;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -36,6 +36,7 @@
 #include "messages/MOSDPGTrim.h"
 #include "messages/MOSDPGScan.h"
 #include "messages/MOSDPGBackfill.h"
+#include "messages/MOSDPGBackfillRemove.h"
 #include "messages/MBackfillReserve.h"
 #include "messages/MRecoveryReserve.h"
 #include "messages/MOSDPGPush.h"
@@ -5513,6 +5514,9 @@ bool PG::can_discard_request(OpRequestRef& op)
     return can_discard_scan(op);
   case MSG_OSD_PG_BACKFILL:
     return can_discard_backfill(op);
+  case MSG_OSD_PG_BACKFILL_REMOVE:
+    return can_discard_replica_op<MOSDPGBackfillRemove,
+				  MSG_OSD_PG_BACKFILL_REMOVE>(op);
   }
   return true;
 }
@@ -5557,6 +5561,11 @@ bool PG::op_must_wait_for_map(epoch_t cur_epoch, OpRequestRef& op)
     return !have_same_or_newer_map(
       cur_epoch,
       static_cast<const MOSDPGBackfill*>(op->get_req())->map_epoch);
+
+  case MSG_OSD_PG_BACKFILL_REMOVE:
+    return !have_same_or_newer_map(
+      cur_epoch,
+      static_cast<const MOSDPGBackfillRemove*>(op->get_req())->map_epoch);
 
   case MSG_OSD_PG_PUSH:
     return !have_same_or_newer_map(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1332,6 +1332,7 @@ public:
   void replica_scrub(
     OpRequestRef op,
     ThreadPool::TPHandle &handle);
+  void do_replica_scrub_map(OpRequestRef op);
   void sub_op_scrub_map(OpRequestRef op);
   void sub_op_scrub_reserve(OpRequestRef op);
   void sub_op_scrub_reserve_reply(OpRequestRef op);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1334,9 +1334,11 @@ public:
     ThreadPool::TPHandle &handle);
   void do_replica_scrub_map(OpRequestRef op);
   void sub_op_scrub_map(OpRequestRef op);
-  void sub_op_scrub_reserve(OpRequestRef op);
-  void sub_op_scrub_reserve_reply(OpRequestRef op);
-  void sub_op_scrub_unreserve(OpRequestRef op);
+
+  void handle_scrub_reserve_request(OpRequestRef op);
+  void handle_scrub_reserve_grant(OpRequestRef op, pg_shard_t from);
+  void handle_scrub_reserve_reject(OpRequestRef op, pg_shard_t from);
+  void handle_scrub_reserve_release(OpRequestRef op);
 
   void reject_reservation();
   void schedule_backfill_full_retry();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -57,8 +57,6 @@ using namespace std;
 class OSD;
 class OSDService;
 class MOSDOp;
-class MOSDSubOp;
-class MOSDSubOpReply;
 class MOSDPGScan;
 class MOSDPGBackfill;
 class MOSDPGInfo;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1689,6 +1689,10 @@ void PrimaryLogPG::do_request(
     replica_scrub(op, handle);
     break;
 
+  case MSG_OSD_REP_SCRUBMAP:
+    do_replica_scrub_map(op);
+    break;
+
   case MSG_OSD_PG_UPDATE_LOG_MISSING:
     do_update_log_missing(op);
     break;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -37,6 +37,7 @@
 #include "messages/MOSDPGScan.h"
 #include "messages/MOSDRepScrub.h"
 #include "messages/MOSDPGBackfill.h"
+#include "messages/MOSDPGBackfillRemove.h"
 #include "messages/MOSDPGUpdateLogMissing.h"
 #include "messages/MOSDPGUpdateLogMissingReply.h"
 #include "messages/MCommandReply.h"
@@ -1678,6 +1679,10 @@ void PrimaryLogPG::do_request(
 
   case MSG_OSD_PG_BACKFILL:
     do_backfill(op);
+    break;
+
+  case MSG_OSD_PG_BACKFILL_REMOVE:
+    do_backfill_remove(op);
     break;
 
   case MSG_OSD_REP_SCRUB:
@@ -3403,6 +3408,23 @@ void PrimaryLogPG::do_backfill(OpRequestRef op)
     }
     break;
   }
+}
+
+void PrimaryLogPG::do_backfill_remove(OpRequestRef op)
+{
+  const MOSDPGBackfillRemove *m = static_cast<const MOSDPGBackfillRemove*>(
+    op->get_req());
+  assert(m->get_type() == MSG_OSD_PG_BACKFILL_REMOVE);
+  dout(7) << __func__ << " " << m->ls << dendl;
+
+  op->mark_started();
+
+  ObjectStore::Transaction t;
+  for (auto& p : m->ls) {
+    remove_snap_mapped_object(t, p.first);
+  }
+  int r = osd->store->queue_transaction(osr.get(), std::move(t), NULL);
+  assert(r == 0);
 }
 
 PrimaryLogPG::OpContextUPtr PrimaryLogPG::trim_object(bool first, const hobject_t &coid)
@@ -11016,14 +11038,43 @@ uint64_t PrimaryLogPG::recover_backfill(
     add_object_context_to_pg_stat(obc, &stat);
     pending_backfill_updates[*i] = stat;
   }
-  for (unsigned i = 0; i < to_remove.size(); ++i) {
-    handle.reset_tp_timeout();
+  if (HAVE_FEATURE(get_min_upacting_features(), SERVER_LUMINOUS)) {
+    map<pg_shard_t,MOSDPGBackfillRemove*> reqs;
+    for (unsigned i = 0; i < to_remove.size(); ++i) {
+      handle.reset_tp_timeout();
+      const hobject_t& oid = to_remove[i].get<0>();
+      eversion_t v = to_remove[i].get<1>();
+      pg_shard_t peer = to_remove[i].get<2>();
+      MOSDPGBackfillRemove *m;
+      auto it = reqs.find(peer);
+      if (it != reqs.end()) {
+	m = it->second;
+      } else {
+	m = reqs[peer] = new MOSDPGBackfillRemove(
+	  spg_t(info.pgid.pgid, peer.shard),
+	  get_osdmap()->get_epoch());
+      }
+      m->ls.push_back(make_pair(oid, v));
 
-    // ordered before any subsequent updates
-    send_remove_op(to_remove[i].get<0>(), to_remove[i].get<1>(), to_remove[i].get<2>());
+      if (oid <= last_backfill_started)
+	pending_backfill_updates[oid]; // add empty stat!
+    }
+    for (auto p : reqs) {
+      osd->send_message_osd_cluster(p.first.osd, p.second,
+				    get_osdmap()->get_epoch());
+    }
+  } else {
+    // for jewel targets
+    for (unsigned i = 0; i < to_remove.size(); ++i) {
+      handle.reset_tp_timeout();
 
-    if (to_remove[i].get<0>() <= last_backfill_started)
-      pending_backfill_updates[to_remove[i].get<0>()]; // add empty stat!
+      // ordered before any subsequent updates
+      send_remove_op(to_remove[i].get<0>(), to_remove[i].get<1>(),
+		     to_remove[i].get<2>());
+
+      if (to_remove[i].get<0>() <= last_backfill_started)
+	pending_backfill_updates[to_remove[i].get<0>()]; // add empty stat!
+    }
   }
 
   PGBackend::RecoveryHandle *h = pgbackend->open_recovery_op();

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -27,8 +27,6 @@
 #include "ReplicatedBackend.h"
 #include "PGTransaction.h"
 
-class MOSDSubOpReply;
-
 class CopyFromCallback;
 class PromoteCallback;
 
@@ -38,7 +36,6 @@ class HitSet;
 struct TierAgentState;
 class MOSDOp;
 class MOSDOpReply;
-class MOSDSubOp;
 class OSDService;
 
 void intrusive_ptr_add_ref(PrimaryLogPG *pg);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1357,6 +1357,7 @@ public:
     OpRequestRef op,
     ThreadPool::TPHandle &handle) override;
   void do_backfill(OpRequestRef op) override;
+  void do_backfill_remove(OpRequestRef op);
 
   void handle_backoff(OpRequestRef& op);
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1055,8 +1055,7 @@ void ReplicatedBackend::sub_op_modify(OpRequestRef op)
 
   const hobject_t& soid = m->poid;
 
-  dout(10) << "sub_op_modify trans"
-           << " " << soid
+  dout(10) << __func__ << " " << soid
            << " v " << m->version
 	   << (m->logbl.length() ? " (transaction)" : " (parallel exec")
 	   << " " << m->logbl.length()
@@ -1139,7 +1138,7 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
   rm->op->mark_event("sub_op_applied");
   rm->applied = true;
 
-  dout(10) << "sub_op_modify_applied on " << rm << " op "
+  dout(10) << __func__ << " on " << rm << " op "
 	   << *rm->op->get_req() << dendl;
   const Message *m = rm->op->get_req();
 
@@ -1181,7 +1180,7 @@ void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
   rm->committed = true;
 
   // send commit.
-  dout(10) << "sub_op_modify_commit on op " << *rm->op->get_req()
+  dout(10) << __func__ << " on op " << *rm->op->get_req()
 	   << ", sending commit to osd." << rm->ackerosd
 	   << dendl;
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -209,8 +209,7 @@ bool ReplicatedBackend::handle_message(
   case MSG_OSD_SUBOP: {
     const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
     if (m->ops.size() == 0) {
-      sub_op_modify(op);
-      return true;
+      assert(0);
     }
     break;
   }

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -66,7 +66,7 @@ struct ReplicatedBackend::C_OSD_RepModifyApply : public Context {
   C_OSD_RepModifyApply(ReplicatedBackend *pg, RepModifyRef r)
     : pg(pg), rm(r) {}
   void finish(int r) override {
-    pg->sub_op_modify_applied(rm);
+    pg->repop_applied(rm);
   }
 };
 
@@ -76,7 +76,7 @@ struct ReplicatedBackend::C_OSD_RepModifyCommit : public Context {
   C_OSD_RepModifyCommit(ReplicatedBackend *pg, RepModifyRef r)
     : pg(pg), rm(r) {}
   void finish(int r) override {
-    pg->sub_op_modify_commit(rm);
+    pg->repop_commit(rm);
   }
 };
 
@@ -215,12 +215,12 @@ bool ReplicatedBackend::handle_message(
   }
 
   case MSG_OSD_REPOP: {
-    sub_op_modify(op);
+    do_repop(op);
     return true;
   }
 
   case MSG_OSD_REPOPREPLY: {
-    sub_op_modify_reply(op);
+    do_repop_reply(op);
     return true;
   }
 
@@ -621,7 +621,7 @@ void ReplicatedBackend::op_commit(
   }
 }
 
-void ReplicatedBackend::sub_op_modify_reply(OpRequestRef op)
+void ReplicatedBackend::do_repop_reply(OpRequestRef op)
 {
   static_cast<MOSDRepOpReply*>(op->get_nonconst_req())->finish_decode();
   const MOSDRepOpReply *r = static_cast<const MOSDRepOpReply *>(op->get_req());
@@ -1045,7 +1045,7 @@ void ReplicatedBackend::issue_op(
 }
 
 // sub op modify
-void ReplicatedBackend::sub_op_modify(OpRequestRef op)
+void ReplicatedBackend::do_repop(OpRequestRef op)
 {
   static_cast<MOSDRepOp*>(op->get_nonconst_req())->finish_decode();
   const MOSDRepOp *m = static_cast<const MOSDRepOp *>(op->get_req());
@@ -1132,7 +1132,7 @@ void ReplicatedBackend::sub_op_modify(OpRequestRef op)
   // op is cleaned up by oncommit/onapply when both are executed
 }
 
-void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
+void ReplicatedBackend::repop_applied(RepModifyRef rm)
 {
   rm->op->mark_event("sub_op_applied");
   rm->applied = true;
@@ -1173,7 +1173,7 @@ void ReplicatedBackend::sub_op_modify_applied(RepModifyRef rm)
   parent->op_applied(version);
 }
 
-void ReplicatedBackend::sub_op_modify_commit(RepModifyRef rm)
+void ReplicatedBackend::repop_commit(RepModifyRef rm)
 {
   rm->op->mark_commit_sent();
   rm->committed = true;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -183,20 +183,6 @@ bool ReplicatedBackend::can_handle_while_inactive(OpRequestRef op)
   switch (op->get_req()->get_type()) {
   case MSG_OSD_PG_PULL:
     return true;
-  case MSG_OSD_SUBOP: {
-    const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
-    if (m->ops.size() >= 1) {
-      const OSDOp *first = &m->ops[0];
-      switch (first->op.op) {
-      case CEPH_OSD_OP_PULL:
-	return true;
-      default:
-	return false;
-      }
-    } else {
-      return false;
-    }
-  }
   default:
     return false;
   }
@@ -222,19 +208,7 @@ bool ReplicatedBackend::handle_message(
 
   case MSG_OSD_SUBOP: {
     const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
-    if (m->ops.size() >= 1) {
-      const OSDOp *first = &m->ops[0];
-      switch (first->op.op) {
-      case CEPH_OSD_OP_PULL:
-	sub_op_pull(op);
-	return true;
-      case CEPH_OSD_OP_PUSH:
-	sub_op_push(op);
-	return true;
-      default:
-	break;
-      }
-    } else {
+    if (m->ops.size() == 0) {
       sub_op_modify(op);
       return true;
     }
@@ -244,20 +218,6 @@ bool ReplicatedBackend::handle_message(
   case MSG_OSD_REPOP: {
     sub_op_modify(op);
     return true;
-  }
-
-  case MSG_OSD_SUBOPREPLY: {
-    const MOSDSubOpReply *r = static_cast<const MOSDSubOpReply*>(op->get_req());
-    if (r->ops.size() >= 1) {
-      const OSDOp &first = r->ops[0];
-      switch (first.op.op) {
-      case CEPH_OSD_OP_PUSH:
-	// continue peer recovery
-	sub_op_push_reply(op);
-	return true;
-      }
-    }
-    break;
   }
 
   case MSG_OSD_REPOPREPLY: {
@@ -1643,41 +1603,6 @@ void ReplicatedBackend::prep_push(
   pi.recovery_progress = new_progress;
 }
 
-int ReplicatedBackend::send_pull_legacy(int prio, pg_shard_t peer,
-					const ObjectRecoveryInfo &recovery_info,
-					ObjectRecoveryProgress progress)
-{
-  // send op
-  ceph_tid_t tid = get_parent()->get_tid();
-  osd_reqid_t rid(get_parent()->get_cluster_msgr_name(), 0, tid);
-
-  dout(10) << "send_pull_op " << recovery_info.soid << " "
-	   << recovery_info.version
-	   << " first=" << progress.first
-	   << " data " << recovery_info.copy_subset
-	   << " from osd." << peer
-	   << " tid " << tid << dendl;
-
-  MOSDSubOp *subop = new MOSDSubOp(
-    rid, parent->whoami_shard(),
-    get_info().pgid, recovery_info.soid,
-    CEPH_OSD_FLAG_ACK,
-    get_osdmap()->get_epoch(), tid,
-    recovery_info.version);
-  subop->set_priority(prio);
-  subop->ops = vector<OSDOp>(1);
-  subop->ops[0].op.op = CEPH_OSD_OP_PULL;
-  subop->ops[0].op.extent.length = cct->_conf->osd_recovery_max_chunk;
-  subop->recovery_info = recovery_info;
-  subop->recovery_progress = progress;
-
-  get_parent()->send_message_osd_cluster(
-    peer.osd, subop, get_osdmap()->get_epoch());
-
-  get_parent()->get_logger()->inc(l_osd_pull);
-  return 0;
-}
-
 void ReplicatedBackend::submit_push_data(
   const ObjectRecoveryInfo &recovery_info,
   bool first,
@@ -2138,56 +2063,11 @@ int ReplicatedBackend::build_push_op(const ObjectRecoveryInfo &recovery_info,
   return 0;
 }
 
-int ReplicatedBackend::send_push_op_legacy(int prio, pg_shard_t peer, PushOp &pop)
-{
-  ceph_tid_t tid = get_parent()->get_tid();
-  osd_reqid_t rid(get_parent()->get_cluster_msgr_name(), 0, tid);
-  MOSDSubOp *subop = new MOSDSubOp(
-    rid, parent->whoami_shard(),
-    spg_t(get_info().pgid.pgid, peer.shard), pop.soid,
-    0, get_osdmap()->get_epoch(),
-    tid, pop.recovery_info.version);
-  subop->ops = vector<OSDOp>(1);
-  subop->ops[0].op.op = CEPH_OSD_OP_PUSH;
-
-  subop->set_priority(prio);
-  subop->version = pop.version;
-  subop->ops[0].indata.claim(pop.data);
-  subop->data_included.swap(pop.data_included);
-  subop->omap_header.claim(pop.omap_header);
-  subop->omap_entries.swap(pop.omap_entries);
-  subop->attrset.swap(pop.attrset);
-  subop->recovery_info = pop.recovery_info;
-  subop->current_progress = pop.before_progress;
-  subop->recovery_progress = pop.after_progress;
-
-  get_parent()->send_message_osd_cluster(peer.osd, subop, get_osdmap()->get_epoch());
-  return 0;
-}
-
 void ReplicatedBackend::prep_push_op_blank(const hobject_t& soid, PushOp *op)
 {
   op->recovery_info.version = eversion_t();
   op->version = eversion_t();
   op->soid = soid;
-}
-
-void ReplicatedBackend::sub_op_push_reply(OpRequestRef op)
-{
-  const MOSDSubOpReply *reply = static_cast<const MOSDSubOpReply*>(op->get_req());
-  const hobject_t& soid = reply->get_poid();
-  assert(reply->get_type() == MSG_OSD_SUBOPREPLY);
-  dout(10) << "sub_op_push_reply from " << reply->get_source() << " " << *reply << dendl;
-  pg_shard_t peer = reply->from;
-
-  op->mark_started();
-
-  PushReplyOp rop;
-  rop.soid = soid;
-  PushOp pop;
-  bool more = handle_push_reply(peer, rop, &pop);
-  if (more)
-    send_push_op_legacy(op->get_req()->get_priority(), peer, pop);
 }
 
 bool ReplicatedBackend::handle_push_reply(
@@ -2238,40 +2118,6 @@ bool ReplicatedBackend::handle_push_reply(
       return false;
     }
   }
-}
-
-/** op_pull
- * process request to pull an entire object.
- * NOTE: called from opqueue.
- */
-void ReplicatedBackend::sub_op_pull(OpRequestRef op)
-{
-  const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
-  assert(m->get_type() == MSG_OSD_SUBOP);
-
-  op->mark_started();
-
-  const hobject_t soid = m->poid;
-
-  dout(7) << "pull" << soid << " v " << m->version
-          << " from " << m->get_source()
-          << dendl;
-
-  assert(!is_primary());  // we should be a replica or stray.
-
-  PullOp pop;
-  pop.soid = soid;
-  pop.recovery_info = m->recovery_info;
-  pop.recovery_progress = m->recovery_progress;
-
-  PushOp reply;
-  handle_pull(m->from, pop, &reply);
-  send_push_op_legacy(
-    m->get_priority(),
-    m->from,
-    reply);
-
-  log_subop_stats(get_parent()->get_logger(), op, l_osd_sop_pull);
 }
 
 void ReplicatedBackend::handle_pull(pg_shard_t peer, PullOp &op, PushOp *reply)
@@ -2344,69 +2190,6 @@ void ReplicatedBackend::trim_pushed_data(
     }
     off += p.get_len();
   }
-}
-
-/** op_push
- * NOTE: called from opqueue.
- */
-void ReplicatedBackend::sub_op_push(OpRequestRef op)
-{
-  op->mark_started();
-  // don't bother with const-ness here; we're about to kill MOSDSubOp
-  // anyway.
-  MOSDSubOp *m = static_cast<MOSDSubOp *>(op->get_nonconst_req());
-
-  PushOp pop;
-  pop.soid = m->poid;
-  pop.version = m->version;
-  m->claim_data(pop.data);
-  pop.data_included.swap(m->data_included);
-  pop.omap_header.swap(m->omap_header);
-  pop.omap_entries.swap(m->omap_entries);
-  pop.attrset.swap(m->attrset);
-  pop.recovery_info = m->recovery_info;
-  pop.before_progress = m->current_progress;
-  pop.after_progress = m->recovery_progress;
-  ObjectStore::Transaction t;
-
-  if (is_primary()) {
-    PullOp resp;
-    RPGHandle *h = _open_recovery_op();
-    list<pull_complete_info> to_continue;
-    bool more = handle_pull_response(
-      m->from, pop, &resp,
-      &to_continue, &t);
-    if (more) {
-      send_pull_legacy(
-	m->get_priority(),
-	m->from,
-	resp.recovery_info,
-	resp.recovery_progress);
-    } else {
-      C_ReplicatedBackend_OnPullComplete *c =
-	new C_ReplicatedBackend_OnPullComplete(
-	  this,
-	  op->get_req()->get_priority());
-      c->to_continue.swap(to_continue);
-      t.register_on_complete(
-	new PG_RecoveryQueueAsync(
-	  get_parent(),
-	  get_parent()->bless_gencontext(c)));
-    }
-    run_recovery_op(h, op->get_req()->get_priority());
-  } else {
-    PushReplyOp resp;
-    MOSDSubOpReply *reply = new MOSDSubOpReply(
-      m, parent->whoami_shard(), 0,
-      get_osdmap()->get_epoch(), CEPH_OSD_FLAG_ACK);
-    reply->set_priority(m->get_priority());
-    assert(entity_name_t::TYPE_OSD == m->get_connection()->peer_type);
-    handle_push(m->from, pop, &resp, &t);
-    t.register_on_complete(new PG_SendMessageOnConn(
-			      get_parent(), reply, m->get_connection()));
-  }
-  get_parent()->queue_transaction(std::move(t));
-  return;
 }
 
 void ReplicatedBackend::_failed_push(pg_shard_t from, const hobject_t &soid)

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -224,10 +224,6 @@ private:
   void clear_pull_from(
     map<hobject_t, PullInfo>::iterator piter);
 
-  void sub_op_push(OpRequestRef op);
-  void sub_op_push_reply(OpRequestRef op);
-  void sub_op_pull(OpRequestRef op);
-
   void _do_push(OpRequestRef op);
   void _do_pull_response(OpRequestRef op);
   void do_push(OpRequestRef op) {
@@ -263,11 +259,6 @@ private:
 
   void send_pushes(int prio, map<pg_shard_t, vector<PushOp> > &pushes);
   void prep_push_op_blank(const hobject_t& soid, PushOp *op);
-  int send_push_op_legacy(int priority, pg_shard_t peer,
-			  PushOp &pop);
-  int send_pull_legacy(int priority, pg_shard_t peer,
-		       const ObjectRecoveryInfo& recovery_info,
-		       ObjectRecoveryProgress progress);
   void send_pulls(
     int priority,
     map<pg_shard_t, vector<PullOp> > &pulls);

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -405,8 +405,8 @@ private:
     ObjectStore::Transaction &op_t);
   void op_applied(InProgressOp *op);
   void op_commit(InProgressOp *op);
-  void sub_op_modify_reply(OpRequestRef op);
-  void sub_op_modify(OpRequestRef op);
+  void do_repop_reply(OpRequestRef op);
+  void do_repop(OpRequestRef op);
 
   struct RepModify {
     OpRequestRef op;
@@ -425,8 +425,8 @@ private:
   struct C_OSD_RepModifyApply;
   struct C_OSD_RepModifyCommit;
 
-  void sub_op_modify_applied(RepModifyRef rm);
-  void sub_op_modify_commit(RepModifyRef rm);
+  void repop_applied(RepModifyRef rm);
+  void repop_commit(RepModifyRef rm);
   bool scrub_supported() override { return true; }
   bool auto_repair_supported() const override { return false; }
 


### PR DESCRIPTION
Replace them with new messages.  Keep some handling around for the jewel -> luminous upgrade (we can remove MOSDSubOp[Reply] entirely post-luminous).