### PR TITLE
jewel: core: an OSD was seen getting ENOSPC even with osd_failsafe_full_ratio passed

### DIFF
--- a/doc/rados/configuration/mon-osd-interaction.rst
+++ b/doc/rados/configuration/mon-osd-interaction.rst
@@ -222,7 +222,7 @@ Monitor Settings
               mark Ceph OSD Daemons ``out``.
               
 :Type: Double
-:Default: ``.3``
+:Default: ``.75``
 
 
 ``mon osd laggy halflife``

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -274,6 +274,7 @@ OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL, true) // warn if cru
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL, true) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL, true)
 OPTION(mon_warn_osd_usage_percent, OPT_FLOAT, .40) // warn if difference in usage percent between OSDs exceeds specified percent
+OPTION(mon_warn_osd_usage_min_max_delta, OPT_FLOAT, .40) // warn if difference between min and max OSD utilizations exceeds specified amount
 OPTION(mon_min_osdmap_epochs, OPT_INT, 500)
 OPTION(mon_max_pgmap_epochs, OPT_INT, 500)
 OPTION(mon_max_log_epochs, OPT_INT, 500)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -273,6 +273,7 @@ OPTION(mon_crush_min_required_version, OPT_STR, "firefly")
 OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL, true) // warn if crush straw_calc_version==0
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL, true) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL, true)
+OPTION(mon_warn_osd_usage_percent, OPT_FLOAT, .40) // warn if difference in usage percent between OSDs exceeds specified percent
 OPTION(mon_min_osdmap_epochs, OPT_INT, 500)
 OPTION(mon_max_pgmap_epochs, OPT_INT, 500)
 OPTION(mon_max_log_epochs, OPT_INT, 500)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -231,7 +231,7 @@ OPTION(mon_osd_auto_mark_new_in, OPT_BOOL, true)      // mark booting new osds '
 OPTION(mon_osd_down_out_interval, OPT_INT, 300) // seconds
 OPTION(mon_osd_down_out_subtree_limit, OPT_STR, "rack")   // smallest crush unit/type that we will not automatically mark out
 OPTION(mon_osd_min_up_ratio, OPT_DOUBLE, .3)    // min osds required to be up to mark things down
-OPTION(mon_osd_min_in_ratio, OPT_DOUBLE, .3)   // min osds required to be in to mark things out
+OPTION(mon_osd_min_in_ratio, OPT_DOUBLE, .75)   // min osds required to be in to mark things out
 OPTION(mon_osd_max_op_age, OPT_DOUBLE, 32)     // max op age before we get concerned (make it a power of 2)
 OPTION(mon_osd_max_split_count, OPT_INT, 32) // largest number of PGs per "involved" OSD to let split create
 OPTION(mon_osd_allow_primary_temp, OPT_BOOL, false)  // allow primary_temp to be set in the osdmap

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -2351,11 +2351,11 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
     float diff = max_osd_usage - min_osd_usage;
     if (diff > g_conf->mon_warn_osd_usage_min_max_delta) {
       ostringstream ss;
-      ss << "difference between min (" << roundf(min_osd_usage*1000.0)/100.0
-	 << "%) and max (" << roundf(max_osd_usage*1000.0)/100.0
-	 << "%) osd usage " << roundf(diff*1000.0)/100.0 << "% > "
-	 << roundf(g_conf->mon_warn_osd_usage_min_max_delta*1000.0)/100.0
-	 << " (mon_warn_osd_usage_min_max_delta)";
+      ss << "difference between min (" << roundf(min_osd_usage*1000.0)/10.0
+	 << "%) and max (" << roundf(max_osd_usage*1000.0)/10.0
+	 << "%) osd usage " << roundf(diff*1000.0)/10.0 << "% > "
+	 << roundf(g_conf->mon_warn_osd_usage_min_max_delta*1000.0)/10.0
+	 << "% (mon_warn_osd_usage_min_max_delta)";
       summary.push_back(make_pair(HEALTH_WARN, ss.str()));
       if (detail)
         detail->push_back(make_pair(HEALTH_WARN, ss.str()));

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -2336,21 +2336,26 @@ void PGMonitor::get_health(list<pair<health_status_t,string> >& summary,
     }
   }
 
