### PR TITLE
librados: fix rados_pool_list when buf is null

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -649,6 +649,8 @@ CEPH_RADOS_API int rados_wait_for_latest_osdmap(rados_t cluster);
  * If len is too short to fit all the pool name entries we need, we will fill
  * as much as we can.
  *
+ * Buf may be null to determine the buffer size needed to list all pools.
+ *
  * @param cluster cluster handle
  * @param buf output buffer
  * @param len output buffer length

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1224,9 +1224,11 @@ extern "C" int ceph_get_osd_crush_location(struct ceph_mount_info *cmount,
     string& name = it->second;
     needed += type.size() + name.size() + 2;
     if (needed <= len) {
-      strcpy(path + cur, type.c_str());
+      if (path)
+	strcpy(path + cur, type.c_str());
       cur += type.size() + 1;
-      strcpy(path + cur, name.c_str());
+      if (path)
+	strcpy(path + cur, name.c_str());
       cur += name.size() + 1;
     }
   }

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -3068,10 +3068,12 @@ extern "C" int rados_pool_list(rados_t cluster, char *buf, size_t len)
       break;
     const char* pool = i->second.c_str();
     tracepoint(librados, rados_pool_list_pool, pool);
-    strncat(b, pool, rl);
+    if (b) {
+      strncat(b, pool, rl);
+      b += rl;
+    }
     needed += rl;
     len -= rl;
-    b += rl;
   }
   for (; i != p_end; ++i) {
     int rl = i->second.length() + 1;

--- a/src/test/librados/pool.cc
+++ b/src/test/librados/pool.cc
@@ -15,6 +15,9 @@ TEST(LibRadosPools, PoolList) {
   ASSERT_EQ("", create_one_pool(pool_name, &cluster));
   ASSERT_LT(rados_pool_list(cluster, buf, POOL_LIST_BUF_SZ), POOL_LIST_BUF_SZ);
 
+  // we can pass a null buffer too.
+  ASSERT_LT(rados_pool_list(cluster, NULL, POOL_LIST_BUF_SZ), POOL_LIST_BUF_SZ);
+
   bool found_pool = false;
   while (buf[0] != '\0') {
     if ((found_pool == false) && (strcmp(buf, pool_name.c_str()) == 0)) {


### PR DESCRIPTION
This was the original intent, but buf==NULL wasn't documented
and only half-way implemented.

Signed-off-by: Sage Weil <sage@redhat.com>