### PR TITLE
qa/suites/upgrade/kraken-x: do not thrash cluster full during upgrade

### DIFF
--- a/qa/suites/upgrade/kraken-x/stress-split-erasure-code/3-thrash/default.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split-erasure-code/3-thrash/default.yaml
@@ -17,4 +17,5 @@ stress-tasks:
     chance_pgnum_grow: 1
     chance_pgpnum_fix: 1
     min_in: 4
+    chance_thrash_cluster_full: 0
 - print: "**** done thrashosds 3-thrash"

--- a/qa/suites/upgrade/kraken-x/stress-split/3-thrash/default.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/3-thrash/default.yaml
@@ -16,4 +16,5 @@ stress-tasks:
     timeout: 1200
     chance_pgnum_grow: 1
     chance_pgpnum_fix: 1
+    chance_thrash_cluster_full: 0
 - print: "**** done thrashosds 3-thrash"


### PR DESCRIPTION
Same thing as 39fdc53fe5f33678fbbd00cf8810b6d523d0040c

Fixes: http://tracker.ceph.com/issues/19232
Signed-off-by: Dan Mick <dan.mick@redhat.com>