### PR TITLE
qa/tasks/ceph: osd_scrub_pgs: reissue scrub requests in loop

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/full-tiering.yaml
@@ -24,3 +24,5 @@ tasks:
       - ceph osd pool set-quota ec max_bytes 20480000
       - ceph osd pool set ec-ca target_max_bytes 20480000
       - timeout 30 rados -p ec-ca bench 30 write || true
+      - ceph osd pool set-quota ec-ca max_bytes 0
+      - ceph osd pool set-quota ec max_bytes 0

--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -31,3 +31,6 @@ tasks:
       - sudo ceph osd in 0 1
 - sleep:
     duration: 60
+- exec:
+    client.0:
+      - sudo ceph osd pool set foo size 2

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1078,6 +1078,13 @@ def osd_scrub_pgs(ctx, config):
             gap_cnt = 0
         else:
             gap_cnt += 1
+            if gap_cnt % 6 == 0:
+                for (pgid, tmval) in timez:
+                    # re-request scrub every so often in case the earlier
+                    # request was missed.  do not do it everytime because
+                    # the scrub may be in progress or not reported yet and
+                    # we will starve progress.
+                    manager.raw_cluster_cmd('pg', 'deep-scrub', pgid)
             if gap_cnt > retries:
                 raise RuntimeError('Exiting scrub checking -- not all pgs scrubbed.')
         if loop:

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1052,7 +1052,12 @@ def osd_scrub_pgs(ctx, config):
     for role in teuthology.cluster_roles_of_type(all_roles, 'osd', cluster_name):
         log.info("Scrubbing {osd}".format(osd=role))
         _, _, id_ = teuthology.split_role(role)
-        manager.raw_cluster_cmd('osd', 'deep-scrub', id_)
+        # allow this to fail; in certain cases the OSD might not be up
+        # at this point.  we will catch all pgs below.
+        try:
+            manager.raw_cluster_cmd('osd', 'deep-scrub', id_)
+        except run.CommandFailedError:
+            pass
     prev_good = 0
     gap_cnt = 0
     loop = True

--- a/qa/tasks/resolve_stuck_peering.py
+++ b/qa/tasks/resolve_stuck_peering.py
@@ -108,3 +108,5 @@ def task(ctx, config):
     while manager.get_num_down():
         assert time.time() - start < timeout, \
             'failed to recover before timeout expired'
+
+    manager.revive_osd(primary)


### PR DESCRIPTION
The scrub commands are not reliable: if the OSD doesn't happen to
be connected at the time the command is issued it may not get
delivered.  Re-request scrubs for each PG that has not yet been
scrubbed so that we don't wait forever when the original request
is dropped.

Signed-off-by: Sage Weil <sage@redhat.com>