### PR TITLE
osdc, class_api: kill implicit string conversions

### DIFF
--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -142,8 +142,8 @@ int cls_getxattr(cls_method_context_t hctx, const char *name,
   int r;
 
   op.op.op = CEPH_OSD_OP_GETXATTR;
-  op.indata.append(name);
   op.op.xattr.name_len = strlen(name);
+  op.indata.append(name, op.op.xattr.name_len);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
   if (r < 0)
     return r;
@@ -167,10 +167,10 @@ int cls_setxattr(cls_method_context_t hctx, const char *name,
   int r;
 
   op.op.op = CEPH_OSD_OP_SETXATTR;
-  op.indata.append(name);
-  op.indata.append(value);
   op.op.xattr.name_len = strlen(name);
   op.op.xattr.value_len = val_len;
+  op.indata.append(name, op.op.xattr.name_len);
+  op.indata.append(value, val_len);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
 
   return r;
@@ -346,8 +346,8 @@ int cls_cxx_getxattr(cls_method_context_t hctx, const char *name,
   int r;
 
   op.op.op = CEPH_OSD_OP_GETXATTR;
-  op.indata.append(name);
   op.op.xattr.name_len = strlen(name);
+  op.indata.append(name, op.op.xattr.name_len);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
   if (r < 0)
     return r;
@@ -387,10 +387,10 @@ int cls_cxx_setxattr(cls_method_context_t hctx, const char *name,
   int r;
 
   op.op.op = CEPH_OSD_OP_SETXATTR;
-  op.indata.append(name);
-  op.indata.append(*inbl);
   op.op.xattr.name_len = strlen(name);
   op.op.xattr.value_len = inbl->length();
+  op.indata.append(name, op.op.xattr.name_len);
+  op.indata.append(*inbl);
   r = (*pctx)->pg->do_osd_ops(*pctx, nops);
 
   return r;

--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -124,7 +124,7 @@ struct ObjectOperation {
     osd_op.op.xattr.name_len = (name ? strlen(name) : 0);
     osd_op.op.xattr.value_len = data.length();
     if (name)
-      osd_op.indata.append(name);
+      osd_op.indata.append(name, osd_op.op.xattr.name_len);
     osd_op.indata.append(data);
   }
   void add_xattr_cmp(int op, const char *name, uint8_t cmp_op,
@@ -135,7 +135,7 @@ struct ObjectOperation {
     osd_op.op.xattr.cmp_op = cmp_op;
     osd_op.op.xattr.cmp_mode = cmp_mode;
     if (name)
-      osd_op.indata.append(name);
+      osd_op.indata.append(name, osd_op.op.xattr.name_len);
     osd_op.indata.append(data);
   }
   void add_call(int op, const char *cname, const char *method,
@@ -2509,7 +2509,7 @@ public:
     ops[i].op.xattr.name_len = (name ? strlen(name) : 0);
     ops[i].op.xattr.value_len = 0;
     if (name)
-      ops[i].indata.append(name);
+      ops[i].indata.append(name, ops[i].op.xattr.name_len);
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags |
 		   CEPH_OSD_FLAG_READ, onfinish, objver);
     o->snapid = snap;
@@ -2827,7 +2827,7 @@ public:
     ops[i].op.xattr.name_len = (name ? strlen(name) : 0);
     ops[i].op.xattr.value_len = bl.length();
     if (name)
-      ops[i].indata.append(name);
+      ops[i].indata.append(name, ops[i].op.xattr.name_len);
     ops[i].indata.append(bl);
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags |
 		   CEPH_OSD_FLAG_WRITE, oncommit, objver);
@@ -2848,7 +2848,7 @@ public:
     ops[i].op.xattr.name_len = (name ? strlen(name) : 0);
     ops[i].op.xattr.value_len = 0;
     if (name)
-      ops[i].indata.append(name);
+      ops[i].indata.append(name, ops[i].op.xattr.name_len);
     Op *o = new Op(oid, oloc, ops, flags | global_op_flags |
 		   CEPH_OSD_FLAG_WRITE, oncommit, objver);
     o->mtime = mtime;


### PR DESCRIPTION
This gets rid of implicit c-string to std::string conversions, as they are expensive and unnecessary anyway.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>