### PR TITLE
rbd:'rbd image-meta remove' of missing key does not return error

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -96,6 +96,7 @@ Eric Lee <eric.lee@hgst.com>
 Eric Mourgaya <eric.mourgaya@arkea.com> <eric.mourgaya@gmail.com>
 Erwin, Brock A <Brock.Erwin@pnl.gov> <Brock.Erwin@pnl.govgit>
 Esteban Molina-Estolano <eestolan@lanl.gov> <eestolan@29311d96-e01e-0410-9327-a35deaab8ce9>
+Fan Yang <yangf@neunn.com> <yfceph@gmail.com>
 Fangchen Sun <sunspot0105@gmail.com>
 Fang Yuxiang <fang.yuxiang@eisoo.com>
 Fang Yuxiang <fang.yuxiang@eisoo.com> <hrchu@users.noreply.github.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -331,6 +331,7 @@ MSys Technologies <contact@msystechnologies.com> Rajesh Nambiar <rajesh.n@msyste
 Nebula <info@nebula.com> Anton Aksola <anton.aksola@nebula.fi>
 Nebula <info@nebula.com> Chris Holcombe <chris.holcombe@nebula.com>
 Netease <contact@netease.com> Dong Wu <archer.wudong@gmail.com>
+Neunn <service@neunn.com> Fan Yang <yangf@neunn.com>
 Ocado <contact@ocado.com> Luis Periquito <luis.periquito@ocado.com>
 Odiso <contact@odiso.com> Alexandre Derumier <aderumier@odiso.com>
 Opower <contact@opower.com> Derrick Schneider <derrick.schneider@opower.com>

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -51,12 +51,16 @@ PRIO_DEBUGONLY = 0
 PRIO_DEFAULT = PRIO_USEFUL
 
 # Make life easier on developers:
-# If in src/, and .libs and pybind exist here, assume we're running
-# from a Ceph source dir and tweak PYTHONPATH and LD_LIBRARY_PATH
-# to use local files
+# If our parent dir contains CMakeCache.txt and bin/init-ceph,
+# assume we're running from a build dir (i.e. src/build/bin/ceph)
+# and tweak sys.path and LD_LIBRARY_PATH to use built files.
+# Since this involves re-execing, if CEPH_DBG is set in the environment
+# re-exec with -mpdb.  Also, if CEPH_DEV is in the env, suppress
+# the warning message about the DEVELOPER MODE.
 
 MYPATH = os.path.abspath(__file__)
 MYDIR = os.path.dirname(MYPATH)
+MYPDIR = os.path.dirname(MYDIR)
 DEVMODEMSG = '*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***'
 
 
@@ -91,10 +95,10 @@ def get_pythonlib_dir():
     """Returns the name of a distutils build directory"""
     return "lib.{version[0]}".format(version=sys.version_info)
 
-if os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
-     and os.path.exists(os.path.join(os.getcwd(), "bin/init-ceph")):
+if os.path.exists(os.path.join(MYPDIR, "CMakeCache.txt")) \
+     and os.path.exists(os.path.join(MYPDIR, "bin/init-ceph")):
     src_path = None
-    for l in open("./CMakeCache.txt"):
+    for l in open(os.path.join(MYPDIR, "CMakeCache.txt")):
         if l.startswith("ceph_SOURCE_DIR:STATIC="):
             src_path = l.split("=")[1].strip()
 
@@ -103,8 +107,8 @@ if os.path.exists(os.path.join(os.getcwd(), "CMakeCache.txt")) \
         pass
     else:
         # Developer mode, but in a cmake build dir instead of the src dir
-        lib_path = os.path.join(os.getcwd(), "lib")
-        bin_path = os.path.join(os.getcwd(), "bin")
+        lib_path = os.path.join(MYPDIR, "lib")
+        bin_path = os.path.join(MYPDIR, "bin")
         pybind_path = os.path.join(src_path, "src", "pybind")
         pythonlib_path = os.path.join(lib_path,
                                       "cython_modules",

--- a/src/common/LogEntry.cc
+++ b/src/common/LogEntry.cc
@@ -51,9 +51,9 @@ clog_type LogEntry::str_to_level(std::string const &str)
     return CLOG_INFO;
   } else if (level_str == "sec") {
     return CLOG_SEC;
-  } else if (level_str == "warn" | level_str == "warning") {
+  } else if (level_str == "warn" || level_str == "warning") {
     return CLOG_WARN;
-  } else if (level_str == "error" | level_str == "err") {
+  } else if (level_str == "error" || level_str == "err") {
     return CLOG_ERROR;
   } else {
     return CLOG_UNKNOWN;

--- a/src/mon/MgrStatMonitor.cc
+++ b/src/mon/MgrStatMonitor.cc
@@ -131,6 +131,10 @@ void MgrStatMonitor::get_health(list<pair<health_status_t,string> >& summary,
 				list<pair<health_status_t,string> > *detail,
 				CephContext *cct) const
 {
+  if (mon->osdmon()->osdmap.require_osd_release < CEPH_RELEASE_LUMINOUS) {
+    return;
+  }
+
   summary.insert(summary.end(), health_summary.begin(), health_summary.end());
   if (detail) {
     detail->insert(detail->end(), health_detail.begin(), health_detail.end());


### PR DESCRIPTION
src/tools/rbd/action/ImageMeta.cc:static int do_metadata_set(librbd::Image& image, const char *key,
'rbd image-meta remove' of missing key does not return error
http://tracker.ceph.com/issues/16990
Signed-off-by: PCzhangPC <pengcheng.zhang@easystack.cn>