### PR TITLE
osd/osd_internal_types: wake snaptrimmer on put_read lock, too

### DIFF
--- a/qa/suites/rados/thrash/thrashers/none.yaml
+++ b/qa/suites/rados/thrash/thrashers/none.yaml
@@ -1,0 +1,3 @@
+tasks:
+- install:
+- ceph:

--- a/src/osd/osd_internal_types.h
+++ b/src/osd/osd_internal_types.h
@@ -254,35 +254,6 @@ public:
     rwstate.put_read(ls);
     rwstate.recovery_read_marker = false;
   }
-  void put_read(list<OpRequestRef> *to_wake) {
-    rwstate.put_read(to_wake);
-  }
-  void put_excl(list<OpRequestRef> *to_wake,
-		 bool *requeue_recovery,
-		 bool *requeue_snaptrimmer) {
-    rwstate.put_excl(to_wake);
-    if (rwstate.empty() && rwstate.recovery_read_marker) {
-      rwstate.recovery_read_marker = false;
-      *requeue_recovery = true;
-    }
-    if (rwstate.empty() && rwstate.snaptrimmer_write_marker) {
-      rwstate.snaptrimmer_write_marker = false;
-      *requeue_snaptrimmer = true;
-    }
-  }
-  void put_write(list<OpRequestRef> *to_wake,
-		 bool *requeue_recovery,
-		 bool *requeue_snaptrimmer) {
-    rwstate.put_write(to_wake);
-    if (rwstate.empty() && rwstate.recovery_read_marker) {
-      rwstate.recovery_read_marker = false;
-      *requeue_recovery = true;
-    }
-    if (rwstate.empty() && rwstate.snaptrimmer_write_marker) {
-      rwstate.snaptrimmer_write_marker = false;
-      *requeue_snaptrimmer = true;
-    }
-  }
   void put_lock_type(
     ObjectContext::RWState::State type,
     list<OpRequestRef> *to_wake,
@@ -290,13 +261,24 @@ public:
     bool *requeue_snaptrimmer) {
     switch (type) {
     case ObjectContext::RWState::RWWRITE:
-      return put_write(to_wake, requeue_recovery, requeue_snaptrimmer);
+      rwstate.put_write(to_wake);
+      break;
     case ObjectContext::RWState::RWREAD:
-      return put_read(to_wake);
+      rwstate.put_read(to_wake);
+      break;
     case ObjectContext::RWState::RWEXCL:
-      return put_excl(to_wake, requeue_recovery, requeue_snaptrimmer);
+      rwstate.put_excl(to_wake);
+      break;
     default:
       assert(0 == "invalid lock type");
+    }
+    if (rwstate.empty() && rwstate.recovery_read_marker) {
+      rwstate.recovery_read_marker = false;
+      *requeue_recovery = true;
+    }
+    if (rwstate.empty() && rwstate.snaptrimmer_write_marker) {
+      rwstate.snaptrimmer_write_marker = false;
+      *requeue_snaptrimmer = true;
     }
   }
   bool is_request_pending() {


### PR DESCRIPTION
The snaptrimmer can block taking a write lock, which might happen due to
a conficting EC read.  When the EC read completes, we need to wake up the
snaptrimmer.

Fixes: http://tracker.ceph.com/issues/19131
Signed-off-by: Sage Weil <sage@redhat.com>