### PR TITLE
qa/suites/krbd: unmap subsuite needs straw buckets

### DIFF
--- a/qa/suites/krbd/unmap/ceph/ceph.yaml
+++ b/qa/suites/krbd/unmap/ceph/ceph.yaml
@@ -4,3 +4,6 @@ overrides:
 tasks:
 - install:
 - ceph:
+- exec:
+    client.0:
+    - "ceph osd getcrushmap -o /dev/stdout | crushtool -d - | sed -e 's/alg straw2/alg straw/g' | crushtool -c /dev/stdin -o /dev/stdout | ceph osd setcrushmap -i /dev/stdin"


### PR DESCRIPTION
The default tunables for luminous allow straw2 buckets, which aren't
supported by pre-single-major.yaml kernel.  The map is generated before
crush_tunables override takes effect, so set the bucket algorithm to
straw manually.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>