### PR TITLE
crush/CrushWrapper: fix has_incompat_choose_args

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -112,7 +112,7 @@ bool CrushWrapper::has_choose_args() const
 
 bool CrushWrapper::has_incompat_choose_args() const
 {
-  if (choose_args.size() != 1)
+  if (choose_args.size() > 1)
     return true;
   crush_choose_arg_map arg_map = choose_args.begin()->second;
   for (__u32 i = 0; i < arg_map.size; i++) {


### PR DESCRIPTION
If the map has *no* choose_args it does not have incompat choose args.
This makes the OSDMap::get_features() check

  if (crush->has_incompat_choose_args())
    features |= CEPH_FEATURE_CRUSH_CHOOSE_ARGS;

happier.

Signed-off-by: Sage Weil <sage@redhat.com>