### PR TITLE
[DNM] crypto: add AES-256 CBC and EBC modes for rgw encryption

### DIFF
--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -35,6 +35,8 @@
 #include "common/debug.h"
 #include <errno.h>
 
+namespace ceph {
+
 int get_random_bytes(char *buf, int len)
 {
   int fd = TEMP_FAILURE_RETRY(::open("/dev/urandom", O_RDONLY));
@@ -61,6 +63,7 @@ uint64_t get_random(uint64_t min_val, uint64_t max_val)
   return r;
 }
 
+}
 
 // ---------------------------------------------------
 namespace ceph {
@@ -69,6 +72,8 @@ const bufferptr AES_IV =
 const bufferptr EMPTY_IV =
     buffer::create_static(0, nullptr);
 }
+
+namespace ceph {
 
 class CryptoNoneKeyHandler : public CryptoKeyHandler {
 public:
@@ -555,7 +560,7 @@ bool CryptoAES_256_CBCKeyHandler::cbc_transform(
   PK11SlotInfo *slot;
   SECItem keyItem;
   PK11SymKey *symkey;
-  CK_AES_CBC_ENCRYPT_DATA_PARAMS ctr_params = {0};
+  CK_AES_CBC_ENCRYPT_DATA_PARAMS cbc_params = {0};
   SECItem ivItem;
   SECItem *param;
   SECStatus ret;
@@ -569,10 +574,10 @@ bool CryptoAES_256_CBCKeyHandler::cbc_transform(
     keyItem.len = CryptoAES_256_CBC::KEY_SIZE;
     symkey = PK11_ImportSymKey(slot, CKM_AES_CBC, PK11_OriginUnwrap, CKA_UNWRAP, &keyItem, NULL);
     if (symkey) {
-      memcpy(ctr_params.iv, iv.c_str(), CryptoAES_256_CBC::IV_SIZE);
+      memcpy(cbc_params.iv, iv.c_str(), CryptoAES_256_CBC::IV_SIZE);
       ivItem.type = siBuffer;
-      ivItem.data = (unsigned char*)&ctr_params;
-      ivItem.len = sizeof(ctr_params);
+      ivItem.data = (unsigned char*)&cbc_params;
+      ivItem.len = sizeof(cbc_params);
 
       param = PK11_ParamFromIV(CKM_AES_CBC, &ivItem);
       if (param) {
@@ -1102,4 +1107,6 @@ CryptoHandler *CryptoHandler::create(int type)
   default:
     return nullptr;
   }
+}
+
 }

--- a/src/auth/Crypto.cc
+++ b/src/auth/Crypto.cc
@@ -1086,7 +1086,9 @@ private:
     }
     if (result == false) {
       if (error) {
-        *error = "Failed to perform AES-CTR encryption: " + PR_GetError();
+        std::ostringstream ss;
+        ss << "Failed to perform AES-CTR encryption: " << PR_GetError();
+        *error = ss.str();
       }
     }
     return result;

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -31,6 +31,7 @@ extern const bufferptr AES_IV;
 extern const bufferptr EMPTY_IV;
 }
 
+namespace ceph {
 /*
  * some per-key context that is specific to a particular crypto backend
  */
@@ -120,15 +121,16 @@ public:
 
   void to_str(std::string& s) const;
 };
-WRITE_CLASS_ENCODER(CryptoKey)
+}
+WRITE_CLASS_ENCODER(ceph::CryptoKey)
 
-static inline ostream& operator<<(ostream& out, const CryptoKey& k)
+static inline ostream& operator<<(ostream& out, const ceph::CryptoKey& k)
 {
   k.print(out);
   return out;
 }
 
