### PR TITLE
mon/HealthMonitor: trigger a proposal if stat updated

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -152,7 +152,15 @@ version_t HealthMonitor::get_trim_to()
 
 bool HealthMonitor::preprocess_query(MonOpRequestRef op)
 {
-  switch (op->get_req()->get_type()) {
+  return false;
+}
+
+bool HealthMonitor::prepare_update(MonOpRequestRef op)
+{
+  Message *m = op->get_req();
+  dout(7) << "prepare_update " << *m
+	  << " from " << m->get_orig_source_inst() << dendl;
+  switch (m->get_type()) {
   case MSG_MON_HEALTH:
     {
       MMonHealth *hm = static_cast<MMonHealth*>(op->get_req());
@@ -164,22 +172,18 @@ bool HealthMonitor::preprocess_query(MonOpRequestRef op)
       }
       return services[service_type]->service_dispatch(op);
     }
-
   case MSG_MON_HEALTH_CHECKS:
-    return preprocess_health_checks(op);
+    return prepare_health_checks(op);
+  default:
+    return false;
   }
-  return false;
 }
 
-bool HealthMonitor::prepare_update(MonOpRequestRef op)
-{
-  return false;
-}
-
-bool HealthMonitor::preprocess_health_checks(MonOpRequestRef op)
+bool HealthMonitor::prepare_health_checks(MonOpRequestRef op)
 {
   MMonHealthChecks *m = static_cast<MMonHealthChecks*>(op->get_req());
-  quorum_checks[m->get_source().num()] = m->health_checks;
+  // no need to check if it's changed, the peon has done so
+  quorum_checks[m->get_source().num()] = std::move(m->health_checks);
   return true;
 }
 

--- a/src/mon/HealthMonitor.h
+++ b/src/mon/HealthMonitor.h
@@ -47,7 +47,6 @@ public:
   bool preprocess_query(MonOpRequestRef op) override;
   bool prepare_update(MonOpRequestRef op) override;
 
-  bool preprocess_health_checks(MonOpRequestRef op);
   bool prepare_health_checks(MonOpRequestRef op);
 
   bool check_leader_health();


### PR DESCRIPTION
leader should always propose if the peon update it with new health stats

Signed-off-by: Kefu Chai <kchai@redhat.com>