### PR TITLE
rgw: fix swift static web can not display index.html automatically in sub-directories

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1803,11 +1803,10 @@ bool RGWSwiftWebsiteHandler::is_web_dir() const
   std::string subdir_name;
   url_decode(s->object.name, subdir_name);
 
-  /* Remove character from the subdir name if it is "/". */
   if (subdir_name.empty()) {
     return false;
   } else if (subdir_name.back() == '/') {
-    subdir_name.pop_back();
+    return true;
   }
 
   rgw_obj obj(s->bucket, subdir_name);


### PR DESCRIPTION
If we create sub-directories(eg. sub-dir) for site, in static web mode, which includes index.html. when we enter the sub-directory(eg.` http://<your site domain>/sub-dir/`), it will not shown the index.html, which is not consistent with openstack swift.

Fixes: http://tracker.ceph.com/issues/19218
Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>