### PR TITLE
add config option mon_warn_osd_pg_percent to warn that OSD PGS not balance

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -320,6 +320,7 @@ OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL, true) // warn if cru
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL, true) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL, true)
 OPTION(mon_warn_osd_usage_percent, OPT_FLOAT, .40) // warn if difference in usage percent between OSDs exceeds specified percent
+OPTION(mon_warn_osd_pg_percent, OPT_FLOAT, .40) // warn if difference in PGS percent between OSDs exceeds specified percent
 OPTION(mon_min_osdmap_epochs, OPT_INT, 500)
 OPTION(mon_max_pgmap_epochs, OPT_INT, 500)
 OPTION(mon_max_log_epochs, OPT_INT, 500)

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1723,6 +1723,33 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
         detail->push_back(make_pair(HEALTH_WARN, ss.str()));
     }
   }
+  if (g_conf->mon_warn_osd_pg_percent) {
+    int max_osd_pgs = 0, min_osd_pgs = INT_MAX;
+    for (auto p = pg_map.osd_stat.begin(); p != pg_map.osd_stat.end(); ++p) {
+      int pgs = pg_map.get_num_pg_by_osd(p->first);
+	  // PGS of OSD should never be 0, if the OSD up and in, otherwise this WARN should ignore it.
+	  if (0 == pgs)
+        continue;
+      if (pgs > max_osd_pgs)
+        max_osd_pgs = pgs;
+      if (pgs < min_osd_pgs)
+        min_osd_pgs = pgs;
+    }
+
+    if (max_osd_pgs) {
+      float diff_perc = (float)(max_osd_pgs - min_osd_pgs)/max_osd_pgs;
+      if (diff_perc > g_conf->mon_warn_osd_pg_percent) {
+        ostringstream ss;
+        ss.precision(1);
+        //avoid scientific
+        ss.setf(std::ios::fixed);
+        ss << "Difference in max osd pgs and min osd pgs " << (diff_perc *100) << "% greater than " << (g_conf->mon_warn_osd_pg_percent * 100) << "%";
+        summary.push_back(make_pair(HEALTH_WARN, ss.str()));
+        if (detail)
+          detail->push_back(make_pair(HEALTH_WARN, ss.str()));
+      }
+    }
+  }
 
   // recovery
   list<string> sl;


### PR DESCRIPTION
add config option mon_warn_osd_pg_percent to tell that OSD PGS not balance, if on_warn_osd_pg_percent is configured 0.0(default is 0.4, which is 40%), than the warn will not work, otherwise if the difference percentage between max OSD PGS and min OSD PGS exceeds mon_warn_osd_pg_percent than the warn will be showed to user.  

Signed-off-by: mychoxin <mychoxin@gmail.com>