### PR TITLE
osd: marked down by monitor when public-network down timeout

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7632,6 +7632,12 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       dout(1) << "state: booting -> active" << dendl;
       set_state(STATE_ACTIVE);
 
+      outstanding_pg_stats.clear();
+      utime_t now = ceph_clock_now();
+      last_mon_report = now;
+      send_pg_stats(now);
+      send_beacon(ceph::coarse_mono_clock::now());
+
       // set incarnation so that osd_reqid_t's we generate for our
       // objecter requests are unique across restarts.
       service.objecter->set_client_incarnation(osdmap->get_epoch());


### PR DESCRIPTION
1.down host.2 public-network over 900s(mon_osd_report_timeout)
2.recovery host.2 public-network, osd marked down by host.1's monitor and can't auto up

Signed-off-by: ningtao <ningtao@sangfor.com.cn>