### PR TITLE
osdc: clean up osd_command/start_mon_command interfaces

### DIFF
--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -888,10 +888,9 @@ int librados::RadosClient::osd_command(int osd, vector<string>& cmd,
 
   lock.Lock();
   // XXX do anything with tid?
-  int r = objecter->osd_command(osd, cmd, inbl, &tid, poutbl, prs,
-			 new C_SafeCond(&mylock, &cond, &done, &ret));
+  objecter->osd_command(osd, cmd, inbl, &tid, poutbl, prs,
+			new C_SafeCond(&mylock, &cond, &done, &ret));
   lock.Unlock();
-  assert(r == 0);
   mylock.Lock();
   while (!done)
     cond.Wait(mylock);
@@ -909,10 +908,9 @@ int librados::RadosClient::pg_command(pg_t pgid, vector<string>& cmd,
   int ret;
   ceph_tid_t tid;
   lock.Lock();
-  int r = objecter->pg_command(pgid, cmd, inbl, &tid, poutbl, prs,
-		        new C_SafeCond(&mylock, &cond, &done, &ret));
+  objecter->pg_command(pgid, cmd, inbl, &tid, poutbl, prs,
+		       new C_SafeCond(&mylock, &cond, &done, &ret));
   lock.Unlock();
-  assert(r == 0);
   mylock.Lock();
   while (!done)
     cond.Wait(mylock);

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -404,10 +404,9 @@ void Mgr::handle_osd_map()
         std::ostringstream cmd;
         cmd << "{\"prefix\": \"osd metadata\", \"id\": "
             << osd_id << "}";
-        int r = monc->start_mon_command(
+        monc->start_mon_command(
             {cmd.str()},
             {}, &c->outbl, &c->outs, c);
-        assert(r == 0);  // start_mon_command defined to not fail
       }
     }
 
@@ -517,10 +516,9 @@ void Mgr::handle_fs_map(MFSMap* m)
       std::ostringstream cmd;
       cmd << "{\"prefix\": \"mds metadata\", \"who\": \""
           << info.name << "\"}";
-      int r = monc->start_mon_command(
+      monc->start_mon_command(
           {cmd.str()},
           {}, &c->outbl, &c->outs, c);
-      assert(r == 0);  // start_mon_command defined to not fail
     }
   }
 }

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -99,13 +99,12 @@ ceph_send_command(PyObject *self, PyObject *args)
   Py_DECREF(set_fn);
 
   auto c = new MonCommandCompletion(completion, tag);
-  auto r = global_handle->get_monc().start_mon_command(
+  global_handle->get_monc().start_mon_command(
       {cmd_json},
       {},
       &c->outbl,
       &c->outs,
       c);
-  assert(r == 0);  // start_mon_command is forbidden to fail
 
   Py_RETURN_NONE;
 }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1028,7 +1028,7 @@ void MonClient::_finish_command(MonCommand *r, int ret, string rs)
   delete r;
 }
 
-int MonClient::start_mon_command(const vector<string>& cmd,
+void MonClient::start_mon_command(const vector<string>& cmd,
 				 const bufferlist& inbl,
 				 bufferlist *outbl, string *outs,
 				 Context *onfinish)
@@ -1056,11 +1056,9 @@ int MonClient::start_mon_command(const vector<string>& cmd,
   }
   mon_commands[r->tid] = r;
   _send_command(r);
-  // can't fail
-  return 0;
 }
 
