### PR TITLE
rgw-multisite: fix the problem of rgw website configure request not redirect to metadata master

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1969,6 +1969,14 @@ void RGWSetBucketWebsite::execute()
   if (op_ret < 0)
     return;
 
+  if (!store->is_meta_master()) {
+    op_ret = forward_request_to_master(s, NULL, store, in_data, nullptr);
+    if (op_ret < 0) {
+      ldout(s->cct, 20) << __func__ << " forward_request_to_master returned ret=" << op_ret << dendl;
+      return;
+    }
+  }
+
   s->bucket_info.has_website = true;
   s->bucket_info.website_conf = website_conf;
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -748,6 +748,7 @@ public:
 
 class RGWSetBucketWebsite : public RGWOp {
 protected:
+  bufferlist in_data;
   RGWBucketWebsiteConf website_conf;
 public:
   RGWSetBucketWebsite() {}

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -850,6 +850,9 @@ int RGWSetBucketWebsite_ObjStore_S3::get_params()
       }
   }
 
+  bufferptr in_ptr(data, len);
+  in_data.append(in_ptr);
+
   RGWXMLDecoder::XMLParser parser;
   if (!parser.init()) {
     ldout(s->cct, 0) << "ERROR: failed to initialize parser" << dendl;

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -13,6 +13,7 @@ from itertools import combinations
 
 import boto
 import boto.s3.connection
+from boto.s3.website import WebsiteConfiguration
 
 from nose.tools import eq_ as eq
 from nose.plugins.attrib import attr
@@ -791,3 +792,14 @@ def test_zonegroup_remove():
 
     # validate the resulting period
     zonegroup.period.update(z1, commit=True)
+
+def test_set_bucket_website():
+    buckets, zone_bucket = create_bucket_per_zone_in_realm()
+    for _, bucket in zone_bucket:
+        website_cfg = WebsiteConfiguration(suffix='index.html',error_key='error.html')
+        try:
+            bucket.set_website_configuration(website_cfg)
+        except boto.exception.S3ResponseError as e:
+            if e.error_code == 'MethodNotAllowed':
+                raise SkipTest("test_set_bucket_website skipped. Requires rgw_enable_static_website = 1.")
+        assert(bucket.get_website_configuration_with_xml()[1] == website_cfg.to_xml())


### PR DESCRIPTION
hi, when i make website configure  request to slave zone rgw， and get website configure from master zone,but i can not get the website configure from master zone, and this pull fix the problem. 

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>