### PR TITLE
mon: extensible output format for health checks

### DIFF
--- a/src/mon/health_check.h
+++ b/src/mon/health_check.h
@@ -35,10 +35,16 @@ struct health_check_t {
 
   void dump(Formatter *f) const {
     f->dump_stream("severity") << severity;
-    f->dump_string("summary", summary);
+
+    f->open_object_section("summary");
+    f->dump_string("message", summary);
+    f->close_section();
+
     f->open_array_section("detail");
     for (auto& p : detail) {
-      f->dump_string("item", p);
+      f->open_object_section("detail_item");
+      f->dump_string("message", p);
+      f->close_section();
     }
     f->close_section();
   }
@@ -138,11 +144,17 @@ struct health_check_map_t {
       if (f) {
 	f->open_object_section(p.first.c_str());
 	f->dump_stream("severity") << p.second.severity;
-	f->dump_string("message", p.second.summary);
+
+        f->open_object_section("summary");
+        f->dump_string("message", p.second.summary);
+        f->close_section();
+
 	if (detail) {
 	  f->open_array_section("detail");
 	  for (auto& d : p.second.detail) {
-	    f->dump_string("item", d);
+            f->open_object_section("detail_item");
+            f->dump_string("message", d);
+            f->close_section();
 	  }
 	  f->close_section();
 	}

--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -235,7 +235,7 @@
                         <ul>
                             <li rv-each-check="health.checks">
                                 <span rv-style="check.severity | health_color">{check.type}</span>:
-                                {check.message}
+                                {check.summary.message}
                             </li>
                         </ul>
                     </div>


### PR DESCRIPTION
The summary field can be extended with the fields
used to construct the message (e.g. including
the down osd count in the message about osds
being down).

The detail entries, similarly, can be extended
with machine-readable fields like the PG ID
for a damaged PG.

For the moment all the internal stuff is just
strings still, but we change the output format
so that we don't break it later when we
add things.

Signed-off-by: John Spray <john.spray@redhat.com>