### PR TITLE
rgw: don't do unneccesary write if buffer with zero length

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2563,6 +2563,9 @@ int RGWPutObjProcessor_Atomic::write_data(bufferlist& bl, off_t ofs, void **phan
 
   *pobj = cur_obj;
 
+  if (!bl.length())
+    return 0;
+
   return RGWPutObjProcessor_Aio::handle_obj_data(cur_obj, bl, ofs - cur_part_ofs, ofs, phandle, exclusive);
 }
 


### PR DESCRIPTION
Don't do unneccesary write if buffer with zero length,
or there will be one more shadow stripe rados object with size 0

Signed-off-by: fang yuxiang <fang.yuxiang@eisoo.com>