### PR TITLE
kv: move 'bluestore-kv' hackery out of KeyValueDB into ceph-kvstore-tool

### DIFF
--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -12,9 +12,6 @@
 #ifdef HAVE_KINETIC
 #include "KineticStore.h"
 #endif
-#ifdef HAVE_LIBAIO
-#include "os/bluestore/BlueStore.h"
-#endif
 
 KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
@@ -37,18 +34,6 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
   }
 #endif
 
-#ifdef HAVE_LIBAIO
-  if (type == "bluestore-kv") {
-    // note: we'll leak this!  the only user is ceph-kvstore-tool and
-    // we don't care.
-    BlueStore *bluestore = new BlueStore(cct, dir);
-    KeyValueDB *db = nullptr;
-    int r = bluestore->start_kv_only(&db);
-    if (r < 0)
-      return nullptr;  // yes, we leak.
-    return db;
-  }
-#endif
   if ((type == "memdb") && 
     cct->check_experimental_feature_enabled("memdb")) {
     return new MemDB(cct, dir, p);

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4130,7 +4130,7 @@ bool BlueStore::test_mount_in_use()
   return ret;
 }
 
-int BlueStore::_open_db(bool create, bool kv_no_open)
+int BlueStore::_open_db(bool create)
 {
   int r;
   assert(!db);
@@ -4369,9 +4369,6 @@ int BlueStore::_open_db(bool create, bool kv_no_open)
   if (kv_backend == "rocksdb")
     options = cct->_conf->bluestore_rocksdb_options;
   db->init(options);
-  if (kv_no_open) {
-    return 0;
-  }
   if (create)
     r = db->create_and_open(err);
   else
@@ -4968,7 +4965,7 @@ int BlueStore::_mount(bool kv_only)
   if (r < 0)
     goto out_fsid;
 
-  r = _open_db(false, kv_only);
+  r = _open_db(false);
   if (r < 0)
     goto out_bdev;
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1906,7 +1906,7 @@ private:
 
   int _open_bdev(bool create);
   void _close_bdev();
-  int _open_db(bool create, bool kv_no_open=false);
+  int _open_db(bool create);
   void _close_db();
   int _open_fm(bool create);
   void _close_fm();


### PR DESCRIPTION
This avoids contaminating libkv with ObjectStore/BlueStore.  It also makes
the blustore kv startup slightly less weird (no need to skip the open
step).

Fixes: http://tracker.ceph.com/issues/19778
Signed-off-by: Sage Weil <sage@redhat.com>