### PR TITLE
os/bluestore: remove unneeded indirection in BitMapZone.

### DIFF
--- a/src/os/bluestore/BitAllocator.h
+++ b/src/os/bluestore/BitAllocator.h
@@ -311,7 +311,7 @@ class BitMapZone: public BitMapArea{
 
 private:
   std::atomic<int32_t> m_used_blocks;
-  BmapEntryVector *m_bmap_list;
+  BmapEntryVector m_bmap_vec;
   std::mutex m_lock;
 
 public:


### PR DESCRIPTION
`BitMapZone` aggregates `BmapEntries` through a pointer to independently-
allocated `std::vector` which in turn has its own pointer to the real
data. This indirection is unnecessary as `std::vector` is pretty cheap
in the terms of memory overhead. For instance, on x86-64 & GCC 5.4.0
`sizeof(std::vector) == 24`, which translates to 3 raw pointers.

Stripping the indirection could have positive impact on processor's
caches and allow to minimize the number of memory accesses.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>