### PR TITLE
qa/objectstore/filestore-btrfs: test btrfs on ubuntu only

### DIFF
--- a/qa/objectstore/filestore-btrfs.yaml
+++ b/qa/objectstore/filestore-btrfs.yaml
@@ -1,3 +1,5 @@
+# centos btrfs hits ENOSPC all the time :(
+os_type: ubuntu
 overrides:
   ceph:
     fs: btrfs


### PR DESCRIPTION
Centos btrfs hits ENOSPC all the time :(

See http://tracker.ceph.com/issues/20169
Signed-off-by: Sage Weil <sage@redhat.com>