### PR TITLE
mon/HealthMonitor: avoid sending unnecessary MMonHealthChecks to leader

### DIFF
--- a/src/mon/HealthMonitor.cc
+++ b/src/mon/HealthMonitor.cc
@@ -278,17 +278,24 @@ bool HealthMonitor::check_member_health()
   }
 
   auto p = quorum_checks.find(mon->rank);
-  if (p == quorum_checks.end() ||
-      p->second != next) {
-    if (mon->is_leader()) {
-      // prepare to propose
-      quorum_checks[mon->rank] = next;
-      changed = true;
-    } else {
-      // tell the leader
-      mon->messenger->send_message(new MMonHealthChecks(next),
-				   mon->monmap->get_inst(mon->get_leader()));
+  if (p == quorum_checks.end()) {
+    if (next.empty()) {
+      return false;
     }
+  } else {
+    if (p->second == next) {
+      return false;
+    }
+  }
+
+  if (mon->is_leader()) {
+    // prepare to propose
+    quorum_checks[mon->rank] = next;
+    changed = true;
+  } else {
+    // tell the leader
+    mon->messenger->send_message(new MMonHealthChecks(next),
+                                 mon->monmap->get_inst(mon->get_leader()));
   }
 
   return changed;

--- a/src/mon/health_check.h
+++ b/src/mon/health_check.h
@@ -87,6 +87,9 @@ struct health_check_map_t {
   void clear() {
     checks.clear();
   }
+  bool empty() const {
+    return checks.empty();
+  }
   void swap(health_check_map_t& other) {
     checks.swap(other.checks);
   }


### PR DESCRIPTION
If there is no historic warnings and no new warnings is generated,
skip sending MMonHealthChecks(for peon) or updating quorum_checks(for leader).

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>