### PR TITLE
rgw: fix RGWPutBucketPolicy error when set BucketPolicy again without delete pre set Policy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6507,6 +6507,7 @@ void RGWPutBucketPolicy::execute()
     Policy p(s->cct, s->bucket_tenant,
 	     bufferlist::static_from_mem(data, len));
     auto attrs = s->bucket_attrs;
+    attrs[RGW_ATTR_IAM_POLICY].clear();
     attrs[RGW_ATTR_IAM_POLICY].append(p.text);
     op_ret = rgw_bucket_set_attrs(store, s->bucket_info, attrs,
 				  &s->bucket_info.objv_tracker);


### PR DESCRIPTION
hi，when i create a bucket and set policy to the bucket,use
```
 s3cmd setpolicy 2-referpolicy  s3://test1
```
 it set policy success. but when i rerun  
```
 s3cmd setpolicy 2-referpolicy  s3://test1
```
and 
then
```
s3cmd ls  s3://test1
```
and it return 403 access deny,

and i found it is rapidjson::KParseErrorDocumentRootNotSigngular error,

and i found the policy turn to be
```
"{\n  \"Version\": \"2012-10-17\",\n  \"Statement\": [{\n    \"Effect\": \"Allow\",\n    \"Principal\": \"*\",\n    \"Action\": \"s3:GetObject\",\n    \"Resource\": [\n      \"arn:aws:s3:::test3/*\"\n    ],\n    \"Condition\": {\n        \"StringLike\": {\n          \"aws:Referer\": \"http://www.baidu.com\"\n        }\n      }\n  }]\n}\n{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":[\"arn:aws:s3:::test3/*\"],\"Condition\":{\"StringLike\":{\"aws:Referer\":\"http://www.baidu.com\"}}}]}\n"
```

yes, it append to the pre set policy, rather to take place of it.
so, we need to clear() before append

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>