### PR TITLE
librados: redirect balanced reads to acting primary when targeting object isn't recovered

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -424,6 +424,7 @@ enum {
 
 #define EOLDSNAPC    85  /* ORDERSNAP flag set; writer has old snapc*/
 #define EBLACKLISTED 108 /* blacklisted */
+#define ERECOVERING  109 /* balanced reads arrived while targeting object hasn't been recovered */
 
 /* xattr comparison */
 enum {

--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -1414,7 +1414,11 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 
   // missing object?
   if (is_unreadable_object(head)) {
-    wait_for_unreadable_object(head, op);
+    if(is_primary()){
+      wait_for_unreadable_object(head, op);
+    }else{
+      osd->reply_op_error(op, -ERECOVERING);
+    }
     return;
   }
 


### PR DESCRIPTION
Redirect balanced read requests to acting primary when the
targeting object hasn't been recovered on replica OSDs.

Fix http://tracker.ceph.com/issues/17968