### PR TITLE
mds: add to get version in the mds_commands

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -765,8 +765,7 @@ int MDSDaemon::_handle_command(
     // We will send response before executing
     ss << "Exiting...";
     *run_later = new SuicideLater(this);
-  }
-  else if (prefix == "respawn") {
+  } else if (prefix == "respawn") {
     // We will send response before executing
     ss << "Respawning...";
     *run_later = new RespawnLater(this);


### PR DESCRIPTION
Sometime we need to determine whether the mds/mon/osd RPM package
is correct, by use the command "ceph tell mds/mon/osd.* version"
is good way.but mds does not support, so I add it.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>