### PR TITLE
rgw: fix infinite loop for data log list

### DIFF
--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -149,13 +149,18 @@ int RGWMetadataLog::list_entries(void *handle,
     *truncated = false;
     return 0;
   }
-
+  
+  list<cls_log_entry> log_entries;
+  
   int ret = store->time_log_list(ctx->cur_oid, ctx->from_time, ctx->end_time,
-				 max_entries, entries, ctx->marker,
+				 max_entries, log_entries, ctx->marker,
 				 last_marker, truncated);
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
+  ctx->marker = *last_marker;
+  entries.splice(entries.end(), log_entries);
+  
   if (ret == -ENOENT)
     *truncated = false;
 


### PR DESCRIPTION
as max_entries_str is empty, it will be infinite loop when data log is more than MAX_ENTRIES(1000) from marker.
and max_entries maybe overflow if use it to count the left entries.

Fixes: http://tracker.ceph.com/issues/20386
Signed-off-by: xierui <jerry.xr86@gmail.com>   lizhong <lz_bruce@126.com>