### PR TITLE
Modify ceph-detect-init to support oracle distribution

### DIFF
--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -24,6 +24,7 @@ from ceph_detect_init import suse
 from ceph_detect_init import gentoo
 from ceph_detect_init import freebsd
 from ceph_detect_init import docker
+from ceph_detect_init import oracle
 import os
 import logging
 import platform

--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -44,7 +44,7 @@ def get(use_rhceph=False):
     module.normalized_name = _normalized_distro_name(distro_name)
     module.distro = module.normalized_name
     module.is_el = module.normalized_name in ['redhat', 'centos',
-                                              'fedora', 'scientific']
+                                              'fedora', 'scientific', 'oracle']
     module.release = release
     module.codename = codename
     module.init = module.choose_init()
@@ -72,6 +72,7 @@ def _get_distro(distro, use_rhceph=False):
         'exherbo': gentoo,
         'freebsd': freebsd,
         'docker': docker,
+        'oracle': oracle,
     }
 
     if distro == 'redhat' and use_rhceph:
@@ -92,6 +93,8 @@ def _normalized_distro_name(distro):
         return 'centos'
     elif distro.startswith(('gentoo', 'funtoo', 'exherbo')):
         return 'gentoo'
+    elif distro.startswith('oracle'):
+        return 'oracle'
     return distro
 
 
@@ -146,6 +149,9 @@ def platform_information():
                 codename = minor
             else:
                 codename = major
+    if not codename and 'oracle' in distro.lower():
+        major_version = release.split('.')[0]
+        codename = 'OL' + major_version
 
     return (
         str(distro).rstrip(),

--- a/src/ceph-detect-init/ceph_detect_init/oracle/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/oracle/__init__.py
@@ -1,0 +1,13 @@
+distro = None
+release = None
+codename = None
+
+
+def choose_init():
+    """Select a init system
+
+    Returns the name of a init system (upstart, sysvinit ...).
+    """
+    if release and int(release.split('.')[0]) >= 7:
+        return 'systemd'
+    return 'sysvinit'


### PR DESCRIPTION
Here at Oracle we started maintaining Ceph in a small team where we try to test and report bugs to upstream. Now we are expecting to commit some fixes in upstream as well. Since Oracle is not supported platform in ceph-detect-init function is wise to add it, other wise we have to rebase our patch for every release. 

One important note here is Oracle is redhat based distribution so, the init function is same as redhat.

Signed-off-by: Muminul Islam <muminul.islam@oracle.com>
