### PR TITLE
mds:fix judgment for MDSDaemon::handle_mds_map()

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -893,7 +893,7 @@ void MDSDaemon::handle_mds_map(MMDSMap *m)
       // We have entered a rank-holding state, we shouldn't be back
       // here!
       if (g_conf->mds_enforce_unique_name) {
-        if (mds_gid_t existing = mdsmap->find_mds_gid_by_name(name)) {
+        if (mds_gid_t existing == mdsmap->find_mds_gid_by_name(name)) {
           const MDSMap::mds_info_t& i = mdsmap->get_info_gid(existing);
           if (i.global_id > monc->get_global_id()) {
             dout(1) << "handle_mds_map i (" << addr


### PR DESCRIPTION
here lossed '=', I add it.

Signed-off-by: yonghengdexin735 <zhang.zezhu@zte.com.cn>