### PR TITLE
osd/PrimaryLogPG: record prior_version for DELETE events

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1726,7 +1726,8 @@ void PG::activate(ObjectStore::Transaction& t,
         for (list<pg_log_entry_t>::iterator p = m->log.log.begin();
              p != m->log.log.end();
              ++p)
-	  if (p->soid <= pi.last_backfill)
+	  if (p->soid <= pi.last_backfill &&
+	      !p->is_error())
 	    pm.add_next_event(*p);
       }
       

--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -584,10 +584,6 @@ public:
     missing.add(oid, need, have);
   }
 
-  void missing_add_event(const pg_log_entry_t &e) {
-    missing.add_next_event(e);
-  }
-
   //////////////////// get or set log ////////////////////
 
   const IndexedLog &get_log() const { return log; }


### PR DESCRIPTION
Leaving this blank is inaccurate.  It also confuses the rewind
divergent log code, leading to behavior like

      ldpp_dout(dpp, 10) << __func__ << ": hoid " << hoid
			 << " prior_version or op type indicates creation,"
			 << " deleting"
			 << dendl;

Fixes: http://tracker.ceph.com/issues/20274
Signed-off-by: Sage Weil <sage@redhat.com>