### PR TITLE
osd: Preserve OSDOp information for historic ops

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -559,7 +559,7 @@ struct ceph_osd_request_head {
   }
 
   void clear_buffers() override {
-    ops.clear();
+    OSDOp::clear_data(ops);
   }
 
   const char *get_type_name() const override { return "osd_op"; }

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -5878,3 +5878,33 @@ ostream& operator<<(ostream& out, const store_statfs_t &s)
       << ")";
   return out;
 }
+
+void OSDOp::clear_data(vector<OSDOp>& ops)
+{
+  for (unsigned i = 0; i < ops.size(); i++) {
+    OSDOp& op = ops[i];
+    op.outdata.clear();
+    if (ceph_osd_op_type_attr(op.op.op) &&
+        op.op.xattr.name_len &&
+	op.indata.length() >= op.op.xattr.name_len) {
+      bufferptr bp(op.op.xattr.name_len);
+      bufferlist bl;
+      bl.append(bp);
+      bl.copy_in(0, op.op.xattr.name_len, op.indata);
+      op.indata.claim(bl);
+    } else if (ceph_osd_op_type_exec(op.op.op) &&
+               op.op.cls.class_len &&
+	       op.indata.length() >
+	         (op.op.cls.class_len + op.op.cls.method_len)) {
+      __u8 len = op.op.cls.class_len + op.op.cls.method_len;
+      bufferptr bp(len);
+      bufferlist bl;
+      bl.append(bp);
+      bl.copy_in(0, len, op.indata);
+      op.indata.claim(bl);
+    } else {
+      op.indata.clear();
+    }
+  }
+}
+

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4777,6 +4777,13 @@ struct OSDOp {
    * @param out [out] combined data buffer
    */
   static void merge_osd_op_vector_out_data(vector<OSDOp>& ops, bufferlist& out);
+
+  /**
+   * Clear data as much as possible, leave minimal data for historical op dump
+   *
+   * @param ops [in] vector of OSDOps
+   */
+  static void clear_data(vector<OSDOp>& ops);
 };
 
 ostream& operator<<(ostream& out, const OSDOp& op);


### PR DESCRIPTION
clear_buffers() actually clears all OSDOp informations, so that we can only see empty ops with `dump_historic_ops`. This commit keeps the op information, and only minimal buffers for printing op information.