### PR TITLE
rgw: Initialize pointer fields

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1722,9 +1722,9 @@ class RGWRequest;
 struct req_state {
   CephContext *cct;
   rgw::io::BasicClient *cio;
-  RGWRequest *req; /// XXX: re-remove??
+  RGWRequest *req{nullptr}; /// XXX: re-remove??
   http_op op;
-  RGWOpType op_type;
+  RGWOpType op_type{};
   bool content_started;
   int format;
   ceph::Formatter *formatter;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -741,7 +741,7 @@ namespace rgw {
   class RGWLibFS
   {
     CephContext* cct;
-    struct rgw_fs fs;
+    struct rgw_fs fs{};
     RGWFileHandle root_fh;
     rgw_fh_callback_t invalidate_cb;
     void *invalidate_arg;

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -242,8 +242,8 @@ WRITE_CLASS_ENCODER(RGWLifecycleConfiguration)
 class RGWLC {
   CephContext *cct;
   RGWRados *store;
-  int max_objs;
-  string *obj_names;
+  int max_objs{0};
+  string *obj_names{nullptr};
   std::atomic<bool> down_flag = { false };
   string cookie;
 

--- a/src/rgw/rgw_lib.h
+++ b/src/rgw/rgw_lib.h
@@ -26,7 +26,7 @@ namespace rgw {
     RGWFrontendConfig* fec;
     RGWLibFrontend* fe;
     OpsLogSocket* olog;
-    rgw::LDAPHelper* ldh;
+    rgw::LDAPHelper* ldh{nullptr};
     RGWREST rest; // XXX needed for RGWProcessEnv
     RGWRados* store;
     boost::intrusive_ptr<CephContext> cct;

--- a/src/rgw/rgw_object_expirer_core.h
+++ b/src/rgw/rgw_object_expirer_core.h
@@ -65,7 +65,7 @@ protected:
     void stop();
   };
 
-  OEWorker *worker;
+  OEWorker *worker{nullptr};
   std::atomic<bool> down_flag = { false };
 
 public:

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2669,7 +2669,7 @@ public:
       } stat_params;
 
       struct ReadParams {
-        rgw_cache_entry_info *cache_info;
+        rgw_cache_entry_info *cache_info{nullptr};
         map<string, bufferlist> *attrs;
 
         ReadParams() : attrs(NULL) {}

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -414,7 +414,7 @@ class RGWReadMDLogEntriesCR : public RGWSimpleCoroutine {
   list<cls_log_entry> *entries;
   bool *truncated;
 
-  RGWAsyncReadMDLogEntries *req;
+  RGWAsyncReadMDLogEntries *req{nullptr};
 
 public:
   RGWReadMDLogEntriesCR(RGWMetaSyncEnv *_sync_env, RGWMetadataLog* mdlog,

--- a/src/rgw/rgw_torrent.h
+++ b/src/rgw/rgw_torrent.h
@@ -96,7 +96,7 @@ private:
 
   string  announce;    // tracker
   string origin; // origin
-  time_t create_date;    // time of the file created
+  time_t create_date{0};    // time of the file created
   string comment;  // comment
   string create_by;    // app name and version
   string encoding;    // if encode use gbk rather than gtf-8 use this field
@@ -104,8 +104,8 @@ private:
   bool is_torrent;  // flag
   bufferlist bl;  // bufflist ready to send
 
-  struct req_state *s;
-  RGWRados *store;
+  struct req_state *s{nullptr};
+  RGWRados *store{nullptr};
   SHA1 h;
 
   TorrentBencode dencode;


### PR DESCRIPTION
This PR Fixes:

```
CID 1402629 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member entries is not initialized in this constructor nor in any functions that it
    calls.
4. uninit_member: Non-static class member max_entries is not initialized in this constructor nor in any functions that it calls.
6. uninit_member: Non-static class member rval is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1396155: Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member req is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1396146 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member max_objs is not initialized in this constructor nor in any functions that it calls.
4. uninit_member: Non-static class member obj_names is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1396116: Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member create_date is not initialized in this constructor
nor in any functions that it calls.
4. uninit_member: Non-static class member s is not initialized in this constructor nor in any
functions that it calls.
6. uninit_member: Non-static class member store is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1353428: Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member cache_info is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1352184: Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member ldh is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1352183: Uninitialized pointer field (UNINIT_CTOR)
4. uninit_member: Non-static class member req is not initialized in this constructor nor in any
functions that it calls.
6. uninit_member: Non-static class member op_type is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1352180 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
2. uninit_member: Non-static class member field fs.rgw is not initialized in this constructor nor in any functions that it calls.
```
```
CID 1351737 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR) 2. uninit_member: Non-static class member worker is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Jos Collin <jcollin@redhat.com>