### PR TITLE
mds: assert straydn to silence coverity error

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -7166,9 +7166,11 @@ void Server::_rename_prepare(MDRequestRef& mdr,
   if (destdn->is_auth() && !destdnl->is_null()) {
     mdcache->predirty_journal_parents(mdr, metablob, oldin, destdn->get_dir(),
 				      (destdnl->is_primary() ? PREDIRTY_PRIMARY:0)|predirty_dir, -1);
-    if (destdnl->is_primary())
+    if (destdnl->is_primary()) {
+      assert(straydn);
       mdcache->predirty_journal_parents(mdr, metablob, oldin, straydn->get_dir(),
 					PREDIRTY_PRIMARY|PREDIRTY_DIR, 1);
+    }
   }
   
   // move srcdn
@@ -7187,6 +7189,7 @@ void Server::_rename_prepare(MDRequestRef& mdr,
   // target inode
   if (!linkmerge) {
     if (destdnl->is_primary()) {
+      assert(straydn);
       if (destdn->is_auth()) {
 	// project snaprealm, too
 	if (oldin->snaprealm || dest_realm->get_newest_seq() + 1 > oldin->get_oldest_snap())
@@ -7280,8 +7283,10 @@ void Server::_rename_prepare(MDRequestRef& mdr,
   if (srcdnl->is_primary() && destdn->is_auth())
     srci->first = destdn->first;  
 
-  if (oldin && oldin->is_dir())
+  if (oldin && oldin->is_dir()) {
+    assert(straydn);
     mdcache->project_subtree_rename(oldin, destdn->get_dir(), straydn->get_dir());
+  }
   if (srci->is_dir())
     mdcache->project_subtree_rename(srci, srcdn->get_dir(), destdn->get_dir());
 


### PR DESCRIPTION
The error:

    ** CID 1412578:  Null pointer dereferences  (FORWARD_NULL)
    /home/brad/working/src/ceph/src/mds/Server.cc: 7032 in Server::_rename_prepare(boost::intrusive_ptr<MDRequestImpl> &, EMetaBlob *, ceph::buffer::list *, CDentry *, CDentry *, CDentry *)()

    ________________________________________________________________________________________________________
    *** CID 1412578:  Null pointer dereferences  (FORWARD_NULL)
    /home/brad/working/src/ceph/src/mds/Server.cc: 7032 in Server::_rename_prepare(boost::intrusive_ptr<MDRequestImpl> &, EMetaBlob *, ceph::buffer::list *, CDentry *, CDentry *, CDentry *)()
    7026           force_journal_dest = true;
    7027         } else
    7028           force_journal_dest = _need_force_journal(srci, false);
    7029       }
    7030
    7031       bool force_journal_stray = false;
    >>>     CID 1412578:  Null pointer dereferences  (FORWARD_NULL)
    >>>     Comparing "straydn" to null implies that "straydn" might be null.
    7032       if (oldin && oldin->is_dir() && straydn && !straydn->is_auth())
    7033         force_journal_stray = _need_force_journal(oldin, true);
    7034
    7035       if (linkmerge)
    7036         dout(10) << " merging remote and primary links to the same inode" << dendl;
    7037       if (silent)

Fixes: http://tracker.ceph.com/issues/20254

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>