### PR TITLE
doc: adds instruction to fix permission issue on osd activate command

### DIFF
--- a/doc/start/quick-ceph-deploy.rst
+++ b/doc/start/quick-ceph-deploy.rst
@@ -117,10 +117,12 @@ configuration details, perform the following steps using ``ceph-deploy``.
 
 	ssh node2
 	sudo mkdir /var/local/osd0
+	sudo chown ceph:ceph /var/local/osd0
 	exit
 
 	ssh node3
 	sudo mkdir /var/local/osd1
+	sudo chown ceph:ceph /var/local/osd1
 	exit
 
    Then, from your admin node, use ``ceph-deploy`` to prepare the OSDs. ::


### PR DESCRIPTION
I needed to change the ownership of /var/local/osd0 and /var/local/osd1 before I could get the `osd activate` command to work from the Storage Cluster Quick Start tutorial. According to [issue #13833](http://tracker.ceph.com/issues/13833) this is just a temporary fix and additional steps are required, but I think it'll be helpful to include for the purposes of continuing on in the tutorial.