### PR TITLE
mds: set ceph-mds name uncond for external tools

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -15,12 +15,14 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #include <iostream>
 #include <string>
 using namespace std;
 
 #include "include/ceph_features.h"
+#include "include/compat.h"
 
 #include "common/config.h"
 #include "common/strtol.h"
@@ -92,6 +94,8 @@ extern "C" int cephd_mds(int argc, const char **argv)
 int main(int argc, const char **argv)
 #endif
 {
+  ceph_pthread_setname(pthread_self(), "ceph-mds");
+
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
   env_to_vec(args);


### PR DESCRIPTION
External tools like logrotate which use killall rely on the "ceph-mds" name to
find it in /proc/*/comm. This is normally the case but when ceph-mds respawns
using /proc/self/exe (on Linux), its name will change to "exe". This makes
logrotate fail to signal ceph-mds the log needs to be reopened and will lead to
the log growing until the disk is full.

This patch unconditionally sets the name so on respawn the name is correct (and
in any other possible scenario, such as a misnamed executable).  Note, there is
still a very small race between execve and ceph_pthread_setname where the
process name is wrong.

Problem was introduced by 66a122025f6cf023cf7b2f3d8fbe4964fb7568a7.

Fixes: http://tracker.ceph.com/issues/19291

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>