### PR TITLE
  common/WorkQueue: use threadpoolname + threadaddr for heartbeat_han…

### DIFF
--- a/src/common/WorkQueue.cc
+++ b/src/common/WorkQueue.cc
@@ -87,9 +87,7 @@ void ThreadPool::worker(WorkThread *wt)
   ldout(cct,10) << "worker start" << dendl;
   
   std::stringstream ss;
-  char name[16] = {0};
-  ceph_pthread_getname(pthread_self(), name, sizeof(name));
-  ss << name << " thread " << name;
+  ss << name << " thread " << (void *)pthread_self();
   heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 
   while (!_stop) {
@@ -298,9 +296,7 @@ void ShardedThreadPool::shardedthreadpool_worker(uint32_t thread_index)
   ldout(cct,10) << "worker start" << dendl;
 
   std::stringstream ss;
-  char name[16] = {0};
-  ceph_pthread_getname(pthread_self(), name, sizeof(name));
-  ss << name << " thread " << name;
+  ss << name << " thread " << (void *)pthread_self();
   heartbeat_handle_d *hb = cct->get_heartbeat_map()->add_worker(ss.str(), pthread_self());
 
   while (!stop_threads) {


### PR DESCRIPTION
…dle_d.name

  Current log: 'tp_osd_tp thread tp_osd_tp'
  changed to 'OSD::osd_op_tp thread 0x7fd83ac52700'

  This reverts commit 50c8c76d8a319a4b8594cb10003c55dc79440fb7

  Signed-off-by: huangjun <huangjun@xsky.com>