### PR TITLE
rgw_ldap: log the ldap err in case of bind failure

### DIFF
--- a/src/rgw/rgw_ldap.cc
+++ b/src/rgw/rgw_ldap.cc
@@ -94,6 +94,7 @@ namespace rgw {
 	if (ret != LDAP_SUCCESS) {
 	  ldout(g_ceph_context, 10)
 	    << __func__ << " simple_bind failed uid=" << uid
+	    << "ldap err=" << ret
 	    << dendl;
 	}
 	ldap_memfree(dn);


### PR DESCRIPTION
Easier to find out misconfigurations if we know what the ldap error was.

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>