### PR TITLE
HashIndex.cc: add compat.h for ENODATA

### DIFF
--- a/src/os/filestore/HashIndex.cc
+++ b/src/os/filestore/HashIndex.cc
@@ -12,6 +12,7 @@
  *
  */
 
+#include "include/compat.h"
 #include "include/types.h"
 #include "include/buffer.h"
 #include "osd/osd_types.h"


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>