### PR TITLE
os/filestore/HashIndex: randomize split threshold by a configurable amount

### DIFF
--- a/doc/rados/configuration/filestore-config-ref.rst
+++ b/doc/rados/configuration/filestore-config-ref.rst
@@ -302,13 +302,26 @@ Misc
 
 ``filestore split multiple``
 
-:Description:  ``filestore_split_multiple * abs(filestore_merge_threshold) * 16`` 
+:Description:  ``(filestore_split_multiple * abs(filestore_merge_threshold) + (rand() % filestore_split_rand_factor)) * 16``
                is the maximum number of files in a subdirectory before 
                splitting into child directories.
 
 :Type: Integer
 :Required: No
 :Default: ``2``
+
+
+``filestore split rand factor``
+
+:Description:  A random factor added to the split threshold to avoid
+               too many filestore splits occurring at once. See
+               ``filestore split multiple`` for details.
+               This can only be changed for an existing osd offline,
+               via ceph-objectstore-tool's apply-layout-settings command.
+
+:Type: Unsigned 32-bit Integer
+:Required: No
+:Default: ``20``
 
 
 ``filestore update to``

--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -598,6 +598,8 @@ flushjournal_out:
     return -1;
 #endif
 
+  srand(time(NULL) + getpid());
+
   osd = new OSD(g_ceph_context,
                 store,
                 whoami,

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1308,6 +1308,7 @@ OPTION(filestore_commit_timeout, OPT_FLOAT, 600)
 OPTION(filestore_fiemap_threshold, OPT_INT, 4096)
 OPTION(filestore_merge_threshold, OPT_INT, 10)
 OPTION(filestore_split_multiple, OPT_INT, 2)
+OPTION(filestore_split_rand_factor, OPT_U32, 20) // randomize the split threshold by adding 16 * [0, rand_factor)
 OPTION(filestore_update_to, OPT_INT, 1000)
 OPTION(filestore_blackhole, OPT_BOOL, false)     // drop any new transactions on the floor
 OPTION(filestore_fd_cache_size, OPT_INT, 128)    // FD lru size

--- a/src/os/filestore/CollectionIndex.h
+++ b/src/os/filestore/CollectionIndex.h
@@ -193,6 +193,9 @@ protected:
 
   virtual int apply_layout_settings() { ceph_abort(); return 0; }
 
+  /// Read index-wide settings (should be called after construction)
+  virtual int read_settings() { return 0; }
+
   /// Virtual destructor
   virtual ~CollectionIndex() {}
 };

--- a/src/os/filestore/HashIndex.h
+++ b/src/os/filestore/HashIndex.h
@@ -43,14 +43,17 @@ extern string reverse_hexdigit_bits_string(string l);
  * ex: ghobject_t("object", CEPH_NO_SNAP, 0xA4CEE0D2)
  * would be located in (root)/2/D/0/
  *
- * Subdirectories are created when the number of objects in a directory
- * exceed (abs(merge_threshhold)) * 16 * split_multiplier.  The number of objects in a directory
- * is encoded as subdir_info_s in an xattr on the directory.
+ * Subdirectories are created when the number of objects in a
+ * directory exceed 16 * (abs(merge_threshhold)) * split_multiplier +
+ * split_rand_factor). The number of objects in a directory is encoded
+ * as subdir_info_s in an xattr on the directory.
  */
 class HashIndex : public LFNIndex {
 private:
   /// Attribute name for storing subdir info @see subdir_info_s
   static const string SUBDIR_ATTR;
+  /// Attribute name for storing index-wide settings
+  static const string SETTINGS_ATTR;
   /// Attribute name for storing in progress op tag
   static const string IN_PROGRESS_OP_TAG;
   /// Size (bits) in object hash
@@ -61,8 +64,12 @@ private:
   /**
    * Merges occur when the number of object drops below
    * merge_threshold and splits occur when the number of objects
-   * exceeds 16 * abs(merge_threshold) * split_multiplier.
-   * Please note if merge_threshold is less than zero, it will never do merging
+   * exceeds:
+   *
+   *   16 * (abs(merge_threshold) * split_multiplier + split_rand_factor)
+   *
+   * Please note if merge_threshold is less than zero, it will never
+   * do merging
    */
   int merge_threshold;
   int split_multiplier;
@@ -94,6 +101,23 @@ private:
       ::decode(hash_level, bl);
     }
   };
+
+  struct settings_s {
+    uint32_t split_rand_factor; ///< random factor added to split threshold (only on root of collection)
+    settings_s() : split_rand_factor(0) {}
+    void encode(bufferlist &bl) const
+    {
+      __u8 v = 1;
+      ::encode(v, bl);
+      ::encode(split_rand_factor, bl);
+    }
+    void decode(bufferlist::iterator &bl)
+    {
+      __u8 v;
+      ::decode(v, bl);
+      ::decode(split_rand_factor, bl);
+    }
+  } settings;
 
   /// Encodes in progress split or merge
   struct InProgressOp {
@@ -143,7 +167,10 @@ public:
     double retry_probability=0) ///< [in] retry probability
     : LFNIndex(cct, collection, base_path, index_version, retry_probability),
       merge_threshold(merge_at),
-      split_multiplier(split_multiple) {}
+      split_multiplier(split_multiple)
+  {}
+
+  int read_settings() override;
 
   /// @see CollectionIndex
   uint32_t collection_version() override { return index_version; }
@@ -410,6 +437,8 @@ private:
 
   /// split each dir below the given path
   int split_dirs(const vector<string> &path);
+
+  int write_settings();
 };
 
 #endif

--- a/src/os/filestore/IndexManager.cc
+++ b/src/os/filestore/IndexManager.cc
@@ -82,7 +82,10 @@ int IndexManager::init_index(coll_t c, const char *path, uint32_t version) {
 		  cct->_conf->filestore_split_multiple,
 		  version,
 		  cct->_conf->filestore_index_retry_probability);
-  return index.init();
+  r = index.init();
+  if (r < 0)
+    return r;
+  return index.read_settings();
 }
 
 int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **index) {
@@ -102,8 +105,9 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
       // Must be a HashIndex
       *index = new HashIndex(cct, c, path,
 			     cct->_conf->filestore_merge_threshold,
-			     cct->_conf->filestore_split_multiple, version);
-      return 0;
+			     cct->_conf->filestore_split_multiple,
+			     version);
+      return (*index)->read_settings();
     }
     default: ceph_abort();
     }
@@ -114,7 +118,7 @@ int IndexManager::build_index(coll_t c, const char *path, CollectionIndex **inde
 			   cct->_conf->filestore_split_multiple,
 			   CollectionIndex::HOBJECT_WITH_POOL,
 			   cct->_conf->filestore_index_retry_probability);
-    return 0;
+    return (*index)->read_settings();
   }
 }
 


### PR DESCRIPTION
Store a random value up to the filestore_split_rand_factor for each
collection when it is created or apply-layout-settings is run. This
should help distribute the load of splitting directories across a
longer period of time.

Fixes: http://tracker.ceph.com/issues/15835
Signed-off-by: Josh Durgin <jdurgin@redhat.com>