### PR TITLE
ceph-disk: Accept bcache devices as data disks

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -810,6 +810,20 @@ def get_partition_base_mpath(dev):
     return os.path.join('/dev/mapper', name)
 
 
+def is_bcache(dev_name):
+    """
+    Check if dev_name is a bcache
+    """
+    if not dev_name.startswith('bcache'):
+        return False
+    if not os.path.exists(os.path.join(BLOCKDIR, dev_name, 'bcache')):
+        return False
+    if os.path.exists(os.path.join(BLOCKDIR, dev_name,
+                                   'bcache/cache_mode')):
+        return True
+    return False
+
+
 def is_partition(dev):
     """
     Check whether a given device path is a partition or a full disk.
@@ -823,6 +837,8 @@ def is_partition(dev):
         raise Error('not a block device', dev)
 
     name = get_dev_name(dev)
+    if is_bcache(name):
+        return True
     if os.path.exists(os.path.join(BLOCKDIR, name)):
         return False
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/13278

This brings the changes from #8497 which I mistakenly only proposed for jewel
into master, with minor updates
