### PR TITLE
qa/suites/rados/singleton-nomsg/health-warnings: behave on ext4

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -3,6 +3,11 @@ roles:
 tasks:
 - install:
 - ceph:
+    conf:
+      osd:
+# we may land on ext4
+        osd max object name len = 400
+        osd max object namespace len = 64
 - workunit:
     clients:
       all:


### PR DESCRIPTION
We may land on an ext4 root partition.

Fixes: http://tracker.ceph.com/issues/20043
Signed-off-by: Sage Weil <sage@redhat.com>