### PR TITLE
librbd: corrected resize RPC message backwards compatibility

### DIFF
--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -165,14 +165,14 @@ void AsyncCompletePayload::dump(Formatter *f) const {
 }
 
 void ResizePayload::encode(bufferlist &bl) const {
-  AsyncRequestPayloadBase::encode(bl);
   ::encode(size, bl);
+  AsyncRequestPayloadBase::encode(bl);
   ::encode(allow_shrink, bl);
 }
 
 void ResizePayload::decode(__u8 version, bufferlist::iterator &iter) {
-  AsyncRequestPayloadBase::decode(version, iter);
   ::decode(size, iter);
+  AsyncRequestPayloadBase::decode(version, iter);
 
   if (version >= 4) {
     ::decode(allow_shrink, iter);


### PR DESCRIPTION
Commit d1f2c557 incorrectly changed the order of variables within
the payload. This resulted in breaking the resize RPC message
with older versions of Ceph.

Fixes: http://tracker.ceph.com/issues/19636
Signed-off-by: Jason Dillaman <dillaman@redhat.com>