### PR TITLE
rgw: fix radosgw will crash when service is restarted during lifecycl…

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3713,14 +3713,14 @@ void RGWRados::finalize()
     delete async_rados;
   }
   
+  delete lc;
+  lc = NULL; 
+
   delete gc;
   gc = NULL;
 
   delete obj_expirer;
   obj_expirer = NULL;
-  
-  delete lc;
-  lc = NULL;
 
   delete rest_master_conn;
 


### PR DESCRIPTION
…e processing

in RGWRados::finalize(), store->gc is destructed before store->lc, if this func is called
(by service restart or others) when lifecycle processing, the lifecycle still use store->gc,
the radosgw daemon will crash.

Signed-off-by: Wei Qiaomiao <wei.qiaomiao@zte.com.cn>