### PR TITLE
test: add explicit braces to avoid ambiguous ‘else’ and to silence warnings

### DIFF
--- a/.organizationmap
+++ b/.organizationmap
@@ -484,6 +484,7 @@ The Linux Box <contact@linuxbox.com> Casey Bodley <casey@linuxbox.com>
 The Linux Box <contact@linuxbox.com> Matt Benjamin <matt@linuxbox.com>
 The University of Arizona <contact@arizona.edu> James Ryan Cresawn <jrcresawn@gmail.com>
 Time Warner Cable Inc. <contact@twcable.com> Bryan Stillwell <bryan.stillwell@twcable.com>
+Trendy Tech <contact@trendytech.com.cn> shiqi <m13913886148@gmail.com>
 Ubuntu Kylin <contact@ubuntukylin.com> Min Chen <minchen@ubuntukylin.com>
 UMCloud <contact@umcloud.com> Jiaying Ren <mikulely@gmail.com>
 UMCloud <contact@umcloud.com> Rongze Zhu <zrzhit@gmail.com>
@@ -639,7 +640,6 @@ Unaffiliated <no@organization.net> Shang Ding <dingshang2013@163.com>
 Unaffiliated <no@organization.net> Shanggao Qiu <qiushanggao@qq.com>
 Unaffiliated <no@organization.net> Shawn Chen <cxwshawn@gmail.com>
 Unaffiliated <no@organization.net> Shawn Edwards <lesser.evil@gmail.com>
-Unaffiliated <no@organization.net> shiqi <m13913886148@gmail.com>
 Unaffiliated <no@organization.net> Simon Guinot <simon.guinot@sequanux.org>
 Unaffiliated <no@organization.net> Stephen F Taylor <steveftaylor@gmail.com>
 Unaffiliated <no@organization.net> Steve Stock <steve@technolope.org>

--- a/admin/build-doc
+++ b/admin/build-doc
@@ -57,7 +57,7 @@ cd build-doc
 [ -z "$vdir" ] && vdir="$TOPDIR/build-doc/virtualenv"
 
 if [ ! -e $vdir ]; then
-    virtualenv --system-site-packages $vdir
+    virtualenv --system-site-packages $vdir -p python2
 fi
 $vdir/bin/pip install --quiet -r $TOPDIR/admin/doc-requirements.txt
 

--- a/admin/serve-doc
+++ b/admin/serve-doc
@@ -1,4 +1,6 @@
 #!/usr/bin/python
+from __future__ import print_function
+
 import SimpleHTTPServer
 import SocketServer
 import os
@@ -24,6 +26,7 @@ httpd = SocketServer.TCPServer(
     ReusingTCPServer,
     )
 try:
+    print("Serving doc at port: http://localhost:8080")
     httpd.serve_forever()
 except KeyboardInterrupt:
     pass

