### PR TITLE
[DNM] jewel: rgw: fix listing of objects that start with underscore

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4986,7 +4986,7 @@ int RGWRados::Bucket::List::list_objects(int max, vector<RGWObjEnt> *result,
 
   /* if marker points at a common prefix, fast forward it into its upperbound string */
   if (!params.delim.empty()) {
-    int delim_pos = cur_marker.name.find(params.delim, params.prefix.size());
+    int delim_pos = cur_marker.name.find(params.delim, cur_prefix.size());
     if (delim_pos >= 0) {
       string s = cur_marker.name.substr(0, delim_pos);
       s.append(bigger_than_delim);
@@ -5062,10 +5062,12 @@ int RGWRados::Bucket::List::list_objects(int max, vector<RGWObjEnt> *result,
               truncated = true;
               goto done;
             }
-            next_marker = prefix_key;
             (*common_prefixes)[prefix_key] = true;
 
-            skip_after_delim = obj.name.substr(0, delim_pos);
+            int marker_delim_pos = cur_marker.name.find(params.delim, cur_prefix.size());
+            next_marker = cur_marker.name.substr(0, marker_delim_pos + 1);
+
+            skip_after_delim = cur_marker.name.substr(0, marker_delim_pos);
             skip_after_delim.append(bigger_than_delim);
 
             ldout(cct, 20) << "skip_after_delim=" << skip_after_delim << dendl;


### PR DESCRIPTION
Current marker and prefix search utilized in rgw's function list_objects should respect index key name in order to correctly list objects which have names starting with underscore.

Fixes: http://tracker.ceph.com/issues/19432

Signed-off-by: Giovani Rinaldi <giovani.rinaldi@azion.com>