### PR TITLE
osd/ReplicatedBackend: clear pull source once we are done with it

### DIFF
--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -221,6 +221,8 @@ private:
   void clear_pull(
     map<hobject_t, PullInfo>::iterator piter,
     bool clear_pull_from_peer = true);
+  void clear_pull_from(
+    map<hobject_t, PullInfo>::iterator piter);
 
   void sub_op_push(OpRequestRef op);
   void sub_op_push_reply(OpRequestRef op);


### PR DESCRIPTION
68defc2b0561414711d4dd0a76bc5d0f46f8a3f8 factored out the clear_pull
behavoir, but we actually need to clear the pull source in
handle_pull_response (even though we don't clear the pulling entry
until the callback) so that we don't clear the pulling entry in
check_recovery_sources.  This should restore the clearing behavior
to basically what it was in kraken.

Fixes: http://tracker.ceph.com/issues/19076
Signed-off-by: Samuel Just <sjust@redhat.com>