### PR TITLE
mon: crush class's name contains `~`, support it in ceph CLI

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -592,7 +592,7 @@ COMMAND("osd crush show-tunables", \
 	"show current crush tunables", "osd", "r", "cli,rest")
 COMMAND("osd crush rule create-simple " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
-	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.~] " \
 	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=mode,type=CephChoices,strings=firstn|indep,req=false",
 	"create crush rule <name> to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)", \


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20446

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>


manual tested :

```

➜  build git:(wip-20446) ✗ ./bin/ceph osd crush rule create-simple ssd default~ssd host firstn 
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2017-06-28 20:34:21.953896 7f4685a34700 -1 WARNING: all dangerous and experimental features are enabled.
2017-06-28 20:34:22.106876 7f4685a34700 -1 WARNING: all dangerous and experimental features are enabled.
Invalid command:  invalid chars ~ in default~ssd
osd crush rule create-simple <name> <root> <type> {firstn|indep} :  create crush rule <name> to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)
Error EINVAL: invalid command


➜  build git:(wip-20446) ✗ ./bin/ceph osd crush rule create-simple ssd default~ssd host firstn
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2017-06-28 20:36:30.057915 7f0a3e103700 -1 WARNING: all dangerous and experimental features are enabled.
2017-06-28 20:36:30.076549 7f0a3e103700 -1 WARNING: all dangerous and experimental features are enabled.


```