### PR TITLE
rgw: Drop dump_usage_bucket_info() to silence warning from -Wunused-function

### DIFF
--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -30,15 +30,6 @@ static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log
   formatter->close_section(); // categories
 }
 
-static void dump_usage_bucket_info(Formatter *formatter, string& name, cls_user_bucket_entry& entry)
-{
-  formatter->open_object_section("Entry");
-  formatter->dump_string("Bucket", name);
-  formatter->dump_int("Bytes", entry.size);
-  formatter->dump_int("Bytes_Rounded", entry.size_rounded);
-  formatter->close_section(); // entry
-}
-
 int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
 		   map<string, bool> *categories,


### PR DESCRIPTION
Fix compile warning in any PR (Ex: https://jenkins.ceph.com/job/ceph-pull-requests/29193/console):
```
/home/jenkins-build/build/workspace/ceph-pull-requests/src/rgw/rgw_usage.cc:33:13: warning: ‘void dump_usage_bucket_info(ceph::Formatter*, std::__cxx11::string&, cls_user_bucket_entry&)’ defined but not used [-Wunused-function]
 static void dump_usage_bucket_info(Formatter *formatter, string& name, cls_user_bucket_entry& entry)
```
Signed-off-by: Wei Qiaomiao <wei.qiaomiao@zte.com.cn>