### PR TITLE
osd: Execute crush_location_hook when configured in ceph.conf

### DIFF
--- a/src/crush/CrushLocation.h
+++ b/src/crush/CrushLocation.h
@@ -19,7 +19,7 @@ class CrushLocation {
 
 public:
   CrushLocation(CephContext *c) : cct(c) {
-    update_from_conf();
+    init_on_startup();
   }
 
   int update_from_conf();  ///< refresh from config


### PR DESCRIPTION
CrushLocation only invoked update_from_conf() which meant that
update_from_hook() was never executed.

By called init_on_startup() both functions are executed so that
the hook is called when configured.

Signed-off-by: Wido den Hollander <wido@42on.com>