### PR TITLE
vstart: print "start osd.$id" instead of "start osd$id"

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -601,7 +601,7 @@ EOF
             echo adding osd$osd key to auth repository
             ceph_adm -i "$key_fn" auth add osd.$osd osd "allow *" mon "allow profile osd" mgr "allow profile osd"
         fi
-        echo start osd$osd
+        echo start osd.$osd
         run 'osd' $SUDO $CEPH_BIN/ceph-osd -i $osd $ARGS $COSD_ARGS
     done
 }


### PR DESCRIPTION
"osd.9" is more consistent with other places where an osd is referenced.

Signed-off-by: Kefu Chai <kchai@redhat.com>