### PR TITLE
qa/tasks/cephfs: use getattr to guarantee inode is in client cache

### DIFF
--- a/qa/tasks/cephfs/test_client_recovery.py
+++ b/qa/tasks/cephfs/test_client_recovery.py
@@ -315,7 +315,7 @@ class TestClientRecovery(CephFSTestCase):
             self.mount_a.run_shell(["touch", "f{0}".format(i)])
 
         # Populate mount_b's cache
-        self.mount_b.run_shell(["ls"])
+        self.mount_b.run_shell(["ls", "-l"])
 
         client_id = self.mount_b.get_global_id()
         num_caps = self._session_num_caps(client_id)


### PR DESCRIPTION
When selinux is enabled, kernel client may releases inodes (without
uptodate xattr) in readdir reply immediately after processing the reply.
The reason is that linking the inode to dentry causes deadlock if xattr
is not uptodate.

We can use stat(2) syscall to guarantee that kernel client caches an
inode.

Fixes: http://tracker.ceph.com/issues/19912
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>