### PR TITLE
tools/rbd_mirror: initialize non-static class member m_do_resync in ImageReplayer

### DIFF
--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -300,7 +300,7 @@ private:
   int m_last_r = 0;
   std::string m_state_desc;
   BootstrapProgressContext m_progress_cxt;
-  bool m_do_resync;
+  bool m_do_resync{false};
   image_replayer::EventPreprocessor<ImageCtxT> *m_event_preprocessor = nullptr;
   image_replayer::ReplayStatusFormatter<ImageCtxT> *m_replay_status_formatter =
     nullptr;


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
CID 1412614 (#2-1 of 2): Uninitialized scalar field (UNINIT_CTOR)
7. uninit_member: Non-static class member m_do_resync is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>