### PR TITLE
doc/cephfs: mention RADOS object size limit

### DIFF
--- a/doc/cephfs/file-layouts.rst
+++ b/doc/cephfs/file-layouts.rst
@@ -34,6 +34,14 @@ stripe_count
 object_size
     Integer in bytes.  File data is chunked into RADOS objects of this size.
 
+.. tip::
+
+    RADOS enforces a configurable limit on object sizes: if you increase CephFS
+    object sizes beyond that limit then writes may not succeed.  The OSD
+    setting is ``rados_max_object_size``, which is 128MB by default.
+    Very large RADOS objects may prevent smooth operation of the cluster,
+    so increasing the object size limit past the default is not recommended.
+
 Reading layouts with ``getfattr``
 ---------------------------------
 


### PR DESCRIPTION
Reflect the recent change in this limit
for 12.x.

Signed-off-by: John Spray <john.spray@redhat.com>