### PR TITLE
ceph-disk: add setting for external py-modules for tox-testing

### DIFF
--- a/src/ceph-disk/tox.ini
+++ b/src/ceph-disk/tox.ini
@@ -16,6 +16,7 @@ deps =
   ../ceph-detect-init
 
 [testenv:py27]
+sitepackages=True
 passenv = CEPH_ROOT CEPH_BIN CEPH_LIB CEPH_BUILD_VIRTUALENV
 changedir = {env:CEPH_BUILD_DIR}
 commands = coverage run --append --source=ceph_disk {envbindir}/py.test -vv {toxinidir}/tests/test_main.py


### PR DESCRIPTION
ceph-disk: use system modules if needed

 - prettytable usage was introduced in:
        https://github.com/ceph/ceph/commit/3fa8bb1
   It is in the install-deps.sh file to be installed, but
   it is not per default installed in the testenvironment
   So allow tox tests to use "external" modules

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>
