### PR TITLE
ceph.in: Check return value when connecting

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -899,7 +899,10 @@ def main():
     try:
         if childargs and childargs[0] == 'ping':
             return ping_monitor(cluster_handle, childargs[1], timeout)
-        run_in_thread(cluster_handle.connect, timeout=timeout)
+        result = run_in_thread(cluster_handle.connect, timeout=timeout)
+        if type(result) is tuple and result[0] == -errno.EINTR:
+            print('Cluster connection interrupted or timed out', file=sys.stderr)
+            return 1
     except KeyboardInterrupt:
         print('Cluster connection aborted', file=sys.stderr)
         return 1


### PR DESCRIPTION
The initial RADOS connection may time out. Detect this condition
and return an error message to the user instead of looping forever.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>