### PR TITLE
rgw_rados: initialize cur_shard

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3486,7 +3486,7 @@ class RGWIndexCompletionManager {
 
   int num_shards;
 
-  std::atomic<int> cur_shard;
+  std::atomic<int> cur_shard {0};
 
 
 public:


### PR DESCRIPTION
valgrind reported an uninitialized value on use of cur_shard at a few
places, so explicitly declaring this to 0 as we are incrementing this
later

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>