### PR TITLE
doc: update Component Technical Leads and maintainers to canonical location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -7,18 +7,7 @@ Sage Weil <sage@redhat.com>
 Component Technical Leads
 -------------------------
 
-Core, RADOS   - Samuel Just <sjust@redhat.com>
-RBD           - Josh Durgin <jdurgin@redhat.com>
-                Jason Dillaman <dillaman@redhat.com>
-RBD (kernel)  - Ilya Dryomov <idryomov@redhat.com>
-RGW           - Yehuda Sadeh <yehuda@redhat.com>
-CephFS        - Greg Farnum <gfarnum@redhat.com>
-                Yan, Zheng <zyan@redhat.com>
-Deployment    - Alfredo Deza <adeza@redhat.com>
-Teuthology    - Zack Cerza <zack@redhat.com>
-Calamari      - Gregory Meno <gmeno@redhat.com>
-Chef Cookbook - Guilhem Lettron <guilhem@lettron.fr>
-
+For a full list of CTLs and maintainers visit: http://ceph.com/team/
 
 Contributors
 ------------


### PR DESCRIPTION
Update Component Technical Leads and maintainers to canonical location of http://ceph.com

signed-off-by: Patrick McGarry <pmcgarry@redhat.com>