### PR TITLE
osd, messages/MOSDPing: bunch of fixes related to ping inflation

### DIFF
--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -100,21 +100,26 @@ public:
     ::encode(peer_stat, payload);
     ::encode(stamp, payload);
 
-    bufferlist pad;
-    size_t s = MAX(min_message_size - payload.length(), 0);
-    // this should be big enough for normal min_message padding sizes. since
-    // we are targetting jumbo ethernet frames around 9000 bytes, 16k should
-    // be more than sufficient!  the compiler will statically zero this so
-    // that at runtime we are only adding a bufferptr reference to it.
-    static char zeros[16384] = {};
-    while (s > sizeof(zeros)) {
-      pad.append(buffer::create_static(sizeof(zeros), zeros));
-      s -= sizeof(zeros);
-    }
+    size_t s = 0;
+    if (min_message_size > payload.length())
+      s = min_message_size - payload.length();
+    ::encode((uint32_t)s, payload);
     if (s) {
-      pad.append(buffer::create_static(s, zeros));
+      bufferlist pad;
+      // this should be big enough for normal min_message padding sizes. since
+      // we are targetting jumbo ethernet frames around 9000 bytes, 16k should
+      // be more than sufficient!  the compiler will statically zero this so
+      // that at runtime we are only adding a bufferptr reference to it.
+      static char zeros[16384] = {};
+      while (s > sizeof(zeros)) {
+	pad.append(buffer::create_static(sizeof(zeros), zeros));
+	s -= sizeof(zeros);
+      }
+      if (s) {
+	pad.append(buffer::create_static(s, zeros));
+      }
+      ::encode(pad, payload);
     }
-    ::encode(pad, payload);
   }
 
   const char *get_type_name() const override { return "osd_ping"; }

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -86,10 +86,11 @@ public:
     ::decode(peer_stat, p);
     ::decode(stamp, p);
     if (header.version >= 3) {
-      bufferlist size_bl;
       int payload_mid_length = p.get_off();
-      ::decode(size_bl, p);
-      min_message_size = size_bl.length() + payload_mid_length;
+      uint32_t size;
+      ::decode(size, p);
+      p.advance(size);
+      min_message_size = size + payload_mid_length;
     }
   }
   void encode_payload(uint64_t features) override {
@@ -105,20 +106,18 @@ public:
       s = min_message_size - payload.length();
     ::encode((uint32_t)s, payload);
     if (s) {
-      bufferlist pad;
       // this should be big enough for normal min_message padding sizes. since
       // we are targetting jumbo ethernet frames around 9000 bytes, 16k should
       // be more than sufficient!  the compiler will statically zero this so
       // that at runtime we are only adding a bufferptr reference to it.
       static char zeros[16384] = {};
       while (s > sizeof(zeros)) {
-	pad.append(buffer::create_static(sizeof(zeros), zeros));
+	payload.append(buffer::create_static(sizeof(zeros), zeros));
 	s -= sizeof(zeros);
       }
       if (s) {
-	pad.append(buffer::create_static(s, zeros));
+	payload.append(buffer::create_static(s, zeros));
       }
-      ::encode(pad, payload);
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9359,6 +9359,8 @@ const char** OSD::get_tracked_conf_keys() const
     "osd_recovery_delay_start",
     "osd_client_message_size_cap",
     "osd_client_message_cap",
+    "osd_heartbeat_min_size",
+    "osd_heartbeat_interval",
     NULL
   };
   return KEYS;


### PR DESCRIPTION
For users who don't care about jumbo frames, or are certain that their setup is correct, the new diagnostic feature (#15535) will provide only unnecessary load. Due to a bug, users can't really disable it and this PR fixes this. Because both "osd heartbeat interval" and "osd heartbeat min size" aren't marked as observed, this causes confusion for users who try to change them at runtime (new options values are used, but the message makes this uncertain). Finally, initial code for heartbeat inflater was slightly optimized to not move dummy data as often.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>