### PR TITLE
cmake: build tracepoint libraries for vstart target

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1038,6 +1038,9 @@ if(WITH_RADOSGW)
   add_dependencies(vstart radosgw radosgw-admin)
 endif(WITH_RADOSGW)
 
+if(WITH_LTTNG)
+  add_dependencies(vstart tracepoint_libraries)
+endif(WITH_LTTNG)
 
 # Everything you need to run CephFS tests
 add_custom_target(cephfs_testing DEPENDS

--- a/src/tracing/CMakeLists.txt
+++ b/src/tracing/CMakeLists.txt
@@ -6,6 +6,8 @@ set(working_dir ${CMAKE_BINARY_DIR}/include)
 set(header_dir ${working_dir}/tracing)
 file(MAKE_DIRECTORY ${header_dir})
 
+add_custom_target(tracepoint_libraries)
+
 file(GLOB tps "*.tp")
 foreach(tp ${tps})
   get_filename_component(name ${tp} NAME_WE)
@@ -36,6 +38,7 @@ function(add_tracing_library name tracings version)
     VERSION ${version}
     SOVERSION ${soversion}
     INSTALL_RPATH "")
+  add_dependencies(tracepoint_libraries ${name})
 endfunction()
 
 set(osd_traces oprequest.tp osd.tp pg.tp)


### PR DESCRIPTION
Avoid a segfault in TracepointProvider::verify_config() when building
for the 'vstart' target. TracepointProvider tries to load the tracepoint
providers libraries at runtime, but these aren't built as part of the
'vstart' target.

Signed-off-by: Mohamad Gebai <mgebai@suse.com>