### PR TITLE
jewel: rgw: 15912 15673 (Fix duplicate tag removal during GC, cls/refcount: store and use list of retired tags)

### DIFF
--- a/src/rgw/rgw_gc.cc
+++ b/src/rgw/rgw_gc.cc
@@ -226,6 +226,10 @@ int RGWGC::process(int index, int max_secs)
         }
       }
     }
+    if (!remove_tags.empty()) {
+      RGWGC::remove(index, remove_tags);
+      remove_tags.clear();
+    }
   } while (truncated);
 
 done:


### PR DESCRIPTION
http://tracker.ceph.com/issues/20719