### PR TITLE
mds: save  projected path into inode_t::stray_prior_path

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -5952,7 +5952,7 @@ void Server::_unlink_local(MDRequestRef& mdr, CDentry *dn, CDentry *straydn)
   dn->pre_dirty();
 
   inode_t *pi = in->project_inode();
-  dn->make_path_string(pi->stray_prior_path);
+  dn->make_path_string(pi->stray_prior_path, true);
   mdr->add_projected_inode(in); // do this _after_ my dn->pre_dirty().. we apply that one manually.
   pi->version = in->pre_dirty();
   pi->ctime = mdr->get_op_stamp();
@@ -7142,7 +7142,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
     if (tpi) {
       tpi->ctime = mdr->get_op_stamp();
       tpi->change_attr++;
-      destdn->make_path_string(tpi->stray_prior_path);
+      destdn->make_path_string(tpi->stray_prior_path, true);
       tpi->nlink--;
       if (tpi->nlink == 0)
 	oldin->state_set(CInode::STATE_ORPHAN);


### PR DESCRIPTION
Otherwise, path string like #10000000000/xxx may get saved into
inode_t::stray_prior_path.

Fixes: http://tracker.ceph.com/issues/20340
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>