### PR TITLE
test/fio: remove experimental option for bluestore & rocksdb.

### DIFF
--- a/src/test/fio/ceph-bluestore.conf
+++ b/src/test/fio/ceph-bluestore.conf
@@ -13,8 +13,6 @@
 [osd]
 	osd objectstore = bluestore
 
-	enable experimental unrecoverable data corrupting features = bluestore rocksdb
-
 	# use directory= option from fio job file
 	osd data = ${fio_dir}
 


### PR DESCRIPTION
Remove experimental option for bluestore & rocksdb, which aren't experimental any more.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>