### PR TITLE
rgw: Removed unnecessary functions and updated intrusive_ptr_add_ref() and intrusive_ptr_release() implementation

### DIFF
--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -108,10 +108,10 @@ namespace rgw {
       int cur_gen = gen;
       for (auto iter = mounted_fs.begin(); iter != mounted_fs.end();
 	   ++iter) {
-	RGWLibFS* fs = iter->first->ref();
+	RGWLibFS* fs = iter->first->intrusive_ptr_add_ref();
 	uniq.unlock();
 	fs->gc();
-	fs->rele();
+	fs->intrusive_ptr_release();
 	uniq.lock();
 	if (cur_gen != gen)
 	  goto restart; /* invalidated */

--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -760,7 +760,7 @@ namespace rgw {
     fh_cache.drain(ObjUnref(this),
 		  RGWFileHandle::FHCache::FLAG_LOCK);
     rgwlib.get_fe()->get_process()->unregister_fs(this);
-    rele();
+    intrusive_ptr_release();
   } /* RGWLibFS::close */
 
   inline std::ostream& operator<<(std::ostream &os, struct timespec const &ts) {


### PR DESCRIPTION
Found the need for this change while reviewing another PR a few days ago.

* Changed the member functions unnecessarily categorized as friend functions. A member function
  can delete an object of it's class. Quoting the State Pattern implementation as a reference:
  https://sourcemaking.com/design_patterns/state/cpp/1

* Removed functions named ref() and rele(), as they were implemented just for calling other functions.
  
Signed-off-by: Jos Collin <jcollin@redhat.com>