### PR TITLE
DNM: mon,mgr: extricate the PGMap from the monitor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -444,6 +444,7 @@ set(libcommon_files
   msg/simple/Accepter.cc
   msg/DispatchQueue.cc
   msg/Message.cc
+  mon/PGMap.cc
   osd/ECMsgTypes.cc
   osd/HitSet.cc
   common/RefCountedObj.cc

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1675,8 +1675,8 @@ OPTION(rgw_swift_versioning_enabled, OPT_BOOL, false) // whether swift object ve
 OPTION(mgr_module_path, OPT_STR, CEPH_PKGLIBDIR "/mgr") // where to load python modules from
 OPTION(mgr_modules, OPT_STR, "rest")  // Which modules to load
 OPTION(mgr_data, OPT_STR, "/var/lib/ceph/mgr/$cluster-$id") // where to find keyring etc
-OPTION(mgr_beacon_period, OPT_INT, 5)  // How frequently to send beacon
-OPTION(mgr_stats_period, OPT_INT, 5) // How frequently to send stats
+OPTION(mgr_tick_period, OPT_INT, 5)  // How frequently to tick
+OPTION(mgr_stats_period, OPT_INT, 5) // How frequently clients send stats
 OPTION(mgr_client_bytes, OPT_U64, 128*1048576) // bytes from clients
 OPTION(mgr_client_messages, OPT_U64, 512)      // messages from clients
 OPTION(mgr_osd_bytes, OPT_U64, 512*1048576)   // bytes from osds

--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -33,7 +33,7 @@ private:
   ~MMonMgrReport() override {}
 
 public:
-
+  bool needs_send = false;
   const char *get_type_name() const override { return "monmgrreport"; }
 
   void print(ostream& out) const override {

--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -17,6 +17,7 @@
 
 #include "messages/PaxosServiceMessage.h"
 #include "include/types.h"
+#include "mon/PGMap.h"
 
 
 class MMonMgrReport : public PaxosServiceMessage {
@@ -34,6 +35,7 @@ private:
 
 public:
   bool needs_send = false;
+  PGMap pg_map;
   const char *get_type_name() const override { return "monmgrreport"; }
 
   void print(ostream& out) const override {
@@ -42,10 +44,14 @@ public:
 
   void encode_payload(uint64_t features) override {
     paxos_encode();
+    bufferlist pmb;
+    pg_map.encode(pmb);
+    payload.append(pmb);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
     paxos_decode(p);
+    ::decode(pg_map, p);
   }
 };
 

--- a/src/messages/MMonMgrReport.h
+++ b/src/messages/MMonMgrReport.h
@@ -1,0 +1,52 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Greg Farnum/Red Hat <gfarnum@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+#ifndef CEPH_MMONMGRREPORT_H
+#define CEPH_MMONMGRREPORT_H
+
+#include "messages/PaxosServiceMessage.h"
+#include "include/types.h"
+
+
+class MMonMgrReport : public PaxosServiceMessage {
+
+  static const int HEAD_VERSION = 1;
+  static const int COMPAT_VERSION = 1;
+
+public:
+  MMonMgrReport()
+    : PaxosServiceMessage(MSG_MON_MGR_REPORT, 0, HEAD_VERSION, COMPAT_VERSION)
+  {}
+
+private:
+  ~MMonMgrReport() override {}
+
+public:
+
+  const char *get_type_name() const override { return "monmgrreport"; }
+
+  void print(ostream& out) const override {
+    out << get_type_name();
+  }
+
+  void encode_payload(uint64_t features) override {
+    paxos_encode();
+  }
+  void decode_payload() override {
+    bufferlist::iterator p = payload.begin();
+    paxos_decode(p);
+  }
+};
+
+#endif

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -117,4 +117,6 @@ void ClusterState::notify_osdmap(const OSDMap &osd_map)
 void ClusterState::tick(MMonMgrReport *m)
 {
   dout(0) << __func__ << dendl;
+  m->pg_map = pg_map;
+  m->needs_send = true;
 }

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -12,6 +12,7 @@
  */
 
 #include "messages/MMgrDigest.h"
+#include "messages/MMonMgrReport.h"
 #include "messages/MPGStats.h"
 
 #include "mgr/ClusterState.h"
@@ -113,3 +114,7 @@ void ClusterState::notify_osdmap(const OSDMap &osd_map)
   // while the full-blown PGMap lives only here.
 }
 
+void ClusterState::tick(MMonMgrReport *m)
+{
+  dout(0) << __func__ << dendl;
+}

--- a/src/mgr/ClusterState.h
+++ b/src/mgr/ClusterState.h
@@ -22,6 +22,7 @@
 #include "mon/PGMap.h"
 
 class MMgrDigest;
+class MMonMgrReport;
 class MPGStats;
 
 
@@ -56,6 +57,8 @@ public:
   void set_fsmap(FSMap const &new_fsmap);
 
   void notify_osdmap(const OSDMap &osd_map);
+
+  void tick(MMonMgrReport *m);
 
   bool have_fsmap() const {
     Mutex::Locker l(lock);

--- a/src/mgr/DaemonServer.h
+++ b/src/mgr/DaemonServer.h
@@ -32,6 +32,7 @@
 
 class MMgrReport;
 class MMgrOpen;
+class MMonMgrReport;
 class MCommand;
 struct MgrCommand;
 
@@ -111,6 +112,7 @@ public:
   bool handle_open(MMgrOpen *m);
   bool handle_report(MMgrReport *m);
   bool handle_command(MCommand *m);
+  void tick(MMonMgrReport *m) {}
 };
 
 #endif

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -26,6 +26,7 @@
 #include "DaemonServer.h"
 #include "messages/MMgrBeacon.h"
 #include "messages/MMgrDigest.h"
+#include "messages/MMonMgrReport.h"
 #include "messages/MCommand.h"
 #include "messages/MCommandReply.h"
 #include "messages/MLog.h"
@@ -570,3 +571,14 @@ void Mgr::handle_mgr_digest(MMgrDigest* m)
   m->put();
 }
 
+void Mgr::tick()
+{
+  dout(0) << __func__ << dendl;
+  MMonMgrReport *m = new MMonMgrReport();
+  cluster_state.tick(m);
+  server.tick(m);
+  // TODO? We currently do not notify the PyModules
+  if (m->needs_send) {
+    monc->send_mon_message(m);
+  }
+}

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -463,16 +463,6 @@ bool Mgr::ms_dispatch(Message *m)
       handle_mgr_digest(static_cast<MMgrDigest*>(m));
       break;
     case CEPH_MSG_MON_MAP:
-      // FIXME: we probably never get called here because MonClient
-      // has consumed the message.  For consuming OSDMap we need
-      // to be the tail dispatcher, but to see MonMap we would
-      // need to be at the head.
-      // Result is that ClusterState has access to monmap (it reads
-      // from monclient anyway), but we don't see notifications.  Hook
-      // into MonClient to get notifications instead of messing
-      // with message delivery to achieve it?
-      ceph_abort();
-
       py_modules.notify_all("mon_map", "");
       m->put();
       break;

--- a/src/mgr/Mgr.h
+++ b/src/mgr/Mgr.h
@@ -84,6 +84,8 @@ public:
 
   bool ms_dispatch(Message *m);
 
+  void tick();
+
   void background_init();
   void shutdown();
 };

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -164,7 +164,12 @@ void MgrStandby::send_beacon()
 
 void MgrStandby::tick()
 {
+  dout(0) << __func__ << dendl;
   send_beacon();
+
+  if (active_mgr) {
+    active_mgr->tick();
+  }
 
   timer.add_event_after(g_conf->mgr_tick_period, new FunctionContext(
         [this](int r){

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -139,7 +139,7 @@ int MgrStandby::init()
   objecter->start();
 
   timer.init();
-  send_beacon();
+  tick();
 
   dout(4) << "Complete." << dendl;
   return 0;
@@ -160,9 +160,15 @@ void MgrStandby::send_beacon()
                                  available);
                                  
   monc->send_mon_message(m);
-  timer.add_event_after(g_conf->mgr_beacon_period, new FunctionContext(
+}
+
+void MgrStandby::tick()
+{
+  send_beacon();
+
+  timer.add_event_after(g_conf->mgr_tick_period, new FunctionContext(
         [this](int r){
-          send_beacon();
+          tick();
         }
   )); 
 }

--- a/src/mgr/MgrStandby.h
+++ b/src/mgr/MgrStandby.h
@@ -54,6 +54,7 @@ protected:
 
   void handle_mgr_map(MMgrMap *m);
   void _update_log_config();
+  void send_beacon();
 
 public:
   MgrStandby();
@@ -71,7 +72,7 @@ public:
   void usage() {}
   int main(vector<const char *> args);
   void handle_signal(int signum);
-  void send_beacon();
+  void tick();
 };
 
 #endif

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -102,7 +102,7 @@ class FsNewHandler : public FileSystemCommandHandler
 
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);
-    int64_t metadata_num_objects = mon->pgmon()->pg_map.pg_pool_sum[metadata].stats.sum.num_objects;
+    int64_t metadata_num_objects = mon->pgservice.get_pool_stat(metadata).stats.sum.num_objects;
     if (force != "--force" && metadata_num_objects > 0) {
       ss << "pool '" << metadata_name
 	 << "' already contains some objects. Use an empty pool instead.";

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -102,7 +102,7 @@ class FsNewHandler : public FileSystemCommandHandler
 
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);
-    const pool_stat_t *stat = mon->pgservice.get_pool_stat(metadata);
+    const pool_stat_t *stat = mon->pgservice->get_pool_stat(metadata);
     if (stat) {
       int64_t metadata_num_objects = stat->stats.sum.num_objects;
       if (force != "--force" && metadata_num_objects > 0) {

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -102,11 +102,14 @@ class FsNewHandler : public FileSystemCommandHandler
 
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);
-    int64_t metadata_num_objects = mon->pgservice.get_pool_stat(metadata).stats.sum.num_objects;
-    if (force != "--force" && metadata_num_objects > 0) {
-      ss << "pool '" << metadata_name
-	 << "' already contains some objects. Use an empty pool instead.";
-      return -EINVAL;
+    const pool_stat_t *stat = mon->pgservice.get_pool_stat(metadata);
+    if (stat) {
+      int64_t metadata_num_objects = stat->stats.sum.num_objects;
+      if (force != "--force" && metadata_num_objects > 0) {
+	ss << "pool '" << metadata_name
+	   << "' already contains some objects. Use an empty pool instead.";
+	return -EINVAL;
+      }
     }
 
     string data_name;

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -250,7 +250,7 @@ bool MgrMonitor::preprocess_report(MonOpRequestRef op) { return false; }
 bool MgrMonitor::prepare_report(MonOpRequestRef op)
 {
   MMonMgrReport *m = static_cast<MMonMgrReport*>(op->get_req());
-  mon->pgservice.reset(m->pg_map);
+  mon->pgservice->reset(m->pg_map);
   return true;
 }
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -250,7 +250,7 @@ bool MgrMonitor::preprocess_report(MonOpRequestRef op) { return false; }
 bool MgrMonitor::prepare_report(MonOpRequestRef op)
 {
   MMonMgrReport *m = static_cast<MMonMgrReport*>(op->get_req());
-  pg_map = m->pg_map;
+  mon->pgservice.reset(m->pg_map);
   return true;
 }
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -250,6 +250,7 @@ bool MgrMonitor::preprocess_report(MonOpRequestRef op) { return false; }
 bool MgrMonitor::prepare_report(MonOpRequestRef op)
 {
   MMonMgrReport *m = static_cast<MMonMgrReport*>(op->get_req());
+  pg_map = m->pg_map;
   return true;
 }
 

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -34,6 +34,102 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon,
 		<< ").mgr e" << mgrmap.get_epoch() << " ";
 }
 
+
+class MgrPGStatService : public PGMap, public PGStatService {
+  PGMap& parent;
+public:
+  MgrPGStatService() : PGMap(), PGStatService(),
+		    parent(*static_cast<PGMap*>(this)) {}
+  MgrPGStatService(const PGMap& o) : PGMap(o), PGStatService(),
+				  parent(*static_cast<PGMap*>(this)) {}
+  void reset(const PGMap& o) {
+    parent = o;
+  }
+
+  const pool_stat_t* get_pool_stat(int poolid) const {
+    auto i = parent.pg_pool_sum.find(poolid);
+    if (i != parent.pg_pool_sum.end()) {
+      return &i->second;
+    }
+    return NULL;
+  }
+  
+  const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
+  const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
+
+  const osd_stat_t *get_osd_stat(int osd) const {
+    auto i = parent.osd_stat.find(osd);
+    if (i == parent.osd_stat.end()) {
+      return NULL;
+    }
+    return &i->second;
+  }
+  const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const {
+    return &parent.osd_stat;
+  }
+  const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const {
+    return &parent.pg_stat;
+  }
+  float get_full_ratio() const { return parent.full_ratio; }
+  float get_nearfull_ratio() const { return parent.nearfull_ratio; }
+
+  bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
+  bool is_creating_pg(pg_t pgid) const { return parent.creating_pgs.count(pgid); }
+  virtual void maybe_add_creating_pgs(epoch_t scan_epoch,
+				      creating_pgs_t *pending_creates) const {
+    if (parent.last_pg_scan >= scan_epoch) {
+      for (auto& pgid : parent.creating_pgs) {
+      auto st = parent.pg_stat.find(pgid);
+      assert(st != parent.pg_stat.end());
+      auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
+      // no need to add the pg, if it already exists in creating_pgs
+      pending_creatings->pgs.emplace(pgid, created);
+      }
+    }
+  }
+  epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
+
+  bool have_full_osds() const { return !parent.full_osds.empty(); }
+  bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
+
+  size_t get_num_pg_by_osd(int osd) const { return parent.get_num_pg_by_osd(osd); }
+
+  void print_summary(Formatter *f, ostream *out) const { parent.print_summary(f, out); }
+  void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const {
+    parent.dump_fs_stats(ss, f, verbose);
+  }
+  void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
+		       bool verbose) const {
+    parent.dump_pool_stats(osdm, ss, f, verbose);
+  }
+
+  int process_pg_command(const string& prefix,
+			 const map<string,cmd_vartype>& cmdmap,
+			 const OSDMap& osdmap,
+			 Formatter *f,
+			 stringstream *ss,
+			 bufferlist *odata) {
+    return process_pg_map_command(prefix, cmdmap, parent, osdmap, f, ss, odata);
+  }
+
+  int reweight_by_utilization(const OSDMap &osd_map,
+			      int oload,
+			      double max_changef,
+			      int max_osds,
+			      bool by_pg, const set<int64_t> *pools,
+			      bool no_increasing,
+			      mempool::osdmap::map<int32_t, uint32_t>* new_weights,
+			      std::stringstream *ss,
+			      std::string *out_str,
+			      Formatter *f) {
+    return reweight::by_utilization(osd_map, parent, oload, max_changef,
+				    max_osds, by_pg, pools, no_increasing,
+				    new_weights, ss, out_str, f);
+  }
+
+};
+
+
 void MgrMonitor::create_initial()
 {
 }
@@ -565,15 +661,15 @@ void MgrMonitor::on_shutdown()
   }
 }
 
