### PR TITLE
common: Fix the exit value after generic_usage()

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -526,10 +526,10 @@ static void generic_usage(bool is_server)
 void generic_server_usage()
 {
   generic_usage(true);
-  exit(1);
+  exit(0);
 }
 void generic_client_usage()
 {
   generic_usage(false);
-  exit(1);
+  exit(0);
 }


### PR DESCRIPTION
The exit value should be 0 after the generic usage is displayed. There is no reason to return 1.
This PR is created as a follow up of the review in: https://github.com/ceph/ceph/pull/16254.

Signed-off-by: Jos Collin <jcollin@redhat.com>