### PR TITLE
doc: fix link that pointed to a nonexistent file

### DIFF
--- a/doc/radosgw/federated-config.rst
+++ b/doc/radosgw/federated-config.rst
@@ -822,4 +822,4 @@ there is a unified namespace between the two regions.
 .. _Configuration Reference - Regions: ../config-ref#regions
 .. _Configuration Reference - Zones: ../config-ref#zones
 .. _Pools: ../../rados/operations/pools
-.. _Simple Configuration: ../config
+.. _Simple Configuration: ../config-fcgi

--- a/doc/start/quick-rgw-old.rst
+++ b/doc/start/quick-rgw-old.rst
@@ -27,4 +27,4 @@ the steps specific to Apache are no longer needed.
 
 .. _Storage Cluster Quick Start: ../quick-ceph-deploy
 .. _RGW Admin Guide: ../../radosgw/admin
-.. _Configuring Ceph Object Gateway: ../../radosgw/config
+.. _Configuring Ceph Object Gateway: ../../radosgw/config-fcgi

--- a/doc/start/quick-rgw.rst
+++ b/doc/start/quick-rgw.rst
@@ -97,5 +97,5 @@ Configuring the Ceph Object Gateway Instance
 See the `Configuring Ceph Object Gateway`_ guide for additional administration
 and API details.
 
-.. _Configuring Ceph Object Gateway: ../../radosgw/config
+.. _Configuring Ceph Object Gateway: ../../radosgw/config-fcgi
 .. _Preflight Checklist: ../quick-start-preflight


### PR DESCRIPTION
commit d788bae60dac374dcf5c7a30fca04426cbee660a renamed config.rst to config-fcgi.rst

Reported-by: fusl in #ceph on irc.oftc.net
Signed-off-by: Peter Maloney <peter.maloney@brockmann-consult.de>