### PR TITLE
debian/rpm: move radosgw-admin to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1020,6 +1020,7 @@ DISABLE_RESTART_ON_UPDATE="yes"
 %{_bindir}/cephfs-journal-tool
 %{_bindir}/cephfs-table-tool
 %{_bindir}/rados
+%{_bindir}/radosgw-admin
 %{_bindir}/rbd
 %{_bindir}/rbd-replay
 %{_bindir}/rbd-replay-many
@@ -1043,6 +1044,7 @@ DISABLE_RESTART_ON_UPDATE="yes"
 %{_mandir}/man8/ceph.8*
 %{_mandir}/man8/mount.ceph.8*
 %{_mandir}/man8/rados.8*
+%{_mandir}/man8/radosgw-admin.8*
 %{_mandir}/man8/rbd.8*
 %{_mandir}/man8/rbdmap.8*
 %{_mandir}/man8/rbd-replay.8*
@@ -1055,6 +1057,7 @@ DISABLE_RESTART_ON_UPDATE="yes"
 %dir %{_sysconfdir}/ceph/
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
+%config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %config(noreplace) %{_sysconfdir}/ceph/rbdmap
 %{_unitdir}/rbdmap.service
 %{python_sitelib}/ceph_argparse.py*
@@ -1320,12 +1323,9 @@ fi
 %files radosgw
 %defattr(-,root,root,-)
 %{_bindir}/radosgw
-%{_bindir}/radosgw-admin
 %{_bindir}/radosgw-token
 %{_bindir}/radosgw-object-expirer
 %{_mandir}/man8/radosgw.8*
-%{_mandir}/man8/radosgw-admin.8*
-%config %{_sysconfdir}/bash_completion.d/radosgw-admin
 %dir %{_localstatedir}/lib/ceph/radosgw
 %{_unitdir}/ceph-radosgw@.service
 %{_unitdir}/ceph-radosgw.target

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -1,6 +1,7 @@
 #! /usr/bin/dh-exec --with=install
 
 etc/bash_completion.d/rados
+etc/bash_completion.d/radosgw-admin
 etc/bash_completion.d/rbd
 usr/bin/ceph
 usr/bin/ceph-authtool
@@ -13,6 +14,7 @@ usr/bin/cephfs-data-scan
 usr/bin/cephfs-journal-tool
 usr/bin/cephfs-table-tool
 usr/bin/rados
+usr/bin/radosgw-admin
 usr/bin/rbd
 usr/bin/rbdmap
 usr/bin/rbd-replay*
@@ -30,6 +32,7 @@ usr/share/man/man8/ceph-post-file.8
 usr/share/man/man8/ceph.8
 usr/share/man/man8/mount.ceph.8
 usr/share/man/man8/rados.8
+usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/rbd.8
 usr/share/man/man8/rbdmap.8
 usr/share/man/man8/rbd-replay*.8

--- a/debian/radosgw.install
+++ b/debian/radosgw.install
@@ -1,7 +1,4 @@
-etc/bash_completion.d/radosgw-admin
 usr/bin/radosgw
-usr/bin/radosgw-admin
 usr/bin/radosgw-token
 usr/bin/radosgw-object-expirer
-usr/share/man/man8/radosgw-admin.8
 usr/share/man/man8/radosgw.8


### PR DESCRIPTION
This commit moves the radosgw-admin command from
the radosgw package to ceph-common.

This allows for a better user expierence since the
radosgw-admin command can be run on any node.

Resolves: rhbz#1430079

Signed-off-by: Ali Maredia <amaredia@redhat.com>