### PR TITLE
ceph_test_rados_api_list: more fix LibRadosListNP.ListObjectsError

### DIFF
--- a/src/test/librados/list.cc
+++ b/src/test/librados/list.cc
@@ -974,6 +974,7 @@ TEST_F(LibRadosListNP, ListObjectsError) {
       "\",\"sure\": \"--yes-i-really-really-mean-it-not-faking\"}";
     const char *cmd[2] = { c.c_str(), 0 };
     ASSERT_EQ(0, rados_mon_command(cluster, (const char **)cmd, 1, "", 0, &buf, &buflen, &st, &stlen));
+    ASSERT_EQ(0, rados_wait_for_latest_osdmap(cluster));
   }
 
   rados_list_ctx_t ctx;


### PR DESCRIPTION
Follow-on to d7e6e8d60309e4800389b36f786b633d0ca2ec07; we need to
make sure the client gets the updated osdmap.

Fixes: http://tracker.ceph.com/issues/19963
Signed-off-by: Sage Weil <sage@redhat.com>