### PR TITLE
os/filestore: require experimental flag for btrfs

### DIFF
--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -389,6 +389,16 @@ upgrade to Luminous.
 Upgrade compatibility notes, Kraken to Luminous
 -----------------------------------------------
 
+* We no longer test the FileStore ceph-osd backend in combination with
+  ``btrfs``.  We recommend against using btrfs.  If you are using
+  btrfs-based OSDs and want to upgrade to luminous you will need to
+  add the follwing to your ceph.conf::
+
+    enable experimental unrecoverable data corrupting features = btrfs
+
+  The code is mature and unlikely to change, but we are only
+  continuing to test the Jewel stable branch against btrfs.  We
+  recommend moving these OSDs to FileStore with XFS or BlueStore.
 * When assigning a network to the public network and not to
   the cluster network the network specification of the public
   network will be used for the cluster network as well.

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -904,6 +904,11 @@ int FileStore::mkfs()
     goto close_fsid_fd;
   }
 
+  if (basefs.f_type == BTRFS_SUPER_MAGIC &&
+      !g_ceph_context->check_experimental_feature_enabled("btrfs")) {
+    derr <<__FUNC__ << ": deprecated btrfs support is not enabled" << dendl;
+    goto close_fsid_fd;
+  }
   create_backend(basefs.f_type);
 
   ret = backend->create_current();
@@ -1158,6 +1163,11 @@ int FileStore::_detect_fs()
 
   blk_size = st.f_bsize;
 
+  if (st.f_type == BTRFS_SUPER_MAGIC &&
+      !g_ceph_context->check_experimental_feature_enabled("btrfs")) {
+    derr <<__FUNC__ << ": deprecated btrfs support is not enabled" << dendl;
+    return -EPERM;
+  }
   create_backend(st.f_type);
 
   r = backend->detect_features();


### PR DESCRIPTION
This isn't strictly accurate since we're really deprecating, but the
message is appropriately scary and reflects the risk of data loss.

Signed-off-by: Sage Weil <sage@redhat.com>