### PR TITLE
osdc: silence warning from `-Wsign-compare`

### DIFF
--- a/src/osdc/Journaler.cc
+++ b/src/osdc/Journaler.cc
@@ -640,7 +640,7 @@ void Journaler::_do_flush(unsigned amount)
       waiting_for_zero = true;
       return;
     }
-    if (newlen < len) {
+    if (static_cast<uint64_t>(newlen) < len) {
       ldout(cct, 10) << "_do_flush wanted to do " << flush_pos << "~" << len
 		     << " but hit prezero_pos " << prezero_pos
 		     << ", will do " << flush_pos << "~" << newlen << dendl;


### PR DESCRIPTION
```
The following warning appears during make:
[ 28%] Building CXX object src/mds/CMakeFiles/mds.dir/__/osdc/Journaler.cc.o
./src/osdc/Journaler.cc: In member function ‘void Journaler::_do_flush(unsigned int)’:
./src/osdc/Journaler.cc:643:16: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (newlen < len) {
         ~~~~~~~^~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>