### PR TITLE
test: use 7130 for crush-classes.sh

### DIFF
--- a/src/test/crush/crush-classes.sh
+++ b/src/test/crush/crush-classes.sh
@@ -22,7 +22,7 @@ function run() {
     local dir=$1
     shift
 
-    export CEPH_MON="127.0.0.1:7127" # git grep '\<7127\>' : there must be only one
+    export CEPH_MON="127.0.0.1:7130" # git grep '\<7130\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "


### PR DESCRIPTION
7127 is already used by mon/misc.sh

Signed-off-by: Loic Dachary <loic@dachary.org>