### PR TITLE
mds/events: Initialize Non-static class members in mds/events

### DIFF
--- a/src/mds/events/EFragment.h
+++ b/src/mds/events/EFragment.h
@@ -29,10 +29,10 @@ WRITE_CLASS_ENCODER(dirfrag_rollback)
 class EFragment : public LogEvent {
 public:
   EMetaBlob metablob;
-  __u8 op;
+  __u8 op{0};
   inodeno_t ino;
   frag_t basefrag;
-  __s32 bits;         // positive for split (from basefrag), negative for merge (to basefrag)
+  __s32 bits{0};         // positive for split (from basefrag), negative for merge (to basefrag)
   list<frag_t> orig_frags;
   bufferlist rollback;
 

--- a/src/mds/events/EImportStart.h
+++ b/src/mds/events/EImportStart.h
@@ -33,7 +33,7 @@ protected:
 public:
   EMetaBlob metablob;
   bufferlist client_map;  // encoded map<__u32,entity_inst_t>
-  version_t cmapv;
+  version_t cmapv{0};
 
   EImportStart(MDLog *log, dirfrag_t di, vector<dirfrag_t>& b, mds_rank_t f) :
     LogEvent(EVENT_IMPORTSTART),

--- a/src/mds/events/EMetaBlob.h
+++ b/src/mds/events/EMetaBlob.h
@@ -66,14 +66,14 @@ public:
     typedef compact_map<snapid_t, old_inode_t> old_inodes_t;
     string  dn;         // dentry
     snapid_t dnfirst, dnlast;
-    version_t dnv;
+    version_t dnv{0};
     inode_t inode;      // if it's not
     fragtree_t dirfragtree;
     map<string,bufferptr> xattrs;
     string symlink;
     snapid_t oldest_snap;
     bufferlist snapbl;
-    __u8 state;
+    __u8 state{0};
     old_inodes_t old_inodes;
 
     fullbit(const fullbit& o);

--- a/src/mds/events/ESession.h
+++ b/src/mds/events/ESession.h
@@ -24,10 +24,10 @@ class ESession : public LogEvent {
  protected:
   entity_inst_t client_inst;
   bool open;    // open or close
-  version_t cmapv;  // client map version
+  version_t cmapv{0};  // client map version
 
   interval_set<inodeno_t> inos;
-  version_t inotablev;
+  version_t inotablev{0};
 
   // Client metadata stored during open
   std::map<std::string, std::string> client_metadata;


### PR DESCRIPTION
Fixes the Coverity Scan Reports:
```
CID 717250: Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member cmapv is not initialized in this constructor nor in any functions that it calls.
4. uninit_member: Non-static class member inotablev is not initialized in this constructor nor
in any functions that it calls.
```

```
CID 717245: Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member dnv is not initialized in this constructor nor in any
functions that it calls.
4. uninit_member: Non-static class member state is not initialized in this constructor nor in any functions that it calls.
```

```
CID 717243: Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member cmapv is not initialized in this constructor nor in any functions that it calls.
```

```
CID 717240: Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member op is not initialized in this constructor nor in any
functions that it calls.
4. uninit_member: Non-static class member bits is not initialized in this constructor nor in any functions that it calls.
```

Signed-off-by: Jos Collin <jcollin@redhat.com>