### PR TITLE
rgw: match wildcards in StringLike policy conditions

### DIFF
--- a/src/common/backport14.h
+++ b/src/common/backport14.h
@@ -27,6 +27,8 @@ template<typename T>
 using remove_reference_t = typename std::remove_reference<T>::type;
 template<typename T>
 using result_of_t = typename std::result_of<T>::type;
+template<typename T>
+using decay_t = typename std::decay<T>::type;
 
 namespace _backport14 {
 template<typename T>
@@ -75,10 +77,52 @@ template <typename T, std::size_t N>
 constexpr std::size_t size(const T (&array)[N]) noexcept {
   return N;
 }
+
+/// http://en.cppreference.com/w/cpp/utility/functional/not_fn
+// this implementation uses c++14's result_of_t (above) instead of the c++17
+// invoke_result_t, and so may not behave correctly when SFINAE is required
+template <typename F>
+class not_fn_result {
+  using DecayF = decay_t<F>;
+  DecayF fn;
+ public:
+  explicit not_fn_result(F&& f) : fn(std::forward<F>(f)) {}
+  not_fn_result(not_fn_result&& f) = default;
+  not_fn_result(const not_fn_result& f) = default;
+
+  template<class... Args>
+  auto operator()(Args&&... args) &
+  -> decltype(!std::declval<result_of_t<DecayF&(Args...)>>()) {
+    return !fn(std::forward<Args>(args)...);
+  }
+  template<class... Args>
+  auto operator()(Args&&... args) const&
+  -> decltype(!std::declval<result_of_t<DecayF const&(Args...)>>()) {
+    return !fn(std::forward<Args>(args)...);
+  }
+
+  template<class... Args>
+  auto operator()(Args&&... args) &&
+  -> decltype(!std::declval<result_of_t<DecayF(Args...)>>()) {
+    return !std::move(fn)(std::forward<Args>(args)...);
+  }
+  template<class... Args>
+  auto operator()(Args&&... args) const&&
+  -> decltype(!std::declval<result_of_t<DecayF const(Args...)>>()) {
+    return !std::move(fn)(std::forward<Args>(args)...);
+  }
+};
+
+template <typename F>
+not_fn_result<F> not_fn(F&& fn) {
+  return not_fn_result<F>(std::forward<F>(fn));
+}
+
 } // namespace _backport17
 using _backport14::make_unique;
 using _backport17::size;
 using _backport14::max;
+using _backport17::not_fn;
 } // namespace ceph
 
 #endif // CEPH_COMMON_BACKPORT14_H

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -110,6 +110,7 @@ set(rgw_a_srcs
   rgw_rest_usage.cc
   rgw_rest_user.cc
   rgw_role.cc
+  rgw_string.cc
   rgw_swift_auth.cc
   rgw_tag.cc
   rgw_tag_s3.cc

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1849,77 +1849,28 @@ int rgw_parse_op_type_list(const string& str, uint32_t *perm)
   return parse_list_of_flags(op_type_mapping, str, perm);
 }
 
-static int match_internal(boost::string_ref pattern, boost::string_ref input, int (*function)(const char&, const char&))
+bool match_policy(boost::string_view pattern, boost::string_view input,
+                  uint32_t flag)
 {
-  boost::string_ref::iterator it1 = pattern.begin();
-  boost::string_ref::iterator it2 = input.begin();
-  while(true) {
-    if (it1 == pattern.end() && it2 == input.end())
-        return 1;
-    if (it1 == pattern.end() || it2 == input.end())
-        return 0;
-    if (*it1 == '*' && (it1 + 1) == pattern.end() && it2 != input.end())
-      return 1;
-    if (*it1 == '*' && (it1 + 1) == pattern.end() && it2 == input.end())
-      return 0;
-    if (function(*it1, *it2) || *it1 == '?') {
-      ++it1;
-      ++it2;
-      continue;
-    }
-    if (*it1 == '*') {
-      if (function(*(it1 + 1), *it2))
-        ++it1;
-      else
-        ++it2;
-      continue;
-    }
-    return 0;
-  }
-  return 0;
-}
+  const uint32_t flag2 = flag & (MATCH_POLICY_ACTION|MATCH_POLICY_ARN) ?
+      MATCH_CASE_INSENSITIVE : 0;
 
