### PR TITLE
osd: constify OpRequest::get_req(); fix a few cases of operator<< vs mutated message races

### DIFF
--- a/src/common/RefCountedObj.cc
+++ b/src/common/RefCountedObj.cc
@@ -14,10 +14,10 @@
 
 #include "common/RefCountedObj.h"
 
-void intrusive_ptr_add_ref(RefCountedObject *p) {
+void intrusive_ptr_add_ref(const RefCountedObject *p) {
   p->get();
 }
-void intrusive_ptr_release(RefCountedObject *p) {
+void intrusive_ptr_release(const RefCountedObject *p) {
   p->put();
 }
 

--- a/src/messages/MOSDFailure.h
+++ b/src/messages/MOSDFailure.h
@@ -59,7 +59,7 @@ public:
   bool is_immediate() const { 
     return flags & FLAG_IMMEDIATE; 
   }
-  epoch_t get_epoch() { return epoch; }
+  epoch_t get_epoch() const { return epoch; }
 
   void decode_payload() {
     bufferlist::iterator p = payload.begin();

--- a/src/messages/MOSDMarkMeDown.h
+++ b/src/messages/MOSDMarkMeDown.h
@@ -40,8 +40,8 @@ class MOSDMarkMeDown : public PaxosServiceMessage {
   ~MOSDMarkMeDown() {}
 
 public: 
-  entity_inst_t get_target() { return target_osd; }
-  epoch_t get_epoch() { return epoch; }
+  entity_inst_t get_target() const { return target_osd; }
+  epoch_t get_epoch() const { return epoch; }
 
   void decode_payload() {
     bufferlist::iterator p = payload.begin();

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -130,14 +130,14 @@ public:
     else
       return object_locator_t(hobj);
   }
-  object_t& get_oid() {
+  const object_t& get_oid() const {
     assert(!final_decode_needed);
     return hobj.oid;
   }
   const hobject_t &get_hobj() const {
     return hobj;
   }
-  snapid_t get_snapid() {
+  snapid_t get_snapid() const {
     assert(!final_decode_needed);
     return hobj.snap;
   }
@@ -231,7 +231,7 @@ public:
     add_simple_op(CEPH_OSD_OP_STAT, 0, 0);
   }
 
-  bool has_flag(__u32 flag) { return flags & flag; };
+  bool has_flag(__u32 flag) const { return flags & flag; };
   bool wants_ack() const { return flags & CEPH_OSD_FLAG_ACK; }
   bool wants_ondisk() const { return flags & CEPH_OSD_FLAG_ONDISK; }
   bool wants_onnvram() const { return flags & CEPH_OSD_FLAG_ONNVRAM; }

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -128,7 +128,8 @@ public:
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION) {
     do_redirect = false;
   }
-  MOSDOpReply(MOSDOp *req, int r, epoch_t e, int acktype, bool ignore_out_data)
+  MOSDOpReply(const MOSDOp *req, int r, epoch_t e, int acktype,
+	      bool ignore_out_data)
     : Message(CEPH_MSG_OSD_OPREPLY, HEAD_VERSION, COMPAT_VERSION),
       oid(req->hobj.oid), pgid(req->pgid.pgid), ops(req->ops) {
 

--- a/src/messages/MOSDPGInfo.h
+++ b/src/messages/MOSDPGInfo.h
@@ -28,7 +28,7 @@ class MOSDPGInfo : public Message {
 public:
   vector<pair<pg_notify_t,pg_interval_map_t> > pg_list;
 
-  epoch_t get_epoch() { return epoch; }
+  epoch_t get_epoch() const { return epoch; }
 
   MOSDPGInfo()
     : Message(MSG_OSD_PG_INFO, HEAD_VERSION, COMPAT_VERSION) {

--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -38,9 +38,9 @@ public:
   pg_missing_t missing;
   pg_interval_map_t past_intervals;
 
-  epoch_t get_epoch() { return epoch; }
-  spg_t get_pgid() { return spg_t(info.pgid.pgid, to); }
-  epoch_t get_query_epoch() { return query_epoch; }
+  epoch_t get_epoch() const { return epoch; }
+  spg_t get_pgid() const { return spg_t(info.pgid.pgid, to); }
+  epoch_t get_query_epoch() const { return query_epoch; }
 
   MOSDPGLog() : Message(MSG_OSD_PG_LOG, HEAD_VERSION, COMPAT_VERSION) { 
     set_priority(CEPH_MSG_PRIO_HIGH); 
@@ -67,6 +67,8 @@ private:
 public:
   const char *get_type_name() const { return "PGlog"; }
   void print(ostream& out) const {
+    // NOTE: log is not const, but operator<< doesn't touch fields
+    // swapped out by OSD code.
     out << "pg_log(" << info.pgid << " epoch " << epoch
 	<< " log " << log
 	<< " query_epoch " << query_epoch << ")";

--- a/src/messages/MOSDPGNotify.h
+++ b/src/messages/MOSDPGNotify.h
@@ -36,12 +36,14 @@ class MOSDPGNotify : public Message {
   vector<pair<pg_notify_t,pg_interval_map_t> > pg_list;   // pgid -> version
 
  public:
-  version_t get_epoch() { return epoch; }
-  vector<pair<pg_notify_t,pg_interval_map_t> >& get_pg_list() { return pg_list; }
+  version_t get_epoch() const { return epoch; }
+  const vector<pair<pg_notify_t,pg_interval_map_t> >& get_pg_list() const {
+    return pg_list;
+  }
 
   MOSDPGNotify()
     : Message(MSG_OSD_PG_NOTIFY, HEAD_VERSION, COMPAT_VERSION) { 
-    set_priority(CEPH_MSG_PRIO_HIGH); 
+    set_priority(CEPH_MSG_PRIO_HIGH);
   }
   MOSDPGNotify(epoch_t e, vector<pair<pg_notify_t,pg_interval_map_t> >& l)
     : Message(MSG_OSD_PG_NOTIFY, HEAD_VERSION, COMPAT_VERSION),

--- a/src/messages/MOSDPGPull.h
+++ b/src/messages/MOSDPGPull.h
@@ -21,12 +21,12 @@ class MOSDPGPull : public MOSDFastDispatchOp {
   static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
+  vector<PullOp> pulls;
 
 public:
   pg_shard_t from;
   spg_t pgid;
   epoch_t map_epoch;
-  vector<PullOp> pulls;
   uint64_t cost;
 
   epoch_t get_map_epoch() const override {
@@ -34,6 +34,13 @@ public:
   }
   spg_t get_spg() const override {
     return pgid;
+  }
+
+  void take_pulls(vector<PullOp> *outpulls) {
+    outpulls->swap(pulls);
+  }
+  void set_pulls(vector<PullOp> *inpulls) {
+    inpulls->swap(pulls);
   }
 
   MOSDPGPull()
@@ -82,9 +89,9 @@ public:
 
   void print(ostream& out) const {
     out << "MOSDPGPull(" << pgid
-	<< " " << map_epoch
-	<< " " << pulls;
-    out << ")";
+	<< " e" << map_epoch
+	<< " cost " << cost
+	<< ")";
   }
 };
 

--- a/src/messages/MOSDPGQuery.h
+++ b/src/messages/MOSDPGQuery.h
@@ -29,7 +29,7 @@ class MOSDPGQuery : public Message {
   version_t       epoch;
 
  public:
-  version_t get_epoch() { return epoch; }
+  version_t get_epoch() const { return epoch; }
   map<spg_t, pg_query_t>  pg_list;
 
   MOSDPGQuery() : Message(MSG_OSD_PG_QUERY,

--- a/src/messages/MOSDPGRemove.h
+++ b/src/messages/MOSDPGRemove.h
@@ -30,7 +30,7 @@ class MOSDPGRemove : public Message {
  public:
   vector<spg_t> pg_list;
 
-  epoch_t get_epoch() { return epoch; }
+  epoch_t get_epoch() const { return epoch; }
 
   MOSDPGRemove() :
     Message(MSG_OSD_PG_REMOVE, HEAD_VERSION, COMPAT_VERSION) {}

--- a/src/messages/MOSDPGTrim.h
+++ b/src/messages/MOSDPGTrim.h
@@ -27,7 +27,7 @@ public:
   spg_t pgid;
   eversion_t trim_to;
 
-  epoch_t get_epoch() { return epoch; }
+  epoch_t get_epoch() const { return epoch; }
 
   MOSDPGTrim() : Message(MSG_OSD_PG_TRIM, HEAD_VERSION, COMPAT_VERSION) {}
   MOSDPGTrim(version_t mv, spg_t p, eversion_t tt) :

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -95,11 +95,11 @@ public:
   int get_result() { return result; }
 
   void set_last_complete_ondisk(eversion_t v) { last_complete_ondisk = v; }
-  eversion_t get_last_complete_ondisk() { return last_complete_ondisk; }
+  eversion_t get_last_complete_ondisk() const { return last_complete_ondisk; }
 
 public:
   MOSDRepOpReply(
-    MOSDRepOp *req, pg_shard_t from, int result_, epoch_t e, int at) :
+    const MOSDRepOp *req, pg_shard_t from, int result_, epoch_t e, int at) :
     MOSDFastDispatchOp(MSG_OSD_REPOPREPLY, HEAD_VERSION, COMPAT_VERSION),
     map_epoch(e),
     reqid(req->reqid),

--- a/src/messages/MOSDSubOpReply.h
+++ b/src/messages/MOSDSubOpReply.h
@@ -116,8 +116,8 @@ public:
 
   epoch_t get_map_epoch() { return map_epoch; }
 
-  spg_t get_pg() { return pgid; }
-  hobject_t get_poid() { return poid; }
+  spg_t get_pg() const { return pgid; }
+  const hobject_t& get_poid() const { return poid; }
 
   int get_ack_type() { return ack_type; }
   bool is_ondisk() { return ack_type & CEPH_OSD_FLAG_ONDISK; }
@@ -136,7 +136,7 @@ public:
 
 public:
   MOSDSubOpReply(
-    MOSDSubOp *req, pg_shard_t from, int result_, epoch_t e, int at)
+    const MOSDSubOp *req, pg_shard_t from, int result_, epoch_t e, int at)
     : MOSDFastDispatchOp(MSG_OSD_SUBOPREPLY, HEAD_VERSION, COMPAT_VERSION),
       map_epoch(e),
       reqid(req->reqid),

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -376,6 +376,7 @@ public:
       byte_throttler->take(data.length());
   }
 
+  const bufferlist& get_data() const { return data; }
   bufferlist& get_data() { return data; }
   void claim_data(bufferlist& bl,
 		  unsigned int flags = buffer::list::CLAIM_DEFAULT) {

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1114,7 +1114,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs of an object
-    void setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferptr>& attrset) {
+    void setattrs(const coll_t& cid, const ghobject_t& oid, const map<string,bufferptr>& attrset) {
       Op* _op = _get_next_op();
       _op->op = OP_SETATTRS;
       _op->cid = _get_coll_id(cid);
@@ -1123,7 +1123,7 @@ public:
       data.ops++;
     }
     /// Set multiple xattrs of an object
-    void setattrs(const coll_t& cid, const ghobject_t& oid, map<string,bufferlist>& attrset) {
+    void setattrs(const coll_t& cid, const ghobject_t& oid, const map<string,bufferlist>& attrset) {
       Op* _op = _get_next_op();
       _op->op = OP_SETATTRS;
       _op->cid = _get_coll_id(cid);

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -733,7 +733,6 @@ bool ECBackend::handle_message(
   case MSG_OSD_EC_WRITE_REPLY: {
     MOSDECSubOpWriteReply *op = static_cast<MOSDECSubOpWriteReply*>(
       _op->get_req());
-    op->set_priority(priority);
     handle_sub_write_reply(op->op.from, op->op);
     return true;
   }
@@ -743,7 +742,6 @@ bool ECBackend::handle_message(
     reply->pgid = get_parent()->primary_spg_t();
     reply->map_epoch = get_parent()->get_epoch();
     handle_sub_read(op->op.from, op->op, &(reply->op));
-    op->set_priority(priority);
     get_parent()->send_message_osd_cluster(
       op->op.from.osd, reply, get_parent()->get_epoch());
     return true;

--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -280,7 +280,7 @@ struct RecoveryMessages {
 };
 
 void ECBackend::handle_recovery_push(
-  PushOp &op,
+  const PushOp &op,
   RecoveryMessages *m)
 {
 
@@ -362,7 +362,7 @@ void ECBackend::handle_recovery_push(
 }
 
 void ECBackend::handle_recovery_push_reply(
-  PushReplyOp &op,
+  const PushReplyOp &op,
   pg_shard_t from,
   RecoveryMessages *m)
 {
@@ -934,12 +934,11 @@ void ECBackend::handle_sub_write(
 
 void ECBackend::handle_sub_read(
   pg_shard_t from,
-  ECSubRead &op,
+  const ECSubRead &op,
   ECSubReadReply *reply)
 {
   shard_id_t shard = get_parent()->whoami_shard().shard;
-  for(map<hobject_t, list<boost::tuple<uint64_t, uint64_t, uint32_t> >>::iterator i =
-        op.to_read.begin();
+  for(auto i = op.to_read.begin();
       i != op.to_read.end();
       ++i) {
     int r = 0;
@@ -953,8 +952,7 @@ void ECBackend::handle_sub_read(
 	goto error;
       }
     }
-    for (list<boost::tuple<uint64_t, uint64_t, uint32_t> >::iterator j =
-	   i->second.begin(); j != i->second.end(); ++j) {
+    for (auto j = i->second.begin(); j != i->second.end(); ++j) {
       bufferlist bl;
       r = store->read(
 	ch,
@@ -1032,7 +1030,7 @@ error:
 
 void ECBackend::handle_sub_write_reply(
   pg_shard_t from,
-  ECSubWriteReply &op)
+  const ECSubWriteReply &op)
 {
   map<ceph_tid_t, Op>::iterator i = tid_to_op_map.find(op.tid);
   assert(i != tid_to_op_map.end());
@@ -1074,8 +1072,7 @@ void ECBackend::handle_sub_read_reply(
     return;
   }
   ReadOp &rop = iter->second;
-  for (map<hobject_t, list<pair<uint64_t, bufferlist> >>::iterator i =
-	 op.buffers_read.begin();
+  for (auto i = op.buffers_read.begin();
        i != op.buffers_read.end();
        ++i) {
     assert(!op.errors.count(i->first));	// If attribute error we better not have sent a buffer
@@ -1102,7 +1099,7 @@ void ECBackend::handle_sub_read_reply(
       riter->get<2>()[from].claim(j->second);
     }
   }
-  for (map<hobject_t, map<string, bufferlist>>::iterator i = op.attrs_read.begin();
+  for (auto i = op.attrs_read.begin();
        i != op.attrs_read.end();
        ++i) {
     assert(!op.errors.count(i->first));	// if read error better not have sent an attribute
@@ -1114,7 +1111,7 @@ void ECBackend::handle_sub_read_reply(
     rop.complete[i->first].attrs = map<string, bufferlist>();
     (*(rop.complete[i->first].attrs)).swap(i->second);
   }
-  for (map<hobject_t, int>::iterator i = op.errors.begin();
+  for (auto i = op.errors.begin();
        i != op.errors.end();
        ++i) {
     rop.complete[i->first].errors.insert(

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -69,12 +69,12 @@ public:
     );
   void handle_sub_read(
     pg_shard_t from,
-    ECSubRead &op,
+    const ECSubRead &op,
     ECSubReadReply *reply
     );
   void handle_sub_write_reply(
     pg_shard_t from,
-    ECSubWriteReply &op
+    const ECSubWriteReply &op
     );
   void handle_sub_read_reply(
     pg_shard_t from,
@@ -305,10 +305,10 @@ private:
     boost::optional<map<string, bufferlist> > attrs,
     RecoveryMessages *m);
   void handle_recovery_push(
-    PushOp &op,
+    const PushOp &op,
     RecoveryMessages *m);
   void handle_recovery_push_reply(
-    PushReplyOp &op,
+    const PushReplyOp &op,
     pg_shard_t from,
     RecoveryMessages *m);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8090,7 +8090,7 @@ void OSD::do_infos(map<int,
  */
 void OSD::handle_pg_notify(OpRequestRef op)
 {
-  MOSDPGNotify *m = (MOSDPGNotify*)op->get_req();
+  const MOSDPGNotify *m = static_cast<const MOSDPGNotify*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_NOTIFY);
 
   dout(7) << "handle_pg_notify from " << m->get_source() << dendl;
@@ -8104,10 +8104,9 @@ void OSD::handle_pg_notify(OpRequestRef op)
 
   op->mark_started();
 
-  for (vector<pair<pg_notify_t, pg_interval_map_t> >::iterator it = m->get_pg_list().begin();
+  for (auto it = m->get_pg_list().begin();
        it != m->get_pg_list().end();
        ++it) {
-
     if (it->first.info.pgid.preferred() >= 0) {
       dout(20) << "ignoring localized pg " << it->first.info.pgid << dendl;
       continue;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1381,7 +1381,7 @@ void OSDService::reply_op_error(OpRequestRef op, int err)
 void OSDService::reply_op_error(OpRequestRef op, int err, eversion_t v,
                                 version_t uv)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   assert(m->get_type() == CEPH_MSG_OSD_OP);
   int flags;
   flags = m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK);
@@ -1394,7 +1394,7 @@ void OSDService::reply_op_error(OpRequestRef op, int err, eversion_t v,
 
 void OSDService::handle_misdirected_op(PG *pg, OpRequestRef op)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   assert(m->get_type() == CEPH_MSG_OSD_OP);
 
   assert(m->get_map_epoch() >= pg->info.history.same_primary_since);
@@ -6310,7 +6310,7 @@ void OSD::do_waiters()
 template<typename T, int MSGTYPE>
 epoch_t replica_op_required_epoch(OpRequestRef op)
 {
-  T *m = static_cast<T *>(op->get_req());
+  const T *m = static_cast<const T *>(op->get_req());
   assert(m->get_type() == MSGTYPE);
   return m->map_epoch;
 }
@@ -6319,11 +6319,11 @@ epoch_t op_required_epoch(OpRequestRef op)
 {
   switch (op->get_req()->get_type()) {
   case CEPH_MSG_OSD_OP: {
-    MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+    const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
     return m->get_map_epoch();
   }
   case CEPH_MSG_OSD_BACKOFF: {
-    MOSDBackoff *m = static_cast<MOSDBackoff*>(op->get_req());
+    const MOSDBackoff *m = static_cast<const MOSDBackoff*>(op->get_req());
     return m->map_epoch;
   }
   case MSG_OSD_SUBOP:
@@ -7696,7 +7696,7 @@ bool OSD::require_same_peer_instance(const Message *m, OSDMapRef& map,
 bool OSD::require_same_or_newer_map(OpRequestRef& op, epoch_t epoch,
 				    bool is_fast_dispatch)
 {
-  Message *m = op->get_req();
+  const Message *m = op->get_req();
   dout(15) << "require_same_or_newer_map " << epoch
 	   << " (i am " << osdmap->get_epoch() << ") " << m << dendl;
 
@@ -8192,7 +8192,7 @@ void OSD::handle_pg_info(OpRequestRef op)
 
 void OSD::handle_pg_trim(OpRequestRef op)
 {
-  MOSDPGTrim *m = (MOSDPGTrim *)op->get_req();
+  const MOSDPGTrim *m = static_cast<const MOSDPGTrim*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_TRIM);
 
   dout(7) << "handle_pg_trim " << *m << " from " << m->get_source() << dendl;
@@ -8246,7 +8246,7 @@ void OSD::handle_pg_trim(OpRequestRef op)
 
 void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 {
-  MBackfillReserve *m = static_cast<MBackfillReserve*>(op->get_req());
+  const MBackfillReserve *m = static_cast<const MBackfillReserve*>(op->get_req());
   assert(m->get_type() == MSG_OSD_BACKFILL_RESERVE);
 
   if (!require_osd_peer(op->get_req()))
@@ -8294,7 +8294,7 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 
 void OSD::handle_pg_recovery_reserve(OpRequestRef op)
 {
-  MRecoveryReserve *m = static_cast<MRecoveryReserve*>(op->get_req());
+  const MRecoveryReserve *m = static_cast<const MRecoveryReserve*>(op->get_req());
   assert(m->get_type() == MSG_OSD_RECOVERY_RESERVE);
 
   if (!require_osd_peer(op->get_req()))
@@ -8751,7 +8751,7 @@ struct send_map_on_destruct {
   OSDMapRef osdmap;
   epoch_t map_epoch;
   bool should_send;
-  send_map_on_destruct(OSD *osd, Message *m,
+  send_map_on_destruct(OSD *osd, const Message *m,
                        OSDMapRef& osdmap, epoch_t map_epoch)
     : osd(osd), name(m->get_source()), con(m->get_connection()),
       osdmap(osdmap), map_epoch(map_epoch),
@@ -8766,7 +8766,7 @@ struct send_map_on_destruct {
 
 void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   assert(m->get_type() == CEPH_MSG_OSD_OP);
   if (op_is_discardable(m)) {
     dout(10) << " discardable " << *m << dendl;
@@ -8864,7 +8864,7 @@ void OSD::handle_op(OpRequestRef& op, OSDMapRef& osdmap)
 
 void OSD::handle_backoff(OpRequestRef& op, OSDMapRef& osdmap)
 {
-  MOSDBackoff *m = static_cast<MOSDBackoff*>(op->get_req());
+  const MOSDBackoff *m = static_cast<const MOSDBackoff*>(op->get_req());
   Session *s = static_cast<Session*>(m->get_connection()->get_priv());
   dout(10) << __func__ << " " << *m << " session " << s << dendl;
   assert(s);
@@ -8885,7 +8885,7 @@ void OSD::handle_backoff(OpRequestRef& op, OSDMapRef& osdmap)
 template<typename T, int MSGTYPE>
 void OSD::handle_replica_op(OpRequestRef& op, OSDMapRef& osdmap)
 {
-  T *m = static_cast<T *>(op->get_req());
+  const T *m = static_cast<const T *>(op->get_req());
   assert(m->get_type() == MSGTYPE);
 
   dout(10) << __func__ << " " << *m << " epoch " << m->map_epoch << dendl;
@@ -9109,7 +9109,7 @@ void OSD::dequeue_op(
 
   // share our map with sender, if they're old
   if (op->send_map_update) {
-    Message *m = op->get_req();
+    const Message *m = op->get_req();
     Session *session = static_cast<Session *>(m->get_connection()->get_priv());
     epoch_t last_sent_epoch;
     if (session) {
@@ -9410,8 +9410,8 @@ void OSD::get_latest_osdmap()
 
 int OSD::init_op_flags(OpRequestRef& op)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
-  vector<OSDOp>::iterator iter;
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
+  vector<OSDOp>::const_iterator iter;
 
   // client flags have no bearing on whether an op is a read, write, etc.
   op->rmw_flags = 0;
@@ -9485,7 +9485,7 @@ int OSD::init_op_flags(OpRequestRef& op)
     switch (iter->op.op) {
     case CEPH_OSD_OP_CALL:
       {
-	bufferlist::iterator bp = iter->indata.begin();
+	bufferlist::iterator bp = const_cast<bufferlist&>(iter->indata).begin();
 	int is_write, is_read;
 	string cname, mname;
 	bp.copy(iter->op.cls.class_len, cname);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3281,7 +3281,7 @@ PG *OSD::_create_lock_pg(
   vector<int>& up, int up_primary,
   vector<int>& acting, int acting_primary,
   pg_history_t history,
-  pg_interval_map_t& pi,
+  const pg_interval_map_t& pi,
   ObjectStore::Transaction& t)
 {
   assert(osd_lock.is_locked());
@@ -3669,7 +3669,7 @@ void OSD::build_past_intervals_parallel()
 void OSD::handle_pg_peering_evt(
   spg_t pgid,
   const pg_history_t& orig_history,
-  pg_interval_map_t& pi,
+  const pg_interval_map_t& pi,
   epoch_t epoch,
   PG::CephPeeringEvtRef evt)
 {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8156,7 +8156,7 @@ void OSD::handle_pg_log(OpRequestRef op)
 
 void OSD::handle_pg_info(OpRequestRef op)
 {
-  MOSDPGInfo *m = static_cast<MOSDPGInfo *>(op->get_req());
+  const MOSDPGInfo *m = static_cast<const MOSDPGInfo *>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_INFO);
   dout(7) << "handle_pg_info " << *m << " from " << m->get_source() << dendl;
 
@@ -8169,7 +8169,7 @@ void OSD::handle_pg_info(OpRequestRef op)
 
   op->mark_started();
 
-  for (vector<pair<pg_notify_t,pg_interval_map_t> >::iterator p = m->pg_list.begin();
+  for (auto p = m->pg_list.begin();
        p != m->pg_list.end();
        ++p) {
     if (p->first.info.pgid.preferred() >= 0) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8456,7 +8456,7 @@ void OSD::handle_pg_query(OpRequestRef op)
 
 void OSD::handle_pg_remove(OpRequestRef op)
 {
-  MOSDPGRemove *m = (MOSDPGRemove *)op->get_req();
+  const MOSDPGRemove *m = static_cast<const MOSDPGRemove *>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_REMOVE);
   assert(osd_lock.is_locked());
 
@@ -8471,7 +8471,7 @@ void OSD::handle_pg_remove(OpRequestRef op)
 
   op->mark_started();
 
-  for (vector<spg_t>::iterator it = m->pg_list.begin();
+  for (auto it = m->pg_list.begin();
        it != m->pg_list.end();
        ++it) {
     spg_t pgid = *it;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7632,7 +7632,7 @@ bool OSD::require_mon_peer(const Message *m)
   return true;
 }
 
-bool OSD::require_osd_peer(Message *m)
+bool OSD::require_osd_peer(const Message *m)
 {
   if (!m->get_connection()->peer_is_osd()) {
     dout(0) << "require_osd_peer received from non-osd "
@@ -7643,7 +7643,7 @@ bool OSD::require_osd_peer(Message *m)
   return true;
 }
 
-bool OSD::require_self_aliveness(Message *m, epoch_t epoch)
+bool OSD::require_self_aliveness(const Message *m, epoch_t epoch)
 {
   epoch_t up_epoch = service.get_up_epoch();
   if (epoch < up_epoch) {
@@ -7659,7 +7659,7 @@ bool OSD::require_self_aliveness(Message *m, epoch_t epoch)
   return true;
 }
 
-bool OSD::require_same_peer_instance(Message *m, OSDMapRef& map,
+bool OSD::require_same_peer_instance(const Message *m, OSDMapRef& map,
 				     bool is_fast_dispatch)
 {
   int from = m->get_source().num();
@@ -8932,7 +8932,7 @@ void OSD::handle_replica_op(OpRequestRef& op, OSDMapRef& osdmap)
   }
 }
 
-bool OSD::op_is_discardable(MOSDOp *op)
+bool OSD::op_is_discardable(const MOSDOp *op)
 {
   // drop client request if they are not connected and can't get the
   // reply anyway.

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7788,7 +7788,7 @@ void OSD::split_pgs(
  */
 void OSD::handle_pg_create(OpRequestRef op)
 {
-  MOSDPGCreate *m = (MOSDPGCreate*)op->get_req();
+  const MOSDPGCreate *m = static_cast<const MOSDPGCreate*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_CREATE);
 
   dout(10) << "handle_pg_create " << *m << dendl;
@@ -7802,8 +7802,8 @@ void OSD::handle_pg_create(OpRequestRef op)
 
   op->mark_started();
 
-  map<pg_t,utime_t>::iterator ci = m->ctimes.begin();
-  for (map<pg_t,pg_create_t>::iterator p = m->mkpg.begin();
+  map<pg_t,utime_t>::const_iterator ci = m->ctimes.begin();
+  for (map<pg_t,pg_create_t>::const_iterator p = m->mkpg.begin();
        p != m->mkpg.end();
        ++p, ++ci) {
     assert(ci != m->ctimes.end() && ci->first == p->first);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8128,7 +8128,7 @@ void OSD::handle_pg_notify(OpRequestRef op)
 
 void OSD::handle_pg_log(OpRequestRef op)
 {
-  MOSDPGLog *m = (MOSDPGLog*) op->get_req();
+  MOSDPGLog *m = static_cast<MOSDPGLog*>(op->get_nonconst_req());
   assert(m->get_type() == MSG_OSD_PG_LOG);
   dout(7) << "handle_pg_log " << *m << " from " << m->get_source() << dendl;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8349,7 +8349,7 @@ void OSD::handle_pg_query(OpRequestRef op)
 {
   assert(osd_lock.is_locked());
 
-  MOSDPGQuery *m = (MOSDPGQuery*)op->get_req();
+  const MOSDPGQuery *m = static_cast<const MOSDPGQuery*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_QUERY);
 
   if (!require_osd_peer(op->get_req()))
@@ -8365,7 +8365,7 @@ void OSD::handle_pg_query(OpRequestRef op)
 
   map< int, vector<pair<pg_notify_t, pg_interval_map_t> > > notify_list;
 
-  for (map<spg_t,pg_query_t>::iterator it = m->pg_list.begin();
+  for (auto it = m->pg_list.begin();
        it != m->pg_list.end();
        ++it) {
     spg_t pgid = it->first;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2230,7 +2230,7 @@ protected:
 		    vector<pair<pg_notify_t, pg_interval_map_t> > >& info_map,
 		OSDMapRef map);
 
-  bool require_mon_peer(Message *m);
+  bool require_mon_peer(const Message *m);
   bool require_osd_peer(Message *m);
   /***
    * Verifies that we were alive in the given epoch, and that

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2063,7 +2063,7 @@ protected:
     vector<int>& up, int up_primary,
     vector<int>& acting, int acting_primary,
     pg_history_t history,
-    pg_interval_map_t& pi,
+    const pg_interval_map_t& pi,
     ObjectStore::Transaction& t);
   PG   *_lookup_qlock_pg(spg_t pgid);
 
@@ -2074,7 +2074,7 @@ protected:
   void handle_pg_peering_evt(
     spg_t pgid,
     const pg_history_t& orig_history,
-    pg_interval_map_t& pi,
+    const pg_interval_map_t& pi,
     epoch_t epoch,
     PG::CephPeeringEvtRef evt);
   

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2231,18 +2231,18 @@ protected:
 		OSDMapRef map);
 
   bool require_mon_peer(const Message *m);
-  bool require_osd_peer(Message *m);
+  bool require_osd_peer(const Message *m);
   /***
    * Verifies that we were alive in the given epoch, and that
    * still are.
    */
-  bool require_self_aliveness(Message *m, epoch_t alive_since);
+  bool require_self_aliveness(const Message *m, epoch_t alive_since);
   /**
    * Verifies that the OSD who sent the given op has the same
    * address as in the given map.
    * @pre op was sent by an OSD using the cluster messenger
    */
-  bool require_same_peer_instance(Message *m, OSDMapRef& map,
+  bool require_same_peer_instance(const Message *m, OSDMapRef& map,
 				  bool is_fast_dispatch);
 
   bool require_same_or_newer_map(OpRequestRef& op, epoch_t e,
@@ -2493,7 +2493,7 @@ public:
   void handle_signal(int signum);
 
   /// check if we can throw out op from a disconnected client
-  static bool op_is_discardable(MOSDOp *m);
+  static bool op_is_discardable(const MOSDOp *m);
 
 public:
   OSDService service;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1404,7 +1404,7 @@ public:
     unsigned mask = ~((~0)<<bits);
     switch (op->get_req()->get_type()) {
     case CEPH_MSG_OSD_OP:
-      return (static_cast<MOSDOp*>(
+      return (static_cast<const MOSDOp*>(
 		op->get_req())->get_raw_pg().m_seed & mask) == match;
     }
     return false;

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -110,7 +110,7 @@ public:
   bool send_map_update;
   epoch_t sent_epoch;
   bool hitset_inserted;
-  Message *get_req() const { return request; }
+  const Message *get_req() const { return request; }
   Message *get_nonconst_req() { return request; }
 
   const char *state_string() const {

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -111,6 +111,7 @@ public:
   epoch_t sent_epoch;
   bool hitset_inserted;
   Message *get_req() const { return request; }
+  Message *get_nonconst_req() { return request; }
 
   const char *state_string() const {
     switch(latest_flag_point) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -341,7 +341,9 @@ void PG::proc_master_log(
     
 void PG::proc_replica_log(
   ObjectStore::Transaction& t,
-  pg_info_t &oinfo, pg_log_t &olog, pg_missing_t& omissing,
+  pg_info_t &oinfo,
+  const pg_log_t &olog,
+  pg_missing_t& omissing,
   pg_shard_t from)
 {
   dout(10) << "proc_replica_log for osd." << from << ": "
@@ -7112,7 +7114,7 @@ boost::statechart::result PG::RecoveryState::ReplicaActive::react(const MLogRec&
   PG *pg = context< RecoveryMachine >().pg;
   ldout(pg->cct, 10) << "received log from " << logevt.from << dendl;
   ObjectStore::Transaction* t = context<RecoveryMachine>().get_cur_transaction();
-  pg->merge_log(*t,logevt.msg->info, logevt.msg->log, logevt.from);
+  pg->merge_log(*t, logevt.msg->info, logevt.msg->log, logevt.from);
   assert(pg->pg_log.get_head() == pg->info.last_update);
 
   return discard_event();

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2796,7 +2796,7 @@ void PG::init(
   const vector<int>& newup, int new_up_primary,
   const vector<int>& newacting, int new_acting_primary,
   const pg_history_t& history,
-  pg_interval_map_t& pi,
+  const pg_interval_map_t& pi,
   bool backfill,
   ObjectStore::Transaction *t)
 {
@@ -2815,7 +2815,7 @@ void PG::init(
     new_acting_primary);
 
   info.history = history;
-  past_intervals.swap(pi);
+  past_intervals = pi;
 
   info.stats.up = up;
   info.stats.up_primary = new_up_primary;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1354,7 +1354,7 @@ public:
     pg_shard_t from;
     pg_info_t info;
     epoch_t msg_epoch;
-    MInfoRec(pg_shard_t from, pg_info_t &info, epoch_t msg_epoch) :
+    MInfoRec(pg_shard_t from, const pg_info_t &info, epoch_t msg_epoch) :
       from(from), info(info), msg_epoch(msg_epoch) {}
     void print(std::ostream *out) const {
       *out << "MInfoRec from " << from << " info: " << info;
@@ -1375,7 +1375,7 @@ public:
     pg_shard_t from;
     pg_notify_t notify;
     uint64_t features;
-    MNotifyRec(pg_shard_t from, pg_notify_t &notify, uint64_t f) :
+    MNotifyRec(pg_shard_t from, const pg_notify_t &notify, uint64_t f) :
       from(from), notify(notify), features(f) {}
     void print(std::ostream *out) const {
       *out << "MNotifyRec from " << from << " notify: " << notify

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -925,7 +925,8 @@ public:
 
   virtual void calc_trim_to() = 0;
 
-  void proc_replica_log(ObjectStore::Transaction& t, pg_info_t &oinfo, pg_log_t &olog,
+  void proc_replica_log(ObjectStore::Transaction& t,
+			pg_info_t &oinfo, const pg_log_t &olog,
 			pg_missing_t& omissing, pg_shard_t from);
   void proc_master_log(ObjectStore::Transaction& t, pg_info_t &oinfo, pg_log_t &olog,
 		       pg_missing_t& omissing, pg_shard_t from);

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2180,7 +2180,7 @@ public:
     const vector<int>& acting,
     int acting_primary,
     const pg_history_t& history,
-    pg_interval_map_t& pim,
+    const pg_interval_map_t& pim,
     bool backfill,
     ObjectStore::Transaction *t);
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -185,7 +185,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual ObjectContextRef get_obc(
        const hobject_t &hoid,
-       map<string, bufferlist> &attrs) = 0;
+       const map<string, bufferlist> &attrs) = 0;
 
      virtual bool try_lock_for_read(
        const hobject_t &hoid,
@@ -202,7 +202,7 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual void log_operation(
        const vector<pg_log_entry_t> &logv,
-       boost::optional<pg_hit_set_history_t> &hset_history,
+       const boost::optional<pg_hit_set_history_t> &hset_history,
        const eversion_t &trim_to,
        const eversion_t &roll_forward_to,
        bool transaction_applied,

--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -131,7 +131,9 @@ void PGLog::trim(
 
 void PGLog::proc_replica_log(
   ObjectStore::Transaction& t,
-  pg_info_t &oinfo, const pg_log_t &olog, pg_missing_t& omissing,
+  pg_info_t &oinfo,
+  const pg_log_t &olog,
+  pg_missing_t& omissing,
   pg_shard_t from) const
 {
   dout(10) << "proc_replica_log for osd." << from << ": "

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -703,7 +703,9 @@ public:
     log.last_requested = 0;
   }
 
-  void proc_replica_log(ObjectStore::Transaction& t, pg_info_t &oinfo, const pg_log_t &olog,
+  void proc_replica_log(ObjectStore::Transaction& t,
+			pg_info_t &oinfo,
+			const pg_log_t &olog,
 			pg_missing_t& omissing, pg_shard_t from) const;
 
 protected:
@@ -972,7 +974,9 @@ public:
                             pg_info_t &info, LogEntryHandler *rollbacker,
                             bool &dirty_info, bool &dirty_big_info);
 
-  void merge_log(ObjectStore::Transaction& t, pg_info_t &oinfo, pg_log_t &olog,
+  void merge_log(ObjectStore::Transaction& t,
+		 pg_info_t &oinfo,
+		 pg_log_t &olog,
 		 pg_shard_t from,
 		 pg_info_t &info, LogEntryHandler *rollbacker,
 		 bool &dirty_info, bool &dirty_big_info);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8861,9 +8861,10 @@ ObjectContextRef PrimaryLogPG::create_object_context(const object_info_t& oi,
   return obc;
 }
 
-ObjectContextRef PrimaryLogPG::get_object_context(const hobject_t& soid,
-						  bool can_create,
-						  map<string, bufferlist> *attrs)
+ObjectContextRef PrimaryLogPG::get_object_context(
+  const hobject_t& soid,
+  bool can_create,
+  const map<string, bufferlist> *attrs)
 {
   assert(
     attrs || !pg_log.get_missing().is_missing(soid) ||
@@ -9280,7 +9281,7 @@ void PrimaryLogPG::kick_object_context_blocked(ObjectContextRef obc)
 SnapSetContext *PrimaryLogPG::get_snapset_context(
   const hobject_t& oid,
   bool can_create,
-  map<string, bufferlist> *attrs,
+  const map<string, bufferlist> *attrs,
   bool oid_existed)
 {
   Mutex::Locker l(snapset_contexts_lock);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1530,7 +1530,7 @@ void PrimaryLogPG::get_src_oloc(const object_t& oid, const object_locator_t& olo
 
 void PrimaryLogPG::handle_backoff(OpRequestRef& op)
 {
-  MOSDBackoff *m = static_cast<MOSDBackoff*>(op->get_req());
+  const MOSDBackoff *m = static_cast<const MOSDBackoff*>(op->get_req());
   SessionRef session((Session *)m->get_connection()->get_priv());
   if (!session)
     return;  // drop it.
@@ -1558,7 +1558,7 @@ void PrimaryLogPG::do_request(
   }
 
   // pg-wide backoffs
-  Message *m = op->get_req();
+  const Message *m = op->get_req();
   if (m->get_connection()->has_feature(CEPH_FEATURE_RADOS_BACKOFF)) {
     SessionRef session((Session *)m->get_connection()->get_priv());
     if (!session)
@@ -1587,7 +1587,7 @@ void PrimaryLogPG::do_request(
     }
     // pg backoff acks at pg-level
     if (op->get_req()->get_type() == CEPH_MSG_OSD_BACKOFF) {
-      MOSDBackoff *ba = static_cast<MOSDBackoff*>(m);
+      const MOSDBackoff *ba = static_cast<const MOSDBackoff*>(m);
       if (ba->begin != ba->end) {
 	handle_backoff(op);
 	return;
@@ -2196,7 +2196,7 @@ void PrimaryLogPG::record_write_error(OpRequestRef op, const hobject_t &soid,
 {
   dout(20) << __func__ << " r=" << r << dendl;
   assert(op->may_write());
-  const osd_reqid_t &reqid = static_cast<MOSDOp*>(op->get_req())->get_reqid();
+  const osd_reqid_t &reqid = static_cast<const MOSDOp*>(op->get_req())->get_reqid();
   ObjectContextRef obc;
   mempool::osd::list<pg_log_entry_t> entries;
   entries.push_back(pg_log_entry_t(pg_log_entry_t::ERROR, soid,
@@ -2218,7 +2218,7 @@ void PrimaryLogPG::record_write_error(OpRequestRef op, const hobject_t &soid,
       {}
     void operator()() {
       ldpp_dout(pg, 20) << "finished " << __func__ << " r=" << r << dendl;
-      MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+      const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
       int flags = m->get_flags() & (CEPH_OSD_FLAG_ACK | CEPH_OSD_FLAG_ONDISK);
       MOSDOpReply *reply = orig_reply.detach();
       if (reply == nullptr) {
@@ -2252,7 +2252,7 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_cache_detail(
   if (op &&
       op->get_req() &&
       op->get_req()->get_type() == CEPH_MSG_OSD_OP &&
-      (static_cast<MOSDOp *>(op->get_req())->get_flags() &
+      (static_cast<const MOSDOp *>(op->get_req())->get_flags() &
        CEPH_OSD_FLAG_IGNORE_CACHE)) {
     dout(20) << __func__ << ": ignoring cache due to flag" << dendl;
     return cache_result_t::NOOP;
@@ -2298,7 +2298,7 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_cache_detail(
     missing_oid = obc->obs.oi.soid;
   }
 
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   const object_locator_t oloc = m->get_object_locator();
 
   if (op->need_skip_handle_cache()) {
@@ -2511,7 +2511,7 @@ bool PrimaryLogPG::maybe_promote(ObjectContextRef obc,
 
 void PrimaryLogPG::do_cache_redirect(OpRequestRef op)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   int flags = m->get_flags() & (CEPH_OSD_FLAG_ACK|CEPH_OSD_FLAG_ONDISK);
   MOSDOpReply *reply = new MOSDOpReply(m, -ENOENT,
 				       get_osdmap()->get_epoch(), flags, false);
@@ -2648,7 +2648,7 @@ void PrimaryLogPG::finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r)
 
   osd->logger->inc(l_osd_tier_proxy_read);
 
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   OpContext *ctx = new OpContext(op, m->get_reqid(), prdop->ops, this);
   ctx->reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false);
   ctx->user_at_version = prdop->user_version;
@@ -2810,7 +2810,7 @@ void PrimaryLogPG::finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r)
 
   osd->logger->inc(l_osd_tier_proxy_write);
 
-  MOSDOp *m = static_cast<MOSDOp*>(pwop->op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(pwop->op->get_req());
   assert(m != NULL);
 
   if (m->wants_ondisk() && !pwop->sent_disk) {
@@ -2944,7 +2944,7 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
   ctx->reset_obs(ctx->obc);
   ctx->update_log_only = false; // reset in case finish_copyfrom() is re-running execute_ctx
   OpRequestRef op = ctx->op;
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
   ObjectContextRef obc = ctx->obc;
   const hobject_t& soid = obc->obs.oi.soid;
 
@@ -3177,7 +3177,7 @@ void PrimaryLogPG::reply_ctx(OpContext *ctx, int r, eversion_t v, version_t uv)
 void PrimaryLogPG::log_op_stats(OpContext *ctx)
 {
   OpRequestRef op = ctx->op;
-  MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
 
   utime_t now = ceph_clock_now();
   utime_t latency = now;
@@ -3226,7 +3226,7 @@ void PrimaryLogPG::log_op_stats(OpContext *ctx)
 
 void PrimaryLogPG::do_sub_op(OpRequestRef op)
 {
-  MOSDSubOp *m = static_cast<MOSDSubOp*>(op->get_req());
+  const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
   assert(have_same_or_newer_map(m->map_epoch));
   assert(m->get_type() == MSG_OSD_SUBOP);
   dout(15) << "do_sub_op " << *op->get_req() << dendl;
@@ -3237,7 +3237,7 @@ void PrimaryLogPG::do_sub_op(OpRequestRef op)
     return;
   }
 
-  OSDOp *first = NULL;
+  const OSDOp *first = NULL;
   if (m->ops.size() >= 1) {
     first = &m->ops[0];
   }
@@ -3262,10 +3262,10 @@ void PrimaryLogPG::do_sub_op(OpRequestRef op)
 
 void PrimaryLogPG::do_sub_op_reply(OpRequestRef op)
 {
-  MOSDSubOpReply *r = static_cast<MOSDSubOpReply *>(op->get_req());
+  const MOSDSubOpReply *r = static_cast<const MOSDSubOpReply *>(op->get_req());
   assert(r->get_type() == MSG_OSD_SUBOPREPLY);
   if (r->ops.size() >= 1) {
-    OSDOp& first = r->ops[0];
+    const OSDOp& first = r->ops[0];
     switch (first.op.op) {
     case CEPH_OSD_OP_SCRUB_RESERVE:
       sub_op_scrub_reserve_reply(op);
@@ -3278,7 +3278,7 @@ void PrimaryLogPG::do_scan(
   OpRequestRef op,
   ThreadPool::TPHandle &handle)
 {
-  MOSDPGScan *m = static_cast<MOSDPGScan*>(op->get_req());
+  const MOSDPGScan *m = static_cast<const MOSDPGScan*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_SCAN);
   dout(10) << "do_scan " << *m << dendl;
 
@@ -3329,7 +3329,7 @@ void PrimaryLogPG::do_scan(
       BackfillInterval& bi = peer_backfill_info[from];
       bi.begin = m->begin;
       bi.end = m->end;
-      bufferlist::iterator p = m->get_data().begin();
+      bufferlist::iterator p = const_cast<bufferlist&>(m->get_data()).begin();
 
       // take care to preserve ordering!
       bi.clear_objects();
@@ -3351,7 +3351,7 @@ void PrimaryLogPG::do_scan(
 
 void PrimaryLogPG::do_backfill(OpRequestRef op)
 {
-  MOSDPGBackfill *m = static_cast<MOSDPGBackfill*>(op->get_req());
+  const MOSDPGBackfill *m = static_cast<const MOSDPGBackfill*>(op->get_req());
   assert(m->get_type() == MSG_OSD_PG_BACKFILL);
   dout(10) << "do_backfill " << *m << dendl;
 
@@ -6601,7 +6601,7 @@ int PrimaryLogPG::prepare_transaction(OpContext *ctx)
        ctx->delta_stats.num_objects > 0) &&  // FIXME: keys?
       (pool.info.has_flag(pg_pool_t::FLAG_FULL) ||
        get_osdmap()->test_flag(CEPH_OSDMAP_FULL))) {
-    MOSDOp *m = static_cast<MOSDOp*>(ctx->op->get_req());
+    const MOSDOp *m = static_cast<const MOSDOp*>(ctx->op->get_req());
     if (ctx->reqid.name.is_mds() ||   // FIXME: ignore MDS for now
 	m->has_flag(CEPH_OSD_FLAG_FULL_FORCE)) {
       dout(20) << __func__ << " full, but proceeding due to FULL_FORCE or MDS"
@@ -6816,7 +6816,7 @@ void PrimaryLogPG::apply_stats(
 
 void PrimaryLogPG::complete_read_ctx(int result, OpContext *ctx)
 {
-  MOSDOp *m = static_cast<MOSDOp*>(ctx->op->get_req());
+  const MOSDOp *m = static_cast<const MOSDOp*>(ctx->op->get_req());
   assert(ctx->async_reads_complete());
 
   for (vector<OSDOp>::iterator p = ctx->ops.begin();
@@ -6924,7 +6924,7 @@ int PrimaryLogPG::fill_in_copy_get(
     return result;
   }
 
-  MOSDOp *op = reinterpret_cast<MOSDOp*>(ctx->op->get_req());
+  const MOSDOp *op = reinterpret_cast<const MOSDOp*>(ctx->op->get_req());
   uint64_t features = op->get_features();
 
   bool async_read_started = false;
@@ -8296,7 +8296,7 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
     }
   } else {
     if (scrubber.active_rep_scrub) {
-      if (last_update_applied == static_cast<MOSDRepScrub*>(
+      if (last_update_applied == static_cast<const MOSDRepScrub*>(
 	    scrubber.active_rep_scrub->get_req())->scrub_to) {
 	osd->op_wq.queue(
 	  make_pair(
@@ -8310,9 +8310,9 @@ void PrimaryLogPG::op_applied(const eversion_t &applied_version)
 
 void PrimaryLogPG::eval_repop(RepGather *repop)
 {
-  MOSDOp *m = NULL;
+  const MOSDOp *m = NULL;
   if (repop->op)
-    m = static_cast<MOSDOp *>(repop->op->get_req());
+    m = static_cast<const MOSDOp *>(repop->op->get_req());
 
   if (m)
     dout(10) << "eval_repop " << *repop
@@ -9528,7 +9528,7 @@ void PrimaryLogPG::_applied_recovered_object_replica()
 
   // requeue an active chunky scrub waiting on recovery ops
   if (!deleting && active_pushes == 0 &&
-      scrubber.active_rep_scrub && static_cast<MOSDRepScrub*>(
+      scrubber.active_rep_scrub && static_cast<const MOSDRepScrub*>(
 	scrubber.active_rep_scrub->get_req())->chunky) {
     osd->op_wq.queue(
       make_pair(
@@ -9578,7 +9578,7 @@ void PrimaryLogPG::failed_push(const list<pg_shard_t> &from, const hobject_t &so
 
 void PrimaryLogPG::sub_op_remove(OpRequestRef op)
 {
-  MOSDSubOp *m = static_cast<MOSDSubOp*>(op->get_req());
+  const MOSDSubOp *m = static_cast<const MOSDSubOp*>(op->get_req());
   assert(m->get_type() == MSG_OSD_SUBOP);
   dout(7) << "sub_op_remove " << m->poid << dendl;
 
@@ -9621,7 +9621,7 @@ eversion_t PrimaryLogPG::pick_newest_available(const hobject_t& oid)
 
 void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
 {
-  MOSDPGUpdateLogMissing *m = static_cast<MOSDPGUpdateLogMissing*>(
+  const MOSDPGUpdateLogMissing *m = static_cast<const MOSDPGUpdateLogMissing*>(
     op->get_req());
   assert(m->get_type() == MSG_OSD_PG_UPDATE_LOG_MISSING);
   ObjectStore::Transaction t;
@@ -9629,7 +9629,7 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
 
   Context *complete = new FunctionContext(
     [=](int) {
-      MOSDPGUpdateLogMissing *msg = static_cast<MOSDPGUpdateLogMissing*>(
+      const MOSDPGUpdateLogMissing *msg = static_cast<const MOSDPGUpdateLogMissing*>(
 	op->get_req());
       lock();
       if (!pg_has_reset_since(msg->get_epoch())) {
@@ -9670,8 +9670,8 @@ void PrimaryLogPG::do_update_log_missing(OpRequestRef &op)
 
 void PrimaryLogPG::do_update_log_missing_reply(OpRequestRef &op)
 {
-  MOSDPGUpdateLogMissingReply *m =
-    static_cast<MOSDPGUpdateLogMissingReply*>(
+  const MOSDPGUpdateLogMissingReply *m =
+    static_cast<const MOSDPGUpdateLogMissingReply*>(
     op->get_req());
   dout(20) << __func__ << " got reply from "
 	   << m->get_from() << dendl;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -337,7 +337,7 @@ public:
 
   ObjectContextRef get_obc(
     const hobject_t &hoid,
-    map<string, bufferlist> &attrs) override {
+    const map<string, bufferlist> &attrs) override {
     return get_object_context(hoid, true, &attrs);
   }
 
@@ -370,7 +370,7 @@ public:
 
   void log_operation(
     const vector<pg_log_entry_t> &logv,
-    boost::optional<pg_hit_set_history_t> &hset_history,
+    const boost::optional<pg_hit_set_history_t> &hset_history,
     const eversion_t &trim_to,
     const eversion_t &roll_forward_to,
     bool transaction_applied,
@@ -952,7 +952,7 @@ protected:
   ObjectContextRef get_object_context(
     const hobject_t& soid,
     bool can_create,
-    map<string, bufferlist> *attrs = 0
+    const map<string, bufferlist> *attrs = 0
     );
 
   void context_registry_on_change();
@@ -972,7 +972,7 @@ protected:
   SnapSetContext *get_snapset_context(
     const hobject_t& oid,
     bool can_create,
-    map<string, bufferlist> *attrs = 0,
+    const map<string, bufferlist> *attrs = 0,
     bool oid_existed = true //indicate this oid whether exsited in backend
     );
   void register_snapset_context(SnapSetContext *ssc) {

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -238,7 +238,7 @@ private:
   void do_pull(OpRequestRef op);
   void do_push_reply(OpRequestRef op);
 
-  bool handle_push_reply(pg_shard_t peer, PushReplyOp &op, PushOp *reply);
+  bool handle_push_reply(pg_shard_t peer, const PushReplyOp &op, PushOp *reply);
   void handle_pull(pg_shard_t peer, PullOp &op, PushOp *reply);
 
   struct pull_complete_info {
@@ -247,10 +247,10 @@ private:
     object_stat_sum_t stat;
   };
   bool handle_pull_response(
-    pg_shard_t from, PushOp &op, PullOp *response,
+    pg_shard_t from, const PushOp &op, PullOp *response,
     list<pull_complete_info> *to_continue,
     ObjectStore::Transaction *t);
-  void handle_push(pg_shard_t from, PushOp &op, PushReplyOp *response,
+  void handle_push(pg_shard_t from, const PushOp &op, PushReplyOp *response,
 		   ObjectStore::Transaction *t);
 
   static void trim_pushed_data(const interval_set<uint64_t> &copy_subset,
@@ -277,17 +277,17 @@ private:
 		    PushOp *out_op,
 		    object_stat_sum_t *stat = 0,
                     bool cache_dont_need = true);
-  void submit_push_data(ObjectRecoveryInfo &recovery_info,
+  void submit_push_data(const ObjectRecoveryInfo &recovery_info,
 			bool first,
 			bool complete,
 			bool cache_dont_need,
 			const interval_set<uint64_t> &intervals_included,
 			bufferlist data_included,
 			bufferlist omap_header,
-			map<string, bufferlist> &attrs,
-			map<string, bufferlist> &omap_entries,
+			const map<string, bufferlist> &attrs,
+			const map<string, bufferlist> &omap_entries,
 			ObjectStore::Transaction *t);
-  void submit_push_complete(ObjectRecoveryInfo &recovery_info,
+  void submit_push_complete(const ObjectRecoveryInfo &recovery_info,
 			    ObjectStore::Transaction *t);
 
   void calc_clone_subsets(

--- a/src/osd/Session.cc
+++ b/src/osd/Session.cc
@@ -83,7 +83,7 @@ void Session::ack_backoff(
 }
 
 bool Session::check_backoff(
-  CephContext *cct, spg_t pgid, const hobject_t& oid, Message *m)
+  CephContext *cct, spg_t pgid, const hobject_t& oid, const Message *m)
 {
   BackoffRef b(have_backoff(pgid, oid));
   if (b) {

--- a/src/osd/Session.h
+++ b/src/osd/Session.h
@@ -195,7 +195,7 @@ struct Session : public RefCountedObject {
   }
 
   bool check_backoff(
-    CephContext *cct, spg_t pgid, const hobject_t& oid, Message *m);
+    CephContext *cct, spg_t pgid, const hobject_t& oid, const Message *m);
 
   void add_backoff(BackoffRef b) {
     Mutex::Locker l(backoff_lock);


### PR DESCRIPTION
Try to use const in as many places as possible.  In cases where a Message we are processing is really mutated, annotate it by using a different OpRequest accessor (get_nonconst_req()) and make sure that it cannot race with the Message::print() method (used by operator<< and, most importantly, the asok 'ops' command, which may run at any time and must break due to any of our mutations).

I tried to order this so that it would build in sequence but didn't go back and verify.  It should be close.