### PR TITLE
mon/MonClient: persist global_id across re-connecting

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -114,7 +114,7 @@ int MonClient::get_monmap_privately()
   std::uniform_int_distribution<unsigned> ranks(0, monmap.size() - 1);
   while (monmap.fsid.is_zero()) {
     auto rank = ranks(rng);
-    auto& pending_con = _add_conn(rank);
+    auto& pending_con = _add_conn(rank, 0);
     auto con = pending_con.get_con();
     ldout(cct, 10) << "querying mon." << monmap.get_name(rank) << " "
 		   << con->get_peer_addr() << dendl;
@@ -572,15 +572,17 @@ void MonClient::_reopen_session(int rank)
   assert(monc_lock.is_locked());
   ldout(cct, 10) << __func__ << " rank " << rank << dendl;
 
+  // save global_id if any before nuking active_con
+  const uint64_t global_id = active_con ? active_con->get_global_id() : 0;
   active_con.reset();
   pending_cons.clear();
 
   _start_hunting();
 
   if (rank >= 0) {
-    _add_conn(rank);
+    _add_conn(rank, global_id);
   } else {
-    _add_conns();
+    _add_conns(global_id);
   }
 
   // throw out old queued messages
@@ -610,11 +612,11 @@ void MonClient::_reopen_session(int rank)
     _renew_subs();
 }
 
-MonConnection& MonClient::_add_conn(unsigned rank)
+MonConnection& MonClient::_add_conn(unsigned rank, uint64_t global_id)
 {
   auto peer = monmap.get_addr(rank);
   auto conn = messenger->get_connection(monmap.get_inst(rank));
-  MonConnection mc(cct, conn);
+  MonConnection mc(cct, conn, global_id);
   auto inserted = pending_cons.insert(move(make_pair(peer, move(mc))));
   ldout(cct, 10) << "picked mon." << monmap.get_name(rank)
                  << " con " << conn
@@ -623,7 +625,7 @@ MonConnection& MonClient::_add_conn(unsigned rank)
   return inserted.first->second;
 }
 
-void MonClient::_add_conns()
+void MonClient::_add_conns(uint64_t global_id)
 {
   const unsigned num_mons = monmap.size();
   vector<unsigned> ranks(num_mons);
@@ -639,7 +641,7 @@ void MonClient::_add_conns()
      n = num_mons;
   }
   for (unsigned i = 0; i < n; i++) {
-    _add_conn(ranks[i]);
+    _add_conn(ranks[i], global_id);
   }
 }
 
@@ -1143,8 +1145,8 @@ AuthAuthorizer* MonClient::build_authorizer(int service_id) const {
 #undef dout_prefix
 #define dout_prefix *_dout << "monclient" << (have_session() ? ": " : "(hunting): ")
 
-MonConnection::MonConnection(CephContext *cct, ConnectionRef con)
-  : cct(cct), con(con)
+MonConnection::MonConnection(CephContext *cct, ConnectionRef con, uint64_t global_id)
+  : cct(cct), con(con), global_id(global_id)
 {}
 
 MonConnection::~MonConnection()

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -97,7 +97,8 @@ struct MonClientPinger : public Dispatcher {
 class MonConnection {
 public:
   MonConnection(CephContext *cct,
-		ConnectionRef conn);
+		ConnectionRef conn,
+		uint64_t global_id);
   ~MonConnection();
   MonConnection(MonConnection&& rhs) = default;
   MonConnection& operator=(MonConnection&&) = default;
@@ -140,7 +141,7 @@ private:
   ConnectionRef con;
 
   std::unique_ptr<AuthClientHandler> auth;
-  uint64_t global_id = 0;
+  uint64_t global_id;
 };
 
 class MonClient : public Dispatcher {
@@ -205,8 +206,8 @@ private:
   void _finish_hunting();
   void _finish_auth(int auth_err);
   void _reopen_session(int rank = -1);
-  MonConnection& _add_conn(unsigned rank);
-  void _add_conns();
+  MonConnection& _add_conn(unsigned rank, uint64_t global_id);
+  void _add_conns(uint64_t global_id);
   void _send_mon_message(Message *m);
 
 public:


### PR DESCRIPTION
MonClient should re-use previously assigned global-id after
re-connecting. and should not have its global-id changed once it is
authenticated unless monitor thinks otherwise.

Fixes: http://tracker.ceph.com/issues/18968
Signed-off-by: Kefu Chai <kchai@redhat.com>