### PR TITLE
rgw: allow larger payload for period commit

### DIFF
--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -84,9 +84,9 @@ void RGWOp_Period_Post::execute()
   period.init(cct, store, false);
 
   // decode the period from input
-#define PERIOD_MAX_LEN 4096
+  const auto max_size = cct->_conf->rgw_max_put_param_size;
   bool empty;
-  http_ret = rgw_rest_get_json_input(cct, s, period, PERIOD_MAX_LEN, &empty);
+  http_ret = rgw_rest_get_json_input(cct, s, period, max_size, &empty);
   if (http_ret < 0) {
     lderr(cct) << "failed to decode period" << dendl;
     return;


### PR DESCRIPTION
testing with 3 zonegroups and 3 zones each, the period json grew larger than 4k and caused decode failures on period commit

updated to use the new config variable `rgw_max_put_param_size`

Fixes: http://tracker.ceph.com/issues/19505