### PR TITLE
mgr, rbd: report rbd images perf stats to mgr

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1411,6 +1411,7 @@ OPTION(rbd_validate_names, OPT_BOOL, true) // true if image specs should be vali
 OPTION(rbd_auto_exclusive_lock_until_manual_request, OPT_BOOL, true) // whether to automatically acquire/release exclusive lock until it is explicitly requested, i.e. before we know the user of librbd is properly using the lock API
 OPTION(rbd_mirroring_resync_after_disconnect, OPT_BOOL, false) // automatically start image resync after mirroring is disconnected due to being laggy
 OPTION(rbd_mirroring_replay_delay, OPT_INT, 0) // time-delay in seconds for rbd-mirror asynchronous replication
+OPTION(rbd_perf_report_period, OPT_DOUBLE, 5.0)
 
 OPTION(rbd_default_pool, OPT_STR, "rbd") // default pool for storing images
 OPTION_VALIDATOR(rbd_default_pool)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -1743,6 +1743,8 @@ OPTION(mgr_mds_bytes, OPT_U64, 128*1048576)   // bytes from mdss
 OPTION(mgr_mds_messages, OPT_U64, 128)        // messages from mdss
 OPTION(mgr_mon_bytes, OPT_U64, 128*1048576)   // bytes from mons
 OPTION(mgr_mon_messages, OPT_U64, 128)        // messages from mons
