### PR TITLE
msg/async: support IPv6 QoS.

### DIFF
--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -278,7 +278,7 @@ int PosixServerSocketImpl::accept(ConnectedSocket *sock, const SocketOptions &op
     ::close(sd);
     return -errno;
   }
-  handler.set_priority(sd, opt.priority);
+  handler.set_priority(sd, opt.priority, out->get_family());
 
   std::unique_ptr<PosixConnectedSocketImpl> csi(new PosixConnectedSocketImpl(handler, *out, sd, true));
   *sock = ConnectedSocket(std::move(csi));
@@ -348,7 +348,7 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
     return -errno;
   }
 
-  net.set_priority(sd, opts.priority);
+  net.set_priority(sd, opts.priority, addr.get_family());
   *socket = ConnectedSocket(
       std::unique_ptr<PosixConnectedSocketImpl>(new PosixConnectedSocketImpl(net, addr, sd, !opts.nonblock)));
   return 0;

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -123,16 +123,30 @@ int NetHandler::set_socket_options(int sd, bool nodelay, int size)
   return r;
 }
 
-void NetHandler::set_priority(int sd, int prio)
+void NetHandler::set_priority(int sd, int prio, int domain)
 {
   if (prio >= 0) {
     int r = -1;
 #ifdef IPTOS_CLASS_CS6
     int iptos = IPTOS_CLASS_CS6;
     r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
-    if (r < 0) {
-      ldout(cct, 0) << __func__ << " couldn't set IP_TOS to " << iptos
-                    << ": " << cpp_strerror(errno) << dendl;
+    if (domain == AF_INET) {
+      r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));
+      r = -errno;
+      if (r < 0) {
+        ldout(cct,0) << "couldn't set IP_TOS to " << iptos
+                           << ": " << cpp_strerror(r) << dendl;
+      }
+    } else if (domain == AF_INET6) {
+      r = ::setsockopt(sd, IPPROTO_IPV6, IPV6_TCLASS, &iptos, sizeof(iptos));
+      r = -errno;
+      if (r < 0) {
+        ldout(cct,0) << "couldn't set IPV6_TCLASS to " << iptos
+                           << ": " << cpp_strerror(r) << dendl;
+      }
+    } else {
+      ldout(cct,0) << "couldn't set ToS of unknown family to " << iptos
+                         << dendl;
     }
 #endif
 #if defined(SO_PRIORITY) 

--- a/src/msg/async/net_handler.h
+++ b/src/msg/async/net_handler.h
@@ -40,7 +40,7 @@ namespace ceph {
      */
     int reconnect(const entity_addr_t &addr, int sd);
     int nonblock_connect(const entity_addr_t &addr, const entity_addr_t& bind_addr);
-    void set_priority(int sd, int priority);
+    void set_priority(int sd, int priority, int domain);
   };
 }
 


### PR DESCRIPTION
Extend DSCP marking for heartbeat packets to IPv6.

Backport: jewel, luminious
See-Also: http://tracker.ceph.com/issues/18887
Fixes: http://tracker.ceph.com/issues/18928
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>