### PR TITLE
rgw: Uninitialized member in LCRule

### DIFF
--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -74,7 +74,7 @@ protected:
   LCExpiration expiration;
   LCExpiration noncur_expiration;
   LCExpiration mp_expiration;
-  bool dm_expiration;
+  bool dm_expiration = false;
 
 public:
 


### PR DESCRIPTION
Fixed the Coverity Scan report:
```
CID 1412979:  Uninitialized members  (UNINIT_CTOR)
ceph/src/rgw/rgw_lc.h: 81 in LCRule::LCRule()()
Non-static class member "dm_expiration" is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>