### PR TITLE
debian: workaround the bug in dpkg-maintscript-helper

### DIFF
--- a/debian/ceph-base.maintscript
+++ b/debian/ceph-base.maintscript
@@ -1,2 +1,2 @@
-rm_conffile /etc/logrotate.d/ceph.logrotate -- "$@"
-rm_conffile /etc/logrotate.d/ceph -- "$@"
+rm_conffile /etc/logrotate.d/ceph.logrotate
+rm_conffile /etc/logrotate.d/ceph


### PR DESCRIPTION
see https://bugs.launchpad.net/ubuntu/+source/snap-confine/+bug/1605052
and https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=582819

Fixes: http://tracker.ceph.com/issues/20453
Signed-off-by: Kefu Chai <kchai@redhat.com>