### PR TITLE
common: use ref to avoid unnecessary memory copy

### DIFF
--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -40,8 +40,8 @@ using std::string;
 
 ////////////////////////////// ConfLine //////////////////////////////
 ConfLine::
-ConfLine(const std::string &key_, const std::string val_,
-      const std::string newsection_, const std::string comment_, int line_no_)
+ConfLine(const std::string &key_, const std::string &val_,
+      const std::string &newsection_, const std::string &comment_, int line_no_)
   : key(key_), val(val_), newsection(newsection_)
 {
   // If you want to implement writable ConfFile support, you'll need to save

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -39,8 +39,8 @@
  */
 class ConfLine {
 public:
-  ConfLine(const std::string &key_, const std::string val_,
-	   const std::string newsection_, const std::string comment_, int line_no_);
+  ConfLine(const std::string &key_, const std::string &val_,
+	   const std::string &newsection_, const std::string &comment_, int line_no_);
   bool operator<(const ConfLine &rhs) const;
   friend std::ostream &operator<<(std::ostream& oss, const ConfLine &l);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19107

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>