### PR TITLE
mon: add mgr metdata commands, and overall 'versions' command for all daemon versions

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -442,6 +442,63 @@ Usage::
 
 	ceph mon_status
 
+mgr
+---
+
+Ceph manager daemon configuration and management.
+
+Subcommand ``dump`` dumps the latest MgrMap, which describes the active
+and standby manager daemons.
+
+Usage::
+
+  ceph mgr dump
+
+Subcommand ``fail`` will mark a manager daemon as failed, removing it
+from the manager map.  If it is the active manager daemon a standby
+will take its place.
+
+Usage::
+
+  ceph mgr fail <name>
+
+Subcommand ``module ls`` will list currently enabled manager modules (plugins).
+
+Usage::
+
+  ceph mgr module ls
+
+Subcommand ``module enable`` will enable a manager module.  Available modules are included in MgrMap and visible via ``mgr dump``.
+
+Usage::
+
+  ceph mgr module enable <module>
+
+Subcommand ``module disable`` will disable an active manager module.
+
+Usage::
+
+  ceph mgr module disable <module>
+
+Subcommand ``metadata`` will report metadata about all manager daemons or, if the name is specified, a single manager daemon.
+
+Usage::
+
+  ceph mgr metadata [name]
+
+Subcommand ``versions`` will report a count of running daemon versions.
+
+Usage::
+
+  ceph mgr versions
+
+Subcommand ``count-metadata`` will report a count of any daemon metadata field.
+
+Usage::
+
+  ceph mgr count-metadata <field>
+
+
 osd
 ---
 

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -160,7 +160,8 @@ Major Changes from Kraken
     - The ``ceph -s`` or ``ceph status`` command has a fresh look.
     - ``ceph mgr metadata`` will dump metadata associated with each mgr
       daemon.
-    - ``ceph {osd,mds,mon,mgr} versions`` summarizes versions of running daemons.
+    - ``ceph versions`` or ``ceph {osd,mds,mon,mgr} versions``
+      summarize versions of running daemons.
     - ``ceph {osd,mds,mon,mgr} count-metadata <property>`` similarly
       tabulates any other daemon metadata visible via the ``ceph
       {osd,mds,mon,mgr} metadata`` commands.
@@ -317,6 +318,10 @@ Upgrade from Jewel or Kraken
 
 #. Do not create any new erasure-code pools while upgrading the monitors.
 
+#. You can monitor the progress of your upgrade at each stage with the
+   ``ceph versions`` command, which will tell you what ceph version is
+   running for each type of daemon.
+
 #. Set the ``noout`` flag for the duration of the upgrade. (Optional
    but recommended.)::
 
@@ -368,7 +373,7 @@ Upgrade from Jewel or Kraken
      # systemctl restart ceph-osd.target
 
    You can monitor the progress of the OSD upgrades with the new
-   ``ceph osd versions`` command.::
+   ``ceph versions`` or ``ceph osd versions`` command.::
 
      # ceph osd versions
      {

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -158,10 +158,12 @@ Major Changes from Kraken
   * *CLI changes*:
 
     - The ``ceph -s`` or ``ceph status`` command has a fresh look.
-    - ``ceph {osd,mds,mon} versions`` summarizes versions of running daemons.
-    - ``ceph {osd,mds,mon} count-metadata <property>`` similarly
+    - ``ceph mgr metadata`` will dump metadata associated with each mgr
+      daemon.
+    - ``ceph {osd,mds,mon,mgr} versions`` summarizes versions of running daemons.
+    - ``ceph {osd,mds,mon,mgr} count-metadata <property>`` similarly
       tabulates any other daemon metadata visible via the ``ceph
-      {osd,mds,mon} metadata`` commands.
+      {osd,mds,mon,mgr} metadata`` commands.
     - ``ceph features`` summarizes features and releases of connected
       clients and daemons.
     - ``ceph osd require-osd-release <release>`` replaces the old

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -749,6 +749,12 @@ function test_mon_misc()
   ceph mon count-metadata ceph_version
   ceph mon versions
 
+  ceph mgr metadata
+  ceph mgr versions
+  ceph mgr count-metadata ceph_version
+
+  ceph versions
+
   ceph node ls
 }
 

