### PR TITLE
mon: do crushtool test with fork and timeout, but w/o exec of crushtool

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -28,7 +28,6 @@ OPTION(lockdep_force_backtrace, OPT_BOOL, false) // always gather current backtr
 OPTION(run_dir, OPT_STR, "/var/run/ceph")       // the "/var/run/ceph" dir, created on daemon startup
 OPTION(admin_socket, OPT_STR, "$run_dir/$cluster-$name.asok") // default changed by common_preinit()
 OPTION(admin_socket_mode, OPT_STR, "") // permission bits to set for admin socket file, e.g., "0775", "0755"
-OPTION(crushtool, OPT_STR, "crushtool") // crushtool utility path
 
 OPTION(daemonize, OPT_BOOL, false) // default changed by common_preinit()
 OPTION(setuser, OPT_STR, "")        // uid or user name

--- a/src/common/fork_function.h
+++ b/src/common/fork_function.h
@@ -1,0 +1,146 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+// Run a function in a forked child, with a timeout.
+
+#pragma once
+
+#include <functional>
+#include <signal.h>
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <common/errno.h>
+#include <ostream>
+#include "common/errno.h"
+
+static void _fork_function_dummy_sighandler(int sig) {}
+
+// Run a function post-fork, with a timeout.  Function can return
+// int8_t only due to unix exit code limitations.  Returns -ETIMEDOUT
+// if timeout is reached.
+
+static inline int fork_function(
+  int timeout,
+  std::ostream& errstr,
+  std::function<int8_t(void)> f)
+{
+  // first fork the forker.
+  pid_t forker_pid = fork();
+  if (forker_pid) {
+    // just wait
+    int status;
+    while (waitpid(forker_pid, &status, 0) == -1) {
+      assert(errno == EINTR);
+    }
+    if (WIFSIGNALED(status)) {
+      errstr << ": got signal: " << WTERMSIG(status) << "\n";
+      return 128 + WTERMSIG(status);
+    }
+    if (WIFEXITED(status)) {
+      int8_t r = WEXITSTATUS(status);
+      errstr << ": exit status: " << (int)r << "\n";
+      return r;
+    }
+    errstr << ": waitpid: unknown status returned\n";
+    return -1;
+  }
+
+  // we are forker (first child)
+  sigset_t mask, oldmask;
+  int pid;
+
+  // Restore default action for SIGTERM in case the parent process decided
+  // to ignore it.
+  if (signal(SIGTERM, SIG_DFL) == SIG_ERR) {
+    std::cerr << ": signal failed: " << cpp_strerror(errno) << "\n";
+    goto fail_exit;
+  }
+  // Because SIGCHLD is ignored by default, setup dummy handler for it,
+  // so we can mask it.
+  if (signal(SIGCHLD, _fork_function_dummy_sighandler) == SIG_ERR) {
+    std::cerr << ": signal failed: " << cpp_strerror(errno) << "\n";
+    goto fail_exit;
+  }
+  // Setup timeout handler.
+  if (signal(SIGALRM, timeout_sighandler) == SIG_ERR) {
+    std::cerr << ": signal failed: " << cpp_strerror(errno) << "\n";
+    goto fail_exit;
+  }
+  // Block interesting signals.
+  sigemptyset(&mask);
+  sigaddset(&mask, SIGINT);
+  sigaddset(&mask, SIGTERM);
+  sigaddset(&mask, SIGCHLD);
+  sigaddset(&mask, SIGALRM);
+  if (sigprocmask(SIG_SETMASK, &mask, &oldmask) == -1) {
+    std::cerr << ": sigprocmask failed: "
+	      << cpp_strerror(errno) << "\n";
+    goto fail_exit;
+  }
+
+  pid = fork();
+
+  if (pid == -1) {
+    std::cerr << ": fork failed: " << cpp_strerror(errno) << "\n";
+    goto fail_exit;
+  }
+
+  if (pid == 0) { // we are second child
+    // Restore old sigmask.
+    if (sigprocmask(SIG_SETMASK, &oldmask, NULL) == -1) {
+      std::cerr << ": sigprocmask failed: "
+		<< cpp_strerror(errno) << "\n";
+      goto fail_exit;
+    }
+    (void)setpgid(0, 0); // Become process group leader.
+    int8_t r = f();
+    _exit((uint8_t)r);
+  }
+
+  // Parent
+  (void)alarm(timeout);
+
+  for (;;) {
+    int signo;
+    if (sigwait(&mask, &signo) == -1) {
+      std::cerr << ": sigwait failed: " << cpp_strerror(errno) << "\n";
+      goto fail_exit;
+    }
+    switch (signo) {
+    case SIGCHLD:
+      int status;
+      if (waitpid(pid, &status, WNOHANG) == -1) {
+	std::cerr << ": waitpid failed: " << cpp_strerror(errno) << "\n";
+	goto fail_exit;
+      }
+      if (WIFEXITED(status))
+	_exit(WEXITSTATUS(status));
+      if (WIFSIGNALED(status))
+	_exit(128 + WTERMSIG(status));
+      std::cerr << ": unknown status returned\n";
+      goto fail_exit;
+    case SIGINT:
+    case SIGTERM:
+      // Pass SIGINT and SIGTERM, which are usually used to terminate
+      // a process, to the child.
+      if (::kill(pid, signo) == -1) {
+	std::cerr << ": kill failed: " << cpp_strerror(errno) << "\n";
+	goto fail_exit;
+      }
+      continue;
+    case SIGALRM:
+      std::cerr << ": timed out (" << timeout << " sec)\n";
+      if (::killpg(pid, SIGKILL) == -1) {
+	std::cerr << ": kill failed: " << cpp_strerror(errno) << "\n";
+	goto fail_exit;
+      }
+      _exit(-ETIMEDOUT);
+    default:
+      std::cerr << ": sigwait: invalid signal: " << signo << "\n";
+      goto fail_exit;
+    }
+  }
+  return 0;
+fail_exit:
+  _exit(EXIT_FAILURE);
+}

