### PR TITLE
os/bluestore: separate kv_sync_thread into two parts

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8221,7 +8221,8 @@ void BlueStore::_kv_finalize_thread()
 	}
 	delete b;
       }
-
+      deferred_stable.clear();
+      
       if (!deferred_aggressive) {
 	std::lock_guard<std::mutex> l(deferred_lock);
 	if (deferred_queue_size >= deferred_batch_ops ||

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3281,6 +3281,7 @@ BlueStore::BlueStore(CephContext *cct, const string& path)
 		       cct->_conf->bluestore_throttle_bytes +
 		       cct->_conf->bluestore_throttle_deferred_bytes),
     kv_sync_thread(this),
+    kv_finalize_thread(this),
     mempool_thread(this)
 {
   _init_logger();
@@ -3309,6 +3310,7 @@ BlueStore::BlueStore(CephContext *cct,
 		       cct->_conf->bluestore_throttle_bytes +
 		       cct->_conf->bluestore_throttle_deferred_bytes),
     kv_sync_thread(this),
+    kv_finalize_thread(this),
     min_alloc_size(_min_alloc_size),
     min_alloc_size_order(ctz(_min_alloc_size)),
     mempool_thread(this)
@@ -5012,6 +5014,7 @@ int BlueStore::_mount(bool kv_only)
     f->start();
   }
   kv_sync_thread.create("bstore_kv_sync");
+  kv_finalize_thread.create("bstore_kv_final");
 
   r = _deferred_replay();
   if (r < 0)
@@ -7752,20 +7755,19 @@ void BlueStore::_txc_committed_kv(TransContext *txc)
     txc->onreadable_sync->complete(0);
     txc->onreadable_sync = NULL;
   }
-  unsigned n = txc->osr->parent->shard_hint.hash_to_shard(m_finisher_num);
   if (txc->oncommit) {
     logger->tinc(l_bluestore_commit_lat, ceph_clock_now() - txc->start);
-    finishers[n]->queue(txc->oncommit);
+    txc->oncommit->complete(0);
     txc->oncommit = NULL;
   }
   if (txc->onreadable) {
-    finishers[n]->queue(txc->onreadable);
+    txc->onreadable->complete(0);
     txc->onreadable = NULL;
   }
-
-  if (!txc->oncommits.empty()) {
-    finishers[n]->queue(txc->oncommits);
+  for (auto c : txc->oncommits) {
+    c->complete(0);
   }
+  txc->oncommits.clear();
 }
 
 void BlueStore::_txc_finish(TransContext *txc)
@@ -7900,6 +7902,10 @@ void BlueStore::_osr_drain_all()
     // wake up any previously finished deferred events
     std::lock_guard<std::mutex> l(kv_lock);
     kv_cond.notify_one();
+  }
+  {
+    std::lock_guard<std::mutex> l(kv_finalize_lock);
+    kv_finalize_cond.notify_one();
   }
   for (auto osr : s) {
     dout(20) << __func__ << " drain " << osr << dendl;
@@ -8128,11 +8134,83 @@ void BlueStore::_kv_sync_thread()
 	logger->tinc(l_bluestore_kv_commit_lat, dur_kv);
 	logger->tinc(l_bluestore_kv_lat, dur);
       }
