### PR TITLE
os/bluestore/NVMEDevice: remove the unnessary bl move for aio_write

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -891,10 +891,7 @@ int NVMEDevice::aio_write(
   assert(off + len <= size);
 
   Task *t = new Task(this, IOCommand::WRITE_COMMAND, off, len);
-
-  // TODO: if upper layer alloc memory with known physical address,
-  // we can reduce this copy
-  t->write_bl = std::move(bl);
+  t->write_bl = bl;
 
   if (buffered) {
     // Only need to push the first entry


### PR DESCRIPTION
I do not see any reason to use move. From the code, we only use
write_bl to copy the data when the io is complete.

Signed-off-by: optimistyzy <optimistyzy@gmail.com>