### PR TITLE
initial changes for gssapi/krb5 authentication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,12 @@ find_package(OpenLdap REQUIRED)
 set(HAVE_OPENLDAP ${OPENLDAP_FOUND})
 endif(${WITH_OPENLDAP})
 
+option(WITH_GSSAPI "GSSAPI is here" ON)
+#if(${WITH_GSSAPI})
+find_package(GSSAPI)
+set(HAVE_GSSAPI ${GSSAPI_FOUND})
+#endif(${WITH_GSSAPI})
+
 option(WITH_FUSE "Fuse is here" ON)
 if(${WITH_FUSE})
 find_package(fuse)

--- a/cmake/modules/FindGSSAPI.cmake
+++ b/cmake/modules/FindGSSAPI.cmake
@@ -1,0 +1,19 @@
+# - Find Gssapi C Libraries
+#
+# GSSAPI_FOUND - True if found.
+# GSSAPI_INCLUDE_DIR - Path to the gssapi include directory
+# GSSAPI_LIBRARIES - Paths to the gssapi libraries
+
+find_path(GSSAPI_INCLUDE_DIR gssapi.h PATHS
+  /usr/include)
+
+find_library(GSSAPI_LIBRARY gssapi_krb5)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(GSSAPI DEFAULT_MSG
+  GSSAPI_INCLUDE_DIR GSSAPI_LIBRARY)
+
+set(GSSAPI_LIBRARIES ${GSSAPI_LIBRARY})
+
+mark_as_advanced(
+  GSSAPI_INCLUDE_DIR GSSAPI_LIBRARY)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -301,6 +301,9 @@ set(auth_files
   auth/cephx/CephxClientHandler.cc
   auth/cephx/CephxProtocol.cc
   auth/cephx/CephxSessionHandler.cc
+  auth/gssapi/GssapiAuthorizeHandler.cc
+  auth/gssapi/GssapiClientHandler.cc
+  auth/gssapi/GssapiProtocol.cc
   auth/none/AuthNoneAuthorizeHandler.cc
   auth/unknown/AuthUnknownAuthorizeHandler.cc
   auth/Crypto.cc
@@ -565,7 +568,7 @@ set(ceph_common_deps
   ${Boost_DATE_TIME_LIBRARY}
   ${Boost_IOSTREAMS_LIBRARY}
   ${BLKID_LIBRARIES} ${Backtrace_LIBRARIES}
-  ${CRYPTO_LIBS} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+  ${CRYPTO_LIBS} ${GSSAPI_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 if(HAVE_RDMA)
   list(APPEND ceph_common_deps ${RDMA_LIBRARY})
 endif()
@@ -636,7 +639,7 @@ if (WITH_MGR)
                  $<TARGET_OBJECTS:heap_profiler_objs>)
   target_include_directories(ceph-mgr PRIVATE "${PYTHON_INCLUDE_DIRS}")
   target_link_libraries(ceph-mgr mds osdc global-static common
-      ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS})
+      ${Boost_PYTHON_LIBRARY} ${PYTHON_LIBRARIES} ${BLKID_LIBRARIES} ${CMAKE_DL_LIBS} ${ALLOC_LIBS} ${GSSAPI_LIBRARY})
   install(TARGETS ceph-mgr DESTINATION bin)
 endif (WITH_MGR)
 
@@ -644,7 +647,7 @@ set(librados_config_srcs
   librados-config.cc)
 add_executable(librados-config ${librados_config_srcs})
 target_link_libraries(librados-config librados global ${BLKID_LIBRARIES} ${RDMA_LIBRARIES}
-  ${CMAKE_DL_LIBS})
+  ${CMAKE_DL_LIBS} ${GSSAPI_LIBRARY})
 
 install(TARGETS librados-config DESTINATION bin)
 
@@ -728,7 +731,8 @@ add_executable(ceph-mon ${ceph_mon_srcs}
 add_dependencies(ceph-mon erasure_code_plugins)
 target_link_libraries(ceph-mon mon common os global-static common
   ${EXTRALIBS}
-  ${CMAKE_DL_LIBS})
+  ${CMAKE_DL_LIBS}
+  ${GSSAPI_LIBRARY})
 install(TARGETS ceph-mon DESTINATION bin)
 
 # OSD/ObjectStore
@@ -933,7 +937,7 @@ if(WITH_LIBCEPHFS)
       ceph_fuse.cc
       client/fuse_ll.cc)
     add_executable(ceph-fuse ${ceph_fuse_srcs})
-    target_link_libraries(ceph-fuse ${ALLOC_LIBS} ${FUSE_LIBRARIES}
+    target_link_libraries(ceph-fuse ${ALLOC_LIBS} ${FUSE_LIBRARIES} ${GSSAPI_LIBRARY}
       client common global-static)
     set_target_properties(ceph-fuse PROPERTIES COMPILE_FLAGS "-I${FUSE_INCLUDE_DIRS}")
     install(TARGETS ceph-fuse DESTINATION bin)

--- a/src/auth/AuthAuthorizeHandler.cc
+++ b/src/auth/AuthAuthorizeHandler.cc
@@ -14,6 +14,7 @@
 
 #include "AuthAuthorizeHandler.h"
 #include "cephx/CephxAuthorizeHandler.h"
+#include "gssapi/GssapiAuthorizeHandler.h"
 #include "none/AuthNoneAuthorizeHandler.h"
 #include "common/Mutex.h"
 
@@ -35,6 +36,10 @@ AuthAuthorizeHandler *AuthAuthorizeHandlerRegistry::get_handler(int protocol)
     
   case CEPH_AUTH_CEPHX:
     m_authorizers[protocol] = new CephxAuthorizeHandler();
+    return m_authorizers[protocol];
+
+  case CEPH_AUTH_GSSAPI:
+    m_authorizers[protocol] = new GssapiAuthorizeHandler();
     return m_authorizers[protocol];
   }
   return NULL;

