### PR TITLE
common: Passing null pointer option_name to operator << in md_config_t::parse_option()

### DIFF
--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -603,6 +603,7 @@ int md_config_t::parse_option(std::vector<const char*>& args,
   }
 
   if (ret != 0 || !error_message.empty()) {
+    assert(option_name);
     if (oss) {
       *oss << "Parse error setting " << option_name << " to '"
            << val << "' using injectargs";


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
CID 1412776 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)19. var_deref_model: Passing null pointer option_name to operator <<, which dereferences it.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>