### PR TITLE
[RFC] librbd: image perf dump support

### DIFF
--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1955,5 +1955,56 @@ namespace librbd {
       return image_get_group_finish(&iter, group_spec);
     }
 
+    void image_perf_update(librados::ObjectWriteOperation *op,
+                           const cls::rbd::PerfCounters &perf)
+    {
+      bufferlist bl;
+      ::encode(perf, bl);
+      op->exec("rbd", "image_perf_update", bl);
+    }
+
+    int image_perf_reset(librados::IoCtx *ioctx, const std::string &oid)
+    {
+      bufferlist in, out;
+      return ioctx->exec(oid, "rbd", "image_perf_reset", in, out);
+    }
+
+    int image_perf_get(librados::IoCtx *ioctx, const std::string &oid,
+                       cls::rbd::PerfCounters *perf)
+    {
+      librados::ObjectReadOperation op;
+      image_perf_get_start(&op);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist::iterator iter = out_bl.begin();
+      r = image_perf_get_finish(&iter, perf);
+      if (r < 0) {
+        return r;
+      }
+      return 0;
+    }
+
+    void image_perf_get_start(librados::ObjectReadOperation *op)
+    {
+      bufferlist empty_bl;
+      op->exec("rbd", "image_perf_get", empty_bl);
+    }
+
+    int image_perf_get_finish(bufferlist::iterator *iter,
+                              cls::rbd::PerfCounters *perf)
+    {
+      try {
+        ::decode(*perf, *iter);
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
   } // namespace cls_client
 } // namespace librbd

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -398,6 +398,16 @@ namespace librbd {
     int image_get_group(librados::IoCtx *ioctx, const std::string &oid,
 			cls::rbd::GroupSpec *group_spec);
 
+    // image perf report functions
+    void image_perf_update(librados::ObjectWriteOperation *op,
+                           const cls::rbd::PerfCounters &perf);
+    int image_perf_reset(librados::IoCtx *ioctx, const std::string &oid);
+    int image_perf_get(librados::IoCtx *ioctx, const std::string &oid,
+                       cls::rbd::PerfCounters *perf);
+    void image_perf_get_start(librados::ObjectReadOperation *op);
+    int image_perf_get_finish(bufferlist::iterator *iter,
+                              cls::rbd::PerfCounters *perf);
+
   } // namespace cls_client
 } // namespace librbd
 #endif // CEPH_LIBRBD_CLS_RBD_CLIENT_H

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -310,6 +310,31 @@ struct SnapshotNamespaceOnDisk {
 };
 WRITE_CLASS_ENCODER(SnapshotNamespaceOnDisk);
 
+// TODO: maybe boost::variant?
+struct PerfCounter {
+  uint32_t type;
+  uint64_t u64;
+  uint64_t avgcount;
+
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &it);
+  void merge(const PerfCounter &rhs);
+
+  PerfCounter& operator=(const PerfCounter &rhs);
+  bool operator==(const PerfCounter &rhs) const;
+};
+WRITE_CLASS_ENCODER(PerfCounter);
+
+struct PerfCounters {
+  std::map<std::string, PerfCounter> counters;
+
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &it);
+  void merge(const PerfCounters &rhs_old);
+  void dump(Formatter *f) const;
+};
+WRITE_CLASS_ENCODER(PerfCounters);
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1330,6 +1330,7 @@ OPTION(rbd_validate_names, OPT_BOOL, true) // true if image specs should be vali
 OPTION(rbd_auto_exclusive_lock_until_manual_request, OPT_BOOL, true) // whether to automatically acquire/release exclusive lock until it is explicitly requested, i.e. before we know the user of librbd is properly using the lock API
 OPTION(rbd_mirroring_resync_after_disconnect, OPT_BOOL, false) // automatically start image resync after mirroring is disconnected due to being laggy
 OPTION(rbd_mirroring_replay_delay, OPT_INT, 0) // time-delay in seconds for rbd-mirror asynchronous replication
