### PR TITLE
osd/PG: clear UNDERSIZED state properly if recovered

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6705,6 +6705,7 @@ PG::RecoveryState::Recovered::Recovered(my_context ctx)
   if (pg->get_osdmap()->get_pg_size(pg->info.pgid.pgid) <=
       pg->actingbackfill.size()) {
     pg->state_clear(PG_STATE_DEGRADED);
+    pg->state_clear(PG_STATE_UNDERSIZED);
     pg->publish_stats_to_osd();
   }
 


### PR DESCRIPTION
If recovery is done and successful, we shall
clear UNDERSIZED state properly in case there is any.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>