### PR TITLE
mon/OSDMonitor: update pg_creatings even the new acting set is empty

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3184,9 +3184,6 @@ void OSDMonitor::update_creating_pgs()
     auto pgid = pg.first;
     auto& created = pg.second.first;
     mapping.get(pgid, nullptr, nullptr, nullptr, &acting_primary);
-    if (acting_primary < 0) {
-      continue;
-    }
     // check the previous creating_pgs, look for the target to whom the pg was
     // previously mapped
     for (const auto& pgs_by_epoch : creating_pgs_by_osd_epoch) {


### PR DESCRIPTION
there are chances that the acting set of a PG being created becomes empty,
and then OSDs join the acting set. in that case, we need also update
the "create" epoch of the creating_pgs, so the new primary can be
updated with the MOSDPCreate message.

Fixes: http://tracker.ceph.com/issues/19744
Signed-off-by: Kefu Chai <kchai@redhat.com>