### PR TITLE
mon/MgrMonitor: only propose if we updated

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -236,7 +236,7 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
     dout(10) << "no change" << dendl;
   }
 
-  return true;
+  return updated;
 }
 
 void MgrMonitor::check_subs()


### PR DESCRIPTION
Otherwise we generate a new map on every beacon, even
though there is no change.

Signed-off-by: Sage Weil <sage@redhat.com>