### PR TITLE
qa: Removed all 'default_idle_timeout' due to chnage in rwg task

### DIFF
--- a/qa/machine_types/vps.yaml
+++ b/qa/machine_types/vps.yaml
@@ -6,8 +6,6 @@ overrides:
         # this line to address issue #1017 
         mon lease: 15
         mon lease ack timeout: 25
-  rgw:
-    default_idle_timeout: 1200
   s3tests:
     idle_timeout: 1200
   ceph-fuse:

--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -9,7 +9,6 @@ overrides:
 tasks:
 - rgw:
     client.0:
-      default_idle_timeout: 3600
 - thrash_pool_snaps:
     pools:
     - .rgw.buckets

--- a/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rgw-swift.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rgw-swift.yaml
@@ -4,7 +4,6 @@ meta:
 tasks:
 - rgw: 
     client.0:
-    default_idle_timeout: 300
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:

--- a/qa/suites/upgrade/jewel-x/stress-split/7-final-workload/rgw-swift.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/7-final-workload/rgw-swift.yaml
@@ -4,7 +4,6 @@ meta:
 tasks:
 - rgw:
     client.0:
-    default_idle_timeout: 300
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:

--- a/qa/suites/upgrade/kraken-x/stress-split/7-final-workload/rgw-swift.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/7-final-workload/rgw-swift.yaml
@@ -4,7 +4,6 @@ meta:
 tasks:
 - rgw:
     client.0:
-    default_idle_timeout: 300
 - print: "**** done rgw 9-workload"
 - swift:
     client.0:


### PR DESCRIPTION
https://github.com/ceph/ceph/commit/8c74c8a639cd3dead52e1942b36f6eb3f1ceab2c#diff-995b04809fcabacc3e3ecfaea903a41aL539

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>