### PR TITLE
logclient: use the seq id of the 1st log entry when resetting session

### DIFF
--- a/src/common/LogClient.cc
+++ b/src/common/LogClient.cc
@@ -268,8 +268,10 @@ Message *LogClient::get_mon_log_message(bool flush)
 {
   Mutex::Locker l(log_lock);
   if (flush) {
+    if (log_queue.empty())
+      return nullptr;
     // reset session
-    last_log_sent = last_log - log_queue.size();
+    last_log_sent = log_queue.front().seq;
   }
   return _get_mon_log_message();
 }


### PR DESCRIPTION
logclient: use the seq id of the 1st log entry when resetting session

because do_log() does not update last_log (see LogClient::get_next_seq())
and log_queue atomically, and log_queue is updated *after* last_log, so
we can not use them to figure out the number of log entries to be sent.
so, we choose to trust log_queue in this change.

Fixes: http://tracker.ceph.com/issues/19427
Signed-off-by: Kefu Chai <kchai@redhat.com>