### PR TITLE
test: migrate atomic_t to std::atomic

### DIFF
--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -4,12 +4,14 @@
 #ifndef CEPH_TEST_IO_CTX_IMPL_H
 #define CEPH_TEST_IO_CTX_IMPL_H
 
+#include <list>
+#include <atomic>
+
+#include <boost/function.hpp>
+
 #include "include/rados/librados.hpp"
-#include "include/atomic.h"
 #include "include/Context.h"
 #include "common/snap_types.h"
-#include <boost/function.hpp>
-#include <list>
 
 namespace librados {
 
@@ -30,7 +32,7 @@ public:
 
   ObjectOperations ops;
 private:
-  atomic_t m_refcount;
+  std::atomic<uint64_t> m_refcount = { 0 };
 };
 
 class TestIoCtxImpl {
@@ -179,8 +181,8 @@ private:
   std::string m_pool_name;
   snap_t m_snap_seq;
   SnapContext m_snapc;
-  atomic_t m_refcount;
-  atomic_t m_pending_ops;
+  std::atomic<uint64_t> m_refcount = { 0 };
+  std::atomic<uint64_t> m_pending_ops = { 0 };
 
   void handle_aio_notify_complete(AioCompletionImpl *aio_comp, int r);
 };

--- a/src/test/librados_test_stub/TestRadosClient.h
+++ b/src/test/librados_test_stub/TestRadosClient.h
@@ -4,17 +4,19 @@
 #ifndef CEPH_TEST_RADOS_CLIENT_H
 #define CEPH_TEST_RADOS_CLIENT_H
 
-#include "include/rados/librados.hpp"
-#include "common/config.h"
-#include "include/atomic.h"
-#include "include/buffer_fwd.h"
-#include "test/librados_test_stub/TestWatchNotify.h"
-#include <boost/function.hpp>
-#include <boost/functional/hash.hpp>
-#include <list>
 #include <map>
+#include <list>
 #include <string>
 #include <vector>
+#include <atomic>
+
+#include <boost/function.hpp>
+#include <boost/functional/hash.hpp>
+
+#include "include/rados/librados.hpp"
+#include "common/config.h"
+#include "include/buffer_fwd.h"
+#include "test/librados_test_stub/TestWatchNotify.h"
 
 class Finisher;
 
@@ -113,7 +115,7 @@ protected:
 private:
 
   CephContext *m_cct;
-  atomic_t m_refcount;
+  std::atomic<uint64_t> m_refcount = { 0 };
 
   TestWatchNotify *m_watch_notify;
 

--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -22,13 +22,14 @@
 
 using namespace std;
 
-#include "include/atomic.h"
 #include "common/ceph_argparse.h"
 #include "common/debug.h"
 #include "common/Cycles.h"
 #include "global/global_init.h"
 #include "msg/Messenger.h"
 #include "messages/MOSDOp.h"
