### PR TITLE
osd: do not try to boot until we've seen the first osdmap

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5607,7 +5607,9 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
   heartbeat();
 
   // if our map within recent history, try to add ourselves to the osdmap.
-  if (osdmap->test_flag(CEPH_OSDMAP_NOUP)) {
+  if (osdmap->get_epoch() == 0) {
+    derr << "waiting for initial osdmap" << dendl;
+  } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP)) {
     derr << "osdmap NOUP flag is set, waiting for it to clear" << dendl;
   } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {
     derr << "osdmap SORTBITWISE OSDMap flag is NOT set; please set it"


### PR DESCRIPTION
This is actually not a change in behavior *except* we see this message
instead of

2017-06-15 18:05:29.760938 24a7f700 -1 osd.1 0 osdmap SORTBITWISE OSDMap flag is NOT set; please set it

because the OSDMap() epoch 0 does not have SORTBITWISE.

Signed-off-by: Sage Weil <sage@redhat.com>