### PR TITLE
osd: fix OpRequest and tracked op dump information

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -437,7 +437,7 @@ void TrackedOp::dump(utime_t now, Formatter *f) const
   f->dump_float("age", now - get_initiated());
   f->dump_float("duration", get_duration());
   {
-    f->open_array_section("type_data");
+    f->open_object_section("type_data");
     _dump(f);
     f->close_section();
   }

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -39,6 +39,7 @@ OpRequest::OpRequest(Message *req, OpTracker *tracker) :
   } else if (req->get_type() == MSG_OSD_REPOP) {
     reqid = static_cast<MOSDRepOp*>(req)->reqid;
   }
+  req_src_inst = req->get_source_inst();
   mark_event("header_read", request->get_recv_stamp());
   mark_event("throttled", request->get_throttle_stamp());
   mark_event("all_read", request->get_recv_complete_stamp());
@@ -52,8 +53,8 @@ void OpRequest::_dump(Formatter *f) const
   if (m->get_orig_source().is_client()) {
     f->open_object_section("client_info");
     stringstream client_name, client_addr;
-    client_name << m->get_orig_source();
-    client_addr << m->get_orig_source_addr();
+    client_name << req_src_inst.name;
+    client_addr << req_src_inst.addr;
     f->dump_string("client", client_name.str());
     f->dump_string("client_addr", client_addr.str());
     f->dump_unsigned("tid", m->get_tid());

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -85,6 +85,7 @@ struct OpRequest : public TrackedOp {
 private:
   Message *request; /// the logical request we are tracking
   osd_reqid_t reqid;
+  entity_inst_t req_src_inst;
   uint8_t hit_flag_points;
   uint8_t latest_flag_point;
   utime_t dequeued_time;


### PR DESCRIPTION
if we use command `ceph daemon osd.# dump_historic_ops` to check the history tracked ops, the `client_addr` is always dumped as `-` which result in clients indistinguishable from each other.

```c++
"description": "osd_op(client.24123.0:328 3.36 3:6ec0d61b:::rbd_data.10472ae8944a.0000000000000289:head [write 4141056~4096 [fadvise_seque
ntial]] snapc 0=[] ondisk+write+known_if_redirected e36)",
            "initiated_at": "2017-07-22 14:24:25.925633",
            "age": 4.893190,
            "duration": 0.272642,
            "type_data": {
                "flag_point": "commit sent; apply or cleanup",
                "client_info": {
                    "client": "client.24123",
                    "client_addr": "-",
                    "tid": 328
                },
```
It is because `connection` was reset to nullptr in function `_unregistered` before the op has been inserted into history, so the `get_orig_source_addr` always return an empty entity addr.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>