### PR TITLE
osd: don't share osdmap with objecter when preboot

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6805,7 +6805,8 @@ void OSD::handle_osd_map(MOSDMap *m)
     session->put();
 
   // share with the objecter
-  service.objecter->handle_osd_map(m);
+  if (!is_preboot())
+    service.objecter->handle_osd_map(m);
 
   epoch_t first = m->get_first();
   epoch_t last = m->get_last();


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/15025

Signed-off-by: Mingxin Liu <mingxin@xsky.com>