### PR TITLE
test: Rename FileJournal object to distinguish

### DIFF
--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -120,9 +120,9 @@ TEST(TestFileJournal, Create) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
+    ASSERT_EQ(0, fj.create());
   }
 }
 
@@ -134,20 +134,20 @@ TEST(TestFileJournal, WriteSmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     vector<ObjectStore::Transaction> tls;
     bufferlist bl;
     bl.append("small");
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
-    j.close();
+    fj.close();
   }
 }
 
@@ -159,10 +159,10 @@ TEST(TestFileJournal, WriteBig) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     bufferlist bl;
     while (bl.length() < size_mb*1000/2) {
@@ -171,11 +171,11 @@ TEST(TestFileJournal, WriteBig) {
       bl.append(foo, sizeof(foo));
     }
     vector<ObjectStore::Transaction> tls;
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(1, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
-    j.close();
+    fj.close();
   }
 }
 
@@ -187,10 +187,10 @@ TEST(TestFileJournal, WriteMany) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
@@ -200,15 +200,15 @@ TEST(TestFileJournal, WriteMany) {
     uint64_t seq = 1;
     for (int i=0; i<100; i++) {
       bl.append("small");
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(seq++, bl, orig_len, gb.new_sub());
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(seq++, bl, orig_len, gb.new_sub());
     }
     gb.activate();
 
     wait();
 
-    j.close();
+    fj.close();
   }
 }
 
@@ -220,19 +220,19 @@ TEST(TestFileJournal, WriteManyVecs) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
     bufferlist first;
     first.append("small");
     vector<ObjectStore::Transaction> tls;
-    int orig_len = j.prepare_entry(tls, &first);
-    j.reserve_throttle_and_backoff(first.length());
-    j.submit_entry(1, first, orig_len, gb.new_sub());
+    int orig_len = fj.prepare_entry(tls, &first);
+    fj.reserve_throttle_and_backoff(first.length());
+    fj.submit_entry(1, first, orig_len, gb.new_sub());
 
     bufferlist bl;
     for (int i=0; i<IOV_MAX * 2; i++) {
@@ -241,23 +241,23 @@ TEST(TestFileJournal, WriteManyVecs) {
       bl.append(bp);
     }
     bufferlist origbl = bl;
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(2, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(2, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
-    j.close();
+    fj.close();
 
-    j.open(1);
+    fj.open(1);
     bufferlist inbl;
     string v;
     uint64_t seq = 0;
-    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 2ull);
     ASSERT_TRUE(inbl.contents_equal(origbl));
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
 
   }
 }
@@ -272,54 +272,54 @@ TEST(TestFileJournal, ReplaySmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
     bufferlist bl;
     bl.append("small");
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(1, bl, orig_len, gb.new_sub());
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(1, bl, orig_len, gb.new_sub());
     bl.append("small");
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(2, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(2, bl, orig_len, gb.new_sub());
     bl.append("small");
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(3, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(3, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
-    j.close();
+    fj.close();
 
-    j.open(1);
+    fj.open(1);
 
     bufferlist inbl;
     string v;
     uint64_t seq = 0;
-    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 2ull);
     inbl.copy(0, inbl.length(), v);
     ASSERT_EQ("small", v);
     inbl.clear();
     v.clear();
 
-    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 3ull);
     inbl.copy(0, inbl.length(), v);
     ASSERT_EQ("small", v);
     inbl.clear();
     v.clear();
 
-    ASSERT_TRUE(!j.read_entry(inbl, seq));
+    ASSERT_TRUE(!fj.read_entry(inbl, seq));
 
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
   }
 }
 
