### PR TITLE
kraken: rgw: Fix handling underscore in object name in swift set_attrs and dlo

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -507,7 +507,8 @@ int rgw_build_object_policies(RGWRados *store, struct req_state *s,
     }
     s->object_acl = new RGWAccessControlPolicy(s->cct);
 
-    rgw_obj obj(s->bucket, s->object);
+    rgw_obj obj(s->bucket, s->object.name);
+    obj.set_instance(s->object.instance);
       
     store->set_atomic(s->obj_ctx, obj);
     if (prefetch_data) {
@@ -5499,7 +5500,8 @@ void RGWSetAttrs::execute()
   if (op_ret < 0)
     return;
 
-  rgw_obj obj(s->bucket, s->object);
+  rgw_obj obj(s->bucket, s->object.name);
+  obj.set_instance(s->object.instance);
 
   store->set_atomic(s->obj_ctx, obj);
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/19338