### PR TITLE
mon: maintain the "cluster" PerfCounters when using ceph-mgr

### DIFF
--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -65,6 +65,7 @@ public:
     return digest.get_last_osd_stat_seq(osd);
   }
 
+  void update_logger();
 
   void print_summary(Formatter *f, std::ostream *ss) const;
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20562

Signed-off-by: Greg Farnum <gfarnum@redhat.com>