### PR TITLE
tests: rados: sleep before ceph tell osd.0 flush_pg_stats after restart

### DIFF
--- a/qa/suites/rados/singleton/all/ec-lost-unfound-upgrade.yaml
+++ b/qa/suites/rados/singleton/all/ec-lost-unfound-upgrade.yaml
@@ -26,5 +26,7 @@ tasks:
 - print: "upgraded mon.a and friends"
 - ceph.restart:
     daemons: [mon.a, mon.b, mon.c, osd.0, osd.1, osd.2]
+- sleep:
+    duration: 20 # http://tracker.ceph.com/issues/16239
 - ec_lost_unfound:
     parallel_bench: false


### PR DESCRIPTION
Even though we wait for HEALTH_OK after restarting the daemons, they are not
ready to respond to flush_pg_stats.

References: http://tracker.ceph.com/issues/16239
Signed-off-by: Nathan Cutler <ncutler@suse.com>