### PR TITLE
mgr/dashboard: load log lines on startup, split out audit log

### DIFF
--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -170,9 +170,9 @@ void MonCapGrant::expand_profile_mon(const EntityName& name) const
   }
   if (profile == "mgr") {
     profile_grants.push_back(MonCapGrant("mgr", MON_CAP_ALL));
-    profile_grants.push_back(MonCapGrant("log", MON_CAP_W));
-    profile_grants.push_back(MonCapGrant("mon", MON_CAP_R));
-    profile_grants.push_back(MonCapGrant("mds", MON_CAP_R));
+    profile_grants.push_back(MonCapGrant("log", MON_CAP_R | MON_CAP_W));
+    profile_grants.push_back(MonCapGrant("mon", MON_CAP_R | MON_CAP_W));
+    profile_grants.push_back(MonCapGrant("mds", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("osd", MON_CAP_R | MON_CAP_W));
     profile_grants.push_back(MonCapGrant("auth", MON_CAP_R | MON_CAP_X));
     profile_grants.push_back(MonCapGrant("config-key", MON_CAP_R | MON_CAP_W));

--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -175,17 +175,39 @@
             <div class="box-header">
                 Cluster log
             </div>
-            <div class="box-body" style="font-family:monospace; background-color: #ddd; color: #333">
-                <span >
-                    <span rv-each-line="clog">
-                        { line.stamp }&nbsp;{line.priority}&nbsp;
-                        <span  rv-style="line | log_color">
-                            <span style="font-weight: bold;">
-                                { line.message }
-                            </span><br>
+            <div class="box-body">
+                <ul class="nav nav-tabs">
+                  <li class="active"><a data-toggle="tab" href="#clog">Cluster log</a></li>
+                  <li><a data-toggle="tab" href="#audit_log">Audit log</a></li>
+                </ul>
+                <div class="tab-content" style="font-family:monospace; background-color: #ddd; color: #333">
+                    <div id="clog" class="tab-pane fade in active">
+                        <span>
+                            <span rv-each-line="clog">
+                                { line.stamp }&nbsp;{line.priority}&nbsp;
+                                <span  rv-style="line | log_color">
+                                    <span style="font-weight: bold;">
+                                        { line.message }
+                                    </span><br>
+                                </span>
+                            </span>
                         </span>
-                    </span>
-                </span>
+                    </div>
+                    <div id="audit_log" class="tab-pane fade in">
+                        <span>
+                            <span rv-each-line="audit_log">
+                                { line.stamp }&nbsp;{line.priority}&nbsp;
+                                <span  rv-style="line | log_color">
+                                    <span style="font-weight: bold;">
+                                        { line.message }
+                                    </span><br>
+                                </span>
+                            </span>
+                        </span>
+
+                    </div>
+                </div>
+
             </div>
 
         </div>

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -663,6 +663,7 @@ class Module(MgrModule):
                         MonStatus).data,
                     "osd_map": osd_map,
                     "clog": list(global_instance().log_buffer),
+                    "audit_log": list(global_instance().audit_buffer),
                     "pools": pools
                 }
 


### PR DESCRIPTION
Previously only saw log lines output after
the module had loaded: now we have `log last`,
let's use it!

Signed-off-by: John Spray <john.spray@redhat.com>