### PR TITLE
rgw: fix get bucket policy s3 compatible issue

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -85,6 +85,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NO_SUCH_UPLOAD, {404, "NoSuchUpload" }},
     { ERR_NOT_FOUND, {404, "Not Found"}},
     { ERR_NO_SUCH_LC, {404, "NoSuchLifecycleConfiguration"}},
+    { ERR_NO_SUCH_BUCKET_POLICY, {404, "NoSuchBucketPolicy"}},
     { ERR_METHOD_NOT_ALLOWED, {405, "MethodNotAllowed" }},
     { ETIMEDOUT, {408, "RequestTimeout" }},
     { EEXIST, {409, "BucketAlreadyExists" }},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -200,6 +200,7 @@ using ceph::crypto::MD5;
 #define ERR_MALFORMED_DOC        2204
 #define ERR_NO_ROLE_FOUND        2205
 #define ERR_DELETE_CONFLICT      2206
+#define ERR_NO_SUCH_BUCKET_POLICY  2207
 #define ERR_BUSY_RESHARDING      2300
 
 #ifndef UINT32_MAX

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6542,7 +6542,23 @@ int RGWGetBucketPolicy::verify_permission()
 void RGWGetBucketPolicy::execute()
 {
   auto attrs = s->bucket_attrs;
-  policy = attrs[RGW_ATTR_IAM_POLICY];
+  map<string, bufferlist>::iterator aiter = attrs.find(RGW_ATTR_IAM_POLICY);
+  if (aiter == attrs.end()) {
+    ldout(s->cct, 0) << __func__ << " can't find bucket IAM POLICY attr" 
+                     << " bucket_name = " << s->bucket_name << dendl;
+    op_ret = -ERR_NO_SUCH_BUCKET_POLICY;
+    s->err.message = "The bucket policy does not exist";
+    return;
+  } else {
+    policy = attrs[RGW_ATTR_IAM_POLICY];
+
+    if (policy.length() == 0) {
+      ldout(s->cct, 10) << "The bucket policy does not exist, bucket: " << s->bucket_name << dendl;
+      op_ret = -ERR_NO_SUCH_BUCKET_POLICY;
+      s->err.message = "The bucket policy does not exist";
+      return;
+    }
+  } 
 }
 
 void RGWDeleteBucketPolicy::send_response()


### PR DESCRIPTION
In AWS S3 get bucket policy should return 404 error code when bucket policy does not exist like following:

Response: {'status': 404, 'headers': {'x-amz-id-2': 'Gncp2wjrOy2Juy0RFbuyWjGFCFNSQd8vXIi8sbxhSdR7bi4VmjSlbmRKkUr3dK3+tmewATJSwZw=', 'server': 'AmazonS3', 'transfer-encoding': 'chunked', 'x-amz-request-id': 'D3F18909B654014A', 'date': 'Thu, 25 May 2017 03:28:35 GMT', 'content-type': 'application/xml'}, 'reason': 'Not Found', 'data': '<?xml version="1.0" encoding="UTF-8"?>\n<Error><Code>NoSuchBucketPolicy</Code><Message>The bucket policy does not exist</Message><BucketName>em-111</BucketName><RequestId>D3F18909B654014A</RequestId><HostId>Gncp2wjrOy2Juy0RFbuyWjGFCFNSQd8vXIi8sbxhSdR7bi4VmjSlbmRKkUr3dK3+tmewATJSwZw=</HostId></Error>'}

Now RGW return is:

Response: {'status': 404, 'headers': {'date': 'Thu, 25 May 2017 06:38:48 GMT', 'content-length': '270', 'x-amz-request-id': 'tx00000000000000000000e-0059267bf8-1013-default', 'content-type': 'application/xml', 'accept-ranges': 'bytes'}, 'reason': 'Not Found', 'data': '<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucketPolicy</Code><Message>The bucket policy does not exist</Message><BucketName>111</BucketName><RequestId>tx00000000000000000000e-0059267bf8-1013-default</RequestId><HostId>1013-default-default</HostId></Error>'}

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>