### PR TITLE
rgw: fix init_bucket_for_sync retcode

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1717,7 +1717,7 @@ static int init_bucket_for_sync(const string& tenant, const string& bucket_name,
   int ret = init_bucket(tenant, bucket_name, bucket_id, bucket_info, bucket);
   if (ret < 0) {
     cerr << "ERROR: could not init bucket: " << cpp_strerror(-ret) << std::endl;
-    return -ret;
+    return ret;
   }
 
   return 0;


### PR DESCRIPTION
init_bucket_for_sync error retcode should be negative

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>