### PR TITLE
mon/MDSMonitor: remove create_new_fs from header

### DIFF
--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -76,7 +76,6 @@ class MDSMonitor : public PaxosService {
 
   // my helpers
   void print_map(FSMap &m, int dbl=7);
-  void create_new_fs(FSMap &m, const std::string &name, int metadata_pool, int data_pool);
   void update_logger();
 
   void _updated(MonOpRequestRef op);


### PR DESCRIPTION
create_new_fs was refactored and moved earlier. This removes a left
over header entry.

Signed-off-by: Henrik Korkuc <henrik@kirneh.eu>