### PR TITLE
os/bluestore/BlueFS: Rebuild memcopy for bufferlist::page_aligned_app…

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1815,6 +1815,16 @@ static std::atomic_flag buffer_debug_lock = ATOMIC_FLAG_INIT;
     bl.last_p = bl.begin();
   }
 
+  void buffer::list::claim_append_piecewise(list& bl)
+  {
+    // steal the other guy's buffers
+    for (std::list<buffer::ptr>::const_iterator i = bl.buffers().begin();
+        i != bl.buffers().end(); i++) {
+      append(*i, 0, i->length());
+    }
+    bl.clear();
+  }
+
   void buffer::list::copy(unsigned off, unsigned len, char *dest) const
   {
     if (off + len > length())

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -788,6 +788,8 @@ namespace buffer CEPH_BUFFER_API {
     void claim(list& bl, unsigned int flags = CLAIM_DEFAULT);
     void claim_append(list& bl, unsigned int flags = CLAIM_DEFAULT);
     void claim_prepend(list& bl, unsigned int flags = CLAIM_DEFAULT);
+    // only for bl is bufferlist::page_aligned_appender
+    void claim_append_piecewise(list& bl);
 
     // clone non-shareable buffers (make shareable)
     void make_shareable() {

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1554,7 +1554,7 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     dout(20) << __func__ << " using partial tail 0x"
              << std::hex << partial << std::dec << dendl;
     assert(h->tail_block.length() == partial);
-    bl.claim_append(h->tail_block);
+    bl.claim_append_piecewise(h->tail_block);
     x_off -= partial;
     offset -= partial;
     length += partial;
@@ -1566,11 +1566,11 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
     }
   }
   if (length == partial + h->buffer.length()) {
-    bl.claim_append(h->buffer);
+    bl.claim_append_piecewise(h->buffer);
   } else {
     bufferlist t;
-    t.substr_of(h->buffer, 0, length);
-    bl.claim_append(t);
+    h->buffer.splice(0, length, &t);
+    bl.claim_append_piecewise(t);
     t.substr_of(h->buffer, length, h->buffer.length() - length);
     h->buffer.swap(t);
     dout(20) << " leaving 0x" << std::hex << h->buffer.length() << std::dec

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -1703,6 +1703,33 @@ TEST(BufferList, is_n_page_sized) {
   }
 }
 
+TEST(BufferList, page_aligned_appender) {
+  bufferlist bl;
+  auto a = bl.get_page_aligned_appender(5);
+  a.append("asdf", 4);
+  a.flush();
+  cout << bl << std::endl;
+  ASSERT_EQ(1u, bl.get_num_buffers());
+  a.append("asdf", 4);
+  for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
+    a.append("x", 1);
+  }
+  a.flush();
+  cout << bl << std::endl;
+  ASSERT_EQ(1u, bl.get_num_buffers());
+  for (unsigned n = 0; n < 3 * CEPH_PAGE_SIZE; ++n) {
+    a.append("y", 1);
+  }
+  a.flush();
+  cout << bl << std::endl;
+  ASSERT_EQ(2u, bl.get_num_buffers());
+  for (unsigned n = 0; n < 10 * CEPH_PAGE_SIZE; ++n) {
+    a.append("asdfasdfasdf", 1);
+  }
+  a.flush();
+  cout << bl << std::endl;
+}
+
 TEST(BufferList, rebuild_aligned_size_and_memory) {
   const unsigned SIMD_ALIGN = 32;
   const unsigned BUFFER_SIZE = 67;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2097,6 +2097,27 @@ TEST(BufferList, claim_prepend) {
   EXPECT_EQ((unsigned)0, from.length());
 }
 
+TEST(BufferList, claim_append_piecewise) {
+  bufferlist bl, t, dst;
+  auto a = bl.get_page_aligned_appender(4);
+  for (uint32_t i = 0; i < (CEPH_PAGE_SIZE + CEPH_PAGE_SIZE - 1333); i++)
+    a.append("x", 1);
+  a.flush();
+  const char *p = bl.c_str();
+  t.claim_append(bl);
+
+  for (uint32_t i = 0; i < (CEPH_PAGE_SIZE + 1333); i++)
+    a.append("x", 1);
+  a.flush();
+  t.claim_append(bl);
+
+  EXPECT_FALSE(t.is_aligned_size_and_memory(CEPH_PAGE_SIZE, CEPH_PAGE_SIZE));
+  dst.claim_append_piecewise(t);
+  EXPECT_TRUE(dst.is_aligned_size_and_memory(CEPH_PAGE_SIZE, CEPH_PAGE_SIZE));
+  const char *p1 = dst.c_str();
+  EXPECT_TRUE(p == p1);
+}
+
 TEST(BufferList, begin) {
   bufferlist bl;
   bl.append("ABC");


### PR DESCRIPTION
…ender

BlueFS use bufferlist::page_aligned_appender to make data aligned
w/ memory. But bufferlist::rebuild_aligned_size_and_memory don't handle
this case. For example:
```c++
buffer::list(len=4096,
  buffer::ptr(90112~2018 0x55f4de51e000 in raw 0x55f4de508000 len 1048576 nref 7),
  buffer::ptr(92130~2078 0x55f4de51e7e2 in raw 0x55f4de508000 len 1048576 nref 7)
)
```
After bufferlist::rebuild_aligned_size_and_memory()
```c++
buffer::list(
len=4096, buffer::ptr(0~4096 0x55f4de6de000 in raw 0x55f4de6de000 len 4096 nref 1)
)
```
Using bufferlist::append(ptr, offset, len) function to make all continue
prt merge.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>