### PR TITLE
src/vstart.sh: kill dead upmap option

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -500,7 +500,6 @@ $extra_conf
 [mon]
         mon pg warn min per osd = 3
         mon osd allow primary affinity = true
-        mon osd allow pg upmap = true
         mon reweight min pgs per osd = 4
         mon osd prime pg temp = true
         crushtool = $CEPH_BIN/crushtool


### PR DESCRIPTION
   So we won't be prevented from use the new "pg upmap" command.
    
    E.g.:
    ~# ./bin/ceph osd pg-upmap-items 0.7 0 1
    Error EPERM: min_compat_client jewel < luminous, which is required for pg-upmap