### PR TITLE
common/bit_vector: utilize deep-copy during data decode

### DIFF
--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -231,8 +231,11 @@ void BitVector<_b>::decode_data(bufferlist::iterator& it, uint64_t byte_offset) 
   while (byte_offset < end_offset) {
     uint64_t len = MIN(BLOCK_SIZE, end_offset - byte_offset);
 
+    bufferptr ptr;
+    it.copy_deep(len, ptr);
+
     bufferlist bit;
-    it.copy(len, bit);
+    bit.append(ptr);
     if (m_crc_enabled &&
 	m_data_crcs[byte_offset / BLOCK_SIZE] != bit.crc32c(0)) {
       throw buffer::malformed_input("invalid data block CRC");


### PR DESCRIPTION
BlueStore utilizes an in-memory cache of bufferlists. If the bit vector
directly manipulates the shallow-copied bufferlist, it can corrupt
the CRC.

Fixes: http://tracker.ceph.com/issues/19863
Signed-off-by: Jason Dillaman <dillaman@redhat.com>