### PR TITLE
mon/FSCommand: fix indentation

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -295,13 +295,14 @@ public:
         });
       }
     } else if (var == "balancer") {
-      if (val.empty())
+      if (val.empty()) {
         ss << "unsetting the metadata load balancer";
-      else 
+      } else {
         ss << "setting the metadata load balancer to " << val;
-        fsmap.modify_filesystem(
-            fs->fscid,
-            [val](std::shared_ptr<Filesystem> fs)
+      }
+      fsmap.modify_filesystem(
+	fs->fscid,
+	[val](std::shared_ptr<Filesystem> fs)
         {
           fs->mds_map.set_balancer(val);
         });


### PR DESCRIPTION
Makes this warning go away

/home/sage/src/ceph4/src/mon/FSCommands.cc: In member function ‘virtual int SetHandler::handle(Monitor*, FSMap&, MonOpRequestRef, std::map<std::__cxx11::basic_string<char>, boost::variant<std::__cxx11::basic_string<char>, bool, long int, double, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::vector<long int, std::allocator<long int> > > >&, std::stringstream&)’:
/home/sage/src/ceph4/src/mon/FSCommands.cc:303:7: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
       else
       ^~~~
/home/sage/src/ceph4/src/mon/FSCommands.cc:305:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘else’
         fsmap.modify_filesystem(
         ^~~~~

Introduced by a1214a702cfd8465deb91847f4dc63c0e80fb586

Signed-off-by: Sage Weil <sage@redhat.com>