### PR TITLE
dmclock: prefer to clock_gettime to get time

### DIFF
--- a/src/dmclock/src/dmclock_util.h
+++ b/src/dmclock/src/dmclock_util.h
@@ -30,11 +30,17 @@ namespace crimson {
 
 
     inline Time get_time() {
+#if defined(__linux__)
+      struct timespec now;
+      clock_gettime(CLOCK_REALTIME, &now);
+      return now.tv_sec + (now.tv_nsec / 1.0e9);
+#else
       struct timeval now;
       auto result = gettimeofday(&now, NULL);
       (void) result;
       assert(0 == result);
-      return now.tv_sec + (now.tv_usec / 1000000.0);
+      return now.tv_sec + (now.tv_usec / 1.0e6);
+#endif
     }
 
     std::string format_time(const Time& time, uint modulo = 1000);


### PR DESCRIPTION
We'd better use `clock_gettime()` function but `gettimeofday()` for:
1. more precise, since nanoseconds returned by `clock_gettime()`;
2. POSIX.1-2008 [says](http://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html)   that: `Applications should use the clock_gettime() function instead of the obsolescent gettimeofday() function.` 
3. consistent with `ceph_clock_now()`

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>