### PR TITLE
rgw: fix handling of --remote in radosgw-admin period commands

### DIFF
--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -19,6 +19,27 @@ RGWRESTConn::RGWRESTConn(CephContext *_cct, RGWRados *store,
   }
 }
 
+RGWRESTConn::RGWRESTConn(RGWRESTConn&& other)
+  : cct(other.cct),
+    endpoints(std::move(other.endpoints)),
+    key(std::move(other.key)),
+    self_zone_group(std::move(other.self_zone_group)),
+    remote_id(std::move(other.remote_id)),
+    counter(other.counter.load())
+{
+}
+
+RGWRESTConn& RGWRESTConn::operator=(RGWRESTConn&& other)
+{
+  cct = other.cct;
+  endpoints = std::move(other.endpoints);
+  key = std::move(other.key);
+  self_zone_group = std::move(other.self_zone_group);
+  remote_id = std::move(other.remote_id);
+  counter = other.counter.load();
+  return *this;
+}
+
 int RGWRESTConn::get_url(string& endpoint)
 {
   if (endpoints.empty()) {

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -61,6 +61,10 @@ class RGWRESTConn
 public:
 
   RGWRESTConn(CephContext *_cct, RGWRados *store, const string& _remote_id, const list<string>& endpoints);
+  // custom move needed for atomic
+  RGWRESTConn(RGWRESTConn&& other);
+  RGWRESTConn& operator=(RGWRESTConn&& other);
+
   int get_url(string& endpoint);
   string get_url();
   const string& get_self_zonegroup() {


### PR DESCRIPTION
`send_to_remote_gateway()` was using `RGWRados::zonegroup_conn_map` and `zone_conn_map` to find a connection to the given `--remote`. the `zone_conn_map` only contains zones in the current zonegroup, however, so `--remote` didn't work for zones in other zonegroups

`radosgw-admin period commit` relies on `send_to_remote_gateway()` to commit the period to the master zone. if that master zone is another zonegroup, the command fails:
```
$ radosgw-admin period update --commit
Sending period to new master zone 2554ff93-3149-4e77-ab94-bfbff0493074
could not find connection for zone or zonegroup id: 2554ff93-3149-4e77-ab94-bfbff0493074
request failed: (2) No such file or directory
failed to commit period: (2) No such file or directory
```

Fixes: http://tracker.ceph.com/issues/19554

`radosgw-admin period pull` also uses `send_to_remote_gateway()`. because it no longer needs `RGWRados::zone_conn_map` for connections, the `period pull` command is now a `raw_storage_op`