### PR TITLE
mon: configurable conditions for fast handling MSG_ALIVE/MSG_PGTEMP

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -399,6 +399,9 @@ OPTION(paxos_stash_full_interval, OPT_INT, 25)   // how often (in commits) to st
 OPTION(paxos_max_join_drift, OPT_INT, 10) // max paxos iterations before we must first sync the monitor stores
 OPTION(paxos_propose_interval, OPT_DOUBLE, 1.0)  // gather updates for this long before proposing a map update
 OPTION(paxos_min_wait, OPT_DOUBLE, 0.05)  // min time to gather updates for after period of inactivity
+OPTION(paxos_upthru_merge_bound, OPT_INT, 1) // number of upthru request to merge before propose new osdmap 
+OPTION(paxos_ptemp_merge_bound, OPT_INT, 1)  // number of primary temp request to merge before propose new osdmap
+OPTION(paxos_nstate_bound, OPT_INT, 2) // number of new osd state allowed for fast osdmap updates proposal 
 OPTION(paxos_min, OPT_INT, 500)       // minimum number of paxos states to keep around
 OPTION(paxos_trim_min, OPT_INT, 250)  // number of extra proposals tolerated before trimming
 OPTION(paxos_trim_max, OPT_INT, 500) // max number of extra proposals to trim at a time

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1428,14 +1428,16 @@ bool OSDMonitor::should_propose(double& delay)
 
   // propose as fast as possible if updating up_thru or pg_temp
   // want to merge OSDMap changes as much as possible
-  if ((pending_inc.new_primary_temp.size() == 1
-      || pending_inc.new_up_thru.size() == 1)
-      && pending_inc.new_state.size() < 2) {
+  if ((pending_inc.new_primary_temp.size() >= 
+      (unsigned)g_conf->paxos_ptemp_merge_bound
+      || pending_inc.new_up_thru.size() >= 
+      (unsigned)g_conf->paxos_upthru_merge_bound)
+      && pending_inc.new_state.size() < (unsigned)g_conf->paxos_nstate_bound) {
     dout(15) << " propose as fast as possible for up_thru/pg_temp" << dendl;
 
     utime_t now = ceph_clock_now();
     if (now - last_attempted_minwait_time > g_conf->paxos_propose_interval
-	&& now - paxos->get_last_commit_time() > g_conf->paxos_min_wait) {
+      || now - paxos->get_last_commit_time() > g_conf->paxos_min_wait) {
       delay = g_conf->paxos_min_wait;
       last_attempted_minwait_time = now;
       return true;


### PR DESCRIPTION
configurable conditions to enable no delay for MSG_ALIVE and MSG_PGTEMP.
if already batched enough MSG_ALIVE and MSG_PGTEMP messages, process
them at once, otherwise wait a long period as before

Signed-off-by: sheng qiu <sheng.qiu@alibaba-inc.com>