### PR TITLE
mon/PGMap: fix osd_epoch update when removing osd_stat

### DIFF
--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -95,6 +95,18 @@ void ClusterState::update_delta_stats()
   pending_inc.stamp = ceph_clock_now();
   pending_inc.version = pg_map.version + 1; // to make apply_incremental happy
   dout(10) << " v" << pending_inc.version << dendl;
+
+  dout(30) << " pg_map before:\n";
+  JSONFormatter jf(true);
+  jf.dump_object("pg_map", pg_map);
+  jf.flush(*_dout);
+  *_dout << dendl;
+  dout(30) << " incremental:\n";
+  JSONFormatter jf(true);
+  jf.dump_object("pending_inc", pending_inc);
+  jf.flush(*_dout);
+  *_dout << dendl;
+
   pg_map.apply_incremental(g_ceph_context, pending_inc);
   pending_inc = PGMap::Incremental();
 }
@@ -121,6 +133,17 @@ void ClusterState::notify_osdmap(const OSDMap &osd_map)
   set<int> need_check_down_pg_osds;
   PGMapUpdater::check_down_pgs(osd_map, pg_map, true,
 			       need_check_down_pg_osds, &pending_inc);
+
+  dout(30) << " pg_map before:\n";
+  JSONFormatter jf(true);
+  jf.dump_object("pg_map", pg_map);
+  jf.flush(*_dout);
+  *_dout << dendl;
+  dout(30) << " incremental:\n";
+  JSONFormatter jf(true);
+  jf.dump_object("pending_inc", pending_inc);
+  jf.flush(*_dout);
+  *_dout << dendl;
 
   pg_map.apply_incremental(g_ceph_context, pending_inc);
   pending_inc = PGMap::Incremental();

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1130,6 +1130,7 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     if (t != osd_stat.end()) {
       stat_osd_sub(t->first, t->second);
       osd_stat.erase(t);
+      osd_epochs.erase(*p);
     }
 
     // remove these old osds from full/nearfull set(s), too


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20208 (one instance of it at least)