### PR TITLE
crush/CrushWrapper: fix has_incompat_choose_args()

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -112,6 +112,8 @@ bool CrushWrapper::has_choose_args() const
 
 bool CrushWrapper::has_incompat_choose_args() const
 {
+  if (choose_args.empty())
+    return false;
   if (choose_args.size() > 1)
     return true;
   crush_choose_arg_map arg_map = choose_args.begin()->second;


### PR DESCRIPTION
Special case empty and return false.  Otherwise the rest of the method
will dereference an invalid iterator on an empty choose_args
map.

Fixes broken fix in b1e4295570b6af4d844cf3ec55d77f5c287b29e6.

Signed-off-by: Sage Weil <sage@redhat.com>