### PR TITLE
rgw: Removed unwanted string headers

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -24,8 +24,6 @@
 #include "acconfig.h"
 
 #include <errno.h>
-#include <string.h>
-#include <string>
 #include <map>
 #include <boost/utility/string_ref.hpp>
 #include "include/types.h"


### PR DESCRIPTION
The string headers are already included in the other included header files in rgw_common.h. So removing them.

Signed-off-by: Jos Collin <jcollin@redhat.com>