### PR TITLE
rgw: multipart copy-part remove '/' for s3 java sdk request header.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1076,6 +1076,7 @@ int RGWPutObj_ObjStore_S3::get_params()
   /* handle x-amz-copy-source */
 
   if (copy_source) {
+    if (*copy_source == '/') ++copy_source;
     copy_source_bucket_name = copy_source;
     pos = copy_source_bucket_name.find("/");
     if (pos == std::string::npos) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20075

Signed-off-by: donglinpeng@cmss.chinamobile.com