### PR TITLE
mon: avoid segfault in wait_auth_rotating

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -899,6 +899,9 @@ int MonClient::wait_auth_rotating(double timeout)
   utime_t until = now;
   until += timeout;
 
+  // Must be initialized
+  assert(auth != nullptr);
+
   if (auth->get_protocol() == CEPH_AUTH_NONE)
     return 0;
   


### PR DESCRIPTION
MonClient users should not be calling into MonClient
after calling shutdown().  However, MonClient should
assert out rather than proceeding to try and
follow a maybe-null pointer.

Related to http://tracker.ceph.com/issues/19566

Signed-off-by: John Spray <john.spray@redhat.com>