### PR TITLE
mon/MgrMonitor: fix standby addition to mgrmap

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -298,6 +298,8 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
       dout(10) << "new standby " << m->get_gid() << dendl;
       mon->clog->debug() << "Standby manager daemon " << m->get_name()
                          << " started";
+      pending_map.standbys[m->get_gid()] = {m->get_gid(), m->get_name(),
+					    m->get_available_modules()};
       updated = true;
     }
   }


### PR DESCRIPTION
Inadvertantly removed by ba45fba01c96bcae5b55c50a6076bb1e879d58b9

Fixes: http://tracker.ceph.com/issues/20647
Signed-off-by: Sage Weil <sage@redhat.com>