### PR TITLE
qa/suites/rgw: Add openstack volume configuration

### DIFF
--- a/qa/clusters/fixed-2.yaml
+++ b/qa/clusters/fixed-2.yaml
@@ -1,3 +1,7 @@
 roles:
 - [mon.a, mon.c, osd.0, osd.1, osd.2, client.0]
 - [mon.b, osd.3, osd.4, osd.5, client.1]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB

--- a/qa/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-admin-data-sync.yaml
@@ -1,6 +1,10 @@
 roles:
 - [mon.a, osd.0, client.0]
 - [osd.1, osd.2, osd.3, client.1]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/singleton/all/radosgw-admin-multi-region.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-admin-multi-region.yaml
@@ -1,6 +1,10 @@
 roles:
 - [mon.a, osd.0, osd.1, osd.2, client.0]
 - [mon.b, mon.c, osd.3, osd.4, osd.5, client.1]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
 tasks:
 - install: 
 - ceph:

--- a/qa/suites/rgw/singleton/all/radosgw-admin.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-admin.yaml
@@ -1,6 +1,10 @@
 roles:
 - [mon.a, osd.0]
 - [client.0, osd.1, osd.2, osd.3]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
 tasks:
 - install:
 - ceph:

--- a/qa/suites/rgw/singleton/all/radosgw-convert-to-region.yaml
+++ b/qa/suites/rgw/singleton/all/radosgw-convert-to-region.yaml
@@ -17,6 +17,10 @@ overrides:
 roles:
 - [mon.a, osd.0, osd.1, osd.2, client.0]
 - [mon.b, mon.c, osd.3, osd.4, osd.5, client.1]
+openstack:
+- volumes: # attached to each instance
+    count: 3
+    size: 10 # GB
 
 tasks:
 - install:


### PR DESCRIPTION
Without this, OSDs will fail to create on instances whose root fs isn't
xfs.

Signed-off-by: Zack Cerza <zack@redhat.com>