### PR TITLE
rgw: silence compile warning from -Wmaybe-uninitialized

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1916,7 +1916,7 @@ int RGWHandler_REST::init_permissions(RGWOp* op)
 
 int RGWHandler_REST::read_permissions(RGWOp* op_obj)
 {
-  bool only_bucket;
+  bool only_bucket = false;
 
   switch (s->op) {
   case OP_HEAD:


### PR DESCRIPTION
```
ceph/src/rgw/rgw_rest.cc: In member function ‘virtual int
RGWHandler_REST::read_permissions(RGWOp*)’:
ceph/src/rgw/rgw_rest.cc:1919:8: warning: ‘only_bucket’ may be used uninitialized in
this function [-Wmaybe-uninitialized]
   bool only_bucket;
           ^
	   [100%] Building CXX ob

```