### PR TITLE
rgw: support store head/tail into different pools

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -254,6 +254,7 @@ void _usage()
   cout << "   --endpoints=<list>        zone endpoints\n";
   cout << "   --index-pool=<pool>       placement target index pool\n";
   cout << "   --data-pool=<pool>        placement target data pool\n";
+  cout << "   --tail-data-pool=<pool>   placement target tail data pool\n";
   cout << "   --data-extra-pool=<pool>  placement target data extra (non-ec) pool\n";
   cout << "   --placement-index-type=<type>\n";
   cout << "                             placement target index type (normal, indexless, or #id)\n";
@@ -2406,6 +2407,7 @@ int main(int argc, const char **argv)
 
   boost::optional<string> index_pool;
   boost::optional<string> data_pool;
+  boost::optional<string> tail_data_pool;
   boost::optional<string> data_extra_pool;
   RGWBucketIndexType placement_index_type = RGWBIType_Normal;
   bool index_type_specified = false;
@@ -2707,6 +2709,8 @@ int main(int argc, const char **argv)
       index_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-pool", (char*)NULL)) {
       data_pool = val;
+    } else if (ceph_argparse_witharg(args, i, &val, "--tail-data-pool", (char*)NULL)) {
+      tail_data_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--data-extra-pool", (char*)NULL)) {
       data_extra_pool = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--placement-index-type", (char*)NULL)) {
@@ -4206,6 +4210,13 @@ int main(int argc, const char **argv)
 
           info.index_pool = *index_pool;
           info.data_pool = *data_pool;
+
+          if (tail_data_pool) {
+            info.tail_data_pool = *tail_data_pool;
+          } else {
+            info.tail_data_pool = *data_pool;
+          }
+
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;
           }
@@ -4228,6 +4239,9 @@ int main(int argc, const char **argv)
           }
           if (data_pool && !data_pool->empty()) {
             info.data_pool = *data_pool;
+          }
+          if (tail_data_pool && !tail_data_pool->empty()) {
+            info.tail_data_pool = *tail_data_pool;
           }
           if (data_extra_pool) {
             info.data_extra_pool = *data_extra_pool;

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -174,6 +174,7 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   if (!cur_part_id) {
     if (ofs < max_head_size) {
       location->set_placement_rule(head_placement_rule);
+      location->using_tail_data_pool = false;
       *location = obj;
       return;
     } else {
@@ -206,6 +207,9 @@ void RGWObjManifest::get_implicit_location(uint64_t cur_part_id, uint64_t cur_st
   loc.key.set_instance(tail_instance);
 
   location->set_placement_rule(tail_placement.placement_rule);
+  location->using_tail_data_pool = true;
+  using_tail_data_pool = true;
+
   *location = loc;
 }
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -920,6 +920,7 @@ void RGWZonePlacementInfo::dump(Formatter *f) const
 {
   encode_json("index_pool", index_pool, f);
   encode_json("data_pool", data_pool, f);
+  encode_json("tail_data_pool", tail_data_pool, f);
   encode_json("data_extra_pool", data_extra_pool, f);
   encode_json("index_type", (uint32_t)index_type, f);
   encode_json("compression", compression_type, f);
@@ -929,6 +930,7 @@ void RGWZonePlacementInfo::decode_json(JSONObj *obj)
 {
   JSONDecoder::decode_json("index_pool", index_pool, obj);
   JSONDecoder::decode_json("data_pool", data_pool, obj);
+  JSONDecoder::decode_json("tail_data_pool", tail_data_pool, obj);
   JSONDecoder::decode_json("data_extra_pool", data_extra_pool, obj);
   uint32_t it;
   JSONDecoder::decode_json("index_type", it, obj);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -85,6 +85,7 @@ static string *notify_oids = NULL;
 static string shadow_ns = "shadow";
 static string dir_oid_prefix = ".dir.";
 static string default_storage_pool_suffix = "rgw.buckets.data";
+static std::string default_tail_storage_pool_suffix = "rgw.buckets.tail";
 static string default_bucket_index_pool_suffix = "rgw.buckets.index";
 static string default_storage_extra_pool_suffix = "rgw.buckets.non-ec";
 static string avail_pools = ".pools.avail";
@@ -1643,6 +1644,7 @@ int get_zones_pool_set(CephContext* cct,
       for(auto& iter : zone.placement_pools) {
 	pool_names.insert(iter.second.index_pool);
 	pool_names.insert(iter.second.data_pool);
+	pool_names.insert(iter.second.tail_data_pool);
 	pool_names.insert(iter.second.data_extra_pool);
       }
     }
@@ -1735,6 +1737,7 @@ int RGWZoneParams::create(bool exclusive)
     RGWZonePlacementInfo default_placement;
     default_placement.index_pool = name + "." + default_bucket_index_pool_suffix;
     default_placement.data_pool =  name + "." + default_storage_pool_suffix;
+    default_placement.tail_data_pool = name + "." + default_tail_storage_pool_suffix;
     default_placement.data_extra_pool = name + "." + default_storage_extra_pool_suffix;
     placement_pools["default-placement"] = default_placement;
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1105,21 +1105,23 @@ struct RGWZonePlacementInfo {
   rgw_pool data_extra_pool; /* if not set we should use data_pool */
   RGWBucketIndexType index_type;
   std::string compression_type;
+  rgw_pool tail_data_pool;
 
   RGWZonePlacementInfo() : index_type(RGWBIType_Normal) {}
 
   void encode(bufferlist& bl) const {
-    ENCODE_START(6, 1, bl);
+    ENCODE_START(7, 1, bl);
     ::encode(index_pool.to_str(), bl);
     ::encode(data_pool.to_str(), bl);
     ::encode(data_extra_pool.to_str(), bl);
     ::encode((uint32_t)index_type, bl);
     ::encode(compression_type, bl);
+    ::encode(tail_data_pool.to_str(), bl);
     ENCODE_FINISH(bl);
   }
 
   void decode(bufferlist::iterator& bl) {
-    DECODE_START(6, bl);
+    DECODE_START(7, bl);
     string index_pool_str;
     string data_pool_str;
     ::decode(index_pool_str, bl);
@@ -1138,6 +1140,12 @@ struct RGWZonePlacementInfo {
     }
     if (struct_v >= 6) {
       ::decode(compression_type, bl);
+    }
+
+    if (struct_v >= 7) {
+      string tail_data_pool_str;
+      ::decode(tail_data_pool_str, bl);
+      tail_data_pool = rgw_pool(tail_data_pool_str);
     }
     DECODE_FINISH(bl);
   }

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -785,6 +785,10 @@ public:
 
     void update_location();
 
+    void set_using_tail_data_pool(bool using_tail_data_pool) {
+      location.using_tail_data_pool = using_tail_data_pool;
+    };
+
     friend class RGWObjManifest;
   };
 

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -198,6 +198,7 @@
      --endpoints=<list>        zone endpoints
      --index-pool=<pool>       placement target index pool
      --data-pool=<pool>        placement target data pool
+     --tail-data-pool=<pool>   placement target tail data pool
      --data-extra-pool=<pool>  placement target data extra (non-ec) pool
      --placement-index-type=<type>
                                placement target index type (normal, indexless, or #id)


### PR DESCRIPTION
This is the first phrase to implement s3 storage class in the rgw.
Similar work with https://github.com/ceph/ceph/pull/16325 , but this
implement is simpler.

This pr is a draft for review. Currently only passed single/multipart Get/Put
test, there're several things need to been addressed and test later:

+ object rewrite
+ object copy

@yehudasa @fangyuxiangGL  your comments are very appreciated.  ；-）


