### PR TITLE
os/bluestore: fix warning

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1131,7 +1131,7 @@ OPTION(bluestore_allocator, OPT_STR, "bitmap")     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT, 128)
 OPTION(bluestore_bitmapallocator_blocks_per_zone, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
 OPTION(bluestore_bitmapallocator_span_size, OPT_INT, 1024) // must be power of 2 aligned, e.g., 512, 1024, 2048...
-OPTION(bluestore_max_deferred_txc, OPT_INT, 32)
+OPTION(bluestore_max_deferred_txc, OPT_U64, 32)
 OPTION(bluestore_rocksdb_options, OPT_STR, "compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152")
 OPTION(bluestore_fsck_on_mount, OPT_BOOL, false)
 OPTION(bluestore_fsck_on_mount_deep, OPT_BOOL, true)


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/os/bluestore/BlueStore.cc: In member function ‘void BlueStore::_txc_finish(BlueStore::TransContext*)’:
ceph/src/os/bluestore/BlueStore.cc:7823:20: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
      osr->q.size() > g_conf->bluestore_max_deferred_txc) {
      ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Signed-off-by: Sage Weil <sage@redhat.com>