### PR TITLE
kraken: qa/tasks: misc systemd updates

### DIFF
--- a/qa/suites/smoke/systemd/distro/centos.yaml
+++ b/qa/suites/smoke/systemd/distro/centos.yaml
@@ -1,1 +1,0 @@
-../../../../distros/all/centos.yaml

--- a/qa/suites/smoke/systemd/distro/ubuntu_16.04.yaml
+++ b/qa/suites/smoke/systemd/distro/ubuntu_16.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "16.04"

--- a/qa/suites/smoke/systemd/distros/centos_latest.yaml
+++ b/qa/suites/smoke/systemd/distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/smoke/systemd/distros/ubuntu_latest.yaml
+++ b/qa/suites/smoke/systemd/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/tasks/systemd.py
+++ b/qa/tasks/systemd.py
@@ -8,6 +8,7 @@ import time
 
 from cStringIO import StringIO
 from teuthology.orchestra import run
+from teuthology.misc import reconnect, get_first_mon, wait_until_healthy
 
 log = logging.getLogger(__name__)
 
@@ -124,4 +125,18 @@ def task(ctx, config):
                 log.info("Failed to stop ceph mds service")
             remote.run(args=['sudo', 'systemctl', 'start', mds_name])
             time.sleep(4)
+
+    # reboot all nodes and verify the systemd units restart
+    # workunit that runs would fail if any of the systemd unit doesnt start
+    ctx.cluster.run(args='sudo reboot', wait=False, check_status=False)
+    # avoid immediate reconnect
+    time.sleep(120)
+    reconnect(ctx, 480)  # reconnect all nodes
+    # for debug info
+    ctx.cluster.run(args=['sudo', 'ps', '-eaf', run.Raw('|'),
+                          'grep', 'ceph'])
+    # wait for HEALTH_OK
+    mon = get_first_mon(ctx, config)
+    (mon_remote,) = ctx.cluster.only(mon).remotes.iterkeys()
+    wait_until_healthy(ctx, mon_remote)
     yield

--- a/qa/tasks/systemd.py
+++ b/qa/tasks/systemd.py
@@ -138,5 +138,5 @@ def task(ctx, config):
     # wait for HEALTH_OK
     mon = get_first_mon(ctx, config)
     (mon_remote,) = ctx.cluster.only(mon).remotes.iterkeys()
-    wait_until_healthy(ctx, mon_remote)
+    wait_until_healthy(ctx, mon_remote, use_sudo=True)
     yield


### PR DESCRIPTION
http://tracker.ceph.com/issues/19719

backport for kraken: misc systemd updates for kraken