### PR TITLE
os/bluestore/BlueStore.cc:remove unuse code in _open_bdev()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3617,7 +3617,6 @@ void BlueStore::_set_alloc_sizes(void)
 
 int BlueStore::_open_bdev(bool create)
 {
-  bluestore_bdev_label_t label;
   assert(bdev == NULL);
   string p = path + "/block";
   bdev = BlockDevice::create(cct, p, aio_cb, static_cast<void*>(this));


### PR DESCRIPTION
Here 'label' is not available in _open_bdev(), remove it.

Signed-off-by: yonghengdexin735 <zhang.zezhu@zte.com.cn>