### PR TITLE
qa: fix float parse error in test_fragment

### DIFF
--- a/qa/tasks/cephfs/test_fragment.py
+++ b/qa/tasks/cephfs/test_fragment.py
@@ -99,7 +99,7 @@ class TestFragmentation(CephFSTestCase):
             mds_bal_split_size=split_size,
             mds_bal_merge_size=merge_size,
             mds_bal_split_bits=3,
-            mds_bal_fragment_size_max=(split_size * 1.5 + 2)
+            mds_bal_fragment_size_max=int(split_size * 1.5 + 2)
         )
 
         # We test this only at a single split level.  If a client was sending


### PR DESCRIPTION
    2017-05-16 17:45:30,663.663 INFO:__main__:run args=['./bin/ceph', 'daemon', 'mds.b', 'perf', 'dump', 'mds']
    2017-05-16 17:45:30,664.664 INFO:__main__:Running ['./bin/ceph', 'daemon', 'mds.b', 'perf', 'dump', 'mds']
    Can't get admin socket path: unable to get conf option admin_socket for mds.b: parse error setting 'mds_bal_fragment_size_max' to '152.0'

    2017-05-16 17:45:30,781.781 INFO:__main__:test_rapid_creation (tasks.cephfs.test_fragment.TestFragmentation) ... ERROR
    2017-05-16 17:45:30,782.782 ERROR:__main__:Traceback (most recent call last):
      File "/home/pdonnell/ceph/qa/tasks/cephfs/test_fragment.py", line 114, in test_rapid_creation
        self.assertEqual(self.get_splits(), 0)
      File "/home/pdonnell/ceph/qa/tasks/cephfs/test_fragment.py", line 15, in get_splits
        return self.fs.mds_asok(['perf', 'dump', 'mds'])['mds']['dir_split']
      File "/home/pdonnell/ceph/qa/tasks/cephfs/filesystem.py", line 788, in mds_asok
        return self.json_asok(command, 'mds', mds_id)
      File "/home/pdonnell/ceph/qa/tasks/cephfs/filesystem.py", line 174, in json_asok
        proc = self.mon_manager.admin_socket(service_type, service_id, command)
      File "../qa/tasks/vstart_runner.py", line 561, in admin_socket
        args=[os.path.join(BIN_PREFIX, "ceph"), "daemon", "{0}.{1}".format(daemon_type, daemon_id)] + command, check_status=check_status
      File "../qa/tasks/vstart_runner.py", line 296, in run
        proc.wait()
      File "../qa/tasks/vstart_runner.py", line 174, in wait
        raise CommandFailedError(self.args, self.exitstatus)
    CommandFailedError: Command failed with status 22: ['./bin/ceph', 'daemon', 'mds.b', 'perf', 'dump', 'mds']

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>