### PR TITLE
common: include: Redo some includes for FreeBSD

### DIFF
--- a/src/common/SubProcess.h
+++ b/src/common/SubProcess.h
@@ -24,6 +24,10 @@
 #include <iostream>
 #include <include/assert.h>
 #include <common/errno.h>
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <signal.h>
+#endif
 
 /**
  * SubProcess:

--- a/src/common/event_socket.h
+++ b/src/common/event_socket.h
@@ -17,8 +17,11 @@
 #ifndef CEPH_COMMON_EVENT_SOCKET_H
 #define CEPH_COMMON_EVENT_SOCKET_H
 
-#include "include/event_type.h"
 #include <unistd.h>
+#if defined(__FreeBSD__)
+#include <errno.h>
+#endif
+#include "include/event_type.h"
 
 class EventSocket {
   int socket;

--- a/src/common/io_priority.cc
+++ b/src/common/io_priority.cc
@@ -12,13 +12,16 @@
  *
  */
 
-#include "io_priority.h"
-
 #include <unistd.h>
+#if defined(__FreeBSD__)
+#include <errno.h>
+#endif
 #ifdef __linux__
 #include <sys/syscall.h>   /* For SYS_xxx definitions */
 #endif
 #include <algorithm>
+
+#include "io_priority.h"
 
 pid_t ceph_gettid(void)
 {

--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -1,9 +1,15 @@
-#include "include/ipaddr.h"
 
 #include <arpa/inet.h>
 #include <ifaddrs.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__FreeBSD__)
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif
+
+#include "include/ipaddr.h"
 
 static void netmask_ipv4(const struct in_addr *addr,
 			 unsigned int prefix_len,

--- a/src/common/module.c
+++ b/src/common/module.c
@@ -15,6 +15,9 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#if defined(__FreeBSD__)
+#include <sys/wait.h>
+#endif 
 
 /*
  * TODO: Switch to libkmod when we abandon older platforms.  The APIs

--- a/src/erasure-code/isa/ErasureCodePluginIsa.cc
+++ b/src/erasure-code/isa/ErasureCodePluginIsa.cc
@@ -25,6 +25,7 @@
 
 // -----------------------------------------------------------------------------
 #include "ceph_ver.h"
+#include "include/buffer.h"
 #include "ErasureCodePluginIsa.h"
 #include "ErasureCodeIsa.h"
 // -----------------------------------------------------------------------------

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -4,6 +4,7 @@
 #if defined(__FreeBSD__)
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <netinet/in.h>
 #endif
 #include <arpa/inet.h>
 #include <ifaddrs.h>


### PR DESCRIPTION
- During include cleanup just a too much was removed for FreeBSD
  to get things compiled.
  This redoes some of the includes.

Tracker: http://tracker.ceph.com/issues/19883
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>