### PR TITLE
kraken: rgw: Response header of swift API returned by radosgw does not contain x-openstack-request-id. But Swift returns it.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -644,6 +644,7 @@ void dump_trans_id(req_state *s)
 {
   if (s->prot_flags & RGW_REST_SWIFT) {
     dump_header(s, "X-Trans-Id", s->trans_id);
+    dump_header(s, "X-Openstack-Request-Id", s->trans_id);
   } else if (s->trans_id.length()) {
     dump_header(s, "x-amz-request-id", s->trans_id);
   }


### PR DESCRIPTION
http://tracker.ceph.com/issues/19573