### PR TITLE
msg: Increase loglevels on some messages

### DIFF
--- a/src/msg/async/EventKqueue.cc
+++ b/src/msg/async/EventKqueue.cc
@@ -38,12 +38,12 @@ int KqueueDriver::restore_events() {
   struct kevent ke[2];
   int i;
 
-  ldout(cct,10) << __func__ << " on kqfd = " << kqfd << dendl;
+  ldout(cct,30) << __func__ << " on kqfd = " << kqfd << dendl;
   for(i=0;i<size;i++) {
     int num = 0;
     if (sav_events[i].mask == 0 )
       continue;
-    ldout(cct,10) << __func__ << " restore kqfd = " << kqfd 
+    ldout(cct,30) << __func__ << " restore kqfd = " << kqfd 
                   << " fd = " << i << " mask " << sav_events[i].mask << dendl;
     if (sav_events[i].mask & EVENT_READABLE)
       EV_SET(&ke[num++], i, EVFILT_READ, EV_ADD, 0, 0, NULL);
@@ -66,7 +66,7 @@ int KqueueDriver::test_thread_change(const char* funcname) {
   int oldkqfd = kqfd;
 
   if (!pthread_equal(mythread, pthread_self())) {
-    ldout(cct,10) << funcname << " We changed thread from " << mythread
+    ldout(cct,20) << funcname << " We changed thread from " << mythread
                   << " to " << pthread_self() << dendl;
     mythread = pthread_self();
     kqfd = -1;
@@ -80,7 +80,7 @@ int KqueueDriver::test_thread_change(const char* funcname) {
   }
   if (kqfd == -1) {
     kqfd = kqueue();
-    ldout(cct,10) << funcname << " kqueue: new kqfd = " << kqfd
+    ldout(cct,30) << funcname << " kqueue: new kqfd = " << kqfd
                   << " (was: " << oldkqfd << ")"
                   << dendl;
     if (kqfd < 0) {
@@ -135,7 +135,7 @@ int KqueueDriver::add_event(int fd, int cur_mask, int add_mask)
   struct kevent ke[2];
   int num = 0;
 
-  ldout(cct,20) << __func__ << " add event kqfd = " << kqfd << " fd = " << fd 
+  ldout(cct,30) << __func__ << " add event kqfd = " << kqfd << " fd = " << fd 
 	<< " cur_mask = " << cur_mask << " add_mask = " << add_mask 
 	<< dendl;
 
@@ -168,7 +168,7 @@ int KqueueDriver::del_event(int fd, int cur_mask, int del_mask)
   int num = 0;
   int mask = cur_mask & del_mask;
 
-  ldout(cct,20) << __func__ << " delete event kqfd = " << kqfd 
+  ldout(cct,30) << __func__ << " delete event kqfd = " << kqfd 
 	<< " fd = " << fd << " cur_mask = " << cur_mask 
 	<< " del_mask = " << del_mask << dendl;
 
@@ -196,7 +196,7 @@ int KqueueDriver::del_event(int fd, int cur_mask, int del_mask)
 
 int KqueueDriver::resize_events(int newsize)
 {
-  ldout(cct,10) << __func__ << " kqfd = " << kqfd << "newsize = " << newsize 
+  ldout(cct,30) << __func__ << " kqfd = " << kqfd << "newsize = " << newsize 
                 << dendl;
   if(newsize > sav_max) {
     sav_events = (struct SaveEvent*)realloc( sav_events, 
@@ -232,7 +232,7 @@ int KqueueDriver::event_wait(vector<FiredFileEvent> &fired_events, struct timeva
 		<< dendl;
       retval = kevent(kqfd, NULL, 0, res_events, size, &timeout);
   } else {
-      ldout(cct,20) << __func__ << " event_wait: " << " NULL" << dendl;
+      ldout(cct,30) << __func__ << " event_wait: " << " NULL" << dendl;
       retval = kevent(kqfd, NULL, 0, res_events, size, KEVENT_NOWAIT);
   }
 

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -140,7 +140,7 @@ void NetworkStack::start()
 
 Worker* NetworkStack::get_worker()
 {
-  ldout(cct, 10) << __func__ << dendl;
+  ldout(cct, 30) << __func__ << dendl;
 
    // start with some reasonably large number
   unsigned min_load = std::numeric_limits<int>::max();
@@ -198,7 +198,7 @@ class C_drain : public EventCallback {
 
 void NetworkStack::drain()
 {
-  ldout(cct, 10) << __func__ << " started." << dendl;
+  ldout(cct, 30) << __func__ << " started." << dendl;
   pthread_t cur = pthread_self();
   pool_spin.lock();
   C_drain drain(num_workers);
@@ -208,5 +208,5 @@ void NetworkStack::drain()
   }
   pool_spin.unlock();
   drain.wait();
-  ldout(cct, 10) << __func__ << " end." << dendl;
+  ldout(cct, 30) << __func__ << " end." << dendl;
 }


### PR DESCRIPTION
- Logging with --debug-ms=20 swamps the logfile with messages that 
   are mostly internal to the functioning of the messages queues.
   They tend to be very verbose info on what is going on, but not 
   informative unless the internals are being debugged.

   So set the level for those messages > 20 to allow better filtering