### PR TITLE
rgw: fix bug: delete too many files pre time when bucket check && Optimize the func named check_bad_index_multipart

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1310,13 +1310,6 @@ int RGWBucketAdminOp::check_index(RGWRados *store, RGWBucketAdminOpState& op_sta
   Formatter *formatter = flusher.get_formatter();
   flusher.start(0);
 
-  ret = bucket.check_bad_index_multipart(op_state, objs_to_unlink);
-  if (ret < 0)
-    return ret;
-
-  dump_mulipart_index_results(objs_to_unlink, formatter);
-  flusher.flush();
-
   ret = bucket.check_object_index(op_state, flusher);
   if (ret < 0)
     return ret;
@@ -1326,6 +1319,13 @@ int RGWBucketAdminOp::check_index(RGWRados *store, RGWBucketAdminOpState& op_sta
     return ret;
 
   dump_index_check(existing_stats, calculated_stats, formatter);
+  flusher.flush();
+
+  ret = bucket.check_bad_index_multipart(op_state, objs_to_unlink);
+  if (ret < 0)
+    return ret;
+
+  dump_mulipart_index_results(objs_to_unlink, formatter);
   flusher.flush();
 
   return 0;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -12257,23 +12257,42 @@ int RGWRados::remove_objs_from_index(RGWBucketInfo& bucket_info, list<rgw_obj_in
   int r = open_bucket_index(bucket_info, index_ctx, dir_oid);
   if (r < 0)
     return r;
-
-  bufferlist updates;
-
-  for (auto iter = oid_list.begin(); iter != oid_list.end(); ++iter) {
-    rgw_bucket_dir_entry entry;
-    entry.key = *iter;
-    dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
-    entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
-    updates.append(CEPH_RGW_REMOVE | suggest_flag);
-    ::encode(entry, updates);
+  {
+    unsigned int skip = 0;
+    int cnt = 1000;
+    do{
+      // if the count of files ,need to be deleted, is too many.
+      // Objecter will return with -90(msg is too long)
+      // so we should send 1000 files one time
+      dout(0) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " objs=" << oid_list.size() << " " << skip << "/" << cnt<< dendl;        
+      bufferlist updates;
+      list<rgw_obj_index_key>::iterator begin = oid_list.begin();
+      if (oid_list.size() > skip ){
+	advance(begin, skip);
+      }
+      list<rgw_obj_index_key>::iterator end = oid_list.begin();
+      if (cnt > 0 && oid_list.size() > skip + cnt) {
+	advance(end, skip + cnt);
+      }else
+	end = oid_list.end();
+      for (auto iter = begin; iter != end; ++iter) {
+	rgw_bucket_dir_entry entry;
+	entry.key = *iter;
+	dout(2) << "RGWRados::remove_objs_from_index bucket=" << bucket_info.bucket << " obj=" << entry.key.name << ":" << entry.key.instance << dendl;
+	entry.ver.epoch = (uint64_t)-1; // ULLONG_MAX, needed to that objclass doesn't skip out request
+	updates.append(CEPH_RGW_REMOVE | suggest_flag);
+	::encode(entry, updates);
+      }
+      
+      bufferlist out;
+      
+      r = index_ctx.exec(dir_oid, RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates, out);
+      if(r < 0)
+	return r;
+      skip += cnt;
+    }while(cnt > 0 && skip < oid_list.size());
   }
-
-  bufferlist out;
-
-  r = index_ctx.exec(dir_oid, RGW_CLASS, RGW_DIR_SUGGEST_CHANGES, updates, out);
-
-  return r;
+  return 0;
 }
 
 int RGWRados::check_disk_state(librados::IoCtx io_ctx,


### PR DESCRIPTION
1 check_bad_index_multipart assume that all of objs is multipart, we perfrom this step after check if the obj is exist to reduce the msg.
2 fix bug : in the case,  we remove a lot of objs at a time, we will get a errno, -90 (mes is too long),so we  will remove 1000 files per time