### PR TITLE
test: reg11184 might not always find pg 2.0 prior to import

### DIFF
--- a/qa/tasks/reg11184.py
+++ b/qa/tasks/reg11184.py
@@ -193,12 +193,11 @@ def task(ctx, config):
     manager.mark_down_osd(non_divergent[0])
     # manager.mark_out_osd(non_divergent[0])
 
-    # An empty collection for pg 2.0 needs to be cleaned up
+    # An empty collection for pg 2.0 might need to be cleaned up
     cmd = ((prefix + "--op remove --pgid 2.0").
            format(id=non_divergent[0]))
     proc = exp_remote.run(args=cmd, wait=True,
                           check_status=False, stdout=StringIO())
-    assert proc.exitstatus == 0
 
     cmd = ((prefix + "--op import --file {file}").
            format(id=non_divergent[0], file=expfile))


### PR DESCRIPTION

As seen in:
teuthology:/a/sage-2017-07-26_14:40:34-rados-wip-sage-testing-distro-basic-smithi/1447421