### PR TITLE
osd: osd does not using MPing Messages,do not include unused include

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -61,7 +61,6 @@
 #include "messages/MLog.h"
 
 #include "messages/MGenericMessage.h"
-#include "messages/MPing.h"
 #include "messages/MOSDPing.h"
 #include "messages/MOSDFailure.h"
 #include "messages/MOSDMarkMeDown.h"


### PR DESCRIPTION
osd just need MPing id CEPH_MSG_PING，MPing Messages not used

Signed-off-by: linbing <linbing@t2cloud.net>