### PR TITLE
rgw: return the version id in get object and object metadata request.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1395,6 +1395,7 @@ void RGWGetObj::execute()
   op_ret = read_op.prepare();
   if (op_ret < 0)
     goto done_err;
+  version_id = read_op.state.obj.key.instance;
 
   /* start gettorrent */
   if (torrent.get_flag())

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -135,6 +135,7 @@ protected:
   bool is_slo;
   string lo_etag;
   bool rgwx_stat; /* extended rgw stat operation */
+  string version_id;
 
   // compression attrs
   RGWCompressionInfo cs_info;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -218,6 +218,10 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
 
   dump_content_length(s, total_len);
   dump_last_modified(s, lastmod);
+  if (!version_id.empty()) {
+    dump_header(s, "x-amz-version-id", version_id);
+  }
+  
 
   if (! op_ret) {
     if (! lo_etag.empty()) {


### PR DESCRIPTION
If bucket versioning is enabled, S3 will return the version id in get object and object metadata request.

Fixes: http://tracker.ceph.com/issues/19370

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>