### PR TITLE
mon: mark `osd create` as deprecated

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -478,6 +478,11 @@ Usage::
 
 Subcommand ``create`` creates new osd (with optional UUID and ID).
 
+This command is DEPRECATED as of the Luminous release, and will be removed in
+a future release.
+
+Subcommand ``new`` should instead be used.
+
 Usage::
 
 	ceph osd create {<uuid>} {<id>}

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -734,10 +734,11 @@ COMMAND("osd lost " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
 	"mark osd as permanently lost. THIS DESTROYS DATA IF NO MORE REPLICAS EXIST, BE CAREFUL", \
 	"osd", "rw", "cli,rest")
-COMMAND("osd create " \
+COMMAND_WITH_FLAG("osd create " \
 	"name=uuid,type=CephUUID,req=false " \
 	"name=id,type=CephOsdName,req=false", \
-	"create new osd (with optional UUID and ID)", "osd", "rw", "cli,rest")
+	"create new osd (with optional UUID and ID)", "osd", "rw", "cli,rest",
+	FLAG(DEPRECATED))
 COMMAND("osd new " \
         "name=uuid,type=CephUUID,req=true " \
         "name=id,type=CephOsdName,req=false", \


### PR DESCRIPTION
With the introduction of `osd new`, we are now deprecating `osd create`
with the intent of removing it in a future release.

Signed-off-by: Joao Eduardo Luis <joao@suse.de>