### PR TITLE
os/bluestore/BlueStore: Avoid double counting state_kv_queued_lat.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8344,26 +8344,29 @@ void BlueStore::_kv_sync_thread()
 	t->set(PREFIX_SUPER, "blobid_max", bl);
 	dout(10) << __func__ << " new_blobid_max " << new_blobid_max << dendl;
       }
-      for (auto txc : kv_submitting) {
-	assert(txc->state == TransContext::STATE_KV_QUEUED);
-	txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
-	int r = cct->_conf->bluestore_debug_omit_kv_commit ? 0 : db->submit_transaction(txc->t);
-	assert(r == 0);
-	_txc_applied_kv(txc);
-	--txc->osr->kv_committing_serially;
-	txc->state = TransContext::STATE_KV_SUBMITTED;
-	if (txc->osr->kv_submitted_waiters) {
-	  std::lock_guard<std::mutex> l(txc->osr->qlock);
-	  if (txc->osr->_is_all_kv_submitted()) {
-	    txc->osr->qcond.notify_all();
-	  }
-	}
-      }
+
       for (auto txc : kv_committing) {
+	if (txc->state == TransContext::STATE_KV_QUEUED) {
+	  txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+	  int r = cct->_conf->bluestore_debug_omit_kv_commit ? 0 : db->submit_transaction(txc->t);
+	  assert(r == 0);
+	  _txc_applied_kv(txc);
+	  --txc->osr->kv_committing_serially;
+	  txc->state = TransContext::STATE_KV_SUBMITTED;
+	  if (txc->osr->kv_submitted_waiters) {
+	    std::lock_guard<std::mutex> l(txc->osr->qlock);
+	    if (txc->osr->_is_all_kv_submitted()) {
+	      txc->osr->qcond.notify_all();
+	    }
+	  }
+
+	} else {
+	  assert(txc->state == TransContext::STATE_KV_SUBMITTED);
+	  txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
+	}
 	if (txc->had_ios) {
 	  --txc->osr->txc_with_unstable_io;
 	}
-	txc->log_state_latency(logger, l_bluestore_state_kv_queued_lat);
       }
 
       // release throttle *before* we commit.  this allows new ops


### PR DESCRIPTION
In fact, if txc in kv_submitting queue it also in kv_committing.
For those txc, we should avoid double counting state_kv_queued_lat.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>