### PR TITLE
msg/async/AsyncConnection: keepalive objecter ping connection to avoid timeout

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -1908,6 +1908,7 @@ int AsyncConnection::send_message(Message *m)
     return 0;
   }
 
+  last_active = ceph::coarse_mono_clock::now();
   // we don't want to consider local message here, it's too lightweight which
   // may disturb users
   logger->inc(l_msgr_send_messages);


### PR DESCRIPTION
…d timeout

For objecter ping connection, previously osd will ack the message to make
sender not timeout. Now we disable ack tag for lossy connection, it wil let
objecter ping connection read timeout.

Update last_active when sending message

Signed-off-by: Haomai Wang <haomai@xsky.com>