### PR TITLE
rgw: fix swift default auth error after auth strategy refactoring

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2530,7 +2530,11 @@ RGWOp *RGWHandler_REST_Obj_SWIFT::op_options()
 
 int RGWHandler_REST_SWIFT::authorize()
 {
-  return rgw::auth::Strategy::apply(auth_strategy, s);
+  int r = rgw::auth::Strategy::apply(auth_strategy, s);
+  if (r == -EACCES) { // XXX: hacky fix for Strategy::apply() refactoring
+    r = -EPERM;
+  }
+  return r;
 }
 
 int RGWHandler_REST_SWIFT::postauth_init()


### PR DESCRIPTION
the changes in bd81c216d0ef36a66c27180f13430c9702393fb6 inadvertently changed swift's default auth error from EPERM to ACCESS. hacky fix to change it back

this fixes the `Status returned: 403 Expected: 401` failures in swift test `testInvalidAuthToken (test.functional.tests.TestAccount[UTF8])`