### PR TITLE
rgw: fix configurable write obj window size

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7684,7 +7684,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
       if (ret < 0) {
         return ret;
       }
-      ret = processor.throttle_data(handle, obj, end - ofs + 1, false);
+      ret = processor.throttle_data(handle, obj, read_len, false);
       if (ret < 0)
         return ret;
     } while (again);


### PR DESCRIPTION
Should use read_len in the copy_obj_data() function, "end-ofs+1" is not necessarily the
written.

Signed-off-by: hechuang <hechuang@xsky.com>