### PR TITLE
qa/workunits/rados/test-upgrade-*: whitelist tests for master

### DIFF
--- a/qa/workunits/rados/test-upgrade-v11.0.0.sh
+++ b/qa/workunits/rados/test-upgrade-v11.0.0.sh
@@ -13,11 +13,14 @@ trap cleanup EXIT ERR HUP INT QUIT
 
 pids=""
 for f in \
-    'api_aio --gtest_filter=-LibRadosAio.RacingRemovePP' \
+    'api_aio --gtest_filter=-LibRadosAio.RacingRemovePP:-*WriteSame*:-*CmpExt*' \
     'api_list --gtest_filter=-LibRadosList*.EnumerateObjects*' \
-    api_io api_lock api_misc \
-    api_tier api_pool api_snapshots api_stat api_watch_notify api_cmd \
-    api_c_write_operations \
+    'api_io --gtest_filter=-*Checksum*' \
+    api_lock \
+    'api_misc --gtest_filter=-*WriteSame*:-*CmpExt*:-*Checksum*' \
+    'api_watch_notify --gtest_filter=-*WatchNotify3*' \
+    api_tier api_pool api_snapshots api_stat api_cmd \
+    'api_c_write_operations --gtest_filter=-*WriteSame*' \
     api_c_read_operations \
     list_parallel \
     open_pools_parallel \


### PR DESCRIPTION
The jewel-x upgrade test now runs this script against a mixed cluster on
a machine with code from master installed.  That means we have to skip
any new tests that will fail on a mixed cluster.

See /a/kchai-2017-05-30_05:52:48-upgrade-wip-mgr-stats-kefu---basic-mira/1244294

Signed-off-by: Sage Weil <sage@redhat.com>