### PR TITLE
mds: Pass empty string to clear mantle balancer

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -393,7 +393,7 @@ void MDBalancer::handle_heartbeat(MHeartbeat *m)
       /* avoid spamming ceph -w if user does not turn mantle on */
       if (mds->mdsmap->get_balancer() != "") {
         int r = mantle_prep_rebalance();
-        if (!r) return;
+        if (!r) goto out;
 	mds->clog->warn() << "using old balancer; mantle failed for "
                           << "balancer=" << mds->mdsmap->get_balancer()
                           << " : " << cpp_strerror(r);

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -295,7 +295,10 @@ public:
         });
       }
     } else if (var == "balancer") {
-      ss << "setting the metadata load balancer to " << val;
+      if (val.empty())
+        ss << "unsetting the metadata load balancer";
+      else 
+        ss << "setting the metadata load balancer to " << val;
         fsmap.modify_filesystem(
             fs->fscid,
             [val](std::shared_ptr<Filesystem> fs)

--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -920,12 +920,12 @@ def validate(args, signature, flags=0, partial=False):
 
             # no arg, but not required?  Continue consuming mysig
             # in case there are later required args
-            if not myarg and not desc.req:
+            if myarg == None and not desc.req:
                 break
 
             # out of arguments for a required param?
             # Either return (if partial validation) or raise
-            if not myarg and desc.req:
+            if myarg == None and desc.req:
                 if desc.N and desc.numseen < 1:
                     # wanted N, didn't even get 1
                     if partial:


### PR DESCRIPTION
Currently we can use `ceph fs set cephfs balancer <lua_conf_file>` to set mantle balancer. Then MDS balancer will try to use this mantle balancer firstly if MDS finds its balancer is not empty when handling hearbeat. If we want to switch back to old balancer, we need to set balancer to some strings which means an non-existed lua file to let MDS failing to reload it. But MDS still has to try reloading this non-existed lua file from OSD every time.

Within this fix, `ceph fs set` can pass empty string to clear mantle balancer.

`ceph fs set cephfs balancer ""`


Fixes: #http://tracker.ceph.com/issues/20076

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>