### PR TITLE
os/FuseStore: include <functional> header in src/os/FuseStore.h for gcc 7.x

### DIFF
--- a/src/os/FuseStore.h
+++ b/src/os/FuseStore.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <map>
 #include <mutex>
+#include <functional>
 
 #include "common/Thread.h"
 #include "include/buffer.h"


### PR DESCRIPTION
This is done as per the Header Dependency Changes in gcc 7.
https://gcc.gnu.org/gcc-7/porting_to.html

Signed-off-by: Jos Collin <jcollin@redhat.com>