### PR TITLE
osd: do not send empty MOSDFull msg

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5719,6 +5719,8 @@ void OSD::send_full_update()
     state = CEPH_OSD_BACKFILLFULL;
   } else if (service.is_nearfull()) {
     state = CEPH_OSD_NEARFULL;
+  } else {
+    return;
   }
   set<string> s;
   OSDMap::calc_state_set(state, s);


### PR DESCRIPTION
the osd stat is updated by the beartbeat thread, while
OSD::send_full_update() is normally called in the
tick_timer_without_osd_lock's thread. so there is rare chance that the
full state is reset after `service.need_fullness_update()` returns true.
this does not hurt at all. but it confuses the mon by adding its burden.
so avoid this if possible.

Signed-off-by: Kefu Chai <kchai@redhat.com>