### PR TITLE
os: Argument cannot be negative

### DIFF
--- a/src/test/os/TestLFNIndex.cc
+++ b/src/test/os/TestLFNIndex.cc
@@ -452,6 +452,10 @@ TEST_F(TestLFNIndex, get_mangled_name) {
 
 int main(int argc, char **argv) {
   int fd = ::creat("detect", 0600);
+  if (fd < 0){
+    cerr << "failed to create file detect" << std::endl;
+    return EXIT_FAILURE;
+  }
   int ret = chain_fsetxattr(fd, "user.test", "A", 1);
   ::close(fd);
   ::unlink("detect");


### PR DESCRIPTION
Fixed:

** CID 1395347 (#1 of 1): Argument cannot be negative (NEGATIVE_RETURNS)
3. negative_returns: fd is passed to a parameter that cannot be negative

Signed-off-by: Amit Kumar amitkuma@redhat.com