### PR TITLE
mon/OSDMonitor: spinlock -> std::mutex

### DIFF
--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -432,7 +432,7 @@ private:
   // the epoch when the pg mapping was calculated
   epoch_t creating_pgs_epoch = 0;
   creating_pgs_t creating_pgs;
-  Spinlock creating_pgs_lock;
+  std::mutex creating_pgs_lock;
 
   creating_pgs_t update_pending_creatings(const OSDMap::Incremental& inc);
   void trim_creating_pgs(creating_pgs_t *creating_pgs, const PGMap& pgm);


### PR DESCRIPTION
I think spinlock is dangerous here: we're doing semi-unbounded
work (decode).  Also seemingly innocuous code like dout macros
take mutexes.

Signed-off-by: Sage Weil <sage@redhat.com>