### PR TITLE
build/ops: conditionalize rgw Beast frontend so it isn't built on s390x architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -513,12 +513,17 @@ endif()
 # Boost
 option(WITH_SYSTEM_BOOST "require and build with system Boost" OFF)
 
+# Boost::thread depends on Boost::atomic, so list it explicitly.
 set(BOOST_COMPONENTS
-	thread system regex random program_options date_time iostreams coroutine context)
+  atomic thread system regex random program_options date_time iostreams)
 set(BOOST_HEADER_COMPONENTS container)
 
 if(WITH_MGR)
 	list(APPEND BOOST_COMPONENTS python)
+endif()
+
+if(WITH_RADOSGW_BEAST_FRONTEND)
+	list(APPEND BOOST_COMPONENTS coroutine context)
 endif()
 
 if (WITH_SYSTEM_BOOST)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -857,6 +857,11 @@ cmake .. \
 %if 0%{with ocf}
     -DWITH_OCF=ON \
 %endif
+%ifarch aarch64 armv7hl mips mipsel ppc ppc64 ppc64le %{ix86} x86_64
+    -DWITH_RADOSGW_BEAST_FRONTEND=ON \
+%else
+    -DWITH_RADOSGW_BEAST_FRONTEND=OFF \
+%endif
     -DBOOST_J=%{_smp_ncpus}
 
 make %{?_smp_mflags}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -23,11 +23,10 @@
 %endif
 %bcond_with make_check
 %bcond_with xio
-%ifnarch s390 s390x
-%bcond_without tcmalloc
-%else
-# no gperftools/tcmalloc on s390(x)
+%ifarch s390 s390x
 %bcond_with tcmalloc
+%else
+%bcond_without tcmalloc
 %endif
 %bcond_with lowmem_builder
 %if 0%{?fedora} || 0%{?rhel}

--- a/debian/rules
+++ b/debian/rules
@@ -22,6 +22,13 @@ ifeq ($(DEB_HOST_ARCH), armel)
   extraopts += -DWITH_ATOMIC_OPS=OFF
 endif
 
+ifneq (,$(filter $(DEB_HOST_ARCH), arm armel armhf arm64 i386 amd64 mips mipsel powerpc ppc64))
+  # beast depends on libboost_context which only support the archs above
+  extraopts += -DWITH_RADOSGW_BEAST_FRONTEND=ON
+else
+  extraopts += -DWITH_RADOSGW_BEAST_FRONTEND=OFF
+endif
+
 %:
 	dh $@ --buildsystem=cmake --with javahelper,python2,python3,systemd --parallel
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -637,7 +637,6 @@ install(TARGETS ceph-common DESTINATION ${CMAKE_INSTALL_PKGLIBDIR})
 
 add_library(common_utf8 STATIC common/utf8.c)
 
-target_link_libraries(common json_spirit common_utf8 erasure_code rt uuid resolv ${CRYPTO_LIBS} ${Boost_LIBRARIES} ${BLKID_LIBRARIES} ${EXECINFO_LIBRARIES} ${BLKIN_LIBRARIES})
 if(${WITH_LTTNG})
   add_subdirectory(tracing)
   add_dependencies(common-objs oprequest-tp)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -174,7 +174,7 @@ target_link_libraries(radosgw radosgw_a librados
   cls_log_client cls_statelog_client cls_timeindex_client
   cls_version_client cls_replica_log_client cls_user_client
   global ${FCGI_LIBRARY} ${LIB_RESOLV}
-  ${CURL_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
+  ${CURL_LIBRARIES} ${Boost_LIBRARIES} ${EXPAT_LIBRARIES} ${BLKID_LIBRARIES}
   ${ALLOC_LIBS})
 # radosgw depends on cls libraries at runtime, but not as link dependencies
 add_dependencies(radosgw cls_rgw cls_lock cls_refcount


### PR DESCRIPTION
Fix for http://tracker.ceph.com/issues/20048

Problem solved by this PR: boost::component is not supported on s390x architecture, breaking the s390x build.

Also, it's a Good Idea in general to tie dependencies to the code that actually uses them.

(N.B.: Ceph is being built on s390x only so Linux VMs on the mainframe can function as Ceph clients.)