### PR TITLE
DNM osd: drop hb front/back addrs and ping normal interfaces

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -473,35 +473,50 @@ flushjournal_out:
 
   public_msg_type = public_msg_type.empty() ? msg_type : public_msg_type;
   cluster_msg_type = cluster_msg_type.empty() ? msg_type : cluster_msg_type;
-  Messenger *ms_public = Messenger::create(g_ceph_context, public_msg_type,
-					   entity_name_t::OSD(whoami), "client",
-					   getpid(),
-					   Messenger::HAS_HEAVY_TRAFFIC |
-					   Messenger::HAS_MANY_CONNECTIONS);
-  Messenger *ms_cluster = Messenger::create(g_ceph_context, cluster_msg_type,
-					    entity_name_t::OSD(whoami), "cluster",
-					    getpid(),
-					    Messenger::HAS_HEAVY_TRAFFIC |
-					    Messenger::HAS_MANY_CONNECTIONS);
-  Messenger *ms_hb_back_client = Messenger::create(g_ceph_context, cluster_msg_type,
-					     entity_name_t::OSD(whoami), "hb_back_client",
-					     getpid(), Messenger::HEARTBEAT);
-  Messenger *ms_hb_front_client = Messenger::create(g_ceph_context, public_msg_type,
-					     entity_name_t::OSD(whoami), "hb_front_client",
-					     getpid(), Messenger::HEARTBEAT);
-  Messenger *ms_hb_back_server = Messenger::create(g_ceph_context, cluster_msg_type,
-						   entity_name_t::OSD(whoami), "hb_back_server",
-						   getpid(), Messenger::HEARTBEAT);
-  Messenger *ms_hb_front_server = Messenger::create(g_ceph_context, public_msg_type,
-						    entity_name_t::OSD(whoami), "hb_front_server",
-						    getpid(), Messenger::HEARTBEAT);
-  Messenger *ms_objecter = Messenger::create(g_ceph_context, public_msg_type,
-					     entity_name_t::OSD(whoami), "ms_objecter",
-					     getpid(), 0);
+  Messenger *ms_public = Messenger::create(
+    g_ceph_context, public_msg_type,
+    entity_name_t::OSD(whoami), "client",
+    getpid(),
+    Messenger::HAS_HEAVY_TRAFFIC |
+    Messenger::HAS_MANY_CONNECTIONS);
+  Messenger *ms_cluster = Messenger::create(
+    g_ceph_context, cluster_msg_type,
+    entity_name_t::OSD(whoami), "cluster",
+    getpid(),
+    Messenger::HAS_HEAVY_TRAFFIC |
+    Messenger::HAS_MANY_CONNECTIONS);
+  Messenger *ms_hb_back_client = Messenger::create(
+    g_ceph_context, cluster_msg_type,
+    entity_name_t::OSD(whoami), "hb_back_client",
+    getpid(), Messenger::HEARTBEAT);
+  Messenger *ms_hb_front_client = Messenger::create(
+    g_ceph_context, public_msg_type,
+    entity_name_t::OSD(whoami), "hb_front_client",
+    getpid(), Messenger::HEARTBEAT);
+  Messenger *ms_hb_front_client_legacy = Messenger::create(
+    g_ceph_context,
+    public_msg_type,
+    entity_name_t::OSD(whoami),
+    "hb_front_client_legacy",
+    getpid(), Messenger::HEARTBEAT);
+  Messenger *ms_hb_back_server = Messenger::create(
+    g_ceph_context, cluster_msg_type,
+    entity_name_t::OSD(whoami),
+    "hb_back_server",
+    getpid(), Messenger::HEARTBEAT);
+  Messenger *ms_hb_front_server = Messenger::create(
+    g_ceph_context, public_msg_type,
+    entity_name_t::OSD(whoami),
+    "hb_front_server",
+    getpid(), Messenger::HEARTBEAT);
+  Messenger *ms_objecter = Messenger::create(
+    g_ceph_context, public_msg_type,
+    entity_name_t::OSD(whoami), "ms_objecter",
+    getpid(), 0);
   if (!ms_public || !ms_cluster || !ms_hb_front_client || !ms_hb_back_client || !ms_hb_back_server || !ms_hb_front_server || !ms_objecter)
     exit(1);
   ms_cluster->set_cluster_protocol(CEPH_OSD_PROTOCOL);
-  ms_hb_front_client->set_cluster_protocol(CEPH_OSD_PROTOCOL);
+  ms_hb_front_client_legacy->set_cluster_protocol(CEPH_OSDC_PROTOCOL);
   ms_hb_back_client->set_cluster_protocol(CEPH_OSD_PROTOCOL);
   ms_hb_back_server->set_cluster_protocol(CEPH_OSD_PROTOCOL);
   ms_hb_front_server->set_cluster_protocol(CEPH_OSD_PROTOCOL);
