### PR TITLE
bluestore/NVMEDEVICE: update SPDK to version 17.03

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1032,8 +1032,9 @@ OPTION(bluestore_bluefs_reclaim_ratio, OPT_FLOAT, .20) // how much to reclaim at
 // Example:
 // bluestore_block_path = spdk:55cd2e404bd73932
 // If you want to run multiple SPDK instances per node, you must specify the
-// amount of memory per socket each instance will use.
-OPTION(bluestore_spdk_socket_mem, OPT_STR, "512,512")
+// amount of dpdk memory size in MB each instance will use, to make sure each
+// instance uses its own dpdk memory
+OPTION(bluestore_spdk_mem, OPT_U32, 512)
 // A hexadecimal bit mask of the cores to run on. Note the core numbering can change between platforms and should be determined beforehand.
 OPTION(bluestore_spdk_coremask, OPT_STR, "0x3")
 // Specify the maximal I/Os to be batched completed while checking queue pair completions.


### PR DESCRIPTION
Do some minor changes:

1 Restrict the total DPDK memory used by an osd instance.
change the name from bluestore_spdk_socket_mem to
bluestore_spdk_mem.

2 use spdk_env_init instead of rte_eal_init. The reason is that
SPDK lib invokes rte_eal_init which reduces the initilization
paramter conversion and check, also spdk 17.03 invokes
spdk_vtophys_register_dpdk_mem() (which is an internal function)
in spdk_env_init, and this func must be called.

Signed-off-by: optimistyzy <optimistyzy@gmail.com>