### PR TITLE
rgw: nullptr returns in rgw_conf_get()

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -513,7 +513,7 @@ bool parse_rfc2616(const char *s, struct tm *t)
 bool parse_iso8601(const char *s, struct tm *t, uint32_t *pns, bool extended_format)
 {
   memset(t, 0, sizeof(*t));
-  const char *p;
+  const char *p = nullptr;
 
   if (!s)
     s = "";


### PR DESCRIPTION
Fixes the following Coverity Scan Report:
```
CID 1412777 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)11. var_deref_model: Passing
null pointer d to basic_string_view, which dereferences it.
8.identity_transfer: Passing NULL as argument 2 to member function get, which returns that argument.
9.alias_transfer: Assigning: d = info.env->get("HTTP_X_AMZ_DATE", NULL).
```

There are several places in rgw_auth_s3.cc where the RGWEnv::get() is called with only one argument. So
fixed the issue in rgw_conf_get().

Signed-off-by: Jos Collin <jcollin@redhat.com>