### PR TITLE
Fix crash of rgw that use erasure-coded buckets.data pool.

### DIFF
--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -2729,7 +2729,7 @@ librados::AioCompletion *librados::Rados::aio_create_completion(void *cb_arg,
 								callback_t cb_complete,
 								callback_t cb_safe)
 {
-  AioCompletionImpl *c;
+  AioCompletionImpl *c = nullptr;
   int r = rados_aio_create_completion(cb_arg, cb_complete, cb_safe, (void**)&c);
   assert(r == 0);
   return new AioCompletion(c);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2683,7 +2683,7 @@ int RGWPutObjProcessor_Atomic::complete_writing_data()
     obj_len = (uint64_t)first_chunk.length();
   }
   while (pending_data_bl.length()) {
-    void *handle;
+    void *handle = nullptr;
     rgw_raw_obj obj;
     uint64_t max_write_size = MIN(max_chunk_size, (uint64_t)next_part_ofs - data_ofs);
     if (max_write_size > pending_data_bl.length()) {
@@ -3309,7 +3309,7 @@ int RGWRados::get_required_alignment(const rgw_pool& pool, uint64_t *alignment)
     return r;
   }
 
-  bool requires;
+  bool requires = false;
   r = ioctx.pool_requires_alignment2(&requires);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: ioctx.pool_requires_alignment2() returned " 
@@ -3322,7 +3322,7 @@ int RGWRados::get_required_alignment(const rgw_pool& pool, uint64_t *alignment)
     return 0;
   }
 
-  uint64_t align;
+  uint64_t align = 0;
   r = ioctx.pool_required_alignment2(&align);
   if (r < 0) {
     ldout(cct, 0) << "ERROR: ioctx.pool_required_alignment2() returned " 
@@ -3338,7 +3338,7 @@ int RGWRados::get_required_alignment(const rgw_pool& pool, uint64_t *alignment)
 
 int RGWRados::get_max_chunk_size(const rgw_pool& pool, uint64_t *max_chunk_size)
 {
-  uint64_t alignment;
+  uint64_t alignment = 0;
   int r = get_required_alignment(pool, &alignment);
   if (r < 0) {
     return r;


### PR DESCRIPTION
For ec pools alignment = osd_pool_erasure_code_stripe_unit * data_chunk_count.
(Not sure that is correct, but that is what I've observed)

So, for example for
  rgw_obj_stripe_size=4M
  rgw_max_chunk_size=4M
  osd_pool_erasure_code_stripe_unit=4k
  data_chunk_count=3 (k=3, m=2)
RGWRados::get_max_chunk_size(const rgw_pool& pool, uint64_t *max_chunk_size) returns max_chunk_size = 4M-4k

Then if uploading to S3 not multipart object with size=16M

While rgw_obj_stripe_size=4M
That leads (somehow) to entering while (pending_data_bl.length()) {
  in int RGWPutObjProcessor_Atomic::complete_writing_data():2710

And there not initialized void *handle leads to invalid pointer librados::AioCompletion::pc
  which leads to rgw crash:

  1: (()+0x1fcee2) [0x55f98c2e0ee2]
  2: (()+0x11390) [0x7f43341c8390]
  3: (Mutex::Lock(bool)+0xd) [0x7f432b5d1a2d]
  4: (librados::AioCompletion::wait_for_safe()+0x15) [0x7f4334425995]
  5: (RGWRados::aio_wait(void*)+0x11) [0x55f98c3efd81]
  6: (RGWPutObjProcessor_Aio::wait_pending_front()+0x4c) [0x55f98c3fc51c]
  7: (RGWPutObjProcessor_Aio::drain_pending()+0x20) [0x55f98c3fc5a0]
  8: (RGWPutObjProcessor_Atomic::complete_writing_data()+0x30d) [0x55f98c40f6bd]
  9: (RGWPutObjProcessor_Atomic::do_complete(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >*, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::buffer::list, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ceph::buffer::list> > >&, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >, char const*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const*, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*)+0x67) [0x55f98c440037]
  10: (RGWPutObjProcessor::complete(unsigned long, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >*, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >, std::map<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, ceph::buffer::list, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::pair<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const, ceph::buffer::list> > >&, std::chrono::time_point<ceph::time_detail::real_clock, std::chrono::duration<unsigned long, std::ratio<1l, 1000000000l> > >, char const*, char const*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const*, std::set<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, std::less<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >, std::allocator<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > > >*)+0x22) [0x55f98c3eea52]
  11: (RGWPutObj::execute()+0x22a9) [0x55f98c3be659]
  12: (rgw_process_authenticated(RGWHandler_REST*, RGWOp*&, RGWRequest*, req_state*, bool)+0x165) [0x55f98c3e8eb5]
  13: (process_request(RGWRados*, RGWREST*, RGWRequest*, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, rgw::auth::StrategyRegistry const&, RGWRestfulIO*, OpsLogSocket*)+0x1abc) [0x55f98c3ead5c]
  14: (RGWCivetWebFrontend::process(mg_connection*)+0x371) [0x55f98c299711]
  15: (()+0x1ee2a9) [0x55f98c2d22a9]
  16: (()+0x1efc79) [0x55f98c2d3c79]
  17: (()+0x76ba) [0x7f43341be6ba]
  18: (clone()+0x6d) [0x7f4329c453dd]