### PR TITLE
test: warning: comparison between signed and unsigned integer expressions

### DIFF
--- a/src/test/simple_spin.cc
+++ b/src/test/simple_spin.cc
@@ -46,7 +46,8 @@ TEST(SimpleSpin, Test1)
   // Should also work with pass-by-reference:
   // (Note that we don't care about cross-threading here as-such.)
   counter = 0;
-  ASSERT_EQ(counter, 0);
+  uint32_t urhs = 0;
+  ASSERT_EQ(counter, urhs);
   async(std::launch::async, []() {
         for(int i = 0; n != i; ++i) {
             simple_spin_lock(lock);


### PR DESCRIPTION
The following warning appears during make:
```
[ 61%] Building CXX object src/test/CMakeFiles/unittest_simple_spin.dir/simple_spin.cc.o
In file included from ./src/test/simple_spin.cc:1:0:
./src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = int]’:
./src/googletest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = int; bool lhs_is_null_literal = false]’
./src/test/simple_spin.cc:49:3:   required from here
./src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>