### PR TITLE
include/rados: Fix typo in rados_ioctx_cct() doc

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -742,7 +742,7 @@ CEPH_RADOS_API int rados_ioctx_create2(rados_t cluster, int64_t pool_id,
 CEPH_RADOS_API void rados_ioctx_destroy(rados_ioctx_t io);
 
 /**
- * Get configuration hadnle for a pool handle
+ * Get configuration handle for a pool handle
  *
  * @param io pool handle
  * @returns rados_config_t for this cluster


### PR DESCRIPTION
This fixes https://github.com/ceph/ceph/pull/15077. I have fixed this, as there is no response from the author of #15077.

Signed-off-by: Jos Collin <jcollin@redhat.com>