### PR TITLE
mon: include device class in tree view; hide shadow hierarchy

### DIFF
--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -150,6 +150,10 @@ namespace CrushTreeDumper {
   inline void dump_item_fields(const CrushWrapper *crush,
 			       const Item &qi, Formatter *f) {
     f->dump_int("id", qi.id);
+    const char *c = crush->get_item_class(qi.id);
+    if (!c)
+      c = "";
+    f->dump_string("device_class", c);
     if (qi.is_bucket()) {
       int type = crush->get_bucket_type(qi.id);
       f->dump_string("name", crush->get_item_name(qi.id));

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -64,7 +64,7 @@ namespace CrushTreeDumper {
   class Dumper : public list<Item> {
   public:
     explicit Dumper(const CrushWrapper *crush_) : crush(crush_) {
-      crush->find_roots(roots);
+      crush->find_nonshadow_roots(roots);
       root = roots.begin();
     }
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -300,6 +300,21 @@ void CrushWrapper::find_roots(set<int>& roots) const
   }
 }
 
+void CrushWrapper::find_nonshadow_roots(set<int>& roots) const
+{
+  for (int i = 0; i < crush->max_buckets; i++) {
+    if (!crush->buckets[i])
+      continue;
+    crush_bucket *b = crush->buckets[i];
+    if (_search_item_exists(b->id))
+      continue;
+    const char *name = get_item_name(b->id);
+    if (name && !is_valid_crush_name(name))
+      continue;
+    roots.insert(b->id);
+  }
+}
+
 bool CrushWrapper::subtree_contains(int root, int item) const
 {
   if (root == item)

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -563,6 +563,14 @@ public:
   void find_roots(set<int>& roots) const;
 
   /**
+   * find tree roots that are not shadow (device class) items
+   *
+   * These are parentless nodes in the map that are not shadow
+   * items for device classes.
+   */
+  void find_nonshadow_roots(set<int>& roots) const;
+
+  /**
    * see if an item is contained within a subtree
    *
    * @param root haystack

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3072,6 +3072,7 @@ public:
 
   void dump(TextTable *tbl) {
     tbl->define_column("ID", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("CLASS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("TYPE NAME", TextTable::LEFT, TextTable::LEFT);
     tbl->define_column("UP/DOWN", TextTable::LEFT, TextTable::RIGHT);
@@ -3089,8 +3090,11 @@ public:
 
 protected:
   void dump_item(const CrushTreeDumper::Item &qi, TextTable *tbl) override {
-
+    const char *c = crush->get_item_class(qi.id);
+    if (!c)
+      c = "";
     *tbl << qi.id
+	 << c
 	 << weightf_t(qi.weight);
 
     ostringstream name;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4071,6 +4071,7 @@ public:
 
   void dump(TextTable *tbl) {
     tbl->define_column("ID", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("CLASS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("SIZE", TextTable::LEFT, TextTable::RIGHT);
@@ -4086,7 +4087,9 @@ public:
 
     dump_stray(tbl);
 
-    *tbl << "" << "" << "TOTAL"
+    *tbl << ""
+	 << ""
+	 << "" << "TOTAL"
 	 << si_t(pgs->get_osd_sum().kb << 10)
 	 << si_t(pgs->get_osd_sum().kb_used << 10)
 	 << si_t(pgs->get_osd_sum().kb_avail << 10)
@@ -4112,7 +4115,11 @@ protected:
 			 double& var,
 			 const size_t num_pgs,
 			 TextTable *tbl) override {
+    const char *c = crush->get_item_class(qi.id);
+    if (!c)
+      c = "";
     *tbl << qi.id
+	 << c
 	 << weightf_t(qi.weight)
 	 << weightf_t(reweight)
 	 << si_t(kb << 10)

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3077,7 +3077,7 @@ public:
     tbl->define_column("TYPE NAME", TextTable::LEFT, TextTable::LEFT);
     tbl->define_column("UP/DOWN", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
-    tbl->define_column("PRIMARY-AFFINITY", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("PRI-AFF", TextTable::LEFT, TextTable::RIGHT);
 
     Parent::dump(tbl);
 

--- a/src/test/cli/osdmaptool/tree.t
+++ b/src/test/cli/osdmaptool/tree.t
@@ -4,16 +4,16 @@
 
   $ osdmaptool --tree=plain om
   osdmaptool: osdmap file 'om'
-  ID WEIGHT  TYPE NAME              UP/DOWN REWEIGHT PRIMARY-AFFINITY 
-  -1 3.00000 root default                                             
-  -3 3.00000     rack localrack                                       
-  -2 3.00000         host localhost                                   
-   0 1.00000             osd.0          DNE        0                  
-   1 1.00000             osd.1          DNE        0                  
-   2 1.00000             osd.2          DNE        0                  
+  ID CLASS WEIGHT  TYPE NAME              UP/DOWN REWEIGHT PRI-AFF 
+  -1       3.00000 root default                                    
+  -3       3.00000     rack localrack                              
+  -2       3.00000         host localhost                          
+   0       1.00000             osd.0          DNE        0         
+   1       1.00000             osd.1          DNE        0         
+   2       1.00000             osd.2          DNE        0         
 
   $ osdmaptool --tree=json om
   osdmaptool: osdmap file 'om'
-  {"nodes":[{"id":-1,"name":"default","type":"root","type_id":10,"children":[-3]},{"id":-3,"name":"localrack","type":"rack","type_id":3,"children":[-2]},{"id":-2,"name":"localhost","type":"host","type_id":1,"children":[2,1,0]},{"id":0,"name":"osd.0","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000},{"id":1,"name":"osd.1","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000},{"id":2,"name":"osd.2","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000}],"stray":[]}
+  {"nodes":[{"id":-1,"device_class":"","name":"default","type":"root","type_id":10,"children":[-3]},{"id":-3,"device_class":"","name":"localrack","type":"rack","type_id":3,"children":[-2]},{"id":-2,"device_class":"","name":"localhost","type":"host","type_id":1,"children":[2,1,0]},{"id":0,"device_class":"","name":"osd.0","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000},{"id":1,"device_class":"","name":"osd.1","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000},{"id":2,"device_class":"","name":"osd.2","type":"osd","type_id":0,"crush_weight":1.000000,"depth":3,"exists":0,"status":"down","reweight":0.000000,"primary_affinity":1.000000}],"stray":[]}
   $ rm -f om
 

--- a/src/test/mon/osd-crush-tree.rng
+++ b/src/test/mon/osd-crush-tree.rng
@@ -14,6 +14,9 @@
       <element name="id">
         <text/>
       </element>
+      <element name="device_class">
+        <text/>
+      </element>
       <element name="name">
         <text/>
       </element>
@@ -34,6 +37,9 @@
   <define name="bucket">
     <element name="bucket">
       <element name="id">
+        <text/>
+      </element>
+      <element name="device_class">
         <text/>
       </element>
       <element name="name">


### PR DESCRIPTION
- Do not show each per-class variation of the hieararchy
- Do include a CLASS column in the tree view