### PR TITLE
kv: column family support 

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1156,6 +1156,8 @@ OPTION(bluestore_debug_omit_kv_commit, OPT_BOOL, false)
 OPTION(bluestore_debug_permit_any_bdev_label, OPT_BOOL, false)
 OPTION(bluestore_shard_finishers, OPT_BOOL, false)
 OPTION(bluestore_debug_random_read_err, OPT_DOUBLE, 0)
+OPTION(bluestore_rocksdb_enable_column_familly, OPT_BOOL, false) // whether to enable column_family 
+                                                                 // or just use default column in bluestore
 
 OPTION(kstore_max_ops, OPT_U64, 512)
 OPTION(kstore_max_bytes, OPT_U64, 64*1024*1024)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3263,6 +3263,10 @@ const std::vector<Option> ceph_options = {
   .set_default(false)
   .set_description(""),
 
+  Option("bluestore_rocksdb_enable_column_familly", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+  .set_default(false)
+  .set_description(""),
+
   Option("filestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
   .set_default("")
   .set_description(""),

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -350,10 +350,6 @@ public:
   typedef ceph::shared_ptr< IteratorImpl > Iterator;
 
   WholeSpaceIterator get_iterator() {
-    // a whole-space iterator cannot be used in combination with
-    // column families because it is not smart enough to traverse
-    // across all of them.
-    assert(cf_handles.empty());
     return _get_iterator();
   }
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -163,9 +163,6 @@ public:
   // vector cfs contains column families to be created when db is created.
   virtual int create_and_open(std::ostream &out, const vector<ColumnFamily>& cfs) {
     assert(0 == "Not implemented"); }
-  virtual int drop_column_family(
-    const string &cf_name         ///< [in] name of CF to delete
-  ) { assert(0 == "Not implemented"); }
 
   virtual Transaction get_transaction() = 0;
   virtual int submit_transaction(Transaction) = 0;

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -350,6 +350,10 @@ public:
   typedef ceph::shared_ptr< IteratorImpl > Iterator;
 
   WholeSpaceIterator get_iterator() {
+    // a whole-space iterator cannot be used in combination with
+    // column families because it is not smart enough to traverse
+    // across all of them.
+    assert(cf_handles.empty());
     return _get_iterator();
   }
 
@@ -377,7 +381,7 @@ public:
   Iterator get_iterator(const std::string &prefix) {
     return is_column_family(prefix) ?
              std::make_shared<IteratorImpl>(prefix, get_cf_iterator(prefix)) :
-             std::make_shared<IteratorImpl>(prefix, get_iterator());
+             std::make_shared<IteratorImpl>(prefix, _get_iterator());
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -14,6 +14,7 @@
 #include "common/Formatter.h"
 
 using std::string;
+using std::vector;
 /**
  * Defines virtual interface to be implemented by key value store
  *
@@ -21,11 +22,23 @@ using std::string;
  */
 class KeyValueDB {
 public:
+  /*
+   *  See RocksDB's definition of a column family(CF) and how to use it.
+   *  The interfaces of KeyValueDB is extended, when a column family is created.
+   *  Prefix will be the name of column family to use.
+   */
+  struct ColumnFamily {
+    string name;      //< name of this individual column family
+    string option;    //< configure option string for this CF
+    ColumnFamily(const string &name, const string &option)
+      : name(name), option(option) {}
+  };
+
   class TransactionImpl {
   public:
     /// Set Keys
     void set(
-      const std::string &prefix,                 ///< [in] Prefix for keys
+      const std::string &prefix,                      ///< [in] Prefix for keys, or CF name
       const std::map<std::string, bufferlist> &to_set ///< [in] keys/values to set
     ) {
       std::map<std::string, bufferlist>::const_iterator it;
@@ -35,8 +48,8 @@ public:
 
     /// Set Keys (via encoded bufferlist)
     void set(
-      const std::string &prefix,      ///< [in] prefix
-      bufferlist& to_set_bl     ///< [in] encoded key/values to set
+      const std::string &prefix,      ///< [in] prefix, or CF name
+      bufferlist& to_set_bl           ///< [in] encoded key/values to set
       ) {
       bufferlist::iterator p = to_set_bl.begin();
       uint32_t num;
@@ -52,9 +65,9 @@ public:
 
     /// Set Key
     virtual void set(
-      const std::string &prefix,   ///< [in] Prefix for the key
+      const std::string &prefix,      ///< [in] Prefix or CF for the key
       const std::string &k,	      ///< [in] Key to set
-      const bufferlist &bl    ///< [in] Value to set
+      const bufferlist &bl            ///< [in] Value to set
       ) = 0;
     virtual void set(
       const std::string &prefix,
@@ -66,8 +79,8 @@ public:
 
     /// Removes Keys (via encoded bufferlist)
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      bufferlist &keys_bl ///< [in] Keys to remove
+      const std::string &prefix,     ///< [in] Prefix or CF to search for
+      bufferlist &keys_bl            ///< [in] Keys to remove
     ) {
       bufferlist::iterator p = keys_bl.begin();
       uint32_t num;
@@ -81,7 +94,7 @@ public:
 
     /// Removes Keys
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,        ///< [in] Prefix/CF to search for
       const std::set<std::string> &keys ///< [in] Keys to remove
     ) {
       std::set<std::string>::const_iterator it;
@@ -91,8 +104,8 @@ public:
 
     /// Remove Key
     virtual void rmkey(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      const std::string &k	      ///< [in] Key to remove
+      const std::string &prefix,       ///< [in] Prefix/CF to search for
+      const std::string &k	       ///< [in] Key to remove
       ) = 0;
     virtual void rmkey(
       const std::string &prefix,   ///< [in] Prefix to search for
@@ -108,13 +121,13 @@ public:
     /// If a key is overwritten (by calling set multiple times), then the result
     /// of calling rm_single_key on this key is undefined.
     virtual void rm_single_key(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,      ///< [in] Prefix/CF to search for
       const std::string &k	      ///< [in] Key to remove
       ) { return rmkey(prefix, k);}
 
     /// Removes keys beginning with prefix
     virtual void rmkeys_by_prefix(
-      const std::string &prefix ///< [in] Prefix by which to remove keys
+      const std::string &prefix       ///< [in] Prefix/CF by which to remove keys
       ) = 0;
 
     virtual void rm_range_keys(
@@ -125,7 +138,7 @@ public:
 
     /// Merge value into key
     virtual void merge(
-      const std::string &prefix,   ///< [in] Prefix ==> MUST match some established merge operator
+      const std::string &prefix,   ///< [in] Prefix/CF ==> MUST match some established merge operator
       const std::string &key,      ///< [in] Key to be merged
       const bufferlist  &value     ///< [in] value to be merged into key
     ) { assert(0 == "Not implemented"); }
@@ -143,8 +156,16 @@ public:
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
   virtual int open(std::ostream &out) = 0;
+  virtual int open(std::ostream &out, const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented"); }
   virtual int create_and_open(std::ostream &out) = 0;
   virtual void close() { }
+  // vector cfs contains column families to be created when db is created.
+  virtual int create_and_open(std::ostream &out, const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented"); }
+  virtual int drop_column_family(
+    const string &cf_name         ///< [in] name of CF to delete
+  ) { assert(0 == "Not implemented"); }
 
   virtual Transaction get_transaction() = 0;
   virtual int submit_transaction(Transaction) = 0;
@@ -154,13 +175,13 @@ public:
 
   /// Retrieve Keys
   virtual int get(
-    const std::string &prefix,        ///< [in] Prefix for key
-    const std::set<std::string> &key,      ///< [in] Key to retrieve
-    std::map<std::string, bufferlist> *out ///< [out] Key value retrieved
+    const std::string &prefix,               ///< [in] Prefix/CF for key
+    const std::set<std::string> &key,        ///< [in] Key to retrieve
+    std::map<std::string, bufferlist> *out   ///< [out] Key value retrieved
     ) = 0;
-  virtual int get(const std::string &prefix, ///< [in] prefix
+  virtual int get(const std::string &prefix, ///< [in] prefix or CF name
 		  const std::string &key,    ///< [in] key
-		  bufferlist *value) {  ///< [out] value
+		  bufferlist *value) {       ///< [out] value
     std::set<std::string> ks;
     ks.insert(key);
     std::map<std::string,bufferlist> om;
@@ -192,6 +213,8 @@ public:
     virtual ~GenericIteratorImpl() {}
   };
 
+  /// When Column Family is used, WholeSpaceIterator is limited to the default column family,
+  /// and user can still use multiple prefixes within the default CF.
   class WholeSpaceIteratorImpl {
   public:
     virtual int seek_to_first() = 0;
@@ -226,77 +249,152 @@ public:
   };
   typedef ceph::shared_ptr< WholeSpaceIteratorImpl > WholeSpaceIterator;
 
+  /// Iterator for column family which is created explicitly and not the default one.
+  class ColumnFamilyIteratorImpl {
+  public:
+    virtual int seek_to_first() = 0;
+    virtual int seek_to_last() = 0;
+    virtual int upper_bound(const std::string &after) = 0;
+    virtual int lower_bound(const std::string &to) = 0;
+    virtual bool valid() = 0;
+    virtual int next() = 0;
+    virtual int prev() = 0;
+    virtual std::string key() = 0;
+    virtual bufferlist value() = 0;
+    virtual bufferptr value_as_ptr() {
+      bufferlist bl = value();
+      if (bl.length()) {
+        return *bl.buffers().begin();
+      } else {
+        return bufferptr();
+      }
+    }
+    virtual int status() = 0;
+    virtual ~ColumnFamilyIteratorImpl() { }
+  };
+  typedef ceph::shared_ptr< ColumnFamilyIteratorImpl > ColumnFamilyIterator;
+
   class IteratorImpl : public GenericIteratorImpl {
-    const std::string prefix;
+    const std::string prefix;         //prefix or CF name
     WholeSpaceIterator generic_iter;
+    ColumnFamilyIterator cf_iter;
+    bool is_cf;                       //is it for a explicit column family
   public:
     IteratorImpl(const std::string &prefix, WholeSpaceIterator iter) :
-      prefix(prefix), generic_iter(iter) { }
+      prefix(prefix), generic_iter(iter), is_cf(false) { }
+    IteratorImpl(const std::string &cf_name, ColumnFamilyIterator iter) :
+      prefix(cf_name), cf_iter(iter), is_cf(true) { }
     ~IteratorImpl() override { }
 
     int seek_to_first() override {
-      return generic_iter->seek_to_first(prefix);
+      return is_cf ? cf_iter->seek_to_first() :
+                     generic_iter->seek_to_first(prefix);
     }
     int seek_to_last() {
-      return generic_iter->seek_to_last(prefix);
+      return is_cf ? cf_iter->seek_to_last() :
+                     generic_iter->seek_to_last(prefix);
     }
     int upper_bound(const std::string &after) override {
-      return generic_iter->upper_bound(prefix, after);
+      return is_cf ? cf_iter->upper_bound(after) :
+                     generic_iter->upper_bound(prefix, after);
     }
     int lower_bound(const std::string &to) override {
-      return generic_iter->lower_bound(prefix, to);
+      return is_cf ? cf_iter->lower_bound(to) :
+                     generic_iter->lower_bound(prefix, to);
     }
     bool valid() override {
-      if (!generic_iter->valid())
-	return false;
-      return generic_iter->raw_key_is_prefixed(prefix);
+      if (is_cf) {
+        return cf_iter->valid();
+      } else {
+        if (!generic_iter->valid())
+	  return false;
+        return generic_iter->raw_key_is_prefixed(prefix);
+      }
     }
     // Note that next() and prev() shouldn't validate iters,
     // it's responsibility of caller to ensure they're valid.
     int next(bool validate=true) override {
       if (validate) {
         if (valid())
-          return generic_iter->next();
+          return is_cf ? cf_iter->next() : generic_iter->next();
         return status();
       } else {
-        return generic_iter->next();  
+        return is_cf ? cf_iter->next() : generic_iter->next();  
       }      
     }
     
     int prev(bool validate=true) {
       if (validate) {
         if (valid())
-          return generic_iter->prev();
+          return is_cf ? cf_iter->prev() : generic_iter->prev();
         return status();
       } else {
-        return generic_iter->prev();  
+        return is_cf ? cf_iter->prev() : generic_iter->prev();
       }      
     }
     std::string key() override {
-      return generic_iter->key();
+      return is_cf ? cf_iter->key() : generic_iter->key();
     }
+    // For column family, keys actually don't contain prefix;
+    // to make interface compatible, prefix is added.
     std::pair<std::string, std::string> raw_key() {
-      return generic_iter->raw_key();
+      return is_cf ? make_pair(prefix, cf_iter->key()) : generic_iter->raw_key();
     }
     bufferlist value() override {
-      return generic_iter->value();
+      return is_cf ? cf_iter->value() : generic_iter->value();
     }
     bufferptr value_as_ptr() {
-      return generic_iter->value_as_ptr();
+      return is_cf ? cf_iter->value_as_ptr() : generic_iter->value_as_ptr();
     }
     int status() override {
-      return generic_iter->status();
+      return is_cf ? cf_iter->status() : generic_iter->status();
     }
   };
-
   typedef ceph::shared_ptr< IteratorImpl > Iterator;
 
   WholeSpaceIterator get_iterator() {
     return _get_iterator();
   }
 
+  ColumnFamilyIterator get_cf_iterator(const std::string& cf_name) {
+    return _get_cf_iterator(cf_name);
+  }
+
+  WholeSpaceIterator get_snapshot_iterator() {
+    return _get_snapshot_iterator();
+  }
+
+  ColumnFamilyIterator get_cf_snapshot_iterator(const std::string& cf_name) {
+    return _get_cf_snapshot_iterator(cf_name);
+  }
+
+  void add_column_family(const std::string& cf_name, void *handle) {
+    cf_handles.insert(std::make_pair(cf_name, handle));
+  }
+
+  void *get_cf_handle(const std::string& cf_name) {
+    std::unordered_map<std::string, void*>::const_iterator iter;
+    iter = cf_handles.find(cf_name);
+    if (iter == cf_handles.end())
+      return nullptr;
+    else
+      return iter->second;
+  }
+
+  bool is_column_family(const std::string& prefix) {
+    return cf_handles.count(prefix); 
+  }
+
   Iterator get_iterator(const std::string &prefix) {
-    return std::make_shared<IteratorImpl>(prefix, get_iterator());
+    return is_column_family(prefix) ?
+             std::make_shared<IteratorImpl>(prefix, get_cf_iterator(prefix)) :
+             std::make_shared<IteratorImpl>(prefix, get_iterator());
+  }
+
+  Iterator get_snapshot_iterator(const std::string &prefix) {
+    return is_column_family(prefix) ?
+             std::make_shared<IteratorImpl>(prefix, get_cf_snapshot_iterator(prefix)) :
+             std::make_shared<IteratorImpl>(prefix, get_snapshot_iterator());
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -351,11 +449,19 @@ public:
     return;
   }
 protected:
-  /// List of matching prefixes and merge operators
+  /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
 
+  /// column families in use, name->handle
+  std::unordered_map<std::string, void *> cf_handles;
+
   virtual WholeSpaceIterator _get_iterator() = 0;
+  virtual WholeSpaceIterator _get_snapshot_iterator() = 0;
+  virtual ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name) {
+    assert(0 == "Not implemented"); }
+  virtual ColumnFamilyIterator _get_cf_snapshot_iterator(const std::string& cf_name) {
+    assert(0 == "Not implemented"); }
 };
 
 #endif

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -360,14 +360,6 @@ public:
     return _get_cf_iterator(cf_name);
   }
 
-  WholeSpaceIterator get_snapshot_iterator() {
-    return _get_snapshot_iterator();
-  }
-
-  ColumnFamilyIterator get_cf_snapshot_iterator(const std::string& cf_name) {
-    return _get_cf_snapshot_iterator(cf_name);
-  }
-
   void add_column_family(const std::string& cf_name, void *handle) {
     cf_handles.insert(std::make_pair(cf_name, handle));
   }
@@ -389,12 +381,6 @@ public:
     return is_column_family(prefix) ?
              std::make_shared<IteratorImpl>(prefix, get_cf_iterator(prefix)) :
              std::make_shared<IteratorImpl>(prefix, get_iterator());
-  }
-
-  Iterator get_snapshot_iterator(const std::string &prefix) {
-    return is_column_family(prefix) ?
-             std::make_shared<IteratorImpl>(prefix, get_cf_snapshot_iterator(prefix)) :
-             std::make_shared<IteratorImpl>(prefix, get_snapshot_iterator());
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -457,10 +443,7 @@ protected:
   std::unordered_map<std::string, void *> cf_handles;
 
   virtual WholeSpaceIterator _get_iterator() = 0;
-  virtual WholeSpaceIterator _get_snapshot_iterator() = 0;
   virtual ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name) {
-    assert(0 == "Not implemented"); }
-  virtual ColumnFamilyIterator _get_cf_snapshot_iterator(const std::string& cf_name) {
     assert(0 == "Not implemented"); }
 };
 

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -56,7 +56,7 @@ public:
     return do_open(out, false);
   }
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) {
+  int create_and_open(ostream &out) override {
     return do_open(out, true);
   }
 

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -177,9 +177,18 @@ public:
   int open(ostream &out) override {
     return do_open(out, false);
   }
+
+  int open(ostream &out, const std::vector<ColumnFamily> &cfs) override {
+    return KeyValueDB::open(out, cfs);
+  }
+
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out) override {
     return do_open(out, true);
+  }
+
+  int create_and_open(ostream& out, const std::vector<ColumnFamily>& cfs) override {
+    return KeyValueDB::create_and_open(out, cfs);
   }
 
   void close() override;

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -122,8 +122,16 @@ public:
   int _init(bool format);
 
   int do_open(ostream &out, bool create);
+
   int open(ostream &out) override { return do_open(out, false); }
+  int open(ostream &out, const std::vector<ColumnFamily>& cfs) override {
+    return KeyValueDB::open(out, cfs);
+  }
+
   int create_and_open(ostream &out) override { return do_open(out, true); }
+  int create_and_open(ostream& out, const std::vector<ColumnFamily>& cfs) override {
+    return KeyValueDB::create_and_open(out, cfs);
+  }
 
   KeyValueDB::Transaction get_transaction() override {
     return std::shared_ptr<MDBTransactionImpl>(new MDBTransactionImpl(this));

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -226,7 +226,7 @@ int RocksDBStore::init(string _options_str)
   return 0;
 }
 
-int RocksDBStore::create_and_open(ostream &out)
+int RocksDBStore::create_db_dir()
 {
   if (env) {
     unique_ptr<rocksdb::Directory> dir;
@@ -241,10 +241,27 @@ int RocksDBStore::create_and_open(ostream &out)
       return r;
     }
   }
+  return 0;
+}
+
+int RocksDBStore::create_and_open(ostream &out)
+{
+  int r = create_db_dir();
+  if (r < 0)
+    return r;
   return do_open(out, true);
 }
 
-int RocksDBStore::do_open(ostream &out, bool create_if_missing)
+int RocksDBStore::create_and_open(ostream &out, const vector<ColumnFamily>& cfs)
+{
+  int r = create_db_dir();
+  if (r < 0)
+    return r;
+  return do_open(out, true, &cfs);
+}
+
+int RocksDBStore::do_open(ostream &out, bool create_if_missing,
+			  const vector<ColumnFamily>* cfs)
 {
   rocksdb::Options opt;
   rocksdb::Status status;
@@ -346,10 +363,71 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
 	   << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
-  status = rocksdb::DB::Open(opt, path, &db);
-  if (!status.ok()) {
-    derr << status.ToString() << dendl;
-    return -EINVAL;
+  if (create_if_missing) {
+    status = rocksdb::DB::Open(opt, path, &db);
+    if (!status.ok()) {
+      derr << status.ToString() << dendl;
+      return -EINVAL;
+    }
+    //create and open column families
+    if (cfs) {
+      rocksdb::ColumnFamilyHandle* cf;
+      for (auto & p : *cfs) {
+	//copy default CF settings, block cache, merge operators as the base for new CF
+	rocksdb::ColumnFamilyOptions cf_opt(opt);
+	//user input options will override the base options
+	status = rocksdb::GetColumnFamilyOptionsFromString(cf_opt, p.option, &cf_opt);
+	if (!status.ok()) {
+	  //unrecognized by rocksdb
+	  derr << __func__ << " invalid db column family option string for CF: "
+	       << p.name << dendl;
+	  return -EINVAL;
+	}
+	status = db->CreateColumnFamily(cf_opt, p.name, &cf);
+	if (!status.ok()) {
+	  derr << __func__ << "Failed to create rocksdb column family: "
+	       << p.name << dendl;
+	  return -EINVAL;
+	}
+	//store the new CF handle
+	add_column_family(p.name, static_cast<void*>(cf));
+      }
+    }
+  } else {
+    if (cfs) {
+      std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
+      std::vector<rocksdb::ColumnFamilyHandle*> handles;
+      column_families.push_back(rocksdb::ColumnFamilyDescriptor(
+				  rocksdb::kDefaultColumnFamilyName,
+				  rocksdb::ColumnFamilyOptions(opt)));
+      for (auto & p : *cfs) {
+	//copy default CF settings, block cache, merge operators as the base for new CF
+	rocksdb::ColumnFamilyOptions cf_opt(opt);
+	//user input options will override the base options
+	status = rocksdb::GetColumnFamilyOptionsFromString(cf_opt, p.option, &cf_opt); 
+	if (!status.ok()) {
+	  //unrecognized by rocksdb
+	  derr << __func__ << " invalid db column family option string for CF: "
+	       << p.name << dendl;
+	  return -EINVAL;
+	}
+	column_families.push_back(rocksdb::ColumnFamilyDescriptor(p.name, cf_opt));
+      }
+      status = rocksdb::DB::Open(rocksdb::DBOptions(opt), path, column_families, &handles, &db);
+      if (!status.ok()) {
+	derr << status.ToString() << dendl;
+	return -EINVAL;
+      }
+      //store the opened CF handles, except for the default CF.
+      for (unsigned i=0; i<(*cfs).size(); i++)
+	  add_column_family((*cfs)[i].name, static_cast<void*>(handles[i+1]));
+    } else {
+      status = rocksdb::DB::Open(opt, path, &db);
+      if (!status.ok()) {
+	derr << status.ToString() << dendl;
+	return -EINVAL;
+      }
+    }
   }
   
   PerfCountersBuilder plb(g_ceph_context, "rocksdb", l_rocksdb_first, l_rocksdb_last);
@@ -379,6 +457,24 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
   return 0;
 }
 
+int RocksDBStore::drop_column_family(const string &cf_name)
+{
+  rocksdb::Status status;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(cf_name));
+  if (cf_handle == nullptr)
+    return -EINVAL;
+
+  status = db->DropColumnFamily(cf_handle);
+  if (!status.ok()) {
+    derr << __func__ << "Failed to delete rocksdb column family: "
+	 << cf_name << dendl;
+    return -EINVAL;
+  } else {
+    return 0;
+  }
+}
+
 int RocksDBStore::_test_init(const string& dir)
 {
   rocksdb::Options options;
@@ -396,6 +492,10 @@ RocksDBStore::~RocksDBStore()
   delete logger;
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
+  for (auto & p : cf_handles) {
+    delete static_cast<rocksdb::ColumnFamilyHandle*>(p.second);
+    p.second = nullptr;
+  }
   delete db;
   db = nullptr;
 
@@ -599,17 +699,26 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const string &k,
   const bufferlist &to_set_bl)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   string key = combine_strings(prefix, k);
 
   // bufferlist::c_str() is non-constant, so we can't call c_str()
   if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
-    bat.Put(rocksdb::Slice(key),
+    bat.Put(cf_handle, rocksdb::Slice(def_cf ? key : k),
 	     rocksdb::Slice(to_set_bl.buffers().front().c_str(),
 			    to_set_bl.length()));
   } else {
-    rocksdb::Slice key_slice(key);
+    rocksdb::Slice key_slice1(key);
+    rocksdb::Slice key_slice2(k);
     rocksdb::Slice value_slices[to_set_bl.buffers().size()];
-    bat.Put(nullptr, rocksdb::SliceParts(&key_slice, 1),
+    bat.Put(cf_handle, rocksdb::SliceParts(def_cf ? &key_slice1 : &key_slice2, 1),
             prepare_sliceparts(to_set_bl, value_slices));
   }
 }
@@ -619,18 +728,27 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const char *k, size_t keylen,
   const bufferlist &to_set_bl)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   string key;
   combine_strings(prefix, k, keylen, &key);
 
   // bufferlist::c_str() is non-constant, so we can't call c_str()
   if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
-    bat.Put(rocksdb::Slice(key),
+    bat.Put(cf_handle, rocksdb::Slice(def_cf ? key : k),
 	     rocksdb::Slice(to_set_bl.buffers().front().c_str(),
 			    to_set_bl.length()));
   } else {
-    rocksdb::Slice key_slice(key);
+    rocksdb::Slice key_slice1(key);
+    rocksdb::Slice key_slice2(k);
     rocksdb::Slice value_slices[to_set_bl.buffers().size()];
-    bat.Put(nullptr, rocksdb::SliceParts(&key_slice, 1),
+    bat.Put(cf_handle, rocksdb::SliceParts(def_cf ? &key_slice1 : &key_slice2, 1),
             prepare_sliceparts(to_set_bl, value_slices));
   }
 }
@@ -638,26 +756,56 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
-  bat.Delete(combine_strings(prefix, k));
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+  bat.Delete(cf_handle, def_cf ? combine_strings(prefix, k) : k);
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const char *k,
 						 size_t keylen)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   string key;
   combine_strings(prefix, k, keylen, &key);
-  bat.Delete(key);
+  bat.Delete(cf_handle, def_cf ? key : k);
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
-  bat.SingleDelete(combine_strings(prefix, k));
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+  bat.SingleDelete(cf_handle, def_cf ? combine_strings(prefix, k) : k);
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }    
+
   if (db->enable_rmrange) {
     string endprefix = prefix;
     endprefix.push_back('\x01');
@@ -668,7 +816,8 @@ void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix
     for (it->seek_to_first();
 	 it->valid();
 	 it->next()) {
-      bat.Delete(combine_strings(prefix, it->key()));
+      bat.Delete(cf_handle, 
+                 def_cf ? combine_strings(prefix, it->key()) : it->key());
     }
   }
 }
@@ -677,8 +826,16 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &start,
                                                          const string &end)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   if (db->enable_rmrange) {
-    bat.DeleteRange(combine_strings(prefix, start), combine_strings(prefix, end));
+    bat.DeleteRange(def_cf ? combine_strings(prefix, start) : start, def_cf ? combine_strings(prefix, end) : end);
   } else {
     auto it = db->get_iterator(prefix);
     it->lower_bound(start);
@@ -686,7 +843,8 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
       if (it->key() >= end) {
         break;
       }
-      bat.Delete(combine_strings(prefix, it->key()));
+      bat.Delete(cf_handle, 
+                 def_cf ? combine_strings(prefix, it->key()) : it->key());
       it->next();
     }
   }
