### PR TITLE
rgw: add mon command admin ops.

### DIFF
--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -93,6 +93,7 @@ set(rgw_a_srcs
   rgw_rest_swift.cc
   rgw_rest_usage.cc
   rgw_rest_user.cc
+  rgw_rest_mon_command.cc
   rgw_role.cc
   rgw_swift_auth.cc
   rgw_tools.cc

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -45,6 +45,7 @@
 #include "rgw_rest_replica_log.h"
 #include "rgw_rest_config.h"
 #include "rgw_rest_realm.h"
+#include "rgw_rest_mon_command.h"
 #include "rgw_swift_auth.h"
 #include "rgw_log.h"
 #include "rgw_tools.h"
@@ -430,6 +431,7 @@ int main(int argc, const char **argv)
     admin_resource->register_resource("replica_log", new RGWRESTMgr_ReplicaLog);
     admin_resource->register_resource("config", new RGWRESTMgr_Config);
     admin_resource->register_resource("realm", new RGWRESTMgr_Realm);
+    admin_resource->register_resource("mon_command", new RGWRESTMgr_MonCommand);
     rest.register_resource(g_conf->rgw_admin_entry, admin_resource);
   }
 

--- a/src/rgw/rgw_rest_mon_command.cc
+++ b/src/rgw/rgw_rest_mon_command.cc
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_op.h"
+#include "rgw_rest_mon_command.h"
+#include "include/str_list.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+class RGWOp_MonCommand_Get : public RGWRESTOp {
+public:
+  RGWOp_MonCommand_Get() = default;
+
+  int check_caps(RGWUserCaps& caps) override {
+    return caps.check_cap("admin", RGW_CAP_READ);
+  }
+  void execute() override;
+
+  virtual const string name() override { return "mon_command"; }
+};
+
+void RGWOp_MonCommand_Get::execute() {
+  std::string format = "xml";
+  if (s->format == RGW_FORMAT_JSON) {
+    format = "json";
+  }
+
+  std::string command;
+  RESTArgs::get_string(s, "command", command, &command);
+    
+  librados::bufferlist inbl;
+  librados::bufferlist outbl;
+  std::string outs;
+  librados::Rados* rados = store->get_rados_handle();
+  http_ret = rados->mon_command("{\"prefix\": \"" + command + "\", \"format\": \"" + format + "\"}", 
+          inbl, &outbl, &outs);
+  if (http_ret != 0) {
+    ldout(s->cct, 2) << "failed to mon_command http_ret " << http_ret << dendl;
+    return;
+  }   
+
+  flusher.start(0);
+  Formatter *formatter = flusher.get_formatter(); 
+  formatter->write_raw_data(std::string(outbl.c_str(), outbl.length()).c_str());
+  flusher.flush();
+
+  http_ret = 0;
+}
+
+class RGWHandler_MonCommand : public RGWHandler_Auth_S3 {
+protected:
+  RGWOp *op_get() override {
+    return new RGWOp_MonCommand_Get; 
+  }
+
+  int read_permissions(RGWOp*) override {
+    return 0;
+  }
+
+public:
+  using RGWHandler_Auth_S3::RGWHandler_Auth_S3;
+  ~RGWHandler_MonCommand() override = default;
+};
+
+RGWHandler_REST* RGWRESTMgr_MonCommand::get_handler(struct req_state* s, 
+        const rgw::auth::StrategyRegistry& auth_registry, 
+        const std::string& frontend_prefix){
+  return new RGWHandler_MonCommand(auth_registry);
+}

--- a/src/rgw/rgw_rest_mon_command.h
+++ b/src/rgw/rgw_rest_mon_command.h
@@ -1,0 +1,17 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RGW_REST_MON_COMMAND_H
+#define RGW_REST_MON_COMMAND_H
+
+#include "rgw_rest.h"
+#include "rgw_rest_s3.h"
+
+class RGWRESTMgr_MonCommand : public RGWRESTMgr {
+public:
+  RGWHandler_REST* get_handler(struct req_state* s,
+                               const rgw::auth::StrategyRegistry& auth_registry,
+                               const std::string& frontend_prefix) override;
+};
+
+#endif /*!RGW_REST_MON_COMMAND_H*/


### PR DESCRIPTION
Add mon command admin ops. Using this API, a command can be sent to the monitor, executed and the response is sent back.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>