### PR TITLE
mds: print rank as int

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -173,9 +173,9 @@ void MDSDaemon::dump_status(Formatter *f)
   f->open_object_section("status");
   f->dump_stream("cluster_fsid") << monc->get_fsid();
   if (mds_rank) {
-    f->dump_unsigned("whoami", mds_rank->get_nodeid());
+    f->dump_int("whoami", mds_rank->get_nodeid());
   } else {
-    f->dump_unsigned("whoami", MDS_RANK_NONE);
+    f->dump_int("whoami", MDS_RANK_NONE);
   }
 
   f->dump_int("id", monc->get_global_id());


### PR DESCRIPTION
If the MDS has no rank then its whoami field would be printed as:

    {"cluster_fsid":"4c1bae66-03fb-4b9a-bd88-108636d29758","whoami":18446744073709551615,"id":54239,"want_state":"up:boot","state":"???","mdsmap_epoch":22,"osdmap_epoch":0,"osdmap_epoch_barrier":0}

Fixes: http://tracker.ceph.com/issues/19201

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>