### PR TITLE
DNM: ceph-disk: Add cluster as an argument to ceph-disk activate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4855,6 +4855,12 @@ def make_activate_parser(subparsers):
         """.format(statedir=STATEDIR))),
         help='Activate a Ceph OSD')
     activate_parser.add_argument(
+        '--cluster',
+        metavar='NAME',
+        default='ceph',
+        help='ceph cluster name (default: ceph)',
+    )
+    activate_parser.add_argument(
         '--mount',
         action='store_true', default=None,
         help='mount a block device [deprecated, ignored]',


### PR DESCRIPTION
Follow-on fix for #11786 to help avoid erroring out using ceph-deploy to
activate osd. Follow-on fix for http://tracker.ceph.com/issues/17821

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>