### PR TITLE
ceph-fuse: use user space permission check by default

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -465,7 +465,7 @@ OPTION(client_dirsize_rbytes, OPT_BOOL, true)
 OPTION(fuse_use_invalidate_cb, OPT_BOOL, true) // use fuse 2.8+ invalidate callback to keep page cache consistent
 OPTION(fuse_disable_pagecache, OPT_BOOL, false)
 OPTION(fuse_allow_other, OPT_BOOL, true)
-OPTION(fuse_default_permissions, OPT_BOOL, true)
+OPTION(fuse_default_permissions, OPT_BOOL, false)
 OPTION(fuse_big_writes, OPT_BOOL, true)
 OPTION(fuse_atomic_o_trunc, OPT_BOOL, true)
 OPTION(fuse_debug, OPT_BOOL, false)


### PR DESCRIPTION
The kernel permission check uses getattr() to get inode's uid, gid
and mode. But due to limitation of fuse API, ceph-fuse has to get
attributes of the inode. Getting direcotry inode's size can be slow
if the directory is fragmented and dirfrags are managed by multiple
mds.

Fixes: http://tracker.ceph.com/issues/19820
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>