### PR TITLE
client: call the lru_remove() twice,when trim cache

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -602,7 +602,7 @@ void Client::trim_cache(bool trim_kernel_dcache)
     if (lru.lru_get_size() <= lru.lru_get_max())  break;
 
     // trim!
-    Dentry *dn = static_cast<Dentry*>(lru.lru_expire());
+    Dentry *dn = static_cast<Dentry*>(lru.lru_get_next_expire());
     if (!dn)
       break;  // done
     


### PR DESCRIPTION
call the lru_remove() twice,when trim cache, 
first:  trim_cache()---> lru_expire() ---> lru_remove();
second: trim_cache()---> trim_dentry() ---> unlink() ---> lru_remove().
fix as: 
In access to LRU's Dentry information, the first does not remove the operation, 
unified in the trim_dentry() to deal with more reasonable.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>