### PR TITLE
mon/MgrStatMonitor: keep mgrstat version ahead of pgmon

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -100,6 +100,11 @@ void MgrStatMonitor::create_pending()
 void MgrStatMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 {
   ++version;
+  if (version < mon->pgmon()->get_last_committed()) {
+    // fast-forward to pgmon version to ensure clients don't see a
+    // jump back in time for MGetPoolStats and MStatFs.
+    version = mon->pgmon()->get_last_committed() + 1;
+  }
   dout(10) << " " << version << dendl;
   bufferlist bl;
   ::encode(pending_digest, bl, mon->get_quorum_con_features());

--- a/src/mon/PGMonitor.cc
+++ b/src/mon/PGMonitor.cc
@@ -467,6 +467,9 @@ void PGMonitor::encode_pending(MonitorDBStore::TransactionRef t)
     return;
   }
 
+  assert(mon->osdmon()->osdmap.require_osd_release < CEPH_RELEASE_LUMINOUS ||
+	 pending_inc.version == 1  /* rebuild-mondb.yaml case */);
+
   version_t version = pending_inc.version;
   dout(10) << __func__ << " v " << version << dendl;
   assert(get_last_committed() + 1 == version);


### PR DESCRIPTION
Pre-luminous, statfs and getpoolstats come from pgmon, and clients will
see and track the paxos version for that.  After the switchover, those
move to mgrstatmon.  If a clients sends a version ahead of the current
mgrstat version, it will block until the paxos version catches up, which
may be years for an aged cluster.

Fix by keeping mgrstat version ahead of pgmon's every time it updates.
This only really matters right at the transition point (we don't update
before that, and after that pgmon doesn't update).

Fixes: http://tracker.ceph.com/issues/20219
Signed-off-by: Sage Weil <sage@redhat.com>

qa
- [x] upgrade/jewel-x
- [x] rados