### PR TITLE
tests: swift.py: clone the ceph-jewel branch

### DIFF
--- a/qa/tasks/swift.py
+++ b/qa/tasks/swift.py
@@ -28,7 +28,10 @@ def download(ctx, config):
     for client in config:
         ctx.cluster.only(client).run(
             args=[
-                'git', 'clone',
+                'git',
+                'clone',
+                '--branch',
+                'ceph-kraken',
                 teuth_config.ceph_git_base_url + 'swift.git',
                 '{tdir}/swift'.format(tdir=testdir),
                 ],


### PR DESCRIPTION
The master branch of ceph/swift.git contains tests that are incompatible with
Jewel and Hammer. The ceph-jewel branch omits these tests.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit a86ce728954a765797ce634025d43650d990e480)

N.B.: The new tests are incompatible with kraken as well
Signed-off-by: Nathan Cutler <ncutler@suse.com>