### PR TITLE
os/bluestore/BlueFS: only flush device which writed by file when do f…

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1380,10 +1380,13 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>& l,
   // drop lock while we wait for io
   list<FS::aio_t> completed_ios;
   _claim_completed_aios(log_writer, &completed_ios);
+
+  set<unsigned int> unsync_bdev = log_writer->unsync_bdev;
+  log_writer->unsync_bdev.clear();
   l.unlock();
   wait_for_aio(log_writer);
   completed_ios.clear();
-  flush_bdev();
+  flush_bdev(unsync_bdev);
   l.lock();
 
   log_flushing = false;
@@ -1600,6 +1603,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
       }
     }
     bdev[p->bdev]->aio_write(p->offset + x_off, t, h->iocv[p->bdev], buffered);
+    h->unsync_bdev.insert(p->bdev);
     bloff += x_len;
     length -= x_len;
     ++p;
@@ -1721,10 +1725,14 @@ int BlueFS::_fsync(FileWriter *h, std::unique_lock<std::mutex>& l)
 
   list<FS::aio_t> completed_ios;
   _claim_completed_aios(h, &completed_ios);
+
+  set<unsigned int> unsync_bdev = h->unsync_bdev;
+  h->unsync_bdev.clear();
   lock.unlock();
+
   wait_for_aio(h);
   completed_ios.clear();
-  flush_bdev();
+  flush_bdev(unsync_bdev);
   lock.lock();
 
   if (old_dirty_seq) {
@@ -1745,6 +1753,16 @@ void BlueFS::flush_bdev()
   for (auto p : bdev) {
     if (p)
       p->flush();
+  }
+}
+
+void BlueFS::flush_bdev(set<unsigned int> &unsync_bdev)
+{
+  // NOTE: this is safe to call without a lock.
+  dout(20) << __func__ << dendl;
+  for (auto p : unsync_bdev) {
+    assert(p < MAX_BDEV && bdev[p] != NULL);
+    bdev[p]->flush();
   }
 }
 

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -126,7 +126,7 @@ public:
 
     std::mutex lock;
     std::array<IOContext*,MAX_BDEV> iocv; ///< for each bdev
-
+    set<unsigned int> unsync_bdev; ///< write but unsync bdev recently
     FileWriter(FileRef f)
       : file(f),
 	pos(0),
@@ -288,6 +288,7 @@ private:
   //void _aio_finish(void *priv);
 
   void flush_bdev();  // this is safe to call without a lock
+  void flush_bdev(set<unsigned int> &unsync_bdev); // only flush bdev in this set
 
   int _preallocate(FileRef f, uint64_t off, uint64_t len);
   int _truncate(FileWriter *h, uint64_t off);


### PR DESCRIPTION
…sync(FileWriter).

For bluefs, we can set three differnet device for
db,db.wal,db.slow.Now every fsync(FileWrite) will flush all existing device. Although,
BlockDevice::flush() check whether need to do flush. But there is a
chance to flush other device.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>