### PR TITLE
rbd: 'image-meta remove' for missing key does not return error

### DIFF
--- a/src/librbd/Operations.cc
+++ b/src/librbd/Operations.cc
@@ -1428,6 +1428,11 @@ int Operations<I>::metadata_remove(const std::string &key) {
     return -EROFS;
   }
 
+  std::string value;
+  r = cls_client::metadata_get(&m_image_ctx.md_ctx, m_image_ctx.header_oid, key, &value);
+  if(r < 0)
+    return r;
+
   {
     RWLock::RLocker owner_lock(m_image_ctx.owner_lock);
     C_SaferCond metadata_ctx;

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -4336,7 +4336,7 @@ TEST_F(TestLibRBD, Metadata)
   ASSERT_STREQ(vals + strlen(vals) + 1, "value2");
 
   ASSERT_EQ(0, rbd_metadata_remove(image1, "key1"));
-  ASSERT_EQ(0, rbd_metadata_remove(image1, "key3"));
+  ASSERT_EQ(-ENOENT, rbd_metadata_remove(image1, "key3"));
   value_len = sizeof(value);
   ASSERT_EQ(-ENOENT, rbd_metadata_get(image1, "key3", value, &value_len));
   ASSERT_EQ(0, rbd_metadata_list(image1, "", 0, keys, &keys_len, vals,
@@ -4502,7 +4502,7 @@ TEST_F(TestLibRBD, MetadataPP)
 
   pairs.clear();
   ASSERT_EQ(0, image1.metadata_remove("key1"));
-  ASSERT_EQ(0, image1.metadata_remove("key3"));
+  ASSERT_EQ(-ENOENT, image1.metadata_remove("key3"));
   ASSERT_TRUE(image1.metadata_get("key3", &value) < 0);
   ASSERT_EQ(0, image1.metadata_list("", 0, &pairs));
   ASSERT_EQ(1U, pairs.size());

--- a/src/tools/rbd/action/ImageMeta.cc
+++ b/src/tools/rbd/action/ImageMeta.cc
@@ -97,9 +97,12 @@ static int do_metadata_set(librbd::Image& image, const char *key,
 static int do_metadata_remove(librbd::Image& image, const char *key)
 {
   int r = image.metadata_remove(key);
-  if (r < 0) {
-    std::cerr << "failed to remove metadata " << key << " of image : "
-              << cpp_strerror(r) << std::endl;
+  if (r == -ENOENT) {
+      std::cerr << "rbd: no existing metadata key " << key << " of image : "
+                << cpp_strerror(r) << std::endl;
+  } else if(r < 0) {
+      std::cerr << "failed to remove metadata " << key << " of image : "
+                << cpp_strerror(r) << std::endl;
   }
   return r;
 }


### PR DESCRIPTION
src/tools/rbd/action/ImageMeta.cc:static int do_metadata_set(librbd::Image& image, const char *key,
'rbd image-meta remove' of missing key does not return error
http://tracker.ceph.com/issues/16990
Signed-off-by: PCzhangPC <pengcheng.zhang@easystack.cn>