### PR TITLE
rgw: switch from "timegm()" to "internal_timegm()" for better portability

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -219,7 +219,7 @@ bool rgw_create_s3_canonical_header(const req_info& info,
         dout(0) << "NOTICE: bad date (predates epoch): " << req_date << dendl;
         return false;
       }
-      *header_time = utime_t(timegm(&t), 0);
+      *header_time = utime_t(internal_timegm(&t), 0);
     }
   }
 

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -479,7 +479,7 @@ int parse_time(const char *time_str, real_time *time)
     return -EINVAL;
   }
 
-  time_t sec = timegm(&tm);
+  time_t sec = internal_timegm(&tm);
   *time = utime_t(sec, ns).to_real_time();
 
   return 0;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1951,7 +1951,7 @@ struct bucket_list_entry {
     uint32_t nsec;
     if (parse_iso8601(mtime_str.c_str(), &t, &nsec)) {
       ceph_timespec ts;
-      ts.tv_sec = (uint64_t)timegm(&t);
+      ts.tv_sec = (uint64_t)internal_timegm(&t);
       ts.tv_nsec = nsec;
       mtime = real_clock::from_ceph_timespec(ts);
     }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1170,7 +1170,7 @@ void rgw::keystone::TokenEnvelope::Token::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("expires", expires_iso8601, obj, true);
 
   if (parse_iso8601(expires_iso8601.c_str(), &t)) {
-    expires = timegm(&t);
+    expires = internal_timegm(&t);
   } else {
     expires = 0;
     throw JSONDecoder::err("Failed to parse ISO8601 expiration date from Keystone response.");
@@ -1215,7 +1215,7 @@ void rgw::keystone::TokenEnvelope::decode_v3(JSONObj* const root_obj)
 
   struct tm t;
   if (parse_iso8601(expires_iso8601.c_str(), &t)) {
-    token.expires = timegm(&t);
+    token.expires = internal_timegm(&t);
   } else {
     token.expires = 0;
     throw JSONDecoder::err("Failed to parse ISO8601 expiration date"

--- a/src/rgw/rgw_policy_s3.cc
+++ b/src/rgw/rgw_policy_s3.cc
@@ -130,7 +130,7 @@ int RGWPolicy::set_expires(const string& e)
   if (!parse_iso8601(e.c_str(), &t))
       return -EINVAL;
 
-  expires = timegm(&t);
+  expires = internal_timegm(&t);
 
   return 0;
 }

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3468,7 +3468,7 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s, bool force_b
         return -EPERM;
       }
       /* handle expiration in epoch time */
-      now_req = (uint64_t)timegm(&date_t);
+      now_req = (uint64_t)internal_timegm(&date_t);
       if (now >= now_req + exp) {
         dout(10) << "NOTICE: now = " << now << ", now_req = " << now_req << ", exp = " << exp << dendl;
         return -EPERM;


### PR DESCRIPTION
rebase of https://github.com/ceph/ceph/pull/12600