### PR TITLE
rgw: fix asctime when logging in rgw_lc

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -662,6 +662,14 @@ void rgw_to_iso8601(const real_time& t, string *dest)
   *dest = buf;
 }
 
+
+string rgw_to_asctime(const utime_t& t)
+{
+  stringstream s;
+  t.asctime(s);
+  return s.str();
+}
+
 /*
  * calculate the sha1 value of a given msg and key
  */

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2182,6 +2182,7 @@ extern string rgw_trim_quotes(const string& val);
 
 extern void rgw_to_iso8601(const real_time& t, char *dest, int buf_size);
 extern void rgw_to_iso8601(const real_time& t, string *dest);
+extern std::string rgw_to_asctime(const utime_t& t);
 
 /** Check if the req_state's user has the necessary permissions
  * to do the requested action */

--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -147,10 +147,10 @@ void *RGWLC::LCWorker::entry() {
 
     utime_t end = ceph_clock_now();
     int secs = schedule_next_start_time(start, end);
-    time_t next_time = end + secs;
-    char buf[30];
-    char *nt = ctime_r(&next_time, buf);
-    dout(5) << "schedule life cycle next start time: " << nt <<dendl;
+    utime_t next;
+    next.set_from_double(end + secs);
+
+    dout(5) << "schedule life cycle next start time: " << rgw_to_asctime(next) <<dendl;
 
     lock.Lock();
     cond.WaitInterval(lock, utime_t(secs, 0));

--- a/src/rgw/rgw_loadgen.cc
+++ b/src/rgw/rgw_loadgen.cc
@@ -13,9 +13,7 @@
 
 void RGWLoadGenRequestEnv::set_date(utime_t& tm)
 {
-  stringstream s;
-  tm.asctime(s);
-  date_str = s.str();
+  date_str = rgw_to_asctime(tm);
 }
 
 int RGWLoadGenRequestEnv::sign(RGWAccessKey& access_key)

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -99,10 +99,7 @@ int RGWRESTSimpleRequest::receive_header(void *ptr, size_t len)
 
 static void get_new_date_str(string& date_str)
 {
-  utime_t tm = ceph_clock_now();
-  stringstream s;
-  tm.asctime(s);
-  date_str = s.str();
+  date_str = rgw_to_asctime(ceph_clock_now());
 }
 
 int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const char *resource)


### PR DESCRIPTION
Since `ctime_r` adds a newline we would end up getting an empty newline in the logs. Since `utime_t` already has a method for printing asctime without the newline use that. Introduces a new helper function `rgw_to_asctime` which prints the asctime representation of `utime_t`