### PR TITLE
mon/OSDMonitor: check last_osd_report only when the whole cluster is lu…

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3303,8 +3303,13 @@ void OSDMonitor::tick()
   bool do_propose = false;
   utime_t now = ceph_clock_now();
 
-  if (handle_osd_timeouts(now, last_osd_report))
-    do_propose = true;
+  if (osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS) &&
+      mon->monmap->get_required_features().contains_all(
+	ceph::features::mon::FEATURE_LUMINOUS)) {
+    if (handle_osd_timeouts(now, last_osd_report)) {
+      do_propose = true;
+    }
+  }
 
   // mark osds down?
   if (check_failures(now))


### PR DESCRIPTION
…minous

if a peon is not luminous, it won't forward the beacon message. if any
OSD is not luminous, it won't report to mon with beacon messages. so, we
can trust the OSDMonitor::last_osd_report only if the whole cluster is
luminous.

Signed-off-by: Kefu Chai <kchai@redhat.com>