### PR TITLE
mon/OSDMonitor: allow to specify osdid range for "ceph osd down/out/in/rm" cmds

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -649,7 +649,7 @@ COMMAND("osd in " \
 	"set osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
 COMMAND("osd rm " \
 	"name=ids,type=CephString,n=N", \
-	"remove osd(s) <id> [<id>...] in", "osd", "rw", "cli,rest")
+	"remove osd(s) <id> [<id>...]", "osd", "rw", "cli,rest")
 COMMAND("osd reweight " \
 	"name=id,type=CephOsdName " \
 	"type=CephFloat,name=weight,range=0.0|1.0", \


### PR DESCRIPTION
E.g.:
```
ceph osd out 0~2
marked out osd.0. marked out osd.1. marked out osd.2.

ceph osd in 0~2
marked in osd.0. marked in osd.1. marked in osd.2.
```

This might be useful for large clusters

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>