### PR TITLE
radosgw-admin: warn that 'realm rename' does not update other clusters

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3286,6 +3286,9 @@ int main(int argc, const char **argv)
 	  cerr << "realm.rename failed: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
+        cout << "Realm name updated. Note that this change only applies to "
+            "the current cluster, so this command must be run separately "
+            "on each of the realm's other clusters." << std::endl;
       }
       break;
     case OPT_REALM_SET:


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19746