--- a/doc/changelog/v10.2.7.txt
+++ b/doc/changelog/v10.2.7.txt
@@ -1,0 +1,1530 @@
+commit 50e863e0f4bc8f4b9e31156de690d765af245185
+Author: Jenkins Build Slave User <ceph-release-team@redhat.com>
+Date:   Mon Apr 10 11:43:44 2017 +0000
+
+    10.2.7
+
+commit a64d3e4b33e904aa6585464df8ffff6aafdec10c
+Merge: c92640a 6c2a40a
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:27:07 2017 -0600
+
+    Merge pull request #14230 from linuxbox2/wip-jewel-expand-argv
+    
+    jewel: rgw_file: expand argv
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit c92640a113843a491678c11319d2352f14486f17
+Merge: 7c35658 fcc3ada
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:17:10 2017 -0600
+
+    Merge pull request #14233 from ktdreyer/wip-19421-jewel
+    
+    jewel: librbd: possible race in ExclusiveLock handle_peer_notification
+    
+    Reviewed-by: Jason Dillaman <dillaman@redhat.com>
+
+commit 7c3565899af5f1f474d82d8802d15c6c216ea894
+Merge: 12467f6 eedb9f7
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:16:48 2017 -0600
+
+    Merge pull request #14231 from linuxbox2/wip-jewel-fhcache
+    
+    jewel: rgw_fh: RGWFileHandle dtor must also cond-unlink from FHCache
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 12467f6c3f346072d81c444ed68eb206402d8c33
+Merge: 2d2521c 78c8be7
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:09:14 2017 -0600
+
+    Merge pull request #14215 from mdw-at-linuxbox/wip-jewel-rgw-openssl-fix1
+    
+    rgw: fix openssl
+    
+    Reviewed-by: Ken Dreyer <kdreyer@redhat.com>
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 2d2521c0300000421740c611a5133c82d2e4d0f6
+Merge: 0840cf8 7e4e290
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:07:48 2017 -0600
+
+    Merge pull request #14206 from linuxbox2/wip-gui-jewel
+    
+    jewel: rgw_file: various fixes
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 0840cf86214c793794c6f913b63cc67e0ab3fc94
+Merge: 0bf6360 b24a8c2
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:07:03 2017 -0600
+
+    Merge pull request #14205 from linuxbox2/wip-dir-orphan-jewel
+    
+    jewel:  rgw_file: wip dir orphan
+    
+     Conflicts:
+    	src/rgw/rgw_file.cc (whitespace, trivial resolution)
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 0bf636057ba853d1d1a777147014a740d5149b17
+Merge: 83b5a7f fb85c68
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:05:40 2017 -0600
+
+    Merge pull request #14169 from linuxbox2/wip-18650-jewel
+    
+    jewel: rgw: rgw_file: FHCache residence check should be exhaustive
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 83b5a7f1c589546645e0f377d5d5f7b1f7363a59
+Merge: 6a175f2 a969c44
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Fri Mar 31 10:02:58 2017 -0600
+
+    Merge pull request #13869 from smithfarm/wip-19161-jewel
+    
+    jewel: rgw: rgw_file: fix marker computation
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit fb85c68dfbfcfb299cac3a7e6723067f216483ef
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Tue Feb 28 15:49:06 2017 -0500
+
+    rgw_file:  use fh_hook::is_linked() to check residence
+    
+    Previously we assumed that !deleted handles were resident--there
+    is an observed case where a !deleted handle is !linked.  Since
+    we currently use safe_link mode, an is_linked() check is
+    available, and exhaustive.
+    
+    Fixes: http://tracker.ceph.com/issues/19111
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit c0aa515f8d8c57ec5ee09e3b60df3cac60453c40)
+
+commit fcc3ada733bac74a642ccd0f1ed6301ad7318a30
+Author: Mykola Golub <mgolub@mirantis.com>
+Date:   Tue Mar 28 15:55:11 2017 +0200
+
+    jewel: librbd: possible race in ExclusiveLock handle_peer_notification
+    
+    This is a cherry-pick from kraken -- the master diverged after
+    ManagedLock refactoring and is not affected.
+    
+    Fix: http://tracker.ceph.com/issues/19368
+    Signed-off-by: Mykola Golub <mgolub@mirantis.com>
+    (cherry picked from commit df59d6d5f7deb586cf14a6ef6984e6847db08852)
+
+commit eedb9f7d2d2a4047b473f23c5a6956c40a3da126
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Tue Feb 28 20:24:12 2017 -0500
+
+    rgw_file: RGWFileHandle dtor must also cond-unlink from FHCache
+    
+    Formerly masked in part by the reclaim() action, direct-delete now
+    substitutes for reclaim() iff its LRU lane is over its high-water
+    mark, and in particular, like reclaim() the destructor is certain
+    to see handles still interned on the FHcache when nfs-ganesha is
+    recycling objects from its own LRU.
+    
+    Fixes: http://tracker.ceph.com/issues/19112
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit d51a3b1224ba62bb53c6c2c7751fcf7853c35a4b)
+
+commit 6c2a40a800277ded302f3183ac6c68b01ca3ed41
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Tue Jan 17 11:23:45 2017 -0500
+
+    rgw_file:  split last argv on ws, if provided
+    
+    This is intended to allow an "extra" unparsed argument string
+    containing various cmdline options to be passed as the last argument
+    in the argv array of librgw_create(), which nfs-ganesha is
+    expecting to happen.
+    
+    While at it, hook env_args() too.
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit fbc19e4effc736c98cc1cc283e5c7b131a0fa766)
+
+commit d2ca03b391340c6944ba453b106f3e1c45b75f1d
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 12 20:18:26 2017 -0500
+
+    rgw_file: fix hiwat behavior
+    
+    Removed logic to skip reclaim processing conditionally on hiwat,
+    this probably meant to be related to a lowat value, which does
+    not exist.
+    
+    Having exercised the hiwat reclaim behavior, noticed that the
+    path which moves unreachable objects to LRU, could and probably
+    should remove them altogether when q.size exceeds hiwat.  Now
+    the max unreachable float is lane hiwat, for all lanes.
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit b8791b2217e9ca87b2d17b51f283fa14bd68b581)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 166cb7f85c240eeaffc70968abf5352d9cd45bd9
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 12 18:20:43 2017 -0500
+
+    rgw_file: refcnt bugfixes
+    
+    This change includes 3 related changes:
+    
+    1. add required lock flags for FHCache updates--this is a crash
+       bug under concurrent update/lookup
+    
+    2. omit to inc/dec refcnt on root filehandles in 2 places--the
+       root handle current is not on the lru list, so it's not
+       valid to do so
+    
+    3. based on observation of LRU behavior during creates/deletes,
+       update (cohort) LRU unref to move objects to LRU when their
+       refcount falls to SENTINEL_REFCNT--this cheaply primes the
+       current reclaim() mechanism, so very significanty improves
+       space use (e.g., after deletes) in the absence of scans
+       (which is common due to nfs-ganesha caching)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit beaeff059375b44188160dbde8a81dd4f4f8c6eb)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 31a71be9c9f24e22cf7e6eb390d3b39811ee3577
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sat Feb 11 16:38:05 2017 -0500
+
+    rgw_file:  add refcount dout traces at debuglevel 17
+    
+    These are helpful for checking RGWFileHandle refcnt invariants.
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 462034e17f919fb783ee33e2c9fa8089f93fd97d)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 1d6c72fe9a59561fb8f33889895b6708342b2856
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Fri Feb 10 17:14:16 2017 -0500
+
+    rgw_file: add pretty-print for RGWFileHandle
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit ef330f385d3407af5f470b5093145f59cc4dcc79)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit a969c449272ce88ddcbbd509432134f19520c8c3
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Mon Feb 20 15:05:18 2017 -0500
+
+    rgw_file: fix marker computation
+    
+    Fixes: http://tracker.ceph.com/issues/19018
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 4454765e7dd08535c50d24205858e18dba4b454c)
+
+commit a70e83c90eb42439ba194ca197f507f972a18c3c
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 19 20:34:31 2017 -0500
+
+    rgw_file: rgw_readdir can't list multi-segment dirs
+    
+    This issue has one root cause in librgw, namely that the marker
+    argument to these requests was incorrectly formatted (though the
+    marker cache was working as intended).
+    
+    Secondarily, for nfs-ganesha users, there is a compounding issue
+    that the RGW fsal was required by "temporary" convention to
+    populate the entire dirent cache for a directory on a single
+    readdir() invocation--the cache_inode/mdcache implementations
+    invariantly pass (before future 2.5 changesets, currently in
+    progress) a null pointer for the start cookie offset, intended
+    to convey this.
+    
+    Fixes: http://tracker.ceph.com/issues/18991
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 2cd60ee9712291b906123aca1704288b18a9742b)
+
+commit 209987e1c764cac7574bf0bb969e93fcf55b4361
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 19 18:21:06 2017 -0500
+
+    rgw_file: allow setattr on placeholder directories
+    
+    When a POSIX path <bucket>/foo/ is known only as an implicit path
+    segment from other objects (e.g., <bucket>/foo/bar.txt), a case
+    that would usually arise from S3 upload of such an object, an
+    RGWFileHandle object representing "<bucket>/foo/" will be constructed
+    as needed, with no backing in RGW.
+    
+    This is by design, but subsequently, if a setattr is performed on
+    such a handle, we must be ready to create the object inline with
+    storing the attributes.
+    
+    Fixes: http://tracker.ceph.com/issues/18989
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 55eec1c0a0e136736961423b7b6244d0f3693c1a)
+
+commit 6a175f27961bd4f0fda8f94c200458f17865c9f9
+Merge: d32ae21 f3face6
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:36:35 2017 -0600
+
+    Merge pull request #14140 from smithfarm/wip-19341-jewel
+    
+    jewel: 'period update' does not remove short_zone_ids of deleted zones
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit d32ae21128d664370f7d07ed14427b75e10da7f8
+Merge: 4dfeed9 0be4e89
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:35:16 2017 -0600
+
+    Merge pull request #13886 from cbodley/wip-17786
+    
+    jewel: rgw: clear data_sync_cr if RGWDataSyncControlCR fails
+    
+    Reviewed-by: Nathan Cutler <ncutler@suse.com>
+
+commit 4dfeed949655a5b5041f612b868225c234e86bba
+Merge: d69c54a 1985662
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:34:57 2017 -0600
+
+    Merge pull request #13867 from smithfarm/wip-19159-jewel
+    
+    jewel: rgw: multisite: RGWMetaSyncShardControlCR gives up on EIO
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit d69c54aca9dde3d64b56e5ee72f1cd29057a80c6
+Merge: 0830135 dfaaec0
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:34:24 2017 -0600
+
+    Merge pull request #13858 from smithfarm/wip-19152-jewel
+    
+    jewel: rgw_file:  restore (corrected) fix for dir partial match (return of FLAG_EXACT_MATCH)
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 0830135f40ac37ac9027bece65b8aac64c2c7ec9
+Merge: 4dd3a9f 97fed01
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:33:18 2017 -0600
+
+    Merge pull request #13848 from smithfarm/wip-19150-jewel
+    
+    jewel: rgw_file:  avoid interning .. in FHCache table and don't ref for them
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 4dd3a9f628053784cff2aa5849ab3c4cdb2acf4e
+Merge: 5eeba9c d333add
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:29:30 2017 -0600
+
+    Merge pull request #13844 from smithfarm/wip-19148-jewel
+    
+    jewel: rgw: DUMPABLE flag is cleared by setuid preventing coredumps
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 5eeba9cb85e9111ef124acd36dccf77c6f00b3e4
+Merge: ae632b0 f7ce5df
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:26:48 2017 -0600
+
+    Merge pull request #13823 from asheplyakov/19176-bp-jewel
+    
+    jewel: rgw: fix swift cannot disable object versioning with empty X-Versions-Location
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit ae632b0da6cc90a993fcae31b56f97c834d15aa1
+Merge: 874120f e8041f6
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:22:23 2017 -0600
+
+    Merge pull request #13778 from smithfarm/wip-18811-jewel
+    
+    jewel: librgw: RGWLibFS::setattr fails on directories
+    
+    Reviewed-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 874120f627f509c75b28d1be699812fce881f4bb
+Merge: b0108ea e475bfa
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:21:44 2017 -0600
+
+    Merge pull request #13717 from asheplyakov/19115-bp-jewel
+    
+    jewel: rgw_file: ensure valid_s3_object_name for directories, too
+    
+    Reviewed-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit b0108ea3bae1662e90c7fb9a911257f45193798c
+Merge: 6518d70 db928d6
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:19:03 2017 -0600
+
+    Merge pull request #13596 from dillaman/wip-19038-jewel
+    
+    jewel: rbd-mirror: deleting a snapshot during sync can result in read errors
+    
+    Reviewed-by: Mykola Golub <mgolub@mirantis.com>
+
+commit 6518d70b89686b9a4e8854a4c6290381fbcdd8c3
+Merge: db50938 8941881
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:10:43 2017 -0600
+
+    Merge pull request #13583 from asheplyakov/jewel-bp-18901
+    
+    jewel: rgw_file:  interned RGWFileHandle objects need parent refs
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit db50938013f0b1c1fe8a23247c91bbfc38d36a8c
+Merge: 7536871 d44263f
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 16:02:43 2017 -0600
+
+    Merge pull request #13503 from linuxbox2/wip-jewel-10156
+    
+    jewel: rgw: make sending Content-Length in 204 and 304 controllable
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+    Reviewed-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>
+
+commit 75368712aafc51b062b674b263354cca2dd4b49a
+Merge: 250071e 2f20328
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 15:53:49 2017 -0600
+
+    Merge pull request #13232 from ovh/wip-rework-recovery-priorities-jewel
+    
+    jewel: osd: Increase priority for inactive PGs backfill
+    
+    Reviewed-by: Sage Weil <sage@redhat.com>
+
+commit 250071eb8dc744237acfed01df2cf04f2d88bc85
+Merge: 6f57a77 9910eac
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 15:51:46 2017 -0600
+
+    Merge pull request #13219 from linuxbox2/jewel-rgw-multipart-upload-copy-4
+    
+    jewel: rgw: multipart uploads copy part support
+    
+    Reviewed-by: Casey Bodley <cbodley@redhat.com>
+
+commit 6f57a775301edce7a1039a4aa4479bbd8883cbf6
+Merge: 8c02e54 3fce77a
+Author: Ken Dreyer <kdreyer@redhat.com>
+Date:   Tue Mar 28 15:51:24 2017 -0600
+
+    Merge pull request #13108 from vumrao/wip-vumrao-jewel-18657
+    
+    jewel: osd: fix OSD network address in OSD heartbeat_check log message
+    
+    Reviewed-by: Josh Durgin <jdurgin@redhat.com>
+
+commit b24a8c2f3890b6fcc60f3b52cba93d573b9d45a2
+Author: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+Date:   Thu Mar 2 17:21:57 2017 +0800
+
+    rgw_file: posix style atime,ctime,mtime
+    
+    As an ganesha FSAL backend, rgw_file should properly maintain
+    the atime,ctime,mtime properly against operations such as:
+    	(read,write) for file
+    	(create,unlink,mkdir,rmdir,rename) for dir
+    	(setattr) for file and dir
+    
+    Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+    (cherry picked from commit ac25da2479b9be876cbdb820560ac46a6e2b17d7)
+
+commit b6181833be925b7eb11afffff7f03486bdde2d25
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Mon Feb 20 15:05:18 2017 -0500
+
+    rgw_file: fix marker computation
+    
+    Fixes: http://tracker.ceph.com/issues/19018
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 4454765e7dd08535c50d24205858e18dba4b454c)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit ed9308cba2af227991a50a9535df30cf9bb18a82
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 19 20:34:31 2017 -0500
+
+    rgw_file: rgw_readdir can't list multi-segment dirs
+    
+    This issue has one root cause in librgw, namely that the marker
+    argument to these requests was incorrectly formatted (though the
+    marker cache was working as intended).
+    
+    Secondarily, for nfs-ganesha users, there is a compounding issue
+    that the RGW fsal was required by "temporary" convention to
+    populate the entire dirent cache for a directory on a single
+    readdir() invocation--the cache_inode/mdcache implementations
+    invariantly pass (before future 2.5 changesets, currently in
+    progress) a null pointer for the start cookie offset, intended
+    to convey this.
+    
+    Fixes: http://tracker.ceph.com/issues/18991
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 2cd60ee9712291b906123aca1704288b18a9742b)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 26a38e2e1525714978feda018c03698d7af65129
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 19 18:21:06 2017 -0500
+
+    rgw_file: allow setattr on placeholder directories
+    
+    When a POSIX path <bucket>/foo/ is known only as an implicit path
+    segment from other objects (e.g., <bucket>/foo/bar.txt), a case
+    that would usually arise from S3 upload of such an object, an
+    RGWFileHandle object representing "<bucket>/foo/" will be constructed
+    as needed, with no backing in RGW.
+    
+    This is by design, but subsequently, if a setattr is performed on
+    such a handle, we must be ready to create the object inline with
+    storing the attributes.
+    
+    Fixes: http://tracker.ceph.com/issues/18989
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 55eec1c0a0e136736961423b7b6244d0f3693c1a)
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 7e4e29038bd820e171d007360cf383c85f67879b
+Author: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+Date:   Wed Mar 8 16:23:11 2017 +0800
+
+    rgw_file: fix reversed return value of getattr
+    
+    When ::getattr returns -ESTALE, rgw_getattr returns ESTALE,
+    which is a not expected postive.
+    
+    Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+    (cherry picked from commit 39203cf872b8f4af86eb0e4a0f96dffd9cc92b41)
+
+commit 3c02ee4fe9ae70f30328a7b015f5cac4a1804c67
+Author: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+Date:   Mon Mar 20 10:53:46 2017 +0800
+
+    rgw_file: fix non-negative return code for open operation
+    
+    The nfs-ganesha expects a negative retcode for errors.
+    
+    Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+    (cherry picked from commit b5f70ef7b066f9ff44770cc8a50ccadaa02f4691)
+
+commit e9a4903c6e77caae6f161056e8aaa5ba10ae5ef2
+Author: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+Date:   Wed Mar 15 15:01:05 2017 +0800
+
+    rgw_file: fix double unref on rgw_fh for rename
+    
+    Skip unref after unlink to fix the problem.
+    
+    Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>
+    (cherry picked from commit bff228734c73b536d2482e2e2fa4ad38b206ebff)
+
+commit 9910eac98474930369d694b236c06ffd627fee04
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 22:20:10 2016 -0700
+
+    rgw: multipart part copy, fix regression
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 66fbe9384703c004c01783eb664f55895d310439)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit a3fdf0e246637ef4145b6b5ba1f4b114ec7ebc62
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 17:44:08 2016 -0700
+
+    rgw: minor optimization
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 4919dc9987c6376d3d4e143702c26417449524c5)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 2161376baf413acfbf02df07e404d2918729bfcc
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 17:43:00 2016 -0700
+
+    rgw: rgw_obj_key use adjustment in multipart copy part
+    
+    This fixes a case where objects start with double underscore.
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 29fece3545cc1df404a25eec46706b16f893a5df)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 135f84d860d10a2961f430708983113a87ddf899
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 17:43:35 2016 -0700
+
+    rgw: multipart copy-part handle versionId
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 53521efffb1cb92e5f5ce992d4127bf9498d7c33)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 9ab65f5501fb59aac17cfdde57371b00af03d84b
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 14:24:13 2016 -0700
+
+    rgw: multipart copy part minor parsing cleanup
+    
+    no need for range.size()
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 6e9b824d5d4017239d58b4752ebc43bfad8f698d)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 3eb9dc96ff8e655415500a3595a78cab80739826
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 14:11:43 2016 -0700
+
+    rgw: multipart copy, check for empty bucket, improve logging
+    
+    also reduce log level for non critical user errors.
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 2bcb3d286b230ef917d5ba96c8276a942f544689)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit 2588e95d9d422d3b33fd710de1f5884873465483
+Author: Yehuda Sadeh <yehuda@redhat.com>
+Date:   Thu Sep 29 14:07:14 2016 -0700
+
+    rgw: multipart copy part, chunked read
+    
+    Don't read the entire range from source object, read it in parts.
+    
+    Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>
+    (cherry picked from commit 4049e47a0cfc1eef6efd502590b68ba7234589d3)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit bd118b556562176ce2390a935b3bb8c25a62d0c4
+Author: Javier M. Mellid <jmunhoz@igalia.com>
+Date:   Tue Jul 26 14:56:50 2016 +0200
+
+    rgw: doc: add multipart uploads copy part feature as supported
+    
+    Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>
+    (cherry picked from commit 8a7ebeee2ff3f10ceb23b7fa43e43c3c450efe22)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit b56b719299becc38ec36d427a36b8c29f2416c08
+Author: Javier M. Mellid <jmunhoz@igalia.com>
+Date:   Tue Jul 26 14:53:44 2016 +0200
+
+    rgw: multipart uploads copy part support
+    
+    Add multipart uploads copy part feature.
+    
+    Fixes: http://tracker.ceph.com/issues/12790
+    
+    Signed-off-by: Javier M. Mellid <jmunhoz@igalia.com>
+    (cherry picked from commit 949480c2e9760855ed6a0501d364d5e766c8207d)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit d44263fc91da12ea0ad4fec0cd2877b36ddb9e9f
+Author: Radoslaw Zarzynski <rzarzynski@mirantis.com>
+Date:   Fri Feb 17 00:56:34 2017 +0100
+
+    rgw: make sending Content-Length in 204 and 304 controllable
+    
+    This commit introduces a new configurable "rgw print prohibited
+    content length" to let operator decide whether RadosGW complies
+    to RFC 7230 (a part of the HTTP specification) or violates it
+    but follows the Swift's behavior.
+    
+    Fixes: http://tracker.ceph.com/issues/16602
+    Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>
+    (cherry picked from commit d8e3e64ec97a3c222a56bb6f510e5e23d7858615)
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+
+commit f3face61351a61f3b71dfb8268a4b645c4d92da2
+Author: Casey Bodley <cbodley@redhat.com>
+Date:   Thu Mar 9 15:24:08 2017 -0500
+
+    rgw: clear old zone short ids on period update
+    
+    the short ids of old, removed zones were being kept in the period to
+    guard against hash collisions with new zones
+    
+    but for a hash collision to cause a wrong object to sync, that object
+    would have to be uploaded simultaneously to two different zones that had
+    the same short id
+    
+    to avoid this, we just have to prevent the period from containing two
+    colliding zones at the same time - we don't have to remember old zone
+    short ids forever
+    
+    Fixes: http://tracker.ceph.com/issues/15618
+    
+    Signed-off-by: Casey Bodley <cbodley@redhat.com>
+    (cherry picked from commit 9c45633c836c966ab1f75ea2b1ad3fa0a4886600)
+
+commit 8c02e54a747644d24feb98dbc15a15cdd55d1afd
+Merge: 9d222b9 952f34f
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri Mar 24 08:13:02 2017 -0700
+
+    Merge pull request #13146 from dzafman/wip-18502-jewel-zafman
+    
+    jewel: osd: Scrub improvements and other fixes
+    
+    Reviewed-by: Kefu Chai <kchai@redhat.com>
+
+commit 9d222b943217a2ec022678e50b34766d231004ce
+Merge: ce2e989 cb9fae5
+Author: Nathan Cutler <presnypreklad@gmail.com>
+Date:   Thu Mar 23 16:49:13 2017 +0100
+
+    Merge pull request #14100 from smithfarm/wip-18781
+    
+    Manually merge PR#13143 which was mistakenly merged to jewel-next
+    
+    Reviewed-by: Loic Dachary <ldachary@redhat.com>
+    Reviewed-by: Ken Dreyer <kdreyer@redhat.com>
+
+commit cb9fae56ebdfda28b0606ee89631deb60e5f7de7
+Merge: ce2e989 ee3c67c
+Author: Nathan Cutler <ncutler@suse.com>
+Date:   Thu Mar 23 09:46:53 2017 +0100
+
+    Merge branch 'jewel-next' into jewel
+    
+    Branch "jewel-next" was merged to jewel on Dec 22 (5b402f8a7b), and then PR
+    https://github.com/ceph/ceph/pull/13143 merged to jewel-next much later (Feb
+    1st), and then jewel-next was never merged to jewel again before we tagged
+    v10.2.6.
+    
+    This merge brings in a single commit, i.e. the one from
+    https://github.com/ceph/ceph/pull/13143
+    
+    Reported-by: Ken Dreyer <kdreyer@redhat.com>
+    Signed-off-by: Nathan Cutler <ncutler@suse.com>
+
+commit ce2e9897c08775cfbe318f637d61e07eb5433df5
+Merge: 656b5b6 d0a0d2f
+Author: Zack Cerza <zack@cerza.org>
+Date:   Tue Mar 14 09:19:28 2017 -0600
+
+    Merge pull request #13952 from smithfarm/wip-fix-merge-error
+    
+    tests: fix merge error in rgw/singleton/all/radosgw-admin.yaml
+
+commit 0be4e89419f2083d081ac784891e4653290cd530
+Author: Casey Bodley <cbodley@redhat.com>
+Date:   Tue Oct 11 15:21:42 2016 -0400
+
+    rgw: hold a reference on data_sync_cr over run()
+    
+    run() will drop its reference to data_sync_cr, so we need to hold a
+    reference until we can reacquire the lock
+    
+    Signed-off-by: Casey Bodley <cbodley@redhat.com>
+    (cherry picked from commit 4cf0d2a768e7402e71280ca16b47353ca2a68505)
+
+commit 18ffdb7baf4aff1fd7f894af1054081f3ee61d28
+Author: Casey Bodley <cbodley@redhat.com>
+Date:   Tue Oct 11 15:19:37 2016 -0400
+
+    rgw: clear data_sync_cr if RGWDataSyncControlCR fails
+    
+    async notifications will still try to call wakeup() on RGWDataSyncControlCR
+    if it fails, leading to segfault
+    
+    Fixes: http://tracker.ceph.com/issues/17569
+    
+    Signed-off-by: Casey Bodley <cbodley@redhat.com>
+    (cherry picked from commit 5cc599b9bf2dde31de16a5b2831baf06851d69d5)
+    
+     Conflicts:
+    	src/rgw/rgw_data_sync.cc: declaration of 'int r'
+
+commit d0a0d2f4bf1dacf7c1f38b968be84a5e905554a8
+Author: Nathan Cutler <ncutler@suse.com>
+Date:   Tue Mar 14 01:26:23 2017 +0100
+
+    tests: fix merge error in rgw/singleton/all/radosgw-admin.yaml
+    
+    Introduced by 94d5888c
+    
+    Reported-by: Robin H. Johnson <robin.johnson@dreamhost.com>
+    Signed-off-by: Nathan Cutler <ncutler@suse.com>
+
+commit 19856624cd5ea8cb82bc5b46e062beb39674bd34
+Author: Casey Bodley <cbodley@redhat.com>
+Date:   Mon Feb 20 16:00:01 2017 -0500
+
+    rgw: RGWMetaSyncShardControlCR retries with backoff on all error codes
+    
+    RGWBackoffControlCR only treats EBUSY and EAGAIN as 'temporary' error
+    codes, with all other errors being fatal when exit_on_error is set
+    
+    to RGWMetaSyncShardControlCR, a 'fatal' error means that no further sync
+    is possible on that shard until the gateway restarts
+    
+    this changes RGWMetaSyncShardControlCR to set exit_on_error to false, so
+    that it will continue to retry with backoff no matter what error code it
+    gets
+    
+    Fixes: http://tracker.ceph.com/issues/19019
+    
+    Signed-off-by: Casey Bodley <cbodley@redhat.com>
+    (cherry picked from commit 3e4059557fd6cad5d31014327f60832b36d04a6c)
+
+commit dfaaec0446c3db458bffe1d725518ab4f7cc2fa8
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Thu Feb 23 10:21:38 2017 -0500
+
+    rgw_file:  return of RGWFileHandle::FLAG_EXACT_MATCH
+    
+    Allow callers of rgw_lookup() on objects attested in an
+    rgw_readdir() callback the ability to bypass exact match in
+    RGWLibFS::stat_leaf() case 2, but restore exact match enforcement
+    for general lookups.
+    
+    This preserves required common_prefix namespace behavior, but
+    prevents clients from eerily permitting things like "cd sara0" via
+    partial name match on "sara01."
+    
+    Fixes: http://tracker.ceph.com/issues/19059
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 70ef7d45e0abf2661bd4e23161d4e70cf5178079)
+
+commit 9b3784d924112d9ba42b2088d5fb2656ef74fadc
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Sun Feb 19 17:43:17 2017 -0500
+
+    rgw_file: invalid use of RGWFileHandle::FLAG_EXACT_MATCH
+    
+    The change which introduced this flag also caused it to be
+    given as the flags argument to RGWLibFS::stat_leaf() when called
+    from rgw_lookup().
+    
+    This was incorrect:  in particular, when a directory is known only
+    as a common prefix of other objects, the AWS namespace mapping
+    convention requires lookup("foo") to match a non-materialized
+    instance of "foo/" (case 2 in RGWLibFS::stat_leaf's stat loop).
+    
+    Fixes: http://tracker.ceph.com/issues/18992
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit e31e9eb980f958640150e8d7f17de1b9e5478b1e)
+
+commit 7761376c92eb38a2dd3d19f0b3d81895a4b1167c
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Wed Feb 22 14:57:59 2017 -0500
+
+    rgw_file: rgw_lookup: don't ref for "/" or ".."
+    
+    These refs won't be returned by nfs-ganesha, and are sufficiently
+    magical that other consumers should be persuaded to understand
+    their specialness.
+    
+    Fixes: http://tracker.ceph.com/issues/19060
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit dea8d1ee373399a21851690a9753388b659b8ede)
+
+commit 97fed013f66a89c404bac5145080e5d556ff5c42
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Wed Feb 22 10:24:29 2017 -0500
+
+    rgw_file: avoid stranding invalid-name bucket handles in fhcache
+    
+    To avoid a string copy in the common mkdir path, handles for
+    proposed buckets currently are staged in the handle table, before
+    being rejected.  They need to be destaged, not just marked deleted
+    (because deleted objects are now assumed not to be linked, as of
+    beaeff059375b44188160dbde8a81dd4f4f8c6eb).
+    
+    This triggered an unhandled Boost assert when deleting staged
+    handles, as current safe_link mode requires first removing from
+    the FHCache.
+    
+    Fixes: http://tracker.ceph.com/issues/19036
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 6cde812c92e5bba9f85fbf8486ebe69b55952370)
+
+commit d333addb71a0a92fbac5a7b922dbd69fc9e0604e
+Author: Brad Hubbard <bhubbard@redhat.com>
+Date:   Mon Feb 27 13:06:59 2017 +1000
+
+    rgw: set dumpable flag after setuid post ff0e521
+    
+    ff0e521 resolved the issue for the other daemons but not for rgw since
+    it calls setuid (via civetweb) after the new code sets PR_SET_DUMPABLE.
+    Add another prctl call before wait_shutdown.
+    
+    Fixes: http://tracker.ceph.com/issues/19089
+    
+    Signed-off-by: Brad Hubbard <bhubbard@redhat.com>
+    (cherry picked from commit bc458d39630b599e0e1ca9fe25ad7455fcffdd10)
+
+commit f7ce5df4064e5538156cb44f9525d7552a0dd098
+Author: Jing Wenjun <jingwenjun@cmss.chinamobile.com>
+Date:   Wed Feb 8 15:07:43 2017 +0800
+
+    rgw: fix swift cannot disable object versioning with empty X-Versions-Location
+    
+    we should be able to disable object verioning by removing its X-Versions-Location
+    metadata header by sending an empty key value. this description can be found at
+    No.8 in http://docs.openstack.org/user-guide/cli-swift-set-object-versions.html.
+    
+    Fixes: http://tracker.ceph.com/issues/18852
+    Signed-off-by: Jing Wenjun <jingwenjun@cmss.chinamobile.com>
+    (cherry picked from commit 17c5a0edd2227703cec867f0f588d4eae36dfe1c)
+
+commit 2f2032814189a4ecbf8dc01b59bebfae8ab3f524
+Author: Bartłomiej Święcki <bartlomiej.swiecki@corp.ovh.com>
+Date:   Fri Dec 2 16:54:46 2016 +0100
+
+    osd: Increase priority for inactive PGs backfill
+    
+    This change does prioritize backfill of PGs which don't
+    have min_size active copies. Such PGs would cause IO stalls
+    for clients and would increase throttlers usage.
+    
+    This change also fixes few subtlle out-of-bounds bugs.
+    
+    Signed-off-by: Bartłomiej Święcki <bartlomiej.swiecki@corp.ovh.com>
+    (cherry picked from commit 6a76adcdb1f92c136841d960aa7cd4e5b94addec)
+    
+    Conflicts:
+    	PendingReleaseNotes (removed version number, merged conflicts)
+
+commit e8041f627c6a05a59dba29819ed610ea0896f4dd
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Fri Feb 3 13:44:45 2017 -0500
+
+    rgw_file:  fix RGWLibFS::setattr for directory objects
+    
+    Fixes:  http://tracker.ceph.com/issues/18808
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 4ad5a9226852d6d564baf2e63278ed6c4c185ecb)
+
+commit e475bfaf7d3a1b0e54172083a92546560219665a
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Thu Feb 23 16:02:07 2017 -0500
+
+    rgw_file: ensure valid_s3_object_name for directories, too
+    
+    The logic in RGWLibFS::mkdir() validated bucket names, but not
+    object names (though RGWLibFS::create() did so).
+    
+    The negative side effect of this was not creating illegal objects
+    (we won't), but in a) failing with -EIO and b) more importantly,
+    not removing up the proposed object from FHCache, which produced a
+    boost assert when recycled.
+    
+    Fixes: http://tracker.ceph.com/issues/19066
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit eb1cd3b30c0504385f05bf2d2dd5e2251b7efed7)
+
+commit 78c8be7a0df3d1c669f8a2a8fd7a5676d0823209
+Author: Marcus Watts <mdw@linuxbox.com>
+Date:   Thu Feb 23 02:30:52 2017 -0500
+
+    rgw/openssl fix: xenial autoconf logic problem: gcc/ld got too smart...
+    
+    On xenial, cc -o foo -lssl -lcrypto doesn't always
+    record libssl.so libcrypto.so as runtime library dependencies.
+    It is necessary to actually *use* a function from the library before
+    it gets recorded.  The ld(1) options "--as-needed" and "no-as-needed"
+    control this.  Evidently the default has changed in xenial.
+    That caused my smart "soname" detecting logic for openssl to
+    stop working.  To make it work, the test program has to
+    actually reference routines or variables inside the library.
+    
+    This is a quick fix for xenial / autoconf.  There needs to be
+    a better fix for cmake and master.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+
+commit db928d6b3f983b3a1ccc07440fcd3680700a1188
+Author: Jason Dillaman <dillaman@redhat.com>
+Date:   Tue Feb 21 15:33:01 2017 -0500
+
+    rbd-mirror: retry object copy after -ENOENT error
+    
+    Fixes: http://tracker.ceph.com/issues/18990
+    Signed-off-by: Jason Dillaman <dillaman@redhat.com>
+    (cherry picked from commit b4f36d5dc3f4f3cbb23f61cbb945b222248a50df)
+    
+    Conflicts:
+    	src/test/librados_test_stub/MockTestMemIoCtxImpl.h: sparse reads not supported
+    	src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc: sparse reads not supported
+
+commit a643fa80e03b41edcc720ff77b69ebaf24a23f3e
+Author: Jason Dillaman <dillaman@redhat.com>
+Date:   Tue Feb 21 13:09:39 2017 -0500
+
+    rbd-mirror: object copy should always reference valid snapshots
+    
+    If a remote snapshot is deleted while an image sync is in-progress,
+    associate the read request against the most recent, valid remote
+    snapshot for a given snapshot object clone.
+    
+    Signed-off-by: Jason Dillaman <dillaman@redhat.com>
+    (cherry picked from commit 9a91efc3047963364944f8be91cee8e8f6afc49a)
+
+commit 37bbc95d56f73e4ec9c6e13ddbae199b14b104b4
+Author: Jason Dillaman <dillaman@redhat.com>
+Date:   Tue Feb 21 11:52:00 2017 -0500
+
+    rbd-mirror: replace complex object op tuple with struct
+    
+    Signed-off-by: Jason Dillaman <dillaman@redhat.com>
+    (cherry picked from commit 0c181527c0e151784a0f7c466aaa70b0772f91b1)
+    
+    Conflicts:
+    	src/tools/rbd_mirror/image_sync/ObjectCopyRequest.cc: sparse reads not supported
+    	src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h: sparse reads not supported
+
+commit 8941881e8986af0b2871c15d188d94d49e95dc02
+Author: Matt Benjamin <mbenjamin@redhat.com>
+Date:   Fri Dec 30 23:30:16 2016 -0500
+
+    rgw_file:  interned RGWFileHandle objects need parent refs
+    
+    RGW NFS fhcache/RGWFileHandle operators assume existence of the
+    full chain of parents from any object to the its fs_root--this is
+    a consequence of the weakly-connected namespace design goal, and
+    not a defect.
+    
+    This change ensures the invariant by taking a parent ref when
+    objects are interned (when a parent ref is guaranteed).  Parent
+    refs are returned when objects are destroyed--essentially by the
+    invariant, such a ref must exist.
+    
+    The extra ref is omitted when parent->is_root(), as that node is
+    not in the LRU cache.
+    
+    Fixes: http://tracker.ceph.com/issues/18650
+    
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 0e5299f3f43e633a5d8a9360893b4b11f6217d81)
+
+commit 952f34f39cdd0438e4a4fb369ea8ca20b26488a8
+Author: David Zafman <dzafman@redhat.com>
+Date:   Mon Dec 12 15:53:25 2016 -0800
+
+    test: Update for new error message when doing scrub with deep-scrub errors
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 85e0774a7dded4aa6c67f237416041e25a7680bc)
+
+commit b655b98e48989ae954dc150fcb3d8976978cd90d
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri Dec 9 12:14:06 2016 -0800
+
+    osd: Add "trigger_scrub" admin socket command
+    
+    This allows testing to fake a schedule scrub (must_scrub not set)
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit c8dc945260ee2ee841aca00fbc802d41036033d6)
+
+commit 94c958d2c9570e55305384ac86185e328746d2ff
+Author: David Zafman <dzafman@redhat.com>
+Date:   Thu Dec 8 23:00:13 2016 -0800
+
+    test: Add test for keeping deep-scrub information
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 64a7012e986ec88994c073b738fd08e8958395c3)
+
+commit 42eb24f18d5114410bd2a3e84e9219584d9e165e
+Author: David Zafman <dzafman@redhat.com>
+Date:   Thu Dec 1 16:39:42 2016 -0800
+
+    osd: When deep-scrub errors present upgrade regular scrubs
+    
+    Previously, if a weekly deep-scrub found errors the next daily scrub
+    would cause the deep-scrub information to be removed.
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 532a759dca466181f37a329f86045c34f1a2506f)
+
+commit 76a457aa7c411dc5ed22f171954b8ed3c4661845
+Author: David Zafman <dzafman@redhat.com>
+Date:   Wed Oct 19 17:10:29 2016 -0700
+
+    tasks/scrub_test.py: Make test deterministic by updating digests
+    
+    ceph_test_rados: Get coverage of digest updates in deep-scrub/repair
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit e000ab2f46b7b98a223176a2a25bb7195e601af6)
+
+commit bd1f1983129d6e1787b8b5eb4884c5e908f7b274
+Author: David Zafman <dzafman@redhat.com>
+Date:   Wed Oct 19 17:10:07 2016 -0700
+
+    repair_test, scrub_test: Fix whitelists for scrub changes
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 5fe8522df47f56842d227e08b2912623504afe24)
+
+commit 28106f06404407df7d05b35f9f570a80e785e635
+Author: David Zafman <dzafman@redhat.com>
+Date:   Wed Aug 31 12:02:31 2016 -0700
+
+    scrub_test: Fix for list-inconsistent-obj output changes
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 5ae0f5c75a8236d4a026f9ddcb5ff59964d90579)
+
+commit abcefc1395f76e5b05a988b970457a7f6dac6e8e
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Aug 30 12:11:44 2016 -0700
+
+    doc, test: Add schemas for list-inconsistent-* rados command output
+    
+    If jsonschema cmd is available use it to test output against schema
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit eb73dd473600fbbb45fad00194f7c46b565d6b81)
+
+commit 2fa2b64676555a91883a5aabb4e4237124308629
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Aug 30 12:22:55 2016 -0700
+
+    test: Update testing for new list-inconsistent-obj output
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit b7bacd219b000869b9c93e21edba4f8a3ace60d9)
+    
+    Adapted for difference in Jewel object_info
+
+commit 304f697ff1106695188b572e0da2415437040a6c
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Aug 30 12:22:29 2016 -0700
+
+    rados, osd: Improve attrs output of list-inconsistent-obj
+    
+    Persist the user_version and shard id of scrubbed obj
+    Rados command dump inconsistent obj's version and shard-id
+        so they can be passed to repair command
+    Rados list-inconsistent-obj output of attrs
+        Make attrs an array since there are more than one
+        Use base64 encode for values with non-printable chars
+        Add indication if base64 encoding used
+    Add checking for ss_attr_missing and ss_attr_corrupted
+        Rename attr errors to attr_key_mismatch and attr_value_mismatch
+    Add missing size_mismatch_oi scrub checking
+    For erasure coded pools add ec_size_error and ec_hash_error not just read_error
+    Use oi_attr_missing and oi_attr_corrupted just like list-inconsistent-snap does
+    Pick an object info based on version and use that to find specific shards in error
+        Check for object info inconsistency which should be rare
+    Make all errors based on comparing shards to each other object errors
+        We don't want give the impression that we've picked the correct one
+    
+    Signed-off-by: Kefu Chai <kchai@redhat.com>
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit df3ff6dafeadb3822b35c424a890db9a14d7f60f)
+
+commit ea52f527e530b111b1bb26d10824c0230d662c4a
+Author: David Zafman <dzafman@redhat.com>
+Date:   Thu Sep 1 14:45:01 2016 -0700
+
+    osd: Fix logging to help with diagnostics
+    
+    These messages were not outputing the intended information
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit b39001ec6ff0996860bcb5a3578bc2c66355c781)
+
+commit 5e8f8a2288aa1a9f1de86d3f7d0f9c66c795113e
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Jun 21 18:05:25 2016 -0700
+
+    test: Fix use of wait_for_clean()
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit d0503a52d0fe5505bdb38dfd613c03a20500c05d)
+
+commit 2230e6adc66ca3e5dbe81aecccdb4a435e93e256
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Aug 30 10:56:06 2016 -0700
+
+    common: Change cleanbin() to use base64 encoding, update ceph-objectstore-tool
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 92e982c71995b863466d83671468f84761cb1793)
+
+commit 83ea077ee560d31a5c302a62b55451a2571fda8d
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Aug 30 11:05:16 2016 -0700
+
+    common: Move cleanbin() function to common/util.cc
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 5c79074ffaee34b2956d9dfc67b1eff9f39b47f3)
+    
+    Conflicts:
+    	src/tools/CMakeLists.txt (changes goes in src/CMakeLists.txt)
+
+commit ba84ca9fa391d963d1d4e46fbf27ce3dbff397be
+Author: David Zafman <dzafman@redhat.com>
+Date:   Wed Jun 8 09:48:00 2016 -0700
+
+    test: Add test support for deep-scrub
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 907e79e2b77835d1aca9e8ba2fae5fa2fd437e5a)
+
+commit 6a421d19d0be4d59beed5c69bb0aa4477d65a14e
+Author: David Zafman <dzafman@redhat.com>
+Date:   Sat Jun 18 17:58:36 2016 -0700
+
+    common: Fix indentation
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit a74418a29e4e469117fc0c4edd80f78b62944c98)
+
+commit c7c3e070336dc898460d4338b4d78b8963467c8a
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri Aug 12 12:06:31 2016 -0700
+
+    osd: Handle corrupt attributes in get_object_context()
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 30f8b0d6593718dd10bcf6ff459c95b4bb68c05c)
+
+commit 8006ba7e86ebb8201a040c427cc95197901064be
+Author: Kefu Chai <kchai@redhat.com>
+Date:   Fri Nov 11 21:37:50 2016 +0800
+
+    ReplicatedPG::failed_push: release read lock on failure
+    
+    and requeue the blocked ops.
+    
+    Fixes: http://tracker.ceph.com/issues/17857
+    Signed-off-by: Kefu Chai <kchai@redhat.com>
+    (cherry picked from commit b3224a18f6acc7ed54c2162b140a33b6146a16be)
+
+commit 5ca69d57dbe2ee7acc64d28ca35bb390bf463199
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri Oct 14 16:17:55 2016 -0700
+
+    test.sh: Make check for flags more robust
+    
+    Low space broke test, saw "flags nearfull,pauserd,pausewr...."
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit b4c080b1b4378d659c1ca8a17811cd6f84595166)
+
+commit 1be38e5ebd2d01d5d527b05e64b026df955ffe69
+Author: David Zafman <dzafman@redhat.com>
+Date:   Thu Jul 21 17:36:34 2016 -0700
+
+    test: Remove extra objectstore_tool call which causes a recovery
+    
+    Caused by: 70e000a9a42c50eda48f5d3b9e432ffc3a70f75b
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 6904529d1b53993304de2927500937ba0d493e9e)
+
+commit 026f181e72f2e09e769a8821dfe2c99f6213e6a3
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Jun 14 20:09:15 2016 -0700
+
+    test: Handle object removals in a non-racey way
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit bfe3ebd94fdc1ef36ebe6e8f9d38acea322eca22)
+
+commit c5ef385c25086dc1582ebe5343481d05283b0cc6
+Author: David Zafman <dzafman@redhat.com>
+Date:   Thu May 26 22:09:42 2016 -0700
+
+    osd: Fix hang on unfound object after mark_unfound_lost is done
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 73a27533beba3587f8447b4d41d200427c45042b)
+    
+    Conflicts:
+    	src/osd/ReplicatedPG.cc (trivial)
+
+commit 6284f745157458439699c76e8616455c50d1eb71
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri May 20 15:20:18 2016 -0700
+
+    osd: Handle recovery read errors
+    
+    Fixes: http://tracker.ceph.com/issues/13937
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit c51d70e1e837c972e42ddd5fa66f7ca4477b95cc)
+    
+    Conflicts:
+    	src/osd/ReplicatedPG.h (trivial)
+
+commit 27393a8c05d4656f342ecd32817307e558a2e400
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri May 20 18:19:42 2016 -0700
+
+    osd: Fix log messages
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit b40ec3fe890679b4c73778815e1bedd492cb264b)
+
+commit cbf66f3b16f194dd0c67b46e0fec247e02e84134
+Author: David Zafman <dzafman@redhat.com>
+Date:   Fri May 20 13:58:32 2016 -0700
+
+    osd: CLEANUP: Remove unused pending_read member
+    
+    Remove unused struct
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 36fd68c96653e83f87767feb08530a9fc6e841b0)
+
+commit 228b91d72a15b62adc10591604c4e8a849df53d5
+Author: David Zafman <dzafman@redhat.com>
+Date:   Tue Oct 11 18:08:12 2016 -0700
+
+    test/osd-scrub-repair.sh: Use test case specific object names to help with diagnostics
+    
+    Signed-off-by: David Zafman <dzafman@redhat.com>
+    (cherry picked from commit 0bf4da589155ee50969812492cfbc66368efb54c)
+
+commit ee3c67c9cbfdeeb3e628bac34b708cf150b3862e
+Merge: 3dbf0c9 39848e4
+Author: Nathan Cutler <presnypreklad@gmail.com>
+Date:   Wed Feb 1 23:28:22 2017 +0100
+
+    Merge pull request #13143 from linuxbox2/jewel-mdw-rgw-lf
+    
+    jewel: rgw: radosgw/swift: clean up flush / newline behavior.
+    
+    Reviewed-by: Nathan Cutler <ncutler@suse.com>
+
+commit 39848e41b7c517cc5faab1ccf77c2804fd7d2628
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Wed Jan 11 00:06:15 2017 -0500
+
+    radosgw/swift: clean up flush / newline behavior.
+    
+    The current code emits a newline after swift errors, but fails
+    to account for it when it calculates 'content-length'.  This results in
+    some clients (go github.com/ncw/swift) producing complaints about the
+    unsolicited newline such as this,
+    	Unsolicited response received on idle HTTP channel starting with "\n"; err=<nil>
+    
+    This logic eliminates the newline on flush.  This makes the content length
+    calculation correct and eliminates the stray newline.
+    
+    There was already existing separator logic in the rgw plain formatter
+    that can emit a newline at the correct point.  It had been checking
+    "len" to decide if previous data had been emitted, but that's reset to 0
+    by flush().  So, this logic adds a new per-instance variable to separately
+    track state that it emitted a previous item (and should emit a newline).
+    
+    Fixes: http://tracker.ceph.com/issues/18473
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
+    (cherry picked from commit 5f229d6a33eae4906f22cdb90941835e47ee9f02)
+
+commit 3fce77ab3662496368e25cbbf6d1b37d3c140db9
+Author: Vikhyat Umrao <vumrao@redhat.com>
+Date:   Wed Jan 25 21:54:27 2017 +0530
+
+    osd: jewel fix OSD network address in OSD heartbeat_check log message
+    
+    Fixes: http://tracker.ceph.com/issues/18657
+    
+    Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>
+
+commit 14a6aabe22f68436ea3297ce0851700f86ee5b12
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Wed Aug 3 17:36:55 2016 -0400
+
+    rgw: Handle multiple listening addreses w/ optional ssl "correctly" with civetweb.
+    
+    For civetweb: accept a range of port numbers joined with '+'.
+    Port numbers may include an ipaddress: prefix and 's' suffix.
+    Additionally, use "mg_get_local_addr" to correctly deduce host port per
+    incoming connection.
+    
+    civetweb can accept connections on multiple ports, some of which
+    might have SSL turned on and some not.  Both s3 and swift have various
+    authorization protocols in which the port number matters.  In the generic
+    radosgw frontend process, each frontend only has one port number, but
+    we should want to have both ssl and non-ssl connections managed within
+    one rgw frontend, because the thread pool is also per front-end, and
+    that *is* a scarce resource.
+    
+    So, this patch enables the use of multiple ports with a single civetweb
+    frontend.  To indicate https: append an 's' to portno.  To use multiple
+    ports, use +.  So 80+443s indicates use of the usual default http ports.
+    The parsed port is not stored in the frontend structure,
+    
+    So instead, this patch adds logic to use the results of
+    mg_get_local_addr() on a per-connection basis insetad of the generic
+    front-end port number.  This will affect "v4" s3 authorization, and also
+    affect swift pre-signed URLs.
+    
+    mg_get_local_addr() is a new customization to civetweb; that submodule
+    was updated (in a temporary repository) by the previous commit to this.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit 8bc6decc0774fae9ac881f91e73da55deebe3360)
+
+commit 698250563ccc4c69e5ca5aebf65dc352d80a8bdd
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Tue Dec 20 00:22:02 2016 -0500
+
+    rgw: s3: secure_port should override port, also apply ssl default right.
+    
+    Without https, only port is set.  With https, secure_port and port are
+    both set to the same value.  The previous logic looked at port first and
+    had overly simplified conditional logic which was liable to try to apply
+    both non-default cases.  The correct behavior is: look secure_port first,
+    and if secure_port is set, then only check to see if it's a non-default
+    port.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit a113cf5ff5a642d2ee4cc83f5c7001b4bfe0a5df)
+
+commit 28f2841c8b9a832e486b9f89c574a4591bf3d448
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Wed Nov 2 00:18:48 2016 -0400
+
+    rgw: Get civetweb ssl enhancement: wip-listen3 = mg_get_local_addr
+    
+    The logic inside of radosgw that computes aws v4 signatures wants to know
+    what server port the client connected.  The patch to civetweb patch adds a
+    call mg_get_local_addr() which will permit that code to actually find out
+    on what address a connection was received, rather than merely guessing
+    based on configuration as it previously did.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit 46ced9ddd2795f00f014e22e5637070b49e7a6d5)
+
+commit 8d83dfb4176ede7490d0cab589e9566bc7d4e387
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Wed Mar 23 17:32:14 2016 -0400
+
+    rgw: Document that radosgw now supports SSL.
+    
+    This includes information on file format and configuration file syntax.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit d4e72dfed30274b3cfbad4ac58c0746a98c0148b)
+
+commit e3f80c9d0ed6762a39fc242561f5ea26f0f26546
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Fri Jan 13 03:39:57 2017 -0500
+
+    rgw: civetweb/openssl: automagic: load libssl.so and libcrypto.so by soname.
+    
+    If building with radosgw, always look for openssl library (even when
+    building with nss).  Then, use objdump to fetch SONAME from the copies
+    of libssl and libcrypto that were found.  When building civetweb; pass
+    the library soname values in as the libraries to load with "dlopen".
+    
+    The issue reported here against master
+    http://tracker.ceph.com/issues/16535
+    reflects stuff that doesn't seem to have made it into jewel
+    	(which had: -lssl -lcrypto hard-wired into it.)
+    Still, since people were pretty riled about making that change,
+    this puts things in congruence to the final result in master.
+    	(which is: runtime shared object load of ssl crypto by soname.)
+    
+    Fixes: http://tracker.ceph.com/issues/11239
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (inspired by commit 7caa0bd002110b62514da83a37a2a3deb841267a)
+
+commit 045551485415309ba9bad77e1aee28a0008881ca
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Mon Jul 11 17:54:07 2016 -0400
+
+    rgw: civetweb/openssl: Load libssl.so and libcrypto.so by soname.
+    
+    If building with radosgw, always look for openssl library (even when
+    building with nss).  Then, use objdump to fetch SONAME from the copies
+    of libssl and libcrypto that were found.  When building civetweb; pass
+    the library soname values in as the libraries to load with "dlopen".
+    
+    This is a problem that went away for a bit, but came back with some
+    changes for
+    http://tracker.ceph.com/issues/16535
+    
+    Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1341775
+    Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1258961
+    
+    Fixes: http://tracker.ceph.com/issues/11239
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit 7caa0bd002110b62514da83a37a2a3deb841267a)
+
+commit 386640865dee30d38f17e55fc87535e419bc3cb5
+Author: Marcus Watts <mwatts@redhat.com>
+Date:   Thu Nov 3 23:33:44 2016 -0400
+
+    rgw: cmake: remove useless civetweb include path side effect.
+    
+    For 'target_include_directories" for the cmake object library
+    'civetweb_common_objs', change from PUBLIC to PRIVATE.  This doesn't
+    break anything, so it wasn't doing anything useful.  If it has it
+    any effect, it would be to cause everything that linked against this
+    "library" to also use the indictated include path.  Which would be great
+    except everything in ceph wants to include "civetweb/civetweb.h" and
+    not "civetweb.h".  We already make separate arrangements elsewhere for
+    that to work.  Additionally, static object libraries in cmake aren't
+    really libraries, so I'm not entirely sure this even does anything.
+    So: making this public is not useful, and could be harmful.  Making it
+    private makes this only take effect for building civetweb.c itself,
+    exactly the effect we we require, and no more.
+    
+    Signed-off-by: Marcus Watts <mwatts@redhat.com>
+    (cherry picked from commit 8308a13b0257c9460fd2a721c20b0c37cb9e7c57)

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -279,14 +279,14 @@ Sends a repair command to OSD.N. To send the command to all OSDs, use ``*``. ::
 
 	ceph osd repair N
 
-Runs a simple throughput benchmark against OSD.N, writing ``NUMBER_OF_OBJECTS``
+Runs a simple throughput benchmark against OSD.N, writing ``TOTAL_DATA_BYTES``
 in write requests of ``BYTES_PER_WRITE`` each. By default, the test
 writes 1 GB in total in 4-MB increments.
 The benchmark is non-destructive and will not overwrite existing live
 OSD data, but might temporarily affect the performance of clients
 concurrently accessing the OSD. ::
 
-	ceph tell osd.N bench [NUMER_OF_OBJECTS] [BYTES_PER_WRITE]
+	ceph tell osd.N bench [TOTAL_DATA_BYTES] [BYTES_PER_WRITE]
 
 
 MDS Subsystem

--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -54,7 +54,8 @@ map is ``active + clean``.
   Ceph detects that a placement group is missing information about
   writes that may have occurred, or does not have any healthy
   copies. If you see this state, try to start any failed OSDs that may
-  contain the needed information.
+  contain the needed information. In the case of an erasure coded pool
+  temporarily reducing min_size may allow recovery.
 
 *Stale*
   The placement group is in an unknown state - the monitors have not received

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -2515,6 +2515,47 @@ Notable Changes
 * test: ceph_test_rados_api_tmap_migrate: remove test for tmap_upgrade (`pr#10234 <http://github.com/ceph/ceph/pull/10234>`_, Kefu Chai)
 
 
