### PR TITLE
[qa/ceph-deploy]:  run create mgr nodes as well

### DIFF
--- a/qa/tasks/ceph_deploy.py
+++ b/qa/tasks/ceph_deploy.py
@@ -241,7 +241,10 @@ def build_ceph_cluster(ctx, config):
         mds_nodes = " ".join(mds_nodes)
         mon_node = get_nodes_using_role(ctx, 'mon')
         mon_nodes = " ".join(mon_node)
+        mgr_nodes = get_nodes_using_role(ctx, 'mgr')
+        mgr_nodes = " ".join(mgr_nodes)
         new_mon = './ceph-deploy new' + " " + mon_nodes
+        mgr_create = './ceph-deploy mgr create' + " " + mgr_nodes
         mon_hostname = mon_nodes.split(' ')[0]
         mon_hostname = str(mon_hostname)
         gather_keys = './ceph-deploy gatherkeys' + " " + mon_hostname
@@ -294,6 +297,7 @@ def build_ceph_cluster(ctx, config):
         # are taking way more than a minute/monitor to form quorum, so lets
         # try the next block which will wait up to 15 minutes to gatherkeys.
         execute_ceph_deploy(mon_create_nodes)
+        execute_ceph_deploy(mgr_create)
 
         # create-keys is explicit now
         # http://tracker.ceph.com/issues/16036

--- a/qa/workunits/ceph-tests/ceph-admin-commands.sh
+++ b/qa/workunits/ceph-tests/ceph-admin-commands.sh
@@ -5,6 +5,7 @@ ceph -s
 #list pools
 rados lspools
 #lisr rbd images
+ceph osd pool create rbd 128 128
 rbd ls
 #check that the monitors work
 ceph osd set nodown


### PR DESCRIPTION
Due to https://github.com/ceph/ceph/pull/16023, the mgr are no longer started alongside monitor nodes.


Testing at: http://pulpito.ceph.com/vasu-2017-07-07_15:53:08-ceph-deploy-master-distro-basic-vps/

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>