### PR TITLE
jewel: rgw: the swift container acl does not support field .ref

### DIFF
--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -54,6 +54,7 @@ static bool uid_is_public(string& uid)
     return false;
 
   return sub.compare(".r") == 0 ||
+         sub.compare(".ref") == 0 ||
          sub.compare(".referer") == 0 ||
          sub.compare(".referrer") == 0;
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/18908