### PR TITLE
osd: dump the field name of object watchers  and cleanups

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2110,8 +2110,8 @@ bool OSD::asok_command(string admin_command, cmdmap_t& cmdmap, string format,
       it->wi.name.dump(f);
       f->close_section(); //entity_name_t
 
-      f->dump_int("cookie", it->wi.cookie);
-      f->dump_int("timeout", it->wi.timeout_seconds);
+      f->dump_unsigned("cookie", it->wi.cookie);
+      f->dump_unsigned("timeout", it->wi.timeout_seconds);
 
       f->open_object_section("entity_addr_t");
       it->wi.addr.dump(f);

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2101,7 +2101,7 @@ bool OSD::asok_command(string admin_command, cmdmap_t& cmdmap, string format,
     for (list<obj_watch_item_t>::iterator it = watchers.begin();
 	it != watchers.end(); ++it) {
 
-      f->open_array_section("watch");
+      f->open_object_section("watch");
 
       f->dump_string("namespace", it->obj.nspace);
       f->dump_string("object", it->obj.oid.name);


### PR DESCRIPTION
field name will not dump in  array section, command `ceph daemon osd.x dump_watchers` print out as following:
```
[
    [
        "",
        "rbd_header.10392ae8944a",
        {
            "type": "client",
            "num": 534114
        },
        140292086877568,
        30,
        {
            "nonce": 532829443,
            "addr": "127.0.0.1:0"
        }
    ]
]
```
so we open object section to dump the field name:
```
[
    {
        "namespace": "",
        "object": "rbd_header.10392ae8944a",
        "entity_name": {
            "type": "client",
            "num": 654126
        },
        "cookie": 140344431791488,
        "timeout": 30,
        "entity_addr_t": {
            "nonce": 2116290762,
            "addr": "127.0.0.1:0"
        }
    }
]
```