### PR TITLE
mon/MgrMonitor: only induce mgr epoch shortly after mkfs

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -490,6 +490,7 @@ void MgrMonitor::tick()
   }
 
   if (!pending_map.available &&
+      !ever_had_active_mgr &&
       should_warn_about_mgr_down() != HEALTH_OK) {
     dout(10) << " exceeded mon_mgr_mkfs_grace " << g_conf->mon_mgr_mkfs_grace
 	     << " seconds" << dendl;


### PR DESCRIPTION
For early clusters, if there isn't an active manager, we eventually want
to trigger a health warning by rolling over the mgrmap epoch.  We don't
want to do that if we have no active/available manager after that.  Fix
by checking ever_had_active_mgr here.

Signed-off-by: Sage Weil <sage@redhat.com>