### PR TITLE
rbd: limit the max iops of an image can reach

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1391,6 +1391,10 @@ OPTION(rbd_cache_max_dirty_age, OPT_FLOAT, 1.0)      // seconds in cache before 
 OPTION(rbd_cache_max_dirty_object, OPT_INT, 0)       // dirty limit for objects - set to 0 for auto calculate from rbd_cache_size
 OPTION(rbd_cache_block_writes_upfront, OPT_BOOL, false) // whether to block writes to the cache before the aio_write call completes (true), or block before the aio completion is called (false)
 OPTION(rbd_concurrent_management_ops, OPT_INT, 10) // how many operations can be in flight for a management operation like deleting or resizing an image
+OPTION(rbd_max_write_iops, OPT_U64, 0) // the max write iops an image can reach, 0 means unlimited.
+                                      //  It can be adjusted by "rbd image-meta set conf_rbd_max_write_iops"
+OPTION(rbd_max_read_iops, OPT_U64, 0) // the max read iops an image can reach, 0 means unlimited.
+                                      //  It can be adjusted by "rbd image-meta set conf_rbd_max_read_iops"
 OPTION(rbd_balance_snap_reads, OPT_BOOL, false)
 OPTION(rbd_localize_snap_reads, OPT_BOOL, false)
 OPTION(rbd_balance_parent_reads, OPT_BOOL, false)

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -994,7 +994,9 @@ struct C_InvalidateCache : public Context {
         "rbd_journal_max_concurrent_object_sets", false)(
         "rbd_mirroring_resync_after_disconnect", false)(
         "rbd_mirroring_replay_delay", false)(
-        "rbd_skip_partial_discard", false);
+        "rbd_skip_partial_discard", false)(
+        "rbd_max_write_iops", false)(
+        "rbd_max_read_iops", false);
 
     md_config_t local_config_t;
     std::map<std::string, bufferlist> res;
@@ -1054,6 +1056,8 @@ struct C_InvalidateCache : public Context {
     ASSIGN_OPTION(mirroring_resync_after_disconnect);
     ASSIGN_OPTION(mirroring_replay_delay);
     ASSIGN_OPTION(skip_partial_discard);
+    ASSIGN_OPTION(max_write_iops);
+    ASSIGN_OPTION(max_read_iops);
   }
 
   ExclusiveLock<ImageCtx> *ImageCtx::create_exclusive_lock() {

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -197,7 +197,9 @@ struct C_InvalidateCache : public Context {
       state(new ImageState<>(this)),
       operations(new Operations<>(*this)),
       exclusive_lock(nullptr), object_map(nullptr),
-      io_work_queue(nullptr), op_work_queue(nullptr),
+      io_work_queue(nullptr),
+      throttling_timer(nullptr), throttling_timer_lock(nullptr),
+      op_work_queue(nullptr),
       asok_hook(nullptr),
       trace_endpoint("librbd")
   {
@@ -210,6 +212,7 @@ struct C_InvalidateCache : public Context {
 
     ThreadPool *thread_pool;
     get_thread_pool_instance(cct, &thread_pool, &op_work_queue);
+    get_timer_instance(cct, &throttling_timer, &throttling_timer_lock);
     io_work_queue = new io::ImageRequestWQ<>(
       this, "librbd::io_work_queue", cct->_conf->rbd_op_thread_timeout,
       thread_pool);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -155,6 +155,8 @@ namespace librbd {
     xlist<operation::ResizeRequest<ImageCtx>*> resize_reqs;
 
     io::ImageRequestWQ<ImageCtx> *io_work_queue;
+    SafeTimer *throttling_timer;
+    Mutex *throttling_timer_lock;
     xlist<io::AioCompletion*> completed_reqs;
     EventSocket event_socket;
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -179,6 +179,8 @@ namespace librbd {
     uint32_t readahead_trigger_requests;
     uint64_t readahead_max_bytes;
     uint64_t readahead_disable_after_bytes;
+    uint64_t max_write_iops;
+    uint64_t max_read_iops;
     bool clone_copy_on_read;
     bool blacklist_on_break_lock;
     uint32_t blacklist_expire_seconds;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -81,8 +81,12 @@ struct MockImageCtx {
       group_spec(image_ctx.group_spec),
       layout(image_ctx.layout),
       io_work_queue(new io::MockImageRequestWQ()),
+      m_timer(image_ctx.m_timer),
+      m_timer_lock(image_ctx.m_timer_lock),
       op_work_queue(new MockContextWQ()),
       readahead_max_bytes(image_ctx.readahead_max_bytes),
+      max_write_iops(image_ctx.max_write_iops),
+      max_read_iops(image_ctx.max_read_iops),
       event_socket(image_ctx.event_socket),
       parent(NULL), operations(new MockOperations()),
       state(new MockImageState()),
@@ -262,12 +266,16 @@ struct MockImageCtx {
   std::list<Context*> async_requests_waiters;
 
   io::MockImageRequestWQ *io_work_queue;
+  SafeTimer *m_timer;
+  Mutex *m_timer_lock;
   MockContextWQ *op_work_queue;
 
   cache::MockImageCache *image_cache = nullptr;
 
   MockReadahead readahead;
   uint64_t readahead_max_bytes;
+  uint64_t max_write_iops;
+  uint64_t max_read_iops;
 
   EventSocket &event_socket;
 


### PR DESCRIPTION
1. Add `max_iops`(default value 0 means unlimited) image metadata.
2. When the `max_iops` image metadata is set, the `process` function in `ImageRequestWQ` will control the send rate of request. 
The following test data is in the case that I set the `max_iops` to 20 for an image within pool.
![1-max-iops](https://user-images.githubusercontent.com/5844041/27373019-3f8f14a8-5699-11e7-905a-cf845c7933f1.png)

Signed-off-by: Jin Cai caijin.caij@alibaba-inc.com