### PR TITLE
tests: fix rados/upgrade/jewel-x-singleton and make workunit task handle repo URLs not ending in ".git"

### DIFF
--- a/qa/suites/rados/upgrade/jewel-x-singleton/6-finish-upgrade.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/6-finish-upgrade.yaml
@@ -13,3 +13,5 @@ tasks:
     daemons: [mds.a]
     wait-for-up: true
     wait-for-healthy: false
+- install.upgrade:
+    client.0:

--- a/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rbd-python.yaml
+++ b/qa/suites/rados/upgrade/jewel-x-singleton/8-workload/rbd-python.yaml
@@ -3,7 +3,6 @@ meta:
    librbd python api tests
 tasks:
 - workunit:
-    branch: jewel
     clients:
       client.0:
         - rbd/test_librbd_python.sh

--- a/qa/tasks/workunit.py
+++ b/qa/tasks/workunit.py
@@ -4,6 +4,7 @@ Workunit task -- Run ceph on sets of specific clients
 import logging
 import pipes
 import os
+import re
 
 from copy import deepcopy
 from util import get_remote_for_role
@@ -377,9 +378,12 @@ def _run_tests(ctx, refspec, role, tests, env, subdir=None, timeout=None):
         remote.run(logger=log.getChild(role),
                    args=refspec.clone(git_url, clonedir))
     except CommandFailedError:
-        if not git_url.endswith('/ceph-ci.git'):
+        if git_url.endswith('/ceph-ci.git'):
+            alt_git_url = git_url.replace('/ceph-ci.git', '/ceph.git')
+        elif git_url.endswith('/ceph-ci'):
+            alt_git_url = re.sub(r'/ceph-ci$', '/ceph.git', git_url)
+        else:
             raise
-        alt_git_url = git_url.replace('/ceph-ci.git', '/ceph.git')
         log.info(
             "failed to check out '%s' from %s; will also try in %s",
             refspec,


### PR DESCRIPTION
http://tracker.ceph.com/issues/20368
http://tracker.ceph.com/issues/20554

Continuation of #16222