### PR TITLE
do_freebsd.sh: Remove ENODATA requirement

### DIFF
--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -47,6 +47,7 @@ rm -rf build && ./do_cmake.sh "$*" \
 	-D CEPH_MAN_DIR=man \
 	-D WITH_LIBCEPHFS=OFF \
 	-D WITH_CEPHFS=OFF \
+	-D WITH_EMBEDDED=OFF \
 	2>&1 | tee cmake.log
 
 cd build

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -12,12 +12,6 @@ fi
 if [ x"$1"x = x"--deps"x ]; then
     sudo ./install-deps.sh
 fi
-if ! grep -q ENODATA /usr/include/errno.h; then
-    echo Need ENODATA in /usr/include/errno.h for cython compilations
-    echo Please add it manually after ENOATTR with value 87
-    echo '#define ENOATTR         87'
-    exit 1
-fi
 if [ -x /usr/bin/getopt ] && [ x"`/usr/bin/getopt -v`"x == x" --"x ]; then
     echo fix getopt path
     echo Native FreeBSD getopt is not compatible with the Linux getopt that is


### PR DESCRIPTION
- This was there because cython did not know about ENOATTR
   But since cython 0.25.2 tus is fixed.
   And we don't need to edit /usr/include/errno.h

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>