### PR TITLE
common/perf_counters: make schema more friendly and update docs

### DIFF
--- a/doc/dev/perf_counters.rst
+++ b/doc/dev/perf_counters.rst
@@ -39,89 +39,121 @@ The ``perf schema`` command dumps a json description of which values are availab
 +------+-------------------------------------+
 | 2    | unsigned 64-bit integer value       |
 +------+-------------------------------------+
-| 4    | average (sum + count pair)          |
+| 4    | average (sum + count pair), where   |
 +------+-------------------------------------+
 | 8    | counter (vs gauge)                  |
 +------+-------------------------------------+
 
-Every value will have either bit 1 or 2 set to indicate the type (float or integer).  If bit 8 is set (counter), the reader may want to subtract off the previously read value to get the delta during the previous interval.  
+Every value will have either bit 1 or 2 set to indicate the type
+(float or integer).
 
-If bit 4 is set (average), there will be two values to read, a sum and a count.  If it is a counter, the average for the previous interval would be sum delta (since the previous read) divided by the count delta.  Alternatively, dividing the values outright would provide the lifetime average value.  Normally these are used to measure latencies (number of requests and a sum of request latencies), and the average for the previous interval is what is interesting.
+If bit 8 is set (counter), the value is monotonically increasing and
+the reader may want to subtract off the previously read value to get
+the delta during the previous interval.
+
+If bit 4 is set (average), there will be two values to read, a sum and
+a count.  If it is a counter, the average for the previous interval
+would be sum delta (since the previous read) divided by the count
+delta.  Alternatively, dividing the values outright would provide the
+lifetime average value.  Normally these are used to measure latencies
+(number of requests and a sum of request latencies), and the average
+for the previous interval is what is interesting.
+
+Instead of interpreting the bit fields, the ``metric type`` has a
+value of either ``guage`` or ``counter``, and the ``value type``
+property will be one of ``real``, ``integer``, ``real-integer-pair``
+(for a sum + real count pair), or ``integer-integer-pair`` (for a
+sum + integer count pair).
 
 Here is an example of the schema output::
 
- {
-   "throttle-msgr_dispatch_throttler-hbserver" : {
-      "get_or_fail_fail" : {
-         "type" : 10
-      },
-      "get_sum" : {
-         "type" : 10
-      },
-      "max" : {
-         "type" : 10
-      },
-      "put" : {
-         "type" : 10
-      },
-      "val" : {
-         "type" : 10
-      },
-      "take" : {
-         "type" : 10
-      },
-      "get_or_fail_success" : {
-         "type" : 10
-      },
-      "wait" : {
-         "type" : 5
-      },
-      "get" : {
-         "type" : 10
-      },
-      "take_sum" : {
-         "type" : 10
-      },
-      "put_sum" : {
-         "type" : 10
-      }
-   },
-   "throttle-msgr_dispatch_throttler-client" : {
-      "get_or_fail_fail" : {
-         "type" : 10
-      },
-      "get_sum" : {
-         "type" : 10
-      },
-      "max" : {
-         "type" : 10
-      },
-      "put" : {
-         "type" : 10
-      },
-      "val" : {
-         "type" : 10
-      },
-      "take" : {
-         "type" : 10
-      },
-      "get_or_fail_success" : {
-         "type" : 10
-      },
-      "wait" : {
-         "type" : 5
-      },
-      "get" : {
-         "type" : 10
-      },
-      "take_sum" : {
-         "type" : 10
-      },
-      "put_sum" : {
-         "type" : 10
-      }
-   }
- }
+  {
+    "throttle-bluestore_throttle_bytes": {
+        "val": {
+            "type": 2,
+            "metric_type": "gauge",
+            "value_type": "integer",
+            "description": "Currently available throttle",
+            "nick": ""
+        },
+        "max": {
+            "type": 2,
+            "metric_type": "gauge",
+            "value_type": "integer",
+            "description": "Max value for throttle",
+            "nick": ""
+        },
+        "get_started": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Number of get calls, increased before wait",
+            "nick": ""
+        },
+        "get": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Gets",
+            "nick": ""
+        },
+        "get_sum": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Got data",
+            "nick": ""
+        },
+        "get_or_fail_fail": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Get blocked during get_or_fail",
+            "nick": ""
+        },
+        "get_or_fail_success": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Successful get during get_or_fail",
+            "nick": ""
+        },
+        "take": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Takes",
+            "nick": ""
+        },
+        "take_sum": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Taken data",
+            "nick": ""
+        },
+        "put": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Puts",
+            "nick": ""
+        },
+        "put_sum": {
+            "type": 10,
+            "metric_type": "counter",
+            "value_type": "integer",
+            "description": "Put data",
+            "nick": ""
+        },
+        "wait": {
+            "type": 5,
+            "metric_type": "gauge",
+            "value_type": "real-integer-pair",
+            "description": "Waiting latency",
+            "nick": ""
+        }
+  }
 
 
 Dump

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -317,7 +317,7 @@ void PerfCounters::hinc(int idx, int64_t x, int64_t y)
   assert(idx < m_upper_bound);
 
   perf_counter_data_any_d& data(m_data[idx - m_lower_bound - 1]);
