### PR TITLE
osd: stop MgrClient callbacks on shutdown

### DIFF
--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -95,6 +95,7 @@ public:
 
   void set_pgstats_cb(std::function<MPGStats*()> cb_)
   {
+    Mutex::Locker l(lock);
     pgstats_cb = cb_;
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2947,6 +2947,8 @@ int OSD::shutdown()
   cct->_conf->set_val("debug_ms", "100");
   cct->_conf->apply_changes(NULL);
 
+  mgrc.set_pgstats_cb(std::function<MPGStats*()>());
+
   service.start_shutdown();
 
   // stop sending work to pgs.  this just prevents any new work in _process


### PR DESCRIPTION
Stop the MgrClient callbacks to report PG stats at the
start of shutdown() so that we don't get a callback
during/after we are done shutting down.

Protect the cb update with the MgrClient's lock so that
we don't race with MgrClient::send_report() itself.

Fixes: http://tracker.ceph.com/issues/19638
Signed-off-by: Sage Weil <sage@redhat.com>