### PR TITLE
src/CMakeLists.txt: Supress FreeBSD/Clang warnings.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -769,7 +769,7 @@ if (NOT WITH_SYSTEM_ROCKSDB)
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 
   if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
-    list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF)
+    list(APPEND ROCKSDB_CMAKE_ARGS -DFAIL_ON_WARNINGS=OFF -Wnoexpansion-to-defined)
   endif()
 
   # we use an external project and copy the sources to bin directory to ensure


### PR DESCRIPTION
-  Rocksdb uses some undefined defines and FReeBSD/Clang complains
    about that

Warning from Clang:
/usr/ports/net/ceph-devel/work/ceph-wip.FreeBSD.201704/src/rocksdb/util/thread_local.h:205:5: warning: macro expansion
      producing 'defined' has undefined behavior [-Wexpansion-to-defined]
/usr/ports/net/ceph-devel/work/ceph-wip.FreeBSD.201704/src/rocksdb/util/thread_local.h:22:47: note: expanded from macro
      'ROCKSDB_SUPPORT_THREAD_LOCAL'
  !defined(OS_WIN) && !defined(OS_MACOSX) && !defined(IOS_CROSS_COMPILE)
                                              ^
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>