### PR TITLE
rocksdb: sync with upstream

### DIFF
--- a/src/test/objectstore/TestRocksdbOptionParse.cc
+++ b/src/test/objectstore/TestRocksdbOptionParse.cc
@@ -25,8 +25,7 @@ TEST(RocksDBOption, simple) {
 			  "max_bytes_for_level_base = 104857600;"
 			  "target_file_size_base = 10485760;"
 			  "num_levels = 3;"
-			  "compression = kNoCompression;"
-			  "disable_data_sync = false;";
+			  "compression = kNoCompression;";
   int r = db->ParseOptionsFromString(options_string, options);
   ASSERT_EQ(0, r);
   ASSERT_EQ(536870912u, options.write_buffer_size);
@@ -38,8 +37,7 @@ TEST(RocksDBOption, simple) {
   ASSERT_EQ(104857600u, options.max_bytes_for_level_base);
   ASSERT_EQ(10485760u, options.target_file_size_base);
   ASSERT_EQ(3, options.num_levels);
-  ASSERT_FALSE(options.disableDataSync);
- // ASSERT_EQ("none", options.compression);
+  ASSERT_EQ(rocksdb::kNoCompression, options.compression);
 }
 TEST(RocksDBOption, interpret) {
   rocksdb::Options options;


### PR DESCRIPTION
to pickup the change removing "add_definitions(-DROCKSDB_JEMALLOC)" in
rocksdb's CMakeListst.txt, so FreeBSD can built without the jemalloc's
header files.

Signed-off-by: Kefu Chai <kchai@redhat.com>