### PR TITLE
tools/rados: support regular expression in rados ls command to filter

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -106,8 +106,8 @@ Pool specific commands
 :command:`listwatchers` *name*
   List the watchers of object name.
 
-:command:`ls` *outfile*
-  List objects in given pool and write to outfile.
+:command:`ls` *outfile* [ --regex *pattern* ]
+  List objects in given pool and write to outfile. Only the matched objects are listed if --regex option is specified.
 
 :command:`lssnap`
   List snapshots for given pool.

--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -381,6 +381,11 @@ test_ls() {
     then
         die "Created $OBJS objects in default namespace but saw $CHECK"
     fi
+    CHECK=$("$RADOS_TOOL" -p $p ls --regex "obj1.*" 2> /dev/null | wc -l)
+    if [ "$CHECK" -ne 11 ];
+    then
+        die "Created 11 objects with the name matached 'obj1.*' in default namespace but saw $CHECK"
+    fi
     TESTNS=NS${NS}
     CHECK=$("$RADOS_TOOL" -p $p -N $TESTNS ls 2> /dev/null | wc -l)
     if [ "$OBJS" -ne "$CHECK" ];

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -17,6 +17,7 @@
 
 #include "boost/tuple/tuple.hpp"
 #include "boost/intrusive_ptr.hpp"
+#include "boost/regex.hpp"
 #include "PG.h"
 #include "PrimaryLogPG.h"
 #include "OSD.h"
@@ -727,6 +728,30 @@ void PrimaryLogPG::maybe_force_recovery()
     maybe_kick_recovery(soid);
 }
 
+class PGLSNameFilter : public PGLSFilter {
+  boost::regex regex;
+public:
+  int init(bufferlist::iterator &params) override
+  {
+    try {
+      string reg_exp ;
+      ::decode(reg_exp, params);
+      if (reg_exp.empty()) {
+        return -EINVAL;
+      } else {
+        regex.assign(reg_exp, boost::regex_constants::no_except);
+      }
+    } catch (buffer::error &e) {
+      return -EINVAL;
+    }
+    return 0;
+  }
+  bool filter(const hobject_t &obj, bufferlist& indata,
+              bufferlist& outdata) override {
+    return boost::regex_match(obj.oid.name, regex);    
+  }
+};
+
 class PGLSPlainFilter : public PGLSFilter {
   string val;
 public:
@@ -840,6 +865,8 @@ int PrimaryLogPG::get_pgls_filter(bufferlist::iterator& iter, PGLSFilter **pfilt
     filter = new PGLSParentFilter(cct);
   } else if (type.compare("plain") == 0) {
     filter = new PGLSPlainFilter();
+  } else if (type.compare("name") == 0) {
+    filter = new PGLSNameFilter(); 
   } else {
     std::size_t dot = type.find(".");
     if (dot == std::string::npos || dot == 0 || dot == type.size() - 1) {


### PR DESCRIPTION
object name.

There will be millions of objects in the backend, and rados ls will be very time consuming, and waste throughput when hight network pressure. The customers ask to provide a method to filter objects by name. 

![image](https://user-images.githubusercontent.com/17977187/27539460-3ee7ac9e-5aaf-11e7-9c9c-3f0f2cadf44b.png)
When use regular expression:
![image](https://user-images.githubusercontent.com/17977187/27539478-4ee83672-5aaf-11e7-99bd-16d95c91b619.png)

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>