### PR TITLE
test/librbd/test_notify.py: don't disable feature in slave

### DIFF
--- a/src/test/librbd/test_notify.py
+++ b/src/test/librbd/test_notify.py
@@ -64,6 +64,7 @@ def master(ioctx):
         image.create_snap('snap1')
         image.protect_snap('snap1')
 
+    features = features & ~(RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF)
     RBD().clone(ioctx, PARENT_IMG_NAME, 'snap1', ioctx, CLONE_IMG_NAME,
                 features=features)
     with Image(ioctx, CLONE_IMG_NAME) as image:
@@ -141,10 +142,7 @@ def slave(ioctx):
         assert(list(image.list_snaps()) == [])
 
         print("rebuild object map")
-        features = image.features() & (
-                RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF)
-        if features:
-            image.update_features(features, False)
+        assert((image.features() & RBD_FEATURE_OBJECT_MAP) == 0)
         image.update_features(RBD_FEATURE_OBJECT_MAP, True)
         assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) != 0)
         image.rebuild_object_map()


### PR DESCRIPTION
On jewel it will have stolen the exclusive lock. Instead, ensure that
object map and fast diff are already disabled on the clone before the
start of the test.

Fixes: http://tracker.ceph.com/issues/19716
Signed-off-by: Mykola Golub <mgolub@mirantis.com>