### PR TITLE
doc: typo in hit_set_search_last_n

### DIFF
--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -466,7 +466,7 @@ You may set values for the following keys:
 :Default: ``20``
 
 
-``hit_set_grade_search_last_n``
+``hit_set_search_last_n``
 
 :Description: Count at most N appearance in hit_sets for temperature calculation
 :Type: Integer


### PR DESCRIPTION
Documentation of pools describes `hit_set_grade_search_last_n` which does not exist in the source code. `hit_set_search_last_n` exists in source but not in documentation. Assuming that this is just a typo, the documentation entry was changed from `hit_set_grade_search_last_n` to `hit_set_search_last_n`.