### PR TITLE
build: execute dh_systemd_{enable,start} after dh_install

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -131,8 +131,15 @@ override_dh_installinit:
 	dh_installinit -p ceph-base --name ceph --no-start
 	dh_installinit -p radosgw --no-start
 
-override_dh_systemd_start:
+	# NOTE: execute systemd helpers so they pickup dh_install'ed units and targets
+	dh_systemd_enable
 	dh_systemd_start --no-restart-on-upgrade
+
+override_dh_systemd_enable:
+	# systemd enable done as part of dh_installinit
+
+override_dh_systemd_start:
+	# systemd start done as part of dh_installinit
 
 override_dh_strip:
 	dh_strip -pceph-mds --dbg-package=ceph-mds-dbg


### PR DESCRIPTION
Ensure that dh_systemd_* debhelpers are executed after dh_install
has installed the systemd unit and target definitions.

This ensures that targets are enabled by default once installed,
resolving issues with startup of ceph daemons on server reboot.

Fixes: http://tracker.ceph.com/issues/19585
Signed-off-by: James Page <james.page@ubuntu.com>