### PR TITLE
dmclock: include missing <functional> header.

### DIFF
--- a/src/dmclock/sim/src/sim_recs.h
+++ b/src/dmclock/sim/src/sim_recs.h
@@ -21,6 +21,7 @@
 #include <string>
 #include <mutex>
 #include <iostream>
+#include <functional>
 
 
 using ClientId = uint;


### PR DESCRIPTION
The following error appears during make:
```
ceph/src/dmclock/test/test_test_client.cc:14:0:
ceph/src/dmclock/test/../sim/src/sim_recs.h:40:12: error: ‘std::function’ has not been declared
       std::function<void()> code) {
```
Signed-off-by: Jos Collin <jcollin@redhat.com>