### PR TITLE
tests: run upgrade/client-upgrade on latest CentOS 7.3

### DIFF
--- a/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos.yaml
@@ -1,0 +1,1 @@
+../../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos_7.2.yaml
+++ b/qa/suites/upgrade/client-upgrade/firefly-client-x/basic/distros/centos_7.2.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos_7.2.yaml

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos.yaml
@@ -1,0 +1,1 @@
+../../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos_7.2.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos_7.2.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos_7.2.yaml

--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos.yaml
@@ -1,0 +1,1 @@
+../../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos_7.2.yaml
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos_7.2.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos_7.2.yaml


### PR DESCRIPTION
Before this patch, all centos jobs were failing because there are no longer any
CentOS 7.2 machines in Sepia.

Signed-off-by: Nathan Cutler <ncutler@suse.com>