### PR TITLE
os/bluestore: get rid off excessive lock at BitMapAllocator

### DIFF
--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -147,7 +147,6 @@ int64_t BitMapAllocator::allocate_dis(
 void BitMapAllocator::release(
   uint64_t offset, uint64_t length)
 {
-  std::lock_guard<std::mutex> l(m_lock);
   dout(10) << __func__ << " 0x"
            << std::hex << offset << "~" << length << std::dec
            << dendl;
@@ -164,7 +163,6 @@ uint64_t BitMapAllocator::get_free()
 
 void BitMapAllocator::dump()
 {
-  std::lock_guard<std::mutex> l(m_lock);
   dout(0) << __func__ << " instance " << this << dendl;
   m_bit_alloc->dump();
 }

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -12,7 +12,6 @@
 
 class BitMapAllocator : public Allocator {
   CephContext* cct;
-  std::mutex m_lock;
 
   int64_t m_block_size;
 


### PR DESCRIPTION
It looks like we don't need this lock since underlying BitAllocator has its own one.
Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>