--- a/src/messages/MMgrBeacon.h
+++ b/src/messages/MMgrBeacon.h
@@ -48,10 +48,10 @@ public:
   MMgrBeacon(const uuid_d& fsid_, uint64_t gid_, const std::string &name_,
              entity_addr_t server_addr_, bool available_,
 	     const std::set<std::string>& module_list,
-	     const map<string,string>& metadata)
+	     map<string,string>&& metadata)
     : PaxosServiceMessage(MSG_MGR_BEACON, 0, HEAD_VERSION, COMPAT_VERSION),
       gid(gid_), server_addr(server_addr_), available(available_), name(name_),
-      fsid(fsid_), available_modules(module_list), metadata(metadata)
+      fsid(fsid_), available_modules(module_list), metadata(std::move(metadata))
   {
   }
 

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -170,7 +170,7 @@ void MgrStandby::send_beacon()
                                  addr,
                                  available,
 				 modules,
-				 metadata);
+				 std::move(metadata));
 
   if (available && !available_in_map) {
     // We are informing the mon that we are done initializing: inform

--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -161,12 +161,16 @@ void MgrStandby::send_beacon()
   dout(10) << "sending beacon as gid " << monc.get_global_id()
 	   << " modules " << modules << dendl;
 
+  map<string,string> metadata;
+  collect_sys_info(&metadata, g_ceph_context);
+
   MMgrBeacon *m = new MMgrBeacon(monc.get_fsid(),
 				 monc.get_global_id(),
                                  g_conf->name.get_id(),
                                  addr,
                                  available,
-				 modules);
+				 modules,
+				 metadata);
 
   if (available && !available_in_map) {
     // We are informing the mon that we are done initializing: inform

--- a/src/mgr/ServiceMap.h
+++ b/src/mgr/ServiceMap.h
@@ -47,7 +47,7 @@ struct ServiceMap {
 	return "no daemons active";
       }
       std::ostringstream ss;
-      ss << daemons.size() << (daemons.size() > 1 ? "daemonss" : "daemon")
+      ss << daemons.size() << (daemons.size() > 1 ? " daemons" : " daemon")
 	 << " active";
       return ss.str();
     }

--- a/src/mgr/ServiceMap.h
+++ b/src/mgr/ServiceMap.h
@@ -51,6 +51,19 @@ struct ServiceMap {
 	 << " active";
       return ss.str();
     }
+
+    void count_metadata(const string& field,
+			std::map<std::string,int> *out) const {
+      for (auto& p : daemons) {
+	auto q = p.second.metadata.find(field);
+	if (q == p.second.metadata.end()) {
+	  (*out)["unknown"]++;
+	} else {
+	  (*out)[q->second]++;
+	}
+      }
+    }
+
   };
 
   epoch_t epoch = 0;

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1864,19 +1864,24 @@ int MDSMonitor::load_metadata(map<mds_gid_t, Metadata>& m)
   return 0;
 }
 
