### PR TITLE
kraken: cephfs: buffer overflow in test LibCephFS.DirLs

### DIFF
--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -362,7 +362,7 @@ TEST(LibCephFS, DirLs) {
 
   // test getdents
   struct dirent *getdents_entries;
-  getdents_entries = (struct dirent *)malloc(r * sizeof(*getdents_entries));
+  getdents_entries = (struct dirent *)malloc((r + 2) * sizeof(*getdents_entries));
 
   int count = 0;
   std::vector<std::string> found;


### PR DESCRIPTION
http://tracker.ceph.com/issues/19045