-PGStatService *MgrMonitor::get_pg_stat_service()
-{
-  if (!pgservice) {
-    pgservice = new PGMapStatService();
-  }
-  return pgservice;
-}
-
 MgrMonitor::~MgrMonitor()
 {
   delete pgservice;
+}
+
+PGStatService *MgrMonitor::get_pg_stat_service()
+{
+  if (!pgservice) {
+    pgservice = new MgrPGStatService();
+  }
+  return pgservice;
 }

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -17,7 +17,7 @@
 #include "messages/MMonMgrReport.h"
 
 #include "PGMap.h"
-#include "PGMonitor.h"
+#include "PGStatService.h"
 #include "include/stringify.h"
 #include "mgr/MgrContext.h"
 #include "OSDMonitor.h"
@@ -250,7 +250,7 @@ bool MgrMonitor::preprocess_report(MonOpRequestRef op) { return false; }
 bool MgrMonitor::prepare_report(MonOpRequestRef op)
 {
   MMonMgrReport *m = static_cast<MMonMgrReport*>(op->get_req());
-  mon->pgservice->reset(m->pg_map);
+  pgservice->reset(m->pg_map);
   return true;
 }
 
@@ -565,3 +565,15 @@ void MgrMonitor::on_shutdown()
   }
 }
 
+PGStatService *MgrMonitor::get_pg_stat_service()
+{
+  if (!pgservice) {
+    pgservice = new PGMapStatService();
+  }
+  return pgservice;
+}
+
+MgrMonitor::~MgrMonitor()
+{
+  delete pgservice;
+}

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -83,7 +83,7 @@ public:
       assert(st != parent.pg_stat.end());
       auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
       // no need to add the pg, if it already exists in creating_pgs
-      pending_creatings->pgs.emplace(pgid, created);
+      pending_creates->pgs.emplace(pgid, created);
       }
     }
   }

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -14,6 +14,7 @@
 #include "messages/MMgrBeacon.h"
 #include "messages/MMgrMap.h"
 #include "messages/MMgrDigest.h"
+#include "messages/MMonMgrReport.h"
 
 #include "PGMap.h"
 #include "PGMonitor.h"
@@ -107,6 +108,8 @@ bool MgrMonitor::preprocess_query(MonOpRequestRef op)
       return preprocess_beacon(op);
     case MSG_MON_COMMAND:
       return preprocess_command(op);
+    case MSG_MON_MGR_REPORT:
+      return preprocess_report(op);
     default:
       mon->no_reply(op);
       derr << "Unhandled message type " << m->get_type() << dendl;
@@ -124,6 +127,9 @@ bool MgrMonitor::prepare_update(MonOpRequestRef op)
     case MSG_MON_COMMAND:
       return prepare_command(op);
 
+    case MSG_MON_MGR_REPORT:
+      return prepare_report(op);
+      
     default:
       mon->no_reply(op);
       derr << "Unhandled message type " << m->get_type() << dendl;
@@ -237,6 +243,14 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
   }
 
   return updated;
+}
+
+bool MgrMonitor::preprocess_report(MonOpRequestRef op) { return false; }
+
+bool MgrMonitor::prepare_report(MonOpRequestRef op)
+{
+  MMonMgrReport *m = static_cast<MMonMgrReport*>(op->get_req());
+  return true;
 }
 
 void MgrMonitor::check_subs()

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -15,6 +15,7 @@
 #include "include/Context.h"
 #include "MgrMap.h"
 #include "PaxosService.h"
+#include "PGMap.h"
 
 
 class MgrMonitor : public PaxosService
@@ -41,6 +42,7 @@ class MgrMonitor : public PaxosService
   bool check_caps(MonOpRequestRef op, const uuid_d& fsid);
 
 public:
+  PGMap pg_map;
   MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name), digest_callback(nullptr)
   {}

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -15,7 +15,6 @@
 #include "include/Context.h"
 #include "MgrMap.h"
 #include "PaxosService.h"
-#include "PGMap.h"
 
 
 class MgrMonitor : public PaxosService
