### PR TITLE
build-doc: pip rpm package name is python2-pip, not python-pip

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -20,7 +20,7 @@ if command -v dpkg >/dev/null; then
         exit 1
     fi
 elif command -v yum >/dev/null; then
-    for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
+    for package in python-devel python2-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
 	if ! rpm -q $package >/dev/null ; then
 		missing="${missing:+$missing }$package"
 	fi


### PR DESCRIPTION
python-pip.spec defined: %package -n python2-%{srcname}. So when using rpm -q, we never got python-pip even though we have install it, instead of that, we must using rpm -q python2-pip. 

And we give attention to that, we could not simply using project name with rpm -q to judgement we have install the  package in the feature, we should see the package name in project spec file.

Signed-off-by: linbing <linbing@t2cloud.net>