### PR TITLE
jewel: osd: Reset() snaptrimmer on shutdown and do not default-abort on leaked pg refs

### DIFF
--- a/qa/clusters/extra-client.yaml
+++ b/qa/clusters/extra-client.yaml
@@ -7,3 +7,8 @@ openstack:
 - volumes: # attached to each instance
     count: 3
     size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/clusters/fixed-1.yaml
+++ b/qa/clusters/fixed-1.yaml
@@ -6,5 +6,9 @@ overrides:
         osd crush chooseleaf type: 0
         osd pool default pg num:  128
         osd pool default pgp num:  128
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true
 roles:
 - [mon.a, osd.0, osd.1, osd.2, client.0]

--- a/qa/clusters/fixed-2.yaml
+++ b/qa/clusters/fixed-2.yaml
@@ -5,3 +5,8 @@ openstack:
 - volumes: # attached to each instance
     count: 3
     size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/clusters/fixed-3-cephfs.yaml
+++ b/qa/clusters/fixed-3-cephfs.yaml
@@ -9,3 +9,8 @@ openstack:
 log-rotate:
   ceph-mds: 10G
   ceph-osd: 10G
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/clusters/fixed-3.yaml
+++ b/qa/clusters/fixed-3.yaml
@@ -6,3 +6,8 @@ openstack:
 - volumes: # attached to each instance
     count: 3
     size: 10 # GB
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/qa/clusters/fixed-4.yaml
+++ b/qa/clusters/fixed-4.yaml
@@ -3,3 +3,8 @@ roles:
 - [mon.b, osd.1, osd.5, osd.9, osd.13] 
 - [mon.c, osd.2, osd.6, osd.10, osd.14] 
 - [osd.3, osd.7, osd.11, osd.15, client.0] 
+overrides:
+  ceph:
+    conf:
+      osd:
+        osd shutdown pgref assert: true

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -883,6 +883,7 @@ OPTION(osd_recovery_op_warn_multiple, OPT_U32, 16)
 
 // Max time to wait between notifying mon of shutdown and shutting down
 OPTION(osd_mon_shutdown_timeout, OPT_DOUBLE, 5)
+OPTION(osd_shutdown_pgref_assert, OPT_BOOL, false) // crash if the OSD has stray PG refs on shutdown
 
 OPTION(osd_max_object_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum object size
 OPTION(osd_max_object_name_len, OPT_U32, 2048) // max rados object name len

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2745,7 +2745,9 @@ int OSD::shutdown()
 #ifdef PG_DEBUG_REFS
 	p->second->dump_live_ids();
 #endif
-        assert(0);
+	if (cct->_conf->osd_shutdown_pgref_assert) {
+	  assert(0);
+	}
       }
       p->second->unlock();
       p->second->put("PGMap");

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -10020,6 +10020,8 @@ void ReplicatedPG::on_shutdown()
   cancel_flush_ops(false);
   cancel_proxy_ops(false);
   apply_and_flush_repops(false);
+  // clean up snap trim references
+  snap_trimmer_machine.process_event(Reset());
 
   pgbackend->on_change();
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/20084

We no longer default-assert on shutdown when we have leaked PGRefs, and the snap trimmer doesn't leak them gratuitously either!