### PR TITLE
librbd: discard related IO should skip op if object non-existent

### DIFF
--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -478,6 +478,8 @@ public:
     return true;
   }
 
+  void send_write() override;
+
 protected:
   void add_write_ops(librados::ObjectWriteOperation *wr,
                      bool set_hints) override {

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -1879,12 +1879,13 @@ TEST_F(TestLibRBD, TestEmptyDiscard)
   int order = 0;
   std::string name = get_temp_image_name();
   uint64_t size = 20 << 20;
-  
+
   ASSERT_EQ(0, create_image(ioctx, name.c_str(), size, &order));
   ASSERT_EQ(0, rbd_open(ioctx, name.c_str(), &image, NULL));
 
   ASSERT_PASSED(aio_discard_test_data, image, 0, 1*1024*1024);
   ASSERT_PASSED(aio_discard_test_data, image, 0, 4*1024*1024);
+  ASSERT_PASSED(aio_discard_test_data, image, 3*1024*1024, 1*1024*1024);
 
   ASSERT_PASSED(validate_object_map, image);
   ASSERT_EQ(0, rbd_close(image));


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19962
Signed-off-by: Mykola Golub <mgolub@mirantis.com>