### PR TITLE
ceph-disk: Fix for missing 'not' in *_is_diskdevice checks

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4097,7 +4097,7 @@ def get_space_osd_uuid(name, path):
     if not os.path.exists(path):
         raise Error('%s does not exist' % path)
 
-    if path_is_diskdevice(path):
+    if not path_is_diskdevice(path):
         raise Error('%s is not a block device' % path)
 
     if (is_partition(path) and
@@ -4701,7 +4701,7 @@ def set_suppress(path):
     disk = os.path.realpath(path)
     if not os.path.exists(disk):
         raise Error('does not exist', path)
-    if ldev_is_diskdevice(path):
+    if not ldev_is_diskdevice(path):
         raise Error('not a block device', path)
     base = get_dev_name(disk)
 


### PR DESCRIPTION
In 85d7f8817e94d7dbf81e20394c6778ecb677079c was introdused
is_diskdevice() tests but in some 'if' statements 'not' are lost.

Closes-Bug: #20706