### PR TITLE
os/bluestore: write "mkfs_done" into disk only if we pass fsck() tests

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4880,12 +4880,6 @@ int BlueStore::mkfs()
     }
   }
 
-  // indicate success by writing the 'mkfs_done' file
-  r = write_meta("mkfs_done", "yes");
-  if (r < 0)
-    goto out_close_alloc;
-  dout(10) << __func__ << " success" << dendl;
-
  out_close_alloc:
   _close_alloc();
  out_close_fm:
@@ -4909,8 +4903,16 @@ int BlueStore::mkfs()
       r = -EIO;
     }
   }
+
+  if (r == 0) {
+    // indicate success by writing the 'mkfs_done' file
+    r = write_meta("mkfs_done", "yes");
+  }
+
   if (r < 0) {
     derr << __func__ << " failed, " << cpp_strerror(r) << dendl;
+  } else {
+    dout(0) << __func__ << " success" << dendl;
   }
   return r;
 }


### PR DESCRIPTION
 In our local test bed, we found mkfs() sometimes can fail
due to errors discovered by fsck(), and is therefore unrecoverable
by redoing mkfs() as the "mkfs_done" flag has been  already successfully saved into disk.

This patch fixes the above case.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>