### PR TITLE
kraken: librbd: corrected resize RPC message backwards compatibility

### DIFF
--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -208,14 +208,14 @@ void AsyncCompletePayload::dump(Formatter *f) const {
 }
 
 void ResizePayload::encode(bufferlist &bl) const {
-  AsyncRequestPayloadBase::encode(bl);
   ::encode(size, bl);
+  AsyncRequestPayloadBase::encode(bl);
   ::encode(allow_shrink, bl);
 }
 
 void ResizePayload::decode(__u8 version, bufferlist::iterator &iter) {
-  AsyncRequestPayloadBase::decode(version, iter);
   ::decode(size, iter);
+  AsyncRequestPayloadBase::decode(version, iter);
 
   if (version >= 4) {
     ::decode(allow_shrink, iter);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19659