### PR TITLE
rgw: avoid using null pointer in rgw_file.cc

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -339,7 +339,7 @@ namespace rgw {
     if (! rgw_fh) {
       ldout(get_context(), 0) << __func__
 		       << " BUG no such src renaming path="
-		       << rgw_fh->full_object_name()
+		       << src_name
 		       << dendl;
       goto out;
     }


### PR DESCRIPTION
When rgw_fh is null, I think we should avoid using rgw_fh->full_object_name().

Signed-off-by: lihongjie <lihongjie@cmss.chinamobile.com>