### PR TITLE
ceph-create-keys: update client.admin if it already exists

### DIFF
--- a/src/ceph-create-keys
+++ b/src/ceph-create-keys
@@ -136,6 +136,19 @@ def get_key(cluster, mon_id):
                             ],
                         stdout=f,
                         )
+                else:
+                    returncode = subprocess.call(
+                        args=args_prefix + [
+                            'auth',
+                            'caps',
+                            'client.admin',
+                            'mon', 'allow *',
+                            'osd', 'allow *',
+                            'mds', 'allow *',
+                            'mgr', 'allow *',
+                            ],
+                        stdout=f,
+                        )
 
             if returncode != 0:
                 if returncode == errno.EPERM or returncode == errno.EACCES:


### PR DESCRIPTION
This means that anyone who de-privileges their client.admin
user will find that it gets resets with full privileges again.
This is necessary because we cannot distinguish between an old
key and a deliberately de-privileged key, and it's okay because
this is the admin key, it's meant to have access to everything.

Fixes: http://tracker.ceph.com/issues/19940
Signed-off-by: John Spray <john.spray@redhat.com>