### PR TITLE
rbd-mirror: remove tracking of image names from pool watcher

### DIFF
--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -26,12 +26,15 @@ using util::create_context_callback;
 using util::create_async_context_callback;
 
 template <typename I>
-CloneRequest<I>::CloneRequest(I *p_imctx, IoCtx &c_ioctx, const std::string &c_name,
+CloneRequest<I>::CloneRequest(I *p_imctx, IoCtx &c_ioctx,
+			      const std::string &c_name,
+			      const std::string &c_id,
 			      ImageOptions c_options,
 			      const std::string &non_primary_global_image_id,
 			      const std::string &primary_mirror_uuid,
 			      ContextWQ *op_work_queue, Context *on_finish)
-  : m_p_imctx(p_imctx), m_ioctx(c_ioctx), m_name(c_name), m_opts(c_options),
+  : m_p_imctx(p_imctx), m_ioctx(c_ioctx), m_name(c_name), m_id(c_id),
+    m_opts(c_options),
     m_pspec(m_p_imctx->md_ctx.get_id(), m_p_imctx->id, m_p_imctx->snap_id),
     m_non_primary_global_image_id(non_primary_global_image_id),
     m_primary_mirror_uuid(primary_mirror_uuid),
@@ -199,7 +202,6 @@ void CloneRequest<I>::send_create() {
   Context *ctx = create_context_callback<klass, &klass::handle_create>(this);
 
   RWLock::RLocker snap_locker(m_p_imctx->snap_lock);
-  m_id = librbd::util::generate_image_id(m_ioctx);
   CreateRequest<I> *req = CreateRequest<I>::create(
     m_ioctx, m_name, m_id, m_size, m_opts, m_non_primary_global_image_id,
     m_primary_mirror_uuid, true, m_op_work_queue, ctx);

--- a/src/librbd/image/CloneRequest.h
+++ b/src/librbd/image/CloneRequest.h
@@ -19,11 +19,11 @@ template <typename ImageCtxT = ImageCtx>
 class CloneRequest {
 public:
   static CloneRequest *create(ImageCtxT *p_imctx, IoCtx &c_ioctx, const std::string &c_name,
-			      ImageOptions c_options,
+			      const std::string &c_id, ImageOptions c_options,
 			      const std::string &non_primary_global_image_id,
 			      const std::string &primary_mirror_uuid,
 			      ContextWQ *op_work_queue, Context *on_finish) {
-    return new CloneRequest(p_imctx, c_ioctx, c_name, c_options,
+    return new CloneRequest(p_imctx, c_ioctx, c_name, c_id, c_options,
                              non_primary_global_image_id, primary_mirror_uuid,
                              op_work_queue, on_finish);
   }
@@ -78,6 +78,7 @@ private:
    */
 
   CloneRequest(ImageCtxT *p_imctx, IoCtx &c_ioctx, const std::string &c_name,
+			      const std::string &c_id,
 			      ImageOptions c_options,
 			      const std::string &non_primary_global_image_id,
 			      const std::string &primary_mirror_uuid,

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -106,8 +106,8 @@ namespace librbd {
   int create(librados::IoCtx& io_ctx, const char *imgname, uint64_t size,
 	     bool old_format, uint64_t features, int *order,
 	     uint64_t stripe_unit, uint64_t stripe_count);
-  int create(IoCtx& io_ctx, const char *imgname, uint64_t size,
-	     ImageOptions& opts,
+  int create(IoCtx& io_ctx, const std::string &image_name,
+	     const std::string &image_id, uint64_t size, ImageOptions& opts,
              const std::string &non_primary_global_image_id,
              const std::string &primary_mirror_uuid,
              bool skip_mirror_enable);
@@ -117,8 +117,8 @@ namespace librbd {
 	    uint64_t stripe_unit, int stripe_count);
   int clone(IoCtx& p_ioctx, const char *p_name, const char *p_snap_name,
 	    IoCtx& c_ioctx, const char *c_name, ImageOptions& c_opts);
-  int clone(ImageCtx *p_imctx, IoCtx& c_ioctx, const char *c_name,
-            ImageOptions& c_opts,
+  int clone(ImageCtx *p_imctx, IoCtx& c_ioctx, const std::string &c_name,
+            const std::string &c_id, ImageOptions& c_opts,
             const std::string &non_primary_global_image_id,
             const std::string &primary_mirror_uuid);
   int rename(librados::IoCtx& io_ctx, const char *srcname, const char *dstname);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -481,7 +481,7 @@ namespace librbd {
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
     tracepoint(librbd, create4_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, opts.opts);
-    int r = librbd::create(io_ctx, name, size, opts, "", "", false);
+    int r = librbd::create(io_ctx, name, "", size, opts, "", "", false);
     tracepoint(librbd, create4_exit, r);
     return r;
   }
@@ -2195,7 +2195,7 @@ extern "C" int rbd_create4(rados_ioctx_t p, const char *name,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(io_ctx));
   tracepoint(librbd, create4_enter, io_ctx.get_pool_name().c_str(), io_ctx.get_id(), name, size, opts);
   librbd::ImageOptions opts_(opts);
-  int r = librbd::create(io_ctx, name, size, opts_, "", "", false);
+  int r = librbd::create(io_ctx, name, "", size, opts_, "", "", false);
   tracepoint(librbd, create4_exit, r);
   return r;
 }

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -214,7 +214,6 @@ struct OpenLocalImageRequest<librbd::MockTestImageCtx> {
 
   static OpenLocalImageRequest* create(librados::IoCtx &local_io_ctx,
                                        librbd::MockTestImageCtx **local_image_ctx,
-                                       const std::string &local_image_name,
                                        const std::string &local_image_id,
                                        ContextWQ *work_queue,
                                        Context *on_finish) {
@@ -429,8 +428,7 @@ public:
     return new MockBootstrapRequest(m_local_io_ctx,
                                     m_remote_io_ctx,
                                     mock_image_sync_throttler,
-                                    &m_local_test_image_ctx,
-                                    "local image name",
+                                    &m_local_test_image_ctx, "",
                                     remote_image_id,
                                     global_image_id,
                                     m_threads->work_queue,

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -132,8 +132,10 @@ struct CreateImageRequest<librbd::MockTestImageCtx> {
                                     const std::string &remote_mirror_uuid,
                                     const std::string &local_image_name,
                                     librbd::MockTestImageCtx *remote_image_ctx,
+				    std::string *local_image_id,
                                     Context *on_finish) {
     assert(s_instance != nullptr);
+    *local_image_id = "local image id";
     s_instance->on_finish = on_finish;
     return s_instance;
   }

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -74,7 +74,7 @@ struct CloneRequest<librbd::MockTestImageCtx> {
 
   static CloneRequest *create(librbd::MockTestImageCtx *p_imctx,
 			      IoCtx &c_ioctx, const std::string &c_name,
-			      ImageOptions c_options,
+			      const std::string &c_id, ImageOptions c_options,
 			      const std::string &non_primary_global_image_id,
 			      const std::string &primary_mirror_uuid,
 			      MockContextWQ *op_work_queue, Context *on_finish) {

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -314,11 +314,12 @@ public:
                                          const std::string &remote_mirror_uuid,
                                          const std::string &local_image_name,
                                          librbd::MockTestImageCtx &mock_remote_image_ctx,
+					 std::string *local_image_id,
                                          Context *on_finish) {
     return new MockCreateImageRequest(m_local_io_ctx, m_threads->work_queue,
                                       global_image_id, remote_mirror_uuid,
                                       local_image_name, &mock_remote_image_ctx,
-                                      on_finish);
+                                      local_image_id, on_finish);
   }
 
   librbd::ImageCtx *m_remote_image_ctx;
@@ -332,11 +333,14 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Create) {
   expect_create_image(mock_create_request, m_local_io_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
-                                                   mock_remote_image_ctx, &ctx);
+                                                   mock_remote_image_ctx,
+						   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(local_image_id.empty());
 }
 
 TEST_F(TestMockImageReplayerCreateImageRequest, CreateError) {
@@ -347,9 +351,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CreateError) {
   expect_create_image(mock_create_request, m_local_io_ctx, -EINVAL);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
-                                                   mock_remote_image_ctx, &ctx);
+                                                   mock_remote_image_ctx,
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -390,12 +396,14 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Clone) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(local_image_id.empty());
 }
 
 TEST_F(TestMockImageReplayerCreateImageRequest, CloneGetGlobalImageIdError) {
@@ -415,10 +423,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneGetGlobalImageIdError) {
   expect_get_parent_global_image_id(m_remote_io_ctx, "global uuid", -ENOENT);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -441,10 +450,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneGetLocalParentImageIdError)
   expect_mirror_image_get_image_id(m_local_io_ctx, "local parent id", -ENOENT);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -472,10 +482,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenRemoteParentError) {
                     m_remote_image_ctx->id, mock_remote_parent_image_ctx, -ENOENT);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -513,10 +524,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenLocalParentError) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -556,10 +568,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneSnapSetError) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -600,10 +613,11 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -644,12 +658,14 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneLocalParentCloseError) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(local_image_id.empty());
 }
 
 TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
@@ -688,12 +704,14 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, -EINVAL);
 
   C_SaferCond ctx;
+  std::string local_image_id;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   &local_image_id, &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
+  ASSERT_FALSE(local_image_id.empty());
 }
 
 } // namespace image_replayer

