### PR TITLE
qa/suites/rbd: restrict python memcheck validation to CentOS

### DIFF
--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,3 +1,5 @@
+os_type: centos
+os_version: "7.3"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,3 +1,5 @@
+os_type: centos
+os_version: "7.3"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,3 +1,5 @@
+os_type: centos
+os_version: "7.3"
 tasks:
 - workunit:
     clients:


### PR DESCRIPTION
The Ubuntu Xenial python implementation throws numerious (false) errors
deep within python. Since we are only interested in errors within our
rbd wrapper, restrict the environment.

Signed-off-by: Jason Dillaman <dillaman@redhat.com>