### PR TITLE
msg/MOSDOpReply: fix missing trace decode

### DIFF
--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -236,6 +236,7 @@ public:
       ::decode(do_redirect, p);
       if (do_redirect)
 	::decode(redirect, p);
+      decode_trace(p);
     } else if (header.version < 2) {
       ceph_osd_reply_head head;
       ::decode(head, p);


### PR DESCRIPTION
**trace** has been encoded in encode_payload() but didn't be decoded, it sounds unreasonable.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>