### PR TITLE
os/filestore: use existing variable for same func.

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -189,9 +189,8 @@ int FileJournal::_open_file(int64_t oldsize, blksize_t blksize,
   }
 
   if (create && (oldsize < conf_journal_sz)) {
-    uint64_t newsize(cct->_conf->osd_journal_size);
-    newsize <<= 20;
-    dout(10) << "_open extending to " << newsize << " bytes" << dendl;
+    uint64_t newsize(conf_journal_sz);
+    dout(10) <<  __func__ << " _open extending to " << newsize << " bytes" << dendl;
     ret = ::ftruncate(fd, newsize);
     if (ret < 0) {
       int err = errno;


### PR DESCRIPTION
Use existing conf_journal_sz  to replace new_size.

Signed-off-by: Pan Liu <liupan1111@gmail.com>