-      while (!kv_committing.empty()) {
-	TransContext *txc = kv_committing.front();
+
+      if (bluefs) {
+       if (!bluefs_gift_extents.empty()) {
+         _commit_bluefs_freespace(bluefs_gift_extents);
+       }
+       for (auto p = bluefs_extents_reclaiming.begin();
+            p != bluefs_extents_reclaiming.end();
+            ++p) {
+         dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
+                  << p.get_start() << "~" << p.get_len() << std::dec
+                  << dendl;
+         alloc->release(p.get_start(), p.get_len());
+       }
+       bluefs_extents_reclaiming.clear();
+      }
+
+      {
+       std::unique_lock<std::mutex> m(kv_finalize_lock);
+       if (kv_committing_to_finalize.empty()) {
+         kv_committing_to_finalize.swap(kv_committing);
+       } else {
+         kv_committing_to_finalize.insert(
+           kv_committing_to_finalize.end(),
+           kv_committing.begin(),
+           kv_committing.end());
+         kv_committing.clear();
+       }
+       if (deferred_stable_to_finalize.empty()) {
+         deferred_stable_to_finalize.swap(deferred_stable);
+       } else {
+         deferred_stable_to_finalize.insert(
+           deferred_stable_to_finalize.end(),
+           deferred_stable.begin(),
+           deferred_stable.end());
+          deferred_stable.clear();
+       }
+       kv_finalize_cond.notify_one();
+      }
+
+      l.lock();
+      // previously deferred "done" are now "stable" by virtue of this
+      // commit cycle.
+      deferred_stable_queue.swap(deferred_done);
+   }
+  }
+  dout(10) << __func__ << " finish" << dendl;
+}
+
+void BlueStore::_kv_finalize_thread()
+{
+  deque<DeferredBatch*> deferred_stable;
+  deque<TransContext*> kv_committed;
+  dout(10) << __func__ << " start" << dendl;
+  std::unique_lock<std::mutex> l(kv_finalize_lock);
+  while (true) {
+    assert(kv_committed.empty());
+    assert(deferred_stable.empty());
+    if (kv_committing_to_finalize.empty() &&
+       deferred_stable_to_finalize.empty()) {
+      if (kv_stop)
+       break;
+      dout(20) << __func__ << " sleep" << dendl;
+      kv_finalize_cond.wait(l);
+      dout(20) << __func__ << " wake" << dendl;
+    } else {
+      kv_committed.swap(kv_committing_to_finalize);
+      deferred_stable.swap(deferred_stable_to_finalize);
+      kv_finalize_cond.notify_one();
+      l.unlock();
+      dout(20) << __func__ << " kv_committed " << kv_committed << dendl;
+      dout(20) << __func__ << " deferred_stable " << deferred_stable << dendl;
+
+      while (!kv_committed.empty()) {
+        TransContext *txc = kv_committed.front();
 	assert(txc->state == TransContext::STATE_KV_SUBMITTED);
 	_txc_state_proc(txc);
-	kv_committing.pop_front();
+	kv_committed.pop_front();
       }
       for (auto b : deferred_stable) {
 	auto p = b->txcs.begin();
@@ -8155,25 +8233,7 @@ void BlueStore::_kv_sync_thread()
       // this is as good a place as any ...
       _reap_collections();
 
-      if (bluefs) {
-	if (!bluefs_gift_extents.empty()) {
-	  _commit_bluefs_freespace(bluefs_gift_extents);
-	}
-	for (auto p = bluefs_extents_reclaiming.begin();
-	     p != bluefs_extents_reclaiming.end();
-	     ++p) {
-	  dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
-		   << p.get_start() << "~" << p.get_len() << std::dec
-		   << dendl;
-	  alloc->release(p.get_start(), p.get_len());
-	}
-	bluefs_extents_reclaiming.clear();
-      }
-
       l.lock();
-      // previously deferred "done" are now "stable" by virtue of this
-      // commit cycle.
-      deferred_stable_queue.swap(deferred_done);
     }
   }
   dout(10) << __func__ << " finish" << dendl;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -106,6 +106,8 @@ bluestore=0
 rgw_frontend="civetweb"
 lockdep=${LOCKDEP:-1}
 
+filestore_path=
+
 VSTART_SEC="client.vstart.sh"
 
 MON_ADDR=""
@@ -249,6 +251,10 @@ case $1 in
             rgw_frontend=$2
             shift
             ;;
+    --filestore_path )
+	filestore_path=$2
+	shift
+	;;
     -m )
 	    [ -z "$2" ] && usage_exit
 	    MON_ADDR=$2
@@ -575,7 +581,11 @@ EOF
             if command -v btrfs > /dev/null; then
                 for f in $CEPH_DEV_DIR/osd$osd/*; do btrfs sub delete $f &> /dev/null || true; done
             fi
-            mkdir -p $CEPH_DEV_DIR/osd$osd
+	    if [ -n "$filestore_path" ]; then
+		ln -s $filestore_path $CEPH_DEV_DIR/osd$osd
+	    else
+		mkdir -p $CEPH_DEV_DIR/osd$osd
+	    fi
 
             local uuid=`uuidgen`
             echo "add osd$osd $uuid"


### PR DESCRIPTION
This is #14035 with the inline completions in kv_finisher_thread and removal of the sharded finishers commits removed.  Slight modifications were made to work with the new deferred writes code.  Additionally a single new commit was added to clear the deferred_stable deque after deleting all of the elements (this was causing an assert during testing).

With these changes, performance appears to be somewhat lower than #14035 but higher than master.  Several other commits have occurred in the interim so the comparison isn't exactly apples to apples.  I should be able to run a further wallclock trace tomorrow.