### PR TITLE
rgw: fix marker encoding problem.

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -498,11 +498,7 @@ static inline std::string aws4_uri_encode(const std::string& src)
 static inline std::string aws4_uri_recode(const boost::string_view& src)
 {
   std::string decoded = url_decode(src);
-  if (decoded.length() != src.length()) {
-    return src.to_string();
-  } else {
-    return aws4_uri_encode(decoded);
-  }
+  return aws4_uri_encode(decoded);
 }
 
 std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)


### PR DESCRIPTION
For object names that contain / and %, it is possible in
some circumstances (at least with boto) for "listobjects"
operations to attempt to fetch additional objects using
'marker=' and a value containing both / and %.  When this
happens, when using AWSv4, radosgw returns a signature
validation error.  It's possible to artifically do this
in boto on any bucket (regardless of content) with
sometihng like s=bucket.get_all_keys(marker='level1/8e%25%25FAH3')
this fails because "recoder" assumes the query string
was already encoded if any value is encoded, and fails
to take into account that the string might be partially
encoded, as in this case.

The fix here is to always decode the value, then always encode.

Fixes: http://tracker.ceph.com/issues/20463
Signed-off-by: Marcus Watts <mwatts@redhat.com>