### PR TITLE
os/bluestore: release bufferlist pinned by extent_map

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3153,6 +3153,7 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
     }
   }
   o.reset(on);
+  o->extent_map.trim_bl();
   return onode_map.add(oid, o);
 }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -869,6 +869,10 @@ public:
 
     /// split a blob (and referring extents)
     BlobRef split_blob(BlobRef lb, uint32_t blob_offset, uint32_t pos);
+    void trim_bl() {
+      if (inline_bl.length() > 0)
+	inline_bl.rebuild();
+    }
   };
 
   /// Compressed Blob Garbage collector


### PR DESCRIPTION
huge amounts of cached onodes should be treated stingily...

Signed-off-by: Zengran Zhang <zhangzengran@sangfor.com.cn>