### PR TITLE
pybind: fix open flags calculation

### DIFF
--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -659,16 +659,26 @@ cdef class LibCephFS(object):
             if flags == '':
                 cephfs_flags = os.O_RDONLY
             else:
+                access_flags = 0;
                 for c in flags:
                     if c == 'r':
-                        cephfs_flags |= os.O_RDONLY
+                        access_flags = 1;
                     elif c == 'w':
-                        cephfs_flags |= os.O_WRONLY | os.O_TRUNC | os.O_CREAT
-                    elif c == '+':
-                        cephfs_flags |= os.O_RDWR
+                        access_flags = 2;
+                        cephfs_flags |= os.O_TRUNC | os.O_CREAT
+                    elif access_flags > 0 and c == '+':
+                        access_flags = 3;
                     else:
                         raise OperationNotSupported(
                             "open flags doesn't support %s" % c)
+
+                if access_flags == 1:
+                    cephfs_flags |= os.O_RDONLY;
+                elif access_flags == 2:
+                    cephfs_flags |= os.O_WRONLY;
+                else:
+                    cephfs_flags |= os.O_RDWR;
+
         elif isinstance(flags, int):
             cephfs_flags = flags
         else:

--- a/src/pybind/cephfs/cephfs.pyx
+++ b/src/pybind/cephfs/cephfs.pyx
@@ -356,7 +356,8 @@ cdef class LibCephFS(object):
         self.state = "uninitialized"
         if rados_inst is not None:
             if auth_id is not None or conffile is not None or conf is not None:
-                raise InvalidValue("May not pass RADOS instance as well as other configuration")
+                raise make_ex(errno.EINVAL,
+                              "May not pass RADOS instance as well as other configuration")
 
             self.create_with_rados(rados_inst)
         else:
@@ -669,8 +670,8 @@ cdef class LibCephFS(object):
                     elif access_flags > 0 and c == '+':
                         access_flags = 3;
                     else:
-                        raise OperationNotSupported(
-                            "open flags doesn't support %s" % c)
+                        raise make_ex(errno.EOPNOTSUPP,
+                                      "open flags doesn't support %s" % c)
 
                 if access_flags == 1:
                     cephfs_flags |= os.O_RDONLY;


### PR DESCRIPTION
(O_WRONLY | O_RDWR) is not vaiid open flags

Fixes: http://tracker.ceph.com/issues/19890
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>