### PR TITLE
[DNM] rbd: show snap location in rbd info.

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1484,6 +1484,36 @@ int get_snapshot_timestamp(cls_method_context_t hctx, bufferlist *in, bufferlist
   return 0;
 }
 
+int get_snapshot_location(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
+{
+  uint64_t snap_id;
+  
+  bufferlist::iterator iter = in->begin();
+  try {
+    ::decode(snap_id, iter);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  CLS_LOG(20, "get_snapshot_location snap_id=%llu", (unsigned long long)snap_id);
+
+  if (snap_id == CEPH_NOSNAP) {
+    return -EINVAL;
+  }
+  
+  cls_rbd_snap snap;
+  string snapshot_key;
+  key_from_snap_id(snap_id, &snapshot_key);
+  int r = read_key(hctx, snapshot_key, &snap);
+  if (r < 0) {
+    return r;
+  }
+
+  ::encode(snap.prev_snap, *out);
+  ::encode(snap.next_snaps, *out);
+  return 0;
+}
+
 /**
  * Retrieve namespace of a snapshot.
  *
@@ -5079,6 +5109,7 @@ CLS_INIT(rbd)
   cls_method_handle_t h_get_snapshot_name;
   cls_method_handle_t h_get_snapshot_namespace;
   cls_method_handle_t h_get_snapshot_timestamp;
+  cls_method_handle_t h_get_snapshot_location;
   cls_method_handle_t h_snapshot_add;
   cls_method_handle_t h_snapshot_remove;
   cls_method_handle_t h_snapshot_rename;
@@ -5177,6 +5208,9 @@ CLS_INIT(rbd)
   cls_register_cxx_method(h_class, "get_snapshot_timestamp",
 			  CLS_METHOD_RD,
 			  get_snapshot_timestamp, &h_get_snapshot_timestamp);
+  cls_register_cxx_method(h_class, "get_snapshot_location",
+			  CLS_METHOD_RD,
+			  get_snapshot_location, &h_get_snapshot_location);
   cls_register_cxx_method(h_class, "snapshot_add",
 			  CLS_METHOD_RD | CLS_METHOD_WR,
 			  snapshot_add, &h_snapshot_add);

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -2784,6 +2784,43 @@ int snapshot_set_limit(cls_method_context_t hctx, bufferlist *in,
   return rc;
 }
 
+int get_head_location(cls_method_context_t hctx, bufferlist *in,
+		      bufferlist *out)
+{
+  uint64_t head_location;
+  int r = read_key(hctx, "head_location", &head_location);
+  if (r < 0) {
+    CLS_ERR("error retrieving head location: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  CLS_LOG(20, "read head location %lu", head_location);
+  ::encode(head_location, *out);
+
+  return 0;
+}
+
+int set_head_location(cls_method_context_t hctx, bufferlist *in,
+		      bufferlist *out)
+{
+  int rc;
+  uint64_t new_location;
+  bufferlist bl;
+
+  try {
+    bufferlist::iterator iter = in->begin();
+    ::decode(new_location, iter);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  CLS_LOG(20, "set head location to %lu\n", new_location);
+  ::encode(new_location, bl);
+  rc = cls_cxx_map_set_val(hctx, "head_location", &bl);
+
+  return rc;
+}
+
 
 /****************************** Old format *******************************/
 
@@ -4925,6 +4962,8 @@ CLS_INIT(rbd)
   cls_method_handle_t h_metadata_get;
   cls_method_handle_t h_snapshot_get_limit;
   cls_method_handle_t h_snapshot_set_limit;
+  cls_method_handle_t h_get_head_location;
+  cls_method_handle_t h_set_head_location;
   cls_method_handle_t h_old_snapshots_list;
   cls_method_handle_t h_old_snapshot_add;
   cls_method_handle_t h_old_snapshot_remove;
@@ -5056,6 +5095,12 @@ CLS_INIT(rbd)
   cls_register_cxx_method(h_class, "snapshot_set_limit",
 			  CLS_METHOD_WR,
 			  snapshot_set_limit, &h_snapshot_set_limit);
+  cls_register_cxx_method(h_class, "get_head_location",
+			  CLS_METHOD_RD,
+			  get_head_location, &h_get_head_location);
+  cls_register_cxx_method(h_class, "set_head_location",
+			  CLS_METHOD_WR,
+			  set_head_location, &h_set_head_location);
 
   /* methods for the rbd_children object */
   cls_register_cxx_method(h_class, "add_child",

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1524,6 +1524,42 @@ int get_snapshot_namespace(cls_method_context_t hctx, bufferlist *in, bufferlist
   return 0;
 }
 
+int snapshot_add_next(cls_method_context_t hctx, uint64_t snap_id, uint64_t next)
+{
+  cls_rbd_snap snap;
+  string snapshot_key;
+  key_from_snap_id(snap_id, &snapshot_key);
+  int r = read_key(hctx, snapshot_key, &snap);
+  if (r < 0) {
+    CLS_ERR("error read previeus snapshot metadatas: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  snap.next_snaps.insert(next);
+
+  bufferlist snap_metabl;
+  ::encode(snap, snap_metabl);
+
+  map<string, bufferlist> vals;
+  vals[snapshot_key] = snap_metabl;
+  r = cls_cxx_map_set_vals(hctx, &vals);
+  if (r < 0) {
+    CLS_ERR("error writing previous snapshot metadatas: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  return 0;
+}
+
+int set_head_location(cls_method_context_t hctx, uint64_t snap_id)
+{
+  bufferlist bl;
+  ::encode(snap_id, bl);
+  int r = cls_cxx_map_set_val(hctx, "head_location", &bl);
+
+  return r;
+}
+
 /**
  * Adds a snapshot to an rbd header. Ensures the id and name are unique.
  *
@@ -1571,6 +1607,18 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   // snap_seq must be monotonically increasing.
   if (snap_meta.id < cur_snap_seq)
     return -ESTALE;
+
+  r = read_key(hctx, "head_location", &snap_meta.prev_snap);
+  if (r == -ENOENT) {
+    r = 0;
+    snap_meta.prev_snap = 0;
+  }
+  if (r < 0) {
+    CLS_ERR("Could not read prev_snap off disk: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  snap_meta.next_snaps.clear();
 
   r = read_key(hctx, "size", &snap_meta.image_size);
   if (r < 0) {
@@ -1664,6 +1712,20 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return r;
   }
 
+  r = set_head_location(hctx, snap_meta.id);
+  if (r < 0) {
+    CLS_ERR("error set head_location to snap: %llu : %s", (unsigned long long)snap_meta.id.val,
+	    cpp_strerror(r).c_str());
+    return r;
+  }
+
+  if (snap_meta.prev_snap != 0) {
+    r = snapshot_add_next(hctx, snap_meta.prev_snap, snap_meta.id);
+    CLS_ERR("error add %llu as next to %lu : %s", (unsigned long long)snap_meta.id.val, snap_meta.prev_snap,
+	    cpp_strerror(r).c_str());
+    return r;
+  }
+
   return 0;
 }
 
@@ -1744,6 +1806,65 @@ int snapshot_rename(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   return 0;
 }
+
+int snapshot_remove_prev(cls_method_context_t hctx, set<uint64_t> next_snaps, uint64_t prev_snap)
+{
+  cls_rbd_snap snap;
+  string snapshot_key;
+  bufferlist snap_metabl;
+  map<string, bufferlist> vals;
+
+  for (auto snap_id : next_snaps) {
+    key_from_snap_id(snap_id, &snapshot_key);
+    int r = read_key(hctx, snapshot_key, &snap);
+    if (r < 0) {
+      CLS_ERR("error read next snapshot %lu metadatas: %s", snap_id, cpp_strerror(r).c_str());
+      return r;
+    }
+
+    snap.prev_snap = prev_snap;
+
+    snap_metabl.clear();
+    vals.clear();
+    ::encode(snap, snap_metabl);
+    vals[snapshot_key] = snap_metabl;
+    r = cls_cxx_map_set_vals(hctx, &vals);
+    if (r < 0) {
+      CLS_ERR("error writing next snapshot %lu metadatas: %s", snap_id, cpp_strerror(r).c_str());
+      return r;
+    }
+  }
+
+  return 0;
+}
+
+int snapshot_remove_next(cls_method_context_t hctx, uint64_t prev_snap, set<uint64_t> next_snaps)
+{
+  cls_rbd_snap snap;
+  string snapshot_key;
+  key_from_snap_id(prev_snap, &snapshot_key);
+  int r = read_key(hctx, snapshot_key, &snap);
+  if (r < 0) {
+    CLS_ERR("error read previeus snapshot %lu metadatas: %s", prev_snap, cpp_strerror(r).c_str());
+    return r;
+  }
+
+  snap.next_snaps.insert(next_snaps.begin(), next_snaps.end());
+
+  bufferlist snap_metabl;
+  ::encode(snap, snap_metabl);
+
+  map<string, bufferlist> vals;
+  vals[snapshot_key] = snap_metabl;
+  r = cls_cxx_map_set_vals(hctx, &vals);
+  if (r < 0) {
+    CLS_ERR("error writing previous snapshot metadatas: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  return 0;
+}
+
 /**
  * Removes a snapshot from an rbd header.
  *
@@ -1783,6 +1904,27 @@ int snapshot_remove(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   r = cls_cxx_map_remove_key(hctx, snapshot_key);
   if (r < 0) {
     CLS_ERR("error writing snapshot metadata: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  r = snapshot_remove_prev(hctx, snap.next_snaps, snap.prev_snap);
+  if (r < 0) {
+    CLS_ERR("error setting the .prev_snap of next_snaps to this.prev_snap: %s",
+	    cpp_strerror(r).c_str());
+    return r;
+  }
+
+  r = snapshot_remove_next(hctx, snap.prev_snap, snap.next_snaps);
+  if (r < 0) {
+    CLS_ERR("error appending this.next_snaps to prev_snap.next_snaps: %s",
+	    cpp_strerror(r).c_str());
+    return r;
+  }
+
+  r = set_head_location(hctx, snap.prev_snap);
+  if (r < 0) {
+    CLS_ERR("error set head_location to this.prev_snap: %s",
+	    cpp_strerror(r).c_str());
     return r;
   }
 

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -66,6 +66,8 @@ struct cls_rbd_snap {
   cls_rbd_parent parent;
   uint64_t flags;
   utime_t timestamp;
+  uint64_t prev_snap;
+  set<uint64_t> next_snaps;
   cls::rbd::SnapshotNamespaceOnDisk snapshot_namespace;
 
   /// true if we have a parent
@@ -78,7 +80,7 @@ struct cls_rbd_snap {
                    flags(0), timestamp(utime_t())
     {}
   void encode(bufferlist& bl) const {
-    ENCODE_START(6, 1, bl);
+    ENCODE_START(8, 1, bl);
     ::encode(id, bl);
     ::encode(name, bl);
     ::encode(image_size, bl);
@@ -88,10 +90,12 @@ struct cls_rbd_snap {
     ::encode(flags, bl);
     ::encode(snapshot_namespace, bl);
     ::encode(timestamp, bl);
+    ::encode(prev_snap, bl);
+    ::encode(next_snaps, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator& p) {
-    DECODE_START(6, p);
+    DECODE_START(8, p);
     ::decode(id, p);
     ::decode(name, p);
     ::decode(image_size, p);
@@ -112,6 +116,12 @@ struct cls_rbd_snap {
     }
     if (struct_v >= 6) {
       ::decode(timestamp, p);
+    }
+    if (struct_v >= 7) {
+      ::decode(prev_snap, p);
+    }
+    if (struct_v >= 8) {
+      ::decode(next_snaps, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -592,6 +592,26 @@ namespace librbd {
                                   protection_statuses);
     }
 
+    void get_snapshot_timestamp_start(librados::ObjectReadOperation *op,
+				      const snapid_t snap_id)
+    {
+      bufferlist bl;
+      ::encode(snap_id, bl);
+      op->exec("rbd", "get_snapshot_timestamp", bl);
+    }
+
+    int get_snapshot_timestamp_finish(bufferlist::iterator *it,
+				      utime_t *timestamp)
+    {
+      try {
+        ::decode(*timestamp, *it);
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+
+      return 0;
+    }
+
     void snapshot_timestamp_list_start(librados::ObjectReadOperation *op,
                                        const std::vector<snapid_t> &ids)
     {

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -111,6 +111,17 @@ namespace librbd {
     int get_snapcontext(librados::IoCtx *ioctx, const std::string &oid,
 			::SnapContext *snapc);
 
+    void get_snapshot_location_start(librados::ObjectReadOperation *op,
+				     const snapid_t snap_id);
+    int get_snapshot_location_finish(bufferlist::iterator *it,
+				     snapid_t *prev_snap,
+				     set<snapid_t> *next_snaps);
+    void snapshot_location_list_start(librados::ObjectReadOperation *op,
+				      const std::vector<snapid_t> &ids);
+    int snapshot_location_list_finish(bufferlist::iterator *it,
+                                      const std::vector<snapid_t> &ids,
+                                      std::vector<snapid_t> *prev_snaps,
+				      std::vector<std::set<snapid_t>> *next_snaps_vec);
     void get_snapshot_timestamp_start(librados::ObjectReadOperation *op,
 				      const snapid_t snap_id);
     int get_snapshot_timestamp_finish(bufferlist::iterator *it,

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -165,6 +165,13 @@ namespace librbd {
     void snapshot_set_limit(librados::ObjectWriteOperation *op,
 			    uint64_t limit);
 
+    int get_head_location(librados::IoCtx *ioctx, const std::string &oid,
+			  uint64_t *head_location);
+    void set_head_location(librados::ObjectWriteOperation *op,
+			   uint64_t snap_id);
+    int set_head_location(librados::IoCtx *ioctx, const std::string &oid,
+			  uint64_t snap_id);
+
     void get_stripe_unit_count_start(librados::ObjectReadOperation *op);
     int get_stripe_unit_count_finish(bufferlist::iterator *it,
                                      uint64_t *stripe_unit,

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -111,6 +111,10 @@ namespace librbd {
     int get_snapcontext(librados::IoCtx *ioctx, const std::string &oid,
 			::SnapContext *snapc);
 
+    void get_snapshot_timestamp_start(librados::ObjectReadOperation *op,
+				      const snapid_t snap_id);
+    int get_snapshot_timestamp_finish(bufferlist::iterator *it,
+				      utime_t *timestamp);
     void snapshot_list_start(librados::ObjectReadOperation *op,
                              const std::vector<snapid_t> &ids);
     int snapshot_list_finish(bufferlist::iterator *it,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -236,6 +236,7 @@ public:
   int overlap(uint64_t *overlap);
   int get_flags(uint64_t *flags);
   int set_image_notification(int fd, int type);
+  int get_head_location(snap_info_t *head_location);
 
   /* exclusive lock feature */
   int is_exclusive_lock_owner(bool *is_owner);

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -298,6 +298,8 @@ public:
   int snap_get_limit(uint64_t *limit);
   int snap_set_limit(uint64_t limit);
   int snap_get_timestamp(uint64_t snap_id, struct timespec *timestamp);
+  int snap_get_location(uint64_t snap_id, uint64_t *prev_snap,
+			std::set<uint64_t> *next_snaps);
 
   /* I/O */
   ssize_t read(uint64_t ofs, size_t len, ceph::bufferlist& bl);

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -552,12 +552,14 @@ struct C_InvalidateCache : public Context {
 			  cls::rbd::SnapshotNamespace in_snap_namespace,
 			  snap_t id, uint64_t in_size,
 			  parent_info parent, uint8_t protection_status,
-                          uint64_t flags, utime_t timestamp)
+                          uint64_t flags, utime_t timestamp,
+			  snapid_t prev_snap, set<snapid_t> next_snaps)
   {
     assert(snap_lock.is_wlocked());
     snaps.push_back(id);
     SnapInfo info(in_snap_name, in_snap_namespace,
-		  in_size, parent, protection_status, flags, timestamp);
+		  in_size, parent, protection_status,
+		  flags, timestamp, prev_snap, next_snaps);
     snap_info.insert(pair<snap_t, SnapInfo>(id, info));
     snap_ids.insert(pair<string, snap_t>(in_snap_name, id));
   }

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -254,7 +254,8 @@ namespace librbd {
 		  cls::rbd::SnapshotNamespace in_snap_namespace,
 		  librados::snap_t id,
 		  uint64_t in_size, parent_info parent,
-		  uint8_t protection_status, uint64_t flags, utime_t timestamp);
+		  uint8_t protection_status, uint64_t flags,
+		  utime_t timestamp, snapid_t prev_snap, set<snapid_t> next_snaps);
     void rm_snap(std::string in_snap_name, librados::snap_t id);
     uint64_t get_image_size(librados::snap_t in_snap_id) const;
     uint64_t get_object_count(librados::snap_t in_snap_id) const;

--- a/src/librbd/SnapInfo.h
+++ b/src/librbd/SnapInfo.h
@@ -18,11 +18,15 @@ namespace librbd {
     uint8_t protection_status;
     uint64_t flags;
     utime_t timestamp;
+    snapid_t prev_snap;
+    set<snapid_t> next_snaps;
     SnapInfo(std::string _name, const cls::rbd::SnapshotNamespace &_snap_namespace,
 	     uint64_t _size, parent_info _parent,
-             uint8_t _protection_status, uint64_t _flags, utime_t _timestamp)
+             uint8_t _protection_status, uint64_t _flags, utime_t _timestamp,
+	     snapid_t _prev_snap, set<snapid_t> _next_snaps)
       : name(_name), snap_namespace(_snap_namespace), size(_size), parent(_parent),
-	protection_status(_protection_status), flags(_flags), timestamp(_timestamp) {}
+	protection_status(_protection_status), flags(_flags), timestamp(_timestamp),
+	prev_snap(_prev_snap), next_snaps(_next_snaps) {}
   };
 }
 

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -139,6 +139,8 @@ private:
   std::vector<uint8_t> m_snap_protection;
   std::vector<uint64_t> m_snap_flags;
   std::vector<utime_t> m_snap_timestamps;
+  std::vector<snapid_t> m_snap_prev_snaps;
+  std::vector<set<snapid_t>> m_snap_next_snaps_vec;
 
   std::map<rados::cls::lock::locker_id_t,
            rados::cls::lock::locker_info_t> m_lockers;
@@ -177,6 +179,9 @@ private:
 
   void send_v2_get_snap_timestamps();
   Context *handle_v2_get_snap_timestamps(int *result);
+
+  void send_v2_get_snap_location();
+  Context *handle_v2_get_snap_location(int *result);
 
   void send_v2_refresh_parent();
   Context *handle_v2_refresh_parent(int *result);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1413,6 +1413,68 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     return 0;
   }
 
+  int get_head_location(ImageCtx *ictx, snap_info_t *head_location)
+  {
+    uint64_t snap_id;
+    int r = cls_client::get_head_location(&ictx->md_ctx, ictx->header_oid,
+					      &snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    r = ictx->state->refresh_if_required();
+    if (r < 0)
+      return r;
+
+    RWLock::RLocker l(ictx->snap_lock);
+    std::map<librados::snap_t, SnapInfo>::iterator snap_it =
+      ictx->snap_info.find(snap_id);
+    if (snap_it != ictx->snap_info.end()) {
+      head_location->name = snap_it->second.name;
+      head_location->id = snap_it->first;
+      head_location->size = snap_it->second.size;
+    } else {
+      return -ENOENT;
+    }
+
+    return 0;
+  }
+
+  int set_head_location(ImageCtx *ictx, uint64_t snap_id)
+  {
+    if (ictx->read_only) {
+      return -EROFS;
+    }
+
+    int r = ictx->state->refresh_if_required();
+    if (r < 0) {
+      return r;
+    }
+
+    {
+      RWLock::RLocker owner_lock(ictx->owner_lock);
+      C_SaferCond ctx;
+
+      if (ictx->exclusive_lock != nullptr &&
+	  !ictx->exclusive_lock->is_lock_owner()) {
+	C_SaferCond lock_ctx;
+
+	ictx->exclusive_lock->acquire_lock(&lock_ctx);
+	r = lock_ctx.wait();
+	if (r < 0) {
+	  return r;
+	}
+      }
+
+      RWLock::RLocker md_locker(ictx->md_lock);
+      RWLock::RLocker snap_locker(ictx->snap_lock);
+      r = cls_client::set_head_location(&ictx->md_ctx, ictx->header_oid, 
+					snap_id);
+    }
+
+    return r;
+  }
+
   int get_flags(ImageCtx *ictx, uint64_t *flags)
   {
     int r = ictx->state->refresh_if_required();

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1795,6 +1795,19 @@ int mirror_image_disable_internal(ImageCtx *ictx, bool force,
     return 0;
   }
 
+  int snap_get_location(ImageCtx *ictx, uint64_t snap_id, uint64_t *prev_snap,
+			set<uint64_t> *next_snaps)
+  {
+    std::map<librados::snap_t, SnapInfo>::iterator snap_it = ictx->snap_info.find(snap_id);
+    assert(snap_it != ictx->snap_info.end());
+    *prev_snap = snap_it->second.prev_snap;
+    next_snaps->clear();
+    for (auto snap_id : snap_it->second.next_snaps) {
+      next_snaps->insert(snap_id);
+    }
+    return 0;
+  }
+
   int snap_get_limit(ImageCtx *ictx, uint64_t *limit)
   {
     int r = cls_client::snapshot_get_limit(&ictx->md_ctx, ictx->header_oid,

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -130,6 +130,8 @@ namespace librbd {
   int get_overlap(ImageCtx *ictx, uint64_t *overlap);
   int get_parent_info(ImageCtx *ictx, std::string *parent_pool_name,
 		      std::string *parent_name, std::string *parent_snap_name);
+  int get_head_location(ImageCtx *ictx, snap_info_t *head_location);
+  int set_head_location(ImageCtx *ictx, uint64_t snap_id);
   int get_flags(ImageCtx *ictx, uint64_t *flags);
   int set_image_notification(ImageCtx *ictx, int fd, int type);
   int is_exclusive_lock_owner(ImageCtx *ictx, bool *is_owner);

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -150,6 +150,8 @@ namespace librbd {
   int snap_get_limit(ImageCtx *ictx, uint64_t *limit);
   int snap_set_limit(ImageCtx *ictx, uint64_t limit);
   int snap_get_timestamp(ImageCtx *ictx, uint64_t snap_id, struct timespec *timestamp);
+  int snap_get_location(ImageCtx *ictx, uint64_t snap_id, uint64_t *prev_snap,
+			set<uint64_t> *next_snaps);
   int snap_remove(ImageCtx *ictx, const char *snap_name, uint32_t flags, ProgressContext& pctx);
   int get_snap_namespace(ImageCtx *ictx,
 			 const char *snap_name,

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1199,6 +1199,16 @@ namespace librbd {
     return r;
   }
 
+  int Image::snap_get_location(uint64_t snap_id, uint64_t *prev_snap,
+                               set<uint64_t> *next_snaps)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, snap_get_location_enter, ictx, ictx->name.c_str());
+    int r = librbd::snap_get_location(ictx, snap_id, prev_snap, next_snaps);
+    tracepoint(librbd, snap_get_location_exit, r);
+    return r;
+  }
+
   int Image::snap_get_limit(uint64_t *limit)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -823,6 +823,15 @@ namespace librbd {
     return r;
   }
 
+  int Image::get_head_location(snap_info_t *head_location)
+  {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    tracepoint(librbd, get_head_location_enter, ictx);
+    int r = librbd::get_head_location(ictx, head_location);
+    tracepoint(librbd, get_head_location_exit, r, head_location->id);
+    return r;
+  }
+
   int Image::get_flags(uint64_t *flags)
   {
     ImageCtx *ictx = (ImageCtx *)ctx;

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -87,6 +87,8 @@ private:
   uint64_t m_snap_id;
   uint64_t m_size;
   parent_info m_parent_info;
+  utime_t m_snap_timestamp;
+  bufferlist m_out_bl;
 
   void send_suspend_requests();
   Context *handle_suspend_requests(int *result);
@@ -102,6 +104,9 @@ private:
 
   void send_create_snap();
   Context *handle_create_snap(int *result);
+
+  Context *send_get_timestamp();
+  Context *handle_get_timestamp(int *result);
 
   Context *send_create_object_map();
   Context *handle_create_object_map(int *result);

--- a/src/librbd/operation/SnapshotCreateRequest.h
+++ b/src/librbd/operation/SnapshotCreateRequest.h
@@ -89,6 +89,8 @@ private:
   parent_info m_parent_info;
   utime_t m_snap_timestamp;
   bufferlist m_out_bl;
+  snapid_t m_prev_snap;
+  set<snapid_t> m_next_snaps;
 
   void send_suspend_requests();
   Context *handle_suspend_requests(int *result);
@@ -107,6 +109,9 @@ private:
 
   Context *send_get_timestamp();
   Context *handle_get_timestamp(int *result);
+
+  Context *send_get_location();
+  Context *handle_get_location(int *result);
 
   Context *send_create_object_map();
   Context *handle_create_object_map(int *result);

--- a/src/librbd/operation/SnapshotRollbackRequest.h
+++ b/src/librbd/operation/SnapshotRollbackRequest.h
@@ -94,6 +94,9 @@ private:
   void send_rollback_objects();
   Context *handle_rollback_objects(int *result);
 
+  Context *send_set_head_location();
+  Context *handle_set_head_location(int *result);
+
   Context *send_refresh_object_map();
   Context *handle_refresh_object_map(int *result);
 

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -224,7 +224,7 @@ public:
 
   void expect_add_snap(MockRefreshImageCtx &mock_image_ctx,
                        const std::string &snap_name, uint64_t snap_id) {
-    EXPECT_CALL(mock_image_ctx, add_snap(snap_name, _, snap_id, _, _, _, _, _));
+    EXPECT_CALL(mock_image_ctx, add_snap(snap_name, _, snap_id, _, _, _, _, _, _, _));
   }
 
   void expect_init_exclusive_lock(MockRefreshImageCtx &mock_image_ctx,

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -154,11 +154,13 @@ struct MockImageCtx {
   MOCK_CONST_METHOD2(is_snap_unprotected, int(librados::snap_t in_snap_id,
                                               bool *is_unprotected));
 
-  MOCK_METHOD8(add_snap, void(std::string in_snap_name,
+  MOCK_METHOD10(add_snap, void(std::string in_snap_name,
 			      cls::rbd::SnapshotNamespace in_snap_namespace,
 			      librados::snap_t id,
 			      uint64_t in_size, parent_info parent,
-			      uint8_t protection_status, uint64_t flags, utime_t timestamp));
+			      uint8_t protection_status, uint64_t flags,
+			      utime_t timestamp, snapid_t prev_snap,
+			      set<snapid_t> next_snaps));
   MOCK_METHOD2(rm_snap, void(std::string in_snap_name, librados::snap_t id));
 
   MOCK_METHOD0(user_flushed, void());

--- a/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/object_map/test_mock_SnapshotCreateRequest.cc
@@ -28,7 +28,8 @@ public:
     ictx->add_snap("snap name",
 	  cls::rbd::UserSnapshotNamespace(), snap_id,
 		   ictx->size, ictx->parent_md,
-                   RBD_PROTECTION_STATUS_UNPROTECTED, 0, utime_t());
+                   RBD_PROTECTION_STATUS_UNPROTECTED, 0, utime_t(),
+		   0, {});
   }
 
   void expect_read_map(librbd::ImageCtx *ictx, int r) {

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -89,7 +89,7 @@ public:
     // state machine checks to ensure a refresh hasn't already added the snap
     EXPECT_CALL(mock_image_ctx, get_snap_info(_))
                   .WillOnce(Return(static_cast<const librbd::SnapInfo*>(NULL)));
-    EXPECT_CALL(mock_image_ctx, add_snap("snap1", _, _, _, _, _, _, _));
+    EXPECT_CALL(mock_image_ctx, add_snap("snap1", _, _, _, _, _, _, _, _, _));
   }
 
   void expect_unblock_writes(MockImageCtx &mock_image_ctx) {

--- a/src/test/rbd_mirror/image_replayer/test_mock_EventPreprocessor.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_EventPreprocessor.cc
@@ -120,7 +120,7 @@ TEST_F(TestMockImageReplayerEventPreprocessor, PreprocessSnapMapPrune) {
   expect_update_client(mock_remote_journaler, 0);
 
   mock_local_image_ctx.snap_info = {
-    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t()}}};
+    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t(), 0U, {}}}};
   m_client_meta.snap_seqs = {{1, 2}, {3, 4}, {5, 6}};
   MockEventPreprocessor event_preprocessor(mock_local_image_ctx,
                                            mock_remote_journaler,
@@ -146,7 +146,7 @@ TEST_F(TestMockImageReplayerEventPreprocessor, PreprocessSnapRename) {
 
   mock_local_image_ctx.snap_ids = {{"snap", 6}};
   mock_local_image_ctx.snap_info = {
-    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t()}}};
+    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t(), 0U, {}}}};
   MockEventPreprocessor event_preprocessor(mock_local_image_ctx,
                                            mock_remote_journaler,
                                            "local mirror uuid",
@@ -197,7 +197,7 @@ TEST_F(TestMockImageReplayerEventPreprocessor, PreprocessSnapRenameKnown) {
   expect_image_refresh(mock_local_image_ctx, 0);
 
   mock_local_image_ctx.snap_info = {
-    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t()}}};
+    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t(), 0U, {}}}};
   m_client_meta.snap_seqs = {{5, 6}};
   MockEventPreprocessor event_preprocessor(mock_local_image_ctx,
                                            mock_remote_journaler,
@@ -246,7 +246,7 @@ TEST_F(TestMockImageReplayerEventPreprocessor, PreprocessClientUpdateError) {
 
   mock_local_image_ctx.snap_ids = {{"snap", 6}};
   mock_local_image_ctx.snap_info = {
-    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t()}}};
+    {6, librbd::SnapInfo{"snap", cls::rbd::UserSnapshotNamespace(), 0U, {}, 0U, 0U, utime_t(), 0U, {}}}};
   MockEventPreprocessor event_preprocessor(mock_local_image_ctx,
                                            mock_remote_journaler,
                                            "local mirror uuid",

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1690,6 +1690,24 @@ TRACEPOINT_EVENT(librbd, get_parent_info_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, get_head_location_enter,
+    TP_ARGS(
+        void*, imagectx),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, get_head_location_exit,
+    TP_ARGS(
+        int, retval,
+        uint64_t, snap_id),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+        ctf_integer(uint64_t, snap_id, snap_id)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, get_overlap_enter,
     TP_ARGS(
         void*, imagectx,

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1400,6 +1400,24 @@ TRACEPOINT_EVENT(librbd, snap_get_timestamp_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, snap_get_location_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, name),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(name, name)
+    )    
+)
+
+TRACEPOINT_EVENT(librbd, snap_get_location_exit,
+    TP_ARGS(
+        int, retval),
+	TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, snap_get_limit_enter,
     TP_ARGS(
         void*, imagectx,


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18917

Build a tree in snapshot for an image. 

```
(snapshot add):                                       
      [init]--->snap1-->snap2--> snap3 
                     |
                     | [snap_location is snap2, add snap4]
                     |
                     v                           |----> snap3
      [init]--->snap1-->snap2--|
                                                  -----> snap4
                                             
(snapshot remove): 
                                                  |----> snap3
      [init]--->snap1-->snap2--|
                                                  -----> snap4
                     |
                     | [remove snap2]
                     |
                     v
                                    |----> snap3
      [init]--->snap1---|
                                    -----> snap4
```
Example:
$ rbd create test -s 1
$ rbd snap add test@snap1
$ rbd info test
rbd image 'test':
	size 1024 kB in 1 objects
	order 22 (4096 kB objects)
	block_name_prefix: rbd_data.103e2ae8944a
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	flags: 
	snapshot location: snap1 Wed Mar  8 22:06:27 2017
$ rbd snap add test@snap2
$ rbd snap add test@snap3
$ rbd info test
rbd image 'test':
	size 1024 kB in 1 objects
	order 22 (4096 kB objects)
	block_name_prefix: rbd_data.103e2ae8944a
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	flags: 
	snapshot location: snap3 Wed Mar  8 22:06:37 2017
$ rbd snap rollback test@snap2
Rolling back to snapshot: 100% complete...done.
$ rbd info test
rbd image 'test':
	size 1024 kB in 1 objects
	order 22 (4096 kB objects)
	block_name_prefix: rbd_data.103e2ae8944a
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	flags: 
	snapshot location: snap2 Wed Mar  8 22:06:33 2017
$ rbd snap remove test@snap2
Removing snap: 100% complete...done.
$ rbd info test
rbd image 'test':
	size 1024 kB in 1 objects
	order 22 (4096 kB objects)
	block_name_prefix: rbd_data.103e2ae8944a
	format: 2
	features: layering, exclusive-lock, object-map, fast-diff, deep-flatten
	flags: 
	snapshot location: snap1 Wed Mar  8 22:06:27 2017
