### PR TITLE
rbd-nbd: display pool/image/snap information in list output

### DIFF
--- a/qa/workunits/rbd/rbd-nbd.sh
+++ b/qa/workunits/rbd/rbd-nbd.sh
@@ -91,18 +91,24 @@ expect_false _sudo rbd-nbd --device INVALIDDEV map ${IMAGE}
 
 # map test using the first unused device
 DEV=`_sudo rbd-nbd map ${POOL}/${IMAGE}`
-_sudo rbd-nbd list-mapped | grep "^${DEV}$"
-
+PID=$(rbd-nbd list-mapped | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
+    '$2 == pool && $3 == img && $5 == dev {print $1}')
+test -n "${PID}"
+ps -p ${PID} -o cmd | grep rbd-nbd
 # map test specifying the device
 expect_false _sudo rbd-nbd --device ${DEV} map ${POOL}/${IMAGE}
 dev1=${DEV}
 _sudo rbd-nbd unmap ${DEV}
-_sudo rbd-nbd list-mapped | expect_false grep "^${DEV}$"
+rbd-nbd list-mapped | expect_false grep "${DEV} $"
 DEV=
 # XXX: race possible when the device is reused by other process
 DEV=`_sudo rbd-nbd --device ${dev1} map ${POOL}/${IMAGE}`
 [ "${DEV}" = "${dev1}" ]
-_sudo rbd-nbd list-mapped | grep "^${DEV}$"
+rbd-nbd list-mapped | grep "${IMAGE}"
+PID=$(rbd-nbd list-mapped | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
+    '$2 == pool && $3 == img && $5 == dev {print $1}')
+test -n "${PID}"
+ps -p ${PID} -o cmd | grep rbd-nbd
 
 # read test
 [ "`dd if=${DATA} bs=1M | md5sum`" = "`_sudo dd if=${DEV} bs=1M | md5sum`" ]
@@ -143,18 +149,40 @@ test ${blocks2} -eq ${blocks}
 # read-only option test
 _sudo rbd-nbd unmap ${DEV}
 DEV=`_sudo rbd-nbd map --read-only ${POOL}/${IMAGE}`
-_sudo rbd-nbd list-mapped | grep "^${DEV}$"
+PID=$(rbd-nbd list-mapped | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
+    '$2 == pool && $3 == img && $5 == dev {print $1}')
+test -n "${PID}"
+ps -p ${PID} -o cmd | grep rbd-nbd
+
 _sudo dd if=${DEV} of=/dev/null bs=1M
 expect_false _sudo dd if=${DATA} of=${DEV} bs=1M oflag=direct
 _sudo rbd-nbd unmap ${DEV}
 
 # exclusive option test
 DEV=`_sudo rbd-nbd map --exclusive ${POOL}/${IMAGE}`
-_sudo rbd-nbd list-mapped | grep "^${DEV}$"
+PID=$(rbd-nbd list-mapped | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
+    '$2 == pool && $3 == img && $5 == dev {print $1}')
+test -n "${PID}"
+ps -p ${PID} -o cmd | grep rbd-nbd
+
 _sudo dd if=${DATA} of=${DEV} bs=1M oflag=direct
 expect_false timeout 10 \
 	rbd bench ${IMAGE} --io-type write --io-size=1024 --io-total=1024
 _sudo rbd-nbd unmap ${DEV}
+
+# auto unmap test
+DEV=`_sudo rbd-nbd map ${POOL}/${IMAGE}`
+PID=$(rbd-nbd list-mapped | awk -v pool=${POOL} -v img=${IMAGE} -v dev=${DEV} \
+    '$2 == pool && $3 == img && $5 == dev {print $1}')
+test -n "${PID}"
+ps -p ${PID} -o cmd | grep rbd-nbd
+_sudo kill ${PID}
+for i in `seq 10`; do
+  rbd-nbd list-mapped | expect_false grep "^${PID} *${POOL} *${IMAGE}" && break
+  sleep 1
+done
+rbd-nbd list-mapped | expect_false grep "^${PID} *${POOL} *${IMAGE}"
+
 DEV=
 rbd bench ${IMAGE} --io-type write --io-size=1024 --io-total=1024
 


### PR DESCRIPTION
a nbd device.

In my local test, The result will be shown like below:
$./rbd-nbd list-mapped
id device       pool image           snap
0  /dev/nbd0 rbd  image
1   /dev/nbd1 rbd  image1
2  /dev/nbd2 rbd  image
3  /dev/nbd3 rbd  image_snap snap1
4  /dev/nbd4 rbd  image11       snap1

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>