### PR TITLE
test/osd/TestRados.cc: run set-redirect test after finishing setup

### DIFF
--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -120,20 +120,27 @@ public:
 	return new SetRedirectOp(m_op, &context, oid.str(), oid2.str(), context.pool_name);
       } 
 
-      if (!context.oid_redirect_not_in_use.size() && m_op == set_redirect_end+1) {
-	for (int t_op = m_objects+1; t_op <= create_objects_end; t_op++) {
-	  stringstream oid;
-	  oid << t_op;
-	  if (t_op % 2) {
-	    oid << " " << string(300, 'o');
-	  }
-	  context.oid_not_flushing.erase(oid.str());
-	  context.oid_not_in_use.erase(oid.str());
-	  context.oid_in_use.erase(oid.str());
-	  if (t_op > m_objects + m_initial_redirected_objects) {
-	    context.oid_redirect_not_in_use.insert(oid.str());
-	  }
-	}
+      if (!context.oid_redirect_not_in_use.size() && m_op > set_redirect_end) {
+	int set_size = context.oid_not_in_use.size();
+        if (set_size < m_objects + m_redirect_objects) {
+          return NULL;
+        }
+        for (int t_op = m_objects+1; t_op <= create_objects_end; t_op++) {
+          stringstream oid;
+          oid << t_op;
+          if (t_op % 2) {
+            oid << " " << string(300, 'o');
+          }
+          context.oid_not_flushing.erase(oid.str());
+          context.oid_not_in_use.erase(oid.str());
+          context.oid_in_use.erase(oid.str());
+          cout << m_op << ": " << " remove oid " << oid.str() << " from oid_*_use " << std::endl;
+          if (t_op > m_objects + m_initial_redirected_objects) {
+            context.oid_redirect_not_in_use.insert(oid.str());
+          }
+        }
+	cout << m_op << ": " << " oid_not_in_use: " << context.oid_not_in_use.size()
+	      << " oid_in_use: " << context.oid_in_use.size() << std::endl;
       }
     }
 


### PR DESCRIPTION
set-redirect (https://github.com/ceph/ceph/pull/14894) test creates more objects than default due to redirect mapping
(let's assume that we create 500 objects, oid 1 -> oid 501, oid 2 -> oid 502)
But the test should use objects within pre-defined range. For example,
If the number of object is 500, only 1~500 oid are allowed for test operations.

In the failure cases, test operation tried to use wrong oids (which means
higher than 500). This is because the bug in the setup phase.
If max_inflights > 1, set-redirect can be finished after setup is completed.
(so wrong oid is included in oid_in_use).
We need to completely remove redirect objects in oid_in_use before start the test.

Fixes: http://tracker.ceph.com/issues/20114
Signed-off-by: Myoungwon Oh omwmw@sk.com