### PR TITLE
qa/tasks/ceph.py: no osd id to 'osd create' command

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1126,11 +1126,11 @@ def run_daemon(ctx, config, type_):
                         ]
                     )
                 except:
-                    # fallback to pre-luminous
+                    # fallback to pre-luminous (hammer or jewel)
                     remote.run(
                         args=[
                             'sudo', 'ceph', '--cluster', cluster_name,
-                            'osd', 'create', osd_uuid, id_,
+                            'osd', 'create', osd_uuid,
                         ]
                     )
                 if config.get('add_osds_to_crush'):


### PR DESCRIPTION
This isn't recognized by hammer, and we don't need it for jewel.

Fixes: http://tracker.ceph.com/issues/20548
Signed-off-by: Sage Weil <sage@redhat.com>