### PR TITLE
client/Client.cc: after reset session from MDS - reconnect

### DIFF
--- a/doc/cephfs/client-config-ref.rst
+++ b/doc/cephfs/client-config-ref.rst
@@ -147,6 +147,12 @@
 :Type: Integer
 :Default: ``131072`` (128KB)
 
+``client_reconnect_stale``
+
+:Description: Automatically reconnect stale session.
+:Type: Boolean
+:Default: ``false``
+
 ``client_snapdir``
 
 :Description: Set the snapshot directory name.

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12708,8 +12708,16 @@ void Client::ms_handle_remote_reset(Connection *con)
 	  break;
 
 	case MetaSession::STATE_OPEN:
-	  ldout(cct, 1) << "reset from mds we were open; mark session as stale" << dendl;
-	  s->state = MetaSession::STATE_STALE;
+	  {
+	    const md_config_t *conf = cct->_conf;
+	    if (conf->client_reconnect_stale) {
+	      ldout(cct, 1) << "reset from mds we were open; close mds session for reconnect" << dendl;
+	      _closed_mds_session(s);
+	    } else {
+	      ldout(cct, 1) << "reset from mds we were open; mark session as stale" << dendl;
+	      s->state = MetaSession::STATE_STALE;
+	    }
+	  }
 	  break;
 
 	case MetaSession::STATE_NEW:

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -423,6 +423,7 @@ OPTION(client_trace, OPT_STR, "")
 OPTION(client_readahead_min, OPT_LONGLONG, 128*1024)  // readahead at _least_ this much.
 OPTION(client_readahead_max_bytes, OPT_LONGLONG, 0)  // default unlimited
 OPTION(client_readahead_max_periods, OPT_LONGLONG, 4)  // as multiple of file layout period (object size * num stripes)
+OPTION(client_reconnect_stale, OPT_BOOL, false)  // automatically reconnect stale session
 OPTION(client_snapdir, OPT_STR, ".snap")
 OPTION(client_mountpoint, OPT_STR, "/")
 OPTION(client_mount_uid, OPT_INT, -1)


### PR DESCRIPTION
Client.cc marks session as stale instead of reconecting after received
reset from MDS. On MDS side session it is closed so MDS is ignoring cap
renew. This fixes it by doing reconnect instead of just marking session
stale.

Fixes: http://tracker.ceph.com/issues/18757

Signed-off-by: Henrik Korkuc <henrik@kirneh.eu>