### PR TITLE
osd/PGMonitor: always update pgmap with latest osdmap

### DIFF
--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -866,6 +866,8 @@ void PGMonitor::check_osd_map(epoch_t epoch)
   set<int> need_check_down_pg_osds;
 
   // apply latest map(s)
+  const OSDMap& osdmap = mon->osdmon()->osdmap;
+  epoch = std::max(epoch, osdmap.get_epoch());
   for (epoch_t e = pg_map.last_osdmap_epoch+1;
        e <= epoch;
        e++) {
@@ -881,7 +883,6 @@ void PGMonitor::check_osd_map(epoch_t epoch)
                                 &last_osd_report, &pg_map, &pending_inc);
   }
 
-  const OSDMap& osdmap = mon->osdmon()->osdmap;
   assert(pg_map.last_osdmap_epoch < epoch);
   pending_inc.osdmap_epoch = epoch;
   PGMapUpdater::update_creating_pgs(osdmap, pg_map, &pending_inc);


### PR DESCRIPTION
without this change, we always update the pgmap with the latest osdmap in
PGMonitor::check_osd_map(), but assign pending_inc.osdmap_epoch with the
epoch passed to PGMonitor::check_osd_map(), even if the osdmap could be
be much newer than "epoch". for example, we could end up with an
MOSDPGCreate with an ancient epoch, but carrying some creating pgs whose
pools do not exist in osdmap of that ancient epoch yet. this happens
when RetryCheckOSDMap is involved.

Fixes: http://tracker.ceph.com/issues/19398
Signed-off-by: Kefu Chai <kchai@redhat.com>