+OPTION(mgr_image_perf_cleanup_interval, OPT_INT, 300)
+OPTION(mgr_image_perf_calc_interval, OPT_INT, 5)
 
 OPTION(mgr_connect_retry_interval, OPT_DOUBLE, 1.0)
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -203,6 +203,11 @@ namespace librbd {
     journal::Policy *journal_policy = nullptr;
 
     ZTracer::Endpoint trace_endpoint;
+    SafeTimer *m_report_timer = nullptr;
+    Mutex *report_timer_lock = nullptr;
+    Context *m_report_callback = nullptr;
+
+    op_stat_t m_perfstat;
 
     static bool _filter_metadata_confs(const string &prefix, std::map<string, bool> &configs,
                                        const map<string, bufferlist> &pairs, map<string, bufferlist> *res);
@@ -230,6 +235,10 @@ namespace librbd {
     void init_layout();
     void perf_start(std::string name);
     void perf_stop();
+    void perf_report_start();
+    void perf_report_stop();
+    void send_report();
+    int get_report_data(op_stat_t *rpdata);
     void set_read_flag(unsigned flag);
     int get_read_flags(librados::snap_t snap_id);
     int snap_set(cls::rbd::SnapshotNamespace in_snap_namespace,

--- a/src/mgr/DaemonState.h
+++ b/src/mgr/DaemonState.h
@@ -23,6 +23,7 @@
 #include "common/Mutex.h"
 
 #include "msg/msg_types.h"
+#include "osd/osd_types.h"
 
 // For PerfCounterType
 #include "messages/MMgrReport.h"
@@ -165,6 +166,40 @@ class DaemonStateIndex
    * is also absent in this class.
    */
   void cull(entity_type_t daemon_type, const std::set<std::string>& names_exist);
+};
+
+struct imageperf_t {
+  string imgname;
+  utime_t last_update;
+  op_stat_t raw_data;
+  op_stat_t pre_data;
+
+  uint32_t rd_ops;	//io/s
+  uint32_t rd_bws;	//Byte/s
+  uint32_t rd_lat;	//millisecond
+  uint32_t wr_ops;
+  uint32_t wr_bws;
+  uint32_t wr_lat;	//millisecond
+  uint32_t total_ops;
+  uint32_t total_bws;
+  uint32_t total_lat;	//millisecond
+
+  imageperf_t(string _imgname)
+    : imgname(_imgname), raw_data(), pre_data(),
+      rd_ops(0), rd_bws(0), rd_lat(0),
+      wr_ops(0), wr_bws(0), wr_lat(0),
+      total_ops(0), total_bws(0), total_lat(0) {
+      last_update = ceph_clock_now();
+  }
+
+  void update_stat(op_stat_t &rdata) {
+    last_update = ceph_clock_now();
+
+    raw_data.add(rdata);
+    raw_data.op_num     = raw_data.rd_num + raw_data.wr_num;
+    raw_data.op_bytes   = raw_data.rd_bytes + raw_data.wr_bytes;
+    raw_data.op_latency = raw_data.rd_latency + raw_data.wr_latency;
+  }
 };
 
 #endif

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -113,3 +113,8 @@ COMMAND("mgr report imgs_perf "				\
 	"name=id,type=CephString",			\
 	"report pool image perf data from clients",     \
 	"mgr", "rw", "cli,rest")
+
+COMMAND("mgr dump imgs_perf "				\
+	"name=dumpcontents,type=CephString,n=N,req=false",
+	"dump image perf statistics",     		\
+	"mgr", "r", "cli,rest")

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -107,3 +107,9 @@ COMMAND("osd deep-scrub " \
 COMMAND("osd repair " \
 	"name=who,type=CephString", \
 	"initiate repair on osd <who>", "osd", "rw", "cli,rest")
+//mgr
+COMMAND("mgr report imgs_perf "				\
+	"name=name,type=CephString "			\
+	"name=id,type=CephString",			\
+	"report pool image perf data from clients",     \
+	"mgr", "rw", "cli,rest")

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -2473,6 +2473,71 @@ bool operator==(const pg_stat_t& l, const pg_stat_t& r)
     l.pin_stats_invalid == r.pin_stats_invalid;
 }
 
+// -- op-stat-t --
+void op_stat_t::dump(Formatter *f) const
+{
+  f->dump_unsigned("op_num", op_num);
+  f->dump_unsigned("op_bytes", op_bytes);
+  f->dump_unsigned("op_latency", op_latency);
+
+  f->dump_unsigned("rd_num", rd_num);
+  f->dump_unsigned("rd_bytes", rd_bytes);
+  f->dump_unsigned("rd_latency", rd_latency);
+
+  f->dump_unsigned("wr_num", wr_num);
+  f->dump_unsigned("wr_bytes", wr_bytes);
+  f->dump_unsigned("wr_latency", wr_latency);
+}
+
+void op_stat_t::encode(bufferlist &bl) const
+{
+  ENCODE_START(1, 1, bl);
+  ::encode(op_num, bl);
+  ::encode(op_bytes, bl);
+  ::encode(op_latency, bl);
+
+  ::encode(rd_num, bl);
+  ::encode(rd_bytes, bl);
+  ::encode(rd_latency, bl);
+
+  ::encode(wr_num, bl);
+  ::encode(wr_bytes, bl);
+  ::encode(wr_latency, bl);
+  ENCODE_FINISH(bl);
+}
+
+void op_stat_t::decode(bufferlist::iterator &bl)
+{
+  DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+  ::decode(op_num, bl);
+  ::decode(op_bytes, bl);
+  ::decode(op_latency, bl);
+
+  ::decode(rd_num, bl);
+  ::decode(rd_bytes, bl);
+  ::decode(rd_latency, bl);
+
+  ::decode(wr_num, bl);
+  ::decode(wr_bytes, bl);
+  ::decode(wr_latency, bl);
+  DECODE_FINISH(bl);
+}
+
+void op_stat_t::generate_test_instances(list<op_stat_t*>& o)
+{
+  op_stat_t a;
+  o.push_back(new op_stat_t(a));
+
+  a.op_num = 12;
+  a.op_latency = 1234;
+  a.rd_num = 23;
+  a.rd_latency = 2345;
+  a.wr_num = 34;
+  a.wr_latency = 3456;
+  o.push_back(new op_stat_t(a));
+}
+
+
 // -- pool_stat_t --
 
 void pool_stat_t::dump(Formatter *f) const

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1987,6 +1987,69 @@ WRITE_CLASS_ENCODER(pg_stat_t)
 bool operator==(const pg_stat_t& l, const pg_stat_t& r);
 
 /*
+ * aggregate op-related stats
+ */
+struct op_stat_t {
+  uint64_t op_num = 0;
+  uint64_t op_bytes = 0;
+  uint64_t op_latency = 0; // in nanoseconds
+  uint64_t rd_num = 0;
+  uint64_t rd_bytes = 0;
+  uint64_t rd_latency = 0; // in nanoseconds
+  uint64_t wr_num = 0;
+  uint64_t wr_bytes = 0;
+  uint64_t wr_latency = 0; // in nanoseconds
+
+  // for memory caching only
+  uint64_t op_average_latency;
+  uint64_t rd_average_latency;
+  uint64_t wr_average_latency;
+
+  op_stat_t()
+    : op_num(0), op_bytes(0), op_latency(0),
+      rd_num(0), rd_bytes(0), rd_latency(0),
+      wr_num(0), wr_bytes(0), wr_latency(0),
+      op_average_latency(0),
+      rd_average_latency(0),
+      wr_average_latency(0) {
+  }
+
+  void add(const op_stat_t& o) {
+    op_num += o.op_num;
+    op_bytes += o.op_bytes;
+    op_latency += o.op_latency;
+
+    rd_num += o.rd_num;
+    rd_bytes += o.rd_bytes;
+    rd_latency += o.rd_latency;
+
+    wr_num += o.wr_num;
+    wr_bytes += o.wr_bytes;
+    wr_latency += o.wr_latency;
+  }
+
+  void sub(const op_stat_t& o) {
+    op_num = op_num > o.op_num ? op_num - o.op_num : 0;
+    op_bytes = op_bytes > o.op_bytes ? op_bytes - o.op_bytes : 0;
+    op_latency = op_latency> o.op_latency ? op_latency - o.op_latency : 0;
+
+    rd_num = rd_num > o.rd_num ? rd_num - o.rd_num : 0;
+    rd_bytes = rd_bytes > o.rd_bytes ? rd_bytes- o.rd_bytes : 0;
+    rd_latency = rd_latency > o.rd_latency ? rd_latency - o.rd_latency : 0;
+
+    wr_num = wr_num > o.wr_num ? wr_num - o.wr_num : 0;
+    wr_bytes = wr_bytes > o.wr_bytes ? wr_bytes - o.wr_bytes : 0;
+    wr_latency = wr_latency > o.wr_latency ? wr_latency - o.wr_latency : 0;
+  }
+
+  void dump(Formatter *f) const;
+  void encode(bufferlist &bl) const;
+  void decode(bufferlist::iterator &bl);
+  static void generate_test_instances(list<op_stat_t*>& o);
+};
+WRITE_CLASS_ENCODER(op_stat_t)
+
+/*
  * summation over an entire pool
  */
 struct pool_stat_t {


### PR DESCRIPTION
As we know,  one perfcounter metric was created in `ImageCtx`  when we opened a rbd image , but these metrics data is scattered and reside in kinds of clients, furthermore, a rbd image could be opened simultaneously by more than one client.  report these information (especially ops, bytes, latency ) to MGR may be useful.

we can get perf information about each rbd image:
```
[root@ceph192-10-10-86 ~]# ceph mgr dump imgs_perf
dumping: all
IMAGE_ID          IOPS IOPS_RD IOPS_WR | THROUGHPUT THRU_RD  THRU_WR | LATENCY LAT_RD LAT_WR | POOL.IMAGE         
1 0.457923d1b58ba    0       0       0 |          0        0       0 |       0      0      0 | pool1.snap1_clone  
2 0.5a2fc2b9d8e1     0       0       0 |          0        0       0 |       0      0      0 | pool1.lun0_migrate 
3 0.5cde7238e1f29    0       0       0 |          0        0       0 |       0      0      0 | pool1.lun3         
4 0.ccae238e1f29  3296    3296       0 |   27000832 27000832       0 |      11     11      0 | pool1.lun1  
```