-void MDSMonitor::count_metadata(const string& field, Formatter *f)
+void MDSMonitor::count_metadata(const string& field, map<string,int> *out)
 {
-  map<string,int> by_val;
   map<mds_gid_t,Metadata> meta;
   load_metadata(meta);
   for (auto& p : meta) {
     auto q = p.second.find(field);
     if (q == p.second.end()) {
-      by_val["unknown"]++;
+      (*out)["unknown"]++;
     } else {
-      by_val[q->second]++;
+      (*out)[q->second]++;
     }
   }
+}
+
+void MDSMonitor::count_metadata(const string& field, Formatter *f)
+{
+  map<string,int> by_val;
+  count_metadata(field, &by_val);
   f->open_object_section(field.c_str());
   for (auto& p : by_val) {
     f->dump_int(p.first.c_str(), p.second);

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -139,6 +139,9 @@ class MDSMonitor : public PaxosService {
   void remove_from_metadata(MonitorDBStore::TransactionRef t);
   int load_metadata(map<mds_gid_t, Metadata>& m);
   void count_metadata(const string& field, Formatter *f);
+public:
+  void count_metadata(const string& field, map<string,int> *out);
+protected:
 
   // MDS daemon GID to latest health state from that GID
   std::map<uint64_t, MDSHealth> pending_daemon_health;

--- a/src/mon/MgrMap.h
+++ b/src/mon/MgrMap.h
@@ -95,6 +95,29 @@ public:
     return true;
   }
 
+  bool have_name(const string& name) const {
+    if (active_name == name) {
+      return true;
+    }
+    for (auto& p : standbys) {
+      if (p.second.name == name) {
+	return true;
+      }
+    }
+    return false;
+  }
+
+  std::set<std::string> get_all_names() const {
+    std::set<std::string> ls;
+    if (active_name.size()) {
+      ls.insert(active_name);
+    }
+    for (auto& p : standbys) {
+      ls.insert(p.second.name);
+    }
+    return ls;
+  }
+
   void encode(bufferlist& bl, uint64_t features) const
   {
     ENCODE_START(2, 1, bl);

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -25,6 +25,8 @@
 
 #include "MgrMonitor.h"
 
+#define MGR_METADATA_PREFIX "mgr_metadata"
+
 #define dout_subsys ceph_subsys_mon
 #undef dout_prefix
 #define dout_prefix _prefix(_dout, mon, map)
@@ -34,7 +36,6 @@ static ostream& _prefix(std::ostream *_dout, Monitor *mon,
 		<< "(" << mon->get_state_name()
 		<< ").mgr e" << mgrmap.get_epoch() << " ";
 }
-
 
 // Prefix for mon store of active mgr's command descriptions
 const static std::string command_descs_prefix = "mgr_command_descs";
@@ -137,6 +138,17 @@ void MgrMonitor::encode_pending(MonitorDBStore::TransactionRef t)
   pending_map.encode(bl, mon->get_quorum_con_features());
   put_version(t, pending_map.epoch, bl);
   put_last_committed(t, pending_map.epoch);
+
+  for (auto& p : pending_metadata) {
+    dout(10) << __func__ << " set metadata for " << p.first << dendl;
+    t->put(MGR_METADATA_PREFIX, p.first, p.second);
+  }
+  for (auto& name : pending_metadata_rm) {
+    dout(10) << __func__ << " rm metadata for " << name << dendl;
+    t->erase(MGR_METADATA_PREFIX, name);
+  }
+  pending_metadata.clear();
+  pending_metadata_rm.clear();
 
   health_check_map_t next;
   if (pending_map.active_gid == 0) {
@@ -329,6 +341,8 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
     pending_map.active_gid = m->get_gid();
     pending_map.active_name = m->get_name();
     pending_map.available_modules = m->get_available_modules();
+    ::encode(m->get_metadata(), pending_metadata[m->get_name()]);
+    pending_metadata_rm.erase(m->get_name());
 
     mon->clog->info() << "Activating manager daemon "
                       << pending_map.active_name;
@@ -353,6 +367,8 @@ bool MgrMonitor::prepare_beacon(MonOpRequestRef op)
                          << " started";
       pending_map.standbys[m->get_gid()] = {m->get_gid(), m->get_name(),
 					    m->get_available_modules()};
+      ::encode(m->get_metadata(), pending_metadata[m->get_name()]);
+      pending_metadata_rm.erase(m->get_name());
       updated = true;
     }
   }
@@ -592,6 +608,8 @@ void MgrMonitor::drop_active()
     last_beacon.erase(pending_map.active_gid);
   }
 
+  pending_metadata_rm.insert(pending_map.active_name);
+  pending_metadata.erase(pending_map.active_name);
   pending_map.active_name = "";
   pending_map.active_gid = 0;
   pending_map.available = false;
@@ -604,11 +622,12 @@ void MgrMonitor::drop_active()
 
 void MgrMonitor::drop_standby(uint64_t gid)
 {
+  pending_metadata_rm.insert(pending_map.standbys[gid].name);
+  pending_metadata.erase(pending_map.standbys[gid].name);
   pending_map.standbys.erase(gid);
   if (last_beacon.count(gid) > 0) {
     last_beacon.erase(gid);
   }
-
 }
 
 bool MgrMonitor::preprocess_command(MonOpRequestRef op)

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -897,20 +897,25 @@ int MgrMonitor::load_metadata(const string& name, std::map<string, string>& m,
   return 0;
 }
 
-void MgrMonitor::count_metadata(const string& field, Formatter *f)
+void MgrMonitor::count_metadata(const string& field, std::map<string,int> *out)
 {
-  std::map<string,int> by_val;
   std::set<string> ls = map.get_all_names();
   for (auto& name : ls) {
     std::map<string,string> meta;
     load_metadata(name, meta, nullptr);
     auto p = meta.find(field);
     if (p == meta.end()) {
-      by_val["unknown"]++;
+      (*out)["unknown"]++;
     } else {
-      by_val[p->second]++;
+      (*out)[p->second]++;
     }
   }
+}
+
+void MgrMonitor::count_metadata(const string& field, Formatter *f)
+{
+  std::map<string,int> by_val;
+  count_metadata(field, &by_val);
   f->open_object_section(field.c_str());
   for (auto& p : by_val) {
     f->dump_int(p.first.c_str(), p.second);

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -103,6 +103,11 @@ public:
     return command_descs;
   }
 
+  int load_metadata(const string& name, std::map<string, string>& m,
+		    ostream *err);
+  int dump_metadata(const string& name, Formatter *f, ostream *err);
+  void count_metadata(const string& field, Formatter *f);
+
   friend class C_Updated;
 };
 

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -14,6 +14,9 @@
 #ifndef CEPH_MGRMONITOR_H
 #define CEPH_MGRMONITOR_H
 
+#include <map>
+#include <set>
+
 #include "include/Context.h"
 #include "MgrMap.h"
 #include "PaxosService.h"
@@ -24,6 +27,9 @@ class MgrMonitor: public PaxosService
   MgrMap map;
   MgrMap pending_map;
   bool ever_had_active_mgr = false;
+
+  std::map<std::string, bufferlist> pending_metadata;
+  std::set<std::string>             pending_metadata_rm;
 
   utime_t first_seen_inactive;
 

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -107,6 +107,7 @@ public:
 		    ostream *err);
   int dump_metadata(const string& name, Formatter *f, ostream *err);
   void count_metadata(const string& field, Formatter *f);
