### PR TITLE
rgw: initialize Non-static class member worker in RGWReshard

### DIFF
--- a/src/rgw/rgw_reshard.cc
+++ b/src/rgw/rgw_reshard.cc
@@ -885,7 +885,7 @@ void RGWReshard::stop_processor()
     worker->join();
   }
   delete worker;
-  worker = NULL;
+  worker = nullptr;
 }
 
 void *RGWReshard::ReshardWorker::entry() {

--- a/src/rgw/rgw_reshard.h
+++ b/src/rgw/rgw_reshard.h
@@ -78,7 +78,7 @@ protected:
     void stop();
   };
 
-  ReshardWorker *worker;
+  ReshardWorker *worker = nullptr;
   std::atomic<bool> down_flag = { false };
 
   string get_logshard_key(const string& tenant, const string& bucket_name);


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
CID 1412616 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member worker is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>