### PR TITLE
rgw: set dumpable flag after setuid post ff0e521

### DIFF
--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -64,6 +64,10 @@
 #include "include/types.h"
 #include "common/BackTrace.h"
 
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
+
 #define dout_subsys ceph_subsys_rgw
 
 using namespace std;
@@ -531,6 +535,12 @@ int main(int argc, const char **argv)
   RGWRealmWatcher realm_watcher(g_ceph_context, store->realm);
   realm_watcher.add_watcher(RGWRealmNotify::Reload, reloader);
   realm_watcher.add_watcher(RGWRealmNotify::ZonesNeedPeriod, pusher);
+
+#if defined(HAVE_SYS_PRCTL_H)
+  if (prctl(PR_SET_DUMPABLE, 1) == -1) {
+    cerr << "warning: unable to set dumpable flag: " << cpp_strerror(errno) << std::endl;
+  }
+#endif
 
   wait_shutdown();
 


### PR DESCRIPTION
ff0e521 resolved the issue for the other daemons but not for rgw since
it calls setuid (via civetweb) after the new code sets PR_SET_DUMPABLE.
Add another prctl call before wait_shutdown.

Fixes: http://tracker.ceph.com/issues/19089

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>