### PR TITLE
tests: fix oversight in yaml comment

### DIFF
--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/2-workload/rbd_api_tests.yaml
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/2-workload/rbd_api_tests.yaml
@@ -10,7 +10,7 @@ tasks:
     client.0:
     - "cp --force $TESTDIR/ceph_test_librbd_api $(which ceph_test_librbd_api)"
     - "rm -rf $TESTDIR/ceph_test_librbd_api"
-- print: "**** done reverting to hammer ceph_test_librbd_api"
+- print: "**** done reverting to infernalis ceph_test_librbd_api"
 - workunit:
     branch: infernalis
     clients:


### PR DESCRIPTION
When the file was copied from the hammer version, the word "hammer"
was not changed to "infernalis".

Signed-off-by: Nathan Cutler <ncutler@suse.com>

This cannot be cherry-picked from master because the test has been dropped.