### PR TITLE
kraken: ceph-disk: Fix getting wrong group name when --setgroup in bluestore

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2907,7 +2907,7 @@ def mkfs(
                 '--osd-uuid', fsid,
                 '--keyring', os.path.join(path, 'keyring'),
                 '--setuser', get_ceph_user(),
-                '--setgroup', get_ceph_user(),
+                '--setgroup', get_ceph_group(),
             ],
         )
     else:


### PR DESCRIPTION
http://tracker.ceph.com/issues/18956