### PR TITLE
mon/MgrMonitor: send digests only if is_active()

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -277,6 +277,10 @@ void MgrMonitor::send_digests()
 {
   cancel_timer();
 
+  if (!is_active()) {
+    return;
+  }
+
   const std::string type = "mgrdigest";
   if (mon->session_map.subs.count(type) == 0)
     return;

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -187,7 +187,7 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
     }
   }
 
-  last_beacon[m->get_gid()] = ceph_clock_now();
+  last_beacon[m->get_gid()] = ceph::coarse_mono_clock::now();
 
   // Track whether we modified pending_map
   bool updated = false;
@@ -357,9 +357,8 @@ void MgrMonitor::tick()
   if (!is_active() || !mon->is_leader())
     return;
 
-  const utime_t now = ceph_clock_now();
-  utime_t cutoff = now;
-  cutoff -= g_conf->mon_mgr_beacon_grace;
+  const auto now = ceph::coarse_mono_clock::now();
+  const auto cutoff = now - std::chrono::seconds(g_conf->mon_mgr_beacon_grace);
 
   // Populate any missing beacons (i.e. no beacon since MgrMonitor
   // instantiation) with the current time, so that they will

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -275,7 +275,7 @@ void MgrMonitor::check_sub(Subscription *sub)
  */
 void MgrMonitor::send_digests()
 {
-  digest_event = nullptr;
+  cancel_timer();
 
   const std::string type = "mgrdigest";
   if (mon->session_map.subs.count(type) == 0)
@@ -302,6 +302,14 @@ void MgrMonitor::send_digests()
       send_digests();
   });
   mon->timer.add_event_after(g_conf->mon_mgr_digest_period, digest_event);
+}
+
+void MgrMonitor::cancel_timer()
+{
+  if (digest_event) {
+    mon->timer.cancel_event(digest_event);
+    digest_event = nullptr;
+  }
 }
 
 void MgrMonitor::on_active()
@@ -545,7 +553,5 @@ void MgrMonitor::init()
 
 void MgrMonitor::on_shutdown()
 {
-  if (digest_event) {
-    mon->timer.cancel_event(digest_event);
-  }
+  cancel_timer();
 }

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -36,13 +36,13 @@ class MgrMonitor : public PaxosService
   void drop_active();
   void drop_standby(uint64_t gid);
 
-  Context *digest_callback;
+  Context *digest_event = nullptr;
 
   bool check_caps(MonOpRequestRef op, const uuid_d& fsid);
 
 public:
   MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
-    : PaxosService(mn, p, service_name), digest_callback(nullptr)
+    : PaxosService(mn, p, service_name)
   {}
 
   void init() override;

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -24,7 +24,7 @@ class MgrMonitor : public PaxosService
 
   utime_t first_seen_inactive;
 
-  std::map<uint64_t, utime_t> last_beacon;
+  std::map<uint64_t, ceph::coarse_mono_clock::time_point> last_beacon;
 
   /**
    * If a standby is available, make it active, given that

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -37,6 +37,7 @@ class MgrMonitor : public PaxosService
   void drop_standby(uint64_t gid);
 
   Context *digest_event = nullptr;
+  void cancel_timer();
 
   bool check_caps(MonOpRequestRef op, const uuid_d& fsid);
 


### PR DESCRIPTION
labeling this a bug fix, because we should cancel an event before resetting it, otherwise the event is leaked.