### PR TITLE
ceph_test_librados_api_misc: fix stupid LibRadosMiscConnectFailure.ConnectFailure test

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -66,8 +66,18 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
   ASSERT_EQ(-ENOTCONN, rados_monitor_log(cluster, "error",
                                          test_rados_log_cb, NULL));
 
-  ASSERT_NE(0, rados_connect(cluster));
-  ASSERT_NE(0, rados_connect(cluster));
+  // try this a few times; sometimes we don't schedule fast enough for the
+  // cond to time out
+  int r;
+  for (unsigned i=0; i<16; ++i) {
+    cout << i << std::endl;
+    r = rados_connect(cluster);
+    if (r < 0)
+      break;  // yay, we timed out
+    // try again
+    rados_shutdown(cluster);
+  }
+  ASSERT_NE(0, r);
 
   rados_shutdown(cluster);
 }

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -353,7 +353,7 @@ TEST(TestRGWManifest, old_obj_manifest) {
 
   gen_old_obj(env, obj_size, head_size, stripe_size, &old_manifest, &old_bucket, &old_head, &old_objs);
 
-  ASSERT_EQ(old_objs.size(), 11);
+  ASSERT_EQ(old_objs.size(), 11u);
 
 
   bufferlist bl;


### PR DESCRIPTION
Sometimes the cond doesn't time out and it wakes up instead.  Just repeat
the test many times to ensure that at least once it times out (usually
it doesn't; it's pretty infrequent that it doesn't).

Fixes: http://tracker.ceph.com/issues/15368
Signed-off-by: Sage Weil <sage@redhat.com>