### PR TITLE
bluestore, NVMEDEVICE: Specify the max io completion in conf

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1030,6 +1030,9 @@ OPTION(bluestore_bluefs_reclaim_ratio, OPT_FLOAT, .20) // how much to reclaim at
 OPTION(bluestore_spdk_socket_mem, OPT_STR, "512,512")
 // A hexadecimal bit mask of the cores to run on. Note the core numbering can change between platforms and should be determined beforehand.
 OPTION(bluestore_spdk_coremask, OPT_STR, "0x3")
+// Specify the maximal I/Os to be batched completed while checking queue pair completions.
+// Default value 0 means that let SPDK nvme library determine the value.
+OPTION(bluestore_spdk_max_io_completion, OPT_U32, 0)
 OPTION(bluestore_block_path, OPT_STR, "")
 OPTION(bluestore_block_size, OPT_U64, 10 * 1024*1024*1024)  // 10gb for testing
 OPTION(bluestore_block_create, OPT_BOOL, true)

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -384,7 +384,6 @@ void SharedDriverData::_aio_thread()
 
   Task *t = nullptr;
   int r = 0;
-  const int max = 4;
   uint64_t lba_off, lba_count;
   ceph::coarse_real_clock::time_point cur, start
     = ceph::coarse_real_clock::now();
@@ -393,7 +392,7 @@ void SharedDriverData::_aio_thread()
  again:
     dout(40) << __func__ << " polling" << dendl;
     if (inflight) {
-      if (!spdk_nvme_qpair_process_completions(qpair, max)) {
+      if (!spdk_nvme_qpair_process_completions(qpair, g_conf->bluestore_spdk_max_io_completion)) {
         dout(30) << __func__ << " idle, have a pause" << dendl;
         _mm_pause();
       }


### PR DESCRIPTION
I do not think that 4 is meaninful. If a value needs to be determined,
it should be configured in the configuration file.

Signed-off-by: optimistyzy <optimistyzy@gmail.com>