### PR TITLE
rgw: cls: ceph::timespan tag_timeout wrong units

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1875,7 +1875,9 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
     return rc;
   }
 
-  timespan tag_timeout(header.tag_timeout ? header.tag_timeout : CEPH_RGW_TAG_TIMEOUT);
+  timespan tag_timeout(
+    std::chrono::seconds(
+      header.tag_timeout ? header.tag_timeout : CEPH_RGW_TAG_TIMEOUT));
 
   bufferlist::iterator in_iter = in->begin();
 


### PR DESCRIPTION
In rgw_dir_suggest(), the ceph::timespan tag_timeout is intended
to be a value in seconds, but has been taken as something much
smaller (millis?).  The incorrect time scale likely induces a race
condition with object deletes.

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>