### PR TITLE
osd/PrimaryLogPG: clear oi from trim_object()

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3767,6 +3767,9 @@ PrimaryLogPG::OpContextUPtr PrimaryLogPG::trim_object(
       coid,
       old_snaps,
       new_snaps);
+
+    obc->obs.oi = object_info_t(coid);
+
     ctx->at_version.version++;
   } else {
     // save adjusted snaps for this object
@@ -3848,7 +3851,7 @@ PrimaryLogPG::OpContextUPtr PrimaryLogPG::trim_object(
 	ctx->delta_stats.num_objects_pinned--;
     }
     ctx->snapset_obc->obs.exists = false;
-    
+    obc->obs.oi = object_info_t(coid);
     t->remove(snapoid);
   } else {
     dout(10) << coid << " filtering snapset on " << snapoid << dendl;


### PR DESCRIPTION
trim_object() is unique in that its resulting OpContxtUPtr is fed to
simple_opc_submit() but does not first pass through finish_ctx().  Almost
none of what finish_ctx is helpful for us because we are the only place
where we delete a clone, and for that reason it is not terribly useful to
put what we do into finish_ctx.  However, *one* thing that finish_ctx()
does do that we don't (didn't) is clear out the object_info_t io on
delete.  This would leave things like version with a value that would
bleed into future instantiations of the object and break things like
the prior_version in pg_log_entry_t's and, much later, break asserts
when loading the missing set off of disk.

Fix by clearing oi.

Fixes: http://tracker.ceph.com/issues/19947
Signed-off-by: Sage Weil <sage@redhat.com>