@@ -42,7 +41,6 @@ class MgrMonitor : public PaxosService
   bool check_caps(MonOpRequestRef op, const uuid_d& fsid);
 
 public:
-  PGMap pg_map;
   MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name), digest_callback(nullptr)
   {}

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -19,6 +19,7 @@
 #include "PaxosService.h"
 
 class PGStatService;
+class MgrPGStatService;
 
 class MgrMonitor: public PaxosService
 {
@@ -27,7 +28,7 @@ class MgrMonitor: public PaxosService
 
   utime_t first_seen_inactive;
 
-  PGStatService *pgservice;
+  MgrPGStatService *pgservice;
   
   std::map<uint64_t, utime_t> last_beacon;
   

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -68,6 +68,9 @@ public:
   bool preprocess_beacon(MonOpRequestRef op);
   bool prepare_beacon(MonOpRequestRef op);
 
+  bool preprocess_report(MonOpRequestRef op);
+  bool prepare_report(MonOpRequestRef op);
+
   void check_sub(Subscription *sub);
   void check_subs();
   void send_digests();

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -11,21 +11,26 @@
  * Foundation.  See file COPYING.
  */
 
+#ifndef CEPH_MGRMONITOR_H
+#define CEPH_MGRMONITOR_H
 
 #include "include/Context.h"
 #include "MgrMap.h"
 #include "PaxosService.h"
 
+class PGStatService;
 
-class MgrMonitor : public PaxosService
+class MgrMonitor: public PaxosService
 {
   MgrMap map;
   MgrMap pending_map;
 
   utime_t first_seen_inactive;
 
+  PGStatService *pgservice;
+  
   std::map<uint64_t, utime_t> last_beacon;
-
+  
   /**
    * If a standby is available, make it active, given that
    * there is currently no active daemon.
@@ -42,8 +47,10 @@ class MgrMonitor : public PaxosService
 
 public:
   MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
-    : PaxosService(mn, p, service_name), digest_callback(nullptr)
+    : PaxosService(mn, p, service_name), pgservice(nullptr),
+      digest_callback(nullptr)
   {}
+  ~MgrMonitor() override;
 
   void init() override;
   void on_shutdown() override;
@@ -83,6 +90,9 @@ public:
 
   void print_summary(Formatter *f, std::ostream *ss) const;
 
+  PGStatService *get_pg_stat_service();
+
   friend class C_Updated;
 };
 
+#endif

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -48,7 +48,8 @@ MonClient::MonClient(CephContext *cct_) :
   Dispatcher(cct_),
   messenger(NULL),
   monc_lock("MonClient::monc_lock"),
-  timer(cct_, monc_lock), finisher(cct_),
+  timer(cct_, monc_lock),
+  finisher(cct_),
   initialized(false),
   no_keyring_disabled_cephx(false),
   log_client(NULL),
@@ -267,6 +268,11 @@ bool MonClient::ms_dispatch(Message *m)
   switch (m->get_type()) {
   case CEPH_MSG_MON_MAP:
     handle_monmap(static_cast<MMonMap*>(m));
+    if (passthrough_monmap) {
+      return false;
+    } else {
+      m->put();
+    }
     break;
   case CEPH_MSG_AUTH_REPLY:
     handle_auth(static_cast<MAuthReply*>(m));
@@ -311,6 +317,8 @@ void MonClient::flush_log()
   send_log();
 }
 
+/* Unlike all the other message-handling functions, we don't put away a reference
+* because we want to support MMonMap passthrough to other Dispatchers. */
 void MonClient::handle_monmap(MMonMap *m)
 {
   ldout(cct, 10) << __func__ << " " << *m << dendl;
@@ -337,8 +345,6 @@ void MonClient::handle_monmap(MMonMap *m)
 
   map_cond.Signal();
   want_monmap = false;
-
-  m->put();
 }
 
 // ----------------------

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -187,7 +187,8 @@ private:
   // monclient
   bool want_monmap;
   Cond map_cond;
-private:
+  bool passthrough_monmap = false;
+
   // authenticate
   std::unique_ptr<AuthClientHandler> auth;
   uint32_t want_keys = 0;
@@ -337,6 +338,21 @@ public:
   int build_initial_monmap();
   int get_monmap();
   int get_monmap_privately();
+  /**
+   * If you want to see MonMap messages, set this and
+   * the MonClient will tell the Messenger it hasn't
+   * dealt with it.
+   * Note that if you do this, *you* are of course responsible for
+   * putting the message reference!
+   */
+  void set_passthrough_monmap() {
+    Mutex::Locker l(monc_lock);
+    passthrough_monmap = true;
+  }
+  void unset_passthrough_monmap() {
+    Mutex::Locker l(monc_lock);
+    passthrough_monmap = false;
+  }
   /**
    * Ping monitor with ID @p mon_id and record the resulting
    * reply in @p result_reply.

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2562,7 +2562,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     osdmon()->osdmap.print_summary(f, cout);
     f->close_section();
     f->open_object_section("pgmap");
-    mgrmon()->pg_map.print_summary(f, NULL);
+    pgservice.print_summary(f, NULL);
     f->close_section();
     f->open_object_section("fsmap");
     mdsmon()->get_fsmap().print_summary(f, NULL);
@@ -2589,7 +2589,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     }
 
     osdmon()->osdmap.print_summary(NULL, ss);
-    mgrmon()->pg_map.print_summary(NULL, &ss);
+    pgservice.print_summary(NULL, &ss);
   }
 }
 
@@ -3054,10 +3054,10 @@ void Monitor::handle_command(MonOpRequestRef op)
       if (f)
         f->open_object_section("stats");
 
-      mgrmon()->pg_map.dump_fs_stats(&ds, f.get(), verbose);
+      pgservice.dump_fs_stats(&ds, f.get(), verbose);
       if (!f)
         ds << '\n';
-      mgrmon()->pg_map.dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
+      pgservice.dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
 
       if (f) {
         f->close_section();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3799,6 +3799,7 @@ void Monitor::dispatch_op(MonOpRequestRef op)
 
     // Mgrs
     case MSG_MGR_BEACON:
+    case MSG_MON_MGR_REPORT:
       paxos_service[PAXOS_MGR]->dispatch(op);
       break;
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -173,6 +173,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   leader_supported_mon_commands_size(0),
   mgr_messenger(mgr_m),
   mgr_client(cct_, mgr_m),
+  pgservice(new PGStatService),
   store(s),
   
   state(STATE_PROBING),
@@ -2562,7 +2563,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     osdmon()->osdmap.print_summary(f, cout);
     f->close_section();
     f->open_object_section("pgmap");
-    pgservice.print_summary(f, NULL);
+    pgservice->print_summary(f, NULL);
     f->close_section();
     f->open_object_section("fsmap");
     mdsmon()->get_fsmap().print_summary(f, NULL);
@@ -2589,7 +2590,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     }
 
     osdmon()->osdmap.print_summary(NULL, ss);
-    pgservice.print_summary(NULL, &ss);
+    pgservice->print_summary(NULL, &ss);
   }
 }
 
@@ -3054,10 +3055,10 @@ void Monitor::handle_command(MonOpRequestRef op)
       if (f)
         f->open_object_section("stats");
 
-      pgservice.dump_fs_stats(&ds, f.get(), verbose);
+      pgservice->dump_fs_stats(&ds, f.get(), verbose);
       if (!f)
         ds << '\n';
-      pgservice.dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
+      pgservice->dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
 
       if (f) {
         f->close_section();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -173,7 +173,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   leader_supported_mon_commands_size(0),
   mgr_messenger(mgr_m),
   mgr_client(cct_, mgr_m),
-  pgservice(new PGMapStatService),
+  pgservice(nullptr),
   store(s),
   
   state(STATE_PROBING),
@@ -241,6 +241,8 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   int cmdsize;
   get_locally_supported_monitor_commands(&cmds, &cmdsize);
   set_leader_supported_commands(cmds, cmdsize);
+
+  pgservice = mgrmon()->get_pg_stat_service();
 }
 
 PaxosService *Monitor::get_paxos_service_by_name(const string& name)

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2562,7 +2562,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     osdmon()->osdmap.print_summary(f, cout);
     f->close_section();
     f->open_object_section("pgmap");
-    pgmon()->pg_map.print_summary(f, NULL);
+    mgrmon()->pg_map.print_summary(f, NULL);
     f->close_section();
     f->open_object_section("fsmap");
     mdsmon()->get_fsmap().print_summary(f, NULL);
@@ -2589,7 +2589,7 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     }
 
     osdmon()->osdmap.print_summary(NULL, ss);
-    pgmon()->pg_map.print_summary(NULL, &ss);
+    mgrmon()->pg_map.print_summary(NULL, &ss);
   }
 }
 
@@ -3054,10 +3054,10 @@ void Monitor::handle_command(MonOpRequestRef op)
       if (f)
         f->open_object_section("stats");
 
-      pgmon()->pg_map.dump_fs_stats(&ds, f.get(), verbose);
+      mgrmon()->pg_map.dump_fs_stats(&ds, f.get(), verbose);
       if (!f)
         ds << '\n';
-      pgmon()->pg_map.dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
+      mgrmon()->pg_map.dump_pool_stats(osdmon()->osdmap, &ds, f.get(), verbose);
 
       if (f) {
         f->close_section();

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -173,7 +173,7 @@ Monitor::Monitor(CephContext* cct_, string nm, MonitorDBStore *s,
   leader_supported_mon_commands_size(0),
   mgr_messenger(mgr_m),
   mgr_client(cct_, mgr_m),
-  pgservice(new PGStatService),
+  pgservice(new PGMapStatService),
   store(s),
   
   state(STATE_PROBING),

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -162,7 +162,7 @@ public:
   MgrClient mgr_client;
   uint64_t mgr_proxy_bytes = 0;  // in-flight proxied mgr command message bytes
 
-  PGStatService pgservice;
+  PGStatService *pgservice;
 
 private:
   void new_tick();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -35,6 +35,7 @@
 #include "Elector.h"
 #include "Paxos.h"
 #include "Session.h"
+#include "PGStatService.h"
 
 #include "common/LogClient.h"
 #include "auth/cephx/CephxKeyServer.h"
@@ -160,6 +161,8 @@ public:
   Messenger *mgr_messenger;
   MgrClient mgr_client;
   uint64_t mgr_proxy_bytes = 0;  // in-flight proxied mgr command message bytes
+
+  PGStatService pgservice;
 
 private:
   void new_tick();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -544,10 +544,10 @@ public:
   typedef CrushTreeDumper::Dumper<F> Parent;
 
   OSDUtilizationDumper(const CrushWrapper *crush, const OSDMap *osdmap_,
-		       const PGMap *pgm_, bool tree_) :
+		       const PGStatService *pgs_, bool tree_) :
     Parent(crush),
     osdmap(osdmap_),
-    pgm(pgm_),
+    pgs(pgs_),
     tree(tree_),
     average_util(average_utilization()),
     min_var(-1),
@@ -579,7 +579,7 @@ protected:
     if (average_util)
       var = util / average_util;
 
-    size_t num_pgs = qi.is_bucket() ? 0 : pgm->get_num_pg_by_osd(qi.id);
+    size_t num_pgs = qi.is_bucket() ? 0 : pgs->get_num_pg_by_osd(qi.id);
 
     dump_item(qi, reweight, kb, kb_used, kb_avail, util, var, num_pgs, f);
 
@@ -626,13 +626,11 @@ protected:
 
   bool get_osd_utilization(int id, int64_t* kb, int64_t* kb_used,
 			   int64_t* kb_avail) const {
-    typedef ceph::unordered_map<int32_t,osd_stat_t> OsdStat;
-    OsdStat::const_iterator p = pgm->osd_stat.find(id);
-    if (p == pgm->osd_stat.end())
-      return false;
-    *kb = p->second.kb;
-    *kb_used = p->second.kb_used;
-    *kb_avail = p->second.kb_avail;
+    const osd_stat_t *p = pgs->get_osd_stat(id);
+    if (!p) return false;
+    *kb = p->kb;
+    *kb_used = p->kb_used;
+    *kb_avail = p->kb_avail;
     return *kb > 0;
   }
 
@@ -666,7 +664,7 @@ protected:
 
 protected:
   const OSDMap *osdmap;
-  const PGMap *pgm;
+  const PGStatService *pgs;
   bool tree;
   double average_util;
   double min_var;
@@ -680,8 +678,8 @@ public:
   typedef OSDUtilizationDumper<TextTable> Parent;
 
   OSDUtilizationPlainDumper(const CrushWrapper *crush, const OSDMap *osdmap,
-		     const PGMap *pgm, bool tree) :
-    Parent(crush, osdmap, pgm, tree) {}
+		     const PGStatService *pgs, bool tree) :
+    Parent(crush, osdmap, pgs, tree) {}
 
   void dump(TextTable *tbl) {
     tbl->define_column("ID", TextTable::LEFT, TextTable::RIGHT);
@@ -701,9 +699,9 @@ public:
     dump_stray(tbl);
 
     *tbl << "" << "" << "TOTAL"
-	 << si_t(pgm->osd_sum.kb << 10)
-	 << si_t(pgm->osd_sum.kb_used << 10)
-	 << si_t(pgm->osd_sum.kb_avail << 10)
+	 << si_t(pgs->get_osd_sum().kb << 10)
+	 << si_t(pgs->get_osd_sum().kb_used << 10)
+	 << si_t(pgs->get_osd_sum().kb_avail << 10)
 	 << lowprecision_t(average_util)
 	 << ""
 	 << TextTable::endrow;
@@ -786,8 +784,8 @@ public:
   typedef OSDUtilizationDumper<Formatter> Parent;
 
   OSDUtilizationFormatDumper(const CrushWrapper *crush, const OSDMap *osdmap,
-			     const PGMap *pgm, bool tree) :
-    Parent(crush, osdmap, pgm, tree) {}
+			     const PGStatService *pgs, bool tree) :
+    Parent(crush, osdmap, pgs, tree) {}
 
   void dump(Formatter *f) {
     f->open_array_section("nodes");
@@ -826,9 +824,9 @@ protected:
 public:
   void summary(Formatter *f) {
     f->open_object_section("summary");
-    f->dump_int("total_kb", pgm->osd_sum.kb);
-    f->dump_int("total_kb_used", pgm->osd_sum.kb_used);
-    f->dump_int("total_kb_avail", pgm->osd_sum.kb_avail);
+    f->dump_int("total_kb", pgs->get_osd_sum().kb);
+    f->dump_int("total_kb_used", pgs->get_osd_sum().kb_used);
+    f->dump_int("total_kb_avail", pgs->get_osd_sum().kb_avail);
     f->dump_float("average_utilization", average_util);
     f->dump_float("min_var", min_var);
     f->dump_float("max_var", max_var);
@@ -839,18 +837,17 @@ public:
 
 void OSDMonitor::print_utilization(ostream &out, Formatter *f, bool tree) const
 {
-  const PGMap *pgm = &mon->pgservice.get_pg_map();
   const CrushWrapper *crush = osdmap.crush.get();
 
   if (f) {
     f->open_object_section("df");
-    OSDUtilizationFormatDumper d(crush, &osdmap, pgm, tree);
+    OSDUtilizationFormatDumper d(crush, &osdmap, &mon->pgservice, tree);
     d.dump(f);
     d.summary(f);
     f->close_section();
     f->flush(out);
   } else {
-    OSDUtilizationPlainDumper d(crush, &osdmap, pgm, tree);
+    OSDUtilizationPlainDumper d(crush, &osdmap, &mon->pgservice, tree);
     TextTable tbl;
     d.dump(&tbl);
     out << tbl

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -839,7 +839,7 @@ public:
 
 void OSDMonitor::print_utilization(ostream &out, Formatter *f, bool tree) const
 {
-  const PGMap *pgm = &mon->pgmon()->pg_map;
+  const PGMap *pgm = &mon->pgservice.get_pg_map();
   const CrushWrapper *crush = osdmap.crush.get();
 
   if (f) {
@@ -1069,12 +1069,12 @@ void OSDMonitor::prime_pg_temp(
 {
   if (mon->monmap->get_required_features().contains_all(
         ceph::features::mon::FEATURE_LUMINOUS)) {
+    // TODO: remove this creating_pgs direct access?
     if (creating_pgs.pgs.count(pgid)) {
       return;
     }
   } else {
-    const auto& pg_map = mon->pgmon()->pg_map;
-    if (pg_map.creating_pgs.count(pgid)) {
+    if (mon->pgservice.is_creating_pg(pgid)) {
       return;
     }
   }
@@ -3832,9 +3832,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   }
   else if (prefix == "osd perf" ||
 	   prefix == "osd blocked-by") {
-    const PGMap &pgm = mon->pgmon()->pg_map;
-    r = process_pg_map_command(prefix, cmdmap, pgm, osdmap,
-			       f.get(), &ss, &rdata);
+    r = process_pg_map_command(prefix, cmdmap, mon->pgservice.get_pg_map(),
+			       osdmap, f.get(), &ss, &rdata);
   }
   else if (prefix == "osd dump" ||
 	   prefix == "osd tree" ||

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1276,7 +1276,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
     if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
       dout(7) << __func__ << " in the middle of upgrading, "
 	      << " trimming pending creating_pgs using pgmap" << dendl;
-      trim_creating_pgs(&pending_creatings, mon->pgservice->get_pg_map());
+      trim_creating_pgs(&pending_creatings, *mon->pgservice->get_pg_stat());
     }
     bufferlist creatings_bl;
     ::encode(pending_creatings, creatings_bl);
@@ -1285,12 +1285,12 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 }
 
 void OSDMonitor::trim_creating_pgs(creating_pgs_t* creating_pgs,
-				   const PGMap& pgm)
+				   const ceph::unordered_map<pg_t,pg_stat_t>& pg_stat)
 {
   auto p = creating_pgs->pgs.begin();
   while (p != creating_pgs->pgs.end()) {
-    auto q = pgm.pg_stat.find(p->first);
-    if (q != pgm.pg_stat.end() &&
+    auto q = pg_stat.find(p->first);
+    if (q != pg_stat.end() &&
 	!(q->second.state & PG_STATE_CREATING)) {
       dout(20) << __func__ << " pgmap shows " << p->first << " is created"
 	       << dendl;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3829,8 +3829,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   }
   else if (prefix == "osd perf" ||
 	   prefix == "osd blocked-by") {
-    r = process_pg_map_command(prefix, cmdmap, mon->pgservice->get_pg_map(),
-			       osdmap, f.get(), &ss, &rdata);
+    r = mon->pgservice->process_pg_command(prefix, cmdmap,
+					   osdmap, f.get(), &ss, &rdata);
   }
   else if (prefix == "osd dump" ||
 	   prefix == "osd tree" ||
@@ -4694,8 +4694,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
     }
     r = 0;
   } else if (prefix == "osd pool stats") {
-    r = process_pg_map_command(prefix, cmdmap, mon->pgservice->get_pg_map(),
-			       osdmap, f.get(), &ss, &rdata);
+    r = mon->pgservice->process_pg_command(prefix, cmdmap,
+					   osdmap, f.get(), &ss, &rdata);
   } else if (prefix == "osd pool get-quota") {
     string pool_name;
     cmd_getval(g_ceph_context, cmdmap, "pool", pool_name);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4697,9 +4697,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
     }
     r = 0;
   } else if (prefix == "osd pool stats") {
-    const auto &pgm = mon->pgmon()->pg_map;
-    r = process_pg_map_command(prefix, cmdmap, pgm, osdmap,
-			       f.get(), &ss, &rdata);
+    r = process_pg_map_command(prefix, cmdmap, mon->pgservice.get_pg_map(),
+			       osdmap, f.get(), &ss, &rdata);
   } else if (prefix == "osd pool get-quota") {
     string pool_name;
     cmd_getval(g_ceph_context, cmdmap, "pool", pool_name);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -880,16 +880,17 @@ void OSDMonitor::create_pending()
   }
   if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS)) {
     // transition full ratios from PGMap to OSDMap (on upgrade)
-    PGMap *pg_map = &mon->pgmon()->pg_map;
-    if (osdmap.full_ratio != pg_map->full_ratio) {
+    float full_ratio = mon->pgservice.get_full_ratio();
+    float nearfull_ratio = mon->pgservice.get_nearfull_ratio();
+    if (osdmap.full_ratio != full_ratio) {
       dout(10) << __func__ << " full_ratio " << osdmap.full_ratio
-	       << " -> " << pg_map->full_ratio << " (from pgmap)" << dendl;
-      pending_inc.new_full_ratio = pg_map->full_ratio;
+	       << " -> " << full_ratio << " (from pgmap)" << dendl;
+      pending_inc.new_full_ratio = full_ratio;
     }
-    if (osdmap.nearfull_ratio != pg_map->nearfull_ratio) {
+    if (osdmap.nearfull_ratio != nearfull_ratio) {
       dout(10) << __func__ << " nearfull_ratio " << osdmap.nearfull_ratio
-	       << " -> " << pg_map->nearfull_ratio << " (from pgmap)" << dendl;
-      pending_inc.new_nearfull_ratio = pg_map->nearfull_ratio;
+	       << " -> " << nearfull_ratio << " (from pgmap)" << dendl;
+      pending_inc.new_nearfull_ratio = nearfull_ratio;
     }
   } else {
     // safety check (this shouldn't really happen)
@@ -1422,6 +1423,7 @@ version_t OSDMonitor::get_trim_to()
   if (mon->monmap->get_required_features().contains_all(
         ceph::features::mon::FEATURE_LUMINOUS)) {
     {
+      // TODO: Get this hidden in PGStatService
       std::lock_guard<std::mutex> l(creating_pgs_lock);
       if (!creating_pgs.pgs.empty()) {
 	return 0;
@@ -1429,12 +1431,12 @@ version_t OSDMonitor::get_trim_to()
     }
     floor = get_min_last_epoch_clean();
   } else {
-    if (!mon->pgmon()->is_readable())
+    if (!mon->pgservice.is_readable())
       return 0;
-    if (mon->pgmon()->pg_map.creating_pgs.empty()) {
+    if (mon->pgservice.creating_pgs.empty()) {
       return 0;
     }
-    floor = mon->pgmon()->pg_map.get_min_last_epoch_clean();
+    floor = mon->pgservice.get_min_last_epoch_clean();
   }
   {
     dout(10) << " min_last_epoch_clean " << floor << dendl;
@@ -3392,9 +3394,9 @@ void OSDMonitor::tick()
 
   // if map full setting has changed, get that info out there!
   if (!osdmap.test_flag(CEPH_OSDMAP_REQUIRE_LUMINOUS) &&
-      mon->pgmon()->is_readable()) {
+      mon->pgservice.is_readable()) {
     // for pre-luminous compat only!
-    if (!mon->pgmon()->pg_map.full_osds.empty()) {
+    if (mon->pgservice.have_full_osds()) {
       dout(5) << "There are full osds, setting full flag" << dendl;
       add_flag(CEPH_OSDMAP_FULL);
     } else if (osdmap.test_flag(CEPH_OSDMAP_FULL)){
@@ -3402,7 +3404,7 @@ void OSDMonitor::tick()
       remove_flag(CEPH_OSDMAP_FULL);
     }
 
-    if (!mon->pgmon()->pg_map.nearfull_osds.empty()) {
+    if (mon->pgservice.have_nearfull_osds()) {
       dout(5) << "There are near full osds, setting nearfull flag" << dendl;
       add_flag(CEPH_OSDMAP_NEARFULL);
     } else if (osdmap.test_flag(CEPH_OSDMAP_NEARFULL)){

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3555,7 +3555,7 @@ void OSDMonitor::get_health(list<pair<health_status_t,string> >& summary,
       }
 
       map<int, float> full, backfillfull, nearfull;
-      osdmap.get_full_osd_util(mon->pgservice->get_pg_map().osd_stat, &full, &backfillfull, &nearfull);
+      osdmap.get_full_osd_util(*mon->pgservice->get_osd_stat(), &full, &backfillfull, &nearfull);
       if (full.size()) {
 	ostringstream ss;
 	ss << full.size() << " full osd(s)";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8928,16 +8928,15 @@ done:
     cmd_getval(g_ceph_context, cmdmap, "no_increasing", no_increasing);
     string out_str;
     mempool::osdmap::map<int32_t, uint32_t> new_weights;
-    err = reweight::by_utilization(osdmap,
-				   mon->pgservice->get_pg_map(),
-				   oload,
-				   max_change,
-				   max_osds,
-				   by_pg,
-				   pools.empty() ? NULL : &pools,
-				   no_increasing == "--no-increasing",
-				   &new_weights,
-				   &ss, &out_str, f.get());
+    err = mon->pgservice->reweight_by_utilization(osdmap,
+					     oload,
+					     max_change,
+					     max_osds,
+					     by_pg,
+					     pools.empty() ? NULL : &pools,
+					     no_increasing == "--no-increasing",
+					     &new_weights,
+					     &ss, &out_str, f.get());
     if (err >= 0) {
       dout(10) << "reweight::by_utilization: finished with " << out_str << dendl;
     }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4878,10 +4878,10 @@ bool OSDMonitor::update_pools_status()
 
   auto& pools = osdmap.get_pools();
   for (auto it = pools.begin(); it != pools.end(); ++it) {
-    if (!mon->pgmon()->pg_map.pg_pool_sum.count(it->first))
+    const pool_stat_t *pstat = mon->pgservice.get_pool_stat(it->first);
+    if (!pstat)
       continue;
-    pool_stat_t& stats = mon->pgmon()->pg_map.pg_pool_sum[it->first];
-    object_stat_sum_t& sum = stats.stats.sum;
+    const object_stat_sum_t& sum = pstat->stats.sum;
     const pg_pool_t &pool = it->second;
     const string& pool_name = osdmap.get_pool_name(it->first);
 
@@ -4927,10 +4927,10 @@ void OSDMonitor::get_pools_health(
 {
   auto& pools = osdmap.get_pools();
   for (auto it = pools.begin(); it != pools.end(); ++it) {
-    if (!mon->pgmon()->pg_map.pg_pool_sum.count(it->first))
+    const pool_stat_t *pstat = mon->pgservice.get_pool_stat(it->first);
+    if (!pstat)
       continue;
-    pool_stat_t& stats = mon->pgmon()->pg_map.pg_pool_sum[it->first];
-    object_stat_sum_t& sum = stats.stats.sum;
+    const object_stat_sum_t& sum = pstat->stats.sum;
     const pg_pool_t &pool = it->second;
     const string& pool_name = osdmap.get_pool_name(it->first);
 
@@ -8410,9 +8410,8 @@ done:
     // make sure new tier is empty
     string force_nonempty;
     cmd_getval(g_ceph_context, cmdmap, "force_nonempty", force_nonempty);
-    const pool_stat_t& tier_stats =
-      mon->pgmon()->pg_map.get_pg_pool_sum_stat(tierpool_id);
-    if (tier_stats.stats.sum.num_objects != 0 &&
+    const pool_stat_t *pstats = mon->pgservice.get_pool_stat(tierpool_id);
+    if (pstats && pstats->stats.sum.num_objects != 0 &&
 	force_nonempty != "--force-nonempty") {
       ss << "tier pool '" << tierpoolstr << "' is not empty; --force-nonempty to force";
       err = -ENOTEMPTY;
@@ -8724,10 +8723,10 @@ done:
 	  mode != pg_pool_t::CACHEMODE_PROXY &&
 	  mode != pg_pool_t::CACHEMODE_READPROXY))) {
 
-      const pool_stat_t& tier_stats =
-        mon->pgmon()->pg_map.get_pg_pool_sum_stat(pool_id);
+      const pool_stat_t* pstats =
+        mon->pgservice.get_pool_stat(pool_id);
 
-      if (tier_stats.stats.sum.num_objects_dirty > 0) {
+      if (pstats && pstats->stats.sum.num_objects_dirty > 0) {
         ss << "unable to set cache-mode '"
            << pg_pool_t::get_cache_mode_name(mode) << "' on pool '" << poolstr
            << "': dirty objects found";
@@ -8792,9 +8791,9 @@ done:
       goto reply;
     }
     // make sure new tier is empty
-    const pool_stat_t& tier_stats =
-      mon->pgmon()->pg_map.get_pg_pool_sum_stat(tierpool_id);
-    if (tier_stats.stats.sum.num_objects != 0) {
+    const pool_stat_t *pstats =
+      mon->pgservice.get_pool_stat(tierpool_id);
+    if (pstats && pstats->stats.sum.num_objects != 0) {
       ss << "tier pool '" << tierpoolstr << "' is not empty";
       err = -ENOTEMPTY;
       goto reply;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -452,7 +452,8 @@ private:
   std::mutex creating_pgs_lock;
 
   creating_pgs_t update_pending_pgs(const OSDMap::Incremental& inc);
-  void trim_creating_pgs(creating_pgs_t *creating_pgs, const PGMap& pgm);
+  void trim_creating_pgs(creating_pgs_t *creating_pgs,
+			 const ceph::unordered_map<pg_t,pg_stat_t>& pgm);
   void scan_for_creating_pgs(
     const mempool::osdmap::map<int64_t,pg_pool_t>& pools,
     const mempool::osdmap::set<int64_t>& removed_pools,

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -19,6 +19,7 @@
 #include "Monitor.h"
 #include "OSDMonitor.h"
 #include "MonitorDBStore.h"
+#include "PGStatService.h"
 
 #include "messages/MPGStats.h"
 #include "messages/MPGStatsAck.h"
@@ -1677,4 +1678,16 @@ bool PGMonitor::check_sub(Subscription *sub)
     }
   }
   return true;
+}
+
+PGStatService *PGMonitor::get_pg_stat_service()
+{
+  if (!pgservice) {
+    pgservice = new PGMapStatService(pg_map);
+  }
+  return pgservice;
+}
+PGMonitor::~PGMonitor()
+{
+  delete pgservice;
 }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1732,7 +1732,7 @@ public:
       assert(st != parent.pg_stat.end());
       auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
       // no need to add the pg, if it already exists in creating_pgs
-      pending_creatings->pgs.emplace(pgid, created);
+      pending_creates->pgs.emplace(pgid, created);
       }
     }
   }

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -1679,11 +1679,109 @@ bool PGMonitor::check_sub(Subscription *sub)
   }
   return true;
 }
+class PGMapStatService : public PGMap, public PGStatService {
+  PGMap& parent;
+  PGMonitor *pgmon;
+public:
+  PGMapStatService() : PGMap(), PGStatService(),
+		       parent(*static_cast<PGMap*>(this)), pgmon(nullptr) {}
+  PGMapStatService(const PGMap& o,
+		   PGMonitor *pgm) : PGMap(o), PGStatService(),
+				     parent(*static_cast<PGMap*>(this)),
+				     pgmon(pgm) {}
+  void reset(const PGMap& o) {
+    parent = o;
+  }
+
+  bool is_readable() const { return pgmon->is_readable(); }
+
+  const pool_stat_t* get_pool_stat(int poolid) const {
+    auto i = parent.pg_pool_sum.find(poolid);
+    if (i != parent.pg_pool_sum.end()) {
+      return &i->second;
+    }
+    return NULL;
+  }
+  
+  const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
+  const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
+
+  const osd_stat_t *get_osd_stat(int osd) const {
+    auto i = parent.osd_stat.find(osd);
+    if (i == parent.osd_stat.end()) {
+      return NULL;
+    }
+    return &i->second;
+  }
+  const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const {
+    return &parent.osd_stat;
+  }
+  const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const {
+    return &parent.pg_stat;
+  }
+  float get_full_ratio() const { return parent.full_ratio; }
+  float get_nearfull_ratio() const { return parent.nearfull_ratio; }
+
+  bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
+  bool is_creating_pg(pg_t pgid) const { return parent.creating_pgs.count(pgid); }
+  virtual void maybe_add_creating_pgs(epoch_t scan_epoch,
+				      creating_pgs_t *pending_creates) const {
+    if (parent.last_pg_scan >= scan_epoch) {
+      for (auto& pgid : parent.creating_pgs) {
+      auto st = parent.pg_stat.find(pgid);
+      assert(st != parent.pg_stat.end());
+      auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
+      // no need to add the pg, if it already exists in creating_pgs
+      pending_creatings->pgs.emplace(pgid, created);
+      }
+    }
+  }
+  epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
+
+  bool have_full_osds() const { return !parent.full_osds.empty(); }
+  bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
+
+  size_t get_num_pg_by_osd(int osd) const { return parent.get_num_pg_by_osd(osd); }
+
+  void print_summary(Formatter *f, ostream *out) const { parent.print_summary(f, out); }
+  void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const {
+    parent.dump_fs_stats(ss, f, verbose);
+  }
+  void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
+		       bool verbose) const {
+    parent.dump_pool_stats(osdm, ss, f, verbose);
+  }
+
+  int process_pg_command(const string& prefix,
+			 const map<string,cmd_vartype>& cmdmap,
+			 const OSDMap& osdmap,
+			 Formatter *f,
+			 stringstream *ss,
+			 bufferlist *odata) {
+    return process_pg_map_command(prefix, cmdmap, parent, osdmap, f, ss, odata);
+  }
+
+  int reweight_by_utilization(const OSDMap &osd_map,
+			      int oload,
+			      double max_changef,
+			      int max_osds,
+			      bool by_pg, const set<int64_t> *pools,
+			      bool no_increasing,
+			      mempool::osdmap::map<int32_t, uint32_t>* new_weights,
+			      std::stringstream *ss,
+			      std::string *out_str,
+			      Formatter *f) {
+    return reweight::by_utilization(osd_map, parent, oload, max_changef,
+				    max_osds, by_pg, pools, no_increasing,
+				    new_weights, ss, out_str, f);
+  }
+
+};
 
 PGStatService *PGMonitor::get_pg_stat_service()
 {
   if (!pgservice) {
-    pgservice = new PGMapStatService(pg_map);
+    pgservice = new PGMapStatService(pg_map, this);
   }
   return pgservice;
 }

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -39,11 +39,12 @@ class MGetPoolStats;
 class TextTable;
 class MPGStats;
 class PGStatService;
+class PGMapStatService;
 
 class PGMonitor : public PaxosService {
 public:
   PGMap pg_map;
-  PGStatService *pgservice;
+  PGMapStatService *pgservice;
 
 private:
   PGMap::Incremental pending_inc;

--- a/src/mon/PGMonitor.h
+++ b/src/mon/PGMonitor.h
@@ -38,10 +38,12 @@ class MGetPoolStats;
 
 class TextTable;
 class MPGStats;
+class PGStatService;
 
 class PGMonitor : public PaxosService {
 public:
   PGMap pg_map;
+  PGStatService *pgservice;
 
 private:
   PGMap::Incremental pending_inc;
@@ -92,11 +94,12 @@ private:
 public:
   PGMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name),
+      pgservice(nullptr),
       pgmap_meta_prefix("pgmap_meta"),
       pgmap_pg_prefix("pgmap_pg"),
       pgmap_osd_prefix("pgmap_osd")
   { }
-  ~PGMonitor() override { }
+  ~PGMonitor() override;
 
   void get_store_prefixes(set<string>& s) override {
     s.insert(get_service_name());
@@ -139,6 +142,8 @@ public:
 
   void check_subs();
   bool check_sub(Subscription *sub);
+
+  PGStatService *get_pg_stat_service();
 
 private:
   // no copying allowed

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -42,10 +42,13 @@ public:
   void reset(const PGMap& o) {
     parent = o;
   }
-  const pool_stat_t& get_pool_stat(int poolid) const {
+
+  const pool_stat_t* get_pool_stat(int poolid) const {
     auto i = parent.pg_pool_sum.find(poolid);
-    assert(i != parent.pg_pool_sum.end());
-    return i->second;
+    if (i != parent.pg_pool_sum.end()) {
+      return &i->second;
+    }
+    return NULL;
   }
 };
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -38,12 +38,6 @@ public:
   virtual const pool_stat_t& get_pg_sum() const = 0;
   virtual const osd_stat_t& get_osd_sum() const = 0;
 
-  typedef ceph::unordered_map<pg_t,pg_stat_t>::const_iterator PGStatIter;
-  typedef ceph::unordered_map<int32_t,osd_stat_t>::const_iterator OSDStatIter;
-  virtual PGStatIter pg_stat_iter_begin() const = 0;
-  virtual PGStatIter pg_stat_iter_end() const = 0;
-  virtual OSDStatIter osd_stat_iter_begin() const = 0;
-  virtual OSDStatIter osd_stat_iter_end() const = 0;
   virtual const osd_stat_t *get_osd_stat(int osd) const = 0;
   virtual const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const = 0;
   virtual const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const = 0;
@@ -113,10 +107,6 @@ public:
   const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
   const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
 
-  PGStatIter pg_stat_iter_begin() const { return parent.pg_stat.begin(); }
-  PGStatIter pg_stat_iter_end() const { return parent.pg_stat.end(); }
-  OSDStatIter osd_stat_iter_begin() const { return parent.osd_stat.begin(); }
-  OSDStatIter osd_stat_iter_end() const { return parent.osd_stat.end(); }
   const osd_stat_t *get_osd_stat(int osd) const {
     auto i = parent.osd_stat.find(osd);
     if (i == parent.osd_stat.end()) {

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -46,6 +46,7 @@ public:
   virtual OSDStatIter osd_stat_iter_end() const = 0;
   virtual const osd_stat_t *get_osd_stat(int osd) const = 0;
   virtual const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const = 0;
+  virtual const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const = 0;
   virtual float get_full_ratio() const = 0;
   virtual float get_nearfull_ratio() const = 0;
   virtual bool have_creating_pgs() const = 0;
@@ -126,7 +127,9 @@ public:
   const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const {
     return &parent.osd_stat;
   }
-
+  const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const {
+    return &parent.pg_stat;
+  }
   float get_full_ratio() const { return parent.full_ratio; }
   float get_nearfull_ratio() const { return parent.nearfull_ratio; }
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -42,6 +42,11 @@ public:
   void reset(const PGMap& o) {
     parent = o;
   }
+  const pool_stat_t& get_pool_stat(int poolid) const {
+    auto i = parent.pg_pool_sum.find(poolid);
+    assert(i != parent.pg_pool_sum.end());
+    return i->second;
+  }
 };
 
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -43,6 +43,7 @@ public:
     parent = o;
   }
 
+  // FIXME: Kill this once we rip out PGMonitor post-luminous
   /** returns true if the underlying data is readable. Always true
    * post-luminous, but not when we are redirecting to the PGMonitor
    */

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -62,6 +62,7 @@ public:
   float get_nearfull_ratio() const { return parent.nearfull_ratio; }
 
   bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
+  bool is_creating_pg(pg_t pgid) const { return parent.creating_pgs.count(pgid); }
   epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
 
   bool have_full_osds() const { return !parent.full_osds.empty(); }

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -105,6 +105,22 @@ public:
 			 bufferlist *odata) {
     return process_pg_map_command(prefix, cmdmap, parent, osdmap, f, ss, odata);
   }
+
+  int reweight_by_utilization(const OSDMap &osd_map,
+			      int oload,
+			      double max_changef,
+			      int max_osds,
+			      bool by_pg, const set<int64_t> *pools,
+			      bool no_increasing,
+			      mempool::osdmap::map<int32_t, uint32_t>* new_weights,
+			      std::stringstream *ss,
+			      std::string *out_str,
+			      Formatter *f) {
+    return reweight::by_utilization(osd_map, parent, oload, max_changef,
+				    max_osds, by_pg, pools, no_increasing,
+				    new_weights, ss, out_str, f);
+  }
+
 };
 
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -67,6 +67,15 @@ public:
 
   bool have_full_osds() const { return !parent.full_osds.empty(); }
   bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
