### PR TITLE
os/bluestore: use correct bound encode size for unused

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -519,7 +519,7 @@ public:
     denc(csum_chunk_order, p);
     denc_varint(csum_data.length(), p);
     p += csum_data.length();
-    p += sizeof(unsigned long long);
+    p += sizeof(unused_t);
   }
 
   void encode(bufferlist::contiguous_appender& p, uint64_t struct_v) const {


### PR DESCRIPTION
Signed-off-by: Haomai Wang <haomai@xsky.com>