### PR TITLE
rgw_file: fix reversed return value of getattr

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1494,7 +1494,7 @@ int rgw_getattr(struct rgw_fs *rgw_fs,
   RGWLibFS *fs = static_cast<RGWLibFS*>(rgw_fs->fs_private);
   RGWFileHandle* rgw_fh = get_rgwfh(fh);
 
-  return -(fs->getattr(rgw_fh, st));
+  return fs->getattr(rgw_fh, st);
 }
 
 /*


### PR DESCRIPTION
When ::getattr returns -ESTALE, rgw_getattr returns ESTALE,
which is a not expected postive.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>