### PR TITLE
os: Combine callback of op_commit/op_applied into to one.

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1974,6 +1974,10 @@ public:
   */
   virtual uint64_t estimate_objects_overhead(uint64_t num_objects) = 0;
 
+  /**
+   *mean the callback op_commit & op_applied can return at the same time.
+   */
+  virtual bool op_commit_equal_applied() const { return false; }
 
   // DEBUG
   virtual void inject_data_error(const ghobject_t &oid) {}

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2143,6 +2143,10 @@ public:
     return num_objects * 300; //assuming per-object overhead is 300 bytes
   }
 
+  bool op_commit_equal_applied() const override {
+    return true;
+  }
+
   struct BSPerfTracker {
     PerfCounters::avg_tracker<uint64_t> os_commit_latency;
     PerfCounters::avg_tracker<uint64_t> os_apply_latency;

--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -550,6 +550,10 @@ public:
     return num_objects * 300; //assuming per-object overhead is 300 bytes
   }
 
+  bool op_commit_equal_applied() const override {
+    return true;
+  }
+
   objectstore_perf_stat_t get_cur_stats() {
     return objectstore_perf_stat_t();
   }

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -386,6 +386,10 @@ public:
     return 0; //do not care
   }
 
+  bool op_commit_equal_applied() const override {
+    return true;
+  }
+
   objectstore_perf_stat_t get_cur_stats() override;
 
   const PerfCounters* get_perf_counters() const {

--- a/src/osd/ECBackend.h
+++ b/src/osd/ECBackend.h
@@ -57,10 +57,11 @@ public:
     );
   friend struct SubWriteApplied;
   friend struct SubWriteCommitted;
-  void sub_write_applied(
-    ceph_tid_t tid, eversion_t version);
-  void sub_write_committed(
-    ceph_tid_t tid, eversion_t version, eversion_t last_complete);
+  friend struct SubWriteCommittedApplied;
+  void sub_write_committed_or_applied(
+    ceph_tid_t tid, eversion_t version, eversion_t last_complete,
+    bool op_commited, bool op_applied);
+
   void handle_sub_write(
     pg_shard_t from,
     OpRequestRef msg,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -358,6 +358,7 @@ private:
 public:
   friend class C_OSD_OnOpCommit;
   friend class C_OSD_OnOpApplied;
+  friend class C_OSD_OnOpCommitApplied;
 
   void call_write_ordered(std::function<void(void)> &&cb) override {
     // ReplicatedBackend submits writes inline in submit_transaction, so
@@ -410,8 +411,7 @@ private:
     boost::optional<pg_hit_set_history_t> &hset_history,
     InProgressOp *op,
     ObjectStore::Transaction &op_t);
-  void op_applied(InProgressOp *op);
-  void op_commit(InProgressOp *op);
+  void op_reply(InProgressOp *op, bool op_commited, bool op_applied);
   void sub_op_modify_reply(OpRequestRef op);
   void sub_op_modify(OpRequestRef op);
 

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -431,9 +431,9 @@ private:
 
   struct C_OSD_RepModifyApply;
   struct C_OSD_RepModifyCommit;
+  struct C_OSD_RepModifyCommitApply;
 
-  void sub_op_modify_applied(RepModifyRef rm);
-  void sub_op_modify_commit(RepModifyRef rm);
+  void sub_op_modify_commit_or_applied(RepModifyRef rm, bool op_commited, bool op_applied);
   bool scrub_supported() { return true; }
   bool auto_repair_supported() const { return false; }
 


### PR DESCRIPTION
For bluestore/memstore, op_commit complete also mean op_applied
complete.  If we combine those callback into one. It can reduce one
pg_lock and remove one callback path.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>