### PR TITLE
radosgw-admin: use zone id when creating a zone

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3737,7 +3737,7 @@ int main(int argc, const char **argv)
 	  }
 	}
 
-	RGWZoneParams zone(zone_name);
+	RGWZoneParams zone(zone_id, zone_name);
 	ret = zone.init(g_ceph_context, store, false);
 	if (ret < 0) {
 	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19498
Signed-off-by: Orit Wasserman <owasserm@redhat.com>