### PR TITLE
jewel: mds: log rotation doesn't work if mds has respawned

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -15,6 +15,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <pthread.h>
 
 #include <iostream>
 #include <string>
@@ -89,6 +90,8 @@ static void handle_mds_signal(int signum)
 
 int main(int argc, const char **argv) 
 {
+  pthread_setname_np(pthread_self(), "ceph-mds");
+
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
   env_to_vec(args);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19466