--- a/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
+++ b/src/test/rbd_mirror/pool_watcher/test_mock_RefreshImagesRequest.cc
@@ -54,24 +54,11 @@ public:
                       Return(r)));
   }
 
-  void expect_dir_list(librados::IoCtx &io_ctx,
-                       const std::map<std::string, std::string> &ids, int r) {
-    bufferlist bl;
-    ::encode(ids, bl);
-
-    EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_list"), _, _, _))
-      .WillOnce(DoAll(WithArg<5>(Invoke([bl](bufferlist *out_bl) {
-                                          *out_bl = bl;
-                                        })),
-                      Return(r)));
-  }
 };
 
 TEST_F(TestMockPoolWatcherRefreshImagesRequest, Success) {
   InSequence seq;
   expect_mirror_image_list(m_remote_io_ctx, {{"local id", "global id"}}, 0);
-  expect_dir_list(m_remote_io_ctx, {{"image name", "local id"}}, 0);
 
   C_SaferCond ctx;
   ImageIds image_ids;
@@ -81,29 +68,23 @@ TEST_F(TestMockPoolWatcherRefreshImagesRequest, Success) {
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
-  ImageIds expected_image_ids = {{"global id", "local id", "image name"}};
+  ImageIds expected_image_ids = {{"global id", "local id"}};
   ASSERT_EQ(expected_image_ids, image_ids);
 }
 
 TEST_F(TestMockPoolWatcherRefreshImagesRequest, LargeDirectory) {
   InSequence seq;
   std::map<std::string, std::string> mirror_list;
-  std::map<std::string, std::string> dir_list;
   ImageIds expected_image_ids;
   for (uint32_t idx = 1; idx <= 1024; ++idx) {
     mirror_list.insert(std::make_pair("local id " + stringify(idx),
                                       "global id " + stringify(idx)));
-    dir_list.insert(std::make_pair("image " + stringify(idx),
-                                   "local id " + stringify(idx)));
     expected_image_ids.insert({{"global id " + stringify(idx),
-                                "local id " + stringify(idx),
-                                "image " + stringify(idx)}});
+                                "local id " + stringify(idx)}});
   }
 
   expect_mirror_image_list(m_remote_io_ctx, mirror_list, 0);
   expect_mirror_image_list(m_remote_io_ctx, {{"local id", "global id"}}, 0);
-  expect_dir_list(m_remote_io_ctx, dir_list, 0);
-  expect_dir_list(m_remote_io_ctx, {{"image name", "local id"}}, 0);
 
   C_SaferCond ctx;
   ImageIds image_ids;
@@ -113,27 +94,13 @@ TEST_F(TestMockPoolWatcherRefreshImagesRequest, LargeDirectory) {
   req->send();
   ASSERT_EQ(0, ctx.wait());
 
-  expected_image_ids.insert({"global id", "local id", "image name"});
+  expected_image_ids.insert({"global id", "local id"});
   ASSERT_EQ(expected_image_ids, image_ids);
 }
 
 TEST_F(TestMockPoolWatcherRefreshImagesRequest, MirrorImageListError) {
   InSequence seq;
   expect_mirror_image_list(m_remote_io_ctx, {}, -EINVAL);
-
-  C_SaferCond ctx;
-  ImageIds image_ids;
-  MockRefreshImagesRequest *req = new MockRefreshImagesRequest(
-    m_remote_io_ctx, &image_ids, &ctx);
-
-  req->send();
-  ASSERT_EQ(-EINVAL, ctx.wait());
-}
-
-TEST_F(TestMockPoolWatcherRefreshImagesRequest, DirListError) {
-  InSequence seq;
-  expect_mirror_image_list(m_remote_io_ctx, {{"local id", "global id"}}, 0);
-  expect_dir_list(m_remote_io_ctx, {{"image name", "local id"}}, -EINVAL);
 
   C_SaferCond ctx;
   ImageIds image_ids;

--- a/src/test/rbd_mirror/test_ClusterWatcher.cc
+++ b/src/test/rbd_mirror/test_ClusterWatcher.cc
@@ -65,7 +65,6 @@ public:
 					           peer.cluster_name,
 					           peer.client_name));
       m_pool_peers[pool_id].insert(peer);
-      m_mirrored_pools.insert(pool_name);
     }
     if (name != nullptr) {
       *name = pool_name;
@@ -77,7 +76,6 @@ public:
     ASSERT_GE(pool_id, 0);
     if (m_pool_peers.find(pool_id) != m_pool_peers.end()) {
       m_pool_peers[pool_id].erase(peer);
-      m_mirrored_pools.erase(name);
       if (m_pool_peers[pool_id].empty()) {
 	m_pool_peers.erase(pool_id);
       }
@@ -126,7 +124,6 @@ public:
     m_cluster_watcher->refresh_pools();
     Mutex::Locker l(m_lock);
     ASSERT_EQ(m_pool_peers, m_cluster_watcher->get_pool_peers());
-    ASSERT_EQ(m_mirrored_pools, m_cluster_watcher->get_pool_names());
   }
 
   Mutex m_lock;
@@ -134,7 +131,6 @@ public:
   unique_ptr<ClusterWatcher> m_cluster_watcher;
 
   set<string> m_pools;
-  set<string> m_mirrored_pools;
   ClusterWatcher::PoolPeers m_pool_peers;
 };
 

--- a/src/test/rbd_mirror/test_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_PoolWatcher.cc
@@ -148,7 +148,7 @@ public:
       image.close();
 
       m_mirrored_images.insert(ImageId(
-        mirror_image_info.global_id, get_image_id(&ioctx, name), name));
+        mirror_image_info.global_id, get_image_id(&ioctx, name)));
     }
     if (image_name != nullptr)
       *image_name = name;
@@ -195,7 +195,7 @@ public:
       image.close();
 
       m_mirrored_images.insert(ImageId(
-        mirror_image_info.global_id, get_image_id(&cioctx, name), name));
+        mirror_image_info.global_id, get_image_id(&cioctx, name)));
     }
     if (image_name != nullptr)
       *image_name = name;

--- a/src/test/rbd_mirror/test_mock_PoolWatcher.cc
+++ b/src/test/rbd_mirror/test_mock_PoolWatcher.cc
@@ -231,26 +231,6 @@ public:
                       Return(r)));
   }
 
