### PR TITLE
mds: fix stray creation/removal notification

### DIFF
--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -249,6 +249,18 @@ void CDentry::unlink_remote(CDentry::linkage_t *dnl)
   dnl->inode = 0;
 }
 
+void CDentry::push_projected_linkage()
+{
+  _project_linkage();
+
+  if (is_auth()) {
+    CInode *diri = dir->inode;
+    if (diri->is_stray())
+      diri->mdcache->notify_stray_removed();
+  }
+}
+
+
 void CDentry::push_projected_linkage(CInode *inode)
 {
   // dirty rstat tracking is in the projected plane
@@ -261,6 +273,12 @@ void CDentry::push_projected_linkage(CInode *inode)
 
   if (dirty_rstat)
     inode->mark_dirty_rstat();
+
+  if (is_auth()) {
+    CInode *diri = dir->inode;
+    if (diri->is_stray())
+      diri->mdcache->notify_stray_created();
+  }
 }
 
 CDentry::linkage_t *CDentry::pop_projected_linkage()

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -168,9 +168,7 @@ public:
     projected.push_back(linkage_t());
     return &projected.back();
   }
-  void push_projected_linkage() {
-    _project_linkage();
-  }
+  void push_projected_linkage();
   void push_projected_linkage(inodeno_t ino, char d_type) {
     linkage_t *p = _project_linkage();
     p->remote_ino = ino;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -142,9 +142,7 @@ public:
     stray_index = (stray_index+1)%NUM_STRAY;
   }
 
-  void activate_stray_manager() {
-    stray_manager.activate();
-  }
+  void activate_stray_manager();
 
   /**
    * Call this when you know that a CDentry is ready to be passed

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7116,20 +7116,6 @@ void Server::_rename_apply(MDRequestRef& mdr, CDentry *srcdn, CDentry *destdn, C
     }
   }
 
-  if (srcdn->get_dir()->inode->is_stray() &&
-      srcdn->get_dir()->inode->get_stray_owner() == mds->get_nodeid()) {
-    // A reintegration event or a migration away from me
-    dout(20) << __func__ << ": src dentry was a stray, updating stats" << dendl;
-    mdcache->notify_stray_removed();
-  }
-
-  if (destdn->get_dir()->inode->is_stray() &&
-      destdn->get_dir()->inode->get_stray_owner() == mds->get_nodeid()) {
-    // A stray migration (to me)
-    dout(20) << __func__ << ": dst dentry was a stray, updating stats" << dendl;
-    mdcache->notify_stray_created();
-  }
-
   // src
   if (srcdn->is_auth())
     srcdn->mark_dirty(mdr->more()->pvmap[srcdn], mdr->ls);

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -226,7 +226,6 @@ void StrayManager::_purge_stray_purged(
     mds->mdlog->submit_entry(le, new C_PurgeStrayLogged(this, dn, pdv,
           mds->mdlog->get_current_segment()));
 
-    num_strays--;
     logger->set(l_mdc_num_strays, num_strays);
   }
 }
@@ -375,6 +374,13 @@ void StrayManager::advance_delayed()
     }
   }
   logger->set(l_mdc_num_strays_delayed, num_strays_delayed);
+}
+
+void StrayManager::set_num_strays(uint64_t num)
+{
+  assert(!started);
+  num_strays = num;
+  logger->set(l_mdc_num_strays, num_strays);
 }
 
 void StrayManager::notify_stray_created()

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -127,6 +127,7 @@ class StrayManager
 
   bool eval_stray(CDentry *dn, bool delay=false);
 
+  void set_num_strays(uint64_t num);
   uint64_t get_num_strays() const { return num_strays; }
 
   /**


### PR DESCRIPTION
In MDCache::scan_stray_dir(), notify_stray_created() is called for
both null and non-null dentries. This is wrong, it should be called
only for non-null dentries.

Calling notify_stray_created() in MDCache::get_or_create_stray_dentry()
is racy too. MDS can create wrong stray dentry because the linkage of
target dentry can change before rename/rmdir has acquired the dentry lock.

Fixes: http://tracker.ceph.com/issues/19630
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>