### PR TITLE
osdc/Objecter: respect epoch barrier in _op_submit()

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2354,8 +2354,13 @@ void Objecter::_op_submit(Op *op, shunique_lock& sul, ceph_tid_t *ptid)
 
   bool need_send = false;
 
-  if ((op->target.flags & CEPH_OSD_FLAG_WRITE) &&
-      osdmap->test_flag(CEPH_OSDMAP_PAUSEWR)) {
+  if (osdmap->get_epoch() < epoch_barrier) {
+    ldout(cct, 10) << " barrier, paused " << op << " tid " << op->tid
+		   << dendl;
+    op->target.paused = true;
+    _maybe_request_map();
+  } else if ((op->target.flags & CEPH_OSD_FLAG_WRITE) &&
+             osdmap->test_flag(CEPH_OSDMAP_PAUSEWR)) {
     ldout(cct, 10) << " paused modify " << op << " tid " << op->tid
 		   << dendl;
     op->target.paused = true;


### PR DESCRIPTION
Epoch barrier instructs us to avoid sending (i.e. pause) any OSD ops
until we see a barrier epoch.  The only thing epoch_barrier check in
target_should_be_paused() does is keep already paused ops paused.  We
need to actually pause incoming OSD ops in _op_submit().

Fixes: http://tracker.ceph.com/issues/19396
Signed-off-by: Ilya Dryomov <idryomov@gmail.com>