### PR TITLE
qa/workunits/ceph-helpers.sh: introduce (and use) wait_for_health

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1267,6 +1267,48 @@ function test_wait_for_clean() {
 #######################################################################
 
 ##
+# Wait until the cluster becomes HEALTH_OK again or if it does not make progress
+# for $TIMEOUT seconds.
+#
+# @return 0 if the cluster is HEALTHY, 1 otherwise
+#
+function wait_for_health() {
+    local grepstr=$1
+    local -a delays=($(get_timeout_delays $TIMEOUT .1))
+    local -i loop=0
+
+    while ! ceph health detail | grep "$grepstr" ; do
+        ceph health detail
+	if (( $loop >= ${#delays[*]} )) ; then
+            return 1
+        fi
+        sleep ${delays[$loop]}
+        loop+=1
+    done    
+    return 0
+}
+
+function wait_for_health_ok() {
+     wait_for_health "HEALTH_OK" || return 1
+     return 0
+} 
+
+function test_wait_for_health_ok() {
+    local dir=$1
+
+    setup $dir || return 1
+    run_mon $dir a --osd_pool_default_size=1 || return 1
+    run_mgr $dir x || return 1
+    ! TIMEOUT=1 wait_for_health_ok || return 1
+    run_osd $dir 0 || return 1
+    wait_for_health_ok || return 1
+    teardown $dir || return 1
+}
+
+
+#######################################################################
+
+##
 # Run repair on **pgid** and wait until it completes. The repair
 # function will fail if repair does not complete within $TIMEOUT
 # seconds.

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1371,6 +1371,9 @@ function test_mon_osd_pool_quota()
 
 function test_mon_pg()
 {
+  # Make sure we start healthy.
+  wait_for_health_ok
+
   ceph pg debug unfound_objects_exist
   ceph pg debug degraded_pgs_exist
   ceph pg deep-scrub 0.0
@@ -1434,7 +1437,6 @@ function test_mon_pg()
   ceph osd set-backfillfull-ratio .912
 
   # Check injected full results
-  WAITFORFULL=10
   ceph --admin-daemon $CEPH_OUT_DIR/osd.0.asok injectfull nearfull
   wait_for_health "HEALTH_WARN.*1 nearfull osd(s)"
   ceph --admin-daemon $CEPH_OUT_DIR/osd.1.asok injectfull backfillfull

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1426,7 +1426,7 @@ function test_mon_pg()
 
   # Check health status
   ceph osd set-nearfull-ratio .913
-  ceph health | grep 'ratio(s) out of order'
+  ceph health | grep 'HEALTH_ERR Full ratio(s) out of order'
   ceph health detail | grep 'backfill_ratio (0.912) < nearfull_ratio (0.913), increased'
   ceph osd set-nearfull-ratio .892
   ceph osd set-backfillfull-ratio .963
@@ -1436,26 +1436,21 @@ function test_mon_pg()
   # Check injected full results
   WAITFORFULL=10
   ceph --admin-daemon $CEPH_OUT_DIR/osd.0.asok injectfull nearfull
-  sleep $WAITFORFULL
-  ceph health | grep "HEALTH_WARN.*1 nearfull osd(s)"
+  wait_for_health "HEALTH_WARN.*1 nearfull osd(s)"
   ceph --admin-daemon $CEPH_OUT_DIR/osd.1.asok injectfull backfillfull
-  sleep $WAITFORFULL
-  ceph health | grep "HEALTH_WARN.*1 backfillfull osd(s)"
+  wait_for_health "HEALTH_WARN.*1 backfillfull osd(s)"
   ceph --admin-daemon $CEPH_OUT_DIR/osd.2.asok injectfull failsafe
-  sleep $WAITFORFULL
   # failsafe and full are the same as far as the monitor is concerned
-  ceph health | grep "HEALTH_ERR.*1 full osd(s)"
+  wait_for_health "HEALTH_ERR.*1 full osd(s)"
   ceph --admin-daemon $CEPH_OUT_DIR/osd.0.asok injectfull full
-  sleep  $WAITFORFULL
-  ceph health | grep "HEALTH_ERR.*2 full osd(s)"
+  wait_for_health "HEALTH_ERR.*2 full osd(s)"
   ceph health detail | grep "osd.0 is full at.*%"
   ceph health detail | grep "osd.2 is full at.*%"
   ceph health detail | grep "osd.1 is backfill full at.*%"
   ceph --admin-daemon $CEPH_OUT_DIR/osd.0.asok injectfull none
   ceph --admin-daemon $CEPH_OUT_DIR/osd.1.asok injectfull none
   ceph --admin-daemon $CEPH_OUT_DIR/osd.2.asok injectfull none
-  sleep $WAITFORFULL
-  ceph health | grep HEALTH_OK
+  wait_for_health_ok
 
   ceph pg stat | grep 'pgs:'
   ceph pg 0.0 query


### PR DESCRIPTION
- Use it in qa/workunits/cephtool/test.sh to reduce the fixed waiting

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>