### PR TITLE
mon: emit cluster log messages on MDS health changes

### DIFF
--- a/qa/suites/fs/basic/tasks/cephfs_scrub_tests.yaml
+++ b/qa/suites/fs/basic/tasks/cephfs_scrub_tests.yaml
@@ -2,6 +2,8 @@ overrides:
   ceph:
     log-whitelist:
       - Scrub error on inode
+      - Behind on trimming
+      - Metadata damage detected
     conf:
       mds:
         mds log max segments: 1

--- a/qa/suites/fs/recovery/tasks/auto-repair.yaml
+++ b/qa/suites/fs/recovery/tasks/auto-repair.yaml
@@ -3,6 +3,7 @@ overrides:
     log-whitelist:
       - force file system read-only
       - bad backtrace
+      - MDS in read-only mode
 
 
 tasks:

--- a/qa/suites/fs/recovery/tasks/client-limits.yaml
+++ b/qa/suites/fs/recovery/tasks/client-limits.yaml
@@ -4,6 +4,11 @@ overrides:
     log-whitelist:
       - responding to mclientcaps\(revoke\)
       - not advance its oldest_client_tid
+      - failing to advance its oldest client/flush tid
+      - Too many inodes in cache
+      - failing to respond to cache pressure
+      - slow requests are blocked
+      - failing to respond to capability release
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/recovery/tasks/damage.yaml
+++ b/qa/suites/fs/recovery/tasks/damage.yaml
@@ -16,6 +16,7 @@ overrides:
       - corrupt sessionmap header
       - Corrupt dentry
       - Scrub error on inode
+      - Metadata damage detected
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/recovery/tasks/data-scan.yaml
+++ b/qa/suites/fs/recovery/tasks/data-scan.yaml
@@ -8,6 +8,8 @@ overrides:
       - error reading sessionmap
       - unmatched fragstat
       - was unreadable, recreating it now
+      - Scrub error on inode
+      - Metadata damage detected
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/recovery/tasks/forward-scrub.yaml
+++ b/qa/suites/fs/recovery/tasks/forward-scrub.yaml
@@ -6,6 +6,7 @@ overrides:
       - bad backtrace on inode
       - inode table repaired for inode
       - Scrub error on inode
+      - Metadata damage detected
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/recovery/tasks/journal-repair.yaml
+++ b/qa/suites/fs/recovery/tasks/journal-repair.yaml
@@ -4,6 +4,9 @@ overrides:
     log-whitelist:
       - bad backtrace on dir ino
       - error reading table object
+      - Metadata damage detected
+      - slow requests are blocked
+      - Behind on trimming
 
 tasks:
   - cephfs_test_runner:

--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -1,3 +1,10 @@
+
+# Valgrind makes everything slow, so ignore slow requests
+overrides:
+  ceph:
+    log-whitelist:
+      - slow requests are blocked
+
 os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:


### PR DESCRIPTION
Previously, when we got a beacon that updated the health
metrics for an MDS, the user would just see mysterious-looking
cluster log messages indicating a rising fsmap epoch number.

It would be good to do this for health messages in general at
some point, but for now just do it for the MDS ones.

Fixes: http://tracker.ceph.com/issues/19551
Signed-off-by: John Spray <john.spray@redhat.com>