### PR TITLE
Fix s3 object uploads with chunked transfers and v4 signatures.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -909,7 +909,7 @@ std::string
 AWSv4ComplMulti::calc_chunk_signature(const std::string& payload_hash) const
 {
   const auto string_to_sign = string_join_reserve("\n",
-    AWS4_HMAC_SHA256_STR,
+    AWS4_HMAC_SHA256_PAYLOAD_STR,
     date,
     credential_scope,
     prev_chunk_signature,

--- a/src/rgw/rgw_auth_s3.h
+++ b/src/rgw/rgw_auth_s3.h
@@ -316,6 +316,7 @@ namespace auth {
 namespace s3 {
 
 static constexpr char AWS4_HMAC_SHA256_STR[] = "AWS4-HMAC-SHA256";
+static constexpr char AWS4_HMAC_SHA256_PAYLOAD_STR[] = "AWS4-HMAC-SHA256-PAYLOAD";
 
 static constexpr char AWS4_EMPTY_PAYLOAD_HASH[] = \
   "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";


### PR DESCRIPTION
With aws-sdk-java 1.11, large uploads use chunked transfer by default,
and v4 signatures are the default.  The java sdk uses a slightly different
string "AWS4-HMAC-SHA256-PAYLOAD" when constructing the per-chunk signature
than ceph was using.  This same string also appears in a current
copy of s3-api.pdf , so it must be the more correct value.

Fixes: http://tracker.ceph.com/issues/20447
Signed-off-by: Marcus Watts <mwatts@redhat.com>