### PR TITLE
tests: Don't dump core when using EXPECT_DEATH

### DIFF
--- a/src/include/coredumpctl.h
+++ b/src/include/coredumpctl.h
@@ -1,0 +1,39 @@
+#ifdef HAVE_SYS_PRCTL_H
+#include <iostream>
+#include <sys/prctl.h>
+#include "common/errno.h"
+
+struct PrCtl {
+  int saved_state = -1;
+  int set_dumpable(int new_state) {
+    int r = prctl(PR_SET_DUMPABLE, new_state);
+    if (r) {
+      r = -errno;
+      std::cerr << "warning: unable to " << (new_state ? "set" : "unset")
+                << " dumpable flag: " << cpp_strerror(r)
+                << std::endl;
+    }
+    return r;
+  }
+  PrCtl(int new_state = 0) {
+    int r = prctl(PR_GET_DUMPABLE);
+    if (r == -1) {
+      r = errno;
+      std::cerr << "warning: unable to get dumpable flag: " << cpp_strerror(r)
+                << std::endl;
+    } else if (r != new_state) {
+      if (!set_dumpable(new_state)) {
+        saved_state = r;
+      }
+    }
+  }
+  ~PrCtl() {
+    if (saved_state < 0) {
+      return;
+    }
+    set_dumpable(saved_state);
+  }
+};
+#else
+struct PrCtl {};
+#endif

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -3,6 +3,7 @@
 #include "log/Log.h"
 #include "common/Clock.h"
 #include "common/PrebufferedStreambuf.h"
+#include "include/coredumpctl.h"
 #include "SubsystemMap.h"
 
 using namespace ceph::logging;
@@ -201,7 +202,10 @@ void do_segv()
 
   log.inject_segv();
   Entry *e = new Entry(ceph_clock_now(), pthread_self(), 10, 1);
-  log.submit_entry(e);  // this should segv
+  {
+    PrCtl unset_dumpable;
+    log.submit_entry(e);  // this should segv
+  }
 
   log.flush();
   log.stop();

--- a/src/test/ceph_compatset.cc
+++ b/src/test/ceph_compatset.cc
@@ -23,6 +23,7 @@
 
 #include "include/types.h"
 #include "include/compat.h"
+#include "include/coredumpctl.h"
 
 //#undef assert
 //#define	assert(foo) if (!(foo)) abort();
