### PR TITLE
os/bluestore: Removed the override and const because of error

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -99,13 +99,13 @@ class BlueRocksRandomAccessFile : public rocksdb::RandomAccessFile {
 
   // Used by the file_reader_writer to decide if the ReadAhead wrapper
   // should simply forward the call and do not enact buffering or locking.
-  bool ShouldForwardRawRequest() const override {
+  bool ShouldForwardRawRequest() {
     return false;
   }
 
   // For cases when read-ahead is implemented in the platform dependent
   // layer
-  void EnableReadAhead() override {}
+  void EnableReadAhead() {}
 
   // Tries to get an unique ID for this file that will be the same each time
   // the file is opened (and will stay the same while the file is open).


### PR DESCRIPTION
The following error appears during make. Removed the override as there is no such virtual function
in the base class to override. Removed the unnessary const function too.
```
ceph/src/os/bluestore/BlueRocksEnv.cc:102:8: error: ‘bool BlueRocksRandomAccessFile::ShouldForwardRawRequest() const’ marked ‘override’, but does not override
   bool ShouldForwardRawRequest() const override {

ceph/src/os/bluestore/BlueRocksEnv.cc:108:8: error: ‘void BlueRocksRandomAccessFile::EnableReadAhead()’ marked ‘override’, but does not override
   void EnableReadAhead() override {}
```
Signed-off-by: Jos Collin <jcollin@redhat.com>