+
+  void print_summary(Formatter *f, ostream *out) const { parent.print_summary(f, out); }
+  void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const {
+    parent.dump_fs_stats(ss, f, verbose);
+  }
+  void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
+		       bool verbose) const {
+    parent.dump_pool_stats(osdm, ss, f, verbose);
+  }
 };
 
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -96,6 +96,15 @@ public:
 		       bool verbose) const {
     parent.dump_pool_stats(osdm, ss, f, verbose);
   }
+
+  int process_pg_command(const string& prefix,
+			 const map<string,cmd_vartype>& cmdmap,
+			 const OSDMap& osdmap,
+			 Formatter *f,
+			 stringstream *ss,
+			 bufferlist *odata) {
+    return process_pg_map_command(prefix, cmdmap, parent, osdmap, f, ss, odata);
+  }
 };
 
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -45,6 +45,7 @@ public:
   virtual OSDStatIter osd_stat_iter_begin() const = 0;
   virtual OSDStatIter osd_stat_iter_end() const = 0;
   virtual const osd_stat_t *get_osd_stat(int osd) const = 0;
+  virtual const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const = 0;
   virtual float get_full_ratio() const = 0;
   virtual float get_nearfull_ratio() const = 0;
   virtual bool have_creating_pgs() const = 0;
