### PR TITLE
jewel: tests: upgrade:hammer-x/stress-split-erasure-code-x86_64 fails in 10.2.8 integration testing

### DIFF
--- a/qa/suites/upgrade/hammer-x/stress-split/1-hammer-install/hammer.yaml
+++ b/qa/suites/upgrade/hammer-x/stress-split/1-hammer-install/hammer.yaml
@@ -1,6 +1,8 @@
 tasks:
 - install:
     branch: hammer
+    exclude_packages: [ 'libcephfs-java', 'libcephfs-jni' ]
+    extra_packages: [ 'libradosstriper1', 'python-rados', 'python-cephfs', 'python-rbd' ]
 - print: "**** done install hammer"
 - ceph:
     fs: xfs


### PR DESCRIPTION
http://tracker.ceph.com/issues/20413