### PR TITLE
kraken: mds: damage reporting by ino number is useless

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1906,7 +1906,7 @@ void CDir::_go_bad()
 void CDir::go_bad_dentry(snapid_t last, const std::string &dname)
 {
   const bool fatal = cache->mds->damage_table.notify_dentry(
-      inode->ino(), frag, last, dname);
+      inode->ino(), frag, last, dname, get_path() + "/" + dname);
   if (fatal) {
     cache->mds->damaged();
     ceph_abort();  // unreachable, damaged() respawns us
@@ -1915,7 +1915,8 @@ void CDir::go_bad_dentry(snapid_t last, const std::string &dname)
 
 void CDir::go_bad(bool complete)
 {
-  const bool fatal = cache->mds->damage_table.notify_dirfrag(inode->ino(), frag);
+  const bool fatal = cache->mds->damage_table.notify_dirfrag(
+      inode->ino(), frag, get_path());
   if (fatal) {
     cache->mds->damaged();
     ceph_abort();  // unreachable, damaged() respawns us

--- a/src/mds/DamageTable.cc
+++ b/src/mds/DamageTable.cc
@@ -49,6 +49,7 @@ class DirFragDamage : public DamageEntry
     f->dump_int("id", id);
     f->dump_int("ino", ino);
     f->dump_stream("frag") << frag;
+    f->dump_string("path", path);
     f->close_section();
   }
 };
@@ -87,6 +88,7 @@ class DentryDamage : public DamageEntry
     f->dump_stream("frag") << frag;
     f->dump_string("dname", dname);
     f->dump_stream("snap_id") << snap_id;
+    f->dump_string("path", path);
     f->close_section();
   }
 };
@@ -115,6 +117,7 @@ class BacktraceDamage : public DamageEntry
     f->dump_string("damage_type", "backtrace");
     f->dump_int("id", id);
     f->dump_int("ino", ino);
+    f->dump_string("path", path);
     f->close_section();
   }
 };
@@ -125,7 +128,7 @@ DamageEntry::~DamageEntry()
 
 bool DamageTable::notify_dentry(
     inodeno_t ino, frag_t frag,
-    snapid_t snap_id, const std::string &dname)
+    snapid_t snap_id, const std::string &dname, const std::string &path)
 {
   if (oversized()) {
     return true;
@@ -147,6 +150,7 @@ bool DamageTable::notify_dentry(
   if (dentries.count(key) == 0) {
     DamageEntryRef entry = std::make_shared<DentryDamage>(
         ino, frag, dname, snap_id);
+    entry->path = path;
     dentries[key][DentryIdent(dname, snap_id)] = entry;
     by_id[entry->id] = std::move(entry);
   }
@@ -154,7 +158,8 @@ bool DamageTable::notify_dentry(
   return false;
 }
 
-bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag)
+bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag,
+                                 const std::string &path)
 {
   // Special cases: damage to these dirfrags is considered fatal to
   // the MDS rank that owns them.
@@ -175,6 +180,7 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag)
   auto key = DirFragIdent(ino, frag);
   if (dirfrags.count(key) == 0) {
     DamageEntryRef entry = std::make_shared<DirFragDamage>(ino, frag);
+    entry->path = path;
     dirfrags[key] = entry;
     by_id[entry->id] = std::move(entry);
   }
@@ -182,7 +188,7 @@ bool DamageTable::notify_dirfrag(inodeno_t ino, frag_t frag)
   return false;
 }
 
-bool DamageTable::notify_remote_damaged(inodeno_t ino)
+bool DamageTable::notify_remote_damaged(inodeno_t ino, const std::string &path)
 {
   if (oversized()) {
     return true;
@@ -190,6 +196,7 @@ bool DamageTable::notify_remote_damaged(inodeno_t ino)
 
   if (remotes.count(ino) == 0) {
     auto entry = std::make_shared<BacktraceDamage>(ino);
+    entry->path = path;
     remotes[ino] = entry;
     by_id[entry->id] = std::move(entry);
   }

--- a/src/mds/DamageTable.h
+++ b/src/mds/DamageTable.h
@@ -37,6 +37,10 @@ class DamageEntry
   damage_entry_id_t id;
   utime_t reported_at;
 
+  // path is optional, advisory.  Used to give the admin an idea of what
+  // part of his tree the damage affects.
+  std::string path;
+
   DamageEntry()
   {
     id = get_random(0, 0xffffffff);
@@ -157,7 +161,7 @@ public:
    *
    * @return true if fatal
    */
-  bool notify_dirfrag(inodeno_t ino, frag_t frag);
+  bool notify_dirfrag(inodeno_t ino, frag_t frag, const std::string &path);
 
   /**
    * Indicate that a particular dentry cannot be loaded.
@@ -166,13 +170,13 @@ public:
    */
   bool notify_dentry(
     inodeno_t ino, frag_t frag,
-    snapid_t snap_id, const std::string &dname);
+    snapid_t snap_id, const std::string &dname, const std::string &path);
 
   /**
    * Indicate that a particular Inode could not be loaded by number
    */
   bool notify_remote_damaged(
-      inodeno_t ino);
+      inodeno_t ino, const std::string &path);
 
   bool is_dentry_damaged(
       const CDir *dir_frag,

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -8243,8 +8243,16 @@ void MDCache::_open_remote_dentry_finish(CDentry *dn, inodeno_t ino, MDSInternal
   if (r < 0) {
       dout(0) << "open_remote_dentry_finish bad remote dentry " << *dn << dendl;
       dn->state_set(CDentry::STATE_BADREMOTEINO);
+
+      std::string path;
+      CDir *dir = dn->get_dir();
+      if (dir) {
+        dir->get_inode()->make_path_string(path);
+        path =  path + "/" + dn->get_name();
+      }
+
       bool fatal = mds->damage_table.notify_remote_damaged(
-          dn->get_projected_linkage()->get_remote_ino());
+          dn->get_projected_linkage()->get_remote_ino(), path);
       if (fatal) {
         mds->damaged();
         ceph_abort();  // unreachable, damaged() respawns us


### PR DESCRIPTION
http://tracker.ceph.com/issues/19680