### PR TITLE
ceph-disk/ceph_disk/main.py: fix calling of the bsdrc init scripts

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3234,14 +3234,10 @@ def start_daemon(
                 ],
             )
         elif os.path.exists(os.path.join(path, 'bsdrc')):
-            base_script = '/usr/local/etc/rc.d/ceph'
-            osd_script = '{base} start osd.{osd_id}'.format(
-                base=base_script,
-                osd_id=osd_id
-            )
             command_check_call(
                 [
-                    osd_script,
+                    '/usr/local/etc/rc.d/ceph start osd.{osd_id}'
+                    .format(osd_id=osd_id),
                 ],
             )
         else:
@@ -3315,7 +3311,6 @@ def stop_daemon(
                 [
                     '/usr/local/etc/rc.d/ceph stop osd.{osd_id}'
                     .format(osd_id=osd_id),
-                    'stop',
                 ],
             )
         else:


### PR DESCRIPTION
- rc.d/ceph does not really like the extra stop/start as las cmd.
 - And make Start and Stop look similar.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>