### PR TITLE
qa/workunits/ceph-helpers.sh: use syntax understood by jq 1.3

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -967,7 +967,7 @@ function get_not_primary() {
 
     local primary=$(get_primary $poolname $objectname)
     ceph --format json osd map $poolname $objectname 2>/dev/null | \
-        jq ".acting | map(select (. != $primary)) | first"
+        jq ".acting | map(select (. != $primary)) | .[0]"
 }
 
 function test_get_not_primary() {


### PR DESCRIPTION
trusty still ships jq 1.3 which does not offer "first". see
https://stedolan.github.io/jq/manual/v1.3/ .

Signed-off-by: Kefu Chai <kchai@redhat.com>