### PR TITLE
osd: Add recovery sleep configuration option for HDDs and SSDs

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -690,9 +690,9 @@ perform well in a degraded state.
 
 ``osd recovery sleep``
 
-:Description: Time to sleep before next recovery. Increasing this value will
-              slow down recovery operation while client operations will be
-              less impacted.
+:Description: Time in seconds to sleep before next recovery or backfill op.
+              Increasing this value will slow down recovery operation while
+              client operations will be less impacted.
 
 :Type: Float
 :Default: ``0``
@@ -700,7 +700,8 @@ perform well in a degraded state.
 
 ``osd recovery sleep hdd``
 
-:Description: Time to sleep before next recovery for HDDs.
+:Description: Time in seconds to sleep before next recovery or backfill op
+              for HDDs.
 
 :Type: Float
 :Default: ``0.1``
@@ -708,7 +709,8 @@ perform well in a degraded state.
 
 ``osd recovery sleep ssd``
 
-:Description: Time to sleep before next recovery for SSDs.
+:Description: Time in seconds to sleep before next recovery or backfill op
+              for SSDs.
 
 :Type: Float
 :Default: ``0``

--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -695,7 +695,23 @@ perform well in a degraded state.
               less impacted.
 
 :Type: Float
-:Default: ``0.01``
+:Default: ``0``
+
+
+``osd recovery sleep hdd``
+
+:Description: Time to sleep before next recovery for HDDs.
+
+:Type: Float
+:Default: ``0.1``
+
+
+``osd recovery sleep ssd``
+
+:Description: Time to sleep before next recovery for SSDs.
+
+:Type: Float
+:Default: ``0``
 
 Tiering
 =======

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -815,7 +815,9 @@ OPTION(osd_op_thread_timeout, OPT_INT, 15)
 OPTION(osd_op_thread_suicide_timeout, OPT_INT, 150)
 OPTION(osd_recovery_thread_timeout, OPT_INT, 30)
 OPTION(osd_recovery_thread_suicide_timeout, OPT_INT, 300)
-OPTION(osd_recovery_sleep, OPT_FLOAT, 0.01)         // seconds to sleep between recovery ops
+OPTION(osd_recovery_sleep, OPT_FLOAT, 0)         // seconds to sleep between recovery ops
+OPTION(osd_recovery_sleep_hdd, OPT_FLOAT, 0.1)
+OPTION(osd_recovery_sleep_ssd, OPT_FLOAT, 0)
 OPTION(osd_snap_trim_sleep, OPT_DOUBLE, 0)
 OPTION(osd_scrub_invalid_stats, OPT_BOOL, true)
 OPTION(osd_remove_thread_timeout, OPT_INT, 60*60)

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2398,6 +2398,8 @@ private:
   int get_num_op_shards();
   int get_num_op_threads();
 
+  float get_osd_recovery_sleep();
+
 public:
   static int peek_meta(ObjectStore *store, string& magic,
 		       uuid_d& cluster_fsid, uuid_d& osd_fsid, int& whoami);


### PR DESCRIPTION
This pull request creates separate osd_recovery_sleep configuration option for HDDs and SSDs.

Signed-off-by: Neha Ojha <nojha@redhat.com>