### PR TITLE
qa/tasks/radosbench: longer timeout

### DIFF
--- a/qa/tasks/radosbench.py
+++ b/qa/tasks/radosbench.py
@@ -127,7 +127,7 @@ def task(ctx, config):
     try:
         yield
     finally:
-        timeout = config.get('time', 360) * 10 + 180
+        timeout = config.get('time', 360) * 30 + 300
         log.info('joining radosbench (timing out after %ss)', timeout)
         run.wait(radosbench.itervalues(), timeout=timeout)
 


### PR DESCRIPTION
Hit another timeout due to aggressive thrashing with size==min_size.

Signed-off-by: Sage Weil <sage@redhat.com>