### PR TITLE
crush: bucket: crush_add_uniform_bucket_item should check for uniformity

### DIFF
--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -685,7 +685,16 @@ int crush_add_uniform_bucket_item(struct crush_bucket_uniform *bucket, int item,
 {
         int newsize = bucket->h.size + 1;
 	void *_realloc = NULL;
-	
+
+	/* In such situation 'CRUSH_BUCKET_UNIFORM', the weight
+	   provided for the item should be the same as
+	   bucket->item_weight defined with 'crush_make_bucket'. This
+	   assumption is enforced by the return value which is always
+	   0. */
+	if (bucket->item_weight != weight) {
+	  return -EINVAL;
+	}
+
 	if ((_realloc = realloc(bucket->h.items, sizeof(__s32)*newsize)) == NULL) {
 		return -ENOMEM;
 	} else {

--- a/src/crush/builder.h
+++ b/src/crush/builder.h
@@ -234,7 +234,7 @@ extern int crush_bucket_add_item(struct crush_map *map, struct crush_bucket *buc
  *
  * If __bucket->alg__ is different from ::CRUSH_BUCKET_UNIFORM,
  * set the  __weight__ of  __item__ in __bucket__. The former weight of the
- * item is subtracted from the weight of of the bucket and the new weight is added.
+ * item is subtracted from the weight of the bucket and the new weight is added.
  * The return value is the difference between the new item weight and the former
  * item weight.
  *

--- a/src/crush/builder.h
+++ b/src/crush/builder.h
@@ -219,6 +219,8 @@ struct crush_bucket *crush_make_bucket(struct crush_map *map, int alg, int hash,
  *
  * - return -ENOMEM if the __bucket__ cannot be resized with __realloc(3)__.
  * - return -ERANGE if adding __weight__ to the weight of the bucket overflows.
+ * - return -EINVAL if __bucket->alg__ is ::CRUSH_BUCKET_UNIFORM and
+ *   the __weight__ is not equal to __(struct crush_bucket_uniform *)bucket->item_weight__.
  * - return -1 if the value of __bucket->alg__ is unknown.
  *
  * @returns 0 on success, < 0 on error

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -428,7 +428,7 @@ extern void crush_destroy_bucket_straw2(struct crush_bucket_straw2 *b);
  *
  * Deallocate a bucket created via crush_add_bucket().
  *
- * @param bucket the bucket to deallocate
+ * @param b the bucket to deallocate
  */
 extern void crush_destroy_bucket(struct crush_bucket *b);
 /** @ingroup API


### PR DESCRIPTION
And a few minor documentation fixes while we're at it.