### PR TITLE
common: initialize array in struct BackTrace

### DIFF
--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -14,11 +14,11 @@ struct BackTrace {
   const static int max = 100;
 
   int skip;
-  void *array[max];
+  void *array[max]{};
   size_t size;
   char **strings;
 
-  explicit BackTrace(int s) : skip(s), array{} {
+  explicit BackTrace(int s) : skip(s) {
 #ifdef HAVE_EXECINFO_H
     size = backtrace(array, max);
     strings = backtrace_symbols(array, size);

--- a/src/common/BackTrace.h
+++ b/src/common/BackTrace.h
@@ -18,7 +18,7 @@ struct BackTrace {
   size_t size;
   char **strings;
 
-  explicit BackTrace(int s) : skip(s) {
+  explicit BackTrace(int s) : skip(s), array{} {
 #ifdef HAVE_EXECINFO_H
     size = backtrace(array, max);
     strings = backtrace_symbols(array, size);


### PR DESCRIPTION
Fixes the coverity scan report:
```
1412839 Uninitialized pointer field
CID 1412839 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)2. uninit_member: Non-static
class member array is not initialized in this constructor nor in any functions that it calls.
```

Quoting:
```
C++11 § 8.5,p7
if T is an array type, then each element is value-initialized;
```

Signed-off-by: Jos Collin <jcollin@redhat.com>