### PR TITLE
rgw: error more verbosely in RGWRados::create_pool

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5307,6 +5307,13 @@ int RGWRados::create_pool(const rgw_pool& pool)
   ret = rad->pool_create(pool.name.c_str(), 0);
   if (ret == -EEXIST)
     ret = 0;
+  else if (ret == -ERANGE) {
+    ldout(cct, 0)
+      << __func__
+      << " ERROR: librados::Rados::pool_create returned " << cpp_strerror(-ret)
+      << " (this can be due to a pool or placement group misconfiguration, e.g., pg_num < pgp_num)"
+      << dendl;
+  }
   if (ret < 0)
     return ret;
 


### PR DESCRIPTION
Adds detail when pool creation fails with ERANGE, which can be
caused by pool settings.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>