### PR TITLE
jewel: tests: drop upgrade/hammer-jewel-x

### DIFF
--- a/qa/suites/upgrade/hammer-jewel-x/parallel/distros/centos.yaml
+++ b/qa/suites/upgrade/hammer-jewel-x/parallel/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/hammer-jewel-x/stress-split/distros/centos.yaml
+++ b/qa/suites/upgrade/hammer-jewel-x/stress-split/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../distros/all/centos.yaml


### PR DESCRIPTION
This suite doesn't have any test logic in it. Its existence in the jewel branch
appears to be an oversight.

This cannot be cherry-picked from master because the upgrade/hammer-jewel-x
suite is present (and justified) in master and is not currently being dropped
there.

Signed-off-by: Nathan Cutler <ncutler@suse.com>