### PR TITLE
qa/rgw: remove default_idle_timeout

### DIFF
--- a/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rgw-swift.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rgw-swift.yaml
@@ -3,8 +3,7 @@ meta:
    swift api tests for rgw
 tasks:
 - rgw: 
-    client.0:
-    default_idle_timeout: 300
+    client.0: null
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:

--- a/qa/suites/upgrade/jewel-x/stress-split/7-final-workload/rgw-swift.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/7-final-workload/rgw-swift.yaml
@@ -3,8 +3,7 @@ meta:
    swift api tests for rgw
 tasks:
 - rgw:
-    client.0:
-    default_idle_timeout: 300
+    client.0: null
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:

--- a/qa/suites/upgrade/kraken-x/stress-split/7-final-workload/rgw-swift.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/7-final-workload/rgw-swift.yaml
@@ -3,8 +3,7 @@ meta:
    swift api tests for rgw
 tasks:
 - rgw:
-    client.0:
-    default_idle_timeout: 300
+    client.0: null
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:


### PR DESCRIPTION
removed as part of fastcgi cleanup

continuation of https://github.com/ceph/ceph/pull/15400