### PR TITLE
rgw: fix segfault in RevokeThread during its shutdown procedure.

### DIFF
--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -16,6 +16,8 @@
 #ifndef CEPH_DOUT_H
 #define CEPH_DOUT_H
 
+#include <type_traits>
+
 #include "global/global_context.h"
 #include "common/config.h"
 #include "common/likely.h"
@@ -50,10 +52,13 @@ public:
     if (0) {								\
       char __array[((v >= -1) && (v <= 200)) ? 0 : -1] __attribute__((unused)); \
     }									\
-    static size_t _log_exp_length=80; \
+    static size_t _log_exp_length = 80; 				\
     ceph::logging::Entry *_dout_e = cct->_log->create_entry(v, sub, &_log_exp_length);	\
     ostream _dout_os(&_dout_e->m_streambuf);				\
-    CephContext *_dout_cct = cct;					\
+    static_assert(std::is_convertible<decltype(&*cct), 			\
+				      CephContext* >::value,		\
+		  "provided cct must be compatible with CephContext*"); \
+    auto _dout_cct = cct;						\
     std::ostream* _dout = &_dout_os;
 
 #define lsubdout(cct, sub, v)  dout_impl(cct, ceph_subsys_##sub, v) dout_prefix

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -12,6 +12,7 @@
 #include "rgw_common.h"
 #include "rgw_http_client.h"
 #include "common/Cond.h"
+#include "global/global_init.h"
 
 #include <atomic>
 
@@ -224,7 +225,7 @@ class TokenCache {
     friend class TokenCache;
     typedef RGWPostHTTPData RGWGetRevokedTokens;
 
-    CephContext * const cct;
+    CephContext* const cct;
     TokenCache* const cache;
     const rgw::keystone::Config& config;
 
@@ -239,12 +240,13 @@ class TokenCache {
         config(config),
         lock("rgw::keystone::TokenCache::RevokeThread") {
     }
+
     void *entry() override;
     void stop();
     int check_revoked();
   } revocator;
 
-  CephContext * const cct;
+  const boost::intrusive_ptr<CephContext> cct;
 
   std::string admin_token_id;
   std::string barbican_token_id;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19831
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>