### PR TITLE
kraken: doc: PendingReleaseNotes: warning about 'osd rm ...' and #19119

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,12 +1,5 @@
-11.1.1
+11.2.1
 ------
-
- * Calculation of recovery priorities has been updated.
-   This could lead to unintuitive recovery prioritization
-   during cluster upgrade. In case of such recovery, OSDs
-   in old version would operate on different priority ranges
-   than new ones. Once upgraded, cluster will operate on
-   consistent values.
 
 * In previous versions, if a client sent an op to the wrong OSD, the OSD
   would reply with ENXIO.  The rationale here is that the client or OSD is
@@ -15,3 +8,16 @@
   is enabled (it's off by default).  This means that a VM using librbd that
   previously would have gotten an EIO and gone read-only will now see a
   blocked/hung IO instead.
+
+* There was a bug introduced in Jewel (#19119) that broke the mapping behavior
+  when an "out" OSD that still existed in the CRUSH map was removed with 'osd rm'.
+  This could result in 'misdirected op' and other errors.  The bug is now fixed,
+  but the fix itself introduces the same risk because the behavior may vary between
+  clients and OSDs.  To avoid problems, please ensure that all OSDs are removed
+  from the CRUSH map before deleting them.  That is, be sure to do::
+
+     ceph osd crush rm osd.123
+
+  before::
+
+     ceph osd rm osd.123


### PR DESCRIPTION
See http://tracker.ceph.com/issues/19119

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit be96003c464481d8e84825178d600234a0d64d22)

Conflicts:
        PendingReleaseNotes
        - drop "Calculation of recovery priorities has been updated" because
          that was included in 11.2.0 release notes
        - do not backport >=12.0.0 release notes
        - change heading to 11.2.1