### PR TITLE
rgw: get wrong content when download object with specific range with compression

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -76,17 +76,18 @@ int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len
     lderr(cct) << "Cannot load compressor of type " << cs_info->compression_type << dendl;
     return -EIO;
   }
-  bufferlist out_bl, in_bl;
+  bufferlist out_bl, in_bl, temp_in_bl;
+  bl.copy(bl_ofs, bl_len, temp_in_bl); 
   bl_ofs = 0;
   if (waiting.length() != 0) {
     in_bl.append(waiting);
-    in_bl.append(bl);        
+    in_bl.append(temp_in_bl);        
     waiting.clear();
   } else {
-    in_bl.claim(bl);
+    in_bl.claim(temp_in_bl);
   }
   bl_len = in_bl.length();
-  
+
   while (first_block <= last_block) {
     bufferlist tmp, tmp_out;
     int ofs_in_bl = first_block->new_ofs - cur_ofs;
@@ -130,7 +131,7 @@ int RGWGetObj_Decompress::fixup_range(off_t& ofs, off_t& end)
       vector<compression_block>::iterator fb, lb;
       // not bad to use auto for lambda, I think
       auto cmp_u = [] (off_t ofs, const compression_block& e) { return (unsigned)ofs < e.old_ofs; };
-      auto cmp_l = [] (const compression_block& e, off_t ofs) { return e.old_ofs < (unsigned)ofs; };
+      auto cmp_l = [] (const compression_block& e, off_t ofs) { return e.old_ofs <= (unsigned)ofs; };
       fb = upper_bound(cs_info->blocks.begin()+1,
                        cs_info->blocks.end(),
                        ofs,
@@ -150,7 +151,7 @@ int RGWGetObj_Decompress::fixup_range(off_t& ofs, off_t& end)
   q_len = end - last_block->old_ofs + 1;
 
   ofs = first_block->new_ofs;
-  end = last_block->new_ofs + last_block->len;
+  end = last_block->new_ofs + last_block->len - 1;
 
   first_data = true;
   cur_ofs = ofs;

--- a/src/test/rgw/test_rgw_compression.cc
+++ b/src/test/rgw/test_rgw_compression.cc
@@ -36,15 +36,15 @@ TEST(Decompress, FixupRangePartial)
   RGWGetObj_Decompress decompress(g_ceph_context, &cs_info, partial, &cb);
 
   // test translation from logical ranges to compressed ranges
-  ASSERT_EQ(range_t(0, 6), fixup_range(&decompress, 0, 1));
-  ASSERT_EQ(range_t(0, 6), fixup_range(&decompress, 1, 7));
-  ASSERT_EQ(range_t(0, 6), fixup_range(&decompress, 7, 8));
-  ASSERT_EQ(range_t(0, 12), fixup_range(&decompress, 0, 9));
-  ASSERT_EQ(range_t(0, 12), fixup_range(&decompress, 7, 9));
-  ASSERT_EQ(range_t(6, 12), fixup_range(&decompress, 8, 9));
-  ASSERT_EQ(range_t(6, 12), fixup_range(&decompress, 8, 16));
-  ASSERT_EQ(range_t(6, 18), fixup_range(&decompress, 8, 17));
-  ASSERT_EQ(range_t(12, 18), fixup_range(&decompress, 16, 24));
-  ASSERT_EQ(range_t(12, 24), fixup_range(&decompress, 16, 999));
-  ASSERT_EQ(range_t(18, 24), fixup_range(&decompress, 998, 999));
+  ASSERT_EQ(range_t(0, 5), fixup_range(&decompress, 0, 1));
+  ASSERT_EQ(range_t(0, 5), fixup_range(&decompress, 1, 7));
+  ASSERT_EQ(range_t(0, 11), fixup_range(&decompress, 7, 8));
+  ASSERT_EQ(range_t(0, 11), fixup_range(&decompress, 0, 9));
+  ASSERT_EQ(range_t(0, 11), fixup_range(&decompress, 7, 9));
+  ASSERT_EQ(range_t(6, 11), fixup_range(&decompress, 8, 9));
+  ASSERT_EQ(range_t(6, 17), fixup_range(&decompress, 8, 16));
+  ASSERT_EQ(range_t(6, 17), fixup_range(&decompress, 8, 17));
+  ASSERT_EQ(range_t(12, 23), fixup_range(&decompress, 16, 24));
+  ASSERT_EQ(range_t(12, 23), fixup_range(&decompress, 16, 999));
+  ASSERT_EQ(range_t(18, 23), fixup_range(&decompress, 998, 999));
 }


### PR DESCRIPTION
get wrong content when download object with specific range with compression
http://tracker.ceph.com/issues/20100

look at the prototype:
RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
we should trim the bl using bl_ofs and bl_len.

consider that we just need small chunk of the head object stripe to decompress the data range needed by client, but in RGWRados::get_obj_iterate_cb:

  if (is_head_obj) {
    /* only when reading from the head object do we need to do the atomic test */
    r = append_atomic_test(rctx, bucket_info, obj, op, &astate);
    if (r < 0)
      return r;

    if (astate &&
        obj_ofs < astate->data.length()) {
      unsigned chunk_len = min((uint64_t)astate->data.length() - obj_ofs, (uint64_t)len);

      d->data_lock.Lock();
      r = d->client_cb->handle_data(astate->data, obj_ofs, chunk_len);// pass the whole head object data to decompress filter
      d->data_lock.Unlock();
      if (r < 0)
        return r;

      d->lock.Lock();
      d->total_read += chunk_len;
      d->lock.Unlock();
  
      len -= chunk_len;
      read_ofs += chunk_len;
      obj_ofs += chunk_len;
      if (!len)
        return 0;
    }
  }

code :
 r = d->client_cb->handle_data(astate->data, obj_ofs, chunk_len);
pass the whole head object data to decompress filter