### PR TITLE
tests: rgw/singleton: drop duplicate filestore-xfs.yaml

### DIFF
--- a/qa/suites/rgw/singleton/filestore-xfs.yaml
+++ b/qa/suites/rgw/singleton/filestore-xfs.yaml
@@ -1,1 +1,0 @@
-../../../objectstore/filestore-xfs.yaml


### PR DESCRIPTION
`qa/suites/rgw/singleton/filestore-xfs.yaml` is duplicated by `qa/suites/rgw/singleton/objectstore/filestore-xfs.yaml` - drop the former.