### PR TITLE
kraken: librgw: RGWLibFS::setattr fails on directories

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -602,6 +602,10 @@ namespace rgw {
 
     string obj_name{rgw_fh->relative_object_name()};
 
+    if (rgw_fh->is_dir()) {
+      obj_name += "/";
+    }
+
     RGWSetAttrsRequest req(cct, get_user(), rgw_fh->bucket_name(), obj_name);
 
     rgw_fh->create_stat(st, mask);


### PR DESCRIPTION
http://tracker.ceph.com/issues/18810