### PR TITLE
Add OSD owner PG_LIST in osd pg dump output, It's usefull for us to s…

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -983,6 +983,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
   tab.define_column("HB_PEERS", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("PG_SUM", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("PRIMARY_PG_SUM", TextTable::LEFT, TextTable::RIGHT);
+  tab.define_column("PG_LIST", TextTable::LEFT, TextTable::RIGHT);
 
   for (ceph::unordered_map<int32_t,osd_stat_t>::const_iterator p = osd_stat.begin();
        p != osd_stat.end();
@@ -994,6 +995,7 @@ void PGMap::dump_osd_stats(ostream& ss) const
         << p->second.hb_peers
         << get_num_pg_by_osd(p->first)
         << get_num_primary_pg_by_osd(p->first)
+        << get_pg_list_by_osd(p->first)
         << TextTable::endrow;
   }
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -252,6 +252,20 @@ public:
     return pool_stat_t();
   }
 
+  vector<string> get_pg_list_by_osd(int osd) const {
+    vector<string> pgs;
+    ceph::unordered_map<int,set<pg_t> >::const_iterator p = pg_by_osd.find(osd);
+    set<pg_t>::iterator i = p->second.begin();
+    while(i != p->second.end())
+    {
+      char buf[pg_t::calc_name_buf_size];
+      buf[pg_t::calc_name_buf_size -1 ] = '\0';
+      pgs.insert(pgs.begin(), i->calc_name(buf+pg_t::calc_name_buf_size -1,""));
+      i++;
+    }
+    return pgs;
+  }
+
   int get_num_primary_pg_by_osd(int osd) const {
     assert(osd >= 0);
     int num = 0;


### PR DESCRIPTION
we can show osd pg list in pg dump, so that we do not need to get osds pg list using other ways like jq or awk.

Signed-off-by: Linbing <hawkerous@gmail.com>