### PR TITLE
ceph-disk: ceph-disk on FreeBSD should not use mpath-code

### DIFF
--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -465,6 +465,9 @@ class TestCephDisk(object):
                   main.PTYPE['regular']['journal']['ready'])
 
     def test_list_bluestore(self):
+        if platform.system() == "FreeBSD":
+            return
+
         self.list(main.PTYPE['plain']['osd']['ready'],
                   main.PTYPE['plain']['block']['ready'])
         self.list(main.PTYPE['luks']['osd']['ready'],


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>