### PR TITLE
rgw: Use comparison instead of assignment

### DIFF
--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -323,7 +323,7 @@ struct Condition {
     try {
       double d = std::stod(s, &p);
       if (p == s.length()) {
-	return !((d == +0.0) || (d = -0.0) || std::isnan(d));
+	return !((d == +0.0) || (d == -0.0) || std::isnan(d));
       }
     } catch (const std::logic_error& e) {
       // Fallthrough


### PR DESCRIPTION
Fixed:

** CID 1409697 (#1 of 1): Assign instead of compare (PW.ASSIGN_WHERE_COMPARE_MEANT)
1. assign_where_compare_meant: use of "=" where "==" may have been intended
2. primary_file: During compilation of file '/src/rgw/librgw.cc'

Signed-off-by: Amit Kumar amitkuma@redhat.com