### PR TITLE
common/Mutex.cc: fixed the error in comment

### DIFF
--- a/src/common/Mutex.cc
+++ b/src/common/Mutex.cc
@@ -61,10 +61,11 @@ Mutex::Mutex(const std::string &n, bool r, bool ld,
       _register();
   }
   else {
-    // If the mutex type is PTHREAD_MUTEX_NORMAL, deadlock detection
-    // shall not be provided. Attempting to relock the mutex causes
-    // deadlock. If a thread attempts to unlock a mutex that  it  has not
-    // locked or a mutex which is unlocked, undefined behavior results.
+    // If the mutex type is PTHREAD_MUTEX_DEFAULT, attempting to recursively
+    // lock the mutex results in undefined behavior. Attempting to unlock the
+    // mutex if it was not locked by the calling thread results in undefined
+    // behavior. Attempting to unlock the mutex if it is not locked results in
+    // undefined behavior.
     pthread_mutex_init(&_m, NULL);
   }
 }


### PR DESCRIPTION
The type of pthread_mutex_lock is PTHREAD_MUTEX_DEFAULT, but it is commented as PTHREAD_MUTEX_NORMAL, and may make the reader misunderstand.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>