### PR TITLE
mon: fix synchronise pgmap with others

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -242,6 +242,8 @@ void PGMonitor::update_from_paxos(bool *need_bootstrap)
       int r = get_version(pg_map.version + 1, bl);
       if (r == -ENOENT) {
 	dout(10) << __func__ << " failed to read_incremental, read_full" << dendl;
+       // reset pg map
+       pg_map = PGMap();
 	read_pgmap_full();
 	goto out;
       }


### PR DESCRIPTION
leader mon down for a long time and then the local pgmap/osdmap was behind latest map a lot,
when it start and sync ,it will read full map from other mons;
if serveral osds/pgs were deleted during mon offline, these osds/pgs will be left over in pgmap until manully restart ceph-mon process

Solution:
reset pgmap before read pgmap full,make sure local maps are the same as the latest map

Signed-off-by: song baisen <song.baisen@zte.com.cn>