### PR TITLE
Revert "Revert "ceph-disk: change get_dmcrypt_key test to support different cluster name""

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2492,7 +2492,7 @@ class Lockbox(object):
                       self.args.lockbox)
             self.partition = self.create_partition()
 
-    def create_key(self, cluster):
+    def create_key(self):
         key_size = CryptHelpers.get_dmcrypt_keysize(self.args)
         key = open('/dev/urandom', 'rb').read(key_size / 8)
         base64_key = base64.b64encode(key)
@@ -2555,7 +2555,7 @@ class Lockbox(object):
         if self.args.cluster_uuid is None:
             self.args.cluster_uuid = get_fsid(cluster=self.args.cluster)
         write_one_line(path, 'ceph_fsid', self.args.cluster_uuid)
-        self.create_key(self.args.cluster)
+        self.create_key()
         self.symlink_spaces(path)
         write_one_line(path, 'magic', CEPH_LOCKBOX_ONDISK_MAGIC)
         if self.device is not None:


### PR DESCRIPTION
This reverts commit d3409d456233f7bc1c0ed23dbc2db29627d33d5c which
reverted 1c747473600a9a7f528ad71a889c35d85ac115b1. Although in the same
pull request, 1c747473600a9a7f528ad71a889c35d85ac115b1 was a fix for
d98d4dbc2741295723f0a316b5bf81f07b140041. The two should have been
squashed but they were not.

When reverting the pull request I reverted all the commits in the pull
request but I did it in the wrong order and the fix became the
problem. Luckily the outcome is a noop instead of a bug, reason why
it was undetected by the tests.

Signed-off-by: Loic Dachary <ldachary@redhat.com>