### PR TITLE
rgw: cleanup: fix variable name in RGWRados::create_pool() declaration

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2513,7 +2513,7 @@ public:
                  bool *is_truncated, RGWUsageIter& read_iter, map<rgw_user_bucket, rgw_usage_log_entry>& usage);
   int trim_usage(rgw_user& user, uint64_t start_epoch, uint64_t end_epoch);
 
-  int create_pool(const rgw_pool& bucket);
+  int create_pool(const rgw_pool& pool);
 
   /**
    * create a bucket with name bucket and the given list of attrs


### PR DESCRIPTION
The function definition was changed to

    RGWRados::create_pool(const rgw_pool& pool)

by 66c2b0c0d66c6019e3f63148eede7802e89d3c51
but the declaration still said "bucket" instead of "pool".

Signed-off-by: Nathan Cutler <ncutler@suse.com>