### PR TITLE
OSDMonitor: check mon_max_pool_pg_num when set pool pg_num

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6008,6 +6008,11 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	return -EEXIST;
       return 0;
     }
+    if (n > (unsigned)g_conf->mon_max_pool_pg_num) {
+     ss << "'pg_num' must be greater than 0 and less than or equal to "
+	<< g_conf->mon_max_pool_pg_num
+        << " (you may adjust 'mon max pool pg num' for higher values)";
+    return -ERANGE;
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);
     if (p.cache_mode != pg_pool_t::CACHEMODE_NONE &&


### PR DESCRIPTION
Check the mon_max_pool_pg_num when creating pools, but not check in the the modification. So we can create a pool and then 

modify pg_num exceeds the mon_max_pool_pg_num limit.

By following these steps can verify this problem

step 1: set  mon_max_pool_pg_num = 65536

step 2: ceph osd pool create testpool 65536 65536

step 3: ceph osd pool set testpool pg_num 65537

Signed-off-by: chenhg <c744402859@gmail.com>