### PR TITLE
rgw_file: remove extra rele() on fs in rgw_umount()

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1419,7 +1419,6 @@ int rgw_umount(struct rgw_fs *rgw_fs, uint32_t flags)
 {
   RGWLibFS *fs = static_cast<RGWLibFS*>(rgw_fs->fs_private);
   fs->close();
-  fs->rele();
   return 0;
 }
 


### PR DESCRIPTION
We got exactly a refcnt=0 after rele in close,
no need to rele twice.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>