### PR TITLE
qa/suites/upgrade/hammer-x: set "sortbitwise" for jewel clusters

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/lfn-upgrade-hammer.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/lfn-upgrade-hammer.yaml
@@ -91,6 +91,7 @@ tasks:
 - exec:
     mon.a:
     - sleep 60
+    - ceph osd set sortbitwise
     - ceph osd set require_jewel_osds
 - ceph_manager.wait_for_clean: null
 - ceph_manager.do_pg_scrub:

--- a/qa/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-all.yaml
+++ b/qa/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-all.yaml
@@ -12,6 +12,7 @@ upgrade-sequence:
    - exec:
        mon.a:
          - sleep 300 # http://tracker.ceph.com/issues/17808
+         - ceph osd set sortbitwise
          - ceph osd set require_jewel_osds
    - ceph.healthy:
    - print: "**** done ceph.healthy"

--- a/qa/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-osd-mds-mon.yaml
+++ b/qa/suites/upgrade/hammer-x/parallel/3-upgrade-sequence/upgrade-osd-mds-mon.yaml
@@ -32,6 +32,7 @@ upgrade-sequence:
    - exec:
        osd.0:
          - sleep 300 # http://tracker.ceph.com/issues/17808
+         - ceph osd set sortbitwise
          - ceph osd set require_jewel_osds
    - ceph.healthy:
    - sleep:

--- a/qa/suites/upgrade/hammer-x/stress-split/8-finish-upgrade/last-osds-and-monc.yaml
+++ b/qa/suites/upgrade/hammer-x/stress-split/8-finish-upgrade/last-osds-and-monc.yaml
@@ -16,5 +16,6 @@ tasks:
 - exec:
     osd.0:
       - sleep 300 # http://tracker.ceph.com/issues/17808
+      - ceph osd set sortbitwise
       - ceph osd set require_jewel_osds
 - print: "**** done wait_for_mon_quorum 8-next-mon"

--- a/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
+++ b/qa/suites/upgrade/hammer-x/tiering/3-upgrade/upgrade.yaml
@@ -77,6 +77,7 @@ upgrade-second-half:
       duration: 60
   - exec:
       mon.a:
+        - ceph osd set sortbitwise
         - ceph osd set require_jewel_osds
   - ceph.healthy:
   - print: "**** HEALTH_OK reached after upgrading last OSD to jewel"

--- a/qa/suites/upgrade/hammer-x/v0-94-4-stop/v0-94-4-stop.yaml
+++ b/qa/suites/upgrade/hammer-x/v0-94-4-stop/v0-94-4-stop.yaml
@@ -106,5 +106,6 @@ tasks:
 - exec:
     mon.a:
       - sleep 300 # http://tracker.ceph.com/issues/17808
+      - ceph osd set sortbitwise
       - ceph osd set require_jewel_osds
 - ceph.healthy:


### PR DESCRIPTION
http://tracker.ceph.com/issues/20401

Inspired by 3734280522a913ca8340ebc98b80978f63bade6f

This cannot be cherry-picked from master because master does not have
qa/suites/upgrade/hammer-x

Signed-off-by: Nathan Cutler <ncutler@suse.com>