### PR TITLE
rbd-nbd: remove debug messages from do_unmap

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -763,11 +763,8 @@ static int do_unmap()
     return nbd;
   }
 
-  dout(20) << __func__ << ": " << "sending NBD_DISCONNECT" << dendl;
   if (ioctl(nbd, NBD_DISCONNECT) < 0) {
     cerr << "rbd-nbd: the device is not used" << std::endl;
-  } else {
-    dout(20) << __func__ << ": " << "disconnected" << dendl;
   }
 
   close(nbd);


### PR DESCRIPTION
Global context is not initialized when do_unmap is called.

Signed-off-by: Pan Liu <liupan1111@gmail.com>