### PR TITLE
common/common_init: disable default dout logging for UTILITY_NODOUT too

### DIFF
--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -52,7 +52,8 @@ CephContext *common_preinit(const CephInitParameters &iparams,
     conf->set_val("keyring", "$osd_data/keyring", false);
   }
 
-  if (code_env == CODE_ENVIRONMENT_LIBRARY) {
+  if (code_env == CODE_ENVIRONMENT_LIBRARY ||
+      code_env == CODE_ENVIRONMENT_UTILITY_NODOUT) {
     conf->set_val_or_die("log_to_stderr", "false");
     conf->set_val_or_die("err_to_stderr", "false");
     conf->set_val_or_die("log_flush_on_exit", "false");


### PR DESCRIPTION
broken by 4d06719f101f49019be25bd6137f72f2cb85bd5a

Fixes: http://tracker.ceph.com/issues/20771