@@ -550,6 +565,8 @@ flushjournal_out:
 
   ms_hb_front_client->set_policy(entity_name_t::TYPE_OSD,
 			  Messenger::Policy::lossy_client(0));
+  ms_hb_front_client_legacy->set_policy(entity_name_t::TYPE_OSD,
+			  Messenger::Policy::lossy_client(0));
   ms_hb_back_client->set_policy(entity_name_t::TYPE_OSD,
 			  Messenger::Policy::lossy_client(0));
   ms_hb_back_server->set_policy(entity_name_t::TYPE_OSD,
@@ -568,6 +585,7 @@ flushjournal_out:
   bool is_delay = g_conf->get_val<bool>("osd_heartbeat_use_min_delay_socket");
   if (is_delay) {
     ms_hb_front_client->set_socket_priority(SOCKET_PRIORITY_MIN_DELAY);
+    ms_hb_front_client_legacy->set_socket_priority(SOCKET_PRIORITY_MIN_DELAY);
     ms_hb_back_client->set_socket_priority(SOCKET_PRIORITY_MIN_DELAY);
     ms_hb_back_server->set_socket_priority(SOCKET_PRIORITY_MIN_DELAY);
     ms_hb_front_server->set_socket_priority(SOCKET_PRIORITY_MIN_DELAY);
@@ -593,6 +611,9 @@ flushjournal_out:
   if (ms_hb_front_server->bind(hb_front_addr) < 0)
     exit(1);
   if (ms_hb_front_client->client_bind(hb_front_addr) < 0)
+    exit(1);
+  r = ms_hb_front_client_legacy->client_bind(hb_front_addr);
+  if (r < 0)
     exit(1);
 
   // Set up crypto, daemonize, etc.
@@ -623,6 +644,7 @@ flushjournal_out:
                 ms_cluster,
                 ms_public,
                 ms_hb_front_client,
+		ms_hb_front_client_legacy,
                 ms_hb_back_client,
                 ms_hb_front_server,
                 ms_hb_back_server,
@@ -640,6 +662,7 @@ flushjournal_out:
 
   ms_public->start();
   ms_hb_front_client->start();
+  ms_hb_front_client_legacy->start();
   ms_hb_back_client->start();
   ms_hb_front_server->start();
   ms_hb_back_server->start();
@@ -671,6 +694,7 @@ flushjournal_out:
 
   ms_public->wait();
   ms_hb_front_client->wait();
+  ms_hb_front_client_legacy->wait();
   ms_hb_back_client->wait();
   ms_hb_front_server->wait();
   ms_hb_back_server->wait();
@@ -686,6 +710,7 @@ flushjournal_out:
   delete osd;
   delete ms_public;
   delete ms_hb_front_client;
+  delete ms_hb_front_client_legacy;
   delete ms_hb_back_client;
   delete ms_hb_front_server;
   delete ms_hb_back_server;

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -97,7 +97,8 @@ public:
 	(features & CEPH_FEATURE_OSDENC) == 0 ||
         (features & CEPH_FEATURE_OSDMAP_ENC) == 0 ||
 	(features & CEPH_FEATURE_MSG_ADDR2) == 0 ||
-	!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+	!HAVE_FEATURE(features, SERVER_LUMINOUS) ||
+	!HAVE_FEATURE(features, SERVER_MIMIC)) {
       if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	  (features & CEPH_FEATURE_PGPOOL3) == 0)
 	header.version = 1;  // old old_client version

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3856,15 +3856,6 @@ void Monitor::remove_all_sessions()
     logger->set(l_mon_num_sessions, session_map.get_size());
 }
 
