### PR TITLE
rgw: remove useless --tier_type in radosgw-admin.

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -252,7 +252,6 @@ void _usage()
   cout << "                             set zone tier config keys, values\n";
   cout << "   --tier-config-rm=<k>[,...]\n";
   cout << "                             unset zone tier config keys\n";
-  cout << "   --tier_type=<type>        zone tier type\n";
   cout << "   --sync-from-all[=false]   set/reset whether zone syncs from all zonegroup peers\n";
   cout << "   --sync-from=[zone-name][,...]\n";
   cout << "                             set list of zones to sync from\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -198,7 +198,6 @@
                                set zone tier config keys, values
      --tier-config-rm=<k>[,...]
                                unset zone tier config keys
-     --tier_type=<type>        zone tier type
      --sync-from-all[=false]   set/reset whether zone syncs from all zonegroup peers
      --sync-from=[zone-name][,...]
                                set list of zones to sync from


### PR DESCRIPTION
"--tier-type" already exists and the "--type_type" is useless.

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>