### PR TITLE
mon: add mon_debug_no_require_luminous

### DIFF
--- a/qa/suites/rados/basic/z-require-luminous
+++ b/qa/suites/rados/basic/z-require-luminous
@@ -1,0 +1,1 @@
+../thrash/z-require-luminous

--- a/qa/suites/rados/monthrash/z-require-luminous
+++ b/qa/suites/rados/monthrash/z-require-luminous
@@ -1,0 +1,1 @@
+../thrash/z-require-luminous

--- a/qa/suites/rados/multimon/z-require-luminous
+++ b/qa/suites/rados/multimon/z-require-luminous
@@ -1,0 +1,1 @@
+../thrash/z-require-luminous

--- a/qa/suites/rados/thrash-erasure-code/z-require-luminous
+++ b/qa/suites/rados/thrash-erasure-code/z-require-luminous
@@ -1,0 +1,1 @@
+../thrash/z-require-luminous

--- a/qa/suites/rados/thrash/z-require-luminous/at-end.yaml
+++ b/qa/suites/rados/thrash/z-require-luminous/at-end.yaml
@@ -1,0 +1,12 @@
+# do not require luminous osds at mkfs time; only set flag at
+# the end of the test run, then do a final scrub (to convert any
+# legacy snapsets), and verify we are healthy.
+tasks:
+- exec_on_cleanup:
+    mon.a:
+      - ceph osd set require_luminous_osds
+overrides:
+  ceph:
+    conf:
+      global:
+        mon debug no require luminous: true

--- a/qa/suites/rados/thrash/z-require-luminous/at-end.yaml
+++ b/qa/suites/rados/thrash/z-require-luminous/at-end.yaml
@@ -10,3 +10,5 @@ overrides:
     conf:
       global:
         mon debug no require luminous: true
+  thrashosds:
+    chance_thrash_cluster_full: 0

--- a/qa/suites/rados/verify/z-require-luminous
+++ b/qa/suites/rados/verify/z-require-luminous
@@ -1,0 +1,1 @@
+../thrash/z-require-luminous

