### PR TITLE
tests: ceph-disk: use communicate() instead of wait() for output

### DIFF
--- a/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
+++ b/qa/suites/ceph-disk/basic/tasks/ceph-disk.yaml
@@ -17,6 +17,9 @@ tasks:
 - ceph:
     fs: xfs # this implicitly means /dev/vd? are used instead of directories
     wait-for-scrub: false
+    log-whitelist:
+      - (OSD_
+      - (PG_
     conf:
        global:
            mon pg warn min per osd: 2


### PR DESCRIPTION
to avoid possible deadlock. quote from doc of Popen.wait()

> This will deadlock when using stdout=PIPE and/or stderr=PIPE and the
child process generates enough output to a pipe such that it blocks
waiting for the OS pipe buffer to accept more data. Use communicate() to
avoid that.

and print out the stdout and stderr using LOG.warn() if the command
fails.

Signed-off-by: Kefu Chai <kchai@redhat.com>