### PR TITLE
librbd: reacquire lock should update lock owner client id

### DIFF
--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -294,6 +294,16 @@ void ExclusiveLock<I>::post_release_lock_handler(bool shutting_down, int r,
 }
 
 template <typename I>
+void ExclusiveLock<I>::post_reacquire_lock_handler(int r, Context *on_finish) {
+  ldout(m_image_ctx.cct, 10) << dendl;
+  if (r >= 0) {
+    m_image_ctx.image_watcher->notify_acquired_lock();
+  }
+
+  on_finish->complete(r);
+}
+
+template <typename I>
 struct ExclusiveLock<I>::C_InitComplete : public Context {
   ExclusiveLock *exclusive_lock;
   uint64_t features;

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -36,6 +36,7 @@ protected:
                                 Context *on_finish) override;
   void post_release_lock_handler(bool shutting_down, int r,
                                  Context *on_finish) override;
+  void post_reacquire_lock_handler(int r, Context *on_finish) override;
 
 private:
 

--- a/src/librbd/ManagedLock.h
+++ b/src/librbd/ManagedLock.h
@@ -134,6 +134,7 @@ protected:
                                         Context *on_finish);
   virtual void post_release_lock_handler(bool shutting_down, int r,
                                           Context *on_finish);
+  virtual void post_reacquire_lock_handler(int r, Context *on_finish);
 
   void execute_next_action();
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19929
Signed-off-by: Jason Dillaman <dillaman@redhat.com>