### PR TITLE
os/bluestore/BlueFS: optimize get_allocated

### DIFF
--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -138,6 +138,7 @@ void bluefs_fnode_t::decode(bufferlist::iterator& p)
   ::decode(prefer_bdev, p);
   ::decode(extents, p);
   DECODE_FINISH(p);
+  recalc_allocated();
 }
 
 void bluefs_fnode_t::dump(Formatter *f) const

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -30,14 +30,18 @@ struct bluefs_fnode_t {
   utime_t mtime;
   uint8_t prefer_bdev;
   mempool::bluefs::vector<bluefs_extent_t> extents;
+  uint64_t allocated;
 
-  bluefs_fnode_t() : ino(0), size(0), prefer_bdev(0) {}
+  bluefs_fnode_t() : ino(0), size(0), prefer_bdev(0), allocated(0) {}
 
   uint64_t get_allocated() const {
-    uint64_t r = 0;
+    return allocated;
+  }
+
+  void recalc_allocated() {
+    allocated = 0;
     for (auto& p : extents)
-      r += p.length;
-    return r;
+      allocated += p.length;
   }
 
   mempool::bluefs::vector<bluefs_extent_t>::iterator seek(


### PR DESCRIPTION
Only update extents it interator all extents to get allocated,
especially for recycling-log-file.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>

Because every change extents, we also need set recalc_alloc=true. This make code complex.  But for every flush_range, we will call get_allocated(). especially for recycling-log-file, it don't change until alloc new extent. 