@@ -697,34 +855,50 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const string &k,
   const bufferlist &to_set_bl)
 {
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(db->get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   string key = combine_strings(prefix, k);
 
   // bufferlist::c_str() is non-constant, so we can't call c_str()
   if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
-    bat.Merge(rocksdb::Slice(key),
-	       rocksdb::Slice(to_set_bl.buffers().front().c_str(),
-			    to_set_bl.length()));
+    bat.Merge(cf_handle, rocksdb::Slice(def_cf ? combine_strings(prefix, k) : k),
+	       rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
   } else {
     // make a copy
-    rocksdb::Slice key_slice(key);
+    rocksdb::Slice key_slice1(key);
+    rocksdb::Slice key_slice2(k);
     rocksdb::Slice value_slices[to_set_bl.buffers().size()];
-    bat.Merge(nullptr, rocksdb::SliceParts(&key_slice, 1),
+    bat.Merge(nullptr, rocksdb::SliceParts(def_cf ? &key_slice1 : &key_slice2, 1),
               prepare_sliceparts(to_set_bl, value_slices));
   }
 }
 
-//gets will bypass RocksDB row cache, since it uses iterator
 int RocksDBStore::get(
     const string &prefix,
     const std::set<string> &keys,
     std::map<string, bufferlist> *out)
 {
   utime_t start = ceph_clock_now();
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   for (std::set<string>::const_iterator i = keys.begin();
        i != keys.end(); ++i) {
     std::string value;
-    std::string bound = combine_strings(prefix, *i);
-    auto status = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(bound), &value);
+    auto status = db->Get(rocksdb::ReadOptions(), cf_handle,
+			  rocksdb::Slice(def_cf ? combine_strings(prefix, *i) : *i),
+			  &value);
     if (status.ok()) {
       (*out)[*i].append(value);
     } else if (status.IsIOError()) {
@@ -745,11 +919,20 @@ int RocksDBStore::get(
 {
   assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now();
+  bool def_cf = false;
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(prefix));
+  if (nullptr == cf_handle) {
+    cf_handle = db->DefaultColumnFamily();
+    def_cf = true;
+  }
+
   int r = 0;
-  string value, k;
+  string value;
   rocksdb::Status s;
-  k = combine_strings(prefix, key);
-  s = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(k), &value);
+  s = db->Get(rocksdb::ReadOptions(), cf_handle,
+	      rocksdb::Slice(def_cf ? combine_strings(prefix, key) : key),
+	      &value);
   if (s.ok()) {
     out->append(value);
   } else if (s.IsNotFound()) {
@@ -892,6 +1075,7 @@ void RocksDBStore::compact_range(const string& start, const string& end)
   rocksdb::Slice cend(end);
   db->CompactRange(options, &cstart, &cend);
 }
+
 RocksDBStore::RocksDBWholeSpaceIteratorImpl::~RocksDBWholeSpaceIteratorImpl()
 {
   delete dbiter;
@@ -1025,5 +1209,80 @@ RocksDBStore::WholeSpaceIterator RocksDBStore::_get_iterator()
 {
   return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
         db->NewIterator(rocksdb::ReadOptions()));
+}
+
+RocksDBStore::RocksDBCFIteratorImpl::~RocksDBCFIteratorImpl()
+{
+  delete dbiter;
+}
+int RocksDBStore::RocksDBCFIteratorImpl::seek_to_first()
+{
+  dbiter->SeekToFirst();
+  return dbiter->status().ok() ? 0 : -1;
+}
+int RocksDBStore::RocksDBCFIteratorImpl::seek_to_last()
+{
+  dbiter->SeekToLast();
+  return dbiter->status().ok() ? 0 : -1;
+}
+int RocksDBStore::RocksDBCFIteratorImpl::upper_bound(const string &after)
+{
+  lower_bound(after);
+  if (valid() && (key() == after)) {
+    next();
+  }
+  return dbiter->status().ok() ? 0 : -1;
+}
+int RocksDBStore::RocksDBCFIteratorImpl::lower_bound(const string &to)
+{
+  rocksdb::Slice slice_bound(to);
+  dbiter->Seek(slice_bound);
+  return dbiter->status().ok() ? 0 : -1;
+}
+bool RocksDBStore::RocksDBCFIteratorImpl::valid()
+{
+  return dbiter->Valid();
+}
+int RocksDBStore::RocksDBCFIteratorImpl::next()
+{
+  if (valid()) {
+    dbiter->Next();
+  }
+  return dbiter->status().ok() ? 0 : -1;
+}
+int RocksDBStore::RocksDBCFIteratorImpl::prev()
+{
+  if (valid()) {
+    dbiter->Prev();
+  }
+  return dbiter->status().ok() ? 0 : -1;
+}
+string RocksDBStore::RocksDBCFIteratorImpl::key()
+{
+  return dbiter->key().ToString();
+}
+bufferlist RocksDBStore::RocksDBCFIteratorImpl::value()
+{
+  return to_bufferlist(dbiter->value());
+}
+bufferptr RocksDBStore::RocksDBCFIteratorImpl::value_as_ptr()
+{
+  rocksdb::Slice val = dbiter->value();
+  return bufferptr(val.data(), val.size());
+}
+int RocksDBStore::RocksDBCFIteratorImpl::status()
+{
+  return dbiter->status().ok() ? 0 : -1;
+}
+
+RocksDBStore::ColumnFamilyIterator RocksDBStore::_get_cf_iterator(
+						  const std::string& cf_name)
+{
+  rocksdb::ColumnFamilyHandle* cf_handle;
+  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(cf_name));
+  assert(cf_handle != nullptr);
+
+  return std::make_shared<RocksDBCFIteratorImpl>(
+		      db->NewIterator(rocksdb::ReadOptions(), cf_handle));
 }
 

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -307,7 +307,8 @@ int RocksDBStore::create_and_open(ostream &out)
   return do_open(out, true);
 }
 
-int RocksDBStore::create_and_open(ostream &out, const vector<ColumnFamily>& cfs)
+int RocksDBStore::create_and_open(ostream &out,
+				  const vector<ColumnFamily>& cfs)
 {
   int r = create_db_dir();
   if (r < 0)

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -476,7 +476,8 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
 	derr << status.ToString() << dendl;
 	return -EINVAL;
       }
-      //store the opened CF handles, except for the default CF.
+      
+      add_column_family(rocksdb::kDefaultColumnFamilyName, static_cast<void*>(handles[0]));
       for (unsigned i=0; i<(*cfs).size(); i++)
 	  add_column_family((*cfs)[i].name, static_cast<void*>(handles[i+1]));
     } else {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -514,24 +514,6 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
   return 0;
 }
 
-int RocksDBStore::drop_column_family(const string &cf_name)
-{
-  rocksdb::Status status;
-  rocksdb::ColumnFamilyHandle* cf_handle;
-  cf_handle = static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(cf_name));
-  if (cf_handle == nullptr)
-    return -EINVAL;
-
-  status = db->DropColumnFamily(cf_handle);
-  if (!status.ok()) {
-    derr << __func__ << "Failed to delete rocksdb column family: "
-	 << cf_name << dendl;
-    return -EINVAL;
-  } else {
-    return 0;
-  }
-}
-
 int RocksDBStore::_test_init(const string& dir)
 {
   rocksdb::Options options;

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -46,10 +46,14 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl, rocksdb::Sli
 }
 
 //
