### PR TITLE
test/osd: initialize Non-static class members in WeightedTestGenerator

### DIFF
--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -338,8 +338,8 @@ private:
   bool m_ec_pool;
   bool m_balance_reads;
   bool m_set_redirect;
-  int m_redirect_objects;
-  int m_initial_redirected_objects; 
+  int m_redirect_objects{0};
+  int m_initial_redirected_objects{0}; 
 };
 
 int main(int argc, char **argv)


### PR DESCRIPTION
Fixes the coverity scan report:
```
CID 1411829: Uninitialized scalar field (UNINIT_CTOR)
8. uninit_member: Non-static class member m_redirect_objects is not initialized in this constructor nor in any functions that it calls.
10. uninit_member: Non-static class member m_initial_redirected_objects is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>