### PR TITLE
mds: repeat dir->is_frozen in rdlock_path_xlock_dentry

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2631,13 +2631,6 @@ CDentry* Server::rdlock_path_xlock_dentry(MDRequestRef& mdr, int n,
   if (!dir) return 0;
   dout(10) << "rdlock_path_xlock_dentry dir " << *dir << dendl;
 
-  // make sure we can auth_pin (or have already authpinned) dir
-  if (dir->is_frozen()) {
-    dout(7) << "waiting for !frozen/authpinnable on " << *dir << dendl;
-    dir->add_waiter(CInode::WAIT_UNFREEZE, new C_MDS_RetryRequest(mdcache, mdr));
-    return 0;
-  }
-
   CInode *diri = dir->get_inode();
   if (!mdr->reqid.name.is_mds()) {
     if (diri->is_system() && !diri->is_root()) {


### PR DESCRIPTION
Because traverse_to_auth_dir() in the rdlock_path_xlock_dentry() call dir->is_frozen,
as "traverse_to_auth_dir ---> validate_dentry_dir() ---> dir->is_frozen()",  
so this is repeated to judge "dir->is_frozen()" in "rdlock_path_xlock_dentry()".

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>