### PR TITLE
rgw_file:  remove post-unlink lookup check

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -342,13 +342,6 @@ namespace rgw {
     fh_cache.remove(rgw_fh->fh.fh_hk.object, rgw_fh,
 		    RGWFileHandle::FHCache::FLAG_LOCK);
 
-#if 1 /* XXX verify clear cache */
-    fh_key fhk(rgw_fh->fh.fh_hk);
-    LookupFHResult tfhr = lookup_fh(fhk, RGWFileHandle::FLAG_LOCKED);
-    RGWFileHandle* nfh = get<0>(tfhr);
-    assert(!nfh);
-#endif
-
     if (! rc) {
       real_time t = real_clock::now();
       parent->set_mtime(real_clock::to_timespec(t));


### PR DESCRIPTION
This could induce asserts in multi-nfs-gateway scenarios.

Fixes: http://tracker.ceph.com/issues/20047

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>