### PR TITLE
rgw: external auth engines of S3 honor rgw_keystone_implicit_tenants.

### DIFF
--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -38,7 +38,7 @@ class ExternalAuthStrategy : public rgw::auth::Strategy,
                             ) const override {
     auto apl = rgw::auth::add_sysreq(cct, store, s,
       rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,
-                               false /* no implicit tenants */));
+                               cct->_conf->rgw_keystone_implicit_tenants));
     /* TODO(rzarzynski): replace with static_ptr. */
     return aplptr_t(new decltype(apl)(std::move(apl)));
   }

--- a/src/rgw/rgw_rest_s3.h
+++ b/src/rgw/rgw_rest_s3.h
@@ -842,7 +842,7 @@ public:
                             ) const override {
     return aplptr_t(
       new rgw::auth::RemoteApplier(cct, store, std::move(acl_alg), info,
-                                   false /* no implicit tenants */));
+                                   cct->_conf->rgw_keystone_implicit_tenants));
   }
 
   aplptr_t create_apl_local(CephContext* const cct,


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/17779
Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>