### PR TITLE
test/osdc: fix comparison error and silence warning from -Wunused-value

### DIFF
--- a/src/test/osdc/object_cacher_stress.cc
+++ b/src/test/osdc/object_cacher_stress.cc
@@ -47,8 +47,8 @@ public:
     : m_op(op), m_outstanding(outstanding) {}
   void finish(int r) override {
     m_op->done++;
-    assert(m_outstanding > 0);
-    *m_outstanding--;
+    assert(*m_outstanding > 0);
+    (*m_outstanding)--;
   }
 };
 


### PR DESCRIPTION
Clang complains:
```
  /home/jenkins/workspace/ceph-freebsd/src/test/osdc/object_cacher_stress.cc:50:26: error: ordered comparison between pointer and zero ('std::atomic<unsigned int> *' and 'int')
      assert(m_outstanding > 0);
               ~~~~~~~~~~~~~ ^ ~
  /home/jenkins/workspace/ceph-freebsd/src/include/assert.h:117:5: note: expanded from macro 'assert'
    ((expr)                                                               \
        ^~~~
```

The following warning appears during build:
```
ceph/src/test/osdc/object_cacher_stress.cc: In member function ‘virtual void C_Count::finish(int)’:
ceph/src/test/osdc/object_cacher_stress.cc:51:5: warning: value computed is not used [-Wunused-value]
*m_outstanding--;
```
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>