### PR TITLE
rgw: add option to bypass gc during delete operation

### DIFF
--- a/doc/radosgw/config-ref.rst
+++ b/doc/radosgw/config-ref.rst
@@ -214,6 +214,20 @@ instances or all radosgw-admin commands can be put into the ``[global]`` or the
 :Default: ``3600``
 
 
+``rgw remove object always bypass gc``
+
+:Description: Delete objects bypass gc (like radosgw-admin --bypass-gc option).
+:Type: Boolean
+:Default: ``false``
+
+
+``rgw remove object max concurrent ios``
+
+:Description: Maximum number of concurrent io operations per single rgw object remove request.
+:Type: Integer
+:Default: ``32``
+
+
 ``rgw s3 success create obj status``
 
 :Description: The alternate success status response for ``create-obj``.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1641,6 +1641,9 @@ OPTION(rgw_copy_obj_progress, OPT_BOOL, true) // should dump progress during lon
 OPTION(rgw_copy_obj_progress_every_bytes, OPT_INT, 1024 * 1024) // min bytes between copy progress output
 OPTION(rgw_obj_tombstone_cache_size, OPT_INT, 1000) // how many objects in tombstone cache, which is used in multi-zone sync to keep
                                                     // track of removed objects' mtime
+OPTION(rgw_remove_object_always_bypass_gc, OPT_BOOL, false) // always bypass gc
+OPTION(rgw_remove_object_max_concurrent_ios, OPT_INT, 32) // Maximum number of concurrent io operations
+                                                          // per single rgw object remove request
 
 OPTION(rgw_data_log_window, OPT_INT, 30) // data log entries window (in seconds)
 OPTION(rgw_data_log_changes_size, OPT_INT, 1000) // number of in-memory entries to hold for data changes log

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -179,6 +179,11 @@ extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
 extern int rgw_remove_object(RGWRados *store, RGWBucketInfo& bucket_info, rgw_bucket& bucket, rgw_obj_key& key);
 extern int rgw_remove_bucket(RGWRados *store, rgw_bucket& bucket, bool delete_children);
 extern int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket, int concurrent_max);
+extern int rgw_remove_object_bypass_gc(RGWRados *store,
+                                       rgw_bucket& bucket, RGWBucketInfo& info,
+                                       RGWObjectCtx& obj_ctx, cls_rgw_obj_key& key,
+                                       int concurrent_max, bool keep_index_consistent,
+                                       std::list<librados::AioCompletion*> &handles);
 
 extern int rgw_bucket_set_attrs(RGWRados *store, RGWBucketInfo& bucket_info,
                                 map<string, bufferlist>& attrs,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4669,6 +4669,12 @@ int RGWRados::list_periods(list<string>& periods)
   return 0;
 }
 
+void RGWRados::update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket,
+                            int obj_delta, uint64_t added_bytes, uint64_t removed_bytes)
+{
+  dout(20) << __func__ << ": obj_delta=" << obj_delta << ", added_bytes=" << added_bytes << ", removed_bytes=" << removed_bytes << dendl;
+  quota_handler->update_stats(bucket_owner, bucket, obj_delta, added_bytes, removed_bytes);
+}
 
 int RGWRados::list_periods(const string& current_period, list<string>& periods)
 {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8625,6 +8625,27 @@ void RGWRados::cls_obj_check_mtime(ObjectOperation& op, const real_time& mtime, 
   cls_rgw_obj_check_mtime(op, mtime, high_precision_time, type);
 }
 
+int RGWRados::Object::Delete::delete_obj_bypass_gc()
+{
+  /* Try to delete object same way like radosgw-admin with --bypass-gc option does. */
+  int max_concurrent_ios = target->store->ctx()->_conf->rgw_remove_object_max_concurrent_ios;
+  std::list<librados::AioCompletion*> handles;
+  cls_rgw_obj_key cls_key(target->obj.key.get_index_key_name(), target->obj.key.instance);
+
+  return rgw_remove_object_bypass_gc(target->store, target->obj.bucket, target->bucket_info,
+                                     target->ctx, cls_key,
+                                     max_concurrent_ios, true,
+                                     handles);
+}
+
+int RGWRados::Object::Delete::delete_obj()
+{
+  if(target->store->ctx()->_conf->rgw_remove_object_always_bypass_gc) {
+    return delete_obj_bypass_gc();
+  } else {
+    return delete_obj_with_gc();
+  }
+}
 
 /**
  * Delete an object.
@@ -8632,7 +8653,7 @@ void RGWRados::cls_obj_check_mtime(ObjectOperation& op, const real_time& mtime, 
  * obj: name of the object to delete
  * Returns: 0 on success, -ERR# otherwise.
  */
-int RGWRados::Object::Delete::delete_obj()
+int RGWRados::Object::Delete::delete_obj_with_gc()
 {
   RGWRados *store = target->get_store();
   rgw_obj& src_obj = target->get_obj();

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2842,6 +2842,8 @@ public:
       
       explicit Delete(RGWRados::Object *_target) : target(_target) {}
 
+      int delete_obj_with_gc();
+      int delete_obj_bypass_gc();
       int delete_obj();
     };
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2525,6 +2525,9 @@ public:
   int list_periods(const string& current_period, list<string>& periods);
   void tick();
 
+  void update_stats(const rgw_user& bucket_owner, rgw_bucket& bucket, int obj_delta,
+                    uint64_t added_bytes, uint64_t removed_bytes);
+
   CephContext *ctx() { return cct; }
   /** do all necessary setup of the storage device */
   int initialize(CephContext *_cct, bool _use_gc_thread, bool _use_lc_thread, bool _quota_threads, bool _run_sync_thread, bool _run_reshard_thread) {


### PR DESCRIPTION
In our case we need to avoid asynchronous features as much as possible,
especially rgw gc which seems to be too slow.

Added config options:
 - rgw_remove_object_always_bypass_gc
     Enables bypassing gc in rgw delete operation,
     like radosgw-admin --bypass-gc option does.
     Default - false.
 - rgw_remove_object_max_concurrent_ios
     Defines maximum number of concurrent ios per delete operation.
     Default - 32.