-  assert(data.type == (PERFCOUNTER_HISTOGRAM | PERFCOUNTER_U64));
+  assert(data.type == (PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER | PERFCOUNTER_U64));
   assert(data.histogram);
 
   data.histogram->inc(x, y);
@@ -407,7 +407,7 @@ void PerfCounters::dump_formatted_generic(Formatter *f, bool schema,
 	}
 	f->close_section();
       } else if (d->type & PERFCOUNTER_HISTOGRAM) {
-        assert(d->type == (PERFCOUNTER_HISTOGRAM | PERFCOUNTER_U64));
+        assert(d->type == (PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER | PERFCOUNTER_U64));
         assert(d->histogram);
         f->open_object_section(d->name);
         d->histogram->dump_formatted(f);
@@ -504,7 +504,7 @@ void PerfCountersBuilder::add_histogram(
   const char *description, const char *nick, int prio)
 {
   add_impl(idx, name, description, nick, prio,
-	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM,
+	   PERFCOUNTER_U64 | PERFCOUNTER_HISTOGRAM | PERFCOUNTER_COUNTER,
            unique_ptr<PerfHistogram<>>{new PerfHistogram<>{x_axis_config, y_axis_config}});
 }
 

--- a/src/common/perf_counters.cc
+++ b/src/common/perf_counters.cc
@@ -521,7 +521,7 @@ void PerfCountersBuilder::add_time_avg(
 	   PERFCOUNTER_TIME | PERFCOUNTER_LONGRUNAVG);
 }
 