-
+namespace ceph {
 /*
  * Driver for a particular algorithm
  *
@@ -150,4 +152,5 @@ public:
 extern int get_random_bytes(char *buf, int len);
 extern uint64_t get_random(uint64_t min_val, uint64_t max_val);
 
+}
 #endif

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -38,8 +38,7 @@ public:
 		       bufferlist& out, std::string *error) const = 0;
   virtual int decrypt(const bufferlist& in,
 		       bufferlist& out, std::string *error) const = 0;
-protected:
-  bufferptr secret;
+
 };
 
 /*
@@ -139,7 +138,7 @@ public:
   virtual int create(bufferptr& secret) = 0;
   virtual int validate_secret(const bufferptr& secret) = 0;
   virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret,
-					    string& error) = 0;
+                                           string& error) = 0;
   virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret, const bufferptr& iv,
               string& error) = 0;
 

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -32,14 +32,14 @@ namespace ceph { class Formatter; }
  */
 class CryptoKeyHandler {
 public:
-  bufferptr secret;
-
   virtual ~CryptoKeyHandler() {}
 
   virtual int encrypt(const bufferlist& in,
 		       bufferlist& out, std::string *error) const = 0;
   virtual int decrypt(const bufferlist& in,
 		       bufferlist& out, std::string *error) const = 0;
+protected:
+  bufferptr secret;
 };
 
 /*
@@ -140,6 +140,8 @@ public:
   virtual int validate_secret(const bufferptr& secret) = 0;
   virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret,
 					    string& error) = 0;
+  virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret, const bufferptr& iv,
+              string& error) = 0;
 
   static CryptoHandler *create(int type);
 };

--- a/src/auth/Crypto.h
+++ b/src/auth/Crypto.h
@@ -26,6 +26,10 @@ class CephContext;
 class CryptoKeyContext;
 namespace ceph { class Formatter; }
 
+namespace ceph {
+extern const bufferptr AES_IV;
+extern const bufferptr EMPTY_IV;
+}
 
 /*
  * some per-key context that is specific to a particular crypto backend
@@ -137,8 +141,6 @@ public:
   virtual int get_type() const = 0;
   virtual int create(bufferptr& secret) = 0;
   virtual int validate_secret(const bufferptr& secret) = 0;
-  virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret,
-                                           string& error) = 0;
   virtual CryptoKeyHandler *get_key_handler(const bufferptr& secret, const bufferptr& iv,
               string& error) = 0;
 

--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1488,7 +1488,6 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
     append_buffer.swap(other.append_buffer);
     other.clear();
   }
-
   void buffer::list::swap(list& other)
   {
     std::swap(_len, other._len);

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -32,7 +32,9 @@ class md_config_obs_t;
 struct md_config_t;
 class CephContextHook;
 class CephContextObs;
+namespace ceph {
 class CryptoHandler;
+}
 
 namespace ceph {
   class PluginRegistry;

--- a/src/crypto/isa-l/isal_crypto_plugin.h
+++ b/src/crypto/isa-l/isal_crypto_plugin.h
@@ -26,11 +26,13 @@ class ISALCryptoPlugin : public CryptoPlugin {
 
   CryptoAccelRef cryptoaccel;
 public:
+  explicit ISALCryptoPlugin(CephContext* cct)
+  : CryptoPlugin(cct) {}
+  ~ISALCryptoPlugin() {
+    assert(cryptoaccel.use_count() <= 1);
+    cryptoaccel = nullptr;
+  }
 
-  explicit ISALCryptoPlugin(CephContext* cct) : CryptoPlugin(cct)
-  {}
-  ~ISALCryptoPlugin()
-  {}
   virtual int factory(CryptoAccelRef *cs,
                       ostream *ss)
   {

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -67,6 +67,7 @@ struct ceph_dir_layout {
 #define CEPH_CRYPTO_AES  0x1
 #define CEPH_CRYPTO_AES_256_CBC 0x2
 #define CEPH_CRYPTO_AES_256_ECB 0x3
+#define CEPH_CRYPTO_AES_256_CTR 0x4
 
 #define CEPH_AES_IV "cephsageyudagreg"
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -65,9 +65,9 @@ struct ceph_dir_layout {
 /* crypto algorithms */
 #define CEPH_CRYPTO_NONE 0x0
 #define CEPH_CRYPTO_AES  0x1
-#define CEPH_CRYPTO_AES_256_CBC 0x2
-#define CEPH_CRYPTO_AES_256_ECB 0x3
-#define CEPH_CRYPTO_AES_256_CTR 0x4
+#define CEPH_CRYPTO_AES_256_CBC 0x2 /* requires data in 16 byte alignment */
+#define CEPH_CRYPTO_AES_256_ECB 0x3 /* requires data in 16 byte alignment */
+#define CEPH_CRYPTO_AES_256_CTR 0x4 /* requires data in 16 byte alignment */
 
 #define CEPH_AES_IV "cephsageyudagreg"
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -65,6 +65,8 @@ struct ceph_dir_layout {
 /* crypto algorithms */
 #define CEPH_CRYPTO_NONE 0x0
 #define CEPH_CRYPTO_AES  0x1
+#define CEPH_CRYPTO_AES_256_CBC 0x2
+#define CEPH_CRYPTO_AES_256_ECB 0x3
 
 #define CEPH_AES_IV "cephsageyudagreg"
 

--- a/src/msg/Dispatcher.h
+++ b/src/msg/Dispatcher.h
@@ -24,7 +24,9 @@ class Messenger;
 class Message;
 class Connection;
 class AuthAuthorizer;
+namespace ceph {
 class CryptoKey;
+}
 class CephContext;
 
 class Dispatcher {

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -125,18 +125,18 @@ public:
   {
     CryptoHandler* ch = CryptoHandler::create(CEPH_CRYPTO_AES_256_CBC);
     string error;
-
+    bool result;
     size_t out_len = out.length();
     CryptoKeyHandler* ckh = ch->get_key_handler(key, iv, error);
     if (encrypt) {
-      ckh->encrypt(in, out, &error);
+      result = ckh->encrypt(in, out, &error);
     } else {
-      ckh->decrypt(in, out, &error);
+      result = ckh->decrypt(in, out, &error);
     }
     assert(out.length() == out_len+in.length());
     delete ckh;
     delete ch;
-    return true;
+    return result;
   }
 
   bool cbc_transform(bufferlist& output,
@@ -360,7 +360,7 @@ bool AES_256_ECB_encrypt(CephContext* cct,
   string error;
   int result;
   size_t out_len = out.length();
-  CryptoKeyHandler* ckh = ch->get_key_handler(key, error);
+  CryptoKeyHandler* ckh = ch->get_key_handler(key, AES_IV, error);
   result = ckh->encrypt(in, out, &error);
 
   if (result != 0) {

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -24,6 +24,19 @@
 #include <cryptopp/cryptlib.h>
 #include <cryptopp/modes.h>
 #include <cryptopp/aes.h>
+
+/*
+ * patching for https://github.com/openssl/openssl/issues/1437
+ * newer versions of civetweb do not experience problems
+ */
+extern "C"
+{
+bool SSL_CTX_set_ecdh_auto(void* dummy, int onoff)
+{
+  return onoff!=0;
+}
+}
+
 using namespace CryptoPP;
 #endif
 

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -125,7 +125,7 @@ public:
   {
     CryptoHandler* ch = CryptoHandler::create(CEPH_CRYPTO_AES_256_CBC);
     string error;
-    bool result;
+    int result;
     size_t out_len = out.length();
     CryptoKeyHandler* ckh = ch->get_key_handler(key, iv, error);
     if (encrypt) {
@@ -136,7 +136,7 @@ public:
     assert(out.length() == out_len+in.length());
     delete ckh;
     delete ch;
-    return result;
+    return result == 0;
   }
 
   bool cbc_transform(bufferlist& output,
@@ -360,7 +360,7 @@ bool AES_256_ECB_encrypt(CephContext* cct,
   string error;
   int result;
   size_t out_len = out.length();
-  CryptoKeyHandler* ckh = ch->get_key_handler(key, AES_IV, error);
+  CryptoKeyHandler* ckh = ch->get_key_handler(key, EMPTY_IV, error);
   result = ckh->encrypt(in, out, &error);
 
   if (result != 0) {

--- a/src/rgw/rgw_crypt.h
+++ b/src/rgw/rgw_crypt.h
@@ -76,12 +76,11 @@ public:
 };
 
 static const size_t AES_256_KEYSIZE = 256 / 8;
+
 bool AES_256_ECB_encrypt(CephContext* cct,
-                         const uint8_t* key,
-                         size_t key_size,
-                         const uint8_t* data_in,
-                         uint8_t* data_out,
-                         size_t data_size);
+                         const bufferptr& key,
+                         const bufferlist& in,
+                         bufferlist& out);
 
 class RGWGetObj_BlockDecrypt : public RGWGetObj_Filter {
   CephContext* cct;

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -52,7 +52,7 @@ TEST(AES, Encrypt) {
 
   bufferlist cipher;
   std::string error;
-  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  CryptoKeyHandler *kh = h->get_key_handler(secret, AES_IV, error);
   int r = kh->encrypt(plaintext, cipher, &error);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(error, "");
@@ -100,7 +100,7 @@ TEST(AES, Decrypt) {
 
   std::string error;
   bufferlist plaintext;
-  CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+  CryptoKeyHandler *kh = h->get_key_handler(secret, AES_IV, error);
   int r = kh->decrypt(cipher, plaintext, &error);
   ASSERT_EQ(r, 0);
   ASSERT_EQ(error, "");
@@ -136,7 +136,7 @@ TEST(AES, Loop) {
       CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
 
       std::string error;
-      CryptoKeyHandler *kh = h->get_key_handler(secret, error);
+      CryptoKeyHandler *kh = h->get_key_handler(secret, AES_IV, error);
       int r = kh->encrypt(plaintext, cipher, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");
@@ -148,7 +148,7 @@ TEST(AES, Loop) {
     {
       CryptoHandler *h = g_ceph_context->get_crypto_handler(CEPH_CRYPTO_AES);
       std::string error;
-      CryptoKeyHandler *ckh = h->get_key_handler(secret, error);
+      CryptoKeyHandler *ckh = h->get_key_handler(secret, AES_IV, error);
       int r = ckh->decrypt(cipher, plaintext, &error);
       ASSERT_EQ(r, 0);
       ASSERT_EQ(error, "");

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -207,7 +207,11 @@ void check_encryption(int mode, const bufferlist& expected)
   in.append(data_in, sizeof(data_in));
   bufferlist out;
   bufferlist out_decrypt;
-  CryptoKeyHandler* ckh = ch->get_key_handler(key, iv, error);
+  CryptoKeyHandler* ckh;
+  if (mode == CEPH_CRYPTO_AES_256_ECB)
+    ckh = ch->get_key_handler(key, EMPTY_IV, error);
+  else
+    ckh = ch->get_key_handler(key, iv, error);
   ASSERT_NE(ckh, nullptr);
   ASSERT_EQ(ckh->encrypt(in, out, &error), 0);
   ASSERT_EQ(ckh->decrypt(out, out_decrypt, &error), 0);
@@ -264,8 +268,14 @@ void check_encryption_errors(int mode, bool check_iv)
     ASSERT_EQ(ckh, nullptr);
     cout << "IV too short: error = " << error << endl;
   }
-  ckh = ch->get_key_handler(key, iv, error);
+  if (mode != CEPH_CRYPTO_AES_256_ECB) {
+    ckh = ch->get_key_handler(key, iv, error);
+  }
+  else {
+    ckh = ch->get_key_handler(key, EMPTY_IV, error);
+  }
   ASSERT_NE(ckh, nullptr);
+
 
   static char data_in[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
   static char data_in_uneven[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};

--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -202,9 +202,19 @@ void check_encryption(int mode, const bufferlist& expected)
   bufferptr key(buffer::create_static(sizeof(key_s), key_s));
   bufferptr iv(buffer::create_static(sizeof(iv_s), iv_s));
 
-  static char data_in[] = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+  char data_in[4096];
+  memset(data_in, 111, sizeof(data_in));
   bufferlist in;
-  in.append(data_in, sizeof(data_in));
+
+  size_t pos = 0;
+  for (int i = 9; i >= 0 ; i--) {
+	  size_t len = rand() % (sizeof(data_in) / 10);
+	  if (i==0)
+		  len = sizeof(data_in) - pos;
+	  in.append(bufferptr(buffer::copy(data_in + pos, len)));
+	  pos += len;
+  }
+
   bufferlist out;
   bufferlist out_decrypt;
   CryptoKeyHandler* ckh;


### PR DESCRIPTION
This is to make elements used in radosgw encryption available for other ceph modules.