### PR TITLE
MDSMonitor: show laggy MDSs at higher debug level

### DIFF
--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -129,7 +129,7 @@ class MDSMonitor : public PaxosService {
 
   bool maybe_promote_standby(std::shared_ptr<Filesystem> fs);
   bool maybe_expand_cluster(std::shared_ptr<Filesystem> fs);
-  void maybe_replace_gid(mds_gid_t gid, const beacon_info_t &beacon,
+  void maybe_replace_gid(mds_gid_t gid, const MDSMap::mds_info_t& info,
       bool *mds_propose, bool *osd_propose);
   void tick() override;     // check state, take actions
 


### PR DESCRIPTION
Also, print laggy daemons even if the OSDMap is not yet writeable.

This is mostly for operators wanting to see a more visible message that an MDS
has been replaced.

Related-to: http://tracker.ceph.com/issues/19706

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>