### PR TITLE
kraken: tests: LibRadosMiscConnectFailure.ConnectFailure hang

### DIFF
--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -76,6 +76,7 @@ TEST(LibRadosMiscConnectFailure, ConnectFailure) {
       break;  // yay, we timed out
     // try again
     rados_shutdown(cluster);
+    ASSERT_EQ(0, rados_create(&cluster, NULL));
   }
   ASSERT_NE(0, r);
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/20271