### PR TITLE
rbd-mirror A/A: leader should track up/down rbd-mirror instances

### DIFF
--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -5,6 +5,7 @@ set(rbd_mirror_test_srcs
   test_ImageDeleter.cc
   test_ImageSync.cc
   test_InstanceWatcher.cc
+  test_Instances.cc
   test_LeaderWatcher.cc
   test_fixture.cc
   )

--- a/src/test/rbd_mirror/test_Instances.cc
+++ b/src/test/rbd_mirror/test_Instances.cc
@@ -1,0 +1,101 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/rados/librados.hpp"
+#include "cls/rbd/cls_rbd_client.h"
+#include "test/rbd_mirror/test_fixture.h"
+#include "tools/rbd_mirror/InstanceWatcher.h"
+#include "tools/rbd_mirror/Instances.h"
+#include "tools/rbd_mirror/Threads.h"
+
+#include "test/librados/test.h"
+#include "gtest/gtest.h"
+
+using rbd::mirror::InstanceWatcher;
+using rbd::mirror::Instances;
+
+void register_test_instances() {
+}
+
+class TestInstances : public ::rbd::mirror::TestFixture {
+public:
+  virtual void SetUp() {
+    TestFixture::SetUp();
+    m_local_io_ctx.remove(RBD_MIRROR_LEADER);
+    EXPECT_EQ(0, m_local_io_ctx.create(RBD_MIRROR_LEADER, true));
+  }
+};
+
+TEST_F(TestInstances, InitShutdown)
+{
+  Instances<> instances(m_threads, m_local_io_ctx);
+
+  std::string instance_id = "instance_id";
+  ASSERT_EQ(0, librbd::cls_client::mirror_instances_add(&m_local_io_ctx,
+                                                        instance_id));
+
+  C_SaferCond on_init;
+  instances.init(&on_init);
+  ASSERT_EQ(0, on_init.wait());
+
+  C_SaferCond on_shut_down;
+  instances.shut_down(&on_shut_down);
+  ASSERT_EQ(0, on_shut_down.wait());
+}
+
+TEST_F(TestInstances, InitEnoent)
+{
+  Instances<> instances(m_threads, m_local_io_ctx);
+
+  m_local_io_ctx.remove(RBD_MIRROR_LEADER);
+
+  C_SaferCond on_init;
+  instances.init(&on_init);
+  ASSERT_EQ(0, on_init.wait());
+
+  C_SaferCond on_shut_down;
+  instances.shut_down(&on_shut_down);
+  ASSERT_EQ(0, on_shut_down.wait());
+}
+
+TEST_F(TestInstances, NotifyRemove)
+{
+  // speed testing up a little
+  EXPECT_EQ(0, _rados->conf_set("rbd_mirror_leader_heartbeat_interval", "1"));
+  EXPECT_EQ(0, _rados->conf_set("rbd_mirror_leader_max_missed_heartbeats",
+                                "2"));
+
+  Instances<> instances(m_threads, m_local_io_ctx);
+
+  std::string instance_id1 = "instance_id1";
+  std::string instance_id2 = "instance_id2";
+
+  ASSERT_EQ(0, librbd::cls_client::mirror_instances_add(&m_local_io_ctx,
+                                                        instance_id1));
+  ASSERT_EQ(0, librbd::cls_client::mirror_instances_add(&m_local_io_ctx,
+                                                        instance_id2));
+
+  C_SaferCond on_init;
+  instances.init(&on_init);
+  ASSERT_EQ(0, on_init.wait());
+
+  std::vector<std::string> instance_ids;
+
+  for (int i = 0; i < 10; i++) {
+    instances.notify(instance_id1);
+    sleep(1);
+    C_SaferCond on_get;
+    InstanceWatcher<>::get_instances(m_local_io_ctx, &instance_ids, &on_get);
+    EXPECT_EQ(0, on_get.wait());
+    if (instance_ids.size() <= 1U) {
+      break;
+    }
+  }
+
+  ASSERT_EQ(1U, instance_ids.size());
+  ASSERT_EQ(instance_ids[0], instance_id1);
+
+  C_SaferCond on_shut_down;
+  instances.shut_down(&on_shut_down);
+  ASSERT_EQ(0, on_shut_down.wait());
+}

--- a/src/test/rbd_mirror/test_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_LeaderWatcher.cc
@@ -4,6 +4,7 @@
 #include "include/rados/librados.hpp"
 #include "librbd/internal.h"
 #include "librbd/Utils.h"
+#include "test/librbd/test_support.h"
 #include "test/rbd_mirror/test_fixture.h"
 #include "tools/rbd_mirror/LeaderWatcher.h"
 #include "tools/rbd_mirror/Threads.h"
