### PR TITLE
#17980: MDS client blacklisting and blacklist on eviction

### DIFF
--- a/doc/cephfs/eviction.rst
+++ b/doc/cephfs/eviction.rst
@@ -80,8 +80,16 @@ output:
 That's it!  The client has now been evicted, and any resources it had locked will
 now be available for other clients.
 
-Background: OSD epoch barrier
------------------------------
+Background: blacklisting and OSD epoch barrier
+----------------------------------------------
+
+After a client is blacklisted, it is necessary to make sure that 
+other clients and MDS daemons have the latest OSDMap (including
+the blacklist entry) before they try to access any data objects
+that the blacklisted client might have been accessing.
+
+This is ensured using an internal "osdmap epoch barrier" mechanism.
+See :doc:
 
 The purpose of the barrier is to ensure that when we hand out any
 capabilities which might allow touching the same RADOS objects, the

--- a/doc/cephfs/eviction.rst
+++ b/doc/cephfs/eviction.rst
@@ -1,4 +1,5 @@
 
+===============================
 Ceph filesystem client eviction
 ===============================
 
@@ -6,122 +7,139 @@ When a filesystem client is unresponsive or otherwise misbehaving, it
 may be necessary to forcibly terminate its access to the filesystem.  This
 process is called *eviction*.
 
-This process is somewhat thorough in order to protect against data inconsistency
-resulting from misbehaving clients.
+Evicting a CephFS client prevents it from communicating further with MDS
+daemons and OSD daemons.  If a client was doing buffered IO to the filesystem,
+any un-flushed data will be lost.
 
-OSD blacklisting
-----------------
+Clients may either be evicted automatically (if they fail to communicate
+promptly with the MDS), or manually (by the system administrator).
 
-First, prevent the client from performing any more data operations by *blacklisting*
-it at the RADOS level.  You may be familiar with this concept as *fencing* in other
-storage systems.
+The client eviction process applies to clients of all kinds, this includes
+FUSE mounts, kernel mounts, nfs-ganesha gateways, and any process using
+libcephfs.
 
-Identify the client to evict from the MDS session list:
+Automatic client eviction
+=========================
+
+There are two situations in which a client may be evicted automatically:
+
+On an active MDS daemon, if a client has not communicated with the MDS for
+over ``mds_session_autoclose`` seconds (300 seconds by default), then it
+will be evicted automatically.
+
+During MDS startup (including on failover), the MDS passes through a
+state called ``reconnect``.  During this state, it waits for all the
+clients to connect to the new MDS daemon.  If any clients fail to do
+so within the time window (``mds_reconnect_timeout``, 45 seconds by default)
+then they will be evicted.
+
+A warning message is sent to the cluster log if either of these situations
+arises.
+
+Manual client eviction
+======================
+
+Sometimes, the administrator may want to evict a client manually.  This
+could happen if a client is died and the administrator does not
+want to wait for its session to time out, or it could happen if
+a client is misbehaving and the administrator does not have access to
+the client node to unmount it.
+
+It is useful to inspect the list of clients first:
 
 ::
 
-    # ceph daemon mds.a session ls
+    ceph tell mds.0 client ls
+
     [
-        { "id": 4117,
-          "num_leases": 0,
-          "num_caps": 1,
-          "state": "open",
-          "replay_requests": 0,
-          "reconnecting": false,
-          "inst": "client.4117 172.16.79.251:0\/3271",
-          "client_metadata": { "entity_id": "admin",
-              "hostname": "fedoravm.localdomain",
-              "mount_point": "\/home\/user\/mnt"}}]
+        {
+            "id": 4305,
+            "num_leases": 0,
+            "num_caps": 3,
+            "state": "open",
+            "replay_requests": 0,
+            "completed_requests": 0,
+            "reconnecting": false,
+            "inst": "client.4305 172.21.9.34:0/422650892",
+            "client_metadata": {
+                "ceph_sha1": "ae81e49d369875ac8b569ff3e3c456a31b8f3af5",
+                "ceph_version": "ceph version 12.0.0-1934-gae81e49 (ae81e49d369875ac8b569ff3e3c456a31b8f3af5)",
+                "entity_id": "0",
+                "hostname": "senta04",
+                "mount_point": "/tmp/tmpcMpF1b/mnt.0",
+                "pid": "29377",
+                "root": "/"
+            }
+        }
+    ]
+    
 
