### PR TITLE
kraken: rgw: 'radosgw-admin usage show' listing 0 bytes_sent/received

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1192,6 +1192,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
 
   int len = 0;
   if (cl) {
+    ACCOUNTING_IO(s)->set_account(true);
     bufferptr bp(cl);
 
     const auto read_len  = recv_body(s, bp.c_str(), cl);
@@ -1222,7 +1223,7 @@ int RGWPutObj_ObjStore::get_data(bufferlist& bl)
         bl.rebuild();
       }
     }
-
+    ACCOUNTING_IO(s)->set_account(false);
   }
 
   if ((uint64_t)ofs + len > s->cct->_conf->rgw_max_put_size) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/20261