### PR TITLE
mgr: drop repeated log info. and unnecessary write permission

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -176,7 +176,7 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
     if (peer_type == CEPH_ENTITY_TYPE_OSD) {
       Mutex::Locker l(lock);
       s->osd_id = atoi(s->entity_name.get_id().c_str());
-      dout(10) << __func__ << " registering osd." << s->osd_id << " session "
+      dout(10) << "registering osd." << s->osd_id << " session "
 	       << s << " con " << con << dendl;
       osd_cons[s->osd_id].insert(con);
     }
@@ -214,7 +214,7 @@ bool DaemonServer::ms_handle_reset(Connection *con)
     }
     session->put(); // SessionRef takes a ref
     Mutex::Locker l(lock);
-    dout(10) << __func__ << " unregistering osd." << session->osd_id
+    dout(10) << "unregistering osd." << session->osd_id
 	     << "  session " << session << " con " << con << dendl;
     osd_cons[session->osd_id].erase(con);
   }
@@ -250,10 +250,10 @@ bool DaemonServer::ms_dispatch(Message *m)
 
 void DaemonServer::shutdown()
 {
-  dout(10) << __func__ << dendl;
+  dout(10) << "begin" << dendl;
   msgr->shutdown();
   msgr->wait();
-  dout(10) << __func__ << " done" << dendl;
+  dout(10) << "done" << dendl;
 }
 
 

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -24,6 +24,7 @@
 #include "messages/MCommandReply.h"
 #include "messages/MPGStats.h"
 #include "messages/MOSDScrub.h"
+#include "common/errno.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
@@ -451,7 +452,7 @@ bool DaemonServer::handle_command(MCommand *m)
         con->mark_disposable();
       }
 
-      dout(1) << "do_command r=" << r << " " << rs << dendl;
+      dout(1) << "handle_command " << cpp_strerror(r) << " " << rs << dendl;
       if (con) {
         MCommandReply *reply = new MCommandReply(r, rs);
         reply->set_tid(m->get_tid());

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -942,6 +942,6 @@ COMMAND("config-key dump", "dump keys and values", "config-key", "r", "cli,rest"
 COMMAND("mgr dump "				     \
 	"name=epoch,type=CephInt,range=0,req=false", \
 	"dump the latest MgrMap",		     \
-	"mgr", "rw", "cli,rest")
+	"mgr", "r", "cli,rest")
 COMMAND("mgr fail name=who,type=CephString", \
 	"treat the named manager daemon as failed", "mgr", "rw", "cli,rest")


### PR DESCRIPTION
In the front of this file, `__func__` has been added to dout_prefix as below:
` #define dout_prefix *_dout << "mgr.server " << __func__ << " "`