### PR TITLE
rgw: set placement rule properly

### DIFF
--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -118,6 +118,7 @@ void RGWObjManifest::obj_iterator::update_location()
 
   if (ofs < manifest->get_head_size()) {
     location = manifest->get_obj();
+    location.set_placement_rule(manifest->get_head_placement_rule());
     return;
   }
 


### PR DESCRIPTION
we should set placement rule in RGWObjManifest::obj_iterator::update_location()
when ofs < manifest->get_head_size().

Signed-off-by: fang yuxiang fang.yuxiang@eisoo.com