### PR TITLE
rgw: restore admin socket path in mrgw.sh

### DIFF
--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -22,7 +22,7 @@ shift 2
 
 run_root=$script_root/run/$name
 pidfile=$run_root/out/radosgw.${port}.pid
-asokfile=$($ceph_bin/ceph-conf --show-config-value admin_socket --name radosgw.${port})
+asokfile=$run_root/out/radosgw.${port}.asok
 logfile=$run_root/out/radosgw.${port}.log
 
 $vstart_path/mstop.sh $name radosgw $port


### PR DESCRIPTION
ceph-conf was rejecting the entity name with:
> error parsing 'radosgw.8000': expected string of the form TYPE.ID, valid
types are: auth, mon, osd, mds, mgr, client

these mstart/mrun/mrgw scripts carefully place their output files under
their respective run/<cluster-name>/out subdirectory to keep them from
clashing