### PR TITLE
librbd: multithread of 'class ThreadPoolSingleton' can result in assertion failure

### DIFF
--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -31,7 +31,7 @@ public:
     //make sure any member variable of ExclusiveLock not being used
     while (!m_can_delete.load())
       usleep(1000);
-      delete this;
+    delete this;
   }
 
   bool is_lock_owner() const;

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -27,6 +27,12 @@ public:
 
   ExclusiveLock(ImageCtxT &image_ctx);
   ~ExclusiveLock();
+  void destroy(){
+    //make sure any member variable of ExclusiveLock not being used
+    while (!m_can_delete.load())
+      usleep(1000);
+      delete this;
+  }
 
   bool is_lock_owner() const;
   bool accept_requests(int *ret_val) const;
@@ -153,6 +159,7 @@ private:
 
   bool m_request_blocked = false;
   int m_request_blocked_ret_val = 0;
+  std::atomic_bool m_can_delete;
 
   std::string encode_lock_cookie() const;
 

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -148,7 +148,7 @@ void CloseRequest<I>::handle_shut_down_exclusive_lock(int r) {
     assert(m_image_ctx->object_map == nullptr);
   }
 
-  delete m_exclusive_lock;
+  m_exclusive_lock->destroy();
   m_exclusive_lock = nullptr;
 
   save_result(r);


### PR DESCRIPTION
before deleting ExclusiveLock, we should wait another thread to finish using member variable  of ExclusiveLock(in this case is m_lock)  
  
http://tracker.ceph.com/issues/19276