### PR TITLE
init-ceph: should have a space before "]"

### DIFF
--- a/src/init-ceph.in
+++ b/src/init-ceph.in
@@ -266,7 +266,7 @@ get_name_list "$@"
 
 # Reverse the order if we are stopping
 
-if [ "$command" = "stop" -o "$command" = "onestop"]; then
+if [ "$command" = "stop" -o "$command" = "onestop" ]; then
     for f in $what; do
        new_order="$f $new_order"
     done


### PR DESCRIPTION
otherwise we will have

./bin/init-ceph: 269: [: missing ]

Signed-off-by: Kefu Chai <kchai@redhat.com>