### PR TITLE
osd: remove copy-get-classic

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -66,3 +66,6 @@
   SORTBITWISE flag enabled (Jewel and later).  (Note that this flag is
   required to be set before upgrading beyond Jewel.)
 
+* The rados copy-get-classic operation has been removed since it has not been
+  used by the OSD since before hammer.  It is unlikely any librados user is
+  using this operation explicitly since there is also the more modern copy-get.

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -240,7 +240,7 @@ extern const char *ceph_osd_state_name(int s);
 									    \
 	/* tiering */							    \
 	f(COPY_FROM,	__CEPH_OSD_OP(WR, DATA, 26),	"copy-from")	    \
-	f(COPY_GET_CLASSIC, __CEPH_OSD_OP(RD, DATA, 27), "copy-get-classic") \
+	/* was copy-get-classic */					\
 	f(UNDIRTY,	__CEPH_OSD_OP(WR, DATA, 28),	"undirty")	    \
 	f(ISDIRTY,	__CEPH_OSD_OP(RD, DATA, 29),	"isdirty")	    \
 	f(COPY_GET,	__CEPH_OSD_OP(RD, DATA, 30),	"copy-get")	    \

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9478,7 +9478,6 @@ int OSD::init_op_flags(OpRequestRef& op)
             (iter->op.op != CEPH_OSD_OP_SETXATTR) &&
             (iter->op.op != CEPH_OSD_OP_RMXATTR) &&
             (iter->op.op != CEPH_OSD_OP_STARTSYNC) &&
