### PR TITLE
tools/rbd_mirror: silence warnings from -Wmaybe-uninitialized

### DIFF
--- a/src/tools/rbd_mirror/instance_watcher/Types.h
+++ b/src/tools/rbd_mirror/instance_watcher/Types.h
@@ -44,7 +44,7 @@ struct ImagePayloadBase : public PayloadBase {
   std::string peer_mirror_uuid;
   std::string peer_image_id;
 
-  ImagePayloadBase() : PayloadBase() {
+  ImagePayloadBase() : PayloadBase(), global_image_id{""}, peer_mirror_uuid{""}, peer_image_id{""} {
   }
 
   ImagePayloadBase(uint64_t request_id, const std::string &global_image_id,
@@ -97,7 +97,7 @@ struct ImageReleasePayload : public ImagePayloadBase {
 struct SyncPayloadBase : public PayloadBase {
   std::string sync_id;
 
-  SyncPayloadBase() : PayloadBase() {
+  SyncPayloadBase() : PayloadBase(), sync_id{""} {
   }
 
   SyncPayloadBase(uint64_t request_id, const std::string &sync_id)


### PR DESCRIPTION
The following warning appears during make:
```
In file included from ceph/src/tools/rbd_mirror/instance_watcher/Types.cc:4:0:
ceph/src/tools/rbd_mirror/instance_watcher/Types.h: In member function ‘void rbd::mirror::instance_watcher::NotifyMessage::decode(ceph::buffer::list::iterator&)’:
ceph/src/tools/rbd_mirror/instance_watcher/Types.h:42:8: warning: ‘*((void*)(& temp)+8).rbd::mirror::instance_watcher::ImagePayloadBase::<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 struct ImagePayloadBase : public PayloadBase {
        ^~~~~~~~~~~~~~~~
ceph/src/tools/rbd_mirror/instance_watcher/Types.h:42:8: warning: ‘*((void*)(& temp)+8).rbd::mirror::instance_watcher::ImagePayloadBase::<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 struct ImagePayloadBase : public PayloadBase {
        ^~~~~~~~~~~~~~~~
ceph/src/tools/rbd_mirror/instance_watcher/Types.h:97:8: warning: ‘*((void*)(& temp)+8).rbd::mirror::instance_watcher::SyncPayloadBase::<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 struct SyncPayloadBase : public PayloadBase {
        ^~~~~~~~~~~~~~~
ceph/src/tools/rbd_mirror/instance_watcher/Types.h:97:8: warning: ‘*((void*)(& temp)+8).rbd::mirror::instance_watcher::SyncPayloadBase::<anonymous>’ may be used uninitialized in this function [-Wmaybe-uninitialized]
 struct SyncPayloadBase : public PayloadBase {
```
Signed-off-by: Jos Collin <jcollin@redhat.com>