### PR TITLE
test: sed on FreeBSD requires "-i extension", so use gsed

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -44,6 +44,7 @@ if [ x`uname`x = xFreeBSDx ]; then
         misc/e2fsprogs-libuuid \
         misc/getopt \
         textproc/expat2 \
+        textproc/gsed \
         textproc/libxml2 \
         textproc/xmlstarlet \
 	textproc/jq \

--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -29,6 +29,11 @@ else
 	echo "Missing xmlstarlet binary!"
 	exit 1
 fi
+if [ `uname` = FreeBSD ]; then
+    SED=gsed
+else
+    SED=sed
+fi 
 
 #! @file ceph-helpers.sh
 #  @brief Toolbox to manage Ceph cluster dedicated to testing

--- a/src/test/crush/crush-classes.sh
+++ b/src/test/crush/crush-classes.sh
@@ -71,7 +71,7 @@ function TEST_classes() {
     #
     ceph osd getcrushmap > $dir/map || return 1
     crushtool -d $dir/map -o $dir/map.txt || return 1
-    sed -i \
+    ${SED} -i \
         -e '/device 0 osd.0/s/$/ class ssd/' \
         -e '/step take default/s/$/ class ssd/' \
         $dir/map.txt || return 1

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -27,7 +27,7 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
 
-    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    local funcs=${@:-$(set | ${SED} -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
         setup $dir || return 1
         $func $dir || return 1
@@ -146,9 +146,9 @@ function generate_manipulated_rules() {
     ceph osd getcrushmap -o $dir/original_map
     crushtool -d $dir/original_map -o $dir/decoded_original_map
     #manipulate the rulesets , to make the rule_id != ruleset_id
-    sed -i 's/ruleset 0/ruleset 3/' $dir/decoded_original_map
-    sed -i 's/ruleset 2/ruleset 0/' $dir/decoded_original_map
-    sed -i 's/ruleset 1/ruleset 2/' $dir/decoded_original_map
+    ${SED} -i 's/ruleset 0/ruleset 3/' $dir/decoded_original_map
+    ${SED} -i 's/ruleset 2/ruleset 0/' $dir/decoded_original_map
+    ${SED} -i 's/ruleset 1/ruleset 2/' $dir/decoded_original_map
 
     crushtool -c $dir/decoded_original_map -o $dir/new_map
     ceph osd setcrushmap -i $dir/new_map

--- a/src/test/test_crush_bucket.sh
+++ b/src/test/test_crush_bucket.sh
@@ -16,7 +16,7 @@ function run() {
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "
 
-    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    local funcs=${@:-$(set | ${SED} -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
     for func in $funcs ; do
         $func $dir || return 1
     done
@@ -33,12 +33,12 @@ function TEST_crush_bucket() {
 
     ceph osd getcrushmap -o "$dir/map1" || return 1
     crushtool -d "$dir/map1" -o "$dir/map1.txt"|| return 1
-    local var=`ceph osd crush dump|grep -w id|grep '-'|grep -Eo '[0-9]+'|sort|uniq|sed -n '$p'`
+    local var=`ceph osd crush dump|grep -w id|grep '-'|grep -Eo '[0-9]+'|sort|uniq|${SED} -n '$p'`
     local id=`expr  $var + 1`
-    local item=`sed -n '/^root/,/}/p' $dir/map1.txt|grep  'item'|head -1`
-    local weight=`sed -n '/^root/,/}/p' $dir/map1.txt|grep  'item'|head -1|awk '{print $4}'`
+    local item=`${SED} -n '/^root/,/}/p' $dir/map1.txt|grep  'item'|head -1`
+    local weight=`${SED} -n '/^root/,/}/p' $dir/map1.txt|grep  'item'|head -1|awk '{print $4}'`
     local bucket="host test {\n id -$id\n # weight $weight\n alg straw \n hash 0  # rjenkins1 \n $item\n}\n"
-    sed -i "/# buckets/a\ $bucket" "$dir/map1.txt"
+    ${SED} -i "/# buckets/a\ $bucket" "$dir/map1.txt"
     crushtool  -c "$dir/map1.txt" -o "$dir/map1.bin" 2>"$dir/rev"
     local result=$(cat "$dir/rev")
     if [ "$result" != "" ];


### PR DESCRIPTION
- FreeBSD sed wants a backup extention after the -i option
   or otherwise it starts eating the next option

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>