### PR TITLE
rgw_file: avoid stranding invalid-name bucket handles in fhcache

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -437,6 +437,8 @@ namespace rgw {
       rc = valid_s3_bucket_name(bname, false /* relaxed */);
       if (rc != 0) {
 	rgw_fh->flags |= RGWFileHandle::FLAG_DELETED;
+	fh_cache.remove(rgw_fh->fh.fh_hk.object, rgw_fh,
+			RGWFileHandle::FHCache::FLAG_LOCK);
 	rgw_fh->mtx.unlock();
 	unref(rgw_fh);
 	get<0>(mkr) = nullptr;


### PR DESCRIPTION
To avoid a string copy in the common mkdir path, handles for
proposed buckets currently are staged in the handle table, before
being rejected.  They need to be destaged, not just marked deleted
(because deleted objects are now assumed not to be linked, as of
beaeff059375b44188160dbde8a81dd4f4f8c6eb).

This triggered an unhandled Boost assert when deleting staged
handles, as current safe_link mode requires first removing from
the FHCache.

Fixes: http://tracker.ceph.com/issues/19036

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>