### PR TITLE
core:" Stringify needs access to << before reference" src/include/stringify.h

### DIFF
--- a/src/include/stringify.h
+++ b/src/include/stringify.h
@@ -4,6 +4,8 @@
 #include <string>
 #include <sstream>
 
+#include "include/types.h"
+
 template<typename T>
 inline std::string stringify(const T& a) {
 #if defined(__GNUC__) && !(defined(__clang__) || defined(__INTEL_COMPILER))


### PR DESCRIPTION
Clang complains:

In file included from /home/jenkins/workspace/ceph-master/src/mon/HealthMonitor.cc:21:
/home/jenkins/workspace/ceph-master/src/include/stringify.h:15:6: error: call to function 'operator<<' that is neither visible in the template definition nor found by argument-dependent lookup
  ss << a;
     ^
/home/jenkins/workspace/ceph-master/src/mon/HealthMonitor.cc:129:32: note: in instantiation of function template specialization 'stringify<std::__1::set<std::__1::basic_string<char>, std::__1::less<std::__1::basic_string<char> >, std::__1::allocator<std::__1::basic_string<char> > > >' requested here
      boost::regex("%names%"), stringify(names[p.first]));
                               ^
/home/jenkins/workspace/ceph-master/src/include/types.h:160:17: note: 'operator<<' should be declared prior to the call site
inline ostream& operator<<(ostream& out, const set<A, Comp, Alloc>& iset) {

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>