### PR TITLE
 cephfs/fuse: set big_writes default is false 

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5613,8 +5613,8 @@ std::vector<Option> get_mds_client_options() {
     .set_description(""),
 
     Option("fuse_big_writes", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
-    .set_description(""),
+    .set_default(false)
+    .set_description("big_writes is deprecated in libfuse 3.0.0"),
 
     Option("fuse_atomic_o_trunc", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)


### PR DESCRIPTION
The -o big_writes mount option has been removed in the libfuse 3.0
because it is now always active.
see: https://github.com/libfuse/libfuse/blob/master/ChangeLog.rst
so we big_writes default is false

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>