### PR TITLE
jewel: rgw: cls: ceph::timespan tag_timeout wrong units

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1904,7 +1904,9 @@ int rgw_dir_suggest_changes(cls_method_context_t hctx, bufferlist *in, bufferlis
     return rc;
   }
 
-  timespan tag_timeout(header.tag_timeout ? header.tag_timeout : CEPH_RGW_TAG_TIMEOUT);
+  timespan tag_timeout(
+    std::chrono::seconds(
+      header.tag_timeout ? header.tag_timeout : CEPH_RGW_TAG_TIMEOUT));
 
   bufferlist::iterator in_iter = in->begin();
 


### PR DESCRIPTION
backport for http://tracker.ceph.com/issues/20513