### PR TITLE
compressor/zlib: fix plugin for non-Intel arches

### DIFF
--- a/src/compressor/zlib/CompressionPluginZlib.h
+++ b/src/compressor/zlib/CompressionPluginZlib.h
@@ -35,19 +35,18 @@ public:
   int factory(CompressorRef *cs,
                       std::ostream *ss) override
   {
+    bool isal = false;
 #if defined(__i386__) || defined(__x86_64__)
-    bool isal;
+    // other arches or lack of support result in isal = false
     if (cct->_conf->compressor_zlib_isal) {
       ceph_arch_probe();
       isal = (ceph_arch_intel_pclmul && ceph_arch_intel_sse41);
-    } else {
-      isal = false;
     }
+#endif
     if (compressor == 0 || has_isal != isal) {
       compressor = std::make_shared<ZlibCompressor>(isal);
       has_isal = isal;
     }
-#endif
     *cs = compressor;
     return 0;
   }


### PR DESCRIPTION
unittest_compressor was failing on arm64 because the zlib
compressor was never initialized, even though it works fine in
non-isal mode

Signed-off-by: Dan Mick <dan.mick@redhat.com>