### PR TITLE
systemd/ceph-mgr: remove automagic mgr creation hack

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -326,10 +326,10 @@ Upgrade from Jewel or Kraken
 
      # systemctl ceph-mgr.target
 
-   If you are upgrading from jewel, you should have new ceph-mgr daemons
-   automatically appear on the same hosts as the ceph-mon daemons.  If not,
-   you can deploy new daemons with tools like ceph-deploy or ceph-ansible.  For
-   example,::
+   If you are upgrading from kraken, you may already have ceph-mgr
+   daemons deployed.  If not, or if you are upgrading from jewel, you
+   can deploy new daemons with tools like ceph-deploy or ceph-ansible.
+   For example,::
 
      # ceph-deploy mgr create HOST
 

--- a/systemd/ceph-mgr@.service
+++ b/systemd/ceph-mgr@.service
@@ -1,26 +1,14 @@
 [Unit]
 Description=Ceph cluster manager daemon
-After=network-online.target local-fs.target time-sync.target ceph-mon@%i.service
+After=network-online.target local-fs.target time-sync.target
 Wants=network-online.target local-fs.target time-sync.target
-PartOf=ceph-mgr.target ceph-mon@%i.service
+PartOf=ceph-mgr.target
 
 [Service]
 LimitNOFILE=1048576
 LimitNPROC=1048576
 EnvironmentFile=-/etc/sysconfig/ceph
 Environment=CLUSTER=ceph
-
-# This ExecStartPre business is a hack to inject a key for the mgr daemon,
-# using whatever key already exists on the mon on this node to gain sufficient
-# permissions to create the mgr key.  Failure is ignored at every step (the
-# '-' prefix) in case someone has already used some other trick to set
-# everything up manually.
-# `sh -c "exec ..."` is required, since different Linux ditributives have different rules on absolute paths of that executables.
-# systemd requires to use absoulte paths.
-ExecStartPre=-/bin/sh -c "exec mkdir -p /var/lib/ceph/mgr/${CLUSTER}-%i"
-ExecStartPre=-/bin/sh -c "[ -f /var/lib/ceph/mgr/${CLUSTER}-%i/keyring ] || /usr/bin/ceph-authtool --create-keyring --gen-key --name=mgr.%i /var/lib/ceph/mgr/${CLUSTER}-%i/keyring"
-ExecStartPre=-/bin/sh -c "exec chown -R ceph.ceph /var/lib/ceph/mgr/${CLUSTER}-%i"
-ExecStartPre=-/usr/bin/ceph -i /var/lib/ceph/mgr/${CLUSTER}-%i/keyring auth add mgr.%i mon 'allow profile mgr' osd 'allow *' mds 'allow *' --keyring=/var/lib/ceph/mon/${CLUSTER}-%i/keyring --name=mon.
 
 ExecStart=/usr/bin/ceph-mgr -f --cluster ${CLUSTER} --id %i --setuser ceph --setgroup ceph
 ExecReload=/bin/kill -HUP $MAINPID

--- a/systemd/ceph-mon@.service
+++ b/systemd/ceph-mon@.service
@@ -6,7 +6,7 @@ Description=Ceph cluster monitor daemon
 # these can be removed once ceph-mon will dynamically change network
 # configuration.
 After=network-online.target local-fs.target time-sync.target
-Wants=network-online.target local-fs.target time-sync.target ceph-mgr@%i.service
+Wants=network-online.target local-fs.target time-sync.target
 
 PartOf=ceph-mon.target
 


### PR DESCRIPTION
For kraken we auto-created mgr daemons next to mon daemons with some
systemd hackery.  This is awkward (you can't not get a new mgr daemon when
you deploy a mon), systemd-specific (not implemented for upstart on
trusty), and mostly unexpected.  Since ceph-mgr daemons are now first-class
citizens and required for every cluster, make their deployment explicit
and transparent to the administrator.  Major upgrades are a rare
opportunity to have the administrator's full attention so take advantage
of it.

This effectively reverts 61d779345e9efbe9a2e3f215af1f1dcf6630f04a and
082199f69dd0bd4c18a5f4baea67a88782586657 (and follow-on fixes).

Fixes/avoids: http://tracker.ceph.com/issues/19994
Signed-off-by: Sage Weil <sage@redhat.com>