### PR TITLE
ceph-disk: command invocation needs all fields separate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3288,8 +3288,8 @@ def start_daemon(
         elif os.path.exists(os.path.join(path, 'bsdrc')):
             command_check_call(
                 [
-                    '/usr/local/etc/rc.d/ceph start osd.{osd_id}'
-                    .format(osd_id=osd_id),
+                    '/usr/sbin/service', 'ceph', 'start',
+                    'osd.{osd_id}'.format(osd_id=osd_id),
                 ],
             )
         else:


### PR DESCRIPTION
- And us the regular command that is used to start (daemon) services

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>