### PR TITLE
os/Filestore: fix wbthrottle assert.

### DIFF
--- a/src/os/filestore/WBThrottle.cc
+++ b/src/os/filestore/WBThrottle.cc
@@ -135,7 +135,7 @@ bool WBThrottle::get_next_should_flush(
 {
   assert(lock.is_locked());
   assert(next);
-  while (!stopping && !beyond_limit())
+  while (!stopping && (!beyond_limit() || pending_wbs.empty()))
          cond.Wait(lock);
   if (stopping)
     return false;


### PR DESCRIPTION
When filestore_wbthrottle_*_*_start_flusher = 0, ceph-osd
will assert on startup due to pending_wbs.empty() == True.

It seems valid for user to set start_flusher to 0 as intend to
flush aggressively all the time, to minimize the impact of
syncfs().

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>