### PR TITLE
mon/OSDMonitor: add "--show-shadow" option for "osd tree" command

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1603,6 +1603,12 @@ function test_mon_osd()
   expect_false ceph osd tree up down
   expect_false ceph osd tree in out
   expect_false ceph osd tree up foo
+  # make sure we reached luminous to enable crush class feature
+  ceph osd set-require-min-compat-client luminous
+  ceph osd crush class create hdd
+  ceph osd crush set-device-class hdd osd.0
+  ceph osd tree --show-shadow | grep '~hdd'
+  ceph osd tree | expect_false grep '~hdd'
 
   ceph osd metadata
   ceph osd count-metadata os

--- a/src/crush/CrushTreeDumper.h
+++ b/src/crush/CrushTreeDumper.h
@@ -67,6 +67,15 @@ namespace CrushTreeDumper {
       crush->find_nonshadow_roots(roots);
       root = roots.begin();
     }
+    explicit Dumper(const CrushWrapper *crush_, bool show_shadow) :
+      crush(crush_) {
+      if (show_shadow) {
+        crush->find_roots(roots);
+      } else {
+        crush->find_nonshadow_roots(roots);
+      }
+      root = roots.begin();
+    }
 
     virtual ~Dumper() {}
 
@@ -185,7 +194,8 @@ namespace CrushTreeDumper {
   class FormattingDumper : public Dumper<Formatter> {
   public:
     explicit FormattingDumper(const CrushWrapper *crush) : Dumper<Formatter>(crush) {}
-
+    explicit FormattingDumper(const CrushWrapper *crush, bool show_shadow) :
+      Dumper<Formatter>(crush, show_shadow) {}
   protected:
     void dump_item(const Item &qi, Formatter *f) override {
       f->open_object_section("item");

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -450,7 +450,8 @@ COMMAND("osd dump " \
 	"print summary of OSD map", "osd", "r", "cli,rest")
 COMMAND("osd tree " \
 	"name=epoch,type=CephInt,range=0,req=false " \
-	"name=states,type=CephChoices,strings=up|down|in|out,n=N,req=false", \
+        "name=states,type=CephChoices,strings=up|down|in|out,n=N,req=false " \
+        "name=shadow,type=CephChoices,strings=--show-shadow,req=false", \
 	"print OSD tree", "osd", "r", "cli,rest")
 COMMAND("osd ls " \
 	"name=epoch,type=CephInt,range=0,req=false", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3972,7 +3972,9 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
       rdata.append(ds);
     } else if (prefix == "osd tree") {
       vector<string> states;
+      string shadow;
       cmd_getval(g_ceph_context, cmdmap, "states", states);
+      cmd_getval(g_ceph_context, cmdmap, "shadow", shadow);
       unsigned filter = 0;
       for (auto& s : states) {
 	if (s == "up") {
@@ -3997,13 +3999,14 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	r = -EINVAL;
 	goto reply;
       }
+      bool show_shadow = shadow == "--show-shadow";
       if (f) {
 	f->open_object_section("tree");
-	p->print_tree(f.get(), NULL, filter);
+	p->print_tree(f.get(), NULL, filter, show_shadow);
 	f->close_section();
 	f->flush(ds);
       } else {
-	p->print_tree(NULL, &ds, filter);
+	p->print_tree(NULL, &ds, filter, show_shadow);
       }
       rdata.append(ds);
     } else if (prefix == "osd getmap") {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3067,6 +3067,12 @@ public:
 		     unsigned f)
     : Parent(crush), osdmap(osdmap_), filter(f) { }
 
+  OSDTreePlainDumper(const CrushWrapper *crush,
+                     const OSDMap *osdmap_,
+                     unsigned f,
+                     bool show_shadow)
+    : Parent(crush, show_shadow), osdmap(osdmap_), filter(f) { }
+
   bool should_dump_leaf(int i) const override {
     if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
 	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
@@ -3145,6 +3151,13 @@ public:
 			  unsigned f)
     : Parent(crush), osdmap(osdmap_), filter(f) { }
 
+
+  OSDTreeFormattingDumper(const CrushWrapper *crush,
+                          const OSDMap *osdmap_,
+                          unsigned f,
+                          bool show_shadow)
+    : Parent(crush, show_shadow), osdmap(osdmap_), filter(f) { }
+
   bool should_dump_leaf(int i) const override {
     if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
 	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
@@ -3188,14 +3201,17 @@ private:
   const unsigned filter;
 };
 
-void OSDMap::print_tree(Formatter *f, ostream *out, unsigned filter) const
+void OSDMap::print_tree(Formatter *f,
+                        ostream *out,
+                        unsigned filter,
+                        bool show_shadow) const
 {
   if (f) {
-    OSDTreeFormattingDumper(crush.get(), this, filter).dump(f);
+    OSDTreeFormattingDumper(crush.get(), this, filter, show_shadow).dump(f);
   } else {
     assert(out);
     TextTable tbl;
-    OSDTreePlainDumper(crush.get(), this, filter).dump(&tbl);
+    OSDTreePlainDumper(crush.get(), this, filter, show_shadow).dump(&tbl);
     *out << tbl;
   }
 }

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1347,7 +1347,8 @@ public:
     DUMP_UP = 4,     // only 'up' osds
     DUMP_DOWN = 8,   // only 'down' osds
   };
-  void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0) const;
+  void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0,
+    bool show_shadow = false) const;
 
   int summarize_mapping_stats(
     OSDMap *newmap,


### PR DESCRIPTION
This is useful for debugging class feature. E.g.:
 **./bin/ceph osd tree --show-shadow**

```
ID CLASS WEIGHT  TYPE NAME                                            UP/DOWN REWEIGHT PRI-AFF
-4   hdd 1.00000 root default~hdd
-3   hdd 1.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic~hdd
 0   hdd 1.00000         osd.0                                             up  1.00000 1.00000
-1       3.00000 root default
-2       3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic
 0   hdd 1.00000         osd.0                                             up  1.00000 1.00000
 1       1.00000         osd.1                                             up  1.00000 1.00000
 2       1.00000         osd.2                                             up  1.00000 1.00000
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>