### PR TITLE
rgw_file: v3: fix write-timer action

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1150,6 +1150,8 @@ namespace rgw {
     int rc = write_finish(FLAG_LOCKED);
 
     flags &= ~FLAG_OPEN;
+    flags &= ~FLAG_STATELESS_OPEN;
+
     return rc;
   } /* RGWFileHandle::close */
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -778,7 +778,7 @@ namespace rgw {
       }
 
       void operator()() {
-	rgw_fh.write_finish();
+	rgw_fh.close(); /* will finish in-progress write */
 	rgw_fh.get_fs()->unref(&rgw_fh);
       }
     };


### PR DESCRIPTION
For now, unify with v4 write-on-close path, by calling
RGWFileHandle::close() on write-timer expire, since it will
call write_finish() as a side-effect.

Fixes: http://tracker.ceph.com/issues/19932

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>