### PR TITLE
rgw: Correcting the condition in ceph_assert while parsing an AWS Principal

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -719,7 +719,7 @@ static optional<Principal> parse_principal(CephContext* cct, TokenID t,
 			  ECMAScript | optimize);
     smatch match;
     if (regex_match(a->resource, match, rx)) {
-      ceph_assert(match.size() == 2);
+      ceph_assert(match.size() == 3);
 
       if (match[1] == "user") {
 	return Principal::user(std::move(a->account),


### PR DESCRIPTION

Signed-off-by: Pritha Srivastava <prsrivas@redhat.com>