### PR TITLE
mon: track features from connect clients, and use it to gate set-require-min-compat-client

### DIFF
--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -2,6 +2,7 @@
  * Ceph string constants
  */
 #include "include/types.h"
+#include "include/ceph_features.h"
 
 const char *ceph_entity_type_name(int type)
 {
@@ -88,6 +89,9 @@ int ceph_release_from_name(const char *s)
 	if (!s) {
 		return -1;
 	}
+	if (strcmp(s, "mimic") == 0) {
+		return CEPH_RELEASE_MIMIC;
+	}
 	if (strcmp(s, "luminous") == 0) {
 		return CEPH_RELEASE_LUMINOUS;
 	}
@@ -125,6 +129,65 @@ int ceph_release_from_name(const char *s)
 		return CEPH_RELEASE_ARGONAUT;
 	}
 	return -1;
+}
+
+uint64_t ceph_release_features(int r)
+{
+	uint64_t req = 0;
+
+	req |= CEPH_FEATURE_CRUSH_TUNABLES;
+	if (r <= CEPH_RELEASE_CUTTLEFISH)
+		return req;
+
+	req |= CEPH_FEATURE_CRUSH_TUNABLES2 |
+		CEPH_FEATURE_OSDHASHPSPOOL;
+	if (r <= CEPH_RELEASE_EMPEROR)
+		return req;
+
+	req |= CEPH_FEATURE_CRUSH_TUNABLES3 |
+		CEPH_FEATURE_OSD_PRIMARY_AFFINITY |
+		CEPH_FEATURE_OSD_CACHEPOOL;
+	if (r <= CEPH_RELEASE_GIANT)
+		return req;
+
+	req |= CEPH_FEATURE_CRUSH_V4;
+	if (r <= CEPH_RELEASE_INFERNALIS)
+		return req;
+
+	req |= CEPH_FEATURE_CRUSH_TUNABLES5;
+	if (r <= CEPH_RELEASE_JEWEL)
+		return req;
+
+	req |= CEPH_FEATURE_MSG_ADDR2;
+	if (r <= CEPH_RELEASE_KRAKEN)
+		return req;
+
+	req |= CEPH_FEATUREMASK_CRUSH_CHOOSE_ARGS; // and overlaps
+	if (r <= CEPH_RELEASE_LUMINOUS)
+		return req;
+
+	return req;
+}
+
+/* return oldest/first release that supports these features */
+int ceph_release_from_features(uint64_t features)
+{
+	int r = 1;
+	while (true) {
+		uint64_t need = ceph_release_features(r);
+		if ((need & features) != need ||
+		    r == CEPH_RELEASE_MAX) {
+			r--;
+			need = ceph_release_features(r);
+			/* we want the first release that looks like this */
+			while (r > 1 && ceph_release_features(r - 1) == need) {
+				r--;
+			}
+			break;
+		}
+		++r;
+	}
+	return r;
 }
 
 const char *ceph_osd_watch_op_name(int o)

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -176,9 +176,12 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_RELEASE_KRAKEN     11
 #define CEPH_RELEASE_LUMINOUS   12
 #define CEPH_RELEASE_MIMIC      13
+#define CEPH_RELEASE_MAX        14  /* highest + 1 */
 
 extern const char *ceph_release_name(int r);
 extern int ceph_release_from_name(const char *s);
