### PR TITLE
os/bluestore: fix bug in aio_read()

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -947,7 +947,6 @@ int NVMEDevice::aio_read(
     bufferlist *pbl,
     IOContext *ioc)
 {
-  uint64_t len = bl.length();
   dout(20) << __func__ << " " << off << "~" << len << " ioc " << ioc << dendl;
   assert(off % block_size == 0);
   assert(len % block_size == 0);


### PR DESCRIPTION
fixed compilation issue  in aio_read() when enable spdk

Signed-off-by: tangwenjun <tang.wenjun3@zte.com.cn>