-// One of these per rocksdb instance, implements the merge operator prefix stuff
+// One of these per rocksdb column family(includes the default CF), 
+// implements the merge operator prefix stuff
 //
 class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperator {
   RocksDBStore& store;
+  //name of the column family associated with this merge operator
+  //only for explicit CF, not for the default CF
+  std::string cf_name;
   public:
   const char *Name() const override {
     // Construct a name that rocksDB will validate against. We want to
@@ -58,7 +62,19 @@ class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperat
     // construct a name from all of those parts.
     store.assoc_name.clear();
     map<std::string,std::string> names;
-    for (auto& p : store.merge_ops) names[p.first] = p.second->name();
+    if (cf_name.empty()) {
+      //for default column family
+      for (auto& p : store.merge_ops) names[p.first] = p.second->name();
+      for (auto& p : store.cf_handles) names.erase(p.first);
+    } else {
+      //for user created explicit column family
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(cf_name) == 0) {
+	  names[cf_name] = p.second->name();
+	  break;
+	}
+      }
+    }
     for (auto& p : names) {
       store.assoc_name += '.';
       store.assoc_name += p.first;
@@ -68,31 +84,53 @@ class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperat
     return store.assoc_name.c_str();
   }
 
+  //for default column family
   MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
+  //for user created explicit CF
+  MergeOperatorRouter(RocksDBStore &_store, const std::string &cf)
+    : store(_store), cf_name(cf) {}
 
   bool Merge(const rocksdb::Slice& key,
                      const rocksdb::Slice* existing_value,
                      const rocksdb::Slice& value,
                      std::string* new_value,
                      rocksdb::Logger* logger) const override {
-    // Check each prefix
-    for (auto& p : store.merge_ops) {
-      if (p.first.compare(0, p.first.length(),
-			  key.data(), p.first.length()) == 0 &&
-	  key.data()[p.first.length()] == 0) {
-        if (existing_value) {
-          p.second->merge(existing_value->data(), existing_value->size(),
-			  value.data(), value.size(),
-			  new_value);
-        } else {
-          p.second->merge_nonexistent(value.data(), value.size(), new_value);
-        }
-        break;
+    if (cf_name.empty()) {
+      // for default column family
+      // extract prefix from key and compare against each registered merge op;
+      // even though merge operator for explicit CF is included in merge_ops, 
+      // it won't be picked up, since it won't match.
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(0, p.first.length(),
+			    key.data(), p.first.length()) == 0 &&
+	    key.data()[p.first.length()] == 0) {
+	  if (existing_value) {
+	    p.second->merge(existing_value->data(), existing_value->size(),
+			    value.data(), value.size(),
+			    new_value);
+	  } else {
+	    p.second->merge_nonexistent(value.data(), value.size(), new_value);
+	  }
+	  break;
+	}
+      }
+    } else {
+      //for user created explicit column family 
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(cf_name) == 0) {
+	  if (existing_value) {
+	    p.second->merge(existing_value->data(), existing_value->size(),
+			    value.data(), value.size(),
+			    new_value);
+	  } else {
+	    p.second->merge_nonexistent(value.data(), value.size(), new_value);
+	  }
+	  break;
+	}
       }
     }
     return true; // OK :)
   }