@@ -121,6 +122,9 @@ public:
       return NULL;
     }
     return &i->second;
+  }
+  const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const {
+    return &parent.osd_stat;
   }
 
   float get_full_ratio() const { return parent.full_ratio; }

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -45,9 +45,13 @@ public:
   virtual float get_nearfull_ratio() const = 0;
   virtual bool have_creating_pgs() const = 0;
   virtual bool is_creating_pg(pg_t pgid) const = 0;
+  /**
+   * For upgrades. If the PGMap has newer data than the monitor's new
+   * creating_pgs (scan_epoch), insert them into the passed pending_creates.
+   */
+  virtual void maybe_add_creating_pgs(epoch_t scan_epoch,
+				      creating_pgs_t *pending_creates) const = 0;
   virtual epoch_t get_min_last_epoch_clean() const = 0;
-
-  virtual PGMap& get_pg_map() = 0;
 
   virtual bool have_full_osds() const = 0;
   virtual bool have_nearfull_osds() const = 0;
@@ -102,8 +106,6 @@ public:
     return NULL;
   }
   
-  PGMap& get_pg_map() { return parent; }
-
   const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
   const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
 
@@ -125,6 +127,18 @@ public:
 
   bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
   bool is_creating_pg(pg_t pgid) const { return parent.creating_pgs.count(pgid); }
