### PR TITLE
hammer: osd: PG: init info.hit_set.current_info.using_gmt with pool.info.use_gmt_hitset

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -247,6 +247,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
 #ifdef PG_DEBUG_REFS
   osd->add_pgid(p, this);
 #endif
+  info.hit_set.current_info.using_gmt = pool.info.use_gmt_hitset;
 }
 
 PG::~PG()


### PR DESCRIPTION
hammer backport tracker: http://tracker.ceph.com/issues/19222

**original description**

Fixes: http://tracker.ceph.com/issues/19185
Signed-off-by: Kefu Chai <kchai@redhat.com>

Conflicts:
    the `current_info` field was droped since jewel, so this change is not
cherry-picked from master.