### PR TITLE
test/osd/osd-scrub-repair.sh: Adjust for FreeBSD and ec_overwrite

### DIFF
--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -17,12 +17,21 @@
 source $(dirname $0)/../detect-build-env-vars.sh
 source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
 
+if [ `uname` = FreeBSD ]; then
+    # erasure coding overwrites are only tested on Bluestore 
+    # erasure coding on filestore is unsafe
+    # http://docs.ceph.com/docs/master/rados/operations/erasure-code/#erasure-coding-with-overwrites
+    use_ec_overwrite=false
+else
+    use_ec_overwrite=true
+fi
+
 # Test development and debugging
 # Set to "yes" in order to ignore diff errors and save results to update test
 getjson="no"
 
 # Ignore the epoch and filter out the attr '_' value because it has date information and won't match
-jqfilter='.inconsistents | (.[].shards[].attrs[] | select(.name == "_") | .value) |= "----Stripped-by-test----"'
+jqfilter='.inconsistents | (.[].shards[].attrs[]? | select(.name == "_") | .value) |= "----Stripped-by-test----"'
 sortkeys='import json; import sys ; JSON=sys.stdin.read() ; ud = json.loads(JSON) ; print json.dumps(ud, sort_keys=True, indent=2)'
 
 # Remove items are not consistent across runs, the pg interval and client
@@ -237,7 +246,9 @@ function TEST_auto_repair_erasure_coded_appends() {
 }
 
 function TEST_auto_repair_erasure_coded_overwrites() {
-    auto_repair_erasure_coded $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        auto_repair_erasure_coded $1 true
+    fi
 }
 
 function corrupt_and_repair_jerasure() {
@@ -268,7 +279,9 @@ function TEST_corrupt_and_repair_jerasure_appends() {
 }
 
 function TEST_corrupt_and_repair_jerasure_overwrites() {
-    corrupt_and_repair_jerasure $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        corrupt_and_repair_jerasure $1 true
+    fi
 }
 
 function corrupt_and_repair_lrc() {
@@ -299,7 +312,9 @@ function TEST_corrupt_and_repair_lrc_appends() {
 }
 
 function TEST_corrupt_and_repair_lrc_overwrites() {
-    corrupt_and_repair_jerasure $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        corrupt_and_repair_jerasure $1 true
+    fi
 }
 
 function unfound_erasure_coded() {
@@ -365,7 +380,9 @@ function TEST_unfound_erasure_coded_appends() {
 }
 
 function TEST_unfound_erasure_coded_overwrites() {
-    unfound_erasure_coded $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        unfound_erasure_coded $1 true
+    fi
 }
 
 #
@@ -443,7 +460,9 @@ function TEST_list_missing_erasure_coded_appends() {
 }
 
 function TEST_list_missing_erasure_coded_overwrites() {
-    list_missing_erasure_coded $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        list_missing_erasure_coded $1 true
+    fi
 }
 
 #
@@ -2498,7 +2517,9 @@ function TEST_corrupt_scrub_erasure_appends() {
 }
 
 function TEST_corrupt_scrub_erasure_overwrites() {
-    corrupt_scrub_erasure $1 true
+    if [ "$use_ec_overwrite" = "true" ]; then
+        corrupt_scrub_erasure $1 true
+    fi
 }
 
 #


### PR DESCRIPTION
- Do not test Bluestore OSDs on FreeBSD, since that does not work
   And all erasure code overwrite tests are executed on BlueStore OSDs
   Erasure code overwrites are unsafe on Filestore, see:
    [docs](http://docs.ceph.com/docs/master/rados/operations/erasure-code/#erasure-coding-with-overwrites)

- the JQ expression errors out with
```
    (version 1.5-1-g940132e-dirty)
    ====
    jq: error (at :232): Cannot iterate over null (null)
    Traceback (most recent call last):
    File "", line 1, in
    File "/usr/lib64/python2.7/json/init.py", line 338, in loads
    return _default_decoder.decode(s)
    File "/usr/lib64/python2.7/json/decoder.py", line 365, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    File "/usr/lib64/python2.7/json/decoder.py", line 383, in raw_decode
    raise ValueError("No JSON object could be decoded")
    ValueError: No JSON object could be decoded
    ====
    Adding a ? to the jq expression allows to proceed on null blocks.
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>