### PR TITLE
mgr: load modules in separate python sub-interpreters

### DIFF
--- a/src/mgr/Gil.h
+++ b/src/mgr/Gil.h
@@ -1,0 +1,96 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 SUSE LLC
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef GIL_H_
+#define GIL_H_
+
+#include "Python.h"
+
+#include "common/debug.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr " << __func__ << " "
+
+//
+// Use one of these in any scope in which you need to hold Python's
+// Global Interpreter Lock.
+//
+// Do *not* nest these, as a second GIL acquire will deadlock (see
+// https://docs.python.org/2/c-api/init.html#c.PyEval_RestoreThread)
+//
+// If in doubt, explicitly put a scope around the block of code you
+// know you need the GIL in.
+//
+// See the comment below for when to set new_thread == true
+//
+class Gil {
+public:
+  Gil(const Gil&) = delete;
+  Gil& operator=(const Gil&) = delete;
+
+  Gil(PyThreadState *ts, bool new_thread = false) : pThreadState(ts)
+  {
+    assert(pThreadState != nullptr);
+
+    // Acquire the GIL, set the current thread state
+    PyEval_RestoreThread(pThreadState);
+    dout(20) << "GIL acquired for thread state " << pThreadState << dendl;
+
+    //
+    // If called from a separate OS thread (i.e. a thread not created
+    // by Python, that does't already have a python thread state that
+    // was created when that thread was active), we need to manually
+    // create and switch to a python thread state specifically for this
+    // OS thread.
+    //
+    // Note that instead of requring the caller to set new_thread == true
+    // when calling this from a separate OS thread, we could figure out
+    // if this was necessary automatically, as follows:
+    //
+    //   if (pThreadState->thread_id != PyThread_get_thread_ident()) {
+    //
+    // However, this means we're accessing pThreadState->thread_id, but
+    // the Python C API docs say that "The only public data member is
+    // PyInterpreterState *interp", i.e. doing this would violate
+    // something that's meant to be a black box.
+    //
+    if (new_thread) {
+      pNewThreadState = PyThreadState_New(pThreadState->interp);
+      PyThreadState_Swap(pNewThreadState);
+      dout(20) << "Switched to new thread state " << pNewThreadState << dendl;
+    }
+  }
+
+  ~Gil()
+  {
+    if (pNewThreadState != nullptr) {
+      dout(20) << "Destroying new thread state " << pNewThreadState << dendl;
+      PyThreadState_Swap(pThreadState);
+      PyThreadState_Clear(pNewThreadState);
+      PyThreadState_Delete(pNewThreadState);
+    }
+    // Release the GIL, reset the thread state to NULL
+    PyEval_SaveThread();
+    dout(20) << "GIL released for thread state " << pThreadState << dendl;
+  }
+
+private:
+  PyThreadState *pThreadState;
+  PyThreadState *pNewThreadState = nullptr;
+};
+
+#endif
+

--- a/src/mgr/MgrPyModule.cc
+++ b/src/mgr/MgrPyModule.cc
@@ -11,6 +11,7 @@
  * Foundation.  See file COPYING.
  */
 
+#include "PyState.h"
 #include "Gil.h"
 
 #include "PyFormatter.h"
@@ -47,27 +48,113 @@ std::string handle_pyerror()
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
+
+#undef dout_prefix
+#define dout_prefix *_dout << "mgr[py] "
+
+namespace {
+  PyObject* log_write(PyObject*, PyObject* args) {
+    char* m = nullptr;
+    if (PyArg_ParseTuple(args, "s", &m)) {
+      auto len = strlen(m);
+      if (len && m[len-1] == '\n') {
+	m[len-1] = '\0';
+      }
+      dout(4) << m << dendl;
+    }
+    Py_RETURN_NONE;
+  }
+
+  PyObject* log_flush(PyObject*, PyObject*){
+    Py_RETURN_NONE;
+  }
+
+  static PyMethodDef log_methods[] = {
+    {"write", log_write, METH_VARARGS, "write stdout and stderr"},
+    {"flush", log_flush, METH_VARARGS, "flush"},
+    {nullptr, nullptr, 0, nullptr}
+  };
+}
+
 #undef dout_prefix
 #define dout_prefix *_dout << "mgr " << __func__ << " "
 
