### PR TITLE
Clean up: Change 2 parameters from public to private

### DIFF
--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -32,7 +32,7 @@ extern ostream& operator<<(ostream& out, const sockaddr *sa);
 typedef uint8_t entity_type_t;
 
 class entity_name_t {
-public:
+private:
   entity_type_t _type;
   int64_t _num;
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6193,8 +6193,10 @@ void OSD::ms_fast_dispatch(Message *m)
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = op->get_reqid();
 #endif
-    tracepoint(osd, ms_fast_dispatch, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc);
+    int64_t num = reqid.name.num();
+    int type = reqid.name.type();
+
+    tracepoint(osd, ms_fast_dispatch, type, num, reqid.tid, reqid.inc);
   }
 
   // note sender epoch
@@ -9392,8 +9394,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
       reqid = (*_op)->get_reqid();
     }
 #endif
-    tracepoint(osd, opwq_process_start, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc);
+    int64_t num = reqid.name.num();
+    int type = reqid.name.type();
+
+    tracepoint(osd, opwq_process_start, type, num, reqid.tid, reqid.inc);
   }
 
   lgeneric_subdout(osd->cct, osd, 30) << "dequeue status: ";
@@ -9416,8 +9420,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
       reqid = (*_op)->get_reqid();
     }
 #endif
-    tracepoint(osd, opwq_process_finish, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc);
+    int64_t num = reqid.name.num();
+    int type = reqid.name.type();
+
+    tracepoint(osd, opwq_process_finish, type, num, reqid.tid, reqid.inc);
   }
 
   pg->unlock();

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -121,9 +121,12 @@ void OpRequest::set_rmw_flags(int flags) {
   int old_rmw_flags = rmw_flags;
 #endif
   rmw_flags |= flags;
-  tracepoint(oprequest, set_rmw_flags, reqid.name._type,
-	     reqid.name._num, reqid.tid, reqid.inc,
-	     flags, old_rmw_flags, rmw_flags);
+
+  int64_t num = reqid.name.num();
+  int type = reqid.name.type();
+
+  tracepoint(oprequest, set_rmw_flags, type, num, reqid.tid, reqid.inc,
+    flags, old_rmw_flags, rmw_flags);
 }
 
 void OpRequest::set_read() { set_rmw_flags(CEPH_OSD_RMW_FLAG_READ); }
@@ -144,9 +147,12 @@ void OpRequest::mark_flag_point(uint8_t flag, const char *s) {
   mark_event(s);
   hit_flag_points |= flag;
   latest_flag_point = flag;
-  tracepoint(oprequest, mark_flag_point, reqid.name._type,
-	     reqid.name._num, reqid.tid, reqid.inc, rmw_flags,
-	     flag, s, old_flags, hit_flag_points);
+
+  int64_t num = reqid.name.num();
+  int type = reqid.name.type();
+
+  tracepoint(oprequest, mark_flag_point, type, num, reqid.tid, reqid.inc,
+    rmw_flags, flag, s, old_flags, hit_flag_points);
 }
 
 void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
@@ -156,9 +162,12 @@ void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
   mark_event_string(s);
   hit_flag_points |= flag;
   latest_flag_point = flag;
-  tracepoint(oprequest, mark_flag_point, reqid.name._type,
-	     reqid.name._num, reqid.tid, reqid.inc, rmw_flags,
-	     flag, s.c_str(), old_flags, hit_flag_points);
+
+  int64_t num = reqid.name.num();
+  int type = reqid.name.type();
+
+  tracepoint(oprequest, mark_flag_point, type, num, reqid.tid, reqid.inc,
+    rmw_flags, flag, s.c_str(), old_flags, hit_flag_points);
 }
 
 ostream& operator<<(ostream& out, const OpRequest::ClassInfo& i)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3005,8 +3005,10 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = ctx->op->get_reqid();
 #endif
-    tracepoint(osd, prepare_tx_enter, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc);
+    int64_t num = reqid.name.num();
+    int type = reqid.name.type();
+
+    tracepoint(osd, prepare_tx_enter, type, num, reqid.tid, reqid.inc);
   }
 
   int result = prepare_transaction(ctx);
@@ -3015,8 +3017,10 @@ void PrimaryLogPG::execute_ctx(OpContext *ctx)
 #ifdef WITH_LTTNG
     osd_reqid_t reqid = ctx->op->get_reqid();
 #endif
-    tracepoint(osd, prepare_tx_exit, reqid.name._type,
-        reqid.name._num, reqid.tid, reqid.inc);
+    int64_t num = reqid.name.num();
+    int type = reqid.name.type();
+
+    tracepoint(osd, prepare_tx_exit, type, num, reqid.tid, reqid.inc);
   }
 
   if (op->may_read()) {


### PR DESCRIPTION
src/msg/msg_types.h: Make ``_type``, ``_num`` private. It's because the
following public interfaces should be used to get values in ``_type``, ``_num``.

  ``int64_t num() const { return _num; }``
  ``int type() const { return _type; }``

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>