### PR TITLE
  qa: fix the wrong keyword

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1682,7 +1682,7 @@ function test_mon_osd_misc()
   ceph pg set_full_ratio 95 2>$TMPFILE; check_response 'not in range' $? 22
 
   # expect "not in range" for invalid overload percentage
-  ceph osd reweight-by-utilization 80 2>$TMPFILE; check_response 'higher than 100' $? 22
+  ceph osd reweight-by-utilization 80 2>$TMPFILE; check_response 'not in range' $? 22
 
   set -e
 


### PR DESCRIPTION
  "ceph osd reweight-by-utilization 80" output should contains
  "not in range" but not "higher than 100"

  Signed-off-by: Jun Huang <hjwsm1989@gmail.com>