### PR TITLE
rgw: initialize Non-static class member val in ESQueryNodeLeafVal_Int

### DIFF
--- a/src/rgw/rgw_es_query.cc
+++ b/src/rgw/rgw_es_query.cc
@@ -184,7 +184,7 @@ public:
 };
 
 class ESQueryNodeLeafVal_Int : public ESQueryNodeLeafVal {
-  int64_t val;
+  int64_t val{0};
 public:
   ESQueryNodeLeafVal_Int() {}
   bool init(const string& str_val, string *perr) override {


### PR DESCRIPTION
Fixed the Coverity Scan Report:
```
CID 1412615 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member val is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>