### PR TITLE
cmake: kill duplicated cmake commands

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,6 @@ if(FREEBSD)
   list(APPEND CMAKE_REQUIRED_INCLUDES /usr/local/include)
 endif(FREEBSD)
 
-#put all the libs and binaries in one place
-set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
-set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-
 #Check Includes
 include(CheckIncludeFiles)
 include(CheckIncludeFileCXX)


### PR DESCRIPTION
@tchaikov , those lines are duplicated with https://github.com/ceph/ceph/compare/master...Liuchang0812:wip-kill-duplicated-cmake-commands?expand=1#diff-af3b638bc2a3e6c650974192a53c7291L89


Signed-off-by: liuchang0812 <liuchang0812@gmail.com>