### PR TITLE
auth/RotatingKeyRing: use std::move() to set secrets

### DIFF
--- a/src/auth/RotatingKeyRing.cc
+++ b/src/auth/RotatingKeyRing.cc
@@ -21,10 +21,10 @@ bool RotatingKeyRing::need_new_secrets(utime_t now) const
   return secrets.need_new_secrets(now);
 }
 
-void RotatingKeyRing::set_secrets(RotatingSecrets& s)
+void RotatingKeyRing::set_secrets(RotatingSecrets&& s)
 {
   Mutex::Locker l(lock);
-  secrets = s;
+  secrets = std::move(s);
   dump_rotating();
 }
 

--- a/src/auth/RotatingKeyRing.h
+++ b/src/auth/RotatingKeyRing.h
@@ -41,7 +41,7 @@ public:
 
   bool need_new_secrets() const;
   bool need_new_secrets(utime_t now) const;
-  void set_secrets(RotatingSecrets& s);
+  void set_secrets(RotatingSecrets&& s);
   void dump_rotating() const;
   bool get_secret(const EntityName& name, CryptoKey& secret) const override;
   bool get_service_secret(uint32_t service_id, uint64_t secret_id,

--- a/src/auth/cephx/CephxClientHandler.cc
+++ b/src/auth/cephx/CephxClientHandler.cc
@@ -186,7 +186,7 @@ int CephxClientHandler::handle_response(int ret, bufferlist::iterator& indata)
 	    << error << dendl;
 	  return -EINVAL;
 	} else {
-	  rotating_secrets->set_secrets(secrets);
+	  rotating_secrets->set_secrets(std::move(secrets));
 	}
       }
     }


### PR DESCRIPTION
the param will be thrown away anyway. see
CephxClientHandler::handle_response().

Signed-off-by: Kefu Chai <kchai@redhat.com>