### PR TITLE
ceph-disk: do not setup_statedir on trigger

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -5601,7 +5601,9 @@ def main(argv):
         path = os.environ.get('PATH', os.defpath)
         os.environ['PATH'] = args.prepend_to_path + ":" + path
 
-    setup_statedir(args.statedir)
+    if args.func.__name__ != 'main_trigger':
+        # trigger may run when statedir is unavailable and does not use it
+        setup_statedir(args.statedir)
     setup_sysconfdir(args.sysconfdir)
 
     global CEPH_PREF_USER


### PR DESCRIPTION
trigger may run when statedir is unavailable and does not use it.

Fixes: http://tracker.ceph.com/issues/19941

Signed-off-by: Loic Dachary <loic@dachary.org>