### PR TITLE
qa: wait for healthy cluster before testing pins

### DIFF
--- a/qa/tasks/cephfs/test_exports.py
+++ b/qa/tasks/cephfs/test_exports.py
@@ -25,6 +25,7 @@ class TestExports(CephFSTestCase):
     def test_export_pin(self):
         self.fs.set_allow_multimds(True)
         self.fs.set_max_mds(2)
+        self.fs.wait_for_daemons()
 
         status = self.fs.status()
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20318

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>