### PR TITLE
rgw: can't download large random file when compression enable

### DIFF
--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -36,7 +36,7 @@ int RGWPutObj_Compress::handle_data(bufferlist& bl, off_t ofs, void **phandle, r
         compression_block newbl;
         int bs = blocks.size();
         newbl.old_ofs = ofs;
-        newbl.new_ofs = bs > 0 ? blocks[bs-1].len + blocks[bs-1].new_ofs : 0;
+        newbl.new_ofs = bs > 0 ? (uint64_t)(blocks[bs-1].len + blocks[bs-1].new_ofs) : 0;
         newbl.len = in_bl.length();
         blocks.push_back(newbl);
       }


### PR DESCRIPTION
overflow in expression.

Given a 5G random file, compression produces larger rados stripe objects for low compression rate.
so new_ofs in block info will be greater than 0xFFFFFFFF(uint32 limit).
then it overflows in an assign expression.

Fixes :http://tracker.ceph.com/issues/20231