### PR TITLE
rpm: build ceph-resource-agents by default

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -14,7 +14,7 @@
 #
 # Please submit bugfixes or comments via http://tracker.ceph.com/
 # 
-%bcond_with ocf
+%bcond_without ocf
 %bcond_without cephfs_java
 %if 0%{?suse_version}
 %bcond_with ceph_test_package


### PR DESCRIPTION
To align with debian build

Fixes: http://tracker.ceph.com/issues/17613
Signed-off-by: Nathan Cutler <ncutler@suse.com>