### PR TITLE
osd/pglog: remove loop through empty collection

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3652,8 +3652,6 @@ public:
 
   template <typename missing_type>
   pg_missing_set(const missing_type &m) {
-    for (auto &&i: missing)
-      tracker.changed(i.first);
     missing = m.get_items();
     rmissing = m.get_rmissing();
     for (auto &&i: missing)


### PR DESCRIPTION
At this point in the constructor _missing_ is empty and therefore looping through it serves no purpose.