### PR TITLE
os/bluestore: clear up redundant size assignment in KerenelDevice

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -130,7 +130,6 @@ int KernelDevice::open(const string& p)
   } else {
     size = st.st_size;
   }
-  size &= ~(block_size);
 
   {
     char partition[PATH_MAX], devname[PATH_MAX];


### PR DESCRIPTION
Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>