### PR TITLE
osdc: remove journaler_allow_split_entries option

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -30,6 +30,7 @@
   to zero will effectively disable the health check.
 * The "ceph mds tell ..." command has been removed.  It is superceded
   by "ceph tell mds.<id> ..."
+* The "journaler allow split entries" config setting has been removed.
 
 12.0.0
 ------

--- a/doc/cephfs/journaler.rst
+++ b/doc/cephfs/journaler.rst
@@ -2,14 +2,6 @@
  Journaler
 ===========
 
-``journaler allow split entries``
-
-:Description: Allow an entry to span a stripe boundary
-:Type: Boolean
-:Required: No
-:Default: ``true``
-
-
 ``journaler write head interval``
 
 :Description: How frequently to update the journal head object

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -488,7 +488,6 @@ OPTION(objecter_debug_inject_relock_delay, OPT_BOOL, false)
 // Max number of deletes at once in a single Filer::purge call
 OPTION(filer_max_purge_ops, OPT_U32, 10)
 
-OPTION(journaler_allow_split_entries, OPT_BOOL, true)
 OPTION(journaler_write_head_interval, OPT_INT, 15)
 OPTION(journaler_prefetch_periods, OPT_INT, 10)   // * journal object size
 OPTION(journaler_prezero_periods, OPT_INT, 5)     // * journal object size

--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -542,41 +542,6 @@ uint64_t Journaler::append_entry(bufferlist& bl)
   assert(!readonly);
   uint32_t s = bl.length();
 
-  if (!cct->_conf->journaler_allow_split_entries) {
-    // will we span a stripe boundary?
-    int p = layout.stripe_unit;
-    if (write_pos / p != (write_pos + (int64_t)(bl.length() + sizeof(s))) / p) {
-      // yes.
-      // move write_pos forward.
-      int64_t owp = write_pos;
-      write_pos += p;
-      write_pos -= (write_pos % p);
-
-      // pad with zeros.
-      bufferptr bp(write_pos - owp);
-      bp.zero();
-      assert(bp.length() >= 4);
-      if (!write_buf_throttle.get_or_fail(bp.length())) {
-        l.unlock();
-        ldout(cct, 10) << "write_buf_throttle wait, bp len " 
-                       << bp.length() << dendl;
-        write_buf_throttle.get(bp.length());
-        l.lock();
-      }
-      ldout(cct, 20) << "write_buf_throttle get, bp len " 
-                     << bp.length() << dendl;
-      write_buf.push_back(bp);
-
-      // now flush.
-      flush();
-
-      ldout(cct, 12) << "append_entry skipped " << (write_pos-owp)
-		     << " bytes to " << write_pos
-		     << " to avoid spanning stripe boundary" << dendl;
-    }
-  }
-
-
   // append
   size_t delta = bl.length() + journal_stream.get_envelope_size();
   // write_buf space is nearly full


### PR DESCRIPTION
This had been broken for some time, as since the new
JournalStream stuff, zero padding was no longer a valid
encoding.

Fixes: http://tracker.ceph.com/issues/19691
Signed-off-by: John Spray <john.spray@redhat.com>