### PR TITLE
cls/rbd: silence warning from -Wunused-variable

### DIFF
--- a/src/cls/rbd/cls_rbd.cc
+++ b/src/cls/rbd/cls_rbd.cc
@@ -5046,7 +5046,6 @@ int trash_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
 
   map<string, cls::rbd::TrashImageSpec> data;
   string last_read = trash::image_key(start_after);
-  int max_read = RBD_MAX_KEYS_READ;
   bool more = true;
 
   CLS_LOG(20, "trash_get_images");


### PR DESCRIPTION
```
[ 31%] Building CXX object src/test/librados_test_stub/CMakeFiles/rados_test_stub.dir/TestMemIoCtxImpl.cc.o
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc: In function ‘int trash_list(cls_method_context_t, ceph::bufferlist*, ceph::bufferlist*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/cls/rbd/cls_rbd.cc:5049:7: warning: unused variable ‘max_read’ [-Wunused-variable]
   int max_read = RBD_MAX_KEYS_READ;
```
Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>