### PR TITLE
tests: set -x in suites/iozone.sh workunit

### DIFF
--- a/qa/workunits/suites/iozone.sh
+++ b/qa/workunits/suites/iozone.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 iozone -c -e -s 1024M -r 16K -t 1 -F f1 -i 0 -i 1
 iozone -c -e -s 1024M -r 1M -t 1 -F f2 -i 0 -i 1


### PR DESCRIPTION
Seems like this should be a "best practice."

Fixes: http://tracker.ceph.com/issues/19740
Signed-off-by: Nathan Cutler <ncutler@suse.com>