### PR TITLE
pybind/ceph_argparse: fix empty string check

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -924,12 +924,12 @@ def validate(args, signature, flags=0, partial=False):
 
             # no arg, but not required?  Continue consuming mysig
             # in case there are later required args
-            if myarg == None and not desc.req:
+            if myarg in (None, []) and not desc.req:
                 break
 
             # out of arguments for a required param?
             # Either return (if partial validation) or raise
-            if myarg == None and desc.req:
+            if myarg in (None, []) and desc.req:
                 if desc.N and desc.numseen < 1:
                     # wanted N, didn't even get 1
                     if partial:


### PR DESCRIPTION
This partially reverts commit a1214a702cfd8465deb91847f4dc63c0e80fb586.

Fixes: http://tracker.ceph.com/issues/20135
Signed-off-by: Sage Weil <sage@redhat.com>