### PR TITLE
qa/vstart_runner: amend ps invocation

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -317,14 +317,14 @@ class LocalDaemon(object):
         Return PID as an integer or None if not found
         """
         ps_txt = self.controller.run(
-            args=["ps", "-xwwu"+str(os.getuid())]
+            args=["ps", "ww", "-u"+str(os.getuid())]
         ).stdout.getvalue().strip()
         lines = ps_txt.split("\n")[1:]
 
         for line in lines:
             if line.find("ceph-{0} -i {1}".format(self.daemon_type, self.daemon_id)) != -1:
                 log.info("Found ps line for daemon: {0}".format(line))
-                return int(line.split()[1])
+                return int(line.split()[0])
         log.info("No match for {0} {1}: {2}".format(
             self.daemon_type, self.daemon_id, ps_txt
             ))


### PR DESCRIPTION
"ps -xwwu<id>" is parsed as BSD, because -x is not a UNIX option.
"u" is a BSD option for user-oriented format, so the <id> ends up being
parsed as an old-style "select by pid".  The only reason this command
doesn't dump other user's processes is that the BSD "only yourself"
restriction is in effect.

I'm not sure what's wrong with a simple "ps xww", but if we want to
select by euid, let's do it right.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>