### PR TITLE
msg: msg/async/EventKqueue.cc: fix possible realloc memory leak

### DIFF
--- a/src/msg/async/EventKqueue.cc
+++ b/src/msg/async/EventKqueue.cc
@@ -199,13 +199,17 @@ int KqueueDriver::resize_events(int newsize)
   ldout(cct,30) << __func__ << " kqfd = " << kqfd << "newsize = " << newsize 
                 << dendl;
   if(newsize > sav_max) {
-    sav_events = (struct SaveEvent*)realloc( sav_events, 
-                    sizeof(struct SaveEvent)*newsize);
-    if (!sav_events) {
+    void *_realloc = NULL;
+    _realloc = realloc(sav_events,
+                          sizeof(struct SaveEvent)*newsize);
+    if (_realloc == NULL) {
       lderr(cct) << __func__ << " unable to realloc memory: "
                              << cpp_strerror(errno) << dendl;
+      free(sav_events);
+      sav_events = NULL;
       return -ENOMEM;
     }
+    sav_events = (struct SaveEvent *)_realloc;
     memset(&sav_events[size], 0, sizeof(struct SaveEvent)*(newsize-sav_max));
     sav_max = newsize;
   }


### PR DESCRIPTION
    Fix handling of realloc. If realloc() fails it returns NULL, assigning
    the return value of realloc() directly to the pointer without checking
    for the result will lead to a memory leak.

Signed-off-by: Weibing Zhang <atheism.zhang@gmail.com>