-  if (g_conf->mon_warn_osd_usage_percent) {
-    float max_osd_perc_avail = 0.0, min_osd_perc_avail = 1.0;
+  if (g_conf->mon_warn_osd_usage_min_max_delta) {
+    float max_osd_usage = 0.0, min_osd_usage = 1.0;
     for (auto p = pg_map.osd_stat.begin(); p != pg_map.osd_stat.end(); ++p) {
       // kb should never be 0, but avoid divide by zero in case of corruption
       if (p->second.kb <= 0)
         continue;
-      float perc_avail = ((float)(p->second.kb - p->second.kb_avail)) / ((float)p->second.kb);
-      if (perc_avail > max_osd_perc_avail)
-        max_osd_perc_avail = perc_avail;
-      if (perc_avail < min_osd_perc_avail)
-        min_osd_perc_avail = perc_avail;
+      float usage = ((float)p->second.kb_used) / ((float)p->second.kb);
+      if (usage > max_osd_usage)
+        max_osd_usage = usage;
+      if (usage < min_osd_usage)
+        min_osd_usage = usage;
     }
-    if ((max_osd_perc_avail - min_osd_perc_avail) > g_conf->mon_warn_osd_usage_percent) {
+    float diff = max_osd_usage - min_osd_usage;
+    if (diff > g_conf->mon_warn_osd_usage_min_max_delta) {
       ostringstream ss;
-      ss << "Difference in osd space utilization " << ((max_osd_perc_avail - min_osd_perc_avail) *100) << "% greater than " << (g_conf->mon_warn_osd_usage_percent * 100) << "%";
+      ss << "difference between min (" << roundf(min_osd_usage*1000.0)/100.0
+	 << "%) and max (" << roundf(max_osd_usage*1000.0)/100.0
+	 << "%) osd usage " << roundf(diff*1000.0)/100.0 << "% > "
+	 << roundf(g_conf->mon_warn_osd_usage_min_max_delta*1000.0)/100.0
+	 << " (mon_warn_osd_usage_min_max_delta)";
       summary.push_back(make_pair(HEALTH_WARN, ss.str()));
       if (detail)
         detail->push_back(make_pair(HEALTH_WARN, ss.str()));

--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -2232,3 +2232,15 @@ void FileJournal::corrupt_header_magic(
     (reinterpret_cast<char*>(&h.magic2) - reinterpret_cast<char*>(&h));
   corrupt(wfd, corrupt_at);
 }
+
+off64_t FileJournal::get_journal_size_estimate()
+{
+  off64_t size, start = header.start;
+  if (write_pos < start) {
+    size = (max_size - start) + write_pos;
+  } else {
+    size = write_pos - start;
+  }
+  dout(20) << __func__ << " journal size=" << size << dendl;
+  return size;
+}

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -472,6 +472,8 @@ private:
 
   void set_wait_on_full(bool b) { wait_on_full = b; }
 
+  off64_t get_journal_size_estimate();
+
   // reads
 
   /// Result code for read_entry

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2895,7 +2895,7 @@ void FileStore::_do_transaction(
 	} else if (r == -ENOSPC) {
 	  // For now, if we hit _any_ ENOSPC, crash, before we do any damage
 	  // by partially applying transactions.
-	  msg = "ENOSPC handling not implemented";
+	  msg = "ENOSPC from disk filesystem, misconfigured cluster";
 	} else if (r == -ENOTEMPTY) {
 	  msg = "ENOTEMPTY suggests garbage data in osd data dir";
 	} else if (r == -EPERM) {

--- a/src/os/filestore/Journal.h
+++ b/src/os/filestore/Journal.h
@@ -81,6 +81,8 @@ public:
 
   virtual int prepare_entry(vector<ObjectStore::Transaction>& tls, bufferlist* tbl) = 0;
 
+  virtual off64_t get_journal_size_estimate() { return 0; }
+
   // reads/recovery
 
 };

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -2774,7 +2774,7 @@ void KStore::_txc_add_transaction(TransContext *txc, Transaction *t)
 	if (r == -ENOSPC)
 	  // For now, if we hit _any_ ENOSPC, crash, before we do any damage
 	  // by partially applying transactions.
-	  msg = "ENOSPC handling not implemented";
+	  msg = "ENOSPC from key value store, misconfigured cluster";
 
 	if (r == -ENOTEMPTY) {
 	  msg = "ENOTEMPTY suggests garbage data in osd data dir";

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -985,7 +985,7 @@ void MemStore::_do_transaction(Transaction& t)
 	if (r == -ENOSPC)
 	  // For now, if we hit _any_ ENOSPC, crash, before we do any damage
 	  // by partially applying transactions.
-	  msg = "ENOSPC handling not implemented";
+	  msg = "ENOSPC from MemStore, misconfigured cluster or insufficient memory";
 
 	if (r == -ENOTEMPTY) {
 	  msg = "ENOTEMPTY suggests garbage data in osd data dir";

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -734,9 +734,9 @@ void OSDService::check_nearfull_warning(const osd_stat_t &osd_stat)
   }
   last_msg = now;
   if (cur_state == FULL)
-    clog->error() << "OSD full dropping all updates " << (int)(ratio * 100) << "% full";
+    clog->error() << "OSD full dropping all updates " << (int)roundf(ratio * 100) << "% full";
   else
-    clog->warn() << "OSD near full (" << (int)(ratio * 100) << "%)";
+    clog->warn() << "OSD near full (" << (int)roundf(ratio * 100) << "%)";
 }
 
 bool OSDService::check_failsafe_full()


### PR DESCRIPTION
http://tracker.ceph.com/issues/19265
http://tracker.ceph.com/issues/19842
http://tracker.ceph.com/issues/20676

This backport contains both https://github.com/ceph/ceph/pull/13425 and https://github.com/ceph/ceph/pull/14611, except BlueStore related commit https://github.com/ceph/ceph/pull/13425/commits/72d83f848a35e8831d66e8529c4e26f51e845da6 (backporting BlueStore part requires a lot of unrelated changes and hardly makes Jewel's BlueStore any better)
