### PR TITLE
rgw: fix error handling in Browser Uploads.

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1492,6 +1492,9 @@ int RGWPostObj_ObjStore::read_form_part_header(struct post_form_part* const part
     }
 
     r = read_line(bl, chunk_size, reached_boundary, done);
+    if (r < 0) {
+      return r;
+    }
   }
 
   return 0;


### PR DESCRIPTION
The recent Coverity Scan for Ceph (published May 11, 2017 on ceph-devel) shows that the `read_form_part_header method` of `RGWPostObj_ObjStore` assigns to a variable but doesn't use it later. The anomaly is caused by lack of proper error handling. This commit rectifies it.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>