### PR TITLE
[DNM]common/Throttle: add callback support for waiting

### DIFF
--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -32,6 +32,7 @@ class Throttle {
   ceph::atomic_t count, max;
   Mutex lock;
   list<Cond*> cond;
+  list<Context*> callbacks;
   const bool use_perf;
 
 public:
@@ -102,9 +103,17 @@ public:
   /**
    * the unblocked version of @p get()
    * @returns true if it successfully got the requested amount,
-   * or false if it would block.
+   * or false if it will return right now.
    */
   bool get_or_fail(int64_t c = 1);
+
+  /**
+   * the unblocked version of @p get()
+   * @returns true if it successfully got the requested amount(caller need to
+   * handle passing ctxt itself),
+   * or false if it would call later(throttle will take over the life of ctxt).
+   */
+  bool get_or_reserve(int64_t c = 1, Context *ctxt);
 
   /**
    * put slots back to the stock


### PR DESCRIPTION
this isn't a ready pr. I want to get ideas from others. The  motivation here is adding async throttle support, I'm not sure working on Throttle is a good direction, or we may expect other fusion implementation. 

The first user is async messenger, which meet Throttle::get_or_fail usage problem under rdma backend. the get_or_fail will result to caller polling and make it ineffective and ugly.