### PR TITLE
doc: correct arguments for ceph tell osd.N bench

### DIFF
--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -284,7 +284,7 @@ The benchmark is non-destructive and will not overwrite existing live
 OSD data, but might temporarily affect the performance of clients
 concurrently accessing the OSD. ::
 
-	ceph tell osd.N bench [TOTAL_DATA_BYTES] [BYTES_PER_WRITE]
+	ceph tell osd.N bench [TOTAL_DATA_BYTES] [BYTES_PER_WRITE] 
 
 
 MDS Subsystem

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -277,14 +277,14 @@ Sends a repair command to OSD.N. To send the command to all OSDs, use ``*``. ::
 
 	ceph osd repair N
 
-Runs a simple throughput benchmark against OSD.N, writing ``NUMBER_OF_OBJECTS``
+Runs a simple throughput benchmark against OSD.N, writing ``TOTAL_DATA_BYTES``
 in write requests of ``BYTES_PER_WRITE`` each. By default, the test
 writes 1 GB in total in 4-MB increments.
 The benchmark is non-destructive and will not overwrite existing live
 OSD data, but might temporarily affect the performance of clients
 concurrently accessing the OSD. ::
 
-	ceph tell osd.N bench [NUMER_OF_OBJECTS] [BYTES_PER_WRITE]
+	ceph tell osd.N bench [TOTAL_DATA_BYTES] [BYTES_PER_WRITE]
 
 
 MDS Subsystem


### PR DESCRIPTION
The docs currently refer to NUMBER_OF_OBJECTS, but it seems the code is interpreting that argument as TOTAL_DATA_BYTES.

Signed-off-by: Patrick Dinnen <pdinnen@gmail.com>