### PR TITLE
common/MemoryModel: Bump int to long and drop mallinfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -294,10 +294,6 @@ else(ALLOCATOR)
   endif(GPERFTOOLS_FOUND)
 endif(ALLOCATOR)
 
-# jemalloc does not support mallinfo
-if(NOT JEMALLOC_FOUND)
-  CHECK_FUNCTION_EXISTS(mallinfo HAVE_MALLINFO)
-endif()
 
 if(WITH_LIBCEPHFS OR WITH_KRBD)
   find_package(keyutils REQUIRED)

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -26,23 +26,22 @@ void MemoryModel::_sample(snap *psnap)
     ldout(cct, 0) << "check_memory_usage unable to open /proc/self/status" << dendl;
     return;
   }
-
   while (!f.eof()) {
     string line;
     getline(f, line);
     
     if (strncmp(line.c_str(), "VmSize:", 7) == 0)
-      psnap->size = atoi(line.c_str() + 7);
+      psnap->size = atol(line.c_str() + 7);
     else if (strncmp(line.c_str(), "VmRSS:", 6) == 0)
-      psnap->rss = atoi(line.c_str() + 7);
+      psnap->rss = atol(line.c_str() + 7);
     else if (strncmp(line.c_str(), "VmHWM:", 6) == 0)
-      psnap->hwm = atoi(line.c_str() + 7);
+      psnap->hwm = atol(line.c_str() + 7);
     else if (strncmp(line.c_str(), "VmLib:", 6) == 0)
-      psnap->lib = atoi(line.c_str() + 7);
+      psnap->lib = atol(line.c_str() + 7);
     else if (strncmp(line.c_str(), "VmPeak:", 7) == 0)
-      psnap->peak = atoi(line.c_str() + 7);
+      psnap->peak = atol(line.c_str() + 7);
     else if (strncmp(line.c_str(), "VmData:", 7) == 0)
-      psnap->data = atoi(line.c_str() + 7);
+      psnap->data = atol(line.c_str() + 7);
   }
   f.close();
 
@@ -52,7 +51,7 @@ void MemoryModel::_sample(snap *psnap)
     return;
   }
 
-  int heap = 0;
+  long heap = 0;
   while (f.is_open() && !f.eof()) {
     string line;
     getline(f, line);
@@ -83,7 +82,7 @@ void MemoryModel::_sample(snap *psnap)
     if (*end)
       end++;
 
-    int size = ae - as;
+    long size = ae - as;
     //ldout(cct, 0) << "size " << size << " mode is '" << mode << "' end is '" << end << "'" << dendl;
 
     /*
@@ -95,13 +94,4 @@ void MemoryModel::_sample(snap *psnap)
 
   psnap->heap = heap >> 10;
 
-  // ...
-#if defined(HAVE_MALLINFO)
-  struct mallinfo mi = mallinfo();
-  
-  psnap->malloc = mi.uordblks >> 10;
-  psnap->mmap = mi.hblks >> 10;
-#else
-#warning "mallinfo not implemented"
-#endif
 }

--- a/src/common/MemoryModel.h
+++ b/src/common/MemoryModel.h
@@ -20,22 +20,22 @@ class CephContext;
 class MemoryModel {
 public:
   struct snap {
-    int peak;
-    int size;
-    int hwm;
-    int rss;
-    int data;
-    int lib;
+    long peak;
+    long size;
+    long hwm;
+    long rss;
+    long data;
+    long lib;
     
-    int heap, malloc, mmap;
+    long heap;
 
     snap() : peak(0), size(0), hwm(0), rss(0), data(0), lib(0),
-	     heap(0), malloc(0), mmap(0)
+	     heap(0)
     {}
 
-    int get_total() { return size; }
-    int get_rss() { return rss; }
-    int get_heap() { return heap; }
+    long get_total() { return size; }
+    long get_rss() { return rss; }
+    long get_heap() { return heap; }
   } last;
 
 private:

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7377,7 +7377,6 @@ void MDCache::check_memory_usage()
 	   << " total " << last.get_total()
 	   << ", rss " << last.get_rss()
 	   << ", heap " << last.get_heap()
-	   << ", malloc " << last.malloc << " mmap " << last.mmap
 	   << ", baseline " << baseline.get_heap()
 	   << ", buffers " << (buffer::get_total_alloc() >> 10)
 	   << ", " << num_inodes_with_caps << " / " << inode_map.size() << " inodes have caps"
@@ -7386,7 +7385,6 @@ void MDCache::check_memory_usage()
 
   mds->mlogger->set(l_mdm_rss, last.get_rss());
   mds->mlogger->set(l_mdm_heap, last.get_heap());
-  mds->mlogger->set(l_mdm_malloc, last.malloc);
 
   if (num_inodes_with_caps > g_conf->mds_cache_size) {
     float ratio = (float)g_conf->mds_cache_size * .9 / (float)num_inodes_with_caps;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2387,7 +2387,6 @@ void MDSRank::create_logger()
     mdm_plb.add_u64_counter(l_mdm_caps, "cap-", "Capabilities removed");
     mdm_plb.add_u64(l_mdm_rss, "rss", "RSS");
     mdm_plb.add_u64(l_mdm_heap, "heap", "Heap size");
-    mdm_plb.add_u64(l_mdm_malloc, "malloc", "Malloc size");
     mdm_plb.add_u64(l_mdm_buf, "buf", "Buffer size");
     mlogger = mdm_plb.create_perf_counters();
     g_ceph_context->get_perfcounters_collection()->add(mlogger);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -87,7 +87,6 @@ enum {
   l_mdm_caps,
   l_mdm_rss,
   l_mdm_heap,
-  l_mdm_malloc,
   l_mdm_buf,
   l_mdm_last,
 };


### PR DESCRIPTION
mallinfo(3) doesnt have 64bit compatible version so when
malloc size > 4GB, either wrapped value or a negtive value
returned, which is really misleading.

Also bump up all int to long to prevent overflow oneday we
have > 2TB memory.

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>