### PR TITLE
os/bluestore: fsck: verify blob.unused field

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1784,6 +1784,11 @@ bool BlueStore::Blob::try_reuse_blob(uint32_t min_alloc_size,
       return false;
     }
 
+    // FIXME: in some cases we could reduce unused resolution
+    if (get_blob().has_unused()) {
+      return false;
+    }
+
     if (overflow > 0) {
       new_blen -= overflow;
       length -= overflow;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -9120,11 +9120,12 @@ int BlueStore::_do_alloc_write(
                                            wi.length0,
                                            wi.b,
                                            nullptr);
+    wi.b->dirty_blob().mark_used(le->blob_offset, le->length);
     txc->statfs_delta.stored() += le->length;
     dout(20) << __func__ << "  lex " << *le << dendl;
     _buffer_cache_write(txc, wi.b, b_off, wi.bl,
                         wctx->buffered ? 0 : Buffer::FLAG_NOCACHE);
-    
+
     // queue io
     if (!g_conf->bluestore_debug_omit_block_device_write) {
       if (l->length() <= prefer_deferred_size) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5173,7 +5173,7 @@ int BlueStore::fsck(bool deep)
 	}
       }
       // lextents
-      map<BlobRef,uint16_t> referenced;
+      map<BlobRef,bluestore_blob_t::unused_t> referenced;
       uint64_t pos = 0;
       map<BlobRef, bluestore_blob_use_tracker_t> ref_map;
       for (auto& l : o->extent_map.extent_map) {
@@ -5209,7 +5209,7 @@ int BlueStore::fsck(bool deep)
 	++num_extents;
 	if (blob.has_unused()) {
 	  auto p = referenced.find(l.blob);
-	  uint16_t *pu;
+	  bluestore_blob_t::unused_t *pu;
 	  if (p == referenced.end()) {
 	    pu = &referenced[l.blob];
 	  } else {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8806,7 +8806,8 @@ void BlueStore::_do_write_small(
                  << std::dec << dendl;
 
         o->extent_map.punch_hole(c, offset, length, &wctx->old_extents);
-	wctx->write(offset, b, alloc_len, b_off0, padded, b_off, length, false, false);
+	wctx->write(offset, b, alloc_len, b_off0, padded, b_off, length,
+		    false, false);
         logger->inc(l_bluestore_write_small_unused);
         return;
       }
@@ -8879,7 +8880,7 @@ void BlueStore::_do_write_big(
 	    b_off = offset - ep->blob_start();
             prev_ep = end; // to avoid check below
 	    dout(20) << __func__ << " reuse blob " << *b << std::hex
-	      << " (" << b_off << "~" << l << ")" << std::dec << dendl;
+		     << " (" << b_off << "~" << l << ")" << std::dec << dendl;
 	  } else {
 	    ++ep;
 	    any_change = true;
@@ -8893,7 +8894,7 @@ void BlueStore::_do_write_big(
 	    b = prev_ep->blob;
 	    b_off = offset - prev_ep->blob_start();
 	    dout(20) << __func__ << " reuse blob " << *b << std::hex
-	      << " (" << b_off << "~" << l << ")" << std::dec << dendl;
+		     << " (" << b_off << "~" << l << ")" << std::dec << dendl;
 	  } else if (prev_ep != begin) {
 	    --prev_ep;
 	    any_change = true;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -863,6 +863,7 @@ public:
   }
   void add_tail(uint32_t new_len) {
     assert(is_mutable());
+    assert(!has_unused());
     assert(new_len > logical_length);
     extents.emplace_back(
       bluestore_pextent_t(
@@ -872,9 +873,10 @@ public:
     if (has_csum()) {
       bufferptr t;
       t.swap(csum_data);
-      csum_data = buffer::create(get_csum_value_size() * logical_length / get_csum_chunk_size());
+      csum_data = buffer::create(
+	get_csum_value_size() * logical_length / get_csum_chunk_size());
       csum_data.copy_in(0, t.length(), t.c_str());
-      csum_data.zero( t.length(), csum_data.length() - t.length());
+      csum_data.zero(t.length(), csum_data.length() - t.length());
     }
   }
   uint32_t get_release_size(uint32_t min_alloc_size) const {

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -494,7 +494,8 @@ public:
 
   uint32_t flags = 0;                 ///< FLAG_*
 
-  uint16_t unused = 0;     ///< portion that has never been written to (bitmap)
+  typedef uint16_t unused_t;
+  unused_t unused = 0;     ///< portion that has never been written to (bitmap)
 
   uint8_t csum_type = Checksummer::CSUM_NONE;      ///< CSUM_*
   uint8_t csum_chunk_order = 0;       ///< csum block size is 1<<block_order bytes


### PR DESCRIPTION
Two checks:

- verify that no logical extents reference the portion of the
  blob marked unused, and
- verify that the csum (if present) is zero for any unused
  region.

And a few fixes to the blob reuse code that the checks turn up!