-  void expect_dir_list(librados::IoCtx &io_ctx,
-                       const std::string &id, const std::string &name, int r) {
-    bufferlist in_bl;
-    ::encode(id, in_bl);
-
-    bufferlist out_bl;
-    ::encode(name, out_bl);
-
-    EXPECT_CALL(get_mock_io_ctx(io_ctx),
-                exec(RBD_DIRECTORY, _, StrEq("rbd"), StrEq("dir_get_name"),
-                     ContentsEqual(in_bl), _, _))
-      .WillOnce(DoAll(WithArg<5>(Invoke([this, out_bl](bufferlist *bl) {
-                          *bl = out_bl;
-                          Mutex::Locker locker(m_lock);
-                          ++m_get_name_count;
-                          m_cond.Signal();
-                        })),
-                      Return(r)));
-  }
-
   void expect_timer_add_event(MockThreads &mock_threads) {
     EXPECT_CALL(*mock_threads.timer, add_event_after(_, _))
       .WillOnce(WithArg<1>(Invoke([this](Context *ctx) {
@@ -283,25 +263,9 @@ public:
     return true;
   }
 
-  bool wait_for_get_name(uint32_t count) {
-    Mutex::Locker locker(m_lock);
-    while (m_get_name_count < count) {
-      if (m_cond.WaitInterval(m_lock, utime_t(10, 0)) != 0) {
-        break;
-      }
-    }
-    if (m_get_name_count < count) {
-      return false;
-    }
-
-    m_get_name_count -= count;
-    return true;
-  }
-
   Mutex m_lock;
   Cond m_cond;
   uint32_t m_update_count = 0;
-  uint32_t m_get_name_count = 0;
 };
 
 TEST_F(TestMockPoolWatcher, EmptyPool) {
@@ -341,8 +305,8 @@ TEST_F(TestMockPoolWatcher, NonEmptyPool) {
   expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
 
   ImageIds image_ids{
-    {"global id 1", "remote id 1", "image name 1"},
-    {"global id 2", "remote id 2", "image name 2"}};
+    {"global id 1", "remote id 1"},
+    {"global id 2", "remote id 2"}};
   MockRefreshImagesRequest mock_refresh_images_request;
   expect_refresh_images(mock_refresh_images_request, image_ids, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
@@ -371,8 +335,8 @@ TEST_F(TestMockPoolWatcher, NotifyDuringRefresh) {
   expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
 
   ImageIds image_ids{
-    {"global id 1", "remote id 1", "image name 1"},
-    {"global id 2", "remote id 2", "image name 2"}};
+    {"global id 1", "remote id 1"},
+    {"global id 2", "remote id 2"}};
   MockRefreshImagesRequest mock_refresh_images_request;
   bool refresh_sent = false;
   EXPECT_CALL(mock_refresh_images_request, send())
@@ -385,16 +349,12 @@ TEST_F(TestMockPoolWatcher, NotifyDuringRefresh) {
         m_cond.Signal();
       }));
 
-  expect_dir_list(m_remote_io_ctx, "remote id 1a", "image name 1a", 0);
-  expect_dir_list(m_remote_io_ctx, "remote id 3", "image name 3", 0);
-  expect_dir_list(m_remote_io_ctx, "dummy", "", -ENOENT);
-
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
 
   MockListener mock_listener(this);
   image_ids = {
-    {"global id 1", "remote id 1a", "image name 1a"},
-    {"global id 3", "remote id 3", "image name 3"}};
+    {"global id 1", "remote id 1a"},
+    {"global id 3", "remote id 3"}};
   expect_listener_handle_update(mock_listener, "remote uuid", image_ids, {});
 
   MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
@@ -414,9 +374,6 @@ TEST_F(TestMockPoolWatcher, NotifyDuringRefresh) {
     cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id 1a", "global id 1");
   MirroringWatcher::get_instance().handle_image_updated(
     cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id 3", "global id 3");
-  MirroringWatcher::get_instance().handle_image_updated(
-    cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "dummy", "dummy");
-  wait_for_get_name(3);
 
   mock_refresh_images_request.on_finish->complete(0);
   ASSERT_TRUE(wait_for_update(1));
@@ -434,8 +391,8 @@ TEST_F(TestMockPoolWatcher, Notify) {
   expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
 
   ImageIds image_ids{
-    {"global id 1", "remote id 1", "image name 1"},
-    {"global id 2", "remote id 2", "image name 2"}};
+    {"global id 1", "remote id 1"},
+    {"global id 2", "remote id 2"}};
   MockRefreshImagesRequest mock_refresh_images_request;
   expect_refresh_images(mock_refresh_images_request, image_ids, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
@@ -456,15 +413,10 @@ TEST_F(TestMockPoolWatcher, Notify) {
         notify_ctx = ctx;
         m_cond.Signal();
       }));
-  expect_dir_list(m_remote_io_ctx, "remote id 1a", "image name 1a", 0);
-  expect_dir_list(m_remote_io_ctx, "remote id 3", "image name 3", 0);
-  expect_dir_list(m_remote_io_ctx, "dummy", "", -ENOENT);
   expect_listener_handle_update(
     mock_listener, "remote uuid",
-    {{"global id 1", "remote id 1a", "image name 1a"},
-     {"global id 3", "remote id 3", "image name 3"}},
-    {{"global id 1", "remote id 1", "image name 1"},
-     {"global id 2", "remote id 2", "image name 2"}});
+    {{"global id 1", "remote id 1a"}, {"global id 3", "remote id 3"}},
+    {{"global id 1", "remote id 1"}, {"global id 2", "remote id 2"}});
 
   MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
                                     mock_listener);
@@ -485,9 +437,6 @@ TEST_F(TestMockPoolWatcher, Notify) {
     cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id 1a", "global id 1");
   MirroringWatcher::get_instance().handle_image_updated(
     cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id 3", "global id 3");
-  MirroringWatcher::get_instance().handle_image_updated(
-    cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "dummy", "dummy");
-  ASSERT_TRUE(wait_for_get_name(3));
   notify_ctx->complete(0);
 
   ASSERT_TRUE(wait_for_update(1));
@@ -768,10 +717,10 @@ TEST_F(TestMockPoolWatcher, Rewatch) {
 
   expect_timer_add_event(mock_threads);
   expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, false);
-  expect_refresh_images(mock_refresh_images_request, {{"global id", "image id", "name"}}, 0);
+  expect_refresh_images(mock_refresh_images_request, {{"global id", "image id"}}, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
   expect_listener_handle_update(mock_listener, "remote uuid",
-                                {{"global id", "image id", "name"}}, {});
+                                {{"global id", "image id"}}, {});
 
   MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
                                     mock_listener);
@@ -835,10 +784,10 @@ TEST_F(TestMockPoolWatcher, RewatchError) {
 
   expect_timer_add_event(mock_threads);
   expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, false);
-  expect_refresh_images(mock_refresh_images_request, {{"global id", "image id", "name"}}, 0);
+  expect_refresh_images(mock_refresh_images_request, {{"global id", "image id"}}, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
   expect_listener_handle_update(mock_listener, "remote uuid",
-                                {{"global id", "image id", "name"}}, {});
+                                {{"global id", "image id"}}, {});
 
   MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
                                     mock_listener);
@@ -848,86 +797,6 @@ TEST_F(TestMockPoolWatcher, RewatchError) {
   ASSERT_TRUE(wait_for_update(1));
 
   MirroringWatcher::get_instance().handle_rewatch_complete(-EINVAL);
-  ASSERT_TRUE(wait_for_update(1));
-
-  expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
-  ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
-}
-
-TEST_F(TestMockPoolWatcher, GetImageNameBlacklist) {
-  MockThreads mock_threads(m_threads);
-  expect_work_queue(mock_threads);
-
-  InSequence seq;
-  MockMirroringWatcher mock_mirroring_watcher;
-  expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, true);
-  expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
-
-  MockRefreshImagesRequest mock_refresh_images_request;
-  expect_refresh_images(mock_refresh_images_request, {}, 0);
-  expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
-
-  MockListener mock_listener(this);
-  expect_listener_handle_update(mock_listener, "remote uuid", {}, {});
-
-  expect_dir_list(m_remote_io_ctx, "remote id", "image name", -EBLACKLISTED);
-
-  MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
-                                    mock_listener);
-  C_SaferCond ctx;
-  mock_pool_watcher.init(&ctx);
-  ASSERT_EQ(0, ctx.wait());
-  ASSERT_TRUE(wait_for_update(1));
-
-  MirroringWatcher::get_instance().handle_image_updated(
-    cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id", "global id");
-  ASSERT_TRUE(wait_for_get_name(1));
-  while (true) {
-    if (mock_pool_watcher.is_blacklisted()) {
-      break;
-    }
-    usleep(1000);
-  }
-
-  expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
-  ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
-}
-
-TEST_F(TestMockPoolWatcher, GetImageNameError) {
-  MockThreads mock_threads(m_threads);
-  expect_work_queue(mock_threads);
-
-  InSequence seq;
-  MockMirroringWatcher mock_mirroring_watcher;
-  expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, true);
-  expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
-
-  MockRefreshImagesRequest mock_refresh_images_request;
-  expect_refresh_images(mock_refresh_images_request, {}, 0);
-  expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
-
-  MockListener mock_listener(this);
-  expect_listener_handle_update(mock_listener, "remote uuid", {}, {});
-
-  expect_dir_list(m_remote_io_ctx, "remote id", "image name", -EINVAL);
-  expect_timer_add_event(mock_threads);
-
-  expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, false);
-  expect_refresh_images(mock_refresh_images_request, {{"global id", "remote id", "name"}}, 0);
-  expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
-  expect_listener_handle_update(mock_listener, "remote uuid",
-                                {{"global id", "remote id", "name"}}, {});
-
-  MockPoolWatcher mock_pool_watcher(&mock_threads, m_remote_io_ctx,
-                                    mock_listener);
-  C_SaferCond ctx;
-  mock_pool_watcher.init(&ctx);
-  ASSERT_EQ(0, ctx.wait());
-  ASSERT_TRUE(wait_for_update(1));
-
-  MirroringWatcher::get_instance().handle_image_updated(
-    cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "remote id", "global id");
-  ASSERT_TRUE(wait_for_get_name(1));
   ASSERT_TRUE(wait_for_update(1));
 
   expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
@@ -982,8 +851,8 @@ TEST_F(TestMockPoolWatcher, MirrorUuidUpdated) {
   expect_mirroring_watcher_register(mock_mirroring_watcher, 0);
 
   ImageIds image_ids{
-    {"global id 1", "remote id 1", "image name 1"},
-    {"global id 2", "remote id 2", "image name 2"}};
+    {"global id 1", "remote id 1"},
+    {"global id 2", "remote id 2"}};
   MockRefreshImagesRequest mock_refresh_images_request;
   expect_refresh_images(mock_refresh_images_request, image_ids, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "remote uuid", 0);
@@ -1001,7 +870,7 @@ TEST_F(TestMockPoolWatcher, MirrorUuidUpdated) {
 
   expect_timer_add_event(mock_threads);
   ImageIds new_image_ids{
-    {"global id 1", "remote id 1", "image name 1"}};
+    {"global id 1", "remote id 1"}};
   expect_mirroring_watcher_is_unregistered(mock_mirroring_watcher, false);
   expect_refresh_images(mock_refresh_images_request, new_image_ids, 0);
   expect_mirror_uuid_get(m_remote_io_ctx, "updated uuid", 0);
@@ -1015,5 +884,6 @@ TEST_F(TestMockPoolWatcher, MirrorUuidUpdated) {
   expect_mirroring_watcher_unregister(mock_mirroring_watcher, 0);
   ASSERT_EQ(0, when_shut_down(mock_pool_watcher));
 }
