### PR TITLE
src/kv: setting rocksdb compressed block cache to reduce disk

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -913,6 +913,8 @@ SAFE_OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_U64, 128*1024*1024)  // default rocksdb cache size
 OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
+OPTION(rocksdb_compressed_cache_size, OPT_U64, 128*1024*1024)  // default rocksdb compressed block cache size
+OPTION(rocksdb_compressed_cache_shard_bits, OPT_INT, 4)  // rocksdb compressed block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 OPTION(rocksdb_perf, OPT_BOOL, false) // Enabling this will have 5-10% impact on performance for the stats collection
 OPTION(rocksdb_collect_compaction_stats, OPT_BOOL, false) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -287,12 +287,16 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
   }
 
   auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size, g_conf->rocksdb_cache_shard_bits);
+  auto compressed_cache = rocksdb::NewLRUCache(g_conf->rocksdb_compressed_cache_size, g_conf->rocksdb_compressed_cache_shard_bits);
   bbt_opts.block_size = g_conf->rocksdb_block_size;
   bbt_opts.block_cache = cache;
+  bbt_opts.block_cache_compressed = compressed_cache;
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
   dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
            << " cache size to " << g_conf->rocksdb_cache_size
-           << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
+           << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits)
+           << " compressed cache size to " << g_conf->rocksdb_compressed_cache_size
+           << " num of compressed cache shards to " << (1 << g_conf->rocksdb_compressed_cache_shard_bits) << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
   status = rocksdb::DB::Open(opt, path, &db);


### PR DESCRIPTION
add rocksdb compressed block cache configuration item

Signed-off-by: vincent-wangzy <striver.wang@qq.com>

When testing 8K random write, large amount of data loading from disk has been found because of rocksdb compressd data reading. Enable rocksdb compressed block cache could reduce data load from disk.