+  virtual void maybe_add_creating_pgs(epoch_t scan_epoch,
+				      creating_pgs_t *pending_creates) const {
+    if (parent.last_pg_scan >= scan_epoch) {
+      for (auto& pgid : parent.creating_pgs) {
+      auto st = parent.pg_stat.find(pgid);
+      assert(st != parent.pg_stat.end());
+      auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
+      // no need to add the pg, if it already exists in creating_pgs
+      pending_creatings->pgs.emplace(pgid, created);
+      }
+    }
+  }
   epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
 
   bool have_full_osds() const { return !parent.full_osds.empty(); }

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -58,6 +58,23 @@ public:
   
   PGMap& get_pg_map() { return parent; }
 
+  const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
+  const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
+
+  typedef ceph::unordered_map<pg_t,pg_stat_t>::const_iterator PGStatIter;
+  typedef ceph::unordered_map<int32_t,osd_stat_t>::const_iterator OSDStatIter;
+  PGStatIter pg_stat_iter_begin() const { return parent.pg_stat.begin(); }
+  PGStatIter pg_stat_iter_end() const { return parent.pg_stat.end(); }
+  OSDStatIter osd_stat_iter_begin() const { return parent.osd_stat.begin(); }
+  OSDStatIter osd_stat_iter_end() const { return parent.osd_stat.end(); }
+  const osd_stat_t *get_osd_stat(int osd) const {
+    auto i = parent.osd_stat.find(osd);
+    if (i == parent.osd_stat.end()) {
+      return NULL;
+    }
+    return &i->second;
+  }
+
   float get_full_ratio() const { return parent.full_ratio; }
   float get_nearfull_ratio() const { return parent.nearfull_ratio; }
 
