### PR TITLE
mon/ConfigKeyService: add 'config-key dump' to show keys and vals

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -13,7 +13,7 @@ Synopsis
 
 | **ceph** **compact**
 
-| **ceph** **config-key** [ *del* | *exists* | *get* | *list* | *put* ] ...
+| **ceph** **config-key** [ *del* | *exists* | *get* | *list* | *dump* | *put* ] ...
 
 | **ceph** **daemon** *<name>* \| *<path>* *<command>* ...
 
@@ -201,7 +201,13 @@ Usage::
 
 	ceph config-key list
 
-Subcommand ``put`` puts configuration key and values.
+Subcommand ``dump`` dumps configuration keys and values.
+
+Usage::
+
+	ceph config-key dump
+
+Subcommand ``put`` puts configuration key and value.
 
 Usage::
 

--- a/src/mon/ConfigKeyService.cc
+++ b/src/mon/ConfigKeyService.cc
@@ -83,6 +83,21 @@ void ConfigKeyService::store_list(stringstream &ss)
   f.flush(ss);
 }
 
+void ConfigKeyService::store_dump(stringstream &ss)
+{
+  KeyValueDB::Iterator iter =
+    mon->store->get_iterator(STORE_PREFIX);
+
+  JSONFormatter f(true);
+  f.open_object_section("config-key store");
+
+  while (iter->valid()) {
+    f.dump_string(iter->key().c_str(), iter->value().to_str());
+    iter->next();
+  }
+  f.close_section();
+  f.flush(ss);
+}
 
 bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
 {
@@ -185,6 +200,12 @@ bool ConfigKeyService::service_dispatch(MonOpRequestRef op)
   } else if (prefix == "config-key list") {
     stringstream tmp_ss;
     store_list(tmp_ss);
+    rdata.append(tmp_ss);
+    ret = 0;
+
+  } else if (prefix == "config-key dump") {
+    stringstream tmp_ss;
+    store_dump(tmp_ss);
     rdata.append(tmp_ss);
     ret = 0;
   }

--- a/src/mon/ConfigKeyService.h
+++ b/src/mon/ConfigKeyService.h
@@ -30,6 +30,7 @@ class ConfigKeyService : public QuorumService
   void store_put(const string &key, bufferlist &bl, Context *cb = NULL);
   void store_delete(const string &key, Context *cb = NULL);
   void store_list(stringstream &ss);
+  void store_dump(stringstream &ss);
   bool store_exists(const string &key);
 
   static const string STORE_PREFIX;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -824,6 +824,7 @@ COMMAND("config-key exists " \
 	"name=key,type=CephString", \
 	"check for <key>'s existence", "config-key", "r", "cli,rest")
 COMMAND("config-key list ", "list keys", "config-key", "r", "cli,rest")
+COMMAND("config-key dump", "dump keys and values", "config-key", "r", "cli,rest")
 
 
 /*

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -1178,6 +1178,9 @@ class TestConfigKey(TestArgparse):
     def test_exists(self):
         self.check_1_string_arg('config-key', 'exists')
 
+    def test_dump(self):
+        self.check_no_arg('config-key', 'dump')
+
     def test_list(self):
         self.check_no_arg('config-key', 'list')
 # Local Variables:


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>