### PR TITLE
rgw: fix test_multi.py default config file path

### DIFF
--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -159,7 +159,7 @@ def init(parse_args):
     try:
         path = os.environ['RGW_MULTI_TEST_CONF']
     except KeyError:
-        path = tpath('test_multi.conf')
+        path = test_path + 'test_multi.conf'
 
     try:
         with open(path) as f:


### PR DESCRIPTION
```
$ python test_multi.py --num-zonegroups=2 --num-zones
2 --gateways-per-zone 1
Traceback (most recent call last):
  File "test_multi.py", line 315, in <module>
      init(True)
        File "test_multi.py", line 162, in init
	    path = tpath('test_multi.conf')
	    NameError: global name 'tpath' is not defined
```

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>