@@ -67,6 +84,8 @@ public:
 
   bool have_full_osds() const { return !parent.full_osds.empty(); }
   bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
+
+  size_t get_num_pg_by_osd(int osd) const { return parent.get_num_pg_by_osd(osd); }
 
   void print_summary(Formatter *f, ostream *out) const { parent.print_summary(f, out); }
   void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const {

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -43,6 +43,11 @@ public:
     parent = o;
   }
 
+  /** returns true if the underlying data is readable. Always true
+   * post-luminous, but not when we are redirecting to the PGMonitor
+   */
+  bool is_readable() { return true; }
+
   const pool_stat_t* get_pool_stat(int poolid) const {
     auto i = parent.pg_pool_sum.find(poolid);
     if (i != parent.pg_pool_sum.end()) {
@@ -50,6 +55,17 @@ public:
     }
     return NULL;
   }
+  
+  PGMap& get_pg_map() { return parent; }
+
+  float get_full_ratio() const { return parent.full_ratio; }
+  float get_nearfull_ratio() const { return parent.nearfull_ratio; }
+
+  bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
+  epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
+
+  bool have_full_osds() const { return !parent.full_osds.empty(); }
+  bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
 };
 
 

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -1,0 +1,48 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Greg Farnum/Red Hat <gfarnum@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software 
+ * Foundation.  See file COPYING.
+ * 
+ */
+
+/**
+ * This service abstracts out the specific implementation providing information
+ * needed by parts of the Monitor based around PGStats. This'll make for
+ * an easier transition from the PGMonitor-based queries where we handle
+ * PGStats directly, to where we are getting information passed in from
+ * the Ceph Manager.
+ *
+ * This initial implementation cheats by wrapping a PGMap so we don't need
+ * to reimplement everything in one go.
+ */
+
+#ifndef CEPH_PGSTATSERVICE_H
+#define CEPH_PGSTATSERVICE_H
+
+#include "mon/PGMap.h"
+
+class PGStatService : public PGMap {
+  PGMap& parent;
+public:
+  PGStatService() : PGMap(),
+		    parent(*static_cast<PGMap*>(this)) {}
+  PGStatService(const PGMap& o) : PGMap(o),
+				  parent(*static_cast<PGMap*>(this)) {}
+  PGStatService& operator=(const PGMap& o) {
+    reset(o);
+    return *this;
+  }
+  void reset(const PGMap& o) {
+    parent = o;
+  }
+};
+
+
+#endif

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -27,6 +27,7 @@
 #define CEPH_PGSTATSERVICE_H
 
 #include "mon/PGMap.h"
