### PR TITLE
vstart.sh: fix mgr vs restful command startup race

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -671,7 +671,9 @@ EOF
         run 'mgr' $CEPH_BIN/ceph-mgr -i $name $ARGS
     done
 
-    if ceph_adm restful create-self-signed-cert; then
+    # use tell mgr here because the first mgr might not have activated yet
+    # to register the python module commands.
+    if ceph_adm tell mgr restful create-self-signed-cert; then
         SF=`mktemp`
         ceph_adm restful create-key admin -o $SF
         RESTFUL_SECRET=`cat $SF`


### PR DESCRIPTION
If the mgr hasn't activated yet we won't have registered the python
commands.  Use 'ceph tell mgr ...' to ensure we block.  (This is only a
problem right after mkfs when the first mgr hasn't started yet.)

Signed-off-by: Sage Weil <sage@redhat.com>