### PR TITLE
qa/suites/rados/thrash/workload/*: enable rados.py cache tiering ops

### DIFF
--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps-readproxy.yaml
@@ -25,9 +25,9 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
-      flush: 50
-      try_flush: 50
-      evict: 50
+      cache_flush: 50
+      cache_try_flush: 50
+      cache_evict: 50
       snap_create: 50
       snap_remove: 50
       rollback: 50

--- a/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-pool-snaps.yaml
@@ -27,9 +27,9 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
-      flush: 50
-      try_flush: 50
-      evict: 50
+      cache_flush: 50
+      cache_try_flush: 50
+      cache_evict: 50
       snap_create: 50
       snap_remove: 50
       rollback: 50

--- a/qa/suites/rados/thrash/workloads/cache-snaps.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-snaps.yaml
@@ -25,9 +25,9 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
-      flush: 50
-      try_flush: 50
-      evict: 50
+      cache_flush: 50
+      cache_try_flush: 50
+      cache_evict: 50
       snap_create: 50
       snap_remove: 50
       rollback: 50

--- a/qa/suites/rados/thrash/workloads/cache.yaml
+++ b/qa/suites/rados/thrash/workloads/cache.yaml
@@ -25,6 +25,6 @@ tasks:
       write: 100
       delete: 50
       copy_from: 50
-      flush: 50
-      try_flush: 50
-      evict: 50
+      cache_flush: 50
+      cache_try_flush: 50
+      cache_evict: 50

--- a/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
+++ b/qa/suites/smoke/basic/tasks/rados_cache_snaps.yaml
@@ -26,13 +26,13 @@ tasks:
     op_weights:
       copy_from: 50
       delete: 50
-      evict: 50
-      flush: 50
+      cache_evict: 50
+      cache_flush: 50
       read: 100
       rollback: 50
       snap_create: 50
       snap_remove: 50
-      try_flush: 50
+      cache_try_flush: 50
       write: 100
     ops: 4000
     pool_snaps: true

--- a/qa/suites/upgrade/hammer-jewel-x/tiering/3-upgrade.yaml
+++ b/qa/suites/upgrade/hammer-jewel-x/tiering/3-upgrade.yaml
@@ -16,9 +16,9 @@ workload:
         write: 100
         delete: 50
         copy_from: 50
-        flush: 50
-        try_flush: 50
-        evict: 50
+        cache_flush: 50
+        cache_try_flush: 50
+        cache_evict: 50
   - print: "**** done rados"
 
 upgrade-sequence:

--- a/qa/suites/upgrade/jewel-x/parallel/2-workload/cache-pool-snaps.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/2-workload/cache-pool-snaps.yaml
@@ -30,9 +30,9 @@ workload:
           write: 100
           delete: 50
           copy_from: 50
-          flush: 50
-          try_flush: 50
-          evict: 50
+          cache_flush: 50
+          cache_try_flush: 50
+          cache_evict: 50
           snap_create: 50
           snap_remove: 50
           rollback: 50


### PR DESCRIPTION
These weren't being exercised!

See http://tracker.ceph.com/issues/11793

Signed-off-by: Sage Weil <sage@redhat.com>