@@ -37,8 +38,11 @@ TEST(CephCompatSet, AllSet) {
   CompatSet::FeatureSet ro;
   CompatSet::FeatureSet incompat;
 
-  EXPECT_DEATH(compat.insert(CompatSet::Feature(0, "test")), "");
-  EXPECT_DEATH(compat.insert(CompatSet::Feature(64, "test")), "");
+  {
+    PrCtl unset_dumpable;
+    EXPECT_DEATH(compat.insert(CompatSet::Feature(0, "test")), "");
+    EXPECT_DEATH(compat.insert(CompatSet::Feature(64, "test")), "");
+  }
 
   for (int i = 1; i < 64; i++) {
     stringstream cname;

--- a/src/test/common/test_mutex.cc
+++ b/src/test/common/test_mutex.cc
@@ -1,5 +1,5 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-// vim: ts=8 sw=2 &smarttab
+// vim: ts=8 sw=2 smarttab
 /*
  * Ceph - scalable distributed file system
  *
@@ -9,6 +9,7 @@
 #include "gtest/gtest.h"
 #include "common/ceph_context.h"
 #include "common/config.h"
+#include "include/coredumpctl.h"
 
 /*
  * Override normal ceph assert.
@@ -62,5 +63,6 @@ TEST(Mutex, RecursiveWithoutLockdep) {
 TEST(Mutex, DeleteLocked) {
   Mutex* m = new Mutex("Recursive3",false);
   m->Lock();
+  PrCtl unset_dumpable;
   EXPECT_DEATH(delete m,".*");
 }

--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -23,6 +23,7 @@
 #include <signal.h>
 #include "os/filestore/chain_xattr.h"
 #include "include/Context.h"
+#include "include/coredumpctl.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include "global/global_init.h"
@@ -120,6 +121,7 @@ TEST(chain_xattr, get_and_set) {
   {
     int x;
     const string name = user + string(CHAIN_XATTR_MAX_NAME_LEN * 2, '@');
+    PrCtl unset_dumpable;
     ASSERT_DEATH(chain_setxattr(file, name.c_str(), &x, sizeof(x)), "");
     ASSERT_DEATH(chain_fsetxattr(fd, name.c_str(), &x, sizeof(x)), "");
   }

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -36,6 +36,7 @@
 #include "common/Cond.h"
 #include "common/errno.h"
 #include "include/stringify.h"
+#include "include/coredumpctl.h"
 
 #include "include/unordered_map.h"
 #include "store_test_fixture.h"
@@ -2825,8 +2826,8 @@ TEST_P(StoreTest, SimpleCloneTest) {
     ObjectStore::Transaction t;
     t.remove_collection(cid);
     cerr << "Invalid rm coll" << std::endl;
+    PrCtl unset_dumpable;
     EXPECT_DEATH(apply_transaction(store, &osr, std::move(t)), ".*Directory not empty.*");
-
   }
   {
     ObjectStore::Transaction t;
@@ -2847,6 +2848,7 @@ TEST_P(StoreTest, SimpleCloneTest) {
     t.remove(cid, hoid);
     t.remove(cid, hoid2);
     t.remove_collection(cid);
+    PrCtl unset_dumpable;
     EXPECT_DEATH(apply_transaction(store, &osr, std::move(t)), ".*Directory not empty.*");
   }
   {

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -24,6 +24,7 @@
 #include "gtest/gtest.h"
 #include "osd/PGLog.h"
 #include "osd/OSDMap.h"
+#include "include/coredumpctl.h"
 
 class PGLogTest : public ::testing::Test, protected PGLog {
 public:
@@ -1211,6 +1212,7 @@ TEST_F(PGLogTest, merge_log) {
     olog.tail = eversion_t(1, 1);
 
     TestHandler h(remove_snap);
+    PrCtl unset_dumpable;
     ASSERT_DEATH(merge_log(oinfo, olog, fromosd, info, &h,
 			   dirty_info, dirty_big_info), "");
   }

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -19,6 +19,7 @@
 #include "osd/osd_types.h"
 #include "osd/OSDMap.h"
 #include "gtest/gtest.h"
+#include "include/coredumpctl.h"
 #include "common/Thread.h"
 #include "include/stringify.h"
 #include "osd/ReplicatedBackend.h"
@@ -882,6 +883,7 @@ TEST(pg_missing_t, add_next_event)
     EXPECT_TRUE(e.object_is_indexed());
     EXPECT_FALSE(e.reqid_is_indexed());
     EXPECT_FALSE(missing.is_missing(oid));
+    PrCtl unset_dumpable;
     EXPECT_DEATH(missing.add_next_event(e), "");
   }
 
@@ -1034,14 +1036,20 @@ TEST(pg_missing_t, got)
     hobject_t oid(object_t("objname"), "key", 123, 456, 0, "");
     pg_missing_t missing;
     // assert if the oid does not exist
-    EXPECT_DEATH(missing.got(oid, eversion_t()), "");
+    {
+      PrCtl unset_dumpable;
+      EXPECT_DEATH(missing.got(oid, eversion_t()), "");
+    }
     EXPECT_FALSE(missing.is_missing(oid));
     epoch_t epoch = 10;
     eversion_t need(epoch,10);
     missing.add(oid, need, eversion_t());
     EXPECT_TRUE(missing.is_missing(oid));
     // assert if that the version to be removed is lower than the version of the object
-    EXPECT_DEATH(missing.got(oid, eversion_t(epoch / 2,20)), "");
+    {
+      PrCtl unset_dumpable;
+      EXPECT_DEATH(missing.got(oid, eversion_t(epoch / 2,20)), "");
+    }
     // remove of a later version removes the object
     missing.got(oid, eversion_t(epoch * 2,20));
     EXPECT_FALSE(missing.is_missing(oid));
@@ -1485,6 +1493,7 @@ TEST(ghobject_t, parse) {
 
 TEST(pool_opts_t, invalid_opt) {
   EXPECT_FALSE(pool_opts_t::is_opt_name("INVALID_OPT"));
+  PrCtl unset_dumpable;
   EXPECT_DEATH(pool_opts_t::get_opt_desc("INVALID_OPT"), "");
 }
 
@@ -1496,7 +1505,10 @@ TEST(pool_opts_t, scrub_min_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::SCRUB_MIN_INTERVAL));
-  EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL), "");
+  {
+    PrCtl unset_dumpable;
+    EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL), "");
+  }
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::SCRUB_MIN_INTERVAL, &val));
   opts.set(pool_opts_t::SCRUB_MIN_INTERVAL, static_cast<double>(2015));
@@ -1514,7 +1526,10 @@ TEST(pool_opts_t, scrub_max_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::SCRUB_MAX_INTERVAL));
-  EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL), "");
+  {
+    PrCtl unset_dumpable;
+    EXPECT_DEATH(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL), "");
+  }
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::SCRUB_MAX_INTERVAL, &val));
   opts.set(pool_opts_t::SCRUB_MAX_INTERVAL, static_cast<double>(2015));
@@ -1532,7 +1547,10 @@ TEST(pool_opts_t, deep_scrub_interval) {
 
   pool_opts_t opts;
   EXPECT_FALSE(opts.is_set(pool_opts_t::DEEP_SCRUB_INTERVAL));
-  EXPECT_DEATH(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL), "");
+  {
+    PrCtl unset_dumpable;
+    EXPECT_DEATH(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL), "");
+  }
   double val;
   EXPECT_FALSE(opts.get(pool_opts_t::DEEP_SCRUB_INTERVAL, &val));
   opts.set(pool_opts_t::DEEP_SCRUB_INTERVAL, static_cast<double>(2015));

--- a/src/test/signals.cc
+++ b/src/test/signals.cc
@@ -2,6 +2,7 @@
 #include "common/signal.h"
 #include "global/signal_handler.h"
 #include "common/debug.h"
+#include "include/coredumpctl.h"
 
 #include "gtest/gtest.h"
 
@@ -118,7 +119,10 @@ TEST(SignalHandler, Multiple)
 TEST(SignalHandler, LogInternal)
 {
   g_ceph_context->_log->inject_segv();
-  ASSERT_DEATH(derr << "foo" << dendl, ".*");
+  {
+    PrCtl unset_dumpable;
+    ASSERT_DEATH(derr << "foo" << dendl, ".*");
+  }
   g_ceph_context->_log->reset_segv();
 }
 

--- a/src/test/test_texttable.cc
+++ b/src/test/test_texttable.cc
@@ -15,6 +15,7 @@
 #include "common/TextTable.h"
 #include <iostream>
 #include "gtest/gtest.h"
+#include "include/coredumpctl.h"
 
 TEST(TextTable, Alignment) {
   TextTable t;
@@ -72,5 +73,6 @@ TEST(TextTable, TooManyItems) {
   t.define_column("3", TextTable::LEFT, TextTable::LEFT);
 
   // expect assertion failure on this, which throws FailedAssertion
+  PrCtl unset_dumpable;
   ASSERT_DEATH((t << "1" << "2" << "3" << "4" << TextTable::endrow), "");
 }


### PR DESCRIPTION
Signed-off-by: Brad Hubbard <bhubbard@redhat.com>