### PR TITLE
ceph_release: we are in the 'rc' phase (12.1.z)

### DIFF
--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
 12
 luminous
-dev
+rc


### PR DESCRIPTION
This is new with luminous.. the ceph_release file has a field with dev, rc, or stable that is included in the ceph version string.