### PR TITLE
qa/suites/rados: s/client.0/client/ in workunit

### DIFF
--- a/qa/suites/rados/singleton/all/erasure-code-nonregression.yaml
+++ b/qa/suites/rados/singleton/all/erasure-code-nonregression.yaml
@@ -12,6 +12,6 @@ openstack:
 tasks:
 - install:
 - workunit:
-    client.0:
+    client:
       all:
         - erasure-code/encode-decode-non-regression.sh


### PR DESCRIPTION
otherwise we will have

configuration must contain a dictionary of clients

Signed-off-by: Kefu Chai <kchai@redhat.com>