### PR TITLE
rgw: fix potential wrong value

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1944,6 +1944,7 @@ int RGWHandler_REST::read_permissions(RGWOp* op_obj)
     if (!s->info.args.exists("tagging")){
       only_bucket = true;
     }
+    only_bucket = false;
     break;
   case OP_OPTIONS:
     only_bucket = true;


### PR DESCRIPTION
`only_bucket` may be used before assignment
```
return do_read_permissions(op_obj, only_bucket);
```
Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>