### PR TITLE
mgr: mkdir bootstrap-mgr

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -892,6 +892,7 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/radosgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-osd
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mds
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
+mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
@@ -962,6 +963,7 @@ rm -rf %{buildroot}
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-osd
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mds
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-rgw
+%attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-mgr
 
 %post base
 /sbin/ldconfig


### PR DESCRIPTION
ceph-deploy rely on bootstrap-mgr 
as follows: https://github.com/ceph/ceph-deploy/blob/master/ceph_deploy/mgr.py#L37

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>