### PR TITLE
osdc/Objecter: resend RWORDERED ops on full

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -122,6 +122,7 @@ class Thrasher:
         self.optrack_toggle_delay = self.config.get('optrack_toggle_delay')
         self.dump_ops_enable = self.config.get('dump_ops_enable')
         self.noscrub_toggle_delay = self.config.get('noscrub_toggle_delay')
+        self.chance_thrash_cluster_full = self.config.get('chance_thrash_cluster_full', .05)
 
         num_osds = self.in_osds + self.out_osds
         self.max_pgs = self.config.get("max_pgs_per_pool_osd", 1200) * num_osds
@@ -494,6 +495,16 @@ class Thrasher:
         self.ceph_manager.raw_cluster_cmd('osd', 'primary-affinity',
                                           str(osd), str(pa))
 
+    def thrash_cluster_full(self):
+        """
+        Set and unset cluster full condition
+        """
+        self.log('Setting full ratio to .001')
+        self.ceph_manager.raw_cluster_cmd('pg', 'set_full_ratio', '.001')
+        time.sleep(1)
+        self.log('Setting full ratio back to .95')
+        self.ceph_manager.raw_cluster_cmd('pg', 'set_full_ratio', '.95')
+
     def all_up(self):
         """
         Make sure all osds are up and not out.
@@ -710,6 +721,8 @@ class Thrasher:
                         chance_test_min_size,))
         actions.append((self.test_backfill_full,
                         chance_test_backfill_full,))
+        if self.chance_thrash_cluster_full > 0:
+            actions.append((self.thrash_cluster_full, self.chance_thrash_cluster_full,))
         for key in ['heartbeat_inject_failure', 'filestore_inject_stall']:
             for scenario in [
                 (lambda:

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -500,10 +500,10 @@ class Thrasher:
         Set and unset cluster full condition
         """
         self.log('Setting full ratio to .001')
-        self.ceph_manager.raw_cluster_cmd('pg', 'set_full_ratio', '.001')
+        self.ceph_manager.raw_cluster_cmd('osd', 'set-full-ratio', '.001')
         time.sleep(1)
         self.log('Setting full ratio back to .95')
-        self.ceph_manager.raw_cluster_cmd('pg', 'set_full_ratio', '.95')
+        self.ceph_manager.raw_cluster_cmd('osd', 'set-full-ratio', '.95')
 
     def all_up(self):
         """

--- a/qa/tasks/thrashosds.py
+++ b/qa/tasks/thrashosds.py
@@ -120,6 +120,8 @@ def task(ctx, config):
     disable_objectstore_tool_tests: (false) disable ceph_objectstore_tool based
                                     tests
 
+    chance_thrash_cluster_full: .05
+
     example:
 
     tasks:

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1073,8 +1073,7 @@ void Objecter::_scan_requests(OSDSession *s,
 			 op->session ? op->session->con.get() : nullptr);
     switch (r) {
     case RECALC_OP_TARGET_NO_ACTION:
-      if (!force_resend &&
-	  (!force_resend_writes || !(op->target.flags & CEPH_OSD_FLAG_WRITE)))
+      if (!force_resend && !(force_resend_writes && op->respects_full()))
 	break;
       // -- fall-thru --
     case RECALC_OP_TARGET_NEED_RESEND:
@@ -2367,9 +2366,7 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
 		   << dendl;
     op->target.paused = true;
     _maybe_request_map();
-  } else if ((op->target.flags & (CEPH_OSD_FLAG_WRITE | CEPH_OSD_FLAG_RWORDERED)) &&
-	     !(op->target.flags & (CEPH_OSD_FLAG_FULL_TRY |
-				   CEPH_OSD_FLAG_FULL_FORCE)) &&
+  } else if (op->respects_full() &&
 	     (_osdmap_full_flag() ||
 	      _osdmap_pool_full(op->target.base_oloc.pool))) {
     ldout(cct, 0) << " FULL, paused modify " << op << " tid "

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1336,6 +1336,12 @@ public:
       return tid < other.tid;
     }
 
+    bool respects_full() const {
+      return
+	(target.flags & (CEPH_OSD_FLAG_WRITE | CEPH_OSD_FLAG_RWORDERED)) &&
+	!(target.flags & (CEPH_OSD_FLAG_FULL_TRY | CEPH_OSD_FLAG_FULL_FORCE));
+    }
+
   private:
     ~Op() {
       while (!out_handler.empty()) {


### PR DESCRIPTION
Our condition for respecting the FULL flag is complex, and involves
the WRITE | RWORDERED flags vs the FULL_FORCE | FULL_TRY flags.  Previously,
we could block a read bc of RWORDRED but not resend it later.

Fix by capturing the complex condition in a respects_full() bool and using
it both for the blocking-on-send and resending-on-possibly-notfull-later
checks.

Fixes: http://tracker.ceph.com/issues/19133

NOTE: the but that actualy cause the failure in that ticket was a jewel
bug where it was missing the backport of 07b2a22210e26eac1b2825c30629788da05e5e12; this bug was found by inspection while debugging that one.  Both should
get backported to jewel and kraken!