### PR TITLE
doc: use do_cmake.sh instead of `cmake ..`

### DIFF
--- a/doc/install/build-ceph.rst
+++ b/doc/install/build-ceph.rst
@@ -28,9 +28,8 @@ Ceph is built using cmake. To build Ceph, navigate to your cloned Ceph
 repository and execute the following::
 
     cd ceph
-    mkdir build
+    ./do_cmake.sh
     cd build
-    cmake ..
     make
 
 .. topic:: Hyperthreading


### PR DESCRIPTION
user could be confused at seeing errors like:

src/CMakeLists.txt:644 (add_subdirectory): The source directory /src/lua
does not contain a CMakeLists.txt file.

Signed-off-by: Kefu Chai <kchai@redhat.com>