### PR TITLE
mgr: add a get_version to the python interface

### DIFF
--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -19,6 +19,7 @@
 #include "Mgr.h"
 
 #include "mon/MonClient.h"
+#include "common/version.h"
 
 #include "PyState.h"
 
@@ -223,6 +224,12 @@ ceph_log(PyObject *self, PyObject *args)
   Py_RETURN_NONE;
 }
 
+static PyObject *
+ceph_get_version(PyObject *self, PyObject *args)
+{
+  return PyString_FromString(pretty_version_to_str().c_str());
+}
+
 static PyObject*
 get_counter(PyObject *self, PyObject *args)
 {
@@ -262,6 +269,8 @@ PyMethodDef CephStateMethods[] = {
       "Get a performance counter"},
     {"log", ceph_log, METH_VARARGS,
      "Emit a (local) log message"},
+    {"get_version", ceph_get_version, METH_VARARGS,
+     "Get the ceph version of this process"},
     {NULL, NULL, 0, NULL}
 };
 

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -59,9 +59,15 @@ class MgrModule(object):
 
         self._logger.addHandler(CPlusPlusHandler())
 
+        self._version = ceph_state.get_version()
+
     @property
     def log(self):
         return self._logger
+
+    @property
+    def version(self):
+        return self._version
 
     def notify(self, notify_type, notify_id):
         """


### PR DESCRIPTION
We had the metadata for all the remote services,
but no quick way for the python module to
ask "what version is the process I'm running in?"

Signed-off-by: John Spray <john.spray@redhat.com>