### PR TITLE
core/common: Fix ENODATA for FreeBSD with compat.h

### DIFF
--- a/src/os/FuseStore.cc
+++ b/src/os/FuseStore.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "FuseStore.h"
 #include "os/ObjectStore.h"
 #include "include/stringify.h"

--- a/src/os/filestore/chain_xattr.h
+++ b/src/os/filestore/chain_xattr.h
@@ -4,6 +4,7 @@
 #ifndef __CEPH_OSD_CHAIN_XATTR_H
 #define __CEPH_OSD_CHAIN_XATTR_H
 
+#include "include/compat.h"
 #include <errno.h>
 #include <stdio.h>
 #include "common/xattr.h"

--- a/src/rgw/librgw.cc
+++ b/src/rgw/librgw.cc
@@ -11,6 +11,7 @@
  * Foundation.  See file COPYING.
  *
  */
+#include "include/compat.h"
 #include <sys/types.h>
 #include <string.h>
 #include <chrono>

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include <errno.h>
 #include <stdlib.h>
 #include <sys/types.h>

--- a/src/test/libradosstriper/striping.cc
+++ b/src/test/libradosstriper/striping.cc
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 // vim: ts=8 sw=2 smarttab
 
+#include "include/compat.h"
 #include "include/types.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"

--- a/src/tools/cephfs/DataScan.cc
+++ b/src/tools/cephfs/DataScan.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "common/errno.h"
 #include "common/ceph_argparse.h"
 #include <fstream>


### PR DESCRIPTION
- When ENODATA used, compat.h needs to be include before any
   of the includes that could possibly define ENODATA by itself.
   Possible problems stem from including Boost files
   Since otherwise xattr-tests will fail to detect that attributes
   are (not) there.

Tracker: http://tracker.ceph.com/issues/19883
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>