### PR TITLE
cephtool/test.sh: Only delete a test pool when no longer needed.

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1984,11 +1984,6 @@ function test_mon_osd_pool_set()
   expect_false ceph osd pool set $TEST_POOL_GETSET hashpspool 1
   ceph osd pool set $TEST_POOL_GETSET hashpspool 1 --yes-i-really-mean-it
 
-  ceph osd pool set $TEST_POOL_GETSET nodelete 1
-  expect_false ceph osd pool delete $TEST_POOL_GETSET $TEST_POOL_GETSET --yes-i-really-really-mean-it
-  ceph osd pool set $TEST_POOL_GETSET nodelete 0
-  ceph osd pool delete $TEST_POOL_GETSET $TEST_POOL_GETSET --yes-i-really-really-mean-it
-
   ceph osd pool get rbd crush_rule | grep 'crush_rule: '
 
   ceph osd pool get $TEST_POOL_GETSET compression_mode | expect_false grep '.'
@@ -2024,6 +2019,12 @@ function test_mon_osd_pool_set()
       ceph osd pool set $TEST_POOL_GETSET $size 0
       ceph osd pool get $TEST_POOL_GETSET $size | expect_false grep '.'
   done
+
+  ceph osd pool set $TEST_POOL_GETSET nodelete 1
+  expect_false ceph osd pool delete $TEST_POOL_GETSET $TEST_POOL_GETSET --yes-i-really-really-mean-it
+  ceph osd pool set $TEST_POOL_GETSET nodelete 0
+  ceph osd pool delete $TEST_POOL_GETSET $TEST_POOL_GETSET --yes-i-really-really-mean-it
+
 }
 
 function test_mon_osd_tiered_pool_set()


### PR DESCRIPTION
the pool_getset pool is deleted before all tests on it are complete
```
4: /home/jenkins/workspace/ceph-master/qa/workunits/cephtool/test.sh:1990: test_mon_osd_pool_set:  ceph osd pool delete pool_get
set pool_getset --yes-i-really-really-mean-it
4: pool 'pool_getset' removed
4: /home/jenkins/workspace/ceph-master/qa/workunits/cephtool/test.sh:1992: test_mon_osd_pool_set:  ceph osd pool get rbd crush_r
ule
4: /home/jenkins/workspace/ceph-master/qa/workunits/cephtool/test.sh:1992: test_mon_osd_pool_set:  grep 'crush_rule: '
4: crush_rule: replicated_rule
4: /home/jenkins/workspace/ceph-master/qa/workunits/cephtool/test.sh:1994: test_mon_osd_pool_set:  ceph -f json osd pool get poo
l_getset compression_mode
4: Error ENOENT: unrecognized pool 'pool_getset'
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>