### PR TITLE
mount.ceph: silently ignore -s option

### DIFF
--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -18,6 +18,7 @@
 #define MAX_SECRET_OPTION_LEN (MAX_SECRET_LEN + 7)
 
 int verboseflag = 0;
+int sloppyflag = 0;
 int skip_mtab_flag = 0;
 static const char * const EMPTY_STRING = "";
 
@@ -281,6 +282,8 @@ static int parse_arguments(int argc, char *const *const argv,
 			skip_mtab_flag = 1;
 		else if (!strcmp("-v", argv[i]))
 			verboseflag = 1;
+		else if (!strcmp("-s", argv[i]))
+			sloppyflag = 1;
 		else if (!strcmp("-o", argv[i])) {
 			++i;
 			if (i >= argc) {
@@ -316,6 +319,7 @@ static void usage(const char *prog_name)
 	printf("\t-h: Print this help\n");
 	printf("\t-n: Do not update /etc/mtab\n");
 	printf("\t-v: Verbose\n");
+	printf("\t-s: Allow sloppy mount options\n");
 	printf("\tceph-options: refer to mount.ceph(8)\n");
 	printf("\n");
 }
@@ -346,6 +350,10 @@ int main(int argc, char *argv[])
 	if (!popts) {
 		printf("failed to parse ceph_options\n");
 		exit(1);
+	}
+	if (sloppyflag) {
+		int out_len = 0;
+		safe_cat(&popts, &out_len, strlen(popts), ",sloppy");
 	}
 
 	block_signals(SIG_BLOCK);


### PR DESCRIPTION
Newer mounts have the -s (sloppy) option to ignore unknown options. The
autofs package on e.g. Debian Jessie specifies this to all mounts.

Fixes: http://tracker.ceph.com/issues/19388
Signed-off-by: Michel Roelofs <michel@michelroelofs.nl>