### PR TITLE
ceph-detect-init: detect init system by poking the system

### DIFF
--- a/doc/man/8/ceph-detect-init.rst
+++ b/doc/man/8/ceph-detect-init.rst
@@ -41,6 +41,17 @@ Options
 
    Display additional information for debugging.
 
+Bugs
+====
+
+:program:`ceph-detect-init` is used by :program:`ceph-disk` to figure out the init system to manage the mount directory of an OSD. But only following combinations are fully tested:
+
+- `upstart` on `Ubuntu 14.04`
+- `systemd` on `Ubuntu 15.04` and up
+- `systemd` on `Debian 8` and up
+- `systemd` on `RHEL/CentOS 7` and up
+- `systemd` on `Fedora 22` and up
+
 Availability
 ============
 

--- a/doc/man/8/ceph-disk.rst
+++ b/doc/man/8/ceph-disk.rst
@@ -78,6 +78,11 @@ the subcommands ``deactivate`` and ``destroy``.
 The documentation for each subcommand (prepare, activate, etc.) can be displayed
 with its ``--help`` option. For instance ``ceph-disk prepare --help``.
 
+Bugs
+====
+
+See also the ``Bugs`` section in :doc:`ceph-detect-init <ceph-detect-init>`\(8).
+
 Availability
 ============
 
@@ -87,5 +92,6 @@ the Ceph documentation at http://ceph.com/docs for more information.
 See also
 ========
 
+:doc:`ceph-detect-init <ceph-detect-init>`\(8)
 :doc:`ceph-osd <ceph-osd>`\(8),
 :doc:`ceph-deploy <ceph-deploy>`\(8)

--- a/src/ceph-detect-init/ceph_detect_init/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/__init__.py
@@ -141,23 +141,7 @@ def platform_information():
     distro_lower = distro.lower()
     # this could be an empty string in Debian
     if not codename and 'debian' in distro_lower:
-        debian_codenames = {
-            '8': 'jessie',
-            '7': 'wheezy',
-            '6': 'squeeze',
-        }
-        major_version = release.split('.')[0]
-        codename = debian_codenames.get(major_version, '')
-
-        # In order to support newer jessie/sid or wheezy/sid strings
-        # we test this if sid is buried in the minor, we should use
-        # sid anyway.
-        if not codename and '/' in release:
-            major, minor = release.split('/')
-            if minor == 'sid':
-                codename = minor
-            else:
-                codename = major
+        pass
     # this is an empty string in Oracle
     elif distro_lower.startswith('oracle linux'):
         codename = 'OL' + release

--- a/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
+++ b/src/ceph-detect-init/ceph_detect_init/debian/__init__.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+
 distro = None
 release = None
 codename = None
