### PR TITLE
rgw: Support SLO Manifest retrieval

### DIFF
--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1419,3 +1419,18 @@ void RGWOrphanSearchState::dump(Formatter *f) const
   encode_json("stage", stage, f);
   f->close_section();
 }
+
+void rgw_slo_entry::dump(Formatter *f, bool raw_format) const
+{
+  f->open_object_section("rgw_slo_manifest_entry");
+  if (raw_format) {
+    encode_json("path", path, f);
+    encode_json("size_bytes", size_bytes, f);
+    encode_json("etag", etag, f);
+  } else {
+    encode_json("name", path, f);
+    encode_json("bytes", size_bytes, f);
+    encode_json("hash", etag, f);
+  }
+  f->close_section();
+}

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -130,6 +130,7 @@ protected:
   bool partial_content;
   bool range_parsed;
   bool skip_manifest;
+  bool raw_manifest_format;
   rgw_obj obj;
   utime_t gc_invalidate_time;
   bool is_slo;
@@ -164,6 +165,7 @@ public:
     partial_content = false;
     range_parsed = false;
     skip_manifest = false;
+    raw_manifest_format = false;
     is_slo = false;
     first_block = 0;
     last_block = 0;
@@ -657,9 +659,9 @@ struct rgw_slo_entry {
   }
 
   void decode_json(JSONObj *obj);
+  void dump(Formatter* f, bool raw_format) const;
 };
 WRITE_CLASS_ENCODER(rgw_slo_entry)
-
 struct RGWSLOInfo {
   vector<rgw_slo_entry> entries;
   uint64_t total_size;


### PR DESCRIPTION
* GET on SLO object with multipart-manifest=get parameter fetches the manifest instead of the object
* Support for format=raw parameter (as described in the Swift API documentation : https://docs.openstack.org/developer/swift/overview_large_objects.html)

Fixes: http://tracker.ceph.com/issues/19053
Signed-off-by: Rajath Shashidhara <rajath.shashidhara@gmail.com>