### PR TITLE
common: Finisher.cc: silence warning from -Wmaybe-uninitialized

### DIFF
--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -47,7 +47,7 @@ void *Finisher::finisher_thread_entry()
   ldout(cct, 10) << "finisher_thread start" << dendl;
 
   utime_t start;
-  uint64_t count;
+  uint64_t count = 0;
   while (!finisher_stop) {
     /// Every time we are woken up, we process the queue until it is empty.
     while (!finisher_queue.empty()) {


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/common/Finisher.cc: In member function ‘void* Finisher::finisher_thread_entry()’:
ceph/src/common/Finisher.cc:89:13: warning: ‘count’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  logger->dec(l_finisher_queue_len, count);
```
Signed-off-by: Jos Collin <jcollin@redhat.com>