### PR TITLE
jewel: rbd: Potential IO hang if image is flattened while read request is in-flight

### DIFF
--- a/src/librbd/AioObjectRequest.cc
+++ b/src/librbd/AioObjectRequest.cc
@@ -191,8 +191,6 @@ bool AioObjectRead<I>::should_complete(int r)
         RWLock::RLocker parent_locker(image_ctx->parent_lock);
         if (image_ctx->parent == NULL) {
           ldout(image_ctx->cct, 20) << "parent is gone; do nothing" << dendl;
-          m_state = LIBRBD_AIO_READ_FLAT;
-          finished = false;
           break;
         }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/20153