+struct creating_pgs_t;
 
 class PGStatService {
 public:

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -28,17 +28,66 @@
 
 #include "mon/PGMap.h"
 
-class PGStatService : public PGMap {
+class PGStatService {
+public:
+  PGStatService() {}
+  virtual ~PGStatService() {}
+  virtual void reset(const PGMap& o) = 0;
+  virtual bool is_readable() const = 0;
+  virtual const pool_stat_t* get_pool_stat(int poolid) const = 0;
+  virtual const pool_stat_t& get_pg_sum() const = 0;
+  virtual const osd_stat_t& get_osd_sum() const = 0;
+
+  typedef ceph::unordered_map<pg_t,pg_stat_t>::const_iterator PGStatIter;
+  typedef ceph::unordered_map<int32_t,osd_stat_t>::const_iterator OSDStatIter;
+  virtual PGStatIter pg_stat_iter_begin() const = 0;
+  virtual PGStatIter pg_stat_iter_end() const = 0;
+  virtual OSDStatIter osd_stat_iter_begin() const = 0;
+  virtual OSDStatIter osd_stat_iter_end() const = 0;
+  virtual const osd_stat_t *get_osd_stat(int osd) const = 0;
+  virtual float get_full_ratio() const = 0;
+  virtual float get_nearfull_ratio() const = 0;
+  virtual bool have_creating_pgs() const = 0;
+  virtual bool is_creating_pg(pg_t pgid) const = 0;
+  virtual epoch_t get_min_last_epoch_clean() const = 0;
+
+  virtual PGMap& get_pg_map() = 0;
+
+  virtual bool have_full_osds() const = 0;
+  virtual bool have_nearfull_osds() const = 0;
+
+  virtual size_t get_num_pg_by_osd(int osd) const = 0;
+  virtual void print_summary(Formatter *f, ostream *out) const = 0;
+  virtual void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const = 0;
+  virtual void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
+			       bool verbose) const = 0;
+
+  virtual int process_pg_command(const string& prefix,
+				 const map<string,cmd_vartype>& cmdmap,
+				 const OSDMap& osdmap,
+				 Formatter *f,
+				 stringstream *ss,
+				 bufferlist *odata) = 0;
+  
+  virtual int reweight_by_utilization(const OSDMap &osd_map,
+			      int oload,
+			      double max_changef,
+			      int max_osds,
+			      bool by_pg, const set<int64_t> *pools,
+			      bool no_increasing,
+			      mempool::osdmap::map<int32_t, uint32_t>* new_weights,
+			      std::stringstream *ss,
+			      std::string *out_str,
+			      Formatter *f) = 0;
+};
+
+class PGMapStatService : public PGMap, public PGStatService {
   PGMap& parent;
 public:
-  PGStatService() : PGMap(),
+  PGMapStatService() : PGMap(), PGStatService(),
 		    parent(*static_cast<PGMap*>(this)) {}
-  PGStatService(const PGMap& o) : PGMap(o),
+  PGMapStatService(const PGMap& o) : PGMap(o), PGStatService(),
 				  parent(*static_cast<PGMap*>(this)) {}
-  PGStatService& operator=(const PGMap& o) {
-    reset(o);
-    return *this;
-  }
   void reset(const PGMap& o) {
     parent = o;
   }
@@ -47,7 +96,7 @@ public:
   /** returns true if the underlying data is readable. Always true
    * post-luminous, but not when we are redirecting to the PGMonitor
    */
-  bool is_readable() { return true; }
+  bool is_readable() const { return true; }
 
   const pool_stat_t* get_pool_stat(int poolid) const {
     auto i = parent.pg_pool_sum.find(poolid);
@@ -62,8 +111,6 @@ public:
   const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
   const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
 
-  typedef ceph::unordered_map<pg_t,pg_stat_t>::const_iterator PGStatIter;
-  typedef ceph::unordered_map<int32_t,osd_stat_t>::const_iterator OSDStatIter;
   PGStatIter pg_stat_iter_begin() const { return parent.pg_stat.begin(); }
   PGStatIter pg_stat_iter_end() const { return parent.pg_stat.end(); }
   OSDStatIter osd_stat_iter_begin() const { return parent.osd_stat.begin(); }

--- a/src/mon/PGStatService.h
+++ b/src/mon/PGStatService.h
@@ -32,8 +32,11 @@ class PGStatService {
 public:
   PGStatService() {}
   virtual ~PGStatService() {}
-  virtual void reset(const PGMap& o) = 0;
-  virtual bool is_readable() const = 0;
+  // FIXME: Kill this once we rip out PGMonitor post-luminous
+  /** returns true if the underlying data is readable. Always true
+   *  post-luminous, but not when we are redirecting to the PGMonitor
+   */
+  virtual bool is_readable() const { return true; }
   virtual const pool_stat_t* get_pool_stat(int poolid) const = 0;
   virtual const pool_stat_t& get_pg_sum() const = 0;
   virtual const osd_stat_t& get_osd_sum() const = 0;
@@ -80,106 +83,5 @@ public:
 			      std::string *out_str,
 			      Formatter *f) = 0;
 };
-
-class PGMapStatService : public PGMap, public PGStatService {
-  PGMap& parent;
-public:
-  PGMapStatService() : PGMap(), PGStatService(),
-		    parent(*static_cast<PGMap*>(this)) {}
-  PGMapStatService(const PGMap& o) : PGMap(o), PGStatService(),
-				  parent(*static_cast<PGMap*>(this)) {}
-  void reset(const PGMap& o) {
-    parent = o;
-  }
-
-  // FIXME: Kill this once we rip out PGMonitor post-luminous
-  /** returns true if the underlying data is readable. Always true
-   * post-luminous, but not when we are redirecting to the PGMonitor
-   */
-  bool is_readable() const { return true; }
-
-  const pool_stat_t* get_pool_stat(int poolid) const {
-    auto i = parent.pg_pool_sum.find(poolid);
-    if (i != parent.pg_pool_sum.end()) {
-      return &i->second;
-    }
-    return NULL;
-  }
-  
-  const pool_stat_t& get_pg_sum() const { return parent.pg_sum; }
-  const osd_stat_t& get_osd_sum() const { return parent.osd_sum; }
-
-  const osd_stat_t *get_osd_stat(int osd) const {
-    auto i = parent.osd_stat.find(osd);
-    if (i == parent.osd_stat.end()) {
-      return NULL;
-    }
-    return &i->second;
-  }
-  const ceph::unordered_map<int32_t,osd_stat_t> *get_osd_stat() const {
-    return &parent.osd_stat;
-  }
-  const ceph::unordered_map<pg_t,pg_stat_t> *get_pg_stat() const {
-    return &parent.pg_stat;
-  }
-  float get_full_ratio() const { return parent.full_ratio; }
-  float get_nearfull_ratio() const { return parent.nearfull_ratio; }
-
-  bool have_creating_pgs() const { return !parent.creating_pgs.empty(); }
-  bool is_creating_pg(pg_t pgid) const { return parent.creating_pgs.count(pgid); }
-  virtual void maybe_add_creating_pgs(epoch_t scan_epoch,
-				      creating_pgs_t *pending_creates) const {
-    if (parent.last_pg_scan >= scan_epoch) {
-      for (auto& pgid : parent.creating_pgs) {
-      auto st = parent.pg_stat.find(pgid);
-      assert(st != parent.pg_stat.end());
-      auto created = make_pair(st->second.created, st->second.last_scrub_stamp);
-      // no need to add the pg, if it already exists in creating_pgs
-      pending_creatings->pgs.emplace(pgid, created);
-      }
-    }
-  }
-  epoch_t get_min_last_epoch_clean() const { return parent.get_min_last_epoch_clean(); }
-
-  bool have_full_osds() const { return !parent.full_osds.empty(); }
-  bool have_nearfull_osds() const { return !parent.nearfull_osds.empty(); }
-
-  size_t get_num_pg_by_osd(int osd) const { return parent.get_num_pg_by_osd(osd); }
-
-  void print_summary(Formatter *f, ostream *out) const { parent.print_summary(f, out); }
-  void dump_fs_stats(stringstream *ss, Formatter *f, bool verbose) const {
-    parent.dump_fs_stats(ss, f, verbose);
-  }
-  void dump_pool_stats(const OSDMap& osdm, stringstream *ss, Formatter *f,
-		       bool verbose) const {
-    parent.dump_pool_stats(osdm, ss, f, verbose);
-  }
-
-  int process_pg_command(const string& prefix,
-			 const map<string,cmd_vartype>& cmdmap,
-			 const OSDMap& osdmap,
-			 Formatter *f,
-			 stringstream *ss,
-			 bufferlist *odata) {
-    return process_pg_map_command(prefix, cmdmap, parent, osdmap, f, ss, odata);
-  }
-
-  int reweight_by_utilization(const OSDMap &osd_map,
-			      int oload,
-			      double max_changef,
-			      int max_osds,
-			      bool by_pg, const set<int64_t> *pools,
-			      bool no_increasing,
-			      mempool::osdmap::map<int32_t, uint32_t>* new_weights,
-			      std::stringstream *ss,
-			      std::string *out_str,
-			      Formatter *f) {
-    return reweight::by_utilization(osd_map, parent, oload, max_changef,
-				    max_osds, by_pg, pools, no_increasing,
-				    new_weights, ss, out_str, f);
-  }
-
-};
-
 
 #endif

--- a/src/msg/Message.cc
+++ b/src/msg/Message.cc
@@ -168,6 +168,7 @@ using namespace std;
 #include "messages/MMgrReport.h"
 #include "messages/MMgrOpen.h"
 #include "messages/MMgrConfigure.h"
+#include "messages/MMonMgrReport.h"
 
 #include "messages/MLock.h"
 
@@ -744,6 +745,10 @@ Message *decode_message(CephContext *cct, int crcflags,
 
   case MSG_MGR_BEACON:
     m = new MMgrBeacon();
+    break;
+
+  case MSG_MON_MGR_REPORT:
+    m = new MMonMgrReport();
     break;
 
   case MSG_MGR_MAP:

--- a/src/msg/Message.h
+++ b/src/msg/Message.h
@@ -195,6 +195,8 @@
 
 // *** ceph-mon(MgrMonitor) -> ceph-mgr
 #define MSG_MGR_DIGEST               0x705
+// *** cephmgr -> ceph-mon
+#define MSG_MON_MGR_REPORT        0x706
 
 // ======================================================
 


### PR DESCRIPTION
This is not done yet, but has finally reached the point where I think it's come together with the other monitor changes and the final bits are pretty clear.

So: we here hide the pgmap from the OSDMonitor behind a new "PGStatService" interface and give one each to the PGMonitor (basically done) and MgrMonitor (very not done). There were some introduced challenges around creating_pgs between when this was drafted and today, but I think they're handled now.

Still to come: persist the necessary pieces of the ceph-mgr's PGMap state, implement the MgrPGStatService in terms of a much lighter-weight set of data than a full PGMap, and set up the upgrades.