### PR TITLE
rgw: switch to std::array in RGWBulkUploadOp due to C++11 and FreeBSD.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5499,7 +5499,7 @@ void RGWBulkDelete::execute()
 }
 
 
-constexpr std::initializer_list<int> RGWBulkUploadOp::terminal_errors;
+constexpr std::array<int, 2> RGWBulkUploadOp::terminal_errors;
 
 int RGWBulkUploadOp::verify_permission()
 {

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -13,6 +13,7 @@
 
 #include <limits.h>
 
+#include <array>
 #include <memory>
 #include <string>
 #include <set>
@@ -402,8 +403,8 @@ protected:
     const std::string path;
   };
 
-  static constexpr std::initializer_list<int> terminal_errors = {
-    -EACCES, -EPERM
+  static constexpr std::array<int, 2> terminal_errors = {
+    { -EACCES, -EPERM }
   };
 
   /* FIXME:  boost::container::small_vector<fail_desc_t, 4> failures; */


### PR DESCRIPTION
Before this patch `RGWBulkUploadOp::terminal_errors` was declared as `std::initializer_list<int>`. Unfortunately, a `constexpr` constructor for it is available since C++14, not C++11. This was causing build failures on FreeBSD.

Tempest confirms the BulkUpload is operational:
```
$ ./run_tempest.sh -V tempest.api.object_storage.test_account_bulk.BulkTest
WARNING: This script is deprecated and will be removed in the near future. Please migrate to tempest run or another method of launching a test runner
running=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-500} \
OS_TEST_LOCK_PATH=${OS_TEST_LOCK_PATH:-${TMPDIR:-'/tmp'}} \
${PYTHON:-python} -m subunit.run discover -t ${OS_TOP_LEVEL:-./} ${OS_TEST_PATH:-./tempest/test_discover} --list 
running=OS_STDOUT_CAPTURE=${OS_STDOUT_CAPTURE:-1} \
OS_STDERR_CAPTURE=${OS_STDERR_CAPTURE:-1} \
OS_TEST_TIMEOUT=${OS_TEST_TIMEOUT:-500} \
OS_TEST_LOCK_PATH=${OS_TEST_LOCK_PATH:-${TMPDIR:-'/tmp'}} \
${PYTHON:-python} -m subunit.run discover -t ${OS_TOP_LEVEL:-./} ${OS_TEST_PATH:-./tempest/test_discover}  --load-list /tmp/tmp491EMe
{0} tempest.api.object_storage.test_account_bulk.BulkTest.test_bulk_delete [4.409547s] ... ok
{0} tempest.api.object_storage.test_account_bulk.BulkTest.test_bulk_delete_by_POST [0.158442s] ... ok
{0} tempest.api.object_storage.test_account_bulk.BulkTest.test_extract_archive [0.083129s] ... ok

======
Totals
======
Ran: 3 tests in 8.0000 sec.
 - Passed: 3
 - Skipped: 0
 - Expected Fail: 0
 - Unexpected Success: 0
 - Failed: 0
Sum of execute time for each test: 4.6511 sec.

==============
Worker Balance
==============
 - Worker 0 (3 tests) => 0:00:04.661215
```

@wjwithagen: could you please verify whether this patch helps FreeBSD? I'm marking it as *DNM* for now.

CC: @oritwas