### PR TITLE
os/bluestore: clear result in BlueRocksEnv::getChildren

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -407,6 +407,7 @@ rocksdb::Status BlueRocksEnv::GetChildren(
   const std::string& dir,
   std::vector<std::string>* result)
 {
+  result->clear();
   int r = fs->readdir(dir, result);
   if (r < 0)
     return rocksdb::Status::IOError(dir, strerror(ENOENT));//    return err_to_status(r);


### PR DESCRIPTION
see https://github.com/facebook/rocksdb/blob/master/env/env_posix.cc#L492. in
rocksdb::env_posix implementation, it will always clear result at first. We will
get a core dump when we use rocksdb::RepairDB if we do not clear result.

Fixes: http://tracker.ceph.com/issues/20857

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>