### PR TITLE
rgw: add a new error code for non-existed user.

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -89,6 +89,7 @@ rgw_http_errors rgw_http_s3_errors({
     { ERR_NOT_FOUND, {404, "Not Found"}},
     { ERR_NO_SUCH_LC, {404, "NoSuchLifecycleConfiguration"}},
     { ERR_NO_SUCH_BUCKET_POLICY, {404, "NoSuchBucketPolicy"}},
+    { ERR_NO_SUCH_USER, {404, "NoSuchUser"}},
     { ERR_NO_SUCH_SUBUSER, {404, "NoSuchSubUser"}},
     { ERR_METHOD_NOT_ALLOWED, {405, "MethodNotAllowed" }},
     { ETIMEDOUT, {408, "RequestTimeout" }},

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -198,6 +198,7 @@ using ceph::crypto::MD5;
 #define ERR_NO_SUCH_WEBSITE_CONFIGURATION 2039
 #define ERR_AMZ_CONTENT_SHA256_MISMATCH 2040
 #define ERR_NO_SUCH_LC           2041
+#define ERR_NO_SUCH_USER         2042
 #define ERR_NO_SUCH_SUBUSER      2043
 #define ERR_USER_SUSPENDED       2100
 #define ERR_INTERNAL_ERROR       2200

--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -693,6 +693,11 @@ void RGWOp_Quota_Info::execute()
   if (http_ret < 0)
     return;
 
+  if (!op_state.has_existing_user()) {
+    http_ret = -ERR_NO_SUCH_USER;
+    return;
+  }
+
   RGWUserInfo info;
   string err_msg;
   http_ret = user.info(info, &err_msg);
@@ -822,6 +827,11 @@ void RGWOp_Quota_Set::execute()
   http_ret = user.init(store, op_state);
   if (http_ret < 0) {
     ldout(store->ctx(), 20) << "failed initializing user info: " << http_ret << dendl;
+    return;
+  }
+
+  if (!op_state.has_existing_user()) {
+    http_ret = -ERR_NO_SUCH_USER;
     return;
   }
 

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2299,7 +2299,7 @@ int RGWUserAdminOp_User::info(RGWRados *store, RGWUserAdminOpState& op_state,
     return ret;
 
   if (!op_state.has_existing_user())
-    return -ENOENT;
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 
@@ -2367,8 +2367,11 @@ int RGWUserAdminOp_User::modify(RGWRados *store, RGWUserAdminOpState& op_state,
   Formatter *formatter = flusher.get_formatter();
 
   ret = user.modify(op_state, NULL);
-  if (ret < 0)
+  if (ret < 0) {
+    if (ret == -ENOENT)
+      ret = -ERR_NO_SUCH_USER;
     return ret;
+  }
 
   ret = user.info(info, NULL);
   if (ret < 0)
@@ -2394,6 +2397,8 @@ int RGWUserAdminOp_User::remove(RGWRados *store, RGWUserAdminOpState& op_state,
 
   ret = user.remove(op_state, NULL);
 
+  if (ret == -ENOENT)
+    ret = -ERR_NO_SUCH_USER;
   return ret;
 }
 
@@ -2405,6 +2410,9 @@ int RGWUserAdminOp_Subuser::create(RGWRados *store, RGWUserAdminOpState& op_stat
   int ret = user.init(store, op_state);
   if (ret < 0)
     return ret;
+
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 
@@ -2432,6 +2440,9 @@ int RGWUserAdminOp_Subuser::modify(RGWRados *store, RGWUserAdminOpState& op_stat
   int ret = user.init(store, op_state);
   if (ret < 0)
     return ret;
+
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 
@@ -2461,6 +2472,9 @@ int RGWUserAdminOp_Subuser::remove(RGWRados *store, RGWUserAdminOpState& op_stat
     return ret;
 
 
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
+
   ret = user.subusers.remove(op_state, NULL);
   if (ret < 0)
     return ret;
@@ -2476,6 +2490,9 @@ int RGWUserAdminOp_Key::create(RGWRados *store, RGWUserAdminOpState& op_state,
   int ret = user.init(store, op_state);
   if (ret < 0)
     return ret;
+
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 
@@ -2511,6 +2528,9 @@ int RGWUserAdminOp_Key::remove(RGWRados *store, RGWUserAdminOpState& op_state,
   if (ret < 0)
     return ret;
 
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
+
 
   ret = user.keys.remove(op_state, NULL);
   if (ret < 0)
@@ -2527,6 +2547,9 @@ int RGWUserAdminOp_Caps::add(RGWRados *store, RGWUserAdminOpState& op_state,
   int ret = user.init(store, op_state);
   if (ret < 0)
     return ret;
+
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 
@@ -2555,6 +2578,9 @@ int RGWUserAdminOp_Caps::remove(RGWRados *store, RGWUserAdminOpState& op_state,
   int ret = user.init(store, op_state);
   if (ret < 0)
     return ret;
+
+  if (!op_state.has_existing_user())
+    return -ERR_NO_SUCH_USER;
 
   Formatter *formatter = flusher.get_formatter();
 


### PR DESCRIPTION
From http://docs.ceph.com/docs/master/radosgw/adminops/, There should be
a "NoSuchUser" response for user actions rather than "NoSuchKey".

Fixes: http://tracker.ceph.com/issues/20468

Signed-off-by: Zhao Chao <zhaochao1984@gmail.com>