### PR TITLE
mgr/restful: fixed restful delete-key

### DIFF
--- a/src/mgr/PyModules.h
+++ b/src/mgr/PyModules.h
@@ -114,6 +114,8 @@ public:
 			      const std::string &prefix) const;
   void set_config(const std::string &handle,
       const std::string &key, const std::string &val);
+  void del_config(const std::string &handle,
+      const std::string &key);
 
   void log(const std::string &handle,
            int level, const std::string &record);
@@ -122,4 +124,3 @@ public:
 };
 
 #endif
-

--- a/src/mgr/PyState.cc
+++ b/src/mgr/PyState.cc
@@ -268,6 +268,20 @@ ceph_config_set(PyObject *self, PyObject *args)
 }
 
 static PyObject*
+ceph_config_del(PyObject *self, PyObject *args)
+{
+  char *handle = nullptr;
+  char *key = nullptr;
+  if (!PyArg_ParseTuple(args, "ss:ceph_config_del", &handle, &key)) {
+    return nullptr;
+  }
+
+  global_handle->del_config(handle, key);
+
+  Py_RETURN_NONE;
+}
+
+static PyObject*
 get_metadata(PyObject *self, PyObject *args)
 {
   char *handle = nullptr;
@@ -367,6 +381,8 @@ PyMethodDef CephStateMethods[] = {
      "Get all configuration values with a given prefix"},
     {"set_config", ceph_config_set, METH_VARARGS,
      "Set a configuration value"},
+    {"del_config", ceph_config_del, METH_VARARGS,
+     "Delete a configuration value"},
     {"get_counter", get_counter, METH_VARARGS,
       "Get a performance counter"},
     {"get_perf_schema", get_perf_schema, METH_VARARGS,
@@ -379,4 +395,3 @@ PyMethodDef CephStateMethods[] = {
       "Get a CephContext* in a python capsule"},
     {NULL, NULL, 0, NULL}
 };
-

--- a/src/pybind/mgr/mgr_module.py
+++ b/src/pybind/mgr/mgr_module.py
@@ -255,6 +255,14 @@ class MgrModule(object):
         """
         self.set_config(key, json.dumps(val))
 
+    def del_config(self, key):
+        """
+        Delete a persistent configuration setting
+
+        :param key: str
+        """
+        ceph_state.del_config(self._handle, key)
+
     def get_config_json(self, key):
         """
         Helper for getting json-serialized config

--- a/src/pybind/mgr/restful/module.py
+++ b/src/pybind/mgr/restful/module.py
@@ -407,7 +407,7 @@ class Module(MgrModule):
         elif command['prefix'] == "restful delete-key":
             if command['key_name'] in self.keys:
                 del self.keys[command['key_name']]
-                self.set_config('keys/' + command['key_name'], None)
+                self.del_config('keys/' + command['key_name'])
 
             return (
                 0,


### PR DESCRIPTION
`ceph restful delete-key` gives the following error message:
```
ubuntu@ceph-1:~/ceph/build$ ./bin/ceph restful delete-key foo
*** DEVELOPER MODE: setting PATH, PYTHONPATH and LD_LIBRARY_PATH ***
2017-07-30 10:34:47.379938 7f86ff67d700 -1 WARNING: all dangerous and experimental features are enabled.
2017-07-30 10:34:47.396167 7f86ff67d700 -1 WARNING: all dangerous and experimental features are enabled.
Error EINVAL: Traceback (most recent call last):
  File "/home/ubuntu/ceph/src/pybind/mgr/restful/module.py", line 410, in handle_command
    self.set_config('keys/' + command['key_name'], None)
  File "/home/ubuntu/ceph/src/pybind/mgr/mgr_module.py", line 238, in set_config
    ceph_state.set_config(self._handle, key, val)
TypeError: ceph_config_set() argument 3 must be string, not None
```

I've fixed this by adding a `del_config` method to the MgrModule.