### PR TITLE
kraken: mds: enable daemon to start when session ino info is corrupt

### DIFF
--- a/src/mds/InoTable.cc
+++ b/src/mds/InoTable.cc
@@ -197,6 +197,17 @@ bool InoTable::is_marked_free(inodeno_t id) const
   return free.contains(id) || projected_free.contains(id);
 }
 
+bool InoTable::intersects_free(
+    const interval_set<inodeno_t> &other,
+    interval_set<inodeno_t> *intersection)
+{
+  interval_set<inodeno_t> i;
+  i.intersection_of(free, other);
+  if (intersection != nullptr) {
+    *intersection = i;
+  }
+  return !(i.empty());
+}
 
 bool InoTable::repair(inodeno_t id)
 {

--- a/src/mds/InoTable.h
+++ b/src/mds/InoTable.h
@@ -43,6 +43,9 @@ class InoTable : public MDSTable {
   void replay_reset();
   bool repair(inodeno_t id);
   bool is_marked_free(inodeno_t id) const;
+  bool intersects_free(
+      const interval_set<inodeno_t> &other,
+      interval_set<inodeno_t> *intersection);
 
   void reset_state() override;
   void encode_state(bufferlist& bl) const override {

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -993,8 +993,42 @@ void MDSRank::boot_start(BootStep step, int r)
       break;
     case MDS_BOOT_REPLAY_DONE:
       assert(is_any_replay());
+
+      // Sessiontable and inotable should be in sync after replay, validate
+      // that they are consistent.
+      validate_sessions();
+
       replay_done();
       break;
+  }
+}
+
+void MDSRank::validate_sessions()
+{
+  assert(mds_lock.is_locked_by_me());
+  std::vector<Session*> victims;
+
+  // Identify any sessions which have state inconsistent with other,
+  // after they have been loaded from rados during startup.
+  // Mitigate bugs like: http://tracker.ceph.com/issues/16842
+  const auto &sessions = sessionmap.get_sessions();
+  for (const auto &i : sessions) {
+    Session *session = i.second;
+    interval_set<inodeno_t> badones;
+    if (inotable->intersects_free(session->info.prealloc_inos, &badones)) {
+      clog->error() << "Client session loaded with invalid preallocated "
+                          "inodes, evicting session " << *session;
+
+      // Make the session consistent with inotable so that it can
+      // be cleanly torn down
+      session->info.prealloc_inos.subtract(badones);
+
+      victims.push_back(session);
+    }
+  }
+
+  for (const auto &session: victims) {
+    server->kill_session(session, nullptr);
   }
 }
 

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -461,6 +461,8 @@ class MDSRank {
     void active_start();
     void stopping_start();
     void stopping_done();
+
+    void validate_sessions();
     // <<<
     
     // >>>

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -1034,3 +1034,13 @@ bool SessionFilter::match(
   return true;
 }
 
+std::ostream& operator<<(std::ostream &out, const Session &s)
+{
+ if (s.get_human_name() == stringify(s.info.inst.name.num())) {
+   out << s.get_human_name();
+ } else {
+   out << s.get_human_name() << " (" << std::dec << s.info.inst.name.num() << ")";
+ }
+ return out;
+}
+

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -665,5 +665,7 @@ public:
                      MDSGatherBuilder *gather_bld);
 };
 
+std::ostream& operator<<(std::ostream &out, const Session &s);
+
 
 #endif


### PR DESCRIPTION
http://tracker.ceph.com/issues/19710