### PR TITLE
os/bluestore: configure rocksdb cache via bluestore_cache_kv_ratio

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1137,7 +1137,8 @@ OPTION(bluestore_cache_type, OPT_STR, "2q")   // lru, 2q
 OPTION(bluestore_2q_cache_kin_ratio, OPT_DOUBLE, .5)    // kin page slot size / max page slot size
 OPTION(bluestore_2q_cache_kout_ratio, OPT_DOUBLE, .5)   // number of kout page slot / total number of page slot
 OPTION(bluestore_cache_size, OPT_U64, 1024*1024*1024)
-OPTION(bluestore_cache_meta_ratio, OPT_DOUBLE, .9)
+OPTION(bluestore_cache_meta_ratio, OPT_DOUBLE, .7)
+OPTION(bluestore_cache_kv_ratio, OPT_DOUBLE, .2)
 OPTION(bluestore_kvbackend, OPT_STR, "rocksdb")
 OPTION(bluestore_allocator, OPT_STR, "bitmap")     // stupid | bitmap
 OPTION(bluestore_freelist_blocks_per_key, OPT_INT, 128)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -945,6 +945,7 @@ OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 SAFE_OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_U64, 128*1024*1024)  // default rocksdb cache size
+OPTION(rocksdb_cache_row_ratio, OPT_FLOAT, .2)   // ratio of cache for row (vs block)
 OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
 OPTION(rocksdb_cache_type, OPT_STR, "lru") // 'lru' or 'clock'
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -946,6 +946,7 @@ SAFE_OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_U64, 128*1024*1024)  // default rocksdb cache size
 OPTION(rocksdb_cache_shard_bits, OPT_INT, 4)  // rocksdb block cache shard bits, 4 bit -> 16 shards
+OPTION(rocksdb_cache_type, OPT_STR, "lru") // 'lru' or 'clock'
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 OPTION(rocksdb_perf, OPT_BOOL, false) // Enabling this will have 5-10% impact on performance for the stats collection
 OPTION(rocksdb_collect_compaction_stats, OPT_BOOL, false) //For rocksdb, this behavior will be an overhead of 5%~10%, collected only rocksdb_perf is enabled.

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -304,6 +304,10 @@ public:
     return -EOPNOTSUPP;
   }
 
+  virtual int set_cache_size(uint64_t) {
+    return -EOPNOTSUPP;
+  }
+
   virtual ~KeyValueDB() {}
 
   /// compact the underlying store

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -297,24 +297,30 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
     opt.env = static_cast<rocksdb::Env*>(priv);
   }
 
-  std::shared_ptr<rocksdb::Cache> cache;
+  // caches
   if (!cache_size) {
     cache_size = g_conf->rocksdb_cache_size;
   }
+  uint64_t row_cache_size = cache_size * g_conf->rocksdb_cache_row_ratio;
+  uint64_t block_cache_size = cache_size - row_cache_size;
   if (g_conf->rocksdb_cache_type == "lru") {
-    cache = rocksdb::NewLRUCache(cache_size,
-				 g_conf->rocksdb_cache_shard_bits);
+    bbt_opts.block_cache = rocksdb::NewLRUCache(
+      block_cache_size,
+      g_conf->rocksdb_cache_shard_bits);
   } else if (g_conf->rocksdb_cache_type == "clock") {
-    cache = rocksdb::NewClockCache(cache_size,
-				   g_conf->rocksdb_cache_shard_bits);
+    bbt_opts.block_cache = rocksdb::NewClockCache(
+      block_cache_size,
+      g_conf->rocksdb_cache_shard_bits);
   } else {
     derr << "unrecognized rocksdb_cache_type '" << g_conf->rocksdb_cache_type
 	 << "'" << dendl;
     return -EINVAL;
   }
-
   bbt_opts.block_size = g_conf->rocksdb_block_size;
