### PR TITLE
jewel: osd: reindex properly on pg log split

### DIFF
--- a/src/osd/PGLog.cc
+++ b/src/osd/PGLog.cc
@@ -67,6 +67,7 @@ void PGLog::IndexedLog::split_into(
   PGLog::IndexedLog *olog)
 {
   list<pg_log_entry_t> oldlog;
+  unindex();
   oldlog.swap(log);
 
   eversion_t old_tail;


### PR DESCRIPTION
http://tracker.ceph.com/issues/19314