### PR TITLE
ceph-dencoder: Silence coverity CID 1412579

### DIFF
--- a/src/test/encoding/ceph_dencoder.cc
+++ b/src/test/encoding/ceph_dencoder.cc
@@ -142,9 +142,7 @@ public:
       i = m_list.size();
     if ((i == 0) || (i > m_list.size()))
       return "invalid id for generated object";
-    typename list<T*>::iterator p = m_list.begin();
-    for (i--; i > 0 && p != m_list.end(); ++p, --i) ;
-    m_object = *p;
+    m_object = *(std::next(m_list.begin(), i-1));
     return string();
   }
 
@@ -270,10 +268,8 @@ public:
       i = m_list.size();
     if ((i == 0) || (i > m_list.size()))
       return "invalid id for generated object";
-    typename list<T*>::iterator p = m_list.begin();
-    for (i--; i > 0 && p != m_list.end(); ++p, --i) ;
     m_object->put();
-    m_object = *p;
+    m_object = *(std::next(m_list.begin(), i-1));
     return string();
   }
   bool is_deterministic() override {


### PR DESCRIPTION
141         if (i == 0)
142           i = m_list.size();
143         if ((i == 0) || (i > m_list.size()))
144           return "invalid id for generated object";
145         typename list<T*>::iterator p = m_list.begin();
146         for (i--; i > 0 && p != m_list.end(); ++p, --i) ;
>>>     CID 1412579:  API usage errors  (INVALIDATE_ITERATOR)
>>>     Dereferencing iterator "p" though it is already past the end
of its container.
147         m_object = *p;
148         return string();
149       }
150
151       bool is_deterministic() override {
152         return !nondeterministic;

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>