### PR TITLE
rgw: drop the unnecessary handling of Swift's X-Storage-Policy on objects

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1193,7 +1193,6 @@ public:
 class RGWPutMetadataObject : public RGWOp {
 protected:
   RGWAccessControlPolicy policy;
-  string placement_rule;
   boost::optional<ceph::real_time> delete_at;
   const char *dlo_manifest;
 

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -943,7 +943,6 @@ int RGWPutMetadataObject_ObjStore_SWIFT::get_params()
     return r;
   }
 
-  placement_rule = s->info.env->get("HTTP_X_STORAGE_POLICY", "");
   dlo_manifest = s->info.env->get("HTTP_X_OBJECT_MANIFEST");
 
   return 0;


### PR DESCRIPTION
We need to check this as we do in [ RGWPutMetadataBucket::execute](https://github.com/ceph/ceph/blob/master/src/rgw/rgw_op.cc#L3906)

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>