### PR TITLE
rgw: respect Swift's negative, HTTP referer-based ACL grants.

### DIFF
--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -71,27 +71,26 @@ uint32_t RGWAccessControlList::get_group_perm(ACLGroupTypeEnum group,
   return 0;
 }
 
-uint32_t RGWAccessControlList::get_referer_perm(const std::string http_referer,
+uint32_t RGWAccessControlList::get_referer_perm(const uint32_t current_perm,
+                                                const std::string http_referer,
                                                 const uint32_t perm_mask)
 {
   ldout(cct, 5) << "Searching permissions for referer=" << http_referer
                 << " mask=" << perm_mask << dendl;
 
-  /* FIXME: C++11 doesn't have std::rbegin nor std::rend. We would like to
-   * switch when C++14 becomes available. */
-  const auto iter = std::find_if(referer_list.crbegin(), referer_list.crend(),
-    [&http_referer](const ACLReferer& r) -> bool {
-      return r.is_match(http_referer);
+  /* This function is bacically a transformation from current perm to
+   * a new one that takes into consideration the Swift's HTTP referer-
+   * based ACLs. We need to go through all items to respect negative
+   * grants. */
+  uint32_t referer_perm = current_perm;
+  for (const auto& r : referer_list) {
+    if (r.is_match(http_referer)) {
+       referer_perm = r.perm;
     }
-  );
-
-  if (referer_list.crend() == iter) {
-    ldout(cct, 5) << "Permissions for referer not found" << dendl;
-    return 0;
-  } else {
-    ldout(cct, 5) << "Found referer permission=" << iter->perm << dendl;
-    return iter->perm & perm_mask;
   }
+
+  ldout(cct, 5) << "Found referer permission=" << referer_perm << dendl;
+  return referer_perm & perm_mask;
 }
 
 uint32_t RGWAccessControlPolicy::get_perm(const rgw::auth::Identity& auth_identity,
@@ -123,7 +122,7 @@ uint32_t RGWAccessControlPolicy::get_perm(const rgw::auth::Identity& auth_identi
 
   /* Should we continue looking up even deeper? */
   if (nullptr != http_referer && (perm & perm_mask) != perm_mask) {
-    perm |= acl.get_referer_perm(http_referer, perm_mask);
+    perm = acl.get_referer_perm(perm, http_referer, perm_mask);
   }
 
   ldout(cct, 5) << "-- Getting permissions done for identity=" << auth_identity

--- a/src/rgw/rgw_acl.cc
+++ b/src/rgw/rgw_acl.cc
@@ -24,6 +24,12 @@ void RGWAccessControlList::_add_grant(ACLGrant *grant)
   switch (type.get_type()) {
   case ACL_TYPE_REFERER:
     referer_list.emplace_back(grant->get_referer(), perm.get_permissions());
+
+    /* We're specially handling the Swift's .r:* as the S3 API has a similar
+     * concept and thus we can have a small portion of compatibility here. */
+     if (grant->get_referer() == RGW_REFERER_WILDCARD) {
+       acl_group_map[ACL_GROUP_ALL_USERS] |= perm.get_permissions();
+     }
     break;
   case ACL_TYPE_GROUP:
     acl_group_map[grant->get_group()] |= perm.get_permissions();

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -29,6 +29,8 @@ using namespace std;
 #define RGW_PERM_ALL_S3          RGW_PERM_FULL_CONTROL
 #define RGW_PERM_INVALID         0xFF00
 
+static constexpr char RGW_REFERER_WILDCARD[] = "*";
+
 enum ACLGranteeTypeEnum {
 /* numbers are encoded, should not change */
   ACL_TYPE_CANON_USER = 0,
@@ -221,6 +223,10 @@ struct ACLReferer {
     const auto http_host = get_http_host(http_referer);
     if (!http_host || http_host->length() < url_spec.length()) {
       return false;
+    }
+
+    if ("*" == url_spec) {
+      return true;
     }
 
     if (http_host->compare(url_spec) == 0) {

--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -302,7 +302,9 @@ public:
   uint32_t get_perm(const rgw::auth::Identity& auth_identity,
                     uint32_t perm_mask);
   uint32_t get_group_perm(ACLGroupTypeEnum group, uint32_t perm_mask);
-  uint32_t get_referer_perm(const std::string http_referer, uint32_t perm_mask);
+  uint32_t get_referer_perm(uint32_t current_perm,
+                            std::string http_referer,
+                            uint32_t perm_mask);
   void encode(bufferlist& bl) const {
     ENCODE_START(4, 3, bl);
     bool maps_initialized = true;

--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -90,11 +90,7 @@ static boost::optional<ACLGrant> referrer_to_grant(std::string url_spec,
       is_negative = false;
     }
 
-    /* We're specially handling the .r:* as the S3 API has a similar concept
-     * and thus we can have a small portion of compatibility here. */
-    if (url_spec == "*") {
-      grant.set_group(ACL_GROUP_ALL_USERS, is_negative ? 0 : perm);
-    } else {
+    if (url_spec != RGW_REFERER_WILDCARD) {
       if ('*' == url_spec[0]) {
         url_spec = url_spec.substr(1);
         boost::algorithm::trim(url_spec);
@@ -103,10 +99,13 @@ static boost::optional<ACLGrant> referrer_to_grant(std::string url_spec,
       if (url_spec.empty() || url_spec == ".") {
         return boost::none;
       }
-
-      grant.set_referer(url_spec, is_negative ? 0 : perm);
+    } else {
+      /* Please be aware we're specially handling the .r:* in _add_grant()
+       * of RGWAccessControlList as the S3 API has a similar concept, and
+       * thus we can have a small portion of compatibility. */
     }
 
+    grant.set_referer(url_spec, is_negative ? 0 : perm);
     return grant;
   } catch (std::out_of_range) {
     return boost::none;


### PR DESCRIPTION
~~For the sake of simplicity and compatibility with S3's ACLs, this patch doesn't handle the case of having multiple `.r:*` in an ACL like:~~
```
  .r:*,.r:-.example.com,.r:*
```
~~`.r:*` is handled specifically because of S3. In the future we can get full support by parsing the whole acl grant map.~~

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>