### PR TITLE
jewel: mds: enable start when session ino info is corrupt

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -190,3 +190,15 @@ void InoTable::generate_test_instances(list<InoTable*>& ls)
 {
   ls.push_back(new InoTable());
 }
+
+bool InoTable::intersects_free(
+    const interval_set<inodeno_t> &other,
+    interval_set<inodeno_t> *intersection)
+{
+  interval_set<inodeno_t> i;
+  i.intersection_of(free, other);
+  if (intersection != nullptr) {
+    *intersection = i;
+  }
+  return !(i.empty());
+}

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -41,6 +41,9 @@ class InoTable : public MDSTable {
   void replay_alloc_ids(interval_set<inodeno_t>& inos);
   void replay_release_ids(interval_set<inodeno_t>& inos);
   void replay_reset();
+  bool intersects_free(
+      const interval_set<inodeno_t> &other,
+      interval_set<inodeno_t> *intersection);
 
   void reset_state();
   void encode_state(bufferlist& bl) const {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -975,8 +975,42 @@ void MDSRank::boot_start(BootStep step, int r)
       break;
     case MDS_BOOT_REPLAY_DONE:
       assert(is_any_replay());
+
+      // Sessiontable and inotable should be in sync after replay, validate
+      // that they are consistent.
+      validate_sessions();
+
       replay_done();
       break;
+  }
+}
+
+void MDSRank::validate_sessions()
+{
+  assert(mds_lock.is_locked_by_me());
+  std::vector<Session*> victims;
+
+  // Identify any sessions which have state inconsistent with other,
+  // after they have been loaded from rados during startup.
+  // Mitigate bugs like: http://tracker.ceph.com/issues/16842
+  const auto &sessions = sessionmap.get_sessions();
+  for (const auto &i : sessions) {
+    Session *session = i.second;
+    interval_set<inodeno_t> badones;
+    if (inotable->intersects_free(session->info.prealloc_inos, &badones)) {
+      clog->error() << "Client session loaded with invalid preallocated "
+                          "inodes, evicting session " << *session;
+
+      // Make the session consistent with inotable so that it can
+      // be cleanly torn down
+      session->info.prealloc_inos.subtract(badones);
+
+      victims.push_back(session);
+    }
+  }
+
+  for (const auto &session: victims) {
+    server->kill_session(session, nullptr);
   }
 }
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -447,6 +447,8 @@ class MDSRank {
     void active_start();
     void stopping_start();
     void stopping_done();
+
+    void validate_sessions();
     // <<<
     
     // >>>

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -999,3 +999,13 @@ bool SessionFilter::match(
   return true;
 }
 
+std::ostream& operator<<(std::ostream &out, const Session &s)
+{
+ if (s.get_human_name() == stringify(s.info.inst.name.num())) {
+   out << s.get_human_name();
+ } else {
+   out << s.get_human_name() << " (" << std::dec << s.info.inst.name.num() << ")";
+ }
+ return out;
+}
+

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -636,5 +636,7 @@ public:
                      MDSGatherBuilder *gather_bld);
 };
 
+std::ostream& operator<<(std::ostream &out, const Session &s);
+
 
 #endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/19709