### PR TITLE
rgw: migrate atomic_t to std::atomic<>

### DIFF
--- a/src/rgw/rgw_loadgen_process.cc
+++ b/src/rgw/rgw_loadgen_process.cc
@@ -39,7 +39,7 @@ void RGWLoadGenProcess::run()
 
   vector<string> buckets(num_buckets);
 
-  std::atomic<long int> failed = { 0 };
+  std::atomic<bool> failed = { false };
 
   for (i = 0; i < num_buckets; i++) {
     buckets[i] = "/loadgen";
@@ -104,7 +104,7 @@ done:
 
 void RGWLoadGenProcess::gen_request(const string& method,
 				    const string& resource,
-				    int content_length, std::atomic<long int>* fail_flag)
+				    int content_length, std::atomic<bool>* fail_flag)
 {
   RGWLoadGenRequest* req =
     new RGWLoadGenRequest(store->get_new_req_id(), method, resource,

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -4,11 +4,11 @@
 #ifndef CEPH_OBJEXP_H
 #define CEPH_OBJEXP_H
 
-#include <errno.h>
-#include <iostream>
-#include <sstream>
-#include <string>
 #include <atomic>
+#include <string>
+#include <cerrno>
+#include <sstream>
+#include <iostream>
 
 #include "auth/Crypto.h"
 
@@ -37,8 +37,6 @@
 #include "rgw_formats.h"
 #include "rgw_usage.h"
 #include "rgw_replica_log.h"
-
-#include <atomic>
 
 class RGWObjectExpirer {
 protected:

--- a/src/rgw/rgw_process.h
+++ b/src/rgw/rgw_process.h
@@ -184,7 +184,7 @@ public:
   void checkpoint();
   void handle_request(RGWRequest* req) override;
   void gen_request(const string& method, const string& resource,
-		  int content_length, std::atomic<int64_t>* fail_flag);
+		  int content_length, std::atomic<bool>* fail_flag);
 
   void set_access_key(RGWAccessKey& key) { access_key = key; }
 };

--- a/src/rgw/rgw_request.h
+++ b/src/rgw/rgw_request.h
@@ -59,10 +59,10 @@ struct RGWLoadGenRequest : public RGWRequest {
 	string method;
 	string resource;
 	int content_length;
-	std::atomic<int64_t>* fail_flag = nullptr;
+	std::atomic<bool>* fail_flag = nullptr;
 
 RGWLoadGenRequest(uint64_t req_id, const string& _m, const  string& _r, int _cl,
-		std::atomic<int64_t> *ff)
+		std::atomic<bool> *ff)
 	: RGWRequest(req_id), method(_m), resource(_r), content_length(_cl),
 		fail_flag(ff) {}
 };


### PR DESCRIPTION
Signed-off-by: Jesse Williamson <jwilliamson@suse.de>