### PR TITLE
rpm: disable dwz to speed up valgrind

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -56,7 +56,8 @@
 # unify libexec for all targets
 %global _libexecdir %{_exec_prefix}/lib
 
-
+# disable dwz which compresses the debuginfo
+%global _find_debuginfo_dwz_opts %{nil}
 #################################################################################
 # common
 #################################################################################


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19099
Signed-off-by: Kefu Chai <kchai@redhat.com>