### PR TITLE
[DNM] kv/LMDBStore: LMDB key/value store based on #4403

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "src/rapidjson"]
 	path = src/rapidjson
 	url = https://github.com/ceph/rapidjson
+[submodule "src/liblmdb"]
+	path = src/liblmdb
+	url = git@github.com:/LMDB/lmdb.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ if(WITH_REENTRANT_STRSIGNAL)
 endif(WITH_REENTRANT_STRSIGNAL)
 
 set(HAVE_LIBROCKSDB 1)
+set(HAVE_LIBLMDB 1)
 
 # -lz link into kv
 find_package(ZLIB REQUIRED)
@@ -528,6 +529,12 @@ endif()
 option(WITH_SYSTEM_ROCKSDB "require and build with system rocksdb" OFF)
 if (WITH_SYSTEM_ROCKSDB)
   find_package(rocksdb REQUIRED)
+endif()
+
+# LibLMDB
+option(WITH_SYSTEM_LMDB "require and build with system liblmdb" OFF)
+if (WITH_SYSTEM_LMDB)
+  find_package(lmdb REQUIRED)
 endif()
 
 # Boost

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -843,6 +843,34 @@ if (NOT WITH_SYSTEM_ROCKSDB)
 
 endif(NOT WITH_SYSTEM_ROCKSDB)
 
+# make lmdb statically
+
+if (NOT WITH_SYSTEM_LMDB)
+  # we use an external project and copy the sources to bin directory to ensure
+  # that object files are built outside of the source tree.
+  include(ExternalProject)
+  ExternalProject_Add(lmdb_ext
+    SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/liblmdb/libraries/liblmdb
+    BUILD_IN_SOURCE 1
+    CONFIGURE_COMMAND "true"
+    BUILD_COMMAND $(MAKE)
+    INSTALL_COMMAND "true")
+
+  # force lmdb make to be called on each time
+  ExternalProject_Add_Step(lmdb_ext forcebuild
+    DEPENDERS build
+    COMMAND "true"
+    ALWAYS 1)
+
+  set(LMDB_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/liblmdb/libraries/liblmdb)
+
+  add_library(lmdb STATIC IMPORTED)
+  add_dependencies(lmdb lmdb_ext)
+  set_property(TARGET lmdb PROPERTY IMPORTED_LOCATION "${CMAKE_CURRENT_SOURCE_DIR}/liblmdb/libraries/liblmdb/liblmdb.a")
+  set(LMDB_LIBRARIES lmdb)
+
+endif(NOT WITH_SYSTEM_LMDB)
+
 include(TestBigEndian)
 test_big_endian(CEPH_BIG_ENDIAN)
 if(NOT CEPH_BIG_ENDIAN)

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -986,6 +986,12 @@ OPTION(filestore_rocksdb_options, OPT_STR, "")
 // rocksdb options that will be used in monstore
 OPTION(mon_rocksdb_options, OPT_STR, "write_buffer_size=33554432,compression=kNoCompression")
 
+OPTION(lmdb_map_size, OPT_U64, 1000*1024*1024*1024) // size of memory map, default 1000 GB
+OPTION(lmdb_max_readers, OPT_U64, 126) // max number of threads/reader 
+OPTION(lmdb_noreadahead, OPT_BOOL, false) // turn off read ahead 
+OPTION(lmdb_nomeminit, OPT_BOOL, false) // do not initialize new-allocated memory 
+OPTION(lmdb_writemap, OPT_BOOL, false) // diable writemap
+
 /**
  * osd_*_priority adjust the relative priority of client io, recovery io,
  * snaptrim io, etc

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -211,6 +211,9 @@
 /* Defined if you have librocksdb enabled */
 #cmakedefine HAVE_LIBROCKSDB
 
+/* Defined if you have liblmdb enabled */
+#cmakedefine HAVE_LIBLMDB
+
 /* Define to 1 if you have the <valgrind/helgrind.h> header file. */
 #cmakedefine HAVE_VALGRIND_HELGRIND_H 1
 

--- a/src/kv/CMakeLists.txt
+++ b/src/kv/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(kv_srcs
   KeyValueDB.cc
+  LMDBStore.cc
   MemDB.cc
   RocksDBStore.cc)
 
@@ -9,9 +10,9 @@ endif (WITH_LEVELDB)
 
 add_library(kv_objs OBJECT ${kv_srcs})
 add_library(kv STATIC $<TARGET_OBJECTS:kv_objs>)
-target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR})
-target_link_libraries(kv ${LEVELDB_LIBRARIES} ${ROCKSDB_LIBRARIES} ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
+target_include_directories(kv_objs BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR} ${LMDB_INCLUDE_DIR})
+target_include_directories(kv BEFORE PUBLIC ${ROCKSDB_INCLUDE_DIR} ${LMDB_INCLUDE_DIR})
+target_link_libraries(kv ${LEVELDB_LIBRARIES} ${ROCKSDB_LIBRARIES} ${LMDB_LIBRARIES} ${ALLOC_LIBS} ${SNAPPY_LIBRARIES} ${ZLIB_LIBRARIES})
 
 # rocksdb detects bzlib and lz4 in its Makefile, which forces us to do the same.
 find_package(BZip2 QUIET)

