### PR TITLE
common/config_opts.h: compaction readahead for bluestore/rocksdb

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1124,7 +1124,7 @@ OPTION(bluestore_allocator, OPT_STR, "bitmap")     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT, 128)
 OPTION(bluestore_bitmapallocator_blocks_per_zone, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
 OPTION(bluestore_bitmapallocator_span_size, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
-OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0")
+OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152")
 OPTION(bluestore_fsck_on_mount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_mount_deep, OPT_BOOL, true)
 OPTION(bluestore_fsck_on_umount, OPT_BOOL, false)


### PR DESCRIPTION
This greatly reduces time spent in the rocksdb compaction thread during 4K random writes on NVMe because compaction reads are mostly sequential anyway so a large readahead reduces a lot of extra overhead.  Previously the CompactionIterator was issuing a read to disk for every Next() call.

Before:

        + 100.00% rocksdb::ThreadPoolImpl::Impl::BGThread
          + 94.70% rocksdb::DBImpl::BackgroundCallCompaction
          | + 94.70% rocksdb::DBImpl::BackgroundCompaction
          |   + 94.70% rocksdb::CompactionJob::Run
          |     + 94.70% rocksdb::CompactionJob::ProcessKeyValueCompaction

After:

        + 100.00% rocksdb::ThreadPoolImpl::Impl::BGThread
          + 81.25% std::condition_variable::wait
          | + 81.25% __gthread_cond_wait
          |   + 81.25% pthread_cond_wait@@GLIBC_2.3.2
          + 18.75% rocksdb::DBImpl::BackgroundCallCompaction
            + 18.75% rocksdb::DBImpl::BackgroundCompaction
              + 18.75% rocksdb::CompactionJob::Run
                + 18.75% rocksdb::CompactionJob::ProcessKeyValueCompaction


Signed-off-by: Mark Nelson <mnelson@redhat.com>