### PR TITLE
mon/OSDMonitor: batch OSDs nodown/noout support

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1440,6 +1440,19 @@ function test_mon_osd()
   ceph osd rm-nodown all
   ! ceph health detail | grep 'nodown osd(s).*0.*1'
 
+  ids=`ceph osd ls-tree default`
+  for osd in $ids
+  do
+    ceph osd add-noout $osd
+    ceph osd add-nodown $osd
+  done
+  ceph -s | grep 'noout osd(s)'
+  ceph -s | grep 'nodown osd(s)'
+  ceph osd rm-noout any
+  ceph osd rm-nodown any
+  ! ceph -s | grep 'noout osd(s)'
+  ! ceph -s | grep 'nodown osd(s)'
+
   # make sure mark out preserves weight
   ceph osd reweight osd.0 .5
   ceph osd dump | grep ^osd.0 | grep 'weight 0.5'

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1430,6 +1430,16 @@ function test_mon_osd()
   ceph osd dump | grep 'osd.0.*in'
   ceph osd find 0
 
+  ceph osd add-noout 0
+  ceph health detail | grep 'noout osd(s).*0'
+  ceph osd rm-noout 0
+  ! ceph health detail | grep 'noout osds(s).*0'
+
+  ceph osd add-nodown 0 1
+  ceph health detail | grep 'nodown osd(s).*0.*1'
+  ceph osd rm-nodown all
+  ! ceph health detail | grep 'nodown osd(s).*0.*1'
+
   # make sure mark out preserves weight
   ceph osd reweight osd.0 .5
   ceph osd dump | grep ^osd.0 | grep 'weight 0.5'

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -46,6 +46,10 @@ const char *ceph_osd_state_name(int s)
 		return "backfillfull";
         case CEPH_OSD_DESTROYED:
                 return "destroyed";
+        case CEPH_OSD_NODOWN:
+                return "nodown";
+        case CEPH_OSD_NOOUT:
+                return "noout";
 	default:
 		return "???";
 	}

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -637,6 +637,15 @@ public:
   int get_children(int id, list<int> *children);
 
   /**
+    * enumerate leaves(devices) of given node
+    *
+    * @param name parent bucket name
+    * @return 0 on success or a negative errno on error.
+    */
+  int get_leaves(const string &name, set<int> *leaves);
+  int _get_leaves(int id, list<int> *leaves); // worker
+
+  /**
    * insert an item into the map at a specific position
    *
    * Add an item as a specific location of the hierarchy.

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -110,14 +110,16 @@ struct ceph_eversion {
  */
 
 /* status bits */
-#define CEPH_OSD_EXISTS  (1<<0)
-#define CEPH_OSD_UP      (1<<1)
-#define CEPH_OSD_AUTOOUT (1<<2)  /* osd was automatically marked out */
-#define CEPH_OSD_NEW     (1<<3)  /* osd is new, never marked in */
-#define CEPH_OSD_FULL    (1<<4)  /* osd is at or above full threshold */
-#define CEPH_OSD_NEARFULL (1<<5) /* osd is at or above nearfull threshold */
+#define CEPH_OSD_EXISTS       (1<<0)
+#define CEPH_OSD_UP           (1<<1)
+#define CEPH_OSD_AUTOOUT      (1<<2) /* osd was automatically marked out */
+#define CEPH_OSD_NEW          (1<<3) /* osd is new, never marked in */
+#define CEPH_OSD_FULL         (1<<4) /* osd is at or above full threshold */
+#define CEPH_OSD_NEARFULL     (1<<5) /* osd is at or above nearfull threshold */
 #define CEPH_OSD_BACKFILLFULL (1<<6) /* osd is at or above backfillfull threshold */
-#define CEPH_OSD_DESTROYED (1<<7) /* osd has been destroyed */
+#define CEPH_OSD_DESTROYED    (1<<7) /* osd has been destroyed */
+#define CEPH_OSD_NODOWN       (1<<8) /* osd can not be marked down */
+#define CEPH_OSD_NOOUT        (1<<9) /* osd can not be marked out */
 
 extern const char *ceph_osd_state_name(int s);
 
@@ -132,24 +134,24 @@ extern const char *ceph_osd_state_name(int s);
 /*
  * osd map flag bits
  */
