### PR TITLE
jewel: librgw: RGWLibFS::setattr fails on directories

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -571,6 +571,10 @@ namespace rgw {
     buffer::list ux_key, ux_attrs;
     string obj_name{rgw_fh->relative_object_name()};
 
+    if (rgw_fh->is_dir()) {
+      obj_name += "/";
+    }
+
     RGWSetAttrsRequest req(cct, get_user(), rgw_fh->bucket_name(), obj_name);
 
     rgw_fh->create_stat(st, mask);


### PR DESCRIPTION
http://tracker.ceph.com/issues/18811