### PR TITLE
mds/MDBalancer: remove useless check_targets and hit_targets logic from MDS balancer

### DIFF
--- a/src/mds/MDBalancer.cc
+++ b/src/mds/MDBalancer.cc
@@ -730,15 +730,6 @@ void MDBalancer::prep_rebalance(int beat)
   try_rebalance(state);
 }
 
-void MDBalancer::hit_targets(const balance_state_t& state)
-{
-  utime_t now = ceph_clock_now();
-  for (auto &it : state.targets) {
-    mds_rank_t target = it.first;
-    mds->hit_export_target(now, target, g_conf->mds_bal_target_decay);
-  }
-}
-
 int MDBalancer::mantle_prep_rebalance()
 {
   balance_state_t state;
@@ -794,9 +785,6 @@ int MDBalancer::mantle_prep_rebalance()
 
 void MDBalancer::try_rebalance(balance_state_t& state)
 {
-  if (!check_targets(state))
-    return;
-
   if (g_conf->mds_thrash_exports) {
     dout(5) << "mds_thrash is on; not performing standard rebalance operation!"
 	    << dendl;
@@ -945,18 +933,6 @@ void MDBalancer::try_rebalance(balance_state_t& state)
 
   dout(5) << "rebalance done" << dendl;
   mds->mdcache->show_subtrees();
-}
-
-
-/* Check that all targets are in the MDSMap export_targets for my rank. */
-bool MDBalancer::check_targets(const balance_state_t& state)
-{
-  for (const auto &it : state.targets) {
-    if (!mds->is_export_target(it.first)) {
-      return false;
-    }
-  }
-  return true;
 }
 
 void MDBalancer::find_exports(CDir *dir,

--- a/src/mds/MDBalancer.h
+++ b/src/mds/MDBalancer.h
@@ -89,8 +89,6 @@ private:
 
   void export_empties();
   int localize_balancer();
-  bool check_targets(const balance_state_t& state);
-  void hit_targets(const balance_state_t& state);
   void send_heartbeat();
   void handle_heartbeat(MHeartbeat *m);
   void find_exports(CDir *dir,


### PR DESCRIPTION
Currently Multiple MDSes fail to do rebalance because MDS's export_targets in MDSMap are empty even if they need to do rebalance.

The reason is that we didn't update MDSRank's export_targets according to balance state, then MDSRank's tick won't update MDSMap's export_targets to Mon. And the new function MDBalancer::hit_targets should be aimed to do such things, but it hadn't been called at anywhere.

Fixes: #http://tracker.ceph.com/issues/20131

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>