### PR TITLE
osd: clean nonused work queue

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -229,7 +229,6 @@ OSDService::OSDService(OSD *osd) :
   peering_wq(osd->peering_wq),
   recovery_gen_wq("recovery_gen_wq", cct->_conf->osd_recovery_thread_timeout,
 		  &osd->disk_tp),
-  op_gen_wq("op_gen_wq", cct->_conf->osd_recovery_thread_timeout, &osd->osd_tp),
   class_handler(osd->class_handler),
   pg_epoch_lock("OSDService::pg_epoch_lock"),
   publish_lock("OSDService::publish_lock"),

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -472,7 +472,6 @@ public:
   MonClient   *&monc;
   ThreadPool::BatchWorkQueue<PG> &peering_wq;
   GenContextWQ recovery_gen_wq;
-  GenContextWQ op_gen_wq;
   ClassHandler  *&class_handler;
 
   void enqueue_back(spg_t pgid, PGQueueable qi);


### PR DESCRIPTION
it was restructured by 3cc48278bf0ee5c9535d04b60a661f988c50063b

Signed-off-by: Wei Jin <wjin.cn@gmail.com>