### PR TITLE
osd/PG: add pool read/write op latency

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1714,6 +1714,8 @@ OPTION(mgr_mds_bytes, OPT_U64, 128*1048576)   // bytes from mdss
 OPTION(mgr_mds_messages, OPT_U64, 128)        // messages from mdss
 OPTION(mgr_mon_bytes, OPT_U64, 128*1048576)   // bytes from mons
 OPTION(mgr_mon_messages, OPT_U64, 128)        // messages from mons
+OPTION(mgr_op_latency_sample_interval, OPT_INT, 5) // interval we sample pool's average op latency
+OPTION(mgr_op_latency_in_us, OPT_BOOL, false) // true if measuring pool's average op latency in us
 
 OPTION(mgr_connect_retry_interval, OPT_DOUBLE, 1.0)
 

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -223,6 +223,8 @@ public:
 
   // mapping of osd to most recently reported osdmap epoch
   mempool::pgmap::unordered_map<int32_t,epoch_t> osd_epochs;
+  map<int, op_stat_t> pool_op_stat; // FIXME: use unordered_map instead?
+  utime_t last_sampled = ceph_clock_now();
 
   class Incremental {
   public:
@@ -325,6 +327,15 @@ public:
     per_pool_sum_deltas_stamps.erase(pool);
     per_pool_sum_delta.erase(pool);
   }
+
+  enum {
+    op_latency_type_misc,
+    op_latency_type_rd,
+    op_latency_type_wr,
+    op_latency_type_max
+  };
+  void calc_pool_op_latency();
+  uint64_t get_pool_op_latency(int pool, int type) const;
 
  private:
   void update_delta(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2537,6 +2537,18 @@ int OSD::init()
 	  const auto lec = pg->pg_stats_publish.get_effective_last_epoch_clean();
 	  min_last_epoch_clean = min(min_last_epoch_clean, lec);
 	  min_last_epoch_clean_pgs.push_back(pg->info.pgid.pgid);
+	  {
+            op_stat_t op_stat;
+            op_stat.op_num = pg->op_num.load();
+            op_stat.op_latency = pg->op_latency.load();
+            op_stat.rd_num = pg->rd_num.load();
+            op_stat.rd_latency = pg->rd_latency.load();
+            op_stat.wr_num = pg->wr_num.load();
+            op_stat.wr_latency = pg->wr_latency.load();
+
+            m->op_stat[pg->info.pgid.pgid] = op_stat;
+            pg->clear_op_stat();
+          }
         }
         pg->pg_stats_publish_lock.Unlock();
       }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3443,6 +3443,16 @@ void PG::requeue_ops(list<OpRequestRef> &ls)
   ls.clear();
 }
 
+void PG::clear_op_stat()
+{
+  op_num = 0;
+  rd_num = 0;
+  wr_num = 0;
+  op_latency = 0;
+  rd_latency = 0;
+  wr_latency = 0;
+}
+
 void PG::requeue_map_waiters()
 {
   epoch_t epoch = get_osdmap()->get_epoch();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -925,6 +925,12 @@ protected:
 
   // stats that persist lazily
   object_stat_collection_t unstable_stats;
+  std::atomic<uint64_t> op_num = {0};
+  std::atomic<uint64_t> op_latency = {0};
+  std::atomic<uint64_t> rd_num = {0};
+  std::atomic<uint64_t> rd_latency = {0};
+  std::atomic<uint64_t> wr_num = {0};
+  std::atomic<uint64_t> wr_latency = {0};
 
   // publish stats
   Mutex pg_stats_publish_lock;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -931,6 +931,7 @@ protected:
   std::atomic<uint64_t> rd_latency = {0};
   std::atomic<uint64_t> wr_num = {0};
   std::atomic<uint64_t> wr_latency = {0};
+  void clear_op_stat();
 
   // publish stats
   Mutex pg_stats_publish_lock;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3386,18 +3386,32 @@ void PrimaryLogPG::log_op_stats(OpContext *ctx)
     osd->logger->hinc(l_osd_op_rw_lat_inb_hist, latency.to_nsec(), inb);
     osd->logger->hinc(l_osd_op_rw_lat_outb_hist, latency.to_nsec(), outb);
     osd->logger->tinc(l_osd_op_rw_process_lat, process_latency);
+    rd_num++;
+    rd_latency += latency.to_nsec();
+    wr_num++;
+    wr_latency += latency.to_nsec();
+    op_num++;
+    op_latency += latency.to_nsec();
   } else if (op->may_read()) {
     osd->logger->inc(l_osd_op_r);
     osd->logger->inc(l_osd_op_r_outb, outb);
     osd->logger->tinc(l_osd_op_r_lat, latency);
     osd->logger->hinc(l_osd_op_r_lat_outb_hist, latency.to_nsec(), outb);
     osd->logger->tinc(l_osd_op_r_process_lat, process_latency);
+    rd_num++;
+    rd_latency += latency.to_nsec();
+    op_num++;
+    op_latency += latency.to_nsec();
   } else if (op->may_write() || op->may_cache()) {
     osd->logger->inc(l_osd_op_w);
     osd->logger->inc(l_osd_op_w_inb, inb);
     osd->logger->tinc(l_osd_op_w_lat, latency);
     osd->logger->hinc(l_osd_op_w_lat_inb_hist, latency.to_nsec(), inb);
     osd->logger->tinc(l_osd_op_w_process_lat, process_latency);
+    wr_num++;
+    wr_latency += latency.to_nsec();
+    op_num++;
+    op_latency += latency.to_nsec();
   } else
     ceph_abort();
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2468,6 +2468,56 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.pin_stats_invalid == r.pin_stats_invalid;
 }
 
