### PR TITLE
  osd/PrimaryLogPG: fix recovering hang when have unfound objects

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -918,7 +918,7 @@ int PrimaryLogPG::do_command(
   ConnectionRef con,
   ceph_tid_t tid)
 {
-  const pg_missing_t &missing = pg_log.get_missing();
+  const auto &missing = pg_log.get_missing();
   string prefix;
   string format;
 
@@ -11136,7 +11136,7 @@ bool PrimaryLogPG::start_recovery_ops(
     return false;
   }
 
-  const pg_missing_t &missing = pg_log.get_missing();
+  const auto &missing = pg_log.get_missing();
 
   unsigned int num_missing = missing.num_missing();
   uint64_t num_unfound = get_num_unfound();
@@ -11276,7 +11276,7 @@ uint64_t PrimaryLogPG::recover_primary(uint64_t max, ThreadPool::TPHandle &handl
 {
   assert(is_primary());
 
-  const pg_missing_t &missing = pg_log.get_missing();
+  const auto &missing = pg_log.get_missing();
 
   dout(10) << "recover_primary recovering " << recovering.size()
 	   << " in pg" << dendl;


### PR DESCRIPTION
  pg_log.get_missing() return type is pg_missing_tracker_t,
  if we use:
    const pg_missing_t &missing = pg_log.get_missing();
  the reference object(missing) will not change when we changed the
  pglog's missing set in recover_primary()/recover_got(),which will
  result the recovering hang.

  Signed-off-by: huangjun <huangjun@xsky.com>