### PR TITLE
osd,mds,mgr: do not dereference null rotating_keys

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1257,9 +1257,16 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
   EntityName name;
   uint64_t global_id;
 
-  is_valid = authorize_handler->verify_authorizer(
-    cct, monc->rotating_secrets.get(),
-    authorizer_data, authorizer_reply, name, global_id, caps_info, session_key);
+  RotatingKeyRing *keys = monc->rotating_secrets.get();
+  if (keys) {
+    is_valid = authorize_handler->verify_authorizer(
+      cct, keys,
+      authorizer_data, authorizer_reply, name, global_id, caps_info,
+      session_key);
+  } else {
+    dout(10) << __func__ << " no rotating_keys (yet), denied" << dendl;
+    is_valid = false;
+  }
 
   if (is_valid) {
     entity_name_t n(con->get_peer_type(), global_id);

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -143,12 +143,18 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
   s->inst.addr = con->get_peer_addr();
   AuthCapsInfo caps_info;
 
-  is_valid = handler->verify_authorizer(
-    cct, monc->rotating_secrets.get(),
-    authorizer_data,
-    authorizer_reply, s->entity_name,
-    s->global_id, caps_info,
-    session_key);
+  RotatingKeyRing *keys = monc->rotating_secrets.get();
+  if (keys) {
+    is_valid = handler->verify_authorizer(
+      cct, keys,
+      authorizer_data,
+      authorizer_reply, s->entity_name,
+      s->global_id, caps_info,
+      session_key);
+  } else {
+    dout(10) << __func__ << " no rotating_keys (yet), denied" << dendl;
+    is_valid = false;
+  }
 
   if (is_valid) {
     if (caps_info.allow_all) {

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -978,8 +978,8 @@ ssize_t AsyncConnection::_process_connection()
                                 << " - presumably this is the same node!" << dendl;
           } else {
             ldout(async_msgr->cct, 10) << __func__ << " connect claims to be "
-                                << paddr << " not " << peer_addr
-                                << " (peer is possibly using public_bind_addr?) " << dendl;
+				       << paddr << " not " << peer_addr << dendl;
+	    goto fail;
           }
         }
 

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1090,8 +1090,8 @@ int Pipe::connect()
 	      << paddr << " not " << peer_addr << " - presumably this is the same node!" << dendl;
     } else {
       ldout(msgr->cct,10) << "connect claims to be "
-	      << paddr << " not " << peer_addr
-              << " (peer is possibly using public_bind_addr?) " << dendl;
+			  << paddr << " not " << peer_addr << dendl;
+      goto fail;
     }
   }
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6941,10 +6941,16 @@ bool OSD::ms_verify_authorizer(Connection *con, int peer_type,
   uint64_t global_id;
   uint64_t auid = CEPH_AUTH_UID_DEFAULT;
 
-  isvalid = authorize_handler->verify_authorizer(
-    cct, monc->rotating_secrets.get(),
-    authorizer_data, authorizer_reply, name, global_id, caps_info, session_key,
-    &auid);
+  RotatingKeyRing *keys = monc->rotating_secrets.get();
+  if (keys) {
+    isvalid = authorize_handler->verify_authorizer(
+      cct, keys,
+      authorizer_data, authorizer_reply, name, global_id, caps_info, session_key,
+      &auid);
+  } else {
+    dout(10) << __func__ << " no rotating_keys (yet), denied" << dendl;
+    isvalid = false;
+  }
 
   if (isvalid) {
     Session *s = static_cast<Session *>(con->get_priv());

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4699,7 +4699,11 @@ void OSD::handle_osd_ping(MOSDPing *m)
   }
 
   OSDMapRef curmap = service.get_osdmap();
-  assert(curmap);
+  if (!curmap) {
+    heartbeat_lock.Unlock();
+    m->put();
+    return;
+  }
 
   switch (m->op) {
 


### PR DESCRIPTION
Immediately after we bind to a port, but before we have set up our
auth infrastructure, we may get incoming connections.  Deny them.  Since
we are not yet advertising ourselves these are peers trying to connect
to old instances of daemons, not us.

This triggers now because of bf4938567943c80345966f9c5a3bdc75a913175b.
Previously, the peer would see we were a different addr and drop the
connection.  Now, it continues.

Fixes: http://tracker.ceph.com/issues/20667
Signed-off-by: Sage Weil <sage@redhat.com>