### PR TITLE
common: remove useless parameter

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -457,7 +457,7 @@ bool ceph_argparse_witharg(std::vector<const char*> &args,
 }
 
 CephInitParameters ceph_argparse_early_args
-	  (std::vector<const char*>& args, uint32_t module_type, int flags,
+	  (std::vector<const char*>& args, uint32_t module_type,
 	   std::string *cluster, std::string *conf_file_list)
 {
   CephInitParameters iparams(module_type);

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -68,7 +68,7 @@ bool ceph_argparse_binary_flag(std::vector<const char*> &args,
 	std::vector<const char*>::iterator &i, int *ret,
 	std::ostream *oss, ...);
 extern CephInitParameters ceph_argparse_early_args
-	    (std::vector<const char*>& args, uint32_t module_type, int flags,
+	    (std::vector<const char*>& args, uint32_t module_type,
 	     std::string *cluster, std::string *conf_file_list);
 extern void generic_server_usage();
 extern void generic_client_usage();

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -83,7 +83,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
 {
   std::string conf_file_list;
   std::string cluster = "";
-  CephInitParameters iparams = ceph_argparse_early_args(args, module_type, flags,
+  CephInitParameters iparams = ceph_argparse_early_args(args, module_type,
 							&cluster, &conf_file_list);
   CephContext *cct = common_preinit(iparams, code_env, flags, data_dir_option);
   cct->_conf->cluster = cluster;


### PR DESCRIPTION
The parameter flag in function ceph_argparse_early_args is not be used.
Signed-off-by: baiyanchun <yanchun.bai@istuary.com>