### PR TITLE
test/librbd/CMakeLists.txt: ceph_test_librbd_fsx requires linux includes/libs

### DIFF
--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -123,6 +123,7 @@ target_link_libraries(ceph_test_librbd_api
 set_target_properties(ceph_test_librbd_api PROPERTIES COMPILE_FLAGS
   ${UNITTEST_CXX_FLAGS})
 
+if(LINUX)
 add_executable(ceph_test_librbd_fsx
   fsx.cc
   $<TARGET_OBJECTS:common_texttable_obj>
@@ -138,6 +139,7 @@ target_link_libraries(ceph_test_librbd_fsx
   ${CRYPTO_LIBS}
   ${EXTRALIBS}
   )
+endif(LINUX)
 
 install(TARGETS
   ceph_test_librbd


### PR DESCRIPTION
- So exclude the test

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>