### PR TITLE
dmclock: Don't dump core when using EXPECT_DEATH_IF_SUPPORTED

### DIFF
--- a/src/dmclock/test/CMakeLists.txt
+++ b/src/dmclock/test/CMakeLists.txt
@@ -1,3 +1,8 @@
+INCLUDE (CheckIncludeFiles)
+CHECK_INCLUDE_FILES("sys/prctl.h" HAVE_SYS_PRCTL_H)
+CONFIGURE_FILE(dmtest-config.h.in dmtest-config.h)
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(../src)
 include_directories(../support/src)
 include_directories(../sim/src)

--- a/src/dmclock/test/dmtest-config.h.in
+++ b/src/dmclock/test/dmtest-config.h.in
@@ -1,0 +1,3 @@
+/* Define to 1 if you have the <sys/prctl.h> header file. */
+#cmakedefine HAVE_SYS_PRCTL_H 1
+

--- a/src/dmclock/test/test_dmclock_server.cc
+++ b/src/dmclock/test/test_dmclock_server.cc
@@ -16,6 +16,10 @@
 #include "dmclock_util.h"
 #include "gtest/gtest.h"
 
+#include <dmtest-config.h>
+#ifdef HAVE_SYS_PRCTL_H
+#include <sys/prctl.h>
+#endif
 
 namespace dmc = crimson::dmclock;
 
@@ -64,6 +68,14 @@ namespace crimson {
       Request req;
       ReqParams req_params(1,1);
 
+#if defined(HAVE_SYS_PRCTL_H)
+      int ret;
+      if ((ret = prctl(PR_SET_DUMPABLE, 0)) == -1) {
+        std::cerr << "warning: unable to unset dumpable flag: "
+                  << strerror(errno) << std::endl;
+      }
+#endif
+
       EXPECT_DEATH_IF_SUPPORTED(pq->add_request(req, client1, req_params),
 				"Assertion.*reservation.*max_tag.*"
 				"proportion.*max_tag") <<
@@ -76,6 +88,13 @@ namespace crimson {
 				"proportion.*max_tag") <<
 	"we should fail if a client tries to generate a reservation tag "
 	"where reservation and proportion are both 0";
+
+#if defined(HAVE_SYS_PRCTL_H)
+      if (prctl(PR_SET_DUMPABLE, ret) == -1) {
+      std::cerr << "warning: unable to reset dumpable flag: "
+                << strerror(errno) << std::endl;
+      }
+#endif
     }
 
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19979

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>