### PR TITLE
mgr: Mark session connections down on shutdown

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -59,7 +59,10 @@ void MgrClient::shutdown()
   command_table.clear();
 
   timer.shutdown();
-  session.reset();
+  if (session) {
+    session->con->mark_down();
+    session.reset();
+  }
 }
 
 bool MgrClient::ms_dispatch(Message *m)

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6655,6 +6655,9 @@ bool OSD::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool for
 {
   dout(10) << "OSD::ms_get_authorizer type=" << ceph_entity_type_name(dest_type) << dendl;
 
+  if (is_stopping())
+    dout(10) << __func__ << " bailing, we are shutting down" << dendl;
+
   if (dest_type == CEPH_ENTITY_TYPE_MON)
     return true;
 


### PR DESCRIPTION
Also return false early from OSD::ms_get_authorizer since it is
dangerous to proceed if we are shutting down.

Fixes: http://tracker.ceph.com/issues/19900

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>