### PR TITLE
jewel: rgw: 'radosgw-admin sync status' on master zone of non-master zonegroup

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1977,7 +1977,7 @@ static void sync_status(Formatter *formatter)
 
   list<string> md_status;
 
-  if (zone.id == zonegroup.master_zone) {
+  if (store->is_meta_master()) {
     md_status.push_back("no sync (zone is master)");
   } else {
     get_md_sync_status(md_status);


### PR DESCRIPTION
http://tracker.ceph.com/issues/18866