### PR TITLE
pybind/mgr/zabbix: fix health in non-compat mode

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -113,7 +113,9 @@ class Module(MgrModule):
         data = dict()
 
         health = json.loads(self.get('health')['json'])
-        data['overall_status'] = health['overall_status']
+        # 'status' is luminous+, 'overall_status' is legacy mode.
+        data['overall_status'] = health.get('status',
+                                            health.get('overall_status'))
         data['overall_status_int'] = \
             self.ceph_health_mapping.get(data['overall_status'])
 


### PR DESCRIPTION
This was apparently written/tested with mon_health_preluminous_compat
enabled.  Fix to behave with or without that option.

Fixes: http://tracker.ceph.com/issues/20767
Signed-off-by: Sage Weil <sage@redhat.com>