### PR TITLE
rgw: delete non-empty buckets in slave zonegroup works not well

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2519,6 +2519,11 @@ void RGWDeleteBucket::execute()
   if ( op_ret < 0) {
      ldout(s->cct, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
   }
+  
+  op_ret = store->check_bucket_empty(s->bucket_info);
+  if (op_ret < 0) {
+    return;
+  }
 
   if (!store->is_meta_master()) {
     bufferlist in_data;
@@ -2534,7 +2539,7 @@ void RGWDeleteBucket::execute()
     }
   }
 
-  op_ret = store->delete_bucket(s->bucket_info, ot);
+  op_ret = store->delete_bucket(s->bucket_info, ot, false);
 
   if (op_ret == -ECANCELED) {
     // lost a race, either with mdlog sync or another delete bucket operation.

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3067,13 +3067,15 @@ public:
                string *ptag,
                ceph::buffer::list *petag,
                struct rgw_err *err);
+  
+  int check_bucket_empty(RGWBucketInfo& bucket_info);
 
   /**
    * Delete a bucket.
    * bucket: the name of the bucket to delete
    * Returns 0 on success, -ERR# otherwise.
    */
-  int delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& objv_tracker);
+  int delete_bucket(RGWBucketInfo& bucket_info, RGWObjVersionTracker& objv_tracker, bool check_empty = true);
 
   bool is_meta_master();
 


### PR DESCRIPTION
If users delete non-empty buckets in slave zonegroup,  they will get non-empty error but the buckets have actually been deleted. Before we forward the request to meta master, we should check whether the bucket is empty.  

Fixes: http://tracker.ceph.com/issues/19313

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>