### PR TITLE
client: refine fsync/close writeback error handling

### DIFF
--- a/qa/tasks/cephfs/test_full.py
+++ b/qa/tasks/cephfs/test_full.py
@@ -236,7 +236,8 @@ class FullnessTestCase(CephFSTestCase):
         self.mount_a.run_python(template.format(
             fill_mb=self.fill_mb,
             file_path=file_path,
-            full_wait=full_wait
+            full_wait=full_wait,
+            is_fuse=isinstance(self.mount_a, FuseMount)
         ))
 
     def test_full_fclose(self):
@@ -285,13 +286,17 @@ class FullnessTestCase(CephFSTestCase):
             # Wait long enough for a background flush that should fail
             time.sleep(30)
 
-            # ...and check that the failed background flush is reflected in fclose
-            try:
-                os.close(f)
-            except OSError:
-                print "close() returned an error as expected"
+            if {is_fuse}:
+                # ...and check that the failed background flush is reflected in fclose
+                try:
+                    os.close(f)
+                except OSError:
+                    print "close() returned an error as expected"
+                else:
+                    raise RuntimeError("close() failed to raise error")
             else:
-                raise RuntimeError("close() failed to raise error")
+                # The kernel cephfs client does not raise errors on fclose
+                os.close(f)
 
             os.unlink("{file_path}")
             """)
@@ -353,13 +358,12 @@ class FullnessTestCase(CephFSTestCase):
             if not full:
                 raise RuntimeError("Failed to reach fullness after writing %d bytes" % bytes)
 
-            # The error sticks to the inode until we dispose of it
-            try:
-                os.close(f)
-            except OSError:
-                print "Saw error from close() as expected"
-            else:
-                raise RuntimeError("Did not see expected error from close()")
+            # close() should not raise an error because we already caught it in
+            # fsync.  There shouldn't have been any more writeback errors
+            # since then because all IOs got cancelled on the full flag.
+            print "calling close"
+            os.close(f)
+            print "close() did not raise error"
 
             os.unlink("{file_path}")
             """)

--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -1,6 +1,7 @@
 set(libclient_srcs
   Client.cc
   Dentry.cc
+  Fh.cc
   Inode.cc
   MetaRequest.cc
   ClientSnapRealm.cc

--- a/src/client/Fh.cc
+++ b/src/client/Fh.cc
@@ -1,0 +1,32 @@
+
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat Inc
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#include "Inode.h"
+
+#include "Fh.h"
+
+Fh::Fh(Inode *in) : inode(in), _ref(1), pos(0), mds(0), mode(0), flags(0),
+                pos_locked(false), actor_perms(), readahead(),
+                fcntl_locks(NULL), flock_locks(NULL)
+{
+  inode->add_fh(this);
+}
+
+Fh::~Fh()
+{
+  inode->rm_fh(this);
+}
+

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -5,6 +5,7 @@
 #include "Inode.h"
 #include "Dentry.h"
 #include "Dir.h"
+#include "Fh.h"
 #include "MetaSession.h"
 #include "ClientSnapRealm.h"
 
@@ -546,3 +547,11 @@ void CapSnap::dump(Formatter *f) const
   f->dump_int("dirty_data", (int)dirty_data);
   f->dump_unsigned("flush_tid", flush_tid);
 }
+
+void Inode::set_async_err(int r)
+{
+  for (const auto &fh : fhs) {
+    fh->async_err = r;
+  }
+}
+


### PR DESCRIPTION
Previously, errors stuck indelibly to the inode, which
meant that a close call would see an error even if the
user already dutifully fsync()'d and handled it.

We should emit each error only once per file handle.

Signed-off-by: John Spray <john.spray@redhat.com>