### PR TITLE
Manually merge PR#13143 which was mistakenly merged to jewel-next

### DIFF
--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -25,6 +25,7 @@ RGWFormatter_Plain::RGWFormatter_Plain(const bool ukv)
   : buf(NULL),
     len(0),
     max_len(0),
+    wrote_something(false),
     min_stack_level(0),
     use_kv(ukv)
 {
@@ -41,7 +42,7 @@ void RGWFormatter_Plain::flush(ostream& os)
     return;
 
   if (len) {
-    os << buf << "\n";
+    os << buf;
     os.flush();
   }
 
@@ -156,13 +157,14 @@ void RGWFormatter_Plain::dump_format_va(const char *name, const char *ns, bool q
   vsnprintf(buf, LARGE_SIZE, fmt, ap);
 
   const char *eol;
-  if (len) {
+  if (wrote_something) {
     if (use_kv && entry.is_array && entry.size > 1)
       eol = ", ";
     else
       eol = "\n";
   } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);
@@ -268,10 +270,11 @@ void RGWFormatter_Plain::dump_value_int(const char *name, const char *fmt, ...)
   va_end(ap);
 
   const char *eol;
-  if (len)
+  if (wrote_something) {
     eol = "\n";
-  else
+  } else
     eol = "";
+  wrote_something = true;
 
   if (use_kv && !entry.is_array)
     write_data("%s%s: %s", eol, name, buf);

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -56,6 +56,7 @@ private:
   std::list<struct plain_stack_entry> stack;
   size_t min_stack_level;
   bool use_kv;
+  bool wrote_something;
 };
 
 class RGWFormatterFlusher {


### PR DESCRIPTION
Merge branch 'jewel-next' into jewel

Branch "jewel-next" was merged to jewel on Dec 22 (5b402f8a7b), and then PR https://github.com/ceph/ceph/pull/13143 merged to jewel-next much later (Feb 1st), and then jewel-next was never merged to jewel again before we tagged v10.2.6.

This merge brings in a single commit, i.e. the one from https://github.com/ceph/ceph/pull/13143

Reported-by: Ken Dreyer <kdreyer@redhat.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>
