### PR TITLE
qa/workunits/rados/test-upgrade-*: whitelist tests for master

### DIFF
--- a/qa/workunits/rados/test-upgrade-v11.0.0.sh
+++ b/qa/workunits/rados/test-upgrade-v11.0.0.sh
@@ -17,7 +17,7 @@ for f in \
     'api_list --gtest_filter=-LibRadosList*.EnumerateObjects*' \
     'api_io --gtest_filter=-*Checksum*' \
     api_lock \
-    'api_misc --gtest_filter=-*WriteSame*:-*CmpExt*:-*Checksum*' \
+    'api_misc --gtest_filter=-*WriteSame*:-*CmpExt*:-*Checksum*:-*CloneRange*' \
     'api_watch_notify --gtest_filter=-*WatchNotify3*' \
     api_tier api_pool api_snapshots api_stat api_cmd \
     'api_c_write_operations --gtest_filter=-*WriteSame*' \


### PR DESCRIPTION
The jewel-x upgrade test now runs this script against a mixed cluster on
a machine with code from master installed.  That means we have to
skip any new tests that will fail on a mixed cluster. CloneRange was
removed in 0d7b0b7.

Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflicts:
    qa/workunits/rados/test-upgrade-v11.0.0.sh: this change is not
cherry-picked from master, because the clone-range op was removed from
master. and only supported in pre-luminous releases.