### PR TITLE
mon/mgr: add detail error infomation

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -579,6 +579,7 @@ bool MgrMonitor::prepare_command(MonOpRequestRef op)
       promote_standby();
     }
   } else {
+    ss << "Command '" << prefix << "' not implemented!";
     r = -ENOSYS;
   }
 


### PR DESCRIPTION
if we add a command such as `mgr dump_stats` in MGR  DaemonServer, then we upgrade ceph from jewel to luminous or later, and `require-osd-release`  has not set to `luminous `, then we get the following errors:
```
[root@control01 rpm]# ceph mgr dump_stats 
Error ENOSYS: 
[root@control01 rpm]# 
```
that's because of `require-osd-release < luminous` , MGR flag of the commands in `MgrCommands.h` will be hidden, and Command will be sent to mon but mgr. 
```
[root@control01 rpm]# ceph mgr dump_stats
Error ENOSYS: Command 'mgr dump_stats' not implemented!
[root@control01 rpm]# 
```
Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>