### PR TITLE
msg/async/Stack.cc: use of pthread_setname_np() needs compat.h

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -14,6 +14,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/Cond.h"
 #include "common/errno.h"
 #include "PosixStack.h"
@@ -37,7 +38,7 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
   return [this, w]() {
       char tp_name[16];
       sprintf(tp_name, "msgr-worker-%d", w->id);
-      pthread_setname_np(pthread_self(), tp_name);
+      ceph_pthread_setname(pthread_self(), tp_name);
       const uint64_t EventMaxWaitUs = 30000000;
       w->center.set_owner();
       ldout(cct, 10) << __func__ << " starting" << dendl;


### PR DESCRIPTION
- Because there is a name decrepancy between FreeBSD and Linux
   Which is repaired in compat.h

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>