+
+#include <atomic>
 
 class MessengerClient {
   class ClientThread;
@@ -67,7 +68,7 @@ class MessengerClient {
     Messenger *msgr;
     int concurrent;
     ConnectionRef conn;
-    atomic_t client_inc;
+    std::atomic<unsigned> client_inc = { 0 };
     object_t oid;
     object_locator_t oloc;
     pg_t pgid;
@@ -82,7 +83,7 @@ class MessengerClient {
     uint64_t inflight;
 
     ClientThread(Messenger *m, int c, ConnectionRef con, int len, int ops, int think_time_us):
-        msgr(m), concurrent(c), conn(con), client_inc(0), oid("object-name"), oloc(1, 1), msg_len(len), ops(ops),
+        msgr(m), concurrent(c), conn(con), oid("object-name"), oloc(1, 1), msg_len(len), ops(ops),
         dispatcher(think_time_us, this), lock("MessengerBenchmark::ClientThread::lock") {
       m->add_dispatcher_head(&dispatcher);
       bufferptr ptr(msg_len);
@@ -98,7 +99,7 @@ class MessengerClient {
 	hobject_t hobj(oid, oloc.key, CEPH_NOSNAP, pgid.ps(), pgid.pool(),
 		       oloc.nspace);
 	spg_t spgid(pgid);
-        MOSDOp *m = new MOSDOp(client_inc.read(), 0, hobj, spgid, 0, 0, 0);
+        MOSDOp *m = new MOSDOp(client_inc, 0, hobj, spgid, 0, 0, 0);
         m->write(0, msg_len, data);
         inflight++;
         conn->send_message(m);

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -22,7 +22,6 @@
 
 using namespace std;
 
-#include "include/atomic.h"
 #include "common/ceph_argparse.h"
 #include "common/debug.h"
 #include "global/global_init.h"

--- a/src/test/msgr/test_async_driver.cc
+++ b/src/test/msgr/test_async_driver.cc
@@ -24,12 +24,13 @@
 #include <stdint.h>
 #include <arpa/inet.h>
 #include "include/Context.h"
-#include "include/atomic.h"
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "global/global_init.h"
 #include "common/ceph_argparse.h"
 #include "msg/async/Event.h"
+
+#include <atomic>
 
 // We use epoll, kqueue, evport, select in descending order by performance.
 #if defined(__linux__)
@@ -293,15 +294,15 @@ class Worker : public Thread {
 };
 
 class CountEvent: public EventCallback {
-  atomic_t *count;
+  std::atomic<unsigned> *count;
   Mutex *lock;
   Cond *cond;
 
  public:
-  CountEvent(atomic_t *atomic, Mutex *l, Cond *c): count(atomic), lock(l), cond(c) {}
+  CountEvent(std::atomic<unsigned> *atomic, Mutex *l, Cond *c): count(atomic), lock(l), cond(c) {}
   void do_request(int id) override {
     lock->Lock();
-    count->dec();
+    (*count)--;
     cond->Signal();
     lock->Unlock();
   }
@@ -309,18 +310,18 @@ class CountEvent: public EventCallback {
 
 TEST(EventCenterTest, DispatchTest) {
   Worker worker1(g_ceph_context, 1), worker2(g_ceph_context, 2);
-  atomic_t count(0);
+  std::atomic<unsigned> count = { 0 };
   Mutex lock("DispatchTest::lock");
   Cond cond;
   worker1.create("worker_1");
   worker2.create("worker_2");
   for (int i = 0; i < 10000; ++i) {
-    count.inc();
+    count++;
     worker1.center.dispatch_event_external(EventCallbackRef(new CountEvent(&count, &lock, &cond)));
-    count.inc();
+    count++;
     worker2.center.dispatch_event_external(EventCallbackRef(new CountEvent(&count, &lock, &cond)));
     Mutex::Locker l(lock);
-    while (count.read())
+    while (count)
       cond.Wait(lock);
   }
   worker1.stop();

--- a/src/test/objectstore/TestObjectStoreState.cc
+++ b/src/test/objectstore/TestObjectStoreState.cc
@@ -77,7 +77,7 @@ void TestObjectStoreState::init(int colls, int objs)
     m_collections_ids.push_back(coll_id);
     m_next_coll_nr++;
   }
-  dout(5) << "init has " << m_in_flight.read() << "in-flight transactions" << dendl;
+  dout(5) << "init has " << m_in_flight.load() << "in-flight transactions" << dendl;
   wait_for_done();
   dout(5) << "init finished" << dendl;
 }

--- a/src/test/objectstore/TestObjectStoreState.h
+++ b/src/test/objectstore/TestObjectStoreState.h
@@ -65,19 +65,19 @@ public:
   int m_num_objects;
 
   int m_max_in_flight;
-  atomic_t m_in_flight;
+  std::atomic<int> m_in_flight = { 0 };
   Mutex m_finished_lock;
   Cond m_finished_cond;
 
   void wait_for_ready() {
     Mutex::Locker locker(m_finished_lock);
-    while ((m_max_in_flight > 0) && ((int)m_in_flight.read() >= m_max_in_flight))
+    while ((m_max_in_flight > 0) && (m_in_flight >= m_max_in_flight))
       m_finished_cond.Wait(m_finished_lock);
   }
 
   void wait_for_done() {
     Mutex::Locker locker(m_finished_lock);
-    while (m_in_flight.read())
+    while (m_in_flight)
       m_finished_cond.Wait(m_finished_lock);
   }
 
@@ -101,7 +101,6 @@ public:
   explicit TestObjectStoreState(ObjectStore *store) :
     m_next_coll_nr(0), m_num_objs_per_coll(10), m_num_objects(0),
     m_max_in_flight(0), m_finished_lock("Finished Lock"), m_next_pool(1) {
-    m_in_flight.set(0);
     m_store.reset(store);
   }
   ~TestObjectStoreState() { 
@@ -119,11 +118,11 @@ public:
   }
 
   int inc_in_flight() {
-    return ((int) m_in_flight.inc());
+    return ++m_in_flight;
   }
 
   int dec_in_flight() {
-    return ((int) m_in_flight.dec());
+    return --m_in_flight;
   }
 
   coll_entry_t *coll_create(int id);

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -60,7 +60,7 @@ WorkloadGenerator::WorkloadGenerator(vector<const char*> args)
 {
   int err = 0;
 
-  m_nr_runs.set(0);
+  m_nr_runs = 0;
 
   init_args(args);
   dout(0) << "data            = " << g_conf->osd_data << dendl;
@@ -352,7 +352,7 @@ void WorkloadGenerator::do_destroy_collection(ObjectStore::Transaction *t,
 					      coll_entry_t *entry,
 					      C_StatState *stat)
 {  
-  m_nr_runs.set(0);
+  m_nr_runs = 0;
   entry->m_osr.flush();
   vector<ghobject_t> ls;
   m_store->collection_list(entry->m_coll, ghobject_t(), ghobject_t::get_max(),
@@ -431,7 +431,7 @@ void WorkloadGenerator::run()
 
     dout(5) << __func__
         << " m_finished_lock is-locked: " << m_finished_lock.is_locked()
-        << " in-flight: " << m_in_flight.read()
+        << " in-flight: " << m_in_flight.load()
         << dendl;
 
     wait_for_ready();
@@ -502,7 +502,7 @@ queue_tx:
   } while (true);
 
   dout(2) << __func__ << " waiting for "
-	  << m_in_flight.read() << " in-flight transactions" << dendl;
+	  << m_in_flight.load() << " in-flight transactions" << dendl;
 
   wait_for_done();
 

--- a/src/test/objectstore/workload_generator.h
+++ b/src/test/objectstore/workload_generator.h
@@ -17,10 +17,12 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
-#include <map>
 #include <sys/time.h>
 
 #include "TestObjectStoreState.h"
+
+#include <map>
+#include <atomic>
 
 typedef boost::mt11213b rngen_t;
 
@@ -57,7 +59,7 @@ class WorkloadGenerator : public TestObjectStoreState {
   int m_max_in_flight;
   int m_num_ops;
   int m_destroy_coll_every_nr_runs;
-  atomic_t m_nr_runs;
+  std::atomic<int> m_nr_runs = { 0 };
 
   int m_num_colls;
 
@@ -110,7 +112,7 @@ class WorkloadGenerator : public TestObjectStoreState {
 
   bool should_destroy_collection() {
     return ((m_destroy_coll_every_nr_runs > 0) &&
-        ((int)m_nr_runs.read() >= m_destroy_coll_every_nr_runs));
+        (m_nr_runs >= m_destroy_coll_every_nr_runs));
   }
   void do_destroy_collection(ObjectStore::Transaction *t, coll_entry_t *entry,
       C_StatState *stat);
@@ -135,7 +137,7 @@ public:
     void finish(int r) override
     {
       TestObjectStoreState::C_OnFinished::finish(r);
-      wrkldgen_state->m_nr_runs.inc();
+      wrkldgen_state->m_nr_runs++;
     }
   };
 

--- a/src/test/osdc/FakeWriteback.cc
+++ b/src/test/osdc/FakeWriteback.cc
@@ -84,7 +84,7 @@ ceph_tid_t FakeWriteback::write(const object_t& oid,
   C_Delay *wrapper = new C_Delay(m_cct, oncommit, m_lock, off, NULL,
 				 m_delay_ns);
   m_finisher->queue(wrapper, 0);
-  return m_tid.inc();
+  return ++m_tid;
 }
 
 bool FakeWriteback::may_copy_on_write(const object_t&, uint64_t, uint64_t,

--- a/src/test/osdc/FakeWriteback.h
+++ b/src/test/osdc/FakeWriteback.h
@@ -3,11 +3,12 @@
 #ifndef CEPH_TEST_OSDC_FAKEWRITEBACK_H
 #define CEPH_TEST_OSDC_FAKEWRITEBACK_H
 
-#include "include/atomic.h"
 #include "include/Context.h"
 #include "include/types.h"
 #include "osd/osd_types.h"
 #include "osdc/WritebackHandler.h"
+
+#include <atomic>
 
 class Finisher;
 class Mutex;
@@ -40,7 +41,7 @@ private:
   CephContext *m_cct;
   Mutex *m_lock;
   uint64_t m_delay_ns;
-  atomic_t m_tid;
+  std::atomic<unsigned> m_tid = { 0 };
   Finisher *m_finisher;
 };
 

--- a/src/test/osdc/MemWriteback.cc
+++ b/src/test/osdc/MemWriteback.cc
@@ -116,7 +116,7 @@ ceph_tid_t MemWriteback::write(const object_t& oid,
   C_DelayWrite *wrapper = new C_DelayWrite(this, m_cct, oncommit, m_lock, oid,
 					   off, len, bl, m_delay_ns);
   m_finisher->queue(wrapper, 0);
-  return m_tid.inc();
+  return ++m_tid;
 }
 
 void MemWriteback::write_object_data(const object_t& oid, uint64_t off, uint64_t len,

--- a/src/test/osdc/MemWriteback.h
+++ b/src/test/osdc/MemWriteback.h
@@ -3,11 +3,12 @@
 #ifndef CEPH_TEST_OSDC_MEMWRITEBACK_H
 #define CEPH_TEST_OSDC_MEMWRITEBACK_H
 
-#include "include/atomic.h"
 #include "include/Context.h"
 #include "include/types.h"
 #include "osd/osd_types.h"
 #include "osdc/WritebackHandler.h"
+
+#include <atomic>
 
 class Finisher;
 class Mutex;
@@ -45,7 +46,7 @@ private:
   CephContext *m_cct;
   Mutex *m_lock;
   uint64_t m_delay_ns;
-  atomic_t m_tid;
+  std::atomic<unsigned> m_tid = { 0 };
   Finisher *m_finisher;
 };
 

--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -14,7 +14,6 @@
 #include "common/Mutex.h"
 #include "common/snap_types.h"
 #include "global/global_init.h"
-#include "include/atomic.h"
 #include "include/buffer.h"
 #include "include/Context.h"
 #include "include/stringify.h"
@@ -22,6 +21,8 @@
 
 #include "FakeWriteback.h"
 #include "MemWriteback.h"
+
+#include <atomic>
 
 // XXX: Only tests default namespace
 struct op_data {
@@ -35,19 +36,19 @@ struct op_data {
   ObjectExtent extent;
   bool is_read;
   ceph::bufferlist result;
-  atomic_t done;
+  std::atomic<unsigned> done = { 0 };
 };
 
 class C_Count : public Context {
   op_data *m_op;
-  atomic_t *m_outstanding;
+  std::atomic<unsigned> *m_outstanding = nullptr;
 public:
-  C_Count(op_data *op, atomic_t *outstanding)
+  C_Count(op_data *op, std::atomic<unsigned> *outstanding)
     : m_op(op), m_outstanding(outstanding) {}
   void finish(int r) override {
-    m_op->done.inc();
-    assert(m_outstanding->read() > 0);
-    m_outstanding->dec();
+    m_op->done++;
+    assert(m_outstanding > 0);
+    *m_outstanding--;
   }
 };
 
@@ -67,7 +68,7 @@ int stress_test(uint64_t num_ops, uint64_t num_objs,
 		   true);
   obc.start();
 
-  atomic_t outstanding_reads;
+  std::atomic<unsigned> outstanding_reads = { 0 };
   vector<ceph::shared_ptr<op_data> > ops;
   ObjectCacher::ObjectSet object_set(NULL, 0, 0);
   SnapContext snapc;
@@ -100,7 +101,7 @@ int stress_test(uint64_t num_ops, uint64_t num_objs,
     if (op->is_read) {
       ObjectCacher::OSDRead *rd = obc.prepare_read(CEPH_NOSNAP, &op->result, 0);
       rd->extents.push_back(op->extent);
-      outstanding_reads.inc();
+      outstanding_reads++;
       Context *completion = new C_Count(op.get(), &outstanding_reads);
       lock.Lock();
       int r = obc.readx(rd, &object_set, completion);
@@ -128,7 +129,7 @@ int stress_test(uint64_t num_ops, uint64_t num_objs,
     std::cout << "waiting for read " << i << ops[i]->extent << std::endl;
     uint64_t done = 0;
     while (done == 0) {
-      done = ops[i]->done.read();
+      done = ops[i]->done;
       if (!done) {
 	usleep(500);
       }

--- a/src/test/system/systest_runnable.cc
+++ b/src/test/system/systest_runnable.cc
@@ -14,7 +14,6 @@
 
 #include "include/compat.h"
 #include "common/errno.h"
-#include "include/atomic.h"
 #include "systest_runnable.h"
 #include "systest_settings.h"
 
@@ -31,6 +30,7 @@
 #include <sys/wait.h>
 #include <unistd.h>
 #include <vector>
+#include <atomic>
 
 using std::ostringstream;
 using std::string;
@@ -44,7 +44,7 @@ static pid_t do_gettid(void)
 #endif
 }
 
-ceph::atomic_t m_highest_id(0);
+std::atomic<unsigned> m_highest_id = { 0 };
 
 SysTestRunnable::
 SysTestRunnable(int argc, const char **argv)
@@ -53,7 +53,7 @@ SysTestRunnable(int argc, const char **argv)
     m_argv_orig(NULL)
 {
   m_started = false;
-  m_id = m_highest_id.inc();
+  m_id = ++m_highest_id;
   memset(&m_pthread, 0, sizeof(m_pthread));
   update_id_str(false);
   set_argv(argc, argv);


### PR DESCRIPTION
The purpose of these PRs is to remove atomic_t, replacing it with the standard library. No new features should be added, and no regressions should be caused. Ultimately, the intent is to entirely remove "include/atomic.h".

The other PRs are:
rgw: 
https://github.com/ceph/ceph/pull/15001

librados,libradosstriper,test: 
https://github.com/ceph/ceph/pull/14658

common,osdc,filestore,test,msg: 
https://github.com/ceph/ceph/pull/14866 

osdc,mds,filestore,librbd,xio,messenger:
https://github.com/ceph/ceph/pull/14657

PR https://github.com/ceph/ceph/pull/14502 is superseded by these PRs.