### PR TITLE
common/perf_counters: fix race condition with atomic variables

### DIFF
--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -120,13 +120,15 @@ public:
       }
     }
 
-    /// read <sum, count> safely
+    // read <sum, count> safely by making sure the post- and pre-count
+    // are identical; in other words the whole loop needs to be run
+    // without any intervening calls to inc, set, or tinc.
     pair<uint64_t,uint64_t> read_avg() const {
       uint64_t sum, count;
       do {
-	count = avgcount.read();
+	count = avgcount2.read();
 	sum = u64.read();
-      } while (avgcount2.read() != count);
+      } while (avgcount.read() != count);
       return make_pair(sum, count);
     }
   };


### PR DESCRIPTION
Please check my logic for this apparent fix. This technique of using two matched atomic variables as a guard against race conditions is new to me.

Fix potential race condition. With the old code it would be possible
to get incorrect pair if the following sequence occurred:

<pre>
    ==inc==          ==read_avg==
    avgcount.inc()
                    avgcount.read()
A)                  u64.read()
    u64.add()
B)                  u64.read()
    avgcount2.inc()
                    avgcount2.read()
</pre>

Depending on whether u64.read() is called at A) or B) we'd get the new
count with either the old value or new value. By flipping the order of
the avgcount & avgcount2 reads we're guaranteed to only get matched
values.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>