### PR TITLE
common: bench test fall into dead loop when <seconds>=0

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -460,7 +460,7 @@ int ObjBencher::write_bench(int secondsToRun,
   stopTime = data.start_time + runtime;
   slot = 0;
   lock.Lock();
-  while (!secondsToRun || ceph_clock_now() < stopTime) {
+  while (secondsToRun && ceph_clock_now() < stopTime) {
     bool found = false;
     while (1) {
       int old_slot = slot;
@@ -690,7 +690,7 @@ int ObjBencher::seq_read_bench(int seconds_to_run, int num_objects, int concurre
   bufferlist *cur_contents;
 
   slot = 0;
-  while ((!seconds_to_run || ceph_clock_now() < finish_time) &&
+  while ((seconds_to_run && ceph_clock_now() < finish_time) &&
 	 num_objects > data.started) {
     lock.Lock();
     int old_slot = slot;
@@ -920,7 +920,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   int rand_id;
 
   slot = 0;
-  while ((!seconds_to_run || ceph_clock_now() < finish_time)) {
+  while ((seconds_to_run && ceph_clock_now() < finish_time)) {
     lock.Lock();
     int old_slot = slot;
     bool found = false;


### PR DESCRIPTION
when using the command : rados bench -p <pool_name> <seconds> <write|seq|rand> -b <block size> -t –no-cleanup ,   if the user set the "seconds" as 0, the program will fall into a dead loop by continuously adding new write or new read.

Signed-off-by:PCzhangPC pengcheng.zhang@easystack.cn