### PR TITLE
use STL find() and iterators instead of count()

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -443,7 +443,7 @@ int AdminSocket::register_command(std::string command, std::string cmddesc, Admi
 {
   int ret;
   m_lock.Lock();
-  if (m_hooks.count(command)) {
+  if (m_hooks.find(command) != m_hooks.end()) {
     ldout(m_cct, 5) << "register_command " << command << " hook " << hook << " EEXIST" << dendl;
     ret = -EEXIST;
   } else {


### PR DESCRIPTION
This PR is 1st part of replacement of if(container.count(foo)) with container.find(foo). Since the .count(foo) code searches for key till end and returns TRUE/FALSE, it's good to quit the search if we find the key at 1st instance.
After this PR gets rolled out, similar PRs would be created for other modules as well.

Resolves: http://tracker.ceph.com/issues/432

Signed-off-by: Amit Kumar amitkuma@redhat.com