### PR TITLE
rgw: fix infinite loop in rest api for log list

### DIFF
--- a/src/cls/log/cls_log_client.cc
+++ b/src/cls/log/cls_log_client.cc
@@ -94,11 +94,11 @@ public:
         bufferlist::iterator iter = outbl.begin();
         ::decode(ret, iter);
         if (entries)
-	  *entries = ret.entries;
+          *entries = std::move(ret.entries);
         if (truncated)
           *truncated = ret.truncated;
         if (marker)
-          *marker = ret.marker;
+          *marker = std::move(ret.marker);
       } catch (buffer::error& err) {
         // nothing we can do about it atm
       }

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -149,13 +149,18 @@ int RGWMetadataLog::list_entries(void *handle,
     *truncated = false;
     return 0;
   }
-
+  
+  list<cls_log_entry> log_entries;
+  
   int ret = store->time_log_list(ctx->cur_oid, ctx->from_time, ctx->end_time,
-				 max_entries, entries, ctx->marker,
+				 max_entries, log_entries, ctx->marker,
 				 last_marker, truncated);
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
+  ctx->marker = *last_marker;
+  entries.splice(entries.end(), log_entries);
+  
   if (ret == -ENOENT)
     *truncated = false;
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -149,18 +149,16 @@ int RGWMetadataLog::list_entries(void *handle,
     *truncated = false;
     return 0;
   }
-  
-  list<cls_log_entry> log_entries;
-  
+
   int ret = store->time_log_list(ctx->cur_oid, ctx->from_time, ctx->end_time,
-				 max_entries, log_entries, ctx->marker,
+				 max_entries, entries, ctx->marker,
 				 last_marker, truncated);
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
   ctx->marker = *last_marker;
-  entries.splice(entries.end(), log_entries);
   
+
   if (ret == -ENOENT)
     *truncated = false;
 

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -150,14 +150,17 @@ int RGWMetadataLog::list_entries(void *handle,
     return 0;
   }
 
+  std::string next_marker;
   int ret = store->time_log_list(ctx->cur_oid, ctx->from_time, ctx->end_time,
 				 max_entries, entries, ctx->marker,
-				 last_marker, truncated);
+				 &next_marker, truncated);
   if ((ret < 0) && (ret != -ENOENT))
     return ret;
 
-  ctx->marker = *last_marker;
-  
+  ctx->marker = std::move(next_marker);
+  if (last_marker) {
+    *last_marker = ctx->marker;
+  }
 
   if (ret == -ENOENT)
     *truncated = false;

--- a/src/rgw/rgw_rest_log.cc
+++ b/src/rgw/rgw_rest_log.cc
@@ -54,8 +54,7 @@ void RGWOp_MDLog_List::execute() {
              ut_et;
   void    *handle;
   unsigned shard_id, max_entries = LOG_CLASS_LIST_MAX_ENTRIES;
-  unsigned left_cnt;
-  
+
   shard_id = (unsigned)strict_strtol(shard.c_str(), 10, &err);
   if (!err.empty()) {
     dout(5) << "Error parsing shard_id " << shard << dendl;
@@ -80,6 +79,9 @@ void RGWOp_MDLog_List::execute() {
       http_ret = -EINVAL;
       return;
     }
+    if (max_entries > LOG_CLASS_LIST_MAX_ENTRIES) {
+      max_entries = LOG_CLASS_LIST_MAX_ENTRIES;
+    }
   } 
 
   if (period.empty()) {
@@ -95,16 +97,9 @@ void RGWOp_MDLog_List::execute() {
   RGWMetadataLog meta_log{s->cct, store, period};
 
   meta_log.init_list_entries(shard_id, ut_st, ut_et, marker, &handle);
-  left_cnt = max_entries;
-  
-  do {
-    http_ret = meta_log.list_entries(handle, left_cnt, entries,
-				     &last_marker, &truncated);
-    if (http_ret < 0) 
-      break;
 
-    left_cnt =  max_entries - entries.size();
-  } while (truncated && (left_cnt > 0));
+  http_ret = meta_log.list_entries(handle, max_entries, entries,
+                                   &last_marker, &truncated);
 
   meta_log.complete_list_entries(handle);
 }
@@ -578,7 +573,6 @@ void RGWOp_DATALog_List::execute() {
   real_time  ut_st, 
              ut_et;
   unsigned shard_id, max_entries = LOG_CLASS_LIST_MAX_ENTRIES;
-  unsigned left_cnt;
 
   s->info.args.get_bool("extra-info", &extra_info, false);
 
@@ -606,25 +600,16 @@ void RGWOp_DATALog_List::execute() {
       http_ret = -EINVAL;
       return;
     }
-  } 
+    if (max_entries > LOG_CLASS_LIST_MAX_ENTRIES) {
+      max_entries = LOG_CLASS_LIST_MAX_ENTRIES;
+    }
+  }
 
-  dout(10) << __func__ << " shard " << shard << " st " << st << " et " << et << " marker " 
-         << marker << " max_entries "<< max_entries << dendl;
-  left_cnt = max_entries;
-
-  do {
-    // Note that last_marker is updated to be the marker of the last
-    // entry listed
-    http_ret = store->data_log->list_entries(shard_id, ut_st, ut_et, 
-					     left_cnt, entries, marker,
-					     &last_marker, &truncated);
-    if (http_ret < 0) 
-      break;
-
-    assert(max_entries >= entries.size());
-    left_cnt = max_entries - entries.size();
-    marker = last_marker;
-  } while (truncated && (left_cnt > 0));
+  // Note that last_marker is updated to be the marker of the last
+  // entry listed
+  http_ret = store->data_log->list_entries(shard_id, ut_st, ut_et,
+                                           max_entries, entries, marker,
+                                           &last_marker, &truncated);
 }
 
 void RGWOp_DATALog_List::send_response() {


### PR DESCRIPTION
followup to https://github.com/ceph/ceph/pull/15841:
* replace `list::splice()` with a move
* limit `max-entries` to `LOG_CLASS_LIST_MAX_ENTRIES` (1000) if client supplied larger value
* fix crash in `radosgw-admin mdlog list` command
* the do-while loops are unnecessary, because `cls_log_list()` will already give us the requested number of entries, unless truncated. and these rest operations return the truncated flag and last_marker, which the client side is already using to run the same loop