### PR TITLE
mon: Incorrect expression in PGMap::get_health()

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2764,7 +2764,7 @@ void PGMap::get_health(
 	}
 	if (num_warn) {
 	  ostringstream ss2;
-	  ss2 << num_err << " osds have slow requests";
+	  ss2 << num_warn << " osds have slow requests";
 	  summary.push_back(make_pair(HEALTH_WARN, ss2.str()));
 	  detail->push_back(make_pair(HEALTH_WARN, ss2.str()));
 	}


### PR DESCRIPTION
Fixes:
```
CID 1412575:  Incorrect expression  (COPY_PASTE_ERROR)
ceph/src/mon/PGMap.cc: 2764 in PGMap::get_health()
"num_err" in "ss2 << num_err" looks like a copy-paste error.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>