### PR TITLE
os/bluestore: add "_" prefix for internal methods

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7118,7 +7118,7 @@ void BlueStore::_txc_finish_kv(TransContext *txc)
   if (!txc->oncommits.empty()) {
     finishers[n]->queue(txc->oncommits);
   }
-  op_queue_release_throttle(txc);
+  _op_queue_release_throttle(txc);
 }
 
 void BlueStore::BSPerfTracker::update_from_perfcounters(
@@ -7157,7 +7157,7 @@ void BlueStore::_txc_finish(TransContext *txc)
     txc->removed_collections.pop_front();
   }
 
-  op_queue_release_wal_throttle(txc);
+  _op_queue_release_wal_throttle(txc);
 
   OpSequencerRef osr = txc->osr;
   {
@@ -7606,8 +7606,8 @@ int BlueStore::queue_transactions(
   if (handle)
     handle->suspend_tp_timeout();
 
-  op_queue_reserve_throttle(txc);
-  op_queue_reserve_wal_throttle(txc);
+  _op_queue_reserve_throttle(txc);
+  _op_queue_reserve_wal_throttle(txc);
 
   if (handle)
     handle->reset_tp_timeout();
@@ -7621,7 +7621,7 @@ int BlueStore::queue_transactions(
   return 0;
 }
 
-void BlueStore::op_queue_reserve_throttle(TransContext *txc)
+void BlueStore::_op_queue_reserve_throttle(TransContext *txc)
 {
   throttle_ops.get(txc->ops);
   throttle_bytes.get(txc->bytes);
@@ -7630,7 +7630,7 @@ void BlueStore::op_queue_reserve_throttle(TransContext *txc)
   logger->set(l_bluestore_cur_bytes_in_queue, throttle_bytes.get_current());
 }
 
-void BlueStore::op_queue_release_throttle(TransContext *txc)
+void BlueStore::_op_queue_release_throttle(TransContext *txc)
 {
   throttle_ops.put(txc->ops);
   throttle_bytes.put(txc->bytes);
@@ -7639,7 +7639,7 @@ void BlueStore::op_queue_release_throttle(TransContext *txc)
   logger->set(l_bluestore_cur_bytes_in_queue, throttle_bytes.get_current());
 }
 
-void BlueStore::op_queue_reserve_wal_throttle(TransContext *txc)
+void BlueStore::_op_queue_reserve_wal_throttle(TransContext *txc)
 {
   throttle_wal_ops.get(txc->ops);
   throttle_wal_bytes.get(txc->bytes);
@@ -7648,7 +7648,7 @@ void BlueStore::op_queue_reserve_wal_throttle(TransContext *txc)
   logger->set(l_bluestore_cur_bytes_in_wal_queue, throttle_wal_bytes.get_current());
 }
 
-void BlueStore::op_queue_release_wal_throttle(TransContext *txc)
+void BlueStore::_op_queue_release_wal_throttle(TransContext *txc)
 {
   throttle_wal_ops.put(txc->ops);
   throttle_wal_bytes.put(txc->bytes);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2311,10 +2311,10 @@ private:
 			CollectionRef& d,
 			unsigned bits, int rem);
 
-  void op_queue_reserve_throttle(TransContext *txc);
-  void op_queue_release_throttle(TransContext *txc);
-  void op_queue_reserve_wal_throttle(TransContext *txc);
-  void op_queue_release_wal_throttle(TransContext *txc);
+  void _op_queue_reserve_throttle(TransContext *txc);
+  void _op_queue_release_throttle(TransContext *txc);
+  void _op_queue_reserve_wal_throttle(TransContext *txc);
+  void _op_queue_release_wal_throttle(TransContext *txc);
 };
 
 inline ostream& operator<<(ostream& out, const BlueStore::OpSequencer& s) {


### PR DESCRIPTION
These 4 methods are reserved for internal use only.
Prefix them with "_" to keep pace with others.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>