### PR TITLE
rbd-mirror: resolve admin socket path names collision

### DIFF
--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -387,6 +387,11 @@ int PoolReplayer::init_rados(const std::string &cluster_name,
     }
   }
 
+  if (!g_ceph_context->_conf->admin_socket.empty()) {
+    cct->_conf->set_val_or_die("admin_socket",
+                               "$run_dir/$name.$pid.$cluster.$cctid.asok");
+  }
+
   // disable unnecessary librbd cache
   cct->_conf->set_val_or_die("rbd_cache", "false");
   cct->_conf->apply_changes(nullptr);
@@ -463,6 +468,13 @@ void PoolReplayer::print_status(Formatter *f, stringstream *ss)
     }
     f->close_section();
   }
+
+  f->dump_string("local_cluster_admin_socket",
+                 reinterpret_cast<CephContext *>(m_local_io_ctx.cct())->_conf->
+                     admin_socket);
+  f->dump_string("remote_cluster_admin_socket",
+                 reinterpret_cast<CephContext *>(m_remote_io_ctx.cct())->_conf->
+                     admin_socket);
 
   m_instance_replayer->print_status(f, ss);
 


### PR DESCRIPTION
If global admin_socket parameter is set, for PoolReplayer admin
sockets generate and use unique paths in $run_dir. Provide the socket
paths in output of PoolReplayer's "rbd mirror status" admin socket
command.

A possible use case:

1) run "rbd mirror status $pool_replayer" command using global admin
   socket (known from configuration) and obtain socket paths for the
   PoolReplayer local and remote context sockets.
2) Use these paths to run commands provides by the contexts.

Fixes: http://tracker.ceph.com/issues/19907
Signed-off-by: Mykola Golub <mgolub@mirantis.com>