### PR TITLE
rgw/rgw_op:Prevents memory leaks when calling func swift_versioning_copy() fails

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3137,7 +3137,7 @@ void RGWPutObj::execute()
                                           s->bucket_info,
                                           obj);
     if (op_ret < 0) {
-      return;
+      goto done;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: jimifm <hong.zhangoole@gmail.com>