### PR TITLE
jewel: osd: also check if the clones' object context exists when determining whether to promote those clones

### DIFF
--- a/src/osd/ReplicatedPG.cc
+++ b/src/osd/ReplicatedPG.cc
@@ -2052,7 +2052,7 @@ void ReplicatedPG::do_op(OpRequestRef& op)
 	}
 
 	ObjectContextRef sobc = get_object_context(clone_oid, false);
-	if (!sobc) {
+	if (!sobc || !sobc->obs.exists) {
 	  if (!maybe_handle_cache(op, write_ordered, sobc, -ENOENT, clone_oid, true))
 	    osd->reply_op_error(op, -ENOENT);
 	  return;


### PR DESCRIPTION
Also check if the clones' object context exists for OPs
whose snapid is CEPH_SNAPDIR in ReplicatedPG::do_op

If the incoming request's snapid is CEPH_SNAPDIR and the object context
of clones of its targeting object doesn't exist, also promote those clones

Fix: http://tracker.ceph.com/issues/17445
Signed-off-by: Xuehan Xu <xuxuehan@360.cn>