### PR TITLE
ceph_test_rados_api_misc: fix LibRadosMiscConnectFailure.ConnectFailure retry

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -78,6 +78,7 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
       break;  // yay, we timed out
     // try again
     rados_shutdown(cluster);
+    ASSERT_EQ(0, rados_create(&cluster, NULL));
   }
   ASSERT_NE(0, r);
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/19901
Signed-off-by: Sage Weil <sage@redhat.com>