### PR TITLE
mgr: fix crash on missing 'ceph_version' in daemon metadata (fixes #18764)

### DIFF
--- a/src/mgr/PyModules.cc
+++ b/src/mgr/PyModules.cc
@@ -48,7 +48,10 @@ void PyModules::dump_server(const std::string &hostname,
     // TODO: pick the highest version, and make sure that
     // somewhere else (during health reporting?) we are
     // indicating to the user if we see mixed versions
-    ceph_version = i.second->metadata.at("ceph_version");
+    auto ver_iter = i.second->metadata.find("ceph_version");
+    if (ver_iter != i.second->metadata.end()) {
+      ceph_version = i.second->metadata.at("ceph_version");
+    }
 
     f->open_object_section("service");
     f->dump_string("type", str_type);

--- a/src/pybind/mgr/fsstatus/module.py
+++ b/src/pybind/mgr/fsstatus/module.py
@@ -156,7 +156,7 @@ class Module(MgrModule):
                         ) + "/s"
 
                     metadata = self.get_metadata('mds', info['name'])
-                    mds_versions[metadata['ceph_version']].append(info['name'])
+                    mds_versions[metadata.get('ceph_version', "unknown")].append(info['name'])
                     rank_table.add_row([
                         self.bold(rank.__str__()), c_state, info['name'],
                         activity,
@@ -215,7 +215,7 @@ class Module(MgrModule):
         standby_table = PrettyTable(["Standby MDS"])
         for standby in fsmap['standbys']:
             metadata = self.get_metadata('mds', standby['name'])
-            mds_versions[metadata['ceph_version']].append(standby['name'])
+            mds_versions[metadata.get('ceph_version', "unknown")].append(standby['name'])
 
             standby_table.add_row([standby['name']])
 


### PR DESCRIPTION
Two commits - the first actually fixes the crash (leaving ceph_version an empty string internally to PyModules.cc), the second fixes a similar problem I noticed in the fsstatus module.