### PR TITLE
tests: upgrade:hammer-x/f-h-x-offline: 'failed to encode ...' warnings are normal on upgrades

### DIFF
--- a/qa/suites/upgrade/hammer-x/f-h-x-offline/0-install.yaml
+++ b/qa/suites/upgrade/hammer-x/f-h-x-offline/0-install.yaml
@@ -11,3 +11,4 @@ tasks:
     fs: xfs
     log-whitelist:
     - reached quota
+    - failed to encode


### PR DESCRIPTION
The upgrade/hammer-x/f-h-x-offline test failed with "cluster [WRN] failed to
encode map e853 with expected crc" in cluster log'" in jewel integration
testing.

This has already been fixed in other tests - see referenced tracker issue.

References: http://tracker.ceph.com/issues/12973
Signed-off-by: Nathan Cutler <ncutler@suse.com>