### PR TITLE
tools: warning, ‘%.16x’ directive output truncated writing 16 bytes into a region of size 9.

### DIFF
--- a/src/tools/radosacl.cc
+++ b/src/tools/radosacl.cc
@@ -151,7 +151,7 @@ int main(int argc, const char **argv)
 
   ACLID id;
 
-  snprintf(id.id, ID_SIZE + 1, "%.16x", 0x1234);
+  snprintf(id.id, sizeof(id.id), "%.8x", 0x1234);
   cout << "id=" << id.id << std::endl;
 
   r = io_ctx.exec(oid, "acl", "get", bl, bl2);


### PR DESCRIPTION
The following warning appears during make.

    radosacl.cc:122:5: warning: ‘%.16x’ directive output truncated writing 16 bytes into a region of size 9 [-Wformat-truncation=]
     int main(int argc, const char **argv)
         ^~~~
                     from ./src/tools/radosacl.cc:19:
    /usr/include/bits/stdio2.h:65:44: note: ‘__builtin___snprintf_chk’ output 17 bytes into a destination of size 9
            __bos (__s), __fmt, __va_arg_pack ());

Signed-off-by: Jos Collin <jcollin@redhat.com>