### PR TITLE
mon: don't call propose_pending in prepare_update()

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -510,8 +510,8 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
       }
     }
 
-    if (changed) {
-      tick();
+    if (changed && pending_map.active_gid == 0) {
+      promote_standby();
     }
   } else {
     r = -ENOSYS;


### PR DESCRIPTION
This was happening indirectly because the command handling
code was calling tick() as a shortcut to "promote something"
and tick calls propose_pending because.

Fixes: http://tracker.ceph.com/issues/19738
Signed-off-by: John Spray <john.spray@redhat.com>