### PR TITLE
rgw:  regard layout as a subresource.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -17,6 +17,7 @@ static const auto signed_subresources = {
   "acl",
   "cors",
   "delete",
+  "layout",
   "lifecycle",
   "location",
   "logging",

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -786,6 +786,7 @@ void RGWHTTPArgs::append(const string& name, const string& val)
 
   if ((name.compare("acl") == 0) ||
       (name.compare("cors") == 0) ||
+      (name.compare("layout") == 0) ||
       (name.compare("location") == 0) ||
       (name.compare("logging") == 0) ||
       (name.compare("usage") == 0) ||


### PR DESCRIPTION
Regard ?layout as a subresource and append it to string_to_sign on authentication.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>