### PR TITLE
osd: filestore merge threadhold and split multiple defaults made ideal

### DIFF
--- a/doc/rados/configuration/filestore-config-ref.rst
+++ b/doc/rados/configuration/filestore-config-ref.rst
@@ -311,7 +311,7 @@ Misc
               NOTE: A negative value means to disable subdir merging
 :Type: Integer
 :Required: No
-:Default: ``10``
+:Default: ``1``
 
 
 ``filestore split multiple``
@@ -322,7 +322,7 @@ Misc
 
 :Type: Integer
 :Required: No
-:Default: ``2``
+:Default: ``20``
 
 
 ``filestore update to``

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1253,8 +1253,8 @@ OPTION(filestore_op_thread_timeout, OPT_INT, 60)
 OPTION(filestore_op_thread_suicide_timeout, OPT_INT, 180)
 OPTION(filestore_commit_timeout, OPT_FLOAT, 600)
 OPTION(filestore_fiemap_threshold, OPT_INT, 4096)
-OPTION(filestore_merge_threshold, OPT_INT, 10)
-OPTION(filestore_split_multiple, OPT_INT, 2)
+OPTION(filestore_merge_threshold, OPT_INT, 1)
+OPTION(filestore_split_multiple, OPT_INT, 20)
 OPTION(filestore_update_to, OPT_INT, 1000)
 OPTION(filestore_blackhole, OPT_BOOL, false)     // drop any new transactions on the floor
 OPTION(filestore_fd_cache_size, OPT_INT, 128)    // FD lru size


### PR DESCRIPTION
Fixes : http://tracker.ceph.com/issues/17043
Signed-off-by : Vedant Nanda <vedant15114@iiitd.ac.in>