### PR TITLE
rgw_file: cleanup an unnecessary function

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1134,7 +1134,7 @@ namespace rgw {
      * like data it and other attrs would arrive after open */
     processor = select_processor(*static_cast<RGWObjectCtx *>(s->obj_ctx),
 				 &multipart);
-    op_ret = processor->prepare(get_store(), NULL);
+    op_ret = processor->prepare(rgwlib.get_store(), NULL);
 
   done:
     return op_ret;
@@ -1183,10 +1183,10 @@ namespace rgw {
 
       string oid_rand;
       char buf[33];
-      gen_rand_alphanumeric(get_store()->ctx(), buf, sizeof(buf) - 1);
+      gen_rand_alphanumeric(rgwlib.get_store()->ctx(), buf, sizeof(buf) - 1);
       oid_rand.append(buf);
 
-      op_ret = processor->prepare(get_store(), &oid_rand);
+      op_ret = processor->prepare(rgwlib.get_store(), &oid_rand);
       if (op_ret < 0) {
 	ldout(s->cct, 0) << "ERROR: processor->prepare() returned "
 			 << op_ret << dendl;
@@ -1215,8 +1215,9 @@ namespace rgw {
     s->obj_size = ofs; // XXX check ofs
     perfcounter->inc(l_rgw_put_b, s->obj_size);
 
-    op_ret = get_store()->check_quota(s->bucket_owner.get_id(), s->bucket,
-				      user_quota, bucket_quota, s->obj_size);
+    op_ret = rgwlib.get_store()->check_quota(s->bucket_owner.get_id(),
+                                             s->bucket, user_quota,
+                                             bucket_quota, s->obj_size);
     if (op_ret < 0) {
       goto done;
     }

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -208,8 +208,6 @@ namespace rgw {
 		   get_state()->trans_id.c_str());
       }
 
-    inline RGWRados* get_store() { return store; }
-
     virtual int execute() final { abort(); }
     virtual int exec_start() = 0;
     virtual int exec_continue() = 0;


### PR DESCRIPTION
RGWLibContinuedReq::get_store() just returns the store pointer
got from RGWLib::get_store(), so we could remove the first one.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>