### PR TITLE
mon: fix hiding mdsmonitor informative strings

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1369,7 +1369,6 @@ int MDSMonitor::filesystem_command(
       pending_fsmap.modify_daemon(gid, [state](MDSMap::mds_info_t *info) {
         info->state = state;
       });
-      stringstream ss;
       ss << "set mds gid " << gid << " to state " << state << " "
          << ceph_mds_state_name(state);
       return 0;
@@ -1400,7 +1399,6 @@ int MDSMonitor::filesystem_command(
         return -EBUSY;
       } else {
         pending_fsmap.erase(gid, {});
-        stringstream ss;
         ss << "removed mds gid " << gid;
         return 0;
       }
@@ -1430,7 +1428,6 @@ int MDSMonitor::filesystem_command(
       fs->mds_map.failed.erase(role.rank);
     });
 
-    stringstream ss;
     ss << "removed failed mds." << role;
     return 0;
   } else if (prefix == "mds compat rm_compat") {


### PR DESCRIPTION
Local `stringstream ss` declarations were hiding
the real variable used to feed back to the user.

Fixes: http://tracker.ceph.com/issues/16709
Signed-off-by: John Spray <john.spray@redhat.com>