### PR TITLE
Resolve some usability papercuts

### DIFF
--- a/doc/rados/operations/placement-groups.rst
+++ b/doc/rados/operations/placement-groups.rst
@@ -296,6 +296,9 @@ resources. However, if 1,000 pools were created with 512 placement
 groups each, the OSDs will handle ~50,000 placement groups each and it
 would require significantly more resources and time for peering.
 
+You may find the `PGCalc`_ tool helpful.
+
+
 .. _setting the number of placement groups:
 
 Set the Number of Placement Groups

--- a/doc/start/quick-rbd.rst
+++ b/doc/start/quick-rbd.rst
@@ -47,6 +47,10 @@ Install Ceph
    directory. Ensure that the keyring file has appropriate read permissions 
    (e.g., ``sudo chmod +r /etc/ceph/ceph.client.admin.keyring``).
 
+Create an rbd pool
+==================
+#. On the admin node, use the ``ceph`` tool to `Create a Pool`_
+   (we recommend the name 'rbd').
 
 Configure a Block Device
 ========================

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -797,6 +797,7 @@ OPTION(osd_heartbeat_interval, OPT_INT, 6)       // (seconds) how often we ping 
 OPTION(osd_heartbeat_grace, OPT_INT, 20)
 OPTION(osd_heartbeat_min_peers, OPT_INT, 10)     // minimum number of peers
 OPTION(osd_heartbeat_use_min_delay_socket, OPT_BOOL, false) // prio the heartbeat tcp socket and set dscp as CS6 on it if true
+OPTION(osd_heartbeat_min_size, OPT_INT, 2000) // the minimum size of OSD heartbeat messages to send
 
 // max number of parallel snap trims/pg
 OPTION(osd_pg_max_concurrent_snap_trims, OPT_U64, 2)

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -12,6 +12,17 @@
  * 
  */
 
+
+/**
+ * This is used to send pings between daemons (so far, the OSDs) for
+ * heartbeat purposes. We include a timestamp and distinguish between
+ * outgoing pings and responses to those. If you set the
+ * min_message in the constructor, the message will inflate itself
+ * to the specified size -- this is good for dealing with network
+ * issues with jumbo frames. See http://tracker.ceph.com/issues/20087
+ *
+ */
+
 #ifndef CEPH_MOSDPING_H
 #define CEPH_MOSDPING_H
 
@@ -23,7 +34,7 @@
 
 class MOSDPing : public Message {
 
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 2;
 
  public:
@@ -52,10 +63,12 @@ class MOSDPing : public Message {
   __u8 op;
   osd_peer_stat_t peer_stat;
   utime_t stamp;
+  uint32_t min_message_size;
 
-  MOSDPing(const uuid_d& f, epoch_t e, __u8 o, utime_t s)
+  MOSDPing(const uuid_d& f, epoch_t e, __u8 o, utime_t s, uint32_t min_message)
     : Message(MSG_OSD_PING, HEAD_VERSION, COMPAT_VERSION),
-      fsid(f), map_epoch(e), peer_as_of_epoch(0), op(o), stamp(s)
+      fsid(f), map_epoch(e), peer_as_of_epoch(0), op(o), stamp(s),
+      min_message_size(min_message)
   { }
   MOSDPing()
     : Message(MSG_OSD_PING, HEAD_VERSION, COMPAT_VERSION)
@@ -72,6 +85,10 @@ public:
     ::decode(op, p);
     ::decode(peer_stat, p);
     ::decode(stamp, p);
+    if (header.version >= 3) {
+      bufferlist size_bl;
+      ::decode(size_bl, p);
+    }
   }
   void encode_payload(uint64_t features) override {
     ::encode(fsid, payload);
@@ -80,6 +97,10 @@ public:
     ::encode(op, payload);
     ::encode(peer_stat, payload);
     ::encode(stamp, payload);
+    if (min_message_size) {
+      bufferlist size_bl(min_message_size - payload.length());
+      ::encode(size_bl, payload);
+    }
   }
 
   const char *get_type_name() const override { return "osd_ping"; }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2835,6 +2835,10 @@ void PGMap::get_health(
   // pg skew
   int num_in = osdmap.get_num_in_osds();
   int sum_pg_up = MAX(pg_sum.up, static_cast<int32_t>(pg_stat.size()));
+  int sum_objects = pg_sum.stats.sum.num_objects;
+  if (sum_objects < cct->_conf->mon_pg_warn_min_objects) {
+    return;
+  }
   if (num_in && cct->_conf->mon_pg_warn_min_per_osd > 0) {
     int per = sum_pg_up / num_in;
     if (per < cct->_conf->mon_pg_warn_min_per_osd && per) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4669,8 +4669,8 @@ void OSD::handle_osd_ping(MOSDPing *m)
 
       Message *r = new MOSDPing(monc->get_fsid(),
 				curmap->get_epoch(),
-				MOSDPing::PING_REPLY,
-				m->stamp);
+				MOSDPing::PING_REPLY, m->stamp,
+				cct->_conf->osd_heartbeat_min_size);
       m->get_connection()->send_message(r);
 
       if (curmap->is_up(from)) {
@@ -4687,7 +4687,8 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	Message *r = new MOSDPing(monc->get_fsid(),
 				  curmap->get_epoch(),
 				  MOSDPing::YOU_DIED,
-				  m->stamp);
+				  m->stamp,
+				  cct->_conf->osd_heartbeat_min_size);
 	m->get_connection()->send_message(r);
       }
     }
