### PR TITLE
osd,librados: add manifest, operations for chunked object

### DIFF
--- a/qa/suites/rados/thrash/workloads/set-chunks.yaml
+++ b/qa/suites/rados/thrash/workloads/set-chunks.yaml
@@ -1,0 +1,9 @@
+tasks:
+- rados:
+    clients: [client.0]
+    ops: 4000
+    objects: 300
+    set_chunk: true
+    op_weights:
+      chunk_read: 100
+      write: 30

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -145,6 +145,8 @@ def task(ctx, config):
         args.extend(['--write-fadvise-dontneed'])
     if config.get('set_redirect', False):
         args.extend(['--set_redirect'])
+    if config.get('set_chunk', False):
+        args.extend(['--set_chunk'])
     if config.get('pool_snaps', False):
         args.extend(['--pool-snaps'])
     args.extend([

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -310,6 +310,7 @@ extern int ceph_release_from_features(uint64_t features);
 									    \
 	/* Extensible */						    \
 	f(SET_REDIRECT,	__CEPH_OSD_OP(WR, DATA, 39),	"set-redirect")	    \
+	f(SET_CHUNK,	__CEPH_OSD_OP(WR, DATA, 40),	"set-chunk")	    \
 									    \
 	/** attrs **/							    \
 	/* read */							    \

--- a/src/include/rados/librados.hpp
+++ b/src/include/rados/librados.hpp
@@ -471,6 +471,9 @@ namespace librados
      */
     void set_redirect(const std::string& tgt_obj, const IoCtx& tgt_ioctx,
 		      uint64_t tgt_version);
+    void set_chunk(uint64_t src_offset, uint64_t src_length, const IoCtx& tgt_ioctx,
+                   std::string tgt_oid, uint64_t tgt_offset);
+
 
     friend class IoCtx;
   };

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -614,6 +614,17 @@ void librados::ObjectWriteOperation::set_redirect(const std::string& tgt_obj,
 			  tgt_ioctx.io_ctx_impl->oloc, tgt_version);
 }
 
