### PR TITLE
os/bluestore: make live changes for BlueStore throttle config work like initial config

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3325,15 +3325,21 @@ void BlueStore::handle_conf_change(const struct md_config_t *conf,
   }
   if (changed.count("bluestore_max_ops")) {
     throttle_ops.reset_max(conf->bluestore_max_ops);
+    throttle_deferred_ops.reset_max(
+      conf->bluestore_max_ops + conf->bluestore_deferred_max_ops);
   }
   if (changed.count("bluestore_max_bytes")) {
     throttle_bytes.reset_max(conf->bluestore_max_bytes);
+    throttle_deferred_bytes.reset_max(
+      conf->bluestore_max_bytes + conf->bluestore_deferred_max_bytes);
   }
   if (changed.count("bluestore_deferred_max_ops")) {
-    throttle_deferred_ops.reset_max(conf->bluestore_deferred_max_ops);
+    throttle_deferred_ops.reset_max(
+      conf->bluestore_max_ops + conf->bluestore_deferred_max_ops);
   }
   if (changed.count("bluestore_deferred_max_bytes")) {
-    throttle_deferred_bytes.reset_max(conf->bluestore_deferred_max_bytes);
+    throttle_deferred_bytes.reset_max(
+      conf->bluestore_max_bytes + conf->bluestore_deferred_max_bytes);
   }
 }
 


### PR DESCRIPTION
Make live changes of configuration options bluestore_max_ops,
bluestore_max_bytes, bluestore_deferred_max_ops,
bluestore_deferred_max_bytes work the same way as initial
configuration. Specifically, the deferred throttles have a max to be
the sum of the deferred value and the non-deferred value during
initial configuration, so live changes now work this way.