### PR TITLE
rgw: fix rgw hang when do RGWRealmReloader::reload after go SIGHUP

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -11588,16 +11588,16 @@ public:
 int RGWRados::get_bucket_stats_async(RGWBucketInfo& bucket_info, int shard_id, RGWGetBucketStats_CB *ctx)
 {
   int num_aio = 0;
-  RGWGetBucketStatsContext *get_ctx = new RGWGetBucketStatsContext(ctx, bucket_info.num_shards);
+  RGWGetBucketStatsContext *get_ctx = new RGWGetBucketStatsContext(ctx, bucket_info.num_shards ? : 1);
   assert(get_ctx);
   int r = cls_bucket_head_async(bucket_info, shard_id, get_ctx, &num_aio);
-  get_ctx->put();
   if (r < 0) {
     ctx->put();
     if (num_aio) {
       get_ctx->unset_cb();
     }
   }
+  get_ctx->put();
   return r;
 }
 


### PR DESCRIPTION
pendings in RGWGetBucketStatsContext is initialized to zero when rgw_override_bucket_index_max_shards is zero.

so --pendings will got 0xffffffff, which lead async_refcount not put correctly, then the thread handle RGWRealmReloader::reload will hang, then cause request process worker thread of rgw frontend hang(the write lock was held by RGWRealmReloader::reload handle thread, but request process worker thread need to get read lock)

the procedure of quota fetch is a bit tricky and worse, this fix is not perfect, but is better with minimum changes

http://tracker.ceph.com/issues/20686