### PR TITLE
mon: clean up 'ceph -s'

### DIFF
--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -125,18 +125,18 @@ public:
     if (f) {
       dump(f);
     } else {
+      *ss << "e" << get_epoch() << ": ";
       if (get_active_gid() != 0) {
 	*ss << "active: " << get_active_name();
         if (!available) {
           // If the daemon hasn't gone active yet, indicate that.
           *ss << "(starting)";
         }
-        *ss << " ";
       } else {
-	*ss << "no daemons active ";
+	*ss << "no daemons active";
       }
       if (standbys.size()) {
-	*ss << "standbys: ";
+	*ss << ", standbys: ";
 	bool first = true;
 	for (const auto &i : standbys) {
 	  if (!first) {

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2590,9 +2590,8 @@ void Monitor::get_cluster_status(stringstream &ss, Formatter *f)
     ss << "    cluster " << monmap->get_fsid() << "\n";
     ss << "     health " << joinify(health.begin(), health.end(), 
 				    string("\n            ")) << "\n";
-    ss << "     monmap " << *monmap << "\n";
-    ss << "            election epoch " << get_epoch()
-       << ", quorum " << get_quorum() << " " << get_quorum_names() << "\n";
+    ss << "     monmap e" << monmap->get_epoch() << ": "
+       << monmap->size() << " mons" << ", quorum " << get_quorum_names() << "\n";
     if (mdsmon()->get_fsmap().filesystem_count() > 0) {
       ss << "      fsmap " << mdsmon()->get_fsmap() << "\n";
     }


### PR DESCRIPTION
Was

     monmap e2: 1 mons at {a=127.0.0.1:40907/0}
            election epoch 4, quorum 0 a

Now

     monmap e2: 1 mons, quorum a

The full summary is clenaed up some too, now

    cluster 0d553373-5de6-4d90-bc60-cfd6f6554631
     health HEALTH_OK
     monmap e2: 1 mons, quorum a
      fsmap e2: 0/0/1 up
        mgr e3: active: x(starting), standbys: y
     osdmap e5: 1 osds: 0 up, 0 in
      pgmap v6: 24 pgs, 3 pools, 0 bytes data, 0 objects
            0 kB used, 0 kB / 0 kB avail
            100.000% pgs inactive
                  24 creating

If the user wants to see the IPs, they can 'ceph mon dump'.
