### PR TITLE
test/osd: Non-static class members not initialized in UnsetRedirectOp

### DIFF
--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2113,8 +2113,7 @@ class UnsetRedirectOp : public TestOp {
 public:
   string oid;
   librados::ObjectWriteOperation op;
-  librados::AioCompletion *completion;
-  librados::AioCompletion *comp;
+  librados::AioCompletion *comp = nullptr;
 
   UnsetRedirectOp(int n,
 	   RadosTestContext *context,


### PR DESCRIPTION
Fixes the coverity scan report:
```
CID 1411830: Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member completion is not initialized in this constructor nor in any functions that it calls.
4. uninit_member: Non-static class member comp is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>