### PR TITLE
common/escape: do not escape / in json

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1059,11 +1059,9 @@ function test_mon_osd()
   # osd blacklist
   #
   bl=192.168.0.1:0/1000
-  # Escaped form which may appear in JSON output
-  bl_json=192.168.0.1:0\\\\/1000
   ceph osd blacklist add $bl
   ceph osd blacklist ls | grep $bl
-  ceph osd blacklist ls --format=json-pretty | grep $bl_json
+  ceph osd blacklist ls --format=json-pretty  | sed 's/\\\//\//' | grep $bl
   ceph osd dump --format=json-pretty | grep $bl
   ceph osd dump | grep "^blacklist $bl"
   ceph osd blacklist rm $bl

--- a/src/common/escape.c
+++ b/src/common/escape.c
@@ -119,7 +119,6 @@ void escape_xml_attr(const char *buf, char *out)
 
 #define DBL_QUOTE_JESCAPE "\\\""
 #define BACKSLASH_JESCAPE "\\\\"
-#define SLASH_JESCAPE "\\/"
 #define TAB_JESCAPE "\\t"
 #define NEWLINE_JESCAPE "\\n"
 
@@ -136,9 +135,6 @@ int escape_json_attr_len(const char *buf, int src_len)
 			break;
 		case '\\':
 			ret += SSTRL(BACKSLASH_JESCAPE);
-			break;
-		case '/':
-			ret += SSTRL(SLASH_JESCAPE);
 			break;
 		case '\t':
 			ret += SSTRL(TAB_JESCAPE);
@@ -178,11 +174,6 @@ void escape_json_attr(const char *buf, int src_len, char *out)
 			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, BACKSLASH_JESCAPE, SSTRL(BACKSLASH_JESCAPE));
 			o += SSTRL(BACKSLASH_JESCAPE);
-			break;
-		case '/':
-			// cppcheck-suppress sizeofDivisionMemfunc
-			memcpy(o, SLASH_JESCAPE, SSTRL(SLASH_JESCAPE));
-			o += SSTRL(SLASH_JESCAPE);
 			break;
 		case '\t':
 			// cppcheck-suppress sizeofDivisionMemfunc

--- a/src/test/escape.cc
+++ b/src/test/escape.cc
@@ -73,9 +73,6 @@ TEST(EscapeJson, Escapes1) {
   ASSERT_EQ(escape_json_attrs("The \"scare quotes\""),
 			     "The \\\"scare quotes\\\"");
   ASSERT_EQ(escape_json_attrs("I <3 JSON"), "I <3 JSON");
-  ASSERT_EQ(escape_json_attrs(
-      "JSON calls a slash / backslash a solidus / reverse solidus"),
-      "JSON calls a slash \\/ backslash a solidus \\/ reverse solidus");
   ASSERT_EQ(escape_json_attrs("Some 'single' \"quotes\" here"),
       "Some 'single' \\\"quotes\\\" here");
   ASSERT_EQ(escape_json_attrs("tabs\tand\tnewlines\n, oh my"),


### PR DESCRIPTION
As far as I can tell '/' is perfectly valid for JSON
strings (keys or values).

Signed-off-by: Sage Weil <sage@redhat.com>