### PR TITLE
kraken: build/ops: spec file mentions non-existent ceph-create-keys systemd unit file, causing ceph-mon units to not be enabled via preset

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1114,7 +1114,7 @@ fi
 %post mon
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
-  /usr/bin/systemctl preset ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target >/dev/null 2>&1 || :
+  /usr/bin/systemctl preset ceph-mon@\*.service ceph-mon.target >/dev/null 2>&1 || :
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1118,7 +1118,7 @@ if [ $1 -eq 1 ] ; then
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_post ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_post ceph-mon@\*.service ceph-mon.target
 %endif
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-mon.target >/dev/null 2>&1 || :
@@ -1126,20 +1126,20 @@ fi
 
 %preun mon
 %if 0%{?suse_version}
-%service_del_preun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%service_del_preun ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_preun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_preun ceph-mon@\*.service ceph-mon.target
 %endif
 
 %postun mon
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%service_del_postun ceph-mon@\*.service ceph-mon.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_postun ceph-create-keys@\*.service ceph-mon@\*.service ceph-mon.target
+%systemd_postun ceph-mon@\*.service ceph-mon.target
 %endif
 if [ $FIRST_ARG -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
@@ -1149,7 +1149,7 @@ if [ $FIRST_ARG -ge 1 ] ; then
     source $SYSCONF_CEPH
   fi
   if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
-    /usr/bin/systemctl try-restart ceph-create-keys@\*.service ceph-mon@\*.service > /dev/null 2>&1 || :
+    /usr/bin/systemctl try-restart ceph-mon@\*.service > /dev/null 2>&1 || :
   fi
 fi
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/19460