### PR TITLE
rgw: list_objects() honors end_marker regardless of namespace.

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5556,17 +5556,13 @@ int RGWRados::Bucket::List::list_objects(int64_t max,
   result->clear();
 
   rgw_obj_key marker_obj(params.marker.name, params.marker.instance, params.ns);
-
-  rgw_obj_key end_marker_obj;
-  rgw_obj_index_key cur_end_marker;
-  if (!params.ns.empty()) {
-    end_marker_obj = rgw_obj_key(params.end_marker.name, params.end_marker.instance, params.ns);
-    end_marker_obj.ns = params.ns;
-    end_marker_obj.get_index_key(&cur_end_marker);
-  }
   rgw_obj_index_key cur_marker;
   marker_obj.get_index_key(&cur_marker);
 
+  rgw_obj_key end_marker_obj(params.end_marker.name, params.end_marker.instance,
+                             params.ns);
+  rgw_obj_index_key cur_end_marker;
+  end_marker_obj.get_index_key(&cur_end_marker);
   const bool cur_end_marker_valid = !params.end_marker.empty();
 
   rgw_obj_key prefix_obj(params.prefix);


### PR DESCRIPTION
This patch fixes a regression related to handling of the `end_marker` parameter during Swift's container listing operation. It has been introduced in a5d1fa0587184f43c69d8e03114b58d43f320781 and causes Tempest's `test_list_container_contents_with_end_marker` to fail.

Fixes: http://tracker.ceph.com/issues/18977
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>