### PR TITLE
debian: sync logrotate packaging with downstream

### DIFF
--- a/debian/ceph-base.maintscript
+++ b/debian/ceph-base.maintscript
@@ -1,0 +1,2 @@
+rm_conffile /etc/logrotate.d/ceph.logrotate -- "$@"
+rm_conffile /etc/logrotate.d/ceph -- "$@"

--- a/debian/rules
+++ b/debian/rules
@@ -59,8 +59,8 @@ override_dh_installdocs:
 	dh_installdocs -a --all ChangeLog
 
 override_dh_installlogrotate:
-	cp src/logrotate.conf debian/ceph-base.ceph.logrotate
-	dh_installlogrotate -pceph-base --name=ceph
+	cp src/logrotate.conf debian/ceph-common.logrotate
+	dh_installlogrotate -pceph-common
 
 override_dh_installinit:
 	# dh_installinit is only set up to handle one upstart script


### PR DESCRIPTION
both Ubuntu and Debian put the logrotate script into
ceph-common, to ensure that radosgw logs are rotated as
well.

to prevent duplicate logrotate scripts handling the same log
files, and to minimize the delta between upstream and
downstream packaging, sync this change back upstream.

Fixes: http://tracker.ceph.com/issues/19938

Signed-off-by: Fabian Grünbichler <f.gruenbichler@proxmox.com>