### PR TITLE
rbd: when Ceph cluster is full, return -ENOSPC for creating image command.

### DIFF
--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -59,6 +59,8 @@ int execute(const po::variables_map &vm) {
     return r;
   }
 
+  io_ctx.set_osdmap_full_try();
+
   librbd::RBD rbd;
   r = do_create(rbd, io_ctx, image_name.c_str(), size, opts);
   if (r < 0) {


### PR DESCRIPTION
As we talked in https://github.com/ceph/ceph/pull/14116, I improved "create" path, and return -ENOSPC when cluster is full.