### PR TITLE
librbd: filter expected error codes from is_exclusive_lock_owner

### DIFF
--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1132,7 +1132,9 @@ int validate_pool(IoCtx &io_ctx, CephContext *cct) {
     // might have been blacklisted by peer -- ensure we still own
     // the lock by pinging the OSD
     int r = ictx->exclusive_lock->assert_header_locked();
-    if (r < 0) {
+    if (r == -EBUSY || r == -ENOENT) {
+      return 0;
+    } else if (r < 0) {
       return r;
     }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20182
Signed-off-by: Jason Dillaman <dillaman@redhat.com>