### PR TITLE
librbd: support migrating images with minimal downtime

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -396,6 +396,29 @@ Commands
   'rbd merge-diff first second - | rbd merge-diff - third result'. Note this command
   currently only support the source incremental diff with stripe_count == 1
 
+:command:`migration abort` *image-spec*
+  Cancel image migration. This step may be run after successful or
+  failed migration prepare or migration execute steps and returns the
+  image to its initial (before migration) state. All modifications to
+  the destination image are lost.
+
+:command:`migration commit` *image-spec*
+  Commit image migration. This step is run after a successful migration
+  prepare and migration execute steps and removes the source image data.
+
+:command:`migration execute` *image-spec*
+  Execute image migration. This step is run after a successful migration
+  prepare step and copies image data to the destination.
+
+:command:`migration prepare` [--order *order*] [--object-size *object-size*] [--image-feature *image-feature*] [--image-shared] [--stripe-unit *stripe-unit*] [--stripe-count *stripe-count*] [--data-pool *data-pool*] *src-image-spec* [*dest-image-spec*]
+  Prepare image migration. This is the first step when migrating an
+  image, i.e. changing the image location, format or other
+  parameters that can't be changed dynamically. The destination can
+  match the source, and in this case *dest-image-spec* can be omitted.
+  After this step the source image is set as a parent of the
+  destination image, and the image is accessible in copy-on-write mode
+  by its destination spec.
+
 :command:`mirror image demote` *image-spec*
   Demote a primary image to non-primary for RBD mirroring.
 

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -538,9 +538,8 @@ int create(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   omap_vals["snap_seq"] = snap_seqbl;
   omap_vals["create_timestamp"] = create_timestampbl;
 
-  if ((features & RBD_FEATURES_INTERNAL) != 0ULL) {
-    CLS_ERR("Attempting to set internal feature: %" PRIu64,
-            static_cast<uint64_t>(features & RBD_FEATURES_INTERNAL));
+  if ((features & RBD_FEATURE_OPERATIONS) != 0ULL) {
+    CLS_ERR("Attempting to set internal feature: operations");
     return -EINVAL;
   }
 

--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -278,6 +278,184 @@ int snapshot_iterate(cls_method_context_t hctx, L& lambda) {
   return 0;
 }
 
+int set_migration(cls_method_context_t hctx,
+                  const cls::rbd::MigrationSpec &migration_spec, bool init) {
+  if (init) {
+    bufferlist bl;
+    int r = cls_cxx_map_get_val(hctx, "migration", &bl);
+    if (r != -ENOENT) {
+      if (r == 0) {
+        CLS_LOG(10, "migration already set");
+        return -EEXIST;
+      }
+      CLS_ERR("failed to read migration off disk: %s", cpp_strerror(r).c_str());
+      return r;
+    }
+
+    uint64_t features = 0;
+    r = read_key(hctx, "features", &features);
+    if (r == -ENOENT) {
+      CLS_LOG(20, "no features, assuming v1 format");
+      bufferlist header;
+      r = cls_cxx_read(hctx, 0, sizeof(RBD_HEADER_TEXT), &header);
+      if (r < 0) {
+        CLS_ERR("failed to read v1 header: %s", cpp_strerror(r).c_str());
+        return r;
+      }
+      if (header.length() != sizeof(RBD_HEADER_TEXT)) {
+        CLS_ERR("unrecognized v1 header format");
+        return -ENXIO;
+      }
+      if (memcmp(RBD_HEADER_TEXT, header.c_str(), header.length()) != 0) {
+        if (memcmp(RBD_MIGRATE_HEADER_TEXT, header.c_str(),
+                   header.length()) == 0) {
+          CLS_LOG(10, "migration already set");
+          return -EEXIST;
+        } else {
+          CLS_ERR("unrecognized v1 header format");
+          return -ENXIO;
+        }
+      }
+      if (migration_spec.header_type != cls::rbd::MIGRATION_HEADER_TYPE_SRC) {
+        CLS_LOG(10, "v1 format image can only be migration source");
+        return -EINVAL;
+      }
+
+      header.clear();
+      header.append(RBD_MIGRATE_HEADER_TEXT);
+      r = cls_cxx_write(hctx, 0, header.length(), &header);
+      if (r < 0) {
+        CLS_ERR("error updating v1 header: %s", cpp_strerror(r).c_str());
+        return r;
+      }
+    } else if (r < 0) {
+      CLS_ERR("failed to read features off disk: %s", cpp_strerror(r).c_str());
+      return r;
+    } else if ((features & RBD_FEATURE_MIGRATING) != 0ULL) {
+      if (migration_spec.header_type != cls::rbd::MIGRATION_HEADER_TYPE_DST) {
+        CLS_LOG(10, "migrating feature already set");
+        return -EEXIST;
+      }
+    } else {
+      features |= RBD_FEATURE_MIGRATING;
+      bl.clear();
+      encode(features, bl);
+      r = cls_cxx_map_set_val(hctx, "features", &bl);
+      if (r < 0) {
+        CLS_ERR("error updating features: %s", cpp_strerror(r).c_str());
+        return r;
+      }
+    }
+  }
+
+  bufferlist bl;
+  encode(migration_spec, bl);
+  int r = cls_cxx_map_set_val(hctx, "migration", &bl);
+  if (r < 0) {
+    CLS_ERR("error setting migration: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  return 0;
+}
+
+int read_migration(cls_method_context_t hctx,
+                   cls::rbd::MigrationSpec *migration_spec) {
+  uint64_t features = 0;
+  int r = read_key(hctx, "features", &features);
+  if (r == -ENOENT) {
+    CLS_LOG(20, "no features, assuming v1 format");
+    bufferlist header;
+    r = cls_cxx_read(hctx, 0, sizeof(RBD_HEADER_TEXT), &header);
+    if (r < 0) {
+      CLS_ERR("failed to read v1 header: %s", cpp_strerror(r).c_str());
+      return r;
+    }
+    if (header.length() != sizeof(RBD_HEADER_TEXT)) {
+      CLS_ERR("unrecognized v1 header format");
+      return -ENXIO;
+    }
+    if (memcmp(RBD_MIGRATE_HEADER_TEXT, header.c_str(), header.length()) != 0) {
+      if (memcmp(RBD_HEADER_TEXT, header.c_str(), header.length()) == 0) {
+        CLS_LOG(10, "migration feature not set");
+        return -EINVAL;
+      } else {
+        CLS_ERR("unrecognized v1 header format");
+        return -ENXIO;
+      }
+    }
+    if (migration_spec->header_type != cls::rbd::MIGRATION_HEADER_TYPE_SRC) {
+      CLS_LOG(10, "v1 format image can only be migration source");
+      return -EINVAL;
+    }
+  } else if (r < 0) {
+    CLS_ERR("failed to read features off disk: %s", cpp_strerror(r).c_str());
+    return r;
+  } else if ((features & RBD_FEATURE_MIGRATING) == 0ULL) {
+    CLS_LOG(10, "migration feature not set");
+    return -EINVAL;
+  }
+
+  r = read_key(hctx, "migration", migration_spec);
+  if (r < 0) {
+    CLS_ERR("failed to read migration off disk: %s", cpp_strerror(r).c_str());
+    return r;
+  }
+
+  return 0;
+}
+
+int remove_migration(cls_method_context_t hctx) {
+  int r = remove_key(hctx, "migration");
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t features = 0;
+  r = read_key(hctx, "features", &features);
+  if (r == -ENOENT) {
+    CLS_LOG(20, "no features, assuming v1 format");
+    bufferlist header;
+    r = cls_cxx_read(hctx, 0, sizeof(RBD_MIGRATE_HEADER_TEXT), &header);
+    if (header.length() != sizeof(RBD_MIGRATE_HEADER_TEXT)) {
+      CLS_ERR("unrecognized v1 header format");
+      return -ENXIO;
+    }
+    if (memcmp(RBD_MIGRATE_HEADER_TEXT, header.c_str(), header.length()) != 0) {
+      if (memcmp(RBD_HEADER_TEXT, header.c_str(), header.length()) == 0) {
+        CLS_LOG(10, "migration feature not set");
+        return -EINVAL;
+      } else {
+        CLS_ERR("unrecognized v1 header format");
+        return -ENXIO;
+      }
+    }
+    header.clear();
+    header.append(RBD_HEADER_TEXT);
+    r = cls_cxx_write(hctx, 0, header.length(), &header);
+    if (r < 0) {
+      CLS_ERR("error updating v1 header: %s", cpp_strerror(r).c_str());
+      return r;
+    }
+  } else if (r < 0) {
+    CLS_ERR("failed to read features off disk: %s", cpp_strerror(r).c_str());
+    return r;
+  } else if ((features & RBD_FEATURE_MIGRATING) == 0ULL) {
+    CLS_LOG(10, "migrating feature not set");
+  } else {
+    features &= ~RBD_FEATURE_MIGRATING;
+    bufferlist bl;
+    encode(features, bl);
+    r = cls_cxx_map_set_val(hctx, "features", &bl);
+    if (r < 0) {
+      CLS_ERR("error updating features: %s", cpp_strerror(r).c_str());
+      return r;
+    }
+  }
+
+  return 0;
+}
+
 } // namespace image
 
 /**
@@ -3449,6 +3627,114 @@ int children_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
   return 0;
 }
 
+/**
+ * Set image migration.
+ *
+ * Input:
+ * @param migration_spec (cls::rbd::MigrationSpec) image migration spec
+ *
+ * Output:
+ *
+ * @returns 0 on success, negative error code on failure
+ */
+int migration_set(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
+  cls::rbd::MigrationSpec migration_spec;
+  try {
+    auto it = in->cbegin();
+    decode(migration_spec, it);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  int r = image::set_migration(hctx, migration_spec, true);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+/**
+ * Set image migration state.
+ *
+ * Input:
+ * @param state (cls::rbd::MigrationState) migration state
+ * @param description (std::string) migration state description
+ *
+ * Output:
+ *
+ * @returns 0 on success, negative error code on failure
+ */
+int migration_set_state(cls_method_context_t hctx, bufferlist *in,
+                        bufferlist *out) {
+  cls::rbd::MigrationState state;
+  std::string description;
+  try {
+    auto it = in->cbegin();
+    decode(state, it);
+    decode(description, it);
+  } catch (const buffer::error &err) {
+    return -EINVAL;
+  }
+
+  cls::rbd::MigrationSpec migration_spec;
+  int r = image::read_migration(hctx, &migration_spec);
+  if (r < 0) {
+    return r;
+  }
+
+  migration_spec.state = state;
+  migration_spec.state_description = description;
+
+  r = image::set_migration(hctx, migration_spec, false);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+/**
+ * Get image migration spec.
+ *
+ * Input:
+ *
+ * Output:
+ * @param migration_spec (cls::rbd::MigrationSpec) image migration spec
+ *
+ * @returns 0 on success, negative error code on failure
+ */
+int migration_get(cls_method_context_t hctx, bufferlist *in, bufferlist *out) {
+  cls::rbd::MigrationSpec migration_spec;
+  int r = image::read_migration(hctx, &migration_spec);
+  if (r < 0) {
+    return r;
+  }
+
+  encode(migration_spec, *out);
+
+  return 0;
+}
+
+/**
+ * Remove image migration spec.
+ *
+ * Input:
+ *
+ * Output:
+ *
+ * @returns 0 on success, negative error code on failure
+ */
+int migration_remove(cls_method_context_t hctx, bufferlist *in,
+                     bufferlist *out) {
+  int r = image::remove_migration(hctx);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
 /****************************** Old format *******************************/
 
 int old_snapshots_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
@@ -6371,6 +6657,10 @@ CLS_INIT(rbd)
   cls_method_handle_t h_child_attach;
   cls_method_handle_t h_child_detach;
   cls_method_handle_t h_children_list;
+  cls_method_handle_t h_migration_set;
+  cls_method_handle_t h_migration_set_state;
+  cls_method_handle_t h_migration_get;
+  cls_method_handle_t h_migration_remove;
   cls_method_handle_t h_old_snapshots_list;
   cls_method_handle_t h_old_snapshot_add;
   cls_method_handle_t h_old_snapshot_remove;
@@ -6536,6 +6826,18 @@ CLS_INIT(rbd)
   cls_register_cxx_method(h_class, "children_list",
                           CLS_METHOD_RD,
                           children_list, &h_children_list);
+  cls_register_cxx_method(h_class, "migration_set",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          migration_set, &h_migration_set);
+  cls_register_cxx_method(h_class, "migration_set_state",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          migration_set_state, &h_migration_set_state);
+  cls_register_cxx_method(h_class, "migration_get",
+                          CLS_METHOD_RD,
+                          migration_get, &h_migration_get);
+  cls_register_cxx_method(h_class, "migration_remove",
+                          CLS_METHOD_RD | CLS_METHOD_WR,
+                          migration_remove, &h_migration_remove);
 
   /* methods for the rbd_children object */
   cls_register_cxx_method(h_class, "add_child",

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1667,6 +1667,23 @@ namespace librbd {
       op->exec("rbd", "migration_remove", bl);
     }
 
+    int assert_snapc_seq(librados::IoCtx *ioctx, const std::string &oid,
+                         uint64_t snapc_seq,
+                         cls::rbd::AssertSnapcSeqState state) {
+      librados::ObjectWriteOperation op;
+      assert_snapc_seq(&op, snapc_seq, state);
+      return ioctx->operate(oid, &op);
+    }
+
+    void assert_snapc_seq(librados::ObjectWriteOperation *op,
+                          uint64_t snapc_seq,
+                          cls::rbd::AssertSnapcSeqState state) {
+      bufferlist bl;
+      encode(snapc_seq, bl);
+      encode(state, bl);
+      op->exec("rbd", "assert_snapc_seq", bl);
+    }
+
     void mirror_uuid_get_start(librados::ObjectReadOperation *op) {
       bufferlist bl;
       op->exec("rbd", "mirror_uuid_get", bl);

--- a/src/cls/rbd/cls_rbd_client.cc
+++ b/src/cls/rbd/cls_rbd_client.cc
@@ -1591,6 +1591,82 @@ namespace librbd {
       return 0;
     }
 
+    int migration_set(librados::IoCtx *ioctx, const std::string &oid,
+                      const cls::rbd::MigrationSpec &migration_spec) {
+      librados::ObjectWriteOperation op;
+      migration_set(&op, migration_spec);
+      return ioctx->operate(oid, &op);
+    }
+
+    void migration_set(librados::ObjectWriteOperation *op,
+                       const cls::rbd::MigrationSpec &migration_spec) {
+      bufferlist bl;
+      encode(migration_spec, bl);
+      op->exec("rbd", "migration_set", bl);
+    }
+
+    int migration_set_state(librados::IoCtx *ioctx, const std::string &oid,
+                            cls::rbd::MigrationState state,
+                            const std::string &description) {
+      librados::ObjectWriteOperation op;
+      migration_set_state(&op, state, description);
+      return ioctx->operate(oid, &op);
+    }
+
+    void migration_set_state(librados::ObjectWriteOperation *op,
+                             cls::rbd::MigrationState state,
+                             const std::string &description) {
+      bufferlist bl;
+      encode(state, bl);
+      encode(description, bl);
+      op->exec("rbd", "migration_set_state", bl);
+    }
+
+    void migration_get_start(librados::ObjectReadOperation *op) {
+      bufferlist bl;
+      op->exec("rbd", "migration_get", bl);
+    }
+
+    int migration_get_finish(bufferlist::const_iterator *it,
+                             cls::rbd::MigrationSpec *migration_spec) {
+      try {
+	decode(*migration_spec, *it);
+      } catch (const buffer::error &err) {
+	return -EBADMSG;
+      }
+      return 0;
+    }
+
+    int migration_get(librados::IoCtx *ioctx, const std::string &oid,
+                      cls::rbd::MigrationSpec *migration_spec) {
+      librados::ObjectReadOperation op;
+      migration_get_start(&op);
+
+      bufferlist out_bl;
+      int r = ioctx->operate(oid, &op, &out_bl);
+      if (r < 0) {
+	return r;
+      }
+
+      auto iter = out_bl.cbegin();
+      r = migration_get_finish(&iter, migration_spec);
+      if (r < 0) {
+	return r;
+      }
+      return 0;
+    }
+
+    int migration_remove(librados::IoCtx *ioctx, const std::string &oid) {
+      librados::ObjectWriteOperation op;
+      migration_remove(&op);
+      return ioctx->operate(oid, &op);
+    }
+
+    void migration_remove(librados::ObjectWriteOperation *op) {
+      bufferlist bl;
+      op->exec("rbd", "migration_remove", bl);
+    }
+
     void mirror_uuid_get_start(librados::ObjectReadOperation *op) {
       bufferlist bl;
       op->exec("rbd", "mirror_uuid_get", bl);

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -276,6 +276,13 @@ namespace librbd {
     int migration_remove(librados::IoCtx *ioctx, const std::string &oid);
     void migration_remove(librados::ObjectWriteOperation *op);
 
+    int assert_snapc_seq(librados::IoCtx *ioctx, const std::string &oid,
+                         uint64_t snapc_seq,
+                         cls::rbd::AssertSnapcSeqState state);
+    void assert_snapc_seq(librados::ObjectWriteOperation *op,
+                          uint64_t snapc_seq,
+                         cls::rbd::AssertSnapcSeqState state);
+
     // operations on rbd_id objects
     void get_id_start(librados::ObjectReadOperation *op);
     int get_id_finish(bufferlist::const_iterator *it, std::string *id);

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -258,6 +258,24 @@ namespace librbd {
                       snapid_t snap_id,
                       cls::rbd::ChildImageSpecs *child_images);
 
+    int migration_set(librados::IoCtx *ioctx, const std::string &oid,
+                    const cls::rbd::MigrationSpec &migration_spec);
+    void migration_set(librados::ObjectWriteOperation *op,
+                     const cls::rbd::MigrationSpec &migration_spec);
+    int migration_set_state(librados::IoCtx *ioctx, const std::string &oid,
+                            cls::rbd::MigrationState state,
+                            const std::string &description);
+    void migration_set_state(librados::ObjectWriteOperation *op,
+                             cls::rbd::MigrationState state,
+                             const std::string &description);
+    void migration_get_start(librados::ObjectReadOperation *op);
+    int migration_get_finish(bufferlist::const_iterator *it,
+                           cls::rbd::MigrationSpec *migration_spec);
+    int migration_get(librados::IoCtx *ioctx, const std::string &oid,
+                      cls::rbd::MigrationSpec *migration_spec);
+    int migration_remove(librados::IoCtx *ioctx, const std::string &oid);
+    void migration_remove(librados::ObjectWriteOperation *op);
+
     // operations on rbd_id objects
     void get_id_start(librados::ObjectReadOperation *op);
     int get_id_finish(bufferlist::const_iterator *it, std::string *id);

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -670,13 +670,7 @@ void TrashImageSpec::decode(bufferlist::const_iterator &it) {
 }
 
 void TrashImageSpec::dump(Formatter *f) const {
-  switch(source) {
-    case TRASH_IMAGE_SOURCE_USER:
-      f->dump_string("source", "user");
-      break;
-    case TRASH_IMAGE_SOURCE_MIRRORING:
-      f->dump_string("source", "rbd_mirror");
-  }
+  f->dump_stream("source") << source;
   f->dump_string("name", name);
   f->dump_unsigned("deletion_time", deletion_time);
   f->dump_unsigned("deferment_end_time", deferment_end_time);

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -732,5 +732,121 @@ std::ostream& operator<<(std::ostream& os,
             << image_map.mapped_time << "]";
 }
 
+std::ostream& operator<<(std::ostream& os,
+                         const MigrationHeaderType& type) {
+  switch (type) {
+  case MIGRATION_HEADER_TYPE_SRC:
+    os << "source";
+    break;
+  case MIGRATION_HEADER_TYPE_DST:
+    os << "destination";
+    break;
+  default:
+    os << "unknown (" << static_cast<uint32_t>(type) << ")";
+    break;
+  }
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MigrationState& migration_state) {
+  switch (migration_state) {
+  case MIGRATION_STATE_ERROR:
+    os << "error";
+    break;
+  case MIGRATION_STATE_PREPARING:
+    os << "preparing";
+    break;
+  case MIGRATION_STATE_PREPARED:
+    os << "prepared";
+    break;
+  case MIGRATION_STATE_EXECUTING:
+    os << "executing";
+    break;
+  case MIGRATION_STATE_EXECUTED:
+    os << "executed";
+    break;
+  default:
+    os << "unknown (" << static_cast<uint32_t>(migration_state) << ")";
+    break;
+  }
+  return os;
+}
+
+void MigrationSpec::encode(bufferlist& bl) const {
+  ENCODE_START(1, 1, bl);
+  encode(header_type, bl);
+  encode(pool_id, bl);
+  encode(image_name, bl);
+  encode(image_id, bl);
+  encode(snap_seqs, bl);
+  encode(overlap, bl);
+  encode(flatten, bl);
+  encode(mirroring, bl);
+  encode(state, bl);
+  encode(state_description, bl);
+  ENCODE_FINISH(bl);
+}
+
+void MigrationSpec::decode(bufferlist::const_iterator& bl) {
+  DECODE_START(1, bl);
+  decode(header_type, bl);
+  decode(pool_id, bl);
+  decode(image_name, bl);
+  decode(image_id, bl);
+  decode(snap_seqs, bl);
+  decode(overlap, bl);
+  decode(flatten, bl);
+  decode(mirroring, bl);
+  decode(state, bl);
+  decode(state_description, bl);
+  DECODE_FINISH(bl);
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const std::map<uint64_t, uint64_t>& snap_seqs) {
+  os << "{";
+  size_t count = 0;
+  for (auto &it : snap_seqs) {
+    os << (count++ > 0 ? ", " : "") << "(" << it.first << ", " << it.second
+       << ")";
+  }
+  os << "}";
+  return os;
+}
+
+void MigrationSpec::dump(Formatter *f) const {
+  f->dump_stream("header_type") << header_type;
+  f->dump_int("pool_id", pool_id);
+  f->dump_string("image_name", image_name);
+  f->dump_string("image_id", image_id);
+  f->dump_stream("snap_seqs") << snap_seqs;
+  f->dump_unsigned("overlap", overlap);
+  f->dump_bool("mirroring", mirroring);
+}
+
+void MigrationSpec::generate_test_instances(std::list<MigrationSpec*> &o) {
+  o.push_back(new MigrationSpec());
+  o.push_back(new MigrationSpec(MIGRATION_HEADER_TYPE_SRC, 1, "image_name",
+                                "image_id", {{1, 2}}, 123, true, true,
+                                MIGRATION_STATE_PREPARED, "description"));
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const MigrationSpec& migration_spec) {
+  os << "["
+     << "header_type=" << migration_spec.header_type << ", "
+     << "pool_id=" << migration_spec.pool_id << ", "
+     << "image_name=" << migration_spec.image_name << ", "
+     << "image_id=" << migration_spec.image_id << ", "
+     << "snap_seqs=" << migration_spec.snap_seqs << ", "
+     << "overlap=" << migration_spec.overlap << ", "
+     << "flatten=" << migration_spec.flatten << ", "
+     << "mirroring=" << migration_spec.mirroring << ", "
+     << "state=" << migration_spec.state << ", "
+     << "state_description=" << migration_spec.state_description << "]";
+  return os;
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.cc
+++ b/src/cls/rbd/cls_rbd_types.cc
@@ -842,5 +842,20 @@ std::ostream& operator<<(std::ostream& os,
   return os;
 }
 
+std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state) {
+  switch (state) {
+  case ASSERT_SNAPC_SEQ_GT_SNAPSET_SEQ:
+    os << "gt";
+    break;
+  case ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ:
+    os << "le";
+    break;
+  default:
+    os << "unknown (" << static_cast<uint32_t>(state) << ")";
+    break;
+  }
+  return os;
+}
+
 } // namespace rbd
 } // namespace cls

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -513,8 +513,28 @@ struct GroupSnapshot {
 WRITE_CLASS_ENCODER(GroupSnapshot);
 enum TrashImageSource {
   TRASH_IMAGE_SOURCE_USER = 0,
-  TRASH_IMAGE_SOURCE_MIRRORING = 1
+  TRASH_IMAGE_SOURCE_MIRRORING = 1,
+  TRASH_IMAGE_SOURCE_MIGRATION = 2,
 };
+
+inline std::ostream& operator<<(std::ostream& os,
+                                const TrashImageSource& source) {
+  switch (source) {
+  case TRASH_IMAGE_SOURCE_USER:
+    os << "user";
+    break;
+  case TRASH_IMAGE_SOURCE_MIRRORING:
+    os << "mirroring";
+    break;
+  case TRASH_IMAGE_SOURCE_MIGRATION:
+    os << "migration";
+    break;
+  default:
+    os << "unknown (" << static_cast<uint32_t>(source) << ")";
+    break;
+  }
+  return os;
+}
 
 inline void encode(const TrashImageSource &source, bufferlist& bl,
 		   uint64_t features=0)

--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -691,6 +691,25 @@ std::ostream& operator<<(std::ostream& os, const MigrationSpec& migration_spec);
 
 WRITE_CLASS_ENCODER(MigrationSpec);
 
+enum AssertSnapcSeqState {
+  ASSERT_SNAPC_SEQ_GT_SNAPSET_SEQ = 0,
+  ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ = 1,
+};
+
+inline void encode(const AssertSnapcSeqState &state, bufferlist& bl) {
+  using ceph::encode;
+  encode(static_cast<uint8_t>(state), bl);
+}
+
+inline void decode(AssertSnapcSeqState &state, bufferlist::const_iterator& it) {
+  uint8_t int_state;
+  using ceph::decode;
+  decode(int_state, it);
+  state = static_cast<AssertSnapcSeqState>(int_state);
+}
+
+std::ostream& operator<<(std::ostream& os, const AssertSnapcSeqState& state);
+
 } // namespace rbd
 } // namespace cls
 

--- a/src/include/rbd/features.h
+++ b/src/include/rbd/features.h
@@ -10,6 +10,7 @@
 #define RBD_FEATURE_JOURNALING          (1ULL<<6)
 #define RBD_FEATURE_DATA_POOL           (1ULL<<7)
 #define RBD_FEATURE_OPERATIONS          (1ULL<<8)
+#define RBD_FEATURE_MIGRATING           (1ULL<<9)
 
 #define RBD_FEATURES_DEFAULT             (RBD_FEATURE_LAYERING | \
                                          RBD_FEATURE_EXCLUSIVE_LOCK | \
@@ -26,6 +27,7 @@
 #define RBD_FEATURE_NAME_JOURNALING      "journaling"
 #define RBD_FEATURE_NAME_DATA_POOL       "data-pool"
 #define RBD_FEATURE_NAME_OPERATIONS      "operations"
+#define RBD_FEATURE_NAME_MIGRATING       "migrating"
 
 /// features that make an image inaccessible for read or write by
 /// clients that don't understand them
@@ -40,7 +42,8 @@
                                          RBD_FEATURE_FAST_DIFF      | \
                                          RBD_FEATURE_DEEP_FLATTEN   | \
                                          RBD_FEATURE_JOURNALING     | \
-                                         RBD_FEATURE_OPERATIONS)
+                                         RBD_FEATURE_OPERATIONS     | \
+                                         RBD_FEATURE_MIGRATING)
 
 #define RBD_FEATURES_ALL          	(RBD_FEATURE_LAYERING       | \
 					 RBD_FEATURE_STRIPINGV2     | \
@@ -50,7 +53,8 @@
                                          RBD_FEATURE_DEEP_FLATTEN   | \
                                          RBD_FEATURE_JOURNALING     | \
                                          RBD_FEATURE_DATA_POOL      | \
-                                         RBD_FEATURE_OPERATIONS)
+                                         RBD_FEATURE_OPERATIONS     | \
+                                         RBD_FEATURE_MIGRATING)
 
 /// features that may be dynamically enabled or disabled
 #define RBD_FEATURES_MUTABLE            (RBD_FEATURE_EXCLUSIVE_LOCK | \
@@ -72,10 +76,12 @@
 #define RBD_FEATURES_IMPLICIT_ENABLE  (RBD_FEATURE_STRIPINGV2 | \
                                        RBD_FEATURE_DATA_POOL  | \
                                        RBD_FEATURE_FAST_DIFF  | \
-                                       RBD_FEATURE_OPERATIONS)
+                                       RBD_FEATURE_OPERATIONS | \
+                                       RBD_FEATURE_MIGRATING)
 
 /// features that cannot be controlled by the user
-#define RBD_FEATURES_INTERNAL         (RBD_FEATURE_OPERATIONS)
+#define RBD_FEATURES_INTERNAL         (RBD_FEATURE_OPERATIONS | \
+                                       RBD_FEATURE_MIGRATING)
 
 #define RBD_OPERATION_FEATURE_CLONE_PARENT      (1ULL<<0)
 #define RBD_OPERATION_FEATURE_CLONE_CHILD       (1ULL<<1)

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -230,6 +230,26 @@ typedef struct {
   uint64_t cookie;
 } rbd_image_watcher_t;
 
+typedef enum {
+  RBD_IMAGE_MIGRATION_STATE_UNKNOWN = -1,
+  RBD_IMAGE_MIGRATION_STATE_ERROR = 0,
+  RBD_IMAGE_MIGRATION_STATE_PREPARING = 1,
+  RBD_IMAGE_MIGRATION_STATE_PREPARED = 2,
+  RBD_IMAGE_MIGRATION_STATE_EXECUTING = 3,
+  RBD_IMAGE_MIGRATION_STATE_EXECUTED = 4,
+} rbd_image_migration_state_t;
+
+typedef struct {
+  int64_t source_pool_id;
+  char *source_image_name;
+  char *source_image_id;
+  int64_t dest_pool_id;
+  char *dest_image_name;
+  char *dest_image_id;
+  rbd_image_migration_state_t state;
+  char *state_description;
+} rbd_image_migration_status_t;
+
 CEPH_RBD_API void rbd_image_options_create(rbd_image_options_t* opts);
 CEPH_RBD_API void rbd_image_options_destroy(rbd_image_options_t opts);
 CEPH_RBD_API int rbd_image_options_set_string(rbd_image_options_t opts,
@@ -308,6 +328,37 @@ CEPH_RBD_API int rbd_trash_remove_with_progress(rados_ioctx_t io, const char *id
                                                 void *cbdata);
 CEPH_RBD_API int rbd_trash_restore(rados_ioctx_t io, const char *id,
                                    const char *name);
+
+/* migration */
+CEPH_RBD_API int rbd_migration_prepare(rados_ioctx_t ioctx,
+                                       const char *image_name,
+                                       rados_ioctx_t dest_ioctx,
+                                       const char *dest_image_name,
+                                       rbd_image_options_t opts);
+CEPH_RBD_API int rbd_migration_execute(rados_ioctx_t ioctx,
+                                       const char *image_name);
+CEPH_RBD_API int rbd_migration_execute_with_progress(rados_ioctx_t ioctx,
+                                                     const char *image_name,
+                                                     librbd_progress_fn_t cb,
+                                                     void *cbdata);
+CEPH_RBD_API int rbd_migration_abort(rados_ioctx_t ioctx,
+                                     const char *image_name);
+CEPH_RBD_API int rbd_migration_abort_with_progress(rados_ioctx_t ioctx,
+                                                   const char *image_name,
+                                                   librbd_progress_fn_t cb,
+                                                   void *cbdata);
+CEPH_RBD_API int rbd_migration_commit(rados_ioctx_t ioctx,
+                                      const char *image_name);
+CEPH_RBD_API int rbd_migration_commit_with_progress(rados_ioctx_t ioctx,
+                                                    const char *image_name,
+                                                    librbd_progress_fn_t cb,
+                                                    void *cbdata);
+CEPH_RBD_API int rbd_migration_status(rados_ioctx_t ioctx,
+                                      const char *image_name,
+                                      rbd_image_migration_status_t *status,
+                                      size_t status_size);
+CEPH_RBD_API void rbd_migration_status_cleanup(
+    rbd_image_migration_status_t *status);
 
 /* pool mirroring */
 CEPH_RBD_API int rbd_mirror_mode_get(rados_ioctx_t io_ctx,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -212,7 +212,8 @@ enum {
 
 typedef enum {
   RBD_TRASH_IMAGE_SOURCE_USER = 0,
-  RBD_TRASH_IMAGE_SOURCE_MIRRORING = 1
+  RBD_TRASH_IMAGE_SOURCE_MIRRORING = 1,
+  RBD_TRASH_IMAGE_SOURCE_MIGRATION = 2
 } rbd_trash_image_source_t;
 
 typedef struct {

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -128,6 +128,19 @@ namespace librbd {
     uint64_t cookie;
   } image_watcher_t;
 
+  typedef rbd_image_migration_state_t image_migration_state_t;
+
+  typedef struct {
+    int64_t source_pool_id;
+    std::string source_image_name;
+    std::string source_image_id;
+    int64_t dest_pool_id;
+    std::string dest_image_name;
+    std::string dest_image_id;
+    image_migration_state_t state;
+    std::string state_description;
+  } image_migration_status_t;
+
 class CEPH_RBD_API RBD
 {
 public:
@@ -194,6 +207,22 @@ public:
   int trash_remove_with_progress(IoCtx &io_ctx, const char *image_id,
                                  bool force, ProgressContext &pctx);
   int trash_restore(IoCtx &io_ctx, const char *id, const char *name);
+
+  // Migration
+  int migration_prepare(IoCtx& io_ctx, const char *image_name,
+                        IoCtx& dest_io_ctx, const char *dest_image_name,
+                        ImageOptions& opts);
+  int migration_execute(IoCtx& io_ctx, const char *image_name);
+  int migration_execute_with_progress(IoCtx& io_ctx, const char *image_name,
+                                      ProgressContext &prog_ctx);
+  int migration_abort(IoCtx& io_ctx, const char *image_name);
+  int migration_abort_with_progress(IoCtx& io_ctx, const char *image_name,
+                                    ProgressContext &prog_ctx);
+  int migration_commit(IoCtx& io_ctx, const char *image_name);
+  int migration_commit_with_progress(IoCtx& io_ctx, const char *image_name,
+                                     ProgressContext &prog_ctx);
+  int migration_status(IoCtx& io_ctx, const char *image_name,
+                       image_migration_status_t *status, size_t status_size);
 
   // RBD pool mirroring support functions
   int mirror_mode_get(IoCtx& io_ctx, rbd_mirror_mode_t *mirror_mode);

--- a/src/include/rbd_types.h
+++ b/src/include/rbd_types.h
@@ -99,6 +99,7 @@
 #define RBD_CRYPT_NONE		0
 
 #define RBD_HEADER_TEXT		"<<< Rados Block Device Image >>>\n"
+#define RBD_MIGRATE_HEADER_TEXT	"<<< Migrating RBD Image      >>>\n"
 #define RBD_HEADER_SIGNATURE	"RBD"
 #define RBD_HEADER_VERSION	"001.005"
 

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -27,6 +27,7 @@ set(librbd_internal_srcs
   api/DiffIterate.cc
   api/Group.cc
   api/Image.cc
+  api/Migration.cc
   api/Mirror.cc
   api/Namespace.cc
   api/Snapshot.cc
@@ -108,6 +109,7 @@ set(librbd_internal_srcs
   operation/FlattenRequest.cc
   operation/MetadataRemoveRequest.cc
   operation/MetadataSetRequest.cc
+  operation/MigrateRequest.cc
   operation/ObjectMapIterate.cc
   operation/RebuildObjectMapRequest.cc
   operation/RenameRequest.cc

--- a/src/librbd/CMakeLists.txt
+++ b/src/librbd/CMakeLists.txt
@@ -49,6 +49,7 @@ set(librbd_internal_srcs
   image/CloseRequest.cc
   image/CreateRequest.cc
   image/DetachChildRequest.cc
+  image/ListWatchersRequest.cc
   image/OpenRequest.cc
   image/RefreshParentRequest.cc
   image/RefreshRequest.cc

--- a/src/librbd/DeepCopyRequest.cc
+++ b/src/librbd/DeepCopyRequest.cc
@@ -122,6 +122,10 @@ void DeepCopyRequest<I>::handle_copy_snapshots(int r) {
     return;
   }
 
+  if (m_snap_id_end == CEPH_NOSNAP) {
+    (*m_snap_seqs)[CEPH_NOSNAP] = CEPH_NOSNAP;
+  }
+
   send_copy_image();
 }
 

--- a/src/librbd/Features.cc
+++ b/src/librbd/Features.cc
@@ -20,7 +20,7 @@ static const std::map<std::string, uint64_t> RBD_FEATURE_MAP = {
   {RBD_FEATURE_NAME_JOURNALING, RBD_FEATURE_JOURNALING},
   {RBD_FEATURE_NAME_DATA_POOL, RBD_FEATURE_DATA_POOL},
 };
-static_assert((RBD_FEATURE_OPERATIONS << 1) > RBD_FEATURES_ALL,
+static_assert((RBD_FEATURE_MIGRATING << 1) > RBD_FEATURES_ALL,
 	      "new RBD feature added");
 
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -113,7 +113,7 @@ public:
       copyup_list_lock(util::unique_lock_name("librbd::ImageCtx::copyup_list_lock", this)),
       completed_reqs_lock(util::unique_lock_name("librbd::ImageCtx::completed_reqs_lock", this)),
       extra_read_flags(0),
-      old_format(true),
+      old_format(false),
       order(0), size(0), features(0),
       format_string(NULL),
       id(image_id), parent(NULL),

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -150,6 +150,12 @@ public:
     journal_policy = new journal::StandardPolicy<ImageCtx>(this);
   }
 
+  ImageCtx::ImageCtx(const string &image_name, const string &image_id,
+		     uint64_t snap_id, IoCtx& p, bool ro)
+    : ImageCtx(image_name, image_id, "", p, ro) {
+    open_snap_id = snap_id;
+  }
+
   ImageCtx::~ImageCtx() {
     assert(image_watcher == NULL);
     assert(exclusive_lock == NULL);

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -69,6 +69,7 @@ namespace librbd {
                                         // a format librados can understand
     std::map<librados::snap_t, SnapInfo> snap_info;
     std::map<std::pair<cls::rbd::SnapshotNamespace, std::string>, librados::snap_t> snap_ids;
+    uint64_t open_snap_id = CEPH_NOSNAP;
     uint64_t snap_id;
     bool snap_exists; // false if our snap_id was deleted
     // whether the image was opened read-only. cannot be changed after opening
@@ -223,6 +224,12 @@ namespace librbd {
                             const char *snap, IoCtx& p, bool read_only) {
       return new ImageCtx(image_name, image_id, snap, p, read_only);
     }
+    static ImageCtx* create(const std::string &image_name,
+                            const std::string &image_id,
+                            librados::snap_t snap_id, IoCtx& p,
+                            bool read_only) {
+      return new ImageCtx(image_name, image_id, snap_id, p, read_only);
+    }
     void destroy() {
       delete this;
     }
@@ -234,6 +241,8 @@ namespace librbd {
      */
     ImageCtx(const std::string &image_name, const std::string &image_id,
 	     const char *snap, IoCtx& p, bool read_only);
+    ImageCtx(const std::string &image_name, const std::string &image_id,
+	     librados::snap_t snap_id, IoCtx& p, bool read_only);
     ~ImageCtx();
     void init();
     void shutdown();

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -122,6 +122,7 @@ namespace librbd {
     ParentInfo parent_md;
     ImageCtx *parent;
     ImageCtx *child = nullptr;
+    MigrationInfo migration_info;
     cls::rbd::GroupSpec group_spec;
     uint64_t stripe_unit, stripe_count;
     uint64_t flags;
@@ -157,6 +158,8 @@ namespace librbd {
     EventSocket event_socket;
 
     ContextWQ *op_work_queue;
+
+    bool ignore_migrating = false;
 
     // Configuration
     static const string METADATA_CONF_PREFIX;

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -124,6 +124,7 @@ namespace librbd {
     ImageCtx *parent;
     ImageCtx *child = nullptr;
     MigrationInfo migration_info;
+    ImageCtx *migration_parent = nullptr;
     cls::rbd::GroupSpec group_spec;
     uint64_t stripe_unit, stripe_count;
     uint64_t flags;

--- a/src/librbd/ImageState.h
+++ b/src/librbd/ImageState.h
@@ -26,8 +26,8 @@ public:
   ImageState(ImageCtxT *image_ctx);
   ~ImageState();
 
-  int open(bool skip_open_parent);
-  void open(bool skip_open_parent, Context *on_finish);
+  int open(uint64_t flags);
+  void open(uint64_t flags, Context *on_finish);
 
   int close();
   void close(Context *on_finish);
@@ -110,7 +110,7 @@ private:
 
   ImageUpdateWatchers *m_update_watchers;
 
-  bool m_skip_open_parent_image;
+  uint64_t m_open_flags;
 
   bool is_transition_state() const;
   bool is_closed() const;

--- a/src/librbd/ImageWatcher.cc
+++ b/src/librbd/ImageWatcher.cc
@@ -282,6 +282,20 @@ void ImageWatcher<I>::notify_update_features(uint64_t features, bool enabled,
 }
 
 template <typename I>
+void ImageWatcher<I>::notify_migrate(uint64_t request_id,
+                                     ProgressContext &prog_ctx,
+                                     Context *on_finish) {
+  assert(m_image_ctx.owner_lock.is_locked());
+  assert(m_image_ctx.exclusive_lock &&
+         !m_image_ctx.exclusive_lock->is_lock_owner());
+
+  AsyncRequestId async_request_id(get_client_id(), request_id);
+
+  notify_async_request(async_request_id, MigratePayload(async_request_id),
+                       prog_ctx, on_finish);
+}
+
+template <typename I>
 void ImageWatcher<I>::notify_header_update(Context *on_finish) {
   ldout(m_image_ctx.cct, 10) << this << ": " << __func__ << dendl;
 
@@ -905,6 +919,33 @@ bool ImageWatcher<I>::handle_payload(const UpdateFeaturesPayload& payload,
       m_image_ctx.operations->execute_update_features(
         payload.features, payload.enabled, new C_ResponseMessage(ack_ctx), 0);
       return false;
+    } else if (r < 0) {
+      encode(ResponseMessage(r), ack_ctx->out);
+    }
+  }
+  return true;
+}
+
+template <typename I>
+bool ImageWatcher<I>::handle_payload(const MigratePayload &payload,
+				     C_NotifyAck *ack_ctx) {
+
+  RWLock::RLocker l(m_image_ctx.owner_lock);
+  if (m_image_ctx.exclusive_lock != nullptr) {
+    int r;
+    if (m_image_ctx.exclusive_lock->accept_requests(&r)) {
+      bool new_request;
+      Context *ctx;
+      ProgressContext *prog_ctx;
+      r = prepare_async_request(payload.async_request_id, &new_request,
+                                &ctx, &prog_ctx);
+      if (r == 0 && new_request) {
+        ldout(m_image_ctx.cct, 10) << this << " remote migrate request: "
+				   << payload.async_request_id << dendl;
+        m_image_ctx.operations->execute_migrate(*prog_ctx, ctx);
+      }
+
+      encode(ResponseMessage(r), ack_ctx->out);
     } else if (r < 0) {
       encode(ResponseMessage(r), ack_ctx->out);
     }

--- a/src/librbd/ImageWatcher.h
+++ b/src/librbd/ImageWatcher.h
@@ -65,6 +65,9 @@ public:
   void notify_update_features(uint64_t features, bool enabled,
                               Context *on_finish);
 
+  void notify_migrate(uint64_t request_id, ProgressContext &prog_ctx,
+                      Context *on_finish);
+
   void notify_acquired_lock();
   void notify_released_lock();
   void notify_request_lock();
@@ -232,6 +235,8 @@ private:
   bool handle_payload(const watch_notify::RenamePayload& payload,
                       C_NotifyAck *ctx);
   bool handle_payload(const watch_notify::UpdateFeaturesPayload& payload,
+                      C_NotifyAck *ctx);
+  bool handle_payload(const watch_notify::MigratePayload& payload,
                       C_NotifyAck *ctx);
   bool handle_payload(const watch_notify::UnknownPayload& payload,
                       C_NotifyAck *ctx);

--- a/src/librbd/Operations.h
+++ b/src/librbd/Operations.h
@@ -100,6 +100,9 @@ public:
   int metadata_remove(const std::string &key);
   void execute_metadata_remove(const std::string &key, Context *on_finish);
 
+  int migrate(ProgressContext &prog_ctx);
+  void execute_migrate(ProgressContext &prog_ctx, Context *on_finish);
+
   int prepare_image_update(bool request_lock);
 
 private:

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -114,6 +114,10 @@ struct SnapInfo {
   }
 };
 
+enum {
+  OPEN_FLAG_SKIP_OPEN_PARENT = 1 << 0,
+};
+
 } // namespace librbd
 
 #endif // LIBRBD_TYPES_H

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -6,6 +6,7 @@
 
 #include "include/types.h"
 #include "cls/rbd/cls_rbd_types.h"
+#include "deep_copy/Types.h"
 #include <map>
 #include <string>
 
@@ -117,6 +118,29 @@ struct SnapInfo {
 enum {
   OPEN_FLAG_SKIP_OPEN_PARENT = 1 << 0,
   OPEN_FLAG_OLD_FORMAT = 1 << 1,
+  OPEN_FLAG_IGNORE_MIGRATING = 1 << 2,
+};
+
+struct MigrationInfo {
+  int64_t pool_id = -1;
+  std::string image_name;
+  std::string image_id;
+  deep_copy::SnapMap snap_map;
+  uint64_t overlap = 0;
+  bool flatten = false;
+
+  MigrationInfo() {
+  }
+  MigrationInfo(int64_t pool_id, std::string image_name, std::string image_id,
+                const deep_copy::SnapMap &snap_map, uint64_t overlap,
+                bool flatten)
+    : pool_id(pool_id), image_name(image_name), image_id(image_id),
+      snap_map(snap_map), overlap(overlap), flatten(flatten) {
+  }
+
+  bool empty() const {
+    return pool_id == -1;
+  }
 };
 
 } // namespace librbd

--- a/src/librbd/Types.h
+++ b/src/librbd/Types.h
@@ -116,6 +116,7 @@ struct SnapInfo {
 
 enum {
   OPEN_FLAG_SKIP_OPEN_PARENT = 1 << 0,
+  OPEN_FLAG_OLD_FORMAT = 1 << 1,
 };
 
 } // namespace librbd

--- a/src/librbd/WatchNotifyTypes.cc
+++ b/src/librbd/WatchNotifyTypes.cc
@@ -368,6 +368,9 @@ void NotifyMessage::decode(bufferlist::const_iterator& iter) {
   case NOTIFY_OP_UPDATE_FEATURES:
     payload = UpdateFeaturesPayload();
     break;
+  case NOTIFY_OP_MIGRATE:
+    payload = MigratePayload();
+    break;
   default:
     payload = UnknownPayload();
     break;
@@ -402,6 +405,7 @@ void NotifyMessage::generate_test_instances(std::list<NotifyMessage *> &o) {
   o.push_back(new NotifyMessage(RebuildObjectMapPayload(AsyncRequestId(ClientId(0, 1), 2))));
   o.push_back(new NotifyMessage(RenamePayload("foo")));
   o.push_back(new NotifyMessage(UpdateFeaturesPayload(1, true)));
+  o.push_back(new NotifyMessage(MigratePayload(AsyncRequestId(ClientId(0, 1), 2))));
 }
 
 void ResponseMessage::encode(bufferlist& bl) const {
@@ -476,6 +480,9 @@ std::ostream &operator<<(std::ostream &out,
     break;
   case NOTIFY_OP_UPDATE_FEATURES:
     out << "UpdateFeatures";
+    break;
+  case NOTIFY_OP_MIGRATE:
+    out << "Migrate";
     break;
   default:
     out << "Unknown (" << static_cast<uint32_t>(op) << ")";

--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -65,6 +65,7 @@ enum NotifyOp {
   NOTIFY_OP_SNAP_UNPROTECT     = 13,
   NOTIFY_OP_RENAME             = 14,
   NOTIFY_OP_UPDATE_FEATURES    = 15,
+  NOTIFY_OP_MIGRATE            = 16,
 };
 
 struct AcquiredLockPayload {
@@ -301,6 +302,14 @@ struct UpdateFeaturesPayload {
   void dump(Formatter *f) const;
 };
 
+struct MigratePayload : public AsyncRequestPayloadBase {
+  static const NotifyOp NOTIFY_OP = NOTIFY_OP_MIGRATE;
+  static const bool CHECK_FOR_REFRESH = true;
+
+  MigratePayload() {}
+  MigratePayload(const AsyncRequestId &id) : AsyncRequestPayloadBase(id) {}
+};
+
 struct UnknownPayload {
   static const NotifyOp NOTIFY_OP = static_cast<NotifyOp>(-1);
   static const bool CHECK_FOR_REFRESH = false;
@@ -326,6 +335,7 @@ typedef boost::variant<AcquiredLockPayload,
                        RebuildObjectMapPayload,
                        RenamePayload,
                        UpdateFeaturesPayload,
+                       MigratePayload,
                        UnknownPayload> Payload;
 
 struct NotifyMessage {

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -235,7 +235,7 @@ int group_snap_remove_by_record(librados::IoCtx& group_ioctx,
 
     C_SaferCond* on_finish = new C_SaferCond;
 
-    image_ctx->state->open(false, on_finish);
+    image_ctx->state->open(0, on_finish);
 
     ictxs.push_back(image_ctx);
     on_finishes.push_back(on_finish);
@@ -787,7 +787,7 @@ int Group<I>::snap_create(librados::IoCtx& group_ioctx,
 
     C_SaferCond* on_finish = new C_SaferCond;
 
-    image_ctx->state->open(false, on_finish);
+    image_ctx->state->open(0, on_finish);
 
     ictxs.push_back(image_ctx);
     on_finishes.push_back(on_finish);

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -248,38 +248,13 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
     // TODO support clone v2 parent namespaces
     parent_io_ctx.set_namespace(dest_md_ctx.get_namespace());
 
-    ImageCtx *src_parent_image_ctx =
-      new ImageCtx("", parent_spec.image_id, nullptr, parent_io_ctx, false);
-    r = src_parent_image_ctx->state->open(true);
-    if (r < 0) {
-      if (r != -ENOENT) {
-        lderr(cct) << "failed to open source parent image: "
-                   << cpp_strerror(r) << dendl;
-      }
-      return r;
-    }
-
-    C_SaferCond cond;
-    src_parent_image_ctx->state->snap_set(parent_spec.snap_id, &cond);
-    r = cond.wait();
-    if (r < 0) {
-      if (r != -ENOENT) {
-        lderr(cct) << "failed to set snapshot: " << cpp_strerror(r) << dendl;
-      }
-      return r;
-    }
-
     C_SaferCond ctx;
     std::string dest_id = util::generate_image_id(dest_md_ctx);
     auto *req = image::CloneRequest<I>::create(
-      src_parent_image_ctx, dest_md_ctx, destname, dest_id, opts,
-      "", "", src->op_work_queue, &ctx);
+      parent_io_ctx, parent_spec.image_id, "", parent_spec.snap_id, dest_md_ctx,
+      destname, dest_id, opts, "", "", src->op_work_queue, &ctx);
     req->send();
     r = ctx.wait();
-    int close_r = src_parent_image_ctx->state->close();
-    if (r == 0 && close_r < 0) {
-      r = close_r;
-    }
   }
   if (r < 0) {
     lderr(cct) << "header creation failed" << dendl;

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -262,7 +262,7 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
   }
   opts.set(RBD_IMAGE_OPTION_ORDER, static_cast<uint64_t>(order));
 
-  ImageCtx *dest = new librbd::ImageCtx(destname, "", NULL,
+  ImageCtx *dest = new librbd::ImageCtx(destname, "", nullptr,
                                         dest_md_ctx, false);
   r = dest->state->open(0);
   if (r < 0) {

--- a/src/librbd/api/Image.cc
+++ b/src/librbd/api/Image.cc
@@ -264,7 +264,7 @@ int Image<I>::deep_copy(I *src, librados::IoCtx& dest_md_ctx,
 
   ImageCtx *dest = new librbd::ImageCtx(destname, "", NULL,
                                         dest_md_ctx, false);
-  r = dest->state->open(false);
+  r = dest->state->open(0);
   if (r < 0) {
     lderr(cct) << "failed to read newly created header" << dendl;
     return r;

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -15,6 +15,7 @@
 #include "librbd/api/Group.h"
 #include "librbd/deep_copy/MetadataCopyRequest.h"
 #include "librbd/deep_copy/SnapshotCopyRequest.h"
+#include "librbd/image/CloneRequest.h"
 #include "librbd/image/CreateRequest.h"
 #include "librbd/image/ListWatchersRequest.h"
 #include "librbd/image/RemoveRequest.h"
@@ -1130,21 +1131,49 @@ int Migration<I>::create_dst_image() {
   ldout(m_cct, 10) << dendl;
 
   uint64_t size;
+  ParentSpec parent_spec;
   {
     RWLock::RLocker snap_locker(m_src_image_ctx->snap_lock);
+    RWLock::RLocker parent_locker(m_src_image_ctx->parent_lock);
     size = m_src_image_ctx->size;
+
+    // use oldest snapshot or HEAD for parent spec
+    if (!m_src_image_ctx->snap_info.empty()) {
+      parent_spec = m_src_image_ctx->snap_info.begin()->second.parent.spec;
+    } else {
+      parent_spec = m_src_image_ctx->parent_md.spec;
+    }
   }
 
   ThreadPool *thread_pool;
   ContextWQ *op_work_queue;
   ImageCtx::get_thread_pool_instance(m_cct, &thread_pool, &op_work_queue);
 
+  int r;
   C_SaferCond on_create;
-  auto *req = image::CreateRequest<I>::create(
-      m_dst_io_ctx, m_dst_image_name, m_dst_image_id, size, m_image_options, "",
-      "", true /* skip_mirror_enable */, op_work_queue, &on_create);
-  req->send();
-  int r = on_create.wait();
+  librados::Rados rados(m_src_image_ctx->md_ctx);
+  librados::IoCtx parent_io_ctx;
+  if (parent_spec.pool_id == -1) {
+    auto *req = image::CreateRequest<I>::create(
+      m_dst_io_ctx, m_dst_image_name, m_dst_image_id, size, m_image_options,
+      "", "", true /* skip_mirror_enable */, op_work_queue, &on_create);
+    req->send();
+  } else {
+    r = rados.ioctx_create2(parent_spec.pool_id, parent_io_ctx);
+    if (r < 0) {
+      lderr(m_cct) << "failed to open source parent pool: "
+                   << cpp_strerror(r) << dendl;
+      return r;
+    }
+
+    auto *req = image::CloneRequest<I>::create(
+      parent_io_ctx, parent_spec.image_id, "", parent_spec.snap_id,
+      m_dst_io_ctx, m_dst_image_name, m_dst_image_id, m_image_options, "", "",
+      op_work_queue, &on_create);
+    req->send();
+  }
+
+  r = on_create.wait();
   if (r < 0) {
     lderr(m_cct) << "header creation failed: " << cpp_strerror(r) << dendl;
     return r;

--- a/src/librbd/api/Migration.cc
+++ b/src/librbd/api/Migration.cc
@@ -1,0 +1,1336 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/api/Migration.h"
+#include "include/rados/librados.hpp"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/Utils.h"
+#include "librbd/api/Group.h"
+#include "librbd/deep_copy/MetadataCopyRequest.h"
+#include "librbd/deep_copy/SnapshotCopyRequest.h"
+#include "librbd/image/CreateRequest.h"
+#include "librbd/image/ListWatchersRequest.h"
+#include "librbd/image/RemoveRequest.h"
+#include "librbd/internal.h"
+#include "librbd/io/ImageRequestWQ.h"
+#include "librbd/mirror/DisableRequest.h"
+#include "librbd/mirror/EnableRequest.h"
+
+#include <boost/scope_exit.hpp>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::Migration: " << __func__ << ": "
+
+namespace librbd {
+namespace api {
+
+namespace {
+
+int trash_search(librados::IoCtx &io_ctx, rbd_trash_image_source_t source,
+                 const std::string &image_name, std::string *image_id) {
+  std::vector<trash_image_info_t> entries;
+
+  int r = trash_list(io_ctx, entries);
+  if (r < 0) {
+    return r;
+  }
+
+  for (auto &entry : entries) {
+    if (entry.source == source && entry.name == image_name) {
+      *image_id = entry.id;
+      return 0;
+    }
+  }
+
+  return -ENOENT;
+}
+
+template <typename I>
+int open_source_image(librados::IoCtx& io_ctx, const std::string &image_name,
+                      I **src_image_ctx, librados::IoCtx *dst_io_ctx,
+                      std::string *dst_image_name, std::string *dst_image_id,
+                      bool *flatten, bool *mirroring,
+                      cls::rbd::MigrationState *state,
+                      std::string *state_description) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  librados::IoCtx src_io_ctx;
+  std::string src_image_name;
+  std::string src_image_id;
+  cls::rbd::MigrationSpec migration_spec;
+  I *image_ctx = I::create(image_name, "", nullptr, io_ctx, false);
+
+  ldout(cct, 10) << "trying to open image by name " << io_ctx.get_pool_name()
+                 << "/" << image_name << dendl;
+
+  int r = image_ctx->state->open(OPEN_FLAG_IGNORE_MIGRATING);
+  if (r < 0) {
+    if (r != -ENOENT) {
+      lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;
+      return r;
+    }
+    image_ctx = nullptr;
+  }
+
+  BOOST_SCOPE_EXIT_TPL(&r, &image_ctx) {
+    if (r != 0 && image_ctx != nullptr) {
+      image_ctx->state->close();
+    }
+  } BOOST_SCOPE_EXIT_END;
+
+  if (r == 0) {
+    // The opened image is either a source (then just proceed) or a
+    // destination (then look for the source image id in the migration
+    // header).
+
+    r = cls_client::migration_get(&image_ctx->md_ctx, image_ctx->header_oid,
+                                  &migration_spec);
+
+    if (r < 0) {
+      lderr(cct) << "failed retrieving migration header: " << cpp_strerror(r)
+                 << dendl;
+      return r;
+    }
+
+    ldout(cct, 10) << "migration spec: " << migration_spec << dendl;
+
+    if (migration_spec.header_type != cls::rbd::MIGRATION_HEADER_TYPE_SRC &&
+        migration_spec.header_type != cls::rbd::MIGRATION_HEADER_TYPE_DST) {
+        lderr(cct) << "unexpected migration header type: "
+                   << migration_spec.header_type << dendl;
+        r = -EINVAL;
+        return r;
+    }
+
+    if (migration_spec.header_type == cls::rbd::MIGRATION_HEADER_TYPE_DST) {
+      ldout(cct, 10) << "the destination image is opened" << dendl;
+
+      // Close and look for the source image.
+      r = image_ctx->state->close();
+      image_ctx = nullptr;
+      if (r < 0) {
+        lderr(cct) << "failed closing image: " << cpp_strerror(r)
+                   << dendl;
+        return r;
+      }
+
+      if (io_ctx.get_id() == migration_spec.pool_id) {
+        src_io_ctx.dup(io_ctx);
+      } else {
+        r = librados::Rados(io_ctx).ioctx_create2(migration_spec.pool_id,
+                                                  src_io_ctx);
+        if (r < 0) {
+          lderr(cct) << "error accessing source pool "
+                     << migration_spec.pool_id << ": " << cpp_strerror(r)
+                     << dendl;
+          return r;
+        }
+      }
+
+      src_image_name = migration_spec.image_name;
+      src_image_id = migration_spec.image_id;
+    } else {
+      ldout(cct, 10) << "the source image is opened" << dendl;
+    }
+  } else {
+    assert (r == -ENOENT);
+
+    ldout(cct, 10) << "source image is not found. Trying trash" << dendl;
+
+    r = trash_search(io_ctx, RBD_TRASH_IMAGE_SOURCE_MIGRATION, image_name,
+                     &src_image_id);
+    if (r < 0) {
+      lderr(cct) << "failed to determine image id: " << cpp_strerror(r)
+                 << dendl;
+      return r;
+    }
+
+    ldout(cct, 10) << "source image id from trash: " << src_image_id << dendl;
+
+    src_io_ctx.dup(io_ctx);
+  }
+
+  if (image_ctx == nullptr) {
+    int flags = OPEN_FLAG_IGNORE_MIGRATING;
+
+    if (src_image_id.empty()) {
+      ldout(cct, 20) << "trying to open v1 image by name "
+                     << src_io_ctx.get_pool_name() << "/" << src_image_name
+                     << dendl;
+
+      flags |= OPEN_FLAG_OLD_FORMAT;
+    } else {
+      ldout(cct, 20) << "trying to open v2 image by id "
+                     << src_io_ctx.get_pool_name() << "/" << src_image_id
+                     << dendl;
+    }
+
+    image_ctx = I::create(src_image_name, src_image_id, nullptr, src_io_ctx,
+                          false);
+    r = image_ctx->state->open(flags);
+    if (r < 0) {
+      lderr(cct) << "failed to open source image " << src_io_ctx.get_pool_name()
+                 << "/" << (src_image_id.empty() ? src_image_name : src_image_id)
+                 << ": " << cpp_strerror(r) << dendl;
+      image_ctx = nullptr;
+      return r;
+    }
+
+    r = cls_client::migration_get(&image_ctx->md_ctx, image_ctx->header_oid,
+                                  &migration_spec);
+    if (r < 0) {
+      lderr(cct) << "failed retrieving migration header: " << cpp_strerror(r)
+                 << dendl;
+      return r;
+    }
+
+    ldout(cct, 20) << "migration spec: " << migration_spec << dendl;
+  }
+
+  if (image_ctx->md_ctx.get_id() == migration_spec.pool_id) {
+    dst_io_ctx->dup(io_ctx);
+  } else {
+    r = librados::Rados(image_ctx->md_ctx).ioctx_create2(migration_spec.pool_id,
+                                                         *dst_io_ctx);
+    if (r < 0) {
+      lderr(cct) << "error accessing destination pool "
+                 << migration_spec.pool_id << ": " << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  *src_image_ctx = image_ctx;
+  *dst_image_name = migration_spec.image_name;
+  *dst_image_id = migration_spec.image_id;
+  *flatten = migration_spec.flatten;
+  *mirroring = migration_spec.mirroring;
+  *state = migration_spec.state;
+  *state_description = migration_spec.state_description;
+
+  return 0;
+}
+
+} // anonymous namespace
+
+template <typename I>
+int Migration<I>::prepare(librados::IoCtx& io_ctx,
+                          const std::string &image_name,
+                          librados::IoCtx& dest_io_ctx,
+                          const std::string &dest_image_name_,
+                          ImageOptions& opts) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  std::string dest_image_name = dest_image_name_.empty() ? image_name :
+    dest_image_name_;
+
+  ldout(cct, 10) << io_ctx.get_pool_name() << "/" << image_name << " -> "
+                 << dest_io_ctx.get_pool_name() << "/" << dest_image_name
+                 << ", opts=" << opts << dendl;
+
+  auto image_ctx = I::create(image_name, "", nullptr, io_ctx, false);
+  int r = image_ctx->state->open(0);
+  if (r < 0) {
+    lderr(cct) << "failed to open image: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+  BOOST_SCOPE_EXIT_TPL(image_ctx) {
+    image_ctx->state->close();
+  } BOOST_SCOPE_EXIT_END;
+
+  std::list<obj_watch_t> watchers;
+  int flags = librbd::image::LIST_WATCHERS_FILTER_OUT_MY_INSTANCE |
+              librbd::image::LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES;
+  C_SaferCond on_list_watchers;
+  auto list_watchers_request = librbd::image::ListWatchersRequest<I>::create(
+      *image_ctx, flags, &watchers, &on_list_watchers);
+  list_watchers_request->send();
+  r = on_list_watchers.wait();
+  if (r < 0) {
+    lderr(cct) << "failed listing watchers:" << cpp_strerror(r) << dendl;
+    return r;
+  }
+  if (!watchers.empty()) {
+    lderr(cct) << "image has watchers - not migrating" << dendl;
+    return -EBUSY;
+  }
+
+  uint64_t format = 2;
+  if (opts.get(RBD_IMAGE_OPTION_FORMAT, &format) != 0) {
+    opts.set(RBD_IMAGE_OPTION_FORMAT, format);
+  }
+  if (format != 2) {
+    lderr(cct) << "unsupported destination image format: " << format << dendl;
+    return -EINVAL;
+  }
+
+  uint64_t features;
+  {
+    RWLock::RLocker snap_locker(image_ctx->snap_lock);
+    features = image_ctx->features;
+  }
+  opts.get(RBD_IMAGE_OPTION_FEATURES, &features);
+  if ((features & ~RBD_FEATURES_ALL) != 0) {
+    lderr(cct) << "librbd does not support requested features" << dendl;
+    return -ENOSYS;
+  }
+  features &= ~RBD_FEATURES_INTERNAL;
+  features |= RBD_FEATURE_MIGRATING;
+  opts.set(RBD_IMAGE_OPTION_FEATURES, features);
+
+  uint64_t order = image_ctx->order;
+  if (opts.get(RBD_IMAGE_OPTION_ORDER, &order) != 0) {
+    opts.set(RBD_IMAGE_OPTION_ORDER, order);
+  }
+  r = image::CreateRequest<I>::validate_order(cct, order);
+  if (r < 0) {
+    return r;
+  }
+
+  uint64_t stripe_unit = image_ctx->stripe_unit;
+  if (opts.get(RBD_IMAGE_OPTION_STRIPE_UNIT, &stripe_unit) != 0) {
+    opts.set(RBD_IMAGE_OPTION_STRIPE_UNIT, stripe_unit);
+  }
+  uint64_t stripe_count = image_ctx->stripe_count;
+  if (opts.get(RBD_IMAGE_OPTION_STRIPE_COUNT, &stripe_count) != 0) {
+    opts.set(RBD_IMAGE_OPTION_STRIPE_COUNT, stripe_count);
+  }
+
+  uint64_t flatten = 0;
+  if (opts.get(RBD_IMAGE_OPTION_FLATTEN, &flatten) == 0) {
+    opts.unset(RBD_IMAGE_OPTION_FLATTEN);
+  }
+
+  ldout(cct, 20) << "updated opts=" << opts << dendl;
+
+  Migration migration(image_ctx, dest_io_ctx, dest_image_name, "", opts, flatten > 0,
+                      false, cls::rbd::MIGRATION_STATE_PREPARING, "", nullptr);
+  r = migration.prepare();
+
+  features &= ~RBD_FEATURE_MIGRATING;
+  opts.set(RBD_IMAGE_OPTION_FEATURES, features);
+
+  return r;
+}
+
+template <typename I>
+int Migration<I>::execute(librados::IoCtx& io_ctx,
+                          const std::string &image_name,
+                          ProgressContext &prog_ctx) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  ldout(cct, 10) << io_ctx.get_pool_name() << "/" << image_name << dendl;
+
+  I *image_ctx;
+  librados::IoCtx dest_io_ctx;
+  std::string dest_image_name;
+  std::string dest_image_id;
+  bool flatten;
+  bool mirroring;
+  cls::rbd::MigrationState state;
+  std::string state_description;
+
+  int r = open_source_image(io_ctx, image_name, &image_ctx, &dest_io_ctx,
+                            &dest_image_name, &dest_image_id, &flatten,
+                            &mirroring, &state, &state_description);
+  if (r < 0) {
+    return r;
+  }
+
+  BOOST_SCOPE_EXIT_TPL(image_ctx) {
+    image_ctx->state->close();
+  } BOOST_SCOPE_EXIT_END;
+
+  if (state != cls::rbd::MIGRATION_STATE_PREPARED) {
+    lderr(cct) << "current migration state is '" << state << "'"
+               << " (should be 'prepared')" << dendl;
+    return -EINVAL;
+  }
+
+  ldout(cct, 5) << "migrating " << image_ctx->md_ctx.get_pool_name() << "/"
+                << image_ctx->name << " -> " << dest_io_ctx.get_pool_name()
+                << "/" << dest_image_name << dendl;
+
+  ImageOptions opts;
+  Migration migration(image_ctx, dest_io_ctx, dest_image_name, dest_image_id,
+                      opts, flatten, mirroring, state, state_description,
+                      &prog_ctx);
+  r = migration.execute();
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::abort(librados::IoCtx& io_ctx, const std::string &image_name,
+                        ProgressContext &prog_ctx) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  ldout(cct, 10) << io_ctx.get_pool_name() << "/" << image_name << dendl;
+
+  I *image_ctx;
+  librados::IoCtx dest_io_ctx;
+  std::string dest_image_name;
+  std::string dest_image_id;
+  bool flatten;
+  bool mirroring;
+  cls::rbd::MigrationState state;
+  std::string state_description;
+
+  int r = open_source_image(io_ctx, image_name, &image_ctx, &dest_io_ctx,
+                            &dest_image_name, &dest_image_id, &flatten,
+                            &mirroring, &state, &state_description);
+  if (r < 0) {
+    return r;
+  }
+
+  ldout(cct, 5) << "canceling incomplete migration "
+                << image_ctx->md_ctx.get_pool_name() << "/" << image_ctx->name
+                << " -> " << dest_io_ctx.get_pool_name() << "/" << dest_image_name
+                << dendl;
+
+  ImageOptions opts;
+  Migration migration(image_ctx, dest_io_ctx, dest_image_name, dest_image_id,
+                      opts, flatten, mirroring, state, state_description,
+                      &prog_ctx);
+  r = migration.abort();
+
+  image_ctx->state->close();
+
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::commit(librados::IoCtx& io_ctx,
+                         const std::string &image_name,
+                         ProgressContext &prog_ctx) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  ldout(cct, 10) << io_ctx.get_pool_name() << "/" << image_name << dendl;
+
+  I *image_ctx;
+  librados::IoCtx dest_io_ctx;
+  std::string dest_image_name;
+  std::string dest_image_id;
+  bool flatten;
+  bool mirroring;
+  cls::rbd::MigrationState state;
+  std::string state_description;
+
+  int r = open_source_image(io_ctx, image_name, &image_ctx, &dest_io_ctx,
+                            &dest_image_name, &dest_image_id, &flatten,
+                            &mirroring, &state, &state_description);
+  if (r < 0) {
+    return r;
+  }
+
+  if (state != cls::rbd::MIGRATION_STATE_EXECUTED) {
+    lderr(cct) << "current migration state is '" << state << "'"
+               << " (should be 'executed')" << dendl;
+    image_ctx->state->close();
+    return -EINVAL;
+  }
+
+  ldout(cct, 5) << "migrating " << image_ctx->md_ctx.get_pool_name() << "/"
+                << image_ctx->name << " -> " << dest_io_ctx.get_pool_name()
+                << "/" << dest_image_name << dendl;
+
+  ImageOptions opts;
+  Migration migration(image_ctx, dest_io_ctx, dest_image_name, dest_image_id,
+                      opts, flatten, mirroring, state, state_description,
+                      &prog_ctx);
+  r = migration.commit();
+
+  // image_ctx is closed in commit when removing src image
+
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::status(librados::IoCtx& io_ctx,
+                         const std::string &image_name,
+                         image_migration_status_t *status) {
+  CephContext* cct = reinterpret_cast<CephContext *>(io_ctx.cct());
+
+  ldout(cct, 10) << io_ctx.get_pool_name() << "/" << image_name << dendl;
+
+  I *image_ctx;
+  librados::IoCtx dest_io_ctx;
+  std::string dest_image_name;
+  std::string dest_image_id;
+  bool flatten;
+  bool mirroring;
+  cls::rbd::MigrationState state;
+  std::string state_description;
+
+  int r = open_source_image(io_ctx, image_name, &image_ctx, &dest_io_ctx,
+                            &dest_image_name, &dest_image_id, &flatten,
+                            &mirroring, &state, &state_description);
+  if (r < 0) {
+    return r;
+  }
+
+  ldout(cct, 5) << "migrating " << image_ctx->md_ctx.get_pool_name() << "/"
+                << image_ctx->name << " -> " << dest_io_ctx.get_pool_name()
+                << "/" << dest_image_name << dendl;
+
+  ImageOptions opts;
+  Migration migration(image_ctx, dest_io_ctx, dest_image_name, dest_image_id,
+                      opts, flatten, mirroring, state, state_description,
+                      nullptr);
+  r = migration.status(status);
+
+  image_ctx->state->close();
+
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+Migration<I>::Migration(I *src_image_ctx, librados::IoCtx& dst_io_ctx,
+                        const std::string &dstname,
+                        const std::string &dst_image_id,
+                        ImageOptions& opts, bool flatten, bool mirroring,
+                        cls::rbd::MigrationState state,
+                        const std::string &state_description,
+                        ProgressContext *prog_ctx)
+  : m_cct(static_cast<CephContext *>(dst_io_ctx.cct())),
+    m_src_image_ctx(src_image_ctx), m_dst_io_ctx(dst_io_ctx),
+    m_src_old_format(m_src_image_ctx->old_format),
+    m_src_image_name(m_src_image_ctx->old_format ? m_src_image_ctx->name : ""),
+    m_src_image_id(m_src_image_ctx->id),
+    m_src_header_oid(m_src_image_ctx->header_oid), m_dst_image_name(dstname),
+    m_dst_image_id(dst_image_id.empty() ?
+                   util::generate_image_id(m_dst_io_ctx) : dst_image_id),
+    m_dst_header_oid(util::header_name(m_dst_image_id)), m_image_options(opts),
+    m_flatten(flatten), m_mirroring(mirroring), m_prog_ctx(prog_ctx),
+    m_src_migration_spec(cls::rbd::MIGRATION_HEADER_TYPE_SRC,
+                         m_dst_io_ctx.get_id(), m_dst_image_name,
+                         m_dst_image_id, {}, 0, flatten, mirroring, state,
+                         state_description),
+    m_dst_migration_spec(cls::rbd::MIGRATION_HEADER_TYPE_DST,
+                         src_image_ctx->md_ctx.get_id(), m_src_image_ctx->name,
+                         m_src_image_ctx->id, {}, 0, flatten, mirroring, state,
+                         state_description) {
+  m_src_io_ctx.dup(src_image_ctx->md_ctx);
+}
+
+template <typename I>
+int Migration<I>::prepare() {
+  ldout(m_cct, 10) << dendl;
+
+  int r = list_snaps();
+  if (r < 0) {
+    return r;
+  }
+
+  r = disable_mirroring(m_src_image_ctx, &m_mirroring);
+  if (r < 0) {
+    return r;
+  }
+
+  r = unlink_src_image();
+  if (r < 0) {
+    enable_mirroring(m_src_image_ctx, m_mirroring);
+    return r;
+  }
+
+  r = set_migration();
+  if (r < 0) {
+    relink_src_image();
+    enable_mirroring(m_src_image_ctx, m_mirroring);
+    return r;
+  }
+
+  r = create_dst_image();
+  if (r < 0) {
+    abort();
+    return r;
+  }
+
+  r = set_state(cls::rbd::MIGRATION_STATE_PREPARED, "");
+  if (r < 0) {
+    return r;
+  }
+
+  ldout(m_cct, 10) << "succeeded" << dendl;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::execute() {
+  ldout(m_cct, 10) << dendl;
+
+  auto dst_image_ctx = I::create(m_dst_image_name, m_dst_image_id, nullptr,
+                                 m_dst_io_ctx, false);
+  int r = dst_image_ctx->state->open(0);
+  if (r < 0) {
+    lderr(m_cct) << "failed to open destination image: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  BOOST_SCOPE_EXIT_TPL(dst_image_ctx) {
+    dst_image_ctx->state->close();
+  } BOOST_SCOPE_EXIT_END;
+
+  r = set_state(cls::rbd::MIGRATION_STATE_EXECUTING, "");
+  if (r < 0) {
+    return r;
+  }
+
+  while (true) {
+    r = dst_image_ctx->operations->migrate(*m_prog_ctx);
+    if (r == -EROFS) {
+      RWLock::RLocker owner_locker(dst_image_ctx->owner_lock);
+      if (dst_image_ctx->exclusive_lock != nullptr &&
+          !dst_image_ctx->exclusive_lock->accept_ops()) {
+        ldout(m_cct, 5) << "lost exclusive lock, retrying remote" << dendl;
+        continue;
+      }
+    }
+    break;
+  }
+  if (r < 0) {
+    lderr(m_cct) << "migration failed: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  r = set_state(cls::rbd::MIGRATION_STATE_EXECUTED, "");
+  if (r < 0) {
+    return r;
+  }
+
+  dst_image_ctx->notify_update();
+
+  ldout(m_cct, 10) << "succeeded" << dendl;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::abort() {
+  ldout(m_cct, 10) << dendl;
+
+  int r;
+
+  m_src_image_ctx->owner_lock.get_read();
+  if (m_src_image_ctx->exclusive_lock != nullptr &&
+      !m_src_image_ctx->exclusive_lock->is_lock_owner()) {
+    C_SaferCond ctx;
+    m_src_image_ctx->exclusive_lock->acquire_lock(&ctx);
+    m_src_image_ctx->owner_lock.put_read();
+    r = ctx.wait();
+    if (r < 0) {
+      lderr(m_cct) << "error acquiring exclusive lock: " << cpp_strerror(r)
+                   << dendl;
+      return r;
+    }
+  } else {
+    m_src_image_ctx->owner_lock.put_read();
+  }
+
+  group_info_t group_info;
+  group_info.pool = -1;
+
+  auto dst_image_ctx = I::create(m_dst_image_name, m_dst_image_id, nullptr,
+                                 m_dst_io_ctx, false);
+  r = dst_image_ctx->state->open(OPEN_FLAG_IGNORE_MIGRATING);
+  if (r < 0) {
+    ldout(m_cct, 1) << "failed to open destination image: " << cpp_strerror(r)
+                    << dendl;
+  } else {
+    ldout(m_cct, 10) << "removing dst image snapshots" << dendl;
+
+    BOOST_SCOPE_EXIT_TPL(&dst_image_ctx) {
+      if (dst_image_ctx != nullptr) {
+        dst_image_ctx->state->close();
+      }
+    } BOOST_SCOPE_EXIT_END;
+
+    std::vector<librbd::snap_info_t> snaps;
+    r = snap_list(dst_image_ctx, snaps);
+    if (r < 0) {
+      lderr(m_cct) << "failed listing snapshots: " << cpp_strerror(r)
+                   << dendl;
+      return r;
+    }
+
+    for (auto &snap : snaps) {
+      librbd::NoOpProgressContext prog_ctx;
+      int r = snap_remove(dst_image_ctx, snap.name.c_str(), 0, prog_ctx);
+      if (r < 0) {
+        lderr(m_cct) << "failed removing snapshot: " << cpp_strerror(r)
+                     << dendl;
+        return r;
+      }
+    }
+
+    ldout(m_cct, 10) << "removing group" << dendl;
+
+    r = remove_group(dst_image_ctx, &group_info);
+    if (r < 0 && r != -ENOENT) {
+      return r;
+    }
+
+    ldout(m_cct, 10) << "removing dst image" << dendl;
+
+    assert(dst_image_ctx->ignore_migrating);
+
+    ThreadPool *thread_pool;
+    ContextWQ *op_work_queue;
+    ImageCtx::get_thread_pool_instance(m_cct, &thread_pool, &op_work_queue);
+    C_SaferCond on_remove;
+    auto req = librbd::image::RemoveRequest<>::create(
+      m_dst_io_ctx, dst_image_ctx, false, false, *m_prog_ctx, op_work_queue,
+      &on_remove);
+    req->send();
+    r = on_remove.wait();
+
+    dst_image_ctx = nullptr;
+
+    if (r < 0) {
+      lderr(m_cct) << "failed removing destination image '"
+                   << m_dst_io_ctx.get_pool_name() << "/" << m_dst_image_name
+                   << " (" << m_dst_image_id << ")': " << cpp_strerror(r)
+                   << dendl;
+      // not fatal
+    }
+  }
+
+  r = relink_src_image();
+  if (r < 0) {
+    return r;
+  }
+
+  r = add_group(m_src_image_ctx, group_info);
+  if (r < 0) {
+    return r;
+  }
+
+  r = remove_migration(m_src_image_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = enable_mirroring(m_src_image_ctx, m_mirroring);
+  if (r < 0) {
+    return r;
+  }
+
+  ldout(m_cct, 10) << "succeeded" << dendl;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::commit() {
+  ldout(m_cct, 10) << dendl;
+
+  BOOST_SCOPE_EXIT_TPL(&m_src_image_ctx) {
+    if (m_src_image_ctx != nullptr) {
+      m_src_image_ctx->state->close();
+    }
+  } BOOST_SCOPE_EXIT_END;
+
+  auto dst_image_ctx = I::create(m_dst_image_name, m_dst_image_id, nullptr,
+                                 m_dst_io_ctx, false);
+  int r = dst_image_ctx->state->open(0);
+  if (r < 0) {
+    lderr(m_cct) << "failed to open destination image: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  BOOST_SCOPE_EXIT_TPL(dst_image_ctx) {
+    dst_image_ctx->state->close();
+  } BOOST_SCOPE_EXIT_END;
+
+  r = remove_migration(dst_image_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  r = remove_src_image();
+
+  if (r < 0) {
+    return r;
+  }
+
+  r = enable_mirroring(dst_image_ctx, m_mirroring);
+  if (r < 0) {
+    return r;
+  }
+
+  ldout(m_cct, 10) << "succeeded" << dendl;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::status(image_migration_status_t *status) {
+  ldout(m_cct, 10) << dendl;
+
+  status->source_pool_id = m_dst_migration_spec.pool_id;
+  status->source_image_name = m_dst_migration_spec.image_name;
+  status->source_image_id = m_dst_migration_spec.image_id;
+  status->dest_pool_id = m_src_migration_spec.pool_id;
+  status->dest_image_name = m_src_migration_spec.image_name;
+  status->dest_image_id = m_src_migration_spec.image_id;
+
+  switch (m_src_migration_spec.state) {
+  case cls::rbd::MIGRATION_STATE_ERROR:
+    status->state = RBD_IMAGE_MIGRATION_STATE_ERROR;
+    break;
+  case cls::rbd::MIGRATION_STATE_PREPARING:
+    status->state = RBD_IMAGE_MIGRATION_STATE_PREPARING;
+    break;
+  case cls::rbd::MIGRATION_STATE_PREPARED:
+    status->state = RBD_IMAGE_MIGRATION_STATE_PREPARED;
+    break;
+  case cls::rbd::MIGRATION_STATE_EXECUTING:
+    status->state = RBD_IMAGE_MIGRATION_STATE_EXECUTING;
+    break;
+  case cls::rbd::MIGRATION_STATE_EXECUTED:
+    status->state = RBD_IMAGE_MIGRATION_STATE_EXECUTED;
+    break;
+  default:
+    status->state = RBD_IMAGE_MIGRATION_STATE_UNKNOWN;
+    break;
+  }
+
+  status->state_description = m_src_migration_spec.state_description;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::set_state(cls::rbd::MigrationState state,
+                            const std::string &description) {
+  int r = cls_client::migration_set_state(&m_src_io_ctx, m_src_header_oid,
+                                          state, description);
+  if (r < 0) {
+    lderr(m_cct) << "failed to set source migration header: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  r = cls_client::migration_set_state(&m_dst_io_ctx, m_dst_header_oid, state,
+                                      description);
+  if (r < 0) {
+    lderr(m_cct) << "failed to set destination migration header: "
+                 << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::list_snaps(std::vector<librbd::snap_info_t> *snapsptr) {
+  ldout(m_cct, 10) << dendl;
+
+  std::vector<librbd::snap_info_t> snaps;
+
+  int r = snap_list(m_src_image_ctx, snaps);
+  if (r < 0) {
+    lderr(m_cct) << "failed listing snapshots: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  for (auto &snap : snaps) {
+    bool is_protected;
+    r = snap_is_protected(m_src_image_ctx, snap.name.c_str(), &is_protected);
+    if (r < 0) {
+      lderr(m_cct) << "failed retrieving snapshot status: " << cpp_strerror(r)
+                   << dendl;
+      return r;
+    }
+    if (is_protected) {
+      lderr(m_cct) << "image has protected snapshot '" << snap.name << "'"
+                   << dendl;
+      return -EBUSY;
+    }
+  }
+
+  if (snapsptr != nullptr) {
+    *snapsptr = snaps;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::set_migration() {
+  ldout(m_cct, 10) << dendl;
+
+  m_src_image_ctx->ignore_migrating = true;
+
+  int r = cls_client::migration_set(&m_src_io_ctx, m_src_header_oid,
+                                    m_src_migration_spec);
+  if (r < 0) {
+    lderr(m_cct) << "failed to set migration header: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  m_src_image_ctx->notify_update();
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::remove_migration(I *image_ctx) {
+  ldout(m_cct, 10) << dendl;
+
+  int r;
+
+  r = cls_client::migration_remove(&image_ctx->md_ctx, image_ctx->header_oid);
+  if (r == -ENOENT) {
+    r = 0;
+  }
+  if (r < 0) {
+    lderr(m_cct) << "failed removing migration header: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  image_ctx->notify_update();
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::unlink_src_image() {
+  if (m_src_old_format) {
+    return v1_unlink_src_image();
+  } else {
+    return v2_unlink_src_image();
+  }
+}
+
+template <typename I>
+int Migration<I>::v1_unlink_src_image() {
+  ldout(m_cct, 10) << dendl;
+
+  int r = tmap_rm(m_src_io_ctx, m_src_image_name);
+  if (r < 0) {
+    lderr(m_cct) << "failed removing " << m_src_image_name << " from tmap: "
+                 << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::v2_unlink_src_image() {
+  ldout(m_cct, 10) << dendl;
+
+  m_src_image_ctx->owner_lock.get_read();
+  if (m_src_image_ctx->exclusive_lock != nullptr &&
+      m_src_image_ctx->exclusive_lock->is_lock_owner()) {
+    C_SaferCond ctx;
+    m_src_image_ctx->exclusive_lock->release_lock(&ctx);
+    m_src_image_ctx->owner_lock.put_read();
+    int r = ctx.wait();
+     if (r < 0) {
+      lderr(m_cct) << "error releasing exclusive lock: " << cpp_strerror(r)
+                   << dendl;
+      return r;
+     }
+  } else {
+    m_src_image_ctx->owner_lock.put_read();
+  }
+
+  int r = trash_move(m_src_io_ctx, RBD_TRASH_IMAGE_SOURCE_MIGRATION,
+                     m_src_image_ctx->name, 0);
+  if (r < 0) {
+    lderr(m_cct) << "failed moving image to trash: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::relink_src_image() {
+  if (m_src_old_format) {
+    return v1_relink_src_image();
+  } else {
+    return v2_relink_src_image();
+  }
+}
+
+template <typename I>
+int Migration<I>::v1_relink_src_image() {
+  ldout(m_cct, 10) << dendl;
+
+  int r = tmap_set(m_src_io_ctx, m_src_image_name);
+  if (r < 0) {
+    lderr(m_cct) << "failed adding " << m_src_image_name << " to tmap: "
+                 << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::v2_relink_src_image() {
+  ldout(m_cct, 10) << dendl;
+
+  int r = trash_restore(m_src_io_ctx, m_src_image_ctx->id, m_src_image_ctx->name);
+  if (r < 0) {
+    lderr(m_cct) << "failed restoring image from trash: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::create_dst_image() {
+  ldout(m_cct, 10) << dendl;
+
+  uint64_t size;
+  {
+    RWLock::RLocker snap_locker(m_src_image_ctx->snap_lock);
+    size = m_src_image_ctx->size;
+  }
+
+  ThreadPool *thread_pool;
+  ContextWQ *op_work_queue;
+  ImageCtx::get_thread_pool_instance(m_cct, &thread_pool, &op_work_queue);
+
+  C_SaferCond on_create;
+  auto *req = image::CreateRequest<I>::create(
+      m_dst_io_ctx, m_dst_image_name, m_dst_image_id, size, m_image_options, "",
+      "", true /* skip_mirror_enable */, op_work_queue, &on_create);
+  req->send();
+  int r = on_create.wait();
+  if (r < 0) {
+    lderr(m_cct) << "header creation failed: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  auto dst_image_ctx = I::create(m_dst_image_name, m_dst_image_id, nullptr,
+                                 m_dst_io_ctx, false);
+
+  r = dst_image_ctx->state->open(OPEN_FLAG_IGNORE_MIGRATING);
+  if (r < 0) {
+    lderr(m_cct) << "failed to open newly created header: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  BOOST_SCOPE_EXIT_TPL(dst_image_ctx) {
+    dst_image_ctx->state->close();
+  } BOOST_SCOPE_EXIT_END;
+
+  {
+    RWLock::RLocker owner_locker(dst_image_ctx->owner_lock);
+    r = dst_image_ctx->operations->prepare_image_update(true);
+    if (r < 0) {
+      lderr(m_cct) << "cannot obtain exclusive lock" << dendl;
+      return r;
+    }
+    if (dst_image_ctx->exclusive_lock != nullptr) {
+      dst_image_ctx->exclusive_lock->block_requests(0);
+    }
+  }
+
+  SnapSeqs snap_seqs;
+
+  C_SaferCond on_snapshot_copy;
+  auto snapshot_copy_req = librbd::deep_copy::SnapshotCopyRequest<I>::create(
+      m_src_image_ctx, dst_image_ctx, CEPH_NOSNAP, m_flatten,
+      m_src_image_ctx->op_work_queue, &snap_seqs, &on_snapshot_copy);
+  snapshot_copy_req->send();
+  r = on_snapshot_copy.wait();
+  if (r < 0) {
+    lderr(m_cct) << "failed to copy snapshots: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  C_SaferCond on_metadata_copy;
+  auto metadata_copy_req = librbd::deep_copy::MetadataCopyRequest<I>::create(
+      m_src_image_ctx, dst_image_ctx, &on_metadata_copy);
+  metadata_copy_req->send();
+  r = on_metadata_copy.wait();
+  if (r < 0) {
+    lderr(m_cct) << "failed to copy metadata: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  m_dst_migration_spec = {cls::rbd::MIGRATION_HEADER_TYPE_DST,
+                          m_src_io_ctx.get_id(), m_src_image_name,
+                          m_src_image_id, snap_seqs, size, m_flatten,
+                          m_mirroring, cls::rbd::MIGRATION_STATE_PREPARING, ""};
+
+  r = cls_client::migration_set(&m_dst_io_ctx, m_dst_header_oid,
+                                m_dst_migration_spec);
+  if (r < 0) {
+    lderr(m_cct) << "failed to set migration header: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  r = update_group(m_src_image_ctx, dst_image_ctx);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::remove_group(I *image_ctx, group_info_t *group_info) {
+  int r = librbd::api::Group<I>::image_get_group(image_ctx, group_info);
+  if (r < 0) {
+    lderr(m_cct) << "failed to get image group: " << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  if (group_info->pool == -1) {
+    return -ENOENT;
+  }
+
+  assert(!image_ctx->id.empty());
+
+  ldout(m_cct, 10) << dendl;
+
+  librados::Rados rados(image_ctx->md_ctx);
+  IoCtx group_ioctx;
+  r = rados.ioctx_create2(group_info->pool, group_ioctx);
+  if (r < 0) {
+    lderr(m_cct) << "failed to access pool by ID " << group_info->pool << ": "
+                 << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  r = librbd::api::Group<I>::image_remove_by_id(group_ioctx,
+                                                group_info->name.c_str(),
+                                                image_ctx->md_ctx,
+                                                image_ctx->id.c_str());
+  if (r < 0) {
+    lderr(m_cct) << "failed to remove image from group: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::add_group(I *image_ctx, group_info_t &group_info) {
+  if (group_info.pool == -1) {
+    return 0;
+  }
+
+  ldout(m_cct, 10) << dendl;
+
+  librados::Rados rados(image_ctx->md_ctx);
+  IoCtx group_ioctx;
+  int r = rados.ioctx_create2(group_info.pool, group_ioctx);
+  if (r < 0) {
+    lderr(m_cct) << "failed to access pool by ID " << group_info.pool << ": "
+                 << cpp_strerror(r) << dendl;
+    return r;
+  }
+
+  r = librbd::api::Group<I>::image_add(group_ioctx, group_info.name.c_str(),
+                                       image_ctx->md_ctx,
+                                       image_ctx->name.c_str());
+  if (r < 0) {
+    lderr(m_cct) << "failed to add image to group: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::update_group(I *from_image_ctx, I *to_image_ctx) {
+  ldout(m_cct, 10) << dendl;
+
+  group_info_t group_info;
+
+  int r = remove_group(from_image_ctx, &group_info);
+  if (r < 0) {
+    return r == -ENOENT ? 0 : r;
+  }
+
+  r = add_group(to_image_ctx, group_info);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::disable_mirroring(I *image_ctx, bool *was_enabled) {
+  *was_enabled = false;
+
+  if (!image_ctx->test_features(RBD_FEATURE_JOURNALING)) {
+    return 0;
+  }
+
+  cls::rbd::MirrorImage mirror_image;
+  int r = cls_client::mirror_image_get(&image_ctx->md_ctx, image_ctx->id,
+                                       &mirror_image);
+  if (r == -ENOENT) {
+    ldout(m_cct, 10) << "mirroring is not enabled for this image" << dendl;
+    return 0;
+  }
+
+  if (r < 0) {
+    lderr(m_cct) << "failed to retrieve mirror image: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  if (mirror_image.state == cls::rbd::MIRROR_IMAGE_STATE_ENABLED) {
+    *was_enabled = true;
+  }
+
+  ldout(m_cct, 10) << dendl;
+
+  C_SaferCond ctx;
+  auto req = mirror::DisableRequest<I>::create(image_ctx, false, true, &ctx);
+  req->send();
+  r = ctx.wait();
+  if (r < 0) {
+    lderr(m_cct) << "failed to disable mirroring: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  m_src_migration_spec.mirroring = true;
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::enable_mirroring(I *image_ctx, bool was_enabled) {
+
+  if (!image_ctx->test_features(RBD_FEATURE_JOURNALING)) {
+    return 0;
+  }
+
+  cls::rbd::MirrorMode mirror_mode;
+  int r = cls_client::mirror_mode_get(&image_ctx->md_ctx, &mirror_mode);
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed to retrieve mirror mode: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  if (mirror_mode == cls::rbd::MIRROR_MODE_DISABLED) {
+    ldout(m_cct, 10) << "mirroring is not enabled for destination pool"
+                     << dendl;
+    return 0;
+  }
+  if (mirror_mode == cls::rbd::MIRROR_MODE_IMAGE && !was_enabled) {
+    ldout(m_cct, 10) << "mirroring is not enabled for image" << dendl;
+    return 0;
+  }
+
+  ldout(m_cct, 10) << dendl;
+
+  C_SaferCond ctx;
+  auto req = mirror::EnableRequest<I>::create(image_ctx->md_ctx, image_ctx->id,
+                                              "", image_ctx->op_work_queue,
+                                              &ctx);
+  req->send();
+  r = ctx.wait();
+  if (r < 0) {
+    lderr(m_cct) << "failed to enable mirroring: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  return 0;
+}
+
+template <typename I>
+int Migration<I>::remove_src_image() {
+  ldout(m_cct, 10) << dendl;
+
+  std::vector<librbd::snap_info_t> snaps;
+  int r = list_snaps(&snaps);
+  if (r < 0) {
+    return r;
+  }
+
+  for (auto &snap : snaps) {
+    librbd::NoOpProgressContext prog_ctx;
+    int r = snap_remove(m_src_image_ctx, snap.name.c_str(), 0, prog_ctx);
+    if (r < 0) {
+      lderr(m_cct) << "failed removing snapshot '" << snap.name << "': "
+                   << cpp_strerror(r) << dendl;
+      return r;
+    }
+  }
+
+  assert(m_src_image_ctx->ignore_migrating);
+
+  ThreadPool *thread_pool;
+  ContextWQ *op_work_queue;
+  ImageCtx::get_thread_pool_instance(m_cct, &thread_pool, &op_work_queue);
+  C_SaferCond on_remove;
+  auto req = librbd::image::RemoveRequest<I>::create(
+      m_src_io_ctx, m_src_image_ctx, false, true, *m_prog_ctx, op_work_queue,
+      &on_remove);
+  req->send();
+  r = on_remove.wait();
+
+  m_src_image_ctx = nullptr;
+
+  // For old format image it will return -ENOENT due to expected
+  // tmap_rm failure at the end.
+  if (r < 0 && r != -ENOENT) {
+    lderr(m_cct) << "failed removing source image: " << cpp_strerror(r)
+                 << dendl;
+    return r;
+  }
+
+  if (!m_src_image_id.empty()) {
+    r = cls_client::trash_remove(&m_src_io_ctx, m_src_image_id);
+    if (r < 0 && r != -ENOENT) {
+      lderr(m_cct) << "error removing image " << m_src_image_id
+                   << " from rbd_trash object" << dendl;
+    }
+  }
+
+  return 0;
+}
+
+} // namespace api
+} // namespace librbd
+
+template class librbd::api::Migration<librbd::ImageCtx>;

--- a/src/librbd/api/Migration.h
+++ b/src/librbd/api/Migration.h
@@ -1,0 +1,100 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_API_MIGRATION_H
+#define CEPH_LIBRBD_API_MIGRATION_H
+
+#include "include/int_types.h"
+#include "include/rbd/librbd.hpp"
+#include "cls/rbd/cls_rbd_types.h"
+
+#include <vector>
+
+namespace librados {
+
+class IoCtx;
+
+}
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace api {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class Migration {
+public:
+  static int prepare(librados::IoCtx& io_ctx, const std::string &image_name,
+                     librados::IoCtx& dest_io_ctx,
+                     const std::string &dest_image_name, ImageOptions& opts);
+  static int execute(librados::IoCtx& io_ctx, const std::string &image_name,
+                     ProgressContext &prog_ctx);
+  static int abort(librados::IoCtx& io_ctx, const std::string &image_name,
+                   ProgressContext &prog_ctx);
+  static int commit(librados::IoCtx& io_ctx, const std::string &image_name,
+                    ProgressContext &prog_ctx);
+  static int status(librados::IoCtx& io_ctx, const std::string &image_name,
+                    image_migration_status_t *status);
+
+private:
+  CephContext* m_cct;
+  ImageCtxT *m_src_image_ctx;
+  librados::IoCtx m_src_io_ctx;
+  librados::IoCtx &m_dst_io_ctx;
+  bool m_src_old_format;
+  std::string m_src_image_name;
+  std::string m_src_image_id;
+  std::string m_src_header_oid;
+  std::string m_dst_image_name;
+  std::string m_dst_image_id;
+  std::string m_dst_header_oid;
+  ImageOptions &m_image_options;
+  bool m_flatten;
+  bool m_mirroring;
+  ProgressContext *m_prog_ctx;
+
+  cls::rbd::MigrationSpec m_src_migration_spec;
+  cls::rbd::MigrationSpec m_dst_migration_spec;
+
+  Migration(ImageCtxT *image_ctx, librados::IoCtx& dest_io_ctx,
+            const std::string &dest_image_name, const std::string &dst_image_id,
+            ImageOptions& opts, bool flatten, bool mirroring,
+            cls::rbd::MigrationState state, const std::string &state_desc,
+            ProgressContext *prog_ctx);
+
+  int prepare();
+  int execute();
+  int abort();
+  int commit();
+  int status(image_migration_status_t *status);
+
+  int set_state(cls::rbd::MigrationState state, const std::string &description);
+
+  int list_snaps(std::vector<librbd::snap_info_t> *snaps = nullptr);
+  int disable_mirroring(ImageCtxT *image_ctx, bool *was_enabled);
+  int enable_mirroring(ImageCtxT *image_ctx, bool was_enabled);
+  int set_migration();
+  int unlink_src_image();
+  int relink_src_image();
+  int create_dst_image();
+  int remove_group(ImageCtxT *image_ctx, group_info_t *group_info);
+  int add_group(ImageCtxT *image_ctx, group_info_t &group_info);
+  int update_group(ImageCtxT *from_image_ctx, ImageCtxT *to_image_ctx);
+  int remove_migration(ImageCtxT *image_ctx);
+  int remove_src_image();
+
+  int v1_set_migration();
+  int v2_set_migration();
+  int v1_unlink_src_image();
+  int v2_unlink_src_image();
+  int v1_relink_src_image();
+  int v2_relink_src_image();
+};
+
+} // namespace api
+} // namespace librbd
+
+extern template class librbd::api::Migration<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_API_MIGRATION_H

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -596,7 +596,7 @@ int Mirror<I>::mode_set(librados::IoCtx& io_ctx,
 
       if ((features & RBD_FEATURE_JOURNALING) != 0) {
         I *img_ctx = I::create("", img_pair.second, nullptr, io_ctx, false);
-        r = img_ctx->state->open(false);
+        r = img_ctx->state->open(0);
         if (r < 0) {
           lderr(cct) << "error opening image "<< img_pair.first << ": "
                      << cpp_strerror(r) << dendl;
@@ -640,7 +640,7 @@ int Mirror<I>::mode_set(librados::IoCtx& io_ctx,
         }
       } else {
         I *img_ctx = I::create("", img_id, nullptr, io_ctx, false);
-        r = img_ctx->state->open(false);
+        r = img_ctx->state->open(0);
         if (r < 0) {
           lderr(cct) << "error opening image id "<< img_id << ": "
                      << cpp_strerror(r) << dendl;

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -200,7 +200,7 @@ void ImageCopyRequest<I>::handle_object_copy(uint64_t object_no, int r) {
     assert(m_current_ops > 0);
     --m_current_ops;
 
-    if (r < 0) {
+    if (r < 0 && r != -ENOENT) {
       lderr(m_cct) << "object copy failed: " << cpp_strerror(r) << dendl;
       if (m_ret_val == 0) {
         m_ret_val = r;

--- a/src/librbd/deep_copy/ImageCopyRequest.cc
+++ b/src/librbd/deep_copy/ImageCopyRequest.cc
@@ -8,7 +8,6 @@
 #include "librbd/deep_copy/Utils.h"
 #include "librbd/image/CloseRequest.h"
 #include "librbd/image/OpenRequest.h"
-#include "librbd/image/SetSnapRequest.h"
 #include "osdc/Striper.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -62,6 +61,7 @@ void ImageCopyRequest<I>::cancel() {
 
 template <typename I>
 void ImageCopyRequest<I>::send_open_parent() {
+  ParentSpec parent_spec;
   {
     RWLock::RLocker snap_locker(m_src_image_ctx->snap_lock);
     RWLock::RLocker parent_locker(m_src_image_ctx->parent_lock);
@@ -72,24 +72,24 @@ void ImageCopyRequest<I>::send_open_parent() {
         ldout(m_cct, 20) << "could not find parent info for snap id " << snap_id
                          << dendl;
     } else {
-      m_parent_spec = parent_info->spec;
+      parent_spec = parent_info->spec;
     }
   }
 
-  if (m_parent_spec.pool_id == -1) {
+  if (parent_spec.pool_id == -1) {
     send_object_copies();
     return;
   }
 
-  ldout(m_cct, 20) << "pool_id=" << m_parent_spec.pool_id << ", image_id="
-                   << m_parent_spec.image_id << ", snap_id="
-                   << m_parent_spec.snap_id << dendl;
+  ldout(m_cct, 20) << "pool_id=" << parent_spec.pool_id << ", image_id="
+                   << parent_spec.image_id << ", snap_id="
+                   << parent_spec.snap_id << dendl;
 
   librados::Rados rados(m_src_image_ctx->md_ctx);
   librados::IoCtx parent_io_ctx;
-  int r = rados.ioctx_create2(m_parent_spec.pool_id, parent_io_ctx);
+  int r = rados.ioctx_create2(parent_spec.pool_id, parent_io_ctx);
   if (r < 0) {
-    lderr(m_cct) << "failed to access parent pool (id=" << m_parent_spec.pool_id
+    lderr(m_cct) << "failed to access parent pool (id=" << parent_spec.pool_id
                  << "): " << cpp_strerror(r) << dendl;
     finish(r);
     return;
@@ -98,9 +98,8 @@ void ImageCopyRequest<I>::send_open_parent() {
   // TODO support clone v2 parent namespaces
   parent_io_ctx.set_namespace(m_src_image_ctx->md_ctx.get_namespace());
 
-  m_src_parent_image_ctx = I::create("", m_parent_spec.image_id, nullptr,
-                                     parent_io_ctx, true);
-
+  m_src_parent_image_ctx = I::create("", parent_spec.image_id,
+                                     parent_spec.snap_id, parent_io_ctx, true);
   auto ctx = create_context_callback<
     ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_open_parent>(this);
 
@@ -117,31 +116,6 @@ void ImageCopyRequest<I>::handle_open_parent(int r) {
     m_src_parent_image_ctx->destroy();
     m_src_parent_image_ctx = nullptr;
     finish(r);
-    return;
-  }
-
-  send_set_parent_snap();
-}
-
-template <typename I>
-void ImageCopyRequest<I>::send_set_parent_snap() {
-  ldout(m_cct, 20) << dendl;
-
-  auto ctx = create_context_callback<
-    ImageCopyRequest<I>, &ImageCopyRequest<I>::handle_set_parent_snap>(this);
-  auto req = image::SetSnapRequest<I>::create(*m_src_parent_image_ctx,
-                                              m_parent_spec.snap_id, ctx);
-  req->send();
-}
-
-template <typename I>
-void ImageCopyRequest<I>::handle_set_parent_snap(int r) {
-  ldout(m_cct, 20) << "r=" << r << dendl;
-
-  if (r < 0) {
-    lderr(m_cct) << "failed to set parent snap: " << cpp_strerror(r) << dendl;
-    m_ret_val = r;
-    send_close_parent();
     return;
   }
 

--- a/src/librbd/deep_copy/ImageCopyRequest.h
+++ b/src/librbd/deep_copy/ImageCopyRequest.h
@@ -59,9 +59,6 @@ private:
    *    v
    * OPEN_PARENT (skip if not needed)
    *    |
-   *    v
-   * SET_PARENT_SNAP (skip if not needed)
-   *    |
    *    |      . . . . .
    *    |      .       .  (parallel execution of
    *    v      v       .   multiple objects at once)
@@ -98,14 +95,10 @@ private:
   bool m_updating_progress = false;
   SnapMap m_snap_map;
   int m_ret_val = 0;
-  ParentSpec m_parent_spec;
   ImageCtxT *m_src_parent_image_ctx = nullptr;
 
   void send_open_parent();
   void handle_open_parent(int r);
-
-  void send_set_parent_snap();
-  void handle_set_parent_snap(int r);
 
   void send_object_copies();
   void send_next_object_copy();

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -329,6 +329,11 @@ void ObjectCopyRequest<I>::send_write_object() {
   librados::ObjectWriteOperation op;
   uint64_t buffer_offset;
 
+  if (!m_dst_image_ctx->migration_info.empty()) {
+    cls_client::assert_snapc_seq(&op, dst_snap_seq,
+                                 cls::rbd::ASSERT_SNAPC_SEQ_GT_SNAPSET_SEQ);
+  }
+
   for (auto &copy_op : copy_ops) {
     switch (copy_op.type) {
     case COPY_OP_TYPE_WRITE:
@@ -366,7 +371,7 @@ void ObjectCopyRequest<I>::send_write_object() {
     }
   }
 
-  if (op.size() == 0) {
+  if (op.size() == (m_dst_image_ctx->migration_info.empty() ? 0 : 1)) {
     handle_write_object(0);
     return;
   }
@@ -388,7 +393,7 @@ void ObjectCopyRequest<I>::send_write_object() {
     });
   librados::AioCompletion *comp = create_rados_callback(ctx);
   int r = m_dst_io_ctx.aio_operate(m_dst_oid, comp, &op, dst_snap_seq,
-                                   dst_snap_ids);
+                                   dst_snap_ids, nullptr);
   assert(r == 0);
   comp->release();
 }
@@ -398,6 +403,9 @@ void ObjectCopyRequest<I>::handle_write_object(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r == -ENOENT) {
+    r = 0;
+  } else if (r == -ERANGE) {
+    ldout(m_cct, 10) << "concurrent deep copy" << dendl;
     r = 0;
   }
   if (r < 0) {

--- a/src/librbd/deep_copy/ObjectCopyRequest.cc
+++ b/src/librbd/deep_copy/ObjectCopyRequest.cc
@@ -284,7 +284,7 @@ void ObjectCopyRequest<I>::handle_read_from_parent(int r) {
 
   if (m_write_ops.empty()) {
     // nothing to copy
-    finish(0);
+    finish(-ENOENT);
     return;
   }
 

--- a/src/librbd/deep_copy/Types.h
+++ b/src/librbd/deep_copy/Types.h
@@ -5,6 +5,7 @@
 #define CEPH_LIBRBD_DEEP_COPY_TYPES_H
 
 #include "include/int_types.h"
+#include "include/rados/librados.hpp"
 #include <boost/optional.hpp>
 
 namespace librbd {

--- a/src/librbd/deep_copy/Utils.cc
+++ b/src/librbd/deep_copy/Utils.cc
@@ -16,16 +16,11 @@ void compute_snap_map(librados::snap_t snap_id_start,
     snap_ids.insert(snap_ids.begin(), it.second);
     if (it.first < snap_id_start) {
       continue;
-    } else if (snap_id_end != CEPH_NOSNAP && it.first > snap_id_end) {
+    } else if (it.first > snap_id_end) {
       break;
     }
 
     (*snap_map)[it.first] = snap_ids;
-  }
-
-  if (snap_id_end == CEPH_NOSNAP) {
-    snap_ids.insert(snap_ids.begin(), CEPH_NOSNAP);
-    (*snap_map)[CEPH_NOSNAP] = snap_ids;
   }
 }
 

--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -238,7 +238,12 @@ void CloneRequest<I>::send_open() {
   using klass = CloneRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_open>(this);
 
-  m_imctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT, ctx);
+  uint64_t flags = OPEN_FLAG_SKIP_OPEN_PARENT;
+  if ((m_features & RBD_FEATURE_MIGRATING) != 0) {
+    flags |= OPEN_FLAG_IGNORE_MIGRATING;
+  }
+
+  m_imctx->state->open(flags, ctx);
 }
 
 template <typename I>

--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -15,7 +15,8 @@
 
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
-#define dout_prefix *_dout << "librbd::image::CloneRequest: "
+#define dout_prefix *_dout << "librbd::image::CloneRequest: " << this << " " \
+                           << __func__ << ": "
 
 #define MAX_KEYS 64
 
@@ -58,13 +59,13 @@ CloneRequest<I>::CloneRequest(I *p_imctx, IoCtx &c_ioctx,
 
 template <typename I>
 void CloneRequest<I>::send() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
   validate_options();
 }
 
 template <typename I>
 void CloneRequest<I>::validate_options() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
 
   uint64_t format = 0;
   m_opts.get(RBD_IMAGE_OPTION_FORMAT, &format);
@@ -108,7 +109,7 @@ void CloneRequest<I>::validate_options() {
 
 template <typename I>
 void CloneRequest<I>::validate_parent() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
 
   if (m_p_imctx->operations_disabled) {
     lderr(m_cct) << "image operations disabled due to unsupported op features"
@@ -155,12 +156,12 @@ void CloneRequest<I>::validate_parent() {
     return;
   }
 
-  send_validate_child();
+  validate_child();
 }
 
 template <typename I>
-void CloneRequest<I>::send_validate_child() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::validate_child() {
+  ldout(m_cct, 20) << dendl;
 
   using klass = CloneRequest<I>;
   librados::AioCompletion *comp = create_rados_callback<
@@ -177,7 +178,7 @@ void CloneRequest<I>::send_validate_child() {
 
 template <typename I>
 void CloneRequest<I>::handle_validate_child(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r != -ENOENT) {
     lderr(m_cct) << "rbd image " << m_name << " already exists" << dendl;
@@ -185,12 +186,12 @@ void CloneRequest<I>::handle_validate_child(int r) {
     return;
   }
 
-  send_create();
+  create_child();
 }
 
 template <typename I>
-void CloneRequest<I>::send_create() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::create_child() {
+  ldout(m_cct, 20) << dendl;
 
   if (m_use_p_features) {
     m_features = (m_p_features & ~RBD_FEATURES_IMPLICIT_ENABLE);
@@ -208,7 +209,8 @@ void CloneRequest<I>::send_create() {
   m_opts.set(RBD_IMAGE_OPTION_FEATURES, m_features);
 
   using klass = CloneRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_create>(this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_create_child>(this);
 
   RWLock::RLocker snap_locker(m_p_imctx->snap_lock);
   CreateRequest<I> *req = CreateRequest<I>::create(
@@ -218,25 +220,26 @@ void CloneRequest<I>::send_create() {
 }
 
 template <typename I>
-void CloneRequest<I>::handle_create(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+void CloneRequest<I>::handle_create_child(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "error creating child: " << cpp_strerror(r) << dendl;
     complete(r);
     return;
   }
-  send_open();
+  open_child();
 }
 
 template <typename I>
-void CloneRequest<I>::send_open() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::open_child() {
+  ldout(m_cct, 20) << dendl;
 
   m_imctx = I::create(m_name, "", NULL, m_ioctx, false);
 
   using klass = CloneRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_open>(this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_open_child>(this);
 
   uint64_t flags = OPEN_FLAG_SKIP_OPEN_PARENT;
   if ((m_features & RBD_FEATURE_MIGRATING) != 0) {
@@ -247,22 +250,22 @@ void CloneRequest<I>::send_open() {
 }
 
 template <typename I>
-void CloneRequest<I>::handle_open(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+void CloneRequest<I>::handle_open_child(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "Error opening new image: " << cpp_strerror(r) << dendl;
     m_r_saved = r;
-    send_remove();
+    remove_child();
     return;
   }
 
-  send_set_parent();
+  set_parent();
 }
 
 template <typename I>
-void CloneRequest<I>::send_set_parent() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::set_parent() {
+  ldout(m_cct, 20) << dendl;
 
   librados::ObjectWriteOperation op;
   librbd::cls_client::set_parent(&op, m_pspec, m_size);
@@ -277,26 +280,26 @@ void CloneRequest<I>::send_set_parent() {
 
 template <typename I>
 void CloneRequest<I>::handle_set_parent(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "couldn't set parent: " << cpp_strerror(r) << dendl;
     m_r_saved = r;
-    send_close();
+    close_child();
     return;
   }
 
-  send_v2_set_op_feature();
+  v2_set_op_feature();
 }
 
 template <typename I>
-void CloneRequest<I>::send_v2_set_op_feature() {
+void CloneRequest<I>::v2_set_op_feature() {
   if (m_clone_format == 1) {
-    send_v1_add_child();
+    v1_add_child();
     return;
   }
 
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
 
   librados::ObjectWriteOperation op;
   cls_client::op_features_set(&op, RBD_OPERATION_FEATURE_CLONE_CHILD,
@@ -311,21 +314,21 @@ void CloneRequest<I>::send_v2_set_op_feature() {
 
 template <typename I>
 void CloneRequest<I>::handle_v2_set_op_feature(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "failed to enable clone v2: " << cpp_strerror(r) << dendl;
     m_r_saved = r;
-    send_close();
+    close_child();
     return;
   }
 
-  send_v2_child_attach();
+  v2_child_attach();
 }
 
 template <typename I>
-void CloneRequest<I>::send_v2_child_attach() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::v2_child_attach() {
+  ldout(m_cct, 20) << dendl;
 
   librados::ObjectWriteOperation op;
   cls_client::child_attach(&op, m_p_imctx->snap_id,
@@ -340,22 +343,22 @@ void CloneRequest<I>::send_v2_child_attach() {
 
 template <typename I>
 void CloneRequest<I>::handle_v2_child_attach(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "failed to attach child image: " << cpp_strerror(r)
                  << dendl;
     m_r_saved = r;
-    send_close();
+    close_child();
     return;
   }
 
-  send_metadata_list();
+  metadata_list();
 }
 
 template <typename I>
-void CloneRequest<I>::send_v1_add_child() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::v1_add_child() {
+  ldout(m_cct, 20) << dendl;
 
   librados::ObjectWriteOperation op;
   cls_client::add_child(&op, m_pspec, m_id);
@@ -370,21 +373,21 @@ void CloneRequest<I>::send_v1_add_child() {
 
 template <typename I>
 void CloneRequest<I>::handle_v1_add_child(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "couldn't add child: " << cpp_strerror(r) << dendl;
     m_r_saved = r;
-    send_close();
+    close_child();
     return;
   }
 
-  send_v1_refresh();
+  v1_refresh();
 }
 
 template <typename I>
-void CloneRequest<I>::send_v1_refresh() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::v1_refresh() {
+  ldout(m_cct, 20) << dendl;
 
   using klass = CloneRequest<I>;
   RefreshRequest<I> *req = RefreshRequest<I>::create(
@@ -395,7 +398,7 @@ void CloneRequest<I>::send_v1_refresh() {
 
 template <typename I>
 void CloneRequest<I>::handle_v1_refresh(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   bool snap_protected = false;
   if (r == 0) {
@@ -406,16 +409,16 @@ void CloneRequest<I>::handle_v1_refresh(int r) {
 
   if (r < 0 || !snap_protected) {
     m_r_saved = -EINVAL;
-    send_close();
+    close_child();
     return;
   }
 
-  send_metadata_list();
+  metadata_list();
 }
 
 template <typename I>
-void CloneRequest<I>::send_metadata_list() {
-  ldout(m_cct, 20) << this << " " << __func__ << ": "
+void CloneRequest<I>::metadata_list() {
+  ldout(m_cct, 20) << ": "
                    << "start_key=" << m_last_metadata_key << dendl;
 
   librados::ObjectReadOperation op;
@@ -432,7 +435,7 @@ void CloneRequest<I>::send_metadata_list() {
 
 template <typename I>
 void CloneRequest<I>::handle_metadata_list(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   map<string, bufferlist> metadata;
   if (r == 0) {
@@ -447,7 +450,7 @@ void CloneRequest<I>::handle_metadata_list(int r) {
     } else {
       lderr(m_cct) << "couldn't list metadata: " << cpp_strerror(r) << dendl;
       m_r_saved = r;
-      send_close();
+      close_child();
     }
     return;
   }
@@ -458,20 +461,20 @@ void CloneRequest<I>::handle_metadata_list(int r) {
   }
 
   if (metadata.size() == MAX_KEYS) {
-    send_metadata_list();
+    metadata_list();
   } else {
-    send_metadata_set();
+    metadata_set();
   }
 }
 
 template <typename I>
-void CloneRequest<I>::send_metadata_set() {
+void CloneRequest<I>::metadata_set() {
   if (m_pairs.empty()) {
     get_mirror_mode();
     return;
   }
 
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
 
   librados::ObjectWriteOperation op;
   cls_client::metadata_set(&op, m_pairs);
@@ -486,12 +489,12 @@ void CloneRequest<I>::send_metadata_set() {
 
 template <typename I>
 void CloneRequest<I>::handle_metadata_set(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "couldn't set metadata: " << cpp_strerror(r) << dendl;
     m_r_saved = r;
-    send_close();
+    close_child();
   } else {
     get_mirror_mode();
   }
@@ -499,10 +502,10 @@ void CloneRequest<I>::handle_metadata_set(int r) {
 
 template <typename I>
 void CloneRequest<I>::get_mirror_mode() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+  ldout(m_cct, 20) << dendl;
 
   if (!m_imctx->test_features(RBD_FEATURE_JOURNALING)) {
-    send_close();
+    close_child();
     return;
   }
 
@@ -520,7 +523,7 @@ void CloneRequest<I>::get_mirror_mode() {
 
 template <typename I>
 void CloneRequest<I>::handle_get_mirror_mode(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r == 0) {
     auto it = m_out_bl.cbegin();
@@ -532,20 +535,20 @@ void CloneRequest<I>::handle_get_mirror_mode(int r) {
                  << dendl;
 
     m_r_saved = r;
-    send_close();
+    close_child();
   } else {
     if (m_mirror_mode == cls::rbd::MIRROR_MODE_POOL ||
 	!m_non_primary_global_image_id.empty()) {
-      send_enable_mirror();
+      enable_mirror();
     } else {
-      send_close();
+      close_child();
     }
   }
 }
 
 template <typename I>
-void CloneRequest<I>::send_enable_mirror() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::enable_mirror() {
+  ldout(m_cct, 20) << dendl;
 
   using klass = CloneRequest<I>;
   Context *ctx = create_context_callback<
@@ -559,32 +562,32 @@ void CloneRequest<I>::send_enable_mirror() {
 
 template <typename I>
 void CloneRequest<I>::handle_enable_mirror(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "failed to enable mirroring: " << cpp_strerror(r)
                << dendl;
     m_r_saved = r;
   }
-  send_close();
+  close_child();
 }
 
 template <typename I>
-void CloneRequest<I>::send_close() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::close_child() {
+  ldout(m_cct, 20) << dendl;
 
   assert(m_imctx != nullptr);
 
   using klass = CloneRequest<I>;
   Context *ctx = create_async_context_callback(
     *m_imctx, create_context_callback<
-      klass, &klass::handle_close>(this));
+      klass, &klass::handle_close_child>(this));
   m_imctx->state->close(ctx);
 }
 
 template <typename I>
-void CloneRequest<I>::handle_close(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::handle_close_child(int r) {
+  ldout(m_cct, 20) << dendl;
 
   m_imctx->destroy();
   m_imctx = nullptr;
@@ -598,16 +601,17 @@ void CloneRequest<I>::handle_close(int r) {
   if (m_r_saved == 0) {
     complete(0);
   } else {
-    send_remove();
+    remove_child();
   }
 }
 
 template <typename I>
-void CloneRequest<I>::send_remove() {
-  ldout(m_cct, 20) << this << " " << __func__ << dendl;
+void CloneRequest<I>::remove_child() {
+  ldout(m_cct, 20) << dendl;
 
   using klass = CloneRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_remove>(this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_remove_child>(this);
 
   auto req = librbd::image::RemoveRequest<I>::create(
    m_ioctx, m_name, m_id, false, false, m_no_op, m_op_work_queue, ctx);
@@ -615,8 +619,8 @@ void CloneRequest<I>::send_remove() {
 }
 
 template <typename I>
-void CloneRequest<I>::handle_remove(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+void CloneRequest<I>::handle_remove_child(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r < 0) {
     lderr(m_cct) << "Error removing failed clone: "
@@ -627,7 +631,7 @@ void CloneRequest<I>::handle_remove(int r) {
 
 template <typename I>
 void CloneRequest<I>::complete(int r) {
-  ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
+  ldout(m_cct, 20) << "r=" << r << dendl;
 
   if (r == 0) {
     ldout(m_cct, 20) << "done." << dendl;

--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -325,7 +325,7 @@ template <typename I>
 void CloneRequest<I>::open_child() {
   ldout(m_cct, 20) << dendl;
 
-  m_imctx = I::create(m_name, "", NULL, m_ioctx, false);
+  m_imctx = I::create(m_name, "", nullptr, m_ioctx, false);
 
   using klass = CloneRequest<I>;
   Context *ctx = create_context_callback<

--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -238,7 +238,7 @@ void CloneRequest<I>::send_open() {
   using klass = CloneRequest<I>;
   Context *ctx = create_context_callback<klass, &klass::handle_open>(this);
 
-  m_imctx->state->open(true, ctx);
+  m_imctx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT, ctx);
 }
 
 template <typename I>

--- a/src/librbd/image/CloneRequest.h
+++ b/src/librbd/image/CloneRequest.h
@@ -52,17 +52,14 @@ private:
    * <start>
    *    |
    *    v
-   * OPEN PARENT                       <finish>
+   * OPEN PARENT
+   *    |
+   *    v
+   * VALIDATE CHILD                    <finish>
    *    |                                 ^
    *    v                                 |
-   * SET PARENT SNAP  * * * * * * * > CLOSE PARENT
-   *    |                       *         ^
-   *    v                       *         |
-   * VALIDATE CHILD             *         |
-   *    |                       *         |
-   *    v                       *         |
-   * CREATE CHILD * * * * * * * *         |
-   *    |                                 |
+   * CREATE CHILD * * * * * * * * * > CLOSE PARENT
+   *    |                                 ^
    *    v                                 |
    * OPEN CHILD * * * * * * * * * * > REMOVE CHILD
    *    |                                 ^
@@ -140,9 +137,6 @@ private:
 
   void open_parent();
   void handle_open_parent(int r);
-
-  void set_parent_snap();
-  void handle_set_parent_snap(int r);
 
   void validate_parent();
 

--- a/src/librbd/image/CloneRequest.h
+++ b/src/librbd/image/CloneRequest.h
@@ -117,47 +117,47 @@ private:
   void validate_options();
   void validate_parent();
 
-  void send_validate_child();
+  void validate_child();
   void handle_validate_child(int r);
 
-  void send_create();
-  void handle_create(int r);
+  void create_child();
+  void handle_create_child(int r);
 
-  void send_open();
-  void handle_open(int r);
+  void open_child();
+  void handle_open_child(int r);
 
-  void send_set_parent();
+  void set_parent();
   void handle_set_parent(int r);
 
-  void send_v2_set_op_feature();
+  void v2_set_op_feature();
   void handle_v2_set_op_feature(int r);
 
-  void send_v2_child_attach();
+  void v2_child_attach();
   void handle_v2_child_attach(int r);
 
-  void send_v1_add_child();
+  void v1_add_child();
   void handle_v1_add_child(int r);
 
-  void send_v1_refresh();
+  void v1_refresh();
   void handle_v1_refresh(int r);
 
-  void send_metadata_list();
+  void metadata_list();
   void handle_metadata_list(int r);
 
-  void send_metadata_set();
+  void metadata_set();
   void handle_metadata_set(int r);
 
   void get_mirror_mode();
   void handle_get_mirror_mode(int r);
 
-  void send_enable_mirror();
+  void enable_mirror();
   void handle_enable_mirror(int r);
 
-  void send_close();
-  void handle_close(int r);
+  void close_child();
+  void handle_close_child(int r);
 
-  void send_remove();
-  void handle_remove(int r);
+  void remove_child();
+  void handle_remove_child(int r);
 
   void complete(int r);
 };

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -290,6 +290,7 @@ void CloseRequest<I>::handle_close_parent(int r) {
   ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
 
   delete m_image_ctx->parent;
+  m_image_ctx->parent = nullptr;
   save_result(r);
   if (r < 0) {
     lderr(cct) << "error closing parent image: " << cpp_strerror(r) << dendl;

--- a/src/librbd/image/CloseRequest.cc
+++ b/src/librbd/image/CloseRequest.cc
@@ -266,6 +266,36 @@ template <typename I>
 void CloseRequest<I>::handle_flush_op_work_queue(int r) {
   CephContext *cct = m_image_ctx->cct;
   ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+  send_close_migration_parent();
+}
+
+template <typename I>
+void CloseRequest<I>::send_close_migration_parent() {
+  if (m_image_ctx->migration_parent == nullptr) {
+    send_close_parent();
+    return;
+  }
+
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  m_image_ctx->migration_parent->state->close(create_async_context_callback(
+    *m_image_ctx, create_context_callback<
+      CloseRequest<I>, &CloseRequest<I>::handle_close_migration_parent>(this)));
+}
+
+template <typename I>
+void CloseRequest<I>::handle_close_migration_parent(int r) {
+  CephContext *cct = m_image_ctx->cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << r << dendl;
+
+  delete m_image_ctx->migration_parent;
+  m_image_ctx->migration_parent = nullptr;
+  save_result(r);
+  if (r < 0) {
+    lderr(cct) << "error closing migration parent image: " << cpp_strerror(r)
+               << dendl;
+  }
   send_close_parent();
 }
 

--- a/src/librbd/image/CloseRequest.h
+++ b/src/librbd/image/CloseRequest.h
@@ -55,6 +55,9 @@ private:
    *    v
    * FLUSH_OP_WORK_QUEUE
    *    |
+   *    v (skip if no migration parent)
+   * CLOSE_MIGRATION_PARENT
+   *    |
    *    v (skip if no parent)
    * CLOSE_PARENT
    *    |
@@ -102,6 +105,9 @@ private:
 
   void send_flush_op_work_queue();
   void handle_flush_op_work_queue(int r);
+
+  void send_close_migration_parent();
+  void handle_close_migration_parent(int r);
 
   void send_close_parent();
   void handle_close_parent(int r);

--- a/src/librbd/image/CreateRequest.cc
+++ b/src/librbd/image/CreateRequest.cc
@@ -36,7 +36,7 @@ int validate_features(CephContext *cct, uint64_t features,
     lderr(cct) << "librbd does not support requested features." << dendl;
     return -ENOSYS;
   }
-  if ((features & RBD_FEATURES_INTERNAL) != 0) {
+  if ((features & RBD_FEATURE_OPERATIONS) != 0) {
     lderr(cct) << "cannot use internally controlled features" << dendl;
     return -EINVAL;
   }

--- a/src/librbd/image/ListWatchersRequest.cc
+++ b/src/librbd/image/ListWatchersRequest.cc
@@ -1,0 +1,184 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "ListWatchersRequest.h"
+#include "common/RWLock.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageWatcher.h"
+#include "librbd/Utils.h"
+
+#include <algorithm>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::image::ListWatchersRequest: " << this \
+                           << " " << __func__ << ": "
+
+namespace librbd {
+namespace image {
+
+using librados::IoCtx;
+using util::create_rados_callback;
+
+template<typename I>
+ListWatchersRequest<I>::ListWatchersRequest(I &image_ctx, int flags,
+                                            std::list<obj_watch_t> *watchers,
+                                            Context *on_finish)
+  : m_image_ctx(image_ctx), m_flags(flags), m_watchers(watchers),
+    m_on_finish(on_finish), m_cct(m_image_ctx.cct) {
+}
+
+template<typename I>
+void ListWatchersRequest<I>::send() {
+  ldout(m_cct, 20) << dendl;
+
+  list_image_watchers();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::list_image_watchers() {
+  ldout(m_cct, 20) << dendl;
+
+  librados::ObjectReadOperation op;
+  op.list_watchers(&m_object_watchers, &m_ret_val);
+
+  using klass = ListWatchersRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_callback<klass, &klass::handle_list_image_watchers>(this);
+
+  int r = m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid,
+                                         rados_completion, &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::handle_list_image_watchers(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
+
+  if (r == 0 && m_ret_val < 0) {
+    r = m_ret_val;
+  }
+  if (r < 0) {
+    lderr(m_cct) << "error listing image watchers: " << cpp_strerror(r)
+                 << dendl;
+    finish(r);
+    return;
+  }
+
+  get_mirror_image();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::get_mirror_image() {
+  ldout(m_cct, 20) << dendl;
+  if ((m_object_watchers.empty()) ||
+      (m_flags & LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES) == 0 ||
+      (m_image_ctx.features & RBD_FEATURE_JOURNALING) == 0) {
+    finish(0);
+    return;
+  }
+
+  librados::ObjectReadOperation op;
+  cls_client::mirror_image_get_start(&op, m_image_ctx.id);
+
+  using klass = ListWatchersRequest<I>;
+  librados::AioCompletion *comp =
+    create_rados_callback<klass, &klass::handle_get_mirror_image>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
+  assert(r == 0);
+  comp->release();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::handle_get_mirror_image(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
+
+  if (r == -ENOENT) {
+    finish(0);
+    return;
+  } else if (r < 0) {
+    ldout(m_cct, 1) << "error retrieving mirror image: " << cpp_strerror(r)
+                    << dendl;
+  }
+
+  list_mirror_watchers();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::list_mirror_watchers() {
+  ldout(m_cct, 20) << dendl;
+
+  librados::ObjectReadOperation op;
+  op.list_watchers(&m_mirror_watchers, &m_ret_val);
+
+  using klass = ListWatchersRequest<I>;
+  librados::AioCompletion *rados_completion =
+    create_rados_callback<klass, &klass::handle_list_mirror_watchers>(this);
+  m_out_bl.clear();
+  int r = m_image_ctx.md_ctx.aio_operate(RBD_MIRRORING, rados_completion,
+                                         &op, &m_out_bl);
+  assert(r == 0);
+  rados_completion->release();
+}
+
+template<typename I>
+void ListWatchersRequest<I>::handle_list_mirror_watchers(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
+
+  if (r == 0 && m_ret_val < 0) {
+    r = m_ret_val;
+  }
+  if (r < 0 && r != -ENOENT) {
+    ldout(m_cct, 1) << "error listing mirror watchers: " << cpp_strerror(r)
+                    << dendl;
+  }
+  finish(0);
+}
+
+template<typename I>
+void ListWatchersRequest<I>::finish(int r) {
+  ldout(m_cct, 20) << "r=" << r << dendl;
+
+  if (r == 0) {
+    m_watchers->clear();
+
+    if (m_object_watchers.size() > 0) {
+      RWLock::RLocker owner_locker(m_image_ctx.owner_lock);
+      uint64_t watch_handle = m_image_ctx.image_watcher != nullptr ?
+        m_image_ctx.image_watcher->get_watch_handle() : 0;
+
+      for (auto &w : m_object_watchers) {
+        if ((m_flags & LIST_WATCHERS_FILTER_OUT_MY_INSTANCE) != 0) {
+          if (w.cookie == watch_handle) {
+            continue;
+          }
+        }
+        if ((m_flags & LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES) != 0) {
+          auto it = std::find_if(m_mirror_watchers.begin(),
+                                 m_mirror_watchers.end(),
+                                 [w] (obj_watch_t &watcher) {
+                                   return (strncmp(w.addr, watcher.addr,
+                                                   sizeof(w.addr)) == 0);
+                                 });
+          if (it != m_mirror_watchers.end()) {
+            continue;
+          }
+        }
+        m_watchers->push_back(w);
+      }
+    }
+  }
+
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image
+} // namespace librbd
+
+template class librbd::image::ListWatchersRequest<librbd::ImageCtx>;

--- a/src/librbd/image/ListWatchersRequest.h
+++ b/src/librbd/image/ListWatchersRequest.h
@@ -1,0 +1,87 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LIBRBD_IMAGE_LIST_WATCHERS_REQUEST_H
+#define CEPH_LIBRBD_IMAGE_LIST_WATCHERS_REQUEST_H
+
+#include "include/rados/rados_types.hpp"
+
+#include <list>
+
+class Context;
+
+namespace librbd {
+
+class ImageCtx;
+
+namespace image {
+
+enum {
+  LIST_WATCHERS_FILTER_OUT_MY_INSTANCE = 1 << 0,
+  LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES = 1 << 1,
+};
+
+template<typename ImageCtxT = ImageCtx>
+class ListWatchersRequest {
+public:
+  static ListWatchersRequest *create(ImageCtxT &image_ctx, int flags,
+                                     std::list<obj_watch_t> *watchers,
+                                     Context *on_finish) {
+    return new ListWatchersRequest(image_ctx, flags, watchers, on_finish);
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * LIST_IMAGE_WATCHERS
+   *    |
+   *    v
+   * GET_MIRROR_IMAGE (skip if not needed)
+   *    |
+   *    v
+   * LIST_MIRROR_WATCHERS (skip if not needed)
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+
+  ListWatchersRequest(ImageCtxT &image_ctx, int flags, std::list<obj_watch_t> *watchers,
+                      Context *on_finish);
+
+  ImageCtxT& m_image_ctx;
+  int m_flags;
+  std::list<obj_watch_t> *m_watchers;
+  Context *m_on_finish;
+
+  CephContext *m_cct;
+  int m_ret_val;
+  bufferlist m_out_bl;
+  std::list<obj_watch_t> m_object_watchers;
+  std::list<obj_watch_t> m_mirror_watchers;
+
+  void list_image_watchers();
+  void handle_list_image_watchers(int r);
+
+  void get_mirror_image();
+  void handle_get_mirror_image(int r);
+
+  void list_mirror_watchers();
+  void handle_list_mirror_watchers(int r);
+
+  void finish(int r);
+};
+
+} // namespace image
+} // namespace librbd
+
+extern template class librbd::image::ListWatchersRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_IMAGE_LIST_WATCHERS_REQUEST_H

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -30,11 +30,18 @@ OpenRequest<I>::OpenRequest(I *image_ctx, uint64_t flags,
   : m_image_ctx(image_ctx),
     m_skip_open_parent_image(flags & OPEN_FLAG_SKIP_OPEN_PARENT),
     m_on_finish(on_finish), m_error_result(0) {
+  if ((flags & OPEN_FLAG_OLD_FORMAT) != 0) {
+    m_image_ctx->old_format = true;
+  }
 }
 
 template <typename I>
 void OpenRequest<I>::send() {
-  send_v2_detect_header();
+  if (m_image_ctx->old_format) {
+    send_v1_detect_header();
+  } else {
+    send_v2_detect_header();
+  }
 }
 
 template <typename I>

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -516,7 +516,8 @@ Context *OpenRequest<I>::handle_register_watch(int *result) {
 
 template <typename I>
 Context *OpenRequest<I>::send_set_snap(int *result) {
-  if (m_image_ctx->snap_name.empty()) {
+  if (m_image_ctx->snap_name.empty() &&
+      m_image_ctx->open_snap_id == CEPH_NOSNAP) {
     *result = 0;
     return m_on_finish;
   }
@@ -525,7 +526,8 @@ Context *OpenRequest<I>::send_set_snap(int *result) {
   ldout(cct, 10) << this << " " << __func__ << dendl;
 
   uint64_t snap_id = CEPH_NOSNAP;
-  {
+  std::swap(m_image_ctx->open_snap_id, snap_id);
+  if (snap_id == CEPH_NOSNAP) {
     RWLock::RLocker snap_locker(m_image_ctx->snap_lock);
     snap_id = m_image_ctx->get_snap_id(m_image_ctx->snap_namespace,
                                        m_image_ctx->snap_name);

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -25,9 +25,10 @@ using util::create_context_callback;
 using util::create_rados_callback;
 
 template <typename I>
-OpenRequest<I>::OpenRequest(I *image_ctx, bool skip_open_parent,
+OpenRequest<I>::OpenRequest(I *image_ctx, uint64_t flags,
                             Context *on_finish)
-  : m_image_ctx(image_ctx), m_skip_open_parent_image(skip_open_parent),
+  : m_image_ctx(image_ctx),
+    m_skip_open_parent_image(flags & OPEN_FLAG_SKIP_OPEN_PARENT),
     m_on_finish(on_finish), m_error_result(0) {
 }
 

--- a/src/librbd/image/OpenRequest.cc
+++ b/src/librbd/image/OpenRequest.cc
@@ -33,6 +33,9 @@ OpenRequest<I>::OpenRequest(I *image_ctx, uint64_t flags,
   if ((flags & OPEN_FLAG_OLD_FORMAT) != 0) {
     m_image_ctx->old_format = true;
   }
+  if ((flags & OPEN_FLAG_IGNORE_MIGRATING) != 0) {
+    m_image_ctx->ignore_migrating = true;
+  }
 }
 
 template <typename I>

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -19,9 +19,9 @@ namespace image {
 template <typename ImageCtxT = ImageCtx>
 class OpenRequest {
 public:
-  static OpenRequest *create(ImageCtxT *image_ctx, bool skip_open_parent,
+  static OpenRequest *create(ImageCtxT *image_ctx, uint64_t flags,
                              Context *on_finish) {
-    return new OpenRequest(image_ctx, skip_open_parent, on_finish);
+    return new OpenRequest(image_ctx, flags, on_finish);
   }
 
   void send();
@@ -75,7 +75,7 @@ private:
    * @endverbatim
    */
 
-  OpenRequest(ImageCtxT *image_ctx, bool skip_open_parent, Context *on_finish);
+  OpenRequest(ImageCtxT *image_ctx, uint64_t flags, Context *on_finish);
 
   ImageCtxT *m_image_ctx;
   bool m_skip_open_parent_image;

--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -121,11 +121,15 @@ void RefreshParentRequest<I>::send_open_parent() {
     m_parent_image_ctx->set_read_flag(librados::OPERATION_LOCALIZE_READS);
   }
 
+  uint64_t flags = 0;
+  if (m_parent_md.spec.image_id.empty()) {
+    flags |= OPEN_FLAG_OLD_FORMAT;
+  }
   using klass = RefreshParentRequest<I>;
   Context *ctx = create_async_context_callback(
     m_child_image_ctx, create_context_callback<
       klass, &klass::handle_open_parent, false>(this));
-  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, 0, ctx);
+  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, flags, ctx);
   req->send();
 }
 

--- a/src/librbd/image/RefreshParentRequest.cc
+++ b/src/librbd/image/RefreshParentRequest.cc
@@ -125,7 +125,7 @@ void RefreshParentRequest<I>::send_open_parent() {
   Context *ctx = create_async_context_callback(
     m_child_image_ctx, create_context_callback<
       klass, &klass::handle_open_parent, false>(this));
-  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, false, ctx);
+  OpenRequest<I> *req = OpenRequest<I>::create(m_parent_image_ctx, 0, ctx);
   req->send();
 }
 

--- a/src/librbd/image/RefreshParentRequest.h
+++ b/src/librbd/image/RefreshParentRequest.h
@@ -20,12 +20,15 @@ class RefreshParentRequest {
 public:
   static RefreshParentRequest *create(ImageCtxT &child_image_ctx,
                                       const ParentInfo &parent_md,
+                                      const MigrationInfo &migration_info,
                                       Context *on_finish) {
-    return new RefreshParentRequest(child_image_ctx, parent_md, on_finish);
+    return new RefreshParentRequest(child_image_ctx, parent_md, migration_info,
+                                    on_finish);
   }
 
   static bool is_refresh_required(ImageCtxT &child_image_ctx,
-                                  const ParentInfo &parent_md);
+                                  const ParentInfo &parent_md,
+                                  const MigrationInfo &migration_info);
 
   void send();
   void apply();
@@ -59,10 +62,11 @@ private:
    */
 
   RefreshParentRequest(ImageCtxT &child_image_ctx, const ParentInfo &parent_md,
-                       Context *on_finish);
+                       const MigrationInfo &migration_info, Context *on_finish);
 
   ImageCtxT &m_child_image_ctx;
   ParentInfo m_parent_md;
+  MigrationInfo m_migration_info;
   Context *m_on_finish;
 
   ImageCtxT *m_parent_image_ctx;
@@ -71,9 +75,14 @@ private:
   int m_error_result;
 
   static bool is_close_required(ImageCtxT &child_image_ctx,
-                                const ParentInfo &parent_md);
+                                const ParentInfo &parent_md,
+                                const MigrationInfo &migration_info);
   static bool is_open_required(ImageCtxT &child_image_ctx,
-                               const ParentInfo &parent_md);
+                               const ParentInfo &parent_md,
+                               const MigrationInfo &migration_info);
+  static bool does_parent_exist(ImageCtxT &child_image_ctx,
+                                const ParentInfo &parent_md,
+                                const MigrationInfo &migration_info);
 
   void send_open_parent();
   Context *handle_open_parent(int *result);

--- a/src/librbd/image/RefreshParentRequest.h
+++ b/src/librbd/image/RefreshParentRequest.h
@@ -41,19 +41,25 @@ private:
    * <start>
    *    |
    *    | (open required)
-   *    |----------------> OPEN_PARENT * * * * * * * * * * * * * * *
-   *    |                     |                                    *
-   *    |                     v                        (on error)  *
-   *    \----------------> <apply>                                 *
-   *                          |                                    *
-   *                          | (close required)                   *
-   *                          |-----------------> CLOSE_PARENT     *
-   *                          |                      |             *
-   *                          |                      v             *
-   *                          |                   RESET_EXISTENCE  *
-   *                          |                      |             *
-   *                          |                      v             *
-   *                          \-----------------> <finish> < * * * *
+   *    |----------------> OPEN_PARENT * * * * * * * * * * * * * * * * * * * * *
+   *    |                     |                                                *
+   *    |                     v                                                *
+   *    |                  OPEN_MIGRATION_PARENT * * * * * * * * * * * * * *   *
+   *    |                     |             (skip if not                   *   *
+   *    |                     v              needed)                       *   *
+   *    \----------------> <apply>                                         *   *
+   *                          |                              (skip if not  *   *
+   *                          | (close required)              needed)      *   *
+   *                          |-----------------> CLOSE_MIGRATION_PARENT   *   *
+   *                          |                      |                     *   *
+   *                          |                      v                     *   *
+   *                          |                   CLOSE_PARENT  <* * * * * *   *
+   *                          |                      |              (on error) *
+   *                          |                      v                         *
+   *                          |                   RESET_EXISTENCE              *
+   *                          |                      |                         *
+   *                          |                      v                         *
+   *                          \-----------------> <finish> < * * * * * * * * * *
    *
    * @endverbatim
    */
@@ -67,6 +73,7 @@ private:
   Context *m_on_finish;
 
   ImageCtxT *m_parent_image_ctx;
+  ImageCtxT *m_migration_parent_image_ctx = nullptr;
   uint64_t m_parent_snap_id;
 
   int m_error_result;
@@ -83,6 +90,12 @@ private:
 
   void send_open_parent();
   Context *handle_open_parent(int *result);
+
+  void send_open_migration_parent();
+  Context *handle_open_migration_parent(int *result);
+
+  void send_close_migration_parent();
+  Context *handle_close_migration_parent(int *result);
 
   void send_close_parent();
   Context *handle_close_parent(int *result);

--- a/src/librbd/image/RefreshParentRequest.h
+++ b/src/librbd/image/RefreshParentRequest.h
@@ -43,13 +43,10 @@ private:
    *    | (open required)
    *    |----------------> OPEN_PARENT * * * * * * * * * * * * * * *
    *    |                     |                                    *
-   *    |                     v                                    *
-   *    |                  SET_PARENT_SNAP * * * * * *             *
-   *    |                     |                      *             *
-   *    |                     v                      * (on error)  *
-   *    \----------------> <apply>                   *             *
-   *                          |                      *             *
-   *                          | (close required)     v             *
+   *    |                     v                        (on error)  *
+   *    \----------------> <apply>                                 *
+   *                          |                                    *
+   *                          | (close required)                   *
    *                          |-----------------> CLOSE_PARENT     *
    *                          |                      |             *
    *                          |                      v             *
@@ -86,9 +83,6 @@ private:
 
   void send_open_parent();
   Context *handle_open_parent(int *result);
-
-  void send_set_parent_snap();
-  Context *handle_set_parent_snap(int *result);
 
   void send_close_parent();
   Context *handle_close_parent(int *result);

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -15,6 +15,7 @@
 #include "librbd/Journal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"
+#include "librbd/deep_copy/Utils.h"
 #include "librbd/image/RefreshParentRequest.h"
 #include "librbd/io/AioCompletion.h"
 #include "librbd/io/ImageDispatchSpec.h"
@@ -68,6 +69,90 @@ void RefreshRequest<I>::send() {
 }
 
 template <typename I>
+void RefreshRequest<I>::send_get_migration_header() {
+  if (m_image_ctx.ignore_migrating) {
+    if (m_image_ctx.old_format) {
+      send_v1_get_snapshots();
+    } else {
+      send_v2_get_metadata();
+    }
+    return;
+  }
+
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << dendl;
+
+  librados::ObjectReadOperation op;
+  cls_client::migration_get_start(&op);
+
+  using klass = RefreshRequest<I>;
+  librados::AioCompletion *comp =
+    create_rados_callback<klass, &klass::handle_get_migration_header>(this);
+  m_out_bl.clear();
+  m_image_ctx.md_ctx.aio_operate(m_image_ctx.header_oid, comp, &op,
+                                 &m_out_bl);
+  comp->release();
+}
+
+template <typename I>
+Context *RefreshRequest<I>::handle_get_migration_header(int *result) {
+  CephContext *cct = m_image_ctx.cct;
+  ldout(cct, 10) << this << " " << __func__ << ": r=" << *result << dendl;
+
+  if (*result == 0) {
+    auto it = m_out_bl.cbegin();
+    *result = cls_client::migration_get_finish(&it, &m_migration_spec);
+  } else if (*result == -ENOENT) {
+    ldout(cct, 5) << this << " " << __func__ << ": no migration header found"
+                  << ", retrying" << dendl;
+    send();
+    return nullptr;
+  }
+
+  if (*result < 0) {
+    lderr(cct) << "failed to retrieve migration header: "
+               << cpp_strerror(*result) << dendl;
+    return m_on_finish;
+  }
+
+  switch(m_migration_spec.header_type) {
+  case cls::rbd::MIGRATION_HEADER_TYPE_SRC:
+    if (!m_image_ctx.read_only) {
+      lderr(cct) << "image being migrated" << dendl;
+      *result = -EROFS;
+      return m_on_finish;
+    }
+    ldout(cct, 1) << this << " " << __func__ << ": migrating to: "
+                  << m_migration_spec << dendl;
+    break;
+  case cls::rbd::MIGRATION_HEADER_TYPE_DST:
+    ldout(cct, 1) << this << " " << __func__ << ": migrating from: "
+                  << m_migration_spec << dendl;
+    if (m_migration_spec.state != cls::rbd::MIGRATION_STATE_PREPARED &&
+        m_migration_spec.state != cls::rbd::MIGRATION_STATE_EXECUTING &&
+        m_migration_spec.state != cls::rbd::MIGRATION_STATE_EXECUTED) {
+      ldout(cct, 5) << this << " " << __func__ << ": current migration state: "
+                    << m_migration_spec.state << ", retrying" << dendl;
+      send();
+      return nullptr;
+    }
+    break;
+  default:
+    ldout(cct, 1) << this << " " << __func__ << ": migration type "
+                  << m_migration_spec.header_type << dendl;
+    *result = -EBADMSG;
+    return m_on_finish;
+  }
+
+  if (m_image_ctx.old_format) {
+    send_v1_get_snapshots();
+  } else {
+    send_v2_get_metadata();
+  }
+  return nullptr;
+}
+
+template <typename I>
 void RefreshRequest<I>::send_v1_read_header() {
   CephContext *cct = m_image_ctx.cct;
   ldout(cct, 10) << this << " " << __func__ << dendl;
@@ -91,6 +176,7 @@ Context *RefreshRequest<I>::handle_v1_read_header(int *result) {
   ldout(cct, 10) << this << " " << __func__ << ": " << "r=" << *result << dendl;
 
   rbd_obj_header_ondisk v1_header;
+  bool migrating = false;
   if (*result < 0) {
     return m_on_finish;
   } else if (m_out_bl.length() < sizeof(v1_header)) {
@@ -99,16 +185,27 @@ Context *RefreshRequest<I>::handle_v1_read_header(int *result) {
     return m_on_finish;
   } else if (memcmp(RBD_HEADER_TEXT, m_out_bl.c_str(),
                     sizeof(RBD_HEADER_TEXT)) != 0) {
-    lderr(cct) << "unrecognized v1 header" << dendl;
-    *result = -ENXIO;
-    return m_on_finish;
+    if (memcmp(RBD_MIGRATE_HEADER_TEXT, m_out_bl.c_str(),
+               sizeof(RBD_MIGRATE_HEADER_TEXT)) == 0) {
+      ldout(cct, 1) << this << " " << __func__ << ": migration v1 header detected"
+                    << dendl;
+      migrating = true;
+    } else {
+      lderr(cct) << "unrecognized v1 header" << dendl;
+      *result = -ENXIO;
+      return m_on_finish;
+    }
   }
 
   memcpy(&v1_header, m_out_bl.c_str(), sizeof(v1_header));
   m_order = v1_header.options.order;
   m_size = v1_header.image_size;
   m_object_prefix = v1_header.block_name;
-  send_v1_get_snapshots();
+  if (migrating) {
+    send_get_migration_header();
+  } else {
+    send_v1_get_snapshots();
+  }
   return nullptr;
 }
 
@@ -297,6 +394,12 @@ Context *RefreshRequest<I>::handle_v2_get_mutable_metadata(int *result) {
     ldout(cct, 5) << "ignoring dynamically disabled exclusive lock" << dendl;
     m_features |= RBD_FEATURE_EXCLUSIVE_LOCK;
     m_incomplete_update = true;
+  }
+
+  if ((m_features & RBD_FEATURE_MIGRATING) != 0) {
+    ldout(cct, 1) << "migrating feature set" << dendl;
+    send_get_migration_header();
+    return nullptr;
   }
 
   send_v2_get_metadata();
@@ -668,9 +771,11 @@ void RefreshRequest<I>::send_v2_refresh_parent() {
     RWLock::RLocker parent_locker(m_image_ctx.parent_lock);
 
     ParentInfo parent_md;
-    int r = get_parent_info(m_image_ctx.snap_id, &parent_md);
+    MigrationInfo migration_info;
+    int r = get_parent_info(m_image_ctx.snap_id, &parent_md, &migration_info);
     if (!m_skip_open_parent_image && (r < 0 ||
-        RefreshParentRequest<I>::is_refresh_required(m_image_ctx, parent_md))) {
+        RefreshParentRequest<I>::is_refresh_required(m_image_ctx, parent_md,
+                                                     migration_info))) {
       CephContext *cct = m_image_ctx.cct;
       ldout(cct, 10) << this << " " << __func__ << dendl;
 
@@ -678,7 +783,7 @@ void RefreshRequest<I>::send_v2_refresh_parent() {
       Context *ctx = create_context_callback<
         klass, &klass::handle_v2_refresh_parent>(this);
       m_refresh_parent = RefreshParentRequest<I>::create(
-        m_image_ctx, parent_md, ctx);
+        m_image_ctx, parent_md, migration_info, ctx);
     }
   }
 
@@ -1140,6 +1245,8 @@ void RefreshRequest<I>::apply() {
     m_image_ctx.lock_tag = m_lock_tag;
     m_image_ctx.exclusive_locked = m_exclusive_locked;
 
+    std::map<uint64_t, uint64_t> migration_reverse_snap_seq;
+
     if (m_image_ctx.old_format) {
       m_image_ctx.order = m_order;
       m_image_ctx.features = 0;
@@ -1155,7 +1262,15 @@ void RefreshRequest<I>::apply() {
       m_image_ctx.operations_disabled = (
         (m_op_features & ~RBD_OPERATION_FEATURES_ALL) != 0ULL);
       m_image_ctx.group_spec = m_group_spec;
-      m_image_ctx.parent_md = m_parent_md;
+      if (get_migration_info(&m_image_ctx.parent_md,
+                             &m_image_ctx.migration_info)) {
+        for (auto it : m_image_ctx.migration_info.snap_map) {
+          migration_reverse_snap_seq[it.second.front()] = it.first;
+        }
+      } else {
+        m_image_ctx.parent_md = m_parent_md;
+        m_image_ctx.migration_info = {};
+      }
     }
 
     for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
@@ -1174,6 +1289,7 @@ void RefreshRequest<I>::apply() {
     m_image_ctx.snaps.clear();
     m_image_ctx.snap_info.clear();
     m_image_ctx.snap_ids.clear();
+    auto overlap = m_image_ctx.parent_md.overlap;
     for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
       uint64_t flags = m_image_ctx.old_format ? 0 : m_snap_flags[i];
       uint8_t protection_status = m_image_ctx.old_format ?
@@ -1181,15 +1297,27 @@ void RefreshRequest<I>::apply() {
         m_snap_protection[i];
       ParentInfo parent;
       if (!m_image_ctx.old_format) {
-        parent = m_snap_parents[i];
+        if (!m_image_ctx.migration_info.empty()) {
+          parent = m_image_ctx.parent_md;
+          auto it = migration_reverse_snap_seq.find(m_snapc.snaps[i].val);
+          if (it != migration_reverse_snap_seq.end()) {
+            parent.spec.snap_id = it->second;
+            parent.overlap = m_snap_infos[i].image_size;
+          } else {
+            overlap = std::min(overlap, m_snap_infos[i].image_size);
+            parent.overlap = overlap;
+          }
+        } else {
+          parent = m_snap_parents[i];
+        }
       }
-
       m_image_ctx.add_snap(m_snap_infos[i].snapshot_namespace,
                            m_snap_infos[i].name, m_snapc.snaps[i].val,
                            m_snap_infos[i].image_size, parent,
 			   protection_status, flags,
                            m_snap_infos[i].timestamp);
     }
+    m_image_ctx.parent_md.overlap = std::min(overlap, m_image_ctx.size);
     m_image_ctx.snapc = m_snapc;
 
     if (m_image_ctx.snap_id != CEPH_NOSNAP &&
@@ -1240,19 +1368,64 @@ void RefreshRequest<I>::apply() {
 
 template <typename I>
 int RefreshRequest<I>::get_parent_info(uint64_t snap_id,
-                                       ParentInfo *parent_md) {
-  if (snap_id == CEPH_NOSNAP) {
+                                       ParentInfo *parent_md,
+                                       MigrationInfo *migration_info) {
+  if (get_migration_info(parent_md, migration_info)) {
+    return 0;
+  } else if (snap_id == CEPH_NOSNAP) {
     *parent_md = m_parent_md;
+    *migration_info = {};
     return 0;
   } else {
     for (size_t i = 0; i < m_snapc.snaps.size(); ++i) {
       if (m_snapc.snaps[i].val == snap_id) {
         *parent_md = m_snap_parents[i];
+        *migration_info = {};
         return 0;
       }
     }
   }
   return -ENOENT;
+}
+
+template <typename I>
+bool RefreshRequest<I>::get_migration_info(ParentInfo *parent_md,
+                                           MigrationInfo *migration_info) {
+  if (m_migration_spec.header_type != cls::rbd::MIGRATION_HEADER_TYPE_DST ||
+      (m_migration_spec.state != cls::rbd::MIGRATION_STATE_PREPARED &&
+       m_migration_spec.state != cls::rbd::MIGRATION_STATE_EXECUTING)) {
+    assert(m_migration_spec.header_type == cls::rbd::MIGRATION_HEADER_TYPE_SRC ||
+           m_migration_spec.pool_id == -1 ||
+           m_migration_spec.state == cls::rbd::MIGRATION_STATE_EXECUTED);
+
+    return false;
+  }
+
+  parent_md->spec.pool_id = m_migration_spec.pool_id;
+  parent_md->spec.image_id = m_migration_spec.image_id;
+  parent_md->spec.snap_id = CEPH_NOSNAP;
+  parent_md->overlap = m_migration_spec.overlap;
+
+  *migration_info = {m_migration_spec.pool_id, m_migration_spec.image_name,
+                     m_migration_spec.image_id, {}, m_migration_spec.overlap,
+                     m_migration_spec.flatten};
+
+  auto snap_seqs = m_migration_spec.snap_seqs;
+  // If new snapshots have been created on destination image after
+  // migration stared, map the source CEPH_NOSNAP to the earliest of
+  // these snapshots.
+  snapid_t snap_id = snap_seqs.empty() ? 0 : snap_seqs.rbegin()->second;
+  auto it = std::upper_bound(m_snapc.snaps.rbegin(), m_snapc.snaps.rend(),
+                             snap_id);
+  if (it != m_snapc.snaps.rend()) {
+    snap_seqs[CEPH_NOSNAP] = *it;
+  } else {
+    snap_seqs[CEPH_NOSNAP] = CEPH_NOSNAP;
+  }
+
+  deep_copy::util::compute_snap_map(0, CEPH_NOSNAP, snap_seqs,
+                                    &migration_info->snap_map);
+  return true;
 }
 
 } // namespace image

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -11,6 +11,7 @@
 #include "librbd/ExclusiveLock.h"
 #include "librbd/MirroringWatcher.h"
 #include "librbd/image/DetachChildRequest.h"
+#include "librbd/image/ListWatchersRequest.h"
 #include "librbd/journal/DisabledPolicy.h"
 #include "librbd/journal/RemoveRequest.h"
 #include "librbd/mirror/DisableRequest.h"
@@ -229,26 +230,21 @@ template<typename I>
 void RemoveRequest<I>::list_image_watchers() {
   ldout(m_cct, 20) << dendl;
 
-  librados::ObjectReadOperation op;
-  op.list_watchers(&m_watchers, &m_ret_val);
-
+  int flags = LIST_WATCHERS_FILTER_OUT_MY_INSTANCE |
+              LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES;
   using klass = RemoveRequest<I>;
-  librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_list_image_watchers>(this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_list_image_watchers>(this);
 
-  int r = m_image_ctx->md_ctx.aio_operate(m_header_oid, rados_completion,
-                                          &op, &m_out_bl);
-  assert(r == 0);
-  rados_completion->release();
+  auto req = ListWatchersRequest<I>::create(*m_image_ctx, flags, &m_watchers,
+                                            ctx);
+  req->send();
 }
 
 template<typename I>
 void RemoveRequest<I>::handle_list_image_watchers(int r) {
   ldout(m_cct, 20) << "r=" << r << dendl;
 
-  if (r == 0 && m_ret_val < 0) {
-    r = m_ret_val;
-  }
   if (r < 0) {
     lderr(m_cct) << "error listing image watchers: " << cpp_strerror(r)
                  << dendl;
@@ -256,86 +252,12 @@ void RemoveRequest<I>::handle_list_image_watchers(int r) {
     return;
   }
 
-  get_mirror_image();
-}
-
-template<typename I>
-void RemoveRequest<I>::get_mirror_image() {
-  ldout(m_cct, 20) << dendl;
-  if ((m_watchers.empty()) ||
-      ((m_image_ctx->features & RBD_FEATURE_JOURNALING) == 0)) {
-    check_image_watchers();
-    return;
-  }
-
-  librados::ObjectReadOperation op;
-  cls_client::mirror_image_get_start(&op, m_image_id);
-
-  using klass = RemoveRequest<I>;
-  librados::AioCompletion *comp =
-    create_rados_callback<klass, &klass::handle_get_mirror_image>(this);
-  m_out_bl.clear();
-  int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, comp, &op, &m_out_bl);
-  assert(r == 0);
-  comp->release();
-}
-
-template<typename I>
-void RemoveRequest<I>::handle_get_mirror_image(int r) {
-  ldout(m_cct, 20) << "r=" << r << dendl;
-
-  if (r == -ENOENT || r == -EOPNOTSUPP) {
-    check_image_watchers();
-    return;
-  } else if (r < 0) {
-    ldout(m_cct, 5) << "error retrieving mirror image: " << cpp_strerror(r)
-                    << dendl;
-  }
-
-  list_mirror_watchers();
-}
-
-template<typename I>
-void RemoveRequest<I>::list_mirror_watchers() {
-  ldout(m_cct, 20) << dendl;
-
-  librados::ObjectReadOperation op;
-  op.list_watchers(&m_mirror_watchers, &m_ret_val);
-
-  using klass = RemoveRequest<I>;
-  librados::AioCompletion *rados_completion =
-    create_rados_callback<klass, &klass::handle_list_mirror_watchers>(this);
-  m_out_bl.clear();
-  int r = m_image_ctx->md_ctx.aio_operate(RBD_MIRRORING, rados_completion,
-                                          &op, &m_out_bl);
-  assert(r == 0);
-  rados_completion->release();
-}
-
-template<typename I>
-void RemoveRequest<I>::handle_list_mirror_watchers(int r) {
-  ldout(m_cct, 20) << "r=" << r << dendl;
-
-  if (r == 0 && m_ret_val < 0) {
-    r = m_ret_val;
-  }
-  if (r < 0 && r != -ENOENT) {
-    ldout(m_cct, 5) << "error listing mirror watchers: " << cpp_strerror(r)
-                    << dendl;
-  }
-
-  for (auto &watcher : m_mirror_watchers) {
-    m_watchers.remove_if([watcher] (obj_watch_t &w) {
-        return (strncmp(w.addr, watcher.addr, sizeof(w.addr)) == 0);
-      });
-  }
-
   check_image_watchers();
 }
 
 template<typename I>
 void RemoveRequest<I>::check_image_watchers() {
-  if (m_watchers.size() > 1) {
+  if (!m_watchers.empty()) {
     lderr(m_cct) << "image has watchers - not removing" << dendl;
     send_close_image(-EBUSY);
     return;

--- a/src/librbd/image/RemoveRequest.cc
+++ b/src/librbd/image/RemoveRequest.cc
@@ -202,6 +202,13 @@ template<typename I>
 void RemoveRequest<I>::validate_image_removal() {
   ldout(m_cct, 20) << dendl;
 
+  if (!m_image_ctx->ignore_migrating &&
+      m_image_ctx->test_features(RBD_FEATURE_MIGRATING)) {
+    lderr(m_cct) << "image in migration state - not removing" << dendl;
+    send_close_image(-EBUSY);
+    return;
+  }
+
   check_image_snaps();
 }
 

--- a/src/librbd/image/RemoveRequest.h
+++ b/src/librbd/image/RemoveRequest.h
@@ -8,6 +8,8 @@
 #include "librbd/ImageCtx.h"
 #include "librbd/image/TypeTraits.h"
 
+#include <list>
+
 class Context;
 class ContextWQ;
 class SafeTimer;
@@ -142,7 +144,6 @@ private:
   int m_ret_val = 0;
   bufferlist m_out_bl;
   std::list<obj_watch_t> m_watchers;
-  std::list<obj_watch_t> m_mirror_watchers;
 
   std::map<uint64_t, SnapInfo> m_snap_infos;
 
@@ -169,12 +170,6 @@ private:
 
   void list_image_watchers();
   void handle_list_image_watchers(int r);
-
-  void get_mirror_image();
-  void handle_get_mirror_image(int r);
-
-  void list_mirror_watchers();
-  void handle_list_mirror_watchers(int r);
 
   void check_image_watchers();
 

--- a/src/librbd/image/RemoveRequest.h
+++ b/src/librbd/image/RemoveRequest.h
@@ -37,6 +37,15 @@ public:
                              on_finish);
   }
 
+  static RemoveRequest *create(librados::IoCtx &ioctx, ImageCtxT *image_ctx,
+                               bool force, bool from_trash_remove,
+                               ProgressContext &prog_ctx,
+                               ContextWQ *op_work_queue,
+                               Context *on_finish) {
+    return new RemoveRequest(ioctx, image_ctx, force, from_trash_remove,
+                             prog_ctx, op_work_queue, on_finish);
+  }
+
   void send();
 
 private:
@@ -46,7 +55,7 @@ private:
    *                                  <start>
    *                                     |
    *                                     v
-   *                                OPEN IMAGE------------------\
+   *       (skip if already opened) OPEN IMAGE------------------\
    *                                     |                      |
    *                                     v                      |
    *	   error		   CHECK EXCLUSIVE LOCK---\     |
@@ -107,9 +116,14 @@ private:
                 ProgressContext &prog_ctx, ContextWQ *op_work_queue,
                 Context *on_finish);
 
+  RemoveRequest(librados::IoCtx &ioctx, ImageCtxT *image_ctx, bool force,
+                bool from_trash_remove, ProgressContext &prog_ctx,
+                ContextWQ *op_work_queue, Context *on_finish);
+
   librados::IoCtx &m_ioctx;
   std::string m_image_name;
   std::string m_image_id;
+  ImageCtxT *m_image_ctx = nullptr;
   bool m_force;
   bool m_from_trash_remove;
   ProgressContext &m_prog_ctx;
@@ -120,7 +134,6 @@ private:
   std::string m_header_oid;
   bool m_old_format = false;
   bool m_unknown_format = true;
-  ImageCtxT *m_image_ctx;
 
   librados::IoCtx m_parent_io_ctx;
 

--- a/src/librbd/image/SetSnapRequest.cc
+++ b/src/librbd/image/SetSnapRequest.cc
@@ -190,8 +190,8 @@ Context *SetSnapRequest<I>::send_refresh_parent(int *result) {
     }
 
     parent_md = *parent_info;
-    refresh_parent = RefreshParentRequest<I>::is_refresh_required(m_image_ctx,
-                                                                  parent_md);
+    refresh_parent = RefreshParentRequest<I>::is_refresh_required(
+        m_image_ctx, parent_md, m_image_ctx.migration_info);
   }
 
   if (!refresh_parent) {
@@ -212,6 +212,7 @@ Context *SetSnapRequest<I>::send_refresh_parent(int *result) {
   Context *ctx = create_context_callback<
     klass, &klass::handle_refresh_parent>(this);
   m_refresh_parent = RefreshParentRequest<I>::create(m_image_ctx, parent_md,
+                                                     m_image_ctx.migration_info,
                                                      ctx);
   m_refresh_parent->send();
   return nullptr;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -1122,7 +1122,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
       }
     }
 
-    if (parent_snap_name) {
+    if (parent_snap_name && parent_spec.snap_id != CEPH_NOSNAP) {
       RWLock::RLocker l(ictx->parent->snap_lock);
       r = ictx->parent->get_snap_name(parent_spec.snap_id,
 				      parent_snap_name);

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -602,7 +602,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
       ioctx.set_namespace(ictx->md_ctx.get_namespace());
 
       for (auto &id_it : info.second) {
-	ImageCtx *imctx = new ImageCtx("", id_it, NULL, ioctx, false);
+	ImageCtx *imctx = new ImageCtx("", id_it, nullptr, ioctx, false);
 	int r = imctx->state->open(0);
 	if (r < 0) {
 	  lderr(cct) << "error opening image: "
@@ -1813,8 +1813,8 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
     }
     opts.set(RBD_IMAGE_OPTION_ORDER, static_cast<uint64_t>(order));
 
-    ImageCtx *dest = new librbd::ImageCtx(destname, "", NULL,
-					  dest_md_ctx, false);
+    ImageCtx *dest = new librbd::ImageCtx(destname, "", nullptr, dest_md_ctx,
+                                          false);
     r = dest->state->open(0);
     if (r < 0) {
       lderr(cct) << "failed to read newly created header" << dendl;

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -597,7 +597,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
 
       for (auto &id_it : info.second) {
 	ImageCtx *imctx = new ImageCtx("", id_it, NULL, ioctx, false);
-	int r = imctx->state->open(false);
+	int r = imctx->state->open(0);
 	if (r < 0) {
 	  lderr(cct) << "error opening image: "
 		     << cpp_strerror(r) << dendl;
@@ -958,7 +958,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
 
     // make sure parent snapshot exists
     ImageCtx *p_imctx = new ImageCtx(p_name, "", p_snap_name, p_ioctx, true);
-    int r = p_imctx->state->open(false);
+    int r = p_imctx->state->open(0);
     if (r < 0) {
       lderr(cct) << "error opening parent image: "
 		 << cpp_strerror(r) << dendl;
@@ -1014,7 +1014,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
 		   << dstname << dendl;
 
     ImageCtx *ictx = new ImageCtx(srcname, "", "", io_ctx, false);
-    int r = ictx->state->open(false);
+    int r = ictx->state->open(0);
     if (r < 0) {
       lderr(cct) << "error opening source image: " << cpp_strerror(r) << dendl;
       return r;
@@ -1392,7 +1392,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
 
     ImageCtx *ictx = new ImageCtx((image_id.empty() ? image_name : ""),
                                   image_id, nullptr, io_ctx, false);
-    r = ictx->state->open(true);
+    r = ictx->state->open(OPEN_FLAG_SKIP_OPEN_PARENT);
     if (r == -ENOENT) {
       return r;
     } else if (r < 0) {
@@ -1801,7 +1801,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
 
     ImageCtx *dest = new librbd::ImageCtx(destname, "", NULL,
 					  dest_md_ctx, false);
-    r = dest->state->open(false);
+    r = dest->state->open(0);
     if (r < 0) {
       lderr(cct) << "failed to read newly created header" << dendl;
       return r;

--- a/src/librbd/internal.h
+++ b/src/librbd/internal.h
@@ -77,10 +77,9 @@ namespace librbd {
 	    IoCtx& c_ioctx, const char *c_name,
 	    uint64_t features, int *c_order,
 	    uint64_t stripe_unit, int stripe_count);
-  int clone(IoCtx& p_ioctx, const char *p_name, const char *p_snap_name,
-	    IoCtx& c_ioctx, const char *c_name, ImageOptions& c_opts);
-  int clone(ImageCtx *p_imctx, IoCtx& c_ioctx, const std::string &c_name,
-            const std::string &c_id, ImageOptions& c_opts,
+  int clone(IoCtx& p_ioctx, const char *p_id, const char *p_name,
+            const char *p_snap_name, IoCtx& c_ioctx, const char *c_id,
+            const char *c_name, ImageOptions& c_opts,
             const std::string &non_primary_global_image_id,
             const std::string &primary_mirror_uuid);
   int rename(librados::IoCtx& io_ctx, const char *srcname, const char *dstname);

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -234,7 +234,7 @@ void CopyupRequest<I>::send()
   if (is_deep_copy()) {
     bool flatten = is_copyup_required() ? true : m_ictx->migration_info.flatten;
     auto req = deep_copy::ObjectCopyRequest<I>::create(
-        m_ictx->parent, m_ictx->parent->parent /* TODO */, m_ictx,
+        m_ictx->parent, m_ictx->migration_parent, m_ictx,
         m_ictx->migration_info.snap_map, m_object_no, flatten,
         util::create_context_callback(this));
     ldout(m_ictx->cct, 20) << "deep copy object req " << req

--- a/src/librbd/io/CopyupRequest.cc
+++ b/src/librbd/io/CopyupRequest.cc
@@ -223,8 +223,7 @@ bool CopyupRequest<I>::is_update_object_map_required() {
 
 template <typename I>
 bool CopyupRequest<I>::is_deep_copy() const {
-  return !m_ictx->migration_info.empty() &&
-    m_ictx->migration_info.snap_map.size() > 1;
+  return !m_ictx->migration_info.empty();
 }
 
 template <typename I>

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -92,6 +92,7 @@ private:
   ZTracer::Trace m_trace;
 
   State m_state;
+  bool m_flatten;
   ceph::bufferlist m_copyup_data;
   std::vector<AbstractObjectWriteRequest<ImageCtxT> *> m_pending_requests;
   std::atomic<unsigned> m_pending_copyups { 0 };
@@ -108,6 +109,7 @@ private:
   bool should_complete(int *r);
 
   void remove_from_list();
+  void remove_from_list(Mutex &lock);
 
   bool send_object_map_head();
   bool send_object_map();

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -105,7 +105,7 @@ private:
 
   void complete_requests(int r);
 
-  bool should_complete(int r);
+  bool should_complete(int *r);
 
   void remove_from_list();
 
@@ -113,7 +113,7 @@ private:
   bool send_object_map();
   bool send_copyup();
   bool is_copyup_required();
-  bool is_update_object_map_required();
+  bool is_update_object_map_required(int r);
   bool is_deep_copy() const;
 };
 

--- a/src/librbd/io/CopyupRequest.h
+++ b/src/librbd/io/CopyupRequest.h
@@ -113,6 +113,8 @@ private:
   bool send_object_map();
   bool send_copyup();
   bool is_copyup_required();
+  bool is_update_object_map_required();
+  bool is_deep_copy() const;
 };
 
 } // namespace io

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -69,6 +69,8 @@ public:
   void block_writes(Context *on_blocked);
   void unblock_writes();
 
+  void wait_on_writes_unblocked(Context *on_unblocked);
+
   void set_require_lock(Direction direction, bool enabled);
 
   void apply_qos_limit(uint64_t limit, const uint64_t flag);
@@ -93,6 +95,7 @@ private:
   mutable RWLock m_lock;
   Contexts m_write_blocker_contexts;
   uint32_t m_write_blockers = 0;
+  Contexts m_unblocked_write_waiter_contexts;
   bool m_require_lock_on_read = false;
   bool m_require_lock_on_write = false;
   std::atomic<unsigned> m_queued_reads { 0 };

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -480,7 +480,7 @@ void AbstractObjectWriteRequest<I>::write_object() {
     ldout(image_ctx->cct, 20) << "guarding write" << dendl;
     if (!image_ctx->migration_info.empty()) {
       cls_client::assert_snapc_seq(
-        &write, m_snap_seq, cls::rbd::ASSERT_SNAPC_SEQ_NOT_GT_SNAPSET_SEQ);
+        &write, m_snap_seq, cls::rbd::ASSERT_SNAPC_SEQ_LE_SNAPSET_SEQ);
     } else {
       write.assert_exists();
     }

--- a/src/librbd/io/ObjectRequest.cc
+++ b/src/librbd/io/ObjectRequest.cc
@@ -352,13 +352,15 @@ void ObjectReadRequest<I>::copyup() {
 
     image_ctx->copyup_list[this->m_object_no] = new_req;
     image_ctx->copyup_list_lock.Unlock();
+    image_ctx->parent_lock.put_read();
+    image_ctx->snap_lock.put_read();
     new_req->send();
   } else {
     image_ctx->copyup_list_lock.Unlock();
+    image_ctx->parent_lock.put_read();
+    image_ctx->snap_lock.put_read();
   }
 
-  image_ctx->parent_lock.put_read();
-  image_ctx->snap_lock.put_read();
   image_ctx->owner_lock.put_read();
   this->finish(0);
 }

--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -74,7 +74,7 @@ public:
   virtual const char *get_op_type() const = 0;
 
 protected:
-  bool compute_parent_extents(Extents *parent_extents);
+  bool compute_parent_extents(Extents *parent_extents, bool read_request);
 
   ImageCtxT *m_ictx;
   std::string m_oid;

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -532,8 +532,8 @@ namespace librbd {
   {
     TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioctx));
     tracepoint(librbd, clone3_enter, p_ioctx.get_pool_name().c_str(), p_ioctx.get_id(), p_name, p_snap_name, c_ioctx.get_pool_name().c_str(), c_ioctx.get_id(), c_name, c_opts.opts);
-    int r = librbd::clone(p_ioctx, p_name, p_snap_name, c_ioctx, c_name,
-			  c_opts);
+    int r = librbd::clone(p_ioctx, nullptr, p_name, p_snap_name, c_ioctx,
+                          nullptr, c_name, c_opts, "", "");
     tracepoint(librbd, clone3_exit, r);
     return r;
   }
@@ -2671,7 +2671,8 @@ extern "C" int rbd_clone3(rados_ioctx_t p_ioctx, const char *p_name,
   TracepointProvider::initialize<tracepoint_traits>(get_cct(p_ioc));
   tracepoint(librbd, clone3_enter, p_ioc.get_pool_name().c_str(), p_ioc.get_id(), p_name, p_snap_name, c_ioc.get_pool_name().c_str(), c_ioc.get_id(), c_name, c_opts);
   librbd::ImageOptions c_opts_(c_opts);
-  int r = librbd::clone(p_ioc, p_name, p_snap_name, c_ioc, c_name, c_opts_);
+  int r = librbd::clone(p_ioc, nullptr, p_name, p_snap_name, c_ioc, nullptr,
+                        c_name, c_opts_, "", "");
   tracepoint(librbd, clone3_exit, r);
   return r;
 }

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -138,7 +138,7 @@ struct C_OpenAfterCloseComplete : public Context {
     delete reinterpret_cast<librbd::ImageCtx*>(*ictxp);
     *ictxp = nullptr;
 
-    ictx->state->open(false, new C_OpenComplete(ictx, comp, ictxp));
+    ictx->state->open(0, new C_OpenComplete(ictx, comp, ictxp));
   }
 };
 
@@ -305,7 +305,7 @@ namespace librbd {
       image.ctx = NULL;
     }
 
-    int r = ictx->state->open(false);
+    int r = ictx->state->open(0);
     if (r < 0) {
       tracepoint(librbd, open_image_exit, r);
       return r;
@@ -329,7 +329,7 @@ namespace librbd {
       image.ctx = nullptr;
     }
 
-    int r = ictx->state->open(false);
+    int r = ictx->state->open(0);
     if (r < 0) {
       tracepoint(librbd, open_image_by_id_exit, r);
       return r;
@@ -351,8 +351,8 @@ namespace librbd {
       reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
 	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
     } else {
-      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
-					   &image.ctx));
+      ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(c),
+                                              &image.ctx));
     }
     tracepoint(librbd, aio_open_image_exit, 0);
     return 0;
@@ -370,8 +370,8 @@ namespace librbd {
       reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
 	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
     } else {
-      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
-                                                  &image.ctx));
+      ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(c),
+                                              &image.ctx));
     }
     tracepoint(librbd, aio_open_image_by_id_exit, 0);
     return 0;
@@ -389,7 +389,7 @@ namespace librbd {
       image.ctx = NULL;
     }
 
-    int r = ictx->state->open(false);
+    int r = ictx->state->open(0);
     if (r < 0) {
       tracepoint(librbd, open_image_exit, r);
       return r;
@@ -413,7 +413,7 @@ namespace librbd {
       image.ctx = nullptr;
     }
 
-    int r = ictx->state->open(false);
+    int r = ictx->state->open(0);
     if (r < 0) {
       tracepoint(librbd, open_image_by_id_exit, r);
       return r;
@@ -435,8 +435,8 @@ namespace librbd {
       reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
 	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
     } else {
-      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
-					   &image.ctx));
+      ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(c),
+                                              &image.ctx));
     }
     tracepoint(librbd, aio_open_image_exit, 0);
     return 0;
@@ -454,8 +454,8 @@ namespace librbd {
       reinterpret_cast<ImageCtx*>(image.ctx)->state->close(
 	new C_OpenAfterCloseComplete(ictx, get_aio_completion(c), &image.ctx));
     } else {
-      ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(c),
-                                                  &image.ctx));
+      ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(c),
+                                              &image.ctx));
     }
     tracepoint(librbd, aio_open_image_by_id_exit, 0);
     return 0;
@@ -2953,7 +2953,7 @@ extern "C" int rbd_open(rados_ioctx_t p, const char *name, rbd_image_t *image,
 						false);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
-  int r = ictx->state->open(false);
+  int r = ictx->state->open(0);
   if (r >= 0) {
     *image = (rbd_image_t)ictx;
   }
@@ -2972,7 +2972,7 @@ extern "C" int rbd_open_by_id(rados_ioctx_t p, const char *id,
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(),
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
-  int r = ictx->state->open(false);
+  int r = ictx->state->open(0);
   if (r < 0) {
     delete ictx;
   } else {
@@ -2993,7 +2993,8 @@ extern "C" int rbd_aio_open(rados_ioctx_t p, const char *name,
 						false);
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
-  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp), image));
+  ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(comp),
+                                          image));
   tracepoint(librbd, aio_open_image_exit, 0);
   return 0;
 }
@@ -3011,7 +3012,8 @@ extern "C" int rbd_aio_open_by_id(rados_ioctx_t p, const char *id,
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(),
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only,
              comp->pc);
-  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp), image));
+  ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(comp),
+                                          image));
   tracepoint(librbd, aio_open_image_exit, 0);
   return 0;
 }
@@ -3026,7 +3028,7 @@ extern "C" int rbd_open_read_only(rados_ioctx_t p, const char *name,
 						true);
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
-  int r = ictx->state->open(false);
+  int r = ictx->state->open(0);
   if (r >= 0) {
     *image = (rbd_image_t)ictx;
   }
@@ -3045,7 +3047,7 @@ extern "C" int rbd_open_by_id_read_only(rados_ioctx_t p, const char *id,
   tracepoint(librbd, open_image_enter, ictx, ictx->name.c_str(),
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only);
 
-  int r = ictx->state->open(false);
+  int r = ictx->state->open(0);
   if (r < 0) {
     delete ictx;
   } else {
@@ -3066,8 +3068,8 @@ extern "C" int rbd_aio_open_read_only(rados_ioctx_t p, const char *name,
 						true);
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(), ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
-  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp),
-                                              image));
+  ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(comp),
+                                          image));
   tracepoint(librbd, aio_open_image_exit, 0);
   return 0;
 }
@@ -3085,8 +3087,8 @@ extern "C" int rbd_aio_open_by_id_read_only(rados_ioctx_t p, const char *id,
   librbd::RBD::AioCompletion *comp = (librbd::RBD::AioCompletion *)c;
   tracepoint(librbd, aio_open_image_enter, ictx, ictx->name.c_str(),
              ictx->id.c_str(), ictx->snap_name.c_str(), ictx->read_only, comp->pc);
-  ictx->state->open(false, new C_OpenComplete(ictx, get_aio_completion(comp),
-                                              image));
+  ictx->state->open(0, new C_OpenComplete(ictx, get_aio_completion(comp),
+                                          image));
   tracepoint(librbd, aio_open_image_exit, 0);
   return 0;
 }

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -1,0 +1,226 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "librbd/operation/MigrateRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "librbd/AsyncObjectThrottle.h"
+#include "librbd/ExclusiveLock.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/Utils.h"
+#include "librbd/deep_copy/ObjectCopyRequest.h"
+#include "librbd/io/AsyncOperation.h"
+#include "librbd/io/ImageRequestWQ.h"
+#include "librbd/io/ObjectRequest.h"
+#include "osdc/Striper.h"
+#include <boost/lambda/bind.hpp>
+#include <boost/lambda/construct.hpp>
+
+#define dout_subsys ceph_subsys_rbd
+#undef dout_prefix
+#define dout_prefix *_dout << "librbd::MigrateRequest: " << this << " " \
+                           << __func__ << ": "
+
+namespace librbd {
+namespace operation {
+
+using util::create_context_callback;
+using util::create_async_context_callback;
+
+namespace {
+
+template <typename I>
+class C_MigrateObject : public C_AsyncObjectThrottle<I> {
+public:
+  C_MigrateObject(AsyncObjectThrottle<I> &throttle, I *image_ctx,
+                  ::SnapContext snapc, uint64_t object_no)
+    : C_AsyncObjectThrottle<I>(throttle, *image_ctx), m_snapc(snapc),
+      m_object_no(object_no) {
+  }
+
+  int send() override {
+    I &image_ctx = this->m_image_ctx;
+    assert(image_ctx.owner_lock.is_locked());
+    CephContext *cct = image_ctx.cct;
+
+    if (image_ctx.exclusive_lock != nullptr &&
+        !image_ctx.exclusive_lock->is_lock_owner()) {
+      ldout(cct, 1) << "lost exclusive lock during migrate" << dendl;
+      return -ERESTART;
+    }
+
+    start_async_op();
+    return 0;
+  }
+
+private:
+  uint64_t m_object_size;
+  ::SnapContext m_snapc;
+  uint64_t m_object_no;
+
+  io::AsyncOperation m_async_op;
+
+  void start_async_op() {
+    I &image_ctx = this->m_image_ctx;
+    assert(image_ctx.owner_lock.is_locked());
+    CephContext *cct = image_ctx.cct;
+    ldout(cct, 10) << dendl;
+
+    m_async_op.start_op(image_ctx);
+
+    if (!image_ctx.io_work_queue->writes_blocked()) {
+      migrate_object();
+      return;
+    }
+
+    auto ctx = create_async_context_callback(
+      image_ctx, create_context_callback<
+        C_MigrateObject<I>, &C_MigrateObject<I>::handle_start_async_op>(this));
+    m_async_op.finish_op();
+    image_ctx.io_work_queue->wait_on_writes_unblocked(ctx);
+  }
+
+  void handle_start_async_op(int r) {
+    I &image_ctx = this->m_image_ctx;
+    CephContext *cct = image_ctx.cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    if (r < 0) {
+      lderr(cct) << "failed to start async op: " << cpp_strerror(r) << dendl;
+      this->complete(r);
+      return;
+    }
+
+    RWLock::RLocker owner_locker(image_ctx.owner_lock);
+    start_async_op();
+  }
+
+  bool is_within_overlap_bounds() {
+    I &image_ctx = this->m_image_ctx;
+    RWLock::RLocker snap_locker(image_ctx.snap_lock);
+
+    auto overlap = std::min(image_ctx.size, image_ctx.migration_info.overlap);
+    return overlap > 0 &&
+      Striper::get_num_objects(image_ctx.layout, overlap) > m_object_no;
+  }
+
+  void migrate_object() {
+    I &image_ctx = this->m_image_ctx;
+    assert(image_ctx.owner_lock.is_locked());
+    CephContext *cct = image_ctx.cct;
+
+    auto ctx = create_context_callback<
+      C_MigrateObject<I>, &C_MigrateObject<I>::handle_migrate_object>(this);
+
+    if (is_within_overlap_bounds()) {
+      bufferlist bl;
+      string oid = image_ctx.get_object_name(m_object_no);
+      auto req = new io::ObjectWriteRequest<I>(&image_ctx, oid, m_object_no, 0,
+                                               std::move(bl), m_snapc, 0, {},
+                                               ctx);
+
+      ldout(cct, 20) << "copyup object req " << req << ", object_no "
+                     << m_object_no << dendl;
+
+      req->send();
+    } else {
+      assert(image_ctx.parent != nullptr);
+
+      auto req = deep_copy::ObjectCopyRequest<I>::create(
+        image_ctx.parent, image_ctx.parent->parent /* TODO */, &image_ctx,
+        image_ctx.migration_info.snap_map, m_object_no,
+        image_ctx.migration_info.flatten, ctx);
+
+      ldout(cct, 20) << "deep copy object req " << req << ", object_no "
+                     << m_object_no << dendl;
+      req->send();
+    }
+  }
+
+  void handle_migrate_object(int r) {
+    CephContext *cct = this->m_image_ctx.cct;
+    ldout(cct, 10) << "r=" << r << dendl;
+
+    m_async_op.finish_op();
+    this->complete(r);
+  }
+};
+
+} // anonymous namespace
+
+template <typename I>
+void MigrateRequest<I>::send_op() {
+  I &image_ctx = this->m_image_ctx;
+  assert(image_ctx.owner_lock.is_locked());
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  migrate_objects();
+}
+
+template <typename I>
+bool MigrateRequest<I>::should_complete(int r) {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 10) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "encountered error: " << cpp_strerror(r) << dendl;
+  }
+
+  return true;
+}
+
+template <typename I>
+void MigrateRequest<I>::migrate_objects() {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  assert(image_ctx.owner_lock.is_locked());
+
+  uint64_t overlap_objects = get_num_overlap_objects();
+
+  ldout(cct, 10) << "from 0 to " << overlap_objects << dendl;
+
+  auto ctx = create_context_callback<
+    MigrateRequest<I>, &MigrateRequest<I>::handle_migrate_objects>(this);
+
+  typename AsyncObjectThrottle<I>::ContextFactory context_factory(
+    boost::lambda::bind(boost::lambda::new_ptr<C_MigrateObject<I> >(),
+      boost::lambda::_1, &image_ctx, image_ctx.snapc, boost::lambda::_2));
+  AsyncObjectThrottle<I> *throttle = new AsyncObjectThrottle<I>(
+    this, image_ctx, context_factory, ctx, &m_prog_ctx, 0, overlap_objects);
+  throttle->start_ops(image_ctx.concurrent_management_ops);
+}
+
+template <typename I>
+void MigrateRequest<I>::handle_migrate_objects(int r) {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 5) << "r=" << r << dendl;
+
+  if (r < 0) {
+    lderr(cct) << "failed to migrate objects: " << cpp_strerror(r) << dendl;
+  }
+
+  this->complete(r);
+}
+
+template <typename I>
+uint64_t MigrateRequest<I>::get_num_overlap_objects() {
+  I &image_ctx = this->m_image_ctx;
+  CephContext *cct = image_ctx.cct;
+  ldout(cct, 10) << dendl;
+
+  RWLock::RLocker snap_locker(image_ctx.snap_lock);
+  RWLock::RLocker parent_locker(image_ctx.parent_lock);
+
+  auto overlap = image_ctx.migration_info.overlap;
+
+  return overlap > 0 ?
+    Striper::get_num_objects(image_ctx.layout, overlap) : 0;
+}
+
+} // namespace operation
+} // namespace librbd
+
+template class librbd::operation::MigrateRequest<librbd::ImageCtx>;

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -141,6 +141,10 @@ private:
     CephContext *cct = this->m_image_ctx.cct;
     ldout(cct, 10) << "r=" << r << dendl;
 
+    if (r == -ENOENT) {
+      r = 0;
+    }
+
     m_async_op.finish_op();
     this->complete(r);
   }

--- a/src/librbd/operation/MigrateRequest.cc
+++ b/src/librbd/operation/MigrateRequest.cc
@@ -127,7 +127,7 @@ private:
       assert(image_ctx.parent != nullptr);
 
       auto req = deep_copy::ObjectCopyRequest<I>::create(
-        image_ctx.parent, image_ctx.parent->parent /* TODO */, &image_ctx,
+        image_ctx.parent, image_ctx.migration_parent, &image_ctx,
         image_ctx.migration_info.snap_map, m_object_no,
         image_ctx.migration_info.flatten, ctx);
 

--- a/src/librbd/operation/MigrateRequest.h
+++ b/src/librbd/operation/MigrateRequest.h
@@ -1,0 +1,69 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef CEPH_LIBRBD_OPERATION_MIGRATE_REQUEST_H
+#define CEPH_LIBRBD_OPERATION_MIGRATE_REQUEST_H
+
+#include "librbd/operation/Request.h"
+#include "common/snap_types.h"
+#include "librbd/Types.h"
+
+namespace librbd {
+
+class ImageCtx;
+class ProgressContext;
+
+namespace operation {
+
+template <typename ImageCtxT = ImageCtx>
+class MigrateRequest : public Request<ImageCtxT>
+{
+public:
+  MigrateRequest(ImageCtxT &image_ctx, Context *on_finish,
+                 ProgressContext &prog_ctx)
+    : Request<ImageCtxT>(image_ctx, on_finish), m_prog_ctx(prog_ctx) {
+  }
+
+protected:
+  void send_op() override;
+  bool should_complete(int r) override;
+  bool can_affect_io() const override {
+    return true;
+  }
+  journal::Event create_event(uint64_t op_tid) const override {
+    assert(0);
+    return journal::UnknownEvent();
+  }
+
+private:
+  /**
+   * Migrate goes through the following state machine to copy objects
+   * from the parent (migrating source) image:
+   *
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * MIGRATE_OBJECTS
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   *
+   */
+
+  ProgressContext &m_prog_ctx;
+
+  void migrate_objects();
+  void handle_migrate_objects(int r);
+
+  uint64_t get_num_overlap_objects();
+};
+
+} // namespace operation
+} // namespace librbd
+
+extern template class librbd::operation::MigrateRequest<librbd::ImageCtx>;
+
+#endif // CEPH_LIBRBD_OPERATION_MIGRATE_REQUEST_H

--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -310,6 +310,17 @@ void SnapshotCreateRequest<I>::update_snap_context() {
   image_ctx.snapc.snaps.swap(snaps);
   image_ctx.data_ctx.selfmanaged_snap_set_write_ctx(
     image_ctx.snapc.seq, image_ctx.snaps);
+
+  if (!image_ctx.migration_info.empty()) {
+    auto it = image_ctx.migration_info.snap_map.find(CEPH_NOSNAP);
+    assert(it != image_ctx.migration_info.snap_map.end());
+    assert(!it->second.empty());
+    if (it->second[0] == CEPH_NOSNAP) {
+      ldout(cct, 5) << this << " " << __func__
+                    << ": updating migration snap_map" << dendl;
+      it->second[0] = m_snap_id;
+    }
+  }
 }
 
 } // namespace operation

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -705,6 +705,15 @@ void cls_cxx_subop_version(cls_method_context_t hctx, string *s)
   *s = buf;
 }
 
+int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq) {
+  PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
+  if (!ctx->new_obs.exists) {
+    return -ENOENT;
+  }
+  *snap_seq = ctx->obc->ssc->snapset.seq;
+  return 0;
+}
+
 int cls_log(int level, const char *format, ...)
 {
    int size = 256;

--- a/src/objclass/objclass.h
+++ b/src/objclass/objclass.h
@@ -160,6 +160,8 @@ extern uint64_t cls_get_client_features(cls_method_context_t hctx);
 /* helpers */
 extern void cls_cxx_subop_version(cls_method_context_t hctx, string *s);
 
+extern int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq);
+
 /* These are also defined in rados.h and librados.h. Keep them in sync! */
 #define CEPH_OSD_TMAP_HDR 'h'
 #define CEPH_OSD_TMAP_SET 's'

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -198,6 +198,24 @@ cdef extern from "rbd/librbd.h" nogil:
         char *name
         rbd_group_snap_state_t state
 
+    ctypedef enum rbd_image_migration_state_t:
+        _RBD_IMAGE_MIGRATION_STATE_UNKNOWN "RBD_IMAGE_MIGRATION_STATE_UNKNOWN"
+        _RBD_IMAGE_MIGRATION_STATE_ERROR "RBD_IMAGE_MIGRATION_STATE_ERROR"
+        _RBD_IMAGE_MIGRATION_STATE_PREPARING "RBD_IMAGE_MIGRATION_STATE_PREPARING"
+        _RBD_IMAGE_MIGRATION_STATE_PREPARED "RBD_IMAGE_MIGRATION_STATE_PREPARED"
+        _RBD_IMAGE_MIGRATION_STATE_EXECUTING "RBD_IMAGE_MIGRATION_STATE_EXECUTING"
+        _RBD_IMAGE_MIGRATION_STATE_EXECUTED "RBD_IMAGE_MIGRATION_STATE_EXECUTED"
+
+    ctypedef struct rbd_image_migration_status_t:
+        int64_t source_pool_id
+        char *source_image_name
+        char *source_image_id
+        int64_t dest_pool_id
+        char *dest_image_name
+        char *dest_image_id
+        rbd_image_migration_state_t state
+        char *state_description
+
     ctypedef void (*rbd_callback_t)(rbd_completion_t cb, void *arg)
     ctypedef int (*librbd_progress_fn_t)(uint64_t offset, uint64_t total, void* ptr)
 
@@ -239,6 +257,17 @@ cdef extern from "rbd/librbd.h" nogil:
                                 size_t num_entries)
     int rbd_trash_remove(rados_ioctx_t io, const char *id, int force)
     int rbd_trash_restore(rados_ioctx_t io, const char *id, const char *name)
+
+    int rbd_migration_prepare(rados_ioctx_t io_ctx, const char *image_name,
+                              rados_ioctx_t dest_io_ctx, const char *dest_image_name,
+                              rbd_image_options_t opts)
+    int rbd_migration_execute(rados_ioctx_t io_ctx, const char *image_name)
+    int rbd_migration_commit(rados_ioctx_t io_ctx, const char *image_name)
+    int rbd_migration_abort(rados_ioctx_t io_ctx, const char *image_name)
+    int rbd_migration_status(rados_ioctx_t io_ctx, const char *image_name,
+                             rbd_image_migration_status_t *status,
+                             size_t status_size)
+    void rbd_migration_status_cleanup(rbd_image_migration_status_t *status)
 
     int rbd_mirror_mode_get(rados_ioctx_t io, rbd_mirror_mode_t *mirror_mode)
     int rbd_mirror_mode_set(rados_ioctx_t io, rbd_mirror_mode_t mirror_mode)
@@ -520,6 +549,13 @@ RBD_GROUP_IMAGE_STATE_INCOMPLETE = _RBD_GROUP_IMAGE_STATE_INCOMPLETE
 
 RBD_GROUP_SNAP_STATE_INCOMPLETE = _RBD_GROUP_SNAP_STATE_INCOMPLETE
 RBD_GROUP_SNAP_STATE_COMPLETE = _RBD_GROUP_SNAP_STATE_COMPLETE
+
+RBD_IMAGE_MIGRATION_STATE_UNKNOWN = _RBD_IMAGE_MIGRATION_STATE_UNKNOWN
+RBD_IMAGE_MIGRATION_STATE_ERROR = _RBD_IMAGE_MIGRATION_STATE_ERROR
+RBD_IMAGE_MIGRATION_STATE_PREPARING = _RBD_IMAGE_MIGRATION_STATE_PREPARING
+RBD_IMAGE_MIGRATION_STATE_PREPARED = _RBD_IMAGE_MIGRATION_STATE_PREPARED
+RBD_IMAGE_MIGRATION_STATE_EXECUTING = _RBD_IMAGE_MIGRATION_STATE_EXECUTING
+RBD_IMAGE_MIGRATION_STATE_EXECUTED = _RBD_IMAGE_MIGRATION_STATE_EXECUTED
 
 class Error(Exception):
     pass
@@ -1137,7 +1173,7 @@ class RBD(object):
         if ret != 0:
             raise make_ex(ret, 'error retrieving image from trash')
 
-        __source_string = ['USER', 'MIRRORING']
+        __source_string = ['USER', 'MIRRORING', 'MIGRATION']
         info = {
             'id'          : decode_cstr(c_info.id),
             'name'        : decode_cstr(c_info.name),
@@ -1178,6 +1214,180 @@ class RBD(object):
             ret = rbd_trash_restore(_ioctx, _image_id, _name)
         if ret != 0:
             raise make_ex(ret, 'error restoring image from trash')
+
+    def migration_prepare(self, ioctx, image_name, dest_ioctx, dest_image_name,
+                          features=None, order=None, stripe_unit=None, stripe_count=None,
+                          data_pool=None):
+        """
+        Prepare an RBD image migration.
+
+        :param ioctx: determines which RADOS pool the image is in
+        :type ioctx: :class:`rados.Ioctx`
+        :param image_name: the current name of the image
+        :type src: str
+        :param dest_ioctx: determines which pool to migration into
+        :type dest_ioctx: :class:`rados.Ioctx`
+        :param dest_image_name: the name of the destination image (may be the same image)
+        :type dest_image_name: str
+        :param features: bitmask of features to enable; if set, must include layering
+        :type features: int
+        :param order: the image is split into (2**order) byte objects
+        :type order: int
+        :param stripe_unit: stripe unit in bytes (default None to let librbd decide)
+        :type stripe_unit: int
+        :param stripe_count: objects to stripe over before looping
+        :type stripe_count: int
+        :param data_pool: optional separate pool for data blocks
+        :type data_pool: str
+        :raises: :class:`TypeError`
+        :raises: :class:`InvalidArgument`
+        :raises: :class:`ImageExists`
+        :raises: :class:`FunctionNotSupported`
+        :raises: :class:`ArgumentOutOfRange`
+        """
+        dest_image_name = cstr(dest_image_name, 'dest_image_name')
+        cdef:
+            rados_ioctx_t _ioctx = convert_ioctx(ioctx)
+            char *_image_name = image_name
+            rados_ioctx_t _dest_ioctx = convert_ioctx(dest_ioctx)
+            char *_dest_image_name = dest_image_name
+            rbd_image_options_t opts
+
+        rbd_image_options_create(&opts)
+        try:
+            if features is not None:
+                rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_FEATURES,
+                                             features)
+            if order is not None:
+                rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_ORDER,
+                                             order)
+            if stripe_unit is not None:
+                rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_STRIPE_UNIT,
+                                             stripe_unit)
+            if stripe_count is not None:
+                rbd_image_options_set_uint64(opts, RBD_IMAGE_OPTION_STRIPE_COUNT,
+                                             stripe_count)
+            if data_pool is not None:
+                rbd_image_options_set_string(opts, RBD_IMAGE_OPTION_DATA_POOL,
+                                             data_pool)
+            with nogil:
+                ret = rbd_migration_prepare(_ioctx, _image_name, _dest_ioctx,
+                                            _dest_image_name, opts)
+        finally:
+            rbd_image_options_destroy(opts)
+        if ret < 0:
+            raise make_ex(ret, 'error migrating image %s' % (image_name))
+
+    def migration_execute(self, ioctx, image_name):
+        """
+        Execute a prepared RBD image migration.
+
+        :param ioctx: determines which RADOS pool the image is in
+        :type ioctx: :class:`rados.Ioctx`
+        :param image_name: the name of the image
+        :type image_name: str
+        :raises: :class:`ImageNotFound`
+        """
+        image_name = cstr(image_name, 'image_name')
+        cdef:
+            rados_ioctx_t _ioctx = convert_ioctx(ioctx)
+            char *_image_name = image_name
+        with nogil:
+            ret = rbd_migration_execute(_ioctx, _image_name)
+        if ret != 0:
+            raise make_ex(ret, 'error aborting migration')
+
+    def migration_commit(self, ioctx, image_name):
+        """
+        Commit an executed RBD image migration.
+
+        :param ioctx: determines which RADOS pool the image is in
+        :type ioctx: :class:`rados.Ioctx`
+        :param image_name: the name of the image
+        :type image_name: str
+        :raises: :class:`ImageNotFound`
+        """
+        image_name = cstr(image_name, 'image_name')
+        cdef:
+            rados_ioctx_t _ioctx = convert_ioctx(ioctx)
+            char *_image_name = image_name
+        with nogil:
+            ret = rbd_migration_commit(_ioctx, _image_name)
+        if ret != 0:
+            raise make_ex(ret, 'error aborting migration')
+
+    def migration_abort(self, ioctx, image_name):
+        """
+        Cancel a previously started but interrupted migration.
+
+        :param ioctx: determines which RADOS pool the image is in
+        :type ioctx: :class:`rados.Ioctx`
+        :param image_name: the name of the image
+        :type image_name: str
+        :raises: :class:`ImageNotFound`
+        """
+        image_name = cstr(image_name, 'image_name')
+        cdef:
+            rados_ioctx_t _ioctx = convert_ioctx(ioctx)
+            char *_image_name = image_name
+        with nogil:
+            ret = rbd_migration_abort(_ioctx, _image_name)
+        if ret != 0:
+            raise make_ex(ret, 'error aborting migration')
+
+    def migration_status(self, ioctx, image_name):
+        """
+        Return RBD image migration status.
+
+        :param ioctx: determines which RADOS pool the image is in
+        :type ioctx: :class:`rados.Ioctx`
+        :param image_name: the name of the image
+        :type image_name: str
+        :returns: dict - contains the following keys:
+
+            * ``source_pool_id`` (int) - source image pool id
+
+            * ``source_image_name`` (str) - source image name
+
+            * ``source_image_id`` (str) - source image id
+
+            * ``dest_pool_id`` (int) - destination image pool id
+
+            * ``dest_image_name`` (str) - destination image name
+
+            * ``dest_image_id`` (str) - destination image id
+
+            * ``state`` (int) - current migration state
+
+            * ``state_description`` (str) - migration state description
+
+        :raises: :class:`ImageNotFound`
+        """
+        image_name = cstr(image_name, 'image_name')
+        cdef:
+            rados_ioctx_t _ioctx = convert_ioctx(ioctx)
+            char *_image_name = image_name
+            rbd_image_migration_status_t c_status
+        with nogil:
+            ret = rbd_migration_status(_ioctx, _image_name, &c_status,
+                                       sizeof(c_status))
+        if ret != 0:
+            raise make_ex(ret, 'error getting migration status')
+
+        status = {
+            'source_pool_id'    : c_status.source_pool_id,
+            'source_image_name' : decode_cstr(c_status.source_image_name),
+            'source_image_id'   : decode_cstr(c_status.source_image_id),
+            'dest_pool_id'      : c_status.source_pool_id,
+            'dest_image_name'   : decode_cstr(c_status.dest_image_name),
+            'dest_image_id'     : decode_cstr(c_status.dest_image_id),
+            'state'             : c_status.state,
+            'state_description' : decode_cstr(c_status.state_description)
+         }
+
+        rbd_migration_status_cleanup(&c_status)
+
+        return status
 
     def mirror_mode_get(self, ioctx):
         """

--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -166,7 +166,8 @@ cdef extern from "rbd/librbd.h" nogil:
 
     ctypedef enum rbd_trash_image_source_t:
         _RBD_TRASH_IMAGE_SOURCE_USER "RBD_TRASH_IMAGE_SOURCE_USER",
-        _RBD_TRASH_IMAGE_SOURCE_MIRRORING "RBD_TRASH_IMAGE_SOURCE_MIRRORING"
+        _RBD_TRASH_IMAGE_SOURCE_MIRRORING "RBD_TRASH_IMAGE_SOURCE_MIRRORING",
+        _RBD_TRASH_IMAGE_SOURCE_MIGRATION "RBD_TRASH_IMAGE_SOURCE_MIGRATION"
 
     ctypedef struct rbd_trash_image_info_t:
         char *id

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -59,6 +59,10 @@
       lock list (lock ls)                 Show locks held on an image.
       lock remove (lock rm)               Release a lock on an image.
       merge-diff                          Merge two diff exports together.
+      migration abort                     Cancel interrupted image migration.
+      migration commit                    Commit image migration.
+      migration execute                   Execute image migration.
+      migration prepare                   Prepare image migration.
       mirror image demote                 Demote an image to non-primary for RBD
                                           mirroring.
       mirror image disable                Disable RBD mirroring for an image.
@@ -1208,6 +1212,112 @@
   Optional arguments
     --path arg           path to merged diff (or '-' for stdout)
     --no-progress        disable progress output
+  
+  rbd help migration abort
+  usage: rbd migration abort [--pool <pool>] [--namespace <namespace>] 
+                             [--image <image>] [--no-progress] 
+                             <image-spec> 
+  
+  Cancel interrupted image migration.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace-name>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --no-progress        disable progress output
+  
+  rbd help migration commit
+  usage: rbd migration commit [--pool <pool>] [--namespace <namespace>] 
+                              [--image <image>] [--no-progress] 
+                              <image-spec> 
+  
+  Commit image migration.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace-name>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --no-progress        disable progress output
+  
+  rbd help migration execute
+  usage: rbd migration execute [--pool <pool>] [--namespace <namespace>] 
+                               [--image <image>] [--no-progress] 
+                               <image-spec> 
+  
+  Execute image migration.
+  
+  Positional arguments
+    <image-spec>         image specification
+                         (example: [<pool-name>/[<namespace-name>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg    pool name
+    --namespace arg      namespace name
+    --image arg          image name
+    --no-progress        disable progress output
+  
+  rbd help migration prepare
+  usage: rbd migration prepare [--pool <pool>] [--namespace <namespace>] 
+                               [--image <image>] [--dest-pool <dest-pool>] 
+                               [--dest-namespace <dest-namespace>] 
+                               [--dest <dest>] [--image-format <image-format>] 
+                               [--new-format] [--order <order>] 
+                               [--object-size <object-size>] 
+                               [--image-feature <image-feature>] 
+                               [--image-shared] [--stripe-unit <stripe-unit>] 
+                               [--stripe-count <stripe-count>] 
+                               [--data-pool <data-pool>] 
+                               [--journal-splay-width <journal-splay-width>] 
+                               [--journal-object-size <journal-object-size>] 
+                               [--journal-pool <journal-pool>] [--flatten] 
+                               <source-image-spec> <dest-image-spec> 
+  
+  Prepare image migration.
+  
+  Positional arguments
+    <source-image-spec>       source image specification
+                              (example:
+                              [<pool-name>/[<namespace-name>/]]<image-name>)
+    <dest-image-spec>         destination image specification
+                              (example:
+                              [<pool-name>/[<namespace-name>/]]<image-name>)
+  
+  Optional arguments
+    -p [ --pool ] arg         source pool name
+    --namespace arg           source namespace name
+    --image arg               source image name
+    --dest-pool arg           destination pool name
+    --dest-namespace arg      destination namespace name
+    --dest arg                destination image name
+    --image-format arg        image format [1 (deprecated) or 2]
+    --new-format              use image format 2
+                              (deprecated)
+    --order arg               object order [12 <= order <= 25]
+    --object-size arg         object size in B/K/M [4K <= object size <= 32M]
+    --image-feature arg       image features
+                              [layering(+), exclusive-lock(+*), object-map(+*),
+                              deep-flatten(+-), journaling(*)]
+    --image-shared            shared image
+    --stripe-unit arg         stripe unit in B/K/M
+    --stripe-count arg        stripe count
+    --data-pool arg           data pool
+    --journal-splay-width arg number of active journal objects
+    --journal-object-size arg size of journal objects
+    --journal-pool arg        pool for journal objects
+    --flatten                 fill clone with parent data (make it independent)
+  
+  Image Features:
+    (*) supports enabling/disabling on existing images
+    (-) supports disabling-only on existing images
+    (+) enabled by default for new images if features not specified
   
   rbd help mirror image demote
   usage: rbd mirror image demote [--pool <pool>] [--namespace <namespace>] 

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -2764,3 +2764,118 @@ TEST_F(TestClsRbd, namespace_methods)
   ASSERT_EQ(0, namespace_list(&ioctx, name1, 1, &entries));
   ASSERT_TRUE(entries.empty());
 }
+
+TEST_F(TestClsRbd, migration)
+{
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  string oid = get_temp_image_name();
+  ASSERT_EQ(0, create_image(&ioctx, oid, 0, 22, 0, oid, -1));
+
+  cls::rbd::MigrationSpec migration_spec(cls::rbd::MIGRATION_HEADER_TYPE_DST, 1,
+                                         "name", "id", {}, 0, false, false,
+                                         cls::rbd::MIGRATION_STATE_PREPARING,
+                                         "123");
+  cls::rbd::MigrationSpec read_migration_spec;
+
+  ASSERT_EQ(-EINVAL, migration_get(&ioctx, oid, &read_migration_spec));
+
+  uint64_t features;
+  ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
+  ASSERT_EQ(0U, features);
+
+  ASSERT_EQ(0, migration_set(&ioctx, oid, migration_spec));
+  ASSERT_EQ(0, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(migration_spec, read_migration_spec);
+
+  ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
+  ASSERT_EQ(RBD_FEATURE_MIGRATING, features);
+
+  ASSERT_EQ(-EEXIST, migration_set(&ioctx, oid, migration_spec));
+
+  migration_spec.state = cls::rbd::MIGRATION_STATE_PREPARED;
+  migration_spec.state_description = "456";
+  ASSERT_EQ(0, migration_set_state(&ioctx, oid, migration_spec.state,
+                                   migration_spec.state_description));
+  ASSERT_EQ(0, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(migration_spec, read_migration_spec);
+
+  ASSERT_EQ(0, migration_remove(&ioctx, oid));
+
+  ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
+  ASSERT_EQ(0U, features);
+
+  ASSERT_EQ(-EINVAL, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(-EINVAL, migration_set_state(&ioctx, oid, migration_spec.state,
+                                         migration_spec.state_description));
+
+  migration_spec.header_type = cls::rbd::MIGRATION_HEADER_TYPE_SRC;
+
+  ASSERT_EQ(0, migration_set(&ioctx, oid, migration_spec));
+
+  ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
+  ASSERT_EQ(RBD_FEATURE_MIGRATING, features);
+
+  ASSERT_EQ(0, migration_remove(&ioctx, oid));
+
+  ASSERT_EQ(-EINVAL, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(0, get_features(&ioctx, oid, CEPH_NOSNAP, &features));
+  ASSERT_EQ(0U, features);
+
+  ioctx.close();
+}
+
+TEST_F(TestClsRbd, migration_v1)
+{
+  librados::IoCtx ioctx;
+  ASSERT_EQ(0, _rados.ioctx_create(_pool_name.c_str(), ioctx));
+
+  bufferlist header;
+  header.append(RBD_HEADER_TEXT, sizeof(RBD_HEADER_TEXT));
+  string oid = get_temp_image_name();
+  ASSERT_EQ(0, ioctx.write(oid, header, header.length(), 0));
+
+  cls::rbd::MigrationSpec migration_spec(cls::rbd::MIGRATION_HEADER_TYPE_DST, 1,
+                                         "name", "id", {}, 0, false, false,
+                                         cls::rbd::MIGRATION_STATE_PREPARING,
+                                         "123");
+  cls::rbd::MigrationSpec read_migration_spec;
+
+  ASSERT_EQ(-EINVAL, migration_get(&ioctx, oid, &read_migration_spec));
+
+  // v1 format image can only be migration source
+  ASSERT_EQ(-EINVAL, migration_set(&ioctx, oid, migration_spec));
+
+  migration_spec.header_type = cls::rbd::MIGRATION_HEADER_TYPE_SRC;
+  ASSERT_EQ(0, migration_set(&ioctx, oid, migration_spec));
+
+  ASSERT_EQ(0, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(migration_spec, read_migration_spec);
+
+  header.clear();
+  ASSERT_EQ(static_cast<int>(sizeof(RBD_MIGRATE_HEADER_TEXT)),
+            ioctx.read(oid, header, sizeof(RBD_MIGRATE_HEADER_TEXT), 0));
+  ASSERT_STREQ(RBD_MIGRATE_HEADER_TEXT, header.c_str());
+
+  ASSERT_EQ(-EEXIST, migration_set(&ioctx, oid, migration_spec));
+
+  migration_spec.state = cls::rbd::MIGRATION_STATE_PREPARED;
+  migration_spec.state_description = "456";
+  ASSERT_EQ(0, migration_set_state(&ioctx, oid, migration_spec.state,
+                                   migration_spec.state_description));
+  ASSERT_EQ(0, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(migration_spec, read_migration_spec);
+
+  ASSERT_EQ(0, migration_remove(&ioctx, oid));
+
+  ASSERT_EQ(-EINVAL, migration_get(&ioctx, oid, &read_migration_spec));
+  ASSERT_EQ(-EINVAL, migration_set_state(&ioctx, oid, migration_spec.state,
+                                         migration_spec.state_description));
+  header.clear();
+  ASSERT_EQ(static_cast<int>(sizeof(RBD_HEADER_TEXT)),
+            ioctx.read(oid, header, sizeof(RBD_HEADER_TEXT), 0));
+  ASSERT_STREQ(RBD_HEADER_TEXT, header.c_str());
+
+  ioctx.close();
+}

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -465,6 +465,7 @@ TYPE(cls_rbd_snap)
 
 #include "cls/rbd/cls_rbd_types.h"
 TYPE(cls::rbd::ChildImageSpec)
+TYPE(cls::rbd::MigrationSpec)
 TYPE(cls::rbd::MirrorPeer)
 TYPE(cls::rbd::MirrorImage)
 TYPE(cls::rbd::MirrorImageMap)

--- a/src/test/librados_test_stub/LibradosTestStub.cc
+++ b/src/test/librados_test_stub/LibradosTestStub.cc
@@ -1355,6 +1355,19 @@ uint64_t cls_get_client_features(cls_method_context_t hctx) {
   return CEPH_FEATURES_SUPPORTED_DEFAULT;
 }
 
+int cls_get_snapset_seq(cls_method_context_t hctx, uint64_t *snap_seq) {
+  librados::TestClassHandler::MethodContext *ctx =
+    reinterpret_cast<librados::TestClassHandler::MethodContext*>(hctx);
+  librados::snap_set_t snapset;
+  int r = ctx->io_ctx_impl->list_snaps(ctx->oid, &snapset);
+  if (r < 0) {
+    return r;
+  }
+
+  *snap_seq = snapset.seq;
+  return 0;
+}
+
 int cls_log(int level, const char *format, ...) {
   int size = 256;
   va_list ap;

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -46,6 +46,7 @@ set(unittest_librbd_srcs
   exclusive_lock/test_mock_PreReleaseRequest.cc
   image/test_mock_CloneRequest.cc
   image/test_mock_DetachChildRequest.cc
+  image/test_mock_ListWatchersRequest.cc
   image/test_mock_RefreshRequest.cc
   image/test_mock_RemoveRequest.cc
   io/test_mock_ImageRequest.cc

--- a/src/test/librbd/CMakeLists.txt
+++ b/src/test/librbd/CMakeLists.txt
@@ -8,6 +8,7 @@ set(librbd_test
   test_BlockGuard.cc
   test_DeepCopy.cc
   test_Groups.cc
+  test_Migration.cc
   test_MirroringWatcher.cc
   test_ObjectMap.cc
   test_Operations.cc

--- a/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ImageCopyRequest.cc
@@ -10,7 +10,6 @@
 #include "librbd/deep_copy/ObjectCopyRequest.h"
 #include "librbd/image/CloseRequest.h"
 #include "librbd/image/OpenRequest.h"
-#include "librbd/image/SetSnapRequest.h"
 #include "librbd/internal.h"
 #include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
 #include "test/librbd/mock/MockImageCtx.h"
@@ -25,7 +24,7 @@ struct MockTestImageCtx : public librbd::MockImageCtx {
   static MockTestImageCtx* s_instance;
   static MockTestImageCtx* create(const std::string &image_name,
                                   const std::string &image_id,
-                                  const char *snap, librados::IoCtx& p,
+                                  librados::snap_t snap_id, librados::IoCtx& p,
                                   bool read_only) {
     assert(s_instance != nullptr);
     return s_instance;
@@ -118,26 +117,6 @@ struct OpenRequest<MockTestImageCtx> {
 };
 
 OpenRequest<MockTestImageCtx>* OpenRequest<MockTestImageCtx>::s_instance = nullptr;
-
-template <>
-struct SetSnapRequest<MockTestImageCtx> {
-  Context* on_finish = nullptr;
-  static SetSnapRequest* s_instance;
-  static SetSnapRequest* create(MockTestImageCtx &image_ctx, uint64_t snap_id,
-                                Context *on_finish) {
-    assert(s_instance != nullptr);
-    s_instance->on_finish = on_finish;
-    return s_instance;
-  }
-
-  MOCK_METHOD0(send, void());
-
-  SetSnapRequest() {
-    s_instance = this;
-  }
-};
-
-SetSnapRequest<MockTestImageCtx>* SetSnapRequest<MockTestImageCtx>::s_instance = nullptr;
 
 } // namespace image
 

--- a/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
+++ b/src/test/librbd/deep_copy/test_mock_ObjectCopyRequest.cc
@@ -464,7 +464,7 @@ TEST_F(TestMockDeepCopyObjectCopyRequest, DNE) {
   expect_list_snaps(mock_src_image_ctx, mock_src_io_ctx, -ENOENT);
 
   request->send();
-  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
 TEST_F(TestMockDeepCopyObjectCopyRequest, Write) {

--- a/src/test/librbd/image/test_mock_CloneRequest.cc
+++ b/src/test/librbd/image/test_mock_CloneRequest.cc
@@ -224,6 +224,17 @@ public:
       .WillOnce(WithArg<1>(Invoke([this, r](Context* ctx) {
                              image_ctx->op_work_queue->queue(ctx, r);
                            })));
+    if (r < 0) {
+      EXPECT_CALL(mock_image_ctx, destroy());
+    }
+  }
+
+  void expect_snap_set(librbd::MockTestImageCtx &mock_image_ctx,
+                       uint64_t snap_id, int r) {
+    EXPECT_CALL(*mock_image_ctx.state, snap_set(snap_id, _))
+      .WillOnce(WithArg<1>(Invoke([this, r](Context *on_finish) {
+          image_ctx->op_work_queue->queue(on_finish, r);
+        })));
   }
 
   void expect_set_parent(MockImageCtx &mock_image_ctx, int r) {
@@ -352,6 +363,9 @@ TEST_F(TestMockImageCloneRequest, SuccessV1) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -380,11 +394,12 @@ TEST_F(TestMockImageCloneRequest, SuccessV1) {
   }
 
   expect_close(mock_image_ctx, 0);
+  expect_close(mock_image_ctx, 0);
 
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -397,6 +412,9 @@ TEST_F(TestMockImageCloneRequest, SuccessV2) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -423,11 +441,12 @@ TEST_F(TestMockImageCloneRequest, SuccessV2) {
   }
 
   expect_close(mock_image_ctx, 0);
+  expect_close(mock_image_ctx, 0);
 
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
@@ -442,6 +461,9 @@ TEST_F(TestMockImageCloneRequest, SuccessAuto) {
 
   InSequence seq;
   expect_get_min_compat_client(1, 0);
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -470,14 +492,53 @@ TEST_F(TestMockImageCloneRequest, SuccessAuto) {
   }
 
   expect_close(mock_image_ctx, 0);
+  expect_close(mock_image_ctx, 0);
 
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageCloneRequest, OpenParentError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  MockTestImageCtx mock_image_ctx(*image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_open(mock_image_ctx, -EINVAL);
+
+  C_SaferCond ctx;
+  ImageOptions clone_opts;
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
+                                  image_ctx->op_work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageCloneRequest, SetParentSnapError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  MockTestImageCtx mock_image_ctx(*image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, -EINVAL);
+  expect_close(mock_image_ctx, 0);
+
+  C_SaferCond ctx;
+  ImageOptions clone_opts;
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
+                                  image_ctx->op_work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
 }
 
 TEST_F(TestMockImageCloneRequest, CreateError) {
@@ -487,16 +548,21 @@ TEST_F(TestMockImageCloneRequest, CreateError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
   MockCreateRequest mock_create_request;
   expect_create(mock_create_request, -EINVAL);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -509,6 +575,9 @@ TEST_F(TestMockImageCloneRequest, OpenError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -520,10 +589,12 @@ TEST_F(TestMockImageCloneRequest, OpenError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -536,6 +607,9 @@ TEST_F(TestMockImageCloneRequest, SetParentError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -549,10 +623,12 @@ TEST_F(TestMockImageCloneRequest, SetParentError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -566,6 +642,9 @@ TEST_F(TestMockImageCloneRequest, AddChildError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -580,10 +659,12 @@ TEST_F(TestMockImageCloneRequest, AddChildError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -597,6 +678,9 @@ TEST_F(TestMockImageCloneRequest, RefreshError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -615,10 +699,12 @@ TEST_F(TestMockImageCloneRequest, RefreshError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -632,6 +718,9 @@ TEST_F(TestMockImageCloneRequest, MetadataListError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -653,10 +742,12 @@ TEST_F(TestMockImageCloneRequest, MetadataListError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -669,6 +760,9 @@ TEST_F(TestMockImageCloneRequest, MetadataSetError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -689,10 +783,12 @@ TEST_F(TestMockImageCloneRequest, MetadataSetError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -706,6 +802,9 @@ TEST_F(TestMockImageCloneRequest, GetMirrorModeError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -730,10 +829,12 @@ TEST_F(TestMockImageCloneRequest, GetMirrorModeError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -746,6 +847,9 @@ TEST_F(TestMockImageCloneRequest, MirrorEnableError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -771,10 +875,12 @@ TEST_F(TestMockImageCloneRequest, MirrorEnableError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, 0);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -787,6 +893,9 @@ TEST_F(TestMockImageCloneRequest, CloseError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -804,10 +913,15 @@ TEST_F(TestMockImageCloneRequest, CloseError) {
 
   expect_close(mock_image_ctx, -EINVAL);
 
+  MockRemoveRequest mock_remove_request;
+  expect_remove(mock_remove_request, 0);
+
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
@@ -820,6 +934,9 @@ TEST_F(TestMockImageCloneRequest, RemoveError) {
   expect_op_work_queue(mock_image_ctx);
 
   InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
   expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
   expect_is_snap_protected(mock_image_ctx, true, 0);
 
@@ -831,10 +948,44 @@ TEST_F(TestMockImageCloneRequest, RemoveError) {
   MockRemoveRequest mock_remove_request;
   expect_remove(mock_remove_request, -EPERM);
 
+  expect_close(mock_image_ctx, 0);
+
   C_SaferCond ctx;
   ImageOptions clone_opts;
-  auto req = new MockCloneRequest(&mock_image_ctx, m_ioctx, "clone name",
-                                  "clone id", clone_opts, "", "",
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
+                                  image_ctx->op_work_queue, &ctx);
+  req->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageCloneRequest, CloseParentError) {
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  MockTestImageCtx mock_image_ctx(*image_ctx);
+  expect_op_work_queue(mock_image_ctx);
+
+  InSequence seq;
+  expect_open(mock_image_ctx, 0);
+  expect_snap_set(mock_image_ctx, 123, 0);
+
+  expect_get_image_size(mock_image_ctx, mock_image_ctx.snaps.front(), 123);
+  expect_is_snap_protected(mock_image_ctx, true, 0);
+
+  MockCreateRequest mock_create_request;
+  expect_create(mock_create_request, 0);
+
+  expect_open(mock_image_ctx, -EINVAL);
+
+  MockRemoveRequest mock_remove_request;
+  expect_remove(mock_remove_request, 0);
+
+  expect_close(mock_image_ctx, -EPERM);
+
+  C_SaferCond ctx;
+  ImageOptions clone_opts;
+  auto req = new MockCloneRequest(m_ioctx, "parent id", "", 123, m_ioctx,
+                                  "clone name", "clone id", clone_opts, "", "",
                                   image_ctx->op_work_queue, &ctx);
   req->send();
   ASSERT_EQ(-EINVAL, ctx.wait());

--- a/src/test/librbd/image/test_mock_ListWatchersRequest.cc
+++ b/src/test/librbd/image/test_mock_ListWatchersRequest.cc
@@ -1,0 +1,220 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librbd/test_mock_fixture.h"
+#include "librbd/image/ListWatchersRequest.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librados_test_stub/MockTestMemRadosClient.h"
+#include "test/librbd/mock/MockContextWQ.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/test_support.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace librbd {
+
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+// template definitions
+#include "librbd/image/ListWatchersRequest.cc"
+template class librbd::image::ListWatchersRequest<librbd::MockImageCtx>;
+
+namespace librbd {
+
+namespace image {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+using ::testing::StrEq;
+
+class TestMockListWatchersRequest : public TestMockFixture {
+public:
+  typedef ListWatchersRequest<MockImageCtx> MockListWatchersRequest;
+
+  obj_watch_t watcher(const std::string &address, uint64_t watch_handle) {
+    obj_watch_t w;
+    strcpy(w.addr, address.c_str());
+    w.watcher_id = 0;
+    w.cookie = watch_handle;
+    w.timeout_seconds = 0;
+
+    return w;
+  }
+
+  void expect_list_watchers(MockTestImageCtx &mock_image_ctx,
+                            const std::string oid,
+                            const std::list<obj_watch_t> &watchers, int r) {
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                               list_watchers(oid, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoAll(SetArgPointee<1>(watchers), Return(0)));
+    }
+  }
+
+  void expect_list_image_watchers(MockTestImageCtx &mock_image_ctx,
+                                  const std::list<obj_watch_t> &watchers,
+                                  int r) {
+    expect_list_watchers(mock_image_ctx, mock_image_ctx.header_oid,
+                         watchers, r);
+  }
+
+  void expect_list_mirror_watchers(MockTestImageCtx &mock_image_ctx,
+                                   const std::list<obj_watch_t> &watchers,
+                                   int r) {
+    expect_list_watchers(mock_image_ctx, RBD_MIRRORING, watchers, r);
+  }
+
+  void expect_mirror_image_get(MockImageCtx &mock_image_ctx, int r) {
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(RBD_MIRRORING, _, StrEq("rbd"), StrEq("mirror_image_get"),
+                     _, _, _))
+      .WillOnce(Return(r));
+  }
+
+  void expect_get_watch_handle(MockImageWatcher &mock_watcher,
+                               uint64_t watch_handle) {
+    EXPECT_CALL(mock_watcher, get_watch_handle())
+      .WillOnce(Return(watch_handle));
+  }
+};
+
+TEST_F(TestMockListWatchersRequest, NoImageWatchers) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageWatcher mock_watcher;
+
+  InSequence seq;
+  expect_list_image_watchers(mock_image_ctx, {}, 0);
+
+  std::list<obj_watch_t> watchers;
+  C_SaferCond ctx;
+  auto req = MockListWatchersRequest::create(mock_image_ctx, 0, &watchers,
+                                             &ctx);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_TRUE(watchers.empty());
+}
+
+TEST_F(TestMockListWatchersRequest, Error) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageWatcher mock_watcher;
+
+  InSequence seq;
+  expect_list_image_watchers(mock_image_ctx, {}, -EINVAL);
+
+  std::list<obj_watch_t> watchers;
+  C_SaferCond ctx;
+  auto req = MockListWatchersRequest::create(mock_image_ctx, 0, &watchers,
+                                             &ctx);
+  req->send();
+
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockListWatchersRequest, Success) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageWatcher mock_watcher;
+
+  InSequence seq;
+  expect_list_image_watchers(mock_image_ctx,
+                             {watcher("a", 123), watcher("b", 456)}, 0);
+  expect_get_watch_handle(*mock_image_ctx.image_watcher, 123);
+
+  std::list<obj_watch_t> watchers;
+  C_SaferCond ctx;
+  auto req = MockListWatchersRequest::create(mock_image_ctx, 0, &watchers,
+                                             &ctx);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(2U, watchers.size());
+
+  auto w = watchers.begin();
+  ASSERT_STREQ("a", w->addr);
+  ASSERT_EQ(123, w->cookie);
+
+  w++;
+  ASSERT_STREQ("b", w->addr);
+  ASSERT_EQ(456, w->cookie);
+}
+
+TEST_F(TestMockListWatchersRequest, FilterOutMyInstance) {
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageWatcher mock_watcher;
+
+  InSequence seq;
+  expect_list_image_watchers(mock_image_ctx,
+                             {watcher("a", 123), watcher("b", 456)}, 0);
+  expect_get_watch_handle(*mock_image_ctx.image_watcher, 123);
+
+  std::list<obj_watch_t> watchers;
+  C_SaferCond ctx;
+  auto req = MockListWatchersRequest::create(
+      mock_image_ctx, LIST_WATCHERS_FILTER_OUT_MY_INSTANCE, &watchers, &ctx);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(1U, watchers.size());
+
+  ASSERT_STREQ("b", watchers.begin()->addr);
+  ASSERT_EQ(456, watchers.begin()->cookie);
+}
+
+TEST_F(TestMockListWatchersRequest, FilterOutMirrorInstance) {
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  librbd::ImageCtx *ictx;
+  ASSERT_EQ(0, open_image(m_image_name, &ictx));
+
+  MockTestImageCtx mock_image_ctx(*ictx);
+  MockImageWatcher mock_watcher;
+
+  InSequence seq;
+  expect_list_image_watchers(mock_image_ctx,
+                             {watcher("a", 123), watcher("b", 456)}, 0);
+  expect_mirror_image_get(mock_image_ctx, 0);
+  expect_list_mirror_watchers(mock_image_ctx, {watcher("b", 789)}, 0);
+  expect_get_watch_handle(*mock_image_ctx.image_watcher, 123);
+
+  std::list<obj_watch_t> watchers;
+  C_SaferCond ctx;
+  auto req = MockListWatchersRequest::create(
+      mock_image_ctx, LIST_WATCHERS_FILTER_OUT_MIRROR_INSTANCES, &watchers,
+      &ctx);
+  req->send();
+
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(1U, watchers.size());
+
+  ASSERT_STREQ("a", watchers.begin()->addr);
+  ASSERT_EQ(123, watchers.begin()->cookie);
+}
+
+} // namespace image
+} // namespace librbd

--- a/src/test/librbd/image/test_mock_RemoveRequest.cc
+++ b/src/test/librbd/image/test_mock_RemoveRequest.cc
@@ -12,6 +12,7 @@
 #include "librbd/Operations.h"
 #include "librbd/image/TypeTraits.h"
 #include "librbd/image/DetachChildRequest.h"
+#include "librbd/image/ListWatchersRequest.h"
 #include "librbd/image/RemoveRequest.h"
 #include "librbd/image/RefreshParentRequest.h"
 #include "librbd/journal/RemoveRequest.h"
@@ -182,6 +183,33 @@ public:
 DisableRequest<MockTestImageCtx> *DisableRequest<MockTestImageCtx>::s_instance;
 
 } // namespace mirror
+
+namespace image {
+
+template<>
+class ListWatchersRequest<MockTestImageCtx> {
+public:
+  static ListWatchersRequest *s_instance;
+  Context *on_finish = nullptr;
+
+  static ListWatchersRequest *create(MockTestImageCtx &image_ctx, int flags,
+                                     std::list<obj_watch_t> *watchers,
+                                     Context *on_finish) {
+    assert(s_instance != nullptr);
+    s_instance->on_finish = on_finish;
+    return s_instance;
+  }
+
+  ListWatchersRequest() {
+    s_instance = this;
+  }
+
+  MOCK_METHOD0(send, void());
+};
+
+ListWatchersRequest<MockTestImageCtx> *ListWatchersRequest<MockTestImageCtx>::s_instance;
+
+} // namespace image
 } // namespace librbd
 
 // template definitions
@@ -217,6 +245,7 @@ public:
   typedef typename TypeTraits::ContextWQ ContextWQ;
   typedef RemoveRequest<MockTestImageCtx> MockRemoveRequest;
   typedef DetachChildRequest<MockTestImageCtx> MockDetachChildRequest;
+  typedef ListWatchersRequest<MockTestImageCtx> MockListWatchersRequest;
   typedef librbd::operation::SnapshotRemoveRequest<MockTestImageCtx> MockSnapshotRemoveRequest;
   typedef librbd::operation::TrimRequest<MockTestImageCtx> MockTrimRequest;
   typedef librbd::journal::RemoveRequest<MockTestImageCtx> MockJournalRemoveRequest;
@@ -264,6 +293,13 @@ public:
                 }));
   }
 
+  void expect_list_image_watchers(
+    MockTestImageCtx &mock_image_ctx,
+    MockListWatchersRequest &mock_list_watchers_request, int r) {
+    EXPECT_CALL(mock_list_watchers_request, send())
+      .WillOnce(FinishRequest(&mock_list_watchers_request, r, &mock_image_ctx));
+  }
+
   void expect_get_group(MockTestImageCtx &mock_image_ctx, int r) {
     auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
                                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
@@ -305,15 +341,6 @@ public:
                 exec(StrEq("rbd_mirroring"), _, StrEq("rbd"), StrEq("mirror_image_remove"),
                      _, _, _))
       .WillOnce(Return(r));
-  }
-
-  void expect_mirror_image_get(MockTestImageCtx &mock_image_ctx, int r) {
-    if ((mock_image_ctx.features & RBD_FEATURE_JOURNALING) != 0ULL) {
-      EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
-                  exec(RBD_MIRRORING, _, StrEq("rbd"),
-                       StrEq("mirror_image_get"), _, _, _))
-        .WillOnce(Return(r));
-    }
   }
 
   void expect_dir_remove_image(librados::IoCtx &ioctx, int r) {
@@ -364,6 +391,9 @@ TEST_F(TestMockImageRemoveRequest, SuccessV1) {
 
   InSequence seq;
   expect_state_open(*m_mock_imctx, 0);
+
+  MockListWatchersRequest mock_list_watchers_request;
+  expect_list_image_watchers(*m_mock_imctx, mock_list_watchers_request, 0);
 
   MockTrimRequest mock_trim_request;
   expect_trim(*m_mock_imctx, mock_trim_request, 0);
@@ -421,7 +451,9 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV1) {
   expect_set_journal_policy(*m_mock_imctx);
   expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
 
-  expect_mirror_image_get(*m_mock_imctx, 0);
+  MockListWatchersRequest mock_list_watchers_request;
+  expect_list_image_watchers(*m_mock_imctx, mock_list_watchers_request, 0);
+
   expect_get_group(*m_mock_imctx, 0);
 
   MockTrimRequest mock_trim_request;
@@ -472,7 +504,9 @@ TEST_F(TestMockImageRemoveRequest, SuccessV2CloneV2) {
   expect_set_journal_policy(*m_mock_imctx);
   expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
 
-  expect_mirror_image_get(*m_mock_imctx, 0);
+  MockListWatchersRequest mock_list_watchers_request;
+  expect_list_image_watchers(*m_mock_imctx, mock_list_watchers_request, 0);
+
   expect_get_group(*m_mock_imctx, 0);
 
   MockTrimRequest mock_trim_request;
@@ -523,7 +557,9 @@ TEST_F(TestMockImageRemoveRequest, NotExistsV2) {
   expect_set_journal_policy(*m_mock_imctx);
   expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
 
-  expect_mirror_image_get(*m_mock_imctx, 0);
+  MockListWatchersRequest mock_list_watchers_request;
+  expect_list_image_watchers(*m_mock_imctx, mock_list_watchers_request, 0);
+
   expect_get_group(*m_mock_imctx, 0);
 
   MockTrimRequest mock_trim_request;
@@ -612,7 +648,9 @@ TEST_F(TestMockImageRemoveRequest, AutoDeleteSnapshots) {
   expect_set_journal_policy(*m_mock_imctx);
   expect_shut_down_exclusive_lock(*m_mock_imctx, *mock_exclusive_lock, 0);
 
-  expect_mirror_image_get(*m_mock_imctx, 0);
+  MockListWatchersRequest mock_list_watchers_request;
+  expect_list_image_watchers(*m_mock_imctx, mock_list_watchers_request, 0);
+
   expect_get_group(*m_mock_imctx, 0);
 
   MockSnapshotRemoveRequest mock_snap_remove_request;

--- a/src/test/librbd/mock/MockImageCtx.h
+++ b/src/test/librbd/mock/MockImageCtx.h
@@ -111,7 +111,8 @@ struct MockImageCtx {
       mirroring_replay_delay(image_ctx.mirroring_replay_delay),
       non_blocking_aio(image_ctx.non_blocking_aio),
       blkin_trace_all(image_ctx.blkin_trace_all),
-      enable_alloc_hint(image_ctx.enable_alloc_hint)
+      enable_alloc_hint(image_ctx.enable_alloc_hint),
+      ignore_migrating(image_ctx.ignore_migrating)
   {
     md_ctx.dup(image_ctx.md_ctx);
     data_ctx.dup(image_ctx.data_ctx);
@@ -264,6 +265,7 @@ struct MockImageCtx {
   std::string id;
   std::string name;
   ParentInfo parent_md;
+  MigrationInfo migration_info;
   char *format_string;
   cls::rbd::GroupSpec group_spec;
 
@@ -316,6 +318,7 @@ struct MockImageCtx {
   bool non_blocking_aio;
   bool blkin_trace_all;
   bool enable_alloc_hint;
+  bool ignore_migrating;
 };
 
 } // namespace librbd

--- a/src/test/librbd/test_Migration.cc
+++ b/src/test/librbd/test_Migration.cc
@@ -1,0 +1,1020 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/librados/test.h"
+#include "test/librbd/test_fixture.h"
+#include "test/librbd/test_support.h"
+#include "librbd/ImageState.h"
+#include "librbd/Operations.h"
+#include "librbd/api/Group.h"
+#include "librbd/api/Image.h"
+#include "librbd/api/Migration.h"
+#include "librbd/api/Mirror.h"
+#include "librbd/internal.h"
+#include "librbd/io/ImageRequestWQ.h"
+#include "librbd/io/ReadResult.h"
+
+void register_test_migration() {
+}
+
+struct TestMigration : public TestFixture {
+  void SetUp() override {
+    TestFixture::SetUp();
+
+    open_image(m_ioctx, m_image_name, &m_ictx);
+    m_image_id = m_ictx->id;
+
+    std::string ref_image_name = get_temp_image_name();
+    ASSERT_EQ(0, create_image_pp(m_rbd, m_ioctx, ref_image_name, m_ictx->size));
+    EXPECT_EQ(0, _rados.ioctx_create2(m_ioctx.get_id(), m_ref_ioctx));
+    open_image(m_ref_ioctx, ref_image_name, &m_ref_ictx);
+
+    resize(20 * (1 << 22));
+  }
+
+  void TearDown() override {
+    if (m_ref_ictx != nullptr) {
+      close_image(m_ref_ictx);
+    }
+    if (m_ictx != nullptr) {
+      close_image(m_ictx);
+    }
+
+    m_other_pool_ioctx.close();
+
+    TestFixture::TearDown();
+  }
+
+  void require_other_pool() {
+    std::string pool_name = get_temp_pool_name("test-librbd-");
+    ASSERT_EQ("", create_one_pool_pp(pool_name, m_other_pool_rados));
+    ASSERT_EQ(0, m_other_pool_rados.ioctx_create(pool_name.c_str(),
+                                                 m_other_pool_ioctx));
+  }
+
+  bool is_librados_test_stub() {
+    std::string fsid;
+    EXPECT_EQ(0, _rados.cluster_fsid(&fsid));
+    return fsid == "00000000-1111-2222-3333-444444444444";
+  }
+
+  void compare(const std::string &description = "") {
+    vector<librbd::snap_info_t> src_snaps, dst_snaps;
+
+    EXPECT_EQ(m_ref_ictx->size, m_ictx->size);
+    EXPECT_EQ(0, librbd::snap_list(m_ref_ictx, src_snaps));
+    EXPECT_EQ(0, librbd::snap_list(m_ictx, dst_snaps));
+    EXPECT_EQ(src_snaps.size(), dst_snaps.size());
+    for (size_t i = 0; i <= src_snaps.size(); i++) {
+      const char *src_snap_name = nullptr;
+      const char *dst_snap_name = nullptr;
+      if (i < src_snaps.size()) {
+        EXPECT_EQ(src_snaps[i].name, dst_snaps[i].name);
+        src_snap_name = src_snaps[i].name.c_str();
+        dst_snap_name = dst_snaps[i].name.c_str();
+      }
+      EXPECT_EQ(0, librbd::api::Image<>::snap_set(
+                     m_ref_ictx, cls::rbd::UserSnapshotNamespace(),
+                     src_snap_name));
+      EXPECT_EQ(0, librbd::api::Image<>::snap_set(
+                     m_ictx, cls::rbd::UserSnapshotNamespace(),
+                     dst_snap_name));
+      compare_snaps(
+        description + " snap: " + (src_snap_name ? src_snap_name : "null"),
+        m_ref_ictx, m_ictx);
+    }
+  }
+
+  void compare_snaps(const std::string &description, librbd::ImageCtx *src_ictx,
+                     librbd::ImageCtx *dst_ictx) {
+    uint64_t src_size, dst_size;
+    {
+      RWLock::RLocker src_locker(src_ictx->snap_lock);
+      RWLock::RLocker dst_locker(dst_ictx->snap_lock);
+      src_size = src_ictx->get_image_size(src_ictx->snap_id);
+      dst_size = dst_ictx->get_image_size(dst_ictx->snap_id);
+    }
+    if (src_size != dst_size) {
+      std::cout << description << ": size differs" << std::endl;
+      EXPECT_EQ(src_size, dst_size);
+    }
+
+    if (dst_ictx->test_features(RBD_FEATURE_LAYERING)) {
+      bool flags_set;
+      EXPECT_EQ(0, dst_ictx->test_flags(RBD_FLAG_OBJECT_MAP_INVALID,
+                                        &flags_set));
+      EXPECT_FALSE(flags_set);
+    }
+
+    ssize_t read_size = 1 << src_ictx->order;
+    uint64_t offset = 0;
+    while (offset < src_size) {
+      read_size = std::min(read_size, static_cast<ssize_t>(src_size - offset));
+
+      bufferptr src_ptr(read_size);
+      bufferlist src_bl;
+      src_bl.push_back(src_ptr);
+      librbd::io::ReadResult src_result{&src_bl};
+      EXPECT_EQ(read_size, src_ictx->io_work_queue->read(
+                  offset, read_size, librbd::io::ReadResult{src_result}, 0));
+
+      bufferptr dst_ptr(read_size);
+      bufferlist dst_bl;
+      dst_bl.push_back(dst_ptr);
+      librbd::io::ReadResult dst_result{&dst_bl};
+      EXPECT_EQ(read_size, dst_ictx->io_work_queue->read(
+                  offset, read_size, librbd::io::ReadResult{dst_result}, 0));
+
+      if (!src_bl.contents_equal(dst_bl)) {
+        std::cout << description
+                  << ", block " << offset << "~" << read_size << " differs"
+                  << std::endl;
+        char *c = getenv("TEST_RBD_MIGRATION_VERBOSE");
+        if (c != NULL && *c != '\0') {
+          std::cout << "src block: " << std::endl; src_bl.hexdump(std::cout);
+          std::cout << "dst block: " << std::endl; dst_bl.hexdump(std::cout);
+        }
+      }
+      EXPECT_TRUE(src_bl.contents_equal(dst_bl));
+      offset += read_size;
+    }
+  }
+
+  void open_image(librados::IoCtx& io_ctx, const std::string &name,
+                  librbd::ImageCtx **ictx) {
+    *ictx = new librbd::ImageCtx(name.c_str(), "", nullptr, io_ctx, false);
+    m_ictxs.insert(*ictx);
+
+    ASSERT_EQ(0, (*ictx)->state->open(0));
+  }
+
+  void migration_prepare(librados::IoCtx& dst_io_ctx,
+                         const std::string &dst_name, int r = 0) {
+    std::cout << __func__ << std::endl;
+
+    close_image(m_ictx);
+    m_ictx = nullptr;
+
+    EXPECT_EQ(r, librbd::api::Migration<>::prepare(m_ioctx, m_image_name,
+                                                   dst_io_ctx, dst_name,
+                                                   m_opts));
+    if (r == 0) {
+      open_image(dst_io_ctx, dst_name, &m_ictx);
+    } else {
+      open_image(m_ioctx, m_image_name, &m_ictx);
+    }
+    compare("after prepare");
+  }
+
+  void migration_execute(librados::IoCtx& io_ctx, const std::string &name,
+                         int r = 0) {
+    std::cout << __func__ << std::endl;
+
+    librbd::NoOpProgressContext no_op;
+    EXPECT_EQ(r, librbd::api::Migration<>::execute(io_ctx, name, no_op));
+  }
+
+  void migration_abort(librados::IoCtx& io_ctx, const std::string &name,
+                       int r = 0) {
+    std::cout << __func__ << std::endl;
+
+    std::string dst_name = m_ictx->name;
+    close_image(m_ictx);
+    m_ictx = nullptr;
+
+    librbd::NoOpProgressContext no_op;
+    EXPECT_EQ(r, librbd::api::Migration<>::abort(io_ctx, name, no_op));
+
+    if (r == 0) {
+      open_image(m_ioctx, m_image_name, &m_ictx);
+    } else {
+      open_image(m_ioctx, dst_name, &m_ictx);
+    }
+
+    compare("after abort");
+  }
+
+  void migration_commit(librados::IoCtx& io_ctx, const std::string &name) {
+    std::cout << __func__ << std::endl;
+
+    librbd::NoOpProgressContext no_op;
+    EXPECT_EQ(0, librbd::api::Migration<>::commit(io_ctx, name, no_op));
+
+    compare("after commit");
+  }
+
+  void migration_status(librbd::image_migration_state_t state) {
+    librbd::image_migration_status_t status;
+    EXPECT_EQ(0, librbd::api::Migration<>::status(m_ioctx, m_image_name,
+                                                  &status));
+    EXPECT_EQ(status.source_pool_id, m_ioctx.get_id());
+    EXPECT_EQ(status.source_image_name, m_image_name);
+    EXPECT_EQ(status.source_image_id, m_image_id);
+    EXPECT_EQ(status.dest_pool_id, m_ictx->md_ctx.get_id());
+    EXPECT_EQ(status.dest_image_name, m_ictx->name);
+    EXPECT_EQ(status.dest_image_id, m_ictx->id);
+    EXPECT_EQ(status.state, state);
+  }
+
+  void migrate(librados::IoCtx& dst_io_ctx, const std::string &dst_name) {
+    migration_prepare(dst_io_ctx, dst_name);
+    migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+    migration_execute(dst_io_ctx, dst_name);
+    migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+    migration_commit(dst_io_ctx, dst_name);
+  }
+
+  void write(uint64_t off, uint64_t len, char c) {
+    std::cout << "write: " << c << " " << off << "~" << len << std::endl;
+
+    bufferlist ref_bl;
+    ref_bl.append(std::string(len, c));
+    ASSERT_EQ(len, m_ref_ictx->io_work_queue->write(off, len, std::move(ref_bl),
+                                                    0));
+    bufferlist bl;
+    bl.append(std::string(len, c));
+    ASSERT_EQ(len, m_ictx->io_work_queue->write(off, len, std::move(bl), 0));
+  }
+
+  void discard(uint64_t off, uint64_t len) {
+    std::cout << "discard: " << off << "~" << len << std::endl;
+
+    ASSERT_EQ(static_cast<ssize_t>(len),
+              m_ref_ictx->io_work_queue->discard(off, len, false));
+    ASSERT_EQ(static_cast<ssize_t>(len),
+              m_ictx->io_work_queue->discard(off, len, false));
+  }
+
+  void flush() {
+    ASSERT_EQ(0, m_ref_ictx->io_work_queue->flush());
+    ASSERT_EQ(0, m_ictx->io_work_queue->flush());
+  }
+
+  void snap_create(const std::string &snap_name) {
+    std::cout << "snap_create: " << snap_name << std::endl;
+
+    flush();
+
+    ASSERT_EQ(0, TestFixture::snap_create(*m_ref_ictx, snap_name));
+    ASSERT_EQ(0, TestFixture::snap_create(*m_ictx, snap_name));
+  }
+
+  void snap_protect(const std::string &snap_name) {
+    std::cout << "snap_protect: " << snap_name << std::endl;
+
+    ASSERT_EQ(0, TestFixture::snap_protect(*m_ref_ictx, snap_name));
+    ASSERT_EQ(0, TestFixture::snap_protect(*m_ictx, snap_name));
+  }
+
+  void clone(const std::string &snap_name) {
+    snap_protect(snap_name);
+
+    int order = m_ref_ictx->order;
+    uint64_t features;
+    ASSERT_EQ(0, librbd::get_features(m_ref_ictx, &features));
+    features &= ~RBD_FEATURES_IMPLICIT_ENABLE;
+
+    std::string ref_clone_name = get_temp_image_name();
+    std::string clone_name = get_temp_image_name();
+
+    std::cout << "clone " << m_ictx->name << " -> " << clone_name
+              << std::endl;
+
+    ASSERT_EQ(0, librbd::clone(m_ref_ictx->md_ctx, m_ref_ictx->name.c_str(),
+                               snap_name.c_str(), m_ref_ioctx,
+                               ref_clone_name.c_str(), features, &order,
+                               m_ref_ictx->stripe_unit,
+                               m_ref_ictx->stripe_count));
+
+    ASSERT_EQ(0, librbd::clone(m_ictx->md_ctx, m_ictx->name.c_str(),
+                               snap_name.c_str(), m_ioctx,
+                               clone_name.c_str(), features, &order,
+                               m_ictx->stripe_unit,
+                               m_ictx->stripe_count));
+
+    close_image(m_ref_ictx);
+    open_image(m_ref_ioctx, ref_clone_name, &m_ref_ictx);
+
+    close_image(m_ictx);
+    open_image(m_ioctx, clone_name, &m_ictx);
+    m_image_name = m_ictx->name;
+    m_image_id = m_ictx->id;
+  }
+
+  void resize(uint64_t size) {
+    std::cout << "resize: " << size << std::endl;
+
+    librbd::NoOpProgressContext no_op;
+    ASSERT_EQ(0, m_ref_ictx->operations->resize(size, true, no_op));
+    ASSERT_EQ(0, m_ictx->operations->resize(size, true, no_op));
+  }
+
+  void test_no_snaps() {
+    uint64_t len = (1 << m_ictx->order) * 2 + 1;
+    write(0 * len, len, '1');
+    write(2 * len, len, '1');
+    flush();
+  }
+
+  void test_snaps() {
+    uint64_t len = (1 << m_ictx->order) * 2 + 1;
+    write(0 * len, len, '1');
+    snap_create("snap1");
+    write(1 * len, len, '1');
+
+    write(0 * len, 1000, 'X');
+    discard(1000 + 10, 1000);
+
+    snap_create("snap2");
+
+    write(1 * len, 1000, 'X');
+    discard(2 * len + 10, 1000);
+
+    uint64_t size = m_ictx->size;
+
+    resize(size << 1);
+
+    write(size - 1, len, '2');
+
+    snap_create("snap3");
+
+    resize(size);
+
+    discard(size - 1, 1);
+
+    flush();
+  }
+
+  void test_clone() {
+    uint64_t len = (1 << m_ictx->order) * 2 + 1;
+    write(0 * len, len, 'X');
+    write(2 * len, len, 'X');
+
+    snap_create("snap");
+    clone("snap");
+
+    write(0, 1000, 'X');
+    discard(1010, 1000);
+
+    snap_create("snap");
+    clone("snap");
+
+    write(1000, 1000, 'X');
+    discard(2010, 1000);
+
+    flush();
+  }
+
+  void test_stress(const std::string &snap_name_prefix = "snap",
+                   char start_char = 'A') {
+    uint64_t initial_size = m_ictx->size;
+
+    int nsnaps = 4;
+    const char *c = getenv("TEST_RBD_MIGRATION_STRESS_NSNAPS");
+    if (c != NULL) {
+      std::stringstream ss(c);
+      ASSERT_TRUE(ss >> nsnaps);
+    }
+
+    int nwrites = 4;
+    c = getenv("TEST_RBD_MIGRATION_STRESS_NWRITES");
+    if (c != NULL) {
+      std::stringstream ss(c);
+      ASSERT_TRUE(ss >> nwrites);
+    }
+
+    for (int i = 0; i < nsnaps; i++) {
+      for (int j = 0; j < nwrites; j++) {
+        size_t len = rand() % ((1 << m_ictx->order) * 2);
+        ASSERT_GT(m_ictx->size, len);
+        uint64_t off = std::min(static_cast<uint64_t>(rand() % m_ictx->size),
+                                static_cast<uint64_t>(m_ictx->size - len));
+        write(off, len, start_char + i);
+
+        len = rand() % ((1 << m_ictx->order) * 2);
+        ASSERT_GT(m_ictx->size, len);
+        off = std::min(static_cast<uint64_t>(rand() % m_ictx->size),
+                       static_cast<uint64_t>(m_ictx->size - len));
+        discard(off, len);
+      }
+
+      std::string snap_name = snap_name_prefix + stringify(i);
+      snap_create(snap_name);
+
+      if (m_ictx->test_features(RBD_FEATURE_LAYERING) &&
+          !m_ictx->test_features(RBD_FEATURE_MIGRATING) &&
+          rand() % 4) {
+        clone(snap_name);
+      }
+
+      if (rand() % 2) {
+        librbd::NoOpProgressContext no_op;
+        uint64_t new_size = initial_size + rand() % m_ictx->size;
+        resize(new_size);
+        ASSERT_EQ(new_size, m_ictx->size);
+      }
+    }
+    flush();
+  }
+
+  void test_stress2(bool concurrent) {
+    test_stress();
+
+    migration_prepare(m_ioctx, m_image_name);
+    migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+    thread user([this]() {
+        test_stress("user", 'a');
+        for (int i = 0; i < 5; i++) {
+          uint64_t off = (i + 1) * m_ictx->size / 10;
+          uint64_t len = m_ictx->size / 40;
+          write(off, len, '1' + i);
+
+          off += len / 4;
+          len /= 2;
+          discard(off, len);
+        }
+        flush();
+      });
+
+    if (concurrent) {
+      librados::IoCtx io_ctx;
+      EXPECT_EQ(0, _rados.ioctx_create2(m_ioctx.get_id(), io_ctx));
+      migration_execute(io_ctx, m_image_name);
+      io_ctx.close();
+      user.join();
+    } else {
+      user.join();
+      compare("before execute");
+      migration_execute(m_ioctx, m_image_name);
+    }
+
+    migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+    migration_commit(m_ioctx, m_image_name);
+  }
+
+  std::string m_image_id;
+  librbd::ImageCtx *m_ictx = nullptr;
+  librados::IoCtx m_ref_ioctx;
+  librbd::ImageCtx *m_ref_ictx = nullptr;
+  librbd::ImageOptions m_opts;
+  librados::Rados m_other_pool_rados;
+  librados::IoCtx m_other_pool_ioctx;
+};
+
+TEST_F(TestMigration, Empty)
+{
+  uint64_t features = m_ictx->features ^ RBD_FEATURE_LAYERING;
+  ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_FEATURES, features));
+
+  migrate(m_ioctx, m_image_name);
+
+  ASSERT_EQ(features, m_ictx->features);
+}
+
+TEST_F(TestMigration, OtherName)
+{
+  std::string name = get_temp_image_name();
+
+  migrate(m_ioctx, name);
+
+  ASSERT_EQ(name, m_ictx->name);
+}
+
+TEST_F(TestMigration, OtherPool)
+{
+  require_other_pool();
+
+  migrate(m_other_pool_ioctx, m_image_name);
+
+  ASSERT_EQ(m_other_pool_ioctx.get_id(), m_ictx->md_ctx.get_id());
+}
+
+TEST_F(TestMigration, DataPool)
+{
+  require_other_pool();
+
+  ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_DATA_POOL,
+                          m_other_pool_ioctx.get_pool_name().c_str()));
+
+  migrate(m_ioctx, m_image_name);
+
+  ASSERT_EQ(m_other_pool_ioctx.get_id(), m_ictx->data_ctx.get_id());
+}
+
+TEST_F(TestMigration, AbortAfterPrepare)
+{
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+  migration_abort(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, AbortAfterFailedPrepare)
+{
+  ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_DATA_POOL, "INVALID_POOL"));
+
+  migration_prepare(m_ioctx, m_image_name, -ENOENT);
+
+  // Migration is automatically aborted if prepare failed
+}
+
+TEST_F(TestMigration, AbortAfterExecute)
+{
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_abort(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, OtherPoolAbortAfterExecute)
+{
+  require_other_pool();
+
+  migration_prepare(m_other_pool_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+  migration_execute(m_other_pool_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_abort(m_other_pool_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, MirroringSamePool)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_enable(m_ictx, false));
+  librbd::mirror_image_info_t info;
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+
+  migrate(m_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+}
+
+TEST_F(TestMigration, MirroringAbort)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_enable(m_ictx, false));
+  librbd::mirror_image_info_t info;
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_DISABLED, info.state);
+
+  migration_abort(m_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+}
+
+TEST_F(TestMigration, MirroringOtherPoolDisabled)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  require_other_pool();
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_enable(m_ictx, false));
+  librbd::mirror_image_info_t info;
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+
+  migrate(m_other_pool_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_DISABLED, info.state);
+}
+
+TEST_F(TestMigration, MirroringOtherPoolEnabled)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  require_other_pool();
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_ioctx, RBD_MIRROR_MODE_IMAGE));
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_other_pool_ioctx,
+                                               RBD_MIRROR_MODE_IMAGE));
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_enable(m_ictx, false));
+  librbd::mirror_image_info_t info;
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+
+  migrate(m_other_pool_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+}
+
+TEST_F(TestMigration, MirroringPool)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_JOURNALING);
+
+  require_other_pool();
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::mode_set(m_other_pool_ioctx,
+                                               RBD_MIRROR_MODE_POOL));
+  librbd::mirror_image_info_t info;
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_DISABLED, info.state);
+
+  migrate(m_other_pool_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Mirror<>::image_get_info(m_ictx, &info));
+  ASSERT_EQ(RBD_MIRROR_IMAGE_ENABLED, info.state);
+}
+
+TEST_F(TestMigration, Group)
+{
+  REQUIRE_FORMAT_V2();
+
+  ASSERT_EQ(0, librbd::api::Group<>::create(m_ioctx, "123"));
+  ASSERT_EQ(0, librbd::api::Group<>::image_add(m_ioctx, "123", m_ioctx,
+                                               m_image_name.c_str()));
+  librbd::group_info_t info;
+  ASSERT_EQ(0, librbd::api::Group<>::image_get_group(m_ictx, &info));
+
+  std::string name = get_temp_image_name();
+
+  migrate(m_ioctx, name);
+
+  ASSERT_EQ(0, librbd::api::Group<>::image_get_group(m_ictx, &info));
+  ASSERT_EQ(info.name, "123");
+
+  ASSERT_EQ(0, librbd::api::Group<>::image_remove(m_ioctx, "123", m_ioctx,
+                                                  name.c_str()));
+  ASSERT_EQ(0, librbd::api::Group<>::remove(m_ioctx, "123"));
+}
+
+TEST_F(TestMigration, GroupAbort)
+{
+  REQUIRE_FORMAT_V2();
+
+  ASSERT_EQ(0, librbd::api::Group<>::create(m_ioctx, "123"));
+  ASSERT_EQ(0, librbd::api::Group<>::image_add(m_ioctx, "123", m_ioctx,
+                                               m_image_name.c_str()));
+  librbd::group_info_t info;
+  ASSERT_EQ(0, librbd::api::Group<>::image_get_group(m_ictx, &info));
+
+  std::string name = get_temp_image_name();
+
+  migration_prepare(m_ioctx, name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  ASSERT_EQ(0, librbd::api::Group<>::image_get_group(m_ictx, &info));
+  ASSERT_EQ(info.name, "123");
+
+  migration_abort(m_ioctx, m_image_name);
+
+  ASSERT_EQ(0, librbd::api::Group<>::image_get_group(m_ictx, &info));
+  ASSERT_EQ(info.name, "123");
+
+  ASSERT_EQ(0, librbd::api::Group<>::image_remove(m_ioctx, "123", m_ioctx,
+                                                  m_image_name.c_str()));
+  ASSERT_EQ(0, librbd::api::Group<>::remove(m_ioctx, "123"));
+}
+
+TEST_F(TestMigration, NoSnaps)
+{
+  test_no_snaps();
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsOtherPool)
+{
+  test_no_snaps();
+
+  require_other_pool();
+
+  test_no_snaps();
+  migrate(m_other_pool_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsDataPool)
+{
+  test_no_snaps();
+
+  require_other_pool();
+
+  ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_DATA_POOL,
+                          m_other_pool_ioctx.get_pool_name().c_str()));
+  migrate(m_ioctx, m_image_name);
+
+  EXPECT_EQ(m_other_pool_ioctx.get_id(), m_ictx->data_ctx.get_id());
+}
+
+TEST_F(TestMigration, NoSnapsShrinkAfterPrepare)
+{
+  test_no_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(m_ictx->size >> 1);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsShrinkToZeroBeforePrepare)
+{
+  test_no_snaps();
+  resize(0);
+
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsShrinkToZeroAfterPrepare)
+{
+  test_no_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(0);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsExpandAfterPrepare)
+{
+  test_no_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(m_ictx->size << 1);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, NoSnapsSnapAfterPrepare)
+{
+  test_no_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  snap_create("after_prepare_snap");
+  resize(m_ictx->size >> 1);
+  write(0, 1000, '*');
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, Snaps)
+{
+  test_snaps();
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsOtherPool)
+{
+  test_snaps();
+
+  require_other_pool();
+
+  test_no_snaps();
+  migrate(m_other_pool_ioctx, m_image_name);
+
+  EXPECT_EQ(m_other_pool_ioctx.get_id(), m_ictx->md_ctx.get_id());
+}
+
+TEST_F(TestMigration, SnapsDataPool)
+{
+  test_snaps();
+
+  require_other_pool();
+
+  ASSERT_EQ(0, m_opts.set(RBD_IMAGE_OPTION_DATA_POOL,
+                          m_other_pool_ioctx.get_pool_name().c_str()));
+  migrate(m_ioctx, m_image_name);
+
+  EXPECT_EQ(m_other_pool_ioctx.get_id(), m_ictx->data_ctx.get_id());
+}
+
+TEST_F(TestMigration, SnapsShrinkAfterPrepare)
+{
+  test_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(m_ictx->size >> 1);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsShrinkToZeroBeforePrepare)
+{
+  test_snaps();
+  resize(0);
+
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsShrinkToZeroAfterPrepare)
+{
+  test_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(0);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsExpandAfterPrepare)
+{
+  test_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  auto size = m_ictx->size;
+  resize(size << 1);
+  write(size, 1000, '*');
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsExpandAfterPrepare2)
+{
+  auto size = m_ictx->size;
+
+  write(size >> 1, 10, 'X');
+  snap_create("snap1");
+  resize(size >> 1);
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  resize(size);
+  write(size >> 1, 5, 'Y');
+
+  compare("before execute");
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsSnapAfterPrepare)
+{
+  test_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  auto ictx = new librbd::ImageCtx(m_ictx->name.c_str(), "", "snap3", m_ioctx,
+                                   false);
+  ASSERT_EQ(0, ictx->state->open(0));
+  EXPECT_EQ(0, librbd::api::Image<>::snap_set(
+              m_ref_ictx, cls::rbd::UserSnapshotNamespace(), "snap3"));
+  compare_snaps("opened after prepare snap3", m_ref_ictx, ictx);
+  EXPECT_EQ(0, librbd::api::Image<>::snap_set(
+              m_ref_ictx, cls::rbd::UserSnapshotNamespace(), nullptr));
+  EXPECT_EQ(0, ictx->state->close());
+
+  snap_create("after_prepare_snap");
+  resize(m_ictx->size >> 1);
+  write(0, 1000, '*');
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapsSnapExpandAfterPrepare)
+{
+  test_snaps();
+
+  migration_prepare(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_PREPARED);
+
+  snap_create("after_prepare_snap");
+  auto size = m_ictx->size;
+  resize(size << 1);
+  write(size, 1000, '*');
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_status(RBD_IMAGE_MIGRATION_STATE_EXECUTED);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, Clone)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  test_clone();
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, CloneUpdateAfterPrepare)
+{
+  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
+
+  write(0, 10, 'X');
+  snap_create("snap");
+  clone("snap");
+
+  migration_prepare(m_ioctx, m_image_name);
+
+  write(0, 1, 'Y');
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, TriggerAssertSnapcSeq)
+{
+  auto size = m_ictx->size;
+
+  write((size >> 1) + 0, 10, 'A');
+  snap_create("snap1");
+  write((size >> 1) + 1, 10, 'B');
+
+  migration_prepare(m_ioctx, m_image_name);
+
+  // copyup => deep copy (first time)
+  write((size >> 1) + 2, 10, 'C');
+
+  // preserve data before resizing
+  snap_create("snap2");
+
+  // decrease head overlap
+  resize(size >> 1);
+
+  // migrate object => deep copy (second time) => assert_snapc_seq => -ERANGE
+  migration_execute(m_ioctx, m_image_name);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, SnapTrimBeforePrepare)
+{
+  auto size = m_ictx->size;
+
+  write(size >> 1, 10, 'A');
+  snap_create("snap1");
+  resize(size >> 1);
+
+  migration_prepare(m_ioctx, m_image_name);
+
+  resize(size);
+  snap_create("snap3");
+  write(size >> 1, 10, 'B');
+  snap_create("snap4");
+  resize(size >> 1);
+
+  migration_execute(m_ioctx, m_image_name);
+  migration_commit(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, StressNoMigrate)
+{
+  test_stress();
+
+  compare();
+}
+
+TEST_F(TestMigration, Stress)
+{
+  test_stress();
+
+  migrate(m_ioctx, m_image_name);
+}
+
+TEST_F(TestMigration, Stress2)
+{
+  test_stress2(false);
+}
+
+TEST_F(TestMigration, StressLive)
+{
+  test_stress2(true);
+}

--- a/src/test/librbd/test_fixture.cc
+++ b/src/test/librbd/test_fixture.cc
@@ -75,7 +75,7 @@ void TestFixture::TearDown() {
 
 int TestFixture::open_image(const std::string &image_name,
 			    librbd::ImageCtx **ictx) {
-  *ictx = new librbd::ImageCtx(image_name.c_str(), "", NULL, m_ioctx, false);
+  *ictx = new librbd::ImageCtx(image_name.c_str(), "", nullptr, m_ioctx, false);
   m_ictxs.insert(*ictx);
 
   return (*ictx)->state->open(false);

--- a/src/test/librbd/test_main.cc
+++ b/src/test/librbd/test_main.cc
@@ -16,6 +16,7 @@ extern void register_test_image_watcher();
 extern void register_test_internal();
 extern void register_test_journal_entries();
 extern void register_test_journal_replay();
+extern void register_test_migration();
 extern void register_test_mirroring();
 extern void register_test_mirroring_watcher();
 extern void register_test_object_map();
@@ -34,6 +35,7 @@ int main(int argc, char **argv)
   register_test_internal();
   register_test_journal_entries();
   register_test_journal_replay();
+  register_test_migration();
   register_test_mirroring();
   register_test_mirroring_watcher();
   register_test_object_map();

--- a/src/test/pybind/test_rbd.py
+++ b/src/test/pybind/test_rbd.py
@@ -22,7 +22,8 @@ from rbd import (RBD, Group, Image, ImageNotFound, InvalidArgument, ImageExists,
                  RBD_MIRROR_MODE_POOL, RBD_MIRROR_IMAGE_ENABLED,
                  RBD_MIRROR_IMAGE_DISABLED, MIRROR_IMAGE_STATUS_STATE_UNKNOWN,
                  RBD_LOCK_MODE_EXCLUSIVE, RBD_OPERATION_FEATURE_GROUP,
-                 RBD_SNAP_NAMESPACE_TYPE_TRASH)
+                 RBD_SNAP_NAMESPACE_TYPE_TRASH,
+                 RBD_IMAGE_MIGRATION_STATE_PREPARED)
 
 rados = None
 ioctx = None
@@ -1908,3 +1909,28 @@ class TestGroups(object):
 def test_rename():
     rbd = RBD()
     image_name2 = get_temp_image_name()
+
+class TestMigration(object):
+
+    def test_migration(self):
+        create_image()
+        RBD().migration_prepare(ioctx, image_name, ioctx, image_name, features=63,
+                                order=23, stripe_unit=1<<23, stripe_count=1,
+                                data_pool=None)
+
+        status = RBD().migration_status(ioctx, image_name)
+        eq(image_name, status['source_image_name'])
+        eq(image_name, status['dest_image_name'])
+        eq(RBD_IMAGE_MIGRATION_STATE_PREPARED, status['state'])
+
+        RBD().migration_execute(ioctx, image_name)
+        RBD().migration_commit(ioctx, image_name)
+        remove_image()
+
+    def test_migrate_abort(self):
+        create_image()
+        RBD().migration_prepare(ioctx, image_name, ioctx, image_name, features=63,
+                                order=23, stripe_unit=1<<23, stripe_count=1,
+                                data_pool=None)
+        RBD().migration_abort(ioctx, image_name)
+        remove_image()

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -72,15 +72,18 @@ struct CloneRequest<librbd::MockTestImageCtx> {
   static CloneRequest *s_instance;
   Context *on_finish = nullptr;
 
-  static CloneRequest *create(librbd::MockTestImageCtx *p_imctx,
+  static CloneRequest *create(IoCtx &p_ioctx, const std::string &p_id,
+                              const std::string &p_snap_name,
+                              uint64_t p_snap_id,
 			      IoCtx &c_ioctx, const std::string &c_name,
 			      const std::string &c_id, ImageOptions c_options,
 			      const std::string &non_primary_global_image_id,
 			      const std::string &primary_mirror_uuid,
-			      MockContextWQ *op_work_queue, Context *on_finish) {
+			      MockContextWQ *op_work_queue,
+                              Context *on_finish) {
     assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
-    s_instance->construct(p_imctx);
+    s_instance->construct();
     return s_instance;
   }
 
@@ -93,7 +96,7 @@ struct CloneRequest<librbd::MockTestImageCtx> {
   }
 
   MOCK_METHOD0(send, void());
-  MOCK_METHOD1(construct, void(librbd::MockTestImageCtx *p_imctx));
+  MOCK_METHOD0(construct, void());
 };
 
 CloneRequest<librbd::MockTestImageCtx>*
@@ -281,22 +284,9 @@ public:
         }));
   }
 
-  void expect_snap_set(librbd::MockTestImageCtx &mock_image_ctx,
-                       const std::string &snap_name, int r) {
-    EXPECT_CALL(*mock_image_ctx.state, snap_set(_, _))
-      .WillOnce(Invoke([this, &mock_image_ctx, snap_name, r](uint64_t snap_id, Context *on_finish) {
-          RWLock::RLocker snap_locker(mock_image_ctx.snap_lock);
-          auto id = mock_image_ctx.image_ctx->get_snap_id(
-            cls::rbd::UserSnapshotNamespace{}, snap_name);
-          ASSERT_EQ(snap_id, id);
-          m_threads->work_queue->queue(on_finish, r);
-        }));
-  }
-
   void expect_clone_image(MockCloneRequest &mock_clone_request,
-			  librbd::MockTestImageCtx &mock_parent_imctx,
                           int r) {
-    EXPECT_CALL(mock_clone_request, construct(&mock_parent_imctx));
+    EXPECT_CALL(mock_clone_request, construct());
     EXPECT_CALL(mock_clone_request, send())
       .WillOnce(Invoke([this, &mock_clone_request, r]() {
             m_threads->work_queue->queue(mock_clone_request.on_finish, r);
@@ -372,7 +362,6 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Clone) {
                &remote_clone_image_ctx));
 
   librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
   librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
   MockCloneRequest mock_clone_request;
   MockOpenImageRequest mock_open_image_request;
@@ -386,11 +375,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Clone) {
 
   expect_open_image(mock_open_image_request, m_remote_io_ctx,
                     m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, 0);
-  expect_snap_set(mock_local_parent_image_ctx, "snap", 0);
-  expect_clone_image(mock_clone_request, mock_local_parent_image_ctx, 0);
-  expect_close_image(mock_close_image_request, mock_local_parent_image_ctx, 0);
+  expect_clone_image(mock_clone_request, 0);
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
@@ -484,91 +469,6 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenRemoteParentError) {
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
 
-TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenLocalParentError) {
-  librbd::RBD rbd;
-  librbd::ImageCtx *local_image_ctx;
-  ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
-  ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &local_image_ctx));
-
-  std::string clone_image_name = get_temp_image_name();
-  ASSERT_EQ(0, clone_image(m_remote_image_ctx, "snap", clone_image_name));
-
-  librbd::ImageCtx *remote_clone_image_ctx;
-  ASSERT_EQ(0, open_image(m_remote_io_ctx, clone_image_name,
-               &remote_clone_image_ctx));
-
-  librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
-  librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
-  MockCloneRequest mock_clone_request;
-  MockOpenImageRequest mock_open_image_request;
-  MockCloseImageRequest mock_close_image_request;
-
-  InSequence seq;
-  expect_ioctx_create(m_remote_io_ctx);
-  expect_ioctx_create(m_local_io_ctx);
-  expect_get_parent_global_image_id(m_remote_io_ctx, "global uuid", 0);
-  expect_mirror_image_get_image_id(m_local_io_ctx, "local parent id", 0);
-
-  expect_open_image(mock_open_image_request, m_remote_io_ctx,
-                    m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, -ENOENT);
-  expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
-
-  C_SaferCond ctx;
-  MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
-                                                   "image name", "101241a7c4c9",
-                                                   mock_remote_clone_image_ctx,
-                                                   &ctx);
-  request->send();
-  ASSERT_EQ(-ENOENT, ctx.wait());
-}
-
-TEST_F(TestMockImageReplayerCreateImageRequest, CloneSnapSetError) {
-  librbd::RBD rbd;
-  librbd::ImageCtx *local_image_ctx;
-  ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
-  ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &local_image_ctx));
-  snap_create(local_image_ctx, "snap");
-
-  std::string clone_image_name = get_temp_image_name();
-  ASSERT_EQ(0, clone_image(m_remote_image_ctx, "snap", clone_image_name));
-
-  librbd::ImageCtx *remote_clone_image_ctx;
-  ASSERT_EQ(0, open_image(m_remote_io_ctx, clone_image_name,
-               &remote_clone_image_ctx));
-
-  librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
-  librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
-  MockCloneRequest mock_clone_request;
-  MockOpenImageRequest mock_open_image_request;
-  MockCloseImageRequest mock_close_image_request;
-
-  InSequence seq;
-  expect_ioctx_create(m_remote_io_ctx);
-  expect_ioctx_create(m_local_io_ctx);
-  expect_get_parent_global_image_id(m_remote_io_ctx, "global uuid", 0);
-  expect_mirror_image_get_image_id(m_local_io_ctx, "local parent id", 0);
-
-  expect_open_image(mock_open_image_request, m_remote_io_ctx,
-                    m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, 0);
-  expect_snap_set(mock_local_parent_image_ctx, "snap", -ENOENT);
-  expect_close_image(mock_close_image_request, mock_local_parent_image_ctx, 0);
-  expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
-
-  C_SaferCond ctx;
-  MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
-                                                   "image name", "101241a7c4c9",
-                                                   mock_remote_clone_image_ctx,
-                                                   &ctx);
-  request->send();
-  ASSERT_EQ(-ENOENT, ctx.wait());
-}
-
 TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
   librbd::RBD rbd;
   librbd::ImageCtx *local_image_ctx;
@@ -584,7 +484,6 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
                &remote_clone_image_ctx));
 
   librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
   librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
   MockCloneRequest mock_clone_request;
   MockOpenImageRequest mock_open_image_request;
@@ -598,11 +497,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
 
   expect_open_image(mock_open_image_request, m_remote_io_ctx,
                     m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, 0);
-  expect_snap_set(mock_local_parent_image_ctx, "snap", 0);
-  expect_clone_image(mock_clone_request, mock_local_parent_image_ctx, -EINVAL);
-  expect_close_image(mock_close_image_request, mock_local_parent_image_ctx, 0);
+  expect_clone_image(mock_clone_request, -EINVAL);
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
 
   C_SaferCond ctx;
@@ -612,51 +507,6 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
                                                    &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
-}
-
-TEST_F(TestMockImageReplayerCreateImageRequest, CloneLocalParentCloseError) {
-  librbd::RBD rbd;
-  librbd::ImageCtx *local_image_ctx;
-  ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
-  ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &local_image_ctx));
-  snap_create(local_image_ctx, "snap");
-
-  std::string clone_image_name = get_temp_image_name();
-  ASSERT_EQ(0, clone_image(m_remote_image_ctx, "snap", clone_image_name));
-
-  librbd::ImageCtx *remote_clone_image_ctx;
-  ASSERT_EQ(0, open_image(m_remote_io_ctx, clone_image_name,
-               &remote_clone_image_ctx));
-
-  librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
-  librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
-  MockCloneRequest mock_clone_request;
-  MockOpenImageRequest mock_open_image_request;
-  MockCloseImageRequest mock_close_image_request;
-
-  InSequence seq;
-  expect_ioctx_create(m_remote_io_ctx);
-  expect_ioctx_create(m_local_io_ctx);
-  expect_get_parent_global_image_id(m_remote_io_ctx, "global uuid", 0);
-  expect_mirror_image_get_image_id(m_local_io_ctx, "local parent id", 0);
-
-  expect_open_image(mock_open_image_request, m_remote_io_ctx,
-                    m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, 0);
-  expect_snap_set(mock_local_parent_image_ctx, "snap", 0);
-  expect_clone_image(mock_clone_request, mock_local_parent_image_ctx, 0);
-  expect_close_image(mock_close_image_request, mock_local_parent_image_ctx, -EINVAL);
-  expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, 0);
-
-  C_SaferCond ctx;
-  MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
-                                                   "image name", "101241a7c4c9",
-                                                   mock_remote_clone_image_ctx,
-                                                   &ctx);
-  request->send();
-  ASSERT_EQ(0, ctx.wait());
 }
 
 TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
@@ -674,7 +524,6 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
                &remote_clone_image_ctx));
 
   librbd::MockTestImageCtx mock_remote_parent_image_ctx(*m_remote_image_ctx);
-  librbd::MockTestImageCtx mock_local_parent_image_ctx(*local_image_ctx);
   librbd::MockTestImageCtx mock_remote_clone_image_ctx(*remote_clone_image_ctx);
   MockCloneRequest mock_clone_request;
   MockOpenImageRequest mock_open_image_request;
@@ -688,11 +537,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
 
   expect_open_image(mock_open_image_request, m_remote_io_ctx,
                     m_remote_image_ctx->id, mock_remote_parent_image_ctx, 0);
-  expect_open_image(mock_open_image_request, m_local_io_ctx,
-                    "local parent id", mock_local_parent_image_ctx, 0);
-  expect_snap_set(mock_local_parent_image_ctx, "snap", 0);
-  expect_clone_image(mock_clone_request, mock_local_parent_image_ctx, 0);
-  expect_close_image(mock_close_image_request, mock_local_parent_image_ctx, 0);
+  expect_clone_image(mock_clone_request, 0);
   expect_close_image(mock_close_image_request, mock_remote_parent_image_ctx, -EINVAL);
 
   C_SaferCond ctx;

--- a/src/test/rbd_mirror/test_ImageDeleter.cc
+++ b/src/test/rbd_mirror/test_ImageDeleter.cc
@@ -193,9 +193,10 @@ public:
     std::string clone_id = librbd::util::generate_image_id(m_local_io_ctx);
     librbd::ImageOptions clone_opts;
     clone_opts.set(RBD_IMAGE_OPTION_FEATURES, ictx->features);
-    EXPECT_EQ(0, librbd::clone(ictx, m_local_io_ctx, "clone1", clone_id,
-                               clone_opts, GLOBAL_CLONE_IMAGE_ID,
-                               m_remote_mirror_uuid));
+    EXPECT_EQ(0, librbd::clone(m_local_io_ctx, m_local_image_id.c_str(),
+                               nullptr, "snap1", m_local_io_ctx,
+                               clone_id.c_str(), "clone1", clone_opts,
+                               GLOBAL_CLONE_IMAGE_ID, m_remote_mirror_uuid));
 
     cls::rbd::MirrorImage mirror_image(
       GLOBAL_CLONE_IMAGE_ID, MirrorImageState::MIRROR_IMAGE_STATE_ENABLED);

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -97,7 +97,7 @@ int TestFixture::create_image(librbd::RBD &rbd, librados::IoCtx &ioctx,
 int TestFixture::open_image(librados::IoCtx &io_ctx,
                             const std::string &image_name,
                             librbd::ImageCtx **image_ctx) {
-  *image_ctx = new librbd::ImageCtx(image_name.c_str(), "", NULL, io_ctx,
+  *image_ctx = new librbd::ImageCtx(image_name.c_str(), "", nullptr, io_ctx,
                                     false);
   m_image_ctxs.insert(*image_ctx);
   return (*image_ctx)->state->open(false);

--- a/src/tools/rbd/CMakeLists.txt
+++ b/src/tools/rbd/CMakeLists.txt
@@ -26,6 +26,7 @@ set(rbd_srcs
   action/List.cc
   action/Lock.cc
   action/MergeDiff.cc
+  action/Migration.cc
   action/MirrorPool.cc
   action/MirrorImage.cc
   action/Namespace.cc

--- a/src/tools/rbd/action/Info.cc
+++ b/src/tools/rbd/action/Info.cc
@@ -295,13 +295,19 @@ static int do_show_info(librados::IoCtx &io_ctx, librbd::Image& image,
       if (trash_image_info_valid) {
         f->dump_string("trash", parent_id);
       }
+      if ((features & RBD_FEATURE_MIGRATING) != 0) {
+        f->dump_bool("migration_source", true);
+      }
       f->dump_unsigned("overlap", overlap);
       f->close_section();
     } else {
       std::cout << "\tparent: " << parent_pool << "/" << parent_name
-                << "@" << parent_snapname;
+                << (parent_snapname.empty() ? "" : "@") << parent_snapname;
       if (trash_image_info_valid) {
         std::cout << " (trash " << parent_id << ")";
+      }
+      if ((features & RBD_FEATURE_MIGRATING) != 0) {
+        std::cout << " (migration source)";
       }
       std::cout << std::endl;
       std::cout << "\toverlap: " << byte_u_t(overlap) << std::endl;

--- a/src/tools/rbd/action/Migration.cc
+++ b/src/tools/rbd/action/Migration.cc
@@ -1,0 +1,270 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "common/errno.h"
+
+#include "tools/rbd/ArgumentTypes.h"
+#include "tools/rbd/Shell.h"
+#include "tools/rbd/Utils.h"
+
+#include <iostream>
+#include <boost/program_options.hpp>
+
+namespace rbd {
+namespace action {
+namespace migration {
+
+namespace at = argument_types;
+namespace po = boost::program_options;
+
+static int do_prepare(librados::IoCtx& io_ctx, const std::string &image_name,
+                      librados::IoCtx& dest_io_ctx,
+                      const std::string &dest_image_name,
+                      librbd::ImageOptions& opts) {
+  int r = librbd::RBD().migration_prepare(io_ctx, image_name.c_str(),
+                                          dest_io_ctx, dest_image_name.c_str(),
+                                          opts);
+  if (r < 0) {
+    std::cerr << "rbd: preparing migration failed: " << cpp_strerror(r)
+              << std::endl;
+    return r;
+  }
+  return 0;
+}
+
+static int do_execute(librados::IoCtx& io_ctx, const std::string &image_name,
+                      bool no_progress) {
+  utils::ProgressContext pc("Image migration", no_progress);
+  int r = librbd::RBD().migration_execute_with_progress(io_ctx,
+                                                        image_name.c_str(), pc);
+  if (r < 0) {
+    pc.fail();
+    std::cerr << "rbd: migration failed: " << cpp_strerror(r) << std::endl;
+    return r;
+  }
+  pc.finish();
+  return 0;
+}
+
+static int do_abort(librados::IoCtx& io_ctx, const std::string &image_name,
+                    bool no_progress) {
+  utils::ProgressContext pc("Abort image migration", no_progress);
+  int r = librbd::RBD().migration_abort_with_progress(io_ctx,
+                                                      image_name.c_str(), pc);
+  if (r < 0) {
+    pc.fail();
+    std::cerr << "rbd: aborting migration failed: " << cpp_strerror(r)
+              << std::endl;
+    return r;
+  }
+  pc.finish();
+  return 0;
+}
+
+static int do_commit(librados::IoCtx& io_ctx, const std::string &image_name,
+                     bool no_progress) {
+  utils::ProgressContext pc("Commit image migration", no_progress);
+  int r = librbd::RBD().migration_commit_with_progress(io_ctx,
+                                                       image_name.c_str(), pc);
+  if (r < 0) {
+    pc.fail();
+    std::cerr << "rbd: committing migration failed: " << cpp_strerror(r)
+              << std::endl;
+    return r;
+  }
+  pc.finish();
+  return 0;
+}
+
+void get_prepare_arguments(po::options_description *positional,
+                           po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_SOURCE);
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_DEST);
+  at::add_create_image_options(options, true);
+  at::add_flatten_option(options);
+}
+
+int execute_prepare(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_SOURCE, &arg_index, &pool_name, &namespace_name,
+    &image_name, nullptr, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+  io_ctx.set_osdmap_full_try();
+
+  std::string dest_pool_name;
+  std::string dest_namespace_name;
+  std::string dest_image_name;
+  r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_DEST, &arg_index, &dest_pool_name,
+    &dest_namespace_name, &dest_image_name, nullptr, false,
+    utils::SNAPSHOT_PRESENCE_NONE, utils::SPEC_VALIDATION_FULL);
+  if (r < 0) {
+    return r;
+  }
+
+  librbd::ImageOptions opts;
+  r = utils::get_image_options(vm, true, &opts);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::IoCtx dest_io_ctx;
+  if (!dest_pool_name.empty()) {
+    r = utils::init_io_ctx(rados, dest_pool_name, dest_namespace_name,
+                           &dest_io_ctx);
+    if (r < 0) {
+      return r;
+    }
+  }
+
+  r = do_prepare(io_ctx, image_name, dest_pool_name.empty() ? io_ctx :
+                 dest_io_ctx, dest_image_name, opts);
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+void get_execute_arguments(po::options_description *positional,
+                           po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_no_progress_option(options);
+}
+
+int execute_execute(const po::variables_map &vm,
+                    const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, nullptr, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+  io_ctx.set_osdmap_full_try();
+
+  r = do_execute(io_ctx, image_name, vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+void get_abort_arguments(po::options_description *positional,
+                          po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_no_progress_option(options);
+}
+
+int execute_abort(const po::variables_map &vm,
+                  const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, nullptr, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+  io_ctx.set_osdmap_full_try();
+
+  r = do_abort(io_ctx, image_name, vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+void get_commit_arguments(po::options_description *positional,
+                          po::options_description *options) {
+  at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
+  at::add_no_progress_option(options);
+}
+
+int execute_commit(const po::variables_map &vm,
+                   const std::vector<std::string> &ceph_global_init_args) {
+  size_t arg_index = 0;
+  std::string pool_name;
+  std::string namespace_name;
+  std::string image_name;
+  int r = utils::get_pool_image_snapshot_names(
+    vm, at::ARGUMENT_MODIFIER_NONE, &arg_index, &pool_name, &namespace_name,
+    &image_name, nullptr, true, utils::SNAPSHOT_PRESENCE_NONE,
+    utils::SPEC_VALIDATION_NONE);
+  if (r < 0) {
+    return r;
+  }
+
+  librados::Rados rados;
+  librados::IoCtx io_ctx;
+  r = utils::init(pool_name, namespace_name, &rados, &io_ctx);
+  if (r < 0) {
+    return r;
+  }
+  io_ctx.set_osdmap_full_try();
+
+  r = do_commit(io_ctx, image_name, vm[at::NO_PROGRESS].as<bool>());
+  if (r < 0) {
+    return r;
+  }
+
+  return 0;
+}
+
+Shell::Action action_prepare(
+  {"migration", "prepare"}, {}, "Prepare image migration.",
+  at::get_long_features_help(), &get_prepare_arguments, &execute_prepare);
+
+Shell::Action action_execute(
+  {"migration", "execute"}, {}, "Execute image migration.", "",
+  &get_execute_arguments, &execute_execute);
+
+Shell::Action action_abort(
+  {"migration", "abort"}, {}, "Cancel interrupted image migration.", "",
+  &get_abort_arguments, &execute_abort);
+
+Shell::Action action_commit(
+  {"migration", "commit"}, {}, "Commit image migration.", "",
+  &get_commit_arguments, &execute_commit);
+
+} // namespace migration
+} // namespace action
+} // namespace rbd

--- a/src/tools/rbd/action/Status.cc
+++ b/src/tools/rbd/action/Status.cc
@@ -5,6 +5,7 @@
 #include "tools/rbd/Shell.h"
 #include "tools/rbd/Utils.h"
 #include "include/rbd_types.h"
+#include "include/stringify.h"
 #include "common/errno.h"
 #include "common/Formatter.h"
 #include <iostream>
@@ -17,7 +18,8 @@ namespace status {
 namespace at = argument_types;
 namespace po = boost::program_options;
 
-static int do_show_status(librbd::Image &image, Formatter *f)
+static int do_show_status(librados::IoCtx& io_ctx, const std::string &image_name,
+                          librbd::Image &image, Formatter *f)
 {
   int r;
   std::list<librbd::image_watcher_t> watchers;
@@ -25,6 +27,63 @@ static int do_show_status(librbd::Image &image, Formatter *f)
   r = image.list_watchers(watchers);
   if (r < 0)
     return r;
+
+  uint64_t features;
+  r = image.features(&features);
+  if (r < 0) {
+    return r;
+  }
+
+  librbd::image_migration_status_t migration_status;
+  std::string source_pool_name;
+  std::string dest_pool_name;
+  std::string migration_state;
+  if ((features & RBD_FEATURE_MIGRATING) != 0) {
+    r = librbd::RBD().migration_status(io_ctx, image_name.c_str(),
+                                       &migration_status,
+                                       sizeof(migration_status));
+    if (r < 0) {
+      std::cerr << "rbd: getting migration status failed: " << cpp_strerror(r)
+                << std::endl;
+      // not fatal
+    } else {
+      librados::IoCtx src_io_ctx;
+      r = librados::Rados(io_ctx).ioctx_create2(migration_status.source_pool_id, src_io_ctx);
+      if (r < 0) {
+        source_pool_name = stringify(migration_status.source_pool_id);
+      } else {
+        source_pool_name = src_io_ctx.get_pool_name();
+      }
+
+      librados::IoCtx dst_io_ctx;
+      r = librados::Rados(io_ctx).ioctx_create2(migration_status.dest_pool_id, dst_io_ctx);
+      if (r < 0) {
+        dest_pool_name = stringify(migration_status.dest_pool_id);
+      } else {
+        dest_pool_name = dst_io_ctx.get_pool_name();
+      }
+
+      switch (migration_status.state) {
+      case RBD_IMAGE_MIGRATION_STATE_ERROR:
+        migration_state = "error";
+        break;
+      case RBD_IMAGE_MIGRATION_STATE_PREPARING:
+        migration_state = "preparing";
+        break;
+      case RBD_IMAGE_MIGRATION_STATE_PREPARED:
+        migration_state = "prepared";
+        break;
+      case RBD_IMAGE_MIGRATION_STATE_EXECUTING:
+        migration_state = "executing";
+        break;
+      case RBD_IMAGE_MIGRATION_STATE_EXECUTED:
+        migration_state = "executed";
+        break;
+      default:
+        migration_state = "unknown";
+      }
+    }
+  }
 
   if (f)
     f->open_object_section("status");
@@ -38,7 +97,19 @@ static int do_show_status(librbd::Image &image, Formatter *f)
       f->dump_unsigned("cookie", watcher.cookie);
       f->close_section();
     }
-    f->close_section();
+    f->close_section(); // watchers
+    if (!migration_state.empty()) {
+      f->open_object_section("migration");
+      f->dump_string("source_pool_name", source_pool_name);
+      f->dump_string("source_image_name", migration_status.source_image_name);
+      f->dump_string("source_image_id", migration_status.source_image_id);
+      f->dump_string("dest_pool_name", dest_pool_name);
+      f->dump_string("dest_image_name", migration_status.dest_image_name);
+      f->dump_string("dest_image_id", migration_status.dest_image_id);
+      f->dump_string("state", migration_state);
+      f->dump_string("state_description", migration_status.state_description);
+      f->close_section(); // migration
+    }
   } else {
     if (watchers.size()) {
       std::cout << "Watchers:" << std::endl;
@@ -49,9 +120,27 @@ static int do_show_status(librbd::Image &image, Formatter *f)
     } else {
       std::cout << "Watchers: none" << std::endl;
     }
+    if (!migration_state.empty()) {
+      std::cout << "Migration:" << std::endl;
+      std::cout << "\tsource: " << source_pool_name << "/"
+              << migration_status.source_image_name;
+      if (!migration_status.source_image_id.empty()) {
+        std::cout << " (" << migration_status.source_image_id <<  ")";
+      }
+      std::cout << std::endl;
+      std::cout << "\tdestination: " << dest_pool_name << "/"
+                << migration_status.dest_image_name << " ("
+                << migration_status.dest_image_id <<  ")" << std::endl;
+      std::cout << "\tstate: " << migration_state;
+      if (!migration_status.state_description.empty()) {
+        std::cout << " (" << migration_status.state_description <<  ")";
+      }
+      std::cout << std::endl;
+    }
   }
+
   if (f) {
-    f->close_section();
+    f->close_section(); // status
     f->flush(std::cout);
   }
 
@@ -94,7 +183,7 @@ int execute(const po::variables_map &vm,
     return r;
   }
 
-  r = do_show_status(image, formatter.get());
+  r = do_show_status(io_ctx, image_name, image, formatter.get());
   if (r < 0) {
     std::cerr << "rbd: show status failed: " << cpp_strerror(r) << std::endl;
     return r;

--- a/src/tools/rbd/action/Trash.cc
+++ b/src/tools/rbd/action/Trash.cc
@@ -268,6 +268,9 @@ int do_list(librbd::RBD &rbd, librados::IoCtx& io_ctx, bool long_flag,
       case RBD_TRASH_IMAGE_SOURCE_MIRRORING:
         del_source = "MIRRORING";
         break;
+      case RBD_TRASH_IMAGE_SOURCE_MIGRATION:
+        del_source = "MIGRATION";
+        break;
     }
 
     std::string time_str = ctime(&entry.deletion_time);

--- a/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
+++ b/src/tools/rbd_mirror/image_deleter/SnapshotPurgeRequest.cc
@@ -42,7 +42,7 @@ void SnapshotPurgeRequest<I>::open_image() {
   Context *ctx = create_context_callback<
     SnapshotPurgeRequest<I>, &SnapshotPurgeRequest<I>::handle_open_image>(
       this);
-  m_image_ctx->state->open(true, ctx);
+  m_image_ctx->state->open(librbd::OPEN_FLAG_SKIP_OPEN_PARENT, ctx);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -202,38 +202,13 @@ void CreateImageRequest<I>::handle_open_remote_parent_image(int r) {
     return;
   }
 
-  open_local_parent_image();
+  clone_image();
 }
 
 template <typename I>
-void CreateImageRequest<I>::open_local_parent_image() {
+void CreateImageRequest<I>::clone_image() {
   dout(20) << dendl;
 
-  Context *ctx = create_context_callback<
-    CreateImageRequest<I>,
-    &CreateImageRequest<I>::handle_open_local_parent_image>(this);
-  OpenImageRequest<I> *request = OpenImageRequest<I>::create(
-    m_local_parent_io_ctx, &m_local_parent_image_ctx,
-    m_local_parent_spec.image_id, true, ctx);
-  request->send();
-}
-
-template <typename I>
-void CreateImageRequest<I>::handle_open_local_parent_image(int r) {
-  dout(20) << ": r=" << r << dendl;
-  if (r < 0) {
-    derr << ": failed to open local parent image " << m_parent_pool_name << "/"
-         << m_local_parent_spec.image_id << dendl;
-    m_ret_val = r;
-    close_remote_parent_image();
-    return;
-  }
-
-  set_local_parent_snap();
-}
-
-template <typename I>
-void CreateImageRequest<I>::set_local_parent_snap() {
   std::string snap_name;
   cls::rbd::SnapshotNamespace snap_namespace;
   {
@@ -246,66 +221,18 @@ void CreateImageRequest<I>::set_local_parent_snap() {
     }
   }
 
-  if (snap_name.empty()) {
-    dout(15) << ": failed to locate remote parent snapshot" << dendl;
-    m_ret_val = -ENOENT;
-    close_local_parent_image();
-    return;
-  }
-
-  m_local_parent_spec.snap_id = CEPH_NOSNAP;
-  {
-    RWLock::RLocker local_snap_locker(m_local_parent_image_ctx->snap_lock);
-    auto it = m_local_parent_image_ctx->snap_ids.find(
-      {snap_namespace, snap_name});
-    if (it != m_local_parent_image_ctx->snap_ids.end()) {
-      m_local_parent_spec.snap_id = it->second;
-    }
-  }
-
-  if (m_local_parent_spec.snap_id == CEPH_NOSNAP) {
-    dout(15) << ": failed to locate local parent snapshot" << dendl;
-    m_ret_val = -ENOENT;
-    close_local_parent_image();
-    return;
-  }
-
-  dout(15) << ": local_snap_id=" << m_local_parent_spec.snap_id << dendl;
-
-  Context *ctx = create_context_callback<
-    CreateImageRequest<I>,
-    &CreateImageRequest<I>::handle_set_local_parent_snap>(this);
-  m_local_parent_image_ctx->state->snap_set(m_local_parent_spec.snap_id, ctx);
-}
-
-template <typename I>
-void CreateImageRequest<I>::handle_set_local_parent_snap(int r) {
-  dout(20) << ": r=" << r << dendl;
-  if (r < 0) {
-    derr << ": failed to set parent snapshot " << m_local_parent_spec.snap_id
-         << ": " << cpp_strerror(r) << dendl;
-    m_ret_val = r;
-    close_local_parent_image();
-    return;
-  }
-
-  clone_image();
-}
-
-template <typename I>
-void CreateImageRequest<I>::clone_image() {
-  dout(20) << dendl;
-
   librbd::ImageOptions opts;
   populate_image_options(&opts);
 
   using klass = CreateImageRequest<I>;
-  Context *ctx = create_context_callback<klass, &klass::handle_clone_image>(this);
+  Context *ctx = create_context_callback<
+    klass, &klass::handle_clone_image>(this);
 
   librbd::image::CloneRequest<I> *req = librbd::image::CloneRequest<I>::create(
-    m_local_parent_image_ctx, m_local_io_ctx, m_local_image_name,
-    m_local_image_id, opts, m_global_image_id, m_remote_mirror_uuid,
-    m_remote_image_ctx->op_work_queue, ctx);
+    m_local_parent_io_ctx, m_local_parent_spec.image_id, snap_name, CEPH_NOSNAP,
+    m_local_io_ctx, m_local_image_name, m_local_image_id, opts,
+    m_global_image_id, m_remote_mirror_uuid, m_remote_image_ctx->op_work_queue,
+    ctx);
   req->send();
 }
 
@@ -314,31 +241,9 @@ void CreateImageRequest<I>::handle_clone_image(int r) {
   dout(20) << ": r=" << r << dendl;
   if (r < 0) {
     derr << ": failed to clone image " << m_parent_pool_name << "/"
-         << m_local_parent_image_ctx->name << " to "
+         << m_remote_parent_spec.image_id << " to "
          << m_local_image_name << dendl;
     m_ret_val = r;
-  }
-
-  close_local_parent_image();
-}
-
-template <typename I>
-void CreateImageRequest<I>::close_local_parent_image() {
-  dout(20) << dendl;
-  Context *ctx = create_context_callback<
-    CreateImageRequest<I>,
-    &CreateImageRequest<I>::handle_close_local_parent_image>(this);
-  CloseImageRequest<I> *request = CloseImageRequest<I>::create(
-    &m_local_parent_image_ctx, ctx);
-  request->send();
-}
-
-template <typename I>
-void CreateImageRequest<I>::handle_close_local_parent_image(int r) {
-  dout(20) << ": r=" << r << dendl;
-  if (r < 0) {
-    derr << ": error encountered closing local parent image: "
-         << cpp_strerror(r) << dendl;
   }
 
   close_remote_parent_image();

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -64,19 +64,10 @@ private:
    *                    OPEN_REMOTE_PARENT  * * * * * * * | * * *   *
    *                        |                             |       * *
    *                        v                             |         *
-   *                    OPEN_LOCAL_PARENT * * * * * * *   |         *
-   *                        |                         *   |         *
-   *                        v                         *   |         *
-   *                    SET_LOCAL_PARENT_SNAP         *   |         *
-   *                        |         *               *   |         *
-   *                        v         *               *   |         *
-   *                    CLONE_IMAGE   *               *   |         *
-   *                        |         *               *   |         *
-   *                        v         v               *   |         *
-   *                    CLOSE_LOCAL_PARENT            *   |         *
-   *                        |                         *   |         *
-   *                        v                         *   |         *
-   *                    CLOSE_REMOTE_PARENT < * * * * *   |         *
+   *                    CLONE_IMAGE                       |         *
+   *                        |                             |         *
+   *                        v                             |         *
+   *                    CLOSE_REMOTE_PARENT               |         *
    *                        |                             v         *
    *                        \------------------------> <finish> < * *
    * @endverbatim
@@ -96,7 +87,6 @@ private:
   librbd::ParentSpec m_remote_parent_spec;
 
   librados::IoCtx m_local_parent_io_ctx;
-  ImageCtxT *m_local_parent_image_ctx = nullptr;
   librbd::ParentSpec m_local_parent_spec;
 
   bufferlist m_out_bl;
@@ -116,17 +106,8 @@ private:
   void open_remote_parent_image();
   void handle_open_remote_parent_image(int r);
 
-  void open_local_parent_image();
-  void handle_open_local_parent_image(int r);
-
-  void set_local_parent_snap();
-  void handle_set_local_parent_snap(int r);
-
   void clone_image();
   void handle_clone_image(int r);
-
-  void close_local_parent_image();
-  void handle_close_local_parent_image(int r);
 
   void close_remote_parent_image();
   void handle_close_remote_parent_image(int r);

--- a/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenImageRequest.cc
@@ -43,7 +43,7 @@ void OpenImageRequest<I>::send_open_image() {
   Context *ctx = create_context_callback<
     OpenImageRequest<I>, &OpenImageRequest<I>::handle_open_image>(
       this);
-  (*m_image_ctx)->state->open(false, ctx);
+  (*m_image_ctx)->state->open(0, ctx);
 }
 
 template <typename I>

--- a/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/OpenLocalImageRequest.cc
@@ -118,7 +118,7 @@ void OpenLocalImageRequest<I>::send_open_image() {
   Context *ctx = create_context_callback<
     OpenLocalImageRequest<I>, &OpenLocalImageRequest<I>::handle_open_image>(
       this);
-  (*m_local_image_ctx)->state->open(false, ctx);
+  (*m_local_image_ctx)->state->open(0, ctx);
 }
 
 template <typename I>

--- a/src/tracing/librbd.tp
+++ b/src/tracing/librbd.tp
@@ -1097,6 +1097,114 @@ TRACEPOINT_EVENT(librbd, rename_exit,
     )
 )
 
+TRACEPOINT_EVENT(librbd, migration_prepare_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        uint64_t, id,
+        const char*, image_name,
+        const char*, dest_pool_name,
+        uint64_t, dest_id,
+        const char*, dest_image_name,
+        void*, opts),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(uint64_t, id, id)
+        ctf_string(image_name, image_name)
+        ctf_string(dest_pool_name, dest_pool_name)
+        ctf_integer(uint64_t, dest_id, dest_id)
+        ctf_string(dest_image_name, dest_image_name)
+        ctf_integer_hex(void*, opts, opts)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_prepare_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_execute_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, pool_id,
+        const char*, image_name),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, pool_id, pool_id)
+        ctf_string(image_name, image_name)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_execute_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_abort_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, pool_id,
+        const char*, image_name),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, pool_id, pool_id)
+        ctf_string(image_name, image_name)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_abort_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_commit_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, pool_id,
+        const char*, image_name),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, pool_id, pool_id)
+        ctf_string(image_name, image_name)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_commit_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_status_enter,
+    TP_ARGS(
+        const char*, pool_name,
+        int64_t, pool_id,
+        const char*, image_name),
+    TP_FIELDS(
+        ctf_string(pool_name, pool_name)
+        ctf_integer(int64_t, pool_id, pool_id)
+        ctf_string(image_name, image_name)
+    )
+)
+
+TRACEPOINT_EVENT(librbd, migration_status_exit,
+    TP_ARGS(
+        int, retval),
+    TP_FIELDS(
+        ctf_integer(int, retval, retval)
+    )
+)
+
 TRACEPOINT_EVENT(librbd, discard_enter,
     TP_ARGS(
         void*, imagectx,


### PR DESCRIPTION
This implements the first stage for the feature to transparently support migrating images with minimal/zero downtime [1]

A new API/CLI function "migrate" has been added, which runs migration by creating a new image header, setting the old image as parent and starting flattening process. Currently it requires the image being migrated is not opened RW (watched) at the moment when "migrate" function is called. After migration is started other clients may start using the image not waiting for migration to complete, thus it allows to migrate images with minimal downtime.

The next stage is to make migration transparent (zero downtime) for new clients. It will require:
- add support to track client API requests to be able to block them when reopening image transparently (discussed in #15491);
- add new image watcher messages and protocol to coordinate migration (and fail if the image is being used by older client).

[1] http://tracker.ceph.com/issues/18430