### PR TITLE
qa/rgw: add cluster name to path when s3tests scans rgw log

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -381,13 +381,15 @@ def scan_for_leaked_encryption_keys(ctx, config):
         for client, client_config in config.iteritems():
             if not client_config.get('scan_for_encryption_keys', True):
                 continue
+            cluster_name, daemon_type, client_id = teuthology.split_role(client)
+            client_with_cluster = '.'.join((cluster_name, daemon_type, client_id))
             (remote,) = ctx.cluster.only(client).remotes.keys()
             proc = remote.run(
                 args=[
                     'grep',
                     '--binary-files=text',
                     s3test_customer_key,
-                    '/var/log/ceph/rgw.{client}.log'.format(client=client),
+                    '/var/log/ceph/rgw.{client}.log'.format(client=client_with_cluster),
                 ],
                 wait=False,
                 check_status=False,


### PR DESCRIPTION
when support for multiple clusters was added in https://github.com/ceph/ceph/pull/12535, the cluster name was added to the radosgw log path. update s3tests task to match

this fixes some `radosgw log is leaking encryption keys!` failures