### PR TITLE
core: make the conversion from wire error to host OS work

### DIFF
--- a/src/common/freebsd_errno.cc
+++ b/src/common/freebsd_errno.cc
@@ -201,7 +201,7 @@ __s32 ceph_to_hostos_errno(__s32 r)
 {
   int sign = (r < 0 ? -1 : 1);
   int err = std::abs(r);
-  if (err < 256 && hostos_to_ceph_conv[err] !=0 ) {
+  if (err < 256 && ceph_to_hostos_conv[err] !=0 ) {
     err = ceph_to_hostos_conv[err];
   }
   return err * sign;

--- a/src/include/types.h
+++ b/src/include/types.h
@@ -489,10 +489,13 @@ struct errorcode32_t {
   // cppcheck-suppress noExplicitConstructor
   errorcode32_t(int32_t i) : code(i) {}
 
-  operator int() const { return code; }
-  int operator==(int i) {
-    return code==i;
-  }
+  operator int() const  { return code; }
+  int* operator&()      { return &code; }
+  int operator==(int i) { return code == i; }
+  int operator>(int i)  { return code > i; }
+  int operator>=(int i) { return code >= i; }
+  int operator<(int i)  { return code < i; }
+  int operator<=(int i) { return code <= i; }
 
   void encode(bufferlist &bl) const {
     __s32 newcode = hostos_to_ceph_errno(code);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4797,7 +4797,7 @@ struct OSDOp {
   sobject_t soid;
 
   bufferlist indata, outdata;
-  int32_t rval;
+  errorcode32_t rval;
 
   OSDOp() : rval(0) {
     memset(&op, 0, sizeof(ceph_osd_op));


### PR DESCRIPTION
- The key change is the type of rval,
   that will call the conversion when en/decoded
 - Remainder is fixes for the type change

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>