### PR TITLE
selinux: Install ceph-base before ceph-selinux

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -765,6 +765,7 @@ Group:		System/Filesystems
 %endif
 Requires:	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires:	policycoreutils, libselinux-utils
+Requires(post):	ceph-base = %{_epoch_prefix}%{version}-%{release}
 Requires(post): selinux-policy-base >= %{_selinux_policy_version}, policycoreutils, gawk
 Requires(postun): policycoreutils
 %description selinux


### PR DESCRIPTION
We need to have ceph-base installed before ceph-selinux to use ceph-disk
in %post script. The default ordering is random and so the installation
randomly failed to relabel the files.

Fixes: http://tracker.ceph.com/issues/20184
Signed-off-by: Boris Ranto <branto@redhat.com>