### PR TITLE
client: warning: ‘*’ in boolean context, suggest ‘&&’ instead

### DIFF
--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -2656,7 +2656,7 @@ int SyntheticClient::random_walk(int num_req)
     }
 
     // descend?
-    if (.9*roll_die(::pow((double).9,(double)cwd.depth())) && !subdirs.empty()) {
+    if ((.9*roll_die(::pow((double).9,(double)cwd.depth()))) && !subdirs.empty()) {
       string s = get_random_subdir();
       cwd.push_dentry( s );
       dout(DBL) << "cd " << s << " -> " << cwd << dendl;


### PR DESCRIPTION
The following warning appears during make:
```
SyntheticClient.cc: In member function ‘int SyntheticClient::random_walk(int)’:
SyntheticClient.cc:2659:11: warning: ‘*’ in boolean context, suggest ‘&&’ instead [-Wint-in-bool-context]
     if (.9*roll_die(::pow((double).9,(double)cwd.depth())) && !subdirs.empty()) {
```
Signed-off-by: Jos Collin <jcollin@redhat.com>