### PR TITLE
debian/rules, ceph.spec.in: invoke cmake with -DBOOST_J

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -779,6 +779,12 @@ export CXXFLAGS="$RPM_OPT_FLAGS"
 
 env | sort
 
+%if %{with lowmem_builder}
+%if 0%{?jobs} > 8
+%define _smp_mflags -j8
+%endif
+%endif
+
 mkdir build
 cd build
 cmake .. \
@@ -818,12 +824,6 @@ cmake .. \
     $CEPH_EXTRA_CMAKE_ARGS \
 %if 0%{with ocf}
     -DWITH_OCF=ON
-%endif
-
-%if %{with lowmem_builder}
-%if 0%{?jobs} > 8
-%define _smp_mflags -j8
-%endif
 %endif
 
 make %{?_smp_mflags}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -785,6 +785,11 @@ env | sort
 %endif
 %endif
 
+# unlimit _smp_mflags in system macro if not set above
+%define _smp_ncpus_max 0
+# extract the number of processors for use with cmake
+%define _smp_ncpus %(echo %{_smp_mflags} | sed 's/-j//')
+
 mkdir build
 cd build
 cmake .. \
@@ -823,8 +828,9 @@ cmake .. \
 %endif
     $CEPH_EXTRA_CMAKE_ARGS \
 %if 0%{with ocf}
-    -DWITH_OCF=ON
+    -DWITH_OCF=ON \
 %endif
+    -DBOOST_J=%{_smp_ncpus}
 
 make %{?_smp_mflags}
 

--- a/debian/rules
+++ b/debian/rules
@@ -11,6 +11,10 @@ extraopts += -DWITH_CEPHFS_JAVA=ON
 extraopts += -DCMAKE_INSTALL_LIBDIR=/usr/lib
 extraopts += -DCMAKE_INSTALL_LIBEXECDIR=/usr/lib
 extraopts += -DCMAKE_INSTALL_SYSCONFDIR=/etc
+ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+  NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
+  extraopts += -DBOOST_J=$(NUMJOBS)
+endif
 
 ifeq ($(DEB_HOST_ARCH), armel)
   # armel supports ARMv4t or above instructions sets.


### PR DESCRIPTION
Allow boost build during toplevel cmake from Debian package build
to benefit from multiple processors.  Should speed build a lot
on many-proc machines (say, arm64).

Signed-off-by: Dan Mick <dan.mick@redhat.com>