### PR TITLE
qa/suites/rados/*/at-end: wait for healthy before scrubbing

### DIFF
--- a/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
+++ b/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
@@ -8,6 +8,7 @@ tasks:
         - ceph osd set require_luminous_osds
 # make sure osds have latest map
         - rados -p rbd bench 5 write -b 4096
+  - ceph.healthy:
   - ceph.osd_scrub_pgs:
       cluster: ceph
   - exec:


### PR DESCRIPTION
The scrub_pgs command also waits for healthy for a while, but fails
silently if it times out, which means the subsequent scrubs will also
fail to clean up.

This forces an earlier failure that does not obscure the root cause.

Signed-off-by: Sage Weil <sage@redhat.com>