### PR TITLE
ceph.in: print return code when json_command failed

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -363,9 +363,9 @@ def do_extended_help(parser, args, target, partial):
                                          prefix='get_command_descriptions',
                                          timeout=10)
         if ret:
-            print("couldn't get command descriptions for {0}: {1}".
-                  format(target, outs), file=sys.stderr)
-            return 1
+            print("couldn't get command descriptions for {0}: {1} ({2})".
+                  format(target, outs, ret), file=sys.stderr)
+            return ret
         else:
             return help_for_sigs(outbuf.decode('utf-8'), partial)
 


### PR DESCRIPTION
@tchaikov  I updated code to print more informations when `json_command` failed, so that we will get more information to debug why `ceph tell mgr help`  test randomly fail.

current output as following( i mocked return code):
```
/home/liuchang/WorkSpace/ceph/qa/workunits/cephtool/test.sh:2066: test_osd_tell_help_command:  ceph tell osd.1 help
2017-05-31 15:39:37.507688 7fe079b09700 -1 WARNING: all dangerous and experimental features are enabled.
2017-05-31 15:39:37.515530 7fe079b09700 -1 WARNING: all dangerous and experimental features are enabled.
couldn't get command descriptions for [u'osd', u'1'], ret code: 1 EPERM
```


Signed-off-by: liuchang0812 <liuchang0812@gmail.com>

