### PR TITLE
doc: mention certain conf vars should be in global

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -7,6 +7,11 @@ The following settings may added to the Ceph configuration file (i.e., usually
 settings may contain default values. If you do not specify each setting in the
 Ceph configuration file, the default value will be set automatically.
 
+Configuration variables set under the ``[client.radosgw.{instance-name}]``
+section will not apply to rgw or radosgw-admin commands without an instance-name
+specified in the command. Thus variables meant to be applied to all RGW
+instances or all radosgw-admin commands can be put into the ``[global]`` or the
+``[client]`` section to avoid specifying instance-name.
 
 ``rgw data``
 
@@ -294,6 +299,8 @@ Ceph configuration file, the default value will be set automatically.
               a value of zero indicates there is no sharding. It is not
               recommended to set a value too large (e.g. thousand) as it
               increases the cost for bucket listing.
+              This variable should be set in the client or global sections
+              so that it is automatically applied to radosgw-admin commands.
 
 :Type: Integer
 :Default: ``0``
@@ -356,6 +363,8 @@ Ceph configuration file, the default value will be set automatically.
 
 :Description: Default max number of objects per bucket. Set on new users,
               if no other quota is specified. Has no effect on existing users.
+              This variable should be set in the client or global sections
+              so that it is automatically applied to radosgw-admin commands.
 :Type: Integer
 :Default: ``-1``
 


### PR DESCRIPTION
This is to make it apply whenever the radsogw-admin
command is run without specifying the instance name

Resolves: rhbz#1391500

Signed-off-by: Ali Maredia <amaredia@redhat.com>