### PR TITLE
tests: double snap trimming timeout

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1771,7 +1771,7 @@ class CephManager:
         Wait for snap trimming on pool to end
         """
         POLL_PERIOD = 10
-        FATAL_TIMEOUT = 600
+        FATAL_TIMEOUT = 1200
         start = time.time()
         poolnum = self.get_pool_num(pool)
         poolnumstr = "%s." % (poolnum,)


### PR DESCRIPTION
After recent snap trimming changes, upgrade tests have been failing
on slow machines (VPS) with "AssertionError: failed to complete snap trimming
before timeout"

Fixes: http://tracker.ceph.com/issues/19783
Signed-off-by: Nathan Cutler <ncutler@suse.com>