### PR TITLE
test/osd: silence warning from -Wnarrowing

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -439,7 +439,7 @@ TEST(PGTempMap, basic)
 {
   PGTempMap m;
   pg_t a(1,1);
-  for (unsigned i=3; i<1000; ++i) {
+  for (int i=3; i<1000; ++i) {
     pg_t x(i, 1);
     m.set(x, {i});
   }


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/test/osd/TestOSDMap.cc: In member function ‘virtual void PGTempMap_basic_Test::TestBody()’:
ceph/src/test/osd/TestOSDMap.cc:444:17: warning: narrowing conversion of ‘i’ from ‘unsigned int’ to ‘int’ inside { } [-Wnarrowing]
     m.set(x, {i});
ceph/src/test/osd/TestOSDMap.cc:444:17: warning: narrowing conversion of ‘i’ from ‘unsigned int’ to ‘int’ inside { } [-Wnarrowing]
```
Signed-off-by: Jos Collin <jcollin@redhat.com>