### PR TITLE
vstart.sh: Work around mgr restfull not available

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -649,11 +649,14 @@ EOF
         run 'mgr' $CEPH_BIN/ceph-mgr -i $name $ARGS
     done
 
-    SF=`mktemp`
-    ceph_adm tell mgr restful create-self-signed-cert
-    ceph_adm tell mgr restful create-key admin -o $SF
-    RESTFUL_SECRET=`cat $SF`
-    rm $SF
+    if ceph_adm tell mgr restful create-self-signed-cert; then
+        SF=`mktemp`
+        ceph_adm tell mgr restful create-key admin -o $SF
+        RESTFUL_SECRET=`cat $SF`
+        rm $SF
+    else 
+        echo MGR Restful is not working, perhaps the package is not installed?
+    fi
 }
 
 start_mds() {


### PR DESCRIPTION
- Since the only effect is writting a CERT to the stdout, it might
   suffice to just make this result optional and not err-out on this
   in vstart.
   Tests that are using this functionality/cert should perhaPs generate
   it themselves.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>