### PR TITLE
osd/OSDMap: hide require_*_osd and sortbitwise flags

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -150,6 +150,12 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_OSDMAP_REQUIRE_KRAKEN (1<<17) /* require kraken for booting osds */
 #define CEPH_OSDMAP_REQUIRE_LUMINOUS (1<<18) /* require l for booting osds */
 
+/* these are hidden in 'ceph status' view */
+#define CEPH_OSDMAP_SEMIHIDDEN_FLAGS (CEPH_OSDMAP_REQUIRE_JEWEL|	\
+				      CEPH_OSDMAP_REQUIRE_KRAKEN |	\
+				      CEPH_OSDMAP_REQUIRE_LUMINOUS |	\
+				      CEPH_OSDMAP_SORTBITWISE)
+
 /*
  * The error code to return when an OSD can't handle a write
  * because it is too large.

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2879,8 +2879,9 @@ void OSDMap::print_summary(Formatter *f, ostream& out) const
     if (get_num_pg_temp())
       out << "; " << get_num_pg_temp() << " remapped pgs";
     out << "\n";
-    if (flags)
-      out << "            flags " << get_flag_string() << "\n";
+    uint64_t important_flags = flags & ~CEPH_OSDMAP_SEMIHIDDEN_FLAGS;
+    if (important_flags)
+      out << "            flags " << get_flag_string(important_flags) << "\n";
   }
 }
 


### PR DESCRIPTION
These will be hidden from 'ceph -s' (as they are less
interesting) but still appear in the OSDMap dump.

Signed-off-by: Sage Weil <sage@redhat.com>