### PR TITLE
osd: When scrub finds an attr error mark shard inconsistent

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -782,16 +782,15 @@ void PGBackend::be_compare_scrubmaps(
 				   object_error,
 				   ss);
 	// Some errors might have already been set in be_select_auth_object()
-	if (shard_map[j->first].errors != 0) {
+	if (found || shard_map[j->first].errors != 0) {
 	  cur_inconsistent.insert(j->first);
           if (shard_map[j->first].has_deep_errors())
 	    ++deep_errors;
-	  else
+	  else if (shard_map[j->first].has_shallow_errors())
 	    ++shallow_errors;
 	  // Only true if be_compare_scrub_objects() found errors and put something
 	  // in ss.
-	  if (found)
-	    errorstream << pgid << " shard " << j->first << ": soid " << *k
+	  errorstream << pgid << " shard " << j->first << ": soid " << *k
 		      << " " << ss.str() << "\n";
 	} else {
 	  // XXX: The auth shard might get here that we don't know


### PR DESCRIPTION
When the only error is an xattr extra/missing key or value difference, it won't be repaired.