### PR TITLE
rgw,test: fix rgw placement rule pool config option

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -253,8 +253,8 @@ void _usage()
   cout << "   --tags-rm=<list>          list of tags to remove for zonegroup placement modify command\n";
   cout << "   --endpoints=<list>        zone endpoints\n";
   cout << "   --index_pool=<pool>       placement target index pool\n";
-  cout << "   --data_pool=<pool>        placement target data pool\n";
-  cout << "   --data_extra_pool=<pool>  placement target data extra (non-ec) pool\n";
+  cout << "   --data-pool=<pool>        placement target data pool\n";
+  cout << "   --data-extra-pool=<pool>  placement target data extra (non-ec) pool\n";
   cout << "   --placement-index-type=<type>\n";
   cout << "                             placement target index type (normal, indexless, or #id)\n";
   cout << "   --compression=<type>      placement target compression type (plugin name or empty/none)\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -197,8 +197,8 @@
      --tags-rm=<list>          list of tags to remove for zonegroup placement modify command
      --endpoints=<list>        zone endpoints
      --index_pool=<pool>       placement target index pool
-     --data_pool=<pool>        placement target data pool
-     --data_extra_pool=<pool>  placement target data extra (non-ec) pool
+     --data-pool=<pool>        placement target data pool
+     --data-extra-pool=<pool>  placement target data extra (non-ec) pool
      --placement-index-type=<type>
                                placement target index type (normal, indexless, or #id)
      --compression=<type>      placement target compression type (plugin name or empty/none)


### PR DESCRIPTION
actually we're checking '--data-pool' and '--data-extra-pool'
during the argument parsing.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>