### PR TITLE
rgw: remove fastcgi from default rgw frontends

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1632,7 +1632,7 @@ OPTION(rgw_bucket_default_quota_max_size, OPT_LONGLONG, -1) // Max size of objec
 
 OPTION(rgw_expose_bucket, OPT_BOOL, false) // Return the bucket name in the 'Bucket' response header
 
-OPTION(rgw_frontends, OPT_STR, "fastcgi, civetweb port=7480") // rgw front ends
+OPTION(rgw_frontends, OPT_STR, "civetweb port=7480") // rgw front ends
 
 OPTION(rgw_user_quota_bucket_sync_interval, OPT_INT, 180) // time period for accumulating modified buckets before syncing stats
 OPTION(rgw_user_quota_sync_interval, OPT_INT, 3600 * 24) // time period for accumulating modified buckets before syncing entire user stats

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -232,7 +232,7 @@ int main(int argc, const char **argv)
   multimap<string, RGWFrontendConfig *> fe_map;
   list<RGWFrontendConfig *> configs;
   if (frontends.empty()) {
-    frontends.push_back("fastcgi");
+    frontends.push_back("civetweb");
   }
   for (list<string>::iterator iter = frontends.begin(); iter != frontends.end(); ++iter) {
     string& f = *iter;


### PR DESCRIPTION
as a followup to https://github.com/ceph/ceph/pull/15070, removes fastcgi from rgw's frontend defaults