### PR TITLE
rgw: reject request if decoded URI contains \0 in the middle.

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -108,6 +108,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_INTERNAL_ERROR, {500, "InternalError" }},
     { ERR_NOT_IMPLEMENTED, {501, "NotImplemented" }},
     { ERR_SERVICE_UNAVAILABLE, {503, "ServiceUnavailable"}},
+    { ERR_ZERO_IN_URL, {400, "InvalidRequest" }},
 });
 
 rgw_http_errors rgw_http_swift_errors({
@@ -118,6 +119,10 @@ rgw_http_errors rgw_http_swift_errors({
     { ERR_BAD_URL, {412, "Bad URL" }},
     { ERR_NOT_SLO_MANIFEST, {400, "Not an SLO manifest" }},
     { ERR_QUOTA_EXCEEDED, {413, "QuotaExceeded" }},
+    /* FIXME(rzarzynski): we need to find a way to apply Swift's error handling
+     * procedures also for ERR_ZERO_IN_URL. This make a problem as the validation
+     * is performed very early, even before setting the req_state::proto_flags. */
+    { ERR_ZERO_IN_URL, {412, "Invalid UTF8 or contains NULL"}},
 });
 
 int rgw_perf_start(CephContext *cct)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -210,6 +210,7 @@ using ceph::crypto::MD5;
 #define ERR_INVALID_LOCATION_CONSTRAINT 2208
 #define ERR_TAG_CONFLICT         2209
 #define ERR_INVALID_TAG          2210
+#define ERR_ZERO_IN_URL          2211
 
 #define ERR_BUSY_RESHARDING      2300
 

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2212,6 +2212,10 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
   }
 
   s->decoded_uri = url_decode(s->info.request_uri);
+  /* Validate for being free of the '\0' buried in the middle of the string. */
+  if (std::strlen(s->decoded_uri.c_str()) != s->decoded_uri.length()) {
+    return -ERR_ZERO_IN_URL;
+  }
 
   /* FastCGI specification, section 6.3
    * http://www.fastcgi.com/devkit/doc/fcgi-spec.html#S6.3


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20418
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>