### PR TITLE
jewel: mon: fail to form large quorum; msg/async busy loop 

### DIFF
--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -414,8 +414,7 @@ private:
 
     // lazy delete, see "deleted_conns"
     Mutex::Locker l(deleted_lock);
-    if (deleted_conns.count(p->second)) {
-      deleted_conns.erase(p->second);
+    if (deleted_conns.erase(p->second)) {
       p->second->get_perf_counter()->dec(l_msgr_active_connections);
       conns.erase(p);
       return NULL;
@@ -452,14 +451,14 @@ public:
 
   int accept_conn(AsyncConnectionRef conn) {
     Mutex::Locker l(lock);
-    if (conns.count(conn->peer_addr)) {
-      AsyncConnectionRef existing = conns[conn->peer_addr];
+    auto it = conns.find(conn->peer_addr);
+    if (it != conns.end()) {
+      AsyncConnectionRef existing = it->second;
 
       // lazy delete, see "deleted_conns"
       // If conn already in, we will return 0
       Mutex::Locker l(deleted_lock);
-      if (deleted_conns.count(existing)) {
-        deleted_conns.erase(existing);
+      if (deleted_conns.erase(existing)) {
       } else if (conn != existing) {
         return -1;
       }

--- a/src/msg/async/AsyncMessenger.h
+++ b/src/msg/async/AsyncMessenger.h
@@ -459,6 +459,8 @@ public:
       // If conn already in, we will return 0
       Mutex::Locker l(deleted_lock);
       if (deleted_conns.erase(existing)) {
+        existing->get_perf_counter()->dec(l_msgr_active_connections);
+        conns.erase(it);
       } else if (conn != existing) {
         return -1;
       }


### PR DESCRIPTION
http://tracker.ceph.com/issues/20314