### PR TITLE
kraken: mds: C_MDSInternalNoop::complete doesn't free itself

### DIFF
--- a/src/mds/MDSContext.h
+++ b/src/mds/MDSContext.h
@@ -131,12 +131,12 @@ public:
 /**
  * No-op for callers expecting MDSInternalContextBase
  */
-class C_MDSInternalNoop : public MDSInternalContextBase
+class C_MDSInternalNoop final : public MDSInternalContextBase
 {
   virtual MDSRank* get_mds() {ceph_abort();}
 public:
   void finish(int r) {}
-  void complete(int r) {}
+  void complete(int r) { delete this; }
 };
 
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/19664