### PR TITLE
mon/MonClient: discard stray messages from non-acitve conns

### DIFF
--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -70,7 +70,8 @@ int CephxClientHandler::build_request(bufferlist& bl) const
 
     ::encode(req, bl);
 
-    ldout(cct, 10) << "get auth session key: client_challenge " << req.client_challenge << dendl;
+    ldout(cct, 10) << "get auth session key: client_challenge "
+		   << hex << req.client_challenge << dendl;
     return 0;
   }
 
@@ -117,7 +118,8 @@ int CephxClientHandler::handle_response(int ret, bufferlist::iterator& indata)
     CephXServerChallenge ch;
     ::decode(ch, indata);
     server_challenge = ch.server_challenge;
-    ldout(cct, 10) << " got initial server challenge " << server_challenge << dendl;
+    ldout(cct, 10) << " got initial server challenge "
+		   << hex << server_challenge << dendl;
     starting = false;
 
     tickets.invalidate_ticket(CEPH_ENTITY_TYPE_AUTH);

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -249,7 +249,9 @@ bool MonClient::ms_dispatch(Message *m)
   Mutex::Locker lock(monc_lock);
 
   if (_hunting()) {
-    if (!pending_cons.count(m->get_source_addr())) {
+    auto pending_con = pending_cons.find(m->get_source_addr());
+    if (pending_con == pending_cons.end() ||
+	pending_con->second.get_con() != m->get_connection()) {
       // ignore any messages outside hunting sessions
       ldout(cct, 10) << "discarding stray monitor message " << *m << dendl;
       m->put();


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19015