### PR TITLE
crypto: cleanup NSPR in main thread

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -21,6 +21,7 @@
 #include "common/admin_socket.h"
 #include "common/perf_counters.h"
 #include "common/Thread.h"
+#include "common/code_environment.h"
 #include "common/ceph_context.h"
 #include "common/ceph_crypto.h"
 #include "common/config.h"
@@ -659,7 +660,7 @@ CephContext::~CephContext()
   delete _crypto_none;
   delete _crypto_aes;
   if (_crypto_inited)
-    ceph::crypto::shutdown();
+    ceph::crypto::shutdown(g_code_env == CODE_ENVIRONMENT_LIBRARY);
 }
 
 void CephContext::put() {

--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -18,6 +18,7 @@
 #include "ceph_crypto.h"
 #include "auth/Crypto.h"
 
+#include <nspr.h>
 #include <pthread.h>
 #include <stdlib.h>
 
@@ -77,12 +78,15 @@ void ceph::crypto::init(CephContext *cct)
   assert(crypto_context != NULL);
 }
 
-void ceph::crypto::shutdown()
+void ceph::crypto::shutdown(bool shared)
 {
   pthread_mutex_lock(&crypto_init_mutex);
   assert(crypto_refs > 0);
   if (--crypto_refs == 0) {
     NSS_ShutdownContext(crypto_context);
+    if (!shared) {
+      PR_Cleanup();
+    }
     crypto_context = NULL;
     crypto_init_pid = 0;
   }

--- a/src/common/ceph_crypto.h
+++ b/src/common/ceph_crypto.h
@@ -23,7 +23,11 @@ namespace ceph {
   namespace crypto {
     void assert_init();
     void init(CephContext *cct);
-    void shutdown();
+    // @param shared true if the the underlying crypto library could be shared
+    //               with the application linked against the Ceph library.
+    // @note we do extra global cleanup specific to the underlying crypto
+    //       library, if @c shared is @c false.
+    void shutdown(bool shared=true);
 
     using CryptoPP::Weak::MD5;
     using CryptoPP::SHA1;
@@ -67,7 +71,7 @@ namespace ceph {
   namespace crypto {
     void assert_init();
     void init(CephContext *cct);
-    void shutdown();
+    void shutdown(bool shared=true);
     class Digest {
     private:
       PK11Context *ctx;

--- a/src/test/ceph_crypto.cc
+++ b/src/test/ceph_crypto.cc
@@ -112,7 +112,10 @@ class ForkDeathTest : public ::testing::Test {
  protected:
   void SetUp() override {
     // shutdown NSS so it can be reinitialized after the fork
-    ceph::crypto::shutdown();
+    // some data structures used by NSPR are only initialized once, and they
+    // will be cleaned up with ceph::crypto::shutdown(false), so we need to
+    // keep them around after fork.
+    ceph::crypto::shutdown(true);
   }
 
   void TearDown() override {


### PR DESCRIPTION
quote from nspr's header file

```
 * Perform a graceful shutdown of NSPR.  PR_Cleanup() may be called by
 * the primordial thread near the end of the main() function.
```

this helps to silence some warnings from valgrind. but it does not hurt
in practice, because the process is about to die. and the freed memory
chunks are only allocated once in NSPR.

Signed-off-by: Kefu Chai <kchai@redhat.com>