### PR TITLE
msg/async/AsyncConnection: fix very rarely send_message racing with fault

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -2064,15 +2064,7 @@ void AsyncConnection::fault()
   replacing = false;
   is_reset_from_peer = false;
   outcoming_bl.clear();
-  if (!once_ready && !is_queued() &&
-      state >=STATE_ACCEPTING && state <= STATE_ACCEPTING_WAIT_CONNECT_MSG_AUTH) {
-    ldout(async_msgr->cct, 10) << __func__ << " with nothing to send and in the half "
-                              << " accept state just closed" << dendl;
-    write_lock.unlock();
-    _stop();
-    dispatch_queue->queue_reset(this);
-    return ;
-  }
+
   reset_recv_state();
   if (policy.standby && !is_queued() && state != STATE_WAIT) {
     ldout(async_msgr->cct, 10) << __func__ << " with nothing to send, going to standby" << dendl;


### PR DESCRIPTION

For osd inter connection, it should be non-lossy and only reset when osd
restart(or other alike ops). So osd inter-connection must be alive and
won't lose.

But we left a special case for this type policy, if the connection is firstly
built and still doesn't enter ready state, no message in send queue, we
allow connection stop when meeting network error. It will meet a failing case:

Thread 1: enter fault, and want to stop because fresh and no message inqueue
Thread 2: call send_message, but wait for write_lock
Thread 1: stop connection
Thread 2: drop message because of closed state

So caller send message but never got ack, and connection dispatch reset event
won't wakeup OSD layer. OSD's policy is really special, it only wait for osdmap
to reset pg state.

The ideal fix is caller check send_message result, then decide to do something,
but it doesn't make sense now. Another fix is make OSD::ms_handle_reset aware of
this, but it also needs lots of magic logics.

So we just remove stop path for OSD's inter connection.

Signed-off-by: Haomai Wang <haomai@xsky.com>