### PR TITLE
rgw: fix the bug that part's index can't be removed after completing multipart upload

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2669,6 +2669,7 @@ int RGWPutObjProcessor_Multipart::do_complete(size_t accounted_size,
   complete_writing_data();
 
   RGWRados::Object op_target(store, s->bucket_info, obj_ctx, head_obj);
+  op_target.set_versioning_disabled(true);
   RGWRados::Object::Write head_obj_op(&op_target);
 
   head_obj_op.meta.set_mtime = set_mtime;


### PR DESCRIPTION
If bucket versioning is enabled, complete multipart upload can't remove the part index.

Fixes: http://tracker.ceph.com/issues/19604

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>