### PR TITLE
osd: do not try to set device class before luminous

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8720,6 +8720,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       err = -EINVAL;
       goto reply;
     }
+    if (rel == osdmap.require_osd_release) {
+      // idempotent
+      err = 0;
+      goto reply;
+    }
     if (rel == CEPH_RELEASE_LUMINOUS) {
       if (!HAVE_FEATURE(osdmap.get_up_osd_features(), SERVER_LUMINOUS)) {
 	ss << "not all up OSDs have CEPH_FEATURE_SERVER_LUMINOUS feature";

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -2635,15 +2635,15 @@ int OSD::init()
 
   r = update_crush_device_class();
   if (r < 0) {
-    derr << __func__ <<" unable to update_crush_device_class: "
-         << cpp_strerror(r) << dendl;
+    derr << __func__ << " unable to update_crush_device_class: "
+	 << cpp_strerror(r) << dendl;
     osd_lock.Lock();
     goto monout;
   }
 
   r = update_crush_location();
   if (r < 0) {
-    derr << __func__ <<" unable to update_crush_location: "
+    derr << __func__ << " unable to update_crush_location: "
          << cpp_strerror(r) << dendl;
     osd_lock.Lock();
     goto monout;
@@ -3524,6 +3524,7 @@ int OSD::update_crush_device_class()
   }
 
   if (device_class.empty()) {
+    dout(20) << __func__ << " no device class stored locally" << dendl;
     return 0;
   }
 
@@ -3533,7 +3534,10 @@ int OSD::update_crush_device_class()
     string("\"ids\": [\"") + stringify(whoami) + string("\"]}");
 
   r = mon_cmd_maybe_osd_create(cmd);
-  if (r == -EPERM) {
+  // we may not have a real osdmap on first boot, so we can't check if
+  // require-osd-release is set to luminous yet. Instead, ignore
+  // EINVAL.
+  if (r == -EPERM || r == -EINVAL) {
     r = 0;
   }
 


### PR DESCRIPTION
This avoids crashing when older monitors do not support it.

Fixes: http://tracker.ceph.com/issues/20850
Signed-off-by: Josh Durgin <jdurgin@redhat.com>

