### PR TITLE
qa/rgw: add encryption config for s3tests under thrash

### DIFF
--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -8,3 +8,5 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl: false


### PR DESCRIPTION
without `rgw crypt require ssl: false`, all encryption tests will fail with `400: Bad Request`