### PR TITLE
[dnm] config: improve handling missing config files

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -289,6 +289,8 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
 					 std::ostream *warnings)
 {
   assert(lock.is_locked());
+  if (conf_files.size() == 0)
+    return -EINVAL;
 
   // open new conf
   list<string>::const_iterator c;
@@ -303,7 +305,7 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
       return ret;
   }
   if (c == conf_files.end())
-    return -EINVAL;
+    return -ENOENT;
 
   if (cluster.size() == 0) {
     /*


### PR DESCRIPTION
Current logic in parse_config_files_impl treated the "no config files
specified" situation in the same way as "no config files found",
causing it to return EINVAL when ENOENT should be returned. This patch
fixes it by checking if conf_files is empty first (and returning EINVAL
in that case), then iterating over it and returning ENOENT when no
config files were found (all attempts ended with ENOENT).

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>