+v10.2.7 Jewel
+=============
+
+This point release fixes several important bugs in RBD mirroring, librbd &  RGW.
+
+We recommend that all v10.2.x users upgrade.
+
+For more detailed information, see :download:`the complete changelog <changelog/v10.2.7.txt>`.
+
+
+Notable Changes
+---------------
+
+* librbd: possible race in ExclusiveLock handle_peer_notification (`issue#19368 <http://tracker.ceph.com/issues/19368>`_, `pr#14233 <https://github.com/ceph/ceph/pull/14233>`_, Mykola Golub)
+* osd: Increase priority for inactive PGs backfill (`issue#18350 <http://tracker.ceph.com/issues/18350>`_, `pr#13232 <https://github.com/ceph/ceph/pull/13232>`_, Bartłomiej Święcki)
+* osd: Scrub improvements and other fixes (`issue#17857 <http://tracker.ceph.com/issues/17857>`_, `issue#18114 <http://tracker.ceph.com/issues/18114>`_, `issue#13937 <http://tracker.ceph.com/issues/13937>`_, `issue#18113 <http://tracker.ceph.com/issues/18113>`_, `pr#13146 <https://github.com/ceph/ceph/pull/13146>`_, Kefu Chai, David Zafman)
+* osd: fix OSD network address in OSD heartbeat_check log message (`issue#18657 <http://tracker.ceph.com/issues/18657>`_, `pr#13108 <https://github.com/ceph/ceph/pull/13108>`_, Vikhyat Umrao)
+* rbd-mirror: deleting a snapshot during sync can result in read errors (`issue#18990 <http://tracker.ceph.com/issues/18990>`_, `pr#13596 <https://github.com/ceph/ceph/pull/13596>`_, Jason Dillaman)
+* rgw: 'period update' does not remove short_zone_ids of deleted zones (`issue#15618 <http://tracker.ceph.com/issues/15618>`_, `pr#14140 <https://github.com/ceph/ceph/pull/14140>`_, Casey Bodley)
+* rgw: DUMPABLE flag is cleared by setuid preventing coredumps (`issue#19089 <http://tracker.ceph.com/issues/19089>`_, `pr#13844 <https://github.com/ceph/ceph/pull/13844>`_, Brad Hubbard)
+* rgw: clear data_sync_cr if RGWDataSyncControlCR fails (`issue#17569 <http://tracker.ceph.com/issues/17569>`_, `pr#13886 <https://github.com/ceph/ceph/pull/13886>`_, Casey Bodley)
+* rgw: fix openssl (`issue#11239 <http://tracker.ceph.com/issues/11239>`_, `issue#19098 <http://tracker.ceph.com/issues/19098>`_, `issue#16535 <http://tracker.ceph.com/issues/16535>`_, `pr#14215 <https://github.com/ceph/ceph/pull/14215>`_, Marcus Watts)
+* rgw: fix swift cannot disable object versioning with empty X-Versions-Location (`issue#18852 <http://tracker.ceph.com/issues/18852>`_, `pr#13823 <https://github.com/ceph/ceph/pull/13823>`_, Jing Wenjun)
+* rgw: librgw: RGWLibFS::setattr fails on directories (`issue#18808 <http://tracker.ceph.com/issues/18808>`_, `pr#13778 <https://github.com/ceph/ceph/pull/13778>`_, Matt Benjamin)
+* rgw: make sending Content-Length in 204 and 304 controllable (`issue#16602 <http://tracker.ceph.com/issues/16602>`_, `pr#13503 <https://github.com/ceph/ceph/pull/13503>`_, Radoslaw Zarzynski, Matt Benjamin)
+* rgw: multipart uploads copy part support (`issue#12790 <http://tracker.ceph.com/issues/12790>`_, `pr#13219 <https://github.com/ceph/ceph/pull/13219>`_, Yehuda Sadeh, Javier M. Mellid, Matt Benjamin)
+* rgw: multisite: RGWMetaSyncShardControlCR gives up on EIO (`issue#19019 <http://tracker.ceph.com/issues/19019>`_, `pr#13867 <https://github.com/ceph/ceph/pull/13867>`_, Casey Bodley)
+* rgw: radosgw/swift: clean up flush / newline behavior (`issue#18473 <http://tracker.ceph.com/issues/18473>`_, `pr#14100 <https://github.com/ceph/ceph/pull/14100>`_, Nathan Cutler, Marcus Watts, Matt Benjamin)
+* rgw: radosgw/swift: clean up flush / newline behavior. (`issue#18473 <http://tracker.ceph.com/issues/18473>`_, `pr#13143 <https://github.com/ceph/ceph/pull/13143>`_, Marcus Watts, Matt Benjamin)
+* rgw: rgw_fh: RGWFileHandle dtor must also cond-unlink from FHCache (`issue#19112 <http://tracker.ceph.com/issues/19112>`_, `pr#14231 <https://github.com/ceph/ceph/pull/14231>`_, Matt Benjamin)
+* rgw: rgw_file:  avoid interning .. in FHCache table and don't ref for them (`issue#19036 <http://tracker.ceph.com/issues/19036>`_, `pr#13848 <https://github.com/ceph/ceph/pull/13848>`_, Matt Benjamin)
+* rgw: rgw_file:  interned RGWFileHandle objects need parent refs (`issue#18650 <http://tracker.ceph.com/issues/18650>`_, `pr#13583 <https://github.com/ceph/ceph/pull/13583>`_, Matt Benjamin)
+* rgw: rgw_file:  restore (corrected) fix for dir partial match (return of FLAG_EXACT_MATCH) (`issue#19060 <http://tracker.ceph.com/issues/19060>`_, `issue#18992 <http://tracker.ceph.com/issues/18992>`_, `issue#19059 <http://tracker.ceph.com/issues/19059>`_, `pr#13858 <https://github.com/ceph/ceph/pull/13858>`_, Matt Benjamin)
+* rgw: rgw_file: FHCache residence check should be exhaustive (`issue#19111 <http://tracker.ceph.com/issues/19111>`_, `pr#14169 <https://github.com/ceph/ceph/pull/14169>`_, Matt Benjamin)
+* rgw: rgw_file: ensure valid_s3_object_name for directories, too (`issue#19066 <http://tracker.ceph.com/issues/19066>`_, `pr#13717 <https://github.com/ceph/ceph/pull/13717>`_, Matt Benjamin)
+* rgw: rgw_file: fix marker computation (`issue#19018 <http://tracker.ceph.com/issues/19018>`_, `issue#18989 <http://tracker.ceph.com/issues/18989>`_, `issue#18992 <http://tracker.ceph.com/issues/18992>`_, `issue#18991 <http://tracker.ceph.com/issues/18991>`_, `pr#13869 <https://github.com/ceph/ceph/pull/13869>`_, Matt Benjamin)
+* rgw: rgw_file: wip dir orphan (`issue#18992 <http://tracker.ceph.com/issues/18992>`_, `issue#18989 <http://tracker.ceph.com/issues/18989>`_, `issue#19018 <http://tracker.ceph.com/issues/19018>`_, `issue#18991 <http://tracker.ceph.com/issues/18991>`_, `pr#14205 <https://github.com/ceph/ceph/pull/14205>`_, Gui Hecheng, Matt Benjamin)
+* rgw: rgw_file: various fixes (`pr#14206 <https://github.com/ceph/ceph/pull/14206>`_, Matt Benjamin)
+* rgw: rgw_file: expand argv (`pr#14230 <https://github.com/ceph/ceph/pull/14230>`_, Matt Benjamin)
+
+
 v10.2.6 Jewel
 =============
 

--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -108,12 +108,12 @@ int main(int argc, const char **argv, const char *envp[]) {
   g_ceph_context->_conf->apply_changes(NULL);
 
   // check for 32-bit arch
-  if (sizeof(long) == 4) {
+#ifndef __LP64__
     cerr << std::endl;
     cerr << "WARNING: Ceph inode numbers are 64 bits wide, and FUSE on 32-bit kernels does" << std::endl;
     cerr << "         not cope well with that situation.  Expect to crash shortly." << std::endl;
     cerr << std::endl;
-  }
+#endif
 
   Preforker forker;
   if (g_conf->daemonize) {

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -811,6 +811,15 @@ void Client::_fragmap_remove_non_leaves(Inode *in)
       ++p;
 }
 
+void Client::_fragmap_remove_stopped_mds(Inode *in, mds_rank_t mds)
+{
+  for (auto p = in->fragmap.begin(); p != in->fragmap.end(); )
+    if (p->second == mds)
+      in->fragmap.erase(p++);
+    else
+      ++p;
+}
+
 Inode * Client::add_update_inode(InodeStat *st, utime_t from,
 				 MetaSession *session,
 				 const UserPerm& request_perms)
@@ -1267,8 +1276,9 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
   ldout(cct, 10) << " features 0x" << hex << features << dec << dendl;
 
   // snap trace
+  SnapRealm *realm = NULL;
   if (reply->snapbl.length())
-    update_snap_trace(reply->snapbl);
+    update_snap_trace(reply->snapbl, &realm);
 
   ldout(cct, 10) << " hrm " 
 	   << " is_target=" << (int)reply->head.is_target
@@ -1376,13 +1386,16 @@ Inode* Client::insert_trace(MetaRequest *request, MetaSession *session)
     }
   }
 
+  if (realm)
+    put_snap_realm(realm);
+
   request->target = in;
   return in;
 }
 
 // -------
 
