### PR TITLE
mon/MonClient: don't return zero global_id

### DIFF
--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -191,6 +191,7 @@ private:
   // authenticate
   std::unique_ptr<AuthClientHandler> auth;
   uint32_t want_keys = 0;
+  uint64_t global_id = 0;
   Cond auth_cond;
   int authenticate_err = 0;
 
@@ -394,11 +395,7 @@ public:
 
   uint64_t get_global_id() const {
     Mutex::Locker l(monc_lock);
-    if (active_con) {
-      return active_con->get_global_id();
-    } else {
-      return 0;
-    }
+    return global_id;
   }
 
   void set_messenger(Messenger *m) { messenger = m; }


### PR DESCRIPTION
active_con is reset after re-connecting. get_global_id() return 0
before mon client receives the MAuthReply. The zero global_id
confuses mds code. in this change, MonClient promote the active_con's
global_id to this->global_id once it's authorized. and returns
this->global_id in get_global_id().

Fixes: http://tracker.ceph.com/issues/19134
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>
Signed-off-by: Kefu Chai <kchai@redhat.com>