-            (iter->op.op != CEPH_OSD_OP_COPY_GET_CLASSIC) &&
             (iter->op.op != CEPH_OSD_OP_COPY_GET) &&
             (iter->op.op != CEPH_OSD_OP_COPY_FROM)) {
           op->set_promote();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2046,13 +2046,8 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   if (r && (r != -ENOENT || !obc)) {
     // copy the reqids for copy get on ENOENT
     if (r == -ENOENT &&
-	(m->ops[0].op.op == CEPH_OSD_OP_COPY_GET_CLASSIC ||
-	 m->ops[0].op.op == CEPH_OSD_OP_COPY_GET)) {
-      bool classic = false;
-      if (m->ops[0].op.op == CEPH_OSD_OP_COPY_GET_CLASSIC) {
-	classic = true;
-      }
-      fill_in_copy_get_noent(op, oid, m->ops[0], classic);
+	(m->ops[0].op.op == CEPH_OSD_OP_COPY_GET)) {
+      fill_in_copy_get_noent(op, oid, m->ops[0]);
       return;
     }
     dout(20) << __func__ << "find_object_context got error " << r << dendl;
@@ -2159,13 +2154,8 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
        ((m->get_snapid() != CEPH_SNAPDIR) &&
 	obc->obs.oi.is_whiteout()))) {
     // copy the reqids for copy get on ENOENT
-    if (m->ops[0].op.op == CEPH_OSD_OP_COPY_GET_CLASSIC ||
-	m->ops[0].op.op == CEPH_OSD_OP_COPY_GET) {
-      bool classic = false;
-      if (m->ops[0].op.op == CEPH_OSD_OP_COPY_GET_CLASSIC) {
-	classic = true;
-      }
-      fill_in_copy_get_noent(op, oid, m->ops[0], classic);
+    if (m->ops[0].op.op == CEPH_OSD_OP_COPY_GET) {
+      fill_in_copy_get_noent(op, oid, m->ops[0]);
       close_op_ctx(ctx);
       return;
     }
@@ -5878,16 +5868,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       obs.oi.clear_omap_digest();
       break;
 
-    case CEPH_OSD_OP_COPY_GET_CLASSIC:
-      ++ctx->num_read;
-      tracepoint(osd, do_osd_op_pre_copy_get_classic, soid.oid.name.c_str(), soid.snap.val);
-      result = fill_in_copy_get(ctx, bp, osd_op, ctx->obc, true);
-      break;
-
     case CEPH_OSD_OP_COPY_GET:
       ++ctx->num_read;
       tracepoint(osd, do_osd_op_pre_copy_get, soid.oid.name.c_str(), soid.snap.val);
-      result = fill_in_copy_get(ctx, bp, osd_op, ctx->obc, false);
+      result = fill_in_copy_get(ctx, bp, osd_op, ctx->obc);
       break;
 
     case CEPH_OSD_OP_COPY_FROM:
@@ -6879,21 +6863,16 @@ struct C_CopyFrom_AsyncReadCb : public Context {
   OSDOp *osd_op;
   object_copy_data_t reply_obj;
   uint64_t features;
-  bool classic;
   size_t len;
-  C_CopyFrom_AsyncReadCb(OSDOp *osd_op, uint64_t features, bool classic) :
-    osd_op(osd_op), features(features), classic(classic), len(0) {}
+  C_CopyFrom_AsyncReadCb(OSDOp *osd_op, uint64_t features) :
+    osd_op(osd_op), features(features), len(0) {}
   void finish(int r) override {
     assert(len > 0);
     assert(len <= reply_obj.data.length());
     bufferlist bl;
     bl.substr_of(reply_obj.data, 0, len);
     reply_obj.data.swap(bl);
-    if (classic) {
-      reply_obj.encode_classic(osd_op->outdata);
-    } else {
-      ::encode(reply_obj, osd_op->outdata, features);
-    }
+    ::encode(reply_obj, osd_op->outdata, features);
   }
 };
 
@@ -6901,8 +6880,7 @@ int PrimaryLogPG::fill_in_copy_get(
   OpContext *ctx,
   bufferlist::iterator& bp,
   OSDOp& osd_op,
-  ObjectContextRef &obc,
-  bool classic)
+  ObjectContextRef &obc)
 {
   object_info_t& oi = obc->obs.oi;
   hobject_t& soid = oi.soid;
@@ -6925,7 +6903,7 @@ int PrimaryLogPG::fill_in_copy_get(
   object_copy_data_t _reply_obj;
   C_CopyFrom_AsyncReadCb *cb = NULL;
   if (pool.info.require_rollback()) {
-    cb = new C_CopyFrom_AsyncReadCb(&osd_op, features, classic);
+    cb = new C_CopyFrom_AsyncReadCb(&osd_op, features);
   }
   object_copy_data_t &reply_obj = cb ? cb->reply_obj : _reply_obj;
   // size, mtime
@@ -7051,11 +7029,7 @@ int PrimaryLogPG::fill_in_copy_get(
 	   << dendl;
   reply_obj.cursor = cursor;
   if (!async_read_started) {
-    if (classic) {
-      reply_obj.encode_classic(osd_op.outdata);
-    } else {
-      ::encode(reply_obj, osd_op.outdata, features);
-    }
+    ::encode(reply_obj, osd_op.outdata, features);
   }
   if (cb && !async_read_started) {
     delete cb;
@@ -7065,7 +7039,7 @@ int PrimaryLogPG::fill_in_copy_get(
 }
 
 void PrimaryLogPG::fill_in_copy_get_noent(OpRequestRef& op, hobject_t oid,
-                                          OSDOp& osd_op, bool classic)
+                                          OSDOp& osd_op)
 {
   MOSDOp *m = static_cast<MOSDOp*>(op->get_req());
   uint64_t features = m->get_features();
@@ -7073,11 +7047,7 @@ void PrimaryLogPG::fill_in_copy_get_noent(OpRequestRef& op, hobject_t oid,
 
   pg_log.get_log().get_object_reqids(oid, 10, &reply_obj.reqids);
   dout(20) << __func__ << " got reqids " << reply_obj.reqids << dendl;
-  if (classic) {
-    reply_obj.encode_classic(osd_op.outdata);
-  } else {
-    ::encode(reply_obj, osd_op.outdata, features);
-  }
+  ::encode(reply_obj, osd_op.outdata, features);
   osd_op.rval = -ENOENT;
   MOSDOpReply *reply = new MOSDOpReply(m, 0, get_osdmap()->get_epoch(), 0, false);
   reply->claim_op_out_data(m->ops);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1233,10 +1233,9 @@ protected:
     OpContext *ctx,
     bufferlist::iterator& bp,
     OSDOp& op,
-    ObjectContextRef& obc,
-    bool classic);
+    ObjectContextRef& obc);
   void fill_in_copy_get_noent(OpRequestRef& op, hobject_t oid,
-                              OSDOp& osd_op, bool classic);
+                              OSDOp& osd_op);
 
   /**
    * To copy an object, call start_copy.

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3919,37 +3919,6 @@ void object_copy_cursor_t::generate_test_instances(list<object_copy_cursor_t*>& 
 
 // -- object_copy_data_t --
 
-void object_copy_data_t::encode_classic(bufferlist& bl) const
-{
-  ::encode(size, bl);
-  ::encode(mtime, bl);
-  ::encode(attrs, bl);
-  ::encode(data, bl);
-  if (omap_data.length())
-    bl.append(omap_data);
-  else
-    ::encode((__u32)0, bl);
-  ::encode(cursor, bl);
-}
-
-void object_copy_data_t::decode_classic(bufferlist::iterator& bl)
-{
-  ::decode(size, bl);
-  ::decode(mtime, bl);
-  ::decode(attrs, bl);
-  ::decode(data, bl);
-  {
-    map<string,bufferlist> omap;
-    ::decode(omap, bl);
-    omap_data.clear();
-    if (!omap.empty())
-      ::encode(omap, omap_data);
-  }
-  ::decode(cursor, bl);
-  flags = 0;
-  data_digest = omap_digest = 0;
-}
-
 void object_copy_data_t::encode(bufferlist& bl, uint64_t features) const
 {
   ENCODE_START(7, 5, bl);
@@ -5365,7 +5334,6 @@ ostream& operator<<(ostream& out, const OSDOp& op)
       out << " cookie " << op.op.notify.cookie;
       break;
     case CEPH_OSD_OP_COPY_GET:
-    case CEPH_OSD_OP_COPY_GET_CLASSIC:
       out << " max " << op.op.copy_get.max;
       break;
     case CEPH_OSD_OP_COPY_FROM:

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3714,8 +3714,6 @@ public:
     truncate_size(0) {}
 
   static void generate_test_instances(list<object_copy_data_t*>& o);
-  void encode_classic(bufferlist& bl) const;
-  void decode_classic(bufferlist::iterator& bl);
   void encode(bufferlist& bl, uint64_t features) const;
   void decode(bufferlist::iterator& bl);
   void dump(Formatter *f) const;


### PR DESCRIPTION
This hasn't been used since well before hammer.

Signed-off-by: Sage Weil <sage@redhat.com>