### PR TITLE
test: osd/TestOSDMap.cc: fix Clang complain about promotion

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -441,7 +441,7 @@ TEST(PGTempMap, basic)
   pg_t a(1,1);
   for (unsigned i=3; i<1000; ++i) {
     pg_t x(i, 1);
-    m.set(x, {i});
+    m.set(x, {static_cast<int>(i)});
   }
   pg_t b(2,1);
   m.set(a, {1, 2});


### PR DESCRIPTION
```
/home/jenkins/workspace/ceph-freebsd/src/test/osd/TestOSDMap.cc:444:15: error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
    m.set(x, {i});
              ^
/home/jenkins/workspace/ceph-freebsd/src/test/osd/TestOSDMap.cc:444:15: note: insert an explicit cast to silence this issue
    m.set(x, {i});
              ^
              static_cast<int>( )
1 error generated.
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>