### PR TITLE
rpm: Fix undefined FIRST_ARG

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1007,6 +1007,7 @@ fi
 
 %postun base
 /sbin/ldconfig
+test -n "$FIRST_ARG" || FIRST_ARG=$1
 %if 0%{?suse_version}
 DISABLE_RESTART_ON_UPDATE="yes"
 %service_del_postun ceph-disk@\*.service ceph.target


### PR DESCRIPTION
If FIRST_ARG is undefined, the rpms will show an error on upgrade
because the condition in the postun script gets broken.

Signed-off-by: Boris Ranto <branto@redhat.com>