### PR TITLE
DNM osd: simplify ShardedOpWQ locking

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9646,8 +9646,8 @@ void OSD::ShardedOpWQ::_enqueue(pair<spg_t, PGQueueable> item) {
   assert (NULL != sdata);
   unsigned priority = item.second.get_priority();
   unsigned cost = item.second.get_cost();
-  sdata->sdata_lock.Lock();
 
+  Mutex::Locker l(sdata->sdata_lock);
   dout(20) << __func__ << " " << item.first << " " << item.second << dendl;
   if (priority >= osd->op_prio_cutoff)
     sdata->pqueue->enqueue_strict(
@@ -9657,7 +9657,6 @@ void OSD::ShardedOpWQ::_enqueue(pair<spg_t, PGQueueable> item) {
       item.second.get_owner(),
       priority, cost, item);
   sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
 }
 
 void OSD::ShardedOpWQ::_enqueue_front(pair<spg_t, PGQueueable> item)
@@ -9665,7 +9664,7 @@ void OSD::ShardedOpWQ::_enqueue_front(pair<spg_t, PGQueueable> item)
   uint32_t shard_index = item.first.hash_to_shard(shard_list.size());
   ShardData* sdata = shard_list[shard_index];
   assert (NULL != sdata);
-  sdata->sdata_lock.Lock();
+  Mutex::Locker l(sdata->sdata_lock);
   auto p = sdata->pg_slots.find(item.first);
   if (p != sdata->pg_slots.end() && !p->second.to_process.empty()) {
     // we may be racing with _process, which has dequeued a new item
@@ -9683,7 +9682,6 @@ void OSD::ShardedOpWQ::_enqueue_front(pair<spg_t, PGQueueable> item)
   }
   sdata->_enqueue_front(item, osd->op_prio_cutoff);
   sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
 }
 
 namespace ceph { 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9347,7 +9347,6 @@ void OSD::ShardedOpWQ::wake_pg_waiters(spg_t pgid)
 {
   uint32_t shard_index = pgid.hash_to_shard(shard_list.size());
   auto sdata = shard_list[shard_index];
-  bool queued = false;
   unsigned pushes_to_free = 0;
   {
     Mutex::Locker l(sdata->sdata_op_ordering_lock);
@@ -9367,16 +9366,11 @@ void OSD::ShardedOpWQ::wake_pg_waiters(spg_t pgid)
       p->second.to_process.clear();
       p->second.waiting_for_pg = false;
       ++p->second.requeue_seq;
-      queued = true;
+      sdata->sdata_cond.SignalOne();
     }
   }
   if (pushes_to_free > 0) {
     osd->service.release_reserved_pushes(pushes_to_free);
-  }
-  if (queued) {
-    sdata->sdata_lock.Lock();
-    sdata->sdata_cond.SignalOne();
-    sdata->sdata_lock.Unlock();
   }
 }
 
