### PR TITLE
test/encoding: fix readable.sh bugs; fix ceph-object-corpus

### DIFF
--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -132,13 +132,13 @@ test_object() {
           failed=$(($failed + 1))
         fi
         numtests=$(($numtests + 1))
-        echo "failed=$failed" > $output_file
-        echo "numtests=$numtests" >> $output_file
       done
     else
       echo "skipping unrecognized type $type"
     fi
 
+    echo "failed=$failed" > $output_file
+    echo "numtests=$numtests" >> $output_file
     rm -f $tmp1 $tmp2
 }
 

--- a/src/test/encoding/readable.sh
+++ b/src/test/encoding/readable.sh
@@ -169,34 +169,7 @@ waitall() { # PID...
 # MAIN
 ######
 
-# Using $MAX_PARALLEL_JOBS jobs if defined, unless the number of logical
-# processors
-if [ `uname` == FreeBSD ]; then
-  NPROC=`sysctl -n hw.ncpu`
-  max_parallel_jobs=${MAX_PARALLEL_JOBS:-${NPROC}}
-else
-  max_parallel_jobs=${MAX_PARALLEL_JOBS:-$(nproc)}
-fi
-
-for arversion in `ls $dir/archive | sort -n`; do
-  vdir="$dir/archive/$arversion"
-  #echo $vdir
-
-  if [ ! -d "$vdir/objects" ]; then
-    continue;
-  fi
-
-  output_file=`mktemp /tmp/typ-XXXXXXXXX`
-  running_jobs=0
-  for type in `ls $vdir/objects`; do
-    test_object $type $output_file.$running_jobs &
-    pids="$pids $!"
-    running_jobs=$(($running_jobs + 1))
-
-    # Once we spawned enough jobs, let's wait them to complete
-    # Every spawned job have almost the same execution time so
-    # it's not a big deal having them not ending at the same time
-    if [ "$running_jobs" -eq "$max_parallel_jobs" ]; then
+do_join() {
         waitall $pids
         pids=""
         # Reading the output of jobs to compute failed & numtests
@@ -213,9 +186,43 @@ for arversion in `ls $dir/archive | sort -n`; do
             running_jobs=$(($running_jobs - 1))
         done
         running_jobs=0
+}
+
+# Using $MAX_PARALLEL_JOBS jobs if defined, unless the number of logical
+# processors
+if [ `uname` == FreeBSD ]; then
+  NPROC=`sysctl -n hw.ncpu`
+  max_parallel_jobs=${MAX_PARALLEL_JOBS:-${NPROC}}
+else
+  max_parallel_jobs=${MAX_PARALLEL_JOBS:-$(nproc)}
+fi
+
+output_file=`mktemp /tmp/typ-XXXXXXXXX`
+running_jobs=0
+
+for arversion in `ls $dir/archive | sort -n`; do
+  vdir="$dir/archive/$arversion"
+  #echo $vdir
+
+  if [ ! -d "$vdir/objects" ]; then
+    continue;
+  fi
+
+  for type in `ls $vdir/objects`; do
+    test_object $type $output_file.$running_jobs &
+    pids="$pids $!"
+    running_jobs=$(($running_jobs + 1))
+
+    # Once we spawned enough jobs, let's wait them to complete
+    # Every spawned job have almost the same execution time so
+    # it's not a big deal having them not ending at the same time
+    if [ "$running_jobs" -eq "$max_parallel_jobs" ]; then
+	do_join
     fi
   done
 done
+
+do_join
 
 if [ $failed -gt 0 ]; then
   echo "FAILED $failed / $numtests tests."


### PR DESCRIPTION
The patch to parallelize this broke it; fix those bugs.

Also fix 2 problems with the corpus that snuck in since then:

 - OSDMap trailing data test case nwo fails, but can be removed
 - ECSubWrite incompat wasn't set when ObjectStore::Transaction was