### PR TITLE
msg/async/rdma: Device::last_poll_dev must be positive

### DIFF
--- a/src/msg/async/rdma/Device.h
+++ b/src/msg/async/rdma/Device.h
@@ -137,7 +137,7 @@ class DeviceList {
   int num;
   Device** devices;
 
-  int last_poll_dev;
+  unsigned last_poll_dev = 0;
   struct pollfd *poll_fds;
 
  public:


### PR DESCRIPTION
Make Device::last_poll_dev `unsigned` - it could overlap and should not
be negative.
Also, add missing initialization.

Signed-off-by: Amir Vadai <amir@vadai.me>