### PR TITLE
rgw: optimize handling of conditional RGWEnv logic

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -382,6 +382,7 @@ public:
   void init(CephContext *cct, char **envp);
   void set(const boost::string_ref& name, const boost::string_ref& val);
   const char *get(const char *name, const char *def_val = NULL);
+  const std::string& get(const std::string& name, bool *exists) const;
   int get_int(const char *name, int def_val = 0);
   bool get_bool(const char *name, bool def_val = 0);
   size_t get_size(const char *name, size_t def_val = 0);

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -51,6 +51,19 @@ const char *RGWEnv::get(const char *name, const char *def_val)
   return iter->second.c_str();
 }
 
+static std::string empty_str;
+const std::string& RGWEnv::get(const std::string& name,
+			       bool *exists) const
+{
+  const auto& iter = env_map.find(name);
+  if (iter == env_map.end()) {
+    *exists = false;
+    return empty_str;
+  }
+  *exists = true;
+  return iter->second;
+}
+
 int RGWEnv::get_int(const char *name, int def_val)
 {
   map<string, string, ltstr_nocase>::iterator iter = env_map.find(name);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -597,13 +597,14 @@ static int get_swift_versioning_settings(
 {
   /* Removing the Swift's versions location has lower priority than setting
    * a new one. That's the reason why we're handling it first. */
-  const std::string vlocdel =
-    s->info.env->get("HTTP_X_REMOVE_VERSIONS_LOCATION", "");
-  if (vlocdel.size()) {
+  bool exists = s->info.env->exists("HTTP_X_REMOVE_VERSIONS_LOCATION");
+  if (exists) {
     swift_ver_location = boost::in_place(std::string());
   }
 
-  if (s->info.env->exists("HTTP_X_VERSIONS_LOCATION")) {
+  const std::string& vloc = s->info.env->get("HTTP_X_VERSIONS_LOCATION",
+					     &exists);
+  if (exists) {
     /* If the Swift's versioning is globally disabled but someone wants to
      * enable it for a given container, new version of Swift will generate
      * the precondition failed error. */
@@ -611,7 +612,7 @@ static int get_swift_versioning_settings(
       return -ERR_PRECONDITION_FAILED;
     }
 
-    swift_ver_location = s->info.env->get("HTTP_X_VERSIONS_LOCATION", "");
+    swift_ver_location = vloc;
   }
 
   return 0;


### PR DESCRIPTION
Follow the pattern established in RGWHTTPArgs, adding a get()
operation which takes an bool "exists" argument--not optional
here for simplicity.

Call the method from (one location in) rgw_rest_swift.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>