### PR TITLE
hammer: tools: ceph-objectstore-tool: Check return value of connect

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -1975,7 +1975,11 @@ int do_import_rados(string pool, bool no_overwrite)
     cerr << "Error " << ret << " in cluster.conf_read_env" << std::endl;
     return ret;
   }
-  cluster.connect();
+  ret = cluster.connect();
+  if (ret) {
+    cerr << "Error " << ret << " in cluster.connect" << std::endl;
+    return ret;
+  }
 
   ret = cluster.ioctx_create(pool.c_str(), ioctx);
   if (ret < 0) {


### PR DESCRIPTION
If connect fails we call ioctx_create anyway and ultimately segfault on
a NULL Objecter object. Better to exit.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>