### PR TITLE
test: add explicit braces to avoid ambiguous ‘else’ and to silence warnings

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -49,8 +49,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create(len));
     history_alloc_bytes += len;
@@ -65,8 +67,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::claim_char
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = new char[len];
     ::memset(str, 'X', len);
@@ -86,8 +90,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_static
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = new char[len];
     bufferptr ptr(buffer::create_static(len, str));
@@ -103,8 +109,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_malloc
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create_malloc(len));
     history_alloc_bytes += len;
@@ -121,8 +129,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::claim_malloc
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     char* str = (char*)malloc(len);
     ::memset(str, 'X', len);
@@ -142,8 +152,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::copy
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     const std::string expected(len, 'X');
     bufferptr ptr(buffer::copy(expected.c_str(), expected.size()));
@@ -160,8 +172,10 @@ TEST(Buffer, constructors) {
   //
   // buffer::create_page_aligned
   //
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     bufferptr ptr(buffer::create_page_aligned(len));
     history_alloc_bytes += len;
@@ -187,8 +201,10 @@ TEST(Buffer, constructors) {
     }
   }
 #ifdef CEPH_HAVE_SPLICE
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
+  
   {
     // no fd
     EXPECT_THROW(buffer::create_zero_copy(len, -1, NULL), buffer::error_code);
@@ -213,8 +229,9 @@ TEST(Buffer, constructors) {
     ::unlink(FILENAME);
   }
 #endif
-  if (ceph_buffer_track)
+  if (ceph_buffer_track) {
     EXPECT_EQ(0, buffer::get_total_alloc());
+  }
 }
 
 void bench_buffer_alloc(int size, int num)
