### PR TITLE
rgw: swift: disable revocation thread if sleep == 0

### DIFF
--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -255,8 +255,16 @@ class TokenCache {
       cct(g_ceph_context),
       lock("rgw::keystone::TokenCache"),
       max(cct->_conf->rgw_keystone_token_cache_size) {
-    /* The thread name has been kept for backward compliance. */
-    revocator.create("rgw_swift_k_rev");
+    /* revocation logic needs to be smarter, but meanwhile,
+     *  make it optional.
+     * see http://tracker.ceph.com/issues/9493
+     *     http://tracker.ceph.com/issues/19499
+     */
+    if (cct->_conf->rgw_keystone_revocation_interval > 0
+        && cct->_conf->rgw_keystone_token_cache_size ) {
+      /* The thread name has been kept for backward compliance. */
+      revocator.create("rgw_swift_k_rev");
+    }
   }
 
   ~TokenCache() {


### PR DESCRIPTION
Keystone tokens can be revoked.  This causes them to fail
validation.  However, in ceph, we cache them.  As long as
they're in the cache we trust them.  To find revoked tokens
there's a call OSI-PKI/revoked but that's only useful for
pki tokens.  Installations using fernet/uuid may not even
have the proper credentials to support the call, in which
case the call blows up in various ways filling up logs
with complaints.

This code makes the revocation thread optional; by disabling it,
the complaints go away.  A further fix is in the works
to use other more modern calls available in modern keystone
installations to properly deal with non-PKI/PKIZ tokens.

To disable the revocation thread, set
        rgw_keystone_revocation_interval = 0
You may also want to set
        rgw_keystone_token_cache_size = 0
to cause tokens to be validate on every call.

Fixes: http://tracker.ceph.com/issues/9493
Fixes: http://tracker.ceph.com/issues/19499

Signed-off-by: Marcus Watts <mwatts@redhat.com>