### PR TITLE
qa: re-enable ENOSPC tests for kclient

### DIFF
--- a/qa/suites/kcephfs/recovery/tasks/mds-full.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/mds-full.yaml
@@ -1,0 +1,19 @@
+
+overrides:
+  ceph:
+    log-whitelist:
+      - OSD full dropping all updates
+      - OSD near full
+      - failsafe engaged, dropping updates
+      - failsafe disengaged, no longer dropping
+      - is full \(reached quota
+    conf:
+      osd:
+        osd mon report interval max: 5
+        osd objectstore: memstore
+        memstore device bytes: 100000000
+
+tasks:
+  - cephfs_test_runner:
+      modules:
+        - tasks.cephfs.test_full

--- a/qa/tasks/cephfs/kernel_mount.py
+++ b/qa/tasks/cephfs/kernel_mount.py
@@ -251,10 +251,7 @@ class KernelMount(CephFSMount):
         """
         osd_map = self._read_debug_file("osdmap")
         lines = osd_map.split("\n")
-        epoch = int(lines[0].split()[1])
+        first_line_tokens = lines[0].split()
+        epoch, barrier = int(first_line_tokens[1]), int(first_line_tokens[3])
 
-        mds_sessions = self._read_debug_file("mds_sessions")
-        lines = mds_sessions.split("\n")
-        epoch_barrier = int(lines[2].split()[1].strip('"'))
-
-        return epoch, epoch_barrier
+        return epoch, barrier

--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -30,9 +30,6 @@ class FullnessTestCase(CephFSTestCase):
     def setUp(self):
         CephFSTestCase.setUp(self)
 
-        if not isinstance(self.mount_a, FuseMount):
-            self.skipTest("FUSE needed: ENOSPC handling in kclient is tracker #17204")
-
         # These tests just use a single active MDS throughout, so remember its ID
         # for use in mds_asok calls
         self.active_mds_id = self.fs.get_active_names()[0]


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19550
Signed-off-by: John Spray <john.spray@redhat.com>