### PR TITLE
ceph.spec.in: add librdmacm-devl package.

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -133,6 +133,7 @@ BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	yasm
 BuildRequires:	libibverbs-devel
+BuildRequires:	librdmacm-devel
 
 #################################################################################
 # distro-conditional dependencies

--- a/debian/control
+++ b/debian/control
@@ -61,7 +61,8 @@ Build-Depends: bc,
                xfsprogs,
                xmlstarlet,
                yasm [amd64],
-               zlib1g-dev
+               zlib1g-dev,
+               librdmacm-dev
 Standards-Version: 3.9.3
 
 Package: ceph


### PR DESCRIPTION
When complie:
In file included from /opt/ceph/src/msg/async/rdma/RDMAStack.h:30:0,
                 from /opt/ceph/src/msg/async/Stack.cc:22:
/opt/ceph/src/msg/async/rdma/Infiniband.h:21:27: fatal error:
rdma/rdma_cma.h: No such file or directory
 #include <rdma/rdma_cma.h>

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>