### PR TITLE
osd: make allow_limit_break configurable for mclock queue

### DIFF
--- a/src/common/OpQueue.h
+++ b/src/common/OpQueue.h
@@ -56,6 +56,8 @@ class OpQueue {
     virtual bool empty() const = 0;
     // Return an op to be dispatch
     virtual T dequeue() = 0;
+    // Time delay of the next pending op to dequeue
+    virtual double next_dequeue_delay() { return 0.0; };
     // Formatted output of the queue
     virtual void dump(ceph::Formatter *f) const = 0;
     // Don't leak resources on destruction

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1967,6 +1967,10 @@ std::vector<Option> get_global_options() {
     .set_default(65536)
     .set_description(""),
 
+    Option("osd_op_pq_mclock_allow_limit_break", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description(""),
+
     Option("osd_disk_threads", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1)
     .set_description(""),

--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -631,6 +631,27 @@ namespace crimson {
 #endif
       } // display_queues
 
+      Time next_request_delay() {
+         Time delay = TimeZero;
+         Time now = get_time();
+         DataGuard g(data_mtx);
+         NextReq next = do_next_request(now);
+         switch(next.type) {
+         case NextReqType::none:
+           delay = TimeMax;
+           break;
+         case NextReqType::returning:
+           // default TimeZero
+           break;
+         case NextReqType::future:
+           delay = next.when_ready - now;
+           assert(delay > 0);
+           break;
+         default:
+           assert(false);
+         }
+         return delay;
+      }
 
     protected:
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -9649,17 +9649,19 @@ void OSD::ShardedOpWQ::_process(uint32_t thread_index, heartbeat_handle_d *hb)
   auto& sdata = shard_list[shard_index];
   assert(sdata);
   // peek at spg_t
+  double delay = osd->cct->_conf->threadpool_empty_queue_max_wait;
   sdata->sdata_op_ordering_lock.Lock();
-  if (sdata->pqueue->empty()) {
+  if (sdata->pqueue->empty() ||
+     (delay = std::min(delay, sdata->pqueue->next_dequeue_delay())) > 0) {
     sdata->sdata_lock.Lock();
     if (!sdata->stop_waiting) {
-      dout(20) << __func__ << " empty q, waiting" << dendl;
+      dout(30) << __func__ << " empty q, waiting " << delay << dendl;
       osd->cct->get_heartbeat_map()->clear_timeout(hb);
       sdata->sdata_op_ordering_lock.Unlock();
-      sdata->sdata_cond.Wait(sdata->sdata_lock);
+      sdata->sdata_cond.WaitInterval(sdata->sdata_lock, utime_t(delay, 0));
       sdata->sdata_lock.Unlock();
       sdata->sdata_op_ordering_lock.Lock();
-      if (sdata->pqueue->empty()) {
+      if (sdata->pqueue->empty() || sdata->pqueue->next_dequeue_delay() > 0) {
 	sdata->sdata_op_ordering_lock.Unlock();
 	return;
       }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1611,7 +1611,7 @@ private:
       ShardData(
 	string lock_name, string ordering_lock,
 	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct,
-	io_queue opqueue)
+	io_queue opqueue, bool allow_limit_break)
 	: sdata_lock(lock_name.c_str(), false, true, false, cct),
 	  sdata_op_ordering_lock(ordering_lock.c_str(), false, true,
 				 false, cct) {
@@ -1624,9 +1624,9 @@ private:
 	    PrioritizedQueue<OpQueueItem,uint64_t>>(
 		max_tok_per_prio, min_cost);
 	} else if (opqueue == io_queue::mclock_opclass) {
-	  pqueue = std::make_unique<ceph::mClockOpClassQueue>(cct);
+	  pqueue = std::make_unique<ceph::mClockOpClassQueue>(cct, allow_limit_break);
 	} else if (opqueue == io_queue::mclock_client) {
-	  pqueue = std::make_unique<ceph::mClockClientQueue>(cct);
+	  pqueue = std::make_unique<ceph::mClockClientQueue>(cct, allow_limit_break);
 	}
       }
     }; // struct ShardData
@@ -1653,7 +1653,8 @@ private:
 	ShardData* one_shard = new ShardData(
 	  lock_name, order_lock,
 	  osd->cct->_conf->osd_op_pq_max_tokens_per_priority, 
-	  osd->cct->_conf->osd_op_pq_min_cost, osd->cct, osd->op_queue);
+	  osd->cct->_conf->osd_op_pq_min_cost, osd->cct, osd->op_queue,
+	  osd->cct->_conf->get_val<bool>("osd_op_pq_mclock_allow_limit_break"));
 	shard_list.push_back(one_shard);
       }
     }

--- a/src/osd/mClockClientQueue.cc
+++ b/src/osd/mClockClientQueue.cc
@@ -33,8 +33,9 @@ namespace ceph {
    * class mClockClientQueue
    */
 
-  mClockClientQueue::mClockClientQueue(CephContext *cct) :
+  mClockClientQueue::mClockClientQueue(CephContext *cct, bool allow_limit_break) :
     queue(std::bind(&mClockClientQueue::op_class_client_info_f, this, _1),
+          allow_limit_break,
 	  cct->_conf->osd_op_queue_mclock_anticipation_timeout),
     client_info_mgr(cct)
   {

--- a/src/osd/mClockClientQueue.h
+++ b/src/osd/mClockClientQueue.h
@@ -49,7 +49,7 @@ namespace ceph {
 
   public:
 
-    mClockClientQueue(CephContext *cct);
+    mClockClientQueue(CephContext *cct, bool allow_limit_break = true);
 
     const crimson::dmclock::ClientInfo* op_class_client_info_f(const InnerClient& client);
 
@@ -98,6 +98,10 @@ namespace ceph {
     // Returns if the queue is empty
     inline bool empty() const override final {
       return queue.empty();
+    }
+
+    inline double next_dequeue_delay() override final {
+      return queue.next_dequeue_delay();
     }
 
     // Formatted output of the queue

--- a/src/osd/mClockOpClassQueue.cc
+++ b/src/osd/mClockOpClassQueue.cc
@@ -33,9 +33,10 @@ namespace ceph {
    * class mClockOpClassQueue
    */
 
-  mClockOpClassQueue::mClockOpClassQueue(CephContext *cct) :
+  mClockOpClassQueue::mClockOpClassQueue(CephContext *cct, bool allow_limit_break) :
     queue(std::bind(&mClockOpClassQueue::op_class_client_info_f, this, _1),
-	  cct->_conf->osd_op_queue_mclock_anticipation_timeout),
+          allow_limit_break,
+          cct->_conf->osd_op_queue_mclock_anticipation_timeout),
     client_info_mgr(cct)
   {
     // empty

--- a/src/osd/mClockOpClassQueue.h
+++ b/src/osd/mClockOpClassQueue.h
@@ -47,7 +47,7 @@ namespace ceph {
 
   public:
 
-    mClockOpClassQueue(CephContext *cct);
+    mClockOpClassQueue(CephContext *cct, bool allow_limit_break = true);
 
     const crimson::dmclock::ClientInfo*
     op_class_client_info_f(const osd_op_type_t& op_type);
@@ -117,6 +117,10 @@ namespace ceph {
     // Return an op to be dispatch
     inline Request dequeue() override final {
       return queue.dequeue();
+    }
+
+    inline double next_dequeue_delay() override final {
+      return queue.next_dequeue_delay();
     }
 
     // Formatted output of the queue


### PR DESCRIPTION
1. allow_limit_break is set to true by default.  as a choice, we can set it to false to allow `limit` of mclock to take effect.
2. on this occasion, mclock queue may dequeue a future op, osd wait until future time arrival or waked up by a new coming request( in enqueue).

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>