### PR TITLE
osd: clear_queued_recovery() in on_shutdown()

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10661,6 +10661,11 @@ void PrimaryLogPG::on_shutdown()
   // handles queue races
   deleting = true;
 
+  if (recovery_queued) {
+    recovery_queued = false;
+    osd->clear_queued_recovery(this);
+  }
+
   clear_scrub_reserved();
   scrub_clear_state();
 


### PR DESCRIPTION
otherwise when we are kicking the PG waiting in OSD's awaiting_throttle
queue, the queue is still holding a strong reference of it. then we will
have warnings like "pgid 0.7 has ref count of 2" when shutting down OSD,
because pgmap is also holding a reference of it.

we could clear the "awaiting_throttle" directly in OSD::shutdown(), but
clear_queued_recovery() is more consistent this way, because it is PG
which registered itself to the queue in OSD, it'd be better if PG can
remove itself from the OSD when it is shutting down itself.

Fixes: http://tracker.ceph.com/issues/20432
Signed-off-by: Kefu Chai <kchai@redhat.com>