### PR TITLE
ceph-kvstore-tool: allow 'bluestore-kv' as kvdb type; add escaping, compaction

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -399,6 +399,7 @@ set(libcommon_files
   ${crush_srcs}
   common/cmdparse.cc
   common/escape.c
+  common/url_escape.cc
   common/io_priority.cc
   common/Clock.cc
   common/ceph_time.cc

--- a/src/common/url_escape.cc
+++ b/src/common/url_escape.cc
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "url_escape.h"
+
+#include <stdexcept>
+#include <sstream>
+
+std::string url_escape(const std::string& s)
+{
+  std::string out;
+  for (auto c : s) {
+    if (std::isalnum(c) || c == '-' || c == '.' || c == '_' || c == '~' ||
+	c == '/') {
+      out.push_back(c);
+    } else {
+      char t[4];
+      snprintf(t, sizeof(t), "%%%02x", (int)(unsigned char)c);
+      out.append(t);
+    }
+  }
+  return out;
+}
+
+std::string url_unescape(const std::string& s)
+{
+  std::string out;
+  const char *end = s.c_str() + s.size();
+  for (const char *c = s.c_str(); c < end; ++c) {
+    switch (*c) {
+    case '%':
+      {
+	unsigned char v = 0;
+	for (unsigned i=0; i<2; ++i) {
+	  ++c;
+	  if (c >= end) {
+	    std::ostringstream ss;
+	    ss << "invalid escaped string at pos " << (c - s.c_str()) << " of '"
+	       << s << "'";
+	    throw std::runtime_error(ss.str());
+	  }
+	  v <<= 4;
+	  if (*c >= '0' && *c <= '9') {
+	    v += *c - '0';
+	  } else if (*c >= 'a' && *c <= 'f') {
+	    v += *c - 'a' + 10;
+	  } else if (*c >= 'A' && *c <= 'F') {
+	    v += *c - 'A' + 10;
+	  } else {
+	    std::ostringstream ss;
+	    ss << "invalid escaped string at pos " << (c - s.c_str()) << " of '"
+	       << s << "'";
+	    throw std::runtime_error(ss.str());
+	  }
+	}
+	out.push_back(v);
+      }
+      break;
+    default:
+      out.push_back(*c);
+    }
+  }
+  return out;
+}

--- a/src/common/url_escape.h
+++ b/src/common/url_escape.h
@@ -1,0 +1,9 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#pragma once
+
+#include <string>
+
+extern std::string url_escape(const std::string& s);
+extern std::string url_unescape(const std::string& s);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4023,7 +4023,7 @@ bool BlueStore::test_mount_in_use()
   return ret;
 }
 
-int BlueStore::_open_db(bool create)
+int BlueStore::_open_db(bool create, bool kv_no_open)
 {
   int r;
   assert(!db);
@@ -4262,6 +4262,9 @@ int BlueStore::_open_db(bool create)
   if (kv_backend == "rocksdb")
     options = cct->_conf->bluestore_rocksdb_options;
   db->init(options);
+  if (kv_no_open) {
+    return 0;
+  }
   if (create)
     r = db->create_and_open(err);
   else
@@ -4810,7 +4813,7 @@ void BlueStore::set_cache_shards(unsigned num)
   }
 }
 
