### PR TITLE
rbd: validate pool and snap name optionals

### DIFF
--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -107,7 +107,8 @@ int get_pool_journal_names(
 
 int validate_snapshot_name(argument_types::ArgumentModifier mod,
                            const std::string &snap_name,
-                           SnapshotPresence snapshot_presence);
+                           SnapshotPresence snapshot_presence,
+			   SpecValidation spec_validation);
 
 int get_image_options(const boost::program_options::variables_map &vm,
                       bool get_format, librbd::ImageOptions* opts);


### PR DESCRIPTION
Currently when user create snapshot by providing --snap argument
in command line than rbd CLI does not validating snapshot name
to ensure that it should not contain "@" or "/" character.

Fix is to add validation logic for validating "@" or "/" character.

Fixes: http://tracker.ceph.com/issues/14535

Reported-by: Jason Dillaman <dillaman@redhat.com>
Signed-off-by: Gaurav Kumar Garg <garg.gaurav52@gmail.com>