### PR TITLE
build: Add Virtuozzo Linux support

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -89,7 +89,7 @@ else
 	$SUDO env DEBIAN_FRONTEND=noninteractive apt-get -y remove ceph-build-deps
 	if [ -n "$backports" ] ; then rm $control; fi
         ;;
-    centos|fedora|rhel|ol)
+    centos|fedora|rhel|ol|virtuozzo)
         yumdnf="yum"
         builddepcmd="yum-builddep -y"
         if test "$(echo "$VERSION_ID >= 22" | bc)" -ne 0; then
@@ -104,7 +104,7 @@ else
                     $SUDO $yumdnf install -y yum-utils
                 fi
                 ;;
-            CentOS|RedHatEnterpriseServer)
+            CentOS|RedHatEnterpriseServer|VirtuozzoLinux)
                 $SUDO yum install -y yum-utils
                 MAJOR_VERSION=$(lsb_release -rs | cut -f1 -d.)
                 if test $(lsb_release -si) = RedHatEnterpriseServer ; then
@@ -116,6 +116,9 @@ else
                 $SUDO rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-$MAJOR_VERSION
                 $SUDO rm -f /etc/yum.repos.d/dl.fedoraproject.org*
                 if test $(lsb_release -si) = CentOS -a $MAJOR_VERSION = 7 ; then
+                    $SUDO yum-config-manager --enable cr
+                fi
+                if test $(lsb_release -si) = VirtuozzoLinux -a $MAJOR_VERSION = 7 ; then
                     $SUDO yum-config-manager --enable cr
                 fi
                 ;;

--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -76,6 +76,7 @@ def _get_distro(distro, use_rhceph=False):
         'exherbo': gentoo,
         'freebsd': freebsd,
         'docker': docker,
+        'virtuozzo': centos,
     }
 
     if distro == 'redhat' and use_rhceph:
@@ -100,6 +101,8 @@ def _normalized_distro_name(distro):
         return 'oraclevms'
     elif distro.startswith(('gentoo', 'funtoo', 'exherbo')):
         return 'gentoo'
+    elif distro.startswith('virtuozzo'):
+        return 'virtuozzo'
     return distro
 
 
@@ -160,6 +163,9 @@ def platform_information():
         codename = 'OL' + release
     elif distro_lower.startswith('oracle vm'):
         codename = 'OVS' + release
+    # this could be an empty string in Virtuozzo linux
+    elif distro_lower.startswith('virtuozzo linux'):
+        codename = 'virtuozzo'
 
     return (
         str(distro).rstrip(),

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -217,6 +217,7 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual(suse, g('suse'))
         self.assertEqual(rhel, g('redhat', use_rhceph=True))
         self.assertEqual(gentoo, g('gentoo'))
+        self.assertEqual(centos, g('virtuozzo'))
 
     def test_normalized_distro_name(self):
         n = ceph_detect_init._normalized_distro_name
@@ -246,6 +247,7 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('gentoo', n('funtoo'))
         self.assertEqual('gentoo', n('Exherbo'))
         self.assertEqual('gentoo', n('exherbo'))
+        self.assertEqual('virtuozzo', n('Virtuozzo Linux'))
 
     @mock.patch('platform.system', lambda: 'Linux')
     def test_platform_information_linux(self):
@@ -282,6 +284,11 @@ class TestCephDetectInit(testtools.TestCase):
         with mock.patch('platform.linux_distribution',
                         lambda **kwargs: (('Oracle VM server', '3.4.2', ''))):
             self.assertEqual(('Oracle VM server', '3.4.2', 'OVS3.4.2'),
+                             ceph_detect_init.platform_information())
+
+        with mock.patch('platform.linux_distribution',
+                        lambda **kwargs: (('Virtuozzo Linux', '7.3', ''))):
+            self.assertEqual(('Virtuozzo Linux', '7.3', 'virtuozzo'),
                              ceph_detect_init.platform_information())
 
     @mock.patch('platform.linux_distribution')

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -542,6 +542,9 @@ def platform_information():
                     codename = minor
                 else:
                     codename = major
+        # this could be an empty string in Virtuozzo linux
+        if not codename and 'virtuozzo linux' in distro.lower():
+            codename = 'virtuozzo'
 
     return (
         str(distro).strip(),


### PR DESCRIPTION
Virtuozzo Linux based on CentOS and got the same major release number and empty codename.

NAME="VirtuozzoLinux"
VERSION="7"
ID="virtuozzo"
ID_LIKE="rhel fedora"
VERSION_ID="7"
PRETTY_NAME="VirtuozzoLinux"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:virtuozzoproject:vz:7"
HOME_URL="http://www.virtuozzo.com"
BUG_REPORT_URL="https://bugs.openvz.org/"

import platform
platform.linux_distribution()
('Virtuozzo Linux', '7.3', '')