### PR TITLE
doc: fix typos in radosgw-admin usage

### DIFF
--- a/doc/man/8/radosgw-admin.rst
+++ b/doc/man/8/radosgw-admin.rst
@@ -268,7 +268,7 @@ Options
 
 .. option:: --key-type=<type>
 
-	key type, options are: swift, S3.
+	key type, options are: swift, s3.
 
 .. option:: --temp-url-key[-2]=<key>
 


### PR DESCRIPTION
The key-type param of radosgw-admin is case sensitive 

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>