-static int matchcase(const char& c1, const char& c2)
-{
-  if (c1 == c2)
-      return 1;
-  return 0;
-}
-
-static int matchignorecase(const char& c1, const char& c2)
-{
-  if (tolower(c1) == tolower(c2))
-      return 1;
-  return 0;
-}
-
-int match(const string& pattern, const string& input, uint32_t flag)
-{
-  auto last_pos_input = 0, last_pos_pattern = 0;
-
-  while(true) {
+  const auto npos = boost::string_view::npos;
+  boost::string_view::size_type last_pos_input = 0, last_pos_pattern = 0;
+  while (true) {
     auto cur_pos_input = input.find(":", last_pos_input);
     auto cur_pos_pattern = pattern.find(":", last_pos_pattern);
 
-    string substr_input = input.substr(last_pos_input, cur_pos_input);
-    string substr_pattern = pattern.substr(last_pos_pattern, cur_pos_pattern);
+    auto substr_input = input.substr(last_pos_input, cur_pos_input);
+    auto substr_pattern = pattern.substr(last_pos_pattern, cur_pos_pattern);
 
-    int res;
-    if (substr_pattern == "*") {
-      res = 1;
-    } else if (flag & MATCH_POLICY_ACTION || flag & MATCH_POLICY_ARN) {
-      res = match_internal(substr_pattern, substr_input, &matchignorecase);
-    } else {
-      res = match_internal(substr_pattern, substr_input, &matchcase);
-    }
-    if (res == 0)
-      return 0;
+    if (!match_wildcards(substr_pattern, substr_input, flag2))
+      return false;
 
-    if (cur_pos_pattern == string::npos && cur_pos_input == string::npos)
-      return 1;
-    else if ((cur_pos_pattern == string::npos && cur_pos_input != string::npos) ||
-	     (cur_pos_pattern != string::npos && cur_pos_input == string::npos))
-      return 0;
+    if (cur_pos_pattern == npos)
+      return cur_pos_input == npos;
+    if (cur_pos_input == npos)
+      return false;
 
     last_pos_pattern = cur_pos_pattern + 1;
     last_pos_input = cur_pos_input + 1;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2307,12 +2307,12 @@ extern std::string calc_hash_sha256_restart_stream(ceph::crypto::SHA256** phash)
 
 extern int rgw_parse_op_type_list(const string& str, uint32_t *perm);
 
-namespace {
-  constexpr uint32_t MATCH_POLICY_ACTION = 0x01;
-  constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;
-  constexpr uint32_t MATCH_POLICY_ARN = 0x04;
-  constexpr uint32_t MATCH_POLICY_STRING = 0x08;
-}
+static constexpr uint32_t MATCH_POLICY_ACTION = 0x01;
+static constexpr uint32_t MATCH_POLICY_RESOURCE = 0x02;
+static constexpr uint32_t MATCH_POLICY_ARN = 0x04;
+static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 
-int match(const std::string& pattern, const std::string& input, uint32_t flag);
+extern bool match_policy(boost::string_view pattern, boost::string_view input,
+                         uint32_t flag);
+
 #endif

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -956,12 +956,11 @@ bool Condition::eval(const Environment& env) const {
   case TokenID::StringNotEqualsIgnoreCase:
     return orrible(std::not2(ci_equal_to()), s, vals);
 
-    // Implement actual StringLike with wildcarding later
   case TokenID::StringLike:
-    return orrible(std::equal_to<std::string>(), s, vals);
+    return orrible(string_like(), s, vals);
+
   case TokenID::StringNotLike:
-    return orrible(std::not2(std::equal_to<std::string>()),
-		   s, vals);
+    return orrible(std::not2(string_like()), s, vals);
 
     // Numeric
   case TokenID::NumericEquals:

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -389,15 +389,15 @@ bool ARN::match(const ARN& candidate) const {
     return false;
   }
 
-  if (!::match(region, candidate.region, MATCH_POLICY_ARN)) {
+  if (!match_policy(region, candidate.region, MATCH_POLICY_ARN)) {
     return false;
   }
 
-  if (!::match(account, candidate.account, MATCH_POLICY_ARN)) {
+  if (!match_policy(account, candidate.account, MATCH_POLICY_ARN)) {
     return false;
   }
 
-  if (!::match(resource, candidate.resource, MATCH_POLICY_ARN)) {
+  if (!match_policy(resource, candidate.resource, MATCH_POLICY_ARN)) {
     return false;
   }
 
@@ -802,7 +802,7 @@ bool ParseState::do_string(CephContext* cct, const char* s, size_t l) {
   } else if ((w->id == TokenID::Action) ||
 	     (w->id == TokenID::NotAction)) {
     for (auto& p : actpairs) {
-      if (match({s, l}, p.name, MATCH_POLICY_ACTION)) {
+      if (match_policy({s, l}, p.name, MATCH_POLICY_ACTION)) {
 	(w->id == TokenID::Action ? t->action : t->notaction) |= p.bit;
       }
     }

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -11,6 +11,7 @@
 #include <iostream>
 #include "rapidjson/reader.h"
 
+#include "common/backport14.h"
 #include "rgw_auth.h"
 #include <arpa/inet.h>
 #include "rgw_iam_policy.h"
@@ -947,27 +948,27 @@ bool Condition::eval(const Environment& env) const {
     return orrible(std::equal_to<std::string>(), s, vals);
 
   case TokenID::StringNotEquals:
-    return orrible(std::not2(std::equal_to<std::string>()),
+    return orrible(ceph::not_fn(std::equal_to<std::string>()),
 		   s, vals);
 
   case TokenID::StringEqualsIgnoreCase:
     return orrible(ci_equal_to(), s, vals);
 
   case TokenID::StringNotEqualsIgnoreCase:
-    return orrible(std::not2(ci_equal_to()), s, vals);
+    return orrible(ceph::not_fn(ci_equal_to()), s, vals);
 
   case TokenID::StringLike:
     return orrible(string_like(), s, vals);
 
   case TokenID::StringNotLike:
-    return orrible(std::not2(string_like()), s, vals);
+    return orrible(ceph::not_fn(string_like()), s, vals);
 
     // Numeric
   case TokenID::NumericEquals:
     return shortible(std::equal_to<double>(), as_number, s, vals);
 
   case TokenID::NumericNotEquals:
-    return shortible(std::not2(std::equal_to<double>()),
+    return shortible(ceph::not_fn(std::equal_to<double>()),
 		     as_number, s, vals);
 
 
@@ -989,7 +990,7 @@ bool Condition::eval(const Environment& env) const {
     return shortible(std::equal_to<ceph::real_time>(), as_date, s, vals);
 
   case TokenID::DateNotEquals:
-    return shortible(std::not2(std::equal_to<ceph::real_time>()),
+    return shortible(ceph::not_fn(std::equal_to<ceph::real_time>()),
 		     as_date, s, vals);
 
   case TokenID::DateLessThan:
@@ -1020,7 +1021,7 @@ bool Condition::eval(const Environment& env) const {
     return shortible(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
-    return shortible(std::not2(std::equal_to<MaskedIP>()), as_network, s,
+    return shortible(ceph::not_fn(std::equal_to<MaskedIP>()), as_network, s,
 		     vals);
 
 #if 0

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -24,11 +24,10 @@
 #include "rapidjson/error/error.h"
 #include "rapidjson/error/en.h"
 
-#include "fnmatch.h"
-
 #include "rgw_acl.h"
 #include "rgw_basic_types.h"
 #include "rgw_iam_policy_keywords.h"
+#include "rgw_string.h"
 
 #include "include/assert.h" // razzin' frazzin' ...grrr.
 
@@ -362,6 +361,14 @@ struct Condition {
     }
   };
 
+  struct string_like : public std::binary_function<const std::string,
+                                                   const std::string,
+                                                   bool> {
+    bool operator ()(const std::string& input,
+                     const std::string& pattern) const {
+      return match_wildcards(pattern, input, 0);
+    }
+  };
 
   template<typename F>
   static bool orrible(F&& f, const std::string& c,

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -352,18 +352,14 @@ struct Condition {
   static boost::optional<MaskedIP> as_network(const std::string& s);
 
 
-  struct ci_equal_to : public std::binary_function<const std::string,
-						   const std::string,
-						   bool> {
+  struct ci_equal_to {
     bool operator ()(const std::string& s1,
 		     const std::string& s2) const {
       return boost::iequals(s1, s2);
     }
   };
 
-  struct string_like : public std::binary_function<const std::string,
-                                                   const std::string,
-                                                   bool> {
+  struct string_like {
     bool operator ()(const std::string& input,
                      const std::string& pattern) const {
       return match_wildcards(pattern, input, 0);

--- a/src/rgw/rgw_string.cc
+++ b/src/rgw/rgw_string.cc
@@ -1,0 +1,45 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "rgw_string.h"
+
+static bool char_eq(char c1, char c2)
+{
+  return c1 == c2;
+}
+
+static bool ci_char_eq(char c1, char c2)
+{
+  return tolower(c1) == tolower(c2);
+}
+
+bool match_wildcards(boost::string_view pattern, boost::string_view input,
+                     uint32_t flags)
+{
+  const auto eq = (flags & MATCH_CASE_INSENSITIVE) ? &ci_char_eq : &char_eq;
+
+  auto it1 = pattern.begin();
+  auto it2 = input.begin();
+  while (true) {
+    if (it1 == pattern.end())
+      return it2 == input.end();
+    if (*it1 == '*') {
+      if (it1 + 1 == pattern.end())
+        return true;
+      if (it2 == input.end() || eq(*(it1 + 1), *it2))
+        ++it1;
+      else
+        ++it2;
+      continue;
+    }
+    if (it2 == input.end())
+      return false;
+    if (*it1 == '?' || eq(*it1, *it2)) {
+      ++it1;
+      ++it2;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}

--- a/src/rgw/rgw_string.h
+++ b/src/rgw/rgw_string.h
@@ -223,4 +223,14 @@ std::string string_join_reserve(char delim, const Args&... args)
   return string_join_reserve(boost::string_view{&delim, 1}, args...);
 }
 
+
+/// use case-insensitive comparison in match_wildcards()
+static constexpr uint32_t MATCH_CASE_INSENSITIVE = 0x01;
+
+/// attempt to match the given input string with the pattern, which may contain
+/// the wildcard characters * and ?
+extern bool match_wildcards(boost::string_view pattern,
+                            boost::string_view input,
+                            uint32_t flags = 0);
+
 #endif

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -271,4 +271,8 @@ add_executable(unittest_iso_8601
     test_iso_8601.cc)
 target_link_libraries(unittest_iso_8601 ceph-common)
 add_ceph_unittest(unittest_iso_8601
-  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_hostname)
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_iso_8601)
+
+add_executable(unittest_backport14 test_backport14.cc)
+add_ceph_unittest(unittest_backport14
+  ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_backport14)

--- a/src/test/common/test_backport14.cc
+++ b/src/test/common/test_backport14.cc
@@ -1,0 +1,94 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * Author: Casey Bodley <cbodley@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include "common/backport14.h" // include first: tests that header is standalone
+#include <gtest/gtest.h>
+
+int int_func() { return 1; }
+bool bool_func0() { return true; }
+bool bool_func1(int a) { return true; }
+bool bool_func2(const std::string& a, int b) { return true; }
+
+// given a callable and argument list, test that the result of ceph::not_fn
+// evaluates to false as both an lvalue and rvalue
+template <typename F, typename ...Args>
+void test_not(F&& fn, Args&&... args)
+{
+  auto res = ceph::not_fn(std::forward<F>(fn));
+  // test res as lvalue
+  EXPECT_FALSE(res(std::forward<Args>(args)...));
+  // test res as rvalue
+  // note: this forwards args twice, but it's okay if none are rvalues
+  EXPECT_FALSE(std::move(res)(std::forward<Args>(args)...));
+}
+
+TEST(Backport14, not_fn)
+{
+  // function pointers
+  test_not(int_func);
+  test_not(&int_func);
+  test_not(bool_func0);
+  test_not(&bool_func0);
+  test_not(bool_func1, 5);
+  test_not(bool_func2, "foo", 5);
+
+  // lambdas
+  auto int_lambda = [] { return 1; };
+  auto bool_lambda0 = [] { return true; };
+  auto bool_lambda1 = [] (int a) { return true; };
+  auto bool_lambda2 = [] (const std::string& a, int b) { return true; };
+
+  test_not(int_lambda);
+  test_not(bool_lambda0);
+  test_not(bool_lambda1, 5);
+  test_not(bool_lambda2, "foo", 5);
+
+  // functors
+  struct int_functor {
+    int operator()() { return 1; }
+  };
+  test_not(int_functor{});
+
+  struct bool_functor {
+    bool operator()() { return true; }
+    bool operator()(int a) { return true; }
+    bool operator()(const std::string& a, int b) { return true; }
+  };
+
+  test_not(bool_functor{});
+  test_not(bool_functor{}, 5);
+  test_not(bool_functor{}, "foo", 5);
+
+  // lvalue-only overload
+  struct lvalue_only_functor {
+    bool operator()() & { return true; } // no overload for rvalue
+  };
+  auto lvalue_result = ceph::not_fn(lvalue_only_functor{});
+  EXPECT_FALSE(lvalue_result());
+  // should not compile:
+  //   EXPECT_FALSE(std::move(lvalue_result)());
+
+  // rvalue-only overload
+  struct rvalue_only_functor {
+    bool operator()() && { return true; } // no overload for lvalue
+  };
+  EXPECT_FALSE(ceph::not_fn(rvalue_only_functor{})());
+  auto lvalue_functor = rvalue_only_functor{};
+  EXPECT_FALSE(ceph::not_fn(lvalue_functor)()); // lvalue functor, rvalue result
+  // should not compile:
+  //   auto lvalue_result2 = ceph::not_fn(rvalue_only_functor{});
+  //   EXPECT_FALSE(lvalue_result2());
+}

--- a/src/test/rgw/CMakeLists.txt
+++ b/src/test/rgw/CMakeLists.txt
@@ -108,11 +108,9 @@ target_link_libraries(unittest_rgw_crypto
 set_target_properties(unittest_rgw_crypto PROPERTIES COMPILE_FLAGS$ {UNITTEST_CXX_FLAGS})
 
 # ceph_test_rgw_iam_policy
-set(test_rgw_iam_policy_srcs test_rgw_iam_policy.cc)
-add_executable(ceph_test_rgw_iam_policy
-  ${test_rgw_iam_policy_srcs}
-  )
-target_link_libraries(ceph_test_rgw_iam_policy
+add_executable(unittest_rgw_iam_policy test_rgw_iam_policy.cc)
+add_ceph_unittest(unittest_rgw_iam_policy ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/unittest_rgw_iam_policy)
+target_link_libraries(unittest_rgw_iam_policy
   rgw_a
   cls_rgw_client
   cls_lock_client
@@ -130,7 +128,7 @@ target_link_libraries(ceph_test_rgw_iam_policy
   ${UNITTEST_LIBS}
   ${CRYPTO_LIBS}
   )
-set_target_properties(ceph_test_rgw_iam_policy PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
+set_target_properties(unittest_rgw_iam_policy PROPERTIES COMPILE_FLAGS ${UNITTEST_CXX_FLAGS})
 
 # unitttest_rgw_string
 add_executable(unittest_rgw_string test_rgw_string.cc)

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -61,7 +61,9 @@ using rgw::IAM::s3GetObject;
 using rgw::IAM::s3GetObjectAcl;
 using rgw::IAM::s3GetObjectVersionAcl;
 using rgw::IAM::s3GetObjectTorrent;
+using rgw::IAM::s3GetObjectTagging;
 using rgw::IAM::s3GetObjectVersion;
+using rgw::IAM::s3GetObjectVersionTagging;
 using rgw::IAM::s3GetObjectVersionTorrent;
 using rgw::IAM::s3GetReplicationConfiguration;
 using rgw::IAM::s3ListAllMyBuckets;
@@ -324,7 +326,9 @@ TEST_F(PolicyTest, Parse3) {
 				      s3GetBucketTagging |
 				      s3GetBucketWebsite |
 				      s3GetLifecycleConfiguration |
-				      s3GetReplicationConfiguration));
+				      s3GetReplicationConfiguration |
+				      s3GetObjectTagging |
+				      s3GetObjectVersionTagging));
   EXPECT_EQ(p->statements[2].notaction, s3None);
   ASSERT_FALSE(p->statements[2].resource.empty());
   ASSERT_EQ(p->statements[2].resource.size(), 2U);
@@ -370,7 +374,8 @@ TEST_F(PolicyTest, Eval3) {
 		  s3GetBucketPolicy | s3GetBucketNotification |
 		  s3GetBucketLogging | s3GetBucketTagging |
 		  s3GetBucketWebsite | s3GetLifecycleConfiguration |
-		  s3GetReplicationConfiguration);
+		  s3GetReplicationConfiguration |
+		  s3GetObjectTagging | s3GetObjectVersionTagging);
 
   EXPECT_EQ(p.eval(em, none, s3PutBucketPolicy,
 		   ARN(Partition::aws, Service::s3,

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -505,3 +505,120 @@ string PolicyTest::example3 = R"(
   ]
 }
 )";
+
+TEST(MatchWildcards, Simple)
+{
+  EXPECT_TRUE(match_wildcards("", ""));
+  EXPECT_TRUE(match_wildcards("", "", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("", "abc"));
+  EXPECT_FALSE(match_wildcards("", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abc", ""));
+  EXPECT_FALSE(match_wildcards("abc", "", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("abc", "abc"));
+  EXPECT_TRUE(match_wildcards("abc", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abc", "abC"));
+  EXPECT_TRUE(match_wildcards("abc", "abC", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abC", "abc"));
+  EXPECT_TRUE(match_wildcards("abC", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abc", "abcd"));
+  EXPECT_FALSE(match_wildcards("abc", "abcd", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abcd", "abc"));
+  EXPECT_FALSE(match_wildcards("abcd", "abc", MATCH_CASE_INSENSITIVE));
+}
+
+TEST(MatchWildcards, QuestionMark)
+{
+  EXPECT_FALSE(match_wildcards("?", ""));
+  EXPECT_FALSE(match_wildcards("?", "", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("?", "a"));
+  EXPECT_TRUE(match_wildcards("?", "a", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("?bc", "abc"));
+  EXPECT_TRUE(match_wildcards("?bc", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a?c", "abc"));
+  EXPECT_TRUE(match_wildcards("a?c", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("abc", "a?c"));
+  EXPECT_FALSE(match_wildcards("abc", "a?c", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("a?c", "abC"));
+  EXPECT_TRUE(match_wildcards("a?c", "abC", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("ab?", "abc"));
+  EXPECT_TRUE(match_wildcards("ab?", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a?c?e", "abcde"));
+  EXPECT_TRUE(match_wildcards("a?c?e", "abcde", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("???", "abc"));
+  EXPECT_TRUE(match_wildcards("???", "abc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("???", "abcd"));
+  EXPECT_FALSE(match_wildcards("???", "abcd", MATCH_CASE_INSENSITIVE));
+}
+
+TEST(MatchWildcards, Asterisk)
+{
+  EXPECT_TRUE(match_wildcards("*", ""));
+  EXPECT_TRUE(match_wildcards("*", "", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("", "*"));
+  EXPECT_FALSE(match_wildcards("", "*", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("*a", ""));
+  EXPECT_FALSE(match_wildcards("*a", "", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("*a", "a"));
+  EXPECT_TRUE(match_wildcards("*a", "a", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a*", "a"));
+  EXPECT_TRUE(match_wildcards("a*", "a", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a*c", "ac"));
+  EXPECT_TRUE(match_wildcards("a*c", "ac", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a*c", "abbc"));
+  EXPECT_TRUE(match_wildcards("a*c", "abbc", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("a*c", "abbC"));
+  EXPECT_TRUE(match_wildcards("a*c", "abbC", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("a*c*e", "abBce"));
+  EXPECT_TRUE(match_wildcards("a*c*e", "abBce", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("http://*.example.com",
+                              "http://www.example.com"));
+  EXPECT_TRUE(match_wildcards("http://*.example.com",
+                              "http://www.example.com", MATCH_CASE_INSENSITIVE));
+  EXPECT_FALSE(match_wildcards("http://*.example.com",
+                               "http://www.Example.com"));
+  EXPECT_TRUE(match_wildcards("http://*.example.com",
+                              "http://www.Example.com", MATCH_CASE_INSENSITIVE));
+  EXPECT_TRUE(match_wildcards("http://example.com/*",
+                              "http://example.com/index.html"));
+  EXPECT_TRUE(match_wildcards("http://example.com/*/*.jpg",
+                              "http://example.com/fun/smiley.jpg"));
+  // note: parsing of * is not greedy, so * does not match 'bc' here
+  EXPECT_FALSE(match_wildcards("a*c", "abcc"));
+  EXPECT_FALSE(match_wildcards("a*c", "abcc", MATCH_CASE_INSENSITIVE));
+}
+
+TEST(MatchPolicy, Action)
+{
+  constexpr auto flag = MATCH_POLICY_ACTION;
+  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
+  EXPECT_TRUE(match_policy("a:b:c", "A:B:C", flag)); // case insensitive
+  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
+  EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
+}
+
+TEST(MatchPolicy, Resource)
+{
+  constexpr auto flag = MATCH_POLICY_RESOURCE;
+  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
+  EXPECT_FALSE(match_policy("a:b:c", "A:B:C", flag)); // case sensitive
+  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
+  EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
+}
+
+TEST(MatchPolicy, ARN)
+{
+  constexpr auto flag = MATCH_POLICY_ARN;
+  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
+  EXPECT_TRUE(match_policy("a:b:c", "A:B:C", flag)); // case insensitive
+  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
+  EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
+}
+
+TEST(MatchPolicy, String)
+{
+  constexpr auto flag = MATCH_POLICY_STRING;
+  EXPECT_TRUE(match_policy("a:b:c", "a:b:c", flag));
+  EXPECT_FALSE(match_policy("a:b:c", "A:B:C", flag)); // case sensitive
+  EXPECT_TRUE(match_policy("a:*:e", "a:bcd:e", flag));
+  EXPECT_FALSE(match_policy("a:*", "a:b:c", flag)); // cannot span segments
+}


### PR DESCRIPTION
the `match()` function used elsewhere in iam has some special handling for `:`s (because wildcards aren't supposed to span sections), so it wasn't appropriate for general-purpose StringLike matching (especially with urls). the `match_internal()` function, however, did most of what we needed. so i refactored that as `match_wildcards()` with some minor changes, and moved it to rgw_string.h. i also renamed `match()` to `match_policy()`. then added several unit tests for both interfaces

continuation of https://github.com/ceph/ceph/pull/15702

Fixes: http://tracker.ceph.com/issues/20308