### PR TITLE
rgw: fix complained about buckets created in other zonegroup

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5893,17 +5893,8 @@ int RGWRados::select_bucket_location_by_rule(const string& location_rule, RGWZon
    * reside.
    */
   map<string, RGWZonePlacementInfo>::iterator piter = get_zone_params().placement_pools.find(location_rule);
-  if (piter == get_zone_params().placement_pools.end()) {
-    /* couldn't find, means we cannot really place data for this bucket in this zone */
-    if (get_zonegroup().equals(zonegroup_id)) {
-      /* that's a configuration error, zone should have that rule, as we're within the requested
-       * zonegroup */
-      return -EINVAL;
-    } else {
-      /* oh, well, data is not going to be placed here, bucket object is just a placeholder */
-      return 0;
-    }
-  }
+  if (piter == get_zone_params().placement_pools.end()) 
+    return -EINVAL;
 
   RGWZonePlacementInfo& placement_info = piter->second;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2313,7 +2313,6 @@ protected:
 
   bool pools_initialized;
 
-  string zonegroup_id;
   string zone_name;
   string trans_id_suffix;
 


### PR DESCRIPTION
1. when display a bucket created in other zonegroup, we shouldn't
try to display the info stored in bucket index, given local rados
cluster doesn't have it.

I create a bucket in master zonegroup specified a placement rule that slave zonegroup doesn't have, then I do radosgw-admin bucket stats in slave zonegroup, it complained as below:

error getting bucket stats ret=-22
2017-06-20 15:13:25.417600 7ffff7fc99c0  0 could not find placement rule head-tail-sperate within zonegroup 

2.meta sync complained:
2017-06-21 03:34:33.533241 7fc2a56f9700  0 could not find placement rule head-tail-sperate within zonegroup
2017-06-21 03:34:33.533283 7fc2a56f9700  0 meta sync: ERROR: can't store key: bucket.instance:master_b1:9566b5b3-997f-4348-a543-9e028a4c2980.4604936.1 ret=-22

cause meta sync in "behind" state:
[root@t-20 build]#  radosgw-admin sync status -n client.radosgw.t-20
          realm 528d4613-1069-4691-b559-a3e818d5314d (default_realm)
      zonegroup 9910e7f6-4c7f-43cb-90a7-d1b71fcee61f (slave)
           zone c7c01e16-6a3b-4d04-af89-14c2211dbd2f (slave)
  metadata sync syncing
                full sync: 0/64 shards
                incremental sync: 64/64 shards
                **metadata is behind on 1 shards**
                oldest incremental change not applied: 2017-06-20 14:09:23.0.230747s
      data sync source: 9566b5b3-997f-4348-a543-9e028a4c2980 (master)
                        syncing
                        full sync: 0/128 shards
                        incremental sync: 128/128 shards
                        data is caught up with source
