### PR TITLE
[DNM] rgw: impl subuser usage log statistics

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -3033,8 +3033,13 @@ static int usage_log_trim_cb(cls_method_context_t hctx, const string& key, rgw_u
   string key_by_user;
 
   string o = entry.owner.to_str();
-  usage_record_name_by_time(entry.epoch, o, entry.bucket, key_by_time);
-  usage_record_name_by_user(o, entry.epoch, entry.bucket, key_by_user);
+  if (entry.subuser.empty()) {
+    usage_record_name_by_time(entry.epoch, o, entry.bucket, key_by_time);
+    usage_record_name_by_user(o, entry.epoch, entry.bucket, key_by_user);
+  } else {
+    usage_record_name_by_time4subuser(entry.epoch, o, entry.subuser, entry.bucket, key_by_time);
+    usage_record_name_by_subuser(o, entry.subuser, entry.epoch, entry.bucket, key_by_user);
+  }
 
   int ret = cls_cxx_map_remove_key(hctx, key_by_time);
   if (ret < 0)
@@ -3063,7 +3068,9 @@ int rgw_user_usage_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlis
   }
 
   string iter;
-  ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch, op.user, iter, 0, NULL, usage_log_trim_cb, NULL);
+  ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch,
+			    op.user, op.subuser,
+			    iter, 0, NULL, usage_log_trim_cb, NULL);
   if (ret < 0)
     return ret;
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2727,10 +2727,26 @@ static void usage_record_prefix_by_time(uint64_t epoch, string& key)
   key = buf;
 }
 
+static void usage_record_prefix_by_time4subuser(uint64_t epoch, string& key)
+{
+  char buf[32];
+  snprintf(buf, sizeof(buf), "$%011llu", (long long unsigned)epoch);
+  key = buf;
+}
+
 static void usage_record_prefix_by_user(string& user, uint64_t epoch, string& key)
 {
   char buf[user.size() + 32];
   snprintf(buf, sizeof(buf), "%s_%011llu_", user.c_str(), (long long unsigned)epoch);
+  key = buf;
+}
+
+static void usage_record_prefix_by_subuser(string& user, string& subuser,
+                                           uint64_t epoch, string& key)
+{
+  char buf[user.size() + subuser.size() + 32];
+  snprintf(buf, sizeof(buf), "$%s:%s_%011llu_",
+	   user.c_str(), subuser.c_str(), (long long unsigned)epoch);
   key = buf;
 }
 
@@ -2852,9 +2868,11 @@ int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist
 }
 
 static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64_t end,
