### PR TITLE
osd: switch filestore to default to rocksdb

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1164,7 +1164,7 @@ OPTION(kstore_onode_map_size, OPT_U64, 1024)
 OPTION(kstore_cache_tails, OPT_BOOL, true)
 OPTION(kstore_default_stripe_size, OPT_INT, 65536)
 
-OPTION(filestore_omap_backend, OPT_STR, "leveldb")
+OPTION(filestore_omap_backend, OPT_STR, "rocksdb")
 OPTION(filestore_omap_backend_path, OPT_STR, "")
 
 /// filestore wb throttle limits


### PR DESCRIPTION
This pull request aims to switch filestore to default to rocksdb instead of leveldb.

Signed-off-by: Neha Ojha <nojha@redhat.com>