### PR TITLE
ceph-disk: fix udev trigger on OSDs with separate /var mounts

### DIFF
--- a/udev/95-ceph-osd.rules
+++ b/udev/95-ceph-osd.rules
@@ -3,7 +3,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-062c0ceff05d", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-062c0ceff05d", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -13,7 +14,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-b4b80ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-b4b80ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -23,7 +25,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-b4b80ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-b4b80ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -33,7 +36,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="30cd0809-c2b2-499c-8879-2d6b78529876", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="30cd0809-c2b2-499c-8879-2d6b78529876", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -43,7 +47,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="5ce17fce-4087-4169-b7ff-056cc58473f9", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="5ce17fce-4087-4169-b7ff-056cc58473f9", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -53,7 +58,8 @@ ACTION=="add", SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="fb3aabf9-d25f-47cc-bf5e-721d1816496b", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="fb3aabf9-d25f-47cc-bf5e-721d1816496", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -62,7 +68,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-8ae0-4982-bf9d-5a8d867af560", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-8ae0-4982-bf9d-5a8d867af560", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -71,7 +78,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-8ae0-4982-bf9d-5a8d867af560", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-8ae0-4982-bf9d-5a8d867af560", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -80,7 +88,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-8ae0-4982-bf9d-5a8d867af560", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-8ae0-4982-bf9d-5a8d867af560", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -89,7 +98,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="ec6d6385-e346-45dc-be91-da2a7c8b3261", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="ec6d6385-e346-45dc-be91-da2a7c8b3261", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -98,7 +108,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="01b41e1b-002a-453c-9f17-88793989ff8f", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="01b41e1b-002a-453c-9f17-88793989ff8f", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -107,7 +118,8 @@ ACTION=="change", SUBSYSTEM=="block", \
 ACTION=="add", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="7f4a666a-16f3-47a2-8445-152ef4d03f6c", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="7f4a666a-16f3-47a2-8445-152ef4d03f6c", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -117,7 +129,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-5ec00ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-5ec00ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -127,7 +140,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-5ec00ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-5ec00ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -137,7 +151,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="93b0052d-02d9-4d8a-a43b-33a3ee4dfbc3", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="93b0052d-02d9-4d8a-a43b-33a3ee4dfbc3", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -147,7 +162,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="306e8683-4fe2-4330-b7c0-00a917c16966", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="306e8683-4fe2-4330-b7c0-00a917c16966", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -157,7 +173,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-35865ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="45b0969e-9b03-4f30-b4c6-35865ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -167,7 +184,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-35865ceff106", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="cafecafe-9b03-4f30-b4c6-35865ceff106", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -177,7 +195,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="166418da-c469-4022-adf4-b30afd37f176", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="166418da-c469-4022-adf4-b30afd37f176", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -187,7 +206,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="86a32090-3647-40b9-bbbd-38d8c573aa86", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="86a32090-3647-40b9-bbbd-38d8c573aa86", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -197,7 +217,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-5ec00ceff05d", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-5ec00ceff05d", \
   OWNER="ceph", GROUP="ceph", MODE="660"
@@ -207,7 +228,8 @@ ACTION=="add" SUBSYSTEM=="block", \
   ENV{DEVTYPE}=="partition", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-35865ceff05d", \
   OWNER:="ceph", GROUP:="ceph", MODE:="660", \
-  RUN+="/usr/sbin/ceph-disk --log-stdout -v trigger /dev/$name"
+  PROGRAM="/usr/bin/systemd-escape -p --template=ceph-disk@.service /dev/$name", \
+  ENV{SYSTEMD_WANTS}+="%c"
 ACTION=="change", SUBSYSTEM=="block", \
   ENV{ID_PART_ENTRY_TYPE}=="4fbd7e29-9d25-41b8-afd0-35865ceff05d", \
   OWNER="ceph", GROUP="ceph", MODE="660"


### PR DESCRIPTION
/usr/sbin/ceph-disk unconditionally calls setup_statedir() during
initialisation, which manipulates /var/lib/ceph/tmp. This may be
done before /var is mounted, as it is triggered directly from udev
once the OSD data/journal partition appears, regardless of the state
of local filesystem mounts.

The ceph-disk@{dev} systemd service includes an After=local-fs.target
directive to ensure that it won't run before an external /var is
mounted.
Initiate this service directly from udev, rather than doing so via
a "/usr/sbin/ceph-disk trigger" invocation.

Fixes: http://tracker.ceph.com/issues/19941

Signed-off-by: David Disseldorp <ddiss@suse.de>