@@ -8,14 +11,11 @@ def choose_init():
 
     Returns the name of a init system (upstart, sysvinit ...).
     """
-    assert(distro and codename)
-    if distro.lower() in ('ubuntu', 'linuxmint'):
-        if codename >= 'vivid':
-            return 'systemd'
-        else:
-            return 'upstart'
-    if distro.lower() == 'debian':
-        if codename in ('squeeze', 'wheezy'):
-            return 'sysvinit'
-        else:
-            return 'systemd'
+    # yes, this is heuristics
+    if os.path.isdir('/run/systemd/system'):
+        return 'systemd'
+    if not subprocess.call('. /lib/lsb/init-functions ; init_is_upstart',
+                           shell=True):
+        return 'upstart'
+    if os.path.isfile('/sbin/init') and not os.path.islink('/sbin/init'):
+        return 'sysvinit'

--- a/src/ceph-detect-init/tests/test_all.py
+++ b/src/ceph-detect-init/tests/test_all.py
@@ -65,30 +65,35 @@ class TestCephDetectInit(testtools.TestCase):
         self.assertEqual('sysvinit', centos.choose_init())
 
     def test_debian(self):
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='debian',
-                                 codename='wheezy'):
-            self.assertEqual('sysvinit', debian.choose_init())
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='debian',
-                                 codename='squeeze'):
-            self.assertEqual('sysvinit', debian.choose_init())
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='debian',
-                                 codename='jessie'):
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: x == '/run/systemd/system'):
             self.assertEqual('systemd', debian.choose_init())
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='ubuntu',
-                                 codename='trusty'):
-            self.assertEqual('upstart', debian.choose_init())
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='ubuntu',
-                                 codename='vivid'):
-            self.assertEqual('systemd', debian.choose_init())
-        with mock.patch.multiple('ceph_detect_init.debian',
-                                 distro='not-debian',
-                                 codename='andy'):
-            self.assertIs(None, debian.choose_init())
+
+        def mock_call_with_upstart(*args, **kwargs):
+            if args[0] == '. /lib/lsb/init-functions ; init_is_upstart' and \
+               kwargs['shell']:
+                return 0
+            else:
+                return 1
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: False,
+                                 isfile=lambda x: False):
+            with mock.patch.multiple('subprocess',
+                                     call=mock_call_with_upstart):
+                self.assertEqual('upstart', debian.choose_init())
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: False,
+                                 isfile=lambda x: x == '/sbin/init',
+                                 islink=lambda x: x != '/sbin/init'):
+            with mock.patch.multiple('subprocess',
+                                     call=lambda *args, **kwargs: 1):
+                self.assertEqual('sysvinit', debian.choose_init())
+        with mock.patch.multiple('os.path',
+                                 isdir=lambda x: False,
+                                 isfile=lambda x: False):
+            with mock.patch.multiple('subprocess',
+                                     call=lambda *args, **kwargs: 1):
+                self.assertIs(None, debian.choose_init())
 
     def test_fedora(self):
         with mock.patch('ceph_detect_init.fedora.release',
@@ -183,8 +188,6 @@ class TestCephDetectInit(testtools.TestCase):
             self.assertEqual('debian', distro.distro)
             self.assertEqual(False, distro.is_el)
             self.assertEqual('6.0', distro.release)
-            self.assertEqual('squeeze', distro.codename)
-            self.assertEqual('sysvinit', distro.init)
 
         with mock.patch.multiple('platform',
                                  system=lambda: 'FreeBSD',
@@ -252,29 +255,9 @@ class TestCephDetectInit(testtools.TestCase):
     @mock.patch('platform.system', lambda: 'Linux')
     def test_platform_information_linux(self):
         with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '6.0', ''))):
-            self.assertEqual(('debian', '6.0', 'squeeze'),
-                             ceph_detect_init.platform_information())
-
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', '7.0', ''))):
-            self.assertEqual(('debian', '7.0', 'wheezy'),
-                             ceph_detect_init.platform_information())
-
-        with mock.patch('platform.linux_distribution',
                         lambda **kwargs: (('debian', '8.0', ''))):
-            self.assertEqual(('debian', '8.0', 'jessie'),
-                             ceph_detect_init.platform_information())
-
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', 'jessie/sid', ''))):
-            self.assertEqual(('debian', 'jessie/sid', 'sid'),
-                             ceph_detect_init.platform_information())
-
-        with mock.patch('platform.linux_distribution',
-                        lambda **kwargs: (('debian', 'sid/jessie', ''))):
-            self.assertEqual(('debian', 'sid/jessie', 'sid'),
-                             ceph_detect_init.platform_information())
+            self.assertEqual(('debian', '8.0'),
+                             ceph_detect_init.platform_information()[:-1])
 
         with mock.patch('platform.linux_distribution',
                         lambda **kwargs: (('Oracle Linux Server', '7.3', ''))):

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -546,53 +546,6 @@ def command_check_call(arguments, exit=False):
         raise
 
 
-def platform_distro():
-    """
-    Returns a normalized, lower case string without any leading nor trailing
-    whitespace that represents the distribution name of the current machine.
-    """
-    distro = platform_information()[0] or ''
-    return distro.strip().lower()
-
-
-def platform_information():
-    if FREEBSD:
-        distro = platform.system()
-        release = platform.version().split()[1]
-        codename = platform.version().split()[3]
-        version = platform.version().split('-')[0][:-1]
-        major_version = version.split('.')[0]
-        major, minor = release.split('.')
-    else:
-        distro, release, codename = platform.linux_distribution()
-        # this could be an empty string in Debian
-        if not codename and 'debian' in distro.lower():
-            debian_codenames = {
-                '8': 'jessie',
-                '7': 'wheezy',
-                '6': 'squeeze',
-            }
-            major_version = release.split('.')[0]
-            codename = debian_codenames.get(major_version, '')
-
-            # In order to support newer jessie/sid,  wheezy/sid strings we test
-            # this if sid is buried in the minor, we should use sid anyway.
-            if not codename and '/' in release:
-                major, minor = release.split('/')
-                if minor == 'sid':
-                    codename = minor
-                else:
-                    codename = major
-        # this could be an empty string in Virtuozzo linux
-        if not codename and 'virtuozzo linux' in distro.lower():
-            codename = 'virtuozzo'
-
-    return (
-        str(distro).strip(),
-        str(release).strip(),
-        str(codename).strip()
-    )
-
 #
 # An alternative block_path implementation would be
 #


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19884