### PR TITLE
jewel: tests: upgrade:client-upgrade/firefly-client-x: drop CentOS

### DIFF
--- a/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos.yaml


### PR DESCRIPTION
The RBD suite needs ceph-cm-ansible to install qemu-kvm on CentOS, but doing
that breaks the firefly install on CentOS because:

1. the qemu-kvm that gets installed is from hammer (0.94.5)
2. qemu-kvm brings in librados2, librbd1 as dependencies

As a result, the hammer librados2 and librbd1 are installed on the test nodes
even before the teuthology install task starts. When it does start and tries
to install firefly, it fails because firefly librados2 and librbd1 cannot be
installed over their hammer versions.

Fixes: http://tracker.ceph.com/issues/19571
Signed-off-by: Nathan Cutler <ncutler@suse.com>