### PR TITLE
doc: fix the links to http://ceph.com/docs

### DIFF
--- a/doc/changelog/v0.61.3.txt
+++ b/doc/changelog/v0.61.3.txt
@@ -685,7 +685,7 @@ Date:   Tue May 21 14:36:11 2013 -0700
     mon: implement --extract-monmap <filename>
 
     This will make for a simpler process for
-      http://ceph.com/docs/master/rados/operations/add-or-rm-mons/#removing-monitors-from-an-unhealthy-cluster
+      http://docs.ceph.com/docs/master/rados/operations/add-or-rm-mons/#removing-monitors-from-an-unhealthy-cluster
 
     Signed-off-by: Sage Weil <sage@inktank.com>
     (cherry picked from commit c0268e27497a4d8228ef54da9d4ca12f3ac1f1bf)

--- a/doc/changelog/v0.94.3.txt
+++ b/doc/changelog/v0.94.3.txt
@@ -1947,7 +1947,7 @@ Date:   Wed Apr 29 13:12:38 2015 +1000
     This adds SuSEfirewall2 service files for Ceph MON, OSD and MDS, for use
     on SLES and openSUSE.  The MON template opens port 6789 and the OSD/MDS
     template opens the range 6800-7300 as per
-    http://ceph.com/docs/master/rados/configuration/network-config-ref/
+    http://docs.ceph.com/docs/master/rados/configuration/network-config-ref/
     
     Signed-off-by: Tim Serong <tserong@suse.com>
     (cherry picked from commit 77685f5b787c56bcb1c4d9f1e058e25312fa62fe)

--- a/doc/install/get-packages.rst
+++ b/doc/install/get-packages.rst
@@ -109,7 +109,7 @@ You may find releases for CentOS/RHEL and others (installed with YUM) at::
 
 The major releases of Ceph are summarized at:
 
-        http://download.ceph.com/docs/master/releases/
+    http://docs.ceph.com/docs/master/releases/
 
 Every second major release is considered Long Term Stable (LTS). Critical
 bugfixes are backported to LTS releases until their retirement. Since retired

--- a/doc/install/upgrading-ceph.rst
+++ b/doc/install/upgrading-ceph.rst
@@ -337,7 +337,7 @@ you may need to uninstall, auto remove dependencies and reinstall.
 
 See `v0.65`_ for details on the new command line interface.
 
-.. _v0.65: http://ceph.com/docs/master/release-notes/#v0-65
+.. _v0.65: http://docs.ceph.com/docs/master/release-notes/#v0-65
 
 
 Monitor
@@ -409,7 +409,7 @@ you may need to uninstall, auto remove dependencies and reinstall.
 
 See `v0.65`_ for details on the new command line interface.
 
-.. _v0.65: http://ceph.com/docs/master/release-notes/#v0-65
+.. _v0.65: http://docs.ceph.com/docs/master/release-notes/#v0-65
 
 
 Upgrade Sequence

--- a/doc/rados/configuration/auth-config-ref.rst
+++ b/doc/rados/configuration/auth-config-ref.rst
@@ -425,7 +425,7 @@ of the enhanced authentication.
 .. _Monitor Bootstrapping: ../../../install/manual-deployment#monitor-bootstrapping
 .. _Operating a Cluster: ../../operations/operating
 .. _Manual Deployment: ../../../install/manual-deployment
-.. _Cephx: http://ceph.com/docs/cuttlefish/rados/configuration/auth-config-ref/
+.. _Cephx: http://docs.ceph.com/docs/cuttlefish/rados/configuration/auth-config-ref/
 .. _Ceph configuration: ../ceph-conf
 .. _Create an Admin Host: ../../deployment/ceph-deploy-admin
 .. _Architecture - High Availability Authentication: ../../../architecture#high-availability-authentication

--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -507,6 +507,6 @@ dashboard, you can boot from that volume by performing the following steps:
 #. Select the volume you created.
 
 .. _qemu-img: ../qemu-rbd/#running-qemu-with-rbd
-.. _Block Devices and OpenStack (Dumpling): http://ceph.com/docs/dumpling/rbd/rbd-openstack
+.. _Block Devices and OpenStack (Dumpling): http://docs.ceph.com/docs/dumpling/rbd/rbd-openstack
 .. _stable/havana: https://github.com/jdurgin/nova/tree/havana-ephemeral-rbd
 .. _stable/icehouse: https://github.com/angdraug/nova/tree/rbd-ephemeral-clone-stable-icehouse

--- a/doc/start/hardware-recommendations.rst
+++ b/doc/start/hardware-recommendations.rst
@@ -350,5 +350,5 @@ configurations for Ceph OSDs, and a lighter configuration for monitors.
 .. _Ceph Write Throughput 2: http://ceph.com/community/ceph-performance-part-2-write-throughput-without-ssd-journals/
 .. _Argonaut v. Bobtail Performance Preview: http://ceph.com/uncategorized/argonaut-vs-bobtail-performance-preview/
 .. _Bobtail Performance - I/O Scheduler Comparison: http://ceph.com/community/ceph-bobtail-performance-io-scheduler-comparison/ 
-.. _Mapping Pools to Different Types of OSDs: http://ceph.com/docs/master/rados/operations/crush-map/#placing-different-pools-on-different-osds
+.. _Mapping Pools to Different Types of OSDs: ../../rados/operations/crush-map#placing-different-pools-on-different-osds
 .. _OS Recommendations: ../os-recommendations

--- a/examples/librados/hello_world.cc
+++ b/examples/librados/hello_world.cc
@@ -149,7 +149,7 @@ int main(int argc, const char **argv)
    * now let's read that object back! Just for fun, we'll do it using
    * async IO instead of synchronous. (This would be more useful if we
    * wanted to send off multiple reads at once; see
-   * http://ceph.com/docs/master/rados/api/librados/#asychronous-io )
+   * http://docs.ceph.com/docs/master/rados/api/librados/#asychronous-io )
    */
   {
     librados::bufferlist read_buf;

--- a/examples/librados/hello_world_c.c
+++ b/examples/librados/hello_world_c.c
@@ -139,7 +139,7 @@ int main(int argc, const char **argv)
    * now let's read that object back! Just for fun, we'll do it using
    * async IO instead of synchronous. (This would be more useful if we
    * wanted to send off multiple reads at once; see
-   * http://ceph.com/docs/master/rados/api/librados/#asychronous-io )
+   * http://docs.ceph.com/docs/master/rados/api/librados/#asychronous-io )
    */
   {
     int read_len = 4194304; // this is way more than we need

--- a/qa/tasks/devstack.py
+++ b/qa/tasks/devstack.py
@@ -51,7 +51,7 @@ def install(ctx, config):
 
     This was created using documentation found here:
         https://github.com/openstack-dev/devstack/blob/master/README.md
-        http://ceph.com/docs/master/rbd/rbd-openstack/
+        http://docs.ceph.com/docs/master/rbd/rbd-openstack/
     """
     if config is None:
         config = {}


### PR DESCRIPTION
they should point to http://docs.ceph.com/docs/master/.. instead

Signed-off-by: Kefu Chai <kchai@redhat.com>