### PR TITLE
ceph-disk: dmcrypt activate must use the same cluster as prepare

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1182,10 +1182,8 @@ def get_dmcrypt_key_path(
 def get_dmcrypt_key(
     _uuid,
     key_dir,
-    luks,
-    cluster
+    luks
 ):
-
     legacy_path = get_dmcrypt_key_path(_uuid, key_dir, luks)
     if os.path.exists(legacy_path):
         return (legacy_path,)
@@ -1197,8 +1195,6 @@ def get_dmcrypt_key(
             key, stderr, ret = command(
                 [
                     'ceph',
-                    '--cluster',
-                    cluster,
                     '--name',
                     'client.osd-lockbox.' + osd_uuid,
                     '--keyring',
@@ -1764,7 +1760,7 @@ class DevicePartitionCryptPlain(DevicePartitionCrypt):
 
         self.osd_dm_key = get_dmcrypt_key(
             self.get_uuid(), self.args.dmcrypt_key_dir,
-            False, self.args.cluster)
+            False)
 
     def set_variables_ptype(self):
         self.ptype_map = PTYPE['plain']
@@ -1790,7 +1786,7 @@ class DevicePartitionCryptLuks(DevicePartitionCrypt):
 
         self.osd_dm_key = get_dmcrypt_key(
             self.get_uuid(), self.args.dmcrypt_key_dir,
-            True, self.args.cluster)
+            True)
 
     def set_variables_ptype(self):
         self.ptype_map = PTYPE['luks']
@@ -2499,8 +2495,6 @@ class Lockbox(object):
                 'ceph',
                 '--name', 'client.bootstrap-osd',
                 '--keyring', bootstrap,
-                '--cluster',
-                cluster,
                 'config-key',
                 'put',
                 'dm-crypt/osd/' + self.args.osd_uuid + '/luks',
@@ -2512,8 +2506,6 @@ class Lockbox(object):
                 'ceph',
                 '--name', 'client.bootstrap-osd',
                 '--keyring', bootstrap,
-                '--cluster',
-                cluster,
                 'auth',
                 'get-or-create',
                 'client.osd-lockbox.' + self.args.osd_uuid,
@@ -3258,7 +3250,7 @@ def dmcrypt_is_mapped(uuid):
         return None
 
 
-def dmcrypt_map(dev, dmcrypt_key_dir, cluster):
+def dmcrypt_map(dev, dmcrypt_key_dir):
     ptype = get_partition_type(dev)
     if ptype in Ptype.get_ready_by_type('plain'):
         luks = False
@@ -3270,7 +3262,7 @@ def dmcrypt_map(dev, dmcrypt_key_dir, cluster):
         raise Error('--dmcrypt called for dev %s with invalid ptype %s'
                     % (dev, ptype))
     part_uuid = get_partition_uuid(dev)
-    dmcrypt_key = get_dmcrypt_key(part_uuid, dmcrypt_key_dir, luks, cluster)
+    dmcrypt_key = get_dmcrypt_key(part_uuid, dmcrypt_key_dir, luks)
     return _dmcrypt_map(
         rawdev=dev,
         key=dmcrypt_key,
@@ -3287,13 +3279,12 @@ def mount_activate(
     init,
     dmcrypt,
     dmcrypt_key_dir,
-    cluster,
     reactivate=False,
 ):
 
     if dmcrypt:
         part_uuid = get_partition_uuid(dev)
-        dev = dmcrypt_map(dev, dmcrypt_key_dir, cluster)
+        dev = dmcrypt_map(dev, dmcrypt_key_dir)
     try:
         fstype = detect_fstype(dev=dev)
     except (subprocess.CalledProcessError,
@@ -3591,7 +3582,6 @@ def main_activate(args):
                 init=args.mark_init,
                 dmcrypt=args.dmcrypt,
                 dmcrypt_key_dir=args.dmcrypt_key_dir,
-                cluster=args.cluster,
                 reactivate=args.reactivate,
             )
             osd_data = get_mount_point(cluster, osd_id)
@@ -3829,7 +3819,7 @@ def _deallocate_osd_id(cluster, osd_id):
     ])
 
 
-def _remove_lockbox(uuid, cluster):
+def _remove_lockbox(uuid):
     command([
         'ceph',
         'auth',
@@ -3838,8 +3828,6 @@ def _remove_lockbox(uuid, cluster):
     ])
     command([
         'ceph',
-        '--cluster',
-        cluster,
         'config-key',
         'del',
         'dm-crypt/osd/' + uuid + '/luks',
@@ -3872,8 +3860,7 @@ def destroy_lookup_device(args, predicate, description):
                     unmap = False
                 else:
                     dmcrypt_path = dmcrypt_map(partition['path'],
-                                               args.dmcrypt_key_dir,
-                                               args.cluster)
+                                               args.dmcrypt_key_dir)
                     unmap = True
                 list_dev_osd(dmcrypt_path, {}, partition)
                 if unmap:
@@ -3938,7 +3925,7 @@ def main_destroy_locked(args):
         for name in Space.NAMES:
             if target_dev.get(name + '_uuid'):
                 dmcrypt_unmap(target_dev[name + '_uuid'])
-        _remove_lockbox(target_dev['uuid'], args.cluster)
+        _remove_lockbox(target_dev['uuid'])
 
     # Check zap flag. If we found zap flag, we need to find device for
     # destroy this osd data.
@@ -3992,7 +3979,7 @@ def main_activate_space(name, args):
     dev = None
     with activate_lock:
         if args.dmcrypt:
-            dev = dmcrypt_map(args.dev, args.dmcrypt_key_dir, args.cluster)
+            dev = dmcrypt_map(args.dev, args.dmcrypt_key_dir)
         else:
             dev = args.dev
         # FIXME: For an encrypted journal dev, does this return the
@@ -4018,7 +4005,6 @@ def main_activate_space(name, args):
             init=args.mark_init,
             dmcrypt=args.dmcrypt,
             dmcrypt_key_dir=args.dmcrypt_key_dir,
-            cluster=args.cluster,
             reactivate=args.reactivate,
         )
 
@@ -4062,7 +4048,6 @@ def main_activate_all(args):
                         activate_key_template=args.activate_key_template,
                         init=args.mark_init,
                         dmcrypt=False,
-                        cluster=args.cluster,
                         dmcrypt_key_dir='',
                     )
                     start_daemon(

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2483,7 +2483,7 @@ class Lockbox(object):
                       self.args.lockbox)
             self.partition = self.create_partition()
 
