### PR TITLE
rgw: add a separate configuration for data notify interval

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4656,6 +4656,10 @@ std::vector<Option> get_rgw_options() {
     .set_default("")
     .set_description(""),
 
+    Option("rgw_data_notify_interval_msec", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(200)
+    .set_description("data changes notification interval to followers"),
+
     Option("rgw_torrent_origin", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description(""),

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3115,7 +3115,7 @@ class RGWDataNotifier : public RGWRadosThread {
   RGWDataNotifierManager notify_mgr;
 
   uint64_t interval_msec() override {
-    return cct->_conf->rgw_md_notify_interval_msec;
+    return cct->_conf->get_val<int64_t>("rgw_data_notify_interval_msec");
   }
 public:
   RGWDataNotifier(RGWRados *_store) : RGWRadosThread(_store, "data-notifier"), notify_mgr(_store) {}


### PR DESCRIPTION
use rgw_md_notify_interval_msec to control both meta and data notify notify seems not reasonable.
Generally speaking, I prefer to use longer data notify interval than meta, which increase probability that meta arrive before data sync, so data sync won't trigger RGWMetaSyncSingleEntryCR for no meta exists in local.

Maybe quantify it is varying, but we should have a separate configuration firstly.