### PR TITLE
Client: mkdirs does not handle correct when two clients send mkdir request for a same dir

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -6466,8 +6466,13 @@ int Client::mkdirs(const char *relpath, mode_t mode, const UserPerm& perms)
     }
     //make new dir
     r = _mkdir(cur.get(), path[i].c_str(), mode, perms, &next);
+    
     //check proper creation/existence
-    if (r < 0) return r;
+    if(-EEXIST == r && i < path.depth() - 1) {
+      r = _lookup(cur.get(), path[i].c_str(), CEPH_CAP_AUTH_SHARED, &next, perms);
+    }	
+    if (r < 0) 
+      return r;
     //move to new dir and continue
     cur.swap(next);
     ldout(cct, 20) << "mkdirs: successfully created directory "


### PR DESCRIPTION
…mkdir request for a same dir

Fixes: http://tracker.ceph.com/issues/20592

Signed-off-by: dongdong tao <tdd21151186@gmail.com>