### PR TITLE
qa/workunits/rest/test_mgr_rest_api: revert json workaround

### DIFF
--- a/qa/workunits/rest/test_mgr_rest_api.py
+++ b/qa/workunits/rest/test_mgr_rest_api.py
@@ -3,7 +3,6 @@
 import requests
 import time
 import sys
-import json
 
 # Do not show the stupid message about verify=False.  ignore exceptions bc
 # this doesn't work on some distros.
@@ -23,11 +22,7 @@ auth = ('admin', sys.argv[2])
 request = None
 
 # Create a pool and get its id
-request = requests.post(
-    addr + '/pool?wait=yes',
-    data=json.dumps({'name': 'supertestfriends', 'pg_num': 128}),
-    verify=False,
-    auth=auth)
+request = requests.post(addr + '/pool?wait=yes', json={'name': 'supertestfriends', 'pg_num': 128}, verify=False, auth=auth)
 print(request.text)
 request = requests.get(addr + '/pool', verify=False, auth=auth)
 assert(request.json()[-1]['pool_name'] == 'supertestfriends')
@@ -79,11 +74,7 @@ for method, endpoint, args in screenplay:
         continue
     url = addr + endpoint
     print("URL = " + url)
-    request = getattr(requests, method)(
-        url,
-        data=json.dumps(args),
-        verify=False,
-        auth=auth)
+    request = getattr(requests, method)(url, json=args, verify=False, auth=auth)
     print(request.text)
     if request.status_code != 200 or 'error' in request.json():
         print('ERROR: %s request for URL "%s" failed' % (method, url))


### PR DESCRIPTION
This makes mgr unhappy:

2017-06-14T20:05:37.676 INFO:tasks.ceph.mgr.x.smithi022.stderr:127.0.0.1 - - [14/Jun/2017 20:05:37] "POST /pool?wait=yes HTTP/1.1" 500 -
2017-06-14T20:05:37.681 INFO:tasks.ceph.mgr.x.smithi022.stderr:Error on request:
2017-06-14T20:05:37.681 INFO:tasks.ceph.mgr.x.smithi022.stderr:Traceback (most recent call last):
2017-06-14T20:05:37.681 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/werkzeug/serving.py", line 177, in run_wsgi
2017-06-14T20:05:37.681 INFO:tasks.ceph.mgr.x.smithi022.stderr:    execute(self.server.app)
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/werkzeug/serving.py", line 165, in execute
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:    application_iter = app(environ, start_response)
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/pecan/middleware/recursive.py", line 56, in __call__
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:    return self.application(environ, start_response)
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/pecan/core.py", line 570, in __call__
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:    self.handle_request(req, resp)
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/pecan/core.py", line 508, in handle_request
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:    result = controller(*args, **kwargs)
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib64/ceph/mgr/restful/decorators.py", line 33, in decorated
2017-06-14T20:05:37.682 INFO:tasks.ceph.mgr.x.smithi022.stderr:    return f(*args, **kwargs)
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib64/ceph/mgr/restful/api/pool.py", line 100, in post
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:    args = request.json
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/pecan/core.py", line 35, in __getattr__
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:    return getattr(obj, attr)
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib/python2.7/site-packages/webob/request.py", line 701, in _json_body__get
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:    return json.loads(self.body.decode(self.charset))
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib64/python2.7/json/__init__.py", line 338, in loads
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:    return _default_decoder.decode(s)
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib64/python2.7/json/decoder.py", line 366, in decode
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
2017-06-14T20:05:37.683 INFO:tasks.ceph.mgr.x.smithi022.stderr:  File "/usr/lib64/python2.7/json/decoder.py", line 384, in raw_decode
2017-06-14T20:05:37.684 INFO:tasks.ceph.mgr.x.smithi022.stderr:    raise ValueError("No JSON object could be decoded")
2017-06-14T20:05:37.684 INFO:tasks.ceph.mgr.x.smithi022.stderr:ValueError: No JSON object could be decoded

There is presumably a real fix for this but in the meantime let's
revert the change.

Signed-off-by: Sage Weil <sage@redhat.com>