### PR TITLE
mon/MDSMonitor: close object section of formatter

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1020,6 +1020,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
           derr << "Unexpected error reading metadata: " << cpp_strerror(r)
                << dendl;
           ss << get_err.str();
+          f->close_section();
           break;
         }
         f->close_section();


### PR DESCRIPTION
Signed-off-by: Chang Liu <liuchang0812@gmail.com>

```diff
➜  build git:(nit-close-formatter-section) ✗ ./bin/ceph mds metadata
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2017-07-23 02:13:45.845648 7f635a42b700 -1 WARNING: all dangerous and experimental features are enabled.
2017-07-23 02:13:45.851948 7f635a42b700 -1 WARNING: all dangerous and experimental features are enabled.
this is a mock wrong
[
    {
        "name": "b",
        "addr": "127.0.0.1:6813/1288745739",
        "arch": "x86_64",
        "ceph_version": "ceph version 12.1.1-410-g27c1d62ae9 (27c1d62ae96ecc0c34fc0da55a7e529e0f718234) luminous (rc)",
        "cpu": "AMD Ryzen 7 1700 Eight-Core Processor",
        "distro": "ubuntu",
        "distro_description": "Ubuntu 17.04",
        "distro_version": "17.04",
        "hostname": "ubuntu",
        "kernel_description": "#30-Ubuntu SMP Tue Jun 27 09:30:12 UTC 2017",
        "kernel_version": "4.10.0-26-generic",
        "mem_swap_kb": "2097148",
        "mem_total_kb": "8746072",
        "os": "Linux"
    }

#comment: need ] here
➜  build git:(nit-close-formatter-section) ✗ git diff
diff --git a/src/boost b/src/boost
--- a/src/boost
+++ b/src/boost
@@ -1 +1 @@
-Subproject commit 1790aff3b34374d2af85f8c16755d101f49d2b6e
+Subproject commit 1790aff3b34374d2af85f8c16755d101f49d2b6e-dirty
diff --git a/src/mon/MDSMonitor.cc b/src/mon/MDSMonitor.cc
index 50fd99ed86..a61d5f6f57 100644
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -1012,6 +1012,8 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
         f->dump_string("name", info.name);
         std::ostringstream get_err;
         r = dump_metadata(info.name, f.get(), get_err);
+        r = 1024; // mock
+        get_err << "this is a mock wrong";
         if (r == -EINVAL || r == -ENOENT) {
           // Drop error, list what metadata we do have
           dout(1) << get_err.str() << dendl;
@@ -1020,6 +1022,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
           derr << "Unexpected error reading metadata: " << cpp_strerror(r)
                << dendl;
           ss << get_err.str();
+          // f->close_section();
           break;
         }
         f->close_section();


```