### PR TITLE
jewel: osd: unlock sdata_op_ordering_lock with sdata_lock hold to avoid missing wakeup signal

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8727,9 +8727,9 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb ) 
   assert(NULL != sdata);
   sdata->sdata_op_ordering_lock.Lock();
   if (sdata->pqueue->empty()) {
-    sdata->sdata_op_ordering_lock.Unlock();
     osd->cct->get_heartbeat_map()->reset_timeout(hb, 4, 0);
     sdata->sdata_lock.Lock();
+    sdata->sdata_op_ordering_lock.Unlock();
     sdata->sdata_cond.WaitInterval(osd->cct, sdata->sdata_lock, utime_t(2, 0));
     sdata->sdata_lock.Unlock();
     sdata->sdata_op_ordering_lock.Lock();


### PR DESCRIPTION
http://tracker.ceph.com/issues/20428