### PR TITLE
rgw: fix ver location owner is not consistent, the object cannot be able to delete

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6205,7 +6205,7 @@ int RGWRados::swift_versioning_restore(RGWObjectCtx& obj_ctx,
    *
    * TODO: delegate this check to un upper layer and compare with ACLs. */
   if (bucket_info.owner != archive_binfo.owner) {
-    return -EPERM;
+    return 0;
   }
 
   /* This code will be executed on latest version of the object. */


### PR DESCRIPTION
when the onwer of swift ver location is not consistent with src bucket, the object in src bucket cannot be deleted, which is not compatible with openstack swift.

http://tracker.ceph.com/issues/18942
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>