--- a/src/kv/KeyValueDB.cc
+++ b/src/kv/KeyValueDB.cc
@@ -12,6 +12,9 @@
 #ifdef HAVE_KINETIC
 #include "KineticStore.h"
 #endif
+#ifdef HAVE_LIBLMDB
+#include "LMDBStore.h"
+#endif
 
 KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
 			       const string& dir,
@@ -33,7 +36,12 @@ KeyValueDB *KeyValueDB::create(CephContext *cct, const string& type,
     return new RocksDBStore(cct, dir, p);
   }
 #endif
-
+#ifdef HAVE_LIBLMDB
+  if (type == "lmdb" &&
+      cct->check_experimental_feature_enabled("lmdb")) {
+    return new LMDBStore(cct, dir);
+  }
+#endif
   if ((type == "memdb") && 
     cct->check_experimental_feature_enabled("memdb")) {
     return new MemDB(cct, dir, p);
@@ -58,7 +66,11 @@ int KeyValueDB::test_init(const string& type, const string& dir)
     return RocksDBStore::_test_init(dir);
   }
 #endif
-
+#ifdef HAVE_LIBLMDB
+  if (type == "lmdb") {
+    return LMDBStore::_test_init(dir);
+  }
+#endif
   if (type == "memdb") {
     return MemDB::_test_init(dir);
   }

