### PR TITLE
mon/ConfigKeyService: mput, mput-prefix, rm-prefix, and some efficiency

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1174,6 +1174,28 @@ function gen_secrets_file()
   return 0
 }
 
+function test_mon_config_key()
+{
+  ceph config-key put aaa/hi ho
+  ceph config-key get aaa/hi | grep ho
+  ceph config-key list | grep aaa/hi
+  ceph config-key dump | grep aaa/hi | grep ho
+
+  ceph config-key mput aaa/hi there aaa/ho there
+  ceph config-key dump | grep aaa/ho | grep there
+
+  ceph config-key mput-prefix aaa/ aaa/ho no aaa/foo bar
+  expect_false ceph config-key exists aaa/hi
+  ceph config-key dump | grep aaa/ho | grep no
+  ceph config-key dump | grep aaa/foo | grep bar
+
+  ceph config-key exists aaa/foo
+  ceph config-key rm aaa/foo
+  expect_false ceph config-key exists aaa/foo
+  ceph config-key rm-prefix aaa/
+  expect_false ceph config-key exists aaa/ho
+}
+
 function test_mon_osd_create_destroy()
 {
   ceph osd new 2>&1 | grep 'EINVAL'
@@ -2385,6 +2407,7 @@ MON_TESTS+=" mon_misc"
 MON_TESTS+=" mon_mon"
 MON_TESTS+=" mon_osd"
 MON_TESTS+=" mon_crush"
+MON_TESTS+=" mon_config_key"
 MON_TESTS+=" mon_osd_create_destroy"
 MON_TESTS+=" mon_osd_pool"
 MON_TESTS+=" mon_osd_pool_quota"

--- a/src/mon/ConfigKeyService.h
+++ b/src/mon/ConfigKeyService.h
@@ -26,6 +26,7 @@ class Formatter;
 class ConfigKeyService : public QuorumService
 {
   Paxos *paxos;
+  map<string,bufferlist> config_keys;
 
   int store_get(const string &key, bufferlist &bl);
   void store_put(const string &key, bufferlist &bl, Context *cb = NULL);
@@ -62,7 +63,8 @@ public:
                   list<pair<health_status_t,string> > *detail) override { }
   bool service_dispatch(MonOpRequestRef op) override;
 
-  void start_epoch() override { }
+  void refresh() override;
+  void start_epoch() override {}
   void finish_epoch() override { }
   void cleanup() override { }
   void service_tick() override { }

--- a/src/mon/ConfigKeyService.h
+++ b/src/mon/ConfigKeyService.h
@@ -27,20 +27,28 @@ class ConfigKeyService : public QuorumService
 {
   Paxos *paxos;
   map<string,bufferlist> config_keys;
+  version_t version;
+  bufferlist metabl;
+
+  void _store_put(MonitorDBStore::TransactionRef t, const string &key,
+		  bufferlist& bl);
+  void _store_delete(MonitorDBStore::TransactionRef t, const string &key);
+  void _store_delete_prefix(MonitorDBStore::TransactionRef t,
+			    const string &prefix);
+  void _store_finish(MonitorDBStore::TransactionRef t,
+		     Context *cb);
+  void store_put(const string &key, bufferlist &bl, Context *cb = NULL);
+  void store_delete(const string &key, Context *cb = NULL);
 
   int store_get(const string &key, bufferlist &bl);
-  void store_put(const string &key, bufferlist &bl, Context *cb = NULL);
-  void store_delete(MonitorDBStore::TransactionRef t, const string &key);
-  void store_delete(const string &key, Context *cb = NULL);
-  void store_delete_prefix(
-      MonitorDBStore::TransactionRef t,
-      const string &prefix);
   void store_list(stringstream &ss);
   void store_dump(stringstream &ss);
   bool store_exists(const string &key);
   bool store_has_prefix(const string &prefix);
 
   static const string STORE_PREFIX;
+  static const string META_PREFIX;
+  static const string META_KEY;
 
 protected:
   void service_shutdown() override { }

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -924,12 +924,23 @@ COMMAND("config-key put " \
 	"name=key,type=CephString " \
 	"name=val,type=CephString,req=false", \
 	"put <key>, value <val>", "config-key", "rw", "cli,rest")
+COMMAND("config-key mput " \
+	"name=keysandvalues,type=CephString,n=N",
+	"mput <key1> <val1> <key2> <val2> ...", "config-key", "rw", "cli,rest")
+COMMAND("config-key mput-prefix " \
+	"name=key_prefix,type=CephString " \
+	"name=keysandvalues,type=CephString,n=N",
+	"mput-prefix <prefix> <key1> <val1> <key2> <val2> ...",
+	"config-key", "rw", "cli,rest")
 COMMAND("config-key del " \
 	"name=key,type=CephString", \
 	"delete <key>", "config-key", "rw", "cli,rest")
 COMMAND("config-key rm " \
 	"name=key,type=CephString", \
 	"rm <key>", "config-key", "rw", "cli,rest")
+COMMAND("config-key rm-prefix " \
+	"name=key_prefix,type=CephString", \
+	"rm-prefix <key-prefix>", "config-key", "rw", "cli,rest")
 COMMAND("config-key exists " \
 	"name=key,type=CephString", \
 	"check for <key>'s existence", "config-key", "r", "cli,rest")

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -846,6 +846,7 @@ void Monitor::refresh_from_paxos(bool *need_bootstrap)
   for (int i = 0; i < PAXOS_NUM; ++i) {
     paxos_service[i]->post_refresh();
   }
+  config_key_service->refresh();
 }
 
 void Monitor::register_cluster_logger()

--- a/src/mon/QuorumService.h
+++ b/src/mon/QuorumService.h
@@ -96,6 +96,8 @@ public:
     finish_epoch();
   }
 
+  virtual void refresh() {}
+
   epoch_t get_epoch() const {
     return epoch;
   }


### PR DESCRIPTION
The in-memory caching makes it possible to pipeline updates (like a put followed by
an rm-prefix).