### PR TITLE
[DNM] rgw_file:  exper. write-behind strategy

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -879,6 +879,67 @@ namespace rgw {
     return os;
   }
 
+  std::ostream& operator<<(std::ostream &os, WPage const &page)
+  {
+    os << "<WPage:";
+    os << "pno=" << page.pno << ";";
+    os << "off=" << "implicit;";
+    os << "len=" << page.len;
+    os << ">";
+    return os;
+  }
+
+  int WPageList::write_back(uint64_t off, uint64_t len, void* buf)
+  {
+      uint64_t toff = off;
+      uint64_t tlen = len;
+      bool need_sort = false;
+
+      lock_guard guard(mtx);
+
+      do {
+	int32_t pno = WPage::page_no(off);
+	if (unlikely(pno <= high_retired)) {
+	  /* out-of-order write, skew to great */
+	  std::cout << "write order skew: "
+		    << " off=" << off
+		    << " page_no=" << pno
+		    << " high_retired=" << high_retired
+		    << " window exceeded, page already sent"
+		    << std::endl;
+	  return -EIO;
+	}
+
+	/* if pno is < high_retired, pno is in queue already, or
+	 * else should be appended by us */
+	WPage *page = get_page(pno);
+	if (! page) {
+	  page = fh->get_fs()->writeback.get_page();
+	  if (! page) {
+	    return -EIO;
+	  }
+	  page->pno = pno;
+	  if (high_pno != pno-1) {
+	    need_sort = true;
+	  }
+	  put_page(page);
+	}
+
+	/* write part of a page */
+	uint32_t poff = WPage::page_off(toff);
+	uint32_t wlen = std::min(tlen, (WPage::PAGE_SIZE-poff));
+	page->store(poff, wlen, buf);
+	toff += wlen;
+	tlen -= wlen;
+
+      } while(tlen > 0);
+
+      if (need_sort)
+	pages.sort();
+
+      return 0;
+    } /* WPageList::write_back */
+
   RGWFileHandle::~RGWFileHandle() {
     /* in the non-delete case, handle may still be in handle table */
     if (fh_hook.is_linked()) {
@@ -1008,14 +1069,39 @@ namespace rgw {
     return rc;
   } /* RGWFileHandle::readdir */
 
-  int RGWFileHandle::write(uint64_t off, size_t len, size_t *bytes_written,
-			   void *buffer)
+  int RGWFileHandle::write_finish(uint32_t flags)
+  {
+    unique_lock guard{mtx, std::defer_lock};
+    int rc = 0;
+
+    if (! (flags & FLAG_LOCKED)) {
+      guard.lock();
+    }
+
+    file* f = get<file>(&variant_type);
+    if (f && (f->write_req2)) {
+      lsubdout(fs->get_context(), rgw, 10)
+	<< __func__
+	<< " finishing write trans on " << object_name()
+	<< dendl;
+      rc = rgwlib.get_fe()->finish_req(f->write_req2);
+      if (! rc) {
+	rc = f->write_req2->get_ret();
+      }
+      delete f->write_req2;
+      f->write_req2 = nullptr;
+    }
+
+    return rc;
+  } /* RGWFileHandle::write_finish */
+
+  int RGWFileHandle::write2(uint64_t off, size_t len, size_t *bytes_written,
+			    void *buffer)
   {
     using std::get;
     using WriteCompletion = RGWLibFS::WriteCompletion;
 
     lock_guard guard(mtx);
-
     int rc = 0;
 
     file* f = get<file>(&variant_type);
@@ -1029,14 +1115,31 @@ namespace rgw {
 	<< this->object_name()
 	<< dendl;
       /* zap write transaction, if any */
-      if (f->write_req) {
-	delete f->write_req;
-	f->write_req = nullptr;
+      if (f->write_req2) {
+	delete f->write_req2;
+	f->write_req2 = nullptr;
       }
       return -ESTALE;
     }
 
-    if (! f->write_req) {
+    std::cout
+      << __func__
+      << " off=" << off
+      << " len=" << len
+      << std::endl;
+
+    if (off &&
+	(f->last_off > off)) {
+      std::cout
+	<< __func__
+	<< " OUT OF ORDER WRITE at off=" << off
+	<< " last_off=" << f->last_off
+	<< std::endl;
+    }
+
+    f->last_off = off;
+
+    if (! f->write_req2) {
       /* guard--we do not support (e.g., COW-backed) partial writes */
       if (off != 0) {
 	lsubdout(fs->get_context(), rgw, 5)
@@ -1049,10 +1152,16 @@ namespace rgw {
 
       /* start */
       std::string object_name = relative_object_name();
-      f->write_req =
-	new RGWWriteRequest(fs->get_context(), fs->get_user(), this,
-			    bucket_name(), object_name);
-      rc = rgwlib.get_fe()->start_req(f->write_req);
+      f->write_req2 =
+	new RGWWriteRequest2(fs->get_context(), fs->get_user(), this,
+			     bucket_name(), object_name);
+
+      std::cout << "created new RGWWriteRequest2"
+		<< " high_retired="
+		<< f->write_req2->page_list.high_retired
+		<< std::endl;
+
+      rc = rgwlib.get_fe()->start_req(f->write_req2);
       if (rc < 0) {
 	lsubdout(fs->get_context(), rgw, 5)
 	  << __func__
@@ -1061,85 +1170,28 @@ namespace rgw {
 	  << " (" << rc << ")"
 	  << dendl;
 	/* zap failed write transaction */
-	delete f->write_req;
-	f->write_req = nullptr;
+	delete f->write_req2;
+	f->write_req2 = nullptr;
         return -EIO;
       } else {
 	if (stateless_open())  {
 	  /* start write timer */
-	  f->write_req->timer_id =
+	  f->write_req2->timer_id =
 	    RGWLibFS::write_timer.add_event(
 	      std::chrono::seconds(RGWLibFS::write_completion_interval_s),
 	      WriteCompletion(*this));
 	}
       }
-    }
+    } /* ! f->write_req2 */
 
-    buffer::list bl;
-    /* XXXX */
-#if 0
-    bl.push_back(
-      buffer::create_static(len, static_cast<char*>(buffer)));
-#else
-    bl.push_back(
-      buffer::copy(static_cast<char*>(buffer), len));
-#endif
-
-    f->write_req->put_data(off, bl);
-    rc = f->write_req->exec_continue();
-
-    if (rc == 0) {
-      size_t min_size = off + len;
-      if (min_size > get_size())
-	set_size(min_size);
-      if (stateless_open()) {
-	/* bump write timer */
-	RGWLibFS::write_timer.adjust_event(
-	  f->write_req->timer_id, std::chrono::seconds(10));
-      }
-    } else {
-      /* continuation failed (e.g., non-contiguous write position) */
-      lsubdout(fs->get_context(), rgw, 5)
-	<< __func__
-	<< object_name()
-	<< " failed write at position " << off
-	<< " (fails write transaction) "
-	<< dendl;
-      /* zap failed write transaction */
-      delete f->write_req;
-      f->write_req = nullptr;
-      rc = -EIO;
+    rc = f->write_req2->page_list.write_back(off, len, buffer);
+    if (likely(rc == 0)) {
+      rc = f->write_req2->exec_continue();
     }
 
     *bytes_written = (rc == 0) ? len : 0;
     return rc;
-  } /* RGWFileHandle::write */
-
-  int RGWFileHandle::write_finish(uint32_t flags)
-  {
-    unique_lock guard{mtx, std::defer_lock};
-    int rc = 0;
-
-    if (! (flags & FLAG_LOCKED)) {
-      guard.lock();
-    }
-
-    file* f = get<file>(&variant_type);
-    if (f && (f->write_req)) {
-      lsubdout(fs->get_context(), rgw, 10)
-	<< __func__
-	<< " finishing write trans on " << object_name()
-	<< dendl;
-      rc = rgwlib.get_fe()->finish_req(f->write_req);
-      if (! rc) {
-	rc = f->write_req->get_ret();
-      }
-      delete f->write_req;
-      f->write_req = nullptr;
-    }
-
-    return rc;
-  } /* RGWFileHandle::write_finish */
+  } /* RGWFileHandle::write2 */
 
   int RGWFileHandle::close()
   {
@@ -1153,7 +1205,7 @@ namespace rgw {
 
   RGWFileHandle::file::~file()
   {
-    delete write_req;
+    delete write_req2;
   }
 
   void RGWFileHandle::clear_state()
@@ -1172,7 +1224,7 @@ namespace rgw {
     }
   }
 
-  int RGWWriteRequest::exec_start() {
+  int RGWWriteRequest2::exec_start() {
     struct req_state* s = get_state();
 
     /* not obviously supportable */
@@ -1208,38 +1260,69 @@ namespace rgw {
     return op_ret;
   } /* exec_start */
 
-  int RGWWriteRequest::exec_continue()
+  int RGWWriteRequest2::write_page(WPage* page, uint32_t flags)
   {
+    int rc = 0;
     struct req_state* s = get_state();
-    op_ret = 0;
+    buffer::list data;
 
-    /* check guards (e.g., contig write) */
-    if (eio)
-      return -EIO;
+    std::cout << __func__
+	      << " page=" << *page
+	      << " flags=" << flags
+	      << std::endl;
+
+    data.push_back(
+      buffer::create_static(page->len,
+			    static_cast<char*>(page->base)));
 
     size_t len = data.length();
     if (! len)
       return 0;
 
-    /* XXX we are currently synchronous--supplied data buffers cannot
-     * be used after the caller returns  */
+    /* XXX we are currently synchronous--not clear we need to be
+     * now that buffers are write-behind */
     bool need_to_wait = true;
     bufferlist orig_data;
+
+    /* partial writes are always whole-page */
+    ofs = page->file_offset();
+
+    if ((! page->full()) &&
+	(! (flags & FLAG_FINISH))) {
+      /* non-full pages contain zeroed data--for upload-only use
+       * case, this is never correct */
+      rgw_fh->get_fs()->writeback.put_page(page);
+      rc = -EIO;
+      goto done;
+    }
 
     if (need_to_wait) {
       orig_data = data;
     }
     hash.Update((const byte *)data.c_str(), data.length());
-    op_ret = put_data_and_throttle(processor, data, ofs,
-				   need_to_wait);
-    if (op_ret < 0) {
-      if (!need_to_wait || op_ret != -EEXIST) {
+
+    std::cout << __func__
+	      << " pre put_data_and_throttle"
+	      << " ofs=" << ofs
+	      << " data.length=" << data.length()
+	      << std::endl;
+
+    rc = put_data_and_throttle(processor, data, ofs, need_to_wait);
+    if (rc < 0) {
+
+      std::cout << __func__
+		<< " put_data_and_throttle returned " << rc
+		<< std::endl;
+
+      if (!need_to_wait || rc != -EEXIST) {
 	ldout(s->cct, 20) << "processor->thottle_data() returned ret="
-			  << op_ret << dendl;
+			  << rc << dendl;
+	rgw_fh->get_fs()->writeback.put_page(page);
 	goto done;
       }
 
-      ldout(s->cct, 5) << "NOTICE: processor->throttle_data() returned -EEXIST, need to restart write" << dendl;
+      ldout(s->cct, 5) << "NOTICE: processor->throttle_data() returned"
+		       << " -EEXIST, need to restart write" << dendl;
 
       /* restore original data */
       data.swap(orig_data);
@@ -1254,33 +1337,95 @@ namespace rgw {
       gen_rand_alphanumeric(get_store()->ctx(), buf, sizeof(buf) - 1);
       oid_rand.append(buf);
 
-      op_ret = processor->prepare(get_store(), &oid_rand);
-      if (op_ret < 0) {
+      rc = processor->prepare(get_store(), &oid_rand);
+      if (rc < 0) {
+	std::cout << __func__
+		  << "ERROR: processor->prepare() returned " << rc
+		  << std::endl;
 	ldout(s->cct, 0) << "ERROR: processor->prepare() returned "
-			 << op_ret << dendl;
+			 << rc << dendl;
+	rgw_fh->get_fs()->writeback.put_page(page);
 	goto done;
       }
 
-      op_ret = put_data_and_throttle(processor, data, ofs, false);
-      if (op_ret < 0) {
+      rc = put_data_and_throttle(processor, data, ofs, false);
+      if (rc < 0) {
+	std::cout << __func__
+		  << "ERROR: put_data_and_throttle() returned " << rc
+		  << std::endl;
+	rgw_fh->get_fs()->writeback.put_page(page);
 	goto done;
       }
     }
+    rgw_fh->get_fs()->writeback.put_page(page);
     bytes_written += len;
 
   done:
+    return rc;
+  }
+
+  int RGWWriteRequest2::exec_continue()
+  {
+    op_ret = 0;
+
+    WPage* page = nullptr;
+    while (((page = page_list.retire_page_lock()) != nullptr) &&
+	   (op_ret == 0)) {
+
+      std::cout
+	<< __func__
+	<< " retire page=" << *page
+	<< std::endl;
+
+      op_ret = write_page(page, FLAG_NONE);
+    } /* retire pages */
+
     return op_ret;
   } /* exec_continue */
 
-  int RGWWriteRequest::exec_finish()
+  int RGWWriteRequest2::exec_finish()
   {
     buffer::list bl, aclbl, ux_key, ux_attrs;
     map<string, string>::iterator iter;
     char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
     unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
+    real_time appx_t = real_clock::now(); /* XXX */
     struct req_state* s = get_state();
 
-    s->obj_size = ofs; // XXX check ofs
+    vector<WPage*> page_vec;
+    page_list.get_pages_lock(page_vec);
+
+    std::cout << __func__
+	      << " reached with " << page_vec.size()
+	      << " tail pages"
+	      << std::endl;
+
+    for (uint32_t ix = 0; ix < page_vec.size(); ++ix) {
+      WPage* page = page_vec[ix];
+      if (op_ret == 0) {
+	/* only last page can be !FULL */
+	uint32_t wp_flags =
+	  (ix == (page_vec.size()-1)) ? FLAG_FINISH : FLAG_NONE;
+
+      std::cout << __func__
+		<< " write_page=" << *page
+		<< std::endl;
+
+      op_ret = write_page(page, wp_flags);
+      } else {
+	// release page
+
+	std::cout << __func__
+		<< " ERROR on write_page=" << *page
+		<< std::endl;
+
+	rgw_fh->get_fs()->writeback.put_page(page);
+      }
+    } /* outstanding pages */
+    if (op_ret != 0)
+      goto done;
+
+    s->obj_size = ofs; // XXX check ofs!!!
     perfcounter->inc(l_rgw_put_b, s->obj_size);
 
     op_ret = get_store()->check_quota(s->bucket_owner.get_id(), s->bucket,
@@ -1299,6 +1444,17 @@ namespace rgw {
 
     policy.encode(aclbl);
     emplace_attr(RGW_ATTR_ACL, std::move(aclbl));
+
+    /* unix attrs */
+    rgw_fh->set_mtime(real_clock::to_timespec(appx_t));
+    rgw_fh->set_ctime(real_clock::to_timespec(appx_t));
+    rgw_fh->set_size(bytes_written);
+
+    std::cout << __func__
+	      << " finalize attrs"
+	      << " bytes_written=" << bytes_written
+	      << " times=" << real_clock::to_timespec(appx_t)
+	      << std::endl;
 
     rgw_fh->encode_attrs(ux_key, ux_attrs);
     emplace_attr(RGW_ATTR_UNIX_KEY1, std::move(ux_key));
@@ -1324,13 +1480,12 @@ namespace rgw {
     }
 
     op_ret = processor->complete(s->obj_size, etag, &mtime, real_time(), attrs,
-                                 (delete_at ? *delete_at : real_time()), if_match, if_nomatch);
-    if (! op_ret) {
-      /* update stats */
-      rgw_fh->set_mtime(real_clock::to_timespec(mtime));
-      rgw_fh->set_ctime(real_clock::to_timespec(mtime));
-      rgw_fh->set_size(bytes_written);
-    }
+                                 (delete_at ? *delete_at : real_time()),
+				 if_match, if_nomatch);
+
+    std::cout << __func__
+	      << " processor->complete returned " << op_ret
+	      << std::endl;
 
   done:
     dispose_processor(processor);
@@ -1730,7 +1885,7 @@ int rgw_write(struct rgw_fs *rgw_fs,
   if (! rgw_fh->is_open())
     return -EPERM;
 
-  rc = rgw_fh->write(offset, length, bytes_written, buffer);
+  rc = rgw_fh->write2(offset, length, bytes_written, buffer);
 
   return rc;
 }


### PR DESCRIPTION
The current write strategy models object upload in simple cases,
but fails in a few we'd like to support:

1. requires -osync mounts, even though MOST writes are in-order
2. forbids some generally-in-order overwrites see w/GNU tar
3. others?

This change implements a write-behind strategy with the existing
atomic update processor, capable of absorbing a bounded number
of out-of-order writes and overwrites.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>