### PR TITLE
Revert "qa: do not restrict valgrind runs to centos"

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -5,6 +5,7 @@ overrides:
     log-whitelist:
       - slow requests are blocked
 
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/qa/suites/rbd/valgrind/validator/memcheck.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/qa/suites/rgw/verify/tasks/rgw_swift.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_swift.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -1,3 +1,4 @@
+os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:


### PR DESCRIPTION
This reverts commit 5923961465e1efd3cc6bc072fef293dda3d975d0.

See http://tracker.ceph.com/issues/20360

Signed-off-by: Sage Weil <sage@redhat.com>