### PR TITLE
qa/tasks: few fixes to get ceph-deploy 1node to working state

### DIFF
--- a/qa/suites/smoke/1node/distros/ubuntu_latest.yaml
+++ b/qa/suites/smoke/1node/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -567,6 +567,8 @@ def cli_test(ctx, config):
                                                 sudo=True)
     new_mon_install = 'install {branch} --mon '.format(
         branch=test_branch) + nodename
+    new_mgr_install = 'install {branch} --mgr '.format(
+        branch=test_branch) + nodename
     new_osd_install = 'install {branch} --osd '.format(
         branch=test_branch) + nodename
     new_admin = 'install {branch} --cli '.format(branch=test_branch) + nodename
@@ -574,6 +576,7 @@ def cli_test(ctx, config):
     # either use create-keys or push command
     push_keys = 'admin ' + nodename
     execute_cdeploy(admin, new_mon_install, path)
+    execute_cdeploy(admin, new_mgr_install, path)
     execute_cdeploy(admin, new_osd_install, path)
     execute_cdeploy(admin, new_admin, path)
     execute_cdeploy(admin, create_initial, path)

--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -571,10 +571,13 @@ def cli_test(ctx, config):
         branch=test_branch) + nodename
     new_admin = 'install {branch} --cli '.format(branch=test_branch) + nodename
     create_initial = 'mon create-initial '
+    # either use create-keys or push command
+    push_keys = 'admin ' + nodename
     execute_cdeploy(admin, new_mon_install, path)
     execute_cdeploy(admin, new_osd_install, path)
     execute_cdeploy(admin, new_admin, path)
     execute_cdeploy(admin, create_initial, path)
+    execute_cdeploy(admin, push_keys, path)
 
     for i in range(3):
         zap_disk = 'disk zap ' + "{n}:{d}".format(n=nodename, d=devs[i])


### PR DESCRIPTION
Few fixes to get it to green state

1) use admin command to push keys to the node, required due to monitor changes
2) install mgr as well
3) dont test on trusty but use xenial

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>