### PR TITLE
ceph-disk/tests/test_main.py: FreeBSD does not do multipath

### DIFF
--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -391,6 +391,9 @@ class TestCephDisk(object):
         #
         # multipath data partition
         #
+        if platform.system() == "FreeBSD":
+            return
+
         partition_uuid = "56244cf5-83ef-4984-888a-2d8b8e0e04b2"
         disk = "Xda"
         partition = "Xda1"


### PR DESCRIPTION
- So don't test it.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>