### PR TITLE
build/ops: rpm: package crypto on x86_64 only

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -929,8 +929,10 @@ rm -rf %{buildroot}
 %{_libdir}/ceph/erasure-code/libec_*.so*
 %dir %{_libdir}/ceph/compressor
 %{_libdir}/ceph/compressor/libceph_*.so*
+%ifarch x86_64
 %dir %{_libdir}/ceph/crypto
 %{_libdir}/ceph/crypto/libceph_*.so*
+%endif
 %if %{with lttng}
 %{_libdir}/libos_tp.so*
 %{_libdir}/libosd_tp.so*


### PR DESCRIPTION
ca40e12845e78e507a0c3f45efa1689979029874 added the following lines to the spec
file:

```
%dir %{_libdir}/ceph/crypto
%{_libdir}/ceph/crypto/libceph_*.so*
```

and 350932979b377b292edd12dc8c612945cd793e7a made it so those build artifacts
are generated on x86_64 only.

The result is a build failure on non-x86_64 architectures:

```
error: Directory not found: /home/abuild/rpmbuild/BUILDROOT/ceph-12.0.2+git.1493119152.181baf6-1.1.ppc64le/usr/lib64/ceph/crypto
error: File not found by glob: /home/abuild/rpmbuild/BUILDROOT/ceph-12.0.2+git.1493119152.181baf6-1.1.ppc64le/usr/lib64/ceph/crypto/libceph_*.so*
```

Signed-off-by: Nathan Cutler <ncutler@suse.com>