### PR TITLE
qa/suites: fix upgrade tests vs cluster full thrashing

### DIFF
--- a/qa/suites/rados/upgrade/jewel-x-singleton/3-thrash/default.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/3-thrash/default.yaml
@@ -17,4 +17,5 @@ split_tasks:
         timeout: 1200
         chance_pgnum_grow: 1
         chance_pgpnum_fix: 1
+        chance_thrash_cluster_full: 0
     - print: "**** done thrashosds 3-thrash"

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/3-thrash/default.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/3-thrash/default.yaml
@@ -17,4 +17,5 @@ stress-tasks:
     chance_pgnum_grow: 1
     chance_pgpnum_fix: 1
     min_in: 4
+    chance_thrash_cluster_full: 0
 - print: "**** done thrashosds 3-thrash"

--- a/qa/suites/upgrade/jewel-x/stress-split/3-thrash/default.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/3-thrash/default.yaml
@@ -16,4 +16,5 @@ stress-tasks:
     timeout: 1200
     chance_pgnum_grow: 1
     chance_pgpnum_fix: 1
+    chance_thrash_cluster_full: 0
 - print: "**** done thrashosds 3-thrash"


### PR DESCRIPTION
296708091ccf49f6ef67b366d1af2e78fb517564 switched to use the new luminous mon command, but we can't use them until the upgrade is done and require_luminous is set.  "EPERM: you must complete the upgrade and set require_luminous_osds before using the new interface"