+
 } // namespace mirror
 } // namespace rbd

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -14,8 +14,8 @@ set(rbd_mirror_internal
   LeaderWatcher.cc
   Mirror.cc
   MirrorStatusWatcher.cc
+  PoolReplayer.cc
   PoolWatcher.cc
-  Replayer.cc
   Threads.cc
   types.cc
   image_replayer/BootstrapRequest.cc

--- a/src/tools/rbd_mirror/ClusterWatcher.cc
+++ b/src/tools/rbd_mirror/ClusterWatcher.cc
@@ -38,12 +38,6 @@ const ClusterWatcher::PoolPeers& ClusterWatcher::get_pool_peers() const
   return m_pool_peers;
 }
 
-const ClusterWatcher::PoolNames& ClusterWatcher::get_pool_names() const
-{
-  assert(m_lock.is_locked());
-  return m_pool_names;
-}
-
 void ClusterWatcher::refresh_pools()
 {
   dout(20) << "enter" << dendl;
@@ -54,7 +48,6 @@ void ClusterWatcher::refresh_pools()
 
   Mutex::Locker l(m_lock);
   m_pool_peers = pool_peers;
-  m_pool_names = pool_names;
   // TODO: perhaps use a workqueue instead, once we get notifications
   // about config changes for existing pools
 }

--- a/src/tools/rbd_mirror/ClusterWatcher.h
+++ b/src/tools/rbd_mirror/ClusterWatcher.h
@@ -35,13 +35,11 @@ public:
   // Caller controls frequency of calls
   void refresh_pools();
   const PoolPeers& get_pool_peers() const;
-  const PoolNames& get_pool_names() const;
 
 private:
   Mutex &m_lock;
   RadosRef m_cluster;
   PoolPeers m_pool_peers;
-  PoolNames m_pool_names;
 
   void read_pool_peers(PoolPeers *pool_peers, PoolNames *pool_names);
 };

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -421,15 +421,14 @@ void ImageReplayer<I>::start(Context *on_finish, bool manual)
 
 template <typename I>
 void ImageReplayer<I>::bootstrap() {
-  dout(20) << "bootstrap params: "
-	   << "local_image_name=" << m_local_image_name << dendl;
+  dout(20) << dendl;
 
   Context *ctx = create_context_callback<
     ImageReplayer, &ImageReplayer<I>::handle_bootstrap>(this);
 
   BootstrapRequest<I> *request = BootstrapRequest<I>::create(
     m_local_ioctx, m_remote_image.io_ctx, m_image_sync_throttler,
-    &m_local_image_ctx, m_local_image_name, m_remote_image.image_id,
+    &m_local_image_ctx, m_local_image_id, m_remote_image.image_id,
     m_global_image_id, m_threads->work_queue, m_threads->timer,
     &m_threads->timer_lock, m_local_mirror_uuid, m_remote_image.mirror_uuid,
     m_remote_journaler, &m_client_meta, ctx, &m_do_resync, &m_progress_cxt);
@@ -455,7 +454,6 @@ void ImageReplayer<I>::handle_bootstrap(int r) {
     m_bootstrap_request = nullptr;
     if (m_local_image_ctx) {
       m_local_image_id = m_local_image_ctx->id;
-      m_local_image_name = m_local_image_ctx->name;
     }
   }
 

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -122,10 +122,6 @@ public:
     Mutex::Locker locker(m_lock);
     return m_local_image_id;
   }
