### PR TITLE
mon: do not dereference empty mgr_commands

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3013,8 +3013,10 @@ void Monitor::handle_command(MonOpRequestRef op)
 
   const MonCommand *leader_cmd;
   const auto& mgr_cmds = mgrmon()->get_command_descs();
-  const MonCommand *mgr_cmd = _get_moncommand(prefix, &mgr_cmds.at(0),
-					      mgr_cmds.size());
+  const MonCommand *mgr_cmd = nullptr;
+  if (!mgr_cmds.empty()) {
+    mgr_cmd = _get_moncommand(prefix, &mgr_cmds.at(0), mgr_cmds.size());
+  }
   leader_cmd = _get_moncommand(prefix,
                                // the boost underlying this isn't const for some reason
                                const_cast<MonCommand*>(leader_supported_mon_commands),


### PR DESCRIPTION
This may be empty before the initial quorum commits the static command
list.

Signed-off-by: Sage Weil <sage@redhat.com>