### PR TITLE
jewel: ceph-disk: don't activate suppressed journal devices

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3789,6 +3789,10 @@ def main_activate_space(name, args):
     if not os.path.exists(args.dev):
         raise Error('%s does not exist' % args.dev)
 
+    if is_suppressed(args.dev):
+        LOG.info('suppressed activate request on space %s', args.dev)
+        return
+
     cluster = None
     osd_id = None
     osd_uuid = None


### PR DESCRIPTION
Multipath device activation currently requires that devices representing
individual paths making up a multipath device are suppressed, to avoid
errors such as:
  ceph_disk.main.Error: Error: /dev/sda1 is not a multipath block device

Activation of suppressed OSD devices is currently handled by checks in
main_activate() and main_activate_space(). However, suppressed journal
and block devices are not detected.

(Along with udev change) Fixes: http://tracker.ceph.com/issues/19489
Backport tracker: http://tracker.ceph.com/issues/20837

Signed-off-by: David Disseldorp <ddiss@suse.de>
(cherry picked from commit c729627450d4032ede7932f4c1b57a6d0cff73b2)