### PR TITLE
os/filestore: Exclude BTRFS on FreeBSD

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -904,11 +904,14 @@ int FileStore::mkfs()
     goto close_fsid_fd;
   }
 
+#if defined(__linux__)
   if (basefs.f_type == BTRFS_SUPER_MAGIC &&
       !g_ceph_context->check_experimental_feature_enabled("btrfs")) {
     derr <<__FUNC__ << ": deprecated btrfs support is not enabled" << dendl;
     goto close_fsid_fd;
   }
+#endif
+
   create_backend(basefs.f_type);
 
   ret = backend->create_current();
@@ -1163,11 +1166,14 @@ int FileStore::_detect_fs()
 
   blk_size = st.f_bsize;
 
+#if defined(__linux__)
   if (st.f_type == BTRFS_SUPER_MAGIC &&
       !g_ceph_context->check_experimental_feature_enabled("btrfs")) {
     derr <<__FUNC__ << ": deprecated btrfs support is not enabled" << dendl;
     return -EPERM;
   }
+#endif
+
   create_backend(st.f_type);
 
   r = backend->detect_features();


### PR DESCRIPTION
- Fix FreeBSd exclusions after depricating btrfs

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>