### PR TITLE
mgr: add the ip addr of standbys

### DIFF
--- a/src/mgr/MgrStandby.cc
+++ b/src/mgr/MgrStandby.cc
@@ -162,6 +162,7 @@ void MgrStandby::send_beacon()
 	   << " modules " << modules << dendl;
 
   map<string,string> metadata;
+  metadata["addr"] = monc.get_my_addr().ip_only_to_str();
   collect_sys_info(&metadata, g_ceph_context);
 
   MMgrBeacon *m = new MMgrBeacon(monc.get_fsid(),

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -290,3 +290,22 @@ void entity_addrvec_t::generate_test_instances(list<entity_addrvec_t*>& ls)
   ls.back()->v.push_back(entity_addr_t());
   ls.back()->v.push_back(entity_addr_t());
 }
+
+std::string entity_addr_t::ip_only_to_str() const 
+{
+  const char *host_ip = NULL;
+  char addr_buf[INET6_ADDRSTRLEN];
+  switch (get_family()) {
+  case AF_INET:
+    host_ip = inet_ntop(AF_INET, &in4_addr().sin_addr, 
+                        addr_buf, INET_ADDRSTRLEN);
+    break;
+  case AF_INET6:
+    host_ip = inet_ntop(AF_INET6, &in6_addr().sin6_addr, 
+                        addr_buf, INET6_ADDRSTRLEN);
+    break;
+  default:
+    break;
+  }
+  return host_ip ? host_ip : "";
+}

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -384,6 +384,8 @@ struct entity_addr_t {
     }
   }
 
+  std::string ip_only_to_str() const;
+
   bool parse(const char *s, const char **end = 0);
 
   void decode_legacy_addr_after_marker(bufferlist::iterator& bl)


### PR DESCRIPTION
we need to manage the ip addr of the "standbys" state,
because the hostname/gid is insufficient to locate the
Standby node.


> [root@node173 build]# ceph mgr metadata
[
    {
        "id": "node173",
        **"addr": "10.118.202.173",**
        "arch": "x86_64",
        "ceph_version": "ceph version 12.1.2-589-gc8c837f (c8c837f665edc6e32efda5f15dedd8a48698214a) luminous (rc)",
        "cpu": "Intel(R) Core(TM) i5-2400 CPU @ 3.10GHz",
        "distro": "centos",
        "distro_description": "CentOS Linux 7 (Core)",
        "distro_version": "7",
        "hostname": "node173",
        "kernel_description": "#1 SMP Mon Jun 30 12:09:22 UTC 2014",
        "kernel_version": "3.10.0-123.el7.x86_64",
        "mem_swap_kb": "4079612",
        "mem_total_kb": "3768768",
        "os": "Linux"
    }
]

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>