### PR TITLE
cmake: do not add dependencies to INTERFACE library on cmake < 3.3

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -137,7 +137,7 @@ macro(build_boost version)
   endforeach()
 
   # for header-only libraries
-  if(CMAKE_VERSION VERSION_LESS 3.0)
+  if(CMAKE_VERSION VERSION_LESS 3.3)
     # only ALIAS and INTERFACE target names allow ":" in it, but
     # INTERFACE library is not allowed until cmake 3.1
     add_custom_target(Boost.boost DEPENDS Boost)


### PR DESCRIPTION
otherwise we will have

add_dependencies Cannot add target-level dependencies to INTERFACE
library

Signed-off-by: Kefu Chai <kchai@redhat.com>