### PR TITLE
rgw: fix memory leak in RGWGetObjLayout

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5526,8 +5526,11 @@ void RGWGetObjLayout::pre_exec()
 void RGWGetObjLayout::execute()
 {
   rgw_obj obj(s->bucket, s->object);
-  target = new RGWRados::Object(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), rgw_obj(s->bucket, s->object));
-  RGWRados::Object::Read stat_op(target);
+  RGWRados::Object target(store,
+                          s->bucket_info,
+                          *static_cast<RGWObjectCtx *>(s->obj_ctx),
+                          rgw_obj(s->bucket, s->object));
+  RGWRados::Object::Read stat_op(&target);
 
   op_ret = stat_op.prepare();
   if (op_ret < 0) {
@@ -5536,7 +5539,7 @@ void RGWGetObjLayout::execute()
 
   head_obj = stat_op.state.head_obj;
 
-  op_ret = target->get_manifest(&manifest);
+  op_ret = target.get_manifest(&manifest);
 }
 
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1768,13 +1768,11 @@ public:
 
 class RGWGetObjLayout : public RGWOp {
 protected:
-  RGWRados::Object *target{nullptr};
   RGWObjManifest *manifest{nullptr};
   rgw_raw_obj head_obj;
 
 public:
   RGWGetObjLayout() {
-    delete target;
   }
 
   int check_caps(RGWUserCaps& caps) {


### PR DESCRIPTION
target was malloced in RGWGetObjLayout::execute(), We should free it in descontrcuted function.

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>