### PR TITLE
common: use std::move() for better performance

### DIFF
--- a/src/common/OutputDataSocket.cc
+++ b/src/common/OutputDataSocket.cc
@@ -298,8 +298,7 @@ void OutputDataSocket::handle_connection(int fd)
 int OutputDataSocket::dump_data(int fd)
 {
   m_lock.Lock(); 
-  list<bufferlist> l;
-  l = data;
+  list<bufferlist> l = std::move(data);
   data.clear();
   data_size = 0;
   m_lock.Unlock();


### PR DESCRIPTION
use std::move() to avoid extra copy constructions in src/common/OutputDataSocket.cc.

See the discussions in
https://github.com/ceph/ceph/pull/16525
https://github.com/ceph/ceph/pull/16555

Signed-off-by: Xinying Song <songxinying@cloudin.cn>