### PR TITLE
osd: Return early on shutdown

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6735,8 +6735,10 @@ bool OSD::ms_get_authorizer(int dest_type, AuthAuthorizer **authorizer, bool for
 {
   dout(10) << "OSD::ms_get_authorizer type=" << ceph_entity_type_name(dest_type) << dendl;
 
-  if (is_stopping())
+  if (is_stopping()) {
     dout(10) << __func__ << " bailing, we are shutting down" << dendl;
+    return false;
+  }
 
   if (dest_type == CEPH_ENTITY_TYPE_MON)
     return true;


### PR DESCRIPTION
eb5c02d was missing a return statement, rectify that.

Fixes: http://tracker.ceph.com/issues/19900

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>