### PR TITLE
ceph-disk: Fix getting wrong group name when --setgroup in bluestore

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2939,7 +2939,7 @@ def mkfs(
                 '--osd-uuid', fsid,
                 '--keyring', os.path.join(path, 'keyring'),
                 '--setuser', get_ceph_user(),
-                '--setgroup', get_ceph_user(),
+                '--setgroup', get_ceph_group(),
             ],
         )
     else:


### PR DESCRIPTION
http://tracker.ceph.com/issues/18955

ceph-disk prepare --setgroup <GROUP NAME> will be wrong when using with
bluestore

Signed-off-by: craigchi <craig10624@gmail.com>