### PR TITLE
osd: moved OpFinisher logic from OSDOp to OpContext

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4491,9 +4491,13 @@ struct C_ChecksumRead : public Context {
 					     &read_bl, maybe_crc, size,
 					     osd, soid, flags)) {
   }
+  ~C_ChecksumRead() override {
+    delete fill_extent_ctx;
+  }
 
   void finish(int r) override {
     fill_extent_ctx->complete(r);
+    fill_extent_ctx = nullptr;
 
     if (osd_op.rval >= 0) {
       bufferlist::iterator init_value_bl_it = init_value_bl.begin();
@@ -4685,9 +4689,13 @@ struct C_ExtentCmpRead : public Context {
 					     &read_bl, maybe_crc, size,
 					     osd, soid, flags)) {
   }
+  ~C_ExtentCmpRead() override {
+    delete fill_extent_ctx;
+  }
 
   void finish(int r) override {
     fill_extent_ctx->complete(r);
+    fill_extent_ctx = nullptr;
 
     if (osd_op.rval >= 0) {
       osd_op.rval = primary_log_pg->finish_extent_cmp(osd_op, read_bl);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -472,6 +472,13 @@ public:
     ObjectContextRef obc,
     const list<watch_disconnect_t> &to_disconnect);
 
+  struct OpFinisher {
+    virtual ~OpFinisher() {
+    }
+
+    virtual int execute() = 0;
+  };
+
   /*
    * Capture all object state associated with an in-progress read or write.
    */
@@ -580,6 +587,8 @@ public:
 
     ObjectContext::RWState::State lock_type;
     ObcLockManager lock_manager;
+
+    std::map<int, std::unique_ptr<OpFinisher>> op_finishers;
 
     OpContext(const OpContext& other);
     const OpContext& operator=(const OpContext& other);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4920,16 +4920,12 @@ struct ScrubMap {
 WRITE_CLASS_ENCODER(ScrubMap::object)
 WRITE_CLASS_ENCODER(ScrubMap)
 
-struct OpFinisher;
-
 struct OSDOp {
   ceph_osd_op op;
   sobject_t soid;
 
   bufferlist indata, outdata;
   errorcode32_t rval;
-
-  OpFinisher *op_finisher = nullptr;
 
   OSDOp() : rval(0) {
     memset(&op, 0, sizeof(ceph_osd_op));


### PR DESCRIPTION
This allows the memory lifetime of the OpFinisher to be tightly
controlled since the OpContext cannot be copied.

Fixes: http://tracker.ceph.com/issues/20783
Signed-off-by: Jason Dillaman <dillaman@redhat.com>