### PR TITLE
rgw: usage log drop unused var

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -554,22 +554,19 @@ WRITE_CLASS_ENCODER(rgw_cls_obj_check_mtime)
 
 struct rgw_cls_usage_log_add_op {
   rgw_usage_log_info info;
-  rgw_user user;
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(2, 1, bl);
+    ENCODE_START(3, 3, bl);
     ::encode(info, bl);
-    ::encode(user.to_str(), bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(2, bl);
+    DECODE_START(3, bl);
     ::decode(info, bl);
-    if (struct_v >= 2) {
+    if (struct_v == 2) {
       string s;
       ::decode(s, bl);
-      user.from_str(s);
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
During impl [rgw: subuser usage log statistics](https://github.com/ceph/ceph/pull/15064) ,I've encountered this. 

@yehudasa is this kind of  cleanup safe?

CC: @rzarzynski