### PR TITLE
qa/tasks/workunit: use the suite repo for cloning workunit

### DIFF
--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -308,51 +308,24 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
     clonedir = '{tdir}/clone.{role}'.format(tdir=testdir, role=role)
     srcdir = '{cdir}/qa/workunits'.format(cdir=clonedir)
 
-    git_url = teuth_config.get_ceph_git_url()
-    try:
-        remote.run(
-            logger=log.getChild(role),
-            args=[
-                'rm',
-                '-rf',
-                clonedir,
-                run.Raw('&&'),
-                'git',
-                'clone',
-                git_url,
-                clonedir,
-                run.Raw('&&'),
-                'cd', '--', clonedir,
-                run.Raw('&&'),
-                'git', 'checkout', refspec,
-            ],
-        )
-    except CommandFailedError:
-        alt_git_url = git_url.replace('ceph-ci', 'ceph')
-        log.info(
-            "failed to check out '%s' from %s; will also try in %s",
-            refspec,
+    git_url = teuth_config.get_ceph_qa_suite_git_url()
+    remote.run(
+        logger=log.getChild(role),
+        args=[
+            'rm',
+            '-rf',
+            clonedir,
+            run.Raw('&&'),
+            'git',
+            'clone',
             git_url,
-            alt_git_url,
-        )
-        remote.run(
-            logger=log.getChild(role),
-            args=[
-                'rm',
-                '-rf',
-                clonedir,
-                run.Raw('&&'),
-                'git',
-                'clone',
-                alt_git_url,
-                clonedir,
-                run.Raw('&&'),
-                'cd', '--', clonedir,
-                run.Raw('&&'),
-                'git', 'checkout', refspec,
-            ],
-        )
-
+            clonedir,
+            run.Raw('&&'),
+            'cd', '--', clonedir,
+            run.Raw('&&'),
+            'git', 'checkout', refspec,
+        ],
+    )
     remote.run(
         logger=log.getChild(role),
         args=[


### PR DESCRIPTION
as "workunits" reside in ceph/qa/workunits, it's more intuitive to
respect suite-repo option when cloning workunits.

Signed-off-by: Kefu Chai <kchai@redhat.com>