### PR TITLE
jewel: rgw: fix the bug that part's index can't be removed after completing

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2351,6 +2351,7 @@ int RGWPutObjProcessor_Multipart::do_complete(string& etag, real_time *mtime, re
   complete_writing_data();
 
   RGWRados::Object op_target(store, s->bucket_info, obj_ctx, head_obj);
+  op_target.set_versioning_disabled(true);
   RGWRados::Object::Write head_obj_op(&op_target);
 
   head_obj_op.meta.set_mtime = set_mtime;


### PR DESCRIPTION
multipart upload when the bucket versioning is enabled.

Fixes: http://tracker.ceph.com/issues/19604

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>