### PR TITLE
mgr/DaemonServer: stop spamming log with pg stats

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -830,10 +830,6 @@ void DaemonServer::send_report()
 	  pg_map.get_health(g_ceph_context, osdmap,
 			    m->health_summary,
 			    &m->health_detail);
-
-	  if (osdmap.require_osd_release >= CEPH_RELEASE_LUMINOUS) {
-	    clog->info() << "pgmap v" << pg_map.version << ": " << pg_map;
-	  }
 	});
     });
   // TODO? We currently do not notify the PyModules


### PR DESCRIPTION
This clutters up the log.  We should instead log to health, or other
important events.

Note that we still have ceph health logged at regular intervals, so some
of this will surface there.

Signed-off-by: Sage Weil <sage@redhat.com>