### PR TITLE
osd/PG: make non-empty PastIntervals non-fatal

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -799,7 +799,6 @@ void PG::check_past_interval_bounds() const
       derr << info.pgid << " required past_interval bounds are"
 	   << " empty [" << rpib << ") but past_intervals is not: "
 	   << past_intervals << dendl;
-      assert(past_intervals.empty());
     }
   } else {
     if (past_intervals.empty()) {


### PR DESCRIPTION
Yes, we should not have past intervals in this case.  However, we don't
need to crash the OSD; the ERR in clog is sufficient to fail the teuthology
run, and users in production don't actually care.

See: http://tracker.ceph.com/issues/20167
Signed-off-by: Sage Weil <sage@redhat.com>