### PR TITLE
libradosstriper: do not assign garbage to returned value

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -1169,10 +1169,13 @@ int libradosstriper::RadosStriperImpl::internal_get_layout_and_size(
   // deal with size
   size_t ssize;
   rc = extract_sizet_attr(attrs, XATTR_SIZE, &ssize);
+  if (rc) {
+    return rc;
+  }
   *size = ssize;
   // make valgrind happy by setting unused fl_pg_pool
   layout->fl_pg_pool = 0;
-  return rc;
+  return 0;
 }
 
 int libradosstriper::RadosStriperImpl::openStripedObjectForRead(

--- a/src/test/messenger/CMakeLists.txt
+++ b/src/test/messenger/CMakeLists.txt
@@ -3,7 +3,7 @@ add_executable(simple_server
   simple_dispatcher.cc
   )
 target_link_libraries(simple_server
-  os global ceph-common
+  global ceph-common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -13,7 +13,7 @@ add_executable(simple_client
   simple_dispatcher.cc
   )
 target_link_libraries(simple_client
-  os global ceph-common
+  global ceph-common
   ${EXTRALIBS}
   ${CMAKE_DL_LIBS}
   )
@@ -24,7 +24,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_server
-    os global ceph-common
+    global ceph-common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}
@@ -35,7 +35,7 @@ if(HAVE_XIO)
     xio_dispatcher.cc
     )
   target_link_libraries(xio_client
-    os global ceph-common
+    global ceph-common
     ${XIO_LIBRARY} pthread rt
     ${EXTRALIBS}
     ${CMAKE_DL_LIBS}

--- a/src/test/messenger/message_helper.h
+++ b/src/test/messenger/message_helper.h
@@ -107,11 +107,12 @@ static inline Message* new_simple_ping_with_data(const char *tag,
   for (uint32_t i = 0; i < nfrags; ++i) {
     if (do_page_alignment) {
       if (posix_memalign(&p, pagesize, segsize))
-	p = NULL;
+	p = nullptr;
     } else {
 	p = malloc(segsize);
     }
-
+    if (!p)
+      throw std::bad_alloc();
     strcpy((char*) p, tag);
     uint32_t* t = (uint32_t* ) (((char*) p) + segsize - 32);
     *t = counter;


### PR DESCRIPTION
kill clang static analyzer warnings.