-  inline std::string get_local_image_name() {
-    Mutex::Locker locker(m_lock);
-    return m_local_image_name;
-  }
 
   void start(Context *on_finish = nullptr, bool manual = false);
   void stop(Context *on_finish = nullptr, bool manual = false,
@@ -296,7 +292,6 @@ private:
   int64_t m_local_pool_id;
   std::string m_local_image_id;
   std::string m_global_image_id;
-  std::string m_local_image_name;
   std::string m_name;
   mutable Mutex m_lock;
   State m_state = STATE_STOPPED;

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -13,7 +13,7 @@
 #include "include/atomic.h"
 #include "include/rados/librados.hpp"
 #include "ClusterWatcher.h"
-#include "Replayer.h"
+#include "PoolReplayer.h"
 #include "ImageDeleter.h"
 #include "types.h"
 
@@ -53,7 +53,7 @@ private:
   typedef ClusterWatcher::PoolPeers PoolPeers;
   typedef std::pair<int64_t, peer_t> PoolPeer;
 
-  void update_replayers(const PoolPeers &pool_peers);
+  void update_pool_replayers(const PoolPeers &pool_peers);
 
   CephContext *m_cct;
   std::vector<const char*> m_args;
@@ -66,7 +66,7 @@ private:
   std::unique_ptr<ClusterWatcher> m_local_cluster_watcher;
   std::shared_ptr<ImageDeleter> m_image_deleter;
   ImageSyncThrottlerRef<> m_image_sync_throttler;
-  std::map<PoolPeer, std::unique_ptr<Replayer> > m_replayers;
+  std::map<PoolPeer, std::unique_ptr<PoolReplayer> > m_pool_replayers;
   atomic_t m_stopping;
   bool m_manual_stop = false;
   MirrorAdminSocketHook *m_asok_hook;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -1,8 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "PoolReplayer.h"
 #include <boost/bind.hpp>
-
 #include "common/Formatter.h"
 #include "common/admin_socket.h"
 #include "common/ceph_argparse.h"
@@ -20,14 +20,13 @@
 #include "InstanceReplayer.h"
 #include "InstanceWatcher.h"
 #include "LeaderWatcher.h"
-#include "Replayer.h"
 #include "Threads.h"
 #include "pool_watcher/RefreshImagesRequest.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
 #undef dout_prefix
-#define dout_prefix *_dout << "rbd::mirror::Replayer: " \
+#define dout_prefix *_dout << "rbd::mirror::PoolReplayer: " \
                            << this << " " << __func__ << ": "
 
 using std::chrono::seconds;
@@ -44,95 +43,94 @@ namespace mirror {
 
 namespace {
 
-class ReplayerAdminSocketCommand {
+class PoolReplayerAdminSocketCommand {
 public:
-  virtual ~ReplayerAdminSocketCommand() {}
+  PoolReplayerAdminSocketCommand(PoolReplayer *pool_replayer)
+    : pool_replayer(pool_replayer) {
+  }
+  virtual ~PoolReplayerAdminSocketCommand() {}
   virtual bool call(Formatter *f, stringstream *ss) = 0;
+protected:
+  PoolReplayer *pool_replayer;
 };
 
-class StatusCommand : public ReplayerAdminSocketCommand {
+class StatusCommand : public PoolReplayerAdminSocketCommand {
 public:
-  explicit StatusCommand(Replayer *replayer) : replayer(replayer) {}
-
-  bool call(Formatter *f, stringstream *ss) override {
-    replayer->print_status(f, ss);
-    return true;
+  explicit StatusCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
   }
 
-private:
-  Replayer *replayer;
-};
-
-class StartCommand : public ReplayerAdminSocketCommand {
-public:
-  explicit StartCommand(Replayer *replayer) : replayer(replayer) {}
-
   bool call(Formatter *f, stringstream *ss) override {
-    replayer->start();
+    pool_replayer->print_status(f, ss);
     return true;
   }
-
-private:
-  Replayer *replayer;
 };
 
-class StopCommand : public ReplayerAdminSocketCommand {
+class StartCommand : public PoolReplayerAdminSocketCommand {
 public:
-  explicit StopCommand(Replayer *replayer) : replayer(replayer) {}
-
-  bool call(Formatter *f, stringstream *ss) override {
-    replayer->stop(true);
-    return true;
+  explicit StartCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
   }
 
-private:
-  Replayer *replayer;
-};
-
-class RestartCommand : public ReplayerAdminSocketCommand {
-public:
-  explicit RestartCommand(Replayer *replayer) : replayer(replayer) {}
-
   bool call(Formatter *f, stringstream *ss) override {
-    replayer->restart();
+    pool_replayer->start();
     return true;
   }
-
-private:
-  Replayer *replayer;
 };
 
-class FlushCommand : public ReplayerAdminSocketCommand {
+class StopCommand : public PoolReplayerAdminSocketCommand {
 public:
-  explicit FlushCommand(Replayer *replayer) : replayer(replayer) {}
-
-  bool call(Formatter *f, stringstream *ss) override {
-    replayer->flush();
-    return true;
+  explicit StopCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
   }
 
-private:
-  Replayer *replayer;
-};
-
-class LeaderReleaseCommand : public ReplayerAdminSocketCommand {
-public:
-  explicit LeaderReleaseCommand(Replayer *replayer) : replayer(replayer) {}
-
   bool call(Formatter *f, stringstream *ss) override {
-    replayer->release_leader();
+    pool_replayer->stop(true);
     return true;
   }
-
-private:
-  Replayer *replayer;
 };
 
-class ReplayerAdminSocketHook : public AdminSocketHook {
+class RestartCommand : public PoolReplayerAdminSocketCommand {
 public:
-  ReplayerAdminSocketHook(CephContext *cct, const std::string &name,
-			  Replayer *replayer) :
-    admin_socket(cct->get_admin_socket()) {
+  explicit RestartCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
+  }
+
+  bool call(Formatter *f, stringstream *ss) override {
+    pool_replayer->restart();
+    return true;
+  }
+};
+
+class FlushCommand : public PoolReplayerAdminSocketCommand {
+public:
+  explicit FlushCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
+  }
+
+  bool call(Formatter *f, stringstream *ss) override {
+    pool_replayer->flush();
+    return true;
+  }
+};
+
+class LeaderReleaseCommand : public PoolReplayerAdminSocketCommand {
+public:
+  explicit LeaderReleaseCommand(PoolReplayer *pool_replayer)
+    : PoolReplayerAdminSocketCommand(pool_replayer) {
+  }
+
+  bool call(Formatter *f, stringstream *ss) override {
+    pool_replayer->release_leader();
+    return true;
+  }
+};
+
+class PoolReplayerAdminSocketHook : public AdminSocketHook {
+public:
+  PoolReplayerAdminSocketHook(CephContext *cct, const std::string &name,
+				PoolReplayer *pool_replayer)
+    : admin_socket(cct->get_admin_socket()) {
     std::string command;
     int r;
 
@@ -140,46 +138,46 @@ public:
     r = admin_socket->register_command(command, command, this,
 				       "get status for rbd mirror " + name);
     if (r == 0) {
-      commands[command] = new StatusCommand(replayer);
+      commands[command] = new StatusCommand(pool_replayer);
     }
 
     command = "rbd mirror start " + name;
     r = admin_socket->register_command(command, command, this,
 				       "start rbd mirror " + name);
     if (r == 0) {
-      commands[command] = new StartCommand(replayer);
+      commands[command] = new StartCommand(pool_replayer);
     }
 
     command = "rbd mirror stop " + name;
     r = admin_socket->register_command(command, command, this,
 				       "stop rbd mirror " + name);
     if (r == 0) {
-      commands[command] = new StopCommand(replayer);
+      commands[command] = new StopCommand(pool_replayer);
     }
 
     command = "rbd mirror restart " + name;
     r = admin_socket->register_command(command, command, this,
 				       "restart rbd mirror " + name);
     if (r == 0) {
-      commands[command] = new RestartCommand(replayer);
+      commands[command] = new RestartCommand(pool_replayer);
     }
 
     command = "rbd mirror flush " + name;
     r = admin_socket->register_command(command, command, this,
 				       "flush rbd mirror " + name);
     if (r == 0) {
-      commands[command] = new FlushCommand(replayer);
+      commands[command] = new FlushCommand(pool_replayer);
     }
 
     command = "rbd mirror leader release " + name;
     r = admin_socket->register_command(command, command, this,
                                        "release rbd mirror leader " + name);
     if (r == 0) {
-      commands[command] = new LeaderReleaseCommand(replayer);
+      commands[command] = new LeaderReleaseCommand(pool_replayer);
     }
   }
 
-  ~ReplayerAdminSocketHook() override {
+  ~PoolReplayerAdminSocketHook() override {
     for (Commands::const_iterator i = commands.begin(); i != commands.end();
 	 ++i) {
       (void)admin_socket->unregister_command(i->first);
@@ -200,7 +198,7 @@ public:
   }
 
 private:
-  typedef std::map<std::string, ReplayerAdminSocketCommand*> Commands;
+  typedef std::map<std::string, PoolReplayerAdminSocketCommand*> Commands;
 
   AdminSocket *admin_socket;
   Commands commands;
@@ -208,40 +206,40 @@ private:
 
 } // anonymous namespace
 
-struct Replayer::C_RefreshLocalImages : public Context {
-  Replayer *replayer;
+struct PoolReplayer::C_RefreshLocalImages : public Context {
+  PoolReplayer *pool_replayer;
   Context *on_finish;
   ImageIds image_ids;
 
-  C_RefreshLocalImages(Replayer *replayer, Context *on_finish)
-    : replayer(replayer), on_finish(on_finish) {
+  C_RefreshLocalImages(PoolReplayer *pool_replayer, Context *on_finish)
+    : pool_replayer(pool_replayer), on_finish(on_finish) {
   }
 
   void finish(int r) override {
-    replayer->handle_refresh_local_images(r, std::move(image_ids), on_finish);
+    pool_replayer->handle_refresh_local_images(r, std::move(image_ids), on_finish);
   }
 };
 
-Replayer::Replayer(Threads<librbd::ImageCtx> *threads,
-                   std::shared_ptr<ImageDeleter> image_deleter,
-                   ImageSyncThrottlerRef<> image_sync_throttler,
-                   int64_t local_pool_id, const peer_t &peer,
-                   const std::vector<const char*> &args) :
+PoolReplayer::PoolReplayer(Threads<librbd::ImageCtx> *threads,
+			   std::shared_ptr<ImageDeleter> image_deleter,
+			   ImageSyncThrottlerRef<> image_sync_throttler,
+			   int64_t local_pool_id, const peer_t &peer,
+			   const std::vector<const char*> &args) :
   m_threads(threads),
   m_image_deleter(image_deleter),
   m_image_sync_throttler(image_sync_throttler),
-  m_lock(stringify("rbd::mirror::Replayer ") + stringify(peer)),
+  m_lock(stringify("rbd::mirror::PoolReplayer ") + stringify(peer)),
   m_peer(peer),
   m_args(args),
   m_local_pool_id(local_pool_id),
   m_pool_watcher_listener(this),
   m_asok_hook(nullptr),
-  m_replayer_thread(this),
+  m_pool_replayer_thread(this),
   m_leader_listener(this)
 {
 }
 
-Replayer::~Replayer()
+PoolReplayer::~PoolReplayer()
 {
   delete m_asok_hook;
 
@@ -250,8 +248,8 @@ Replayer::~Replayer()
     Mutex::Locker l(m_lock);
     m_cond.Signal();
   }
-  if (m_replayer_thread.is_started()) {
-    m_replayer_thread.join();
+  if (m_pool_replayer_thread.is_started()) {
+    m_pool_replayer_thread.join();
   }
   if (m_leader_watcher) {
     m_leader_watcher->shut_down();
@@ -266,17 +264,17 @@ Replayer::~Replayer()
   assert(!m_pool_watcher);
 }
 
-bool Replayer::is_blacklisted() const {
+bool PoolReplayer::is_blacklisted() const {
   Mutex::Locker locker(m_lock);
   return m_blacklisted;
 }
 
-bool Replayer::is_leader() const {
+bool PoolReplayer::is_leader() const {
   Mutex::Locker locker(m_lock);
   return m_leader_watcher && m_leader_watcher->is_leader();
 }
 
-int Replayer::init()
+int PoolReplayer::init()
 {
   dout(20) << "replaying for " << m_peer << dendl;
 
@@ -344,14 +342,15 @@ int Replayer::init()
     return r;
   }
 
-  m_replayer_thread.create("replayer");
+  m_pool_replayer_thread.create("pool replayer");
 
   return 0;
 }
 
-int Replayer::init_rados(const std::string &cluster_name,
-                         const std::string &client_name,
-                         const std::string &description, RadosRef *rados_ref) {
+int PoolReplayer::init_rados(const std::string &cluster_name,
+			     const std::string &client_name,
+			     const std::string &description,
+			     RadosRef *rados_ref) {
   rados_ref->reset(new librados::Rados());
 
   // NOTE: manually bootstrap a CephContext here instead of via
@@ -420,7 +419,7 @@ int Replayer::init_rados(const std::string &cluster_name,
   return 0;
 }
 
-void Replayer::run()
+void PoolReplayer::run()
 {
   dout(20) << "enter" << dendl;
 
@@ -431,8 +430,8 @@ void Replayer::run()
       m_asok_hook_name = asok_hook_name;
       delete m_asok_hook;
 
-      m_asok_hook = new ReplayerAdminSocketHook(g_ceph_context,
-                                                m_asok_hook_name, this);
+      m_asok_hook = new PoolReplayerAdminSocketHook(g_ceph_context,
+						    m_asok_hook_name, this);
     }
 
     Mutex::Locker locker(m_lock);
@@ -446,7 +445,7 @@ void Replayer::run()
   }
 }
 
-void Replayer::print_status(Formatter *f, stringstream *ss)
+void PoolReplayer::print_status(Formatter *f, stringstream *ss)
 {
   dout(20) << "enter" << dendl;
 
@@ -456,7 +455,7 @@ void Replayer::print_status(Formatter *f, stringstream *ss)
 
   Mutex::Locker l(m_lock);
 
-  f->open_object_section("replayer_status");
+  f->open_object_section("pool_replayer_status");
   f->dump_string("pool", m_local_io_ctx.get_pool_name());
   f->dump_stream("peer") << m_peer;
   f->dump_string("instance_id", m_instance_watcher->get_instance_id());
@@ -483,7 +482,7 @@ void Replayer::print_status(Formatter *f, stringstream *ss)
   f->flush(*ss);
 }
 
-void Replayer::start()
+void PoolReplayer::start()
 {
   dout(20) << "enter" << dendl;
 
@@ -496,7 +495,7 @@ void Replayer::start()
   m_instance_replayer->start();
 }
 
-void Replayer::stop(bool manual)
+void PoolReplayer::stop(bool manual)
 {
   dout(20) << "enter: manual=" << manual << dendl;
 
@@ -512,7 +511,7 @@ void Replayer::stop(bool manual)
   m_instance_replayer->stop();
 }
 
-void Replayer::restart()
+void PoolReplayer::restart()
 {
   dout(20) << "enter" << dendl;
 
@@ -525,7 +524,7 @@ void Replayer::restart()
   m_instance_replayer->restart();
 }
 
-void Replayer::flush()
+void PoolReplayer::flush()
 {
   dout(20) << "enter" << dendl;
 
@@ -538,7 +537,7 @@ void Replayer::flush()
   m_instance_replayer->flush();
 }
 
-void Replayer::release_leader()
+void PoolReplayer::release_leader()
 {
   dout(20) << "enter" << dendl;
 
@@ -551,9 +550,9 @@ void Replayer::release_leader()
   m_leader_watcher->release_leader();
 }
 
-void Replayer::handle_update(const std::string &mirror_uuid,
-                             const ImageIds &added_image_ids,
-                             const ImageIds &removed_image_ids) {
+void PoolReplayer::handle_update(const std::string &mirror_uuid,
+				 const ImageIds &added_image_ids,
+				 const ImageIds &removed_image_ids) {
   assert(!mirror_uuid.empty());
   if (m_stopping.read()) {
     return;
@@ -619,17 +618,17 @@ void Replayer::handle_update(const std::string &mirror_uuid,
   gather_ctx->activate();
 }
 
-void Replayer::handle_post_acquire_leader(Context *on_finish) {
+void PoolReplayer::handle_post_acquire_leader(Context *on_finish) {
   dout(20) << dendl;
   refresh_local_images(on_finish);
 }
 
-void Replayer::handle_pre_release_leader(Context *on_finish) {
+void PoolReplayer::handle_pre_release_leader(Context *on_finish) {
   dout(20) << dendl;
   shut_down_pool_watcher(on_finish);
 }
 
-void Replayer::refresh_local_images(Context *on_finish) {
+void PoolReplayer::refresh_local_images(Context *on_finish) {
   dout(20) << dendl;
 
   // ensure the initial set of local images is up-to-date
@@ -640,8 +639,8 @@ void Replayer::refresh_local_images(Context *on_finish) {
   req->send();
 }
 
-void Replayer::handle_refresh_local_images(int r, ImageIds &&image_ids,
-                                           Context *on_finish) {
+void PoolReplayer::handle_refresh_local_images(int r, ImageIds &&image_ids,
+					       Context *on_finish) {
   dout(20) << "r=" << r << dendl;
 
   {
@@ -658,7 +657,7 @@ void Replayer::handle_refresh_local_images(int r, ImageIds &&image_ids,
   init_pool_watcher(on_finish);
 }
 
-void Replayer::init_pool_watcher(Context *on_finish) {
+void PoolReplayer::init_pool_watcher(Context *on_finish) {
   dout(20) << dendl;
 
   Mutex::Locker locker(m_lock);
@@ -671,7 +670,7 @@ void Replayer::init_pool_watcher(Context *on_finish) {
   m_cond.Signal();
 }
 
-void Replayer::shut_down_pool_watcher(Context *on_finish) {
+void PoolReplayer::shut_down_pool_watcher(Context *on_finish) {
   dout(20) << dendl;
 
   {
@@ -690,7 +689,7 @@ void Replayer::shut_down_pool_watcher(Context *on_finish) {
   on_finish->complete(0);
 }
 
-void Replayer::handle_shut_down_pool_watcher(int r, Context *on_finish) {
+void PoolReplayer::handle_shut_down_pool_watcher(int r, Context *on_finish) {
   dout(20) << "r=" << r << dendl;
 
   {
@@ -701,7 +700,7 @@ void Replayer::handle_shut_down_pool_watcher(int r, Context *on_finish) {
   wait_for_update_ops(on_finish);
 }
 
-void Replayer::wait_for_update_ops(Context *on_finish) {
+void PoolReplayer::wait_for_update_ops(Context *on_finish) {
   dout(20) << dendl;
 
   Mutex::Locker locker(m_lock);
@@ -714,7 +713,7 @@ void Replayer::wait_for_update_ops(Context *on_finish) {
   m_update_op_tracker.wait_for_ops(ctx);
 }
 
-void Replayer::handle_wait_for_update_ops(int r, Context *on_finish) {
+void PoolReplayer::handle_wait_for_update_ops(int r, Context *on_finish) {
   dout(20) << "r=" << r << dendl;
 
   assert(r == 0);

--- a/src/tools/rbd_mirror/PoolWatcher.cc
+++ b/src/tools/rbd_mirror/PoolWatcher.cc
@@ -217,18 +217,6 @@ void PoolWatcher<I>::refresh_images() {
     // a full image list refresh
     m_pending_added_image_ids.clear();
     m_pending_removed_image_ids.clear();
-    if (!m_updated_images.empty()) {
-      auto it = m_updated_images.begin();
-      it->invalid = true;
-
-      // only have a single in-flight request -- remove the rest
-      ++it;
-      while (it != m_updated_images.end()) {
-        m_id_to_updated_images.erase({it->global_image_id,
-                                      it->remote_image_id});
-        it = m_updated_images.erase(it);
-      }
-    }
   }
 
   m_async_op_tracker.start_op();
@@ -413,108 +401,13 @@ void PoolWatcher<I>::handle_image_updated(const std::string &remote_image_id,
   m_pending_added_image_ids.erase(image_id);
   m_pending_removed_image_ids.erase(image_id);
 
-  auto id = std::make_pair(global_image_id, remote_image_id);
-  auto id_it = m_id_to_updated_images.find(id);
-  if (id_it != m_id_to_updated_images.end()) {
-    id_it->second->enabled = enabled;
-    id_it->second->invalid = false;
-  } else if (enabled) {
-    // need to resolve the image name before notifying listener
-    auto it = m_updated_images.emplace(m_updated_images.end(),
-                                       global_image_id, remote_image_id);
-    m_id_to_updated_images[id] = it;
-    schedule_get_image_name();
+  if (enabled) {
+    m_pending_added_image_ids.insert(image_id);
+    schedule_listener();
   } else {
-    // delete image w/ if no resolve name in-flight
     m_pending_removed_image_ids.insert(image_id);
     schedule_listener();
   }
-}
-
-template <typename I>
-void PoolWatcher<I>::schedule_get_image_name() {
-  assert(m_lock.is_locked());
-  if (m_shutting_down || m_blacklisted || m_updated_images.empty() ||
-      m_get_name_in_progress) {
-    return;
-  }
-  m_get_name_in_progress = true;
-
-  auto &updated_image = m_updated_images.front();
-  dout(10) << "global_image_id=" << updated_image.global_image_id << ", "
-           << "remote_image_id=" << updated_image.remote_image_id << dendl;
-
-  librados::ObjectReadOperation op;
-  librbd::cls_client::dir_get_name_start(&op, updated_image.remote_image_id);
-
-  m_async_op_tracker.start_op();
-
-  m_out_bl.clear();
-  librados::AioCompletion *aio_comp = create_rados_callback<
-    PoolWatcher, &PoolWatcher<I>::handle_get_image_name>(this);
-  int r = m_remote_io_ctx.aio_operate(RBD_DIRECTORY, aio_comp, &op, &m_out_bl);
-  assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void PoolWatcher<I>::handle_get_image_name(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  std::string name;
-  if (r == 0) {
-    bufferlist::iterator it = m_out_bl.begin();
-    r = librbd::cls_client::dir_get_name_finish(&it, &name);
-  }
-
-  bool image_ids_invalid = false;
-  {
-    Mutex::Locker locker(m_lock);
-    assert(!m_updated_images.empty());
-    m_get_name_in_progress = false;
-
-    auto updated_image = m_updated_images.front();
-    m_updated_images.pop_front();
-    m_id_to_updated_images.erase(std::make_pair(updated_image.global_image_id,
-                                                updated_image.remote_image_id));
-
-    if (r == 0) {
-      // since names are resolved in event order -- the current update is
-      // the latest state
-      ImageId image_id(updated_image.global_image_id,
-                       updated_image.remote_image_id, name);
-      m_pending_added_image_ids.erase(image_id);
-      m_pending_removed_image_ids.erase(image_id);
-      if (!updated_image.invalid) {
-        if (updated_image.enabled) {
-          m_pending_added_image_ids.insert(image_id);
-        } else {
-          m_pending_removed_image_ids.insert(image_id);
-        }
-        schedule_listener();
-      }
-    } else if (r == -EBLACKLISTED) {
-      dout(0) << "detected client is blacklisted" << dendl;
-
-      m_blacklisted = true;
-    } else if (r == -ENOENT) {
-      dout(10) << "image removed after add notification" << dendl;
-    } else {
-      derr << "error resolving image name " << updated_image.remote_image_id
-           << " (" << updated_image.global_image_id << "): " << cpp_strerror(r)
-           << dendl;
-      image_ids_invalid = true;
-    }
-
-    if (!image_ids_invalid) {
-      schedule_get_image_name();
-    }
-  }
-
-  if (image_ids_invalid) {
-    schedule_refresh_images(5);
-  }
-  m_async_op_tracker.finish_op();
 }
 
 template <typename I>
@@ -603,24 +496,9 @@ void PoolWatcher<I>::notify_listener() {
 
     // merge add/remove notifications into pending set (a given image
     // can only be in one set or another)
-    for (auto it = m_pending_removed_image_ids.begin();
-         it != m_pending_removed_image_ids.end(); ) {
-      if (std::find_if(m_updated_images.begin(), m_updated_images.end(),
-                       [&it](const UpdatedImage &updated_image) {
-              return (it->id == updated_image.remote_image_id);
-            }) != m_updated_images.end()) {
-        // still resolving the name -- so keep it in the pending set
-        auto image_id_it = m_image_ids.find(*it);
-        if (image_id_it != m_image_ids.end()) {
-          m_pending_image_ids.insert(*image_id_it);
-        }
-        ++it;
-        continue;
-      }
-
-      // merge the remove event into the pending set
-      m_pending_image_ids.erase(*it);
-      it = m_pending_removed_image_ids.erase(it);
+    for (auto &image_id : m_pending_removed_image_ids) {
+      dout(20) << "image_id=" << image_id << dendl;
+      m_pending_image_ids.erase(image_id);
     }
 
     for (auto &image_id : m_pending_added_image_ids) {

--- a/src/tools/rbd_mirror/PoolWatcher.h
+++ b/src/tools/rbd_mirror/PoolWatcher.h
@@ -14,8 +14,6 @@
 #include "common/Mutex.h"
 #include "include/rados/librados.hpp"
 #include "types.h"
-#include <list>
-#include <unordered_map>
 #include <boost/functional/hash.hpp>
 #include <boost/optional.hpp>
 #include "include/assert.h"
@@ -101,31 +99,6 @@ private:
    */
   class MirroringWatcher;
 
-  struct UpdatedImage {
-    std::string global_image_id;
-    std::string remote_image_id;
-    bool enabled = true;
-    bool invalid = false;
-
-    UpdatedImage(const std::string &global_image_id,
-                 const std::string &remote_image_id)
-      : global_image_id(global_image_id), remote_image_id(remote_image_id) {
-    }
-  };
-
-  typedef std::pair<std::string, std::string> GlobalRemoteIds;
-  typedef std::list<UpdatedImage> UpdatedImages;
-  typedef std::unordered_map<GlobalRemoteIds, typename UpdatedImages::iterator,
-                             boost::hash<GlobalRemoteIds> > IdToUpdatedImages;
-
-  struct StrictImageIdCompare {
-    bool operator()(const ImageId &lhs, const ImageId &rhs) const {
-      if (lhs.global_id != rhs.global_id) {
-        return lhs.global_id < rhs.global_id;
-      }
-      return lhs.id < rhs.id;
-    }
-  };
   Threads<ImageCtxT> *m_threads;
   librados::IoCtx m_remote_io_ctx;
   Listener &m_listener;
@@ -159,10 +132,6 @@ private:
   bool m_refresh_in_progress = false;
   bool m_deferred_refresh = false;
 
-  UpdatedImages m_updated_images;
-  IdToUpdatedImages m_id_to_updated_images;
-  bool m_get_name_in_progress = false;
-
   void register_watcher();
   void handle_register_watcher(int r);
   void unregister_watcher();
@@ -180,9 +149,6 @@ private:
   void handle_image_updated(const std::string &remote_image_id,
                             const std::string &global_image_id,
                             bool enabled);
-
-  void schedule_get_image_name();
-  void handle_get_image_name(int r);
 
   void schedule_listener();
   void notify_listener();

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -440,7 +440,7 @@ void BootstrapRequest<I>::create_local_image() {
       this);
   CreateImageRequest<I> *request = CreateImageRequest<I>::create(
     m_local_io_ctx, m_work_queue, m_global_image_id, m_remote_mirror_uuid,
-    m_local_image_name, m_remote_image_ctx, ctx);
+    m_local_image_name, m_remote_image_ctx, &m_local_image_id, ctx);
   request->send();
 }
 

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -42,7 +42,7 @@ public:
         librados::IoCtx &remote_io_ctx,
         ImageSyncThrottlerRef<ImageCtxT> image_sync_throttler,
         ImageCtxT **local_image_ctx,
-        const std::string &local_image_name,
+        const std::string &local_image_id,
         const std::string &remote_image_id,
         const std::string &global_image_id,
         ContextWQ *work_queue, SafeTimer *timer,
@@ -56,7 +56,7 @@ public:
         ProgressContext *progress_ctx = nullptr) {
     return new BootstrapRequest(local_io_ctx, remote_io_ctx,
                                 image_sync_throttler, local_image_ctx,
-                                local_image_name, remote_image_id,
+                                local_image_id, remote_image_id,
                                 global_image_id, work_queue, timer, timer_lock,
                                 local_mirror_uuid, remote_mirror_uuid,
                                 journaler, client_meta, on_finish, do_resync,
@@ -67,7 +67,7 @@ public:
                    librados::IoCtx &remote_io_ctx,
                    ImageSyncThrottlerRef<ImageCtxT> image_sync_throttler,
                    ImageCtxT **local_image_ctx,
-                   const std::string &local_image_name,
+                   const std::string &local_image_id,
                    const std::string &remote_image_id,
                    const std::string &global_image_id, ContextWQ *work_queue,
                    SafeTimer *timer, Mutex *timer_lock,
@@ -150,7 +150,6 @@ private:
   librados::IoCtx &m_remote_io_ctx;
   ImageSyncThrottlerRef<ImageCtxT> m_image_sync_throttler;
   ImageCtxT **m_local_image_ctx;
-  std::string m_local_image_name;
   std::string m_local_image_id;
   std::string m_remote_image_id;
   std::string m_global_image_id;

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -34,12 +34,13 @@ CreateImageRequest<I>::CreateImageRequest(librados::IoCtx &local_io_ctx,
                                           const std::string &remote_mirror_uuid,
                                           const std::string &local_image_name,
                                           I *remote_image_ctx,
+					  std::string *local_image_id,
                                           Context *on_finish)
   : m_local_io_ctx(local_io_ctx), m_work_queue(work_queue),
     m_global_image_id(global_image_id),
     m_remote_mirror_uuid(remote_mirror_uuid),
     m_local_image_name(local_image_name), m_remote_image_ctx(remote_image_ctx),
-    m_on_finish(on_finish) {
+    m_local_image_id(local_image_id), m_on_finish(on_finish) {
 }
 
 template <typename I>
@@ -74,12 +75,12 @@ void CreateImageRequest<I>::create_image() {
   image_options.set(RBD_IMAGE_OPTION_STRIPE_COUNT,
                     m_remote_image_ctx->stripe_count);
 
-  std::string id = librbd::util::generate_image_id(m_local_io_ctx);
+  *m_local_image_id = librbd::util::generate_image_id(m_local_io_ctx);;
 
   librbd::image::CreateRequest<I> *req = librbd::image::CreateRequest<I>::create(
-    m_local_io_ctx, m_local_image_name, id, m_remote_image_ctx->size,
-    image_options, m_global_image_id, m_remote_mirror_uuid, false,
-    m_remote_image_ctx->op_work_queue, ctx);
+    m_local_io_ctx, m_local_image_name, *m_local_image_id,
+    m_remote_image_ctx->size, image_options, m_global_image_id,
+    m_remote_mirror_uuid, false, m_remote_image_ctx->op_work_queue, ctx);
   req->send();
 }
 
@@ -289,14 +290,14 @@ void CreateImageRequest<I>::clone_image() {
   opts.set(RBD_IMAGE_OPTION_STRIPE_UNIT, m_remote_image_ctx->stripe_unit);
   opts.set(RBD_IMAGE_OPTION_STRIPE_COUNT, m_remote_image_ctx->stripe_count);
 
-  std::string id = librbd::util::generate_image_id(m_local_io_ctx);
+  *m_local_image_id = librbd::util::generate_image_id(m_local_io_ctx);;
 
   using klass = CreateImageRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_clone_image>(this);
 
   librbd::image::CloneRequest<I> *req = librbd::image::CloneRequest<I>::create(
-    m_local_parent_image_ctx, m_local_io_ctx, m_local_image_name, id, opts,
-    m_global_image_id, m_remote_mirror_uuid,
+    m_local_parent_image_ctx, m_local_io_ctx, m_local_image_name,
+    *m_local_image_id, opts, m_global_image_id, m_remote_mirror_uuid,
     m_remote_image_ctx->op_work_queue, ctx);
   req->send();
 }

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -289,11 +289,13 @@ void CreateImageRequest<I>::clone_image() {
   opts.set(RBD_IMAGE_OPTION_STRIPE_UNIT, m_remote_image_ctx->stripe_unit);
   opts.set(RBD_IMAGE_OPTION_STRIPE_COUNT, m_remote_image_ctx->stripe_count);
 
+  std::string id = librbd::util::generate_image_id(m_local_io_ctx);
+
   using klass = CreateImageRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_clone_image>(this);
 
   librbd::image::CloneRequest<I> *req = librbd::image::CloneRequest<I>::create(
-    m_local_parent_image_ctx, m_local_io_ctx, m_local_image_name, opts,
+    m_local_parent_image_ctx, m_local_io_ctx, m_local_image_name, id, opts,
     m_global_image_id, m_remote_mirror_uuid,
     m_remote_image_ctx->op_work_queue, ctx);
   req->send();

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -27,10 +27,11 @@ public:
                                     const std::string &remote_mirror_uuid,
                                     const std::string &local_image_name,
                                     ImageCtxT *remote_image_ctx,
+				    std::string *local_image_id,
                                     Context *on_finish) {
     return new CreateImageRequest(local_io_ctx, work_queue, global_image_id,
                                   remote_mirror_uuid, local_image_name,
-                                  remote_image_ctx, on_finish);
+                                  remote_image_ctx, local_image_id, on_finish);
   }
 
   CreateImageRequest(librados::IoCtx &local_io_ctx, ContextWQ *work_queue,
@@ -38,6 +39,7 @@ public:
                      const std::string &remote_mirror_uuid,
                      const std::string &local_image_name,
                      ImageCtxT *remote_image_ctx,
+		     std::string *local_image_id,
                      Context *on_finish);
 
   void send();
@@ -85,6 +87,7 @@ private:
   std::string m_remote_mirror_uuid;
   std::string m_local_image_name;
   ImageCtxT *m_remote_image_ctx;
+  std::string *m_local_image_id;
   Context *m_on_finish;
 
   librados::IoCtx m_remote_parent_io_ctx;

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -70,13 +70,12 @@ struct MirrorJournalPolicy : public librbd::journal::Policy {
 template <typename I>
 OpenLocalImageRequest<I>::OpenLocalImageRequest(librados::IoCtx &local_io_ctx,
                                                 I **local_image_ctx,
-                                                const std::string &local_image_name,
                                                 const std::string &local_image_id,
                                                 ContextWQ *work_queue,
                                                 Context *on_finish)
   : m_local_io_ctx(local_io_ctx), m_local_image_ctx(local_image_ctx),
-    m_local_image_name(local_image_name), m_local_image_id(local_image_id),
-    m_work_queue(work_queue), m_on_finish(on_finish) {
+    m_local_image_id(local_image_id), m_work_queue(work_queue),
+    m_on_finish(on_finish) {
 }
 
 template <typename I>
@@ -88,7 +87,7 @@ template <typename I>
 void OpenLocalImageRequest<I>::send_open_image() {
   dout(20) << dendl;
 
-  *m_local_image_ctx = I::create(m_local_image_name, m_local_image_id, nullptr,
+  *m_local_image_ctx = I::create("", m_local_image_id, nullptr,
                                  m_local_io_ctx, false);
   {
     RWLock::WLocker owner_locker((*m_local_image_ctx)->owner_lock);

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.h
@@ -21,18 +21,15 @@ class OpenLocalImageRequest {
 public:
   static OpenLocalImageRequest* create(librados::IoCtx &local_io_ctx,
                                        ImageCtxT **local_image_ctx,
-                                       const std::string &local_image_name,
                                        const std::string &local_image_id,
                                        ContextWQ *work_queue,
                                        Context *on_finish) {
     return new OpenLocalImageRequest(local_io_ctx, local_image_ctx,
-                                     local_image_name, local_image_id,
-                                     work_queue, on_finish);
+                                     local_image_id, work_queue, on_finish);
   }
 
   OpenLocalImageRequest(librados::IoCtx &local_io_ctx,
                         ImageCtxT **local_image_ctx,
-                        const std::string &local_image_name,
                         const std::string &local_image_id,
                         ContextWQ *m_work_queue,
                         Context *on_finish);
@@ -61,7 +58,6 @@ private:
    */
   librados::IoCtx &m_local_io_ctx;
   ImageCtxT **m_local_image_ctx;
-  std::string m_local_image_name;
   std::string m_local_image_id;
   ContextWQ *m_work_queue;
   Context *m_on_finish;

--- a/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.cc
+++ b/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.cc
@@ -24,6 +24,7 @@ using librbd::util::create_rados_callback;
 
 template <typename I>
 void RefreshImagesRequest<I>::send() {
+  m_image_ids->clear();
   mirror_image_list();
 }
 
@@ -58,67 +59,15 @@ void RefreshImagesRequest<I>::handle_mirror_image_list(int r) {
     return;
   }
 
-  if (!ids.empty()) {
-    m_local_to_global_ids.insert(ids.begin(), ids.end());
-    if (ids.size() == MAX_RETURN) {
-      m_start_after = ids.rbegin()->first;
-      mirror_image_list();
-      return;
-    }
+  // store as global -> local image ids
+  for (auto &id : ids) {
+    m_image_ids->emplace(id.second, id.first);
   }
 
-  dir_list();
-}
-
-template <typename I>
-void RefreshImagesRequest<I>::dir_list() {
-  dout(10) << dendl;
-
-  m_out_bl.clear();
-  m_start_after = "";
-
-  librados::ObjectReadOperation op;
-  librbd::cls_client::dir_list_start(&op, m_start_after, MAX_RETURN);
-
-  librados::AioCompletion *aio_comp = create_rados_callback<
-    RefreshImagesRequest<I>,
-    &RefreshImagesRequest<I>::handle_dir_list>(this);
-  int r = m_remote_io_ctx.aio_operate(RBD_DIRECTORY, aio_comp, &op, &m_out_bl);
-  assert(r == 0);
-  aio_comp->release();
-}
-
-template <typename I>
-void RefreshImagesRequest<I>::handle_dir_list(int r) {
-  dout(10) << "r=" << r << dendl;
-
-  std::map<std::string, std::string> name_to_ids;
-  if (r == 0) {
-    bufferlist::iterator it = m_out_bl.begin();
-    r = librbd::cls_client::dir_list_finish(&it, &name_to_ids);
-  }
-
-  if (r < 0 && r != -ENOENT) {
-    derr << "failed to list images: " << cpp_strerror(r) << dendl;
-    finish(r);
+  if (ids.size() == MAX_RETURN) {
+    m_start_after = ids.rbegin()->first;
+    mirror_image_list();
     return;
-  }
-
-  if (!name_to_ids.empty()) {
-    for (auto &pair : name_to_ids) {
-      auto it = m_local_to_global_ids.find(pair.second);
-      if (it != m_local_to_global_ids.end()) {
-        // mirrored image must exist within directory to be treated as
-        // a valid image
-        m_image_ids->insert(ImageId(it->second, it->first, pair.first));
-      }
-    }
-
-    if (name_to_ids.size() == MAX_RETURN) {
-      m_start_after = name_to_ids.rbegin()->first;
-      dir_list();
-      return;
-    }
   }
 
   finish(0);

--- a/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.h
+++ b/src/tools/rbd_mirror/pool_watcher/RefreshImagesRequest.h
@@ -8,7 +8,6 @@
 #include "include/rados/librados.hpp"
 #include "tools/rbd_mirror/types.h"
 #include <string>
-#include <unordered_map>
 
 struct Context;
 
@@ -45,18 +44,11 @@ private:
    *    v   v             | (more images)
    * MIRROR_IMAGE_LIST ---/
    *    |
-   *    |   /-------------\
-   *    |   |             |
-   *    v   v             | (more images)
-   * DIR_LIST ------------/
-   *    |
    *    v
    * <finish>
    *
    * @endverbatim
    */
-
-  typedef std::unordered_map<std::string, std::string> LocalToGlobalIds;
 
   librados::IoCtx &m_remote_io_ctx;
   ImageIds *m_image_ids;
@@ -64,13 +56,9 @@ private:
 
   bufferlist m_out_bl;
   std::string m_start_after;
-  LocalToGlobalIds m_local_to_global_ids;
 
   void mirror_image_list();
   void handle_mirror_image_list(int r);
-
-  void dir_list();
-  void handle_dir_list(int r);
 
   void finish(int r);
 

--- a/src/tools/rbd_mirror/types.cc
+++ b/src/tools/rbd_mirror/types.cc
@@ -8,8 +8,7 @@ namespace mirror {
 
 std::ostream &operator<<(std::ostream &os, const ImageId &image_id) {
   return os << "global id=" << image_id.global_id << ", "
-            << "id=" << image_id.id << ", "
-            << "name=" << image_id.name;
+            << "id=" << image_id.id;
 }
 
 std::ostream& operator<<(std::ostream& lhs, const peer_t &peer) {

--- a/src/tools/rbd_mirror/types.h
+++ b/src/tools/rbd_mirror/types.h
@@ -9,7 +9,6 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <boost/optional.hpp>
 
 #include "include/rbd/librbd.hpp"
 #include "ImageSyncThrottler.h"
@@ -27,20 +26,15 @@ using ImageSyncThrottlerRef = std::shared_ptr<ImageSyncThrottler<I>>;
 struct ImageId {
   std::string global_id;
   std::string id;
-  boost::optional<std::string> name;
 
   explicit ImageId(const std::string &global_id) : global_id(global_id) {
   }
   ImageId(const std::string &global_id, const std::string &id)
     : global_id(global_id), id(id) {
   }
-  ImageId(const std::string &global_id, const std::string &id,
-          const std::string &name)
-    : global_id(global_id), id(id), name(name) {
-  }
 
   inline bool operator==(const ImageId &rhs) const {
-    return (global_id == rhs.global_id && id == rhs.id && name == rhs.name);
+    return (global_id == rhs.global_id && id == rhs.id);
   }
   inline bool operator<(const ImageId &rhs) const {
     return global_id < rhs.global_id;


### PR DESCRIPTION
Previously, during bootstrap a known image name needed to be used to create the images so that the auto-generated image id could be retrieved. Now rbd-mirror will provide its own auto-generated image id to librbd -- eliminating the need to pass around an initial image name upon creation.