### PR TITLE
mon/OSDMonitor: batch noup/noin osds support

### DIFF
--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -112,14 +112,16 @@ struct ceph_eversion {
 /* status bits */
 #define CEPH_OSD_EXISTS       (1<<0)
 #define CEPH_OSD_UP           (1<<1)
-#define CEPH_OSD_AUTOOUT      (1<<2) /* osd was automatically marked out */
-#define CEPH_OSD_NEW          (1<<3) /* osd is new, never marked in */
-#define CEPH_OSD_FULL         (1<<4) /* osd is at or above full threshold */
-#define CEPH_OSD_NEARFULL     (1<<5) /* osd is at or above nearfull threshold */
-#define CEPH_OSD_BACKFILLFULL (1<<6) /* osd is at or above backfillfull threshold */
-#define CEPH_OSD_DESTROYED    (1<<7) /* osd has been destroyed */
-#define CEPH_OSD_NODOWN       (1<<8) /* osd can not be marked down */
-#define CEPH_OSD_NOOUT        (1<<9) /* osd can not be marked out */
+#define CEPH_OSD_AUTOOUT      (1<<2)  /* osd was automatically marked out */
+#define CEPH_OSD_NEW          (1<<3)  /* osd is new, never marked in */
+#define CEPH_OSD_FULL         (1<<4)  /* osd is at or above full threshold */
+#define CEPH_OSD_NEARFULL     (1<<5)  /* osd is at or above nearfull threshold */
+#define CEPH_OSD_BACKFILLFULL (1<<6)  /* osd is at or above backfillfull threshold */
+#define CEPH_OSD_DESTROYED    (1<<7)  /* osd has been destroyed */
+#define CEPH_OSD_NOUP         (1<<8)  /* osd can not be marked up */
+#define CEPH_OSD_NODOWN       (1<<9)  /* osd can not be marked down */
+#define CEPH_OSD_NOIN         (1<<10) /* osd can not be marked in */
+#define CEPH_OSD_NOOUT        (1<<11) /* osd can not be marked out */
 
 extern const char *ceph_osd_state_name(int s);
 

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -687,27 +687,49 @@ COMMAND("osd rm " \
 	"remove osd(s) <id> [<id>...], "
         "or use <any|all|*> to remove all osds", \
         "osd", "rw", "cli,rest")
-COMMAND("osd add-noout " \
+COMMAND("osd add-noup " \
         "name=ids,type=CephString,n=N", \
-        "mark osd(s) <id> [<id>...] as noout, " \
-        "or use <all|any|*> to mark all osds as noout", \
+        "mark osd(s) <id> [<id>...] as noup, " \
+        "or use <all|any|*> to mark all osds as noup", \
         "osd", "rw", "cli,rest")
 COMMAND("osd add-nodown " \
         "name=ids,type=CephString,n=N", \
         "mark osd(s) <id> [<id>...] as nodown, " \
         "or use <all|any|*> to mark all osds as nodown", \
         "osd", "rw", "cli,rest")
-COMMAND("osd rm-noout " \
+COMMAND("osd add-noin " \
         "name=ids,type=CephString,n=N", \
-        "allow osd(s) <id> [<id>...] to be marked out " \
-        "(if they are currently marked as noout), " \
-        "can use <all|any|*> to automatically filter out all noout osds", \
+        "mark osd(s) <id> [<id>...] as noin, " \
+        "or use <all|any|*> to mark all osds as noin", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd add-noout " \
+        "name=ids,type=CephString,n=N", \
+        "mark osd(s) <id> [<id>...] as noout, " \
+        "or use <all|any|*> to mark all osds as noout", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd rm-noup " \
+        "name=ids,type=CephString,n=N", \
+        "allow osd(s) <id> [<id>...] to be marked up " \
+        "(if they are currently marked as noup), " \
+        "can use <all|any|*> to automatically filter out all noup osds", \
         "osd", "rw", "cli,rest")
 COMMAND("osd rm-nodown " \
         "name=ids,type=CephString,n=N", \
         "allow osd(s) <id> [<id>...] to be marked down " \
         "(if they are currently marked as nodown), " \
         "can use <all|any|*> to automatically filter out all nodown osds", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd rm-noin " \
+        "name=ids,type=CephString,n=N", \
+        "allow osd(s) <id> [<id>...] to be marked in " \
+        "(if they are currently marked as noin), " \
+        "can use <all|any|*> to automatically filter out all noin osds", \
+        "osd", "rw", "cli,rest")
+COMMAND("osd rm-noout " \
+        "name=ids,type=CephString,n=N", \
+        "allow osd(s) <id> [<id>...] to be marked out " \
+        "(if they are currently marked as noout), " \
+        "can use <all|any|*> to automatically filter out all noout osds", \
         "osd", "rw", "cli,rest")
 COMMAND("osd reweight " \
 	"name=id,type=CephOsdName " \

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5609,7 +5609,7 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
   // if our map within recent history, try to add ourselves to the osdmap.
   if (osdmap->get_epoch() == 0) {
     derr << "waiting for initial osdmap" << dendl;
-  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP)) {
+  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP) || osdmap->is_noup(whoami)) {
     derr << "osdmap NOUP flag is set, waiting for it to clear" << dendl;
   } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
     derr << "osdmap SORTBITWISE OSDMap flag is NOT set; please set it"
@@ -7604,8 +7604,9 @@ void OSD::_committed_osd_maps(epoch_t first, epoch_t last, MOSDMap *m)
       }
     }
 
-    if (osdmap->test_flag(CEPH_OSDMAP_NOUP) !=
-	newmap->test_flag(CEPH_OSDMAP_NOUP)) {
+    if ((osdmap->test_flag(CEPH_OSDMAP_NOUP) !=
+        newmap->test_flag(CEPH_OSDMAP_NOUP)) ||
+        (osdmap->is_noup(whoami) != newmap->is_noup(whoami))) {
       dout(10) << __func__ << " NOUP flag changed in " << newmap->get_epoch()
 	       << dendl;
       if (is_booting()) {


### PR DESCRIPTION
This is a follow-up change of https://github.com/ceph/ceph/pull/15381.
This patch also simplifies the original code logic a bit.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>