+extern uint64_t ceph_release_features(int r);
+extern int ceph_release_from_features(uint64_t features);
 
 /*
  * The error code to return when an OSD can't handle a write

--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -22,7 +22,7 @@
 
 class MMonPaxos : public Message {
 
-  static const int HEAD_VERSION = 3;
+  static const int HEAD_VERSION = 4;
   static const int COMPAT_VERSION = 3;
 
  public:
@@ -62,6 +62,8 @@ class MMonPaxos : public Message {
   bufferlist latest_value;
 
   map<version_t,bufferlist> values;
+
+  bufferlist feature_map;
 
   MMonPaxos() : Message(MSG_MON_PAXOS, HEAD_VERSION, COMPAT_VERSION) { }
   MMonPaxos(epoch_t e, int o, utime_t now) : 
@@ -103,6 +105,7 @@ public:
     ::encode(latest_version, payload);
     ::encode(latest_value, payload);
     ::encode(values, payload);
+    ::encode(feature_map, payload);
   }
   void decode_payload() override {
     bufferlist::iterator p = payload.begin();
@@ -118,6 +121,9 @@ public:
     ::decode(latest_version, p);
     ::decode(latest_value, p);
     ::decode(values, p);
+    if (header.version >= 4) {
+      ::decode(feature_map, p);
+    }
   }
 };
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -613,7 +613,8 @@ COMMAND("osd set-nearfull-ratio " \
 	"set usage ratio at which OSDs are marked near-full",
 	"osd", "rw", "cli,rest")
 COMMAND("osd set-require-min-compat-client " \
-	"name=version,type=CephString",
+	"name=version,type=CephString " \
+	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"set the minimum client version we will maintain compatibility with",
 	"osd", "rw", "cli,rest")
 COMMAND("osd pause", "pause osd", "osd", "rw", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -206,6 +206,8 @@ COMMAND("df name=detail,type=CephChoices,strings=detail,req=false", \
 COMMAND("report name=tags,type=CephString,n=N,req=false", \
 	"report full status of cluster, optional title tag strings", \
 	"mon", "r", "cli,rest")
+COMMAND("features", "report of connected features", \
+        "mon", "r", "cli,rest")
 COMMAND("quorum_status", "report status of monitor quorum", \
 	"mon", "r", "cli,rest")
 

--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -218,4 +218,30 @@ public:
 
 typedef MonOpRequest::Ref MonOpRequestRef;
 
+struct C_MonOp : public Context
+{
+  MonOpRequestRef op;
+
+  explicit C_MonOp(MonOpRequestRef o) :
+    op(o) { }
+
+  void finish(int r) override {
+    if (op && r == -ECANCELED) {
+      op->mark_event("callback canceled");
+    } else if (op && r == -EAGAIN) {
+      op->mark_event("callback retry");
+    } else if (op && r == 0) {
+      op->mark_event("callback finished");
+    }
+    _finish(r);
+  }
+
+  void mark_op_event(const string &event) {
+    if (op)
+      op->mark_event_string(event);
+  }
+
+  virtual void _finish(int r) = 0;
+};
+
 #endif /* MON_OPREQUEST_H_ */

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -1091,6 +1091,7 @@ void Monitor::_reset()
   }
   quorum.clear();
   outside_quorum.clear();
+  quorum_feature_map.clear();
 
   scrub_reset();
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2242,6 +2242,7 @@ void Monitor::get_mon_status(Formatter *f, ostream& ss)
   monmap->dump(f);
   f->close_section();
 
+  f->dump_object("feature_map", session_map.feature_map);
   f->close_section(); // mon_status
 
   if (free_formatter) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -576,6 +576,8 @@ public:
   void apply_monmap_to_compatset_features();
   void calc_quorum_requirements();
 
+  void get_combined_feature_map(FeatureMap *fm);
+
 private:
   void _reset();   ///< called from bootstrap, start_, or join_election
   void wait_for_paxos_write();

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -230,6 +230,11 @@ private:
   set<int> quorum;       // current active set of monitors (if !starting)
   utime_t leader_since;  // when this monitor became the leader, if it is the leader
   utime_t exited_quorum; // time detected as not in quorum; 0 if in
+
+  // map of counts of connected clients, by type and features, for
+  // each quorum mon
+  map<int,FeatureMap> quorum_feature_map;
+
   /**
    * Intersection of quorum member's connection feature bits.
    */

--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -17,6 +17,7 @@
 #include "Monitor.h"
 #include "messages/MMonPaxos.h"
 
+#include "mon/mon_types.h"
 #include "common/config.h"
 #include "include/assert.h"
 #include "include/stringify.h"
@@ -1113,6 +1114,7 @@ void Paxos::handle_lease(MonOpRequestRef op)
   ack->last_committed = last_committed;
   ack->first_committed = first_committed;
   ack->lease_timestamp = ceph_clock_now();
+  ::encode(mon->session_map.feature_map, ack->feature_map);
   lease->get_connection()->send_message(ack);
 
   // (re)set timeout event.
