### PR TITLE
mon,mgr: ceph logs shouldn't display dmcrypt keys

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -454,6 +454,7 @@ set(libcommon_files
   common/SloppyCRCMap.cc
   common/types.cc
   common/iso_8601.cc
+  common/security.cc
   log/Log.cc
   log/SubsystemMap.cc
   mon/MonCap.cc
@@ -682,6 +683,7 @@ add_subdirectory(libradosstriper)
 if (WITH_MGR)
   set(mgr_srcs
       ceph_mgr.cc
+      common/security.cc
       mon/PGMap.cc
       mgr/DaemonState.cc
       mgr/DaemonServer.cc

--- a/src/common/security.cc
+++ b/src/common/security.cc
@@ -1,0 +1,39 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <boost/regex.hpp>
+
+#include "common/security.h"
+
+const std::string ceph::security::mask(const std::string &candidate) {
+  boost::regex reg(
+      "(\"key\": \"dm-crypt\\/osd\\/.*\\/luks\", \"val\": \")(.*)(\")");
+  if (boost::regex_search(candidate, reg))
+    return boost::regex_replace(candidate, reg, "$1REDACTED$3");
+  else
+    return candidate;
+}
+
+const std::vector<std::string> ceph::security::mask(const std::vector<std::string> &candidate) {
+  std::vector<std::string> ret;
+  ret.reserve(candidate.size());
+  std::for_each(
+      candidate.begin(), candidate.end(),
+      [&](std::string mask_target) { ret.push_back(ceph::security::mask(mask_target)); });
+  return ret;
+}

--- a/src/common/security.h
+++ b/src/common/security.h
@@ -1,0 +1,27 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_SECURITY_H
+#define CEPH_SECURITY_H
+
+namespace ceph { namespace security {
+
+// Mask security sensitive output which would otherwise end up in the logs
+
+const std::string mask(const std::string &candidate);
+const std::vector<std::string> mask(const std::vector<std::string> &candidate);
+
+}} // namespace ceph::security
+
+#endif // CEPH_SECURITY_H

--- a/src/messages/MMonCommand.h
+++ b/src/messages/MMonCommand.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_MMONCOMMAND_H
 #define CEPH_MMONCOMMAND_H
 
+#include "common/security.h"
 #include "messages/PaxosServiceMessage.h"
 
 #include <vector>
@@ -40,11 +41,11 @@ public:
     o << "mon_command(";
     for (unsigned i=0; i<cmd.size(); i++) {
       if (i) o << ' ';
-      o << cmd[i];
+      o << ceph::security::mask(cmd[i]);
     }
     o << " v " << version << ")";
   }
-  
+
   void encode_payload(uint64_t features) override {
     paxos_encode();
     ::encode(fsid, payload);

--- a/src/messages/MMonCommandAck.h
+++ b/src/messages/MMonCommandAck.h
@@ -15,6 +15,7 @@
 #ifndef CEPH_MMONCOMMANDACK_H
 #define CEPH_MMONCOMMANDACK_H
 
+#include "common/security.h"
 #include "messages/PaxosServiceMessage.h"
 
 class MMonCommandAck : public PaxosServiceMessage {
@@ -33,7 +34,8 @@ private:
 public:
   const char *get_type_name() const override { return "mon_command"; }
   void print(ostream& o) const override {
-    o << "mon_command_ack(" << cmd << "=" << r << " " << rs << " v" << version << ")";
+    o << "mon_command_ack(" << ceph::security::mask(cmd) << "=" << r << " "
+      << rs << " v" << version << ")";
   }
   
   void encode_payload(uint64_t features) override {

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -28,6 +28,7 @@
 #include "messages/MPGStats.h"
 #include "messages/MOSDScrub.h"
 #include "common/errno.h"
+#include "common/security.h"
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mgr
@@ -645,7 +646,8 @@ bool DaemonServer::handle_command(MCommand *m)
       dout(1) << " access denied" << dendl;
       audit_clog->info() << "from='" << session->inst << "' "
                          << "entity='" << session->entity_name << "' "
-                         << "cmd=" << m->cmd << ":  access denied";
+                         << "cmd=" << ceph::security::mask(m->cmd)
+                         << ":  access denied";
       ss << "access denied' does your client key have mgr caps?"
 	" See http://docs.ceph.com/docs/master/mgr/administrator/#client-authentication";
       cmdctx->reply(-EACCES, ss);
@@ -656,7 +658,7 @@ bool DaemonServer::handle_command(MCommand *m)
   audit_clog->debug()
     << "from='" << session->inst << "' "
     << "entity='" << session->entity_name << "' "
-    << "cmd=" << m->cmd << ": dispatch";
+    << "cmd=" << ceph::security::mask(m->cmd) << ": dispatch";
 
   // ----------------
   // service map commands

--- a/src/mon/CMakeLists.txt
+++ b/src/mon/CMakeLists.txt
@@ -21,7 +21,8 @@ set(lib_mon_srcs
   PGMonitor.cc
   PGMap.cc
   ConfigKeyService.cc
-  ../mgr/mgr_commands.cc)
+  ../mgr/mgr_commands.cc
+  ../common/security.cc)
 add_library(mon STATIC
   ${lib_mon_srcs}
   $<TARGET_OBJECTS:kv_objs>

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -61,6 +61,7 @@
 #include "common/errno.h"
 #include "common/perf_counters.h"
 #include "common/admin_socket.h"
+#include "common/security.h"
 #include "global/signal_handler.h"
 #include "common/Formatter.h"
 #include "include/stringify.h"
@@ -271,7 +272,8 @@ void Monitor::do_admin_command(string command, cmdmap_t& cmdmap, string format,
 
   (read_only ? audit_clog->debug() : audit_clog->info())
     << "from='admin socket' entity='admin socket' "
-    << "cmd='" << command << "' args=" << args << ": dispatch";
+    << "cmd='" << ceph::security::mask(command) << "' args=" << args
+    << ": dispatch";
 
   if (command == "mon_status") {
     get_mon_status(f.get(), ss);
@@ -322,7 +324,7 @@ void Monitor::do_admin_command(string command, cmdmap_t& cmdmap, string format,
   (read_only ? audit_clog->debug() : audit_clog->info())
     << "from='admin socket' "
     << "entity='admin socket' "
-    << "cmd=" << command << " "
+    << "cmd=" << ceph::security::mask(command) << " "
     << "args=" << args << ": finished";
   return;
 
@@ -330,7 +332,7 @@ abort:
   (read_only ? audit_clog->debug() : audit_clog->info())
     << "from='admin socket' "
     << "entity='admin socket' "
-    << "cmd=" << command << " "
+    << "cmd=" << ceph::security::mask(command) << " "
     << "args=" << args << ": aborted";
 }
 
@@ -3094,7 +3096,7 @@ void Monitor::handle_command(MonOpRequestRef op)
     (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
       << "from='" << session->inst << "' "
       << "entity='" << session->entity_name << "' "
-      << "cmd=" << m->cmd << ":  access denied";
+      << "cmd=" << ceph::security::mask(m->cmd) << ":  access denied";
     reply_command(op, -EACCES, "access denied", 0);
     return;
   }
@@ -3102,7 +3104,7 @@ void Monitor::handle_command(MonOpRequestRef op)
   (cmd_is_rw ? audit_clog->info() : audit_clog->debug())
     << "from='" << session->inst << "' "
     << "entity='" << session->entity_name << "' "
-    << "cmd=" << m->cmd << ": dispatch";
+    << "cmd=" << ceph::security::mask(m->cmd) << ": dispatch";
 
   if (mon_cmd->is_mgr() &&
       osdmon()->osdmap.require_osd_release >= CEPH_RELEASE_LUMINOUS) {

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -50,6 +50,7 @@
 #include "mgr/MgrClient.h"
 
 #include "mon/MonOpRequest.h"
+#include "common/security.h"
 #include "common/WorkQueue.h"
 
 
@@ -843,7 +844,7 @@ public:
             ss << "session dropped for command ";
           }
         }
-        ss << "cmd='" << m->cmd << "': finished";
+        ss << "cmd='" << ceph::security::mask(m->cmd) << "': finished";
 
         mon->audit_clog->info() << ss.str();
 	mon->reply_command(op, rc, rs, rdata, version);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20790

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>