### PR TITLE
cmake: fix the linked lib reference of unittest_rgw_crypto

### DIFF
--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -99,9 +99,8 @@ target_link_libraries(unittest_rgw_crypto
   cls_user_client
   librados
   global
-  curl
-  uuid
-  expat
+  ${CURL_LIBRARIES}
+  ${EXPAT_LIBRARIES}
   ${CMAKE_DL_LIBS}
   ${UNITTEST_LIBS}
   ${CRYPTO_LIBS}


### PR DESCRIPTION
- And while there also fix direct hard curl and expat usuage

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>