### PR TITLE
cephfs/ceph-fuse: add and modify ceph-fuse mount hint

### DIFF
--- a/src/ceph_fuse.cc
+++ b/src/ceph_fuse.cc
@@ -62,9 +62,9 @@ static void fuse_usage()
 void usage()
 {
   cout <<
-"usage: ceph-fuse [-m mon-ip-addr:mon-port] <mount point> [OPTIONS]\n"
-"  --client_mountpoint/-r <root_directory>\n"
-"                    use root_directory as the mounted root, rather than the full Ceph tree.\n"
+"usage: ceph-fuse [-n client.username] [-m mon-ip-addr:mon-port] <mount point> [OPTIONS]\n"
+"  --client_mountpoint/-r <sub_directory>\n"
+"                    use sub_directory as the mounted root, rather than the full Ceph tree.\n"
 "\n";
   fuse_usage();
   generic_client_usage();


### PR DESCRIPTION
1. "-n" is applied the client authorization feature.
2. "root_directory" misleading to mount the root directory , 
     in fact, here mount should be "sub_directory".
Refer to: http://docs.ceph.com/docs/master/cephfs/client-auth/#cephfs-client-capabilities

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>