### PR TITLE
inline_memory: optimized mem_is_zero for non-x64

### DIFF
--- a/src/include/inline_memory.h
+++ b/src/include/inline_memory.h
@@ -124,6 +124,15 @@ bool mem_is_zero(const char *data, size_t len)
 
 static inline bool mem_is_zero(const char *data, size_t len) {
   const char *end = data + len;
+  const char* end64 = data + (len / sizeof(uint64_t))*sizeof(uint64_t);
+
+  while (data < end64) {
+    if (*(uint64_t*)data != 0) {
+      return false;
+    }
+    data += sizeof(uint64_t);
+  }
+
   while (data < end) {
     if (*data != 0) {
       return false;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1764,6 +1764,17 @@ TEST(BufferList, is_zero) {
     bl.append_zero(1);
     EXPECT_TRUE(bl.is_zero());
   }
+
+  for (size_t i = 1; i <= 256; ++i) {
+    bufferlist bl;
+    bl.append_zero(i);
+    EXPECT_TRUE(bl.is_zero());
+    bl.append('A');
+    // ensure buffer is a single, contiguous before testing
+    bl.rebuild();
+    EXPECT_FALSE(bl.is_zero());
+  }
+
 }
 
 TEST(BufferList, clear) {


### PR DESCRIPTION
mem_is_zero is fast for x64 where 128-bit registers are available, but it's very easy to optimze it for 32-bit Intel and ARM CPUs (and non-x64 CPUs in general) as well, the speed won't be anywhere near the fastest one but still almost 7x faster than regular byte-by-byte check - checked on both 32bit x86 system and 32bit ARM CPU (ARMv7 Processor rev 3 (v7l)). This works because GCC on 32bit archs is smart enough to do two loads and one flag compare, making checking by 8 bytes at a time still around 50% faster than checking by 4 bytes even if we don't have 64-bit registers:
```assembly
.L6:
        movl    4(%eax), %edx  # load first 4 bytes
        orl     (%eax), %edx   # OR it with 4 next bytes
        jne     .L4            # proceed if still zero
.L5:
        addl    $8, %eax
        cmpl    %eax, %ecx
```
and on ARM:
```assembly
        ldrd    r2, [r0]    # load first 4 bytes
        orrs    r3, r2, r3  # OR it with 4 next bytes
        bne     .L13        # branch out if not zero anymore
[..]
.L13:
        movs    r0, #0
        pop     {r4, r5, r6}
        bx      lr
```

Patch includes extra test to check for corner cases that may pop with such implementations.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>