### PR TITLE
mon: Error Handling in MgrStatMonitor::update_from_paxos()

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -79,7 +79,9 @@ void MgrStatMonitor::update_from_paxos(bool *need_bootstrap)
   version = get_last_committed();
   dout(10) << " " << version << dendl;
   bufferlist bl;
-  get_version(version, bl);
+  int err = get_version(version, bl);
+  assert(err == 0);
+  
   if (version) {
     assert(bl.length());
     auto p = bl.begin();


### PR DESCRIPTION
Fixed:
```
** CID 1412572:  Error handling issues  (CHECKED_RETURN)
ceph/src/mon/MgrStatMonitor.cc: 82 in MgrStatMonitor::update_from_paxos(bool *)()
Calling "get_version" without checking return value (as is done elsewhere 14 out of 15 times).
```
Signed-off-by: Jos Collin <jcollin@redhat.com>