### PR TITLE
common: bench test get incorrect iops result 

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -799,6 +799,11 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   }
 
   runtime = ceph_clock_now() - data.start_time;
+  if(runtime < 1) {
+      if(data.idata.max_iops == 0 && data.idata.min_iops == INT_MAX)
+          data.idata.max_iops = data.idata.min_iops = (int)(data.finished/runtime);
+  }
+
   lock.Lock();
   data.done = true;
   lock.Unlock();
@@ -1032,6 +1037,11 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   }
 
   runtime = ceph_clock_now() - data.start_time;
+  if(runtime < 1) {
+      if(data.idata.max_iops == 0 && data.idata.min_iops == INT_MAX)
+          data.idata.max_iops = data.idata.min_iops = (int)(data.finished/runtime);
+  }
+
   lock.Lock();
   data.done = true;
   lock.Unlock();


### PR DESCRIPTION
when running : rados -p test bench 20 seq(rand), if the running time of this command is less than 1s,the max/min_iops will not be updated after initialized to 0 and MAX_INT, so the result would be incorrect as below:  
 Average IOPS:         180
Stddev IOPS:          0
Max IOPS:             0
Min IOPS:             2147483647

Signed-off-by: PCzhangPC <pengcheng.zhang@easystack.cn>