### PR TITLE
yasm-wrapper: strip -E (stops ccache trashing source files)

### DIFF
--- a/src/yasm-wrapper
+++ b/src/yasm-wrapper
@@ -12,7 +12,7 @@ while [ -n "$*" ]; do
 	    new="$new -f $1"
 	    shift
 	    ;;
-	-g* | -f* | -W* | -MD | -MP | -fPIC | -c | -D* | --param* | -O* | -m* | -pipe | ggc-min* )
+	-g* | -f* | -W* | -MD | -MP | -fPIC | -c | -D* | -E | --param* | -O* | -m* | -pipe | ggc-min* )
 	    shift
 	    ;;
 	-I | -isystem )


### PR DESCRIPTION
When building with ccache (`./do_cmake.sh -DWITH_CCACHE=ON`), it seems
ccache invokes `yast-wrapper` more than once per source file, the first
time with '-E' immediately before the source file in the argument list.
'-E' is an option for gcc which tells it to stop after the preprocessing
stage.  With yasm however, -E means "redirect error messages to file",
which makes yasm thinks there's no input files, and writes "yasm: No input
files specified" *over* the source file.  Then, the second run of
`yast-wrapper` (attempting to actually compile) fails with:

~/src/common/crc32c_intel_fast_asm.S:1: error: instruction expected after label

Curiously, this doesn't seem to affect all asm files; for me it
trashes crc32c_intel_fast_asm.S, but various other asm files build fine
without being clobbered.  I'm uncertain whether this is an issue
peculiar to openSUSE Tumbleweed, to ccache 3.3.3, or something else,
but in any case, having `yast-wrapper` strip '-E' fixes it.

Signed-off-by: Tim Serong <tserong@suse.com>