### PR TITLE
qa/suites/ceph-deploy: Drop OpenStack volume count

### DIFF
--- a/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
+++ b/qa/suites/ceph-deploy/basic/tasks/ceph-admin-commands.yaml
@@ -11,7 +11,7 @@ openstack:
       ram: 2000 # MB
       cpus: 1
     volumes: # attached to each instance
-      count: 3
+      count: 2
       size: 10 # GB
 tasks:
 - ssh_keys:


### PR DESCRIPTION
Looks like we only need two per node, since there is only one OSD per
node, and ceph-deploy wants two disks per OSD to account for the
journal.

Signed-off-by: Zack Cerza <zack@redhat.com>