### PR TITLE
build/ops: rpm: sane packaging of %{_docdir}/ceph directory

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1027,8 +1027,7 @@ if [ $FIRST_ARG -ge 1 ] ; then
 fi
 
 %files common
-%docdir %{_docdir}
-%docdir %{_docdir}/ceph
+%dir %{_docdir}/ceph
 %doc %{_docdir}/ceph/sample.ceph.conf
 %doc %{_docdir}/ceph/COPYING
 %{_bindir}/ceph


### PR DESCRIPTION
Sane packaging of documentation directory `%_docdir/ceph`