### PR TITLE
test/osd: kill compile warning

### DIFF
--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2793,7 +2793,7 @@ TEST_F(PGLogTrimTest, TestTrimNoDups)
 
   log.trim(cct, mk_evt(19, 157), &trimmed, &trimmed_dups, &dirty_dups);
 
-  EXPECT_EQ(false, dirty_dups);
+  EXPECT_FALSE(dirty_dups);
   EXPECT_EQ(3u, log.log.size());
   EXPECT_EQ(3u, trimmed.size());
   EXPECT_EQ(0u, log.dups.size());
@@ -2821,7 +2821,7 @@ TEST_F(PGLogTrimTest, TestNoTrim)
 
   log.trim(cct, mk_evt(9, 99), &trimmed, &trimmed_dups, &dirty_dups);
 
-  EXPECT_EQ(false, dirty_dups);
+  EXPECT_FALSE(dirty_dups);
   EXPECT_EQ(6u, log.log.size());
   EXPECT_EQ(0u, trimmed.size());
   EXPECT_EQ(0u, log.dups.size());
@@ -2906,7 +2906,7 @@ TEST_F(PGLogTrimTest, TestGetRequest) {
   EXPECT_EQ(mk_evt(15, 155), version);
 
   result = log.get_request(bad_reqid, &version, &user_version, &return_code);
-  EXPECT_EQ(false, result);
+  EXPECT_FALSE(result);
 }
 
 


### PR DESCRIPTION
```
[ 88%] Building CXX object src/tools/CMakeFiles/ceph-objectstore-tool.dir/ceph_objectstore_tool.cc.o
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc: In member function ‘virtual void PGLogTrimTest_TestTrimNoDups_Test::TestBody()’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc:2796:165: warning: converting ‘false’ to pointer type for argument 1 of ‘char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)’ [-Wconversion-null]
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc: In member function ‘virtual void PGLogTrimTest_TestNoTrim_Test::TestBody()’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc:2824:165: warning: converting ‘false’ to pointer type for argument 1 of ‘char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)’ [-Wconversion-null]
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc: In member function ‘virtual void PGLogTrimTest_TestGetRequest_Test::TestBody()’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/test/osd/TestPGLog.cc:2909:165: warning: converting ‘false’ to pointer type for argument 1 of ‘char testing::internal::IsNullLiteralHelper(testing::internal::Secret*)’ [-Wconversion-null]
```

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>