### PR TITLE
test/perf_msgr: fix incorrect fast dispatch message type for client/server

### DIFF
--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -42,7 +42,7 @@ class MessengerClient {
     bool ms_can_fast_dispatch_any() const override { return true; }
     bool ms_can_fast_dispatch(const Message *m) const override {
       switch (m->get_type()) {
-      case CEPH_MSG_OSD_OPREPLY:
+      case CEPH_MSG_OSD_OP:
         return true;
       default:
         return false;

--- a/src/test/msgr/perf_msgr_server.cc
+++ b/src/test/msgr/perf_msgr_server.cc
@@ -80,7 +80,7 @@ class ServerDispatcher : public Dispatcher {
   bool ms_can_fast_dispatch_any() const override { return true; }
   bool ms_can_fast_dispatch(const Message *m) const override {
     switch (m->get_type()) {
-    case CEPH_MSG_OSD_OP:
+    case CEPH_MSG_OSD_OPREPLY:
       return true;
     default:
       return false;


### PR DESCRIPTION

Signed-off-by: Haomai Wang <haomai@xsky.com>