### PR TITLE
tests: run certain upgrade/jewel-x tests on Xenial only

### DIFF
--- a/qa/suites/upgrade/jewel-x/parallel/distros
+++ b/qa/suites/upgrade/jewel-x/parallel/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/jewel-x/parallel/distros/centos_7.3.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/distros/centos_7.3.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/all/centos_7.3.yaml

--- a/qa/suites/upgrade/jewel-x/parallel/distros/ubuntu_16.04.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/distros/ubuntu_16.04.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/all/ubuntu_16.04.yaml

--- a/qa/suites/upgrade/jewel-x/parallel/kraken.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/kraken.yaml
@@ -1,1 +1,0 @@
-../../../../releases/kraken.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/centos_7.3.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/centos_7.3.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/all/centos_7.3.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/ubuntu_16.04.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/ubuntu_16.04.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/all/ubuntu_16.04.yaml


### PR DESCRIPTION
There are two upgrade/jewel-x test cases that are not compatible with
https://github.com/ceph/ceph/pull/14597 - they both involve Ubuntu 14.04.

This approach of dropping Ubuntu 14.04 is probably too heavy-handed, but I'm not sure the surgical approach (which would involve splitting the `parallel` and `stress-split-erasure-code` subsuites) is worth the effort?