### PR TITLE
RFC rgw: bucket placement cleanup

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4187,7 +4187,7 @@ int main(int argc, const char **argv)
             return EINVAL;
           }
 
-          RGWZonePlacementInfo& info = zone.placement_pools[placement_id];
+          RGWZonePlacementInfo& info = zone.placement_rules[placement_id];
 
           info.index_pool = *index_pool;
           info.data_pool = *data_pool;
@@ -4201,8 +4201,8 @@ int main(int argc, const char **argv)
             info.compression_type = *compression_type;
           }
         } else if (opt_cmd == OPT_ZONE_PLACEMENT_MODIFY) {
-          auto p = zone.placement_pools.find(placement_id);
-          if (p == zone.placement_pools.end()) {
+          auto p = zone.placement_rules.find(placement_id);
+          if (p == zone.placement_rules.end()) {
             cerr << "ERROR: zone placement target '" << placement_id
                 << "' not found" << std::endl;
             return -ENOENT;
@@ -4224,7 +4224,7 @@ int main(int argc, const char **argv)
             info.compression_type = *compression_type;
           }
         } else if (opt_cmd == OPT_ZONE_PLACEMENT_RM) {
-          zone.placement_pools.erase(placement_id);
+          zone.placement_rules.erase(placement_id);
         }
 
         ret = zone.update();
@@ -4245,7 +4245,7 @@ int main(int argc, const char **argv)
 	  cerr << "unable to initialize zone: " << cpp_strerror(-ret) << std::endl;
 	  return -ret;
 	}
-	encode_json("placement_pools", zone.placement_pools, formatter);
+	encode_json("placement_rules", zone.placement_rules, formatter);
 	formatter->flush(cout);
       }
       break;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3743,7 +3743,7 @@ int main(int argc, const char **argv)
 
         if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_ADD) {
           RGWZoneGroupPlacementTarget target;
-          target.name = placement_id;
+          target.id = placement_id;
           for (auto& t : tags) {
             target.tags.insert(t);
           }
@@ -3756,7 +3756,7 @@ int main(int argc, const char **argv)
               target.tags.insert(t);
             }
           }
-          target.name = placement_id;
+          target.id = placement_id;
           for (auto& t : tags_rm) {
             target.tags.erase(t);
           }
@@ -3767,7 +3767,7 @@ int main(int argc, const char **argv)
           zonegroup.placement_targets.erase(placement_id);
         } else if (opt_cmd == OPT_ZONEGROUP_PLACEMENT_DEFAULT) {
           if (!zonegroup.placement_targets.count(placement_id)) {
-            cerr << "failed to find a zonegroup placement target named '"
+            cerr << "failed to find a zonegroup placement target id '"
                 << placement_id << "'" << std::endl;
             return -ENOENT;
           }

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -136,10 +136,10 @@ void _usage()
   cout << "  zone set                   set zone cluster params (requires infile)\n";
   cout << "  zone list                  list all zones set on this cluster\n";
   cout << "  zone rename                rename a zone\n";
-  cout << "  zone placement list        list zone's placement targets\n";
-  cout << "  zone placement add         add a zone placement target\n";
-  cout << "  zone placement modify      modify a zone placement target\n";
-  cout << "  zone placement rm          remove a zone placement target\n";
+  cout << "  zone placement list        list zone's placement rules\n";
+  cout << "  zone placement add         add a zone placement rule\n";
+  cout << "  zone placement modify      modify a zone placement rule\n";
+  cout << "  zone placement rm          remove a zone placement rule\n";
   cout << "  pool add                   add an existing pool for data placement\n";
   cout << "  pool rm                    remove an existing pool from data placement set\n";
   cout << "  pools list                 list placement active set\n";
@@ -247,17 +247,17 @@ void _usage()
   cout << "   --source-zone             specify the source zone (for data sync)\n";
   cout << "   --default                 set entity (realm, zonegroup, zone) as default\n";
   cout << "   --read-only               set zone as read-only (when adding to zonegroup)\n";
-  cout << "   --placement-id            placement id for zonegroup placement commands\n";
+  cout << "   --placement-id            placement rule id for zonegroup/zone placement commands\n";
   cout << "   --tags=<list>             list of tags for zonegroup placement add and modify commands\n";
   cout << "   --tags-add=<list>         list of tags to add for zonegroup placement modify command\n";
   cout << "   --tags-rm=<list>          list of tags to remove for zonegroup placement modify command\n";
   cout << "   --endpoints=<list>        zone endpoints\n";
-  cout << "   --index_pool=<pool>       placement target index pool\n";
-  cout << "   --data-pool=<pool>        placement target data pool\n";
-  cout << "   --data-extra-pool=<pool>  placement target data extra (non-ec) pool\n";
+  cout << "   --index-pool=<pool>       placement rule index pool for zone placement commands\n";
+  cout << "   --data-pool=<pool>        placement rule data pool for zone placement commands\n";
+  cout << "   --data-extra-pool=<pool>  placement rule data extra (non-ec) pool for zone placement commands\n";
   cout << "   --placement-index-type=<type>\n";
-  cout << "                             placement target index type (normal, indexless, or #id)\n";
-  cout << "   --compression=<type>      placement target compression type (plugin name or empty/none)\n";
+  cout << "                             placement rule index type (normal, indexless, or #id) for zone placement commands\n";
+  cout << "   --compression=<type>      placement rule compression type (plugin name or empty/none) for zone placement commands\n";
   cout << "   --tier-type=<type>        zone tier type\n";
   cout << "   --tier-config=<k>=<v>[,...]\n";
   cout << "                             set zone tier config keys, values\n";
@@ -4203,8 +4203,8 @@ int main(int argc, const char **argv)
         } else if (opt_cmd == OPT_ZONE_PLACEMENT_MODIFY) {
           auto p = zone.placement_rules.find(placement_id);
           if (p == zone.placement_rules.end()) {
-            cerr << "ERROR: zone placement target '" << placement_id
-                << "' not found" << std::endl;
+            cerr << "failed to find a zone placement id '"
+                 << placement_id << "'" << std::endl;
             return -ENOENT;
           }
           auto& info = p->second;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3771,7 +3771,7 @@ int main(int argc, const char **argv)
                 << placement_id << "'" << std::endl;
             return -ENOENT;
           }
-          zonegroup.default_placement = placement_id;
+          zonegroup.default_placement_id = placement_id;
         }
 
         zonegroup.post_process_params();

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2230,16 +2230,16 @@ public:
       string bucket_instance;
       parse_bucket(key, &tenant_name, &bucket_name, &bucket_instance);
 
-      RGWZonePlacementInfo rule_info;
+      RGWZonePlacementInfo placement_info;
       bci.info.bucket.name = bucket_name;
       bci.info.bucket.bucket_id = bucket_instance;
       bci.info.bucket.tenant = tenant_name;
-      ret = store->select_bucket_location_by_rule(bci.info.default_placement_id, &rule_info);
+      ret = store->select_bucket_placement_info(bci.info.default_placement_id, &placement_info);
       if (ret < 0) {
-        ldout(store->ctx(), 0) << "ERROR: select_bucket_location_by_rule() returned " << ret << dendl;
+        ldout(store->ctx(), 0) << "ERROR: select_bucket_placement_info() returned " << ret << dendl;
         return ret;
       }
