### PR TITLE
qa/workunits/rbd: increased trash deferment period

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -408,7 +408,7 @@ test_trash() {
     rbd ls | wc -l | grep 1
     rbd ls -l | grep 'test2.*2.*'
 
-    rbd trash mv test2 --delay 10
+    rbd trash mv test2 --delay 3600
     rbd trash ls | grep test2
     rbd trash ls | wc -l | grep 1
     rbd trash ls -l | grep 'test2.*USER.*protected until'


### PR DESCRIPTION
Teuthology would periodically fail due to a delay >10 seconds
between moving the item to the trash and checking its status.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>