### PR TITLE
os/bluestore: optimize the processing in ExtentMap::encode_some

### DIFF
--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -501,7 +501,7 @@ namespace buffer CEPH_BUFFER_API {
 	  pbl->append(bufferptr(bp, 0, l));
 	  bp.set_length(bp.length() - l);
 	  bp.set_offset(bp.offset() + l);
-	} else {
+	} else if (pbl) {
 	  // we are using pbl's append_buffer
 	  size_t l = pos - pbl->append_buffer.end_c_str();
 	  if (l) {
@@ -515,12 +515,18 @@ namespace buffer CEPH_BUFFER_API {
       friend class list;
 
     public:
+      contiguous_appender(char* pos)
+        : pbl(nullptr),
+          pos(pos),
+          deep(true) {
+      }
+
       ~contiguous_appender() {
 	if (bp.have_raw()) {
 	  // we allocated a new buffer
 	  bp.set_length(pos - bp.c_str());
 	  pbl->append(std::move(bp));
-	} else {
+	} else if (pbl) {
 	  // we are using pbl's append_buffer
 	  size_t l = pos - pbl->append_buffer.end_c_str();
 	  if (l) {

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -657,6 +657,11 @@ namespace buffer CEPH_BUFFER_API {
       reserve(prealloc);
     }
 
+    list(ptr append_buffer) : _len(0), _memcopy_count(0),
+                              append_buffer(append_buffer), last_p(this) {
+      this->append_buffer.set_length(0);   // unused, so far.
+    }
+
     list(const list& other) : _buffers(other._buffers), _len(other._len),
 			      _memcopy_count(other._memcopy_count), last_p(this) {
       make_shareable();

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -349,6 +349,14 @@ inline void denc_signed_varint(T& v, bufferptr::iterator& p)
 inline void denc_varint_lowz(uint64_t v, size_t& p) {
   p += sizeof(v) + 2;
 }
+
+inline void denc_varint_lowz_exact(uint64_t v, size_t& p) {
+  int lowznib = v ? (ctz(v) / 4) : 0;
+  if (lowznib > 3)
+    lowznib = 3;
+  v >>= lowznib * 4 - 2;
+  denc_varint_exact(v, p);
+}
 inline void denc_varint_lowz(uint64_t v, bufferlist::contiguous_appender& p) {
   int lowznib = v ? (ctz(v) / 4) : 0;
   if (lowznib > 3)

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -1248,18 +1248,19 @@ struct denc_traits<boost::none_t> {
 // Write denc_traits<> for a class that defines bound_encode/encode/decode
 // methods.
 
-#define WRITE_CLASS_DENC(T) _DECLARE_CLASS_DENC(T, false)
-#define WRITE_CLASS_DENC_BOUNDED(T) _DECLARE_CLASS_DENC(T, true)
-#define _DECLARE_CLASS_DENC(T, b)					\
+#define WRITE_CLASS_DENC(T) _DECLARE_CLASS_DENC(T, false, )
+#define WRITE_CLASS_DENC_ATTR(T, attr) _DECLARE_CLASS_DENC(T, false, attr)
+#define WRITE_CLASS_DENC_BOUNDED(T) _DECLARE_CLASS_DENC(T, true, )
+#define _DECLARE_CLASS_DENC(T, b, attr)					\
   template<> struct denc_traits<T> {					\
     static constexpr bool supported = true;				\
     static constexpr bool featured = false;				\
     static constexpr bool bounded = b;					\
-    static void bound_encode(const T& v, size_t& p, uint64_t f=0) {	\
+    static void bound_encode(const T& v, size_t& p, uint64_t f=0) attr { \
       v.bound_encode(p);						\
     }									\
     static void encode(const T& v, buffer::list::contiguous_appender& p, \
-		       uint64_t f=0) {					\
+		       uint64_t f=0) attr {				\
       v.encode(p);							\
     }									\
     static void decode(T& v, buffer::ptr::iterator& p, uint64_t f=0) {	\
@@ -1267,18 +1268,19 @@ struct denc_traits<boost::none_t> {
     }									\
   };
 
-#define WRITE_CLASS_DENC_FEATURED(T) _DECLARE_CLASS_DENC_FEATURED(T, false)
-#define WRITE_CLASS_DENC_FEATURED_BOUNDED(T) _DECLARE_CLASS_DENC_FEATURED(T, true)
-#define _DECLARE_CLASS_DENC_FEATURED(T, b)				\
+#define WRITE_CLASS_DENC_FEATURED(T) _DECLARE_CLASS_DENC_FEATURED(T, false, )
+#define WRITE_CLASS_DENC_FEATURED_ATTR(T, attr) _DECLARE_CLASS_DENC_FEATURED(T, false, attr)
+#define WRITE_CLASS_DENC_FEATURED_BOUNDED(T) _DECLARE_CLASS_DENC_FEATURED(T, true, )
+#define _DECLARE_CLASS_DENC_FEATURED(T, b, attr)			\
   template<> struct denc_traits<T> {					\
     static constexpr bool supported = true;				\
     static constexpr bool featured = true;				\
     static constexpr bool bounded = b;					\
-    static void bound_encode(const T& v, size_t& p, uint64_t f) {	\
+    static void bound_encode(const T& v, size_t& p, uint64_t f) attr {	\
       v.bound_encode(p, f);						\
     }									\
     static void encode(const T& v, buffer::list::contiguous_appender& p, \
-		       uint64_t f) {					\
+		       uint64_t f) attr {				\
       v.encode(p, f);							\
     }									\
     static void decode(T& v, buffer::ptr::iterator& p, uint64_t f=0) {	\

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -242,8 +242,50 @@ WRITE_INT_DENC(bool, uint8_t);
 // high bit of each byte indicates another byte follows.
 template<typename T>
 inline void denc_varint(T v, size_t& p) {
-  p += sizeof(T) + 1;
+  p += sizeof(v) + 1;
 }
+
+template<typename T>
+inline void denc_varint_exact(T v, size_t& p) {
+  static_assert(std::is_unsigned<T>::value,
+                "denc_varint() operates on unsigned integers only");
+  register size_t i;
+  for (i = 1; v; i++) {
+    v >>= 7;
+  }
+  p += i;
+}
+
+#if 1
+template<>
+inline void denc_varint_exact<unsigned>(const unsigned v, size_t& p) {
+  if (v == 0) {
+    p++;
+  } else {
+    p += (sizeof(v) * CHAR_BIT - clz(v) + 6) / (CHAR_BIT - 1);
+  }
+}
+
+template<>
+inline void denc_varint_exact<unsigned long>(const unsigned long v, size_t& p) {
+  if (v == 0) {
+    p++;
+  } else {
+    p += (sizeof(v) * CHAR_BIT - clzl(v) + 6) / (CHAR_BIT - 1);
+  }
+}
+
+template<>
+inline void denc_varint_exact<unsigned long long>(const unsigned long long v,
+                                            size_t& p) {
+
+  if (v == 0) {
+    p++;
+  } else {
+    p += (sizeof(v) * CHAR_BIT - clzll(v) + 6) / (CHAR_BIT - 1);
+  }
+}
+#endif
 
 template<typename T>
 inline void denc_varint(T v, bufferlist::contiguous_appender& p) {

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -253,6 +253,9 @@ public:
 void dump(ceph::Formatter *f, size_t skip=2);
 
 
+// Object pool.
+// FIXME(rzarzynski): provide an implementation based on boost::object_pool.
+
 // STL allocator for use with containers.  All actual state
 // is stored in the static pool_allocator_base_t, which saves us from
 // passing the allocator to container constructors.
@@ -439,6 +442,8 @@ DEFINE_MEMORY_POOLS_HELPER(P)
 //
 #define MEMPOOL_CLASS_HELPERS()						\
   void *operator new(size_t size);					\
+  /* The placement-new is necessary is for boost::object_pool. */       \
+  void *operator new(size_t size, void* where) { return where; }        \
   void *operator new[](size_t size) noexcept {				\
     assert(0 == "no array new");					\
     return nullptr; }							\

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -59,6 +59,7 @@ extern "C" {
 #include <iostream>
 #include <iomanip>
 
+#include <boost/container/small_vector.hpp>
 using namespace std;
 
 #include "include/unordered_map.h"
@@ -97,6 +98,17 @@ inline ostream& operator<<(ostream& out, const pair<A,B>& v) {
 
 template<class A, class Alloc>
 inline ostream& operator<<(ostream& out, const vector<A,Alloc>& v) {
+  out << "[";
+  for (auto p = v.begin(); p != v.end(); ++p) {
+    if (p != v.begin()) out << ",";
+    out << *p;
+  }
+  out << "]";
+  return out;
+}
+template<class A, size_t N, class Alloc>
+inline ostream& operator<<(ostream& out,
+                           const boost::container::small_vector<A,N,Alloc>& v) {
   out << "[";
   for (auto p = v.begin(); p != v.end(); ++p) {
     if (p != v.begin()) out << ",";

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2362,7 +2362,6 @@ bool BlueStore::ExtentMap::encode_some(
     p->blob->bound_encode(
       bound,
       struct_v,
-      p->blob->shared_blob->get_sbid(),
       false);
   }
   if (must_reshard) {
@@ -2418,7 +2417,7 @@ bool BlueStore::ExtentMap::encode_some(
       }
       pos = p->logical_end();
       if (include_blob) {
-	p->blob->encode(app, struct_v, p->blob->shared_blob->get_sbid(), false);
+	p->blob->encode(app, struct_v, false);
       }
     }
   }
@@ -2520,7 +2519,7 @@ void BlueStore::ExtentMap::bound_encode_spanning_blobs(size_t& p)
   denc_varint((uint32_t)0, key_size);
   p += spanning_blob_map.size() * key_size;
   for (const auto& i : spanning_blob_map) {
-    i.second->bound_encode(p, struct_v, i.second->shared_blob->get_sbid(), true);
+    i.second->bound_encode(p, struct_v, true);
   }
 }
 
@@ -2536,7 +2535,7 @@ void BlueStore::ExtentMap::encode_spanning_blobs(
   denc_varint(spanning_blob_map.size(), p);
   for (auto& i : spanning_blob_map) {
     denc_varint(i.second->id, p);
-    i.second->encode(p, struct_v, i.second->shared_blob->get_sbid(), true);
+    i.second->encode(p, struct_v, true);
   }
 }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8811,6 +8811,7 @@ int BlueStore::_do_alloc_write(
     // counting machinery.
     assert(!b->is_referenced());
     b->get_ref(coll.get(), wi.b_off0, wi.length0); 
+    b->_encode_blob_to_cache(3);
                                                
 
     // queue io

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2344,7 +2344,7 @@ bool BlueStore::ExtentMap::encode_some(
   denc_varint(0ul, bound);
   bool must_reshard = false;
   for (auto p = start;
-       p != extent_map.end() && p->logical_offset < end;
+       unlikely(p != extent_map.end()) && p->logical_offset < end;
        ++p, ++n) {
     assert(p->logical_offset >= offset);
     p->blob->last_encoded_id = -1;
@@ -2385,7 +2385,7 @@ bool BlueStore::ExtentMap::encode_some(
 	 ++p, ++n) {
       unsigned blobid;
       bool include_blob = false;
-      if (p->blob->is_spanning()) {
+      if (unlikely(p->blob->is_spanning())) {
 	blobid = p->blob->id << BLOBID_SHIFT_BITS;
 	blobid |= BLOBID_FLAG_SPANNING;
       } else if (p->blob->last_encoded_id < 0) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2339,25 +2339,26 @@ bool BlueStore::ExtentMap::encode_some(
                      // handling at ExtentMap level.
 
   unsigned n = 0;
-  size_t bound = 0;
+  register size_t bound = 0;
   denc(struct_v, bound);
-  denc_varint(0, bound);
+  denc_varint(0ul, bound);
   bool must_reshard = false;
   for (auto p = start;
        p != extent_map.end() && p->logical_offset < end;
        ++p, ++n) {
     assert(p->logical_offset >= offset);
     p->blob->last_encoded_id = -1;
-    if (!p->blob->is_spanning() && p->blob_escapes_range(offset, length)) {
+    if (unlikely(p->blob_escapes_range(offset, length)) &&
+        likely(!p->blob->is_spanning())) {
       dout(30) << __func__ << " 0x" << std::hex << offset << "~" << length
 	       << std::dec << " hit new spanning blob " << *p << dendl;
       request_reshard(p->blob_start(), p->blob_end());
       must_reshard = true;
     }
-    denc_varint(0, bound); // blobid
-    denc_varint(0, bound); // logical_offset
-    denc_varint(0, bound); // len
-    denc_varint(0, bound); // blob_offset
+    denc_varint(0ul, bound); // blobid
+    denc_varint(0ul, bound); // logical_offset
+    denc_varint(0ul, bound); // len
+    denc_varint(0ul, bound); // blob_offset
 
     p->blob->bound_encode(
       bound,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -562,11 +562,10 @@ public:
     void bound_encode(
       size_t& p,
       uint64_t struct_v,
-      uint64_t sbid,
       bool include_ref_map) const {
       denc(blob, p, struct_v);
       if (blob.is_shared()) {
-        denc(sbid, p);
+        denc(shared_blob->get_sbid(), p);
       }
       if (include_ref_map) {
 	used_in_blob.bound_encode(p);
@@ -575,11 +574,10 @@ public:
     void encode(
       bufferlist::contiguous_appender& p,
       uint64_t struct_v,
-      uint64_t sbid,
       bool include_ref_map) const {
       denc(blob, p, struct_v);
       if (blob.is_shared()) {
-        denc(sbid, p);
+        denc(shared_blob->get_sbid(), p);
       }
       if (include_ref_map) {
 	used_in_blob.encode(p);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -426,26 +426,37 @@ public:
     }
   };
 
-//#define CACHE_BLOB_BL  // not sure if this is a win yet or not... :/
+#define CACHE_BLOB_BL
 
   /// in-memory blob metadata and associated cached buffers (if any)
   struct Blob {
     MEMPOOL_CLASS_HELPERS();
 
-    std::atomic_int nref = {0};     ///< reference count
+#ifdef CACHE_BLOB_BL
+    /* 32 bytes seems to be optimal for cache size. Typically L1 cache line
+     * is 64 bytes long, so other hot data should fit as well. On the other
+     * hand the capacity should cover most situations as serialized blob with
+     * single physical extent + sbid is less than 8 byte long while testing
+     * 4 KiB rand-write across 4 MiB  objects (usual RBD segment size).  */
+    static constexpr size_t BLOB_CACHE_MAX_SIZE = 32;
+
+    mutable struct {
+      uint8_t size = 0;
+      char buffer[BLOB_CACHE_MAX_SIZE - sizeof(size)];
+    } blob_cache;                   ///< cached encoded blob
+    static_assert(sizeof(blob_cache) == BLOB_CACHE_MAX_SIZE,
+                  "struct blob_cache should be padding-free!");
+#endif
+
     int16_t id = -1;                ///< id, for spanning blobs only, >= 0
     int16_t last_encoded_id = -1;   ///< (ephemeral) used during encoding only
+
     SharedBlobRef shared_blob;      ///< shared blob state (if any)
 
-  private:
     mutable bluestore_blob_t blob;  ///< decoded blob metadata
-#ifdef CACHE_BLOB_BL
-    mutable bufferlist blob_bl;     ///< cached encoded blob, blob is dirty if empty
-#endif
     /// refs from this shard.  ephemeral if id<0, persisted if spanning.
     bluestore_blob_use_tracker_t used_in_blob;
-
-  public:
+    std::atomic_int nref = {0};     ///< reference count
 
     friend void intrusive_ptr_add_ref(Blob *b) { b->get(); }
     friend void intrusive_ptr_release(Blob *b) { b->put(); }
@@ -482,8 +493,17 @@ public:
     void dup(Blob& o) {
       o.shared_blob = shared_blob;
       o.blob = blob;
+
 #ifdef CACHE_BLOB_BL
-      o.blob_bl = blob_bl;
+      if (likely(blob_cache.size > 0 &&
+          blob_cache.size <= sizeof(blob_cache.buffer))) {
+        /* Copy also the buffer only if it actually contains encoded blob.
+         * As the data cache is fixed sized, blob can be too large. */
+        o.blob_cache = blob_cache;
+      } else {
+        /* Copy only size cache. */
+        o.blob_cache.size = blob_cache.size;
+      }
 #endif
     }
 
@@ -492,7 +512,7 @@ public:
     }
     bluestore_blob_t& dirty_blob() {
 #ifdef CACHE_BLOB_BL
-      blob_bl.clear();
+      blob_cache.size = 0;
 #endif
       return blob;
     }
@@ -518,46 +538,96 @@ public:
       }
     }
 
-
 #ifdef CACHE_BLOB_BL
-    void _encode(const uint64_t struct_v) const {
-      if (blob_bl.length() == 0) {
-        size_t bound = 0;
-        denc(blob, bound, struct_v);
-        auto app = blob_bl.get_contiguous_appender(bound);
-        denc(blob, app, struct_v);
-      } else {
-	assert(blob_bl.length());
+    size_t _encode_blob_to_cache(const uint64_t struct_v) const {
+      /* XXX: we don't memorize struct_v in the cache as it's supposed that
+       * value doesn't change. */
+
+      if (unlikely(blob_cache.size == 0)) {
+        /* Neither cached size nor data -- we need to fill the cache now. */
+        register size_t p_blob = 0;
+        blob.bound_encode(p_blob, struct_v);
+
+        register size_t p_blob_shared = 0;
+        if (unlikely(blob.is_shared())) {
+          denc(shared_blob->get_sbid(), p_blob_shared, struct_v);
+        }
+
+        if (likely((p_blob + p_blob_shared) <= sizeof(blob_cache.buffer))) {
+          /* Great, data is small enough to fit in the cache. It is a part
+           * of the Blob object itself to allow CPU's prefetchers do their
+           * job effectively. */
+          auto ap = ceph::buffer::list::contiguous_appender(blob_cache.buffer);
+          blob.encode(ap, struct_v);
+
+          if (unlikely(blob.is_shared())) {
+            denc(shared_blob->get_sbid(), ap, struct_v);
+          }
+
+          /* The real size can be smaller than the bound. The rationale is
+           * to make the computations optimizable at compile-time. */
+          blob_cache.size = ap.get_pos() - blob_cache.buffer;
+        } else {
+          blob_cache.size = p_blob + p_blob_shared;
+        }
       }
+
+      return blob_cache.size;
     }
+
     void bound_encode(
       size_t& p,
       const uint64_t struct_v,
       const bool include_ref_map) const {
-      _encode(struct_v);
-      p += blob_bl.length();
 
-      if (blob.is_shared()) {
-        denc(shared_blob->get_sbid(), p);
-      }
+      const auto p_blob = _encode_blob_to_cache(struct_v);
+
+      size_t p_ref_map = 0;
       if (include_ref_map) {
-	used_in_blob.bound_encode(p);
+	used_in_blob.bound_encode(p_ref_map);
       }
+
+      p += p_ref_map + p_blob;
     }
+
+    BLUESTORE_FORCEINLINE
     void encode(
       bufferlist::contiguous_appender& p,
       const uint64_t struct_v,
       const bool include_ref_map) const {
-      _encode(struct_v);
-      p.append(blob_bl);
 
-      if (blob.is_shared()) {
-        denc(shared_blob->get_sbid(), p);
+#ifdef CACHE_BLOB_BL
+      auto serialized_size = _encode_blob_to_cache(struct_v);
+      if (unlikely(serialized_size > sizeof(blob_cache.buffer))) {
+        /* Blob was too large -- no size/data caching, sorry. */
+        denc(blob, p, struct_v);
+
+        if (unlikely(blob.is_shared())) {
+          denc(shared_blob->get_sbid(), p, struct_v);
+        }
+      } else {
+        /* OK, we can finally use data cache. The implementation of appender's
+        * append() method has been duplicated here to avoid extra call. objdump
+        * shows that GCC 5.4.0 on AMD64 doesn't inline it without the global
+        * always_inline __attribute__. */
+        char* const dest_buffer = p.get_pos_add(blob_cache.size);
+        maybe_inline_memcpy(dest_buffer, blob_cache.buffer,
+                            blob_cache.size, 16);
+
+        static_assert(sizeof(blob_cache.buffer) <= UINT8_MAX,
+                      "blob_cache.buffer is too long");
       }
+#else
+      denc(blob, p, struct_v);
+      if (unlikely(blob.is_shared())) {
+        denc(shared_blob->get_sbid(), p, struct_v);
+      }
+#endif
       if (include_ref_map) {
 	used_in_blob.encode(p);
       }
     }
+
     void decode(
       Collection* const coll,
       bufferptr::iterator& p,
@@ -567,13 +637,27 @@ public:
 
       const char *start = p.get_pos();
       denc(blob, p, struct_v);
-      const char *end = p.get_pos();
-      blob_bl.clear();
-      blob_bl.append(start, end - start);
-
       if (blob.is_shared()) {
         denc(*sbid, p);
       }
+
+      const size_t serialized_size = p.get_pos() - start;
+      if (serialized_size <=
+          std::numeric_limits<decltype(blob_cache.size)>::max()) {
+        blob_cache.size = p.get_pos() - start;
+      }
+      if (serialized_size <= sizeof(blob_cache.buffer)) {
+        /* The cache is supposed to cover small blobs only. If we're
+         * here, we can safely assume the data size is less than 256
+         * bytes. Thus, We can cast from size_t to uint8_t. Compiler
+         * can treat this as a hint for inlining the memcpy. GCC 5.4
+         * on AMD64 behaves exactly in that way. */
+        memcpy(blob_cache.buffer, start,
+               static_cast<uint8_t>(serialized_size));
+        static_assert(sizeof(blob_cache.buffer) <= UINT8_MAX,
+                      "blob_cache.buffer is too long");
+      }
+
       if (include_ref_map) {
         if (struct_v > 1) {
           used_in_blob.decode(p);

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -513,8 +513,9 @@ public:
       ++nref;
     }
     void put() {
-      if (--nref == 0)
-	delete this;
+      if (--nref == 0) {
+	//delete this;
+      }
     }
 
 
@@ -961,6 +962,7 @@ public:
     bluestore_onode_t onode;  ///< metadata stored as value in kv store
     bool exists;              ///< true if object logically exists
 
+    boost::object_pool<Blob> blob_pool{4096};
     boost::object_pool<Extent> extent_pool{4096,4096};
     ExtentMap extent_map;
 
@@ -1295,8 +1297,8 @@ public:
     void load_shared_blob(SharedBlobRef sb);
     void make_blob_shared(uint64_t sbid, BlobRef b);
 
-    BlobRef new_blob() {
-      BlobRef b = new Blob();
+    BlobRef new_blob(Onode* const onode) {
+      BlobRef b = onode->blob_pool.construct();
       b->shared_blob = new SharedBlob(this);
       return b;
     }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -539,6 +539,7 @@ public:
     }
 
 #ifdef CACHE_BLOB_BL
+    BLUESTORE_FORCEINLINE
     size_t _encode_blob_to_cache(const uint64_t struct_v) const {
       /* XXX: we don't memorize struct_v in the cache as it's supposed that
        * value doesn't change. */
@@ -575,6 +576,7 @@ public:
       return blob_cache.size;
     }
 
+    BLUESTORE_FORCEINLINE
     void bound_encode(
       size_t& p,
       const uint64_t struct_v,

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -17,6 +17,7 @@
 
 #include <ostream>
 #include <bitset>
+#include <boost/container/small_vector.hpp>
 #include "include/types.h"
 #include "include/interval_set.h"
 #include "include/utime.h"
@@ -156,7 +157,7 @@ WRITE_CLASS_DENC(bluestore_pextent_t)
 
 ostream& operator<<(ostream& out, const bluestore_pextent_t& o);
 
-typedef mempool::bluestore_meta_other::vector<bluestore_pextent_t> PExtentVector;
+typedef boost::container::small_vector<bluestore_pextent_t, 1> PExtentVector;
 
 template<>
 struct denc_traits<PExtentVector> {

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -497,7 +497,8 @@ struct bluestore_blob_t {
     }
   }
 
-  inline void encode(bufferlist::contiguous_appender& p, uint64_t struct_v) const __attribute__((always_inline)) {
+  BLUESTORE_FORCEINLINE
+  inline void encode(bufferlist::contiguous_appender& p, uint64_t struct_v) const {
 //    assert(struct_v == 1 || struct_v == 2);
     denc(extents, p);
     denc_varint(flags, p);

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -145,15 +145,23 @@ struct bluestore_pextent_t : public AllocExtent {
     return offset != INVALID_OFFSET;
   }
 
-  DENC(bluestore_pextent_t, v, p) {
-    denc_lba(v.offset, p);
-    denc_varint_lowz(v.length, p);
+  void bound_encode(size_t& p) const {
+    denc_lba(offset, p);
+    denc_varint_lowz(length, p);
+  }
+  void encode(bufferlist::contiguous_appender& p) const {
+    denc_lba(offset, p);
+    denc_varint_lowz(length, p);
+  }
+  void decode(bufferptr::iterator& p) {
+    denc_lba(offset, p);
+    denc_varint_lowz(length, p);
   }
 
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluestore_pextent_t*>& ls);
 };
-WRITE_CLASS_DENC(bluestore_pextent_t)
+WRITE_CLASS_DENC_ATTR(bluestore_pextent_t, __attribute__((always_inline)))
 
 ostream& operator<<(ostream& out, const bluestore_pextent_t& o);
 

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -756,10 +756,10 @@ struct bluestore_blob_t {
   }
 
   uint32_t get_logical_length() const {
-    if (is_compressed()) {
-      return compressed_length_orig;
-    } else {
+    if (! is_compressed()) {
       return get_ondisk_length();
+    } else {
+      return compressed_length_orig;
     }
   }
   size_t get_csum_value_size() const;

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -964,14 +964,12 @@ TEST(Blob, legacy_decode)
     B.bound_encode(
       bound,
       1, /*struct_v*/
-      0, /*sbid*/
       false);
     fake_ref_map.bound_encode(bound);
 
     B.bound_encode(
       bound2,
       2, /*struct_v*/
-      0, /*sbid*/
       true);
 
     {
@@ -980,14 +978,12 @@ TEST(Blob, legacy_decode)
       B.encode(
         app,
         1, /*struct_v*/
-        0, /*sbid*/
         false);
       fake_ref_map.encode(app);
 
       B.encode(
         app2,
         2, /*struct_v*/
-        0, /*sbid*/
         true);
     }
 


### PR DESCRIPTION
This pull request is dedicated to lower the CPU pressure in BlueStore pipeline's front-end.

Quick & rough performance testing results (BlueStore: `bluestore_debug_omit_block_device_write = true`, FIO: `nr_files=64`, `size=256M`, `bs=4k`, `numjobs=1`) during 4 KiB rand-writes across 4 MiB are attached below. The IO writes have been disabled and single feeding thread (consuming whole physical core) was used to expose the CPU bottleneck we have there.

* `master` (3580d224d7bbe4ff8e258c09c75320f06b6b8e49):
```
bluestore: (groupid=0, jobs=1): err= 0: pid=15575: Wed Mar 15 15:29:05 2017
  write: IOPS=30.6k, BW=119MiB/s (125MB/s)(2385MiB/20001msec)
    clat (usec): min=56, max=4991, avg=2239.62, stdev=1132.92
     lat (usec): min=84, max=5023, avg=2271.69, stdev=1133.25
    clat percentiles (usec):
     |  1.00th=[  213],  5.00th=[  502], 10.00th=[  700], 20.00th=[ 1080],
     | 30.00th=[ 1464], 40.00th=[ 1848], 50.00th=[ 2224], 60.00th=[ 2608],
     | 70.00th=[ 2992], 80.00th=[ 3408], 90.00th=[ 3824], 95.00th=[ 4048],
     | 99.00th=[ 4256], 99.50th=[ 4320], 99.90th=[ 4512], 99.95th=[ 4576],
     | 99.99th=[ 4704]
    lat (usec) : 100=0.18%, 250=1.09%, 500=3.65%, 750=6.41%, 1000=6.54%
    lat (msec) : 2=26.19%, 4=50.17%, 10=5.77%
  cpu          : usr=98.28%, sys=1.54%, ctx=7897, majf=0, minf=7671
  IO depths    : 1=0.1%, 2=0.1%, 4=0.9%, 8=3.4%, 16=13.2%, 32=27.2%, >=64=55.2%
     submit    : 0=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.1%, >=64=100.0%
     issued rwt: total=0,610682,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=128

Run status group 0 (all jobs):
  WRITE: bw=119MiB/s (125MB/s), 119MiB/s-119MiB/s (125MB/s-125MB/s), io=2385MiB (2501MB), run=20001-20001msec

 Performance counter stats for '/home/radek/fio/fio ceph-bluestore.fio':

      36920.625226      task-clock (msec)         #    1.641 CPUs utilized          
           1106127      context-switches          #    0.030 M/sec                  
             57620      cpu-migrations            #    0.002 M/sec                  
             79651      page-faults               #    0.002 M/sec                  
      123128155925      cycles                    #    3.335 GHz                      (30.99%)
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
       93261852300      instructions              #    0.76  insns per cycle          (38.67%)
       20106565367      branches                  #  544.589 M/sec                    (38.64%)
         262092655      branch-misses             #    1.30% of all branches          (38.86%)
       31064336698      L1-dcache-loads           #  841.382 M/sec                    (23.36%)
        3274540355      L1-dcache-load-misses     #   10.54% of all L1-dcache hits    (19.71%)
        1649746776      LLC-loads                 #   44.684 M/sec                    (15.90%)
         327165672      LLC-load-misses           #   39.66% of all LL-cache hits     (22.96%)
   <not supported>      L1-icache-loads          
        1868473489      L1-icache-load-misses     #   50.608 M/sec                    (30.71%)
       29885263168      dTLB-loads                #  809.446 M/sec                    (28.54%)
         205740699      dTLB-load-misses          #    0.69% of all dTLB cache hits   (17.39%)
         195524816      iTLB-loads                #    5.296 M/sec                    (15.78%)
          37196569      iTLB-load-misses          #   19.02% of all iTLB cache hits   (23.14%)
   <not supported>      L1-dcache-prefetches     
   <not supported>      L1-dcache-prefetch-misses

      22.500588004 seconds time elapsed

```
* after the changset:
```
bluestore: (groupid=0, jobs=1): err= 0: pid=19306: Wed Mar 15 15:45:31 2017
  write: IOPS=40.2k, BW=157MiB/s (165MB/s)(3141MiB/20001msec)
    clat (usec): min=67, max=34994, avg=1754.04, stdev=873.51
     lat (usec): min=86, max=35015, avg=1778.36, stdev=874.59
    clat percentiles (usec):
     |  1.00th=[  171],  5.00th=[  426], 10.00th=[  628], 20.00th=[  924],
     | 30.00th=[ 1192], 40.00th=[ 1480], 50.00th=[ 1752], 60.00th=[ 2024],
     | 70.00th=[ 2320], 80.00th=[ 2608], 90.00th=[ 2896], 95.00th=[ 3056],
     | 99.00th=[ 3216], 99.50th=[ 3280], 99.90th=[ 3376], 99.95th=[ 3472],
     | 99.99th=[13504]
    lat (usec) : 100=0.12%, 250=2.10%, 500=4.27%, 750=7.45%, 1000=8.93%
    lat (msec) : 2=36.06%, 4=41.05%, 10=0.01%, 20=0.01%, 50=0.01%
  cpu          : usr=96.78%, sys=3.00%, ctx=9637, majf=0, minf=119240
  IO depths    : 1=0.1%, 2=0.1%, 4=0.9%, 8=3.1%, 16=10.1%, 32=28.2%, >=64=57.7%
     submit    : 0=0.0%, 4=0.0%, 8=0.0%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=0.0%
     complete  : 0=0.0%, 4=0.0%, 8=0.1%, 16=0.0%, 32=0.0%, 64=0.0%, >=64=100.0%
     issued rwt: total=0,803973,0, short=0,0,0, dropped=0,0,0
     latency   : target=0, window=0, percentile=100.00%, depth=128

Run status group 0 (all jobs):
  WRITE: bw=157MiB/s (165MB/s), 157MiB/s-157MiB/s (165MB/s-165MB/s), io=3141MiB (3293MB), run=20001-20001msec

 Performance counter stats for '/home/radek/fio/fio ceph-bluestore.fio':

      38747.117548      task-clock (msec)         #    1.733 CPUs utilized          
           1150669      context-switches          #    0.030 M/sec                  
             30423      cpu-migrations            #    0.785 K/sec                  
            191266      page-faults               #    0.005 M/sec                  
      129629213751      cycles                    #    3.346 GHz                      (30.78%)
   <not supported>      stalled-cycles-frontend  
   <not supported>      stalled-cycles-backend   
      109579169902      instructions              #    0.85  insns per cycle          (38.57%)
       23565725542      branches                  #  608.193 M/sec                    (38.48%)
         326559443      branch-misses             #    1.39% of all branches          (38.61%)
       36429308177      L1-dcache-loads           #  940.181 M/sec                    (24.04%)
        3449323919      L1-dcache-load-misses     #    9.47% of all L1-dcache hits    (19.81%)
        1533309666      LLC-loads                 #   39.572 M/sec                    (16.35%)
         283070954      LLC-load-misses           #   36.92% of all LL-cache hits     (23.42%)
   <not supported>      L1-icache-loads          
        1843635114      L1-icache-load-misses     #   47.581 M/sec                    (31.07%)
       35484225188      dTLB-loads                #  915.790 M/sec                    (25.19%)
         120743225      dTLB-load-misses          #    0.34% of all dTLB cache hits   (23.88%)
         257682737      iTLB-loads                #    6.650 M/sec                    (15.51%)
          25705049      iTLB-load-misses          #    9.98% of all iTLB cache hits   (22.99%)
   <not supported>      L1-dcache-prefetches     
   <not supported>      L1-dcache-prefetch-misses

      22.355413651 seconds time elapsed
```