### PR TITLE
pybind/mgr/fsstatus: use mds_mem.dn as dentry counter

### DIFF
--- a/src/pybind/mgr/fsstatus/module.py
+++ b/src/pybind/mgr/fsstatus/module.py
@@ -122,7 +122,7 @@ class Module(MgrModule):
                 if up:
                     gid = mdsmap['up']["mds_{0}".format(rank)]
                     info = mdsmap['info']['gid_{0}'.format(gid)]
-                    dns = self.get_latest("mds", info['name'], "mds.inodes")
+                    dns = self.get_latest("mds", info['name'], "mds_mem.dn")
                     inos = self.get_latest("mds", info['name'], "mds_mem.ino")
 
                     if rank == 0:
@@ -175,7 +175,7 @@ class Module(MgrModule):
                     continue
 
                 inos = self.get_latest("mds", daemon_info['name'], "mds_mem.ino")
-                dns = self.get_latest("mds", daemon_info['name'], "mds.inodes")
+                dns = self.get_latest("mds", daemon_info['name'], "mds_mem.dn")
 
                 activity = "Evts: " + self.format_dimless(
                     self.get_rate("mds", daemon_info['name'], "mds_log.replay"),


### PR DESCRIPTION
Occasionally mds.inodes is not equal to mds_mem.dn. As dentry counter in mgr fs status, mds_mem.dn is more clear and accurate than mds.inodes. 

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>