### PR TITLE
src/osd: write IO returns after the primary receives a majority of commit from replicas.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -852,6 +852,8 @@ OPTION(osd_rollback_to_cluster_snap, OPT_STR, "")
 OPTION(osd_default_notify_timeout, OPT_U32, 30) // default notify timeout in seconds
 OPTION(osd_kill_backfill_at, OPT_INT, 0)
 
+OPTION(osd_commit_majority, OPT_BOOL, false) //default disable,if send 3 replica,now return 2 ack ,can response to client
+
 // Bounds how infrequently a new map epoch will be persisted for a pg
 OPTION(osd_pg_epoch_persisted_max_stale, OPT_U32, 150) // make this < map_cache_size!
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -290,6 +290,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
   _ref_id_lock("PG::_ref_id_lock"), _ref_id(0),
   #endif
   deleting(false),
+  allow_uncommitted_replicas(0),
   trace_endpoint("0.0.0.0", 0, "PG"),
   dirty_info(false), dirty_big_info(false),
   info(p),
@@ -1963,7 +1964,7 @@ void PG::all_activated_and_committed()
   assert(peer_activated.size() == actingbackfill.size());
   assert(!actingbackfill.empty());
   assert(blocked_by.empty());
-
+  allow_uncommitted_replicas = (pool.info.min_size>0)?(pool.info.min_size-1):(0);
   queue_peering_event(
     CephPeeringEvtRef(
       std::make_shared<CephPeeringEvt>(

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -310,6 +310,7 @@ protected:
 
 public:
   bool deleting;  // true while in removing or OSD is shutting down
+  unsigned allow_uncommitted_replicas;
 
   ZTracer::Endpoint trace_endpoint;
 

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -245,6 +245,9 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual uint64_t min_peer_features() const = 0;
 
+     virtual bool can_commit_majority() const = 0;
+     virtual unsigned get_allow_uncommitted_replicas() const = 0;
+
      virtual hobject_t get_temp_recovery_object(const hobject_t& target,
 						eversion_t version) = 0;
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -435,6 +435,13 @@ public:
     return get_min_peer_features();
   }
 
+  unsigned get_allow_uncommitted_replicas() const {
+    return allow_uncommitted_replicas;
+  }
+  bool can_commit_majority() const {
+    return !is_degraded();
+  }
+
   void send_message_osd_cluster(
     int peer, Message *m, epoch_t from_epoch) override;
   void send_message_osd_cluster(

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -614,10 +614,17 @@ void ReplicatedBackend::op_commit(
   }
 
   op->waiting_for_commit.erase(get_parent()->whoami_shard());
-
-  if (op->waiting_for_commit.empty()) {
-    op->on_commit->complete(0);
-    op->on_commit = 0;
+  if (cct->_conf->osd_commit_majority && parent->can_commit_majority()) {
+    if (op->waiting_for_commit.size() <= parent->get_allow_uncommitted_replicas() &&
+            op->on_commit){
+        op->on_commit->complete(0);
+        op->on_commit = 0;
+    }
+  }else{
+    if (op->waiting_for_commit.empty()) {
+      op->on_commit->complete(0);
+      op->on_commit = 0;
+    }
   }
   if (op->done()) {
     assert(!op->on_commit && !op->on_applied);
@@ -687,10 +694,18 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
       ip_op.on_applied->complete(0);
       ip_op.on_applied = 0;
     }
-    if (ip_op.waiting_for_commit.empty() &&
-        ip_op.on_commit) {
-      ip_op.on_commit->complete(0);
-      ip_op.on_commit= 0;
+    if (cct->_conf->osd_commit_majority && parent->can_commit_majority()) {
+      if (ip_op.waiting_for_commit.size() <= parent->get_allow_uncommitted_replicas() && 
+          ip_op.on_commit) {
+        ip_op.on_commit->complete(0);
+        ip_op.on_commit= 0;
+      }    
+    }else{
+      if (ip_op.waiting_for_commit.empty() &&
+          ip_op.on_commit) {
+        ip_op.on_commit->complete(0);
+        ip_op.on_commit= 0;
+      }
     }
     if (ip_op.done()) {
       assert(!ip_op.on_commit && !ip_op.on_applied);


### PR DESCRIPTION
**The behavior In original flow:**
1\) In the case of 3 copies, the client sends the write to the primary, and then the primary forwards to the other two replicas. The primary must wait for the commit until all the replicas from completion. The real write IO latency is the longest latency among three copies.
2\) When the data distribution is not uniform, the osd node which owns hottest data will become the bottleneck of total latency. 

**The behavior In my enhancement:**
commit_majority function is not required to wait for all copies of commit to complete: as long as the majority of the commit is completed, the cluster would notify the client to complete.

**As in my implementation:**
We also follow the scenario: When the number of copies is less than min_size, ceph does not provide read and write capabilities. In order to ensure security, you must ensure that the number of commit to majority.
And I defined two important variables:
`allow_uncommitted_replicas = pool_min_size - 1, `
`majority = pool_default_size - allow_uncommitted_replicas. `

**Test case:**
1\) 3 copies, pool_default_size = 3, pool_min_size = 2, majority = 2,allow_uncommitted_replicas=1
2\) The average latency decreased by **11.5%**;
3\) Long tail (99.9%) latency decreased by **71.59%**;
4\) IOPS  increased by **13%**.