### PR TITLE
common: Better handling for missing/inaccessible ceph.conf files

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -704,7 +704,7 @@ def main():
                                        conffile=conffile)
         retargs = run_in_thread(cluster_handle.conf_parse_argv, childargs)
     except rados.Error as e:
-        print('Error initializing cluster client: {0}'.format(e), file=sys.stderr)
+        print('Error initializing cluster client: {0!r}'.format(e), file=sys.stderr)
         return 1
 
     childargs = retargs

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -102,7 +102,7 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
   FILE *fp = fopen(fname.c_str(), "r");
   if (!fp) {
     ostringstream oss;
-    oss << "parse_file: cannot open " << fname << ": " << cpp_strerror(errno);
+    oss << __func__ << ": cannot open " << fname << ": " << cpp_strerror(errno);
     errors->push_back(oss.str());
     ret = -errno;
     return ret;
@@ -112,14 +112,14 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
   if (fstat(fileno(fp), &st_buf)) {
     ret = -errno;
     ostringstream oss;
-    oss << "parse_file: failed to fstat '" << fname << "': " << cpp_strerror(ret);
+    oss << __func__ << ": failed to fstat '" << fname << "': " << cpp_strerror(ret);
     errors->push_back(oss.str());
     goto done;
   }
 
   if (st_buf.st_size > MAX_CONFIG_FILE_SZ) {
     ostringstream oss;
-    oss << "parse_file: config file '" << fname << "' is " << st_buf.st_size
+    oss << __func__ << ": config file '" << fname << "' is " << st_buf.st_size
 	<< " bytes, but the maximum is " << MAX_CONFIG_FILE_SZ;
     errors->push_back(oss.str());
     ret = -EINVAL;
@@ -137,14 +137,14 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
     if (ferror(fp)) {
       ret = -errno;
       ostringstream oss;
-      oss << "parse_file: fread error while reading '" << fname << "': "
+      oss << __func__ << ": fread error while reading '" << fname << "': "
 	  << cpp_strerror(ret);
       errors->push_back(oss.str());
       goto done;
     }
     else {
       ostringstream oss;
-      oss << "parse_file: unexpected EOF while reading '" << fname << "': "
+      oss << __func__ << ": unexpected EOF while reading '" << fname << "': "
 	  << "possible concurrent modification?";
       errors->push_back(oss.str());
       ret = -EIO;

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -101,6 +101,9 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
   char *buf = NULL;
   FILE *fp = fopen(fname.c_str(), "r");
   if (!fp) {
+    ostringstream oss;
+    oss << "parse_file: cannot open " << fname << ": " << cpp_strerror(errno);
+    errors->push_back(oss.str());
     ret = -errno;
     return ret;
   }

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -112,14 +112,14 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
   if (fstat(fileno(fp), &st_buf)) {
     ret = -errno;
     ostringstream oss;
-    oss << "read_conf: failed to fstat '" << fname << "': " << cpp_strerror(ret);
+    oss << "parse_file: failed to fstat '" << fname << "': " << cpp_strerror(ret);
     errors->push_back(oss.str());
     goto done;
   }
 
   if (st_buf.st_size > MAX_CONFIG_FILE_SZ) {
     ostringstream oss;
-    oss << "read_conf: config file '" << fname << "' is " << st_buf.st_size
+    oss << "parse_file: config file '" << fname << "' is " << st_buf.st_size
 	<< " bytes, but the maximum is " << MAX_CONFIG_FILE_SZ;
     errors->push_back(oss.str());
     ret = -EINVAL;
@@ -137,14 +137,14 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
     if (ferror(fp)) {
       ret = -errno;
       ostringstream oss;
-      oss << "read_conf: fread error while reading '" << fname << "': "
+      oss << "parse_file: fread error while reading '" << fname << "': "
 	  << cpp_strerror(ret);
       errors->push_back(oss.str());
       goto done;
     }
     else {
       ostringstream oss;
-      oss << "read_conf: unexpected EOF while reading '" << fname << "': "
+      oss << "parse_file: unexpected EOF while reading '" << fname << "': "
 	  << "possible concurrent modification?";
       errors->push_back(oss.str());
       ret = -EIO;

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -302,8 +302,9 @@ int md_config_t::parse_config_files_impl(const std::list<std::string> &conf_file
     else if (ret != -ENOENT)
       return ret;
   }
+  // it must have been all ENOENTs, that's the only way we got here
   if (c == conf_files.end())
-    return -EINVAL;
+    return -ENOENT;
 
   if (cluster.size() == 0) {
     /*

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -105,7 +105,7 @@ void global_pre_init(std::vector < const char * > *alt_def_args,
     dout_emergency("global_init: error parsing config file.\n");
     _exit(1);
   }
-  else if (ret == -EINVAL) {
+  else if (ret == -ENOENT) {
     if (!(flags & CINIT_FLAG_NO_DEFAULT_CONFIG_FILE)) {
       if (conf_file_list.length()) {
 	ostringstream oss;

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2823,7 +2823,7 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path_list)
   ostringstream warnings;
   int ret = conf->parse_config_files(path_list, &warnings, 0);
   if (ret) {
-    if (warnings.str().length())
+    if (warnings.tellp() > 0)
       lderr(client->cct) << warnings.str() << dendl;
     client->cct->_conf->complain_about_parse_errors(client->cct);
     tracepoint(librados, rados_conf_read_file_exit, ret);

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2820,8 +2820,12 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path_list)
   tracepoint(librados, rados_conf_read_file_enter, cluster, path_list);
   librados::RadosClient *client = (librados::RadosClient *)cluster;
   md_config_t *conf = client->cct->_conf;
-  int ret = conf->parse_config_files(path_list, NULL, 0);
+  ostringstream warnings;
+  int ret = conf->parse_config_files(path_list, &warnings, 0);
   if (ret) {
+    if (warnings.str().length())
+      lderr(client->cct) << warnings.str() << dendl;
+    client->cct->_conf->complain_about_parse_errors(client->cct);
     tracepoint(librados, rados_conf_read_file_exit, ret);
     return ret;
   }

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -301,7 +301,7 @@ class Error(Exception):
     """ `Error` class, derived from `Exception` """
 
 
-class InvalidArgument(Error):
+class InvalidArgumentError(Error):
     pass
 
 
@@ -388,7 +388,8 @@ IF UNAME_SYSNAME == "FreeBSD":
         errno.ENOATTR   : NoData,
         errno.EINTR     : InterruptedOrTimeoutError,
         errno.ETIMEDOUT : TimedOut,
-        errno.EACCES    : PermissionDeniedError
+        errno.EACCES    : PermissionDeniedError,
+        errno.EINVAL    : InvalidArgumentError,
     }
 ELSE:
     cdef errno_to_exception = {
@@ -401,7 +402,8 @@ ELSE:
         errno.ENODATA   : NoData,
         errno.EINTR     : InterruptedOrTimeoutError,
         errno.ETIMEDOUT : TimedOut,
-        errno.EACCES    : PermissionDeniedError
+        errno.EACCES    : PermissionDeniedError,
+        errno.EINVAL    : InvalidArgumentError,
     }
 
 

--- a/src/test/cli/ceph-conf/env-vs-args.t
+++ b/src/test/cli/ceph-conf/env-vs-args.t
@@ -1,6 +1,10 @@
 # we can use CEPH_CONF to override the normal configuration file location.
   $ env CEPH_CONF=from-env ceph-conf -s foo bar
   .* \-1 did not load config file, using default settings. (re)
+  .* \-1 Errors while parsing config file! (re)
+  .* \-1 parse_file: cannot open from-env: \(2\) No such file or directory (re)
+  .* \-1 Errors while parsing config file! (re)
+  .* \-1 parse_file: cannot open from-env: \(2\) No such file or directory (re)
   [1]
 
 # command-line arguments should override environment

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -170,7 +170,7 @@ extern "C" int rados_conf_read_file(rados_t cluster, const char *path) {
     conf->parse_env();
     conf->apply_changes(NULL);
     conf->complain_about_parse_errors(client->cct());
-  } else if (ret == -EINVAL) {
+  } else if (ret == -ENOENT) {
     // ignore missing client config
     return 0;
   }


### PR DESCRIPTION
- Note EINVAL as a specific Python exception type in rados.pyx
- print the repr() of the exception so both the type and the message are shown
- if the only error on conf search is ENOENT, report ENOENT
- create/accumulate specific error messages for ENOENTs to report if all fail
- log both warnings and errors to the client logger on failure to parse configs

I'm hopeful that this addresses many of the long-standing complaints about missing/inaccessible ceph.conf files being such a pain point, particularly for new Ceph users

Related Tracker issue: http://tracker.ceph.com/issues/19658