### PR TITLE
osd: Handle read errors on copy_from() operations

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7594,6 +7594,10 @@ struct C_CopyFrom_AsyncReadCb : public Context {
   C_CopyFrom_AsyncReadCb(OSDOp *osd_op, uint64_t features) :
     osd_op(osd_op), features(features), len(0) {}
   void finish(int r) override {
+    if (r < 0) {
+      osd_op->rval = r;
+      return;
+    }
     assert(len > 0);
     assert(len <= reply_obj.data.length());
     bufferlist bl;


### PR DESCRIPTION

This was tested manually.  A copy_from() in an EC pool with too many shards missing got ENOENT with this change.

In Replicated read we hold the request and initiate a repair.  If there are OSDs down, theoretically we should wait for the EC pool to repair itself before returning an error.  But in this tracker there aren't enough shards to repair the object.

This commit may or may not be all we do for http://tracker.ceph.com/issues/20687