### PR TITLE
systemd: Add explicit Before=ceph.target

### DIFF
--- a/systemd/ceph-fuse.target
+++ b/systemd/ceph-fuse.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-fuse@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=remote-fs.target ceph.target

--- a/systemd/ceph-mds.target
+++ b/systemd/ceph-mds.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-mds@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mgr.target
+++ b/systemd/ceph-mgr.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-mgr@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-mon.target
+++ b/systemd/ceph-mon.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-mon@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-osd.target
+++ b/systemd/ceph-osd.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-osd@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-radosgw.target
+++ b/systemd/ceph-radosgw.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-radosgw@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target

--- a/systemd/ceph-rbd-mirror.target
+++ b/systemd/ceph-rbd-mirror.target
@@ -1,5 +1,6 @@
 [Unit]
 Description=ceph target allowing to start/stop all ceph-rbd-mirror@.service instances at once
 PartOf=ceph.target
+Before=ceph.target
 [Install]
 WantedBy=multi-user.target ceph.target


### PR DESCRIPTION
The PartOf= and WantedBy= directives in the various systemd
unit files and targets create the following hierarchy:

- ceph.target
  - ceph-fuse.target
    - ceph-fuse@.service
  - ceph-mds.target
    - ceph-mds@.service
  - ceph-mgr.target
    - ceph-mgr@.service
  - ceph-mon.target
    - ceph-mon@.service
  - ceph-osd.target
    - ceph-osd@.service
  - ceph-radosgw.target
    - ceph-radosgw@.service
  - ceph-rbd-mirror.target
    - ceph-rbd-mirror@.service

Additionally, the ceph-{fuse,mds,mon,osd,radosgw,rbd-mirror}
targets have WantedBy=multi-user.target.  This gives the
following behaviour:

- `systemctl {start,stop,restart}` of any target will restart
  all dependent services (e.g.: `systemctl restart ceph.target`
  will restart all services; `systemctl restart ceph-mon.target`
  will restart all the mons, and so forth).
- `systemctl {enable,disable}` for the second level targets
  (ceph-mon.target etc.) will cause depenent services to come
  up on boot, or not (of course the individual services can
  be enabled or disabled as well - for a service to start
  on boot, both the service and its target must be enabled;
  disabling either will cause the service to be disabled).
- `systemctl {enable,disable} ceph.target` has no effect on
  whether or not services come up at boot; if the second level
  targets and services are enabled, they'll start regardless of
  whether ceph.target is enabled.  This is due to the second
  level targets all having WantedBy=multi-user.target.
- The OSDs will always start regardless of ceph-osd.target
  (unless they are explicitly masked), thanks to udev magic.

So far, so good.  Except, several users have encountered
services not starting with the following error:

  Failed to start ceph-osd@5.service: Transaction order is
  cyclic. See system logs for details.

I've not reproduced this myself, but have inspected systems
with this problem.  It seems that somehow systemd gets
confused, and thinks:

1) ceph-osd@5.service needs to start after ceph-mon.target
2) ceph-mon.target needs to start after ceph.target
3) ceph.target needs to start after ceph-osd.target
4) ceph-osd.target needs to start after ceph-osd@5.service

i.e. ceph.target has wound up stuck in the middle of a
dependency cycle, rather than being after everything where
it should be.  My best guess is that *somehow* the automatic
enablement and starting of OSDs on boot (thanks to udev
rules) is causing systemd to become confused about what's
meant to happen when.

Like I said, I haven't reproduced this myself, but I do have
a workaround.  We can change PartOf= and WantedBy= in the
various service and target files to flatten the hierarchy,
removing all dependencies between the current second level
targets and ceph.target.  This gives the following structure:

- ceph.target
  - ceph-fuse@.service
  - ceph-mds@.service
  - ceph-mgr@.service
  - ceph-mon@.service
  - ceph-osd@.service
  - ceph-radosgw@.service
  - ceph-rbd-mirror@.service
- ceph-fuse.target
  - ceph-fuse@.service
- ceph-mds.target
  - ceph-mds@.service
- ceph-mgr.target
  - ceph-mgr@.service
- ceph-mon.target
  - ceph-mon@.service
- ceph-osd.target
  - ceph-osd@.service
- ceph-radosgw.target
  - ceph-radosgw@.service
- ceph-rbd-mirror.target
  - ceph-rbd-mirror@.service

The behaviour remains the same as described above for the
existing hierarchy (start/stop/restart/enable/disable still
all work the same way), but by splitting ceph.target out, there's
no way for it to end up being stuck at point 3 in the cycle.

There is one caveat: existing systems using the original hierarchy
will have systemd's symlinks set up something like this:

[...]
/etc/systemd/system/ceph.target.wants/ceph-mon.target
/etc/systemd/system/ceph.target.wants/ceph-osd.target
/etc/systemd/system/ceph-mon.target.wants/ceph-mon@ses4-3.service
/etc/systemd/system/ceph-osd.target.wants/ceph-osd@2.service\
[...]

But, with this change, the ceph.target.wants symlinks need to point
to services, not the old second level targets, i.e. it needs to
be as follows:

[...]
/etc/systemd/system/ceph.target.wants/ceph-osd@2.service
/etc/systemd/system/ceph.target.wants/ceph-mon@ses4-3.service
/etc/systemd/system/ceph-osd.target.wants/ceph-osd@2.service
/etc/systemd/system/ceph-mon.target.wants/ceph-mon@ses4-3.service
[...]

To fix these symlinks, you need to run `systemctl disable` then
`systemctl enable` for each of the target files, and each of the
individual services.  Until you do this, systemctl start, stop and
restart on ceph.target will have no effect (start, stop and restart
on the other targets will work just fine though).

Fixes: https://bugzilla.suse.com/show_bug.cgi?id=1042973
Signed-off-by: Tim Serong <tserong@suse.com>