### PR TITLE
osd/PGLog: fix index for parent and child log on split

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -35,8 +35,10 @@ PGLog::IndexedLog PGLog::IndexedLog::split_out_child(
   pg_t child_pgid,
   unsigned split_bits)
 {
+  unindex();
   IndexedLog ret(pg_log_t::split_out_child(child_pgid, split_bits));
   index();
+  ret.index();
   reset_rollback_info_trimmed_to_riter();
   return ret;
 }

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -31,16 +31,16 @@ static ostream& _prefix(std::ostream *_dout, const PGLog *pglog)
 
 //////////////////// PGLog::IndexedLog ////////////////////
 
-PGLog::IndexedLog PGLog::IndexedLog::split_out_child(
+void PGLog::IndexedLog::split_out_child(
   pg_t child_pgid,
-  unsigned split_bits)
+  unsigned split_bits,
+  PGLog::IndexedLog *target)
 {
   unindex();
-  IndexedLog ret(pg_log_t::split_out_child(child_pgid, split_bits));
+  *target = pg_log_t::split_out_child(child_pgid, split_bits);
   index();
-  ret.index();
+  target->index();
   reset_rollback_info_trimmed_to_riter();
-  return ret;
 }
 
 void PGLog::IndexedLog::trim(

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -213,9 +213,10 @@ public:
       index();
     }
 
-    IndexedLog split_out_child(
+    void split_out_child(
       pg_t child_pgid,
-      unsigned split_bits);
+      unsigned split_bits,
+      IndexedLog *target);
 
     void zero() {
       // we must have already trimmed the old entries
@@ -655,7 +656,7 @@ public:
       pg_t child_pgid,
       unsigned split_bits,
       PGLog *opg_log) { 
-    opg_log->log = log.split_out_child(child_pgid, split_bits);
+    log.split_out_child(child_pgid, split_bits, &opg_log->log);
     missing.split_into(child_pgid, split_bits, &(opg_log->missing));
     opg_log->mark_dirty_to(eversion_t::max());
     mark_dirty_to(eversion_t::max());


### PR DESCRIPTION
This fixes dup op detection post-split.

http://tracker.ceph.com/issues/18975