### PR TITLE
msg: don't set msgr addr when disabing client bind

### DIFF
--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -412,6 +412,8 @@ int AsyncMessenger::rebind(const set<int>& avoid_ports)
 
 int AsyncMessenger::client_bind(const entity_addr_t &bind_addr)
 {
+  if (!cct->_conf->ms_bind_before_connect)
+    return 0;
   Mutex::Locker l(lock);
   if (did_bind) {
     assert(my_inst.addr == bind_addr);

--- a/src/msg/simple/SimpleMessenger.cc
+++ b/src/msg/simple/SimpleMessenger.cc
@@ -309,6 +309,8 @@ int SimpleMessenger::rebind(const set<int>& avoid_ports)
 
 int SimpleMessenger::client_bind(const entity_addr_t &bind_addr)
 {
+  if (!cct->_conf->ms_bind_before_connect)
+    return 0;
   Mutex::Locker l(lock);
   if (did_bind) {
     assert(my_inst.addr == bind_addr);


### PR DESCRIPTION
if disabling client bind, client side will send handshake message with blank
ip. so the server side will ignore this.

otherwise, server side decide to learn this addr which isn't the expected addr

Signed-off-by: Haomai Wang <haomai@xsky.com>