### PR TITLE
qa/cephfs: disable mds_bal_frag for TestStrays.test_purge_queue_op_rate

### DIFF
--- a/qa/tasks/cephfs/test_strays.py
+++ b/qa/tasks/cephfs/test_strays.py
@@ -910,6 +910,7 @@ class TestStrays(CephFSTestCase):
 
         max_purge_files = 2
 
+        self.set_conf('mds', 'mds_bal_frag', 'false')
         self.set_conf('mds', 'mds_max_purge_files', "%d" % max_purge_files)
         self.fs.mds_fail_restart()
         self.fs.wait_for_daemons()


### PR DESCRIPTION
directory fragmentation generates extra osd ops, which affects checks
in the test.

Fixes: http://tracker.ceph.com/issues/19892
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>