### PR TITLE
kraken: cephfs: MDS server crashes due to inconsistent metadata.

### DIFF
--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -354,6 +354,7 @@ int MetadataDriver::inject_unlinked_inode(
   // they don't have to mount the filesystem to correct it?
   inode.inode.layout = file_layout_t::get_default();
   inode.inode.layout.pool_id = data_pool_id;
+  inode.inode.dir_layout.dl_dir_hash = g_conf->mds_default_dir_hash;
 
   // Assume that we will get our stats wrong, and that we may
   // be ignoring dirfrags that exist
@@ -1626,6 +1627,8 @@ int MetadataDriver::inject_with_backtrace(
         // accurate, but it should avoid functional issues.
 
         ancestor_dentry.inode.dirstat.nfiles = 1;
+        ancestor_dentry.inode.dir_layout.dl_dir_hash =
+                                               g_conf->mds_default_dir_hash;
 
         ancestor_dentry.inode.nlink = 1;
         ancestor_dentry.inode.ino = ino;
@@ -1967,6 +1970,7 @@ void MetadataTool::build_dir_dentry(
   out->inode.ctime.tv.tv_sec = fragstat.mtime;
 
   out->inode.layout = layout;
+  out->inode.dir_layout.dl_dir_hash = g_conf->mds_default_dir_hash;
 
   out->inode.truncate_seq = 1;
   out->inode.truncate_size = -1ull;


### PR DESCRIPTION
http://tracker.ceph.com/issues/19620