### PR TITLE
rgw: fix Swift container naming rules.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1636,6 +1636,14 @@ int RGWHandler_REST::validate_bucket_name(const string& bucket)
     return -ERR_INVALID_BUCKET_NAME;
   }
 
+  const char *s = bucket.c_str();
+  for (int i = 0; i < len; ++i, ++s) {
+    if (*(unsigned char *)s == 0xff)
+      return -ERR_INVALID_BUCKET_NAME;
+    if (*(unsigned char *)s == '/')
+      return -ERR_INVALID_BUCKET_NAME;
+  }
+
   return 0;
 }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2228,6 +2228,8 @@ int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
   for (int i = 0; i < len; ++i, ++s) {
     if (*(unsigned char *)s == 0xff)
       return -ERR_INVALID_BUCKET_NAME;
+    if (*(unsigned char *)s == '/')
+      return -ERR_INVALID_BUCKET_NAME;
   }
 
   return 0;


### PR DESCRIPTION
Swift containers are declared in the upstream documentation as 1-256
bytes of UTF-8, and the only forbidden character is '/'.

We did not previously enforce the no-slash rule.

See-Also: https://docs.openstack.org/developer/swift/api/object_api_v1_overview.html
Fixes: http://tracker.ceph.com/issues/19264
Backport: hammer, jewel
Signed-off-by: Robin H. Johnson <robin.johnson@dreamhost.com>