### PR TITLE
common: use std::move() for better performance

### DIFF
--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -298,9 +298,7 @@ void OutputDataSocket::handle_connection(int fd)
 int OutputDataSocket::dump_data(int fd)
 {
   m_lock.Lock(); 
-  list<bufferlist> l;
-  l = data;
-  data.clear();
+  list<bufferlist> l = std::move(data);
   data_size = 0;
   m_lock.Unlock();
 


### PR DESCRIPTION
use std::move() to avoid extra copy constructions in src/common/OutputDataSocket.cc.

Signed-off-by: Xinying Song <songxinying@kmail.cloudin.com>