### PR TITLE
os/bluestore: Make BitmapFreelistManager kv itereator short lived.

### DIFF
--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -183,6 +183,7 @@ void BitmapFreelistManager::enumerate_reset()
   enumerate_offset = 0;
   enumerate_bl_pos = 0;
   enumerate_bl.clear();
+  enumerate_p.reset();
 }
 
 int get_next_clear_bit(bufferlist& bl, int start)

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4246,6 +4246,7 @@ int BlueStore::_open_alloc()
     ++num;
     bytes += length;
   }
+  fm->enumerate_reset();
   dout(1) << __func__ << " loaded " << pretty_si_t(bytes)
 	  << " in " << num << " extents"
 	  << dendl;
@@ -5963,6 +5964,7 @@ int BlueStore::fsck(bool deep)
 	++errors;
       }
     }
+    fm->enumerate_reset();
     size_t count = used_blocks.count();
     if (used_blocks.size() != count) {
       assert(used_blocks.size() > count);


### PR DESCRIPTION
Various KV stores want to keep read iterators/cursors/etc as short lived as possible.  This PR resets KeyValueDB iterator in BitmapFreelistManager when enumerate is reset.  In addition to calling enumerate_reset before enumerate loops, it calls it afterward as well.

In rocksdb:

"An iterator keeps a reference count on all underlying files that correspond to that point-in-time-view of the database - these files are not deleted until the Iterator is released."

In lmdb:

"While any reader exists, writers cannot reuse space in the database file that has become unused in later versions. Due to this, continual use of long-lived read transactions may cause the database to grow without bound."

Without this change an lmdb backed bluestore db will grow without bound (tested up to 93GB after several minutes of 4kb writes to an NVMe).  With this change, the database grows to ~122MB.

Rocksdb may not suffer as badly, though still may keep some files open indefinitely without the change.

Signed-off-by: Mark Nelson <mnelson@redhat.com>