+// -- op-stat-t --
+void op_stat_t::dump(Formatter *f) const
+{
+  f->dump_unsigned("op_num", op_num);
+  f->dump_unsigned("op_latency", op_latency);
+  f->dump_unsigned("rd_num", rd_num);
+  f->dump_unsigned("rd_latency", rd_latency);
+  f->dump_unsigned("wr_num", wr_num);
+  f->dump_unsigned("wr_latency", wr_latency);
+}
+
+void op_stat_t::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(op_num, bl);
+  ::encode(op_latency, bl);
+  ::encode(rd_num, bl);
+  ::encode(rd_latency, bl);
+  ::encode(wr_num, bl);
+  ::encode(wr_latency, bl);
+  ENCODE_FINISH(bl);
+}
+
+void op_stat_t::decode(bufferlist::iterator &bl)
+{
+  DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+  ::decode(op_num, bl);
+  ::decode(op_latency, bl);
+  ::decode(rd_num, bl);
+  ::decode(rd_latency, bl);
+  ::decode(wr_num, bl);
+  ::decode(wr_latency, bl);
+  DECODE_FINISH(bl);
+}
+
+void op_stat_t::generate_test_instances(list<op_stat_t*>& o)
+{
+  op_stat_t a;
+  o.push_back(new op_stat_t(a));
+
+  a.op_num = 12;
+  a.op_latency = 1234;
+  a.rd_num = 23;
+  a.rd_latency = 2345;
+  a.wr_num = 34;
+  a.wr_latency = 3456;
+  o.push_back(new op_stat_t(a));
+}
+
+
 // -- pool_stat_t --
 
 void pool_stat_t::dump(Formatter *f) const

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1986,6 +1986,38 @@ WRITE_CLASS_ENCODER(pg_stat_t)
 bool operator==(const pg_stat_t& l, const pg_stat_t& r);
 
 /*
+ * aggregate op-related stats
+ */
+struct op_stat_t {
+  uint64_t op_num = 0;
+  uint64_t op_latency = 0; // in nanoseconds
+  uint64_t rd_num = 0;
+  uint64_t rd_latency = 0; // in nanoseconds
+  uint64_t wr_num = 0;
+  uint64_t wr_latency = 0; // in nanoseconds
+
+  // for memory caching only
+  uint64_t op_average_latency;
+  uint64_t rd_average_latency;
+  uint64_t wr_average_latency;
+
+  void add(const op_stat_t& o) {
+    op_num = o.op_num;
+    op_latency = o.op_latency;
+    rd_num = o.rd_num;
+    rd_latency = o.rd_latency;
+    wr_num = o.wr_num;
+    wr_latency = o.wr_latency;
+  }
+
+  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  static void generate_test_instances(list<op_stat_t*>& o);
+};
+WRITE_CLASS_ENCODER(op_stat_t)
+
+/*
  * summation over an entire pool
  */
 struct pool_stat_t {


### PR DESCRIPTION
add it so we can get op latency of different pools as below:
```
# ceph pg dump pools
dumped pools
POOLID OBJECTS MISSING_ON_PRIMARY DEGRADED MISPLACED UNFOUND BYTES      LOG   DISK_LOG OP_LATENCY RD_LATENCY WR_LATENCY 
2           21                  0        0         0       0       2246    49       49          0          0          0 
1            0                  0        0         0       0          0     0        0          0          0          0 
0          470                  0        0         0       0 1929109701 24241    24241       1850        365       7870 
```