### PR TITLE
rgw_file: fix double unref on rgw_fh for rename

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -396,7 +396,7 @@ namespace rgw {
 	    << dendl;
 	}
       }
-      break;
+      goto out;
       default:
 	abort();
       } /* switch */


### PR DESCRIPTION
Skip unref after unlink to fix the problem.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>