### PR TITLE
librbd: minor fixes for image trash move

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1351,7 +1351,6 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     int r = ictx->state->open(true);
     if (r < 0) {
       ldout(cct, 2) << "error opening image: " << cpp_strerror(-r) << dendl;
-      delete ictx;
       if (r != -ENOENT) {
 	return r;
       }


### PR DESCRIPTION
1. do not free `ictx` a second time if the sync open failed, otherwise it will assert in perf counter code
1. do not try to move the image to trash can if the image does not exist

Signed-off-by: runsisi runsisi@zte.com.cn