### PR TITLE
cleanup: fix 'variable unused warnings

### DIFF
--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -316,7 +316,7 @@ global_init(std::vector < const char * > *alt_def_args,
   if (g_conf->debug_deliberately_leak_memory) {
     derr << "deliberately leaking some memory" << dendl;
     char *s = new char[1234567];
-    (void)s;
+    IGNORE_UNUSED(s);
     // cppcheck-suppress memleak
   }
 

--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -96,7 +96,7 @@ static void handle_fatal_signal(int signum)
   char buf[1024];
   char pthread_name[16] = {0}; //limited by 16B include terminating null byte.
   int r = ceph_pthread_getname(pthread_self(), pthread_name, sizeof(pthread_name));
-  (void)r;
+  IGNORE_UNUSED(r);
 #if defined(__sun)
   char message[SIG2STR_MAX];
   sig2str(signum,message);

--- a/src/include/compat.h
+++ b/src/include/compat.h
@@ -165,4 +165,6 @@
     0; })
 #endif
 
+#define IGNORE_UNUSED(v) ((void)(v))
+
 #endif /* !CEPH_COMPAT_H */

--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -21,6 +21,7 @@
 #include <netinet/tcp.h>
 #include <arpa/inet.h>
 
+#include "include/compat.h"
 #include "net_handler.h"
 #include "common/errno.h"
 #include "common/debug.h"
@@ -34,6 +35,7 @@ namespace ceph{
 int NetHandler::create_socket(int domain, bool reuse_addr)
 {
   int s, on = 1;
+  IGNORE_UNUSED(on);
 
   if ((s = ::socket(domain, SOCK_STREAM, 0)) == -1) {
     lderr(cct) << __func__ << " couldn't create socket " << cpp_strerror(errno) << dendl;
@@ -127,6 +129,7 @@ void NetHandler::set_priority(int sd, int prio, int domain)
 {
   if (prio >= 0) {
     int r = -1;
+    IGNORE_UNUSED(r);
 #ifdef IPTOS_CLASS_CS6
     int iptos = IPTOS_CLASS_CS6;
     r = ::setsockopt(sd, IPPROTO_IP, IP_TOS, &iptos, sizeof(iptos));

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -920,6 +920,7 @@ void Pipe::set_socket_options()
   int prio = msgr->get_socket_priority();
   if (prio >= 0) {
     int r = -1;
+    IGNORE_UNUSED(r);
 #ifdef IPTOS_CLASS_CS6
     int iptos = IPTOS_CLASS_CS6;
 
@@ -1841,7 +1842,7 @@ void Pipe::writer()
       if (sd >= 0) {
 	// we can ignore return value, actually; we don't care if this succeeds.
 	int r = ::write(sd, &tag, 1);
-	(void)r;
+	IGNORE_UNUSED(r);
       }
       pipe_lock.Lock();
       continue;

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -824,6 +824,7 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
     list<write_item>::iterator it = items.begin();
     while (it != items.end()) {
       uint64_t bytes = it->bl.length();
+      IGNORE_UNUSED(bytes);
       int r = prepare_single_write(*it, bl, queue_pos, orig_ops, orig_bytes);
       if (r == 0) { // prepare ok, delete it
 	items.erase(it++);

--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -908,7 +908,12 @@ function TEST_corrupt_scrub_replicated() {
 EOF
 
     jq "$jqfilter" $dir/json | python -c "$sortkeys" | sed -e "$sedfilter" > $dir/csjson
-    diff -y $termwidth $dir/checkcsjson $dir/csjson || test $getjson = "yes" || return 1
+    if [ `uname` != FreeBSD ]; then
+        diff -y $termwidth $dir/checkcsjson $dir/csjson || test $getjson = "yes" || return 1
+    else
+        # FreeBSD does not have side-by-side diff
+        diff $dir/checkcsjson $dir/csjson || test $getjson = "yes" || return 1
+    fi
     if test $getjson = "yes"
     then
         jq '.' $dir/json > save1.json


### PR DESCRIPTION
- unused variable reference are fixed by prefixing with (void),
   making this into a macro with obvious title makes that more than clear.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>