### PR TITLE
osd: fix argument-dependent lookup of swap()

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -3259,7 +3259,7 @@ PastIntervals::PastIntervals(const PastIntervals &rhs)
 PastIntervals &PastIntervals::operator=(const PastIntervals &rhs)
 {
   PastIntervals other(rhs);
-  ::swap(other, *this);
+  swap(other);
   return *this;
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -2739,7 +2739,8 @@ public:
   }
 
   void swap(PastIntervals &other) {
-    ::swap(other.past_intervals, past_intervals);
+    using std::swap;
+    swap(other.past_intervals, past_intervals);
   }
 
   /**
@@ -3131,9 +3132,10 @@ public:
   void swap(ObjectModDesc &other) {
     bl.swap(other.bl);
 
-    ::swap(other.can_local_rollback, can_local_rollback);
-    ::swap(other.rollback_info_completed, rollback_info_completed);
-    ::swap(other.max_required_version, max_required_version);
+    using std::swap;
+    swap(other.can_local_rollback, can_local_rollback);
+    swap(other.rollback_info_completed, rollback_info_completed);
+    swap(other.max_required_version, max_required_version);
   }
   void append_id(ModID id) {
     uint8_t _id(id);
@@ -3466,7 +3468,8 @@ public:
     while (true) {
       if (p == log.begin()) {
 	// yikes, the whole thing is divergent!
-	::swap(divergent, log);
+	using std::swap;
+	swap(divergent, log);
 	break;
       }
       --p;
@@ -4705,9 +4708,10 @@ struct ScrubMap {
     objects.insert(r.objects.begin(), r.objects.end());
   }
   void swap(ScrubMap &r) {
-    ::swap(objects, r.objects);
-    ::swap(valid_through, r.valid_through);
-    ::swap(incr_since, r.incr_since);
+    using std::swap;
+    swap(objects, r.objects);
+    swap(valid_through, r.valid_through);
+    swap(incr_since, r.incr_since);
   }
 
   void encode(bufferlist& bl) const;


### PR DESCRIPTION
because include/types.h has a `using namespace std`, the calls to
`::swap()` had previously been selecting overloads from `namespace std`. but
once any other `swap()` functions are present in the global namespace,
argument-dependent lookup [1] will not consider those from std

for example, when common/sstring.hh has been included, its global `swap()`
function is the only overload considered, so calls to `::swap()` result in
errors like this:

> /home/cbodley/ceph/src/osd/osd_types.h: In member function ‘void ObjectModDesc::swap(ObjectModDesc&)’:
/home/cbodley/ceph/src/osd/osd_types.h:3135:56: error: no matching function for call to ‘swap(bool&, bool&)’
     ::swap(other.can_local_rollback, can_local_rollback);
                                                        ^
/home/cbodley/ceph/src/common/sstring.hh:589:6: note: candidate: template<class char_type, class size_type, size_type max_size> void swap(basic_sstring<char_type, size_type, Max>&, basic_sstring<char_type, size_type, Max>&)
 void swap(basic_sstring<char_type, size_type, max_size>& x,
      ^
/home/cbodley/ceph/src/common/sstring.hh:589:6: note:   template argument deduction/substitution failed:
/home/cbodley/ceph/src/osd/osd_types.h:3135:56: note:   mismatched types ‘basic_sstring<char_type, size_type, Max>’ and ‘bool’
     ::swap(other.can_local_rollback, can_local_rollback);

adding a `using std::swap;` to the calling scope and removing :: from
the call to `swap()` allows argument-dependent lookup to resolve the
overloads in both namespaces

[1] http://en.cppreference.com/w/cpp/language/adl