### PR TITLE
qa/workunits/ceph-helpers: enable experimental features for osd

### DIFF
--- a/qa/workunits/ceph-helpers.sh
+++ b/qa/workunits/ceph-helpers.sh
@@ -676,6 +676,7 @@ function activate_osd() {
     ceph_args+=" --pid-file=$dir/\$name.pid"
     ceph_args+=" --osd-max-object-name-len 460"
     ceph_args+=" --osd-max-object-namespace-len 64"
+    ceph_args+=" --enable-experimental-unrecoverable-data-corrupting-features *"
     ceph_args+=" "
     ceph_args+="$@"
     mkdir -p $osd_data


### PR DESCRIPTION
it matches the settings in vstart.sh, also it would be handy for those
who are still developing on btrfs, which is now marked as an experimental
features now.

Signed-off-by: Kefu Chai <kchai@redhat.com>