### PR TITLE
rgw: lease_stack: use reset method instead of assignment

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -835,7 +835,7 @@ public:
                                                 sync_env->store,
                                                 rgw_raw_obj(sync_env->store->get_zone_params().log_pool, sync_env->status_oid()),
                                                 lock_name, lock_duration, this));
-        lease_stack = spawn(lease_cr.get(), false);
+        lease_stack.reset(spawn(lease_cr.get(), false));
       }
       while (!lease_cr->is_locked()) {
         if (lease_cr->is_done()) {


### PR DESCRIPTION
It seems that the intent of 45877d38fd9a385b2f8b13e90be94d784898b0b3 was to
change all instances of "lease_stack = ..." to "lease_stack.reset(...)", but
this one was missed.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

@fangyuxiangGL @cbodley