### PR TITLE
rgw: add option to control multisite sync speed

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1666,6 +1666,8 @@ OPTION(rgw_sync_log_trim_interval, OPT_INT, 1200) // time in seconds between att
 OPTION(rgw_sync_data_inject_err_probability, OPT_DOUBLE, 0) // range [0, 1]
 OPTION(rgw_sync_meta_inject_err_probability, OPT_DOUBLE, 0) // range [0, 1]
 
+OPTION(rgw_bucket_shard_full_sync_window, OPT_INT, 20) // max outstanding sync request number of a bucket shard when doing full sync
+OPTION(rgw_bucket_shard_incremental_sync_window, OPT_INT, 20) // max outstanding sync request number of a bucket shard when doing incremental sync 
 
 OPTION(rgw_period_push_interval, OPT_DOUBLE, 2) // seconds to wait before retrying "period push"
 OPTION(rgw_period_push_interval_max, OPT_DOUBLE, 30) // maximum interval after exponential backoff

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2295,8 +2295,6 @@ done:
   }
 };
 
-#define BUCKET_SYNC_SPAWN_WINDOW 20
-
 class RGWBucketShardFullSyncCR : public RGWCoroutine {
   RGWDataSyncEnv *sync_env;
   const rgw_bucket_shard& bs;
@@ -2379,7 +2377,7 @@ int RGWBucketShardFullSyncCR::operate()
                                  entry->key, &marker_tracker, zones_trace),
                       false);
         }
-        while (num_spawned() > BUCKET_SYNC_SPAWN_WINDOW) {
+        while (num_spawned() >= sync_env->cct->_conf->rgw_bucket_shard_full_sync_window) {
           yield wait_for_child();
           bool again = true;
           while (again) {
@@ -2617,8 +2615,8 @@ int RGWBucketShardIncrementalSyncCR::operate()
                   false);
           }
         // }
-        while (num_spawned() > BUCKET_SYNC_SPAWN_WINDOW) {
-          set_status() << "num_spawned() > spawn_window";
+        while (num_spawned() >= sync_env->cct->_conf->rgw_bucket_shard_incremental_sync_window) {
+          set_status() << "num_spawned() >= sync_window";
           yield wait_for_child();
           bool again = true;
           while (again) {


### PR DESCRIPTION
In production environments, we have need to limit the bandwidth consumed by syncing, which allowed spawned number of RGWBucketSyncSingleEntryCR has something to do with, so change it from a macro to configurable option is useful.