### PR TITLE
osd: PrimaryLogPG, PGBackend: complete callback even if interval changes

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -137,8 +137,10 @@ void PGBackend::handle_recovery_delete(OpRequestRef op)
   ConnectionRef conn = m->get_connection();
 
   gather.set_finisher(new FunctionContext(
-    [=](int) {
-      get_parent()->send_message_osd_cluster(reply, conn.get());
+    [=](int r) {
+      if (r != -EAGAIN) {
+	get_parent()->send_message_osd_cluster(reply, conn.get());
+      }
     }));
   gather.activate();
 }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10243,8 +10243,11 @@ void PrimaryLogPG::remove_missing_object(const hobject_t &soid,
 	 t2.register_on_complete(on_complete);
 	 int r = osd->store->queue_transaction(osr.get(), std::move(t2), nullptr);
 	 assert(r == 0);
+	 unlock();
+       } else {
+	 unlock();
+	 on_complete->complete(-EAGAIN);
        }
-       unlock();
      }));
   int r = osd->store->queue_transaction(osr.get(), std::move(t), nullptr);
   assert(r == 0);


### PR DESCRIPTION
This avoids leaking the callback passed to remove_missing_object().
Use EAGAIN to signal that the work was not completed, so we don't have
to take the pg lock and check if the interval changed again in
PGBackend.

Fixes: http://tracker.ceph.com/issues/20747
Signed-off-by: Josh Durgin <jdurgin@redhat.com>