### PR TITLE
mon:  add the warn info when the pool size or min_size below the user config value

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1325,7 +1325,7 @@ function test_wait_for_health_ok() {
     local dir=$1
 
     setup $dir || return 1
-    run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
+    run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 --mon_pool_warn_size=0 --mon_pool_warn_min_size=0 || return 1
     run_mgr $dir x || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     run_osd $dir 0 || return 1

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -425,6 +425,8 @@ OPTION(mon_client_max_log_entries_per_message, OPT_INT, 1000)
 OPTION(mon_max_pool_pg_num, OPT_INT, 65536)
 OPTION(mon_pool_quota_warn_threshold, OPT_INT, 0) // percent of quota at which to issue warnings
 OPTION(mon_pool_quota_crit_threshold, OPT_INT, 0) // percent of quota at which to issue errors
+OPTION(mon_pool_warn_size, OPT_INT, 1) // pool size below which to issue warnings
+OPTION(mon_pool_warn_min_size, OPT_INT, 1) // pool min size below which to issue warnings
 OPTION(client_cache_size, OPT_INT, 16384)
 OPTION(client_cache_mid, OPT_FLOAT, .75)
 OPTION(client_use_random_mds, OPT_BOOL, false)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4945,6 +4945,30 @@ void OSDMonitor::get_pools_health(
 	detail->push_back(make_pair(HEALTH_WARN, ss.str()));
     }
 
+    if (pool.size <= g_conf->mon_pool_warn_size) {
+      stringstream ss;
+      ss << "pool '" << pool_name << "' size below mon_pool_warn_size";
+      summary.push_back(make_pair(HEALTH_WARN, ss.str()));
+      if (detail) {
+        stringstream ss;
+        ss << "pool '" << pool_name << "' size " << pool.size 
+           << " <= mon_pool_warn_size " << g_conf->mon_pool_warn_size;
+        detail->push_back(make_pair(HEALTH_WARN, ss.str()));
+      }
+    }
+
+    if (pool.min_size <= g_conf->mon_pool_warn_min_size) {
+      stringstream ss;
+      ss << "pool '" << pool_name << "' min_size below mon_pool_warn_min_size";
+      summary.push_back(make_pair(HEALTH_WARN, ss.str()));
+      if (detail) {
+        stringstream ss;
+        ss << "pool '" << pool_name << "' min_size " << pool.min_size
+           << " <= mon_pool_warn_min_size " << g_conf->mon_pool_warn_min_size;
+        detail->push_back(make_pair(HEALTH_WARN, ss.str()));
+      }
+    }
+
     float warn_threshold = (float)g_conf->mon_pool_quota_warn_threshold/100;
     float crit_threshold = (float)g_conf->mon_pool_quota_crit_threshold/100;
 


### PR DESCRIPTION
 mon:  add the warn info when the pool size or min_size below the user config value
 
   if the pool size or min_size below the user config value, the pool is not safe enough.
    so we should let the user known it.

Signed-off-by: song baisen <song.baisen@zte.com.cn>