### PR TITLE
mon,crush: add 'osd crush swap-bucket' command

### DIFF
--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -402,6 +402,16 @@ public:
       name_rmap[name] = i;
     return 0;
   }
+  void swap_names(int a, int b) {
+    string an = name_map[a];
+    string bn = name_map[b];
+    name_map[a] = bn;
+    name_map[b] = an;
+    if (have_rmaps) {
+      name_rmap[an] = b;
+      name_rmap[bn] = a;
+    }
+  }
   bool id_has_class(int i) {
     int idout;
     int classout;
@@ -650,6 +660,16 @@ public:
    * @return 0 for success, negative on error
    */
   int move_bucket(CephContext *cct, int id, const map<string,string>& loc);
+
+  /**
+   * swap bucket contents of two buckets without touching bucket ids
+   *
+   * @param cct cct
+   * @param src bucket a
+   * @param dst bucket b
+   * @return 0 for success, negative on error
+   */
+  int swap_bucket(CephContext *cct, int src, int dst);
 
   /**
    * add a link to an existing bucket in the hierarchy to the new location

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -506,6 +506,24 @@ static inline int crush_calc_tree_node(int i)
 	return ((i+1) << 1)-1;
 }
 
+static inline const char *crush_alg_name(int alg)
+{
+	switch (alg) {
+	case CRUSH_BUCKET_UNIFORM:
+		return "uniform";
+	case CRUSH_BUCKET_LIST:
+		return "list";
+	case CRUSH_BUCKET_TREE:
+		return "tree";
+	case CRUSH_BUCKET_STRAW:
+		return "straw";
+	case CRUSH_BUCKET_STRAW2:
+		return "straw2";
+	default:
+		return "unknown";
+	}
+}
+
 /* ---------------------------------------------------------------------
 			       Private
    --------------------------------------------------------------------- */

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -512,6 +512,12 @@ COMMAND("osd crush move " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"move existing entry for <name> to location <args>", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd crush swap-bucket " \
+	"name=source,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=dest,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
+	"swap existing bucket contents from (orphan) bucket <source> and <target>", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd crush link " \
 	"name=name,type=CephString " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6711,6 +6711,14 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -EPERM;
       goto reply;
     }
+    if (newcrush.get_bucket_alg(sid) != newcrush.get_bucket_alg(did) &&
+	force != "--yes-i-really-mean-it") {
+      ss << "source bucket alg " << crush_alg_name(newcrush.get_bucket_alg(sid)) << " != "
+	 << "dest bucket alg " << crush_alg_name(newcrush.get_bucket_alg(did))
+	 << "; pass --yes-i-really-mean-it to proceed anyway";
+      err = -EPERM;
+      goto reply;
+    }
     int r = newcrush.swap_bucket(g_ceph_context, sid, did);
     if (r < 0) {
       ss << "failed to swap bucket contents: " << cpp_strerror(r);


### PR DESCRIPTION
This is a generally useful command but is specifically intended to be used
when migrating an entire host at a time from filestore to bluestore.