### PR TITLE
common: make some message informative, instead of error

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -285,8 +285,8 @@ int main(int argc, const char **argv)
 	   << g_conf->osd_data << ": " << cpp_strerror(-err) << TEXT_NORMAL << dendl;
       exit(1);
     }
-    derr << "created object store " << g_conf->osd_data
-	 << " for osd." << whoami << " fsid " << mc.monmap.fsid << dendl;
+    dout(0) << "created object store " << g_conf->osd_data
+	    << " for osd." << whoami << " fsid " << mc.monmap.fsid << dendl;
   }
   if (mkkey) {
     common_init_finish(g_ceph_context);

--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -16,6 +16,7 @@
 #ifndef CEPH_FILEJOURNAL_H
 #define CEPH_FILEJOURNAL_H
 
+#include <stdlib.h>
 #include <deque>
 using std::deque;
 
@@ -433,7 +434,7 @@ private:
         aio = false;
       }
 #ifndef HAVE_LIBAIO
-      if (aio) {
+      if (aio && ::getenv("CEPH_DEV") == NULL) {
 	lderr(cct) << "FileJournal::_open_any: libaio not compiled in; disabling aio" << dendl;
         aio = false;
       }


### PR DESCRIPTION
- Life goes on without any problem after these messages. 
   So they should not be errors, and should not be on the CLI output

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>