### PR TITLE
qa/tasks/dump_stuck: fix dump_stuck test bug

### DIFF
--- a/qa/tasks/dump_stuck.py
+++ b/qa/tasks/dump_stuck.py
@@ -100,6 +100,7 @@ def task(ctx, config):
     log.info('stopping first osd')
     manager.kill_osd(0)
     manager.mark_down_osd(0)
+    manager.wait_for_active(timeout)
 
     log.info('waiting for all to be unclean')
     starttime = time.time()


### PR DESCRIPTION
  Test cluster with 2 osds, stop osd.0, if osd.1
  report the pg stats during pg peering, mon will
  record pg state to 'peering',then stop osd.1,
  finally the pg state will stuck in 'stale+peering',
  which is unexpected.

  Let's wait_for_active() after stop osd.0.

  Signed-off-by: huangjun <huangjun@xsky.com>