### PR TITLE
init-ceph: add ceph libraries path to environment

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -33,6 +33,10 @@ else
 	LIBEXECDIR=$CEPH_ROOT/src
 	ETCDIR=.
 	ASSUME_DEV=1
+	CEPH_LIB=$CEPH_ROOT/build/lib
+	echo "$PYTHONPATH" | grep -q $CEPH_LIB || export PYTHONPATH=$CEPH_LIB/cython_modules/lib.2:$PYTHONPATH
+	echo "$LD_LIBRARY_PATH" | grep -q $CEPH_LIB || export LD_LIBRARY_PATH=$CEPH_LIB:$LD_LIBRARY_PATH
+	echo "$DYLD_LIBRARY_PATH" | grep -q $CEPH_LIB || export DYLD_LIBRARY_PATH=$CEPH_LIB:$DYLD_LIBRARY_PATH
     else
 	BINDIR=@bindir@
 	SBINDIR=@sbindir@


### PR DESCRIPTION
These libraries are set in vstart.sh, but not in init-ceph. When
init-ceph is not invoked through vstart.sh, library paths are missing.

Signed-off-by: Mohamad Gebai <mgebai@suse.com>