### PR TITLE
test: c_write_operations.cc: silence warning from -Wsign-compare

### DIFF
--- a/src/test/librados/c_write_operations.cc
+++ b/src/test/librados/c_write_operations.cc
@@ -243,7 +243,7 @@ TEST(LibRadosCWriteOps, CmpExt) {
   ASSERT_EQ(0, rados_write_op_operate(op, ioctx, "test", NULL, 0));
   rados_release_write_op(op);
   char hi[4];
-  ASSERT_EQ(sizeof(hi), rados_read(ioctx, "test", hi, sizeof(hi), 0));
+  ASSERT_EQ(sizeof(hi), static_cast<std::size_t>(rados_read(ioctx, "test", hi, sizeof(hi), 0)));
   ASSERT_EQ(0, memcmp("four", hi, sizeof(hi)));
 
   // compare and overwrite on (expected) match
@@ -255,7 +255,7 @@ TEST(LibRadosCWriteOps, CmpExt) {
   ASSERT_EQ(0, rados_write_op_operate(op, ioctx, "test", NULL, 0));
   ASSERT_EQ(0, val);
   rados_release_write_op(op);
-  ASSERT_EQ(sizeof(hi), rados_read(ioctx, "test", hi, sizeof(hi), 0));
+  ASSERT_EQ(sizeof(hi), static_cast<std::size_t>(rados_read(ioctx, "test", hi, sizeof(hi), 0)));
   ASSERT_EQ(0, memcmp("five", hi, sizeof(hi)));
 
   // compare and bail before write due to mismatch


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
ceph/src/googletest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
ceph/src/test/librados/c_write_operations.cc:246:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>