### PR TITLE
qa/tasks/reg11184: use literal 'foo' instead pool_name

### DIFF
--- a/qa/tasks/reg11184.py
+++ b/qa/tasks/reg11184.py
@@ -57,7 +57,7 @@ def task(ctx, config):
     manager.raw_cluster_cmd('osd', 'pool', 'create', 'foo', '1')
     manager.raw_cluster_cmd(
         'osd', 'pool', 'application', 'enable',
-        pool_name, 'rados', run.Raw('||'), 'true')
+        'foo', 'rados', run.Raw('||'), 'true')
 
     # Remove extra pool to simlify log output
     manager.raw_cluster_cmd('osd', 'pool', 'delete', 'rbd', 'rbd', '--yes-i-really-really-mean-it')


### PR DESCRIPTION
partially reverts 836ab7a.

* pool_name not defined here
* this test is not relevant to this test case

Signed-off-by: Kefu Chai <kchai@redhat.com>