### PR TITLE
pybind/mgr/dashboard: monkeypatch os.exit to stop cherrypy from taking down mgr

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -43,6 +43,12 @@ log = logging.getLogger("dashboard")
 # python module for the convenience of the GUI?
 LOG_BUFFER_SIZE = 30
 
+# cherrypy likes to sys.exit on error.  don't let it take us down too!
+def os_exit_noop():
+    pass
+
+os._exit = os_exit_noop
+
 
 def recurse_refs(root, path):
     if isinstance(root, dict):


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20216
Suggested-by: Tim Serong <tserong@suse.com>
Signed-off-by: Sage Weil <sage@redhat.com>

qa
- [ ] upgrade/jewel-x
- [ ] rados