### PR TITLE
cmake: add "container" to required boost components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,7 +513,7 @@ endif()
 option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 
 set(BOOST_COMPONENTS
-	thread system regex random program_options date_time iostreams)
+	container thread system regex random program_options date_time iostreams)
 if(WITH_MGR)
 	list(APPEND BOOST_COMPONENTS python)
 endif()


### PR DESCRIPTION
it is used by our denc

Signed-off-by: Kefu Chai <kchai@redhat.com>