### PR TITLE
cmake: use CMAKE_INSTALL_INCLUDEDIR

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -824,6 +824,7 @@ cmake .. \
     -DCMAKE_INSTALL_SYSCONFDIR=%{_sysconfdir} \
     -DCMAKE_INSTALL_MANDIR=%{_mandir} \
     -DCMAKE_INSTALL_DOCDIR=%{_docdir}/ceph \
+    -DCMAKE_INSTALL_INCLUDEDIR=%{_includedir} \
     -DWITH_EMBEDDED=OFF \
     -DWITH_MANPAGE=ON \
     -DWITH_PYTHON3=ON \

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -993,7 +993,7 @@ if(WITH_LIBCEPHFS)
   install(TARGETS cephfs DESTINATION ${CMAKE_INSTALL_LIBDIR})
   install(DIRECTORY
     "${CMAKE_SOURCE_DIR}/src/include/cephfs"
-    DESTINATION include)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
   set(ceph_syn_srcs
     ceph_syn.cc
     client/SyntheticClient.cc)

--- a/src/include/CMakeLists.txt
+++ b/src/include/CMakeLists.txt
@@ -9,23 +9,23 @@ install(FILES rados/librados.h
   page.h
   crc32c.h
   rados/objclass.h
-  DESTINATION include/rados)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rados)
 install(FILES
   radosstriper/libradosstriper.h
   radosstriper/libradosstriper.hpp
-  DESTINATION include/radosstriper)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/radosstriper)
 
 if(WITH_RBD)
   install(FILES
     rbd/features.h
     rbd/librbd.h
     rbd/librbd.hpp
-    DESTINATION include/rbd)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rbd)
 endif()
 
 if(WITH_RADOSGW)
   install(FILES
     rados/librgw.h
     rados/rgw_file.h
-  DESTINATION include/rados)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rados)
 endif()

--- a/src/libcephd/CMakeLists.txt
+++ b/src/libcephd/CMakeLists.txt
@@ -41,4 +41,5 @@ merge_static_libraries(cephd ${merge_libs})
 
 # TODO: install these libraries and add them to rpm and deb packages
 #install(TARGETS cephd DESTINATION ${CMAKE_INSTALL_LIBDIR})
-#install(FILES ../include/cephd/libcephd.h DESTINATION include/cephd)
+#install(FILES ../include/cephd/libcephd.h
+#  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cephd)


### PR DESCRIPTION
Header files are currently installed under a hardcoded "include" path.
Use CMAKE_INSTALL_INCLUDEDIR instead, which defaults to "include" but
allows for customisation alongside other (already used) CMAKE_INSTALL_X
paths.

Signed-off-by: David Disseldorp <ddiss@suse.de>