### PR TITLE
test/osd/osd-dup.sh: use wait_for_clean

### DIFF
--- a/src/test/osd/osd-dup.sh
+++ b/src/test/osd/osd-dup.sh
@@ -72,7 +72,7 @@ function TEST_filestore_to_bluestore() {
     # and make sure mon is sync'ed
     flush_pg_stats
 
-    ceph -s | grep '20 active+clean' || return 1
+    wait_for_clean || return 1
 }
 
 main osd-dup "$@"


### PR DESCRIPTION
Rather than a onetime 'ceph -s' test, which might be too early
on a loaded machine, use wait_for_clean; that's its job

Signed-off-by: Dan Mick <dan.mick@redhat.com>