### PR TITLE
test/crush: silence warnings from -Walloc-size-larger-than= and -Wstringop-overflow=

### DIFF
--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1054,8 +1054,10 @@ TEST(CrushWrapper, choose_args_compat) {
   crush_weight_set weight_set;
   weight_set.size = 1;
   weight_set.weights = &weights;
-  crush_choose_arg choose_args[c.get_max_buckets()];
-  memset(choose_args, '\0', sizeof(crush_choose_arg) * c.get_max_buckets());
+  int maxbuckets = c.get_max_buckets();
+  assert(maxbuckets > 0);
+  crush_choose_arg choose_args[maxbuckets];
+  memset(choose_args, '\0', sizeof(crush_choose_arg) * maxbuckets);
   choose_args[-1-id].ids_size = 0;
   choose_args[-1-id].weight_set_size = 1;
   choose_args[-1-id].weight_set = &weight_set;


### PR DESCRIPTION
The following warnings appear during make:
```
/home/jcollin/workspace/ceph/src/test/crush/CrushWrapper.cc: In member function ‘virtual void CrushWrapper_choose_args_compat_Test::TestBody()’:
/home/jcollin/workspace/ceph/src/test/crush/CrushWrapper.cc:1057:20: warning: argument 1 value ‘18446744073709550912’ exceeds maximum object size 9223372036854775807 [-Walloc-size-larger-than=]
   crush_choose_arg choose_args[c.get_max_buckets()];
                    ^~~~~~~~~~~

In function ‘void* memset(void*, int, size_t)’,
    inlined from ‘virtual void CrushWrapper_choose_args_compat_Test::TestBody()’ at /home/jcollin/workspace/ceph/src/test/crush/CrushWrapper.cc:1058:9:
/usr/include/bits/string3.h:90:70: warning: ‘void* __builtin_memset(void*, int, long unsigned int)’: specified size 18446744073709550912 exceeds maximum object size 9223372036854775807 [-Wstringop-overflow=]
   return __builtin___memset_chk (__dest, __ch, __len, __bos0 (__dest));
```
Signed-off-by: Jos Collin <jcollin@redhat.com>