### PR TITLE
rgw: update bucket cors in secondary zonegroup should forward to master

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4678,6 +4678,14 @@ void RGWPutCORS::execute()
   if (op_ret < 0)
     return;
 
+  if (!store->is_meta_master()) {
+    op_ret = forward_request_to_master(s, NULL, store, in_data, nullptr);
+    if (op_ret < 0) {
+      ldout(s->cct, 20) << __func__ << "forward_request_to_master returned ret=" << op_ret << dendl;
+      return;
+    }
+  }
+
   map<string, bufferlist> attrs = s->bucket_attrs;
   attrs[RGW_ATTR_CORS] = cors_bl;
   op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs, &s->bucket_info.objv_tracker);

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1423,6 +1423,7 @@ public:
 class RGWPutCORS : public RGWOp {
 protected:
   bufferlist cors_bl;
+  bufferlist in_data;
 
 public:
   RGWPutCORS() {}

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2130,6 +2130,12 @@ int RGWPutCORS_ObjStore_S3::get_params()
     return -EINVAL;
   }
 
+  // forward bucket cors requests to meta master zone
+  if (!store->is_meta_master()) {
+    /* only need to keep this data around if we're not meta master */
+    in_data.append(data, len);
+  }
+
   if (s->cct->_conf->subsys.should_gather(ceph_subsys_rgw, 15)) {
     ldout(s->cct, 15) << "CORSConfiguration";
     cors_config->to_xml(*_dout);

--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -14,6 +14,7 @@ from itertools import combinations
 import boto
 import boto.s3.connection
 from boto.s3.website import WebsiteConfiguration
+from boto.s3.cors import CORSConfiguration
 
 from nose.tools import eq_ as eq
 from nose.plugins.attrib import attr
@@ -654,6 +655,14 @@ def test_bucket_acl():
         assert(len(bucket.get_acl().acl.grants) == 1) # single grant on owner
         bucket.set_acl('public-read')
         assert(len(bucket.get_acl().acl.grants) == 2) # new grant on AllUsers
+
+def test_bucket_cors():
+    buckets, zone_bucket = create_bucket_per_zone_in_realm()
+    for _, bucket in zone_bucket:
+        cors_cfg = CORSConfiguration()
+        cors_cfg.add_rule(['DELETE'], 'https://www.example.com', allowed_header='*', max_age_seconds=3000)
+        bucket.set_cors(cors_cfg)
+        assert(bucket.get_cors().to_xml() == cors_cfg.to_xml())
 
 def test_bucket_delete_notempty():
     zonegroup = realm.master_zonegroup()


### PR DESCRIPTION
#14082 is incomplete, cors should be redirect to master

Fixes: http://tracker.ceph.com/issues/16888

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>