### PR TITLE
rgw: update Beast for streaming reads in asio frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -340,7 +340,7 @@ endif(WITH_DPDK)
 #option for RGW
 option(WITH_RADOSGW "Rados Gateway is enabled" ON)
 option(WITH_RADOSGW_FCGI_FRONTEND "Rados Gateway's FCGI frontend is enabled" ON)
-option(WITH_RADOSGW_ASIO_FRONTEND "Rados Gateway's ASIO frontend is enabled" ON)
+option(WITH_RADOSGW_BEAST_FRONTEND "Rados Gateway's Beast frontend is enabled" ON)
 if(WITH_RADOSGW)
   find_package(EXPAT REQUIRED)
   if(WITH_RADOSGW_FCGI_FRONTEND)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -508,7 +508,7 @@ endif()
 option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 
 set(BOOST_COMPONENTS
-	container thread system regex random program_options date_time iostreams)
+	container thread system regex random program_options date_time iostreams coroutine context)
 if(WITH_MGR)
 	list(APPEND BOOST_COMPONENTS python)
 endif()

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -157,8 +157,8 @@
 /* define if leveldb is enabled */
 #cmakedefine WITH_LEVELDB
 
-/* define if radosgw's asio frontend enabled */
-#cmakedefine WITH_RADOSGW_ASIO_FRONTEND
+/* define if radosgw's beast frontend enabled */
+#cmakedefine WITH_RADOSGW_BEAST_FRONTEND
 
 /* define if HAVE_THREAD_SAFE_RES_QUERY */
 #cmakedefine HAVE_THREAD_SAFE_RES_QUERY

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -135,11 +135,11 @@ if (WITH_RADOSGW_FCGI_FRONTEND)
   list(APPEND radosgw_srcs rgw_fcgi_process.cc)
 endif()
 
-if (WITH_RADOSGW_ASIO_FRONTEND)
+if (WITH_RADOSGW_BEAST_FRONTEND)
   list(APPEND radosgw_srcs
     rgw_asio_client.cc
     rgw_asio_frontend.cc)
-endif (WITH_RADOSGW_ASIO_FRONTEND)
+endif (WITH_RADOSGW_BEAST_FRONTEND)
 
 add_library(radosgw_a STATIC ${radosgw_srcs}
   $<TARGET_OBJECTS:civetweb_common_objs>)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -116,11 +116,12 @@ add_dependencies(rgw_a civetweb_h)
 target_include_directories(rgw_a PUBLIC
   "../Beast/include"
   ${FCGI_INCLUDE_DIR})
+target_compile_definitions(rgw_a PUBLIC BOOST_COROUTINES_NO_DEPRECATION_WARNING)
 
 target_link_libraries(rgw_a librados cls_lock_client cls_rgw_client cls_refcount_client
   cls_log_client cls_statelog_client cls_timeindex_client cls_version_client
   cls_replica_log_client cls_user_client ceph-common common_utf8 global
-  ${CURL_LIBRARIES}
+  ${CURL_LIBRARIES} ${Boost_LIBRARIES}
   ${EXPAT_LIBRARIES}
   ${OPENLDAP_LIBRARIES} ${CRYPTO_LIBS})
 

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -4,36 +4,58 @@
 #define RGW_ASIO_CLIENT_H
 
 #include <boost/asio/ip/tcp.hpp>
-#include <beast/http/body_type.hpp>
-#include <beast/http/concepts.hpp>
-#include <beast/http/message_v1.hpp>
+#include <beast/http/message.hpp>
+#include <beast/http/message_parser.hpp>
+#include <beast/core/flat_streambuf.hpp>
 #include "include/assert.h"
 
 #include "rgw_client_io.h"
 
