### PR TITLE
kraken: rgw: reduce log level of 'storing entry at' in cls_log

### DIFF
--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -126,7 +126,7 @@ static int cls_log_add(cls_method_context_t hctx, bufferlist *in, bufferlist *ou
       index = entry.id;
     }
 
-    CLS_LOG(0, "storing entry at %s", index.c_str());
+    CLS_LOG(20, "storing entry at %s", index.c_str());
 
 
     if (index > header.max_marker)


### PR DESCRIPTION
http://tracker.ceph.com/issues/19839