### PR TITLE
rgw: fix build of conflict after auth rework

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -878,7 +878,7 @@ int RGWGetObj::read_user_manifest_part(rgw_bucket& bucket,
    * stored inside different accounts. */
   if (s->system_request) {
     ldout(s->cct, 2) << "overriding permissions due to system operation" << dendl;
-  } else if (s->auth_identity->is_admin_of(s->user->user_id)) {
+  } else if (s->auth.identity->is_admin_of(s->user->user_id)) {
     ldout(s->cct, 2) << "overriding permissions due to admin operation" << dendl;
   } else if (!verify_object_permission(s, s->user_acl.get(), bucket_policy,
                                        &obj_policy, RGW_PERM_READ)) {


### PR DESCRIPTION
github didn't detect a merge conflict between https://github.com/ceph/ceph/pull/13561 and https://github.com/ceph/ceph/pull/12893, leading to this compile error:
```
/home/cbodley/ceph/src/rgw/rgw_op.cc: In member function ‘int RGWGetObj::read_user_manifest_part(rgw_bucket&, const rgw_bucket_dir_entry&, RGWAccessControlPolicy*, off_t, 
off_t)’:
/home/cbodley/ceph/src/rgw/rgw_op.cc:881:17: error: ‘struct req_state’ has no member named ‘auth_identity’
   } else if (s->auth_identity->is_admin_of(s->user->user_id)) {
                 ^
src/rgw/CMakeFiles/rgw_a.dir/build.make:1094: recipe for target 'src/rgw/CMakeFiles/rgw_a.dir/rgw_op.cc.o' failed
```