### PR TITLE
rgw: lower some log's level in gc process.

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -151,7 +151,7 @@ int RGWGC::process(int index, int max_secs)
 
   int ret = l.lock_exclusive(&store->gc_pool_ctx, obj_names[index]);
   if (ret == -EBUSY) { /* already locked by another gc processor */
-    dout(0) << "RGWGC::process() failed to acquire lock on " << obj_names[index] << dendl;
+    dout(10) << "RGWGC::process() failed to acquire lock on " << obj_names[index] << dendl;
     return 0;
   }
   if (ret < 0)
@@ -203,7 +203,7 @@ int RGWGC::process(int index, int max_secs)
 
         const string& oid = obj.key.name; /* just stored raw oid there */
 
-	dout(0) << "gc::process: removing " << obj.pool << ":" << obj.key.name << dendl;
+	dout(5) << "gc::process: removing " << obj.pool << ":" << obj.key.name << dendl;
 	ObjectWriteOperation op;
 	cls_refcount_put(op, info.tag, true);
         ret = ctx->operate(oid, &op);


### PR DESCRIPTION
The level 0 is too high in these two places and it makes no sense. 
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>