### PR TITLE
common/simple_spin: use __ppc_yield() on all powerpc archs

### DIFF
--- a/src/common/simple_spin.cc
+++ b/src/common/simple_spin.cc
@@ -32,7 +32,7 @@ void simple_spin_lock(simple_spinlock_t *lock)
     asm volatile("pause");
 #elif defined(__arm__) || defined(__aarch64__)
     asm volatile("yield");
-#elif defined(__ppc64__)
+#elif defined(__powerpc__) || defined(__ppc__)
     asm volatile("or 27,27,27");
 #else
 #error "Unknown architecture"


### PR DESCRIPTION
__ppc_yield() is declared in sys/platform/ppc.h by glibc, for better
portability we just use the inlined assembly here. the shared resource
hints are supported by PowerPC ISA 2.06 but on older PowerPC cores, they
are no-ops. so it's fine to do this way.

Signed-off-by: Kefu Chai <kchai@redhat.com>