### PR TITLE
src/:Remove invalid file path

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -983,7 +983,6 @@ endif(${ENABLE_SHARED})
 endif(WITH_LIBCEPHFS)
 
 set(journal_srcs
-  journal/AsyncOpTracker.cc
   journal/Entry.cc
   journal/Future.cc
   journal/FutureImpl.cc


### PR DESCRIPTION
jewel：AsyncOpTracker.cc is not in the journal directory

Signed-off-by: ztczll <243290414@qq.com>