### PR TITLE
crush: add missing tunable in tests

### DIFF
--- a/src/test/crush/crush-choose-args-expected-one-more-0.txt
+++ b/src/test/crush/crush-choose-args-expected-one-more-0.txt
@@ -4,6 +4,7 @@ tunable choose_local_fallback_tries 0
 tunable choose_total_tries 50
 tunable chooseleaf_descend_once 1
 tunable chooseleaf_vary_r 1
+tunable chooseleaf_stable 1
 tunable straw_calc_version 1
 tunable allowed_bucket_algs 54
 

--- a/src/test/crush/crush-choose-args-expected-one-more-3.txt
+++ b/src/test/crush/crush-choose-args-expected-one-more-3.txt
@@ -4,6 +4,7 @@ tunable choose_local_fallback_tries 0
 tunable choose_total_tries 50
 tunable chooseleaf_descend_once 1
 tunable chooseleaf_vary_r 1
+tunable chooseleaf_stable 1
 tunable straw_calc_version 1
 tunable allowed_bucket_algs 54
 


### PR DESCRIPTION
Signed-off-by: Loic Dachary <loic@dachary.org>