### PR TITLE
client: specify inode in get_caps log message

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -3111,7 +3111,7 @@ int Client::get_caps(Inode *in, int need, int want, int *phave, loff_t endoff)
 	  return 0;
 	}
       }
-      ldout(cct, 10) << "waiting for caps need " << ccap_string(need) << " want " << ccap_string(want) << dendl;
+      ldout(cct, 10) << "waiting for caps " << *in << " need " << ccap_string(need) << " want " << ccap_string(want) << dendl;
       waitfor_caps = true;
     }
 


### PR DESCRIPTION
Otherwise when a client is stuck waiting for caps
and periodically emitting this message, we have
a hard time knowing which inode is involved.

Signed-off-by: John Spray <john.spray@redhat.com>