### PR TITLE
[DNM] cleanup: Fix and assert the use of ENODATA vs. ENOATTR

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10451,6 +10451,10 @@ int Client::_getxattr(Inode *in, const char *name, void *value, size_t size,
 {
   int r;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif 
+
   const VXattr *vxattr = _match_vxattr(in, name);
   if (vxattr) {
     r = -ENODATA;

--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -74,6 +74,10 @@ static int read_lock(cls_method_context_t hctx, const string& name, lock_info_t 
   string key = LOCK_PREFIX;
   key.append(name);
  
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   int r = cls_cxx_getxattr(hctx, key.c_str(), &bl);
   if (r < 0) {
     if (r ==  -ENODATA) {

--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -277,6 +277,10 @@ static int cls_log_trim(cls_method_context_t hctx, bufferlist *in, bufferlist *o
     removed = true;
   }
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (!removed)
     return -ENODATA;
 

--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -64,6 +64,10 @@ int cls_log_trim(librados::IoCtx& io_ctx, const string& oid, const utime_t& from
 {
   bool done = false;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   do {
     ObjectWriteOperation op;
 

--- a/src/cls/numops/cls_numops.cc
+++ b/src/cls/numops/cls_numops.cc
@@ -59,6 +59,10 @@ static int add(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   double value;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (ret == -ENODATA || bl.length() == 0) {
     value = 0;
   } else if (ret < 0) {

--- a/src/cls/refcount/cls_refcount.cc
+++ b/src/cls/refcount/cls_refcount.cc
@@ -48,6 +48,12 @@ static int read_refcount(cls_method_context_t hctx, bool implicit_ref, obj_refco
   bufferlist bl;
   objr->refs.clear();
   int ret = cls_cxx_getxattr(hctx, REFCOUNT_ATTR, &bl);
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
+
   if (ret == -ENODATA) {
     if (implicit_ref) {
       objr->refs[wildcard_tag] = true;

--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -585,6 +585,10 @@ int rgw_bucket_init_index(cls_method_context_t hctx, bufferlist *in, bufferlist 
 {
   bufferlist::iterator iter;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   bufferlist header_bl;
   int rc = cls_cxx_map_read_header(hctx, &header_bl);
   if (rc < 0) {

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -404,7 +404,12 @@ class CLSRGWIssueBILogTrim : public CLSRGWConcurrentIO {
 protected:
   int issue_op(int shard_id, const string& oid) override;
   // Trim until -ENODATA is returned.
-  int valid_ret_code() override { return -ENODATA; }
+  int valid_ret_code() override { 
+    return -ENODATA; 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+  }
   bool need_multiple_rounds() override { return true; }
   void add_object(int shard, const string& oid) override { objs_container[shard] = oid; }
   void reset_container(map<int, string>& objs) override {

--- a/src/cls/timeindex/cls_timeindex.cc
+++ b/src/cls/timeindex/cls_timeindex.cc
@@ -242,6 +242,9 @@ static int cls_timeindex_trim(cls_method_context_t hctx,
     removed = true;
   }
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
   if (!removed) {
     return -ENODATA;
   }

--- a/src/cls/timeindex/cls_timeindex_client.cc
+++ b/src/cls/timeindex/cls_timeindex_client.cc
@@ -84,6 +84,10 @@ int cls_timeindex_trim(
 {
   bool done = false;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   do {
     librados::ObjectWriteOperation op;
     cls_timeindex_trim(op, from_time, to_time, from_marker, to_marker);

--- a/src/cls/version/cls_version.cc
+++ b/src/cls/version/cls_version.cc
@@ -60,6 +60,11 @@ static int read_version(cls_method_context_t hctx, obj_version *objv, bool impli
 {
   bufferlist bl;
   int ret = cls_cxx_getxattr(hctx, VERSION_ATTR, &bl);
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
+
   if (ret == -ENOENT || ret == -ENODATA) {
     objv->ver = 0;
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1820,6 +1820,10 @@ void CDir::_omap_fetched(bufferlist& hdrbl, map<string, bufferlist>& omap,
   dout(10) << "_fetched header " << hdrbl.length() << " bytes "
 	   << omap.size() << " keys for " << *this << dendl;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   assert(r == 0 || r == -ENOENT || r == -ENODATA);
   assert(is_auth());
   assert(!is_frozen());

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3164,6 +3164,10 @@ void Server::_lookup_ino_2(MDRequestRef& mdr, int r)
     return;
   }
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   // give up
   if (r == -ENOENT || r == -ENODATA)
     r = -ESTALE;

--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -3,6 +3,7 @@
 
 #include "FuseStore.h"
 #include "os/ObjectStore.h"
+#include "include/compat.h"
 #include "include/stringify.h"
 #include "common/errno.h"
 
@@ -357,6 +358,11 @@ static int os_getattr(const char *path, struct stat *stbuf)
 
   case FN_OBJECT_ATTR_VAL:
     {
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
       if (!fs->store->exists(cid, oid))
 	return -ENOENT;
       bufferptr v;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6517,6 +6517,10 @@ int BlueStore::getattr(
   if (!c->exists)
     return -ENOENT;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   int r;
   {
     RWLock::RLocker l(c->lock);
@@ -7516,9 +7520,6 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	  kv_queue_unsubmitted.push_back(txc);
 	  ++txc->osr->kv_committing_serially;
 	}
-	if (txc->had_ios)
-	  kv_ios++;
-	kv_throttle_costs += txc->cost;
       }
       return;
     case TransContext::STATE_KV_SUBMITTED:
@@ -7965,8 +7966,6 @@ void BlueStore::_kv_sync_thread()
     } else {
       deque<TransContext*> kv_submitting;
       deque<DeferredBatch*> deferred_done, deferred_stable;
-      uint64_t aios = 0, costs = 0;
-
       dout(20) << __func__ << " committing " << kv_queue.size()
 	       << " submitting " << kv_queue_unsubmitted.size()
 	       << " deferred done " << deferred_done_queue.size()
@@ -7976,10 +7975,6 @@ void BlueStore::_kv_sync_thread()
       kv_submitting.swap(kv_queue_unsubmitted);
       deferred_done.swap(deferred_done_queue);
       deferred_stable.swap(deferred_stable_queue);
-      aios = kv_ios;
-      costs = kv_throttle_costs;
-      kv_ios = 0;
-      kv_throttle_costs = 0;
       utime_t start = ceph_clock_now();
       l.unlock();
 
@@ -7988,13 +7983,20 @@ void BlueStore::_kv_sync_thread()
       dout(30) << __func__ << " deferred_done " << deferred_done << dendl;
       dout(30) << __func__ << " deferred_stable " << deferred_stable << dendl;
 
+      int num_aios = 0;
+      for (auto txc : kv_committing) {
+	if (txc->had_ios) {
+	  ++num_aios;
+	}
+      }
+
       bool force_flush = false;
       // if bluefs is sharing the same device as data (only), then we
       // can rely on the bluefs commit to flush the device and make
       // deferred aios stable.  that means that if we do have done deferred
       // txcs AND we are not on a single device, we need to force a flush.
       if (bluefs_single_shared_device && bluefs) {
-	if (aios) {
+	if (num_aios) {
 	  force_flush = true;
 	} else if (kv_committing.empty() && kv_submitting.empty() &&
 		   deferred_stable.empty()) {
@@ -8006,7 +8008,7 @@ void BlueStore::_kv_sync_thread()
 	force_flush = true;
 
       if (force_flush) {
-	dout(20) << __func__ << " num_aios=" << aios
+	dout(20) << __func__ << " num_aios=" << num_aios
 		 << " force_flush=" << (int)force_flush
 		 << ", flushing, deferred done->stable" << dendl;
 	// flush/barrier on block device
@@ -8065,15 +8067,14 @@ void BlueStore::_kv_sync_thread()
 	  --txc->osr->txc_with_unstable_io;
 	}
 	txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+	// release throttle *before* we commit.  this allows new ops
+	// to be prepared and enter pipeline while we are waiting on
+	// the kv commit sync/flush.  then hopefully on the next
+	// iteration there will already be ops awake.  otherwise, we
+	// end up going to sleep, and then wake up when the very first
+	// transaction is ready for commit.
+	throttle_bytes.put(txc->cost);
       }
-
-      // release throttle *before* we commit.  this allows new ops
-      // to be prepared and enter pipeline while we are waiting on
-      // the kv commit sync/flush.  then hopefully on the next
-      // iteration there will already be ops awake.  otherwise, we
-      // end up going to sleep, and then wake up when the very first
-      // transaction is ready for commit.
-      throttle_bytes.put(costs);
 
       PExtentVector bluefs_gift_extents;
       if (bluefs &&
@@ -8365,15 +8366,13 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
   }
 
   {
-    uint64_t costs = 0;
     std::lock_guard<std::mutex> l2(osr->qlock);
     for (auto& i : b->txcs) {
       TransContext *txc = &i;
       txc->state = TransContext::STATE_DEFERRED_CLEANUP;
-      costs += txc->cost;
+      txc->osr->qcond.notify_all();
+      throttle_deferred_bytes.put(txc->cost);
     }
-    osr->qcond.notify_all();
-    throttle_deferred_bytes.put(costs);
     std::lock_guard<std::mutex> l(kv_lock);
     deferred_done_queue.emplace_back(b);
   }

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -3028,6 +3028,11 @@ void FileStore::_do_transaction(
 	// -ENOENT is normally okay
 	// ...including on a replayed OP_RMCOLL with checkpoint mode
 	ok = true;
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
       if (r == -ENODATA)
 	ok = true;
 

--- a/src/os/filestore/GenericFileStoreBackend.cc
+++ b/src/os/filestore/GenericFileStoreBackend.cc
@@ -335,6 +335,11 @@ int GenericFileStoreBackend::_crc_load_or_init(int fd, SloppyCRCMap *cm)
   bufferptr bp;
   int r = 0;
   int l = chain_fgetxattr(fd, SLOPPY_CRC_XATTR, buf, sizeof(buf));
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (l == -ENODATA) {
     return 0;
   }

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -712,6 +712,10 @@ int LFNIndex::lfn_get_name(const vector<string> &path,
   string full_name = lfn_generate_object_name(oid);
   int r;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (!lfn_must_hash(full_name)) {
     if (mangled_name)
       *mangled_name = full_name;

--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <stdio.h>
+#include "include/compat.h"
 #include "common/xattr.h"
 #include "include/assert.h"
 #include "include/buffer_fwd.h"
@@ -98,6 +99,10 @@ int chain_setxattr(
   static_assert(
     !skip_chain_cleanup || ensure_single_attr,
     "skip_chain_cleanup must imply ensure_single_attr");
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR,
+    "Include error ENODATA needs to be ENOATTR" );
+#endif
 
   do {
     size_t chunk_size = (size < max_chunk_size ? size : max_chunk_size);

--- a/src/os/kstore/KStore.cc
+++ b/src/os/kstore/KStore.cc
@@ -1344,6 +1344,10 @@ int KStore::getattr(
     goto out;
   }
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (!o->onode.attrs.count(k)) {
     r = -ENODATA;
     goto out;

--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -399,6 +399,11 @@ int MemStore::getattr(CollectionHandle &c_, const ghobject_t& oid,
 {
   Collection *c = static_cast<Collection*>(c_.get());
   dout(10) << __func__ << " " << c->cid << " " << oid << " " << name << dendl;
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   if (!c->exists)
     return -ENOENT;
   ObjectRef o = c->get_object(oid);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -807,6 +807,10 @@ bool PrimaryLogPG::pgls_filter(PGLSFilter *filter, hobject_t& sobj, bufferlist& 
 {
   bufferlist bl;
 
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   // If filter has expressed an interest in an xattr, load it.
   if (!filter->get_xattr().empty()) {
     int ret = pgbackend->objects_get_attr(
@@ -10444,10 +10448,6 @@ void PrimaryLogPG::on_shutdown()
   cancel_proxy_ops(false);
   apply_and_flush_repops(false);
   cancel_log_updates();
-  // we must remove PGRefs, so do this this prior to release_backoffs() callers
-  clear_backoffs(); 
-  // clean up snap trim references
-  snap_trimmer_machine.process_event(Reset());
 
   pgbackend->on_change();
 

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -20,6 +20,7 @@
 #include "rgw/rgw_acl_s3.h"
 #include "rgw_acl.h"
 
+#include "include/compat.h"
 #include "include/str_list.h"
 #include "global/global_init.h"
 #include "common/config.h"
@@ -587,6 +588,11 @@ namespace rgw {
 
   int RGWLibRequest::read_permissions(RGWOp* op) {
     /* bucket and object ops */
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
     int ret =
       rgw_build_bucket_policies(rgwlib.get_store(), get_state());
     if (ret < 0) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -10,6 +10,7 @@
 #include <boost/optional.hpp>
 #include <boost/utility/in_place_factory.hpp>
 
+#include "include/compat.h"
 #include "common/ceph_json.h"
 #include "common/utf8.h"
 
@@ -130,7 +131,7 @@ static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZonePa
     if (!obj.in_extra_data) {
       *pool = placement.data_pool;
     } else {
-      *pool = placement.get_data_extra_pool();
+      *pool = placement.data_extra_pool;
     }
   }
 
@@ -8855,6 +8856,11 @@ int RGWRados::Object::get_manifest(RGWObjManifest **pmanifest)
 int RGWRados::Object::Read::get_attr(const char *name, bufferlist& dest)
 {
   RGWObjState *state;
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
   int r = source->get_state(&state, true);
   if (r < 0)
     return r;

--- a/src/test/libcephfs/acl.cc
+++ b/src/test/libcephfs/acl.cc
@@ -171,6 +171,9 @@ TEST(ACL, SetACL) {
   ASSERT_EQ(generate_empty_acl(acl_buf, acl_buf_size, 0600), 0);
   ASSERT_EQ(ceph_fsetxattr(cmount, fd, ACL_EA_ACCESS, acl_buf, acl_buf_size, 0), 0);
   // ACL was deleted
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
   ASSERT_EQ(ceph_fgetxattr(cmount, fd, ACL_EA_ACCESS, NULL, 0), -ENODATA);
 
   ASSERT_EQ(ceph_fstatx(cmount, fd, &stx, CEPH_STATX_MODE, 0), 0);

--- a/src/test/libradosstriper/striping.cc
+++ b/src/test/libradosstriper/striping.cc
@@ -2,6 +2,7 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "include/types.h"
+#include "include/compat.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/radosstriper/libradosstriper.h"
@@ -245,6 +246,9 @@ TEST_P(StriperTestRT, StripedRoundtrip) {
     // check that stat fails
     uint64_t size;
     time_t mtime;   
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
     ASSERT_EQ(-ENODATA, striper.stat(soid, &size, &mtime));
     // call remove
     ASSERT_EQ(0, striper.remove(soid));

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -2334,6 +2334,9 @@ TEST_P(StoreTest, SimpleAttrTest) {
   {
     bufferptr bp;
     r = store->getattr(cid, hoid, "nofoo", bp);
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
     ASSERT_EQ(-ENODATA, r);
 
     r = store->getattr(cid, hoid, "foo", bp);

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include <fstream>
@@ -1159,6 +1160,11 @@ int DataScan::scan_frags()
     op.getxattr("parent", &parent_bl, &parent_r);
     op.getxattr("layout", &layout_bl, &layout_r);
     r = metadata_io.operate(oid, &op, &op_bl);
+
+#if defined(ENOATTR)
+  static_assert( ENODATA == ENOATTR, "ENODATA and ENOATRR need to be equal");
+#endif
+
     if (r != 0 && r != -ENODATA) {
       derr << "Unexpected error reading backtrace: " << cpp_strerror(parent_r) << dendl;
       return r;


### PR DESCRIPTION
- FreeBSD has ENOATTR as return value of the xattr function
   and asigns this to ENODATA
   But Boost defines ENODATA as well, but this is not the same
   value as Linux ENODATA or FreeBSD ENOATTR

   Added a static_assert to all files where ENODATA is referenced
   to make sure that at compile time the values are defined correctly.
   This will detect any wrong definitions, in case includes are
   reorganised

 - fixed files which did not have compat.h included to repair the
   missing ENODATA

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>