### PR TITLE
os/filestore: use new sleep strategy when io_submit gets EAGAIN.

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1416,15 +1416,15 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
       int r = io_submit(aio_ctx, 1, &piocb);
       dout(20) << "write_aio_bl io_submit return value: " << r << dendl;
       if (r < 0) {
-	derr << "io_submit to " << aio.off << "~" << cur_len
-	     << " got " << cpp_strerror(r) << dendl;
-	if (r == -EAGAIN && attempts-- > 0) {
-	  usleep(500);
-	  continue;
-	}
-	assert(0 == "io_submit got unexpected error");
+        derr << "io_submit to " << aio.off << "~" << cur_len
+             << " got " << cpp_strerror(r) << dendl;
+        if (r == -EAGAIN && attempts-- > 0) {
+          usleep(500);
+          continue;
+        }
+        assert(0 == "io_submit got unexpected error");
       } else {
-	break;
+        break;
       }
     } while (true);
     pos += cur_len;

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1411,7 +1411,10 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
     aio_lock.Unlock();
 
     iocb *piocb = &aio.iocb;
-    int attempts = 10;
+
+    // 2^16 * 125us = ~8 seconds, so max sleep is ~16 seconds
+    int attempts = 16;
+    int delay = 125;
     do {
       int r = io_submit(aio_ctx, 1, &piocb);
       dout(20) << "write_aio_bl io_submit return value: " << r << dendl;
@@ -1419,7 +1422,8 @@ int FileJournal::write_aio_bl(off64_t& pos, bufferlist& bl, uint64_t seq)
         derr << "io_submit to " << aio.off << "~" << cur_len
              << " got " << cpp_strerror(r) << dendl;
         if (r == -EAGAIN && attempts-- > 0) {
-          usleep(500);
+          usleep(delay);
+          delay *= 2;
           continue;
         }
         assert(0 == "io_submit got unexpected error");

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -196,10 +196,10 @@ int FS::aio_queue_t::submit(aio_t &aio, int *retries)
     int r = io_submit(ctx, 1, &piocb);
     if (r < 0) {
       if (r == -EAGAIN && attempts-- > 0) {
-	usleep(delay);
-	delay *= 2;
-	(*retries)++;
-	continue;
+        usleep(delay);
+        delay *= 2;
+        (*retries)++;
+        continue;
       }
       return r;
     }


### PR DESCRIPTION
In FileJournal, the sleep strategy when io_submit return EAGAIN is different from the io_submit in os/fs/FS.cc. I prefer the one in FS.cc, which use exponent to get sleep time.

In addition, the default "500us" is too long. As I know, more and more users use PCIE SSD as journal device, 500us is too long for SSD. 