### PR TITLE
RGW: Add more information to the "req done" log message

### DIFF
--- a/src/rgw/rgw_process.cc
+++ b/src/rgw/rgw_process.cc
@@ -123,7 +123,7 @@ int process_request(RGWRados* const store,
 
   req->log_init();
 
-  dout(1) << "====== starting new request req=" << hex << req << dec
+  dout(2) << "====== starting new request req=" << hex << req << dec
 	  << " =====" << dendl;
   perfcounter->inc(l_rgw_req);
 
@@ -229,10 +229,18 @@ done:
     handler->put_op(op);
   rest->put_handler(handler);
 
-  dout(1) << "====== req done req=" << hex << req << dec
-	  << " op status=" << op_ret
-	  << " http_status=" << http_ret
+  dout(2) << "====== req done req=" << hex << req << dec
 	  << " ======"
+	  << dendl;
+  dout(1) << "processed op status=" << op_ret
+	  << " op_name=" << (op ? op->name() : "unknown")
+	  << " user_id=" << (s->user ? s->user->user_id.to_str() : "")
+	  << " http_status=" << http_ret
+	  << " domain=" << s->info.domain
+	  << " request_uri=" << s->info.request_uri
+	  << " request_params=" << s->info.request_params
+	  << " obj_size=" << s->obj_size
+	  << " duration=" << req->get_elapsed_time()
 	  << dendl;
 
   return (ret < 0 ? ret : s->err.ret);

--- a/src/rgw/rgw_request.cc
+++ b/src/rgw/rgw_request.cc
@@ -25,6 +25,10 @@ void RGWRequest::log_init() {
   ts = ceph_clock_now();
 }
 
+utime_t RGWRequest::get_elapsed_time() {
+  return ceph_clock_now() - ts;
+}
+
 void RGWRequest::log(struct req_state *s, const char *msg) {
   if (s->info.method && req_str.size() == 0) {
     req_str = s->info.method;

--- a/src/rgw/rgw_request.h
+++ b/src/rgw/rgw_request.h
@@ -35,6 +35,7 @@ struct RGWRequest
 
   void log_format(struct req_state *s, const char *fmt, ...);
   void log_init();
+  utime_t get_elapsed_time();
   void log(struct req_state *s, const char *msg);
 }; /* RGWRequest */
 


### PR DESCRIPTION
As discussed in [1], add some further information when logging a finished
request in rgw:

- op_name
- user_id
- domain
- request_uri
- duration

In the end it would be nice to aggregate all this information together
with the additional data that civetweb is keeping, in particular
remote_addr and num_bytes_sent, but this seems useful as a first step.

[1] http://tracker.ceph.com/issues/19917

Signed-off-by: Jens Rosenboom <j.rosenboom@x-ion.de>