### PR TITLE
osd: Move statically defined const parameter to header file

### DIFF
--- a/src/osd/ECUtil.cc
+++ b/src/osd/ECUtil.cc
@@ -201,14 +201,12 @@ void ECUtil::HashInfo::generate_test_instances(list<HashInfo*>& o)
   o.push_back(new HashInfo(4));
 }
 
-const string HINFO_KEY = "hinfo_key";
-
 bool ECUtil::is_hinfo_key_string(const string &key)
 {
-  return key == HINFO_KEY;
+  return key == ECUtil::HINFO_KEY;
 }
 
 const string &ECUtil::get_hinfo_key()
 {
-  return HINFO_KEY;
+  return ECUtil::HINFO_KEY;
 }

--- a/src/osd/ECUtil.h
+++ b/src/osd/ECUtil.h
@@ -32,6 +32,8 @@ const uint64_t CHUNK_INFO = 8;
 const uint64_t CHUNK_PADDING = 8;
 const uint64_t CHUNK_OVERHEAD = 16; // INFO + PADDING
 
+const std::string HINFO_KEY = "hinfo_key";
+
 class stripe_info_t {
   const uint64_t stripe_width;
   const uint64_t chunk_size;


### PR DESCRIPTION
Clean up const parameter

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>