### PR TITLE
kraken: rgw: add apis to support ragweed suite

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -446,7 +446,8 @@ enum RGWOpType {
   RGW_OP_GET_INFO,
 
   /* rgw specific */
-  RGW_OP_ADMIN_SET_METADATA
+  RGW_OP_ADMIN_SET_METADATA,
+  RGW_OP_GET_OBJ_LAYOUT,
 };
 
 class RGWAccessControlPolicy;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5517,6 +5517,29 @@ void RGWSetAttrs::execute()
   }
 }
 
+void RGWGetObjLayout::pre_exec()
+{
+  rgw_bucket_object_pre_exec(s);
+}
+
+void RGWGetObjLayout::execute()
+{
+  rgw_obj obj(s->bucket, s->object.name);
+  obj.set_instance(s->object.instance);
+  target = new RGWRados::Object(store, s->bucket_info, *static_cast<RGWObjectCtx *>(s->obj_ctx), obj);
+  RGWRados::Object::Read stat_op(target);
+
+  op_ret = stat_op.prepare();
+  if (op_ret < 0) {
+    return;
+  }
+
+  head_obj = stat_op.state.obj;
+
+  op_ret = target->get_manifest(&manifest);
+}
+
+
 RGWHandler::~RGWHandler()
 {
 }

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1764,4 +1764,32 @@ public:
   virtual uint32_t op_mask() { return RGW_OP_TYPE_WRITE; }
 };
 
+class RGWGetObjLayout : public RGWOp {
+protected:
+  RGWRados::Object *target{nullptr};
+  RGWObjManifest *manifest{nullptr};
+  rgw_obj head_obj;
+
+public:
+  RGWGetObjLayout() {
+    delete target;
+  }
+
+  int check_caps(RGWUserCaps& caps) {
+    return caps.check_cap("admin", RGW_CAP_READ);
+  }
+  int verify_permission() {
+    return check_caps(s->user->caps);
+  }
+  void pre_exec();
+  void execute();
+
+  virtual void send_response() = 0;
+  virtual const string name() { return "get_obj_layout"; }
+  virtual RGWOpType get_type() { return RGW_OP_GET_OBJ_LAYOUT; }
+  virtual uint32_t op_mask() { return RGW_OP_TYPE_READ; }
+};
+
+
+
 #endif /* CEPH_RGW_OP_H */

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8644,6 +8644,19 @@ int RGWRados::get_obj_state(RGWObjectCtx *rctx, rgw_obj& obj, RGWObjState **stat
   return ret;
 }
 
+int RGWRados::Object::get_manifest(RGWObjManifest **pmanifest)
+{
+  RGWObjState *astate;
+  int r = get_state(&astate, true);
+  if (r < 0) {
+    return r;
+  }
+
+  *pmanifest = &astate->manifest;
+
+  return 0;
+}
+
 int RGWRados::Object::Read::get_attr(const char *name, bufferlist& dest)
 {
   RGWObjState *state;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2368,6 +2368,7 @@ public:
     rgw_obj& get_obj() { return obj; }
     RGWObjectCtx& get_ctx() { return ctx; }
     RGWBucketInfo& get_bucket_info() { return bucket_info; }
+    int get_manifest(RGWObjManifest **pmanifest);
 
     int get_bucket_shard(BucketShard **pbs) {
       if (!bs_initialized) {

--- a/src/rgw/rgw_rest_config.cc
+++ b/src/rgw/rgw_rest_config.cc
@@ -52,12 +52,28 @@ void RGWOp_ZoneGroupMap_Get::send_response() {
   flusher.flush();
 }
 
+void RGWOp_ZoneConfig_Get::send_response() {
+  const RGWZoneParams& zone_params = store->get_zone_params();
+
+  set_req_state_err(s, http_ret);
+  dump_errno(s);
+  end_header(s);
+
+  if (http_ret < 0)
+    return;
+
+  encode_json("zone_params", zone_params, s->formatter);
+  flusher.flush();
+}
+
 RGWOp* RGWHandler_Config::op_get() {
   bool exists;
   string type = s->info.args.get("type", &exists);
 
   if (type.compare("zonegroup-map") == 0) {
     return new RGWOp_ZoneGroupMap_Get(false);
+  } else if (type.compare("zone") == 0) {
+    return new RGWOp_ZoneConfig_Get();
   } else {
     return new RGWOp_ZoneGroupMap_Get(true);
   }

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -36,6 +36,24 @@ public:
   }
 };
 
+class RGWOp_ZoneConfig_Get : public RGWRESTOp {
+  RGWZoneParams zone_params;
+public:
+  RGWOp_ZoneConfig_Get() {}
+
+  int check_caps(RGWUserCaps& caps) {
+    return caps.check_cap("admin", RGW_CAP_READ);
+  }
+  int verify_permission() {
+    return check_caps(s->user->caps);
+  }
+  void execute() {} /* store already has the info we need, just need to send response */
+  void send_response();
+  const string name() {
+    return "get_zone_config";
+  }
+};
+
 class RGWHandler_Config : public RGWHandler_Auth_S3 {
 protected:
   RGWOp *op_get();

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2898,6 +2898,38 @@ void RGWDeleteMultiObj_ObjStore_S3::end_response()
   rgw_flush_formatter_and_reset(s, s->formatter);
 }
 
+void RGWGetObjLayout_ObjStore_S3::send_response()
+{
+  if (op_ret)
+    set_req_state_err(s, op_ret);
+  dump_errno(s);
+  end_header(s, this, "application/json");
+
+  JSONFormatter f;
+
+  if (op_ret < 0) {
+    return;
+  }
+
+  f.open_object_section("result");
+  ::encode_json("head", head_obj, &f);
+  ::encode_json("manifest", *manifest, &f);
+  f.open_array_section("data_location");
+  for (auto miter = manifest->obj_begin(); miter != manifest->obj_end(); ++miter) {
+    f.open_object_section("obj");
+    rgw_obj loc = miter.get_location();
+    ::encode_json("ofs", miter.get_ofs(), &f);
+    ::encode_json("loc", loc, &f);
+    ::encode_json("loc_ofs", miter.location_ofs(), &f);
+    ::encode_json("loc_size", miter.get_stripe_size(), &f);
+    f.close_section();
+    rgw_flush_formatter(s, &f);
+  }
+  f.close_section();
+  f.close_section();
+  rgw_flush_formatter(s, &f);
+}
+
 RGWOp *RGWHandler_REST_Service_S3::op_get()
 {
   if (is_usage_op()) {
@@ -3035,6 +3067,8 @@ RGWOp *RGWHandler_REST_Obj_S3::op_get()
     return new RGWGetACLs_ObjStore_S3;
   } else if (s->info.args.exists("uploadId")) {
     return new RGWListMultipart_ObjStore_S3;
+  } else if (s->info.args.exists("layout")) {
+    return new RGWGetObjLayout_ObjStore_S3;
   }
   return get_obj_op(true);
 }

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -398,6 +398,14 @@ public:
   void end_response();
 };
 
+class RGWGetObjLayout_ObjStore_S3 : public RGWGetObjLayout {
+public:
+  RGWGetObjLayout_ObjStore_S3() {}
+  ~RGWGetObjLayout_ObjStore_S3() {}
+
+  void send_response();
+};
+
 class RGW_Auth_S3_Keystone_ValidateToken : public RGWHTTPClient {
 private:
   bufferlist rx_buffer;


### PR DESCRIPTION
http://tracker.ceph.com/issues/19809

Add missing apis to support running ragweed against kraken.
 - rest api to retrieve object layout
 - rest api to read zone config params