### PR TITLE
execute objectstore->queue_transaction() out side of PG worker thread

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -753,7 +753,8 @@ OPTION(osd_op_num_threads_per_shard, OPT_INT, 2)
 OPTION(osd_op_num_shards, OPT_INT, 5)
 OPTION(osd_op_queue, OPT_STR, "wpq") // PrioritzedQueue (prio), Weighted Priority Queue (wpq), or debug_random
 OPTION(osd_op_queue_cut_off, OPT_STR, "low") // Min priority to go to strict queue. (low, high, debug_random)
-
+OPTION(osd_async_queue_transaction, OPT_BOOL, false)
+OPTION(osd_async_queue_transaction_worker, OPT_INT, 0)
 OPTION(osd_ignore_stale_divergent_priors, OPT_BOOL, false) // do not assert on divergent_prior entries which aren't in the log and whose on-disk objects are newer
 
 // Set to true for testing.  Users should NOT set this.


### PR DESCRIPTION
1. create a new thread pool inside objectstore layer, let this thread pool execute queue_transaction.
2. PG worker thread only insert objectstore layer's transaction requests into the thread pool's queues and then return and release pg_lock.
3. the new thread pool "transaction worker" shared a common data structure implemented in objectstore.h while keep a virtual thread_fun() implementation inheritable by the specific objectstore instance.
4. the pull request demonstrated a way of implementing the thread_fun() in bluestore. The "transaction worker" is responsible to submit data aio and rocksdb metadata sync request individually. ksync thread is only used to pull completed request into finisher queue. 

performance gains on seq-write is shown bellow.
 
![async-transaction-worker-perf](https://cloud.githubusercontent.com/assets/1810505/26181488/43d9df82-3b25-11e7-9f93-53d58b676ab4.png)
