### PR TITLE
librados,libradosstriper,test: migrate atomic_t to std::atomic (baragon)

### DIFF
--- a/src/librados/IoCtxImpl.h
+++ b/src/librados/IoCtxImpl.h
@@ -15,11 +15,12 @@
 #ifndef CEPH_LIBRADOS_IOCTXIMPL_H
 #define CEPH_LIBRADOS_IOCTXIMPL_H
 
+#include <atomic>
+
 #include "common/Cond.h"
 #include "common/Mutex.h"
 #include "common/snap_types.h"
 #include "common/zipkin_trace.h"
-#include "include/atomic.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
@@ -30,7 +31,7 @@
 class RadosClient;
 
 struct librados::IoCtxImpl {
-  atomic_t ref_cnt;
+  std::atomic<uint64_t> ref_cnt = { 0 };
   RadosClient *client;
   int64_t poolid;
   snapid_t snap_seq;
@@ -69,11 +70,11 @@ struct librados::IoCtxImpl {
   int set_snap_write_context(snapid_t seq, vector<snapid_t>& snaps);
 
   void get() {
-    ref_cnt.inc();
+    ref_cnt++;
   }
 
   void put() {
-    if (ref_cnt.dec() == 0)
+    if (--ref_cnt == 0)
       delete this;
   }
 

--- a/src/libradosstriper/RadosStriperImpl.h
+++ b/src/libradosstriper/RadosStriperImpl.h
@@ -17,8 +17,6 @@
 
 #include <string>
 
-#include "include/atomic.h"
-
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/radosstriper/libradosstriper.h"


### PR DESCRIPTION
refer-to: https://github.com/ceph/ceph/pull/14655