### PR TITLE
rgw: can't download large random file when compression enable

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5158,7 +5158,7 @@ void RGWCompleteMultipart::execute()
           op_ret = -ERR_INVALID_PART;
           return;
         }
-        int new_ofs; // offset in compression data for new part
+        int64_t new_ofs; // offset in compression data for new part
         if (cs_info.blocks.size() > 0)
           new_ofs = cs_info.blocks.back().new_ofs + cs_info.blocks.back().len;
         else


### PR DESCRIPTION
overflow in expression.

for s3 multipart upload

Given a 5G random file, compression produces larger rados stripe objects for low compression rate.
so new_ofs in block info will be greater than 0xFFFFFFFF(uint32 limit).
then it overflows in an assign expression.

Fixes :http://tracker.ceph.com/issues/20231