### PR TITLE
rgw,nfs: Add hint to use -o sync when mouting

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1124,6 +1124,7 @@ namespace rgw {
 	  << __func__
 	  << " " << object_name()
 	  << " non-0 initial write position " << off
+	  << " (mounting with -o sync required)"
 	  << dendl;
 	return -EIO;
       }
@@ -1297,8 +1298,13 @@ namespace rgw {
     op_ret = 0;
 
     /* check guards (e.g., contig write) */
-    if (eio)
+    if (eio) {
+      ldout(s->cct, 5)
+        << " chunks arrived in wrong order"
+        << " (mounting with -o sync required)"
+        << dendl;
       return -EIO;
+    }
 
     size_t len = data.length();
     if (! len)


### PR DESCRIPTION
when erratic operations suggest it. This is only convenience.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>