### PR TITLE
os/bluestore: fix BitMapAllocator assert on out-of-bound hint value

### DIFF
--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -14,6 +14,7 @@ class BitMapAllocator : public Allocator {
   CephContext* cct;
 
   int64_t m_block_size;
+  int64_t m_total_size;
 
   BitAllocator *m_bit_alloc; // Bit allocator instance
 

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1833,7 +1833,8 @@ int BlueFS::_allocate(uint8_t id, uint64_t len,
                           &extents);
   if (alloc_len < (int64_t)left) {
     derr << __func__ << " allocate failed on 0x" << std::hex << left
-	 << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
+	 << " min_alloc_size 0x" << min_alloc_size 
+         << " hint 0x" <<  hint << std::dec << dendl;
     alloc[id]->dump();
     assert(0 == "allocate failed... wtf");
     return -ENOSPC;

--- a/src/test/objectstore/Allocator_test.cc
+++ b/src/test/objectstore/Allocator_test.cc
@@ -259,6 +259,18 @@ TEST_P(AllocTest, test_alloc_hint_bmap)
   ASSERT_EQ(zone_size, allocated);
   EXPECT_EQ(zone_size, (int)extents.size());
   EXPECT_EQ(extents[0].offset, (uint64_t) 0);
+  /*
+   * Verify out-of-bound hint
+   */
+  extents.clear();
+  allocated = alloc->allocate(1, 1, 1, blocks, &extents);
+  ASSERT_EQ(1, allocated);
+  EXPECT_EQ(1, (int)extents.size());
+
+  extents.clear();
+  allocated = alloc->allocate(1, 1, 1, blocks * 3 + 1 , &extents);
+  ASSERT_EQ(1, allocated);
+  EXPECT_EQ(1, (int)extents.size());
 }
 
 


### PR DESCRIPTION
BlueFS might provide a hint pointing to the end of the disk and BitMapAllocator asserts on that.

Signed-off-by: Igor Fedotov <ifedotov@mirantis.com>