### PR TITLE
qa/suites/rados/rest: test restful mgr module

### DIFF
--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -1,3 +1,6 @@
+# ubuntu trusty has old requests.  xenial is okay, but we can't blacklist
+# just trusty, so:
+os_type: centos
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, mds.a, client.a]
 tasks:

--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -1,0 +1,15 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, mds.a, client.a]
+tasks:
+- install:
+- ceph:
+- exec:
+    mon.a:
+      - ceph config-key put mgr/restful/x/server_addr 127.0.0.1
+      - ceph config-key put mgr/restful/x/server_port 9999
+      - ceph tell mgr.x restful create-key admin
+- ceph.restart: [mgr.x]
+- workunit:
+    clients:
+      client.a:
+        - rest/test-restful.sh

--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -3,10 +3,15 @@
 import requests
 import time
 import sys
+import json
 
-# Do not show the stupid message about verify=False
-from requests.packages.urllib3.exceptions import InsecureRequestWarning
-requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+# Do not show the stupid message about verify=False.  ignore exceptions bc
+# this doesn't work on some distros.
+try:
+    from requests.packages.urllib3.exceptions import InsecureRequestWarning
+    requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+except:
+    pass
 
 if len(sys.argv) < 3:
     print("Usage: %s <url> <admin_key>" % sys.argv[0])
@@ -18,7 +23,11 @@ auth = ('admin', sys.argv[2])
 request = None
 
 # Create a pool and get its id
-request = requests.post(addr + '/pool?wait=yes', json={'name': 'supertestfriends', 'pg_num': 128}, verify=False, auth=auth)
+request = requests.post(
+    addr + '/pool?wait=yes',
+    data=json.dumps({'name': 'supertestfriends', 'pg_num': 128}),
+    verify=False,
+    auth=auth)
 print(request.text)
 request = requests.get(addr + '/pool', verify=False, auth=auth)
 assert(request.json()[-1]['pool_name'] == 'supertestfriends')
@@ -70,7 +79,11 @@ for method, endpoint, args in screenplay:
         continue
     url = addr + endpoint
     print("URL = " + url)
-    request = getattr(requests, method)(url, json=args, verify=False, auth=auth)
+    request = getattr(requests, method)(
+        url,
+        data=json.dumps(args),
+        verify=False,
+        auth=auth)
     print(request.text)
     if request.status_code != 200 or 'error' in request.json():
         print('ERROR: %s request for URL "%s" failed' % (method, url))


### PR DESCRIPTION
The problem is this fails on trusty because requests doesn't support the json
thing

<pre>
2017-06-09T16:51:56.648 INFO:tasks.workunit.client.a.smithi063.stderr:Traceback (most recent call last):
2017-06-09T16:51:56.649 INFO:tasks.workunit.client.a.smithi063.stderr:  File "/home/ubuntu/cephtest/clone.client.a/qa/workunits/rest/test_mgr_rest_api.py", line 21, in <module>
2017-06-09T16:51:56.651 INFO:tasks.workunit.client.a.smithi063.stderr:    request = requests.post(addr + '/pool?wait=yes', json={'name': 'supertestfriends', 'pg_num': 128}, verify=False, auth=auth)
2017-06-09T16:51:56.651 INFO:tasks.workunit.client.a.smithi063.stderr:  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 88, in post
2017-06-09T16:51:56.658 INFO:tasks.workunit.client.a.smithi063.stderr:    return request('post', url, data=data, **kwargs)
2017-06-09T16:51:56.658 INFO:tasks.workunit.client.a.smithi063.stderr:  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 44, in request
2017-06-09T16:51:56.658 INFO:tasks.workunit.client.a.smithi063.stderr:    return session.request(method=method, url=url, **kwargs)
2017-06-09T16:51:56.658 INFO:tasks.workunit.client.a.smithi063.stderr:TypeError: request() got an unexpected keyword argument 'json'
</pre>

and/or the urllib3 thing doesn't work:

<pre>
2017-06-09T16:36:44.341 INFO:tasks.workunit.client.a.smithi063.stderr:Traceback (most recent call last):
2017-06-09T16:36:44.341 INFO:tasks.workunit.client.a.smithi063.stderr:  File "/home/ubuntu/cephtest/clone.client.a/qa/workunits/rest/test_mgr_rest_api.py", line 8, in <module>
2017-06-09T16:36:44.341 INFO:tasks.workunit.client.a.smithi063.stderr:    from requests.packages.urllib3.exceptions import InsecureRequestWarning
2017-06-09T16:36:44.341 INFO:tasks.workunit.client.a.smithi063.stderr:ImportError: No module named packages.urllib3.exceptions
</pre>