### PR TITLE
mon: don't prefix mgr summary with epoch number

### DIFF
--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -125,7 +125,6 @@ public:
     if (f) {
       dump(f);
     } else {
-      *ss << "e" << get_epoch() << ": ";
       if (get_active_gid() != 0) {
 	*ss << get_active_name();
         if (!available) {


### PR DESCRIPTION
Missed this one when culling the various epochs
from the human readable ceph status output.

Signed-off-by: John Spray <john.spray@redhat.com>