### PR TITLE
rgw: add tail tag to track tail instance

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -67,6 +67,7 @@ using ceph::crypto::MD5;
 #define RGW_ATTR_EXPIRES	RGW_ATTR_PREFIX "expires"
 #define RGW_ATTR_DELETE_AT 	RGW_ATTR_PREFIX "delete_at"
 #define RGW_ATTR_ID_TAG    	RGW_ATTR_PREFIX "idtag"
+#define RGW_ATTR_TAIL_TAG    	RGW_ATTR_PREFIX "tail_tag"
 #define RGW_ATTR_SHADOW_OBJ    	RGW_ATTR_PREFIX "shadow_name"
 #define RGW_ATTR_MANIFEST    	RGW_ATTR_PREFIX "manifest"
 #define RGW_ATTR_USER_MANIFEST  RGW_ATTR_PREFIX "user_manifest"

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3024,6 +3024,7 @@ int RGWPutObjProcessor_Multipart::do_complete(size_t accounted_size,
   head_obj_op.meta.owner = s->owner.get_id();
   head_obj_op.meta.delete_at = delete_at;
   head_obj_op.meta.zones_trace = zones_trace;
+  head_obj_op.meta.modify_tail = true;
 
   int r = head_obj_op.write_meta(obj_len, accounted_size, attrs);
   if (r < 0)
@@ -5451,6 +5452,7 @@ void RGWCompleteMultipart::execute()
   obj_op.meta.ptag = &s->req_id; /* use req_id as operation tag */
   obj_op.meta.owner = s->owner.get_id();
   obj_op.meta.flags = PUT_OBJ_CREATE;
+  obj_op.meta.modify_tail = true;
   op_ret = obj_op.write_meta(ofs, accounted_size, attrs);
   if (op_ret < 0)
     return;


### PR DESCRIPTION
Use tail_tag instead of idtag. The tail_tag is modified when either
creating a new tail, or adding a refcount to the tail (e.g., when
copying object). When just modifying the object's head, tail_tag
should remain the same. The gc will then use the tail_tag (if
exists, idtag if not) as the refcount id.

Fixes: http://tracker.ceph.com/issues/20234

Signed-off-by: Yehuda Sadeh <yehuda@redhat.com>