### PR TITLE
rgw: Added code to correctly account for bytes sent/ received during a 'PUT' operation.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1192,6 +1192,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
 
   int len = 0;
   if (cl) {
+    ACCOUNTING_IO(s)->set_account(true);
     bufferptr bp(cl);
 
     const auto read_len  = recv_body(s, bp.c_str(), cl);
@@ -1222,7 +1223,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
         bl.rebuild();
       }
     }
-
+    ACCOUNTING_IO(s)->set_account(false);
   }
 
   if ((uint64_t)ofs + len > s->cct->_conf->rgw_max_put_size) {


### PR DESCRIPTION
Currently, the bytes sent/ received are both set to zero after
an object is uploaded to a bucket. Added code to correct the logic.

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>