### PR TITLE
osd: add cls_cxx_map_remove_range()

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -2737,35 +2737,6 @@ static int rgw_bi_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist
   return 0;
 }
 
-static int bi_log_list_trim_cb(cls_method_context_t hctx, const string& key, rgw_bi_log_entry& info, void *param)
-{
-  list<rgw_bi_log_entry> *entries = (list<rgw_bi_log_entry> *)param;
-
-  entries->push_back(info);
-  return 0;
-}
-
-static int bi_log_remove_entry(cls_method_context_t hctx, rgw_bi_log_entry& entry)
-{
-  string key;
-  key = BI_PREFIX_CHAR;
-  key.append(bucket_index_prefixes[BI_BUCKET_LOG_INDEX]);
-  key.append(entry.id);
-  return cls_cxx_map_remove_key(hctx, key);
-}
-
-static int bi_log_list_trim_entries(cls_method_context_t hctx,
-                                    const string& start_marker, const string& end_marker,
-			            list<rgw_bi_log_entry>& entries, bool *truncated)
-{
-  string key_iter;
-#define MAX_TRIM_ENTRIES 1000 /* max entries to trim in a single operation */
-  int ret = bi_log_iterate_entries(hctx, start_marker, end_marker,
-                              key_iter, MAX_TRIM_ENTRIES, truncated,
-                              bi_log_list_trim_cb, &entries);
-  return ret;
-}
-
 static int rgw_bi_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 {
   auto in_iter = in->cbegin();
@@ -2778,26 +2749,52 @@ static int rgw_bi_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist
     return -EINVAL;
   }
 
-  cls_rgw_bi_log_list_ret op_ret;
-  list<rgw_bi_log_entry> entries;
-#define MAX_TRIM_ENTRIES 1000 /* don't do more than that in a single operation */
-  bool truncated;
-  int ret = bi_log_list_trim_entries(hctx, op.start_marker, op.end_marker, entries, &truncated);
-  if (ret < 0)
-    return ret;
+  string key_begin(1, BI_PREFIX_CHAR);
+  key_begin.append(bucket_index_prefixes[BI_BUCKET_LOG_INDEX]);
+  key_begin.append(op.start_marker);
 
-  if (entries.empty())
-    return -ENODATA;
-
-  list<rgw_bi_log_entry>::iterator iter;
-  for (iter = entries.begin(); iter != entries.end(); ++iter) {
-    rgw_bi_log_entry& entry = *iter;
-
-    ret = bi_log_remove_entry(hctx, entry);
-    if (ret < 0)
-      return ret;
+  string key_end;
+  if (op.end_marker.empty()) {
+    key_end = BI_PREFIX_CHAR;
+    key_end.append(bucket_index_prefixes[BI_BUCKET_LOG_INDEX + 1]);
+  } else {
+    key_end = BI_PREFIX_CHAR;
+    key_end.append(bucket_index_prefixes[BI_BUCKET_LOG_INDEX]);
+    key_end.append(op.end_marker);
+    // cls_cxx_map_remove_range() expects one-past-end
+    key_end.append(1, '\0');
   }
 
+  // list a single key to detect whether the range is empty
+  const size_t max_entries = 1;
+  std::set<std::string> keys;
+  bool more = false;
+
+  int rc = cls_cxx_map_get_keys(hctx, key_begin, max_entries, &keys, &more);
+  if (rc < 0) {
+    CLS_LOG(1, "ERROR: cls_cxx_map_get_keys failed rc=%d", rc);
+    return rc;
+  }
+
+  if (keys.empty()) {
+    CLS_LOG(20, "range is empty key_begin=%s", key_begin.c_str());
+    return -ENODATA;
+  }
+
+  const std::string& first_key = *keys.begin();
+  if (key_end < first_key) {
+    CLS_LOG(20, "listed key %s past key_end=%s", first_key.c_str(), key_end.c_str());
+    return -ENODATA;
+  }
+
+  CLS_LOG(20, "listed key %s, removing through %s",
+          first_key.c_str(), key_end.c_str());
+
+  rc = cls_cxx_map_remove_range(hctx, first_key, key_end);
+  if (rc < 0) {
+    CLS_LOG(1, "ERROR: cls_cxx_map_remove_range failed rc=%d", rc);
+    return rc;
+  }
   return 0;
 }
 

