### PR TITLE
rbd: check if an image is already mapped before rbd map

### DIFF
--- a/src/include/krbd.h
+++ b/src/include/krbd.h
@@ -45,6 +45,10 @@ namespace ceph {
 
 int krbd_showmapped(struct krbd_ctx *ctx, ceph::Formatter *f);
 
+int krbd_is_image_mapped(struct krbd_ctx *ctx, const char *poolname, 
+                         const char *imgname, const char *snapname,
+                         std::ostringstream &mapped_info, bool &is_mapped);
+
 #endif /* __cplusplus */
 
 #endif /* CEPH_KRBD_H */

--- a/src/tools/rbd/action/Kernel.cc
+++ b/src/tools/rbd/action/Kernel.cc
@@ -289,9 +289,10 @@ static int do_kernel_map(const char *poolname, const char *imgname,
 {
 #if defined(WITH_KRBD)
   struct krbd_ctx *krbd;
-  std::ostringstream oss;
+  std::ostringstream oss, mapped_info;
   char *devnode;
   int r;
+  bool img_mapped;
 
   r = krbd_create_from_context(g_ceph_context, &krbd);
   if (r < 0)
@@ -310,6 +311,15 @@ static int do_kernel_map(const char *poolname, const char *imgname,
       oss << it->second;
       ++it;
     }
+  }
+
+  r = krbd_is_image_mapped(krbd, poolname, imgname, snapname,
+			   mapped_info, img_mapped);
+  if (r < 0) {
+    std::cerr << "rbd: warning: can't get image map infomation: "
+	      << cpp_strerror(r) << std::endl;
+  } else if (img_mapped) {
+    std::cerr << "rbd: warning: " << mapped_info.str() << std::endl;
   }
 
   r = krbd_map(krbd, poolname, imgname, snapname, oss.str().c_str(), &devnode);


### PR DESCRIPTION
RBD should check if an image is already mapped before mapping one image as serveral devices.

Fixes: http://tracker.ceph.com/issues/20580
Signed-off-by: Jing Li <lijing@gohighsec.com>