### PR TITLE
jewel: tools: brag fails to count "in" mds

### DIFF
--- a/src/brag/client/ceph-brag
+++ b/src/brag/client/ceph-brag
@@ -245,7 +245,10 @@ def get_nums():
   oj = json.loads(o)
   num_mons = len(oj['monmap']['mons'])
   num_osds = int(oj['osdmap']['osdmap']['num_in_osds'])
-  num_mdss = oj['mdsmap']['in']
+  try:
+    num_mdss = oj['mdsmap']['in']
+  except KeyError:
+    num_mdss = 0
 
   pgmap = oj['pgmap']
   num_pgs = pgmap['num_pgs']

--- a/src/brag/client/ceph-brag
+++ b/src/brag/client/ceph-brag
@@ -246,7 +246,7 @@ def get_nums():
   num_mons = len(oj['monmap']['mons'])
   num_osds = int(oj['osdmap']['osdmap']['num_in_osds'])
   try:
-    num_mdss = oj['mdsmap']['in']
+    num_mdss = oj['fsmap']['in']
   except KeyError:
     num_mdss = 0
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/19332

Since cherry-picking 2d25a9c caused conflicts as below because jewel does not have 8d4d278. To cleanly cherry-piking 2d25a9c, 8d4d278 needed to be cherry-picked.
```
diff --cc src/brag/client/ceph-brag
index ba785e3,d5e5a2d..0000000
--- a/src/brag/client/ceph-brag
+++ b/src/brag/client/ceph-brag
@@@ -245,7 -257,10 +245,14 @@@ def get_nums()
    oj = json.loads(o)
    num_mons = len(oj['monmap']['mons'])
    num_osds = int(oj['osdmap']['osdmap']['num_in_osds'])
++<<<<<<< HEAD
 +  num_mdss = oj['mdsmap']['in']
++=======
+   try:
+     num_mdss = oj['fsmap']['in']
+   except KeyError:
+     num_mdss = 0
++>>>>>>> 2d25a9c... brag: count the number of mds in fsmap not in mdsmap
```
Fix conflicts
Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>