### PR TITLE
Context: C_ContextsBase: delete enclosed contexts in dtor

### DIFF
--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -217,7 +217,11 @@ public:
     : cct(cct_)
   {
   }
-
+  ~C_ContextsBase() override {
+    for (auto c : contexts) {
+      delete c;
+    }
+  }
   void add(ContextType* c) {
     contexts.push_back(c);
   }


### PR DESCRIPTION
there are chances that these contexts are never finished/completed

Fixes: http://tracker.ceph.com/issues/20432
Signed-off-by: Kefu Chai <kchai@redhat.com>