### PR TITLE
make-srpm: Pass first parameter to make-dist for building SRPM

### DIFF
--- a/make-srpm.sh
+++ b/make-srpm.sh
@@ -1,4 +1,11 @@
 #!/bin/sh
 
-./make-dist
+#
+# Create a SRPM which can be used to build Ceph
+#
+# ./make-srpm.sh <version>
+# rpmbuild --rebuild /tmp/ceph/ceph-<version>-0.el7.centos.src.rpm
+#
+
+./make-dist $1
 rpmbuild -D"_sourcedir `pwd`" -D"_specdir `pwd`" -D"_srcrpmdir `pwd`" -bs ceph.spec


### PR DESCRIPTION
This allows for overriding the version to be build in the SRPM.

make-dist already supports this, pass down the parameter so you can run:

  $ ./make-srpm.sh 12.0.0

Afterwards RPMs can be build using:

  $ rpmbuild --rebuild /tmp/ceph-12.0.0.el7.src.rpm

Signed-off-by: Wido den Hollander <wido@42on.com>