### PR TITLE
rgw: fix transition from full to incremental meta sync

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1485,7 +1485,7 @@ public:
 	  using WriteMarkerCR = RGWSimpleRadosWriteCR<rgw_meta_sync_marker>;
 	  yield call(new WriteMarkerCR(sync_env->async_rados, sync_env->store,
 				       rgw_raw_obj(pool, sync_env->shard_obj_name(shard_id)),
-				       sync_marker));
+				       *temp_marker));
         }
 
         if (retcode < 0) {


### PR DESCRIPTION
when transitioning to incremental sync, we need to write temp_marker
instead of sync_marker, because temp_marker has replaced the full sync
marker (which is a metadata key, rather than an log marker) with
next_step_marker

this was breaking the metadata checkpoint in test_multi.py, because it
was comparing metadata keys (i.e. 'user:zone.user') against mdlog
markers