@@ -206,8 +207,10 @@ TEST_F(TestLeaderWatcher, ListenerError)
 
 TEST_F(TestLeaderWatcher, Two)
 {
+  REQUIRE(!is_librados_test_stub());
+
   Listener listener1;
-  LeaderWatcher<> leader_watcher1(m_threads, m_local_io_ctx, &listener1);
+  LeaderWatcher<> leader_watcher1(m_threads, create_connection(), &listener1);
 
   C_SaferCond on_init_acquire;
   listener1.on_acquire(0, &on_init_acquire);
@@ -215,7 +218,7 @@ TEST_F(TestLeaderWatcher, Two)
   ASSERT_EQ(0, on_init_acquire.wait());
 
   Listener listener2;
-  LeaderWatcher<> leader_watcher2(m_threads, m_local_io_ctx, &listener2);
+  LeaderWatcher<> leader_watcher2(m_threads, create_connection(), &listener2);
 
   ASSERT_EQ(0, leader_watcher2.init());
   ASSERT_TRUE(leader_watcher1.is_leader());
@@ -244,11 +247,7 @@ TEST_F(TestLeaderWatcher, Two)
 
 TEST_F(TestLeaderWatcher, Break)
 {
-  if (is_librados_test_stub()) {
-    // break_lock (blacklist) does not work on librados test stub
-    std::cout << "SKIPPING" << std::endl;
-    return SUCCEED();
-  }
+  REQUIRE(!is_librados_test_stub());
 
   Listener listener1, listener2;
   LeaderWatcher<> leader_watcher1(m_threads,
@@ -276,11 +275,7 @@ TEST_F(TestLeaderWatcher, Break)
 
 TEST_F(TestLeaderWatcher, Stress)
 {
-  if (is_librados_test_stub()) {
-    // skipping due to possible break request sent
-    std::cout << "SKIPPING" << std::endl;
-    return SUCCEED();
-  }
+  REQUIRE(!is_librados_test_stub());
 
   const int WATCHERS_COUNT = 20;
   std::list<LeaderWatcher<> *> leader_watchers;

--- a/src/test/rbd_mirror/test_main.cc
+++ b/src/test/rbd_mirror/test_main.cc
@@ -11,6 +11,7 @@
 extern void register_test_cluster_watcher();
 extern void register_test_image_sync();
 extern void register_test_instance_watcher();
+extern void register_test_instances();
 extern void register_test_leader_watcher();
 extern void register_test_pool_watcher();
 extern void register_test_rbd_mirror();
@@ -21,6 +22,7 @@ int main(int argc, char **argv)
   register_test_cluster_watcher();
   register_test_image_sync();
   register_test_instance_watcher();
+  register_test_instances();
   register_test_leader_watcher();
   register_test_pool_watcher();
   register_test_rbd_mirror();

--- a/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_LeaderWatcher.cc
@@ -1,10 +1,13 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "librbd/Utils.h"
 #include "test/librbd/mock/MockImageCtx.h"
 #include "test/rbd_mirror/test_mock_fixture.h"
 #include "tools/rbd_mirror/LeaderWatcher.h"
 #include "tools/rbd_mirror/Threads.h"
+
+using librbd::util::create_async_context_callback;
 
 namespace librbd {
 
@@ -28,6 +31,11 @@ struct MockManagedLock {
   MockManagedLock() {
     s_instance = this;
   }
+
+  bool m_release_lock_on_shutdown = false;
+
+  MOCK_METHOD0(construct, void());
+  MOCK_METHOD0(destroy, void());
 
   MOCK_CONST_METHOD0(is_lock_owner, bool());
 
@@ -53,48 +61,165 @@ struct ManagedLock<MockTestImageCtx> {
               const std::string& oid, librbd::Watcher *watcher,
               managed_lock::Mode  mode, bool blacklist_on_break_lock,
               uint32_t blacklist_expire_seconds)
-    : m_lock("ManagedLock::m_lock") {
+    : m_work_queue(work_queue), m_lock("ManagedLock::m_lock") {
+    MockManagedLock::get_instance().construct();
   }
 
-  virtual ~ManagedLock() = default;
+  virtual ~ManagedLock() {
+    MockManagedLock::get_instance().destroy();
+  }
+
+  ContextWQ *m_work_queue;
 
   mutable Mutex m_lock;
 
   bool is_lock_owner() const {
     return MockManagedLock::get_instance().is_lock_owner();
   }
+
   void shut_down(Context *on_shutdown) {
+    if (MockManagedLock::get_instance().m_release_lock_on_shutdown) {
+      on_shutdown = new FunctionContext(
+        [this, on_shutdown](int r) {
+          MockManagedLock::get_instance().m_release_lock_on_shutdown = false;
+          shut_down(on_shutdown);
+        });
+      release_lock(on_shutdown);
+      return;
+    }
+
     MockManagedLock::get_instance().shut_down(on_shutdown);
   }
+
   void try_acquire_lock(Context *on_acquired) {
-    MockManagedLock::get_instance().try_acquire_lock(on_acquired);
+    Context *post_acquire_ctx = create_async_context_callback(
+      m_work_queue, new FunctionContext(
+        [this, on_acquired](int r) {
+          post_acquire_lock_handler(r, on_acquired);
+        }));
+    MockManagedLock::get_instance().try_acquire_lock(post_acquire_ctx);
   }
+
   void release_lock(Context *on_released) {
-    MockManagedLock::get_instance().release_lock(on_released);
+    Context *post_release_ctx = new FunctionContext(
+      [this, on_released](int r) {
+        post_release_lock_handler(false, r, on_released);
+      });
+
+    Context *release_ctx = new FunctionContext(
+      [this, on_released, post_release_ctx](int r) {
+        if (r < 0) {
+          on_released->complete(r);
+        } else {
+          MockManagedLock::get_instance().release_lock(post_release_ctx);
+        }
+      });
+
+    Context *pre_release_ctx = new FunctionContext(
+      [this, release_ctx](int r) {
+        bool shutting_down =
+          MockManagedLock::get_instance().m_release_lock_on_shutdown;
+        pre_release_lock_handler(shutting_down, release_ctx);
+      });
+
+    m_work_queue->queue(pre_release_ctx, 0);
   }
+
   void get_locker(managed_lock::Locker *locker, Context *on_finish) {
     MockManagedLock::get_instance().get_locker(locker, on_finish);
   }
+
   void break_lock(const managed_lock::Locker &locker, bool force_break_lock,
                   Context *on_finish) {
     MockManagedLock::get_instance().break_lock(locker, force_break_lock,
                                                on_finish);
   }
+
   void set_state_post_acquiring() {
     MockManagedLock::get_instance().set_state_post_acquiring();
   }
+
   bool is_shutdown() const {
     return MockManagedLock::get_instance().is_shutdown();
   }
+
   bool is_state_post_acquiring() const {
     return MockManagedLock::get_instance().is_state_post_acquiring();
   }
+
   bool is_state_locked() const {
     return MockManagedLock::get_instance().is_state_locked();
   }
+
+  virtual void post_acquire_lock_handler(int r, Context *on_finish) = 0;
+  virtual void pre_release_lock_handler(bool shutting_down,
+                                        Context *on_finish) = 0;
+  virtual void post_release_lock_handler(bool shutting_down, int r,
+                                         Context *on_finish) = 0;
 };
 
 } // namespace librbd
+
+namespace rbd {
+namespace mirror {
+
+template <>
+struct MirrorStatusWatcher<librbd::MockTestImageCtx> {
+  static MirrorStatusWatcher* s_instance;
+
+  static MirrorStatusWatcher *create(librados::IoCtx &io_ctx,
+                                     ContextWQ *work_queue) {
+    assert(s_instance != nullptr);
+    return s_instance;
+  }
+
+  MirrorStatusWatcher() {
+    assert(s_instance == nullptr);
+    s_instance = this;
+  }
+
+  ~MirrorStatusWatcher() {
+    assert(s_instance == this);
+    s_instance = nullptr;
+  }
+
+  MOCK_METHOD0(destroy, void());
+  MOCK_METHOD1(init, void(Context *));
+  MOCK_METHOD1(shut_down, void(Context *));
+};
+
+MirrorStatusWatcher<librbd::MockTestImageCtx> *MirrorStatusWatcher<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+template <>
+struct Instances<librbd::MockTestImageCtx> {
+  static Instances* s_instance;
+
+  static Instances *create(Threads *threads, librados::IoCtx &ioctx) {
+    assert(s_instance != nullptr);
+    return s_instance;
+  }
+
+  Instances() {
+    assert(s_instance == nullptr);
+    s_instance = this;
+  }
+
+  ~Instances() {
+    assert(s_instance == this);
+    s_instance = nullptr;
+  }
+
+  MOCK_METHOD0(destroy, void());
+  MOCK_METHOD1(init, void(Context *));
+  MOCK_METHOD1(shut_down, void(Context *));
+  MOCK_METHOD1(notify, void(const std::string &));
+};
+
+Instances<librbd::MockTestImageCtx> *Instances<librbd::MockTestImageCtx>::s_instance = nullptr;
+
+} // namespace mirror
+} // namespace rbd
+
 
 // template definitions
 #include "tools/rbd_mirror/LeaderWatcher.cc"
@@ -111,22 +236,47 @@ using ::testing::Return;
 
 using librbd::MockManagedLock;
 
+struct MockListener : public LeaderWatcher<librbd::MockTestImageCtx>::Listener {
+  static MockListener* s_instance;
+
+  MockListener() {
+    assert(s_instance == nullptr);
+    s_instance = this;
+  }
+
+  ~MockListener() override {
+    assert(s_instance == this);
+    s_instance = nullptr;
+  }
+
+  MOCK_METHOD1(post_acquire_handler, void(Context *));
+  MOCK_METHOD1(pre_release_handler, void(Context *));
+};
+
+MockListener *MockListener::s_instance = nullptr;
+
 class TestMockLeaderWatcher : public TestMockFixture {
 public:
+  typedef MirrorStatusWatcher<librbd::MockTestImageCtx> MockMirrorStatusWatcher;
+  typedef Instances<librbd::MockTestImageCtx> MockInstances;
   typedef LeaderWatcher<librbd::MockTestImageCtx> MockLeaderWatcher;
 
-  class MockListener : public MockLeaderWatcher::Listener {
-  public:
-    MOCK_METHOD1(post_acquire_handler, void(Context *));
-    MOCK_METHOD1(pre_release_handler, void(Context *));
-  };
+  void expect_construct(MockManagedLock &mock_managed_lock) {
+    EXPECT_CALL(mock_managed_lock, construct());
+  }
+
+  void expect_destroy(MockManagedLock &mock_managed_lock) {
+    EXPECT_CALL(mock_managed_lock, destroy());
+  }
 
   void expect_is_lock_owner(MockManagedLock &mock_managed_lock, bool owner) {
     EXPECT_CALL(mock_managed_lock, is_lock_owner())
       .WillOnce(Return(owner));
   }
 
-  void expect_shut_down(MockManagedLock &mock_managed_lock, int r) {
+  void expect_shut_down(MockManagedLock &mock_managed_lock,
+                        bool release_lock_on_shutdown, int r) {
+    mock_managed_lock.m_release_lock_on_shutdown = release_lock_on_shutdown;
     EXPECT_CALL(mock_managed_lock, shut_down(_))
       .WillOnce(CompleteContext(r));
   }
@@ -134,11 +284,20 @@ public:
   void expect_try_acquire_lock(MockManagedLock &mock_managed_lock, int r) {
     EXPECT_CALL(mock_managed_lock, try_acquire_lock(_))
       .WillOnce(CompleteContext(r));
+    if (r == 0) {
+      expect_set_state_post_acquiring(mock_managed_lock);
+    }
   }
 
-  void expect_release_lock(MockManagedLock &mock_managed_lock, int r) {
+  void expect_release_lock(MockManagedLock &mock_managed_lock, int r,
+                           Context *on_finish = nullptr) {
     EXPECT_CALL(mock_managed_lock, release_lock(_))
-      .WillOnce(CompleteContext(r));
+      .WillOnce(Invoke([on_finish, r](Context *ctx) {
+                         ctx->complete(r);
+                         if (on_finish != nullptr) {
+                           on_finish->complete(0);
+                         }
+                       }));
   }
 
   void expect_get_locker(MockManagedLock &mock_managed_lock,
@@ -158,8 +317,8 @@ public:
   }
 
   void expect_break_lock(MockManagedLock &mock_managed_lock,
-			 const librbd::managed_lock::Locker &locker, int r,
-			 Context *on_finish) {
+                         const librbd::managed_lock::Locker &locker, int r,
+                         Context *on_finish) {
     EXPECT_CALL(mock_managed_lock, break_lock(locker, true, _))
       .WillOnce(Invoke([on_finish, r](const librbd::managed_lock::Locker &,
                                       bool, Context *ctx) {
@@ -196,74 +355,164 @@ public:
 
   void expect_notify_heartbeat(MockManagedLock &mock_managed_lock,
                                Context *on_finish) {
+    // is_leader in notify_heartbeat
     EXPECT_CALL(mock_managed_lock, is_state_post_acquiring())
       .WillOnce(Return(false));
     EXPECT_CALL(mock_managed_lock, is_state_locked())
       .WillOnce(Return(true));
+
+    // is_leader in handle_notify_heartbeat
     EXPECT_CALL(mock_managed_lock, is_state_post_acquiring())
       .WillOnce(Return(false));
     EXPECT_CALL(mock_managed_lock, is_state_locked())
       .WillOnce(DoAll(Invoke([on_finish]() {
                         on_finish->complete(0);
                       }),
-	              Return(true)));
+                      Return(true)));
+  }
+
+  void expect_destroy(MockMirrorStatusWatcher &mock_mirror_status_watcher) {
+    EXPECT_CALL(mock_mirror_status_watcher, destroy());
+  }
+
+  void expect_init(MockMirrorStatusWatcher &mock_mirror_status_watcher, int r) {
+    EXPECT_CALL(mock_mirror_status_watcher, init(_))
+      .WillOnce(CompleteContext(m_threads->work_queue, r));
+  }
+
+  void expect_shut_down(MockMirrorStatusWatcher &mock_mirror_status_watcher, int r) {
+    EXPECT_CALL(mock_mirror_status_watcher, shut_down(_))
+      .WillOnce(CompleteContext(m_threads->work_queue, r));
+    expect_destroy(mock_mirror_status_watcher);
+  }
+
+  void expect_destroy(MockInstances &mock_instances) {
+    EXPECT_CALL(mock_instances, destroy());
+  }
+
+  void expect_init(MockInstances &mock_instances, int r) {
+    EXPECT_CALL(mock_instances, init(_))
+      .WillOnce(CompleteContext(m_threads->work_queue, r));
+  }
+
+  void expect_shut_down(MockInstances &mock_instances, int r) {
+    EXPECT_CALL(mock_instances, shut_down(_))
+      .WillOnce(CompleteContext(m_threads->work_queue, r));
+    expect_destroy(mock_instances);
+  }
+
+  void expect_acquire_notify(MockManagedLock &mock_managed_lock,
+                             MockListener &mock_listener, int r) {
+    expect_is_leader(mock_managed_lock, true, false);
+    EXPECT_CALL(mock_listener, post_acquire_handler(_))
+      .WillOnce(CompleteContext(r));
+    expect_is_leader(mock_managed_lock, true, false);
+  }
+
+  void expect_release_notify(MockManagedLock &mock_managed_lock,
+                             MockListener &mock_listener, int r) {
+    expect_is_leader(mock_managed_lock, false, false);
+    EXPECT_CALL(mock_listener, pre_release_handler(_))
+      .WillOnce(CompleteContext(r));
+    expect_is_leader(mock_managed_lock, false, false);
   }
 };
 
 TEST_F(TestMockLeaderWatcher, InitShutdown) {
   MockManagedLock mock_managed_lock;
+  MockMirrorStatusWatcher mock_mirror_status_watcher;
+  MockInstances mock_instances;
   MockListener listener;
-  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
 
   expect_is_shutdown(mock_managed_lock);
+  expect_destroy(mock_managed_lock);
 
   InSequence seq;
+
+  expect_construct(mock_managed_lock);
+  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
+
+  // Inint
   C_SaferCond on_heartbeat_finish;
   expect_try_acquire_lock(mock_managed_lock, 0);
+  expect_init(mock_mirror_status_watcher, 0);
+  expect_init(mock_instances, 0);
+  expect_acquire_notify(mock_managed_lock, listener, 0);
   expect_notify_heartbeat(mock_managed_lock, &on_heartbeat_finish);
 
   ASSERT_EQ(0, leader_watcher.init());
   ASSERT_EQ(0, on_heartbeat_finish.wait());
 
-  expect_shut_down(mock_managed_lock, 0);
+  // Shutdown
+  expect_release_notify(mock_managed_lock, listener, 0);
+  expect_shut_down(mock_instances, 0);
+  expect_shut_down(mock_mirror_status_watcher, 0);
+  expect_is_leader(mock_managed_lock, false, false);
+  expect_release_lock(mock_managed_lock, 0);
+  expect_shut_down(mock_managed_lock, true, 0);
 
   leader_watcher.shut_down();
 }
 
 TEST_F(TestMockLeaderWatcher, InitReleaseShutdown) {
   MockManagedLock mock_managed_lock;
+  MockMirrorStatusWatcher mock_mirror_status_watcher;
+  MockInstances mock_instances;
   MockListener listener;
-  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
 
   expect_is_shutdown(mock_managed_lock);
+  expect_destroy(mock_managed_lock);
 
   InSequence seq;
+
+  expect_construct(mock_managed_lock);
+  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
+
+  // Inint
   C_SaferCond on_heartbeat_finish;
   expect_try_acquire_lock(mock_managed_lock, 0);
+  expect_init(mock_mirror_status_watcher, 0);
+  expect_init(mock_instances, 0);
+  expect_acquire_notify(mock_managed_lock, listener, 0);
   expect_notify_heartbeat(mock_managed_lock, &on_heartbeat_finish);
 
   ASSERT_EQ(0, leader_watcher.init());
   ASSERT_EQ(0, on_heartbeat_finish.wait());
 
+  // Release
   expect_is_leader(mock_managed_lock, false, true);
-  expect_release_lock(mock_managed_lock, 0);
+  expect_release_notify(mock_managed_lock, listener, 0);
+  expect_shut_down(mock_instances, 0);
+  expect_shut_down(mock_mirror_status_watcher, 0);
+  expect_is_leader(mock_managed_lock, false, false);
+  C_SaferCond on_release;
+  expect_release_lock(mock_managed_lock, 0, &on_release);
 
   leader_watcher.release_leader();
+  ASSERT_EQ(0, on_release.wait());
 
-  expect_shut_down(mock_managed_lock, 0);
+  // Shutdown
+  expect_shut_down(mock_managed_lock, false, 0);
 
   leader_watcher.shut_down();
 }
 
 TEST_F(TestMockLeaderWatcher, AcquireError) {
   MockManagedLock mock_managed_lock;
+  MockMirrorStatusWatcher mock_mirror_status_watcher;
+  MockInstances mock_instances;
   MockListener listener;
-  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
 
   expect_is_shutdown(mock_managed_lock);
   expect_is_leader(mock_managed_lock);
+  expect_destroy(mock_managed_lock);
 
   InSequence seq;
+
+  expect_construct(mock_managed_lock);
+  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
+
+  // Inint
   C_SaferCond on_get_locker_finish;
   expect_try_acquire_lock(mock_managed_lock, -EAGAIN);
   expect_get_locker(mock_managed_lock, librbd::managed_lock::Locker(), 0,
@@ -271,32 +520,51 @@ TEST_F(TestMockLeaderWatcher, AcquireError) {
   ASSERT_EQ(0, leader_watcher.init());
   ASSERT_EQ(0, on_get_locker_finish.wait());
 
-  expect_shut_down(mock_managed_lock, 0);
+  // Shutdown
+  expect_shut_down(mock_managed_lock, false, 0);
 
   leader_watcher.shut_down();
 }
 
 TEST_F(TestMockLeaderWatcher, ReleaseError) {
   MockManagedLock mock_managed_lock;
+  MockMirrorStatusWatcher mock_mirror_status_watcher;
+  MockInstances mock_instances;
   MockListener listener;
-  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
 
   expect_is_shutdown(mock_managed_lock);
+  expect_destroy(mock_managed_lock);
 
   InSequence seq;
+
+  expect_construct(mock_managed_lock);
+  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
+
+  // Inint
   C_SaferCond on_heartbeat_finish;
   expect_try_acquire_lock(mock_managed_lock, 0);
+  expect_init(mock_mirror_status_watcher, 0);
+  expect_init(mock_instances, 0);
+  expect_acquire_notify(mock_managed_lock, listener, 0);
   expect_notify_heartbeat(mock_managed_lock, &on_heartbeat_finish);
 
   ASSERT_EQ(0, leader_watcher.init());
   ASSERT_EQ(0, on_heartbeat_finish.wait());
 
+  // Release
   expect_is_leader(mock_managed_lock, false, true);
-  expect_release_lock(mock_managed_lock, -EINVAL);
+  expect_release_notify(mock_managed_lock, listener, -EINVAL);
+  expect_shut_down(mock_instances, 0);
+  expect_shut_down(mock_mirror_status_watcher, -EINVAL);
+  expect_is_leader(mock_managed_lock, false, false);
+  C_SaferCond on_release;
+  expect_release_lock(mock_managed_lock, -EINVAL, &on_release);
 
   leader_watcher.release_leader();
+  ASSERT_EQ(0, on_release.wait());
 
-  expect_shut_down(mock_managed_lock, 0);
+  // Shutdown
+  expect_shut_down(mock_managed_lock, false, 0);
 
   leader_watcher.shut_down();
 }
@@ -304,21 +572,28 @@ TEST_F(TestMockLeaderWatcher, ReleaseError) {
 TEST_F(TestMockLeaderWatcher, Break) {
   EXPECT_EQ(0, _rados->conf_set("rbd_mirror_leader_heartbeat_interval", "1"));
   EXPECT_EQ(0, _rados->conf_set("rbd_mirror_leader_max_missed_heartbeats",
-				"1"));
+                                "1"));
   CephContext *cct = reinterpret_cast<CephContext *>(m_local_io_ctx.cct());
   int max_acquire_attempts =
     cct->_conf->rbd_mirror_leader_max_acquire_attempts_before_break;
 
   MockManagedLock mock_managed_lock;
+  MockMirrorStatusWatcher mock_mirror_status_watcher;
+  MockInstances mock_instances;
   MockListener listener;
-  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
   librbd::managed_lock::Locker
     locker{entity_name_t::CLIENT(1), "auto 123", "1.2.3.4:0/0", 123};
 
   expect_is_shutdown(mock_managed_lock);
   expect_is_leader(mock_managed_lock);
+  expect_destroy(mock_managed_lock);
 
   InSequence seq;
+
+  expect_construct(mock_managed_lock);
+  MockLeaderWatcher leader_watcher(m_threads, m_local_io_ctx, &listener);
+
+  // Init
   for (int i = 0; i <= max_acquire_attempts; i++) {
     expect_try_acquire_lock(mock_managed_lock, -EAGAIN);
     if (i < max_acquire_attempts) {
@@ -329,12 +604,21 @@ TEST_F(TestMockLeaderWatcher, Break) {
   expect_break_lock(mock_managed_lock, locker, 0, &on_break);
   C_SaferCond on_heartbeat_finish;
   expect_try_acquire_lock(mock_managed_lock, 0);
+  expect_init(mock_mirror_status_watcher, 0);
+  expect_init(mock_instances, 0);
+  expect_acquire_notify(mock_managed_lock, listener, 0);
   expect_notify_heartbeat(mock_managed_lock, &on_heartbeat_finish);
 
   ASSERT_EQ(0, leader_watcher.init());
   ASSERT_EQ(0, on_heartbeat_finish.wait());
 
-  expect_shut_down(mock_managed_lock, 0);
+  // Shutdown
+  expect_release_notify(mock_managed_lock, listener, 0);
+  expect_shut_down(mock_instances, 0);
+  expect_shut_down(mock_mirror_status_watcher, 0);
+  expect_is_leader(mock_managed_lock, false, false);
+  expect_release_lock(mock_managed_lock, 0);
+  expect_shut_down(mock_managed_lock, true, 0);
 
   leader_watcher.shut_down();
 }

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -6,6 +6,7 @@
 
 #include "test/rbd_mirror/test_fixture.h"
 #include "test/librados_test_stub/LibradosTestStub.h"
+#include "common/WorkQueue.h"
 #include <boost/shared_ptr.hpp>
 #include <gmock/gmock.h>
 
@@ -21,6 +22,11 @@ class MockImageCtx;
 
 ACTION_P(CompleteContext, r) {
   arg0->complete(r);
+}
+
+ACTION_P2(CompleteContext, wq, r) {
+  ContextWQ *context_wq = reinterpret_cast<ContextWQ *>(wq);
+  context_wq->queue(arg0, r);
 }
 
 MATCHER_P(ContentsEqual, bl, "") {

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -8,6 +8,7 @@ set(rbd_mirror_internal
   ImageSync.cc
   ImageSyncThrottler.cc
   InstanceWatcher.cc
+  Instances.cc
   LeaderWatcher.cc
   Mirror.cc
   MirrorStatusWatcher.cc

--- a/src/tools/rbd_mirror/InstanceWatcher.cc
+++ b/src/tools/rbd_mirror/InstanceWatcher.cc
@@ -118,7 +118,7 @@ int InstanceWatcher<I>::init() {
 
 template <typename I>
 void InstanceWatcher<I>::init(Context *on_finish) {
-  dout(20) << dendl;
+  dout(20) << "instance_id=" << m_instance_id << dendl;
 
   Mutex::Locker locker(m_lock);
 

--- a/src/tools/rbd_mirror/Instances.cc
+++ b/src/tools/rbd_mirror/Instances.cc
@@ -1,0 +1,252 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "include/stringify.h"
+#include "common/Timer.h"
+#include "common/WorkQueue.h"
+#include "common/debug.h"
+#include "common/errno.h"
+#include "librbd/Utils.h"
+#include "InstanceWatcher.h"
+#include "Instances.h"
+#include "Threads.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::Instances: " \
+                           << this << " " << __func__ << ": "
+
+namespace rbd {
+namespace mirror {
+
+using librbd::util::create_async_context_callback;
+using librbd::util::create_context_callback;
+using librbd::util::create_rados_ack_callback;
+
+template <typename I>
+Instances<I>::Instances(Threads *threads, librados::IoCtx &ioctx) :
+  m_threads(threads), m_ioctx(ioctx),
+  m_cct(reinterpret_cast<CephContext *>(ioctx.cct())),
+  m_lock("rbd::mirror::Instances " + ioctx.get_pool_name()) {
+}
+
+template <typename I>
+Instances<I>::~Instances() {
+}
+
+template <typename I>
+void Instances<I>::init(Context *on_finish) {
+  dout(20) << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_on_finish == nullptr);
+  m_on_finish = on_finish;
+  get_instances();
+}
+
+template <typename I>
+void Instances<I>::shut_down(Context *on_finish) {
+  dout(20) << dendl;
+
+  Mutex::Locker locker(m_lock);
+  assert(m_on_finish == nullptr);
+  m_on_finish = on_finish;
+
+  Context *ctx = new FunctionContext(
+    [this](int r) {
+      Mutex::Locker timer_locker(m_threads->timer_lock);
+      Mutex::Locker locker(m_lock);
+
+      for (auto it : m_instances) {
+        cancel_remove_task(it.second);
+      }
+      wait_for_ops();
+    });
+
+  m_threads->work_queue->queue(ctx, 0);
+}
+
+template <typename I>
+void Instances<I>::notify(const std::string &instance_id) {
+  dout(20) << instance_id << dendl;
+
+  Mutex::Locker locker(m_lock);
+
+  if (m_on_finish != nullptr) {
+    dout(20) << "received on shut down, ignoring" << dendl;
+    return;
+  }
+
+  Context *ctx = new C_Notify(this, instance_id);
+
+  m_threads->work_queue->queue(ctx, 0);
+}
+
+template <typename I>
+void Instances<I>::handle_notify(const std::string &instance_id) {
+  dout(20) << instance_id << dendl;
+
+  Mutex::Locker timer_locker(m_threads->timer_lock);
+  Mutex::Locker locker(m_lock);
+
+  if (m_on_finish != nullptr) {
+    dout(20) << "handled on shut down, ignoring" << dendl;
+    return;
+  }
+
+  auto &instance = m_instances.insert(
+    std::make_pair(instance_id, Instance(instance_id))).first->second;
+
+  schedule_remove_task(instance);
+}
+
+template <typename I>
+void Instances<I>::list(std::vector<std::string> *instance_ids) {
+  dout(20) << dendl;
+
+  Mutex::Locker locker(m_lock);
+
+  for (auto it : m_instances) {
+    instance_ids->push_back(it.first);
+  }
+}
+
+
+template <typename I>
+void Instances<I>::get_instances() {
+  dout(20) << dendl;
+
+  assert(m_lock.is_locked());
+
+  Context *ctx = create_context_callback<
+    Instances, &Instances<I>::handle_get_instances>(this);
+
+  InstanceWatcher<I>::get_instances(m_ioctx, &m_instance_ids, ctx);
+}
+
+template <typename I>
+void Instances<I>::handle_get_instances(int r) {
+  dout(20) << "r=" << r << dendl;
+
+  Context *on_finish = nullptr;
+  {
+    Mutex::Locker timer_locker(m_threads->timer_lock);
+    Mutex::Locker locker(m_lock);
+
+    if (r < 0) {
+      derr << "error retrieving instances: " << cpp_strerror(r) << dendl;
+    } else {
+      auto my_instance_id = stringify(m_ioctx.get_instance_id());
+      for (auto &instance_id : m_instance_ids) {
+        if (instance_id == my_instance_id) {
+          continue;
+        }
+        auto &instance = m_instances.insert(
+          std::make_pair(instance_id, Instance(instance_id))).first->second;
+        schedule_remove_task(instance);
+      }
+    }
+    std::swap(on_finish, m_on_finish);
+  }
+  on_finish->complete(r);
+}
+
+template <typename I>
+void Instances<I>::wait_for_ops() {
+  dout(20) << dendl;
+
+  assert(m_lock.is_locked());
+
+  Context *ctx = create_async_context_callback(
+    m_threads->work_queue, create_context_callback<
+    Instances, &Instances<I>::handle_wait_for_ops>(this));
+
+  m_async_op_tracker.wait_for_ops(ctx);
+}
+
+template <typename I>
+void Instances<I>::handle_wait_for_ops(int r) {
+  dout(20) << "r=" << r << dendl;
+
+  assert(r == 0);
+
+  Context *on_finish = nullptr;
+  {
+    Mutex::Locker locker(m_lock);
+    std::swap(on_finish, m_on_finish);
+  }
+  on_finish->complete(r);
+}
+
+template <typename I>
+void Instances<I>::remove_instance(Instance &instance) {
+  assert(m_lock.is_locked());
+
+  dout(20) << instance.id << dendl;
+
+  Context *ctx = create_async_context_callback(
+    m_threads->work_queue, create_context_callback<
+    Instances, &Instances<I>::handle_remove_instance>(this));
+
+  m_async_op_tracker.start_op();
+  InstanceWatcher<I>::remove_instance(m_ioctx, m_threads->work_queue,
+                                      instance.id, ctx);
+  m_instances.erase(instance.id);
+}
+
+template <typename I>
+void Instances<I>::handle_remove_instance(int r) {
+  Mutex::Locker locker(m_lock);
+
+  dout(20) << " r=" << r << dendl;
+
+  assert(r == 0);
+
+  m_async_op_tracker.finish_op();
+}
+
+template <typename I>
+void Instances<I>::cancel_remove_task(Instance &instance) {
+  assert(m_threads->timer_lock.is_locked());
+  assert(m_lock.is_locked());
+
+  if (instance.timer_task == nullptr) {
+    return;
+  }
+
+  dout(20) << instance.timer_task << dendl;
+
+  bool canceled = m_threads->timer->cancel_event(instance.timer_task);
+  assert(canceled);
+  instance.timer_task = nullptr;
+}
+
+template <typename I>
+void Instances<I>::schedule_remove_task(Instance &instance) {
+  dout(20) << dendl;
+
+  cancel_remove_task(instance);
+
+  int after = max(1, m_cct->_conf->rbd_mirror_leader_heartbeat_interval) *
+    (1 + m_cct->_conf->rbd_mirror_leader_max_missed_heartbeats +
+     m_cct->_conf->rbd_mirror_leader_max_acquire_attempts_before_break);
+
+  instance.timer_task = new FunctionContext(
+    [this, &instance](int r) {
+      assert(m_threads->timer_lock.is_locked());
+      Mutex::Locker locker(m_lock);
+      instance.timer_task = nullptr;
+      remove_instance(instance);
+    });
+
+  dout(20) << "scheduling instance " << instance.id << " remove after " << after
+           << " sec (task " << instance.timer_task << ")" << dendl;
+
+  m_threads->timer->add_event_after(after, instance.timer_task);
+}
+
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::Instances<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/Instances.h
+++ b/src/tools/rbd_mirror/Instances.h
@@ -1,0 +1,112 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_INSTANCES_H
+#define CEPH_RBD_MIRROR_INSTANCES_H
+
+#include <map>
+#include <vector>
+
+#include "include/buffer.h"
+#include "common/AsyncOpTracker.h"
+#include "common/Mutex.h"
+#include "librbd/Watcher.h"
+
+namespace librados { class IoCtx; }
+namespace librbd { class ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+
+struct Threads;
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class Instances {
+public:
+  static Instances *create(Threads *threads, librados::IoCtx &ioctx) {
+    return new Instances(threads, ioctx);
+  }
+  void destroy() {
+    delete this;
+  }
+
+  Instances(Threads *threads, librados::IoCtx &ioctx);
+  virtual ~Instances();
+
+  void init(Context *on_finish);
+  void shut_down(Context *on_finish);
+
+  void notify(const std::string &instance_id);
+  void list(std::vector<std::string> *instance_ids);
+
+private:
+  /**
+   * @verbatim
+   *
+   * <uninitialized> <---------------------\
+   *    | (init)           ^               |
+   *    v          (error) *               |
+   * GET_INSTANCES * * * * *            WAIT_FOR_OPS
+   *    |                                  ^
+   *    v          (shut_down)             |
+   * <initialized> ------------------------/
+   *      .
+   *      . (remove_instance)
+   *      v
+   *   REMOVE_INSTANCE
+   *
+   * @endverbatim
+   */
+
+  struct Instance {
+    std::string id;
+    Context *timer_task = nullptr;
+
+    Instance(const std::string &instance_id) : id(instance_id) {
+    }
+  };
+
+  struct C_Notify : Context {
+    Instances *instances;
+    std::string instance_id;
+
+    C_Notify(Instances *instances, const std::string &instance_id)
+      : instances(instances), instance_id(instance_id) {
+      instances->m_async_op_tracker.start_op();
+    }
+
+    void finish(int r) override {
+      instances->handle_notify(instance_id);
+      instances->m_async_op_tracker.finish_op();
+    }
+  };
+
+  Threads *m_threads;
+  librados::IoCtx &m_ioctx;
+  CephContext *m_cct;
+
+  Mutex m_lock;
+  std::vector<std::string> m_instance_ids;
+  std::map<std::string, Instance> m_instances;
+  Context *m_on_finish = nullptr;
+  AsyncOpTracker m_async_op_tracker;
+
+  void handle_notify(const std::string &instance_id);
+
+  void get_instances();
+  void handle_get_instances(int r);
+
+  void wait_for_ops();
+  void handle_wait_for_ops(int r);
+
+  void remove_instance(Instance &instance);
+  void handle_remove_instance(int r);
+
+  void cancel_remove_task(Instance &instance);
+  void schedule_remove_task(Instance &instance);
+};
+
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_INSTANCES_H

--- a/src/tools/rbd_mirror/MirrorStatusWatcher.cc
+++ b/src/tools/rbd_mirror/MirrorStatusWatcher.cc
@@ -18,12 +18,18 @@ namespace mirror {
 
 using librbd::util::create_rados_ack_callback;
 
-MirrorStatusWatcher::MirrorStatusWatcher(librados::IoCtx &io_ctx,
-                                         ContextWQ *work_queue)
+template <typename I>
+MirrorStatusWatcher<I>::MirrorStatusWatcher(librados::IoCtx &io_ctx,
+                                            ContextWQ *work_queue)
   : Watcher(io_ctx, work_queue, RBD_MIRRORING) {
 }
 
-void MirrorStatusWatcher::init(Context *on_finish) {
+template <typename I>
+MirrorStatusWatcher<I>::~MirrorStatusWatcher() {
+}
+
+template <typename I>
+void MirrorStatusWatcher<I>::init(Context *on_finish) {
   dout(20) << dendl;
 
   on_finish = new FunctionContext(
@@ -45,14 +51,17 @@ void MirrorStatusWatcher::init(Context *on_finish) {
   aio_comp->release();
 }
 
-void MirrorStatusWatcher::shut_down(Context *on_finish) {
+template <typename I>
+void MirrorStatusWatcher<I>::shut_down(Context *on_finish) {
   dout(20) << dendl;
 
   unregister_watch(on_finish);
 }
 
-void MirrorStatusWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
-                                        uint64_t notifier_id, bufferlist &bl) {
+template <typename I>
+void MirrorStatusWatcher<I>::handle_notify(uint64_t notify_id, uint64_t handle,
+                                           uint64_t notifier_id,
+                                           bufferlist &bl) {
   dout(20) << dendl;
 
   bufferlist out;
@@ -61,3 +70,5 @@ void MirrorStatusWatcher::handle_notify(uint64_t notify_id, uint64_t handle,
 
 } // namespace mirror
 } // namespace rbd
+
+template class rbd::mirror::MirrorStatusWatcher<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/MirrorStatusWatcher.h
+++ b/src/tools/rbd_mirror/MirrorStatusWatcher.h
@@ -6,12 +6,24 @@
 
 #include "librbd/Watcher.h"
 
+namespace librbd { class ImageCtx; }
+
 namespace rbd {
 namespace mirror {
 
+template <typename ImageCtxT = librbd::ImageCtx>
 class MirrorStatusWatcher : protected librbd::Watcher {
 public:
+  static MirrorStatusWatcher *create(librados::IoCtx &io_ctx,
+                                     ContextWQ *work_queue) {
+    return new MirrorStatusWatcher(io_ctx, work_queue);
+  }
+  void destroy() {
+    delete this;
+  }
+
   MirrorStatusWatcher(librados::IoCtx &io_ctx, ContextWQ *work_queue);
+  ~MirrorStatusWatcher() override;
 
   void init(Context *on_finish);
   void shut_down(Context *on_finish);

--- a/src/tools/rbd_mirror/Replayer.cc
+++ b/src/tools/rbd_mirror/Replayer.cc
@@ -480,26 +480,37 @@ void Replayer::print_status(Formatter *f, stringstream *ss)
 {
   dout(20) << "enter" << dendl;
 
+  if (!f) {
+    return;
+  }
+
   Mutex::Locker l(m_lock);
 
-  if (f) {
-    f->open_object_section("replayer_status");
-    f->dump_string("pool", m_local_io_ctx.get_pool_name());
-    f->dump_stream("peer") << m_peer;
-    f->dump_bool("leader", m_leader_watcher->is_leader());
-    f->open_array_section("image_replayers");
-  };
+  f->open_object_section("replayer_status");
+  f->dump_string("pool", m_local_io_ctx.get_pool_name());
+  f->dump_stream("peer") << m_peer;
+
+  bool leader = m_leader_watcher->is_leader();
+  f->dump_bool("leader", leader);
+  if (leader) {
+    std::vector<std::string> instance_ids;
+    m_leader_watcher->list_instances(&instance_ids);
+    f->open_array_section("instances");
+    for (auto instance_id : instance_ids) {
+      f->dump_string("instance_id", instance_id);
+    }
+    f->close_section();
+  }
+  f->open_array_section("image_replayers");
 
   for (auto &kv : m_image_replayers) {
     auto &image_replayer = kv.second;
     image_replayer->print_status(f, ss);
   }
 
-  if (f) {
-    f->close_section();
-    f->close_section();
-    f->flush(*ss);
-  }
+  f->close_section();
+  f->close_section();
+  f->flush(*ss);
 }
 
 void Replayer::start()


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18784
Signed-off-by: Mykola Golub <mgolub@mirantis.com>