### PR TITLE
tests: add require_jewel_osds to upgrade/hammer-x/tiering

### DIFF
--- a/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
+++ b/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
@@ -71,9 +71,15 @@ upgrade-second-half:
       duration: 60
   - ceph.restart:
       daemons: [osd.3]
-      wait-for-healthy: true
+      wait-for-healthy: false
+      wait-for-osds-up: true
   - sleep:
       duration: 60
+   - exec:
+       mon.a:
+         - ceph osd set require_jewel_osds
+  - ceph.healthy:
+  - print: "**** HEALTH_OK reached after upgrading last OSD to jewel"
 
 flip-but-fail:
   sequential:


### PR DESCRIPTION
Note that there is no `upgrade/jewel-x/tiering` in kraken+master, so it's enough to fix this in jewel.

This PR fixes the test yaml so it properly sets `require_jewel_osds`.

Without this patch the test should fail all the time, but it doesn't - there are occasional false positives due to a race condition in `ceph.restart` which is tracked by http://tracker.ceph.com/issues/18920