### PR TITLE
msg/async/rdma: Support two IB cards to work simultaneously.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -157,7 +157,8 @@ OPTION(ms_async_set_affinity, OPT_BOOL)
 // If ms_async_affinity_cores is empty, all threads will be bind to current running
 // core
 OPTION(ms_async_affinity_cores, OPT_STR)
-OPTION(ms_async_rdma_device_name, OPT_STR)
+OPTION(ms_async_rdma_public_device_name, OPT_STR)
+OPTION(ms_async_rdma_cluster_device_name, OPT_STR)
 OPTION(ms_async_rdma_enable_hugepage, OPT_BOOL)
 OPTION(ms_async_rdma_buffer_size, OPT_INT)
 OPTION(ms_async_rdma_send_buffers, OPT_U32)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -768,7 +768,11 @@ std::vector<Option> get_global_options() {
     .set_default("")
     .set_description(""),
 
-    Option("ms_async_rdma_device_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    Option("ms_async_rdma_public_device_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("")
+    .set_description(""),
+
+    Option("ms_async_rdma_cluster_device_name", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description(""),
 

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -192,7 +192,7 @@ class EventCenter {
   ostream& _event_prefix(std::ostream *_dout);
 
   int init(int nevent, unsigned idx, const std::string &t);
-  void set_owner();
+  void set_owner(string mname = "empty");
   pthread_t get_owner() const { return owner; }
   unsigned get_id() const { return idx; }
 

--- a/src/msg/async/PosixStack.cc
+++ b/src/msg/async/PosixStack.cc
@@ -278,8 +278,8 @@ int PosixWorker::connect(const entity_addr_t &addr, const SocketOptions &opts, C
   return 0;
 }
 
-PosixNetworkStack::PosixNetworkStack(CephContext *c, const string &t)
-    : NetworkStack(c, t)
+PosixNetworkStack::PosixNetworkStack(CephContext *c, const string &t, string mname)
+    : NetworkStack(c, t, mname)
 {
   vector<string> corestrs;
   get_str_vec(cct->_conf->ms_async_affinity_cores, corestrs);

--- a/src/msg/async/PosixStack.h
+++ b/src/msg/async/PosixStack.h
@@ -40,7 +40,7 @@ class PosixNetworkStack : public NetworkStack {
   vector<std::thread> threads;
 
  public:
-  explicit PosixNetworkStack(CephContext *c, const string &t);
+  explicit PosixNetworkStack(CephContext *c, const string &t, string mname);
 
   int get_cpuid(int id) const {
     if (coreids.empty())

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -42,7 +42,7 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
       sprintf(tp_name, "msgr-worker-%d", w->id);
       ceph_pthread_setname(pthread_self(), tp_name);
       const uint64_t EventMaxWaitUs = 30000000;
-      w->center.set_owner();
+      w->center.set_owner(mname);
       ldout(cct, 10) << __func__ << " starting" << dendl;
       w->initialize();
       w->init_done();
@@ -63,17 +63,17 @@ std::function<void ()> NetworkStack::add_thread(unsigned i)
   };
 }
 
-std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string &t)
+std::shared_ptr<NetworkStack> NetworkStack::create(CephContext *c, const string &t, string mname)
 {
   if (t == "posix")
-    return std::make_shared<PosixNetworkStack>(c, t);
+    return std::make_shared<PosixNetworkStack>(c, t, mname);
 #ifdef HAVE_RDMA
   else if (t == "rdma")
-    return std::make_shared<RDMAStack>(c, t);
+    return std::make_shared<RDMAStack>(c, t, mname);
 #endif
 #ifdef HAVE_DPDK
   else if (t == "dpdk")
-    return std::make_shared<DPDKStack>(c, t);
+    return std::make_shared<DPDKStack>(c, t, mname);
 #endif
 
   lderr(c) << __func__ << " ms_async_transport_type " << t <<
@@ -101,7 +101,7 @@ Worker* NetworkStack::create_worker(CephContext *c, const string &type, unsigned
   return nullptr;
 }
 
-NetworkStack::NetworkStack(CephContext *c, const string &t): type(t), started(false), cct(c)
+NetworkStack::NetworkStack(CephContext *c, const string &t, string mname): type(t), started(false), mname(mname), cct(c)
 {
   assert(cct->_conf->ms_async_op_threads > 0);
 

--- a/src/msg/async/Stack.h
+++ b/src/msg/async/Stack.h
@@ -289,6 +289,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   unsigned num_workers = 0;
   ceph::spinlock pool_spin;
   bool started = false;
+  std::string mname;
 
   std::function<void ()> add_thread(unsigned i);
 
@@ -296,7 +297,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   CephContext *cct;
   vector<Worker*> workers;
 
-  explicit NetworkStack(CephContext *c, const string &t);
+  explicit NetworkStack(CephContext *c, const string &t, string mname = "empty");
  public:
   NetworkStack(const NetworkStack &) = delete;
   NetworkStack& operator=(const NetworkStack &) = delete;
@@ -306,7 +307,7 @@ class NetworkStack : public CephContext::ForkWatcher {
   }
 
   static std::shared_ptr<NetworkStack> create(
-          CephContext *c, const string &type);
+          CephContext *c, const string &type, string mname = "empty");
 
   static Worker* create_worker(
           CephContext *c, const string &t, unsigned i);

--- a/src/msg/async/dpdk/DPDKStack.h
+++ b/src/msg/async/dpdk/DPDKStack.h
@@ -241,7 +241,7 @@ class DPDKWorker : public Worker {
 class DPDKStack : public NetworkStack {
   vector<std::function<void()> > funcs;
  public:
-  explicit DPDKStack(CephContext *cct, const string &t): NetworkStack(cct, t) {
+  explicit DPDKStack(CephContext *cct, const string &t, string mname): NetworkStack(cct, t, mname) {
     funcs.resize(cct->_conf->ms_async_max_op_threads);
   }
   virtual bool support_zero_copy_read() const override { return true; }

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -97,36 +97,14 @@ class Device {
 class DeviceList {
   struct ibv_device ** device_list;
   int num;
-  Device** devices;
+  //Device** devices;
+  std::map<std::string, std::string> m_dev_name; // <ib0, mlx4_0>
+  std::map<std::string, Device*> m_device; // <mlx4_0, Device *>
  public:
-  DeviceList(CephContext *cct): device_list(ibv_get_device_list(&num)) {
-    if (device_list == NULL || num == 0) {
-      lderr(cct) << __func__ << " failed to get rdma device list.  " << cpp_strerror(errno) << dendl;
-      ceph_abort();
-    }
-    devices = new Device*[num];
+  DeviceList(CephContext *cct);
+  ~DeviceList();
 
-    for (int i = 0;i < num; ++i) {
-      devices[i] = new Device(cct, device_list[i]);
-    }
-  }
-  ~DeviceList() {
-    for (int i=0; i < num; ++i) {
-      delete devices[i];
-    }
-    delete []devices;
-    ibv_free_device_list(device_list);
-  }
-
-  Device* get_device(const char* device_name) {
-    assert(devices);
-    for (int i = 0; i < num; ++i) {
-      if (!strlen(device_name) || !strcmp(device_name, devices[i]->get_name())) {
-        return devices[i];
-      }
-    }
-    return NULL;
-  }
+  Device* get_device(CephContext *cct, const char* device_name);
 };
 
 // stat counters
@@ -366,11 +344,11 @@ class Infiniband {
   CephContext *cct;
   Mutex lock;
   bool initialized = false;
-  const std::string &device_name;
+  std::string device_name;
   uint8_t port_num;
 
  public:
-  explicit Infiniband(CephContext *c);
+  explicit Infiniband(CephContext *c, string mname);
   ~Infiniband();
   void init();
   static void verify_prereq(CephContext *cct);

--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -567,8 +567,8 @@ void RDMAWorker::handle_pending_message()
   dispatcher->notify_pending_workers();
 }
 
-RDMAStack::RDMAStack(CephContext *cct, const string &t)
-  : NetworkStack(cct, t), ib(cct), dispatcher(cct, this)
+RDMAStack::RDMAStack(CephContext *cct, const string &t, string mname)
+  : NetworkStack(cct, t, mname), ib(cct, mname), dispatcher(cct, this)
 {
   ldout(cct, 20) << __func__ << " constructing RDMAStack..." << dendl;
 

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -265,7 +265,7 @@ class RDMAStack : public NetworkStack {
   std::atomic<bool> fork_finished = {false};
 
  public:
-  explicit RDMAStack(CephContext *cct, const string &t);
+  explicit RDMAStack(CephContext *cct, const string &t, string mname);
   virtual ~RDMAStack();
   virtual bool support_zero_copy_read() const override { return false; }
   virtual bool nonblock_connect_need_writable_event() const { return false; }


### PR DESCRIPTION
Under the mode of RDMA communication, this modification allows you to work with two IB cards. It can select the appropriate network card according to the different messenger types. When we want ceph to work in double cards mode, ms_async_rdma_public_device_name and ms_async_rdma_cluster_device_name should be configred as "ib0" or "ib1" which is the network name of ib card. When the value of ms_async_rdma_public_device_name is the same as ms_async_rdma_cluster_device_name, it works in the single card mode.

Signed-off-by: shangfufei <shangfufei@inspur.com>