### PR TITLE
ceph: perfcounter priorities and daemonperf updates to use them

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -121,6 +121,7 @@ BuildRequires:	pkgconfig
 BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
+BuildRequires:	python-prettytable
 BuildRequires:	python-requests
 BuildRequires:	python-sphinx
 BuildRequires:	python-virtualenv
@@ -256,6 +257,7 @@ Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python-rgw = %{epoch}:%{version}-%{release}
+Requires:	python-prettytable
 Requires:	python-requests
 %{?systemd_requires}
 %if 0%{?suse_version}

--- a/debian/control
+++ b/debian/control
@@ -50,6 +50,7 @@ Build-Depends: bc,
                python (>= 2.7),
                python-all-dev,
                python-nose,
+	       python-prettytable,
 	       python-setuptools,
                python-sphinx,
                python3-all-dev,
@@ -363,7 +364,8 @@ Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
          python-rbd (= ${binary:Version}),
          python-rgw (= ${binary:Version}),
          ${python:Depends},
-	 python-requests
+	 python-requests,
+	 python-prettytable
 Conflicts: ceph-client-tools
 Replaces: ceph-client-tools,
 	  ceph (<< 10),

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -671,11 +671,12 @@ def daemonperf(childargs, sockpath):
         # 'list'?
         if arg in ['list', 'ls']:
             do_list = True;
-            continue;
+            continue
         # prio?
-        priority = prio_from_name(arg)
-        if priority is not None:
-            continue;
+        prio = prio_from_name(arg)
+        if prio is not None:
+            priority = prio
+            continue
         # statpats
         statpats = arg.split(',')
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -276,10 +276,12 @@ ping <mon.id>           Send simple presence/life test to a mon
 daemon {type.id|path} <cmd>
                         Same as --admin-daemon, but auto-find admin socket
 daemonperf {type.id | path} [stat-pats] [priority] [<interval>] [<count>]
+daemonperf {type.id | path} list [stat-pats] [priority]
                         Get selected perf stats from daemon/admin socket
                         Optional shell-glob comma-delim match string stat-pats
                         Optional selection priority (can abbreviate name):
                          critical, interesting, useful, noninteresting, debug
+                        List shows a table of all available stats
                         Run <count> times (default forever),
                          once per <interval> seconds (default 1)
     """, file=sys.stdout)
@@ -636,12 +638,14 @@ def daemonperf(childargs, sockpath):
     Handle daemonperf command; returns errno or 0
 
     daemonperf <daemon> [priority string] [statpats] [interval] [count]
+    daemonperf <daemon> list [statpats]
     """
 
     interval = 1
     count = None
     statpats = None
     priority = None
+    do_list = False
 
     def prio_from_name(arg):
 
@@ -664,6 +668,10 @@ def daemonperf(childargs, sockpath):
     # consume and analyze non-numeric args
     while len(childargs) and not isnum(childargs[0]):
         arg = childargs.pop(0)
+        # 'list'?
+        if arg == 'list':
+            do_list = True;
+            continue;
         # prio?
         priority = prio_from_name(arg)
         if priority is not None:
@@ -690,7 +698,11 @@ def daemonperf(childargs, sockpath):
             return errno.EINVAL
         count = int(arg)
 
-    DaemonWatcher(sockpath, statpats, priority).run(interval, count)
+    watcher = DaemonWatcher(sockpath, statpats, priority)
+    if do_list:
+        watcher.list()
+    else:
+        watcher.run(interval, count)
 
     return 0
 

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -600,23 +600,7 @@ def maybe_daemon_command(parsed_args, childargs):
             return True, errno.EINVAL
 
     if sockpath and daemon_perf:
-        interval = 1
-        count = None
-        if len(childargs) > 0:
-            try:
-                interval = float(childargs[0])
-                if interval < 0:
-                    raise ValueError
-            except ValueError:
-                print('daemonperf: interval should be a positive number', file=sys.stderr)
-                return True, errno.EINVAL
-        if len(childargs) > 1:
-            if not childargs[1].isdigit():
-                print('daemonperf: count should be a positive integer', file=sys.stderr)
-                return True, errno.EINVAL
-            count = int(childargs[1])
-        DaemonWatcher(sockpath).run(interval, count)
-        return True, 0
+        return True, daemonperf(childargs, sockpath)
     elif sockpath:
         try:
             raw_write(admin_socket(sockpath, childargs, parsed_args.output_format))
@@ -626,6 +610,27 @@ def maybe_daemon_command(parsed_args, childargs):
         return True, 0
 
     return False, 0
+
+
+def daemonperf(childargs, sockpath):
+    """ Handle daemonperf command; returns errno or 0 """
+    interval = 1
+    count = None
+    if len(childargs) > 0:
+        try:
+            interval = float(childargs[0])
+            if interval < 0:
+                raise ValueError
+        except ValueError:
+            print('daemonperf: interval should be a positive number', file=sys.stderr)
+            return errno.EINVAL
+    if len(childargs) > 1:
+        if not childargs[1].isdigit():
+            print('daemonperf: count should be a positive integer', file=sys.stderr)
+            return errno.EINVAL
+        count = int(childargs[1])
+    DaemonWatcher(sockpath).run(interval, count)
+    return 0
 
 ###
 # main

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -276,7 +276,7 @@ ping <mon.id>           Send simple presence/life test to a mon
 daemon {type.id|path} <cmd>
                         Same as --admin-daemon, but auto-find admin socket
 daemonperf {type.id | path} [stat-pats] [priority] [<interval>] [<count>]
-daemonperf {type.id | path} list [stat-pats] [priority]
+daemonperf {type.id | path} list|ls [stat-pats] [priority]
                         Get selected perf stats from daemon/admin socket
                         Optional shell-glob comma-delim match string stat-pats
                         Optional selection priority (can abbreviate name):
@@ -638,7 +638,7 @@ def daemonperf(childargs, sockpath):
     Handle daemonperf command; returns errno or 0
 
     daemonperf <daemon> [priority string] [statpats] [interval] [count]
-    daemonperf <daemon> list [statpats]
+    daemonperf <daemon> list|ls [statpats]
     """
 
     interval = 1
@@ -669,7 +669,7 @@ def daemonperf(childargs, sockpath):
     while len(childargs) and not isnum(childargs[0]):
         arg = childargs.pop(0)
         # 'list'?
-        if arg == 'list':
+        if arg in ['list', 'ls']:
             do_list = True;
             continue;
         # prio?

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -266,8 +266,9 @@ ping <mon.id>           Send simple presence/life test to a mon
                         <mon.id> may be 'mon.*' for all mons
 daemon {type.id|path} <cmd>
                         Same as --admin-daemon, but auto-find admin socket
-daemonperf {type.id | path} [<interval>] [<count>]
+daemonperf {type.id | path} [stat-pats] [<interval>] [<count>]
                         Get selected perf stats from daemon/admin socket
+                        Optional shell-glob comma-delim match string stat-pats
                         Run <count> times (default forever),
                         once per <interval> seconds (default 1)
     """, file=sys.stdout)
@@ -612,10 +613,24 @@ def maybe_daemon_command(parsed_args, childargs):
     return False, 0
 
 
+def isnum(object):
+    try:
+        float(object)
+        return True
+    except ValueError:
+        return False
+
 def daemonperf(childargs, sockpath):
     """ Handle daemonperf command; returns errno or 0 """
     interval = 1
     count = None
+    statpats = None
+
+    if len(childargs) > 0:
+        # optional leading comma-separated list arg
+        if not isnum(childargs[0]):
+            statpats = childargs.pop(0).split(',')
+
     if len(childargs) > 0:
         try:
             interval = float(childargs[0])
@@ -629,7 +644,7 @@ def daemonperf(childargs, sockpath):
             print('daemonperf: count should be a positive integer', file=sys.stderr)
             return errno.EINVAL
         count = int(childargs[1])
-    DaemonWatcher(sockpath).run(interval, count)
+    DaemonWatcher(sockpath, statpats).run(interval, count)
     return 0
 
 ###

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -38,6 +38,15 @@ FLAG_NOFORWARD  = (1 << 0)
 FLAG_OBSOLETE   = (1 << 1)
 FLAG_DEPRECATED = (1 << 2)
 
+# priorities from src/common/perf_counters.h
+PRIO_CRITICAL = 10
+PRIO_INTERESTING = 8
+PRIO_USEFUL = 5
+PRIO_UNINTERESTING = 2
+PRIO_DEBUGONLY = 0
+
+PRIO_DEFAULT = PRIO_USEFUL
+
 # Make life easier on developers:
 # If in src/, and .libs and pybind exist here, assume we're running
 # from a Ceph source dir and tweak PYTHONPATH and LD_LIBRARY_PATH
@@ -266,11 +275,13 @@ ping <mon.id>           Send simple presence/life test to a mon
                         <mon.id> may be 'mon.*' for all mons
 daemon {type.id|path} <cmd>
                         Same as --admin-daemon, but auto-find admin socket
-daemonperf {type.id | path} [stat-pats] [<interval>] [<count>]
+daemonperf {type.id | path} [stat-pats] [priority] [<interval>] [<count>]
                         Get selected perf stats from daemon/admin socket
                         Optional shell-glob comma-delim match string stat-pats
