### PR TITLE
mon,crush: create crush rules using device classes for replicated and ec pools via cli

### DIFF
--- a/doc/dev/erasure-coded-pool.rst
+++ b/doc/dev/erasure-coded-pool.rst
@@ -60,13 +60,13 @@ Set up an erasure-coded pool and the associated crush ruleset::
 Set the ruleset failure domain to osd (instead of the host which is the default)::
 
  $ ceph osd erasure-code-profile set myprofile \
-     ruleset-failure-domain=osd
+     crush-failure-domain=osd
  $ ceph osd erasure-code-profile get myprofile
  k=2
  m=1
  plugin=jerasure
  technique=reed_sol_van
- ruleset-failure-domain=osd
+ crush-failure-domain=osd
  $ ceph osd pool create ecpool 12 12 erasure myprofile
 
 Control the parameters of the erasure code plugin::
@@ -127,11 +127,11 @@ Remove a profile that is no longer in use (otherwise it will fail with EBUSY)::
 Set the ruleset to take ssd (instead of default)::
 
  $ ceph osd erasure-code-profile set myprofile \
-     ruleset-root=ssd
+     crush-root=ssd
  $ ceph osd erasure-code-profile get myprofile
  k=2
  m=1
  plugin=jerasure
  technique=reed_sol_van
- ruleset-root=ssd
+ crush-root=ssd
 

--- a/doc/dev/osd_internals/erasure_coding/developer_notes.rst
+++ b/doc/dev/osd_internals/erasure_coding/developer_notes.rst
@@ -166,14 +166,14 @@ key=value pairs stored in an `erasure code profile`_.
 ::
  
  $ ceph osd erasure-code-profile set myprofile \
-     ruleset-failure-domain=osd
+     crush-failure-domain=osd
  $ ceph osd erasure-code-profile get myprofile
  directory=/usr/lib/ceph/erasure-code
  k=2
  m=1
  plugin=jerasure
  technique=reed_sol_van
- ruleset-failure-domain=osd
+ crush-failure-domain=osd
  $ ceph osd pool create ecpool 12 12 erasure myprofile
 
 The *plugin* is dynamically loaded from *directory*  and expected to

--- a/doc/rados/operations/erasure-code-isa.rst
+++ b/doc/rados/operations/erasure-code-isa.rst
@@ -16,8 +16,9 @@ To create a new *isa* erasure code profile::
              technique={reed_sol_van|cauchy} \
              [k={data-chunks}] \
              [m={coding-chunks}] \
-             [ruleset-root={root}] \
-             [ruleset-failure-domain={bucket-type}] \
+             [crush-root={root}] \
+             [crush-failure-domain={bucket-type}] \
+             [crush-device-class={device-class}] \
              [directory={directory}] \
              [--force]
 
@@ -55,7 +56,7 @@ Where:
 :Required: No.
 :Default: reed_sol_van
 
-``ruleset-root={root}``
+``crush-root={root}``
 
 :Description: The name of the crush bucket used for the first step of
               the ruleset. For intance **step take default**.
@@ -64,7 +65,7 @@ Where:
 :Required: No.
 :Default: default
 
-``ruleset-failure-domain={bucket-type}``
+``crush-failure-domain={bucket-type}``
 
 :Description: Ensure that no two chunks are in a bucket with the same
               failure domain. For instance, if the failure domain is
@@ -75,6 +76,16 @@ Where:
 :Type: String
 :Required: No.
 :Default: host
+
+``crush-device-class={device-class}``
+
+:Description: Restrict placement to devices of a specific class (e.g.,
+              ``ssd`` or ``hdd``), using the crush device class names
+              in the CRUSH map.
+
+:Type: String
+:Required: No.
+:Default:
 
 ``directory={directory}``
 

--- a/doc/rados/operations/erasure-code-jerasure.rst
+++ b/doc/rados/operations/erasure-code-jerasure.rst
@@ -20,8 +20,9 @@ To create a new *jerasure* erasure code profile::
              k={data-chunks} \
              m={coding-chunks} \
              technique={reed_sol_van|reed_sol_r6_op|cauchy_orig|cauchy_good|liberation|blaum_roth|liber8tion} \
-             [ruleset-root={root}] \
-             [ruleset-failure-domain={bucket-type}] \
+             [crush-root={root}] \
+             [crush-failure-domain={bucket-type}] \
+             [crush-device-class={device-class}] \
              [directory={directory}] \
              [--force]
 
@@ -70,7 +71,7 @@ Where:
 :Required: No.
 :Default: 2048
 
-``ruleset-root={root}``
+``crush-root={root}``
 
 :Description: The name of the crush bucket used for the first step of
               the ruleset. For intance **step take default**.
@@ -79,7 +80,7 @@ Where:
 :Required: No.
 :Default: default
 
-``ruleset-failure-domain={bucket-type}``
+``crush-failure-domain={bucket-type}``
 
 :Description: Ensure that no two chunks are in a bucket with the same
               failure domain. For instance, if the failure domain is
@@ -91,7 +92,17 @@ Where:
 :Required: No.
 :Default: host
 
-``directory={directory}``
+``crush-device-class={device-class}``
+
+:Description: Restrict placement to devices of a specific class (e.g.,
+              ``ssd`` or ``hdd``), using the crush device class names
+              in the CRUSH map.
+
+:Type: String
+:Required: No.
+:Default:
+
+ ``directory={directory}``
 
 :Description: Set the **directory** name from which the erasure code
               plugin is loaded.

--- a/doc/rados/operations/erasure-code-lrc.rst
+++ b/doc/rados/operations/erasure-code-lrc.rst
@@ -27,7 +27,7 @@ observed.::
         $ ceph osd erasure-code-profile set LRCprofile \
              plugin=lrc \
              k=4 m=2 l=3 \
-             ruleset-failure-domain=host
+             crush-failure-domain=host
         $ ceph osd pool create lrcpool 12 12 erasure LRCprofile
 
 
@@ -40,8 +40,8 @@ OSD is in the same rack as the lost chunk.::
         $ ceph osd erasure-code-profile set LRCprofile \
              plugin=lrc \
              k=4 m=2 l=3 \
-             ruleset-locality=rack \
-             ruleset-failure-domain=host
+             crush-locality=rack \
+             crush-failure-domain=host
         $ ceph osd pool create lrcpool 12 12 erasure LRCprofile
 
 
@@ -55,9 +55,10 @@ To create a new lrc erasure code profile::
              k={data-chunks} \
              m={coding-chunks} \
              l={locality} \
-             [ruleset-root={root}] \
-             [ruleset-locality={bucket-type}] \
-             [ruleset-failure-domain={bucket-type}] \
+             [crush-root={root}] \
+             [crush-locality={bucket-type}] \
+             [crush-failure-domain={bucket-type}] \
+             [crush-device-class={device-class}] \
              [directory={directory}] \
              [--force]
 
@@ -94,7 +95,7 @@ Where:
 :Required: Yes.
 :Example: 3
 
-``ruleset-root={root}``
+``crush-root={root}``
 
 :Description: The name of the crush bucket used for the first step of
               the ruleset. For intance **step take default**.
@@ -103,7 +104,7 @@ Where:
 :Required: No.
 :Default: default
 
-``ruleset-locality={bucket-type}``
+``crush-locality={bucket-type}``
 
 :Description: The type of the crush bucket in which each set of chunks
               defined by **l** will be stored. For instance, if it is
@@ -115,7 +116,7 @@ Where:
 :Type: String
 :Required: No.
 
-``ruleset-failure-domain={bucket-type}``
+``crush-failure-domain={bucket-type}``
 
 :Description: Ensure that no two chunks are in a bucket with the same
               failure domain. For instance, if the failure domain is
@@ -126,6 +127,16 @@ Where:
 :Type: String
 :Required: No.
 :Default: host
+
+``crush-device-class={device-class}``
+
+:Description: Restrict placement to devices of a specific class (e.g.,
+              ``ssd`` or ``hdd``), using the crush device class names
+              in the CRUSH map.
+
+:Type: String
+:Required: No.
+:Default:
 
 ``directory={directory}``
 
@@ -220,7 +231,7 @@ OSD is in the same rack as the lost chunk.::
                        [ "cDDD____", "" ],
                        [ "____cDDD", "" ],
                      ]' \
-             ruleset-steps='[
+             crush-steps='[
                              [ "choose", "rack", 2 ],
                              [ "chooseleaf", "host", 4 ],
                             ]'
@@ -351,7 +362,7 @@ racks.
 
 For instance::
 
-   ruleset-steps='[ [ "choose", "rack", 2 ], [ "chooseleaf", "host", 4 ] ]'
+   crush-steps='[ [ "choose", "rack", 2 ], [ "chooseleaf", "host", 4 ] ]'
 
 will create a ruleset that will select two crush buckets of type
 *rack* and for each of them choose four OSDs, each of them located in

--- a/doc/rados/operations/erasure-code-shec.rst
+++ b/doc/rados/operations/erasure-code-shec.rst
@@ -16,8 +16,9 @@ To create a new *shec* erasure code profile::
              [k={data-chunks}] \
              [m={coding-chunks}] \
              [c={durability-estimator}] \
-             [ruleset-root={root}] \
-             [ruleset-failure-domain={bucket-type}] \
+             [crush-root={root}] \
+             [crush-failure-domain={bucket-type}] \
+             [crush-device-class={device-class}] \
              [directory={directory}] \
              [--force]
 
@@ -52,7 +53,7 @@ Where:
 :Required: No.
 :Default: 2
 
-``ruleset-root={root}``
+``crush-root={root}``
 
 :Description: The name of the crush bucket used for the first step of
               the ruleset. For intance **step take default**.
@@ -61,7 +62,7 @@ Where:
 :Required: No.
 :Default: default
 
-``ruleset-failure-domain={bucket-type}``
+``crush-failure-domain={bucket-type}``
 
 :Description: Ensure that no two chunks are in a bucket with the same
               failure domain. For instance, if the failure domain is
@@ -72,6 +73,16 @@ Where:
 :Type: String
 :Required: No.
 :Default: host
+
+``crush-device-class={device-class}``
+
+:Description: Restrict placement to devices of a specific class (e.g.,
+              ``ssd`` or ``hdd``), using the crush device class names
+              in the CRUSH map.
+
+:Type: String
+:Required: No.
+:Default:
 
 ``directory={directory}``
 
@@ -129,5 +140,5 @@ Erasure code profile examples
         $ ceph osd erasure-code-profile set SHECprofile \
              plugin=shec \
              k=8 m=4 c=3 \
-             ruleset-failure-domain=host
+             crush-failure-domain=host
         $ ceph osd pool create shecpool 256 256 erasure SHECprofile

--- a/doc/rados/operations/erasure-code.rst
+++ b/doc/rados/operations/erasure-code.rst
@@ -37,7 +37,7 @@ displayed with::
     k=2
     m=1
     plugin=jerasure
-    ruleset-failure-domain=host
+    crush-failure-domain=host
     technique=reed_sol_van
 
 Choosing the right profile is important because it cannot be modified
@@ -45,7 +45,7 @@ after the pool is created: a new pool with a different profile needs
 to be created and all objects from the previous pool moved to the new.
 
 The most important parameters of the profile are *K*, *M* and
-*ruleset-failure-domain* because they define the storage overhead and
+*crush-failure-domain* because they define the storage overhead and
 the data durability. For instance, if the desired architecture must
 sustain the loss of two racks with a storage overhead of 40% overhead,
 the following profile can be defined::
@@ -53,7 +53,7 @@ the following profile can be defined::
     $ ceph osd erasure-code-profile set myprofile \
        k=3 \
        m=2 \
-       ruleset-failure-domain=rack
+       crush-failure-domain=rack
     $ ceph osd pool create ecpool 12 12 erasure myprofile
     $ echo ABCDEFGHI | rados --pool ecpool put NYAN -
     $ rados --pool ecpool get NYAN -
@@ -62,7 +62,7 @@ the following profile can be defined::
 The *NYAN* object will be divided in three (*K=3*) and two additional
 *chunks* will be created (*M=2*). The value of *M* defines how many
 OSD can be lost simultaneously without losing any data. The
-*ruleset-failure-domain=rack* will create a CRUSH ruleset that ensures
+*crush-failure-domain=rack* will create a CRUSH ruleset that ensures
 no two *chunks* are stored in the same rack.
 
 .. ditaa::

--- a/doc/rados/operations/pools.rst
+++ b/doc/rados/operations/pools.rst
@@ -57,9 +57,9 @@ For example::
 To create a pool, execute:: 
 
 	ceph osd pool create {pool-name} {pg-num} [{pgp-num}] [replicated] \
-             [crush-ruleset-name] [expected-num-objects]
+             [crush-rule-name] [expected-num-objects]
 	ceph osd pool create {pool-name} {pg-num}  {pgp-num}   erasure \
-             [erasure-code-profile] [crush-ruleset-name] [expected_num_objects]
+             [erasure-code-profile] [crush-rule-name] [expected_num_objects]
 
 Where: 
 
@@ -104,10 +104,10 @@ Where:
 :Required: No. 
 :Default: replicated
 
-``[crush-ruleset-name]``
+``[crush-rule-name]``
 
-:Description: The name of a CRUSH ruleset to use for this pool.  The specified
-              ruleset must exist.
+:Description: The name of a CRUSH rule to use for this pool.  The specified
+              rule must exist.
 
 :Type: String
 :Required: No. 

--- a/doc/rados/troubleshooting/troubleshooting-pg.rst
+++ b/doc/rados/troubleshooting/troubleshooting-pg.rst
@@ -516,7 +516,7 @@ ruleset::
 You can resolve the problem by creating a new pool in which PGs are allowed
 to have OSDs residing on the same host with::
 
-     ceph osd erasure-code-profile set myprofile ruleset-failure-domain=osd
+     ceph osd erasure-code-profile set myprofile crush-failure-domain=osd
      ceph osd pool create erasurepool 16 16 erasure myprofile
 
 CRUSH gives up too soon

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -309,6 +309,8 @@ Upgrade from Jewel or Kraken
 #. Make sure your cluster is stable and healthy (no down or
    recoverying OSDs).  (Optional, but recommended.)
 
+#. Do not create any new erasure-code pools while upgrading the monitors.
+
 #. Set the ``noout`` flag for the duration of the upgrade. (Optional
    but recommended.)::
 
