### PR TITLE
rgw_file:  pre-compute unix attrs in write_finish()

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -340,6 +340,7 @@ namespace rgw {
     uint32_t get_owner_uid() const { return state.owner_uid; }
     uint32_t get_owner_gid() const { return state.owner_gid; }
 
+    struct timespec get_ctime() const { return state.ctime; }
     struct timespec get_mtime() const { return state.mtime; }
 
     void create_stat(struct stat* st, uint32_t mask) {


### PR DESCRIPTION
New serialized Unix attrs need to reflect the change being made,
and should be reverted if the change fails.

Fixes: http://tracker.ceph.com/issues/19653

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>