### PR TITLE
doc/radosgw/nfs: mount cmdline example missing -osync

### DIFF
--- a/doc/radosgw/nfs.rst
+++ b/doc/radosgw/nfs.rst
@@ -326,7 +326,7 @@ following conventions work on Linux and some Unix platforms:
 
 From the command line::
 
-  mount -t nfs -o nfsvers=4,noauto,soft,proto=tcp <ganesha-host-name>:/ <mount-point>
+  mount -t nfs -o nfsvers=4.1,noauto,soft,sync,proto=tcp <ganesha-host-name>:/ <mount-point>
 
 In /etc/fstab::
 


### PR DESCRIPTION
The /etc/fstab example has it correctly.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>