+  void count_metadata(const string& field, std::map<string,int> *out);
 
   friend class C_Updated;
 };

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -1017,3 +1017,12 @@ COMMAND("mgr module enable "						\
 COMMAND("mgr module disable "						\
 	"name=module,type=CephString",
 	"disable mgr module", "mgr", "rw", "cli,rest")
+COMMAND("mgr metadata name=id,type=CephString,req=false",
+	"dump metadata for all daemons or a specific daemon",
+	"mgr", "r", "cli,rest")
+COMMAND("mgr count-metadata name=property,type=CephString",
+	"count ceph-mgr daemons by metadata field property",
+	"mgr", "r", "cli,rest")
+COMMAND("mgr versions", \
+	"check running versions of ceph-mgr daemons",
+	"mgr", "r", "cli,rest")

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -279,6 +279,10 @@ COMMAND("mon count-metadata name=property,type=CephString",
 COMMAND("mon versions",
 	"check running versions of monitors",
 	"mon", "r", "cli,rest")
+COMMAND("versions",
+	"check running versions of ceph daemons",
+	"mon", "r", "cli,rest")
+
 
 
 /*

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5011,17 +5011,22 @@ int Monitor::get_mon_metadata(int mon, Formatter *f, ostream& err)
   return 0;
 }
 
-void Monitor::count_metadata(const string& field, Formatter *f)
+void Monitor::count_metadata(const string& field, map<string,int> *out)
 {
-  map<string,int> by_val;
   for (auto& p : mon_metadata) {
     auto q = p.second.find(field);
     if (q == p.second.end()) {
-      by_val["unknown"]++;
+      (*out)["unknown"]++;
     } else {
-      by_val[q->second]++;
+      (*out)[q->second]++;
     }
   }
+}
+
+void Monitor::count_metadata(const string& field, Formatter *f)
+{
+  map<string,int> by_val;
+  count_metadata(field, &by_val);
   f->open_object_section(field.c_str());
   for (auto& p : by_val) {
     f->dump_int(p.first.c_str(), p.second);

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3564,6 +3564,65 @@ void Monitor::handle_command(MonOpRequestRef op)
     rdata.append(ds);
     rs = "";
     r = 0;
+  } else if (prefix == "versions") {
+    if (!f)
+      f.reset(Formatter::create("json-pretty"));
+    map<string,int> overall;
+    f->open_object_section("version");
+    map<string,int> mon, mgr, osd, mds;
+
+    count_metadata("ceph_version", &mon);
+    f->open_object_section("mon");
+    for (auto& p : mon) {
+      f->dump_int(p.first.c_str(), p.second);
+      overall[p.first] += p.second;
+    }
+    f->close_section();
+
+    mgrmon()->count_metadata("ceph_version", &mgr);
+    f->open_object_section("mgr");
+    for (auto& p : mgr) {
+      f->dump_int(p.first.c_str(), p.second);
+      overall[p.first] += p.second;
+    }
+    f->close_section();
+
+    osdmon()->count_metadata("ceph_version", &osd);
+    f->open_object_section("osd");
+    for (auto& p : osd) {
+      f->dump_int(p.first.c_str(), p.second);
+      overall[p.first] += p.second;
+    }
+    f->close_section();
+
+    mdsmon()->count_metadata("ceph_version", &mds);
+    f->open_object_section("mds");
+    for (auto& p : mon) {
+      f->dump_int(p.first.c_str(), p.second);
+      overall[p.first] += p.second;
+    }
+    f->close_section();
+
+    for (auto& p : mgrstatmon()->get_service_map().services) {
+      f->open_object_section(p.first.c_str());
+      map<string,int> m;
+      p.second.count_metadata("ceph_version", &m);
+      for (auto& q : m) {
+	f->dump_int(q.first.c_str(), q.second);
+	overall[q.first] += q.second;
+      }
+      f->close_section();
+    }
+
+    f->open_object_section("overall");
+    for (auto& p : overall) {
+      f->dump_int(p.first.c_str(), p.second);
+    }
+    f->close_section();
+    f->close_section();
+    f->flush(rdata);
+    rs = "";
+    r = 0;
   }
 
  out:

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -901,6 +901,7 @@ public:
   void update_mon_metadata(int from, Metadata&& m);
   int load_metadata();
   void count_metadata(const string& field, Formatter *f);
+  void count_metadata(const string& field, map<string,int> *out);
 
   // features
   static CompatSet get_initial_supported_features();

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -1226,21 +1226,26 @@ int OSDMonitor::load_metadata(int osd, map<string, string>& m, ostream *err)
   return 0;
 }
 
-void OSDMonitor::count_metadata(const string& field, Formatter *f)
+void OSDMonitor::count_metadata(const string& field, map<string,int> *out)
 {
-  map<string,int> by_val;
   for (int osd = 0; osd < osdmap.get_max_osd(); ++osd) {
     if (osdmap.is_up(osd)) {
       map<string,string> meta;
       load_metadata(osd, meta, nullptr);
       auto p = meta.find(field);
       if (p == meta.end()) {
-	by_val["unknown"]++;
+	(*out)["unknown"]++;
       } else {
-	by_val[p->second]++;
+	(*out)[p->second]++;
       }
     }
   }
+}
+
+void OSDMonitor::count_metadata(const string& field, Formatter *f)
+{
+  map<string,int> by_val;
+  count_metadata(field, &by_val);
   f->open_object_section(field.c_str());
   for (auto& p : by_val) {
     f->dump_int(p.first.c_str(), p.second);

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -428,6 +428,9 @@ private:
 
   int load_metadata(int osd, map<string, string>& m, ostream *err);
   void count_metadata(const string& field, Formatter *f);
+public:
+  void count_metadata(const string& field, map<string,int> *out);
+protected:
   int get_osd_objectstore_type(int osd, std::string *type);
   bool is_pool_currently_all_bluestore(int64_t pool_id, const pg_pool_t &pool,
 				       ostream *err);


### PR DESCRIPTION
<pre>
$ ceph versions
{
    "mon": {
        "ceph version 12.1.1-235-g9c3232d (9c3232d4c9375963f7f5f6c04b035788a13c0b79) luminous (rc)": 1
    },
    "mgr": {
        "ceph version 12.1.1-233-g1b51c63 (1b51c63d72ec10fd176af672e9cca7a85226021e) luminous (rc)": 2
    },
    "osd": {
        "ceph version 12.1.1-233-g1b51c63 (1b51c63d72ec10fd176af672e9cca7a85226021e) luminous (rc)": 1
    },
    "mds": {
        "ceph version 12.1.1-235-g9c3232d (9c3232d4c9375963f7f5f6c04b035788a13c0b79) luminous (rc)": 1
    },
    "rgw": {
        "ceph version 12.1.1-233-g1b51c63 (1b51c63d72ec10fd176af672e9cca7a85226021e) luminous (rc)": 1
    },
    "overall": {
        "ceph version 12.1.1-233-g1b51c63 (1b51c63d72ec10fd176af672e9cca7a85226021e) luminous (rc)": 4,
        "ceph version 12.1.1-235-g9c3232d (9c3232d4c9375963f7f5f6c04b035788a13c0b79) luminous (rc)": 2
    }
}
</pre>