### PR TITLE
mon/OSDMonitor: update creating_pgs using pending_creatings

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -935,7 +935,7 @@ OSDMonitor::update_pending_pgs(const OSDMap::Incremental& inc)
       assert(st != pgm.pg_stat.end());
       auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
       // no need to add the pg, if it already exists in creating_pgs
-      creating_pgs.pgs.emplace(pgid, created);
+      pending_creatings.pgs.emplace(pgid, created);
     }
   }
   for (auto old_pool : inc.old_pools) {
@@ -3233,6 +3233,7 @@ epoch_t OSDMonitor::send_pg_creates(int osd, Connection *con, epoch_t next)
 {
   dout(30) << __func__ << " osd." << osd << " next=" << next
 	   << " " << creating_pgs_by_osd_epoch << dendl;
+  std::lock_guard<std::mutex> l(creating_pgs_lock);
   auto creating_pgs_by_epoch = creating_pgs_by_osd_epoch.find(osd);
   if (creating_pgs_by_epoch == creating_pgs_by_osd_epoch.end())
     return next;


### PR DESCRIPTION
* without this change, in OSDMonitor::update_pending_pgs(), creating_pgs
  is updated directly without lock, and the change will be overwritten
  with pending changes eventually. so we should update it using
  pending_creatings
* also, should acquire the lock in OSDMonitor::send_pg_creates() when
  reading creating_pgs_by_osd_epoch and createing_pgs.

Fixes: http://tracker.ceph.com/issues/19814
Signed-off-by: Kefu Chai <kchai@redhat.com>