-void Monitor::send_command(const entity_inst_t& inst,
-			   const vector<string>& com)
-{
-  dout(10) << "send_command " << inst << "" << com << dendl;
-  MMonCommand *c = new MMonCommand(monmap->fsid);
-  c->cmd = com;
-  try_send_message(c, inst);
-}
-
 void Monitor::waitlist_or_zap_client(MonOpRequestRef op)
 {
   /**

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -4248,7 +4248,6 @@ void Monitor::handle_ping(MonOpRequestRef op)
   MPing *m = static_cast<MPing*>(op->get_req());
   dout(10) << __func__ << " " << *m << dendl;
   MPing *reply = new MPing;
-  entity_inst_t inst = m->get_source_inst();
   bufferlist payload;
   boost::scoped_ptr<Formatter> f(new JSONFormatter(true));
   f->open_object_section("pong");
@@ -4264,8 +4263,9 @@ void Monitor::handle_ping(MonOpRequestRef op)
   f->flush(ss);
   ::encode(ss.str(), payload);
   reply->set_payload(payload);
-  dout(10) << __func__ << " reply payload len " << reply->get_payload().length() << dendl;
-  messenger->send_message(reply, inst);
+  dout(10) << __func__ << " reply payload len " << reply->get_payload().length()
+	   << dendl;
+  m->get_connection()->send_message(reply);
 }
 
 void Monitor::timecheck_start()

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -801,9 +801,6 @@ public:
   void remove_all_sessions();
   void waitlist_or_zap_client(MonOpRequestRef op);
 
-  void send_command(const entity_inst_t& inst,
-		    const vector<string>& com);
-
 public:
   struct C_Command : public C_MonOp {
     Monitor *mon;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -152,6 +152,15 @@ struct MonSessionMap {
     return s;
   }
 
+  void get_osd_sessions(int osd, list<MonSession*> *ls) {
+    auto p = by_osd.find(osd);
+    while (p != by_osd.end() &&
+	   p->first == osd) {
+      ls->push_back(p->second);
+      ++p;
+    }
+  }
+
   MonSession *get_random_osd_session(OSDMap *osdmap) {
     // ok, this isn't actually random, but close enough.
     if (by_osd.empty())

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -456,6 +456,10 @@ int Pipe::accept()
     // note peer's type, flags
     set_peer_type(connect.host_type);
     policy = msgr->get_policy(connect.host_type);
+    if ((connect.flags & CEPH_MSG_CONNECT_LOSSY) && !policy.lossy) {
+      ldout(msgr->cct, 10) << __func__ << " client forcing lossy session" << dendl;
+      policy = Messenger::Policy::stateless_server(policy.features_required);
+    }
     ldout(msgr->cct,10) << "accept of host_type " << connect.host_type
 			<< ", policy.lossy=" << policy.lossy
 			<< " policy.server=" << policy.server

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1030,9 +1030,20 @@ pair<ConnectionRef,ConnectionRef> OSDService::get_con_osd_hb(int peer, epoch_t f
     release_map(next_map);
     return ret;
   }
-  ret.first = osd->hb_back_client_messenger->get_connection(next_map->get_hb_back_inst(peer));
-  if (next_map->get_hb_front_addr(peer) != entity_addr_t())
-    ret.second = osd->hb_front_client_messenger->get_connection(next_map->get_hb_front_inst(peer));
+
+  if (HAVE_FEATURE(next_map->get_xinfo(peer).features, SERVER_MIMIC)) {
+    ret.first = osd->hb_back_client_messenger->get_connection(
+      next_map->get_cluster_inst(peer));
+    ret.second = osd->hb_front_client_messenger->get_connection(
+      next_map->get_inst(peer));
+  } else {
+    // for luminous compat only
+    ret.first = osd->hb_back_client_messenger->get_connection(
+      next_map->get_hb_back_inst(peer));
+    if (next_map->get_hb_front_addr(peer) != entity_addr_t())
+      ret.second = osd->hb_front_client_messenger->get_connection(
+	next_map->get_hb_front_inst(peer));
+  }
   release_map(next_map);
   return ret;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5591,7 +5591,10 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
 	   << oldest << ".." << newest << dendl;
 
   // ensure our local fullness awareness is accurate
-  heartbeat();
+  {
+    Mutex::Locker l(heartbeat_lock);
+    heartbeat();
+  }
 
   // if our map within recent history, try to add ourselves to the osdmap.
   if (osdmap->get_epoch() == 0) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6613,6 +6613,17 @@ void OSD::ms_fast_dispatch(Message *m)
     m->put();
     return;
   }
+
+  switch (m->get_type()) {
+  case CEPH_MSG_PING:
+    dout(10) << "ping from " << m->get_source_inst() << dendl;
+    m->put();
+    return;
+  case MSG_OSD_PING:
+    handle_osd_ping(static_cast<MOSDPing*>(m));
+    return;
+  }
+
   OpRequestRef op = op_tracker.create_request<OpRequest, Message*>(m);
   {
 #ifdef WITH_LTTNG

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7658,12 +7658,7 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 	       !osdmap->get_addr(whoami).probably_equals(
 		 client_messenger->get_myaddr()) ||
 	       !osdmap->get_cluster_addr(whoami).probably_equals(
-		 cluster_messenger->get_myaddr()) ||
-	       !osdmap->get_hb_back_addr(whoami).probably_equals(
-		 hb_back_server_messenger->get_myaddr()) ||
-	       (osdmap->get_hb_front_addr(whoami) != entity_addr_t() &&
-                !osdmap->get_hb_front_addr(whoami).probably_equals(
-		  hb_front_server_messenger->get_myaddr()))) {
+		 cluster_messenger->get_myaddr())) {
       if (!osdmap->is_up(whoami)) {
 	if (service.is_preparing_to_stop() || service.is_stopping()) {
 	  service.got_stop_ack();
@@ -7685,21 +7680,6 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
 		      << " had wrong cluster addr ("
 		      << osdmap->get_cluster_addr(whoami)
 		      << " != my " << cluster_messenger->get_myaddr() << ")";
-      } else if (!osdmap->get_hb_back_addr(whoami).probably_equals(
-		   hb_back_server_messenger->get_myaddr())) {
-	clog->error() << "map e" << osdmap->get_epoch()
-		      << " had wrong heartbeat back addr ("
-		      << osdmap->get_hb_back_addr(whoami)
-		      << " != my " << hb_back_server_messenger->get_myaddr()
-		      << ")";
-      } else if (osdmap->get_hb_front_addr(whoami) != entity_addr_t() &&
-		 !osdmap->get_hb_front_addr(whoami).probably_equals(
-		   hb_front_server_messenger->get_myaddr())) {
-	clog->error() << "map e" << osdmap->get_epoch()
-		      << " had wrong heartbeat front addr ("
-		      << osdmap->get_hb_front_addr(whoami)
-		      << " != my " << hb_front_server_messenger->get_myaddr()
-		      << ")";
       }
 
       if (!service.is_stopping()) {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1491,6 +1491,7 @@ private:
   map<int,HeartbeatInfo> heartbeat_peers;  ///< map of osd id to HeartbeatInfo
   utime_t last_mon_heartbeat;
   Messenger *hb_front_client_messenger;
+  Messenger *hb_front_client_legacy_messenger;
   Messenger *hb_back_client_messenger;
   Messenger *hb_front_server_messenger;
   Messenger *hb_back_server_messenger;
@@ -2306,6 +2307,7 @@ private:
       Messenger *internal,
       Messenger *external,
       Messenger *hb_front_client,
+      Messenger *hb_front_client_legacy,
       Messenger *hb_back_client,
       Messenger *hb_front_server,
       Messenger *hb_back_server,

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1566,7 +1566,11 @@ public:
       isvalid = true;
       return true;
     }
-  } heartbeat_dispatcher;
+    bool ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer,
+			   bool force_new) override {
+      return osd->ms_get_authorizer(dest_type, authorizer, force_new);
+    }
+ } heartbeat_dispatcher;
 
 private:
   // -- waiters --

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2246,6 +2246,8 @@ private:
     case MSG_OSD_PG_UPDATE_LOG_MISSING_REPLY:
     case MSG_OSD_PG_RECOVERY_DELETE:
     case MSG_OSD_PG_RECOVERY_DELETE_REPLY:
+    case CEPH_MSG_PING:
+    case MSG_OSD_PING:
       return true;
     default:
       return false;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2861,6 +2861,13 @@ void OSDMap::post_decode()
     name_pool[pname.second] = pname.first;
   }
 
+  if (require_osd_release >= CEPH_RELEASE_MIMIC) {
+    assert(osd_addrs->hb_front_addr.empty());
+    assert(osd_addrs->hb_back_addr.empty());
+  } else {
+    assert(osd_addrs->hb_front_addr.size() == osd_addrs->cluster_addr.size());
+    assert(osd_addrs->hb_back_addr.size() == osd_addrs->cluster_addr.size());
+  }
   calc_num_osds();
   _calc_up_osd_features();
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -872,12 +872,16 @@ public:
       return get_addr(osd);
     return *osd_addrs->cluster_addr[osd];
   }
-  const entity_addr_t &get_hb_back_addr(int osd) const {
+  entity_addr_t get_hb_back_addr(int osd) const {
     assert(exists(osd));
+    if (osd_addrs->hb_back_addr.empty())
+      return entity_addr_t();
     return osd_addrs->hb_back_addr[osd] ? *osd_addrs->hb_back_addr[osd] : osd_addrs->blank;
   }
-  const entity_addr_t &get_hb_front_addr(int osd) const {
+  entity_addr_t get_hb_front_addr(int osd) const {
     assert(exists(osd));
+    if (osd_addrs->hb_back_addr.empty())
+      return entity_addr_t();
     return osd_addrs->hb_front_addr[osd] ? *osd_addrs->hb_front_addr[osd] : osd_addrs->blank;
   }
   entity_inst_t get_most_recent_inst(int osd) const {


### PR DESCRIPTION
The ping processing methods are fast dispatch, so there is no need for a
separate dispatch queue provided by a separate messenger.  Ping the normal
OSD interface if the peer has been upgraded to luminous.

To make this work we tweak the messenger to respect the client's request
for a lossy session even though the default peer osd policy is lossless.
We also fix the messengers not to register lossy connections in their
connection table (which was a waste of time).