--- a/src/kv/LMDBStore.cc
+++ b/src/kv/LMDBStore.cc
@@ -1,0 +1,670 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include <set>
+#include <map>
+#include <string>
+#include <memory>
+#include <errno.h>
+
+#include "lmdb.h"
+using std::string;
+#include "common/perf_counters.h"
+#include "common/debug.h"
+#include "KeyValueDB.h"
+#include "LMDBStore.h"
+
+#define dout_context g_ceph_context 
+#define dout_subsys ceph_subsys_lmdb
+#undef dout_prefix
+#define dout_prefix *_dout << "lmdb: "
+
+int LMDBStore::set_merge_operator(
+  const string& prefix,
+  std::shared_ptr<KeyValueDB::MergeOperator> mop)
+{
+  merge_ops.push_back(std::make_pair(prefix,mop));
+  return 0;
+}
+
+int LMDBStore::init(string option_str)
+{
+  options.map_size = g_conf->lmdb_map_size;
+  options.max_readers = g_conf->lmdb_max_readers;
+  options.noreadahead = g_conf->lmdb_noreadahead;
+  options.writemap = g_conf->lmdb_writemap;
+  options.nomeminit = g_conf->lmdb_nomeminit;
+  return 0;
+}
+
+int LMDBStore::create_and_open(ostream &out) {
+  int r = ::mkdir(path.c_str(), 0755);
+  if (r < 0)
+    r = -errno;
+  if (r < 0 && r != -EEXIST) {
+    derr << __func__ << " failed to create " << path << ": " << cpp_strerror(r)
+         << dendl;
+    return r;
+  }
+  return do_open(out, true);
+}
+
+int LMDBStore::do_open(ostream &out, bool create_if_missing)
+{
+  MDB_txn *txn = NULL;
+  int rc;
+  unsigned flags = 0;
+
+  if (options.map_size > 0)
+    mdb_env_set_mapsize(env.get(), options.map_size);
+  if (options.max_readers > 0)
+    mdb_env_set_maxreaders(env.get(), options.max_readers);
+  if (options.noreadahead)
+    flags |= MDB_NORDAHEAD;
+  if (options.writemap)
+    flags |= MDB_WRITEMAP;
+  if (options.nomeminit)
+    flags |= MDB_NOMEMINIT;
+  if (create_if_missing)
+    flags |= MDB_CREATE;
+  flags |= MDB_NOTLS;
+  flags |= MDB_NOMETASYNC;
+  flags |= MDB_NOSYNC;
+
+  rc = mdb_env_open(env.get(), path.c_str(), flags, 0644);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_env_close(env.get());
+    return -1;
+  }
+
+  rc = mdb_txn_begin(env.get(), NULL, 0, &txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(txn);
+    mdb_env_close(env.get());
+    return -1;
+  }
+
+  rc = mdb_dbi_open(txn, NULL, 0, &dbi);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(txn);
+    mdb_env_close(env.get());
+    return -1;
+  }
+  rc = mdb_txn_commit(txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(txn);
+    mdb_dbi_close(env.get(), dbi);
+    mdb_env_close(env.get());
+    return -1;
+  }
+  rc = mdb_env_sync(env.get(), 1);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    return -1;
+  }
+
+  PerfCountersBuilder plb(g_ceph_context, "lmdb", l_lmdb_first, l_lmdb_last);
+  plb.add_u64_counter(l_lmdb_gets, "lmdb_get");
+  plb.add_u64_counter(l_lmdb_txns, "lmdb_transaction");
+  plb.add_time_avg(l_lmdb_get_latency, "lmdb_get_latency", "Get Latency");
+  plb.add_time_avg(l_lmdb_submit_latency, "lmdb_submit_latency", "Submit Latency");
+  plb.add_time_avg(l_lmdb_submit_sync_latency, "lmdb_submit_sync_latency", "Submit Sync Latency");
+  logger = plb.create_perf_counters();
+  cct->get_perfcounters_collection()->add(logger);
+  return 0;
+}
+
+int LMDBStore::_test_init(const string& dir)
+{
+  MDB_env *_env;
+  MDB_txn *_txn;
+  MDB_dbi _dbi;
+  int rc;
+  string k = "key_test";
+  string v = "value_test";
+  MDB_val key,value;
+  key.mv_size = k.size();
+  key.mv_data = (void *)(k.data());
+  value.mv_size = v.size();
+  value.mv_data = (void *)(v.data());
+  rc = mdb_env_create(&_env);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    return -1;
+  }
+  rc = mdb_env_open(_env, dir.c_str(), MDB_FIXEDMAP, 0644);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_env_close(_env);
+    return -EIO;
+  }
+  rc = mdb_txn_begin(_env, NULL, 0, &_txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(_txn);
+    mdb_env_close(_env);
+    return -EIO;
+  }
+  rc = mdb_dbi_open(_txn, NULL, 0, &_dbi);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(_txn);
+    mdb_env_close(_env);
+    return -EIO;
+  }
+  rc = mdb_put(_txn, _dbi, &key, &value, MDB_NOOVERWRITE);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(_txn);
+    mdb_dbi_close(_env, _dbi);
+    mdb_env_close(_env);
+    return -EIO;
+  }
+  rc = mdb_del(_txn, _dbi, &key, NULL);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(_txn);
+    mdb_dbi_close(_env, _dbi);
+    mdb_env_close(_env);
+    return -EIO;
+  }
+  rc = mdb_txn_commit(_txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(_txn);
+    mdb_dbi_close(_env, _dbi);
+    mdb_env_close(_env);
+    return -EIO;
+   }
+  mdb_dbi_close(_env, _dbi);
+  mdb_env_close(_env);
+  return (rc == 0) ? 0 : -EIO;
+} 
+
+LMDBStore::LMDBStore(CephContext *c, const string &path) :
+  cct(c),
+  logger(NULL),
+  path(path),
+  dbi(0),
+  options()
+{
+  MDB_env *_env;
+  int rc = mdb_env_create(&_env);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << dendl;
+  }
+  env.reset(_env, mdb_env_close);
+}
+
+LMDBStore::~LMDBStore()
+{
+  close();
+  mdb_dbi_close(env.get(), dbi);
+  if (env.get()) {
+    env.reset();
+  }
+  delete logger;
+}
+
+void LMDBStore::close()
+{
+  if (logger)
+    cct->get_perfcounters_collection()->remove(logger);
+}
+
+int LMDBStore::submit_transaction(KeyValueDB::Transaction t)
+{ 
+  int rc;
+  utime_t start = ceph_clock_now();
+  LMDBTransactionImpl * _t =
+    static_cast<LMDBTransactionImpl *>(t.get());
+  rc = mdb_txn_commit(_t->txn);
+  utime_t lat = ceph_clock_now() - start;
+  logger->inc(l_lmdb_txns);
+  logger->tinc(l_lmdb_submit_latency, lat);
+  return (rc == 0) ? 0 : -1;
+}
+
+int LMDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
+{
+  int rc;
+  utime_t start = ceph_clock_now();
+  LMDBTransactionImpl * _t =
+    static_cast<LMDBTransactionImpl *>(t.get());
+  MDB_env *_env = mdb_txn_env(_t->txn);
+  rc = mdb_txn_commit(_t->txn);
+  rc = mdb_env_sync(_env, 1);
+  utime_t lat = ceph_clock_now() - start;
+  logger->inc(l_lmdb_txns);
+  logger->tinc(l_lmdb_submit_sync_latency, lat);
+  return (rc == 0) ? 0 : -1;
+}
+
+LMDBStore::LMDBTransactionImpl::LMDBTransactionImpl(LMDBStore *_db)
+{
+  int rc;
+  db = _db;
+  dbi = db->dbi;
+  rc = mdb_txn_begin(db->env.get(), NULL, 0, &txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(txn);
+    db = NULL;
+    dbi = 0;
+  }
+  rc = mdb_dbi_open(txn, NULL, 0, &dbi);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+    mdb_txn_abort(txn);
+  }
+}
+
+void LMDBStore::LMDBTransactionImpl::set(
+  const string &prefix,
+  const string &key,
+  const bufferlist &to_set_bl)
+{
+  buffers.push_back(to_set_bl);
+  bufferlist &bl = *(buffers.rbegin());
+  string kk = combine_strings(prefix, key);
+  keys.push_back(kk);
+  MDB_val k, v;
+  k.mv_size = keys.rbegin()->size();
+  k.mv_data = (void *)keys.rbegin()->data();
+  v.mv_size = bl.length();
+  v.mv_data = (void *)bl.c_str();
+  mdb_put(txn, dbi, &k, &v, 0);
+}
+
+void LMDBStore::LMDBTransactionImpl::rmkey(const string &prefix,
+					         const string &key)
+{
+  string kk = combine_strings(prefix, key);
+  keys.push_back(kk);
+  MDB_val k;
+  k.mv_size = keys.rbegin()->size();
+  k.mv_data = (void *)keys.rbegin()->data();
+  mdb_del(txn, dbi, &k, NULL);
+}
+
+void LMDBStore::LMDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
+{ 
+  KeyValueDB::Iterator it = db->get_iterator(prefix);
+  for (it->seek_to_first();
+       it->valid();
+        it->next()) {
+    string key = combine_strings(prefix, it->key());
+    keys.push_back(key);
+    MDB_val k;
+    k.mv_size = keys.rbegin()->size();
+    k.mv_data = (void *)keys.rbegin()->data();
+    mdb_del(txn, dbi, &k, NULL);
+  }
+}
+
+void LMDBStore::LMDBTransactionImpl::rm_range_keys(const string &prefix,
+                                                   const string &start,
+						   const string &end)
+{
+  auto it = db->get_iterator(prefix);
+  it->lower_bound(start);
+  while (it->valid()) {
+    if (it->key() >= end) {
+      break;
+    }
+    string key = combine_strings(prefix, it->key());
+    keys.push_back(key);
+    MDB_val k;
+    k.mv_size = keys.rbegin()->size();
+    k.mv_data = (void *)keys.rbegin()->data();
+    mdb_del(txn, dbi, &k, NULL);
+    it->next();
+  }
+}
+
+void LMDBStore::LMDBTransactionImpl::merge(const string& prefix,
+                                           const string& key,
+                                           const bufferlist &to_set_bl)
+{
+  std::string bound = combine_strings(prefix, key);
+  auto it  = db->get_iterator(prefix);
+  MDB_val k, v, nv;
+  k.mv_size = bound.size();
+  k.mv_data = (void *)bound.data();
+  int rc = mdb_get(txn, dbi, &k, &v);
+  string new_value;
+
+  const char* nd;
+  size_t ndl = to_set_bl.length();
+  // bufferlist::c_str() is non-constant, so we can't call c_str()
+  if (to_set_bl.is_contiguous() && ndl > 0) {
+    nd = to_set_bl.buffers().front().c_str();
+  } else if ((ndl <= 32 * 1024) && (ndl > 0)) {
+    nd = (char*) alloca(ndl);
+    std::list<buffer::ptr>::const_iterator pb;
+    for (pb = to_set_bl.buffers().begin(); pb != to_set_bl.buffers().end(); ++pb) {
+      size_t ptrlen = (*pb).length();
+      memcpy((void*)nd, (*pb).c_str(), ptrlen);
+      nd += ptrlen;
+    }
+  } else {
+    bufferlist bl = to_set_bl;
+    nd = bl.c_str();
+  }
+
+  // Check each prefix
+  for (auto& p : db->merge_ops) {
+    if (p.first.compare(0, p.first.length(),
+                        bound.c_str(), p.first.length()) == 0 &&
+        bound.c_str()[p.first.length()] == 0) {
+      if (rc == 0) {
+        string existing_value = string((const char *)v.mv_data, v.mv_size);
+        p.second->merge(existing_value.c_str(), existing_value.length(),
+                        nd, ndl,
+                        &new_value);
+      } else {
+        p.second->merge_nonexistent(nd, ndl, &new_value);
+      }
+      break;
+    }
+  }
+
+  nv.mv_size = new_value.length();
+  nv.mv_data = (void *)new_value.c_str();
+  rc = mdb_put(txn, dbi, &k, &nv, 0);
+  lgeneric_dout(g_ceph_context, 0) << __func__ << " rc: " << rc << dendl;
+}
+
+
+int LMDBStore::get(
+    const string &prefix,
+    const std::set<string> &keys,
+    std::map<string, bufferlist> *out)
+{
+  utime_t start = ceph_clock_now();
+  KeyValueDB::Iterator it = get_iterator(prefix);
+  for (std::set<string>::const_iterator i = keys.begin();
+       i != keys.end(); ++i) {
+    it->lower_bound(*i);
+    bool v = it->valid();
+//    lgeneric_dout(g_ceph_context, 0) << __func__ << " prefix: " << prefix << ", *i: " << *i << ", valid: " << v <<dendl;
+//    if (v)
+//      lgeneric_dout(g_ceph_context, 0) << __func__ << " key: " << it->key() << dendl;
+    if (v && it->key() == *i) {
+//      lgeneric_dout(g_ceph_context, 0) << __func__ << " before value()" << dendl;
+      out->insert(make_pair(*i, it->value()));
+    } else if (!v)
+      break;
+  }
+
+  
+  utime_t lat = ceph_clock_now() - start;
+  logger->inc(l_lmdb_gets);
+  logger->tinc(l_lmdb_get_latency, lat);
+  return 0;
+} 
+
+string LMDBStore::combine_strings(const string &prefix, const string &value)
+{
+  string out = prefix;
+  out.push_back(0);
+  out.append(value);
+  return out;
+}
+
+bufferlist LMDBStore::to_bufferlist(string &in)
+{
+  bufferlist bl;
+  bl.append(bufferptr(in.data(), in.size()));
+  return bl;
+}
+
+int LMDBStore::split_key(string &in, string *prefix, string *key)
+{
+  string &in_prefix = in;
+  size_t prefix_len = in_prefix.find('\0');
+  if (prefix_len >= in_prefix.size())
+    return -EINVAL;
+
+  if (prefix)
+    *prefix = string(in_prefix, 0, prefix_len);
+  if (key)
+    *key= string(in_prefix, prefix_len + 1);
+  return 0;
+}
+
+bool LMDBStore::check_omap_dir(string &omap_dir)
+{ 
+  int rc = _test_init(omap_dir); 
+  return (rc == 0) ? true : false;
+}
+LMDBStore::LMDBWholeSpaceIteratorImpl::LMDBWholeSpaceIteratorImpl(LMDBStore *store)
+{
+  int rc = 1;
+  MDB_env *env = store->env.get();
+  MDB_dbi dbi = store->dbi;
+  rc = mdb_txn_begin(env, NULL, MDB_RDONLY, &txn);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  rc = mdb_dbi_open(txn, NULL, 0, &dbi);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  rc = mdb_cursor_open(txn, dbi, &cursor);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  invalid = false;
+}
+LMDBStore::LMDBWholeSpaceIteratorImpl::~LMDBWholeSpaceIteratorImpl()
+{
+  if (cursor) {
+    mdb_cursor_close(cursor);
+    cursor = NULL;
+  }
+  if (txn) { 
+    mdb_txn_commit(txn);
+    txn = NULL;
+  }
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::seek_to_first()
+{
+  invalid = false;
+  int rc = mdb_cursor_get(cursor, NULL, NULL, MDB_FIRST);
+  return (rc == 0) ? 0 : -1;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::seek_to_first(const string &prefix)
+{
+  int rc;
+  MDB_val key;
+  invalid = false;
+  if (prefix.size() == 0) {
+    rc = mdb_cursor_get(cursor, &key, NULL, MDB_FIRST);
+  } else {
+    key.mv_size = prefix.size();
+    key.mv_data = (void *)prefix.data();
+    rc = mdb_cursor_get(cursor, &key, NULL, MDB_SET_RANGE);
+  }
+  return (rc == 0) ? 0 : -1;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::seek_to_last()
+{
+  invalid = false;
+  int rc = mdb_cursor_get(cursor, NULL, NULL, MDB_LAST);
+  return (rc == 0) ? 0 : -1;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::seek_to_last(const string &prefix)
+{
+  int rc;
+  invalid = false;
+  MDB_val key;
+  string limit = past_prefix(prefix);
+  if (prefix.size() == 0) {
+    invalid = true;
+    rc = 0;
+  } else {
+    key.mv_size = limit.size();
+    key.mv_data = (void *)limit.data();
+    rc = mdb_cursor_get(cursor, &key, NULL, MDB_SET_RANGE);
+    if (rc != 0) {
+      rc = mdb_cursor_get(cursor, NULL, NULL, MDB_LAST);
+    } else {
+      rc = mdb_cursor_get(cursor, NULL, NULL, MDB_PREV);
+      if (rc != 0) {
+        invalid = true;
+        rc = 0;
+      }
+    }
+  }
+  return (rc == 0) ? 0 : 1;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::upper_bound(const string &prefix, const string &after)
+{
+  int rc;
+  invalid = false;
+  rc = lower_bound(prefix, after);
+  if (valid()) {
+    pair<string,string> key = raw_key();
+    if (key.first == prefix && key.second == after)
+      rc = next();
+  }
+  return (rc == 0) ? 0 : 1;
+}
+
+int LMDBStore::LMDBWholeSpaceIteratorImpl::lower_bound(const string &prefix, const string &to)
+{
+  int rc;
+  invalid = false;
+  MDB_val key;
+  string bound = combine_strings(prefix, to);
+  key.mv_size = bound.size();
+  key.mv_data = (void *)bound.data();
+  rc = mdb_cursor_get(cursor, &key, NULL, MDB_SET_RANGE);
+
+  string kstring = string((const char *)key.mv_data, key.mv_size);
+  lgeneric_dout(g_ceph_context, 0) << __func__ << " prefix: " << prefix << " key: " << to << " rc: " << rc << dendl;
+  lgeneric_dout(g_ceph_context, 0) << __func__ << " key before: " << kstring << dendl;
+
+  if (rc != 0) {
+    lgeneric_dout(g_ceph_context, 0) << __func__ << " Setting Invalid" << dendl;
+    invalid = true;
+    rc = mdb_cursor_get(cursor, NULL, NULL, MDB_LAST);
+  }
+  lgeneric_dout(g_ceph_context, 0) << __func__ << " key after: " << kstring << dendl;
+  return (rc == 0) ? 0 : 1;
+}
+bool LMDBStore::LMDBWholeSpaceIteratorImpl::valid()
+{
+  if (invalid) {
+//    lgeneric_dout(g_ceph_context, 0) << __func__ << " invalid set true" << dendl;
+    return false;
+  }
+  MDB_val k, v;
+  int rc = mdb_cursor_get(cursor, &k, &v, MDB_GET_CURRENT);
+  if (rc == 0) {
+    string key = string((const char *)k.mv_data, k.mv_size);    
+    string value = string((const char *)v.mv_data, v.mv_size);
+//    lgeneric_dout(g_ceph_context, 0) << __func__ << " key: " << key << ", value: " << value << ", rc: " << rc << dendl;
+  }
+  return (rc == 0) ? true : false;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::next()
+{
+  int rc = 1;
+  if (valid())
+    rc = mdb_cursor_get(cursor, NULL, NULL, MDB_NEXT);
+  if (rc != 0) {
+    invalid = true;
+  }
+  return 0;
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::prev()
+{
+  int rc = 1;
+  if (valid())
+    rc = mdb_cursor_get(cursor, NULL, NULL, MDB_PREV);
+  if (rc != 0) {
+    invalid = true;
+  }
+  return 0;
+}
+string LMDBStore::LMDBWholeSpaceIteratorImpl::key()
+{
+  string key, out_key;
+  MDB_val k, v;
+  int rc = mdb_cursor_get(cursor, &k, &v, MDB_GET_CURRENT);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  key = string((const char *)k.mv_data, k.mv_size);
+  split_key(key, 0, &out_key);
+  return out_key;
+}
+pair<string,string> LMDBStore::LMDBWholeSpaceIteratorImpl::raw_key()
+{
+  string prefix, key, out;
+  MDB_val k, v;
+  int rc = mdb_cursor_get(cursor, &k, &v, MDB_GET_CURRENT);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  out = string((const char *)k.mv_data, k.mv_size);
+  split_key(out, &prefix, &key);
+  return make_pair(prefix, key);
+}
+bool LMDBStore::LMDBWholeSpaceIteratorImpl::raw_key_is_prefixed(const string &prefix) {
+  string key, out;
+  MDB_val k, v;
+  int rc = mdb_cursor_get(cursor, &k, &v, MDB_GET_CURRENT);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  out = string((const char *)k.mv_data, k.mv_size);
+  if ((out.length() > prefix.length() && key[prefix.length()] == '\0')) {
+    return memcmp(out.c_str(), prefix.c_str(), prefix.length()) == 0;
+  } else {
+    return false;
+  }
+}
+bufferlist LMDBStore::LMDBWholeSpaceIteratorImpl::value()
+{
+  MDB_val k, v;
+  string value;
+  int rc = mdb_cursor_get(cursor, &k, &v, MDB_GET_CURRENT);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  value = string((const char *)v.mv_data, v.mv_size);
+//  lgeneric_dout(g_ceph_context, 0) << __func__ << " value: " << value << dendl;
+
+  return to_bufferlist(value);
+}
+int LMDBStore::LMDBWholeSpaceIteratorImpl::status()
+{
+  int rc = mdb_cursor_get(cursor, NULL, NULL, MDB_GET_CURRENT);
+  if (rc != 0) {
+    derr << __FILE__ << ":" << __LINE__ << " " << mdb_strerror(rc) << dendl;
+  }
+  return (rc == 0) ? 0 : -1;
+}
+
+string LMDBStore::past_prefix(const string &prefix)
+{
+  string limit = prefix;
+  limit.push_back(1);
+  return limit;
+}
+
+
+LMDBStore::WholeSpaceIterator LMDBStore::_get_iterator()
+{
+  return std::shared_ptr<KeyValueDB::WholeSpaceIteratorImpl>(
+    new LMDBWholeSpaceIteratorImpl(this)
+  );
+}
+

--- a/src/kv/LMDBStore.h
+++ b/src/kv/LMDBStore.h
@@ -120,9 +120,8 @@ public:
       const bufferlist &bl) override;
   };
 
-  KeyValueDB::Transaction get_transaction() {
-    return std::shared_ptr< LMDBTransactionImpl >(
-      new LMDBTransactionImpl(this));
+  KeyValueDB::Transaction get_transaction() override {
+    return std::make_shared<LMDBTransactionImpl>(this);
   }
 
   int submit_transaction(KeyValueDB::Transaction t);

--- a/src/kv/LMDBStore.h
+++ b/src/kv/LMDBStore.h
@@ -1,0 +1,242 @@
+#ifndef LM_DB_STORE_H
+#define LM_DB_STORE_H
+
+#include "include/types.h"
+#include "include/buffer.h"
+#include "KeyValueDB.h"
+#include <set>
+#include <map>
+#include <string>
+#include <tr1/memory>
+#include <boost/scoped_ptr.hpp>
+
+#include <errno.h>
+#include "common/errno.h"
+#include "common/dout.h"
+#include "include/assert.h"
+#include "common/Formatter.h"
+
+#include "common/ceph_context.h"
+
+#include "lmdb.h"
+
+class PerfCounters;
+
+enum {
+  l_lmdb_first = 34300,
+  l_lmdb_gets,
+  l_lmdb_txns,
+  l_lmdb_get_latency,
+  l_lmdb_submit_latency,
+  l_lmdb_submit_sync_latency,
+  l_lmdb_last,
+};
+
+/**
+ * Uses LMDB to implement the KeyValueDB interface
+ */
+class LMDBStore : public KeyValueDB {
+  CephContext *cct;
+  PerfCounters *logger;
+  string path;
+  boost::shared_ptr<MDB_env> env;
+  MDB_dbi dbi;
+  int do_open(ostream &out, bool create_if_missing);
+
+
+public:
+
+  static int _test_init(const string& dir);
+  int init(string option_str="");
+  /**
+   * options_t: Holds options which are minimally interpreted
+   * on initialization and then passed through to LMDB.
+   * We transform a couple of these into actual LMDB
+   * structures, but the rest are simply passed through unchanged. See
+   * lmdb.h for more precise details on each.
+   *
+   * Set them after constructing the LMDBStore, but before calling
+   * open() or create_and_open().
+   */
+  struct options_t {
+    uint64_t map_size; /// size of memory map
+    uint64_t max_readers; /// max number of threads/reader
+    bool nomeminit;  // do not initialize memory
+    bool noreadahead; // turn off read ahead
+    bool writemap;   // use write map
+
+
+    options_t() :
+      map_size(0),
+      max_readers(0), 
+      nomeminit(false),
+      noreadahead(false),
+      writemap(false)
+    {}
+  } options;
+
+  LMDBStore(CephContext *c, const string &path);
+
+  ~LMDBStore();
+
+  static bool check_omap_dir(string &omap_dir);
+  /// Opens underlying db
+  int open(ostream &out) {
+    return do_open(out, false);
+  }
+  /// Creates underlying db if missing and opens it
+  int create_and_open(ostream &out) override;
+
+  void close();
+
+  class LMDBTransactionImpl : public KeyValueDB::TransactionImpl {
+  public:
+    MDB_txn *txn;
+    list<bufferlist> buffers;
+    list<string> keys;
+    LMDBStore *db;
+    MDB_dbi dbi;
+
+    LMDBTransactionImpl(LMDBStore *_db);
+    ~LMDBTransactionImpl(){}
+    void set(
+      const string &prefix,
+      const string &key,
+      const bufferlist &bl);
+    void rmkey(
+      const string &prefix,
+      const string &key);
+    void rmkeys_by_prefix(
+      const string &prefix
+      );
+    void rm_range_keys(
+      const string &prefix,
+      const string &start,
+      const string &end
+      );
+    void merge(
+      const string& prefix,
+      const string& key,
+      const bufferlist &bl) override;
+  };
+
+  KeyValueDB::Transaction get_transaction() {
+    return std::shared_ptr< LMDBTransactionImpl >(
+      new LMDBTransactionImpl(this));
+  }
+
+  int submit_transaction(KeyValueDB::Transaction t);
+  int submit_transaction_sync(KeyValueDB::Transaction t);
+  int get(
+    const string &prefix,
+    const std::set<string> &key,
+    std::map<string, bufferlist> *out
+    );
+
+  class LMDBWholeSpaceIteratorImpl :
+    public KeyValueDB::WholeSpaceIteratorImpl {
+  protected:
+    MDB_cursor *cursor;
+    MDB_txn *txn;
+    bool invalid;
+  public:
+    LMDBWholeSpaceIteratorImpl(LMDBStore *store);
+   
+    ~LMDBWholeSpaceIteratorImpl();
+
+    int seek_to_first();
+    int seek_to_first(const string &prefix);
+    int seek_to_last();
+    int seek_to_last(const string &prefix);
+    int upper_bound(const string &prefix, const string &after);
+    int lower_bound(const string &prefix, const string &to);
+    bool valid();
+    int next();
+    int prev();
+    string key();
+    pair<string,string> raw_key();
+    bool raw_key_is_prefixed(const string &prefix) override;
+    bufferlist value();
+    int status();
+  };
+
+  /// Utility
+  static string combine_strings(const string &prefix, const string &value);
+  static int split_key(string &in, string *prefix, string *key);
+  static bufferlist to_bufferlist(string &in);
+  static string past_prefix(const string &prefix);
+  int set_merge_operator(const std::string& prefix,
+		                 std::shared_ptr<KeyValueDB::MergeOperator> mop) override;
+  virtual uint64_t get_estimated_size(map<string,uint64_t> &extra) {
+    DIR *store_dir = opendir(path.c_str());
+    if (!store_dir) {
+      lderr(cct) << __func__ << " something happened opening the store: "
+                 << cpp_strerror(errno) << dendl;
+      return 0;
+    }
+
+    uint64_t total_size = 0;
+    uint64_t data_size = 0;
+    uint64_t misc_size = 0;
+
+    struct dirent *entry = NULL;
+    while ((entry = readdir(store_dir)) != NULL) {
+      string n(entry->d_name);
+
+      if (n == "." || n == "..")
+        continue;
+
+      string fpath = path + '/' + n;
+      struct stat s;
+      int err = stat(fpath.c_str(), &s);
+      if (err < 0)
+	err = -errno;
+      // we may race against lmdb while reading files; this should only
+      // happen when those files are being updated, data is being shuffled
+      // and files get removed, in which case there's not much of a problem
+      // as we'll get to them next time around.
+      if (err == -ENOENT) {
+	continue;
+      }
+      if (err < 0) {
+        lderr(cct) << __func__ << " error obtaining stats for " << fpath
+                   << ": " << cpp_strerror(err) << dendl;
+        goto err;
+      }
+
+      size_t pos = n.find_last_of('.');
+      if (pos == string::npos) {
+        misc_size += s.st_size;
+        continue;
+      }
+
+      string ext = n.substr(0, pos);
+      if (ext == "data") {
+        data_size += s.st_size;
+      } else {
+        misc_size += s.st_size;
+      }
+    }
+
+    total_size = data_size + misc_size;
+
+    extra["data"] = data_size;
+    extra["misc"] = misc_size;
+    extra["total"] = total_size;
+
+err:
+    closedir(store_dir);
+    return total_size;
+  }
+
+
+protected:
+  WholeSpaceIterator _get_iterator();
+
+  WholeSpaceIterator _get_snapshot_iterator() {
+    return _get_iterator();
+  }
+
+};
+
+#endif

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -33,6 +33,10 @@ if(NOT WITH_SYSTEM_ROCKSDB)
   list(APPEND merge_libs ${ROCKSDB_LIBRARIES})
 endif(NOT WITH_SYSTEM_ROCKSDB)
 
+if (NOT WITH_SYSTEM_LMDB)
+  list(APPEND merge_libs ${LMDB_LIBRARIES})
+endif(NOT WITH_SYSTEM_LMDB)
+
 if(HAVE_ARMV8_CRC)
   list(APPEND merge_libs common_crc_aarch64)
 endif(HAVE_ARMV8_CRC)


### PR DESCRIPTION
This is an LMDB key/value store based on Xinxin Shu's original version #4403.  This adds cmake support, adds the required functionality for the current KeyValueDB interface, reduces the length of time transactions are kept open, and fixes various other bugs.

Currently BlueStore's BitmapFreelistManager keeps an iterator open indefinitely which results in an lmdb read cursor/txn being kept open.  This results in new data always being appended to the database instead of recycling free pages (ie writes will cause the database to grow without bound).  This is being worked on in another PR here:

https://github.com/ceph/ceph/pull/16243

This code is not very well optimized yet with some unnecessary char * to string conversions and other issues still present.  Current performance tests on a single LSI Nytro Warp PCIe SSD show lower performance vs rocksdb for bluestore (these tests were CPU limited in some cases).  The biggest difference was in 4KB Random writes.

4KB Random Read

RocksDBStore: 38.7K IOPS
LMDBStore: 34.9K IOPS

4KB Random Write (min_alloc = 4k):
RocksDBStore: 17.6K IOPS
LMDBStore: 3.5K IOPS

Probably a WAL would help dramatically here since (even with 4k min_alloc) we appear to write short-lived data to the database.

A quick (pruned) wall-clock profile of 4KB random writes shows we are spending almost all of our time waiting on the kv_sync_thread.  The biggest time consumers are syncing the data to disk followed by txn commits, and the actual put and get calls:
```
100.00% BlueStore::_kv_sync_thread
+ 69.20% LMDBStore::submit_transaction_sync
| + 69.15% mdb_env_sync
| | + 69.15% mdb_env_sync0
| |   + 69.15% fdatasync
+ 29.65% LMDBStore::submit_transaction
| + 15.25% mdb_txn_commit
| | + 14.05% mdb_page_flush
| | | + 14.05% pwrite64
| + 14.20% LMDBStore::LMDBTransactionImpl::do_tasks
| | + 10.25% LMDBStore::LMDBPutTask::submit
| | | + 10.25% mdb_put
| | |   + 10.20% mdb_cursor_put
| | |   | + 10.20% mdb_cursor_put
| | |   |   + 8.60% mdb_cursor_set
| | |   |   | + 8.10% mdb_page_search
| | |   |   | | + 8.00% mdb_page_search_root
| | |   |   | |   + 0.90% mdb_node_search
| | |   |   + 1.05% mdb_cursor_touch
| | |   |   | + 1.05% mdb_page_touch
| | |   |   |   + 0.85% __memcpy_ssse3
| | + 2.95% LMDBStore::LMDBMergeTask::submit
| | | + 1.50% mdb_get
| | | | + 1.50% mdb_cursor_set
| | | |   + 1.35% mdb_page_search
| | | |   | + 1.35% mdb_page_search_root
| | | + 1.20% mdb_put
```

One good point is that after 10-15 minutes of 4K random writes to a 16GB RBD volume, only 164MB was used for the DB.  It's possible that space-amp might be much lower than with our current rocksdb configuration.