### PR TITLE
mds: use debug_mds for most subsys

### DIFF
--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -88,8 +88,6 @@ particular daemons are set under the daemon section in your configuration file
 	[mds]
 		debug mds = 1
 		debug mds balancer = 1
-		debug mds log = 1
-		debug mds migrator = 1
 
 
 See `Subsystem, Log and Debug Settings`_ for details.
@@ -171,7 +169,7 @@ as ``debug ms = 1/5``. For example:
 
 	debug {subsystem} = {log-level}/{memory-level}
 	#for example
-	debug mds log = 1/20
+	debug mds balancer = 1/20
 
 
 The following table provides a list of Ceph subsystems and their default log and

--- a/src/common/dout.h
+++ b/src/common/dout.h
@@ -77,9 +77,11 @@ public:
 
 // NOTE: depend on magic value in _ASSERT_H so that we detect when
 // /usr/include/assert.h clobbers our fancier version.
-#define dendl std::flush;				\
+#define dendl_impl std::flush;				\
   _ASSERT_H->_log->submit_entry(_dout_e);		\
     }						\
   } while (0)
+
+#define dendl dendl_impl
 
 #endif

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -47,8 +47,6 @@
 
 #define dout_subsys ceph_subsys_mds
 #undef dout_prefix
-#undef DOUT_COND
-#define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_locker
 #define dout_context g_ceph_context
 #define dout_prefix _prefix(_dout, mds)
 static ostream& _prefix(std::ostream *_dout, MDSRank *mds) {

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -33,8 +33,6 @@
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
-#undef DOUT_COND
-#define DOUT_COND(cct, l) l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_log
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".log "
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -78,8 +78,6 @@
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
-#undef DOUT_COND
-#define DOUT_COND(cct, l) (l <= cct->_conf->debug_mds || l <= cct->_conf->debug_mds_migrator)
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".migrator "
 

--- a/src/mds/journal.cc
+++ b/src/mds/journal.cc
@@ -54,9 +54,6 @@
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
-#undef DOUT_COND
-#define DOUT_COND(cct, l) (l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_log \
-			      || l <= cct->_conf->debug_mds_log_expire)
 #undef dout_prefix
 #define dout_prefix *_dout << "mds." << mds->get_nodeid() << ".journal "
 
@@ -297,9 +294,6 @@ void LogSegment::try_to_expire(MDSRank *mds, MDSGatherBuilder &gather_bld, int o
     dout(6) << "LogSegment(" << seq << "/" << offset << ").try_to_expire success" << dendl;
   }
 }
-
-#undef DOUT_COND
-#define DOUT_COND(cct, l) (l<=cct->_conf->debug_mds || l <= cct->_conf->debug_mds_log)
 
 
 // -----------------------


### PR DESCRIPTION
DOUT_COND was obsoleted by f41887e38d70970f4d0181fb73e835ece68cee6c.

Balancer and Mantle use a dout hack to continue working since we will probably
specifically want very verbose balancer output in the future.

Fixes: http://tracker.ceph.com/issues/19734

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>