### PR TITLE
mds: Remove unused variable ops_allowance in C_IO_PurgeStrayPurged

### DIFF
--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -73,14 +73,12 @@ public:
 class C_IO_PurgeStrayPurged : public StrayManagerIOContext {
   CDentry *dn;
   bool only_head;
-  // How many ops_in_flight were allocated to this purge?
-  uint32_t ops_allowance;
 public:
   C_IO_PurgeStrayPurged(StrayManager *sm_, CDentry *d, bool oh) : 
     StrayManagerIOContext(sm_), dn(d), only_head(oh) { }
   void finish(int r) override {
     assert(r == 0 || r == -ENOENT);
-    sm->_purge_stray_purged(dn, ops_allowance, only_head);
+    sm->_purge_stray_purged(dn, only_head);
   }
 };
 
@@ -163,7 +161,7 @@ public:
 };
 
 void StrayManager::_purge_stray_purged(
-    CDentry *dn, uint32_t ops_allowance, bool only_head)
+    CDentry *dn, bool only_head)
 {
   CInode *in = dn->get_projected_linkage()->get_inode();
   dout(10) << "_purge_stray_purged " << *dn << " " << *in << dendl;

--- a/src/mds/StrayManager.h
+++ b/src/mds/StrayManager.h
@@ -63,7 +63,7 @@ class StrayManager
   /**
    * Completion handler for a Filer::purge on a stray inode.
    */
-  void _purge_stray_purged(CDentry *dn, uint32_t ops, bool only_head);
+  void _purge_stray_purged(CDentry *dn, bool only_head);
 
   void _purge_stray_logged(CDentry *dn, version_t pdv, LogSegment *ls);
 


### PR DESCRIPTION
Fixes:

** CID 1402142 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member ops_allowance is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com