### PR TITLE
mon: osd crush set crushmap need sanity check

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5900,18 +5900,16 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       goto reply;
     }
     
-    if (prefix == "osd setcrushmap") {
-      const map<int64_t,pg_pool_t> &osdmap_pools = osdmap.get_pools();
-      map<int64_t,pg_pool_t>::const_iterator pit;
-      for (pit = osdmap_pools.begin(); pit != osdmap_pools.end(); ++pit) {
-        const int64_t pool_id = pit->first;
-        const pg_pool_t &pool = pit->second;
-        int ruleno = pool.get_crush_ruleset();
-        if (!crush.rule_exists(ruleno)) {
-          ss << " the crush rule no "<< ruleno << " for pool id " << pool_id << " is in use";
-          err = -EINVAL;
-          goto reply;
-        }
+    const map<int64_t,pg_pool_t> &osdmap_pools = osdmap.get_pools();
+    map<int64_t,pg_pool_t>::const_iterator pit;
+    for (pit = osdmap_pools.begin(); pit != osdmap_pools.end(); ++pit) {
+      const int64_t pool_id = pit->first;
+      const pg_pool_t &pool = pit->second;
+      int ruleno = pool.get_crush_ruleset();
+      if (!crush.rule_exists(ruleno)) {
+	ss << " the crush rule no "<< ruleno << " for pool id " << pool_id << " is in use";
+	err = -EINVAL;
+	goto reply;
       }
     }
 


### PR DESCRIPTION
The sanity check verifying the new crushmap does not remove crush rules
that are in use is not exclusive to ceph setcrushmap.

Fixes: http://tracker.ceph.com/issues/19302

Signed-off-by: Loic Dachary <loic@dachary.org>