### PR TITLE
doc: fix typo in config.rst

### DIFF
--- a/doc/dev/config.rst
+++ b/doc/dev/config.rst
@@ -94,7 +94,7 @@ Defining config options
 =======================
 
 New-style config options are defined in common/options.cc. All new config
-options should go here (and not into legacy config_opts.h).
+options should go here (and not into legacy_config_opts.h).
 
 Levels
 ------


### PR DESCRIPTION
Fixed the typo introduced by https://github.com/ceph/ceph/pull/16681

Signed-off-by: Jos Collin <jcollin@redhat.com>