### PR TITLE
mon/MgrMap: print mgr epoch in cluster status

### DIFF
--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -125,6 +125,7 @@ public:
     if (f) {
       dump(f);
     } else {
+      *ss << "e" << get_epoch() << ": ";
       if (get_active_gid() != 0) {
 	*ss << "active: " << get_active_name();
         if (!available) {


### PR DESCRIPTION
Other services print epoch in cluster status.

Within this change, `ceph -s` will print mgr info like this:
```
mgr e35: active: c167
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>