### PR TITLE
msg/async/rdma: add rdma local configuration for systemd

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -171,3 +171,7 @@
   versions of Ceph will likely include an alternative object
   enumeration interface that makes it more natural and efficient to
   enumerate all objects along with their snapshot and clone metadata.
+
+* When using ceph systemd services with RDMA, a script is run that adds/removes
+  configurations to the systemd service file. Therefore,the rdma option in the
+  ceph.conf should not be edited before stopping the service.

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -980,6 +980,7 @@ rm -rf %{buildroot}
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mds
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-rgw
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mgr
+%attr(755,root,root) %{_libexecdir}/ceph/systemd-rdma-settings.sh
 
 %post base
 /sbin/ldconfig

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -956,6 +956,7 @@ install(FILES
 install(PROGRAMS
   ceph_common.sh
   ceph-osd-prestart.sh
+  systemd-rdma-settings.sh
   DESTINATION ${CMAKE_INSTALL_LIBEXECDIR}/ceph)
 
 install(PROGRAMS

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -481,7 +481,6 @@ Infiniband::MemoryManager::Chunk::Chunk(ibv_mr* m, uint32_t len, char* b)
 
 Infiniband::MemoryManager::Chunk::~Chunk()
 {
-  assert(ibv_dereg_mr(mr) == 0);
 }
 
 void Infiniband::MemoryManager::Chunk::set_offset(uint32_t o)
@@ -567,10 +566,8 @@ Infiniband::MemoryManager::Cluster::Cluster(MemoryManager& m, uint32_t s)
 
 Infiniband::MemoryManager::Cluster::~Cluster()
 {
-  const auto chunk_end = chunk_base + num_chunk;
-  for (auto chunk = chunk_base; chunk != chunk_end; chunk++) {
-    chunk->~Chunk();
-  }
+  int r = ibv_dereg_mr(chunk_base->mr);
+  assert(r == 0);
 
   ::free(chunk_base);
   if (manager.enabled_huge_page)
@@ -594,10 +591,10 @@ int Infiniband::MemoryManager::Cluster::fill(uint32_t num)
   chunk_base = static_cast<Chunk*>(::malloc(sizeof(Chunk) * num));
   memset(chunk_base, 0, sizeof(Chunk) * num);
   free_chunks.reserve(num);
+  ibv_mr* m = ibv_reg_mr(manager.pd->pd, base, bytes, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE);
+  assert(m);
   Chunk* chunk = chunk_base;
   for (uint32_t offset = 0; offset < bytes; offset += buffer_size){
-    ibv_mr* m = ibv_reg_mr(manager.pd->pd, base+offset, buffer_size, IBV_ACCESS_REMOTE_WRITE | IBV_ACCESS_LOCAL_WRITE);
-    assert(m);
     new(chunk) Chunk(m, buffer_size, base+offset);
     free_chunks.push_back(chunk);
     chunk++;

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -769,7 +769,7 @@ Infiniband::~Infiniband()
   if (dispatcher)
     dispatcher->polling_stop();
 
-  assert(ibv_destroy_srq(srq) == 0);
+  ibv_destroy_srq(srq);
   delete memory_manager;
   delete pd;
 }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -470,8 +470,7 @@ Infiniband::ProtectionDomain::ProtectionDomain(CephContext *cct, Device *device)
 
 Infiniband::ProtectionDomain::~ProtectionDomain()
 {
-  int rc = ibv_dealloc_pd(pd);
-  assert(rc == 0);
+  ibv_dealloc_pd(pd);
 }
 
 

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -600,10 +600,12 @@ void RDMAConnectedSocketImpl::cleanup() {
 void RDMAConnectedSocketImpl::notify()
 {
   uint64_t i = 1;
-  int ret;
-
-  ret = write(notify_fd, &i, sizeof(i));
-  assert(ret = sizeof(i));
+  int ret = write(notify_fd, &i, sizeof(i));
+  if (ret == -1) {
+     int write_errno = errno;
+     lderr(cct) <<__func__ << " failed to write to fd=" << notify_fd << ", error: " << cpp_strerror(errno) <<dendl;
+     assert(write_errno != EAGAIN);
+  }
 }
 
 void RDMAConnectedSocketImpl::shutdown()

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -25,7 +25,7 @@ RDMAConnectedSocketImpl::RDMAConnectedSocketImpl(CephContext *cct, Infiniband* i
   : cct(cct), connected(0), error(0), infiniband(ib),
     dispatcher(s), worker(w), lock("RDMAConnectedSocketImpl::lock"),
     is_server(false), con_handler(new C_handle_connection(this)),
-    active(false)
+    active(false), pending(0)
 {
   qp = infiniband->create_queue_pair(
 				     cct, s->get_tx_cq(), s->get_rx_cq(), IBV_QPT_RC);

--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -201,7 +201,7 @@ int RDMAConnectedSocketImpl::try_connect(const entity_addr_t& peer_addr, const S
 }
 
 void RDMAConnectedSocketImpl::handle_connection() {
-  ldout(cct, 20) << __func__ << " QP: " << my_msg.qpn << " tcp_fd: " << tcp_fd << " fd: " << notify_fd << dendl;
+  ldout(cct, 20) << __func__ << " QP: " << my_msg.qpn << " tcp_fd: " << tcp_fd << " notify_fd: " << notify_fd << dendl;
   int r = infiniband->recv_msg(cct, tcp_fd, peer_msg);
   if (r < 0) {
     if (r != -EAGAIN) {
@@ -256,16 +256,25 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
   uint64_t i = 0;
   int r = ::read(notify_fd, &i, sizeof(i));
   ldout(cct, 20) << __func__ << " notify_fd : " << i << " in " << my_msg.qpn << " r = " << r << dendl;
-  if (error)
-    return -error;
   ssize_t read = 0;
   if (!buffers.empty())
     read = read_buffers(buf,len);
 
   std::vector<ibv_wc> cqe;
   get_wc(cqe);
-  if (cqe.empty())
-    return read == 0 ? -EAGAIN : read;
+  if (cqe.empty()) {
+    if (!buffers.empty()) {
+      notify();
+    }
+    if (read > 0) {
+      return read;
+    }
+    if (error) {
+      return -error;
+    } else {
+      return -EAGAIN;
+    }
+  }
 
   ldout(cct, 20) << __func__ << " poll queue got " << cqe.size() << " responses. QP: " << my_msg.qpn << dendl;
   for (size_t i = 0; i < cqe.size(); ++i) {
@@ -305,6 +314,10 @@ ssize_t RDMAConnectedSocketImpl::read(char* buf, size_t len)
     connected = 1; //if so, we don't need the last handshake
     cleanup();
     submit(false);
+  }
+
+  if (!buffers.empty()) {
+    notify();
   }
 
   if (read == 0 && error)

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -499,7 +499,7 @@ void RDMAWorker::handle_pending_message()
       ldout(cct, 20) << __func__ << " sent pending bl socket=" << o << " r=" << r << dendl;
       if (r < 0) {
         if (r == -EAGAIN) {
-          pending_sent_conns.push_front(o);
+          pending_sent_conns.push_back(o);
           dispatcher->make_pending_worker(this);
           return ;
         }

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -474,7 +474,7 @@ int RDMAWorker::get_reged_mem(RDMAConnectedSocketImpl *o, std::vector<Chunk*> &c
   size_t got = global_infiniband->get_memory_manager()->get_tx_buffer_size() * r;
   ldout(cct, 30) << __func__ << " need " << bytes << " bytes, reserve " << got << " registered  bytes, inflight " << dispatcher->inflight << dendl;
   stack->get_dispatcher()->inflight += r;
-  if (got == bytes)
+  if (got >= bytes)
     return r;
 
   if (o) {

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -417,6 +417,7 @@ RDMAWorker::RDMAWorker(CephContext *c, unsigned i)
   plb.add_u64_counter(l_msgr_rdma_tx_bytes, "tx_bytes", "The bytes of tx chunks transmitted");
   plb.add_u64_counter(l_msgr_rdma_rx_chunks, "rx_chunks", "The number of rx chunks transmitted");
   plb.add_u64_counter(l_msgr_rdma_rx_bytes, "rx_bytes", "The bytes of rx chunks transmitted");
+  plb.add_u64_counter(l_msgr_rdma_pending_sent_conns, "pending_sent_conns", "The count of pending conns");
 
   perf_logger = plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(perf_logger);
@@ -478,8 +479,11 @@ int RDMAWorker::get_reged_mem(RDMAConnectedSocketImpl *o, std::vector<Chunk*> &c
     return r;
 
   if (o) {
-    if (pending_sent_conns.back() != o)
+    if (!o->is_pending()) {
       pending_sent_conns.push_back(o);
+      perf_logger->inc(l_msgr_rdma_pending_sent_conns, 1);
+      o->set_pending(1);
+    }
     dispatcher->make_pending_worker(this);
   }
   return r;
@@ -489,25 +493,22 @@ int RDMAWorker::get_reged_mem(RDMAConnectedSocketImpl *o, std::vector<Chunk*> &c
 void RDMAWorker::handle_pending_message()
 {
   ldout(cct, 20) << __func__ << " pending conns " << pending_sent_conns.size() << dendl;
-  std::set<RDMAConnectedSocketImpl*> done;
   while (!pending_sent_conns.empty()) {
     RDMAConnectedSocketImpl *o = pending_sent_conns.front();
     pending_sent_conns.pop_front();
-    if (!done.count(o)) {
-      done.insert(o);
-      ssize_t r = o->submit(false);
-      ldout(cct, 20) << __func__ << " sent pending bl socket=" << o << " r=" << r << dendl;
-      if (r < 0) {
-        if (r == -EAGAIN) {
-          pending_sent_conns.push_back(o);
-          dispatcher->make_pending_worker(this);
-          return ;
-        }
-        o->fault();
+    ssize_t r = o->submit(false);
+    ldout(cct, 20) << __func__ << " sent pending bl socket=" << o << " r=" << r << dendl;
+    if (r < 0) {
+      if (r == -EAGAIN) {
+        pending_sent_conns.push_back(o);
+        dispatcher->make_pending_worker(this);
+        return ;
       }
+      o->fault();
     }
+    o->set_pending(0);
+    perf_logger->dec(l_msgr_rdma_pending_sent_conns, 1);
   }
-
   dispatcher->notify_pending_workers();
 }
 

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -516,10 +516,21 @@ RDMAStack::RDMAStack(CephContext *cct, const string &t): NetworkStack(cct, t)
   //
   //On RDMA MUST be called before fork
   //
+
   int rc = ibv_fork_init();
   if (rc) {
      lderr(cct) << __func__ << " failed to call ibv_for_init(). On RDMA must be called before fork. Application aborts." << dendl;
      ceph_abort();
+  }
+
+  ldout(cct, 20) << __func__ << " ms_async_rdma_enable_hugepage value is: " << cct->_conf->ms_async_rdma_enable_hugepage <<  dendl;
+  if (cct->_conf->ms_async_rdma_enable_hugepage){
+    rc =  setenv("RDMAV_HUGEPAGES_SAFE","1",1);
+    ldout(cct, 20) << __func__ << " RDMAV_HUGEPAGES_SAFE is set as: " << getenv("RDMAV_HUGEPAGES_SAFE") <<  dendl;
+    if (rc) {
+      lderr(cct) << __func__ << " failed to export RDMA_HUGEPAGES_SAFE. On RDMA must be exported before using huge pages. Application aborts." << dendl;
+      ceph_abort();
+    }
   }
 
   //Check ulimit
@@ -548,6 +559,10 @@ RDMAStack::RDMAStack(CephContext *cct, const string &t): NetworkStack(cct, t)
 
 RDMAStack::~RDMAStack()
 {
+  if (cct->_conf->ms_async_rdma_enable_hugepage){
+    unsetenv("RDMAV_HUGEPAGES_SAFE");	//remove env variable on destruction
+  }
+
   delete dispatcher;
 }
 

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -158,6 +158,7 @@ enum {
   l_msgr_rdma_tx_bytes,
   l_msgr_rdma_rx_chunks,
   l_msgr_rdma_rx_bytes,
+  l_msgr_rdma_pending_sent_conns,
 
   l_msgr_rdma_last,
 };
@@ -229,6 +230,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   EventCallbackRef con_handler;
   int tcp_fd = -1;
   bool active;// qp is active ?
+  bool pending;
 
   void notify();
   ssize_t read_buffers(char* buf, size_t len);
@@ -258,7 +260,8 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
   void cleanup();
   void set_accept_fd(int sd);
   int try_connect(const entity_addr_t&, const SocketOptions &opt);
-
+  bool is_pending() {return pending;}
+  void set_pending(bool val) {pending = val;}
   class C_handle_connection : public EventCallback {
     RDMAConnectedSocketImpl *csi;
     bool active;

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -127,10 +127,11 @@ class RDMADispatcher {
   int register_qp(QueuePair *qp, RDMAConnectedSocketImpl* csi);
   void make_pending_worker(RDMAWorker* w) {
     Mutex::Locker l(w_lock);
-    if (pending_workers.back() != w) {
-      pending_workers.push_back(w);
-      ++num_pending_workers;
-    }
+    auto it = std::find(pending_workers.begin(), pending_workers.end(), w);
+    if (it != pending_workers.end())
+      return;
+    pending_workers.push_back(w);
+    ++num_pending_workers;
   }
   RDMAStack* get_stack() { return stack; }
   RDMAConnectedSocketImpl* get_conn_lockless(uint32_t qp);

--- a/src/systemd-rdma-settings.sh
+++ b/src/systemd-rdma-settings.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+
+SERV=`echo $1 | awk -F@ '{print $1}'`
+FILE="/usr/lib/systemd/system/"$SERV"@.service"
+ARG_DIR=/run/systemd/system/$1
+NAME=$1
+FLAG=false
+
+add_config(){
+	if [ -f "/run/systemd/system/ceph-osd.target.wants/"$NAME"" ]; then
+		sudo rm -rf "/run/systemd/system/ceph-osd.target.wants/"$NAME""
+	fi
+
+	for CONF in "$@"
+	do
+		if [ ! -f $CONF ]; then
+			touch $CONF
+			FLAG=true
+			cat $FILE > $CONF
+		fi
+		if ! grep -q "[Service]" $CONF ; then
+			echo "[Service]"| sudo tee -a $CONF
+			FLAG=true
+		fi
+		if grep -q "PrivateDevices=yes" $CONF; then
+			sudo sed -i 's/PrivateDevices=yes/PrivateDevices=no/g' $CONF
+			FLAG=true
+		fi
+		if ! grep -q "LimitMEMLOCK=infinity" $CONF ; then
+			sudo sed -i '/\[Service\]/a LimitMEMLOCK=infinity' $CONF
+			FLAG=true
+		fi
+	done
+}
+
+rm_config(){
+	if [ -f "/run/systemd/system/ceph-osd.target.wants/"$NAME"" ]; then
+		sudo rm -rf "/run/systemd/system/ceph-osd.target.wants/"$NAME""
+	fi
+
+	for CONF in "$@"
+	do
+		if [ -f $CONF ]; then
+			sudo rm -f $CONF
+			FLAG=true
+		fi
+	done
+}
+
+if [ "$2" != "clean" ]; then
+	add_config $ARG_DIR
+	if [ "$FLAG" = true ]; then
+		sudo systemctl daemon-reload
+	fi
+else
+	rm_config $ARG_DIR
+	if [ "$FLAG" = true ]; then
+		sudo systemctl daemon-reload
+	fi
+fi

--- a/systemd/ceph-disk@.service
+++ b/systemd/ceph-disk@.service
@@ -7,5 +7,7 @@ Wants=local-fs.target
 Type=oneshot
 KillMode=none
 Environment=CEPH_DISK_TIMEOUT=300
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/bin/sh -c 'timeout $CEPH_DISK_TIMEOUT flock /var/lock/ceph-disk-$(basename %f) /usr/sbin/ceph-disk --verbose --log-stdout trigger --sync %f'
 TimeoutSec=0
+ExecStopPost=-/bin/sh -c 'if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi'

--- a/systemd/ceph-fuse@.service
+++ b/systemd/ceph-fuse@.service
@@ -8,11 +8,13 @@ PartOf=ceph-fuse.target
 [Service]
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/ceph-fuse -f --cluster ${CLUSTER} %I
 TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-fuse.target

--- a/systemd/ceph-mds@.service
+++ b/systemd/ceph-mds@.service
@@ -9,6 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/ceph-mds -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 PrivateDevices=yes
@@ -19,6 +20,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-mds.target

--- a/systemd/ceph-mgr@.service
+++ b/systemd/ceph-mgr@.service
@@ -9,7 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 # This ExecStartPre business is a hack to inject a key for the mgr daemon,
 # using whatever key already exists on the mon on this node to gain sufficient
 # permissions to create the mgr key.  Failure is ignored at every step (the
@@ -27,6 +27,7 @@ ExecReload=/bin/kill -HUP $MAINPID
 Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-mgr.target

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -15,6 +15,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/ceph-mon -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 PrivateDevices=yes
@@ -26,6 +27,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=5
 RestartSec=10
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-mon.target

--- a/systemd/ceph-osd@.service
+++ b/systemd/ceph-osd@.service
@@ -9,6 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/ceph-osd -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecStartPre=/usr/lib/ceph/ceph-osd-prestart.sh --cluster ${CLUSTER} --id %i
 ExecReload=/bin/kill -HUP $MAINPID
@@ -20,6 +21,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=30
 RestartSec=20s
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-osd.target

--- a/systemd/ceph-radosgw@.service
+++ b/systemd/ceph-radosgw@.service
@@ -9,6 +9,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/radosgw -f --cluster ${CLUSTER} --name client.%i --setuser ceph --setgroup ceph
 PrivateDevices=yes
 ProtectHome=true
@@ -18,6 +19,7 @@ TasksMax=infinity
 Restart=on-failure
 StartLimitInterval=30s
 StartLimitBurst=5
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=ceph-radosgw.target

--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -8,6 +8,7 @@ LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/rbd-mirror -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID
 PrivateDevices=yes
@@ -18,6 +19,7 @@ Restart=on-failure
 StartLimitInterval=30min
 StartLimitBurst=3
 TasksMax=infinity
+ExecStopPost=-/bin/sh -c 'if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi'
 
 [Install]
 WantedBy=ceph-rbd-mirror.target

--- a/systemd/rbdmap.service
+++ b/systemd/rbdmap.service
@@ -9,9 +9,11 @@ EnvironmentFile=-/etc/sysconfig/ceph
 Environment=RBDMAPFILE=/etc/ceph/rbdmap
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n; fi"
 ExecStart=/usr/bin/rbdmap map
 ExecReload=/usr/bin/rbdmap map
 ExecStop=/usr/bin/rbdmap unmap-all
+ExecStopPost=-/bin/sh -c "if echo $(ceph-conf ms_type) $(ceph-conf ms_public_type) $(ceph-conf ms_cluster_type) | egrep -q '*rdma*'; then /usr/lib/ceph/systemd-rdma-settings.sh %n clean; fi"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The script is only called if rdma is found in ceph.conf.

If ceph-conf or the script return an error, the comand/script is
ignored and won't affect the service, since both ExecStartPre and
ExecStopPost commands begin with the '-' sign.

Service is only reloaded if a change was made to any of the conf files.

No changes are kept after rdma is removed and services restarted (the
script restores previous configuration when stopping the service).

All changes are made in /run/systemd/system/ where all files are
considered temporary and are  only kept for the current run of the service.

Signed-off-by: DanielBar-On <danielbo@mellanox.com>