### PR TITLE
ceph_common.sh: fix syntax error

### DIFF
--- a/src/ceph_common.sh
+++ b/src/ceph_common.sh
@@ -159,7 +159,7 @@ do_root_cmd_okfail() {
 get_local_daemon_list() {
     type=$1
     if [ -d "/var/lib/ceph/$type" ]; then
-	for p in `find -L /var/lib/ceph/$type -mindepth 1 -maxdepth 1 -type d'`; do
+	for p in `find -L /var/lib/ceph/$type -mindepth 1 -maxdepth 1 -type d`; do
 	    i=`basename $p` 
 	    if [ -e "/var/lib/ceph/$type/$i/sysvinit" ]; then
 		id=`echo $i | sed 's/[^-]*-//'`


### PR DESCRIPTION
Introduced by 299b7d06ac18c5cd30b8b65c7d25df9fc00287db
Fixes: http://tracker.ceph.com/issues/17826

Signed-off-by: Dan Mick <dan.mick@redhat.com>