### PR TITLE
rgw: stat requests skip compression, manifest handling, etc

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1396,6 +1396,11 @@ void RGWGetObj::execute()
   if (op_ret < 0)
     goto done_err;
 
+  /* STAT ops don't need data, and do no i/o */
+  if (get_type() == RGW_OP_STAT_OBJ) {
+    return;
+  }
+
   /* start gettorrent */
   if (torrent.get_flag())
   {
@@ -1471,11 +1476,6 @@ void RGWGetObj::execute()
   }
 
   start = ofs;
-
-  /* STAT ops don't need data, and do no i/o */
-  if (get_type() == RGW_OP_STAT_OBJ) {
-    return;
-  }
 
   if (!get_data || ofs > end) {
     send_response_data(bl, 0, 0);


### PR DESCRIPTION
the early return for stat requests in RGWGetObj::execute() can happen as soon as we've read the head object