### PR TITLE
qa: remove 'apply' from journal_tool_smoke.sh

### DIFF
--- a/qa/workunits/suites/cephfs_journal_tool_smoke.sh
+++ b/qa/workunits/suites/cephfs_journal_tool_smoke.sh
@@ -71,7 +71,7 @@ if [ ! -s $BINARY_OUTPUT ] ; then
     echo "Export to $BINARY_OUTPUT failed"
     exit -1
 fi
-$BIN event apply summary
+$BIN event recover_dentries summary
 $BIN event splice summary
 
 echo "Rolling back journal to original state..."


### PR DESCRIPTION
Recently removed this command from the tool.  The
correct one is `recover_dentries`.

Signed-off-by: John Spray <john.spray@redhat.com>