### PR TITLE
doc: rgw clarify limitations when creating tenant names

### DIFF
--- a/doc/radosgw/multitenancy.rst
+++ b/doc/radosgw/multitenancy.rst
@@ -38,7 +38,9 @@ Create a user testx$tester to be accessed with Swift::
   # radosgw-admin --tenant testx --uid tester --display-name "Test User" --subuser tester:test --key-type swift --access full user create
   # radosgw-admin --subuser 'testx$tester:test' --key-type swift --secret test123
 
-Note that the subuser with explicit tenant had to be quoted in the shell.
+.. note:: The subuser with explicit tenant has to be quoted in the shell.
+
+   Tenant names may contain only alphanumeric characters and underscores.
 
 Accessing Buckets with Explicit Tenants
 =======================================


### PR DESCRIPTION
We only allow alphanumeric and underscore characters in tenant names
according to the validation in `RGWHandler_REST::validate_tenant_name`

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>