### PR TITLE
mon: delete unused config opts of mon_sync_fs_threshold

### DIFF
--- a/doc/rados/configuration/mon-config-ref.rst
+++ b/doc/rados/configuration/mon-config-ref.rst
@@ -1025,12 +1025,6 @@ Miscellaneous
 :Type: 32-bit Integer
 :Default: ``100``
 
-``mon sync fs threshold`` 
-
-:Description: Synchronize with the filesystem when writing the specified number of objects. Set it to ``0`` to disable it.
-:Type: 32-bit Integer
-:Default: ``5`` 
-
 ``mon subscribe interval`` 
 
 :Description: The refresh interval (in seconds) for subscriptions. The 

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -264,7 +264,6 @@ OPTION(inject_early_sigterm, OPT_BOOL, false)
 
 OPTION(mon_data, OPT_STR, "/var/lib/ceph/mon/$cluster-$id")
 OPTION(mon_initial_members, OPT_STR, "")    // list of initial cluster mon ids; if specified, need majority to form initial quorum and create new cluster
-OPTION(mon_sync_fs_threshold, OPT_INT, 5)   // sync() when writing this many objects; 0 to disable.
 OPTION(mon_compact_on_start, OPT_BOOL, false)  // compact leveldb on ceph-mon start
 OPTION(mon_compact_on_bootstrap, OPT_BOOL, false)  // trigger leveldb compaction on bootstrap
 OPTION(mon_compact_on_trim, OPT_BOOL, true)       // compact (a prefix) when we trim old states


### PR DESCRIPTION
When arrange my config, I found mon_sync_fs_threshold is not used since hammer, so i suggest to delete it in config_opts

Signed-off-by: linbing <linbing@t2cloud.net>