### PR TITLE
common: ms_inject_delay_type missing auth type in config_opts annotation

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -217,7 +217,7 @@ OPTION(ms_tcp_read_timeout, OPT_U64, 900)
 OPTION(ms_pq_max_tokens_per_priority, OPT_U64, 16777216)
 OPTION(ms_pq_min_cost, OPT_U64, 65536)
 OPTION(ms_inject_socket_failures, OPT_U64, 0)
-SAFE_OPTION(ms_inject_delay_type, OPT_STR, "")          // "osd mds mon client" allowed
+SAFE_OPTION(ms_inject_delay_type, OPT_STR, "")          // "osd mds mon mgr client auth" allowed
 OPTION(ms_inject_delay_msg_type, OPT_STR, "")      // the type of message to delay, as returned by Message::get_type_name(). This is an additional restriction on the general type filter ms_inject_delay_type.
 OPTION(ms_inject_delay_max, OPT_DOUBLE, 1)         // seconds
 OPTION(ms_inject_delay_probability, OPT_DOUBLE, 0) // range [0, 1]


### PR DESCRIPTION
this may cause mistake that ms_inject_delay_type not support auth. however, it's supported in ceph_entity_type_name.

Signed-off-by: linbing <linbing@t2cloud.net>