### PR TITLE
os/bluestore: fix bug in _open_alloc()

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3760,6 +3760,13 @@ int BlueStore::_open_alloc()
   alloc = Allocator::create(cct, cct->_conf->bluestore_allocator,
                             bdev->get_size(),
                             min_alloc_size);
+  if (!alloc) {
+    lderr(cct) << __func__ << " Allocator::unknown alloc type "
+               << cct->_conf->bluestore_allocator
+               << dendl;
+    return -EINVAL;
+  }
+
   uint64_t num = 0, bytes = 0;
 
   // initialize from freelist


### PR DESCRIPTION
Here adding judgement for Allocator::create in _open_alloc(), bluestore_allocator may not equal stuqid or bitmap and then alloc = nullptr.

Signed-off-by: yonghengdexin735 <zhang.zezhu@zte.com.cn>