### PR TITLE
mds: use same inode count in health check as in trim

### DIFF
--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -483,10 +483,10 @@ void Beacon::notify_health(MDSRank const *mds)
   }
 
   // Report if we have significantly exceeded our cache size limit
-  if (CInode::count() >
+  if (mds->mdcache->get_cache_size() >
         g_conf->mds_cache_size * g_conf->mds_health_cache_threshold) {
     std::ostringstream oss;
-    oss << "Too many inodes in cache (" << CInode::count()
+    oss << "Too many inodes in cache (" << mds->mdcache->get_cache_size()
         << "/" << g_conf->mds_cache_size << "), "
         << mds->mdcache->num_inodes_with_caps << " inodes in use by clients, "
         << mds->mdcache->get_num_strays() << " stray files";


### PR DESCRIPTION
Otherwise we could have a strange situation in which trimming
is working fine, but the health check thinks there's a problem.

Seen in: http://tracker.ceph.com/issues/19395

Signed-off-by: John Spray <john.spray@redhat.com>