### PR TITLE
test/rados: fix wrong parameter order of RETURN1_IF_NOT_VAL

### DIFF
--- a/src/test/system/rados_open_pools_parallel.cc
+++ b/src/test/system/rados_open_pools_parallel.cc
@@ -81,7 +81,7 @@ public:
     rados_pool_create(cl, m_pool_name.c_str());
     rados_ioctx_t io_ctx;
     printf("%s: rados_ioctx_create.\n", get_id_str());
-    RETURN1_IF_NOT_VAL(0, rados_ioctx_create(cl, m_pool_name.c_str(), &io_ctx));
+    RETURN1_IF_NONZERO(rados_ioctx_create(cl, m_pool_name.c_str(), &io_ctx));
     if (m_open_pool_sem)
       m_open_pool_sem->post();
     rados_ioctx_destroy(io_ctx);

--- a/src/test/system/st_rados_watch.cc
+++ b/src/test/system/st_rados_watch.cc
@@ -72,11 +72,10 @@ run()
   RETURN1_IF_NONZERO(rados_ioctx_create(cl, m_pool_name.c_str(), &io_ctx));
   printf("%s: watching object %s\n", get_id_str(), m_obj_name.c_str());
 
-  RETURN1_IF_NOT_VAL(
+  RETURN1_IF_NOT_VAL(m_watch_retcode,
     rados_watch(io_ctx, m_obj_name.c_str(), 0, &handle,
 		reinterpret_cast<rados_watchcb_t>(notify_cb),
-		reinterpret_cast<void*>(&num_notifies)),
-    m_watch_retcode
+		reinterpret_cast<void*>(&num_notifies))
     );
   if (m_watch_sem) {
     m_watch_sem->post();


### PR DESCRIPTION

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>