### PR TITLE
common, global: Make 'global' to be shared library.

### DIFF
--- a/src/compressor/zlib/CMakeLists.txt
+++ b/src/compressor/zlib/CMakeLists.txt
@@ -39,7 +39,7 @@ endif(HAVE_INTEL_SSE4_1 AND HAVE_BETTER_YASM_ELF64)
 
 add_library(ceph_zlib SHARED ${zlib_sources})
 add_dependencies(ceph_zlib ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zlib ${ZLIB_LIBRARIES})
+target_link_libraries(ceph_zlib ${ZLIB_LIBRARIES} global ceph-common)
 target_include_directories(ceph_zlib PRIVATE "${CMAKE_SOURCE_DIR}/src/isa-l/include")
 set_target_properties(ceph_zlib PROPERTIES
   VERSION 2.0.0

--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -34,7 +34,7 @@ set(zstd_sources
 
 add_library(ceph_zstd SHARED ${zstd_sources})
 add_dependencies(ceph_zstd ${CMAKE_SOURCE_DIR}/src/ceph_ver.h)
-target_link_libraries(ceph_zstd zstd)
+target_link_libraries(ceph_zstd zstd global ceph-common)
 set_target_properties(ceph_zstd PROPERTIES VERSION 2.0.0 SOVERSION 2)
 install(TARGETS ceph_zstd DESTINATION ${compressor_plugin_dir})
 

--- a/src/global/CMakeLists.txt
+++ b/src/global/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(global-static STATIC
   $<TARGET_OBJECTS:libglobal_objs>
   $<TARGET_OBJECTS:global_common_objs>)
 
-add_library(global STATIC
+add_library(global SHARED
   $<TARGET_OBJECTS:libglobal_objs>
   $<TARGET_OBJECTS:global_common_objs>)
 target_link_libraries(global ceph-common ${DPDK_LIBRARIES} ${EXTRALIBS})

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -20,7 +20,7 @@ set(merge_libs
   common
   common_utf8
   erasure_code
-  global
+  global-static
   json_spirit
   kv
   mds


### PR DESCRIPTION
  If global is not shared library, then plugins link to
  private copies of 'g_conf' and 'g_ceph_context'.
  This happens only when 'g_conf' an 'g_ceph_context' come
  from different shared libraries. This is the case for nfsd-ganesha,
  as it loads librgw.so, which loads libceph_zlib.so.
  That causes that librgw.so's 'g_conf' is initialized properly,
  but libceph_zlib.so's 'g_conf' is never set.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>