### PR TITLE
rgw: fix compatible with Swift URL

### DIFF
--- a/doc/radosgw/keystone.rst
+++ b/doc/radosgw/keystone.rst
@@ -111,6 +111,67 @@ object-storage endpoint::
   | service_type | object-store                             |
   +--------------+------------------------------------------+
 
+As of Newton
+------------
+
+Keystone itself needs to be configured to point to the Ceph Object Gateway as an
+object-storage endpoint::
+
+  $ openstack service create --name swift --description "Swift Service" object-store
+  +-------------+----------------------------------+
+  | Field       | Value                            |
+  +-------------+----------------------------------+
+  | description | Swift Service                    |
+  | enabled     | True                             |
+  | id          | b143395708b5410db1ef22dbef9bfb91 |
+  | name        | swift                            |
+  | type        | object-store                     |
+  +-------------+----------------------------------+
+
+  $ openstack endpoint create --region RegionOne swift public 'http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s'
+  +--------------+--------------------------------------------------------------+
+  | Field        | Value                                                        |
+  +--------------+--------------------------------------------------------------+
+  | enabled      | True                                                         |
+  | id           | 4d092bf234b94f5e94d26118bd0dd954                             |
+  | interface    | public                                                       |
+  | region       | RegionOne                                                    |
+  | region_id    | RegionOne                                                    |
+  | service_id   | b143395708b5410db1ef22dbef9bfb91                             |
+  | service_name | swift                                                        |
+  | service_type | object-store                                                 |
+  | url          | http://radosgw.example.com:8080/swift/v1/AUTH_$(project_id)s |
+  +--------------+--------------------------------------------------------------+
+
+  $ openstack endpoint create --region RegionOne swift admin http://radosgw.example.com:8080/swift/v1
+  +--------------+------------------------------------------+
+  | Field        | Value                                    |
+  +--------------+------------------------------------------+
+  | enabled      | True                                     |
+  | id           | 8e40fbe1bd584a1a8dcf1c869e7afa9b         |
+  | interface    | admin                                    |
+  | region       | RegionOne                                |
+  | region_id    | RegionOne                                |
+  | service_id   | b143395708b5410db1ef22dbef9bfb91         |
+  | service_name | swift                                    |
+  | service_type | object-store                             |
+  | url          | http://radosgw.example.com:8080/swift/v1 |
+  +--------------+------------------------------------------+
+
+  $ openstack endpoint create --region RegionOne swift internal http://radosgw.example.com:8080/swift/v1
+  +--------------+------------------------------------------+
+  | Field        | Value                                    |
+  +--------------+------------------------------------------+
+  | enabled      | True                                     |
+  | id           | 50f51d9833884ab68d7d6709bf837d34         |
+  | interface    | internal                                 |
+  | region       | RegionOne                                |
+  | region_id    | RegionOne                                |
+  | service_id   | b143395708b5410db1ef22dbef9bfb91         |
+  | service_name | swift                                    |
+  | service_type | object-store                             |
+  | url          | http://radosgw.example.com:8080/swift/v1 |
+  +--------------+------------------------------------------+
 
 The keystone URL is the Keystone admin RESTful API URL. The admin token is the
 token that is configured internally in Keystone for admin requests.

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2304,23 +2304,18 @@ int RGWHandler_REST_SWIFT::init_from_header(struct req_state* const s,
   }
 
   std::string tenant_path;
-  if (! g_conf->rgw_swift_tenant_name.empty()) {
-    tenant_path = "/AUTH_";
-    tenant_path.append(g_conf->rgw_swift_tenant_name);
-  }
-
   /* verify that the request_uri conforms with what's expected */
-  char buf[g_conf->rgw_swift_url_prefix.length() + 16 + tenant_path.length()];
+  char buf[g_conf->rgw_swift_url_prefix.length() + 16];
   int blen;
   if (g_conf->rgw_swift_url_prefix == "/") {
-    blen = sprintf(buf, "/v1%s", tenant_path.c_str());
+    blen = sprintf(buf, "/v1/AUTH_");
   } else {
-    blen = sprintf(buf, "/%s/v1%s",
-                   g_conf->rgw_swift_url_prefix.c_str(), tenant_path.c_str());
+    blen = sprintf(buf, "/%s/v1/AUTH_",
+                   g_conf->rgw_swift_url_prefix.c_str());
   }
 
-  if (strncmp(reqbuf, buf, blen) != 0) {
-    return -ENOENT;
+  if (strncmp(reqbuf, buf, blen) == 0) {
+    tenant_path = "/AUTH_";
   }
 
   int ret = allocate_formatter(s, RGW_FORMAT_PLAIN, true);
@@ -2349,6 +2344,8 @@ int RGWHandler_REST_SWIFT::init_from_header(struct req_state* const s,
 
     if (account_name.empty()) {
       return -ERR_PRECONDITION_FAILED;
+    } else if ( ! g_conf->rgw_swift_tenant_name.empty() && account_name.compare(g_conf->rgw_swift_tenant_name) != 0) {
+      return -ENOENT;
     } else {
       s->account_name = account_name;
     }


### PR DESCRIPTION
Add support for "/AUTH_(project ID)" path when integrating with
OpenStack Keystone.

Fixes: http://tracker.ceph.com/issues/19264
Signed-off-by: Albert Tu <albert.t@inwinstack.com>