### PR TITLE
build/ops: rpm: fix typo WTIH_BABELTRACE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -838,10 +838,10 @@ cmake .. \
 %endif
 %if %{with lttng}
     -DWITH_LTTNG=ON \
-    -DWTIH_BABELTRACE=ON \
+    -DWITH_BABELTRACE=ON \
 %else
     -DWITH_LTTNG=OFF \
-    -DWTIH_BABELTRACE=OFF \
+    -DWITH_BABELTRACE=OFF \
 %endif
     $CEPH_EXTRA_CMAKE_ARGS \
 %if 0%{with ocf}


### PR DESCRIPTION
Introduced by b331898ea9aefc547265b388dddbc388417184fe

Breaks the ppc64le and s390x builds

Signed-off-by: Nathan Cutler <ncutler@suse.com>