### PR TITLE
mon: silence warning from -Wmisleading-indentation

### DIFF
--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -295,9 +295,10 @@ public:
         });
       }
     } else if (var == "balancer") {
-      if (val.empty())
+      if (val.empty()) {
         ss << "unsetting the metadata load balancer";
-      else 
+      }
+      else { 
         ss << "setting the metadata load balancer to " << val;
         fsmap.modify_filesystem(
             fs->fscid,
@@ -305,6 +306,7 @@ public:
         {
           fs->mds_map.set_balancer(val);
         });
+      }
       return true;
     } else if (var == "max_file_size") {
       if (interr.length()) {


### PR DESCRIPTION
The following warning appears during build. I request @david-z and @jcsp to review the logic, especially the `return true`.

```
ceph/src/mon/FSCommands.cc: In member function ‘virtual int SetHandler::handle(Monitor*, FSMap&, MonOpRequestRef, std::map<std::__cxx11::basic_string<char>, boost::variant<std::__cxx11::basic_string<char>, bool, long int, double, std::vector<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >, std::vector<long int, std::allocator<long int> > > >&, std::stringstream&)’:
ceph/src/mon/FSCommands.cc:300:7: warning: this ‘else’ clause does not guard... [-Wmisleading-indentation]
       else
       ^~~~
ceph/src/mon/FSCommands.cc:302:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘else’
         fsmap.modify_filesystem(
         ^~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>