### PR TITLE
mon,mgr: print pgmap reports to debug (not cluster) log

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -850,7 +850,7 @@ void DaemonServer::send_report()
 	  // FIXME: no easy way to get mon features here.  this will do for
 	  // now, though, as long as we don't make a backward-incompat change.
 	  pg_map.encode_digest(osdmap, m->get_data(), CEPH_FEATURES_ALL);
-
+	  dout(10) << pg_map << dendl;
 	  pg_map.get_health(g_ceph_context, osdmap,
 			    m->health_summary,
 			    &m->health_detail);

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -187,6 +187,7 @@ bool MgrStatMonitor::prepare_report(MonOpRequestRef op)
   bufferlist bl = m->get_data();
   auto p = bl.begin();
   ::decode(pending_digest, p);
+  dout(10) << __func__ << " " << pending_digest << dendl;
   pending_health_summary.swap(m->health_summary);
   pending_health_detail.swap(m->health_detail);
   return true;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -500,7 +500,7 @@ public:
 WRITE_CLASS_ENCODER_FEATURES(PGMap::Incremental)
 WRITE_CLASS_ENCODER_FEATURES(PGMap)
 
-inline ostream& operator<<(ostream& out, const PGMap& m) {
+inline ostream& operator<<(ostream& out, const PGMapDigest& m) {
   m.print_oneline_summary(NULL, &out);
   return out;
 }


### PR DESCRIPTION
These are really helpful for debugging and they aren't in the cluster
log any more!