@@ -332,10 +332,10 @@ TEST(TestFileJournal, ReplayCorrupt) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
@@ -343,25 +343,25 @@ TEST(TestFileJournal, ReplayCorrupt) {
     const char *newneedle = "in a haystack";
     bufferlist bl;
     bl.append(needle);
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(1, bl, orig_len, gb.new_sub());
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(1, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(2, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(2, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(3, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(3, bl, orig_len, gb.new_sub());
     bl.append(needle);
-    orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(4, bl, orig_len, gb.new_sub());
+    orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(4, bl, orig_len, gb.new_sub());
     gb.activate();
     wait();
 
-    j.close();
+    fj.close();
 
     cout << "corrupting journal" << std::endl;
     char buf[1024*128];
@@ -389,23 +389,23 @@ TEST(TestFileJournal, ReplayCorrupt) {
     ASSERT_EQ(r, 0);
     close(fd);
 
-    j.open(1);
+    fj.open(1);
 
     bufferlist inbl;
     string v;
     uint64_t seq = 0;
-    ASSERT_EQ(true, j.read_entry(inbl, seq));
+    ASSERT_EQ(true, fj.read_entry(inbl, seq));
     ASSERT_EQ(seq, 2ull);
     inbl.copy(0, inbl.length(), v);
     ASSERT_EQ(needle, v);
     inbl.clear();
     v.clear();
     bool corrupt;
-    ASSERT_FALSE(j.read_entry(inbl, seq, &corrupt));
+    ASSERT_FALSE(fj.read_entry(inbl, seq, &corrupt));
     ASSERT_TRUE(corrupt);
 
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
   }
 }
 
@@ -417,10 +417,10 @@ TEST(TestFileJournal, WriteTrim) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     list<C_Sync*> ls;
 
@@ -436,27 +436,27 @@ TEST(TestFileJournal, WriteTrim) {
       bl.push_back(buffer::copy(foo, sizeof(foo)));
       bl.zero();
       ls.push_back(new C_Sync);
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(seq++, bl, orig_len, ls.back()->c);
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(seq++, bl, orig_len, ls.back()->c);
 
       while (ls.size() > size_mb/2) {
         delete ls.front();
         ls.pop_front();
         committed++;
-        j.committed_thru(committed);
+        fj.committed_thru(committed);
       }
     }
 
     while (ls.size()) {
       delete ls.front();
       ls.pop_front();
-      j.committed_thru(++committed);
+      fj.committed_thru(++committed);
     }
 
-    ASSERT_TRUE(j.journalq_empty());
+    ASSERT_TRUE(fj.journalq_empty());
 
-    j.close();
+    fj.close();
   }
 }
 
@@ -469,10 +469,10 @@ TEST(TestFileJournal, WriteTrimSmall) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     list<C_Sync*> ls;
 
@@ -488,25 +488,25 @@ TEST(TestFileJournal, WriteTrimSmall) {
         bl.push_back(buffer::copy(foo, sizeof(foo) / 128));
       bl.zero();
       ls.push_back(new C_Sync);
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(seq++, bl, orig_len, ls.back()->c);
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(seq++, bl, orig_len, ls.back()->c);
 
       while (ls.size() > size_mb/2) {
         delete ls.front();
         ls.pop_front();
         committed++;
-        j.committed_thru(committed);
+        fj.committed_thru(committed);
       }
     }
 
     while (ls.size()) {
       delete ls.front();
       ls.pop_front();
-      j.committed_thru(committed);
+      fj.committed_thru(committed);
     }
 
-    j.close();
+    fj.close();
   }
 }
 
@@ -519,10 +519,10 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
@@ -530,41 +530,41 @@ TEST(TestFileJournal, ReplayDetectCorruptFooterMagic) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(i, bl, orig_len, gb.new_sub());
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
-    j.close();
+    fj.close();
     int fd = open(path, O_WRONLY);
 
     cout << "corrupting journal" << std::endl;
-    j.open(0);
-    j.corrupt_footer_magic(fd, 2);
+    fj.open(0);
+    fj.corrupt_footer_magic(fd, 2);
 
     uint64_t seq = 0;
     bl.clear();
     bool corrupt = false;
-    bool result = j.read_entry(bl, seq, &corrupt);
+    bool result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_TRUE(result);
     ASSERT_EQ(seq, 1UL);
     ASSERT_FALSE(corrupt);
 
-    result = j.read_entry(bl, seq, &corrupt);
+    result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_FALSE(result);
     ASSERT_TRUE(corrupt);
 
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
     ::close(fd);
   }
 }
