### PR TITLE
build/ops: make package groups comply with openSUSE guidelines

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -59,7 +59,7 @@
 # disable dwz which compresses the debuginfo
 %global _find_debuginfo_dwz_opts %{nil}
 #################################################################################
-# common
+# main package definition
 #################################################################################
 Name:		ceph
 Version:	@VERSION@
@@ -68,7 +68,7 @@ Epoch:		1
 Summary:	User space components of the Ceph file system
 License:	LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
 %if 0%{?suse_version}
-Group:         System/Filesystems
+Group:		System/Filesystems
 %endif
 URL:		http://ceph.com/
 Source0:	http://ceph.com/download/@TARBALL_BASENAME@.tar.bz2
@@ -209,11 +209,13 @@ on commodity hardware and delivers object, block and file system storage.
 
 
 #################################################################################
-# packages
+# subpackages
 #################################################################################
 %package base
 Summary:       Ceph Base Package
-Group:         System Environment/Base
+%if 0%{?suse_version}
+Group:         System/Filesystems
+%endif
 Requires:      ceph-common = %{epoch}:%{version}-%{release}
 Requires:      librbd1 = %{epoch}:%{version}-%{release}
 Requires:      librados2 = %{epoch}:%{version}-%{release}
@@ -244,7 +246,9 @@ Base is the package that includes all the files shared amongst ceph servers
 
 %package -n ceph-common
 Summary:	Ceph Common
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
@@ -266,7 +270,9 @@ Comprised of files that are common to Ceph clients and servers.
 
 %package mds
 Summary:	Ceph Metadata Server Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{epoch}:%{version}-%{release}
 %description mds
 ceph-mds is the metadata server daemon for the Ceph distributed file system.
@@ -275,7 +281,9 @@ namespace, coordinating access to the shared OSD cluster.
 
 %package mon
 Summary:	Ceph Monitor Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{epoch}:%{version}-%{release}
 # For ceph-rest-api
 %if 0%{?fedora} || 0%{?rhel}
@@ -293,7 +301,9 @@ of cluster membership, configuration, and state.
 %package mgr
 Summary:        Ceph Manager Daemon
 License:        LGPL-2.1 and CC-BY-SA-1.0 and GPL-2.0 and BSL-1.0 and GPL-2.0-with-autoconf-exception and BSD-3-Clause and MIT
-Group:          System Environment/Base
+%if 0%{?suse_version}
+Group:          System/Filesystems
+%endif
 Requires:       ceph-base = %{epoch}:%{version}-%{release}
 
 %description mgr
@@ -304,13 +314,17 @@ exposes all these to the python modules.
 
 %package fuse
 Summary:	Ceph fuse-based client
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 %description fuse
 FUSE based client for Ceph distributed network file system
 
 %package -n rbd-fuse
 Summary:	Ceph fuse-based client
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 %description -n rbd-fuse
@@ -318,7 +332,9 @@ FUSE based client to map Ceph rbd images to files
 
 %package -n rbd-mirror
 Summary:	Ceph daemon for mirroring RBD images
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-common = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 %description -n rbd-mirror
@@ -327,7 +343,9 @@ changes asynchronously.
 
 %package -n rbd-nbd
 Summary:	Ceph RBD client base on NBD
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 %description -n rbd-nbd
@@ -335,7 +353,9 @@ NBD based client to map Ceph rbd images to local device
 
 %package radosgw
 Summary:	Rados REST gateway
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-common = %{epoch}:%{version}-%{release}
 %if 0%{with selinux}
 Requires:	ceph-selinux = %{epoch}:%{version}-%{release}
@@ -354,7 +374,9 @@ service as well as the OpenStack Object Storage ("Swift") API.
 %if %{with ocf}
 %package resource-agents
 Summary:	OCF-compliant resource agents for Ceph daemons
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 License:	LGPL-2.0
 Requires:	ceph-base = %{epoch}:%{version}
 Requires:	resource-agents
@@ -366,7 +388,9 @@ managers such as Pacemaker.
 
 %package osd
 Summary:	Ceph Object Storage Daemon
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{epoch}:%{version}-%{release}
 # for sgdisk, used by ceph-disk
 %if 0%{?fedora} || 0%{?rhel}
@@ -383,7 +407,9 @@ and providing access to them over the network.
 
 %package -n librados2
 Summary:	RADOS distributed object store client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{epoch}:%{version}-%{release}
@@ -396,7 +422,9 @@ store using a simple file-like interface.
 
 %package -n librados-devel
 Summary:	RADOS headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Obsoletes:	ceph-devel < %{epoch}:%{version}-%{release}
@@ -408,7 +436,9 @@ that use RADOS object store.
 
 %package -n librgw2
 Summary:	RADOS gateway client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 %description -n librgw2
@@ -417,7 +447,9 @@ This package provides a library implementation of the RADOS gateway
 
 %package -n librgw-devel
 Summary:	RADOS gateway client library
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librados-devel = %{epoch}:%{version}-%{release}
 Requires:	librgw2 = %{epoch}:%{version}-%{release}
@@ -429,7 +461,9 @@ that use RADOS gateway client library.
 
 %package -n python-rgw
 Summary:	Python 2 libraries for the RADOS gateway
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librgw2 = %{epoch}:%{version}-%{release}
 Requires:	python-rados = %{epoch}:%{version}-%{release}
