### PR TITLE
pybind/mgr/dashboard: fix get kernel_version error

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -536,7 +536,7 @@ class Module(MgrModule):
                         client['hostname'] = client['client_metadata']['hostname']
                     elif "kernel_version" in client['client_metadata']:
                         client['type'] = "kernel"
-                        client['version'] = client['kernel_version']
+                        client['version'] = client['client_metadata']['kernel_version']
                         client['hostname'] = client['client_metadata']['hostname']
                     else:
                         client['type'] = "unknown"


### PR DESCRIPTION
fix :
```
File "/usr/lib64/ceph/mgr/dashboard/module.py", line 523, in _clients
client['version'] = client['kernel_version']
```
----------

change client['kernel_version'] to
client['client_metadata']['kernel_version']

Signed-off-by: Peng Zhang zphj1987@gmail.com