### PR TITLE
restful: limit SSL certificate and key permissions

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1215,6 +1215,8 @@ if [ ! -e "$CERT" -o ! -e "$PKEY" ]; then
   openssl req -new -nodes -x509 \
     -subj "/O=IT/CN=ceph-mgr-restful" \
     -days 3650 -keyout "$PKEY" -out "$CERT" -extensions v3_ca
+  chown root:ceph "$CERT" "$PKEY"
+  chmod 640 "$CERT" "$PKEY"
 fi
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then

--- a/debian/ceph-mgr.postinst
+++ b/debian/ceph-mgr.postinst
@@ -30,6 +30,8 @@ case "$1" in
 	    openssl req -new -nodes -x509 \
 		-subj "/O=IT/CN=ceph-mgr-restful" \
 		-days 3650 -keyout "$PKEY" -out "$CERT" -extensions v3_ca
+	    chown root:ceph "$CERT" "$PKEY"
+	    chmod 640 "$CERT" "$PKEY"
 	fi
 	[ -x /sbin/start ] && start ceph-mgr-all || :
 


### PR DESCRIPTION
This avoids having a world-readable SSL key.

Signed-off-by: Tim Serong <tserong@suse.com>