+void librados::ObjectWriteOperation::set_chunk(uint64_t src_offset,
+					       uint64_t src_length,
+					       const IoCtx& tgt_ioctx,
+					       string tgt_oid,
+					       uint64_t tgt_offset)
+{
+  ::ObjectOperation *o = &impl->o;
+  o->set_chunk(src_offset, src_length, 
+	       tgt_ioctx.io_ctx_impl->oloc, object_t(tgt_oid), tgt_offset);
+}
+
 void librados::ObjectWriteOperation::tmap_put(const bufferlist &bl)
 {
   ::ObjectOperation *o = &impl->o;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8378,7 +8378,8 @@ void PrimaryLogPG::_copy_some_manifest(ObjectContextRef obc, CopyOpRef cop, uint
     uint64_t length = manifest->chunk_map[iter->first].length;
     hobject_t soid = manifest->chunk_map[iter->first].oid;
     object_locator_t oloc(soid);
-    CopyOpRef sub_cop(std::make_shared<CopyOp>(cop->cb, cop->obc, cop->src, oloc,
+    CopyCallback * cb = NULL;
+    CopyOpRef sub_cop(std::make_shared<CopyOp>(cb, ObjectContextRef(), cop->src, oloc,
 		       cop->results.user_version, cop->flags, cop->mirror_snapset,
 		       cop->src_obj_fadvise_flags, cop->dest_obj_fadvise_flags));
     sub_cop->cursor.data_offset = obj_offset;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2329,7 +2329,8 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_manifest_detail(
   for (vector<OSDOp>::iterator p = ops.begin(); p != ops.end(); ++p) {
     OSDOp& osd_op = *p;
     ceph_osd_op& op = osd_op.op;
-    if (op.op == CEPH_OSD_OP_SET_REDIRECT) {
+    if (op.op == CEPH_OSD_OP_SET_REDIRECT ||
+	op.op == CEPH_OSD_OP_SET_CHUNK) {
       return cache_result_t::NOOP;
     }
   }
@@ -2347,11 +2348,14 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_manifest_detail(
       do_proxy_chunked_op(op, obc->obs.oi.soid, obc, write_ordered);
       return cache_result_t::HANDLED_PROXY;
     }
-    if (obc->obs.oi.size == 0) {
-      const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
-      const object_locator_t oloc = m->get_object_locator();
-      promote_object(obc, obc->obs.oi.soid, oloc, op, NULL);
-      return cache_result_t::BLOCKED_PROMOTE;
+    
+    for (auto& p : obc->obs.oi.manifest.chunk_map) {
+      if (p.second.flags == chunk_info_t::FLAG_MISSING) {
+	const MOSDOp *m = static_cast<const MOSDOp*>(op->get_req());
+	const object_locator_t oloc = m->get_object_locator();
+	promote_object(obc, obc->obs.oi.soid, oloc, op, NULL);
+	return cache_result_t::BLOCKED_PROMOTE;
+      }
     }
     return cache_result_t::NOOP;
   default:
@@ -3316,6 +3320,24 @@ public:
   }
 };
 
+class PromoteManifestCallback: public PrimaryLogPG::CopyCallback {
+  ObjectContextRef obc;
+  PrimaryLogPG *pg;
+  utime_t start;
+public:
+  PromoteManifestCallback(ObjectContextRef obc_, PrimaryLogPG *pg_)
+    : obc(obc_),
+      pg(pg_),
+      start(ceph_clock_now()) {}
+
+  void finish(PrimaryLogPG::CopyCallbackResults results) override {
+    PrimaryLogPG::CopyResults *results_data = results.get<1>();
+    int r = results.get<0>();
+    pg->finish_promote_manifest(r, results_data, obc);
+    pg->osd->logger->tinc(l_osd_tier_promote_lat, ceph_clock_now() - start);
+  }
+};
+
 void PrimaryLogPG::promote_object(ObjectContextRef obc,
 				  const hobject_t& missing_oid,
 				  const object_locator_t& oloc,
@@ -3355,13 +3377,16 @@ void PrimaryLogPG::promote_object(ObjectContextRef obc,
     src_fadvise_flags |= LIBRADOS_OP_FLAG_FADVISE_DONTNEED;
   }
 
-  PromoteCallback *cb = new PromoteCallback(obc, this);
+  CopyCallback *cb;
   object_locator_t my_oloc = oloc;
   my_oloc.pool = pool.info.tier_of;
-  if (obc->obs.oi.has_manifest()) {
+  if (!obc->obs.oi.has_manifest()) {
+    cb = new PromoteCallback(obc, this);
+  } else {
     if (obc->obs.oi.manifest.is_chunked()) {
-      object_locator_t chunk_oloc(obc->obs.oi.manifest.chunk_map[0].oid);
-      my_oloc = chunk_oloc;
+      cb = new PromoteManifestCallback(obc, this);
+    } else {
+      assert(0);
     }
   }
 
@@ -6411,10 +6436,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 
 	pg_t raw_pg;
 	chunk_info_t chunk_info;
+	get_osdmap()->object_locator_to_pg(tgt_name, tgt_oloc, raw_pg);
 	hobject_t target(tgt_name, tgt_oloc.key, snapid_t(),
 			 raw_pg.ps(), raw_pg.pool(),
 			 tgt_oloc.nspace);
-	get_osdmap()->object_locator_to_pg(tgt_name, tgt_oloc, raw_pg);
 	chunk_info.flags = chunk_info_t::FLAG_MISSING;
 	chunk_info.oid = target;
 	chunk_info.offset = tgt_offset;
@@ -7969,6 +7994,29 @@ struct C_CopyFrom_AsyncReadCb : public Context {
   }
 };
 
+struct C_CopyChunk : public Context {
+  PrimaryLogPGRef pg;
+  hobject_t oid;
+  epoch_t last_peering_reset;
+  ceph_tid_t tid;
+  PrimaryLogPG::CopyOpRef cop;
+  uint64_t offset;
+  C_CopyChunk(PrimaryLogPG *p, hobject_t o, epoch_t lpr,
+	     const PrimaryLogPG::CopyOpRef& c)
+    : pg(p), oid(o), last_peering_reset(lpr),
+      tid(0), cop(c) 
+  {}
+  void finish(int r) override {
+    if (r == -ECANCELED)
+      return;
+    pg->lock();
+    if (last_peering_reset == pg->get_last_peering_reset()) {
+      pg->process_copy_chunk_manifest(oid, tid, r, offset);
+    }
+    pg->unlock();
+  }
+};
+
 int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::iterator& bp,
 			      OSDOp& osd_op, ObjectContextRef &obc)
 {
@@ -8193,7 +8241,12 @@ void PrimaryLogPG::start_copy(CopyCallback *cb, ObjectContextRef obc,
   copy_ops[dest] = cop;
   obc->start_block();
 
-  _copy_some(obc, cop);
+  if (!obc->obs.oi.has_manifest()) {
+    _copy_some(obc, cop);
+  } else {
+    auto p = obc->obs.oi.manifest.chunk_map.begin();
+    _copy_some_manifest(obc, cop, p->first);
+  }
 }
 
 void PrimaryLogPG::_copy_some(ObjectContextRef obc, CopyOpRef cop)
@@ -8262,6 +8315,95 @@ void PrimaryLogPG::_copy_some(ObjectContextRef obc, CopyOpRef cop)
   fin->tid = tid;
   cop->objecter_tid = tid;
   gather.activate();
+}
+
+void PrimaryLogPG::_copy_some_manifest(ObjectContextRef obc, CopyOpRef cop, uint64_t start_offset)
+{
+  dout(10) << __func__ << " " << obc << " " << cop << dendl;
+
+  unsigned flags = 0;
+  if (cop->flags & CEPH_OSD_COPY_FROM_FLAG_FLUSH)
+    flags |= CEPH_OSD_FLAG_FLUSH;
+  if (cop->flags & CEPH_OSD_COPY_FROM_FLAG_IGNORE_CACHE)
+    flags |= CEPH_OSD_FLAG_IGNORE_CACHE;
+  if (cop->flags & CEPH_OSD_COPY_FROM_FLAG_IGNORE_OVERLAY)
+    flags |= CEPH_OSD_FLAG_IGNORE_OVERLAY;
+  if (cop->flags & CEPH_OSD_COPY_FROM_FLAG_MAP_SNAP_CLONE)
+    flags |= CEPH_OSD_FLAG_MAP_SNAP_CLONE;
+  if (cop->flags & CEPH_OSD_COPY_FROM_FLAG_RWORDERED)
+    flags |= CEPH_OSD_FLAG_RWORDERED;
+
+  int num_chunks = 0;
+  uint64_t last_offset = 0, chunks_size = 0;
+  object_manifest_t *manifest = &obc->obs.oi.manifest;
+  map<uint64_t, chunk_info_t>::iterator iter = manifest->chunk_map.find(start_offset); 
+  for (;iter != manifest->chunk_map.end(); ++iter) {
+    num_chunks++;
+    chunks_size += iter->second.length;
+    last_offset = iter->first;
+    if (get_copy_chunk_size() < chunks_size) {
+      break;
+    }
+  }
+
+  cop->num_chunk = num_chunks;
+  cop->start_offset = start_offset;
+  cop->last_offset = last_offset;
+  dout(20) << __func__ << " oid " << obc->obs.oi.soid << " num_chunks: " << num_chunks
+	  << " start_offset: " << start_offset << " chunks_size: " << chunks_size 
+	  << " last_offset: " << last_offset << dendl;
+
+  iter = manifest->chunk_map.find(start_offset);
+  for (;iter != manifest->chunk_map.end(); ++iter) {
+    uint64_t obj_offset = iter->first;
+    uint64_t length = manifest->chunk_map[iter->first].length;
+    hobject_t soid = manifest->chunk_map[iter->first].oid;
+    object_locator_t oloc(soid);
+    CopyOpRef sub_cop(std::make_shared<CopyOp>(cop->cb, cop->obc, cop->src, oloc,
+		       cop->results.user_version, cop->flags, cop->mirror_snapset,
+		       cop->src_obj_fadvise_flags, cop->dest_obj_fadvise_flags));
+    sub_cop->cursor.data_offset = obj_offset;
+    cop->chunk_cops[obj_offset] = sub_cop;
+
+    int s = sub_cop->chunk_ops.size();
+    sub_cop->chunk_ops.resize(s+1);
+    sub_cop->chunk_ops[s].op.op =  CEPH_OSD_OP_READ;
+    sub_cop->chunk_ops[s].op.extent.offset = manifest->chunk_map[iter->first].offset;
+    sub_cop->chunk_ops[s].op.extent.length = length;
+
+    ObjectOperation op;
+    op.dup(sub_cop->chunk_ops);
+
+    dout(20) << __func__ << " tgt_oid: " << soid.oid << " tgt_offset: " 
+	    << manifest->chunk_map[iter->first].offset
+	    << " length: " << length << " pool id: " << oloc.pool << dendl;
+
+    if (cop->results.user_version) {
+      op.assert_version(cop->results.user_version);
+    } else {
+      // we should learn the version after the first chunk, if we didn't know
+      // it already!
+      assert(cop->cursor.is_initial());
+    }
+    op.set_last_op_flags(cop->src_obj_fadvise_flags);
+
+    C_CopyChunk *fin = new C_CopyChunk(this, obc->obs.oi.soid,
+				     get_last_peering_reset(), cop);
+    fin->offset = obj_offset;
+    unsigned n = info.pgid.hash_to_shard(osd->m_objecter_finishers);
+
+    ceph_tid_t tid = osd->objecter->read(soid.oid, oloc, op,
+				    sub_cop->src.snap, NULL,
+				    flags,
+				    new C_OnFinisher(fin, osd->objecter_finishers[n]),
+				    // discover the object version if we don't know it yet
+				    sub_cop->results.user_version ? NULL : &sub_cop->results.user_version);
+    fin->tid = tid;
+    sub_cop->objecter_tid = tid;
+    if (last_offset < iter->first) {
+      break;
+    }
+  }
 }
 
 void PrimaryLogPG::process_copy_chunk(hobject_t oid, ceph_tid_t tid, int r)
@@ -8449,26 +8591,131 @@ void PrimaryLogPG::process_copy_chunk(hobject_t oid, ceph_tid_t tid, int r)
 
   // cancel and requeue proxy ops on this object
   if (!r) {
-    for (map<ceph_tid_t, ProxyReadOpRef>::iterator it = proxyread_ops.begin();
-	it != proxyread_ops.end();) {
-      if (it->second->soid == cobc->obs.oi.soid) {
-	cancel_proxy_read((it++)->second);
-      } else {
-	++it;
-      }
-    }
-    for (map<ceph_tid_t, ProxyWriteOpRef>::iterator it = proxywrite_ops.begin();
-	 it != proxywrite_ops.end();) {
-      if (it->second->soid == cobc->obs.oi.soid) {
-	cancel_proxy_write((it++)->second);
-      } else {
-	++it;
-      }
-    }
-    kick_proxy_ops_blocked(cobc->obs.oi.soid);
+    cancel_and_requeue_proxy_ops(cobc->obs.oi.soid);
   }
 
   kick_object_context_blocked(cobc);
+}
+
+void PrimaryLogPG::process_copy_chunk_manifest(hobject_t oid, ceph_tid_t tid, int r, uint64_t offset)
+{
+  dout(10) << __func__ << " " << oid << " tid " << tid
+	   << " " << cpp_strerror(r) << dendl;
+  map<hobject_t,CopyOpRef>::iterator p = copy_ops.find(oid);
+  if (p == copy_ops.end()) {
+    dout(10) << __func__ << " no copy_op found" << dendl;
+    return;
+  }
+  CopyOpRef obj_cop = p->second;
+  CopyOpRef chunk_cop = obj_cop->chunk_cops[offset];
+
+  if (tid != chunk_cop->objecter_tid) {
+    dout(10) << __func__ << " tid " << tid << " != cop " << chunk_cop
+	     << " tid " << chunk_cop->objecter_tid << dendl;
+    return;
+  }
+
+  if (chunk_cop->omap_data.length() || chunk_cop->omap_header.length()) {
+    r = -EOPNOTSUPP;
+  }
+
+  chunk_cop->objecter_tid = 0;
+  chunk_cop->objecter_tid2 = 0;  // assume this ordered before us (if it happened)
+  ObjectContextRef& cobc = obj_cop->obc;
+  OSDOp &chunk_data = chunk_cop->chunk_ops[0];
+
+  if (r < 0) {
+    obj_cop->failed = true;
+    goto out;
+  }   
+
+  if (obj_cop->failed) {
+    return;
+  }                                                                                                                  
+
+  if (!chunk_data.outdata.length()) {
+    r = -EIO;
+    obj_cop->failed = true;
+    goto out;
+  }
+
+  obj_cop->num_chunk--;
+
+  /* check all of the copyop are completed */
+  if (obj_cop->num_chunk) {
+    dout(20) << __func__ << " num_chunk: " << obj_cop->num_chunk << dendl;
+    return;
+  }
+
+  {
+    OpContextUPtr ctx = simple_opc_create(obj_cop->obc);
+    PGTransaction *t = ctx->op_t.get();
+    ObjectState& obs = ctx->new_obs;
+    for (auto p : obj_cop->chunk_cops) {
+      OSDOp &sub_chunk = p.second->chunk_ops[0];
+      t->write(cobc->obs.oi.soid,
+	      p.second->cursor.data_offset,
+	      sub_chunk.outdata.length(),
+	      sub_chunk.outdata,
+	      p.second->dest_obj_fadvise_flags);
+      obs.oi.manifest.chunk_map[p.second->cursor.data_offset].flags = 0; // clean
+      dout(20) << __func__ << " offset: " << p.second->cursor.data_offset 
+	      << " length: " << sub_chunk.outdata.length() << dendl;
+      sub_chunk.outdata.clear();
+      write_update_size_and_usage(ctx->delta_stats, obs.oi, ctx->modified_ranges,
+				  p.second->cursor.data_offset, sub_chunk.outdata.length());
+    }
+    obs.oi.clear_data_digest();
+    ctx->at_version = get_next_version(); 
+    finish_ctx(ctx.get(), pg_log_entry_t::PROMOTE);
+    simple_opc_submit(std::move(ctx));
+
+    auto p = cobc->obs.oi.manifest.chunk_map.end();
+    /* check remaining work */
+    if (obj_cop->last_offset >= p->first + p->second.length) {
+      for (auto &en : cobc->obs.oi.manifest.chunk_map) {
+	if (obj_cop->last_offset < en.first) {
+	  _copy_some_manifest(cobc, obj_cop, en.first);
+	  return;
+	}
+      }
+    }
+  }
+
+ out:
+  dout(20) << __func__ << " complete r = " << cpp_strerror(r) << dendl;
+  CopyCallbackResults results(r, &obj_cop->results);
+  obj_cop->cb->complete(results);
+
+  copy_ops.erase(cobc->obs.oi.soid);
+  cobc->stop_block();
+
+  // cancel and requeue proxy ops on this object
+  if (!r) {
+    cancel_and_requeue_proxy_ops(cobc->obs.oi.soid);
+  }
+
+  kick_object_context_blocked(cobc);
+}
+
+void PrimaryLogPG::cancel_and_requeue_proxy_ops(hobject_t oid) {
+  for (map<ceph_tid_t, ProxyReadOpRef>::iterator it = proxyread_ops.begin();
+      it != proxyread_ops.end();) {
+    if (it->second->soid == oid) {
+      cancel_proxy_read((it++)->second);
+    } else {
+      ++it;
+    }
+  }
+  for (map<ceph_tid_t, ProxyWriteOpRef>::iterator it = proxywrite_ops.begin();
+       it != proxywrite_ops.end();) {
+    if (it->second->soid == oid) {
+      cancel_proxy_write((it++)->second);
+    } else {
+      ++it;
+    }
+  }
+  kick_proxy_ops_blocked(oid);
 }
 
 void PrimaryLogPG::_write_copy_chunk(CopyOpRef cop, PGTransaction *t)
@@ -8807,6 +9054,42 @@ void PrimaryLogPG::finish_promote(int r, CopyResults *results,
 
   simple_opc_submit(std::move(tctx));
 
+  osd->logger->inc(l_osd_tier_promote);
+
+  if (agent_state &&
+      agent_state->is_idle())
+    agent_choose_mode();
+}
+
+void PrimaryLogPG::finish_promote_manifest(int r, CopyResults *results,
+					    ObjectContextRef obc)
+{
+  const hobject_t& soid = obc->obs.oi.soid;
+  dout(10) << __func__ << " " << soid << " r=" << r
+	   << " uv" << results->user_version << dendl;
+
+  if (r == -ECANCELED) {
+    return;
+  }
+
+  if (r < 0) {
+    derr << __func__ << " unexpected promote error " << cpp_strerror(r) << dendl;
+    // pass error to everyone blocked on this object
+    // FIXME: this is pretty sloppy, but at this point we got
+    // something unexpected and don't have many other options.
+    map<hobject_t,list<OpRequestRef>>::iterator blocked_iter =
+      waiting_for_blocked_object.find(soid);
+    if (blocked_iter != waiting_for_blocked_object.end()) {
+      while (!blocked_iter->second.empty()) {
+	osd->reply_op_error(blocked_iter->second.front(), r);
+	blocked_iter->second.pop_front();
+      }
+      waiting_for_blocked_object.erase(blocked_iter);
+    }
+    return;
+  }
+  
+  osd->promote_finish(results->object_size);
   osd->logger->inc(l_osd_tier_promote);
 
   if (agent_state &&

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1137,6 +1137,7 @@ protected:
     HANDLED_PROXY,
     HANDLED_REDIRECT,
     REPLIED_WITH_EAGAIN,
+    BLOCKED_RECOVERY,
   };
   cache_result_t maybe_handle_cache_detail(OpRequestRef op,
 					   bool write_ordered,

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1378,6 +1378,16 @@ protected:
 
   friend struct C_ProxyWrite_Commit;
 
+  // -- chunkop --
+  void do_proxy_chunked_op(OpRequestRef op, const hobject_t& missing_oid, 
+			   ObjectContextRef obc, bool write_ordered);
+  void do_proxy_chunked_read(OpRequestRef op, ObjectContextRef obc, int op_index,
+			     uint64_t chunk_index, uint64_t req_offset, uint64_t req_length,
+			     uint64_t req_total_len);
+  bool can_proxy_chunked_read(OpRequestRef op, ObjectContextRef obc);
+  
+  friend struct C_ProxyChunkRead;
+
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,
 	       const PGPool &_pool, spg_t p);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -117,6 +117,9 @@ public:
     {}
   };
 
+  struct CopyOp;
+  typedef ceph::shared_ptr<CopyOp> CopyOpRef;
+
   struct CopyOp {
     CopyCallback *cb;
     ObjectContextRef obc;
@@ -149,6 +152,13 @@ public:
     unsigned src_obj_fadvise_flags;
     unsigned dest_obj_fadvise_flags;
 
+    map<uint64_t, CopyOpRef> chunk_cops;
+    int num_chunk;
+    bool failed;
+    uint64_t start_offset;
+    uint64_t last_offset;
+    vector<OSDOp> chunk_ops;
+  
     CopyOp(CopyCallback *cb_, ObjectContextRef _obc, hobject_t s,
 	   object_locator_t l,
            version_t v,
@@ -162,13 +172,14 @@ public:
 	objecter_tid2(0),
 	rval(-1),
 	src_obj_fadvise_flags(src_obj_fadvise_flags),
-	dest_obj_fadvise_flags(dest_obj_fadvise_flags)
+	dest_obj_fadvise_flags(dest_obj_fadvise_flags),
+	num_chunk(0),
+	failed(false)
     {
       results.user_version = v;
       results.mirror_snapset = mirror_snapset;
     }
   };
-  typedef ceph::shared_ptr<CopyOp> CopyOpRef;
 
   /**
    * The CopyCallback class defines an interface for completions to the
@@ -1385,8 +1396,14 @@ protected:
 			     uint64_t chunk_index, uint64_t req_offset, uint64_t req_length,
 			     uint64_t req_total_len);
   bool can_proxy_chunked_read(OpRequestRef op, ObjectContextRef obc);
-  
+  void _copy_some_manifest(ObjectContextRef obc, CopyOpRef cop, uint64_t start_offset);
+  void process_copy_chunk_manifest(hobject_t oid, ceph_tid_t tid, int r, uint64_t offset);
+  void finish_promote_manifest(int r, CopyResults *results, ObjectContextRef obc);
+  void cancel_and_requeue_proxy_ops(hobject_t oid);
+
   friend struct C_ProxyChunkRead;
+  friend class PromoteManifestCallback;
+  friend class C_CopyChunk;
 
 public:
   PrimaryLogPG(OSDService *o, OSDMapRef curmap,

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4538,15 +4538,48 @@ static inline ostream& operator<<(ostream& out, const notify_info_t& n) {
 	     << " " << n.timeout << "s)";
 }
 
+struct chunk_info_t {
+  enum {
+    FLAG_DIRTY = 1, 
+    FLAG_MISSING = 2,
+  };
+  uint32_t offset;
+  uint32_t length;
+  hobject_t oid;
+  uint32_t flags;   // FLAG_*
+
+  chunk_info_t() : length(0), flags(0) { }
+
+  static string get_flag_string(uint64_t flags) {
+    string r;
+    if (flags & FLAG_DIRTY) {
+      r += "|dirty";
+    }
+    if (flags & FLAG_MISSING) {
+      r += "|missing";
+    }
+    if (r.length())
+      return r.substr(1);
+    return r;
+  }
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  void dump(Formatter *f) const;
+  friend ostream& operator<<(ostream& out, const chunk_info_t& ci);
+};
+WRITE_CLASS_ENCODER(chunk_info_t)
+ostream& operator<<(ostream& out, const chunk_info_t& ci);
+
 struct object_info_t;
 struct object_manifest_t {
   enum {
     TYPE_NONE = 0,
-    TYPE_REDIRECT = 1,  // start with this
-    TYPE_CHUNKED = 2,   // do this later
+    TYPE_REDIRECT = 1, 
+    TYPE_CHUNKED = 2, 
   };
   uint8_t type;  // redirect, chunked, ...
   hobject_t redirect_target;
+  map <uint64_t, chunk_info_t> chunk_map;
 
   object_manifest_t() : type(0) { }
   object_manifest_t(uint8_t type, const hobject_t& redirect_target) 
@@ -4571,6 +4604,11 @@ struct object_manifest_t {
   }
   const char *get_type_name() const {
     return get_type_name(type);
+  }
+  void clear() {
+    type = 0;
+    redirect_target = hobject_t();
+    chunk_map.clear();
   }
   static void generate_test_instances(list<object_manifest_t*>& o);
   void encode(bufferlist &bl) const;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4548,7 +4548,7 @@ struct chunk_info_t {
   hobject_t oid;
   uint32_t flags;   // FLAG_*
 
-  chunk_info_t() : length(0), flags(0) { }
+  chunk_info_t() : offset(0), length(0), flags(0) { }
 
   static string get_flag_string(uint64_t flags) {
     string r;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -1141,6 +1141,16 @@ struct ObjectOperation {
     ::encode(tgt_oloc, osd_op.indata);
   }
 
+  void set_chunk(uint64_t src_offset, uint64_t src_length, object_locator_t tgt_oloc,
+		 object_t tgt_oid, uint64_t tgt_offset) {
+    OSDOp& osd_op = add_op(CEPH_OSD_OP_SET_CHUNK);
+    ::encode(src_offset, osd_op.indata);
+    ::encode(src_length, osd_op.indata);
+    ::encode(tgt_oloc, osd_op.indata);
+    ::encode(tgt_oid, osd_op.indata);
+    ::encode(tgt_offset, osd_op.indata);
+  }
+
   void set_alloc_hint(uint64_t expected_object_size,
                       uint64_t expected_write_size,
 		      uint32_t flags) {

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -51,6 +51,13 @@ WRITE_CLASS_ENCODER(ContDesc)
 
 std::ostream &operator<<(std::ostream &out, const ContDesc &rhs);
 
+class ChunkDesc {
+public:
+  uint32_t offset;
+  uint32_t length;
+  std::string oid;
+};
+
 class ContentsGenerator {
 public:
 
@@ -507,6 +514,7 @@ public:
 
   uint64_t version;
   std::string redirect_target;
+  std::map<uint64_t, ChunkDesc> chunk_info;
 private:
   std::list<std::pair<ceph::shared_ptr<ContentsGenerator>, ContDesc> > layers;
 };

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -30,13 +30,15 @@ public:
 			int max_seconds,
 			bool ec_pool,
 			bool balance_reads,
-			bool set_redirect) :
+			bool set_redirect,
+			bool set_chunk) :
     m_nextop(NULL), m_op(0), m_ops(ops), m_seconds(max_seconds),
     m_objects(objects), m_stats(stats),
     m_total_weight(0),
     m_ec_pool(ec_pool),
     m_balance_reads(balance_reads),
-    m_set_redirect(set_redirect)
+    m_set_redirect(set_redirect),
+    m_set_chunk(set_chunk)
   {
     m_start = time(0);
     for (map<TestOpType, unsigned int>::const_iterator it = op_weights.begin();
@@ -46,11 +48,17 @@ public:
       m_weight_sums.insert(pair<TestOpType, unsigned int>(it->first,
 							  m_total_weight));
     }
-    if (m_set_redirect) {
-      /* create redirect objects + set-redirect*/
-      m_redirect_objects = objects*2; // for copy_from + set-redirect test
-      m_initial_redirected_objects = objects;
-      m_ops = ops+m_redirect_objects+m_initial_redirected_objects;
+    if (m_set_redirect || m_set_chunk) {
+      m_redirect_objects = objects*2; // for creating objects using copy_from 
+      m_initial_redirected_objects = objects; // for rediect or set-chunk
+      // we need pre-initialization process before run the test
+      // so, m_ops is increased
+      if (m_set_redirect) {
+	m_ops = ops+m_redirect_objects+m_initial_redirected_objects;
+      } else {
+	/* create 10 chunks per an object*/
+	m_ops = ops+m_redirect_objects+m_initial_redirected_objects+m_objects*10;
+      }
     }
   }
 
@@ -77,11 +85,11 @@ public:
       return NULL;
     }
     
-    if (m_set_redirect) {
+    if (m_set_redirect || m_set_chunk) {
       if (pre_init_extensible_tier(context, retval)) {
 	return retval;
       }
-    }
+    } 
 
     if (m_nextop) {
       retval = m_nextop;
@@ -108,15 +116,20 @@ public:
     return retval;
   }
   
-  bool pre_init_extensible_tier(RadosTestContext &context, TestOp *& op)
-  {
+  bool pre_init_extensible_tier(RadosTestContext &context, TestOp *& op) {
     /*
-     * set-redirect test
-     * 1. create objects (copy from)
-     * 2. set-redirect
+     * set-redirect or set-chunk test
+     * 0. create default objects
+     * 1. create target objects (using copy from)
+     * 2. set-redirect or set-chunk
+     * 3. wait for set-* completion
      */
     int create_objects_end = m_objects + m_redirect_objects;
     int set_redirect_end = create_objects_end + m_initial_redirected_objects; 
+    if (m_set_chunk) {
+      /* create 10 chunks per an object*/
+      set_redirect_end += set_redirect_end + m_objects * 10;
+    }
 
     if (m_op <= create_objects_end) {
       stringstream oid;
@@ -131,33 +144,83 @@ public:
       if ((_oid2) % 2) {
 	oid2 << " " << string(300, 'o');
       }
-      cout << m_op << ": " << "(create redirect oid) copy_from oid " << oid.str() 
+      cout << m_op << ": " << "(create target oid) copy_from oid " << oid.str() 
 	    << " from oid " << oid2.str() << std::endl;
       op = new CopyFromOp(m_op, &context, oid.str(), oid2.str(), m_stats);
       return true;
     } else if (m_op <= set_redirect_end) {
-      stringstream oid;
-      int _oid = m_op-create_objects_end;
-      oid << _oid;
-      if ((_oid) % 2) {
-	oid << " " << string(300, 'o');
+      if (m_set_redirect) {
+	stringstream oid;
+	int _oid = m_op-create_objects_end;
+	oid << _oid;
+	if ((_oid) % 2) {
+	  oid << " " << string(300, 'o');
+	}
+	stringstream oid2;
+	int _oid2 = _oid + m_objects;
+	oid2 << _oid2;
+	if ((_oid2) % 2) {
+	  oid2 << " " << string(300, 'o');
+	}
+	cout << m_op << ": " << "set_redirect oid " << oid.str() << " target oid " 
+	      << oid2.str() << std::endl;
+	op = new SetRedirectOp(m_op, &context, oid.str(), oid2.str(), context.pool_name);
+	return true;
+      } else if (m_set_chunk) {
+	stringstream oid;
+	int _oid = m_op % m_objects +1;
+	oid << _oid;
+	if ((_oid) % 2) {
+	  oid << " " << string(300, 'o');
+	}
+	if (context.oid_in_use.count(oid.str())) {
+	  /* previous set-chunk is not finished */
+	  op = NULL;
+	  m_op--;
+	  cout << m_op << " retry set_chunk !" << std::endl;
+	  return true;
+	}
+	stringstream oid2;
+	int _oid2 = _oid + m_objects;
+	oid2 << _oid2;
+	if ((_oid2) % 2) {
+	  oid2 << " " << string(300, 'o');
+	}
+
+	/* make a chunk like source object (random offset, random length) --> 
+	 * target object (random offset)
+	 */
+	ObjectDesc contents, contents2;
+	context.find_object(oid.str(), &contents);
+	context.find_object(oid2.str(), &contents2);
+	uint32_t max_len = contents.most_recent_gen()->get_length(contents.most_recent());
+	if (max_len > contents2.most_recent_gen()->get_length(contents2.most_recent())) {
+	  max_len = contents2.most_recent_gen()->get_length(contents2.most_recent());
+	}
+	uint32_t rand_offset = rand() % max_len;
+	uint32_t rand_length = rand() % max_len;
+
+	while (rand_offset + rand_length > max_len || rand_length == 0) {
+	  rand_offset = rand() % max_len;
+	  rand_length = rand() % max_len;
+	}
+	uint32_t rand_tgt_offset = rand_offset;
+	cout << m_op << ": " << "set_chunk oid " << oid.str() << " offset: " << rand_offset 
+	     << " length: " << rand_length <<  " target oid " << oid2.str() 
+	     << " tgt_offset: " << rand_tgt_offset << std::endl;
+	op = new SetChunkOp(m_op, &context, oid.str(), rand_offset, rand_length, oid2.str(), 
+			      context.pool_name, rand_tgt_offset, m_stats);
+	return true;
       }
-      stringstream oid2;
-      int _oid2 = _oid + m_objects;
-      oid2 << _oid2;
-      if ((_oid2) % 2) {
-	oid2 << " " << string(300, 'o');
-      }
-      cout << m_op << ": " << "set_redirect oid " << oid.str() << " target oid " 
-	    << oid2.str() << std::endl;
-      op = new SetRedirectOp(m_op, &context, oid.str(), oid2.str(), context.pool_name);
-      return true;
     } 
 
     if (!context.oid_redirect_not_in_use.size() && m_op > set_redirect_end) {
       int set_size = context.oid_not_in_use.size();
+      /* wait until redirect or set_chunk completion */
       if (set_size < m_objects + m_redirect_objects) {
 	op = NULL;
+	m_op--;
+	cout << m_op << " wait completion " << std::endl;
 	return true;
       }
       for (int t_op = m_objects+1; t_op <= create_objects_end; t_op++) {
@@ -319,6 +382,11 @@ private:
 	   << context.current_snap << std::endl;
       return new WriteOp(m_op, &context, oid, true, true, m_stats);
 
+    case TEST_OP_CHUNK_READ:
+      oid = *(rand_choose(context.oid_not_in_use));
+      cout << m_op << ": " << "chunk read oid " << oid << " target oid " << oid2 << std::endl;
+      return new ChunkReadOp(m_op, &context, oid, context.pool_name, false, m_stats);
+
     case TEST_OP_SET_REDIRECT:
       oid = *(rand_choose(context.oid_not_in_use));
       oid2 = *(rand_choose(context.oid_redirect_not_in_use));
@@ -349,6 +417,7 @@ private:
   bool m_ec_pool;
   bool m_balance_reads;
   bool m_set_redirect;
+  bool m_set_chunk;
   int m_redirect_objects{0};
   int m_initial_redirected_objects{0}; 
 };
@@ -391,6 +460,7 @@ int main(int argc, char **argv)
     { TEST_OP_APPEND_EXCL, "append_excl", true },
     { TEST_OP_SET_REDIRECT, "set_redirect", true },
     { TEST_OP_UNSET_REDIRECT, "unset_redirect", true },
+    { TEST_OP_CHUNK_READ, "chunk_read", true },
     { TEST_OP_READ /* grr */, NULL },
   };
 
@@ -401,6 +471,7 @@ int main(int argc, char **argv)
   bool no_sparse = false;
   bool balance_reads = false;
   bool set_redirect = false;
+  bool set_chunk = false;
 
   for (int i = 1; i < argc; ++i) {
     if (strcmp(argv[i], "--max-ops") == 0)
@@ -473,6 +544,8 @@ int main(int argc, char **argv)
       }
     } else if (strcmp(argv[i], "--set_redirect") == 0) {
       set_redirect = true;
+    } else if (strcmp(argv[i], "--set_chunk") == 0) {
+      set_chunk = true;
     } else {
       cerr << "unknown arg " << argv[i] << std::endl;
       exit(1);
@@ -533,7 +606,7 @@ int main(int argc, char **argv)
   WeightedTestGenerator gen = WeightedTestGenerator(
     ops, objects,
     op_weights, &stats, max_seconds,
-    ec_pool, balance_reads, set_redirect);
+    ec_pool, balance_reads, set_redirect, set_chunk);
   int r = context.init();
   if (r < 0) {
     cerr << "Error initializing rados test context: "

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -122,6 +122,10 @@ void usage(ostream& out)
 "   listwatchers <obj-name>          list the watchers of this object\n"
 "   set-alloc-hint <obj-name> <expected-object-size> <expected-write-size>\n"
 "                                    set allocation hint for an object\n"
+"   set-redirect <object A> --target-pool <caspool> <target object A>\n"
+"                                    set redirect target\n"
+"   set-chunk <object A> <offset> <length> --target-pool <caspool> <target object A> <taget-offset>\n"
+"                                    convert an object to chunked object\n"
 "\n"
 "IMPORT AND EXPORT\n"
 "   export [filename]\n"
@@ -3484,6 +3488,54 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ret = io_ctx.operate(nargs[1], &op);
     if (ret < 0) {
       cerr << "error set-redirect " << pool_name << "/" << nargs[1] << " => " << target << "/" << target_obj << ": " << cpp_strerror(ret) << std::endl;
+      goto out;
+    }
+  } else if (strcmp(nargs[0], "set-chunk") == 0) {
+    if (!pool_name)
+      usage_exit();
+
+    const char *target = target_pool_name;
+    if (!target)
+      target = pool_name;
+
+    uint64_t offset;
+    uint64_t length;
+    uint64_t tgt_offset;
+    string tgt_oid;
+    if (nargs.size() < 6) {
+      usage_exit();
+    } else {
+      char* endptr = NULL;
+      offset = strtoull(nargs[2], &endptr, 10);
+      if (*endptr) {
+	cerr << "Invalid value for size: '" << nargs[2] << "'" << std::endl;
+	ret = -EINVAL;
+	goto out;
+      }
+      length = strtoull(nargs[3], &endptr, 10);
+      if (*endptr) {
+	cerr << "Invalid value for size: '" << nargs[2] << "'" << std::endl;
+	ret = -EINVAL;
+	goto out;
+      }
+      tgt_oid = string(nargs[4]);
+      tgt_offset = strtoull(nargs[5], &endptr, 10);
+      if (*endptr) {
+	cerr << "Invalid value for size: '" << nargs[2] << "'" << std::endl;
+	ret = -EINVAL;
+	goto out;
+      }
+    }
+
+    IoCtx target_ctx;
+    ret = rados.ioctx_create(target, target_ctx);
+    ObjectWriteOperation op;
+    op.set_chunk(offset, length, target_ctx, tgt_oid, tgt_offset);
+    ret = io_ctx.operate(nargs[1], &op);
+    if (ret < 0) {
+      cerr << "error set-chunk " << pool_name << "/" << nargs[1] << " " << " offset " << offset
+	    << " length " << length << " target_pool " << target 
+	    << "tgt_offset: " << tgt_offset << " : " << cpp_strerror(ret) << std::endl;
       goto out;
     }
   } else if (strcmp(nargs[0], "export") == 0) {


### PR DESCRIPTION
As discussed with @liewegas, These commits are the second stage (chunked manifest) for deduplication
(http://pad.ceph.com/p/deduplication_how_dedup_manifists,
http://pad.ceph.com/p/deduplication_how_do_we_store_chunk)

Signed-off-by: Myoungwon Oh <omwmw@sk.com>