### PR TITLE
test/mon: silence warnings from -Wreorder

### DIFF
--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -219,12 +219,11 @@ class MonMsgTest : public MonClientHelper,
 {
 protected:
   int reply_type;
-  Message *reply_msg;
+  Message *reply_msg = nullptr;
   Mutex lock;
   Cond cond;
 
   MonMsgTest() :
-    reply_msg(NULL),
     MonClientHelper(g_ceph_context),
     lock("lock") { }
 
@@ -233,7 +232,7 @@ public:
     reply_type = -1;
     if (reply_msg) {
       reply_msg->put();
-      reply_msg = NULL;
+      reply_msg = nullptr;
     }
     ASSERT_EQ(init(), 0);
   }
@@ -242,7 +241,7 @@ public:
     shutdown();
     if (reply_msg) {
       reply_msg->put();
-      reply_msg = NULL;
+      reply_msg = nullptr;
     }
   }
 
@@ -280,7 +279,7 @@ public:
     }
 
     if (!reply_msg)
-      dout(20) << __func__ << " reply_msg is NULL" << dendl;
+      dout(20) << __func__ << " reply_msg is nullptr" << dendl;
     else
       dout(20) << __func__ << " reply_msg " << *reply_msg << dendl;
     return reply_msg;


### PR DESCRIPTION
The following warning appears during make:
```
ceph/src/test/mon/test-mon-msg.cc: In constructor ‘MonMsgTest::MonMsgTest()’:
ceph/src/test/mon/test-mon-msg.cc:222:12: warning: ‘MonMsgTest::reply_msg’ will be initialized after [-Wreorder]
   Message *reply_msg;
            ^~~~~~~~~
ceph/src/test/mon/test-mon-msg.cc:229:16: warning:   base ‘MonClientHelper’ [-Wreorder]
     lock("lock") { }
                ^
ceph/src/test/mon/test-mon-msg.cc:226:3: warning:   when initialized here [-Wreorder]
   MonMsgTest() :
```
Signed-off-by: Jos Collin <jcollin@redhat.com>