### PR TITLE
qa/workunits/objectstore/test_fuse.sh: use portable function decl

### DIFF
--- a/qa/workunits/objectstore/test_fuse.sh
+++ b/qa/workunits/objectstore/test_fuse.sh
@@ -2,7 +2,7 @@
 
 if ! id -u | grep -q '^0$'; then
     echo "not root, re-running self via sudo"
-    sudo PATH=$PATH TYPE=$TYPE $0 || echo FAIL
+    sudo PATH=$PATH TYPE=$TYPE $0
     exit 0
 fi
 

--- a/qa/workunits/objectstore/test_fuse.sh
+++ b/qa/workunits/objectstore/test_fuse.sh
@@ -6,7 +6,7 @@ if ! id -u | grep -q '^0$'; then
     exit 0
 fi
 
-function expect_false()
+expect_false()
 {
         set -x
         if "$@"; then return 1; else return 0; fi


### PR DESCRIPTION
function f() is illegal in strict POSIX shells, like dash, which is
the default /bin/sh on Ubuntu

Signed-off-by: Dan Mick <dan.mick@redhat.com>