### PR TITLE
msg/async: fix crash that writing char to nonblock-fd gets EAGAIN in EventCenter::wakeup

### DIFF
--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -323,8 +323,10 @@ void EventCenter::wakeup()
   // wake up "event_wait"
   int n = write(notify_send_fd, &buf, sizeof(buf));
   if (n < 0) {
-    ldout(cct, 1) << __func__ << " write notify pipe failed: " << cpp_strerror(errno) << dendl;
-    ceph_abort();
+    if (errno != EAGAIN) {
+      ldout(cct, 1) << __func__ << " write notify pipe failed: " << cpp_strerror(errno) << dendl;
+      ceph_abort();
+    }
   }
 }
 


### PR DESCRIPTION

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>


@yuyuyu101 take a look, please