### PR TITLE
rgw_file: add lock protection for readdir against gc

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1012,6 +1012,7 @@ namespace rgw {
 	inc_nlink(req.d_count);
 	*eof = req.eof();
 	event ev(event::type::READDIR, get_key(), state.atime);
+	lock_guard sguard(fs->state.mtx);
 	fs->state.push_event(ev);
       }
     } else {
@@ -1026,6 +1027,7 @@ namespace rgw {
 	inc_nlink(req.d_count);
 	*eof = req.eof();
 	event ev(event::type::READDIR, get_key(), state.atime);
+	lock_guard sguard(fs->state.mtx);
 	fs->state.push_event(ev);
       }
     }


### PR DESCRIPTION
The state.mtx protects state.events accessed both from readdir and gc.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>