### PR TITLE
qa: Fix shebangs on openstack scripts

### DIFF
--- a/qa/qa_scripts/openstack/ceph_install.sh
+++ b/qa/qa_scripts/openstack/ceph_install.sh
@@ -1,7 +1,8 @@
-#/bin/bash -fv
+#!/usr/bin/env bash
 #
 # Install a simple ceph cluster upon which openstack images will be stored.
 #
+set -fv
 ceph_node=${1}
 source copy_func.sh
 copy_file files/$OS_CEPH_ISO $ceph_node .

--- a/qa/qa_scripts/openstack/connectceph.sh
+++ b/qa/qa_scripts/openstack/connectceph.sh
@@ -1,4 +1,4 @@
-#/bin/bash -fv
+#!/usr/bin/env bash
 #
 # Connect openstack node just installed to a ceph cluster.
 #
@@ -9,6 +9,7 @@
 # The directory named files contains templates for the /etc/glance/glance-api.conf,
 # /etc/cinder/cinder.conf, /etc/nova/nova.conf Openstack files
 #
+set -fv
 source ./copy_func.sh
 source ./fix_conf_file.sh
 openstack_node=${1}

--- a/qa/qa_scripts/openstack/copy_func.sh
+++ b/qa/qa_scripts/openstack/copy_func.sh
@@ -1,4 +1,3 @@
-#/bin/bash -fv
 #
 # copy_file(<filename>, <node>, <directory>, [<permissions>], [<owner>]
 # 

--- a/qa/qa_scripts/openstack/fix_conf_file.sh
+++ b/qa/qa_scripts/openstack/fix_conf_file.sh
@@ -1,4 +1,3 @@
-#/bin/bash -fv
 source ./copy_func.sh
 #
 # Take a templated file, modify a local copy, and write it to the

--- a/qa/qa_scripts/openstack/image_create.sh
+++ b/qa/qa_scripts/openstack/image_create.sh
@@ -1,7 +1,8 @@
-#/bin/bash -fv
+#!/usr/bin/env bash
 #
 # Set up a vm on packstack.  Use the iso in RHEL_ISO (defaults to home dir)
 #
+set -fv
 source ./copy_func.sh
 source ./fix_conf_file.sh
 openstack_node=${1}

--- a/qa/qa_scripts/openstack/openstack.sh
+++ b/qa/qa_scripts/openstack/openstack.sh
@@ -1,4 +1,4 @@
-#/bin/bash -fv
+#!/usr/bin/env bash
 #
 # Install Openstack.
 #     Usage: openstack <openstack-site> <ceph-monitor>
@@ -14,6 +14,7 @@
 # The files directory contains files to be copied to remote sites.
 #
 
+set -fv
 source ./copy_func.sh
 source ./fix_conf_file.sh
 openstack_node=${1}

--- a/qa/qa_scripts/openstack/packstack.sh
+++ b/qa/qa_scripts/openstack/packstack.sh
@@ -1,4 +1,4 @@
-#/bin/bash -fv
+#!/usr/bin/env bash
 #
 # Install openstack by running packstack.
 #
@@ -7,6 +7,7 @@
 #
 # The directory named files contains a template for the kilo.conf file used by packstack.
 #
+set -fv
 source ./copy_func.sh
 source ./fix_conf_file.sh
 openstack_node=${1}


### PR DESCRIPTION
Many of the files in qa/qa_scripts/openstack had incorrect shebang
lines: the bang was missing.  This means that those scripts would
execute using the calling user's login shell, which is doubtless not
what the author intended.  Now they'll always use bash.

Two scripts do not need shebangs, because they contain only library
functions and don't execute anything.  I removed their shebangs.

Signed-off-by: Alan Somers <asomers@gmail.com>