### PR TITLE
pybind: cephfs should be built without librados / python-rados

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -572,7 +572,9 @@ Summary:	Python 2 libraries for Ceph distributed file system
 Group:		System Environment/Libraries
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
-Requires:	python-rados = %{epoch}:%{version}-%{release}
+%if 0%{?suse_version}
+Recommends: python-rados = %{epoch}:%{version}-%{release}
+%endif
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
 %description -n python-cephfs
 This package contains Python 2 libraries for interacting with Cephs distributed

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -361,7 +361,7 @@ cdef class LibCephFS(object):
         if conf is not None and not isinstance(conf, dict):
             raise TypeError("conf must be dict or None")
         cstr(conffile, 'configfile', opt=True)
-        auth_id = cstr(auth_id, 'configfile', opt=True)
+        auth_id = cstr(auth_id, 'auth_id', opt=True)
 
         cdef:
             char* _auth_id = opt_str(auth_id)

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -339,6 +339,13 @@ cdef class LibCephFS(object):
                                   "CephFS object in state %s." % (self.state))
 
     def __cinit__(self, conf=None, conffile=None, auth_id=None, rados_inst=None):
+        """Create a libcephfs wrapper
+
+        :param conf dict opt: settings overriding the default ones and conffile
+        :param conffile str opt: the path to ceph.conf to override the default settings
+        :auth_id str opt: the id used to authenticate the client entity
+        :rados_inst Rados opt: a rados.Rados instance
+        """
         PyEval_InitThreads()
         self.state = "uninitialized"
         if rados_inst is not None:

--- a/src/pybind/cephfs/setup.py
+++ b/src/pybind/cephfs/setup.py
@@ -106,7 +106,7 @@ def check_sanity():
         compiler.link_executable(
             objects=link_objects,
             output_progname=os.path.join(tmp_dir, 'cephfs_dummy'),
-            libraries=['cephfs', 'rados'],
+            libraries=['cephfs'],
             output_dir=tmp_dir,
         )
 
@@ -180,7 +180,7 @@ setup(
                 [source],
                 include_dirs=flags['cflags']['I'],
                 library_dirs=flags['ldflags']['L'],
-                libraries=['rados', 'cephfs'] + flags['ldflags']['l'],
+                libraries=['cephfs'] + flags['ldflags']['l'],
                 extra_compile_args=flags['cflags']['extras'] + flags['ldflags']['extras'],
             )
         ],


### PR DESCRIPTION
this addresses the build failure at https://jenkins.ceph.com/job/ceph-dev-new-build/ARCH=x86_64,AVAILABLE_ARCH=x86_64,AVAILABLE_DIST=centos7,DIST=centos7,MACHINE_SIZE=huge/1284//consoleFull , and includes some cleanups along the way.

```
Scanning dependencies of target cython3_cephfs
/usr/bin/ld: cannot find -lrados
collect2: error: ld returned 1 exit status

Link Error: Ceph FS library not found
make[2]: *** [src/pybind/cephfs3/CMakeFiles/cython3_cephfs] Error 1
make[1]: *** [src/pybind/cephfs3/CMakeFiles/cython3_cephfs.dir/all] Error 2
```