### PR TITLE
librbd: rbd ack cleanup

### DIFF
--- a/src/librbd/AsyncRequest.cc
+++ b/src/librbd/AsyncRequest.cc
@@ -27,7 +27,7 @@ void AsyncRequest<T>::async_complete(int r) {
 
 template <typename T>
 librados::AioCompletion *AsyncRequest<T>::create_callback_completion() {
-  return util::create_rados_safe_callback(this);
+  return util::create_rados_callback(this);
 }
 
 template <typename T>

--- a/src/librbd/DiffIterate.cc
+++ b/src/librbd/DiffIterate.cc
@@ -61,7 +61,7 @@ public:
   void send() {
     C_OrderedThrottle *ctx = m_diff_context.throttle.start_op(this);
     librados::AioCompletion *rados_completion =
-      util::create_rados_safe_callback(ctx);
+      util::create_rados_callback(ctx);
 
     librados::ObjectReadOperation op;
     op.list_snaps(&m_snap_set, &m_snap_ret);

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -27,7 +27,7 @@ using namespace image_watcher;
 using namespace watch_notify;
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 using librbd::watcher::HandlePayloadVisitor;
 using librbd::watcher::C_NotifyAck;
 

--- a/src/librbd/LibrbdWriteback.cc
+++ b/src/librbd/LibrbdWriteback.cc
@@ -216,7 +216,7 @@ namespace librbd {
     int flags = m_ictx->get_read_flags(snapid);
 
     librados::AioCompletion *rados_completion =
-      util::create_rados_ack_callback(req);
+      util::create_rados_callback(req);
     int r = m_ictx->data_ctx.aio_operate(oid.name, rados_completion, &op,
 					 flags, NULL);
     rados_completion->release();

--- a/src/librbd/MirroringWatcher.cc
+++ b/src/librbd/MirroringWatcher.cc
@@ -46,7 +46,7 @@ void MirroringWatcher<I>::notify_mode_updated(librados::IoCtx &io_ctx,
   bufferlist bl;
   ::encode(NotifyMessage{ModeUpdatedPayload{mirror_mode}}, bl);
 
-  librados::AioCompletion *comp = util::create_rados_ack_callback(on_finish);
+  librados::AioCompletion *comp = util::create_rados_callback(on_finish);
   int r = io_ctx.aio_notify(RBD_MIRRORING, comp, bl, NOTIFY_TIMEOUT_MS,
                             nullptr);
   assert(r == 0);
@@ -76,7 +76,7 @@ void MirroringWatcher<I>::notify_image_updated(
   ::encode(NotifyMessage{ImageUpdatedPayload{
       mirror_image_state, image_id, global_image_id}}, bl);
 
-  librados::AioCompletion *comp = util::create_rados_ack_callback(on_finish);
+  librados::AioCompletion *comp = util::create_rados_callback(on_finish);
   int r = io_ctx.aio_notify(RBD_MIRRORING, comp, bl, NOTIFY_TIMEOUT_MS,
                             nullptr);
   assert(r == 0);

--- a/src/librbd/ObjectMap.cc
+++ b/src/librbd/ObjectMap.cc
@@ -185,7 +185,7 @@ void ObjectMap<I>::aio_save(Context *on_finish) {
   cls_client::object_map_save(&op, m_object_map);
 
   std::string oid(object_map_name(m_image_ctx.id, m_snap_id));
-  librados::AioCompletion *comp = util::create_rados_safe_callback(on_finish);
+  librados::AioCompletion *comp = util::create_rados_callback(on_finish);
 
   int r = m_image_ctx.md_ctx.aio_operate(oid, comp, &op);
   assert(r == 0);

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -41,8 +41,8 @@ std::string unique_lock_name(const std::string &name, void *address) {
   return name + " (" + stringify(address) + ")";
 }
 
-librados::AioCompletion *create_rados_ack_callback(Context *on_finish) {
-  return create_rados_ack_callback<Context, &Context::complete>(on_finish);
+librados::AioCompletion *create_rados_callback(Context *on_finish) {
+  return create_rados_callback<Context, &Context::complete>(on_finish);
 }
 
 std::string generate_image_id(librados::IoCtx &ioctx) {

--- a/src/librbd/Utils.h
+++ b/src/librbd/Utils.h
@@ -100,42 +100,24 @@ const std::string header_name(const std::string &image_id);
 const std::string old_header_name(const std::string &image_name);
 std::string unique_lock_name(const std::string &name, void *address);
 
-librados::AioCompletion *create_rados_ack_callback(Context *on_finish);
+librados::AioCompletion *create_rados_callback(Context *on_finish);
 
 template <typename T>
-librados::AioCompletion *create_rados_ack_callback(T *obj) {
+librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
     obj, &detail::rados_callback<T>, nullptr);
 }
 
 template <typename T, void(T::*MF)(int)>
-librados::AioCompletion *create_rados_ack_callback(T *obj) {
+librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
     obj, &detail::rados_callback<T, MF>, nullptr);
 }
 
 template <typename T, Context*(T::*MF)(int*), bool destroy=true>
-librados::AioCompletion *create_rados_ack_callback(T *obj) {
+librados::AioCompletion *create_rados_callback(T *obj) {
   return librados::Rados::aio_create_completion(
     obj, &detail::rados_state_callback<T, MF, destroy>, nullptr);
-}
-
-template <typename T>
-librados::AioCompletion *create_rados_safe_callback(T *obj) {
-  return librados::Rados::aio_create_completion(
-    obj, nullptr, &detail::rados_callback<T>);
-}
-
-template <typename T, void(T::*MF)(int)>
-librados::AioCompletion *create_rados_safe_callback(T *obj) {
-  return librados::Rados::aio_create_completion(
-    obj, nullptr, &detail::rados_callback<T, MF>);
-}
-
-template <typename T, Context*(T::*MF)(int*), bool destroy=true>
-librados::AioCompletion *create_rados_safe_callback(T *obj) {
-  return librados::Rados::aio_create_completion(
-    obj, nullptr, &detail::rados_state_callback<T, MF, destroy>);
 }
 
 template <typename T, void(T::*MF)(int) = &T::complete>

--- a/src/librbd/Watcher.cc
+++ b/src/librbd/Watcher.cc
@@ -20,7 +20,7 @@ namespace librbd {
 using namespace watcher;
 
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 using std::string;
 
 namespace {
@@ -43,7 +43,7 @@ struct C_UnwatchAndFlush : public Context {
     if (!flushing) {
       flushing = true;
 
-      librados::AioCompletion *aio_comp = create_rados_safe_callback(this);
+      librados::AioCompletion *aio_comp = create_rados_callback(this);
       r = rados.aio_watch_flush(aio_comp);
       assert(r == 0);
       aio_comp->release();
@@ -87,7 +87,7 @@ void Watcher::register_watch(Context *on_finish) {
   assert(m_watch_state == WATCH_STATE_UNREGISTERED);
   m_watch_state = WATCH_STATE_REGISTERING;
 
-  librados::AioCompletion *aio_comp = create_rados_safe_callback(
+  librados::AioCompletion *aio_comp = create_rados_callback(
                                          new C_RegisterWatch(this, on_finish));
   int r = m_ioctx.aio_watch(m_oid, aio_comp, &m_watch_handle, &m_watch_ctx);
   assert(r == 0);
@@ -141,7 +141,7 @@ void Watcher::unregister_watch(Context *on_finish) {
         m_watch_state == WATCH_STATE_ERROR) {
       m_watch_state = WATCH_STATE_UNREGISTERED;
 
-      librados::AioCompletion *aio_comp = create_rados_safe_callback(
+      librados::AioCompletion *aio_comp = create_rados_callback(
                         new C_UnwatchAndFlush(m_ioctx, on_finish));
       int r = m_ioctx.aio_unwatch(m_watch_handle, aio_comp);
       assert(r == 0);

--- a/src/librbd/exclusive_lock/PostAcquireRequest.cc
+++ b/src/librbd/exclusive_lock/PostAcquireRequest.cc
@@ -28,9 +28,7 @@ namespace exclusive_lock {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_ack_callback;
-using util::create_rados_safe_callback;
-
+using util::create_rados_callback;
 
 template <typename I>
 PostAcquireRequest<I>* PostAcquireRequest<I>::create(I &image_ctx,

--- a/src/librbd/exclusive_lock/PreAcquireRequest.cc
+++ b/src/librbd/exclusive_lock/PreAcquireRequest.cc
@@ -19,9 +19,7 @@ namespace exclusive_lock {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_ack_callback;
-using util::create_rados_safe_callback;
-
+using util::create_rados_callback;
 
 template <typename I>
 PreAcquireRequest<I>* PreAcquireRequest<I>::create(I &image_ctx,

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -23,7 +23,7 @@
 namespace librbd {
 namespace image {
 
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 using util::create_context_callback;
 
 namespace {
@@ -276,7 +276,7 @@ void CreateRequest<I>::validate_pool() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_validate_pool>(this);
+    create_rados_callback<klass, &klass::handle_validate_pool>(this);
 
   librados::ObjectReadOperation op;
   op.stat(NULL, NULL, NULL);
@@ -340,7 +340,7 @@ void CreateRequest<I>::create_id_object() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_create_id_object>(this);
+    create_rados_callback<klass, &klass::handle_create_id_object>(this);
   int r = m_ioctx.aio_operate(m_id_obj, comp, &op);
   assert(r == 0);
   comp->release();
@@ -368,7 +368,7 @@ void CreateRequest<I>::add_image_to_directory() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_add_image_to_directory>(this);
+    create_rados_callback<klass, &klass::handle_add_image_to_directory>(this);
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, comp, &op);
   assert(r == 0);
   comp->release();
@@ -404,7 +404,7 @@ void CreateRequest<I>::negotiate_features() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_negotiate_features>(this);
+    create_rados_callback<klass, &klass::handle_negotiate_features>(this);
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, comp, &op, &m_outbl);
   assert(r == 0);
   comp->release();
@@ -456,7 +456,7 @@ void CreateRequest<I>::create_image() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_create_image>(this);
+    create_rados_callback<klass, &klass::handle_create_image>(this);
   int r = m_ioctx.aio_operate(m_header_obj, comp, &op);
   assert(r == 0);
   comp->release();
@@ -492,7 +492,7 @@ void CreateRequest<I>::set_stripe_unit_count() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_set_stripe_unit_count>(this);
+    create_rados_callback<klass, &klass::handle_set_stripe_unit_count>(this);
   int r = m_ioctx.aio_operate(m_header_obj, comp, &op);
   assert(r == 0);
   comp->release();
@@ -528,7 +528,7 @@ void CreateRequest<I>::object_map_resize() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_object_map_resize>(this);
+    create_rados_callback<klass, &klass::handle_object_map_resize>(this);
   int r = m_ioctx.aio_operate(m_objmap_name, comp, &op);
   assert(r == 0);
   comp->release();
@@ -564,7 +564,7 @@ void CreateRequest<I>::fetch_mirror_mode() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_fetch_mirror_mode>(this);
+    create_rados_callback<klass, &klass::handle_fetch_mirror_mode>(this);
   m_outbl.clear();
   int r = m_ioctx.aio_operate(RBD_MIRRORING, comp, &op, &m_outbl);
   assert(r == 0);
@@ -738,7 +738,7 @@ void CreateRequest<I>::remove_object_map() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_remove_object_map>(this);
+    create_rados_callback<klass, &klass::handle_remove_object_map>(this);
   int r = m_ioctx.aio_remove(m_objmap_name, comp);
   assert(r == 0);
   comp->release();
@@ -763,7 +763,7 @@ void CreateRequest<I>::remove_header_object() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_remove_header_object>(this);
+    create_rados_callback<klass, &klass::handle_remove_header_object>(this);
   int r = m_ioctx.aio_remove(m_header_obj, comp);
   assert(r == 0);
   comp->release();
@@ -791,7 +791,7 @@ void CreateRequest<I>::remove_from_dir() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_remove_from_dir>(this);
+    create_rados_callback<klass, &klass::handle_remove_from_dir>(this);
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, comp, &op);
   assert(r == 0);
   comp->release();
@@ -816,7 +816,7 @@ void CreateRequest<I>::remove_id_object() {
 
   using klass = CreateRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_remove_id_object>(this);
+    create_rados_callback<klass, &klass::handle_remove_id_object>(this);
   int r = m_ioctx.aio_remove(m_id_obj, comp);
   assert(r == 0);
   comp->release();

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -27,7 +27,7 @@ static uint64_t MAX_METADATA_ITEMS = 128;
 }
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 OpenRequest<I>::OpenRequest(I *image_ctx, bool skip_open_parent,
@@ -49,7 +49,7 @@ void OpenRequest<I>::send_v1_detect_header() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_v1_detect_header>(this);
+    create_rados_callback<klass, &klass::handle_v1_detect_header>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(util::old_header_name(m_image_ctx->name),
                                  comp, &op, &m_out_bl);
@@ -91,7 +91,7 @@ void OpenRequest<I>::send_v2_detect_header() {
 
     using klass = OpenRequest<I>;
     librados::AioCompletion *comp =
-      create_rados_ack_callback<klass, &klass::handle_v2_detect_header>(this);
+      create_rados_callback<klass, &klass::handle_v2_detect_header>(this);
     m_out_bl.clear();
     m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
                                    comp, &op, &m_out_bl);
@@ -130,7 +130,7 @@ void OpenRequest<I>::send_v2_get_id() {
 
     using klass = OpenRequest<I>;
     librados::AioCompletion *comp =
-      create_rados_ack_callback<klass, &klass::handle_v2_get_id>(this);
+      create_rados_callback<klass, &klass::handle_v2_get_id>(this);
     m_out_bl.clear();
     m_image_ctx->md_ctx.aio_operate(util::id_obj_name(m_image_ctx->name),
                                     comp, &op, &m_out_bl);
@@ -168,7 +168,7 @@ void OpenRequest<I>::send_v2_get_name() {
   cls_client::dir_get_name_start(&op, m_image_ctx->id);
 
   using klass = OpenRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_name>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(RBD_DIRECTORY, comp, &op, &m_out_bl);
@@ -207,7 +207,7 @@ void OpenRequest<I>::send_v2_get_immutable_metadata() {
   cls_client::get_immutable_metadata_start(&op);
 
   using klass = OpenRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_immutable_metadata>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
@@ -245,7 +245,7 @@ void OpenRequest<I>::send_v2_get_stripe_unit_count() {
   cls_client::get_stripe_unit_count_start(&op);
 
   using klass = OpenRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_stripe_unit_count>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
@@ -288,7 +288,7 @@ void OpenRequest<I>::send_v2_get_data_pool() {
   cls_client::get_data_pool_start(&op);
 
   using klass = OpenRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_data_pool>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
@@ -343,7 +343,7 @@ void OpenRequest<I>::send_v2_apply_metadata() {
 
   using klass = OpenRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_v2_apply_metadata>(this);
+    create_rados_callback<klass, &klass::handle_v2_apply_metadata>(this);
   m_out_bl.clear();
   m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op,
                                   &m_out_bl);

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -22,7 +22,7 @@
 namespace librbd {
 namespace image {
 
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 using util::create_async_context_callback;
 using util::create_context_callback;
 
@@ -64,7 +64,7 @@ void RefreshRequest<I>::send_v1_read_header() {
   op.read(0, 0, nullptr, nullptr);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v1_read_header>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -109,7 +109,7 @@ void RefreshRequest<I>::send_v1_get_snapshots() {
   cls_client::old_snapshot_list_start(&op);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v1_get_snapshots>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -161,7 +161,7 @@ void RefreshRequest<I>::send_v1_get_locks() {
   rados::cls::lock::get_lock_info_start(&op, RBD_LOCK_NAME);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v1_get_locks>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -236,7 +236,7 @@ void RefreshRequest<I>::send_v2_get_mutable_metadata() {
   cls_client::get_mutable_metadata_start(&op, read_only);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_mutable_metadata>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -298,7 +298,7 @@ void RefreshRequest<I>::send_v2_get_flags() {
   cls_client::get_flags_start(&op, m_snapc.snaps);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_flags>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -352,7 +352,7 @@ void RefreshRequest<I>::send_v2_get_group() {
   cls_client::image_get_group_start(&op);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_group>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -405,7 +405,7 @@ void RefreshRequest<I>::send_v2_get_snapshots() {
   cls_client::snapshot_list_start(&op, m_snapc.snaps);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_snapshots>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -451,7 +451,7 @@ void RefreshRequest<I>::send_v2_get_snap_timestamps() {
   cls_client::snapshot_timestamp_list_start(&op, m_snapc.snaps);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
 		  klass, &klass::handle_v2_get_snap_timestamps>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
@@ -495,7 +495,7 @@ void RefreshRequest<I>::send_v2_get_snap_namespaces() {
   cls_client::snapshot_namespace_list_start(&op, m_snapc.snaps);
 
   using klass = RefreshRequest<I>;
-  librados::AioCompletion *comp = create_rados_ack_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     klass, &klass::handle_v2_get_snap_namespaces>(this);
   m_out_bl.clear();
   int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -25,7 +25,7 @@ namespace image {
 using librados::IoCtx;
 using util::create_context_callback;
 using util::create_async_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template<typename I>
 RemoveRequest<I>::RemoveRequest(IoCtx &ioctx, const std::string &image_name,
@@ -173,7 +173,7 @@ void RemoveRequest<I>::check_image_watchers() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_check_image_watchers>(this);
+    create_rados_callback<klass, &klass::handle_check_image_watchers>(this);
 
   int r = m_image_ctx->md_ctx.aio_operate(m_header_oid, rados_completion,
                                           &op, &m_out_bl);
@@ -256,7 +256,7 @@ void RemoveRequest<I>::check_image_consistency_group() {
   librbd::cls_client::image_get_group_start(&op);
 
   using klass = RemoveRequest<I>;
-  librados::AioCompletion *rados_completion = create_rados_ack_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     klass, &klass::handle_check_image_consistency_group>(this);
   m_out_bl.clear();
   int r = m_image_ctx->md_ctx.aio_operate(m_header_oid, rados_completion, &op,
@@ -340,7 +340,7 @@ void RemoveRequest<I>::remove_child() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_remove_child>(this);
+    create_rados_callback<klass, &klass::handle_remove_child>(this);
   int r = m_image_ctx->md_ctx.aio_operate(RBD_CHILDREN, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();
@@ -430,7 +430,7 @@ void RemoveRequest<I>::remove_header() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_remove_header>(this);
+    create_rados_callback<klass, &klass::handle_remove_header>(this);
   int r = m_ioctx.aio_remove(m_header_oid, rados_completion);
   assert(r == 0);
   rados_completion->release();
@@ -459,7 +459,7 @@ void RemoveRequest<I>::remove_header_v2() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_remove_header_v2>(this);
+    create_rados_callback<klass, &klass::handle_remove_header_v2>(this);
   int r = m_ioctx.aio_remove(m_header_oid, rados_completion);
   assert(r == 0);
   rados_completion->release();
@@ -513,7 +513,7 @@ void RemoveRequest<I>::send_object_map_remove() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_object_map_remove>(this);
+    create_rados_callback<klass, &klass::handle_object_map_remove>(this);
 
   int r = ObjectMap<>::aio_remove(m_ioctx,
 				  m_image_id,
@@ -547,7 +547,7 @@ void RemoveRequest<I>::mirror_image_remove() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_mirror_image_remove>(this);
+    create_rados_callback<klass, &klass::handle_mirror_image_remove>(this);
   int r = m_ioctx.aio_operate(RBD_MIRRORING, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();
@@ -638,7 +638,7 @@ void RemoveRequest<I>::dir_get_image_id() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_dir_get_image_id>(this);
+    create_rados_callback<klass, &klass::handle_dir_get_image_id>(this);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op, &m_out_bl);
   assert(r == 0);
@@ -676,7 +676,7 @@ void RemoveRequest<I>::dir_get_image_name() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_dir_get_image_name>(this);
+    create_rados_callback<klass, &klass::handle_dir_get_image_name>(this);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op, &m_out_bl);
   assert(r == 0);
@@ -711,7 +711,7 @@ void RemoveRequest<I>::remove_id_object() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_remove_id_object>(this);
+    create_rados_callback<klass, &klass::handle_remove_id_object>(this);
   int r = m_ioctx.aio_remove(util::id_obj_name(m_image_name), rados_completion);
   assert(r == 0);
   rados_completion->release();
@@ -740,7 +740,7 @@ void RemoveRequest<I>::dir_remove_image() {
 
   using klass = RemoveRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_dir_remove_image>(this);
+    create_rados_callback<klass, &klass::handle_dir_remove_image>(this);
   int r = m_ioctx.aio_operate(RBD_DIRECTORY, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/image/SetFlagsRequest.cc
+++ b/src/librbd/image/SetFlagsRequest.cc
@@ -17,7 +17,7 @@ namespace librbd {
 namespace image {
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 SetFlagsRequest<I>::SetFlagsRequest(I *image_ctx, uint64_t flags,
@@ -52,7 +52,7 @@ void SetFlagsRequest<I>::send_set_flags() {
     cls_client::set_flags(&op, snap_id, m_flags, m_mask);
 
     librados::AioCompletion *comp =
-      create_rados_ack_callback(gather_ctx->new_sub());
+      create_rados_callback(gather_ctx->new_sub());
     int r = m_image_ctx->md_ctx.aio_operate(m_image_ctx->header_oid, comp, &op);
     assert(r == 0);
     comp->release();

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -147,7 +147,7 @@ bool CopyupRequest::send_copyup() {
 
     ldout(m_ictx->cct, 20) << __func__ << " " << this << " copyup with "
                            << "empty snapshot context" << dendl;
-    librados::AioCompletion *comp = util::create_rados_safe_callback(this);
+    librados::AioCompletion *comp = util::create_rados_callback(this);
 
     librados::Rados rados(m_ictx->data_ctx);
     r = rados.ioctx_create2(m_ictx->data_ctx.get_id(), m_data_ctx);
@@ -175,7 +175,7 @@ bool CopyupRequest::send_copyup() {
     assert(write_op.size() != 0);
 
     snaps.insert(snaps.end(), snapc.snaps.begin(), snapc.snaps.end());
-    librados::AioCompletion *comp = util::create_rados_safe_callback(this);
+    librados::AioCompletion *comp = util::create_rados_callback(this);
     r = m_ictx->data_ctx.aio_operate(m_oid, comp, &write_op);
     assert(r == 0);
     comp->release();

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -292,7 +292,7 @@ void ObjectReadRequest<I>::send() {
   op.set_op_flags2(m_op_flags);
 
   librados::AioCompletion *rados_completion =
-    util::create_rados_ack_callback(this);
+    util::create_rados_callback(this);
   int r = image_ctx->data_ctx.aio_operate(this->m_oid, rados_completion, &op,
                                           flags, nullptr);
   assert(r == 0);
@@ -556,7 +556,7 @@ void AbstractObjectWriteRequest::send_write_op()
   assert(m_write.size() != 0);
 
   librados::AioCompletion *rados_completion =
-    util::create_rados_safe_callback(this);
+    util::create_rados_callback(this);
   int r = m_ictx->data_ctx.aio_operate(m_oid, rados_completion, &m_write,
                                        m_snap_seq, m_snaps);
   assert(r == 0);

--- a/src/librbd/managed_lock/AcquireRequest.cc
+++ b/src/librbd/managed_lock/AcquireRequest.cc
@@ -26,8 +26,7 @@ namespace librbd {
 
 using librbd::util::detail::C_AsyncCallback;
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_safe_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 namespace managed_lock {
 
@@ -113,7 +112,7 @@ void AcquireRequest<I>::send_lock() {
 
   using klass = AcquireRequest;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_lock>(this);
+    create_rados_callback<klass, &klass::handle_lock>(this);
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/managed_lock/BreakRequest.cc
+++ b/src/librbd/managed_lock/BreakRequest.cc
@@ -20,8 +20,7 @@ namespace librbd {
 namespace managed_lock {
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 namespace {
 
@@ -73,7 +72,7 @@ void BreakRequest<I>::send_get_watchers() {
 
   using klass = BreakRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_get_watchers>(this);
+    create_rados_callback<klass, &klass::handle_get_watchers>(this);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op, &m_out_bl);
   assert(r == 0);
@@ -161,7 +160,7 @@ void BreakRequest<I>::send_break_lock() {
 
   using klass = BreakRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_break_lock>(this);
+    create_rados_callback<klass, &klass::handle_break_lock>(this);
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/managed_lock/GetLockerRequest.cc
+++ b/src/librbd/managed_lock/GetLockerRequest.cc
@@ -20,7 +20,7 @@
 namespace librbd {
 namespace managed_lock {
 
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 GetLockerRequest<I>::GetLockerRequest(librados::IoCtx& ioctx,
@@ -45,7 +45,7 @@ void GetLockerRequest<I>::send_get_lockers() {
 
   using klass = GetLockerRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_get_lockers>(this);
+    create_rados_callback<klass, &klass::handle_get_lockers>(this);
   m_out_bl.clear();
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op, &m_out_bl);
   assert(r == 0);

--- a/src/librbd/managed_lock/ReacquireRequest.cc
+++ b/src/librbd/managed_lock/ReacquireRequest.cc
@@ -21,7 +21,7 @@ using std::string;
 namespace librbd {
 namespace managed_lock {
 
-using librbd::util::create_rados_safe_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 ReacquireRequest<I>::ReacquireRequest(librados::IoCtx& ioctx,
@@ -51,7 +51,7 @@ void ReacquireRequest<I>::set_cookie() {
                                m_old_cookie, util::get_watcher_lock_tag(),
                                m_new_cookie);
 
-  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     ReacquireRequest, &ReacquireRequest::handle_set_cookie>(this);
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op);
   assert(r == 0);

--- a/src/librbd/managed_lock/ReleaseRequest.cc
+++ b/src/librbd/managed_lock/ReleaseRequest.cc
@@ -21,7 +21,7 @@ namespace managed_lock {
 
 using util::detail::C_AsyncCallback;
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 template <typename I>
 ReleaseRequest<I>* ReleaseRequest<I>::create(librados::IoCtx& ioctx,
@@ -62,7 +62,7 @@ void ReleaseRequest<I>::send_unlock() {
 
   using klass = ReleaseRequest;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_unlock>(this);
+    create_rados_callback<klass, &klass::handle_unlock>(this);
   int r = m_ioctx.aio_operate(m_oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/mirror/DisableRequest.cc
+++ b/src/librbd/mirror/DisableRequest.cc
@@ -22,7 +22,7 @@
 namespace librbd {
 namespace mirror {
 
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 DisableRequest<I>::DisableRequest(I *image_ctx, bool force, bool remove,
@@ -46,7 +46,7 @@ void DisableRequest<I>::send_get_mirror_image() {
 
   using klass = DisableRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_get_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_get_mirror_image>(this);
   m_out_bl.clear();
   int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
   assert(r == 0);
@@ -128,7 +128,7 @@ void DisableRequest<I>::send_set_mirror_image() {
 
   using klass = DisableRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_set_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_set_mirror_image>(this);
   m_out_bl.clear();
   int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, comp, &op);
   assert(r == 0);
@@ -364,7 +364,7 @@ void DisableRequest<I>::send_unregister_client(
   librados::ObjectWriteOperation op;
   cls::journal::client::client_unregister(&op, client_id);
   std::string header_oid = ::journal::Journaler::header_oid(m_image_ctx->id);
-  librados::AioCompletion *comp = create_rados_ack_callback(ctx);
+  librados::AioCompletion *comp = create_rados_callback(ctx);
 
   int r = m_image_ctx->md_ctx.aio_operate(header_oid, comp, &op);
   assert(r == 0);
@@ -411,7 +411,7 @@ void DisableRequest<I>::send_remove_mirror_image() {
 
   using klass = DisableRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_remove_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_remove_mirror_image>(this);
   m_out_bl.clear();
   int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, comp, &op);
   assert(r == 0);

--- a/src/librbd/mirror/EnableRequest.cc
+++ b/src/librbd/mirror/EnableRequest.cc
@@ -18,7 +18,7 @@ namespace librbd {
 namespace mirror {
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 EnableRequest<I>::EnableRequest(librados::IoCtx &io_ctx,
@@ -80,7 +80,7 @@ void EnableRequest<I>::send_get_mirror_image() {
 
   using klass = EnableRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_get_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_get_mirror_image>(this);
   m_out_bl.clear();
   int r = m_io_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
   assert(r == 0);
@@ -136,7 +136,7 @@ void EnableRequest<I>::send_set_mirror_image() {
 
   using klass = EnableRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_set_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_set_mirror_image>(this);
   m_out_bl.clear();
   int r = m_io_ctx.aio_operate(RBD_MIRRORING, comp, &op);
   assert(r == 0);

--- a/src/librbd/object_map/CreateRequest.cc
+++ b/src/librbd/object_map/CreateRequest.cc
@@ -18,7 +18,7 @@ namespace librbd {
 namespace object_map {
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 CreateRequest<I>::CreateRequest(I *image_ctx, Context *on_finish)
@@ -67,7 +67,7 @@ void CreateRequest<I>::send_object_map_resize() {
 				  OBJECT_NONEXISTENT);
 
     std::string oid(ObjectMap<>::object_map_name(m_image_ctx->id, snap_id));
-    librados::AioCompletion *comp = create_rados_ack_callback(gather_ctx->new_sub());
+    librados::AioCompletion *comp = create_rados_callback(gather_ctx->new_sub());
     int r = m_image_ctx->md_ctx.aio_operate(oid, comp, &op);
     assert(r == 0);
     comp->release();

--- a/src/librbd/object_map/LockRequest.cc
+++ b/src/librbd/object_map/LockRequest.cc
@@ -16,8 +16,7 @@
 namespace librbd {
 namespace object_map {
 
-using util::create_rados_ack_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 template <typename I>
 LockRequest<I>::LockRequest(I &image_ctx, Context *on_finish)
@@ -41,7 +40,7 @@ void LockRequest<I>::send_lock() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_lock>(this);
+    create_rados_callback<klass, &klass::handle_lock>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();
@@ -80,7 +79,7 @@ void LockRequest<I>::send_get_lock_info() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_get_lock_info>(this);
+    create_rados_callback<klass, &klass::handle_get_lock_info>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op, &m_out_bl);
   assert(r == 0);
   rados_completion->release();
@@ -129,7 +128,7 @@ void LockRequest<I>::send_break_locks() {
 
   using klass = LockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_break_locks>(this);
+    create_rados_callback<klass, &klass::handle_break_locks>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/object_map/RefreshRequest.cc
+++ b/src/librbd/object_map/RefreshRequest.cc
@@ -20,8 +20,7 @@
 namespace librbd {
 
 using util::create_context_callback;
-using util::create_rados_ack_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 namespace object_map {
 
@@ -105,7 +104,7 @@ void RefreshRequest<I>::send_load() {
   using klass = RefreshRequest<I>;
   m_out_bl.clear();
   librados::AioCompletion *rados_completion =
-    create_rados_ack_callback<klass, &klass::handle_load>(this);
+    create_rados_callback<klass, &klass::handle_load>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op, &m_out_bl);
   assert(r == 0);
   rados_completion->release();
@@ -234,7 +233,7 @@ void RefreshRequest<I>::send_resize() {
 
   using klass = RefreshRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_resize>(this);
+    create_rados_callback<klass, &klass::handle_resize>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/object_map/RemoveRequest.cc
+++ b/src/librbd/object_map/RemoveRequest.cc
@@ -17,7 +17,7 @@
 namespace librbd {
 namespace object_map {
 
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 RemoveRequest<I>::RemoveRequest(I *image_ctx, Context *on_finish)
@@ -50,7 +50,7 @@ void RemoveRequest<I>::send_remove_object_map() {
     std::string oid(ObjectMap<>::object_map_name(m_image_ctx->id, snap_id));
     using klass = RemoveRequest<I>;
     librados::AioCompletion *comp =
-      create_rados_ack_callback<klass, &klass::handle_remove_object_map>(this);
+      create_rados_callback<klass, &klass::handle_remove_object_map>(this);
 
     int r = m_image_ctx->md_ctx.aio_remove(oid, comp);
     assert(r == 0);

--- a/src/librbd/object_map/UnlockRequest.cc
+++ b/src/librbd/object_map/UnlockRequest.cc
@@ -16,7 +16,7 @@
 namespace librbd {
 namespace object_map {
 
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 template <typename I>
 UnlockRequest<I>::UnlockRequest(I &image_ctx, Context *on_finish)
@@ -39,7 +39,7 @@ void UnlockRequest<I>::send_unlock() {
 
   using klass = UnlockRequest<I>;
   librados::AioCompletion *rados_completion =
-    create_rados_safe_callback<klass, &klass::handle_unlock>(this);
+    create_rados_callback<klass, &klass::handle_unlock>(this);
   int r = m_image_ctx.md_ctx.aio_operate(oid, rados_completion, &op);
   assert(r == 0);
   rados_completion->release();

--- a/src/librbd/operation/DisableFeaturesRequest.cc
+++ b/src/librbd/operation/DisableFeaturesRequest.cc
@@ -25,7 +25,7 @@ namespace operation {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 DisableFeaturesRequest<I>::DisableFeaturesRequest(I &image_ctx,
@@ -228,7 +228,7 @@ void DisableFeaturesRequest<I>::send_get_mirror_mode() {
 
   using klass = DisableFeaturesRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_get_mirror_mode>(this);
+    create_rados_callback<klass, &klass::handle_get_mirror_mode>(this);
   m_out_bl.clear();
   int r = image_ctx.md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
   assert(r == 0);
@@ -276,7 +276,7 @@ void DisableFeaturesRequest<I>::send_get_mirror_image() {
 
   using klass = DisableFeaturesRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_get_mirror_image>(this);
+    create_rados_callback<klass, &klass::handle_get_mirror_image>(this);
   m_out_bl.clear();
   int r = image_ctx.md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
   assert(r == 0);
@@ -496,7 +496,7 @@ void DisableFeaturesRequest<I>::send_set_features() {
 
   using klass = DisableFeaturesRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_set_features>(this);
+    create_rados_callback<klass, &klass::handle_set_features>(this);
   int r = image_ctx.md_ctx.aio_operate(image_ctx.header_oid, comp, &op);
   assert(r == 0);
   comp->release();

--- a/src/librbd/operation/EnableFeaturesRequest.cc
+++ b/src/librbd/operation/EnableFeaturesRequest.cc
@@ -24,7 +24,7 @@ namespace operation {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_ack_callback;
+using util::create_rados_callback;
 
 template <typename I>
 EnableFeaturesRequest<I>::EnableFeaturesRequest(I &image_ctx,
@@ -132,7 +132,7 @@ void EnableFeaturesRequest<I>::send_get_mirror_mode() {
 
   using klass = EnableFeaturesRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_get_mirror_mode>(this);
+    create_rados_callback<klass, &klass::handle_get_mirror_mode>(this);
   m_out_bl.clear();
   int r = image_ctx.md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
   assert(r == 0);
@@ -340,7 +340,7 @@ void EnableFeaturesRequest<I>::send_set_features() {
 
   using klass = EnableFeaturesRequest<I>;
   librados::AioCompletion *comp =
-    create_rados_ack_callback<klass, &klass::handle_set_features>(this);
+    create_rados_callback<klass, &klass::handle_set_features>(this);
   int r = image_ctx.md_ctx.aio_operate(image_ctx.header_oid, comp, &op);
   assert(r == 0);
   comp->release();

--- a/src/librbd/operation/ObjectMapIterate.cc
+++ b/src/librbd/operation/ObjectMapIterate.cc
@@ -96,7 +96,7 @@ private:
     librados::ObjectReadOperation op;
     op.list_snaps(&m_snap_set, &m_snap_list_ret);
 
-    librados::AioCompletion *comp = util::create_rados_safe_callback(this);
+    librados::AioCompletion *comp = util::create_rados_callback(this);
     int r = m_io_ctx.aio_operate(m_oid, comp, &op, NULL);
     assert(r == 0);
     comp->release();

--- a/src/librbd/operation/ResizeRequest.cc
+++ b/src/librbd/operation/ResizeRequest.cc
@@ -21,7 +21,7 @@ namespace operation {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 template <typename I>
 ResizeRequest<I>::ResizeRequest(I &image_ctx, Context *on_finish,
@@ -391,7 +391,7 @@ void ResizeRequest<I>::send_update_header() {
     cls_client::set_size(&op, m_new_size);
   }
 
-  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     ResizeRequest<I>, &ResizeRequest<I>::handle_update_header>(this);
   int r = image_ctx.md_ctx.aio_operate(image_ctx.header_oid,
     				       rados_completion, &op);

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -20,7 +20,7 @@ namespace operation {
 
 using util::create_async_context_callback;
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 template <typename I>
 SnapshotCreateRequest<I>::SnapshotCreateRequest(I &image_ctx,
@@ -126,7 +126,7 @@ void SnapshotCreateRequest<I>::send_allocate_snap_id() {
   CephContext *cct = image_ctx.cct;
   ldout(cct, 5) << this << " " << __func__ << dendl;
 
-  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_allocate_snap_id>(this);
   image_ctx.md_ctx.aio_selfmanaged_snap_create(&m_snap_id, rados_completion);
@@ -177,7 +177,7 @@ void SnapshotCreateRequest<I>::send_create_snap() {
     cls_client::snapshot_add(&op, m_snap_id, m_snap_name, m_snap_namespace);
   }
 
-  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_create_snap>(this);
   int r = image_ctx.md_ctx.aio_operate(image_ctx.header_oid,
@@ -252,7 +252,7 @@ void SnapshotCreateRequest<I>::send_release_snap_id() {
 
   assert(m_snap_id != CEPH_NOSNAP);
 
-  librados::AioCompletion *rados_completion = create_rados_safe_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_release_snap_id>(this);
   image_ctx.md_ctx.aio_selfmanaged_snap_remove(m_snap_id, rados_completion);

--- a/src/librbd/operation/SnapshotRollbackRequest.cc
+++ b/src/librbd/operation/SnapshotRollbackRequest.cc
@@ -23,7 +23,7 @@ namespace librbd {
 namespace operation {
 
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 namespace {
 
@@ -48,7 +48,7 @@ public:
     op.selfmanaged_snap_rollback(m_snap_id);
 
     librados::AioCompletion *rados_completion =
-      util::create_rados_safe_callback(this);
+      util::create_rados_callback(this);
     image_ctx.data_ctx.aio_operate(oid, rados_completion, &op);
     rados_completion->release();
     return 0;

--- a/src/librbd/operation/SnapshotUnprotectRequest.cc
+++ b/src/librbd/operation/SnapshotUnprotectRequest.cc
@@ -102,7 +102,7 @@ public:
     cls_client::get_children_start(&op, m_pspec);
 
     librados::AioCompletion *rados_completion =
-      util::create_rados_ack_callback(this);
+      util::create_rados_callback(this);
     r = m_pool_ioctx.aio_operate(RBD_CHILDREN, rados_completion, &op,
                                  &m_children_bl);
     assert(r == 0);

--- a/src/librbd/operation/TrimRequest.cc
+++ b/src/librbd/operation/TrimRequest.cc
@@ -82,7 +82,7 @@ public:
     ldout(image_ctx.cct, 10) << "removing " << oid << dendl;
 
     librados::AioCompletion *rados_completion =
-      util::create_rados_safe_callback(this);
+      util::create_rados_callback(this);
     int r = image_ctx.data_ctx.aio_remove(oid, rados_completion);
     assert(r == 0);
     rados_completion->release();

--- a/src/librbd/watcher/Notifier.cc
+++ b/src/librbd/watcher/Notifier.cc
@@ -48,7 +48,7 @@ void Notifier::notify(bufferlist &bl, bufferlist *out_bl, Context *on_finish) {
   }
 
   C_AioNotify *ctx = new C_AioNotify(this, on_finish);
-  librados::AioCompletion *comp = util::create_rados_ack_callback(ctx);
+  librados::AioCompletion *comp = util::create_rados_callback(ctx);
   int r = m_ioctx.aio_notify(m_oid, comp, bl, NOTIFY_TIMEOUT, out_bl);
   assert(r == 0);
   comp->release();

--- a/src/librbd/watcher/RewatchRequest.cc
+++ b/src/librbd/watcher/RewatchRequest.cc
@@ -14,7 +14,7 @@
 namespace librbd {
 
 using util::create_context_callback;
-using util::create_rados_safe_callback;
+using util::create_rados_callback;
 
 namespace watcher {
 
@@ -40,7 +40,7 @@ void RewatchRequest::unwatch() {
   CephContext *cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
   ldout(cct, 10) << dendl;
 
-  librados::AioCompletion *aio_comp = create_rados_safe_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
                         RewatchRequest, &RewatchRequest::handle_unwatch>(this);
   int r = m_ioctx.aio_unwatch(*m_watch_handle, aio_comp);
   assert(r == 0);
@@ -67,7 +67,7 @@ void RewatchRequest::rewatch() {
   CephContext *cct = reinterpret_cast<CephContext *>(m_ioctx.cct());
   ldout(cct, 10) << dendl;
 
-  librados::AioCompletion *aio_comp = create_rados_safe_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
                         RewatchRequest, &RewatchRequest::handle_rewatch>(this);
   int r = m_ioctx.aio_watch(m_oid, aio_comp, &m_rewatch_handle, m_watch_ctx);
   assert(r == 0);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -44,7 +44,7 @@ namespace rbd {
 namespace mirror {
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 using namespace rbd::mirror::image_replayer;
 
 template <typename I>
@@ -1318,7 +1318,7 @@ void ImageReplayer<I>::send_mirror_status_update(const OptionalState &opt_state)
   librados::ObjectWriteOperation op;
   librbd::cls_client::mirror_image_status_set(&op, m_global_image_id, status);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     ImageReplayer<I>, &ImageReplayer<I>::handle_mirror_status_update>(this);
   int r = m_local_ioctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
   assert(r == 0);

--- a/src/tools/rbd_mirror/InstanceWatcher.cc
+++ b/src/tools/rbd_mirror/InstanceWatcher.cc
@@ -20,7 +20,7 @@ namespace mirror {
 
 using librbd::util::create_async_context_callback;
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 namespace {
 
@@ -74,7 +74,7 @@ void InstanceWatcher<I>::get_instances(librados::IoCtx &io_ctx,
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_instances_list_start(&op);
   C_GetInstances *ctx = new C_GetInstances(instance_ids, on_finish);
-  librados::AioCompletion *aio_comp = create_rados_ack_callback(ctx);
+  librados::AioCompletion *aio_comp = create_rados_callback(ctx);
 
   int r = io_ctx.aio_operate(RBD_MIRROR_LEADER, aio_comp, &op, &ctx->out_bl);
   assert(r == 0);
@@ -181,7 +181,7 @@ void InstanceWatcher<I>::register_instance() {
 
   librados::ObjectWriteOperation op;
   librbd::cls_client::mirror_instances_add(&op, m_instance_id);
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     InstanceWatcher<I>, &InstanceWatcher<I>::handle_register_instance>(this);
 
   int r = m_ioctx.aio_operate(RBD_MIRROR_LEADER, aio_comp, &op);
@@ -219,7 +219,7 @@ void InstanceWatcher<I>::create_instance_object() {
   librados::ObjectWriteOperation op;
   op.create(true);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     InstanceWatcher<I>,
     &InstanceWatcher<I>::handle_create_instance_object>(this);
   int r = m_ioctx.aio_operate(m_oid, aio_comp, &op);
@@ -372,7 +372,7 @@ void InstanceWatcher<I>::remove_instance_object() {
   librados::ObjectWriteOperation op;
   op.remove();
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     InstanceWatcher<I>,
     &InstanceWatcher<I>::handle_remove_instance_object>(this);
   int r = m_ioctx.aio_operate(m_oid, aio_comp, &op);
@@ -405,7 +405,7 @@ void InstanceWatcher<I>::unregister_instance() {
 
   librados::ObjectWriteOperation op;
   librbd::cls_client::mirror_instances_remove(&op, m_instance_id);
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     InstanceWatcher<I>, &InstanceWatcher<I>::handle_unregister_instance>(this);
 
   int r = m_ioctx.aio_operate(RBD_MIRROR_LEADER, aio_comp, &op);

--- a/src/tools/rbd_mirror/Instances.cc
+++ b/src/tools/rbd_mirror/Instances.cc
@@ -22,7 +22,7 @@ namespace mirror {
 
 using librbd::util::create_async_context_callback;
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 Instances<I>::Instances(Threads *threads, librados::IoCtx &ioctx) :

--- a/src/tools/rbd_mirror/LeaderWatcher.cc
+++ b/src/tools/rbd_mirror/LeaderWatcher.cc
@@ -22,7 +22,7 @@ using namespace leader_watcher;
 
 using librbd::util::create_async_context_callback;
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 LeaderWatcher<I>::LeaderWatcher(Threads *threads, librados::IoCtx &io_ctx,
@@ -72,7 +72,7 @@ void LeaderWatcher<I>::create_leader_object() {
   librados::ObjectWriteOperation op;
   op.create(false);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     LeaderWatcher<I>, &LeaderWatcher<I>::handle_create_leader_object>(this);
   int r = m_ioctx.aio_operate(m_oid, aio_comp, &op);
   assert(r == 0);

--- a/src/tools/rbd_mirror/MirrorStatusWatcher.cc
+++ b/src/tools/rbd_mirror/MirrorStatusWatcher.cc
@@ -16,7 +16,7 @@
 namespace rbd {
 namespace mirror {
 
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 MirrorStatusWatcher<I>::MirrorStatusWatcher(librados::IoCtx &io_ctx,
@@ -44,7 +44,7 @@ void MirrorStatusWatcher<I>::init(Context *on_finish) {
 
   librados::ObjectWriteOperation op;
   librbd::cls_client::mirror_image_status_remove_down(&op);
-  librados::AioCompletion *aio_comp = create_rados_ack_callback(on_finish);
+  librados::AioCompletion *aio_comp = create_rados_callback(on_finish);
 
   int r = m_ioctx.aio_operate(RBD_MIRRORING, aio_comp, &op);
   assert(r == 0);

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -35,7 +35,7 @@ namespace mirror {
 namespace image_replayer {
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 using librbd::util::unique_lock_name;
 
 template <typename I>
@@ -102,7 +102,7 @@ void BootstrapRequest<I>::get_local_image_id() {
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_image_get_image_id_start(&op, m_global_image_id);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     BootstrapRequest<I>, &BootstrapRequest<I>::handle_get_local_image_id>(
       this);
   int r = m_local_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op, &m_out_bl);

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -21,7 +21,7 @@
                            << this << " " << __func__
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 namespace rbd {
 namespace mirror {
@@ -102,7 +102,7 @@ void CreateImageRequest<I>::get_parent_global_image_id() {
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_image_get_start(&op, m_remote_parent_spec.image_id);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     CreateImageRequest<I>,
     &CreateImageRequest<I>::handle_get_parent_global_image_id>(this);
   m_out_bl.clear();
@@ -149,7 +149,7 @@ void CreateImageRequest<I>::get_local_parent_image_id() {
   librbd::cls_client::mirror_image_get_image_id_start(
     &op, m_parent_global_image_id);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     CreateImageRequest<I>,
     &CreateImageRequest<I>::handle_get_local_parent_image_id>(this);
   m_out_bl.clear();

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
@@ -21,7 +21,7 @@ namespace mirror {
 namespace image_replayer {
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 IsPrimaryRequest<I>::IsPrimaryRequest(I *image_ctx, bool *primary,
@@ -41,7 +41,7 @@ void IsPrimaryRequest<I>::send_get_mirror_state() {
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_image_get_start(&op, m_image_ctx->id);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     IsPrimaryRequest<I>, &IsPrimaryRequest<I>::handle_get_mirror_state>(this);
   int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op,
                                           &m_out_bl);

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc
@@ -34,8 +34,7 @@ namespace mirror {
 namespace image_sync {
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_ack_callback;
-using librbd::util::create_rados_safe_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 ObjectCopyRequest<I>::ObjectCopyRequest(I *local_image_ctx, I *remote_image_ctx,
@@ -67,7 +66,7 @@ template <typename I>
 void ObjectCopyRequest<I>::send_list_snaps() {
   dout(20) << dendl;
 
-  librados::AioCompletion *rados_completion = create_rados_ack_callback<
+  librados::AioCompletion *rados_completion = create_rados_callback<
     ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_list_snaps>(this);
 
   librados::ObjectReadOperation op;
@@ -162,7 +161,7 @@ void ObjectCopyRequest<I>::send_read_object() {
     return;
   }
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_read_object>(this);
   int r = m_remote_io_ctx.aio_operate(m_remote_oid, comp, &op, nullptr);
   assert(r == 0);
@@ -271,7 +270,7 @@ void ObjectCopyRequest<I>::send_write_object() {
     }
   }
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     ObjectCopyRequest<I>, &ObjectCopyRequest<I>::handle_write_object>(this);
   int r = m_local_io_ctx.aio_operate(m_local_oid, comp, &op, local_snap_seq,
                                      local_snap_ids);

--- a/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.cc
@@ -21,7 +21,7 @@ namespace mirror {
 namespace image_sync {
 
 using librbd::util::create_context_callback;
-using librbd::util::create_rados_safe_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 SnapshotCreateRequest<I>::SnapshotCreateRequest(I *local_image_ctx,
@@ -62,7 +62,7 @@ void SnapshotCreateRequest<I>::send_set_size() {
   librados::ObjectWriteOperation op;
   librbd::cls_client::set_size(&op, m_size);
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     SnapshotCreateRequest<I>, &SnapshotCreateRequest<I>::handle_set_size>(this);
   int r = m_local_image_ctx->md_ctx.aio_operate(m_local_image_ctx->header_oid,
                                                 comp, &op);
@@ -106,7 +106,7 @@ void SnapshotCreateRequest<I>::send_remove_parent() {
   librados::ObjectWriteOperation op;
   librbd::cls_client::remove_parent(&op);
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_remove_parent>(this);
   int r = m_local_image_ctx->md_ctx.aio_operate(m_local_image_ctx->header_oid,
@@ -152,7 +152,7 @@ void SnapshotCreateRequest<I>::send_set_parent() {
   librados::ObjectWriteOperation op;
   librbd::cls_client::set_parent(&op, m_parent_spec, m_parent_overlap);
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_set_parent>(this);
   int r = m_local_image_ctx->md_ctx.aio_operate(m_local_image_ctx->header_oid,
@@ -241,7 +241,7 @@ void SnapshotCreateRequest<I>::send_create_object_map() {
   librados::ObjectWriteOperation op;
   librbd::cls_client::object_map_resize(&op, object_count, OBJECT_NONEXISTENT);
 
-  librados::AioCompletion *comp = create_rados_safe_callback<
+  librados::AioCompletion *comp = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_create_object_map>(this);
   int r = m_local_image_ctx->md_ctx.aio_operate(object_map_oid, comp, &op);

--- a/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.cc
+++ b/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.cc
@@ -20,7 +20,7 @@ namespace pool_watcher {
 
 static const uint32_t MAX_RETURN = 1024;
 
-using librbd::util::create_rados_ack_callback;
+using librbd::util::create_rados_callback;
 
 template <typename I>
 void RefreshImagesRequest<I>::send() {
@@ -34,7 +34,7 @@ void RefreshImagesRequest<I>::mirror_image_list() {
   librados::ObjectReadOperation op;
   librbd::cls_client::mirror_image_list_start(&op, m_start_after, MAX_RETURN);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     RefreshImagesRequest<I>,
     &RefreshImagesRequest<I>::handle_mirror_image_list>(this);
   int r = m_remote_io_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op, &m_out_bl);
@@ -80,7 +80,7 @@ void RefreshImagesRequest<I>::dir_list() {
   librados::ObjectReadOperation op;
   librbd::cls_client::dir_list_start(&op, m_start_after, MAX_RETURN);
 
-  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+  librados::AioCompletion *aio_comp = create_rados_callback<
     RefreshImagesRequest<I>,
     &RefreshImagesRequest<I>::handle_dir_list>(this);
   int r = m_remote_io_ctx.aio_operate(RBD_DIRECTORY, aio_comp, &op, &m_out_bl);


### PR DESCRIPTION
since #12607 has killed the distinction between onack and onsafe, we can do a little bit cleanup now

Signed-off-by: runsisi <runsisi@zte.com.cn>