### PR TITLE
common: add a newline when get version

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -507,7 +507,7 @@ public:
     if (command == "0") {
       out.append(CEPH_ADMIN_SOCK_VERSION);
     } else {
-      JSONFormatter jf;
+      JSONFormatter jf(true);
       jf.open_object_section("version");
       if (command == "version")
 	jf.dump_string("version", ceph_version_to_str());


### PR DESCRIPTION
I get the version info  as follows:
"{"version":"12.0.3-2271-geda363e","release":"luminous","release_type":"dev"}[root@nodeXXX~]#",when the command is “ceph --admin-daemon/var/run/ceph/ceph-mon.nodeXXX.asok version”.
and after fixup as follows:
{
    "version": "12.1.0",
    "release": "luminous",
    "release_type": "dev
}

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>

