### PR TITLE
systemd: remove ceph-create-keys from presets

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1194,7 +1194,7 @@ if [ $1 -eq 1 ] ; then
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_post ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_post ceph-mon@\*.service ceph-mon.target
 %endif
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-mon.target >/dev/null 2>&1 || :
@@ -1202,20 +1202,20 @@ fi
 
 %preun mon
 %if 0%{?suse_version}
-%service_del_preun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%service_del_preun ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_preun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_preun ceph-mon@\*.service ceph-mon.target
 %endif
 
 %postun mon
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%service_del_postun ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_postun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_postun ceph-mon@\*.service ceph-mon.target
 %endif
 if [ $FIRST_ARG -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
@@ -1225,7 +1225,7 @@ if [ $FIRST_ARG -ge 1 ] ; then
     source $SYSCONF_CEPH
   fi
   if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
-    /usr/bin/systemctl try-restart ceph-create-keys@\*.service ceph-mon@\*.service > /dev/null 2>&1 || :
+    /usr/bin/systemctl try-restart ceph-mon@\*.service > /dev/null 2>&1 || :
   fi
 fi
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1190,7 +1190,7 @@ fi
 %post mon
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
-  /usr/bin/systemctl preset ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target >/dev/null 2>&1 || :
+  /usr/bin/systemctl preset ceph-mon@\*.service ceph-mon.target >/dev/null 2>&1 || :
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}


### PR DESCRIPTION
ceph-create-keys unit file was removed here:

* https://github.com/ceph/ceph/commit/8bcb4646b6b9846bb965cdec3ca2a21eb3b26bab
* https://github.com/ceph/ceph/commit/dc5fe8d415858358bd0baf5d8dce0a753f5e0cea

As a consequence the systemctl preset command now fails to run since the
unit does not exist anymore. Due to the redirection in /dev/null we
don't know what's happening.

Ultimately the mon unit doesn't get enabled and the mon service won't
start after reboot.
Removing the old/non-existent unit makes the command succeed now.

Signed-off-by: Sébastien Han <seb@redhat.com>