### PR TITLE
rgw: fix parse/eval of policy conditions with IfExists

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -912,7 +912,7 @@ bool Condition::eval(const Environment& env) const {
   }
 
   if (i == env.end()) {
-    return false;
+    return ifexists;
   }
   const auto& s = i->second;
 

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -473,6 +473,7 @@ struct ParseState {
 
   bool arraying = false;
   bool objecting = false;
+  bool cond_ifexists = false;
 
   void reset();
 
@@ -645,13 +646,22 @@ bool ParseState::obj_end() {
 }
 
 bool ParseState::key(const char* s, size_t l) {
-  auto k = pp->tokens.lookup(s, l);
+  auto token_len = l;
+  bool ifexists = false;
+  if (w->id == TokenID::Condition && w->kind == TokenKind::statement) {
+    static constexpr char IfExists[] = "IfExists";
+    if (boost::algorithm::ends_with(boost::string_view{s, l}, IfExists)) {
+      ifexists = true;
+      token_len -= sizeof(IfExists)-1;
+    }
+  }
+  auto k = pp->tokens.lookup(s, token_len);
 
   if (!k) {
     if (w->kind == TokenKind::cond_op) {
       auto& t = pp->policy.statements.back();
       pp->s.emplace_back(pp, cond_key);
-      t.conditions.emplace_back(w->id, s, l);
+      t.conditions.emplace_back(w->id, s, l, cond_ifexists);
       return true;
     } else {
       return false;
@@ -680,6 +690,7 @@ bool ParseState::key(const char* s, size_t l) {
   } else if ((w->id == TokenID::Condition) &&
 	     (k->kind == TokenKind::cond_op)) {
     pp->s.emplace_back(pp, k);
+    pp->s.back().cond_ifexists = ifexists;
     return true;
   }
   return false;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -26,6 +26,7 @@
 
 #include "fnmatch.h"
 
+#include "rgw_acl.h"
 #include "rgw_basic_types.h"
 #include "rgw_iam_policy_keywords.h"
 
@@ -273,18 +274,8 @@ struct Condition {
   std::vector<std::string> vals;
 
   Condition() = default;
-  Condition(TokenID op, const char* s, std::size_t len) : op(op) {
-    static constexpr char ifexistr[] = "IfExists";
-    auto l = static_cast<const char*>(memmem(static_cast<const void*>(s), len,
-					     static_cast<const void*>(ifexistr),
-					     sizeof(ifexistr) -1));
-    if (l && ((l + sizeof(ifexistr) - 1 == (s + len)))) {
-      ifexists = true;
-      key.assign(s, static_cast<const char*>(l) - s);
-    } else {
-      key.assign(s, len);
-    }
-  }
+  Condition(TokenID op, const char* s, std::size_t len, bool ifexists)
+    : op(op), key(s, len), ifexists(ifexists) {}
 
   bool eval(const Environment& e) const;
 

--- a/src/rgw/rgw_iam_policy_keywords.gperf
+++ b/src/rgw/rgw_iam_policy_keywords.gperf
@@ -1,6 +1,7 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 %language=C++
+%compare-strncmp
 %define class-name keyword_hash
 %define lookup-function-name lookup
 %struct-type


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20708

Makes progress in passing `test_bucket_policy_set_condition_operator_end_with_IfExists` from https://github.com/ceph/s3-tests/pull/167, but we still need wildcard support from https://github.com/ceph/ceph/pull/15702