### PR TITLE
jewel: core: os/filestore: fix clang static check warn use-after-free

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3103,12 +3103,15 @@ more:
     last = extent++;
   }
   const bool is_last = last->fe_flags & FIEMAP_EXTENT_LAST;
-  free(fiemap);
   if (!is_last) {
     uint64_t xoffset = last->fe_logical + last->fe_length - offset;
     offset = last->fe_logical + last->fe_length;
     len -= xoffset;
+    free(fiemap); /* fix clang warn: use-after-free */
     goto more;
+  }
+  else {
+    free(fiemap);
   }
 
   return r;


### PR DESCRIPTION
use-after-free causes segmentation fault