### PR TITLE
test/libcephfs: avoid buffer overflow when testing ceph_getdents()

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -362,7 +362,7 @@ TEST(LibCephFS, DirLs) {
 
   // test getdents
   struct dirent *getdents_entries;
-  getdents_entries = (struct dirent *)malloc(r * sizeof(*getdents_entries));
+  getdents_entries = (struct dirent *)malloc((r + 2) * sizeof(*getdents_entries));
 
   int count = 0;
   std::vector<std::string> found;


### PR DESCRIPTION
The buffer size should be at least "2 * sizeof(struct dirent)".
Otherwise, the code that checks dentry '..' overflow.

Fixes: http://tracker.ceph.com/issues/18941
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>