### PR TITLE
do_cmake.sh: fix syntax for /bin/sh (doesn't have +=)

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -8,7 +8,7 @@ fi
 ARGS=""
 if which ccache ; then
     echo "enabling ccache"
-    ARGS+="-DWITH_CCACHE=ON"
+    ARGS="$ARGS -DWITH_CCACHE=ON"
 fi
 
 mkdir build


### PR DESCRIPTION
Signed-off-by: Dan Mick <dan.mick@redhat.com>