### PR TITLE
mon/MgrStatMonitor: avoid dup health warnings during luminous upgrade

### DIFF
--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -131,6 +131,10 @@ void MgrStatMonitor::get_health(list<pair<health_status_t,string> >& summary,
 				list<pair<health_status_t,string> > *detail,
 				CephContext *cct) const
 {
+  if (mon->osdmon()->osdmap.require_osd_release < CEPH_RELEASE_LUMINOUS) {
+    return;
+  }
+
   summary.insert(summary.end(), health_summary.begin(), health_summary.end());
   if (detail) {
     detail->insert(detail->end(), health_detail.begin(), health_detail.end());


### PR DESCRIPTION
PGMonitor is still providing warnings; do not expose the ones we are
getting from ceph-mgr (which also come from PGMap::get_health()) too or
else we'll get dups!

Fixes: http://tracker.ceph.com/issues/20435
Signed-off-by: Sage Weil <sage@redhat.com>