### PR TITLE
ceph-disk: prepare reject directory in /dev

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2623,6 +2623,9 @@ class PrepareData(object):
         if self.args.osd_uuid is None:
             self.args.osd_uuid = str(uuid.uuid4())
 
+        if os.path.realpath(self.args.data).startswith('/dev/'):
+            self.args.data_dev = True
+
     def set_type(self):
         dmode = os.stat(self.args.data).st_mode
 


### PR DESCRIPTION
 * Added check for directory in /dev
 * Added check for when dir is a symlink to somewhere in /dev

Passing a directory with real path in /dev/ will automatically
invoke --data-dev

Fixes: http://tracker.ceph.com/issues/18976
Signed-off-by: Matthew C. Sedam <sedammatthew@gmail.com>