### PR TITLE
crush/CrushWrapper: make get_immediate_parent[_id] ignore per-class shadow hierarchy

### DIFF
--- a/qa/workunits/rados/test_health_warnings.sh
+++ b/qa/workunits/rados/test_health_warnings.sh
@@ -53,8 +53,25 @@ test_mark_all_but_last_osds_down() {
   wait_for_healthy
 }
 
+test_mark_two_osds_same_host_down_with_classes() {
+    ceph osd set noup
+    ceph osd crush class create ssd
+    ceph osd crush class create hdd
+    ceph osd crush set-device-class ssd osd.0 osd.2 osd.4 osd.6 osd.8
+    ceph osd crush set-device-class hdd osd.1 osd.3 osd.5 osd.7 osd.9
+    ceph osd down osd.0 osd.1
+    ceph health detail
+    ceph health | grep "1 host"
+    ceph health | grep "2 osds"
+    ceph health detail | grep "osd.0"
+    ceph health detail | grep "osd.1"
+    ceph osd unset noup
+    wait_for_healthy
+}
+
 test_mark_two_osds_same_host_down
 test_mark_two_osds_same_rack_down
 test_mark_all_but_last_osds_down
+test_mark_two_osds_same_host_down_with_classes
 
 exit 0

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1211,6 +1211,9 @@ pair<string,string> CrushWrapper::get_immediate_parent(int id, int *_ret)
     crush_bucket *b = crush->buckets[bidx];
     if (b == 0)
       continue;
+    const char *n = get_item_name(b->id);
+    if (n && !is_valid_crush_name(n))
+      continue;
     for (unsigned i = 0; i < b->size; i++)
       if (b->items[i] == id) {
         string parent_id = name_map[b->id];
@@ -1232,6 +1235,9 @@ int CrushWrapper::get_immediate_parent_id(int id, int *parent) const
   for (int bidx = 0; bidx < crush->max_buckets; bidx++) {
     crush_bucket *b = crush->buckets[bidx];
     if (b == 0)
+      continue;
+    const char *n = get_item_name(b->id);
+    if (n && !is_valid_crush_name(n))
       continue;
     for (unsigned i = 0; i < b->size; i++) {
       if (b->items[i] == id) {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -297,8 +297,14 @@ bool OSDMap::containing_subtree_is_down(CephContext *cct, int id, int subtree_ty
   }
 }
 
-bool OSDMap::subtree_type_is_down(CephContext *cct, int id, int subtree_type, set<int> *down_in_osds, set<int> *up_in_osds,
-                                           set<int> *subtree_up, unordered_map<int, set<int> > *subtree_type_down) const
+bool OSDMap::subtree_type_is_down(
+  CephContext *cct,
+  int id,
+  int subtree_type,
+  set<int> *down_in_osds,
+  set<int> *up_in_osds,
+  set<int> *subtree_up,
+  unordered_map<int, set<int> > *subtree_type_down) const
 {
   if (id >= 0) {
     bool is_down_ret = is_down(id);
@@ -320,7 +326,9 @@ bool OSDMap::subtree_type_is_down(CephContext *cct, int id, int subtree_type, se
   list<int> children;
   crush->get_children(id, &children);
   for (const auto &child : children) {
-    if (!subtree_type_is_down(cct, child, crush->get_bucket_type(child), down_in_osds, up_in_osds, subtree_up, subtree_type_down)) {
+    if (!subtree_type_is_down(
+	  cct, child, crush->get_bucket_type(child),
+	  down_in_osds, up_in_osds, subtree_up, subtree_type_down)) {
       subtree_up->insert(id);
       return false;
     }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4334,23 +4334,19 @@ void OSDMap::check_health(health_check_map_t *checks) const
       for (auto j = subtree_type_down[type].begin();
 	   j != subtree_type_down[type].end();
 	   ++j) {
-	if (type == 1) {
-          list<int> children;
-          int num = crush->get_children(*j, &children);
-          num_osds_subtree[*j] = num;
-        } else {
-          list<int> children;
-          int num = 0;
-          int num_children = crush->get_children(*j, &children);
-          if (num_children == 0)
-	    continue;
-          for (auto l = children.begin(); l != children.end(); ++l) {
-            if (num_osds_subtree[*l] > 0) {
-              num = num + num_osds_subtree[*l];
-            }
-          }
-          num_osds_subtree[*j] = num;
+	list<int> children;
+	int num = 0;
+	int num_children = crush->get_children(*j, &children);
+	if (num_children == 0)
+	  continue;
+	for (auto l = children.begin(); l != children.end(); ++l) {
+	  if (*l >= 0) {
+	    ++num;
+	  } else if (num_osds_subtree[*l] > 0) {
+	    num = num + num_osds_subtree[*l];
+	  }
 	}
+	num_osds_subtree[*j] = num;
       }
     }
     num_down_in_osds = down_in_osds.size();

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -6,6 +6,7 @@
      --test-map-pgs [--pool <poolid>] [--pg_num <pg_num>] map all pgs
      --test-map-pgs-dump [--pool <poolid>] map all pgs
      --test-map-pgs-dump-all [--pool <poolid>] map all pgs to osds
+     --health                dump health checks
      --mark-up-in            mark osds up and in (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp

--- a/src/test/cli/osdmaptool/missing-argument.t
+++ b/src/test/cli/osdmaptool/missing-argument.t
@@ -6,6 +6,7 @@
      --test-map-pgs [--pool <poolid>] [--pg_num <pg_num>] map all pgs
      --test-map-pgs-dump [--pool <poolid>] map all pgs
      --test-map-pgs-dump-all [--pool <poolid>] map all pgs to osds
+     --health                dump health checks
      --mark-up-in            mark osds up and in (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20546
Signed-off-by: Sage Weil <sage@redhat.com>