### PR TITLE
mon/OSDMonitor: cancel mapping job from update_from_paxos

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -256,6 +256,15 @@ void OSDMonitor::update_from_paxos(bool *need_bootstrap)
   dout(15) << "update_from_paxos paxos e " << version
 	   << ", my e " << osdmap.epoch << dendl;
 
+  if (mapping_job) {
+    if (!mapping_job->is_done()) {
+      dout(1) << __func__ << " mapping job "
+	      << mapping_job.get() << " did not complete, "
+	      << mapping_job->shards << " left, canceling" << dendl;
+      mapping_job->abort();
+    }
+    mapping_job.reset();
+  }
 
   /*
    * We will possibly have a stashed latest that *we* wrote, and we will


### PR DESCRIPTION
On the leader we cancel the mapping job in encode_pending.  On a peon,
we don't cancel it at all!  It is surprising this didn't already cause
problems, but with the PGtempMap is pretty reliably crashes with a
largish map.

Signed-off-by: Sage Weil <sage@redhat.com>