### PR TITLE
build/ops: rpm: explicitly provide --with-ocf to configure

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -668,7 +668,9 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--without-babeltrace \
 %endif
 		$CEPH_EXTRA_CONFIGURE_ARGS \
-		%{?_with_ocf} \
+%if 0%{with ocf}
+		--with-ocf \
+%endif
 %if %{without tcmalloc}
 		--without-tcmalloc \
 %endif

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -667,13 +667,13 @@ export RPM_OPT_FLAGS=`echo $RPM_OPT_FLAGS | sed -e 's/i386/i486/'`
 		--without-lttng \
 		--without-babeltrace \
 %endif
-		$CEPH_EXTRA_CONFIGURE_ARGS \
 %if 0%{with ocf}
 		--with-ocf \
 %endif
 %if %{without tcmalloc}
 		--without-tcmalloc \
 %endif
+		$CEPH_EXTRA_CONFIGURE_ARGS \
 		CFLAGS="$RPM_OPT_FLAGS" CXXFLAGS="$RPM_OPT_FLAGS"
 
 %if %{with lowmem_builder}


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19546
Signed-off-by: Nathan Cutler <ncutler@suse.com>