-In this case the 'fedoravm' client has address ``172.16.79.251:0/3271``, so we blacklist
-it as follows:
+
+Once you have identified the client you want to evict, you can
+do that using its unique ID, or various other attributes to identify it:
+
+::
+    
+    # These all work
+    ceph tell mds.0 client evict id=4305
+    ceph tell mds.0 client evict client_metadata.=4305
+
+
+Advanced: Un-blacklisting a client
+==================================
+
+Ordinarily, a blacklisted client may not reconnect to the servers: it
+must be unmounted and then mounted anew.
+
+However, in some situations it may be useful to permit a client that
+was evicted to attempt to reconnect.
+
+Because CephFS uses the RADOS OSD blacklist to control client eviction,
+CephFS clients can be permitted to reconnect by removing them from
+the blacklist:
 
 ::
 
-    # ceph osd blacklist add 172.16.79.251:0/3271
-    blacklisting 172.16.79.251:0/3271 until 2014-12-09 13:09:56.569368 (3600 sec)
+    ceph osd blacklist ls
+    # ... identify the address of the client ...
+    ceph osd blacklist rm <address>
 
-OSD epoch barrier
------------------
+Doing this may put data integrity at risk if other clients have accessed
+files that the blacklisted client was doing buffered IO to.  It is also not
+guaranteed to result in a fully functional client -- the best way to get
+a fully healthy client back after an eviction is to unmount the client
+and do a fresh mount.
 
-While the evicted client is now marked as blacklisted in the central (mon) copy of the OSD
-map, it is now necessary to ensure that this OSD map update has propagated to all daemons
-involved in subsequent filesystem I/O.  To do this, use the ``osdmap barrier`` MDS admin
-socket command.
+If you are trying to reconnect clients in this way, you may also
+find it useful to set ``client_reconnect_stale`` to true in the
+FUSE client, to prompt the client to try to reconnect.
 
-First read the latest OSD epoch:
+Advanced: Configuring blacklisting
+==================================
 
-::
+If you are experiencing frequent client evictions, due to slow
+client hosts or an unreliable network, and you cannot fix the underlying
+issue, then you may want to ask the MDS to be less strict.
 
-    # ceph osd dump
-    epoch 12
-    fsid fd61ca96-53ff-4311-826c-f36b176d69ea
-    created 2014-12-09 12:03:38.595844
-    modified 2014-12-09 12:09:56.619957
-    ...
+It is possible to respond to slow clients by simply dropping their
+MDS sessions, but permit them to re-open sessions and permit them
+to continue talking to OSDs.  To enable this mode, set
+``mds_session_blacklist_on_timeout`` to false on your MDS nodes.
 
-In this case it is 12.  Now request the MDS to barrier on this epoch:
+For the equivalent behaviour on manual evictions, set
+``mds_session_blacklist_on_evict`` to false.
 
-::
+Note that if blacklisting is disabled, then evicting a client will
+only have an effect on the MDS you send the command to.  On a system
+with multiple active MDS daemons, you would need to send an
+eviction command to each active daemon.  When blacklisting is enabled 
+(the default), sending an eviction to command to just a single
+MDS is sufficient, because the blacklist propagates it to the others.
 
-    # ceph daemon mds.a osdmap barrier 12
+Advanced options
+================
 
-MDS session eviction
---------------------
+``mds_blacklist_interval`` - this setting controls how many seconds
+entries will remain in the blacklist for.
 
