### PR TITLE
librbd: add LIBRBD_SUPPORTS_WRITESAME support

### DIFF
--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -45,6 +45,7 @@ extern "C" {
 #define LIBRBD_SUPPORTS_INVALIDATE 1
 #define LIBRBD_SUPPORTS_IOVEC 1
 #define LIBRBD_SUPPORTS_WATCH 0
+#define LIBRBD_SUPPORTS_WRITESAME 1
 
 #if __GNUC__ >= 4
   #define CEPH_RBD_API    __attribute__ ((visibility ("default")))


### PR DESCRIPTION
This will be very helpful when release ceph package(like RPM) with
backporting writesame feature to previous version.

Signed-off-by: Xiubo Li <lixiubo@cmss.chinamobile.com>