### PR TITLE
tools/rados: Check return value of connect

### DIFF
--- a/src/tools/rados/RadosImport.cc
+++ b/src/tools/rados/RadosImport.cc
@@ -43,7 +43,11 @@ int RadosImport::import(std::string pool, bool no_overwrite)
     cerr << "Error " << ret << " in cluster.conf_read_env" << std::endl;
     return ret;
   }
-  cluster.connect();
+  ret = cluster.connect();
+  if (ret) {
+    cerr << "Error " << ret << " in cluster.connect" << std::endl;
+    return ret;
+  }
 
   ret = cluster.ioctx_create(pool.c_str(), ioctx);
   if (ret < 0) {


### PR DESCRIPTION
Fail gracefully if Rados::connect returns an error.

Fixes: http://tracker.ceph.com/issues/19319
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>