### PR TITLE
mgr: remove default cert; disable both restful and dashboard by default

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -331,7 +331,6 @@ Requires: 	python-CherryPy
 Requires:       python-Werkzeug
 %endif
 Requires:       python-pecan
-Requires(post):	openssl
 %description mgr
 ceph-mgr enables python modules that provide services (such as the REST
 module derived from Calamari) and expose CLI hooks.  ceph-mgr gathers
@@ -1182,13 +1181,6 @@ fi
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/mgr
 
 %post mgr
-CERT="%{_sysconfdir}/ceph/ceph-mgr-restful.crt"
-PKEY="%{_sysconfdir}/ceph/ceph-mgr-restful.key"
-if [ ! -e "$CERT" -o ! -e "$PKEY" ]; then
-  openssl req -new -nodes -x509 \
-    -subj "/O=IT/CN=ceph-mgr-restful" \
-    -days 3650 -keyout "$PKEY" -out "$CERT" -extensions v3_ca
-fi
 %if 0%{?suse_version}
 if [ $1 -eq 1 ] ; then
   /usr/bin/systemctl preset ceph-mgr@\*.service ceph-mgr.target >/dev/null 2>&1 || :

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -325,10 +325,12 @@ Requires:       ceph-base = %{_epoch_prefix}%{version}-%{release}
 %if 0%{?fedora} || 0%{?rhel}
 Requires:       python-cherrypy
 Requires:       python-werkzeug
+Requires:       pyOpenSSL
 %endif
 %if 0%{?suse_version}
 Requires: 	python-CherryPy
 Requires:       python-Werkzeug
+Requires:       python-pyOpenSSL
 %endif
 Requires:       python-pecan
 %description mgr

--- a/debian/ceph-mgr.postinst
+++ b/debian/ceph-mgr.postinst
@@ -24,13 +24,6 @@ set -e
 
 case "$1" in
     configure)
-	CERT="/etc/ceph/ceph-mgr-restful.crt"
-	PKEY="/etc/ceph/ceph-mgr-restful.key"
-	if [ ! -e "$CERT" -o ! -e "$PKEY" ]; then
-	    openssl req -new -nodes -x509 \
-		-subj "/O=IT/CN=ceph-mgr-restful" \
-		-days 3650 -keyout "$PKEY" -out "$CERT" -extensions v3_ca
-	fi
 	[ -x /sbin/start ] && start ceph-mgr-all || :
 
 	if ! dpkg-statoverride --list /var/lib/ceph/mgr >/dev/null

--- a/debian/control
+++ b/debian/control
@@ -163,7 +163,6 @@ Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
          python-pecan,
          python-werkzeug,
-         openssl,
          ${misc:Depends},
          ${python:Depends},
 	 python-cherrypy3,

--- a/debian/control
+++ b/debian/control
@@ -161,6 +161,7 @@ Description: debugging symbols for ceph-mds
 Package: ceph-mgr
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
+         python-openssl,
          python-pecan,
          python-werkzeug,
          ${misc:Depends},

--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -8,6 +8,7 @@ tasks:
       - ceph config-key put mgr/restful/x/server_addr 127.0.0.1
       - ceph config-key put mgr/restful/x/server_port 9999
       - ceph tell mgr.x restful create-key admin
+      - ceph tell mgr.x restful create-self-signed-cert
 - ceph.restart: [mgr.x]
 - workunit:
     clients:

