### PR TITLE
msg/async: add assert of ms_async_op_threads > 0

### DIFF
--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -101,6 +101,8 @@ Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned
 
 NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(false), cct(c)
 {
+  assert(cct->_conf->ms_async_op_threads > 0);
+
   const uint64_t InitEventNumber = 5000;
   num_workers = cct->_conf->ms_async_op_threads;
   if (num_workers >= EventCenter::MAX_EVENTCENTER) {


### PR DESCRIPTION
we would not allowed ms_async_op_thread to set 0, so we need an assert to make ms_async_op_threads > 0

Signed-off-by: linbing <linbing@t2cloud.net>