### PR TITLE
qa: do not restrict valgrind runs to centos

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -5,7 +5,6 @@ overrides:
     log-whitelist:
       - slow requests are blocked
 
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rbd/valgrind/validator/memcheck.yaml
+++ b/qa/suites/rbd/valgrind/validator/memcheck.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:

--- a/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/qa/suites/rgw/verify/tasks/rgw_swift.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_swift.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 tasks:
 - install:
     flavor: notcmalloc

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -1,4 +1,3 @@
-os_type: centos   # xenial valgrind buggy, see http://tracker.ceph.com/issues/18126
 overrides:
   install:
     ceph:


### PR DESCRIPTION
This reverts 693bd238510e69569cc3461f84b04c8667bc11da, which was
added in response to http://tracker.ceph.com/issues/18126. But
we updated the Ubuntu packages in sepia so it should be good to go.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>