### PR TITLE
mds: make C_MDSInternalNoop::complete() delete 'this'

### DIFF
--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -131,12 +131,12 @@ public:
 /**
  * No-op for callers expecting MDSInternalContextBase
  */
-class C_MDSInternalNoop : public MDSInternalContextBase
+class C_MDSInternalNoop final : public MDSInternalContextBase
 {
   MDSRank* get_mds() override {ceph_abort();}
 public:
   void finish(int r) override {}
-  void complete(int r) override {}
+  void complete(int r) override { delete this; }
 };
 
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19501
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>