### PR TITLE
build/ops: move psmisc dependency from ceph-base to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -235,7 +235,6 @@ Requires:      logrotate
 Requires:      util-linux
 Requires:      cryptsetup
 Requires:      findutils
-Requires:      psmisc
 Requires:      which
 %if 0%{?suse_version}
 Recommends:    ntp-daemon
@@ -254,6 +253,7 @@ Group:		System/Filesystems
 Requires:	librbd1 = %{epoch}:%{version}-%{release}
 Requires:	librados2 = %{epoch}:%{version}-%{release}
 Requires:	libcephfs2 = %{epoch}:%{version}-%{release}
+Requires:	psmisc
 Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}

--- a/debian/control
+++ b/debian/control
@@ -87,7 +87,6 @@ Depends: binutils,
          gdisk,
          grep,
          logrotate,
-         psmisc,
          ${python:Depends},
          xfsprogs,
          ${misc:Depends},
@@ -360,6 +359,7 @@ Description: debugging symbols for rbd-nbd
 Package: ceph-common
 Architecture: linux-any
 Depends: librbd1 (= ${binary:Version}), ${misc:Depends}, ${shlibs:Depends},
+         psmisc,
          python-rados (= ${binary:Version}),
          python-cephfs (= ${binary:Version}),
          python-rbd (= ${binary:Version}),


### PR DESCRIPTION
When I saw http://tracker.ceph.com/issues/19937 I realized ceph-common is the right place for the dependency, not ceph-base.

