### PR TITLE
common: Fix unused variable references warnings

### DIFF
--- a/src/msg/async/net_handler.cc
+++ b/src/msg/async/net_handler.cc
@@ -33,7 +33,7 @@ namespace ceph{
 
 int NetHandler::create_socket(int domain, bool reuse_addr)
 {
-  int s, on = 1;
+  int s;
 
   if ((s = ::socket(domain, SOCK_STREAM, 0)) == -1) {
     lderr(cct) << __func__ << " couldn't create socket " << cpp_strerror(errno) << dendl;
@@ -44,6 +44,7 @@ int NetHandler::create_socket(int domain, bool reuse_addr)
   /* Make sure connection-intensive things like the benchmark
    * will be able to close/open sockets a zillion of times */
   if (reuse_addr) {
+    int on = 1;
     if (::setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &on, sizeof(on)) == -1) {
       lderr(cct) << __func__ << " setsockopt SO_REUSEADDR failed: "
                  << strerror(errno) << dendl;

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -835,6 +835,8 @@ int FileJournal::prepare_multi_write(bufferlist& bl, uint64_t& orig_ops, uint64_
 	  assert(aio_write_queue_bytes >= bytes);
 	  aio_write_queue_bytes -= bytes;
 	}
+#else
+	(void)bytes;
 #endif
       }
       if (r == -ENOSPC) {


### PR DESCRIPTION
- FreeBSD excludes some that that causes unused warnings

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>