### PR TITLE
isa-l: update isa-l to v2.18

### DIFF
--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -4,21 +4,31 @@ if(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 	set(zlib_sources
 	  CompressionPluginZlib.cc
 	  ZlibCompressor.cc
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc32_gzip.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc32_gzip_base.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/detect_repeated_char.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/encode_df.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/encode_df_04.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/flatten_ll.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/huff_codes.c
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/hufftables_c.c
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc_utils_01.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc_utils_04.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_base.c
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_body_01.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_body_02.asm
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_body_04.asm
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_finish.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_stateless_01.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_stateless_04.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc_data.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/crc32_gzip.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/detect_repeated_char.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_base.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_body_01.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_body_02.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_body_04.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_icf_finish.asm
 	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_multibinary.asm
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_stateless_base.c
-	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_base.c
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_update_histogram_01.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/igzip_update_histogram_04.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/proc_heap.asm
+	  ${CMAKE_SOURCE_DIR}/src/isa-l/igzip/rfc1951_lookup.asm
 	)
 else(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 	set(zlib_sources

--- a/src/erasure-code/isa/CMakeLists.txt
+++ b/src/erasure-code/isa/CMakeLists.txt
@@ -64,7 +64,7 @@ add_library(ec_isa SHARED
 add_dependencies(ec_isa ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_isa ${EXTRALIBS})
 set_target_properties(ec_isa PROPERTIES
-  VERSION 2.16.0
+  VERSION 2.18.0
   SOVERSION 2
   INSTALL_RPATH "")
 install(TARGETS ec_isa DESTINATION ${erasure_plugin_dir})


### PR DESCRIPTION
This upgrade brings
-  Complete rewrite of DEFLATE optimizations resulting in 5X better
   throughput and compression ratios comapred to  zlib, lz4, lzo and 2X
   better decompression performance when compared to zlib.
-  AVX512 improvements to multi-buffer versions of MD5, SHA-1 and SHA-256
   cryptographic hashing functions resulting in 3X better in performance
   compared to the AVX2 generation.

This update has the potential to improve bluestore compression
and dedup performance.

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>
Signed-off-by: Tushar Gohad <tushar.gohad@intel.com>