### PR TITLE
rgw: fix lc list failure when shards not be all created

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -545,8 +545,15 @@ int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries, map<stri
   for(; index <max_objs; index++) {
     map<string, int > entries;
     int ret = cls_rgw_lc_list(store->lc_pool_ctx, obj_names[index], marker, max_entries, entries);
-    if (ret < 0)
-      return ret;
+    if (ret < 0) {
+      if (ret == -ENOENT) {
+        dout(10) << __func__ << " ignoring unfound lc object="
+                             << obj_names[index] << dendl;
+        continue;
+      } else {
+        return ret;
+      }
+    }
     map<string, int>::iterator iter;
     for (iter = entries.begin(); iter != entries.end(); ++iter) {
       progress_map->insert(*iter);


### PR DESCRIPTION
Default lc shard is 32, if we had created few lc config,that all been
sharded to lc.31, then `radosgw-admin lc list` failed by can't find
lc.0.

Fixes: http://tracker.ceph.com/issues/19898

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>