### PR TITLE
doc: various fixes

### DIFF
--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -30,7 +30,7 @@ ________
 
 One or more OSDs are marked down
 
-OSD_<crush type>_DOWN 
+OSD_<crush type>_DOWN
 _____________________
 
 (e.g. OSD_HOST_DOWN, OSD_ROOT_DOWN)

--- a/doc/rados/operations/index.rst
+++ b/doc/rados/operations/index.rst
@@ -14,6 +14,7 @@ and, monitoring an operating cluster.
 	:maxdepth: 1 
 	
 	operating
+	health-checks
 	monitoring
 	monitoring-osd-pg
 	user-management

--- a/doc/radosgw/s3/bucketops.rst
+++ b/doc/radosgw/s3/bucketops.rst
@@ -292,7 +292,7 @@ You may specify parameters for ``GET /{bucket}?uploads``, but none of them are r
 +------------------------+-----------+--------------------------------------------------------------------------------------+
 | ``max-uploads``        | Integer   | The maximum number of multipart uploads. The range from 1-1000. The default is 1000. |
 +------------------------+-----------+--------------------------------------------------------------------------------------+
-| ``upload-id-marker``   | String    | Ignored if ``key-marker`` is not specified. Specifies the ``ID`` of first             |
+| ``upload-id-marker``   | String    | Ignored if ``key-marker`` is not specified. Specifies the ``ID`` of first            |
 |                        |           | upload to list in lexicographical order at or following the ``ID``.                  |
 +------------------------+-----------+--------------------------------------------------------------------------------------+
 

--- a/doc/rbd/rados-rbd-cmds.rst
+++ b/doc/rbd/rados-rbd-cmds.rst
@@ -190,7 +190,7 @@ For example::
     force.
 
 Restoring a Block Device Image
-=============================
+==============================
 
 To restore a deferred delete block device in the rbd pool, execute the 
 following, but replace ``{image-id}`` with the id of the image::


### PR DESCRIPTION
- radosgw/s3/bucketops.rst: fix Malformed table.
- operations/health-checks.rst: Title underline too short
- rbd/rados-rbd-cmds.rst: Title underline too short
- rados/operations/index.rst: include health-checks in toc

Signed-off-by: Kefu Chai <kchai@redhat.com>