### PR TITLE
test/crush/crush-classes: make port unique

### DIFF
--- a/src/test/crush/crush-classes.sh
+++ b/src/test/crush/crush-classes.sh
@@ -22,7 +22,7 @@ function run() {
     local dir=$1
     shift
 
-    export CEPH_MON="127.0.0.1:7127" # git grep '\<7127\>' : there must be only one
+    export CEPH_MON="127.0.0.1:7187" # git grep '\<7187\>' : there must be only one
     export CEPH_ARGS
     CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
     CEPH_ARGS+="--mon-host=$CEPH_MON "


### PR DESCRIPTION
test/mon/misc.sh uses 7127.

Signed-off-by: Sage Weil <sage@redhat.com>