### PR TITLE
os/bluestore: leverage the type knowledge in BitMapAreaLeaf.

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -450,8 +450,7 @@ public:
     return false;
   }
 
-  bool child_check_n_lock(BitMapArea *child, int64_t required, bool lock);
-  void child_unlock(BitMapArea *child);
+  bool child_check_n_lock(BitMapZone* child, int64_t required, bool lock);
 
   int64_t alloc_blocks_int(int64_t num_blocks, int64_t hint, int64_t *start_block);
   int64_t alloc_blocks_dis_int(int64_t num_blocks, int64_t min_alloc, int64_t hint,

--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -331,7 +331,10 @@ public:
        */
       return NULL;
     }
-    alloc_assert(cur_idx < m_list->size());
+
+    /* This method should be *really* fast as it's being executed over
+     * and over during traversal of allocators indexes. */
+    alloc_dbg_assert(cur_idx < m_list->size());
     return m_list->get_nth_item(cur_idx);
   }
 


### PR DESCRIPTION
We're sure the only element type `BitMapAreaLeaf` aggregates is `BitMapZone`. There is no business to go through vptrs and thus prohibit compiler to inline in a method that is crucial for overall performance of the BitMap allocator.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>