### PR TITLE
build/ops: rpm: move RDMA and python-prettytables build dependencies to distro-conditional section

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -133,7 +133,6 @@ BuildRequires:	xfsprogs
 BuildRequires:	xfsprogs-devel
 BuildRequires:	xmlstarlet
 BuildRequires:	yasm
-BuildRequires:	libibverbs-devel
 
 #################################################################################
 # distro-conditional dependencies
@@ -155,6 +154,7 @@ BuildRequires:  openldap2-devel
 BuildRequires:	python-CherryPy
 BuildRequires:	python-Cython
 BuildRequires:	python-Sphinx
+BuildRequires:  rdma-core-devel
 %endif
 %if 0%{?fedora} || 0%{?rhel} 
 Requires:	systemd
@@ -162,6 +162,7 @@ BuildRequires:  boost-random
 BuildRequires:	btrfs-progs
 BuildRequires:	nss-devel
 BuildRequires:	keyutils-libs-devel
+BuildRequires:	libibverbs-devel
 BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -122,7 +122,6 @@ BuildRequires:	pkgconfig
 BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
-BuildRequires:	python-prettytable
 BuildRequires:	python-requests
 BuildRequires:	python-virtualenv
 BuildRequires:	snappy-devel
@@ -153,6 +152,7 @@ BuildRequires:  lsb-release
 BuildRequires:  openldap2-devel
 BuildRequires:	python-CherryPy
 BuildRequires:	python-Cython
+BuildRequires:	python-PrettyTable
 BuildRequires:	python-Sphinx
 BuildRequires:  rdma-core-devel
 %endif
@@ -168,6 +168,7 @@ BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
 BuildRequires:	python-cherrypy
+BuildRequires:	python-prettytable
 BuildRequires:	python-sphinx
 %endif
 # python34-... for RHEL, python3-... for all other supported distros
@@ -262,7 +263,12 @@ Requires:	python-rados = %{epoch}:%{version}-%{release}
 Requires:	python-rbd = %{epoch}:%{version}-%{release}
 Requires:	python-cephfs = %{epoch}:%{version}-%{release}
 Requires:	python-rgw = %{epoch}:%{version}-%{release}
+%if 0%{?fedora} || 0%{?rhel}
 Requires:	python-prettytable
+%endif
+%if 0%{?suse_version}
+Requires:	python-PrettyTable
+%endif
 Requires:	python-requests
 %{?systemd_requires}
 %if 0%{?suse_version}


### PR DESCRIPTION
SUSE ships this package under the name "rdma-core-devel". See
https://build.opensuse.org/package/view_file/openSUSE:Factory/rdma-core/rdma-core.spec?expand=1

Signed-off-by: Nathan Cutler <ncutler@suse.com>