### PR TITLE
rbd-mirror: assertion failure during pool replayer shut down

### DIFF
--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -357,12 +357,15 @@ void PoolReplayer::shut_down() {
   }
   if (m_leader_watcher) {
     m_leader_watcher->shut_down();
+    m_leader_watcher.reset();
   }
   if (m_instance_watcher) {
     m_instance_watcher->shut_down();
+    m_instance_watcher.reset();
   }
   if (m_instance_replayer) {
     m_instance_replayer->shut_down();
+    m_instance_replayer.reset();
   }
 
   assert(!m_local_pool_watcher);
@@ -471,7 +474,9 @@ void PoolReplayer::run()
       break;
     }
 
-    m_cond.WaitInterval(m_lock, utime_t(1, 0));
+    if (!m_stopping) {
+      m_cond.WaitInterval(m_lock, utime_t(1, 0));
+    }
   }
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20644
Signed-off-by: Jason Dillaman <dillaman@redhat.com>