### PR TITLE
build/ops: rpm: fix python-Sphinx package name for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -123,7 +123,6 @@ BuildRequires:	python-devel
 BuildRequires:	python-nose
 BuildRequires:	python-prettytable
 BuildRequires:	python-requests
-BuildRequires:	python-sphinx
 BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel
 BuildRequires:	udev
@@ -153,6 +152,7 @@ BuildRequires:  libopenssl-devel
 BuildRequires:  lsb-release
 BuildRequires:  openldap2-devel
 BuildRequires:	python-Cython
+BuildRequires:	python-Sphinx
 %endif
 %if 0%{?fedora} || 0%{?rhel} 
 Requires:	systemd
@@ -164,6 +164,7 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
+BuildRequires:	python-sphinx
 %endif
 # python34-... for RHEL, python3-... for all other supported distros
 %if 0%{?rhel}


### PR DESCRIPTION
This commit moves "BuildRequires: python-sphinx" down to the RH/CentOS/Fedora
distro conditional and adds a "BuildRequires: python-Sphinx" to the SUSE
conditional.

Signed-off-by: Jan Matejek <jmatejek@suse.com>
Signed-off-by: Nathan Cutler <ncutler@suse.com>