### PR TITLE
arch: fix build on PowerPC with FreeBSD

### DIFF
--- a/src/arch/ppc.c
+++ b/src/arch/ppc.c
@@ -13,9 +13,9 @@
 int ceph_arch_ppc_crc32 = 0;
 
 #include <stdio.h>
-#include <sys/auxv.h>
 
 #if __linux__ && __powerpc64__
+#include <sys/auxv.h>
 #include <asm/cputable.h>
 #endif /* __linux__ && __powerpc64__ */
 


### PR DESCRIPTION
The #include file <sys/auxv.h> is present on linux but
not FreeBSD.  Move it under the #if __linux__ directive.

Signed-off-by: Andrew Solomon <asolomon@us.ibm.com>