### PR TITLE
qa/objectstore/filestore-btrfs: test btrfs on trusty only

### DIFF
--- a/qa/objectstore/filestore-btrfs.yaml
+++ b/qa/objectstore/filestore-btrfs.yaml
@@ -1,3 +1,7 @@
+# centos btrfs hits ENOSPC all the time :(
+# xenial too.  so far trusty seems to behave?
+os_type: ubuntu
+os_version: "14.04"
 overrides:
   ceph:
     fs: btrfs


### PR DESCRIPTION
Centos btrfs hits ENOSPC all the time :(, and now xenial is doing
it too.

See http://tracker.ceph.com/issues/20169
Signed-off-by: Sage Weil <sage@redhat.com>