### PR TITLE
crush: silence warning from -Woverflow

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1319,7 +1319,8 @@ int32_t CrushWrapper::_alloc_class_id() const {
     return class_id;
   }
   // wrapped, pick a random start and do exhaustive search
-  uint32_t upperlimit = numeric_limits<int32_t>::max() + 1;
+  uint32_t upperlimit = numeric_limits<int32_t>::max();
+  upperlimit++;
   class_id = rand() % upperlimit;
   const auto start = class_id;
   do {


### PR DESCRIPTION
The following warning appears during build:
```
ceph/src/crush/CrushWrapper.cc: In member function ‘int32_t CrushWrapper::_alloc_class_id() const’:
ceph/src/crush/CrushWrapper.cc:1322:56: warning: integer overflow in expression [-Woverflow]
   uint32_t upperlimit = numeric_limits<int32_t>::max() + 1;
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
```

This can also be fixed by:
```
   uint32_t upperlimit = numeric_limits<int32_t>::max();
   upperlimit++;

```

Signed-off-by: Jos Collin <jcollin@redhat.com>