### PR TITLE
test/librbd/test_librbd.cc: set *features even if RBD_FEATURES is unset

### DIFF
--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -84,6 +84,7 @@ static int get_features(bool *old_format, uint64_t *features)
     cout << "using new format!" << std::endl;
   } else {
     *old_format = true;
+    *features = 0;
     cout << "using old format" << std::endl;
   }
 


### PR DESCRIPTION
If RBD_FEATURES is not in the environment, set *features to 0 in
get_features(); callers rely on a valid return value.  (This was
breaking on arm64.)

Fixes: http://tracker.ceph.com/issues/19865
Signed-off-by: Dan Mick <dan.mick@redhat.com>