### PR TITLE
build/ops: rpm: put mgr python build dependencies in make_check bcond

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -112,6 +112,7 @@ BuildRequires:	python-CherryPy
 BuildRequires:	python-Werkzeug
 %endif
 BuildRequires:	python-pecan
+BuildRequires:	socat
 %endif
 BuildRequires:	bc
 BuildRequires:	gperf
@@ -140,7 +141,6 @@ BuildRequires:	python-devel
 BuildRequires:	python-nose
 BuildRequires:	python-requests
 BuildRequires:	python-virtualenv
-BuildRequires:	socat
 BuildRequires:	snappy-devel
 BuildRequires:	udev
 BuildRequires:	util-linux

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -102,6 +102,17 @@ BuildRequires:	checkpolicy
 BuildRequires:	selinux-policy-devel
 BuildRequires:	/usr/share/selinux/devel/policyhelp
 %endif
+%if 0%{with make_check}
+%if 0%{?fedora} || 0%{?rhel}
+BuildRequires:	python-cherrypy
+BuildRequires:	python-werkzeug
+%endif
+%if 0%{?suse_version}
+BuildRequires:	python-CherryPy
+BuildRequires:	python-Werkzeug
+%endif
+BuildRequires:	python-pecan
+%endif
 BuildRequires:	bc
 BuildRequires:	gperf
 BuildRequires:  cmake
@@ -127,10 +138,8 @@ BuildRequires:	pkgconfig
 BuildRequires:	python
 BuildRequires:	python-devel
 BuildRequires:	python-nose
-BuildRequires:	python-pecan
 BuildRequires:	python-requests
 BuildRequires:	python-virtualenv
-BuildRequires:	python-werkzeug
 BuildRequires:	socat
 BuildRequires:	snappy-devel
 BuildRequires:	udev
@@ -159,7 +168,6 @@ BuildRequires:	keyutils-devel
 BuildRequires:  libopenssl-devel
 BuildRequires:  lsb-release
 BuildRequires:  openldap2-devel
-BuildRequires:	python-CherryPy
 BuildRequires:	python-Cython
 BuildRequires:	python-PrettyTable
 BuildRequires:	python-Sphinx
@@ -176,7 +184,6 @@ BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
-BuildRequires:	python-cherrypy
 BuildRequires:	python-prettytable
 BuildRequires:	python-sphinx
 %endif

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -19,6 +19,11 @@ if test $(id -u) != 0 ; then
 fi
 export LC_ALL=C # the following is vulnerable to i18n
 
+function munge_ceph_spec_in {
+    local OUTFILE=$1
+    sed -e 's/@//g' -e 's/%bcond_with make_check/%bcond_without make_check/g' < ceph.spec.in > $OUTFILE
+}
+
 if [ x`uname`x = xFreeBSDx ]; then
     $SUDO pkg install -yq \
         devel/git \
@@ -129,14 +134,14 @@ else
                 fi
                 ;;
         esac
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+        munge_ceph_spec_in $DIR/ceph.spec
         $SUDO $builddepcmd $DIR/ceph.spec 2>&1 | tee $DIR/yum-builddep.out
         ! grep -q -i error: $DIR/yum-builddep.out || exit 1
         ;;
     opensuse|suse|sles)
         echo "Using zypper to install dependencies"
         $SUDO zypper --gpg-auto-import-keys --non-interactive install lsb-release systemd-rpm-macros
-        sed -e 's/@//g' < ceph.spec.in > $DIR/ceph.spec
+        munge_ceph_spec_in $DIR/ceph.spec
         $SUDO zypper --non-interactive install $(rpmspec -q --buildrequires $DIR/ceph.spec) || exit 1
         ;;
     alpine)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20425

Quoting from the tracker:

> Some dependencies - notably the mgr dependencies "python-cherrypy", "python-pecan" and "python-werkzeug" - are only needed to run "make check". Since these dependencies bring in a pretty long list of packages (dependencies of dependencies of dependencies. . .) it would make sense to put them inside the "make_check" bcond so RPM builds that do not run "make check" (the default) would not pull in all these python modules that are not used.
> 
> There is one wrinkle, though: the bcond is "off" by default, so install-deps.sh will need to activate it before parsing the spec file for dependencies, otherwise "run-make-check.sh" will fail due to missing dependencies.

Note that this is RPM-only (at least for now) since the "make_check" bcond itself if RPM-only.