### PR TITLE
kraken: tests: ObjectStore/StoreTest.OnodeSizeTracking/2 fails on bluestore

### DIFF
--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -5596,7 +5596,6 @@ TEST_P(StoreTest, OnodeSizeTracking) {
   uint64_t total_bytes, total_bytes2;
   uint64_t total_onodes;
   get_mempool_stats(&total_bytes, &total_onodes);
-  ASSERT_EQ(total_bytes, 0u);
   ASSERT_EQ(total_onodes, 0u);
 
   {


### PR DESCRIPTION
http://tracker.ceph.com/issues/20499