### PR TITLE
Supports two IB cards to work simultaneously

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -233,7 +233,8 @@ OPTION(ms_async_set_affinity, OPT_BOOL, true)
 // If ms_async_affinity_cores is empty, all threads will be bind to current running
 // core
 OPTION(ms_async_affinity_cores, OPT_STR, "")
-OPTION(ms_async_rdma_device_name, OPT_STR, "")
+OPTION(ms_async_rdma_public_device_name, OPT_STR, "")
+OPTION(ms_async_rdma_cluster_device_name, OPT_STR, "")
 OPTION(ms_async_rdma_enable_hugepage, OPT_BOOL, false)
 OPTION(ms_async_rdma_buffer_size, OPT_INT, 128 << 10)
 OPTION(ms_async_rdma_send_buffers, OPT_U32, 1024)

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -217,9 +217,9 @@ struct StackSingleton {
   std::shared_ptr<NetworkStack> stack;
 
   StackSingleton(CephContext *c): cct(c) {}
-  void ready(std::string &type) {
+  void ready(std::string &type, string mname = "empty") {
     if (!stack)
-      stack = NetworkStack::create(cct, type);
+      stack = NetworkStack::create(cct, type, mname);
   }
   ~StackSingleton() {
     stack->stop();
@@ -259,8 +259,21 @@ AsyncMessenger::AsyncMessenger(CephContext *cct, entity_name_t name,
 
   ceph_spin_init(&global_seq_lock);
   StackSingleton *single;
-  cct->lookup_or_create_singleton_object<StackSingleton>(single, "AsyncMessenger::NetworkStack::"+transport_type);
-  single->ready(transport_type);
+  string _stack_name;
+
+  if ("rdma" != transport_type ||
+      cct->_conf->ms_async_rdma_cluster_device_name ==
+      cct->_conf->ms_async_rdma_public_device_name)
+    _stack_name = "AsyncMessenger::NetworkStack";
+  else {
+    if ("hb_back_client" == mname || "hb_back_server" == mname || "cluster" == mname)
+      _stack_name = "AsyncMessenger::NetworkStack::Cluster";
+    else
+      _stack_name = "AsyncMessenger::NetworkStack::Public";
+  }
+
+  cct->lookup_or_create_singleton_object<StackSingleton>(single, _stack_name+"::"+transport_type);
+  single->ready(transport_type, mname);
   stack = single->stack.get();
   stack->start();
   local_worker = stack->get_worker();

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -192,7 +192,7 @@ class EventCenter {
   ostream& _event_prefix(std::ostream *_dout);
 
   int init(int nevent, unsigned idx, const std::string &t);
-  void set_owner();
+  void set_owner(string mname = "empty");
   pthread_t get_owner() const { return owner; }
   unsigned get_id() const { return idx; }
 

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -355,8 +355,8 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
   return 0;
 }
 
-PosixNetworkStack::PosixNetworkStack(CephContext *c, const string &t)
-    : NetworkStack(c, t)
+PosixNetworkStack::PosixNetworkStack(CephContext *c, const string &t, string mname)
+    : NetworkStack(c, t, mname)
 {
   vector<string> corestrs;
   get_str_vec(cct->_conf->ms_async_affinity_cores, corestrs);

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -40,7 +40,7 @@ class PosixNetworkStack : public NetworkStack {
   vector<std::thread> threads;
 
  public:
-  explicit PosixNetworkStack(CephContext *c, const string &t);
+  explicit PosixNetworkStack(CephContext *c, const string &t, string mname);
 
   int get_cpuid(int id) const {
     if (coreids.empty())

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -40,7 +40,7 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
       sprintf(tp_name, "msgr-worker-%d", w->id);
       ceph_pthread_setname(pthread_self(), tp_name);
       const uint64_t EventMaxWaitUs = 30000000;
-      w->center.set_owner();
+      w->center.set_owner(mname);
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();
       w->init_done();
@@ -61,17 +61,17 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
   };
 }
 
-std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string &t)
+std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string &t, string mname)
 {
   if (t == "posix")
-    return std::make_shared<PosixNetworkStack>(c, t);
+    return std::make_shared<PosixNetworkStack>(c, t, mname);
 #ifdef HAVE_RDMA
   else if (t == "rdma")
-    return std::make_shared<RDMAStack>(c, t);
+    return std::make_shared<RDMAStack>(c, t, mname);
 #endif
 #ifdef HAVE_DPDK
   else if (t == "dpdk")
-    return std::make_shared<DPDKStack>(c, t);
+    return std::make_shared<DPDKStack>(c, t, mname);
 #endif
 
   lderr(c) << __func__ << " ms_async_transport_type " << t <<
@@ -99,7 +99,7 @@ Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned
   return nullptr;
 }
 
-NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(false), cct(c)
+NetworkStack::NetworkStack(CephContext *c, const string &t, string mname): type(t), started(false), mname(mname), cct(c)
 {
   assert(cct->_conf->ms_async_op_threads > 0);
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -290,6 +290,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   unsigned num_workers = 0;
   Spinlock pool_spin;
   bool started = false;
+  std::string mname;
 
   std::function<void ()> add_thread(unsigned i);
 
@@ -297,7 +298,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   CephContext *cct;
   vector<Worker*> workers;
 
-  explicit NetworkStack(CephContext *c, const string &t);
+  explicit NetworkStack(CephContext *c, const string &t, string mname = "empty");
  public:
   NetworkStack(const NetworkStack &) = delete;
   NetworkStack& operator=(const NetworkStack &) = delete;
@@ -307,7 +308,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   }
 
   static std::shared_ptr<NetworkStack> create(
-          CephContext *c, const string &type);
+          CephContext *c, const string &type, string mname = "empty");
 
   static Worker* create_worker(
           CephContext *c, const string &t, unsigned i);

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -241,7 +241,7 @@ class DPDKWorker : public Worker {
 class DPDKStack : public NetworkStack {
   vector<std::function<void()> > funcs;
  public:
-  explicit DPDKStack(CephContext *cct, const string &t): NetworkStack(cct, t) {
+  explicit DPDKStack(CephContext *cct, const string &t, string mname): NetworkStack(cct, t, mname) {
     funcs.resize(cct->_conf->ms_async_max_op_threads);
   }
   virtual bool support_zero_copy_read() const override { return true; }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -14,6 +14,11 @@
  *
  */
 
+#include <stdlib.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
 #include "Infiniband.h"
 #include "common/errno.h"
 #include "common/debug.h"
@@ -145,6 +150,107 @@ void Device::binding_port(CephContext *cct, int port_num) {
   }
 }
 
+DeviceList::DeviceList(CephContext *cct): device_list(ibv_get_device_list(&num)) {
+  if (device_list == NULL || num == 0) {
+    lderr(cct) << __func__ << " failed to get rdma device list.  " << cpp_strerror(errno) << dendl;
+    assert(0);
+  }
+
+  int iRet = -1;
+  FILE *fd = NULL;
+  Device *pstDevice;
+  fd = fopen("/dev/devinfo.txt", "r");
+  if (NULL == fd)
+  {
+    iRet = system("/usr/bin/ibdev2netdev > /dev/devinfo.txt");
+    if (0 != iRet)
+    {
+      lderr(cct) << __func__ << " failed to execute ibdev2netdev. " << cpp_strerror(errno) << dendl;
+      assert(0);
+    }
+    fd = fopen("/dev/devinfo.txt", "r");
+    if (NULL == fd)
+    {
+      lderr(cct) << __func__ << " failed to open file /dev/devinfo.txt. " << cpp_strerror(errno) << dendl;
+      assert(0);
+    }
+  }
+
+  //devices = new Device*[num];
+
+  char szDevName[16];  // mlx4_0 or mlx4_1 or mlx5_0
+  char szNetName[16];  // ib0 or ib1
+  char szDevStatus[8]; // Up or Down
+  for (int i = 0;i < num; ++i) {
+    szDevName[0] = '\0';
+    szNetName[0] = '\0';
+    szDevStatus[0] = '\0';
+    iRet = fscanf(fd, "%15s port 1 ==> %15s (%7s)", szDevName, szNetName, szDevStatus);
+    if (3 != iRet)
+    {
+      fclose(fd);
+      lderr(cct) << __func__ << " failed to analyze the dev name. " << cpp_strerror(errno) << dendl;
+      assert(0);
+    }
+    int iLen = 0;
+    iLen = strlen(szDevStatus);
+    szDevStatus[iLen - 1] = '\0';
+    m_dev_name.insert(make_pair<std::string, std::string>(szNetName, szDevName));
+    pstDevice = new Device(cct, device_list[i]);
+    if (NULL == pstDevice)
+    {
+      fclose(fd);
+      lderr(cct) << __func__ << " failed to new the struct of Device. " << cpp_strerror(errno) << dendl;
+      assert(0);
+    }
+    m_device[pstDevice->get_name()] = pstDevice;
+  }
+  fclose(fd);
+}
+
+Device* DeviceList::get_device(CephContext *cct, const char* net_dev_name) {
+  string ib_dev_name;
+
+  //assert(devices);
+
+  ib_dev_name = m_dev_name[net_dev_name];
+
+  ldout(cct, 1) << __func__ << " number of device: " << num
+    << ", net_dev_name: " << net_dev_name << ", ib_dev_name: " << ib_dev_name << dendl;
+
+  return m_device[ib_dev_name];
+/*
+  for (int i = 0; i < num; ++i) {
+    if (!strlen(device_name) || !strcmp(device_name, devices[i]->get_name())) {
+      return devices[i];
+    }
+  }
+
+  return NULL;
+*/
+}
+
+DeviceList::~DeviceList() {
+  std::map<std::string, Device*>::iterator dev_it;
+  for (dev_it = m_device.begin(); dev_it != m_device.end(); dev_it++)
+  {
+    delete dev_it->second;
+    dev_it = m_device.erase(dev_it);
+  }
+
+  std::map<std::string, std::string>::iterator name_it;
+  for (name_it = m_dev_name.begin(); name_it != m_dev_name.end(); name_it++)
+  {
+    name_it = m_dev_name.erase(name_it);
+  }
+  /*
+  for (int i=0; i < num; ++i) {
+    delete devices[i];
+  }
+  delete []devices;
+  */
+  ibv_free_device_list(device_list);
+}
 
 Infiniband::QueuePair::QueuePair(
     CephContext *c, Infiniband& infiniband, ibv_qp_type type,
@@ -708,7 +814,7 @@ int Infiniband::MemoryManager::get_channel_buffers(std::vector<Chunk*> &chunks, 
 }
 
 
-Infiniband::Infiniband(CephContext *cct, const std::string &device_name, uint8_t port_num)
+Infiniband::Infiniband(CephContext *cct, const std::string &device_name, uint8_t port_num, string mname)
   : cct(cct), lock("IB lock"), device_name(device_name), port_num(port_num)
 {
 }
@@ -723,9 +829,9 @@ void Infiniband::init()
   device_list = new DeviceList(cct);
   initialized = true;
 
-  device = device_list->get_device(device_name.c_str());
-  device->binding_port(cct, port_num);
+  device = device_list->get_device(cct, device_name.c_str());
   assert(device);
+  device->binding_port(cct, port_num);
   ib_physical_port = device->active_port->get_port_num();
   pd = new ProtectionDomain(cct, device);
   assert(NetHandler(cct).set_nonblock(device->ctxt->async_fd) == 0);

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -89,36 +89,14 @@ class Device {
 class DeviceList {
   struct ibv_device ** device_list;
   int num;
-  Device** devices;
+  //Device** devices;
+  std::map<std::string, std::string> m_dev_name; // <ib0, mlx4_0>
+  std::map<std::string, Device*> m_device; // <mlx4_0, Device *>
  public:
-  DeviceList(CephContext *cct): device_list(ibv_get_device_list(&num)) {
-    if (device_list == NULL || num == 0) {
-      lderr(cct) << __func__ << " failed to get rdma device list.  " << cpp_strerror(errno) << dendl;
-      ceph_abort();
-    }
-    devices = new Device*[num];
+  DeviceList(CephContext *cct);
+  ~DeviceList();
 
-    for (int i = 0;i < num; ++i) {
-      devices[i] = new Device(cct, device_list[i]);
-    }
-  }
-  ~DeviceList() {
-    for (int i=0; i < num; ++i) {
-      delete devices[i];
-    }
-    delete []devices;
-    ibv_free_device_list(device_list);
-  }
-
-  Device* get_device(const char* device_name) {
-    assert(devices);
-    for (int i = 0; i < num; ++i) {
-      if (!strlen(device_name) || !strcmp(device_name, devices[i]->get_name())) {
-        return devices[i];
-      }
-    }
-    return NULL;
-  }
+  Device* get_device(CephContext *cct, const char* device_name);
 };
 
 
@@ -236,7 +214,7 @@ class Infiniband {
   uint8_t port_num;
 
  public:
-  explicit Infiniband(CephContext *c, const std::string &device_name, uint8_t p);
+  explicit Infiniband(CephContext *c, const std::string &device_name, uint8_t p, string mname);
   ~Infiniband();
   void init();
 


### PR DESCRIPTION
Under the mode of RDMA communication, this modification allows you to work with two IB cards. It can select the appropriate network card according to the different messenger types. When we want ceph to work in double cards mode, ms_async_rdma_public_device_name and ms_async_rdma_cluster_device_name should be configred as "ib0" or "ib1" which is the network name of ib card. When the value of ms_async_rdma_public_device_name is the same as ms_async_rdma_cluster_device_name, it works in the single card mode. 

Signed-off-by: Shang Fufei <shangfufei@inspur.com>