### PR TITLE
mon: add "mgr dump" command

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -832,3 +832,7 @@ COMMAND("config-key dump", "dump keys and values", "config-key", "r", "cli,rest"
  */
 COMMAND("mgr fail name=who,type=CephString", \
 	"treat the named manager daemon as failed", "mgr", "rw", "cli,rest")
+COMMAND("mgr dump " \
+        "name=epoch,type=CephInt,range=0,req=false", \
+	"dump formatted mgrmap (optionally from epoch)", \
+	"mgr", "r", "cli,rest")


### PR DESCRIPTION
Sometimes it takes more information about mgr,
such as epoch and active_addr, so add mgr dump
to show those info.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>