### PR TITLE
debian: Add missing tp files in deb packaging

### DIFF
--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -12,3 +12,5 @@ usr/share/man/man8/ceph-clsinfo.8
 usr/share/man/man8/ceph-disk.8
 usr/share/man/man8/ceph-osd.8
 usr/lib/python*/dist-packages/ceph_disk*
+usr/lib/libosd_tp.so*
+usr/lib/libos_tp.so*

--- a/debian/librados-dev.install
+++ b/debian/librados-dev.install
@@ -10,4 +10,5 @@ usr/include/rados/rados_types.h
 usr/include/rados/rados_types.hpp
 usr/include/rados/memory.h
 usr/lib/librados.so
+usr/lib/librados_tp.so
 usr/share/man/man8/librados-config.8

--- a/debian/librbd-dev.install
+++ b/debian/librbd-dev.install
@@ -2,3 +2,4 @@ usr/include/rbd/features.h
 usr/include/rbd/librbd.h
 usr/include/rbd/librbd.hpp
 usr/lib/librbd.so
+usr/lib/librbd_tp.so


### PR DESCRIPTION
DEB packaging builds happen with LTTNG enabled but are missing a few
files.
*  libosd_tp.so*, libos_tp.so* are needed to trace OSD
*  librados_tp.so, librbd_tp.so are needed along with the other files
for trace visibility within lttng tool.

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>