### PR TITLE
tools: ceph-release-notes: warn about python3 incompability

### DIFF
--- a/src/script/ceph-release-notes
+++ b/src/script/ceph-release-notes
@@ -3,8 +3,10 @@
 # https://gist.github.com/aisrael/b2b78d9dfdd176a232b9
 """To run this script first install the dependencies
 
+  IMPORTANT NOTE: This script requires python 2. It does not work with python 3.
+  Make sure the value passed with --python is the python 2 binary on your system.
 
-  virtualenv v
+  virtualenv --python=/usr/bin/python2 v
   source v/bin/activate
   pip install githubpy GitPython requests
 


### PR DESCRIPTION
The script is not compatible with python3:

```
(v) smithfarm@wilbur:~/src/ceph/smithfarm/ceph/src/script> python -m py_compile ceph-release-notes
  File "ceph-release-notes", line 220
    pr2info.iteritems(), key=lambda (k, v): (v[2], v[1])
                                    ^
SyntaxError: invalid syntax
```
