### PR TITLE
rgw: drop using std ns in header files and other cleanups

### DIFF
--- a/src/rgw/rgw_acl.h
+++ b/src/rgw/rgw_acl.h
@@ -15,8 +15,6 @@
 
 #include "rgw_basic_types.h"
 
-using namespace std;
-
 #define RGW_PERM_NONE            0x00
 #define RGW_PERM_READ            0x01
 #define RGW_PERM_WRITE           0x02

--- a/src/rgw/rgw_acl_s3.h
+++ b/src/rgw/rgw_acl_s3.h
@@ -13,9 +13,6 @@
 #include "rgw_xml.h"
 #include "rgw_acl.h"
 
-
-using namespace std;
-
 class RGWRados;
 
 class ACLPermission_S3 : public ACLPermission, public XMLObj

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -20,9 +20,6 @@
 #include "common/ceph_time.h"
 #include "rgw_formats.h"
 
-
-using namespace std;
-
 // define as static when RGWBucket implementation compete
 extern void rgw_get_buckets_obj(const rgw_user& user_id, string& buckets_obj_id);
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -29,8 +29,6 @@
 #include "cls/rgw/cls_rgw_types.h"
 #include "include/rados/librados.hpp"
 
-using namespace std;
-
 namespace ceph {
   class Formatter;
 }

--- a/src/rgw/rgw_cors_s3.h
+++ b/src/rgw/rgw_cors_s3.h
@@ -25,8 +25,6 @@
 #include "rgw_xml.h"
 #include "rgw_cors.h"
 
-using namespace std;
-
 class RGWCORSRule_S3 : public RGWCORSRule, public XMLObj
 {
   public:

--- a/src/rgw/rgw_cors_s3.h
+++ b/src/rgw/rgw_cors_s3.h
@@ -18,7 +18,6 @@
 #include <map>
 #include <string>
 #include <iosfwd>
-#include <expat.h>
 
 #include <include/types.h>
 #include <common/Formatter.h>

--- a/src/rgw/rgw_cors_swift.h
+++ b/src/rgw/rgw_cors_swift.h
@@ -23,8 +23,6 @@
 
 #include "rgw_cors.h"
 
-using namespace std;
-
 class RGWCORSConfiguration_SWIFT : public RGWCORSConfiguration
 {
   public:

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -20,7 +20,6 @@
 
 #include <atomic>
 
-using namespace std;
 #define HASH_PRIME 7877
 #define MAX_ID_LEN 255
 static string lc_oid_prefix = "lc";

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -12,10 +12,6 @@
 #include "rgw_lc.h"
 #include "rgw_xml.h"
 
-
-
-using namespace std;
-
 class LCID_S3 : public XMLObj
 {
 public:

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -6,8 +6,6 @@
 #include <iostream>
 #include <include/types.h>
 
-#include <expat.h>
-
 #include "include/str_list.h"
 #include "rgw_lc.h"
 #include "rgw_xml.h"

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -43,7 +43,6 @@
 
 #include "include/assert.h"
 
-using namespace std;
 using ceph::crypto::SHA1;
 
 struct req_state;

--- a/src/rgw/rgw_replica_log.h
+++ b/src/rgw/rgw_replica_log.h
@@ -22,8 +22,6 @@
 class RGWRados;
 class CephContext;
 
-using namespace std;
-
 #define META_REPLICA_LOG_OBJ_PREFIX "meta.replicalog."
 #define DATA_REPLICA_LOG_OBJ_PREFIX "data.replicalog."
 

--- a/src/rgw/rgw_rest_role.cc
+++ b/src/rgw/rgw_rest_role.cc
@@ -15,8 +15,6 @@
 
 #define dout_subsys ceph_subsys_rgw
 
-using namespace std;
-
 void RGWRestRole::send_response()
 {
   if (op_ret) {

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -11,7 +11,6 @@
 #include "rgw_rados.h"
 #include "rgw_common.h"
 
-using namespace std;
 using ceph::crypto::SHA1;
 
 struct req_state;

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -19,8 +19,6 @@
 #include "common/Formatter.h"
 #include "rgw_formats.h"
 
-using namespace std;
-
 #define RGW_USER_ANON_ID "anonymous"
 
 #define SECRET_KEY_LEN 40

--- a/src/rgw/rgw_xml.h
+++ b/src/rgw/rgw_xml.h
@@ -10,9 +10,6 @@
 #include <include/types.h>
 #include <common/Formatter.h>
 
-using namespace std;
-
-
 class XMLObj;
 
 class XMLObjIter {


### PR DESCRIPTION
We're still having the include in include/type.h, so just sweeping things
under the rug for now, also dropped the expat include in a couple of
header files