### PR TITLE
qa/rgw: don't scan radosgw logs for encryption keys on jewel upgrade test

### DIFF
--- a/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -112,6 +112,7 @@ workload_jewel:
          client.0:
            force-branch: ceph-jewel
            rgw_server: client.0
+           scan_for_encryption_keys: false
      - print: "**** done s3tests workload_jewel"
 upgrade-sequence_jewel:
    sequential:

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -379,6 +379,8 @@ def scan_for_leaked_encryption_keys(ctx, config):
         log.debug('Scanning radosgw logs for leaked encryption keys...')
         procs = list()
         for client, client_config in config.iteritems():
+            if not client_config.get('scan_for_encryption_keys', True):
+                continue
             (remote,) = ctx.cluster.only(client).remotes.keys()
             proc = remote.run(
                 args=[


### PR DESCRIPTION
fix for `grep: /var/log/ceph/rgw.client.0.log: Permission denied` in upgrade test