+OPTION(rbd_perf_report_interval, OPT_INT, 10)
 
 /*
  * The following options change the behavior for librbd's image creation methods that

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -428,6 +428,12 @@ const std::string &PerfCounters::get_name() const
   return m_name;
 }
 
+void PerfCounters::with_counters(std::function<void(
+    const perf_counter_data_vec_t &)> fn) const
+{
+  fn(m_data);
+}
+
 PerfCounters::PerfCounters(CephContext *cct, const std::string &name,
 	   int lower_bound, int upper_bound)
   : m_cct(cct),

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -179,6 +179,10 @@ public:
     m_name = s;
   }
 
+  typedef std::vector<perf_counter_data_any_d> perf_counter_data_vec_t;
+
+  void with_counters(std::function<void(const perf_counter_data_vec_t &)>) const;
+
 private:
   PerfCounters(CephContext *cct, const std::string &name,
 	     int lower_bound, int upper_bound);
@@ -186,8 +190,6 @@ private:
   PerfCounters& operator=(const PerfCounters &rhs);
   void dump_formatted_generic(ceph::Formatter *f, bool schema, bool histograms,
                               const std::string &counter = "");
-
-  typedef std::vector<perf_counter_data_any_d> perf_counter_data_vec_t;
 
   CephContext *m_cct;
   int m_lower_bound;

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -417,6 +417,8 @@ public:
 
   int update_watch(UpdateWatchCtx *ctx, uint64_t *handle);
   int update_unwatch(uint64_t handle);
+  int perf_reset();
+  int perf_dump(const std::string &format, bufferlist *outbl);
 
 private:
   friend class RBD;

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -19,12 +19,14 @@ set(librbd_internal_srcs
   MirroringWatcher.cc
   ObjectMap.cc
   Operations.cc
+  PerfReporter.cc
   Utils.cc
   Watcher.cc
   api/DiffIterate.cc
   api/Group.cc
   api/Image.cc
   api/Mirror.cc
+  api/Perf.cc
   cache/ImageWriteback.cc
   cache/PassthroughImageCache.cc
   exclusive_lock/AutomaticPolicy.cc

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -45,6 +45,7 @@ namespace librbd {
   class LibrbdAdminSocketHook;
   template <typename> class ObjectMap;
   template <typename> class Operations;
+  template <typename> class PerfReporter;
   class LibrbdWriteback;
 
   namespace cache { struct ImageCache; }
@@ -85,6 +86,8 @@ namespace librbd {
     IoCtx data_ctx, md_ctx;
     ImageWatcher<ImageCtx> *image_watcher;
     Journal<ImageCtx> *journal;
+
+    PerfReporter<ImageCtx> *m_perf_reporter;
 
     /**
      * Lock ordering:
@@ -225,6 +228,8 @@ namespace librbd {
     void init_layout();
     void perf_start(std::string name);
     void perf_stop();
+    void perf_report_start();
+    void perf_report_stop();
     void set_read_flag(unsigned flag);
     int get_read_flags(librados::snap_t snap_id);
     int snap_set(std::string in_snap_name);

--- a/src/librbd/PerfReporter.cc
+++ b/src/librbd/PerfReporter.cc
@@ -1,0 +1,128 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "cls/rbd/cls_rbd_client.h"
+#include "common/Mutex.h"
+#include "common/Timer.h"
+#include "common/perf_counters.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/PerfReporter.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::PerfReporter: " << this << " " \
+                           << __func__ << ": "
+
+namespace librbd {
+
+using util::create_rados_callback;
+
+template <typename I>
+PerfReporter<I>::PerfReporter(I &image_ctx) : m_image_ctx(image_ctx) {
+  CephContext *cct = m_image_ctx.cct;
+
+  ImageCtx::get_timer_instance(cct, &m_timer, &m_timer_lock);
+}
+
+template <typename I>
+PerfReporter<I>::~PerfReporter() {
+}
+
+template <typename I>
+void PerfReporter<I>::init(PerfCounters *raw_counters) {
+  CephContext *cct = m_image_ctx.cct;
+
+  m_raw_counters = raw_counters;
+  m_report_ctx = new FunctionContext([this](int r) {
+      report();
+    });
+
+  Mutex::Locker timer_locker(*m_timer_lock);
+  m_timer->add_event_after(cct->_conf->rbd_perf_report_interval, m_report_ctx);
+}
+
+template <typename I>
+void PerfReporter<I>::shutdown() {
+  Mutex::Locker timer_locker(*m_timer_lock);
+
+  if (m_report_ctx != nullptr) {
+    m_timer->cancel_event(m_report_ctx);
+    m_report_ctx = nullptr;
+  }
+}
+
+template <typename I>
+void PerfReporter<I>::report() {
+  CephContext *cct = m_image_ctx.cct;
+
+  assert(m_timer_lock->is_locked());
+
+  bool toreport = false;
+  auto &counters = m_counters.counters;
+
+  // TODO: report only part of the counters
+  m_raw_counters->with_counters([this, cct, &counters, &toreport](
+      const PerfCounters::perf_counter_data_vec_t &data) {
+      for (const auto &c : data) {
+        cls::rbd::PerfCounter counter;
+
+        if (c.type & PERFCOUNTER_HISTOGRAM) {
+          continue;
+        }
+
+        auto a = c.read_avg();
+
+        counter.type = static_cast<uint32_t>(c.type);
+        counter.u64 = a.first;
+        counter.avgcount = a.second;
+
+        if (counters.count(c.name)) {
+          if (counters[c.name] == counter)
+            continue;
+
+          toreport = true;
+          counters[c.name] = counter;
+        }
+
+        toreport = true;
+        counters.insert({c.name, counter});
+      }
+    });
+
+  if (!toreport) {
+    m_report_ctx = new FunctionContext([this](int r) {
+        report();
+      });
+    m_timer->add_event_after(cct->_conf->rbd_perf_report_interval, m_report_ctx);
+    return;
+  }
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::image_perf_update(&op, m_counters);
+  using klass = PerfReporter<I>;
+  librados::AioCompletion *rados_completion = create_rados_callback<
+      klass, &klass::handle_report>(this);
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+      rados_completion, &op);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template <typename I>
+void PerfReporter<I>::handle_report(int r) {
+  CephContext *cct = m_image_ctx.cct;
+
+  ldout(cct, 20) << "r=" << r << dendl;
+
+  Mutex::Locker timer_locker(*m_timer_lock);
+
+  m_report_ctx = new FunctionContext([this](int r) {
+      report();
+    });
+  m_timer->add_event_after(cct->_conf->rbd_perf_report_interval, m_report_ctx);
+}
+
+} // namespace librbd
+
+template class librbd::PerfReporter<librbd::ImageCtx>;

--- a/src/librbd/PerfReporter.h
+++ b/src/librbd/PerfReporter.h
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef CEPH_LIBRBD_PERF_REPORTER_H
+#define CEPH_LIBRBD_PERF_REPORTER_H
+
+#include "cls/rbd/cls_rbd_types.h"
+
+class Context;
+class Mutex;
+class PerfCounters;
+class SafeTimer;
+
+namespace librbd {
+
+struct ImageCtx;
+
+template <typename ImageCtxT = ImageCtx>
+class PerfReporter {
+public:
+  PerfReporter(const PerfReporter&) = delete;
+  PerfReporter& operator=(const PerfReporter&) = delete;
+  explicit PerfReporter(ImageCtxT &image_ctx);
+  ~PerfReporter();
+
+  void init(PerfCounters *raw_counters);
+  void shutdown();
+
+  void report();
+  void handle_report(int r);
+
+private:
+  ImageCtxT &m_image_ctx;
+  PerfCounters *m_raw_counters = nullptr;
+  cls::rbd::PerfCounters m_counters = {};
+  SafeTimer *m_timer = nullptr;
+  Mutex *m_timer_lock = nullptr;
+  Context *m_report_ctx = nullptr;
+};
+
+} // namespace librbd
+
+extern template class librbd::PerfReporter<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_PERF_REPORTER_H

--- a/src/librbd/api/Perf.cc
+++ b/src/librbd/api/Perf.cc
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/api/Perf.h"
+#include "common/dout.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ImageCtx.h"
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::api::Perf: " << __func__ << ": "
+
+namespace librbd {
+namespace api {
+
+template <typename I>
+int Perf<I>::perf_reset(I *ictx)
+{
+  CephContext *cct = ictx->cct;
+  ldout(cct, 20) << ictx << dendl;
+
+  return cls_client::image_perf_reset(&ictx->md_ctx, ictx->header_oid);
+}
+
+template <typename I>
+int Perf<I>::perf_dump(I *ictx, const std::string &format, bufferlist *outbl)
+{
+  CephContext *cct = ictx->cct;
+  ldout(cct, 20) << ictx << dendl;
+
+  cls::rbd::PerfCounters perf;
+  int r = cls_client::image_perf_get(&ictx->md_ctx, ictx->header_oid, &perf);
+  if (r < 0) {
+    return r;
+  }
+
+  Formatter *f = Formatter::create(format);
+  if (f == nullptr) {
+    return -EINVAL;
+  }
+
+  perf.dump(f);
+  f->flush(*outbl);
+  delete f;
+
+  return 0;
+}
+
+} // namespace api
+} // namespace librbd
+
+template class librbd::api::Perf<librbd::ImageCtx>;

--- a/src/librbd/api/Perf.h
+++ b/src/librbd/api/Perf.h
@@ -1,0 +1,28 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_API_PERF_H
+#define CEPH_LIBRBD_API_PERF_H
+
+#include "librbd/Types.h"
+
+namespace librbd {
+
+struct ImageCtx;
+
+namespace api {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+struct Perf {
+
+  static int perf_reset(ImageCtxT *ictx);
+  static int perf_dump(ImageCtxT *ictx, const std::string &format, bufferlist *outbl);
+
+};
+
+} // namespace api
+} // namespace librbd
+
+extern template class librbd::api::Perf<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_API_PERF_H

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -30,6 +30,7 @@
 #include "librbd/api/DiffIterate.h"
 #include "librbd/api/Group.h"
 #include "librbd/api/Mirror.h"
+#include "librbd/api/Perf.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageRequestWQ.h"
 #include "librbd/io/ReadResult.h"
@@ -1679,6 +1680,16 @@ namespace librbd {
     int r = ictx->state->unregister_update_watcher(handle);
     tracepoint(librbd, update_unwatch_exit, r);
     return r;
+  }
+
+  int Image::perf_reset() {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Perf<>::perf_reset(ictx);
+  }
+
+  int Image::perf_dump(const std::string &format, bufferlist *outbl) {
+    ImageCtx *ictx = (ImageCtx *)ctx;
+    return librbd::api::Perf<>::perf_dump(ictx, format, outbl);
   }
 
 } // namespace librbd

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -28,6 +28,7 @@ set(rbd_srcs
   action/MirrorImage.cc
   action/Nbd.cc
   action/ObjectMap.cc
+  action/Perf.cc
   action/Remove.cc
   action/Rename.cc
   action/Resize.cc

--- a/src/tools/rbd/action/Perf.cc
+++ b/src/tools/rbd/action/Perf.cc
@@ -1,0 +1,136 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+#include "include/rbd_types.h"
+#include "common/errno.h"
+#include <iostream>
+#include <boost/program_options.hpp>
+
+namespace rbd {
+namespace action {
+namespace perf {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+static int do_perf_dump(librbd::Image& image, const std::string &format)
+{
+  bufferlist outbl;
+  int r = image.perf_dump(format, &outbl);
+  if (r < 0) {
+    std::cerr << "failed to dump image perf counters" << std::endl;
+    return r;
+  }
+
+  std::cout << outbl.c_str();
+  return 0;
+}
+
+static int do_perf_reset(librbd::Image& image)
+{
+  int r = image.perf_reset();
+  if (r < 0) {
+    std::cerr << "failed to reset image perf counters" << std::endl;
+    return r;
+  }
+  return 0;
+}
+
+void get_dump_arguments(po::options_description *positional,
+                       po::options_description *options)
+{
+  at::add_image_spec_options(positional, options,
+                             at::ARGUMENT_MODIFIER_NONE);
+  // TODO: TypedValue
+  options->add_options()
+    (at::FORMAT.c_str(), po::value<std::string>(),
+     "output format [json, json-pretty, xml, or xml-pretty]");
+}
+
+int execute_dump(const po::variables_map &vm)
+{
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
+    nullptr, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string format = "json-pretty";
+  if (vm.count(at::FORMAT)) {
+    format = vm[at::FORMAT].as<std::string>();
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, image_name, "", true,
+                                 &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_perf_dump(image, format);
+  if (r < 0) {
+    std::cerr << "rbd: dump image perf counters error: "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  return 0;
+}
+
+void get_reset_arguments(po::options_description *positional,
+                         po::options_description *options)
+{
+  at::add_image_spec_options(positional, options,
+                             at::ARGUMENT_MODIFIER_NONE);
+}
+
+int execute_reset(const po::variables_map &vm)
+{
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
+    nullptr, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  librbd::Image image;
+  r = utils::init_and_open_image(pool_name, image_name, "", false,
+                                 &rados, &io_ctx, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = do_perf_reset(image);
+  if (r < 0) {
+    std::cerr << "rbd: reset perf counter error: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  return 0;
+}
+
+Shell::Action action_dump(
+  {"perf", "dump"}, {}, "Dump image perf counters.", "",
+  &get_dump_arguments, &execute_dump);
+
+Shell::Action action_reset(
+  {"perf", "reset"}, {}, "Reset image perf counters.", "",
+  &get_reset_arguments, &execute_reset);
+
+} // namespace perf
+} // namespace action
+} // namespace rbd


### PR DESCRIPTION
currently to get the stats, e.g., IOPS, BW etc., of the image, we have no general approach(except  through admin socket?), to take care of this, i can think of three possible approaches:
1. write the perf counters to the image header periodically
which is very simple and intuitive, no special care to be taken
2. request from the exclusive lock owner
the exclusive-lock feature must be enabled, and if we open the image as readonly or open snapshot for read, we  lost the read stats
3. report to ceph-mgr
currently ceph-mgr can only maintain cluster stats and daemon, i.e., MON/OSD/MDS, etc., stats, to extend the support to rados client is possible, not in the near future though

@dillaman hi, Jason, since i have implemented part of the first approach, i am stopping here and want to know if this is the right direction,  any advice or suggestions would be appreciated.

Signed-off-by: runsisi <runsisi@zte.com.cn>