### PR TITLE
rgw: fix rest client's order of args in get_v2_signature

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -131,7 +131,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const c
 
   string digest;
   try {
-    digest = rgw::auth::s3::get_v2_signature(cct, canonical_header, key.key);
+    digest = rgw::auth::s3::get_v2_signature(cct, key.key, canonical_header);
   } catch (int ret) {
     return ret;
   }
@@ -232,7 +232,7 @@ int RGWRESTSimpleRequest::sign_request(RGWAccessKey& key, RGWEnv& env, req_info&
 
   string digest;
   try {
-    digest = rgw::auth::s3::get_v2_signature(cct, canonical_header, key.key);
+    digest = rgw::auth::s3::get_v2_signature(cct, key.key, canonical_header);
   } catch (int ret) {
     return ret;
   }


### PR DESCRIPTION
multisite requests were failing to authenticate, because the order of arguments for `get_v2_signature()` were swapped in aws4 rework c89222850e84d6a1a72646e7a20e47216d533f07