### PR TITLE
rgw: clean-up error mapping in Swift's authentication strategy.

### DIFF
--- a/src/rgw/rgw_auth.cc
+++ b/src/rgw/rgw_auth.cc
@@ -523,7 +523,7 @@ rgw::auth::Engine::result_t
 rgw::auth::AnonymousEngine::authenticate(const req_state* const s) const
 {
   if (! is_applicable(s)) {
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   } else {
     RGWUserInfo user_info;
     rgw_get_anon_user(user_info);

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -262,7 +262,7 @@ TokenEngine::authenticate(const std::string& token,
     ldout(cct, 0) << "got expired token: " << t->get_project_name()
                   << ":" << t->get_user_name()
                   << " expired: " << t->get_expires() << dendl;
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   /* Check for necessary roles. */
@@ -281,7 +281,7 @@ TokenEngine::authenticate(const std::string& token,
   ldout(cct, 0) << "user does not hold a matching role; required roles: "
                 << g_conf->rgw_keystone_accepted_roles << dendl;
 
-  return result_t::deny();
+  return result_t::deny(-EPERM);
 }
 
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2530,11 +2530,7 @@ RGWOp *RGWHandler_REST_Obj_SWIFT::op_options()
 
 int RGWHandler_REST_SWIFT::authorize()
 {
-  int r = rgw::auth::Strategy::apply(auth_strategy, s);
-  if (r == -EACCES) { // XXX: hacky fix for Strategy::apply() refactoring
-    r = -EPERM;
-  }
-  return r;
+  return rgw::auth::Strategy::apply(auth_strategy, s);
 }
 
 int RGWHandler_REST_SWIFT::postauth_init()

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -328,17 +328,17 @@ ExternalTokenEngine::authenticate(const std::string& token,
                 ",", swift_groups);
 
     if (0 == swift_groups.size()) {
-      return result_t::deny();
+      return result_t::deny(-EPERM);
     } else {
       swift_user = std::move(swift_groups[0]);
     }
   } catch (std::out_of_range) {
     /* The X-Auth-Groups header isn't present in the response. */
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   if (swift_user.empty()) {
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   ldout(cct, 10) << "swift user=" << swift_user << dendl;
@@ -416,7 +416,7 @@ SignedTokenEngine::authenticate(const std::string& token,
                                 const req_state* const s) const
 {
   if (! is_applicable(token)) {
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   /* Effective token string is the part after the prefix. */
@@ -458,7 +458,7 @@ SignedTokenEngine::authenticate(const std::string& token,
     ldout(cct, 0) << "NOTICE: old timed out token was used now=" << now
 	          << " token.expiration=" << expiration
                   << dendl;
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   RGWUserInfo user_info;
@@ -471,7 +471,7 @@ SignedTokenEngine::authenticate(const std::string& token,
 
   const auto siter = user_info.swift_keys.find(swift_user);
   if (siter == std::end(user_info.swift_keys)) {
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   const auto swift_key = siter->second;
@@ -487,7 +487,7 @@ SignedTokenEngine::authenticate(const std::string& token,
                   << " tok_bl.length()=" << tok_bl.length()
 	          << " local_tok_bl.length()=" << local_tok_bl.length()
                   << dendl;
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   if (memcmp(local_tok_bl.c_str(), tok_bl.c_str(),
@@ -498,7 +498,7 @@ SignedTokenEngine::authenticate(const std::string& token,
                local_tok_bl.length(), buf);
 
     ldout(cct, 0) << "NOTICE: tokens mismatch tok=" << buf << dendl;
-    return result_t::deny();
+    return result_t::deny(-EPERM);
   }
 
   auto apl = apl_factory->create_apl_local(cct, s, user_info,


### PR DESCRIPTION
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>

This PR is a follow-up to the #15711. It has been verified using the Keystone backend with Tempest and manually tested on the `SignedTokenEngine`. A Teuthology run is necessary.

CC: @cbodley.