### PR TITLE
dashboard: ceph config-key has no set command

### DIFF
--- a/src/pybind/mgr/dashboard/README.rst
+++ b/src/pybind/mgr/dashboard/README.rst
@@ -39,7 +39,7 @@ IPv4 and IPv6 addresses.
 
 ::
 
-    ceph config-key set mgr/dashboard/server_addr ::
+    ceph config-key put mgr/dashboard/server_addr ::
 
 Restart the ceph-mgr daemon after modifying the setting to load the module.
 


### PR DESCRIPTION
ceph config-key comand has no set subcommand, It should be put.