### PR TITLE
os/bluestore: increase aio queue size by 16x

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1053,7 +1053,7 @@ OPTION(bdev_inject_crash, OPT_INT, 0)  // if N>0, then ~ 1/N IOs will complete b
 OPTION(bdev_inject_crash_flush_delay, OPT_INT, 2) // wait N more seconds on flush
 OPTION(bdev_aio, OPT_BOOL, true)
 OPTION(bdev_aio_poll_ms, OPT_INT, 250)  // milliseconds
-OPTION(bdev_aio_max_queue_depth, OPT_INT, 1024)
+OPTION(bdev_aio_max_queue_depth, OPT_INT, 16384)
 OPTION(bdev_block_size, OPT_INT, 4096)
 OPTION(bdev_debug_aio, OPT_BOOL, false)
 OPTION(bdev_debug_aio_suicide_timeout, OPT_FLOAT, 60.0)


### PR DESCRIPTION
It is possible for the aio submission to deadlock trying to submit
deferred ios while the completion thread is trying to complete deferred
aios.  It's tricky to fix but we can avoid it by having a very big
aio queue.

See http://tracker.ceph.com/issues/20381
Signed-off-by: Sage Weil <sage@redhat.com>