### PR TITLE
jewel: rgw_fh: RGWFileHandle dtor must also cond-unlink from FHCache

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -720,6 +720,11 @@ namespace rgw {
   } /* RGWLibFS::gc */
 
   RGWFileHandle::~RGWFileHandle() {
+    /* in the non-delete case, handle may still be in handle table */
+    if (fh_hook.is_linked()) {
+      fs->fh_cache.remove(fh.fh_hk.object, this, FHCache::FLAG_LOCK);
+    }
+    /* cond-unref parent */
     if (parent && (! parent->is_root())) {
       /* safe because if parent->unref causes its deletion,
        * there are a) by refcnt, no other objects/paths pointing


### PR DESCRIPTION
Formerly masked in part by the reclaim() action, direct-delete now
substitutes for reclaim() iff its LRU lane is over its high-water
mark, and in particular, like reclaim() the destructor is certain
to see handles still interned on the FHcache when nfs-ganesha is
recycling objects from its own LRU.

Fixes: http://tracker.ceph.com/issues/19112

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
(cherry picked from commit d51a3b1224ba62bb53c6c2c7751fcf7853c35a4b)