### PR TITLE
qa/tests: Remove ubuntu 14.04 ceph-deploy tests

### DIFF
--- a/qa/distros/supported/ubuntu_14.04.yaml
+++ b/qa/distros/supported/ubuntu_14.04.yaml
@@ -1,1 +1,0 @@
-../all/ubuntu_14.04.yaml


### PR DESCRIPTION
mgr changes that dont work on 14.04 but work on 16.04

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>