### PR TITLE
librados: redirect balanced reads to acting primary when targeting object isn't recovered 

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1989,6 +1989,10 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 
   // missing object?
   if (is_unreadable_object(head)) {
+    if (!is_primary()) {
+      osd->reply_op_error(op, -EAGAIN);
+      return;
+    }
     if (can_backoff &&
 	(g_conf->osd_backoff_on_degraded ||
 	 (g_conf->osd_backoff_on_unfound && missing_loc.is_unfound(head)))) {

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3412,6 +3412,22 @@ void Objecter::handle_osd_op_reply(MOSDOpReply *m)
   if (rc == -EAGAIN) {
     ldout(cct, 7) << " got -EAGAIN, resubmitting" << dendl;
 
+    if ((op->target.flags & CEPH_OSD_FLAG_BALANCE_READS) 
+	&& (op->target.acting_primary != op->target.osd)) {
+      if (op->onfinish)
+	num_in_flight--;
+      _session_op_remove(s, op);
+      sl.unlock();
+      put_session(s);
+
+      op->tid = 0;
+      op->target.flags &= ~CEPH_OSD_FLAG_BALANCE_READS;
+      op->target.pgid = pg_t();
+      _op_submit(op, sul, NULL);
+      m->put();
+      return;
+    }
+
     // new tid
     s->ops.erase(op->tid);
     op->tid = ++last_tid;


### PR DESCRIPTION
Redirect balanced read requests to acting primary when the
targeting object hasn't been recovered on replica OSDs.

Fixes: http://tracker.ceph.com/issues/17968
Signed-off-by: Xuehan Xu <xxhdx1985126@163.com>