### PR TITLE
src: put-to operator function - const input cleanup

### DIFF
--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -119,7 +119,7 @@ struct LogSummary {
 };
 WRITE_CLASS_ENCODER_FEATURES(LogSummary)
 
-inline ostream& operator<<(ostream& out, clog_type t)
+inline ostream& operator<<(ostream& out, const clog_type t)
 {
   switch (t) {
   case CLOG_DEBUG:

--- a/src/common/code_environment.cc
+++ b/src/common/code_environment.cc
@@ -41,7 +41,7 @@ extern "C" const char *code_environment_to_str(enum code_environment_t e)
   }
 }
 
-std::ostream &operator<<(std::ostream &oss, enum code_environment_t e)
+std::ostream &operator<<(std::ostream &oss, const enum code_environment_t e)
 {
   oss << code_environment_to_str(e);
   return oss;

--- a/src/common/code_environment.h
+++ b/src/common/code_environment.h
@@ -28,14 +28,14 @@ enum code_environment_t {
 
 extern "C" code_environment_t g_code_env;
 extern "C" const char *code_environment_to_str(enum code_environment_t e);
-std::ostream &operator<<(std::ostream &oss, enum code_environment_t e);
+std::ostream &operator<<(std::ostream &oss, const enum code_environment_t e);
 extern "C" int get_process_name(char *buf, int len);
 std::string get_process_name_cpp();
 
 #else
 
 extern code_environment_t g_code_env;
-const char *code_environment_to_str(enum code_environment_t e);
+const char *code_environment_to_str(const enum code_environment_t e);
 extern int get_process_name(char *buf, int len);
 
 #endif

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -904,7 +904,7 @@ namespace buffer CEPH_BUFFER_API {
     // cppcheck-suppress noExplicitConstructor
     hash(uint32_t init) : crc(init) { }
 
-    void update(buffer::list& bl) {
+    void update(const buffer::list& bl) {
       crc = bl.crc32c(crc);
     }
 
@@ -956,7 +956,7 @@ std::ostream& operator<<(std::ostream& out, const buffer::list& bl);
 
 std::ostream& operator<<(std::ostream& out, const buffer::error& e);
 
-inline bufferhash& operator<<(bufferhash& l, bufferlist &r) {
+inline bufferhash& operator<<(bufferhash& l, const bufferlist &r) {
   l.update(r);
   return l;
 }

--- a/src/include/frag.h
+++ b/src/include/frag.h
@@ -148,7 +148,7 @@ class frag_t {
   }
 };
 
-inline std::ostream& operator<<(std::ostream& out, frag_t hb)
+inline std::ostream& operator<<(std::ostream& out, const frag_t& hb)
 {
   //out << std::hex << hb.value() << std::dec << "/" << hb.bits() << '=';
   unsigned num = hb.bits();

--- a/src/include/fs_types.h
+++ b/src/include/fs_types.h
@@ -44,7 +44,7 @@ struct denc_traits<inodeno_t> {
   }
 };
 
-inline ostream& operator<<(ostream& out, inodeno_t ino) {
+inline ostream& operator<<(ostream& out, const inodeno_t& ino) {
   return out << hex << ino.val << dec;
 }
 

--- a/src/include/object.h
+++ b/src/include/object.h
@@ -139,7 +139,7 @@ struct denc_traits<snapid_t> {
   }
 };
 
-inline ostream& operator<<(ostream& out, snapid_t s) {
+inline ostream& operator<<(ostream& out, const snapid_t& s) {
   if (s == CEPH_NOSNAP)
     return out << "head";
   else if (s == CEPH_SNAPDIR)

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -418,7 +418,7 @@ enum health_status_t {
 };
 
 #ifdef __cplusplus
-inline ostream& operator<<(ostream &oss, health_status_t status) {
+inline ostream& operator<<(ostream &oss, const health_status_t status) {
   switch (status) {
     case HEALTH_ERR:
       oss << "HEALTH_ERR";

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -327,7 +327,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     }
   }
 
-  std::ostream &operator<<(std::ostream &os, rbd_image_options_t &opts) {
+  std::ostream &operator<<(std::ostream &os, const rbd_image_options_t &opts) {
     image_options_ref* opts_ = static_cast<image_options_ref*>(opts);
 
     os << "[";
@@ -343,7 +343,7 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     return os;
   }
 
-  std::ostream &operator<<(std::ostream &os, ImageOptions &opts) {
+  std::ostream &operator<<(std::ostream &os, const ImageOptions &opts) {
     os << "[";
 
     const char *delimiter = "";

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -48,10 +48,10 @@ struct mdsco_db_line_prefix {
   MDSCacheObject *object;
   explicit mdsco_db_line_prefix(MDSCacheObject *o) : object(o) {}
 };
-std::ostream& operator<<(std::ostream& out, mdsco_db_line_prefix o);
+std::ostream& operator<<(std::ostream& out, const mdsco_db_line_prefix& o);
 
 // printer
-std::ostream& operator<<(std::ostream& out, MDSCacheObject &o);
+std::ostream& operator<<(std::ostream& out, const MDSCacheObject &o);
 
 class MDSCacheObject {
  public:
@@ -406,7 +406,7 @@ inline std::ostream& operator<<(std::ostream& out, MDSCacheObject &o) {
   return out;
 }
 
-inline std::ostream& operator<<(std::ostream& out, mdsco_db_line_prefix o) {
+inline std::ostream& operator<<(std::ostream& out, const mdsco_db_line_prefix& o) {
   o.object->print_db_line_prefix(out);
   return out;
 }

--- a/src/messages/MMDSResolve.h
+++ b/src/messages/MMDSResolve.h
@@ -86,7 +86,7 @@ public:
   }
 };
 
-inline ostream& operator<<(ostream& out, const MMDSResolve::slave_request) {
+inline ostream& operator<<(ostream& out, const MMDSResolve::slave_request&) {
     return out;
 }
 

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -44,7 +44,7 @@ using std::vector;
 
 #define dout_subsys ceph_subsys_mon
 
-ostream& operator<<(ostream& out, mon_rwxa_t p)
+ostream& operator<<(ostream& out, const mon_rwxa_t& p)
 { 
   if (p == MON_CAP_ANY)
     return out << "*";

--- a/src/mon/MonCap.h
+++ b/src/mon/MonCap.h
@@ -32,7 +32,7 @@ struct mon_rwxa_t {
   }
 };
 
-ostream& operator<<(ostream& out, mon_rwxa_t p);
+ostream& operator<<(ostream& out, const mon_rwxa_t& p);
 
 struct StringConstraint {
   string value;

--- a/src/msg/async/dpdk/IP.cc
+++ b/src/msg/async/dpdk/IP.cc
@@ -48,7 +48,7 @@
 #undef dout_prefix
 #define dout_prefix *_dout << "dpdk "
 
-std::ostream& operator<<(std::ostream& os, ipv4_address a) {
+std::ostream& operator<<(std::ostream& os, const ipv4_address& a) {
   auto ip = a.ip;
   return os << ((ip >> 24) & 0xff) << "." << ((ip >> 16) & 0xff)
             << "." << ((ip >> 8) & 0xff) << "." << ((ip >> 0) & 0xff);

--- a/src/msg/async/dpdk/TCP.h
+++ b/src/msg/async/dpdk/TCP.h
@@ -69,7 +69,7 @@ inline tcp_state operator|(tcp_state s1, tcp_state s2) {
   return tcp_state(uint16_t(s1) | uint16_t(s2));
 }
 
-inline std::ostream & operator<<(std::ostream & str, tcp_state s) {
+inline std::ostream & operator<<(std::ostream & str, const tcp_state& s) {
   switch (s) {
     case tcp_state::CLOSED: return str << "CLOSED";
     case tcp_state::LISTEN: return str << "LISTEN";
@@ -154,7 +154,7 @@ tcp_sequence hton(tcp_sequence ts) {
   return tcp_sequence { ::hton(ts.raw) };
 }
 
-inline std::ostream& operator<<(std::ostream& os, tcp_sequence s) {
+inline std::ostream& operator<<(std::ostream& os, const tcp_sequence& s) {
   return os << s.raw;
 }
 

--- a/src/msg/async/dpdk/ethernet.cc
+++ b/src/msg/async/dpdk/ethernet.cc
@@ -2,7 +2,7 @@
 
 #include "ethernet.h"
 
-std::ostream& operator<<(std::ostream& os, ethernet_address ea) {
+std::ostream& operator<<(std::ostream& os, const ethernet_address& ea) {
   auto& m = ea.mac;
   using u = uint32_t;
   os << std::hex << std::setw(2)

--- a/src/msg/async/dpdk/ethernet.h
+++ b/src/msg/async/dpdk/ethernet.h
@@ -53,7 +53,7 @@ struct ethernet_address {
 inline bool operator==(const ethernet_address& a, const ethernet_address& b) {
   return a.mac == b.mac;
 }
-std::ostream& operator<<(std::ostream& os, ethernet_address ea);
+std::ostream& operator<<(std::ostream& os, const ethernet_address& ea);
 
 struct ethernet {
   using address = ethernet_address;

--- a/src/msg/async/dpdk/ip_types.h
+++ b/src/msg/async/dpdk/ip_types.h
@@ -95,7 +95,7 @@ struct ipv4_address {
 
 static inline bool is_unspecified(ipv4_address addr) { return addr.ip == 0; }
 
-std::ostream& operator<<(std::ostream& os, ipv4_address a);
+std::ostream& operator<<(std::ostream& os, const ipv4_address& a);
 
 namespace std {
 

--- a/src/os/bluestore/bluefs_types.cc
+++ b/src/os/bluestore/bluefs_types.cc
@@ -23,7 +23,7 @@ void bluefs_extent_t::generate_test_instances(list<bluefs_extent_t*>& ls)
   ls.back()->bdev = 1;
 }
 
-ostream& operator<<(ostream& out, bluefs_extent_t e)
+ostream& operator<<(ostream& out, const bluefs_extent_t& e)
 {
   return out << (int)e.bdev << ":0x" << std::hex << e.offset << "+" << e.length
 	     << std::dec;

--- a/src/os/bluestore/bluefs_types.h
+++ b/src/os/bluestore/bluefs_types.h
@@ -28,7 +28,7 @@ public:
 };
 WRITE_CLASS_DENC(bluefs_extent_t)
 
-ostream& operator<<(ostream& out, bluefs_extent_t e);
+ostream& operator<<(ostream& out, const bluefs_extent_t& e);
 
 
 struct bluefs_fnode_t {

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -24,7 +24,7 @@
 using std::ostream;
 using std::vector;
 
-ostream& operator<<(ostream& out, osd_rwxa_t p)
+ostream& operator<<(ostream& out, const osd_rwxa_t& p)
 { 
   if (p == OSD_CAP_ANY)
     return out << "*";

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -54,7 +54,7 @@ struct osd_rwxa_t {
   }
 };
 
-ostream& operator<<(ostream& out, osd_rwxa_t p);
+ostream& operator<<(ostream& out, const osd_rwxa_t& p);
 
 struct OSDCapSpec {
   osd_rwxa_t allow;


### PR DESCRIPTION
Fixed the instances of the issue specified in Tracker#3977 inside src/ folder utmost, by adding
const input. This fix avoids the following directories inside src: rocksdb/ zstd/ boost/ rapidjson/ googletest/ Beast/.

Fixes: http://tracker.ceph.com/issues/3977

Signed-off-by: Jos Collin <jcollin@redhat.com>