### PR TITLE
src/msg/simple/Pipe.cc: Fix the inclusion of '}'

### DIFF
--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -953,8 +953,8 @@ void Pipe::set_socket_options()
       ldout(msgr->cct,0) << "couldn't set SO_PRIORITY to " << prio
                          << ": " << cpp_strerror(r) << dendl;
     }
-#endif
   }
+#endif
 }
 
 int Pipe::connect()


### PR DESCRIPTION
- All the includes only work for Linux, and on FreeBSD a single 
   and unmatched } is left behind.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>