-Finally, it is safe to evict the client's MDS session, such that any capabilities it held
-may be issued to other clients.  The ID here is the ``id`` attribute from the ``session ls``
-output:
-
-::
-
-    # ceph daemon mds.a session evict 4117
-
-That's it!  The client has now been evicted, and any resources it had locked will
-now be available for other clients.
-
-Background: blacklisting and OSD epoch barrier
-----------------------------------------------
-
-After a client is blacklisted, it is necessary to make sure that 
-other clients and MDS daemons have the latest OSDMap (including
-the blacklist entry) before they try to access any data objects
-that the blacklisted client might have been accessing.
-
-This is ensured using an internal "osdmap epoch barrier" mechanism.
-See :doc:
-
-The purpose of the barrier is to ensure that when we hand out any
-capabilities which might allow touching the same RADOS objects, the
-clients we hand out the capabilities to must have a sufficiently recent
-OSD map to not race with cancelled operations (from ENOSPC) or
-blacklisted clients (from evictions)
-
-More specifically, the cases where we set an epoch barrier are:
-
- * Client eviction (where the client is blacklisted and other clients
-   must wait for a post-blacklist epoch to touch the same objects)
- * OSD map full flag handling in the client (where the client may
-   cancel some OSD ops from a pre-full epoch, so other clients must
-   wait until the full epoch or later before touching the same objects).
- * MDS startup, because we don't persist the barrier epoch, so must
-   assume that latest OSD map is always required after a restart.
-
-Note that this is a global value for simplicity: we could maintain this on
-a per-inode basis.  We don't, because:
-
- * It would be more complicated
- * It would use an extra 4 bytes of memory for every inode
- * It would not be much more efficient as almost always everyone has the latest
-   OSD map anyway, in most cases everyone will breeze through this barrier
-   rather than waiting.
- * We only do this barrier in very rare cases, so any benefit from per-inode
-   granularity would only very rarely be seen.
-
-The epoch barrier is transmitted along with all capability messages, and
-instructs the receiver of the message to avoid sending any more RADOS
-operations to OSDs until it has seen this OSD epoch.  This mainly applies
-to clients (doing their data writes directly to files), but also applies
-to the MDS because things like file size probing and file deletion are
-done directly from the MDS.
 

--- a/qa/suites/fs/basic_functional/tasks/client-recovery.yaml
+++ b/qa/suites/fs/basic_functional/tasks/client-recovery.yaml
@@ -4,6 +4,7 @@
 overrides:
   ceph:
     log-whitelist:
+      - evicting unresponsive client
       - wrongly marked me down
       - slow request
 

--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -2,3 +2,8 @@ tasks:
 - cephfs_test_runner:
     modules:
       - tasks.cephfs.test_misc
+
+overrides:
+  ceph:
+    log-whitelist:
+      - evicting unresponsive client

--- a/qa/tasks/cephfs/cephfs_test_case.py
+++ b/qa/tasks/cephfs/cephfs_test_case.py
@@ -193,8 +193,10 @@ class CephFSTestCase(CephTestCase):
         if ls_data is None:
             ls_data = self.fs.mds_asok(['session', 'ls'], mds_id=mds_id)
 
-        self.assertEqual(expected, len(ls_data), "Expected {0} sessions, found {1}".format(
-            expected, len(ls_data)
+        alive_count = len([s for s in ls_data if s['state'] != 'killing'])
+
+        self.assertEqual(expected, alive_count, "Expected {0} sessions, found {1}".format(
+            expected, alive_count
         ))
 
     def assert_session_state(self, client_id,  expected_state):

--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -331,10 +331,7 @@ class TestClientRecovery(CephFSTestCase):
                             count, num_caps
                         ))
 
-    def test_filelock(self):
-        """
-        Check that file lock doesn't get lost after an MDS restart
-        """
+    def _is_flockable(self):
         a_version_str = get_package_version(self.mount_a.client_remote, "fuse")
         b_version_str = get_package_version(self.mount_b.client_remote, "fuse")
         flock_version_str = "2.9"
