### PR TITLE
mon/MgrMonitor: reset mgrdigest timer with new subscription

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -408,6 +408,10 @@ void MgrMonitor::check_sub(Subscription *sub)
     }
   } else {
     assert(sub->type == "mgrdigest");
+    if (sub->next == 0) {
+      // new registration; cancel previous timer
+      cancel_timer();
+    }
     if (digest_event == nullptr) {
       send_digests();
     }


### PR DESCRIPTION
If the manager reconnects, we want to send the digest immediately and
reset the previous timer.

Fixes: http://tracker.ceph.com/issues/20633
Signed-off-by: Sage Weil <sage@redhat.com>