### PR TITLE
rgw: drop unused rgw_pool parameter, local variables and member variable

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -799,8 +799,6 @@ public:
     string oid_prefix;
 
     rgw_obj_select cur_obj;
-    rgw_pool pool;
-
 
     RGWObjManifestRule rule;
 
@@ -2294,7 +2292,7 @@ class RGWRados
 
   int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx);
   int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
-  int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref, rgw_pool *pool = NULL);
+  int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
   uint64_t max_bucket_id;
 
   int get_olh_target_state(RGWObjectCtx& rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
@@ -2529,7 +2527,7 @@ public:
     return rgw_shards_max();
   }
 
-  int get_raw_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref, rgw_pool *pool = NULL);
+  int get_raw_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
 
   int list_raw_objects(const rgw_pool& pool, const string& prefix_filter, int max,
                        RGWListRawObjsCtx& ctx, list<string>& oids,


### PR DESCRIPTION
This pr contains:

+ drop unused `rgw_pool` parameter in `get_raw_obj_ref() and get_system_obj_ref()`, because each method needs a `rgw_raw_obj` as param which includes its own `rgw_pool`.
+ drop misc unused local vars `rgw_pool`
+ drop member variable `pool`

 @mattbenjamin @yehudasa mind to take a look? It's continuation part after [RFC rgw: bucket placement cleanup #15797
](https://github.com/ceph/ceph/pull/15797)