### PR TITLE
ceph-disk: Write 10M to all partitions before zapping

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1510,6 +1510,34 @@ def zap(dev):
     if not stat.S_ISBLK(dmode) or is_partition(dev):
         raise Error('not full block device; cannot zap', dev)
     try:
+        # Thoroughly wipe all partitions from any traces of Filesystems or OSD Journals
+        #
+        # In addition we need to write 10M of data to each partition first to make
+        # sure that after re-creating the same paritions there is no trace
+        # left of any previous Filesystem or OSD Journal
+
+        LOG.debug('Writing zeros to existing partitions on %s', dev)
+
+        for partition in list_partitions(dev):
+            path = '/dev/{partition}'.format(partition=partition)
+            command_check_call(
+                [
+                    'wipefs',
+                    '--all',
+                    path,
+                ],
+            )
+
+            command_check_call(
+                [
+                    'dd',
+                    'if=/dev/zero',
+                    'of={path}'.format(path=path),
+                    'bs=1M',
+                    'count=10',
+                ],
+            )
+
         LOG.debug('Zapping partition table on %s', dev)
 
         # try to wipe out any GPT partition table backups.  sgdisk


### PR DESCRIPTION
By writing 10M of zeroes to each partition of the device we prevent that
old data causes troubles if exactly the same partition scheme is created
on the disk again and is read by the OSD.

This mainly involves the OSD's journal which will contain data from the
previous OSD and results in a assert of the OSD.

Fixes: http://tracker.ceph.com/issues/18962

Signed-off-by: Wido den Hollander <wido@42on.com>