### PR TITLE
qa/tasks: rbd-mirror daemon not properly run in foreground mode

### DIFF
--- a/qa/tasks/rbd_mirror.py
+++ b/qa/tasks/rbd_mirror.py
@@ -91,7 +91,7 @@ class RBDMirror(Task):
             )
 
         args.extend([
-            'rbd-mirror',
+            'rbd-mirror', '--foreground',
             '--cluster',
             self.cluster_name,
             '--id',


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20630
Signed-off-by: Jason Dillaman <dillaman@redhat.com>