### PR TITLE
kraken: cephfs: MDS heartbeat timeout during rejoin, when working with large amount of caps/inodes

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -5610,6 +5610,8 @@ void MDCache::export_remaining_imported_caps()
 	mds->send_message_client_counted(stale, q->first);
       }
     }
+
+    mds->heartbeat_reset();
   }
 
   for (map<inodeno_t, list<MDSInternalContextBase*> >::iterator p = cap_reconnect_waiters.begin();

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -438,6 +438,8 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
       dout(0) << "unrecognized message " << *m << dendl;
       return false;
     }
+
+    heartbeat_reset();
   }
 
   if (dispatch_depth > 1)

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -226,7 +226,6 @@ class MDSRank {
     bool _dispatch(Message *m, bool new_msg);
 
     ceph::heartbeat_handle_d *hb;  // Heartbeat for threads using mds_lock
-    void heartbeat_reset();
 
     bool is_stale_message(Message *m) const;
 
@@ -296,6 +295,12 @@ class MDSRank {
     void suicide();
     void respawn();
     // <<<
+
+    /**
+     * Call this periodically if inside a potentially long running piece
+     * of code while holding the mds_lock
+     */
+    void heartbeat_reset();
 
     /**
      * Report state DAMAGED to the mon, and then pass on to respawn().  Call


### PR DESCRIPTION
http://tracker.ceph.com/issues/19335