### PR TITLE
tools/ceph_kvstore_tool: add "bluestore-kv" to usage

### DIFF
--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -245,7 +245,7 @@ class StoreTool
 
 void usage(const char *pname)
 {
-  std::cerr << "Usage: " << pname << " <leveldb|rocksdb|...> <store path> command [args...]\n"
+  std::cerr << "Usage: " << pname << " <leveldb|rocksdb|bluestore-kv> <store path> command [args...]\n"
     << "\n"
     << "Commands:\n"
     << "  list [prefix]\n"


### PR DESCRIPTION
We are soon going to use BlueStore as the default OS, and
hence "bluestore-kv" shall be the preferred option.

By applying this patch, the help message shall be slightly
nicer to newcomers to this tool now.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>