### PR TITLE
kraken: rgw: Lifecycle thread will still handle the bucket even if it has been removed.

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -362,8 +362,8 @@ int RGWLC::bucket_lc_post(int index, int max_lock_sec, cls_rgw_lc_obj_head& head
       ret = cls_rgw_lc_rm_entry(store->lc_pool_ctx, obj_names[index],  entry);
       if (ret < 0) {
         dout(0) << "RGWLC::bucket_lc_post() failed to remove entry " << obj_names[index] << dendl;
-        goto clean;
       }
+      goto clean;
     } else if (result < 0) {
       entry.second = lc_failed;
     } else {


### PR DESCRIPTION
http://tracker.ceph.com/issues/20405