--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -50,7 +50,6 @@ screenplay = [
     ('get',    '/', {}),
     ('get',    '/config/cluster', {}),
     ('get',    '/crush/rule', {}),
-    ('get',    '/crush/ruleset', {}),
     ('get',    '/doc', {}),
     ('get',    '/mon', {}),
     ('get',    '/mon/' + firstmon, {}),

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -732,8 +732,10 @@ class Module(MgrModule):
 
                 return dict(result)
 
-        server_addr = self.get_localized_config('server_addr') or '127.0.0.1'
+        server_addr = self.get_localized_config('server_addr')
         server_port = self.get_localized_config('server_port') or '7000'
+        if server_addr is None:
+            raise RuntimeError('no server_addr configured; try "ceph config-key put mgr/dashboard/server_addr <ip>"')
         log.info("server_addr: %s server_port: %s" % (server_addr, server_port))
         cherrypy.config.update({
             'server.socket_host': server_addr,

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -285,7 +285,7 @@ class Module(MgrModule):
             cert_tmp.flush()
             cert_fname = cert_tmp.name
         else:
-            cert_fname = self.get_localized_config('crt_file') or '/etc/ceph/ceph-mgr-restful.crt'
+            cert_fname = self.get_localized_config('crt_file')
 
         pkey = self.get_localized_config("key")
         if pkey is not None:
@@ -294,7 +294,7 @@ class Module(MgrModule):
             pkey_tmp.flush()
             pkey_fname = pkey_tmp.name
         else:
-            pkey_fname = self.get_localized_config('key_file') or '/etc/ceph/ceph-mgr-restful.key'
+            pkey_fname = self.get_localized_config('key_file')
 
         if not cert_fname or not pkey_fname:
             raise RuntimeError('no certificate configured')

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -256,7 +256,9 @@ class Module(MgrModule):
             separators=(',', ': '),
         )
 
-        server_addr = self.get_localized_config('server_addr') or '127.0.0.1'
+        server_addr = self.get_localized_config('server_addr')
+        if server_addr is None:
+            raise RuntimeError('no server_addr configured; try "ceph config-key put mgr/restful/server_addr <ip>"')
         server_port = int(self.get_localized_config('server_port') or '8003')
         self.log.info('server_addr: %s server_port: %d',
                       server_addr, server_port)

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -218,6 +218,11 @@ class Module(MgrModule):
             "desc": "Create localized self signed certificate",
             "perm": "rw"
         },
+        {
+            "cmd": "restful restart",
+            "desc": "Restart API server",
+            "perm": "rw"
+        },
     ]
 
     def __init__(self, *args, **kwargs):
@@ -431,6 +436,14 @@ class Module(MgrModule):
             self.set_config(self.get_mgr_id() + '/key', pkey)
 
             self.restart()
+            return (
+                0,
+                "Restarting RESTful API server...",
+                ""
+            )
+
+        elif command['prefix'] == 'restful restart':
+            self.restart();
             return (
                 0,
                 "Restarting RESTful API server...",

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -296,6 +296,13 @@ class Module(MgrModule):
         else:
             pkey_fname = self.get_localized_config('key_file') or '/etc/ceph/ceph-mgr-restful.key'
 
+        if not cert_fname or not pkey_fname:
+            raise RuntimeError('no certificate configured')
+        if not os.path.isfile(cert_fname):
+            raise RuntimeError('certificate %s does not exist' % cert_fname)
+        if not os.path.isfile(pkey_fname):
+            raise RuntimeError('private key %s does not exist' % pkey_fname)
+
         # Create the HTTPS werkzeug server serving pecan app
         self.server = make_server(
             host=server_addr,

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -639,16 +639,8 @@ EOF
 	DASH_URLS+="http://$IP:$MGR_PORT/"
 	MGR_PORT=$(($MGR_PORT + 1000))
 
-	CERT=`mktemp`
-	PKEY=`mktemp`
-	openssl req -new -nodes -x509 \
-		-subj "/O=IT/CN=ceph-mgr-restful" \
-		-days 3650 -keyout "$PKEY" -out "$CERT" -extensions v3_ca
 	ceph_adm config-key put mgr/restful/$name/server_addr $IP
 	ceph_adm config-key put mgr/restful/$name/server_port $MGR_PORT
-	ceph_adm config-key put mgr/restful/$name/crt -i $CERT
-	ceph_adm config-key put mgr/restful/$name/key -i $PKEY
-	rm $CERT $PKEY
 
 	RESTFUL_URLS+="https://$IP:$MGR_PORT"
 	MGR_PORT=$(($MGR_PORT + 1000))
@@ -658,7 +650,8 @@ EOF
     done
 
     SF=`mktemp`
-    ceph_adm tell mgr.x restful create-key admin -o $SF
+    ceph_adm tell mgr restful create-self-signed-cert
+    ceph_adm tell mgr restful create-key admin -o $SF
     RESTFUL_SECRET=`cat $SF`
     rm $SF
 }


### PR DESCRIPTION
- no auto-cert creation by package
- both restful and dashboard lose the default addr, so they will not start if the admin hasn't explicitly set server_addr

I don't think we want to enable either of these by default.  And once the admin has to type in or cut&paste a command to turn on restful, they can also paste another 3 lines to generate and insert a self-signed cert (if they choose).