### PR TITLE
qa: silence upgrade test failure

### DIFF
--- a/qa/tasks/cephfs/filesystem.py
+++ b/qa/tasks/cephfs/filesystem.py
@@ -457,7 +457,14 @@ class Filesystem(MDSCluster):
         self.mon_manager.raw_cluster_cmd('fs', 'new',
                                          self.name, self.metadata_pool_name, data_pool_name)
         # Turn off spurious standby count warnings from modifying max_mds in tests.
-        self.mon_manager.raw_cluster_cmd('fs', 'set', self.name, 'standby_count_wanted', '0')
+        try:
+            self.mon_manager.raw_cluster_cmd('fs', 'set', self.name, 'standby_count_wanted', '0')
+        except CommandFailedError as e:
+            if e.exitstatus == 22:
+                # standby_count_wanted not available prior to luminous (upgrade tests would fail otherwise)
+                pass
+            else:
+                raise
 
         self.getinfo(refresh = True)
 


### PR DESCRIPTION
The new fs setting standby_count_wanted is only avialable in luminous. Upgrade
tests were tripping on this.

Fixes: http://tracker.ceph.com/issues/19934

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>