### PR TITLE
common: adding line break at end of some cli results

### DIFF
--- a/src/common/Formatter.cc
+++ b/src/common/Formatter.cc
@@ -127,6 +127,8 @@ void JSONFormatter::flush(std::ostream& os)
 {
   finish_pending_string();
   os << m_ss.str();
+  if (m_line_break_enabled)
+    os << "\n";
   m_ss.clear();
   m_ss.str("");
 }
@@ -325,6 +327,8 @@ void XMLFormatter::flush(std::ostream& os)
   /* There is a small catch here. If the rest of the formatter had NO output,
    * we should NOT output a newline. This primarily triggers on HTTP redirects */
   if (m_pretty && !m_ss_str.empty())
+    os << "\n";
+  else if (m_line_break_enabled)
     os << "\n";
   m_ss.clear();
   m_ss.str("");

--- a/src/common/Formatter.h
+++ b/src/common/Formatter.h
@@ -37,6 +37,7 @@ namespace ceph {
     Formatter();
     virtual ~Formatter();
 
+    virtual void enable_line_break() = 0;
     virtual void flush(std::ostream& os) = 0;
     void flush(bufferlist &bl);
     virtual void reset() = 0;
@@ -93,6 +94,7 @@ namespace ceph {
     void set_status(int status, const char* status_name) override {};
     void output_header() override {};
     void output_footer() override {};
+    void enable_line_break() override { m_line_break_enabled = true; }
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;
@@ -128,6 +130,7 @@ namespace ceph {
     std::stringstream m_ss, m_pending_string;
     std::list<json_formatter_stack_entry_d> m_stack;
     bool m_is_pending_string;
+    bool m_line_break_enabled = false;
   };
 
   class XMLFormatter : public Formatter {
@@ -139,6 +142,7 @@ namespace ceph {
     void output_header() override;
     void output_footer() override;
 
+    void enable_line_break() override { m_line_break_enabled = true; }
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;
@@ -176,6 +180,7 @@ namespace ceph {
     const bool m_underscored;
     std::string m_pending_string_name;
     bool m_header_done;
+    bool m_line_break_enabled = false;
   };
 
   class TableFormatter : public Formatter {
@@ -185,6 +190,7 @@ namespace ceph {
     void set_status(int status, const char* status_name) override {};
     void output_header() override {};
     void output_footer() override {};
+    void enable_line_break() override {};
     void flush(std::ostream& os) override;
     using Formatter::flush; // don't hide Formatter::flush(bufferlist &bl)
     void reset() override;

--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -536,7 +536,7 @@ public:
   explicit GetdescsHook(AdminSocket *as) : m_as(as) {}
   bool call(string command, cmdmap_t &cmdmap, string format, bufferlist& out) override {
     int cmdnum = 0;
-    JSONFormatter jf(false);
+    JSONFormatter jf;
     jf.open_object_section("command_descriptions");
     for (map<string,string>::iterator p = m_as->m_descs.begin();
 	 p != m_as->m_descs.end();
@@ -550,6 +550,7 @@ public:
       cmdnum++;
     }
     jf.close_section(); // command_descriptions
+    jf.enable_line_break();
     ostringstream ss;
     jf.flush(ss);
     out.append(ss.str());

--- a/src/mgr/PyFormatter.h
+++ b/src/mgr/PyFormatter.h
@@ -76,7 +76,7 @@ public:
   void set_status(int status, const char* status_name) override {}
   void output_header() override {};
   void output_footer() override {};
-
+  void enable_line_break() override {};
 
   void open_array_section(const char *name) override;
   void open_object_section(const char *name) override;

--- a/src/rgw/rgw_formats.h
+++ b/src/rgw/rgw_formats.h
@@ -29,6 +29,7 @@ public:
   void set_status(int status, const char* status_name) override {};
   void output_header() override {};
   void output_footer() override {};
+  void enable_line_break() override {};
   void flush(ostream& os) override;
   void reset() override;
 

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -5,9 +5,9 @@ ls on empty pool never containing images
   $ rados -p rbd rm rbd_directory >/dev/null 2>&1 || true
   $ rbd ls
   $ rbd ls --format json
-  [] (no-eol)
+  []
   $ rbd ls --format xml
-  <images></images> (no-eol)
+  <images></images>
 
 create
 =======

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -143,7 +143,7 @@
     -p [ --pool ] arg    pool name
     --image arg          image name
     --snap arg           snapshot name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help clone
@@ -303,7 +303,7 @@
     --snap arg            snapshot name
     --from-snap arg       snapshot starting point
     --whole-object        compare whole object
-    --format arg          output format [plain, json, or xml]
+    --format arg          output format (plain, json, or xml) [default: plain]
     --pretty-format       pretty formatting (json and xml)
   
   rbd help disk-usage
@@ -322,7 +322,7 @@
     -p [ --pool ] arg     pool name
     --image arg           image name
     --snap arg            snapshot name
-    --format arg          output format [plain, json, or xml]
+    --format arg          output format (plain, json, or xml) [default: plain]
     --pretty-format       pretty formatting (json and xml)
     --from-snap arg       snapshot starting point
   
@@ -473,7 +473,7 @@
                          (example: [<pool-name>/]<group-name>)
   
   Optional arguments
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
     -p [ --pool ] arg    pool name
     --group arg          group name
@@ -507,7 +507,7 @@
   
   Optional arguments
     -p [ --pool ] arg    pool name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help group remove
@@ -553,7 +553,7 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help image-meta remove
@@ -675,7 +675,7 @@
     --image arg           image name
     --snap arg            snapshot name
     --image-id arg        image id
-    --format arg          output format [plain, json, or xml]
+    --format arg          output format (plain, json, or xml) [default: plain]
     --pretty-format       pretty formatting (json and xml)
   
   rbd help journal client disconnect
@@ -754,7 +754,7 @@
     -p [ --pool ] arg    pool name
     --image arg          image name
     --journal arg        journal name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help journal inspect
@@ -806,7 +806,7 @@
     -p [ --pool ] arg    pool name
     --image arg          image name
     --journal arg        journal name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help list
@@ -821,7 +821,7 @@
   Optional arguments
     -l [ --long ]        long listing format
     -p [ --pool ] arg    pool name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help lock add
@@ -854,7 +854,7 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help lock remove
@@ -993,7 +993,7 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help mirror pool demote
@@ -1045,7 +1045,7 @@
   
   Optional arguments
     -p [ --pool ] arg    pool name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help mirror pool peer add
@@ -1119,7 +1119,7 @@
   
   Optional arguments
     -p [ --pool ] arg    pool name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
     --verbose            be verbose
   
@@ -1265,7 +1265,7 @@
   Show the rbd images mapped by the kernel.
   
   Optional arguments
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help snap create
@@ -1327,7 +1327,7 @@
     -p [ --pool ] arg    pool name
     --image arg          image name
     --image-id arg       image id
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help snap protect
@@ -1451,7 +1451,7 @@
   Optional arguments
     -p [ --pool ] arg    pool name
     --image arg          image name
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help trash list
@@ -1468,7 +1468,7 @@
     -p [ --pool ] arg    pool name
     -a [ --all ]         list images from all sources
     -l [ --long ]        long listing format
-    --format arg         output format [plain, json, or xml]
+    --format arg         output format (plain, json, or xml) [default: plain]
     --pretty-format      pretty formatting (json and xml)
   
   rbd help trash move

--- a/src/tools/rbd/ArgumentTypes.cc
+++ b/src/tools/rbd/ArgumentTypes.cc
@@ -332,7 +332,7 @@ void add_no_progress_option(boost::program_options::options_description *opt) {
 
 void add_format_options(boost::program_options::options_description *opt) {
   opt->add_options()
-    (FORMAT.c_str(), po::value<Format>(), "output format [plain, json, or xml]")
+    (FORMAT.c_str(), po::value<Format>(), "output format (plain, json, or xml) [default: plain]")
     (PRETTY_FORMAT.c_str(), po::bool_switch(),
      "pretty formatting (json and xml)");
 }

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -831,6 +831,8 @@ int get_formatter(const po::variables_map &vm,
       std::cerr << "rbd: --pretty-format only works when --format "
                 << "is json or xml" << std::endl;
       return -EINVAL;
+    } else if (*formatter != nullptr && !pretty) {
+      formatter->get()->enable_line_break();
     }
   } else if (vm[at::PRETTY_FORMAT].as<bool>()) {
     std::cerr << "rbd: --pretty-format only works when --format "

--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -832,6 +832,10 @@ int get_formatter(const po::variables_map &vm,
                 << "is json or xml" << std::endl;
       return -EINVAL;
     }
+  } else if (vm[at::PRETTY_FORMAT].as<bool>()) {
+    std::cerr << "rbd: --pretty-format only works when --format "
+              << "is json or xml" << std::endl;
+    return -EINVAL;
   }
   return 0;
 }

--- a/src/tools/rbd/action/DiskUsage.cc
+++ b/src/tools/rbd/action/DiskUsage.cc
@@ -283,7 +283,7 @@ int execute(const po::variables_map &vm) {
                     from_snap_name.empty() ? nullptr : from_snap_name.c_str(),
                     formatter.get());
   if (r < 0) {
-    std::cerr << "du failed: " << cpp_strerror(r) << std::endl;
+    std::cerr << "rbd: du failed: " << cpp_strerror(r) << std::endl;
     return r;
   }
   return 0;


### PR DESCRIPTION
I get rbd list info as follows, when using `--format xml`.
```
[root@s248 ~]# rbd ls --format xml
<images><name>i1</name></images>[root@s248 ~]# 
[root@s248 ~]#
```
This occurs when only `--format` used, and after fixup as follows:
```
[root@s248 build]# ./bin/rbd ls --format xml
<images><name>i1</name></images>
[root@s248 build]#
```
If `--pretty-format` used while `--format` not works, it does not return error: 
```
[root@s248 ~]# rbd ls --pretty-format
i1
[root@s248 ~]#
```
fixes: http://tracker.ceph.com/issues/21019
Signed-off-by: songweibin <song.weibin@zte.com.cn>