### PR TITLE
os/bluestore: add flush_store_cache cmd

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1502,6 +1502,7 @@ public:
 
   virtual void get_db_statistics(Formatter *f) { }
   virtual void generate_db_histogram(Formatter *f) { }
+  virtual void flush_cache() { }
   virtual void dump_perf_counters(Formatter *f) {}
 
   virtual string get_type() = 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9874,4 +9874,11 @@ void BlueStore::generate_db_histogram(Formatter *f)
   dout(20) << __func__ << " finished in " << duration << " seconds" << dendl;
 
 }
+
+void BlueStore::flush_cache()
+{
+  for (auto i : cache_shards) {
+    i->trim_all();
+  }
+}
 // ===========================================

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -904,6 +904,10 @@ public:
     void trim(uint64_t target_bytes, float target_meta_ratio,
 	      float bytes_per_onode);
 
+    void trim_all() {
+      _trim(0, 0);
+    }
+
     virtual void _trim(uint64_t onode_max, uint64_t buffer_max) = 0;
 
     virtual void add_stats(uint64_t *onodes, uint64_t *extents,
@@ -1875,6 +1879,7 @@ public:
 
   void get_db_statistics(Formatter *f) override;
   void generate_db_histogram(Formatter *f) override;
+  void flush_cache() override;
   void dump_perf_counters(Formatter *f) override {
     f->open_object_section("perf_counters");
     logger->dump_formatted(f, false);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1950,6 +1950,8 @@ bool OSD::asok_command(string command, cmdmap_t& cmdmap, string format,
     service.dumps_scrub(f);
   } else if (command == "calc_objectstore_db_histogram") {
     store->generate_db_histogram(f);
+  } else if (command == "flush_store_cache") {
+    store->flush_cache();
   } else {
     assert(0 == "broken asok registration");
   }
@@ -2421,8 +2423,16 @@ void OSD::final_init()
 				     "print scheduled scrubs");
   assert(r == 0);
 
-  r = admin_socket->register_command("calc_objectstore_db_histogram", "calc_objectstore_db_histogram", asok_hook,
-					 "Generate key value histogram of kvdb(rocksdb) which used by bluestore");
+  r = admin_socket->register_command("calc_objectstore_db_histogram",
+                                     "calc_objectstore_db_histogram",
+                                     asok_hook,
+                                     "Generate key value histogram of kvdb(rocksdb) which used by bluestore");
+  assert(r == 0);
+
+  r = admin_socket->register_command("flush_store_cache",
+                                     "flush_store_cache",
+                                     asok_hook,
+                                     "Flush bluestore internal cache");
   assert(r == 0);
 
   test_ops_hook = new TestOpsSocketHook(&(this->service), this->store);
@@ -2782,6 +2792,7 @@ int OSD::shutdown()
   cct->get_admin_socket()->unregister_command("get_heap_property");
   cct->get_admin_socket()->unregister_command("dump_objectstore_kv_stats");
   cct->get_admin_socket()->unregister_command("calc_objectstore_db_histogram");
+  cct->get_admin_socket()->unregister_command("flush_store_cache");
   delete asok_hook;
   asok_hook = NULL;
 


### PR DESCRIPTION
We want this cmd for bluestore testing, e.g., to exclude the impact of
the bluestore internal cache without rebooting host.

e.g.:
[root@tecs131 ~]# ceph --admin-daemon /run/ceph/ceph-osd.1.asok perf dump | grep "bluestore_buffers"
        "bluestore_buffers": 3166,
[root@tecs131 ~]# ceph --admin-daemon /run/ceph/ceph-osd.1.asok flush_store_cache
[root@tecs131 ~]# ceph --admin-daemon /run/ceph/ceph-osd.1.asok perf dump | grep "bluestore_buffers"
        "bluestore_buffers": 95,

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>