@@ -9461,14 +9455,10 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   if (sdata->pqueue->empty()) {
     dout(20) << __func__ << " empty q, waiting" << dendl;
     // optimistically sleep a moment; maybe another work item will come along.
-    sdata->sdata_op_ordering_lock.Unlock();
     osd->cct->get_heartbeat_map()->reset_timeout(hb,
       osd->cct->_conf->threadpool_default_timeout, 0);
-    sdata->sdata_lock.Lock();
-    sdata->sdata_cond.WaitInterval(sdata->sdata_lock,
+    sdata->sdata_cond.WaitInterval(sdata->sdata_op_ordering_lock,
       utime_t(osd->cct->_conf->threadpool_empty_queue_max_wait, 0));
-    sdata->sdata_lock.Unlock();
-    sdata->sdata_op_ordering_lock.Lock();
     if (sdata->pqueue->empty()) {
       sdata->sdata_op_ordering_lock.Unlock();
       return;
@@ -9666,12 +9656,8 @@ void OSD::ShardedOpWQ::_enqueue(pair<spg_t, PGQueueable> item) {
     sdata->pqueue->enqueue(
       item.second.get_owner(),
       priority, cost, item);
-  sdata->sdata_op_ordering_lock.Unlock();
-
-  sdata->sdata_lock.Lock();
   sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
-
+  sdata->sdata_op_ordering_lock.Unlock();
 }
 
 void OSD::ShardedOpWQ::_enqueue_front(pair<spg_t, PGQueueable> item)
@@ -9696,10 +9682,8 @@ void OSD::ShardedOpWQ::_enqueue_front(pair<spg_t, PGQueueable> item)
     dout(20) << __func__ << " " << item.first << " " << item.second << dendl;
   }
   sdata->_enqueue_front(item, osd->op_prio_cutoff);
-  sdata->sdata_op_ordering_lock.Unlock();
-  sdata->sdata_lock.Lock();
   sdata->sdata_cond.SignalOne();
-  sdata->sdata_lock.Unlock();
+  sdata->sdata_op_ordering_lock.Unlock();
 }
 
 namespace ceph { 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1717,7 +1717,6 @@ private:
     : public ShardedThreadPool::ShardedWQ<pair<spg_t,PGQueueable>>
   {
     struct ShardData {
-      Mutex sdata_lock;
       Cond sdata_cond;
 
       Mutex sdata_op_ordering_lock;   ///< protects all members below
@@ -1762,8 +1761,7 @@ private:
 	string lock_name, string ordering_lock,
 	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct,
 	io_queue opqueue)
-	: sdata_lock(lock_name.c_str(), false, true, false, cct),
-	  sdata_op_ordering_lock(ordering_lock.c_str(), false, true,
+	: sdata_op_ordering_lock(ordering_lock.c_str(), false, true,
 				 false, cct) {
 	if (opqueue == weightedpriority) {
 	  pqueue = std::unique_ptr
@@ -1837,9 +1835,9 @@ private:
       for(uint32_t i = 0; i < num_shards; i++) {
 	ShardData* sdata = shard_list[i];
 	assert (NULL != sdata); 
-	sdata->sdata_lock.Lock();
+	sdata->sdata_op_ordering_lock.Lock();
 	sdata->sdata_cond.Signal();
-	sdata->sdata_lock.Unlock();
+	sdata->sdata_op_ordering_lock.Unlock();
       }
     }
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1761,7 +1761,7 @@ private:
 	string lock_name, string ordering_lock,
 	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct,
 	io_queue opqueue)
-	: sdata_lock(ordering_lock.c_str(), false, true, false, cct) {
+	: sdata_lock(ordering_lock, false, true, false, cct) {
 	if (opqueue == weightedpriority) {
 	  pqueue = std::unique_ptr
 	    <WeightedPriorityQueue<pair<spg_t,PGQueueable>,entity_inst_t>>(
@@ -1834,9 +1834,8 @@ private:
       for(uint32_t i = 0; i < num_shards; i++) {
 	ShardData* sdata = shard_list[i];
 	assert (NULL != sdata); 
-	sdata->sdata_lock.Lock();
+	Mutex::Locker l(sdata->sdata_lock);
 	sdata->sdata_cond.Signal();
-	sdata->sdata_lock.Unlock();
       }
     }
 
@@ -1846,11 +1845,10 @@ private:
 	char lock_name[32] = {0};
 	snprintf(lock_name, sizeof(lock_name), "%s%d", "OSD:ShardedOpWQ:", i);
 	assert (NULL != sdata);
-	sdata->sdata_lock.Lock();
+	Mutex::Locker l(sdata->sdata_lock);
 	f->open_object_section(lock_name);
 	sdata->pqueue->dump(f);
 	f->close_section();
-	sdata->sdata_lock.Unlock();
       }
     }
 


### PR DESCRIPTION
sdata_lock serves no real purpose; all users just dropped the sdata_op_ordering_lock a moment before.  I assume this is some artifact of the earlier implementation.

Fix by signaling the cond under the other lock before we release it, and eliminate sdata_lock entirely.

Pretty sure this is just vestigal from the original sharded implementation; I didn't look at this lock at all when I did the recent refactor, but given the state of things now it doesn't seem to serve any purpose.