### PR TITLE
rgw: initialize non-static class members in ESQueryCompiler

### DIFF
--- a/src/rgw/rgw_es_query.h
+++ b/src/rgw/rgw_es_query.h
@@ -102,8 +102,8 @@ class ESQueryCompiler {
   ESEntityTypeMap *generic_type_map{nullptr};
   ESEntityTypeMap *custom_type_map{nullptr};
 
-  map<string, string, ltstr_nocase> *field_aliases;
-  set<string> *restricted_fields;
+  map<string, string, ltstr_nocase> *field_aliases = nullptr;
+  set<string> *restricted_fields = nullptr;
 
 public:
   ESQueryCompiler(const string& query, list<pair<string, string> > *prepend_eq_conds, const string& _custom_prefix) : parser(query), custom_prefix(_custom_prefix) {


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
CID 1412617 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
3. uninit_member: Non-static class member field_aliases is not initialized in this constructor nor in any functions that it calls.
5. uninit_member: Non-static class member restricted_fields is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>