### PR TITLE
mds: clear dirty rstat flag on non-auth inode when finishing scatter

### DIFF
--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -5168,10 +5168,10 @@ void Locker::handle_file_lock(ScatterLock *lock, MLock *m)
 	mds->mdlog->flush();
       break;
     } 
-    
+
     // ok
-    lock->decode_locked_state(m->get_data());
     lock->set_state(LOCK_MIX);
+    lock->decode_locked_state(m->get_data());
 
     if (caps)
       issue_caps(in);


### PR DESCRIPTION
Fixes: #http://tracker.ceph.com/issues/20569

Signed-off-by: Zhi Zhang zhangz.david@outlook.com