### PR TITLE
hammer: librbd: potential read IO hang when image is flattened

### DIFF
--- a/src/librbd/AioRequest.cc
+++ b/src/librbd/AioRequest.cc
@@ -140,8 +140,6 @@ namespace librbd {
           RWLock::RLocker l2(m_ictx->parent_lock);
           if (m_ictx->parent == NULL) {
 	    ldout(m_ictx->cct, 20) << "parent is gone; do nothing" << dendl;
-	    m_state = LIBRBD_AIO_READ_FLAT;
-	    finished = false;
 	    break;
 	  }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/20152
