### PR TITLE
osd: fix occasional MOSDMap leak

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6772,6 +6772,7 @@ struct C_OnMapCommit : public Context {
     : osd(o), first(f), last(l), msg(m) {}
   void finish(int r) override {
     osd->_committed_osd_maps(first, last, msg);
+    msg->put();
   }
 };
 
@@ -7319,7 +7320,6 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
   else if (do_restart)
     start_boot();
 
-  m->put();
 }
 
 void OSD::check_osdmap_features(ObjectStore *fs)


### PR DESCRIPTION
_committed_osd_maps() may return early (without putting
the ref) on shutdown.

Fixes: http://tracker.ceph.com/issues/18293
Signed-off-by: Sage Weil <sage@redhat.com>