### PR TITLE
Switch turns WBThrottle to be sync statistic helper

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1157,6 +1157,10 @@ OPTION(filestore_wbthrottle_xfs_bytes_hard_limit, OPT_U64, 419430400)
 OPTION(filestore_wbthrottle_xfs_ios_start_flusher, OPT_U64, 500)
 OPTION(filestore_wbthrottle_xfs_ios_hard_limit, OPT_U64, 5000)
 OPTION(filestore_wbthrottle_xfs_inodes_start_flusher, OPT_U64, 500)
+/* Switch which turns wbthrottle to be a pure statistic helper
+ * which count up bytes, ios and inodes for every sync operation
+ */
+OPTION(filestore_wbthrottle_sync_statistic_helper, OPT_BOOL, false)
 
 /// These must be less than the fd limit
 OPTION(filestore_wbthrottle_btrfs_inodes_hard_limit, OPT_U64, 5000)

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3951,7 +3951,10 @@ void FileStore::sync_entry()
 	  derr << "object_map sync got " << cpp_strerror(err) << dendl;
 	  assert(0 == "object_map sync returned error");
 	}
-
+        // dump sync bytes, ios and inodes
+        if(!m_disable_wbthrottle && wbthrottle.is_statistic_helper()) {
+          wbthrottle.dump_info();
+        }
 	err = backend->syncfs();
 	if (err < 0) {
 	  derr << "syncfs got " << cpp_strerror(err) << dendl;

--- a/src/os/filestore/WBThrottle.h
+++ b/src/os/filestore/WBThrottle.h
@@ -82,7 +82,7 @@ class WBThrottle : Thread, public md_config_obs_t {
   bool stopping;
   Mutex lock;
   Cond cond;
-
+  bool statistic_helper;
 
   /**
    * Flush objects in lru order
@@ -137,9 +137,10 @@ private:
       return true;
   }
   bool need_flush() const {
-    if (cur_ios < io_limits.second &&
+    if (statistic_helper || 
+        (cur_ios < io_limits.second &&
 	pending_wbs.size() < fd_limits.second &&
-	cur_size < size_limits.second)
+	cur_size < size_limits.second))
       return false;
     else
       return true;
@@ -183,6 +184,11 @@ public:
 
   /// Thread
   void *entry();
+  /// Dump wb current info
+  void dump_info();
+  bool is_statistic_helper() {
+    return statistic_helper;      
+  }
 };
 
 #endif


### PR DESCRIPTION
Hi Ceph owner,

Can we add the switch turning WBThrottle to be a pure statistic helper, which makes filestore backend sync performance evaluation easy ?

Cheers,
Klaus  