### PR TITLE
mon: show destroyed status in tree view; do not auto-out destroyed osds

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1618,12 +1618,16 @@ function test_mon_osd()
   ceph osd tree down
   ceph osd tree in
   ceph osd tree out
+  ceph osd tree destroyed
   ceph osd tree up in
   ceph osd tree up out
   ceph osd tree down in
   ceph osd tree down out
   ceph osd tree out down
   expect_false ceph osd tree up down
+  expect_false ceph osd tree up destroyed
+  expect_false ceph osd tree down destroyed
+  expect_false ceph osd tree up down destroyed
   expect_false ceph osd tree in out
   expect_false ceph osd tree up foo
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -212,6 +212,7 @@ OPTION(mon_osd_adjust_down_out_interval, OPT_BOOL)  // true if we should scale b
 OPTION(mon_osd_auto_mark_in, OPT_BOOL)         // mark any booting osds 'in'
 OPTION(mon_osd_auto_mark_auto_out_in, OPT_BOOL) // mark booting auto-marked-out osds 'in'
 OPTION(mon_osd_auto_mark_new_in, OPT_BOOL)      // mark booting new osds 'in'
+OPTION(mon_osd_destroyed_out_interval, OPT_INT) // seconds
 OPTION(mon_osd_down_out_interval, OPT_INT) // seconds
 OPTION(mon_osd_down_out_subtree_limit, OPT_STR)   // smallest crush unit/type that we will not automatically mark out
 OPTION(mon_osd_min_up_ratio, OPT_DOUBLE)    // min osds required to be up to mark things down

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -907,6 +907,10 @@ std::vector<Option> global_options = {
   .set_default(true)
   .set_description(""),
 
+  Option("mon_osd_destroyed_out_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+  .set_default(600)
+  .set_description(""),
+
   Option("mon_osd_down_out_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
   .set_default(600)
   .set_description(""),

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -460,7 +460,7 @@ COMMAND("osd dump " \
 	"print summary of OSD map", "osd", "r", "cli,rest")
 COMMAND("osd tree " \
 	"name=epoch,type=CephInt,range=0,req=false " \
-	"name=states,type=CephChoices,strings=up|down|in|out,n=N,req=false", \
+	"name=states,type=CephChoices,strings=up|down|in|out|destroyed,n=N,req=false", \
 	"print OSD tree", "osd", "r", "cli,rest")
 COMMAND("osd ls " \
 	"name=epoch,type=CephInt,range=0,req=false", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4137,6 +4137,8 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	  filter |= OSDMap::DUMP_IN;
 	} else if (s == "out") {
 	  filter |= OSDMap::DUMP_OUT;
+	} else if (s == "destroyed") {
+	  filter |= OSDMap::DUMP_DESTROYED;
 	} else {
 	  ss << "unrecognized state '" << s << "'";
 	  r = -EINVAL;
@@ -4144,10 +4146,18 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
 	}
       }
       if ((filter & (OSDMap::DUMP_IN|OSDMap::DUMP_OUT)) ==
-	  (OSDMap::DUMP_IN|OSDMap::DUMP_OUT) ||
-	  (filter & (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) ==
-	  (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) {
-	ss << "cannot specify both up and down or both in and out";
+	  (OSDMap::DUMP_IN|OSDMap::DUMP_OUT)) {
+        ss << "cannot specify both 'in' and 'out'";
+        r = -EINVAL;
+        goto reply;
+      }
+      if (((filter & (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) ==
+	   (OSDMap::DUMP_UP|OSDMap::DUMP_DOWN)) ||
+           ((filter & (OSDMap::DUMP_UP|OSDMap::DUMP_DESTROYED)) ==
+           (OSDMap::DUMP_UP|OSDMap::DUMP_DESTROYED)) ||
+           ((filter & (OSDMap::DUMP_DOWN|OSDMap::DUMP_DESTROYED)) ==
+           (OSDMap::DUMP_DOWN|OSDMap::DUMP_DESTROYED))) {
+	ss << "can specify only one of 'up', 'down' and 'destroyed'";
 	r = -EINVAL;
 	goto reply;
       }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3362,8 +3362,15 @@ void OSDMonitor::tick()
 	  }
 	}
 
-	if (g_conf->mon_osd_down_out_interval > 0 &&
-	    down.sec() >= grace) {
+        bool down_out = !osdmap.is_destroyed(o) &&
+          g_conf->mon_osd_down_out_interval > 0 && down.sec() >= grace;
+        bool destroyed_out = osdmap.is_destroyed(o) &&
+          g_conf->mon_osd_destroyed_out_interval > 0 &&
+        // this is not precise enough as we did not make a note when this osd
+        // was marked as destroyed, but let's not bother with that
+        // complexity for now.
+          down.sec() >= g_conf->mon_osd_destroyed_out_interval;
+        if (down_out || destroyed_out) {
 	  dout(10) << "tick marking osd." << o << " OUT after " << down
 		   << " sec (target " << grace << " = " << orig_grace << " + " << my_grace << ")" << dendl;
 	  pending_inc.new_weight[o] = CEPH_OSD_OUT;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5679,6 +5679,9 @@ void OSD::_preboot(epoch_t oldest, epoch_t newest)
   // if our map within recent history, try to add ourselves to the osdmap.
   if (osdmap->get_epoch() == 0) {
     derr << "waiting for initial osdmap" << dendl;
+  } else if (osdmap->is_destroyed(whoami)) {
+    derr << "osdmap says I am destroyed, exiting" << dendl;
+    exit(0);
   } else if (osdmap->test_flag(CEPH_OSDMAP_NOUP) || osdmap->is_noup(whoami)) {
     derr << "osdmap NOUP flag is set, waiting for it to clear" << dendl;
   } else if (!osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE)) {

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3074,7 +3074,7 @@ public:
     tbl->define_column("CLASS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("WEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("TYPE NAME", TextTable::LEFT, TextTable::LEFT);
-    tbl->define_column("UP/DOWN", TextTable::LEFT, TextTable::RIGHT);
+    tbl->define_column("STATUS", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("REWEIGHT", TextTable::LEFT, TextTable::RIGHT);
     tbl->define_column("PRI-AFF", TextTable::LEFT, TextTable::RIGHT);
 
@@ -3112,7 +3112,15 @@ protected:
 	*tbl << "DNE"
 	     << 0;
       } else {
-	*tbl << (osdmap->is_up(qi.id) ? "up" : "down")
+        string s;
+        if (osdmap->is_up(qi.id)) {
+          s = "up";
+        } else if (osdmap->is_destroyed(qi.id)) {
+          s = "destroyed";
+        } else {
+          s = "down";
+        }
+	*tbl << s
 	     << weightf_t(osdmap->get_weightf(qi.id))
 	     << weightf_t(osdmap->get_primary_affinityf(qi.id));
       }
@@ -3164,8 +3172,16 @@ protected:
     Parent::dump_item_fields(qi, f);
     if (!qi.is_bucket())
     {
+      string s;
+      if (osdmap->is_up(qi.id)) {
+        s = "up";
+      } else if (osdmap->is_destroyed(qi.id)) {
+        s = "destroyed";
+      } else {
+        s = "down";
+      }
       f->dump_unsigned("exists", (int)osdmap->exists(qi.id));
-      f->dump_string("status", osdmap->is_up(qi.id) ? "up" : "down");
+      f->dump_string("status", s);
       f->dump_float("reweight", osdmap->get_weightf(qi.id));
       f->dump_float("primary_affinity", osdmap->get_primary_affinityf(qi.id));
     }

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3056,13 +3056,17 @@ public:
     : Parent(crush, osdmap_->get_pool_names()), osdmap(osdmap_), filter(f) { }
 
   bool should_dump_leaf(int i) const override {
-    if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
-	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
-	((filter & OSDMap::DUMP_IN) && !osdmap->is_in(i)) ||
-	((filter & OSDMap::DUMP_OUT) && !osdmap->is_out(i))) {
-      return false;
+    if (!filter) {
+      return true; // normal case
     }
-    return true;
+    if (((filter & OSDMap::DUMP_UP) && osdmap->is_up(i)) ||
+	((filter & OSDMap::DUMP_DOWN) && osdmap->is_down(i)) ||
+	((filter & OSDMap::DUMP_IN) && osdmap->is_in(i)) ||
+	((filter & OSDMap::DUMP_OUT) && osdmap->is_out(i)) ||
+        ((filter & OSDMap::DUMP_DESTROYED) && osdmap->is_destroyed(i))) {
+      return true;
+    }
+    return false;
   }
 
   bool should_dump_empty_bucket() const override {
@@ -3142,13 +3146,17 @@ public:
     : Parent(crush, osdmap_->get_pool_names()), osdmap(osdmap_), filter(f) { }
 
   bool should_dump_leaf(int i) const override {
-    if (((filter & OSDMap::DUMP_UP) && !osdmap->is_up(i)) ||
-	((filter & OSDMap::DUMP_DOWN) && !osdmap->is_down(i)) ||
-	((filter & OSDMap::DUMP_IN) && !osdmap->is_in(i)) ||
-	((filter & OSDMap::DUMP_OUT) && !osdmap->is_out(i))) {
-      return false;
+    if (!filter) {
+      return true; // normal case
     }
-    return true;
+    if (((filter & OSDMap::DUMP_UP) && osdmap->is_up(i)) ||
+        ((filter & OSDMap::DUMP_DOWN) && osdmap->is_down(i)) ||
+        ((filter & OSDMap::DUMP_IN) && osdmap->is_in(i)) ||
+        ((filter & OSDMap::DUMP_OUT) && osdmap->is_out(i)) ||
+        ((filter & OSDMap::DUMP_DESTROYED) && osdmap->is_destroyed(i))) {
+      return true;
+    }
+    return false;
   }
 
   bool should_dump_empty_bucket() const override {

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1345,10 +1345,11 @@ public:
   void print_oneline_summary(ostream& out) const;
 
   enum {
-    DUMP_IN = 1,     // only 'in' osds
-    DUMP_OUT = 2,    // only 'out' osds
-    DUMP_UP = 4,     // only 'up' osds
-    DUMP_DOWN = 8,   // only 'down' osds
+    DUMP_IN = 1,         // only 'in' osds
+    DUMP_OUT = 2,        // only 'out' osds
+    DUMP_UP = 4,         // only 'up' osds
+    DUMP_DOWN = 8,       // only 'down' osds
+    DUMP_DESTROYED = 16, // only 'destroyed' osds
   };
   void print_tree(Formatter *f, ostream *out, unsigned dump_flags=0) const;
 

--- a/src/test/cli/osdmaptool/tree.t
+++ b/src/test/cli/osdmaptool/tree.t
@@ -4,13 +4,13 @@
 
   $ osdmaptool --tree=plain om
   osdmaptool: osdmap file 'om'
-  ID CLASS WEIGHT  TYPE NAME              UP/DOWN REWEIGHT PRI-AFF 
-  -1       3.00000 root default                                    
-  -3       3.00000     rack localrack                              
-  -2       3.00000         host localhost                          
-   0       1.00000             osd.0          DNE        0         
-   1       1.00000             osd.1          DNE        0         
-   2       1.00000             osd.2          DNE        0         
+  ID CLASS WEIGHT  TYPE NAME              STATUS REWEIGHT PRI-AFF 
+  -1       3.00000 root default                                   
+  -3       3.00000     rack localrack                             
+  -2       3.00000         host localhost                         
+   0       1.00000             osd.0         DNE        0         
+   1       1.00000             osd.1         DNE        0         
+   2       1.00000             osd.2         DNE        0         
 
   $ osdmaptool --tree=json-pretty om
   osdmaptool: osdmap file 'om'


### PR DESCRIPTION
E.g:

```
ID CLASS WEIGHT  TYPE NAME                                        UP/DOWN REWEIGHT PRI-AFF DESTROYED 
-1       3.00000 root default                                                                        
-2       3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic                                    
 0   ssd 1.00000         osd.0                                       down  1.00000 1.00000       yes 
 1   ssd 1.00000         osd.1                                       down  1.00000 1.00000       yes 
 2   ssd 1.00000         osd.2                                         up  1.00000 1.00000        no 
```

```
HEALTH_WARN 2 osds destroyed; 2 osds down; Degraded data redundancy: 42/63 objects degraded (66.667%), 16 pgs unclean, 16 pgs degraded, 16 pgs undersized
OSD_DESTROYED 2 osds destroyed
    osd.0 is destroyed
    osd.1 is destroyed
```