### PR TITLE
cls_lock: move lock_info_t definition to cls_lock_types.h

### DIFF
--- a/src/cls/lock/cls_lock.cc
+++ b/src/cls/lock/cls_lock.cc
@@ -34,34 +34,6 @@ CLS_NAME(lock)
 
 #define LOCK_PREFIX    "lock."
 
-typedef struct lock_info_s {
-  map<locker_id_t, locker_info_t> lockers; // map of lockers
-  ClsLockType lock_type;                              // lock type (exclusive / shared)
-  string tag;                                         // tag: operations on lock can only succeed with this tag
-                                                      //      as long as set of non expired lockers
-                                                      //      is bigger than 0.
-
-  void encode(bufferlist &bl, uint64_t features) const {
-    ENCODE_START(1, 1, bl);
-    ::encode(lockers, bl, features);
-    uint8_t t = (uint8_t)lock_type;
-    ::encode(t, bl);
-    ::encode(tag, bl);
-    ENCODE_FINISH(bl);
-  }
-  void decode(bufferlist::iterator &bl) {
-    DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
-    ::decode(lockers, bl);
-    uint8_t t;
-    ::decode(t, bl);
-    lock_type = (ClsLockType)t; 
-    ::decode(tag, bl);
-    DECODE_FINISH(bl);
-  }
-  lock_info_s() : lock_type(LOCK_NONE) {}
-} lock_info_t;
-WRITE_CLASS_ENCODER_FEATURES(lock_info_t)
-
 static int read_lock(cls_method_context_t hctx, const string& name, lock_info_t *lock)
 {
   bufferlist bl;

--- a/src/cls/lock/cls_lock_types.cc
+++ b/src/cls/lock/cls_lock_types.cc
@@ -67,3 +67,32 @@ void locker_info_t::generate_test_instances(list<locker_info_t*>& o)
   o.push_back(new locker_info_t);
 }
 
+void lock_info_t::dump(Formatter *f) const
+{
+  f->dump_int("lock_type", lock_type);
+  f->dump_string("tag", tag);
+  f->open_array_section("lockers");
+  for (auto &i : lockers) {
+    f->open_object_section("locker");
+    f->dump_object("id", i.first);
+    f->dump_object("info", i.second);
+    f->close_section();
+  }
+  f->close_section();
+}
+
+void lock_info_t::generate_test_instances(list<lock_info_t *>& o)
+{
+  lock_info_t *i = new lock_info_t;
+  locker_id_t id;
+  locker_info_t info;
+  generate_lock_id(id, 1, "cookie");
+  info.expiration = utime_t(5, 0);
+  generate_test_addr(info.addr, 1, 2);
+  info.description = "description";
+  i->lockers[id] = info;
+  i->lock_type = LOCK_EXCLUSIVE;
+  i->tag = "tag";
+  o.push_back(i);
+  o.push_back(new lock_info_t);
+}

--- a/src/cls/lock/cls_lock_types.h
+++ b/src/cls/lock/cls_lock_types.h
@@ -96,10 +96,41 @@ namespace rados {
         static void generate_test_instances(list<locker_info_t *>& o);
       };
       WRITE_CLASS_ENCODER_FEATURES(rados::cls::lock::locker_info_t)
+
+      struct lock_info_t {
+        map<locker_id_t, locker_info_t> lockers; // map of lockers
+        ClsLockType lock_type;                   // lock type (exclusive / shared)
+        string tag;                              // tag: operations on lock can only succeed with this tag
+                                                 //      as long as set of non expired lockers
+                                                 //      is bigger than 0.
+
+        void encode(bufferlist &bl, uint64_t features) const {
+          ENCODE_START(1, 1, bl);
+          ::encode(lockers, bl, features);
+          uint8_t t = (uint8_t)lock_type;
+          ::encode(t, bl);
+          ::encode(tag, bl);
+          ENCODE_FINISH(bl);
+        }
+        void decode(bufferlist::iterator &bl) {
+          DECODE_START_LEGACY_COMPAT_LEN(1, 1, 1, bl);
+          ::decode(lockers, bl);
+          uint8_t t;
+          ::decode(t, bl);
+          lock_type = (ClsLockType)t;
+          ::decode(tag, bl);
+          DECODE_FINISH(bl);
+        }
+        lock_info_t() : lock_type(LOCK_NONE) {}
+        void dump(Formatter *f) const;
+        static void generate_test_instances(list<lock_info_t *>& o);
+      };
+      WRITE_CLASS_ENCODER_FEATURES(rados::cls::lock::lock_info_t)
     }
   }
 }
 WRITE_CLASS_ENCODER_FEATURES(rados::cls::lock::locker_info_t)
 WRITE_CLASS_ENCODER(rados::cls::lock::locker_id_t)
+WRITE_CLASS_ENCODER_FEATURES(rados::cls::lock::lock_info_t)
 
 #endif

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -399,6 +399,7 @@ TYPE(cls::rbd::MirrorImage)
 #include "cls/lock/cls_lock_types.h"
 TYPE(rados::cls::lock::locker_id_t)
 TYPE_FEATUREFUL(rados::cls::lock::locker_info_t)
+TYPE_FEATUREFUL(rados::cls::lock::lock_info_t)
 
 #include "cls/lock/cls_lock_ops.h"
 TYPE(cls_lock_lock_op)


### PR DESCRIPTION
lock_info_t is an ondisk structure, make it testable by ceph-dencoder.

Signed-off-by: runsisi <runsisi@zte.com.cn>