### PR TITLE
qa/tasks/ceph_manager: wait for osd to start after objectstore-tool sequence

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1074,6 +1074,7 @@ class ObjectStoreTool:
         finally:
             if self.do_revive:
                 self.manager.revive_osd(self.osd)
+                self.manager.wait_till_osd_is_up(self.osd, 300)
 
 
 class CephManager:

--- a/qa/tasks/reg11184.py
+++ b/qa/tasks/reg11184.py
@@ -10,6 +10,7 @@ import logging
 import time
 from cStringIO import StringIO
 
+from teuthology.orchestra import run
 from teuthology import misc as teuthology
 from util.rados import rados
 import os


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20705
Signed-off-by: Sage Weil <sage@redhat.com>