### PR TITLE
common: the latency dumped by "ceph osd perf" is not real

### DIFF
--- a/src/common/perf_counters.h
+++ b/src/common/perf_counters.h
@@ -133,11 +133,9 @@ public:
     pair<uint64_t, T> last;
     pair<uint64_t, T> cur;
     avg_tracker() : last(0, 0), cur(0, 0) {}
-    T avg() const {
+    T current_avg() const {
       if (cur.first == last.first)
-	return cur.first ?
-	  cur.second / cur.first :
-	  0; // no change, report avg over all time
+        return 0;
       return (cur.second - last.second) / (cur.first - last.first);
     }
     void consume_next(const pair<uint64_t, T> &next) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2357,8 +2357,8 @@ public:
 
     objectstore_perf_stat_t get_cur_stats() const {
       objectstore_perf_stat_t ret;
-      ret.os_commit_latency = os_commit_latency.avg();
-      ret.os_apply_latency = os_apply_latency.avg();
+      ret.os_commit_latency = os_commit_latency.current_avg();
+      ret.os_apply_latency = os_apply_latency.current_avg();
       return ret;
     }
 

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -135,8 +135,8 @@ public:
 
     objectstore_perf_stat_t get_cur_stats() const {
       objectstore_perf_stat_t ret;
-      ret.os_commit_latency = os_commit_latency.avg();
-      ret.os_apply_latency = os_apply_latency.avg();
+      ret.os_commit_latency = os_commit_latency.current_avg();
+      ret.os_apply_latency = os_apply_latency.current_avg();
       return ret;
     }
 


### PR DESCRIPTION
"ceph osd perf" is used to monitor the real time commit latency and apply latency.

When there is no IO for the cluster(or an OSD), the latency should be zero for "ceph osd perf" command, instead of old value.

Fixes: http://tracker.ceph.com/issues/20749