### PR TITLE
osd/PG: only correct filestore collection bits on load

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5850,7 +5850,10 @@ void PG::update_store_with_options()
   if(r < 0 && r != -EOPNOTSUPP) {
     derr << __func__ << "set_collection_opts returns error:" << r << dendl;
   }
+}
 
+void PG::update_store_on_load()
+{
   if (osd->store->get_type() == "filestore") {
     // legacy filestore didn't store collection bit width; fix.
     int bits = osd->store->collection_bits(coll);
@@ -5906,6 +5909,8 @@ boost::statechart::result PG::RecoveryState::Initial::react(const Load& l)
   // do we tell someone we're here?
   pg->send_notify = (!pg->is_primary());
   pg->update_store_with_options();
+
+  pg->update_store_on_load();
 
   return transit< Reset >();
 }

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2242,6 +2242,7 @@ private:
   void prepare_write_info(map<string,bufferlist> *km);
 
   void update_store_with_options();
+  void update_store_on_load();
 
 public:
   static int _prepare_write_info(


### PR DESCRIPTION
PG::update_store_with_options() is called on load *and* when the pool
properties change, but if we only need to fix bits right at load time.
More importantly, but doing a second check on pool change, we may race
with a previously queued collection create that is not yet readable via
filestore, try to (synchronously) set the property again, and deadlock.

Fixes: http://tracker.ceph.com/issues/19541
Signed-off-by: Sage Weil <sage@redhat.com>