### PR TITLE
osd: add dump filter for tracked ops

### DIFF
--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -68,7 +68,7 @@ void OpHistory::cleanup(utime_t now)
   }
 }
 
-void OpHistory::dump_ops(utime_t now, Formatter *f)
+void OpHistory::dump_ops(utime_t now, Formatter *f, set<string> filters)
 {
   Mutex::Locker history_lock(ops_history_lock);
   cleanup(now);
@@ -81,6 +81,8 @@ void OpHistory::dump_ops(utime_t now, Formatter *f)
 	   arrived.begin();
 	 i != arrived.end();
 	 ++i) {
+      if (!i->second->filter_out(filters))
+        continue;
       f->open_object_section("op");
       i->second->dump(now, f);
       f->close_section();
@@ -90,7 +92,7 @@ void OpHistory::dump_ops(utime_t now, Formatter *f)
   f->close_section();
 }
 
-void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f)
+void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f, set<string> filters)
 {
   Mutex::Locker history_lock(ops_history_lock);
   cleanup(now);
@@ -107,6 +109,8 @@ void OpHistory::dump_ops_by_duration(utime_t now, Formatter *f)
 	     arrived.begin();
 	   i != arrived.end();
 	   ++i) {
+	if (!i->second->filter_out(filters))
+	  continue;
 	durationvec.push_back(pair<double, TrackedOpRef>(i->second->get_duration(), i->second));
       }
 
@@ -152,7 +156,7 @@ OpTracker::~OpTracker() {
   }
 }
 
-bool OpTracker::dump_historic_ops(Formatter *f, bool by_duration)
+bool OpTracker::dump_historic_ops(Formatter *f, bool by_duration, set<string> filters)
 {
   RWLock::RLocker l(lock);
   if (!tracking_enabled)
@@ -160,14 +164,14 @@ bool OpTracker::dump_historic_ops(Formatter *f, bool by_duration)
 
   utime_t now = ceph_clock_now();
   if (by_duration) {
-    history.dump_ops_by_duration(now, f);
+    history.dump_ops_by_duration(now, f, filters);
   } else {
-    history.dump_ops(now, f);
+    history.dump_ops(now, f, filters);
   }
   return true;
 }
 
-void OpHistory::dump_slow_ops(utime_t now, Formatter *f)
+void OpHistory::dump_slow_ops(utime_t now, Formatter *f, set<string> filters)
 {
   Mutex::Locker history_lock(ops_history_lock);
   cleanup(now);
@@ -180,6 +184,8 @@ void OpHistory::dump_slow_ops(utime_t now, Formatter *f)
 	   slow_op.begin();
 	 i != slow_op.end();
 	 ++i) {
+      if (!i->second->filter_out(filters))
+        continue;
       f->open_object_section("Op");
       i->second->dump(now, f);
       f->close_section();
@@ -189,18 +195,18 @@ void OpHistory::dump_slow_ops(utime_t now, Formatter *f)
   f->close_section();
 }
 
-bool OpTracker::dump_historic_slow_ops(Formatter *f)
+bool OpTracker::dump_historic_slow_ops(Formatter *f, set<string> filters)
 {
   RWLock::RLocker l(lock);
   if (!tracking_enabled)
     return false;
 
   utime_t now = ceph_clock_now();
-  history.dump_slow_ops(now, f);
+  history.dump_slow_ops(now, f, filters);
   return true;
 }
 
-bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked)
+bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked, set<string> filters)
 {
   RWLock::RLocker l(lock);
   if (!tracking_enabled)
@@ -217,6 +223,8 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked)
     for (auto& op : sdata->ops_in_flight_sharded) {
       if (print_only_blocked && (now - op.get_initiated() <= complaint_time))
         break;
+      if (!op.filter_out(filters))
+        continue;
       f->open_object_section("op");
       op.dump(now, f);
       f->close_section(); // this TrackedOp

--- a/src/common/TrackedOp.cc
+++ b/src/common/TrackedOp.cc
@@ -216,7 +216,7 @@ bool OpTracker::dump_ops_in_flight(Formatter *f, bool print_only_blocked)
     Mutex::Locker locker(sdata->ops_in_flight_lock_sharded);
     for (auto& op : sdata->ops_in_flight_sharded) {
       if (print_only_blocked && (now - op.get_initiated() <= complaint_time))
-	break;
+        break;
       f->open_object_section("op");
       op.dump(now, f);
       f->close_section(); // this TrackedOp
@@ -401,7 +401,7 @@ void TrackedOp::mark_event_string(const string &event, utime_t stamp)
     events.push_back(Event(stamp, event));
     current = events.back().c_str();
   }
-  dout(6) <<  "seq: " << seq
+  dout(6) << " seq: " << seq
 	  << ", time: " << stamp
 	  << ", event: " << event
 	  << ", op: " << get_desc()
@@ -419,7 +419,7 @@ void TrackedOp::mark_event(const char *event, utime_t stamp)
     events.push_back(Event(stamp, event));
     current = event;
   }