-
 };
 
 int RocksDBStore::set_merge_operator(
@@ -244,6 +282,23 @@ int RocksDBStore::create_db_dir()
   return 0;
 }
 
+int RocksDBStore::install_cf_mergeop(const string &cf_name,
+				  rocksdb::ColumnFamilyOptions *cf_opt)
+{
+  assert(cf_opt != nullptr);
+  bool found_mop = false;
+  for (auto &mop : merge_ops) {
+    if (mop.first.compare(cf_name) == 0) {
+      cf_opt->merge_operator.reset(new MergeOperatorRouter(*this, cf_name));
+      found_mop = true; 
+      break; 
+    }
+  }
+  if (!found_mop)
+      cf_opt->merge_operator.reset();
+  return 0;
+}
+
 int RocksDBStore::create_and_open(ostream &out)
 {
   int r = create_db_dir();
@@ -383,6 +438,7 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
 	       << p.name << dendl;
 	  return -EINVAL;
 	}
+	install_cf_mergeop(p.name, &cf_opt);
 	status = db->CreateColumnFamily(cf_opt, p.name, &cf);
 	if (!status.ok()) {
 	  derr << __func__ << "Failed to create rocksdb column family: "
@@ -411,6 +467,7 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing,
 	       << p.name << dendl;
 	  return -EINVAL;
 	}
