### PR TITLE
mds: fix handling very fast delete ops

### DIFF
--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -124,7 +124,7 @@ protected:
   void _execute_item(
       const PurgeItem &item,
       uint64_t expire_to);
-  void execute_item_complete(
+  void _execute_item_complete(
       uint64_t expire_to);
 
 


### PR DESCRIPTION
Deletions can complete so quickly that we're
ready to call execute_item_complete before
the end of execute_item.  We could use a finisher
here so that the completion was always called
from outside PurgeQueue::lock, but it's more efficient
to just handle the inline case directly.

Fixes: http://tracker.ceph.com/issues/19245
Signed-off-by: John Spray <john.spray@redhat.com>