### PR TITLE
os/bluestore: fix false assert in IOContext::aio_wake

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -29,6 +29,11 @@
 
 /// track in-flight io
 struct IOContext {
+private:
+  std::mutex lock;
+  std::condition_variable cond;
+
+public:
   CephContext* cct;
   void *priv;
 #ifdef HAVE_SPDK
@@ -36,8 +41,6 @@ struct IOContext {
   void *nvme_task_last = nullptr;
 #endif
 
-  std::mutex lock;
-  std::condition_variable cond;
 
   std::list<aio_t> pending_aios;    ///< not yet submitted
   std::list<aio_t> running_aios;    ///< submitting or submitted
@@ -58,11 +61,15 @@ struct IOContext {
 
   void aio_wait();
 
-  void aio_wake() {
-    std::lock_guard<std::mutex> l(lock);
-    cond.notify_all();
-    --num_running;
-    assert(num_running == 0);
+  void try_aio_wake() {
+    if (num_running == 1) {
+      std::lock_guard<std::mutex> l(lock);
+      cond.notify_all();
+      --num_running;
+      assert(num_running == 0);
+    } else {
+      --num_running;
+    }
   }
 };
 

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -63,10 +63,15 @@ public:
 
   void try_aio_wake() {
     if (num_running == 1) {
+
+      // we might have some pending IOs submitted after the check
+      // as there is no lock protection for aio_submit.
+      // Hence we might have false conditional trigger.
+      // aio_wait has to handle that hence do not care here.
       std::lock_guard<std::mutex> l(lock);
       cond.notify_all();
       --num_running;
-      assert(num_running == 0);
+      assert(num_running >= 0);
     } else {
       --num_running;
     }

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -380,7 +380,7 @@ void KernelDevice::_aio_thread()
 	    aio_callback(aio_callback_priv, ioc->priv);
 	  }
 	} else {
-            ioc->try_aio_wake();
+          ioc->try_aio_wake();
 	}
       }
     }

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -380,11 +380,7 @@ void KernelDevice::_aio_thread()
 	    aio_callback(aio_callback_priv, ioc->priv);
 	  }
 	} else {
-	  if (ioc->num_running == 1) {
-	    ioc->aio_wake();
-	  } else {
-	    --ioc->num_running;
-	  }
+            ioc->try_aio_wake();
 	}
       }
     }

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -816,11 +816,7 @@ void io_complete(void *t, const struct spdk_nvme_cpl *completion)
         task->device->aio_callback(task->device->aio_callback_priv, ctx->priv);
       }
     } else {
-      if (ctx->num_running == 1) {
-	ctx->aio_wake();
-      } else {
-	--ctx->num_running;
-      }
+      ctx->try_aio_wake();
     }
     task->release_segs(queue);
     delete task;
@@ -837,11 +833,7 @@ void io_complete(void *t, const struct spdk_nvme_cpl *completion)
           task->device->aio_callback(task->device->aio_callback_priv, ctx->priv);
 	}
       } else {
-	if (ctx->num_running == 1) {
-	  ctx->aio_wake();
-	} else {
-	  --ctx->num_running;
-	}
+	ctx->try_aio_wake();
       }
       delete task;
     } else {


### PR DESCRIPTION
IOContext::aio_wake might assert improperly on (num_running == 0) due to the race between aio_wake and aio_submit. In fact that's a false assertion hence making it less strict. Some cleanup around aio_wake as well.
