### PR TITLE
ceph-disk: avoid remove '/var/lib/ceph/osd/ceph-xx' directory when de…

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1376,6 +1376,7 @@ def mount(
 
 def unmount(
     path,
+    dont_rm=False,
 ):
     """
     Unmount and removes the given mount point.
@@ -1399,7 +1400,8 @@ def unmount(
             else:
                 time.sleep(0.5 + retries * 1.0)
                 retries += 1
-
+    if dont_rm:
+        return
     os.rmdir(path)
 
 
@@ -3787,7 +3789,7 @@ def main_deactivate_locked(args):
         with open(os.path.join(mounted_path, 'deactive'), 'w'):
             path_set_context(os.path.join(mounted_path, 'deactive'))
 
-    unmount(mounted_path)
+    unmount(mounted_path, args.once)
     LOG.info("Umount `%s` successfully.", mounted_path)
 
     if dmcrypt:

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -797,7 +797,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                 stop_daemon=lambda cluster, osd_id: True,
                 _remove_osd_directory_files=lambda path, cluster: True,
                 path_set_context=lambda path: True,
-                unmount=lambda path: True,
+                unmount=lambda path,False: True,
                 dmcrypt_unmap=lambda part_uuid: True,
         ):
             main.main_deactivate(args)
@@ -831,7 +831,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                 stop_daemon=lambda cluster, osd_id: True,
                 _remove_osd_directory_files=lambda path, cluster: True,
                 path_set_context=lambda path: True,
-                unmount=lambda path: True,
+                unmount=lambda path,False: True,
                 dmcrypt_unmap=lambda part_uuid: True,
         ):
             main.main_deactivate(args)

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -797,7 +797,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                 stop_daemon=lambda cluster, osd_id: True,
                 _remove_osd_directory_files=lambda path, cluster: True,
                 path_set_context=lambda path: True,
-                unmount=lambda path,False: True,
+                unmount=lambda path, False: True,
                 dmcrypt_unmap=lambda part_uuid: True,
         ):
             main.main_deactivate(args)
@@ -831,7 +831,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                 stop_daemon=lambda cluster, osd_id: True,
                 _remove_osd_directory_files=lambda path, cluster: True,
                 path_set_context=lambda path: True,
-                unmount=lambda path,False: True,
+                unmount=lambda path, False: True,
                 dmcrypt_unmap=lambda part_uuid: True,
         ):
             main.main_deactivate(args)


### PR DESCRIPTION
ceph-disk: avoid remove '/var/lib/ceph/osd/ceph-xx' directory when when deactivate with --once

  when using deactivate with --once, '/var/lib/ceph/osd/ceph-xx' will be deleted by call unmount func in ceph-disk,
  but '--once' means to keep that directory for reactivate. 

Signed-off-by: shun-s <song.shun3@zte.com.cn>