-mds_rank_t Client::choose_target_mds(MetaRequest *req) 
+mds_rank_t Client::choose_target_mds(MetaRequest *req, Inode** phash_diri)
 {
   mds_rank_t mds = MDS_RANK_NONE;
   __u32 hash = 0;
@@ -1451,9 +1464,11 @@ mds_rank_t Client::choose_target_mds(MetaRequest *req)
     if (is_hash && S_ISDIR(in->mode) && !in->fragmap.empty()) {
       frag_t fg = in->dirfragtree[hash];
       if (in->fragmap.count(fg)) {
-        mds = in->fragmap[fg];
-        ldout(cct, 10) << "choose_target_mds from dirfragtree hash" << dendl;
-        goto out;
+	mds = in->fragmap[fg];
+	if (phash_diri)
+	  *phash_diri = in;
+	ldout(cct, 10) << "choose_target_mds from dirfragtree hash" << dendl;
+	goto out;
       }
     }
   
@@ -1656,27 +1671,28 @@ int Client::make_request(MetaRequest *request,
     request->caller_cond = &caller_cond;
 
     // choose mds
-    mds_rank_t mds = choose_target_mds(request);
-    if (mds == MDS_RANK_NONE || !mdsmap->is_active_or_stopping(mds)) {
-      ldout(cct, 10) << " target mds." << mds << " not active, waiting for new mdsmap" << dendl;
-      wait_on_list(waiting_for_mdsmap);
+    Inode *hash_diri = NULL;
+    mds_rank_t mds = choose_target_mds(request, &hash_diri);
+    int mds_state = (mds == MDS_RANK_NONE) ? MDSMap::STATE_NULL : mdsmap->get_state(mds);
+    if (mds_state != MDSMap::STATE_ACTIVE && mds_state != MDSMap::STATE_STOPPING) {
+      if (mds_state == MDSMap::STATE_NULL && mds >= mdsmap->get_max_mds()) {
+	if (hash_diri) {
+	  ldout(cct, 10) << " target mds." << mds << " has stopped, remove it from fragmap" << dendl;
+	  _fragmap_remove_stopped_mds(hash_diri, mds);
+	} else {
+	  ldout(cct, 10) << " target mds." << mds << " has stopped, trying a random mds" << dendl;
+	  request->resend_mds = _get_random_up_mds();
+	}
+      } else {
+	ldout(cct, 10) << " target mds." << mds << " not active, waiting for new mdsmap" << dendl;
+	wait_on_list(waiting_for_mdsmap);
+      }
       continue;
     }
 
     // open a session?
     MetaSession *session = NULL;
     if (!have_open_session(mds)) {
-      if (!mdsmap->is_active_or_stopping(mds)) {
-	ldout(cct, 10) << "no address for mds." << mds << ", waiting for new mdsmap" << dendl;
-	wait_on_list(waiting_for_mdsmap);
-
-	if (!mdsmap->is_active_or_stopping(mds)) {
-	  ldout(cct, 10) << "hmm, still have no address for mds." << mds << ", trying a random mds" << dendl;
-	  request->resend_mds = _get_random_up_mds();
-	  continue;
-	}
-      }
-      
       session = _get_or_open_mds_session(mds);
 
       // wait
@@ -2565,32 +2581,30 @@ void Client::handle_mds_map(MMDSMap* m)
 
   // reset session
   for (map<mds_rank_t,MetaSession*>::iterator p = mds_sessions.begin();
-       p != mds_sessions.end();
-       ++p) {
-    int oldstate = oldmap->get_state(p->first);
-    int newstate = mdsmap->get_state(p->first);
-    if (!mdsmap->is_up(p->first) ||
-	mdsmap->get_inst(p->first) != p->second->inst) {
-      p->second->con->mark_down();
-      if (mdsmap->is_up(p->first)) {
-	p->second->inst = mdsmap->get_inst(p->first);
-	// When new MDS starts to take over, notify kernel to trim unused entries
-	// in its dcache/icache. Hopefully, the kernel will release some unused
-	// inodes before the new MDS enters reconnect state.
-	trim_cache_for_reconnect(p->second);
-      }
+       p != mds_sessions.end(); ) {
+    mds_rank_t mds = p->first;
+    MetaSession *session = p->second;
+    ++p;
+
+    int oldstate = oldmap->get_state(mds);
+    int newstate = mdsmap->get_state(mds);
+    if (!mdsmap->is_up(mds)) {
+      session->con->mark_down();
+    } else if (mdsmap->get_inst(mds) != session->inst) {
+      session->con->mark_down();
+      session->inst = mdsmap->get_inst(mds);
+      // When new MDS starts to take over, notify kernel to trim unused entries
+      // in its dcache/icache. Hopefully, the kernel will release some unused
+      // inodes before the new MDS enters reconnect state.
+      trim_cache_for_reconnect(session);
     } else if (oldstate == newstate)
       continue;  // no change
     
-    MetaSession *session = p->second;
     session->mds_state = newstate;
     if (newstate == MDSMap::STATE_RECONNECT) {
-      session->inst = mdsmap->get_inst(p->first);
       session->con = messenger->get_connection(session->inst);
       send_reconnect(session);
-    }
-
-    if (newstate >= MDSMap::STATE_ACTIVE) {
+    } else if (newstate >= MDSMap::STATE_ACTIVE) {
       if (oldstate < MDSMap::STATE_ACTIVE) {
 	// kick new requests
 	kick_requests(session);
@@ -2599,7 +2613,10 @@ void Client::handle_mds_map(MMDSMap* m)
 	kick_maxsize_requests(session);
 	wake_inode_waiters(session);
       }
-      connect_mds_targets(p->first);
+      connect_mds_targets(mds);
+    } else if (newstate == MDSMap::STATE_NULL &&
+	       mds >= mdsmap->get_max_mds()) {
+      _closed_mds_session(session);
     }
   }
 
@@ -3904,8 +3921,9 @@ void Client::remove_session_caps(MetaSession *s)
   while (s->caps.size()) {
     Cap *cap = *s->caps.begin();
     Inode *in = cap->inode;
-    int dirty_caps = 0;
+    bool dirty_caps = false, cap_snaps = false;
     if (in->auth_cap == cap) {
+      cap_snaps = !in->cap_snaps.empty();
       dirty_caps = in->dirty_caps | in->flushing_caps;
       in->wanted_max_size = 0;
       in->requested_max_size = 0;
@@ -3913,6 +3931,10 @@ void Client::remove_session_caps(MetaSession *s)
     }
     remove_cap(cap, false);
     signal_cond_list(in->waitfor_caps);
+    if (cap_snaps) {
+      InodeRef tmp_ref(in);
+      in->cap_snaps.clear();
+    }
     if (dirty_caps) {
       lderr(cct) << "remove_session_caps still has dirty|flushing caps on " << *in << dendl;
       if (in->flushing_caps) {
@@ -4345,9 +4367,9 @@ static bool has_new_snaps(const SnapContext& old_snapc,
 }
 
 
-inodeno_t Client::update_snap_trace(bufferlist& bl, bool flush)
+void Client::update_snap_trace(bufferlist& bl, SnapRealm **realm_ret, bool flush)
 {
-  inodeno_t first_realm = 0;
+  SnapRealm *first_realm = NULL;
   ldout(cct, 10) << "update_snap_trace len " << bl.length() << dendl;
 
   map<SnapRealm*, SnapContext> dirty_realms;
@@ -4356,8 +4378,6 @@ inodeno_t Client::update_snap_trace(bufferlist& bl, bool flush)
   while (!p.end()) {
     SnapRealmInfo info;
     ::decode(info, p);
-    if (first_realm == 0)
-      first_realm = info.ino();
     SnapRealm *realm = get_snap_realm(info.ino());
 
     bool invalidate = false;
@@ -4409,7 +4429,10 @@ inodeno_t Client::update_snap_trace(bufferlist& bl, bool flush)
 	       << " <= " << realm->seq << " and same parent, SKIPPING" << dendl;
     }
         
-    put_snap_realm(realm);
+    if (!first_realm)
+      first_realm = realm;
+    else
+      put_snap_realm(realm);
   }
 
   for (map<SnapRealm*, SnapContext>::iterator q = dirty_realms.begin();
@@ -4431,7 +4454,10 @@ inodeno_t Client::update_snap_trace(bufferlist& bl, bool flush)
     put_snap_realm(realm);
   }
 
-  return first_realm;
+  if (realm_ret)
+    *realm_ret = first_realm;
+  else
+    put_snap_realm(first_realm);
 }
 
 void Client::handle_snap(MClientSnap *m)
@@ -4494,7 +4520,7 @@ void Client::handle_snap(MClientSnap *m)
     }
   }
 
-  update_snap_trace(m->bl, m->head.op != CEPH_SNAP_OP_DESTROY);
+  update_snap_trace(m->bl, NULL, m->head.op != CEPH_SNAP_OP_DESTROY);
 
   if (realm) {
     for (auto p = to_move.begin(); p != to_move.end(); ++p) {
@@ -4631,7 +4657,9 @@ void Client::handle_cap_import(MetaSession *session, Inode *in, MClientCaps *m)
   }
 
   // add/update it
-  update_snap_trace(m->snapbl);
+  SnapRealm *realm = NULL;
+  update_snap_trace(m->snapbl, &realm);
+
   add_update_cap(in, session, m->get_cap_id(),
 		 m->get_caps(), m->get_seq(), m->get_mseq(), m->get_realm(),
 		 CEPH_CAP_FLAG_AUTH, cap_perms);
@@ -4639,6 +4667,9 @@ void Client::handle_cap_import(MetaSession *session, Inode *in, MClientCaps *m)
   if (cap && cap->cap_id == m->peer.cap_id) {
       remove_cap(cap, (m->peer.flags & CEPH_CAP_FLAG_RELEASE));
   }
+
+  if (realm)
+    put_snap_realm(realm);
   
   if (in->auth_cap && in->auth_cap->session->mds_num == mds) {
     // reflush any/all caps (if we are now the auth_cap)

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -371,7 +371,7 @@ protected:
 			   int unless,int force=0);
   void encode_dentry_release(Dentry *dn, MetaRequest *req,
 			     mds_rank_t mds, int drop, int unless);
-  mds_rank_t choose_target_mds(MetaRequest *req);
+  mds_rank_t choose_target_mds(MetaRequest *req, Inode** phash_diri=NULL);
   void connect_mds_targets(mds_rank_t mds);
   void send_request(MetaRequest *request, MetaSession *session,
 		    bool drop_cap_releases=false);
@@ -443,8 +443,7 @@ protected:
   SnapRealm *get_snap_realm_maybe(inodeno_t r);
   void put_snap_realm(SnapRealm *realm);
   bool adjust_realm_parent(SnapRealm *realm, inodeno_t parent);
-  inodeno_t update_snap_trace(bufferlist& bl, bool must_flush=true);
-  inodeno_t _update_snap_trace(vector<SnapRealmInfo>& trace);
+  void update_snap_trace(bufferlist& bl, SnapRealm **realm_ret, bool must_flush=true);
   void invalidate_snaprealm_and_children(SnapRealm *realm);
 
   Inode *open_snapdir(Inode *diri);
@@ -737,6 +736,7 @@ private:
 
   // other helpers
   void _fragmap_remove_non_leaves(Inode *in);
+  void _fragmap_remove_stopped_mds(Inode *in, mds_rank_t mds);
 
   void _ll_get(Inode *in);
   int _ll_put(Inode *in, int num);

--- a/src/cls/lua/lua_bufferlist.cc
+++ b/src/cls/lua/lua_bufferlist.cc
@@ -35,7 +35,7 @@ bufferlist *clslua_checkbufferlist(lua_State *L, int pos)
  */
 bufferlist *clslua_pushbufferlist(lua_State *L, bufferlist *set)
 {
-  bufferlist_wrap *blw = (bufferlist_wrap *)lua_newuserdata(L, sizeof(*blw));
+  bufferlist_wrap *blw = static_cast<bufferlist_wrap *>(lua_newuserdata(L, sizeof(*blw)));
   blw->bl = set ? set : new bufferlist();
   blw->gc = set ? 0 : 1;
   luaL_getmetatable(L, LUA_BUFFERLIST);

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -403,6 +403,27 @@ namespace librbd {
     int image_get_group(librados::IoCtx *ioctx, const std::string &oid,
 			cls::rbd::GroupSpec *group_spec);
 
+    // operations on rbd_trash object
+    void trash_add(librados::ObjectWriteOperation *op,
+                   const std::string &id,
+                   const cls::rbd::TrashImageSpec &trash_spec);
+    int trash_add(librados::IoCtx *ioctx, const std::string &id,
+                  const cls::rbd::TrashImageSpec &trash_spec);
+    void trash_remove(librados::ObjectWriteOperation *op,
+                      const std::string &id);
+    int trash_remove(librados::IoCtx *ioctx, const std::string &id);
+    void trash_list_start(librados::ObjectReadOperation *op);
+    int trash_list_finish(bufferlist::iterator *it,
+                          map<string, cls::rbd::TrashImageSpec> *entries);
+    int trash_list(librados::IoCtx *ioctx,
+                   map<string, cls::rbd::TrashImageSpec> *entries);
+    void trash_get_start(librados::ObjectReadOperation *op,
+                         const std::string &id);
+    int trash_get_finish(bufferlist::iterator *it,
+                         cls::rbd::TrashImageSpec *trash_spec);
+    int trash_get(librados::IoCtx *ioctx, const std::string &id,
+                  cls::rbd::TrashImageSpec *trash_spec);
+
   } // namespace cls_client
 } // namespace librbd
 #endif // CEPH_LIBRBD_CLS_RBD_CLIENT_H

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -448,5 +448,36 @@ std::ostream& operator<<(std::ostream& os, const UnknownSnapshotNamespace& ns) {
   return os;
 }
 
+void TrashImageSpec::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  ::encode(source, bl);
+  ::encode(name, bl);
+  ::encode(deletion_time, bl);
+  ::encode(deferment_end_time, bl);
+  ENCODE_FINISH(bl);
+}
+
+void TrashImageSpec::decode(bufferlist::iterator &it) {
+  DECODE_START(1, it);
+  ::decode(source, it);
+  ::decode(name, it);
+  ::decode(deletion_time, it);
+  ::decode(deferment_end_time, it);
+  DECODE_FINISH(it);
+}
+
+void TrashImageSpec::dump(Formatter *f) const {
+  switch(source) {
+    case TRASH_IMAGE_SOURCE_USER:
+      f->dump_string("source", "user");
+      break;
+    case TRASH_IMAGE_SOURCE_MIRRORING:
+      f->dump_string("source", "rbd_mirror");
+  }
+  f->dump_string("name", name);
+  f->dump_unsigned("deletion_time", deletion_time);
+  f->dump_unsigned("deferment_end_time", deferment_end_time);
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -328,6 +328,42 @@ struct SnapshotNamespaceOnDisk {
 };
 WRITE_CLASS_ENCODER(SnapshotNamespaceOnDisk);
 
+enum TrashImageSource {
+  TRASH_IMAGE_SOURCE_USER = 0,
+  TRASH_IMAGE_SOURCE_MIRRORING = 1
+};
+
+inline void encode(const TrashImageSource &source, bufferlist& bl,
+		   uint64_t features=0)
+{
+  ::encode(static_cast<uint8_t>(source), bl);
+}
+
+inline void decode(TrashImageSource &source, bufferlist::iterator& it)
+{
+  uint8_t int_source;
+  ::decode(int_source, it);
+  source = static_cast<TrashImageSource>(int_source);
+}
+
+struct TrashImageSpec {
+  TrashImageSource source = TRASH_IMAGE_SOURCE_USER;
+  std::string name;
+  utime_t deletion_time; // time of deletion
+  utime_t deferment_end_time;
+
+  TrashImageSpec() {}
+  TrashImageSpec(TrashImageSource source, const std::string &name,
+                   utime_t deletion_time, utime_t deferment_end_time) :
+    source(source), name(name), deletion_time(deletion_time),
+    deferment_end_time(deferment_end_time) {}
+
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator& it);
+  void dump(Formatter *f) const;
+};
+WRITE_CLASS_ENCODER(TrashImageSpec);
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -101,6 +101,8 @@ public:
     int r = io_ctx.aio_operate(oid, c, (librados::ObjectReadOperation*)op, NULL);
     if (r >= 0) {
       add_pending(arg->id, c, oid);
+    } else {
+      c->release();
     }
     return r;
   }
@@ -115,6 +117,8 @@ public:
     int r = io_ctx.aio_operate(oid, c, (librados::ObjectWriteOperation*)op);
     if (r >= 0) {
       add_pending(arg->id, c, oid);
+    } else {
+      c->release();
     }
     return r;
   }

--- a/src/common/MemoryModel.cc
+++ b/src/common/MemoryModel.cc
@@ -1,5 +1,6 @@
 
 #include "acconfig.h"
+#include "include/compat.h"
 #include "include/types.h"
 #include "MemoryModel.h"
 #include "common/config.h"
@@ -21,9 +22,9 @@ void MemoryModel::_sample(snap *psnap)
 {
   ifstream f;
 
-  f.open("/proc/self/status");
+  f.open(PROCPREFIX "/proc/self/status");
   if (!f.is_open()) {
-    ldout(cct, 0) << "check_memory_usage unable to open /proc/self/status" << dendl;
+    ldout(cct, 0) << "check_memory_usage unable to open " PROCPREFIX "/proc/self/status" << dendl;
     return;
   }
   while (!f.eof()) {
@@ -45,9 +46,9 @@ void MemoryModel::_sample(snap *psnap)
   }
   f.close();
 
-  f.open("/proc/self/maps");
+  f.open(PROCPREFIX "/proc/self/maps");
   if (!f.is_open()) {
-    ldout(cct, 0) << "check_memory_usage unable to open /proc/self/maps" << dendl;
+    ldout(cct, 0) << "check_memory_usage unable to open " PROCPREFIX "/proc/self/maps" << dendl;
     return;
   }
 

--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -46,6 +46,7 @@ int get_block_device_size(int fd, int64_t *psize)
   int ret = ::ioctl(fd, BLKGETSIZE, &sectors);
   *psize = sectors * 512ULL;
 #else
+// cppcheck-suppress preprocessorErrorDirective
 # error "Linux configuration error (get_block_device_size)"
 #endif
   if (ret < 0)

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -12,6 +12,7 @@
  * 
  */
 
+#include "include/compat.h"
 #include "include/mempool.h"
 #include "armor.h"
 #include "common/environment.h"
@@ -119,9 +120,9 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
     int r;
     std::string err;
     struct stat stat_result;
-    if (::stat("/proc/sys/fs/pipe-max-size", &stat_result) == -1)
+    if (::stat(PROCPREFIX "/proc/sys/fs/pipe-max-size", &stat_result) == -1)
       return -errno;
-    r = safe_read_file("/proc/sys/fs/", "pipe-max-size",
+    r = safe_read_file(PROCPREFIX "/proc/sys/fs/", "pipe-max-size",
 		       buf, sizeof(buf) - 1);
     if (r < 0)
       return r;

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -177,6 +177,7 @@ namespace ceph {
 }
 
 #else
+// cppcheck-suppress preprocessorErrorDirective
 # error "No supported crypto implementation found."
 #endif
 

--- a/src/common/escape.c
+++ b/src/common/escape.c
@@ -76,27 +76,22 @@ void escape_xml_attr(const char *buf, char *out)
 		unsigned char c = *b;
 		switch (c) {
 		case '<':
-			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, LESS_THAN_XESCAPE, SSTRL(LESS_THAN_XESCAPE));
 			o += SSTRL(LESS_THAN_XESCAPE);
 			break;
 		case '&':
-			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, AMPERSAND_XESCAPE, SSTRL(AMPERSAND_XESCAPE));
 			o += SSTRL(AMPERSAND_XESCAPE);
 			break;
 		case '>':
-			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, GREATER_THAN_XESCAPE, SSTRL(GREATER_THAN_XESCAPE));
 			o += SSTRL(GREATER_THAN_XESCAPE);
 			break;
 		case '\'':
-			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, SGL_QUOTE_XESCAPE, SSTRL(SGL_QUOTE_XESCAPE));
 			o += SSTRL(SGL_QUOTE_XESCAPE);
 			break;
 		case '"':
-			// cppcheck-suppress sizeofDivisionMemfunc
 			memcpy(o, DBL_QUOTE_XESCAPE, SSTRL(DBL_QUOTE_XESCAPE));
 			o += SSTRL(DBL_QUOTE_XESCAPE);
 			break;
@@ -166,22 +161,22 @@ void escape_json_attr(const char *buf, int src_len, char *out)
 		unsigned char c = *b;
 		switch (c) {
 		case '"':
-			// cppcheck-suppress sizeofDivisionMemfunc
+			// cppcheck-suppress invalidFunctionArg
 			memcpy(o, DBL_QUOTE_JESCAPE, SSTRL(DBL_QUOTE_JESCAPE));
 			o += SSTRL(DBL_QUOTE_JESCAPE);
 			break;
 		case '\\':
-			// cppcheck-suppress sizeofDivisionMemfunc
+			// cppcheck-suppress invalidFunctionArg
 			memcpy(o, BACKSLASH_JESCAPE, SSTRL(BACKSLASH_JESCAPE));
 			o += SSTRL(BACKSLASH_JESCAPE);
 			break;
 		case '\t':
-			// cppcheck-suppress sizeofDivisionMemfunc
+			// cppcheck-suppress invalidFunctionArg
 			memcpy(o, TAB_JESCAPE, SSTRL(TAB_JESCAPE));
 			o += SSTRL(TAB_JESCAPE);
 			break;
 		case '\n':
-			// cppcheck-suppress sizeofDivisionMemfunc
+			// cppcheck-suppress invalidFunctionArg
 			memcpy(o, NEWLINE_JESCAPE, SSTRL(NEWLINE_JESCAPE));
 			o += SSTRL(NEWLINE_JESCAPE);
 			break;

--- a/src/common/fd.cc
+++ b/src/common/fd.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "fd.h"
 
 #include <sys/types.h>
@@ -24,7 +25,7 @@
 
 void dump_open_fds(CephContext *cct)
 {
-  const char *fn = "/proc/self/fd";
+  const char *fn = PROCPREFIX "/proc/self/fd";
   DIR *d = opendir(fn);
   if (!d) {
     lderr(cct) << "dump_open_fds unable to open " << fn << dendl;

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -16,6 +16,7 @@
 #include <sys/utsname.h>
 #include <boost/lexical_cast.hpp>
 
+#include "include/compat.h"
 #include "include/util.h"
 #include "common/debug.h"
 #include "common/errno.h"
@@ -202,7 +203,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   }
 
   // memory
-  FILE *f = fopen("/proc/meminfo", "r");
+  FILE *f = fopen(PROCPREFIX "/proc/meminfo", "r");
   if (f) {
     char buf[100];
     while (!feof(f)) {
@@ -223,7 +224,7 @@ void collect_sys_info(map<string, string> *m, CephContext *cct)
   }
 
   // processor
-  f = fopen("/proc/cpuinfo", "r");
+  f = fopen(PROCPREFIX "/proc/cpuinfo", "r");
   if (f) {
     char buf[100];
     while (!feof(f)) {

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -160,7 +160,7 @@ void install_standard_sighandlers(void)
 string get_name_by_pid(pid_t pid)
 {
   char proc_pid_path[PATH_MAX] = {0};
-  snprintf(proc_pid_path, PATH_MAX, "/proc/%d/cmdline", pid);
+  snprintf(proc_pid_path, PATH_MAX, PROCPREFIX "/proc/%d/cmdline", pid);
   int fd = open(proc_pid_path, O_RDONLY);
 
   if (fd < 0) {

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -14,7 +14,15 @@
 
 #include "acconfig.h"
 
+#if defined(__linux__)
+#define PROCPREFIX
+#endif
+
 #if defined(__FreeBSD__)
+
+// FreeBSD supports Linux procfs with its compatibility module
+// And all compatibility stuff is standard mounted on this 
+#define PROCPREFIX "/compat/linux"
 
 /* Make sure that ENODATA is defined in the correct way */
 #ifndef ENODATA

--- a/src/include/denc.h
+++ b/src/include/denc.h
@@ -290,7 +290,7 @@ inline void denc_signed_varint(int64_t v, bufferlist::contiguous_appender& p) {
 template<typename T>
 inline void denc_signed_varint(T& v, bufferptr::iterator& p)
 {
-  int64_t i;
+  int64_t i = 0;
   denc_varint(i, p);
   if (i & 1) {
     v = -(i >> 1);
@@ -320,7 +320,7 @@ inline void denc_varint_lowz(uint64_t v, bufferlist::contiguous_appender& p) {
 template<typename T>
 inline void denc_varint_lowz(T& v, bufferptr::iterator& p)
 {
-  uint64_t i;
+  uint64_t i = 0;
   denc_varint(i, p);
   int lowznib = (i & 3);
   i >>= 2;
@@ -357,7 +357,7 @@ inline void denc_signed_varint_lowz(int64_t v,
 template<typename T>
 inline void denc_signed_varint_lowz(T& v, bufferptr::iterator& p)
 {
-  int64_t i;
+  int64_t i = 0;
   denc_varint(i, p);
   int lowznib = (i & 6) >> 1;
   if (i & 1) {

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -183,6 +183,19 @@ enum {
   RBD_IMAGE_OPTION_DATA_POOL = 10
 };
 
+typedef enum {
+  RBD_TRASH_IMAGE_SOURCE_USER = 0,
+  RBD_TRASH_IMAGE_SOURCE_MIRRORING = 1
+} rbd_trash_image_source_t;
+
+typedef struct {
+  char *id;
+  char *name;
+  rbd_trash_image_source_t source;
+  time_t deletion_time;
+  time_t deferment_end_time;
+} rbd_trash_image_info_t;
+
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);
 CEPH_RBD_API void rbd_image_options_destroy(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_set_string(rbd_image_options_t opts,
@@ -242,6 +255,19 @@ CEPH_RBD_API int rbd_remove(rados_ioctx_t io, const char *name);
 CEPH_RBD_API int rbd_remove_with_progress(rados_ioctx_t io, const char *name,
 			                  librbd_progress_fn_t cb,
                                           void *cbdata);
+CEPH_RBD_API int rbd_trash_move(rados_ioctx_t io, const char *name,
+                                uint64_t delay);
+CEPH_RBD_API int rbd_trash_list(rados_ioctx_t io,
+                                rbd_trash_image_info_t *trash_entries,
+                                size_t *num_entries);
+CEPH_RBD_API void rbd_trash_list_cleanup(rbd_trash_image_info_t *trash_entries,
+                                         size_t num_entries);
+CEPH_RBD_API int rbd_trash_remove(rados_ioctx_t io, const char *id, bool force);
+CEPH_RBD_API int rbd_trash_remove_with_progress(rados_ioctx_t io, const char *id,
+                                                bool force, librbd_progress_fn_t cb,
+                                                void *cbdata);
+CEPH_RBD_API int rbd_trash_restore(rados_ioctx_t io, const char *id,
+                                   const char *name);
 CEPH_RBD_API int rbd_rename(rados_ioctx_t src_io_ctx, const char *srcname,
                             const char *destname);
 
@@ -278,10 +304,16 @@ CEPH_RBD_API int rbd_mirror_image_status_summary(rados_ioctx_t io_ctx,
 
 CEPH_RBD_API int rbd_open(rados_ioctx_t io, const char *name,
                           rbd_image_t *image, const char *snap_name);
+CEPH_RBD_API int rbd_open_by_id(rados_ioctx_t io, const char *id,
+                                rbd_image_t *image, const char *snap_name);
 
 CEPH_RBD_API int rbd_aio_open(rados_ioctx_t io, const char *name,
 			      rbd_image_t *image, const char *snap_name,
 			      rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_open_by_id(rados_ioctx_t io, const char *id,
+                                    rbd_image_t *image, const char *snap_name,
+                                    rbd_completion_t c);
+
 /**
  * Open an image in read-only mode.
  *
@@ -303,9 +335,14 @@ CEPH_RBD_API int rbd_aio_open(rados_ioctx_t io, const char *name,
  */
 CEPH_RBD_API int rbd_open_read_only(rados_ioctx_t io, const char *name,
                                     rbd_image_t *image, const char *snap_name);
+CEPH_RBD_API int rbd_open_by_id_read_only(rados_ioctx_t io, const char *id,
+                                          rbd_image_t *image, const char *snap_name);
 CEPH_RBD_API int rbd_aio_open_read_only(rados_ioctx_t io, const char *name,
 					rbd_image_t *image, const char *snap_name,
 					rbd_completion_t c);
+CEPH_RBD_API int rbd_aio_open_by_id_read_only(rados_ioctx_t io, const char *id,
+                                              rbd_image_t *image, const char *snap_name,
+                                              rbd_completion_t c);
 CEPH_RBD_API int rbd_close(rbd_image_t image);
 CEPH_RBD_API int rbd_aio_close(rbd_image_t image, rbd_completion_t c);
 CEPH_RBD_API int rbd_resize(rbd_image_t image, uint64_t size);
@@ -790,6 +827,9 @@ CEPH_RBD_API int rbd_group_image_add(
 CEPH_RBD_API int rbd_group_image_remove(
 				rados_ioctx_t group_p, const char *group_name,
 				rados_ioctx_t image_p, const char *image_name);
+CEPH_RBD_API int rbd_group_image_remove_by_id(
+				rados_ioctx_t group_p, const char *group_name,
+				rados_ioctx_t image_p, const char *image_id);
 CEPH_RBD_API int rbd_group_image_list(
 				  rados_ioctx_t group_p, const char *group_name,
 				  rbd_group_image_status_t *images,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -93,6 +93,14 @@ namespace librbd {
     virtual int update_progress(uint64_t offset, uint64_t total) = 0;
   };
 
+  typedef struct {
+    std::string id;
+    std::string name;
+    rbd_trash_image_source_t source;
+    time_t deletion_time;
+    time_t deferment_end_time;
+  } trash_image_info_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -116,13 +124,21 @@ public:
 
   int open(IoCtx& io_ctx, Image& image, const char *name);
   int open(IoCtx& io_ctx, Image& image, const char *name, const char *snapname);
+  int open_by_id(IoCtx& io_ctx, Image& image, const char *id);
+  int open_by_id(IoCtx& io_ctx, Image& image, const char *id, const char *snapname);
   int aio_open(IoCtx& io_ctx, Image& image, const char *name,
 	       const char *snapname, RBD::AioCompletion *c);
+  int aio_open_by_id(IoCtx& io_ctx, Image& image, const char *id,
+	             const char *snapname, RBD::AioCompletion *c);
   // see librbd.h
   int open_read_only(IoCtx& io_ctx, Image& image, const char *name,
 		     const char *snapname);
+  int open_by_id_read_only(IoCtx& io_ctx, Image& image, const char *id,
+                           const char *snapname);
   int aio_open_read_only(IoCtx& io_ctx, Image& image, const char *name,
 			 const char *snapname, RBD::AioCompletion *c);
+  int aio_open_by_id_read_only(IoCtx& io_ctx, Image& image, const char *id,
+                               const char *snapname, RBD::AioCompletion *c);
   int list(IoCtx& io_ctx, std::vector<std::string>& names);
   int create(IoCtx& io_ctx, const char *name, uint64_t size, int *order);
   int create2(IoCtx& io_ctx, const char *name, uint64_t size,
@@ -142,6 +158,13 @@ public:
 	     IoCtx& c_ioctx, const char *c_name, ImageOptions& opts);
   int remove(IoCtx& io_ctx, const char *name);
   int remove_with_progress(IoCtx& io_ctx, const char *name, ProgressContext& pctx);
+  int trash_move(IoCtx &io_ctx, const char *name, uint64_t delay);
+  int trash_list(IoCtx &io_ctx, std::vector<trash_image_info_t> &entries);
+  int trash_remove(IoCtx &io_ctx, const char *image_id, bool force);
+  int trash_remove_with_progress(IoCtx &io_ctx, const char *image_id, bool force,
+                                 ProgressContext &pctx);
+  int trash_restore(IoCtx &io_ctx, const char *id, const char *name);
+
   int rename(IoCtx& src_io_ctx, const char *srcname, const char *destname);
 
   // RBD pool mirroring support functions
@@ -170,6 +193,8 @@ public:
 		      IoCtx& image_io_ctx, const char *image_name);
   int group_image_remove(IoCtx& io_ctx, const char *group_name,
 			 IoCtx& image_io_ctx, const char *image_name);
+  int group_image_remove_by_id(IoCtx& io_ctx, const char *group_name,
+                               IoCtx& image_io_ctx, const char *image_id);
   int group_image_list(IoCtx& io_ctx, const char *group_name,
 		       std::vector<group_image_status_t> *images);
 

--- a/src/include/rbd_types.h
+++ b/src/include/rbd_types.h
@@ -105,6 +105,8 @@
 
 #define RBD_GROUP_DIRECTORY "rbd_group_directory"
 
+#define RBD_TRASH "rbd_trash"
+
 struct rbd_info {
 	__le64 max_id;
 } __attribute__ ((packed));

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -235,6 +235,30 @@ int Group<I>::image_remove(librados::IoCtx& group_ioctx, const char *group_name,
 		 << " group name " << group_name << " image "
 		 << &image_ioctx << " name " << image_name << dendl;
 
+  string image_id;
+  int r = cls_client::dir_get_id(&image_ioctx, RBD_DIRECTORY, image_name,
+                                 &image_id);
+  if (r < 0) {
+    lderr(cct) << "error reading image id object: "
+               << cpp_strerror(-r) << dendl;
+    return r;
+  }
+
+  return Group<I>::image_remove_by_id(group_ioctx, group_name, image_ioctx,
+                                      image_id.c_str());
+}
+
+template <typename I>
+int Group<I>::image_remove_by_id(librados::IoCtx& group_ioctx,
+                                 const char *group_name,
+                                 librados::IoCtx& image_ioctx,
+                                 const char *image_id)
+{
+  CephContext *cct = (CephContext *)group_ioctx.cct();
+  ldout(cct, 20) << "group_remove_image_by_id " << &group_ioctx
+                 << " group name " << group_name << " image "
+                 << &image_ioctx << " id " << image_id << dendl;
+
   string group_id;
 
   int r = cls_client::dir_get_id(&group_ioctx, RBD_GROUP_DIRECTORY, group_name,
@@ -250,19 +274,9 @@ int Group<I>::image_remove(librados::IoCtx& group_ioctx, const char *group_name,
   ldout(cct, 20) << "adding image to group name " << group_name
 		 << " group id " << group_header_oid << dendl;
 
-  string image_id;
-  r = cls_client::dir_get_id(&image_ioctx, RBD_DIRECTORY, image_name,
-                             &image_id);
-  if (r < 0) {
-    lderr(cct) << "error reading image id object: "
-	       << cpp_strerror(-r) << dendl;
-    return r;
-  }
-
   string image_header_oid = util::header_name(image_id);
 
-  ldout(cct, 20) << "removing image " << image_name
-		 << " image id " << image_header_oid << dendl;
+  ldout(cct, 20) << "removing " << " image id " << image_header_oid << dendl;
 
   cls::rbd::GroupSpec group_spec(group_id, group_ioctx.get_id());
 

--- a/src/librbd/api/Group.h
+++ b/src/librbd/api/Group.h
@@ -27,6 +27,10 @@ struct Group {
 		       librados::IoCtx& image_ioctx, const char *image_name);
   static int image_remove(librados::IoCtx& group_ioctx, const char *group_name,
 		          librados::IoCtx& image_ioctx, const char *image_name);
+  static int image_remove_by_id(librados::IoCtx& group_ioctx,
+                                const char *group_name,
+                                librados::IoCtx& image_ioctx,
+                                const char *image_id);
   static int image_list(librados::IoCtx& group_ioctx, const char *group_name,
 		        std::vector<group_image_status_t> *images);
 

--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -532,7 +532,7 @@ void CloneRequest<I>::send_remove() {
   Context *ctx = create_context_callback<klass, &klass::handle_remove>(this);
 
   librbd::image::RemoveRequest<> *req = librbd::image::RemoveRequest<>::create(
-   m_ioctx, m_name, m_id, false, m_no_op, m_op_work_queue, ctx);
+   m_ioctx, m_name, m_id, false, false, m_no_op, m_op_work_queue, ctx);
   req->send();
 }
 

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -43,6 +43,9 @@ private:
    *            V2_GET_ID|NAME                      |
    *                |                               |
    *                v                               |
+   *            V2_GET_NAME_FROM_TRASH              |
+   *                |                               |
+   *                v                               |
    *            V2_GET_IMMUTABLE_METADATA           |
    *                |                               |
    *                v                               |
@@ -92,6 +95,9 @@ private:
 
   void send_v2_get_name();
   Context *handle_v2_get_name(int *result);
+
+  void send_v2_get_name_from_trash();
+  Context *handle_v2_get_name_from_trash(int *result);
 
   void send_v2_get_immutable_metadata();
   Context *handle_v2_get_immutable_metadata(int *result);

--- a/src/librbd/image/RemoveRequest.h
+++ b/src/librbd/image/RemoveRequest.h
@@ -27,11 +27,13 @@ public:
   static RemoveRequest *create(librados::IoCtx &ioctx,
                                const std::string &image_name,
                                const std::string &image_id,
-                               bool force, ProgressContext &prog_ctx,
+                               bool force, bool from_trash_remove,
+                               ProgressContext &prog_ctx,
                                ContextWQ *op_work_queue,
                                Context *on_finish) {
-    return new RemoveRequest(ioctx, image_name, image_id, force, prog_ctx,
-                             op_work_queue, on_finish);
+    return new RemoveRequest(ioctx, image_name, image_id, force,
+                             from_trash_remove, prog_ctx, op_work_queue,
+                             on_finish);
   }
 
   void send();
@@ -97,7 +99,7 @@ private:
    */
 
   RemoveRequest(librados::IoCtx &ioctx, const std::string &image_name,
-                const std::string &image_id, bool force,
+                const std::string &image_id, bool force, bool from_trash_remove,
                 ProgressContext &prog_ctx, ContextWQ *op_work_queue,
                 Context *on_finish);
 
@@ -105,6 +107,7 @@ private:
   std::string m_image_name;
   std::string m_image_id;
   bool m_force;
+  bool m_from_trash_remove;
   ProgressContext &m_prog_ctx;
   ContextWQ *m_op_work_queue;
   Context *m_on_finish;

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -141,7 +141,16 @@ namespace librbd {
 
   int remove(librados::IoCtx& io_ctx, const std::string &image_name,
              const std::string &image_id, ProgressContext& prog_ctx,
-             bool force=false);
+             bool force=false, bool from_trash_remove=false);
+  int trash_move(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+                 const std::string &image_name, uint64_t delay);
+  int trash_list(librados::IoCtx &io_ctx,
+                 std::vector<trash_image_info_t> &entries);
+  int trash_remove(librados::IoCtx &io_ctx, const std::string &image_id,
+                   bool force, ProgressContext& prog_ctx);
+  int trash_restore(librados::IoCtx &io_ctx, const std::string &image_id,
+                    const std::string &image_new_name);
+
   int snap_list(ImageCtx *ictx, std::vector<snap_info_t>& snaps);
   int snap_exists(ImageCtx *ictx, const cls::rbd::SnapshotNamespace& snap_namespace,
 		  const char *snap_name, bool *exists);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -272,6 +272,11 @@ namespace librbd {
     return open(io_ctx, image, name, NULL);
   }
 
+  int RBD::open_by_id(IoCtx& io_ctx, Image& image, const char *id)
+  {
+    return open_by_id(io_ctx, image, id, nullptr);
+  }
+
   int RBD::open(IoCtx& io_ctx, Image& image, const char *name,
 		const char *snap_name)
   {
@@ -295,6 +300,30 @@ namespace librbd {
     return 0;
   }
 
+  int RBD::open_by_id(IoCtx& io_ctx, Image& image, const char *id,
+		      const char *snap_name)
+  {
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, false);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, open_image_by_id_enter, ictx, ictx->id.c_str(),
+               ictx->snap_name.c_str(), ictx->read_only);
+
+    if (image.ctx != nullptr) {
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close();
+      image.ctx = nullptr;
+    }
+
+    int r = ictx->state->open(false);
+    if (r < 0) {
+      tracepoint(librbd, open_image_by_id_exit, r);
+      return r;
+    }
+
+    image.ctx = (image_ctx_t) ictx;
+    tracepoint(librbd, open_image_by_id_exit, 0);
+    return 0;
+  }
+
   int RBD::aio_open(IoCtx& io_ctx, Image& image, const char *name,
 		    const char *snap_name, RBD::AioCompletion *c)
   {
@@ -310,6 +339,25 @@ namespace librbd {
 					   &image.ctx));
     }
     tracepoint(librbd, aio_open_image_exit, 0);
+    return 0;
+  }
+
+  int RBD::aio_open_by_id(IoCtx& io_ctx, Image& image, const char *id,
+		          const char *snap_name, RBD::AioCompletion *c)
+  {
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, false);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, aio_open_image_by_id_enter, ictx, ictx->id.c_str(),
+               ictx->snap_name.c_str(), ictx->read_only, c->pc);
+
+    if (image.ctx != nullptr) {
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
+	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
+    } else {
+      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
+                                                  &image.ctx));
+    }
+    tracepoint(librbd, aio_open_image_by_id_exit, 0);
     return 0;
   }
 
@@ -336,6 +384,30 @@ namespace librbd {
     return 0;
   }
 
+  int RBD::open_by_id_read_only(IoCtx& io_ctx, Image& image, const char *id,
+			        const char *snap_name)
+  {
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, true);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, open_image_by_id_enter, ictx, ictx->id.c_str(),
+               ictx->snap_name.c_str(), ictx->read_only);
+
+    if (image.ctx != nullptr) {
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close();
+      image.ctx = nullptr;
+    }
+
+    int r = ictx->state->open(false);
+    if (r < 0) {
+      tracepoint(librbd, open_image_by_id_exit, r);
+      return r;
+    }
+
+    image.ctx = (image_ctx_t) ictx;
+    tracepoint(librbd, open_image_by_id_exit, 0);
+    return 0;
+  }
+
   int RBD::aio_open_read_only(IoCtx& io_ctx, Image& image, const char *name,
 			      const char *snap_name, RBD::AioCompletion *c)
   {
@@ -351,6 +423,25 @@ namespace librbd {
 					   &image.ctx));
     }
     tracepoint(librbd, aio_open_image_exit, 0);
+    return 0;
+  }
+
+  int RBD::aio_open_by_id_read_only(IoCtx& io_ctx, Image& image, const char *id,
+	                            const char *snap_name, RBD::AioCompletion *c)
+  {
+    ImageCtx *ictx = new ImageCtx("", id, snap_name, io_ctx, true);
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, aio_open_image_by_id_enter, ictx, ictx->id.c_str(),
+               ictx->snap_name.c_str(), ictx->read_only, c->pc);
+
+    if (image.ctx != nullptr) {
+      reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
+	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
+    } else {
+      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
+                                                  &image.ctx));
+    }
+    tracepoint(librbd, aio_open_image_by_id_exit, 0);
     return 0;
   }
 
@@ -447,6 +538,59 @@ namespace librbd {
     tracepoint(librbd, remove_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name);
     int r = librbd::remove(io_ctx, name, "", pctx);
     tracepoint(librbd, remove_exit, r);
+    return r;
+  }
+
+  int RBD::trash_move(IoCtx &io_ctx, const char *name, uint64_t delay) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, trash_move_enter, io_ctx.get_pool_name().c_str(),
+               io_ctx.get_id(), name);
+    int r = librbd::trash_move(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER, name,
+                               delay);
+    tracepoint(librbd, trash_move_exit, r);
+    return r;
+  }
+
+  int RBD::trash_list(IoCtx &io_ctx, vector<trash_image_info_t> &entries) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, trash_list_enter,
+               io_ctx.get_pool_name().c_str(), io_ctx.get_id());
+    int r = librbd::trash_list(io_ctx, entries);
+    if (r >= 0) {
+      for (const auto& entry : entries) {
+	tracepoint(librbd, trash_list_entry, entry.id.c_str());
+      }
+    }
+    tracepoint(librbd, trash_list_exit, r, r);
+    return r;
+  }
+
+  int RBD::trash_remove(IoCtx &io_ctx, const char *image_id, bool force) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, trash_remove_enter, io_ctx.get_pool_name().c_str(),
+               io_ctx.get_id(), image_id, force);
+    librbd::NoOpProgressContext prog_ctx;
+    int r = librbd::trash_remove(io_ctx, image_id, force, prog_ctx);
+    tracepoint(librbd, trash_remove_exit, r);
+    return r;
+  }
+
+  int RBD::trash_remove_with_progress(IoCtx &io_ctx, const char *image_id,
+                                      bool force, ProgressContext &pctx) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, trash_remove_enter, io_ctx.get_pool_name().c_str(),
+               io_ctx.get_id(), image_id, force);
+    int r = librbd::trash_remove(io_ctx, image_id, force, pctx);
+    tracepoint(librbd, trash_remove_exit, r);
+    return r;
+  }
+
+  int RBD::trash_restore(IoCtx &io_ctx, const char *id, const char *name) {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+    tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
+               io_ctx.get_id(), id, name);
+    int r = librbd::trash_restore(io_ctx, id, name);
+    tracepoint(librbd, trash_undelete_exit, r);
     return r;
   }
 
@@ -576,6 +720,21 @@ namespace librbd {
     int r = librbd::api::Group<>::image_remove(group_ioctx, group_name,
                                                image_ioctx, image_name);
     tracepoint(librbd, group_image_remove_exit, r);
+    return r;
+  }
+
+  int RBD::group_image_remove_by_id(IoCtx& group_ioctx, const char *group_name,
+                                    IoCtx& image_ioctx, const char *image_id)
+  {
+    TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
+    tracepoint(librbd, group_image_remove_by_id_enter,
+               group_ioctx.get_pool_name().c_str(),
+               group_ioctx.get_id(), group_name,
+               image_ioctx.get_pool_name().c_str(),
+               image_ioctx.get_id(), image_id);
+    int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
+                                                     image_ioctx, image_id);
+    tracepoint(librbd, group_image_remove_by_id_exit, r);
     return r;
   }
 
@@ -2112,6 +2271,102 @@ extern "C" int rbd_remove_with_progress(rados_ioctx_t p, const char *name,
   return r;
 }
 
+extern "C" int rbd_trash_move(rados_ioctx_t p, const char *name,
+                              uint64_t delay) {
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  tracepoint(librbd, trash_move_enter, io_ctx.get_pool_name().c_str(),
+             io_ctx.get_id(), name);
+  int r = librbd::trash_move(io_ctx, RBD_TRASH_IMAGE_SOURCE_USER, name, delay);
+  tracepoint(librbd, trash_move_exit, r);
+  return r;
+}
+
+extern "C" int rbd_trash_list(rados_ioctx_t p, rbd_trash_image_info_t *entries,
+                              size_t *num_entries) {
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  tracepoint(librbd, trash_list_enter,
+             io_ctx.get_pool_name().c_str(), io_ctx.get_id());
+
+  vector<librbd::trash_image_info_t> cpp_entries;
+  int r = librbd::trash_list(io_ctx, cpp_entries);
+  if (r < 0) {
+    tracepoint(librbd, trash_list_exit, r, *num_entries);
+    return r;
+  }
+
+  if (*num_entries < cpp_entries.size()) {
+    *num_entries = cpp_entries.size();
+    tracepoint(librbd, trash_list_exit, -ERANGE, *num_entries);
+    return -ERANGE;
+  }
+
+  int i=0;
+  for (const auto &entry : cpp_entries) {
+    entries[i].id = strdup(entry.id.c_str());
+    entries[i].name = strdup(entry.name.c_str());
+    entries[i].source = entry.source;
+    entries[i].deletion_time = entry.deletion_time;
+    entries[i].deferment_end_time = entry.deferment_end_time;
+    i++;
+  }
+  *num_entries = cpp_entries.size();
+
+  return *num_entries;
+}
+
+extern "C" void rbd_trash_list_cleanup(rbd_trash_image_info_t *entries,
+                                       size_t num_entries) {
+  for (size_t i=0; i < num_entries; i++) {
+    free(entries[i].id);
+    free(entries[i].name);
+  }
+}
+
+extern "C" int rbd_trash_remove(rados_ioctx_t p, const char *image_id,
+                                bool force) {
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  tracepoint(librbd, trash_remove_enter, io_ctx.get_pool_name().c_str(),
+             io_ctx.get_id(), image_id, force);
+  librbd::NoOpProgressContext prog_ctx;
+  int r = librbd::trash_remove(io_ctx, image_id, force, prog_ctx);
+  tracepoint(librbd, trash_remove_exit, r);
+  return r;
+}
+
+extern "C" int rbd_trash_remove_with_progress(rados_ioctx_t p,
+                                              const char *image_id,
+                                              bool force,
+                                              librbd_progress_fn_t cb,
+                                              void *cbdata) {
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  tracepoint(librbd, trash_remove_enter, io_ctx.get_pool_name().c_str(),
+             io_ctx.get_id(), image_id, force);
+  librbd::CProgressContext prog_ctx(cb, cbdata);
+  int r = librbd::trash_remove(io_ctx, image_id, force, prog_ctx);
+  tracepoint(librbd, trash_remove_exit, r);
+  return r;
+}
+
+extern "C" int rbd_trash_restore(rados_ioctx_t p, const char *id,
+                                 const char *name) {
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  tracepoint(librbd, trash_undelete_enter, io_ctx.get_pool_name().c_str(),
+             io_ctx.get_id(), id, name);
+  int r = librbd::trash_restore(io_ctx, id, name);
+  tracepoint(librbd, trash_undelete_exit, r);
+  return r;
+}
+
 extern "C" int rbd_copy(rbd_image_t image, rados_ioctx_t dest_p,
 			const char *destname)
 {
@@ -2276,6 +2531,27 @@ extern "C" int rbd_open(rados_ioctx_t p, const char *name, rbd_image_t *image,
   return r;
 }
 
+extern "C" int rbd_open_by_id(rados_ioctx_t p, const char *id,
+                              rbd_image_t *image, const char *snap_name)
+{
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  librbd::ImageCtx *ictx = new librbd::ImageCtx("", id, snap_name, io_ctx,
+						false);
+  tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(),
+             ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
+
+  int r = ictx->state->open(false);
+  if (r < 0) {
+    delete ictx;
+  } else {
+    *image = (rbd_image_t)ictx;
+  }
+  tracepoint(librbd, open_image_exit, r);
+  return r;
+}
+
 extern "C" int rbd_aio_open(rados_ioctx_t p, const char *name,
 			    rbd_image_t *image, const char *snap_name,
 			    rbd_completion_t c)
@@ -2287,6 +2563,24 @@ extern "C" int rbd_aio_open(rados_ioctx_t p, const char *name,
 						false);
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
+  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp), image));
+  tracepoint(librbd, aio_open_image_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_open_by_id(rados_ioctx_t p, const char *id,
+			          rbd_image_t *image, const char *snap_name,
+			          rbd_completion_t c)
+{
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  librbd::ImageCtx *ictx = new librbd::ImageCtx("", id, snap_name, io_ctx,
+						false);
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(),
+             ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only,
+             comp->pc);
   ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp), image));
   tracepoint(librbd, aio_open_image_exit, 0);
   return 0;
@@ -2310,6 +2604,27 @@ extern "C" int rbd_open_read_only(rados_ioctx_t p, const char *name,
   return r;
 }
 
