### PR TITLE
os/bluestore: fix bug in _open_super_meta()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6899,7 +6899,7 @@ int BlueStore::_open_super_meta()
   }
 
   // bluefs alloc
-  {
+  if (cct->_conf->bluestore_bluefs) {
     bluefs_extents.clear();
     bufferlist bl;
     db->get(PREFIX_SUPER, "bluefs_extents", &bl);


### PR DESCRIPTION
os/bluestore: fix bug in _open_super_meta
If rocksdb isn't used, kvbackend can't have the key 'bluefs_extents'.

Signed-off-by: Taeksang Kim <voidbag@gmail.com>