### PR TITLE
common: event trace lttng enhancement

### DIFF
--- a/src/common/EventTrace.cc
+++ b/src/common/EventTrace.cc
@@ -1,4 +1,3 @@
-// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
@@ -18,10 +17,13 @@
 #include "common/EventTrace.h"
 #include "common/dout.h"
 #include "common/TracepointProvider.h"
+#include "common/perf_counters.h"
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
+#include "include/str_list.h"
 #include <iostream>
 #include <string>
+#include <atomic>
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -33,21 +35,59 @@
 #define tracepoint(...)
 #endif
 
+enum {
+  l_eventtrace_first = 90000,
+};
+
 TracepointProvider::Traits event_tracepoint_traits("libeventtrace_tp.so", "event_tracing");
-bool EventTrace::tpinit = false;
 
-void EventTrace::init_tp(CephContext *_ctx)
+PerfCounters* EventTrace::m_logger = nullptr;
+std::atomic<bool> EventTrace::m_init(false);
+std::map<std::string, int> EventTrace::m_counters;
+
+bool EventTrace::init(CephContext *cct)
 {
-  if (unlikely(!_ctx))
-    return;
+  if (unlikely(!cct)) return false;
+  if (likely(m_init)) return true; 
 
-  if (unlikely(!tpinit)) {
-    TracepointProvider::initialize<event_tracepoint_traits>(_ctx);
-    tpinit = true;
+  if (!m_init.exchange(true)) {
+
+    TracepointProvider::initialize<event_tracepoint_traits>(cct);
+
+    // we will only check once and if passed context doesn't have _conf 
+    // initialized this will never turn on performance counters
+    if (cct->_conf) { 
+      char *buf = NULL;
+      int r = cct->_conf->get_val("event_tracing_perf_counters", &buf, -1);
+      assert(r >= 0);
+      string str(buf);
+      free(buf);
+      std::vector<string> str_vec;
+      get_str_vec(str, str_vec);
+      int index = l_eventtrace_first;
+      PerfCountersBuilder b(cct, "event_trace", l_eventtrace_first, l_eventtrace_first+str_vec.size()+1);
+      for (auto it=str_vec.begin(); it != str_vec.end(); ++it) {
+        ++index;
+        lsubdout(cct, eventtrace, LOG_LEVEL) << "Adding counter [" << index << "] = " << *it << dendl;
+        m_counters[*it] = index;
+      }
+  
+      // Note: add_u64 perf_counter_data_any_d.name points to passed name string pointer, 
+      // so string needs to be of global scope
+      for (auto it = m_counters.begin(); it != m_counters.end(); ++it)
+        b.add_time_avg(it->second, it->first.c_str(), "event latency");
+
+      m_logger = b.create_perf_counters();
+      cct->get_perfcounters_collection()->add(m_logger);
+    }
+    return true;
+  }
+  else {
+    return false; // being initialized by other thread
   }
 }
 
-void EventTrace::set_message_attrs(const Message *m, string& oid, string& context, bool incl_oid)
+void EventTrace::set_message_attrs(const Message *m, string& oid, string& evctx, bool incl_oid)
 {
   // arg1 = oid, arg2 = message type, arg3 = source!source_addr!tid!sequence
   if (m && (m->get_type() == CEPH_MSG_OSD_OP || m->get_type() == CEPH_MSG_OSD_OPREPLY)) {
@@ -61,71 +101,90 @@ void EventTrace::set_message_attrs(const Message *m, string& oid, string& contex
     ostringstream buf;
     buf << m->get_source() << "!" << m->get_source_addr() << "!"
         << m->get_tid() << "!" << m->get_seq() << "!" << m->get_type();;
-    context = buf.str();
+    evctx = buf.str();
   }
 }
 
-EventTrace::EventTrace(CephContext *_ctx, const char *_file, const char *_func, int _line) :
-  ctx(_ctx),
-  file(_file),
-  func(_func),
-  line(_line)
+EventTrace::EventTrace(CephContext *cct, const char *file, const char *func, int line) :
+  m_cct(cct), m_file(file), m_func(func), m_line(line)
 {
-  if (unlikely(!ctx)) 
-    return;
-  last_ts = ceph_clock_now();
-  init_tp(ctx);
-
-  lsubdout(ctx, eventtrace, LOG_LEVEL) << "ENTRY (" <<  func << ") " << file << ":" << line << dendl;
-  tracepoint(eventtrace, func_enter, file.c_str(), func.c_str(), line);
+  m_func_enter_ts = m_last_event_ts = ceph_clock_now();
+  if (unlikely(!init(m_cct))) return;
+  lsubdout(m_cct, eventtrace, LOG_LEVEL) << "ENTRY (" <<  m_func << ") " << m_file << ":" << m_line << dendl;
+  tracepoint(eventtrace, func_enter, m_file.c_str(), m_func.c_str(), m_line);
 }
 
 EventTrace::~EventTrace()
 {
-  if (unlikely(!ctx)) 
-    return;
-  lsubdout(ctx, eventtrace, LOG_LEVEL) << "EXIT (" << func << ") " << file << dendl;
-  tracepoint(eventtrace, func_exit, file.c_str(), func.c_str());
+  if (unlikely(!init(m_cct))) return;
+  lsubdout(m_cct, eventtrace, LOG_LEVEL) << "EXIT (" << m_func << ") " << m_file << dendl;
+  tracepoint(eventtrace, func_exit, m_file.c_str(), m_func.c_str());
+  utime_t now = ceph_clock_now();
+  double usecs = (now.to_nsec()-m_func_enter_ts.to_nsec())/1000;
+  tracepoint(eventtrace, event_elapsed, m_func.c_str(), "", usecs); 
+  log_perf_counter(m_func.c_str(), usecs);
+}
+
+void EventTrace::log_perf_counter(const char *event, double usecs)
+{
+  assert (m_logger != NULL);
+  // this function gets called once m_counters is initialized completely
+  // since it is read only after initialization as long as we use const iterator
+  // we don't need to use expensive mutex
+  auto it = m_counters.find(event); 
+  utime_t ut(0, usecs * 1000);
+  if (it != m_counters.end())
+    m_logger->tinc(it->second, ut);
 }
 
 void EventTrace::log_event_latency(const char *event)
 {
   utime_t now = ceph_clock_now();
-  double usecs = (now.to_nsec()-last_ts.to_nsec())/1000;
-  OID_ELAPSED("", usecs, event);
-  last_ts = now;
+  if (likely(init(m_cct))) {
+    double usecs = (now.to_nsec()-m_last_event_ts.to_nsec())/1000;
+    tracepoint(eventtrace, event_elapsed, event, "", usecs);
+    log_perf_counter(event, usecs);
+  }
+  m_last_event_ts = now;
 }
 
-void EventTrace::trace_oid_event(const char *oid, const char *event, const char *context,
-  const char *file, const char *func, int line)
+void EventTrace::trace_oid_event(CephContext *cct, const char *oid, const char *event, const char *evctx)
 {
-  if (unlikely(!g_ceph_context))
-    return;
-  init_tp(g_ceph_context);
-  tracepoint(eventtrace, oid_event, oid, event, context, file, func, line);
+  if (unlikely(!init(cct))) return;
+  tracepoint(eventtrace, oid_event, oid, event, evctx);
 }
 
-void EventTrace::trace_oid_event(const Message *m, const char *event, const char *file,
-  const char *func, int line, bool incl_oid)
+void EventTrace::trace_oid_event(CephContext *cct, const Message *m, const char *event, bool incl_oid)
 {
-  string oid, context;
-  set_message_attrs(m, oid, context, incl_oid);
-  trace_oid_event(oid.c_str(), event, context.c_str(), file, func, line);
+  if (unlikely(!init(cct))) return;
+  string oid, evctx;
+  set_message_attrs(m, oid, evctx, incl_oid);
+  tracepoint(eventtrace, oid_event, oid.c_str(), event, evctx.c_str());
 }
 
-void EventTrace::trace_oid_elapsed(const char *oid, const char *event, const char *context,
-  double elapsed, const char *file, const char *func, int line)
+void EventTrace::trace_oid_elapsed(CephContext *cct, const char *oid, const char *event, 
+  const char *evctx, double elapsed)
 {
-  if (unlikely(!g_ceph_context))
-    return;
-  init_tp(g_ceph_context);
-  tracepoint(eventtrace, oid_elapsed, oid, event, context, elapsed, file, func, line);
+  if (unlikely(!init(cct))) return;
+  tracepoint(eventtrace, oid_elapsed, oid, event, evctx, elapsed);
+  log_perf_counter(event, elapsed); // note - we are tracing an event (not oid here)
 }
 
-void EventTrace::trace_oid_elapsed(const Message *m, const char *event, double elapsed,
-  const char *file, const char *func, int line, bool incl_oid)
+void EventTrace::trace_oid_elapsed(CephContext *cct, const Message *m, const char *event, 
+  double elapsed, bool incl_oid)
 {
-  string oid, context;
-  set_message_attrs(m, oid, context, incl_oid);
-  trace_oid_elapsed(oid.c_str(), event, context.c_str(), elapsed, file, func, line);
+  if (unlikely(!init(cct))) return;
+  string oid, evctx;
+  set_message_attrs(m, oid, evctx, incl_oid);
+  tracepoint(eventtrace, oid_elapsed, oid.c_str(), event, evctx.c_str(), elapsed);
+  log_perf_counter(event, elapsed); // note - we are tracing an event (not oid here)
 }
+
+void EventTrace::trace_event_elapsed(CephContext *cct, const char *event, const char *evctx, double elapsed)
+{
+  if (unlikely(!init(cct))) return;
+  tracepoint(eventtrace, event_elapsed, event, evctx, elapsed);
+  log_perf_counter(event, elapsed); 
+}
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-

--- a/src/common/EventTrace.h
+++ b/src/common/EventTrace.h
@@ -25,24 +25,30 @@
 #if defined(WITH_LTTNG) && defined(WITH_EVENTTRACE)
 
 #define OID_EVENT_TRACE(oid, event) \
-  EventTrace::trace_oid_event(oid, event, "", __FILE__, __func__, __LINE__)
+  EventTrace::trace_oid_event(g_ceph_context, oid, event, "")
 #define OID_EVENT_TRACE_WITH_MSG(msg, event, incl_oid) \
-  EventTrace::trace_oid_event(msg, event, __FILE__, __func__, __LINE__, incl_oid)
+  EventTrace::trace_oid_event(g_ceph_context, msg, event, incl_oid)
 #define OID_ELAPSED(oid, elapsed, event) \
-  EventTrace::trace_oid_elapsed(oid, event, "", elapsed, __FILE__, __func__, __LINE__)
+  EventTrace::trace_oid_elapsed(g_ceph_context, oid, event, "", elapsed)
 #define OID_ELAPSED_WITH_MSG(m, elapsed, event, incl_oid) \
-  EventTrace::trace_oid_elapsed(m, event, elapsed, __FILE__, __func__, __LINE__, incl_oid)
+  EventTrace::trace_oid_elapsed(g_ceph_context, m, event, elapsed, incl_oid)
 #define FUNCTRACE() EventTrace _t1(g_ceph_context, __FILE__, __func__, __LINE__)
 #define OID_ELAPSED_FUNC_EVENT(event) _t1.log_event_latency(event)
+#define RESET_FUNC_TIMER() _t1.reset_event_timer()
+#define EVENT_ELAPSED(event, evctx, elapsed) \
+  EventTrace::trace_event_elapsed(g_ceph_context, event, evctx, elapsed)
+  
 
 #else
 
-#define OID_EVENT_TRACE(oid, event)
-#define OID_EVENT_TRACE_WITH_MSG(msg, event, incl_oid)
+#define OID_EVENT_TRACE(oid, event) 
+#define OID_EVENT_TRACE_WITH_MSG(msg, event, incl_oid) 
 #define OID_ELAPSED(oid, elapsed, event)
-#define OID_ELAPSED_WITH_MSG(m, elapsed, event, incl_oid)
-#define FUNCTRACE()
+#define OID_ELAPSED_WITH_MSG(m, elapsed, event, incl_oid) 
+#define FUNCTRACE() 
 #define OID_ELAPSED_FUNC_EVENT(event)
+#define RESET_FUNC_TIMER()
+#define EVENT_ELAPSED(event, evctx, elapsed)
 
 #endif
 
@@ -50,32 +56,37 @@
 
 class EventTrace {
 private:
-  CephContext *ctx;
-  string file;
-  string func;
-  int line;
-  utime_t last_ts;
+  CephContext *m_cct;
+  string m_file;
+  string m_func;
+  int m_line;
+  utime_t m_last_event_ts;
+  utime_t m_func_enter_ts;
 
-  static bool tpinit;
+  static PerfCounters *m_logger;
+  static std::atomic<bool> m_init;
+  static std::map<std::string, int> m_counters;
 
-  static void init_tp(CephContext *_ctx);
-  static void set_message_attrs(const Message *m, string& oid, string& context, bool incl_oid);
+  static bool init(CephContext *cct);
+  static void set_message_attrs(const Message *m, string& oid, string& evctx, bool incl_oid);
+  static void log_perf_counter(const char *event, double usecs);
 
 public:
 
-  EventTrace(CephContext *_ctx, const char *_file, const char *_func, int line);
+  EventTrace(CephContext *cct, const char *file, const char *func, int line);
   ~EventTrace();
+
   void log_event_latency(const char *tag);
+  inline void reset_event_timer() {
+    m_last_event_ts = ceph_clock_now(); 
+  }
 
-  static void trace_oid_event(const char *oid, const char *event, const char *context,
-    const char *file, const char *func, int line);
-  static void trace_oid_event(const Message *m, const char *event, const char *file,
-    const char *func, int line, bool incl_oid);
+  static void trace_oid_event(CephContext *cct, const char *oid, const char *event, const char *evctx);
+  static void trace_oid_event(CephContext *cct, const Message *m, const char *event, bool incl_oid);
 
-  static void trace_oid_elapsed(const char *oid, const char *event, const char *context,
-    double elapsed, const char *file, const char *func, int line);
-  static void trace_oid_elapsed(const Message *m, const char *event, double elapsed,
-    const char *file, const char *func, int line, bool incl_oid);
+  static void trace_oid_elapsed(CephContext *cct, const char *oid, const char *event, const char *evctx, double elapsed);
+  static void trace_oid_elapsed(CephContext *cct, const Message *m, const char *event, double elapsed, bool incl_oid);
+  static void trace_event_elapsed(CephContext *cct, const char *event, const char *evctx, double elapsed);
   
 };
 #endif

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1666,6 +1666,7 @@ OPTION(rgw_torrent_encoding, OPT_STR, "")    // torrent field encoding
 OPTION(rgw_torrent_origin, OPT_STR, "")    // torrent origin
 OPTION(rgw_torrent_sha_unit, OPT_INT, 512*1024)    // torrent field piece length 512K
 
+OPTION(event_tracing_perf_counters, OPT_STR, "") // list of functions that need latency to be published as perf counter
 OPTION(event_tracing, OPT_BOOL, false) // true if LTTng-UST tracepoints should be enabled
 
 // This will be set to true when it is safe to start threads.

--- a/src/tracing/eventtrace.tp
+++ b/src/tracing/eventtrace.tp
@@ -26,17 +26,11 @@ TRACEPOINT_EVENT(eventtrace, oid_event,
     TP_ARGS(
         const char*, oid,
         const char*, event,
-        const char*, context,
-        const char*, file,
-        const char*, func,
-        uint32_t, line),
+        const char*, context),
     TP_FIELDS(
         ctf_string(oid, oid)
         ctf_string(event, event)
         ctf_string(context, context)
-        ctf_string(file, file)
-        ctf_string(func, func)
-        ctf_integer(uint32_t, line, line)
     )
 )
 
@@ -45,17 +39,23 @@ TRACEPOINT_EVENT(eventtrace, oid_elapsed,
         const char*, oid,
         const char*, event,
         const char*, context,
-        double, elapsed,
-        const char*, file,
-        const char*, func,
-        uint32_t, line),
+        double, elapsed),
     TP_FIELDS(
         ctf_string(oid, oid)
         ctf_string(event, event)
         ctf_string(context, context)
         ctf_float(double, elapsed, elapsed)
-        ctf_string(file, file)
-        ctf_string(func, func)
-        ctf_integer(uint32_t, line, line)
+    )
+)
+
+TRACEPOINT_EVENT(eventtrace, event_elapsed,
+    TP_ARGS(
+        const char*, event,
+        const char*, context,
+        double, elapsed),
+    TP_FIELDS(
+        ctf_string(event, event)
+        ctf_string(context, context)
+        ctf_float(double, elapsed, elapsed)
     )
 )


### PR DESCRIPTION
Added event_elapsed event to track function latency and optionally publish function 
latency as perf counter for scale testing latency analysis

Signed-off-by: Anjaneya Chagam <anjaneya.chagam@intel.com>