### PR TITLE
mds: pretty json from `tell` commands

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2571,7 +2571,7 @@ bool MDSRankDispatcher::handle_command(
       return true;
     }
 
-    Formatter *f = new JSONFormatter();
+    Formatter *f = new JSONFormatter(true);
     dump_sessions(filter, f);
     f->flush(*ds);
     delete f;
@@ -2591,7 +2591,7 @@ bool MDSRankDispatcher::handle_command(
     *need_reply = false;
     return true;
   } else if (prefix == "damage ls") {
-    Formatter *f = new JSONFormatter();
+    Formatter *f = new JSONFormatter(true);
     damage_table.dump(f);
     f->flush(*ds);
     delete f;


### PR DESCRIPTION
The overhead of the whitespace is trivial and
makes the output somewhat human readable.  Previously
I was always taking `damage ls` into a file and
parsing it out with python.

Signed-off-by: John Spray <john.spray@redhat.com>