### PR TITLE
os/filestore/FileStore.cc: remove a redundant judgement when get max latency

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -4044,7 +4044,7 @@ void FileStore::sync_entry()
       utime_t dur = done - startwait;
       dout(10) << __FUNC__ << ": commit took " << lat << ", interval was " << dur << dendl;
       utime_t max_pause_lat = logger->tget(l_filestore_sync_pause_max_lat);
-      if (max_pause_lat == utime_t() || max_pause_lat < dur - lat) {
+      if (max_pause_lat < dur - lat) {
         logger->tinc(l_filestore_sync_pause_max_lat, dur - lat);
       }
 


### PR DESCRIPTION
In fact, utime_t default is utime_t(). So we can remove this judgement.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>