-int BlueStore::mount()
+int BlueStore::_mount(bool kv_only)
 {
   dout(1) << __func__ << " path " << path << dendl;
 
@@ -4858,9 +4861,12 @@ int BlueStore::mount()
   if (r < 0)
     goto out_fsid;
 
-  r = _open_db(false);
+  r = _open_db(false, kv_only);
   if (r < 0)
     goto out_bdev;
+
+  if (kv_only)
+    return 0;
 
   r = _open_super_meta();
   if (r < 0)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1870,7 +1870,7 @@ private:
 
   int _open_bdev(bool create);
   void _close_bdev();
-  int _open_db(bool create);
+  int _open_db(bool create, bool kv_no_open=false);
   void _close_db();
   int _open_fm(bool create);
   void _close_fm();
@@ -2031,8 +2031,21 @@ public:
 
   bool test_mount_in_use() override;
 
-  int mount() override;
+private:
+  int _mount(bool kv_only);
+public:
+  int mount() override {
+    return _mount(false);
+  }
   int umount() override;
+
+  int start_kv_only(KeyValueDB **pdb) {
+    int r = _mount(true);
+    if (r < 0)
+      return r;
+    *pdb = db;
+    return 0;
+  }
 
   int fsck(bool deep) override;
 

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -139,6 +139,13 @@ add_executable(unittest_safe_io
 add_ceph_unittest(unittest_safe_io ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_safe_io)
 target_link_libraries(unittest_safe_io global)
 
+# unittest_url_escape
+add_executable(unittest_url_escape
+  test_url_escape.cc
+  )
+add_ceph_unittest(unittest_url_escape ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_url_escape)
+target_link_libraries(unittest_url_escape ceph-common)
+
 # unittest_readahead
 add_executable(unittest_readahead
   Readahead.cc

--- a/src/test/common/test_url_escape.cc
+++ b/src/test/common/test_url_escape.cc
@@ -1,0 +1,36 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/url_escape.h"
+
+#include "gtest/gtest.h"
+
+TEST(url_escape, escape) {
+  ASSERT_EQ(url_escape("foo bar"), std::string("foo%20bar"));
+  ASSERT_EQ(url_escape("foo\nbar"), std::string("foo%0abar"));
+}
+
+TEST(url_escape, unescape) {
+  ASSERT_EQ(url_unescape("foo%20bar"), std::string("foo bar"));
+  ASSERT_EQ(url_unescape("foo%0abar"), std::string("foo\nbar"));
+  ASSERT_EQ(url_unescape("%20"), std::string(" "));
+  ASSERT_EQ(url_unescape("\0%20"), std::string("\0 "));
+  ASSERT_EQ(url_unescape("\x01%20"), std::string("\x01 "));
+}
+
+TEST(url_escape, all_chars) {
+  std::string a;
+  for (unsigned j=0; j<256; ++j) {
+    a.push_back((char)j);
+  }
+  std::string b = url_escape(a);
+  std::cout << "escaped: " << b << std::endl;
+  ASSERT_EQ(a, url_unescape(b));
+}
+
+TEST(url_escape, invalid) {
+  ASSERT_THROW(url_unescape("foo%xx"), std::runtime_error);
+  ASSERT_THROW(url_unescape("foo%%"), std::runtime_error);
+  ASSERT_THROW(url_unescape("foo%"), std::runtime_error);
+  ASSERT_THROW(url_unescape("foo%0"), std::runtime_error);
+}

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -64,7 +64,7 @@ class StoreTool
         break;
 
       if (out)
-        *out << rk.first << ":" << rk.second;
+        *out << rk.first << "\t" << rk.second;
       if (do_crc) {
         bufferlist bl;
         bl.append(rk.first);
@@ -73,7 +73,7 @@ class StoreTool
 
         crc = bl.crc32c(crc);
         if (out) {
-          *out << " (" << bl.crc32c(0) << ")";
+          *out << "\t" << bl.crc32c(0);
         }
       }
       if (out)

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -26,6 +26,7 @@
 #include "include/utime.h"
 #include "common/Clock.h"
 #include "kv/KeyValueDB.h"
+#include "common/url_escape.h"
 
 using namespace std;
 
@@ -64,7 +65,7 @@ class StoreTool
         break;
 
       if (out)
-        *out << rk.first << "\t" << rk.second;
+        *out << url_escape(rk.first) << "\t" << url_escape(rk.second);
       if (do_crc) {
         bufferlist bl;
         bl.append(rk.first);
@@ -255,7 +256,7 @@ int main(int argc, const char *argv[])
   if (cmd == "list" || cmd == "list-crc") {
     string prefix;
     if (argc > 4)
-      prefix = argv[4];
+      prefix = url_unescape(argv[4]);
 
     bool do_crc = (cmd == "list-crc");
 
@@ -267,12 +268,12 @@ int main(int argc, const char *argv[])
       usage(argv[0]);
       return 1;
     }
-    string prefix(argv[4]);
+    string prefix(url_unescape(argv[4]));
     if (argc > 5)
-      key = argv[5];
+      key = url_unescape(argv[5]);
 
     bool ret = st.exists(prefix, key);
-    std::cout << "(" << prefix << ", " << key << ") "
+    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ") "
       << (ret ? "exists" : "does not exist")
       << std::endl;
     return (ret ? 0 : 1);
@@ -282,12 +283,12 @@ int main(int argc, const char *argv[])
       usage(argv[0]);
       return 1;
     }
-    string prefix(argv[4]);
-    string key(argv[5]);
+    string prefix(url_unescape(argv[4]));
+    string key(url_unescape(argv[5]));
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
-    std::cout << "(" << prefix << ", " << key << ")";
+    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ")";
     if (!exists) {
       std::cout << " does not exist" << std::endl;
       return 1;
@@ -329,12 +330,12 @@ int main(int argc, const char *argv[])
       usage(argv[0]);
       return 1;
     }
-    string prefix(argv[4]);
-    string key(argv[5]);
+    string prefix(url_unescape(argv[4]));
+    string key(url_unescape(argv[5]));
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
-    std::cout << "(" << prefix << ", " << key << ") ";
+    std::cout << "(" << url_escape(prefix) << ", " << url_escape(key) << ") ";
     if (!exists) {
       std::cout << " does not exist" << std::endl;
       return 1;
@@ -351,17 +352,17 @@ int main(int argc, const char *argv[])
       usage(argv[0]);
       return 1;
     }
-    string prefix(argv[4]);
-    string key(argv[5]);
+    string prefix(url_unescape(argv[4]));
+    string key(url_unescape(argv[5]));
 
     bool exists = false;
     bufferlist bl = st.get(prefix, key, exists);
     if (!exists) {
-      std::cerr << "(" << prefix << "," << key
+      std::cerr << "(" << url_escape(prefix) << "," << url_escape(key)
                 << ") does not exist" << std::endl;
       return 1;
     }
-    std::cout << "(" << prefix << "," << key
+    std::cout << "(" << url_escape(prefix) << "," << url_escape(key)
               << ") size " << si_t(bl.length()) << std::endl;
 
   } else if (cmd == "set") {
@@ -369,8 +370,8 @@ int main(int argc, const char *argv[])
       usage(argv[0]);
       return 1;
     }
-    string prefix(argv[4]);
-    string key(argv[5]);
+    string prefix(url_unescape(argv[4]));
+    string key(url_unescape(argv[5]));
     string subcmd(argv[6]);
 
     bufferlist val;
@@ -397,7 +398,7 @@ int main(int argc, const char *argv[])
     bool ret = st.set(prefix, key, val);
     if (!ret) {
       std::cerr << "error setting ("
-                << prefix << "," << key << ")" << std::endl;
+                << url_escape(prefix) << "," << url_escape(key) << ")" << std::endl;
       return 1;
     }
   } else if (cmd == "store-copy") {

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -37,7 +37,12 @@ class StoreTool
   public:
   StoreTool(string type, const string &path) : store_path(path) {
     KeyValueDB *db_ptr = KeyValueDB::create(g_ceph_context, type, path);
-    assert(!db_ptr->open(std::cerr));
+    int r = db_ptr->open(std::cerr);
+    if (r < 0) {
+      cerr << "failed to open type " << type << " path " << path << ": "
+	   << cpp_strerror(r) << std::endl;
+      exit(1);
+    }
     db.reset(db_ptr);
   }
 

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -211,6 +211,16 @@ class StoreTool
 
     return 0;
   }
+
+  void compact() {
+    db->compact();
+  }
+  void compact_prefix(string prefix) {
+    db->compact_prefix(prefix);
+  }
+  void compact_range(string prefix, string start, string end) {
+    db->compact_range(prefix, start, end);
+  }
 };
 
 void usage(const char *pname)
