### PR TITLE
tests: remove extra indentation in exec block

### DIFF
--- a/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
+++ b/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
@@ -75,9 +75,9 @@ upgrade-second-half:
       wait-for-osds-up: true
   - sleep:
       duration: 60
-   - exec:
-       mon.a:
-         - ceph osd set require_jewel_osds
+  - exec:
+      mon.a:
+        - ceph osd set require_jewel_osds
   - ceph.healthy:
   - print: "**** HEALTH_OK reached after upgrading last OSD to jewel"
 


### PR DESCRIPTION
The exec block was indented by an extra space, causing

line 439, in parse_block_mapping_key
    "expected <block end>, but found %r" % token.id, token.start_mark)
yaml.parser.ParserError: while parsing a block mapping
  in "<string>", line 111, column 3:
      sequential:
      ^
expected <block end>, but found '<block sequence start>'
  in "<string>", line 126, column 4:
       - exec:
       ^

when trying to run upgrade/hammer-x

Reported-by: Yuri Weinstein <yweins@redhat.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>