### PR TITLE
core: Install Pecan for FreeBSD

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -52,12 +52,16 @@ if [ x`uname`x = xFreeBSDx ]; then
         emulators/fuse \
         java/junit \
         lang/python27 \
+	devel/py-pip \
         devel/py-argparse \
         devel/py-nose \
         www/py-flask \
         www/fcgi \
         sysutils/flock \
         sysutils/fusefs-libs \
+
+	# Now use pip to install some extra python modules
+	pip install pecan
 
     exit
 else


### PR DESCRIPTION
- Currently it is not a package, so use pip to install it.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>