### PR TITLE
buffer, osd: add missing crc cache miss perf counter

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -91,6 +91,7 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
 
   static atomic_t buffer_cached_crc;
   static atomic_t buffer_cached_crc_adjusted;
+  static atomic_t buffer_missed_crc;
   static bool buffer_track_crc = get_env_bool("CEPH_BUFFER_TRACK");
 
   void buffer::track_cached_crc(bool b) {
@@ -101,6 +102,10 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
   }
   int buffer::get_cached_crc_adjusted() {
     return buffer_cached_crc_adjusted.read();
+  }
+
+  int buffer::get_missed_crc() {
+    return buffer_missed_crc.read();
   }
 
   static atomic_t buffer_c_str_accesses;
@@ -2391,6 +2396,8 @@ __u32 buffer::list::crc32c(__u32 crc) const
 	    buffer_cached_crc_adjusted.inc();
 	}
       } else {
+	if (buffer_track_crc)
+	  buffer_missed_crc.inc();
 	uint32_t base = crc;
 	crc = ceph_crc32c(crc, (unsigned char*)it->c_str(), it->length());
 	r->set_crc(ofs, make_pair(base, crc));

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -116,6 +116,8 @@ namespace buffer CEPH_BUFFER_API {
   int get_cached_crc();
   /// count of cached crc hits (mismatching input, required adjustment)
   int get_cached_crc_adjusted();
+  /// count of crc cache misses
+  int get_missed_crc();
   /// enable/disable tracking of cached crcs
   void track_cached_crc(bool b);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2891,6 +2891,8 @@ void OSD::create_logger()
   osd_plb.add_u64(
     l_osd_cached_crc_adjusted, "cached_crc_adjusted",
     "Total number getting crc from crc_cache with adjusting");
+  osd_plb.add_u64(l_osd_missed_crc, "missed_crc", 
+    "Total number of crc cache misses");
 
   osd_plb.add_u64(l_osd_pg, "numpg", "Placement groups",
 		  "pgs", PerfCountersBuilder::PRIO_USEFUL);
@@ -4869,6 +4871,7 @@ void OSD::tick_without_osd_lock()
   logger->set(l_osd_history_alloc_num, buffer::get_history_alloc_num());
   logger->set(l_osd_cached_crc, buffer::get_cached_crc());
   logger->set(l_osd_cached_crc_adjusted, buffer::get_cached_crc_adjusted());
+  logger->set(l_osd_missed_crc, buffer::get_missed_crc());
 
   // osd_lock is not being held, which means the OSD state
   // might change when doing the monitor report

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -114,6 +114,7 @@ enum {
   l_osd_history_alloc_num,
   l_osd_cached_crc,
   l_osd_cached_crc_adjusted,
+  l_osd_missed_crc,
 
   l_osd_pg,
   l_osd_pg_primary,


### PR DESCRIPTION
This helps tracking if/how effective is the CRC cache in bufferlists.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>