### PR TITLE
common: initialize _hash in LogEntryKey()

### DIFF
--- a/src/common/LogEntry.h
+++ b/src/common/LogEntry.h
@@ -55,7 +55,7 @@ string clog_type_to_string(clog_type t);
 
 struct LogEntryKey {
 private:
-  uint64_t _hash;
+  uint64_t _hash = 0;
 
   void _calc_hash() {
     hash<entity_inst_t> h;


### PR DESCRIPTION
Fixed:
```
** CID 717210:  Uninitialized members  (UNINIT_CTOR)
ceph/src/common/LogEntry.h: 70 in LogEntryKey::LogEntryKey()()
Non-static class member "_hash" is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>