@@ -268,8 +285,9 @@ protected:
 TEST_F(TestRawPipe, create_zero_copy) {
   bufferptr ptr(buffer::create_zero_copy(len, fd, NULL));
   EXPECT_EQ(len, ptr.length());
-  if (get_env_bool("CEPH_BUFFER_TRACK"))
+  if (get_env_bool("CEPH_BUFFER_TRACK")) {
     EXPECT_EQ(len, (unsigned)buffer::get_total_alloc());
+  }
 }
 
 TEST_F(TestRawPipe, c_str_no_fd) {
@@ -2402,8 +2420,9 @@ TEST(BufferList, read_file) {
   EXPECT_EQ(-ENOENT, bl.read_file("UNLIKELY", &error));
   snprintf(cmd, sizeof(cmd), "echo ABC > %s ; chmod 0 %s", FILENAME, FILENAME);
   EXPECT_EQ(0, ::system(cmd));
-  if (getuid() != 0)
+  if (getuid() != 0) {
     EXPECT_EQ(-EACCES, bl.read_file(FILENAME, &error));
+  }
   snprintf(cmd, sizeof(cmd), "chmod +r %s", FILENAME);
   EXPECT_EQ(0, ::system(cmd));
   EXPECT_EQ(0, bl.read_file(FILENAME, &error));

--- a/src/test/cls_lock/test_cls_lock.cc
+++ b/src/test/cls_lock/test_cls_lock.cc
@@ -42,11 +42,13 @@ void lock_info(IoCtx *ioctx, string& oid, string& name, map<locker_id_t, locker_
   cout << "  tag: " << tag << std::endl;
   cout << "  lockers:" << std::endl;
 
-  if (assert_type)
+  if (assert_type) {
     ASSERT_EQ(*assert_type, lock_type);
+  }
 
-  if (assert_tag)
+  if (assert_tag) {
     ASSERT_EQ(*assert_tag, tag);
+  }
 
   map<locker_id_t, locker_info_t>::iterator liter;
   for (liter = lockers.begin(); liter != lockers.end(); ++liter) {

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -606,10 +606,11 @@ TEST(CRUSH, straw2_reweight) {
     sum[out1[0]]++;
     //sum[rand()%n]++;
 
-    if (out1[0] == changed)
+    if (out1[0] == changed) {
       ASSERT_EQ(changed, out0[0]);
-    else if (out0[0] != changed)
+    } else if (out0[0] != changed) {
       ASSERT_EQ(out0[0], out1[0]);
+    }
   }
 
   double expected = (double)total / (double)n;

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1293,8 +1293,9 @@ TEST(LibCephFS, GetExtentOsds) {
   EXPECT_EQ(len, (int64_t)stripe_unit/2-1);
 
   /* only when more than 1 osd */
-  if (ret > 1)
+  if (ret > 1) {
     EXPECT_EQ(-ERANGE, ceph_get_file_extent_osds(cmount, fd, 0, NULL, osds, 1));
+  }
 
   ceph_close(cmount, fd);
 

--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -104,8 +104,9 @@ protected:
       if (key == NULL)
 	break;
       EXPECT_EQ(std::string(keys[i]), std::string(key));
-      if (val != NULL)
+      if (val != NULL) {
         EXPECT_EQ(0, memcmp(vals[i], val, val_len));
+      }
       EXPECT_EQ(lens[i], val_len);
       ++i;
     }

--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -212,8 +212,9 @@ TEST_F(TestLFNIndex, remove_object) {
     ghobject_t hoid(hobject_t(sobject_t("ABC", CEPH_NOSNAP)));
 
     EXPECT_EQ(0, ::chmod("PATH_1", 0000));
-    if (getuid() != 0)
+    if (getuid() != 0) {
       EXPECT_EQ(-EACCES, remove_object(path, hoid));
+    }
     EXPECT_EQ(0, ::chmod("PATH_1", 0700));
     EXPECT_EQ(-ENOENT, remove_object(path, hoid));
     EXPECT_EQ(0, get_mangled_name(path, hoid, &mangled_name, &exists));
@@ -404,8 +405,9 @@ TEST_F(TestLFNIndex, get_mangled_name) {
     exists = 666;
     EXPECT_EQ(0, ::close(::creat(pathname.c_str(), 0600)));
     EXPECT_EQ(0, ::chmod("PATH_1", 0500));
-    if (getuid() != 0)
+    if (getuid() != 0) {
       EXPECT_EQ(-EACCES, get_mangled_name(path, hoid, &mangled_name, &exists));
+    }
     EXPECT_EQ("", mangled_name);
     EXPECT_EQ(666, exists);
     EXPECT_EQ(0, ::chmod("PATH_1", 0700));

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -391,8 +391,9 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
 	  ASSERT_LT(0, first[i]);
 	  ASSERT_LT(0, primary[i]);
 	} else {
-	  if (p->second.is_replicated())
+	  if (p->second.is_replicated()) {
 	    ASSERT_EQ(0, first[i]);
+	  }
 	  ASSERT_EQ(0, primary[i]);
 	}
       }
@@ -412,8 +413,9 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
 	  ASSERT_LT(0, first[i]);
 	  ASSERT_LT(0, primary[i]);
 	} else if (i == 1) {
-	  if (p->second.is_replicated())
+	  if (p->second.is_replicated()) {
 	    ASSERT_EQ(0, first[i]);
+	  }
 	  ASSERT_EQ(0, primary[i]);
 	} else {
 	  ASSERT_LT(10000/6/4, primary[0]);


### PR DESCRIPTION
The following warning appears during make for several files in the test submodule:
warning: suggest explicit braces to avoid ambiguous ‘else’ [-Wdangling-else]

Files affected:
src/test/bufferlist.cc
src/test/cls_lock/test_cls_lock.cc
src/test/crush/crush.cc
src/test/libcephfs/test.cc
src/test/librados/c_read_operations.cc
src/test/os/TestLFNIndex.cc
src/test/osd/TestOSDMap.cc

Signed-off-by: Jos Collin <jcollin@redhat.com>