### PR TITLE
mgr: apply a threshold to perf counter prios

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -11,6 +11,9 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/regex.hpp>
 
+// Definitions for enums
+#include "common/perf_counters.h"
+
 
 void Option::dump_value(const char *field_name,
     const Option::value_t &v, Formatter *f) const
@@ -4024,6 +4027,14 @@ std::vector<Option> get_global_options() {
     Option("journal_replay_from", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description(""),
+
+  Option("mgr_stats_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+  .set_default((int64_t)PerfCountersBuilder::PRIO_USEFUL)
+  .set_description("Lowest perfcounter priority collected by mgr")
+  .set_long_description("Daemons only set perf counter data to the manager "
+    "daemon if the counter has a priority higher than this.")
+  .set_min_max((int64_t)PerfCountersBuilder::PRIO_DEBUGONLY,
+               (int64_t)PerfCountersBuilder::PRIO_CRITICAL),
 
     Option("journal_zero_on_create", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(false)

--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -23,25 +23,33 @@
  */
 class MMgrConfigure : public Message
 {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
 public:
   uint32_t stats_period;
+  
+  // Default 0 means if unspecified will include all stats
+  uint32_t stats_threshold = 0;
 
   void decode_payload() override
   {
     bufferlist::iterator p = payload.begin();
     ::decode(stats_period, p);
+    if (header.version >= 2) {
+      ::decode(stats_threshold, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
     ::encode(stats_period, payload);
+    ::encode(stats_threshold, payload);
   }
 
   const char *get_type_name() const override { return "mgrconfigure"; }
   void print(ostream& out) const override {
-    out << get_type_name() << "()";
+    out << get_type_name() << "(period=" << stats_period
+                           << ", threshold=" << stats_threshold << ")";
   }
 
   MMgrConfigure()

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -74,10 +74,13 @@ DaemonServer::DaemonServer(MonClient *monc_,
                       g_conf->auth_cluster_required :
                       g_conf->auth_supported),
       lock("DaemonServer")
-{}
+{
+  g_conf->add_observer(this);
+}
 
 DaemonServer::~DaemonServer() {
   delete msgr;
+  g_conf->remove_observer(this);
 }
 
 int DaemonServer::init(uint64_t gid, entity_addr_t client_addr)
@@ -233,6 +236,11 @@ bool DaemonServer::ms_handle_reset(Connection *con)
     dout(10) << "unregistering osd." << session->osd_id
 	     << "  session " << session << " con " << con << dendl;
     osd_cons[session->osd_id].erase(con);
+
+    auto iter = daemon_connections.find(con);
+    if (iter != daemon_connections.end()) {
+      daemon_connections.erase(iter);
+    }
   }
   return false;
 }
@@ -316,10 +324,7 @@ bool DaemonServer::handle_open(MMgrOpen *m)
 
   dout(4) << "from " << m->get_connection() << "  " << key << dendl;
 
-  auto configure = new MMgrConfigure();
-  configure->stats_period = g_conf->mgr_stats_period;
-  configure->stats_threshold = g_conf->get_val<int64_t>("mgr_stats_threshold");
-  m->get_connection()->send_message(configure);
+  _send_configure(m->get_connection());
 
   DaemonStatePtr daemon;
   if (daemon_state.exists(key)) {
@@ -358,6 +363,15 @@ bool DaemonServer::handle_open(MMgrOpen *m)
       d->metadata = m->daemon_metadata;
       pending_service_map_dirty = pending_service_map.epoch;
     }
+  }
+
+  if (m->get_connection()->get_peer_type() != entity_name_t::TYPE_CLIENT &&
+      m->service_name.empty())
+  {
+    // Store in set of the daemon/service connections, i.e. those
+    // connections that require an update in the event of stats
+    // configuration changes.
+    daemon_connections.insert(m->get_connection());
   }
 
   m->put();
@@ -703,6 +717,19 @@ bool DaemonServer::handle_command(MCommand *m)
     }
     f->close_section();
     f->flush(cmdctx->odata);
+    cmdctx->reply(0, ss);
+    return true;
+  }
+
+  if (prefix == "config set") {
+    std::string key;
+    std::string val;
+    cmd_getval(cct, cmdctx->cmdmap, "key", key);
+    cmd_getval(cct, cmdctx->cmdmap, "value", val);
+    r = cct->_conf->set_val(key, val, true, &ss);
+    if (r == 0) {
+      cct->_conf->apply_changes(nullptr);
+    }
     cmdctx->reply(0, ss);
     return true;
   }
@@ -1406,3 +1433,48 @@ void DaemonServer::got_service_map()
     daemon_state.cull(p.first, names);
   }
 }