-int MonClient::start_mon_command(const string &mon_name,
+void MonClient::start_mon_command(const string &mon_name,
 				 const vector<string>& cmd,
 				 const bufferlist& inbl,
 				 bufferlist *outbl, string *outs,
@@ -1076,11 +1074,9 @@ int MonClient::start_mon_command(const string &mon_name,
   r->onfinish = onfinish;
   mon_commands[r->tid] = r;
   _send_command(r);
-  // can't fail
-  return 0;
 }
 
-int MonClient::start_mon_command(int rank,
+void MonClient::start_mon_command(int rank,
 				 const vector<string>& cmd,
 				 const bufferlist& inbl,
 				 bufferlist *outbl, string *outs,
@@ -1096,7 +1092,6 @@ int MonClient::start_mon_command(int rank,
   r->onfinish = onfinish;
   mon_commands[r->tid] = r;
   _send_command(r);
-  return 0;
 }
 
 // ---------

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -439,14 +439,14 @@ private:
   void handle_mon_command_ack(MMonCommandAck *ack);
 
 public:
-  int start_mon_command(const vector<string>& cmd, const bufferlist& inbl,
+  void start_mon_command(const vector<string>& cmd, const bufferlist& inbl,
 			bufferlist *outbl, string *outs,
 			Context *onfinish);
-  int start_mon_command(int mon_rank,
+  void start_mon_command(int mon_rank,
 			const vector<string>& cmd, const bufferlist& inbl,
 			bufferlist *outbl, string *outs,
 			Context *onfinish);
-  int start_mon_command(const string &mon_name,  ///< mon name, with mon. prefix
+  void start_mon_command(const string &mon_name,  ///< mon name, with mon. prefix
 			const vector<string>& cmd, const bufferlist& inbl,
 			bufferlist *outbl, string *outs,
 			Context *onfinish);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3039,9 +3039,8 @@ int OSD::update_crush_location()
     bufferlist inbl;
     C_SaferCond w;
     string outs;
-    int r = monc->start_mon_command(vcmd, inbl, NULL, &outs, &w);
-    if (r == 0)
-      r = w.wait();
+    monc->start_mon_command(vcmd, inbl, NULL, &outs, &w);
+    int r = w.wait();
     if (r < 0) {
       if (r == -ENOENT && !created) {
 	string newcmd = "{\"prefix\": \"osd create\", \"id\": " + stringify(whoami)
@@ -3050,9 +3049,8 @@ int OSD::update_crush_location()
 	bufferlist inbl;
 	C_SaferCond w;
 	string outs;
-	int r = monc->start_mon_command(vnewcmd, inbl, NULL, &outs, &w);
-	if (r == 0)
-	  r = w.wait();
+	monc->start_mon_command(vnewcmd, inbl, NULL, &outs, &w);
+	int r = w.wait();
 	if (r < 0) {
 	  derr << __func__ << " fail: osd does not exist and created failed: "
 	       << cpp_strerror(r) << dendl;

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -4674,7 +4674,7 @@ void Objecter::handle_command_reply(MCommandReply *m)
     s->put();
 }
 
-int Objecter::submit_command(CommandOp *c, ceph_tid_t *ptid)
+void Objecter::submit_command(CommandOp *c, ceph_tid_t *ptid)
 {
   shunique_lock sul(rwlock, ceph::acquire_unique);
 
@@ -4706,8 +4706,6 @@ int Objecter::submit_command(CommandOp *c, ceph_tid_t *ptid)
   *ptid = tid;
 
   logger->inc(l_osdc_command_active);
-
-  return 0;
 }
 
 int Objecter::_calc_command_target(CommandOp *c, shunique_lock& sul)

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1554,7 +1554,7 @@ public:
 
   };
 
-  int submit_command(CommandOp *c, ceph_tid_t *ptid);
+  void submit_command(CommandOp *c, ceph_tid_t *ptid);
   int _calc_command_target(CommandOp *c, shunique_lock &sul);
   void _assign_command_session(CommandOp *c, shunique_lock &sul);
   void _send_command(CommandOp *c);
@@ -2112,7 +2112,7 @@ public:
   epoch_t op_cancel_writes(int r, int64_t pool=-1);
 
   // commands
-  int osd_command(int osd, vector<string>& cmd,
+  void osd_command(int osd, vector<string>& cmd,
 		  const bufferlist& inbl, ceph_tid_t *ptid,
 		  bufferlist *poutbl, string *prs, Context *onfinish) {
     assert(osd >= 0);
@@ -2123,9 +2123,9 @@ public:
       poutbl,
       prs,
       onfinish);
-    return submit_command(c, ptid);
+    submit_command(c, ptid);
   }
-  int pg_command(pg_t pgid, vector<string>& cmd,
+  void pg_command(pg_t pgid, vector<string>& cmd,
 		 const bufferlist& inbl, ceph_tid_t *ptid,
 		 bufferlist *poutbl, string *prs, Context *onfinish) {
     CommandOp *c = new CommandOp(
@@ -2135,7 +2135,7 @@ public:
       poutbl,
       prs,
       onfinish);
-    return submit_command(c, ptid);
+    submit_command(c, ptid);
   }
 
   // mid-level helpers

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2112,7 +2112,7 @@ public:
   epoch_t op_cancel_writes(int r, int64_t pool=-1);
 
   // commands
-  void osd_command(int osd, vector<string>& cmd,
+  void osd_command(int osd, const std::vector<string>& cmd,
 		  const bufferlist& inbl, ceph_tid_t *ptid,
 		  bufferlist *poutbl, string *prs, Context *onfinish) {
     assert(osd >= 0);


### PR DESCRIPTION
Functions that can't return errors should return void.  I was using these interfaces from #13725 and didn't like writing in even more places where we would either assert(r==0) or do an error handling branch that would never get taken.