### PR TITLE
osd: OSDMap-Replaced pointers with references

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1262,7 +1262,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 
     if (tmp.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
       int full, nearfull;
-      tmp.count_full_nearfull_osds(&full, &nearfull);
+      tmp.count_full_nearfull_osds(full, nearfull);
       if (full > 0) {
 	if (!tmp.test_flag(CEPH_OSDMAP_FULL)) {
 	  dout(10) << __func__ << " setting full flag" << dendl;
@@ -3523,7 +3523,7 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
 
     if (osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
       int full, nearfull;
-      osdmap.count_full_nearfull_osds(&full, &nearfull);
+      osdmap.count_full_nearfull_osds(full, nearfull);
       if (full > 0) {
 	ostringstream ss;
 	ss << full << " full osds(s)";

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1022,16 +1022,16 @@ int OSDMap::calc_num_osds()
   return num_osd;
 }
 
-void OSDMap::count_full_nearfull_osds(int *full, int *nearfull) const
+void OSDMap::count_full_nearfull_osds(int& full, int& nearfull) const
 {
-  *full = 0;
-  *nearfull = 0;
+  full = 0;
+  nearfull = 0;
   for (int i = 0; i < max_osd; ++i) {
     if (exists(i) && is_up(i) && is_in(i)) {
       if (osd_state[i] & CEPH_OSD_FULL)
-	++(*full);
+	++full;
       else if (osd_state[i] & CEPH_OSD_NEARFULL)
-	++(*nearfull);
+	++nearfull;
     }
   }
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -339,7 +339,7 @@ public:
   float get_nearfull_ratio() const {
     return nearfull_ratio;
   }
-  void count_full_nearfull_osds(int *full, int *nearfull) const;
+  void count_full_nearfull_osds(int&, int&) const;
 
   /***** cluster state *****/
   /* osds */


### PR DESCRIPTION
Replaced the old C-Style pointers with references for the function count_full_nearfull_osds()
in OSDMap. Updated it's usage in OSDMonitor.cc too.

Signed-off-by: Jos Collin <jcollin@redhat.com>