### PR TITLE
qa/workunits/rados/test-upgrade-*: whitelist tests the right way

### DIFF
--- a/qa/workunits/rados/test-upgrade-v11.0.0.sh
+++ b/qa/workunits/rados/test-upgrade-v11.0.0.sh
@@ -13,11 +13,11 @@ trap cleanup EXIT ERR HUP INT QUIT
 
 pids=""
 for f in \
-    'api_aio --gtest_filter=-LibRadosAio.RacingRemovePP:-*WriteSame*:-*CmpExt*' \
+    'api_aio --gtest_filter=-LibRadosAio.RacingRemovePP:*WriteSame*:*CmpExt*' \
     'api_list --gtest_filter=-LibRadosList*.EnumerateObjects*' \
     'api_io --gtest_filter=-*Checksum*' \
     api_lock \
-    'api_misc --gtest_filter=-*WriteSame*:-*CmpExt*:-*Checksum*:-*CloneRange*' \
+    'api_misc --gtest_filter=-*WriteSame*:*CmpExt*:*Checksum*:*CloneRange*' \
     'api_watch_notify --gtest_filter=-*WatchNotify3*' \
     api_tier api_pool api_snapshots api_stat api_cmd \
     'api_c_write_operations --gtest_filter=-*WriteSame*' \


### PR DESCRIPTION
--gtest_filter=POSTIVE_PATTERNS[-NEGATIVE_PATTERNS], so we cannot add
multiple exclusive patterns using -pattern:-pattern, instead, we should
use: -pattern:pattern

Signed-off-by: Kefu Chai <kchai@redhat.com>
Conflicts:
        qa/workunits/rados/test-upgrade-v11.0.0.sh: this change is not
    cherry-picked from master, because the clone-range op was removed
    from master. and only supported in pre-luminous releases.