### PR TITLE
rgw: change loglevel to 5 in user's quota sync.

### DIFF
--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -591,7 +591,7 @@ int RGWUserStatsCache::sync_user(const rgw_user& user)
   string user_str = user.to_str();
   int ret = store->cls_user_get_header(user_str, &header);
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "ERROR: can't read user header: ret=" << ret << dendl;
+    ldout(store->ctx(), 5) << "ERROR: can't read user header: ret=" << ret << dendl;
     return ret;
   }
 
@@ -644,7 +644,7 @@ int RGWUserStatsCache::sync_all_users()
       ldout(store->ctx(), 20) << "RGWUserStatsCache: sync user=" << user << dendl;
       int ret = sync_user(user);
       if (ret < 0) {
-        ldout(store->ctx(), 0) << "ERROR: sync_user() failed, user=" << user << " ret=" << ret << dendl;
+        ldout(store->ctx(), 5) << "ERROR: sync_user() failed, user=" << user << " ret=" << ret << dendl;
 
         /* continuing to next user */
         continue;


### PR DESCRIPTION
If we create a user and the user hasn't do anything, user's quota sync also print the error:
`0 ERROR: can't read user header: ret=-2`  
`0 ERROR: sync_user() failed, user=testuser ret=-2`

Fixes: http://tracker.ceph.com/issues/18921

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>