### PR TITLE
librbd: changed the return type of ImageRequestWQ::discard()

### DIFF
--- a/src/librbd/io/ImageRequestWQ.cc
+++ b/src/librbd/io/ImageRequestWQ.cc
@@ -69,7 +69,7 @@ ssize_t ImageRequestWQ::write(uint64_t off, uint64_t len,
   return len;
 }
 
-int ImageRequestWQ::discard(uint64_t off, uint64_t len, bool skip_partial_discard) {
+ssize_t ImageRequestWQ::discard(uint64_t off, uint64_t len, bool skip_partial_discard) {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 20) << "discard: ictx=" << &m_image_ctx << ", off=" << off << ", "
                  << "len = " << len << dendl;

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -28,7 +28,7 @@ public:
   ssize_t read(uint64_t off, uint64_t len, ReadResult &&read_result,
                int op_flags);
   ssize_t write(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
-  int discard(uint64_t off, uint64_t len, bool skip_partial_discard);
+  ssize_t discard(uint64_t off, uint64_t len, bool skip_partial_discard);
   ssize_t writesame(uint64_t off, uint64_t len, bufferlist &&bl, int op_flags);
 
   void aio_read(AioCompletion *c, uint64_t off, uint64_t len,


### PR DESCRIPTION
Changed the return type of ImageRequestWQ::discard() to ssize_t, as it returns a valid size or a negative value to indicate an error.

Fixes: http://tracker.ceph.com/issues/18511
Signed-off-by: Jos Collin <jcollin@redhat.com>