### PR TITLE
mds: use find in is_data_pool

### DIFF
--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -314,7 +314,10 @@ public:
   int64_t get_first_data_pool() const { return *data_pools.begin(); }
   int64_t get_metadata_pool() const { return metadata_pool; }
   bool is_data_pool(int64_t poolid) const {
-    return std::binary_search(data_pools.begin(), data_pools.end(), poolid);
+    auto p = std::find(data_pools.begin(), data_pools.end(), poolid);
+    if (p == data_pools.end())
+      return false;
+    return true;
   }
 
   bool pool_in_use(int64_t poolid) const {


### PR DESCRIPTION
binary_search assumes that vector data_pools is ordered. add_data_pool
however only appends to the vector, so no order can be assumed.

Fixes: http://tracker.ceph.com/issues/20452

Signed-off-by: Jan Fajerski <jfajerski@suse.com>