### PR TITLE
qa/workunits/cephtool/test.sh: only include last line for epoch

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1601,24 +1601,19 @@ function test_mon_osd()
 function test_mon_crush()
 {
   f=$TEMP_DIR/map.$$
-  ceph osd getcrushmap -o $f 2> $f.epoch
+  epoch=$(ceph osd getcrushmap -o $f 2>&1 | tail -n1)
   [ -s $f ]
-  epoch=`cat $f.epoch`
   [ "$epoch" -gt 1 ]
   nextepoch=$(( $epoch + 1 ))
   echo epoch $epoch nextepoch $nextepoch
   rm -f $f.epoch
   expect_false ceph osd setcrushmap $nextepoch -i $f
-  ceph osd setcrushmap $epoch -i $f 2> $f.epoch
-  gotepoch=`cat $f.epoch`
+  gotepoch=$(ceph osd setcrushmap $epoch -i $f 2>&1 | tail -n1)
   echo gotepoch $gotepoch
-  rm -f $f.epoch
   [ "$gotepoch" -eq "$nextepoch" ]
   # should be idempotent
-  ceph osd setcrushmap $epoch -i $f 2> $f.epoch
-  gotepoch=`cat $f.epoch`
+  gotepoch=$(ceph osd setcrushmap $epoch -i $f 2>&1 | tail -n1)
   echo epoch $gotepoch
-  rm -f $f.epoch
   [ "$gotepoch" -eq "$nextepoch" ]
   rm $f
 }


### PR DESCRIPTION
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/qa/workunits/cephtool/test.sh:1606: test_mon_crush:  epoch='2017-06-20 04:44:52.862459 ffffad4d0200 -1 asok(0xffffa8000b10) AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: The UNIX domain socket path /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/build/src/test/td/t-7202/out/client.admin.48876.asok is too long! The maximum length on this system is 107
12'
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/qa/workunits/cephtool/test.sh:1607: test_mon_crush:  '[' '2017-06-20 04:44:52.862459 ffffad4d0200 -1 asok(0xffffa8000b10) AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: The UNIX domain socket path /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/build/src/test/td/t-7202/out/client.admin.48876.asok is too long! The maximum length on this system is 107
12' -gt 1 ']'
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/qa/workunits/cephtool/test.sh: line 1607: [: 2017-06-20 04:44:52.862459 ffffad4d0200 -1 asok(0xffffa8000b10) AdminSocketConfigObs::init: failed: AdminSocket::bind_and_listen: The UNIX domain socket path /home/jenkins-build/build/workspace/ceph-pull-requests-arm64/build/src/test/td/t-7202/out/client.admin.48876.asok is too long! The maximum length on this system is 107
12: integer expression expected

Signed-off-by: Kefu Chai <kchai@redhat.com>