### PR TITLE
rgw_file: fix non-posix errcode EINVAL to ENAMETOOLONG

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1522,8 +1522,9 @@ public:
     RGWOp::init(rados_ctx->store, get_state(), this);
     op = this; // assign self as op: REQUIRED
 
-    if (! valid_s3_object_name(obj_name))
-      return -ERR_INVALID_OBJECT_NAME;
+    int rc = valid_s3_object_name(obj_name);
+    if (rc != 0)
+      return rc;
 
     return 0;
   }
@@ -2169,8 +2170,9 @@ public:
     dest_object = dst_parent->format_child_name(dst_name);
     // need s->object_name?
 
-    if (! valid_s3_object_name(dest_object))
-      return -ERR_INVALID_OBJECT_NAME;
+    int rc = valid_s3_object_name(dest_object);
+    if (rc != 0)
+      return rc;
 
     /* XXX and fixup key attr (could optimize w/string ref and
      * dest_object) */

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -610,14 +610,14 @@ static inline bool looks_like_ip_address(const char *bucket)
   return (num_periods == 3);
 }
 
-static inline bool valid_s3_object_name(const string& name) {
+static inline int valid_s3_object_name(const string& name) {
   if (name.size() > 1024) {
-    return false;
+    return -ERR_INVALID_OBJECT_NAME;
   }
   if (check_utf8(name.c_str(), name.size())) {
-    return false;
+    return -ERR_INVALID_OBJECT_NAME;
   }
-  return true;
+  return 0;
 }
 
 static inline int valid_s3_bucket_name(const string& name, bool relaxed=false)


### PR DESCRIPTION
When exec the following cmd in RGW FS, we get EINVAL:
	> mkdir <very/long/path> -p
Because the path name exceeds 1024 which is the max object name
length for s3.
Actually we should get ENAMETOOLONG here in posix, so we could
make the validation check functions return the exact errcode inside
and let the callers decide what behavior they want.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>