### PR TITLE
test: test_denc.cc: silence warning from -Wsign-compare

### DIFF
--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -666,7 +666,7 @@ TEST(denc, no_copy_if_segmented_and_lengthy)
     bufferlist segmented;
     segmented.append(large_bl);
     segmented.append(small_bl);
-    ASSERT_GT(segmented.get_num_buffers(), 1);
+    ASSERT_GT(segmented.get_num_buffers(), 1u);
     ASSERT_GT(segmented.length(), CEPH_PAGE_SIZE);
     auto p = segmented.begin();
     p.advance(large_bl.length());
@@ -684,7 +684,7 @@ TEST(denc, no_copy_if_segmented_and_lengthy)
     bufferlist segmented;
     segmented.append(small_bl);
     segmented.append(large_bl);
-    ASSERT_GT(segmented.get_num_buffers(), 1);
+    ASSERT_GT(segmented.get_num_buffers(), 1u);
     ASSERT_GT(segmented.length(), CEPH_PAGE_SIZE);
     auto p = segmented.begin();
     p.advance(small_bl.length());


### PR DESCRIPTION
```
In file included from ceph/src/test/test_denc.cc:23:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperGT(const char*, const char*, const T1&, const T2&) [with T1 = unsigned int; T2 = int]’:
ceph/src/test/test_denc.cc:669:5:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1530:28: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:7:
   if (val1 op val2) {\
       ~~~~~~~~~             
ceph/src/googletest/googletest/include/gtest/gtest.h:1530:28:
 GTEST_IMPL_CMP_HELPER_(GT, >);
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:12: note: in definition of macro ‘GTEST_IMPL_CMP_HELPER_’
   if (val1 op val2) {\

```

Signed-off-by: Jos Collin <jcollin@redhat.com>