### PR TITLE
rbd-mirror: permit release of local image exclusive lock after force promotion

### DIFF
--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -6,7 +6,6 @@ add_library(rbd_types STATIC
 
 set(librbd_internal_srcs
   AsyncObjectThrottle.cc
-  AsyncOperation.cc
   AsyncRequest.cc
   ExclusiveLock.cc
   ImageCtx.cc
@@ -44,6 +43,7 @@ set(librbd_internal_srcs
   image/SetSnapRequest.cc
   image_watcher/NotifyLockOwner.cc
   io/AioCompletion.cc
+  io/AsyncOperation.cc
   io/CopyupRequest.cc
   io/ImageRequest.cc
   io/ImageRequestWQ.cc

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -54,7 +54,6 @@ template <typename I>
 bool ExclusiveLock<I>::accept_ops() const {
   Mutex::Locker locker(ML<I>::m_lock);
   bool accept_ops = (!ML<I>::is_state_shutdown() &&
-                     !ML<I>::is_state_pre_releasing() &&
                      (ML<I>::is_state_locked() ||
                       ML<I>::is_state_post_acquiring()));
 

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -51,6 +51,18 @@ bool ExclusiveLock<I>::accept_requests(int *ret_val) const {
 }
 
 template <typename I>
+bool ExclusiveLock<I>::accept_ops() const {
+  Mutex::Locker locker(ML<I>::m_lock);
+  bool accept_ops = (!ML<I>::is_state_shutdown() &&
+                     !ML<I>::is_state_pre_releasing() &&
+                     (ML<I>::is_state_locked() ||
+                      ML<I>::is_state_post_acquiring()));
+
+  ldout(m_image_ctx.cct, 20) << "=" << accept_ops << dendl;
+  return accept_ops;
+}
+
+template <typename I>
 void ExclusiveLock<I>::block_requests(int r) {
   Mutex::Locker locker(ML<I>::m_lock);
 

--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -42,7 +42,9 @@ bool ExclusiveLock<I>::accept_requests(int *ret_val) const {
   bool accept_requests = (!ML<I>::is_state_shutdown() &&
                           ML<I>::is_state_locked() &&
                           m_request_blocked_count == 0);
-  *ret_val = m_request_blocked_ret_val;
+  if (ret_val != nullptr) {
+    *ret_val = m_request_blocked_ret_val;
+  }
 
   ldout(m_image_ctx.cct, 20) << "=" << accept_requests << dendl;
   return accept_requests;

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -5,7 +5,7 @@
 #define CEPH_LIBRBD_EXCLUSIVE_LOCK_H
 
 #include "librbd/ManagedLock.h"
-#include "librbd/ImageCtx.h"
+#include "common/AsyncOpTracker.h"
 
 namespace librbd {
 
@@ -28,6 +28,8 @@ public:
   void shut_down(Context *on_shutdown);
 
   void handle_peer_notification(int r);
+
+  Context *start_op();
 
 protected:
   void shutdown_handler(int r, Context *on_finish) override;
@@ -84,10 +86,14 @@ private:
   ImageCtxT& m_image_ctx;
   Context *m_pre_post_callback = nullptr;
 
+  AsyncOpTracker m_async_op_tracker;
+
   uint32_t m_request_blocked_count = 0;
   int m_request_blocked_ret_val = 0;
 
   int m_acquire_lock_peer_ret_val = 0;
+
+  bool accept_ops(const Mutex &lock) const;
 
   void handle_init_complete(uint64_t features);
   void handle_post_acquiring_lock(int r);

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -19,6 +19,7 @@ public:
   ExclusiveLock(ImageCtxT &image_ctx);
 
   bool accept_requests(int *ret_val = nullptr) const;
+  bool accept_ops() const;
 
   void block_requests(int r);
   void unblock_requests();

--- a/src/librbd/ExclusiveLock.h
+++ b/src/librbd/ExclusiveLock.h
@@ -18,7 +18,7 @@ public:
 
   ExclusiveLock(ImageCtxT &image_ctx);
 
-  bool accept_requests(int *ret_val) const;
+  bool accept_requests(int *ret_val = nullptr) const;
 
   void block_requests(int r);
   void unblock_requests();

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -11,7 +11,6 @@
 #include "common/WorkQueue.h"
 #include "common/Timer.h"
 
-#include "librbd/AsyncOperation.h"
 #include "librbd/AsyncRequest.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/internal.h"
@@ -28,6 +27,7 @@
 #include "librbd/exclusive_lock/AutomaticPolicy.h"
 #include "librbd/exclusive_lock/StandardPolicy.h"
 #include "librbd/io/AioCompletion.h"
+#include "librbd/io/AsyncOperation.h"
 #include "librbd/io/ImageRequestWQ.h"
 #include "librbd/journal/StandardPolicy.h"
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -38,7 +38,6 @@ class SafeTimer;
 
 namespace librbd {
 
-  class AsyncOperation;
   template <typename> class ExclusiveLock;
   template <typename> class ImageState;
   template <typename> class ImageWatcher;
@@ -52,6 +51,7 @@ namespace librbd {
   namespace exclusive_lock { struct Policy; }
   namespace io {
   class AioCompletion;
+  class AsyncOperation;
   class ImageRequestWQ;
   class CopyupRequest;
   }
@@ -141,7 +141,7 @@ namespace librbd {
 
     std::map<uint64_t, io::CopyupRequest*> copyup_list;
 
-    xlist<AsyncOperation*> async_ops;
+    xlist<io::AsyncOperation*> async_ops;
     xlist<AsyncRequest<>*> async_requests;
     std::list<Context*> async_requests_waiters;
 

--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -1332,9 +1332,11 @@ void Journal<I>::handle_replay_process_safe(ReplayEntry replay_entry, int r) {
 
   ldout(cct, 20) << this << " " << __func__ << ": r=" << r << dendl;
   if (r < 0) {
-    lderr(cct) << this << " " << __func__ << ": "
-               << "failed to commit journal event to disk: " << cpp_strerror(r)
-               << dendl;
+    if (r != -ECANCELED) {
+      lderr(cct) << this << " " << __func__ << ": "
+                 << "failed to commit journal event to disk: "
+                 << cpp_strerror(r) << dendl;
+    }
 
     if (m_state == STATE_REPLAYING) {
       // abort the replay if we have an error

--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -192,9 +192,8 @@ struct C_InvokeAsyncRequest : public Context {
       return;
     }
 
-    int r;
     if (image_ctx.exclusive_lock->is_lock_owner() &&
-        image_ctx.exclusive_lock->accept_requests(&r)) {
+        image_ctx.exclusive_lock->accept_requests()) {
       send_local_request();
       owner_lock.put_read();
       return;
@@ -1473,7 +1472,6 @@ int Operations<I>::prepare_image_update() {
   }
 
   // need to upgrade to a write lock
-  int r = 0;
   bool trying_lock = false;
   C_SaferCond ctx;
   m_image_ctx.owner_lock.put_read();
@@ -1481,12 +1479,13 @@ int Operations<I>::prepare_image_update() {
     RWLock::WLocker owner_locker(m_image_ctx.owner_lock);
     if (m_image_ctx.exclusive_lock != nullptr &&
         (!m_image_ctx.exclusive_lock->is_lock_owner() ||
-         !m_image_ctx.exclusive_lock->accept_requests(&r))) {
+         !m_image_ctx.exclusive_lock->accept_requests())) {
       m_image_ctx.exclusive_lock->try_acquire_lock(&ctx);
       trying_lock = true;
     }
   }
 
+  int r = 0;
   if (trying_lock) {
     r = ctx.wait();
   }

--- a/src/librbd/io/AioCompletion.h
+++ b/src/librbd/io/AioCompletion.h
@@ -10,8 +10,8 @@
 #include "include/utime.h"
 #include "include/rbd/librbd.hpp"
 
-#include "librbd/AsyncOperation.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/io/AsyncOperation.h"
 #include "librbd/io/ReadResult.h"
 #include "librbd/io/Types.h"
 

--- a/src/librbd/io/AsyncOperation.cc
+++ b/src/librbd/io/AsyncOperation.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-#include "librbd/AsyncOperation.h"
+
+#include "librbd/io/AsyncOperation.h"
 #include "librbd/ImageCtx.h"
 #include "common/dout.h"
 #include "common/WorkQueue.h"
@@ -8,9 +9,10 @@
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::AsyncOperation: "
+#define dout_prefix *_dout << "librbd::io::AsyncOperation: "
 
 namespace librbd {
+namespace io {
 
 namespace {
 
@@ -78,4 +80,5 @@ void AsyncOperation::add_flush_context(Context *on_finish) {
   m_flush_contexts.push_back(on_finish);
 }
 
+} // namespace io
 } // namespace librbd

--- a/src/librbd/io/AsyncOperation.h
+++ b/src/librbd/io/AsyncOperation.h
@@ -1,7 +1,8 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-#ifndef LIBRBD_ASYNC_OPERATION_H
-#define LIBRBD_ASYNC_OPERATION_H
+
+#ifndef LIBRBD_IO_ASYNC_OPERATION_H
+#define LIBRBD_IO_ASYNC_OPERATION_H
 
 #include "include/assert.h"
 #include "include/xlist.h"
@@ -12,6 +13,8 @@ class Context;
 namespace librbd {
 
 class ImageCtx;
+
+namespace io {
 
 class AsyncOperation {
 public:
@@ -43,6 +46,7 @@ private:
 
 };
 
+} // namespace io
 } // namespace librbd
 
-#endif // LIBRBD_ASYNC_OPERATION_H
+#endif // LIBRBD_IO_ASYNC_OPERATION_H

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -4,11 +4,11 @@
 #ifndef CEPH_LIBRBD_IO_COPYUP_REQUEST_H
 #define CEPH_LIBRBD_IO_COPYUP_REQUEST_H
 
-#include "librbd/AsyncOperation.h"
 #include "include/int_types.h"
 #include "include/rados/librados.hpp"
 #include "include/buffer.h"
 #include "common/zipkin_trace.h"
+#include "librbd/io/AsyncOperation.h"
 #include "librbd/io/Types.h"
 
 #include <string>

--- a/src/librbd/journal/Replay.cc
+++ b/src/librbd/journal/Replay.cc
@@ -216,6 +216,7 @@ void Replay<I>::shut_down(bool cancel_ops, Context *on_finish) {
     // safely commit any remaining AIO modify operations
     if ((m_in_flight_aio_flush + m_in_flight_aio_modify) != 0) {
       flush_comp = create_aio_flush_completion(nullptr);
+      assert(flush_comp != nullptr);
     }
 
     for (auto &op_event_pair : m_op_events) {
@@ -240,6 +241,9 @@ void Replay<I>::shut_down(bool cancel_ops, Context *on_finish) {
       }
     }
 
+    assert(!m_shut_down);
+    m_shut_down = true;
+
     assert(m_flush_ctx == nullptr);
     if (m_in_flight_op_events > 0 || flush_comp != nullptr) {
       std::swap(m_flush_ctx, on_finish);
@@ -263,6 +267,9 @@ void Replay<I>::flush(Context *on_finish) {
     Mutex::Locker locker(m_lock);
     aio_comp = create_aio_flush_completion(
       util::create_async_context_callback(m_image_ctx, on_finish));
+    if (aio_comp == nullptr) {
+      return;
+    }
   }
 
   RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
@@ -318,6 +325,10 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
   auto aio_comp = create_aio_modify_completion(on_ready, on_safe,
                                                io::AIO_TYPE_DISCARD,
                                                &flush_required);
+  if (aio_comp == nullptr) {
+    return;
+  }
+
   io::ImageRequest<I>::aio_discard(&m_image_ctx, aio_comp, event.offset,
                                    event.length, event.skip_partial_discard,
 				   {});
@@ -326,7 +337,9 @@ void Replay<I>::handle_event(const journal::AioDiscardEvent &event,
     auto flush_comp = create_aio_flush_completion(nullptr);
     m_lock.Unlock();
 
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    if (flush_comp != nullptr) {
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    }
   }
 }
 
@@ -341,6 +354,10 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
   auto aio_comp = create_aio_modify_completion(on_ready, on_safe,
                                                io::AIO_TYPE_WRITE,
                                                &flush_required);
+  if (aio_comp == nullptr) {
+    return;
+  }
+
   io::ImageRequest<I>::aio_write(&m_image_ctx, aio_comp,
                                  {{event.offset, event.length}},
                                  std::move(data), 0, {});
@@ -349,7 +366,9 @@ void Replay<I>::handle_event(const journal::AioWriteEvent &event,
     auto flush_comp = create_aio_flush_completion(nullptr);
     m_lock.Unlock();
 
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    if (flush_comp != nullptr) {
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    }
   }
 }
 
@@ -364,8 +383,10 @@ void Replay<I>::handle_event(const journal::AioFlushEvent &event,
     Mutex::Locker locker(m_lock);
     aio_comp = create_aio_flush_completion(on_safe);
   }
-  io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp, {});
 
+  if (aio_comp != nullptr) {
+    io::ImageRequest<I>::aio_flush(&m_image_ctx, aio_comp, {});
+  }
   on_ready->complete(0);
 }
 
@@ -380,6 +401,10 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
   auto aio_comp = create_aio_modify_completion(on_ready, on_safe,
                                                io::AIO_TYPE_WRITESAME,
                                                &flush_required);
+  if (aio_comp == nullptr) {
+    return;
+  }
+
   io::ImageRequest<I>::aio_writesame(&m_image_ctx, aio_comp, event.offset,
                                      event.length, std::move(data), 0, {});
   if (flush_required) {
@@ -387,7 +412,9 @@ void Replay<I>::handle_event(const journal::AioWriteSameEvent &event,
     auto flush_comp = create_aio_flush_completion(nullptr);
     m_lock.Unlock();
 
-    io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    if (flush_comp != nullptr) {
+      io::ImageRequest<I>::aio_flush(&m_image_ctx, flush_comp, {});
+    }
   }
 }
 
@@ -861,6 +888,12 @@ Context *Replay<I>::create_op_context_callback(uint64_t op_tid,
                                                Context *on_safe,
                                                OpEvent **op_event) {
   CephContext *cct = m_image_ctx.cct;
+  if (m_shut_down) {
+    ldout(cct, 5) << ": ignoring event after shut down" << dendl;
+    on_ready->complete(0);
+    m_image_ctx.op_work_queue->queue(on_safe, -ESHUTDOWN);
+    return nullptr;
+  }
 
   assert(m_lock.is_locked());
   if (m_op_events.count(op_tid) != 0) {
@@ -898,7 +931,10 @@ void Replay<I>::handle_op_complete(uint64_t op_tid, int r) {
     op_event = std::move(op_it->second);
     m_op_events.erase(op_it);
 
-    shutting_down = (m_flush_ctx != nullptr);
+    if (m_shut_down) {
+      assert(m_flush_ctx != nullptr);
+      shutting_down = true;
+    }
   }
 
   assert(op_event.on_start_ready == nullptr || (r < 0 && r != -ERESTART));
@@ -958,6 +994,13 @@ Replay<I>::create_aio_modify_completion(Context *on_ready, Context *on_safe,
   CephContext *cct = m_image_ctx.cct;
   assert(m_on_aio_ready == nullptr);
 
+  if (m_shut_down) {
+    ldout(cct, 5) << ": ignoring event after shut down" << dendl;
+    on_ready->complete(0);
+    m_image_ctx.op_work_queue->queue(on_safe, -ESHUTDOWN);
+    return nullptr;
+  }
+
   ++m_in_flight_aio_modify;
   m_aio_modify_unsafe_contexts.push_back(on_safe);
 
@@ -996,6 +1039,15 @@ Replay<I>::create_aio_modify_completion(Context *on_ready, Context *on_safe,
 template <typename I>
 io::AioCompletion *Replay<I>::create_aio_flush_completion(Context *on_safe) {
   assert(m_lock.is_locked());
+
+  CephContext *cct = m_image_ctx.cct;
+  if (m_shut_down) {
+    ldout(cct, 5) << ": ignoring event after shut down" << dendl;
+    if (on_safe != nullptr) {
+      m_image_ctx.op_work_queue->queue(on_safe, -ESHUTDOWN);
+    }
+    return nullptr;
+  }
 
   ++m_in_flight_aio_flush;
 

--- a/src/librbd/journal/Replay.h
+++ b/src/librbd/journal/Replay.h
@@ -126,6 +126,7 @@ private:
   OpEvents m_op_events;
   uint64_t m_in_flight_op_events = 0;
 
+  bool m_shut_down = false;
   Context *m_flush_ctx = nullptr;
   Context *m_on_aio_ready = nullptr;
 

--- a/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PreReleaseRequest.cc
@@ -7,6 +7,7 @@
 #include "test/librbd/mock/MockJournal.h"
 #include "test/librbd/mock/MockObjectMap.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "common/AsyncOpTracker.h"
 #include "librbd/exclusive_lock/PreReleaseRequest.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
@@ -118,6 +119,7 @@ public:
     EXPECT_CALL(*mock_image_ctx.state, handle_prepare_lock_complete());
   }
 
+  AsyncOpTracker m_async_op_tracker;
 };
 
 TEST_F(TestMockExclusiveLockPreReleaseRequest, Success) {
@@ -149,7 +151,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, Success) {
 
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, false, &ctx);
+    mock_image_ctx, false, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -179,7 +181,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, SuccessJournalDisabled) {
 
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, false, &ctx);
+    mock_image_ctx, false, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -203,7 +205,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, SuccessObjectMapDisabled) {
   C_SaferCond release_ctx;
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, true, &ctx);
+    mock_image_ctx, true, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -239,7 +241,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, Blacklisted) {
 
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, false, &ctx);
+    mock_image_ctx, false, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -261,7 +263,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, BlockWritesError) {
 
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, true, &ctx);
+    mock_image_ctx, true, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -284,7 +286,7 @@ TEST_F(TestMockExclusiveLockPreReleaseRequest, UnlockError) {
 
   C_SaferCond ctx;
   MockPreReleaseRequest *req = MockPreReleaseRequest::create(
-    mock_image_ctx, true, &ctx);
+    mock_image_ctx, true, m_async_op_tracker, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
 }

--- a/src/test/librbd/journal/test_mock_Replay.cc
+++ b/src/test/librbd/journal/test_mock_Replay.cc
@@ -128,6 +128,11 @@ public:
   TestMockJournalReplay() : m_invoke_lock("m_invoke_lock") {
   }
 
+  void expect_accept_ops(MockExclusiveLock &mock_exclusive_lock, bool accept) {
+    EXPECT_CALL(mock_exclusive_lock, accept_ops()).WillRepeatedly(
+      Return(accept));
+  }
+
   void expect_aio_discard(MockIoImageRequest &mock_io_image_request,
                           io::AioCompletion **aio_comp, uint64_t off,
                           uint64_t len, bool skip_partial_discard) {
@@ -333,6 +338,11 @@ TEST_F(TestMockJournalReplay, AioDiscard) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -361,6 +371,11 @@ TEST_F(TestMockJournalReplay, AioWrite) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -389,6 +404,11 @@ TEST_F(TestMockJournalReplay, AioFlush) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -415,6 +435,11 @@ TEST_F(TestMockJournalReplay, AioWriteSame) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -443,6 +468,11 @@ TEST_F(TestMockJournalReplay, IOError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -471,6 +501,11 @@ TEST_F(TestMockJournalReplay, SoftFlushIO) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -510,6 +545,11 @@ TEST_F(TestMockJournalReplay, PauseIO) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -551,6 +591,11 @@ TEST_F(TestMockJournalReplay, Flush) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -579,6 +624,11 @@ TEST_F(TestMockJournalReplay, OpFinishError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -610,6 +660,11 @@ TEST_F(TestMockJournalReplay, BlockedOpFinishError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -649,6 +704,11 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -703,6 +763,11 @@ TEST_F(TestMockJournalReplay, MissingOpFinishEventCancelOps) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -750,6 +815,11 @@ TEST_F(TestMockJournalReplay, UnknownOpFinishEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -770,6 +840,11 @@ TEST_F(TestMockJournalReplay, OpEventError) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -806,6 +881,11 @@ TEST_F(TestMockJournalReplay, SnapCreateEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -847,6 +927,11 @@ TEST_F(TestMockJournalReplay, SnapCreateEventExists) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -884,6 +969,11 @@ TEST_F(TestMockJournalReplay, SnapRemoveEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -920,6 +1010,11 @@ TEST_F(TestMockJournalReplay, SnapRemoveEventDNE) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -956,6 +1051,11 @@ TEST_F(TestMockJournalReplay, SnapRenameEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -989,6 +1089,11 @@ TEST_F(TestMockJournalReplay, SnapRenameEventExists) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1022,6 +1127,11 @@ TEST_F(TestMockJournalReplay, SnapProtectEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1058,6 +1168,11 @@ TEST_F(TestMockJournalReplay, SnapProtectEventBusy) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1094,6 +1209,11 @@ TEST_F(TestMockJournalReplay, SnapUnprotectEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1130,6 +1250,11 @@ TEST_F(TestMockJournalReplay, SnapUnprotectOpFinishBusy) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1162,6 +1287,11 @@ TEST_F(TestMockJournalReplay, SnapUnprotectEventInvalid) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1198,6 +1328,11 @@ TEST_F(TestMockJournalReplay, SnapRollbackEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1234,6 +1369,11 @@ TEST_F(TestMockJournalReplay, RenameEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1266,6 +1406,11 @@ TEST_F(TestMockJournalReplay, RenameEventExists) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1298,6 +1443,11 @@ TEST_F(TestMockJournalReplay, ResizeEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1335,6 +1485,11 @@ TEST_F(TestMockJournalReplay, FlattenEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1367,6 +1522,11 @@ TEST_F(TestMockJournalReplay, FlattenEventInvalid) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1402,6 +1562,11 @@ TEST_F(TestMockJournalReplay, UpdateFeaturesEvent) {
   bool enabled = !ictx->test_features(features);
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1440,6 +1605,11 @@ TEST_F(TestMockJournalReplay, MetadataSetEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1472,6 +1642,11 @@ TEST_F(TestMockJournalReplay, MetadataRemoveEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1504,6 +1679,11 @@ TEST_F(TestMockJournalReplay, MetadataRemoveEventDNE) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1536,6 +1716,11 @@ TEST_F(TestMockJournalReplay, UnknownEvent) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1562,6 +1747,11 @@ TEST_F(TestMockJournalReplay, RefreshImageBeforeOpStart) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   expect_op_work_queue(mock_image_ctx);
 
@@ -1599,6 +1789,11 @@ TEST_F(TestMockJournalReplay, FlushEventAfterShutDown) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -1620,6 +1815,11 @@ TEST_F(TestMockJournalReplay, ModifyEventAfterShutDown) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -1642,6 +1842,11 @@ TEST_F(TestMockJournalReplay, OpEventAfterShutDown) {
   ASSERT_EQ(0, open_image(m_image_name, &ictx));
 
   MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, true);
+
   MockJournalReplay mock_journal_replay(mock_image_ctx);
   MockIoImageRequest mock_io_image_request;
   expect_op_work_queue(mock_image_ctx);
@@ -1654,6 +1859,69 @@ TEST_F(TestMockJournalReplay, OpEventAfterShutDown) {
                &on_ready, &on_safe);
   ASSERT_EQ(0, on_ready.wait());
   ASSERT_EQ(-ESHUTDOWN, on_safe.wait());
+}
+
+TEST_F(TestMockJournalReplay, LockLostBeforeProcess) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, false);
+
+  MockJournalReplay mock_journal_replay(mock_image_ctx);
+  MockIoImageRequest mock_io_image_request;
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  C_SaferCond on_ready;
+  C_SaferCond on_safe;
+  when_process(mock_journal_replay, EventEntry{AioFlushEvent()},
+               &on_ready, &on_safe);
+  ASSERT_EQ(0, on_ready.wait());
+  ASSERT_EQ(-ECANCELED, on_safe.wait());
+
+  ASSERT_EQ(0, when_shut_down(mock_journal_replay, false));
+}
+
+TEST_F(TestMockJournalReplay, LockLostBeforeExecuteOp) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockReplayImageCtx mock_image_ctx(*ictx);
+
+  MockExclusiveLock mock_exclusive_lock;
+  mock_image_ctx.exclusive_lock = &mock_exclusive_lock;
+  expect_accept_ops(mock_exclusive_lock, false);
+
+  MockJournalReplay mock_journal_replay(mock_image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  EXPECT_CALL(mock_exclusive_lock, accept_ops()).WillOnce(Return(true));
+  EXPECT_CALL(mock_exclusive_lock, accept_ops()).WillOnce(Return(true));
+  expect_refresh_image(mock_image_ctx, false, 0);
+
+  C_SaferCond on_start_ready;
+  C_SaferCond on_start_safe;
+  when_process(mock_journal_replay, EventEntry{RenameEvent(123, "image")},
+               &on_start_ready, &on_start_safe);
+  ASSERT_EQ(0, on_start_ready.wait());
+
+  C_SaferCond on_finish_ready;
+  C_SaferCond on_finish_safe;
+  when_process(mock_journal_replay, EventEntry{OpFinishEvent(123, 0)},
+               &on_finish_ready, &on_finish_safe);
+
+  ASSERT_EQ(-ECANCELED, on_start_safe.wait());
+  ASSERT_EQ(0, on_finish_ready.wait());
+  ASSERT_EQ(-ECANCELED, on_finish_safe.wait());
 }
 
 } // namespace journal

--- a/src/test/librbd/mock/MockExclusiveLock.h
+++ b/src/test/librbd/mock/MockExclusiveLock.h
@@ -26,6 +26,9 @@ struct MockExclusiveLock {
 
   MOCK_METHOD1(acquire_lock, void(Context *));
   MOCK_METHOD1(release_lock, void(Context *));
+
+  MOCK_METHOD0(accept_requests, bool());
+  MOCK_METHOD0(accept_ops, bool());
 };
 
 } // namespace librbd

--- a/src/test/librbd/mock/MockExclusiveLock.h
+++ b/src/test/librbd/mock/MockExclusiveLock.h
@@ -29,6 +29,8 @@ struct MockExclusiveLock {
 
   MOCK_METHOD0(accept_requests, bool());
   MOCK_METHOD0(accept_ops, bool());
+
+  MOCK_METHOD0(start_op, Context*());
 };
 
 } // namespace librbd

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -126,7 +126,7 @@ template <>
 struct PreReleaseRequest<MockExclusiveLockImageCtx> : public BaseRequest<PreReleaseRequest<MockExclusiveLockImageCtx> > {
   static PreReleaseRequest<MockExclusiveLockImageCtx> *create(
       MockExclusiveLockImageCtx &image_ctx, bool shutting_down,
-      Context *on_finish) {
+      AsyncOpTracker &async_op_tracker, Context *on_finish) {
     return BaseRequest::create(image_ctx, nullptr, on_finish);
   }
   MOCK_METHOD0(send, void());

--- a/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ImageCopyRequest.cc
@@ -87,6 +87,7 @@ using ::testing::_;
 using ::testing::InSequence;
 using ::testing::Invoke;
 using ::testing::Return;
+using ::testing::ReturnNew;
 using ::testing::WithArg;
 using ::testing::InvokeWithoutArgs;
 
@@ -104,6 +105,11 @@ public:
 
     ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
     ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
+    EXPECT_CALL(mock_exclusive_lock, start_op()).WillOnce(
+      ReturnNew<FunctionContext>([](int) {}));
   }
 
   void expect_get_snap_id(librbd::MockTestImageCtx &mock_image_ctx) {
@@ -216,12 +222,16 @@ TEST_F(TestMockImageSyncImageCopyRequest, SimpleImage) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   InSequence seq;
   expect_get_object_count(mock_remote_image_ctx, 1);
   expect_get_object_count(mock_remote_image_ctx, 0);
   expect_update_client(mock_journaler, 0);
+  expect_start_op(mock_exclusive_lock);
   expect_object_copy_send(mock_object_copy_request);
   expect_update_client(mock_journaler, 0);
 
@@ -263,11 +273,16 @@ TEST_F(TestMockImageSyncImageCopyRequest, Throttled) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   expect_get_object_count(mock_remote_image_ctx, object_count);
   expect_get_object_count(mock_remote_image_ctx, 0);
 
+  EXPECT_CALL(mock_exclusive_lock, start_op())
+    .Times(object_count).WillRepeatedly(ReturnNew<FunctionContext>([](int) {}));
   EXPECT_CALL(mock_object_copy_request, send()).Times(object_count);
 
   boost::optional<uint64_t> expected_object_number(boost::none);
@@ -326,6 +341,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, SnapshotSubset) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   InSequence seq;
@@ -334,6 +352,7 @@ TEST_F(TestMockImageSyncImageCopyRequest, SnapshotSubset) {
   expect_get_object_count(mock_remote_image_ctx, 1);
   expect_get_object_count(mock_remote_image_ctx, 1);
   expect_update_client(mock_journaler, 0);
+  expect_start_op(mock_exclusive_lock);
   expect_object_copy_send(mock_object_copy_request);
   expect_update_client(mock_journaler, 0);
 
@@ -364,6 +383,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartCatchup) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   InSequence seq;
@@ -371,6 +393,7 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartCatchup) {
   expect_get_object_count(mock_remote_image_ctx, 0);
   expect_get_object_count(mock_remote_image_ctx, 0);
   expect_update_client(mock_journaler, 0);
+  expect_start_op(mock_exclusive_lock);
   expect_object_copy_send(mock_object_copy_request);
   expect_update_client(mock_journaler, 0);
 
@@ -398,12 +421,16 @@ TEST_F(TestMockImageSyncImageCopyRequest, RestartPartialSync) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   InSequence seq;
   expect_get_object_count(mock_remote_image_ctx, 1);
   expect_get_object_count(mock_remote_image_ctx, 2);
   expect_update_client(mock_journaler, 0);
+  expect_start_op(mock_exclusive_lock);
   expect_object_copy_send(mock_object_copy_request);
   expect_update_client(mock_journaler, 0);
 
@@ -435,12 +462,16 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   InSequence seq;
   expect_get_object_count(mock_remote_image_ctx, 2);
   expect_get_object_count(mock_remote_image_ctx, 2);
   expect_update_client(mock_journaler, 0);
+  expect_start_op(mock_exclusive_lock);
   expect_object_copy_send(mock_object_copy_request);
 
   C_SaferCond ctx;
@@ -481,11 +512,16 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel_Inflight_Sync) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   expect_get_object_count(mock_remote_image_ctx, 10);
   expect_get_object_count(mock_remote_image_ctx, 0);
 
+  EXPECT_CALL(mock_exclusive_lock, start_op())
+    .Times(6).WillRepeatedly(ReturnNew<FunctionContext>([](int) {}));
   EXPECT_CALL(mock_object_copy_request, send()).Times(6);
 
   EXPECT_CALL(mock_journaler, update_client(_, _))
@@ -529,6 +565,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, Cancel1) {
   journal::MockJournaler mock_journaler;
   MockObjectCopyRequest mock_object_copy_request;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   C_SaferCond ctx;
   MockImageCopyRequest *request = create_request(mock_remote_image_ctx,
                                                  mock_local_image_ctx,
@@ -559,6 +598,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, MissingSnap) {
   librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   C_SaferCond ctx;
@@ -581,6 +623,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, MissingFromSnap) {
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
   librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
   expect_get_snap_id(mock_remote_image_ctx);
 
@@ -607,6 +652,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapMap) {
   librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
 
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
   expect_get_snap_id(mock_remote_image_ctx);
 
   C_SaferCond ctx;
@@ -631,6 +679,9 @@ TEST_F(TestMockImageSyncImageCopyRequest, EmptySnapSeqs) {
   librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
   librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
   journal::MockJournaler mock_journaler;
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
 
   expect_get_snap_id(mock_remote_image_ctx);
 

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -385,6 +385,10 @@ public:
       .WillOnce(CompleteContext(r));
   }
 
+  void expect_flush(MockReplay &mock_replay, int r) {
+    EXPECT_CALL(mock_replay, flush(_)).WillOnce(CompleteContext(r));
+  }
+
   void expect_shut_down(MockReplay &mock_replay, bool cancel_ops, int r) {
     EXPECT_CALL(mock_replay, shut_down(cancel_ops, _))
       .WillOnce(WithArg<1>(CompleteContext(r)));
@@ -514,16 +518,14 @@ TEST_F(TestMockImageReplayer, StartStop) {
 
   MockCloseImageRequest mock_close_local_image_request;
 
-  expect_stop_replay(mock_remote_journaler, 0);
   expect_shut_down(mock_local_replay, true, 0);
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
   EXPECT_CALL(mock_local_journal, stop_external_replay());
+  expect_send(mock_close_local_image_request, 0);
 
+  expect_stop_replay(mock_remote_journaler, 0);
   EXPECT_CALL(mock_remote_journaler, remove_listener(_));
   expect_shut_down(mock_remote_journaler, 0);
-
-  expect_send(mock_close_local_image_request, 0);
 
   C_SaferCond stop_ctx;
   m_image_replayer->stop(&stop_ctx);
@@ -650,13 +652,11 @@ TEST_F(TestMockImageReplayer, StartExternalReplayError) {
   expect_start_external_replay(mock_local_journal, nullptr, -EINVAL);
 
   MockCloseImageRequest mock_close_local_image_request;
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
+  expect_send(mock_close_local_image_request, 0);
 
   EXPECT_CALL(mock_remote_journaler, remove_listener(_));
   expect_shut_down(mock_remote_journaler, 0);
-
-  expect_send(mock_close_local_image_request, 0);
 
   C_SaferCond start_ctx;
   m_image_replayer->start(&start_ctx);
@@ -706,16 +706,14 @@ TEST_F(TestMockImageReplayer, StopError) {
 
   MockCloseImageRequest mock_close_local_image_request;
 
-  expect_stop_replay(mock_remote_journaler, -EINVAL);
   expect_shut_down(mock_local_replay, true, -EINVAL);
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
   EXPECT_CALL(mock_local_journal, stop_external_replay());
+  expect_send(mock_close_local_image_request, -EINVAL);
 
+  expect_stop_replay(mock_remote_journaler, -EINVAL);
   EXPECT_CALL(mock_remote_journaler, remove_listener(_));
   expect_shut_down(mock_remote_journaler, -EINVAL);
-
-  expect_send(mock_close_local_image_request, -EINVAL);
 
   C_SaferCond stop_ctx;
   m_image_replayer->stop(&stop_ctx);
@@ -806,17 +804,14 @@ TEST_F(TestMockImageReplayer, Replay) {
   // STOP
 
   MockCloseImageRequest mock_close_local_image_request;
-
-  expect_stop_replay(mock_remote_journaler, 0);
   expect_shut_down(mock_local_replay, true, 0);
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
   EXPECT_CALL(mock_local_journal, stop_external_replay());
+  expect_send(mock_close_local_image_request, 0);
 
+  expect_stop_replay(mock_remote_journaler, 0);
   EXPECT_CALL(mock_remote_journaler, remove_listener(_));
   expect_shut_down(mock_remote_journaler, 0);
-
-  expect_send(mock_close_local_image_request, 0);
 
   C_SaferCond stop_ctx;
   m_image_replayer->stop(&stop_ctx);
@@ -886,14 +881,9 @@ TEST_F(TestMockImageReplayer, DecodeError) {
     .WillOnce(Return(-EINVAL));
 
   // stop on error
-  expect_stop_replay(mock_remote_journaler, 0);
   expect_shut_down(mock_local_replay, true, 0);
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
   EXPECT_CALL(mock_local_journal, stop_external_replay());
-
-  EXPECT_CALL(mock_remote_journaler, remove_listener(_));
-  expect_shut_down(mock_remote_journaler, 0);
 
   MockCloseImageRequest mock_close_local_image_request;
   C_SaferCond close_ctx;
@@ -903,6 +893,10 @@ TEST_F(TestMockImageReplayer, DecodeError) {
 	  mock_close_local_image_request.on_finish->complete(0);
 	  close_ctx.complete(0);
 	}));
+
+  expect_stop_replay(mock_remote_journaler, 0);
+  EXPECT_CALL(mock_remote_journaler, remove_listener(_));
+  expect_shut_down(mock_remote_journaler, 0);
 
   // fire
   m_image_replayer->handle_replay_ready();
@@ -1010,16 +1004,14 @@ TEST_F(TestMockImageReplayer, DelayedReplay) {
 
   MockCloseImageRequest mock_close_local_image_request;
 
-  expect_stop_replay(mock_remote_journaler, 0);
   expect_shut_down(mock_local_replay, true, 0);
-
   EXPECT_CALL(mock_local_journal, remove_listener(_));
   EXPECT_CALL(mock_local_journal, stop_external_replay());
+  expect_send(mock_close_local_image_request, 0);
 
+  expect_stop_replay(mock_remote_journaler, 0);
   EXPECT_CALL(mock_remote_journaler, remove_listener(_));
   expect_shut_down(mock_remote_journaler, 0);
-
-  expect_send(mock_close_local_image_request, 0);
 
   C_SaferCond stop_ctx;
   m_image_replayer->stop(&stop_ctx);

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -810,6 +810,17 @@ void ImageReplayer<I>::handle_replay_ready()
   }
 
   m_event_replay_tracker.start_op();
+
+  m_lock.Lock();
+  bool stopping = (m_state == STATE_STOPPING);
+  m_lock.Unlock();
+
+  if (stopping) {
+    dout(10) << "stopping event replay" << dendl;
+    m_event_replay_tracker.finish_op();
+    return;
+  }
+
   if (m_replay_tag_valid && m_replay_tag.tid == m_replay_tag_tid) {
     preprocess_entry();
     return;
@@ -1452,19 +1463,18 @@ void ImageReplayer<I>::shut_down(int r) {
     }
   }
 
+  // NOTE: it's important to ensure that the local image is fully
+  // closed before attempting to close the remote journal in
+  // case the remote cluster is unreachable
+
   // chain the shut down sequence (reverse order)
   Context *ctx = new FunctionContext(
     [this, r](int _r) {
       update_mirror_image_status(true, STATE_STOPPED);
       handle_shut_down(r);
     });
-  if (m_local_image_ctx) {
-    ctx = new FunctionContext([this, ctx](int r) {
-      CloseImageRequest<I> *request = CloseImageRequest<I>::create(
-        &m_local_image_ctx, ctx);
-      request->send();
-    });
-  }
+
+  // close the remote journal
   if (m_remote_journaler != nullptr) {
     ctx = new FunctionContext([this, ctx](int r) {
         delete m_remote_journaler;
@@ -1481,6 +1491,30 @@ void ImageReplayer<I>::shut_down(int r) {
         });
     }
   }
+
+  // stop the replay of remote journal events
+  if (m_replay_handler != nullptr) {
+    ctx = new FunctionContext([this, ctx](int r) {
+        delete m_replay_handler;
+        m_replay_handler = nullptr;
+
+        m_event_replay_tracker.wait_for_ops(ctx);
+      });
+    ctx = new FunctionContext([this, ctx](int r) {
+        m_remote_journaler->stop_replay(ctx);
+      });
+  }
+
+  // close the local image (release exclusive lock)
+  if (m_local_image_ctx) {
+    ctx = new FunctionContext([this, ctx](int r) {
+      CloseImageRequest<I> *request = CloseImageRequest<I>::create(
+        &m_local_image_ctx, ctx);
+      request->send();
+    });
+  }
+
+  // shut down event replay into the local image
   if (m_local_journal != nullptr) {
     ctx = new FunctionContext([this, ctx](int r) {
         m_local_journal = nullptr;
@@ -1497,32 +1531,29 @@ void ImageReplayer<I>::shut_down(int r) {
         });
     }
     ctx = new FunctionContext([this, ctx](int r) {
-        if (r < 0) {
-          derr << "error flushing journal replay: " << cpp_strerror(r) << dendl;
-        }
-
         // blocks if listener notification is in-progress
         m_local_journal->remove_listener(m_journal_listener);
-
-        // wait for all in-flight replayed events to complete
-        m_event_replay_tracker.wait_for_ops(ctx);
-      });
-    if (m_local_replay != nullptr) {
-      ctx = new FunctionContext([this, ctx](int r) {
-          m_local_replay->shut_down(true, ctx);
-        });
-    }
-  }
-  if (m_replay_handler != nullptr) {
-    ctx = new FunctionContext([this, ctx](int r) {
-        delete m_replay_handler;
-        m_replay_handler = nullptr;
         ctx->complete(0);
       });
+  }
+
+  // wait for all local in-flight replay events to complete
+  ctx = new FunctionContext([this, ctx](int r) {
+      if (r < 0) {
+        derr << "error shutting down journal replay: " << cpp_strerror(r)
+             << dendl;
+      }
+
+      m_event_replay_tracker.wait_for_ops(ctx);
+    });
+
+  // flush any local in-flight replay events
+  if (m_local_replay != nullptr) {
     ctx = new FunctionContext([this, ctx](int r) {
-        m_remote_journaler->stop_replay(ctx);
+        m_local_replay->shut_down(true, ctx);
       });
   }
+
   m_threads->work_queue->queue(ctx, 0);
 }
 

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -1168,9 +1168,14 @@ void ImageReplayer<I>::handle_preprocess_entry_safe(int r) {
   dout(20) << "r=" << r << dendl;
 
   if (r < 0) {
-    derr << "failed to preprocess journal event" << dendl;
     m_event_replay_tracker.finish_op();
-    handle_replay_complete(r, "failed to preprocess journal event");
+
+    if (r == -ECANCELED) {
+      handle_replay_complete(0, "lost exclusive lock");
+    } else {
+      derr << "failed to preprocess journal event" << dendl;
+      handle_replay_complete(r, "failed to preprocess journal event");
+    }
     return;
   }
 

--- a/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/ImageCopyRequest.cc
@@ -7,6 +7,7 @@
 #include "common/errno.h"
 #include "common/Timer.h"
 #include "journal/Journaler.h"
+#include "librbd/ExclusiveLock.h"
 #include "librbd/Utils.h"
 #include "tools/rbd_mirror/ProgressContext.h"
 
@@ -141,6 +142,7 @@ void ImageCopyRequest<I>::send_object_copies() {
 
   bool complete;
   {
+    RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
     Mutex::Locker locker(m_lock);
     for (int i = 0; i < cct->_conf->rbd_concurrent_management_ops; ++i) {
       send_next_object_copy();
@@ -172,6 +174,7 @@ void ImageCopyRequest<I>::send_object_copies() {
 
 template <typename I>
 void ImageCopyRequest<I>::send_next_object_copy() {
+  assert(m_local_image_ctx->owner_lock.is_locked());
   assert(m_lock.is_locked());
 
   if (m_canceled && m_ret_val == 0) {
@@ -189,8 +192,20 @@ void ImageCopyRequest<I>::send_next_object_copy() {
 
   ++m_current_ops;
 
-  Context *ctx = create_context_callback<
-    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_object_copy>(this);
+  Context *finish_op_ctx = nullptr;
+  if (m_local_image_ctx->exclusive_lock != nullptr) {
+    finish_op_ctx = m_local_image_ctx->exclusive_lock->start_op();
+  }
+  if (finish_op_ctx == nullptr) {
+    derr << ": lost exclusive lock" << dendl;
+    finish(-EROFS);
+    return;
+  }
+
+  auto ctx = new FunctionContext([this, finish_op_ctx](int r) {
+      handle_object_copy(r);
+      finish_op_ctx->complete(0);
+    });
   ObjectCopyRequest<I> *req = ObjectCopyRequest<I>::create(
     m_local_image_ctx, m_remote_image_ctx, &m_snap_map, ono, ctx);
   req->send();
@@ -203,6 +218,7 @@ void ImageCopyRequest<I>::handle_object_copy(int r) {
   int percent;
   bool complete;
   {
+    RWLock::RLocker owner_locker(m_local_image_ctx->owner_lock);
     Mutex::Locker locker(m_lock);
     assert(m_current_ops > 0);
     --m_current_ops;

--- a/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCopyRequest.h
@@ -134,6 +134,8 @@ private:
 
   int validate_parent(ImageCtxT *image_ctx, librbd::ParentSpec *spec);
 
+  Context *start_local_op();
+
 };
 
 } // namespace image_sync

--- a/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.h
@@ -94,6 +94,8 @@ private:
   void send_create_object_map();
   void handle_create_object_map(int r);
 
+  Context *start_local_op();
+
   void finish(int r);
 };
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/18963
Signed-off-by: Jason Dillaman <dillaman@redhat.com>