### PR TITLE
osd/PrimaryLogPG: do not call on_shutdown() if (pg.deleting)

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10230,7 +10230,8 @@ void PrimaryLogPG::on_removal(ObjectStore::Transaction *t)
 
   write_if_dirty(*t);
 
-  on_shutdown();
+  if (!deleting)
+    on_shutdown();
 }
 
 void PrimaryLogPG::on_shutdown()


### PR DESCRIPTION
when a callback is called, it could be facing a PG already shut down by
OSD. but if that callback wants to shut that PG down. it should check
the PG's status first.

Fixes: http://tracker.ceph.com/issues/19902
Signed-off-by: Kefu Chai <kchai@redhat.com>