### PR TITLE
src/OSD: add more useful perf counters for performance tuning.

### DIFF
--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -94,6 +94,7 @@ enum {
   l_filestore_bytes,
   l_filestore_apply_latency,
   l_filestore_queue_transaction_latency_avg,
+  l_filestore_sync_pause_max_lat,
   l_filestore_last,
 };
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -90,6 +90,9 @@ enum {
   l_osd_op_rw_process_lat,
   l_osd_op_rw_prepare_lat,
 
+  l_osd_op_before_queue_op_lat,
+  l_osd_op_before_dequeue_op_lat,
+
   l_osd_sop,
   l_osd_sop_inb,
   l_osd_sop_lat,


### PR DESCRIPTION
1) add perf counters for the latency before enqueue_op and dequeue_op
2) add max latency to tune the latency of op_wq.pause. If this max latency is too long, it may cause osd_op_tp thread timeout, and OSD unhealthy.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>