### PR TITLE
jewel: build/ops: ceph-base package missing dependency for psmisc

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -214,6 +214,7 @@ Requires:      util-linux
 Requires:      hdparm
 Requires:      cryptsetup
 Requires:      findutils
+Requires:      psmisc
 Requires:      which
 %if 0%{?suse_version}
 Recommends:    ntp-daemon

--- a/debian/control
+++ b/debian/control
@@ -93,6 +93,7 @@ Depends: binutils,
          python-argparse | libpython2.7-stdlib,
          python-pkg-resources,
          sdparm | hdparm,
+         psmisc,
          xfsprogs,
          ${misc:Depends},
          ${shlibs:Depends}


### PR DESCRIPTION
http://tracker.ceph.com/issues/19142

Modify:
	debian/control (jewel does not have f11acf2b 7e71cd2c)