### PR TITLE
MDS: clean up traverse_to_auth_dir and C_MDS_Tick

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -78,8 +78,6 @@ public:
   explicit C_MDS_Tick(MDSDaemon *m) : mds_daemon(m) {}
   void finish(int r) override {
     assert(mds_daemon->mds_lock.is_locked_by_me());
-
-    mds_daemon->tick_event = 0;
     mds_daemon->tick();
   }
 };

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -2629,7 +2629,6 @@ CDentry* Server::rdlock_path_xlock_dentry(MDRequestRef& mdr, int n,
 
   CDir *dir = traverse_to_auth_dir(mdr, mdr->dn[n], refpath);
   if (!dir) return 0;
-  dout(10) << "rdlock_path_xlock_dentry dir " << *dir << dendl;
 
   // make sure we can auth_pin (or have already authpinned) dir
   if (dir->is_frozen()) {


### PR DESCRIPTION
1. "traverse_to_auth_dir()" will be print "*dir", so this place is repeated,
    This extra print was found when I was using log location problems

2. "tick_event" will be assign in the MDSDaemon::tick(), so this place is unnecessary

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>
