### PR TITLE
MDS: update the mlogger of mds in function check_memory_usage

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -7437,6 +7437,7 @@ void MDCache::check_memory_usage()
 	   << ", " << Capability::count() << " caps, " << caps_per_inode << " caps per inode"
 	   << dendl;
 
+  mds->update_mlogger();
   mds->mlogger->set(l_mdm_rss, last.get_rss());
   mds->mlogger->set(l_mdm_heap, last.get_heap());
 

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -657,12 +657,17 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
   }
   */
 
+  update_mlogger();
+  return true;
+}
+
+void MDSRank::update_mlogger()
+{
   if (mlogger) {
     mlogger->set(l_mdm_ino, CInode::count());
     mlogger->set(l_mdm_dir, CDir::count());
     mlogger->set(l_mdm_dn, CDentry::count());
     mlogger->set(l_mdm_cap, Capability::count());
-
     mlogger->set(l_mdm_inoa, CInode::increments());
     mlogger->set(l_mdm_inos, CInode::decrements());
     mlogger->set(l_mdm_dira, CDir::increments());
@@ -671,11 +676,8 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
     mlogger->set(l_mdm_dns, CDentry::decrements());
     mlogger->set(l_mdm_capa, Capability::increments());
     mlogger->set(l_mdm_caps, Capability::decrements());
-
     mlogger->set(l_mdm_buf, buffer::get_total_alloc());
   }
-
-  return true;
 }
 
 /*

--- a/src/mds/MDSRank.h
+++ b/src/mds/MDSRank.h
@@ -210,6 +210,7 @@ class MDSRank {
       purge_queue.handle_conf_change(conf, changed, *mdsmap);
     }
 
+    void update_mlogger();
   protected:
     // Flag to indicate we entered shutdown: anyone seeing this to be true
     // after taking mds_lock must drop out.


### PR DESCRIPTION
If we don't update the mlogger here, we will encounter following bug:
suppose we first create 10000 inode in mdcache, then we trimmed it to 1000
but the "ceph daemon mds.* perf dump" will not show the correct inode number, it still shows 10000.
because for now we only update the mlogger at MDSRank::_dispatch.
check_memory_usage is called right after "mdcache trimming" at every mds tick interval
so this change will keep "ceph daemon mds.* perf dump" got the right number for "mds_mem".

Signed-off-by: dongdong tao <tdd21151186@gmail.com>