### PR TITLE
rgw: optimize generating torrent file. Object data won't stay in memory  now.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3044,8 +3044,8 @@ void RGWPutObj::execute()
       hash.Update((const byte *)data.c_str(), data.length());
     }
 
-    /* save data for producing torrent data */
-    torrent.save_data(data_in);
+    /* update torrrent */
+    torrent.update(data_in);
 
     /* do we need this operation to be synchronous? if we're dealing with an object with immutable
      * head, e.g., multipart object we need to make sure we're the first one writing to this object
@@ -3236,7 +3236,7 @@ void RGWPutObj::execute()
   {
     torrent.init(s, store);
     torrent.set_create_date(mtime);
-    op_ret =  torrent.handle_data();
+    op_ret =  torrent.complete();
     if (0 != op_ret)
     {
       ldout(s->cct, 0) << "ERROR: torrent.handle_data() returned " << op_ret << dendl;

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -104,10 +104,10 @@ private:
   uint64_t sha_len;  // sha1 length
   bool is_torrent;  // flag
   bufferlist bl;  // bufflist ready to send
-  list<bufferlist> torrent_bl;   // meate data
 
   struct req_state *s;
   RGWRados *store;
+  SHA1 h;
 
   TorrentBencode dencode;
 public:
@@ -122,17 +122,16 @@ public:
   off_t get_data_len();
   bool get_flag();
 
-  int handle_data();
-  void save_data(bufferlist &bl);
   void set_create_date(ceph::real_time& value);
-  void set_info_name(const string& value); 
+  void set_info_name(const string& value);
+  void update(bufferlist &bl);
+  int complete();
 
 private:
   void do_encode ();
   void set_announce();
   void set_exist(bool exist);
   void set_info_pieces(char *buff);
-  int sha1_process();
   void sha1(SHA1 *h, bufferlist &bl, off_t bl_len);
   int save_torrent_file();
 };


### PR DESCRIPTION
Change the way to create the torrent like generating md5. Object data won't stay in memory and this is useful if object's size is large.
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>