### PR TITLE
qa/suites/jewel-x/point-to-point: do not upgrade ceph-test

### DIFF
--- a/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -70,6 +70,7 @@ tasks:
       branch: jewel
 - print: "**** done branch: jewel install.upgrade on client.1"
 - install.upgrade:
+    exclude_packages: ['ceph-test']
     mon.a:
     mon.b:
 - print: "**** done branch: -x install.upgrade on mon.a and mon.b"
@@ -79,6 +80,7 @@ tasks:
 - print: "**** done parallel -x branch"
 # Run librados tests on the -x upgraded cluster
 - install.upgrade:
+    exclude_packages: ['ceph-test']
     client.1:
 - workunit:
     branch: jewel


### PR DESCRIPTION
the luminous tests exercise the op introduced in after jewel, so if we
don't exclude ceph-test from upgraded packages, -EOPNOTSUPP (-95) would
be returned if OSD is not upgraded when serving the requests from new
ceph-test tests.

Signed-off-by: Kefu Chai <kchai@redhat.com>