### PR TITLE
test/osd/osd-dup.sh: warn on low open file limit

### DIFF
--- a/src/test/osd/osd-dup.sh
+++ b/src/test/osd/osd-dup.sh
@@ -23,6 +23,11 @@ function run() {
 function TEST_filestore_to_bluestore() {
     local dir=$1
 
+    local flimit=$(ulimit -n)
+    if [ $flimit -lt 1536 ]; then
+        echo "Low open file limit ($flimit), test may fail. Increase to 1536 or higher and retry if that happens."
+    fi
+
     run_mon $dir a || return 1
     run_osd $dir 0 || return 1
     osd_pid=$(cat $dir/osd.0.pid)


### PR DESCRIPTION
This test fails badly when open file limit is low. Increasing it to around 1536 seems to be doing the trick, so warn the user with appropriate message and try to proceed anyway.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>