### PR TITLE
osd: initialize waiting_for_pg_osdmap on startup

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2515,6 +2515,9 @@ int OSD::init()
 
   clear_temp_objects();
 
+  // initialize osdmap references in sharded wq
+  op_shardedwq.prune_pg_waiters(osdmap, whoami);
+
   // load up pgs (as they previously existed)
   load_pgs();
 


### PR DESCRIPTION
We assume this is always initialized and non-null in _process.  Currently
we have a window between startup and the first call to prune_pg_waiters
(via consume_map()) when it is null, which can lead to a segv.

Signed-off-by: Sage Weil <sage@redhat.com>

Fixes http://tracker.ceph.com/issues/20748