### PR TITLE
osd: Do not subtract object overlaps from cache usage

### DIFF
--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1101,6 +1101,7 @@ protected:
 				   interval_set<uint64_t>& modified, uint64_t offset,
 				   uint64_t length, bool write_full=false);
   void add_interval_usage(interval_set<uint64_t>& s, object_stat_sum_t& st);
+  void sub_interval_usage(interval_set<uint64_t>& s, object_stat_sum_t& st);
 
 
   enum class cache_result_t {

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1850,6 +1850,7 @@ ostream& operator<<(ostream& out, const pg_pool_t& p)
 void object_stat_sum_t::dump(Formatter *f) const
 {
   f->dump_int("num_bytes", num_bytes);
+  f->dump_int("num_bytes_overlap", num_bytes_overlap);
   f->dump_int("num_objects", num_objects);
   f->dump_int("num_object_clones", num_object_clones);
   f->dump_int("num_object_copies", num_object_copies);
@@ -1888,11 +1889,12 @@ void object_stat_sum_t::dump(Formatter *f) const
 
 void object_stat_sum_t::encode(bufferlist& bl) const
 {
-  ENCODE_START(16, 14, bl);
+  ENCODE_START(17, 14, bl);
 #if defined(CEPH_LITTLE_ENDIAN)
   bl.append((char *)(&num_bytes), sizeof(object_stat_sum_t));
 #else
   ::encode(num_bytes, bl);
+  ::encode(num_bytes_overlap, bl);
   ::encode(num_objects, bl);
   ::encode(num_object_clones, bl);
   ::encode(num_object_copies, bl);
@@ -1943,6 +1945,8 @@ void object_stat_sum_t::decode(bufferlist::iterator& bl)
 #endif
   if (!decode_finish) {
     ::decode(num_bytes, bl);
+    if (struct_v >= 17)
+      ::decode(num_bytes_overlap, bl);
     ::decode(num_objects, bl);
     ::decode(num_object_clones, bl);
     ::decode(num_object_copies, bl);
@@ -2026,6 +2030,7 @@ void object_stat_sum_t::generate_test_instances(list<object_stat_sum_t*>& o)
 void object_stat_sum_t::add(const object_stat_sum_t& o)
 {
   num_bytes += o.num_bytes;
+  num_bytes_overlap += o.num_bytes_overlap;
   num_objects += o.num_objects;
   num_object_clones += o.num_object_clones;
   num_object_copies += o.num_object_copies;
@@ -2065,6 +2070,7 @@ void object_stat_sum_t::add(const object_stat_sum_t& o)
 void object_stat_sum_t::sub(const object_stat_sum_t& o)
 {
   num_bytes -= o.num_bytes;
+  num_bytes_overlap -= o.num_bytes_overlap;
   num_objects -= o.num_objects;
   num_object_clones -= o.num_object_clones;
   num_object_copies -= o.num_object_copies;
@@ -2105,6 +2111,7 @@ bool operator==(const object_stat_sum_t& l, const object_stat_sum_t& r)
 {
   return
     l.num_bytes == r.num_bytes &&
+    l.num_bytes_overlap == r.num_bytes_overlap &&
     l.num_objects == r.num_objects &&
     l.num_object_clones == r.num_object_clones &&
     l.num_object_copies == r.num_object_copies &&

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1584,6 +1584,7 @@ struct object_stat_sum_t {
    * adding/removing fields!
    **************************************************************************/
   int64_t num_bytes;    // in bytes
+  int64_t num_bytes_overlap;  // date in clone objects overlaps
   int64_t num_objects;
   int64_t num_object_clones;
   int64_t num_object_copies;  // num_objects * num_replicas
@@ -1620,7 +1621,7 @@ struct object_stat_sum_t {
   int64_t num_legacy_snapsets; ///< upper bound on pre-luminous-style SnapSets
 
   object_stat_sum_t()
-    : num_bytes(0),
+    : num_bytes(0), num_bytes_overlap(0),
       num_objects(0), num_object_clones(0), num_object_copies(0),
       num_objects_missing_on_primary(0), num_objects_degraded(0),
       num_objects_unfound(0),
@@ -1652,6 +1653,7 @@ struct object_stat_sum_t {
   void floor(int64_t f) {
 #define FLOOR(x) if (x < f) x = f
     FLOOR(num_bytes);
+    FLOOR(num_bytes_overlap);
     FLOOR(num_objects);
     FLOOR(num_object_clones);
     FLOOR(num_object_copies);
@@ -1706,6 +1708,7 @@ struct object_stat_sum_t {
     }
 
     SPLIT(num_bytes);
+    SPLIT(num_bytes_overlap);
     SPLIT(num_objects);
     SPLIT(num_object_clones);
     SPLIT(num_object_copies);
@@ -1764,6 +1767,7 @@ struct object_stat_sum_t {
     static_assert(
       sizeof(object_stat_sum_t) ==
         sizeof(num_bytes) +
+        sizeof(num_bytes_overlap) +
         sizeof(num_objects) +
         sizeof(num_object_clones) +
         sizeof(num_object_copies) +


### PR DESCRIPTION
Based on [mailing list recommendation](https://www.spinics.net/lists/ceph-devel/msg36346.html) I post the patch for discussion via the PR interface. 

Related question: Does BlueStore store overlaps only once?

Thanks

Cc: @gregsfortytwo 

PG group field num_bytes does not include space that is part of clone
object overlaps. Introduce a new field num_bytes_overlap that stands for
this space only, so that it can be used to strictly limit cache tier
usage with object storage backends that do not support storing overlaps
efficiently.

