### PR TITLE
kv/leveldb: fix deadlock when close db

### DIFF
--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -357,6 +357,8 @@ void LevelDBStore::compact_thread_entry()
       compact_queue_lock.Lock();
       continue;
     }
+    if (compact_queue_stop)
+      break;
     compact_queue_cond.Wait(compact_queue_lock);
   }
   compact_queue_lock.Unlock();


### PR DESCRIPTION
because db may closed when compact_thread compacting,
so the compact_queue_cond may singaled before wait,
if we dont check the compact_queue_stop,
we deadlock after compact_queue_cond.wait()!

Signed-off-by: Zengran <13121369189@126.com>