### PR TITLE
qa/suites/upgrade/kraken-x: enable experimental for bluestore

### DIFF
--- a/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
+++ b/qa/suites/upgrade/kraken-x/parallel/0-cluster/start.yaml
@@ -25,4 +25,6 @@ overrides:
     - ScrubResult
     - wrongly marked
     conf:
+      global:
+        enable experimental unrecoverable data corrupting features: "*"
     fs: xfs

--- a/qa/suites/upgrade/kraken-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/0-cluster/start.yaml
@@ -6,6 +6,9 @@ meta:
 overrides:
   ceph:
     fs: xfs
+    conf:
+      global:
+        enable experimental unrecoverable data corrupting features: "*"
 roles:
 - - mon.a
   - mon.b


### PR DESCRIPTION
because we removed it from master

Signed-off-by: Sage Weil <sage@redhat.com>