### PR TITLE
src/osd: remove unnecessary snap trimming when pool is self-managed

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1263,6 +1263,12 @@ void pg_pool_t::build_removed_snaps(interval_set<snapid_t>& rs) const
 	rs.insert(s);
   } else {
     rs = removed_snaps;
+    if (rs.contains(snapid_t(1)))
+      rs.erase(snapid_t(1));
+    if (rs.contains(snapid_t(2)))
+      rs.erase(snapid_t(2));
+    if (rs.contains(snapid_t(3)))
+      rs.erase(snapid_t(3));
   }
 }
 


### PR DESCRIPTION
When pool is self-managed, to create a new image will trigger snap-trimming by validate_pool, but these trimming operations are unnecessary and increase cpu-usage in vain.

Signed-off-by: tang.jin <tang.jin@istuary.com>