### PR TITLE
rgw_file: store bucket uxattrs on the bucket

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -695,7 +695,8 @@ namespace rgw {
 
     string obj_name{rgw_fh->relative_object_name()};
 
-    if (rgw_fh->is_dir()) {
+    if (rgw_fh->is_dir() &&
+	(likely(! rgw_fh->is_bucket()))) {
       obj_name += "/";
     }
 


### PR DESCRIPTION
This turns out to be the corollary of the earlier bug in removing
buckets w/uxattrs. Rather than conditionally put the attrs on a '/'
object, put them on the bucket--because that works, and will be
slightly more efficient when the check for the '/' object goes
away.

Fixes: http://tracker.ceph.com/issues/20082

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>