### PR TITLE
osd: renamed the new vector name in OSDMap::build_simple_crush_map_from_conf

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3092,15 +3092,15 @@ int OSDMap::build_simple_crush_map_from_conf(CephContext *cct,
       continue;
 
     string host, rack, row, room, dc, pool;
-    vector<string> sections;
-    sections.push_back("osd");
-    sections.push_back(*i);
-    conf->get_val_from_conf_file(sections, "host", host, false);
-    conf->get_val_from_conf_file(sections, "rack", rack, false);
-    conf->get_val_from_conf_file(sections, "row", row, false);
-    conf->get_val_from_conf_file(sections, "room", room, false);
-    conf->get_val_from_conf_file(sections, "datacenter", dc, false);
-    conf->get_val_from_conf_file(sections, "root", pool, false);
+    vector<string> section;
+    section.push_back("osd");
+    section.push_back(*i);
+    conf->get_val_from_conf_file(section, "host", host, false);
+    conf->get_val_from_conf_file(section, "rack", rack, false);
+    conf->get_val_from_conf_file(section, "row", row, false);
+    conf->get_val_from_conf_file(section, "room", room, false);
+    conf->get_val_from_conf_file(section, "datacenter", dc, false);
+    conf->get_val_from_conf_file(section, "root", pool, false);
 
     if (host.length() == 0)
       host = "unknownhost";


### PR DESCRIPTION
Renamed the new vector name in OSDMap::build_simple_crush_map_from_conf, to avoid confusing
it with the sections vector outside the for loop and which is iterating.

Signed-off-by: Jos Collin <jcollin@redhat.com>