### PR TITLE
common/TracepointProvider: add assert if dlopen error.

### DIFF
--- a/src/common/TracepointProvider.cc
+++ b/src/common/TracepointProvider.cc
@@ -40,5 +40,6 @@ void TracepointProvider::verify_config(const struct md_config_t *conf) {
   }
 
   m_handle = dlopen(m_library.c_str(), RTLD_NOW);
+  assert(m_handle);
 }
 


### PR DESCRIPTION
Because some reasons, if dlopen error the ceph-osd still work. But we
don't see related tracepoint by 'lttng list -u'. So add this assert to
make easily find the problem.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>