### PR TITLE
mon/Paxos: fix rare assertion failure for OP_ACCEPT

### DIFF
--- a/src/mon/Paxos.cc
+++ b/src/mon/Paxos.cc
@@ -771,14 +771,14 @@ void Paxos::handle_accept(MonOpRequestRef op)
     op->mark_paxos_event("have higher pn, ignore");
     return;
   }
-  if (last_committed > 0 &&
-      accept->last_committed < last_committed-1) {
-    dout(10) << " this is from an old round, ignoring" << dendl;
-    op->mark_paxos_event("old round, ignore");
+
+  if (accept->last_committed != last_committed){
+    dout(10) << " this is from another round, ignoring" <<dendl;
+    op->mark_paxos_event("another round, ignoring");
     return;
   }
-  assert(accept->last_committed == last_committed ||   // not committed
-	 accept->last_committed == last_committed-1);  // committed
+
+  assert(accept->last_committed == last_committed);
 
   assert(is_updating() || is_updating_previous());
   assert(accepted.count(from) == 0);


### PR DESCRIPTION
When the leader received a MMonPaxos::OP_ACCEPT with the its last_committed already committed, the leader must be in STATE_WRITING or STATE_WRITING_PREVIOUS, the coming assertion about leader state will fail. On the other side, when we are already in STATE_WRITING or STATE_WRITING_PREVIOUS, it must collect all OP_ACCEPT message from the quorum, so we can safely ignore it.
