### PR TITLE
osd: Check whether journal is rotational or not

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -988,6 +988,15 @@ perform well in a degraded state.
 :Type: Float
 :Default: ``0``
 
+
+``osd recovery sleep hybrid``
+
+:Description: Time in seconds to sleep before next recovery or backfill op
+              when osd data is on HDD and osd journal is on SSD.
+
+:Type: Float
+:Default: ``0.025``
+
 Tiering
 =======
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1985,15 +1985,19 @@ std::vector<Option> get_global_options() {
 
     Option("osd_recovery_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description(""),
+    .set_description("Time in seconds to sleep before next recovery or backfill op"),
 
     Option("osd_recovery_sleep_hdd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0.1)
-    .set_description(""),
+    .set_description("Time in seconds to sleep before next recovery or backfill op for HDDs"),
 
     Option("osd_recovery_sleep_ssd", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
-    .set_description(""),
+    .set_description("Time in seconds to sleep before next recovery or backfill op for SSDs"),
+
+    Option("osd_recovery_sleep_hybrid", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(0.025)
+    .set_description("Time in seconds to sleep before next recovery or backfill op when data is on HDD and journal is on SSD"),
 
     Option("osd_snap_trim_sleep", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1575,6 +1575,19 @@ public:
     return true;
   }
 
+  /**
+   * is_journal_rotational
+   *
+   * Check whether journal is backed by a rotational (HDD) or non-rotational
+   * (SSD) device.
+   *
+   *
+   * @return true for HDD, false for SSD
+   */
+  virtual bool is_journal_rotational() {
+    return true;
+  }
+
   virtual string get_default_device_class() {
     return is_rotational() ? "hdd" : "ssd";
   }

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -2292,3 +2292,10 @@ int BlueFS::unlink(const string& dirname, const string& filename)
   _drop_link(file);
   return 0;
 }
+
+bool BlueFS::wal_is_rotational()
+{
+  if (!bdev[BDEV_WAL] || bdev[BDEV_WAL]->is_rotational())
+    return true;
+  return false;
+}

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -370,6 +370,7 @@ public:
   int unlink(const string& dirname, const string& filename);
   int mkdir(const string& dirname);
   int rmdir(const string& dirname);
+  bool wal_is_rotational();
 
   bool dir_exists(const string& dirname);
   int stat(const string& dirname, const string& filename,

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4396,6 +4396,13 @@ bool BlueStore::is_rotational()
   return rotational;
 }
 
+bool BlueStore::is_journal_rotational()
+{
+  assert(bluefs);
+  dout(10) << __func__ << " " << (int)bluefs->wal_is_rotational() << dendl;
+  return bluefs->wal_is_rotational();
+}
+
 bool BlueStore::test_mount_in_use()
 {
   // most error conditions mean the mount is not in use (e.g., because

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2109,6 +2109,7 @@ public:
   bool allows_journal() override { return false; };
 
   bool is_rotational() override;
+  bool is_journal_rotational() override;
 
   string get_default_device_class() override {
     string device_class;

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -484,6 +484,7 @@ public:
   }
 
   bool is_rotational() override;
+  bool is_journal_rotational() override;
 
   void dump_perf_counters(Formatter *f) override {
     f->open_object_section("perf_counters");
@@ -837,6 +838,9 @@ protected:
   const string& get_basedir_path() {
     return filestore->basedir;
   }
+  const string& get_journal_path() {
+    return filestore->journalpath;
+  }
   const string& get_current_path() {
     return filestore->current_fn;
   }
@@ -874,6 +878,7 @@ public:
   virtual bool has_fiemap() = 0;
   virtual bool has_seek_data_hole() = 0;
   virtual bool is_rotational() = 0;
+  virtual bool is_journal_rotational() = 0;
   virtual int do_fiemap(int fd, off_t start, size_t len, struct fiemap **pfiemap) = 0;
   virtual int clone_range(int from, int to, uint64_t srcoff, uint64_t len, uint64_t dstoff) = 0;
   virtual int set_alloc_hint(int fd, uint64_t hint) = 0;

--- a/src/os/filestore/GenericFileStoreBackend.h
+++ b/src/os/filestore/GenericFileStoreBackend.h
@@ -29,6 +29,7 @@ private:
   bool m_filestore_fsync_flushes_journal_data;
   bool m_filestore_splice;
   bool m_rotational = true;
+  bool m_journal_rotational = true;
 public:
   explicit GenericFileStoreBackend(FileStore *fs);
   ~GenericFileStoreBackend() override {}
@@ -41,6 +42,9 @@ public:
   bool can_checkpoint() override { return false; }
   bool is_rotational() override {
     return m_rotational;
+  }
+  bool is_journal_rotational() override {
+    return m_journal_rotational;
   }
   int list_checkpoints(list<string>& ls) override { return 0; }
   int create_checkpoint(const string& name, uint64_t *cid) override { return -EOPNOTSUPP; }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2357,8 +2357,10 @@ float OSD::get_osd_recovery_sleep()
 {
   if (cct->_conf->osd_recovery_sleep)
     return cct->_conf->osd_recovery_sleep;
-  if (store_is_rotational)
+  if (store_is_rotational && journal_is_rotational)
     return cct->_conf->osd_recovery_sleep_hdd;
+  else if (store_is_rotational && !journal_is_rotational)
+    return cct->_conf->get_val<double>("osd_recovery_sleep_hybrid");
   else
     return cct->_conf->osd_recovery_sleep_ssd;
 }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2357,12 +2357,12 @@ float OSD::get_osd_recovery_sleep()
 {
   if (cct->_conf->osd_recovery_sleep)
     return cct->_conf->osd_recovery_sleep;
-  if (store_is_rotational && journal_is_rotational)
-    return cct->_conf->osd_recovery_sleep_hdd;
+  if (!store_is_rotational && !journal_is_rotational)
+    return cct->_conf->osd_recovery_sleep_ssd;
   else if (store_is_rotational && !journal_is_rotational)
     return cct->_conf->get_val<double>("osd_recovery_sleep_hybrid");
   else
-    return cct->_conf->osd_recovery_sleep_ssd;
+    return cct->_conf->osd_recovery_sleep_hdd;
 }
 
 int OSD::init()

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2379,6 +2379,7 @@ int OSD::init()
   dout(2) << "init " << dev_path
 	  << " (looks like " << (store_is_rotational ? "hdd" : "ssd") << ")"
 	  << dendl;
+  dout(2) << "journal " << journal_path << dendl;
   assert(store);  // call pre_init() first!
 
   store->set_cache_shards(get_num_op_shards());
@@ -2388,6 +2389,9 @@ int OSD::init()
     derr << "OSD:init: unable to mount object store" << dendl;
     return r;
   }
+  journal_is_rotational = store->is_journal_rotational();
+  dout(2) << "journal looks like " << (journal_is_rotational ? "hdd" : "ssd")
+          << dendl;
 
   enable_disable_fuse(false);
 
@@ -5889,6 +5893,7 @@ void OSD::_collect_metadata(map<string,string> *pm)
   // backend
   (*pm)["osd_objectstore"] = store->get_type();
   (*pm)["rotational"] = store_is_rotational ? "1" : "0";
+  (*pm)["journal_rotational"] = journal_is_rotational ? "1" : "0";
   (*pm)["default_device_class"] = store->get_default_device_class();
   store->collect_metadata(pm);
 

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1222,6 +1222,7 @@ protected:
   std::string dev_path, journal_path;
 
   bool store_is_rotational = true;
+  bool journal_is_rotational = true;
 
   ZTracer::Endpoint trace_endpoint;
   void create_logger();


### PR DESCRIPTION
This feature is required before we can introduce the `osd_recovery_sleep_hybrid` configuration option. 
It creates `is_journal_rotational()` method for FileStore and BlueStore, which checks whether the journal is on a rotational device or not.

Signed-off-by: Neha Ojha <nojha@redhat.com>