### PR TITLE
kraken: tests: insufficient timeout in radosbench task

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -96,7 +96,7 @@ def task(ctx, config):
     try:
         yield
     finally:
-        timeout = config.get('time', 360) * 5 + 180
+        timeout = config.get('time', 360) * 10 + 180
         log.info('joining radosbench (timing out after %ss)', timeout)
         run.wait(radosbench.itervalues(), timeout=timeout)
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/20497