### PR TITLE
rgw: PutACLs drop the set_atomic before modifying xattr

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4210,7 +4210,6 @@ void RGWPutACLs::execute()
 
   if (!s->object.empty()) {
     obj = rgw_obj(s->bucket, s->object);
-    store->set_atomic(s->obj_ctx, obj);
     //if instance is empty, we should modify the latest object
     op_ret = modify_obj_attr(store, s, obj, RGW_ATTR_ACL, bl);
   } else {


### PR DESCRIPTION
Since we call `store->set_atomic` in `modify_obj_attr` anyway before
doing the write and the read op doesn't warrant a need for setting atomic

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>