### PR TITLE
rgw: Do not decrement stats cache when the cache values are zero

### DIFF
--- a/src/rgw/rgw_quota.cc
+++ b/src/rgw/rgw_quota.cc
@@ -232,9 +232,23 @@ public:
     const uint64_t rounded_added = rgw_rounded_objsize(added_bytes);
     const uint64_t rounded_removed = rgw_rounded_objsize(removed_bytes);
 
-    entry->stats.size += added_bytes - removed_bytes;
-    entry->stats.size_rounded += rounded_added - rounded_removed;
-    entry->stats.num_objects += objs_delta;
+    if ((entry->stats.size + added_bytes - removed_bytes) >= 0) {
+      entry->stats.size += added_bytes - removed_bytes;
+    } else {
+      entry->stats.size = 0;
+    }
+
+    if ((entry->stats.size_rounded + rounded_added - rounded_removed) >= 0) {
+      entry->stats.size_rounded += rounded_added - rounded_removed;
+    } else {
+      entry->stats.size_rounded = 0;
+    }
+
+    if ((entry->stats.num_objects + objs_delta) >= 0) {
+      entry->stats.num_objects += objs_delta;
+    } else {
+      entry->stats.num_objects = 0;
+    }
 
     return true;
   }


### PR DESCRIPTION
With RGWs configured in a load balancer, there is a possibility of
having the cached values going unbound, when PUT/DELETE operations
do not land up on the same RGW. To avoid such cases, make sure the
decrement of stats happen only when the cached values are sane.

Fixes: http://tracker.ceph.com/issues/20661
Signed-off-by: Pavan Rallabhandi <PRallabhandi@walmartlabs.com>