### PR TITLE
mds: change the type of data_pools

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -237,7 +237,7 @@ void FSMap::create_filesystem(const std::string &name,
   auto fs = std::make_shared<Filesystem>();
   fs->mds_map.fs_name = name;
   fs->mds_map.max_mds = 1;
-  fs->mds_map.data_pools.insert(data_pool);
+  fs->mds_map.data_pools.push_back(data_pool);
   fs->mds_map.metadata_pool = metadata_pool;
   fs->mds_map.cas_pool = -1;
   fs->mds_map.max_file_size = g_conf->mds_max_file_size;
@@ -408,7 +408,7 @@ void FSMap::decode(bufferlist::iterator& p)
       while (n--) {
         __u32 m;
         ::decode(m, p);
-        legacy_mds_map.data_pools.insert(m);
+        legacy_mds_map.data_pools.push_back(m);
       }
       __s32 s;
       ::decode(s, p);

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -178,8 +178,8 @@ void MDSMap::dump(Formatter *f) const
   }
   f->close_section();
   f->open_array_section("data_pools");
-  for (set<int64_t>::const_iterator p = data_pools.begin(); p != data_pools.end(); ++p)
-    f->dump_int("pool", *p);
+  for (const auto p: data_pools)
+    f->dump_int("pool", p);
   f->close_section();
   f->dump_int("metadata_pool", metadata_pool);
   f->dump_bool("enabled", enabled);
@@ -192,7 +192,7 @@ void MDSMap::generate_test_instances(list<MDSMap*>& ls)
 {
   MDSMap *m = new MDSMap();
   m->max_mds = 1;
-  m->data_pools.insert(0);
+  m->data_pools.push_back(0);
   m->metadata_pool = 1;
   m->cas_pool = 2;
   m->compat = get_mdsmap_compat_set_all();
@@ -498,8 +498,8 @@ void MDSMap::encode(bufferlist& bl, uint64_t features) const
     }
     n = data_pools.size();
     ::encode(n, bl);
