### PR TITLE
rgw: use get_data_extra_pool() when get extra pool

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -130,7 +130,7 @@ static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZonePa
     if (!obj.in_extra_data) {
       *pool = placement.data_pool;
     } else {
-      *pool = placement.data_extra_pool;
+      *pool = placement.get_data_extra_pool();
     }
   }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1121,7 +1121,7 @@ struct RGWZonePlacementInfo {
     }
     DECODE_FINISH(bl);
   }
-  const rgw_pool& get_data_extra_pool() {
+  const rgw_pool& get_data_extra_pool() const {
     if (data_extra_pool.empty()) {
       return data_pool;
     }
@@ -1293,7 +1293,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
     if (!obj.in_extra_data) {
       *pool = iter->second.data_pool;
     } else {
-      *pool = iter->second.data_extra_pool;
+      *pool = iter->second.get_data_extra_pool();
     }
     return true;
   }


### PR DESCRIPTION
use member data_extra_pool of RGWZonePlacementInfo isn't properly, because it maybe not configured.

Fixes: http://tracker.ceph.com/issues/20064

Signed-off-by: fang yuxiang <fang.yuxiang@eisoo.com>