### PR TITLE
common: CLI result should have a line break when only --format works

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -237,7 +237,7 @@ void JSONFormatter::close_section()
   }
   m_ss << (entry.is_array ? ']' : '}');
   m_stack.pop_back();
-  if (m_pretty && m_stack.empty())
+  if (m_stack.empty())
     m_ss << "\n";
 }
 
@@ -399,7 +399,7 @@ void XMLFormatter::close_section()
   m_sections.pop_back();
   print_spaces();
   m_ss << "</" << section << ">";
-  if (m_pretty)
+  if (m_sections.empty())
     m_ss << "\n";
 }
 

--- a/src/test/common/test_context.cc
+++ b/src/test/common/test_context.cc
@@ -42,7 +42,7 @@ TEST(CephContext, do_command)
     bufferlist out;
     cct->do_command("config get", cmdmap, "xml", &out);
     string s(out.c_str(), out.length());
-    EXPECT_EQ("<config_get><key>" + value + "</key></config_get>", s);
+    EXPECT_EQ("<config_get><key>" + value + "</key></config_get>\n", s);
   }
 
   {
@@ -57,7 +57,7 @@ TEST(CephContext, do_command)
     cct->do_command("config diff get", cmdmap, "xml", &out);
     string s(out.c_str(), out.length());
     EXPECT_EQ("<config_diff_get><diff><current><key>" + value + 
-      "</key></current><defaults><key></key></defaults></diff></config_diff_get>", s);
+      "</key></current><defaults><key></key></defaults></diff></config_diff_get>\n", s);
   }
   cct->put();
 }

