### PR TITLE
vstart: add rgw configuration needed to pass all s3tests

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -411,6 +411,11 @@ prepare_conf() {
         plugin dir = $CEPH_LIB
         osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd
         rgw frontends = $rgw_frontend port=$CEPH_RGW_PORT
+        ; needed for s3tests
+        rgw enable static website = 1
+        rgw crypt s3 kms encryption keys = testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl = false
+        rgw lc debug interval = 10
         filestore fd cache size = 32
         run dir = $CEPH_OUT_DIR
         enable experimental unrecoverable data corrupting features = *


### PR DESCRIPTION
these configuration variables are needed to pass the lifecycle and encryption tests in the master branch of s3tests