### PR TITLE
osd: do not send pgstats unless luminous

### DIFF
--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -295,7 +295,9 @@ void MgrClient::send_report()
 void MgrClient::send_pgstats()
 {
   if (pgstats_cb && session) {
-    session->con->send_message(pgstats_cb());
+    if (auto pgstats = pgstats_cb()) {
+      session->con->send_message(pgstats);
+    }
   }
 }
 


### PR DESCRIPTION
MgrClient send_report() upon MMgrConfigure when it is starting. and
send_report() sends a pgstats to mgr. but osd is not supposed to update
mgr with pgstats unless luminous is required. if we send a pgstats, the
stale pgstats will be kept by mgr until "require-osd-release luminous".

this false alarm is annoying and misleading to those who are upgrading
to luminous.

Signed-off-by: Kefu Chai <kchai@redhat.com>