### PR TITLE
mon,osd: add crush_version to OSDMap, and allow crush map updates to gate on crush_version

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -8,6 +8,7 @@ set -e
 set -o functrace
 PS4='${BASH_SOURCE[0]}:$LINENO: ${FUNCNAME[0]}:  '
 SUDO=${SUDO:-sudo}
+export CEPH_DEV=1
 
 function get_admin_socket()
 {

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -264,7 +264,7 @@ void MgrClient::send_report()
 
 void MgrClient::send_pgstats()
 {
-  if (pgstats_cb) {
+  if (pgstats_cb && session) {
     session->con->send_message(pgstats_cb());
   }
 }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -493,9 +493,11 @@ COMMAND("osd crush rule dump " \
 COMMAND("osd crush dump", \
 	"dump crush map", \
 	"osd", "r", "cli,rest")
-COMMAND("osd setcrushmap", "set crush map from input file", \
+COMMAND("osd setcrushmap name=prior_version,type=CephInt,req=false", \
+	"set crush map from input file",	\
 	"osd", "rw", "cli,rest")
-COMMAND("osd crush set", "set crush map from input file", \
+COMMAND("osd crush set name=prior_version,type=CephInt,req=false", \
+	"set crush map from input file",	\
 	"osd", "rw", "cli,rest")
 COMMAND("osd crush add-bucket " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7222,6 +7222,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
  
   if (prefix == "osd setcrushmap" ||
       (prefix == "osd crush set" && !osdid_present)) {
+    if (pending_inc.crush.length()) {
+      dout(10) << __func__ << " waiting for pending crush update " << dendl;
+      wait_for_finished_proposal(op, new C_RetryMessage(this, op));
+      return true;
+    }
     dout(10) << "prepare_command setting new crush map" << dendl;
     bufferlist data(m->get_data());
     CrushWrapper crush;
@@ -7233,6 +7238,32 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -EINVAL;
       ss << "Failed to parse crushmap: " << e.what();
       goto reply;
+    }
+
+    int64_t prior_version = 0;
+    if (cmd_getval(g_ceph_context, cmdmap, "prior_version", prior_version)) {
+      if (prior_version == osdmap.get_crush_version() - 1) {
+	// see if we are a resend of the last update.  this is imperfect
+	// (multiple racing updaters may not both get reliable success)
+	// but we expect crush updaters (via this interface) to be rare-ish.
+	bufferlist current, proposed;
+	osdmap.crush->encode(current, mon->get_quorum_con_features());
+	crush.encode(proposed, mon->get_quorum_con_features());
+	if (current.contents_equal(proposed)) {
+	  dout(10) << __func__
+		   << " proposed matches current and version equals previous"
+		   << dendl;
+	  err = 0;
+	  ss << osdmap.get_crush_version();
+	  goto reply;
+	}
+      }
+      if (prior_version != osdmap.get_crush_version()) {
+	err = -EPERM;
+	ss << "prior_version " << prior_version << " != crush version "
+	   << osdmap.get_crush_version();
+	goto reply;
+      }
     }
 
     if (!validate_crush_against_features(&crush, ss)) {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4201,7 +4201,7 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       ss << "got osdmap epoch " << p->get_epoch();
     } else if (prefix == "osd getcrushmap") {
       p->crush->encode(rdata, mon->get_quorum_con_features());
-      ss << "got crush map from osdmap epoch " << p->get_epoch();
+      ss << p->get_crush_version();
     } else if (prefix == "osd ls-tree") {
       string bucket_name;
       cmd_getval(g_ceph_context, cmdmap, "name", bucket_name);
@@ -7273,7 +7273,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     dout(10) << " result " << ess.str() << dendl;
 
     pending_inc.crush = data;
-    ss << "set crush map";
+    ss << osdmap.get_crush_version() + 1;
     goto update;
 
   } else if (prefix == "osd crush set-device-class") {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -554,6 +554,8 @@ private:
   uint32_t get_crc() const { return crc; }
 
   ceph::shared_ptr<CrushWrapper> crush;       // hierarchical map
+private:
+  uint32_t crush_version = 1;
 
   friend class OSDMonitor;
 
@@ -605,6 +607,10 @@ public:
   void inc_epoch() { epoch++; }
 
   void set_epoch(epoch_t e);
+
+  uint32_t get_crush_version() const {
+    return crush_version;
+  }
 
   /* stamps etc */
   const utime_t& get_created() const { return created; }

--- a/src/test/cli/osdmaptool/clobber.t
+++ b/src/test/cli/osdmaptool/clobber.t
@@ -19,6 +19,7 @@
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
+  crush_version 1
   full_ratio 0
   backfillfull_ratio 0
   nearfull_ratio 0
@@ -44,6 +45,7 @@
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
+  crush_version 1
   full_ratio 0
   backfillfull_ratio 0
   nearfull_ratio 0

--- a/src/test/cli/osdmaptool/create-print.t
+++ b/src/test/cli/osdmaptool/create-print.t
@@ -78,6 +78,7 @@
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
+  crush_version 1
   full_ratio 0
   backfillfull_ratio 0
   nearfull_ratio 0

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -791,6 +791,7 @@
   created \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   modified \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d+ (re)
   flags 
+  crush_version 1
   full_ratio 0
   backfillfull_ratio 0
   nearfull_ratio 0


### PR DESCRIPTION
This allows safe offline updates to the crush map.  The caller can fetch the map,
note the version, go make some changes, and when reinjecting the map, specify the
same version to ensure there weren't intervening updates.