### PR TITLE
qa/tasks/ceph: don't hard-code cluster name when copying fsid

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1111,7 +1111,8 @@ def run_daemon(ctx, config, type_):
             _, _, id_ = teuthology.split_role(role)
 
             if type_ == 'osd':
-                datadir='/var/lib/ceph/osd/ceph-' + id_
+                datadir='/var/lib/ceph/osd/{cluster}-{id}'.format(
+                    cluster=cluster_name, id=id_)
                 osd_uuid = teuthology.get_file(
                     remote=remote,
                     path=datadir + '/fsid',

--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1121,38 +1121,24 @@ def run_daemon(ctx, config, type_):
                 try:
                     remote.run(
                         args=[
-                            'sudo',
-                            'ceph',
-                            'osd',
-                            'new',
-                            osd_uuid,
-                            id_,
+                            'sudo', 'ceph', '--cluster', cluster_name,
+                            'osd', 'new', osd_uuid, id_,
                         ]
                     )
                 except:
                     # fallback to pre-luminous
                     remote.run(
                         args=[
-                            'sudo',
-                            'ceph',
-                            'osd',
-                            'create',
-                            osd_uuid,
-                            id_,
+                            'sudo', 'ceph', '--cluster', cluster_name,
+                            'osd', 'create', osd_uuid, id_,
                         ]
                     )
                 if config.get('add_osds_to_crush'):
                     remote.run(
                         args=[
-                            'sudo',
-                            'ceph',
-                            'osd',
-                            'crush',
-                            'create-or-move',
-                            'osd.' + id_,
-                            '1.0',
-                            'host=localhost',
-                            'root=default',
+                            'sudo', 'ceph', '--cluster', cluster_name,
+                            'osd', 'crush', 'create-or-move', 'osd.' + id_,
+                            '1.0', 'host=localhost', 'root=default',
                         ]
                     )
 


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>