### PR TITLE
osd: EC read handling: don't grab an objectstore error to use as the …

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1217,13 +1217,11 @@ void ECBackend::handle_sub_read_reply(
 	    }
 	    // Couldn't read any additional shards so handle as completed with errors
 	  }
-	  if (rop.complete[iter->first].errors.empty()) {
-	    dout(20) << __func__ << " simply not enough copies err=" << err << dendl;
-	  } else {
-	    // Grab the first error
-	    err = rop.complete[iter->first].errors.begin()->second;
-	    dout(20) << __func__ << ": Use one of the shard errors err=" << err << dendl;
-	  }
+	  // We don't want to confuse clients / RBD with objectstore error
+	  // values in particular ENOENT.  We may have different error returns
+	  // from different shards, so we'll return minimum_to_decode() error
+	  // (usually EIO) to reader.  It is likely an error here is due to a
+	  // damaged pg.
 	  rop.complete[iter->first].r = err;
 	  ++is_complete;
 	}


### PR DESCRIPTION
…read error

A missing shard (ENOENT from objectstore) will currently get back to the client. Since ErasureCode::minimum_to_decode() returns EIO when there aren't enough shards to read an object, I'm going to always use that error code even though we've collected any and all errors from each shard's attempt to read.

If you use cmpext to read an object that doesn't exist, you should still get ENOENT I assume based on the primary having no shard. Also, if OSDs are down such that there aren't enough readable shards available that is handled earlier in the process (maybe that case hangs). Finally, if we get past those two cases and reading shards get ENOENT from the objectstore, we need to decide what error code to return. I hadn't thought about the fact that a client can't tell if ENOENT means that an object doesn't exist, or there are not enough shards because one or more shards got ENOENT when attempting to read from the objectstore.