### PR TITLE
jewel: rgw: fix failed to create bucket if a non-master zonegroup has a single zone

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3861,9 +3861,9 @@ int RGWRados::init_complete()
     meta_mgr->init_oldest_log_period();
   }
 
-  /* not point of running sync thread if there is a single zone or
-     we don't have a master zone configured or there is no rest_master_conn */
-  if (get_zonegroup().zones.size() < 2 || get_zonegroup().master_zone.empty() || !rest_master_conn) {
+  /* no point of running sync thread if we don't have a master zone configured
+     or there is no rest_master_conn */
+  if (get_zonegroup().master_zone.empty() || !rest_master_conn) {
     run_sync_thread = false;
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/19757