@@ -4865,14 +4866,14 @@ void OSD::heartbeat()
     dout(30) << "heartbeat sending ping to osd." << peer << dendl;
     i->second.con_back->send_message(new MOSDPing(monc->get_fsid(),
 					  service.get_osdmap()->get_epoch(),
-					  MOSDPing::PING,
-					  now));
+					  MOSDPing::PING, now,
+					  cct->_conf->osd_heartbeat_min_size));
 
     if (i->second.con_front)
       i->second.con_front->send_message(new MOSDPing(monc->get_fsid(),
 					     service.get_osdmap()->get_epoch(),
-						     MOSDPing::PING,
-						     now));
+					     MOSDPing::PING, now,
+					  cct->_conf->osd_heartbeat_min_size));
   }
 
   logger->set(l_osd_hb_to, heartbeat_peers.size());

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3137,8 +3137,7 @@ int OSDMap::build_simple(CephContext *cct, epoch_t e, uuid_d &fsid,
 			  int nosd, int pg_bits, int pgp_bits)
 {
   ldout(cct, 10) << "build_simple on " << num_osd
-		 << " osds with " << pg_bits << " pg bits per osd, "
-		 << dendl;
+		 << " osds with " << dendl;
   epoch = e;
   set_fsid(fsid);
   created = modified = ceph_clock_now();
@@ -3174,13 +3173,6 @@ int OSDMap::build_simple(CephContext *cct, epoch_t e, uuid_d &fsid,
     set_max_osd(maxosd + 1);
   }
 
-  // pgp_num <= pg_num
-  if (pgp_bits > pg_bits)
-    pgp_bits = pg_bits;
-
-  vector<string> pool_names;
-  pool_names.push_back("rbd");
-
   stringstream ss;
   int r;
   if (nosd >= 0)
@@ -3188,34 +3180,6 @@ int OSDMap::build_simple(CephContext *cct, epoch_t e, uuid_d &fsid,
   else
     r = build_simple_crush_map_from_conf(cct, *crush, &ss);
   assert(r == 0);
-
-  int poolbase = get_max_osd() ? get_max_osd() : 1;
-
-  int const default_replicated_ruleset = crush->get_osd_pool_default_crush_replicated_ruleset(cct);
-  assert(default_replicated_ruleset >= 0);
-
-  for (auto &plname : pool_names) {
-    int64_t pool = ++pool_max;
-    pools[pool].type = pg_pool_t::TYPE_REPLICATED;
-    pools[pool].flags = cct->_conf->osd_pool_default_flags;
-    if (cct->_conf->osd_pool_default_flag_hashpspool)
-      pools[pool].set_flag(pg_pool_t::FLAG_HASHPSPOOL);
-    if (cct->_conf->osd_pool_default_flag_nodelete)
-      pools[pool].set_flag(pg_pool_t::FLAG_NODELETE);
-    if (cct->_conf->osd_pool_default_flag_nopgchange)
-      pools[pool].set_flag(pg_pool_t::FLAG_NOPGCHANGE);
-    if (cct->_conf->osd_pool_default_flag_nosizechange)
-      pools[pool].set_flag(pg_pool_t::FLAG_NOSIZECHANGE);
-    pools[pool].size = cct->_conf->osd_pool_default_size;
-    pools[pool].min_size = cct->_conf->get_osd_pool_default_min_size();
-    pools[pool].crush_ruleset = default_replicated_ruleset;
-    pools[pool].object_hash = CEPH_STR_HASH_RJENKINS;
-    pools[pool].set_pg_num(poolbase << pg_bits);
-    pools[pool].set_pgp_num(poolbase << pgp_bits);
-    pools[pool].last_change = epoch;
-    pool_name[pool] = plname;
-    name_pool[plname] = pool;
-  }
 
   for (int i=0; i<get_max_osd(); i++) {
     set_state(i, 0);

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -534,7 +534,7 @@ private:
 
  public:
   OSDMap() : epoch(0), 
-	     pool_max(-1),
+	     pool_max(0),
 	     flags(0),
 	     num_osd(0), num_up_osd(0), num_in_osd(0),
 	     max_osd(0),


### PR DESCRIPTION
1) Stop automatically creating an rbd pool, which means we don't need to try and create it at a sane size
2) don't warn on PG counts if the cluster is empty (by extending an existing config's coverage area)
3) force MOSDPing messages to be at least 2000 bytes (which exceeds non-jumbo-frame size) so we detect misconfigured switches in heartbeating rather than confusingly dropping all "real" messages