### PR TITLE
common/LogEntry: only store hash in LogSummary

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -253,7 +253,7 @@ void LogSummary::decode(bufferlist::iterator& bl)
   DECODE_FINISH(bl);
   keys.clear();
   for (auto& p : tail) {
-    keys.insert(p.key());
+    keys.insert(p.key().get_hash());
   }
 }
 


### PR DESCRIPTION
what we need is but the hash, so just store the hash of LogEntryKeys.

Signed-off-by: Kefu Chai <kchai@redhat.com>