### PR TITLE
jewel: rgw: make sending Content-Length in 204 and 304 controllable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1313,6 +1313,7 @@ OPTION(rgw_admin_entry, OPT_STR, "admin")  // entry point for which a url is con
 OPTION(rgw_enforce_swift_acls, OPT_BOOL, true)
 OPTION(rgw_swift_token_expiration, OPT_INT, 24 * 3600) // time in seconds for swift token expiration
 OPTION(rgw_print_continue, OPT_BOOL, true)  // enable if 100-Continue works
+OPTION(rgw_print_prohibited_content_length, OPT_BOOL, false) // violate RFC 7230 and send Content-Length in 204 and 304
 OPTION(rgw_remote_addr_param, OPT_STR, "REMOTE_ADDR")  // e.g. X-Forwarded-For, if you have a reverse proxy
 OPTION(rgw_op_thread_timeout, OPT_INT, 10*60)
 OPTION(rgw_op_thread_suicide_timeout, OPT_INT, 0)

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -64,7 +64,8 @@ int RGWMongoose::complete_request()
        * 'given in the response.'
        *
        */
-      if (status_num == 204 || status_num == 304) {
+      if ((status_num == 204 || status_num == 304) &&
+          ! g_conf->rgw_print_prohibited_content_length) {
         has_content_length = true;
       } else if (0 && data.length() == 0) {
         has_content_length = true;

--- a/src/rgw/rgw_fcgi.cc
+++ b/src/rgw/rgw_fcgi.cc
@@ -52,8 +52,10 @@ int RGWFCGX::send_content_length(uint64_t len)
    * Status 204 should not include a content-length header
    * RFC7230 says so
    */
-  if (status_num == 204)
+  if ((status_num == 204 || status_num == 304) &&
+      ! g_conf->rgw_print_prohibited_content_length) {
     return 0;
+  }
 
   char buf[21];
   snprintf(buf, sizeof(buf), "%" PRIu64, len);


### PR DESCRIPTION
This is a Jewel backport of PR #10156.