### PR TITLE
rgw: reduce cycle time in rgw_user_get_all_buckets_stats()

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -1441,12 +1441,11 @@ int RGWBucketAdminOp::limit_check(RGWRados *store,
   for (const auto& user_id : user_ids) {
     formatter->open_object_section("user");
     formatter->dump_string("user_id", user_id);
-    bool done;
     formatter->open_array_section("buckets");
+    bool is_truncated = false;
     do {
       RGWUserBuckets buckets;
       string marker;
-      bool is_truncated;
 
       ret = rgw_read_user_buckets(store, user_id, buckets,
 				  marker, string(), max_entries, false,
@@ -1522,8 +1521,7 @@ int RGWBucketAdminOp::limit_check(RGWRados *store,
 	}
       }
 
-      done = (m_buckets.size() < max_entries);
-    } while (!done); /* foreach: bucket */
+    } while (is_truncated); /* foreach: bucket */
 
     formatter->close_section();
     formatter->close_section();

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -98,8 +98,7 @@ int rgw_user_get_all_buckets_stats(RGWRados *store, const rgw_user& user_id, map
 {
   CephContext *cct = store->ctx();
   size_t max_entries = cct->_conf->rgw_list_buckets_max_chunk;
-  bool done;
-  bool is_truncated;
+  bool is_truncated = false;
   string marker;
   int ret;
 
@@ -124,8 +123,7 @@ int rgw_user_get_all_buckets_stats(RGWRados *store, const rgw_user& user_id, map
       }
       buckets_usage_map.emplace(bucket_ent.bucket.name, entry);
     }
-    done = (buckets.size() < max_entries);
-  } while (!done);
+  } while (is_truncated);
 
   return 0;
 }


### PR DESCRIPTION
no need to call rgw_read_user_buckets() again if (buckets.size() == max_entries)

Signed-off-by: Wei Qiaomiao <wei.qiaomiao@zte.com.cn>