### PR TITLE
rgw: Removed unwanted string headers

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -24,8 +24,6 @@
 #include "acconfig.h"
 
 #include <errno.h>
-#include <string.h>
-#include <string>
 #include <map>
 #include <boost/utility/string_ref.hpp>
 #include "include/types.h"

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -17,19 +17,9 @@
 #define CEPH_RGW_COMMON_H
 
 #include "common/ceph_crypto.h"
-
-#include "common/debug.h"
 #include "common/perf_counters.h"
-
 #include "acconfig.h"
-
-#include <errno.h>
-#include <map>
-#include <boost/utility/string_ref.hpp>
-#include "include/types.h"
-#include "include/utime.h"
 #include "rgw_acl.h"
-#include "rgw_basic_types.h"
 #include "rgw_cors.h"
 #include "rgw_quota.h"
 #include "rgw_string.h"


### PR DESCRIPTION
The following headers are already included in the other included header files in rgw_common.h. So removed them.