### PR TITLE
rpm: bump epoch ahead of RHEL base

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -65,7 +65,7 @@ Name:		ceph
 Version:	@VERSION@
 Release:	@RPM_RELEASE@%{?dist}
 %if 0%{?fedora} || 0%{?rhel}
-Epoch:		1
+Epoch:		2
 %endif
 
 # define %_epoch_prefix macro which will expand to the empty string if %epoch is undefined


### PR DESCRIPTION
RHEL's ceph-common package is `1`. Move our upstream packages' epoch ahead of that, so that upstream will always override whatever is in RHEL, even if it happens to have a higher NVR one day.

Fixes: http://tracker.ceph.com/issues/20508
Signed-off-by: Ken Dreyer <kdreyer@redhat.com>