### PR TITLE
messages: default-initialize MOSDPGRecoveryDelete[Reply] members

### DIFF
--- a/src/messages/MOSDPGRecoveryDelete.h
+++ b/src/messages/MOSDPGRecoveryDelete.h
@@ -44,7 +44,7 @@ public:
 
   MOSDPGRecoveryDelete()
     : MOSDFastDispatchOp(MSG_OSD_PG_RECOVERY_DELETE, HEAD_VERSION,
-			COMPAT_VERSION) {}
+			 COMPAT_VERSION), cost(0) {}
 
   MOSDPGRecoveryDelete(pg_shard_t from, spg_t pgid, epoch_t map_epoch,
 		       epoch_t min_epoch)
@@ -53,7 +53,8 @@ public:
       from(from),
       pgid(pgid),
       map_epoch(map_epoch),
-      min_epoch(min_epoch) {}
+      min_epoch(min_epoch),
+      cost(0) {}
 
 private:
   ~MOSDPGRecoveryDelete() {}

--- a/src/messages/MOSDPGRecoveryDeleteReply.h
+++ b/src/messages/MOSDPGRecoveryDeleteReply.h
@@ -26,7 +26,8 @@ struct MOSDPGRecoveryDeleteReply : public MOSDFastDispatchOp {
   }
 
   MOSDPGRecoveryDeleteReply()
-    : MOSDFastDispatchOp(MSG_OSD_PG_RECOVERY_DELETE_REPLY, HEAD_VERSION, COMPAT_VERSION)
+    : MOSDFastDispatchOp(MSG_OSD_PG_RECOVERY_DELETE_REPLY, HEAD_VERSION, COMPAT_VERSION),
+      map_epoch(0), min_epoch(0)
     {}
 
   void decode_payload() override {


### PR DESCRIPTION
This makes Coverity happy and is good practice, even though we do
a member-by-member initialization in the only place we create these messages.

Signed-off-by: Greg Farnum <gfarnum@redhat.com>