### PR TITLE
compressor/zlib: remove g_ceph_context/g_conf from compressor plugin

### DIFF
--- a/src/compressor/zlib/CompressionPluginZlib.h
+++ b/src/compressor/zlib/CompressionPluginZlib.h
@@ -44,7 +44,7 @@ public:
     }
 #endif
     if (compressor == 0 || has_isal != isal) {
-      compressor = std::make_shared<ZlibCompressor>(isal);
+      compressor = std::make_shared<ZlibCompressor>(cct, isal);
       has_isal = isal;
     }
     *cs = compressor;

--- a/src/compressor/zlib/ZlibCompressor.cc
+++ b/src/compressor/zlib/ZlibCompressor.cc
@@ -22,7 +22,7 @@
 #include <zlib.h>
 
 // -----------------------------------------------------------------------------
-#define dout_context g_ceph_context
+#define dout_context cct
 #define dout_subsys ceph_subsys_compressor
 #undef dout_prefix
 #define dout_prefix _prefix(_dout)
@@ -59,7 +59,7 @@ int ZlibCompressor::zlib_compress(const bufferlist &in, bufferlist &out)
   strm.zalloc = Z_NULL;
   strm.zfree = Z_NULL;
   strm.opaque = Z_NULL;
-  ret = deflateInit2(&strm, g_conf->compressor_zlib_level, Z_DEFLATED, ZLIB_DEFAULT_WIN_SIZE, ZLIB_MEMORY_LEVEL, Z_DEFAULT_STRATEGY);
+  ret = deflateInit2(&strm, cct->_conf->compressor_zlib_level, Z_DEFLATED, ZLIB_DEFAULT_WIN_SIZE, ZLIB_MEMORY_LEVEL, Z_DEFAULT_STRATEGY);
   if (ret != Z_OK) {
     dout(1) << "Compression init error: init return "
          << ret << " instead of Z_OK" << dendl;

--- a/src/compressor/zlib/ZlibCompressor.h
+++ b/src/compressor/zlib/ZlibCompressor.h
@@ -21,8 +21,10 @@
 
 class ZlibCompressor : public Compressor {
   bool isal_enabled;
+  CephContext *const cct;
 public:
-  ZlibCompressor(bool isal) : Compressor(COMP_ALG_ZLIB, "zlib"), isal_enabled(isal) {}
+  ZlibCompressor(CephContext *cct, bool isal)
+    : Compressor(COMP_ALG_ZLIB, "zlib"), isal_enabled(isal), cct(cct) {}
 
   int compress(const bufferlist &in, bufferlist &out) override;
   int decompress(const bufferlist &in, bufferlist &out) override;


### PR DESCRIPTION
plugins should not depend on libglobal