### PR TITLE
rgw/rgw_frontend.h: Return negative value for empty uid in RGWLoadGenFrontend::init()

### DIFF
--- a/src/rgw/rgw_frontend.h
+++ b/src/rgw/rgw_frontend.h
@@ -213,7 +213,7 @@ public:
     if (uid_str.empty()) {
       derr << "ERROR: uid param must be specified for loadgen frontend"
 	   << dendl;
-      return EINVAL;
+      return -EINVAL;
     }
 
     rgw_user uid(uid_str);


### PR DESCRIPTION
A negative value should be returned for empty uid in RGWLoadGenFrontend::init(), otherwise the program will continue to run.

Signed-off-by: jimifm <hong.zhangoole@gmail.com>