### PR TITLE
rgw: don't log the env_map twice

### DIFF
--- a/src/rgw/rgw_client_io.cc
+++ b/src/rgw/rgw_client_io.cc
@@ -16,11 +16,10 @@ void BasicClient::init(CephContext *cct) {
   init_env(cct);
 
   if (cct->_conf->subsys.should_gather(ceph_subsys_rgw, 20)) {
-    std::map<string, string, ltstr_nocase>& env_map = get_env().get_map();
-    std::map<string, string, ltstr_nocase>::iterator iter;
+    const auto& env_map = get_env().get_map();
 
-    for (iter = env_map.begin(); iter != env_map.end(); ++iter) {
-      ldout(cct, 20) << iter->first << "=" << iter->second << dendl;
+    for (const auto& iter: env_map) {
+      ldout(cct, 20) << iter.first << "=" << iter.second << dendl;
     }
   }
 }

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -19,8 +19,6 @@ void RGWEnv::init(CephContext *cct)
 void RGWEnv::set(const boost::string_ref& name, const boost::string_ref& val)
 {
   env_map[std::string{name}] = std::string{val};
-
-  dout(20) << "RGWEnv::set(): " << name << ": " << val << dendl;
 }
 
 void RGWEnv::init(CephContext *cct, char **envp)


### PR DESCRIPTION
We already print the env_map during the `RGWEnv::set` operation,
making this redundant

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>