### PR TITLE
mon: DIVIDE_BY_ZERO in PGMapDigest::dump_pool_stats_full()

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -680,8 +680,10 @@ void PGMapDigest::dump_pool_stats_full(
       if (pm != ecp.end() && pk != ecp.end()) {
 	int k = atoi(pk->second.c_str());
 	int m = atoi(pm->second.c_str());
-	avail = avail * k / (m + k);
-	raw_used_rate = (float)(m + k) / k;
+	int mk = m + k;
+	assert(mk != 0);
+	avail = avail * k / mk;
+	raw_used_rate = (float)mk / k;
       } else {
 	raw_used_rate = 0.0;
       }


### PR DESCRIPTION
Fixed:
```
** CID 1412576:  Integer handling issues  (DIVIDE_BY_ZERO)
ceph/src/mon/PGMap.cc: 683 in PGMapDigest::dump_pool_stats_full(const OSDMap &,
std::__cxx11::basic_stringstream<char, std::char_traits<char>, std::allocator<char>> *,
ceph::Formatter *, bool) const()

In expression "avail * k / (m + k)", division by expression "m + k" which may be zero has undefined behavior.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>