### PR TITLE
mgr: shutdown py_modules in Mgr::shutdown()

### DIFF
--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -341,6 +341,9 @@ void Mgr::shutdown()
   // First stop the server so that we're not taking any more incoming requests
   server.shutdown();
 
+  // after the messenger is stopped, signal modules to shutdown via finisher
+  py_modules.shutdown();
+
   // Then stop the finisher to ensure its enqueued contexts aren't going
   // to touch references to the things we're about to tear down
   finisher.wait_for_empty();

--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -460,6 +460,7 @@ void PyModules::shutdown()
   }
   modules.clear();
 
+  PyGILState_Ensure();
   Py_Finalize();
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19258
Signed-off-by: Kefu Chai <kchai@redhat.com>