### PR TITLE
osd/PrimaryLogPG solve cache tier osd high memory consumption

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9221,6 +9221,7 @@ void PrimaryLogPG::simple_opc_submit(OpContextUPtr ctx)
   dout(20) << __func__ << " " << repop << dendl;
   issue_repop(repop, ctx.get());
   eval_repop(repop);
+  calc_trim_to();
   repop->put();
 }
 


### PR DESCRIPTION
during cache tier dirty data flushing, cache tier osd memroy consumption
will get increasing due to the accumulative pg log which will not be trimmed

Fixes: http://tracker.ceph.com/issues/20464
Fixes: #20464
Signed-off-by: Peng Xie <peng.hse@xtaotech.com>