### PR TITLE
rgw_file: replace raw fs->fh_lru.unref with predefined fs->unref

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -760,7 +760,7 @@ namespace rgw {
 	  << fh->name
 	  << " before ObjUnref refs=" << fh->get_refcnt()
 	  << dendl;
-	fs->fh_lru.unref(fh, cohort::lru::FLAG_NONE);
+	fs->unref(fh);
       }
     };
 
@@ -932,7 +932,7 @@ namespace rgw {
        * no unsafe iterators reaching it either--n.b., this constraint
        * is binding oncode which may in future attempt to e.g.,
        * cause the eviction of objects in LRU order */
-      (void) get_fs()->fh_lru.unref(parent, cohort::lru::FLAG_NONE);
+      (void) get_fs()->unref(parent);
     }
   }
 

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -1133,7 +1133,6 @@ namespace rgw {
       if (! fh) {
 	if (unlikely(fh_hk == root_fh.fh.fh_hk)) {
 	  fh = &root_fh;
-	  ref(fh);
 	}
       }
 


### PR DESCRIPTION
Cleanup for conciseness, also removes a ref on root_fh which does nothing.

Signed-off-by: Gui Hecheng <guihecheng@cmss.chinamobile.com>