### PR TITLE
mds: fix client ID truncation

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3079,7 +3079,7 @@ int CInode::encode_inodestat(bufferlist& bl, Session *session,
 			     unsigned max_bytes,
 			     int getattr_caps)
 {
-  int client = session->info.inst.name.num();
+  client_t client = session->info.inst.name.num();
   assert(snapid);
   assert(session->connection);
   

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -1853,7 +1853,7 @@ Capability* Locker::issue_new_caps(CInode *in,
 
   // my needs
   assert(session->info.inst.name.is_client());
-  int my_client = session->info.inst.name.num();
+  client_t my_client = session->info.inst.name.num();
   int my_want = ceph_caps_for_mode(mode);
 
   // register a capability


### PR DESCRIPTION
'int' causes value truncation since client ID is int64_t. It will cause problems in a long-lived cluster.
