### PR TITLE
qa/workunits/cephtool/test.sh: Be more liberal in testing health-output.

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1426,7 +1426,7 @@ function test_mon_pg()
 
   # Check health status
   ceph osd set-nearfull-ratio .913
-  ceph health | grep 'HEALTH_ERR Full ratio(s) out of order'
+  ceph health | grep 'ratio(s) out of order'
   ceph health detail | grep 'backfill_ratio (0.912) < nearfull_ratio (0.913), increased'
   ceph osd set-nearfull-ratio .892
   ceph osd set-backfillfull-ratio .963


### PR DESCRIPTION
Sometimes I get output like:
   HEALTH_ERR 2 pgs stuck unclean; Full ratio(s) out of order

Which goes away over time. So it is a transit issue

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>