### PR TITLE
qa/suits/rados/basic/tasks/rgw_snaps: wait for pools to be created

### DIFF
--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -9,6 +9,14 @@ overrides:
 tasks:
 - rgw:
     client.0:
+- ceph_manager.wait_for_pools:
+    kwargs:
+      pools:
+        - .rgw.buckets
+        - .rgw.root
+        - default.rgw.control
+        - default.rgw.meta
+        - default.rgw.log
 - thrash_pool_snaps:
     pools:
     - .rgw.buckets

--- a/qa/suites/rados/basic/tasks/rgw_snaps.yaml
+++ b/qa/suites/rados/basic/tasks/rgw_snaps.yaml
@@ -13,11 +13,9 @@ tasks:
     pools:
     - .rgw.buckets
     - .rgw.root
-    - .rgw.control
-    - .rgw
-    - .users.uid
-    - .users.email
-    - .users
+    - default.rgw.control
+    - default.rgw.meta
+    - default.rgw.log
 - s3readwrite:
     client.0:
       rgw_server: client.0

--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2091,6 +2091,27 @@ class CephManager:
             time.sleep(3)
         self.log("all up!")
 
+    def pool_exists(self, pool):
+        if pool in self.list_pools():
+            return True
+        return False
+
+    def wait_for_pool(self, pool, timeout=300):
+        """
+        Wait for a pool to exist
+        """
+        self.log('waiting for pool %s to exist' % pool)
+        start = time.time()
+        while not self.pool_exists(pool):
+            if timeout is not None:
+                assert time.time() - start < timeout, \
+                    'timeout expired in wait_for_pool'
+            time.sleep(3)
+
+    def wait_for_pools(self, pools):
+        for pool in pools:
+            self.wait_for_pool(pool)
+
     def wait_for_recovery(self, timeout=None):
         """
         Check peering. When this exists, we have recovered.
@@ -2450,3 +2471,5 @@ remove_pool = utility_task("remove_pool")
 wait_for_clean = utility_task("wait_for_clean")
 set_pool_property = utility_task("set_pool_property")
 do_pg_scrub = utility_task("do_pg_scrub")
+wait_for_pool = utility_task("wait_for_pool")
+wait_for_pools = utility_task("wait_for_pools")


### PR DESCRIPTION
This avoids the thrasher trying to create/delete snaps on pools that rgw
hasn't created yet.