### PR TITLE
osd/osd_types: enable default move semantics for pg_log_t

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2962,6 +2962,11 @@ public:
   mempool::osd::list<pg_log_entry_t> log;  // the actual log.
   
   pg_log_t() = default;
+  pg_log_t(const pg_log_t& other) = default;
+  pg_log_t& operator=(const pg_log_t& other) = default;
+  pg_log_t(pg_log_t&& other) = default;
+  pg_log_t& operator=(pg_log_t&& other) = default;
+
   pg_log_t(const eversion_t &last_update,
 	   const eversion_t &log_tail,
 	   const eversion_t &can_rollback_to,


### PR DESCRIPTION
so we don't need to *copy* the pg_log_t::log when assigning the return
value of pg_log_t::split_out_child() to the child's log.

Signed-off-by: Kefu Chai <kchai@redhat.com>