### PR TITLE
rgw: fix "period --commit" in secondary zonegroup

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1613,12 +1613,6 @@ static int commit_period(RGWRealm& realm, RGWPeriod& period,
     return ret;
   }
 
-  if (remote.empty() && url.empty()) {
-    // use the new master zone's connection
-    remote = master_zone;
-    cout << "Sending period to new master zone " << remote << std::endl;
-  }
-
   // push period to the master with an empty period id
   period.set_id("");
 


### PR DESCRIPTION
"radosgw-admin period update --commit" in secondary zonegroup will return "could not find connection for zone or zonegroup id"
when commit period in secodary zonegroup, "commit_period" function set remote=master_zone. while zonegroup_conn_map and zone_conn_map doesn't contain master zone.
"send_to_remote_gateway" function will set conn=store->rest_master_conn when remote is empty. So there is no need to set remote in "commit_period" function.

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>