### PR TITLE
qa/tasks/repair_test: unset flags we set

### DIFF
--- a/qa/tasks/repair_test.py
+++ b/qa/tasks/repair_test.py
@@ -303,3 +303,6 @@ def task(ctx, config):
     repair_test_2(ctx, manager, config, choose_replica)
 
     repair_test_erasure_code(manager, hinfoerr, 'primary', "deep-scrub")
+
+    manager.raw_cluster_cmd('osd', 'unset', 'noscrub')
+    manager.raw_cluster_cmd('osd', 'unset', 'nodeep-scrub')


### PR DESCRIPTION
In particular, noscrub and nodeepscrub leave a health
warning, which prevents shutdown with at-end.yaml.

Signed-off-by: Sage Weil <sage@redhat.com>