### PR TITLE
jewel: rbd: rbd-mirror: ensure missing images are re-synced when detected

### DIFF
--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -171,7 +171,6 @@ private:
   uint64_t m_remote_tag_class = 0;
   ImageCtxT *m_remote_image_ctx = nullptr;
   bool m_primary = false;
-  bool m_created_local_image = false;
   int m_ret_val = 0;
 
   bufferlist m_out_bl;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19811
Signed-off-by: Jason Dillaman <dillaman@redhat.com>
(cherry picked from commit 74bd4f230a0cb7b709f2cb5c6db3dc79f0d8dede)

Conflicts:
	src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc: trivial resolution
	src/tools/rbd_mirror/image_replayer/BootstrapRequest.h: trivial resolution