### PR TITLE
mgr,osd:  ceph-mgr --help, unify usage text of other daemons

### DIFF
--- a/src/ceph_mds.cc
+++ b/src/ceph_mds.cc
@@ -53,7 +53,7 @@ using namespace std;
 
 static void usage()
 {
-  cout << "usage: ceph-mds -i name [flags] [[--hot-standby][rank]]\n"
+  cout << "usage: ceph-mds -i <ID> [flags] [[--hot-standby][rank]]\n"
        << "  -m monitorip:port\n"
        << "        connect to monitor at given address\n"
        << "  --debug_mds n\n"

--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -24,6 +24,12 @@
 
 #include "mgr/MgrStandby.h"
 
+static void usage()
+{
+  cout << "usage: ceph-mgr -i <ID> [flags]\n"
+       << std::endl;
+  generic_server_usage();
+}
 
 /**
  * A short main() which just instantiates a MgrStandby and
@@ -43,9 +49,7 @@ int main(int argc, const char **argv)
 
   // Handle --help
   if ((args.size() == 1 && (std::string(args[0]) == "--help" || std::string(args[0]) == "-h"))) {
-    MgrStandby mgr;
-    mgr.usage();
-    return 0;
+    usage();
   }
 
   global_init_daemonize(g_ceph_context);

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -158,25 +158,26 @@ int check_mon_data_empty()
 
 static void usage()
 {
-  cerr << "usage: ceph-mon -i monid [flags]" << std::endl;
-  cerr << "  --debug_mon n\n";
-  cerr << "        debug monitor level (e.g. 10)\n";
-  cerr << "  --mkfs\n";
-  cerr << "        build fresh monitor fs\n";
-  cerr << "  --force-sync\n";
-  cerr << "        force a sync from another mon by wiping local data (BE CAREFUL)\n";
-  cerr << "  --yes-i-really-mean-it\n";
-  cerr << "        mandatory safeguard for --force-sync\n";
-  cerr << "  --compact\n";
-  cerr << "        compact the monitor store\n";
-  cerr << "  --osdmap <filename>\n";
-  cerr << "        only used when --mkfs is provided: load the osdmap from <filename>\n";
-  cerr << "  --inject-monmap <filename>\n";
-  cerr << "        write the <filename> monmap to the local monitor store and exit\n";
-  cerr << "  --extract-monmap <filename>\n";
-  cerr << "        extract the monmap from the local monitor store and exit\n";
-  cerr << "  --mon-data <directory>\n";
-  cerr << "        where the mon store and keyring are located\n";
+  cout << "usage: ceph-mon -i <ID> [flags]\n"
+       << "  --debug_mon n\n"
+       << "        debug monitor level (e.g. 10)\n"
+       << "  --mkfs\n"
+       << "        build fresh monitor fs\n"
+       << "  --force-sync\n"
+       << "        force a sync from another mon by wiping local data (BE CAREFUL)\n"
+       << "  --yes-i-really-mean-it\n"
+       << "        mandatory safeguard for --force-sync\n"
+       << "  --compact\n"
+       << "        compact the monitor store\n"
+       << "  --osdmap <filename>\n"
+       << "        only used when --mkfs is provided: load the osdmap from <filename>\n"
+       << "  --inject-monmap <filename>\n"
+       << "        write the <filename> monmap to the local monitor store and exit\n"
+       << "  --extract-monmap <filename>\n"
+       << "        extract the monmap from the local monitor store and exit\n"
+       << "  --mon-data <directory>\n"
+       << "        where the mon store and keyring are located\n"
+       << std::endl;
   generic_server_usage();
 }
 

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -69,7 +69,7 @@ void handle_osd_signal(int signum)
 
 static void usage()
 {
-  cout << "usage: ceph-osd -i <osdid>\n"
+  cout << "usage: ceph-osd -i <ID> [flags]\n"
        << "  --osd-data PATH data directory\n"
        << "  --osd-journal PATH\n"
        << "                    journal file or block device\n"

--- a/src/mgr/MgrStandby.h
+++ b/src/mgr/MgrStandby.h
@@ -73,7 +73,6 @@ public:
 
   int init();
   void shutdown();
-  void usage() {}
   int main(vector<const char *> args);
   void handle_signal(int signum);
   void send_beacon();


### PR DESCRIPTION
`ceph-mgr --help` did nothing before, now it prints something useful.  I've also cleaned up the usage text of ceph-mon, ceph-mds and ceph-osd slightly to make everything more consistent.