### PR TITLE
selinux: Do parallel relabel on package install

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -949,6 +949,7 @@ rm -rf %{buildroot}
 %{_bindir}/ceph-detect-init
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
 %{_sbindir}/ceph-create-keys
+%{_sbindir}/ceph-disk
 %{_sbindir}/rcceph
 %dir %{_libexecdir}/ceph
 %{_libexecdir}/ceph/ceph_common.sh
@@ -976,12 +977,14 @@ rm -rf %{buildroot}
 %config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-mon
 %config %{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/ceph-osd-mds
 %endif
+%{_unitdir}/ceph-disk@.service
 %{_unitdir}/ceph.target
 %{python_sitelib}/ceph_detect_init*
 %{python_sitelib}/ceph_disk*
 %{_mandir}/man8/ceph-deploy.8*
 %{_mandir}/man8/ceph-detect-init.8*
 %{_mandir}/man8/ceph-create-keys.8*
+%{_mandir}/man8/ceph-disk.8*
 %{_mandir}/man8/ceph-run.8*
 %{_mandir}/man8/crushtool.8*
 %{_mandir}/man8/osdmaptool.8*
@@ -998,11 +1001,11 @@ rm -rf %{buildroot}
 %if 0%{?suse_version}
 %fillup_only
 if [ $1 -eq 1 ] ; then
-  /usr/bin/systemctl preset ceph.target >/dev/null 2>&1 || :
+  /usr/bin/systemctl preset ceph-disk@\*.service ceph.target >/dev/null 2>&1 || :
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_post ceph.target
+%systemd_post ceph-disk@\*.service ceph.target
 %endif
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph.target >/dev/null 2>&1 || :
@@ -1010,21 +1013,32 @@ fi
 
 %preun base
 %if 0%{?suse_version}
-%service_del_preun ceph.target
+%service_del_preun ceph-disk@\*.service ceph.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_preun ceph.target
+%systemd_preun ceph-disk@\*.service ceph.target
 %endif
 
 %postun base
 /sbin/ldconfig
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph.target
+%service_del_postun ceph-disk@\*.service ceph.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_postun ceph.target
+%systemd_postun ceph-disk@\*.service ceph.target
 %endif
+if [ $FIRST_ARG -ge 1 ] ; then
+  # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
+  # "yes". In any case: if units are not running, do not touch them.
+  SYSCONF_CEPH=%{_sysconfdir}/sysconfig/ceph
+  if [ -f $SYSCONF_CEPH -a -r $SYSCONF_CEPH ] ; then
+    source $SYSCONF_CEPH
+  fi
+  if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
+    /usr/bin/systemctl try-restart ceph-disk@\*.service > /dev/null 2>&1 || :
+  fi
+fi
 
 %files common
 %defattr(-,root,root,-)
@@ -1397,30 +1411,27 @@ fi
 %{_bindir}/ceph-bluestore-tool
 %{_bindir}/ceph-objectstore-tool
 %{_bindir}/ceph-osd
-%{_sbindir}/ceph-disk
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_udevrulesdir}
 %{_udevrulesdir}/60-ceph-by-parttypeuuid.rules
 %{_udevrulesdir}/95-ceph-osd.rules
 %{_mandir}/man8/ceph-clsinfo.8*
-%{_mandir}/man8/ceph-disk.8*
 %{_mandir}/man8/ceph-osd.8*
 %if 0%{?rhel} && ! 0%{?centos}
 %attr(0755,-,-) %{_sysconfdir}/cron.hourly/subman
 %endif
 %{_unitdir}/ceph-osd@.service
 %{_unitdir}/ceph-osd.target
-%{_unitdir}/ceph-disk@.service
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/osd
 
 %post osd
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
-  /usr/bin/systemctl preset ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target >/dev/null 2>&1 || :
+  /usr/bin/systemctl preset ceph-osd@\*.service ceph-osd.target >/dev/null 2>&1 || :
 fi
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_post ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target
+%systemd_post ceph-osd@\*.service ceph-osd.target
 %endif
 if [ $1 -eq 1 ] ; then
 /usr/bin/systemctl start ceph-osd.target >/dev/null 2>&1 || :
@@ -1428,20 +1439,20 @@ fi
 
 %preun osd
 %if 0%{?suse_version}
-%service_del_preun ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target
+%service_del_preun ceph-osd@\*.service ceph-osd.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_preun ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target
+%systemd_preun ceph-osd@\*.service ceph-osd.target
 %endif
 
 %postun osd
 test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
-%service_del_postun ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target
+%service_del_postun ceph-osd@\*.service ceph-osd.target
 %endif
 %if 0%{?fedora} || 0%{?rhel}
-%systemd_postun ceph-disk@\*.service ceph-osd@\*.service ceph-osd.target
+%systemd_postun ceph-osd@\*.service ceph-osd.target
 %endif
 if [ $FIRST_ARG -ge 1 ] ; then
   # Restart on upgrade, but only if "CEPH_AUTO_RESTART_ON_UPGRADE" is set to
@@ -1451,7 +1462,7 @@ if [ $FIRST_ARG -ge 1 ] ; then
     source $SYSCONF_CEPH
   fi
   if [ "X$CEPH_AUTO_RESTART_ON_UPGRADE" = "Xyes" ] ; then
