### PR TITLE
qa/rgw_snaps: move default_idle_timeout config under the client

### DIFF
--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -8,8 +8,8 @@ overrides:
         osd_max_omap_entries_per_request: 10
 tasks:
 - rgw:
-    default_idle_timeout: 3600
-    client.0: null
+    client.0:
+      default_idle_timeout: 3600
 - thrash_pool_snaps:
     pools:
     - .rgw.buckets


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20128

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>