### PR TITLE
jewel: ceph-disk: remove the special check to bcache devices

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -734,20 +734,6 @@ def get_partition_base_mpath(dev):
     return os.path.join('/dev/mapper', name)
 
 
-def is_bcache(dev_name):
-    """
-    Check if dev_name is a bcache
-    """
-    if not dev_name.startswith('bcache'):
-        return False
-    if not os.path.exists(os.path.join('/sys/block', dev_name, 'bcache')):
-        return False
-    if os.path.exists(os.path.join('/sys/block', dev_name,
-                                   'bcache/cache_mode')):
-        return True
-    return False
-
-
 def is_partition(dev):
     """
     Check whether a given device path is a partition or a full disk.
@@ -761,8 +747,6 @@ def is_partition(dev):
         raise Error('not a block device', dev)
 
     name = get_dev_name(dev)
-    if is_bcache(name):
-        return True
     if os.path.exists(os.path.join('/sys/block', name)):
         return False
 


### PR DESCRIPTION
if we skip partition when coming cross the bcache device in ceph-disk,
the udev can't detect the osd in such devices when we reboot the osd's host,
so the osd who deploy in bcache device can't auto start when the host restart.

And partition is now supported by bcache devices (https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/commit/drivers/md/bcache?id=b8c0d911ac5285e6be8967713271a51bdc5a936a),
we can remove this special check now.

Signed-off-by: Wei Qiaomiao <wei.qiaomiao@zte.com.cn>