### PR TITLE
common: Remove redundant includes

### DIFF
--- a/src/ceph_ver.c
+++ b/src/ceph_ver.c
@@ -1,5 +1,4 @@
 
-#include "acconfig.h"
 #include "ceph_ver.h"
 
 #define CONCAT_VER_SYMBOL(x) ceph_ver__##x

--- a/src/common/BackTrace.cc
+++ b/src/common/BackTrace.cc
@@ -7,7 +7,6 @@
 #include "BackTrace.h"
 
 #include "common/version.h"
-#include "acconfig.h"
 
 #define _STR(x) #x
 #define STRINGIFY(x) _STR(x)

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -1,7 +1,7 @@
 
 #include <syslog.h>
 
-#include <boost/algorithm/string.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include "LogEntry.h"
 #include "Formatter.h"

--- a/src/common/PrebufferedStreambuf.h
+++ b/src/common/PrebufferedStreambuf.h
@@ -1,7 +1,6 @@
 #ifndef CEPH_COMMON_PREBUFFEREDSTREAMBUF_H
 #define CEPH_COMMON_PREBUFFEREDSTREAMBUF_H
 
-#include <iosfwd>
 #include <string>
 #include <streambuf>
 

--- a/src/common/bloom_filter.cc
+++ b/src/common/bloom_filter.cc
@@ -1,8 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "include/types.h"
 #include "common/bloom_filter.hpp"
+#include "common/Formatter.h"
+#include "include/buffer.h"
 
 MEMPOOL_DEFINE_FACTORY(unsigned char, byte, bloom_filter);
 
@@ -66,7 +67,7 @@ void bloom_filter::dump(Formatter *f) const
   f->close_section();
 }
 
-void bloom_filter::generate_test_instances(list<bloom_filter*>& ls)
+void bloom_filter::generate_test_instances(std::list<bloom_filter*>& ls)
 {
   ls.push_back(new bloom_filter(10, .5, 1));
   ls.push_back(new bloom_filter(10, .5, 1));
@@ -88,7 +89,7 @@ void compressible_bloom_filter::encode(bufferlist& bl) const
 
   uint32_t s = size_list.size();
   ::encode(s, bl);
-  for (vector<size_t>::const_iterator p = size_list.begin();
+  for (std::vector<size_t>::const_iterator p = size_list.begin();
        p != size_list.end(); ++p)
     ::encode((uint64_t)*p, bl);
 
@@ -117,13 +118,13 @@ void compressible_bloom_filter::dump(Formatter *f) const
   bloom_filter::dump(f);
 
   f->open_array_section("table_sizes");
-  for (vector<size_t>::const_iterator p = size_list.begin();
+  for (std::vector<size_t>::const_iterator p = size_list.begin();
        p != size_list.end(); ++p)
     f->dump_unsigned("size", (uint64_t)*p);
   f->close_section();
 }
 
-void compressible_bloom_filter::generate_test_instances(list<compressible_bloom_filter*>& ls)
+void compressible_bloom_filter::generate_test_instances(std::list<compressible_bloom_filter*>& ls)
 {
   ls.push_back(new compressible_bloom_filter(10, .5, 1));
   ls.push_back(new compressible_bloom_filter(10, .5, 1));

--- a/src/common/bloom_filter.hpp
+++ b/src/common/bloom_filter.hpp
@@ -32,7 +32,6 @@
 
 #include "include/mempool.h"
 #include "include/encoding.h"
-#include "common/Formatter.h"
 
 static const std::size_t bits_per_char = 0x08;    // 8 bits in 1 char(unsigned)
 static const unsigned char bit_mask[bits_per_char] = {

--- a/src/common/io_priority.cc
+++ b/src/common/io_priority.cc
@@ -12,7 +12,6 @@
  *
  */
 
-#include <sys/types.h>
 #include <unistd.h>
 #ifdef __linux__
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
@@ -20,7 +19,6 @@
 #include <algorithm>
 #include <errno.h>
 
-#include "common/errno.h"
 #include "io_priority.h"
 
 pid_t ceph_gettid(void)

--- a/src/common/perf_histogram.h
+++ b/src/common/perf_histogram.h
@@ -17,7 +17,6 @@
 
 #include "common/Formatter.h"
 #include "include/atomic.h"
-#include "include/int_types.h"
 
 #include <array>
 #include <memory>

--- a/src/common/sctp_crc32.c
+++ b/src/common/sctp_crc32.c
@@ -43,8 +43,6 @@ __FBSDID("$FreeBSD: src/sys/netinet/sctp_crc32.c,v 1.8 2007/05/08 17:01:10 rrs E
 
 #include <stdint.h>
 
-#include "include/byteorder.h"
-
 #ifndef SCTP_USE_ADLER32
 
 

--- a/src/common/utf8.c
+++ b/src/common/utf8.c
@@ -13,7 +13,6 @@
  */
 #include "common/utf8.h"
 
-#include <stdio.h>
 #include <string.h>
 
 static int high_bits_set(int c)

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -14,19 +14,15 @@
 
 #ifndef _CEPH_INCLUDE_MEMPOOL_H
 #define _CEPH_INCLUDE_MEMPOOL_H
-#include <iostream>
-#include <fstream>
 
 #include <cstddef>
 #include <map>
 #include <unordered_map>
 #include <set>
 #include <vector>
-#include <assert.h>
 #include <list>
 #include <mutex>
 #include <atomic>
-#include <climits>
 #include <typeinfo>
 
 #include <common/Formatter.h>

--- a/src/mount/mount.ceph.c
+++ b/src/mount/mount.ceph.c
@@ -3,8 +3,6 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <sys/mount.h>
-#include <sys/types.h>
-#include <sys/wait.h>
 
 #include "common/module.h"
 #include "common/secret.h"

--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 
 #include <iostream>
+#include <fstream>
 #include <boost/regex.hpp>
 
 #include "mon/MonClient.h"


### PR DESCRIPTION
This is the first of many PRs for this. Reducing the amount of redundant includes should help to improve compilation times and reduce the potential for confusion. The result should be a cleaner codebase. 


Fixes: http://tracker.ceph.com/issues/19883 (Partially)

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>