### PR TITLE
ceph-disk: fix possible key error when using ceph-disk deactivate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3892,6 +3892,7 @@ def main_deactivate_locked(args):
     osd_id = args.deactivate_by_id
     path = args.path
     target_dev = None
+    data_dev = None
     dmcrypt = False
     devices = list_devices()
 
@@ -3906,7 +3907,19 @@ def main_deactivate_locked(args):
                 elif (path and
                         'path' in dev_part and
                         dev_part['path'] == path):
-                    target_dev = dev_part
+                    if ('type' in dev_part and
+                            dev_part['type'] == 'data'):
+                        target_dev = dev_part
+                    elif ('type' in dev_part and
+                            (dev_part['type'] + '_for') in dev_part):
+                        data_dev = dev_part[dev_part['type'] + '_for']
+    if data_dev:
+        for device in devices:
+            if 'partitions' in device:
+                for dev_part in device.get('partitions'):
+                    if ('path' in dev_part and
+                            dev_part['path'] == data_dev):
+                        target_dev = dev_part
     if not target_dev:
         raise Error('Cannot find any match device!!')
 

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -748,6 +748,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                         'partitions': [{
                             'ptype': DMCRYPT_LUKS_OSD_UUID,
                             'path': '/dev/sdX1',
+                            'type': 'data',
                             'whoami': '5566',
                             'mount': '/var/lib/ceph/osd/ceph-5566/',
                             'uuid': part_uuid,
@@ -770,6 +771,7 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
                         'partitions': [{
                             'ptype': DMCRYPT_LUKS_OSD_UUID,
                             'path': '/dev/sdX1',
+                            'type': 'data',
                             'whoami': '5566',
                             'mount': '/var/lib/ceph/osd/ceph-5566/',
                             'uuid': part_uuid,


### PR DESCRIPTION
  if using ceph-disk deactivate to not data partition,like block_db
  partition--sdb1, it'll refer to no exsiting keys with sdb1,such as
  'whoami','mount'.instead, this pr trys to figure it out by finding which osd sdb1 belongs to,
  and then deactivate that osd.

Signed-off-by: shun-s <song.shu3@zte.com.cn>