### PR TITLE
mon/MonClient: cancel pending commands on shutdown

### DIFF
--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -408,7 +408,10 @@ void MonClient::shutdown()
     delete version_requests.begin()->second;
     version_requests.erase(version_requests.begin());
   }
-
+  while (!mon_commands.empty()) {
+    auto tid = mon_commands.begin()->first;
+    _cancel_mon_command(tid);
+  }
   while (!waiting_for_session.empty()) {
     ldout(cct, 20) << __func__ << " discarding pending message " << *waiting_for_session.front() << dendl;
     waiting_for_session.front()->put();

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -1003,7 +1003,7 @@ void MonClient::handle_mon_command_ack(MMonCommandAck *ack)
   ack->put();
 }
 
-int MonClient::_cancel_mon_command(uint64_t tid, int r)
+int MonClient::_cancel_mon_command(uint64_t tid)
 {
   assert(monc_lock.is_locked());
 
@@ -1053,7 +1053,7 @@ void MonClient::start_mon_command(const vector<string>& cmd,
       public:
       C_CancelMonCommand(uint64_t tid, MonClient *monc) : tid(tid), monc(monc) {}
       void finish(int r) override {
-	monc->_cancel_mon_command(tid, -ETIMEDOUT);
+	monc->_cancel_mon_command(tid);
       }
     };
     r->ontimeout = new C_CancelMonCommand(r->tid, this);

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -432,7 +432,7 @@ private:
 
   void _send_command(MonCommand *r);
   void _resend_mon_commands();
-  int _cancel_mon_command(uint64_t tid, int r);
+  int _cancel_mon_command(uint64_t tid);
   void _finish_command(MonCommand *r, int ret, string rs);
   void _finish_auth();
   void handle_mon_command_ack(MMonCommandAck *ack);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20051