### PR TITLE
rgw: rgw file use quota info as fssize

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -2054,7 +2054,7 @@ public:
     return bucket.creation_time;
   }
 
-  bool only_bucket() override { return false; }
+  bool only_bucket() override { return true; }
 
   int op_init() override {
     // assign store, s, and dialect_handler


### PR DESCRIPTION
With this one and the related commit from nfs-ganesha:
         FSAL_RGW: support rgw quota-related fs info
the df command will be able to show info of a mounted RGW-NFS(of course only with bucket quota enabled).