### PR TITLE
cephfs: Open system dirfrag if needed at startup

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -2512,7 +2512,7 @@ ESubtreeMap *MDCache::create_subtree_map()
   map<dirfrag_t, CDir*> dirs_to_add;
 
   if (myin) {
-    CDir* mydir = myin->get_dirfrag(frag_t());
+    CDir* mydir = myin->get_or_open_dirfrag(this, frag_t());
     dirs_to_add[mydir->dirfrag()] = mydir;
   }
 


### PR DESCRIPTION
An MDS may not have the system dirfrag in cache at startup if it
already existed from a previous incarnation. Open it if necessary.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>