### PR TITLE
rgw: use a namespace for rgw reshard pool for upgrades as well

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -5,6 +5,8 @@
 * Added new configuration "public bind addr" to support dynamic environments
   like Kubernetes. When set the Ceph MON daemon could bind locally to an IP
   address and advertise a different IP address "public addr" on the network.
+* RGW: bucket index resharding now uses the reshard namespace in upgrade scenarios as well
+  this is a changed behaviour from RC1 where a new pool for reshard was created
 
 12.0.0
 ------

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -904,6 +904,7 @@ void RGWZoneParams::dump(Formatter *f) const
   encode_json("log_pool", log_pool, f);
   encode_json("intent_log_pool", intent_log_pool, f);
   encode_json("usage_log_pool", usage_log_pool, f);
+  encode_json("reshard_pool", reshard_pool, f);
   encode_json("user_keys_pool", user_keys_pool, f);
   encode_json("user_email_pool", user_email_pool, f);
   encode_json("user_swift_pool", user_swift_pool, f);
@@ -944,6 +945,7 @@ void RGWZoneParams::decode_json(JSONObj *obj)
   JSONDecoder::decode_json("lc_pool", lc_pool, obj);
   JSONDecoder::decode_json("log_pool", log_pool, obj);
   JSONDecoder::decode_json("intent_log_pool", intent_log_pool, obj);
+  JSONDecoder::decode_json("reshard_pool", reshard_pool, obj);
   JSONDecoder::decode_json("usage_log_pool", usage_log_pool, obj);
   JSONDecoder::decode_json("user_keys_pool", user_keys_pool, obj);
   JSONDecoder::decode_json("user_email_pool", user_email_pool, obj);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1266,7 +1266,7 @@ struct RGWZoneParams : RGWSystemMetaObj {
     if (struct_v >= 10) {
       ::decode(reshard_pool, bl);
     } else {
-      reshard_pool = name + ".rgw.reshard";
+      reshard_pool = log_pool.name + ":reshard";
     }
     DECODE_FINISH(bl);
   }


### PR DESCRIPTION
We were previously (for dev & RC1) creating a new pool for bucket index
resharding during upgrades, moving to a namespace similar to new deployments since this
will avoid the creation of a new pool, also clarify the log message if
we do encounter the situation where the pool can't be accessed.

However there might be possible misconfigurations seen when upgrading
from luminous dev/RC1 releases to RC2 where a different pool for reshard
will still be used from the previous upgrade. Also need clarification
whether we need to bump up the zone params struct version number from 10
to 11

Fixes: http://tracker.ceph.com/issues/20289