### PR TITLE
osd: reduce rados_max_object_size from 100 GB -> 128 MB

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -147,3 +147,9 @@
   ``mon_osd_err_op_age_ratio`` that is a expressed as a multitple of
   ``mon_osd_warn_op_age`` (default: 128, for roughly 60 minutes) to
   control when an error is generated.
+
+* The default maximum size for a single RADOS object has been reduced from
+  100GB to 128MB.  The 100GB limit was completely impractical in practice
+  while the 128MB limit is a bit high but not unreasonable.  If you have an
+  application written directly to librados that is using objects larger than
+  128MB you may need to adjust ``osd_max_object_size``.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -993,7 +993,7 @@ OPTION(osd_recovery_op_warn_multiple, OPT_U32, 16)
 OPTION(osd_mon_shutdown_timeout, OPT_DOUBLE, 5)
 OPTION(osd_shutdown_pgref_assert, OPT_BOOL, false) // crash if the OSD has stray PG refs on shutdown
 
-OPTION(osd_max_object_size, OPT_U64, 100*1024L*1024L*1024L) // OSD's maximum object size
+OPTION(osd_max_object_size, OPT_U64, 128*1024L*1024L) // OSD's maximum object size
 OPTION(osd_max_object_name_len, OPT_U32, 2048) // max rados object name len
 OPTION(osd_max_object_namespace_len, OPT_U32, 256) // max rados object namespace len
 OPTION(osd_max_attr_name_len, OPT_U32, 100)    // max rados attr name len; cannot go higher than 100 chars for file system backends


### PR DESCRIPTION
I'm not sure why we had this so huge!  128 MB is a pretty reasonable size.

qa
- [x] rados