### PR TITLE
ceph-disk: switch sgdisk to parted to support 2T partition 

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1666,7 +1666,7 @@ class Device(object):
         if num == 0:
             num = get_free_partition_index(dev=self.path)
         if size > 0:
-            new = '--new={num}:0:+{size}M'.format(num=num, size=size)
+            end = '{size}M'.format(size=size)
             if size > self.get_dev_size():
                 LOG.error('refusing to create %s on %s' % (name, self.path))
                 LOG.error('%s size (%sM) is bigger than device (%sM)'
@@ -1674,18 +1674,25 @@ class Device(object):
                 raise Error('%s device size (%sM) is not big enough for %s'
                             % (self.path, self.get_dev_size(), name))
         else:
-            new = '--largest-new={num}'.format(num=num)
+            end = '100%'
 
         LOG.debug('Creating %s partition num %d size %d on %s',
                   name, num, size, self.path)
         command_check_call(
             [
+               'parted',
+               self.path,
+               'mkpart',
+               '{num}:ceph {name}'.format(num=num, name=name),
+               '0:{end}'.format(end=end)
+            ],
+            exit=True
+        )
+        command_check_call(
+            [
                 'sgdisk',
-                new,
-                '--change-name={num}:ceph {name}'.format(num=num, name=name),
                 '--partition-guid={num}:{uuid}'.format(num=num, uuid=uuid),
                 '--typecode={num}:{uuid}'.format(num=num, uuid=ptype),
-                '--mbrtogpt',
                 '--',
                 self.path,
             ],

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -1674,17 +1674,17 @@ class Device(object):
                 raise Error('%s device size (%sM) is not big enough for %s'
                             % (self.path, self.get_dev_size(), name))
         else:
-            end = '100%'
+            end = '100%%'
 
         LOG.debug('Creating %s partition num %d size %d on %s',
                   name, num, size, self.path)
         command_check_call(
             [
-               'parted',
-               self.path,
-               'mkpart',
-               '{num}:ceph {name}'.format(num=num, name=name),
-               '0:{end}'.format(end=end)
+                'parted',
+                self.path,
+                'mkpart',
+                '{num}:ceph {name}'.format(num=num, name=name),
+                '0:{end}'.format(end=end),
             ],
             exit=True
         )

--- a/src/ceph-disk/tests/test_prepare.py
+++ b/src/ceph-disk/tests/test_prepare.py
@@ -175,26 +175,22 @@ class TestDevice(Base):
             uuid=uuid, name=name, size=size)
         assert actual_partition_number == partition_number
         command = ['sgdisk',
-                   '--new=%d:0:+%dM' % (partition_number, size),
-                   '--change-name=%d:ceph %s' % (partition_number, name),
                    '--partition-guid=%d:%s' % (partition_number, uuid),
                    '--typecode=%d:%s' % (
                        partition_number,
                        main.PTYPE['regular']['journal']['ready']),
-                   '--mbrtogpt', '--', path]
+                   '--', path]
         m_command_check_call.assert_called_with(command, exit=True)
         m_update_partition.assert_called_with(path, 'created')
 
         actual_partition_number = device.create_partition(
             uuid=uuid, name=name)
         command = ['sgdisk',
-                   '--largest-new=%d' % partition_number,
-                   '--change-name=%d:ceph %s' % (partition_number, name),
                    '--partition-guid=%d:%s' % (partition_number, uuid),
                    '--typecode=%d:%s' % (
                        partition_number,
                        main.PTYPE['regular']['journal']['ready']),
-                   '--mbrtogpt', '--', path]
+                   '--', path]
         m_command_check_call.assert_called_with(command, exit=True)
 
 


### PR DESCRIPTION
Switch sgdisk to parted when create a new disk partition to support partition bigger than 2T. Also keep the sgdisk command for partition-guid and typecode.
Signed-off-by: Erqi Chen bestchenerqi@126.com