### PR TITLE
os/aio: remove the redundant memset(struct iocb)

### DIFF
--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -257,7 +257,6 @@ private:
     aio_info(bufferlist& b, uint64_t o, uint64_t s)
       : iov(NULL), done(false), off(o), len(b.length()), seq(s) {
       bl.claim(b);
-      memset((void*)&iocb, 0, sizeof(iocb));
     }
     ~aio_info() {
       delete[] iov;

--- a/src/os/fs/FS.h
+++ b/src/os/fs/FS.h
@@ -65,7 +65,6 @@ public:
     boost::intrusive::list_member_hook<> queue_item;
 
     aio_t(void *p, int f) : priv(p), fd(f), offset(0), length(0), rval(-1000) {
-      memset(&iocb, 0, sizeof(iocb));
     }
 
     void pwritev(uint64_t _offset, uint64_t len) {


### PR DESCRIPTION
In fact, io_prep_read/write/pwritev/preadv do the memset(struct iocb).
So no need do it.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>