### PR TITLE
delete redundant break statement;

### DIFF
--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -1255,11 +1255,9 @@ namespace crimson {
 	switch(next.type) {
 	case super::NextReqType::none:
 	  return result;
-	  break;
 	case super::NextReqType::future:
 	  result.data = next.when_ready;
 	  return result;
-	  break;
 	case super::NextReqType::returning:
 	  // to avoid nesting, break out and let code below handle this case
 	  break;


### PR DESCRIPTION
since there is such a return why break statement?