### PR TITLE
messages/MOSDOp: fix pg_t decoding for version <7 decoding

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -475,7 +475,7 @@ struct ceph_osd_request_head {
 	::decode_raw(opgid, p);
 	pgid.pgid = opgid;
       } else {
-	::decode(pgid, p);
+	::decode(pgid.pgid, p);
       }
 
       ::decode(hobj.oid, p);


### PR DESCRIPTION
This was broken by f6e219a4df8553336839bb914733a78090561ec8

Fixes: http://tracker.ceph.com/issues/19005
Signed-off-by: Sage Weil <sage@redhat.com>