### PR TITLE
cmake: Rewrite HAVE_BABELTRACE  option to WITH_

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -453,14 +453,14 @@ endif(${WITH_LTTNG})
 option(WITH_OSD_INSTRUMENT_FUNCTIONS OFF)
 
 #option for Babeltrace
-option(HAVE_BABELTRACE "Babeltrace libraries are enabled" ON)
-if(${HAVE_BABELTRACE})
+option(WITH_BABELTRACE "Babeltrace libraries are enabled" ON)
+if(WITH_BABELTRACE)
+  set(HAVE_BABELTRACE ON)
   find_package(babeltrace REQUIRED)
-  set(WITH_BABELTRACE ${BABELTRACE_FOUND})
   set(HAVE_BABELTRACE_BABELTRACE_H ${BABELTRACE_FOUND})
   set(HAVE_BABELTRACE_CTF_EVENTS_H ${BABELTRACE_FOUND})
   set(HAVE_BABELTRACE_CTF_ITERATOR_H ${BABELTRACE_FOUND})
-endif(${HAVE_BABELTRACE})
+endif(WITH_BABELTRACE)
 
 option(DEBUG_GATHER "C_Gather debugging is enabled" ON)
 option(HAVE_LIBZFS "LibZFS is enabled" OFF)

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -836,10 +836,10 @@ cmake .. \
 %endif
 %if %{with lttng}
     -DWITH_LTTNG=ON \
-    -DHAVE_BABELTRACE=ON \
+    -DWTIH_BABELTRACE=ON \
 %else
     -DWITH_LTTNG=OFF \
-    -DHAVE_BABELTRACE=OFF \
+    -DWTIH_BABELTRACE=OFF \
 %endif
     $CEPH_EXTRA_CMAKE_ARGS \
 %if 0%{with ocf}

--- a/src/rbd_replay/CMakeLists.txt
+++ b/src/rbd_replay/CMakeLists.txt
@@ -23,7 +23,7 @@ set(librbd_replay_ios_srcs
 add_library(rbd_replay_ios STATIC ${librbd_replay_ios_srcs})
 target_link_libraries(rbd_replay_ios librbd librados global)
 
-if(${WITH_BABELTRACE})
+if(HAVE_BABELTRACE)
   add_executable(rbd-replay-prep
     rbd-replay-prep.cc)
   target_link_libraries(rbd-replay-prep
@@ -39,4 +39,5 @@ if(${WITH_BABELTRACE})
     Boost::date_time
     )
   install(TARGETS rbd-replay-prep DESTINATION bin)
-endif(${WITH_BABELTRACE})
+endif(HAVE_BABELTRACE)
+


### PR DESCRIPTION
All options to en/disable inclusion of libraries or other software
are of the format WITH_ so that the Cmake commaind like ahs all
WITH_* options. The WITH_=ON option will result in a HAVE_ setting
in CMAKE so that tests can use that variable.

Last 2 "abusers" to actually follow this
format.

 - HAVE_BABELTRACE

 - HAVE_ZFSLIB is fixed in #15907

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>