### PR TITLE
mds: mds perf item 'l_mdl_expos' always behind journaler

### DIFF
--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -782,9 +782,11 @@ void MDLog::_trim_expired_segments()
     // this was the oldest segment, adjust expire pos
     if (journaler->get_expire_pos() < ls->end) {
       journaler->set_expire_pos(ls->end);
+      logger->set(l_mdl_expos, ls->end);
+    } else {
+      logger->set(l_mdl_expos, ls->offset);
     }
     
-    logger->set(l_mdl_expos, ls->offset);
     logger->inc(l_mdl_segtrm);
     logger->inc(l_mdl_evtrm, ls->num_events);
     


### PR DESCRIPTION
When trimming expired logsegment, the expire_pos of journaler is set to logsegment's end, but perf item 'l_mdl_expos' is set to logsegment's offset. 

Signed-off-by: redickwang <redickwang@tencent.com>