### PR TITLE
mon/MonClient: make get_mon_log_message() atomic

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -264,15 +264,13 @@ void LogChannel::do_log(clog_type prio, const std::string& s)
   }
 }
 
-void LogClient::reset_session()
+Message *LogClient::get_mon_log_message(bool flush)
 {
   Mutex::Locker l(log_lock);
-  last_log_sent = last_log - log_queue.size();
-}
-
-Message *LogClient::get_mon_log_message()
-{
-  Mutex::Locker l(log_lock);
+  if (flush) {
+    // reset session
+    last_log_sent = last_log - log_queue.size();
+  }
   return _get_mon_log_message();
 }
 

--- a/src/common/LogClient.h
+++ b/src/common/LogClient.h
@@ -206,8 +206,7 @@ public:
   }
 
   bool handle_log_ack(MLogAck *m);
-  void reset_session();
-  Message *get_mon_log_message();
+  Message *get_mon_log_message(bool flush);
   bool are_pending();
 
   LogChannelRef create_channel() {

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -295,10 +295,10 @@ bool MonClient::ms_dispatch(Message *m)
   return true;
 }
 
-void MonClient::send_log()
+void MonClient::send_log(bool flush)
 {
   if (log_client) {
-    Message *lm = log_client->get_mon_log_message();
+    Message *lm = log_client->get_mon_log_message(flush);
     if (lm)
       _send_mon_message(lm);
     more_log_pending = log_client->are_pending();
@@ -521,13 +521,8 @@ void MonClient::handle_auth(MAuthReply *m)
       _send_mon_message(waiting_for_session.front());
       waiting_for_session.pop_front();
     }
-
     _resend_mon_commands();
-
-    if (log_client) {
-      log_client->reset_session();
-      send_log();
-    }
+    send_log(true);
     if (active_con) {
       std::swap(auth, active_con->get_auth());
       global_id = active_con->get_global_id();

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -167,7 +167,7 @@ private:
   LogClient *log_client;
   bool more_log_pending;
 
-  void send_log();
+  void send_log(bool flush = false);
 
   std::unique_ptr<AuthMethodList> auth_supported;
 


### PR DESCRIPTION
* LogClient: move reset_session() into get_mon_log_message() and add a
  "flush" param to the latter. so it can get_mon_log_message()
  atomically. otherwise another call changing the log queue could sneak
  in between reset_session() and get_mon_log_message().
* MonClient: add a "flush" param to do_send() so we can reset the
  LogClient session once we are connected to a monitor.

Fixes: http://tracker.ceph.com/issues/19427
Signed-off-by: Kefu Chai <kchai@redhat.com>