### PR TITLE
make filestore roughly support lvm2 volumes

### DIFF
--- a/udev/60-ceph-by-parttypeuuid.rules
+++ b/udev/60-ceph-by-parttypeuuid.rules
@@ -28,4 +28,7 @@ KERNEL!="sr*", IMPORT{program}="/sbin/blkid -o udev -p $tempnode"
 # NEW: by-parttypeuuid links (type.id)
 ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_TYPE}=="?*", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-parttypeuuid/$env{ID_PART_ENTRY_TYPE}.$env{ID_PART_ENTRY_UUID}"
 
+# when ceph-disk prepares a filestore osd with a journal it makes the symbolic link by disk/by-partuuid but LVM2 currently doesn't seem to populate /dev/disk/by-partuuid.
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_TYPE}=="?*", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
+
 LABEL="persistent_storage_end_two"


### PR DESCRIPTION
Hi, it's very naive and simple implementation; hope a ceph developer will polish it up a bit.

I still need to do a 'partprobe' and a 'udevadm trigger' on every boot-up so that 1) the device mapped virtual block devices for the lvm partitions show up and 2) the udev rule populates the directory /dev/disk/by-partuuid which is used by the symbolic link of the filestore journal prepared by ceph-disk.

a related mailing list thread : https://www.mail-archive.com/ceph-users@lists.ceph.com/msg36362.html