--- a/qa/tasks/exec_on_cleanup.py
+++ b/qa/tasks/exec_on_cleanup.py
@@ -1,0 +1,62 @@
+"""
+Exececute custom commands during unwind/cleanup
+"""
+import logging
+import contextlib
+
+from teuthology import misc as teuthology
+from teuthology import contextutil
+
+log = logging.getLogger(__name__)
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    Execute commands on a given role
+
+        tasks:
+        - ceph:
+        - kclient: [client.a]
+        - exec:
+            client.a:
+              - "echo 'module libceph +p' > /sys/kernel/debug/dynamic_debug/control"
+              - "echo 'module ceph +p' > /sys/kernel/debug/dynamic_debug/control"
+        - interactive:
+
+    It stops and fails with the first command that does not return on success. It means
+    that if the first command fails, the second won't run at all.
+
+    To avoid confusion it is recommended to explicitly enclose the commands in 
+    double quotes. For instance if the command is false (without double quotes) it will
+    be interpreted as a boolean by the YAML parser.
+
+    :param ctx: Context
+    :param config: Configuration
+    """
+    try:
+        yield
+    finally:
+        log.info('Executing custom commands...')
+        assert isinstance(config, dict), "task exec got invalid config"
+
+        testdir = teuthology.get_testdir(ctx)
+
+        if 'all' in config and len(config) == 1:
+            a = config['all']
+            roles = teuthology.all_roles(ctx.cluster)
+            config = dict((id_, a) for id_ in roles)
+
+            for role, ls in config.iteritems():
+                (remote,) = ctx.cluster.only(role).remotes.iterkeys()
+                log.info('Running commands on role %s host %s', role, remote.name)
+                for c in ls:
+                    c.replace('$TESTDIR', testdir)
+                    remote.run(
+                        args=[
+                            'sudo',
+                            'TESTDIR={tdir}'.format(tdir=testdir),
+                            'bash',
+                            '-c',
+                            c],
+                    )
+

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -370,6 +370,7 @@ OPTION(mon_debug_deprecated_as_obsolete, OPT_BOOL, false) // consider deprecated
 OPTION(mon_debug_dump_transactions, OPT_BOOL, false)
 OPTION(mon_debug_dump_json, OPT_BOOL, false)
 OPTION(mon_debug_dump_location, OPT_STR, "/var/log/ceph/$cluster-$name.tdump")
+OPTION(mon_debug_no_require_luminous, OPT_BOOL, false)
 OPTION(mon_inject_transaction_delay_max, OPT_DOUBLE, 10.0)      // seconds
 OPTION(mon_inject_transaction_delay_probability, OPT_DOUBLE, 0) // range [0, 1]
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -248,7 +248,9 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
     auto p = bl.begin();
     std::lock_guard<std::mutex> l(creating_pgs_lock);
     creating_pgs.decode(p);
-    dout(7) << __func__ << " loading creating_pgs e" << creating_pgs.last_scan_epoch << dendl;
+    dout(7) << __func__ << " loading creating_pgs last_scan_epoch "
+	    << creating_pgs.last_scan_epoch
+	    << " with " << creating_pgs.pgs.size() << " pgs" << dendl;
   }
 
   // walk through incrementals

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3676,7 +3676,9 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
     }
 
     // warn about upgrade flags that can be set but are not.
-    if (HAVE_FEATURE(osdmap.get_up_osd_features(), SERVER_LUMINOUS) &&
+    if (g_conf->mon_debug_no_require_luminous) {
+      // ignore these checks
+    } else if (HAVE_FEATURE(osdmap.get_up_osd_features(), SERVER_LUMINOUS) &&
 	!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
       string msg = "all OSDs are running luminous or later but the"
 	" 'require_luminous_osds' osdmap flag is not set";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -159,7 +159,8 @@ void OSDMonitor::create_initial()
   // new cluster should require latest by default
   newmap.set_flag(CEPH_OSDMAP_REQUIRE_JEWEL);
   newmap.set_flag(CEPH_OSDMAP_REQUIRE_KRAKEN);
-  newmap.set_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS);
+  if (!g_conf->mon_debug_no_require_luminous)
+    newmap.set_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS);
 
   newmap.full_ratio = g_conf->mon_osd_full_ratio;
   newmap.nearfull_ratio = g_conf->mon_osd_nearfull_ratio;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7429,6 +7429,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -EPERM;
       goto reply;
     }
+    if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
+      ss << "you must set the require_luminous_osds flag to use this feature";
+      err = -EPERM;
+      goto reply;
+    }
     err = check_cluster_features(CEPH_FEATUREMASK_OSDMAP_REMAP, ss);
     if (err == -EAGAIN)
       goto wait;
@@ -7484,6 +7489,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -EPERM;
       goto reply;
     }
+    if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
+      ss << "you must set the require_luminous_osds flag to use this feature";
+      err = -EPERM;
+      goto reply;
+    }
     err = check_cluster_features(CEPH_FEATUREMASK_OSDMAP_REMAP, ss);
     if (err == -EAGAIN)
       goto wait;
@@ -7520,6 +7530,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   } else if (prefix == "osd pg-remap-items") {
     if (!g_conf->mon_osd_allow_pg_remap) {
       ss << "you must enable 'mon osd allow pg remap = true' on the mons before you can adjust pg_remap.  note that pre-luminous clients will no longer be able to communicate with the cluster.";
+      err = -EPERM;
+      goto reply;
+    }
+    if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
+      ss << "you must set the require_luminous_osds flag to use this feature";
       err = -EPERM;
       goto reply;
     }
@@ -7587,6 +7602,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
   } else if (prefix == "osd rm-pg-remap-items") {
     if (!g_conf->mon_osd_allow_pg_remap) {
       ss << "you must enable 'mon osd allow pg remap = true' on the mons before you can adjust pg_remap.  note that pre-luminous clients will no longer be able to communicate with the cluster.";
+      err = -EPERM;
+      goto reply;
+    }
+    if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
+      ss << "you must set the require_luminous_osds flag to use this feature";
       err = -EPERM;
       goto reply;
     }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -159,11 +159,11 @@ void OSDMonitor::create_initial()
   // new cluster should require latest by default
   newmap.set_flag(CEPH_OSDMAP_REQUIRE_JEWEL);
   newmap.set_flag(CEPH_OSDMAP_REQUIRE_KRAKEN);
-  if (!g_conf->mon_debug_no_require_luminous)
+  if (!g_conf->mon_debug_no_require_luminous) {
     newmap.set_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS);
-
-  newmap.full_ratio = g_conf->mon_osd_full_ratio;
-  newmap.nearfull_ratio = g_conf->mon_osd_nearfull_ratio;
+    newmap.full_ratio = g_conf->mon_osd_full_ratio;
+    newmap.nearfull_ratio = g_conf->mon_osd_nearfull_ratio;
+  }
 
   // encode into pending incremental
   newmap.encode(pending_inc.fullmap,


### PR DESCRIPTION
This allows us to create new clusters without the luminous osdmap flag,
improving test coverage of the cluster when operating in the not-quite-
yet-upgraded state in compatibility mode (albeit without any actual kraken
or jewel osds in the mix).