### PR TITLE
cephfs: Fix races when several MDS boot at once

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -9715,7 +9715,7 @@ void MDCache::handle_discover(MDiscover *dis)
 
   if (mds->get_state() <= MDSMap::STATE_REJOIN) {
     if (mds->get_state() < MDSMap::STATE_REJOIN &&
-	mds->get_want_state() != CEPH_MDS_STATE_REJOIN) {
+	mds->get_want_state() < CEPH_MDS_STATE_REJOIN) {
       dis->put();
       return;
     }

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1666,7 +1666,7 @@ void MDSRankDispatcher::handle_mds_map(
 
   // REJOIN
   // is everybody finally rejoining?
-  if (is_rejoin() || is_clientreplay() || is_active() || is_stopping()) {
+  if (is_starting() || is_rejoin() || is_clientreplay() || is_active() || is_stopping()) {
     // did we start?
     if (!oldmap->is_rejoining() && mdsmap->is_rejoining())
       rejoin_joint_start();
@@ -1676,7 +1676,8 @@ void MDSRankDispatcher::handle_mds_map(
 	oldmap->is_rejoining() && !mdsmap->is_rejoining())
       mdcache->dump_cache();      // for DEBUG only
 
-    if (oldstate >= MDSMap::STATE_REJOIN) {
+    if (oldstate >= MDSMap::STATE_REJOIN ||
+	oldstate == MDSMap::STATE_STARTING) {
       // ACTIVE|CLIENTREPLAY|REJOIN => we can discover from them.
       set<mds_rank_t> olddis, dis;
       oldmap->get_mds_set(olddis, MDSMap::STATE_ACTIVE);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1144,8 +1144,14 @@ void MDSRank::starting_done()
 
   mdcache->open_root();
 
-  // start new segment
-  mdlog->start_new_segment();
+  if (mdcache->is_open()) {
+    mdlog->start_new_segment();
+  } else {
+    mdcache->wait_for_open(new MDSInternalContextWrapper(this,
+			   new FunctionContext([this] (int r) {
+			       mdlog->start_new_segment();
+			   })));
+  }
 }
 
 


### PR DESCRIPTION
MDLog raced with the MDCache opening the root inode, causing a
segmentation fault when opening the root inode too took long.

Additionally, a starting MDS will drop discover messages on the floor.
Wait for an MDSMap that is after STATE_STARTING to determine what to do.

Fixes: http://tracker.ceph.com/issues/20799

Signed-off-by: Douglas Fuller <dfuller@redhat.com>