@@ -440,7 +474,9 @@ gateway.
 
 %package -n python%{python3_pkgversion}-rgw
 Summary:	Python 3 libraries for the RADOS gateway
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librgw2 = %{epoch}:%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
@@ -450,7 +486,9 @@ gateway.
 
 %package -n python-rados
 Summary:	Python 2 libraries for the RADOS object store
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Obsoletes:	python-ceph < %{epoch}:%{version}-%{release}
@@ -460,7 +498,9 @@ object store.
 
 %package -n python%{python3_pkgversion}-rados
 Summary:	Python 3 libraries for the RADOS object store
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	python%{python3_pkgversion}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
@@ -470,7 +510,9 @@ object store.
 
 %package -n libradosstriper1
 Summary:	RADOS striping interface
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 %description -n libradosstriper1
@@ -480,7 +522,9 @@ an interface very similar to the rados one.
 
 %package -n libradosstriper-devel
 Summary:	RADOS striping interface headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	libradosstriper1 = %{epoch}:%{version}-%{release}
 Requires:	librados-devel = %{epoch}:%{version}-%{release}
@@ -493,7 +537,9 @@ that use RADOS striping interface.
 
 %package -n librbd1
 Summary:	RADOS block device client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 %if 0%{?rhel} || 0%{?fedora}
@@ -507,7 +553,9 @@ shared library allowing applications to manage these block devices.
 
 %package -n librbd-devel
 Summary:	RADOS block device headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados-devel = %{epoch}:%{version}-%{release}
@@ -520,7 +568,9 @@ that use RADOS block device.
 
 %package -n python-rbd
 Summary:	Python 2 libraries for the RADOS block device
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	python-rados = %{epoch}:%{version}-%{release}
@@ -531,7 +581,9 @@ block device.
 
 %package -n python%{python3_pkgversion}-rbd
 Summary:	Python 3 libraries for the RADOS block device
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
@@ -541,7 +593,9 @@ block device.
 
 %package -n libcephfs2
 Summary:	Ceph distributed file system client library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{epoch}:%{version}-%{release}
@@ -555,7 +609,9 @@ POSIX-like interface.
 
 %package -n libcephfs-devel
 Summary:	Ceph distributed file system headers
-Group:		Development/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/C and C++
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
 Requires:	librados-devel = %{epoch}:%{version}-%{release}
@@ -568,7 +624,9 @@ that use Cephs distributed file system.
 
 %package -n python-cephfs
 Summary:	Python 2 libraries for Ceph distributed file system
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
 %if 0%{?suse_version}
@@ -581,7 +639,9 @@ file system.
 
 %package -n python%{python3_pkgversion}-cephfs
 Summary:	Python 3 libraries for Ceph distributed file system
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
 Requires:	python%{python3_pkgversion}-rados = %{epoch}:%{version}-%{release}
@@ -591,7 +651,9 @@ file system.
 
 %package -n python%{python3_pkgversion}-ceph-argparse
 Summary:	Python 3 utility libraries for Ceph CLI
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 %description -n python%{python3_pkgversion}-ceph-argparse
 This package contains types and routines for Python 3 used by the Ceph CLI as
@@ -602,7 +664,9 @@ descriptions, and submitting the command to the appropriate daemon.
 %if 0%{with ceph_test_package}
 %package -n ceph-test
 Summary:	Ceph benchmarks and test tools
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Benchmark
+%endif
 License:	LGPL-2.0
 Requires:	ceph-common
 Requires:	xmlstarlet
@@ -614,7 +678,9 @@ This package contains Ceph benchmarks and test tools.
 
 %package -n libcephfs_jni1
 Summary:	Java Native Interface library for CephFS Java bindings
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
@@ -624,7 +690,9 @@ bindings.
 
 %package -n libcephfs_jni-devel
 Summary:	Development files for CephFS Java Native Interface library
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Libraries/Java
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{epoch}:%{version}-%{release}
@@ -637,7 +705,9 @@ library.
 
 %package -n cephfs-java
 Summary:	Java libraries for the Ceph File System
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		System/Libraries
+%endif
 License:	LGPL-2.0
 Requires:	java
 Requires:	libcephfs_jni1 = %{epoch}:%{version}-%{release}
@@ -652,7 +722,9 @@ This package contains the Java libraries for the Ceph File System.
 
 %package selinux
 Summary:	SELinux support for Ceph MON, OSD and MDS
-Group:		System Environment/Base
+%if 0%{?suse_version}
+Group:		System/Filesystems
+%endif
 Requires:	ceph-base = %{epoch}:%{version}-%{release}
 Requires:	policycoreutils, libselinux-utils
 Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils, gawk
@@ -666,7 +738,9 @@ populated file-systems.
 
 %package -n python-ceph-compat
 Summary:	Compatibility package for Cephs python libraries
-Group:		System Environment/Libraries
+%if 0%{?suse_version}
+Group:		Development/Languages/Python
+%endif
 License:	LGPL-2.0
 Obsoletes:	python-ceph
 Requires:	python-rados = %{epoch}:%{version}-%{release}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -2,7 +2,7 @@
 #
 # spec file for package ceph
 #
-# Copyright (C) 2004-2016 The Ceph Project Developers. See COPYING file
+# Copyright (C) 2004-2017 The Ceph Project Developers. See COPYING file
 # at the top-level directory of this distribution and at
 # https://github.com/ceph/ceph/blob/master/COPYING
 #


### PR DESCRIPTION
. . . and put all Group: lines in SUSE conditional blocks.

Fixes: http://tracker.ceph.com/issues/19184
Signed-off-by: Nathan Cutler <ncutler@suse.com>