### PR TITLE
rgw: ban anonymous user during user creation clearly

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4333,6 +4333,10 @@ int main(int argc, const char **argv)
   if (!user_id.empty() || !subuser.empty()) {
     ret = user.init(store, user_op);
     if (ret < 0) {
+      if (opt_cmd == OPT_USER_CREATE && user_op.is_reserved_user()) {
+          cerr << "uid: " << user_id << " is reserved by radosgw,"
+	       << " please choose another uid." << std::endl;
+      }
       cerr << "user.init failed: " << cpp_strerror(-ret) << std::endl;
       return -ret;
     }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1735,6 +1735,7 @@ int RGWUser::init(RGWUserAdminOpState& op_state)
   }
 
   if (!uid.empty() && (uid.compare(RGW_USER_ANON_ID) != 0)) {
+    op_state.set_reserved_user(false);
     found = (rgw_get_user_info_by_uid(store, uid, user_info, &op_state.objv) >= 0);
     op_state.found_by_uid = found;
   }

--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -179,6 +179,7 @@ struct RGWUserAdminOpState {
 
   // operation attributes
   bool existing_user;
+  bool reserved_user;
   bool existing_key;
   bool existing_subuser;
   bool existing_email;
@@ -388,6 +389,7 @@ struct RGWUserAdminOpState {
   bool is_populated() { return populated; }
   bool is_initialized() { return initialized; }
   bool has_existing_user() { return existing_user; }
+  bool is_reserved_user() { return reserved_user; }
   bool has_existing_key() { return existing_key; }
   bool has_existing_subuser() { return existing_subuser; }
   bool has_existing_email() { return existing_email; }
@@ -409,6 +411,7 @@ struct RGWUserAdminOpState {
   void clear_populated() { populated = false; }
   void set_initialized() { initialized = true; }
   void set_existing_user(bool flag) { existing_user = flag; }
+  void set_reserved_user(bool flag) { reserved_user = flag; }
   void set_existing_key(bool flag) { existing_key = flag; }
   void set_existing_subuser(bool flag) { existing_subuser = flag; }
   void set_existing_email(bool flag) { existing_email = flag; }
@@ -488,6 +491,7 @@ struct RGWUserAdminOpState {
     op_mask = 0;
 
     existing_user = false;
+    reserved_user = true;
     existing_key = false;
     existing_subuser = false;
     existing_email = false;


### PR DESCRIPTION
uid `anonymous` is reserved by rgw for anonymous user in rgw usage log.

The error msg was confusing, I‘ve encountered this when debug rgw usage log show with `--uid=anonymous`  .