### PR TITLE
tools: ceph-release-notes: strip trailing punctuation

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -195,6 +195,7 @@ def make_release_notes(gh, repo, ref, plaintext, verbose, strict, use_tags):
             if use_tags:
                 title = split_component(title, gh, number)
 
+            title = title.strip(' \t\n\r\f\v\.\,\;\:\-\=')
             pr2info[number] = (author, title, message)
 
             for issue in set(issues):


### PR DESCRIPTION
Sometimes people put periods and whitespace at the end of their
PR/commit descriptions - strip these off for the purposes of
generating the release notes.

Signed-off-by: Nathan Cutler <ncutler@suse.com>