-  dout(6) <<  "seq: " << seq
+  dout(6) << " seq: " << seq
 	  << ", time: " << stamp
 	  << ", event: " << event
 	  << ", op: " << get_desc()

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -46,9 +46,9 @@ public:
     assert(slow_op.empty());
   }
   void insert(utime_t now, TrackedOpRef op);
-  void dump_ops(utime_t now, Formatter *f);
-  void dump_ops_by_duration(utime_t now, Formatter *f);
-  void dump_slow_ops(utime_t now, Formatter *f);
+  void dump_ops(utime_t now, Formatter *f, set<string> filters = {""});
+  void dump_ops_by_duration(utime_t now, Formatter *f, set<string> filters = {""});
+  void dump_slow_ops(utime_t now, Formatter *f, set<string> filters = {""});
   void on_shutdown();
   void set_size_and_duration(uint32_t new_size, uint32_t new_duration) {
     history_size = new_size;
@@ -90,9 +90,9 @@ public:
     RWLock::WLocker l(lock);
     tracking_enabled = enable;
   }
-  bool dump_ops_in_flight(Formatter *f, bool print_only_blocked=false);
-  bool dump_historic_ops(Formatter *f, bool by_duration = false);
-  bool dump_historic_slow_ops(Formatter *f);
+  bool dump_ops_in_flight(Formatter *f, bool print_only_blocked = false, set<string> filters = {""});
+  bool dump_historic_ops(Formatter *f, bool by_duration = false, set<string> filters = {""});
+  bool dump_historic_slow_ops(Formatter *f, set<string> filters = {""});
   bool register_inflight_op(TrackedOp *i);
   void unregister_inflight_op(TrackedOp *i);
 
@@ -214,6 +214,8 @@ protected:
   virtual void _dump_op_descriptor_unlocked(ostream& stream) const = 0;
   /// called when the last non-OpTracker reference is dropped
   virtual void _unregistered() {};
+
+  virtual bool filter_out(const set<string>& filters) { return true; }
 
 public:
   ZTracer::Trace osd_trace;

--- a/src/common/TrackedOp.h
+++ b/src/common/TrackedOp.h
@@ -213,7 +213,7 @@ protected:
   /// return a unique descriptor of the Op; eg the message it's attached to
   virtual void _dump_op_descriptor_unlocked(ostream& stream) const = 0;
   /// called when the last non-OpTracker reference is dropped
-  virtual void _unregistered() {};
+  virtual void _unregistered() {}
 
   virtual bool filter_out(const set<string>& filters) { return true; }
 

--- a/src/osd/OpRequest.cc
+++ b/src/osd/OpRequest.cc
@@ -162,6 +162,34 @@ void OpRequest::mark_flag_point_string(uint8_t flag, const string& s) {
 	     flag, s.c_str(), old_flags, hit_flag_points);
 }
 
+bool OpRequest::filter_out(const set<string>& filters)
+{
+  set<entity_addr_t> addrs;
+  for (auto it = filters.begin(); it != filters.end(); it++) {
+    entity_addr_t addr;
+    if (addr.parse((*it).c_str())) {
+      addrs.insert(addr);
+    }
+  }
+  if (addrs.empty())
+    return true;
+
+  entity_addr_t cmp_addr = req_src_inst.addr;
+  if (addrs.count(cmp_addr)) {
+    return true;
+  }
+  cmp_addr.set_nonce(0);
+  if (addrs.count(cmp_addr)) {
+    return true;
+  }
+  cmp_addr.set_port(0);
+  if (addrs.count(cmp_addr)) {
+    return true;
+  }
+
+  return false;
+}
+
 ostream& operator<<(ostream& out, const OpRequest::ClassInfo& i)
 {
   out << "class " << i.name << " rd " << i.read

--- a/src/osd/OpRequest.h
+++ b/src/osd/OpRequest.h
@@ -103,6 +103,7 @@ private:
 protected:
   void _dump_op_descriptor_unlocked(ostream& stream) const override;
   void _unregistered() override;
+  bool filter_out(const set<string>& filters) override;
 
 public:
   ~OpRequest() override {


### PR DESCRIPTION
add filters to dump the tracked ops just what we need.

While diagnosing a problem about client's op, we tried to dump the history tracked ops, but there were too many unrelated ops (set osd_op_history_size=1000), this change help us to focus on a certain client. 

additional, extend this filter to other tracked op dump commands, using this as following:
1. `ceph daemon osd.# dump_historic_ops ` , filter nothing, dump all things as before;
2. `ceph daemon osd.# dump_historic_ops  ip1:port1/nonce1 ...` , filter ip, port, nonce, `port` and `nonce` are optional;

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>