### PR TITLE
crc32c: include acconfig.h to fix ceph_crc32c_aarch64()

### DIFF
--- a/src/common/crc32c_aarch64.h
+++ b/src/common/crc32c_aarch64.h
@@ -1,6 +1,7 @@
 #ifndef CEPH_COMMON_CRC32C_AARCH64_H
 #define CEPH_COMMON_CRC32C_AARCH64_H
 
+#include "acconfig.h"
 #include "arch/arm.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
it's a regresssion introduced by 2a3382f

Signed-off-by: Kefu Chai <kchai@redhat.com>