-// bufferlist to represent the message body
-class RGWBufferlistBody {
- public:
-  using value_type = ceph::bufferlist;
+namespace rgw {
+namespace asio {
 
-  class reader;
-  class writer;
+/// streaming message body interface
+struct streaming_body {
+  using value_type = boost::asio::mutable_buffer;
 
-  template <bool isRequest, typename Headers>
-  using message_type = beast::http::message<isRequest, RGWBufferlistBody,
-                                            Headers>;
+  class reader {
+    value_type& buffer;
+   public:
+    using mutable_buffers_type = boost::asio::mutable_buffers_1;
+
+    static const bool is_direct{true}; // reads directly into user buffer
+
+    template<bool isRequest, class Fields>
+    explicit reader(beast::http::message<isRequest, streaming_body, Fields>& m)
+      : buffer(m.body)
+    {}
+
+    void init() {}
+    void init(uint64_t content_length) {}
+    void finish() {}
+
+    mutable_buffers_type prepare(size_t n) {
+      n = std::min(n, boost::asio::buffer_size(buffer));
+      auto position = boost::asio::buffer_cast<char*>(buffer);
+      return {position, n};
+    }
+
+    void commit(size_t n) {
+      buffer = buffer + n;
+    }
+  };
 };
 
-class RGWAsioClientIO : public rgw::io::RestfulClient,
-                        public rgw::io::BuffererSink {
+using header_type = beast::http::fields;
+using parser_type = beast::http::message_parser<true, streaming_body, header_type>;
+
+class ClientIO : public io::RestfulClient,
+                 public io::BuffererSink {
+ private:
   using tcp = boost::asio::ip::tcp;
-  tcp::socket socket;
-
-  using body_type = RGWBufferlistBody;
-  using request_type = beast::http::request_v1<body_type>;
-  request_type request;
-
-  bufferlist::const_iterator body_iter;
+  tcp::socket& socket;
+  parser_type& parser;
+  beast::flat_streambuf& buffer; //< parse buffer
 
   bool conn_keepalive{false};
   bool conn_close{false};
@@ -45,8 +67,11 @@ class RGWAsioClientIO : public rgw::io::RestfulClient,
   size_t read_data(char *buf, size_t max);
 
  public:
-  RGWAsioClientIO(tcp::socket&& socket, request_type&& request);
-  ~RGWAsioClientIO() override;
+  ClientIO(tcp::socket& socket, parser_type& parser,
+           beast::flat_streambuf& buffer);
+  ~ClientIO() override;
+
+  bool get_conn_close() const { return conn_close; }
 
   void init_env(CephContext *cct) override;
   size_t complete_request() override;
@@ -71,45 +96,7 @@ class RGWAsioClientIO : public rgw::io::RestfulClient,
   }
 };
 
-// used by beast::http::read() to read the body into a bufferlist
-class RGWBufferlistBody::reader {
-  value_type& bl;
- public:
-  template<bool isRequest, typename Headers>
-  explicit reader(message_type<isRequest, Headers>& m) : bl(m.body) {}
-
-  void write(const char* data, size_t size, boost::system::error_code&) {
-    bl.append(data, size);
-  }
-};
-
-// used by beast::http::write() to write the buffered body
-class RGWBufferlistBody::writer {
-  const value_type& bl;
- public:
-  template<bool isRequest, typename Headers>
-  explicit writer(const message_type<isRequest, Headers>& msg)
-    : bl(msg.body) {}
-
-  void init(boost::system::error_code& ec) {}
-  uint64_t content_length() const { return bl.length(); }
-
-  template<typename Write>
-  boost::tribool operator()(beast::http::resume_context&&,
-                            boost::system::error_code&, Write&& write) {
-    // translate from bufferlist to a ConstBufferSequence for beast
-    std::vector<boost::asio::const_buffer> buffers;
-    buffers.reserve(bl.get_num_buffers());
-    for (auto& ptr : bl.buffers()) {
-      buffers.emplace_back(ptr.c_str(), ptr.length());
-    }
-    write(buffers);
-    return true;
-  }
-};
-static_assert(beast::http::is_ReadableBody<RGWBufferlistBody>{},
-              "RGWBufferlistBody does not satisfy ReadableBody");
-static_assert(beast::http::is_WritableBody<RGWBufferlistBody>{},
-              "RGWBufferlistBody does not satisfy WritableBody");
+} // namespace asio
+} // namespace rgw
 
 #endif // RGW_ASIO_CLIENT_H

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -7,13 +7,11 @@
 #include <vector>
 
 #include <boost/asio.hpp>
-#include <boost/optional.hpp>
+#include <boost/asio/spawn.hpp>
 
 #include <beast/core/placeholders.hpp>
-#include <beast/core/streambuf.hpp>
-#include <beast/http/empty_body.hpp>
-#include <beast/http/parse_error.hpp>
 #include <beast/http/read.hpp>
+#include <beast/http/string_body.hpp>
 #include <beast/http/write.hpp>
 
 #include "rgw_asio_frontend.h"
@@ -71,28 +69,47 @@ void Pauser::wait()
 
 using tcp = boost::asio::ip::tcp;
 
-class AsioConnection : public std::enable_shared_from_this<AsioConnection> {
-  RGWProcessEnv& env;
-  boost::asio::io_service::strand strand;
-  tcp::socket socket;
-  tcp::endpoint endpoint;
-  beast::streambuf buf;
-  beast::http::request_v1<RGWBufferlistBody> request;
+// coroutine to handle a client connection to completion
+static void handle_connection(RGWProcessEnv& env, tcp::socket socket,
+                              boost::asio::yield_context yield)
+{
+  auto cct = env.store->ctx();
+  boost::system::error_code ec;
 
- public:
-  void on_read(boost::system::error_code ec) {
-    auto cct = env.store->ctx();
-    if (ec) {
-      if (ec.category() == beast::http::get_parse_error_category()) {
-        ldout(cct, 1) << "parse failed: " << ec.message() << dendl;
-      } else {
-        ldout(cct, 1) << "read failed: " << ec.message() << dendl;
-      }
-      write_bad_request();
+  beast::flat_streambuf buffer{1024};
+
+  // read messages from the socket until eof
+  for (;;) {
+    // parse the header
+    rgw::asio::parser_type parser;
+    do {
+      auto bytes = beast::http::async_read_some(socket, buffer, parser, yield[ec]);
+      buffer.consume(bytes);
+    } while (!ec && !parser.got_header());
+
+    if (ec == boost::asio::error::connection_reset ||
+        ec == boost::asio::error::eof) {
       return;
     }
+    if (ec) {
+      auto& message = parser.get();
+      ldout(cct, 1) << "read failed: " << ec.message() << dendl;
+      ldout(cct, 1) << "====== req done http_status=400 ======" << dendl;
+      beast::http::response<beast::http::string_body> response;
+      response.status = 400;
+      response.reason = "Bad Request";
+      response.version = message.version == 10 ? 10 : 11;
+      beast::http::prepare(response);
+      beast::http::async_write(socket, std::move(response), yield[ec]);
+      // ignore ec
+      return;
+    }
+
+    // process the request
     RGWRequest req{env.store->get_new_req_id()};
-    RGWAsioClientIO real_client{std::move(socket), std::move(request)};
+
+    rgw::asio::ClientIO real_client{socket, parser, buffer};
+
     auto real_client_io = rgw::io::add_reordering(
                             rgw::io::add_buffering(
                               rgw::io::add_chunking(
@@ -101,40 +118,12 @@ class AsioConnection : public std::enable_shared_from_this<AsioConnection> {
     RGWRestfulIO client(&real_client_io);
     process_request(env.store, env.rest, &req, env.uri_prefix,
                     *env.auth_registry, &client, env.olog);
-  }
 
-  void write_bad_request() {
-    beast::http::response_v1<beast::http::empty_body> response;
-    response.status = 400;
-    response.reason = "Bad Request";
-    /* If the request is so terribly malformed that we can't extract even
-     * the protocol version, we will use HTTP/1.1 as a fallback. */
-    response.version = request.version ? request.version : 11;
-    beast::http::prepare(response);
-    beast::http::async_write(socket, std::move(response),
-                             std::bind(&AsioConnection::on_write,
-                                       shared_from_this(),
-                                       beast::asio::placeholders::error));
-  }
-
-  void on_write(boost::system::error_code ec) {
-    auto cct = env.store->ctx();
-    if (ec) {
-      ldout(cct, 1) << "write failed: " << ec.message() << dendl;
+    if (real_client.get_conn_close()) {
+      return;
     }
   }
-
- public:
-  AsioConnection(RGWProcessEnv& env, tcp::socket&& socket)
-    : env(env), strand(socket.get_io_service()), socket(std::move(socket))
-  {}
-
-  void read() {
-    beast::http::async_read(socket, buf, request, strand.wrap(
-            std::bind(&AsioConnection::on_read, shared_from_this(),
-                      beast::asio::placeholders::error)));
-  }
-};
+}
 
 class AsioFrontend {
   RGWProcessEnv env;
@@ -168,9 +157,19 @@ int AsioFrontend::init()
   auto ep = tcp::endpoint{tcp::v4(), static_cast<unsigned short>(env.port)};
   ldout(ctx(), 4) << "frontend listening on " << ep << dendl;
 
-  acceptor.open(ep.protocol());
+  boost::system::error_code ec;
+  acceptor.open(ep.protocol(), ec);
+  if (ec) {
+    lderr(ctx()) << "failed to open socket: " << ec.message() << dendl;
+    return -ec.value();
+  }
   acceptor.set_option(tcp::acceptor::reuse_address(true));
-  acceptor.bind(ep);
+  acceptor.bind(ep, ec);
+  if (ec) {
+    lderr(ctx()) << "failed to bind address " << ep <<
+        ": " << ec.message() << dendl;
+    return -ec.value();
+  }
   acceptor.listen(boost::asio::socket_base::max_connections);
   acceptor.async_accept(peer_socket,
                         [this] (boost::system::error_code ec) {
@@ -189,13 +188,15 @@ void AsioFrontend::accept(boost::system::error_code ec)
     throw ec;
   }
   auto socket = std::move(peer_socket);
-
+  // spawn a coroutine to handle the connection
+  boost::asio::spawn(service,
+                     [&] (boost::asio::yield_context yield) {
+                       handle_connection(env, std::move(socket), yield);
+                     });
   acceptor.async_accept(peer_socket,
                         [this] (boost::system::error_code ec) {
                           return accept(ec);
                         });
-
-  std::make_shared<AsioConnection>(env, std::move(socket))->read();
 }
 
 int AsioFrontend::run()

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -53,9 +53,9 @@
 #include "rgw_request.h"
 #include "rgw_process.h"
 #include "rgw_frontend.h"
-#if defined(WITH_RADOSGW_ASIO_FRONTEND)
+#if defined(WITH_RADOSGW_BEAST_FRONTEND)
 #include "rgw_asio_frontend.h"
-#endif /* WITH_RADOSGW_ASIO_FRONTEND */
+#endif /* WITH_RADOSGW_BEAST_FRONTEND */
 
 #include <map>
 #include <string>
@@ -488,9 +488,9 @@ int main(int argc, const char **argv)
 
       fe = new RGWLoadGenFrontend(env, config);
     }
-#if defined(WITH_RADOSGW_ASIO_FRONTEND)
-    else if ((framework == "asio") &&
-	cct->check_experimental_feature_enabled("rgw-asio-frontend")) {
+#if defined(WITH_RADOSGW_BEAST_FRONTEND)
+    else if ((framework == "beast") &&
+	cct->check_experimental_feature_enabled("rgw-beast-frontend")) {
       int port;
       config->get_val("port", 80, &port);
       std::string uri_prefix;
@@ -498,7 +498,7 @@ int main(int argc, const char **argv)
       RGWProcessEnv env{ store, &rest, olog, port, uri_prefix, auth_registry };
       fe = new RGWAsioFrontend(env);
     }
-#endif /* WITH_RADOSGW_ASIO_FRONTEND */
+#endif /* WITH_RADOSGW_BEAST_FRONTEND */
 #if defined(WITH_RADOSGW_FCGI_FRONTEND)
     else if (framework == "fastcgi" || framework == "fcgi") {
       std::string uri_prefix;


### PR DESCRIPTION
tracking an upstream Beast development branch that adds support for streaming reads (see issue https://github.com/vinniefalco/Beast/issues/154)

passes all swift functional tests (which cover chunked encoding), and all s3tests except for 12 that send unreadable header values (some tests expect success, and others expect 403). the beast parser rejects these headers, so we reply with 400 Bad Request. you can run s3tests with the tag `!fails_strict_rfc2616` to skip these

for early review - DNM until the development branch is finalized