@@ -348,14 +345,20 @@ class TestClientRecovery(CephFSTestCase):
         b_version = version.StrictVersion(b_result.group())
         flock_version=version.StrictVersion(flock_version_str)
 
-        flockable = False
         if (a_version >= flock_version and b_version >= flock_version):
-            log.info("testing flock locks")
-            flockable = True
+            log.info("flock locks are available")
+            return True
         else:
             log.info("not testing flock locks, machines have versions {av} and {bv}".format(
                 av=a_version_str,bv=b_version_str))
+            return False
 
+    def test_filelock(self):
+        """
+        Check that file lock doesn't get lost after an MDS restart
+        """
+
+        flockable = self._is_flockable()
         lock_holder = self.mount_a.lock_background(do_flock=flockable)
 
         self.mount_b.wait_for_visible("background_file-2")
@@ -373,6 +376,33 @@ class TestClientRecovery(CephFSTestCase):
         except (CommandFailedError, ConnectionLostError):
             # We killed it, so it raises an error
             pass
+
+    def test_filelock_eviction(self):
+        """
+        Check that file lock held by evicted client is given to
+        waiting client.
+        """
+        if not self._is_flockable():
+            self.skipTest("flock is not available")
+
+        lock_holder = self.mount_a.lock_background()
+        self.mount_b.wait_for_visible("background_file-2")
+        self.mount_b.check_filelock()
+
+        lock_taker = self.mount_b.lock_and_release()
+        # Check the taker is waiting (doesn't get it immediately)
+        time.sleep(2)
+        self.assertFalse(lock_holder.finished)
+        self.assertFalse(lock_taker.finished)
+
+        mount_a_client_id = self.mount_a.get_global_id()
+        self.fs.mds_asok(['session', 'evict', "%s" % mount_a_client_id])
+
+        # Evicting mount_a should let mount_b's attepmt to take the lock
+        # suceed
+        self.wait_until_true(
+            lambda: lock_taker.finished,
+            timeout=10)
 
     def test_dir_fsync(self):
 	self._test_fsync(True);

--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -6,6 +6,7 @@ from teuthology.orchestra.run import CommandFailedError
 import errno
 import time
 
+
 class TestMisc(CephFSTestCase):
     CLIENTS_REQUIRED = 2
 
@@ -101,12 +102,12 @@ class TestMisc(CephFSTestCase):
         only session
         """
 
-        self.mount_b.umount_wait();
+        self.mount_b.umount_wait()
         ls_data = self.fs.mds_asok(['session', 'ls'])
         self.assert_session_count(1, ls_data)
 
-        self.mount_a.kill();
-        self.mount_a.kill_cleanup();
+        self.mount_a.kill()
+        self.mount_a.kill_cleanup()
 
         time.sleep(self.mds_session_autoclose * 1.5)
         ls_data = self.fs.mds_asok(['session', 'ls'])

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -490,12 +490,17 @@ vc.disconnect()
         )))
 
         # Evicted guest client, guest_mounts[0], should not be able to do
-        # anymore metadata ops. It behaves as if it has lost network
-        # connection.
-        background = guest_mounts[0].write_n_mb("rogue.bin", 1, wait=False)
-        # Approximate check for 'stuck' as 'still running after 10s'.
-        time.sleep(10)
-        self.assertFalse(background.finished)
+        # anymore metadata ops.  It should start failing all operations
+        # when it sees that its own address is in the blacklist.
+        try:
+            guest_mounts[0].write_n_mb("rogue.bin", 1)
+        except CommandFailedError:
+            pass
+        else:
+            raise RuntimeError("post-eviction write should have failed!")
+
+        # The blacklisted guest client should now be unmountable
+        guest_mounts[0].umount_wait()
 
         # Guest client, guest_mounts[1], using the same auth ID 'guest', but
         # has mounted the other volume, should be able to use its volume
@@ -515,8 +520,6 @@ vc.disconnect()
                 guest_entity=guest_entity
             )))
 
-        # We must hard-umount the one that we evicted
-        guest_mounts[0].umount_wait(force=True)
 
     def test_purge(self):
         """

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -11,10 +11,6 @@ log = logging.getLogger(__name__)
 
 
 class TestVolumeClient(CephFSTestCase):
