### PR TITLE
jewel: tests: test_notify.py: assert(not image.is_exclusive_lock_owner()) on line 147

### DIFF
--- a/src/test/librbd/test_notify.py
+++ b/src/test/librbd/test_notify.py
@@ -61,6 +61,7 @@ def master(ioctx):
         image.create_snap('snap1')
         image.protect_snap('snap1')
 
+    features = features & ~(RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF)
     RBD().clone(ioctx, PARENT_IMG_NAME, 'snap1', ioctx, CLONE_IMG_NAME,
                 features=features)
     with Image(ioctx, CLONE_IMG_NAME) as image:
@@ -137,10 +138,7 @@ def slave(ioctx):
         assert(list(image.list_snaps()) == [])
 
         print("rebuild object map")
-        features = image.features() & (
-                RBD_FEATURE_OBJECT_MAP | RBD_FEATURE_FAST_DIFF)
-        if features:
-            image.update_features(features, False)
+        assert((image.features() & RBD_FEATURE_OBJECT_MAP) == 0)
         image.update_features(RBD_FEATURE_OBJECT_MAP, True)
         assert((image.flags() & RBD_FLAG_OBJECT_MAP_INVALID) != 0)
         image.rebuild_object_map()


### PR DESCRIPTION
http://tracker.ceph.com/issues/19795