### PR TITLE
messages/: always set header.version in encode_payload()

### DIFF
--- a/src/messages/MOSDPGInfo.h
+++ b/src/messages/MOSDPGInfo.h
@@ -58,7 +58,9 @@ public:
   }
 
   void encode_payload(uint64_t features) override {
-    if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+    if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
+    } else {
       header.version = 4;
 
       // for kraken+jewel only

--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -82,6 +82,7 @@ public:
     ::encode(missing, payload);
     ::encode(query_epoch, payload);
     if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
       ::encode(past_intervals, payload);
     } else {
       header.version = 4;

--- a/src/messages/MOSDPGNotify.h
+++ b/src/messages/MOSDPGNotify.h
@@ -58,7 +58,9 @@ public:
   const char *get_type_name() const override { return "PGnot"; }
 
   void encode_payload(uint64_t features) override {
-    if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+    if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
+    } else {
       // for jewel+kraken compat only
       header.version = 5;
 

--- a/src/messages/MOSDPGQuery.h
+++ b/src/messages/MOSDPGQuery.h
@@ -63,7 +63,9 @@ public:
   }
 
   void encode_payload(uint64_t features) override {
-    if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+    if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
+    } else {
       // for kraken/jewel only
       header.version = 3;
       ::encode(epoch, payload);

--- a/src/messages/MOSDPGRemove.h
+++ b/src/messages/MOSDPGRemove.h
@@ -46,7 +46,9 @@ public:
   const char *get_type_name() const override { return "PGrm"; }
 
   void encode_payload(uint64_t features) override {
-    if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+    if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
+    } else {
       // for jewel+kraken
       header.version = 2;
       ::encode(epoch, payload);

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -102,7 +102,10 @@ public:
     ::encode(map_epoch, payload);
     
     // with luminous, we drop peer_as_of_epoch and peer_stat
-    if (!HAVE_FEATURE(features, SERVER_LUMINOUS)) { 
+    if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
+      ::encode(op, payload);
+    } else {
       epoch_t dummy_epoch = {};
       osd_peer_stat_t dummy_stat = {};
       header.version = 3;
@@ -110,8 +113,6 @@ public:
       ::encode(dummy_epoch, payload);
       ::encode(op, payload);   
       ::encode(dummy_stat, payload);
-    } else {
-      ::encode(op, payload);
     }
     ::encode(stamp, payload);
     size_t s = 0;

--- a/src/messages/MOSDRepOp.h
+++ b/src/messages/MOSDRepOp.h
@@ -115,6 +115,7 @@ public:
   void encode_payload(uint64_t features) override {
     ::encode(map_epoch, payload);
     if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
       ::encode(min_epoch, payload);
       encode_trace(payload, features);
     } else {

--- a/src/messages/MOSDRepOpReply.h
+++ b/src/messages/MOSDRepOpReply.h
@@ -86,6 +86,7 @@ public:
   void encode_payload(uint64_t features) override {
     ::encode(map_epoch, payload);
     if (HAVE_FEATURE(features, SERVER_LUMINOUS)) {
+      header.version = HEAD_VERSION;
       ::encode(min_epoch, payload);
       encode_trace(payload, features);
     } else {


### PR DESCRIPTION
we encode the payload w/o the writelock even can_write == NOWRITE, if
the message "can_fast_prepare". in that case, the "feature" of the
connection is 0, as no handshake happens yet. so the header.version is
always set to a version compatible with pre-luminous. but when the
message is re-encoded when the connection is re-established with feature
with luminous, the header.version is not set back to HEADER_VERSION.
that's why the message's encoding is not consistent with header.version
sometimes.

in this change, we always set the header.version in encode_payload(), so
it's consistent even after connection reset and message re-encoding.

Fixes: http://tracker.ceph.com/issues/19939
Signed-off-by: Kefu Chai <kchai@redhat.com>