### PR TITLE
librbd: image-extent cache needs to clip out-of-bounds read buffers

### DIFF
--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -83,6 +83,8 @@ public:
                    int op_flags);
 
 protected:
+  int clip_request() override;
+
   void send_request() override;
   void send_image_cache_request() override;
 


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>