--- a/src/cls/rgw/cls_rgw_client.cc
+++ b/src/cls/rgw/cls_rgw_client.cc
@@ -474,17 +474,26 @@ int cls_rgw_clear_olh(IoCtx& io_ctx, librados::ObjectWriteOperation& op, string&
   return op_ret;
 }
 
-static bool issue_bi_log_list_op(librados::IoCtx& io_ctx, const string& oid, int shard_id,
-                                 BucketIndexShardsManager& marker_mgr, uint32_t max, BucketIndexAioManager *manager,
-    cls_rgw_bi_log_list_ret *pdata) {
-  bufferlist in;
+void cls_rgw_bilog_list(librados::ObjectReadOperation& op,
+                        const std::string& marker, uint32_t max,
+                        cls_rgw_bi_log_list_ret *pdata, int *ret)
+{
   cls_rgw_bi_log_list_op call;
-  call.marker = marker_mgr.get(shard_id, "");
+  call.marker = marker;
   call.max = max;
-  encode(call, in);
 
+  bufferlist in;
+  encode(call, in);
+  op.exec(RGW_CLASS, RGW_BI_LOG_LIST, in, new ClsBucketIndexOpCtx<cls_rgw_bi_log_list_ret>(pdata, ret));
+}
+
+static bool issue_bi_log_list_op(librados::IoCtx& io_ctx, const string& oid, int shard_id,
+                                 BucketIndexShardsManager& marker_mgr, uint32_t max,
+                                 BucketIndexAioManager *manager,
+                                 cls_rgw_bi_log_list_ret *pdata)
+{
   librados::ObjectReadOperation op;
-  op.exec(RGW_CLASS, RGW_BI_LOG_LIST, in, new ClsBucketIndexOpCtx<cls_rgw_bi_log_list_ret>(pdata, NULL));
+  cls_rgw_bilog_list(op, marker_mgr.get(shard_id, ""), max, pdata, nullptr);
   return manager->aio_operate(io_ctx, oid, &op);
 }
 
@@ -493,16 +502,26 @@ int CLSRGWIssueBILogList::issue_op(int shard_id, const string& oid)
   return issue_bi_log_list_op(io_ctx, oid, shard_id, marker_mgr, max, &manager, &result[shard_id]);
 }
 
+void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
+                        const std::string& start_marker,
+                        const std::string& end_marker)
+{
+  cls_rgw_bi_log_trim_op call;
+  call.start_marker = start_marker;
+  call.end_marker = end_marker;
+
+  bufferlist in;
+  encode(call, in);
+  op.exec(RGW_CLASS, RGW_BI_LOG_TRIM, in);
+}
+
 static bool issue_bi_log_trim(librados::IoCtx& io_ctx, const string& oid, int shard_id,
                               BucketIndexShardsManager& start_marker_mgr,
                               BucketIndexShardsManager& end_marker_mgr, BucketIndexAioManager *manager) {
-  bufferlist in;
   cls_rgw_bi_log_trim_op call;
-  call.start_marker = start_marker_mgr.get(shard_id, "");
-  call.end_marker = end_marker_mgr.get(shard_id, "");
-  encode(call, in);
-  ObjectWriteOperation op;
-  op.exec(RGW_CLASS, RGW_BI_LOG_TRIM, in);
+  librados::ObjectWriteOperation op;
+  cls_rgw_bilog_trim(op, start_marker_mgr.get(shard_id, ""),
+                     end_marker_mgr.get(shard_id, ""));
   return manager->aio_operate(io_ctx, oid, &op);
 }
 

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -437,6 +437,10 @@ void cls_rgw_bucket_list_op(librados::ObjectReadOperation& op,
                             bool list_versions,
                             rgw_cls_list_ret* result);
 
+void cls_rgw_bilog_list(librados::ObjectReadOperation& op,
+                        const std::string& marker, uint32_t max,
+                        cls_rgw_bi_log_list_ret *pdata, int *ret = nullptr);
+
 class CLSRGWIssueBILogList : public CLSRGWConcurrentIO {
   map<int, cls_rgw_bi_log_list_ret>& result;
   BucketIndexShardsManager& marker_mgr;
@@ -450,6 +454,10 @@ public:
     CLSRGWConcurrentIO(io_ctx, oids, max_aio), result(bi_log_lists),
     marker_mgr(_marker_mgr), max(_max) {}
 };
