### PR TITLE
ceph-osd: fix auto detect which objectstore is currently running

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -246,6 +246,7 @@ int main(int argc, const char **argv)
       bl.read_fd(fd, 64);
       if (bl.length()) {
 	store_type = string(bl.c_str(), bl.length() - 1);  // drop \n
+	g_conf->set_val("osd_objectstore", store_type);
 	dout(5) << "object store type is " << store_type << dendl;
       }
       ::close(fd);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20865

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>