### PR TITLE
osd: sched_scrub() lock pg only if all scrubbing conditions are fulfilled

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6833,11 +6833,16 @@ void OSD::sched_scrub()
         break;
       }
 
+      if ((scrub.deadline >= now) && !(time_permit && load_is_low)) {
+        dout(10) << __func__ << " not scheduling scrub for " << scrub.pgid << " due to "
+                 << (!time_permit ? "time not permit" : "high load") << dendl;
+        continue;
+      }
+
       PG *pg = _lookup_lock_pg(scrub.pgid);
       if (!pg)
 	continue;
-      if (pg->get_pgbackend()->scrub_supported() && pg->is_active() &&
-	  (scrub.deadline < now || (time_permit && load_is_low))) {
+      if (pg->get_pgbackend()->scrub_supported() && pg->is_active()) {
 	dout(10) << "sched_scrub scrubbing " << scrub.pgid << " at " << scrub.sched_time
 		 << (pg->scrubber.must_scrub ? ", explicitly requested" :
 		     (load_is_low ? ", load_is_low" : " deadline < now"))


### PR DESCRIPTION
There are multiple constraints when determining whether scheduling a scrub or not .We should make sure all conditional checks have passed before locking this pg.

Signed-off-by: Jin Cai <caijin.caij@alibaba-inc.com>