### PR TITLE
mon:  we should return the key value when we use ceph auth caps command

### DIFF
--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -983,8 +983,10 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
 
     ss << "updated caps for " << auth_inc.name;
     getline(ss, rs);
+    ds << auth_inc.auth.key;
+    rdata.append(ds);
     wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
-					      get_last_committed() + 1));
+					rdata, get_last_committed() + 1));
     return true;
   } else if ((prefix == "auth del" || prefix == "auth rm") &&
              !entity_name.empty()) {


### PR DESCRIPTION
mon:  we should return the key value when we use ceph auth caps command

 if we do not return the key value, when user use -o option, this will

  result in the user key to empty.

Signed-off-by: song baisen <song.baisen@zte.com.cn>