### PR TITLE
denc: add encode/decode for basic_sstring

### DIFF
--- a/src/common/sstring.hh
+++ b/src/common/sstring.hh
@@ -38,6 +38,9 @@
 #include <type_traits>
 #include <boost/utility/string_ref.hpp>
 
+#include "include/buffer.h"
+#include "include/denc.h"
+
 template <typename char_type, typename Size, Size max_size>
 class basic_sstring;
 
@@ -646,6 +649,60 @@ template <typename string_type, typename T>
 inline string_type to_sstring(T value) {
     return sstring::to_sstring<string_type>(value);
 }
+
+
+// encode/decode
+template <typename Char, typename Size, Size Max>
+struct denc_traits<basic_sstring<Char, Size, Max>> {
+private:
+  using value_type = basic_sstring<Char, Size, Max>;
+public:
+  static constexpr bool supported = true;
+  static constexpr bool featured = false;
+  static constexpr bool bounded = false;
+
+  static void bound_encode(const value_type& s, size_t& p, uint64_t f=0) {
+    p += sizeof(Size) + s.size();
+  }
+
+  static void encode_nohead(const value_type& s,
+                            buffer::list::contiguous_appender& p)
+  {
+    auto len = s.size();
+    if (len) {
+      p.append(reinterpret_cast<const char*>(s.c_str()), len);
+    }
+  }
+
+  static void decode_nohead(size_t len, value_type& s,
+                            buffer::ptr::iterator& p)
+  {
+    s.reset();
+    if (len) {
+      s.append(reinterpret_cast<const Char*>(p.get_pos_add(len)), len);
+    }
+  }
+
+  static void encode(const value_type& s,
+                     buffer::list::contiguous_appender& p,
+                     uint64_t f=0)
+  {
+    Size len = (Size)(s.size());
+    ::denc(len, p);
+    if (len) {
+      p.append(reinterpret_cast<const char*>(s.c_str()), len);
+    }
+  }
+
+  static void decode(value_type& s,
+                     buffer::ptr::iterator& p,
+                     uint64_t f=0)
+  {
+    Size len;
+    ::denc(len, p);
+    decode_nohead(len, s, p);
+  }
+};
 
 #if 0 /* XXX conflicts w/Ceph types.h */
 template <typename T>

--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -512,6 +512,7 @@ decode(boost::container::flat_set<T, Comp, Alloc>& s, bufferlist::iterator& p)
   __u32 n;
   decode(n, p);
   s.clear();
+  s.reserve(n);
   while (n--) {
     T v;
     decode(v, p);
@@ -532,6 +533,7 @@ inline typename std::enable_if<!traits::supported>::type
 decode_nohead(int len, boost::container::flat_set<T, Comp, Alloc>& s,
 	      bufferlist::iterator& p)
 {
+  s.reserve(len);
   for (int i=0; i<len; i++) {
     T v;
     decode(v, p);
@@ -817,6 +819,7 @@ template<class T, class U, class Comp, class Alloc,
   __u32 n;
   decode(n, p);
   m.clear();
+  m.reserve(n);
   while (n--) {
     T k;
     decode(k, p);
@@ -829,6 +832,7 @@ inline void decode_noclear(boost::container::flat_map<T,U,Comp,Alloc>& m,
 {
   __u32 n;
   decode(n, p);
+  m.reserve(m.size() + n);
   while (n--) {
     T k;
     decode(k, p);

--- a/src/test/encoding/test_sstring.h
+++ b/src/test/encoding/test_sstring.h
@@ -1,0 +1,40 @@
+#ifndef TEST_SSTRING_H
+#define TEST_SSTRING_H
+
+#include "common/sstring.hh"
+
+// wrapper for sstring that implements the dencoder interface
+class sstring_wrapper {
+  using sstring16 = basic_sstring<char, uint32_t, 16>;
+  sstring16 s1;
+  using sstring24 = basic_sstring<unsigned char, uint16_t, 24>;
+  sstring24 s2;
+ public:
+  sstring_wrapper() = default;
+  sstring_wrapper(sstring16&& s1, sstring24&& s2)
+    : s1(std::move(s1)), s2(std::move(s2))
+  {}
+
+  DENC(sstring_wrapper, w, p) {
+    DENC_START(1, 1, p);
+    denc(w.s1, p);
+    denc(w.s2, p);
+    DENC_FINISH(p);
+  }
+  void dump(Formatter* f) {
+    f->dump_string("s1", s1.c_str());
+    f->dump_string("s2", reinterpret_cast<const char*>(s2.c_str()));
+  }
+  static void generate_test_instances(std::list<sstring_wrapper*>& ls) {
+    ls.push_back(new sstring_wrapper());
+    // initialize sstrings that fit in internal storage
+    constexpr auto cstr6 = "abcdef";
+    ls.push_back(new sstring_wrapper(sstring16{cstr6}, sstring24{cstr6}));
+    // initialize sstrings that overflow into external storage
+    constexpr auto cstr26 = "abcdefghijklmnopqrstuvwxyz";
+    ls.push_back(new sstring_wrapper(sstring16{cstr26}, sstring24{cstr26}));
+  }
+};
+WRITE_CLASS_DENC(sstring_wrapper)
+
+#endif

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -17,6 +17,9 @@ TYPE(compressible_bloom_filter)
 #include "test_ceph_time.h"
 TYPE(real_time_wrapper)
 
+#include "test_sstring.h"
+TYPE(sstring_wrapper)
+
 #include "common/snap_types.h"
 TYPE(SnapContext)
 TYPE(SnapRealmInfo)


### PR DESCRIPTION
also adds calls to `reserve()` when decoding into `boost::container::flat_set`/`flat_map`

note: depends on https://github.com/ceph/ceph/pull/15124 to fix build issues in `osd/osd_types`