### PR TITLE
merge v12.0.2 release tag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.11)
 
 project(ceph)
-set(VERSION 12.0.1)
+set(VERSION 12.0.2)
 
 if(POLICY CMP0046)
   # Tweak policies (this one disables "missing" dependency warning)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ceph (12.0.2-1) stable; urgency=medium
+
+  * New upstream release
+
+ -- Ceph Release Team <ceph-maintainers@ceph.com>  Thu, 20 Apr 2017 19:59:57 +0000
+
 ceph (12.0.1-1) stable; urgency=medium
 
   * New upstream release


### PR DESCRIPTION
Next time we'll push the release tags to both the branches maybe, until then this has to be done to fast-forward master to Luminous
