### PR TITLE
rgw_file:  use fh_hook::is_linked() to check residence

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -813,8 +813,8 @@ namespace rgw {
     lsubdout(fs->get_context(), rgw, 17)
       << __func__ << " " << *this
       << dendl;
-    /* if !deleted, then object still in fh_cache */
-    if (! deleted()) {
+    /* remove if still in fh_cache */
+    if (fh_hook.is_linked()) {
       fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_LOCK);
     }
     return true;


### PR DESCRIPTION
Previously we assumed that !deleted handles were resident--there
is an observed case where a !deleted handle is !linked.  Since
we currently use safe_link mode, an is_linked() check is
available, and exhaustive.

Fixes: http://tracker.ceph.com/issues/19111

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>