### PR TITLE
qa: enable valgrind leak checks on ceph-mgr

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -22,6 +22,7 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
+      mgr: [--tool=memcheck]
   ceph-fuse:
     client.0:
       valgrind: [--tool=memcheck, --leak-check=full, --show-reachable=yes]

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -20,3 +20,4 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
+      mgr: [--tool=memcheck]

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -16,3 +16,4 @@ overrides:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]
       mds: [--tool=memcheck]
+      mgr: [--tool=memcheck]

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -170,7 +170,7 @@ int DaemonServer::ms_handle_authentication(Connection *con)
 {
   int ret = 0;
   MgrSession *s = new MgrSession(cct);
-  con->set_priv(s->get());
+  con->set_priv(s);
   s->inst.addr = con->get_peer_addr();
   s->entity_name = con->peer_name;
   dout(10) << __func__ << " new session " << s << " con " << con

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -210,7 +210,9 @@ struct DeviceState : public RefCountedObject
   pair<utime_t,utime_t> life_expectancy;  ///< when device failure is expected
   utime_t life_expectancy_stamp;          ///< when life expectency was recorded
 
-  DeviceState(const std::string& n) : devid(n) {}
+  DeviceState(const std::string& n)
+    : RefCountedObject(nullptr, 0),
+      devid(n) {}
 
   void set_metadata(map<string,string>&& m);
 

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -163,6 +163,7 @@ private:
   Finisher finisher;
 
   bool initialized;
+  bool stopping = false;
   bool no_keyring_disabled_cephx;
 
   LogClient *log_client;


### PR DESCRIPTION
Depends on https://github.com/ceph/teuthology/pull/1235 which suppresses all leaks in the Py code.  Clearly room for improvement there, but it was sufficient to find and fix several leaks in the rest of the mgr code!

There are several leak fixes we'll want to backport.  Opened http://tracker.ceph.com/issues/36744 to track the backports.