### PR TITLE
rgw: policy: support for s3 conditionals in ListBucket Op

### DIFF
--- a/doc/radosgw/bucketpolicy.rst
+++ b/doc/radosgw/bucketpolicy.rst
@@ -120,6 +120,11 @@ Currently, the only condition keys we support are:
 - aws:UserAgent
 - aws:username
 
+We support the following condition keys for ListBucket Op
+- s3:prefix
+- s3:delimiter
+- s3:max-keys
+
 More may be supported soon as we integrate with the recently rewritten
 Authentication/Authorization subsystem.
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2168,6 +2168,19 @@ int RGWListBucket::verify_permission()
   if (op_ret < 0) {
     return op_ret;
   }
+  if (!prefix.empty())
+    s->env.emplace(std::piecewise_construct,
+		   std::forward_as_tuple("s3:prefix"),
+		   std::forward_as_tuple(prefix));
+
+  if (!delimiter.empty())
+    s->env.emplace(std::piecewise_construct,
+		   std::forward_as_tuple("s3:delimiter"),
+		   std::forward_as_tuple(delimiter));
+
+  s->env.emplace(std::piecewise_construct,
+		 std::forward_as_tuple("s3:max-keys"),
+		 std::forward_as_tuple(to_string(max)));
 
   if (!verify_bucket_permission(s,
 				list_versions ?


### PR DESCRIPTION
This adds support for s3:prefix,delimeter & maxkeys identifiers when
specified as conditionals in policy. 

See https://github.com/ceph/s3-tests/pull/178/ for an accompanying test case 

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>