### PR TITLE
tests: ceph_objectstore_tool.py: kill all daemons

### DIFF
--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -399,7 +399,7 @@ CEPH_DIR = CEPH_BUILD_DIR + "/cot_dir"
 CEPH_CONF = os.path.join(CEPH_DIR, 'ceph.conf')
 
 def kill_daemons():
-    call("{path}/init-ceph -c {conf} stop osd mon > /dev/null 2>&1".format(conf=CEPH_CONF, path=CEPH_BIN), shell=True)
+    call("{path}/init-ceph -c {conf} stop > /dev/null 2>&1".format(conf=CEPH_CONF, path=CEPH_BIN), shell=True)
 
 
 def check_data(DATADIR, TMPFILE, OSDDIR, SPLIT_NAME):


### PR DESCRIPTION
init-ceph kills all daemons that can be identified by get_name_list() by
default, so no need to list them explicitly. also, without this change,
mgr is not stopped when the test finishes.

Signed-off-by: Kefu Chai <kchai@redhat.com>