+
+
+const char** DaemonServer::get_tracked_conf_keys() const
+{
+  static const char *KEYS[] = {
+    "mgr_stats_threshold",
+    "mgr_stats_period",
+    nullptr
+  };
+
+  return KEYS;
+}
+
+void DaemonServer::handle_conf_change(const struct md_config_t *conf,
+                                              const std::set <std::string> &changed)
+{
+  dout(4) << "ohai" << dendl;
+  // We may be called within lock (via MCommand `config set`) or outwith the
+  // lock (via admin socket `config set`), so handle either case.
+  const bool initially_locked = lock.is_locked_by_me();
+  if (!initially_locked) {
+    lock.Lock();
+  }
+
+  if (changed.count("mgr_stats_threshold") || changed.count("mgr_stats_period")) {
+    dout(4) << "Updating stats threshold/period on "
+            << daemon_connections.size() << " clients" << dendl;
+    // Send a fresh MMgrConfigure to all clients, so that they can follow
+    // the new policy for transmitting stats
+    for (auto &c : daemon_connections) {
+      _send_configure(c);
+    }
+  }
+}
+
+void DaemonServer::_send_configure(ConnectionRef c)
+{
+  assert(lock.is_locked_by_me());
+
+  auto configure = new MMgrConfigure();
+  configure->stats_period = g_conf->get_val<int64_t>("mgr_stats_period");
+  configure->stats_threshold = g_conf->get_val<int64_t>("mgr_stats_threshold");
+  c->send_message(configure);
+}
+

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -318,6 +318,7 @@ bool DaemonServer::handle_open(MMgrOpen *m)
 
   auto configure = new MMgrConfigure();
   configure->stats_period = g_conf->mgr_stats_period;
+  configure->stats_threshold = g_conf->get_val<int64_t>("mgr_stats_threshold");
   m->get_connection()->send_message(configure);
 
   DaemonStatePtr daemon;

--- a/src/mgr/MgrClient.cc
+++ b/src/mgr/MgrClient.cc
@@ -228,9 +228,15 @@ void MgrClient::send_report()
   pcc->with_counters([this, report](
         const PerfCountersCollection::CounterMap &by_path)
   {
+    auto include_counter = [this](
+        const PerfCounters::perf_counter_data_any_d &ctr)
+    {
+      return ctr.prio >= (int)stats_threshold;
+    };
+
     ENCODE_START(1, 1, report->packed);
     for (auto p = session->declared.begin(); p != session->declared.end(); ) {
-      if (by_path.count(*p) == 0) {
+      if (by_path.count(*p) == 0 || !include_counter(*(by_path.at(*p)))) {
 	report->undeclare_types.push_back(*p);
 	ldout(cct,20) << __func__ << " undeclare " << *p << dendl;
 	p = session->declared.erase(p);
@@ -242,8 +248,12 @@ void MgrClient::send_report()
       auto& path = i.first;
       auto& data = *(i.second);
 
+      if (!include_counter(data)) {
+        continue;
+      }
+
       if (session->declared.count(path) == 0) {
-	ldout(cct,20) << __func__ << " declare " << path << dendl;
+	ldout(cct,20) << " declare " << path << dendl;
 	PerfCounterType type;
 	type.path = path;
 	if (data.description) {
@@ -265,8 +275,11 @@ void MgrClient::send_report()
     }
     ENCODE_FINISH(report->packed);
 
-    ldout(cct, 20) << by_path.size() << " counters, of which "
-		   << report->declare_types.size() << " new" << dendl;
+    ldout(cct, 20) << "sending " << session->declared.size() << " counters ("
+                      "of possible " << by_path.size() << "), "
+		   << report->declare_types.size() << " new, "
+                   << report->undeclare_types.size() << " removed"
+                   << dendl;
   });
 
   ldout(cct, 20) << "encoded " << report->packed.length() << " bytes" << dendl;
@@ -313,6 +326,11 @@ bool MgrClient::handle_mgr_configure(MMgrConfigure *m)
   }
 
   ldout(cct, 4) << "stats_period=" << m->stats_period << dendl;
+
+  if (stats_threshold != m->stats_threshold) {
+    ldout(cct, 4) << "updated stats threshold: " << m->stats_threshold << dendl;
+    stats_threshold = m->stats_threshold;
+  }
 
   bool starting = (stats_period == 0) && (m->stats_period != 0);
   stats_period = m->stats_period;

--- a/src/mgr/MgrClient.h
+++ b/src/mgr/MgrClient.h
@@ -59,6 +59,7 @@ protected:
   Mutex lock = {"MgrClient::lock"};
 
   uint32_t stats_period = 0;
+  uint32_t stats_threshold = 0;
   SafeTimer timer;
 
   CommandTable<MgrCommand> command_table;

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -131,3 +131,8 @@ COMMAND("service dump",
         "dump service map", "service", "r", "cli,rest")
 COMMAND("service status",
         "dump service state", "service", "r", "cli,rest")
+
+COMMAND("config set " \
+	"name=key,type=CephString name=value,type=CephString",
+	"Set a configuration option at runtime (not persistent)",
+	"mgr", "rw", "cli,rest")


### PR DESCRIPTION
...so that we can control the level of load
we're putting on ceph-mgr with perf counters.  Don't collect
anything below PRIO_USEFUL by default.

Signed-off-by: John Spray <john.spray@redhat.com>