### PR TITLE
pybind/ceph_argparse: cleanup automatically created file when validating CephFilepath

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -492,11 +492,16 @@ class CephFilepath(CephArgtype):
     Openable file
     """
     def valid(self, s, partial=False):
+        cleanup = False
+        if not os.path.exists(s):
+            cleanup = True
         try:
             f = open(s, 'a+')
         except Exception as e:
             raise ArgumentValid('can\'t open {0}: {1}'.format(s, e))
         f.close()
+        if cleanup:
+            os.remove(s)
         self.val = s
 
     def __str__(self):


### PR DESCRIPTION
otherwise `ceph tell osd.<id> debug dump_missing /path/to/file` executed on the same node as the target osd will fail:

```
[root@ceph192-33-1-4 ~]# ll -d /xxx/
drwxr-xr-x 2 ceph ceph 4096 Jul  5 14:04 /xxx/
[root@ceph192-33-1-4 ~]# ceph tell osd.51 debug dump_missing /xxx/xxx
Error EINVAL: failed to open file '/xxx/xxx'

```

Signed-off-by: runsisi <runsisi@zte.com.cn>