### PR TITLE
osd: we need to make sure superblokc.current_epoch has been equal with current osdmap's epoch

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2457,6 +2457,13 @@ int OSD::init()
 
   {
     epoch_t bind_epoch = osdmap->get_epoch();
+    if (bind_epoch != superblock.current_epoch){
+      derr << "OSD::init: superblock.current_epoch: "
+        << superblock.current_epoch << " but osdmap.epoch: "
+        << bind_epoch << dendl;
+      r = -EINVAL;
+      goto out;
+    }
     service.set_epochs(NULL, NULL, &bind_epoch);
   }
 


### PR DESCRIPTION
  osd: we need to make sure superblokc.current_epoch has been equal with current osdmap's epoch

Signed-off-by: linbing <linbing@t2cloud.net>