### PR TITLE
kraken: rbd: 'metadata_set' API operation should not change global config setting

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -1342,8 +1342,9 @@ int Operations<I>::metadata_set(const std::string &key,
   size_t conf_prefix_len = start.size();
 
   if (key.size() > conf_prefix_len && !key.compare(0, conf_prefix_len, start)) {
+    // validate config setting
     string subkey = key.substr(conf_prefix_len, key.size() - conf_prefix_len);
-    int r = cct->_conf->set_val(subkey.c_str(), value);
+    int r = md_config_t().set_val(subkey.c_str(), value);
     if (r < 0) {
       return r;
     }

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -3943,6 +3943,11 @@ TEST_F(TestLibRBD, Metadata)
   ASSERT_EQ(1U, pairs.size());
   ASSERT_EQ(0, strncmp("value2", pairs["key2"].c_str(), 6));
 
+  // test config setting
+  ASSERT_EQ(0, image1.metadata_set("conf_rbd_cache", "false"));
+  ASSERT_EQ(-EINVAL, image1.metadata_set("conf_rbd_cache", "INVALID_VALUE"));
+  ASSERT_EQ(0, image1.metadata_remove("conf_rbd_cache"));
+
   // test metadata with snapshot adding
   ASSERT_EQ(0, image1.snap_create("snap1"));
   ASSERT_EQ(0, image1.snap_protect("snap1"));


### PR DESCRIPTION
http://tracker.ceph.com/issues/18549