### PR TITLE
rbd-nbd: prompt protecting snap when rbd-nbd map a snap

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -682,6 +682,18 @@ static int do_map(int argc, const char *argv[], Config *cfg)
   }
 
   if (!cfg->snapname.empty()) {
+    bool is_protected = false;
+    r = image.snap_is_protected(cfg->snapname.c_str(), &is_protected);
+    if (r < 0) {
+      cerr << "rbd-nbd: failed to get protect info of snap " << cfg->snapname
+           << ": " << cpp_strerror(r) << std::endl;
+      goto close_nbd;
+    } else if (!is_protected) {
+      cerr << "rbd-nbd: snapshot must be protected" << std::endl;
+      r = -EINVAL;
+      goto close_nbd;
+    }
+
     r = image.snap_set(cfg->snapname.c_str());
     if (r < 0)
       goto close_nbd;


### PR DESCRIPTION
prompt protecting snap when rbd-nbd map a snap  
this avoid the snap being removing while the nbd device is using  
Fixes: http://tracker.ceph.com/issues/20485  
Signed-off-by: mychoxin <mychoxin@gmail.com>