### PR TITLE
rgw: don't init rgw_obj from rgw_obj_key when it's incorrect to do so

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -508,7 +508,8 @@ int rgw_build_object_policies(RGWRados *store, struct req_state *s,
     }
     s->object_acl = new RGWAccessControlPolicy(s->cct);
 
-    rgw_obj obj(s->bucket, s->object);
+    rgw_obj obj(s->bucket, s->object.name);
+    obj.set_instance(s->object.instance);
       
     store->set_atomic(s->obj_ctx, obj);
     if (prefetch_data) {
@@ -5500,7 +5501,8 @@ void RGWSetAttrs::execute()
   if (op_ret < 0)
     return;
 
-  rgw_obj obj(s->bucket, s->object);
+  rgw_obj obj(s->bucket, s->object.name);
+  obj.set_instance(s->object.instance);
 
   store->set_atomic(s->obj_ctx, obj);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19096

rgw_obj_key currently deals with the bucket index key, and not
representing a (name, instance, ns) tupple. Need to initialize
it in two steps.

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>