### PR TITLE
objclass-sdk: use namespace ceph for bufferlist

### DIFF
--- a/src/include/rados/objclass.h
+++ b/src/include/rados/objclass.h
@@ -78,7 +78,7 @@ extern int cls_register(const char *name, cls_handle_t *handle);
  *
  */
 typedef int (*cls_method_cxx_call_t)(cls_method_context_t ctx,
-    class buffer::list *inbl, class buffer::list *outbl);
+    class ceph::buffer::list *inbl, class ceph::buffer::list *outbl);
 
 /**
  * Register a method.
@@ -124,7 +124,7 @@ extern int cls_cxx_stat(cls_method_context_t hctx, uint64_t *size, time_t *mtime
  * @param len
  * @param bl
  */
-extern int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, bufferlist *bl);
+extern int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, ceph::bufferlist *bl);
 
 /**
  * Write to the object.
@@ -134,7 +134,7 @@ extern int cls_cxx_read(cls_method_context_t hctx, int ofs, int len, bufferlist 
  * @param len
  * @param bl
  */
-extern int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, bufferlist *bl);
+extern int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, ceph::bufferlist *bl);
 
 /**
  * Get xattr of the object.
@@ -144,7 +144,7 @@ extern int cls_cxx_write(cls_method_context_t hctx, int ofs, int len, bufferlist
  * @param outbl
  */
 extern int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
-                            bufferlist *outbl);
+                            ceph::bufferlist *outbl);
 
 /**
  * Set xattr of the object.
@@ -154,7 +154,7 @@ extern int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
  * @param inbl
  */
 extern int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
-                            bufferlist *inbl);
+                            ceph::bufferlist *inbl);
 
 /**
  * Get value corresponding to a key from the map.
@@ -164,7 +164,7 @@ extern int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
  * @param outbl
  */
 extern int cls_cxx_map_get_val(cls_method_context_t hctx,
-                               const std::string &key, bufferlist *outbl);
+                               const std::string &key, ceph::bufferlist *outbl);
 
 /**
  * Set value corresponding to a key in the map.
@@ -174,7 +174,7 @@ extern int cls_cxx_map_get_val(cls_method_context_t hctx,
  * @param inbl
  */
 extern int cls_cxx_map_set_val(cls_method_context_t hctx,
-                               const std::string &key, bufferlist *inbl);
+                               const std::string &key, ceph::bufferlist *inbl);
 
 #endif
 


### PR DESCRIPTION
Add namespace ceph to bufferlist in rados/objclass.h

Signed-off-by: Neha Ojha <nojha@redhat.com>