### PR TITLE
osd: the condition of last epoch <= superblock.newest_map epoch has been check twice

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -7527,12 +7527,6 @@ void OSD::handle_osd_map(MOSDMap *m)
     rerequest_full_maps();
   }
 
-  if (last <= superblock.newest_map) {
-    dout(10) << " no new maps here, dropping" << dendl;
-    m->put();
-    return;
-  }
-
   if (superblock.oldest_map) {
     // make sure we at least keep pace with incoming maps
     trim_maps(m->oldest_map, last - first + 1, skip_maps);


### PR DESCRIPTION
we have checked condition of last epoch <= superblock.newest_map epoch before we puts diff osdmap to transaction, so , it's unnecessary to check it again after that. last and superblock.newest_map does not be changed during that time.

Signed-off-by: linbing <linbing@t2cloud.net>