### PR TITLE
qa: flush out monc's dropped msgs on msgr failure injection

### DIFF
--- a/qa/suites/rados/monthrash/msgr-failures/mon-delay.yaml
+++ b/qa/suites/rados/monthrash/msgr-failures/mon-delay.yaml
@@ -7,3 +7,5 @@ overrides:
         ms inject delay probability: .005
         ms inject delay max: 1
         ms inject internal delays: .002
+      mgr:
+        debug monc: 10

--- a/qa/suites/rados/singleton/msgr-failures/many.yaml
+++ b/qa/suites/rados/singleton/msgr-failures/many.yaml
@@ -3,3 +3,5 @@ overrides:
     conf:
       global:
         ms inject socket failures: 500
+      mgr:
+        debug monc: 10


### PR DESCRIPTION
We have a few open tickets regarding the mgr being down during suites
involving messenger failure injection. There are a few suspicions that
this may be related with the monclient, but we'll need more logs to
validate those suspicions and, more, to validate we're actually fixing
the issue.

Signed-off-by: Joao Eduardo Luis <joao@suse.de>

(this is related to http://tracker.ceph.com/issues/20371 and other tickets)