### PR TITLE
kraken: rgw: "period update" does not remove short_zone_ids of deleted zones

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1220,6 +1220,10 @@ int RGWPeriod::update()
     return ret;
   }
 
+  // clear zone short ids of removed zones. period_map.update() will add the
+  // remaining zones back
+  period_map.short_zone_ids.clear();
+
   for (auto& iter : zonegroups) {
     RGWZoneGroup zg(string(), iter);
     ret = zg.init(cct, store);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19342