### PR TITLE
rgw: only log metadata on metadata master zone

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3557,7 +3557,7 @@ public:
   }
 
   bool need_to_log_metadata() {
-    return get_zone().log_meta;
+    return is_meta_master() && get_zone().log_meta;
   }
 
   librados::Rados* get_rados_handle();


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20244