### PR TITLE
qa/workunits/ceph-helpers.sh: fix test_wait_for_health.

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1329,7 +1329,7 @@ function test_wait_for_health_ok() {
     run_mgr $dir x || return 1
     ! TIMEOUT=1 wait_for_health_ok || return 1
     run_osd $dir 0 || return 1
-    wait_for_health_ok || return 1
+    wait_for_health "HEALTH_ERR too few PGs per OSD" || return 1
     teardown $dir || return 1
 }
 


### PR DESCRIPTION
- There are not enough pg's to actually start a clean cluster

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>