### PR TITLE
qa/tasks: use sudo to check ceph health for systemd test

### DIFF
--- a/qa/suites/smoke/systemd/bluestore.yaml
+++ b/qa/suites/smoke/systemd/bluestore.yaml
@@ -1,1 +1,0 @@
-../../../objectstore/bluestore.yaml

--- a/qa/tasks/systemd.py
+++ b/qa/tasks/systemd.py
@@ -138,5 +138,5 @@ def task(ctx, config):
     # wait for HEALTH_OK
     mon = get_first_mon(ctx, config)
     (mon_remote,) = ctx.cluster.only(mon).remotes.iterkeys()
-    wait_until_healthy(ctx, mon_remote)
+    wait_until_healthy(ctx, mon_remote, use_sudo=True)
     yield


### PR DESCRIPTION
without sudo it will will not have read access to key
http://pulpito.ceph.com/vasu-2017-04-11_21:01:29-smoke-master---basic-vps/
