### PR TITLE
osd/OSDMap: don't set weight to IN when OSD is destroyed

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1378,7 +1378,6 @@ int OSDMap::apply_incremental(const Incremental &inc)
       (*osd_uuid)[i->first] = uuid_d();
       osd_info[i->first] = osd_info_t();
       osd_xinfo[i->first] = osd_xinfo_t();
-      osd_weight[i->first] = CEPH_OSD_IN;
       set_primary_affinity(i->first, CEPH_OSD_DEFAULT_PRIMARY_AFFINITY);
       osd_addrs->client_addr[i->first].reset(new entity_addr_t());
       osd_addrs->cluster_addr[i->first].reset(new entity_addr_t());


### PR DESCRIPTION
Since commit 4e28f9e63644 ("osd/OSDMap: clear osd_info, osd_xinfo on
osd deletion"), weight is set to IN when OSD is deleted.  This changes
the result of applying an incremental for clients, not just OSDs.
Because CRUSH computations are obviously affected, pre-4e28f9e63644
servers disagree with post-4e28f9e63644 clients on object placement,
resulting in misdirected requests.

Fixes: http://tracker.ceph.com/issues/19119
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>