### PR TITLE
pybind/mgr/rest: don't set timezone to Chicago

### DIFF
--- a/src/pybind/mgr/rest/app/settings.py
+++ b/src/pybind/mgr/rest/app/settings.py
@@ -21,7 +21,7 @@ ALLOWED_HOSTS = ['*']
 # http://en.wikipedia.org/wiki/List_of_tz_zones_by_name
 # although not all choices may be available on all operating systems.
 # In a Windows environment this must be set to your system time zone.
-TIME_ZONE = 'America/Chicago'
+TIME_ZONE = None
 
 # Language code for this installation. All choices can be found here:
 # http://www.i18nguy.com/unicode/language-identifiers.html


### PR DESCRIPTION
Setting TIME_ZONE in the Django app causes the timestamps printed in
the mgr log to suddenly be wrong after the rest module starts up
(unless, I imagine, if the host happens to be in Chicago).

Signed-off-by: Tim Serong <tserong@suse.com>