### PR TITLE
qa/workunits/ceph-helpers: test wait_for_health_ok differently

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -1325,8 +1325,10 @@ function test_wait_for_health_ok() {
     setup $dir || return 1
     run_mon $dir a --osd_pool_default_size=1 --osd_failsafe_full_ratio=.99 --mon_pg_warn_min_per_osd=0 || return 1
     run_mgr $dir x --mon_pg_warn_min_per_osd=0 || return 1
-    ! TIMEOUT=1 wait_for_health_ok || return 1
     run_osd $dir 0 || return 1
+    kill_daemons $dir TERM osd || return 1
+    ! TIMEOUT=1 wait_for_health_ok || return 1
+    activate_osd $dir 0 || return 1
     wait_for_health_ok || return 1
     teardown $dir || return 1
 }


### PR DESCRIPTION
0 OSDs is not an error anymore in the new health checking implemented by
OSDMap::check_health(). this case was treated as an error before, see
OSDMonitor::get_health(). but an osdmap without any OSD is fine, i
think. but an osdmap with 3 OSDs, but all of them are down and out, this
is an error. and we do report this as an error. so, let's update the
test instead.

Signed-off-by: Kefu Chai <kchai@redhat.com>