-                            string& user, string& key_iter, uint32_t max_entries, bool *truncated,
-                            int (*cb)(cls_method_context_t, const string&, rgw_usage_log_entry&, void *),
-                            void *param)
+			       string& user, string& subuser,
+			       string& key_iter, uint32_t max_entries, bool *truncated,
+			       int (*cb)(cls_method_context_t, const string&,
+					 rgw_usage_log_entry&, void *),
+			       void *param)
 {
   CLS_LOG(10, "usage_iterate_range");
 
@@ -2863,8 +2881,10 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
   string filter_prefix;
   string start_key, end_key;
   bool by_user = !user.empty();
+  bool by_subuser = !subuser.empty();
   uint32_t i = 0;
   string user_key;
+  string subuser_key;
 
   if (truncated)
     *truncated = false;
@@ -2872,13 +2892,25 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
   if (!by_user) {
     usage_record_prefix_by_time(end, end_key);
   } else {
-    user_key = user;
-    user_key.append("_");
+    if (!by_subuser) {
+      user_key = user;
+      user_key += "_";
+    } else {
+      usage_record_prefix_by_time4subuser(end, end_key);
+      subuser_key = "$";
+      subuser_key += user;
+      subuser_key += ":";
+      subuser_key += subuser;
+      subuser_key += "_";
+    }
   }
 
   if (key_iter.empty()) {
     if (by_user) {
-      usage_record_prefix_by_user(user, start, start_key);
+      if (!by_subuser)
+	usage_record_prefix_by_user(user, start, start_key);
+      else
+	usage_record_prefix_by_subuser(user, subuser, start, start_key);
     } else {
       usage_record_prefix_by_time(start, start_key);
     }
@@ -2906,7 +2938,12 @@ static int usage_iterate_range(cls_method_context_t hctx, uint64_t start, uint64
         return 0;
       }
 
-      if (by_user && key.compare(0, user_key.size(), user_key) != 0) {
+      if (by_user && !by_subuser && key.compare(0, user_key.size(), user_key) != 0) {
+        CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
+        return 0;
+      }
+
+      if (by_subuser && by_user && key.compare(0, subuser_key.size(), subuser_key) != 0) {
         CLS_LOG(20, "usage_iterate_range reached key=%s, done", key.c_str());
         return 0;
       }
@@ -2950,7 +2987,7 @@ static int usage_log_read_cb(cls_method_context_t hctx, const string& key, rgw_u
   } else {
     puser = &entry.owner;
   }
-  rgw_user_bucket ub(puser->to_str(), entry.bucket);
+  rgw_user_bucket ub(puser->to_str(), entry.bucket, entry.subuser);
   rgw_usage_log_entry& le = (*usage)[ub];
   le.aggregate(entry);
 
@@ -2976,7 +3013,10 @@ int rgw_user_usage_log_read(cls_method_context_t hctx, bufferlist *in, bufferlis
   string iter = op.iter;
 #define MAX_ENTRIES 1000
   uint32_t max_entries = (op.max_entries ? op.max_entries : MAX_ENTRIES);
-  int ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch, op.owner, iter, max_entries, &ret_info.truncated, usage_log_read_cb, (void *)usage);
+  int ret = usage_iterate_range(hctx, op.start_epoch, op.end_epoch,
+				op.owner, op.subuser,
+				iter, max_entries, &ret_info.truncated,
+				usage_log_read_cb, (void *)usage);
   if (ret < 0)
     return ret;
 

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2741,10 +2741,29 @@ static void usage_record_name_by_time(uint64_t epoch, const string& user, string
   key = buf;
 }
 
+static void usage_record_name_by_time4subuser(uint64_t epoch, const string& user,
+					      const string& subuser,
+					      string& bucket, string& key)
+{
+  char buf[32 + user.size() + subuser.size() + bucket.size()];
+  snprintf(buf, sizeof(buf), "$%011llu_%s:%s_%s", (long long unsigned)epoch,
+	   user.c_str(), subuser.c_str(), bucket.c_str());
+  key = buf;
+}
+
 static void usage_record_name_by_user(const string& user, uint64_t epoch, string& bucket, string& key)
 {
   char buf[32 + user.size() + bucket.size()];
   snprintf(buf, sizeof(buf), "%s_%011llu_%s", user.c_str(), (long long unsigned)epoch, bucket.c_str());
+  key = buf;
+}
+
+static void usage_record_name_by_subuser(const string& user, const string& subuser,
+					 uint64_t epoch, string& bucket, string& key)
+{
+  char buf[32 + user.size() + subuser.size() + bucket.size()];
+  snprintf(buf, sizeof(buf), "$%s:%s_%011llu_%s", user.c_str(), subuser.c_str(),
+	   (long long unsigned)epoch, bucket.c_str());
   key = buf;
 }
 
@@ -2784,9 +2803,16 @@ int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist
 
     rgw_user *puser = (entry.payer.empty() ? &entry.owner : &entry.payer);
 
-    usage_record_name_by_time(entry.epoch, puser->to_str(), entry.bucket, key_by_time);
-
-    CLS_LOG(10, "rgw_user_usage_log_add user=%s bucket=%s\n", puser->to_str().c_str(), entry.bucket.c_str());
+    if (entry.subuser.empty()) {
+      usage_record_name_by_time(entry.epoch, puser->to_str(), entry.bucket, key_by_time);
+      CLS_LOG(10, "rgw_user_usage_log_add user=%s bucket=%s\n",
+	      puser->to_str().c_str(), entry.bucket.c_str());
+    } else {
+      usage_record_name_by_time4subuser(entry.epoch, puser->to_str(), entry.subuser,
+					entry.bucket, key_by_time);
+      CLS_LOG(10, "rgw_user_usage_log_add user=%s subuser=%s, bucket=%s\n",
+	      puser->to_str().c_str(), entry.subuser.c_str(), entry.bucket.c_str());
+    }
 
     bufferlist record_bl;
     int ret = cls_cxx_map_get_val(hctx, key_by_time, &record_bl);
@@ -2810,7 +2836,13 @@ int rgw_user_usage_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist
       return ret;
 
     string key_by_user;
-    usage_record_name_by_user(puser->to_str(), entry.epoch, entry.bucket, key_by_user);
+
+    if (entry.subuser.empty())
+      usage_record_name_by_user(puser->to_str(), entry.epoch, entry.bucket, key_by_user);
+    else
+      usage_record_name_by_subuser(puser->to_str(), entry.subuser, entry.epoch,
+				   entry.bucket, key_by_user);
+
     ret = cls_cxx_map_set_val(hctx, key_by_user, &new_record_bl);
     if (ret < 0)
       return ret;

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -554,7 +554,7 @@ int cls_rgw_get_dir_header_async(IoCtx& io_ctx, string& oid, RGWGetDirHeader_CB 
   return 0;
 }
 
-int cls_rgw_usage_log_read(IoCtx& io_ctx, string& oid, string& user,
+int cls_rgw_usage_log_read(IoCtx& io_ctx, string& oid, string& user, string& subuser,
                            uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
                            string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage,
                            bool *is_truncated)
@@ -567,6 +567,7 @@ int cls_rgw_usage_log_read(IoCtx& io_ctx, string& oid, string& user,
   call.start_epoch = start_epoch;
   call.end_epoch = end_epoch;
   call.owner = user;
+  call.subuser = subuser;
   call.max_entries = max_entries;
   call.iter = read_iter;
   ::encode(call, in);

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -591,7 +591,7 @@ int cls_rgw_usage_log_read(IoCtx& io_ctx, string& oid, string& user, string& sub
   return 0;
 }
 
-void cls_rgw_usage_log_trim(ObjectWriteOperation& op, string& user,
+void cls_rgw_usage_log_trim(ObjectWriteOperation& op, string& user, string& subuser,
                            uint64_t start_epoch, uint64_t end_epoch)
 {
   bufferlist in;
@@ -599,6 +599,7 @@ void cls_rgw_usage_log_trim(ObjectWriteOperation& op, string& user,
   call.start_epoch = start_epoch;
   call.end_epoch = end_epoch;
   call.user = user;
+  call.subuser = subuser;
   ::encode(call, in);
   op.exec("rgw", "user_usage_log_trim", in);
 }

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -459,7 +459,7 @@ void cls_rgw_encode_suggestion(char op, rgw_bucket_dir_entry& dirent, bufferlist
 void cls_rgw_suggest_changes(librados::ObjectWriteOperation& o, bufferlist& updates);
 
 /* usage logging */
-int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user,
+int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user, string& subuser,
                            uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
                            string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage,
                            bool *is_truncated);

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -464,7 +464,7 @@ int cls_rgw_usage_log_read(librados::IoCtx& io_ctx, string& oid, string& user, s
                            string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage,
                            bool *is_truncated);
 
-void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, string& user,
+void cls_rgw_usage_log_trim(librados::ObjectWriteOperation& op, string& user, string& subuser,
                            uint64_t start_epoch, uint64_t end_epoch);
 
 void cls_rgw_usage_log_add(librados::ObjectWriteOperation& op, rgw_usage_log_info& info);

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -554,23 +554,16 @@ WRITE_CLASS_ENCODER(rgw_cls_obj_check_mtime)
 
 struct rgw_cls_usage_log_add_op {
   rgw_usage_log_info info;
-  rgw_user user;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 1, bl);
     ::encode(info, bl);
-    ::encode(user.to_str(), bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     ::decode(info, bl);
-    if (struct_v >= 2) {
-      string s;
-      ::decode(s, bl);
-      user.from_str(s);
-    }
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -740,20 +740,25 @@ struct rgw_cls_usage_log_trim_op {
   uint64_t start_epoch;
   uint64_t end_epoch;
   string user;
+  string subuser;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 2, bl);
+    ENCODE_START(3, 2, bl);
     ::encode(start_epoch, bl);
     ::encode(end_epoch, bl);
     ::encode(user, bl);
+    ::encode(subuser, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     ::decode(start_epoch, bl);
     ::decode(end_epoch, bl);
     ::decode(user, bl);
+    if (struct_v >= 3) {
+      ::decode(subuser, bl);
+     }
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -682,27 +682,32 @@ struct rgw_cls_usage_log_read_op {
   uint64_t start_epoch;
   uint64_t end_epoch;
   string owner;
+  string subuser;
 
   string iter;  // should be empty for the first call, non empty for subsequent calls
   uint32_t max_entries;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     ::encode(start_epoch, bl);
     ::encode(end_epoch, bl);
     ::encode(owner, bl);
     ::encode(iter, bl);
     ::encode(max_entries, bl);
+    ::encode(subuser, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     ::decode(start_epoch, bl);
     ::decode(end_epoch, bl);
     ::decode(owner, bl);
     ::decode(iter, bl);
     ::decode(max_entries, bl);
+    if (struct_v >=2 ) {
+      ::decode(subuser, bl);
+    }
     DECODE_FINISH(bl);
   }
 };

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -697,6 +697,7 @@ struct rgw_usage_log_entry {
   rgw_user owner;
   rgw_user payer; /* if empty, same as owner */
   string bucket;
+  string subuser;
   uint64_t epoch;
   rgw_usage_data total_usage; /* this one is kept for backwards compatibility */
   map<string, rgw_usage_data> usage_map;
@@ -704,9 +705,10 @@ struct rgw_usage_log_entry {
   rgw_usage_log_entry() : epoch(0) {}
   rgw_usage_log_entry(string& o, string& b) : owner(o), bucket(b), epoch(0) {}
   rgw_usage_log_entry(string& o, string& p, string& b) : owner(o), payer(p), bucket(b), epoch(0) {}
+  rgw_usage_log_entry(string& o, string& p, string& b, string& sb) : owner(o), payer(p), bucket(b), subuser(sb), epoch(0)  {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(3, 1, bl);
+    ENCODE_START(4, 1, bl);
     ::encode(owner.to_str(), bl);
     ::encode(bucket, bl);
     ::encode(epoch, bl);
@@ -716,12 +718,13 @@ struct rgw_usage_log_entry {
     ::encode(total_usage.successful_ops, bl);
     ::encode(usage_map, bl);
     ::encode(payer.to_str(), bl);
+    ::encode(subuser, bl);
     ENCODE_FINISH(bl);
   }
 
 
    void decode(bufferlist::iterator& bl) {
-    DECODE_START(3, bl);
+    DECODE_START(4, bl);
     string s;
     ::decode(s, bl);
     owner.from_str(s);
@@ -740,6 +743,9 @@ struct rgw_usage_log_entry {
       string p;
       ::decode(p, bl);
       payer.from_str(p);
+    }
+    if (struct_v >= 4) {
+      ::decode(subuser, bl);
     }
     DECODE_FINISH(bl);
   }
@@ -798,31 +804,44 @@ WRITE_CLASS_ENCODER(rgw_usage_log_info)
 struct rgw_user_bucket {
   string user;
   string bucket;
+  string subuser;
 
   rgw_user_bucket() {}
   rgw_user_bucket(const string& u, const string& b) : user(u), bucket(b) {}
+  rgw_user_bucket(const string& u, const string& b, const string& sb) : user(u), bucket(b), subuser(sb) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(1, 1, bl);
+    ENCODE_START(2, 1, bl);
     ::encode(user, bl);
     ::encode(bucket, bl);
+    ::encode(subuser, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(1, bl);
+    DECODE_START(2, bl);
     ::decode(user, bl);
     ::decode(bucket, bl);
+    if (struct_v >= 2) {
+      ::decode(subuser, bl);
+    }
     DECODE_FINISH(bl);
   }
 
   bool operator<(const rgw_user_bucket& ub2) const {
-    int comp = user.compare(ub2.user);
-    if (comp < 0)
+    int ucomp = user.compare(ub2.user);
+    if (ucomp < 0) {
       return true;
-    else if (!comp)
-      return bucket.compare(ub2.bucket) < 0;
-
+    } else if (!ucomp)
+    {
+      int bcomp = bucket.compare(ub2.bucket) < 0;
+      if (bcomp < 0) {
+        return true;
+      }
+      else if (!bcomp) {
+        return subuser.compare(ub2.subuser) < 0;
+      }
+    }
     return false;
   }
 };

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -758,6 +758,9 @@ struct rgw_usage_log_entry {
       payer = e.payer;
     }
 
+    if (subuser.empty() && !(e.subuser.empty()))
+      subuser = e.subuser;
+
     map<string, rgw_usage_data>::const_iterator iter;
     for (iter = e.usage_map.begin(); iter != e.usage_map.end(); ++iter) {
       if (!categories || !categories->size() || categories->count(iter->first)) {

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1539,6 +1539,7 @@ OPTION(rgw_usage_max_shards, OPT_INT, 32)
 OPTION(rgw_usage_max_user_shards, OPT_INT, 1)
 OPTION(rgw_enable_ops_log, OPT_BOOL, false) // enable logging every rgw operation
 OPTION(rgw_enable_usage_log, OPT_BOOL, false) // enable logging bandwidth usage
+OPTION(rgw_enable_usage_log_at_subuser_level, OPT_BOOL, false) // enable logging bandwidth usage at subuser level
 OPTION(rgw_ops_log_rados, OPT_BOOL, true) // whether ops log should go to rados
 OPTION(rgw_ops_log_socket_path, OPT_STR, "") // path to unix domain socket where ops log can go
 OPTION(rgw_ops_log_data_backlog, OPT_INT, 5 << 20) // max data backlog for ops log

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5018,7 +5018,7 @@ next:
 
     ret = RGWUsage::trim(store, user_id, start_epoch, end_epoch);
     if (ret < 0) {
-      cerr << "ERROR: read_usage() returned ret=" << ret << std::endl;
+      cerr << "ERROR: trim_usage() returned ret=" << ret << std::endl;
       return 1;
     }
   }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5016,7 +5016,7 @@ next:
       }
     }
 
-    ret = RGWUsage::trim(store, user_id, start_epoch, end_epoch);
+    ret = RGWUsage::trim(store, user_id, subuser, start_epoch, end_epoch);
     if (ret < 0) {
       cerr << "ERROR: trim_usage() returned ret=" << ret << std::endl;
       return 1;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4980,7 +4980,7 @@ next:
     }
 
 
-    ret = RGWUsage::show(store, user_id, start_epoch, end_epoch,
+    ret = RGWUsage::show(store, user_id, subuser, start_epoch, end_epoch,
 			 show_log_entries, show_log_sum, &categories,
 			 f);
     if (ret < 0) {

--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -387,26 +387,27 @@ void rgw::auth::LocalApplier::to_str(std::ostream& out) const
 {
   out << "rgw::auth::LocalApplier(acct_user=" << user_info.user_id
       << ", acct_name=" << user_info.display_name
-      << ", subuser=" << subuser
+      << ", subuser=" << get_subuser_name()
       << ", perm_mask=" << get_perm_mask()
       << ", is_admin=" << static_cast<bool>(user_info.admin) << ")";
 }
 
-uint32_t rgw::auth::LocalApplier::get_perm_mask(const std::string& subuser_name,
-                                                const RGWUserInfo &uinfo) const
+void rgw::auth::LocalApplier::parse_subuser_info(const std::string& subuser_name,
+                                                 const RGWUserInfo &uinfo)
 {
   if (! subuser_name.empty() && subuser_name != NO_SUBUSER) {
     const auto iter = uinfo.subusers.find(subuser_name);
 
     if (iter != std::end(uinfo.subusers)) {
-      return iter->second.perm_mask;
+      perm_mask = iter->second.perm_mask;
+      subuser = iter->second.name;
     } else {
       /* Subuser specified but not found. */
-      return RGW_PERM_NONE;
+      perm_mask = RGW_PERM_NONE;
     }
   } else {
     /* Due to backward compatibility. */
-    return RGW_PERM_FULL_CONTROL;
+    perm_mask = RGW_PERM_FULL_CONTROL;
   }
 }
 

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -135,7 +135,7 @@ public:
     entry.epoch = round_timestamp.sec();
     bool account;
     string u = user.to_str();
-    rgw_user_bucket ub(u, entry.bucket);
+    rgw_user_bucket ub(u, entry.bucket, entry.subuser);
     real_time rt = round_timestamp.to_real_time();
     usage_map[ub].insert(rt, entry, &account);
     if (account)
@@ -226,6 +226,18 @@ static void log_usage(struct req_state *s, const string& op_name)
   utime_t ts = ceph_clock_now();
 
   usage_logger->insert(ts, entry);
+
+  if(s->cct->_conf->rgw_enable_usage_log_at_subuser_level) {
+    const auto subuser = s->auth.identity->get_subuser_name();
+
+    if (subuser) {
+      string subuser_name = *subuser;
+      ldout(s->cct, 5) << "usage log subuser entry: " << subuser_name << dendl;
+      rgw_usage_log_entry sentry(u, p, bucket_name, subuser_name);
+      sentry.add(op_name, data);
+      usage_logger->insert(ts, sentry);
+    }
+  }
 }
 
 void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1655,7 +1655,7 @@ void RGWGetUsage::execute()
   RGWUsageIter usage_iter;
   
   while (is_truncated) {
-    op_ret = store->read_usage(s->user->user_id, start_epoch, end_epoch, max_entries,
+    op_ret = store->read_usage(s->user->user_id, subuser_name, start_epoch, end_epoch, max_entries,
                                 &is_truncated, usage_iter, usage);
 
     if (op_ret == -ENOENT) {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -443,6 +443,7 @@ protected:
   map<rgw_user_bucket, rgw_usage_log_entry> usage;
   map<string, rgw_usage_log_entry> summary_map;
   cls_user_header header;
+  string subuser_name;
 public:
   RGWGetUsage() : sent_data(false), show_log_entries(true), show_log_sum(true){
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4635,8 +4635,9 @@ int RGWRados::log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info)
   return 0;
 }
 
-int RGWRados::read_usage(const rgw_user& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-                         bool *is_truncated, RGWUsageIter& usage_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage)
+int RGWRados::read_usage(const rgw_user& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch,
+                         uint32_t max_entries, bool *is_truncated, RGWUsageIter& usage_iter, 
+			 map<rgw_user_bucket, rgw_usage_log_entry>& usage)
 {
   uint32_t num = max_entries;
   string hash, first_hash;
@@ -4655,7 +4656,7 @@ int RGWRados::read_usage(const rgw_user& user, uint64_t start_epoch, uint64_t en
     map<rgw_user_bucket, rgw_usage_log_entry> ret_usage;
     map<rgw_user_bucket, rgw_usage_log_entry>::iterator iter;
 
-    int ret =  cls_obj_usage_log_read(hash, user_str, start_epoch, end_epoch, num,
+    int ret =  cls_obj_usage_log_read(hash, user_str, subuser, start_epoch, end_epoch, num,
                                     usage_iter.read_iter, ret_usage, is_truncated);
     if (ret == -ENOENT)
       goto next;
@@ -12092,8 +12093,11 @@ int RGWRados::cls_obj_usage_log_add(const string& oid, rgw_usage_log_info& info)
   return r;
 }
 
-int RGWRados::cls_obj_usage_log_read(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-                                     string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated)
+int RGWRados::cls_obj_usage_log_read(string& oid, string& user, string& subuser, 
+                                     uint64_t start_epoch, uint64_t end_epoch, 
+				     uint32_t max_entries, string& read_iter, 
+				     map<rgw_user_bucket, rgw_usage_log_entry>& usage,
+				     bool *is_truncated)
 {
   rgw_raw_obj obj(get_zone_params().usage_log_pool, oid);
 
@@ -12106,7 +12110,7 @@ int RGWRados::cls_obj_usage_log_read(string& oid, string& user, uint64_t start_e
 
   *is_truncated = false;
 
-  r = cls_rgw_usage_log_read(ref.ioctx, ref.oid, user, start_epoch, end_epoch,
+  r = cls_rgw_usage_log_read(ref.ioctx, ref.oid, user, subuser, start_epoch, end_epoch,
 			     max_entries, read_iter, usage, is_truncated);
 
   return r;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4679,7 +4679,7 @@ next:
   return 0;
 }
 
-int RGWRados::trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoch)
+int RGWRados::trim_usage(rgw_user& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch)
 {
   uint32_t index = 0;
   string hash, first_hash;
@@ -4689,7 +4689,7 @@ int RGWRados::trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoc
   hash = first_hash;
 
   do {
-    int ret =  cls_obj_usage_log_trim(hash, user_str, start_epoch, end_epoch);
+    int ret =  cls_obj_usage_log_trim(hash, user_str, subuser, start_epoch, end_epoch);
     if (ret == -ENOENT)
       goto next;
 
@@ -12116,7 +12116,7 @@ int RGWRados::cls_obj_usage_log_read(string& oid, string& user, string& subuser,
   return r;
 }
 
-int RGWRados::cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch)
+int RGWRados::cls_obj_usage_log_trim(string& oid, string& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch)
 {
   rgw_raw_obj obj(get_zone_params().usage_log_pool, oid);
 
@@ -12128,7 +12128,7 @@ int RGWRados::cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_e
   }
 
   ObjectWriteOperation op;
-  cls_rgw_usage_log_trim(op, user, start_epoch, end_epoch);
+  cls_rgw_usage_log_trim(op, user, subuser, start_epoch, end_epoch);
 
   r = ref.ioctx.operate(ref.oid, &op);
   return r;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2500,8 +2500,9 @@ public:
 
   // log bandwidth info
   int log_usage(map<rgw_user_bucket, RGWUsageBatch>& usage_info);
-  int read_usage(const rgw_user& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-                 bool *is_truncated, RGWUsageIter& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage);
+  int read_usage(const rgw_user& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch, 
+                 uint32_t max_entries, bool *is_truncated, RGWUsageIter& read_iter, map<rgw_user_bucket,
+		 rgw_usage_log_entry>& usage);
   int trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoch);
 
   int create_pool(rgw_pool& bucket);
@@ -3321,8 +3322,11 @@ public:
   int bi_remove(BucketShard& bs);
 
   int cls_obj_usage_log_add(const string& oid, rgw_usage_log_info& info);
-  int cls_obj_usage_log_read(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch, uint32_t max_entries,
-                             string& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage, bool *is_truncated);
+  int cls_obj_usage_log_read(string& oid, string& user, string& subuser,
+			     uint64_t start_epoch, uint64_t end_epoch,
+			     uint32_t max_entries, string& read_iter,
+			     map<rgw_user_bucket, rgw_usage_log_entry>& usage,
+			     bool *is_truncated);
   int cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch);
 
   int key_to_shard_id(const string& key, int max_shards);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2503,7 +2503,7 @@ public:
   int read_usage(const rgw_user& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch, 
                  uint32_t max_entries, bool *is_truncated, RGWUsageIter& read_iter, map<rgw_user_bucket,
 		 rgw_usage_log_entry>& usage);
-  int trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoch);
+  int trim_usage(rgw_user& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch);
 
   int create_pool(rgw_pool& bucket);
 
@@ -3327,7 +3327,7 @@ public:
 			     uint32_t max_entries, string& read_iter,
 			     map<rgw_user_bucket, rgw_usage_log_entry>& usage,
 			     bool *is_truncated);
-  int cls_obj_usage_log_trim(string& oid, string& user, uint64_t start_epoch, uint64_t end_epoch);
+  int cls_obj_usage_log_trim(string& oid, string& user, string& subuser, uint64_t start_epoch, uint64_t end_epoch);
 
   int key_to_shard_id(const string& key, int max_shards);
   void shard_name(const string& prefix, unsigned max_shards, const string& key, string& name, int *shard_id);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -344,6 +344,7 @@ int RGWGetUsage_ObjStore_S3::get_params()
 {
   start_date = s->info.args.get("start-date");
   end_date = s->info.args.get("end-date"); 
+  subuser_name = s->info.args.get("subuser"); 
   return 0;
 }
 
@@ -398,6 +399,8 @@ void RGWGetUsage_ObjStore_S3::send_response()
         }
         formatter->open_object_section("User");
         formatter->dump_string("Owner", ub.user);
+	if (!ub.subuser.empty())
+          formatter->dump_string("Subuser", ub.subuser);
         formatter->open_array_section("Buckets");
         user_section_open = true;
         last_owner = ub.user;
@@ -429,6 +432,8 @@ void RGWGetUsage_ObjStore_S3::send_response()
        const rgw_usage_log_entry& entry = siter->second;
        formatter->open_object_section("User");
        formatter->dump_string("User", siter->first);
+       if (!entry.subuser.empty())
+         formatter->dump_string("Subuser", entry.subuser);
        dump_usage_categories_info(formatter, entry, &categories);
        rgw_usage_data total_usage;
        entry.sum(total_usage, categories);

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -71,10 +71,12 @@ public:
 
 void RGWOp_Usage_Delete::execute() {
   string uid_str;
+  string subuser_str;
   uint64_t start, end;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   rgw_user uid(uid_str);
+  RESTArgs::get_string(s, "subuser", subuser_str, &subuser_str);
 
   RESTArgs::get_epoch(s, "start", 0, &start);
   RESTArgs::get_epoch(s, "end", (uint64_t)-1, &end);
@@ -90,7 +92,7 @@ void RGWOp_Usage_Delete::execute() {
     }
   }
 
-  http_ret = RGWUsage::trim(store, uid, start, end);
+  http_ret = RGWUsage::trim(store, uid, subuser_str, start, end);
 }
 
 RGWOp *RGWHandler_Usage::op_get()

--- a/src/rgw/rgw_rest_usage.cc
+++ b/src/rgw/rgw_rest_usage.cc
@@ -26,12 +26,14 @@ void RGWOp_Usage_Get::execute() {
   map<std::string, bool> categories;
 
   string uid_str;
+  string subuser_str;
   uint64_t start, end;
   bool show_entries;
   bool show_summary;
 
   RESTArgs::get_string(s, "uid", uid_str, &uid_str);
   rgw_user uid(uid_str);
+  RESTArgs::get_string(s, "subuser", subuser_str, &subuser_str);
 
   RESTArgs::get_epoch(s, "start", 0, &start);
   RESTArgs::get_epoch(s, "end", (uint64_t)-1, &end);
@@ -50,7 +52,8 @@ void RGWOp_Usage_Get::execute() {
     }
   }
 
-  http_ret = RGWUsage::show(store, uid, start, end, show_entries, show_summary, &categories, flusher);
+  http_ret = RGWUsage::show(store, uid, subuser_str, start, end, show_entries,
+			    show_summary, &categories, flusher);
 }
 
 class RGWOp_Usage_Delete : public RGWRESTOp {

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -30,14 +30,16 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
   formatter->close_section(); // categories
 }
 
-int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
-		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
+int RGWUsage::show(RGWRados *store, rgw_user& uid, string& subuser,
+		   uint64_t start_epoch, uint64_t end_epoch,
+		   bool show_log_entries, bool show_log_sum,
 		   map<string, bool> *categories,
 		   RGWFormatterFlusher& flusher)
 {
   uint32_t max_entries = 1000;
 
   bool is_truncated = true;
+  bool by_subuser = !subuser.empty();
 
   RGWUsageIter usage_iter;
   Formatter *formatter = flusher.get_formatter();
@@ -54,7 +56,7 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
   bool user_section_open = false;
   map<string, rgw_usage_log_entry> summary_map;
   while (is_truncated) {
-    int ret = store->read_usage(uid, start_epoch, end_epoch, max_entries,
+    int ret = store->read_usage(uid, subuser, start_epoch, end_epoch, max_entries,
                                 &is_truncated, usage_iter, usage);
 
     if (ret == -ENOENT) {
@@ -79,6 +81,8 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
           }
           formatter->open_object_section("user");
           formatter->dump_string("user", ub.user);
+	  if (by_subuser)
+            formatter->dump_string("subuser", ub.subuser);
           formatter->open_array_section("buckets");
           user_section_open = true;
           last_owner = ub.user;
@@ -99,7 +103,10 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
         flusher.flush();
       }
 
-      summary_map[ub.user].aggregate(entry, categories);
+      if (by_subuser)
+        summary_map[ub.user + ub.subuser].aggregate(entry, categories);
+      else
+        summary_map[ub.user].aggregate(entry, categories);
     }
   }
   if (show_log_entries) {
@@ -117,6 +124,8 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
       const rgw_usage_log_entry& entry = siter->second;
       formatter->open_object_section("user");
       formatter->dump_string("user", siter->first);
+      if (by_subuser)
+        formatter->dump_string("subuser", entry.subuser);
       dump_usage_categories_info(formatter, entry, categories);
       rgw_usage_data total_usage;
       entry.sum(total_usage, *categories);

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -150,8 +150,8 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, string& subuser,
   return 0;
 }
 
-int RGWUsage::trim(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
-		   uint64_t end_epoch)
+int RGWUsage::trim(RGWRados *store, rgw_user& uid, string& subuser,
+                   uint64_t start_epoch, uint64_t end_epoch)
 {
-  return store->trim_usage(uid, start_epoch, end_epoch);
+  return store->trim_usage(uid, subuser, start_epoch, end_epoch);
 }

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -22,8 +22,8 @@ public:
 		  std::map<std::string, bool> *categories,
 	          RGWFormatterFlusher& flusher);
 
-  static int trim(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
-	          uint64_t end_epoch);
+  static int trim(RGWRados *store, rgw_user& uid, string& subuser,
+		  uint64_t start_epoch, uint64_t end_epoch);
 };
 
 

--- a/src/rgw/rgw_usage.h
+++ b/src/rgw/rgw_usage.h
@@ -16,8 +16,9 @@ class RGWRados;
 class RGWUsage
 {
 public:
-  static int show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
-	          uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
+  static int show(RGWRados *store, rgw_user& uid, string& subuser,
+		  uint64_t start_epoch, uint64_t end_epoch,
+		  bool show_log_entries, bool show_log_sum,
 		  std::map<std::string, bool> *categories,
 	          RGWFormatterFlusher& flusher);
 


### PR DESCRIPTION
Currently, rgw usage log impl only support record usage statistics at
user level,we've impl more finer usage statistics at subuser level.
it's made the billing possible.Typical usage scenarios:

1. create user stands for a department
2. create subusers stands for employees belongs to the department

functionality description:

```
$ # setup a test cluster
$ CEPH_NUM_MON=1 CEPH_NUM_OSD=3 CEPH_NUM_MDS=0 ./vstart.sh -n -X -l -r -k

$ # make sure subser statistics is enabled
$ ./ceph daemon osd.0 config show  | grep rgw_enable_usage_log
 *** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
    "rgw_enable_usage_log": "true",
    "rgw_enable_usage_log_at_subuser_level": "true",

$ # create user,subuser for test
$ ./radosgw-admin user create --uid=testuser --access-key=testuser --secret-key=testuser \
--display-name=”testuser”
$ ./radosgw-admin subuser create --key-type=s3 --uid=testuser --subuser=testsubuser \
--access=full --access-key=testsubuser --secret-key=testsubuser

$ s3cmd -c ~/testsubuser.s3cfg ls
$ s3cmd -c ~/testsubuser.s3cfg ls
$ # waiting `rgw_usage_log_tick_interval` second before usage log flush to rados
$ sleep 30

$ # check subuser statistics
$ ./radosgw-admin usage show --uid=testuser:testsubuser
{
    "entries": [
        {
            "user": "testuser:testsubuser",
            "buckets": [
                {
                    "bucket": "",
                    "time": "2017-02-20 14:00:00.000000Z",
                    "epoch": 1487599200,
                    "owner": "testuser:testsubuser",
                    "categories": [
                        {
                            "category": "list_buckets",
                            "bytes_sent": 496,
                            "bytes_received": 0,
                            "ops": 2,
                            "successful_ops": 2
                        }
                    ]
                }
            ]
        }
    ],
    "summary": [
        {
            "user": "testuser:testsubuser",  
            "categories": [
                {
                    "category": "list_buckets",
                    "bytes_sent": 496,
                    "bytes_received": 0,
                    "ops": 2,
                    "successful_ops": 2
                }
            ],
            "total": {
                "bytes_sent": 496,
                "bytes_received": 0,
                "ops": 2,
                "successful_ops": 2
            }
        }
    ]
}

$ ./radosgw-admin usage trim --uid=testuser:testsubuser
$ # verify trim works
$ ./radosgw-admin usage show --uid=testuser:testsubuser
{
    "entries": [],
    "summary": []
}
```