### PR TITLE
build/ops: rpm: obsolete libcephfs1

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -611,6 +611,7 @@ Summary:	Ceph distributed file system client library
 %if 0%{?suse_version}
 Group:		System/Libraries
 %endif
+Obsoletes:	libcephfs1
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 Obsoletes:	ceph-libcephfs


### PR DESCRIPTION
Although under normal packaging circumstances this would probably not be done,
in Ceph there is no reasonable deployment scenario where multiple major
versions of libcephfs would need to be present at the same time.

Signed-off-by: Nathan Cutler <ncutler@suse.com>