+extern "C" int rbd_open_by_id_read_only(rados_ioctx_t p, const char *id,
+			                rbd_image_t *image, const char *snap_name)
+{
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  librbd::ImageCtx *ictx = new librbd::ImageCtx("", id, snap_name, io_ctx,
+						true);
+  tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(),
+             ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
+
+  int r = ictx->state->open(false);
+  if (r < 0) {
+    delete ictx;
+  } else {
+    *image = (rbd_image_t)ictx;
+  }
+  tracepoint(librbd, open_image_exit, r);
+  return r;
+}
+
 extern "C" int rbd_aio_open_read_only(rados_ioctx_t p, const char *name,
 				      rbd_image_t *image, const char *snap_name,
 				      rbd_completion_t c)
@@ -2321,6 +2636,25 @@ extern "C" int rbd_aio_open_read_only(rados_ioctx_t p, const char *name,
 						true);
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
+  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp),
+                                              image));
+  tracepoint(librbd, aio_open_image_exit, 0);
+  return 0;
+}
+
+extern "C" int rbd_aio_open_by_id_read_only(rados_ioctx_t p, const char *id,
+				            rbd_image_t *image,
+                                            const char *snap_name,
+                                            rbd_completion_t c)
+{
+  librados::IoCtx io_ctx;
+  librados::IoCtx::from_rados_ioctx_t(p, io_ctx);
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
+  librbd::ImageCtx *ictx = new librbd::ImageCtx("", id, snap_name, io_ctx,
+						true);
+  librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
+  tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(),
+             ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
   ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp),
                                               image));
   tracepoint(librbd, aio_open_image_exit, 0);
@@ -3715,6 +4049,31 @@ extern "C" int rbd_group_image_remove(
                                              image_ioctx, image_name);
 
   tracepoint(librbd, group_image_remove_exit, r);
+  return r;
+}
+
+extern "C" int rbd_group_image_remove_by_id(rados_ioctx_t group_p,
+                                            const char *group_name,
+                                            rados_ioctx_t image_p,
+                                            const char *image_id)
+{
+  librados::IoCtx group_ioctx;
+  librados::IoCtx image_ioctx;
+
+  librados::IoCtx::from_rados_ioctx_t(group_p, group_ioctx);
+  librados::IoCtx::from_rados_ioctx_t(image_p, image_ioctx);
+
+  TracepointProvider::initialize<tracepoint_traits>(get_cct(group_ioctx));
+  tracepoint(librbd, group_image_remove_by_id_enter,
+             group_ioctx.get_pool_name().c_str(),
+             group_ioctx.get_id(), group_name,
+             image_ioctx.get_pool_name().c_str(),
+             image_ioctx.get_id(), image_id);
+
+  int r = librbd::api::Group<>::image_remove_by_id(group_ioctx, group_name,
+                                                   image_ioctx, image_id);
+
+  tracepoint(librbd, group_image_remove_by_id_exit, r);
   return r;
 }
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -554,6 +554,8 @@ void CDir::link_inode_work( CDentry *dn, CInode *in)
   // verify open snaprealm parent
   if (in->snaprealm)
     in->snaprealm->adjust_parent();