-    for (set<int64_t>::const_iterator p = data_pools.begin(); p != data_pools.end(); ++p) {
-      n = *p;
+    for (const auto p: data_pools) {
+      n = p;
       ::encode(n, bl);
     }
 
@@ -603,7 +603,7 @@ void MDSMap::decode(bufferlist::iterator& p)
     while (n--) {
       __u32 m;
       ::decode(m, p);
-      data_pools.insert(m);
+      data_pools.push_back(m);
     }
     __s32 s;
     ::decode(s, p);

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -25,6 +25,7 @@
 #include <set>
 #include <map>
 #include <string>
+#include <algorithm>
 
 #include "common/config.h"
 
@@ -178,7 +179,7 @@ protected:
   __u32 session_autoclose;
   uint64_t max_file_size;
 
-  std::set<int64_t> data_pools;  // file data pools available to clients (via an ioctl).  first is the default.
+  std::vector<int64_t> data_pools;  // file data pools available to clients (via an ioctl).  first is the default.
   int64_t cas_pool;            // where CAS objects go
   int64_t metadata_pool;       // where fs metadata objects go
   
@@ -309,11 +310,11 @@ public:
   mds_rank_t get_tableserver() const { return tableserver; }
   mds_rank_t get_root() const { return root; }
 
-  const std::set<int64_t> &get_data_pools() const { return data_pools; }
+  const std::vector<int64_t> &get_data_pools() const { return data_pools; }
   int64_t get_first_data_pool() const { return *data_pools.begin(); }
   int64_t get_metadata_pool() const { return metadata_pool; }
   bool is_data_pool(int64_t poolid) const {
-    return data_pools.count(poolid);
+    return std::binary_search(data_pools.begin(), data_pools.end(), poolid);
   }
 
   bool pool_in_use(int64_t poolid) const {
@@ -364,10 +365,10 @@ public:
 
   // data pools
   void add_data_pool(int64_t poolid) {
-    data_pools.insert(poolid);
+    data_pools.push_back(poolid);
   }
   int remove_data_pool(int64_t poolid) {
-    std::set<int64_t>::iterator p = data_pools.find(poolid);
+    std::vector<int64_t>::iterator p = std::find(data_pools.begin(), data_pools.end(), poolid);
     if (p == data_pools.end())
       return -ENOENT;
     data_pools.erase(p);

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -515,7 +515,7 @@ void PurgeQueue::update_op_limit(const MDSMap &mds_map)
   uint64_t pg_count = 0;
   objecter->with_osdmap([&](const OSDMap& o) {
     // Number of PGs across all data pools
-    const std::set<int64_t> &data_pools = mds_map.get_data_pools();
+    const std::vector<int64_t> &data_pools = mds_map.get_data_pools();
     for (const auto dp : data_pools) {
       if (o.get_pg_pool(dp) == NULL) {
         // It is possible that we have an older OSDMap than MDSMap,

--- a/src/mds/SnapServer.cc
+++ b/src/mds/SnapServer.cc
@@ -166,11 +166,9 @@ bool SnapServer::_commit(version_t tid, MMDSTableRequest *req)
     dout(7) << "commit " << tid << " destroy " << sn << " seq " << seq << dendl;
     snaps.erase(sn);
 
-    for (set<int64_t>::const_iterator p = mds->mdsmap->get_data_pools().begin();
-	 p != mds->mdsmap->get_data_pools().end();
-	 ++p) {
-      need_to_purge[*p].insert(sn);
-      need_to_purge[*p].insert(seq);
+    for (const auto p : mds->mdsmap->get_data_pools()) {
+      need_to_purge[p].insert(sn);
+      need_to_purge[p].insert(seq);
     }
 
     pending_destroy.erase(tid);

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -152,9 +152,9 @@ class FsNewHandler : public FileSystemCommandHandler
     }
 
     for (auto fs : fsmap.get_filesystems()) {
-      const set<int64_t>& data_pools = fs->mds_map.get_data_pools();
+      const std::vector<int64_t> &data_pools = fs->mds_map.get_data_pools();
       string sure;
-      if ((data_pools.find(data) != data_pools.end()
+      if ((std::find(data_pools.begin(), data_pools.end(), data) != data_pools.end()
 	   || fs->mds_map.get_metadata_pool() == metadata)
 	  && ((!cmd_getval(g_ceph_context, cmdmap, "sure", sure)
 	       || sure != "--allow-dangerous-metadata-overlay"))) {

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -488,6 +488,12 @@ class AddDataPoolHandler : public FileSystemCommandHandler
       return r;
     }
 
+    // no-op when the data_pool already on fs
+    if (fs->mds_map.is_data_pool(poolid)) {
+      ss << "data pool " << poolid << " is already on fs " << fs_name;
+      return 0;
+    }
+
     fsmap.modify_filesystem(
         fs->fscid,
         [poolid](std::shared_ptr<Filesystem> fs)

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1071,9 +1071,8 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
         
         ds << "name: " << mds_map.fs_name << ", metadata pool: "
            << md_pool_name << ", data pools: [";
-        for (std::set<int64_t>::iterator dpi = mds_map.data_pools.begin();
-           dpi != mds_map.data_pools.end(); ++dpi) {
-          const string &pool_name = mon->osdmon()->osdmap.get_pool_name(*dpi);
+        for (auto dpi : mds_map.data_pools) {
+          const string &pool_name = mon->osdmon()->osdmap.get_pool_name(dpi);
           ds << pool_name << " ";
         }
         ds << "]" << std::endl;


### PR DESCRIPTION
In following scenario, we found something strange here.

Here we have two pools as following:

	- data_pool1    id: 20
	- data_pool2    id: 21

First, we create ceph fs with `data_pool2` and default data_pool is `data_pool2`.
Then, add the new data pool `data_pool1`.
Now, the default data_pool will be data_pool1.

Because set will sort, we can't remain the default data_pool as we wish.
(we assume that the default data_pool should be the data_pool that we create cephfs)

It seems vector is more suitable than set.
