### PR TITLE
mds: miscellaneous multimds fixes

### DIFF
--- a/src/mds/Locker.h
+++ b/src/mds/Locker.h
@@ -192,7 +192,7 @@ public:
   void handle_client_caps(class MClientCaps *m);
   void _update_cap_fields(CInode *in, int dirty, MClientCaps *m, inode_t *pi);
   void _do_snap_update(CInode *in, snapid_t snap, int dirty, snapid_t follows, client_t client, MClientCaps *m, MClientCaps *ack);
-  void _do_null_snapflush(CInode *head_in, client_t client);
+  void _do_null_snapflush(CInode *head_in, client_t client, snapid_t last=CEPH_NOSNAP);
   bool _do_cap_update(CInode *in, Capability *cap, int dirty, snapid_t follows, MClientCaps *m,
 		      MClientCaps *ack=0, bool *need_flush=NULL);
   void handle_client_cap_release(class MClientCapRelease *m);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6080,6 +6080,20 @@ void MDCache::rejoin_send_acks()
   rejoin_imported_caps.clear();
 }
 
+class C_MDC_ReIssueCaps : public MDCacheContext {
+  CInode *in;
+public:
+  C_MDC_ReIssueCaps(MDCache *mdc, CInode *i) :
+    MDCacheContext(mdc), in(i)
+  {
+    in->get(CInode::PIN_PTRWAITER);
+  }
+  void finish(int r) override {
+    if (!mdcache->mds->locker->eval(in, CEPH_CAP_LOCKS))
+      mdcache->mds->locker->issue_caps(in);
+    in->put(CInode::PIN_PTRWAITER);
+  }
+};
 
 void MDCache::reissue_all_caps()
 {
@@ -6090,6 +6104,11 @@ void MDCache::reissue_all_caps()
        ++p) {
     CInode *in = p->second;
     if (in->is_head() && in->is_any_caps()) {
+      // called by MDSRank::active_start(). There shouldn't be any frozen subtree.
+      if (in->is_frozen_inode()) {
+	in->add_waiter(CInode::WAIT_UNFREEZE, new C_MDC_ReIssueCaps(this, in));
+	continue;
+      }
       if (!mds->locker->eval(in, CEPH_CAP_LOCKS))
 	mds->locker->issue_caps(in);
     }

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7627,6 +7627,11 @@ bool MDCache::shutdown_pass()
   assert(!migrator->is_exporting());
   assert(!migrator->is_importing());
 
+  if ((myin && myin->is_auth_pinned()) ||
+      (mydir && mydir->is_auth_pinned())) {
+    dout(7) << "still have auth pinned objects" << dendl;
+    return false;
+  }
 
   // flush what we can from the log
   mds->mdlog->trim(0);

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -116,6 +116,21 @@ void PurgeQueue::init()
   timer.init();
 }
 
+void PurgeQueue::activate()
+{
+  Mutex::Locker l(lock);
+  if (journaler.get_read_pos() == journaler.get_write_pos())
+    return;
+
+  if (in_flight.empty()) {
+    dout(4) << "start work (by drain)" << dendl;
+    finisher.queue(new FunctionContext([this](int r) {
+	  Mutex::Locker l(lock);
+	  _consume();
+	  }));
+  }
+}
+
 void PurgeQueue::shutdown()
 {
   Mutex::Locker l(lock);

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -133,6 +133,7 @@ protected:
 
 public:
   void init();
+  void activate();
   void shutdown();
 
   void create_logger();

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -545,6 +545,7 @@ void StrayManager::activate()
 {
   dout(10) << __func__ << dendl;
   started = true;
+  purge_queue.activate();
 }
 
 bool StrayManager::eval_stray(CDentry *dn, bool delay)

--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -314,27 +314,13 @@ class C_OpenSnapParents : public StrayManagerContext {
 
 void StrayManager::_enqueue(CDentry *dn, bool trunc)
 {
+  assert(started);
+
   CInode *in = dn->get_linkage()->get_inode();
   if (in->snaprealm &&
       !in->snaprealm->have_past_parents_open() &&
       !in->snaprealm->open_parents(new C_OpenSnapParents(this, dn, trunc))) {
     // this can happen if the dentry had been trimmed from cache.
-    return;
-  }
-
-  if (!started) {
-    // If the MDS is not yet active, defer executing this purge
-    // in order to avoid the mdlog writes we do on purge completion.
-    mds->wait_for_active(
-        new MDSInternalContextWrapper(mds,
-          new FunctionContext([this, dn, trunc](int r){
-            // It is safe to hold on to this CDentry* pointer
-            // because the dentry is pinned with PIN_PURGING
-           _enqueue(dn, trunc); 
-            })
-        )
-      );
-
     return;
   }
 
@@ -348,6 +334,9 @@ void StrayManager::_enqueue(CDentry *dn, bool trunc)
 
 void StrayManager::advance_delayed()
 {
+  if (!started)
+    return;
+
   for (elist<CDentry*>::iterator p = delayed_eval_stray.begin(); !p.end(); ) {
     CDentry *dn = *p;
     ++p;
@@ -434,6 +423,9 @@ bool StrayManager::_eval_stray(CDentry *dn, bool delay)
   if (!dn->is_auth()) {
     return false;
   }
+
+  if (!started)
+    delay = true;
 
   if (dn->item_stray.is_on_list()) {
     if (delay)


### PR DESCRIPTION
When mds goes into active state, it re-issue caps for all inodes.
It's possible that some inodes are in frozen state. (mds starts to
process slave request in clientreplay state, slave rename may freeze
inode)

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>