### PR TITLE
msg/async/rdma: move active_queue_pairs perf counter dec to polling

### DIFF
--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -42,7 +42,6 @@ RDMAConnectedSocketImpl::RDMAConnectedSocketImpl(CephContext *cct, Infiniband* i
 RDMAConnectedSocketImpl::~RDMAConnectedSocketImpl()
 {
   ldout(cct, 20) << __func__ << " destruct." << dendl;
-  dispatcher->perf_logger->dec(l_msgr_rdma_active_queue_pair);
   cleanup();
   worker->remove_pending_conn(this);
   dispatcher->erase_qpn(my_msg.qpn);

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -146,6 +146,7 @@ void RDMADispatcher::polling()
         while (!dead_queue_pairs.empty()) {
           ldout(cct, 10) << __func__ << " finally delete qp=" << dead_queue_pairs.back() << dendl;
           delete dead_queue_pairs.back();
+          perf_logger->dec(l_msgr_rdma_active_queue_pair);
           dead_queue_pairs.pop_back();
         }
       }


### PR DESCRIPTION
removing dead qp's is actually done at polling. if polling is busy then
dead qp will not be removed and active_queue_pair counter is not correct.

Signed-off-by: DanielBar-On <danielbo@mellanox.com>