### PR TITLE
src/common/ceph_string: stringify new osd states

### DIFF
--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -47,8 +47,12 @@ const char *ceph_osd_state_name(int s)
 		return "backfillfull";
         case CEPH_OSD_DESTROYED:
                 return "destroyed";
+        case CEPH_OSD_NOUP:
+                return "noup";
         case CEPH_OSD_NODOWN:
                 return "nodown";
+        case CEPH_OSD_NOIN:
+                return "noin";
         case CEPH_OSD_NOOUT:
                 return "noout";
 	default:


### PR DESCRIPTION
In https://github.com/ceph/ceph/pull/15725 I introduce
two more osd states.

This patch pulls them in.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>