@@ -1136,7 +1138,11 @@ void Paxos::handle_lease_ack(MonOpRequestRef op)
   }
   else if (acked_lease.count(from) == 0) {
     acked_lease.insert(from);
-    
+    if (ack->feature_map.length()) {
+      auto p = ack->feature_map.begin();
+      FeatureMap& t = mon->quorum_feature_map[from];
+      ::decode(t, p);
+    }
     if (acked_lease == mon->get_quorum()) {
       // yay!
       dout(10) << "handle_lease_ack from " << ack->get_source() 

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -96,6 +96,8 @@ struct FeatureMap {
       for (auto& q : p.second) {
 	f->open_object_section("group");
 	f->dump_unsigned("features", q.first);
+	f->dump_string("release", ceph_release_name(
+			 ceph_release_from_features(q.first)));
 	f->dump_unsigned("num", q.second);
 	f->close_section();
       }

--- a/src/mon/mon_types.h
+++ b/src/mon/mon_types.h
@@ -20,7 +20,6 @@
 #include "common/Formatter.h"
 #include "common/bit_str.h"
 #include "include/Context.h"
-#include "mon/MonOpRequest.h"
 
 #define PAXOS_PGMAP      0  // before osd, for pg kick to behave
 #define PAXOS_MDSMAP     1
@@ -210,32 +209,6 @@ static inline ostream& operator<<(ostream& out, const ScrubResult& r) {
 
 /// for information like os, kernel, hostname, memory info, cpu model.
 typedef map<string, string> Metadata;
-
-struct C_MonOp : public Context
-{
-  MonOpRequestRef op;
-
-  explicit C_MonOp(MonOpRequestRef o) :
-    op(o) { }
-
-  void finish(int r) override {
-    if (op && r == -ECANCELED) {
-      op->mark_event("callback canceled");
-    } else if (op && r == -EAGAIN) {
-      op->mark_event("callback retry");
-    } else if (op && r == 0) {
-      op->mark_event("callback finished");
-    }
-    _finish(r);
-  }
-
-  void mark_op_event(const string &event) {
-    if (op)
-      op->mark_event_string(event);
-  }
-
-  virtual void _finish(int r) = 0;
-};
 
 namespace ceph {
   namespace features {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -728,6 +728,13 @@ add_executable(unittest_mempool
 add_ceph_unittest(unittest_mempool ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_mempool)
 target_link_libraries(unittest_mempool global)
 
+# unittest_features
+add_executable(unittest_features
+  test_features.cc
+  )
+add_ceph_unittest(unittest_features ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_features)
+target_link_libraries(unittest_features global)
+
 # unittest_crypto
 add_executable(unittest_crypto
   crypto.cc

--- a/src/test/test_features.cc
+++ b/src/test/test_features.cc
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include <stdio.h>
+
+#include "global/global_init.h"
+#include "common/ceph_argparse.h"
+#include "global/global_context.h"
+#include "gtest/gtest.h"
+#include "include/ceph_features.h"
+#include "include/rados.h"
+
+
+TEST(features, release_features)
+{
+  for (int r = 1; r < CEPH_RELEASE_MAX; ++r) {
+    const char *name = ceph_release_name(r);
+    ASSERT_NE(string("unknown"), name);
+    ASSERT_EQ(r, ceph_release_from_name(name));
+    uint64_t features = ceph_release_features(r);
+    int rr = ceph_release_from_features(features);
+    cout << r << " " << name << " features 0x" << std::hex << features
+	 << std::dec << " looks like " << ceph_release_name(rr) << std::endl;
+    EXPECT_LE(rr, r);
+  }
+}
+
+TEST(features, release_from_features) {
+  ASSERT_EQ(CEPH_RELEASE_JEWEL, ceph_release_from_features(575862587619852283));
+  ASSERT_EQ(CEPH_RELEASE_LUMINOUS,
+	    ceph_release_from_features(1152323339925389307));
+}
+
+int main(int argc, char **argv)
+{
+  vector<const char*> args;
+  argv_to_vec(argc, (const char **)argv, args);
+
+  auto cct = global_init(NULL, args, CEPH_ENTITY_TYPE_CLIENT,
+			 CODE_ENVIRONMENT_UTILITY, 0);
+  common_init_finish(g_ceph_context);
+
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
As an aside, I kind of hate the 'ceph osd set-require-min-compat-client' naming.  Any better ideas?