### PR TITLE
os/bluestore: only submit deferred if there is any

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8599,7 +8599,7 @@ void BlueStore::deferred_try_submit()
     osrs.push_back(&osr);
   }
   for (auto& osr : osrs) {
-    if (!osr->deferred_running) {
+    if (osr->deferred_pending && !osr->deferred_running) {
       _deferred_submit_unlock(osr.get());
       deferred_lock.lock();
     }


### PR DESCRIPTION
We drop the lock, so it's possible another thread submits the pending.
(_deferred_submit_unlock assumes osr->deferred_pending != nullptr.)

Signed-off-by: Sage Weil <sage@redhat.com>