### PR TITLE
rgw_file: release rgw_fh lock and ref on ENOTEMPTY

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -273,7 +273,9 @@ namespace rgw {
       /* a bucket may have an object storing Unix attributes, check
        * for and delete it */
       LookupFHResult fhr;
-      fhr = stat_bucket(parent, name, bs, RGWFileHandle::FLAG_LOCKED);
+      fhr = stat_bucket(parent, name, bs, (rgw_fh) ?
+			RGWFileHandle::FLAG_LOCKED :
+			RGWFileHandle::FLAG_NONE);
       bkt_fh = get<0>(fhr);
       if (unlikely(! bkt_fh)) {
 	/* implies !rgw_fh, so also !LOCKED */
@@ -281,7 +283,14 @@ namespace rgw {
       }
 
       if (bs.num_entries > 1) {
-	unref(bkt_fh); /* return extra ref */
+	unref(bkt_fh); /* return stat_bucket ref */
+	if (likely(!! rgw_fh)) { /* return lock and ref from
+				  * lookup_fh (or caller in the
+				  * special case of
+				  * RGWFileHandle::FLAG_UNLINK_THIS) */
+	  rgw_fh->mtx.unlock();
+	  unref(rgw_fh);
+	}
 	return -ENOTEMPTY;
       } else {
 	/* delete object w/key "<bucket>/" (uxattrs), if any */


### PR DESCRIPTION
An early return in new unlink bucket num_entries check was
missing a conditional unlock and unref.

Fixes: http://tracker.ceph.com/issues/20061

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>