### PR TITLE
os/filestore: queue ondisk completion before apply work

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2215,18 +2215,19 @@ void FileStore::_journaled_ahead(OpSequencer *osr, Op *o, Context *ondisk)
 {
   dout(5) << "_journaled_ahead " << o << " seq " << o->op << " " << *osr << " " << o->tls << dendl;
 
-  // this should queue in order because the journal does it's completions in order.
-  queue_op(osr, o);
-
-  list<Context*> to_queue;
-  osr->dequeue_journal(&to_queue);
-
   // do ondisk completions async, to prevent any onreadable_sync completions
   // getting blocked behind an ondisk completion.
   if (ondisk) {
     dout(10) << " queueing ondisk " << ondisk << dendl;
     ondisk_finishers[osr->id % m_ondisk_finisher_num]->queue(ondisk);
   }
+
+  // this should queue in order because the journal does it's completions in order.
+  queue_op(osr, o);
+
+  list<Context*> to_queue;
+  osr->dequeue_journal(&to_queue);
+
   if (!to_queue.empty()) {
     ondisk_finishers[osr->id % m_ondisk_finisher_num]->queue(to_queue);
   }


### PR DESCRIPTION
…and improve write op performance.

Signed-off-by: Pan Liu <liupan1111@gmail.com>