### PR TITLE
jewel: build/ops: "osd marked itself down" will not recognised if host runs mon + osd on shutdown/reboot

### DIFF
--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Ceph object storage daemon
-After=network-online.target local-fs.target time-sync.target
+After=network-online.target local-fs.target time-sync.target ceph-mon.target
 Wants=network-online.target local-fs.target time-sync.target
 PartOf=ceph-osd.target
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/18906