### PR TITLE
osd: fix osd balance reads might not get expected length of file content from replica osd

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -942,13 +942,15 @@ protected:
   void get_obc_watchers(ObjectContextRef obc, list<obj_watch_item_t> &pg_watchers);
 public:
   void handle_watch_timeout(WatchRef watch);
+  void check_object_context_and_purge(const hobject_t& oid);
 protected:
 
   ObjectContextRef create_object_context(const object_info_t& oi, SnapSetContext *ssc);
   ObjectContextRef get_object_context(
     const hobject_t& soid,
     bool can_create,
-    const map<string, bufferlist> *attrs = 0
+    const map<string, bufferlist> *attrs = 0,
+    bool lookup_only = false
     );
 
   void context_registry_on_change();

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -22,6 +22,7 @@
 #include "messages/MOSDPGPull.h"
 #include "messages/MOSDPGPushReply.h"
 #include "common/EventTrace.h"
+#include "PrimaryLogPG.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_osd
@@ -1065,6 +1066,8 @@ void ReplicatedBackend::do_repop(OpRequestRef op)
   assert(MSG_OSD_REPOP == msg_type);
 
   const hobject_t& soid = m->poid;
+  PrimaryLogPG *_rPG = dynamic_cast<PrimaryLogPG *>(get_parent());
+  _rPG->check_object_context_and_purge(soid);
 
   dout(10) << __func__ << " " << soid
            << " v " << m->version


### PR DESCRIPTION
Steps to reproduce:

1. write a file with length len_1
2. try to read this file from replica osd (using CEPH_OSD_FLAG_BALANCE_READS flag)
3. continue appending some contents to this file, now file length is len_2 (len_2 > len_1)
4. try to read this file again from just above replica osd in step-2.

This issue happened after step-4. The content read back from replica osd is not correct, only first len_1 length's content is correct, while next (len_2 - len_1) length's content is not.

The root cause is that after reading file directly from replica osd, replica osd would have its object context in cache. When this file has been updated later, e.g, size is increased, primary osd will update this object context accordingly, such as size info in write_update_size_and_usage(), so next reading on primary osd will get correct length's content. But osd repop just queues filestore transactions and won't update this object context, so if next reading hits on this replica osd again, it will find object context already in cache and use the size info in object context (which is smaller than real size now) as op's extent length and pass this smaller size to filestore to read file content.

The better fix might be letting osd repop to update object context accordingly, but it is difficult to check expected ops from a bunch of transactions and get real file size from them, and it also seems unworthy to do this. So the alternative here is to check if object context is in cache or not and remove it if exists when handle osd repop, which looks like invalidating this object context in cache. Then next reading will find no cache and recreate it. 

Fixes: http://tracker.ceph.com/issues/19868

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>
