### PR TITLE
jewel: core: test_envlibrados_for_rocksdb.yaml fails on crypto restart

### DIFF
--- a/src/common/ceph_crypto.cc
+++ b/src/common/ceph_crypto.cc
@@ -66,7 +66,7 @@ void ceph::crypto::init(CephContext *cct)
     memset(&init_params, 0, sizeof(init_params));
     init_params.length = sizeof(init_params);
 
-    uint32_t flags = NSS_INIT_READONLY;
+    uint32_t flags = (NSS_INIT_READONLY | NSS_INIT_PK11RELOAD);
     if (cct->_conf->nss_db_path.empty()) {
       flags |= (NSS_INIT_NOCERTDB | NSS_INIT_NOMODDB);
     }

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -2057,7 +2057,9 @@ private:
     }
   }
   void ms_fast_dispatch(Message *m) {
-    ms_dispatch(m);
+    if (!ms_dispatch(m)) {
+      m->put();
+    }
   }
 
   void handle_osd_op_reply(class MOSDOpReply *m);


### PR DESCRIPTION
http://tracker.ceph.com/issues/20460