### PR TITLE
qa/suites/rados/thrash: make sure osds have map before legacy scrub

### DIFF
--- a/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
+++ b/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
@@ -6,6 +6,8 @@ tasks:
   - exec:
       mon.a:
         - ceph osd set require_luminous_osds
+# make sure osds have latest map
+        - rados -p rbd bench 5 write -b 4096
   - ceph.osd_scrub_pgs:
       cluster: ceph
   - exec:


### PR DESCRIPTION
The OSDs must have a map reflecting the require_luminous flag in order
for the legacy conversion to happen.  A quick rados bench should ensure
that.

Signed-off-by: Sage Weil <sage@redhat.com>