### PR TITLE
qa/suites/rados: at-end: ignore PG_{AVAILABILITY,DEGRADED}

### DIFF
--- a/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
+++ b/qa/suites/rados/thrash/d-require-luminous/at-end.yaml
@@ -21,5 +21,11 @@ overrides:
     conf:
       global:
         mon debug no require luminous: true
+
+# setting luminous triggers peering, which *might* trigger health alerts
+    log-whitelist:
+      - overall HEALTH_
+      - (PG_AVAILABILITY)
+      - (PG_DEGRADED)
   thrashosds:
     chance_thrash_cluster_full: 0


### PR DESCRIPTION
With the peering deletes change, setting luminous sets the osdmap flag
which triggers a new peering interval.  That can lead to health warnings
about PG_AVAILABILITY or PG_DEGRADED.  Ignore those!

Fixes: http://tracker.ceph.com/issues/20693
Signed-off-by: Sage Weil <sage@redhat.com>