### PR TITLE
common: fix log warnings

### DIFF
--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -51,9 +51,9 @@ clog_type LogEntry::str_to_level(std::string const &str)
     return CLOG_INFO;
   } else if (level_str == "sec") {
     return CLOG_SEC;
-  } else if (level_str == "warn" | level_str == "warning") {
+  } else if (level_str == "warn" || level_str == "warning") {
     return CLOG_WARN;
-  } else if (level_str == "error" | level_str == "err") {
+  } else if (level_str == "error" || level_str == "err") {
     return CLOG_ERROR;
   } else {
     return CLOG_UNKNOWN;


### PR DESCRIPTION
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/LogEntry.cc:54:24: warning: suggest parentheses around comparison in operand of ‘|’ [-Wparentheses]
   } else if (level_str == "warn" | level_str == "warning") {
                        ^
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/LogEntry.cc:56:24: warning: suggest parentheses around comparison in operand of ‘|’ [-Wparentheses]
   } else if (level_str == "error" | level_str == "err") {

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>