### PR TITLE
rgw:  support store head and tail objects separately

### DIFF
--- a/src/cls/user/cls_user_types.h
+++ b/src/cls/user/cls_user_types.h
@@ -19,8 +19,9 @@ struct cls_user_bucket {
   std::string placement_id;
   struct {
     std::string data_pool;
+    std::string data_tail_pool;//No need to decode/encode
     std::string index_pool;
-    std::string data_extra_pool;
+    std::string data_extra_pool;  
   } explicit_placement;
 
   void encode(bufferlist& bl) const {

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -254,6 +254,7 @@ void _usage()
   cout << "   --endpoints=<list>        zone endpoints\n";
   cout << "   --index-pool=<pool>       placement target index pool\n";
   cout << "   --data-pool=<pool>        placement target data pool\n";
+  cout << "   --data-tail-pool=<pool>   placement target data tail pool\n";
   cout << "   --data-extra-pool=<pool>  placement target data extra (non-ec) pool\n";
   cout << "   --placement-index-type=<type>\n";
   cout << "                             placement target index type (normal, indexless, or #id)\n";
@@ -2406,6 +2407,7 @@ int main(int argc, const char **argv)
 
   boost::optional<string> index_pool;
   boost::optional<string> data_pool;
+  boost::optional<string> data_tail_pool;
   boost::optional<string> data_extra_pool;
   RGWBucketIndexType placement_index_type = RGWBIType_Normal;
   bool index_type_specified = false;
@@ -2707,6 +2709,8 @@ int main(int argc, const char **argv)
       index_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-pool", (char*)NULL)) {
       data_pool = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--data-tail-pool", (char*)NULL)) {
+      data_tail_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-extra-pool", (char*)NULL)) {
       data_extra_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-index-type", (char*)NULL)) {
@@ -4209,6 +4213,9 @@ int main(int argc, const char **argv)
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;
           }
+          if (data_tail_pool) { 
+            info.data_tail_pool = *data_tail_pool;
+          }
           if (index_type_specified) {
             info.index_type = placement_index_type;
           }
@@ -4228,6 +4235,9 @@ int main(int argc, const char **argv)
           }
           if (data_pool && !data_pool->empty()) {
             info.data_pool = *data_pool;
+          }
+          if (data_tail_pool) { 
+            info.data_tail_pool = *data_tail_pool;
           }
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1938,7 +1938,6 @@ struct rgw_obj {
   rgw_obj_key key;
 
   bool in_extra_data{false}; /* in-memory only member, does not serialize */
-  bool head_obj{true}; /* in-memory only member, does not serialize */
 
   // Represents the hash index source for this object once it is set (non-empty)
   std::string index_hash_source;
@@ -1985,14 +1984,6 @@ struct rgw_obj {
 
   bool is_in_extra_data() const {
     return in_extra_data;
-  }
-
-  void set_head_obj(bool val) {
-    head_obj = val;
-  }
-
-  bool is_head_obj() const {
-    return head_obj;
   }
 
   void encode(bufferlist& bl) const {
@@ -2063,16 +2054,11 @@ struct rgw_obj {
   }
 
   const rgw_pool& get_explicit_data_pool() {
-    if (!in_extra_data) {
-      if (head_obj)
-        return bucket.explicit_placement.data_pool;
-      else
-        return bucket.explicit_placement.data_tail_pool.empty() ?
-          bucket.explicit_placement.data_pool : bucket.explicit_placement.data_tail_pool;
-    } else {
-        return bucket.explicit_placement.data_extra_pool.empty() ?
-          bucket.explicit_placement.data_pool : bucket.explicit_placement.data_extra_pool;
-    }
+    if (!in_extra_data || bucket.explicit_placement.data_extra_pool.empty()) {
+      return bucket.explicit_placement.data_pool;
+    }  
+
+    return bucket.explicit_placement.data_extra_pool;
   }
 };
 WRITE_CLASS_ENCODER(rgw_obj)

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1938,6 +1938,7 @@ struct rgw_obj {
   rgw_obj_key key;
 
   bool in_extra_data{false}; /* in-memory only member, does not serialize */
+  bool head_obj{true}; /* in-memory only member, does not serialize */
 
   // Represents the hash index source for this object once it is set (non-empty)
   std::string index_hash_source;
@@ -1984,6 +1985,14 @@ struct rgw_obj {
 
   bool is_in_extra_data() const {
     return in_extra_data;
+  }
+
+  void set_head_obj(bool val) {
+    head_obj = val;
+  }
+
+  bool is_head_obj() const {
+    return head_obj;
   }
 
   void encode(bufferlist& bl) const {
@@ -2054,10 +2063,16 @@ struct rgw_obj {
   }
 
   const rgw_pool& get_explicit_data_pool() {
-    if (!in_extra_data || bucket.explicit_placement.data_extra_pool.empty()) {
-      return bucket.explicit_placement.data_pool;
+    if (!in_extra_data) {
+      if (head_obj)
+        return bucket.explicit_placement.data_pool;
+      else
+        return bucket.explicit_placement.data_tail_pool.empty() ?
+          bucket.explicit_placement.data_pool : bucket.explicit_placement.data_tail_pool;
+    } else {
+        return bucket.explicit_placement.data_extra_pool.empty() ?
+          bucket.explicit_placement.data_pool : bucket.explicit_placement.data_extra_pool;
     }
-    return bucket.explicit_placement.data_extra_pool;
   }
 };
 WRITE_CLASS_ENCODER(rgw_obj)

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -205,9 +205,9 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   // Always overwrite instance with tail_instance
   // to get the right shadow object location
   loc.key.set_instance(tail_instance);
-  loc.set_head_obj(false);
   location->set_placement_rule(tail_placement.placement_rule);
   *location = loc;
+  location->set_head_obj(false);
 }
 
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -205,7 +205,7 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   // Always overwrite instance with tail_instance
   // to get the right shadow object location
   loc.key.set_instance(tail_instance);
-
+  loc.set_head_obj(false);
   location->set_placement_rule(tail_placement.placement_rule);
   *location = loc;
 }

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -12,13 +12,14 @@
 
 static string shadow_ns = RGW_OBJ_NS_SHADOW;
 
-static void init_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *ip, const char *m, const char *id)
+static void init_bucket(rgw_bucket *b, const char *t, const char *n, const char *dp, const char *dtp, const char *ip, const char *m, const char *id)
 {
   b->tenant = t;
   b->name = n;
   b->marker = m;
   b->bucket_id = id;
   b->explicit_placement.data_pool = rgw_pool(dp);
+  b->explicit_placement.data_tail_pool = rgw_pool(dtp);
   b->explicit_placement.index_pool = rgw_pool(ip);
 }
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -29,7 +29,7 @@ void RGWObjManifestPart::generate_test_instances(std::list<RGWObjManifestPart*>&
 
   RGWObjManifestPart *p = new RGWObjManifestPart;
   rgw_bucket b;
-  init_bucket(&b, "tenant", "bucket", ".pool", ".index_pool", "marker_", "12");
+  init_bucket(&b, "tenant", "bucket", ".pool", ".tail_pool", ".index_pool", "marker_", "12");
 
   p->loc = rgw_obj(b, "object");
   p->loc_ofs = 512 * 1024;
@@ -146,7 +146,7 @@ void RGWObjManifest::generate_test_instances(std::list<RGWObjManifest*>& o)
   for (int i = 0; i<10; i++) {
     RGWObjManifestPart p;
     rgw_bucket b;
-    init_bucket(&b, "tenant", "bucket", ".pool", ".index_pool", "marker_", "12");
+    init_bucket(&b, "tenant", "bucket", ".pool", ".tail_pool", ".index_pool", "marker_", "12");
     p.loc = rgw_obj(b, "object");
     p.loc_ofs = 0;
     p.size = 512 * 1024;
@@ -425,7 +425,7 @@ void RGWUserInfo::generate_test_instances(list<RGWUserInfo*>& o)
 void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 {
   rgw_bucket *b = new rgw_bucket;
-  init_bucket(b, "tenant", "name", "pool", ".index_pool", "marker", "123");
+  init_bucket(b, "tenant", "name", "pool", ".tail_pool", ".index_pool", "marker", "123");
   o.push_back(b);
   o.push_back(new rgw_bucket);
 }
@@ -433,7 +433,7 @@ void rgw_bucket::generate_test_instances(list<rgw_bucket*>& o)
 void RGWBucketInfo::generate_test_instances(list<RGWBucketInfo*>& o)
 {
   RGWBucketInfo *i = new RGWBucketInfo;
-  init_bucket(&i->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
+  init_bucket(&i->bucket, "tenant", "bucket", "pool", ".tail_pool", ".index_pool", "marker", "10");
   i->owner = "owner";
   i->flags = BUCKET_SUSPENDED;
   o.push_back(i);
@@ -471,7 +471,7 @@ void RGWOLHInfo::generate_test_instances(list<RGWOLHInfo*> &o)
 void RGWBucketEnt::generate_test_instances(list<RGWBucketEnt*>& o)
 {
   RGWBucketEnt *e = new RGWBucketEnt;
-  init_bucket(&e->bucket, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
+  init_bucket(&e->bucket, "tenant", "bucket", "pool", ".tail_pool", ".index_pool", "marker", "10");
   e->size = 1024;
   e->size_rounded = 4096;
   e->count = 1;
@@ -492,7 +492,7 @@ void RGWUploadPartInfo::generate_test_instances(list<RGWUploadPartInfo*>& o)
 void rgw_obj::generate_test_instances(list<rgw_obj*>& o)
 {
   rgw_bucket b;
-  init_bucket(&b, "tenant", "bucket", "pool", ".index_pool", "marker", "10");
+  init_bucket(&b, "tenant", "bucket", "pool", ".tail_pool", ".index_pool", "marker", "10");
   rgw_obj *obj = new rgw_obj(b, "object");
   o.push_back(obj);
   o.push_back(new rgw_obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -922,6 +922,7 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
 {
   encode_json("index_pool", index_pool, f);
   encode_json("data_pool", data_pool, f);
+  encode_json("data_tail_pool", data_tail_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
   encode_json("index_type", (uint32_t)index_type, f);
   encode_json("compression", compression_type, f);
@@ -931,6 +932,7 @@ void RGWZonePlacementInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("index_pool", index_pool, obj);
   JSONDecoder::decode_json("data_pool", data_pool, obj);
+  JSONDecoder::decode_json("data_tail_pool", data_tail_pool, obj);
   JSONDecoder::decode_json("data_extra_pool", data_extra_pool, obj);
   uint32_t it;
   JSONDecoder::decode_json("index_type", it, obj);

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -572,12 +572,14 @@ void RGWQuotaInfo::decode_json(JSONObj *obj)
 void rgw_data_placement_target::dump(Formatter *f) const
 {
   encode_json("data_pool", data_pool, f);
+  encode_json("data_tail_pool", data_tail_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
   encode_json("index_pool", index_pool, f);
 }
   
 void rgw_data_placement_target::decode_json(JSONObj *obj) {
   JSONDecoder::decode_json("data_pool", data_pool, obj);
+  JSONDecoder::decode_json("data_tail_pool", data_tail_pool, obj);
   JSONDecoder::decode_json("data_extra_pool", data_extra_pool, obj);
   JSONDecoder::decode_json("index_pool", index_pool, obj);
 }
@@ -600,6 +602,7 @@ void rgw_bucket::decode_json(JSONObj *obj) {
   if (explicit_placement.data_pool.empty()) {
     /* decoding old format */
     JSONDecoder::decode_json("pool", explicit_placement.data_pool, obj);
+    JSONDecoder::decode_json("data_tail_pool", explicit_placement.data_tail_pool, obj);
     JSONDecoder::decode_json("data_extra_pool", explicit_placement.data_extra_pool, obj);
     JSONDecoder::decode_json("index_pool", explicit_placement.index_pool, obj);
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2963,6 +2963,7 @@ int RGWPutObjProcessor_Multipart::prepare(RGWRados *store, string *oid_rand)
   cur_obj = manifest_gen.get_cur_obj(store);
   rgw_raw_obj_to_obj(bucket, cur_obj, &head_obj);
   head_obj.index_hash_source = obj_str;
+  head_obj.set_head_obj(false);
 
   r = prepare_init(store, NULL);
   if (r < 0) {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2963,7 +2963,6 @@ int RGWPutObjProcessor_Multipart::prepare(RGWRados *store, string *oid_rand)
   cur_obj = manifest_gen.get_cur_obj(store);
   rgw_raw_obj_to_obj(bucket, cur_obj, &head_obj);
   head_obj.index_hash_source = obj_str;
-  head_obj.set_head_obj(false);
 
   r = prepare_init(store, NULL);
   if (r < 0) {
@@ -2992,6 +2991,8 @@ int RGWPutObjProcessor_Multipart::do_complete(size_t accounted_size,
   head_obj_op.meta.owner = s->owner.get_id();
   head_obj_op.meta.delete_at = delete_at;
   head_obj_op.meta.zones_trace = zones_trace;
+
+  op_target.set_in_tail(true);
 
   int r = head_obj_op.write_meta(obj_len, accounted_size, attrs);
   if (r < 0)

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7970,19 +7970,19 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     return ret;
   }
 
-  rgw_pool src_pool;
-  rgw_pool dest_pool;
-  if (!get_obj_data_pool(src_bucket_info.placement_rule, src_obj, &src_pool)) {
+
+  rgw_pool s_data_tail_pool;
+  rgw_pool d_data_tail_pool;
+  if (!zone_params.get_tail_data_pool(src_bucket_info.placement_rule, src_obj, &s_data_tail_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << src_obj << dendl;
     return -EIO;
   }
-  if (!get_obj_data_pool(dest_bucket_info.placement_rule, dest_obj, &dest_pool)) {
+  if (!zone_params.get_tail_data_pool(dest_bucket_info.placement_rule, dest_obj, &d_data_tail_pool)) {
     ldout(cct, 0) << "ERROR: failed to locate data pool for " << dest_obj << dendl;
     return -EIO;
   }
 
-
-  bool copy_data = !astate->has_manifest || (src_pool != dest_pool);
+  bool copy_data = !astate->has_manifest || (s_data_tail_pool != d_data_tail_pool);
   bool copy_first = false;
   if (astate->has_manifest) {
     if (!astate->manifest.has_tail()) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1644,9 +1644,10 @@ int get_zones_pool_set(CephContext* cct,
       pool_names.insert(zone.roles_pool);
       pool_names.insert(zone.reshard_pool);
       for(auto& iter : zone.placement_pools) {
-	pool_names.insert(iter.second.index_pool);
-	pool_names.insert(iter.second.data_pool);
-	pool_names.insert(iter.second.data_extra_pool);
+        pool_names.insert(iter.second.index_pool);
+        pool_names.insert(iter.second.data_pool);
+        pool_names.insert(iter.second.data_extra_pool);
+        pool_names.insert(iter.second.data_tail_pool);
       }
     }
   }
@@ -6043,6 +6044,7 @@ read_omap:
 
   rule_info->data_pool = pool_name;
   rule_info->data_extra_pool = pool_name;
+  rule_info->data_tail_pool = pool_name;
   rule_info->index_pool = pool_name;
   rule_info->index_type = RGWBIType_Normal;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -128,14 +128,17 @@ class rgw_obj_select {
   rgw_obj obj;
   rgw_raw_obj raw_obj;
   bool is_raw;
+  bool is_head;
 
 public:
-  rgw_obj_select() : is_raw(false) {}
-  rgw_obj_select(const rgw_obj& _obj) : obj(_obj), is_raw(false) {}
-  rgw_obj_select(const rgw_raw_obj& _raw_obj) : raw_obj(_raw_obj), is_raw(true) {}
+  rgw_obj_select() : is_raw(false), is_head(true) {}
+  rgw_obj_select(const rgw_obj& _obj) : obj(_obj), is_raw(false), is_head(true) {}
+  rgw_obj_select(const rgw_raw_obj& _raw_obj) : raw_obj(_raw_obj), is_raw(true), is_head(true) {}
   rgw_obj_select(const rgw_obj_select& rhs) {
+    placement_rule = rhs.placement_rule;
     is_raw = rhs.is_raw;
-    if (is_raw) {
+    is_head = rhs.is_head;
+   if (is_raw) {
       raw_obj = rhs.raw_obj;
     } else {
       obj = rhs.obj;
@@ -144,6 +147,14 @@ public:
 
   rgw_raw_obj get_raw_obj(const RGWZoneGroup& zonegroup, const RGWZoneParams& zone_params) const;
   rgw_raw_obj get_raw_obj(RGWRados *store) const;
+
+  void set_head_obj(bool val) { 
+    is_head = val; 
+  }
+
+  bool is_head_obj() const { 
+    return is_head;
+  }
 
   rgw_obj_select& operator=(const rgw_obj& rhs) {
     obj = rhs;
@@ -2323,8 +2334,8 @@ class RGWRados
   // This field represents the number of bucket index object shards
   uint32_t bucket_index_max_shards;
 
-  int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx);
-  int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref);
+  int get_obj_head_ioctx(const RGWBucketInfo& bucket_info, const rgw_obj& obj, librados::IoCtx *ioctx, bool in_tail = false);
+  int get_obj_head_ref(const RGWBucketInfo& bucket_info, const rgw_obj& obj, rgw_rados_ref *ref, bool in_tail = false);
   int get_system_obj_ref(const rgw_raw_obj& obj, rgw_rados_ref *ref);
   uint64_t max_bucket_id;
 
@@ -2332,7 +2343,7 @@ class RGWRados
                            RGWObjState *olh_state, RGWObjState **target_state);
   int get_system_obj_state_impl(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWRawObjState **state, RGWObjVersionTracker *objv_tracker);
   int get_obj_state_impl(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
-                         bool follow_olh, bool assume_noent = false);
+                         bool follow_olh, bool assume_noent = false, bool in_tail = false);
   int append_atomic_test(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj,
                          librados::ObjectOperation& op, RGWObjState **state);
 
@@ -2638,8 +2649,8 @@ public:
   int select_bucket_location_by_rule(const string& location_rule, RGWZonePlacementInfo *rule_info);
   void create_bucket_id(string *bucket_id);
 
-  bool get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool);
-  bool obj_to_raw(const string& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj);
+  bool get_obj_data_pool(const string& placement_rule, const rgw_obj& obj, rgw_pool *pool, bool is_tail = false);
+  bool obj_to_raw(const string& placement_rule, const rgw_obj& obj, rgw_raw_obj *raw_obj, bool in_tail = false);
 
   int create_bucket(RGWUserInfo& owner, rgw_bucket& bucket,
                             const string& zonegroup_id,
@@ -2741,7 +2752,7 @@ public:
     bool versioning_disabled;
 
     bool bs_initialized;
-
+    bool in_tail;
   protected:
     int get_state(RGWObjState **pstate, bool follow_olh, bool assume_noent = false);
     void invalidate_state();
@@ -2754,13 +2765,16 @@ public:
     Object(RGWRados *_store, const RGWBucketInfo& _bucket_info, RGWObjectCtx& _ctx, const rgw_obj& _obj) : store(_store), bucket_info(_bucket_info),
                                                                                                ctx(_ctx), obj(_obj), bs(store),
                                                                                                state(NULL), versioning_disabled(false),
-                                                                                               bs_initialized(false) {}
+                                                                                               bs_initialized(false), in_tail(false) {}
 
     RGWRados *get_store() { return store; }
     rgw_obj& get_obj() { return obj; }
     RGWObjectCtx& get_ctx() { return ctx; }
     RGWBucketInfo& get_bucket_info() { return bucket_info; }
     int get_manifest(RGWObjManifest **pmanifest);
+
+    bool is_in_tail() {return in_tail;}
+    void set_in_tail(bool val) {in_tail = val;}
 
     int get_bucket_shard(BucketShard **pbs) {
       if (!bs_initialized) {
@@ -3283,7 +3297,7 @@ public:
 
   int get_system_obj_state(RGWObjectCtx *rctx, rgw_raw_obj& obj, RGWRawObjState **state, RGWObjVersionTracker *objv_tracker);
   int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state,
-                    bool follow_olh, bool assume_noent = false);
+                    bool follow_olh, bool assume_noent = false, bool in_tail = false);
   int get_obj_state(RGWObjectCtx *rctx, const RGWBucketInfo& bucket_info, const rgw_obj& obj, RGWObjState **state) {
     return get_obj_state(rctx, bucket_info, obj, state, true);
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1336,6 +1336,23 @@ struct RGWZoneParams : RGWSystemMetaObj {
     }
     return true;
   }
+
+  bool get_tail_data_pool(const string& placement_id, const rgw_obj& obj, rgw_pool *pool) const {
+    const rgw_data_placement_target& explicit_placement = obj.bucket.explicit_placement;
+    if (!explicit_placement.data_pool.empty()) {
+      *pool = explicit_placement.get_data_tail_pool();
+      return true;
+    }
+    if (placement_id.empty()) {
+      return false;
+    }
+    auto iter = placement_pools.find(placement_id);
+    if (iter == placement_pools.end()) {
+      return false;
+    }
+    *pool = iter->second.get_data_tail_pool();
+    return true;
+  }
 };
 WRITE_CLASS_ENCODER(RGWZoneParams)
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -198,6 +198,7 @@
      --endpoints=<list>        zone endpoints
      --index-pool=<pool>       placement target index pool
      --data-pool=<pool>        placement target data pool
+     --data-tail-pool=<pool>   placement target data tail pool
      --data-extra-pool=<pool>  placement target data extra (non-ec) pool
      --placement-index-type=<type>
                                placement target index type (normal, indexless, or #id)


### PR DESCRIPTION
We ever faced a problem when created radosgw object storage on ec pool(k=4, m=2).  Using cosbench to do upload test, we got 700-800 ops of 4K size objects,  but 2212.18 ops of 4K size objects from 3 replicated pool. Performance from ec is lower than 3 replicated pool, but they eventually have similar throughput when object size become bigger(4MB, 8MB or bigger). This phenomena is easy to explain, cpu is the bottleneck when upload small objects, but disks will be the bottleneck when upload bigger objects.

Our customers always concern cost, so ec is a good choice to lower the cost of capacity; but it also brings trouble as mentioned above. So I wanted to find a way to improve the performance of ec for object storage based radosgw, and found a way to leverage capacity and performance.

My opinion is that we should support store head and tail objects of radosgw object separately, which means that stores head objects in 3 replicated pool and tail objects in ec pool. So for small objects, we
can get performance of 3 replicated pool, and we also benefit 67% capacity utility from ec(3 replicated only has 33%).

Consider a scene: we want to upload big size(MB or GB) objects , we prefer to use multipart, radosgw will stripe every part to several tail rados objects but no head object and all of them will land in ec
pool. So we will get similar throughput as 3 replicated pool for they are big objects, and we also benefit capacity utility.

Pareto principle (also known as the 80–20 rule) generally exists in workload, which means 20% files/objects occupy 80% capacity. It is not just subjective guess,  my company's share disk(like dropbox, storing
department e-doc, software, and so on) obey the rule and even 85-15(15% files occupy 85% capacity).