--- a/src/test/formatter.cc
+++ b/src/test/formatter.cc
@@ -31,7 +31,7 @@ TEST(JsonFormatter, Simple1) {
   fmt.dump_int("c", 3);
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "{\"a\":1,\"b\":2,\"c\":3}");
+  ASSERT_EQ(oss.str(), "{\"a\":1,\"b\":2,\"c\":3}\n");
 }
 
 TEST(JsonFormatter, Simple2) {
@@ -48,7 +48,7 @@ TEST(JsonFormatter, Simple2) {
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "{\"bar\":{\"int\":263882790666240,\
 \"unsigned\":9223372036854775809,\"float\":1.234000},\
-\"string\":\"str\"}");
+\"string\":\"str\"}\n");
 }
 
 TEST(JsonFormatter, Empty) {
@@ -67,7 +67,7 @@ TEST(XmlFormatter, Simple1) {
   fmt.dump_int("c", 3);
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><a>1</a><b>2</b><c>3</c></foo>");
+  ASSERT_EQ(oss.str(), "<foo><a>1</a><b>2</b><c>3</c></foo>\n");
 }
 
 TEST(XmlFormatter, Simple2) {
@@ -87,7 +87,7 @@ TEST(XmlFormatter, Simple2) {
 <unsigned>9223372036854775809</unsigned>\
 <float>1.234</float>\
 </bar><string>str</string>\
-</foo>");
+</foo>\n");
 }
 
 TEST(XmlFormatter, Empty) {
@@ -113,7 +113,7 @@ TEST(XmlFormatter, DumpStream2) {
   fmt.dump_stream("blah") << "hithere";
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><blah>hithere</blah></foo>");
+  ASSERT_EQ(oss.str(), "<foo><blah>hithere</blah></foo>\n");
 }
 
 TEST(XmlFormatter, DumpStream3) {
@@ -125,7 +125,7 @@ TEST(XmlFormatter, DumpStream3) {
   fmt.dump_float("pi", 3.14);
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><blah>hithere</blah><pi>3.14</pi></foo>");
+  ASSERT_EQ(oss.str(), "<foo><blah>hithere</blah><pi>3.14</pi></foo>\n");
 }
 
 TEST(XmlFormatter, DTD) {
@@ -139,7 +139,7 @@ TEST(XmlFormatter, DTD) {
   fmt.close_section();
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    "<foo><blah>hithere</blah><pi>3.14</pi></foo>");
+    "<foo><blah>hithere</blah><pi>3.14</pi></foo>\n");
 }
 
 TEST(XmlFormatter, Clear) {
@@ -153,7 +153,7 @@ TEST(XmlFormatter, Clear) {
   fmt.close_section();
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    "<foo><blah>hithere</blah><pi>3.14</pi></foo>");
+    "<foo><blah>hithere</blah><pi>3.14</pi></foo>\n");
 
   ostringstream oss2;
   fmt.flush(oss2);
@@ -178,7 +178,7 @@ TEST(XmlFormatter, NamespaceTest) {
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     "<foo xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-    "<blah>hithere</blah><pi>3.14</pi></foo>");
+    "<blah>hithere</blah><pi>3.14</pi></foo>\n");
 }
 
 TEST(XmlFormatter, DumpFormatNameSpaceTest) {
@@ -209,7 +209,7 @@ TEST(HtmlFormatter, Simple1) {
   fmt.dump_int("c", 3);
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><li>a: 1</li><li>b: 2</li><li>c: 3</li></foo>");
+  ASSERT_EQ(oss.str(), "<foo><li>a: 1</li><li>b: 2</li><li>c: 3</li></foo>\n");
 }
 
 TEST(HtmlFormatter, Simple2) {
@@ -229,7 +229,7 @@ TEST(HtmlFormatter, Simple2) {
 <li>unsigned: 9223372036854775809</li>\
 <li>float: 1.234</li>\
 </bar><li>string: str</li>\
-</foo>");
+</foo>\n");
 }
 
 TEST(HtmlFormatter, Empty) {
@@ -255,7 +255,7 @@ TEST(HtmlFormatter, DumpStream2) {
   fmt.dump_stream("blah") << "hithere";
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><li>blah: hithere</li></foo>");
+  ASSERT_EQ(oss.str(), "<foo><li>blah: hithere</li></foo>\n");
 }
 
 TEST(HtmlFormatter, DumpStream3) {
@@ -267,7 +267,7 @@ TEST(HtmlFormatter, DumpStream3) {
   fmt.dump_float("pi", 3.14);
   fmt.close_section();
   fmt.flush(oss);
-  ASSERT_EQ(oss.str(), "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>");
+  ASSERT_EQ(oss.str(), "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>\n");
 }
 
 TEST(HtmlFormatter, DTD) {
@@ -281,7 +281,7 @@ TEST(HtmlFormatter, DTD) {
   fmt.close_section();
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>");
+    "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>\n");
 }
 
 TEST(HtmlFormatter, Clear) {
@@ -295,7 +295,7 @@ TEST(HtmlFormatter, Clear) {
   fmt.close_section();
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-    "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>");
+    "<foo><li>blah: hithere</li><li>pi: 3.14</li></foo>\n");
 
   ostringstream oss2;
   fmt.flush(oss2);
@@ -320,7 +320,7 @@ TEST(HtmlFormatter, NamespaceTest) {
   fmt.flush(oss);
   ASSERT_EQ(oss.str(), "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
     "<foo xmlns=\"http://s3.amazonaws.com/doc/2006-03-01/\">"
-    "<li>blah: hithere</li><li>pi: 3.14</li></foo>");
+    "<li>blah: hithere</li><li>pi: 3.14</li></foo>\n");
 }
 
 TEST(HtmlFormatter, DumpFormatNameSpaceTest) {

--- a/src/test/perf_counters.cc
+++ b/src/test/perf_counters.cc
@@ -103,24 +103,24 @@ TEST(PerfCounters, SinglePerfCounters) {
   std::string msg;
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":0,"
-	    "\"element2\":0.000000000,\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}"), msg);
+	    "\"element2\":0.000000000,\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}\n"), msg);
   fake_pf->inc(TEST_PERFCOUNTERS1_ELEMENT_1);
   fake_pf->tset(TEST_PERFCOUNTERS1_ELEMENT_2, utime_t(0, 500000000));
   fake_pf->tinc(TEST_PERFCOUNTERS1_ELEMENT_3, utime_t(100, 0));
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":1,"
-	    "\"element2\":0.500000000,\"element3\":{\"avgcount\":1,\"sum\":100.000000000,\"avgtime\":100.000000000}}}"), msg);
+	    "\"element2\":0.500000000,\"element3\":{\"avgcount\":1,\"sum\":100.000000000,\"avgtime\":100.000000000}}}\n"), msg);
   fake_pf->tinc(TEST_PERFCOUNTERS1_ELEMENT_3, utime_t());
   fake_pf->tinc(TEST_PERFCOUNTERS1_ELEMENT_3, utime_t(20,0));
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":1,\"element2\":0.500000000,"
-	    "\"element3\":{\"avgcount\":3,\"sum\":120.000000000,\"avgtime\":40.000000000}}}"), msg);
+	    "\"element3\":{\"avgcount\":3,\"sum\":120.000000000,\"avgtime\":40.000000000}}}\n"), msg);
 
   fake_pf->reset();
   msg.clear();
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":1,"
-	    "\"element2\":0.000000000,\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}"), msg);
+	    "\"element2\":0.000000000,\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}\n"), msg);
 
 }
 
