### PR TITLE
mgr: pass through cluster log to plugins

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -28,6 +28,7 @@
 #include "messages/MMgrDigest.h"
 #include "messages/MCommand.h"
 #include "messages/MCommandReply.h"
+#include "messages/MLog.h"
 
 #include "Mgr.h"
 
@@ -180,6 +181,7 @@ void Mgr::init()
   // Subscribe to OSDMap update to pass on to ClusterState
   objecter->maybe_request_map();
 
+  monc->sub_want("log-info", 0, 0);
   monc->sub_want("mgrdigest", 0, 0);
 
   // Prepare to receive FSMap and request it
@@ -196,6 +198,7 @@ void Mgr::init()
   lock.Lock();
   waiting_for_fs_map = nullptr;
   dout(4) << "Got FSMap." << dendl;
+
 
   // Wait for MgrDigest...?
   // TODO
@@ -418,6 +421,13 @@ void Mgr::handle_osd_map()
   daemon_state.cull(CEPH_ENTITY_TYPE_OSD, names_exist);
 }
 
+void Mgr::handle_log(MLog *m)
+{
+  for (const auto &e : m->entries) {
+    py_modules.notify_all(e);
+  }
+}
+
 bool Mgr::ms_dispatch(Message *m)
 {
   derr << *m << dendl;
@@ -453,6 +463,10 @@ bool Mgr::ms_dispatch(Message *m)
       // Continuous subscribe, so that we can generate notifications
       // for our MgrPyModules
       objecter->maybe_request_map();
+      m->put();
+      break;
+    case MSG_LOG:
+      handle_log(static_cast<MLog *>(m));
       m->put();
       break;
 

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -38,6 +38,7 @@
 
 class MCommand;
 class MMgrDigest;
+class MLog;
 class Objecter;
 
 
@@ -78,6 +79,7 @@ public:
   void handle_mgr_digest(MMgrDigest* m);
   void handle_fs_map(MFSMap* m);
   void handle_osd_map();
+  void handle_log(MLog *m);
 
   bool ms_dispatch(Message *m);
 

--- a/src/mgr/MgrPyModule.h
+++ b/src/mgr/MgrPyModule.h
@@ -20,6 +20,7 @@
 #include "Python.h"
 
 #include "common/cmdparse.h"
+#include "common/LogEntry.h"
 
 #include <vector>
 #include <string>
@@ -58,6 +59,7 @@ public:
   int serve();
   void shutdown();
   void notify(const std::string &notify_type, const std::string &notify_id);
+  void notify_clog(const LogEntry &le);
 
   const std::vector<ModuleCommand> &get_commands() const
   {

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -38,6 +38,9 @@ class PyFormatter : public ceph::Formatter
 public:
   PyFormatter(bool pretty = false, bool array = false)
   {
+    // It is forbidden to instantiate me outside of the GIL,
+    // because I construct python objects right away
+
     // Initialise cursor to an empty dict
     if (!array) {
       root = cursor = PyDict_New();

--- a/src/mgr/PyModules.h
+++ b/src/mgr/PyModules.h
@@ -73,6 +73,7 @@ public:
   // send it to only the module that sent the command, not everyone
   void notify_all(const std::string &notify_type,
                   const std::string &notify_id);
+  void notify_all(const LogEntry &log_entry);
 
   int init();
   void start();


### PR DESCRIPTION
This is the simplest way -- no filtering on the C++ side, every python module gets notified of everything, and it's up to the python side to ignore it or do something with it