### PR TITLE
rbd: warning, ‘devno’ may be used uninitialized in this function

### DIFF
--- a/src/krbd.cc
+++ b/src/krbd.cc
@@ -552,7 +552,7 @@ static int unmap_image(struct krbd_ctx *ctx, const char *devnode,
                        const char *options)
 {
   struct stat sb;
-  dev_t wholedevno;
+  dev_t wholedevno = 0;
   string id;
   int r;
 
@@ -588,7 +588,7 @@ static int unmap_image(struct krbd_ctx *ctx, const char *pool,
                        const char *image, const char *snap,
                        const char *options)
 {
-  dev_t devno;
+  dev_t devno = 0;
   string id;
   int r;
 


### PR DESCRIPTION
The following warning appears during make. Fixed in both unmap_image() functions in krbd.cc

```
krbd.cc: In function ‘int krbd_unmap_by_spec(krbd_ctx*, const char*, const char*, const char*, const char*)’:
krbd.cc:608:65: warning: ‘devno’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   return do_unmap(ctx->udev, devno, build_unmap_buf(id, options));
                                                                 ^
krbd.cc:591:9: note: ‘devno’ was declared here
   dev_t devno;
```

Signed-off-by: Jos Collin <jcollin@redhat.com>