### PR TITLE
rgw: remove the useless output when listing zonegroups.

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3521,7 +3521,6 @@ int main(int argc, const char **argv)
 	}
 	string default_zonegroup;
 	ret = zonegroup.read_default_id(default_zonegroup);
-	cout << "read_default_id : " << ret << std::endl;
 	if (ret < 0 && ret != -ENOENT) {
 	  cerr << "could not determine default zonegroup: " << cpp_strerror(-ret) << std::endl;
 	}


### PR DESCRIPTION
If we don't create a zonegroup, and use the command zonegroup list, it will return -2.
[root@user ~/ceph/build]#  ./bin/radosgw-admin zonegroup list -c ceph.conf 
read_default_id : -2
{
    "default_info": "",
    "zonegroups": [
        "default"
    ]
}
This error doesn't need to be printed. 
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>