### PR TITLE
tools/cephfs: set dir_layout when injecting inodes

### DIFF
--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -358,6 +358,7 @@ int MetadataDriver::inject_unlinked_inode(
   // they don't have to mount the filesystem to correct it?
   inode.inode.layout = file_layout_t::get_default();
   inode.inode.layout.pool_id = data_pool_id;
+  inode.inode.dir_layout.dl_dir_hash = g_conf->mds_default_dir_hash;
 
   // Assume that we will get our stats wrong, and that we may
   // be ignoring dirfrags that exist
@@ -1636,6 +1637,8 @@ int MetadataDriver::inject_with_backtrace(
         // accurate, but it should avoid functional issues.
 
         ancestor_dentry.inode.dirstat.nfiles = 1;
+        ancestor_dentry.inode.dir_layout.dl_dir_hash =
+                                               g_conf->mds_default_dir_hash;
 
         ancestor_dentry.inode.nlink = 1;
         ancestor_dentry.inode.ino = ino;
@@ -1982,6 +1985,7 @@ void MetadataTool::build_dir_dentry(
   out->inode.ctime.tv.tv_sec = fragstat.mtime;
 
   out->inode.layout = layout;
+  out->inode.dir_layout.dl_dir_hash = g_conf->mds_default_dir_hash;
 
   out->inode.truncate_seq = 1;
   out->inode.truncate_size = -1ull;


### PR DESCRIPTION
When we left this as zero, the MDS would interpret it was HASH_LINUX
rather than the default HASH_RJENKINS.  Potentially that
could cause problems if there perhaps were already dirfrags in
the metadata pool that were set up using rjenkins.  Mainly
it just seems more appropriate to explicitly set this field
rather than hit the fallback behaviour.

Related: http://tracker.ceph.com/issues/19406
Signed-off-by: John Spray <john.spray@redhat.com>