### PR TITLE
rgw: get torrent request's parameter is not the same as amazon s3.

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -69,3 +69,7 @@
 * The rados copy-get-classic operation has been removed since it has not been
   used by the OSD since before hammer.  It is unlikely any librados user is
   using this operation explicitly since there is also the more modern copy-get.
+
+* The RGW api for getting object torrent has changed its params from 'get_torrent'
+  to 'torrent' so that it can be compatible with Amazon S3. Now the request for 
+  object torrent is like 'GET /ObjectName?torrent'.

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -29,7 +29,7 @@ struct req_state;
 #define PIECE_LENGTH       "piece length"
 #define PIECES             "pieces"
 #define INFO_PIECES        "info"
-#define GET_TORRENT        "get_torrent"
+#define GET_TORRENT        "torrent"
 
 class TorrentBencode
 {


### PR DESCRIPTION
In Amazon S3, corrent request is `GET /ObjectName?torrent`

Fixes: http://tracker.ceph.com/issues/19136

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>