### PR TITLE
ReplicatedBackend: don't queue Context outside of ObjectStore with obc

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -875,7 +875,11 @@ struct C_ReplicatedBackend_OnPullComplete : GenContext<ThreadPool::TPHandle&> {
   void finish(ThreadPool::TPHandle &handle) {
     ReplicatedBackend::RPGHandle *h = bc->_open_recovery_op();
     for (auto &&i: to_continue) {
-      if (!bc->start_pushes(i.hoid, i.obc, h)) {
+      auto j = bc->pulling.find(i.hoid);
+      assert(j != bc->pulling.end());
+      ObjectContextRef obc = j->second.obc;
+      bc->clear_pull(j);
+      if (!bc->start_pushes(i.hoid, obc, h)) {
 	bc->get_parent()->on_global_recover(
 	  i.hoid, i.stat);
       }
@@ -1865,10 +1869,9 @@ bool ReplicatedBackend::handle_pull_response(
 
   if (complete) {
     pi.stat.num_objects_recovered++;
-    to_continue->push_back({hoid, pi.obc, pi.stat});
+    to_continue->push_back({hoid, pi.stat});
     get_parent()->on_local_recover(
       hoid, pi.recovery_info, pi.obc, t);
-    clear_pull(pulling.find(hoid));
     return false;
   } else {
     response->soid = pop.soid;

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -245,7 +245,6 @@ private:
 
   struct pull_complete_info {
     hobject_t hoid;
-    ObjectContextRef obc;
     object_stat_sum_t stat;
   };
   bool handle_pull_response(


### PR DESCRIPTION
We only flush the ObjectStore callbacks, not everything else.  Thus,
there isn't a guarrantee that the obc held by pull_complete_info will
be cleaned up before the Flush callback is triggered.  Instead, just
defer clearing the pull state until the callback (it'll be cleaned up
during the interval change) and remove the ObjectContext from
pull_complete_info.

Introduced: 68defc2b0561414711d4dd0a76bc5d0f46f8a3f8
Fixes: http://tracker.ceph.com/issues/18927
Signed-off-by: Samuel Just <sjust@redhat.com>