### PR TITLE
mon: {mon,osd,mds} {versions,count-metadata}

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -708,6 +708,9 @@ function test_mon_misc()
 
   ceph mon metadata a
   ceph mon metadata
+  ceph mon count-metadata ceph_version
+  ceph mon versions
+
   ceph node ls
 }
 
@@ -864,6 +867,8 @@ function test_mon_mds()
       ceph mds metadata $mds_id
   done
   ceph mds metadata
+  ceph mds versions
+  ceph mds count-metadata os
 
   # XXX mds fail, but how do you undo it?
   mdsmapfile=$TEMP_DIR/mdsmap.$$
@@ -1351,6 +1356,10 @@ function test_mon_osd()
   expect_false ceph osd tree up down
   expect_false ceph osd tree in out
   expect_false ceph osd tree up foo
+
+  ceph osd metadata
+  ceph osd count-metadata os
+  ceph osd versions
 
   ceph osd perf
   ceph osd blocked-by

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -36,7 +36,7 @@ const char *git_version_to_str(void)
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
-  oss << "ceph version " << " " << CEPH_GIT_NICE_VER
+  oss << "ceph version " << CEPH_GIT_NICE_VER
       << " (" << STRINGIFY(CEPH_GIT_VER) << ") "
       << ceph_release_name(CEPH_RELEASE)
       << " (" << CEPH_RELEASE_TYPE << ")";

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -138,6 +138,7 @@ class MDSMonitor : public PaxosService {
   void update_metadata(mds_gid_t gid, const Metadata& metadata);
   void remove_from_metadata(MonitorDBStore::TransactionRef t);
   int load_metadata(map<mds_gid_t, Metadata>& m);
+  void count_metadata(const string& field, Formatter *f);
 
   // MDS daemon GID to latest health state from that GID
   std::map<uint64_t, MDSHealth> pending_daemon_health;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -253,6 +253,12 @@ COMMAND_WITH_FLAG("mon sync force " \
 COMMAND("mon metadata name=id,type=CephString,req=false",
 	"fetch metadata for mon <id>",
 	"mon", "r", "cli,rest")
+COMMAND("mon count-metadata name=property,type=CephString",
+	"count mons by metadata field property",
+	"mon", "r", "cli,rest")
+COMMAND("mon versions",
+	"check running versions of monitors",
+	"mon", "r", "cli,rest")
 
 
 /*
@@ -272,6 +278,12 @@ COMMAND_WITH_FLAG("mds getmap " \
 	"get MDS map, optionally from epoch", "mds", "r", "cli,rest", FLAG(DEPRECATED))
 COMMAND("mds metadata name=who,type=CephString,req=false",
 	"fetch metadata for mds <who>",
+	"mds", "r", "cli,rest")
+COMMAND("mds count-metadata name=property,type=CephString",
+	"count MDSs by metadata field property",
+	"mds", "r", "cli,rest")
+COMMAND("mds versions",
+	"check running versions of MDSs",
 	"mds", "r", "cli,rest")
 COMMAND_WITH_FLAG("mds tell " \
 	"name=who,type=CephString " \
@@ -441,6 +453,12 @@ COMMAND("osd find " \
 COMMAND("osd metadata " \
 	"name=id,type=CephOsdName,req=false", \
 	"fetch metadata for osd {id} (default all)", \
+	"osd", "r", "cli,rest")
+COMMAND("osd count-metadata name=property,type=CephString",
+	"count OSDs by metadata field property",
+	"osd", "r", "cli,rest")
+COMMAND("osd versions", \
+	"check running versions of OSDs",
 	"osd", "r", "cli,rest")
 COMMAND("osd map " \
 	"name=pool,type=CephPoolname " \

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -861,6 +861,7 @@ public:
 
   void update_mon_metadata(int from, Metadata&& m);
   int load_metadata(map<int, Metadata>& m);
+  void count_metadata(const string& field, Formatter *f);
 
   // features
   static CompatSet get_initial_supported_features();

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -429,6 +429,7 @@ private:
   OpTracker op_tracker;
 
   int load_metadata(int osd, map<string, string>& m, ostream *err);
+  void count_metadata(const string& field, Formatter *f);
   int get_osd_objectstore_type(int osd, std::string *type);
   bool is_pool_currently_all_bluestore(int64_t pool_id, const pg_pool_t &pool,
 				       ostream *err);


### PR DESCRIPTION
<pre>
gnit:build (wip-versions) 02:46 PM $ bin/ceph osd versions
{
    "ceph version 12.0.2-2073-gafcfc1d (afcfc1d7d99fae1697d687f65ce297de5c94b3a8) luminous (dev)": 3
}
gnit:build (wip-versions) 02:47 PM $ bin/ceph mds count-metadata kernel_version
{
    "4.8.8-300.fc25.x86_64": 1
}
</pre>

also fix an accidental change to the ceph version string (extra space)