+	install_cf_mergeop(p.name, &cf_opt);
 	column_families.push_back(rocksdb::ColumnFamilyDescriptor(p.name, cf_opt));
       }
       status = rocksdb::DB::Open(rocksdb::DBOptions(opt), path, column_families, &handles, &db);

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -166,6 +166,10 @@ public:
 
   void close() override;
 
+  rocksdb::ColumnFamilyHandle* get_column_family_handle(
+    const string &prefix,
+    bool &is_default_cf);
+
   void split_stats(const std::string &s, char delim, std::vector<std::string> &elems);
   void get_statistics(Formatter *f) override;
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -82,7 +82,7 @@ class RocksDBStore : public KeyValueDB {
   bool set_cache_flag = false;
 
   int create_db_dir();
-
+  int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int do_open(ostream &out, bool create_if_missing,
 	      const vector<ColumnFamily>* cfs = nullptr);
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -162,7 +162,6 @@ public:
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out) override;
   int create_and_open(ostream &out, const vector<ColumnFamily>& cfs);
-  int drop_column_family(const string &cf_name);
 
   void close() override;
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -156,12 +156,13 @@ public:
   int open(ostream &out) override {
     return do_open(out, false);
   }
-  int open(ostream &out, const vector<ColumnFamily>& cfs) {
+  int open(ostream &out, const vector<ColumnFamily>& cfs) override {
     return do_open(out, false, &cfs);
   }
   /// Creates underlying db if missing and opens it
   int create_and_open(ostream &out) override;
-  int create_and_open(ostream &out, const vector<ColumnFamily>& cfs);
+  int create_and_open(ostream &out,
+		      const vector<ColumnFamily>& cfs) override;
 
   void close() override;
 
@@ -477,7 +478,7 @@ err:
 
 protected:
   WholeSpaceIterator _get_iterator() override;
-  ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name);
+  ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name) override;
 };
 
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -372,17 +372,6 @@ public:
     int status();
   };
 