@@ -227,6 +237,9 @@ void usage(const char *pname)
     << "  set <prefix> <key> [ver <N>|in <file>]\n"
     << "  store-copy <path> [num-keys-per-tx]\n"
     << "  store-crc <path>\n"
+    << "  compact\n"
+    << "  compact-prefix <prefix>\n"
+    << "  compact-range <prefix> <start> <end>\n"
     << std::endl;
 }
 
@@ -426,6 +439,24 @@ int main(int argc, const char *argv[])
     uint32_t crc = st.traverse(string(), true, NULL);
     std::cout << "store at '" << path << "' crc " << crc << std::endl;
 
+  } else if (cmd == "compact") {
+    st.compact();
+  } else if (cmd == "compact-prefix") {
+    if (argc < 5) {
+      usage(argv[0]);
+      return 1;
+    }
+    string prefix(url_unescape(argv[4]));
+    st.compact_prefix(prefix);
+  } else if (cmd == "compact-range") {
+    if (argc < 7) {
+      usage(argv[0]);
+      return 1;
+    }
+    string prefix(url_unescape(argv[4]));
+    string start(url_unescape(argv[5]));
+    string end(url_unescape(argv[6]));
+    st.compact_range(prefix, start, end);
   } else {
     std::cerr << "Unrecognized command: " << cmd << std::endl;
     return 1;


### PR DESCRIPTION
Also some clenaup to wip-bluestore-tool in here.

This is enough to let you manipulate a rocksdb instance embedded in bluestore (and bluefs)
for debugging/repair purposes.

It leaks memory. I think this is fine.