### PR TITLE
mon/MonClient: don't return zero global_id

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -47,6 +47,7 @@
 MonClient::MonClient(CephContext *cct_) :
   Dispatcher(cct_),
   messenger(NULL),
+  global_id(0),
   monc_lock("MonClient::monc_lock"),
   timer(cct_, monc_lock), finisher(cct_),
   initialized(false),
@@ -575,7 +576,8 @@ void MonClient::_reopen_session(int rank)
   ldout(cct, 10) << __func__ << " rank " << rank << dendl;
 
   // save global_id if any before nuking active_con
-  const uint64_t global_id = active_con ? active_con->get_global_id() : 0;
+  if (active_con)
+    global_id = active_con->get_global_id();
   active_con.reset();
   pending_cons.clear();
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -152,6 +152,7 @@ private:
 
   std::unique_ptr<MonConnection> active_con;
   std::map<entity_addr_t, MonConnection> pending_cons;
+  uint64_t global_id;
 
   EntityName entity_name;
 
@@ -397,7 +398,7 @@ public:
     if (active_con) {
       return active_con->get_global_id();
     } else {
-      return 0;
+      return global_id;
     }
   }
 


### PR DESCRIPTION
active_con is reset after re-connecting. get_global_id() should
return previously assigned global_id

Fixes: http://tracker.ceph.com/issues/19134
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>