+  else if (in->is_any_caps())
+    in->move_to_realm(inode->find_snaprealm());
 }
 
 void CDir::unlink_inode(CDentry *dn)

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -135,7 +135,8 @@ void Locker::send_lock_message(SimpleLock *lock, int msg)
   for (compact_map<mds_rank_t,unsigned>::iterator it = lock->get_parent()->replicas_begin();
        it != lock->get_parent()->replicas_end();
        ++it) {
-    if (mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
+    if (mds->is_cluster_degraded() &&
+	mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
       continue;
     MLock *m = new MLock(lock, msg, mds->get_nodeid());
     mds->send_message_mds(m, it->first);
@@ -147,7 +148,8 @@ void Locker::send_lock_message(SimpleLock *lock, int msg, const bufferlist &data
   for (compact_map<mds_rank_t,unsigned>::iterator it = lock->get_parent()->replicas_begin();
        it != lock->get_parent()->replicas_end();
        ++it) {
-    if (mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
+    if (mds->is_cluster_degraded() &&
+	mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
       continue;
     MLock *m = new MLock(lock, msg, mds->get_nodeid());
     m->set_data(data);
@@ -343,7 +345,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
     
     if (!object->is_auth()) {
       if (!mdr->locks.empty())
-	mds->locker->drop_locks(mdr.get());
+	drop_locks(mdr.get());
       if (object->is_ambiguous_auth()) {
 	// wait
 	dout(10) << " ambiguous auth, waiting to authpin " << *object << dendl;
@@ -356,7 +358,7 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
     }
     if (!object->can_auth_pin()) {
       // wait
-      mds->locker->drop_locks(mdr.get());
+      drop_locks(mdr.get());
       mdr->drop_local_auth_pins();
       if (auth_pin_nonblock) {
 	dout(10) << " can't auth_pin (freezing?) " << *object << ", nonblocking" << dendl;
@@ -401,7 +403,8 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
       dout(10) << "requesting remote auth_pins from mds." << p->first << dendl;
 
       // wait for active auth
-      if (!mds->mdsmap->is_clientreplay_or_active_or_stopping(p->first)) {
+      if (mds->is_cluster_degraded() &&
+	  !mds->mdsmap->is_clientreplay_or_active_or_stopping(p->first)) {
 	dout(10) << " mds." << p->first << " is not active" << dendl;
 	if (mdr->more()->waiting_on_slave.empty())
 	  mds->wait_for_active_peer(p->first, new C_MDS_RetryRequest(mdcache, mdr));
@@ -545,6 +548,37 @@ bool Locker::acquire_locks(MDRequestRef& mdr,
 	dout(10) << " got wrlock on " << **p << " " << *(*p)->get_parent() << dendl;
       }
     } else {
+      assert(mdr->is_master());
+      if ((*p)->is_scatterlock()) {
+	ScatterLock *slock = static_cast<ScatterLock *>(*p);
+	if (slock->is_rejoin_mix()) {
+	  // If there is a recovering mds who replcated an object when it failed
+	  // and scatterlock in the object was in MIX state, It's possible that
+	  // the recovering mds needs to take wrlock on the scatterlock when it
+	  // replays unsafe requests. So this mds should delay taking rdlock on
+	  // the scatterlock until the recovering mds finishes replaying unsafe.
+	  // Otherwise unsafe requests may get replayed after current request.
+	  //
+	  // For example:
+	  // The recovering mds is auth mds of a dirfrag, this mds is auth mds
+	  // of correspinding inode. when 'rm -rf' the direcotry, this mds should
+	  // delay the rmdir request until the recovering mds has replayed unlink
+	  // requests.
+	  if (mds->is_cluster_degraded()) {
+	    if (!mdr->is_replay()) {
+	      drop_locks(mdr.get());
+	      mds->wait_for_cluster_recovered(new C_MDS_RetryRequest(mdcache, mdr));
+	      dout(10) << " rejoin mix scatterlock " << *slock << " " << *(*p)->get_parent()
+		       << ", waiting for cluster recovered" << dendl;
+	      marker.message = "rejoin mix scatterlock, waiting for cluster recovered";
+	      return false;
+	    }
+	  } else {
+	    slock->clear_rejoin_mix();
+	  }
+	}
+      }
+
       marker.message = "failed to rdlock, waiting";
       if (!rdlock_start(*p, mdr)) 
 	goto out;
@@ -648,7 +682,8 @@ void Locker::_drop_non_rdlocks(MutationImpl *mut, set<CInode*> *pneed_issue)
   }
 
   for (set<mds_rank_t>::iterator p = slaves.begin(); p != slaves.end(); ++p) {
-    if (mds->mdsmap->get_state(*p) >= MDSMap::STATE_REJOIN) {
+    if (!mds->is_cluster_degraded() ||
+	mds->mdsmap->get_state(*p) >= MDSMap::STATE_REJOIN) {
       dout(10) << "_drop_non_rdlocks dropping remote locks on mds." << *p << dendl;
       MMDSSlaveRequest *slavereq = new MMDSSlaveRequest(mut->reqid, mut->attempt,
 							MMDSSlaveRequest::OP_DROPLOCKS);
@@ -797,7 +832,8 @@ void Locker::eval_gather(SimpleLock *lock, bool first, bool *pneed_issue, list<M
 	return;
       }
 
-      if (mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
+      if (!mds->is_cluster_degraded() ||
+	  mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
 	switch (lock->get_state()) {
 	case LOCK_SYNC_LOCK:
 	  mds->send_message_mds(new MLock(lock, LOCK_AC_LOCKACK, mds->get_nodeid()),
@@ -1195,7 +1231,8 @@ bool Locker::_rdlock_kick(SimpleLock *lock, bool as_anon)
     } else {
       // request rdlock state change from auth
       mds_rank_t auth = lock->get_parent()->authority().first;
-      if (mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
+      if (!mds->is_cluster_degraded() ||
+	  mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
 	dout(10) << "requesting rdlock from auth on "
 		 << *lock << " on " << *lock->get_parent() << dendl;
 	mds->send_message_mds(new MLock(lock, LOCK_AC_REQRDLOCK, mds->get_nodeid()), auth);
@@ -1423,7 +1460,8 @@ bool Locker::wrlock_start(SimpleLock *lock, MDRequestRef& mut, bool nowait)
       // replica.
       // auth should be auth_pinned (see acquire_locks wrlock weird mustpin case).
       mds_rank_t auth = lock->get_parent()->authority().first;
-      if (mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
+      if (!mds->is_cluster_degraded() ||
+	  mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
 	dout(10) << "requesting scatter from auth on "
 		 << *lock << " on " << *lock->get_parent() << dendl;
 	mds->send_message_mds(new MLock(lock, LOCK_AC_REQSCATTER, mds->get_nodeid()), auth);
@@ -1471,7 +1509,8 @@ void Locker::remote_wrlock_start(SimpleLock *lock, mds_rank_t target, MDRequestR
   dout(7) << "remote_wrlock_start mds." << target << " on " << *lock << " on " << *lock->get_parent() << dendl;
 
   // wait for active target
-  if (!mds->mdsmap->is_clientreplay_or_active_or_stopping(target)) {
+  if (mds->is_cluster_degraded() &&
+      !mds->mdsmap->is_clientreplay_or_active_or_stopping(target)) {
     dout(7) << " mds." << target << " is not active" << dendl;
     if (mut->more()->waiting_on_slave.empty())
       mds->wait_for_active_peer(target, new C_MDS_RetryRequest(mdcache, mut));
@@ -1501,7 +1540,8 @@ void Locker::remote_wrlock_finish(SimpleLock *lock, mds_rank_t target,
   
   dout(7) << "remote_wrlock_finish releasing remote wrlock on mds." << target
 	  << " " << *lock->get_parent()  << dendl;
-  if (mds->mdsmap->get_state(target) >= MDSMap::STATE_REJOIN) {
+  if (!mds->is_cluster_degraded() ||
+      mds->mdsmap->get_state(target) >= MDSMap::STATE_REJOIN) {
     MMDSSlaveRequest *slavereq = new MMDSSlaveRequest(mut->reqid, mut->attempt,
 						      MMDSSlaveRequest::OP_UNWRLOCK);
     slavereq->set_lock_type(lock->get_type());
@@ -1573,7 +1613,8 @@ bool Locker::xlock_start(SimpleLock *lock, MDRequestRef& mut)
     
     // wait for active auth
     mds_rank_t auth = lock->get_parent()->authority().first;
-    if (!mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
+    if (mds->is_cluster_degraded() &&
+	!mds->mdsmap->is_clientreplay_or_active_or_stopping(auth)) {
       dout(7) << " mds." << auth << " is not active" << dendl;
       if (mut->more()->waiting_on_slave.empty())
 	mds->wait_for_active_peer(auth, new C_MDS_RetryRequest(mdcache, mut));
@@ -1647,7 +1688,8 @@ void Locker::xlock_finish(SimpleLock *lock, MutationImpl *mut, bool *pneed_issue
     // tell auth
     dout(7) << "xlock_finish releasing remote xlock on " << *lock->get_parent()  << dendl;
     mds_rank_t auth = lock->get_parent()->authority().first;
-    if (mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
+    if (!mds->is_cluster_degraded() ||
+	mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
       MMDSSlaveRequest *slavereq = new MMDSSlaveRequest(mut->reqid, mut->attempt,
 							MMDSSlaveRequest::OP_UNXLOCK);
       slavereq->set_lock_type(lock->get_type());
@@ -2124,7 +2166,8 @@ void Locker::request_inode_file_caps(CInode *in)
     }
 
     mds_rank_t auth = in->authority().first;
-    if (mds->mdsmap->get_state(auth) == MDSMap::STATE_REJOIN) {
+    if (mds->is_cluster_degraded() &&
+	mds->mdsmap->get_state(auth) == MDSMap::STATE_REJOIN) {
       mds->wait_for_active_peer(auth, new C_MDL_RequestInodeFileCaps(this, in));
       return;
     }
@@ -2135,7 +2178,8 @@ void Locker::request_inode_file_caps(CInode *in)
 
     in->replica_caps_wanted = wanted;
 
-    if (mds->mdsmap->is_clientreplay_or_active_or_stopping(auth))
+    if (!mds->is_cluster_degraded() ||
+	mds->mdsmap->is_clientreplay_or_active_or_stopping(auth))
       mds->send_message_mds(new MInodeFileCaps(in->ino(), in->replica_caps_wanted),
 			    auth);
   }
@@ -4501,7 +4545,8 @@ void Locker::scatter_nudge(ScatterLock *lock, MDSInternalContextBase *c, bool fo
 	     << *lock << " on " << *p << dendl;
     // request unscatter?
     mds_rank_t auth = lock->get_parent()->authority().first;
-    if (mds->mdsmap->is_clientreplay_or_active_or_stopping(auth))
+    if (!mds->is_cluster_degraded() ||
+	mds->mdsmap->is_clientreplay_or_active_or_stopping(auth))
       mds->send_message_mds(new MLock(lock, LOCK_AC_NUDGE, mds->get_nodeid()), auth);
 
     // wait...

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -211,7 +211,7 @@ void MDBalancer::send_heartbeat()
 {
   utime_t now = ceph_clock_now();
   
-  if (mds->mdsmap->is_degraded()) {
+  if (mds->is_cluster_degraded()) {
     dout(10) << "send_heartbeat degraded" << dendl;
     return;
   }
@@ -284,7 +284,7 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
     return;
   }
 
-  if (mds->mdsmap->is_degraded()) {
+  if (mds->is_cluster_degraded()) {
     dout(10) << " degraded, ignoring" << dendl;
     goto out;
   }

--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "mdstypes.h"
 
 #include "MDBalancer.h"
@@ -154,11 +155,11 @@ mds_load_t MDBalancer::get_load(utime_t now)
   load.req_rate = mds->get_req_rate();
   load.queue_len = messenger->get_dispatch_queue_len();
 
-  ifstream cpu("/proc/loadavg");
+  ifstream cpu(PROCPREFIX "/proc/loadavg");
   if (cpu.is_open())
     cpu >> load.cpu_load_avg;
   else
-    derr << "input file '/proc/loadavg' not found" << dendl;
+    derr << "input file " PROCPREFIX "'/proc/loadavg' not found" << dendl;
   
   dout(15) << "get_load " << load << dendl;
   return load;

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2998,6 +2998,10 @@ void MDCache::handle_mds_failure(mds_rank_t who)
     fragment_unmark_unfreeze_dirs(dirs);
   }
 
+  // MDCache::shutdown_export_strays() always exports strays to mds.0
+  if (who == mds_rank_t(0))
+    shutdown_exported_strays.clear();
+
   show_subtrees();  
 }
 
@@ -3649,42 +3653,36 @@ void MDCache::remove_inode_recursive(CInode *in)
 
 bool MDCache::expire_recursive(
   CInode *in,
-  map<mds_rank_t, MCacheExpire*>& expiremap,
-  CDir *subtree)
+  map<mds_rank_t, MCacheExpire*>& expiremap)
 {
   assert(!in->is_auth());
 
   dout(10) << __func__ << ":" << *in << dendl;
 
-  mds_rank_t owner = subtree->dir_auth.first;
-  MCacheExpire *expire_msg = expiremap[owner];
-  assert(expire_msg);
-
   // Recurse into any dirfrags beneath this inode
   list<CDir*> ls;
   in->get_dirfrags(ls);
-  for (std::list<CDir*>::iterator p = ls.begin(); p != ls.end(); ++p) {
-    CDir *subdir = *p;
+  for (auto subdir : ls) {
+    if (!in->is_mdsdir() && subdir->is_subtree_root()) {
+      dout(10) << __func__ << ": stray still has subtree " << *in << dendl;
+      return true;
+    }
 
-    dout(10) << __func__ << ": entering dirfrag " << subdir << dendl;
-    for (CDir::map_t::iterator q = subdir->items.begin();
-         q != subdir->items.end(); ++q) {
-      CDentry *dn = q->second;
+    for (auto &it : subdir->items) {
+      CDentry *dn = it.second;
       CDentry::linkage_t *dnl = dn->get_linkage();
       if (dnl->is_primary()) {
 	CInode *tin = dnl->get_inode();
-        dout(10) << __func__ << ": tin="
-          << *tin << dendl;
 
         /* Remote strays with linkage (i.e. hardlinks) should not be
          * expired, because they may be the target of
          * a rename() as the owning MDS shuts down */
-        if (!tin->is_dir() && tin->inode.nlink) {
-          dout(10) << __func__ << ": child still has linkage" << dendl;
+        if (!tin->is_stray() && tin->inode.nlink) {
+          dout(10) << __func__ << ": stray still has linkage " << *tin << dendl;
           return true;
         }
 
-	const bool abort = expire_recursive(tin, expiremap, subtree);
+	const bool abort = expire_recursive(tin, expiremap);
         if (abort) {
           return true;
         }
@@ -3692,7 +3690,7 @@ bool MDCache::expire_recursive(
       if (dn->lru_is_expireable()) {
         trim_dentry(dn, expiremap);
       } else {
-        dout(10) << __func__ << ": dn still has linkage " << *dn << dendl;
+        dout(10) << __func__ << ": stray dn is not expireable " << *dn << dendl;
         return true;
       }
     }
@@ -6461,45 +6459,33 @@ bool MDCache::trim(int max, int count)
       trim_inode(0, root, 0, expiremap);
   }
 
-  // Trim remote stray dirs for stopping MDS ranks
-  std::list<CDir*> subtree_list;
-  list_subtrees(subtree_list);  // Take copy because will modify in loop
-  for (std::list<CDir*>::iterator s = subtree_list.begin();
-       s != subtree_list.end(); ++s) {
-    CDir *subtree = *s;
-    if (subtree->inode->is_mdsdir()) {
-      mds_rank_t owner = mds_rank_t(MDS_INO_MDSDIR_OWNER(subtree->inode->ino()));
-      if (owner == mds->get_nodeid() || !mds->mdsmap->is_up(owner)) {
-        continue;
+  std::set<mds_rank_t> stopping;
+  mds->mdsmap->get_mds_set(stopping, MDSMap::STATE_STOPPING);
+  stopping.erase(mds->get_nodeid());
+  for (auto rank : stopping) {
+    CInode* mdsdir_in = get_inode(MDS_INO_MDSDIR(rank));
+    if (!mdsdir_in)
+      continue;
+
+    if (expiremap.count(rank) == 0)  {
+      expiremap[rank] = new MCacheExpire(mds->get_nodeid());
+    }
+
+    dout(20) << __func__ << ": try expiring " << *mdsdir_in << " for stopping mds." << mds <<  dendl;
+
+    const bool aborted = expire_recursive(mdsdir_in, expiremap);
+    if (!aborted) {
+      dout(20) << __func__ << ": successfully expired mdsdir" << dendl;
+      list<CDir*> ls;
+      mdsdir_in->get_dirfrags(ls);
+      for (auto dir : ls) {
+	if (dir->get_num_ref() == 1)  // subtree pin
+	  trim_dirfrag(dir, dir, expiremap);
       }
-
-      dout(20) << __func__ << ": checking remote MDS dir " << *(subtree) << dendl;
-
-      const MDSMap::mds_info_t &owner_info = mds->mdsmap->get_mds_info(owner);
-      if (owner_info.state == MDSMap::STATE_STOPPING) {
-        dout(20) << __func__ << ": it's stopping, remove it" << dendl;
-        if (expiremap.count(owner) == 0)  {
-          expiremap[owner] = new MCacheExpire(mds->get_nodeid());
-        }
-
-	const bool aborted = expire_recursive(
-            subtree->inode, expiremap, subtree);
-        if (!aborted) {
-          dout(20) << __func__ << ": successfully expired mdsdir" << dendl;
-          CInode *subtree_in = subtree->inode;
-          list<CDir*> ls;
-          subtree->inode->get_dirfrags(ls);
-          for (std::list<CDir*>::iterator p = ls.begin(); p != ls.end(); ++p) {
-            CDir *frag = *p;
-            trim_dirfrag(frag, subtree, expiremap);
-          }
-          trim_inode(NULL, subtree_in, NULL, expiremap);
-        } else {
-          dout(20) << __func__ << ": some unexpirable contents in mdsdir" << dendl;
-        }
-      } else {
-        dout(20) << __func__ << ": not stopping, leaving it alone" << dendl;
-      }
+      if (mdsdir_in->get_num_ref() == 0)
+	trim_inode(NULL, mdsdir_in, NULL, expiremap);
+    } else {
+      dout(20) << __func__ << ": some unexpirable contents in mdsdir" << dendl;
     }
   }
 
@@ -6528,9 +6514,10 @@ void MDCache::send_expire_messages(map<mds_rank_t, MCacheExpire*>& expiremap)
   for (map<mds_rank_t, MCacheExpire*>::iterator it = expiremap.begin();
        it != expiremap.end();
        ++it) {
-    if (mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN ||
-	(mds->mdsmap->get_state(it->first) == MDSMap::STATE_REJOIN &&
-	 rejoin_sent.count(it->first) == 0)) {
+    if (mds->is_cluster_degraded() &&
+	(mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN ||
+	 (mds->mdsmap->get_state(it->first) == MDSMap::STATE_REJOIN &&
+	  rejoin_sent.count(it->first) == 0))) {
       it->second->put();
       continue;
     }
@@ -7459,22 +7446,6 @@ bool MDCache::shutdown_pass()
     return true;
   }
 
-  // close out any sessions (and open files!) before we try to trim the log, etc.
-  if (!mds->server->terminating_sessions &&
-      mds->sessionmap.have_unclosed_sessions()) {
-    mds->server->terminate_sessions();
-    return false;
-  }
-
-
-  // flush what we can from the log
-  mds->mdlog->trim(0);
-
-  if (mds->mdlog->get_num_segments() > 1) {
-    dout(7) << "still >1 segments, waiting for log to trim" << dendl;
-    return false;
-  }
-
   // empty stray dir
   if (!shutdown_export_strays()) {
     dout(7) << "waiting for strays to migrate" << dendl;
@@ -7496,11 +7467,10 @@ bool MDCache::shutdown_pass()
   dout(5) << "lru size now " << lru.lru_get_size() << dendl;
 
   // SUBTREES
+  int num_auth_subtree = 0;
   if (!subtrees.empty() &&
       mds->get_nodeid() != 0 && 
-      !migrator->is_exporting() //&&
-      //!migrator->is_importing()
-      ) {
+      migrator->get_export_queue_size() == 0) {
     dout(7) << "looking for subtrees to export to mds0" << dendl;
     list<CDir*> ls;
     for (map<CDir*, set<CDir*> >::iterator it = subtrees.begin();
@@ -7509,27 +7479,36 @@ bool MDCache::shutdown_pass()
       CDir *dir = it->first;
       if (dir->get_inode()->is_mdsdir())
 	continue;
-      if (dir->is_frozen() || dir->is_freezing())
-	continue;
-      if (!dir->is_full_dir_auth())
-	continue;
-      ls.push_back(dir);
+      if (dir->is_auth()) {
+	num_auth_subtree++;
+	if (dir->is_frozen() ||
+	    dir->is_freezing() ||
+	    dir->is_ambiguous_dir_auth() ||
+	    dir->state_test(CDir::STATE_EXPORTING))
+	  continue;
+	ls.push_back(dir);
+      }
     }
-    int max = 5; // throttle shutdown exports.. hack!
     for (list<CDir*>::iterator p = ls.begin(); p != ls.end(); ++p) {
       CDir *dir = *p;
       mds_rank_t dest = dir->get_inode()->authority().first;
       if (dest > 0 && !mds->mdsmap->is_active(dest))
 	dest = 0;
       dout(7) << "sending " << *dir << " back to mds." << dest << dendl;
-      migrator->export_dir(dir, dest);
-      if (--max == 0)
-	break;
+      migrator->export_dir_nicely(dir, dest);
     }
   }
 
-  if (!shutdown_export_caps()) {
-    dout(7) << "waiting for residual caps to export" << dendl;
+  if (num_auth_subtree > 0) {
+    dout(7) << "still have " << num_auth_subtree << " auth subtrees" << dendl;
+    show_subtrees();
+    return false;
+  }
+
+  // close out any sessions (and open files!) before we try to trim the log, etc.
+  if (mds->sessionmap.have_unclosed_sessions()) {
+    if (!mds->server->terminating_sessions)
+      mds->server->terminate_sessions();
     return false;
   }
 
@@ -7562,6 +7541,13 @@ bool MDCache::shutdown_pass()
     // We do this because otherwise acks to locks could come in after
     // we cap the log.
     dout(7) << "waiting for mydir replicas to release: " << *mydir << dendl;
+    return false;
+  }
+
+  // flush what we can from the log
+  mds->mdlog->trim(0);
+  if (mds->mdlog->get_num_segments() > 1) {
+    dout(7) << "still >1 segments, waiting for log to trim" << dendl;
     return false;
   }
 
@@ -7610,12 +7596,14 @@ bool MDCache::shutdown_pass()
 
 bool MDCache::shutdown_export_strays()
 {
-  if (mds->get_nodeid() == 0) return true;
+  if (mds->get_nodeid() == 0)
+    return true;
   
   dout(10) << "shutdown_export_strays" << dendl;
 
+  bool mds0_active = mds->mdsmap->is_active(mds_rank_t(0));
+
   bool done = true;
-  static set<inodeno_t> exported_strays;
 
   list<CDir*> dfs;
   for (int i = 0; i < NUM_STRAY; ++i) {
@@ -7633,6 +7621,8 @@ bool MDCache::shutdown_export_strays()
     if (!dir->is_complete()) {
       dir->fetch(0);
       done = false;
+      if (!mds0_active)
+	break;
     }
     
     for (CDir::map_t::iterator p = dir->items.begin();
@@ -7640,8 +7630,11 @@ bool MDCache::shutdown_export_strays()
 	 ++p) {
       CDentry *dn = p->second;
       CDentry::linkage_t *dnl = dn->get_linkage();
-      if (dnl->is_null()) continue;
+      if (dnl->is_null())
+	continue;
       done = false;
+      if (!mds0_active)
+	break;
       
       if (dn->state_test(CDentry::STATE_PURGING)) {
         // Don't try to migrate anything that is actually
@@ -7649,9 +7642,8 @@ bool MDCache::shutdown_export_strays()
         continue;
       }
 
-      // FIXME: we'll deadlock if a rename fails.
-      if (exported_strays.count(dnl->get_inode()->ino()) == 0) {
-	exported_strays.insert(dnl->get_inode()->ino());
+      if (shutdown_exported_strays.count(dnl->get_inode()->ino()) == 0) {
+	shutdown_exported_strays.insert(dnl->get_inode()->ino());
 	stray_manager.migrate_stray(dn, mds_rank_t(0));  // send to root!
       } else {
 	dout(10) << "already exporting " << *dn << dendl;
@@ -7661,54 +7653,6 @@ bool MDCache::shutdown_export_strays()
 
   return done;
 }
-
-bool MDCache::shutdown_export_caps()
-{
-  // export caps?
-  //  note: this runs more often than it should.
-  static bool exported_caps = false;
-  static set<CDir*> exported_caps_in;
-  if (!exported_caps) {
-    dout(7) << "searching for caps to export" << dendl;
-    exported_caps = true;
-
-    list<CDir*> dirq;
-    for (map<CDir*,set<CDir*> >::iterator p = subtrees.begin();
-	 p != subtrees.end();
-	 ++p) {
-      if (exported_caps_in.count(p->first)) continue;
-      if (p->first->is_auth() ||
-	  p->first->is_ambiguous_auth())
-	exported_caps = false; // we'll have to try again
-      else {
-	dirq.push_back(p->first);
-	exported_caps_in.insert(p->first);
-      }
-    }
-    while (!dirq.empty()) {
-      CDir *dir = dirq.front();
-      dirq.pop_front();
-      for (CDir::map_t::iterator p = dir->items.begin();
-	   p != dir->items.end();
-	   ++p) {
-	CDentry *dn = p->second;
-	CDentry::linkage_t *dnl = dn->get_linkage();
-	if (!dnl->is_primary()) continue;
-	CInode *in = dnl->get_inode();
-	if (in->is_dir())
-	  in->get_nested_dirfrags(dirq);
-	if (in->is_any_caps() && !in->state_test(CInode::STATE_EXPORTINGCAPS))
-	  migrator->export_caps(in);
-      }
-    }
-  }
-
-  return true;
-}
-
-
-
-
 
 // ========= messaging ==============
 
@@ -8159,7 +8103,8 @@ void MDCache::open_remote_dirfrag(CInode *diri, frag_t approxfg, MDSInternalCont
 
   mds_rank_t auth = diri->authority().first;
 
-  if (mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
+  if (!mds->is_cluster_degraded() ||
+      mds->mdsmap->get_state(auth) >= MDSMap::STATE_REJOIN) {
     discover_dir_frag(diri, approxfg, fin);
   } else {
     // mds is down or recovering.  forge a replica!
@@ -8614,7 +8559,11 @@ void MDCache::do_open_ino_peer(inodeno_t ino, open_ino_info_t& info)
     }
   } else {
     info.checking = peer;
-    mds->send_message_mds(new MMDSOpenIno(info.tid, ino, info.ancestors), peer);
+    vector<inode_backpointer_t> *pa = NULL;
+    // got backtrace from peer or backtrace just fetched
+    if (info.discover || !info.fetch_backtrace)
+      pa = &info.ancestors;
+    mds->send_message_mds(new MMDSOpenIno(info.tid, ino, pa), peer);
   }
 }
 
@@ -10751,7 +10700,7 @@ bool MDCache::can_fragment(CInode *diri, list<CDir*>& dirs)
     dout(7) << "can_fragment: read-only FS, no fragmenting for now" << dendl;
     return false;
   }
-  if (mds->mdsmap->is_degraded()) {
+  if (mds->is_cluster_degraded()) {
     dout(7) << "can_fragment: cluster degraded, no fragmenting for now" << dendl;
     return false;
   }

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -694,8 +694,7 @@ public:
    */
   bool expire_recursive(
     CInode *in,
-    std::map<mds_rank_t, MCacheExpire*>& expiremap,
-    CDir *subtree);
+    std::map<mds_rank_t, MCacheExpire*>& expiremap);
 
   void trim_client_leases();
   void check_memory_usage();
@@ -703,11 +702,13 @@ public:
   utime_t last_recall_state;
 
   // shutdown
+private:
+  set<inodeno_t> shutdown_exported_strays;
+public:
   void shutdown_start();
   void shutdown_check();
   bool shutdown_pass();
   bool shutdown_export_strays();
-  bool shutdown_export_caps();
   bool shutdown();                    // clear cache (ie at shutodwn)
 
   bool did_shutdown_log_cap;

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -14,6 +14,7 @@
 
 #include <unistd.h>
 
+#include "include/compat.h"
 #include "global/signal_handler.h"
 
 #include "include/types.h"
@@ -1041,7 +1042,7 @@ void MDSDaemon::respawn()
    * unlinked.
    */
   char exe_path[PATH_MAX] = "";
-  if (readlink("/proc/self/exe", exe_path, PATH_MAX-1) == -1) {
+  if (readlink(PROCPREFIX "/proc/self/exe", exe_path, PATH_MAX-1) == -1) {
     /* Print CWD for the user's interest */
     char buf[PATH_MAX];
     char *cwd = getcwd(buf, sizeof(buf));
@@ -1052,7 +1053,7 @@ void MDSDaemon::respawn()
     strncpy(exe_path, orig_argv[0], PATH_MAX-1);
   } else {
     dout(1) << "respawning with exe " << exe_path << dendl;
-    strcpy(exe_path, "/proc/self/exe");
+    strcpy(exe_path, PROCPREFIX "/proc/self/exe");
   }
 
   dout(1) << " exe_path " << exe_path << dendl;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -66,7 +66,7 @@ MDSRank::MDSRank(
                g_conf->osd_num_op_tracker_shard),
     last_state(MDSMap::STATE_BOOT),
     state(MDSMap::STATE_BOOT),
-    stopping(false),
+    cluster_degraded(false), stopping(false),
     purge_queue(g_ceph_context, whoami_,
       mdsmap_->get_metadata_pool(), objecter,
       new FunctionContext(
@@ -1573,8 +1573,15 @@ void MDSRankDispatcher::handle_mds_map(
     }
   }
 
-  if (oldmap->is_degraded() && !mdsmap->is_degraded() && state >= MDSMap::STATE_ACTIVE)
+  cluster_degraded = mdsmap->is_degraded();
+  if (oldmap->is_degraded() && !cluster_degraded && state >= MDSMap::STATE_ACTIVE) {
     dout(1) << "cluster recovered." << dendl;
+    auto it = waiting_for_active_peer.find(MDS_RANK_NONE);
+    if (it != waiting_for_active_peer.end()) {
+      queue_waiters(it->second);
+      waiting_for_active_peer.erase(it);
+    }
+  }
 
   // did someone go active?
   if (oldstate >= MDSMap::STATE_CLIENTREPLAY &&

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -181,6 +181,8 @@ class MDSRank {
     // The state assigned to me by the MDSMap
     MDSMap::DaemonState state;
 
+    bool cluster_degraded;
+
     MDSMap::DaemonState get_state() const { return state; } 
     MDSMap::DaemonState get_want_state() const { return beacon.get_want_state(); } 
 
@@ -197,6 +199,7 @@ class MDSRank {
     bool is_stopping() const { return state == MDSMap::STATE_STOPPING; }
     bool is_any_replay() const { return (is_replay() || is_standby_replay()); }
     bool is_stopped() const { return mdsmap->is_stopped(whoami); }
+    bool is_cluster_degraded() const { return cluster_degraded; }
 
     void handle_write_error(int err);
 
@@ -349,11 +352,16 @@ class MDSRank {
       send_message(m, c.get());
     }
 
-    void wait_for_active(MDSInternalContextBase *c) { 
-      waiting_for_active.push_back(c); 
-    }
     void wait_for_active_peer(mds_rank_t who, MDSInternalContextBase *c) { 
       waiting_for_active_peer[who].push_back(c);
+    }
+    void wait_for_cluster_recovered(MDSInternalContextBase *c) {
+      assert(cluster_degraded);
+      waiting_for_active_peer[MDS_RANK_NONE].push_back(c);
+    }
+
+    void wait_for_active(MDSInternalContextBase *c) {
+      waiting_for_active.push_back(c);
     }
     void wait_for_replay(MDSInternalContextBase *c) { 
       waiting_for_replay.push_back(c); 

--- a/src/mds/Mutation.cc
+++ b/src/mds/Mutation.cc
@@ -306,10 +306,16 @@ void MDRequestImpl::set_filepath(const filepath& fp)
   assert(!client_request);
   more()->filepath1 = fp;
 }
+
 void MDRequestImpl::set_filepath2(const filepath& fp)
 {
   assert(!client_request);
   more()->filepath2 = fp;
+}
+
+bool MDRequestImpl::is_replay() const
+{
+  return client_request ? client_request->is_replay() : false;
 }
 
 void MDRequestImpl::print(ostream &out) const

--- a/src/mds/Mutation.h
+++ b/src/mds/Mutation.h
@@ -332,6 +332,7 @@ struct MDRequestImpl : public MutationImpl {
   const filepath& get_filepath2();
   void set_filepath(const filepath& fp);
   void set_filepath2(const filepath& fp);
+  bool is_replay() const;
 
   void print(ostream &out) const override;
   void dump(Formatter *f) const override;

--- a/src/mds/ScatterLock.h
+++ b/src/mds/ScatterLock.h
@@ -58,6 +58,7 @@ class ScatterLock : public SimpleLock {
     DIRTY            = 1 << 2,
     FLUSHING         = 1 << 3,
     FLUSHED          = 1 << 4,
+    REJOIN_MIX	     = 1 << 5, // no rdlock until the recovering mds become active
   };
 
 public:
@@ -147,6 +148,9 @@ public:
   bool is_dirty_or_flushing() const {
     return have_more() ? (is_dirty() || is_flushing()) : false;
   }
+  bool is_rejoin_mix() const {
+    return have_more() ? _more->state_flags & REJOIN_MIX : false;
+  }
 
   void mark_dirty() { 
     if (!is_dirty()) {
@@ -182,6 +186,13 @@ public:
     }
   }
 
+  void clear_rejoin_mix() {
+    if (have_more()) {
+      _more->state_flags &= ~REJOIN_MIX;
+      try_clear_more();
+    }
+  }
+
   void set_last_scatter(utime_t t) { more()->last_scatter = t; }
   utime_t get_last_scatter() {
     return more()->last_scatter;
@@ -190,14 +201,13 @@ public:
   void infer_state_from_strong_rejoin(int rstate, bool locktoo) {
     if (rstate == LOCK_MIX || 
 	rstate == LOCK_MIX_LOCK || // replica still has wrlocks?
-	rstate == LOCK_MIX_SYNC || // "
-	rstate == LOCK_MIX_TSYN)  // "
+	rstate == LOCK_MIX_SYNC)
       state = LOCK_MIX;
     else if (locktoo && rstate == LOCK_LOCK)
       state = LOCK_LOCK;
   }
 
-  void encode_state_for_rejoin(bufferlist& bl, int rep) const {
+  void encode_state_for_rejoin(bufferlist& bl, int rep) {
     __s16 s = get_replica_state();
     if (is_gathering(rep)) {
       // the recovering mds may hold rejoined wrlocks
@@ -206,6 +216,10 @@ public:
       else
 	s = LOCK_MIX_LOCK;
     }
+
+    if (s == LOCK_MIX || s == LOCK_MIX_LOCK || s == LOCK_MIX_SYNC)
+      more()->state_flags |= REJOIN_MIX;
+
     ::encode(s, bl);
   }
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -2105,6 +2105,9 @@ void EUpdate::update_segment()
 {
   metablob.update_segment(_segment);
 
+  if (client_map.length())
+    _segment->sessionmapv = cmapv;
+
   if (had_slaves)
     _segment->uncommitted_masters.insert(reqid);
 }
@@ -2137,6 +2140,7 @@ void EUpdate::replay(MDSRank *mds)
       mds->sessionmap.set_projected(mds->sessionmap.get_version());
     }
   }
+  update_segment();
 }
 
 

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -78,7 +78,7 @@ public:
   filepath path, path2;
   vector<uint64_t> gid_list;
 
-
+  bool queued_for_replay = false;
 
  public:
   // cons
@@ -166,6 +166,9 @@ public:
   const filepath& get_filepath2() const { return path2; }
 
   int get_dentry_wanted() { return get_flags() & CEPH_MDS_FLAG_WANT_DENTRY; }
+
+  void mark_queued_for_replay() { queued_for_replay = true; }
+  bool is_queued_for_replay() { return queued_for_replay; }
 
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -260,6 +263,8 @@ public:
       out << " RETRY=" << (int)head.num_retry;
     if (get_flags() & CEPH_MDS_FLAG_REPLAY)
       out << " REPLAY";
+    if (queued_for_replay)
+      out << " QUEUED_FOR_REPLAY";
     out << " caller_uid=" << head.caller_uid
 	<< ", caller_gid=" << head.caller_gid
 	<< '{';

--- a/src/messages/MMDSOpenIno.h
+++ b/src/messages/MMDSOpenIno.h
@@ -22,9 +22,11 @@ struct MMDSOpenIno : public Message {
   vector<inode_backpointer_t> ancestors;
 
   MMDSOpenIno() : Message(MSG_MDS_OPENINO) {}
-  MMDSOpenIno(ceph_tid_t t, inodeno_t i, vector<inode_backpointer_t>& a) :
-    Message(MSG_MDS_OPENINO), ino(i), ancestors(a) {
+  MMDSOpenIno(ceph_tid_t t, inodeno_t i, vector<inode_backpointer_t>* pa) :
+    Message(MSG_MDS_OPENINO), ino(i) {
     header.tid = t;
+    if (pa)
+      ancestors = *pa;
   }
 
   const char *get_type_name() const override { return "openino"; }

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -171,6 +171,7 @@ static char *parse_options(const char *data, int *filesys_flags)
 		} else if (strncmp(data, "secret", 6) == 0) {
 			if (!value || !*value) {
 				printf("mount option secret requires a value.\n");
+				free(saw_name);
 				return NULL;
 			}
 

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -533,9 +533,11 @@ ConnectionRef AsyncMessenger::get_loopback_connection()
 int AsyncMessenger::_send_message(Message *m, const entity_inst_t& dest)
 {
   FUNCTRACE();
-  if (m && m->get_type() == CEPH_MSG_OSD_OP)
+  assert(m);
+
+  if (m->get_type() == CEPH_MSG_OSD_OP)
     OID_EVENT_TRACE(((MOSDOp *)m)->get_oid().name.c_str(), "SEND_MSG_OSD_OP");
-  else if (m && m->get_type() == CEPH_MSG_OSD_OPREPLY)
+  else if (m->get_type() == CEPH_MSG_OSD_OPREPLY)
     OID_EVENT_TRACE(((MOSDOpReply *)m)->get_oid().name.c_str(), "SEND_MSG_OSD_OP_REPLY");
 
   ldout(cct, 1) << __func__ << "--> " << dest.name << " "

--- a/src/os/bluestore/BitAllocator.cc
+++ b/src/os/bluestore/BitAllocator.cc
@@ -528,7 +528,7 @@ void BitMapZone::dump_state(CephContext* const cct, int& count)
   BitMapEntityIter <BmapEntry> iter = BitMapEntityIter<BmapEntry>(
           &m_bmap_vec, 0);
   dout(0) << __func__ << " zone " << count << " dump start " << dendl;
-  while ((bmap = (BmapEntry *) iter.next())) {
+  while ((bmap = static_cast<BmapEntry *>(iter.next()))) {
     bmap->dump_state(cct, bmap_idx);
     bmap_idx++;
   }
@@ -770,8 +770,8 @@ bool BitMapAreaIN::is_allocated(int64_t start_block, int64_t num_blocks)
   }
 
   while (num_blocks) {
-    area = (BitMapArea *) m_child_list.get_nth_item(
-                    start_block / m_child_size_blocks);
+    area = static_cast<BitMapArea *>(m_child_list.get_nth_item(
+                    start_block / m_child_size_blocks));
 
     area_block_offset = start_block % m_child_size_blocks;
     falling_in_area = MIN(m_child_size_blocks - area_block_offset,
@@ -795,7 +795,7 @@ int64_t BitMapAreaIN::alloc_blocks_dis_int_work(bool wrap, int64_t num_blocks, i
   BmapEntityListIter iter = BmapEntityListIter(
         &m_child_list, hint / m_child_size_blocks, wrap);
 
-  while ((child = (BitMapArea *) iter.next())) {
+  while ((child = static_cast<BitMapArea *>(iter.next()))) {
     if (!child_check_n_lock(child, 1)) {
       hint = 0;
       continue;
@@ -846,8 +846,8 @@ void BitMapAreaIN::set_blocks_used_int(int64_t start_block, int64_t num_blocks)
   alloc_assert(start_block >= 0);
 
   while (blks) {
-    child = (BitMapArea *) m_child_list.get_nth_item(
-                  start_blk / m_child_size_blocks);
+    child = static_cast<BitMapArea *>(m_child_list.get_nth_item(
+                  start_blk / m_child_size_blocks));
 
     child_block_offset = start_blk % child->size();
     falling_in_child = MIN(m_child_size_blocks - child_block_offset,
@@ -886,8 +886,8 @@ void BitMapAreaIN::free_blocks_int(int64_t start_block, int64_t num_blocks)
   }
 
   while (num_blocks) {
-    child = (BitMapArea *) m_child_list.get_nth_item(
-          start_block / m_child_size_blocks);
+    child = static_cast<BitMapArea *>(m_child_list.get_nth_item(
+          start_block / m_child_size_blocks));
 
     child_block_offset = start_block % m_child_size_blocks;
 
@@ -920,7 +920,7 @@ void BitMapAreaIN::dump_state(CephContext* const cct, int& count)
   BmapEntityListIter iter = BmapEntityListIter(
         &m_child_list, 0, false);
 
-  while ((child = (BitMapArea *) iter.next())) {
+  while ((child = static_cast<BitMapArea *>(iter.next()))) {
     child->dump_state(cct, count);
   }
 }
@@ -974,7 +974,7 @@ BitMapAreaLeaf::~BitMapAreaLeaf()
   lock_excl();
 
   for (int64_t i = 0; i < m_child_list.size(); i++) {
-    BitMapArea *child = (BitMapArea *) m_child_list.get_nth_item(i);
+    auto child = static_cast<BitMapArea *>(m_child_list.get_nth_item(i));
     delete child;
   }
 
@@ -1054,8 +1054,8 @@ void BitMapAreaLeaf::free_blocks_int(int64_t start_block, int64_t num_blocks)
   }
 
   while (num_blocks) {
-    child = (BitMapArea *) m_child_list.get_nth_item(
-          start_block / m_child_size_blocks);
+    child = static_cast<BitMapArea *>(m_child_list.get_nth_item(
+          start_block / m_child_size_blocks));
 
     child_block_offset = start_block % m_child_size_blocks;
 
@@ -1170,7 +1170,7 @@ BitAllocator::~BitAllocator()
   lock_excl();
 
   for (int64_t i = 0; i < m_child_list.size(); i++) {
-    BitMapArea *child = (BitMapArea *) m_child_list.get_nth_item(i);
+    auto child = static_cast<BitMapArea *>(m_child_list.get_nth_item(i));
     delete child;
   }
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -890,7 +890,7 @@ void NVMEDevice::close()
   dout(1) << __func__ << " end" << dendl;
 }
 
-void NVMEDevice::collect_metadata(map<string,string> *pm)
+int NVMEDevice::collect_metadata(string prefix, map<string,string> *pm) const
 {
   (*pm)[prefix + "rotational"] = "0";
   (*pm)[prefix + "size"] = stringify(get_size());
@@ -899,6 +899,8 @@ void NVMEDevice::collect_metadata(map<string,string> *pm)
   (*pm)[prefix + "type"] = "nvme";
   (*pm)[prefix + "access_mode"] = "spdk";
   (*pm)[prefix + "nvme_serial_number"] = name;
+
+  return 0;
 }
 
 int NVMEDevice::flush()

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -236,7 +236,7 @@ class NVMEDevice : public BlockDevice {
   int invalidate_cache(uint64_t off, uint64_t len) override;
   int open(const string& path) override;
   void close() override;
-  void collect_metadata(map<string,string> *pm) override;
+  int collect_metadata(string prefix, map<string,string> *pm) const override;
 };
 
 #endif

--- a/src/os/fs/FS.cc
+++ b/src/os/fs/FS.cc
@@ -222,9 +222,6 @@ int FS::aio_queue_t::get_next_completed(int timeout_ms, aio_t **paio, int max)
     r = io_getevents(ctx, 1, max, event, &t);
   } while (r == -EINTR);
   
-  if (r <= 0) {
-    return r;
-  }
   for (int i=0; i<r; ++i) {
     paio[i] = (aio_t *)event[i].obj;
     paio[i]->rval = event[i].res;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5058,7 +5058,7 @@ void OSD::ms_handle_fast_accept(Connection *con)
 
 bool OSD::ms_handle_reset(Connection *con)
 {
-  Session *session = (Session *)con->get_priv();
+  Session *session = static_cast<Session*>(con->get_priv());
   dout(2) << "ms_handle_reset con " << con << " session " << session << dendl;
   if (!session)
     return false;
@@ -5077,7 +5077,7 @@ bool OSD::ms_handle_refused(Connection *con)
   if (!cct->_conf->osd_fast_fail_on_connection_refused)
     return false;
 
-  Session *session = (Session *)con->get_priv();
+  Session *session = static_cast<Session*>(con->get_priv());
   dout(2) << "ms_handle_refused con " << con << " session " << session << dendl;
   if (!session)
     return false;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1880,7 +1880,7 @@ bool PG::op_has_sufficient_caps(OpRequestRef& op)
 
   const MOSDOp *req = static_cast<const MOSDOp*>(op->get_req());
 
-  Session *session = (Session *)req->get_connection()->get_priv();
+  Session *session = static_cast<Session*>(req->get_connection()->get_priv());
   if (!session) {
     dout(0) << "op_has_sufficient_caps: no session for op " << *req << dendl;
     return false;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1533,7 +1533,7 @@ void PrimaryLogPG::get_src_oloc(const object_t& oid, const object_locator_t& olo
 void PrimaryLogPG::handle_backoff(OpRequestRef& op)
 {
   const MOSDBackoff *m = static_cast<const MOSDBackoff*>(op->get_req());
-  SessionRef session((Session *)m->get_connection()->get_priv());
+  SessionRef session = static_cast<Session*>(m->get_connection()->get_priv());
   if (!session)
     return;  // drop it.
   session->put();  // get_priv takes a ref, and so does the SessionRef
@@ -1579,7 +1579,7 @@ void PrimaryLogPG::do_request(
   // pg-wide backoffs
   const Message *m = op->get_req();
   if (m->get_connection()->has_feature(CEPH_FEATURE_RADOS_BACKOFF)) {
-    SessionRef session((Session *)m->get_connection()->get_priv());
+    SessionRef session = static_cast<Session*>(m->get_connection()->get_priv());
     if (!session)
       return;  // drop it.
     session->put();  // get_priv takes a ref, and so does the SessionRef
@@ -1779,7 +1779,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     m->get_connection()->has_feature(CEPH_FEATURE_RADOS_BACKOFF);
   SessionRef session;
   if (can_backoff) {
-    session = ((Session *)m->get_connection()->get_priv());
+    session = static_cast<Session*>(m->get_connection()->get_priv());
     if (!session.get()) {
       dout(10) << __func__ << " no session" << dendl;
       return;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -140,6 +140,10 @@ int rgw_read_user_buckets(RGWRados * store,
 
   } while (truncated && total < max);
 
+  if (is_truncated != nullptr) {
+    *is_truncated = truncated;
+  }
+
   if (need_stats) {
     map<string, RGWBucketEnt>& m = buckets.get_buckets();
     ret = store->update_containers_stats(m);
@@ -440,8 +444,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id,
 				   bool fix)
 {
   RGWUserBuckets user_buckets;
-  bool done;
-  bool is_truncated;
+  bool is_truncated = false;
   string marker;
 
   CephContext *cct = store->ctx();
@@ -492,8 +495,7 @@ void check_bad_user_bucket_mapping(RGWRados *store, const rgw_user& user_id,
         }
       }
     }
-    done = (buckets.size() < max_entries);
-  } while (!done);
+  } while (is_truncated);
 }
 
 static bool bucket_object_check_filter(const string& oid)
@@ -1427,8 +1429,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
 
     RGWUserBuckets buckets;
     string marker;
-    bool done;
-    bool is_truncated;
+    bool is_truncated = false;
 
     do {
       ret = rgw_read_user_buckets(store, op_state.get_user_id(), buckets,
@@ -1451,8 +1452,7 @@ int RGWBucketAdminOp::info(RGWRados *store, RGWBucketAdminOpState& op_state,
       }
 
       flusher.flush();
-      done = (m.size() < max_entries);
-    } while (!done);
+    } while (is_truncated);
 
     formatter->close_section();
   } else if (!bucket_name.empty()) {

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -534,6 +534,7 @@ namespace rgw {
     }
 
     void set_times(real_time t) {
+      lock_guard guard(mtx);
       state.ctime = real_clock::to_timespec(t);
       state.mtime = state.ctime;
       state.atime = state.ctime;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4172,9 +4172,13 @@ void RGWPutACLs::execute()
     return;
   }
 
+  // forward bucket acl requests to meta master zone
   if (s->object.empty() && !store->is_meta_master()) {
     bufferlist in_data;
-    in_data.append(data, len);
+    // include acl data unless it was generated from a canned_acl
+    if (s->canned_acl.empty()) {
+      in_data.append(data, len);
+    }
     op_ret = forward_request_to_master(s, NULL, store, in_data, NULL);
     if (op_ret < 0) {
       ldout(s->cct, 20) << __func__ << "forward_request_to_master returned ret=" << op_ret << dendl;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1551,6 +1551,7 @@ void RGWListBuckets::execute()
     }
   }
 
+  is_truncated = false;
   do {
     RGWUserBuckets buckets;
     uint64_t read_count;
@@ -1595,7 +1596,7 @@ void RGWListBuckets::execute()
       map<string, RGWBucketEnt>::reverse_iterator riter = m.rbegin();
       marker = riter->first;
     }
-  } while (!done);
+  } while (is_truncated && !done);
 
 send_end:
   if (!started) {
@@ -1676,8 +1677,7 @@ int RGWStatAccount::verify_permission()
 void RGWStatAccount::execute()
 {
   string marker;
-  bool done;
-  bool is_truncated;
+  bool is_truncated = false;
   uint64_t max_buckets = s->cct->_conf->rgw_list_buckets_max_chunk;
 
   do {
@@ -1704,9 +1704,8 @@ void RGWStatAccount::execute()
       }
       buckets_count += m.size();
 
-      done = (m.size() < max_buckets);
     }
-  } while (!done);
+  } while (is_truncated);
 }
 
 int RGWGetBucketVersioning::verify_permission()
@@ -2004,7 +2003,7 @@ int RGWCreateBucket::verify_permission()
   if (s->user->max_buckets) {
     RGWUserBuckets buckets;
     string marker;
-    bool is_truncated;
+    bool is_truncated = false;
     op_ret = rgw_read_user_buckets(store, s->user->user_id, buckets,
 				   marker, string(), s->user->max_buckets,
 				   false, &is_truncated);
@@ -5363,7 +5362,7 @@ int RGWBulkUploadOp::handle_dir_verify_permission()
   if (s->user->max_buckets > 0) {
     RGWUserBuckets buckets;
     std::string marker;
-    bool is_truncated;
+    bool is_truncated = false;
     op_ret = rgw_read_user_buckets(store, s->user->user_id, buckets,
                                    marker, std::string(), s->user->max_buckets,
                                    false, &is_truncated);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -440,6 +440,12 @@ int rgw_build_bucket_policies(RGWRados* store, struct req_state* s)
     if (!r) {
       if (!zonegroup.endpoints.empty()) {
 	s->zonegroup_endpoint = zonegroup.endpoints.front();
+      } else {
+        // use zonegroup's master zone endpoints
+        auto z = zonegroup.zones.find(zonegroup.master_zone);
+        if (z != zonegroup.zones.end() && !z->second.endpoints.empty()) {
+          s->zonegroup_endpoint = z->second.endpoints.front();
+        }
       }
       s->zonegroup_name = zonegroup.get_name();
     }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -776,7 +776,7 @@ void abort_early(struct req_state *s, RGWOp *op, int err_no,
       if (!s->redirect.empty()) {
         dest_uri = s->redirect;
       } else if (!s->zonegroup_endpoint.empty()) {
-        string dest_uri = s->zonegroup_endpoint;
+        dest_uri = s->zonegroup_endpoint;
         /*
          * reqest_uri is always start with slash, so we need to remove
          * the unnecessary slash at the end of dest_uri.

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -84,9 +84,9 @@ void RGWOp_Period_Post::execute()
   period.init(cct, store, false);
 
   // decode the period from input
-#define PERIOD_MAX_LEN 4096
+  const auto max_size = cct->_conf->rgw_max_put_param_size;
   bool empty;
-  http_ret = rgw_rest_get_json_input(cct, s, period, PERIOD_MAX_LEN, &empty);
+  http_ret = rgw_rest_get_json_input(cct, s, period, max_size, &empty);
   if (http_ret < 0) {
     lderr(cct) << "failed to decode period" << dendl;
     return;

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1234,7 +1234,7 @@ int RGWPutObj_ObjStore_S3::validate_and_unwrap_available_aws4_chunked_data(buffe
 
     /* grab chunk size */
 
-    while ((*(chunk_str+chunk_offset) != ';') && (chunk_offset < chunk_str_min_len))
+    while ((chunk_offset < chunk_str_min_len) && (chunk_str[chunk_offset] != ';'))
       chunk_offset++;
     string str = string(chunk_str, chunk_offset);
     unsigned int chunk_data_size;
@@ -4032,7 +4032,7 @@ int RGWHandler_REST_S3Website::serve_errordoc(int http_ret, const string& errord
   int ret = 0;
   s->formatter->reset(); /* Try to throw it all away */
 
-  std::shared_ptr<RGWGetObj_ObjStore_S3Website> getop( (RGWGetObj_ObjStore_S3Website*) op_get() );
+  std::shared_ptr<RGWGetObj_ObjStore_S3Website> getop( static_cast<RGWGetObj_ObjStore_S3Website*>(op_get()));
   if (getop.get() == NULL) {
     return -1; // Trigger double error handler
   }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -45,8 +45,7 @@ int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
 {
   CephContext *cct = store->ctx();
   size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
-  bool done;
-  bool is_truncated;
+  bool is_truncated = false;
   string marker;
   int ret;
   RGWObjectCtx obj_ctx(store);
@@ -79,8 +78,7 @@ int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
         return ret;
       }
     }
-    done = (buckets.size() < max_entries);
-  } while (!done);
+  } while (is_truncated);
 
   ret = store->complete_sync_user_stats(user_id);
   if (ret < 0) {
@@ -2030,8 +2028,7 @@ int RGWUser::execute_remove(RGWUserAdminOpState& op_state, std::string *err_msg)
     return -ENOENT;
   }
 
-  bool done;
-  bool is_truncated;
+  bool is_truncated = false;
   string marker;
   CephContext *cct = store->ctx();
   size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
@@ -2061,8 +2058,7 @@ int RGWUser::execute_remove(RGWUserAdminOpState& op_state, std::string *err_msg)
       marker = it->first;
     }
 
-    done = (m.size() < max_buckets);
-  } while (!done);
+  } while (is_truncated);
 
   ret = rgw_delete_user(store, user_info, op_state.objv);
   if (ret < 0) {
@@ -2193,8 +2189,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
       return -EINVAL;
     }
 
-    bool done;
-    bool is_truncated;
+    bool is_truncated = false;
     string marker;
     CephContext *cct = store->ctx();
     size_t max_buckets = cct->_conf->rgw_list_buckets_max_chunk;
@@ -2223,8 +2218,7 @@ int RGWUser::execute_modify(RGWUserAdminOpState& op_state, std::string *err_msg)
         return ret;
       }
 
-      done = (m.size() < max_buckets);
-    } while (!done);
+    } while (is_truncated);
   }
   op_state.set_user_info(user_info);
 

--- a/src/stop.sh
+++ b/src/stop.sh
@@ -52,7 +52,7 @@ while [ $# -ge 1 ]; do
             stop_all=0
             ;;
         mgr | ceph-mgr )
-            stop_mon=1
+            stop_mgr=1
             stop_all=0
             ;;
         mds | ceph-mds )

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -49,8 +49,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create(len));
     history_alloc_bytes += len;
@@ -65,8 +67,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::claim_char
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = new char[len];
     ::memset(str, 'X', len);
@@ -86,8 +90,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_static
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = new char[len];
     bufferptr ptr(buffer::create_static(len, str));
@@ -103,8 +109,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_malloc
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create_malloc(len));
     history_alloc_bytes += len;
@@ -121,8 +129,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::claim_malloc
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = (char*)malloc(len);
     ::memset(str, 'X', len);
@@ -142,8 +152,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::copy
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     const std::string expected(len, 'X');
     bufferptr ptr(buffer::copy(expected.c_str(), expected.size()));
@@ -160,8 +172,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_page_aligned
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create_page_aligned(len));
     history_alloc_bytes += len;
@@ -187,8 +201,10 @@ TEST(Buffer, constructors) {
     }
   }
 #ifdef CEPH_HAVE_SPLICE
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     // no fd
     EXPECT_THROW(buffer::create_zero_copy(len, -1, NULL), buffer::error_code);
@@ -213,8 +229,9 @@ TEST(Buffer, constructors) {
     ::unlink(FILENAME);
   }
 #endif
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
 }
 
 void bench_buffer_alloc(int size, int num)
@@ -268,8 +285,9 @@ protected:
 TEST_F(TestRawPipe, create_zero_copy) {
   bufferptr ptr(buffer::create_zero_copy(len, fd, NULL));
   EXPECT_EQ(len, ptr.length());
-  if (get_env_bool("CEPH_BUFFER_TRACK"))
+  if (get_env_bool("CEPH_BUFFER_TRACK")) {
     EXPECT_EQ(len, (unsigned)buffer::get_total_alloc());
+  }
 }
 
 TEST_F(TestRawPipe, c_str_no_fd) {
@@ -2402,8 +2420,9 @@ TEST(BufferList, read_file) {
   EXPECT_EQ(-ENOENT, bl.read_file("UNLIKELY", &error));
   snprintf(cmd, sizeof(cmd), "echo ABC > %s ; chmod 0 %s", FILENAME, FILENAME);
   EXPECT_EQ(0, ::system(cmd));
-  if (getuid() != 0)
+  if (getuid() != 0) {
     EXPECT_EQ(-EACCES, bl.read_file(FILENAME, &error));
+  }
   snprintf(cmd, sizeof(cmd), "chmod +r %s", FILENAME);
   EXPECT_EQ(0, ::system(cmd));
   EXPECT_EQ(0, bl.read_file(FILENAME, &error));

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -86,6 +86,10 @@
       snap rollback (snap revert) Rollback image to snapshot.
       snap unprotect              Allow a snapshot to be deleted.
       status                      Show the status of this image.
+      trash list (trash ls)       List trash images.
+      trash move (trash mv)       Moves an image to the trash.
+      trash remove (trash rm)     Removes an image from trash.
+      trash restore               Restores an image from trash.
       unmap                       Unmap a rbd device that was used by the kernel.
       watch                       Watch events on image.
   
@@ -476,7 +480,7 @@
   rbd help group image remove
   usage: rbd group image remove [--group-pool <group-pool>] [--group <group>] 
                                 [--image-pool <image-pool>] [--image <image>] 
-                                [--pool <pool>] 
+                                [--pool <pool>] [--image-id <image-id>] 
                                 <group-spec> <image-spec> 
   
   Remove an image from a consistency group.
@@ -493,6 +497,7 @@
     --image-pool arg     image pool name
     --image arg          image name
     -p [ --pool ] arg    pool name unless overridden
+    --image-id arg       image id
   
   rbd help group list
   usage: rbd group list [--pool <pool>] [--format <format>] [--pretty-format] 
@@ -655,7 +660,7 @@
   
   rbd help info
   usage: rbd info [--pool <pool>] [--image <image>] [--snap <snap>] 
-                  [--format <format>] [--pretty-format] 
+                  [--image-id <image-id>] [--format <format>] [--pretty-format] 
                   <image-or-snap-spec> 
   
   Show information about image size, striping, etc.
@@ -668,6 +673,7 @@
     -p [ --pool ] arg     pool name
     --image arg           image name
     --snap arg            snapshot name
+    --image-id arg        image id
     --format arg          output format [plain, json, or xml]
     --pretty-format       pretty formatting (json and xml)
   
@@ -1291,8 +1297,8 @@
     --limit arg          maximum allowed snapshot count
   
   rbd help snap list
-  usage: rbd snap list [--pool <pool>] [--image <image>] [--format <format>] 
-                       [--pretty-format] 
+  usage: rbd snap list [--pool <pool>] [--image <image>] [--image-id <image-id>] 
+                       [--format <format>] [--pretty-format] 
                        <image-spec> 
   
   Dump list of image snapshots.
@@ -1304,6 +1310,7 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
+    --image-id arg       image id
     --format arg         output format [plain, json, or xml]
     --pretty-format      pretty formatting (json and xml)
   
@@ -1323,7 +1330,8 @@
     --snap arg           snapshot name
   
   rbd help snap purge
-  usage: rbd snap purge [--pool <pool>] [--image <image>] [--no-progress] 
+  usage: rbd snap purge [--pool <pool>] [--image <image>] 
+                        [--image-id <image-id>] [--no-progress] 
                         <image-spec> 
   
   Deletes all snapshots.
@@ -1335,11 +1343,12 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
+    --image-id arg       image id
     --no-progress        disable progress output
   
   rbd help snap remove
   usage: rbd snap remove [--pool <pool>] [--image <image>] [--snap <snap>] 
-                         [--no-progress] [--force] 
+                         [--no-progress] [--image-id <image-id>] [--force] 
                          <snap-spec> 
   
   Deletes a snapshot.
@@ -1353,6 +1362,7 @@
     --image arg          image name
     --snap arg           snapshot name
     --no-progress        disable progress output
+    --image-id arg       image id
     --force              flatten children and unprotect snapshot if needed.
   
   rbd help snap rename
@@ -1396,6 +1406,7 @@
   
   rbd help snap unprotect
   usage: rbd snap unprotect [--pool <pool>] [--image <image>] [--snap <snap>] 
+                            [--image-id <image-id>] 
                             <snap-spec> 
   
   Allow a snapshot to be deleted.
@@ -1408,6 +1419,7 @@
     -p [ --pool ] arg    pool name
     --image arg          image name
     --snap arg           snapshot name
+    --image-id arg       image id
   
   rbd help status
   usage: rbd status [--pool <pool>] [--image <image>] [--format <format>] 
@@ -1425,6 +1437,71 @@
     --image arg          image name
     --format arg         output format [plain, json, or xml]
     --pretty-format      pretty formatting (json and xml)
+  
+  rbd help trash list
+  usage: rbd trash list [--pool <pool>] [--all] [--long] [--format <format>] 
+                        [--pretty-format] 
+                        <pool-name> 
+  
+  List trash images.
+  
+  Positional arguments
+    <pool-name>          pool name
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    -a [ --all ]         list images from all sources
+    -l [ --long ]        long listing format
+    --format arg         output format [plain, json, or xml]
+    --pretty-format      pretty formatting (json and xml)
+  
+  rbd help trash move
+  usage: rbd trash move [--pool <pool>] [--image <image>] [--delay <delay>] 
+                        <image-spec> 
+  
+  Moves an image to the trash.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --image arg          image name
+    --delay arg          time delay in seconds until effectively remove the image
+  
+  rbd help trash remove
+  usage: rbd trash remove [--pool <pool>] [--image-id <image-id>] 
+                          [--no-progress] [--force] 
+                          <image-id> 
+  
+  Removes an image from trash.
+  
+  Positional arguments
+    <image-id>           image id
+                         (example: [<pool-name>/]<image-id>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --image-id arg       image id
+    --no-progress        disable progress output
+    --force              force remove of non-expired delayed images
+  
+  rbd help trash restore
+  usage: rbd trash restore [--pool <pool>] [--image-id <image-id>] 
+                           [--image <image>] 
+                           <image-id> 
+  
+  Restores an image from trash.
+  
+  Positional arguments
+    <image-id>           image id
+                         (example: [<pool-name>/]<image-id>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --image-id arg       image id
+    --image arg          image name
   
   rbd help unmap
   usage: rbd unmap [--pool <pool>] [--image <image>] [--snap <snap>] 

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -42,11 +42,13 @@ void lock_info(IoCtx *ioctx, string& oid, string& name, map<locker_id_t, locker_
   cout << "  tag: " << tag << std::endl;
   cout << "  lockers:" << std::endl;
 
-  if (assert_type)
+  if (assert_type) {
     ASSERT_EQ(*assert_type, lock_type);
+  }
 
-  if (assert_tag)
+  if (assert_tag) {
     ASSERT_EQ(*assert_tag, tag);
+  }
 
   map<locker_id_t, locker_info_t>::iterator liter;
   for (liter = lockers.begin(); liter != lockers.end(); ++liter) {

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -608,8 +608,7 @@ TEST(CRUSH, straw2_reweight) {
 
     if (out1[0] == changed) {
       ASSERT_EQ(changed, out0[0]);
-    }
-    else if (out0[0] != changed) {
+    }else if (out0[0] != changed) {
       ASSERT_EQ(out0[0], out1[0]);
     }
   }

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -606,10 +606,12 @@ TEST(CRUSH, straw2_reweight) {
     sum[out1[0]]++;
     //sum[rand()%n]++;
 
-    if (out1[0] == changed)
+    if (out1[0] == changed) {
       ASSERT_EQ(changed, out0[0]);
-    else if (out0[0] != changed)
+    }
+    else if (out0[0] != changed) {
       ASSERT_EQ(out0[0], out1[0]);
+    }
   }
 
   double expected = (double)total / (double)n;

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1293,8 +1293,9 @@ TEST(LibCephFS, GetExtentOsds) {
   EXPECT_EQ(len, (int64_t)stripe_unit/2-1);
 
   /* only when more than 1 osd */
-  if (ret > 1)
+  if (ret > 1) {
     EXPECT_EQ(-ERANGE, ceph_get_file_extent_osds(cmount, fd, 0, NULL, osds, 1));
+  }
 
   ceph_close(cmount, fd);
 

--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -104,8 +104,9 @@ protected:
       if (key == NULL)
 	break;
       EXPECT_EQ(std::string(keys[i]), std::string(key));
-      if (val != NULL)
+      if (val != NULL) {
         EXPECT_EQ(0, memcmp(vals[i], val, val_len));
+      }
       EXPECT_EQ(lens[i], val_len);
       ++i;
     }

--- a/src/test/librbd/image/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_RemoveRequest.cc
@@ -247,7 +247,7 @@ TEST_F(TestMockImageRemoveRequest, SuccessV1) {
   expect_wq_queue(op_work_queue, 0);
 
   MockRemoveRequest *req = MockRemoveRequest::create(m_ioctx, m_image_name, "",
-					      true, no_op, &op_work_queue, &ctx);
+					      true, false, no_op, &op_work_queue, &ctx);
   req->send();
 
   ASSERT_EQ(0, ctx.wait());
@@ -269,7 +269,7 @@ TEST_F(TestMockImageRemoveRequest, OpenFailV1) {
   expect_wq_queue(op_work_queue, 0);
 
   MockRemoveRequest *req = MockRemoveRequest::create(m_ioctx, m_image_name, "",
-					      true, no_op, &op_work_queue, &ctx);
+					      true, false, no_op, &op_work_queue, &ctx);
   req->send();
 
   ASSERT_EQ(0, ctx.wait());
@@ -303,7 +303,7 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2) {
   expect_dir_remove_image(m_ioctx, 0);
 
   MockRemoveRequest *req = MockRemoveRequest::create(m_ioctx, m_image_name, "",
-					      true, no_op, &op_work_queue, &ctx);
+					      true, false, no_op, &op_work_queue, &ctx);
   req->send();
 
   ASSERT_EQ(0, ctx.wait());
@@ -337,7 +337,7 @@ TEST_F(TestMockImageRemoveRequest, NotExistsV2) {
   expect_dir_remove_image(m_ioctx, -ENOENT);
 
   MockRemoveRequest *req = MockRemoveRequest::create(m_ioctx, m_image_name, "",
-					      true, no_op, &op_work_queue, &ctx);
+					      true, false, no_op, &op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -657,7 +657,7 @@ TEST_F(TestLibRBD, UpdateWatchAndResize)
   uint64_t size = 2 << 20;
   struct Watcher {
     static void cb(void *arg) {
-      Watcher *watcher = (Watcher *)arg;
+      Watcher *watcher = static_cast<Watcher *>(arg);
       watcher->handle_notify();
     }
     Watcher(rbd_image_t &image) : m_image(image), m_lock("lock") {}

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -99,7 +99,7 @@ TEST(BitAllocator, test_bmap_iter)
   i = off;
   last_idx = off;
   count = 0;
-  while ((obj = (BmapEntityTmp*) iter.next())) {
+  while ((obj = static_cast<BmapEntityTmp*>(iter.next()))) {
     bmap_test_assert(obj->get_index() == last_idx);
     bmap_test_assert(obj->get_index() == i);
     bmap_test_assert(obj == &(*arr)[i]);

--- a/src/test/on_exit.cc
+++ b/src/test/on_exit.cc
@@ -10,6 +10,7 @@
 # ifdef MAP_ANON
 #  define MAP_ANONYMOUS MAP_ANON
 # else
+// cppcheck-suppress preprocessorErrorDirective
 #  error "Don't know how to create anonymous mmap"
 # endif
 #endif

--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -212,8 +212,9 @@ TEST_F(TestLFNIndex, remove_object) {
     ghobject_t hoid(hobject_t(sobject_t("ABC", CEPH_NOSNAP)));
 
     EXPECT_EQ(0, ::chmod("PATH_1", 0000));
-    if (getuid() != 0)
+    if (getuid() != 0) {
       EXPECT_EQ(-EACCES, remove_object(path, hoid));
+    }
     EXPECT_EQ(0, ::chmod("PATH_1", 0700));
     EXPECT_EQ(-ENOENT, remove_object(path, hoid));
     EXPECT_EQ(0, get_mangled_name(path, hoid, &mangled_name, &exists));
@@ -404,8 +405,9 @@ TEST_F(TestLFNIndex, get_mangled_name) {
     exists = 666;
     EXPECT_EQ(0, ::close(::creat(pathname.c_str(), 0600)));
     EXPECT_EQ(0, ::chmod("PATH_1", 0500));
-    if (getuid() != 0)
+    if (getuid() != 0) {
       EXPECT_EQ(-EACCES, get_mangled_name(path, hoid, &mangled_name, &exists));
+    }
     EXPECT_EQ("", mangled_name);
     EXPECT_EQ(666, exists);
     EXPECT_EQ(0, ::chmod("PATH_1", 0700));

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -391,8 +391,9 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
 	  ASSERT_LT(0, first[i]);
 	  ASSERT_LT(0, primary[i]);
 	} else {
-	  if (p->second.is_replicated())
+	  if (p->second.is_replicated()) {
 	    ASSERT_EQ(0, first[i]);
+	  }
 	  ASSERT_EQ(0, primary[i]);
 	}
       }
@@ -412,8 +413,9 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
 	  ASSERT_LT(0, first[i]);
 	  ASSERT_LT(0, primary[i]);
 	} else if (i == 1) {
-	  if (p->second.is_replicated())
+	  if (p->second.is_replicated()) {
 	    ASSERT_EQ(0, first[i]);
+	  }
 	  ASSERT_EQ(0, primary[i]);
 	} else {
 	  ASSERT_LT(10000/6/4, primary[0]);

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -15,7 +15,7 @@ from rados import (Rados,
 from rbd import (RBD, Image, ImageNotFound, InvalidArgument, ImageExists,
                  ImageBusy, ImageHasSnapshots, ReadOnlyImage,
                  FunctionNotSupported, ArgumentOutOfRange,
-                 DiskQuotaExceeded, ConnectionShutdown,
+                 DiskQuotaExceeded, ConnectionShutdown, PermissionError,
                  RBD_FEATURE_LAYERING, RBD_FEATURE_STRIPINGV2,
                  RBD_FEATURE_EXCLUSIVE_LOCK, RBD_FEATURE_JOURNALING,
                  RBD_MIRROR_MODE_DISABLED, RBD_MIRROR_MODE_IMAGE,
@@ -1428,3 +1428,78 @@ class TestMirroring(object):
         eq(N + 1, len(images))
         for i in range(N):
             self.rbd.remove(ioctx, image_name + str(i))
+
+
+class TestTrash(object):
+
+    def setUp(self):
+        global rados2
+        rados2 = Rados(conffile='')
+        rados2.connect()
+        global ioctx2
+        ioctx2 = rados2.open_ioctx(pool_name)
+
+    def tearDown(self):
+        global ioctx2
+        ioctx2.close()
+        global rados2
+        rados2.shutdown()
+
+    def test_move(self):
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+
+        RBD().trash_move(ioctx, image_name, 1000)
+        RBD().trash_remove(ioctx, image_id, True)
+
+    def test_remove_denied(self):
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+
+        RBD().trash_move(ioctx, image_name, 1000)
+        assert_raises(PermissionError, RBD().trash_remove, ioctx, image_id)
+
+    def test_remove(self):
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+
+        RBD().trash_move(ioctx, image_name, 0)
+        RBD().trash_remove(ioctx, image_id)
+
+    def test_list(self):
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id1 = image.id()
+            image_name1 = image_name
+        RBD().trash_move(ioctx, image_name, 1000)
+
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id2 = image.id()
+            image_name2 = image_name
+        RBD().trash_move(ioctx, image_name, 1000)
+
+        entries = list(RBD().trash_list(ioctx))
+        for e in entries:
+            if e['id'] == image_id1:
+                eq(e['name'], image_name1)
+            elif e['id'] == image_id2:
+                eq(e['name'], image_name2)
+            else:
+                assert False
+            eq(e['source'], 'USER')
+            assert e['deferment_end_time'] > e['deletion_time']
+
+        RBD().trash_remove(ioctx, image_id1, True)
+        RBD().trash_remove(ioctx, image_id2, True)
+
+    def test_restore(self):
+        create_image()
+        with Image(ioctx, image_name) as image:
+            image_id = image.id()
+        RBD().trash_move(ioctx, image_name, 1000)
+        RBD().trash_restore(ioctx, image_id, image_name)
+        remove_image()

--- a/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceWatcher.cc
@@ -115,8 +115,14 @@ public:
     EXPECT_CALL(mock_managed_lock, shut_down(_)).WillOnce(CompleteContext(r));
   }
 
-  void expect_destroy_lock(MockManagedLock &mock_managed_lock) {
-    EXPECT_CALL(mock_managed_lock, destroy());
+  void expect_destroy_lock(MockManagedLock &mock_managed_lock,
+                           Context *ctx = nullptr) {
+    EXPECT_CALL(mock_managed_lock, destroy())
+      .WillOnce(Invoke([ctx]() {
+            if (ctx != nullptr) {
+              ctx->complete(0);
+            }
+          }));
   }
 
   void expect_get_locker(MockManagedLock &mock_managed_lock,
@@ -218,12 +224,14 @@ TEST_F(TestMockInstanceWatcher, Remove) {
   expect_get_locker(mock_managed_lock, locker, 0);
   expect_break_lock(mock_managed_lock, locker, 0);
   expect_unregister_instance(mock_io_ctx, 0);
-  expect_destroy_lock(mock_managed_lock);
+  C_SaferCond on_destroy;
+  expect_destroy_lock(mock_managed_lock, &on_destroy);
 
   C_SaferCond on_remove;
   MockInstanceWatcher::remove_instance(m_local_io_ctx, m_threads->work_queue,
                                        "instance_id", &on_remove);
   ASSERT_EQ(0, on_remove.wait());
+  ASSERT_EQ(0, on_destroy.wait());
 }
 
 TEST_F(TestMockInstanceWatcher, RemoveNoent) {
@@ -234,12 +242,14 @@ TEST_F(TestMockInstanceWatcher, RemoveNoent) {
 
   expect_get_locker(mock_managed_lock, librbd::managed_lock::Locker(), -ENOENT);
   expect_unregister_instance(mock_io_ctx, 0);
-  expect_destroy_lock(mock_managed_lock);
+  C_SaferCond on_destroy;
+  expect_destroy_lock(mock_managed_lock, &on_destroy);
 
   C_SaferCond on_remove;
   MockInstanceWatcher::remove_instance(m_local_io_ctx, m_threads->work_queue,
                                        "instance_id", &on_remove);
   ASSERT_EQ(0, on_remove.wait());
+  ASSERT_EQ(0, on_destroy.wait());
 }
 
 } // namespace mirror

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -34,6 +34,8 @@ TEST(CommonIPAddr, TestNotFound)
   struct sockaddr_in net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -57,6 +59,8 @@ TEST(CommonIPAddr, TestV4_Simple)
   struct sockaddr_in6 a_two;
   struct sockaddr_in net;
   const struct sockaddr *result;
+
+  memset(&net, '0', sizeof(net));
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
@@ -82,6 +86,8 @@ TEST(CommonIPAddr, TestV4_Prefix25)
   struct sockaddr_in net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -106,6 +112,8 @@ TEST(CommonIPAddr, TestV4_Prefix16)
   struct sockaddr_in net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -129,6 +137,8 @@ TEST(CommonIPAddr, TestV4_PrefixTooLong)
   struct sockaddr_in net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+
   one.ifa_next = NULL;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -147,6 +157,8 @@ TEST(CommonIPAddr, TestV4_PrefixZero)
   struct sockaddr_in a_two;
   struct sockaddr_in net;
   const struct sockaddr *result;
+
+  memset(&net, '0', sizeof(net));
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
@@ -172,6 +184,8 @@ TEST(CommonIPAddr, TestV6_Simple)
   struct sockaddr_in6 net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+  
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -196,6 +210,8 @@ TEST(CommonIPAddr, TestV6_Prefix57)
   struct sockaddr_in6 net;
   const struct sockaddr *result;
 
+  memset(&net, '0', sizeof(net));
+
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
   one.ifa_name = eth0;
@@ -218,6 +234,8 @@ TEST(CommonIPAddr, TestV6_PrefixTooLong)
   struct sockaddr_in6 a_one;
   struct sockaddr_in6 net;
   const struct sockaddr *result;
+
+  memset(&net, '0', sizeof(net));
 
   one.ifa_next = NULL;
   one.ifa_addr = (struct sockaddr*)&a_one;

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -114,6 +114,17 @@ void add_image_option(po::options_description *opt,
     (name.c_str(), po::value<std::string>(), description.c_str());
 }
 
+void add_image_id_option(po::options_description *opt,
+                         const std::string &desc_suffix) {
+  std::string name = IMAGE_ID;
+  std::string description = "image id";
+  description += desc_suffix;
+
+  // TODO add validator
+  opt->add_options()
+    (name.c_str(), po::value<std::string>(), description.c_str());
+}
+
 void add_group_option(po::options_description *opt,
 		      ArgumentModifier modifier,
 		      const std::string &desc_suffix) {
@@ -248,7 +259,6 @@ void add_journal_spec_options(po::options_description *pos,
   add_image_option(opt, modifier);
   add_journal_option(opt, modifier);
 }
-
 
 void add_create_image_options(po::options_description *opt,
                               bool include_format) {

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -43,6 +43,7 @@ static const std::string SNAPSHOT_SPEC("snap-spec");
 static const std::string IMAGE_OR_SNAPSHOT_SPEC("image-or-snap-spec");
 static const std::string JOURNAL_SPEC("journal-spec");
 static const std::string PATH_NAME("path-name");
+static const std::string IMAGE_ID("image-id");
 
 // optional arguments
 static const std::string CONFIG_PATH("conf");
@@ -81,6 +82,8 @@ static const std::string FORMAT("format");
 static const std::string PRETTY_FORMAT("pretty-format");
 static const std::string VERBOSE("verbose");
 static const std::string NO_ERROR("no-error");
+
+static const std::string DELAY("delay");
 
 static const std::string LIMIT("limit");
 
@@ -135,6 +138,9 @@ void add_pool_option(boost::program_options::options_description *opt,
 void add_image_option(boost::program_options::options_description *opt,
                       ArgumentModifier modifier,
                       const std::string &desc_suffix = "");
+
+void add_image_id_option(boost::program_options::options_description *opt,
+                         const std::string &desc_suffix = "");
 
 void add_group_option(boost::program_options::options_description *opt,
 		      ArgumentModifier modifier,

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -33,6 +33,7 @@ set(rbd_srcs
   action/Resize.cc
   action/Snap.cc
   action/Status.cc
+  action/Trash.cc
   action/Watch.cc)
 add_executable(rbd ${rbd_srcs}
   $<TARGET_OBJECTS:common_util_obj>

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -148,6 +148,28 @@ int extract_group_spec(const std::string &spec,
   return 0;
 }
 
+int extract_image_id_spec(const std::string &spec, std::string *pool_name,
+                          std::string *image_id) {
+  boost::regex pattern;
+  pattern = "^(?:([^/]+)/)?(.+)?$";
+
+  boost::smatch match;
+  if (!boost::regex_match(spec, match, pattern)) {
+    std::cerr << "rbd: invalid spec '" << spec << "'" << std::endl;
+    return -EINVAL;
+  }
+
+  if (pool_name != nullptr && match[1].matched) {
+    *pool_name = match[1];
+  }
+  if (image_id != nullptr) {
+    *image_id = match[2];
+  }
+
+  return 0;
+ 
+}
+
 std::string get_positional_argument(const po::variables_map &vm, size_t index) {
   if (vm.count(at::POSITIONAL_ARGUMENTS) == 0) {
     return "";
@@ -275,6 +297,41 @@ int get_special_pool_image_names(const po::variables_map &vm,
   return 0;
 }
 
+int get_pool_image_id(const po::variables_map &vm,
+		      size_t *spec_arg_index,
+		      std::string *pool_name,
+		      std::string *image_id) {
+
+  if (vm.count(at::POOL_NAME) && pool_name != nullptr) {
+    *pool_name = vm[at::POOL_NAME].as<std::string>();
+  }
+  if (vm.count(at::IMAGE_ID) && image_id != nullptr) {
+    *image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  int r;
+  if (image_id != nullptr && spec_arg_index != nullptr && image_id->empty()) {
+    std::string spec = get_positional_argument(vm, (*spec_arg_index)++);
+    if (!spec.empty()) {
+      r = extract_image_id_spec(spec, pool_name, image_id);
+      if (r < 0) {
+        return r;
+      }
+    }
+  }
+
+  if (pool_name->empty()) {
+    *pool_name = at::DEFAULT_POOL_NAME;
+  }
+
+  if (image_id != nullptr && image_id->empty()) {
+    std::cerr << "rbd: image id was not specified" << std::endl;
+    return -EINVAL;
+  }
+
+  return 0;
+}
+
 int get_pool_group_names(const po::variables_map &vm,
 			 at::ArgumentModifier mod,
 			 size_t *spec_arg_index,
@@ -343,7 +400,7 @@ int get_pool_image_snapshot_names(const po::variables_map &vm,
   }
   if (vm.count(snap_key) && snap_name != nullptr) {
      *snap_name = vm[snap_key].as<std::string>();
-   }
+  }
 
   int r;
   if (image_name != nullptr && !image_name->empty()) {
@@ -392,6 +449,39 @@ int get_pool_image_snapshot_names(const po::variables_map &vm,
   if (snap_name != nullptr) {
     r = validate_snapshot_name(mod, *snap_name, snapshot_presence,
 	                       spec_validation);
+    if (r < 0) {
+      return r;
+    }
+  }
+  return 0;
+}
+
+int get_pool_snapshot_names(const po::variables_map &vm,
+                            at::ArgumentModifier mod,
+                            size_t *spec_arg_index,
+                            std::string *pool_name,
+                            std::string *snap_name,
+                            SnapshotPresence snapshot_presence,
+                            SpecValidation spec_validation) {
+  std::string pool_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
+    at::DEST_POOL_NAME : at::POOL_NAME);
+  std::string snap_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
+	at::DEST_SNAPSHOT_NAME : at::SNAPSHOT_NAME);
+
+  if (vm.count(pool_key) && pool_name != nullptr) {
+    *pool_name = vm[pool_key].as<std::string>();
+  }
+  if (vm.count(snap_key) && snap_name != nullptr) {
+     *snap_name = vm[snap_key].as<std::string>();
+  }
+
+  if (pool_name != nullptr && pool_name->empty()) {
+    *pool_name = at::DEFAULT_POOL_NAME;
+  }
+
+  if (snap_name != nullptr) {
+    int r = validate_snapshot_name(mod, *snap_name, snapshot_presence,
+                                   spec_validation);
     if (r < 0) {
       return r;
     }
@@ -468,7 +558,7 @@ int get_pool_journal_names(const po::variables_map &vm,
     librados::Rados rados;
     librados::IoCtx io_ctx;
     librbd::Image image;
-    int r = init_and_open_image(*pool_name, image_name, "", true, &rados,
+    int r = init_and_open_image(*pool_name, image_name, "", "", true, &rados,
                                 &io_ctx, &image);
     if (r < 0) {
       std::cerr << "rbd: failed to open image " << image_name
@@ -802,8 +892,27 @@ int open_image(librados::IoCtx &io_ctx, const std::string &image_name,
   return 0;
 }
 
+int open_image_by_id(librados::IoCtx &io_ctx, const std::string &image_id,
+                     bool read_only, librbd::Image *image) {
+  int r;
+  librbd::RBD rbd;
+  if (read_only) {
+    r = rbd.open_by_id_read_only(io_ctx, *image, image_id.c_str(), NULL);
+  } else {
+    r = rbd.open_by_id(io_ctx, *image, image_id.c_str());
+  }
+
+  if (r < 0) {
+    std::cerr << "rbd: error opening image with id " << image_id << ": "
+              << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  return 0;
+}
+
 int init_and_open_image(const std::string &pool_name,
                         const std::string &image_name,
+                        const std::string &image_id,
                         const std::string &snap_name, bool read_only,
                         librados::Rados *rados, librados::IoCtx *io_ctx,
                         librbd::Image *image) {
@@ -812,7 +921,11 @@ int init_and_open_image(const std::string &pool_name,
     return r;
   }
 
-  r = open_image(*io_ctx, image_name, read_only, image);
+  if (image_id.empty()) {
+    r = open_image(*io_ctx, image_name, read_only, image);
+  } else {
+    r = open_image_by_id(*io_ctx, image_id, read_only, image);
+  }
   if (r < 0) {
     return r;
   }
@@ -928,6 +1041,24 @@ std::string timestr(time_t t) {
 uint64_t get_rbd_default_features(CephContext* cct) {
   auto features = cct->_conf->get_val<std::string>("rbd_default_features");
   return boost::lexical_cast<uint64_t>(features);
+}
+
+bool check_if_image_spec_present(const po::variables_map &vm,
+                                 at::ArgumentModifier mod,
+                                 size_t spec_arg_index) {
+  std::string image_key = (mod == at::ARGUMENT_MODIFIER_DEST ?
+    at::DEST_IMAGE_NAME : at::IMAGE_NAME);
+
+  if (vm.count(image_key)) {
+    return true;
+  }
+
+  std::string spec = get_positional_argument(vm, spec_arg_index);
+  if (!spec.empty()) {
+    return true;
+  }
+
+  return false;
 }
 
 } // namespace utils

--- a/src/tools/rbd/Utils.h
+++ b/src/tools/rbd/Utils.h
@@ -96,6 +96,9 @@ int extract_group_spec(const std::string &spec,
 		       std::string *pool_name,
 		       std::string *group_name);
 
+int extract_image_id_spec(const std::string &spec, std::string *pool_name,
+                          std::string *image_id);
+
 std::string get_positional_argument(
     const boost::program_options::variables_map &vm, size_t index);
 
@@ -109,6 +112,13 @@ int get_pool_image_snapshot_names(
     SnapshotPresence snapshot_presence, SpecValidation spec_validation,
     bool image_required = true);
 
+int get_pool_snapshot_names(const boost::program_options::variables_map &vm,
+                            argument_types::ArgumentModifier mod,
+                            size_t *spec_arg_index, std::string *pool_name,
+                            std::string *snap_name,
+                            SnapshotPresence snapshot_presence,
+                            SpecValidation spec_validation);
+
 int get_special_pool_group_names(const boost::program_options::variables_map &vm,
 				 size_t *arg_index,
 				 std::string *group_pool_name,
@@ -118,6 +128,10 @@ int get_special_pool_image_names(const boost::program_options::variables_map &vm
 				 size_t *arg_index,
 				 std::string *image_pool_name,
 				 std::string *image_name);
+
+int get_pool_image_id(const boost::program_options::variables_map &vm,
+		      size_t *arg_index, std::string *image_pool_name,
+		      std::string *image_id);
 
 int get_pool_group_names(const boost::program_options::variables_map &vm,
 			 argument_types::ArgumentModifier mod,
@@ -161,8 +175,12 @@ int init_io_ctx(librados::Rados &rados, const std::string &pool_name,
 int open_image(librados::IoCtx &io_ctx, const std::string &image_name,
                bool read_only, librbd::Image *image);
 
+int open_image_by_id(librados::IoCtx &io_ctx, const std::string &image_id,
+                     bool read_only, librbd::Image *image);
+
 int init_and_open_image(const std::string &pool_name,
                         const std::string &image_name,
+                        const std::string &image_id,
                         const std::string &snap_name, bool read_only,
                         librados::Rados *rados, librados::IoCtx *io_ctx,
                         librbd::Image *image);
@@ -175,6 +193,10 @@ bool calc_sparse_extent(const bufferptr &bp,
                         size_t *write_offset,
                         size_t *write_length,
                         size_t *offset);
+
+bool check_if_image_spec_present(const boost::program_options::variables_map &vm,
+                                 argument_types::ArgumentModifier mod,
+                                 size_t spec_arg_index);
 
 std::string image_id(librbd::Image& image);
 

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -388,7 +388,7 @@ int bench_execute(const po::variables_map &vm, io_type_t bench_io_type) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Children.cc
+++ b/src/tools/rbd/action/Children.cc
@@ -74,7 +74,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, true,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Copy.cc
+++ b/src/tools/rbd/action/Copy.cc
@@ -72,7 +72,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, true,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Diff.cc
+++ b/src/tools/rbd/action/Diff.cc
@@ -115,7 +115,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, true,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Export.cc
+++ b/src/tools/rbd/action/Export.cc
@@ -275,7 +275,7 @@ int execute_diff(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, true,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -568,7 +568,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, true,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Feature.cc
+++ b/src/tools/rbd/action/Feature.cc
@@ -72,7 +72,7 @@ int execute(const po::variables_map &vm, bool enabled) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Flatten.cc
+++ b/src/tools/rbd/action/Flatten.cc
@@ -48,7 +48,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Group.cc
+++ b/src/tools/rbd/action/Group.cc
@@ -188,10 +188,27 @@ int execute_remove_image(const po::variables_map &vm) {
 
   std::string image_name;
   std::string image_pool_name;
+  std::string image_id;
 
-  r = utils::get_special_pool_image_names(vm, &arg_index,
-					  &image_pool_name,
-					  &image_name);
+  if (vm.count(at::IMAGE_ID)) {
+    image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  bool has_image_spec = utils::check_if_image_spec_present(
+      vm, at::ARGUMENT_MODIFIER_NONE, arg_index);
+
+  if (!image_id.empty() && has_image_spec) {
+    std::cerr << "rbd: trying to access image using both name and id. "
+              << std::endl;
+    return -EINVAL;
+  }
+
+  if (image_id.empty()) {
+    r = utils::get_special_pool_image_names(vm, &arg_index, &image_pool_name,
+                                            &image_name);
+  } else {
+    image_pool_name = utils::get_pool_name(vm, &arg_index);
+  }
 
   if (r < 0) {
     std::cerr << "rbd: image remove error: " << cpp_strerror(r) << std::endl;
@@ -213,8 +230,13 @@ int execute_remove_image(const po::variables_map &vm) {
   }
 
   librbd::RBD rbd;
-  r = rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
-			     image_io_ctx, image_name.c_str());
+  if (image_id.empty()) {
+    r = rbd.group_image_remove(cg_io_ctx, group_name.c_str(),
+                               image_io_ctx, image_name.c_str());
+  } else {
+    r = rbd.group_image_remove_by_id(cg_io_ctx, group_name.c_str(),
+                                     image_io_ctx, image_id.c_str());
+  }
   if (r < 0) {
     std::cerr << "rbd: remove image error: " << cpp_strerror(r) << std::endl;
     return r;
@@ -350,6 +372,7 @@ void get_remove_image_arguments(po::options_description *positional,
 
   at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE,
 	       " unless overridden");
+  at::add_image_id_option(options);
 }
 
 void get_list_images_arguments(po::options_description *positional,

--- a/src/tools/rbd/action/ImageMeta.cc
+++ b/src/tools/rbd/action/ImageMeta.cc
@@ -144,7 +144,7 @@ int execute_list(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -186,7 +186,7 @@ int execute_get(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -236,7 +236,7 @@ int execute_set(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -278,7 +278,7 @@ int execute_remove(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Import.cc
+++ b/src/tools/rbd/action/Import.cc
@@ -454,7 +454,7 @@ int execute_diff(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -227,7 +227,7 @@ static void print_error_description(const char *poolname, const char *imgname,
   if (maperrno == -ENOENT)
     goto done;
 
-  r = utils::init_and_open_image(poolname, imgname, snapname,
+  r = utils::init_and_open_image(poolname, imgname, "", snapname,
 				 true, &rados, &ioctx, &image);
   if (r < 0)
     goto done;

--- a/src/tools/rbd/action/Lock.cc
+++ b/src/tools/rbd/action/Lock.cc
@@ -130,7 +130,7 @@ int execute_list(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", true,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", true,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -178,7 +178,7 @@ int execute_add(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -237,7 +237,7 @@ int execute_remove(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/MirrorImage.cc
+++ b/src/tools/rbd/action/MirrorImage.cc
@@ -60,7 +60,7 @@ int execute_enable_disable(const po::variables_map &vm, bool enable,
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -109,7 +109,7 @@ int execute_promote(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -140,7 +140,7 @@ int execute_demote(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -171,7 +171,7 @@ int execute_resync(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -214,7 +214,7 @@ int execute_status(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/ObjectMap.cc
+++ b/src/tools/rbd/action/ObjectMap.cc
@@ -50,7 +50,7 @@ int execute_rebuild(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, false,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -100,7 +100,7 @@ int execute_check(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, false,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, false,
 				 &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Resize.cc
+++ b/src/tools/rbd/action/Resize.cc
@@ -57,7 +57,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, snap_name, false,
+  r = utils::init_and_open_image(pool_name, image_name, "", snap_name, false,
                                  &rados, &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -180,6 +180,7 @@ int do_clear_limit(librbd::Image& image)
 void get_list_arguments(po::options_description *positional,
                         po::options_description *options) {
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
   at::add_format_options(options);
 }
 
@@ -188,9 +189,34 @@ int execute_list(const po::variables_map &vm) {
   std::string pool_name;
   std::string image_name;
   std::string snap_name;
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
-    &snap_name, utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_NONE);
+  std::string image_id;
+
+  if (vm.count(at::IMAGE_ID)) {
+    image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  bool has_image_spec = utils::check_if_image_spec_present(
+      vm, at::ARGUMENT_MODIFIER_NONE, arg_index);
+
+  if (!image_id.empty() && has_image_spec) {
+    std::cerr << "rbd: trying to access image using both name and id. "
+              << std::endl;
+    return -EINVAL;
+  }
+
+  int r;
+  if (image_id.empty()) {
+    r = utils::get_pool_image_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                             &arg_index, &pool_name,
+                                             &image_name, &snap_name,
+                                             utils::SNAPSHOT_PRESENCE_NONE,
+                                             utils::SPEC_VALIDATION_NONE);
+  } else {
+    r = utils::get_pool_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                       &arg_index, &pool_name, &snap_name,
+                                       utils::SNAPSHOT_PRESENCE_NONE,
+                                       utils::SPEC_VALIDATION_NONE);
+  }
   if (r < 0) {
     return r;
   }
@@ -204,8 +230,8 @@ int execute_list(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", true, &rados,
-                                 &io_ctx, &image);
+  r = utils::init_and_open_image(pool_name, image_name, image_id, "", true,
+                                 &rados, &io_ctx, &image);
   if (r < 0) {
     return r;
   }
@@ -239,7 +265,7 @@ int execute_create(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -258,7 +284,8 @@ void get_remove_arguments(po::options_description *positional,
                           po::options_description *options) {
   at::add_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
   at::add_no_progress_option(options);
-  
+  at::add_image_id_option(options);
+
   options->add_options()
     ("force", po::bool_switch(), "flatten children and unprotect snapshot if needed.");
 }
@@ -268,10 +295,35 @@ int execute_remove(const po::variables_map &vm) {
   std::string pool_name;
   std::string image_name;
   std::string snap_name;
+  std::string image_id;
   bool force = vm["force"].as<bool>();
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
-    &snap_name, utils::SNAPSHOT_PRESENCE_REQUIRED, utils::SPEC_VALIDATION_NONE);
+
+  if (vm.count(at::IMAGE_ID)) {
+    image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  bool has_image_spec = utils::check_if_image_spec_present(
+      vm, at::ARGUMENT_MODIFIER_NONE, arg_index);
+
+  if (!image_id.empty() && has_image_spec) {
+    std::cerr << "rbd: trying to access image using both name and id. "
+              << std::endl;
+    return -EINVAL;
+  }
+
+  int r;
+  if (image_id.empty()) {
+    r = utils::get_pool_image_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                             &arg_index, &pool_name,
+                                             &image_name, &snap_name,
+                                             utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                             utils::SPEC_VALIDATION_NONE);
+  } else {
+    r = utils::get_pool_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                       &arg_index, &pool_name, &snap_name,
+                                       utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                       utils::SPEC_VALIDATION_NONE);
+  }
   if (r < 0) {
     return r;
   }
@@ -285,7 +337,11 @@ int execute_remove(const po::variables_map &vm) {
   }
 
   io_ctx.set_osdmap_full_try();
-  r = utils::open_image(io_ctx, image_name, false, &image);
+  if (image_id.empty()) {
+    r = utils::open_image(io_ctx, image_name, false, &image);
+  } else {
+    r = utils::open_image_by_id(io_ctx, image_id, false, &image);
+  }
   if (r < 0) {
     return r;
   }
@@ -307,6 +363,7 @@ int execute_remove(const po::variables_map &vm) {
 void get_purge_arguments(po::options_description *positional,
                          po::options_description *options) {
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
   at::add_no_progress_option(options);
 }
 
@@ -315,9 +372,34 @@ int execute_purge(const po::variables_map &vm) {
   std::string pool_name;
   std::string image_name;
   std::string snap_name;
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
-    &snap_name, utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_NONE);
+  std::string image_id;
+
+  if (vm.count(at::IMAGE_ID)) {
+    image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  bool has_image_spec = utils::check_if_image_spec_present(
+      vm, at::ARGUMENT_MODIFIER_NONE, arg_index);
+
+  if (!image_id.empty() && has_image_spec) {
+    std::cerr << "rbd: trying to access image using both name and id. "
+              << std::endl;
+    return -EINVAL;
+  }
+
+  int r;
+  if (image_id.empty()) {
+    r = utils::get_pool_image_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                             &arg_index, &pool_name,
+                                             &image_name, &snap_name,
+                                             utils::SNAPSHOT_PRESENCE_NONE,
+                                             utils::SPEC_VALIDATION_NONE);
+  } else {
+    r = utils::get_pool_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                       &arg_index, &pool_name, &snap_name,
+                                       utils::SNAPSHOT_PRESENCE_NONE,
+                                       utils::SPEC_VALIDATION_NONE);
+  }
   if (r < 0) {
     return r;
   }
@@ -331,7 +413,11 @@ int execute_purge(const po::variables_map &vm) {
   }
 
   io_ctx.set_osdmap_full_try();
-  r = utils::open_image(io_ctx, image_name, false, &image);
+  if (image_id.empty()) {
+    r = utils::open_image(io_ctx, image_name, false, &image);
+  } else {
+    r = utils::open_image_by_id(io_ctx, image_id, false, &image);
+  }
   if (r < 0) {
     return r;
   }
@@ -368,7 +454,7 @@ int execute_rollback(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -403,7 +489,7 @@ int execute_protect(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;
@@ -432,6 +518,7 @@ int execute_protect(const po::variables_map &vm) {
 void get_unprotect_arguments(po::options_description *positional,
                              po::options_description *options) {
   at::add_snap_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
 }
 
 int execute_unprotect(const po::variables_map &vm) {
@@ -439,9 +526,34 @@ int execute_unprotect(const po::variables_map &vm) {
   std::string pool_name;
   std::string image_name;
   std::string snap_name;
-  int r = utils::get_pool_image_snapshot_names(
-    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
-    &snap_name, utils::SNAPSHOT_PRESENCE_REQUIRED, utils::SPEC_VALIDATION_NONE);
+  std::string image_id;
+
+  if (vm.count(at::IMAGE_ID)) {
+    image_id = vm[at::IMAGE_ID].as<std::string>();
+  }
+
+  bool has_image_spec = utils::check_if_image_spec_present(
+      vm, at::ARGUMENT_MODIFIER_NONE, arg_index);
+
+  if (!image_id.empty() && has_image_spec) {
+    std::cerr << "rbd: trying to access image using both name and id. "
+              << std::endl;
+    return -EINVAL;
+  }
+
+  int r;
+  if (image_id.empty()) {
+    r = utils::get_pool_image_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                             &arg_index, &pool_name,
+                                             &image_name, &snap_name,
+                                             utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                             utils::SPEC_VALIDATION_NONE);
+  } else {
+    r = utils::get_pool_snapshot_names(vm, at::ARGUMENT_MODIFIER_NONE,
+                                       &arg_index, &pool_name, &snap_name,
+                                       utils::SNAPSHOT_PRESENCE_REQUIRED,
+                                       utils::SPEC_VALIDATION_NONE);
+  }
   if (r < 0) {
     return r;
   }
@@ -455,11 +567,15 @@ int execute_unprotect(const po::variables_map &vm) {
   }
 
   io_ctx.set_osdmap_full_try();
-  r = utils::open_image(io_ctx, image_name, false, &image);
+  if (image_id.empty()) {
+    r = utils::open_image(io_ctx, image_name, false, &image);
+  } else {
+    r = utils::open_image_by_id(io_ctx, image_id, false, &image);
+  }
   if (r < 0) {
     return r;
   }
-  
+
   bool is_protected = false;
   r = image.snap_is_protected(snap_name.c_str(), &is_protected);
   if (r < 0) {
@@ -510,7 +626,7 @@ int execute_set_limit(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
 				 &io_ctx, &image);
   if (r < 0) {
       return r;
@@ -546,7 +662,7 @@ int execute_clear_limit(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
 				 &io_ctx, &image);
   if (r < 0) {
       return r;
@@ -604,7 +720,7 @@ int execute_rename(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", false, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", false, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -106,7 +106,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", true, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", true, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -1,0 +1,373 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 SUSE LINUX GmbH
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+#include "common/errno.h"
+#include "include/stringify.h"
+#include "common/Formatter.h"
+#include "common/TextTable.h"
+#include "common/Clock.h"
+#include <iostream>
+#include <sstream>
+#include <boost/program_options.hpp>
+
+namespace rbd {
+namespace action {
+namespace trash {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+
+void get_move_arguments(po::options_description *positional,
+                        po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  options->add_options()
+    (at::DELAY.c_str(), po::value<uint64_t>(),
+     "time delay in seconds until effectively remove the image");
+}
+
+int execute_move(const po::variables_map &vm) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_name;
+  std::string snap_name;
+
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &image_name,
+    &snap_name, utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t delay = 0;
+  if (vm.find(at::DELAY) != vm.end()) {
+    delay = vm[at::DELAY].as<uint64_t>();
+  }
+
+  librbd::RBD rbd;
+  r = rbd.trash_move(io_ctx, image_name.c_str(), delay);
+  if (r < 0) {
+    std::cerr << "rbd: deferred delete error: " << cpp_strerror(r)
+              << std::endl;
+  }
+
+  return r;
+
+}
+
+void get_remove_arguments(po::options_description *positional,
+                          po::options_description *options) {
+  positional->add_options()
+    (at::IMAGE_ID.c_str(), "image id\n(example: [<pool-name>/]<image-id>)");
+  at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
+
+  at::add_no_progress_option(options);
+  options->add_options()
+      ("force", po::bool_switch(), "force remove of non-expired delayed images");
+}
+
+int execute_remove(const po::variables_map &vm) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_id;
+  int r = utils::get_pool_image_id(vm, &arg_index, &pool_name, &image_id);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  librbd::RBD rbd;
+
+  utils::ProgressContext pc("Removing image", vm[at::NO_PROGRESS].as<bool>());
+  r = rbd.trash_remove_with_progress(io_ctx, image_id.c_str(),
+                                     vm["force"].as<bool>(), pc);
+  if (r < 0) {
+    if (r == -ENOTEMPTY) {
+      std::cerr << "rbd: image has snapshots - these must be deleted"
+                << " with 'rbd snap purge' before the image can be removed."
+                << std::endl;
+    } else if (r == -EBUSY) {
+      std::cerr << "rbd: error: image still has watchers"
+                << std::endl
+                << "This means the image is still open or the client using "
+                << "it crashed. Try again after closing/unmapping it or "
+                << "waiting 30s for the crashed client to timeout."
+                << std::endl;
+    } else if (r == -EMLINK) {
+      std::cerr << std::endl
+		<< "Remove the image from the consistency group and try again."
+		<< std::endl;
+    } else if (r == -EPERM) {
+      std::cerr << std::endl
+                << "Deferment time has not expired, please use --force if you "
+                << "really want to remove the image"
+                << std::endl;
+    } else {
+      std::cerr << "rbd: remove error: " << cpp_strerror(r) << std::endl;
+    }
+    pc.fail();
+    return r;
+  }
+
+  pc.finish();
+
+  return r;
+}
+
+std::string delete_status(time_t deferment_end_time) {
+  time_t now = ceph_clock_gettime();
+
+  std::string time_str = ctime(&deferment_end_time);
+  time_str = time_str.substr(0, time_str.length() - 1);
+
+  std::stringstream ss;
+  if (now < deferment_end_time) {
+    ss << "protected until " << time_str;
+  }
+
+  return ss.str();
+}
+
+int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
+            bool all_flag, Formatter *f) {
+  std::vector<librbd::trash_image_info_t> trash_entries;
+  int r = rbd.trash_list(io_ctx, trash_entries);
+  if (r < 0 && r != -ENOENT) {
+    return r;
+  }
+  r = 0;
+
+  if (!long_flag) {
+    if (f) {
+      f->open_array_section("trash");
+    }
+    for (const auto& entry : trash_entries) {
+      if (!all_flag &&
+          entry.source == RBD_TRASH_IMAGE_SOURCE_MIRRORING) {
+        continue;
+      }
+       if (f) {
+         f->dump_string("id", entry.id);
+         f->dump_string("name", entry.name);
+       } else {
+         std::cout << entry.id << " " << entry.name << std::endl;
+       }
+    }
+    if (f) {
+      f->close_section();
+      f->flush(std::cout);
+    }
+    return 0;
+  }
+
+  TextTable tbl;
+
+  if (f) {
+    f->open_array_section("trash");
+  } else {
+    tbl.define_column("ID", TextTable::LEFT, TextTable::LEFT);
+    tbl.define_column("NAME", TextTable::LEFT, TextTable::LEFT);
+    tbl.define_column("SOURCE", TextTable::LEFT, TextTable::LEFT);
+    tbl.define_column("DELETED_AT", TextTable::LEFT, TextTable::LEFT);
+    tbl.define_column("STATUS", TextTable::LEFT, TextTable::LEFT);
+  }
+
+  for (const auto& entry : trash_entries) {
+    if (!all_flag &&
+        entry.source == RBD_TRASH_IMAGE_SOURCE_MIRRORING) {
+      continue;
+    }
+    librbd::Image im;
+
+    r = rbd.open_by_id_read_only(io_ctx, im, entry.id.c_str(), NULL);
+    // image might disappear between rbd.list() and rbd.open(); ignore
+    // that, warn about other possible errors (EPERM, say, for opening
+    // an old-format image, because you need execute permission for the
+    // class method)
+    if (r < 0) {
+      if (r != -ENOENT) {
+        std::cerr << "rbd: error opening " << entry.id << ": "
+                  << cpp_strerror(r) << std::endl;
+      }
+      // in any event, continue to next image
+      continue;
+    }
+
+    std::string del_source;
+    switch (entry.source) {
+      case RBD_TRASH_IMAGE_SOURCE_USER:
+        del_source = "USER";
+        break;
+      case RBD_TRASH_IMAGE_SOURCE_MIRRORING:
+        del_source = "MIRRORING";
+        break;
+    }
+
+    std::string time_str = ctime(&entry.deletion_time);
+    time_str = time_str.substr(0, time_str.length() - 1);
+
+    if (f) {
+      f->open_object_section("image");
+      f->dump_string("id", entry.id);
+      f->dump_string("name", entry.name);
+      f->dump_string("source", del_source);
+      f->dump_string("deleted_at", time_str);
+      f->dump_string("status",
+                     delete_status(entry.deferment_end_time));
+      f->close_section();
+    } else {
+      tbl << entry.id
+          << entry.name
+          << del_source
+          << time_str
+          << delete_status(entry.deferment_end_time)
+          << TextTable::endrow;
+    }
+  }
+
+  if (f) {
+    f->close_section();
+    f->flush(std::cout);
+  } else if (!trash_entries.empty()) {
+    std::cout << tbl;
+  }
+
+  return r < 0 ? r : 0;
+}
+
+void get_list_arguments(po::options_description *positional,
+                        po::options_description *options) {
+  at::add_pool_options(positional, options);
+  options->add_options()
+    ("all,a", po::bool_switch(), "list images from all sources");
+  options->add_options()
+    ("long,l", po::bool_switch(), "long listing format");
+  at::add_format_options(options);
+}
+
+int execute_list(const po::variables_map &vm) {
+  size_t arg_index = 0;
+  std::string pool_name = utils::get_pool_name(vm, &arg_index);
+
+  at::Format::Formatter formatter;
+  int r = utils::get_formatter(vm, &formatter);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  librbd::RBD rbd;
+  r = do_list(rbd, io_ctx, vm["long"].as<bool>(), vm["all"].as<bool>(),
+              formatter.get());
+  if (r < 0) {
+    std::cerr << "rbd: trash list: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+
+  return 0;
+}
+
+void get_restore_arguments(po::options_description *positional,
+                            po::options_description *options) {
+  positional->add_options()
+    (at::IMAGE_ID.c_str(), "image id\n(example: [<pool-name>/]<image-id>)");
+  at::add_pool_option(options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_image_id_option(options);
+  at::add_image_option(options, at::ARGUMENT_MODIFIER_NONE, "");
+}
+
+int execute_restore(const po::variables_map &vm) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string image_id;
+  int r = utils::get_pool_image_id(vm, &arg_index, &pool_name, &image_id);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  std::string name;
+  if (vm.find(at::IMAGE_NAME) != vm.end()) {
+    name = vm[at::IMAGE_NAME].as<std::string>();
+  }
+
+  librbd::RBD rbd;
+  r = rbd.trash_restore(io_ctx, image_id.c_str(), name.c_str());
+  if (r < 0) {
+    if (r == -ENOENT) {
+      std::cerr << "rbd: error: image does not exist in trash"
+                << std::endl;
+    } else if (r == -EEXIST) {
+      std::cerr << "rbd: error: an image with the same name already exists, "
+                << "try again with with a different name"
+                << std::endl;
+    } else {
+      std::cerr << "rbd: restore error: " << cpp_strerror(r) << std::endl;
+    }
+    return r;
+  }
+
+  return r;
+}
+
+
+Shell::Action action_move(
+    {"trash", "move"}, {"trash", "mv"}, "Moves an image to the trash.", "",
+    &get_move_arguments, &execute_move);
+
+Shell::Action action_remove(
+  {"trash", "remove"}, {"trash", "rm"}, "Removes an image from trash.", "",
+  &get_remove_arguments, &execute_remove);
+
+Shell::SwitchArguments switched_arguments({"long", "l"});
+Shell::Action action_list(
+  {"trash", "list"}, {"trash", "ls"}, "List trash images.", "",
+  &get_list_arguments, &execute_list);
+
+Shell::Action action_restore(
+    {"trash", "restore"}, {}, "Restores an image from trash.", "",
+    &get_restore_arguments, &execute_restore);
+
+} // namespace trash
+} // namespace action
+} // namespace rbd

--- a/src/tools/rbd/action/Watch.cc
+++ b/src/tools/rbd/action/Watch.cc
@@ -109,7 +109,7 @@ int execute(const po::variables_map &vm) {
   librados::Rados rados;
   librados::IoCtx io_ctx;
   librbd::Image image;
-  r = utils::init_and_open_image(pool_name, image_name, "", true, &rados,
+  r = utils::init_and_open_image(pool_name, image_name, "", "", true, &rados,
                                  &io_ctx, &image);
   if (r < 0) {
     return r;

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -204,6 +204,28 @@ TRACEPOINT_EVENT(librbd, writesame_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, open_image_by_id_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, id,
+        const char*, snap_name,
+        int, read_only),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(id, id)
+        ctf_string(snap_name, snap_name)
+        ctf_integer(uint8_t, read_only, read_only ? 1 : 0)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, open_image_by_id_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, aio_open_image_enter,
     TP_ARGS(
         void*, imagectx,
@@ -223,6 +245,30 @@ TRACEPOINT_EVENT(librbd, aio_open_image_enter,
 )
 
 TRACEPOINT_EVENT(librbd, aio_open_image_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, aio_open_image_by_id_enter,
+    TP_ARGS(
+        void*, imagectx,
+        const char*, id,
+        const char*, snap_name,
+        int, read_only,
+        const void*, completion),
+    TP_FIELDS(
+        ctf_integer_hex(void*, imagectx, imagectx)
+        ctf_string(id, id)
+        ctf_string(snap_name, snap_name)
+        ctf_integer(uint8_t, read_only, read_only ? 1 : 0)
+        ctf_integer_hex(const void*, completion, completion)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, aio_open_image_by_id_exit,
     TP_ARGS(
         int, retval),
     TP_FIELDS(
@@ -420,6 +466,98 @@ TRACEPOINT_EVENT(librbd, remove_enter,
 )
 
 TRACEPOINT_EVENT(librbd, remove_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_move_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, id,
+        const char*, imgname),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, id, id)
+        ctf_string(imgname, imgname)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_move_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_list_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, id),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, id, id)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_list_entry,
+    TP_ARGS(
+        const char*, id),
+    TP_FIELDS(
+        ctf_string(id, id)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_list_exit,
+    TP_ARGS(
+        int, retval,
+        int, size),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+        ctf_integer(size_t, size, size)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_remove_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, id,
+        const char*, imgid,
+        uint8_t, force),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, id, id)
+        ctf_string(imgid, imgid)
+        ctf_integer(uint8_t, force, force)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_remove_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_undelete_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, id,
+        const char*, imgid,
+        const char*, imgnewname),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, id, id)
+        ctf_string(imgid, imgid)
+        ctf_string(imgnewname, imgnewname)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, trash_undelete_exit,
     TP_ARGS(
         int, retval),
     TP_FIELDS(
@@ -2205,6 +2343,32 @@ TRACEPOINT_EVENT(librbd, group_image_remove_enter,
 )
 
 TRACEPOINT_EVENT(librbd, group_image_remove_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, group_image_remove_by_id_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, id,
+        const char*, group_name,
+        const char*, image_pool_name,
+        int64_t, image_ioctx_id,
+        const char*, image_id),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, id, id)
+        ctf_string(group_name, group_name)
+        ctf_string(image_pool_name, image_pool_name)
+        ctf_integer(int64_t, image_ioctx_id, image_ioctx_id)
+        ctf_string(image_id, image_id)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, group_image_remove_by_id_exit,
     TP_ARGS(
         int, retval),
     TP_FIELDS(


### PR DESCRIPTION
The following warning appears during make for several files in the test submodule:
warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]

Files affected:
src/test/bufferlist.cc 
src/test/cls_lock/test_cls_lock.cc 
src/test/crush/crush.cc 
src/test/libcephfs/test.cc 
src/test/librados/c_read_operations.cc 
src/test/os/TestLFNIndex.cc 
src/test/osd/TestOSDMap.cc 

Signed-off-by: Jos Collin <jcollin@redhat.com>