### PR TITLE
rgw: some cleanup and fixes for librgw_file unittest

### DIFF
--- a/src/test/librgw_file.cc
+++ b/src/test/librgw_file.cc
@@ -28,7 +28,7 @@
 
 namespace {
   librgw_t rgw = nullptr;
-  string uid("testuser");
+  string userid("testuser");
   string access_key("");
   string secret_key("");
   struct rgw_fs *fs = nullptr;
@@ -53,7 +53,7 @@ TEST(LibRGW, INIT) {
 }
 
 TEST(LibRGW, MOUNT) {
-  int ret = rgw_mount2(rgw, uid.c_str(), access_key.c_str(), secret_key.c_str(),
+  int ret = rgw_mount2(rgw, userid.c_str(), access_key.c_str(), secret_key.c_str(),
                        "/", &fs, RGW_MOUNT_FLAG_NONE);
   ASSERT_EQ(ret, 0);
   ASSERT_NE(fs, nullptr);
@@ -264,9 +264,9 @@ int main(int argc, char *argv[])
     } else if (ceph_argparse_witharg(args, arg_iter, &val, "--secret",
 				     (char*) nullptr)) {
       secret_key = val;
-    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--uid",
+    } else if (ceph_argparse_witharg(args, arg_iter, &val, "--userid",
 				     (char*) nullptr)) {
-      uid = val;
+      userid = val;
     } else if (ceph_argparse_flag(args, arg_iter, "--getattr",
 					    (char*) nullptr)) {
       do_getattr = true;

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -331,6 +331,11 @@ TEST(LibRGW, DELETE_OBJECT) {
     int ret = rgw_unlink(fs, bucket_fh, object_name.c_str(),
 			 RGW_UNLINK_FLAG_NONE);
     ASSERT_EQ(ret, 0);
+    if (do_create) {
+      // delete test bucket that is empty
+      ret = rgw_unlink(fs, fs->root_fh, bucket_name.c_str(), RGW_UNLINK_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+    }
   }
 }
 

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -328,9 +328,12 @@ TEST(LibRGW, STAT_OBJECT) {
 
 TEST(LibRGW, DELETE_OBJECT) {
   if (do_delete) {
-    int ret = rgw_unlink(fs, bucket_fh, object_name.c_str(),
-			 RGW_UNLINK_FLAG_NONE);
-    ASSERT_EQ(ret, 0);
+    int ret;
+    if (do_large) {
+      ret = rgw_unlink(fs, bucket_fh, object_name.c_str(),
+                       RGW_UNLINK_FLAG_NONE);
+      ASSERT_EQ(ret, 0);
+    }
     if (do_create) {
       // delete test bucket that is empty
       ret = rgw_unlink(fs, fs->root_fh, bucket_name.c_str(), RGW_UNLINK_FLAG_NONE);

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -937,7 +937,7 @@ TEST(LibRGW, HIER1) {
 	  << " elt.name=" << elt.name
 	  << dendl;
 	rc = rgw_lookup(fs, parent_fh, elt.name.c_str(), &elt.fh,
-			RGW_LOOKUP_FLAG_NONE);
+			RGW_LOOKUP_FLAG_RCB);
 	ASSERT_EQ(rc, 0);
 	// XXXX
 	RGWFileHandle* efh = get_rgwfh(elt.fh);

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -610,19 +610,15 @@ TEST(LibRGW, BAD_DELETES_DIRS1) {
       rc = rgw_unlink(fs, dirs1_b.parent_fh, dirs1_b.name.c_str(),
 		      RGW_UNLINK_FLAG_NONE);
       ASSERT_NE(rc, 0);
+      /* try to unlink a non-empty directory (non-bucket) */
+      obj_rec& dir_0 = get<0>(dirs_vec[0]);
+
+      ASSERT_EQ(dir_0.name, "dir_0");
+      ASSERT_TRUE(dir_0.rgw_fh->is_dir());
+      rc = rgw_unlink(fs, dir_0.parent_fh, dir_0.name.c_str(),
+		      RGW_UNLINK_FLAG_NONE);
+      ASSERT_NE(rc, 0);
     }
-    /* try to unlink a non-empty directory (non-bucket) */
-    obj_rec& sdir_0 = get<1>(dirs_vec[0])[0];
-    ASSERT_EQ(sdir_0.name, "sdir_0");
-    ASSERT_TRUE(sdir_0.rgw_fh->is_dir());
-    /* XXX we can't enforce this currently */
-#if 0
-    ASSERT_EQ(sdir_0.name, "sdir_0");
-    ASSERT_TRUE(sdir_0.rgw_fh->is_dir());
-    rc = rgw_unlink(fs, sdir_0.parent_fh, sdir_0.name.c_str(),
-		    RGW_UNLINK_FLAG_NONE);
-    ASSERT_NE(rc, 0);
-#endif
   }
 }
 


### PR DESCRIPTION
Try to do cleanup works when --do_create && --do_delete specified in order to make it possible to run multiple-times continuously.