### PR TITLE
bluestore: wrap blob id when it reaches maximum value of int16_t

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -776,6 +776,7 @@ public:
     }
 
     void update(KeyValueDB::Transaction t, bool force);
+    decltype(BlueStore::Blob::id) allocate_spanning_blob_id();
     void reshard(
       KeyValueDB *db,
       KeyValueDB::Transaction t);


### PR DESCRIPTION
Blob id exceeds maximum value, this patch is to prevent it.
Fixes: http://tracker.ceph.com/issues/19555

Signed-off-by: Xiaoyan Li <xiaoyan.li@intel.com>