### PR TITLE
doc: rgw: correct get usage parameter default value

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -54,7 +54,7 @@ Request Parameters
 
 :Description: Specifies whether data entries should be returned.
 :Type: Boolean
-:Example: True [False]
+:Example: True [True]
 :Required: No
 
 
@@ -62,7 +62,7 @@ Request Parameters
 
 :Description: Specifies whether data summary should be returned.
 :Type: Boolean
-:Example: True [False]
+:Example: True [True]
 :Required: No
 
 


### PR DESCRIPTION
```show-entries``` and ```show-summary``` are default in ```True``` instead of ```False```, ref the corresponding code section here: https://github.com/ceph/ceph/blob/master/src/rgw/rgw_rest_usage.cc#L38