### PR TITLE
librbd: if child image is in trash bin do not error out when listing children

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -679,11 +679,26 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
       for (auto &id_it : info.second) {
 	string name;
 	r = cls_client::dir_get_name(&ioctx, RBD_DIRECTORY, id_it, &name);
-	if (r < 0) {
-	  lderr(cct) << "Error looking up name for image id " << id_it
-		     << " in pool " << info.first.second << dendl;
-	  return r;
+	if (r < 0 && r != -ENOENT) {
+          lderr(cct) << "Error looking up name for image id " << id_it
+                     << " in pool " << info.first.second << dendl;
+          return r;
+        } else if (r == -ENOENT) {
+          cls::rbd::TrashImageSpec trash_spec;
+          r = cls_client::trash_get(&ioctx, id_it, &trash_spec);
+          if (r < 0) {
+            if (r != -EOPNOTSUPP && r != -ENOENT) {
+              lderr(cct) << "Error looking up name for image id " << id_it
+                         << " in rbd trash" << dendl;
+              return r;
+            }
+            return -ENOENT;
+          }
+
+          // the child image is in trash bin
+          continue;
 	}
+
 	names.insert(make_pair(info.first.second, name));
       }
     }


### PR DESCRIPTION
if any child image has been moved to trash bin, do not report error when listing the children
```
# rbd create i1 -s 1G 
# rbd snap create i1@s1 && rbd snap protect i1@s1
# rbd clone i1@s1 c1
# rbd trash mv c1
# rbd children i1@s1
rbd: listing children failed: (2) No such file or directory
2017-04-28 15:43:42.403353 7f2685edb900 -1 librbd: Error looking up name for image id 1037238e1f29 in pool rbd
# echo $?
2
```

Signed-off-by: runsisi <runsisi@zte.com.cn>