### PR TITLE
librados: add log channel to rados_monitor_log2 callback

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3677,6 +3677,7 @@ typedef void (*rados_log_callback_t)(void *arg,
  */
 typedef void (*rados_log_callback2_t)(void *arg,
 				     const char *line,
+				     const char *channel,
 				     const char *who,
 				     const char *name,
 				     uint64_t sec, uint64_t nsec,

--- a/src/librados/RadosClient.cc
+++ b/src/librados/RadosClient.cc
@@ -1001,7 +1001,9 @@ void librados::RadosClient::handle_log(MLog *m)
 		 stamp.tv_sec, stamp.tv_nsec,
 		 e.seq, level.c_str(), e.msg.c_str());
 	if (log_cb2)
-	  log_cb2(log_cb_arg, line.c_str(), who.c_str(), name.c_str(),
+	  log_cb2(log_cb_arg, line.c_str(),
+		  e.channel.c_str(),
+		  who.c_str(), name.c_str(),
 		  stamp.tv_sec, stamp.tv_nsec,
 		  e.seq, level.c_str(), e.msg.c_str());
       }

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -98,7 +98,7 @@ cdef extern from "rados/librados.h" nogil:
     ctypedef void (*rados_callback_t)(rados_completion_t cb, void *arg)
     ctypedef void (*rados_log_callback_t)(void *arg, const char *line, const char *who,
                                           uint64_t sec, uint64_t nsec, uint64_t seq, const char *level, const char *msg)
-    ctypedef void (*rados_log_callback2_t)(void *arg, const char *line, const char *who, const char *name,
+    ctypedef void (*rados_log_callback2_t)(void *arg, const char *line, const char *channel, const char *who, const char *name,
                                           uint64_t sec, uint64_t nsec, uint64_t seq, const char *level, const char *msg)
 
 
@@ -558,12 +558,13 @@ cdef int __monitor_callback(void *arg, const char *line, const char *who,
     cb_info[0](cb_info[1], line, who, sec, nsec, seq, level, msg)
     return 0
 
-cdef int __monitor_callback2(void *arg, const char *line, const char *who,
+cdef int __monitor_callback2(void *arg, const char *line, const char *channel,
+                             const char *who,
                              const char *name,
                              uint64_t sec, uint64_t nsec, uint64_t seq,
                              const char *level, const char *msg) with gil:
     cdef object cb_info = <object>arg
-    cb_info[0](cb_info[1], line, name, who, sec, nsec, seq, level, msg)
+    cb_info[0](cb_info[1], line, channel, name, who, sec, nsec, seq, level, msg)
     return 0
 
 


### PR DESCRIPTION
log2 was just added and not yet released, so we can freely add this field.

Signed-off-by: Sage Weil <sage@redhat.com>