### PR TITLE
rgw: fix error handling in get_params() of RGWPostObj_ObjStore_S3.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1578,7 +1578,7 @@ int RGWPostObj_ObjStore_S3::get_params()
     bool boundary;
     uint64_t chunk_size = s->cct->_conf->rgw_max_chunk_size;
     r = read_data(part.data, chunk_size, boundary, done);
-    if (!boundary) {
+    if (r < 0 || !boundary) {
       err_msg = "Couldn't find boundary";
       return -EINVAL;
     }
@@ -1768,7 +1768,7 @@ int RGWPostObj_ObjStore_S3::complete_get_params()
     bool boundary;
     uint64_t chunk_size = s->cct->_conf->rgw_max_chunk_size;
     r = read_data(part.data, chunk_size, boundary, done);
-    if (!boundary) {
+    if (r < 0 || !boundary) {
       return -EINVAL;
     }
 


### PR DESCRIPTION
The recent Static Analysis for Ceph (linked 13 June 2017 on ceph-devel) shows that the `get_params()` method of `RGWPostObj_ObjStore` assigns to a variable but doesn't use it later. The anomaly is caused by lack of proper error handling. This commit rectifies it.

Signed-off-by: Radoslaw Zarzynski <rzarzynski@mirantis.com>