### PR TITLE
rgw: don't use strlen in constexprs to not brake Clang builds.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -919,8 +919,8 @@ AWSv4ComplMulti::ChunkMeta::create_next(CephContext* const cct,
 std::string
 AWSv4ComplMulti::calc_chunk_signature(const std::string& payload_hash) const
 {
-  constexpr size_t algorithm_len = std::strlen(AWS4_HMAC_SHA256_STR);
-  constexpr size_t empty_hash_len = std::strlen(AWS4_EMPTY_PAYLOAD_HASH);
+  const size_t algorithm_len = std::strlen(AWS4_HMAC_SHA256_STR);
+  const size_t empty_hash_len = std::strlen(AWS4_EMPTY_PAYLOAD_HASH);
 
   /* We want to avoid reallocations when concatenating the string_to_sign. */
   const size_t total_len = algorithm_len + date.length() + \

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -169,11 +169,11 @@ class AWSv4ComplMulti : public rgw::auth::Completer,
 
     /* Let's suppose the data length fields can't exceed uint64_t. */
     static constexpr size_t META_MAX_SIZE = \
-      strlen("\r\nffffffffffffffff;chunk-signature=") + SIG_SIZE + strlen("\r\n");
+      sarrlen("\r\nffffffffffffffff;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
 
     /* The metadata size of for the last, empty chunk. */
     static constexpr size_t META_MIN_SIZE = \
-      strlen("0;chunk-signature=") + SIG_SIZE + strlen("\r\n");
+      sarrlen("0;chunk-signature=") + SIG_SIZE + sarrlen("\r\n");
 
     /* Detect whether a given stream_pos fits in boundaries of a chunk. */
     bool is_new_chunk_in_stream(size_t stream_pos) const;

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -125,4 +125,13 @@ static inline StringT create_n_reserve(const size_t reserve_len)
   return ret;
 }
 
+/* std::strlen() isn't guaranteed to be computable at compile-time. Although
+ * newer GCCs actually do that, Clang doesn't. Please be aware this function
+ * IS NOT A DROP-IN REPLACEMENT FOR STRLEN -- it returns a different result
+ * for strings having \0 in the middle. */
+template<size_t N>
+static inline constexpr size_t sarrlen(const char (&arr)[N]) {
+  return N - 1;
+}
+
 #endif


### PR DESCRIPTION
@wjwithagen: could you please take a look?