### PR TITLE
mds: remove "mds log" config option

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -164,15 +164,6 @@
 :Default: ``2`` (i.e., rjenkins)
 
 
-``mds log``
-
-:Description: Set to ``true`` if the MDS should journal metadata updates 
-              (disabled for benchmarking only).
-              
-:Type:  Boolean
-:Default: ``true``
-
-
 ``mds log skip corrupt events``
 
 :Description: Determines whether the MDS should try to skip corrupt journal 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -522,7 +522,6 @@ OPTION(mds_scatter_nudge_interval, OPT_FLOAT, 5)  // how quickly dirstat changes
 OPTION(mds_client_prealloc_inos, OPT_INT, 1000)
 OPTION(mds_early_reply, OPT_BOOL, true)
 OPTION(mds_default_dir_hash, OPT_INT, CEPH_STR_HASH_RJENKINS)
-OPTION(mds_log, OPT_BOOL, true)
 OPTION(mds_log_pause, OPT_BOOL, false)
 OPTION(mds_log_skip_corrupt_events, OPT_BOOL, false)
 OPTION(mds_log_max_events, OPT_INT, -1)

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -280,14 +280,6 @@ void MDLog::_submit_entry(LogEvent *le, MDSLogContextBase *c)
   assert(le == cur_event);
   cur_event = NULL;
 
-  if (!g_conf->mds_log) {
-    // hack: log is disabled.
-    if (c) {
-      mds->finisher->queue(c, 0);
-    }
-    return;
-  }
-
   // let the event register itself in the segment
   assert(!segments.empty());
   LogSegment *ls = segments.rbegin()->second;
@@ -446,12 +438,6 @@ void MDLog::_submit_thread()
 
 void MDLog::wait_for_safe(MDSInternalContextBase *c)
 {
-  if (!g_conf->mds_log) {
-    // hack: bypass.
-    c->complete(0);
-    return;
-  }
-
   submit_mutex.Lock();
 
   bool no_pending = true;


### PR DESCRIPTION
This was occasionally useful for establishing a journal-less
performance baseline, but it has two big problems:
* We don't test it, so it's probably broken a lot of the time
* It sounds a lot to a naive user like an option for controlling
  logging.

IMO, anyone who wants this behaviour is in sufficiently advanced
territory that then can hack it in and recompile, we don't need
to leave dangerous things like this in our releases.

Fixes: http://tracker.ceph.com/issues/18816
Signed-off-by: John Spray <john.spray@redhat.com>