### PR TITLE
mon: when create pool use ruleset_name is more clearly than ruleset

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -687,7 +687,7 @@ COMMAND("osd pool create " \
 	"name=pgp_num,type=CephInt,range=0,req=false " \
         "name=pool_type,type=CephChoices,strings=replicated|erasure,req=false " \
 	"name=erasure_code_profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.] " \
-	"name=ruleset,type=CephString,req=false " \
+	"name=ruleset_name,type=CephString,req=false " \
         "name=expected_num_objects,type=CephInt,req=false", \
 	"create pool", "osd", "rw", "cli,rest")
 COMMAND("osd pool delete " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7893,7 +7893,7 @@ done:
 
     bool implicit_ruleset_creation = false;
     string ruleset_name;
-    cmd_getval(g_ceph_context, cmdmap, "ruleset", ruleset_name);
+    cmd_getval(g_ceph_context, cmdmap, "ruleset_name", ruleset_name);
     string erasure_code_profile;
     cmd_getval(g_ceph_context, cmdmap, "erasure_code_profile", erasure_code_profile);
 


### PR DESCRIPTION
mon: when create pool use ruleset_name is more clearly than ruleset

the ruleset always make user conflict that is the ruleset_num , but it is the ruleset_name when 

create pool.

Signed-off-by: song baisen <song.baisen@zte.com.cn>