### PR TITLE
[DNM] rgw, qa: local runner for RadosGW's tasks

### DIFF
--- a/qa/tasks/local_cluster.py
+++ b/qa/tasks/local_cluster.py
@@ -1,0 +1,128 @@
+import contextlib
+import logging
+import os
+
+import vstart_runner
+
+from teuthology import misc as teuthology
+from teuthology import safepath
+from teuthology.orchestra import run
+
+
+class LocalRemote(vstart_runner.LocalRemote):
+    def run(self, args, **kwargs):
+        filtered = []
+        i = 0
+        while i < len(args):
+            if args[i] == 'adjust-ulimits':
+                i += 1
+            elif args[i] == 'ceph-coverage':
+                i += 2
+            elif args[i] == 'timeout':
+                i += 2
+            else:
+                filtered.append(args[i])
+                i += 1
+        return super(LocalRemote, self).run(filtered, **kwargs)
+
+
+class LocalCluster(object):
+    def __init__(self, rolename="placeholder"):
+        self.remotes = {
+            LocalRemote(): ['client.0']
+        }
+
+    def only(self, requested):
+        return self.__class__(rolename=requested)
+
+    def run(self, **kwargs):
+        """
+        Run a command on all the nodes in this cluster.
+
+        Goes through nodes in alphabetical order.
+
+        If you don't specify wait=False, this will be sequentially.
+
+        Returns a list of `RemoteProcess`.
+        """
+        remotes = sorted(self.remotes.iterkeys(), key=lambda rem: rem.name)
+        return [remote.run(**kwargs) for remote in remotes]
+
+
+def setup_one_keyring(cluster_path, remote, role):
+    client_name = teuthology.ceph_role(role)
+    master_keyring_path = \
+        '{cluster_path}/keyring'.format(cluster_path=cluster_path)
+    remote.run(
+        args=[
+            'ceph',
+            'auth',
+            'get-or-create',
+            client_name,
+            'osd', 'allow rwx',
+            'mon', 'allow rwx',
+            run.Raw('&&'),
+            'ceph',
+            'auth',
+            'export',
+            '-o', master_keyring_path,
+            ],
+        )
+
+def setup_keyrings(ctx, cluster_name, cluster_path):
+    """
+    Setup keyrings for all clients
+    """
+    clients = ctx.cluster.only(teuthology.is_type('client', cluster_name))
+    testdir = teuthology.get_testdir(ctx)
+    coverage_dir = '{tdir}/archive/coverage'.format(tdir=testdir)
+    for remote, roles_for_host in clients.remotes.iteritems():
+        for role in teuthology.cluster_roles_of_type(roles_for_host, 'client',
+                                                     cluster_name):
+            setup_one_keyring(cluster_path, remote, role)
+
+@contextlib.contextmanager
+def task(ctx, config):
+    """
+    local_cluster: replacement for initial stages of the Teuthology
+    task's pipeline. Instead of deploying a new Ceph cluster, it
+    exposes a local one.
+
+    Example of config:
+      tasks:
+      - local_cluster:
+          cluster_path: /home/rzarzynski/ceph-1/build
+      - local_rgw:
+      - s3tests:
+          client.0:
+            force-branch: ceph-master
+
+    Example of invocation:
+      $ source ~/teuthology/virtualenv/bin/activate
+      $ python ~/ceph-1/qa/tasks/local_runner.py  --verbose \
+               --suite-path ~/ceph-1/qa /tmp/config.yaml
+
+    Remarks:
+      - RadosGW must be liseting on 7280,
+      - everything is a very, very early PoC.
+    """
+    # we need to update the PATH variable to let shell find binaries
+    # of a cluster deployed with vstart.sh
+    try:
+      cluster_bin_dir = config['cluster_path'] + os.sep + 'bin'
+    except TypeError:
+        raise ValueError("the mandatory cluster_path is undefined")
+    os.environ['PATH'] += os.pathsep + cluster_bin_dir
+
+    # create the test hierarchy. It defaults to /home/ubuntu/cephtest,
+    # be ready for EACCESS here
+    safepath.makedirs('/', teuthology.get_testdir(ctx))
+
+    # create the archive space. /home/ubuntu/cephtest/archihve by default
+    safepath.makedirs('/', teuthology.get_archive_dir(ctx))
+
+    ctx.cluster = LocalCluster()
+
+    # let's provision credentials for clients
+    setup_keyrings(ctx, 'ceph', config['cluster_path'])
+    yield

