### PR TITLE
rgw: set user quota which is less than user's current usage should fail.

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1279,9 +1279,26 @@ int set_user_quota(int opt_cmd, RGWUser& user, RGWUserAdminOpState& op_state, in
   set_quota_info(user_info.user_quota, opt_cmd, max_size, max_objects, have_max_size, have_max_objects);
 
   op_state.set_user_quota(user_info.user_quota);
-
+  
+  RGWStorageStats user_stats;
+  int r = user.get_store()->get_user_stats(op_state.get_user_id(), user_stats);
+  if (r < 0 && r != -ENOENT) {
+    cerr << "ERROR: fail to get user's stats" << cpp_strerror(-r) <<std::endl;
+    return -r;
+  } else if (r >= 0) {
+    if (user_info.user_quota.max_objects > 0 && 
+        static_cast<uint64_t>(user_info.user_quota.max_objects) < user_stats.num_objects) {
+      cerr << "ERROR: quota's max objects is less than user's total entries" << std::endl;
+      return EINVAL;
+    }
+    if (user_info.user_quota.max_size > 0 && 
+        static_cast<uint64_t>(user_info.user_quota.max_size) < user_stats.size) {
+      cerr << "ERROR: quota's max size is less than user's total bytes" << std::endl;
+      return EINVAL;
+    }
+  }
   string err;
-  int r = user.modify(op_state, &err);
+  r = user.modify(op_state, &err);
   if (r < 0) {
     cerr << "ERROR: failed updating user info: " << cpp_strerror(-r) << ": " << err << std::endl;
     return -r;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3493,6 +3493,25 @@ void RGWPutMetadataAccount::execute()
   /* Handle the quota extracted at the verify_permission step. */
   if (new_quota_extracted) {
     new_uinfo.user_quota = std::move(new_quota);
+    RGWStorageStats user_stats;
+    op_ret = store->get_user_stats(new_uinfo.user_id, user_stats);
+    if (op_ret < 0 && op_ret != -ENOENT) {
+      ldout(s->cct, 0) << "fail to get user stats" << dendl;
+      return;
+    } else if (op_ret >= 0) {
+      if (new_uinfo.user_quota.max_objects > 0 && 
+          static_cast<uint64_t>(new_uinfo.user_quota.max_objects) < user_stats.num_objects) {
+        ldout(s->cct, 0) << "quota's max objects is less than user's total entries" << dendl;
+        op_ret = -EINVAL;
+        return;
+      }
+      if (new_uinfo.user_quota.max_size > 0 && 
+          static_cast<uint64_t>(new_uinfo.user_quota.max_size) < user_stats.size) {
+        ldout(s->cct, 0) << "quota's max size is less than user's total bytes" << dendl;
+        op_ret = -EINVAL;
+        return;
+      }
+    }
   }
 
   /* We are passing here the current (old) user info to allow the function


### PR DESCRIPTION
Before setting user's quota, we should check whether his usage has exceeded the new quota. 

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>