### PR TITLE
rgw/rgw_swift_auth.cc: using string::back() instead as the C++11 recommend

### DIFF
--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -304,7 +304,7 @@ ExternalTokenEngine::authenticate(const std::string& token,
   }
 
   std::string auth_url = g_conf->rgw_swift_auth_url;
-  if (auth_url[auth_url.length() - 1] != '/') {
+  if (auth_url.back() != '/') {
     auth_url.append("/");
   }
 


### PR DESCRIPTION
Signed-off-by: liuyuhong <liuyuhong@cmss.chinamobile.com>