### PR TITLE
rgw: silence warning from -Wmisleading-indentation

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -774,8 +774,9 @@ int RGWDeleteObjTags::verify_permission(){
 }
 
 void RGWDeleteObjTags::execute() {
-  if (s->object.empty())
+  if (s->object.empty()) {
     return;
+  }
 
     rgw_obj obj;
     obj = rgw_obj(s->bucket, s->object);


### PR DESCRIPTION
The following warning appears during build:
```
ceph/src/rgw/rgw_op.cc: In member function ‘virtual void RGWDeleteObjTags::execute()’:
ceph/src/rgw/rgw_op.cc:777:3: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
   if (s->object.empty())
ceph/src/rgw/rgw_op.cc:780:5: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
     rgw_obj obj;
```
Signed-off-by: Jos Collin <jcollin@redhat.com>