### PR TITLE
kv: resolve a crash issue in ~LevelDBStore()

### DIFF
--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -150,10 +150,10 @@ LevelDBStore::~LevelDBStore()
 {
   close();
   delete logger;
-  delete ceph_logger;
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
   db.reset();
+  delete ceph_logger;
 }
 
 void LevelDBStore::close()


### PR DESCRIPTION
if ceph_logger is deleted earlier than db, it may still be used by db, which cause a segment fault.