### PR TITLE
ceph-disk: change the lockbox partition number to 5

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2596,7 +2596,7 @@ class Lockbox(object):
 
     def create_partition(self):
         self.device = Device.factory(self.args.lockbox, argparse.Namespace())
-        partition_number = 3
+        partition_number = 5
         self.device.create_partition(uuid=self.args.lockbox_uuid,
                                      name='lockbox',
                                      num=partition_number,


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20556
Signed-off-by: Shangzhong Zhu <zhu.shangzhong@zte.com.cn>