### PR TITLE
mon: skip crush smoke test when running under valgrind

### DIFF
--- a/qa/suites/fs/verify/validater/valgrind.yaml
+++ b/qa/suites/fs/verify/validater/valgrind.yaml
@@ -16,6 +16,8 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 40
+      mon:
+        mon osd crush smoke test: false
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/valgrind-leaks.yaml
@@ -16,6 +16,8 @@ overrides:
         debug deliberately leak memory: true
         osd max object name len: 460
         osd max object namespace len: 64
+      mon:
+        mon osd crush smoke test: false
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -10,6 +10,8 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 40
+      mon:
+        mon osd crush smoke test: false
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/qa/suites/rgw/multisite/valgrind.yaml
+++ b/qa/suites/rgw/multisite/valgrind.yaml
@@ -9,6 +9,8 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 40
+      mon:
+        mon osd crush smoke test: false
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/qa/suites/rgw/verify/validater/valgrind.yaml
+++ b/qa/suites/rgw/verify/validater/valgrind.yaml
@@ -10,6 +10,8 @@ overrides:
     conf:
       global:
         osd heartbeat grace: 40
+      mon:
+        mon osd crush smoke test: false
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -395,6 +395,7 @@ OPTION(mon_keyvaluedb, OPT_STR, "rocksdb")   // type of keyvaluedb backend
 // UNSAFE -- TESTING ONLY! Allows addition of a cache tier with preexisting snaps
 OPTION(mon_debug_unsafe_allow_tier_with_nonempty_snaps, OPT_BOOL, false)
 OPTION(mon_osd_blacklist_default_expire, OPT_DOUBLE, 60*60) // default one hour
+OPTION(mon_osd_crush_smoke_test, OPT_BOOL, true)
 
 OPTION(paxos_stash_full_interval, OPT_INT, 25)   // how often (in commits) to stash a full copy of the PaxosService state
 OPTION(paxos_max_join_drift, OPT_INT, 10) // max paxos iterations before we must first sync the monitor stores


### PR DESCRIPTION
Valgrind tries to analyze the forked child process, and is slow enough
that it times out pretty reliably.

http://tracker.ceph.com/issues/20602