### PR TITLE
common: allow long paths for socket bind

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -614,6 +614,7 @@ set(ceph_common_objs
   $<TARGET_OBJECTS:crush_objs>)
 set(ceph_common_deps
   json_spirit erasure_code rt ${LIB_RESOLV}
+  Boost::filesystem
   Boost::thread
   Boost::system
   Boost::regex

--- a/src/common/admin_socket.h
+++ b/src/common/admin_socket.h
@@ -81,6 +81,7 @@ private:
 
   std::string create_shutdown_pipe(int *pipe_rd, int *pipe_wr);
   std::string destroy_shutdown_pipe();
+  std::string do_bind(int fd, const std::string &path);
   std::string bind_and_listen(const std::string &sock_path, int *fd);
 
   void *entry() override;


### PR DESCRIPTION
This allows arbitrarily long socket paths independent of the UNIX socket path
limit which is comically small at ~100 characters. (However, this doesn't
permit file names larger than the UNIX socket path limit and there is no way to
fix that nor is it really desired.)

Addresses: http://tracker.ceph.com/issues/15249
Addresses: http://tracker.ceph.com/issues/16014
Partially addresses: http://tracker.ceph.com/issues/16895

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>