### PR TITLE
rgw multisite: remove the redundant post in OPT_ZONEGROUP_MODIFY

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3621,7 +3621,6 @@ int main(int argc, const char **argv)
         }
 
         if (need_update) {
-          zonegroup.post_process_params();
 	  ret = zonegroup.update();
 	  if (ret < 0) {
 	    cerr << "failed to update zonegroup: " << cpp_strerror(-ret) << std::endl;


### PR DESCRIPTION
the post_process_params has been included in `zonegroup.update_master(is_master).` and the other params updating does not need to use post. `zonegroup.update()` is enough.

Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>