### PR TITLE
rgw:multisite: fix RGWRadosRemoveOmapKeysCR and change cn to intrusive_ptr

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -220,13 +220,6 @@ RGWRadosSetOmapKeysCR::RGWRadosSetOmapKeysCR(RGWRados *_store,
   s << "]";
 }
 
-RGWRadosSetOmapKeysCR::~RGWRadosSetOmapKeysCR()
-{
-  if (cn) {
-    cn->put();
-  }
-}
-
 int RGWRadosSetOmapKeysCR::send_request()
 {
   int r = store->get_raw_obj_ref(obj, &ref);
@@ -241,7 +234,6 @@ int RGWRadosSetOmapKeysCR::send_request()
   op.omap_set(entries);
 
   cn = stack->create_completion_notifier();
-  cn->get();
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op);
 }
 
@@ -264,10 +256,6 @@ RGWRadosGetOmapKeysCR::RGWRadosGetOmapKeysCR(RGWRados *_store,
                                                 obj(_obj), cn(NULL)
 {
   set_description() << "set omap keys dest=" << obj << " marker=" << marker;
-}
-
-RGWRadosGetOmapKeysCR::~RGWRadosGetOmapKeysCR()
-{
 }
 
 int RGWRadosGetOmapKeysCR::send_request() {
@@ -294,10 +282,6 @@ RGWRadosRemoveOmapKeysCR::RGWRadosRemoveOmapKeysCR(RGWRados *_store,
                                                 obj(_obj), cn(NULL)
 {
   set_description() << "remove omap keys dest=" << obj << " keys=" << keys;
-}
-
-RGWRadosRemoveOmapKeysCR::~RGWRadosRemoveOmapKeysCR()
-{
 }
 
 int RGWRadosRemoveOmapKeysCR::send_request() {
@@ -701,19 +685,11 @@ RGWRadosTimelogAddCR::RGWRadosTimelogAddCR(RGWRados *_store, const string& _oid,
   entries.push_back(entry);
 }
 
-RGWRadosTimelogAddCR::~RGWRadosTimelogAddCR()
-{
-  if (cn) {
-    cn->put();
-  }
-}
-
 int RGWRadosTimelogAddCR::send_request()
 {
   set_status() << "sending request";
 
   cn = stack->create_completion_notifier();
-  cn->get();
   return store->time_log_add(oid, entries, cn->completion(), true);
 }
 
@@ -741,19 +717,11 @@ RGWRadosTimelogTrimCR::RGWRadosTimelogTrimCR(RGWRados *store,
       << " from_marker=" << from_marker << " to_marker=" << to_marker;
 }
 
-RGWRadosTimelogTrimCR::~RGWRadosTimelogTrimCR()
-{
-  if (cn) {
-    cn->put();
-  }
-}
-
 int RGWRadosTimelogTrimCR::send_request()
 {
   set_status() << "sending request";
 
   cn = stack->create_completion_notifier();
-  cn->get();
   return store->time_log_trim(oid, start_time, end_time, from_marker,
                               to_marker, cn->completion());
 }

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -316,6 +316,15 @@ int RGWRadosRemoveOmapKeysCR::send_request() {
   return ref.ioctx.aio_operate(ref.oid, cn->completion(), &op);
 }
 
+int RGWRadosRemoveOmapKeysCR::request_complete()
+{
+  int r = cn->completion()->get_return_value();
+
+  set_status() << "request complete; ret=" << r;
+
+  return r;
+}
+
 RGWRadosRemoveCR::RGWRadosRemoveCR(RGWRados *store, const rgw_raw_obj& obj)
   : RGWSimpleCoroutine(store->ctx()), store(store), obj(obj)
 {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -441,18 +441,13 @@ public:
 class RGWRadosRemoveOmapKeysCR : public RGWSimpleCoroutine {
   RGWRados *store;
 
-  string marker;
-  map<string, bufferlist> *entries;
-  int max_entries;
-
-  int rval;
   rgw_rados_ref ref;
 
   set<string> keys;
 
   rgw_raw_obj obj;
 
-  RGWAioCompletionNotifier *cn;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
   RGWRadosRemoveOmapKeysCR(RGWRados *_store,
@@ -463,9 +458,7 @@ public:
 
   int send_request() override;
 
-  int request_complete() override {
-    return rval;
-  }
+  int request_complete() override;
 };
 
 class RGWRadosRemoveCR : public RGWSimpleCoroutine {

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -396,14 +396,12 @@ class RGWRadosSetOmapKeysCR : public RGWSimpleCoroutine {
 
   rgw_raw_obj obj;
 
-  RGWAioCompletionNotifier *cn;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
   RGWRadosSetOmapKeysCR(RGWRados *_store,
 		      const rgw_raw_obj& _obj,
 		      map<string, bufferlist>& _entries);
-
-  ~RGWRadosSetOmapKeysCR() override;
 
   int send_request() override;
   int request_complete() override;
@@ -421,15 +419,13 @@ class RGWRadosGetOmapKeysCR : public RGWSimpleCoroutine {
 
   rgw_raw_obj obj;
 
-  RGWAioCompletionNotifier *cn;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
   RGWRadosGetOmapKeysCR(RGWRados *_store,
 		      const rgw_raw_obj& _obj,
 		      const string& _marker,
 		      map<string, bufferlist> *_entries, int _max_entries);
-
-  ~RGWRadosGetOmapKeysCR() override;
 
   int send_request() override;
 
@@ -453,8 +449,6 @@ public:
   RGWRadosRemoveOmapKeysCR(RGWRados *_store,
 		      const rgw_raw_obj& _obj,
 		      const set<string>& _keys);
-
-  ~RGWRadosRemoveOmapKeysCR() override;
 
   int send_request() override;
 
@@ -1078,12 +1072,11 @@ class RGWRadosTimelogAddCR : public RGWSimpleCoroutine {
 
   string oid;
 
-  RGWAioCompletionNotifier *cn;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
 
 public:
   RGWRadosTimelogAddCR(RGWRados *_store, const string& _oid,
 		        const cls_log_entry& entry);
-  ~RGWRadosTimelogAddCR() override;
 
   int send_request() override;
   int request_complete() override;
@@ -1091,7 +1084,7 @@ public:
 
 class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
   RGWRados *store;
-  RGWAioCompletionNotifier *cn{nullptr};
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
  protected:
   std::string oid;
   real_time start_time;
@@ -1104,7 +1097,6 @@ class RGWRadosTimelogTrimCR : public RGWSimpleCoroutine {
                         const real_time& start_time, const real_time& end_time,
                         const std::string& from_marker,
                         const std::string& to_marker);
-  ~RGWRadosTimelogTrimCR() override;
 
   int send_request() override;
   int request_complete() override;


### PR DESCRIPTION
RGWRadosRemoveOmapKeysCR::request_complete return val is wrong. The return val should get from completion.  Some member variables is not used, clear up those variables.
change raw 'RGWAioCompletionNotifier*' to intrusive_ptr for rgw_cr_rados

Fixes:http://tracker.ceph.com/issues/20539

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>