### PR TITLE
libradosstriper: Add example code

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -1,7 +1,7 @@
 
 CXX?=g++
 CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
-CXX_LIBS?=-lboost_system -lrados
+CXX_LIBS?=-lboost_system -lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
 CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS) $(CXX_LIBS)
 
@@ -13,11 +13,12 @@ CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS) $(CC_LIBS)
 
 # Relative path to the Ceph source:
 CEPH_SRC_HOME?=../../src
+CEPH_BLD_HOME?=../../build
 
-LOCAL_LIBRADOS?=-L$(CEPH_SRC_HOME)/.libs/ -Wl,-rpath,$(CEPH_SRC_HOME)/.libs
+LOCAL_LIBRADOS?=-L$(CEPH_BLD_HOME)/lib/ -Wl,-rpath,$(CEPH_BLD_HOME)/lib
 LOCAL_LIBRADOS_INC?=-I$(CEPH_SRC_HOME)/include
 
-all: hello_world_cpp hello_world_c
+all: hello_world_cpp hello_radosstriper_cpp hello_world_c
 
 # Build against the system librados instead of the one in the build tree:
 all-system: LOCAL_LIBRADOS=
@@ -27,9 +28,12 @@ all-system: all
 hello_world_cpp: hello_world.cc
 	$(CXX_CC) -o hello_world_cpp hello_world.cc
 
+hello_radosstriper_cpp: hello_radosstriper.cc
+	$(CXX_CC) -o hello_radosstriper_cpp hello_radosstriper.cc
+
 hello_world_c: hello_world_c.c
 	$(CC_CC) -o hello_world_c hello_world_c.c
 
 clean:
-	rm -f hello_world_cpp hello_world_c
+	rm -f hello_world_cpp hello_radosstriper_cpp hello_world_c
 

--- a/examples/librados/hello_radosstriper.cc
+++ b/examples/librados/hello_radosstriper.cc
@@ -1,0 +1,102 @@
+#include "rados/librados.hpp"
+#include "radosstriper/libradosstriper.hpp"
+#include <iostream>
+#include <string>
+
+
+int main(int argc, char* argv[])
+{
+  if(argc != 6)
+  {
+      std::cout <<"Please put in correct params\n"<<
+          "Stripe Count:\n"<<
+          "Object Size:\n" <<
+          "File Name:\n" <<
+          "Object Name:\n"
+          "Pool Name:"<< std::endl;
+      return EXIT_FAILURE;
+  }
+  uint32_t strip_count = std::stoi(argv[1]);
+  uint32_t obj_size = std::stoi(argv[2]);
+  std::string fname = argv[3];
+  std::string obj_name = argv[4];
+  std::string pool_name = argv[5];
+  int ret = 0;
+  librados::IoCtx io_ctx;
+  librados::Rados cluster;
+  libradosstriper::RadosStriper* rs = new libradosstriper::RadosStriper;
+
+  // make sure the keyring file is in /etc/ceph/ and is world readable
+  ret = cluster.init2("client.admin","ceph",0);
+  if( ret < 0)
+  {
+      std::cerr << "Couldn't init cluster "<< ret << std::endl;
+  }
+
+  // make sure ceph.conf is in /etc/ceph/ and is world readable
+  ret = cluster.conf_read_file("ceph.conf");
+  if( ret < 0)
+  {
+      std::cerr << "Couldn't read conf file "<< ret << std::endl;
+  }
+  ret = cluster.connect();
+  if(ret < 0)
+  {
+      std::cerr << "Couldn't connect to cluster "<< ret << std::endl;
+  }
+  else
+  {
+      std::cout << "Connected to Cluster"<< std::endl;
+  }
+
+  ret = cluster.ioctx_create(pool_name.c_str(), io_ctx);
+
+  if(ret < 0)
+  {
+      std::cerr << "Couldn't Create IO_CTX"<< ret << std::endl;
+  }
+  ret = libradosstriper::RadosStriper::striper_create(io_ctx,rs);
+  if(ret < 0)
+  {
+      std::cerr << "Couldn't Create RadosStriper"<< ret << std::endl;
+      delete rs;
+  }
+  uint64_t alignment = 0;
+  ret = io_ctx.pool_required_alignment2(&alignment);
+  if(ret < 0)
+  {
+      std::cerr << "IO_CTX didn't give alignment "<< ret
+          << "\n Is this an erasure coded pool? "<< std::endl;
+
+      delete rs;
+      io_ctx.close();
+      cluster.shutdown();
+      return EXIT_FAILURE;
+  }
+  std::cout << "Pool alignment: "<< alignment << std::endl;
+  rs->set_object_layout_stripe_unit(alignment);
+  // how many objects are we striping across?
+  rs->set_object_layout_stripe_count(strip_count);
+  // how big should each object be?
+  rs->set_object_layout_object_size(obj_size);
+
+  std::string err = "no_err";
+  librados::bufferlist bl;
+  bl.read_file(fname.c_str(),&err);
+  if(err != "no_err")
+  {
+      std::cout << "Error reading file into bufferlist: "<< err << std::endl;
+      delete rs;
+      io_ctx.close();
+      cluster.shutdown();
+      return EXIT_FAILURE;
+  }
+
+  std::cout << "Writing: " << fname << "\nas: "<< obj_name << std::endl;
+  rs->write_full(obj_name,bl);
+  std::cout << "done with: " << fname << std::endl;
+
+  delete rs;
+  io_ctx.close();
+  cluster.shutdown();
+}


### PR DESCRIPTION
The examples directory did not have any example code for libradosstriper. 
Also the Makefile wasn't working, I think it hadn't been updated since the switch to CMake