### PR TITLE
t/osd/osd-scrub-repair.sh: Adjust for FreeBSD

### DIFF
--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -17,15 +17,22 @@
 source $(dirname $0)/../detect-build-env-vars.sh
 source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
 
+if [ `uname` = FreeBSD ]; then
+    use_bluestore=false
+    termwidth=$(stty -a | head -1 | sed -e 's/.* \([0-9]*\) columns.*/\1/')
+else
+    use_bluestore=true
+    termwidth=$(stty -a | head -1 | sed -e 's/.*columns \([0-9]*\).*/\1/')
+fi
+
 # Test development and debugging
 # Set to "yes" in order to ignore diff errors and save results to update test
 getjson="no"
 
-termwidth=$(stty -a | head -1 | sed -e 's/.*columns \([0-9]*\).*/\1/')
 if test -n "$termwidth" -a "$termwidth" != "0"; then termwidth="-W ${termwidth}"; fi
 
 # Ignore the epoch and filter out the attr '_' value because it has date information and won't match
-jqfilter='.inconsistents | (.[].shards[].attrs[] | select(.name == "_") | .value) |= "----Stripped-by-test----"'
+jqfilter='.inconsistents | (.[].shards[].attrs[]? | select(.name == "_") | .value) |= "----Stripped-by-test----"'
 sortkeys='import json; import sys ; JSON=sys.stdin.read() ; ud = json.loads(JSON) ; print json.dumps(ud, sort_keys=True, indent=2)'
 
 # Remove items are not consistent across runs, the pg interval and client
@@ -240,7 +247,9 @@ function TEST_auto_repair_erasure_coded_appends() {
 }
 
 function TEST_auto_repair_erasure_coded_overwrites() {
-    auto_repair_erasure_coded $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        auto_repair_erasure_coded $1 true
+    fi
 }
 
 function corrupt_and_repair_jerasure() {
@@ -271,7 +280,9 @@ function TEST_corrupt_and_repair_jerasure_appends() {
 }
 
 function TEST_corrupt_and_repair_jerasure_overwrites() {
-    corrupt_and_repair_jerasure $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        corrupt_and_repair_jerasure $1 true
+    fi
 }
 
 function corrupt_and_repair_lrc() {
@@ -302,7 +313,9 @@ function TEST_corrupt_and_repair_lrc_appends() {
 }
 
 function TEST_corrupt_and_repair_lrc_overwrites() {
-    corrupt_and_repair_jerasure $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        corrupt_and_repair_jerasure $1 true
+    fi
 }
 
 function unfound_erasure_coded() {
@@ -368,7 +381,9 @@ function TEST_unfound_erasure_coded_appends() {
 }
 
 function TEST_unfound_erasure_coded_overwrites() {
-    unfound_erasure_coded $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        unfound_erasure_coded $1 true
+    fi
 }
 
 #
@@ -446,7 +461,9 @@ function TEST_list_missing_erasure_coded_appends() {
 }
 
 function TEST_list_missing_erasure_coded_overwrites() {
-    list_missing_erasure_coded $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        list_missing_erasure_coded $1 true
+    fi
 }
 
 #
@@ -2231,7 +2248,9 @@ function TEST_corrupt_scrub_erasure_appends() {
 }
 
 function TEST_corrupt_scrub_erasure_overwrites() {
-    corrupt_scrub_erasure $1 true
+    if [ "$use_bluestore" = "true" ]; then
+        corrupt_scrub_erasure $1 true
+    fi
 }
 
 #

--- a/src/test/osd/osd-scrub-snaps.sh
+++ b/src/test/osd/osd-scrub-snaps.sh
@@ -17,6 +17,15 @@
 source $(dirname $0)/../detect-build-env-vars.sh
 source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
 
+if [ `uname` = FreeBSD ]; then
+    DIFFCOLOPTS=""
+else
+    termwidth=$(stty -a | head -1 | sed -e 's/.*columns \([0-9]*\).*/\1/')
+    if test -n "$termwidth" -a "$termwidth" != "0"; then termwidth="-W ${termwidth}"; fi
+    DIFCOLOPTS="-y -W $termwidth"
+fi
+
+
 function run() {
     local dir=$1
     shift
@@ -400,7 +409,7 @@ function TEST_scrub_snaps() {
 EOF
 
     jq "$jqfilter" $dir/json | python -c "$sortkeys" > $dir/csjson
-    diff -y $dir/checkcsjson $dir/csjson || return 1
+    diff ${DIFFCOLOPTS} $dir/checkcsjson $dir/csjson || return 1
 
     if which jsonschema > /dev/null;
     then


### PR DESCRIPTION
- Do not test Bluestore
 - output of stty has diffrent order
 - the JQ expression errors out with:
    (version 1.5-1-g940132e-dirty)
====
jq: error (at <stdin>:232): Cannot iterate over null (null)
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
    return _default_decoder.decode(s)
  File "/usr/lib64/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib64/python2.7/json/decoder.py", line 383, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
====
    Adding a ? to the jq expression allows to proceed on null blocks.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>