@@ -152,40 +152,40 @@ TEST(PerfCounters, MultiplePerfCounters) {
 
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":0,\"element2\":0.000000000,\"element3\":"
-	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}"), msg);
+	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}\n"), msg);
 
   fake_pf1->inc(TEST_PERFCOUNTERS1_ELEMENT_1);
   fake_pf1->inc(TEST_PERFCOUNTERS1_ELEMENT_1, 5);
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":6,\"element2\":0.000000000,\"element3\":"
-	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}"), msg);
+	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}\n"), msg);
 
   coll->reset(string("test_perfcounter_1"));
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":6,\"element2\":0.000000000,\"element3\":"
-	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}"), msg);
+	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}\n"), msg);
 
   fake_pf1->inc(TEST_PERFCOUNTERS1_ELEMENT_1);
   fake_pf1->inc(TEST_PERFCOUNTERS1_ELEMENT_1, 6);
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":13,\"element2\":0.000000000,\"element3\":"
-	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}"), msg);
+	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}\n"), msg);
 
   coll->reset(string("all"));
   msg.clear();
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":13,\"element2\":0.000000000,\"element3\":"
-	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}"), msg);
+	    "{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}},\"test_perfcounter_2\":{\"foo\":0,\"bar\":0.000000000}}\n"), msg);
 
   coll->remove(fake_pf2);
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
   ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":13,\"element2\":0.000000000,"
-	    "\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}"), msg);
+	    "\"element3\":{\"avgcount\":0,\"sum\":0.000000000,\"avgtime\":0.000000000}}}\n"), msg);
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf schema\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":{\"type\":2,\"metric_type\":\"gauge\",\"value_type\":\"integer\",\"description\":\"\",\"nick\":\"\"},\"element2\":{\"type\":1,\"metric_type\":\"gauge\",\"value_type\":\"real\",\"description\":\"\",\"nick\":\"\"},\"element3\":{\"type\":5,\"metric_type\":\"gauge\",\"value_type\":\"real-integer-pair\",\"description\":\"\",\"nick\":\"\"}}}"), msg);
+  ASSERT_EQ(sd("{\"test_perfcounter_1\":{\"element1\":{\"type\":2,\"metric_type\":\"gauge\",\"value_type\":\"integer\",\"description\":\"\",\"nick\":\"\"},\"element2\":{\"type\":1,\"metric_type\":\"gauge\",\"value_type\":\"real\",\"description\":\"\",\"nick\":\"\"},\"element3\":{\"type\":5,\"metric_type\":\"gauge\",\"value_type\":\"real-integer-pair\",\"description\":\"\",\"nick\":\"\"}}}\n"), msg);
   coll->clear();
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ("{}", msg);
+  ASSERT_EQ("{}\n", msg);
 }
 
 TEST(PerfCounters, CephContextPerfCounters) {
@@ -195,7 +195,7 @@ TEST(PerfCounters, CephContextPerfCounters) {
   std::string msg;
 
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf dump\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"cct\":{\"total_workers\":0,\"unhealthy_workers\":0}}"), msg);
+  ASSERT_EQ(sd("{\"cct\":{\"total_workers\":0,\"unhealthy_workers\":0}}\n"), msg);
 
   // Restore to avoid impact to other test cases
   g_ceph_context->disable_perf_counter();
@@ -210,12 +210,12 @@ TEST(PerfCounters, ResetPerfCounters) {
   coll->add(fake_pf1);
 
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf reset\", \"var\": \"all\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"success\":\"perf reset all\"}"), msg);
+  ASSERT_EQ(sd("{\"success\":\"perf reset all\"}\n"), msg);
 
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf reset\", \"var\": \"test_perfcounter_1\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"success\":\"perf reset test_perfcounter_1\"}"), msg);
+  ASSERT_EQ(sd("{\"success\":\"perf reset test_perfcounter_1\"}\n"), msg);
 
   coll->clear();
   ASSERT_EQ("", client.do_request("{ \"prefix\": \"perf reset\", \"var\": \"test_perfcounter_1\", \"format\": \"json\" }", &msg));
-  ASSERT_EQ(sd("{\"error\":\"Not find: test_perfcounter_1\"}"), msg);
+  ASSERT_EQ(sd("{\"error\":\"Not find: test_perfcounter_1\"}\n"), msg);
 }


### PR DESCRIPTION
```
[root@s248 ~]# rbd ls --format json
["i1","i1_s1_c1"][root@s248 ~]# 
[root@s248 ~]#
 ```
In rbd/Utils: utils::get_formatter, if only `--format` works, the value of `m_pretty` is `False` and code `m_ss << "\n";` is unreachable.
And, some other CLI commands also have a similar situation as below: (this pr seems can fix them as well)
```
[root@s248 ceph]# ceph daemon osd.0 version
{"version":"12.1.1-686-g0a24a99","release":"luminous","release_type":"rc"}[root@s248 ceph]# 
[root@s248 ceph]# ceph daemon osd.0 git_version
{"git_version":"0a24a992f497e9827866670c9dadfc81ba8459c3"}[root@s248 ceph]#
```
Signed-off-by: songweibin <song.weibin@zte.com.cn>