### PR TITLE
mon: revise "ceph status" output

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -124,16 +124,15 @@ void FSMap::print_summary(Formatter *f, ostream *out) const
       f->dump_unsigned("max", fs->mds_map.max_mds);
     }
   } else {
-    *out << "e" << get_epoch() << ":";
     if (filesystems.size() == 1) {
       auto fs = filesystems.begin()->second;
-      *out << " " << fs->mds_map.up.size() << "/" << fs->mds_map.in.size() << "/"
+      *out << fs->mds_map.up.size() << "/" << fs->mds_map.in.size() << "/"
            << fs->mds_map.max_mds << " up";
     } else {
       for (auto i : filesystems) {
         auto fs = i.second;
-        *out << " " << fs->mds_map.fs_name << "-" << fs->mds_map.up.size() << "/"
-             << fs->mds_map.in.size() << "/" << fs->mds_map.max_mds << " up";
+        *out << fs->mds_map.fs_name << "-" << fs->mds_map.up.size() << "/"
+             << fs->mds_map.in.size() << "/" << fs->mds_map.max_mds << " up ";
       }
     }
   }

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -126,10 +126,12 @@ public:
       dump(f);
     } else {
       if (get_active_gid() != 0) {
-	*ss << "active: " << get_active_name();
+	*ss << get_active_name();
         if (!available) {
           // If the daemon hasn't gone active yet, indicate that.
-          *ss << "(starting)";
+          *ss << "(active, starting)";
+        } else {
+          *ss << "(active)";
         }
         *ss << " ";
       } else {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3076,8 +3076,7 @@ void OSDMap::print_summary(Formatter *f, ostream& out) const
     f->dump_unsigned("num_remapped_pgs", get_num_pg_temp());
     f->close_section();
   } else {
-    out << "     osdmap e" << get_epoch() << ": "
-	<< get_num_osds() << " osds: "
+    out << get_num_osds() << " osds: "
 	<< get_num_up_osds() << " up, "
 	<< get_num_in_osds() << " in";
     if (get_num_pg_temp())
@@ -3092,7 +3091,7 @@ void OSDMap::print_summary(Formatter *f, ostream& out) const
 void OSDMap::print_oneline_summary(ostream& out) const
 {
   out << "e" << get_epoch() << ": "
-      << get_num_osds() << " osds: "
+      << get_num_osds() << " total, "
       << get_num_up_osds() << " up, "
       << get_num_in_osds() << " in";
   if (test_flag(CEPH_OSDMAP_FULL))


### PR DESCRIPTION

Old:
```
    cluster 8ba08162-a390-479c-a698-6d8911c4f451
     health HEALTH_OK
     monmap e2: 3 mons at {a=172.21.9.34:6789/0,b=172.21.9.34:6790/0,c=172.21.9.34:6791/0}
            election epoch 8, quorum 0,1,2 a,b,c
      fsmap e15: 1/1/1 up {0=b=up:active}, 1 up:standby
        mgr active: x 
     osdmap e21: 1 osds: 1 up, 1 in
      pgmap v191: 26 pgs, 3 pools, 4145 kB data, 23 objects
            494 GB used, 436 GB / 931 GB avail
                  26 active+clean
```

New:
```
  cluster:
    id:     0554f6f9-6061-425d-a343-f246020f1464
    health: HEALTH_OK
 
  services:
    mon: 1 daemons, quorum a
    mgr: x(active) 
    mds: cephfs_a-1/1/1 up cephfs_b-1/1/1 up  {[cephfs_a:0]=b=up:active,[cephfs_b:0]=a=up:active}, 1 up:standby
    osd: 3 osds: 3 up, 3 in
 
  data:
    pools:   5 pools, 40 pgs
    objects: 42 objects, 4492 bytes
    usage:   1486 GB used, 1306 GB / 2793 GB avail
    pgs:     40 active+clean
 
  io:
    client io: 0 B/s wr, 0 op/s rd, 1 op/s wr
```