### PR TITLE
rgw: fix obj copied from remote gateway acl full_control issue

### DIFF
--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -394,7 +394,7 @@ struct grant_type_to_header grants_headers_def[] = {
 
 static bool grants_by_type_check_perm(map<int, string>& grants_by_type, int perm, ACLGrant& grant, int check_perm)
 {
-  if ((perm & check_perm) == perm) {
+  if ((perm & check_perm) == check_perm) {
     grants_by_type_add_one_grant(grants_by_type, check_perm, grant);
     return true;
   }


### PR DESCRIPTION
This part of the code is commit in
https://github.com/ceph/ceph/pull/415/commits/ea3efca3fd161d9ed56df3c28f558ce593aae470

When copy a object to a remote gateway, the check processing which is done by
"Bitwise And" between source object's acl elements and grants_headers_def array elements
will be done to produce the target object's acl elements.

So when the full_control is the first element of grants_headers_def, no matter the
source object's acl element permission field is write or read, the result of
bitwise and will always be true, then call grants_by_type_add_one_grant with
check_perm which is full_control, all of the permission field of the target object's
acl elements will be full_control.

Fixes: http://tracker.ceph.com/issues/20658

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>