### PR TITLE
os/memstore: performance optimization related to osd and pg lock

### DIFF
--- a/src/os/memstore/MemStore.cc
+++ b/src/os/memstore/MemStore.cc
@@ -47,14 +47,11 @@ int MemStore::mount()
   int r = _load();
   if (r < 0)
     return r;
-  finisher.start();
   return 0;
 }
 
 int MemStore::umount()
 {
-  finisher.wait_for_empty();
-  finisher.stop();
   return _save();
 }
 
@@ -725,9 +722,9 @@ int MemStore::queue_transactions(Sequencer *osr,
   if (on_apply_sync)
     on_apply_sync->complete(0);
   if (on_apply)
-    finisher.queue(on_apply);
+    on_apply->complete(0);
   if (on_commit)
-    finisher.queue(on_commit);
+    on_commit->complete(0);
   return 0;
 }
 

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -196,8 +196,6 @@ private:
 
   CollectionRef get_collection(const coll_t& cid);
 
-  Finisher finisher;
-
   uint64_t used_bytes;
 
   void _do_transaction(Transaction& t);
@@ -241,7 +239,6 @@ public:
   MemStore(CephContext *cct, const string& path)
     : ObjectStore(cct, path),
       coll_lock("MemStore::coll_lock"),
-      finisher(cct),
       used_bytes(0) {}
   ~MemStore() override { }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -1877,7 +1877,7 @@ OSD::OSD(CephContext *cct_, ObjectStore *store_,
 	 MonClient *mc,
 	 const std::string &dev, const std::string &jdev) :
   Dispatcher(cct_),
-  osd_lock("OSD::osd_lock"),
+  osd_lock("OSD::osd_lock", true),
   tick_timer(cct, osd_lock),
   tick_timer_lock("OSD::tick_timer_lock"),
   tick_timer_without_osd_lock(cct, tick_timer_lock),

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -285,7 +285,7 @@ PG::PG(OSDService *o, OSDMapRef curmap,
     _pool.id,
     p.shard),
   osdmap_ref(curmap), last_persisted_osdmap_ref(curmap), pool(_pool),
-  _lock("PG::_lock"),
+  _lock("PG::_lock", true),
   #ifdef PG_DEBUG_REFS
   _ref_id_lock("PG::_ref_id_lock"), _ref_id(0),
   #endif

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -279,7 +279,7 @@ protected:
   void requeue_map_waiters();
 
   void update_osdmap_ref(OSDMapRef newmap) {
-    assert(_lock.is_locked_by_me());
+    Mutex::Locker l(_lock); //It's a recursive lock!
     osdmap_ref = std::move(newmap);
   }
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -3442,7 +3442,7 @@ public:
 			 unsigned alignment)
     : cid(cid), write_alignment(alignment), max_object_len(max_size),
       max_write_len(max_write), in_flight(0), object_gen(gen),
-      rng(rng), store(store), osr(osr), lock("State lock") {}
+      rng(rng), store(store), osr(osr), lock("State lock", true) {}
 
   int init() {
     ObjectStore::Transaction t;


### PR DESCRIPTION
*MemStore* can be a performance criterion. However, *MemStore* was not much faster than other *ObjectStore* implementations such as *FileStore* and *BlueStore* for unknown reasons. I have been doing profiling for that reason and have been able to identify two causes.

1. *MemStore*'s finisher thread is single.
It is difficult to send a response quickly in a single thread.

2. *Finisher* threads and IO threads are competing with *PG* and *OSD* lock. 
Normally this is not a problem, but it can be a problem with fast media like SSD or Memory. This is because the likelihood and frequency of collisions will be higher. Furthermore, It makes the situation worse that two threads running on different cores compete for one lock.

So I made the following modifications:

1. I removed the *Finisher* thread from *MemStore* and modified the IO thread to send a direct response(RTC, Run To Completion). Since IO Thread is a worker of *op_wq*,  it does not violate the consistency requirements of each *PG*.

2. #1 modification has a side effect on the execution of the *Context* instances, which are attached to a transaction as callback listeners and executed in the context of *Finisher* thread. Applying RTC to it changes the runtime context of the *Context* instance and causes a problem trying to acquire *PG/OSD* locks redundantly. To solve this problem, the *PG/OSD* lock was modified to be recursive.
This modification will not affect the behavior of the other *ObjectStore*. Their performance will be the same as before, because the relatively slow performance of them has different causes hiding this issue.

Experimental results show that the performance of a single *OSD* without replication is more than two times better than the original *MemStore*(**50K IOPS->120K IOPS, 4KB RW,** 61a87c2c31bc06604d1b6ff4bd9efcdae817e43c), and the performance of a 16 *OSD*s with 1 replica is improved **70%**.

Signed-off-by: Ilsoo Byun <ilsoo.byun@sk.com>