--- a/qa/tasks/local_rgw.py
+++ b/qa/tasks/local_rgw.py
@@ -1,0 +1,24 @@
+import argparse
+import contextlib
+
+def assign_ports(ctx, config):
+    """
+    Assign port numberst starting with port 7280.
+    """
+    port = 8000
+    role_endpoints = {}
+    for remote, roles_for_host in ctx.cluster.remotes.iteritems():
+        for role in roles_for_host:
+            if role in config:
+                role_endpoints[role] = (remote.name.split('@')[1], port)
+                port += 1
+
+    return role_endpoints
+
+@contextlib.contextmanager
+def task(ctx, config):
+    ctx.rgw = argparse.Namespace()
+    #role_endpoints = assign_ports(ctx, config)
+    #ctx.rgw.role_endpoints = role_endpoints
+    ctx.rgw.use_fastcgi = True
+    yield

--- a/qa/tasks/local_runner.py
+++ b/qa/tasks/local_runner.py
@@ -1,0 +1,80 @@
+"""
+usage: local_runner.py --help
+       local_runner.py --version
+       local_runner.py [options] [--] <config>...
+
+Run ceph integration tests against a local, vstart-deployed Ceph cluster
+
+positional arguments:
+  <config> one or more config files to read
+
+optional arguments:
+  -h, --help                     show this help message and exit
+  -v, --verbose                  be more verbose
+  --version                      the current installed version of teuthology
+  -a DIR, --archive DIR          path to archive results in
+  --suite-path SUITE_PATH        Location of ceph-qa-suite on disk. If not specified,
+                                 it will be fetched
+"""
+
+import docopt
+import logging
+import yaml
+
+from teuthology.run import set_up_logging
+from teuthology.run import setup_config
+from teuthology.run import validate_tasks
+from teuthology.run import fetch_tasks_if_needed
+
+from teuthology.config import FakeNamespace
+
+from teuthology.run_tasks import run_tasks
+
+log = logging.getLogger(__name__)
+log.setLevel(logging.DEBUG)
+
+def main(args):
+    verbose = args["--verbose"]
+    archive = args["--archive"]
+    # someone could provide a path to already fetched tasks
+    suite_path = args["--suite-path"]
+
+    set_up_logging(verbose, archive)
+
+    # print the command being ran
+    log.debug("Starting local_runner of Teuthology")
+
+    config = setup_config(args["<config>"])
+    config["tasks"] = validate_tasks(config)
+
+    if suite_path is not None:
+        config['suite_path'] = suite_path
+
+    log.debug(
+        '\n  '.join(['Config:', ] + yaml.safe_dump(
+            config, default_flow_style=False).splitlines()))
+
+    # fetches the tasks and returns a new suite_path if needed
+    config["suite_path"] = fetch_tasks_if_needed(config)
+
+    # create a FakeNamespace instance that mimics the old argparse way of doing
+    # things we do this so we can pass it to run_tasks without porting those
+    # tasks to the new way of doing things right now
+    args["<config>"] = config
+    fake_ctx = FakeNamespace(args)
+
+    # store on global config if interactive-on-error, for contextutil.nested()
+    # FIXME this should become more generic, and the keys should use
+    # '_' uniformly
+    if fake_ctx.config.get('interactive-on-error'):
+        teuthology.config.config.ctx = fake_ctx
+
+    try:
+        run_tasks(tasks=config['tasks'], ctx=fake_ctx)
+    finally:
+        pass
+
+
+if __name__ == "__main__":
+    args = docopt.docopt(__doc__, version="0.0")
+    main(args)

--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -231,8 +231,8 @@ def run_tests(ctx, config):
     attrs = ["!fails_on_rgw"]
     for client, client_config in config.iteritems():
         args = [
-            'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),
-            'BOTO_CONFIG={tdir}/boto.cfg'.format(tdir=testdir),
+            run.Raw('S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client)),
+            run.Raw('BOTO_CONFIG={tdir}/boto.cfg'.format(tdir=testdir)),
             '{tdir}/s3-tests/virtualenv/bin/nosetests'.format(tdir=testdir),
             '-w',
             '{tdir}/s3-tests'.format(tdir=testdir),


### PR DESCRIPTION
This is an extremely early PoC of local runner for (RadosGW's) QA tasks against a cluster deployed by `vstart.sh`. At the moment it can run `s3tests` only. Maybe it will can do more in the future.

For the usage instruction please consult `tasks.local_cluster.task.__doc__`.

CC: @yehudasa, @mattbenjamin, @cbodley.