### PR TITLE
auth: 'ceph auth import -i' overwrites caps, if caps are not specified

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -518,6 +518,9 @@ function test_auth()
   #
   local auid=444
   ceph-authtool --create-keyring --name client.TEST --gen-key --set-uid $auid TEST-keyring
+  expect_false ceph auth import --in-file TEST-keyring
+  rm TEST-keyring
+  ceph-authtool --create-keyring --name client.TEST --gen-key --cap mon "allow r" --set-uid $auid TEST-keyring
   ceph auth import --in-file TEST-keyring
   rm TEST-keyring
   ceph auth get client.TEST > $TMPFILE

--- a/src/mon/AuthMonitor.h
+++ b/src/mon/AuthMonitor.h
@@ -112,7 +112,7 @@ private:
   void upgrade_format();
 
   void export_keyring(KeyRing& keyring);
-  void import_keyring(KeyRing& keyring);
+  int import_keyring(KeyRing& keyring);
 
   void push_cephx_inc(KeyServerData::Incremental& auth_inc) {
     Incremental inc;


### PR DESCRIPTION
auth: 'ceph auth import -i' overwrites caps, if caps are not specified
in given keyring file, should alert user and should not allow this import.
Because in 'ceph auth list' we keep all the keyrings with caps and importing
'client.admin' user keyring without caps locks the cluster with error[1]
because admin keyring caps are missing in 'ceph auth'.

[1] Error connecting to cluster: PermissionDeniedError

Fixes: http://tracker.ceph.com/issues/18932

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>