### PR TITLE
librbd: multithread of 'class ThreadPoolSingleton' can result in asse…

### DIFF
--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -11,6 +11,7 @@
 #include <list>
 #include <string>
 #include <utility>
+#include <atomic>
 
 namespace librbd {
 
@@ -27,6 +28,12 @@ public:
 
   ExclusiveLock(ImageCtxT &image_ctx);
   ~ExclusiveLock();
+  void destroy(){
+    //make sure any member variable of ExclusiveLock not being used
+    while (!m_can_delete.load())
+      usleep(1000);
+    delete this;
+  }
 
   bool is_lock_owner() const;
   bool accept_requests(int *ret_val) const;
@@ -153,6 +160,7 @@ private:
 
   bool m_request_blocked = false;
   int m_request_blocked_ret_val = 0;
+  std::atomic_bool m_can_delete;
 
   std::string encode_lock_cookie() const;
 

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -148,7 +148,7 @@ void CloseRequest<I>::handle_shut_down_exclusive_lock(int r) {
     assert(m_image_ctx->object_map == nullptr);
   }
 
-  delete m_exclusive_lock;
+  m_exclusive_lock->destroy();
   m_exclusive_lock = nullptr;
 
   save_result(r);


### PR DESCRIPTION
…rtion failure.  

before deleting ExclusiveLock, we should wait another thread to finish using member variable of ExclusiveLock(in this case is m_lock)  

http://tracker.ceph.com/issues/19276  

Signed-off-by: mychoxin <xin.yuan@istuary.com>