### PR TITLE
librbd: optimize copy-up to add hints only once to object op

### DIFF
--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -167,7 +167,8 @@ bool CopyupRequest::send_copyup() {
     for (size_t i=0; i<m_pending_requests.size(); ++i) {
       ObjectRequest<> *req = m_pending_requests[i];
       ldout(m_ictx->cct, 20) << "add_copyup_ops " << req << dendl;
-      req->add_copyup_ops(&write_op);
+      bool set_hints = (i == 0);
+      req->add_copyup_ops(&write_op, set_hints);
     }
     assert(write_op.size() != 0);
 

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -548,7 +548,7 @@ void AbstractObjectWriteRequest::send_write_op()
     guard_write();
   }
 
-  add_write_ops(&m_write);
+  add_write_ops(&m_write, true);
   assert(m_write.size() != 0);
 
   librados::AioCompletion *rados_completion =
@@ -577,9 +577,10 @@ void AbstractObjectWriteRequest::handle_write_guard()
   }
 }
 
-void ObjectWriteRequest::add_write_ops(librados::ObjectWriteOperation *wr) {
+void ObjectWriteRequest::add_write_ops(librados::ObjectWriteOperation *wr,
+                                       bool set_hints) {
   RWLock::RLocker snap_locker(m_ictx->snap_lock);
-  if (m_ictx->enable_alloc_hint &&
+  if (set_hints && m_ictx->enable_alloc_hint &&
       (m_ictx->object_map == nullptr || !m_object_exist)) {
     wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
   }
@@ -628,9 +629,10 @@ void ObjectTruncateRequest::send_write() {
   }
 }
 
-void ObjectWriteSameRequest::add_write_ops(librados::ObjectWriteOperation *wr) {
+void ObjectWriteSameRequest::add_write_ops(librados::ObjectWriteOperation *wr,
+                                           bool set_hints) {
   RWLock::RLocker snap_locker(m_ictx->snap_lock);
-  if (m_ictx->enable_alloc_hint &&
+  if (set_hints && m_ictx->enable_alloc_hint &&
       (m_ictx->object_map == nullptr || !m_object_exist)) {
     wr->set_alloc_hint(m_ictx->get_object_size(), m_ictx->get_object_size());
   }

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -83,7 +83,9 @@ public:
                 Context *completion, bool hide_enoent);
   ~ObjectRequest() override {}
 
-  virtual void add_copyup_ops(librados::ObjectWriteOperation *wr) {};
+  virtual void add_copyup_ops(librados::ObjectWriteOperation *wr,
+                              bool set_hints) {
+  };
 
   void complete(int r) override;
 
@@ -209,9 +211,10 @@ public:
                              uint64_t len, const ::SnapContext &snapc,
                              Context *completion, bool hide_enoent);
 
-  void add_copyup_ops(librados::ObjectWriteOperation *wr) override
+  void add_copyup_ops(librados::ObjectWriteOperation *wr,
+                      bool set_hints) override
   {
-    add_write_ops(wr);
+    add_write_ops(wr, set_hints);
   }
 
   bool should_complete(int r) override;
@@ -270,7 +273,8 @@ protected:
   bool m_object_exist;
   bool m_guard = true;
 
-  virtual void add_write_ops(librados::ObjectWriteOperation *wr) = 0;
+  virtual void add_write_ops(librados::ObjectWriteOperation *wr,
+                             bool set_hints) = 0;
   virtual void guard_write();
   virtual bool post_object_map_update() {
     return false;
@@ -311,7 +315,8 @@ public:
   }
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override;
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override;
 
   void send_write() override;
 
@@ -358,7 +363,8 @@ public:
   void send_write() override;
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override {
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override {
     if (has_parent()) {
       wr->truncate(0);
     } else {
@@ -397,7 +403,8 @@ public:
   }
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override {
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override {
     wr->remove();
   }
 
@@ -429,7 +436,8 @@ public:
   void send_write() override;
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override {
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override {
     wr->truncate(m_object_off);
   }
 };
@@ -453,7 +461,8 @@ public:
   }
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override {
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override {
     wr->zero(m_object_off, m_object_len);
   }
 };
@@ -480,7 +489,8 @@ public:
   }
 
 protected:
-  void add_write_ops(librados::ObjectWriteOperation *wr) override;
+  void add_write_ops(librados::ObjectWriteOperation *wr,
+                     bool set_hints) override;
 
   void send_write() override;
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19875
Signed-off-by: Mykola Golub <mgolub@mirantis.com>