### PR TITLE
tools: change compare_exchange_weak to compare_exchange_strong

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -125,7 +125,7 @@ private:
   void shutdown()
   {
     bool expected = false;
-    if (terminated.compare_exchange_weak(expected, true)) {
+    if (terminated.compare_exchange_strong(expected, true)) {
       ::shutdown(fd, SHUT_RDWR);
 
       Mutex::Locker l(lock);


### PR DESCRIPTION
On non x86 platforms without a dedicated compare-exchange instruction, std::compare_exchange_weak() could fail.

This is a fixup for PR:
https://github.com/ceph/ceph/pull/14656#pullrequestreview-36315756

Signed-off-by: Jesse Williamson <jwilliamson@suse.de>