### PR TITLE
 rgw: fix the subdir without slash of s3 website url

### DIFF
--- a/src/rgw/rgw_rest_s3website.h
+++ b/src/rgw/rgw_rest_s3website.h
@@ -17,6 +17,7 @@
 #include "rgw_rest_s3.h"
 
 class RGWHandler_REST_S3Website : public RGWHandler_REST_S3 {
+  bool web_dir() const;
 protected:
   int retarget(RGWOp *op, RGWOp **new_op) override;
   // TODO: this should be virtual I think, and ensure that it's always

--- a/src/rgw/rgw_website.cc
+++ b/src/rgw/rgw_website.cc
@@ -106,13 +106,15 @@ bool RGWBucketWebsiteConf::should_redirect(const string& key, const int http_err
   return true;
 }
 
-void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key) const
+void RGWBucketWebsiteConf::get_effective_key(const string& key, string *effective_key, bool is_file) const
 {
 
   if (key.empty()) {
     *effective_key = index_doc_suffix;
   } else if (key[key.size() - 1] == '/') {
     *effective_key = key + index_doc_suffix;
+  } else if (! is_file) {
+    *effective_key = key + "/" + index_doc_suffix; 
   } else {
     *effective_key = key;
   }

--- a/src/rgw/rgw_website.h
+++ b/src/rgw/rgw_website.h
@@ -210,7 +210,7 @@ struct RGWBucketWebsiteConf
                        RGWBWRoutingRule *redirect);
 
   void get_effective_key(const std::string& key,
-                         std::string *effective_key) const;
+                         std::string *effective_key, bool is_file) const;
 
   const std::string& get_index_doc() const {
     return index_doc_suffix;


### PR DESCRIPTION
if we use the subdir without slash, we cannot visit the default index.html,
which we configured.It is not consistent with AWS S3.

Fixes: http://tracker.ceph.com/issues/20307
Signed-off-by: liuhong <liuhong@cmss.chinamobile.com>