### PR TITLE
rgw: warning, output may be truncated before the last format character

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -17,21 +17,9 @@
 #define CEPH_RGW_COMMON_H
 
 #include "common/ceph_crypto.h"
-
-#include "common/debug.h"
 #include "common/perf_counters.h"
-
 #include "acconfig.h"
-
-#include <errno.h>
-#include <string.h>
-#include <string>
-#include <map>
-#include <boost/utility/string_ref.hpp>
-#include "include/types.h"
-#include "include/utime.h"
 #include "rgw_acl.h"
-#include "rgw_basic_types.h"
 #include "rgw_cors.h"
 #include "rgw_quota.h"
 #include "rgw_string.h"

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4585,7 +4585,7 @@ static void usage_log_hash(CephContext *cct, const string& name, string& hash, u
     val %= max_user_shards;
     val += ceph_str_hash_linux(name.c_str(), name.size());
   }
-  char buf[16];
+  char buf[17];
   int max_shards = max(cct->_conf->rgw_usage_max_shards, 1);
   snprintf(buf, sizeof(buf), RGW_USAGE_OBJ_PREFIX "%u", (unsigned)(val % max_shards));
   hash = buf;


### PR DESCRIPTION
The following warning appears during make:

    ```
    rgw_rados.cc: In function ‘void usage_log_hash(CephContext*, const string&, std::__cxx11::string&, uint32_t)’:
    rgw_rados.cc:4579:13: warning: ‘__builtin___snprintf_chk’ output may be truncated before the last format character [-Wformat-truncation=]
     static void usage_log_hash(CephContext *cct, const string& name, string& hash, uint32_t index)
                 ^~~~~~~~~~~~~~
    /usr/include/bits/stdio2.h:65:44: note: ‘__builtin___snprintf_chk’ output between 8 and 17 bytes into a destination of size 16
            __bos (__s), __fmt, __va_arg_pack ());
    ```
Signed-off-by: Jos Collin <jcollin@redhat.com>