@@ -578,10 +578,10 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
@@ -589,41 +589,41 @@ TEST(TestFileJournal, ReplayDetectCorruptPayload) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(i, bl, orig_len, gb.new_sub());
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
-    j.close();
+    fj.close();
     int fd = open(path, O_WRONLY);
 
     cout << "corrupting journal" << std::endl;
-    j.open(0);
-    j.corrupt_payload(fd, 2);
+    fj.open(0);
+    fj.corrupt_payload(fd, 2);
 
     uint64_t seq = 0;
     bl.clear();
     bool corrupt = false;
-    bool result = j.read_entry(bl, seq, &corrupt);
+    bool result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_TRUE(result);
     ASSERT_EQ(seq, 1UL);
     ASSERT_FALSE(corrupt);
 
-    result = j.read_entry(bl, seq, &corrupt);
+    result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_FALSE(result);
     ASSERT_TRUE(corrupt);
 
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
     ::close(fd);
   }
 }
@@ -637,10 +637,10 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
   for (unsigned i = 0 ; i < 3; ++i) {
     SCOPED_TRACE(subtests[i].description);
     fsid.generate_random();
-    FileJournal j(g_ceph_context, fsid, finisher, &sync_cond, path,
+    FileJournal fj(g_ceph_context, fsid, finisher, &sync_cond, path,
 		  subtests[i].directio, subtests[i].aio, subtests[i].faio);
-    ASSERT_EQ(0, j.create());
-    ASSERT_EQ(0, j.make_writeable());
+    ASSERT_EQ(0, fj.create());
+    ASSERT_EQ(0, fj.make_writeable());
 
     C_GatherBuilder gb(g_ceph_context, new C_SafeCond(&wait_lock, &cond, &done));
 
@@ -648,41 +648,41 @@ TEST(TestFileJournal, ReplayDetectCorruptHeader) {
     for (unsigned i = 1; i <= 4; ++i) {
       bufferlist bl;
       bl.append(needle);
-      int orig_len = j.prepare_entry(tls, &bl);
-      j.reserve_throttle_and_backoff(bl.length());
-      j.submit_entry(i, bl, orig_len, gb.new_sub());
+      int orig_len = fj.prepare_entry(tls, &bl);
+      fj.reserve_throttle_and_backoff(bl.length());
+      fj.submit_entry(i, bl, orig_len, gb.new_sub());
     }
     gb.activate();
     wait();
 
     bufferlist bl;
     bl.append("needle");
-    int orig_len = j.prepare_entry(tls, &bl);
-    j.reserve_throttle_and_backoff(bl.length());
-    j.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
+    int orig_len = fj.prepare_entry(tls, &bl);
+    fj.reserve_throttle_and_backoff(bl.length());
+    fj.submit_entry(5, bl, orig_len, new C_SafeCond(&wait_lock, &cond, &done));
     wait();
 
-    j.close();
+    fj.close();
     int fd = open(path, O_WRONLY);
 
     cout << "corrupting journal" << std::endl;
-    j.open(0);
-    j.corrupt_header_magic(fd, 2);
+    fj.open(0);
+    fj.corrupt_header_magic(fd, 2);
 
     uint64_t seq = 0;
     bl.clear();
     bool corrupt = false;
-    bool result = j.read_entry(bl, seq, &corrupt);
+    bool result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_TRUE(result);
     ASSERT_EQ(seq, 1UL);
     ASSERT_FALSE(corrupt);
 
-    result = j.read_entry(bl, seq, &corrupt);
+    result = fj.read_entry(bl, seq, &corrupt);
     ASSERT_FALSE(result);
     ASSERT_TRUE(corrupt);
 
-    ASSERT_EQ(0, j.make_writeable());
-    j.close();
+    ASSERT_EQ(0, fj.make_writeable());
+    fj.close();
     ::close(fd);
   }
 }


### PR DESCRIPTION
Renamed FileJournal object for easier searching and identifying with in
test_filejournal.cc. This difficulty is found while reviewing
https://github.com/ceph/ceph/pull/15266. Avoid using Single Character Object Names.

Signed-off-by: Jos Collin <jcollin@redhat.com>