### PR TITLE
qa: add a sleep after restarting osd before "tell"ing it

### DIFF
--- a/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
+++ b/qa/suites/rados/singleton/all/pg-removal-interruption.yaml
@@ -25,6 +25,8 @@ tasks:
     client.0:
       - sudo ceph osd down 0
 - ceph.restart: [osd.0]
+- sleep:
+    duration: 20 # http://tracker.ceph.com/issues/16239
 - exec:
     client.0:
       - sudo ceph tell osd.0 flush_pg_stats


### PR DESCRIPTION
without the fast-fail feature, the monitor marks osd down after
a grace time. so we cannot truest the "healthy()" in ceph.restart task.

also, "restart" task wait-for-healthy by default, so no need to do it
explicitly.

Fixes: http://tracker.ceph.com/issues/16239
Signed-off-by: Kefu Chai <kchai@redhat.com>