### PR TITLE
cls_rbd: default initialize snapshot namespace for legacy clients

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -1554,6 +1554,12 @@ int snapshot_add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
     return -EINVAL;
   }
 
+  if (boost::get<cls::rbd::UnknownSnapshotNamespace>(
+        &snap_meta.snapshot_namespace.snapshot_namespace) != nullptr) {
+    CLS_ERR("Unknown snapshot namespace provided");
+    return -EINVAL;
+  }
+
   CLS_LOG(20, "snapshot_add name=%s id=%llu", snap_meta.name.c_str(),
 	 (unsigned long long)snap_meta.id.val);
 

--- a/src/cls/rbd/cls_rbd.h
+++ b/src/cls/rbd/cls_rbd.h
@@ -66,7 +66,8 @@ struct cls_rbd_snap {
   cls_rbd_parent parent;
   uint64_t flags;
   utime_t timestamp;
-  cls::rbd::SnapshotNamespaceOnDisk snapshot_namespace;
+  cls::rbd::SnapshotNamespaceOnDisk snapshot_namespace = {
+    cls::rbd::UserSnapshotNamespace{}};
 
   /// true if we have a parent
   bool has_parent() const {
@@ -107,8 +108,6 @@ struct cls_rbd_snap {
     }
     if (struct_v >= 5) {
       ::decode(snapshot_namespace, p);
-    } else {
-      snapshot_namespace = cls::rbd::SnapshotNamespaceOnDisk(cls::rbd::UserSnapshotNamespace());
     }
     if (struct_v >= 6) {
       ::decode(timestamp, p);


### PR DESCRIPTION
Creating a snapshot on >=Kraken OSDs using <=Jewel clients can result
in an improperly initialized snapshot namespace. As a result, attempting
to remove the snapshot using a >=Kraken client will result in an -EINVAL
error.

Fixes: http://tracker.ceph.com/issues/19413
Signed-off-by: Jason Dillaman <dillaman@redhat.com>