### PR TITLE
mds: explicitly output error msg for dump cache asok command

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11844,26 +11844,26 @@ void MDCache::show_cache()
   }
 }
 
-void MDCache::dump_cache(std::string const &file_name)
+int MDCache::dump_cache(std::string const &file_name)
 {
-  dump_cache(file_name.c_str(), NULL);
+  return dump_cache(file_name.c_str(), NULL);
 }
 
-void MDCache::dump_cache(Formatter *f)
+int MDCache::dump_cache(Formatter *f)
 {
-  dump_cache(NULL, f);
+  return dump_cache(NULL, f);
 }
 
-void MDCache::dump_cache(const string& dump_root, int depth, Formatter *f)
+int MDCache::dump_cache(const string& dump_root, int depth, Formatter *f)
 {
-  dump_cache(NULL, f, dump_root, depth);
+  return dump_cache(NULL, f, dump_root, depth);
 }
 
 /**
  * Dump the metadata cache, either to a Formatter, if
  * provided, else to a plain text file.
  */
-void MDCache::dump_cache(const char *fn, Formatter *f,
+int MDCache::dump_cache(const char *fn, Formatter *f,
 			 const string& dump_root, int depth)
 {
   int r = 0;
@@ -11883,7 +11883,7 @@ void MDCache::dump_cache(const char *fn, Formatter *f,
     fd = ::open(fn, O_WRONLY|O_CREAT|O_EXCL, 0600);
     if (fd < 0) {
       derr << "failed to open " << fn << ": " << cpp_strerror(errno) << dendl;
-      return;
+      return errno;
     }
   }
 
@@ -11985,6 +11985,7 @@ void MDCache::dump_cache(const char *fn, Formatter *f,
   } else {
     ::close(fd);
   }
+  return r;
 }
 
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1116,14 +1116,14 @@ public:
   void discard_delayed_expire(CDir *dir);
 
 protected:
-  void dump_cache(const char *fn, Formatter *f,
+  int dump_cache(const char *fn, Formatter *f,
 		  const std::string& dump_root = "",
 		  int depth = -1);
 public:
-  void dump_cache() {dump_cache(NULL, NULL);}
-  void dump_cache(const std::string &filename);
-  void dump_cache(Formatter *f);
-  void dump_cache(const std::string& dump_root, int depth, Formatter *f);
+  int dump_cache() { return dump_cache(NULL, NULL); }
+  int dump_cache(const std::string &filename);
+  int dump_cache(Formatter *f);
+  int dump_cache(const std::string& dump_root, int depth, Formatter *f);
 
   void dump_resolve_status(Formatter *f) const;
   void dump_rejoin_status(Formatter *f) const;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1919,10 +1919,15 @@ bool MDSRankDispatcher::handle_asok_command(
   } else if (command == "dump cache") {
     Mutex::Locker l(mds_lock);
     string path;
+    int r;
     if(!cmd_getval(g_ceph_context, cmdmap, "path", path)) {
-      mdcache->dump_cache(f);
+      r = mdcache->dump_cache(f);
     } else {
-      mdcache->dump_cache(path);
+      r = mdcache->dump_cache(path);
+    }
+
+    if (r != 0) {
+      ss << "Failed to dump cache: " << cpp_strerror(r);
     }
   } else if (command == "dump tree") {
     string root;
@@ -1932,7 +1937,10 @@ bool MDSRankDispatcher::handle_asok_command(
       depth = -1;
     {
       Mutex::Locker l(mds_lock);
-      mdcache->dump_cache(root, depth, f);
+      int r = mdcache->dump_cache(root, depth, f);
+      if (r != 0) {
+        ss << "Failed to dump tree: " << cpp_strerror(r);
+      }
     }
   } else if (command == "force_readonly") {
     Mutex::Locker l(mds_lock);


### PR DESCRIPTION
MDS asok command `dump cache` didn't output error msg in stderr even if something is wrong. It saved error msg in log file only.  Some users try to use this command with the same path `dump cache <file_path>` every time and they didn't know no latest cache was dumped into this file if the path is already existed.

Within this change, `dump cache` to the existed file will output following error msg, or other error msg if something else gets wrong too.

```
sudo ceph --admin-daemon /var/run/ceph/ceph-mds.c167.asok dump cache /tmp/c167.cache
Failed to dump cache: (17) File exists
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>