### PR TITLE
rbd-nbd: don't map an image with size 0.

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -649,6 +649,10 @@ static int do_map(int argc, const char *argv[])
   r = image.stat(info, sizeof(info));
   if (r < 0)
     goto close_nbd;
+  if (info.size == 0) {
+    cerr << "rbd-nbd: cannot map an image with size 0" << std::endl;
+    goto close_nbd;
+  }
 
   r = ioctl(nbd, NBD_SET_BLKSIZE, RBD_NBD_BLKSIZE);
   if (r < 0) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19347
Signed-off-by: Pan Liu <liupan1111@gmail.com>