### PR TITLE
hammer: tests: ignore missing ceph-objectstore-tool apply-layout-settings sub…

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -297,6 +297,8 @@ class Thrasher:
                 output = proc.stderr.getvalue()
                 if 'Couldn\'t find pool' in output:
                     continue
+                if proc.exitstatus == 1 and 'Invalid syntax, missing command' in output:
+                    continue
                 if proc.exitstatus:
                     raise Exception("ceph-objectstore-tool apply-layout-settings"
                                     " failed with {status}".format(status=proc.exitstatus))


### PR DESCRIPTION
…command

In the upgrade/firefly-x suite, there are tests where the client is still
on firefly when this command is run.

Signed-off-by: Nathan Cutler <ncutler@suse.com>