### PR TITLE
include/mempool.h: fix Clangs complaint about types

### DIFF
--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -376,11 +376,12 @@ public:
                                                                         \
     template<typename k,typename v, typename cmp = std::less<k> >	\
     using map = std::map<k, v, cmp,					\
-			 pool_allocator<std::pair<k,v>>>;		\
+			 pool_allocator<std::pair<const k,v>>>;		\
                                                                         \
     template<typename k,typename v, typename cmp = std::less<k> >	\
     using multimap = std::multimap<k,v,cmp,				\
-				   pool_allocator<std::pair<k,v>>>;	\
+				   pool_allocator<std::pair<const k,	\
+							    v>>>;	\
                                                                         \
     template<typename k, typename cmp = std::less<k> >			\
     using set = std::set<k,cmp,pool_allocator<k>>;			\
@@ -395,7 +396,7 @@ public:
 	     typename h=std::hash<k>,					\
 	     typename eq = std::equal_to<k>>				\
     using unordered_map =						\
-      std::unordered_map<k,v,h,eq,pool_allocator<std::pair<k,v>>>;	\
+      std::unordered_map<k,v,h,eq,pool_allocator<std::pair<const k,v>>>;\
                                                                         \
     inline size_t allocated_bytes() {					\
       return mempool::get_pool(id).allocated_bytes();			\


### PR DESCRIPTION
- Clang generates the following error:

In file included from /home/jenkins/workspace/ceph-master/src/test/objectstore/store_test.cc:21:
In file included from /home/jenkins/workspace/ceph-master/src/os/ObjectStore.h:17:
In file included from /home/jenkins/workspace/ceph-master/src/include/Context.h:19:
In file included from /home/jenkins/workspace/ceph-master/src/common/dout.h:20:
In file included from /home/jenkins/workspace/ceph-master/src/common/config.h:21:
/usr/include/c++/v1/map:820:5: error: static_assert failed "Allocator::value_type must be same type as value_type"
    static_assert((is_same<typename allocator_type::value_type, value_type>::value),
    ^             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/jenkins/workspace/ceph-master/src/os/bluestore/bluestore_types.h:204:9: note: in instantiation of template class 'std::__1::map<unsigned long, bluestore_extent_ref_map_t::record_t, std::__1::less<unsigned long>, mempool::pool_allocator<mempool::pool_index_t::mempool_bluestore_meta_other, std::__1::pair<unsigned long, bluestore_extent_ref_map_t::record_t> > >' requested here
  map_t ref_map;

This is fixed by make the K in std::pair<k,v> a const.
Perhaps the other std::pair<> constuctors could do with a const
as well.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>