### PR TITLE
jewel: tests: test/librados/tmap_migrate: g_ceph_context->put() upon return

### DIFF
--- a/src/test/librados/tmap_migrate.cc
+++ b/src/test/librados/tmap_migrate.cc
@@ -2,6 +2,7 @@
 #include "include/rados/librados.hpp"
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
+#include "test/unit.h"
 #include "include/encoding.h"
 #include "tools/cephfs/DataScan.h"
 #include "global/global_init.h"
@@ -16,10 +17,6 @@ using namespace librados;
 typedef RadosTestPP TmapMigratePP;
 
 TEST_F(TmapMigratePP, DataScan) {
-  std::vector<const char *> args;
-  global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY, 0);
-  common_init_finish(g_ceph_context);
-
   // DataScan isn't namespace-aware, so override RadosTestPP's default
   // behaviour of putting everything into a namespace
   ioctx.set_namespace("");


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflict: test/librados/tmap_migrate.cc
  this change is not cherry-picked from master, because tmap_migrate was
removed in master. so we are applying the same change in
cb1cda96713b2ec0f6418c4cbe3d964c2020729c to this test.