### PR TITLE
common: Update the error string when res_nsearch() or res_search() fails 

### DIFF
--- a/src/common/dns_resolve.cc
+++ b/src/common/dns_resolve.cc
@@ -299,7 +299,7 @@ int DNSResolver::resolve_srv_hosts(CephContext *cct, const string& service_name,
   }
 #endif
   if (len < 0) {
-    lderr(cct) << "res_search() failed" << dendl;
+    lderr(cct) << "failed for service " << query_str << dendl;
     return len;
   }
   else if (len == 0) {


### PR DESCRIPTION
I don't know the abort information about DNS Resolver,
if not add "query_str". 

> 2017-06-21 15:06:49.890097 7f56a7c20fc0  0 set uid:gid to 167:167 (ceph:ceph)
2017-06-21 15:06:49.890115 7f56a7c20fc0  0 ceph version 12.0.2.10-2-gd5e04f6 (d5e04f6afed7838703aea490ab7e68399abb4d25), process ceph-mgr, pid 47787
2017-06-21 15:06:49.890128 7f56a7c20fc0  0 pidfile_write: ignore empty --pid-file
2017-06-21 15:06:49.893929 7f56a7c20fc0 **-1 res_search() failed**


Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>