### PR TITLE
common/EventTrace: fix compiler warning.

### DIFF
--- a/src/common/EventTrace.cc
+++ b/src/common/EventTrace.cc
@@ -47,7 +47,7 @@ void EventTrace::init_tp(CephContext *_ctx)
   }
 }
 
-void EventTrace::set_message_attrs(Message *m, string& oid, string& context, bool incl_oid)
+void EventTrace::set_message_attrs(const Message *m, string& oid, string& context, bool incl_oid)
 {
   // arg1 = oid, arg2 = message type, arg3 = source!source_addr!tid!sequence
   if (m && (m->get_type() == CEPH_MSG_OSD_OP || m->get_type() == CEPH_MSG_OSD_OPREPLY)) {
@@ -105,7 +105,7 @@ void EventTrace::trace_oid_event(const char *oid, const char *event, const char 
   tracepoint(eventtrace, oid_event, oid, event, context, file, func, line);
 }
 
-void EventTrace::trace_oid_event(Message *m, const char *event, const char *file,
+void EventTrace::trace_oid_event(const Message *m, const char *event, const char *file,
   const char *func, int line, bool incl_oid)
 {
   string oid, context;
@@ -122,7 +122,7 @@ void EventTrace::trace_oid_elapsed(const char *oid, const char *event, const cha
   tracepoint(eventtrace, oid_elapsed, oid, event, context, elapsed, file, func, line);
 }
 
-void EventTrace::trace_oid_elapsed(Message *m, const char *event, double elapsed, 
+void EventTrace::trace_oid_elapsed(const Message *m, const char *event, double elapsed,
   const char *file, const char *func, int line, bool incl_oid)
 {
   string oid, context;

--- a/src/common/EventTrace.h
+++ b/src/common/EventTrace.h
@@ -59,7 +59,7 @@ private:
   static bool tpinit;
 
   static void init_tp(CephContext *_ctx);
-  static void set_message_attrs(Message *m, string& oid, string& context, bool incl_oid);
+  static void set_message_attrs(const Message *m, string& oid, string& context, bool incl_oid);
 
 public:
 
@@ -69,12 +69,12 @@ public:
 
   static void trace_oid_event(const char *oid, const char *event, const char *context,
     const char *file, const char *func, int line);
-  static void trace_oid_event(Message *m, const char *event, const char *file,
+  static void trace_oid_event(const Message *m, const char *event, const char *file,
     const char *func, int line, bool incl_oid);
 
   static void trace_oid_elapsed(const char *oid, const char *event, const char *context,
     double elapsed, const char *file, const char *func, int line);
-  static void trace_oid_elapsed(Message *m, const char *event, double elapsed, 
+  static void trace_oid_elapsed(const Message *m, const char *event, double elapsed,
     const char *file, const char *func, int line, bool incl_oid);
   
 };


### PR DESCRIPTION
/mnt/ceph/src/osd/OSD.cc: In member function ‘void
OSD::dequeue_op(PGRef, OpRequestRef, ThreadPool::TPHandle&)’:
/mnt/ceph/src/osd/OSD.cc:9112:42: error: invalid conversion from ‘const
Message*’ to ‘Message*’ [-fpermissive]
   OID_EVENT_TRACE_WITH_MSG(op->get_req(), "DEQUEUE_OP_BEGIN", false);
                                          ^
In file included from /mnt/ceph/src/osd/OSD.h:57:0,
                 from /mnt/ceph/src/osd/OSD.cc:38:
/mnt/ceph/src/common/EventTrace.h:72:15: note:   initializing argument 1
of ‘static void EventTrace::trace_oid_event(Message*, const char*, const
char*, const char*, int, bool)’
   static void trace_oid_event(Message *m, const char *event, const char
*file,
               ^
/mnt/ceph/src/osd/OSD.cc:9158:42: error: invalid conversion from ‘const
Message*’ to ‘Message*’ [-fpermissive]
   OID_EVENT_TRACE_WITH_MSG(op->get_req(), "DEQUEUE_OP_END", true);
                                          ^
In file included from /mnt/ceph/src/osd/OSD.h:57:0,
                 from /mnt/ceph/src/osd/OSD.cc:38:
/mnt/ceph/src/common/EventTrace.h:72:15: note:   initializing argument 1
of ‘static void EventTrace::trace_oid_event(Message*, const char*, const
char*, const char*, int, bool)’
   static void trace_oid_event(Message *m, const char *event, const char
*file,
               ^
src/osd/CMakeFiles/osd.dir/build.make:62: recipe for target
'src/osd/CMakeFiles/osd.dir/OSD.cc.o' failed

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>