### PR TITLE
test: Division by zero in Legacy::encode_n()

### DIFF
--- a/src/test/test_denc.cc
+++ b/src/test/test_denc.cc
@@ -613,6 +613,7 @@ bufferlist Legacy::encode_n(unsigned n, const vector<unsigned>& segments) {
   auto p = bl.begin();
 
   auto sum = std::accumulate(segments.begin(), segments.end(), 0u);
+  assert(sum != 0u);
   for (auto i : segments) {
     buffer::ptr seg;
     p.copy_deep(bl.length() * i / sum, seg);


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
CID 1411820 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
9. divide_by_zero: In expression bl.length() * i / sum, division by expression sum which may be zero has undefined behavior.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>