### PR TITLE
qa: remove unused quota config option

### DIFF
--- a/qa/suites/fs/basic_functional/tasks/cfuse_workunit_quota.yaml
+++ b/qa/suites/fs/basic_functional/tasks/cfuse_workunit_quota.yaml
@@ -4,9 +4,3 @@ tasks:
     clients:
       all:
         - fs/quota
-
-overrides:
-  ceph:
-    conf:
-      client:
-        client quota: true


### PR DESCRIPTION
Quotas are no longer configurable on-off since
0f250a889dba2100d3afcea0a18e4f6a8d086b86.

Related to: http://tracker.ceph.com/issues/20412

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>