### PR TITLE
ceph-conf: fix typo in usage: 'mon add' should be 'mon addr'

### DIFF
--- a/src/test/cli/ceph-conf/help.t
+++ b/src/test/cli/ceph-conf/help.t
@@ -26,7 +26,7 @@
   
   EXAMPLES
   [$] ceph-conf --name mon.0 -c /etc/ceph/ceph.conf 'mon addr' (re)
-  Find out what the value of 'mon add' is for monitor 0.
+  Find out what the value of 'mon addr' is for monitor 0.
   
   [$] ceph-conf -l mon (re)
   List sections beginning with 'mon'.

--- a/src/tools/ceph_conf.cc
+++ b/src/tools/ceph_conf.cc
@@ -51,7 +51,7 @@ If there is no action given, the action will default to --lookup.\n\
 \n\
 EXAMPLES\n\
 $ ceph-conf --name mon.0 -c /etc/ceph/ceph.conf 'mon addr'\n\
-Find out what the value of 'mon add' is for monitor 0.\n\
+Find out what the value of 'mon addr' is for monitor 0.\n\
 \n\
 $ ceph-conf -l mon\n\
 List sections beginning with 'mon'.\n\


### PR DESCRIPTION
src/test/cli/ceph-conf/help.t
src/tools/ceph_conf.cc

fix add to addr

Signed-off-by: Peng Zhang zphj1987@gmail.com