### PR TITLE
debian: ceph-mgr: fix package description

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -169,7 +169,7 @@ Depends: ceph-base (= ${binary:Version}),
          ${shlibs:Depends}
 Replaces: ceph (<< 0.93-417)
 Breaks: ceph (<< 0.93-417)
-Description: metadata server for the ceph distributed file system
+Description: manager for the ceph distributed storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
  block and file system storage.


### PR DESCRIPTION
wrongly copy-pasted in 042b6b44542cfd155e9be3a8a4de280470de7499

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>