### PR TITLE
hammer: upstart: radosgw-all does not start on boot if ceph-base is not installed

### DIFF
--- a/src/upstart/radosgw-all.conf
+++ b/src/upstart/radosgw-all.conf
@@ -1,4 +1,4 @@
 description "Ceph radosgw (all instances)"
 
-start on starting ceph-all
+start on starting ceph-all or runlevel [2345]
 stop on runlevel [!2345] or stopping ceph-all


### PR DESCRIPTION
http://tracker.ceph.com/issues/18854