### PR TITLE
rpm: drop boost build dependencies

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -96,10 +96,6 @@ BuildRequires:	selinux-policy-devel
 BuildRequires:	/usr/share/selinux/devel/policyhelp
 %endif
 BuildRequires:	bc
-BuildRequires:	boost-devel
-%if ! 0%{?suse_version}
-BuildRequires:	boost-python
-%endif
 BuildRequires:  cmake
 BuildRequires:	cryptsetup
 BuildRequires:	fuse-devel


### PR DESCRIPTION
The boost-python build dependency was added by 88977572f94adadbb77bda9a0bfc7f85099404c2 the description of which indicates that it was needed by ceph-mgr.