### PR TITLE
fio_ceph_objectstore: Print db_statistics when rocksdb_perf is enabled

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -87,10 +87,16 @@ struct Engine {
       ostringstream ostr;
       Formatter* f = Formatter::create("json-pretty", "json-pretty", "json-pretty");
       os->dump_perf_counters(f);
+      ostr << "FIO plugin ";
       f->flush(ostr);
+      if (g_conf->rocksdb_perf) {
+        os->get_db_statistics(f);
+        ostr << "FIO get_db_statistics ";
+        f->flush(ostr);
+      }
       delete f;
       os->umount();
-      dout(0) << "FIO plugin " << ostr.str() << dendl;
+      dout(0) <<  ostr.str() << dendl;
     }
   }
 };


### PR DESCRIPTION
Currently users can't use ceph admin command to get db stats
when running bluestore fio plugin. This patch is to print db stats
when rocksdb_perf is set in config file.

Signed-off-by: Xiaoyan Li <xiaoyan.li@intel.com>