### PR TITLE
rgw: multisite log tracing

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1537,6 +1537,8 @@ OPTION(rgw_sync_log_trim_interval, OPT_INT) // time in seconds between attempts 
 OPTION(rgw_sync_data_inject_err_probability, OPT_DOUBLE) // range [0, 1]
 OPTION(rgw_sync_meta_inject_err_probability, OPT_DOUBLE) // range [0, 1]
 OPTION(rgw_sync_trace_history_size, OPT_INT) // max number of complete sync trace entries to keep
+OPTION(rgw_sync_trace_per_node_log_size, OPT_INT) // how many log entries to keep per node
+OPTION(rgw_sync_trace_servicemap_update_interval, OPT_INT) // interval in seconds between sync trace servicemap update
 
 
 OPTION(rgw_period_push_interval, OPT_DOUBLE) // seconds to wait before retrying "period push"

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1536,6 +1536,7 @@ OPTION(rgw_sync_log_trim_interval, OPT_INT) // time in seconds between attempts 
 
 OPTION(rgw_sync_data_inject_err_probability, OPT_DOUBLE) // range [0, 1]
 OPTION(rgw_sync_meta_inject_err_probability, OPT_DOUBLE) // range [0, 1]
+OPTION(rgw_sync_trace_history_size, OPT_INT) // max number of complete sync trace entries to keep
 
 
 OPTION(rgw_period_push_interval, OPT_DOUBLE) // seconds to wait before retrying "period push"

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5787,6 +5787,7 @@ std::vector<Option> get_mds_client_options() {
     .set_default("")
     .set_description(""),
 
+
     Option("client_readahead_min", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(128*1024)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4856,6 +4856,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(0)
     .set_description(""),
 
+    Option("rgw_sync_trace_history_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(4096)
+    .set_description(""),
+
     Option("rgw_period_push_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(2)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4860,6 +4860,14 @@ std::vector<Option> get_rgw_options() {
     .set_default(4096)
     .set_description(""),
 
+    Option("rgw_sync_trace_per_node_log_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(32)
+    .set_description(""),
+
+    Option("rgw_sync_trace_servicemap_update_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(10)
+    .set_description(""),
+
     Option("rgw_period_push_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(2)
     .set_description(""),

--- a/src/common/subsys.h
+++ b/src/common/subsys.h
@@ -56,6 +56,7 @@ SUBSYS(finisher, 1, 1)
 SUBSYS(heartbeatmap, 1, 5)
 SUBSYS(perfcounter, 1, 5)
 SUBSYS(rgw, 1, 5)                 // log level for the Rados gateway
+SUBSYS(rgw_sync, 1, 5)
 SUBSYS(civetweb, 1, 10)
 SUBSYS(javaclient, 1, 5)
 SUBSYS(asok, 1, 5)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -76,6 +76,7 @@ set(rgw_a_srcs
   rgw_sync_module_es.cc
   rgw_sync_module_es_rest.cc
   rgw_sync_module_log.cc
+  rgw_sync_trace.cc
   rgw_period_history.cc
   rgw_period_puller.cc
   rgw_period_pusher.cc

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2899,22 +2899,19 @@ int RGWRunBucketSyncCoroutine::operate()
     tn->log(10, "took lease");
     yield call(new RGWReadBucketSyncStatusCoroutine(sync_env, bs, &sync_status));
     if (retcode < 0 && retcode != -ENOENT) {
-      tn->log(0, SSTR("ERROR: failed to read sync status for bucket="
-          << bucket_shard_str{bs}));
+      tn->log(0, "ERROR: failed to read sync status for bucket");
       lease_cr->go_down();
       drain_all();
       return set_cr_error(retcode);
     }
 
-    tn->log(20, SSTR("sync status for bucket "
-        << bucket_shard_str{bs} << ": " << sync_status.state));
+    tn->log(20, SSTR("sync status for bucket: " << sync_status.state));
 
     yield call(new RGWGetBucketInstanceInfoCR(sync_env->async_rados, sync_env->store, bs.bucket, &bucket_info));
     if (retcode == -ENOENT) {
       /* bucket instance info has not been synced in yet, fetch it now */
       yield {
-        tn->log(10, SSTR("no local info for bucket "
-            << bucket_str{bs.bucket} << ": fetching metadata"));
+        tn->log(10, SSTR("no local info for bucket:" << ": fetching metadata"));
         string raw_key = string("bucket.instance:") + bs.bucket.get_key();
 
         meta_sync_env.init(cct, sync_env->store, sync_env->store->rest_master_conn, sync_env->async_rados,
@@ -2945,8 +2942,7 @@ int RGWRunBucketSyncCoroutine::operate()
     if (sync_status.state == rgw_bucket_shard_sync_info::StateInit) {
       yield call(new RGWInitBucketShardSyncStatusCoroutine(sync_env, bs, sync_status));
       if (retcode < 0) {
-        tn->log(0, SSTR("ERROR: init sync on " << bucket_shard_str{bs}
-            << " failed, retcode=" << retcode));
+        tn->log(0, SSTR("ERROR: init sync on bucket failed, retcode=" << retcode));
         lease_cr->go_down();
         drain_all();
         return set_cr_error(retcode);
@@ -2958,8 +2954,7 @@ int RGWRunBucketSyncCoroutine::operate()
                                               status_oid, lease_cr.get(),
                                               sync_status.full_marker, tn));
       if (retcode < 0) {
-        tn->log(5, SSTR("full sync on " << bucket_shard_str{bs}
-            << " failed, retcode=" << retcode));
+        tn->log(5, SSTR("full sync on bucket failed, retcode=" << retcode));
         lease_cr->go_down();
         drain_all();
         return set_cr_error(retcode);
@@ -2972,8 +2967,7 @@ int RGWRunBucketSyncCoroutine::operate()
                                                      status_oid, lease_cr.get(),
                                                      sync_status.inc_marker, tn));
       if (retcode < 0) {
-        tn->log(5, SSTR("incremental sync on " << bucket_shard_str{bs}
-            << " failed, retcode=" << retcode));
+        tn->log(5, SSTR("incremental sync on bucket failed, retcode=" << retcode));
         lease_cr->go_down();
         drain_all();
         return set_cr_error(retcode);

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2776,10 +2776,12 @@ int RGWRunBucketSyncCoroutine::operate()
         meta_sync_env.init(cct, sync_env->store, sync_env->store->rest_master_conn, sync_env->async_rados,
                            sync_env->http_manager, sync_env->error_logger, sync_env->sync_tracer);
 
+#warning FIXME replace root_node with actual parent node
         call(new RGWMetaSyncSingleEntryCR(&meta_sync_env, raw_key,
                                           string() /* no marker */,
                                           MDLOG_STATUS_COMPLETE,
-                                          NULL /* no marker tracker */));
+                                          NULL /* no marker tracker */,
+                                          meta_sync_env.sync_tracer->root_node));
       }
       if (retcode < 0) {
         ldout(sync_env->cct, 0) << "ERROR: failed to fetch bucket instance info for " << bucket_str{bs.bucket} << dendl;

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -208,27 +208,29 @@ struct rgw_bucket_entry_owner {
 class RGWSyncErrorLogger;
 
 struct RGWDataSyncEnv {
-  CephContext *cct;
-  RGWRados *store;
-  RGWRESTConn *conn;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWHTTPManager *http_manager;
-  RGWSyncErrorLogger *error_logger;
+  CephContext *cct{nullptr};
+  RGWRados *store{nullptr};
+  RGWRESTConn *conn{nullptr};
+  RGWAsyncRadosProcessor *async_rados{nullptr};
+  RGWHTTPManager *http_manager{nullptr};
+  RGWSyncErrorLogger *error_logger{nullptr};
+  RGWSyncTraceManager *sync_tracer{nullptr};
   string source_zone;
-  RGWSyncModuleInstanceRef sync_module;
+  RGWSyncModuleInstanceRef sync_module{nullptr};
 
-  RGWDataSyncEnv() : cct(NULL), store(NULL), conn(NULL), async_rados(NULL), http_manager(NULL), error_logger(NULL), sync_module(NULL) {}
+  RGWDataSyncEnv() {}
 
   void init(CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
-            RGWSyncErrorLogger *_error_logger, const string& _source_zone,
-            RGWSyncModuleInstanceRef& _sync_module) {
+            RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
+            const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module) {
     cct = _cct;
     store = _store;
     conn = _conn;
     async_rados = _async_rados;
     http_manager = _http_manager;
     error_logger = _error_logger;
+    sync_tracer = _sync_tracer;
     source_zone = _source_zone;
     sync_module = _sync_module;
   }
@@ -256,7 +258,8 @@ public:
       http_manager(store->ctx(), completion_mgr),
       lock("RGWRemoteDataLog::lock"), data_sync_cr(NULL),
       initialized(false) {}
-  int init(const string& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger, RGWSyncModuleInstanceRef& module);
+  int init(const string& _source_zone, RGWRESTConn *_conn, RGWSyncErrorLogger *_error_logger,
+           RGWSyncTraceManager *_sync_tracer, RGWSyncModuleInstanceRef& module);
   void finish();
 
   int read_log_info(rgw_datalog_info *log_info);
@@ -467,6 +470,7 @@ public:
   int init(const string& _source_zone, RGWRESTConn *_conn,
            const rgw_bucket& bucket, int shard_id,
            RGWSyncErrorLogger *_error_logger,
+           RGWSyncTraceManager *_sync_tracer,
            RGWSyncModuleInstanceRef& _sync_module);
   void finish();
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -6,6 +6,7 @@
 #include "rgw_bucket.h"
 
 #include "rgw_sync_module.h"
+#include "rgw_sync_trace.h"
 
 #include "common/RWLock.h"
 #include "common/ceph_json.h"
@@ -248,6 +249,8 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
 
   RWLock lock;
   RGWDataSyncControlCR *data_sync_cr;
+
+  RGWSTNCRef tn;
 
   bool initialized;
 

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -250,7 +250,7 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
   RWLock lock;
   RGWDataSyncControlCR *data_sync_cr;
 
-  RGWSTNCRef tn;
+  RGWSyncTraceNodeRef tn;
 
   bool initialized;
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3673,7 +3673,6 @@ void RGWRados::finalize()
       sync_log_trimmer->stop();
     }
   }
-  delete sync_tracer;
   if (async_rados) {
     async_rados->stop();
   }
@@ -3711,6 +3710,7 @@ void RGWRados::finalize()
     delete data_notifier;
   }
   delete data_log;
+  delete sync_tracer;
   if (async_rados) {
     delete async_rados;
   }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -4527,6 +4527,10 @@ int RGWRados::init_complete()
 
   /* init it anyway, might run sync through radosgw-admin explicitly */
   sync_tracer = new RGWSyncTraceManager(cct, cct->_conf->rgw_sync_trace_history_size);
+  ret = sync_tracer->hook_to_admin_command();
+  if (ret < 0) {
+    return ret;
+  }
 
   if (run_sync_thread) {
     Mutex::Locker l(meta_sync_thread_lock);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -69,6 +69,7 @@ using namespace librados;
 
 #include "rgw_object_expirer_core.h"
 #include "rgw_sync.h"
+#include "rgw_sync_trace.h"
 #include "rgw_data_sync.h"
 #include "rgw_realm_watcher.h"
 #include "rgw_reshard.h"
@@ -3672,6 +3673,7 @@ void RGWRados::finalize()
       sync_log_trimmer->stop();
     }
   }
+  delete sync_tracer;
   if (async_rados) {
     async_rados->stop();
   }
@@ -4522,6 +4524,9 @@ int RGWRados::init_complete()
     meta_notifier = new RGWMetaNotifier(this, md_log);
     meta_notifier->start();
   }
+
+  /* init it anyway, might run sync through radosgw-admin explicitly */
+  sync_tracer = new RGWSyncTraceManager(cct, cct->_conf->rgw_sync_trace_history_size);
 
   if (run_sync_thread) {
     Mutex::Locker l(meta_sync_thread_lock);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -35,6 +35,7 @@ class RGWObjectExpirer;
 class RGWMetaSyncProcessorThread;
 class RGWDataSyncProcessorThread;
 class RGWSyncLogTrimThread;
+class RGWSyncTraceManager;
 class RGWRESTConn;
 struct RGWZoneGroup;
 struct RGWZoneParams;
@@ -2261,6 +2262,7 @@ class RGWRados
   RGWMetaNotifier *meta_notifier;
   RGWDataNotifier *data_notifier;
   RGWMetaSyncProcessorThread *meta_sync_processor_thread;
+  RGWSyncTraceManager *sync_tracer;
   map<string, RGWDataSyncProcessorThread *> data_sync_processor_threads;
 
   RGWSyncLogTrimThread *sync_log_trimmer{nullptr};
@@ -2507,6 +2509,9 @@ public:
   }
   const RGWSyncModuleInstanceRef& get_sync_module() {
     return sync_module;
+  }
+  RGWSyncTraceManager *get_sync_tracer() {
+    return sync_tracer;
   }
 
   int get_required_alignment(const rgw_pool& pool, uint64_t *alignment);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2565,6 +2565,7 @@ public:
   void finalize();
 
   int register_to_service_map(const string& daemon_type, const map<string, string>& meta);
+  int update_service_map(const std::map<std::string, std::string>& status);
 
   void schedule_context(Context *c);
 
@@ -3998,4 +3999,65 @@ public:
                    RGWPutObjProcessor_Atomic(obj_ctx, bucket_info, _s->bucket, _s->object.name, _p, _s->req_id, false), s(_s) {}
   void get_mp(RGWMPObj** _mp);
 }; /* RGWPutObjProcessor_Multipart */
+
+class RGWRadosThread {
+  class Worker : public Thread {
+    CephContext *cct;
+    RGWRadosThread *processor;
+    Mutex lock;
+    Cond cond;
+
+    void wait() {
+      Mutex::Locker l(lock);
+      cond.Wait(lock);
+    };
+
+    void wait_interval(const utime_t& wait_time) {
+      Mutex::Locker l(lock);
+      cond.WaitInterval(lock, wait_time);
+    }
+
+  public:
+    Worker(CephContext *_cct, RGWRadosThread *_p) : cct(_cct), processor(_p), lock("RGWRadosThread::Worker") {}
+    void *entry() override;
+    void signal() {
+      Mutex::Locker l(lock);
+      cond.Signal();
+    }
+  };
+
+  Worker *worker;
+
+protected:
+  CephContext *cct;
+  RGWRados *store;
+
+  std::atomic<bool> down_flag = { false };
+
+  string thread_name;
+
+  virtual uint64_t interval_msec() = 0;
+  virtual void stop_process() {}
+public:
+  RGWRadosThread(RGWRados *_store, const string& thread_name = "radosgw") 
+    : worker(NULL), cct(_store->ctx()), store(_store), thread_name(thread_name) {}
+  virtual ~RGWRadosThread() {
+    stop();
+  }
+
+  virtual int init() { return 0; }
+  virtual int process() = 0;
+
+  bool going_down() { return down_flag; }
+
+  void start();
+  void stop();
+
+  void signal() {
+    if (worker) {
+      worker->signal();
+    }
+  }
+};
+
 #endif

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -20,6 +20,7 @@
 #include "rgw_cr_rados.h"
 #include "rgw_cr_rest.h"
 #include "rgw_http_client.h"
+#include "rgw_sync_trace.h"
 
 #include "cls/lock/cls_lock_client.h"
 

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1735,7 +1735,7 @@ public:
               tn->log(0, SSTR("ERROR: failed to convert mdlog entry, shard_id=" << shard_id << " log_entry: " << log_iter->id << ":" << log_iter->section << ":" << log_iter->name << ":" << log_iter->timestamp << " ... skipping entry"));
               continue;
             }
-            tn->log(20, SSTR(" log_entry: " << log_iter->id << ":" << log_iter->section << ":" << log_iter->name << ":" << log_iter->timestamp));
+            tn->log(20, SSTR("log_entry: " << log_iter->id << ":" << log_iter->section << ":" << log_iter->name << ":" << log_iter->timestamp));
             if (!marker_tracker->start(log_iter->id, 0, log_iter->timestamp.to_real_time())) {
               ldout(sync_env->cct, 0) << "ERROR: cannot start syncing " << log_iter->id << ". Duplicate entry?" << dendl;
             } else {

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -426,18 +426,13 @@ class RGWMetaSyncSingleEntryCR : public RGWCoroutine {
 
   bool error_injection;
 
+  RGWSTNCRef tn;
+
 public:
   RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,
 		           const string& _raw_key, const string& _entry_marker,
                            const RGWMDLogStatus& _op_status,
-                           RGWMetaSyncShardMarkerTrack *_marker_tracker) : RGWCoroutine(_sync_env->cct),
-                                                      sync_env(_sync_env),
-						      raw_key(_raw_key), entry_marker(_entry_marker),
-                                                      op_status(_op_status),
-                                                      pos(0), sync_status(0),
-                                                      marker_tracker(_marker_tracker), tries(0) {
-    error_injection = (sync_env->cct->_conf->rgw_sync_meta_inject_err_probability > 0);
-  }
+                           RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent);
 
   int operate() override;
 };

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -60,6 +60,7 @@ class RGWAsyncRadosProcessor;
 class RGWMetaSyncStatusManager;
 class RGWMetaSyncCR;
 class RGWRESTConn;
+class RGWSyncTraceManager;
 
 class RGWSyncErrorLogger {
   RGWRados *store;
@@ -162,18 +163,19 @@ public:
 };
 
 struct RGWMetaSyncEnv {
-  CephContext *cct;
-  RGWRados *store;
-  RGWRESTConn *conn;
-  RGWAsyncRadosProcessor *async_rados;
-  RGWHTTPManager *http_manager;
-  RGWSyncErrorLogger *error_logger;
+  CephContext *cct{nullptr};
+  RGWRados *store{nullptr};
+  RGWRESTConn *conn{nullptr};
+  RGWAsyncRadosProcessor *async_rados{nullptr};
+  RGWHTTPManager *http_manager{nullptr};
+  RGWSyncErrorLogger *error_logger{nullptr};
+  RGWSyncTraceManager *sync_tracer{nullptr};
 
-  RGWMetaSyncEnv() : cct(NULL), store(NULL), conn(NULL), async_rados(NULL), http_manager(NULL), error_logger(NULL) {}
+  RGWMetaSyncEnv() {}
 
   void init(CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
-            RGWSyncErrorLogger *_error_logger);
+            RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer);
 
   string shard_obj_name(int shard_id);
   string status_oid();
@@ -186,9 +188,10 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
 
   RGWHTTPManager http_manager;
   RGWMetaSyncStatusManager *status_manager;
-  RGWSyncErrorLogger *error_logger;
+  RGWSyncErrorLogger *error_logger{nullptr};
+  RGWSyncTraceManager *sync_tracer{nullptr};
 
-  RGWMetaSyncCR *meta_sync_cr;
+  RGWMetaSyncCR *meta_sync_cr{nullptr};
 
   RGWSyncBackoff backoff;
 
@@ -205,7 +208,7 @@ public:
     : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
       store(_store), conn(NULL), async_rados(async_rados),
       http_manager(store->ctx(), completion_mgr),
-      status_manager(_sm), error_logger(NULL), meta_sync_cr(NULL) {}
+      status_manager(_sm) {}
 
   ~RGWRemoteMetaLog() override;
 

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -4,6 +4,7 @@
 #include "rgw_coroutine.h"
 #include "rgw_http_client.h"
 #include "rgw_meta_sync_status.h"
+#include "rgw_sync_trace.h"
 
 #include "include/stringify.h"
 #include "common/RWLock.h"
@@ -201,6 +202,8 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
   int store_sync_info(const rgw_meta_sync_info& sync_info);
 
   std::atomic<bool> going_down = { false };
+
+  RGWSTNCRef tn;
 
 public:
   RGWRemoteMetaLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -203,7 +203,7 @@ class RGWRemoteMetaLog : public RGWCoroutinesManager {
 
   std::atomic<bool> going_down = { false };
 
-  RGWSTNCRef tn;
+  RGWSyncTraceNodeRef tn;
 
 public:
   RGWRemoteMetaLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
@@ -426,7 +426,7 @@ class RGWMetaSyncSingleEntryCR : public RGWCoroutine {
 
   bool error_injection;
 
-  RGWSTNCRef tn;
+  RGWSyncTraceNodeRef tn;
 
 public:
   RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -430,7 +430,7 @@ class RGWMetaSyncSingleEntryCR : public RGWCoroutine {
 
 public:
   RGWMetaSyncSingleEntryCR(RGWMetaSyncEnv *_sync_env,
-		           const string& _raw_key, const string& _entry_marker,
+                           const string& _raw_key, const string& _entry_marker,
                            const RGWMDLogStatus& _op_status,
                            RGWMetaSyncShardMarkerTrack *_marker_tracker, const RGWSyncTraceNodeRef& _tn_parent);
 

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -1,18 +1,44 @@
 #ifndef CEPH_RGW_SYNC_TRACE_H
 #define CEPH_RGW_SYNC_TRACE_H
 
+#include "common/debug.h"
+
 #include "rgw_sync_trace.h"
 
 using namespace std;
 
-RGWSyncTraceNode::RGWSyncTraceNode(RGWSyncTraceManager *_manager, RGWSyncTraceNodeRef& _parent,
-                   const string& _type, const string& _trigger, const string& _id) : manager(_manager),
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rgw_sync
+
+RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_manager, const RGWSyncTraceNodeRef& _parent,
+                   const string& _type, const string& _trigger, const string& _id) : cct(_cct),
+                                                                                     manager(_manager),
                                                                                      parent(_parent),
                                                                                      type(_type),
                                                                                      trigger(_trigger),
                                                                                      id(_id)
 {
+  if (parent.get()) {
+    prefix = parent->get_prefix();
+  }
+  if (!trigger.empty()) {
+    prefix += trigger + ":";
+  }
+
+  if (!type.empty()) {
+    prefix += type;
+    if (!id.empty()) {
+      prefix += "[" + id + "]";
+    }
+    prefix += ":";
+  }
   handle = manager->alloc_handle();
+}
+
+void RGWSyncTraceNode::log(int level, const string& s)
+{
+  status = s;
+  ldout(cct, level) << "RGW-SYNC:" << to_str() << dendl;
 }
 
 void RGWSyncTraceNode::finish(int ret) {

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -41,22 +41,23 @@ void RGWSyncTraceNode::log(int level, const string& s)
   ldout(cct, level) << "RGW-SYNC:" << to_str() << dendl;
 }
 
-void RGWSyncTraceNode::finish(int ret) {
-  char buf[32];
-  snprintf(buf, sizeof(buf), "status=%d", ret);
-
-  status = buf;
-
+void RGWSyncTraceNode::finish()
+{
   manager->finish_node(this);
 }
 
 
-RGWSyncTraceNodeRef& RGWSyncTraceManager::add_node(RGWSyncTraceNode *node)
+RGWSTNCRef RGWSyncTraceManager::add_node(RGWSyncTraceNode *node)
 {
   RWLock::WLocker wl(lock);
   RGWSyncTraceNodeRef& ref = nodes[node->handle];
   ref.reset(node);
-  return ref;
+  return RGWSTNCRef(new RGWSyncTraceNodeContainer(ref));
+}
+
+RGWSyncTraceNodeContainer::~RGWSyncTraceNodeContainer()
+{
+  tn->finish();
 }
 
 void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -38,7 +38,12 @@ RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_mana
 void RGWSyncTraceNode::log(int level, const string& s)
 {
   status = s;
-  ldout(cct, level) << "RGW-SYNC:" << to_str() << dendl;
+  /* dump output on either rgw_sync, or rgw -- but only once */
+  if (cct->_conf->subsys.should_gather(ceph_subsys_rgw_sync, level)) {
+    lsubdout(cct, rgw_sync, level) << "RGW-SYNC:" << to_str() << dendl;
+  } else {
+    lsubdout(cct, rgw, level) << "RGW-SYNC:" << to_str() << dendl;
+  }
 }
 
 void RGWSyncTraceNode::finish()

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -1,0 +1,51 @@
+#ifndef CEPH_RGW_SYNC_TRACE_H
+#define CEPH_RGW_SYNC_TRACE_H
+
+#include "rgw_sync_trace.h"
+
+using namespace std;
+
+RGWSyncTraceNode::RGWSyncTraceNode(RGWSyncTraceManager *_manager, RGWSyncTraceNodeRef& _parent,
+                   const string& _type, const string& _trigger, const string& _id) : manager(_manager),
+                                                                                     parent(_parent),
+                                                                                     type(_type),
+                                                                                     trigger(_trigger),
+                                                                                     id(_id)
+{
+  handle = manager->alloc_handle();
+}
+
+void RGWSyncTraceNode::finish(int ret) {
+  char buf[32];
+  snprintf(buf, sizeof(buf), "status=%d", ret);
+
+  status = buf;
+
+  manager->finish_node(this);
+}
+
+
+RGWSyncTraceNodeRef& RGWSyncTraceManager::add_node(RGWSyncTraceNode *node)
+{
+  RWLock::WLocker wl(lock);
+  RGWSyncTraceNodeRef& ref = nodes[node->handle];
+  ref.reset(node);
+  return ref;
+}
+
+void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)
+{
+  RWLock::WLocker wl(lock);
+  auto iter = nodes.find(node->handle);
+  if (iter == nodes.end()) {
+    /* not found, already finished */
+    return;
+  }
+
+  complete_nodes.push_back(iter->second);
+  nodes.erase(iter);
+};
+
+
+#endif
+

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -194,6 +194,9 @@ bool RGWSyncTraceManager::call(std::string command, cmdmap_t& cmdmap, std::strin
 void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)
 {
   RWLock::WLocker wl(lock);
+  if (!node) {
+    return;
+  }
   auto iter = nodes.find(node->handle);
   if (iter == nodes.end()) {
     /* not found, already finished */

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -2,6 +2,7 @@
 #define CEPH_RGW_SYNC_TRACE_H
 
 #include "common/debug.h"
+#include "common/ceph_json.h"
 
 #include "rgw_sync_trace.h"
 
@@ -10,13 +11,14 @@ using namespace std;
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw_sync
 
+#warning history size configurable
 RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_manager, const RGWSyncTraceNodeRef& _parent,
                    const string& _type, const string& _trigger, const string& _id) : cct(_cct),
                                                                                      manager(_manager),
                                                                                      parent(_parent),
                                                                                      type(_type),
                                                                                      trigger(_trigger),
-                                                                                     id(_id)
+                                                                                     id(_id), history(32)
 {
   if (parent.get()) {
     prefix = parent->get_prefix();
@@ -38,6 +40,7 @@ RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_mana
 void RGWSyncTraceNode::log(int level, const string& s)
 {
   status = s;
+  history.push_back(status);
   /* dump output on either rgw_sync, or rgw -- but only once */
   if (cct->_conf->subsys.should_gather(ceph_subsys_rgw_sync, level)) {
     lsubdout(cct, rgw_sync, level) << "RGW-SYNC:" << to_str() << dendl;
@@ -65,6 +68,113 @@ RGWSyncTraceNodeContainer::~RGWSyncTraceNodeContainer()
   tn->finish();
 }
 
+bool RGWSyncTraceNode::match(const string& search_term, bool search_history)
+{
+  if (prefix.find(search_term) != string::npos) {
+    return true;
+  }
+  if (status.find(search_term) != string::npos) {
+    return true;
+  }
+  if (!search_history) {
+    return false;
+  }
+
+  for (auto h : history) {
+    if (h.find(search_term) != string::npos) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+RGWSyncTraceManager::~RGWSyncTraceManager()
+{
+  AdminSocket *admin_socket = cct->get_admin_socket();
+  for (auto cmd : admin_commands) {
+    admin_socket->unregister_command(cmd[0]);
+  }
+}
+
+int RGWSyncTraceManager::hook_to_admin_command()
+{
+  AdminSocket *admin_socket = cct->get_admin_socket();
+
+  admin_commands = { { "sync trace show", "sync trace show name=search,type=CephString,req=false", "sync trace show [filter_str]: show current multisite tracing information" },
+                     { "sync trace history", "sync trace history name=search,type=CephString,req=false", "sync trace history [filter_str]: show history of multisite tracing information" } };
+  for (auto cmd : admin_commands) {
+    int r = admin_socket->register_command(cmd[0], cmd[1], this,
+                                           cmd[2]);
+    if (r < 0) {
+      lderr(cct) << "ERROR: fail to register admin socket command (r=" << r << ")" << dendl;
+      return r;
+    }
+  }
+  return 0;
+}
+
+static void dump_node(RGWSyncTraceNode *entry, bool show_history, JSONFormatter& f)
+{
+  f.open_object_section("entry");
+  ::encode_json("status", entry->to_str(), &f);
+  if (show_history) {
+    f.open_array_section("history");
+    for (auto h : entry->get_history()) {
+      ::encode_json("entry", h, &f);
+    }
+    f.close_section();
+  }
+  f.close_section();
+}
+
+bool RGWSyncTraceManager::call(std::string command, cmdmap_t& cmdmap, std::string format,
+	    bufferlist& out) {
+
+  bool show_history = (command == "sync trace history");
+
+  string search;
+
+  auto si = cmdmap.find("search");
+  if (si != cmdmap.end()) {
+    search = boost::get<string>(si->second);
+  }
+
+  RWLock::RLocker rl(lock);
+
+  stringstream ss;
+  JSONFormatter f(true);
+
+  f.open_object_section("result");
+  f.open_array_section("running");
+  for (auto n : nodes) {
+    auto& entry = n.second;
+
+    if (!search.empty() && !entry->match(search, show_history)) {
+      continue;
+    }
+    dump_node(entry.get(), show_history, f);
+    f.flush(ss);
+  }
+  f.close_section();
+
+  f.open_array_section("complete");
+  for (auto& entry : complete_nodes) {
+    if (!search.empty() && !entry->match(search, show_history)) {
+      continue;
+    }
+    dump_node(entry.get(), show_history, f);
+    f.flush(ss);
+  }
+  f.close_section();
+
+  f.close_section();
+  f.flush(ss);
+  out.append(ss);
+
+  return true;
+}
+
 void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)
 {
   RWLock::WLocker wl(lock);
@@ -77,7 +187,6 @@ void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)
   complete_nodes.push_back(iter->second);
   nodes.erase(iter);
 };
-
 
 #endif
 

--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -81,7 +81,7 @@ int RGWSyncTraceServiceMapThread::process()
 
 RGWSyncTraceNodeRef RGWSyncTraceManager::add_node(RGWSyncTraceNode *node)
 {
-  RWLock::WLocker wl(lock);
+  shunique_lock wl(lock, ceph::acquire_unique);
   RGWSyncTraceNodeRef& ref = nodes[node->handle];
   ref.reset(node);
   // return a separate shared_ptr that calls finish() on the node instead of
@@ -208,7 +208,7 @@ bool RGWSyncTraceManager::call(std::string command, cmdmap_t& cmdmap, std::strin
     search = boost::get<string>(si->second);
   }
 
-  RWLock::RLocker rl(lock);
+  shunique_lock rl(lock, ceph::acquire_shared);
 
   stringstream ss;
   JSONFormatter f(true);
@@ -258,7 +258,7 @@ bool RGWSyncTraceManager::call(std::string command, cmdmap_t& cmdmap, std::strin
 
 void RGWSyncTraceManager::finish_node(RGWSyncTraceNode *node)
 {
-  RWLock::WLocker wl(lock);
+  shunique_lock wl(lock, ceph::acquire_unique);
   if (!node) {
     return;
   }

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -1,0 +1,87 @@
+#ifndef CEPH_RGW_SYNC_LOG_H
+#define CEPH_RGW_SYNC_LOG_H
+
+#include "include/atomic.h"
+
+#include "common/Mutex.h"
+#include "common/RWLock.h"
+
+#include <set>
+#include <ostream>
+#include <string>
+#include <boost/circular_buffer.hpp>
+
+enum RGWSyncTraceNodeState {
+  SNS_INACTIVE = 0,
+  SNS_ACTIVE   = 1,
+};
+
+class RGWSyncTraceManager;
+class RGWSyncTraceNode;
+
+using RGWSyncTraceNodeRef = std::shared_ptr<RGWSyncTraceNode>;
+
+class RGWSyncTraceNode {
+  friend class RGWSyncTraceManager;
+
+  RGWSyncTraceManager *manager{nullptr};
+  RGWSyncTraceNodeRef parent;
+
+  RGWSyncTraceNodeState state{SNS_INACTIVE};
+  std::string status;
+
+  Mutex lock{"RGWSyncTraceNode::lock"};
+
+protected:
+  std::string type;
+  std::string trigger;
+  std::string id;
+
+  uint64_t handle;
+
+public:
+  RGWSyncTraceNode(RGWSyncTraceManager *_manager, RGWSyncTraceNodeRef& _parent,
+           const std::string& _type, const std::string& _trigger, const std::string& _id);
+
+  void set_state(RGWSyncTraceNodeState s);
+  void set(const std::string& s) {
+    status = s;
+  }
+
+  std::string to_str() {
+    return trigger + ":" + id + ": " + status;
+  }
+
+  void finish(int ret);
+
+  std::ostream& operator<<(std::ostream& os) { 
+    os << to_str();
+    return os;            
+  }
+};
+
+
+class RGWSyncTraceManager {
+  friend class RGWSyncTraceNode;
+
+  std::map<uint64_t, RGWSyncTraceNodeRef> nodes;
+  boost::circular_buffer<RGWSyncTraceNodeRef> complete_nodes;
+
+  RWLock lock{"RGWSyncTraceManager::lock"};
+
+  atomic64_t count;
+
+protected:
+  uint64_t alloc_handle() {
+    return count.inc();
+  }
+
+public:
+  RGWSyncTraceManager(int max_lru) {}
+
+  RGWSyncTraceNodeRef& add_node(RGWSyncTraceNode *node);
+  void finish_node(RGWSyncTraceNode *node);
+};
+
+
+#endif

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -21,9 +21,11 @@
 #define RGW_SNS_FLAG_ACTIVE   1
 #define RGW_SNS_FLAG_ERROR    2
 
+class RGWRados;
 class RGWSyncTraceManager;
 class RGWSyncTraceNode;
 class RGWSyncTraceNodeContainer;
+class RGWSyncTraceServiceMapThread;
 
 using RGWSyncTraceNodeRef = std::shared_ptr<RGWSyncTraceNode>;
 using RGWSTNCRef = std::shared_ptr<RGWSyncTraceNodeContainer>;
@@ -146,6 +148,7 @@ class RGWSyncTraceManager : public AdminSocketHook {
   friend class RGWSyncTraceNode;
 
   CephContext *cct;
+  RGWSyncTraceServiceMapThread *service_map_thread{nullptr};
 
   std::map<uint64_t, RGWSyncTraceNodeRef> nodes;
   boost::circular_buffer<RGWSyncTraceNodeRef> complete_nodes;
@@ -161,9 +164,10 @@ protected:
   }
 
 public:
-#warning complete_nodes size configurable
-  RGWSyncTraceManager(CephContext *_cct, int max_lru) : cct(_cct), complete_nodes(512) {}
+  RGWSyncTraceManager(CephContext *_cct, int max_lru) : cct(_cct), complete_nodes(max_lru) {}
   ~RGWSyncTraceManager();
+
+  void init(RGWRados *store);
 
   const RGWSyncTraceNodeRef root_node;
 
@@ -172,6 +176,7 @@ public:
 
   int hook_to_admin_command();
   bool call(std::string command, cmdmap_t& cmdmap, std::string format, bufferlist& out);
+  string get_active_names();
 };
 
 

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -47,12 +47,22 @@ protected:
 
   std::string prefix;
 
+  std::string resource_name;
+
   uint64_t handle;
 
   boost::circular_buffer<string> history;
 public:
   RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_manager, const RGWSyncTraceNodeRef& _parent,
            const std::string& _type, const std::string& _id);
+
+  void set_resource_name(const string& s) {
+    resource_name = s;
+  }
+
+  const string& get_resource_name() {
+    return resource_name;
+  }
 
   void set_flag(uint16_t s) {
     state |= s;
@@ -104,6 +114,14 @@ public:
 
   RGWSyncTraceNodeRef& operator->() {
     return tn;
+  }
+
+  void set_resource_name(const string& s) {
+    tn->set_resource_name(s);
+  }
+
+  const string& get_resource_name() {
+    return tn->get_resource_name();
   }
 
   void set_flag(uint16_t flag) {

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -24,11 +24,9 @@
 class RGWRados;
 class RGWSyncTraceManager;
 class RGWSyncTraceNode;
-class RGWSyncTraceNodeContainer;
 class RGWSyncTraceServiceMapThread;
 
 using RGWSyncTraceNodeRef = std::shared_ptr<RGWSyncTraceNode>;
-using RGWSTNCRef = std::shared_ptr<RGWSyncTraceNodeContainer>;
 
 class RGWSyncTraceNode {
   friend class RGWSyncTraceManager;
@@ -98,52 +96,6 @@ public:
   bool match(const string& search_term, bool search_history);
 };
 
-/*
- * a container to RGWSyncTraceNodeRef, responsible to keep track
- * of live nodes, and when last ref is dropped, calls ->finish()
- * so that node moves to the retired list in the manager
- */
-class RGWSyncTraceNodeContainer {
-  RGWSyncTraceNodeRef tn;
-public:
-  RGWSyncTraceNodeContainer(RGWSyncTraceNodeRef& _tn) : tn(_tn) {}
-
-  ~RGWSyncTraceNodeContainer();
-
-  RGWSyncTraceNodeRef& operator*() {
-    return tn;
-  }
-
-  RGWSyncTraceNodeRef& operator->() {
-    return tn;
-  }
-
-  void set_resource_name(const string& s) {
-    tn->set_resource_name(s);
-  }
-
-  const string& get_resource_name() {
-    return tn->get_resource_name();
-  }
-
-  void set_flag(uint16_t flag) {
-    tn->set_flag(flag);
-  }
-  void unset_flag(uint16_t flag) {
-    tn->unset_flag(flag);
-  }
-  bool test_flags(uint16_t f) {
-    return tn->test_flags(f);
-  }
-  void log(int level, const std::string& s) {
-    return tn->log(level, s);
-  }
-  RGWSyncTraceNodeRef& ref() {
-    return tn;
-  }
-};
-
-
 class RGWSyncTraceManager : public AdminSocketHook {
   friend class RGWSyncTraceNode;
 
@@ -171,7 +123,7 @@ public:
 
   const RGWSyncTraceNodeRef root_node;
 
-  RGWSTNCRef add_node(RGWSyncTraceNode *node);
+  RGWSyncTraceNodeRef add_node(RGWSyncTraceNode *node);
   void finish_node(RGWSyncTraceNode *node);
 
   int hook_to_admin_command();

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -4,7 +4,7 @@
 #include <atomic>
 
 #include "common/Mutex.h"
-#include "common/RWLock.h"
+#include "common/shunique_lock.h"
 #include "common/admin_socket.h"
 
 #include <set>
@@ -105,7 +105,8 @@ class RGWSyncTraceManager : public AdminSocketHook {
   std::map<uint64_t, RGWSyncTraceNodeRef> nodes;
   boost::circular_buffer<RGWSyncTraceNodeRef> complete_nodes;
 
-  RWLock lock{"RGWSyncTraceManager::lock"};
+  mutable boost::shared_mutex lock;
+  using shunique_lock = ceph::shunique_lock<decltype(lock)>;
 
   std::atomic<uint64_t> count = { 0 };
 

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -1,7 +1,7 @@
 #ifndef CEPH_RGW_SYNC_LOG_H
 #define CEPH_RGW_SYNC_LOG_H
 
-#include "include/atomic.h"
+#include <atomic>
 
 #include "common/Mutex.h"
 #include "common/RWLock.h"
@@ -152,12 +152,12 @@ class RGWSyncTraceManager : public AdminSocketHook {
 
   RWLock lock{"RGWSyncTraceManager::lock"};
 
-  atomic64_t count;
+  std::atomic<uint64_t> count = { 0 };
 
   std::list<std::array<string, 3> > admin_commands;
 protected:
   uint64_t alloc_handle() {
-    return count.inc();
+    return ++count;
   }
 
 public:

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -99,14 +99,14 @@ public:
 class RGWSyncTraceManager : public AdminSocketHook {
   friend class RGWSyncTraceNode;
 
+  mutable boost::shared_mutex lock;
+  using shunique_lock = ceph::shunique_lock<decltype(lock)>;
+
   CephContext *cct;
   RGWSyncTraceServiceMapThread *service_map_thread{nullptr};
 
   std::map<uint64_t, RGWSyncTraceNodeRef> nodes;
   boost::circular_buffer<RGWSyncTraceNodeRef> complete_nodes;
-
-  mutable boost::shared_mutex lock;
-  using shunique_lock = ceph::shunique_lock<decltype(lock)>;
 
   std::atomic<uint64_t> count = { 0 };
 


### PR DESCRIPTION
A new framework that tracks in memory of current rgw sync process. The new system allows following a specific sync entity (vs. the current flat log dump). Each entity has an id that is a concatenation of the path within the execution tree. An entity would roughly reflect a sync role (meta, meta shard, meta entry, data, data shard, bucket shard, object), and it is possible to look at the history of that entity's point of view. New admin socket commands were added:
```
    "sync trace active": "show active multisite sync entities information"
    "sync trace active_short": "show active multisite sync entities entries"
    "sync trace history": "sync trace history [filter_str]: show history of multisite tracing information"
    "sync trace show": "sync trace show [filter_str]: show current multisite tracing information"
```
All commands can get an extra param that is a regex that can be used to search for a specific entity (matching the history of that entity). E.g.,

```
$ ceph --admin-daemon=/home/yehudasa/ceph/build/run/c2/out/radosgw.8001.asok sync trace show meta.*shard.13
{
    "running": [
        {
            "status": "meta:shard[13]: took lease"
        }
    ],
    "complete": []
}
```

We keep info about all current running nodes, and also keep some history of complete nodes. We can see a view of current nodes that are marked as active (where we identified and deal with actual meta/data sync):
```
$ ceph --admin-daemon=/home/yehudasa/ceph/build/run/c1/out/radosgw.8000.asok sync trace active
{
    "running": [
        {
            "status": "data:sync:shard[115]:entry[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]:bucket[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]:inc_sync[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]: listing bilog for incremental sync"
        },
        {
            "status": "data:sync:shard[115]:entry[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]:bucket[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]:inc_sync[buck:a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5]:entry[fff3]: bucket sync: sync obj: 8ef1cd9f-d0f2-485d-ba1e-c02f1f085b1c/buck[a6fabc5f-23bc-473c-9b05-ae8d1948dc08.4185.5])/fff3[0]"
        }
    ],
    "complete": []
}
```
There's a active_short option that can be used to just get a plain name of the entities that are current syncing (e.g., list of <bucket>/<object>). This list is being sent to the service map periodically and can be retrieved via the `ceph service status` command.