### PR TITLE
test/msgr: silence warnings from -Wsign-compare

### DIFF
--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -1461,7 +1461,7 @@ TEST_P(MessengerTest, MarkdownTest) {
   client_msgr->start();
 
   int i = 1000;
-  uint64_t last = 0;
+  int64_t last = 0;
   bool equal = false;
   uint64_t equal_count = 0;
   while (i--) {


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/test/msgr/test_msgr.cc: In member function ‘virtual void MessengerTest_MarkdownTest_Test::TestBody()’:
ceph/src/test/msgr/test_msgr.cc:1474:46: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     CHECK_AND_WAIT_TRUE(srv_dispatcher.count > last + 1);
                         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~
ceph/src/test/msgr/test_msgr.cc:54:9: note: in definition of macro ‘CHECK_AND_WAIT_TRUE’
     if (expr)                           \
         ^~~~
ceph/src/test/msgr/test_msgr.cc:1475:30: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (srv_dispatcher.count == last) {
         ~~~~~~~~~~~~~~~~~~~~~^~~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>