### PR TITLE
krbd: warning, ‘devno’ may be used uninitialized in this function

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -588,7 +588,7 @@ static int unmap_image(struct krbd_ctx *ctx, const char *pool,
                        const char *image, const char *snap,
                        const char *options)
 {
-  dev_t devno;
+  dev_t devno = 0;
   string id;
   int r;
 


### PR DESCRIPTION
The following warning appears during make:
```
krbd.cc: In function ‘int krbd_unmap_by_spec(krbd_ctx*, const char*, const char*, const char*, const char*)’:
krbd.cc:608:65: warning: ‘devno’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return do_unmap(ctx->udev, devno, build_unmap_buf(id, options));
                                                                 ^
krbd.cc:591:9: note: ‘devno’ was declared here
   dev_t devno;
         ^~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>