### PR TITLE
jewel: client: fix the cross-quota rename boundary check conditions

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10929,11 +10929,14 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
       return -EROFS;
   }
   if (cct->_conf->client_quota &&
-      fromdir != todir &&
-      (fromdir->quota.is_enable() ||
-       todir->quota.is_enable() ||
-       get_quota_root(fromdir) != get_quota_root(todir))) {
-    return -EXDEV;
+      fromdir != todir) {
+    Inode *fromdir_root =
+      fromdir->quota.is_enable() ? fromdir : get_quota_root(fromdir);
+    Inode *todir_root =
+      todir->quota.is_enable() ? todir : get_quota_root(todir);
+    if (fromdir_root != todir_root) {
+      return -EXDEV;
+    }
   }
 
   InodeRef target;


### PR DESCRIPTION
http://tracker.ceph.com/issues/18699