### PR TITLE
build: build erasure-code isa lib without versions

### DIFF
--- a/src/erasure-code/isa/CMakeLists.txt
+++ b/src/erasure-code/isa/CMakeLists.txt
@@ -64,8 +64,6 @@ add_library(ec_isa SHARED
 add_dependencies(ec_isa ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
 target_link_libraries(ec_isa ${EXTRALIBS})
 set_target_properties(ec_isa PROPERTIES
-  VERSION 2.18.0
-  SOVERSION 2
   INSTALL_RPATH "")
 install(TARGETS ec_isa DESTINATION ${erasure_plugin_dir})
 


### PR DESCRIPTION
As erasure coding modules are loaded dynamically by Ceph, there
is no need to build the backend modules with library versioning.

This change brings the isa library inline with other erasure-code
sub-modules.

Signed-off-by: James Page <james.page@ubuntu.com>