### PR TITLE
src/msg/async/AsyncConnect.cc: Use of sizeof() on a Pointer Type

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -417,7 +417,7 @@ void AsyncConnection::process()
       case STATE_OPEN_TAG_ACK:
         {
           ceph_le64 *seq;
-          r = read_until(sizeof(seq), state_buffer);
+          r = read_until(sizeof(*seq), state_buffer);
           if (r < 0) {
             ldout(async_msgr->cct, 1) << __func__ << " read ack seq failed" << dendl;
             goto fail;


### PR DESCRIPTION
We have found and fixed a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V568](https://www.viva64.com/en/w/V568/) It's odd that 'sizeof()' operator evaluates the size of a pointer to a class, but not the size of the 'seq' class object. AsyncConnection.cc 420
