### PR TITLE
common: do not print error when asok is closed

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -320,8 +320,10 @@ bool AdminSocket::do_accept()
   while (1) {
     int ret = safe_read(connection_fd, &cmd[pos], 1);
     if (ret <= 0) {
-      lderr(m_cct) << "AdminSocket: error reading request code: "
-		   << cpp_strerror(ret) << dendl;
+      if (ret < 0) {
+        lderr(m_cct) << "AdminSocket: error reading request code: "
+		     << cpp_strerror(ret) << dendl;
+      }
       VOID_TEMP_FAILURE_RETRY(close(connection_fd));
       return false;
     }


### PR DESCRIPTION
If the admin socket is closed without sending a command, we get stderr messages like:

    ceph-mds[17174]: 2017-03-16 02:30:06.240322 7f40c7e44700 -1 asok(0x561abb4d4000) AdminSocket: error reading request code: (0) Success

If the socket is closed on the other end, just return.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>