### PR TITLE
osd/PG: ignore CancelRecovery in NotRecovering

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1930,9 +1930,13 @@ public:
 
     struct NotRecovering : boost::statechart::state< NotRecovering, Active>, NamedState {
       typedef boost::mpl::list<
-	boost::statechart::transition< DoRecovery, WaitLocalRecoveryReserved >
+	boost::statechart::transition< DoRecovery, WaitLocalRecoveryReserved >,
+	boost::statechart::custom_reaction< CancelRecovery >
 	> reactions;
       explicit NotRecovering(my_context ctx);
+      boost::statechart::result react(const CancelRecovery& evt) {
+	/* no-op */
+      }
       void exit();
     };
 


### PR DESCRIPTION
It's possible to get >1 CancelRecovery events in the queue.
The first will transition us from Recovering to NotRecovering.
Currently the second will make us crash.

This is harmless; instead just swallow the event.

Fixes: http://tracker.ceph.com/issues/20804
Signed-off-by: Sage Weil <sage@redhat.com>