### PR TITLE
rgw：fix s3 aws v2 signature priority between header['X-Amz-Date'] and header['Date']

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -178,16 +178,15 @@ bool rgw_create_s3_canonical_header(const req_info& info,
   if (qsr) {
     date = info.args.get("Expires");
   } else {
-    const char *str = info.env->get("HTTP_DATE");
+    const char *str = info.env->get("HTTP_X_AMZ_DATE");
     const char *req_date = str;
-    if (str) {
-      date = str;
-    } else {
-      req_date = info.env->get("HTTP_X_AMZ_DATE");
+    if (str == NULL) {
+      req_date = info.env->get("HTTP_DATE");
       if (!req_date) {
         dout(0) << "NOTICE: missing date for auth header" << dendl;
         return false;
       }
+      date = req_date;
     }
 
     if (header_time) {


### PR DESCRIPTION
as http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html  Time Stamp Requirement section metioned

> When an x-amz-date header is present in a request, the system will ignore any Date header when computing the request signature. Therefore, if you include the x-amz-date header, use the empty string for the Date when constructing the StringToSign

and in real life, some client mechine's  time is shift to rgw server, and those mechine's time is not able to adjust, but we can set X-Amz-Date in request header to fix this problem, but in current version code, the header['Date'] priority is higher than header['X-Amz-Date'].

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>