### PR TITLE
mon/PGMap: make si units more readable in PGMap summary

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1605,7 +1605,7 @@ void PGMap::print_summary(Formatter *f, ostream *out) const
     *out << "      pgmap v" << version << ": "
          << pg_stat.size() << " pgs, " << pg_pool_sum.size() << " pools, "
          << prettybyte_t(pg_sum.stats.sum.num_bytes) << " data, "
-         << pretty_si_t(pg_sum.stats.sum.num_objects) << "objects\n";
+         << si_t(pg_sum.stats.sum.num_objects) << " objects\n";
     *out << "            "
          << kb_t(osd_sum.kb_used) << " used, "
          << kb_t(osd_sum.kb_avail) << " / "


### PR DESCRIPTION
Signed-off-by: liuhong <liuhong@cmss.chinamobile.com>
Before:
you execute the command(ceph -s) when there are many objects in the cluster.
eg: pgmap 300 Mobjects
Now:
eg: pgmap 300M objects