### PR TITLE
os/bluestore: fix build errors when spdk is on

### DIFF
--- a/cmake/modules/Finddpdk.cmake
+++ b/cmake/modules/Finddpdk.cmake
@@ -71,5 +71,5 @@ if (EXISTS ${WITH_DPDK_MLX5})
   list(APPEND check_LIBRARIES -libverbs)
 endif()
   set(DPDK_LIBRARIES
-    -Wl,--whole-archive ${check_LIBRARIES} -lpthread -Wl,--no-whole-archive)
+    -Wl,--whole-archive ${check_LIBRARIES} -Wl,--no-whole-archive)
 endif(DPDK_FOUND)

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -1028,7 +1028,7 @@ int NVMEDevice::aio_write(
 int NVMEDevice::write(uint64_t off, bufferlist &bl, bool buffered)
 {
   // FIXME: there is presumably a more efficient way to do this...
-  IOContext ioc(NULL);
+  IOContext ioc(cct, NULL);
   aio_write(off, bl, &ioc, buffered);
   ioc.aio_wait();
   return 0;

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -28,6 +28,7 @@
 #include "include/interval_set.h"
 #include "common/ceph_time.h"
 #include "common/Mutex.h"
+#include "common/Cond.h"
 #include "BlockDevice.h"
 
 enum class IOCommand {


### PR DESCRIPTION
- remove pthread library link from dpdk cmake
- fix the bugs of NVMEDevice

Signed-off-by: Ilsoo Byun <ilsoo.byun@sk.com>