### PR TITLE
test: c_read_operations.cc: silence warning from -Wsign-compare

### DIFF
--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -11,7 +11,7 @@
 
 const char *data = "testdata";
 const char *obj = "testobj";
-const int len = strlen(data);
+const size_t len = strlen(data);
 
 class CReadOpsTest : public RadosTest {
 protected:
@@ -283,7 +283,7 @@ TEST_F(CReadOpsTest, Read) {
     size_t bytes_read = 0;
     rados_read_op_read(op, 0, len, buf, &bytes_read, NULL);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
-    ASSERT_EQ(len, (int)bytes_read);
+    ASSERT_EQ(len, bytes_read);
     ASSERT_EQ(0, memcmp(data, buf, len));
     rados_release_read_op(op);
   }
@@ -294,7 +294,7 @@ TEST_F(CReadOpsTest, Read) {
     int rval;
     rados_read_op_read(op, 0, len, buf, &bytes_read, &rval);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
-    ASSERT_EQ(len, (int)bytes_read);
+    ASSERT_EQ(len, bytes_read);
     ASSERT_EQ(0, rval);
     ASSERT_EQ(0, memcmp(data, buf, len));
     rados_release_read_op(op);
@@ -307,7 +307,7 @@ TEST_F(CReadOpsTest, Read) {
     rados_read_op_read(op, 0, len, buf, &bytes_read, &rval);
     rados_read_op_set_flags(op, LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
-    ASSERT_EQ(len, (int)bytes_read);
+    ASSERT_EQ(len, bytes_read);
     ASSERT_EQ(0, rval);
     ASSERT_EQ(0, memcmp(data, buf, len));
     rados_release_read_op(op);
@@ -394,7 +394,7 @@ TEST_F(CReadOpsTest, RWOrderedRead) {
   rados_read_op_set_flags(op, LIBRADOS_OP_FLAG_FADVISE_DONTNEED);
   ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj,
 				     LIBRADOS_OPERATION_ORDER_READS_WRITES));
-  ASSERT_EQ(len, (int)bytes_read);
+  ASSERT_EQ(len, bytes_read);
   ASSERT_EQ(0, rval);
   ASSERT_EQ(0, memcmp(data, buf, len));
   rados_release_read_op(op);
@@ -431,7 +431,7 @@ TEST_F(CReadOpsTest, ShortRead) {
     size_t bytes_read = 0;
     rados_read_op_read(op, 0, len * 2, buf, &bytes_read, NULL);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
-    ASSERT_EQ(len, (int)bytes_read);
+    ASSERT_EQ(len, bytes_read);
     ASSERT_EQ(0, memcmp(data, buf, len));
     rados_release_read_op(op);
   }
@@ -442,7 +442,7 @@ TEST_F(CReadOpsTest, ShortRead) {
     int rval;
     rados_read_op_read(op, 0, len * 2, buf, &bytes_read, &rval);
     ASSERT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
-    ASSERT_EQ(len, (int)bytes_read);
+    ASSERT_EQ(len, bytes_read);
     ASSERT_EQ(0, rval);
     ASSERT_EQ(0, memcmp(data, buf, len));
     rados_release_read_op(op);
@@ -527,7 +527,7 @@ TEST_F(CReadOpsTest, Stat) {
   rados_read_op_stat(op, &size, NULL, &rval);
   EXPECT_EQ(0, rados_read_op_operate(op, ioctx, obj, 0));
   EXPECT_EQ(0, rval);
-  EXPECT_EQ(len, (int)size);
+  EXPECT_EQ(len, size);
   rados_release_read_op(op);
 
   op = rados_create_read_op();


### PR DESCRIPTION
The following warning appears during make:
```
In file included from ceph/src/test/librados/TestCase.h:9:0,
                 from ceph/src/test/librados/c_read_operations.cc:10:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]’:
ceph/src/googletest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int; bool lhs_is_null_literal = false]’
ceph/src/test/librados/c_read_operations.cc:685:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>