--- a/src/common/fork_function.h
+++ b/src/common/fork_function.h
@@ -46,6 +46,21 @@ static inline int fork_function(
   }
 
   // we are forker (first child)
+
+  // close all fds
+  int maxfd = sysconf(_SC_OPEN_MAX);
+  if (maxfd == -1)
+    maxfd = 16384;
+  for (int fd = 0; fd <= maxfd; fd++) {
+    if (fd == STDIN_FILENO)
+      continue;
+    if (fd == STDOUT_FILENO)
+      continue;
+    if (fd == STDERR_FILENO)
+      continue;
+    ::close(fd);
+  }
+
   sigset_t mask, oldmask;
   int pid;
 

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -19,6 +19,7 @@
 #include <boost/icl/interval_map.hpp>
 #include <boost/algorithm/string/join.hpp>
 #include "common/SubProcess.h"
+#include "common/fork_function.h"
 
 void CrushTester::set_device_weight(int dev, float f)
 {
@@ -357,6 +358,18 @@ void CrushTester::write_integer_indexed_scalar_data_string(vector<string> &dst, 
 
   // write the data buffer to the destination
   dst.push_back( data_buffer.str() );
+}
+
+int CrushTester::test_with_fork(int timeout)
+{
+  ostringstream sink;
+  int r = fork_function(timeout, sink, [&]() {
+      return test();
+    });
+  if (r == -ETIMEDOUT) {
+    err << "timed out during smoke test (" << timeout << " seconds)";
+  }
+  return r;
 }
 
 int CrushTester::test_with_crushtool(const char *crushtool_cmd,

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -358,6 +358,7 @@ public:
    */
   void check_overlapped_rules() const;
   int test();
+  int test_with_fork(int timeout);
   int test_with_crushtool(const char *crushtool_cmd = "crushtool",
 			  int max_id = -1,
 			  int timeout = 0,

--- a/src/crush/CrushTester.h
+++ b/src/crush/CrushTester.h
@@ -359,10 +359,6 @@ public:
   void check_overlapped_rules() const;
   int test();
   int test_with_fork(int timeout);
-  int test_with_crushtool(const char *crushtool_cmd = "crushtool",
-			  int max_id = -1,
-			  int timeout = 0,
-			  int ruleset = -1);
 };
 
 #endif

--- a/src/test/test_subprocess.cc
+++ b/src/test/test_subprocess.cc
@@ -21,6 +21,7 @@
 #include "common/SubProcess.h"
 #include "common/safe_io.h"
 #include "gtest/gtest.h"
+#include "common/fork_function.h"
 
 bool read_from_fd(int fd, std::string &out) {
   out.clear();
@@ -265,4 +266,28 @@ TEST(SubProcessTimed, SubshellTimedout)
   ASSERT_EQ(sh.join(), 128 + SIGTERM);
   std::cerr << "err: " << sh.err() << std::endl;
   ASSERT_FALSE(sh.err().c_str()[0] == '\0');
+}
+
+TEST(fork_function, normal)
+{
+  ASSERT_EQ(0, fork_function(10, std::cerr, [&]() { return 0; }));
+  ASSERT_EQ(1, fork_function(10, std::cerr, [&]() { return 1; }));
+  ASSERT_EQ(13, fork_function(10, std::cerr, [&]() { return 13; }));
+  ASSERT_EQ(-1, fork_function(10, std::cerr, [&]() { return -1; }));
+  ASSERT_EQ(-13, fork_function(10, std::cerr, [&]() { return -13; }));
+  ASSERT_EQ(-ETIMEDOUT,
+	    fork_function(10, std::cerr, [&]() { return -ETIMEDOUT; }));
+}
+
+TEST(fork_function, timeout)
+{
+  ASSERT_EQ(-ETIMEDOUT, fork_function(2, std::cerr, [&]() {
+	sleep(60);
+	return 0; }));
+  ASSERT_EQ(-ETIMEDOUT, fork_function(2, std::cerr, [&]() {
+	sleep(60);
+	return 1; }));
+  ASSERT_EQ(-ETIMEDOUT, fork_function(2, std::cerr, [&]() {
+	sleep(60);
+	return -111; }));
 }


### PR DESCRIPTION
This basically copies the Subprocess hackery for the timeout of the forked
subprocess, but operates on a lamba (in this case, CrushTester::test()) instead
of running crushtool via exec(2).