### PR TITLE
rgw: when create_bucket use the same num_shards with info.num_shards

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5452,7 +5452,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
       info.quota = *pquota_info;
     }
 
-    int r = init_bucket_index(info, bucket_index_max_shards);
+    int r = init_bucket_index(info, info.num_shards);
     if (r < 0) {
       return r;
     }


### PR DESCRIPTION
pr #14388 only fix the num_shards in BucketInfo, "init_bucket_index" function still use local num_shards

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>