### PR TITLE
osd/PG: reset the missing set when restarting backfill

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2232,6 +2232,10 @@ void PG::split_into(pg_t child_pgid, PG *child, unsigned split_bits)
     // in the future).
     info.set_last_backfill(hobject_t());
     child->info.set_last_backfill(hobject_t());
+    // restarting backfill implies that the missing set is empty,
+    // since it is only used for objects prior to last_backfill
+    pg_log.reset_backfill();
+    child->pg_log.reset_backfill();
   }
 
   child->info.stats = info.stats;


### PR DESCRIPTION
During split we restart backfill by resetting last_backfill. When we
are backfilling, we assume our missing set is only relevant before
last_backfill, so we need to reset it here as well.

Fixes: http://tracker.ceph.com/issues/19191
Signed-off-by: Josh Durgin <jdurgin@redhat.com>