### PR TITLE
common/ceph_context: fewer warnings about experimental features

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -305,14 +305,6 @@ public:
 	conf->enable_experimental_unrecoverable_data_corrupting_features,
 	cct->_experimental_features);
       ceph_spin_unlock(&cct->_feature_lock);
-      if (!cct->_experimental_features.empty()) {
-        if (cct->_experimental_features.count("*")) {
-          lderr(cct) << "WARNING: all dangerous and experimental features are enabled." << dendl;
-        } else {
-          lderr(cct) << "WARNING: the following dangerous and experimental features are enabled: "
-	    << cct->_experimental_features << dendl;
-        }
-      }
     }
     if (changed.count("crush_location")) {
       cct->crush_location.update_from_conf();


### PR DESCRIPTION
As Pete Zaitcev points out, check_experimental_feature_enabled
warns when an actual experimental feature is used; we don't need
to also warn that we might use it here.

This means we don't notice when a feature is enabled but it isn't
used, but that noise arguably has no value.

Signed-off-by: Sage Weil <sage@redhat.com>

This is an update/rebase of https://github.com/ceph/ceph/pull/8547