-#define CEPH_OSDMAP_NEARFULL (1<<0)  /* sync writes (near ENOSPC) */
-#define CEPH_OSDMAP_FULL     (1<<1)  /* no data writes (ENOSPC) */
-#define CEPH_OSDMAP_PAUSERD  (1<<2)  /* pause all reads */
-#define CEPH_OSDMAP_PAUSEWR  (1<<3)  /* pause all writes */
-#define CEPH_OSDMAP_PAUSEREC (1<<4)  /* pause recovery */
-#define CEPH_OSDMAP_NOUP     (1<<5)  /* block osd boot */
-#define CEPH_OSDMAP_NODOWN   (1<<6)  /* block osd mark-down/failure */
-#define CEPH_OSDMAP_NOOUT    (1<<7)  /* block osd auto mark-out */
-#define CEPH_OSDMAP_NOIN     (1<<8)  /* block osd auto mark-in */
-#define CEPH_OSDMAP_NOBACKFILL (1<<9) /* block osd backfill */
-#define CEPH_OSDMAP_NORECOVER (1<<10) /* block osd recovery and backfill */
-#define CEPH_OSDMAP_NOSCRUB  (1<<11) /* block periodic scrub */
-#define CEPH_OSDMAP_NODEEP_SCRUB (1<<12) /* block periodic deep-scrub */
-#define CEPH_OSDMAP_NOTIERAGENT (1<<13) /* disable tiering agent */
-#define CEPH_OSDMAP_NOREBALANCE (1<<14) /* block osd backfill unless pg is degraded */
-#define CEPH_OSDMAP_SORTBITWISE (1<<15) /* use bitwise hobject_t sort */
-#define CEPH_OSDMAP_REQUIRE_JEWEL (1<<16) /* require jewel for booting osds */
-#define CEPH_OSDMAP_REQUIRE_KRAKEN (1<<17) /* require kraken for booting osds */
+#define CEPH_OSDMAP_NEARFULL         (1<<0)  /* sync writes (near ENOSPC) */
+#define CEPH_OSDMAP_FULL             (1<<1)  /* no data writes (ENOSPC) */
+#define CEPH_OSDMAP_PAUSERD          (1<<2)  /* pause all reads */
+#define CEPH_OSDMAP_PAUSEWR          (1<<3)  /* pause all writes */
+#define CEPH_OSDMAP_PAUSEREC         (1<<4)  /* pause recovery */
+#define CEPH_OSDMAP_NOUP             (1<<5)  /* block osd boot */
+#define CEPH_OSDMAP_NODOWN           (1<<6)  /* block osd mark-down/failure */
+#define CEPH_OSDMAP_NOOUT            (1<<7)  /* block osd auto mark-out */
+#define CEPH_OSDMAP_NOIN             (1<<8)  /* block osd auto mark-in */
+#define CEPH_OSDMAP_NOBACKFILL       (1<<9)  /* block osd backfill */
+#define CEPH_OSDMAP_NORECOVER        (1<<10) /* block osd recovery and backfill */
+#define CEPH_OSDMAP_NOSCRUB          (1<<11) /* block periodic scrub */
+#define CEPH_OSDMAP_NODEEP_SCRUB     (1<<12) /* block periodic deep-scrub */
+#define CEPH_OSDMAP_NOTIERAGENT      (1<<13) /* disable tiering agent */
+#define CEPH_OSDMAP_NOREBALANCE      (1<<14) /* block osd backfill unless pg is degraded */
+#define CEPH_OSDMAP_SORTBITWISE      (1<<15) /* use bitwise hobject_t sort */
+#define CEPH_OSDMAP_REQUIRE_JEWEL    (1<<16) /* require jewel for booting osds */
+#define CEPH_OSDMAP_REQUIRE_KRAKEN   (1<<17) /* require kraken for booting osds */
 #define CEPH_OSDMAP_REQUIRE_LUMINOUS (1<<18) /* require l for booting osds */
 
 /* these are hidden in 'ceph status' view */

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -645,16 +645,24 @@ COMMAND("osd cluster_snap", "take cluster snapshot (disabled)", \
 	"osd", "r", "")
 COMMAND("osd down " \
 	"type=CephString,name=ids,n=N", \
-	"set osd(s) <id> [<id>...] down", "osd", "rw", "cli,rest")
+	"set osd(s) <id> [<id>...] down, " \
+        "or use <any|all|*> to set all osds down", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd out " \
 	"name=ids,type=CephString,n=N", \
-	"set osd(s) <id> [<id>...] out", "osd", "rw", "cli,rest")
+	"set osd(s) <id> [<id>...] out, " \
+        "or use <any|all|*> to set all osds out", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd in " \
 	"name=ids,type=CephString,n=N", \
-	"set osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
+	"set osd(s) <id> [<id>...] in, "
+        "can use <any|all|*> to automatically set all previously out osds in", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd rm " \
 	"name=ids,type=CephString,n=N", \
-	"remove osd(s) <id> [<id>...]", "osd", "rw", "cli,rest")
+	"remove osd(s) <id> [<id>...], "
+        "or use <any|all|*> to remove all osds", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd add-noout " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noout, " \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -650,6 +650,28 @@ COMMAND("osd in " \
 COMMAND("osd rm " \
 	"name=ids,type=CephString,n=N", \
 	"remove osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
+COMMAND("osd add-noout " \
+        "name=ids,type=CephString,n=N", \
+        "mark osd(s) <id> [<id>...] as noout, " \
+        "or use <all|any|*> to mark all osds as noout", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd add-nodown " \
+        "name=ids,type=CephString,n=N", \
+        "mark osd(s) <id> [<id>...] as nodown, " \
+        "or use <all|any|*> to mark all osds as nodown", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd rm-noout " \
+        "name=ids,type=CephString,n=N", \
+        "allow osd(s) <id> [<id>...] to be marked out " \
+        "(if they are currently marked as noout), " \
+        "can use <all|any|*> to automatically filter out all noout osds", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd rm-nodown " \
+        "name=ids,type=CephString,n=N", \
+        "allow osd(s) <id> [<id>...] to be marked down " \
+        "(if they are currently marked as nodown), " \
+        "can use <all|any|*> to automatically filter out all nodown osds", \
+        "osd", "rw", "cli,rest")
 COMMAND("osd reweight " \
 	"name=id,type=CephOsdName " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -437,6 +437,11 @@ COMMAND("osd getcrushmap " \
 	"name=epoch,type=CephInt,range=0,req=false", \
 	"get CRUSH map", "osd", "r", "cli,rest")
 COMMAND("osd getmaxosd", "show largest OSD id", "osd", "r", "cli,rest")
+COMMAND("osd ls-tree " \
+        "name=epoch,type=CephInt,range=0,req=false "
+        "name=name,type=CephString,req=true", \
+        "show OSD ids under bucket <name> in the CRUSH map", \
+        "osd", "r", "cli,rest")
 COMMAND("osd find " \
 	"name=id,type=CephOsdName", \
 	"find osd <id> in the CRUSH map and show its location", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -654,7 +654,7 @@ COMMAND("osd in " \
 	"set osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
 COMMAND("osd rm " \
 	"name=ids,type=CephString,n=N", \
-	"remove osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
+	"remove osd(s) <id> [<id>...]", "osd", "rw", "cli,rest")
 COMMAND("osd add-noout " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as noout, " \

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -1219,6 +1219,14 @@ void OSDMap::get_up_osds(set<int32_t>& ls) const
   }
 }
 
+void OSDMap::get_out_osds(set<int32_t>& ls) const
+{
+  for (int i = 0; i < max_osd; i++) {
+    if (is_out(i))
+      ls.insert(i);
+  }
+}
+
 void OSDMap::calc_state_set(int state, set<string>& st)
 {
   unsigned t = state;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3895,3 +3895,8 @@ int OSDMap::calc_pg_upmaps(
   ldout(cct, 10) << " end deviation " << end_deviation << dendl;
   return num_changed;
 }
+
+int OSDMap::get_osds_by_bucket_name(const string &name, set<int> *osds) const
+{
+  return crush->get_leaves(name, osds);
+}

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -659,6 +659,7 @@ public:
 
   void get_all_osds(set<int32_t>& ls) const;
   void get_up_osds(set<int32_t>& ls) const;
+  void get_out_osds(set<int32_t>& ls) const;
   unsigned get_num_pg_temp() const {
     return pg_temp->size();
   }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1221,6 +1221,8 @@ public:
     Incremental *pending_inc
     );
 
+  int get_osds_by_bucket_name(const string &name, set<int> *osds) const;
+
   /*
    * handy helpers to build simple maps...
    */


### PR DESCRIPTION
This patch allow us to add batch OSDs(e.g., from a specific host which is currently in maintenance)
into a specific nodown/noout list, which can not be automatically marked down/out
and hence can be eliminated from data migration.

This has the same effect with the global nodown/noout flag but is more fine-grained.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>