### PR TITLE
librbd: Prompt the users to try again when snap rollback failed by stale watcher on disk

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -779,7 +779,9 @@ int Operations<I>::snap_rollback(const cls::rbd::SnapshotNamespace& snap_namespa
   }
 
   r = prepare_image_update();
-  if (r < 0) {
+  if (r == -EAGAIN) {
+    return r;
+  } else if (r < 0) {
     return -EROFS;
   }
   if (m_image_ctx.exclusive_lock != nullptr &&


### PR DESCRIPTION
In case snap rollback was interrupted by rbd client exited or osd rebooted abnornally, the rbd_lock and watcher of stale client were still on disk. When rbd client run snap rollback next time, the watcher check in osd will start to transfer from ondisk state to disconnect state and be loaded into memory, waiting for check, but meanwhile rbd client get and retrieve rbd_lock will fail, and finally print "Read-Only", these words would confuse users.
So I change it to prompt the users to try again. In fact it will be succeeded after 30s.

http://tracker.ceph.com/issues/19459

Signed-off-by: tang.jin <tang.jin@istuary.com>