@@ -409,6 +411,15 @@ Upgrade compatibility notes, Kraken to Luminous
   The code is mature and unlikely to change, but we are only
   continuing to test the Jewel stable branch against btrfs.  We
   recommend moving these OSDs to FileStore with XFS or BlueStore.
+* The ``ruleset-*`` properties for the erasure code profiles have been
+  renamed to ``crush-*`` to (1) move away from the obsolete 'ruleset'
+  term and to be more clear about their purpose.  There is also a new
+  optional ``crush-device-class`` property to specify a CRUSH device
+  class to use for the erasure coded pool.  Existing erasure code
+  profiles will be converted automatically when upgrade completes
+  (when the ``ceph osd require-osd-release luminous`` command is run)
+  but any provisioning tools that create erasure coded pools may need
+  to be updated.
 * When assigning a network to the public network and not to
   the cluster network the network specification of the public
   network will be used for the cluster network as well.

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -224,9 +224,14 @@ Major Changes from Kraken
     - ``ceph osd reweightn`` will specify the `reweight` values for
       multiple OSDs in a single command.  This is equivalent to a series of
       ``ceph osd reweight`` commands.
-    - ``ceph crush class {create,rm,ls,rename}`` manage the new CRUSH *device
-      class* feature.  ``ceph crush set-device-class <osd> <class>``
-      will set the class for a particular device.
+    - ``ceph osd crush class {create,rm,ls,rename}`` manage the new
+      CRUSH *device class* feature.  ``ceph crush set-device-class
+      <osd> <class>`` will set the class for a particular device.
+    - ``ceph osd crush rule create-replicated`` replaces the old
+      ``ceph osd crush rule create-simple`` command to create a CRUSH
+      rule for a replicated pool.  Notably it takes a `class` argument
+      for the *device class* the rule should target (e.g., `ssd` or
+      `hdd`).
     - ``ceph mon feature ls`` will list monitor features recorded in the
       MonMap.  ``ceph mon feature set`` will set an optional feature (none of
       these exist yet).

--- a/qa/erasure-code/ec-rados-plugin=isa-k=2-m=1.yaml
+++ b/qa/erasure-code/ec-rados-plugin=isa-k=2-m=1.yaml
@@ -12,7 +12,7 @@ tasks:
       k: 2
       m: 1
       technique: reed_sol_van
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/erasure-code/ec-rados-plugin=jerasure-k=2-m=1.yaml
+++ b/qa/erasure-code/ec-rados-plugin=jerasure-k=2-m=1.yaml
@@ -11,7 +11,7 @@ tasks:
       k: 2
       m: 1
       technique: reed_sol_van
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/erasure-code/ec-rados-plugin=jerasure-k=3-m=1.yaml
+++ b/qa/erasure-code/ec-rados-plugin=jerasure-k=3-m=1.yaml
@@ -17,7 +17,7 @@ tasks:
       k: 3
       m: 1
       technique: reed_sol_van
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
+++ b/qa/erasure-code/ec-rados-plugin=lrc-k=4-m=2-l=3.yaml
@@ -11,7 +11,7 @@ tasks:
       k: 4
       m: 2
       l: 3
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/erasure-code/ec-rados-plugin=shec-k=4-m=3-c=2.yaml
+++ b/qa/erasure-code/ec-rados-plugin=shec-k=4-m=3-c=2.yaml
@@ -11,7 +11,7 @@ tasks:
       k: 4
       m: 3
       c: 2
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/rgw_pool_type/ec-profile.yaml
+++ b/qa/rgw_pool_type/ec-profile.yaml
@@ -5,6 +5,6 @@ overrides:
       name: testprofile
       k: 3
       m: 1
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
   s3tests:
     slow_backend: true

--- a/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-big.yaml
@@ -5,7 +5,7 @@ overrides:
 tasks:
 - exec:
     client.0:
-      - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+      - sudo ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
       - sudo ceph osd pool create base 4 4 erasure teuthologyprofile
       - sudo ceph osd pool set base min_size 2
       - sudo ceph osd pool create cache 4

--- a/qa/suites/rbd/cli/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/cli/pool/ec-data-pool.yaml
@@ -1,7 +1,7 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+      - sudo ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
       - sudo ceph osd pool create datapool 4 4 erasure teuthologyprofile
       - sudo ceph osd pool set datapool allow_ec_overwrites true
 

--- a/qa/suites/rbd/librbd/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/librbd/pool/ec-data-pool.yaml
@@ -1,7 +1,7 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+      - sudo ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
       - sudo ceph osd pool create datapool 4 4 erasure teuthologyprofile
       - sudo ceph osd pool set datapool allow_ec_overwrites true
 

--- a/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/ec-cache-pool.yaml
@@ -1,7 +1,7 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+      - sudo ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
       - sudo ceph osd pool delete rbd rbd --yes-i-really-really-mean-it
       - sudo ceph osd pool create rbd 4 4 erasure teuthologyprofile
       - sudo ceph osd pool create cache 4

--- a/qa/suites/rbd/qemu/pool/ec-data-pool.yaml
+++ b/qa/suites/rbd/qemu/pool/ec-data-pool.yaml
@@ -1,7 +1,7 @@
 tasks:
 - exec:
     client.0:
-      - sudo ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+      - sudo ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
       - sudo ceph osd pool create datapool 4 4 erasure teuthologyprofile
       - sudo ceph osd pool set datapool allow_ec_overwrites true
 

--- a/qa/suites/upgrade/hammer-jewel-x/parallel/6-workload/ec-rados-default.yaml
+++ b/qa/suites/upgrade/hammer-jewel-x/parallel/6-workload/ec-rados-default.yaml
@@ -9,7 +9,7 @@ workload2:
         name: teuthologyprofile2
         k: 2
         m: 1
-        ruleset-failure-domain: osd
+        crush-failure-domain: osd
       clients: [client.0]
       ops: 4000
       objects: 50

--- a/qa/suites/upgrade/hammer-jewel-x/tiering/2-setup-cache-tiering/0-create-base-tier/create-ec-pool.yaml
+++ b/qa/suites/upgrade/hammer-jewel-x/tiering/2-setup-cache-tiering/0-create-base-tier/create-ec-pool.yaml
@@ -1,5 +1,5 @@
 tasks:
 - exec:
     client.0:
-      - ceph osd erasure-code-profile set t-profile ruleset-failure-domain=osd k=2 m=1
+      - ceph osd erasure-code-profile set t-profile crush-failure-domain=osd k=2 m=1
       - ceph osd pool create base-pool 4 4 erasure t-profile

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/7-final-workload/ec-rados-plugin=jerasure-k=3-m=1.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/7-final-workload/ec-rados-plugin=jerasure-k=3-m=1.yaml
@@ -21,7 +21,7 @@ tasks:
       k: 3
       m: 1
       technique: reed_sol_van
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/suites/upgrade/kraken-x/stress-split-erasure-code/7-final-workload.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split-erasure-code/7-final-workload.yaml
@@ -21,7 +21,7 @@ tasks:
       k: 3
       m: 1
       technique: reed_sol_van
-      ruleset-failure-domain: osd
+      crush-failure-domain: osd
     op_weights:
       read: 100
       write: 0

--- a/qa/tasks/ec_lost_unfound.py
+++ b/qa/tasks/ec_lost_unfound.py
@@ -34,7 +34,7 @@ def task(ctx, config):
     profile = config.get('erasure_code_profile', {
         'k': '2',
         'm': '2',
-        'ruleset-failure-domain': 'osd'
+        'crush-failure-domain': 'osd'
     })
     profile_name = profile.get('name', 'lost_unfound')
     manager.create_erasure_code_profile(profile_name, profile)

--- a/qa/tasks/rados.py
+++ b/qa/tasks/rados.py
@@ -62,7 +62,7 @@ def task(ctx, config):
               name: teuthologyprofile
               k: 2
               m: 1
-              ruleset-failure-domain: osd
+              crush-failure-domain: osd
             pool_snaps: true
 	    write_fadvise_dontneed: true
             runs: 10

--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -29,7 +29,7 @@ def task(ctx, config):
           name: teuthologyprofile
           k: 2
           m: 1
-          ruleset-failure-domain: osd
+          crush-failure-domain: osd
         cleanup: false (defaults to true)
         type: <write|seq|rand> (defaults to write)
     example:

--- a/qa/tasks/util/rados.py
+++ b/qa/tasks/util/rados.py
@@ -57,7 +57,7 @@ def cmd_erasure_code_profile(profile_name, profile):
 
     If profile is {}, it is replaced with 
 
-      { 'k': '2', 'm': '1', 'ruleset-failure-domain': 'osd'}
+      { 'k': '2', 'm': '1', 'crush-failure-domain': 'osd'}
 
     for backward compatibility. In previous versions of teuthology,
     these values were hardcoded as function arguments and some yaml