-void PerfCountersBuilder::add_histogram(
+void PerfCountersBuilder::add_u64_counter_histogram(
   int idx, const char *name,
   PerfHistogramCommon::axis_config_d x_axis_config,
   PerfHistogramCommon::axis_config_d y_axis_config,

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -313,12 +313,14 @@ public:
 		    const char *description=NULL,
 		    const char *nick = NULL,
 		    int prio=0);
-  void add_histogram(int key, const char* name,
-		     PerfHistogramCommon::axis_config_d x_axis_config,
-		     PerfHistogramCommon::axis_config_d y_axis_config,
-		     const char *description=NULL,
-		     const char* nick = NULL,
-		     int prio=0);
+  void add_u64_counter_histogram(
+    int key, const char* name,
+    PerfHistogramCommon::axis_config_d x_axis_config,
+    PerfHistogramCommon::axis_config_d y_axis_config,
+    const char *description=NULL,
+    const char* nick = NULL,
+    int prio=0);
+
   PerfCounters* create_perf_counters();
 private:
   PerfCountersBuilder(const PerfCountersBuilder &rhs);

--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -37,11 +37,11 @@ class PerfCountersBuilder;
 enum perfcounter_type_d : uint8_t
 {
   PERFCOUNTER_NONE = 0,
-  PERFCOUNTER_TIME = 0x1,
-  PERFCOUNTER_U64 = 0x2,
-  PERFCOUNTER_LONGRUNAVG = 0x4,
-  PERFCOUNTER_COUNTER = 0x8,
-  PERFCOUNTER_HISTOGRAM = 0x10,
+  PERFCOUNTER_TIME = 0x1,       // float (measuring seconds)
+  PERFCOUNTER_U64 = 0x2,        // integer (note: either TIME or U64 *must* be set)
+  PERFCOUNTER_LONGRUNAVG = 0x4, // paired counter + sum (time)
+  PERFCOUNTER_COUNTER = 0x8,    // counter (vs guage)
+  PERFCOUNTER_HISTOGRAM = 0x10, // histogram (vector) of values
 };
 
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2797,7 +2797,7 @@ void OSD::create_logger()
   osd_plb.add_time_avg(
     l_osd_op_r_lat, "op_r_latency",
     "Latency of read operation (including queue time)");
-  osd_plb.add_histogram(
+  osd_plb.add_u64_counter_histogram(
     l_osd_op_r_lat_outb_hist, "op_r_latency_out_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
     "Histogram of operation latency (including queue time) + data read");
@@ -2814,7 +2814,7 @@ void OSD::create_logger()
   osd_plb.add_time_avg(
     l_osd_op_w_lat,  "op_w_latency",
     "Latency of write operation (including queue time)");
-  osd_plb.add_histogram(
+  osd_plb.add_u64_counter_histogram(
     l_osd_op_w_lat_inb_hist, "op_w_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
     "Histogram of operation latency (including queue time) + data written");
@@ -2836,11 +2836,11 @@ void OSD::create_logger()
   osd_plb.add_time_avg(
     l_osd_op_rw_lat, "op_rw_latency",
     "Latency of read-modify-write operation (including queue time)");
-  osd_plb.add_histogram(
+  osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_inb_hist, "op_rw_latency_in_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
     "Histogram of rw operation latency (including queue time) + data written");
-  osd_plb.add_histogram(
+  osd_plb.add_u64_counter_histogram(
     l_osd_op_rw_lat_outb_hist, "op_rw_latency_out_bytes_histogram",
     op_hist_x_axis_config, op_hist_y_axis_config,
     "Histogram of rw operation latency (including queue time) + data read");

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -182,8 +182,7 @@ TEST(PerfCounters, MultiplePerfCounters) {
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":13,\"element2\":0.000000000,"
 	    "\"element3\":{\"avgcount\":0,\"sum\":0.000000000}}}"), msg);
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf schema\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":{\"type\":2,\"description\":\"\",\"nick\":\"\"},"
-	    "\"element2\":{\"type\":1,\"description\":\"\",\"nick\":\"\"},\"element3\":{\"type\":5,\"description\":\"\",\"nick\":\"\"}}}"), msg);
+  ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":{\"type\":2,\"metric_type\":\"gauge\",\"value_type\":\"integer\",\"description\":\"\",\"nick\":\"\"},\"element2\":{\"type\":1,\"metric_type\":\"gauge\",\"value_type\":\"real\",\"description\":\"\",\"nick\":\"\"},\"element3\":{\"type\":5,\"metric_type\":\"gauge\",\"value_type\":\"real-integer-pair\",\"description\":\"\",\"nick\":\"\"}}}"), msg);
   coll->clear();
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ("{}", msg);


### PR DESCRIPTION
I just spoke with a user yesterday who was complaining about the lack of documentation for the metrics.  (The docs exist, but they're stale; when I showed him the ideally self-documenting  'perf schema' output it wasn't obvious what was a guage or metric.)