### PR TITLE
os/bluestore: introduce an additional thread for post-processing contexts after kv commit.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -7516,6 +7516,7 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
 
 void BlueStore::_kv_sync_thread1()
 {
+  deque<TransContext*> wal_cleaning2, kv_committing2;
   dout(10) << __func__ << " start" << dendl;
   std::unique_lock<std::mutex> l(kv_lock1);
   while (true) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1740,7 +1740,6 @@ private:
   deque<TransContext*> kv_committing;        ///< currently syncing
   deque<TransContext*> wal_cleanup_queue;    ///< wal done, ready for cleanup
   deque<TransContext*> wal_cleaning1, kv_committing1;
-  deque<TransContext*> wal_cleaning2, kv_committing2;
 
 
   PerfCounters *logger;


### PR DESCRIPTION
This is a resurrection of PR #11189 by @majianpeng.  The patch shows good performance imrovement (to be provided later) for write path.