### PR TITLE
rbd: removed spurious error message from mirror pool commands

### DIFF
--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -466,7 +466,7 @@ public:
     // mirror image operations
     librbd::RBD rbd;
     int r = rbd.list(m_io_ctx, m_image_names);
-    if (r < 0) {
+    if (r < 0 && r != -ENOENT) {
       std::cerr << "rbd: failed to list images within pool" << std::endl;
       return r;
     }


### PR DESCRIPTION
If the pool was empty, the rbd CLI would report the error
"rbd: failed to list images within pool".

Signed-off-by: Jason Dillaman <dillaman@redhat.com>