### PR TITLE
mon/OSDMonitor: add osd_pool_default_expected_objects_per_pg = 10000

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -709,6 +709,7 @@ OPTION(osd_erasure_code_plugins, OPT_STR,
        " isa"
 #endif
        ) // list of erasure code plugins
+OPTION(osd_pool_default_expected_objects_per_pg, OPT_U64, 0)
 
 // Allows the "peered" state for recovery and backfill below min_size
 OPTION(osd_allow_recovery_below_min_size, OPT_BOOL, true)
@@ -1305,7 +1306,7 @@ OPTION(filestore_op_thread_timeout, OPT_INT, 60)
 OPTION(filestore_op_thread_suicide_timeout, OPT_INT, 180)
 OPTION(filestore_commit_timeout, OPT_FLOAT, 600)
 OPTION(filestore_fiemap_threshold, OPT_INT, 4096)
-OPTION(filestore_merge_threshold, OPT_INT, 10)
+OPTION(filestore_merge_threshold, OPT_INT, -10)
 OPTION(filestore_split_multiple, OPT_INT, 2)
 OPTION(filestore_update_to, OPT_INT, 1000)
 OPTION(filestore_blackhole, OPT_BOOL, false)     // drop any new transactions on the floor

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5582,7 +5582,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
                                  unsigned pg_num, unsigned pgp_num,
 				 const string &erasure_code_profile,
                                  const unsigned pool_type,
-                                 const uint64_t expected_num_objects,
+				 uint64_t expected_num_objects,
                                  FastReadType fast_read,
 				 ostream *ss)
 {
@@ -5697,6 +5697,12 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
     pi->use_gmt_hitset = true;
   else
     pi->use_gmt_hitset = false;
+
+  if (!expected_num_objects &&
+      g_conf->osd_pool_default_expected_objects_per_pg > 0) {
+    expected_num_objects = g_conf->osd_pool_default_expected_objects_per_pg *
+      pg_num;
+  }
 
   pi->size = size;
   pi->min_size = min_size;

--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -508,7 +508,7 @@ int HashIndex::pre_split_folder(uint32_t pg_num, uint64_t expected_num_objs)
   const ps_t ps = spgid.pgid.ps();
 
   // the most significant bits of pg_num
-  const int pg_num_bits = calc_num_bits(pg_num - 1);
+  const int pg_num_bits = calc_num_bits(std::max(1u, pg_num - 1));
   ps_t tmp_id = ps;
   // calculate the number of levels we only create one sub folder
   int num = pg_num_bits / 4;


### PR DESCRIPTION
By default, set the expected_num_objects for a pool to be enough objects
per PG so that FileStore will do some of its initial splitting.  This
avoids a throughput collapse later when the pool starts to fill and we
have to do a split.  It also avoids moving objects around between
directories and subverting XFS attempts to keep files in the same directory
within the same AG.

The default of 10,000 should be sufficient to avoid the first two levels
of PG splits (based on the default FileStore parameters).  We disable
the filestore_merge_threshold at the same time so that this will stick
for empty PGs.  The expectation is that pools that get large and then
small again are a rare exception and one we do not care about optimizing
performance for.

Signed-off-by: Sage Weil <sage@redhat.com>