### PR TITLE
os/bluestore: make bluestore_max_blob_size parameter hdd/ssd case dependant

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1079,7 +1079,9 @@ OPTION(bluestore_gc_enable_blob_threshold, OPT_INT, 0)
  */
 OPTION(bluestore_gc_enable_total_threshold, OPT_INT, 0)  
 
-OPTION(bluestore_max_blob_size, OPT_U32, 512*1024)
+OPTION(bluestore_max_blob_size, OPT_U32, 0)
+OPTION(bluestore_max_blob_size_hdd, OPT_U32, 512*1024)
+OPTION(bluestore_max_blob_size_ssd, OPT_U32, 64*1024)
 /*
  * Require the net gain of compression at least to be at this ratio,
  * otherwise we don't compress.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1060,8 +1060,12 @@ OPTION(bluestore_prefer_deferred_size_hdd, OPT_U32, 32768)
 OPTION(bluestore_prefer_deferred_size_ssd, OPT_U32, 0)
 OPTION(bluestore_compression_mode, OPT_STR, "none")  // force|aggressive|passive|none
 OPTION(bluestore_compression_algorithm, OPT_STR, "snappy")
-OPTION(bluestore_compression_min_blob_size, OPT_U32, 128*1024)
-OPTION(bluestore_compression_max_blob_size, OPT_U32, 512*1024)
+OPTION(bluestore_compression_min_blob_size, OPT_U32, 0)
+OPTION(bluestore_compression_min_blob_size_hdd, OPT_U32, 128*1024)
+OPTION(bluestore_compression_min_blob_size_ssd, OPT_U32, 8*1024)
+OPTION(bluestore_compression_max_blob_size, OPT_U32, 0)
+OPTION(bluestore_compression_max_blob_size_hdd, OPT_U32, 512*1024)
+OPTION(bluestore_compression_max_blob_size_ssd, OPT_U32, 64*1024)
 /*
  * Specifies minimum expected amount of saved allocation units
  * per single blob to enable compressed blobs garbage collection

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4899,9 +4899,6 @@ int BlueStore::mount()
 
   mempool_thread.init();
 
-  _set_csum();
-  _set_compression();
-  _set_blob_size();
 
   mounted = true;
   return 0;
@@ -7170,6 +7167,10 @@ int BlueStore::_open_super_meta()
   }
   _set_alloc_sizes();
   _set_throttle_params();
+
+  _set_csum();
+  _set_compression();
+  _set_blob_size();
 
   return 0;
 }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1790,13 +1790,19 @@ private:
   size_t block_size_order = 0; ///< bits to shift to get block size
 
   uint64_t min_alloc_size = 0; ///< minimum allocation unit (power of 2)
-  size_t min_alloc_size_order = 0; ///< bits for min_alloc_size
-  uint64_t prefer_deferred_size = 0; ///< size threshold for forced deferred writes
   int deferred_batch_ops = 0; ///< deferred batch size
 
-  uint64_t max_alloc_size = 0; ///< maximum allocation unit (power of 2)
+  ///< bits for min_alloc_size
+  std::atomic<size_t> min_alloc_size_order = {0};
+  
+  ///< size threshold for forced deferred writes
+  std::atomic<uint64_t> prefer_deferred_size = {0};
 
-  uint64_t throttle_cost_per_io = 0;   ///< approx cost per io, in bytes
+  ///< maximum allocation unit (power of 2)
+  std::atomic<uint64_t> max_alloc_size = {0};
+
+  ///< approx cost per io, in bytes
+  std::atomic<uint64_t> throttle_cost_per_io = {0};
 
   std::atomic<Compressor::CompressionMode> comp_mode = {Compressor::COMP_NONE}; ///< compression mode
   CompressorRef compressor;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1803,6 +1803,8 @@ private:
   std::atomic<uint64_t> comp_min_blob_size = {0};
   std::atomic<uint64_t> comp_max_blob_size = {0};
 
+  std::atomic<uint64_t> max_blob_size = {0};  ///< maximum blob size
+
   // cache trim control
 
   // note that these update in a racy way, but we don't *really* care if
@@ -1856,6 +1858,8 @@ private:
   int _write_fsid();
   void _close_fsid();
   void _set_alloc_sizes();
+  void _set_blob_size();
+
   int _open_bdev(bool create);
   void _close_bdev();
   int _open_db(bool create);

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -6449,6 +6449,7 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
 
   StartDeferred(65536);
 
+  g_conf->set_val("bluestore_compression_max_blob_size", "524288");
   g_conf->set_val("bluestore_compression_min_blob_size", "262144");
   g_conf->set_val("bluestore_compression_mode", "force");
   g_conf->apply_changes(NULL);
@@ -6582,7 +6583,8 @@ TEST_P(StoreTestSpecificAUSize, garbageCollection) {
     }
   }
   g_conf->set_val("bluestore_gc_enable_total_threshold", "0");
-  g_conf->set_val("bluestore_compression_min_blob_size", "131072");
+  g_conf->set_val("bluestore_compression_min_blob_size", "0");
+  g_conf->set_val("bluestore_compression_max_blob_size", "0");
   g_conf->set_val("bluestore_compression_mode", "none");
   g_conf->apply_changes(NULL);
 }

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5988,7 +5988,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwrite) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  g_conf->set_val("bluestore_max_blob_size", "524288");
+  g_conf->set_val("bluestore_max_blob_size", "0");
 
 }
 
@@ -6171,7 +6171,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnOverwriteReverse) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  g_conf->set_val("bluestore_max_blob_size", "524288");
+  g_conf->set_val("bluestore_max_blob_size", "0");
 }
 
 TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
@@ -6245,7 +6245,7 @@ TEST_P(StoreTestSpecificAUSize, BlobReuseOnSmallOverwrite) {
     r = apply_transaction(store, &osr, std::move(t));
     ASSERT_EQ(r, 0);
   }
-  g_conf->set_val("bluestore_max_blob_size", "524288");
+  g_conf->set_val("bluestore_max_blob_size", "0");
 }
 
 // The test case to reproduce an issue when write happens

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -1549,9 +1549,10 @@ TEST_P(StoreTestSpecificAUSize, BluestoreStatFSTest) {
   g_ceph_context->_conf->apply_changes(NULL);
 }
 
-TEST_P(StoreTest, BluestoreFragmentedBlobTest) {
+TEST_P(StoreTestSpecificAUSize, BluestoreFragmentedBlobTest) {
   if(string(GetParam()) != "bluestore")
     return;
+  StartDeferred(0x10000);
 
   ObjectStore::Sequencer osr("test");
   int r;
@@ -5662,9 +5663,12 @@ void doMany4KWritesTest(boost::scoped_ptr<ObjectStore>& store,
   test_obj.shutdown();
 }
 
-TEST_P(StoreTest, Many4KWritesTest) {
+TEST_P(StoreTestSpecificAUSize, Many4KWritesTest) {
   if (string(GetParam()) != "bluestore")
     return;
+
+  StartDeferred(0x10000);
+
   store_statfs_t res_stat;
   unsigned max_object = 4*1024*1024;
 
@@ -5674,9 +5678,10 @@ TEST_P(StoreTest, Many4KWritesTest) {
   ASSERT_EQ(res_stat.allocated, max_object);
 }
 
-TEST_P(StoreTest, Many4KWritesNoCSumTest) {
+TEST_P(StoreTestSpecificAUSize, Many4KWritesNoCSumTest) {
   if (string(GetParam()) != "bluestore")
     return;
+  StartDeferred(0x10000);
   g_conf->set_val("bluestore_csum_type", "none");
   g_ceph_context->_conf->apply_changes(NULL);
   store_statfs_t res_stat;
@@ -5689,9 +5694,10 @@ TEST_P(StoreTest, Many4KWritesNoCSumTest) {
   g_conf->set_val("bluestore_csum_type", "crc32c");
 }
 
-TEST_P(StoreTest, TooManyBlobsTest) {
+TEST_P(StoreTestSpecificAUSize, TooManyBlobsTest) {
   if (string(GetParam()) != "bluestore")
     return;
+  StartDeferred(0x10000);
   store_statfs_t res_stat;
   unsigned max_object = 4*1024*1024;
   doMany4KWritesTest(store, 1, 1000, max_object, 4*1024, 0, &res_stat);


### PR DESCRIPTION
Additionally some cleanup around dynamically loadable bluestore params.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>