### PR TITLE
script: build-doc/serve-doc fixes

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -57,7 +57,7 @@ cd build-doc
 [ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
 if [ ! -e $vdir ]; then
-    virtualenv --system-site-packages $vdir
+    virtualenv --system-site-packages $vdir -p python2
 fi
 $vdir/bin/pip install --quiet -r $TOPDIR/admin/doc-requirements.txt
 

--- a/admin/serve-doc
+++ b/admin/serve-doc
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+from __future__ import print_function
+
 import SimpleHTTPServer
 import SocketServer
 import os
@@ -24,6 +26,7 @@ httpd = SocketServer.TCPServer(
     ReusingTCPServer,
     )
 try:
+    print("Serving doc at port: http://localhost:8080")
     httpd.serve_forever()
 except KeyboardInterrupt:
     pass


### PR DESCRIPTION
`virtualenv` we create for docs would default to system default python which might be python3 in many OSes, this would fail eventually as we use the sphinx-ditaa module which errors out in py3. Also added a small print statement on the port we're serving in serve-doc