--- a/src/auth/AuthClientHandler.cc
+++ b/src/auth/AuthClientHandler.cc
@@ -17,6 +17,7 @@
 
 #include "AuthClientHandler.h"
 #include "cephx/CephxClientHandler.h"
+#include "gssapi/GssapiClientHandler.h"
 #include "none/AuthNoneClientHandler.h"
 
 AuthClientHandler *get_auth_client_handler(CephContext *cct, int proto,
@@ -25,6 +26,8 @@ AuthClientHandler *get_auth_client_handler(CephContext *cct, int proto,
   switch (proto) {
   case CEPH_AUTH_CEPHX:
     return new CephxClientHandler(cct, rkeys);
+  case CEPH_AUTH_GSSAPI:
+    return new GssapiClientHandler(cct, rkeys);
   case CEPH_AUTH_NONE:
     return new AuthNoneClientHandler(cct, rkeys);
   default:

--- a/src/auth/AuthMethodList.cc
+++ b/src/auth/AuthMethodList.cc
@@ -32,6 +32,8 @@ AuthMethodList::AuthMethodList(CephContext *cct, string str)
     ldout(cct, 5) << "adding auth protocol: " << *iter << dendl;
     if (iter->compare("cephx") == 0) {
       auth_supported.push_back(CEPH_AUTH_CEPHX);
+    } else if (iter->compare("gssapi") == 0) {
+      auth_supported.push_back(CEPH_AUTH_GSSAPI);
     } else if (iter->compare("none") == 0) {
       auth_supported.push_back(CEPH_AUTH_NONE);
     } else {

--- a/src/auth/AuthServiceHandler.cc
+++ b/src/auth/AuthServiceHandler.cc
@@ -14,6 +14,7 @@
 
 #include "AuthServiceHandler.h"
 #include "cephx/CephxServiceHandler.h"
+#include "gssapi/GssapiServiceHandler.h"
 #include "none/AuthNoneServiceHandler.h"
 
 #define dout_subsys ceph_subsys_auth
@@ -24,6 +25,8 @@ AuthServiceHandler *get_auth_service_handler(int type, CephContext *cct, KeyServ
   switch (type) {
   case CEPH_AUTH_CEPHX:
     return new CephxServiceHandler(cct, ks);
+  case CEPH_AUTH_GSSAPI:
+    return new GssapiServiceHandler(cct, ks);
   case CEPH_AUTH_NONE:
     return new AuthNoneServiceHandler(cct);
   }

--- a/src/auth/AuthSessionHandler.cc
+++ b/src/auth/AuthSessionHandler.cc
@@ -15,6 +15,7 @@
 #include "common/debug.h"
 #include "AuthSessionHandler.h"
 #include "cephx/CephxSessionHandler.h"
+#include "gssapi/GssapiSessionHandler.h"
 #include "none/AuthNoneSessionHandler.h"
 #include "unknown/AuthUnknownSessionHandler.h"
 
@@ -31,6 +32,8 @@ AuthSessionHandler *get_auth_session_handler(CephContext *cct, int protocol, Cry
   switch (protocol) {
   case CEPH_AUTH_CEPHX:
     return new CephxSessionHandler(cct, key, features);
+  case CEPH_AUTH_GSSAPI:
+    return new GssapiSessionHandler(cct, key);
   case CEPH_AUTH_NONE:
     return new AuthNoneSessionHandler(cct, key);
   case CEPH_AUTH_UNKNOWN:

--- a/src/auth/gssapi/GssapiAuthorizeHandler.cc
+++ b/src/auth/gssapi/GssapiAuthorizeHandler.cc
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2009-2011 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "GssapiAuthorizeHandler.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_auth
+
+bool GssapiAuthorizeHandler::verify_authorizer(
+  CephContext *cct,
+  KeyStore *keys,
+  bufferlist& authorizer_data,
+  bufferlist& authorizer_reply,
+  EntityName& entity_name,
+  uint64_t& global_id,
+  AuthCapsInfo& caps_info,
+  CryptoKey& session_key,
+  uint64_t *auid)
+{
+  bufferlist::iterator iter = authorizer_data.begin();
+
+  try {
+    __u8 struct_v = 1;
+    ::decode(struct_v, iter);
+    ::decode(entity_name, iter);
+    ::decode(global_id, iter);
+  } catch (const buffer::error &err) {
+    ldout(cct, 0) << "verify_authorizer: failed to decode" << dendl;
+    return false;
+  }
+
+  caps_info.allow_all = true;
+
+  return true;
+}
+
+// Return type of crypto used for this session's data;  for none, no crypt used
+
+int GssapiAuthorizeHandler::authorizer_session_crypto(void)
+{
+  return SESSION_SYMMETRIC_AUTHENTICATE;
+}

--- a/src/auth/gssapi/GssapiAuthorizeHandler.h
+++ b/src/auth/gssapi/GssapiAuthorizeHandler.h
@@ -1,0 +1,32 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_AUTHGSSAPIAUTHORIZEHANDLER_H
+#define CEPH_AUTHGSSAPIAUTHORIZEHANDLER_H
+
+#include "auth/AuthAuthorizeHandler.h"
+
+class CephContext;
+
+struct GssapiAuthorizeHandler : public AuthAuthorizeHandler {
+  bool verify_authorizer(CephContext *cct, KeyStore *keys,
+			 bufferlist& authorizer_data, bufferlist& authorizer_reply,
+                         EntityName& entity_name, uint64_t& global_id,
+			 AuthCapsInfo& caps_info, CryptoKey& session_key, uint64_t *auid=NULL);
+  int authorizer_session_crypto();
+};
+
+
+
+#endif

--- a/src/auth/gssapi/GssapiClientHandler.cc
+++ b/src/auth/gssapi/GssapiClientHandler.cc
@@ -1,0 +1,209 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#include <errno.h>
+
+#include "GssapiProtocol.h"
+#include "GssapiClientHandler.h"
+
+#include "auth/KeyRing.h"
+#include "common/config.h"
+#include "common/dout.h"
+
+#define dout_subsys ceph_subsys_auth
+#undef dout_prefix
+#define dout_prefix *_dout << "gssapi client: "
+
+static gss_OID_desc gss_spnego_mechanism_oid_desc =
+    {6, (void *)"\x2b\x06\x01\x05\x05\x02"};
+
+GssapiClientHandler::~GssapiClientHandler(void)
+{
+  OM_uint32 min_stat;
+
+  gss_release_name(&min_stat, &gss_client_name);
+  gss_release_name(&min_stat, &gss_service_name);
+  gss_release_cred(&min_stat, &gss_cred);
+  gss_delete_sec_context(&min_stat, &gss_sec_context, GSS_C_NO_BUFFER);
+  gss_release_buffer(&min_stat, (gss_buffer_t)&gss_output_token);
+}
+
+int GssapiClientHandler::build_request(bufferlist& bl) const
+{
+  ldout(cct, 20) << "build_request" << dendl;
+  RWLock::RLocker l(lock);
+
+  GssapiTokenBlob token_blob;
+  GssapiRequestHeader header;
+  header.request_type = GSSAPI_TOKEN;
+  ::encode(header, bl);
+
+  if (gss_output_token.length != 0) {
+    token_blob.blob.append(buffer::create_static(
+          gss_output_token.length,
+          (char*)gss_output_token.value));
+
+    ::encode(token_blob, bl);
+
+    ldout(cct, 20) << "build_request: gssapi token blob is:\n";
+    token_blob.blob.hexdump(*_dout);
+    *_dout << dendl;
+  }
+
+  return 0;
+}
+
+
+int GssapiClientHandler::handle_response(
+  int ret,
+  bufferlist::iterator& indata)
+{
+  ldout(cct, 20) << "handle_response ret = " << ret << dendl;
+  RWLock::WLocker l(lock);
+
+  if (ret < 0)
+    return ret;
+
+  int retval = 0;
+  OM_uint32 maj_stat, min_stat;
+  gss_buffer_desc input_token = {0};
+  gss_OID_set_desc desired_mechs;
+
+  desired_mechs.elements = &gss_spnego_mechanism_oid_desc;
+  desired_mechs.count = 1;
+
+  struct GssapiResponseHeader header;
+  ::decode(header, indata);
+
+  if (gss_cred == GSS_C_NO_CREDENTIAL) {
+    string client_name = cct->_conf->name.to_str();
+    gss_OID client_name_type = gss_nt_user_name;
+    gss_buffer_desc client_name_buffer;
+
+    client_name_buffer.value = (void *)client_name.c_str();
+    client_name_buffer.length = client_name.length();
+
+    if (cct->_conf->name.get_type() == CEPH_ENTITY_TYPE_CLIENT) {
+      maj_stat = gss_import_name(
+                         &min_stat,
+                         &client_name_buffer,
+                         client_name_type,
+                         &gss_client_name);
+      if (maj_stat != GSS_S_COMPLETE) {
+        string st = auth_gssapi_display_status(maj_stat, min_stat);
+        ldout(cct, 0) << "gss_import_name() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+      }
+    }
+
+    maj_stat = gss_acquire_cred(
+                       &min_stat,
+                       gss_client_name,
+                       0,
+                       &desired_mechs,
+                       GSS_C_INITIATE,
+                       &gss_cred,
+                       NULL,
+                       NULL);
+    if (maj_stat != GSS_S_COMPLETE) {
+      string st = auth_gssapi_display_status(maj_stat, min_stat);
+      ldout(cct, 0) << "gss_acquire_cred() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+      return -EPERM;
+    }
+
+    string target_name = "ceph";
+    gss_OID input_name_type = gss_nt_service_name;
+    gss_buffer_desc input_name_buffer;
+
+    input_name_buffer.value = (void *)target_name.c_str();
+    input_name_buffer.length = target_name.length();
+
+    maj_stat = gss_import_name(
+                       &min_stat,
+                       &input_name_buffer,
+                       input_name_type,
+                       &gss_service_name);
+    if (maj_stat != GSS_S_COMPLETE) {
+      // error parsing name
+      string st = auth_gssapi_display_status(maj_stat, min_stat);
+      ldout(cct, 0) << "gss_import_name() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+    }
+
+  } else {
+
+    GssapiTokenBlob input_token_blob;
+    ::decode(input_token_blob, indata);
+
+    ldout(cct, 20) << "gssapi token blob is:\n";
+    input_token_blob.blob.hexdump(*_dout);
+    *_dout << dendl;
+
+    input_token.value = input_token_blob.blob.c_str();
+    input_token.length = input_token_blob.blob.length();
+  }
+
+  const gss_OID mech_type = desired_mechs.elements;
+  OM_uint32 req_flags = GSS_C_MUTUAL_FLAG | GSS_C_INTEG_FLAG;
+  OM_uint32 ret_flags = 0;
+
+  if (gss_output_token.length != 0) {
+    gss_release_buffer(&min_stat, (gss_buffer_t)&gss_output_token);
+  }
+
+  maj_stat = gss_init_sec_context(
+                     &min_stat,
+                     gss_cred,
+                     &gss_sec_context,
+                     gss_service_name,
+                     mech_type,
+                     req_flags,
+                     0,
+                     NULL, /* channel bindings */
+                     &input_token,
+                     NULL, /* mech type */
+                     &gss_output_token,
+                     &ret_flags,
+                     NULL);  /* time_rec */
+  switch (maj_stat) {
+    case GSS_S_COMPLETE:
+      ldout(cct, 20) << "gss_init_sec_context() COMPLETE" << dendl;
+      retval = 0;
+      break;
+
+    case GSS_S_CONTINUE_NEEDED:
+      ldout(cct, 20) << "gss_init_sec_context() CONTINUE_NEEDED" << dendl;
+      retval = -EAGAIN;
+      break;
+
+    default:
+      string st = auth_gssapi_display_status(maj_stat, min_stat);
+      ldout(cct, 0) << "gss_init_sec_context() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+
+      retval = -EPERM;
+      break;
+  }
+
+  return retval;
+}
+
+
+AuthAuthorizer *GssapiClientHandler::build_authorizer(uint32_t service_id) const
+{
+  RWLock::RLocker l(lock);
+  ldout(cct, 20) << "build_authorizer for service " << ceph_entity_type_name(service_id) << dendl;
+  GssapiAuthorizer *auth = new GssapiAuthorizer();
+  if (auth) {
+    auth->build_authorizer(cct->_conf->name, global_id);
+  }
+  return auth;
+}

--- a/src/auth/gssapi/GssapiClientHandler.h
+++ b/src/auth/gssapi/GssapiClientHandler.h
@@ -1,0 +1,76 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_AUTHGSSAPICLIENTHANDLER_H
+#define CEPH_AUTHGSSAPICLIENTHANDLER_H
+
+#include "auth/AuthClientHandler.h"
+#include "GssapiProtocol.h"
+#include "common/ceph_context.h"
+#include "common/config.h"
+
+#include <gssapi/gssapi_generic.h>
+#include <gssapi/gssapi_krb5.h>
+#include <gssapi/gssapi_ext.h>
+ 
+class GssapiClientHandler : public AuthClientHandler {
+
+  gss_name_t gss_client_name;
+  gss_name_t gss_service_name;
+  gss_cred_id_t gss_cred;
+  gss_ctx_id_t gss_sec_context;
+  gss_buffer_desc gss_output_token;
+
+public:
+  GssapiClientHandler(CephContext *cct_, RotatingKeyRing *rsecrets) 
+    : AuthClientHandler(cct_),
+      gss_client_name(GSS_C_NO_NAME),
+      gss_service_name(GSS_C_NO_NAME),
+      gss_cred(GSS_C_NO_CREDENTIAL),
+      gss_sec_context(GSS_C_NO_CONTEXT),
+      gss_output_token({0})
+  {
+    reset();
+  }
+
+  void reset() {
+    RWLock::WLocker l(lock);
+    gss_client_name = GSS_C_NO_NAME;
+    gss_service_name = GSS_C_NO_NAME;
+    gss_cred = GSS_C_NO_CREDENTIAL;
+    gss_sec_context = GSS_C_NO_CONTEXT;
+    gss_output_token = {0};
+  }
+
+  ~GssapiClientHandler();
+
+  void prepare_build_request() {}
+  int build_request(bufferlist& bl) const;
+  int handle_response(int ret, bufferlist::iterator& iter);
+  bool build_rotating_request(bufferlist& bl) const { return false; }
+
+  int get_protocol() const { return CEPH_AUTH_GSSAPI; }
+  
+  AuthAuthorizer *build_authorizer(uint32_t service_id) const;
+
+  bool need_tickets() { return false; }
+
+  void set_global_id(uint64_t id) {
+    RWLock::WLocker l(lock);
+    global_id = id;
+  }
+  void validate_tickets() {}
+};
+
+#endif

--- a/src/auth/gssapi/GssapiProtocol.cc
+++ b/src/auth/gssapi/GssapiProtocol.cc
@@ -1,0 +1,78 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2009-2011 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "GssapiProtocol.h"
+
+#include "common/Clock.h"
+#include "common/config.h"
+#include "common/debug.h"
+#include "include/buffer.h"
+
+#define dout_subsys ceph_subsys_auth
+#undef dout_prefix
+#define dout_prefix *_dout << "gssapi: "
+
+static gss_OID_desc gss_mech_krb5_oid =
+        { 9, (void *)"\052\206\110\206\367\022\001\002\002" };
+
+string auth_gssapi_display_status(
+  OM_uint32 major,
+  OM_uint32 minor)
+{
+  string str;
+  OM_uint32 maj_stat;
+  OM_uint32 min_stat;
+  OM_uint32 message_context = 0;
+  gss_buffer_desc status_string = {0};
+
+  do {
+    maj_stat = gss_display_status(
+                       &min_stat,
+                       major,
+                       GSS_C_GSS_CODE,
+                       GSS_C_NO_OID,
+                       &message_context,
+                       &status_string);
+    if (maj_stat == GSS_S_COMPLETE) {
+      str.append((char *)status_string.value, status_string.length);
+      str += ".";
+      if (message_context != 0) {
+          str += " ";
+      }
+      gss_release_buffer(&min_stat, &status_string);
+    }
+  } while (message_context != 0);
+
+  if (major == GSS_S_FAILURE) {
+    do {
+       maj_stat = gss_display_status(
+                 &min_stat,
+                 minor,
+                 GSS_C_MECH_CODE,
+                 &gss_mech_krb5_oid,
+                 &message_context,
+                 &status_string);
+       if (maj_stat == GSS_S_COMPLETE) {
+         str.append((char *)status_string.value, status_string.length);
+         str += ".";
+         if (message_context != 0) {
+             str += " ";
+         }
+         gss_release_buffer(&min_stat, &status_string);
+       }
+    } while (message_context != 0);
+  }
+
+  return str;
+}

--- a/src/auth/gssapi/GssapiProtocol.h
+++ b/src/auth/gssapi/GssapiProtocol.h
@@ -1,0 +1,102 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_AUTHGSSAPIPROTOCOL_H
+#define CEPH_AUTHGSSAPIPROTOCOL_H
+
+/* authenticate requests */
+#define GSSAPI_MUTUAL_AUTH               0x0100
+#define GSSAPI_TOKEN                     0x0200
+
+#define GSSAPI_REQUEST_TYPE_MASK            0x0F00
+#define GSSAPI_CRYPT_ERR			1
+
+#include "auth/Auth.h"
+#include <errno.h>
+#include <sstream>
+
+#include <gssapi/gssapi_generic.h>
+#include <gssapi/gssapi_krb5.h>
+#include <gssapi/gssapi_ext.h>
+
+
+string auth_gssapi_display_status(
+  OM_uint32 major,
+  OM_uint32 minor);
+
+class CephContext;
+
+/*
+ * Authentication
+ */
+
+// request/reply headers, for subsequent exchanges.
+
+struct GssapiRequestHeader {
+  uint16_t request_type;
+
+  void encode(bufferlist& bl) const {
+    ::encode(request_type, bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    ::decode(request_type, bl);
+  }
+};
+WRITE_CLASS_ENCODER(GssapiRequestHeader)
+
+struct GssapiResponseHeader {
+  uint16_t response_type;
+
+  void encode(bufferlist& bl) const {
+    ::encode(response_type, bl);
+  }
+  void decode(bufferlist::iterator& bl) {
+    ::decode(response_type, bl);
+  }
+};
+WRITE_CLASS_ENCODER(GssapiResponseHeader)
+
+struct GssapiTokenBlob {
+  bufferlist blob;
+
+  GssapiTokenBlob() {}
+
+  void encode(bufferlist& bl) const {
+     __u8 struct_v = 1;
+    ::encode(struct_v, bl);
+    ::encode(blob, bl);
+  }
+
+  void decode(bufferlist::iterator& bl) {
+    __u8 struct_v;
+    ::decode(struct_v, bl);
+    ::decode(blob, bl);
+  }
+};
+WRITE_CLASS_ENCODER(GssapiTokenBlob)
+
+
+struct GssapiAuthorizer : public AuthAuthorizer {
+  GssapiAuthorizer() : AuthAuthorizer(CEPH_AUTH_GSSAPI) { }
+  bool build_authorizer(const EntityName &ename, uint64_t global_id) {
+    __u8 struct_v = 1;
+    ::encode(struct_v, bl);
+    ::encode(ename, bl);
+    ::encode(global_id, bl);
+    return 0;
+  }
+  bool verify_reply(bufferlist::iterator& reply) { return true; }
+};
+
+#endif

--- a/src/auth/gssapi/GssapiServiceHandler.cc
+++ b/src/auth/gssapi/GssapiServiceHandler.cc
@@ -1,0 +1,190 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+
+#include "GssapiProtocol.h"
+#include "GssapiServiceHandler.h"
+
+#include <errno.h>
+#include <sstream>
+
+#include "common/config.h"
+#include "common/debug.h"
+
+#define dout_subsys ceph_subsys_auth
+#undef dout_prefix
+#define dout_prefix *_dout << "gssapi server " << entity_name << ": "
+
+GssapiServiceHandler::~GssapiServiceHandler(void)
+{
+  OM_uint32 min_stat;
+
+  gss_release_name(&min_stat, &gss_service_name);
+  gss_release_cred(&min_stat, &gss_cred);
+  gss_delete_sec_context(&min_stat, &gss_sec_context, GSS_C_NO_BUFFER);
+  gss_release_buffer(&min_stat, (gss_buffer_t)&gss_output_token);
+}
+
+int GssapiServiceHandler::start_session(
+  EntityName& name,
+  bufferlist::iterator& indata,
+  bufferlist& result_bl,
+  AuthCapsInfo& caps)
+{
+  ldout(cct, 20) << "start_session" << dendl;
+
+  entity_name = name;
+
+  int ret = 0;
+  OM_uint32 maj_stat, min_stat;
+  gss_buffer_desc name_buffer;
+  gss_OID input_name_type = (gss_OID) gss_nt_service_name;
+
+  string service_name = "ceph";
+  name_buffer.value = (void *)service_name.c_str();
+  name_buffer.length = service_name.length();
+
+  maj_stat = gss_import_name(
+                     &min_stat,
+                     &name_buffer,
+                     input_name_type,
+                     &gss_service_name);
+  if (maj_stat != GSS_S_COMPLETE) {
+    string st = auth_gssapi_display_status(maj_stat, min_stat);
+    ldout(cct, 0) << "gss_import_name() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+  }
+
+  gss_OID_set desired_mechs = GSS_C_NO_OID_SET;
+
+  maj_stat = gss_acquire_cred(
+                     &min_stat,
+                     gss_service_name,
+                     0,
+                     desired_mechs,
+                     GSS_C_ACCEPT,
+                     &gss_cred,
+                     NULL,
+                     NULL);
+  if (maj_stat != GSS_S_COMPLETE) {
+    string st = auth_gssapi_display_status(maj_stat, min_stat);
+    ldout(cct, 0) << "gss_acquire_cred() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+    ret = -EPERM;
+  } else {
+    GssapiResponseHeader header;
+    header.response_type = GSSAPI_MUTUAL_AUTH;
+    ::encode(header, result_bl);
+    ret = CEPH_AUTH_GSSAPI;
+  }
+
+  return ret;
+}
+
+int GssapiServiceHandler::handle_request(
+  bufferlist::iterator& indata,
+  bufferlist& result_bl,
+  uint64_t& global_id,
+  AuthCapsInfo& caps,
+  uint64_t *auid)
+{
+  ldout(cct, 20) << "handle_request" << dendl;
+
+  int ret = 0;
+
+  struct GssapiRequestHeader header;
+  ::decode(header, indata);
+
+  GssapiTokenBlob token_blob;
+  ::decode(token_blob, indata);
+
+  ldout(cct, 20) << "gssapi input token blob is:\n";
+  token_blob.blob.hexdump(*_dout);
+  *_dout << dendl;
+
+  OM_uint32 maj_stat, min_stat;
+
+  gss_buffer_desc input_token = {0};
+  gss_name_t client_name = GSS_C_NO_NAME;
+  OM_uint32 ret_flags;
+  gss_OID doid;
+
+  input_token.value = token_blob.blob.c_str();
+  input_token.length = token_blob.blob.length();
+
+  if (gss_output_token.length != 0) {
+    gss_release_buffer(&min_stat, (gss_buffer_t)&gss_output_token);
+  }
+
+  maj_stat = gss_accept_sec_context(
+                     &min_stat,
+                     &gss_sec_context,
+                     gss_cred,
+                     &input_token,
+                     GSS_C_NO_CHANNEL_BINDINGS,
+                     &client_name,
+                     &doid,
+                     &gss_output_token,
+                     &ret_flags,
+                     NULL,  /* time_rec */
+                     NULL); /* del_cred_handle */
+  switch (maj_stat) {
+    case GSS_S_COMPLETE:
+      ldout(cct, 20) << "gss_accept_sec_context() SUCCESS " << dendl;
+      ret = 0;
+
+      if (!key_server->get_service_caps(entity_name, CEPH_ENTITY_TYPE_MON, caps)) {
+        ldout(cct, 0) << " could not get mon caps for " << entity_name << dendl;
+        ret = -EACCES;
+      } else {
+        char *caps_str = caps.caps.c_str();
+        if (!caps_str || !caps_str[0]) {
+          ldout(cct,0) << "mon caps null for " << entity_name << dendl;
+          ret = -EACCES;
+        }
+      }
+      break;
+
+    case GSS_S_CONTINUE_NEEDED:
+      ldout(cct, 20) << "gss_accept_sec_context() CONTINUE_NEEDED" << dendl;
+      ret = 0;
+      break;
+
+    default:
+      string st = auth_gssapi_display_status(maj_stat, min_stat);
+      ldout(cct, 0) << "gss_accept_sec_context() failed: " << maj_stat << " " << min_stat << " " << st << dendl;
+      ret = -EPERM;
+      break;
+  }
+
+  if (gss_output_token.length != 0) {
+    GssapiResponseHeader header;
+    header.response_type = GSSAPI_TOKEN;
+    ::encode(header, result_bl);
+
+    GssapiTokenBlob token_blob;
+
+    token_blob.blob.append(buffer::create_static(
+          gss_output_token.length,
+          (char*)gss_output_token.value));
+
+    ::encode(token_blob, result_bl);
+
+    ldout(cct, 20) << "gssapi output token blob is:\n";
+    token_blob.blob.hexdump(*_dout);
+    *_dout << dendl;
+  }
+
+  gss_release_name(&min_stat, &client_name);
+
+  return ret;
+}

--- a/src/auth/gssapi/GssapiServiceHandler.h
+++ b/src/auth/gssapi/GssapiServiceHandler.h
@@ -1,0 +1,50 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_AUTHGSSAPISERVICEHANDLER_H
+#define CEPH_AUTHGSSAPISERVICEHANDLER_H
+
+#include "auth/AuthServiceHandler.h"
+#include "auth/Auth.h"
+#include "auth/cephx/CephxKeyServer.h"
+
+#include <gssapi/gssapi_generic.h>
+#include <gssapi/gssapi_krb5.h>
+#include <gssapi/gssapi_ext.h>
+
+class CephContext;
+class KeyServer;
+
+class GssapiServiceHandler  : public AuthServiceHandler {
+
+  KeyServer *key_server;
+  gss_name_t gss_service_name;
+  gss_cred_id_t gss_cred;
+  gss_ctx_id_t gss_sec_context;
+  gss_buffer_desc gss_output_token;
+
+public:
+  explicit GssapiServiceHandler(CephContext *cct_, KeyServer *ks)
+    : AuthServiceHandler(cct_),
+      key_server(ks),
+      gss_service_name(GSS_C_NO_NAME),
+      gss_cred(GSS_C_NO_CREDENTIAL),
+      gss_sec_context(GSS_C_NO_CONTEXT),
+      gss_output_token({0}) {}
+  ~GssapiServiceHandler();
+  int start_session(EntityName& name, bufferlist::iterator& indata, bufferlist& result_bl, AuthCapsInfo& caps);
+  int handle_request(bufferlist::iterator& indata, bufferlist& result_bl, uint64_t& global_id, AuthCapsInfo& caps, uint64_t *auid = NULL);
+};
+
+#endif

--- a/src/auth/gssapi/GssapiSessionHandler.h
+++ b/src/auth/gssapi/GssapiSessionHandler.h
@@ -1,0 +1,53 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2009 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_AUTHGSSAPISESSIONHANDLER_H
+#define CEPH_AUTHGSSAPISESSIONHANDLER_H
+
+#include "auth/AuthSessionHandler.h"
+#include "msg/Message.h"
+
+class CephContext;
+
+class GssapiSessionHandler  : public AuthSessionHandler {
+public:
+  GssapiSessionHandler(CephContext *cct_, CryptoKey session_key)
+    : AuthSessionHandler(cct_, CEPH_AUTH_GSSAPI, session_key) {}
+  ~GssapiSessionHandler() {}
+  
+  bool no_security() {
+    return true;
+  }
+
+  // The Gssapi suite neither signs nor encrypts messages, so these functions just return success.
+  // Since nothing was signed or encrypted, don't increment the stats.  PLR
+
+  int sign_message(Message *m) {
+    return 0;
+  }
+
+  int check_message_signature(Message *m) {
+    return 0;
+  }
+
+  int encrypt_message(Message *m) {
+    return 0;
+  }
+
+  int decrypt_message(Message *m) {
+    return 0;
+  }
+
+};
+#endif

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -41,6 +41,8 @@ OPTION(restapi_base_url, OPT_STR, "")	// "
 OPTION(fatal_signal_handlers, OPT_BOOL, true)
 OPTION(erasure_code_dir, OPT_STR, CEPH_PKGLIBDIR"/erasure-code") // default location for erasure-code plugins
 
+OPTION(krb5_client_keytab_file, OPT_STR, "/var/lib/ceph/$name/krb5_client.keytab")
+
 OPTION(log_file, OPT_STR, "/var/log/ceph/$cluster-$name.log") // default changed by common_preinit()
 OPTION(log_max_new, OPT_INT, 1000) // default changed by common_preinit()
 OPTION(log_max_recent, OPT_INT, 10000) // default changed by common_preinit()

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -72,6 +72,7 @@ struct ceph_dir_layout {
 #define CEPH_AUTH_UNKNOWN	0x0
 #define CEPH_AUTH_NONE	 	0x1
 #define CEPH_AUTH_CEPHX	 	0x2
+#define CEPH_AUTH_GSSAPI 	0x3
 
 #define CEPH_AUTH_UID_DEFAULT ((__u64) -1)
 

--- a/src/librados/CMakeLists.txt
+++ b/src/librados/CMakeLists.txt
@@ -9,7 +9,7 @@ add_library(rados_a STATIC
   $<TARGET_OBJECTS:librados_objs>
   $<TARGET_OBJECTS:common_buffer_obj>)
 target_link_libraries(rados_a osdc ceph-common cls_lock_client
-    ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
+    ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS} ${GSSAPI_LIBRARY})
 if(WITH_LTTNG)
   add_dependencies(librados_api_obj librados-tp)
 endif()
@@ -20,7 +20,7 @@ if(ENABLE_SHARED)
     $<TARGET_OBJECTS:common_buffer_obj>)
   # LINK_PRIVATE instead of PRIVATE is used to backward compatibility with cmake 2.8.11
   target_link_libraries(librados LINK_PRIVATE osdc ceph-common cls_lock_client
-    ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS})
+    ${BLKID_LIBRARIES} ${CRYPTO_LIBS} ${EXTRALIBS} ${GSSAPI_LIBRARY})
   set_target_properties(librados PROPERTIES
     OUTPUT_NAME rados
     VERSION 2.0.0

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -118,7 +118,8 @@ target_link_libraries(librbd LINK_PRIVATE
   ceph-common
   pthread
   ${CMAKE_DL_LIBS}
-  ${EXTRALIBS})
+  ${EXTRALIBS}
+  ${GSSAPI_LIBRARY})
 if(HAVE_UDEV)
   target_link_libraries(librbd LINK_PRIVATE
     udev)

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -89,6 +89,7 @@ MDSDaemon::MDSDaemon(const std::string &n, Messenger *m, MonClient *mc) :
   mds_lock("MDSDaemon::mds_lock"),
   stopping(false),
   timer(m->cct, mds_lock),
+  client_keytab(m->cct->_conf->krb5_client_keytab_file),
   beacon(m->cct, mc, n),
   authorize_handler_cluster_registry(new AuthAuthorizeHandlerRegistry(m->cct,
 								      m->cct->_conf->auth_supported.empty() ?
@@ -109,8 +110,14 @@ MDSDaemon::MDSDaemon(const std::string &n, Messenger *m, MonClient *mc) :
 {
   orig_argc = 0;
   orig_argv = NULL;
+  int r = 0;
 
   clog = log_client.create_channel();
+
+  if (!client_keytab.empty()){
+    r = setenv("KRB5_CLIENT_KTNAME", client_keytab.c_str(), 1);
+    assert(!r);
+  }
 
   monc->set_messenger(messenger);
 

--- a/src/mds/MDSDaemon.h
+++ b/src/mds/MDSDaemon.h
@@ -71,7 +71,7 @@ class MDSDaemon : public Dispatcher, public md_config_obs_t {
   bool         stopping;
 
   SafeTimer    timer;
-
+  string       client_keytab;
  protected:
   Beacon  beacon;
 

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -6,6 +6,7 @@ set(lib_mon_srcs
   ${CMAKE_SOURCE_DIR}/src/auth/cephx/CephxKeyServer.cc
   ${CMAKE_SOURCE_DIR}/src/auth/cephx/CephxServiceHandler.cc
   ${CMAKE_SOURCE_DIR}/src/auth/AuthServiceHandler.cc
+  ${CMAKE_SOURCE_DIR}/src/auth/gssapi/GssapiServiceHandler.cc
   ${osd_mon_files}
   Paxos.cc
   PaxosService.cc

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -153,6 +153,7 @@ public:
 
   const MonCommand *leader_supported_mon_commands;
   int leader_supported_mon_commands_size;
+  string client_keytab;
 
 private:
   void new_tick();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1717,6 +1717,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
   tick_timer(cct, osd_lock),
   tick_timer_lock("OSD::tick_timer_lock"),
   tick_timer_without_osd_lock(cct, tick_timer_lock),
+  client_keytab(cct->_conf->krb5_client_keytab_file),
   authorize_handler_cluster_registry(new AuthAuthorizeHandlerRegistry(cct,
 								      cct->_conf->auth_supported.empty() ?
 								      cct->_conf->auth_cluster_required :
@@ -1795,6 +1796,12 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
     &disk_tp),
   service(this)
 {
+  int r = 0;
+  if (!client_keytab.empty()){
+    r = setenv("KRB5_CLIENT_KTNAME", client_keytab.c_str(), 1);
+    assert(!r);
+  }
+
   monc->set_messenger(client_messenger);
   op_tracker.set_complaint_and_threshold(cct->_conf->osd_op_complaint_time,
                                          cct->_conf->osd_op_log_threshold);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1261,6 +1261,7 @@ class OSD : public Dispatcher,
   // Tick timer for those stuff that do not need osd_lock
   Mutex tick_timer_lock;
   SafeTimer tick_timer_without_osd_lock;
+  string client_keytab;
 public:
   // config observer bits
   virtual const char** get_tracked_conf_keys() const;

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 include(AddCephTest)
 
-set(UNITTEST_LIBS gmock_main gmock gtest ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
+set(UNITTEST_LIBS gmock_main gmock gtest ${GSSAPI_LIBRARY} ${CMAKE_THREAD_LIBS_INIT} ${CMAKE_DL_LIBS})
 set(UNITTEST_CXX_FLAGS "-I${CMAKE_SOURCE_DIR}/src/googletest/googlemock/include -I${CMAKE_BINARY_DIR}/src/googletest/googlemock/include -I${CMAKE_SOURCE_DIR}/src/googletest/googletest/include -I${CMAKE_BINARY_DIR}/src/googletest/googletest/include -fno-strict-aliasing")
 
 add_library(unit-main OBJECT unit.cc)

--- a/src/test/librados/CMakeLists.txt
+++ b/src/test/librados/CMakeLists.txt
@@ -3,7 +3,7 @@ set(libradostest_srcs
   test.cc 
   TestCase.cc)
 add_library(radostest STATIC ${libradostest_srcs})
-target_link_libraries(radostest ceph-common json_spirit ${EXTRALIBS})
+target_link_libraries(radostest ceph-common json_spirit ${GSSAPI_LIBRARY} ${EXTRALIBS})
 set_target_properties(radostest PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
 # ceph_test_rados_api_cmd
@@ -157,7 +157,7 @@ add_executable(unittest_librados
   librados.cc
   )
 add_ceph_unittest(unittest_librados ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_librados)
-target_link_libraries(unittest_librados librados ${BLKID_LIBRARIES})
+target_link_libraries(unittest_librados librados ${BLKID_LIBRARIES} ${GSSAPI_LIBRARY})
 
 # unittest_librados_config
 add_executable(unittest_librados_config
@@ -167,5 +167,6 @@ add_ceph_unittest(unittest_librados_config ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/uni
 target_link_libraries(unittest_librados_config
   librados
   ${BLKID_LIBRARIES}
+  ${GSSAPI_LIBRARY}
   )
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -93,6 +93,7 @@ ec=0
 hitset=""
 overwrite_conf=1
 cephx=1 #turn cephx on by default
+gssapi=0
 cache=""
 memstore=0
 bluestore=0
@@ -137,6 +138,7 @@ usage=$usage"\t--cache <pool>: enable cache tiering on pool\n"
 usage=$usage"\t--short: short object names only; necessary for ext4 dev\n"
 usage=$usage"\t--nolockdep disable lockdep\n"
 usage=$usage"\t--multimds <count> allow multimds with maximum active count\n"
+usage=$usage"\t-g, --gssapi use gssapi authentication\n"
 
 usage_exit() {
 	printf "$usage"
@@ -283,6 +285,9 @@ case $1 in
     --multimds)
         CEPH_MAX_MDS="$2"
         shift
+        ;;
+    -g | --gssapi )
+        gssapi=1
         ;;
     * )
 	    usage_exit
@@ -530,6 +535,13 @@ EOF
         auth cluster required = cephx
         auth service required = cephx
         auth client required = cephx
+EOF
+		elif [ "$gssapi" -eq 1 ] ; then
+			wconf <<EOF
+        auth cluster required = gssapi
+        auth service required = gssapi
+        auth client required = gssapi
+        krb5 client keytab file = $CEPH_DEV_DIR/krb5_\$name.keytab
 EOF
 		else
 			wconf <<EOF


### PR DESCRIPTION
This is a prototype of a new Kerberos authentication
mechansim for Ceph.  This will allow client users
with Kerberos credentials to authenticate with MON
using GSSAPI/krb5.  It also supports cluster
authentication using client keytab files.
Kerberos users map directly to ceph users, and
authorization is done using the existing ceph user
caps.

Signed-off-by: Jonathan Brown <brownj@vmware.com>
Signed-off-by: Dheeraj Shetty <dheerajs@vmware.com>