### PR TITLE
cephfs: fix mount point break off problem after mds switch occured 

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -801,6 +801,7 @@ void Server::handle_client_reconnect(MClientReconnect *m)
 
   // notify client of success with an OPEN
   m->get_connection()->send_message(new MClientSession(CEPH_SESSION_OPEN));
+  session->last_cap_renew = ceph_clock_now();
   mds->clog->debug() << "reconnect by " << session->info.inst << " after " << delay;
   
   // snaprealms


### PR DESCRIPTION
The hot-standby become active as we expected but the mount piont broken strangely when the active mds is down. The root reason is the new mds use  last_cap_renews decoded from ESesson::replay in find_idle_sessions and wrongly killed the session. Maybe we should reset session->last_cap_renew to the current time when server send OPEN to client in reconnect stage.
