### PR TITLE
src/rgw/rgw_crypt.cc: Compiler Removal of Code to Clear Buffers

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1305,6 +1305,13 @@ int rgw_s3_prepare_decrypt(struct req_state* s,
                             AES_256_KEYSIZE,
                             reinterpret_cast<const uint8_t*>(attr_key_selector.c_str()),
                             actual_key, AES_256_KEYSIZE) != true) {
+      /* FIXME
+         Unfortunately, the code may leave the buffer uncleared.
+         That's why when building the Release version of the application,
+         the compiler will most likely delete the call of the memset() function.
+         To clear buffers containing private information you should use a special functions.
+         For example: memset_s() http://en.cppreference.com/w/c/string/byte/memset
+      */
       memset(actual_key, 0, sizeof(actual_key));
       return -EIO;
     }


### PR DESCRIPTION
We have found a weakness using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warning: [V597](https://www.viva64.com/en/w/V597/) The compiler could delete the 'memset' function call, which is used to flush 'actual_key' buffer. The memset_s() function should be used to erase the private data. rgw_crypt.cc 1308

```
int rgw_s3_prepare_decrypt(....)
{
  ....
  uint8_t actual_key[AES_256_KEYSIZE];
  if (AES_256_ECB_encrypt(....) {
    memset(actual_key, 0, sizeof(actual_key)); // <=
    return -EIO;
  }
  ....
}
```