### PR TITLE
qa/suites/rados/singleton-nomsgr: fix syntax

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -8,6 +8,8 @@ tasks:
 # we may land on ext4
         osd max object name len: 400
         osd max object namespace len: 64
+    log-whitelist:
+      - wrongly marked me down
 - workunit:
     clients:
       all:

--- a/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/health-warnings.yaml
@@ -6,8 +6,8 @@ tasks:
     conf:
       osd:
 # we may land on ext4
-        osd max object name len = 400
-        osd max object namespace len = 64
+        osd max object name len: 400
+        osd max object namespace len: 64
 - workunit:
     clients:
       all:


### PR DESCRIPTION
This parsed out as

<pre>
  tasks:
  - install: null
  - ceph:
      conf:
        osd: osd max object name len = 400 osd max object namespace len = 64
  - workunit:
      clients:
        all:
        - rados/test_health_warnings.sh
</pre>
which is clearly not correct.

Signed-off-by: Sage Weil <sage@redhat.com>