### PR TITLE
src/test/encoding/types.h: replace WITH_LIBAIO with HAVE_LIBAIO

### DIFF
--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -116,14 +116,13 @@ TYPE(ObjectStore::Transaction)
 #include "os/filestore/SequencerPosition.h"
 TYPE(SequencerPosition)
 
-#ifdef WITH_LIBAIO
+#ifdef HAVE_LIBAIO
 #include "os/bluestore/bluestore_types.h"
 TYPE(bluestore_cnode_t)
 TYPE(bluestore_compression_header_t)
 TYPE(bluestore_extent_ref_map_t)
 TYPE(bluestore_pextent_t)
-TYPE(bluestore_blob_t)
-TYPE(bluestore_lextent_t)
+TYPE_FEATUREFUL(bluestore_blob_t)
 TYPE(bluestore_onode_t)
 TYPE(bluestore_wal_op_t)
 TYPE(bluestore_wal_transaction_t)


### PR DESCRIPTION
- WITH_* is used in Cmake
 - HAVE_* is used in c/c++ files

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>