### PR TITLE
qa/tasks/dump_stuck: fix for active+clean+remapped

### DIFF
--- a/qa/tasks/dump_stuck.py
+++ b/qa/tasks/dump_stuck.py
@@ -63,6 +63,7 @@ def task(ctx, config):
 #                            '--mon-osd-report-timeout 90',
                             '--mon-pg-stuck-threshold 10')
 
+    # all active+clean
     check_stuck(
         manager,
         num_inactive=0,
@@ -76,10 +77,11 @@ def task(ctx, config):
     manager.flush_pg_stats([1])
     manager.wait_for_recovery(timeout)
 
+    # all active+clean+remapped
     check_stuck(
         manager,
         num_inactive=0,
-        num_unclean=num_pgs,
+        num_unclean=0,
         num_stale=0,
         )
 
@@ -87,6 +89,7 @@ def task(ctx, config):
     manager.flush_pg_stats([0, 1])
     manager.wait_for_clean(timeout)
 
+    # all active+clean
     check_stuck(
         manager,
         num_inactive=0,


### PR DESCRIPTION
In d24a8886658c2d8882275d69c6409717a62701be we made remapped a clean
state but didn't fix this test.

Fixes: http://tracker.ceph.com/issues/20431
Signed-off-by: Sage Weil <sage@redhat.com>