### PR TITLE
cmake: enable crosscompilation of boost 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,24 @@ else()
   endif()
   list(APPEND b2
     variant=release link=static threading=multi cxxflags=${BOOST_CFLAGS})
+  if(NOT CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL CMAKE_SYSTEM_PROCESSOR)
+    # we are crosscompiling
+    if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)
+      set(b2_cc gcc)
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL Clang)
+      set(b2_cc clang)
+    else()
+      message(SEND_ERROR "unknown compiler: ${CMAKE_CXX_COMPILER_ID}")
+    endif()
+    # edit the config.jam so, b2 will be able to use the specified toolset
+    execute_process(
+      COMMAND
+      sed -i
+      "s|using ${b2_cc} ;|using ${b2_cc} : ${CMAKE_SYSTEM_PROCESSOR} : ${CMAKE_CXX_COMPILER} ;|"
+      ${PROJECT_SOURCE_DIR}/src/boost/project-config.jam)
+    # use ${CMAKE_SYSTEM_PROCESSOR} as the version identifier of compiler
+    list(APPEND b2 toolset=${b2_cc}-${CMAKE_SYSTEM_PROCESSOR})
+  endif()
   # 2. install headers
   execute_process(COMMAND
     ${b2}

--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -6,8 +6,10 @@ set(ZSTD_C_FLAGS -fPIC -Wno-unused-variable -O3)
 include(ExternalProject)
 ExternalProject_Add(zstd_ext
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/zstd/build/cmake
-  CMAKE_ARGS -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
+  CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER}
+             -DCMAKE_C_COMPILER=${CMAKE_C_COMPILER}
              -DCMAKE_C_FLAGS=${ZSTD_C_FLAGS}
+             -DCMAKE_AR=${CMAKE_AR}
   BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR}/libzstd
   BUILD_COMMAND $(MAKE) libzstd_static
   INSTALL_COMMAND "true")


### PR DESCRIPTION
and various changes for enabling cross-compiling on armhf.

see also: http://tracker.ceph.com/issues/18938

i guess downstream maintainers would be happier at seeing this.