### PR TITLE
rgw/rgw_rados: Remove duplicate calls in RGWRados::finalize()

### DIFF
--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -70,7 +70,10 @@ protected:
 
 public:
   explicit RGWObjectExpirer(RGWRados *_store)
-    : store(_store) {
+    : store(_store), worker(NULL) {
+  }
+  ~RGWObjectExpirer() {
+    stop_processor();
   }
 
   int garbage_single_object(objexp_hint_entry& hint);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3406,9 +3406,11 @@ void RGWRados::finalize()
     delete finisher;
   }
   if (meta_notifier) {
+    meta_notifier->stop();
     delete meta_notifier;
   }
   if (data_notifier) {
+    data_notifier->stop();
     delete data_notifier;
   }
   delete data_log;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3406,32 +3406,24 @@ void RGWRados::finalize()
     delete finisher;
   }
   if (meta_notifier) {
-    meta_notifier->stop();
     delete meta_notifier;
   }
   if (data_notifier) {
-    data_notifier->stop();
     delete data_notifier;
   }
   delete data_log;
   if (async_rados) {
     delete async_rados;
   }
-  if (use_gc_thread) {
-    gc->stop_processor();
-    obj_expirer->stop_processor();
-  }
+  
   delete gc;
   gc = NULL;
 
-  if (use_lc_thread) {
-    lc->stop_processor();
-  }
-  delete lc;
-  lc = NULL;
-
   delete obj_expirer;
   obj_expirer = NULL;
+  
+  delete lc;
+  lc = NULL;
 
   delete rest_master_conn;
 


### PR DESCRIPTION
Remove duplicate calls because the destructor has been processed
Uniform class RGWObjectExpirer and class RGWGC's destructor

Signed-off-by: jimifm <hong.zhangoole@gmail.com>