### PR TITLE
mgr/dashboard: show rbd image features

### DIFF
--- a/src/pybind/mgr/dashboard/rbd_pool.html
+++ b/src/pybind/mgr/dashboard/rbd_pool.html
@@ -51,6 +51,7 @@
                     <th>Size</th>
                     <th>Objects</th>
                     <th>Object size</th>
+                    <th>Features</th>
                     <th>Parent</th>
                 </tr>
                 </thead>
@@ -60,6 +61,7 @@
                     <td>{image.size | dimless_binary}</td>
                     <td>{image.num_objs | dimless}</td>
                     <td>{image.obj_size | dimless_binary}</td>
+                    <td>{image.features_name}</td>
                     <td>{image.parent}</td>
                 </tr>
                 </tbody>


### PR DESCRIPTION

>[root@ceph14 build]# rbd map disk01
rbd: sysfs write failed
RBD image feature set mismatch. Try disabling features unsupported by the kernel with "rbd feature disable".
In some cases useful info is found in syslog - try "dmesg | tail".
rbd: map failed: (6) No such device or address

![mgr-rbd-images-show](https://user-images.githubusercontent.com/3417522/28446630-8c40de7c-6dfe-11e7-9785-6d5edef4376e.png)

we can see the RBD images features, disabling features unsupported by the kernel

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>