### PR TITLE
librbd: Uninitialized variable used handle_refresh()

### DIFF
--- a/src/librbd/image/CloneRequest.cc
+++ b/src/librbd/image/CloneRequest.cc
@@ -316,7 +316,7 @@ template <typename I>
 void CloneRequest<I>::handle_refresh(int r) {
   ldout(m_cct, 20) << this << " " << __func__ << " r=" << r << dendl;
 
-  bool snap_protected;
+  bool snap_protected = false;
   if (r == 0) {
     m_p_imctx->snap_lock.get_read();
     r = m_p_imctx->is_snap_protected(m_p_imctx->snap_id, &snap_protected);


### PR DESCRIPTION
Fixed:

** CID 1403249 (#1 of 1): Uninitialized scalar variable (UNINIT)
6. uninit_use: Using uninitialized value snap_protected.

Signed-off-by: Amit Kumar amitkuma@redhat.com