### PR TITLE
osd/OSDMap: improve upmap calculation

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2239,15 +2239,7 @@ int CrushWrapper::_choose_type_stack(
       for (int pos = 0; pos < fanout; ++pos) {
 	if (type > 0) {
 	  // non-leaf
-	  int item = *tmpi;
-	  do {
-	    int r = get_immediate_parent_id(item, &item);
-	    if (r < 0) {
-	      ldout(cct, 10) << __func__ << " parent of " << item << " got "
-			     << cpp_strerror(r) << dendl;
-	      return -EINVAL;
-	    }
-	  } while (get_bucket_type(item) != type);
+	  int item = get_parent_of_type(*tmpi, type);
 	  o.push_back(item);
 	  ldout(cct, 10) << __func__ << "   from " << *tmpi << " got " << item
 			 << " of type " << type << dendl;

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1218,6 +1218,11 @@ int CrushWrapper::get_rule_weight_osd_map(unsigned ruleno, map<int,float> *pmap)
   crush_rule *rule = crush->rules[ruleno];
 
   // build a weight map for each TAKE in the rule, and then merge them
+
+  // FIXME: if there are multiple takes that place a different number of
+  // objects we do not take that into account.  (Also, note that doing this
+  // right is also a function of the pool, since the crush rule
+  // might choose 2 + choose 2 but pool size may only be 3.)
   for (unsigned i=0; i<rule->len; ++i) {
     map<int,float> m;
     float sum = 0;

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1044,6 +1044,17 @@ int CrushWrapper::get_immediate_parent_id(int id, int *parent) const
   return -ENOENT;
 }
 
+int CrushWrapper::get_parent_of_type(int item, int type) const
+{
+  do {
+    int r = get_immediate_parent_id(item, &item);
+    if (r < 0) {
+      return 0;
+    }
+  } while (get_bucket_type(item) != type);
+  return item;
+}
+
 bool CrushWrapper::class_is_in_use(int class_id)
 {
   for (auto &i : class_bucket)

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -572,6 +572,12 @@ public:
   int get_immediate_parent_id(int id, int *parent) const;
 
   /**
+   * return ancestor of the given type, or 0 if none
+   * (parent is always a bucket and thus <0)
+   */
+  int get_parent_of_type(int id, int type) const;
+
+  /**
    * get the fully qualified location of a device by successively finding
    * parents beginning at ID and ending at highest type number specified in
    * the CRUSH map which assumes that if device foo is under device bar, the

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3480,7 +3480,7 @@ int OSDMap::calc_pg_upmaps(
 		     << dendl;
       osd_deviation[i.first] = deviation;
       deviation_osd.insert(make_pair(deviation, i.first));
-      if (deviation > 0)
+      if (deviation >= 1.0)
 	overfull.insert(i.first);
     }
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3502,8 +3502,8 @@ int OSDMap::calc_pg_upmaps(
     bool restart = false;
     for (auto p = deviation_osd.rbegin(); p != deviation_osd.rend(); ++p) {
       int osd = p->second;
+      float deviation = p->first;
       float target = osd_weight[osd] * pgs_per_weight;
-      float deviation = deviation_osd.rbegin()->first;
       if (deviation/target < max_deviation) {
 	ldout(cct, 10) << " osd." << osd
 		       << " target " << target

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3405,7 +3405,7 @@ bool OSDMap::try_pg_upmap(
 
 int OSDMap::calc_pg_upmaps(
   CephContext *cct,
-  float max_deviation,
+  float max_deviation_ratio,
   int max,
   const set<int64_t>& only_pools_orig,
   OSDMap::Incremental *pending_inc)
@@ -3504,12 +3504,12 @@ int OSDMap::calc_pg_upmaps(
       int osd = p->second;
       float deviation = p->first;
       float target = osd_weight[osd] * pgs_per_weight;
-      if (deviation/target < max_deviation) {
+      if (deviation/target < max_deviation_ratio) {
 	ldout(cct, 10) << " osd." << osd
 		       << " target " << target
 		       << " deviation " << deviation
-		       << " -> " << deviation/target
-		       << " < max " << max_deviation << dendl;
+		       << " -> ratio " << deviation/target
+		       << " < max ratio " << max_deviation_ratio << dendl;
 	break;
       }
       int num_to_move = deviation;


### PR DESCRIPTION
The current version does not remap across hosts or racks (or other intervening
CRUSH bucket types)--it only moves PGs within the same lowest-level bucket referenced
by the rule.  This change fixes that.

On a test map (lab cluster) I'm able to get *all* devices to +/- 1 PG.

Also fix a bug or two.