### PR TITLE
kv/RocksDBStore: use vector instead of VLA for holding slices

### DIFF
--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -34,15 +34,16 @@ using std::string;
 #undef dout_prefix
 #define dout_prefix *_dout << "rocksdb: "
 
-static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl, rocksdb::Slice *slices)
+static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
+					      vector<rocksdb::Slice> *slices)
 {
   unsigned n = 0;
-  for (std::list<buffer::ptr>::const_iterator p = bl.buffers().begin();
-       p != bl.buffers().end(); ++p, ++n) {
-    slices[n].data_ = p->c_str();
-    slices[n].size_ = p->length();
+  for (auto& buf : bl.buffers()) {
+    (*slices)[n].data_ = buf.c_str();
+    (*slices)[n].size_ = buf.length();
+    n++;
   }
-  return rocksdb::SliceParts(slices, n);
+  return rocksdb::SliceParts(slices->data(), slices->size());
 }
 
 //
@@ -608,9 +609,9 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 			    to_set_bl.length()));
   } else {
     rocksdb::Slice key_slice(key);
-    rocksdb::Slice value_slices[to_set_bl.buffers().size()];
+    vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
     bat.Put(nullptr, rocksdb::SliceParts(&key_slice, 1),
-            prepare_sliceparts(to_set_bl, value_slices));
+            prepare_sliceparts(to_set_bl, &value_slices));
   }
 }
 
@@ -629,9 +630,9 @@ void RocksDBStore::RocksDBTransactionImpl::set(
 			    to_set_bl.length()));
   } else {
     rocksdb::Slice key_slice(key);
-    rocksdb::Slice value_slices[to_set_bl.buffers().size()];
+    vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
     bat.Put(nullptr, rocksdb::SliceParts(&key_slice, 1),
-            prepare_sliceparts(to_set_bl, value_slices));
+            prepare_sliceparts(to_set_bl, &value_slices));
   }
 }
 
@@ -707,9 +708,9 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   } else {
     // make a copy
     rocksdb::Slice key_slice(key);
-    rocksdb::Slice value_slices[to_set_bl.buffers().size()];
+    vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
     bat.Merge(nullptr, rocksdb::SliceParts(&key_slice, 1),
-              prepare_sliceparts(to_set_bl, value_slices));
+              prepare_sliceparts(to_set_bl, &value_slices));
   }
 }
 


### PR DESCRIPTION
clang complains:

ceph/src/kv/RocksDBStore.cc:611:32: error: variable length array of
non-POD element type
      'rocksdb::Slice'
    rocksdb::Slice value_slices[to_set_bl.buffers().size()];

and i believe GCC will also complains with: -Wvla or -pedantic. as
to_set_bl.buffers().size() is not a const expr at compile time.

Signed-off-by: Kefu Chai <kchai@redhat.com>