### PR TITLE
rdma: Assign instead of compare

### DIFF
--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -599,11 +599,8 @@ void RDMAConnectedSocketImpl::cleanup() {
 
 void RDMAConnectedSocketImpl::notify()
 {
-  uint64_t i = 1;
-  int ret;
-
-  ret = write(notify_fd, &i, sizeof(i));
-  assert(ret = sizeof(i));
+  int i = 1;
+  assert(sizeof(i) == write(notify_fd, &i, sizeof(i)));
 }
 
 void RDMAConnectedSocketImpl::shutdown()


### PR DESCRIPTION
Fixed:

** CID 1414508 (#1 of 1): Assign instead of compare (PW.ASSIGN_WHERE_COMPARE_MEANT)
1. assign_where_compare_meant: use of "=" where "==" may have been intended

Signed-off-by: Amit Kumar amitkuma@redhat.com