### PR TITLE
rbd-mirror A/A: introduce basic image mapping policy

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -3132,6 +3132,7 @@ static const std::string IMAGE_KEY_PREFIX("image_");
 static const std::string GLOBAL_KEY_PREFIX("global_");
 static const std::string STATUS_GLOBAL_KEY_PREFIX("status_global_");
 static const std::string INSTANCE_KEY_PREFIX("instance_");
+static const std::string MIRROR_IMAGE_MAP_KEY_PREFIX("image_map_");
 
 std::string peer_key(const std::string &uuid) {
   return PEER_KEY_PREFIX + uuid;
@@ -3151,6 +3152,10 @@ std::string status_global_key(const string &global_id) {
 
 std::string instance_key(const string &instance_id) {
   return INSTANCE_KEY_PREFIX + instance_id;
+}
+
+std::string mirror_image_map_key(const string& global_image_id) {
+  return MIRROR_IMAGE_MAP_KEY_PREFIX + global_image_id;
 }
 
 int uuid_get(cls_method_context_t hctx, std::string *mirror_uuid) {
@@ -3686,6 +3691,53 @@ int instances_remove(cls_method_context_t hctx, const string &instance_id) {
             cpp_strerror(r).c_str());
     return r;
   }
+  return 0;
+}
+
+int mirror_image_map_list(cls_method_context_t hctx,
+                          const std::string &start_after,
+                          uint64_t max_return,
+                          std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping) {
+  bool more = true;
+  std::string last_read = mirror_image_map_key(start_after);
+
+  while (more && image_mapping->size() < max_return) {
+    std::map<std::string, bufferlist> vals;
+    CLS_LOG(20, "last read: '%s'", last_read.c_str());
+
+    int max_read = MIN(RBD_MAX_KEYS_READ, max_return - image_mapping->size());
+    int r = cls_cxx_map_get_vals(hctx, last_read, MIRROR_IMAGE_MAP_KEY_PREFIX,
+                                 max_read, &vals, &more);
+    if (r < 0) {
+      CLS_ERR("error reading image map: %s", cpp_strerror(r).c_str());
+      return r;
+    }
+
+    if (vals.empty()) {
+      return 0;
+    }
+
+    for (auto it = vals.begin(); it != vals.end(); ++it) {
+      const std::string &global_image_id =
+        it->first.substr(MIRROR_IMAGE_MAP_KEY_PREFIX.size());
+
+      cls::rbd::MirrorImageMap mirror_image_map;
+      bufferlist::iterator iter = it->second.begin();
+      try {
+        ::decode(mirror_image_map, iter);
+      } catch (const buffer::error &err) {
+        CLS_ERR("could not decode image map payload: %s", cpp_strerror(r).c_str());
+        return -EINVAL;
+      }
+
+      image_mapping->insert(std::make_pair(global_image_id, mirror_image_map));
+    }
+
+    if (!vals.empty()) {
+      last_read = mirror_image_map_key(vals.rbegin()->first);
+    }
+  }
+
   return 0;
 }
 
@@ -4424,6 +4476,101 @@ int mirror_instances_remove(cls_method_context_t hctx, bufferlist *in,
   if (r < 0) {
     return r;
   }
+  return 0;
+}
+
+/**
+ * Input:
+ * @param start_after: key to start after
+ * @param max_return: max return items
+ *
+ * Output:
+ * @param std::map<std::string, cls::rbd::MirrorImageMap>: image mapping
+ * @returns 0 on success, negative error code on failure
+ */
+int mirror_image_map_list(cls_method_context_t hctx, bufferlist *in,
+                          bufferlist *out) {
+  std::string start_after;
+  uint64_t max_return;
+  try {
+    bufferlist::iterator it = in->begin();
+    ::decode(start_after, it);
+    ::decode(max_return, it);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  std::map<std::string, cls::rbd::MirrorImageMap> image_mapping;
+  int r = mirror::mirror_image_map_list(hctx, start_after, max_return, &image_mapping);
+  if (r < 0) {
+    return r;
+  }
+
+  ::encode(image_mapping, *out);
+  return 0;
+}
+
+/**
+ * Input:
+ * @param global_image_id: global image id
+ * @param image_map: image map
+ *
+ * Output:
+ * @returns 0 on success, negative error code on failure
+ */
+int mirror_image_map_update(cls_method_context_t hctx, bufferlist *in,
+                            bufferlist *out) {
+  std::string global_image_id;
+  cls::rbd::MirrorImageMap image_map;
+
+  try {
+    bufferlist::iterator it = in->begin();
+    ::decode(global_image_id, it);
+    ::decode(image_map, it);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  bufferlist bl;
+  ::encode(image_map, bl);
+
+  const std::string key = mirror::mirror_image_map_key(global_image_id);
+  int r = cls_cxx_map_set_val(hctx, key, &bl);
+  if (r < 0) {
+    CLS_ERR("error updating image map %s: %s", key.c_str(),
+            cpp_strerror(r).c_str());
+    return r;
+  }
+
+  return 0;
+}
+
+/**
+ * Input:
+ * @param global_image_id: global image id
+ *
+ * Output:
+ * @returns 0 on success, negative error code on failure
+ */
+int mirror_image_map_remove(cls_method_context_t hctx, bufferlist *in,
+                            bufferlist *out) {
+  std::string global_image_id;
+
+  try {
+    bufferlist::iterator it = in->begin();
+    ::decode(global_image_id, it);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  const std::string key = mirror::mirror_image_map_key(global_image_id);
+  int r = cls_cxx_map_remove_key(hctx, key);
+  if (r < 0 && r != -ENOENT) {
+    CLS_ERR("error removing image map %s: %s", key.c_str(),
+            cpp_strerror(r).c_str());
+    return r;
+  }
+
   return 0;
 }
 
@@ -5196,6 +5343,9 @@ CLS_INIT(rbd)
   cls_method_handle_t h_mirror_instances_list;
   cls_method_handle_t h_mirror_instances_add;
   cls_method_handle_t h_mirror_instances_remove;
+  cls_method_handle_t h_mirror_image_map_list;
+  cls_method_handle_t h_mirror_image_map_update;
+  cls_method_handle_t h_mirror_image_map_remove;
   cls_method_handle_t h_group_create;
   cls_method_handle_t h_group_dir_list;
   cls_method_handle_t h_group_dir_add;
@@ -5447,6 +5597,15 @@ CLS_INIT(rbd)
                           CLS_METHOD_RD | CLS_METHOD_WR,
                           mirror_instances_remove,
                           &h_mirror_instances_remove);
+  cls_register_cxx_method(h_class, "mirror_image_map_list",
+                          CLS_METHOD_RD, mirror_image_map_list,
+                          &h_mirror_image_map_list);
+  cls_register_cxx_method(h_class, "mirror_image_map_update",
+                          CLS_METHOD_WR, mirror_image_map_update,
+                          &h_mirror_image_map_update);
+  cls_register_cxx_method(h_class, "mirror_image_map_remove",
+                          CLS_METHOD_WR, mirror_image_map_remove,
+                          &h_mirror_image_map_remove);
   /* methods for the consistency groups feature */
   cls_register_cxx_method(h_class, "group_create",
 			  CLS_METHOD_RD | CLS_METHOD_WR,

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1870,6 +1870,44 @@ namespace librbd {
       return ioctx->operate(RBD_MIRROR_LEADER, &op);
     }
 
+    void mirror_image_map_list_start(librados::ObjectReadOperation *op,
+                                     const std::string &start_after,
+                                     uint64_t max_read) {
+      bufferlist bl;
+      ::encode(start_after, bl);
+      ::encode(max_read, bl);
+
+      op->exec("rbd", "mirror_image_map_list", bl);
+    }
+
+    int mirror_image_map_list_finish(bufferlist::iterator *iter,
+                                     std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping) {
+      try {
+        ::decode(*image_mapping, *iter);
+      } catch (const buffer::error &err) {
+        return -EBADMSG;
+      }
+      return 0;
+    }
+
+    void mirror_image_map_update(librados::ObjectWriteOperation *op,
+                                 const std::string &global_image_id,
+                                 const cls::rbd::MirrorImageMap &image_map) {
+      bufferlist bl;
+      ::encode(global_image_id, bl);
+      ::encode(image_map, bl);
+
+      op->exec("rbd", "mirror_image_map_update", bl);
+    }
+
+    void mirror_image_map_remove(librados::ObjectWriteOperation *op,
+                                 const std::string &global_image_id) {
+      bufferlist bl;
+      ::encode(global_image_id, bl);
+
+      op->exec("rbd", "mirror_image_map_remove", bl);
+    }
+
     // Consistency groups functions
     int group_create(librados::IoCtx *ioctx, const std::string &oid)
     {

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -382,6 +382,18 @@ namespace librbd {
     int mirror_instances_remove(librados::IoCtx *ioctx,
                                 const std::string &instance_id);
 
+    // image mapping related routines
+    void mirror_image_map_list_start(librados::ObjectReadOperation *op,
+                                     const std::string &start_after,
+                                     uint64_t max_read);
+    int mirror_image_map_list_finish(bufferlist::iterator *iter,
+                                     std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping);
+    void mirror_image_map_update(librados::ObjectWriteOperation *op,
+                                 const std::string &global_image_id,
+                                 const cls::rbd::MirrorImageMap &image_map);
+    void mirror_image_map_remove(librados::ObjectWriteOperation *op,
+                                 const std::string &global_image_id);
+
     // Consistency groups functions
     int group_create(librados::IoCtx *ioctx, const std::string &oid);
     int group_dir_list(librados::IoCtx *ioctx, const std::string &oid,

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -479,5 +479,50 @@ void TrashImageSpec::dump(Formatter *f) const {
   f->dump_unsigned("deferment_end_time", deferment_end_time);
 }
 
+void MirrorImageMap::encode(bufferlist &bl) const {
+  ENCODE_START(1, 1, bl);
+  ::encode(instance_id, bl);
+  ::encode(data, bl);
+  ENCODE_FINISH(bl);
+}
+
+void MirrorImageMap::decode(bufferlist::iterator &it) {
+  DECODE_START(1, it);
+  ::decode(instance_id, it);
+  ::decode(data, it);
+  DECODE_FINISH(it);
+}
+
+void MirrorImageMap::dump(Formatter *f) const {
+  f->dump_string("instance_id", instance_id);
+
+  std::stringstream data_ss;
+  data.hexdump(data_ss);
+  f->dump_string("data", data_ss.str());
+}
+
+void MirrorImageMap::generate_test_instances(
+  std::list<MirrorImageMap*> &o) {
+  bufferlist data;
+  data.append(std::string(128, '1'));
+
+  o.push_back(new MirrorImageMap("uuid-123", data));
+  o.push_back(new MirrorImageMap("uuid-abc", data));
+}
+
+bool MirrorImageMap::operator==(const MirrorImageMap &rhs) const {
+  return instance_id == rhs.instance_id && data.contents_equal(data);
+}
+
+bool MirrorImageMap::operator<(const MirrorImageMap &rhs) const {
+  return  instance_id < rhs.instance_id;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MirrorImageMap &image_map) {
+  return os << "["
+            << "instance_id=" << image_map.instance_id << "]";
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -364,6 +364,33 @@ struct TrashImageSpec {
 };
 WRITE_CLASS_ENCODER(TrashImageSpec);
 
+struct MirrorImageMap {
+  MirrorImageMap() {
+  }
+
+  MirrorImageMap(const std::string &instance_id,
+                 const bufferlist &data)
+    : instance_id(instance_id),
+      data(data) {
+  }
+
+  std::string instance_id;
+  bufferlist data;
+
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &it);
+  void dump(Formatter *f) const;
+
+  static void generate_test_instances(std::list<MirrorImageMap*> &o);
+
+  bool operator==(const MirrorImageMap &rhs) const;
+  bool operator<(const MirrorImageMap &rhs) const;
+};
+
+std::ostream& operator<<(std::ostream& os, const MirrorImageMap &image_map);
+
+WRITE_CLASS_ENCODER(MirrorImageMap);
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -397,6 +397,7 @@ TYPE(cls_rbd_snap)
 #include "cls/rbd/cls_rbd_types.h"
 TYPE(cls::rbd::MirrorPeer)
 TYPE(cls::rbd::MirrorImage)
+TYPE(cls::rbd::MirrorImageMap)
 #endif
 
 #endif

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -19,6 +19,8 @@ set(rbd_mirror_internal
   ServiceDaemon.cc
   Threads.cc
   types.cc
+  image_map/LoadRequest.cc
+  image_map/UpdateRequest.cc
   image_replayer/BootstrapRequest.cc
   image_replayer/CloseImageRequest.cc
   image_replayer/CreateImageRequest.cc
@@ -38,6 +40,7 @@ set(rbd_mirror_internal
   image_sync/SyncPointPruneRequest.cc
   pool_watcher/RefreshImagesRequest.cc
   service_daemon/Types.cc)
+
 add_library(rbd_mirror_internal STATIC
   ${rbd_mirror_internal})
 

--- a/src/tools/rbd_mirror/image_map/LoadRequest.cc
+++ b/src/tools/rbd_mirror/image_map/LoadRequest.cc
@@ -1,0 +1,98 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/debug.h"
+#include "common/errno.h"
+
+#include "librbd/Utils.h"
+#include "include/rbd_types.h"
+#include "cls/rbd/cls_rbd_client.h"
+
+#include "LoadRequest.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_map::LoadRequest: "   \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_map {
+
+static const uint32_t MAX_RETURN = 1024;
+
+using librbd::util::create_rados_callback;
+
+template<typename I>
+LoadRequest<I>::LoadRequest(librados::IoCtx &ioctx,
+                            std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping,
+                            Context *on_finish)
+  : m_ioctx(ioctx),
+    m_image_mapping(image_mapping),
+    m_on_finish(on_finish) {
+}
+
+template<typename I>
+void LoadRequest<I>::send() {
+  dout(20) << dendl;
+
+  image_map_list();
+}
+
+template<typename I>
+void LoadRequest<I>::image_map_list() {
+  dout(20) << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::mirror_image_map_list_start(&op, m_start_after, MAX_RETURN);
+
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    LoadRequest, &LoadRequest::handle_image_map_list>(this);
+
+  m_out_bl.clear();
+  int r = m_ioctx.aio_operate(RBD_MIRROR_LEADER, aio_comp, &op, &m_out_bl);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template<typename I>
+void LoadRequest<I>::handle_image_map_list(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  std::map<std::string, cls::rbd::MirrorImageMap> image_mapping;
+  if (r == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    r = librbd::cls_client::mirror_image_map_list_finish(&it, &image_mapping);
+  }
+
+  if (r < 0) {
+    derr << ": failed to get image map: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  m_image_mapping->insert(image_mapping.begin(), image_mapping.end());
+
+  if (image_mapping.size() == MAX_RETURN) {
+    m_start_after = image_mapping.rbegin()->first;
+    image_map_list();
+    return;
+  }
+
+  finish(0);
+}
+
+template<typename I>
+void LoadRequest<I>::finish(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_map
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_map::LoadRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_map/LoadRequest.h
+++ b/src/tools/rbd_mirror/image_map/LoadRequest.h
@@ -1,0 +1,64 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_MAP_LOAD_REQUEST_H
+#define CEPH_RBD_MIRROR_IMAGE_MAP_LOAD_REQUEST_H
+
+#include "cls/rbd/cls_rbd_types.h"
+#include "include/rados/librados.hpp"
+
+class Context;
+
+namespace librbd { class ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+namespace image_map {
+
+template<typename ImageCtxT = librbd::ImageCtx>
+class LoadRequest {
+public:
+  static LoadRequest *create(librados::IoCtx &ioctx,
+                             std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping,
+                             Context *on_finish) {
+    return new LoadRequest(ioctx, image_mapping, on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   *     <start>
+   *        |     . . . . . . . .
+   *        v     v             . MAX_RETURN
+   *  IMAGE_MAP_LIST. . . . . . .
+   *        |
+   *        v
+   *    <finish>
+   *
+   * @endverbatim
+   */
+  LoadRequest(librados::IoCtx &ioctx,
+              std::map<std::string, cls::rbd::MirrorImageMap> *image_mapping,
+              Context *on_finish);
+
+  librados::IoCtx &m_ioctx;
+  std::map<std::string, cls::rbd::MirrorImageMap> *m_image_mapping;
+  Context *m_on_finish;
+
+  bufferlist m_out_bl;
+  std::string m_start_after;
+
+  void image_map_list();
+  void handle_image_map_list(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_map
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_IMAGE_MAP_LOAD_REQUEST_H

--- a/src/tools/rbd_mirror/image_map/UpdateRequest.cc
+++ b/src/tools/rbd_mirror/image_map/UpdateRequest.cc
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/debug.h"
+#include "common/errno.h"
+
+#include "librbd/Utils.h"
+#include "include/rbd_types.h"
+#include "cls/rbd/cls_rbd_client.h"
+
+#include "UpdateRequest.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_map::UpdateRequest: "   \
+                           << this << " " << __func__
+
+namespace rbd {
+namespace mirror {
+namespace image_map {
+
+using librbd::util::create_rados_callback;
+
+static const uint32_t MAX_UPDATE = 256;
+
+template <typename I>
+UpdateRequest<I>::UpdateRequest(librados::IoCtx &ioctx,
+                                std::map<std::string, cls::rbd::MirrorImageMap> &&update_mapping,
+                                std::set<std::string> &&remove_global_image_ids, Context *on_finish)
+  : m_ioctx(ioctx),
+    m_update_mapping(update_mapping),
+    m_remove_global_image_ids(remove_global_image_ids),
+    m_on_finish(on_finish) {
+}
+
+template <typename I>
+void UpdateRequest<I>::send() {
+  dout(20) << dendl;
+
+  update_image_map();
+}
+
+template <typename I>
+void UpdateRequest<I>::update_image_map() {
+  dout(20) << dendl;
+
+  if (m_update_mapping.empty() && m_remove_global_image_ids.empty()) {
+    finish(0);
+    return;
+  }
+
+  uint32_t nr_updates = 0;
+  librados::ObjectWriteOperation op;
+
+  auto it1 = m_update_mapping.begin();
+  while (it1 != m_update_mapping.end() && nr_updates++ < MAX_UPDATE) {
+    librbd::cls_client::mirror_image_map_update(&op, it1->first, it1->second);
+    it1 = m_update_mapping.erase(it1);
+  }
+
+  auto it2 = m_remove_global_image_ids.begin();
+  while (it2 != m_remove_global_image_ids.end() && nr_updates++ < MAX_UPDATE) {
+    librbd::cls_client::mirror_image_map_remove(&op, *it2);
+    it2 = m_remove_global_image_ids.erase(it2);
+  }
+
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    UpdateRequest, &UpdateRequest::handle_update_image_map>(this);
+  int r = m_ioctx.aio_operate(RBD_MIRROR_LEADER, aio_comp, &op);
+  assert(r == 0);
+  aio_comp->release();
+}
+
+template <typename I>
+void UpdateRequest<I>::handle_update_image_map(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  if (r < 0) {
+    derr << ": failed to update image map: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  update_image_map();
+}
+
+template <typename I>
+void UpdateRequest<I>::finish(int r) {
+  dout(20) << ": r=" << r << dendl;
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_map
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_map::UpdateRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_map/UpdateRequest.h
+++ b/src/tools/rbd_mirror/image_map/UpdateRequest.h
@@ -1,0 +1,65 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_RBD_MIRROR_IMAGE_MAP_UPDATE_REQUEST_H
+#define CEPH_RBD_MIRROR_IMAGE_MAP_UPDATE_REQUEST_H
+
+#include "cls/rbd/cls_rbd_types.h"
+#include "include/rados/librados.hpp"
+
+class Context;
+
+namespace librbd { class ImageCtx; }
+
+namespace rbd {
+namespace mirror {
+namespace image_map {
+
+template<typename ImageCtxT = librbd::ImageCtx>
+class UpdateRequest {
+public:
+  // accepts an image map for updation and a collection of
+  // global image ids to purge.
+  static UpdateRequest *create(librados::IoCtx &ioctx,
+                               std::map<std::string, cls::rbd::MirrorImageMap> &&update_mapping,
+                               std::set<std::string> &&remove_global_image_ids, Context *on_finish) {
+    return new UpdateRequest(ioctx, std::move(update_mapping), std::move(remove_global_image_ids),
+                             on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   *     <start>
+   *        |       . . . . . . . .
+   *        v       v             . MAX_UPDATE
+   *  UPDATE_IMAGE_MAP. . . . . . .
+   *        |
+   *        v
+   *    <finish>
+   *
+   * @endverbatim
+   */
+  UpdateRequest(librados::IoCtx &ioctx,
+                std::map<std::string, cls::rbd::MirrorImageMap> &&update_mapping,
+                std::set<std::string> &&remove_global_image_ids, Context *on_finish);
+
+  librados::IoCtx &m_ioctx;
+  std::map<std::string, cls::rbd::MirrorImageMap> m_update_mapping;
+  std::set<std::string> m_remove_global_image_ids;
+  Context *m_on_finish;
+
+  void update_image_map();
+  void handle_update_image_map(int r);
+
+  void finish(int r);
+};
+
+} // namespace image_map
+} // namespace mirror
+} // namespace rbd
+
+#endif // CEPH_RBD_MIRROR_IMAGE_MAP_UPDATE_REQUEST_H


### PR DESCRIPTION
NOTE: this pr was carved out a branch (https://github.com/vshankar/ceph/commits/rbd-mirror-image-distribution) which was intended to be pr itself which distributes images amongst mirror instances based on a policy. The actual logic to map/remap images is still a part of the branch which as of now conflicts master.

Introduce a simple image mapping policy (with lookup/map/shuffle semantics), state machines to save/load image to instance mapping states to/from on-disk and notify mirror instances to acquire/release a given image.

Part of tracker: http://tracker.ceph.com/issues/18786