### PR TITLE
test/fio: fix compiler error.

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -209,7 +209,7 @@ Job::Job(Engine* engine, const thread_data* td)
   for (uint32_t i = 0; i < td->o.nr_files; i++) {
     auto f = td->files[i];
     f->real_file_size = file_size;
-    f->engine_data = i;
+    f->engine_data = reinterpret_cast<void*>(i);
 
     // associate each object with a collection in a round-robin fashion
     auto& coll = collections[i % collections.size()];
@@ -329,7 +329,7 @@ int fio_ceph_os_queue(thread_data* td, io_u* u)
   fio_ro_check(td, u);
 
   auto job = static_cast<Job*>(td->io_ops_data);
-  auto& object = job->objects[u->file->engine_data];
+  auto& object = job->objects[(unsigned long)u->file->engine_data];
   auto& coll = object.coll;
   auto& os = job->engine->os;
 


### PR DESCRIPTION
When call ./do_cmake.sh -DWITH_FIO, met the following errorL

/opt/ceph/src/test/fio/fio_ceph_objectstore.cc: In constructor
‘{anonymous}::Job::Job({anonymous}::Engine*, const thread_data*)’:
/opt/ceph/src/test/fio/fio_ceph_objectstore.cc:212:22: error: invalid
conversion from ‘uint32_t {aka unsigned int}’ to ‘void*’ [-fpermissive]
     f->engine_data = i;
                      ^
/opt/ceph/src/test/fio/fio_ceph_objectstore.cc: In function ‘int
{anonymous}::fio_ceph_os_queue(thread_data*, io_u*)’:
/opt/ceph/src/test/fio/fio_ceph_objectstore.cc:332:40: error: invalid
conversion from ‘void*’ to ‘std::vector<{anonymous}::Object>::size_type
{aka long unsigned int}’ [-fpermissive]
   auto& object = job->objects[u->file->engine_data];
                               ~~~~~~~~~^~~~~~~~~~~
In file included from /usr/include/c++/6.3.1/vector:64:0,
                 from /opt/ceph/src/test/fio/fio_ceph_objectstore.cc:13:
/usr/include/c++/6.3.1/bits/stl_vector.h:780:7: note:   initializing
argument 1 of ‘std::vector<_Tp, _Alloc>::reference std::vector<_Tp,
_Alloc>::operator[](std::vector<_Tp, _Alloc>::size_type) [with _Tp =
{anonymous}::Object; _Alloc = std::allocator<{anonymous}::Object>;
std::vector<_Tp, _Alloc>::reference = {anonymous}::Object&;
std::vector<_Tp, _Alloc>::size_type = long unsigned int]’
       operator[](size_type __n) _GLIBCXX_NOEXCEPT

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>