+
+void cls_rgw_bilog_trim(librados::ObjectWriteOperation& op,
+                        const std::string& start_marker,
+                        const std::string& end_marker);
 
 class CLSRGWIssueBILogTrim : public CLSRGWConcurrentIO {
   BucketIndexShardsManager& start_marker_mgr;

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -828,7 +828,6 @@ OPTION(rocksdb_perf, OPT_BOOL) // Enabling this will have 5-10% impact on perfor
 OPTION(rocksdb_collect_compaction_stats, OPT_BOOL) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
 OPTION(rocksdb_collect_extended_stats, OPT_BOOL) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
 OPTION(rocksdb_collect_memory_stats, OPT_BOOL) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.
-OPTION(rocksdb_enable_rmrange, OPT_BOOL) // see https://github.com/facebook/rocksdb/blob/master/include/rocksdb/db.h#L253
 
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3947,15 +3947,6 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
-    Option("rocksdb_enable_rmrange", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
-    .set_description("Refer to github.com/facebook/rocksdb/wiki/DeleteRange-Implementation"),
-
-    Option("rocksdb_max_items_rmrange", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1024)
-    .set_description("Delete Range will be called if number of keys exceeded, must enable rocksdb_enable_rmrange first")
-    .add_see_also("rocksdb_enable_rmrange"),
-
     Option("rocksdb_bloom_bits_per_key", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(20)
     .set_description("Number of bits per key to use for RocksDB's bloom filters.")

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -284,6 +284,7 @@ extern const char *ceph_osd_state_name(int s);
 	f(OMAPSETHEADER, __CEPH_OSD_OP(WR, DATA, 22),	"omap-set-header")  \
 	f(OMAPCLEAR,	__CEPH_OSD_OP(WR, DATA, 23),	"omap-clear")	    \
 	f(OMAPRMKEYS,	__CEPH_OSD_OP(WR, DATA, 24),	"omap-rm-keys")	    \
+	f(OMAPRMKEYRANGE, __CEPH_OSD_OP(WR, DATA, 44),	"omap-rm-key-range") \
 	f(OMAP_CMP,	__CEPH_OSD_OP(RD, DATA, 25),	"omap-cmp")	    \
 									    \
 	/* tiering */							    \

--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3043,6 +3043,23 @@ CEPH_RADOS_API void rados_write_op_omap_rm_keys2(rados_write_op_t write_op,
                                                 const size_t* key_lens,
                                                 size_t keys_len);
 
+
+/**
+ * Remove key/value pairs from an object whose keys are in the range
+ * [key_begin, key_end)
+ *
+ * @param write_op operation to add this action to
+ * @param key_begin the lower bound of the key range to remove
+ * @param key_begin_len length of key_begin
+ * @param key_end the upper bound of the key range to remove
+ * @param key_end_len length of key_end
+ */
+CEPH_RADOS_API void rados_write_op_omap_rm_range2(rados_write_op_t write_op,
+                                                  const char *key_begin,
+                                                  size_t key_begin_len,
+                                                  const char *key_end,
+                                                  size_t key_end_len);
+
 /**
  * Remove all key/value pairs from an object
  *

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -119,8 +119,6 @@ public:
   /// compact the underlying rocksdb store
   bool compact_on_mount;
   bool disableWAL;
-  bool enable_rmrange;
-  const uint64_t max_items_rmrange;
   void compact() override;
 
   void compact_async() override {
@@ -159,9 +157,7 @@ public:
     compact_queue_stop(false),
     compact_thread(this),
     compact_on_mount(false),
-    disableWAL(false),
-    enable_rmrange(cct->_conf->rocksdb_enable_rmrange),
-    max_items_rmrange(cct->_conf.get_val<uint64_t>("rocksdb_max_items_rmrange"))
+    disableWAL(false)
   {}
 
   ~RocksDBStore() override;

--- a/src/librados/librados_c.cc
+++ b/src/librados/librados_c.cc
@@ -3362,6 +3362,20 @@ extern "C" void _rados_write_op_omap_rm_keys2(rados_write_op_t write_op,
 }
 LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_keys2);
 
+extern "C" void _rados_write_op_omap_rm_range2(rados_write_op_t write_op,
+                                               const char *key_begin,
+                                               size_t key_begin_len,
+                                               const char *key_end,
+                                               size_t key_end_len)
+{
+  tracepoint(librados, rados_write_op_omap_rm_range_enter,
+             write_op, key_begin, key_end);
+  ((::ObjectOperation *)write_op)->omap_rm_range({key_begin, key_begin_len},
+                                                 {key_end, key_end_len});
+  tracepoint(librados, rados_write_op_omap_rm_range_exit);
+}
+LIBRADOS_C_API_BASE_DEFAULT(rados_write_op_omap_rm_range2);
+
 extern "C" void _rados_write_op_omap_clear(rados_write_op_t write_op)
 {
   tracepoint(librados, rados_write_op_omap_clear_enter, write_op);

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -622,6 +622,23 @@ int cls_cxx_map_remove_key(cls_method_context_t hctx, const string &key)
   return (*pctx)->pg->do_osd_ops(*pctx, ops);
 }
 
+int cls_cxx_map_remove_range(cls_method_context_t hctx,
+                             const std::string& key_begin,
+                             const std::string& key_end)
+{
+  PrimaryLogPG::OpContext **pctx = (PrimaryLogPG::OpContext **)hctx;
+  vector<OSDOp> ops(1);
+  OSDOp& op = ops[0];
+  bufferlist& update_bl = op.indata;
+
+  ::encode(key_begin, update_bl);
+  ::encode(key_end, update_bl);
+
+  op.op.op = CEPH_OSD_OP_OMAPRMKEYRANGE;
+
+  return (*pctx)->pg->do_osd_ops(*pctx, ops);
+}
+
 int cls_cxx_list_watchers(cls_method_context_t hctx,
 			  obj_list_watch_response_t *watchers)
 {

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -145,6 +145,10 @@ extern int cls_cxx_map_set_vals(cls_method_context_t hctx,
                                 const std::map<std::string, ceph::buffer::list> *map);
 extern int cls_cxx_map_write_header(cls_method_context_t hctx, ceph::buffer::list *inbl);
 extern int cls_cxx_map_remove_key(cls_method_context_t hctx, const std::string &key);
+/* remove keys in the range [key_begin, key_end) */
+extern int cls_cxx_map_remove_range(cls_method_context_t hctx,
+                                    const std::string& key_begin,
+                                    const std::string& key_end);
 extern int cls_cxx_map_update(cls_method_context_t hctx, ceph::buffer::list *inbl);
 
 extern int cls_cxx_list_watchers(cls_method_context_t hctx,

--- a/src/os/Transaction.h
+++ b/src/os/Transaction.h
@@ -1140,15 +1140,29 @@ public:
     const std::string& first,    ///< [in] first key in range
     const std::string& last      ///< [in] first key past range, range is [first,last)
     ) {
-      using ceph::encode;
-	Op* _op = _get_next_op();
-	_op->op = OP_OMAP_RMKEYRANGE;
-	_op->cid = _get_coll_id(cid);
-	_op->oid = _get_object_id(oid);
-	encode(first, data_bl);
-	encode(last, data_bl);
-	data.ops++;
-    }
+    using ceph::encode;
+    Op* _op = _get_next_op();
+    _op->op = OP_OMAP_RMKEYRANGE;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    encode(first, data_bl);
+    encode(last, data_bl);
+    data.ops++;
+  }
+
+  /// Remove key range from oid omap
+  void omap_rmkeyrange(
+    const coll_t cid,       ///< [in] Collection containing oid
+    const ghobject_t &oid,  ///< [in] Object from which to remove the omap keys
+    const bufferlist &keys_bl ///< [in] range of keys to clear
+    ) {
+    Op* _op = _get_next_op();
+    _op->op = OP_OMAP_RMKEYRANGE;
+    _op->cid = _get_coll_id(cid);
+    _op->oid = _get_object_id(oid);
+    data_bl.append(keys_bl);
+    data.ops++;
+  }
 
   /// Set omap header
   void omap_setheader(

--- a/src/osd/PGTransaction.h
+++ b/src/osd/PGTransaction.h
@@ -131,7 +131,7 @@ public:
 
     std::map<string, std::optional<bufferlist> > attr_updates;
 
-    enum class OmapUpdateType {Remove, Insert};
+    enum class OmapUpdateType {Remove, Insert, RemoveRange};
     std::vector<std::pair<OmapUpdateType, bufferlist> > omap_updates;
 
     std::optional<bufferlist> omap_header;
@@ -478,6 +478,26 @@ public:
     bufferlist bl;
     encode(keys, bl);
     omap_rmkeys(hoid, bl);
+  }
+  void omap_rmkeyrange(
+    const hobject_t &hoid,         ///< [in] object to write
+    bufferlist &range_bl           ///< [in] encode string[2]
+    ) {
+    auto &op = get_object_op_for_modify(hoid);
+    op.omap_updates.emplace_back(
+      make_pair(
+	ObjectOperation::OmapUpdateType::RemoveRange,
+	range_bl));
+  }
+  void omap_rmkeyrange(
+    const hobject_t &hoid,         ///< [in] object to write
+    std::string& key_begin,        ///< [in] first key in range
+    std::string& key_end           ///< [in] first key past range, range is [first,last)
+    ) {
+    bufferlist bl;
+    ::encode(key_begin, bl);
+    ::encode(key_end, bl);
+    omap_rmkeyrange(hoid, bl);
   }
   void omap_setheader(
     const hobject_t &hoid,         ///< [in] object to write

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7558,6 +7558,32 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       obs.oi.clear_omap_digest();
       break;
 
+    case CEPH_OSD_OP_OMAPRMKEYRANGE:
+      tracepoint(osd, do_osd_op_pre_omaprmkeyrange, soid.oid.name.c_str(), soid.snap.val);
+      if (!pool.info.supports_omap()) {
+	result = -EOPNOTSUPP;
+	break;
+      }
+      ++ctx->num_write;
+      {
+	if (!obs.exists || oi.is_whiteout()) {
+	  result = -ENOENT;
+	  break;
+	}
+	std::string key_begin, key_end;
+	try {
+	  decode(key_begin, bp);
+	  decode(key_end, bp);
+	} catch (buffer::error& e) {
+	  result = -EINVAL;
+	  goto fail;
+	}
+	t->omap_rmkeyrange(soid, key_begin, key_end);
+	ctx->delta_stats.num_wr++;
+      }
+      obs.oi.clear_omap_digest();
+      break;
+
     case CEPH_OSD_OP_COPY_GET:
       ++ctx->num_read;
       tracepoint(osd, do_osd_op_pre_copy_get, soid.oid.name.c_str(),

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -378,6 +378,9 @@ void generate_transaction(
 	case UpdateType::Insert:
 	  t->omap_setkeys(coll, goid, up.second);
 	  break;
+	case UpdateType::RemoveRange:
+	  t->omap_rmkeyrange(coll, goid, up.second);
+	  break;
 	}
       }
 

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1003,6 +1003,13 @@ struct ObjectOperation {
     add_data(CEPH_OSD_OP_OMAPRMKEYS, 0, bl.length(), bl);
   }
 
+  void omap_rm_range(std::string_view key_begin, std::string_view key_end) {
+    bufferlist bl;
+    encode(key_begin, bl);
+    encode(key_end, bl);
+    add_data(CEPH_OSD_OP_OMAPRMKEYRANGE, 0, bl.length(), bl);
+  }
+
   // object classes
   void call(const char *cname, const char *method, ceph::buffer::list &indata) {
     add_call(CEPH_OSD_OP_CALL, cname, method, indata, NULL, NULL, NULL);

--- a/src/test/cls_log/test_cls_log.cc
+++ b/src/test/cls_log/test_cls_log.cc
@@ -36,19 +36,6 @@ class cls_log : public ::testing::Test {
   }
 };
 
-static librados::ObjectWriteOperation *new_op() {
-  return new librados::ObjectWriteOperation();
-}
-
-static librados::ObjectReadOperation *new_rop() {
-  return new librados::ObjectReadOperation();
-}
-
-static void reset_rop(librados::ObjectReadOperation **pop) {
-  delete *pop;
-  *pop = new_rop();
-}
-
 static int read_bl(bufferlist& bl, int *i)
 {
   auto iter = bl.cbegin();
@@ -85,7 +72,7 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
 {
   string section = "global";
 
-  librados::ObjectWriteOperation *op = new_op();
+  librados::ObjectWriteOperation op;
 
   int i;
 
@@ -97,12 +84,10 @@ void generate_log(librados::IoCtx& ioctx, string& oid, int max, utime_t& start_t
     utime_t ts(secs, start_time.nsec());
     string name = get_name(i);
 
-    add_log(op, ts, section, name, i);
+    add_log(&op, ts, section, name, i);
   }
 
-  ASSERT_EQ(0, ioctx.operate(oid, op));
-
-  delete op;
+  ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
 utime_t get_time(utime_t& start_time, int i, bool modify_time)
@@ -124,6 +109,27 @@ void check_entry(cls_log_entry& entry, utime_t& start_time, int i, bool modified
   ASSERT_EQ(ts, entry.timestamp);
 }
 
+static int log_list(librados::IoCtx& ioctx, const std::string& oid,
+                    utime_t& from, utime_t& to,
+                    const string& in_marker, int max_entries,
+                    list<cls_log_entry>& entries,
+                    string *out_marker, bool *truncated)
+{
+  librados::ObjectReadOperation rop;
+  cls_log_list(rop, from, to, in_marker, max_entries,
+               entries, out_marker, truncated);
+  bufferlist obl;
+  return ioctx.operate(oid, &rop, &obl);
+}
+
+static int log_list(librados::IoCtx& ioctx, const std::string& oid,
+                    utime_t& from, utime_t& to, int max_entries,
+                    list<cls_log_entry>& entries, bool *truncated)
+{
+  std::string marker;
+  return log_list(ioctx, oid, from, to, marker, max_entries,
+                  entries, &marker, truncated);
+}
 
 TEST_F(cls_log, test_log_add_same_time)
 {
@@ -135,27 +141,19 @@ TEST_F(cls_log, test_log_add_same_time)
 
   /* generate log */
   utime_t start_time = ceph_clock_now();
+  utime_t to_time = get_time(start_time, 1, true);
   generate_log(ioctx, oid, 10, start_time, false);
-
-  librados::ObjectReadOperation *rop = new_rop();
 
   list<cls_log_entry> entries;
   bool truncated;
 
   /* check list */
-
-  utime_t to_time = get_time(start_time, 1, true);
-
-  string marker;
-
-  cls_log_list(*rop, start_time, to_time, marker, 0, entries, &marker, &truncated);
-
-  bufferlist obl;
-  ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
-
-  ASSERT_EQ(10, (int)entries.size());
-  ASSERT_EQ(0, (int)truncated);
-
+  {
+    ASSERT_EQ(0, log_list(ioctx, oid, start_time, to_time, 0,
+                          entries, &truncated));
+    ASSERT_EQ(10, (int)entries.size());
+    ASSERT_EQ(0, (int)truncated);
+  }
   list<cls_log_entry>::iterator iter;
 
   /* need to sort returned entries, all were using the same time as key */
@@ -185,21 +183,13 @@ TEST_F(cls_log, test_log_add_same_time)
     check_entry(entry, start_time, i, false);
   }
 
-  reset_rop(&rop);
-
   /* check list again, now want to be truncated*/
-
-  marker.clear();
-
-  cls_log_list(*rop, start_time, to_time, marker, 1, entries, &marker, &truncated);
-
-  ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
-
-  ASSERT_EQ(1, (int)entries.size());
-  ASSERT_EQ(1, (int)truncated);
-
-  delete rop;
-
+  {
+    ASSERT_EQ(0, log_list(ioctx, oid, start_time, to_time, 1,
+                          entries, &truncated));
+    ASSERT_EQ(1, (int)entries.size());
+    ASSERT_EQ(1, (int)truncated);
+  }
 }
 
 TEST_F(cls_log, test_log_add_different_time)
@@ -214,23 +204,18 @@ TEST_F(cls_log, test_log_add_different_time)
   utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
-  librados::ObjectReadOperation *rop = new_rop();
-
   list<cls_log_entry> entries;
   bool truncated;
 
   utime_t to_time = utime_t(start_time.sec() + 10, start_time.nsec());
 
-  string marker;
-
-  /* check list */
-  cls_log_list(*rop, start_time, to_time, marker, 0, entries, &marker, &truncated);
-
-  bufferlist obl;
-  ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
-
-  ASSERT_EQ(10, (int)entries.size());
-  ASSERT_EQ(0, (int)truncated);
+  {
+    /* check list */
+    ASSERT_EQ(0, log_list(ioctx, oid, start_time, to_time, 0,
+                          entries, &truncated));
+    ASSERT_EQ(10, (int)entries.size());
+    ASSERT_EQ(0, (int)truncated);
+  }
 
   list<cls_log_entry>::iterator iter;
 
@@ -251,31 +236,21 @@ TEST_F(cls_log, test_log_add_different_time)
     check_entry(entry, start_time, i, true);
   }
 
-  reset_rop(&rop);
-
   /* check list again with shifted time */
-  utime_t next_time = get_time(start_time, 1, true);
+  {
+    utime_t next_time = get_time(start_time, 1, true);
+    ASSERT_EQ(0, log_list(ioctx, oid, next_time, to_time, 0,
+                          entries, &truncated));
+    ASSERT_EQ(9u, entries.size());
+    ASSERT_FALSE(truncated);
+  }
 
-  marker.clear();
-
-  cls_log_list(*rop, next_time, to_time, marker, 0, entries, &marker, &truncated);
-
-  ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
-
-  ASSERT_EQ(9, (int)entries.size());
-  ASSERT_EQ(0, (int)truncated);
-
-  reset_rop(&rop);
-
-  marker.clear();
-
+  string marker;
   i = 0;
   do {
-    bufferlist obl;
-    string old_marker = marker;
-    cls_log_list(*rop, start_time, to_time, old_marker, 1, entries, &marker, &truncated);
-
-    ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
+    string old_marker = std::move(marker);
+    ASSERT_EQ(0, log_list(ioctx, oid, start_time, to_time, old_marker, 1,
+                          entries, &marker, &truncated));
     ASSERT_NE(old_marker, marker);
     ASSERT_EQ(1, (int)entries.size());
 
@@ -298,8 +273,6 @@ TEST_F(cls_log, test_log_trim)
   utime_t start_time = ceph_clock_now();
   generate_log(ioctx, oid, 10, start_time, true);
 
-  librados::ObjectReadOperation *rop = new_rop();
-
   list<cls_log_entry> entries;
   bool truncated;
 
@@ -316,14 +289,9 @@ TEST_F(cls_log, test_log_trim)
 
     ASSERT_EQ(0, cls_log_trim(ioctx, oid, zero_time, trim_time, start_marker, end_marker));
 
-    string marker;
-
-    cls_log_list(*rop, start_time, to_time, marker, 0, entries, &marker, &truncated);
-
-    bufferlist obl;
-    ASSERT_EQ(0, ioctx.operate(oid, rop, &obl));
-
-    ASSERT_EQ(9 - i, (int)entries.size());
-    ASSERT_EQ(0, (int)truncated);
+    ASSERT_EQ(0, log_list(ioctx, oid, start_time, to_time, 0,
+                          entries, &truncated));
+    ASSERT_EQ(9u - i, entries.size());
+    ASSERT_FALSE(truncated);
   }
 }

--- a/src/test/cls_rgw/test_cls_rgw.cc
+++ b/src/test/cls_rgw/test_cls_rgw.cc
@@ -68,21 +68,22 @@ void test_stats(librados::IoCtx& ioctx, string& oid, RGWObjCategory category, ui
   ASSERT_EQ(num_entries, entries);
 }
 
-void index_prepare(librados::IoCtx& ioctx, string& oid, RGWModifyOp index_op, string& tag,
-		   string& obj, string& loc, uint16_t bi_flags = 0, bool log_op = true)
+void index_prepare(librados::IoCtx& ioctx, string& oid, RGWModifyOp index_op,
+                   string& tag, const cls_rgw_obj_key& key, string& loc,
+                   uint16_t bi_flags = 0, bool log_op = true)
 {
   ObjectWriteOperation op;
-  cls_rgw_obj_key key(obj, string());
   rgw_zone_set zones_trace;
   cls_rgw_bucket_prepare_op(op, index_op, tag, key, loc, log_op, bi_flags, zones_trace);
   ASSERT_EQ(0, ioctx.operate(oid, &op));
 }
 
-void index_complete(librados::IoCtx& ioctx, string& oid, RGWModifyOp index_op, string& tag,
-		    int epoch, string& obj, rgw_bucket_dir_entry_meta& meta, uint16_t bi_flags = 0, bool log_op = true)
+void index_complete(librados::IoCtx& ioctx, string& oid, RGWModifyOp index_op,
+                    string& tag, int epoch, const cls_rgw_obj_key& key,
+                    rgw_bucket_dir_entry_meta& meta, uint16_t bi_flags = 0,
+                    bool log_op = true)
 {
   ObjectWriteOperation op;
-  cls_rgw_obj_key key(obj, string());
   rgw_bucket_entry_ver ver;
   ver.pool = ioctx.get_id();
   ver.epoch = epoch;
@@ -105,7 +106,7 @@ TEST_F(cls_rgw, index_basic)
 
 #define NUM_OBJS 10
   for (int i = 0; i < NUM_OBJS; i++) {
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag", i);
     string loc = str_int("loc", i);
 
@@ -133,7 +134,7 @@ TEST_F(cls_rgw, index_multiple_obj_writers)
 
   uint64_t obj_size = 1024;
 
-  string obj = str_int("obj", 0);
+  cls_rgw_obj_key obj = str_int("obj", 0);
   string loc = str_int("loc", 0);
   /* multi prepare on a single object */
   for (int i = 0; i < NUM_OBJS; i++) {
@@ -174,7 +175,7 @@ TEST_F(cls_rgw, index_remove_object)
 
   /* prepare multiple objects */
   for (int i = 0; i < NUM_OBJS; i++) {
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag", i);
     string loc = str_int("loc", i);
 
@@ -195,7 +196,7 @@ TEST_F(cls_rgw, index_remove_object)
   int i = NUM_OBJS / 2;
   string tag_remove = "tag-rm";
   string tag_modify = "tag-mod";
-  string obj = str_int("obj", i);
+  cls_rgw_obj_key obj = str_int("obj", i);
   string loc = str_int("loc", i);
 
   /* prepare both removal and modification on the same object */
@@ -268,7 +269,7 @@ TEST_F(cls_rgw, index_suggest)
 
   /* create multiple objects */
   for (int i = 0; i < num_objs; i++) {
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag", i);
     string loc = str_int("loc", i);
 
@@ -288,7 +289,7 @@ TEST_F(cls_rgw, index_suggest)
 
   /* prepare (without completion) some of the objects */
   for (int i = 0; i < num_objs; i += 2) {
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag-prepare", i);
     string loc = str_int("loc", i);
 
@@ -300,7 +301,7 @@ TEST_F(cls_rgw, index_suggest)
   int actual_num_objs = num_objs;
   /* remove half of the objects */
   for (int i = num_objs / 2; i < num_objs; i++) {
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag-rm", i);
     string loc = str_int("loc", i);
 
@@ -319,12 +320,12 @@ TEST_F(cls_rgw, index_suggest)
   bufferlist updates;
 
   for (int i = 0; i < num_objs; i += 2) { 
-    string obj = str_int("obj", i);
+    cls_rgw_obj_key obj = str_int("obj", i);
     string tag = str_int("tag-rm", i);
     string loc = str_int("loc", i);
 
     rgw_bucket_dir_entry dirent;
-    dirent.key.name = obj;
+    dirent.key.name = obj.name;
     dirent.locator = loc;
     dirent.exists = (i < num_objs / 2); // we removed half the objects
     dirent.meta.size = 1024;

--- a/src/tracing/librados.tp
+++ b/src/tracing/librados.tp
@@ -3347,6 +3347,23 @@ TRACEPOINT_EVENT(librados, rados_write_op_omap_rm_keys_exit,
     TP_FIELDS()
 )
 
+TRACEPOINT_EVENT(librados, rados_write_op_omap_rm_range_enter,
+    TP_ARGS(
+        rados_write_op_t, op,
+        const char*, key_begin,
+        const char*, key_end),
+    TP_FIELDS(
+        ctf_integer_hex(rados_write_op_t, op, op)
+        ceph_ctf_string(key_begin, key_begin)
+        ceph_ctf_string(key_end, key_end)
+    )
+)
+
+TRACEPOINT_EVENT(librados, rados_write_op_omap_rm_range_exit,
+    TP_ARGS(),
+    TP_FIELDS()
+)
+
 TRACEPOINT_EVENT(librados, rados_write_op_omap_clear_enter,
     TP_ARGS(
         rados_write_op_t, op),

--- a/src/tracing/osd.tp
+++ b/src/tracing/osd.tp
@@ -749,6 +749,16 @@ TRACEPOINT_EVENT(osd, do_osd_op_pre_omaprmkeys,
     )
 )
 
+TRACEPOINT_EVENT(osd, do_osd_op_pre_omaprmkeyrange,
+    TP_ARGS(
+        const char*, oid,
+        uint64_t, snap),
+    TP_FIELDS(
+        ctf_string(oid, oid)
+        ctf_integer(uint64_t, snap, snap)
+    )
+)
+
 TRACEPOINT_EVENT(osd, do_osd_op_pre_copy_get_classic,
     TP_ARGS(
         const char*, oid,


### PR DESCRIPTION
this adds a new `CEPH_OSD_OP_OMAPRMKEYRANGE` for the ObjectStore's `OP_OMAP_RMKEYRANGE`, and exposes it in the cls api as `cls_cxx_map_remove_range()` and the librados api as `rados_write_op_omap_rm_range()` and `ObjectWriteOperation::omap_rm_range()`

this is used by cls trim operations to avoid sending separate osd ops for each key with `cls_cxx_map_remove_key()`

Fixes: http://tracker.ceph.com/issues/19975