### PR TITLE
rgw: Fix duplicate tag removal during GC

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -222,6 +222,10 @@ int RGWGC::process(int index, int max_secs)
         }
       }
     }
+    if (!remove_tags.empty()) {
+      RGWGC::remove(index, remove_tags);
+      remove_tags.clear();
+    }
   } while (truncated);
 
 done:


### PR DESCRIPTION
We need to remove all processed tags before we fetch a new batch of tags
for removal, otherwise some tags might get processed twice.

Fixes: http://tracker.ceph.com/issues/20107

Signed-off-by: Jens Rosenboom <j.rosenboom@x-ion.de>