### PR TITLE
build: move bash_completion.d/ceph to ceph-common

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -951,7 +951,6 @@ rm -rf %{buildroot}
 %{_libdir}/libos_tp.so*
 %{_libdir}/libosd_tp.so*
 %endif
-%config %{_sysconfdir}/bash_completion.d/ceph
 %config(noreplace) %{_sysconfdir}/logrotate.d/ceph
 %if 0%{?fedora} || 0%{?rhel}
 %config(noreplace) %{_sysconfdir}/sysconfig/ceph
@@ -1059,6 +1058,7 @@ DISABLE_RESTART_ON_UPDATE="yes"
 %{_datadir}/ceph/id_rsa_drop.ceph.com
 %{_datadir}/ceph/id_rsa_drop.ceph.com.pub
 %dir %{_sysconfdir}/ceph/
+%config %{_sysconfdir}/bash_completion.d/ceph
 %config %{_sysconfdir}/bash_completion.d/rados
 %config %{_sysconfdir}/bash_completion.d/rbd
 %config %{_sysconfdir}/bash_completion.d/radosgw-admin

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -1,4 +1,3 @@
-etc/bash_completion.d/ceph
 etc/init.d/ceph
 usr/sbin/ceph-create-keys
 usr/bin/ceph-detect-init

--- a/debian/ceph-common.install
+++ b/debian/ceph-common.install
@@ -1,5 +1,6 @@
 #! /usr/bin/dh-exec --with=install
 
+etc/bash_completion.d/ceph
 etc/bash_completion.d/rados
 etc/bash_completion.d/radosgw-admin
 etc/bash_completion.d/rbd


### PR DESCRIPTION
When only ceph-common is installed, can also use ceph completion

Signed-off-by: Leo Zhang <nguzcf@gmail.com>