### PR TITLE
kv/RocksDBStore: extract common code to a new function

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -498,9 +498,8 @@ void RocksDBStore::get_statistics(Formatter *f)
   }
 }
 
-int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
+int RocksDBStore::submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t) 
 {
-  utime_t start = ceph_clock_now();
   // enable rocksdb breakdown
   // considering performance overhead, default is disabled
   if (g_conf->rocksdb_perf) {
@@ -510,7 +509,6 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
 
   RocksDBTransactionImpl * _t =
     static_cast<RocksDBTransactionImpl *>(t.get());
-  rocksdb::WriteOptions woptions;
   woptions.disableWAL = disableWAL;
   lgeneric_subdout(cct, rocksdb, 30) << __func__;
   RocksWBHandler bat_txc;
@@ -524,7 +522,6 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
     derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
          << " Rocksdb transaction: " << rocks_txc.seen << dendl;
   }
-  utime_t lat = ceph_clock_now() - start;
 
   if (g_conf->rocksdb_perf) {
     utime_t write_memtable_time;
@@ -545,64 +542,37 @@ int RocksDBStore::submit_transaction(KeyValueDB::Transaction t)
     logger->tinc(l_rocksdb_write_pre_and_post_process_time, write_pre_and_post_process_time);
   }
 
+  return s.ok() ? 0 : -1;
+}
+
+int RocksDBStore::submit_transaction(KeyValueDB::Transaction t) 
+{
+  utime_t start = ceph_clock_now();
+  rocksdb::WriteOptions woptions;
+  woptions.sync = false;
+
+  int result = submit_common(woptions, t);
+
+  utime_t lat = ceph_clock_now() - start;
   logger->inc(l_rocksdb_txns);
   logger->tinc(l_rocksdb_submit_latency, lat);
-
-  return s.ok() ? 0 : -1;
+  
+  return result;
 }
 
 int RocksDBStore::submit_transaction_sync(KeyValueDB::Transaction t)
 {
   utime_t start = ceph_clock_now();
-  // enable rocksdb breakdown
-  // considering performance overhead, default is disabled
-  if (g_conf->rocksdb_perf) {
-    rocksdb::SetPerfLevel(rocksdb::PerfLevel::kEnableTimeExceptForMutex);
-    rocksdb::perf_context.Reset();
-  }
-
-  RocksDBTransactionImpl * _t =
-    static_cast<RocksDBTransactionImpl *>(t.get());
   rocksdb::WriteOptions woptions;
   woptions.sync = true;
-  woptions.disableWAL = disableWAL;
-  lgeneric_subdout(cct, rocksdb, 30) << __func__;
-  RocksWBHandler bat_txc;
-  _t->bat.Iterate(&bat_txc);
-  *_dout << " Rocksdb transaction: " << bat_txc.seen << dendl;
-
-  rocksdb::Status s = db->Write(woptions, &_t->bat);
-  if (!s.ok()) {
-    RocksWBHandler rocks_txc;
-    _t->bat.Iterate(&rocks_txc);
-    derr << __func__ << " error: " << s.ToString() << " code = " << s.code()
-         << " Rocksdb transaction: " << rocks_txc.seen << dendl;
-  }
+  
+  int result = submit_common(woptions, t);
+  
   utime_t lat = ceph_clock_now() - start;
-
-  if (g_conf->rocksdb_perf) {
-    utime_t write_memtable_time;
-    utime_t write_delay_time;
-    utime_t write_wal_time;
-    utime_t write_pre_and_post_process_time;
-    write_wal_time.set_from_double(
-	static_cast<double>(rocksdb::perf_context.write_wal_time)/1000000000);
-    write_memtable_time.set_from_double(
-	static_cast<double>(rocksdb::perf_context.write_memtable_time)/1000000000);
-    write_delay_time.set_from_double(
-	static_cast<double>(rocksdb::perf_context.write_delay_time)/1000000000);
-    write_pre_and_post_process_time.set_from_double(
-	static_cast<double>(rocksdb::perf_context.write_pre_and_post_process_time)/1000000000);
-    logger->tinc(l_rocksdb_write_memtable_time, write_memtable_time);
-    logger->tinc(l_rocksdb_write_delay_time, write_delay_time);
-    logger->tinc(l_rocksdb_write_wal_time, write_wal_time);
-    logger->tinc(l_rocksdb_write_pre_and_post_process_time, write_pre_and_post_process_time);
-  }
-
   logger->inc(l_rocksdb_txns_sync);
   logger->tinc(l_rocksdb_submit_sync_latency, lat);
 
-  return s.ok() ? 0 : -1;
+  return result;
 }
 
 RocksDBStore::RocksDBTransactionImpl::RocksDBTransactionImpl(RocksDBStore *_db)

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -78,6 +78,7 @@ class RocksDBStore : public KeyValueDB {
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
 
+  int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
   int do_open(ostream &out, bool create_if_missing);
 
   // manage async compactions


### PR DESCRIPTION
1) two set(...) functions have most of same code.
2) submit_transaction and submit_transaction_sync has almost same code, accept "sync" option value. 