### PR TITLE
ceph-disk:  support lvm2 volumes

### DIFF
--- a/udev/60-ceph-by-parttypeuuid.rules
+++ b/udev/60-ceph-by-parttypeuuid.rules
@@ -28,4 +28,7 @@ KERNEL!="sr*", IMPORT{program}="/sbin/blkid -o udev -p $tempnode"
 # NEW: by-parttypeuuid links (type.id)
 ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_TYPE}=="?*", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-parttypeuuid/$env{ID_PART_ENTRY_TYPE}.$env{ID_PART_ENTRY_UUID}"
 
+# when ceph-disk prepares a filestore osd with a journal it makes the symbolic link by disk/by-partuuid but LVM2 currently doesn't seem to populate /dev/disk/by-partuuid.
+ENV{ID_PART_ENTRY_SCHEME}=="gpt", ENV{ID_PART_ENTRY_TYPE}=="?*", ENV{ID_PART_ENTRY_UUID}=="?*", SYMLINK+="disk/by-partuuid/$env{ID_PART_ENTRY_UUID}"
+
 LABEL="persistent_storage_end_two"

--- a/udev/95-ceph-osd.rules
+++ b/udev/95-ceph-osd.rules
@@ -1,6 +1,7 @@
 # OSD_UUID
+# also respond to lvm2 partitions coming up as a "disk" in
+# ENV{DEVTYPE} instead of a "partition".
 ACTION=="add", SUBSYSTEM=="block", \
-  ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-062c0ceff05d", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
   RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"


### PR DESCRIPTION
Hi, it's very naive and simple implementation; hope a ceph developer will polish it up a bit.

I still need to do a 'partprobe' and a 'udevadm trigger' on every boot-up so that 1) the device-mapped virtual block devices for the lvm partitions show up and 2) the udev rule populates the directory /dev/disk/by-partuuid which is used by the symbolic link of the filestore journal prepared by ceph-disk.

a related mailing list thread : https://www.mail-archive.com/ceph-users@lists.ceph.com/msg36362.html


Signed-off-by: Gunwoo Gim (a.k.a. Nicho1as) <wind8702@gmail.com>