### PR TITLE
cmake: disable -fvar-tracking-assignments for config.cc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -540,6 +540,11 @@ set(libcommon_files
   ${auth_files}
   ${mds_files})
 
+if(HAS_VTA)
+  set_source_files_properties(common/config.cc
+    PROPERTIES COMPILE_FLAGS -fno-var-tracking-assignments)
+endif()
+
 if(FREEBSD)
   list(APPEND libcommon_files common/freebsd_errno.cc)
 elseif(DARWIN)


### PR DESCRIPTION
there are too many variables involved in config.cc, but
-fvar-tracking-assignments is enabled by default, when the compiler
finds that the number of variables exceeds the limit
"max-vartrack-size", it gives up, and tries again disabling this
option.

this change avoids the recompilation of config.cc and also
silences the warning of

src/common/config.cc:77:1: note: variable tracking size limit exceeded
with -fvar-tracking-assignments, retrying without
 md_config_t::md_config_t(bool is_daemon)
 ^

Signed-off-by: Kefu Chai <kchai@redhat.com>