-  class RocksDBCFSnapshotIteratorImpl : public RocksDBCFIteratorImpl{
-    rocksdb::DB *db;
-    const rocksdb::Snapshot *snapshot;
-  public:
-    RocksDBCFSnapshotIteratorImpl(rocksdb::DB *db, const rocksdb::Snapshot *s,
-				rocksdb::Iterator *iter) :
-      RocksDBCFIteratorImpl(iter), db(db), snapshot(s) { }
-
-    ~RocksDBCFSnapshotIteratorImpl();
-  };
-
   /// Utility
   static string combine_strings(const string &prefix, const string &value) {
     string out = prefix;
@@ -489,9 +478,7 @@ err:
 
 protected:
   WholeSpaceIterator _get_iterator() override;
-  WholeSpaceIterator _get_snapshot_iterator();
   ColumnFamilyIterator _get_cf_iterator(const std::string& cf_name);
-  ColumnFamilyIterator _get_cf_snapshot_iterator(const std::string& cf_name);
 };
 
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -67,9 +67,10 @@ const string PREFIX_DEFERRED = "L";  // id -> deferred_transaction_t
 const string PREFIX_ALLOC = "B";   // u64 offset -> u64 length (freelist)
 const string PREFIX_SHARED_BLOB = "X"; // u64 offset -> shared_blob_t
 
