### PR TITLE
osd: start pool IDs from 1

### DIFF
--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -570,7 +570,7 @@ private:
 
  public:
   OSDMap() : epoch(0), 
-	     pool_max(0),
+	     pool_max(1),
 	     flags(0),
 	     num_osd(0), num_up_osd(0), num_in_osd(0),
 	     max_osd(0),


### PR DESCRIPTION
CephFS doesn't like id=0 pools, which didn't used to
matter because id 0 was always consumed by RBD.  Now,
there is no default rbd pool, so cephfs users
encounter this problem.

Fixes: http://tracker.ceph.com/issues/20792
Signed-off-by: John Spray <john.spray@redhat.com>