-    def create_key(self):
+    def create_key(self, cluster):
         key_size = CryptHelpers.get_dmcrypt_keysize(self.args)
         key = open('/dev/urandom', 'rb').read(key_size / 8)
         base64_key = base64.b64encode(key)
@@ -2541,7 +2541,7 @@ class Lockbox(object):
         LOG.debug('Mounting lockbox ' + str(" ".join(args)))
         command_check_call(args)
         write_one_line(path, 'osd-uuid', self.args.osd_uuid)
-        self.create_key()
+        self.create_key(self.args.cluster)
         self.symlink_spaces(path)
         write_one_line(path, 'magic', CEPH_LOCKBOX_ONDISK_MAGIC)
         if self.device is not None:

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1191,10 +1191,19 @@ def get_dmcrypt_key(
     if os.path.exists(path):
         mode = get_oneliner(path, 'key-management-mode')
         osd_uuid = get_oneliner(path, 'osd-uuid')
+        ceph_fsid = read_one_line(path, 'ceph_fsid')
+        if ceph_fsid is None:
+            raise Error('No cluster uuid assigned.')
+        cluster = find_cluster_by_uuid(ceph_fsid)
+        if cluster is None:
+            raise Error('No cluster conf found in ' + SYSCONFDIR +
+                        ' with fsid %s' % ceph_fsid)
+
         if mode == KEY_MANAGEMENT_MODE_V1:
             key, stderr, ret = command(
                 [
                     'ceph',
+                    '--cluster', cluster,
                     '--name',
                     'client.osd-lockbox.' + osd_uuid,
                     '--keyring',
@@ -2493,6 +2502,7 @@ class Lockbox(object):
         command_check_call(
             [
                 'ceph',
+                '--cluster', cluster,
                 '--name', 'client.bootstrap-osd',
                 '--keyring', bootstrap,
                 'config-key',
@@ -2504,6 +2514,7 @@ class Lockbox(object):
         keyring, stderr, ret = command(
             [
                 'ceph',
+                '--cluster', cluster,
                 '--name', 'client.bootstrap-osd',
                 '--keyring', bootstrap,
                 'auth',
@@ -2541,6 +2552,9 @@ class Lockbox(object):
         LOG.debug('Mounting lockbox ' + str(" ".join(args)))
         command_check_call(args)
         write_one_line(path, 'osd-uuid', self.args.osd_uuid)
+        if self.args.cluster_uuid is None:
+            self.args.cluster_uuid = get_fsid(cluster=self.args.cluster)
+        write_one_line(path, 'ceph_fsid', self.args.cluster_uuid)
         self.create_key(self.args.cluster)
         self.symlink_spaces(path)
         write_one_line(path, 'magic', CEPH_LOCKBOX_ONDISK_MAGIC)
@@ -3819,15 +3833,17 @@ def _deallocate_osd_id(cluster, osd_id):
     ])
 
 
-def _remove_lockbox(uuid):
+def _remove_lockbox(uuid, cluster):
     command([
         'ceph',
+        '--cluster', cluster,
         'auth',
         'del',
         'client.osd-lockbox.' + uuid,
     ])
     command([
         'ceph',
+        '--cluster', cluster,
         'config-key',
         'del',
         'dm-crypt/osd/' + uuid + '/luks',
@@ -3925,7 +3941,7 @@ def main_destroy_locked(args):
         for name in Space.NAMES:
             if target_dev.get(name + '_uuid'):
                 dmcrypt_unmap(target_dev[name + '_uuid'])
-        _remove_lockbox(target_dev['uuid'])
+        _remove_lockbox(target_dev['uuid'], args.cluster)
 
     # Check zap flag. If we found zap flag, we need to find device for
     # destroy this osd data.

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -319,7 +319,7 @@ class TestDevicePartitionCrypt(Base):
             partition.map()
             assert m['_dmcrypt_map'].called
             m['get_dmcrypt_key'].assert_called_with(
-                uuid, '/etc/ceph/dmcrypt-keys', True, 'ceph')
+                uuid, '/etc/ceph/dmcrypt-keys', True)
 
 
 class TestCryptHelpers(Base):


### PR DESCRIPTION
When dmcrypt is used, the fsid cannot be retrieved from the data
partition because it is encrypted. Store the fsid in the lockbox to
enable dmcrypt activation using the same logic as regular activation.

The fsid is used to retrive the cluster name that was used during
prepare, reason why activation does not and must not have a --cluster
argument.

Fixes: http://tracker.ceph.com/issues/17821

Signed-off-by: Loic Dachary <ldachary@redhat.com>
