### PR TITLE
FINISH HIM!!!

### DIFF
--- a/src/common/Finisher.cc
+++ b/src/common/Finisher.cc
@@ -1,6 +1,9 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "common/convenience.h"
+#include "common/config.h"
+#include "common/ceph_time.h"
 #include "Finisher.h"
 
 #define dout_subsys ceph_subsys_finisher
@@ -10,18 +13,19 @@
 void Finisher::start()
 {
   ldout(cct, 10) << __func__ << dendl;
-  finisher_thread.create(thread_name.c_str());
+  finisher_thread = make_named_thread(thread_name,
+				      &Finisher::finisher_thread_entry, this);
 }
 
 void Finisher::stop()
 {
   ldout(cct, 10) << __func__ << dendl;
-  finisher_lock.lock();
+  std::unique_lock l(finisher_lock);
   finisher_stop = true;
   // we don't have any new work to do, but we want the worker to wake up anyway
   // to process the stop condition.
   finisher_cond.notify_all();
-  finisher_lock.unlock();
+  l.unlock();
   finisher_thread.join(); // wait until the worker exits completely
   ldout(cct, 10) << __func__ << " finish" << dendl;
 }
@@ -38,27 +42,29 @@ void Finisher::wait_for_empty()
   finisher_empty_wait = false;
 }
 
-void *Finisher::finisher_thread_entry()
+void Finisher::finisher_thread_entry() noexcept
 {
   std::unique_lock ul(finisher_lock);
   ldout(cct, 10) << "finisher_thread start" << dendl;
 
-  utime_t start;
+  ceph::coarse_mono_time start;
   uint64_t count = 0;
   while (!finisher_stop) {
     /// Every time we are woken up, we process the queue until it is empty.
     while (!finisher_queue.empty()) {
+      if (logger)
+	start = ceph::coarse_mono_clock::now();
       // To reduce lock contention, we swap out the queue to process.
       // This way other threads can submit new contexts to complete
       // while we are working.
-      vector<pair<Context*,int>> ls;
+      std::vector<pair<Context*,int>> ls;
       ls.swap(finisher_queue);
       finisher_running = true;
       ul.unlock();
       ldout(cct, 10) << "finisher_thread doing " << ls << dendl;
 
       if (logger) {
-	start = ceph_clock_now();
+	start = ceph::coarse_mono_clock::now();
 	count = ls.size();
       }
 
@@ -70,7 +76,8 @@ void *Finisher::finisher_thread_entry()
       ls.clear();
       if (logger) {
 	logger->dec(l_finisher_queue_len, count);
-	logger->tinc(l_finisher_complete_lat, ceph_clock_now() - start);
+	logger->tinc(l_finisher_complete_lat,
+		     ceph::coarse_mono_clock::now() - start);
       }
 
       ul.lock();
@@ -81,7 +88,7 @@ void *Finisher::finisher_thread_entry()
       finisher_empty_cond.notify_all();
     if (finisher_stop)
       break;
-    
+
     ldout(cct, 10) << "finisher_thread sleeping" << dendl;
     finisher_cond.wait(ul);
   }
@@ -91,6 +98,4 @@ void *Finisher::finisher_thread_entry()
 
   ldout(cct, 10) << "finisher_thread stop" << dendl;
   finisher_stop = false;
-  return 0;
 }
-

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1948,7 +1948,7 @@ public:
 		    uint32_t register_gen);
   int _normalize_watch_error(int r);
 
-  friend class C_DoWatchError;
+  friend class CB_DoWatchError;
 public:
   void linger_callback_flush(Context *ctx) {
     finisher->queue(ctx);

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -320,3 +320,8 @@ target_link_libraries(unittest_async_completion Boost::system)
 add_executable(unittest_async_shared_mutex test_async_shared_mutex.cc)
 add_ceph_unittest(unittest_async_shared_mutex)
 target_link_libraries(unittest_async_shared_mutex ceph-common Boost::system)
+
+add_executable(unittest_finisher test_finisher.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(unittest_finisher global ceph-common)
+add_ceph_unittest(unittest_finisher)

--- a/src/test/common/test_finisher.cc
+++ b/src/test/common/test_finisher.cc
@@ -1,0 +1,54 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2018 Red Hat <contact@redhat.com>
+ *
+ * LGPL2.1 (see COPYING-LGPL2.1) or later
+ */
+
+#include <atomic>
+
+#include <gtest/gtest.h>
+
+#include "include/Context.h"
+
+#include "common/ceph_time.h"
+#include "common/Cond.h"
+#include "common/Finisher.h"
+
+TEST(UpDown, Finisher) {
+  auto cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  Finisher f(cct);
+  f.start();
+  f.stop();
+  cct->put();
+}
+
+TEST(Fire, Finisher) {
+  auto cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  Finisher f(cct);
+  C_SaferCond c;
+  f.start();
+  f.queue(&c);
+  c.wait();
+  f.stop();
+  cct->put();
+}
+
+TEST(Bench, Finisher) {
+  using namespace std::literals;
+  auto cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  Finisher f(cct);
+  std::vector<C_SaferCond> cs(1'000'000);
+  f.start();
+  auto begin = ceph::coarse_mono_clock::now();
+  for (auto& c : cs) f.queue(&c);
+  for (auto& c : cs) c.wait();
+  auto end = ceph::coarse_mono_clock::now();
+  f.stop();
+  cct->put();
+  std::cout << "Queued and completed 1,000,000 C_SaferCond objects in " << end - begin
+	    << std::endl;
+}

--- a/src/test/common/test_finisher.cc
+++ b/src/test/common/test_finisher.cc
@@ -52,3 +52,17 @@ TEST(Bench, Finisher) {
   std::cout << "Queued and completed 1,000,000 C_SaferCond objects in " << end - begin
 	    << std::endl;
 }
+
+
+TEST(FireFuction, Finisher) {
+  std::atomic<bool> fired = false;
+  auto cct = (new CephContext(CEPH_ENTITY_TYPE_CLIENT))->get();
+  Finisher f(cct);
+  f.start();
+  ASSERT_FALSE(fired);
+  f.queue([&fired]() { fired = true; });
+  std::this_thread::sleep_for(5s);
+  ASSERT_TRUE(fired);
+  f.stop();
+  cct->put();
+}

--- a/src/test/librados_test_stub/TestWatchNotify.cc
+++ b/src/test/librados_test_stub/TestWatchNotify.cc
@@ -5,6 +5,7 @@
 #include "include/Context.h"
 #include "common/Cond.h"
 #include "include/stringify.h"
+#include "common/Cond.h"
 #include "common/Finisher.h"
 #include "test/librados_test_stub/TestCluster.h"
 #include "test/librados_test_stub/TestRadosClient.h"


### PR DESCRIPTION
Update the finisher. Clean it up a bit for memory/exception safety (not that we throw exceptions, it's just the principle of the thing, and it eliminates memory related bugs, too) and rewrite it to use function objects instead of Context pointers. (Context pointers and are λ-fied and shoved in, so it's not like they don't work.)

Then update the Objecter to use the new interface to the Finisher. Except in the case of the linger op stuff, since that's an external interface and I don't want to deal with it at the moment.

This is an installment of the General Plan to Optimize/Organize/Cleanup client side stuff, but from past experience holding everything off for a SINGLE GIANT PUSH is difficult to manage.