### PR TITLE
os/bluestore: remove CephContext* from BmapEntry.

### DIFF
--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -123,8 +123,7 @@ void BmapEntry::_init_bit_mask()
   BmapEntry::m_bit_mask_init = true;
 }
 
-BmapEntry::BmapEntry(CephContext* cct, bool full)
-  : cct(cct)
+BmapEntry::BmapEntry(CephContext*, const bool full)
 {
 
   BmapEntry::_init_bit_mask();
@@ -334,7 +333,7 @@ BmapEntry::find_first_set_bits(int64_t required_blocks,
   return allocated;
 }
 
-void BmapEntry::dump_state(int& count)
+void BmapEntry::dump_state(CephContext* const cct, const int& count)
 {
   dout(0) << count << ":: 0x" << std::hex << m_bits << std::dec << dendl;
 }
@@ -628,7 +627,7 @@ void BitMapZone::dump_state(int& count)
           m_bmap_list, 0);
   dout(0) << __func__ << " zone " << count << " dump start " << dendl;
   while ((bmap = (BmapEntry *) iter.next())) {
-    bmap->dump_state(bmap_idx);
+    bmap->dump_state(cct, bmap_idx);
     bmap_idx++;
   }
   dout(0) << __func__ << " zone " << count << " dump end " << dendl;

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -139,8 +139,6 @@ typedef unsigned long bmap_t;
 typedef mempool::bluestore_alloc::vector<bmap_t> bmap_mask_vec_t;
 
 class BmapEntry {
-  CephContext* cct;
-
 private:
   bmap_t m_bits;
   static bool m_bit_mask_init;
@@ -157,12 +155,11 @@ public:
   static bmap_t align_mask(int x);
   static bmap_t bit_mask(int bit_num);
   bmap_t atomic_fetch();
-  BmapEntry(CephContext* cct, bool val);
-  BmapEntry(CephContext* cct) : cct(cct) {
+  BmapEntry(CephContext*, bool val);
+  BmapEntry(CephContext*) {
     m_bits = 0;
   }
   BmapEntry(const BmapEntry& bmap) {
-    cct = bmap.cct;
     m_bits = bmap.m_bits;
   }
 
@@ -179,7 +176,7 @@ public:
   int find_first_set_bits(int64_t required_blocks, int bit_offset,
           int *start_offset, int64_t *scanned);
 
-  void dump_state(int& count);
+  void dump_state(CephContext* cct, const int& count);
   ~BmapEntry();
 
 };


### PR DESCRIPTION
Each `BmapEntry` instance stores a pointer to the same `CephContext`.
As we expect to have thousands of instances the overhead might
be too high. For example, serving 1 TiB SSD disk on x86-64,
while using the default settings, results in 32 MiB of extra
memory consumption:

```
  # assuming sizeof(unsigned long) * CHAR_BIT == 64
  >>> 1024 * 1024 * 1024 * 1024 / 4096 / 64
  4194304
  >>> 4194304 * 8 / 1024
  32768
```

Although memory is cheap, CPU's caches are not.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>