-const std::vector<KeyValueDB::ColumnFamily> cfs = {
-  KeyValueDB::ColumnFamily(PREFIX_SUPER, ""),
-  KeyValueDB::ColumnFamily(PREFIX_STAT, ""),
+const std::vector<KeyValueDB::ColumnFamily> cfs =
+{
+  KeyValueDB::ColumnFamily (PREFIX_SUPER, ""),
+  KeyValueDB::ColumnFamily (PREFIX_STAT, ""),
   KeyValueDB::ColumnFamily(PREFIX_COLL, ""),
   KeyValueDB::ColumnFamily(PREFIX_OBJ, ""),
   KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
@@ -77,7 +78,6 @@ const std::vector<KeyValueDB::ColumnFamily> cfs = {
   KeyValueDB::ColumnFamily(PREFIX_ALLOC, ""),
   KeyValueDB::ColumnFamily(PREFIX_SHARED_BLOB, "")
 };
-
 
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
@@ -4682,10 +4682,17 @@ int BlueStore::_open_db(bool create)
     options = cct->_conf->bluestore_rocksdb_options;
   db->init(options);
 
-  if (create)
-    r = db->create_and_open(err, cfs);
-  else
-    r = db->open(err, cfs);
+  if (g_conf->bluestore_rocksdb_enable_column_familly) {
+    if (create)
+      r = db->create_and_open(err, cfs);
+    else
+      r = db->open(err, cfs);
+  } else {
+    if (create)
+      r = db->create_and_open(err);
+    else
+      r = db->open(err);
+  }
   if (r) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;
     if (bluefs) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -70,15 +70,8 @@ const string PREFIX_BITMAP = "b";
 
 const std::vector<KeyValueDB::ColumnFamily> cfs =
 {
-  //KeyValueDB::ColumnFamily(PREFIX_SUPER, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_STAT, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_COLL, ""),
-  KeyValueDB::ColumnFamily(PREFIX_OBJ, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_DEFERRED, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_ALLOC, ""),
-  KeyValueDB::ColumnFamily(PREFIX_BITMAP, ""),
-  //KeyValueDB::ColumnFamily(PREFIX_SHARED_BLOB, "")
+  KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
+  KeyValueDB::ColumnFamily(PREFIX_DEFERRED, ""),
 };
 
 // write a label in the first block.  always use this size.  note that

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -66,17 +66,19 @@ const string PREFIX_OMAP = "M";    // u64 + keyname -> value
 const string PREFIX_DEFERRED = "L";  // id -> deferred_transaction_t
 const string PREFIX_ALLOC = "B";   // u64 offset -> u64 length (freelist)
 const string PREFIX_SHARED_BLOB = "X"; // u64 offset -> shared_blob_t
+const string PREFIX_BITMAP = "b";
 
 const std::vector<KeyValueDB::ColumnFamily> cfs =
 {
-  KeyValueDB::ColumnFamily (PREFIX_SUPER, ""),
-  KeyValueDB::ColumnFamily (PREFIX_STAT, ""),
-  KeyValueDB::ColumnFamily(PREFIX_COLL, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_SUPER, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_STAT, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_COLL, ""),
   KeyValueDB::ColumnFamily(PREFIX_OBJ, ""),
-  KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
-  KeyValueDB::ColumnFamily(PREFIX_DEFERRED, ""),
-  KeyValueDB::ColumnFamily(PREFIX_ALLOC, ""),
-  KeyValueDB::ColumnFamily(PREFIX_SHARED_BLOB, "")
+  //KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_DEFERRED, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_ALLOC, ""),
+  KeyValueDB::ColumnFamily(PREFIX_BITMAP, ""),
+  //KeyValueDB::ColumnFamily(PREFIX_SHARED_BLOB, "")
 };
 
 // write a label in the first block.  always use this size.  note that

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -67,6 +67,18 @@ const string PREFIX_DEFERRED = "L";  // id -> deferred_transaction_t
 const string PREFIX_ALLOC = "B";   // u64 offset -> u64 length (freelist)
 const string PREFIX_SHARED_BLOB = "X"; // u64 offset -> shared_blob_t
 
+const std::vector<KeyValueDB::ColumnFamily> cfs = {
+  KeyValueDB::ColumnFamily(PREFIX_SUPER, ""),
+  KeyValueDB::ColumnFamily(PREFIX_STAT, ""),
+  KeyValueDB::ColumnFamily(PREFIX_COLL, ""),
+  KeyValueDB::ColumnFamily(PREFIX_OBJ, ""),
+  KeyValueDB::ColumnFamily(PREFIX_OMAP, ""),
+  KeyValueDB::ColumnFamily(PREFIX_DEFERRED, ""),
+  KeyValueDB::ColumnFamily(PREFIX_ALLOC, ""),
+  KeyValueDB::ColumnFamily(PREFIX_SHARED_BLOB, "")
+};
+
+
 // write a label in the first block.  always use this size.  note that
 // bluefs makes a matching assumption about the location of its
 // superblock (always the second block of the device).
@@ -4669,10 +4681,11 @@ int BlueStore::_open_db(bool create)
   if (kv_backend == "rocksdb")
     options = cct->_conf->bluestore_rocksdb_options;
   db->init(options);
+
   if (create)
-    r = db->create_and_open(err);
+    r = db->create_and_open(err, cfs);
   else
-    r = db->open(err);
+    r = db->open(err, cfs);
   if (r) {
     derr << __func__ << " erroring opening db: " << err.str() << dendl;
     if (bluefs) {

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2161,6 +2161,30 @@ public:
   }
 
   void get_db_statistics(Formatter *f) override;
+
+  struct DBHistogramStats {
+    uint64_t num_onodes = 0;
+    uint64_t num_shards = 0;
+    uint64_t num_super = 0;
+    uint64_t num_coll = 0;
+    uint64_t num_omap = 0;
+    uint64_t num_deferred = 0;
+    uint64_t num_alloc = 0;
+    uint64_t num_stat = 0;
+    uint64_t num_others = 0;
+    uint64_t num_shared_shards = 0;
+    size_t max_key_size =0;
+    size_t max_value_size = 0;
+    uint64_t total_key_size = 0;
+    uint64_t total_value_size = 0;
+    DBHistogram hist;
+  };
+
+  void _db_stats_entry(
+    const string &key,
+    const bufferlist &value,
+    const pair<string,string> &raw_key,
+    DBHistogramStats &db_stats);
   void generate_db_histogram(Formatter *f) override;
   void _flush_cache();
   void flush_cache() override;

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -25,7 +25,16 @@ public:
   int open(ostream &out) override {
     return 0;
   }
+
+  int open(ostream &out, const std::vector<ColumnFamily> &cfs) override {
+    return 0;
+  } 
+
   int create_and_open(ostream &out) override {
+    return 0;
+  }
+
+  int create_and_open(ostream &out, const std::vector<ColumnFamily> &cfs) override {
     return 0;
   }
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -417,6 +417,56 @@ TEST_P(KVTest, RocksDBIteratorTest) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBCFMerge) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  shared_ptr<KeyValueDB::MergeOperator> p(new AppendMOP);
+  int r = db->set_merge_operator("cf1",p);
+  if (r < 0)
+    return; // No merge operators for this database type
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist v1, v2, v3;
+    v1.append(string("1"));
+    v2.append(string("2"));
+    v3.append(string("3"));
+    t->set("P", "K1", v1);
+    t->set("cf1", "A1", v2);
+    t->rmkey("cf1", "A2");
+    t->merge("cf1", "A2", v3);
+    db->submit_transaction_sync(t);
+  }
+  {
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(0, db->get("P", "K1", &v1));
+    ASSERT_EQ(tostr(v1), "1");
+    ASSERT_EQ(0, db->get("cf1", "A1", &v2));
+    ASSERT_EQ(tostr(v2), "2");
+    ASSERT_EQ(0, db->get("cf1", "A2", &v3));
+    ASSERT_EQ(tostr(v3), "?3");
+  }
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist v1;
+    v1.append(string("1"));
+    t->merge("cf1", "A2", v1);
+    db->submit_transaction_sync(t);
+  }
+  {
+    bufferlist v;
+    ASSERT_EQ(0, db->get("cf1", "A2", &v));
+    ASSERT_EQ(tostr(v), "?31");
+  }
+  fini();
+}
+
 INSTANTIATE_TEST_CASE_P(
   KeyValueDB,
   KVTest,

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -35,6 +35,11 @@ public:
 
   KVTest() : db(0) {}
 
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
   void rm_r(string path) {
     string cmd = string("rm -r ") + path;
     cout << "==> " << cmd << std::endl;
@@ -199,7 +204,6 @@ struct AppendMOP : public KeyValueDB::MergeOperator {
     const char *ldata, size_t llen,
     const char *rdata, size_t rlen,
     std::string *new_value) override {
-
     *new_value = std::string(ldata, llen) + std::string(rdata, rlen);
   }
   // We use each operator name and each prefix to construct the
@@ -308,6 +312,110 @@ TEST_P(KVTest, RMRange) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBColumnFamilyTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  cfs.push_back(KeyValueDB::ColumnFamily("cf2", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating two column families and opening them" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist value;
+    value.append("value");
+    cout << "write a transaction includes three keys in different CFs" << std::endl;
+    t->set("prefix", "key", value);
+    t->set("cf1", "key", value);
+    t->set("cf2", "key2", value);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    bufferlist v1, v2, v3;
+    cout << "reopen db and read those keys" << std::endl;
+    ASSERT_EQ(0, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, _bl_to_str(v1) != "value");
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(0, db->get("cf2", "key2", &v3));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+  }
+  {
+    cout << "delete two keys in CFs" << std::endl;
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rmkey("prefix", "key");
+    t->rmkey("cf2", "key2");
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    cout << "reopen db and read keys again." << std::endl;
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(-ENOENT, db->get("cf2", "key2", &v3));
+  }
+  fini();
+}
+
+TEST_P(KVTest, RocksDBIteratorTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist bl1;
+    bl1.append("hello");
+    bufferlist bl2;
+    bl2.append("world");
+    cout << "write some kv pairs into default and new CFs" << std::endl;
+    t->set("prefix", "key1", bl1);
+    t->set("prefix", "key2", bl2);
+    t->set("cf1", "key1", bl1);
+    t->set("cf1", "key2", bl2);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  {
+    cout << "iterating the default CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("prefix");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the new CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  fini();
+}
 
 INSTANTIATE_TEST_CASE_P(
   KeyValueDB,


### PR DESCRIPTION
Column family is a very useful feature which RocksDB provides, basically user can create a dedicated column family for one kind of prefixed keys, and RocksDB will create dedicated LSM tree for it, still a transaction includes multiple kv updates into different CFs can be atomic.

This PR adds CF support into KeyValueDB interface and RocksDBStore implementation. The basic model is, the default column family can still have multiple prefixes, while each explicitly created column family can only have on prefix which is the name of the CF. All old APIs are kept backward compatible, user will have to call new API to create column families for some prefixes, then use old get/set APIs to access prefixed keys. RocksDBStore internally will remember all opened column families, if prefix matches name of created column family, it will go to that column family.

We also integrate column families in bluestore. 

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Xiaoyan Li <xiaoyan.li@intel.com>
Signed-off-by: Jianjian Huo <jj.huo@alibaba-inc.com>