-    #
-    # TODO: Test that VolumeClient can recover from partial auth updates.
-    #
-
     # One for looking at the global filesystem, one for being
     # the VolumeClient, two for mounting the created shares
     CLIENTS_REQUIRED = 4

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -250,7 +250,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     whoami(mc->get_global_id()), cap_epoch_barrier(0),
     last_tid(0), oldest_tid(0), last_flush_tid(1),
     initialized(false),
-    mounted(false), unmounting(false),
+    mounted(false), unmounting(false), blacklisted(false),
     local_osd(-1), local_osd_epoch(0),
     unsafe_sync_write(0),
     client_lock("Client::client_lock")
@@ -293,6 +293,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
 				  true));
   objecter_finisher.start();
   filer.reset(new Filer(objecter, &objecter_finisher));
+  objecter->enable_blacklist_events();
 }
 
 
@@ -1649,6 +1650,11 @@ int Client::make_request(MetaRequest *request,
     if (request->aborted())
       break;
 
+    if (blacklisted) {
+      request->abort(-EBLACKLISTED);
+      break;
+    }
+
     // set up wait cond
     Cond caller_cond;
     request->caller_cond = &caller_cond;
@@ -2398,6 +2404,46 @@ void Client::_handle_full_flag(int64_t pool)
 
 void Client::handle_osd_map(MOSDMap *m)
 {
+  std::set<entity_addr_t> new_blacklists;
+  objecter->consume_blacklist_events(&new_blacklists);
+
+  const auto myaddr = messenger->get_myaddr();
+  if (!blacklisted && new_blacklists.count(myaddr)) {
+    auto epoch = objecter->with_osdmap([](const OSDMap &o){
+        return o.get_epoch();
+        });
+    lderr(cct) << "I was blacklisted at osd epoch " << epoch << dendl;
+    blacklisted = true;
+    for (std::map<ceph_tid_t, MetaRequest*>::iterator p = mds_requests.begin();
+         p != mds_requests.end(); ) {
+      auto req = p->second;
+      ++p;
+      req->abort(-EBLACKLISTED);
+      if (req->caller_cond) {
+	req->kick = true;
+	req->caller_cond->Signal();
+      }
+    }
+
+    // Progress aborts on any requests that were on this waitlist.  Any
+    // requests that were on a waiting_for_open session waitlist
+    // will get kicked during close session below.
+    signal_cond_list(waiting_for_mdsmap);
+
+    // Force-close all sessions: assume this is not abandoning any state
+    // on the MDS side because the MDS will have seen the blacklist too.
+    while(!mds_sessions.empty()) {
+      auto i = mds_sessions.begin();
+      auto session = i->second;
+      _closed_mds_session(session);
+    }
+
+  } else if (blacklisted) {
+    // Handle case where we were blacklisted but no longer are
+    blacklisted = objecter->with_osdmap([myaddr](const OSDMap &o){
+        return o.is_blacklisted(myaddr);});
+  }
+
   if (objecter->osdmap_full_flag()) {
     _handle_full_flag(-1);
   } else {
@@ -5763,6 +5809,12 @@ void Client::unmount()
   }
 
   _ll_drop_pins();
+
+  if (blacklisted) {
+    ldout(cct, 0) << " skipping clean shutdown, we are blacklisted" << dendl;
+    mounted = false;
+    return;
+  }
 
   while (unsafe_sync_write > 0) {
     ldout(cct, 0) << unsafe_sync_write << " unsafe_sync_writes, waiting"  << dendl;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -388,6 +388,7 @@ protected:
   bool   initialized;
   bool   mounted;
   bool   unmounting;
+  bool   blacklisted;
 
   // When an MDS has sent us a REJECT, remember that and don't
   // contact it again.  Remember which inst rejected us, so that

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -511,7 +511,11 @@ OPTION(mds_beacon_interval, OPT_FLOAT, 4)
 OPTION(mds_beacon_grace, OPT_FLOAT, 15)
 OPTION(mds_enforce_unique_name, OPT_BOOL, true)
 OPTION(mds_blacklist_interval, OPT_FLOAT, 24.0*60.0)  // how long to blacklist failed nodes
+
 OPTION(mds_session_timeout, OPT_FLOAT, 60)    // cap bits and leases time out if client idle
+OPTION(mds_session_blacklist_on_timeout, OPT_BOOL, true)    // whether to blacklist clients whose sessions are dropped due to timeout
+OPTION(mds_session_blacklist_on_evict, OPT_BOOL, true)  // whether to blacklist clients whose sessions are dropped via admin commands
+
 OPTION(mds_sessionmap_keys_per_op, OPT_U32, 1024)    // how many sessions should I try to load/store in a single OMAP operation?
 OPTION(mds_revoke_cap_timeout, OPT_FLOAT, 60)    // detect clients which aren't revoking caps
 OPTION(mds_recall_state_timeout, OPT_FLOAT, 60)    // detect clients which aren't trimming caps

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -661,7 +661,13 @@ COMMAND("cpu_profiler " \
 COMMAND("session ls " \
 	"name=filters,type=CephString,n=N,req=false",
 	"List client sessions", "mds", "r", "cli,rest")
+COMMAND("client ls " \
+	"name=filters,type=CephString,n=N,req=false",
+	"List client sessions", "mds", "r", "cli,rest")
 COMMAND("session evict " \
+	"name=filters,type=CephString,n=N,req=false",
+	"Evict client session(s)", "mds", "rw", "cli,rest")
+COMMAND("client evict " \
 	"name=filters,type=CephString,n=N,req=false",
 	"Evict client session(s)", "mds", "rw", "cli,rest")
 COMMAND("damage ls",

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -774,7 +774,8 @@ int MDSDaemon::_handle_command(
     int64_t session_id = 0;
     bool got = cmd_getval(cct, cmdmap, "session_id", session_id);
     assert(got);
-    bool killed = mds_rank->kill_session(session_id, false, ss);
+    bool killed = mds_rank->kill_session(session_id, false,
+        g_conf->mds_session_blacklist_on_evict, ss);
     if (!killed)
       r = -ENOENT;
   } else if (prefix == "heap") {

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -774,8 +774,9 @@ int MDSDaemon::_handle_command(
     int64_t session_id = 0;
     bool got = cmd_getval(cct, cmdmap, "session_id", session_id);
     assert(got);
-    bool killed = mds_rank->kill_session(session_id, false,
-        g_conf->mds_session_blacklist_on_evict, ss);
+    bool killed = mds_rank->evict_client(session_id, false,
+                                         g_conf->mds_session_blacklist_on_evict,
+                                         ss);
     if (!killed)
       r = -ENOENT;
   } else if (prefix == "heap") {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2795,7 +2795,7 @@ bool MDSRankDispatcher::handle_command(
   std::string prefix;
   cmd_getval(g_ceph_context, cmdmap, "prefix", prefix);
 
-  if (prefix == "session ls") {
+  if (prefix == "session ls" || prefix == "client ls") {
     std::vector<std::string> filter_args;
     cmd_getval(g_ceph_context, cmdmap, "filters", filter_args);
 
@@ -2810,7 +2810,7 @@ bool MDSRankDispatcher::handle_command(
     f->flush(*ds);
     delete f;
     return true;
-  } else if (prefix == "session evict") {
+  } else if (prefix == "session evict" || prefix == "client evict") {
     std::vector<std::string> filter_args;
     cmd_getval(g_ceph_context, cmdmap, "filters", filter_args);
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -975,9 +975,6 @@ void MDSRank::set_osd_epoch_barrier(epoch_t e)
   osd_epoch_barrier = e;
 }
 
-/**
- * FIXME ugly call up to MDS daemon until the dispatching is separated out
- */
 void MDSRank::retry_dispatch(Message *m)
 {
   inc_dispatch_depth();

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -406,7 +406,7 @@ class MDSRank {
       return map_targets.count(rank);
     }
 
-    bool kill_session(int64_t session_id, bool wait, bool blacklist,
+    bool evict_client(int64_t session_id, bool wait, bool blacklist,
                       std::stringstream& ss, Context *on_killed=nullptr);
 
   protected:
@@ -549,7 +549,7 @@ public:
     bool *need_reply);
 
   void dump_sessions(const SessionFilter &filter, Formatter *f) const;
-  void evict_sessions(const SessionFilter &filter, MCommand *m);
+  void evict_clients(const SessionFilter &filter, MCommand *m);
 
   // Call into me from MDS::ms_dispatch
   bool ms_dispatch(Message *m);

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -406,6 +406,9 @@ class MDSRank {
       return map_targets.count(rank);
     }
 
+    bool kill_session(int64_t session_id, bool wait, bool blacklist,
+                      std::stringstream& ss, Context *on_killed=nullptr);
+
   protected:
     void dump_clientreplay_status(Formatter *f) const;
     void command_scrub_path(Formatter *f, const string& path, vector<string>& scrubop_vec);
@@ -535,7 +538,6 @@ public:
                            Formatter *f, std::ostream& ss);
   void handle_mds_map(MMDSMap *m, MDSMap *oldmap);
   void handle_osd_map();
-  bool kill_session(int64_t session_id, bool wait, std::stringstream& ss);
   void update_log_config();
 
   bool handle_command(

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -760,8 +760,8 @@ void Server::find_idle_sessions()
 
     if (g_conf->mds_session_blacklist_on_timeout) {
       std::stringstream ss;
-      mds->kill_session(session->info.inst.name.num(), false, true,
-          ss, nullptr);
+      mds->evict_client(session->info.inst.name.num(), false, true,
+                        ss, nullptr);
     } else {
       kill_session(session, NULL);
     }
@@ -1025,7 +1025,8 @@ void Server::reconnect_tick()
 
       if (g_conf->mds_session_blacklist_on_timeout) {
         std::stringstream ss;
-        mds->kill_session(session->info.inst.name.num(), false, true, ss, gather.new_sub());
+        mds->evict_client(session->info.inst.name.num(), false, true, ss,
+                          gather.new_sub());
       } else {
         kill_session(session, NULL);
       }

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -753,8 +753,8 @@ void Server::find_idle_sessions()
   for (const auto &session: to_evict) {
     utime_t age = now;
     age -= session->last_cap_renew;
-    mds->clog->info() << "closing stale session " << session->info.inst
-	<< " after " << age;
+    mds->clog->warn() << "evicting unresponsive client " << *session
+                      << ", after " << age << " seconds";
     dout(10) << "autoclosing stale session " << session->info.inst << " last "
              << session->last_cap_renew << dendl;
 
@@ -1022,6 +1022,10 @@ void Server::reconnect_tick()
       Session *session = mds->sessionmap.get_session(entity_name_t::CLIENT(p->v));
       assert(session);
       dout(1) << "reconnect gave up on " << session->info.inst << dendl;
+
+      mds->clog->warn() << "evicting unresponsive client " << *session
+                        << ", after waiting " << g_conf->mds_reconnect_timeout
+                        << " seconds during MDS startup";
 
       if (g_conf->mds_session_blacklist_on_timeout) {
         std::stringstream ss;

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -122,6 +122,7 @@ public:
   void terminate_sessions();
   void find_idle_sessions();
   void kill_session(Session *session, Context *on_safe);
+  size_t apply_blacklist(const std::set<entity_addr_t> &blacklist);
   void journal_close_session(Session *session, int state, Context *on_safe);
   void reconnect_clients(MDSInternalContext *reconnect_done_);
   void handle_client_reconnect(class MClientReconnect *m);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -80,6 +80,8 @@ private:
   // State for while in reconnect
   MDSInternalContext *reconnect_done;
   int failed_reconnects;
+  bool reconnect_evicting;  // true if I am waiting for evictions to complete
+                            // before proceeding to reconnect_gather_finish
 
   friend class MDSContinuation;
   friend class ServerContext;

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -165,6 +165,7 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R));
     // This command grant is checked explicitly in MRemoveSnaps handling
     profile_grants.push_back(MonCapGrant("osd pool rmsnap"));
+    profile_grants.push_back(MonCapGrant("osd blacklist"));
     profile_grants.push_back(MonCapGrant("log", MON_CAP_W));
   }
   if (profile == "mgr") {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1017,6 +1017,13 @@ void OSDMap::get_blacklist(list<pair<entity_addr_t,utime_t> > *bl) const
    std::copy(blacklist.begin(), blacklist.end(), std::back_inserter(*bl));
 }
 
+void OSDMap::get_blacklist(std::set<entity_addr_t> *bl) const
+{
+  for (const auto &i : blacklist) {
+    bl->insert(i.first);
+  }
+}
+
 void OSDMap::set_max_osd(int m)
 {
   int o = max_osd;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -345,6 +345,7 @@ public:
 
   bool is_blacklisted(const entity_addr_t& a) const;
   void get_blacklist(list<pair<entity_addr_t,utime_t > > *bl) const;
+  void get_blacklist(std::set<entity_addr_t> *bl) const;
 
   string get_cluster_snapshot() const {
     if (cluster_snapshot_epoch == epoch)

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1193,8 +1193,15 @@ private:
   bool honor_osdmap_full;
   bool osdmap_full_try;
 
+  // If this is true, accumulate a set of blacklisted entities
+  // to be drained by consume_blacklist_events.
+  bool blacklist_events_enabled;
+  std::set<entity_addr_t> blacklist_events;
+
 public:
   void maybe_request_map();
+
+  void enable_blacklist_events();
 private:
 
   void _maybe_request_map();
@@ -1980,6 +1987,7 @@ private:
     osdmap(new OSDMap), initialized(0), last_tid(0), client_inc(-1),
     max_linger_id(0), num_in_flight(0), global_op_flags(0),
     keep_balanced_budget(false), honor_osdmap_full(true), osdmap_full_try(false),
+    blacklist_events_enabled(false),
     last_seen_osdmap_version(0), last_seen_pgmap_version(0),
     logger(NULL), tick_event(0), m_request_state_hook(NULL),
     num_homeless_ops(0),
@@ -2073,6 +2081,17 @@ private:
   void handle_osd_map(class MOSDMap *m);
   void wait_for_osd_map();
 
+  /**
+   * Get list of entities blacklisted since this was last called,
+   * and reset the list.
+   *
+   * Uses a std::set because typical use case is to compare some
+   * other list of clients to see which overlap with the blacklisted
+   * addrs.
+   *
+   */
+  void consume_blacklist_events(std::set<entity_addr_t> *events);
+
   int pool_snap_by_name(int64_t poolid,
 			const char *snap_name,
 			snapid_t *snap) const;
@@ -2080,6 +2099,10 @@ private:
 			 pool_snap_info_t *info) const;
   int pool_snap_list(int64_t poolid, vector<uint64_t> *snaps);
 private:
+
+  void emit_blacklist_events(const OSDMap::Incremental &inc);
+  void emit_blacklist_events(const OSDMap &old_osd_map,
+                             const OSDMap &new_osd_map);
 
   // low-level
   void _op_submit(Op *op, shunique_lock& lc, ceph_tid_t *ptid);


### PR DESCRIPTION
This is the big rework/strengthening of eviction:
 * Evicting a client from one MDS daemon evicts it from all
 * Once a client is evicted it cannot reconnect to any MDS daemon
 * Evicted clients are blacklisted in the OSDMap, so they can no longer write data to OSDs
 * Clients notice their own eviction and do some teardown so that they can error out any operations in flight and be unmountable.
