### PR TITLE
[DNM] jewel: [test] remove hard-coded image name from TestLibRBD.Mirror

### DIFF
--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -215,7 +215,7 @@ namespace librbd {
   int mirror_image_status_summary(IoCtx& io_ctx,
       std::map<mirror_image_status_state_t, int> *states);
 
-  int mirror_image_enable(ImageCtx *ictx);
+  int mirror_image_enable(ImageCtx *ictx, bool relax_same_pool_parent_check);
   int mirror_image_disable(ImageCtx *ictx, bool force);
   int mirror_image_promote(ImageCtx *ictx, bool force);
   int mirror_image_demote(ImageCtx *ictx);

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1328,7 +1328,7 @@ namespace librbd {
 
   int Image::mirror_image_enable() {
     ImageCtx *ictx = (ImageCtx *)ctx;
-    return librbd::mirror_image_enable(ictx);
+    return librbd::mirror_image_enable(ictx, false);
   }
 
   int Image::mirror_image_disable(bool force) {
@@ -2873,7 +2873,7 @@ extern "C" int rbd_metadata_list(rbd_image_t image, const char *start, uint64_t 
 extern "C" int rbd_mirror_image_enable(rbd_image_t image)
 {
   librbd::ImageCtx *ictx = (librbd::ImageCtx *)image;
-  return librbd::mirror_image_enable(ictx);
+  return librbd::mirror_image_enable(ictx, false);
 }
 
 extern "C" int rbd_mirror_image_disable(rbd_image_t image, bool force)

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -4555,20 +4555,23 @@ TEST_F(TestLibRBD, Mirror) {
 
   // Add some images to the pool
   int order = 0;
-  ASSERT_EQ(0, create_image_pp(rbd, ioctx, "parent", 2 << 20, &order));
+  std::string parent_name = get_temp_image_name();
+  std::string child_name = get_temp_image_name();
+  ASSERT_EQ(0, create_image_pp(rbd, ioctx, parent_name.c_str(), 2 << 20,
+                               &order));
   bool old_format;
   uint64_t features;
   ASSERT_EQ(0, get_features(&old_format, &features));
   if ((features & RBD_FEATURE_LAYERING) != 0) {
     librbd::Image parent;
-    ASSERT_EQ(0, rbd.open(ioctx, parent, "parent", NULL));
+    ASSERT_EQ(0, rbd.open(ioctx, parent, parent_name.c_str(), NULL));
     ASSERT_EQ(0, parent.snap_create("parent_snap"));
     ASSERT_EQ(0, parent.close());
-    ASSERT_EQ(0, rbd.open(ioctx, parent, "parent", "parent_snap"));
+    ASSERT_EQ(0, rbd.open(ioctx, parent, parent_name.c_str(), "parent_snap"));
     ASSERT_EQ(0, parent.snap_protect("parent_snap"));
     ASSERT_EQ(0, parent.close());
-    ASSERT_EQ(0, rbd.clone(ioctx, "parent", "parent_snap", ioctx, "child",
-                           features, &order));
+    ASSERT_EQ(0, rbd.clone(ioctx, parent_name.c_str(), "parent_snap", ioctx,
+                           child_name.c_str(), features, &order));
   }
 
   ASSERT_EQ(RBD_MIRROR_MODE_IMAGE, mirror_mode);

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -426,7 +426,7 @@ TEST_F(TestImageReplayer, BootstrapMirrorDisabling)
   ASSERT_EQ(0, librbd::mirror_mode_set(m_remote_ioctx, RBD_MIRROR_MODE_IMAGE));
   librbd::ImageCtx *ictx;
   open_remote_image(&ictx);
-  ASSERT_EQ(0, librbd::mirror_image_enable(ictx));
+  ASSERT_EQ(0, librbd::mirror_image_enable(ictx, false));
   cls::rbd::MirrorImage mirror_image;
   ASSERT_EQ(0, librbd::cls_client::mirror_image_get(&m_remote_ioctx, ictx->id,
                                                     &mirror_image));


### PR DESCRIPTION
http://tracker.ceph.com/issues/19808