### PR TITLE
qa/suites/powercycle/osd/tasks/radosbench: consume less space

### DIFF
--- a/qa/objectstore/bluestore-comp.yaml
+++ b/qa/objectstore/bluestore-comp.yaml
@@ -14,6 +14,11 @@ overrides:
         debug rocksdb: 10
         bluestore compression mode: aggressive
         bluestore fsck on mount: true
+        # lower the full ratios since we can fill up a 100gb osd so quickly
+        mon osd full ratio: .9
+        mon osd backfillfull_ratio: .85
+        mon osd nearfull ratio: .8
+        osd failsafe full ratio: .95
 
 # this doesn't work with failures bc the log writes are not atomic across the two backends
 #        bluestore bluefs env mirror: true

--- a/qa/objectstore/bluestore.yaml
+++ b/qa/objectstore/bluestore.yaml
@@ -13,6 +13,10 @@ overrides:
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true
-
+        # lower the full ratios since we can fill up a 100gb osd so quickly
+        mon osd full ratio: .9
+        mon osd backfillfull_ratio: .85
+        mon osd nearfull ratio: .8
+        osd failsafe full ratio: .95
 # this doesn't work with failures bc the log writes are not atomic across the two backends
 #        bluestore bluefs env mirror: true

--- a/qa/suites/powercycle/osd/tasks/radosbench.yaml
+++ b/qa/suites/powercycle/osd/tasks/radosbench.yaml
@@ -2,25 +2,37 @@ tasks:
 - full_sequential:
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
   - radosbench:
       clients: [client.0]
-      time: 150
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90
+  - radosbench:
+      clients: [client.0]
+      time: 90


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20302

qa
- [x] powercycle
- [x] rados