### PR TITLE
rgw: add 'state==SyncState::IncrementalSync' condition when add item …

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1897,7 +1897,8 @@ static void get_md_sync_status(list<string>& status)
         continue;
       }
       auto master_marker = iter->second.marker;
-      if (master_marker > local_iter.second.marker) {
+      if (local_iter.second.state == rgw_meta_sync_marker::SyncState::IncrementalSync &&
+          master_marker > local_iter.second.marker) {
         shards_behind[shard_id] = local_iter.second.marker;
       }
     }
@@ -2044,7 +2045,8 @@ static void get_data_sync_status(const string& source_zone, list<string>& status
       continue;
     }
     auto master_marker = iter->second.marker;
-    if (master_marker > local_iter.second.marker) {
+    if (local_iter.second.state == rgw_data_sync_marker::SyncState::IncrementalSync &&
+        master_marker > local_iter.second.marker) {
       shards_behind[shard_id] = local_iter.second.marker;
     }
   }


### PR DESCRIPTION
…to shards_behind.

after running 'radosgw-admin data sync init', the sync_marker's state will change to FullSync, but the marker didn't clean. So 'sync status' command will wrongly inset shards_behind.

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>