### PR TITLE
test: create asok files in a temp directory under $TMPDIR

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -14,9 +14,9 @@ function get_admin_socket()
 {
   local client=$1
 
-  if test -n "$CEPH_OUT_DIR";
+  if test -n "$CEPH_ASOK_DIR";
   then
-    echo $CEPH_OUT_DIR/$client.asok
+    echo $(get_asok_dir)/$client.asok
   else
     local cluster=$(echo $CEPH_ARGS | sed  -r 's/.*--cluster[[:blank:]]*([[:alnum:]]*).*/\1/')
     echo "/var/run/ceph/$cluster-$client.asok"

--- a/run-make-check.sh
+++ b/run-make-check.sh
@@ -71,7 +71,10 @@ function run() {
     $DRY_RUN ./do_cmake.sh $@ || return 1
     $DRY_RUN cd build
     $DRY_RUN make $BUILD_MAKEOPTS tests || return 1
-    $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure || return 1
+    if ! $DRY_RUN ctest $CHECK_MAKEOPTS --output-on-failure; then
+        rm -f ${TMPDIR:-/tmp}/ceph-asok.*
+        return 1
+    fi
 }
 
 function main() {

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -781,7 +781,8 @@ def main():
             i = sys.argv.index("injectargs")
             sys.argv = sys.argv[:i] + ceph_args.split() + sys.argv[i:]
         else:
-            sys.argv.extend(ceph_args.split())
+            sys.argv.extend([arg for arg in ceph_args.split()
+                             if '--admin-socket' not in arg])
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:

--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -10,6 +10,7 @@ elif [ -e $script_root/../build/CMakeCache.txt ]; then
     cd $script_root/../build
     script_root=$PWD
 fi
+ceph_bin=$script_root/bin
 vstart_path=`dirname $0`
 
 [ "$#" -lt 2 ] && echo "usage: $0 <name> <port> [params...]" && exit 1
@@ -21,7 +22,7 @@ shift 2
 
 run_root=$script_root/run/$name
 pidfile=$run_root/out/radosgw.${port}.pid
-asokfile=$run_root/out/radosgw.${port}.asok
+asokfile=$($ceph_bin/ceph-conf --show-config-value admin_socket --name radosgw.${port})
 logfile=$run_root/out/radosgw.${port}.log
 
 $vstart_path/mstop.sh $name radosgw $port

--- a/src/stop.sh
+++ b/src/stop.sh
@@ -19,8 +19,6 @@
 test -d dev/osd0/. && test -e dev/sudo && SUDO="sudo"
 
 if [ -e CMakeCache.txt ]; then
-  [ -z "$CEPH_BIN" ] && CEPH_BIN=src
-else
   [ -z "$CEPH_BIN" ] && CEPH_BIN=bin
 fi
 
@@ -104,6 +102,8 @@ if [ $stop_all -eq 1 ]; then
     pkill -u $MYUID -f valgrind.bin.\*ceph-mon
     $SUDO pkill -u $MYUID -f valgrind.bin.\*ceph-osd
     pkill -u $MYUID -f valgrind.bin.\*ceph-mds
+    asok_dir=`dirname $("${CEPH_BIN}"/ceph-conf --show-config-value admin_socket)`
+    rm -rf "${asok_dir}"
 else
     [ $stop_mon -eq 1 ] && do_killall ceph-mon
     [ $stop_mds -eq 1 ] && do_killall ceph-mds

--- a/src/test/erasure-code/test-erasure-code-plugins.sh
+++ b/src/test/erasure-code/test-erasure-code-plugins.sh
@@ -44,9 +44,9 @@ function TEST_preload_warning() {
         setup $dir || return 1
         run_mon $dir a --osd_erasure_code_plugins="${plugin}" || return 1 
 	run_mgr $dir x || return 1
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
         run_osd $dir 0 --osd_erasure_code_plugins="${plugin}" || return 1 
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
         grep "WARNING: osd_erasure_code_plugins contains plugin ${plugin}" $dir/mon.a.log || return 1
         grep "WARNING: osd_erasure_code_plugins contains plugin ${plugin}" $dir/osd.0.log || return 1
         teardown $dir || return 1
@@ -61,9 +61,9 @@ function TEST_preload_no_warning() {
         setup $dir || return 1
         run_mon $dir a --osd_erasure_code_plugins="${plugin}" || return 1 
 	run_mgr $dir x || return 1
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
         run_osd $dir 0 --osd_erasure_code_plugins="${plugin}" || return 1 
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
         ! grep "WARNING: osd_erasure_code_plugins contains plugin" $dir/mon.a.log || return 1
         ! grep "WARNING: osd_erasure_code_plugins contains plugin" $dir/osd.0.log || return 1
         teardown $dir || return 1
@@ -77,10 +77,10 @@ function TEST_preload_no_warning_default() {
 
     setup $dir || return 1
     run_mon $dir a || return 1 
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     run_mgr $dir x || return 1
     run_osd $dir 0 || return 1 
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     ! grep "WARNING: osd_erasure_code_plugins" $dir/mon.a.log || return 1
     ! grep "WARNING: osd_erasure_code_plugins" $dir/osd.0.log || return 1
     teardown $dir || return 1
@@ -101,13 +101,13 @@ function TEST_ec_profile_warning() {
 
     for plugin in ${legacy_jerasure_plugins[*]}; do
         ceph osd erasure-code-profile set prof-${plugin} crush-failure-domain=osd technique=reed_sol_van plugin=${plugin} || return 1
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
         grep "WARNING: erasure coding profile prof-${plugin} uses plugin ${plugin}" $dir/mon.a.log || return 1
     done
 
     for plugin in ${legacy_shec_plugins[*]}; do
         ceph osd erasure-code-profile set prof-${plugin} crush-failure-domain=osd plugin=${plugin} || return 1
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
         grep "WARNING: erasure coding profile prof-${plugin} uses plugin ${plugin}" $dir/mon.a.log || return 1
     done
 

--- a/src/test/erasure-code/test-erasure-code.sh
+++ b/src/test/erasure-code/test-erasure-code.sh
@@ -32,14 +32,14 @@ function run() {
     run_mon $dir a || return 1
     run_mgr $dir x || return 1
     # check that erasure code plugins are preloaded
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep 'load: jerasure.*lrc' $dir/mon.a.log || return 1
     for id in $(seq 0 10) ; do
         run_osd $dir $id || return 1
     done
     wait_for_clean || return 1
     # check that erasure code plugins are preloaded
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'load: jerasure.*lrc' $dir/osd.0.log || return 1
     create_erasure_coded_pool ecpool || return 1
 

--- a/src/test/erasure-code/test-erasure-eio.sh
+++ b/src/test/erasure-code/test-erasure-eio.sh
@@ -34,7 +34,7 @@ function run() {
         run_mon $dir a || return 1
 	run_mgr $dir x || return 1
         # check that erasure code plugins are preloaded
-        CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+        CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
         grep 'load: jerasure.*lrc' $dir/mon.a.log || return 1
         $func $dir || return 1
         teardown $dir || return 1
@@ -48,7 +48,7 @@ function setup_osds() {
     wait_for_clean || return 1
 
     # check that erasure code plugins are preloaded
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'load: jerasure.*lrc' $dir/osd.0.log || return 1
 }
 
@@ -153,7 +153,7 @@ function inject_eio() {
     local -a initial_osds=($(get_osds $poolname $objname))
     local osd_id=${initial_osds[$shard_id]}
     set_config osd $osd_id filestore_debug_inject_read_err true || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.$osd_id.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.$osd_id) \
              injectdataerr $poolname $objname $shard_id || return 1
 }
 

--- a/src/test/mon/mon-handle-forward.sh
+++ b/src/test/mon/mon-handle-forward.sh
@@ -36,19 +36,19 @@ function run() {
 
     timeout 360 ceph --mon-host $MONA mon stat || return 1
     # check that MONB is indeed a peon
-    ceph --admin-daemon $dir/ceph-mon.b.asok mon_status |
+    ceph --admin-daemon $(get_asok_path mon.b) mon_status |
        grep '"peon"' || return 1
     # when the leader ( MONA ) is used, there is no message forwarding
     ceph --mon-host $MONA osd pool create POOL1 12 
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/a/mon.a.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.b.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'mon_command(.*"POOL1"' $dir/mon.b.log && return 1
     # when the peon ( MONB ) is used, the message is forwarded to the leader
     ceph --mon-host $MONB osd pool create POOL2 12
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.b.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.b) log flush || return 1
     grep 'forward_request.*mon_command(.*"POOL2"' $dir/mon.b.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep ' forward(mon_command(.*"POOL2"' $dir/mon.a.log
     # forwarded messages must retain features from the original connection
     features=$(sed -n -e 's|.*127.0.0.1:0.*accept features \([0-9][0-9]*\)|\1|p' < \

--- a/src/test/mon/osd-crush.sh
+++ b/src/test/mon/osd-crush.sh
@@ -114,7 +114,7 @@ function TEST_crush_rule_create_erasure() {
     ceph osd erasure-code-profile rm default || return 1
     ! ceph osd erasure-code-profile ls | grep default || return 1
     ceph osd crush rule create-erasure $ruleset || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-mon.a.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path mon.a) log flush || return 1
     grep 'profile set default' $dir/mon.a.log || return 1
     ceph osd erasure-code-profile ls | grep default || return 1
     ceph osd crush rule rm $ruleset || return 1

--- a/src/test/osd/osd-config.sh
+++ b/src/test/osd/osd-config.sh
@@ -49,7 +49,7 @@ function TEST_config_init() {
         --osd-map-cache-size $cache \
         --osd-pg-epoch-persisted-max-stale $stale \
         || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     grep 'is not > osd_pg_epoch_persisted_max_stale' $dir/osd.0.log || return 1
 }
@@ -73,10 +73,10 @@ function TEST_config_track() {
     ! grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     local cache=$(($osd_map_max_advance / 2))
     ceph tell osd.0 injectargs "--osd-map-cache-size $cache" || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     rm $dir/osd.0.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log reopen || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log reopen || return 1
 
     #
     # reset cache_size to the default and assert that it does not trigger the warning
@@ -84,10 +84,10 @@ function TEST_config_track() {
     ! grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     local cache=$osd_map_cache_size
     ceph tell osd.0 injectargs "--osd-map-cache-size $cache" || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     ! grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     rm $dir/osd.0.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log reopen || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log reopen || return 1
 
     #
     # increase the osd_map_max_advance above the default cache_size
@@ -95,10 +95,10 @@ function TEST_config_track() {
     ! grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     local advance=$(($osd_map_cache_size * 2))
     ceph tell osd.0 injectargs "--osd-map-max-advance $advance" || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'is not > osd_map_max_advance' $dir/osd.0.log || return 1
     rm $dir/osd.0.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log reopen || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log reopen || return 1
 
     #
     # increase the osd_pg_epoch_persisted_max_stale above the default cache_size
@@ -106,10 +106,10 @@ function TEST_config_track() {
     ! grep 'is not > osd_pg_epoch_persisted_max_stale' $dir/osd.0.log || return 1
     local stale=$(($osd_map_cache_size * 2))
     ceph tell osd.0 injectargs "--osd-pg-epoch-persisted-max-stale $stale" || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log flush || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log flush || return 1
     grep 'is not > osd_pg_epoch_persisted_max_stale' $dir/osd.0.log || return 1
     rm $dir/osd.0.log
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok log reopen || return 1
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) log reopen || return 1
 }
 
 main osd-config "$@"

--- a/src/test/osd/osd-scrub-repair.sh
+++ b/src/test/osd/osd-scrub-repair.sh
@@ -494,9 +494,9 @@ function TEST_corrupt_scrub_replicated() {
     local pg=$(get_pg $poolname ROBJ0)
 
     # Compute an old omap digest and save oi
-    CEPH_ARGS='' ceph daemon $dir//ceph-osd.0.asok \
+    CEPH_ARGS='' ceph daemon $(get_asok_path osd.0) \
         config set osd_deep_scrub_update_digest_min_age 0
-    CEPH_ARGS='' ceph daemon $dir//ceph-osd.1.asok \
+    CEPH_ARGS='' ceph daemon $(get_asok_path osd.1) \
         config set osd_deep_scrub_update_digest_min_age 0
     pg_deep_scrub $pg
 
@@ -593,13 +593,13 @@ function TEST_corrupt_scrub_replicated() {
 
     set_config osd 0 filestore_debug_inject_read_err true || return 1
     set_config osd 1 filestore_debug_inject_read_err true || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.1.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.1) \
              injectdataerr $poolname ROBJ11 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
              injectmdataerr $poolname ROBJ12 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
              injectmdataerr $poolname ROBJ13 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.1.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.1) \
              injectdataerr $poolname ROBJ13 || return 1
 
     pg_scrub $pg
@@ -965,13 +965,13 @@ EOF
 
     set_config osd 0 filestore_debug_inject_read_err true || return 1
     set_config osd 1 filestore_debug_inject_read_err true || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.1.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.1) \
              injectdataerr $poolname ROBJ11 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
              injectmdataerr $poolname ROBJ12 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.0.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.0) \
              injectmdataerr $poolname ROBJ13 || return 1
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.1.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.1) \
              injectdataerr $poolname ROBJ13 || return 1
     pg_deep_scrub $pg
 
@@ -2564,7 +2564,7 @@ function TEST_periodic_scrub_replicated() {
 
     local last_scrub=$(get_last_scrub_stamp $pg)
     # Fake a schedule scrub
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.${primary}.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
              trigger_scrub $pg || return 1
     # Wait for schedule regular scrub
     wait_for_scrub $pg "$last_scrub"
@@ -2582,7 +2582,7 @@ function TEST_periodic_scrub_replicated() {
 
     # Fake a schedule scrub
     local last_scrub=$(get_last_scrub_stamp $pg)
-    CEPH_ARGS='' ceph --admin-daemon $dir/ceph-osd.${primary}.asok \
+    CEPH_ARGS='' ceph --admin-daemon $(get_asok_path osd.${primary}) \
              trigger_scrub $pg || return 1
     # Wait for schedule regular scrub
     # to notice scrub and skip it

--- a/src/test/vstart_wrapper.sh
+++ b/src/test/vstart_wrapper.sh
@@ -22,6 +22,7 @@ export CEPH_VSTART_WRAPPER=1
 export CEPH_DIR="${TMPDIR:-$PWD}/td/t-$CEPH_PORT"
 export CEPH_DEV_DIR="$CEPH_DIR/dev"
 export CEPH_OUT_DIR="$CEPH_DIR/out"
+export CEPH_ASOK_DIR="$CEPH_DIR/out"
 
 export MGR_PYTHON_PATH=$CEPH_ROOT/src/pybind/mgr
 


### PR DESCRIPTION
to shorten the pathname of unix domain socket created for admin socket,
so it does not exceed the limit of 107 on GNU/Linux:

* ceph-helper.sh: the temp directory is named ${TMPDIR:-/tmp}/ceph-asok.$$
* vstart.sh: the temp directory is named `mktemp -u -d "${TMPDIR:-/tmp}/ceph-asok.XXXXXX"`

Fixes: http://tracker.ceph.com/issues/16895
Signed-off-by: Kefu Chai <kchai@redhat.com>