### PR TITLE
rgw/lifecycle: do not send lifecycle rules when GetLifeCycle failed

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2374,6 +2374,9 @@ void RGWGetLC_ObjStore_S3::send_response()
   end_header(s, this, "application/xml");
   dump_start(s);
 
+  if (op_ret < 0)
+    return;
+
   config.dump_xml(s->formatter);
   rgw_flush_formatter_and_reset(s, s->formatter);
 }


### PR DESCRIPTION
Now, RGW will send two HTTP responses when GetLifeCycle failed. The first one is
Error Respnse like 404, and the second is lifecycle rules. It will breaks s3 sdk
and s3 utilities.

Fixes: http://tracker.ceph.com/issues/19363
Signed-off-by: liuchang0812 <liuchang0812@gmail.com>