### PR TITLE
build: revert -Wvla from #15342

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -34,7 +34,6 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wpointer-arith -Werror=format-security -fno
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ftemplate-depth-1024 -Wno-invalid-offsetof")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wvla")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-pragmas")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unknown-pragmas")
 if(CMAKE_CXX_COMPILER_ID STREQUAL GNU)


### PR DESCRIPTION
- VLAs are in GCC and Clang, and are there to stay forever,
   if only to be compatible with all the software that is already
   out there.
   - Theoretical debates about VLA being hard to implement are
     long superceded by th actual implentations
 - Before setting this flag is would be required to first start
   work on fixing all the fallout/warnings that will arise from
   setting -Wvla
 - Allocating large variable/stuctures on the stack could be asking
   for trouble, but changes that ceph tools are going to be running
   on small embedded devices are rather slim.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>