### PR TITLE
osd: fix a signed/unsigned warning in PG

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2584,7 +2584,7 @@ void PG::_update_calc_stats()
   if ((is_degraded() || is_undersized() || !is_clean()) && is_peered()) {
     // NOTE: we only generate copies, degraded, misplaced and unfound
     // values for the summation, not individual stat categories.
-    uint64_t num_objects = info.stats.stats.sum.num_objects;
+    int64_t num_objects = info.stats.stats.sum.num_objects;
 
     // Total sum of all missing
     int64_t missing = 0;


### PR DESCRIPTION
It would be nice if the stats were unsigned, since they can't go negative,
but that's not the world we live in.
(Also, we probably use these structures as deltas which *do*
need to go negative? I didn't check.)

Signed-off-by: Greg Farnum <gfarnum@redhat.com>