### PR TITLE
rgw: rgw_op: remove unused variable iter

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4594,7 +4594,6 @@ void RGWInitMultipart::execute()
   bufferlist aclbl;
   map<string, bufferlist> attrs;
   rgw_obj obj;
-  map<string, string>::iterator iter;
 
   if (get_params() < 0)
     return;


### PR DESCRIPTION
    The variable iter is not used in  RGWInitMultipart::execute().

Signed-off-by: Weibing Zhang <zhangweibing@unitedstack.com>