@@ -71,7 +71,7 @@ def cmd_erasure_code_profile(profile_name, profile):
         profile = {
             'k': '2',
             'm': '1',
-            'ruleset-failure-domain': 'osd'
+            'crush-failure-domain': 'osd'
         }
     return [
         'osd', 'erasure-code-profile', 'set',

--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -26,6 +26,10 @@ ceph osd crush set-device-class osd.1 hdd
 ceph osd crush rule create-replicated foo-ssd default host ssd
 ceph osd crush rule create-replicated foo-hdd default host hdd
 
+ceph osd erasure-code-profile set ec-foo-ssd crush-device-class=ssd m=2 k=2
+ceph osd pool create ec-foo 2 erasure ec-foo-ssd
+ceph osd pool rm ec-foo ec-foo --yes-i-really-really-mean-it
+
 ceph osd crush rule ls | grep foo
 
 ceph osd crush rule rm foo

--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -19,6 +19,8 @@ ceph osd crush rule create-simple foo default host
 ceph osd crush rule create-simple foo default host
 ceph osd crush rule create-simple bar default host
 
+# make sure we're at luminous+ before using crush device classes
+ceph osd require-osd-release luminous
 ceph osd crush class create ssd
 ceph osd crush class create hdd
 ceph osd crush set-device-class osd.0 ssd

--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -19,6 +19,13 @@ ceph osd crush rule create-simple foo default host
 ceph osd crush rule create-simple foo default host
 ceph osd crush rule create-simple bar default host
 
+ceph osd crush class create ssd
+ceph osd crush class create hdd
+ceph osd crush set-device-class osd.0 ssd
+ceph osd crush set-device-class osd.1 hdd
+ceph osd crush rule create-replicated foo-ssd default host ssd
+ceph osd crush rule create-replicated foo-hdd default host hdd
+
 ceph osd crush rule ls | grep foo
 
 ceph osd crush rule rm foo

--- a/qa/workunits/rados/test_alloc_hint.sh
+++ b/qa/workunits/rados/test_alloc_hint.sh
@@ -153,7 +153,7 @@ ceph osd pool delete "${POOL}" "${POOL}" --yes-i-really-really-mean-it
 
 PROFILE="alloc_hint-ecprofile"
 POOL="alloc_hint-ec"
-ceph osd erasure-code-profile set "${PROFILE}" k=2 m=1 ruleset-failure-domain=osd
+ceph osd erasure-code-profile set "${PROFILE}" k=2 m=1 crush-failure-domain=osd
 ceph osd erasure-code-profile get "${PROFILE}" # just so it's logged
 ceph osd pool create "${POOL}" "${NUM_PG}" "${NUM_PGP}" erasure "${PROFILE}"
 

--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -87,7 +87,7 @@ run_expect_nosignal "$RADOS_TOOL" --object_locator "asdf" ls
 run_expect_nosignal "$RADOS_TOOL" --namespace "asdf" ls
 
 run_expect_succ "$RADOS_TOOL" mkpool "$POOL"
-run_expect_succ "$CEPH_TOOL" osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K ruleset-failure-domain=osd --force
+run_expect_succ "$CEPH_TOOL" osd erasure-code-profile set myprofile k=2 m=1 stripe_unit=2K crush-failure-domain=osd --force
 run_expect_succ "$CEPH_TOOL" osd pool create "$POOL_EC" 100 100 erasure myprofile
 
 

--- a/qa/workunits/rbd/krbd_data_pool.sh
+++ b/qa/workunits/rbd/krbd_data_pool.sh
@@ -99,7 +99,7 @@ function get_num_clones() {
 }
 
 ceph osd pool create repdata 24 24
-ceph osd erasure-code-profile set teuthologyprofile ruleset-failure-domain=osd m=1 k=2
+ceph osd erasure-code-profile set teuthologyprofile crush-failure-domain=osd m=1 k=2
 ceph osd pool create ecdata 24 24 erasure teuthologyprofile
 ceph osd pool set ecdata allow_ec_overwrites true
 ceph osd pool create rbdnonzero 24 24

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1300,8 +1300,10 @@ void CrushWrapper::reweight(CephContext *cct)
 int CrushWrapper::add_simple_rule_at(
   string name, string root_name,
   string failure_domain_name,
+  string device_class,
   string mode, int rule_type,
-  int rno, ostream *err)
+  int rno,
+  ostream *err)
 {
   if (rule_exists(name)) {
     if (err)
@@ -1339,6 +1341,22 @@ int CrushWrapper::add_simple_rule_at(
 	*err << "unknown type " << failure_domain_name;
       return -EINVAL;
     }
+  }
+  if (device_class.size()) {
+    if (!class_exists(device_class)) {
+      if (err)
+	*err << "device class " << device_class << " does not exist";
+      return -EINVAL;
+    }
+    int c = get_class_id(device_class);
+    if (class_bucket.count(root) == 0 ||
+	class_bucket[root].count(c) == 0) {
+      if (err)
+	*err << "root " << root_name << " has no devices with class "
+	     << device_class;
+      return -EINVAL;
+    }
+    root = class_bucket[root][c];
   }
   if (mode != "firstn" && mode != "indep") {
     if (err)
@@ -1387,10 +1405,12 @@ int CrushWrapper::add_simple_rule_at(
 int CrushWrapper::add_simple_rule(
   string name, string root_name,
   string failure_domain_name,
+  string device_class,
   string mode, int rule_type,
   ostream *err)
 {
-  return add_simple_rule_at(name, root_name, failure_domain_name, mode,
+  return add_simple_rule_at(name, root_name, failure_domain_name, device_class,
+			    mode,
 			    rule_type, -1, err);
 }
 

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1015,6 +1015,7 @@ public:
 
   int add_simple_rule(
     string name, string root_name, string failure_domain_type,
+    string device_class,
     string mode, int rule_type, ostream *err = 0);
 
   /**
@@ -1022,7 +1023,7 @@ public:
    */
   int add_simple_rule_at(
     string name, string root_name,
-    string failure_domain_type, string mode,
+    string failure_domain_type, string device_class, string mode,
     int rule_type, int rno, ostream *err = 0);
 
   int remove_rule(int ruleno);

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -22,10 +22,53 @@
 
 #include "common/strtol.h"
 #include "include/buffer.h"
+#include "crush/CrushWrapper.h"
+#include "osd/osd_types.h"
 
 using namespace std;
 
 const unsigned ErasureCode::SIMD_ALIGN = 32;
+
+#define DEFAULT_RULE_ROOT "default"
+#define DEFAULT_RULE_FAILURE_DOMAIN "host"
+
+int ErasureCode::init(
+  ErasureCodeProfile &profile,
+  std::ostream *ss)
+{
+  int err = 0;
+  err |= to_string("crush-root", profile,
+		   &rule_root,
+		   DEFAULT_RULE_ROOT, ss);
+  err |= to_string("crush-failure-domain", profile,
+		   &rule_failure_domain,
+		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
+  if (err)
+    return err;
+  _profile = profile;
+  return 0;
+}
+
+int ErasureCode::create_rule(
+  const std::string &name,
+  CrushWrapper &crush,
+  std::ostream *ss) const
+{
+  int ruleid = crush.add_simple_rule(
+    name,
+    rule_root,
+    rule_failure_domain,
+    "",
+    "indep",
+    pg_pool_t::TYPE_ERASURE,
+    ss);
+
+  if (ruleid < 0)
+    return ruleid;
+
+  crush.set_rule_mask_max_size(ruleid, get_chunk_count());
+  return ruleid;
+}
 
 int ErasureCode::sanity_check_k(int k, ostream *ss)
 {

--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -43,6 +43,9 @@ int ErasureCode::init(
   err |= to_string("crush-failure-domain", profile,
 		   &rule_failure_domain,
 		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
+  err |= to_string("crush-device-class", profile,
+		   &rule_device_class,
+		   "", ss);
   if (err)
     return err;
   _profile = profile;
@@ -58,7 +61,7 @@ int ErasureCode::create_rule(
     name,
     rule_root,
     rule_failure_domain,
-    "",
+    rule_device_class,
     "indep",
     pg_pool_t::TYPE_ERASURE,
     ss);

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -36,6 +36,7 @@ namespace ceph {
     // for CRUSH rule
     std::string rule_root;
     std::string rule_failure_domain;
+    std::string rule_device_class;
 
     ~ErasureCode() override {}
 

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -33,16 +33,21 @@ namespace ceph {
     std::vector<int> chunk_mapping;
     ErasureCodeProfile _profile;
 
+    // for CRUSH rule
+    std::string rule_root;
+    std::string rule_failure_domain;
+
     ~ErasureCode() override {}
 
-    int init(ErasureCodeProfile &profile, std::ostream *ss) override {
-      _profile = profile;
-      return 0;
-    }
+    int init(ErasureCodeProfile &profile, std::ostream *ss) override;
 
     const ErasureCodeProfile &get_profile() const override {
       return _profile;
     }
+
+    int create_rule(const std::string &name,
+		    CrushWrapper &crush,
+		    std::ostream *ss) const;
 
     int sanity_check_k(int k, std::ostream *ss);
 

--- a/src/erasure-code/ErasureCodeInterface.h
+++ b/src/erasure-code/ErasureCodeInterface.h
@@ -196,22 +196,22 @@ namespace ceph {
     virtual const ErasureCodeProfile &get_profile() const = 0;
 
     /**
-     * Create a new ruleset in **crush** under the name **name**,
+     * Create a new rule in **crush** under the name **name**,
      * unless it already exists.
      *
-     * Return the ruleset number that was created on success. If a
-     * ruleset **name** already exists, return -EEXISTS, otherwise
+     * Return the rule number that was created on success. If a
+     * rule **name** already exists, return -EEXISTS, otherwise
      * return a negative value indicating an error with a semantic
      * defined by the implementation.
      *
-     * @param [in] name of the ruleset to create
-     * @param [in] crush crushmap in which the ruleset is created
+     * @param [in] name of the rule to create
+     * @param [in] crush crushmap in which the rule is created
      * @param [out] ss contains informative messages when an error occurs
-     * @return a ruleset on success or a negative errno on error.
+     * @return a rule on success or a negative errno on error.
      */
-    virtual int create_ruleset(const std::string &name,
-			       CrushWrapper &crush,
-			       std::ostream *ss) const = 0;
+    virtual int create_rule(const std::string &name,
+			    CrushWrapper &crush,
+			    std::ostream *ss) const = 0;
 
     /**
      * Return the number of chunks created by a call to the **encode**

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -55,6 +55,7 @@ ErasureCodeIsa::create_ruleset(const string &name,
     name,
     ruleset_root,
     ruleset_failure_domain,
+    "",
     "indep",
     pg_pool_t::TYPE_ERASURE,
     ss);

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -47,14 +47,14 @@ const std::string ErasureCodeIsaDefault::DEFAULT_K("7");
 const std::string ErasureCodeIsaDefault::DEFAULT_M("3");
 
 int
-ErasureCodeIsa::create_ruleset(const string &name,
-                               CrushWrapper &crush,
-                               ostream *ss) const
+ErasureCodeIsa::create_rule(const string &name,
+			    CrushWrapper &crush,
+			    ostream *ss) const
 {
   int ruleid = crush.add_simple_rule(
     name,
-    ruleset_root,
-    ruleset_failure_domain,
+    rule_root,
+    rule_failure_domain,
     "",
     "indep",
     pg_pool_t::TYPE_ERASURE,
@@ -64,7 +64,7 @@ ErasureCodeIsa::create_ruleset(const string &name,
     return ruleid;
   else {
     crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return crush.get_rule_mask_ruleset(ruleid);
+    return ruleid;
   }
 }
 
@@ -74,12 +74,12 @@ int
 ErasureCodeIsa::init(ErasureCodeProfile &profile, ostream *ss)
 {
   int err = 0;
-  err |= to_string("ruleset-root", profile,
-		   &ruleset_root,
-		   DEFAULT_RULESET_ROOT, ss);
-  err |= to_string("ruleset-failure-domain", profile,
-		   &ruleset_failure_domain,
-		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
+  err |= to_string("crush-root", profile,
+		   &rule_root,
+		   DEFAULT_RULE_ROOT, ss);
+  err |= to_string("crush-failure-domain", profile,
+		   &rule_failure_domain,
+		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;

--- a/src/erasure-code/isa/ErasureCodeIsa.cc
+++ b/src/erasure-code/isa/ErasureCodeIsa.cc
@@ -19,8 +19,7 @@
 #include "common/debug.h"
 #include "ErasureCodeIsa.h"
 #include "xor_op.h"
-#include "crush/CrushWrapper.h"
-#include "osd/osd_types.h"
+#include "include/assert.h"
 using namespace std;
 
 // -----------------------------------------------------------------------------
@@ -46,27 +45,6 @@ _prefix(std::ostream* _dout)
 const std::string ErasureCodeIsaDefault::DEFAULT_K("7");
 const std::string ErasureCodeIsaDefault::DEFAULT_M("3");
 
-int
-ErasureCodeIsa::create_rule(const string &name,
-			    CrushWrapper &crush,
-			    ostream *ss) const
-{
-  int ruleid = crush.add_simple_rule(
-    name,
-    rule_root,
-    rule_failure_domain,
-    "",
-    "indep",
-    pg_pool_t::TYPE_ERASURE,
-    ss);
-
-  if (ruleid < 0)
-    return ruleid;
-  else {
-    crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return ruleid;
-  }
-}
 
 // -----------------------------------------------------------------------------
 
@@ -74,18 +52,11 @@ int
 ErasureCodeIsa::init(ErasureCodeProfile &profile, ostream *ss)
 {
   int err = 0;
-  err |= to_string("crush-root", profile,
-		   &rule_root,
-		   DEFAULT_RULE_ROOT, ss);
-  err |= to_string("crush-failure-domain", profile,
-		   &rule_failure_domain,
-		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;
   prepare();
-  ErasureCode::init(profile, ss);
-  return err;
+  return ErasureCode::init(profile, ss);
 }
 
 // -----------------------------------------------------------------------------

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -30,8 +30,8 @@
 #include "ErasureCodeIsaTableCache.h"
 // -----------------------------------------------------------------------------
 
-#define DEFAULT_RULESET_ROOT "default"
-#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+#define DEFAULT_RULE_ROOT "default"
+#define DEFAULT_RULE_FAILURE_DOMAIN "host"
 
 class ErasureCodeIsa : public ErasureCode {
 public:
@@ -46,8 +46,8 @@ public:
 
   ErasureCodeIsaTableCache &tcache;
   const char *technique;
-  std::string ruleset_root;
-  std::string ruleset_failure_domain;
+  std::string rule_root;
+  std::string rule_failure_domain;
 
   ErasureCodeIsa(const char *_technique,
                  ErasureCodeIsaTableCache &_tcache) :
@@ -56,8 +56,8 @@ public:
   w(0),
   tcache(_tcache),
   technique(_technique),
-  ruleset_root(DEFAULT_RULESET_ROOT),
-  ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN)
+  rule_root(DEFAULT_RULE_ROOT),
+  rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN)
   {
   }
 
@@ -66,9 +66,9 @@ public:
   {
   }
 
-  int create_ruleset(const std::string &name,
-                             CrushWrapper &crush,
-                             std::ostream *ss) const override;
+  int create_rule(const std::string &name,
+		  CrushWrapper &crush,
+		  std::ostream *ss) const override;
 
   unsigned int
   get_chunk_count() const override

--- a/src/erasure-code/isa/ErasureCodeIsa.h
+++ b/src/erasure-code/isa/ErasureCodeIsa.h
@@ -30,9 +30,6 @@
 #include "ErasureCodeIsaTableCache.h"
 // -----------------------------------------------------------------------------
 
-#define DEFAULT_RULE_ROOT "default"
-#define DEFAULT_RULE_FAILURE_DOMAIN "host"
-
 class ErasureCodeIsa : public ErasureCode {
 public:
 
@@ -46,8 +43,6 @@ public:
 
   ErasureCodeIsaTableCache &tcache;
   const char *technique;
-  std::string rule_root;
-  std::string rule_failure_domain;
 
   ErasureCodeIsa(const char *_technique,
                  ErasureCodeIsaTableCache &_tcache) :
@@ -55,9 +50,7 @@ public:
   m(0),
   w(0),
   tcache(_tcache),
-  technique(_technique),
-  rule_root(DEFAULT_RULE_ROOT),
-  rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN)
+  technique(_technique)
   {
   }
 
@@ -65,10 +58,6 @@ public:
   ~ErasureCodeIsa() override
   {
   }
-
-  int create_rule(const std::string &name,
-		  CrushWrapper &crush,
-		  std::ostream *ss) const override;
 
   unsigned int
   get_chunk_count() const override

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -17,8 +17,6 @@
 
 #include "common/debug.h"
 #include "ErasureCodeJerasure.h"
-#include "crush/CrushWrapper.h"
-#include "osd/osd_types.h"
 
 using namespace std;
 
@@ -42,43 +40,17 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "ErasureCodeJerasure: ";
 }
 
-int ErasureCodeJerasure::create_rule(const string &name,
-					CrushWrapper &crush,
-					ostream *ss) const
-{
-  int ruleid = crush.add_simple_rule(
-    name,
-    rule_root,
-    rule_failure_domain,
-    "",
-    "indep",
-    pg_pool_t::TYPE_ERASURE,
-    ss);
-  if (ruleid < 0)
-    return ruleid;
-  else {
-    crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return ruleid;
-  }
-}
 
 int ErasureCodeJerasure::init(ErasureCodeProfile& profile, ostream *ss)
 {
   int err = 0;
   dout(10) << "technique=" << technique << dendl;
   profile["technique"] = technique;
-  err |= to_string("crush-root", profile,
-		   &rule_root,
-		   DEFAULT_RULE_ROOT, ss);
-  err |= to_string("crush-failure-domain", profile,
-		   &rule_failure_domain,
-		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;
   prepare();
-  ErasureCode::init(profile, ss);
-  return err;
+  return ErasureCode::init(profile, ss);
 }
 
 int ErasureCodeJerasure::parse(ErasureCodeProfile &profile,

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -47,7 +47,7 @@ int ErasureCodeJerasure::create_ruleset(const string &name,
 					ostream *ss) const
 {
   int ruleid = crush.add_simple_rule(
-    name, ruleset_root, ruleset_failure_domain,
+    name, ruleset_root, ruleset_failure_domain, "",
     "indep", pg_pool_t::TYPE_ERASURE, ss);
   if (ruleid < 0)
     return ruleid;

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.cc
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.cc
@@ -42,18 +42,23 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "ErasureCodeJerasure: ";
 }
 
-int ErasureCodeJerasure::create_ruleset(const string &name,
+int ErasureCodeJerasure::create_rule(const string &name,
 					CrushWrapper &crush,
 					ostream *ss) const
 {
   int ruleid = crush.add_simple_rule(
-    name, ruleset_root, ruleset_failure_domain, "",
-    "indep", pg_pool_t::TYPE_ERASURE, ss);
+    name,
+    rule_root,
+    rule_failure_domain,
+    "",
+    "indep",
+    pg_pool_t::TYPE_ERASURE,
+    ss);
   if (ruleid < 0)
     return ruleid;
   else {
     crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return crush.get_rule_mask_ruleset(ruleid);
+    return ruleid;
   }
 }
 
@@ -62,12 +67,12 @@ int ErasureCodeJerasure::init(ErasureCodeProfile& profile, ostream *ss)
   int err = 0;
   dout(10) << "technique=" << technique << dendl;
   profile["technique"] = technique;
-  err |= to_string("ruleset-root", profile,
-		   &ruleset_root,
-		   DEFAULT_RULESET_ROOT, ss);
-  err |= to_string("ruleset-failure-domain", profile,
-		   &ruleset_failure_domain,
-		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
+  err |= to_string("crush-root", profile,
+		   &rule_root,
+		   DEFAULT_RULE_ROOT, ss);
+  err |= to_string("crush-failure-domain", profile,
+		   &rule_failure_domain,
+		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile, ss);
   if (err)
     return err;

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -20,9 +20,6 @@
 
 #include "erasure-code/ErasureCode.h"
 
-#define DEFAULT_RULE_ROOT "default"
-#define DEFAULT_RULE_FAILURE_DOMAIN "host"
-
 class ErasureCodeJerasure : public ErasureCode {
 public:
   int k;
@@ -44,17 +41,11 @@ public:
     w(0),
     DEFAULT_W("8"),
     technique(_technique),
-    rule_root(DEFAULT_RULE_ROOT),
-    rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN),
     per_chunk_alignment(false)
   {}
 
   ~ErasureCodeJerasure() override {}
   
-  int create_rule(const std::string &name,
-		  CrushWrapper &crush,
-		  std::ostream *ss) const override;
-
   unsigned int get_chunk_count() const override {
     return k + m;
   }

--- a/src/erasure-code/jerasure/ErasureCodeJerasure.h
+++ b/src/erasure-code/jerasure/ErasureCodeJerasure.h
@@ -20,8 +20,8 @@
 
 #include "erasure-code/ErasureCode.h"
 
-#define DEFAULT_RULESET_ROOT "default"
-#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+#define DEFAULT_RULE_ROOT "default"
+#define DEFAULT_RULE_FAILURE_DOMAIN "host"
 
 class ErasureCodeJerasure : public ErasureCode {
 public:
@@ -32,8 +32,8 @@ public:
   int w;
   std::string DEFAULT_W;
   const char *technique;
-  std::string ruleset_root;
-  std::string ruleset_failure_domain;
+  std::string rule_root;
+  std::string rule_failure_domain;
   bool per_chunk_alignment;
 
   explicit ErasureCodeJerasure(const char *_technique) :
@@ -44,16 +44,16 @@ public:
     w(0),
     DEFAULT_W("8"),
     technique(_technique),
-    ruleset_root(DEFAULT_RULESET_ROOT),
-    ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN),
+    rule_root(DEFAULT_RULE_ROOT),
+    rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN),
     per_chunk_alignment(false)
   {}
 
   ~ErasureCodeJerasure() override {}
   
-  int create_ruleset(const std::string &name,
-			     CrushWrapper &crush,
-			     std::ostream *ss) const override;
+  int create_rule(const std::string &name,
+		  CrushWrapper &crush,
+		  std::ostream *ss) const override;
 
   unsigned int get_chunk_count() const override {
     return k + m;

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -43,7 +43,7 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "ErasureCodeLrc: ";
 }
 
-int ErasureCodeLrc::create_ruleset(const string &name,
+int ErasureCodeLrc::create_rule(const string &name,
 				   CrushWrapper &crush,
 				   ostream *ss) const
 {
@@ -51,25 +51,25 @@ int ErasureCodeLrc::create_ruleset(const string &name,
     *ss << "rule " << name << " exists";
     return -EEXIST;
   }
-  if (!crush.name_exists(ruleset_root)) {
-    *ss << "root item " << ruleset_root << " does not exist";
+  if (!crush.name_exists(rule_root)) {
+    *ss << "root item " << rule_root << " does not exist";
     return -ENOENT;
   }
-  int root = crush.get_item_id(ruleset_root);
+  int root = crush.get_item_id(rule_root);
 
-  int ruleset = 0;
+  int rule = 0;
   int rno = 0;
   for (rno = 0; rno < crush.get_max_rules(); rno++) {
     if (!crush.rule_exists(rno) && !crush.ruleset_exists(rno))
        break;
   }
-  ruleset = rno;
+  rule = rno;
 
-  int steps = 4 + ruleset_steps.size();
+  int steps = 4 + rule_steps.size();
   int min_rep = 3;
   int max_rep = get_chunk_count();
   int ret;
-  ret = crush.add_rule(steps, ruleset, pg_pool_t::TYPE_ERASURE,
+  ret = crush.add_rule(steps, rule, pg_pool_t::TYPE_ERASURE,
 		  min_rep, max_rep, rno);
   assert(ret == rno);
   int step = 0;
@@ -82,8 +82,8 @@ int ErasureCodeLrc::create_ruleset(const string &name,
   assert(ret == 0);
   // [ [ "choose", "rack", 2 ],
   //   [ "chooseleaf", "host", 5 ] ]
-  for (vector<Step>::const_iterator i = ruleset_steps.begin();
-       i != ruleset_steps.end();
+  for (vector<Step>::const_iterator i = rule_steps.begin();
+       i != rule_steps.end();
        ++i) {
     int op = i->op == "chooseleaf" ?
       CRUSH_RULE_CHOOSELEAF_INDEP : CRUSH_RULE_CHOOSE_INDEP;
@@ -98,7 +98,7 @@ int ErasureCodeLrc::create_ruleset(const string &name,
   ret = crush.set_rule_step(rno, step++, CRUSH_RULE_EMIT, 0, 0);
   assert(ret == 0);
   crush.set_rule_name(rno, name);
-  return ruleset;
+  return rule;
 }
 
 int ErasureCodeLrc::layers_description(const ErasureCodeProfile &profile,
@@ -275,7 +275,7 @@ int ErasureCodeLrc::parse(ErasureCodeProfile &profile,
   if (r)
     return r;
 
-  return parse_ruleset(profile, ss);
+  return parse_rule(profile, ss);
 }
 
 const string ErasureCodeLrc::DEFAULT_KML("-1");
@@ -302,7 +302,7 @@ int ErasureCodeLrc::parse_kml(ErasureCodeProfile &profile,
 
   const char *generated[] = { "mapping",
 			      "layers",
-			      "ruleset-steps" };
+			      "crush-steps" };
 
   for (int i = 0; i < 3; i++) {
     if (profile.count(generated[i])) {
@@ -363,54 +363,54 @@ int ErasureCodeLrc::parse_kml(ErasureCodeProfile &profile,
   profile["layers"] = layers + "]";
 
   ErasureCodeProfile::const_iterator parameter;
-  string ruleset_locality;
-  parameter = profile.find("ruleset-locality");
+  string rule_locality;
+  parameter = profile.find("crush-locality");
   if (parameter != profile.end())
-    ruleset_locality = parameter->second;
-  string ruleset_failure_domain = "host";
-  parameter = profile.find("ruleset-failure-domain");
+    rule_locality = parameter->second;
+  string rule_failure_domain = "host";
+  parameter = profile.find("crush-failure-domain");
   if (parameter != profile.end())
-    ruleset_failure_domain = parameter->second;
+    rule_failure_domain = parameter->second;
 
-  if (ruleset_locality != "") {
-    ruleset_steps.clear();
-    ruleset_steps.push_back(Step("choose", ruleset_locality,
+  if (rule_locality != "") {
+    rule_steps.clear();
+    rule_steps.push_back(Step("choose", rule_locality,
 				 local_group_count));
-    ruleset_steps.push_back(Step("chooseleaf", ruleset_failure_domain,
+    rule_steps.push_back(Step("chooseleaf", rule_failure_domain,
 				 l + 1));
-  } else if (ruleset_failure_domain != "") {
-    ruleset_steps.clear();
-    ruleset_steps.push_back(Step("chooseleaf", ruleset_failure_domain, 0));
+  } else if (rule_failure_domain != "") {
+    rule_steps.clear();
+    rule_steps.push_back(Step("chooseleaf", rule_failure_domain, 0));
   }
 
   return err;
 }
 
-int ErasureCodeLrc::parse_ruleset(ErasureCodeProfile &profile,
+int ErasureCodeLrc::parse_rule(ErasureCodeProfile &profile,
 				  ostream *ss)
 {
   int err = 0;
-  err |= to_string("ruleset-root", profile,
-		   &ruleset_root,
+  err |= to_string("crush-root", profile,
+		   &rule_root,
 		   "default", ss);
 
-  if (profile.count("ruleset-steps") != 0) {
-    ruleset_steps.clear();
-    string str = profile.find("ruleset-steps")->second;
+  if (profile.count("crush-steps") != 0) {
+    rule_steps.clear();
+    string str = profile.find("crush-steps")->second;
     json_spirit::mArray description;
     try {
       json_spirit::mValue json;
       json_spirit::read_or_throw(str, json);
 
       if (json.type() != json_spirit::array_type) {
-	*ss << "ruleset-steps='" << str
+	*ss << "crush-steps='" << str
 	    << "' must be a JSON array but is of type "
 	    << json.type() << " instead" << std::endl;
 	return ERROR_LRC_ARRAY;
       }
       description = json.get_array();
     } catch (json_spirit::Error_position &e) {
-      *ss << "failed to parse ruleset-steps='" << str << "'"
+      *ss << "failed to parse crush-steps='" << str << "'"
 	  << " at line " << e.line_ << ", column " << e.column_
 	  << " : " << e.reason_ << std::endl;
       return ERROR_LRC_PARSE_JSON;
@@ -429,7 +429,7 @@ int ErasureCodeLrc::parse_ruleset(ErasureCodeProfile &profile,
 	    << " is of type " << i->type() << " instead" << std::endl;
 	return ERROR_LRC_ARRAY;
       }
-      int r = parse_ruleset_step(str, i->get_array(), ss);
+      int r = parse_rule_step(str, i->get_array(), ss);
       if (r)
 	return r;
     }
@@ -437,7 +437,7 @@ int ErasureCodeLrc::parse_ruleset(ErasureCodeProfile &profile,
   return 0;
 }
 
-int ErasureCodeLrc::parse_ruleset_step(string description_string,
+int ErasureCodeLrc::parse_rule_step(string description_string,
 				       json_spirit::mArray description,
 				       ostream *ss)
 {
@@ -456,14 +456,14 @@ int ErasureCodeLrc::parse_ruleset_step(string description_string,
 	  << json_string.str() << " found in " << description_string
 	  << " must be a JSON string but is of type "
 	  << i->type() << " instead" << std::endl;
-      return position == 0 ? ERROR_LRC_RULESET_OP : ERROR_LRC_RULESET_TYPE;
+      return position == 0 ? ERROR_LRC_RULE_OP : ERROR_LRC_RULE_TYPE;
     }
     if (position == 2 && i->type() != json_spirit::int_type) {
       *ss << "element " << position << " of the array "
 	  << json_string.str() << " found in " << description_string
 	  << " must be a JSON int but is of type "
 	  << i->type() << " instead" << std::endl;
-      return ERROR_LRC_RULESET_N;
+      return ERROR_LRC_RULE_N;
     }
 
     if (position == 0)
@@ -473,7 +473,7 @@ int ErasureCodeLrc::parse_ruleset_step(string description_string,
     if (position == 2)
       n = i->get_int();
   }
-  ruleset_steps.push_back(Step(op, type, n));
+  rule_steps.push_back(Step(op, type, n));
   return 0;
 }
 

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -63,6 +63,7 @@ public:
   unsigned int chunk_count;
   unsigned int data_chunk_count;
   std::string rule_root;
+  std::string rule_device_class;
   struct Step {
     Step(std::string _op, std::string _type, int _n) :
       op(_op),

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -35,9 +35,9 @@
 #define ERROR_LRC_COUNT_CONSTRAINT	-(MAX_ERRNO + 11)
 #define ERROR_LRC_CONFIG_OPTIONS	-(MAX_ERRNO + 12)
 #define ERROR_LRC_LAYERS_COUNT		-(MAX_ERRNO + 13)
-#define ERROR_LRC_RULESET_OP		-(MAX_ERRNO + 14)
-#define ERROR_LRC_RULESET_TYPE		-(MAX_ERRNO + 15)
-#define ERROR_LRC_RULESET_N		-(MAX_ERRNO + 16)
+#define ERROR_LRC_RULE_OP		-(MAX_ERRNO + 14)
+#define ERROR_LRC_RULE_TYPE		-(MAX_ERRNO + 15)
+#define ERROR_LRC_RULE_N		-(MAX_ERRNO + 16)
 #define ERROR_LRC_ALL_OR_NOTHING	-(MAX_ERRNO + 17)
 #define ERROR_LRC_GENERATED		-(MAX_ERRNO + 18)
 #define ERROR_LRC_K_M_MODULO		-(MAX_ERRNO + 19)
@@ -62,7 +62,7 @@ public:
   std::string directory;
   unsigned int chunk_count;
   unsigned int data_chunk_count;
-  std::string ruleset_root;
+  std::string rule_root;
   struct Step {
     Step(std::string _op, std::string _type, int _n) :
       op(_op),
@@ -72,13 +72,13 @@ public:
     std::string type;
     int n;
   };
-  std::vector<Step> ruleset_steps;
+  std::vector<Step> rule_steps;
 
   explicit ErasureCodeLrc(const std::string &dir)
     : directory(dir),
-      chunk_count(0), data_chunk_count(0), ruleset_root("default")
+      chunk_count(0), data_chunk_count(0), rule_root("default")
   {
-    ruleset_steps.push_back(Step("chooseleaf", "host", 0));
+    rule_steps.push_back(Step("chooseleaf", "host", 0));
   }
 
   ~ErasureCodeLrc() override {}
@@ -90,7 +90,7 @@ public:
 				const std::set<int> &available,
 				std::set<int> *minimum) override;
 
-  int create_ruleset(const std::string &name,
+  int create_rule(const std::string &name,
 			     CrushWrapper &crush,
 			     std::ostream *ss) const override;
 
@@ -117,11 +117,11 @@ public:
 
   int parse_kml(ErasureCodeProfile &profile, std::ostream *ss);
 
-  int parse_ruleset(ErasureCodeProfile &profile, std::ostream *ss);
+  int parse_rule(ErasureCodeProfile &profile, std::ostream *ss);
 
-  int parse_ruleset_step(std::string description_string,
-			 json_spirit::mArray description,
-			 std::ostream *ss);
+  int parse_rule_step(std::string description_string,
+		      json_spirit::mArray description,
+		      std::ostream *ss);
 
   int layers_description(const ErasureCodeProfile &profile,
 			 json_spirit::mArray *description,

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -47,18 +47,23 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "ErasureCodeShec: ";
 }
 
-int ErasureCodeShec::create_ruleset(const string &name,
+int ErasureCodeShec::create_rule(const string &name,
 				    CrushWrapper &crush,
 				    ostream *ss) const
 {
   int ruleid = crush.add_simple_rule(
-    name, ruleset_root, ruleset_failure_domain, "",
-    "indep", pg_pool_t::TYPE_ERASURE, ss);
+    name,
+    rule_root,
+    rule_failure_domain,
+    "",
+    "indep",
+    pg_pool_t::TYPE_ERASURE,
+    ss);
   if (ruleid < 0) {
     return ruleid;
   } else {
     crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return crush.get_rule_mask_ruleset(ruleid);
+    return ruleid;
   }
 }
 
@@ -66,12 +71,12 @@ int ErasureCodeShec::init(ErasureCodeProfile &profile,
 			  ostream *ss)
 {
   int err = 0;
-  err |= ErasureCode::to_string("ruleset-root", profile,
-		   &ruleset_root,
-		   DEFAULT_RULESET_ROOT, ss);
-  err |= ErasureCode::to_string("ruleset-failure-domain", profile,
-		   &ruleset_failure_domain,
-		   DEFAULT_RULESET_FAILURE_DOMAIN, ss);
+  err |= ErasureCode::to_string("crush-root", profile,
+		   &rule_root,
+		   DEFAULT_RULE_ROOT, ss);
+  err |= ErasureCode::to_string("crush-failure-domain", profile,
+		   &rule_failure_domain,
+		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile);
   if (err)
     return err;

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -52,7 +52,7 @@ int ErasureCodeShec::create_ruleset(const string &name,
 				    ostream *ss) const
 {
   int ruleid = crush.add_simple_rule(
-    name, ruleset_root, ruleset_failure_domain,
+    name, ruleset_root, ruleset_failure_domain, "",
     "indep", pg_pool_t::TYPE_ERASURE, ss);
   if (ruleid < 0) {
     return ruleid;

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -27,8 +27,6 @@ using namespace std;
 
 #include "common/debug.h"
 #include "ErasureCodeShec.h"
-#include "crush/CrushWrapper.h"
-#include "osd/osd_types.h"
 extern "C" {
 #include "jerasure/include/jerasure.h"
 #include "jerasure/include/galois.h"
@@ -47,42 +45,15 @@ static ostream& _prefix(std::ostream* _dout)
   return *_dout << "ErasureCodeShec: ";
 }
 
-int ErasureCodeShec::create_rule(const string &name,
-				    CrushWrapper &crush,
-				    ostream *ss) const
-{
-  int ruleid = crush.add_simple_rule(
-    name,
-    rule_root,
-    rule_failure_domain,
-    "",
-    "indep",
-    pg_pool_t::TYPE_ERASURE,
-    ss);
-  if (ruleid < 0) {
-    return ruleid;
-  } else {
-    crush.set_rule_mask_max_size(ruleid, get_chunk_count());
-    return ruleid;
-  }
-}
-
 int ErasureCodeShec::init(ErasureCodeProfile &profile,
 			  ostream *ss)
 {
   int err = 0;
-  err |= ErasureCode::to_string("crush-root", profile,
-		   &rule_root,
-		   DEFAULT_RULE_ROOT, ss);
-  err |= ErasureCode::to_string("crush-failure-domain", profile,
-		   &rule_failure_domain,
-		   DEFAULT_RULE_FAILURE_DOMAIN, ss);
   err |= parse(profile);
   if (err)
     return err;
   prepare();
-  ErasureCode::init(profile, ss);
-  return err;
+  return ErasureCode::init(profile, ss);
 }
 
 unsigned int ErasureCodeShec::get_chunk_size(unsigned int object_size) const

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -24,9 +24,6 @@
 #include "erasure-code/ErasureCode.h"
 #include "ErasureCodeShecTableCache.h"
 
-#define DEFAULT_RULE_ROOT "default"
-#define DEFAULT_RULE_FAILURE_DOMAIN "host"
-
 class ErasureCodeShec : public ErasureCode {
 
 public:
@@ -45,8 +42,6 @@ public:
   int w;
   int DEFAULT_W;
   int technique;
-  string rule_root;
-  string rule_failure_domain;
   int *matrix;
 
   ErasureCodeShec(const int _technique,
@@ -61,16 +56,10 @@ public:
     w(0),
     DEFAULT_W(8),
     technique(_technique),
-    rule_root(DEFAULT_RULE_ROOT),
-    rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN),
     matrix(0)
   {}
 
   ~ErasureCodeShec() override {}
-
-  int create_rule(const string &name,
-		  CrushWrapper &crush,
-		  ostream *ss) const override;
 
   unsigned int get_chunk_count() const override {
     return k + m;

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -24,8 +24,8 @@
 #include "erasure-code/ErasureCode.h"
 #include "ErasureCodeShecTableCache.h"
 
-#define DEFAULT_RULESET_ROOT "default"
-#define DEFAULT_RULESET_FAILURE_DOMAIN "host"
+#define DEFAULT_RULE_ROOT "default"
+#define DEFAULT_RULE_FAILURE_DOMAIN "host"
 
 class ErasureCodeShec : public ErasureCode {
 
@@ -45,8 +45,8 @@ public:
   int w;
   int DEFAULT_W;
   int technique;
-  string ruleset_root;
-  string ruleset_failure_domain;
+  string rule_root;
+  string rule_failure_domain;
   int *matrix;
 
   ErasureCodeShec(const int _technique,
@@ -61,16 +61,16 @@ public:
     w(0),
     DEFAULT_W(8),
     technique(_technique),
-    ruleset_root(DEFAULT_RULESET_ROOT),
-    ruleset_failure_domain(DEFAULT_RULESET_FAILURE_DOMAIN),
+    rule_root(DEFAULT_RULE_ROOT),
+    rule_failure_domain(DEFAULT_RULE_FAILURE_DOMAIN),
     matrix(0)
   {}
 
   ~ErasureCodeShec() override {}
 
-  int create_ruleset(const string &name,
-			     CrushWrapper &crush,
-			     ostream *ss) const override;
+  int create_rule(const string &name,
+		  CrushWrapper &crush,
+		  ostream *ss) const override;
 
   unsigned int get_chunk_count() const override {
     return k + m;

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -602,6 +602,13 @@ COMMAND("osd crush rule create-simple " \
 	"name=mode,type=CephChoices,strings=firstn|indep,req=false",
 	"create crush rule <name> to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd crush rule create-replicated " \
+	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=root,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=type,type=CephString,goodchars=[A-Za-z0-9-_.] " \
+	"name=class,type=CephString,goodchars=[A-Za-z0-9-_.],req=false",
+	"create crush rule <name> for replicated pool to start from <root>, replicate across buckets of type <type>, using a choose mode of <firstn|indep> (default firstn; indep best for erasure pools)", \
+	"osd", "rw", "cli,rest")
 COMMAND("osd crush rule create-erasure " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=profile,type=CephString,req=false,goodchars=[A-Za-z0-9-_.=]", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7794,8 +7794,48 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       ss << "rule " << name << " already exists";
       err = 0;
     } else {
-      int ruleno = newcrush.add_simple_rule(name, root, type, mode,
+      int ruleno = newcrush.add_simple_rule(name, root, type, "", mode,
 					       pg_pool_t::TYPE_REPLICATED, &ss);
+      if (ruleno < 0) {
+	err = ruleno;
+	goto reply;
+      }
+
+      pending_inc.crush.clear();
+      newcrush.encode(pending_inc.crush, mon->get_quorum_con_features());
+    }
+    getline(ss, rs);
+    wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
+					      get_last_committed() + 1));
+    return true;
+
+  } else if (prefix == "osd crush rule create-replicated") {
+    string name, root, type, device_class;
+    cmd_getval(g_ceph_context, cmdmap, "name", name);
+    cmd_getval(g_ceph_context, cmdmap, "root", root);
+    cmd_getval(g_ceph_context, cmdmap, "type", type);
+    cmd_getval(g_ceph_context, cmdmap, "class", device_class);
+
+    if (osdmap.crush->rule_exists(name)) {
+      // The name is uniquely associated to a ruleid and the rule it contains
+      // From the user point of view, the rule is more meaningfull.
+      ss << "rule " << name << " already exists";
+      err = 0;
+      goto reply;
+    }
+
+    CrushWrapper newcrush;
+    _get_pending_crush(newcrush);
+
+    if (newcrush.rule_exists(name)) {
+      // The name is uniquely associated to a ruleid and the rule it contains
+      // From the user point of view, the rule is more meaningfull.
+      ss << "rule " << name << " already exists";
+      err = 0;
+    } else {
+      int ruleno = newcrush.add_simple_rule(
+	name, root, type, device_class,
+	"firstn", pg_pool_t::TYPE_REPLICATED, &ss);
       if (ruleno < 0) {
 	err = ruleno;
 	goto reply;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3471,7 +3471,7 @@ int OSDMap::build_simple_crush_rules(
 
   int r;
   r = crush.add_simple_rule_at(
-    "replicated_rule", root, failure_domain,
+    "replicated_rule", root, failure_domain, "",
     "firstn", pg_pool_t::TYPE_REPLICATED,
     crush_rule, ss);
   if (r < 0)

--- a/src/test/ceph_objectstore_tool.py
+++ b/src/test/ceph_objectstore_tool.py
@@ -713,7 +713,7 @@ def main(argv):
 
     print("Created Replicated pool #{repid}".format(repid=REPID))
 
-    cmd = "{path}/ceph osd erasure-code-profile set {prof} ruleset-failure-domain=osd".format(prof=PROFNAME, path=CEPH_BIN)
+    cmd = "{path}/ceph osd erasure-code-profile set {prof} crush-failure-domain=osd".format(prof=PROFNAME, path=CEPH_BIN)
     logging.debug(cmd)
     call(cmd, shell=True, stdout=nullfd, stderr=nullfd)
     cmd = "{path}/ceph osd erasure-code-profile get {prof}".format(prof=PROFNAME, path=CEPH_BIN)

--- a/src/test/cli/crushtool/help.t
+++ b/src/test/cli/crushtool/help.t
@@ -62,6 +62,11 @@
                            create crush rule <name> to start from <root>,
                            replicate across buckets of type <type>, using
                            a choose mode of <firstn|indep>
+     -i mapfn --create-replicated-rule name root type
+                           create crush rule <name> to start from <root>,
+                           replicate across buckets of type <type>
+     --device-class <class>
+                           use device class <class> for new rule
      -i mapfn --remove-rule name
                            remove the specified crush rule
   

--- a/src/test/cli/crushtool/rules.t
+++ b/src/test/cli/crushtool/rules.t
@@ -1,7 +1,7 @@
   $ crushtool -c $TESTDIR/rules.txt --create-replicated-rule foo default host -o one > /dev/null
   $ crushtool -d one
   # begin crush map
-
+  
   # devices
   device 0 osd.0 class ssd
   device 1 osd.1 class ssd
@@ -9,12 +9,12 @@
   device 3 osd.3 class hdd
   device 4 osd.4 class hdd
   device 5 osd.5 class hdd
-
+  
   # types
   type 0 osd
   type 1 host
   type 2 root
-
+  
   # buckets
   host foo {
   \tid -3\t\t# do not change unnecessarily (esc)
@@ -48,7 +48,7 @@
   \titem foo weight 3.000 (esc)
   \titem bar weight 3.000 (esc)
   }
-
+  
   # rules
   rule data {
   \truleset 0 (esc)
@@ -68,8 +68,13 @@
   \tstep chooseleaf firstn 0 type host (esc)
   \tstep emit (esc)
   }
-
+  
   # end crush map
+
+
+
+
+
 
 
 
@@ -78,7 +83,7 @@
   $ crushtool -c $TESTDIR/rules.txt --create-replicated-rule foo-ssd default host -o two --device-class ssd > /dev/null
   $ crushtool -d two
   # begin crush map
-
+  
   # devices
   device 0 osd.0 class ssd
   device 1 osd.1 class ssd
@@ -86,12 +91,12 @@
   device 3 osd.3 class hdd
   device 4 osd.4 class hdd
   device 5 osd.5 class hdd
-
+  
   # types
   type 0 osd
   type 1 host
   type 2 root
-
+  
   # buckets
   host foo {
   \tid -3\t\t# do not change unnecessarily (esc)
@@ -125,7 +130,7 @@
   \titem foo weight 3.000 (esc)
   \titem bar weight 3.000 (esc)
   }
-
+  
   # rules
   rule data {
   \truleset 0 (esc)
@@ -145,5 +150,10 @@
   \tstep chooseleaf firstn 0 type host (esc)
   \tstep emit (esc)
   }
-
+  
   # end crush map
+
+
+
+
+

--- a/src/test/cli/crushtool/rules.t
+++ b/src/test/cli/crushtool/rules.t
@@ -1,0 +1,149 @@
+  $ crushtool -c $TESTDIR/rules.txt --create-replicated-rule foo default host -o one > /dev/null
+  $ crushtool -d one
+  # begin crush map
+
+  # devices
+  device 0 osd.0 class ssd
+  device 1 osd.1 class ssd
+  device 2 osd.2 class ssd
+  device 3 osd.3 class hdd
+  device 4 osd.4 class hdd
+  device 5 osd.5 class hdd
+
+  # types
+  type 0 osd
+  type 1 host
+  type 2 root
+
+  # buckets
+  host foo {
+  \tid -3\t\t# do not change unnecessarily (esc)
+  \tid -4 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -7 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 3.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem osd.0 weight 1.000 (esc)
+  \titem osd.1 weight 1.000 (esc)
+  \titem osd.2 weight 1.000 (esc)
+  }
+  host bar {
+  \tid -2\t\t# do not change unnecessarily (esc)
+  \tid -5 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -8 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 3.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem osd.3 weight 1.000 (esc)
+  \titem osd.4 weight 1.000 (esc)
+  \titem osd.5 weight 1.000 (esc)
+  }
+  root default {
+  \tid -1\t\t# do not change unnecessarily (esc)
+  \tid -6 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -9 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 6.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem foo weight 3.000 (esc)
+  \titem bar weight 3.000 (esc)
+  }
+
+  # rules
+  rule data {
+  \truleset 0 (esc)
+  \ttype replicated (esc)
+  \tmin_size 1 (esc)
+  \tmax_size 10 (esc)
+  \tstep take default (esc)
+  \tstep chooseleaf firstn 0 type host (esc)
+  \tstep emit (esc)
+  }
+  rule foo {
+  \truleset 1 (esc)
+  \ttype replicated (esc)
+  \tmin_size 1 (esc)
+  \tmax_size 10 (esc)
+  \tstep take default (esc)
+  \tstep chooseleaf firstn 0 type host (esc)
+  \tstep emit (esc)
+  }
+
+  # end crush map
+
+
+
+
+
+  $ crushtool -c $TESTDIR/rules.txt --create-replicated-rule foo-ssd default host -o two --device-class ssd > /dev/null
+  $ crushtool -d two
+  # begin crush map
+
+  # devices
+  device 0 osd.0 class ssd
+  device 1 osd.1 class ssd
+  device 2 osd.2 class ssd
+  device 3 osd.3 class hdd
+  device 4 osd.4 class hdd
+  device 5 osd.5 class hdd
+
+  # types
+  type 0 osd
+  type 1 host
+  type 2 root
+
+  # buckets
+  host foo {
+  \tid -3\t\t# do not change unnecessarily (esc)
+  \tid -4 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -7 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 3.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem osd.0 weight 1.000 (esc)
+  \titem osd.1 weight 1.000 (esc)
+  \titem osd.2 weight 1.000 (esc)
+  }
+  host bar {
+  \tid -2\t\t# do not change unnecessarily (esc)
+  \tid -5 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -8 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 3.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem osd.3 weight 1.000 (esc)
+  \titem osd.4 weight 1.000 (esc)
+  \titem osd.5 weight 1.000 (esc)
+  }
+  root default {
+  \tid -1\t\t# do not change unnecessarily (esc)
+  \tid -6 class ssd\t\t# do not change unnecessarily (esc)
+  \tid -9 class hdd\t\t# do not change unnecessarily (esc)
+  \t# weight 6.000 (esc)
+  \talg straw2 (esc)
+  \thash 0\t# rjenkins1 (esc)
+  \titem foo weight 3.000 (esc)
+  \titem bar weight 3.000 (esc)
+  }
+
+  # rules
+  rule data {
+  \truleset 0 (esc)
+  \ttype replicated (esc)
+  \tmin_size 1 (esc)
+  \tmax_size 10 (esc)
+  \tstep take default (esc)
+  \tstep chooseleaf firstn 0 type host (esc)
+  \tstep emit (esc)
+  }
+  rule foo-ssd {
+  \truleset 1 (esc)
+  \ttype replicated (esc)
+  \tmin_size 1 (esc)
+  \tmax_size 10 (esc)
+  \tstep take default class ssd (esc)
+  \tstep chooseleaf firstn 0 type host (esc)
+  \tstep emit (esc)
+  }
+
+  # end crush map

--- a/src/test/cli/crushtool/rules.txt
+++ b/src/test/cli/crushtool/rules.txt
@@ -1,0 +1,54 @@
+# begin crush map
+
+# devices
+device 0 osd.0 class ssd
+device 1 osd.1 class ssd
+device 2 osd.2 class ssd
+device 3 osd.3 class hdd
+device 4 osd.4 class hdd
+device 5 osd.5 class hdd
+
+# types
+type 0 osd
+type 1 host
+type 2 root
+
+# buckets
+host foo {
+     id -3
+     alg straw2
+     hash 0
+     item osd.0 weight 1.0
+     item osd.1 weight 1.0
+     item osd.2 weight 1.0
+}
+
+host bar {
+     id -2
+     alg straw2
+     hash 0
+     item osd.3 weight 1.0
+     item osd.4 weight 1.0
+     item osd.5 weight 1.0
+}
+
+root default {
+     id -1
+     alg straw2
+     hash 0
+     item foo weight 3.0
+     item bar weight 3.0
+}
+
+# rules
+rule data {
+	ruleset 0
+	type replicated
+	min_size 1
+	max_size 10
+	step take default
+	step chooseleaf firstn 0 type host
+	step emit
+}
+
+# end crush map

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -909,7 +909,7 @@ TEST(CrushWrapper, dump_rules) {
   }
 
   string name("NAME");
-  int rule = c->add_simple_rule(name, root_name, failure_domain_type,
+  int rule = c->add_simple_rule(name, root_name, failure_domain_type, "",
 				   "firstn", pg_pool_t::TYPE_ERASURE);
   EXPECT_EQ(0, rule);
 
@@ -1032,7 +1032,8 @@ TEST(CrushWrapper, choose_args_compat) {
   item = 2;
   c.insert_item(g_ceph_context, item, weight, "osd.2", loc);
 
-  assert(c.add_simple_rule("rule1", "r11", "host", "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
+  assert(c.add_simple_rule("rule1", "r11", "host", "",
+			   "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
 
   int id = c.get_item_id("b1");
 
@@ -1102,7 +1103,8 @@ TEST(CrushWrapper, remove_unused_root) {
   loc["root"] = "default";
   c.insert_item(g_ceph_context, item, weight, "osd.2", loc);
 
-  assert(c.add_simple_rule("rule1", "r11", "host", "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
+  assert(c.add_simple_rule("rule1", "r11", "host", "",
+			   "firstn", pg_pool_t::TYPE_ERASURE) >= 0);
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("r11"));
   ASSERT_TRUE(c.name_exists("r12"));
@@ -1346,7 +1348,8 @@ TEST(CrushWrapper, try_remap_rule) {
   {
     cout << "take + choose + emit" << std::endl;
     ostringstream err;
-    int rule = c.add_simple_rule("one", "default", "osd", "firstn", 0, &err);
+    int rule = c.add_simple_rule("one", "default", "osd", "",
+				 "firstn", 0, &err);
     ASSERT_EQ(rule, 0);
 
     vector<int> orig = { 0, 3, 9 };
@@ -1382,7 +1385,8 @@ TEST(CrushWrapper, try_remap_rule) {
   {
     cout << "take + chooseleaf + emit" << std::endl;
     ostringstream err;
-    int rule = c.add_simple_rule("two", "default", "host", "firstn", 0, &err);
+    int rule = c.add_simple_rule("two", "default", "host", "",
+				 "firstn", 0, &err);
     ASSERT_EQ(rule, 1);
 
     vector<int> orig = { 0, 3, 9 };

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -271,7 +271,7 @@ TEST(CRUSH, straw_zero) {
   EXPECT_EQ(0, c->set_item_name(root0, root_name0));
 
   string name0("rule0");
-  int rule0 = c->add_simple_rule(name0, root_name0, "osd",
+  int rule0 = c->add_simple_rule(name0, root_name0, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(0, rule0);
 
@@ -282,7 +282,7 @@ TEST(CRUSH, straw_zero) {
   EXPECT_EQ(0, c->set_item_name(root1, root_name1));
 
   string name1("rule1");
-  int rule1 = c->add_simple_rule(name1, root_name1, "osd",
+  int rule1 = c->add_simple_rule(name1, root_name1, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(1, rule1);
 
@@ -336,7 +336,7 @@ TEST(CRUSH, straw_same) {
   EXPECT_EQ(0, c->set_item_name(root0, root_name0));
 
   string name0("rule0");
-  int rule0 = c->add_simple_rule(name0, root_name0, "osd",
+  int rule0 = c->add_simple_rule(name0, root_name0, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(0, rule0);
 
@@ -352,7 +352,7 @@ TEST(CRUSH, straw_same) {
   EXPECT_EQ(0, c->set_item_name(root1, root_name1));
 
   string name1("rule1");
-  int rule1 = c->add_simple_rule(name1, root_name1, "osd",
+  int rule1 = c->add_simple_rule(name1, root_name1, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(1, rule1);
 
@@ -436,7 +436,7 @@ double calc_straw2_stddev(int *weights, int n, bool verbose)
   c->set_item_name(root0, root_name0);
 
   string name0("rule0");
-  int rule0 = c->add_simple_rule(name0, root_name0, "osd",
+  int rule0 = c->add_simple_rule(name0, root_name0, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
 
   int sum[n];
@@ -561,7 +561,7 @@ TEST(CRUSH, straw2_reweight) {
   EXPECT_EQ(0, c->set_item_name(root0, root_name0));
 
   string name0("rule0");
-  int rule0 = c->add_simple_rule(name0, root_name0, "osd",
+  int rule0 = c->add_simple_rule(name0, root_name0, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(0, rule0);
 
@@ -577,7 +577,7 @@ TEST(CRUSH, straw2_reweight) {
   EXPECT_EQ(0, c->set_item_name(root1, root_name1));
 
   string name1("rule1");
-  int rule1 = c->add_simple_rule(name1, root_name1, "osd",
+  int rule1 = c->add_simple_rule(name1, root_name1, "osd", "",
 				       "firstn", pg_pool_t::TYPE_REPLICATED);
   EXPECT_EQ(1, rule1);
 

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -42,7 +42,7 @@ public:
   int create_ruleset(const string &name,
 			     CrushWrapper &crush,
 			     ostream *ss) const override {
-    return crush.add_simple_rule(name, "default", "host",
+    return crush.add_simple_rule(name, "default", "host", "",
 				 "indep", pg_pool_t::TYPE_ERASURE, ss);
   }
   

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -39,7 +39,7 @@ class ErasureCodeExample : public ErasureCode {
 public:
   ~ErasureCodeExample() override {}
 
-  int create_ruleset(const string &name,
+  int create_rule(const string &name,
 			     CrushWrapper &crush,
 			     ostream *ss) const override {
     return crush.add_simple_rule(name, "default", "host", "",

--- a/src/test/erasure-code/TestErasureCode.cc
+++ b/src/test/erasure-code/TestErasureCode.cc
@@ -47,10 +47,9 @@ public:
     encode_chunks_encoded = *encoded;
     return 0;
   }
-  int create_ruleset(const string &name,
-			     CrushWrapper &crush,
-			     ostream *ss) const override { return 0; }
-
+  int create_rule(const string &name,
+		  CrushWrapper &crush,
+		  ostream *ss) const override { return 0; }
 };
 
 /*

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -201,7 +201,7 @@ TEST(ErasureCodeExample, decode)
   EXPECT_EQ(-ERANGE, example.decode_concat(degraded, &out));
 }
 
-TEST(ErasureCodeExample, create_ruleset)
+TEST(ErasureCodeExample, create_rule)
 {
   CrushWrapper *c = new CrushWrapper;
   c->create();
@@ -229,7 +229,7 @@ TEST(ErasureCodeExample, create_ruleset)
 
   stringstream ss;
   ErasureCodeExample example;
-  EXPECT_EQ(0, example.create_ruleset("myrule", *c, &ss));
+  EXPECT_EQ(0, example.create_rule("myrule", *c, &ss));
 }
 
 /*

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -874,7 +874,7 @@ TEST_F(IsaErasureCodeTest, isa_xor_codec)
   EXPECT_EQ(5, cnt_cf);
 }
 
-TEST_F(IsaErasureCodeTest, create_ruleset)
+TEST_F(IsaErasureCodeTest, create_rule)
 {
   CrushWrapper *c = new CrushWrapper;
   c->create();
@@ -913,9 +913,9 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     isa.init(profile, &cerr);
-    int ruleset = isa.create_ruleset("myrule", *c, &ss);
+    int ruleset = isa.create_rule("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
-    EXPECT_EQ(-EEXIST, isa.create_ruleset("myrule", *c, &ss));
+    EXPECT_EQ(-EEXIST, isa.create_rule("myrule", *c, &ss));
     //
     // the minimum that is expected from the created ruleset is to
     // successfully map get_chunk_count() devices from the crushmap,
@@ -936,9 +936,9 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    profile["ruleset-root"] = "BAD";
+    profile["crush-root"] = "BAD";
     isa.init(profile, &cerr);
-    EXPECT_EQ(-ENOENT, isa.create_ruleset("otherrule", *c, &ss));
+    EXPECT_EQ(-ENOENT, isa.create_rule("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
   {
@@ -948,9 +948,9 @@ TEST_F(IsaErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    profile["ruleset-failure-domain"] = "WORSE";
+    profile["crush-failure-domain"] = "WORSE";
     isa.init(profile, &cerr);
-    EXPECT_EQ(-EINVAL, isa.create_ruleset("otherrule", *c, &ss));
+    EXPECT_EQ(-EINVAL, isa.create_rule("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }
 }

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -277,7 +277,7 @@ TEST(ErasureCodeTest, encode)
   }
 }
 
-TEST(ErasureCodeTest, create_ruleset)
+TEST(ErasureCodeTest, create_rule)
 {
   CrushWrapper *c = new CrushWrapper;
   c->create();
@@ -316,9 +316,9 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["m"] = "2";
     profile["w"] = "8";
     jerasure.init(profile, &cerr);
-    int ruleset = jerasure.create_ruleset("myrule", *c, &ss);
+    int ruleset = jerasure.create_rule("myrule", *c, &ss);
     EXPECT_EQ(0, ruleset);
-    EXPECT_EQ(-EEXIST, jerasure.create_ruleset("myrule", *c, &ss));
+    EXPECT_EQ(-EEXIST, jerasure.create_rule("myrule", *c, &ss));
     //
     // the minimum that is expected from the created ruleset is to
     // successfully map get_chunk_count() devices from the crushmap,
@@ -339,9 +339,9 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    profile["ruleset-root"] = "BAD";
+    profile["crush-root"] = "BAD";
     jerasure.init(profile, &cerr);
-    EXPECT_EQ(-ENOENT, jerasure.create_ruleset("otherrule", *c, &ss));
+    EXPECT_EQ(-ENOENT, jerasure.create_rule("otherrule", *c, &ss));
     EXPECT_EQ("root item BAD does not exist", ss.str());
   }
   {
@@ -351,9 +351,9 @@ TEST(ErasureCodeTest, create_ruleset)
     profile["k"] = "2";
     profile["m"] = "2";
     profile["w"] = "8";
-    profile["ruleset-failure-domain"] = "WORSE";
+    profile["crush-failure-domain"] = "WORSE";
     jerasure.init(profile, &cerr);
-    EXPECT_EQ(-EINVAL, jerasure.create_ruleset("otherrule", *c, &ss));
+    EXPECT_EQ(-EINVAL, jerasure.create_rule("otherrule", *c, &ss));
     EXPECT_EQ("unknown type WORSE", ss.str());
   }
 }

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -48,7 +48,7 @@ TEST(ErasureCodeShec, init_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -61,8 +61,8 @@ TEST(ErasureCodeShec, init_1)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -80,8 +80,8 @@ TEST(ErasureCodeShec, init_2)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-root"] = "test";
-  (*profile)["ruleset-failure-domain"] = "host";
+  (*profile)["crush-root"] = "test";
+  (*profile)["crush-failure-domain"] = "host";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -95,8 +95,8 @@ TEST(ErasureCodeShec, init_2)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("test", shec->ruleset_root.c_str());
-  EXPECT_STREQ("host", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("test", shec->rule_root.c_str());
+  EXPECT_STREQ("host", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -114,7 +114,7 @@ TEST(ErasureCodeShec, init_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -128,8 +128,8 @@ TEST(ErasureCodeShec, init_3)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(16, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -147,7 +147,7 @@ TEST(ErasureCodeShec, init_4)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -161,8 +161,8 @@ TEST(ErasureCodeShec, init_4)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(32, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -179,7 +179,7 @@ TEST(ErasureCodeShec, init_5)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   //plugin is not specified
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -202,7 +202,7 @@ TEST(ErasureCodeShec, init_6)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "jerasure";	//unexpected value
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -225,7 +225,7 @@ TEST(ErasureCodeShec, init_7)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "abc";	//unexpected value
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -248,7 +248,7 @@ TEST(ErasureCodeShec, init_8)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -271,8 +271,8 @@ TEST(ErasureCodeShec, init_9)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-root"] = "abc";	//unexpected value
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-root"] = "abc";	//unexpected value
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -295,7 +295,7 @@ TEST(ErasureCodeShec, init_10)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "abc";	//unexpected value
+  (*profile)["crush-failure-domain"] = "abc";	//unexpected value
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -318,7 +318,7 @@ TEST(ErasureCodeShec, init_11)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "abc";		//unexpected value
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -341,7 +341,7 @@ TEST(ErasureCodeShec, init_12)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "-1";	//unexpected value
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -363,7 +363,7 @@ TEST(ErasureCodeShec, init_13)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "abc";
+  (*profile)["crush-failure-domain"] = "abc";
   (*profile)["k"] = "0.1";	//unexpected value
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -385,7 +385,7 @@ TEST(ErasureCodeShec, init_14)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "a";		//unexpected value
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -407,7 +407,7 @@ TEST(ErasureCodeShec, init_15)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   //k is not specified
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -429,7 +429,7 @@ TEST(ErasureCodeShec, init_16)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "-1";		//unexpected value
   (*profile)["c"] = "2";
@@ -451,7 +451,7 @@ TEST(ErasureCodeShec, init_17)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "0.1";		//unexpected value
   (*profile)["c"] = "2";
@@ -473,7 +473,7 @@ TEST(ErasureCodeShec, init_18)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "a";		//unexpected value
   (*profile)["c"] = "2";
@@ -495,7 +495,7 @@ TEST(ErasureCodeShec, init_19)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   //m is not specified
   (*profile)["c"] = "2";
@@ -517,7 +517,7 @@ TEST(ErasureCodeShec, init_20)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "-1";		//unexpected value
@@ -539,7 +539,7 @@ TEST(ErasureCodeShec, init_21)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "0.1";		//unexpected value
@@ -561,7 +561,7 @@ TEST(ErasureCodeShec, init_22)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "a";		//unexpected value
@@ -583,7 +583,7 @@ TEST(ErasureCodeShec, init_23)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   //c is not specified
@@ -605,7 +605,7 @@ TEST(ErasureCodeShec, init_24)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -634,7 +634,7 @@ TEST(ErasureCodeShec, init_25)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -663,7 +663,7 @@ TEST(ErasureCodeShec, init_26)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -692,7 +692,7 @@ TEST(ErasureCodeShec, init_27)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -721,7 +721,7 @@ TEST(ErasureCodeShec, init_28)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "10";	//c > m
@@ -743,7 +743,7 @@ TEST(ErasureCodeShec, init_29)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   //k is not specified
   //m is not specified
   //c is not specified
@@ -770,7 +770,7 @@ TEST(ErasureCodeShec, init_30)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "12";
   (*profile)["m"] = "8";
   (*profile)["c"] = "8";
@@ -796,7 +796,7 @@ TEST(ErasureCodeShec, init_31)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "13";
   (*profile)["m"] = "7";
   (*profile)["c"] = "7";
@@ -818,7 +818,7 @@ TEST(ErasureCodeShec, init_32)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "7";
   (*profile)["m"] = "13";
   (*profile)["c"] = "13";
@@ -840,7 +840,7 @@ TEST(ErasureCodeShec, init_33)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "12";
   (*profile)["m"] = "9";
   (*profile)["c"] = "8";
@@ -862,7 +862,7 @@ TEST(ErasureCodeShec, init_34)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "8";
   (*profile)["m"] = "12";
   (*profile)["c"] = "12";
@@ -885,7 +885,7 @@ TEST(ErasureCodeShec, init2_4)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -898,8 +898,8 @@ TEST(ErasureCodeShec, init2_4)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -918,7 +918,7 @@ TEST(ErasureCodeShec, init2_5)
   ErasureCodeProfile *profile2 = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "host";
+  (*profile)["crush-failure-domain"] = "host";
   (*profile)["k"] = "10";
   (*profile)["m"] = "6";
   (*profile)["c"] = "5";
@@ -929,7 +929,7 @@ TEST(ErasureCodeShec, init2_5)
   //reexecute init
   (*profile2)["plugin"] = "shec";
   (*profile2)["technique"] = "";
-  (*profile2)["ruleset-failure-domain"] = "osd";
+  (*profile2)["crush-failure-domain"] = "osd";
   (*profile2)["k"] = "4";
   (*profile2)["m"] = "3";
   (*profile2)["c"] = "2";
@@ -940,8 +940,8 @@ TEST(ErasureCodeShec, init2_5)
   EXPECT_EQ(2, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
 
@@ -959,7 +959,7 @@ TEST(ErasureCodeShec, minimum_to_decode_8)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -995,7 +995,7 @@ TEST(ErasureCodeShec, minimum_to_decode_9)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1031,7 +1031,7 @@ TEST(ErasureCodeShec, minimum_to_decode_10)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1067,7 +1067,7 @@ TEST(ErasureCodeShec, minimum_to_decode_11)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1103,7 +1103,7 @@ TEST(ErasureCodeShec, minimum_to_decode_12)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1136,7 +1136,7 @@ TEST(ErasureCodeShec, minimum_to_decode_13)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1177,7 +1177,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1213,7 +1213,7 @@ TEST(ErasureCodeShec, minimum_to_decode2_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1262,7 +1262,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1298,7 +1298,7 @@ TEST(ErasureCodeShec, minimum_to_decode_with_cost_2_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1347,7 +1347,7 @@ TEST(ErasureCodeShec, encode_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1408,7 +1408,7 @@ TEST(ErasureCodeShec, encode_2)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1464,7 +1464,7 @@ TEST(ErasureCodeShec, encode_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1521,7 +1521,7 @@ TEST(ErasureCodeShec, encode_4)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1580,7 +1580,7 @@ TEST(ErasureCodeShec, encode_8)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1614,7 +1614,7 @@ TEST(ErasureCodeShec, encode_9)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1652,7 +1652,7 @@ TEST(ErasureCodeShec, encode2_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1711,7 +1711,7 @@ TEST(ErasureCodeShec, encode2_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1782,7 +1782,7 @@ TEST(ErasureCodeShec, decode_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1848,7 +1848,7 @@ TEST(ErasureCodeShec, decode_8)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1914,7 +1914,7 @@ TEST(ErasureCodeShec, decode_9)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -1992,7 +1992,7 @@ TEST(ErasureCodeShec, decode_10)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2043,7 +2043,7 @@ TEST(ErasureCodeShec, decode_11)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2093,7 +2093,7 @@ TEST(ErasureCodeShec, decode_12)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2141,7 +2141,7 @@ TEST(ErasureCodeShec, decode_13)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2196,7 +2196,7 @@ TEST(ErasureCodeShec, decode2_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2252,7 +2252,7 @@ TEST(ErasureCodeShec, decode2_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2319,7 +2319,7 @@ TEST(ErasureCodeShec, decode2_4)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2361,7 +2361,7 @@ TEST(ErasureCodeShec, decode2_4)
   delete profile;
 }
 
-TEST(ErasureCodeShec, create_ruleset_1_2)
+TEST(ErasureCodeShec, create_rule_1_2)
 {
   //create ruleset
   CrushWrapper *crush = new CrushWrapper;
@@ -2397,21 +2397,21 @@ TEST(ErasureCodeShec, create_ruleset_1_2)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
   shec->init(*profile, &cerr);
 
-  //create_ruleset
+  //create_rule
   stringstream ss;
 
-  int r = shec->create_ruleset("myrule", *crush, &ss);
+  int r = shec->create_rule("myrule", *crush, &ss);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("myrule", crush->rule_name_map[0].c_str());
 
-  //reexecute create_ruleset
-  r = shec->create_ruleset("myrule", *crush, &ss);
+  //reexecute create_rule
+  r = shec->create_rule("myrule", *crush, &ss);
   EXPECT_EQ(-EEXIST, r);
 
   delete shec;
@@ -2419,7 +2419,7 @@ TEST(ErasureCodeShec, create_ruleset_1_2)
   delete crush;
 }
 
-TEST(ErasureCodeShec, create_ruleset_4)
+TEST(ErasureCodeShec, create_rule_4)
 {
   //create ruleset
   CrushWrapper *crush = new CrushWrapper;
@@ -2455,14 +2455,14 @@ TEST(ErasureCodeShec, create_ruleset_4)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
   shec->init(*profile, &cerr);
 
-  //create_ruleset
-  int r = shec->create_ruleset("myrule", *crush, NULL);	//ss = NULL
+  //create_rule
+  int r = shec->create_rule("myrule", *crush, NULL);	//ss = NULL
   EXPECT_EQ(0, r);
 
   delete shec;
@@ -2470,7 +2470,7 @@ TEST(ErasureCodeShec, create_ruleset_4)
   delete crush;
 }
 
-TEST(ErasureCodeShec, create_ruleset2_1)
+TEST(ErasureCodeShec, create_rule2_1)
 {
   //create ruleset
   CrushWrapper *crush = new CrushWrapper;
@@ -2506,16 +2506,16 @@ TEST(ErasureCodeShec, create_ruleset2_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
   shec->init(*profile, &cerr);
 
-  //create_ruleset
+  //create_rule
   stringstream ss;
 
-  int r = shec->create_ruleset("myrule", *crush, &ss);
+  int r = shec->create_rule("myrule", *crush, &ss);
   EXPECT_EQ(0, r);
   EXPECT_STREQ("myrule", crush->rule_name_map[0].c_str());
 
@@ -2529,7 +2529,7 @@ struct CreateRuleset2_3_Param_d {
   CrushWrapper *crush;
 };
 
-TEST(ErasureCodeShec, create_ruleset2_3)
+TEST(ErasureCodeShec, create_rule2_3)
 {
   //create ruleset
   CrushWrapper *crush = new CrushWrapper;
@@ -2565,13 +2565,13 @@ TEST(ErasureCodeShec, create_ruleset2_3)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
   shec->init(*profile, &cerr);
 
-  //create_ruleset
+  //create_rule
   stringstream ss;
 
   pthread_t tid;
@@ -2582,7 +2582,7 @@ TEST(ErasureCodeShec, create_ruleset2_3)
   }
   sleep(1);
   printf("*** test start ***\n");
-  int r = (shec->create_ruleset("myrule", *crush, &ss));
+  int r = (shec->create_rule("myrule", *crush, &ss));
   EXPECT_TRUE(r >= 0);
   printf("*** test end ***\n");
   g_flag = 0;
@@ -2603,7 +2603,7 @@ TEST(ErasureCodeShec, get_chunk_count_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2626,7 +2626,7 @@ TEST(ErasureCodeShec, get_data_chunk_count_1)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2649,7 +2649,7 @@ TEST(ErasureCodeShec, get_chunk_size_1_2)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = "4";
   (*profile)["m"] = "3";
   (*profile)["c"] = "2";
@@ -2750,7 +2750,7 @@ void* thread3(void* pParam)
   g_flag = 1;
   while (g_flag == 1) {
     sprintf(name, "myrule%d", i);
-    shec->create_ruleset(name, *crush, &ss);
+    shec->create_rule(name, *crush, &ss);
     ++i;
   }
   printf("*** thread loop end ***\n");

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -77,7 +77,7 @@ TEST_P(ParameterTest, parameter_all)
   ErasureCodeProfile *profile = new ErasureCodeProfile();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = k;
   (*profile)["m"] = m;
   (*profile)["c"] = c;
@@ -90,8 +90,8 @@ TEST_P(ParameterTest, parameter_all)
   EXPECT_EQ(i_c, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, result);
 
@@ -215,7 +215,7 @@ TEST_P(ParameterTest, parameter_all)
   EXPECT_FALSE(out1 == in);
   EXPECT_TRUE(usable == in);
 
-  //create_ruleset
+  //create_rule
   stringstream ss;
   CrushWrapper *crush = new CrushWrapper;
   crush->create();
@@ -242,7 +242,7 @@ TEST_P(ParameterTest, parameter_all)
     }
   }
 
-  result = shec->create_ruleset("myrule", *crush, &ss);
+  result = shec->create_rule("myrule", *crush, &ss);
   EXPECT_EQ(0, result);
   EXPECT_STREQ("myrule", crush->rule_name_map[0].c_str());
 

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -189,7 +189,7 @@ TEST(ParameterTest, combination_all)
 							 std::string>();
   (*profile)["plugin"] = "shec";
   (*profile)["technique"] = "";
-  (*profile)["ruleset-failure-domain"] = "osd";
+  (*profile)["crush-failure-domain"] = "osd";
   (*profile)["k"] = k;
   (*profile)["m"] = m;
   (*profile)["c"] = c;
@@ -202,8 +202,8 @@ TEST(ParameterTest, combination_all)
   EXPECT_EQ(i_c, shec->c);
   EXPECT_EQ(8, shec->w);
   EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-  EXPECT_STREQ("default", shec->ruleset_root.c_str());
-  EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+  EXPECT_STREQ("default", shec->rule_root.c_str());
+  EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, result);
 

--- a/src/test/erasure-code/TestErasureCodeShec_thread.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_thread.cc
@@ -129,7 +129,7 @@ void* thread1(void* pParam)
     ErasureCodeProfile *profile = new ErasureCodeProfile();
     (*profile)["plugin"] = "shec";
     (*profile)["technique"] = "multiple";
-    (*profile)["ruleset-failure-domain"] = "osd";
+    (*profile)["crush-failure-domain"] = "osd";
     (*profile)["k"] = param->k;
     (*profile)["m"] = param->m;
     (*profile)["c"] = param->c;
@@ -147,8 +147,8 @@ void* thread1(void* pParam)
     EXPECT_EQ(i_c, shec->c);
     EXPECT_EQ(i_w, shec->w);
     EXPECT_EQ(ErasureCodeShec::MULTIPLE, shec->technique);
-    EXPECT_STREQ("default", shec->ruleset_root.c_str());
-    EXPECT_STREQ("osd", shec->ruleset_failure_domain.c_str());
+    EXPECT_STREQ("default", shec->rule_root.c_str());
+    EXPECT_STREQ("osd", shec->rule_failure_domain.c_str());
     EXPECT_TRUE(shec->matrix != NULL);
     if ((shec->matrix == NULL)) {
       std::cout << "matrix is null" << std::endl;

--- a/src/test/erasure-code/test-erasure-code-plugins.sh
+++ b/src/test/erasure-code/test-erasure-code-plugins.sh
@@ -100,13 +100,13 @@ function TEST_ec_profile_warning() {
     wait_for_clean || return 1
 
     for plugin in ${legacy_jerasure_plugins[*]}; do
-        ceph osd erasure-code-profile set prof-${plugin} ruleset-failure-domain=osd technique=reed_sol_van plugin=${plugin} || return 1
+        ceph osd erasure-code-profile set prof-${plugin} crush-failure-domain=osd technique=reed_sol_van plugin=${plugin} || return 1
         CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
         grep "WARNING: erasure coding profile prof-${plugin} uses plugin ${plugin}" $dir/mon.a.log || return 1
     done
 
     for plugin in ${legacy_shec_plugins[*]}; do
-        ceph osd erasure-code-profile set prof-${plugin} ruleset-failure-domain=osd plugin=${plugin} || return 1
+        ceph osd erasure-code-profile set prof-${plugin} crush-failure-domain=osd plugin=${plugin} || return 1
         CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
         grep "WARNING: erasure coding profile prof-${plugin} uses plugin ${plugin}" $dir/mon.a.log || return 1
     done

--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -56,7 +56,7 @@ function create_erasure_coded_pool() {
     local poolname=$1
 
     ceph osd erasure-code-profile set myprofile \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 12 12 erasure myprofile \
         || return 1
     wait_for_clean || return 1
@@ -162,7 +162,7 @@ function TEST_rados_put_get_lrc_advanced() {
     ceph osd erasure-code-profile set $profile \
         plugin=lrc \
         mapping=DD_ \
-        ruleset-steps='[ [ "chooseleaf", "osd", 0 ] ]' \
+        crush-steps='[ [ "chooseleaf", "osd", 0 ] ]' \
         layers='[ [ "DDc", "" ] ]'  || return 1
     ceph osd pool create $poolname 12 12 erasure $profile \
         || return 1
@@ -181,7 +181,7 @@ function TEST_rados_put_get_lrc_kml() {
     ceph osd erasure-code-profile set $profile \
         plugin=lrc \
         k=4 m=2 l=3 \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 12 12 erasure $profile \
         || return 1
 
@@ -201,7 +201,7 @@ function TEST_rados_put_get_isa() {
 
     ceph osd erasure-code-profile set profile-isa \
         plugin=isa \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 1 1 erasure profile-isa \
         || return 1
 
@@ -221,7 +221,7 @@ function TEST_rados_put_get_jerasure() {
     ceph osd erasure-code-profile set $profile \
         plugin=jerasure \
         k=4 m=2 \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 12 12 erasure $profile \
         || return 1
 
@@ -241,7 +241,7 @@ function TEST_rados_put_get_shec() {
     ceph osd erasure-code-profile set $profile \
         plugin=shec \
         k=2 m=1 c=1 \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 12 12 erasure $profile \
         || return 1
 
@@ -316,7 +316,7 @@ function TEST_chunk_mapping() {
         plugin=lrc \
         layers='[ [ "_DD", "" ] ]' \
         mapping='_DD' \
-        ruleset-steps='[ [ "choose", "osd", 0 ] ]' || return 1
+        crush-steps='[ [ "choose", "osd", 0 ] ]' || return 1
     ceph osd erasure-code-profile get remap-profile
     ceph osd pool create remap-pool 12 12 erasure remap-profile \
         || return 1

--- a/src/test/erasure-code/test-erasure-eio.sh
+++ b/src/test/erasure-code/test-erasure-eio.sh
@@ -58,7 +58,7 @@ function create_erasure_coded_pool() {
     ceph osd erasure-code-profile set myprofile \
         plugin=jerasure \
         k=2 m=1 \
-        ruleset-failure-domain=osd || return 1
+        crush-failure-domain=osd || return 1
     ceph osd pool create $poolname 1 1 erasure myprofile \
         || return 1
     wait_for_clean || return 1

--- a/src/test/librados/test.cc
+++ b/src/test/librados/test.cc
@@ -114,7 +114,7 @@ std::string create_one_ec_pool(const std::string &pool_name, rados_t *cluster)
   char *cmd[2];
   cmd[1] = NULL;
 
-  std::string profile_create = "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile-" + pool_name + "\", \"profile\": [ \"k=2\", \"m=1\", \"ruleset-failure-domain=osd\"]}";
+  std::string profile_create = "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile-" + pool_name + "\", \"profile\": [ \"k=2\", \"m=1\", \"crush-failure-domain=osd\"]}";
   cmd[0] = (char *)profile_create.c_str();
   ret = rados_mon_command(*cluster, (const char **)cmd, 1, "", 0, NULL, 0, NULL, 0);
   if (ret) {
@@ -207,7 +207,7 @@ std::string create_one_ec_pool_pp(const std::string &pool_name, Rados &cluster)
 
   bufferlist inbl;
   ret = cluster.mon_command(
-    "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile-" + pool_name + "\", \"profile\": [ \"k=2\", \"m=1\", \"ruleset-failure-domain=osd\"]}",
+    "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile-" + pool_name + "\", \"profile\": [ \"k=2\", \"m=1\", \"crush-failure-domain=osd\"]}",
     inbl, NULL, NULL);
   if (ret) {
     cluster.shutdown();

--- a/src/test/mon/osd-erasure-code-profile.sh
+++ b/src/test/mon/osd-erasure-code-profile.sh
@@ -142,9 +142,9 @@ function TEST_set_idempotent() {
     #
     profile=profileidempotent1
     ! ceph osd erasure-code-profile ls | grep $profile || return 1
-    ceph osd erasure-code-profile set $profile k=2 ruleset-failure-domain=osd 2>&1 || return 1
+    ceph osd erasure-code-profile set $profile k=2 crush-failure-domain=osd 2>&1 || return 1
     ceph osd erasure-code-profile ls | grep $profile || return 1
-    ceph osd erasure-code-profile set $profile k=2 ruleset-failure-domain=osd 2>&1 || return 1
+    ceph osd erasure-code-profile set $profile k=2 crush-failure-domain=osd 2>&1 || return 1
     ceph osd erasure-code-profile rm $profile # cleanup
 
     #
@@ -152,9 +152,9 @@ function TEST_set_idempotent() {
     #
     profile=profileidempotent2
     ! ceph osd erasure-code-profile ls | grep $profile || return 1
-    ceph osd erasure-code-profile set $profile plugin=lrc k=4 m=2 l=3 ruleset-failure-domain=osd 2>&1 || return 1
+    ceph osd erasure-code-profile set $profile plugin=lrc k=4 m=2 l=3 crush-failure-domain=osd 2>&1 || return 1
     ceph osd erasure-code-profile ls | grep $profile || return 1
-    ceph osd erasure-code-profile set $profile plugin=lrc k=4 m=2 l=3 ruleset-failure-domain=osd 2>&1 || return 1
+    ceph osd erasure-code-profile set $profile plugin=lrc k=4 m=2 l=3 crush-failure-domain=osd 2>&1 || return 1
     ceph osd erasure-code-profile rm $profile # cleanup
 }
 

--- a/src/test/multi_stress_watch.cc
+++ b/src/test/multi_stress_watch.cc
@@ -85,7 +85,7 @@ test_erasure(Rados &cluster, std::string pool_name, std::string obj_name)
   bufferlist inbl;
   int ret;
   ret = cluster.mon_command(
-    "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile\", \"profile\": [ \"k=2\", \"m=1\", \"ruleset-failure-domain=osd\"]}",
+    "{\"prefix\": \"osd erasure-code-profile set\", \"name\": \"testprofile\", \"profile\": [ \"k=2\", \"m=1\", \"crush-failure-domain=osd\"]}",
     inbl, NULL, &outs);
   if (ret < 0) {
     std::cerr << "mon_command erasure-code-profile set failed with " << ret << std::endl;

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -60,7 +60,7 @@ public:
 
     // Create an EC ruleset and a pool using it
     int r = osdmap.crush->add_simple_rule(
-      "erasure", "default", "osd",
+      "erasure", "default", "osd", "",
       "indep", pg_pool_t::TYPE_ERASURE,
       &cerr);
 

--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -181,7 +181,7 @@ function create_ec_pool() {
     local pool_name=$1
     local allow_overwrites=$2
 
-    ceph osd erasure-code-profile set myprofile ruleset-failure-domain=osd $3 $4 $5 $6 $7 || return 1
+    ceph osd erasure-code-profile set myprofile crush-failure-domain=osd $3 $4 $5 $6 $7 || return 1
 
     ceph osd pool create "$poolname" 1 1 erasure myprofile || return 1
 

--- a/src/tools/crushtool.cc
+++ b/src/tools/crushtool.cc
@@ -170,6 +170,11 @@ void usage()
        << "                         create crush rule <name> to start from <root>,\n"
        << "                         replicate across buckets of type <type>, using\n"
        << "                         a choose mode of <firstn|indep>\n";
+  cout << "   -i mapfn --create-replicated-rule name root type\n"
+       << "                         create crush rule <name> to start from <root>,\n"
+       << "                         replicate across buckets of type <type>\n";
+  cout << "   --device-class <class>\n";
+  cout << "                         use device class <class> for new rule\n";
   cout << "   -i mapfn --remove-rule name\n"
        << "                         remove the specified crush rule\n";
   cout << "\n";
@@ -259,7 +264,7 @@ int main(int argc, const char **argv)
   int add_item = -1;
   bool update_item = false;
   bool add_rule = false;
-  std::string rule_name, rule_root, rule_type, rule_mode;
+  std::string rule_name, rule_root, rule_type, rule_mode, rule_device_class;
   bool del_rule = false;
   float add_weight = 0;
   map<string,string> add_loc;
@@ -450,6 +455,41 @@ int main(int argc, const char **argv)
            << " mode=" << rule_mode
            << std::endl;
       add_rule = true;
+    } else if (ceph_argparse_witharg(args, i, &val, err, "--create-replicated-rule", (char*)NULL)) {
+      rule_name.assign(val);
+      if (!err.str().empty()) {
+        cerr << err.str() << std::endl;
+        return EXIT_FAILURE;
+      }
+      if (i == args.end()) {
+        cerr << "expecting additional argument to --create-replicated-rule" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      rule_root.assign(*i);
+      i = args.erase(i);
+      if (i == args.end()) {
+        cerr << "expecting additional argument to --create-replicated-rule" << std::endl;
+        return EXIT_FAILURE;
+      }
+
+      rule_type.assign(*i);
+      i = args.erase(i);
+      rule_mode = "firstn";
+
+      cout << "--create-replicated-rule:"
+           << " name=" << rule_name
+           << " root=" << rule_root
+           << " type=" << rule_type
+           << std::endl;
+      add_rule = true;
+
+    } else if (ceph_argparse_witharg(args, i, &val, "--device-class", (char*)NULL)) {
+      rule_device_class.assign(val);
+      if (!err.str().empty()) {
+        cerr << err.str() << std::endl;
+        return EXIT_FAILURE;
+      }
     } else if (ceph_argparse_witharg(args, i, &val, "--remove-rule", (char*)NULL)) {
       rule_name.assign(val);
       if (!err.str().empty()) {
@@ -896,8 +936,9 @@ int main(int argc, const char **argv)
       cerr << "rule " << rule_name << " already exists" << std::endl;
       return EXIT_FAILURE;
     }
-    int r = crush.add_simple_rule(rule_name, rule_root, rule_type, rule_mode,
-      pg_pool_t::TYPE_REPLICATED, &err);
+    int r = crush.add_simple_rule(rule_name, rule_root, rule_type,
+				  rule_device_class,
+				  rule_mode, pg_pool_t::TYPE_REPLICATED, &err);
     if (r < 0) {
       cerr << err.str() << std::endl;
       return EXIT_FAILURE;

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -409,7 +409,7 @@ prepare_conf() {
         mon data avail crit = 1
         erasure code dir = $EC_PATH
         plugin dir = $CEPH_LIB
-        osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 ruleset-failure-domain=osd
+        osd pool default erasure code profile = plugin=jerasure technique=reed_sol_van k=2 m=1 crush-failure-domain=osd
         rgw frontends = $rgw_frontend port=$CEPH_RGW_PORT
         ; needed for s3tests
         rgw crypt s3 kms encryption keys = testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=


### PR DESCRIPTION
for replicated pools:

  ceph osd crush rule create-replicated <name> <root> <failuredomain> [class]

for ec pools:

  ceph osd erasure-code-profile set ec-foo-ssd crush-device-class=ssd m=2 k=2
  ceph osd pool create ec-foo 8 erasure ec-foo-ssd

also some cleanup in the ec profiles, mainly renaming ruleset-* properties to crush-* properties.