### PR TITLE
librbd/exclusive_lock: CTOR_DTOR_LEAK in PreReleaseRequest<I>::PreReleaseRequest()

### DIFF
--- a/src/librbd/exclusive_lock/PreReleaseRequest.cc
+++ b/src/librbd/exclusive_lock/PreReleaseRequest.cc
@@ -46,6 +46,7 @@ PreReleaseRequest<I>::~PreReleaseRequest() {
   if (!m_shutting_down) {
     m_image_ctx.state->handle_prepare_lock_complete();
   }
+  delete m_on_finish;
 }
 
 template <typename I>


### PR DESCRIPTION
Fixes:
```
CID 1412574:    (CTOR_DTOR_LEAK)
ceph/src/librbd/exclusive_lock/PreReleaseRequest.cc:
41 in librbd::exclusive_lock::PreReleaseRequest<librbd::MockImageCtx>::PreReleaseRequest(librbd::MockImageCtx&, bool, AsyncOpTracker &, Context *)()
The constructor allocates field "m_on_finish" of
"librbd::exclusive_lock::PreReleaseRequest<librbd::MockImageCtx>" but the destructor and whatever functions it calls do not free it.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>