### PR TITLE
rgw: omit X-Account-Access-Control if there is no grant to serialize.

### DIFF
--- a/src/rgw/rgw_acl_swift.cc
+++ b/src/rgw/rgw_acl_swift.cc
@@ -371,7 +371,7 @@ bool RGWAccessControlPolicy_SWIFTAcct::create(RGWRados * const store,
   return true;
 }
 
-void RGWAccessControlPolicy_SWIFTAcct::to_str(std::string& acl_str) const
+boost::optional<std::string> RGWAccessControlPolicy_SWIFTAcct::to_str() const
 {
   std::vector<std::string> admin;
   std::vector<std::string> readwrite;
@@ -403,6 +403,12 @@ void RGWAccessControlPolicy_SWIFTAcct::to_str(std::string& acl_str) const
     }
   }
 
+  /* If there is no grant to serialize, let's exit earlier to not return
+   * an empty JSON object which brakes the functional tests of Swift. */
+  if (admin.empty() && readwrite.empty() && readonly.empty()) {
+    return boost::none;
+  }
+
   /* Serialize the groups. */
   JSONFormatter formatter;
 
@@ -421,5 +427,5 @@ void RGWAccessControlPolicy_SWIFTAcct::to_str(std::string& acl_str) const
   std::ostringstream oss;
   formatter.flush(oss);
 
-  acl_str = oss.str();
+  return oss.str();
 }

--- a/src/rgw/rgw_acl_swift.h
+++ b/src/rgw/rgw_acl_swift.h
@@ -9,6 +9,8 @@
 #include <string>
 #include <include/types.h>
 
+#include <boost/optional.hpp>
+
 #include "rgw_acl.h"
 
 class RGWAccessControlPolicy_SWIFT : public RGWAccessControlPolicy
@@ -48,6 +50,6 @@ public:
               const rgw_user& id,
               const std::string& name,
               const std::string& acl_str);
-  void to_str(std::string& acl) const;
+  boost::optional<std::string> to_str() const;
 };
 #endif

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -130,10 +130,9 @@ static void dump_account_metadata(struct req_state * const s,
   }
 
   /* Dump account ACLs */
-  string acct_acl;
-  policy.to_str(acct_acl);
-  if (acct_acl.size()) {
-    dump_header(s, "X-Account-Access-Control", std::move(acct_acl));
+  auto account_acls = policy.to_str();
+  if (account_acls) {
+    dump_header(s, "X-Account-Access-Control", std::move(*account_acls));
   }
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20395
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>