### PR TITLE
rgw/rgw_rest: kill warning

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1943,6 +1943,8 @@ int RGWHandler_REST::read_permissions(RGWOp* op_obj)
   case OP_DELETE:
     if (!s->info.args.exists("tagging")){
       only_bucket = true;
+    } else {
+      only_bucket = false;
     }
     break;
   case OP_OPTIONS:


### PR DESCRIPTION
rgw/rgw_rest.cc: In member function ‘virtual int RGWHandler_REST::read_permissions(RGWOp*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_rest.cc:1919:8: warning: ‘only_bucket’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   bool only_bucket;

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>