### PR TITLE
Cleanup: common/config_opts.h: Remove deprecated osd_compact_leveldb_on_mount option

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -615,9 +615,6 @@ OPTION(mds_damage_table_max_entries, OPT_INT, 10000)
 // verify backend can support configured max object name length
 OPTION(osd_check_max_object_name_len_on_startup, OPT_BOOL, true)
 
-// If true, compact leveldb store on mount
-OPTION(osd_compact_leveldb_on_mount, OPT_BOOL, false)
-
 // Maximum number of backfills to or from a single osd
 OPTION(osd_max_backfills, OPT_U64, 1)
 


### PR DESCRIPTION
common/config_opts.h: Remove deprecated osd_compact_leveldb_on_mount option.
This option was removed in commit 1a5dea72012a8818b076d6ca97b71bd6766fa903.

Fixes: http://tracker.ceph.com/issues/19318

Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>