### PR TITLE
doc: change osd_op_thread_timeout default value to 15

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -448,7 +448,7 @@ recovery operations to ensure optimal performance during recovery.
 
 :Description: The Ceph OSD Daemon operation thread timeout in seconds.
 :Type: 32-bit Integer
-:Default: ``30`` 
+:Default: ``15`` 
 
 
 ``osd op complaint time`` 


### PR DESCRIPTION
update default value of the `osd_op_thread_timeout` setting in the docs to match current default value in the code: https://github.com/ceph/ceph/commit/61eafffc3242357d9add48be9308222085536898