### PR TITLE
pybind/mgr/restful: use list to pass hooks to create a `Pecan` instance

### DIFF
--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -1,6 +1,3 @@
-# ubuntu trusty has old requests.  xenial is okay, but we can't blacklist
-# just trusty, so:
-os_type: centos
 roles:
 - [mon.a, mgr.x, osd.0, osd.1, osd.2, mds.a, client.a]
 tasks:

--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -19,6 +19,7 @@ if len(sys.argv) < 3:
 
 addr = sys.argv[1]
 auth = ('admin', sys.argv[2])
+headers = {'Content-type': 'application/json'}
 
 request = None
 
@@ -26,6 +27,7 @@ request = None
 request = requests.post(
     addr + '/pool?wait=yes',
     data=json.dumps({'name': 'supertestfriends', 'pg_num': 128}),
+    headers=headers,
     verify=False,
     auth=auth)
 print(request.text)
@@ -82,6 +84,7 @@ for method, endpoint, args in screenplay:
     request = getattr(requests, method)(
         url,
         data=json.dumps(args),
+        headers=headers,
         verify=False,
         auth=auth)
     print(request.text)

--- a/src/pybind/mgr/restful/api/pool.py
+++ b/src/pybind/mgr/restful/api/pool.py
@@ -34,7 +34,11 @@ class PoolId(RestController):
         """
         Modify the information for the pool id
         """
-        args = request.json
+	try:
+            args = request.json
+        except ValueError:
+            response.status = 400
+            return {'message': 'Bad request: malformed JSON or wrong Content-Type'}
 
         # Get the pool info for its name
         pool = module.instance.get_pool_by_id(self.pool_id)

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -285,7 +285,7 @@ class Module(MgrModule):
             port=server_port,
             app=make_app(
                 root='restful.api.Root',
-                hooks = lambda: [ErrorHook()],
+                hooks = [ErrorHook()],  # use a callable if pecan >= 0.3.2
             ),
             ssl_context=(cert_fname, pkey_fname),
         )


### PR DESCRIPTION
pecan 0.3.2 introduced the new way to pass the hooks to construct a
Pecan instance, but the "callable" builder for hooks is not compatible
with pecan < 0.3.2. and ubuntu trusty ships pecan 0.3.0, so we need to
do this the old way: pass a list of hooks instead of a callable.

see https://github.com/pecan/pecan/blame/0.3.2/pecan/core.py and
https://github.com/pecan/pecan/commit/fb2cf166aaf5b5af461879ec5b7a46806e8aee45

Fixes: http://tracker.ceph.com/issues/20258
Signed-off-by: Kefu Chai <kchai@redhat.com>