### PR TITLE
rgw_rados: create sync module instances only if run_sync_thread is set

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4029,10 +4029,12 @@ int RGWRados::init_complete()
 
   zone_short_id = current_period.get_map().get_zone_short_id(zone_params.get_id());
 
-  ret = sync_modules_manager->create_instance(cct, zone_public_config.tier_type, zone_params.tier_config, &sync_module);
-  if (ret < 0) {
-    lderr(cct) << "ERROR: failed to init sync module instance, ret=" << ret << dendl;
-    return ret;
+  if (run_sync_thread) {
+    ret = sync_modules_manager->create_instance(cct, zone_public_config.tier_type, zone_params.tier_config, &sync_module);
+    if (ret < 0) {
+      lderr(cct) << "ERROR: failed to init sync module instance, ret=" << ret << dendl;
+      return ret;
+    }
   }
 
   writeable_zone = (zone_public_config.tier_type.empty() || zone_public_config.tier_type == "rgw");


### PR DESCRIPTION
This allows for radosgw-admin to run even if there was a
misconfiguration in setting tier types which would otherwise make it
difficult to revert an invalid tier type setting. Since sync modules are
necessary only for rgw and not for the admin itself, this allows for
invalid tier configurations to be corrected as rgw-admin wouldn't fail

Fixes: http://tracker.ceph.com/issues/19830