### PR TITLE
kraken: librbd: possible race in ExclusiveLock handle_peer_notification

### DIFF
--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -242,6 +242,7 @@ void ExclusiveLock<I>::handle_peer_notification(int r) {
 
     ldout(m_image_ctx.cct, 10) << this << " " << __func__ << dendl;
     assert(get_active_action() == ACTION_REQUEST_LOCK);
+    m_state = STATE_ACQUIRING;
 
     if (r >= 0) {
       execute_next_action();


### PR DESCRIPTION
This is a direct commit to kraken -- the master diverged after
ManagedLock refactoring and is not affected.

Fix: http://tracker.ceph.com/issues/19368
Signed-off-by: Mykola Golub <mgolub@mirantis.com>