-MgrPyModule::MgrPyModule(const std::string &module_name_, PyThreadState *main_ts_)
+MgrPyModule::MgrPyModule(const std::string &module_name_, const std::string &sys_path, PyThreadState *main_ts_)
   : module_name(module_name_),
     pClassInstance(nullptr),
     pMainThreadState(main_ts_)
 {
   assert(pMainThreadState != nullptr);
+
+  Gil gil(pMainThreadState);
+
+  pMyThreadState = Py_NewInterpreter();
+  if (pMyThreadState == nullptr) {
+    derr << "Failed to create python sub-interpreter for '" << module_name << '"' << dendl;
+  } else {
+    // Some python modules do not cope with an unpopulated argv, so lets
+    // fake one.  This step also picks up site-packages into sys.path.
+    const char *argv[] = {"ceph-mgr"};
+    PySys_SetArgv(1, (char**)argv);
+
+    if (g_conf->daemonize) {
+      auto py_logger = Py_InitModule("ceph_logger", log_methods);
+#if PY_MAJOR_VERSION >= 3
+      PySys_SetObject("stderr", py_logger);
+      PySys_SetObject("stdout", py_logger);
+#else
+      PySys_SetObject(const_cast<char*>("stderr"), py_logger);
+      PySys_SetObject(const_cast<char*>("stdout"), py_logger);
+#endif
+    }
+    // Populate python namespace with callable hooks
+    Py_InitModule("ceph_state", CephStateMethods);
+
+    PySys_SetPath(const_cast<char*>(sys_path.c_str()));
+  }
 }
 
 MgrPyModule::~MgrPyModule()
 {
-  Gil gil(pMainThreadState);
+  if (pMyThreadState != nullptr) {
+    Gil gil(pMyThreadState);
 
-  Py_XDECREF(pClassInstance);
+    Py_XDECREF(pClassInstance);
+
+    //
+    // Ideally, now, we'd be able to do this:
+    //
+    //    Py_EndInterpreter(pMyThreadState);
+    //    PyThreadState_Swap(pMainThreadState);
+    //
+    // Unfortunately, if the module has any other *python* threads active
+    // at this point, Py_EndInterpreter() will abort with:
+    //
+    //    Fatal Python error: Py_EndInterpreter: not the last thread
+    //
+    // This can happen when using CherryPy in a module, becuase CherryPy
+    // runs an extra thread as a timeout monitor, which spends most of its
+    // life inside a time.sleep(60).  Unless you are very, very lucky with
+    // the timing calling this destructor, that thread will still be stuck
+    // in a sleep, and Py_EndInterpreter() will abort.
+    //
+    // This could of course also happen with a poorly written module which
+    // made no attempt to clean up any additional threads it created.
+    //
+    // The safest thing to do is just not call Py_EndInterpreter(), and
+    // let Py_Finalize() kill everything after all modules are shut down.
+    //
+  }
 }
 
 int MgrPyModule::load()
 {
-  Gil gil(pMainThreadState);
+  if (pMyThreadState == nullptr) {
+    derr << "No python sub-interpreter exists for module '" << module_name << "'" << dendl;
+    return -EINVAL;
+  }
+
+  Gil gil(pMyThreadState);
 
   // Load the module
   PyObject *pName = PyString_FromString(module_name.c_str());
@@ -115,7 +202,7 @@ int MgrPyModule::serve()
 
   // This method is called from a separate OS thread (i.e. a thread not
   // created by Python), so tell Gil to wrap this in a new thread state.
-  Gil gil(pMainThreadState, true);
+  Gil gil(pMyThreadState, true);
 
   auto pValue = PyObject_CallMethod(pClassInstance,
       const_cast<char*>("serve"), nullptr);
@@ -137,7 +224,7 @@ void MgrPyModule::shutdown()
 {
   assert(pClassInstance != nullptr);
 
-  Gil gil(pMainThreadState);
+  Gil gil(pMyThreadState);
 
   auto pValue = PyObject_CallMethod(pClassInstance,
       const_cast<char*>("shutdown"), nullptr);
@@ -154,7 +241,7 @@ void MgrPyModule::notify(const std::string &notify_type, const std::string &noti
 {
   assert(pClassInstance != nullptr);
 
-  Gil gil(pMainThreadState);
+  Gil gil(pMyThreadState);
 
   // Execute
   auto pValue = PyObject_CallMethod(pClassInstance,
@@ -177,7 +264,7 @@ void MgrPyModule::notify_clog(const LogEntry &log_entry)
 {
   assert(pClassInstance != nullptr);
 
-  Gil gil(pMainThreadState);
+  Gil gil(pMyThreadState);
 
   // Construct python-ized LogEntry
   PyFormatter f;
@@ -247,7 +334,7 @@ int MgrPyModule::handle_command(
   assert(ss != nullptr);
   assert(ds != nullptr);
 
-  Gil gil(pMainThreadState);
+  Gil gil(pMyThreadState);
 
   PyFormatter f;
   cmdmap_dump(cmdmap, &f);

--- a/src/mgr/MgrPyModule.h
+++ b/src/mgr/MgrPyModule.h
@@ -44,13 +44,14 @@ class MgrPyModule
 private:
   const std::string module_name;
   PyObject *pClassInstance;
+  PyThreadState *pMainThreadState;
 
   std::vector<ModuleCommand> commands;
 
   int load_commands();
 
 public:
-  MgrPyModule(const std::string &module_name);
+  MgrPyModule(const std::string &module_name, PyThreadState *main_ts);
   ~MgrPyModule();
 
   int load();

--- a/src/mgr/MgrPyModule.h
+++ b/src/mgr/MgrPyModule.h
@@ -45,13 +45,14 @@ private:
   const std::string module_name;
   PyObject *pClassInstance;
   PyThreadState *pMainThreadState;
+  PyThreadState *pMyThreadState = nullptr;
 
   std::vector<ModuleCommand> commands;
 
   int load_commands();
 
 public:
-  MgrPyModule(const std::string &module_name, PyThreadState *main_ts);
+  MgrPyModule(const std::string &module_name, const std::string &sys_path, PyThreadState *main_ts);
   ~MgrPyModule();
 
   int load();

--- a/src/mgr/PyModules.h
+++ b/src/mgr/PyModules.h
@@ -43,6 +43,8 @@ class PyModules
 
   std::string get_site_packages();
 
+  PyThreadState *pMainThreadState = nullptr;
+
 public:
   static std::string config_prefix;
 

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -22,8 +22,10 @@
 #include "common/version.h"
 
 #include "PyState.h"
+#include "Gil.h"
 
 #define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_mgr
 
 PyModules *global_handle = NULL;
 
@@ -32,13 +34,14 @@ class MonCommandCompletion : public Context
 {
   PyObject *python_completion;
   const std::string tag;
+  PyThreadState *pThreadState;
 
 public:
   std::string outs;
   bufferlist outbl;
 
-  MonCommandCompletion(PyObject* ev, const std::string &tag_)
-    : python_completion(ev), tag(tag_)
+  MonCommandCompletion(PyObject* ev, const std::string &tag_, PyThreadState *ts_)
+    : python_completion(ev), tag(tag_), pThreadState(ts_)
   {
     assert(python_completion != nullptr);
     Py_INCREF(python_completion);
@@ -51,28 +54,28 @@ public:
 
   void finish(int r) override
   {
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
+    dout(10) << "MonCommandCompletion::finish()" << dendl;
+    {
+      // Scoped so the Gil is released before calling notify_all()
+      Gil gil(pThreadState);
 
-    auto set_fn = PyObject_GetAttrString(python_completion, "complete");
-    assert(set_fn != nullptr);
+      auto set_fn = PyObject_GetAttrString(python_completion, "complete");
+      assert(set_fn != nullptr);
 
-    auto pyR = PyInt_FromLong(r);
-    auto pyOutBl = PyString_FromString(outbl.to_str().c_str());
-    auto pyOutS = PyString_FromString(outs.c_str());
-    auto args = PyTuple_Pack(3, pyR, pyOutBl, pyOutS);
-    Py_DECREF(pyR);
-    Py_DECREF(pyOutBl);
-    Py_DECREF(pyOutS);
+      auto pyR = PyInt_FromLong(r);
+      auto pyOutBl = PyString_FromString(outbl.to_str().c_str());
+      auto pyOutS = PyString_FromString(outs.c_str());
+      auto args = PyTuple_Pack(3, pyR, pyOutBl, pyOutS);
+      Py_DECREF(pyR);
+      Py_DECREF(pyOutBl);
+      Py_DECREF(pyOutS);
 
-    auto rtn = PyObject_CallObject(set_fn, args);
-    if (rtn != nullptr) {
-      Py_DECREF(rtn);
+      auto rtn = PyObject_CallObject(set_fn, args);
+      if (rtn != nullptr) {
+	Py_DECREF(rtn);
+      }
+      Py_DECREF(args);
     }
-    Py_DECREF(args);
-
-    PyGILState_Release(gstate);
-
     global_handle->notify_all("command", tag);
   }
 };
@@ -105,7 +108,7 @@ ceph_send_command(PyObject *self, PyObject *args)
   }
   Py_DECREF(set_fn);
 
-  auto c = new MonCommandCompletion(completion, tag);
+  auto c = new MonCommandCompletion(completion, tag, PyThreadState_Get());
   if (std::string(type) == "mon") {
     global_handle->get_monc().start_mon_command(
         {cmd_json},


### PR DESCRIPTION
This provides a reasonable amount of isolation between mgr
modules.  Notably, with this change, it's possible to have more
than one mgr module use cherrypy.

I consider this implementation to be a bit messy; I think it'd
be neater if the sub-interpreter was created inside MgrPyModule,
rather than in PyModules::init(), but see the comment in that
function for more details.

Also, due to the lack of documentation on python sub-interpreters,
I'm not completely confident that I'm doing everything correctly.
Notably, there's still calls to PyGILState_Ensure() and
PyEval_ReleaseThread() in PyState.cc, and apparently those two
are either not-compatible with sub-interpreters, or at least need
to be handled delicately.

TL;DR: Everything seems to work for me so far, but should be
considered experimental until further notice.

Signed-off-by: Tim Serong <tserong@suse.com>