### PR TITLE
kraken: rgw: make sending Content-Length in 204 and 304 controllable

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1443,6 +1443,7 @@ OPTION(rgw_admin_entry, OPT_STR, "admin")  // entry point for which a url is con
 OPTION(rgw_enforce_swift_acls, OPT_BOOL, true)
 OPTION(rgw_swift_token_expiration, OPT_INT, 24 * 3600) // time in seconds for swift token expiration
 OPTION(rgw_print_continue, OPT_BOOL, true)  // enable if 100-Continue works
+OPTION(rgw_print_prohibited_content_length, OPT_BOOL, false) // violate RFC 7230 and send Content-Length in 204 and 304
 OPTION(rgw_remote_addr_param, OPT_STR, "REMOTE_ADDR")  // e.g. X-Forwarded-For, if you have a reverse proxy
 OPTION(rgw_op_thread_timeout, OPT_INT, 10*60)
 OPTION(rgw_op_thread_suicide_timeout, OPT_INT, 0)

--- a/src/rgw/rgw_client_io_filters.h
+++ b/src/rgw/rgw_client_io_filters.h
@@ -291,7 +291,8 @@ public:
 
   size_t send_status(const int status,
                      const char* const status_name) override {
-    if (204 == status || 304 == status) {
+    if ((204 == status || 304 == status) &&
+        ! g_conf->rgw_print_prohibited_content_length) {
       action = ContentLengthAction::INHIBIT;
     } else {
       action = ContentLengthAction::FORWARD;


### PR DESCRIPTION
This is the Kraken backport of PR #10156.
Corresponding backport ticket: http://tracker.ceph.com/issues/18985.

CC: @mattbenjamin, @cbodley.