### PR TITLE
os/bluestore: fix bug for calc extent_avg in reshard function

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2127,7 +2127,7 @@ void BlueStore::ExtentMap::reshard(
   unsigned target = cct->_conf->bluestore_extent_map_shard_target_size;
   unsigned slop = target *
     cct->_conf->bluestore_extent_map_shard_target_size_slop;
-  unsigned extent_avg = bytes / MAX(1, extent_map.size());
+  unsigned extent_avg = bytes / MAX(1, extents);
   dout(20) << __func__ << "  extent_avg " << extent_avg << ", target " << target
 	   << ", slop " << slop << dendl;
 


### PR DESCRIPTION
os/bluestore: fix bug for calc extent_avg in reshard function