### PR TITLE
osd: 'osd tree in|out|up|down' to filter tree results

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1312,6 +1312,19 @@ function test_mon_osd()
   ceph osd unpause
 
   ceph osd tree
+  ceph osd tree up
+  ceph osd tree down
+  ceph osd tree in
+  ceph osd tree out
+  ceph osd tree up in
+  ceph osd tree up out
+  ceph osd tree down in
+  ceph osd tree down out
+  ceph osd tree out down
+  expect_false ceph osd tree up down
+  expect_false ceph osd tree in out
+  expect_false ceph osd tree up foo
+
   ceph osd perf
   ceph osd blocked-by
 

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -76,10 +76,10 @@ namespace CrushTreeDumper {
       clear();
     }
 
-    virtual bool should_dump_leaf(int i) {
+    virtual bool should_dump_leaf(int i) const {
       return true;
     }
-    virtual bool should_dump_empty_bucket() {
+    virtual bool should_dump_empty_bucket() const {
       return true;
     }
 

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -76,8 +76,31 @@ namespace CrushTreeDumper {
       clear();
     }
 
+    virtual bool should_dump_leaf(int i) {
+      return true;
+    }
+    virtual bool should_dump_empty_bucket() {
+      return true;
+    }
+
+    bool should_dump(int id) {
+      if (id >= 0)
+	return should_dump_leaf(id);
+      if (should_dump_empty_bucket())
+	return true;
+      int s = crush->get_bucket_size(id);
+      for (int k = s - 1; k >= 0; k--) {
+	int c = crush->get_bucket_item(id, k);
+	if (should_dump(c))
+	  return true;
+      }
+      return false;
+    }
+
     bool next(Item &qi) {
       if (empty()) {
+	while (root != roots.end() && !should_dump(*root))
+	  ++root;
 	if (root == roots.end())
 	  return false;
 	push_back(Item(*root, 0, crush->get_bucket_weightf(*root)));
@@ -93,9 +116,11 @@ namespace CrushTreeDumper {
 	int s = crush->get_bucket_size(qi.id);
 	for (int k = s - 1; k >= 0; k--) {
 	  int id = crush->get_bucket_item(qi.id, k);
-	  qi.children.push_back(id);
-	  push_front(Item(id, qi.depth + 1,
-			  crush->get_bucket_item_weightf(qi.id, k)));
+	  if (should_dump(id)) {
+	    qi.children.push_back(id);
+	    push_front(Item(id, qi.depth + 1,
+			    crush->get_bucket_item_weightf(qi.id, k)));
+	  }
 	}
       }
       return true;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -421,7 +421,8 @@ COMMAND("osd dump " \
 	"name=epoch,type=CephInt,range=0,req=false",
 	"print summary of OSD map", "osd", "r", "cli,rest")
 COMMAND("osd tree " \
-	"name=epoch,type=CephInt,range=0,req=false", \
+	"name=epoch,type=CephInt,range=0,req=false " \
+	"name=states,type=CephChoices,strings=up|down|in|out,n=N,req=false", \
 	"print OSD tree", "osd", "r", "cli,rest")
 COMMAND("osd ls " \
 	"name=epoch,type=CephInt,range=0,req=false", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4012,13 +4012,39 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       }
       rdata.append(ds);
     } else if (prefix == "osd tree") {
+      vector<string> states;
+      cmd_getval(g_ceph_context, cmdmap, "states", states);
+      unsigned filter = 0;
+      for (auto& s : states) {
+	if (s == "up") {
+	  filter |= OSDMap::DUMP_UP;
+	} else if (s == "down") {
+	  filter |= OSDMap::DUMP_DOWN;
+	} else if (s == "in") {
+	  filter |= OSDMap::DUMP_IN;
+	} else if (s == "out") {
+	  filter |= OSDMap::DUMP_OUT;
+	} else {
+	  ss << "unrecognized state '" << s << "'";
+	  r = -EINVAL;
+	  goto reply;
+	}
+      }
+      if ((filter & (OSDMap::DUMP_IN|OSDMap::DUMP_OUT)) ==
+	  (OSDMap::DUMP_IN|OSDMap::DUMP_OUT) ||
+	  (filter & (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) ==
+	  (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) {
+	ss << "cannot specify both up and down or both in and out";
+	r = -EINVAL;
+	goto reply;
+      }
       if (f) {
 	f->open_object_section("tree");
-	p->print_tree(f.get(), NULL);
+	p->print_tree(f.get(), NULL, filter);
 	f->close_section();
 	f->flush(ds);
       } else {
-	p->print_tree(NULL, &ds);
+	p->print_tree(NULL, &ds, filter);
       }
       rdata.append(ds);
     } else if (prefix == "osd getmap") {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -2849,8 +2849,24 @@ void OSDMap::print(ostream& out) const
 class OSDTreePlainDumper : public CrushTreeDumper::Dumper<TextTable> {
 public:
   typedef CrushTreeDumper::Dumper<TextTable> Parent;
-  OSDTreePlainDumper(const CrushWrapper *crush, const OSDMap *osdmap_)
-    : Parent(crush), osdmap(osdmap_) {}
+
+  OSDTreePlainDumper(const CrushWrapper *crush, const OSDMap *osdmap_,
+		     unsigned f)
+    : Parent(crush), osdmap(osdmap_), filter(f) { }
+
+  bool should_dump_leaf(int i) const override {
+    if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
+	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
+	((filter & OSDMap::DUMP_IN) && !osdmap->is_in(i)) ||
+	((filter & OSDMap::DUMP_OUT) && !osdmap->is_out(i))) {
+      return false;
+    }
+    return true;
+  }
+
+  bool should_dump_empty_bucket() const override {
+    return !filter;
+  }
 
   void dump(TextTable *tbl) {
     tbl->define_column("ID", TextTable::LEFT, TextTable::RIGHT);
@@ -2863,8 +2879,9 @@ public:
     Parent::dump(tbl);
 
     for (int i = 0; i < osdmap->get_max_osd(); i++) {
-      if (osdmap->exists(i) && !is_touched(i))
+      if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i)) {
 	dump_item(CrushTreeDumper::Item(i, 0, 0), tbl);
+      }
     }
   }
 
@@ -2900,14 +2917,30 @@ protected:
 
 private:
   const OSDMap *osdmap;
+  const unsigned filter;
 };
 
 class OSDTreeFormattingDumper : public CrushTreeDumper::FormattingDumper {
 public:
   typedef CrushTreeDumper::FormattingDumper Parent;
 
-  OSDTreeFormattingDumper(const CrushWrapper *crush, const OSDMap *osdmap_)
-    : Parent(crush), osdmap(osdmap_) {}
+  OSDTreeFormattingDumper(const CrushWrapper *crush, const OSDMap *osdmap_,
+			  unsigned f)
+    : Parent(crush), osdmap(osdmap_), filter(f) { }
+
+  bool should_dump_leaf(int i) const override {
+    if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
+	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
+	((filter & OSDMap::DUMP_IN) && !osdmap->is_in(i)) ||
+	((filter & OSDMap::DUMP_OUT) && !osdmap->is_out(i))) {
+      return false;
+    }
+    return true;
+  }
+
+  bool should_dump_empty_bucket() const override {
+    return !filter;
+  }
 
   void dump(Formatter *f) {
     f->open_array_section("nodes");
@@ -2915,7 +2948,7 @@ public:
     f->close_section();
     f->open_array_section("stray");
     for (int i = 0; i < osdmap->get_max_osd(); i++) {
-      if (osdmap->exists(i) && !is_touched(i))
+      if (osdmap->exists(i) && !is_touched(i) && should_dump_leaf(i))
 	dump_item(CrushTreeDumper::Item(i, 0, 0), f);
     }
     f->close_section();
@@ -2935,16 +2968,17 @@ protected:
 
 private:
   const OSDMap *osdmap;
+  const unsigned filter;
 };
 
-void OSDMap::print_tree(Formatter *f, ostream *out) const
+void OSDMap::print_tree(Formatter *f, ostream *out, unsigned filter) const
 {
-  if (f)
-    OSDTreeFormattingDumper(crush.get(), this).dump(f);
-  else {
+  if (f) {
+    OSDTreeFormattingDumper(crush.get(), this, filter).dump(f);
+  } else {
     assert(out);
     TextTable tbl;
-    OSDTreePlainDumper(crush.get(), this).dump(&tbl);
+    OSDTreePlainDumper(crush.get(), this, filter).dump(&tbl);
     *out << tbl;
   }
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -957,7 +957,14 @@ public:
   void print_pools(ostream& out) const;
   void print_summary(Formatter *f, ostream& out) const;
   void print_oneline_summary(ostream& out) const;
-  void print_tree(Formatter *f, ostream *out) const;
+
+  enum {
+    DUMP_IN = 1,     // only 'in' osds
+    DUMP_OUT = 2,    // only 'out' osds
+    DUMP_UP = 4,     // only 'up' osds
+    DUMP_DOWN = 8,   // only 'down' osds
+  };
+  void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0) const;
 
   int summarize_mapping_stats(
     OSDMap *newmap,

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -210,8 +210,10 @@ function TEST_crush_rename_bucket() {
     run_mon $dir a || return 1
 
     ceph osd crush add-bucket host1 host
+    ceph osd tree
     ! ceph osd tree | grep host2 || return 1
     ceph osd crush rename-bucket host1 host2 || return 1
+    ceph osd tree
     ceph osd tree | grep host2 || return 1
     ceph osd crush rename-bucket host1 host2 || return 1 # idempotency
     ceph osd crush rename-bucket nonexistent something 2>&1 | grep "Error ENOENT" || return 1


### PR DESCRIPTION
This lets you easily see down OSDs and where they are with
'ceph osd tree down'.

<pre>
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-2 3.00000     host gnit                                   
 0 1.00000         osd.0      up  1.00000          1.00000 
 1 1.00000         osd.1      up  1.00000          1.00000 
 2 1.00000         osd.2      up        0          1.00000 
-3 2.00000     host foo                                    
 3 1.00000         osd.3    down        0          1.00000 
 4 1.00000         osd.4      up  1.00000          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree up
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-2 3.00000     host gnit                                   
 0 1.00000         osd.0      up  1.00000          1.00000 
 1 1.00000         osd.1      up  1.00000          1.00000 
 2 1.00000         osd.2      up        0          1.00000 
-3 2.00000     host foo                                    
 4 1.00000         osd.4      up  1.00000          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree down
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-3 2.00000     host foo                                    
 3 1.00000         osd.3    down        0          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree in
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-2 3.00000     host gnit                                   
 0 1.00000         osd.0      up  1.00000          1.00000 
 1 1.00000         osd.1      up  1.00000          1.00000 
-3 2.00000     host foo                                    
 4 1.00000         osd.4      up  1.00000          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree out
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-2 3.00000     host gnit                                   
 2 1.00000         osd.2      up        0          1.00000 
-3 2.00000     host foo                                    
 3 1.00000         osd.3    down        0          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree out down
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-3 2.00000     host foo                                    
 3 1.00000         osd.3    down        0          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree out up
ID WEIGHT  TYPE NAME     UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-1 5.00000 root default                                    
-2 3.00000     host gnit                                   
 2 1.00000         osd.2      up        0          1.00000 
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree in out
Error EINVAL: cannot specify both up and down or both in and out
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree up down
Error EINVAL: cannot specify both up and down or both in and out
gnit:build (wip-osd-tree) 11:37 AM $ bin/ceph osd tree foo
foo not valid:  foo not in up|down|in|out
Invalid command:  unused arguments: [u'foo']
osd tree {<int[0-]>} {up|down|in|out [up|down|in|out...]} :  print OSD tree
Error EINVAL: invalid command
gnit:build (wip-osd-tree) 11:38 AM $ bin/ceph osd tree foo up
foo not valid:  foo not in up|down|in|out
Invalid command:  unused arguments: [u'foo', u'up']
osd tree {<int[0-]>} {up|down|in|out [up|down|in|out...]} :  print OSD tree
Error EINVAL: invalid command
</pre>