### PR TITLE
include/denc: add {encode,decode}_nohead for denc_traits<basic_string>

### DIFF
--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -524,21 +524,24 @@ inline typename std::enable_if<traits::supported &&
 //
 template<typename A>
 struct denc_traits<std::basic_string<char,std::char_traits<char>,A>> {
+private:
+  using value_type = std::basic_string<char,std::char_traits<char>,A>;
+
+public:
   static constexpr bool supported = true;
   static constexpr bool featured = false;
   static constexpr bool bounded = false;
-  static void bound_encode(const std::basic_string<char,
-			   std::char_traits<char>,A>& s, size_t& p,
-			   uint64_t f=0) {
+
+  static void bound_encode(const value_type& s, size_t& p, uint64_t f=0) {
     p += sizeof(uint32_t) + s.size();
   }
-  static void encode(const std::basic_string<char,std::char_traits<char>,A>& s,
+  static void encode(const value_type& s,
 		     buffer::list::contiguous_appender& p,
 	      uint64_t f=0) {
     ::denc((uint32_t)s.size(), p);
     memcpy(p.get_pos_add(s.size()), s.data(), s.size());
   }
-  static void decode(std::basic_string<char,std::char_traits<char>,A>& s,
+  static void decode(value_type& s,
 		     buffer::ptr::iterator& p,
 		     uint64_t f=0) {
     uint32_t len;

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -546,10 +546,18 @@ public:
 		     uint64_t f=0) {
     uint32_t len;
     ::denc(len, p);
+    decode_nohead(len, s, p);
+  }
+  static void decode_nohead(size_t len, value_type& s,
+			    buffer::ptr::iterator& p) {
     s.clear();
     if (len) {
       s.append(p.get_pos_add(len), len);
     }
+  }
+  static void encode_nohead(const value_type& s,
+			    buffer::list::contiguous_appender& p) {
+    p.append(s.data(), s.length());
   }
 };
 
@@ -597,6 +605,17 @@ struct denc_traits<bufferlist> {
     ::denc(len, p);
     v.clear();
     v.push_back(p.get_ptr(len));
+  }
+  static void encode_nohead(const bufferlist& v,
+			    buffer::list::contiguous_appender& p) {
+    p.append(v);
+  }
+  static void decode_nohead(size_t len, bufferlist& v,
+			    buffer::ptr::iterator& p) {
+    v.clear();
+    if (len) {
+      v.append(p.get_ptr(len));
+    }
   }
 };
 

--- a/src/test/encoding.cc
+++ b/src/test/encoding.cc
@@ -32,6 +32,40 @@ TEST(EncodingRoundTrip, StringNewline) {
   test_encode_and_decode < std::string >(my_str);
 }
 
+template <typename Size, typename T>
+static void test_encode_and_nohead_nohead(Size len, const T& src)
+{
+  bufferlist bl(1000000);
+  encode(len, bl);
+  encode_nohead(src, bl);
+  T dst;
+  bufferlist::iterator i(bl.begin());
+  decode(len, i);
+  decode_nohead(len, dst, i);
+  ASSERT_EQ(src, dst) << "Encoding roundtrip changed the string: orig=" << src << ", but new=" << dst;
+}
+
+TEST(EncodingRoundTrip, StringNoHead) {
+  const string str("The quick brown fox jumps over the lazy dog");
+  auto size = str.size();
+  test_encode_and_nohead_nohead(static_cast<int>(size), str);
+  test_encode_and_nohead_nohead(static_cast<unsigned>(size), str);
+  test_encode_and_nohead_nohead(static_cast<uint32_t>(size), str);
+  test_encode_and_nohead_nohead(static_cast<__u32>(size), str);
+  test_encode_and_nohead_nohead(static_cast<size_t>(size), str);
+}
+
+TEST(EncodingRoundTrip, BufferListNoHead) {
+  bufferlist bl;
+  bl.append("is this a dagger which i see before me?");
+  auto size = bl.length();
+  test_encode_and_nohead_nohead(static_cast<int>(size), bl);
+  test_encode_and_nohead_nohead(static_cast<unsigned>(size), bl);
+  test_encode_and_nohead_nohead(static_cast<uint32_t>(size), bl);
+  test_encode_and_nohead_nohead(static_cast<__u32>(size), bl);
+  test_encode_and_nohead_nohead(static_cast<size_t>(size), bl);
+}
+
 typedef std::multimap < int, std::string > multimap_t;
 typedef multimap_t::value_type my_val_ty;
 


### PR DESCRIPTION
otherwise, on arm32, the denc.h version of decode_nohead() is chosen
instead. we should force the compiler to use the one in encoding.h.

Signed-off-by: Kefu Chai <kchai@redhat.com>