### PR TITLE
kraken: rbd-mirror: check remote image mirroring state when bootstrapping

### DIFF
--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -99,6 +99,7 @@ public:
 
     EXPECT_EQ(0, m_remote_cluster.ioctx_create(m_remote_pool_name.c_str(),
 					       m_remote_ioctx));
+    EXPECT_EQ(0, librbd::mirror_mode_set(m_remote_ioctx, RBD_MIRROR_MODE_POOL));
 
     m_image_name = get_temp_image_name();
     uint64_t features = librbd::util::get_rbd_default_features(g_ceph_context);
@@ -392,7 +393,7 @@ TEST_F(TestImageReplayer, BootstrapErrorLocalImageExists)
 
 TEST_F(TestImageReplayer, BootstrapErrorNoJournal)
 {
-  // disable remote journal journaling
+  // disable remote image journaling
   librbd::ImageCtx *ictx;
   open_remote_image(&ictx);
   uint64_t features;
@@ -405,6 +406,58 @@ TEST_F(TestImageReplayer, BootstrapErrorNoJournal)
   C_SaferCond cond;
   m_replayer->start(&cond);
   ASSERT_EQ(-ENOENT, cond.wait());
+}
+
+TEST_F(TestImageReplayer, BootstrapErrorMirrorDisabled)
+{
+  // disable remote image mirroring
+  ASSERT_EQ(0, librbd::mirror_mode_set(m_remote_ioctx, RBD_MIRROR_MODE_IMAGE));
+  librbd::ImageCtx *ictx;
+  open_remote_image(&ictx);
+  ASSERT_EQ(0, librbd::mirror_image_disable(ictx, true));
+  close_image(ictx);
+
+  create_replayer<>();
+  C_SaferCond cond;
+  m_replayer->start(&cond);
+  ASSERT_EQ(-ENOENT, cond.wait());
+}
+
+TEST_F(TestImageReplayer, BootstrapMirrorDisabling)
+{
+  // set remote image mirroring state to DISABLING
+  ASSERT_EQ(0, librbd::mirror_mode_set(m_remote_ioctx, RBD_MIRROR_MODE_IMAGE));
+  librbd::ImageCtx *ictx;
+  open_remote_image(&ictx);
+  ASSERT_EQ(0, librbd::mirror_image_enable(ictx));
+  cls::rbd::MirrorImage mirror_image;
+  ASSERT_EQ(0, librbd::cls_client::mirror_image_get(&m_remote_ioctx, ictx->id,
+                                                    &mirror_image));
+  mirror_image.state = cls::rbd::MirrorImageState::MIRROR_IMAGE_STATE_DISABLING;
+  ASSERT_EQ(0, librbd::cls_client::mirror_image_set(&m_remote_ioctx, ictx->id,
+                                                    mirror_image));
+  close_image(ictx);
+
+  create_replayer<>();
+  C_SaferCond cond;
+  m_replayer->start(&cond);
+  ASSERT_EQ(0, cond.wait());
+  ASSERT_TRUE(m_replayer->is_stopped());
+}
+
+TEST_F(TestImageReplayer, BootstrapDemoted)
+{
+  // demote remote image
+  librbd::ImageCtx *ictx;
+  open_remote_image(&ictx);
+  ASSERT_EQ(0, librbd::mirror_image_demote(ictx));
+  close_image(ictx);
+
+  create_replayer<>();
+  C_SaferCond cond;
+  m_replayer->start(&cond);
+  ASSERT_EQ(0, cond.wait());
+  ASSERT_TRUE(m_replayer->is_stopped());
 }
 
 TEST_F(TestImageReplayer, StartInterrupted)

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -13,6 +13,7 @@ set(rbd_mirror_internal
   image_replayer/CloseImageRequest.cc
   image_replayer/CreateImageRequest.cc
   image_replayer/EventPreprocessor.cc
+  image_replayer/IsPrimaryRequest.cc
   image_replayer/OpenImageRequest.cc
   image_replayer/OpenLocalImageRequest.cc
   image_replayer/ReplayStatusFormatter.cc

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -101,6 +101,9 @@ private:
    *    v                                               *
    * OPEN_REMOTE_IMAGE  * * * * * * * * * * * * * * * * *
    *    |                                               *
+   *    v                                               *
+   * IS_PRIMARY * * * * * * * * * * * * * * * * * * * * *
+   *    |                                               *
    *    | (remote image primary)                        *
    *    \----> OPEN_LOCAL_IMAGE * * * * * * * * * * * * *
    *    |         |   .   ^                             *
@@ -167,6 +170,7 @@ private:
   cls::journal::Client m_client;
   uint64_t m_remote_tag_class = 0;
   ImageCtxT *m_remote_image_ctx = nullptr;
+  bool m_primary = false;
   bool m_created_local_image = false;
   int m_ret_val = 0;
 
@@ -186,6 +190,9 @@ private:
 
   void open_remote_image();
   void handle_open_remote_image(int r);
+
+  void is_primary();
+  void handle_is_primary(int r);
 
   void update_client_state();
   void handle_update_client_state(int r);

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
@@ -1,0 +1,74 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "IsPrimaryRequest.h"
+#include "common/errno.h"
+#include "common/WorkQueue.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Journal.h"
+#include "librbd/Utils.h"
+#include <type_traits>
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_replayer::IsPrimaryRequest: " \
+                           << this << " " << __func__ << " "
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+
+using librbd::util::create_context_callback;
+
+template <typename I>
+IsPrimaryRequest<I>::IsPrimaryRequest(I *image_ctx, bool *primary,
+                                      Context *on_finish)
+  : m_image_ctx(image_ctx), m_primary(primary), m_on_finish(on_finish) {
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::send() {
+  send_is_tag_owner();
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::send_is_tag_owner() {
+  // deduce the class type for the journal to support unit tests
+  using Journal = typename std::decay<
+    typename std::remove_pointer<decltype(std::declval<I>().journal)>
+    ::type>::type;
+
+  dout(20) << dendl;
+
+  Context *ctx = create_context_callback<
+    IsPrimaryRequest<I>, &IsPrimaryRequest<I>::handle_is_tag_owner>(this);
+
+  Journal::is_tag_owner(m_image_ctx, m_primary, ctx);
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::handle_is_tag_owner(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    derr << ": failed to query remote image tag owner: " << cpp_strerror(r)
+         << dendl;
+  }
+
+  finish(r);
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::finish(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_replayer::IsPrimaryRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.cc
@@ -4,6 +4,7 @@
 #include "IsPrimaryRequest.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"
+#include "cls/rbd/cls_rbd_client.h"
 #include "librbd/ImageCtx.h"
 #include "librbd/Journal.h"
 #include "librbd/Utils.h"
@@ -20,6 +21,7 @@ namespace mirror {
 namespace image_replayer {
 
 using librbd::util::create_context_callback;
+using librbd::util::create_rados_ack_callback;
 
 template <typename I>
 IsPrimaryRequest<I>::IsPrimaryRequest(I *image_ctx, bool *primary,
@@ -29,7 +31,53 @@ IsPrimaryRequest<I>::IsPrimaryRequest(I *image_ctx, bool *primary,
 
 template <typename I>
 void IsPrimaryRequest<I>::send() {
-  send_is_tag_owner();
+  send_get_mirror_state();
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::send_get_mirror_state() {
+  dout(20) << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::mirror_image_get_start(&op, m_image_ctx->id);
+
+  librados::AioCompletion *aio_comp = create_rados_ack_callback<
+    IsPrimaryRequest<I>, &IsPrimaryRequest<I>::handle_get_mirror_state>(this);
+  int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, aio_comp, &op,
+                                          &m_out_bl);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void IsPrimaryRequest<I>::handle_get_mirror_state(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  cls::rbd::MirrorImage mirror_image;
+  if (r == 0) {
+    bufferlist::iterator iter = m_out_bl.begin();
+    r = librbd::cls_client::mirror_image_get_finish(&iter, &mirror_image);
+    if (r == 0) {
+      if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_ENABLED) {
+        send_is_tag_owner();
+        return;
+      } else if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_DISABLING) {
+        dout(5) << ": image mirroring is being disabled" << dendl;
+        *m_primary = false;
+      } else {
+        derr << ": image mirroring is disabled" << dendl;
+        r = -EINVAL;
+      }
+    } else {
+      derr << ": failed to decode image mirror state: " << cpp_strerror(r)
+           << dendl;
+    }
+  } else {
+    derr << ": failed to retrieve image mirror state: " << cpp_strerror(r)
+         << dendl;
+  }
+
+  finish(r);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.h
@@ -1,0 +1,57 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_REPLAYER_IS_PRIMARY_REQUEST_H
+#define RBD_MIRROR_IMAGE_REPLAYER_IS_PRIMARY_REQUEST_H
+
+class Context;
+class ContextWQ;
+namespace librbd { class ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+namespace image_replayer {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class IsPrimaryRequest {
+public:
+  static IsPrimaryRequest* create(ImageCtxT *image_ctx, bool *primary,
+                                  Context *on_finish) {
+    return new IsPrimaryRequest(image_ctx, primary, on_finish);
+  }
+
+  IsPrimaryRequest(ImageCtxT *image_ctx, bool *primary, Context *on_finish);
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * IS_TAG_OWNER * * * * * * *
+   *    |                     * (error)
+   *    v                     *
+   * <finish> < * * * * * * * *
+   *
+   * @endverbatim
+   */
+  ImageCtxT *m_image_ctx;
+  bool *m_primary;
+  Context *m_on_finish;
+
+  void send_is_tag_owner();
+  void handle_is_tag_owner(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_replayer
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_replayer::IsPrimaryRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_REPLAYER_IS_PRIMARY_REQUEST_H

--- a/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/IsPrimaryRequest.h
@@ -4,6 +4,8 @@
 #ifndef RBD_MIRROR_IMAGE_REPLAYER_IS_PRIMARY_REQUEST_H
 #define RBD_MIRROR_IMAGE_REPLAYER_IS_PRIMARY_REQUEST_H
 
+#include "include/buffer.h"
+
 class Context;
 class ContextWQ;
 namespace librbd { class ImageCtx; }
@@ -31,8 +33,11 @@ private:
    * <start>
    *    |
    *    v
-   * IS_TAG_OWNER * * * * * * *
-   *    |                     * (error)
+   * GET_MIRROR_STATE * * * * *
+   *    |                     *
+   *    v                     *
+   * IS_TAG_OWNER * * * * * * * (error)
+   *    |                     *
    *    v                     *
    * <finish> < * * * * * * * *
    *
@@ -41,6 +46,11 @@ private:
   ImageCtxT *m_image_ctx;
   bool *m_primary;
   Context *m_on_finish;
+
+  bufferlist m_out_bl;
+
+  void send_get_mirror_state();
+  void handle_get_mirror_state(int r);
 
   void send_is_tag_owner();
   void handle_is_tag_owner(int r);

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -2,8 +2,9 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/compat.h"
-#include "OpenLocalImageRequest.h"
 #include "CloseImageRequest.h"
+#include "IsPrimaryRequest.h"
+#include "OpenLocalImageRequest.h"
 #include "common/errno.h"
 #include "common/WorkQueue.h"
 #include "librbd/ExclusiveLock.h"
@@ -114,39 +115,51 @@ void OpenLocalImageRequest<I>::handle_open_image(int r) {
     return;
   }
 
-  send_lock_image();
+  send_is_primary();
 }
 
 template <typename I>
-void OpenLocalImageRequest<I>::send_lock_image() {
-  // deduce the class type for the journal to support unit tests
-  using Journal = typename std::decay<
-    typename std::remove_pointer<decltype(std::declval<I>().journal)>
-    ::type>::type;
-
+void OpenLocalImageRequest<I>::send_is_primary() {
   dout(20) << dendl;
 
-  RWLock::RLocker owner_locker((*m_local_image_ctx)->owner_lock);
-  if ((*m_local_image_ctx)->exclusive_lock == nullptr) {
-    derr << ": image does not support exclusive lock" << dendl;
-    send_close_image(false, -EINVAL);
-    return;
-  }
+  Context *ctx = create_context_callback<
+    OpenLocalImageRequest<I>, &OpenLocalImageRequest<I>::handle_is_primary>(
+      this);
+  IsPrimaryRequest<I> *request = IsPrimaryRequest<I>::create(*m_local_image_ctx,
+                                                             &m_primary, ctx);
+  request->send();
+}
 
-  // TODO: make an async version
-  bool tag_owner;
-  int r = Journal::is_tag_owner(*m_local_image_ctx, &tag_owner);
+template <typename I>
+void OpenLocalImageRequest<I>::handle_is_primary(int r) {
+  dout(20) << ": r=" << r << dendl;
+
   if (r < 0) {
-    derr << ": failed to query journal: " << cpp_strerror(r) << dendl;
+    derr << ": error querying local image primary status: " << cpp_strerror(r)
+         << dendl;
     send_close_image(false, r);
     return;
   }
 
   // if the local image owns the tag -- don't steal the lock since
   // we aren't going to mirror peer data into this image anyway
-  if (tag_owner) {
+  if (m_primary) {
     dout(10) << ": local image is primary -- skipping image replay" << dendl;
     send_close_image(false, -EREMOTEIO);
+    return;
+  }
+
+  send_lock_image();
+}
+
+template <typename I>
+void OpenLocalImageRequest<I>::send_lock_image() {
+  dout(20) << dendl;
+
+  RWLock::RLocker owner_locker((*m_local_image_ctx)->owner_lock);
+  if ((*m_local_image_ctx)->exclusive_lock == nullptr) {
+    derr << ": image does not support exclusive lock" << dendl;
+    send_close_image(false, -EINVAL);
     return;
   }
 

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.h
@@ -48,6 +48,9 @@ private:
    *    v
    * OPEN_IMAGE * * * * * * * *
    *    |                     *
+   *    v                     *
+   * IS_PRIMARY * * * * * * * *
+   *    |                     *
    *    v (skip if primary)   v
    * LOCK_IMAGE * * * > CLOSE_IMAGE
    *    |                     |
@@ -63,10 +66,14 @@ private:
   ContextWQ *m_work_queue;
   Context *m_on_finish;
 
+  bool m_primary = false;
   int m_ret_val = 0;
 
   void send_open_image();
   void handle_open_image(int r);
+
+  void send_is_primary();
+  void handle_is_primary(int r);
 
   void send_lock_image();
   void handle_lock_image(int r);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18555