### PR TITLE
mds: bump client_reply debug to match client_req

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -1116,7 +1116,7 @@ void Server::reply_client_request(MDRequestRef& mdr, MClientReply *reply)
   assert(mdr.get());
   MClientRequest *req = mdr->client_request;
   
-  dout(10) << "reply_client_request " << reply->get_result() 
+  dout(7) << "reply_client_request " << reply->get_result()
 	   << " (" << cpp_strerror(reply->get_result())
 	   << ") " << *req << dendl;
 


### PR DESCRIPTION
handle_client_request is at level 7, show the replies at that same level:

    2017-03-02 22:36:03.044273 7f014b94c700  4 mds.7.server handle_client_request client_request(client.14435:99257 lookup #800000273f9/linux 2017-03-02 22:36:03.042255 caller_uid=0, caller_gid=0{}) v4

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>