+                        Optional selection priority (can abbreviate name):
+                         critical, interesting, useful, noninteresting, debug
                         Run <count> times (default forever),
-                        once per <interval> seconds (default 1)
+                         once per <interval> seconds (default 1)
     """, file=sys.stdout)
 
 
@@ -613,38 +624,74 @@ def maybe_daemon_command(parsed_args, childargs):
     return False, 0
 
 
-def isnum(object):
+def isnum(s):
     try:
-        float(object)
+        float(s)
         return True
     except ValueError:
         return False
 
 def daemonperf(childargs, sockpath):
-    """ Handle daemonperf command; returns errno or 0 """
+    """
+    Handle daemonperf command; returns errno or 0
+
+    daemonperf <daemon> [priority string] [statpats] [interval] [count]
+    """
+
     interval = 1
     count = None
     statpats = None
+    priority = None
 
-    if len(childargs) > 0:
-        # optional leading comma-separated list arg
-        if not isnum(childargs[0]):
-            statpats = childargs.pop(0).split(',')
+    def prio_from_name(arg):
+
+        PRIOMAP = {
+            'critical': PRIO_CRITICAL,
+            'interesting': PRIO_INTERESTING,
+            'useful': PRIO_USEFUL,
+            'uninteresting': PRIO_UNINTERESTING,
+            'debugonly': PRIO_DEBUGONLY,
+        }
+
+        if arg in PRIOMAP:
+            return PRIOMAP[arg]
+        # allow abbreviation
+        for name, val in PRIOMAP.items():
+            if name.startswith(arg):
+                return val
+        return None
+
+    # consume and analyze non-numeric args
+    while len(childargs) and not isnum(childargs[0]):
+        arg = childargs.pop(0)
+        # prio?
+        priority = prio_from_name(arg)
+        if priority is not None:
+            continue;
+        # statpats
+        statpats = arg.split(',')
+
+    if priority is None:
+        priority = PRIO_DEFAULT
 
     if len(childargs) > 0:
         try:
-            interval = float(childargs[0])
+            interval = float(childargs.pop(0))
             if interval < 0:
                 raise ValueError
         except ValueError:
             print('daemonperf: interval should be a positive number', file=sys.stderr)
             return errno.EINVAL
-    if len(childargs) > 1:
-        if not childargs[1].isdigit():
+
+    if len(childargs) > 0:
+        arg = childargs.pop(0)
+        if (not isnum(arg)) or (int(arg) < 0):
             print('daemonperf: count should be a positive integer', file=sys.stderr)
             return errno.EINVAL
-        count = int(childargs[1])
-    DaemonWatcher(sockpath, statpats).run(interval, count)
+        count = int(arg)
+
+    DaemonWatcher(sockpath, statpats, priority).run(interval, count)
+
     return 0
 
 ###

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -565,6 +565,68 @@ def ping_monitor(cluster_handle, name, timeout):
             print(s)
     return 0
 
+
+def maybe_daemon_command(parsed_args, childargs):
+    """
+    Check if --admin-socket, daemon, or daemonperf command
+    if it is, returns (boolean handled, return code if handled == True)
+    """
+
+    daemon_perf = False
+    sockpath = None
+    if parsed_args.admin_socket:
+        sockpath = parsed_args.admin_socket
+    elif len(childargs) > 0 and childargs[0] in ["daemon", "daemonperf"]:
+        daemon_perf = (childargs[0] == "daemonperf")
+        # Treat "daemon <path>" or "daemon <name>" like --admin_daemon <path>
+        # Handle "daemonperf <path>" the same but requires no trailing args
+        require_args = 2 if daemon_perf else 3
+        if len(childargs) >= require_args:
+            if childargs[1].find('/') >= 0:
+                sockpath = childargs[1]
+            else:
+                # try resolve daemon name
+                try:
+                    sockpath = ceph_conf(parsed_args, 'admin_socket',
+                                         childargs[1])
+                except Exception as e:
+                    print('Can\'t get admin socket path: ' + str(e), file=sys.stderr)
+                    return True, errno.EINVAL
+            # for both:
+            childargs = childargs[2:]
+        else:
+            print('{0} requires at least {1} arguments'.format(childargs[0], require_args), 
+                file=sys.stderr) 
+            return True, errno.EINVAL
+
+    if sockpath and daemon_perf:
+        interval = 1
+        count = None
+        if len(childargs) > 0:
+            try:
+                interval = float(childargs[0])
+                if interval < 0:
+                    raise ValueError
+            except ValueError:
+                print('daemonperf: interval should be a positive number', file=sys.stderr)
+                return True, errno.EINVAL
+        if len(childargs) > 1:
+            if not childargs[1].isdigit():
+                print('daemonperf: count should be a positive integer', file=sys.stderr)
+                return True, errno.EINVAL
+            count = int(childargs[1])
+        DaemonWatcher(sockpath).run(interval, count)
+        return True, 0
+    elif sockpath:
+        try:
+            raw_write(admin_socket(sockpath, childargs, parsed_args.output_format))
+        except Exception as e:
+            print('admin_socket: {0}'.format(e), file=sys.stderr)
+            return True, errno.EINVAL
+        return True, 0
+
+    return False, 0
+
 ###
 # main
 ###
@@ -610,58 +672,9 @@ def main():
 
     format = parsed_args.output_format
 
-    daemon_perf = False
-    sockpath = None
-    if parsed_args.admin_socket:
-        sockpath = parsed_args.admin_socket
-    elif len(childargs) > 0 and childargs[0] in ["daemon", "daemonperf"]:
-        daemon_perf = (childargs[0] == "daemonperf")
-        # Treat "daemon <path>" or "daemon <name>" like --admin_daemon <path>
-        # Handle "daemonperf <path>" the same but requires no trailing args
-        require_args = 2 if daemon_perf else 3
-        if len(childargs) >= require_args:
-            if childargs[1].find('/') >= 0:
-                sockpath = childargs[1]
-            else:
-                # try resolve daemon name
-                try:
-                    sockpath = ceph_conf(parsed_args, 'admin_socket',
-                                         childargs[1])
-                except Exception as e:
-                    print('Can\'t get admin socket path: ' + str(e), file=sys.stderr)
-                    return errno.EINVAL
-            # for both:
-            childargs = childargs[2:]
-        else:
-            print('{0} requires at least {1} arguments'.format(childargs[0], require_args), 
-                file=sys.stderr) 
-            return errno.EINVAL
-
-    if sockpath and daemon_perf:
-        interval = 1
-        count = None
-        if len(childargs) > 0:
-            try:
-                interval = float(childargs[0])
-                if interval < 0:
-                    raise ValueError
-            except ValueError:
-                print('daemonperf: interval should be a positive number', file=sys.stderr)
-                return errno.EINVAL
-        if len(childargs) > 1:
-            if not childargs[1].isdigit():
-                print('daemonperf: count should be a positive integer', file=sys.stderr)
-                return errno.EINVAL
-            count = int(childargs[1])
-        DaemonWatcher(sockpath).run(interval, count)
-        return 0
-    elif sockpath:
-        try:
-            raw_write(admin_socket(sockpath, childargs, format))
-        except Exception as e:
-            print('admin_socket: {0}'.format(e), file=sys.stderr)
-            return errno.EINVAL
-        return 0
+    done, ret = maybe_daemon_command(parsed_args, childargs)
+    if done:
+        return ret
 
     timeout = None
     if parsed_args.cluster_timeout:

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -504,6 +504,10 @@ void PerfCountersBuilder::add_impl(int idx, const char *name,
   assert(data.type == PERFCOUNTER_NONE);
   data.name = name;
   data.description = description;
+  // nick must be <= 4 chars
+  if (nick) {
+    assert(strlen(nick) <= 4);
+  }
   data.nick = nick;
   data.type = (enum perfcounter_type_d)ty;
   data.histogram = std::move(histogram);

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -378,13 +378,16 @@ void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
         f->dump_string("description", "");
       }
 
-      if (d->nick != NULL && !suppress_nicks) {
+      if (d->nick != NULL) {
         f->dump_string("nick", d->nick);
       } else {
         f->dump_string("nick", "");
       }
       if (d->prio) {
-	f->dump_int("priority", d->prio);
+	int p = std::max(std::min(d->prio + prio_adjust,
+				  (int)PerfCountersBuilder::PRIO_CRITICAL),
+			 0);
+	f->dump_int("priority", p);
       }
       f->close_section();
     } else {

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -383,6 +383,9 @@ void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
       } else {
         f->dump_string("nick", "");
       }
+      if (d->prio) {
+	f->dump_int("priority", d->prio);
+      }
       f->close_section();
     } else {
       if (d->type & PERFCOUNTER_LONGRUNAVG) {
@@ -453,48 +456,59 @@ PerfCountersBuilder::~PerfCountersBuilder()
   m_perf_counters = NULL;
 }
 
-void PerfCountersBuilder::add_u64_counter(int idx, const char *name,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_u64_counter(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_U64 | PERFCOUNTER_COUNTER);
+  add_impl(idx, name, description, nick, prio,
+	   PERFCOUNTER_U64 | PERFCOUNTER_COUNTER);
 }
 
-void PerfCountersBuilder::add_u64(int idx, const char *name,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_u64(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_U64);
+  add_impl(idx, name, description, nick, prio, PERFCOUNTER_U64);
 }
 
-void PerfCountersBuilder::add_u64_avg(int idx, const char *name,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_u64_avg(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_U64 | PERFCOUNTER_LONGRUNAVG);
+  add_impl(idx, name, description, nick, prio,
+	   PERFCOUNTER_U64 | PERFCOUNTER_LONGRUNAVG);
 }
 
-void PerfCountersBuilder::add_time(int idx, const char *name,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_time(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_TIME);
+  add_impl(idx, name, description, nick, prio, PERFCOUNTER_TIME);
 }
 
-void PerfCountersBuilder::add_time_avg(int idx, const char *name,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_time_avg(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_TIME | PERFCOUNTER_LONGRUNAVG);
+  add_impl(idx, name, description, nick, prio,
+	   PERFCOUNTER_TIME | PERFCOUNTER_LONGRUNAVG);
 }
 
-void PerfCountersBuilder::add_histogram(int idx, const char *name,
-    PerfHistogramCommon::axis_config_d x_axis_config,
-    PerfHistogramCommon::axis_config_d y_axis_config,
-    const char *description, const char *nick)
+void PerfCountersBuilder::add_histogram(
+  int idx, const char *name,
+  PerfHistogramCommon::axis_config_d x_axis_config,
+  PerfHistogramCommon::axis_config_d y_axis_config,
+  const char *description, const char *nick, int prio)
 {
-  add_impl(idx, name, description, nick, PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM,
+  add_impl(idx, name, description, nick, prio,
+	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM,
            unique_ptr<PerfHistogram<>>{new PerfHistogram<>{x_axis_config, y_axis_config}});
 }
 
-void PerfCountersBuilder::add_impl(int idx, const char *name,
-    const char *description, const char *nick, int ty,
-    unique_ptr<PerfHistogram<>> histogram)
+void PerfCountersBuilder::add_impl(
+  int idx, const char *name,
+  const char *description, const char *nick, int prio, int ty,
+  unique_ptr<PerfHistogram<>> histogram)
 {
   assert(idx > m_perf_counters->m_lower_bound);
   assert(idx < m_perf_counters->m_upper_bound);
@@ -509,6 +523,7 @@ void PerfCountersBuilder::add_impl(int idx, const char *name,
     assert(strlen(nick) <= 4);
   }
   data.nick = nick;
+  data.prio = prio;
   data.type = (enum perfcounter_type_d)ty;
   data.histogram = std::move(histogram);
 }

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -102,6 +102,7 @@ public:
     const char *name;
     const char *description;
     const char *nick;
+    int prio = 0;
     enum perfcounter_type_d type;
     atomic64_t u64;
     atomic64_t avgcount;
@@ -282,26 +283,47 @@ public:
   PerfCountersBuilder(CephContext *cct, const std::string &name,
 		    int first, int last);
   ~PerfCountersBuilder();
+
+  // prio values: higher is better, and higher values get included in
+  // 'ceph daemonperf' (and similar) results.
+  enum {
+    PRIO_CRITICAL = 10,
+    PRIO_INTERESTING = 8,
+    PRIO_USEFUL = 5,
+    PRIO_UNINTERESTING = 2,
+    PRIO_DEBUGONLY = 0,
+  };
   void add_u64(int key, const char *name,
-      const char *description=NULL, const char *nick = NULL);
+	       const char *description=NULL, const char *nick = NULL,
+	       int prio=0);
   void add_u64_counter(int key, const char *name,
-      const char *description=NULL, const char *nick = NULL);
+		       const char *description=NULL,
+		       const char *nick = NULL,
+		       int prio=0);
   void add_u64_avg(int key, const char *name,
-      const char *description=NULL, const char *nick = NULL);
+		   const char *description=NULL,
+		   const char *nick = NULL,
+		   int prio=0);
   void add_time(int key, const char *name,
-      const char *description=NULL, const char *nick = NULL);
+		const char *description=NULL,
+		const char *nick = NULL,
+		int prio=0);
   void add_time_avg(int key, const char *name,
-      const char *description=NULL, const char *nick = NULL);
+		    const char *description=NULL,
+		    const char *nick = NULL,
+		    int prio=0);
   void add_histogram(int key, const char* name,
-      PerfHistogramCommon::axis_config_d x_axis_config,
-      PerfHistogramCommon::axis_config_d y_axis_config,
-      const char *description=NULL, const char* nick = NULL);
+		     PerfHistogramCommon::axis_config_d x_axis_config,
+		     PerfHistogramCommon::axis_config_d y_axis_config,
+		     const char *description=NULL,
+		     const char* nick = NULL,
+		     int prio=0);
   PerfCounters* create_perf_counters();
 private:
   PerfCountersBuilder(const PerfCountersBuilder &rhs);
   PerfCountersBuilder& operator=(const PerfCountersBuilder &rhs);
   void add_impl(int idx, const char *name,
-                const char *description, const char *nick, int ty,
+                const char *description, const char *nick, int prio, int ty,
                 unique_ptr<PerfHistogram<>> histogram = nullptr);
 
   PerfCounters *m_perf_counters;

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -182,8 +182,9 @@ public:
     m_name = s;
   }
 
-  void set_suppress_nicks(bool b) {
-    suppress_nicks = b;
+  /// adjust priority values by some value
+  void set_prio_adjust(int p) {
+    prio_adjust = p;
   }
 
 private:
@@ -202,7 +203,7 @@ private:
   std::string m_name;
   const std::string m_lock_name;
 
-  bool suppress_nicks = false;
+  int prio_adjust = 0;
 
   /** Protects m_data */
   mutable Mutex m_lock;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -2429,43 +2429,60 @@ void MDSRank::create_logger()
   {
     PerfCountersBuilder mds_plb(g_ceph_context, "mds", l_mds_first, l_mds_last);
 
-    mds_plb.add_u64_counter(l_mds_request, "request", "Requests");
+    mds_plb.add_u64_counter(
+      l_mds_request, "request", "Requests", "req",
+      PerfCountersBuilder::PRIO_CRITICAL);
     mds_plb.add_u64_counter(l_mds_reply, "reply", "Replies");
-    mds_plb.add_time_avg(l_mds_reply_latency, "reply_latency",
-        "Reply latency", "rlat");
-    mds_plb.add_u64_counter(l_mds_forward, "forward", "Forwarding request");
-
+    mds_plb.add_time_avg(
+      l_mds_reply_latency, "reply_latency", "Reply latency", "rlat",
+      PerfCountersBuilder::PRIO_CRITICAL);
+    mds_plb.add_u64_counter(
+      l_mds_forward, "forward", "Forwarding request", "fwd",
+      PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64_counter(l_mds_dir_fetch, "dir_fetch", "Directory fetch");
     mds_plb.add_u64_counter(l_mds_dir_commit, "dir_commit", "Directory commit");
     mds_plb.add_u64_counter(l_mds_dir_split, "dir_split", "Directory split");
     mds_plb.add_u64_counter(l_mds_dir_merge, "dir_merge", "Directory merge");
 
     mds_plb.add_u64(l_mds_inode_max, "inode_max", "Max inodes, cache size");
-    mds_plb.add_u64(l_mds_inodes, "inodes", "Inodes", "inos");
+    mds_plb.add_u64(l_mds_inodes, "inodes", "Inodes", "inos",
+		    PerfCountersBuilder::PRIO_CRITICAL);
     mds_plb.add_u64(l_mds_inodes_top, "inodes_top", "Inodes on top");
     mds_plb.add_u64(l_mds_inodes_bottom, "inodes_bottom", "Inodes on bottom");
-    mds_plb.add_u64(l_mds_inodes_pin_tail, "inodes_pin_tail", "Inodes on pin tail");
+    mds_plb.add_u64(
+      l_mds_inodes_pin_tail, "inodes_pin_tail", "Inodes on pin tail");
     mds_plb.add_u64(l_mds_inodes_pinned, "inodes_pinned", "Inodes pinned");
     mds_plb.add_u64(l_mds_inodes_expired, "inodes_expired", "Inodes expired");
-    mds_plb.add_u64(l_mds_inodes_with_caps, "inodes_with_caps", "Inodes with capabilities");
-    mds_plb.add_u64(l_mds_caps, "caps", "Capabilities", "caps");
+    mds_plb.add_u64(
+      l_mds_inodes_with_caps, "inodes_with_caps", "Inodes with capabilities");
+    mds_plb.add_u64(l_mds_caps, "caps", "Capabilities", "caps",
+		    PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64(l_mds_subtrees, "subtrees", "Subtrees");
 
     mds_plb.add_u64_counter(l_mds_traverse, "traverse", "Traverses");
     mds_plb.add_u64_counter(l_mds_traverse_hit, "traverse_hit", "Traverse hits");
-    mds_plb.add_u64_counter(l_mds_traverse_forward, "traverse_forward", "Traverse forwards");
-    mds_plb.add_u64_counter(l_mds_traverse_discover, "traverse_discover", "Traverse directory discovers");
-    mds_plb.add_u64_counter(l_mds_traverse_dir_fetch, "traverse_dir_fetch", "Traverse incomplete directory content fetchings");
-    mds_plb.add_u64_counter(l_mds_traverse_remote_ino, "traverse_remote_ino", "Traverse remote dentries");
-    mds_plb.add_u64_counter(l_mds_traverse_lock, "traverse_lock", "Traverse locks");
+    mds_plb.add_u64_counter(l_mds_traverse_forward, "traverse_forward",
+			    "Traverse forwards");
+    mds_plb.add_u64_counter(l_mds_traverse_discover, "traverse_discover",
+			    "Traverse directory discovers");
+    mds_plb.add_u64_counter(l_mds_traverse_dir_fetch, "traverse_dir_fetch",
+			    "Traverse incomplete directory content fetchings");
+    mds_plb.add_u64_counter(l_mds_traverse_remote_ino, "traverse_remote_ino",
+			    "Traverse remote dentries");
+    mds_plb.add_u64_counter(l_mds_traverse_lock, "traverse_lock",
+			    "Traverse locks");
 
     mds_plb.add_u64(l_mds_load_cent, "load_cent", "Load per cent");
     mds_plb.add_u64(l_mds_dispatch_queue_len, "q", "Dispatch queue length");
 
     mds_plb.add_u64_counter(l_mds_exported, "exported", "Exports");
-    mds_plb.add_u64_counter(l_mds_exported_inodes, "exported_inodes", "Exported inodes");
+    mds_plb.add_u64_counter(
+      l_mds_exported_inodes, "exported_inodes", "Exported inodes", "exi",
+      PerfCountersBuilder::PRIO_INTERESTING);
     mds_plb.add_u64_counter(l_mds_imported, "imported", "Imports");
-    mds_plb.add_u64_counter(l_mds_imported_inodes, "imported_inodes", "Imported inodes");
+    mds_plb.add_u64_counter(
+      l_mds_imported_inodes, "imported_inodes", "Imported inodes", "imi",
+      PerfCountersBuilder::PRIO_INTERESTING);
     logger = mds_plb.create_perf_counters();
     g_ceph_context->get_perfcounters_collection()->add(logger);
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -60,31 +60,42 @@ void BlueFS::_init_logger()
   b.add_u64_counter(l_bluefs_reclaim_bytes, "reclaim_bytes",
 		    "Bytes reclaimed by BlueStore");
   b.add_u64(l_bluefs_db_total_bytes, "db_total_bytes",
-	    "Total bytes (main db device)");
+	    "Total bytes (main db device)",
+	    "b", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64(l_bluefs_db_used_bytes, "db_used_bytes",
-	    "Used bytes (main db device)");
+	    "Used bytes (main db device)",
+	    "u", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64(l_bluefs_wal_total_bytes, "wal_total_bytes",
-	    "Total bytes (wal device)");
+	    "Total bytes (wal device)",
+	    "walb", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64(l_bluefs_wal_used_bytes, "wal_used_bytes",
-	    "Used bytes (wal device)");
+	    "Used bytes (wal device)",
+	    "walu", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64(l_bluefs_slow_total_bytes, "slow_total_bytes",
-	    "Total bytes (slow device)");
+	    "Total bytes (slow device)",
+	    "slob", PerfCountersBuilder::PRIO_USEFUL);
   b.add_u64(l_bluefs_slow_used_bytes, "slow_used_bytes",
-	    "Used bytes (slow device)");
-  b.add_u64(l_bluefs_num_files, "num_files", "File count");
-  b.add_u64(l_bluefs_log_bytes, "log_bytes", "Size of the metadata log");
+	    "Used bytes (slow device)",
+	    "slou", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64(l_bluefs_num_files, "num_files", "File count",
+	    "f", PerfCountersBuilder::PRIO_USEFUL);
+  b.add_u64(l_bluefs_log_bytes, "log_bytes", "Size of the metadata log",
+	    "jlen", PerfCountersBuilder::PRIO_INTERESTING);
   b.add_u64_counter(l_bluefs_log_compactions, "log_compactions",
 		    "Compactions of the metadata log");
   b.add_u64_counter(l_bluefs_logged_bytes, "logged_bytes",
-		    "Bytes written to the metadata log", "j");
+		    "Bytes written to the metadata log", "j",
+		    PerfCountersBuilder::PRIO_CRITICAL);
   b.add_u64_counter(l_bluefs_files_written_wal, "files_written_wal",
 		    "Files written to WAL");
   b.add_u64_counter(l_bluefs_files_written_sst, "files_written_sst",
 		    "Files written to SSTs");
   b.add_u64_counter(l_bluefs_bytes_written_wal, "bytes_written_wal",
-		    "Bytes written to WAL", "wal");
+		    "Bytes written to WAL", "wal",
+		    PerfCountersBuilder::PRIO_CRITICAL);
   b.add_u64_counter(l_bluefs_bytes_written_sst, "bytes_written_sst",
-		    "Bytes written to SSTs", "sst");
+		    "Bytes written to SSTs", "sst",
+		    PerfCountersBuilder::PRIO_CRITICAL);
   logger = b.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3421,15 +3421,15 @@ void BlueStore::_init_logger()
   PerfCountersBuilder b(cct, "bluestore",
                         l_bluestore_first, l_bluestore_last);
   b.add_time_avg(l_bluestore_kv_flush_lat, "kv_flush_lat",
-		 "Average kv_thread flush latency", "kflat");
+		 "Average kv_thread flush latency", "fl_l");
   b.add_time_avg(l_bluestore_kv_commit_lat, "kv_commit_lat",
 		 "Average kv_thread commit latency");
   b.add_time_avg(l_bluestore_kv_lat, "kv_lat",
-		 "Average kv_thread sync latency", "klat");
+		 "Average kv_thread sync latency", "k_l");
   b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
     "Average prepare state latency");
   b.add_time_avg(l_bluestore_state_aio_wait_lat, "state_aio_wait_lat",
-		 "Average aio_wait state latency", "iolat");
+		 "Average aio_wait state latency", "io_l");
   b.add_time_avg(l_bluestore_state_io_done_lat, "state_io_done_lat",
     "Average io_done state latency");
   b.add_time_avg(l_bluestore_state_kv_queued_lat, "state_kv_queued_lat",
@@ -3449,13 +3449,13 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_state_done_lat, "state_done_lat",
     "Average done state latency");
   b.add_time_avg(l_bluestore_throttle_lat, "throttle_lat",
-		 "Average submit throttle latency", "tlat");
+		 "Average submit throttle latency", "t_l");
   b.add_time_avg(l_bluestore_submit_lat, "submit_lat",
-		 "Average submit latency", "slat");
+		 "Average submit latency", "s_l");
   b.add_time_avg(l_bluestore_commit_lat, "commit_lat",
-		 "Average commit latency", "clat");
+		 "Average commit latency", "c_l");
   b.add_time_avg(l_bluestore_read_lat, "read_lat",
-		 "Average read latency", "rlat");
+		 "Average read latency", "r_l");
   b.add_time_avg(l_bluestore_read_onode_meta_lat, "read_onode_meta_lat",
     "Average read onode metadata latency");
   b.add_time_avg(l_bluestore_read_wait_aio_lat, "read_wait_aio_lat",

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3421,15 +3421,18 @@ void BlueStore::_init_logger()
   PerfCountersBuilder b(cct, "bluestore",
                         l_bluestore_first, l_bluestore_last);
   b.add_time_avg(l_bluestore_kv_flush_lat, "kv_flush_lat",
-		 "Average kv_thread flush latency", "fl_l");
+		 "Average kv_thread flush latency",
+		 "fl_l", PerfCountersBuilder::PRIO_INTERESTING);
   b.add_time_avg(l_bluestore_kv_commit_lat, "kv_commit_lat",
 		 "Average kv_thread commit latency");
   b.add_time_avg(l_bluestore_kv_lat, "kv_lat",
-		 "Average kv_thread sync latency", "k_l");
+		 "Average kv_thread sync latency",
+		 "k_l", PerfCountersBuilder::PRIO_INTERESTING);
   b.add_time_avg(l_bluestore_state_prepare_lat, "state_prepare_lat",
     "Average prepare state latency");
   b.add_time_avg(l_bluestore_state_aio_wait_lat, "state_aio_wait_lat",
-		 "Average aio_wait state latency", "io_l");
+		 "Average aio_wait state latency",
+		 "io_l", PerfCountersBuilder::PRIO_INTERESTING);
   b.add_time_avg(l_bluestore_state_io_done_lat, "state_io_done_lat",
     "Average io_done state latency");
   b.add_time_avg(l_bluestore_state_kv_queued_lat, "state_kv_queued_lat",
@@ -3449,13 +3452,17 @@ void BlueStore::_init_logger()
   b.add_time_avg(l_bluestore_state_done_lat, "state_done_lat",
     "Average done state latency");
   b.add_time_avg(l_bluestore_throttle_lat, "throttle_lat",
-		 "Average submit throttle latency", "t_l");
+		 "Average submit throttle latency",
+		 "th_l", PerfCountersBuilder::PRIO_CRITICAL);
   b.add_time_avg(l_bluestore_submit_lat, "submit_lat",
-		 "Average submit latency", "s_l");
+		 "Average submit latency",
+		 "s_l", PerfCountersBuilder::PRIO_CRITICAL);
   b.add_time_avg(l_bluestore_commit_lat, "commit_lat",
-		 "Average commit latency", "c_l");
+		 "Average commit latency",
+		 "c_l", PerfCountersBuilder::PRIO_CRITICAL);
   b.add_time_avg(l_bluestore_read_lat, "read_lat",
-		 "Average read latency", "r_l");
+		 "Average read latency",
+		 "r_l", PerfCountersBuilder::PRIO_CRITICAL);
   b.add_time_avg(l_bluestore_read_onode_meta_lat, "read_onode_meta_lat",
     "Average read onode metadata latency");
   b.add_time_avg(l_bluestore_read_wait_aio_lat, "read_wait_aio_lat",

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2746,15 +2746,16 @@ void OSD::create_logger()
     "Replication operations currently being processed (primary)");
   osd_plb.add_u64_counter(
     l_osd_op, "op",
-    "Client operations", "ops", PerfCountersBuilder::PRIO_CRITICAL);
+    "Client operations",
+    "ops", PerfCountersBuilder::PRIO_CRITICAL);
   osd_plb.add_u64_counter(
     l_osd_op_inb,   "op_in_bytes",
-    "Client operations total write size", "wr",
-    PerfCountersBuilder::PRIO_INTERESTING);
+    "Client operations total write size",
+    "wr", PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op_outb,  "op_out_bytes",
-    "Client operations total read size", "rd",
-    PerfCountersBuilder::PRIO_INTERESTING);
+    "Client operations total read size",
+    "rd", PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_lat,   "op_latency",
     "Latency of client operations (including queue time)",
@@ -2855,8 +2856,8 @@ void OSD::create_logger()
 
   osd_plb.add_u64_counter(
     l_osd_rop, "recovery_ops",
-    "Started recovery operations", "rop",
-    PerfCountersBuilder::PRIO_INTERESTING);
+    "Started recovery operations",
+    "rop", PerfCountersBuilder::PRIO_INTERESTING);
 
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
   osd_plb.add_u64(l_osd_buf, "buffer_bytes", "Total allocated buffer size");
@@ -2868,8 +2869,8 @@ void OSD::create_logger()
     l_osd_cached_crc_adjusted, "cached_crc_adjusted",
     "Total number getting crc from crc_cache with adjusting");
 
-  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups", "pgs",
-		  PerfCountersBuilder::PRIO_USEFUL);
+  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups",
+		  "pgs", PerfCountersBuilder::PRIO_USEFUL);
   osd_plb.add_u64(
     l_osd_pg_primary, "numpg_primary",
     "Placement groups for which this osd is primary");

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2741,145 +2741,220 @@ void OSD::create_logger()
   };
 
 
-  osd_plb.add_u64(l_osd_op_wip, "op_wip",
-      "Replication operations currently being processed (primary)");   // rep ops currently being processed (primary)
-  osd_plb.add_u64_counter(l_osd_op,       "op",
-      "Client operations", "ops");           // client ops
-  osd_plb.add_u64_counter(l_osd_op_inb,   "op_in_bytes",
-      "Client operations total write size", "wr");       // client op in bytes (writes)
-  osd_plb.add_u64_counter(l_osd_op_outb,  "op_out_bytes",
-      "Client operations total read size", "rd");      // client op out bytes (reads)
-  osd_plb.add_time_avg(l_osd_op_lat,   "op_latency",
-      "Latency of client operations (including queue time)", "l");       // client op latency
-  osd_plb.add_time_avg(l_osd_op_process_lat, "op_process_latency",
-      "Latency of client operations (excluding queue time)");   // client op process latency
-  osd_plb.add_time_avg(l_osd_op_prepare_lat, "op_prepare_latency",
-      "Latency of client operations (excluding queue time and wait for finished)"); // client op prepare latency
+  osd_plb.add_u64(
+    l_osd_op_wip, "op_wip",
+    "Replication operations currently being processed (primary)");
+  osd_plb.add_u64_counter(
+    l_osd_op, "op",
+    "Client operations", "ops");
+  osd_plb.add_u64_counter(
+    l_osd_op_inb,   "op_in_bytes",
+    "Client operations total write size", "wr");
+  osd_plb.add_u64_counter(
+    l_osd_op_outb,  "op_out_bytes",
+    "Client operations total read size", "rd");
+  osd_plb.add_time_avg(
+    l_osd_op_lat,   "op_latency",
+    "Latency of client operations (including queue time)",
+    "l", 9);
+  osd_plb.add_time_avg(
+    l_osd_op_process_lat, "op_process_latency",
+    "Latency of client operations (excluding queue time)");
+  osd_plb.add_time_avg(
+    l_osd_op_prepare_lat, "op_prepare_latency",
+    "Latency of client operations (excluding queue time and wait for finished)");
 
-  osd_plb.add_u64_counter(l_osd_op_r,      "op_r",
-      "Client read operations");        // client reads
-  osd_plb.add_u64_counter(l_osd_op_r_outb, "op_r_out_bytes",
-      "Client data read");   // client read out bytes
-  osd_plb.add_time_avg(l_osd_op_r_lat,  "op_r_latency",
-      "Latency of read operation (including queue time)");    // client read latency
-  osd_plb.add_histogram(l_osd_op_r_lat_outb_hist,  "op_r_latency_out_bytes_histogram",
-      op_hist_x_axis_config, op_hist_y_axis_config,
-      "Histogram of operation latency (including queue time) + data read");
-  osd_plb.add_time_avg(l_osd_op_r_process_lat, "op_r_process_latency",
-      "Latency of read operation (excluding queue time)");   // client read process latency
-  osd_plb.add_time_avg(l_osd_op_r_prepare_lat, "op_r_prepare_latency",
-      "Latency of read operations (excluding queue time and wait for finished)"); // client read prepare latency
-  osd_plb.add_u64_counter(l_osd_op_w,      "op_w",
-      "Client write operations");        // client writes
-  osd_plb.add_u64_counter(l_osd_op_w_inb,  "op_w_in_bytes",
-      "Client data written");    // client write in bytes
-  osd_plb.add_time_avg(l_osd_op_w_lat,  "op_w_latency",
-      "Latency of write operation (including queue time)");    // client write latency
-  osd_plb.add_histogram(l_osd_op_w_lat_inb_hist,  "op_w_latency_in_bytes_histogram",
-      op_hist_x_axis_config, op_hist_y_axis_config,
-      "Histogram of operation latency (including queue time) + data written");
-  osd_plb.add_time_avg(l_osd_op_w_process_lat, "op_w_process_latency",
-      "Latency of write operation (excluding queue time)");   // client write process latency
-  osd_plb.add_time_avg(l_osd_op_w_prepare_lat, "op_w_prepare_latency",
-      "Latency of write operations (excluding queue time and wait for finished)"); // client write prepare latency
-  osd_plb.add_u64_counter(l_osd_op_rw,     "op_rw",
-      "Client read-modify-write operations");       // client rmw
-  osd_plb.add_u64_counter(l_osd_op_rw_inb, "op_rw_in_bytes",
-      "Client read-modify-write operations write in");   // client rmw in bytes
-  osd_plb.add_u64_counter(l_osd_op_rw_outb,"op_rw_out_bytes",
-      "Client read-modify-write operations read out ");  // client rmw out bytes
-  osd_plb.add_time_avg(l_osd_op_rw_lat, "op_rw_latency",
-      "Latency of read-modify-write operation (including queue time)");   // client rmw latency
-  osd_plb.add_histogram(l_osd_op_rw_lat_inb_hist, "op_rw_latency_in_bytes_histogram",
-      op_hist_x_axis_config, op_hist_y_axis_config,
-      "Histogram of rw operation latency (including queue time) + data written");
-  osd_plb.add_histogram(l_osd_op_rw_lat_outb_hist, "op_rw_latency_out_bytes_histogram",
-      op_hist_x_axis_config, op_hist_y_axis_config,
-      "Histogram of rw operation latency (including queue time) + data read");
-  osd_plb.add_time_avg(l_osd_op_rw_process_lat, "op_rw_process_latency",
-      "Latency of read-modify-write operation (excluding queue time)");   // client rmw process latency
-  osd_plb.add_time_avg(l_osd_op_rw_prepare_lat, "op_rw_prepare_latency",
-      "Latency of read-modify-write operations (excluding queue time and wait for finished)"); // client rmw prepare latency
+  osd_plb.add_u64_counter(
+    l_osd_op_r, "op_r", "Client read operations");
+  osd_plb.add_u64_counter(
+    l_osd_op_r_outb, "op_r_out_bytes", "Client data read");
+  osd_plb.add_time_avg(
+    l_osd_op_r_lat, "op_r_latency",
+    "Latency of read operation (including queue time)");
+  osd_plb.add_histogram(
+    l_osd_op_r_lat_outb_hist, "op_r_latency_out_bytes_histogram",
+    op_hist_x_axis_config, op_hist_y_axis_config,
+    "Histogram of operation latency (including queue time) + data read");
+  osd_plb.add_time_avg(
+    l_osd_op_r_process_lat, "op_r_process_latency",
+    "Latency of read operation (excluding queue time)");
+  osd_plb.add_time_avg(
+    l_osd_op_r_prepare_lat, "op_r_prepare_latency",
+    "Latency of read operations (excluding queue time and wait for finished)");
+  osd_plb.add_u64_counter(
+    l_osd_op_w, "op_w", "Client write operations");
+  osd_plb.add_u64_counter(
+    l_osd_op_w_inb, "op_w_in_bytes", "Client data written");
+  osd_plb.add_time_avg(
+    l_osd_op_w_lat,  "op_w_latency",
+    "Latency of write operation (including queue time)");
+  osd_plb.add_histogram(
+    l_osd_op_w_lat_inb_hist, "op_w_latency_in_bytes_histogram",
+    op_hist_x_axis_config, op_hist_y_axis_config,
+    "Histogram of operation latency (including queue time) + data written");
+  osd_plb.add_time_avg(
+    l_osd_op_w_process_lat, "op_w_process_latency",
+    "Latency of write operation (excluding queue time)");
+  osd_plb.add_time_avg(
+    l_osd_op_w_prepare_lat, "op_w_prepare_latency",
+    "Latency of write operations (excluding queue time and wait for finished)");
+  osd_plb.add_u64_counter(
+    l_osd_op_rw, "op_rw",
+    "Client read-modify-write operations");
+  osd_plb.add_u64_counter(
+    l_osd_op_rw_inb, "op_rw_in_bytes",
+    "Client read-modify-write operations write in");
+  osd_plb.add_u64_counter(
+    l_osd_op_rw_outb,"op_rw_out_bytes",
+    "Client read-modify-write operations read out ");
+  osd_plb.add_time_avg(
+    l_osd_op_rw_lat, "op_rw_latency",
+    "Latency of read-modify-write operation (including queue time)");
+  osd_plb.add_histogram(
+    l_osd_op_rw_lat_inb_hist, "op_rw_latency_in_bytes_histogram",
+    op_hist_x_axis_config, op_hist_y_axis_config,
+    "Histogram of rw operation latency (including queue time) + data written");
+  osd_plb.add_histogram(
+    l_osd_op_rw_lat_outb_hist, "op_rw_latency_out_bytes_histogram",
+    op_hist_x_axis_config, op_hist_y_axis_config,
+    "Histogram of rw operation latency (including queue time) + data read");
+  osd_plb.add_time_avg(
+    l_osd_op_rw_process_lat, "op_rw_process_latency",
+    "Latency of read-modify-write operation (excluding queue time)");
+  osd_plb.add_time_avg(
+    l_osd_op_rw_prepare_lat, "op_rw_prepare_latency",
+    "Latency of read-modify-write operations (excluding queue time and wait for finished)");
 
-  osd_plb.add_u64_counter(l_osd_sop,       "subop", "Suboperations");         // subops
-  osd_plb.add_u64_counter(l_osd_sop_inb,   "subop_in_bytes", "Suboperations total size");     // subop in bytes
-  osd_plb.add_time_avg(l_osd_sop_lat,   "subop_latency", "Suboperations latency");     // subop latency
+  osd_plb.add_u64_counter(
+    l_osd_sop, "subop", "Suboperations");
+  osd_plb.add_u64_counter(
+    l_osd_sop_inb, "subop_in_bytes", "Suboperations total size");
+  osd_plb.add_time_avg(l_osd_sop_lat, "subop_latency", "Suboperations latency");
 
-  osd_plb.add_u64_counter(l_osd_sop_w,     "subop_w", "Replicated writes");          // replicated (client) writes
-  osd_plb.add_u64_counter(l_osd_sop_w_inb, "subop_w_in_bytes", "Replicated written data size");      // replicated write in bytes
-  osd_plb.add_time_avg(l_osd_sop_w_lat, "subop_w_latency", "Replicated writes latency");      // replicated write latency
-  osd_plb.add_u64_counter(l_osd_sop_pull,     "subop_pull", "Suboperations pull requests");       // pull request
-  osd_plb.add_time_avg(l_osd_sop_pull_lat, "subop_pull_latency", "Suboperations pull latency");
-  osd_plb.add_u64_counter(l_osd_sop_push,     "subop_push", "Suboperations push messages");       // push (write)
-  osd_plb.add_u64_counter(l_osd_sop_push_inb, "subop_push_in_bytes", "Suboperations pushed size");
-  osd_plb.add_time_avg(l_osd_sop_push_lat, "subop_push_latency", "Suboperations push latency");
+  osd_plb.add_u64_counter(l_osd_sop_w, "subop_w", "Replicated writes");
+  osd_plb.add_u64_counter(
+    l_osd_sop_w_inb, "subop_w_in_bytes", "Replicated written data size");
+  osd_plb.add_time_avg(
+    l_osd_sop_w_lat, "subop_w_latency", "Replicated writes latency");
+  osd_plb.add_u64_counter(
+    l_osd_sop_pull, "subop_pull", "Suboperations pull requests");
+  osd_plb.add_time_avg(
+    l_osd_sop_pull_lat, "subop_pull_latency", "Suboperations pull latency");
+  osd_plb.add_u64_counter(
+    l_osd_sop_push, "subop_push", "Suboperations push messages");
+  osd_plb.add_u64_counter(
+    l_osd_sop_push_inb, "subop_push_in_bytes", "Suboperations pushed size");
+  osd_plb.add_time_avg(
+    l_osd_sop_push_lat, "subop_push_latency", "Suboperations push latency");
 
-  osd_plb.add_u64_counter(l_osd_pull,      "pull", "Pull requests sent");       // pull requests sent
-  osd_plb.add_u64_counter(l_osd_push,      "push", "Push messages sent");       // push messages
-  osd_plb.add_u64_counter(l_osd_push_outb, "push_out_bytes", "Pushed size");  // pushed bytes
+  osd_plb.add_u64_counter(l_osd_pull, "pull", "Pull requests sent");
+  osd_plb.add_u64_counter(l_osd_push, "push", "Push messages sent");
+  osd_plb.add_u64_counter(l_osd_push_outb, "push_out_bytes", "Pushed size");
 
-  osd_plb.add_u64_counter(l_osd_rop, "recovery_ops",
-      "Started recovery operations", "rop");       // recovery ops (started)
+  osd_plb.add_u64_counter(
+    l_osd_rop, "recovery_ops",
+    "Started recovery operations", "rop");
 
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
-  osd_plb.add_u64(l_osd_buf, "buffer_bytes", "Total allocated buffer size");       // total ceph::buffer bytes
-  osd_plb.add_u64(l_osd_history_alloc_bytes, "history_alloc_Mbytes");       // total ceph::buffer bytes in history
-  osd_plb.add_u64(l_osd_history_alloc_num, "history_alloc_num");       // total ceph::buffer num in history
-  osd_plb.add_u64(l_osd_cached_crc, "cached_crc", "Total number getting crc from crc_cache"); // total ceph::buffer buffer_cached_crc
-  osd_plb.add_u64(l_osd_cached_crc_adjusted, "cached_crc_adjusted", "Total number getting crc from crc_cache with adjusting"); // total ceph::buffer buffer_cached_crc_adjusted
+  osd_plb.add_u64(l_osd_buf, "buffer_bytes", "Total allocated buffer size");
+  osd_plb.add_u64(l_osd_history_alloc_bytes, "history_alloc_Mbytes");
+  osd_plb.add_u64(l_osd_history_alloc_num, "history_alloc_num");
+  osd_plb.add_u64(
+    l_osd_cached_crc, "cached_crc", "Total number getting crc from crc_cache");
+  osd_plb.add_u64(
+    l_osd_cached_crc_adjusted, "cached_crc_adjusted",
+    "Total number getting crc from crc_cache with adjusting");
 
-  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups");   // num pgs
-  osd_plb.add_u64(l_osd_pg_primary, "numpg_primary", "Placement groups for which this osd is primary"); // num primary pgs
-  osd_plb.add_u64(l_osd_pg_replica, "numpg_replica", "Placement groups for which this osd is replica"); // num replica pgs
-  osd_plb.add_u64(l_osd_pg_stray, "numpg_stray", "Placement groups ready to be deleted from this osd");   // num stray pgs
-  osd_plb.add_u64(l_osd_hb_to, "heartbeat_to_peers", "Heartbeat (ping) peers we send to");     // heartbeat peers we send to
-  osd_plb.add_u64_counter(l_osd_map, "map_messages", "OSD map messages");           // osdmap messages
-  osd_plb.add_u64_counter(l_osd_mape, "map_message_epochs", "OSD map epochs");         // osdmap epochs
-  osd_plb.add_u64_counter(l_osd_mape_dup, "map_message_epoch_dups", "OSD map duplicates"); // dup osdmap epochs
-  osd_plb.add_u64_counter(l_osd_waiting_for_map, "messages_delayed_for_map", "Operations waiting for OSD map"); // dup osdmap epochs
-  osd_plb.add_u64_counter(l_osd_map_cache_hit, "osd_map_cache_hit", "osdmap cache hit");
-  osd_plb.add_u64_counter(l_osd_map_cache_miss, "osd_map_cache_miss", "osdmap cache miss");
-  osd_plb.add_u64_counter(l_osd_map_cache_miss_low, "osd_map_cache_miss_low", "osdmap cache miss below cache lower bound");
-  osd_plb.add_u64_avg(l_osd_map_cache_miss_low_avg, "osd_map_cache_miss_low_avg", "osdmap cache miss, avg distance below cache lower bound");
+  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups", "pgs");
+  osd_plb.add_u64(
+    l_osd_pg_primary, "numpg_primary",
+    "Placement groups for which this osd is primary");
+  osd_plb.add_u64(
+    l_osd_pg_replica, "numpg_replica",
+    "Placement groups for which this osd is replica");
+  osd_plb.add_u64(
+    l_osd_pg_stray, "numpg_stray",
+    "Placement groups ready to be deleted from this osd");
+  osd_plb.add_u64(
+    l_osd_hb_to, "heartbeat_to_peers", "Heartbeat (ping) peers we send to");
+  osd_plb.add_u64_counter(l_osd_map, "map_messages", "OSD map messages");
+  osd_plb.add_u64_counter(l_osd_mape, "map_message_epochs", "OSD map epochs");
+  osd_plb.add_u64_counter(
+    l_osd_mape_dup, "map_message_epoch_dups", "OSD map duplicates");
+  osd_plb.add_u64_counter(
+    l_osd_waiting_for_map, "messages_delayed_for_map",
+    "Operations waiting for OSD map");
+  osd_plb.add_u64_counter(
+    l_osd_map_cache_hit, "osd_map_cache_hit", "osdmap cache hit");
+  osd_plb.add_u64_counter(
+    l_osd_map_cache_miss, "osd_map_cache_miss", "osdmap cache miss");
+  osd_plb.add_u64_counter(
+    l_osd_map_cache_miss_low, "osd_map_cache_miss_low",
+    "osdmap cache miss below cache lower bound");
+  osd_plb.add_u64_avg(
+    l_osd_map_cache_miss_low_avg, "osd_map_cache_miss_low_avg",
+    "osdmap cache miss, avg distance below cache lower bound");
 
   osd_plb.add_u64(l_osd_stat_bytes, "stat_bytes", "OSD size");
   osd_plb.add_u64(l_osd_stat_bytes_used, "stat_bytes_used", "Used space");
   osd_plb.add_u64(l_osd_stat_bytes_avail, "stat_bytes_avail", "Available space");
 
-  osd_plb.add_u64_counter(l_osd_copyfrom, "copyfrom", "Rados \"copy-from\" operations");
+  osd_plb.add_u64_counter(
+    l_osd_copyfrom, "copyfrom", "Rados \"copy-from\" operations");
 
   osd_plb.add_u64_counter(l_osd_tier_promote, "tier_promote", "Tier promotions");
   osd_plb.add_u64_counter(l_osd_tier_flush, "tier_flush", "Tier flushes");
-  osd_plb.add_u64_counter(l_osd_tier_flush_fail, "tier_flush_fail", "Failed tier flushes");
-  osd_plb.add_u64_counter(l_osd_tier_try_flush, "tier_try_flush", "Tier flush attempts");
-  osd_plb.add_u64_counter(l_osd_tier_try_flush_fail, "tier_try_flush_fail", "Failed tier flush attempts");
-  osd_plb.add_u64_counter(l_osd_tier_evict, "tier_evict", "Tier evictions");
-  osd_plb.add_u64_counter(l_osd_tier_whiteout, "tier_whiteout", "Tier whiteouts");
-  osd_plb.add_u64_counter(l_osd_tier_dirty, "tier_dirty", "Dirty tier flag set");
-  osd_plb.add_u64_counter(l_osd_tier_clean, "tier_clean", "Dirty tier flag cleaned");
-  osd_plb.add_u64_counter(l_osd_tier_delay, "tier_delay", "Tier delays (agent waiting)");
-  osd_plb.add_u64_counter(l_osd_tier_proxy_read, "tier_proxy_read", "Tier proxy reads");
-  osd_plb.add_u64_counter(l_osd_tier_proxy_write, "tier_proxy_write", "Tier proxy writes");
+  osd_plb.add_u64_counter(
+    l_osd_tier_flush_fail, "tier_flush_fail", "Failed tier flushes");
+  osd_plb.add_u64_counter(
+    l_osd_tier_try_flush, "tier_try_flush", "Tier flush attempts");
+  osd_plb.add_u64_counter(
+    l_osd_tier_try_flush_fail, "tier_try_flush_fail",
+    "Failed tier flush attempts");
+  osd_plb.add_u64_counter(
+    l_osd_tier_evict, "tier_evict", "Tier evictions");
+  osd_plb.add_u64_counter(
+    l_osd_tier_whiteout, "tier_whiteout", "Tier whiteouts");
+  osd_plb.add_u64_counter(
+    l_osd_tier_dirty, "tier_dirty", "Dirty tier flag set");
+  osd_plb.add_u64_counter(
+    l_osd_tier_clean, "tier_clean", "Dirty tier flag cleaned");
+  osd_plb.add_u64_counter(
+    l_osd_tier_delay, "tier_delay", "Tier delays (agent waiting)");
+  osd_plb.add_u64_counter(
+    l_osd_tier_proxy_read, "tier_proxy_read", "Tier proxy reads");
+  osd_plb.add_u64_counter(
+    l_osd_tier_proxy_write, "tier_proxy_write", "Tier proxy writes");
 
-  osd_plb.add_u64_counter(l_osd_agent_wake, "agent_wake", "Tiering agent wake up");
-  osd_plb.add_u64_counter(l_osd_agent_skip, "agent_skip", "Objects skipped by agent");
-  osd_plb.add_u64_counter(l_osd_agent_flush, "agent_flush", "Tiering agent flushes");
-  osd_plb.add_u64_counter(l_osd_agent_evict, "agent_evict", "Tiering agent evictions");
+  osd_plb.add_u64_counter(
+    l_osd_agent_wake, "agent_wake", "Tiering agent wake up");
+  osd_plb.add_u64_counter(
+    l_osd_agent_skip, "agent_skip", "Objects skipped by agent");
+  osd_plb.add_u64_counter(
+    l_osd_agent_flush, "agent_flush", "Tiering agent flushes");
+  osd_plb.add_u64_counter(
+    l_osd_agent_evict, "agent_evict", "Tiering agent evictions");
 
-  osd_plb.add_u64_counter(l_osd_object_ctx_cache_hit, "object_ctx_cache_hit", "Object context cache hits");
-  osd_plb.add_u64_counter(l_osd_object_ctx_cache_total, "object_ctx_cache_total", "Object context cache lookups");
+  osd_plb.add_u64_counter(
+    l_osd_object_ctx_cache_hit, "object_ctx_cache_hit", "Object context cache hits");
+  osd_plb.add_u64_counter(
+    l_osd_object_ctx_cache_total, "object_ctx_cache_total", "Object context cache lookups");
 
   osd_plb.add_u64_counter(l_osd_op_cache_hit, "op_cache_hit");
-  osd_plb.add_time_avg(l_osd_tier_flush_lat, "osd_tier_flush_lat", "Object flush latency");
-  osd_plb.add_time_avg(l_osd_tier_promote_lat, "osd_tier_promote_lat", "Object promote latency");
-  osd_plb.add_time_avg(l_osd_tier_r_lat, "osd_tier_r_lat", "Object proxy read latency");
+  osd_plb.add_time_avg(
+    l_osd_tier_flush_lat, "osd_tier_flush_lat", "Object flush latency");
+  osd_plb.add_time_avg(
+    l_osd_tier_promote_lat, "osd_tier_promote_lat", "Object promote latency");
+  osd_plb.add_time_avg(
+    l_osd_tier_r_lat, "osd_tier_r_lat", "Object proxy read latency");
 
-  osd_plb.add_u64_counter(l_osd_pg_info, "osd_pg_info",
-			  "PG updated its info (using any method)");
-  osd_plb.add_u64_counter(l_osd_pg_fastinfo, "osd_pg_fastinfo",
-			  "PG updated its info using fastinfo attr");
-  osd_plb.add_u64_counter(l_osd_pg_biginfo, "osd_pg_biginfo",
-			  "PG updated its biginfo attr");
+  osd_plb.add_u64_counter(
+    l_osd_pg_info, "osd_pg_info", "PG updated its info (using any method)");
+  osd_plb.add_u64_counter(
+    l_osd_pg_fastinfo, "osd_pg_fastinfo",
+    "PG updated its info using fastinfo attr");
+  osd_plb.add_u64_counter(
+    l_osd_pg_biginfo, "osd_pg_biginfo", "PG updated its biginfo attr");
 
   logger = osd_plb.create_perf_counters();
   cct->get_perfcounters_collection()->add(logger);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2746,13 +2746,15 @@ void OSD::create_logger()
     "Replication operations currently being processed (primary)");
   osd_plb.add_u64_counter(
     l_osd_op, "op",
-    "Client operations", "ops");
+    "Client operations", "ops", PerfCountersBuilder::PRIO_CRITICAL);
   osd_plb.add_u64_counter(
     l_osd_op_inb,   "op_in_bytes",
-    "Client operations total write size", "wr");
+    "Client operations total write size", "wr",
+    PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_u64_counter(
     l_osd_op_outb,  "op_out_bytes",
-    "Client operations total read size", "rd");
+    "Client operations total read size", "rd",
+    PerfCountersBuilder::PRIO_INTERESTING);
   osd_plb.add_time_avg(
     l_osd_op_lat,   "op_latency",
     "Latency of client operations (including queue time)",
@@ -2853,7 +2855,8 @@ void OSD::create_logger()
 
   osd_plb.add_u64_counter(
     l_osd_rop, "recovery_ops",
-    "Started recovery operations", "rop");
+    "Started recovery operations", "rop",
+    PerfCountersBuilder::PRIO_INTERESTING);
 
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
   osd_plb.add_u64(l_osd_buf, "buffer_bytes", "Total allocated buffer size");
@@ -2865,7 +2868,8 @@ void OSD::create_logger()
     l_osd_cached_crc_adjusted, "cached_crc_adjusted",
     "Total number getting crc from crc_cache with adjusting");
 
-  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups", "pgs");
+  osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups", "pgs",
+		  PerfCountersBuilder::PRIO_USEFUL);
   osd_plb.add_u64(
     l_osd_pg_primary, "numpg_primary",
     "Placement groups for which this osd is primary");

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2750,7 +2750,7 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(l_osd_op_outb,  "op_out_bytes",
       "Client operations total read size", "rd");      // client op out bytes (reads)
   osd_plb.add_time_avg(l_osd_op_lat,   "op_latency",
-      "Latency of client operations (including queue time)", "lat");       // client op latency
+      "Latency of client operations (including queue time)", "l");       // client op latency
   osd_plb.add_time_avg(l_osd_op_process_lat, "op_process_latency",
       "Latency of client operations (excluding queue time)");   // client op process latency
   osd_plb.add_time_avg(l_osd_op_prepare_lat, "op_prepare_latency",
@@ -2819,7 +2819,7 @@ void OSD::create_logger()
   osd_plb.add_u64_counter(l_osd_push_outb, "push_out_bytes", "Pushed size");  // pushed bytes
 
   osd_plb.add_u64_counter(l_osd_rop, "recovery_ops",
-      "Started recovery operations", "recop");       // recovery ops (started)
+      "Started recovery operations", "rop");       // recovery ops (started)
 
   osd_plb.add_u64(l_osd_loadavg, "loadavg", "CPU load");
   osd_plb.add_u64(l_osd_buf, "buffer_bytes", "Total allocated buffer size");       // total ceph::buffer bytes

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -514,8 +514,8 @@ void OSDService::init()
   objecter_finisher.start();
   objecter->set_client_incarnation(0);
 
-  // exclude objecter from daemonperf output
-  objecter->get_logger()->set_suppress_nicks(true);
+  // deprioritize objecter in daemonperf output
+  objecter->get_logger()->set_prio_adjust(-3);
 
   watch_timer.init();
   agent_timer.init();

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -252,11 +252,11 @@ void Objecter::init()
 
     pcb.add_u64_counter(l_osdc_op, "op", "Operations");
     pcb.add_u64_counter(l_osdc_op_r, "op_r",
-			"Read operations", "read");
+			"Read operations", "rd");
     pcb.add_u64_counter(l_osdc_op_w, "op_w",
-			"Write operations", "writ");
+			"Write operations", "wr");
     pcb.add_u64_counter(l_osdc_op_rmw, "op_rmw",
-			"Read-modify-write operations");
+			"Read-modify-write operations", "rdwr");
     pcb.add_u64_counter(l_osdc_op_pg, "op_pg", "PG operation");
 
     pcb.add_u64_counter(l_osdc_osdop_stat, "osdop_stat", "Stat operations");

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -242,8 +242,8 @@ void Objecter::init()
   if (!logger) {
     PerfCountersBuilder pcb(cct, "objecter", l_osdc_first, l_osdc_last);
 
-    pcb.add_u64(l_osdc_op_active, "op_active",
-		"Operations active", "actv");
+    pcb.add_u64(l_osdc_op_active, "op_active", "Operations active", "actv",
+		PerfCountersBuilder::PRIO_CRITICAL);
     pcb.add_u64(l_osdc_op_laggy, "op_laggy", "Laggy operations");
     pcb.add_u64_counter(l_osdc_op_send, "op_send", "Sent operations");
     pcb.add_u64_counter(l_osdc_op_send_bytes, "op_send_bytes", "Sent data");
@@ -251,12 +251,12 @@ void Objecter::init()
     pcb.add_u64_counter(l_osdc_op_reply, "op_reply", "Operation reply");
 
     pcb.add_u64_counter(l_osdc_op, "op", "Operations");
-    pcb.add_u64_counter(l_osdc_op_r, "op_r",
-			"Read operations", "rd");
-    pcb.add_u64_counter(l_osdc_op_w, "op_w",
-			"Write operations", "wr");
-    pcb.add_u64_counter(l_osdc_op_rmw, "op_rmw",
-			"Read-modify-write operations", "rdwr");
+    pcb.add_u64_counter(l_osdc_op_r, "op_r", "Read operations", "rd",
+			PerfCountersBuilder::PRIO_CRITICAL);
+    pcb.add_u64_counter(l_osdc_op_w, "op_w", "Write operations", "wr",
+			PerfCountersBuilder::PRIO_CRITICAL);
+    pcb.add_u64_counter(l_osdc_op_rmw, "op_rmw", "Read-modify-write operations",
+			"rdwr", PerfCountersBuilder::PRIO_INTERESTING);
     pcb.add_u64_counter(l_osdc_op_pg, "op_pg", "PG operation");
 
     pcb.add_u64_counter(l_osdc_osdop_stat, "osdop_stat", "Stat operations");

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -335,7 +335,7 @@ class DaemonWatcher(object):
         self._stats = OrderedDict()
         for section_name, section_stats in self._schema.items():
             for name, schema_data in section_stats.items():
-                prio = schema_data.get('priority')
+                prio = schema_data.get('priority', 0)
                 if self._should_include(section_name, name, prio):
                     if section_name not in self._stats:
                         self._stats[section_name] = OrderedDict()

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -88,7 +88,12 @@ def admin_socket(asok_path, cmd, format=''):
 
 
 def _gettermsize():
-    return struct.unpack('hhhh', ioctl(0, TIOCGWINSZ, 8*'\x00'))[0:2]
+    try:
+        rows, cols = struct.unpack('hhhh', ioctl(0, TIOCGWINSZ, 8*'\x00'))[0:2]
+    except IOError:
+        return 25, 80
+
+    return rows,cols
 
 
 class Termsize(object):

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -341,6 +341,11 @@ class DaemonWatcher(object):
                         break
                 rows_since_header += 1
                 last_dump = dump
-                time.sleep(interval)
+
+                # time.sleep() is interrupted by SIGWINCH; avoid that
+                end = time.time() + interval
+                while time.time() < end:
+                    time.sleep(end - time.time())
+
         except KeyboardInterrupt:
             return

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -331,7 +331,7 @@ class DaemonWatcher(object):
             signal(SIGWINCH, self._handle_sigwinch)
             while True:
                 dump = json.loads(admin_socket(self.asok_path, ["perf", "dump"]).decode('utf-8'))
-                if rows_since_header > self.termsize.rows - 2:
+                if rows_since_header >= self.termsize.rows - 2:
                     self._print_headers(ostr)
                     rows_since_header = 0
                 self._print_vals(ostr, dump, last_dump)

--- a/src/pybind/ceph_daemon.py
+++ b/src/pybind/ceph_daemon.py
@@ -214,7 +214,7 @@ class DaemonWatcher(object):
         Get a possibly-truncated list of stats to display based on
         current terminal width.  Allow breaking mid-section.
         '''
-        current_fit = {}
+        current_fit = OrderedDict()
         if self.termsize.changed or not self._stats_that_fit:
             width = 0
             for section_name, names in self._stats.items():
@@ -223,7 +223,7 @@ class DaemonWatcher(object):
                     if width > self.termsize.cols:
                         break
                     if section_name not in current_fit:
-                        current_fit[section_name] = {}
+                        current_fit[section_name] = OrderedDict()
                     current_fit[section_name][name] = stat_data
                 if width > self.termsize.cols:
                     break


### PR DESCRIPTION
Builds on Sage's perfcounter priorities branch, adds to daemonperf.  

New features:

- [stat-pats]:   optional list of shell-glob patterns to select stats
- [priority]:   optional minimum priority of stat to allow (default: 'useful')
- daemonperf list|ls: Show tabular list of selected stats and their nicknames
- daemonperf display now reacts when terminal is resized, truncating sections if necessary