### PR TITLE
crush: crush_init_workspace starts with struct crush_work

### DIFF
--- a/src/crush/mapper.c
+++ b/src/crush/mapper.c
@@ -849,7 +849,7 @@ void crush_init_workspace(const struct crush_map *m, void *v) {
 	struct crush_work *w = (struct crush_work *)v;
 	char *point = (char *)v;
 	__s32 b;
-	point += sizeof(struct crush_work *);
+	point += sizeof(struct crush_work);
 	w->work = (struct crush_work_bucket **)point;
 	point += m->max_buckets * sizeof(struct crush_work_bucket *);
 	for (b = 0; b < m->max_buckets; ++b) {


### PR DESCRIPTION
It is not just a pointer to crush_work, it is the whole structure.
That is not a problem since it only contains a pointer. But it will
be a problem if new data members are added to crush_work.

Signed-off-by: Loic Dachary <loic@dachary.org>