### PR TITLE
pybind/mgr/rest: completely terminate cherrypy in shutdown

### DIFF
--- a/src/pybind/mgr/rest/module.py
+++ b/src/pybind/mgr/rest/module.py
@@ -156,7 +156,7 @@ class Module(MgrModule):
         return [self._auth_cls()]
 
     def shutdown(self):
-        cherrypy.engine.stop()
+        cherrypy.engine.exit()
 
     def serve(self):
         self.keys = self._load_keys()


### PR DESCRIPTION
cherrypy.engine.stop() doesn't actually completely kill cherrypy,
which means cherrypy.engine.block() never returns, so this module's
thread never completes cleanly.

Signed-off-by: Tim Serong <tserong@suse.com>