### PR TITLE
src/common: change last_work_queue to next_work_queue. 

### DIFF
--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -39,7 +39,6 @@ ThreadPool::ThreadPool(CephContext *cct_, string nm, string tn, int n, const cha
     ioprio_class(-1),
     ioprio_priority(-1),
     _num_threads(n),
-    last_work_queue(0),
     processing(0)
 {
   if (option) {
@@ -117,9 +116,8 @@ void ThreadPool::worker(WorkThread *wt)
       int tries = work_queues.size();
       bool did = false;
       while (tries--) {
-	last_work_queue++;
-	last_work_queue %= work_queues.size();
-	wq = work_queues[last_work_queue];
+	next_work_queue %= work_queues.size();
+	wq = work_queues[next_work_queue++];
 	
 	void *item = wq->_void_dequeue();
 	if (item) {

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -434,7 +434,7 @@ public:
   };
 private:
   vector<WorkQueue_*> work_queues;
-  int last_work_queue;
+  int next_work_queue = 0;
  
 
   // threads


### PR DESCRIPTION
 In current ceph code, last_work_queue(0) in construction list of ThreadPool, so that wq is always started from work_queue[1] instead of work_queue[0] when multiple queues: 
```
   last_work_queue++;
   last_work_queue %= work_queues.size();
   wq = work_queues[last_work_queue];
```

Signed-off-by: Pan Liu <liupan1111@gmail.com>