### PR TITLE
common/Timer: do not add event if already shutdown

### DIFF
--- a/src/common/Timer.cc
+++ b/src/common/Timer.cc
@@ -126,8 +126,11 @@ void SafeTimer::add_event_after(double seconds, Context *callback)
 void SafeTimer::add_event_at(utime_t when, Context *callback)
 {
   assert(lock.is_locked());
-  ldout(cct,10) << "add_event_at " << when << " -> " << callback << dendl;
-
+  ldout(cct,10) << __func__ << " " << when << " -> " << callback << dendl;
+  if (stopping) {
+    ldout(cct,5) << __func__ << " already shutdown, event not added" << dendl;
+    delete callback;
+  }
   scheduled_map_t::value_type s_val(when, callback);
   scheduled_map_t::iterator i = schedule.insert(s_val);
 


### PR DESCRIPTION
otherwise the callback is leaked.

Fixes: http://tracker.ceph.com/issues/20432
Signed-off-by: Kefu Chai <kchai@redhat.com>