### PR TITLE
os/bluestore: preserve allocator's hints across multiple allocations

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8647,7 +8647,7 @@ int BlueStore::_do_alloc_write(
     return r;
   }
 
-  uint64_t hint = 0;
+  thread_local uint64_t hint = 0;
   CompressorRef c;
   double crr = 0;
   if (wctx->compress) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4283,9 +4283,11 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
     int r = alloc->reserve(gift);
     assert(r == 0);
 
+    thread_local uint64_t hint = 0;
+
     AllocExtentVector exts;
     int64_t alloc_len = alloc->allocate(gift, cct->_conf->bluefs_alloc_size,
-					0, 0, &exts);
+					0, hint, &exts);
 
     if (alloc_len < (int64_t)gift) {
       derr << __func__ << " allocate failed on 0x" << std::hex << gift
@@ -4298,6 +4300,7 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
       bluestore_pextent_t e = bluestore_pextent_t(p);
       dout(1) << __func__ << " gifting " << e << " to bluefs" << dendl;
       extents->push_back(e);
+      hint = p.end();
     }
     gift = 0;
 


### PR DESCRIPTION
`BitMapAllocator` seems to have a performance issue that affects rand-writes in small chunks (4KiB) on SSDs. Even a completely IO-sanitised (`bluestore_debug_omit_block_device_write = true` + https://github.com/rzarzynski/ceph/commit/96776b8220a2ba32924ed86e808556c84b7d7f61) BlueStore can't overcome the 50 kIOPS limit on my machine (`nr_files=64`, `size=256k`, `bs=4k`, `numjobs=1`). This is clearly a CPU boundary.

Investigation suggests that [`BitMapAreaIN::alloc_blocks_dis_int_work`](https://github.com/ceph/ceph/blob/master/src/os/bluestore/BitAllocator.cc#L1112) is one of the main contributors. It generates extensive locking traffic while accessing scattered memory. This isn't friendly for CPU caches nor TLBs.

These experimental patches are intended to minimise the traffic by preserving the allocator's hint across multiple allocations and thus requiring fewer turns to find a free space. Although they allowed to reach 100 kIOPS in local testing, I don't see them as an ultimate solution. Something more sophisticated might be necessary -- lock free data structures, bitmaps kept together on huge pages? Just thinking loudly.

The main motivation behind this pull request is to bring attention to the allocator's performance and ask for verification of the local results.

CC: @liewegas, @markhpc, @ifed01.