### PR TITLE
Kraken: rgw: mulisite: using BucketInfo.bucket in rgw_bucket_sync_use…

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2489,7 +2489,7 @@ void RGWDeleteBucket::execute()
     }
   }
 
-  op_ret = rgw_bucket_sync_user_stats(store, s->user->user_id, s->bucket);
+  op_ret = rgw_bucket_sync_user_stats(store, s->user->user_id.tenant, s->bucket.name);
   if ( op_ret < 0) {
      ldout(s->cct, 1) << "WARNING: failed to sync user stats before bucket delete: op_ret= " << op_ret << dendl;
   }

--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -575,7 +575,7 @@ int RGWUserStatsCache::fetch_stats_from_storage(const rgw_user& user, rgw_bucket
 
 int RGWUserStatsCache::sync_bucket(const rgw_user& user, rgw_bucket& bucket)
 {
-  int r = rgw_bucket_sync_user_stats(store, user, bucket);
+  int r = rgw_bucket_sync_user_stats(store, user.tenant, bucket.name);
   if (r < 0) {
     ldout(store->ctx(), 0) << "ERROR: rgw_bucket_sync_user_stats() for user=" << user << ", bucket=" << bucket << " returned " << r << dendl;
     return r;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -65,7 +65,7 @@ int rgw_user_sync_all_stats(RGWRados *store, const rgw_user& user_id)
       marker = i->first;
 
       RGWBucketEnt& bucket_ent = i->second;
-      ret = rgw_bucket_sync_user_stats(store, user_id, bucket_ent.bucket);
+      ret = rgw_bucket_sync_user_stats(store, user_id.tenant, bucket_ent.bucket.name);
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: could not sync bucket stats: ret=" << ret << dendl;
         return ret;


### PR DESCRIPTION
…r_stats

Buckets and users will sync to peer zonegroup. Creating bucket in secondary zonegroup will forward to master zone. The cls_user_bucket_entry's index pool is always be master zone's index pool. rgw_bucket_sync_user_stats should use BucketInfo.bucket instead of cls_user_bucket_entry's bucket.

Fixes: http://tracker.ceph.com/issues/20280

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>