### PR TITLE
kraken: rgw: fix RadosGW hang during multi-chunk upload of AWSv4.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2991,7 +2991,7 @@ void RGWPutObj::execute()
     }
 
     bufferlist &data = data_in;
-    if (s->aws4_auth_streaming_mode) {
+    if (len && s->aws4_auth_streaming_mode) {
       /* use unwrapped data */
       data = s->aws4_auth->bl;
       len = data.length();


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19754
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>
(cherry picked from commit 72c1e2e351d984d0425a20f2c772951cbc36f13e)

-----

This is the Kraken backport of PR #14770.
Corresponding backport ticket: http://tracker.ceph.com/issues/19837.

CC: @mattbenjamin, @oritwas.