### PR TITLE
cls/log/cls_log.cc: reduce logging noise

### DIFF
--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -126,7 +126,7 @@ static int cls_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
       index = entry.id;
     }
 
-    CLS_LOG(0, "storing entry at %s", index.c_str());
+    CLS_LOG(20, "storing entry at %s", index.c_str());
 
 
     if (index > header.max_marker)


### PR DESCRIPTION
- The other reference in the source as already at 20.
      ./src/cls/timeindex/cls_timeindex.cc:85:
	CLS_LOG(20, "storing entry at %s", index.c_str());

   And we need not always know where in the log items are stored.
   So it looks like a leftover debug feature.

Fixes: http://tracker.ceph.com/issues/19835
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>