### PR TITLE
tracing: fix segv

### DIFF
--- a/src/common/TracepointProvider.cc
+++ b/src/common/TracepointProvider.cc
@@ -39,7 +39,7 @@ void TracepointProvider::verify_config(const struct md_config_t *conf) {
     return;
   }
 
-  m_handle = dlopen(m_library.c_str(), RTLD_NOW);
+  m_handle = dlopen(m_library.c_str(), RTLD_NOW | RTLD_NODELETE);
   assert(m_handle);
 }
 


### PR DESCRIPTION
Refer to http://lttng.org/docs/v2.9/ on dlclose side effects. Workaround is to use
RTLD_NODELETE flag when calling dlopen.

Signed-off-by: Anjaneya Chagam <anjaneya.chagam@intel.com>