### PR TITLE
rbd: 1351525 Argument cannot be negative

### DIFF
--- a/src/tools/rbd/action/MergeDiff.cc
+++ b/src/tools/rbd/action/MergeDiff.cc
@@ -389,7 +389,7 @@ static int do_merge_diff(const char *first, const char *second,
 done:
   if (pd > 2)
     close(pd);
-  if (sd)
+  if (sd > 2)
     close(sd);
   if (fd > 2)
     close(fd);


### PR DESCRIPTION
Fixed:

** CID 1351525 (#1 of 1): Argument cannot be negative (NEGATIVE_RETURNS)
7. negative_returns: sd is passed to a parameter that cannot be negative.

Signed-off-by: Amit Kumar amitkuma@redhat.com