### PR TITLE
osd: the osd should not share map with others when it is in stopping state

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1000,7 +1000,7 @@ void OSDService::share_map(
 	   << name << " " << con->get_peer_addr()
 	   << " " << epoch << dendl;
 
-  if ((!osd->is_active()) && (!osd->is_stopping())) {
+  if (!osd->is_active()) {
     /*It is safe not to proceed as OSD is not in healthy state*/
     return;
   }


### PR DESCRIPTION
osd: the osd should not share map with others when it is in stopping state
     
    the osd may not share its map with others when the osd is in stopping state.
    because it may from unhealthy to stopping.

Signed-off-by: song baisen <song.baisen@zte.com.cn>