### PR TITLE
script: drop the -x arg for credits script

### DIFF
--- a/src/script/credits.sh
+++ b/src/script/credits.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -x
+#!/bin/sh
 
 range="$1"
 TMP=/tmp/credits


### PR DESCRIPTION
while useful for debugging creates a whole lot of output which we don't
need normally

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>