### PR TITLE
qa: split the osd-scrub-repair tests up

### DIFF
--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -23,7 +23,39 @@ add_ceph_test(osd-config.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-config.sh)
 add_ceph_test(osd-markdown.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-markdown.sh) 
 add_ceph_test(osd-reactivate.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-reactivate.sh) 
 add_ceph_test(osd-reuse-id.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-reuse-id.sh)
-add_ceph_test(osd-scrub-repair.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh) 
+
+add_ceph_test(osd-scrub-repair.sh-auto-repair
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_auto_repair_erasure_coded_appends
+    TEST_auto_repair_erasure_coded_overwrites)
+add_ceph_test(osd-scrub-repair.sh-corrupt-scrub
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_corrupt_scrub_erasure_appends
+    TEST_corrupt_scrub_erasure_overwrites
+    TEST_corrupt_scrub_replicated)
+add_ceph_test(osd-scrub-repair.sh-jerasure
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_corrupt_and_repair_jerasure_appends
+    TEST_corrupt_and_repair_jerasure_overwrites)
+add_ceph_test(osd-scrub-repair.sh-list-missing
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_list_missing_erasure_coded_appends
+    TEST_list_missing_erasure_coded_overwrites)
+add_ceph_test(osd-scrub-repair.sh-lrc
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_corrupt_and_repair_lrc_appends
+    TEST_corrupt_and_repair_lrc_overwrites)
+add_ceph_test(osd-scrub-repair.sh-periodic-scrub
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_periodic_scrub_replicated)
+add_ceph_test(osd-scrub-repair.sh-replicated
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_corrupt_and_repair_replicated)
+add_ceph_test(osd-scrub-repair.sh-unfound-erasure
+    ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-repair.sh
+    TEST_unfound_erasure_coded_appends
+    TEST_unfound_erasure_coded_overwrites)
+
 add_ceph_test(osd-scrub-snaps.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-scrub-snaps.sh)
 add_ceph_test(osd-copy-from.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-copy-from.sh)
 add_ceph_test(osd-fast-mark-down.sh ${CMAKE_CURRENT_SOURCE_DIR}/osd-fast-mark-down.sh)

--- a/src/test/osd/osd-scrub-repair-auto-repair.sh
+++ b/src/test/osd/osd-scrub-repair-auto-repair.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_auto_repair_erasure_coded_appends \
+    TEST_auto_repair_erasure_coded_overwrites

--- a/src/test/osd/osd-scrub-repair-corrupt-scrub.sh
+++ b/src/test/osd/osd-scrub-repair-corrupt-scrub.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_corrupt_scrub_erasure_appends \
+    TEST_corrupt_scrub_erasure_overwrites \
+    TEST_corrupt_scrub_replicated

--- a/src/test/osd/osd-scrub-repair-jerasure.sh
+++ b/src/test/osd/osd-scrub-repair-jerasure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_corrupt_and_repair_jerasure_appends \
+    TEST_corrupt_and_repair_jerasure_overwrites

--- a/src/test/osd/osd-scrub-repair-list-missing.sh
+++ b/src/test/osd/osd-scrub-repair-list-missing.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_list_missing_erasure_coded_appends \
+    TEST_list_missing_erasure_coded_overwrites

--- a/src/test/osd/osd-scrub-repair-lrc.sh
+++ b/src/test/osd/osd-scrub-repair-lrc.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_corrupt_and_repair_lrc_appends \
+    TEST_corrupt_and_repair_lrc_overwrites

--- a/src/test/osd/osd-scrub-repair-periodic-scrub.sh
+++ b/src/test/osd/osd-scrub-repair-periodic-scrub.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_periodic_scrub_replicated

--- a/src/test/osd/osd-scrub-repair-replicated.sh
+++ b/src/test/osd/osd-scrub-repair-replicated.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_corrupt_and_repair_replicated

--- a/src/test/osd/osd-scrub-repair-unfound-erasure.sh
+++ b/src/test/osd/osd-scrub-repair-unfound-erasure.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+source $(dirname $0)/../detect-build-env-vars.sh
+source $CEPH_ROOT/qa/workunits/ceph-helpers.sh
+$CEPH_ROOT/src/test/osd/osd-scrub-repair.sh \
+    TEST_unfound_erasure_coded_appends \
+    TEST_unfound_erasure_coded_overwrites


### PR DESCRIPTION
It's better to have more smaller jobs than one large one, the shorter
ones can be run concurrently and are therefor faster

Signed-off-by: Caleb Boylan calebboylan@gmail.com