### PR TITLE
crypto: add openssl support for RGW encryption

### DIFF
--- a/src/crypto/CMakeLists.txt
+++ b/src/crypto/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_custom_target(crypto_plugins)
 set(crypto_plugin_dir ${CMAKE_INSTALL_PKGLIBDIR}/crypto)
 
+add_subdirectory(openssl)
+
 if(HAVE_INTEL AND HAVE_BETTER_YASM_ELF64 AND (NOT APPLE))
   add_subdirectory(isa-l)
 endif()

--- a/src/crypto/openssl/CMakeLists.txt
+++ b/src/crypto/openssl/CMakeLists.txt
@@ -1,0 +1,10 @@
+## openssl
+
+set(openssl_crypto_plugin_srcs
+  openssl_crypto_accel.cc
+  openssl_crypto_plugin.cc)
+
+add_library(ceph_crypto_openssl SHARED ${openssl_crypto_plugin_srcs})
+target_link_libraries(ceph_crypto_openssl PRIVATE crypto)
+add_dependencies(crypto_plugins ceph_crypto_openssl)
+install(TARGETS ceph_crypto_openssl DESTINATION ${crypto_plugin_dir})

--- a/src/crypto/openssl/openssl_crypto_accel.cc
+++ b/src/crypto/openssl/openssl_crypto_accel.cc
@@ -1,0 +1,49 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Intel Corporation
+ *
+ * Author: Qiaowei Ren <qiaowei.ren@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#include "crypto/openssl/openssl_crypto_accel.h"
+#include <openssl/aes.h>
+
+bool OpenSSLCryptoAccel::cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
+                             const unsigned char (&iv)[AES_256_IVSIZE],
+                             const unsigned char (&key)[AES_256_KEYSIZE])
+{
+  if ((size % AES_256_IVSIZE) != 0) {
+    return false;
+  }
+
+  AES_KEY aes_key;
+  if (AES_set_encrypt_key(const_cast<unsigned char*>(&key[0]), 256, &aes_key) < 0)
+    return false;
+
+  AES_cbc_encrypt(const_cast<unsigned char*>(in), out, size, &aes_key,
+                  const_cast<unsigned char*>(&iv[0]), AES_ENCRYPT);
+  return true;
+}
+bool OpenSSLCryptoAccel::cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
+                             const unsigned char (&iv)[AES_256_IVSIZE],
+                             const unsigned char (&key)[AES_256_KEYSIZE])
+{
+  if ((size % AES_256_IVSIZE) != 0) {
+    return false;
+  }
+
+  AES_KEY aes_key;
+  if (AES_set_decrypt_key(const_cast<unsigned char*>(&key[0]), 256, &aes_key) < 0)
+    return false;
+
+  AES_cbc_encrypt(const_cast<unsigned char*>(in), out, size, &aes_key,
+                  const_cast<unsigned char*>(&iv[0]), AES_DECRYPT);
+  return true;
+}

--- a/src/crypto/openssl/openssl_crypto_accel.h
+++ b/src/crypto/openssl/openssl_crypto_accel.h
@@ -1,0 +1,32 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Intel Corporation
+ *
+ * Author: Qiaowei Ren <qiaowei.ren@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef OPENSSL_CRYPTO_ACCEL_H
+#define OPENSSL_CRYPTO_ACCEL_H
+
+#include "crypto/crypto_accel.h"
+
+class OpenSSLCryptoAccel : public CryptoAccel {
+ public:
+  OpenSSLCryptoAccel() {}
+  virtual ~OpenSSLCryptoAccel() {}
+
+  bool cbc_encrypt(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char (&iv)[AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override;
+  bool cbc_decrypt(unsigned char* out, const unsigned char* in, size_t size,
+                   const unsigned char (&iv)[AES_256_IVSIZE],
+                   const unsigned char (&key)[AES_256_KEYSIZE]) override;
+};
+#endif

--- a/src/crypto/openssl/openssl_crypto_plugin.cc
+++ b/src/crypto/openssl/openssl_crypto_plugin.cc
@@ -1,0 +1,32 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Intel Corporation
+ *
+ * Author: Qiaowei Ren <qiaowei.ren@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+
+#include "crypto/openssl/openssl_crypto_plugin.h"
+
+#include "ceph_ver.h"
+
+const char *__ceph_plugin_version()
+{
+  return CEPH_GIT_NICE_VER;
+}
+
+int __ceph_plugin_init(CephContext *cct,
+                       const std::string& type,
+                       const std::string& name)
+{
+  PluginRegistry *instance = cct->get_plugin_registry();
+
+  return instance->add(type, name, new OpenSSLCryptoPlugin(cct));
+}

--- a/src/crypto/openssl/openssl_crypto_plugin.h
+++ b/src/crypto/openssl/openssl_crypto_plugin.h
@@ -1,0 +1,36 @@
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Intel Corporation
+ *
+ * Author: Qiaowei Ren <qiaowei.ren@intel.com>
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ */
+
+#ifndef ISAL_CRYPTO_PLUGIN_H
+#define ISAL_CRYPTO_PLUGIN_H
+
+#include "crypto/crypto_plugin.h"
+#include "crypto/openssl/openssl_crypto_accel.h"
+
+
+class OpenSSLCryptoPlugin : public CryptoPlugin {
+
+  CryptoAccelRef cryptoaccel;
+public:
+  explicit OpenSSLCryptoPlugin(CephContext* cct) : CryptoPlugin(cct)
+  {}
+  int factory(CryptoAccelRef *cs, ostream *ss) override {
+    if (cryptoaccel == nullptr)
+      cryptoaccel = CryptoAccelRef(new OpenSSLCryptoAccel);
+
+    *cs = cryptoaccel;
+    return 0;
+  }
+};
+#endif


### PR DESCRIPTION
The commit (https://github.com/ceph/ceph/pull/11049/files) adds the
support for encryption into RGW and a plugin framework for crypto.
Based on this framework, This patch adds new OpenSSL plugin to
support OpenSSL for RGW encryption.

With the support for OpenSSL, Intel QAT (QuickAssist Integrated
Acceleration) can be used to accelerate the encryption. QAT allows
compute-intensive workloads, including data compression and encryption,
to be offloaded from the CPU to hardware accelerators, which are more
efficient in terms of cost and power than general purpose CPUs for
these specific workloads.

OpenSSL 1.1.0 (and beyond) now has async support for QAT hardware
accelerators through QAT engine (https://github.com/01org/QAT_Engine).
To use QAT hardware accelerators, we only need to configure this
QAT engine based on OpenSSL. If no this engine, this patch will
only use general OpenSSL crypto feature.

Signed-off-by: Qiaowei Ren <qiaowei.ren@intel.com>