### PR TITLE
selinux: Allow ceph daemons to read net stats

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -58,6 +58,7 @@ manage_files_pattern(ceph_t, ceph_var_run_t, ceph_var_run_t)
 manage_lnk_files_pattern(ceph_t, ceph_var_run_t, ceph_var_run_t)
 
 kernel_read_system_state(ceph_t)
+kernel_read_network_state(ceph_t)
 
 corenet_all_recvfrom_unlabeled(ceph_t)
 corenet_all_recvfrom_netlabel(ceph_t)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19254

Signed-off-by: Boris Ranto <branto@redhat.com>