### PR TITLE
mon: fix kvstore type in mon compact command

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3026,7 +3026,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     end -= start;
     dout(1) << "finished manual compaction in " << end << " seconds" << dendl;
     ostringstream oss;
-    oss << "compacted leveldb in " << end;
+    oss << "compacted " << g_conf->get_val<std::string>("mon_keyvaluedb") << " in " << end << " seconds";
     rs = oss.str();
     r = 0;
   }


### PR DESCRIPTION
Signed-off-by: liuchang0812 <liuchang0812@gmail.com>


```
➜  build git:(wip-osd-compact) ✗ ./bin/ceph mon compact                 
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2017-06-27 23:42:51.338683 7f6cd5067700 -1 WARNING: all dangerous and experimental features are enabled.
2017-06-27 23:42:51.347515 7f6cd5067700 -1 WARNING: all dangerous and experimental features are enabled.
compacted rocksdb in 0.945768 seconds
```
