### PR TITLE
qa: drop ubuntu trusty support

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_14.04.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_14.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "14.04"


### PR DESCRIPTION
ceph-ansible dropped support for OS that doesnt support systemd

Signed-off-by: Tamil Muthamizhan <tmuthami@redhat.com>
(cherry picked from commit 4d4b38eca81f7b57e3d3b31e1c13e7ab0ba5b30f)
