### PR TITLE
kraken: rbd: Add missing parameter feedback to 'rbd snap limit'

### DIFF
--- a/src/tools/rbd/action/Snap.cc
+++ b/src/tools/rbd/action/Snap.cc
@@ -474,6 +474,7 @@ int execute_set_limit(const po::variables_map &vm) {
   if (vm.count(at::LIMIT)) {
     limit = vm[at::LIMIT].as<uint64_t>();
   } else {
+    std::cerr << "rbd: must specify --limit <num>" << std::endl;
     return -ERANGE;
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/18601