### PR TITLE
jewel: rgw: multisite: fetch_remote_obj() gets wrong version when copying from remote

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6759,9 +6759,8 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   RGWPutObjProcessor_Atomic processor(obj_ctx,
                                       dest_bucket_info, dest_obj.bucket, dest_obj.get_orig_obj(),
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
-  const string& instance = dest_obj.get_instance();
-  if (instance != "null") {
-    processor.set_version_id(dest_obj.get_instance());
+  if (version_id) {
+    processor.set_version_id(*version_id);
   }
   processor.set_olh_epoch(olh_epoch);
   int ret = processor.prepare(this, NULL);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6759,7 +6759,7 @@ int RGWRados::fetch_remote_obj(RGWObjectCtx& obj_ctx,
   RGWPutObjProcessor_Atomic processor(obj_ctx,
                                       dest_bucket_info, dest_obj.bucket, dest_obj.get_orig_obj(),
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
-  if (version_id) {
+  if (version_id && *version_id != "null") {
     processor.set_version_id(*version_id);
   }
   processor.set_olh_epoch(olh_epoch);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19607