### PR TITLE
rgw: if user.email is empty, dont try to delete

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8421,6 +8421,11 @@ int RGWRados::delete_obj(RGWObjectCtx& obj_ctx,
 
 int RGWRados::delete_system_obj(rgw_obj& obj, RGWObjVersionTracker *objv_tracker)
 {
+  if (obj.get_object().empty()) {
+    ldout(cct, 1) << "delete_system_obj got empty object name "
+        << obj << ", returning EINVAL" << dendl;
+    return -EINVAL;
+  }
   rgw_rados_ref ref;
   rgw_bucket bucket;
   int r = get_obj_ref(obj, &ref, &bucket);

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -375,9 +375,11 @@ int rgw_remove_uid_index(RGWRados *store, rgw_user& uid)
 
 int rgw_remove_email_index(RGWRados *store, string& email)
 {
+  if (email.empty()) {
+    return 0;
+  }
   rgw_obj obj(store->get_zone_params().user_email_pool, email);
-  int ret = store->delete_system_obj(obj);
-  return ret;
+  return store->delete_system_obj(obj);
 }
 
 int rgw_remove_swift_name_index(RGWRados *store, string& swift_name)
@@ -445,11 +447,11 @@ int rgw_delete_user(RGWRados *store, RGWUserInfo& info, RGWObjVersionTracker& ob
     }
   }
 
-  rgw_obj email_obj(store->get_zone_params().user_email_pool, info.user_email);
   ldout(store->ctx(), 10) << "removing email index: " << info.user_email << dendl;
-  ret = store->delete_system_obj(email_obj);
+  ret = rgw_remove_email_index(store, info.user_email);
   if (ret < 0 && ret != -ENOENT) {
-    ldout(store->ctx(), 0) << "ERROR: could not remove " << info.user_id << ":" << email_obj << ", should be fixed (err=" << ret << ")" << dendl;
+    ldout(store->ctx(), 0) << "ERROR: could not remove email index object for "
+        << info.user_email << ", should be fixed (err=" << ret << ")" << dendl;
     return ret;
   }
 


### PR DESCRIPTION
`rgw_delete_user()` was attempting to delete the email index object even if the user's email address was empty. this was causing the osds to issue a cluster warning about `bad locator @9 on object @9...` and led to many teuthology failures

`rgw_delete_user()` now uses `rgw_remove_email_index()`, which has a new check for empty email address

`RGWRados::delete_system_obj()` also has a new check for empty object name, which it will reject immediately with `-EINVAL` to catch any other related issues

Fixes: http://tracker.ceph.com/issues/18980