### PR TITLE
crush: allow uniform buckets with no items

### DIFF
--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -1416,6 +1416,8 @@ int crush_addition_is_unsafe(__u32 a, __u32 b)
 int crush_multiplication_is_unsafe(__u32  a, __u32 b)
 {
 	/* prevent division by zero */
+        if (!a)
+                return 0;
 	if (!b)
 		return 1;
 	if ((((__u32)(-1)) / b) < a)


### PR DESCRIPTION
When a uniform bucket is created with zero size, it returns on error
because crush_multiplication_is_unsafe returns false. Since the goal
of this safegard is to avoid overflow, it should not fail.

Signed-off-by: Loic Dachary <ldachary@redhat.com>