### PR TITLE
pybind/rbd: OSError should be picklable

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -394,6 +394,8 @@ class OSError(Error):
     def __str__(self):
         return '[Errno {0}] {1}'.format(self.errno, self.strerror)
 
+    def __reduce__(self):
+        return (self.__class__, (self.errno, self.strerror))
 
 class PermissionError(OSError):
     pass


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20223
Signed-off-by: Jason Dillaman <dillaman@redhat.com>