-      bci.info.index_type = rule_info.index_type;
+      bci.info.index_type = placement_info.index_type;
     } else {
       /* existing bucket, keep its placement */
       bci.info.bucket.explicit_placement = old_bci.info.bucket.explicit_placement;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2234,9 +2234,9 @@ public:
       bci.info.bucket.name = bucket_name;
       bci.info.bucket.bucket_id = bucket_instance;
       bci.info.bucket.tenant = tenant_name;
-      ret = store->select_bucket_placement_info(bci.info.default_placement_id, &placement_info);
+      ret = store->get_bucket_placement_info(bci.info.default_placement_id, &placement_info);
       if (ret < 0) {
-        ldout(store->ctx(), 0) << "ERROR: select_bucket_placement_info() returned " << ret << dendl;
+        ldout(store->ctx(), 0) << "ERROR: get_bucket_placement_info() returned " << ret << dendl;
         return ret;
       }
       bci.info.index_type = placement_info.index_type;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2236,7 +2236,7 @@ public:
       bci.info.bucket.tenant = tenant_name;
       ret = store->select_bucket_location_by_rule(bci.info.placement_rule, &rule_info);
       if (ret < 0) {
-        ldout(store->ctx(), 0) << "ERROR: select_bucket_placement() returned " << ret << dendl;
+        ldout(store->ctx(), 0) << "ERROR: select_bucket_location_by_rule() returned " << ret << dendl;
         return ret;
       }
       bci.info.index_type = rule_info.index_type;

--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -657,7 +657,7 @@ int rgw_remove_bucket_bypass_gc(RGWRados *store, rgw_bucket& bucket,
         RGWObjManifest::obj_iterator miter = manifest.obj_begin();
         rgw_obj head_obj = manifest.get_obj();
         rgw_raw_obj raw_head_obj;
-        store->obj_to_raw(info.placement_rule, head_obj, &raw_head_obj);
+        store->obj_to_raw(info.default_placement_id, head_obj, &raw_head_obj);
 
 
         for (; miter != manifest.obj_end() && max_aio--; ++miter) {
@@ -1374,7 +1374,7 @@ static int bucket_stats(RGWRados *store, const std::string& tenant_name, std::st
   formatter->open_object_section("stats");
   formatter->dump_string("bucket", bucket.name);
   formatter->dump_string("zonegroup", bucket_info.zonegroup);
-  formatter->dump_string("placement_rule", bucket_info.placement_rule);
+  formatter->dump_string("default_placement_id", bucket_info.default_placement_id);
   ::encode_json("explicit_placement", bucket.explicit_placement, formatter);
   formatter->dump_string("id", bucket.bucket_id);
   formatter->dump_string("marker", bucket.marker);
@@ -2234,7 +2234,7 @@ public:
       bci.info.bucket.name = bucket_name;
       bci.info.bucket.bucket_id = bucket_instance;
       bci.info.bucket.tenant = tenant_name;
-      ret = store->select_bucket_location_by_rule(bci.info.placement_rule, &rule_info);
+      ret = store->select_bucket_location_by_rule(bci.info.default_placement_id, &rule_info);
       if (ret < 0) {
         ldout(store->ctx(), 0) << "ERROR: select_bucket_location_by_rule() returned " << ret << dendl;
         return ret;
@@ -2243,7 +2243,7 @@ public:
     } else {
       /* existing bucket, keep its placement */
       bci.info.bucket.explicit_placement = old_bci.info.bucket.explicit_placement;
-      bci.info.placement_rule = old_bci.info.placement_rule;
+      bci.info.default_placement_id = old_bci.info.default_placement_id;
     }
 
     // are we actually going to perform this put, or is it too old?

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -612,7 +612,7 @@ struct RGWUserInfo
   RGWUserCaps caps;
   __u8 admin;
   __u8 system;
-  string default_placement;
+  std::string default_placement_id;
   list<string> placement_tags;
   RGWQuotaInfo bucket_quota;
   map<int, string> temp_url_keys;
@@ -670,7 +670,7 @@ struct RGWUserInfo
      ::encode(caps, bl);
      ::encode(op_mask, bl);
      ::encode(system, bl);
-     ::encode(default_placement, bl);
+     ::encode(default_placement_id, bl);
      ::encode(placement_tags, bl);
      ::encode(bucket_quota, bl);
      ::encode(temp_url_keys, bl);
@@ -731,7 +731,7 @@ struct RGWUserInfo
     }
     if (struct_v >= 13) {
       ::decode(system, bl);
-      ::decode(default_placement, bl);
+      ::decode(default_placement_id, bl);
       ::decode(placement_tags, bl); /* tags of allowed placement rules */
     }
     if (struct_v >= 14) {

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1167,7 +1167,7 @@ struct RGWBucketInfo
   uint32_t flags;
   string zonegroup;
   ceph::real_time creation_time;
-  string placement_rule;
+  std::string default_placement_id;
   bool has_instance_obj;
   RGWObjVersionTracker objv_tracker; /* we don't need to serialize this, for runtime tracking */
   obj_version ep_objv; /* entry point object version, for runtime tracking only */
@@ -1209,7 +1209,7 @@ struct RGWBucketInfo
      ::encode(zonegroup, bl);
      uint64_t ct = real_clock::to_time_t(creation_time);
      ::encode(ct, bl);
-     ::encode(placement_rule, bl);
+     ::encode(default_placement_id, bl);
      ::encode(has_instance_obj, bl);
      ::encode(quota, bl);
      ::encode(num_shards, bl);
@@ -1250,7 +1250,7 @@ struct RGWBucketInfo
 	 creation_time = ceph::real_clock::from_time_t((time_t)ct);
      }
      if (struct_v >= 7)
-       ::decode(placement_rule, bl);
+       ::decode(default_placement_id, bl);
      if (struct_v >= 8)
        ::decode(has_instance_obj, bl);
      if (struct_v >= 9)

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -784,7 +784,7 @@ int RGWSyncLogTrimCR::request_complete()
 int RGWAsyncStatObj::_send_request()
 {
   rgw_raw_obj raw_obj;
-  store->obj_to_raw(bucket_info.placement_rule, obj, &raw_obj);
+  store->obj_to_raw(bucket_info.default_placement_id, obj, &raw_obj);
   return store->raw_obj_stat(raw_obj, psize, pmtime, pepoch,
                              nullptr, nullptr, objv_tracker);
 }

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -1011,7 +1011,7 @@ void RGWZoneGroup::dump(Formatter *f) const
   encode_json("master_zone", master_zone, f);
   encode_json_map("zones", zones, f); /* more friendly representation */
   encode_json_map("placement_targets", placement_targets, f); /* more friendly representation */
-  encode_json("default_placement", default_placement, f);
+  encode_json("default_placement_id", default_placement_id, f);
   encode_json("realm_id", realm_id, f);
 }
 
@@ -1046,10 +1046,9 @@ void RGWZoneGroup::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("master_zone", master_zone, obj);
   JSONDecoder::decode_json("zones", zones, decode_zones, obj);
   JSONDecoder::decode_json("placement_targets", placement_targets, decode_placement_targets, obj);
-  JSONDecoder::decode_json("default_placement", default_placement, obj);
+  JSONDecoder::decode_json("default_placement_id", default_placement_id, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);
 }
-
 
 void RGWPeriodMap::dump(Formatter *f) const
 {

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -729,7 +729,7 @@ void RGWBucketInfo::dump(Formatter *f) const
   encode_json("owner", owner.to_str(), f);
   encode_json("flags", flags, f);
   encode_json("zonegroup", zonegroup, f);
-  encode_json("placement_rule", placement_rule, f);
+  encode_json("default_placement_id", default_placement_id, f);
   encode_json("has_instance_obj", has_instance_obj, f);
   encode_json("quota", quota, f);
   encode_json("num_shards", num_shards, f);
@@ -759,7 +759,7 @@ void RGWBucketInfo::decode_json(JSONObj *obj) {
   if (zonegroup.empty()) {
     JSONDecoder::decode_json("region", zonegroup, obj);
   }
-  JSONDecoder::decode_json("placement_rule", placement_rule, obj);
+  JSONDecoder::decode_json("default_placement_id", default_placement_id, obj);
   JSONDecoder::decode_json("has_instance_obj", has_instance_obj, obj);
   JSONDecoder::decode_json("quota", quota, obj);
   JSONDecoder::decode_json("num_shards", num_shards, obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -448,7 +448,7 @@ void RGWUserInfo::dump(Formatter *f) const
   if (system) { /* no need to show it for every user */
     encode_json("system", (bool)system, f);
   }
-  encode_json("default_placement", default_placement, f);
+  encode_json("default_placement_id", default_placement_id, f);
   encode_json("placement_tags", placement_tags, f);
   encode_json("bucket_quota", bucket_quota, f);
   encode_json("user_quota", user_quota, f);
@@ -525,7 +525,7 @@ void RGWUserInfo::decode_json(JSONObj *obj)
   bool sys = false;
   JSONDecoder::decode_json("system", sys, obj);
   system = (__u8)sys;
-  JSONDecoder::decode_json("default_placement", default_placement, obj);
+  JSONDecoder::decode_json("default_placement_id", default_placement_id, obj);
   JSONDecoder::decode_json("placement_tags", placement_tags, obj);
   JSONDecoder::decode_json("bucket_quota", bucket_quota, obj);
   JSONDecoder::decode_json("user_quota", user_quota, obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -909,7 +909,7 @@ void RGWZoneParams::dump(Formatter *f) const
   encode_json("user_swift_pool", user_swift_pool, f);
   encode_json("user_uid_pool", user_uid_pool, f);
   encode_json_plain("system_key", system_key, f);
-  encode_json("placement_pools", placement_pools, f);
+  encode_json("placement_rules", placement_rules, f);
   encode_json("metadata_heap", metadata_heap, f);
   encode_json("tier_config", tier_config, f);
   encode_json("realm_id", realm_id, f);
@@ -950,7 +950,7 @@ void RGWZoneParams::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("user_swift_pool", user_swift_pool, obj);
   JSONDecoder::decode_json("user_uid_pool", user_uid_pool, obj);
   JSONDecoder::decode_json("system_key", system_key, obj);
-  JSONDecoder::decode_json("placement_pools", placement_pools, obj);
+  JSONDecoder::decode_json("placement_rules", placement_rules, obj);
   JSONDecoder::decode_json("metadata_heap", metadata_heap, obj);
   JSONDecoder::decode_json("tier_config", tier_config, obj);
   JSONDecoder::decode_json("realm_id", realm_id, obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -990,13 +990,13 @@ void RGWZone::decode_json(JSONObj *obj)
 
 void RGWZoneGroupPlacementTarget::dump(Formatter *f) const
 {
-  encode_json("name", name, f);
+  encode_json("id", id, f);
   encode_json("tags", tags, f);
 }
 
 void RGWZoneGroupPlacementTarget::decode_json(JSONObj *obj)
 {
-  JSONDecoder::decode_json("name", name, obj);
+  JSONDecoder::decode_json("id", id, obj);
   JSONDecoder::decode_json("tags", tags, obj);
 }
 
@@ -1026,7 +1026,7 @@ static void decode_placement_targets(map<string, RGWZoneGroupPlacementTarget>& t
 {
   RGWZoneGroupPlacementTarget t;
   t.decode_json(o);
-  targets[t.name] = t;
+  targets[t.id] = t;
 }
 
 

--- a/src/rgw/rgw_multi.cc
+++ b/src/rgw/rgw_multi.cc
@@ -89,7 +89,7 @@ int list_multipart_parts(RGWRados *store, RGWBucketInfo& bucket_info, CephContex
   obj.set_in_extra_data(true);
 
   rgw_raw_obj raw_obj;
-  store->obj_to_raw(bucket_info.placement_rule, obj, &raw_obj);
+  store->obj_to_raw(bucket_info.default_placement_id, obj, &raw_obj);
 
   bool sorted_omap = is_v2_upload_id(upload_id) && !assume_unsorted;
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2524,6 +2524,17 @@ void RGWCreateBucket::execute()
     return;
   }
 
+  if(!requested_placement_id.empty()) {
+    if (!store->get_zonegroup().has_placement_target(requested_placement_id)) {
+      ldout(s->cct, 0) << "placement target (" << requested_placement_id << ")"
+                       << " doesn't exist in the placement targets of zonegroup"
+		       << " (" << store->get_zonegroup().api_name << ")" << dendl;
+      op_ret = -ERR_INVALID_LOCATION_CONSTRAINT;
+      s->err.message = "The specified placement target does not exist";
+      return;
+    }
+  }
+
   /* we need to make sure we read bucket info, it's not read before for this
    * specific request */
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3955,6 +3955,13 @@ void RGWPutMetadataObject::execute()
   }
 
   rgw_get_request_metadata(s->cct, s->info, attrs);
+
+  if (!requested_placement_id.empty() &&
+      requested_placement_id != s->bucket_info.default_placement_id) {
+    op_ret = -EEXIST;
+    return;
+  }
+
   /* check if obj exists, read orig attrs */
   op_ret = get_obj_attrs(store, s, obj, orig_attrs);
   if (op_ret < 0) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2584,14 +2584,15 @@ void RGWCreateBucket::execute()
   }
 
   if (s->bucket_exists) {
-    string selected_placement_rule;
+    std::string selected_placement_id;
     rgw_bucket bucket;
     bucket.tenant = s->bucket_tenant;
     bucket.name = s->bucket_name;
     op_ret = store->select_bucket_placement(*(s->user), zonegroup_id,
-					    placement_rule,
-					    &selected_placement_rule, nullptr);
-    if (selected_placement_rule != s->bucket_info.default_placement_id) {
+                                            requested_placement_id,
+                                            &selected_placement_id, 
+                                            nullptr);
+    if (selected_placement_id != s->bucket_info.default_placement_id) {
       op_ret = -EEXIST;
       return;
     }
@@ -2639,7 +2640,7 @@ void RGWCreateBucket::execute()
   }
 
   op_ret = store->create_bucket(*(s->user), s->bucket, zonegroup_id,
-                                placement_rule, s->bucket_info.swift_ver_location,
+                                requested_placement_id, s->bucket_info.swift_ver_location,
                                 pquota_info, attrs,
                                 info, pobjv, &ep_objv, creation_time,
                                 pmaster_bucket, pmaster_num_shards, true);
@@ -5961,18 +5962,18 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
   }
 
 
-  std::string placement_rule;
+  std::string requested_placement_id;
   if (bucket_exists) {
-    std::string selected_placement_rule;
+    std::string selected_placement_id;
     rgw_bucket bucket;
     bucket.tenant = s->bucket_tenant;
     bucket.name = s->bucket_name;
     op_ret = store->select_bucket_placement(*(s->user),
                                             store->get_zonegroup().get_id(),
-                                            placement_rule,
-                                            &selected_placement_rule,
+                                            requested_placement_id,
+                                            &selected_placement_id,
                                             nullptr);
-    if (selected_placement_rule != binfo.default_placement_id) {
+    if (selected_placement_id != binfo.default_placement_id) {
       op_ret = -EEXIST;
       ldout(s->cct, 20) << "bulk upload: non-coherent placement rule" << dendl;
       return op_ret;
@@ -5999,7 +6000,7 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
   op_ret = store->create_bucket(*(s->user),
                                 bucket,
                                 store->get_zonegroup().get_id(),
-                                placement_rule, binfo.swift_ver_location,
+                                requested_placement_id, binfo.swift_ver_location,
                                 pquota_info, attrs,
                                 out_info, pobjv, &ep_objv, creation_time,
                                 pmaster_bucket, pmaster_num_shards, true);

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3870,8 +3870,8 @@ void RGWPutMetadataBucket::execute()
 
   rgw_get_request_metadata(s->cct, s->info, attrs, false);
 
-  if (!placement_rule.empty() &&
-      placement_rule != s->bucket_info.default_placement_id) {
+  if (!requested_placement_id.empty() &&
+      requested_placement_id != s->bucket_info.default_placement_id) {
     op_ret = -EEXIST;
     return;
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2588,10 +2588,9 @@ void RGWCreateBucket::execute()
     rgw_bucket bucket;
     bucket.tenant = s->bucket_tenant;
     bucket.name = s->bucket_name;
-    op_ret = store->select_bucket_placement(*(s->user), zonegroup_id,
+    op_ret = store->select_bucket_placement_id(*(s->user), zonegroup_id,
                                             requested_placement_id,
-                                            &selected_placement_id, 
-                                            nullptr);
+                                            &selected_placement_id);
     if (selected_placement_id != s->bucket_info.default_placement_id) {
       op_ret = -EEXIST;
       return;
@@ -5968,11 +5967,10 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
     rgw_bucket bucket;
     bucket.tenant = s->bucket_tenant;
     bucket.name = s->bucket_name;
-    op_ret = store->select_bucket_placement(*(s->user),
-                                            store->get_zonegroup().get_id(),
-                                            requested_placement_id,
-                                            &selected_placement_id,
-                                            nullptr);
+    op_ret = store->select_bucket_placement_id(*(s->user),
+                                               store->get_zonegroup().get_id(),
+                                               requested_placement_id,
+                                               &selected_placement_id);
     if (selected_placement_id != binfo.default_placement_id) {
       op_ret = -EEXIST;
       ldout(s->cct, 20) << "bulk upload: non-coherent placement rule" << dendl;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1162,7 +1162,7 @@ protected:
   uint32_t policy_rw_mask;
   RGWAccessControlPolicy policy;
   RGWCORSConfiguration cors_config;
-  string placement_rule;
+  std::string requested_placement_id;
   boost::optional<std::string> swift_ver_location;
 
 public:

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1193,7 +1193,7 @@ public:
 class RGWPutMetadataObject : public RGWOp {
 protected:
   RGWAccessControlPolicy policy;
-  string placement_rule;
+  std::string requested_placement_id;
   boost::optional<ceph::real_time> delete_at;
   const char *dlo_manifest;
 

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -845,7 +845,7 @@ class RGWCreateBucket : public RGWOp {
 protected:
   RGWAccessControlPolicy policy;
   string location_constraint;
-  string placement_rule;
+  std::string requested_placement_id;
   RGWBucketInfo info;
   obj_version ep_objv;
   bool has_cors;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -122,15 +122,15 @@ static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZonePa
                                   const string& placement_id, const rgw_obj& obj, rgw_pool *pool)
 {
   if (!zone_params.get_head_data_pool(placement_id, obj, pool)) {
-    RGWZonePlacementInfo placement;
-    if (!zone_params.get_placement(zonegroup.default_placement_id, &placement)) {
+    RGWZonePlacementInfo placement_info;
+    if (!zone_params.get_placement_info(zonegroup.default_placement_id, &placement_info)) {
       return false;
     }
 
     if (!obj.in_extra_data) {
-      *pool = placement.data_pool;
+      *pool = placement_info.data_pool;
     } else {
-      *pool = placement.get_data_extra_pool();
+      *pool = placement_info.get_data_extra_pool();
     }
   }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1715,11 +1715,11 @@ int RGWZoneParams::create(bool exclusive)
   if (r < 0) {
     ldout(store->ctx(), 10) << "couldn't find old placement rules, setting up default one for the zone" << dendl;
     /* a new system, let's set new placement info */
-    RGWZonePlacementInfo default_placement;
-    default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
-    default_placement.data_pool =  name + "." + default_storage_pool_suffix;
-    default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
-    placement_rules["default-placement-id"] = default_placement;
+    RGWZonePlacementInfo default_placement_info;
+    default_placement_info.index_pool = name + "." + default_bucket_index_pool_suffix;
+    default_placement_info.data_pool =  name + "." + default_storage_pool_suffix;
+    default_placement_info.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
+    placement_rules["default-placement-id"] = default_placement_info;
   }
 
   r = fix_pool_names();

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1830,10 +1830,10 @@ int RGWZoneParams::set_as_default(bool exclusive)
   return RGWSystemMetaObj::set_as_default(exclusive);
 }
 
-const string& RGWZoneParams::get_compression_type(const string& placement_rule) const
+const string& RGWZoneParams::get_compression_type(const string& placement_id) const
 {
   static const std::string NONE{"none"};
-  auto p = placement_rules.find(placement_rule);
+  auto p = placement_rules.find(placement_id);
   if (p == placement_rules.end()) {
     return NONE;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5736,13 +5736,13 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
 			    bool exclusive)
 {
 #define MAX_CREATE_RETRIES 20 /* need to bound retries */
-  string selected_placement_rule_name;
+  std::string selected_placement_id;
   RGWZonePlacementInfo rule_info;
 
   for (int i = 0; i < MAX_CREATE_RETRIES; i++) {
     int ret = 0;
     ret = select_bucket_placement(owner, zonegroup_id, placement_rule,
-                                  &selected_placement_rule_name, &rule_info);
+                                  &selected_placement_id, &rule_info);
     if (ret < 0)
       return ret;
 
@@ -5765,7 +5765,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.bucket = bucket;
     info.owner = owner.user_id;
     info.zonegroup = zonegroup_id;
-    info.default_placement_id = selected_placement_rule_name;
+    info.default_placement_id = selected_placement_id;
     info.index_type = rule_info.index_type;
     info.swift_ver_location = swift_ver_location;
     info.swift_versioning = (!swift_ver_location.empty());
@@ -5918,15 +5918,15 @@ int RGWRados::select_bucket_location_by_rule(const string& location_rule, RGWZon
 }
 
 int RGWRados::select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& placement_rule,
-                                      string *pselected_rule_name, RGWZonePlacementInfo *rule_info)
+                                      std::string *pselected_rule_id, RGWZonePlacementInfo *rule_info)
 {
   if (!get_zone_params().placement_rules.empty()) {
     return select_new_bucket_location(user_info, zonegroup_id, placement_rule,
-                                      pselected_rule_name, rule_info);
+                                      pselected_rule_id, rule_info);
   }
 
-  if (pselected_rule_name) {
-    pselected_rule_name->clear();
+  if (pselected_rule_id) {
+    pselected_rule_id->clear();
   }
 
   return select_legacy_bucket_placement(rule_info);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -243,8 +243,8 @@ int RGWZoneGroup::create_default(bool old_format)
   is_master = true;
 
   RGWZoneGroupPlacementTarget placement_target;
-  placement_target.name = "default-placement";
-  placement_targets[placement_target.name] = placement_target;
+  placement_target.id = "default-placement";
+  placement_targets[placement_target.id] = placement_target;
   default_placement = "default-placement";
 
   RGWZoneParams zone_params(default_zone_name);
@@ -437,11 +437,11 @@ void RGWZoneGroup::post_process_params()
 
     for (auto iter = zone_params.placement_rules.begin();
          iter != zone_params.placement_rules.end(); ++iter) {
-      const string& placement_name = iter->first;
-      if (placement_targets.find(placement_name) == placement_targets.end()) {
+      const std::string& placement_id = iter->first;
+      if (placement_targets.find(placement_id) == placement_targets.end()) {
         RGWZoneGroupPlacementTarget placement_target;
-        placement_target.name = placement_name;
-        placement_targets[placement_name] = placement_target;
+        placement_target.id = placement_id;
+        placement_targets[placement_id] = placement_target;
       }
     }
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5737,12 +5737,12 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
 {
 #define MAX_CREATE_RETRIES 20 /* need to bound retries */
   std::string selected_placement_id;
-  RGWZonePlacementInfo rule_info;
+  RGWZonePlacementInfo placement_info;
 
   for (int i = 0; i < MAX_CREATE_RETRIES; i++) {
     int ret = 0;
     ret = select_bucket_placement(owner, zonegroup_id, requested_placement_id,
-                                  &selected_placement_id, &rule_info);
+                                  &selected_placement_id, &placement_info);
     if (ret < 0)
       return ret;
 
@@ -5766,7 +5766,7 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
     info.owner = owner.user_id;
     info.zonegroup = zonegroup_id;
     info.default_placement_id = selected_placement_id;
-    info.index_type = rule_info.index_type;
+    info.index_type = placement_info.index_type;
     info.swift_ver_location = swift_ver_location;
     info.swift_versioning = (!swift_ver_location.empty());
     if (pmaster_num_shards) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -123,7 +123,7 @@ static bool rgw_get_obj_data_pool(const RGWZoneGroup& zonegroup, const RGWZonePa
 {
   if (!zone_params.get_head_data_pool(placement_id, obj, pool)) {
     RGWZonePlacementInfo placement;
-    if (!zone_params.get_placement(zonegroup.default_placement, &placement)) {
+    if (!zone_params.get_placement(zonegroup.default_placement_id, &placement)) {
       return false;
     }
 
@@ -243,9 +243,9 @@ int RGWZoneGroup::create_default(bool old_format)
   is_master = true;
 
   RGWZoneGroupPlacementTarget placement_target;
-  placement_target.id = "default-placement";
+  placement_target.id = "default-placement-id";
   placement_targets[placement_target.id] = placement_target;
-  default_placement = "default-placement";
+  default_placement_id = "default-placement-id";
 
   RGWZoneParams zone_params(default_zone_name);
 
@@ -446,8 +446,8 @@ void RGWZoneGroup::post_process_params()
     }
   }
 
-  if (default_placement.empty() && !placement_targets.empty()) {
-    default_placement = placement_targets.begin()->first;
+  if (default_placement_id.empty() && !placement_targets.empty()) {
+    default_placement_id = placement_targets.begin()->first;
   }
 }
 
@@ -1715,7 +1715,7 @@ int RGWZoneParams::create(bool exclusive)
     default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
     default_placement.data_pool =  name + "." + default_storage_pool_suffix;
     default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
-    placement_rules["default-placement"] = default_placement;
+    placement_rules["default-placement-id"] = default_placement;
   }
 
   r = fix_pool_names();
@@ -4797,7 +4797,7 @@ int RGWRados::open_bucket_index_ctx(const RGWBucketInfo& bucket_info, librados::
 {
   const string *rule = &bucket_info.placement_rule;
   if (rule->empty()) {
-    rule = &zonegroup.default_placement;
+    rule = &zonegroup.default_placement_id;
   }
   auto iter = zone_params.placement_rules.find(*rule);
   if (iter == zone_params.placement_rules.end()) {
@@ -5849,7 +5849,7 @@ int RGWRados::select_new_bucket_location(RGWUserInfo& user_info, const string& z
   if (rule.empty()) {
     rule = user_info.default_placement;
     if (rule.empty())
-      rule = zonegroup.default_placement;
+      rule = zonegroup.default_placement_id;
   }
 
   if (rule.empty()) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5741,8 +5741,8 @@ int RGWRados::create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
 
   for (int i = 0; i < MAX_CREATE_RETRIES; i++) {
     int ret = 0;
-    ret = select_bucket_placement(owner, zonegroup_id, requested_placement_id,
-                                  &selected_placement_id, &placement_info);
+    ret = init_bucket_placement(owner, zonegroup_id, requested_placement_id,
+                                &selected_placement_id, &placement_info);
     if (ret < 0)
       return ret;
 
@@ -5910,11 +5910,15 @@ int RGWRados::get_bucket_placement_info(const std::string& placement_id, RGWZone
   return 0;
 }
 
-int RGWRados::select_bucket_placement(RGWUserInfo& user_info, const std::string& zonegroup_id,
-                                      const std::string& requested_placement_id,
-                                      std::string *pselected_placement_id,
-                                      RGWZonePlacementInfo *placement_info)
+int RGWRados::init_bucket_placement(RGWUserInfo& user_info, const std::string& zonegroup_id,
+                                    const std::string& requested_placement_id,
+                                    std::string *pselected_placement_id,
+                                    RGWZonePlacementInfo *placement_info)
 {
+  /*
+   * 1. select placement id
+   * 2. get placement info
+   */
   if (!get_zone_params().placement_rules.empty()) {
     int ret = select_bucket_placement_id(user_info, zonegroup_id,
                                          requested_placement_id, pselected_placement_id);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -251,24 +251,28 @@ int RGWZoneGroup::create_default(bool old_format)
 
   int r = zone_params.init(cct, store, false);
   if (r < 0) {
-    ldout(cct, 0) << "create_default: error initializing zone params: " << cpp_strerror(-r) << dendl;
+    ldout(cct, 0) << __func__ << " zone_params::init() init zone_params for default zone "
+                  << default_zone_name << " error: " << cpp_strerror(-r) << dendl;
     return r;
   }
 
   r = zone_params.create_default();
   if (r < 0 && r != -EEXIST) {
-    ldout(cct, 0) << "create_default: error in create_default  zone params: " << cpp_strerror(-r) << dendl;
+    ldout(cct, 0) <<  __func__ << " zone_params::create_default() for default zone "
+                  << default_zone_name << " error: " << cpp_strerror(-r) << dendl;
     return r;
   } else if (r == -EEXIST) {
-    ldout(cct, 10) << "zone_params::create_default() returned -EEXIST, we raced with another default zone_params creation" << dendl;
+    ldout(cct, 10) << __func__ << " zone_params::create_default() returned -EEXIST,"
+                   << " we raced with another default zone_params creation" << dendl;
     zone_params.clear_id();
     r = zone_params.init(cct, store);
     if (r < 0) {
-      ldout(cct, 0) << "create_default: error in init existing zone params: " << cpp_strerror(-r) << dendl;
+      ldout(cct, 0) << __func__ << " zone_params::init() init existing zone_params for zone"
+                    << default_zone_name <<  " error: " << cpp_strerror(-r) << dendl;
       return r;
     }
-    ldout(cct, 20) << "zone_params::create_default() " << zone_params.get_name() << " id " << zone_params.get_id()
-		   << dendl;
+    ldout(cct, 20) << __func__ << "zone_params::create_default()"
+                   << " name " << zone_params.get_name() << " id " << zone_params.get_id() << dendl;
   }
   
   RGWZone& default_zone = zones[zone_params.get_id()];
@@ -278,12 +282,12 @@ int RGWZoneGroup::create_default(bool old_format)
   
   r = create();
   if (r < 0 && r != -EEXIST) {
-    ldout(cct, 0) << "error storing zone group info: " << cpp_strerror(-r) << dendl;
+    ldout(cct, 0) << __func__ << " storing zone group info error: " << cpp_strerror(-r) << dendl;
     return r;
   }
 
   if (r == -EEXIST) {
-    ldout(cct, 10) << "create_default() returned -EEXIST, we raced with another zonegroup creation" << dendl;
+    ldout(cct, 10) << __func__ << " returned -EEXIST, we raced with another zonegroup creation" << dendl;
     id.clear();
     r = init(cct, store);
     if (r < 0) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5851,7 +5851,7 @@ int RGWRados::select_new_bucket_location(RGWUserInfo& user_info, const string& z
   /* find placement rule. Hierarchy: request rule > user default rule > zonegroup default rule */
   string rule = request_rule;
   if (rule.empty()) {
-    rule = user_info.default_placement;
+    rule = user_info.default_placement_id;
     if (rule.empty())
       rule = zonegroup.default_placement_id;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5927,7 +5927,7 @@ int RGWRados::select_bucket_placement(RGWUserInfo& user_info, const std::string&
   return select_legacy_bucket_placement(rule_info);
 }
 
-int RGWRados::select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info)
+int RGWRados::select_legacy_bucket_placement(RGWZonePlacementInfo *placement_info)
 {
   bufferlist map_bl;
   map<string, bufferlist> m;
@@ -6000,10 +6000,10 @@ read_omap:
     pool_name = miter->first;
   }
 
-  rule_info->data_pool = pool_name;
-  rule_info->data_extra_pool = pool_name;
-  rule_info->index_pool = pool_name;
-  rule_info->index_type = RGWBIType_Normal;
+  placement_info->data_pool = pool_name;
+  placement_info->data_extra_pool = pool_name;
+  placement_info->index_pool = pool_name;
+  placement_info->index_type = RGWBIType_Normal;
 
   return 0;
 }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1172,7 +1172,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
 
   RGWAccessKey system_key;
 
-  map<string, RGWZonePlacementInfo> placement_pools;
+  map<string, RGWZonePlacementInfo> placement_rules;
 
   string realm_id;
 
@@ -1215,7 +1215,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
     ::encode(user_uid_pool, bl);
     RGWSystemMetaObj::encode(bl);
     ::encode(system_key, bl);
-    ::encode(placement_pools, bl);
+    ::encode(placement_rules, bl);
     ::encode(metadata_heap, bl);
     ::encode(realm_id, bl);
     ::encode(lc_pool, bl);
@@ -1246,7 +1246,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
     if (struct_v >= 3)
       ::decode(system_key, bl);
     if (struct_v >= 4)
-      ::decode(placement_pools, bl);
+      ::decode(placement_rules, bl);
     if (struct_v >= 5)
       ::decode(metadata_heap, bl);
     if (struct_v >= 6) {
@@ -1277,7 +1277,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   static void generate_test_instances(list<RGWZoneParams*>& o);
 
   bool find_placement(const rgw_data_placement_target& placement, string *placement_id) {
-    for (const auto& pp : placement_pools) {
+    for (const auto& pp : placement_rules) {
       const RGWZonePlacementInfo& info = pp.second;
       if (info.index_pool == placement.index_pool.to_str() &&
           info.data_pool == placement.data_pool.to_str() &&
@@ -1290,8 +1290,8 @@ struct RGWZoneParams : RGWSystemMetaObj {
   }
 
   bool get_placement(const string& placement_id, RGWZonePlacementInfo *placement) const {
-    auto iter = placement_pools.find(placement_id);
-    if (iter == placement_pools.end()) {
+    auto iter = placement_rules.find(placement_id);
+    if (iter == placement_rules.end()) {
       return false;
     }
     *placement = iter->second;
@@ -1314,8 +1314,8 @@ struct RGWZoneParams : RGWSystemMetaObj {
     if (placement_id.empty()) {
       return false;
     }
-    auto iter = placement_pools.find(placement_id);
-    if (iter == placement_pools.end()) {
+    auto iter = placement_rules.find(placement_id);
+    if (iter == placement_rules.end()) {
       return false;
     }
     if (!obj.in_extra_data) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2587,7 +2587,7 @@ public:
    */
   int init_bucket_index(RGWBucketInfo& bucket_info, int num_shards);
   int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
-                              string *pselected_rule_name, RGWZonePlacementInfo *rule_info);
+                              std::string *pselected_rule_id, RGWZonePlacementInfo *rule_info);
   int select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info);
   int select_new_bucket_location(RGWUserInfo& user_info, const std::string& zonegroup_id,
                                  const std::string& request_rule_id, std::string *pselected_rule_id,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2585,12 +2585,11 @@ public:
   int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, 
                               const std::string& requested_placement_id,
                               std::string *pselected_placement_id, RGWZonePlacementInfo *rule_info);
-  int select_legacy_bucket_placement(RGWZonePlacementInfo *placement_info);
-  int select_new_bucket_location(RGWUserInfo& user_info, const std::string& zonegroup_id,
+  int select_bucket_placement_id(RGWUserInfo& user_info, const std::string& zonegroup_id,
                                  const std::string& requested_placement_id,
-                                 std::string *pselected_placement_id,
-                                 RGWZonePlacementInfo *rule_info);
-  int select_bucket_placement_info(const std::string& placement_id, RGWZonePlacementInfo *placement_info);
+                                 std::string *pselected_placement_id);
+  int get_bucket_placement_info(const std::string& placement_id, RGWZonePlacementInfo *placement_info);
+  int get_legacy_bucket_placement_info(RGWZonePlacementInfo *placement_info);
   void create_bucket_id(string *bucket_id);
 
   bool get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1276,12 +1276,12 @@ struct RGWZoneParams : RGWSystemMetaObj {
   void decode_json(JSONObj *obj);
   static void generate_test_instances(list<RGWZoneParams*>& o);
 
-  bool get_placement(const string& placement_id, RGWZonePlacementInfo *placement) const {
+  bool get_placement_info(const std::string& placement_id, RGWZonePlacementInfo *placement_info) const {
     auto iter = placement_rules.find(placement_id);
     if (iter == placement_rules.end()) {
       return false;
     }
-    *placement = iter->second;
+    *placement_info = iter->second;
     return true;
   }
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1276,19 +1276,6 @@ struct RGWZoneParams : RGWSystemMetaObj {
   void decode_json(JSONObj *obj);
   static void generate_test_instances(list<RGWZoneParams*>& o);
 
-  bool find_placement(const rgw_data_placement_target& placement, string *placement_id) {
-    for (const auto& pp : placement_rules) {
-      const RGWZonePlacementInfo& info = pp.second;
-      if (info.index_pool == placement.index_pool.to_str() &&
-          info.data_pool == placement.data_pool.to_str() &&
-          info.data_extra_pool == placement.data_extra_pool.to_str()) {
-        *placement_id = pp.first;
-        return true;
-      }
-    }
-    return false;
-  }
-
   bool get_placement(const string& placement_id, RGWZonePlacementInfo *placement) const {
     auto iter = placement_rules.find(placement_id);
     if (iter == placement_rules.end()) {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2589,8 +2589,9 @@ public:
   int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
                               string *pselected_rule_name, RGWZonePlacementInfo *rule_info);
   int select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info);
-  int select_new_bucket_location(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
-                                 string *pselected_rule_name, RGWZonePlacementInfo *rule_info);
+  int select_new_bucket_location(RGWUserInfo& user_info, const std::string& zonegroup_id,
+                                 const std::string& request_rule_id, std::string *pselected_rule_id,
+                                 RGWZonePlacementInfo *rule_info);
   int select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info);
   void create_bucket_id(string *bucket_id);
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1285,33 +1285,6 @@ struct RGWZoneParams : RGWSystemMetaObj {
     return true;
   }
 
-  /*
-   * return data pool of the head object
-   */
-  bool get_head_data_pool(const string& placement_id, const rgw_obj& obj, rgw_pool *pool) const {
-    const rgw_data_placement_target& explicit_placement = obj.bucket.explicit_placement;
-    if (!explicit_placement.data_pool.empty()) {
-      if (!obj.in_extra_data) {
-        *pool = explicit_placement.data_pool;
-      } else {
-        *pool = explicit_placement.get_data_extra_pool();
-      }
-      return true;
-    }
-    if (placement_id.empty()) {
-      return false;
-    }
-    auto iter = placement_rules.find(placement_id);
-    if (iter == placement_rules.end()) {
-      return false;
-    }
-    if (!obj.in_extra_data) {
-      *pool = iter->second.data_pool;
-    } else {
-      *pool = iter->second.get_data_extra_pool();
-    }
-    return true;
-  }
 };
 WRITE_CLASS_ENCODER(RGWZoneParams)
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1457,7 +1457,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
   map<string, RGWZone> zones;
 
   map<string, RGWZoneGroupPlacementTarget> placement_targets;
-  string default_placement;
+  std::string default_placement_id;
 
   list<string> hostnames;
   list<string> hostnames_s3website;
@@ -1504,7 +1504,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
     ::encode(master_zone, bl);
     ::encode(zones, bl);
     ::encode(placement_targets, bl);
-    ::encode(default_placement, bl);
+    ::encode(default_placement_id, bl);
     ::encode(hostnames, bl);
     ::encode(hostnames_s3website, bl);
     RGWSystemMetaObj::encode(bl);
@@ -1521,7 +1521,7 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
     ::decode(master_zone, bl);
     ::decode(zones, bl);
     ::decode(placement_targets, bl);
-    ::decode(default_placement, bl);
+    ::decode(default_placement_id, bl);
     if (struct_v >= 2) {
       ::decode(hostnames, bl);
     }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2594,7 +2594,7 @@ public:
                                  const std::string& requested_placement_id,
                                  std::string *pselected_placement_id,
                                  RGWZonePlacementInfo *rule_info);
-  int select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info);
+  int select_bucket_placement_info(const std::string& placement_id, RGWZonePlacementInfo *placement_info);
   void create_bucket_id(string *bucket_id);
 
   bool get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2589,7 +2589,7 @@ public:
   int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, 
                               const std::string& requested_placement_id,
                               std::string *pselected_placement_id, RGWZonePlacementInfo *rule_info);
-  int select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info);
+  int select_legacy_bucket_placement(RGWZonePlacementInfo *placement_info);
   int select_new_bucket_location(RGWUserInfo& user_info, const std::string& zonegroup_id,
                                  const std::string& requested_placement_id,
                                  std::string *pselected_placement_id,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2586,11 +2586,13 @@ public:
    * returns 0 on success, -ERR# otherwise.
    */
   int init_bucket_index(RGWBucketInfo& bucket_info, int num_shards);
-  int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, const string& rule,
-                              std::string *pselected_rule_id, RGWZonePlacementInfo *rule_info);
+  int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, 
+                              const std::string& requested_placement_id,
+                              std::string *pselected_placement_id, RGWZonePlacementInfo *rule_info);
   int select_legacy_bucket_placement(RGWZonePlacementInfo *rule_info);
   int select_new_bucket_location(RGWUserInfo& user_info, const std::string& zonegroup_id,
-                                 const std::string& request_rule_id, std::string *pselected_rule_id,
+                                 const std::string& requested_placement_id,
+                                 std::string *pselected_placement_id,
                                  RGWZonePlacementInfo *rule_info);
   int select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info);
   void create_bucket_id(string *bucket_id);
@@ -2600,7 +2602,7 @@ public:
 
   int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
-                            const string& placement_rule,
+                            const std::string& requested_placement_id,
                             const string& swift_ver_location,
                             const RGWQuotaInfo * pquota_info,
                             map<std::string,bufferlist>& attrs,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1519,6 +1519,14 @@ struct RGWZoneGroup : public RGWSystemMetaObj {
                bool *psync_from_all, list<string>& sync_from, list<string>& sync_from_rm);
   int remove_zone(const std::string& zone_id);
   int rename_zone(const RGWZoneParams& zone_params);
+  bool has_placement_target(const std::string& placement_id) const {
+    auto titer = placement_targets.find(placement_id);
+    if (titer != placement_targets.end()) {
+      return true;
+    }
+    return false;
+  }
+
   rgw_pool get_pool(CephContext *cct);
   const string get_default_oid(bool old_region_format = false) override;
   const string& get_info_oid_prefix(bool old_region_format = false) override;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2581,10 +2581,6 @@ public:
 
   int create_pool(const rgw_pool& pool);
 
-  /**
-   * create a bucket with name bucket and the given list of attrs
-   * returns 0 on success, -ERR# otherwise.
-   */
   int init_bucket_index(RGWBucketInfo& bucket_info, int num_shards);
   int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, 
                               const std::string& requested_placement_id,

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1199,7 +1199,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
   int create(bool exclusive = true) override;
   int fix_pool_names();
 
-  const string& get_compression_type(const string& placement_rule) const;
+  const string& get_compression_type(const string& placement_id) const;
   
   void encode(bufferlist& bl) const override {
     ENCODE_START(10, 1, bl);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1414,7 +1414,7 @@ struct RGWDefaultZoneGroupInfo {
 WRITE_CLASS_ENCODER(RGWDefaultZoneGroupInfo)
 
 struct RGWZoneGroupPlacementTarget {
-  string name;
+  string id;
   set<string> tags;
 
   bool user_permitted(list<string>& user_tags) {
@@ -1431,14 +1431,14 @@ struct RGWZoneGroupPlacementTarget {
 
   void encode(bufferlist& bl) const {
     ENCODE_START(1, 1, bl);
-    ::encode(name, bl);
+    ::encode(id, bl);
     ::encode(tags, bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
     DECODE_START(1, bl);
-    ::decode(name, bl);
+    ::decode(id, bl);
     ::decode(tags, bl);
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2582,9 +2582,10 @@ public:
   int create_pool(const rgw_pool& pool);
 
   int init_bucket_index(RGWBucketInfo& bucket_info, int num_shards);
-  int select_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id, 
-                              const std::string& requested_placement_id,
-                              std::string *pselected_placement_id, RGWZonePlacementInfo *rule_info);
+  int init_bucket_placement(RGWUserInfo& user_info, const string& zonegroup_id,
+                            const std::string& requested_placement_id,
+                            std::string *pselected_placement_id,
+                            RGWZonePlacementInfo *placement_info);
   int select_bucket_placement_id(RGWUserInfo& user_info, const std::string& zonegroup_id,
                                  const std::string& requested_placement_id,
                                  std::string *pselected_placement_id);

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1154,7 +1154,7 @@ int RGWCreateBucket_ObjStore_S3::get_params()
 
   size_t pos = location_constraint.find(':');
   if (pos != string::npos) {
-    placement_rule = location_constraint.substr(pos + 1);
+    requested_placement_id = location_constraint.substr(pos + 1);
     location_constraint = location_constraint.substr(0, pos);
   }
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1664,7 +1664,7 @@ void RGWInfo_ObjStore_SWIFT::list_swift_data(Formatter& formatter,
 
   for (const auto& placement_targets : zonegroup.placement_targets) {
     formatter.open_object_section("policy");
-    if (placement_targets.second.id.compare(zonegroup.default_placement) == 0)
+    if (placement_targets.second.id.compare(zonegroup.default_placement_id) == 0)
       formatter.dump_bool("default", true);
     formatter.dump_string("name", placement_targets.second.id.c_str());
     formatter.close_section();

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -941,7 +941,7 @@ int RGWPutMetadataObject_ObjStore_SWIFT::get_params()
     return r;
   }
 
-  placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
+  requested_placement_id = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
   dlo_manifest = s->info.env->get("HTTP_X_OBJECT_MANIFEST");
 
   return 0;

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -638,7 +638,7 @@ int RGWCreateBucket_ObjStore_SWIFT::get_params()
   location_constraint = store->get_zonegroup().api_name;
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX,
                            CONT_REMOVE_ATTR_PREFIX, rmattr_names);
-  placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
+  requested_placement_id = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -392,8 +392,8 @@ static void dump_container_metadata(struct req_state *s,
     if (write_acl.size()) {
       dump_header(s, "X-Container-Write", write_acl);
     }
-    if (!s->bucket_info.placement_rule.empty()) {
-      dump_header(s, "X-Storage-Policy", s->bucket_info.placement_rule);
+    if (!s->bucket_info.default_placement_id.empty()) {
+      dump_header(s, "X-Storage-Policy", s->bucket_info.default_placement_id);
     }
 
     /* Dump user-defined metadata items and generic attrs. */

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -912,7 +912,7 @@ int RGWPutMetadataBucket_ObjStore_SWIFT::get_params()
 
   get_rmattrs_from_headers(s, CONT_PUT_ATTR_PREFIX, CONT_REMOVE_ATTR_PREFIX,
 			   rmattr_names);
-  placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
+  requested_placement_id = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
 
   return get_swift_versioning_settings(s, swift_ver_location);
 }

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -1664,9 +1664,9 @@ void RGWInfo_ObjStore_SWIFT::list_swift_data(Formatter& formatter,
 
   for (const auto& placement_targets : zonegroup.placement_targets) {
     formatter.open_object_section("policy");
-    if (placement_targets.second.name.compare(zonegroup.default_placement) == 0)
+    if (placement_targets.second.id.compare(zonegroup.default_placement) == 0)
       formatter.dump_bool("default", true);
-    formatter.dump_string("name", placement_targets.second.name.c_str());
+    formatter.dump_string("name", placement_targets.second.id.c_str());
     formatter.close_section();
   }
   formatter.close_section();

--- a/src/rgw/rgw_torrent.cc
+++ b/src/rgw/rgw_torrent.cc
@@ -244,7 +244,7 @@ int seed::save_torrent_file()
   rgw_obj obj(s->bucket, s->object.name);    
 
   rgw_raw_obj raw_obj;
-  store->obj_to_raw(s->bucket_info.placement_rule, obj, &raw_obj);
+  store->obj_to_raw(s->bucket_info.default_placement_id, obj, &raw_obj);
 
   op_ret = store->omap_set(raw_obj, key, bl);
   if (op_ret < 0)

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -80,10 +80,10 @@
     zone set                   set zone cluster params (requires infile)
     zone list                  list all zones set on this cluster
     zone rename                rename a zone
-    zone placement list        list zone's placement targets
-    zone placement add         add a zone placement target
-    zone placement modify      modify a zone placement target
-    zone placement rm          remove a zone placement target
+    zone placement list        list zone's placement rules
+    zone placement add         add a zone placement rule
+    zone placement modify      modify a zone placement rule
+    zone placement rm          remove a zone placement rule
     pool add                   add an existing pool for data placement
     pool rm                    remove an existing pool from data placement set
     pools list                 list placement active set
@@ -191,17 +191,17 @@
      --source-zone             specify the source zone (for data sync)
      --default                 set entity (realm, zonegroup, zone) as default
      --read-only               set zone as read-only (when adding to zonegroup)
-     --placement-id            placement id for zonegroup placement commands
+     --placement-id            placement rule id for zonegroup/zone placement commands
      --tags=<list>             list of tags for zonegroup placement add and modify commands
      --tags-add=<list>         list of tags to add for zonegroup placement modify command
      --tags-rm=<list>          list of tags to remove for zonegroup placement modify command
      --endpoints=<list>        zone endpoints
-     --index_pool=<pool>       placement target index pool
-     --data-pool=<pool>        placement target data pool
-     --data-extra-pool=<pool>  placement target data extra (non-ec) pool
+     --index-pool=<pool>       placement rule index pool for zone placement commands
+     --data-pool=<pool>        placement rule data pool for zone placement commands
+     --data-extra-pool=<pool>  placement rule data extra (non-ec) pool for zone placement commands
      --placement-index-type=<type>
-                               placement target index type (normal, indexless, or #id)
-     --compression=<type>      placement target compression type (plugin name or empty/none)
+                               placement rule index type (normal, indexless, or #id) for zone placement commands
+     --compression=<type>      placement rule compression type (plugin name or empty/none) for zone placement commands
      --tier-type=<type>        zone tier type
      --tier-config=<k>=<v>[,...]
                                set zone tier config keys, values

--- a/src/test/rgw/test_rgw_common.cc
+++ b/src/test/rgw/test_rgw_common.cc
@@ -10,7 +10,7 @@ void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params,
   pinfo.data_extra_pool = rgw_pool(name + ".extra").to_str();
   
   if (is_default) {
-    zonegroup->default_placement = name;
+    zonegroup->default_placement_id = name;
   }
 }
 

--- a/src/test/rgw/test_rgw_common.cc
+++ b/src/test/rgw/test_rgw_common.cc
@@ -4,7 +4,7 @@ void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params,
 {
   zonegroup->placement_targets[name] = { name };
 
-  RGWZonePlacementInfo& pinfo = zone_params->placement_pools[name];
+  RGWZonePlacementInfo& pinfo = zone_params->placement_rules[name];
   pinfo.index_pool = rgw_pool(name + ".index").to_str();
   pinfo.data_pool = rgw_pool(name + ".data").to_str();
   pinfo.data_extra_pool = rgw_pool(name + ".extra").to_str();

--- a/src/test/rgw/test_rgw_common.cc
+++ b/src/test/rgw/test_rgw_common.cc
@@ -16,7 +16,7 @@ void test_rgw_add_placement(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params,
 
 void test_rgw_init_env(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params)
 {
-  test_rgw_add_placement(zonegroup, zone_params, "default-placement", true);
+  test_rgw_add_placement(zonegroup, zone_params, "default-placement-id", true);
 
 }
 

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -463,12 +463,12 @@ void test_rgw_init_env(RGWZoneGroup *zonegroup, RGWZoneParams *zone_params);
 struct test_rgw_env {
   RGWZoneGroup zonegroup;
   RGWZoneParams zone_params;
-  rgw_data_placement_target default_placement;
+  rgw_data_placement_target placement_target;
 
   test_rgw_env() {
     test_rgw_init_env(&zonegroup, &zone_params);
-    default_placement.data_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_pool);
-    default_placement.data_extra_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_extra_pool);
+    placement_target.data_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_pool);
+    placement_target.data_extra_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_extra_pool);
   }
 
   rgw_data_placement_target get_placement(const std::string& placement_id) {

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -467,8 +467,8 @@ struct test_rgw_env {
 
   test_rgw_env() {
     test_rgw_init_env(&zonegroup, &zone_params);
-    default_placement.data_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement].data_pool);
-    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_rules[zonegroup.default_placement].data_extra_pool);
+    default_placement.data_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_pool);
+    default_placement.data_extra_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_extra_pool);
   }
 
   rgw_data_placement_target get_placement(const std::string& placement_id) {

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -471,7 +471,7 @@ struct test_rgw_env {
     placement_target.data_extra_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement_id].data_extra_pool);
   }
 
-  rgw_data_placement_target get_placement(const std::string& placement_id) {
+  rgw_data_placement_target get_placement_target(const std::string& placement_id) {
     const RGWZonePlacementInfo& pi = zone_params.placement_rules[placement_id];
     rgw_data_placement_target pt;
     pt.index_pool = pi.index_pool;

--- a/src/test/rgw/test_rgw_common.h
+++ b/src/test/rgw/test_rgw_common.h
@@ -467,12 +467,12 @@ struct test_rgw_env {
 
   test_rgw_env() {
     test_rgw_init_env(&zonegroup, &zone_params);
-    default_placement.data_pool = rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_pool);
-    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_pools[zonegroup.default_placement].data_extra_pool);
+    default_placement.data_pool = rgw_pool(zone_params.placement_rules[zonegroup.default_placement].data_pool);
+    default_placement.data_extra_pool =  rgw_pool(zone_params.placement_rules[zonegroup.default_placement].data_extra_pool);
   }
 
   rgw_data_placement_target get_placement(const std::string& placement_id) {
-    const RGWZonePlacementInfo& pi = zone_params.placement_pools[placement_id];
+    const RGWZonePlacementInfo& pi = zone_params.placement_rules[placement_id];
     rgw_data_placement_target pt;
     pt.index_pool = pi.index_pool;
     pt.data_pool = pi.data_pool;

--- a/src/test/rgw/test_rgw_manifest.cc
+++ b/src/test/rgw/test_rgw_manifest.cc
@@ -225,7 +225,7 @@ TEST(TestRGWManifest, head_only_obj) {
 
   list<rgw_obj> objs;
 
-  gen_obj(env, obj_size, 512 * 1024, 4 * 1024 * 1024, &manifest, env.zonegroup.default_placement, &bucket, &head, &gen, &objs);
+  gen_obj(env, obj_size, 512 * 1024, 4 * 1024 * 1024, &manifest, env.zonegroup.default_placement_id, &bucket, &head, &gen, &objs);
 
   cout <<  " manifest.get_obj_size()=" << manifest.get_obj_size() << std::endl;
   cout <<  " manifest.get_head_size()=" << manifest.get_head_size() << std::endl;
@@ -261,7 +261,7 @@ TEST(TestRGWManifest, obj_with_head_and_tail) {
   int stripe_size = 4 * 1024 * 1024;
   int head_size = 512 * 1024;
 
-  gen_obj(env, obj_size, head_size, stripe_size, &manifest, env.zonegroup.default_placement, &bucket, &head, &gen, &objs);
+  gen_obj(env, obj_size, head_size, stripe_size, &manifest, env.zonegroup.default_placement_id, &bucket, &head, &gen, &objs);
 
   list<rgw_obj>::iterator liter;
 
@@ -313,7 +313,7 @@ TEST(TestRGWManifest, multipart) {
     rgw_obj head;
     for (ofs = 0; ofs < part_size; ofs += stripe_size) {
       if (ofs == 0) {
-        int r = gen.create_begin(g_ceph_context, &manifest, env.zonegroup.default_placement, bucket, head);
+        int r = gen.create_begin(g_ceph_context, &manifest, env.zonegroup.default_placement_id, bucket, head);
         ASSERT_EQ(r, 0);
         continue;
       }

--- a/src/test/rgw/test_rgw_obj.cc
+++ b/src/test/rgw/test_rgw_obj.cc
@@ -173,7 +173,7 @@ static void test_obj_to_raw(test_rgw_env& env, const rgw_bucket& b,
   dump(f, "raw_obj", raw_obj);
 
   if (!placement_id.empty()) {
-    ASSERT_EQ(raw_obj.pool, env.get_placement(placement_id).data_pool);
+    ASSERT_EQ(raw_obj.pool, env.get_placement_target(placement_id).data_pool);
   } else {
     ASSERT_EQ(raw_obj.pool, b.explicit_placement.data_pool);
   }

--- a/src/test/rgw/test_rgw_obj.cc
+++ b/src/test/rgw/test_rgw_obj.cc
@@ -200,7 +200,7 @@ TEST(TestRGWObj, obj_to_raw) {
   for (auto name : { "myobj", "_myobj", "_myobj_"}) {
     for (auto inst : { "", "inst"}) {
       for (auto ns : { "", "ns"}) {
-        test_obj_to_raw(env, b, name, inst, ns, env.zonegroup.default_placement);
+        test_obj_to_raw(env, b, name, inst, ns, env.zonegroup.default_placement_id);
         test_obj_to_raw(env, eb, name, inst, ns, string());
       }
     }


### PR DESCRIPTION
This pr mainly contains:

+ rename placement_pools as placement_rules
+ clarify placement target is different with placement rule
+ unify rule_name, placement_rule, placement_rule_name,etc to
  placement_id(because we've defined `--placemet-id` argument in the
  rgw-admin.cc, it works as user interface, we should stick to it.)
+ cleanup the vague `default placement` in many places, sometimes it means
`placement target`/ `placement rule` / `placement id`
+ decouple the procedure of select `placement id` and get the `placement
info` of certain `placement id`
+ cleanup outdated doc/comments

After cleanup the concepts of bucket placement is more clear and consistent:

+ `placement rule` is key-value pair, the `placement id` as key, the
  `placement info` as value. the `placement info` collect a bunch of
  pools.

+ `placement target` contains a `placement id` and a list of
  `placement tags`,that only used to determine whether the user can
  use the `placement rule` or not.

+ `placement target` can be manipulated only in the zonegroup, and
  `placement rule` only in the zone

@cbodley @yehudasa @fangyuxiangGL mind to take a look? 

@rzarzynski mind to take a look? Especially [the swift part](https://github.com/ceph/ceph/commit/60a17f3401a9804562ea4ff43757cc6933db7bcf).