### PR TITLE
mon: we should need to handle the error happen when use osd crush create-or-move cmd

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -78,6 +78,7 @@ ceph osd crush add-bucket foo host
 ceph osd crush move foo root=default rack=localrack
 
 ceph osd crush create-or-move osd.$o1 1.0 root=default
+expect_false ceph osd crush create-or-move osd.$o1 1.0 root=empty
 ceph osd crush move osd.$o1 host=foo
 ceph osd find osd.$o1 | grep host | grep foo
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6114,6 +6114,9 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 	wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
 						  get_last_committed() + 1));
 	return true;
+      } else {
+        ss << "can not create-or-move updated item name '" << name << "' weight " << weight
+           << " at location " << loc << " to crush map";
       }
     } while (false);
 


### PR DESCRIPTION
mon: we should need to handle the error happen when use osd crush create-or-move cmd

Signed-off-by: song baisen <song.baisen@zte.com.cn>