### PR TITLE
DNM: rgw: Fix Clang error on constexpr

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -402,7 +402,7 @@ protected:
     const std::string path;
   };
 
-  static constexpr std::initializer_list<int> terminal_errors = {
+  static std::initializer_list<int> terminal_errors = {
     -EACCES, -EPERM
   };
 


### PR DESCRIPTION
- Error is:
/home/jenkins/workspace/ceph-master/src/rgw/rgw_op.h:405:47: error: constexpr variable cannot have non-literal type 'const std::
initializer_list<int>'
  static constexpr std::initializer_list<int> terminal_errors = {
                                              ^
/usr/include/c++/v1/initializer_list:59:29: note: 'initializer_list<int>' is not literal because it is not an aggregate and has
no constexpr constructors other than copy or move constructors

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>