### PR TITLE
rgw: fix for null version_id in fetch_remote_obj()

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7141,7 +7141,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   RGWPutObjProcessor_Atomic processor(obj_ctx,
                                       dest_bucket_info, dest_obj.bucket, dest_obj.key.name,
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
-  if (version_id) {
+  if (version_id && *version_id != "null") {
     processor.set_version_id(*version_id);
   }
   processor.set_olh_epoch(olh_epoch);


### PR DESCRIPTION
https://github.com/ceph/ceph/pull/14010 fixed the wrong use of the dest_obj's version, but removed the check for "null" version

this was causing failures in `test_multi.py:test_object_delete()`, because it was creating versioned objects in a non-versioned bucket

