### PR TITLE
ceph_test_rados_api_c_read_operations: do not assert per-op rval is correct

### DIFF
--- a/src/test/librados/c_read_operations.cc
+++ b/src/test/librados/c_read_operations.cc
@@ -606,7 +606,9 @@ TEST_F(CReadOpsTest, Omap) {
   rados_write_op_omap_rm_keys(op, keys, 2);
   EXPECT_EQ(-ECANCELED, rados_write_op_operate(op, ioctx, obj, NULL, 0));
   rados_release_write_op(op);
-  ASSERT_EQ(-ECANCELED, r_vals);
+
+  // see http://tracker.ceph.com/issues/19518
+  //ASSERT_EQ(-ECANCELED, r_vals);
 
   // verifying the keys are still there, and then remove them
   op = rados_create_write_op();


### PR DESCRIPTION
This is not included in the pg log and may be zeroed if there is an op
replayed.  Disable the assertion until the underlying bug is fixed.  See
http://tracker.ceph.com/issues/19518

Signed-off-by: Sage Weil <sage@redhat.com>