### PR TITLE
mds: fixup may be an unclaimed tick_event

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -548,8 +548,6 @@ void MDSDaemon::reset_tick()
 
 void MDSDaemon::tick()
 {
-  tick_event = 0;
-
   // reschedule
   reset_tick();
 


### PR DESCRIPTION
The unclaimed tick_event of C_MDS_Tick may be will repeat exist in SafeTimer,
because the timer.cancel_event of reset_tick() will not real-time undo it when "tick_event = 0".

Signed-off-by: huanwen ren ren.huanwen@zte.com.cn