-  bbt_opts.block_cache = cache;
+
+  opt.row_cache = rocksdb::NewLRUCache(row_cache_size,
+				       g_conf->rocksdb_cache_shard_bits);
+
   if (g_conf->kstore_rocksdb_bloom_bits_per_key > 0) {
     dout(10) << __func__ << " set bloom filter bits per key to "
 	     << g_conf->kstore_rocksdb_bloom_bits_per_key << dendl;
@@ -322,10 +328,13 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
 				   g_conf->kstore_rocksdb_bloom_bits_per_key));
   }
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
-  dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
-           << ", cache size to " << prettybyte_t(cache_size)
-           << ", cache shards to "
-	   << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
+  dout(10) << __func__ << " block size " << g_conf->rocksdb_block_size
+           << ", block_cache size " << prettybyte_t(block_cache_size)
+	   << ", row_cache size " << prettybyte_t(row_cache_size)
+	   << "; shards "
+	   << (1 << g_conf->rocksdb_cache_shard_bits)
+	   << ", type " << g_conf->rocksdb_cache_type
+	   << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
   status = rocksdb::DB::Open(opt, path, &db);

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -297,18 +297,32 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
     opt.env = static_cast<rocksdb::Env*>(priv);
   }
 
-  auto cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size, g_conf->rocksdb_cache_shard_bits);
+  std::shared_ptr<rocksdb::Cache> cache;
+  if (g_conf->rocksdb_cache_type == "lru") {
+    cache = rocksdb::NewLRUCache(g_conf->rocksdb_cache_size,
+				 g_conf->rocksdb_cache_shard_bits);
+  } else if (g_conf->rocksdb_cache_type == "clock") {
+    cache = rocksdb::NewClockCache(g_conf->rocksdb_cache_size,
+				   g_conf->rocksdb_cache_shard_bits);
+  } else {
+    derr << "unrecognized rocksdb_cache_type '" << g_conf->rocksdb_cache_type
+	 << "'" << dendl;
+    return -EINVAL;
+  }
+
   bbt_opts.block_size = g_conf->rocksdb_block_size;
   bbt_opts.block_cache = cache;
   if (g_conf->kstore_rocksdb_bloom_bits_per_key > 0) {
     dout(10) << __func__ << " set bloom filter bits per key to "
 	     << g_conf->kstore_rocksdb_bloom_bits_per_key << dendl;
-    bbt_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(g_conf->kstore_rocksdb_bloom_bits_per_key));
+    bbt_opts.filter_policy.reset(rocksdb::NewBloomFilterPolicy(
+				   g_conf->kstore_rocksdb_bloom_bits_per_key));
   }
   opt.table_factory.reset(rocksdb::NewBlockBasedTableFactory(bbt_opts));
   dout(10) << __func__ << " set block size to " << g_conf->rocksdb_block_size
            << " cache size to " << g_conf->rocksdb_cache_size
-           << " num of cache shards to " << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
+           << " num of cache shards to "
+	   << (1 << g_conf->rocksdb_cache_shard_bits) << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
   status = rocksdb::DB::Open(opt, path, &db);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -75,6 +75,8 @@ class RocksDBStore : public KeyValueDB {
   rocksdb::BlockBasedTableOptions bbt_opts;
   string options_str;
 
+  uint64_t cache_size = 0;
+
   int do_open(ostream &out, bool create_if_missing);
 
   // manage async compactions
@@ -435,6 +437,10 @@ err:
     return total_size;
   }
 
+  int set_cache_size(uint64_t s) override {
+    cache_size = s;
+    return 0;
+  }
 
 protected:
   WholeSpaceIterator _get_iterator() override;

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -132,6 +132,7 @@ public:
   void _set_csum();
   void _set_compression();
   void _set_throttle_params();
+  int _set_cache_sizes();
 
   class TransContext;
 
@@ -1067,7 +1068,9 @@ public:
       --num_blobs;
     }
 
-    void trim(uint64_t target_bytes, float target_meta_ratio,
+    void trim(uint64_t target_bytes,
+	      float target_meta_ratio,
+	      float target_data_ratio,
 	      float bytes_per_onode);
 
     void trim_all();
@@ -1899,6 +1902,10 @@ private:
 
   uint64_t kv_ios = 0;
   uint64_t kv_throttle_costs = 0;
+
+  float cache_meta_ratio = 0;   ///< cache ratio dedicated to metadata
+  float cache_kv_ratio = 0;     ///< cache ratio dedicated to kv (e.g., rocksdb)
+  float cache_data_ratio = 0;   ///< cache ratio dedicated to object data
 
   // cache trim control
 


### PR DESCRIPTION
Also, enable the rocksdb row cache via rocksdb_cache_row_meta (default: .2)

Also, add rocksdb_cache_type = lru|clock option.  Note that 'clock' doesn't seem to work
in that it reports 'block_cache_name: LRUCache' when specified, and row_cache
comes back as None if I try to use it there.