### PR TITLE
common/types: make numbers a bit nicer when displaying space usage

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -322,20 +322,42 @@ struct si_t {
 
 inline ostream& operator<<(ostream& out, const si_t& b)
 {
-  uint64_t bump_after = 100;
-  if (b.v > bump_after << 60)
-    return out << (b.v >> 60) << "E";
-  if (b.v > bump_after << 50)
-    return out << (b.v >> 50) << "P";
-  if (b.v > bump_after << 40)
-    return out << (b.v >> 40) << "T";
-  if (b.v > bump_after << 30)
-    return out << (b.v >> 30) << "G";
-  if (b.v > bump_after << 20)
-    return out << (b.v >> 20) << "M";
-  if (b.v > bump_after << 10)
-    return out << (b.v >> 10) << "k";
-  return out << b.v;
+  char buffer[32];
+  uint64_t n = b.v;
+  int index = 0;
+  char u;
+
+  while (n >= 1024 && index < 6) {
+    n /= 1024;
+    index++;
+  }
+
+  u = " KMGTPE"[index];
+
+  if (index == 0) {
+    (void) snprintf(buffer, sizeof(buffer), "%llu", (unsigned long long)n);
+  } else if ((b.v & ((1ULL << 10 * index) - 1)) == 0) {
+    // If this is an even multiple of the base, always display
+    // without any decimal precision.
+    (void) snprintf(buffer, sizeof(buffer), "%llu%c",
+      (unsigned long long)n, u);
+  } else {
+    // We want to choose a precision that reflects the best choice
+    // for fitting in 5 characters.  This can get rather tricky when
+    // we have numbers that are very close to an order of magnitude.
+    // For example, when displaying 10239 (which is really 9.999K),
+    // we want only a single place of precision for 10.0K.  We could
+    // develop some complex heuristics for this, but it's much
+    // easier just to try each combination in turn.
+    int i;
+    for (i = 2; i >= 0; i--) {
+      if (snprintf(buffer, sizeof(buffer), "%.*f%c", i,
+        (double)b.v / (1ULL << 10 * index), u) <= 5)
+        break;
+    }
+  }
+
+  return out << buffer;
 }
 
 struct pretty_si_t {

--- a/src/test/mon/test_pool_quota.sh
+++ b/src/test/mon/test_pool_quota.sh
@@ -52,7 +52,7 @@ function TEST_pool_quota() {
     objects=`ceph df detail | grep -w $poolname|awk '{print $3}'`
     bytes=`ceph df detail | grep -w $poolname|awk '{print $4}'`
    
-     if [ $objects != '1000' ] || [ $bytes != '1024' ] ;
+     if [ $objects != '1000' ] || [ $bytes != '1K' ] ;
        then
        return 1
      fi


### PR DESCRIPTION
Was:

```
GLOBAL:
    SIZE       AVAIL      RAW USED     %RAW USED
    30911M     27050M        3861M         12.49
POOLS:
    NAME                  ID     USED        %USED     MAX AVAIL     OBJECTS
    rbd                   0      101216k      1.10         8913M        1178
    cephfs_data_a         1            0         0         8913M           0
    cephfs_metadata_a     2          892         0         8913M          21
```

Now:

```
GLOBAL:
    SIZE      AVAIL     RAW USED     %RAW USED
    30.2G     26.4G        3.77G         12.50
POOLS:
    NAME                  ID     USED      %USED     MAX AVAIL     OBJECTS
    rbd                   0      99.2M      1.10         8.70G        1180
    cephfs_data_a         1          0         0         8.70G           0
    cephfs_metadata_a     2        892         0         8.70G          21
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>