### PR TITLE
build/ops: rpm: gperftools-devel >= 2.4

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -103,7 +103,7 @@ BuildRequires:	fuse-devel
 BuildRequires:	gcc-c++
 BuildRequires:	gdbm
 %if 0%{with tcmalloc}
-BuildRequires:	gperftools-devel
+BuildRequires:	gperftools-devel >= 2.4
 %endif
 BuildRequires:  jq
 BuildRequires:	leveldb-devel > 1.2


### PR DESCRIPTION
There be dragons in older versions . . .

References: http://tracker.ceph.com/issues/13522
Signed-off-by: Nathan Cutler <ncutler@suse.com>