### PR TITLE
core: remove startsync

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -384,8 +384,6 @@ public:
       OP_COLL_SETATTRS = 26,  // cid, attrset
       OP_COLL_MOVE =    8,   // newcid, oldcid, oid
 
-      OP_STARTSYNC =    27,  // start a sync
-
       OP_RMATTRS =      28,  // cid, oid
       OP_COLL_RENAME =       29,  // cid, newcid
 
@@ -639,7 +637,6 @@ public:
 
       switch (op->op) {
       case OP_NOP:
-      case OP_STARTSYNC:
         break;
 
       case OP_TOUCH:
@@ -1026,12 +1023,6 @@ private:
     }
 
 public:
-    /// Commence a global file system sync operation.
-    void start_sync() {
-      Op* _op = _get_next_op();
-      _op->op = OP_STARTSYNC;
-      data.ops++;
-    }
     /// noop. 'nuf said
     void nop() {
       Op* _op = _get_next_op();

--- a/src/os/Transaction.cc
+++ b/src/os/Transaction.cc
@@ -294,10 +294,6 @@ void ObjectStore::Transaction::dump(ceph::Formatter *f)
       }
       break;
 
-    case Transaction::OP_STARTSYNC:
-      f->dump_string("op_name", "startsync");
-      break;
-
     case Transaction::OP_COLL_RENAME:
       {
 	f->dump_string("op_name", "collection_rename");

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -2939,12 +2939,6 @@ void FileStore::_do_transaction(
       assert(0 == "collection attr methods no longer implemented");
       break;
 
-    case Transaction::OP_STARTSYNC:
-      tracepoint(objectstore, startsync_enter, osr_name);
-      _start_sync();
-      tracepoint(objectstore, startsync_exit);
-      break;
-
     case Transaction::OP_COLL_RENAME:
       {
         r = -EOPNOTSUPP;
@@ -4116,16 +4110,6 @@ void FileStore::sync_entry()
   }
   stop = false;
   lock.Unlock();
-}
-
-void FileStore::_start_sync()
-{
-  if (!journal) {  // don't do a big sync if the journal is on
-    dout(10) << __FUNC__ << dendl;
-    sync_cond.Signal();
-  } else {
-    dout(10) << __FUNC__ << ": - NOOP (journal is on)" << dendl;
-  }
 }
 
 void FileStore::do_force_sync()

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -615,8 +615,6 @@ public:
   int _fgetattrs(int fd, map<string,bufferptr>& aset);
   int _fsetattrs(int fd, map<string, bufferptr> &aset);
 
-  void _start_sync();
-
   void do_force_sync();
   void start_sync(Context *onsafe);
   void sync();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6244,10 +6244,8 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
       break;
 
     case CEPH_OSD_OP_STARTSYNC:
-      tracepoint(osd, do_osd_op_pre_startsync, soid.oid.name.c_str(), soid.snap.val);
       t->nop(soid);
       break;
-
 
       // -- trivial map --
     case CEPH_OSD_OP_TMAPGET:

--- a/src/tracing/objectstore.tp
+++ b/src/tracing/objectstore.tp
@@ -449,19 +449,6 @@ TRACEPOINT_EVENT(objectstore, omap_clear_exit,
     )
 )
 
-TRACEPOINT_EVENT(objectstore, startsync_enter,
-    TP_ARGS(
-        const char *, osr_name),
-    TP_FIELDS(
-        ctf_string(osr_name, osr_name)
-    )
-)
-
-TRACEPOINT_EVENT(objectstore, startsync_exit,
-    TP_ARGS(),
-    TP_FIELDS()
-)
-
 TRACEPOINT_EVENT(objectstore, coll_rmattr_enter,
     TP_ARGS(
         const char *, osr_name),

--- a/src/tracing/osd.tp
+++ b/src/tracing/osd.tp
@@ -605,16 +605,6 @@ TRACEPOINT_EVENT(osd, do_osd_op_pre_append,
     )
 )
 
-TRACEPOINT_EVENT(osd, do_osd_op_pre_startsync,
-    TP_ARGS(
-        const char*, oid,
-        uint64_t, snap),
-    TP_FIELDS(
-        ctf_string(oid, oid)
-        ctf_integer(uint64_t, snap, snap)
-    )
-)
-
 TRACEPOINT_EVENT(osd, do_osd_op_pre_tmapget,
     TP_ARGS(
         const char*, oid,


### PR DESCRIPTION
client is still sending write,startsync which is deprecated long back. Hence cleaning up OP_STARTSYNC

Resolves: http://tracker.ceph.com/issues/20604

Signed-off-by: Amit kumar <amitkuma@redhat.com>