-    /usr/bin/systemctl try-restart ceph-disk@\*.service ceph-osd@\*.service > /dev/null 2>&1 || :
+    /usr/bin/systemctl try-restart ceph-osd@\*.service > /dev/null 2>&1 || :
   fi
 fi
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1719,8 +1719,14 @@ if test $STATUS -eq 0; then
     /usr/bin/systemctl stop ceph.target > /dev/null 2>&1
 fi
 
-# Now, relabel the files
-/usr/sbin/fixfiles -C ${FILE_CONTEXT}.pre restore 2> /dev/null
+# Relabel the files
+# Use ceph-disk fix for first package install and fixfiles otherwise
+if [ "$1" = "1" ]; then
+    /usr/sbin/ceph-disk fix --selinux
+else
+    /usr/sbin/fixfiles -C ${FILE_CONTEXT}.pre restore 2> /dev/null
+fi
+
 rm -f ${FILE_CONTEXT}.pre
 # The fixfiles command won't fix label for /var/run/ceph
 /usr/sbin/restorecon -R /var/run/ceph > /dev/null 2>&1

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4830,9 +4830,14 @@ def main_trigger(args):
 def main_fix(args):
     # A hash table containing 'path': ('uid', 'gid', blocking, recursive)
     fix_table = [
+        ('/usr/bin/ceph-mon', 'ceph', 'ceph', True, False),
+        ('/usr/bin/ceph-mds', 'ceph', 'ceph', True, False),
+        ('/usr/bin/ceph-osd', 'ceph', 'ceph', True, False),
+        ('/usr/bin/radosgw', 'ceph', 'ceph', True, False),
         ('/etc/ceph', 'ceph', 'ceph', True, True),
         ('/var/run/ceph', 'ceph', 'ceph', True, True),
         ('/var/log/ceph', 'ceph', 'ceph', True, True),
+        ('/var/log/radosgw', 'ceph', 'ceph', True, True),
         ('/var/lib/ceph', 'ceph', 'ceph', True, False),
     ]
 

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4830,11 +4830,11 @@ def main_trigger(args):
 def main_fix(args):
     # A hash table containing 'path': ('uid', 'gid', blocking, recursive)
     fix_table = [
-        ('/usr/bin/ceph-mon', 'ceph', 'ceph', True, False),
-        ('/usr/bin/ceph-mds', 'ceph', 'ceph', True, False),
-        ('/usr/bin/ceph-osd', 'ceph', 'ceph', True, False),
-        ('/usr/bin/radosgw', 'ceph', 'ceph', True, False),
-        ('/etc/ceph', 'ceph', 'ceph', True, True),
+        ('/usr/bin/ceph-mon', 'root', 'root', True, False),
+        ('/usr/bin/ceph-mds', 'root', 'root', True, False),
+        ('/usr/bin/ceph-osd', 'root', 'root', True, False),
+        ('/usr/bin/radosgw', 'root', 'root', True, False),
+        ('/etc/ceph', 'root', 'root', True, True),
         ('/var/run/ceph', 'ceph', 'ceph', True, True),
         ('/var/log/ceph', 'ceph', 'ceph', True, True),
         ('/var/log/radosgw', 'ceph', 'ceph', True, True),
@@ -4892,6 +4892,10 @@ def main_fix(args):
     # Use find to relabel + chown ~simultaenously
     if args.all:
         for directory, uid, gid, blocking, recursive in fix_table:
+            # Skip directories/files that are not installed
+            if not os.access(directory, os.F_OK):
+                continue
+
             c = [
                 'find',
                 directory,
@@ -4931,6 +4935,10 @@ def main_fix(args):
     # Fix permissions
     if args.permissions:
         for directory, uid, gid, blocking, recursive in fix_table:
+            # Skip directories/files that are not installed
+            if not os.access(directory, os.F_OK):
+                continue
+
             if recursive:
                 c = [
                     'chown',
@@ -4966,6 +4974,10 @@ def main_fix(args):
     # Fix SELinux labels
     if args.selinux:
         for directory, uid, gid, blocking, recursive in fix_table:
+            # Skip directories/files that are not installed
+            if not os.access(directory, os.F_OK):
+                continue
+
             if recursive:
                 c = [
                     'restorecon',

--- a/src/ceph-disk/tests/test_main.py
+++ b/src/ceph-disk/tests/test_main.py
@@ -1328,11 +1328,19 @@ class TestCephDiskDeactivateAndDestroy(unittest.TestCase):
             commands.append(" ".join(x))
             return ("", "", None)
 
+        class Os(object):
+            F_OK = 0
+
+            @staticmethod
+            def access(x, y):
+                return True
+
         with patch.multiple(
             main,
             command=_command,
             command_init=lambda x: commands.append(x),
             command_wait=lambda x: None,
+            os=Os,
         ):
             main.main_fix(args)
             commands = " ".join(commands)


### PR DESCRIPTION
We can take advantage of ceph-disk fix subcommand when doing a package
install. We will keep using the differential fixfiles command otherwise.

We also need to add relabel for /usr/bin/ daemons so that we could use
this.

Signed-off-by: Boris Ranto <branto@redhat.com>

This should help when we are upgrading from a non-SELinux enabled ceph version to a SELinux enabled ceph version since we will be doing relabel in parallel per OSD.