### PR TITLE
RFC: osd/ReplicatedBackend: adjust sub_op_modify assert

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1106,7 +1106,7 @@ void ReplicatedBackend::sub_op_modify(OpRequestRef op)
   assert(m->map_epoch >= get_info().history.same_interval_since);
 
   // we better not be missing this.
-  assert(!parent->get_log().get_missing().is_missing(soid));
+  assert(rm->opt.empty() || !parent->get_log().get_missing().is_missing(soid));
 
   int ackerosd = m->get_source().num();
 


### PR DESCRIPTION
If we're a backfill target, we may be missing an object
we get an empty opt for (something past our
last_backfill line).  This is fine.

Fixes: http://tracker.ceph.com/issues/19191
Signed-off-by: Sage Weil <sage@redhat.com>