### PR TITLE
cls/rbd/cls_rbd_types.h: add missing destructor

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -133,6 +133,7 @@ inline void decode(MirrorImageStatusState &state, bufferlist::iterator& it)
 
 struct MirrorImageStatus {
   MirrorImageStatus() {}
+  ~MirrorImageStatus() {}
   MirrorImageStatus(MirrorImageStatusState state,
 		    const std::string &description = "")
     : state(state), description(description) {}


### PR DESCRIPTION
- FreeBSD/Clang complains during linkage

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>