### PR TITLE
tests: reproducer for rbd-on-EC backing pool issue

### DIFF
--- a/qa/suites/rbd/singleton/all/issue-20925.yaml
+++ b/qa/suites/rbd/singleton/all/issue-20925.yaml
@@ -1,0 +1,14 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
+- [mon.b, mgr.y, osd.3, osd.4, osd.5]
+- [mon.c, mgr.z, osd.6, osd.7, osd.8]
+- [osd.9, osd.10, osd.11]
+tasks:
+- install:
+- ceph:
+- exec:
+    client.0:
+      - ceph osd pool create ecpool 12 12 erasure
+      - ceph osd pool set ecpool allow_ec_overwrites true
+      - rbd --data-pool ecpool create --size 1024G test1
+      - rbd bench-write test1 --io-pattern=rand


### PR DESCRIPTION
This is my first humble attempt at a teuthology reproducer for http://tracker.ceph.com/issues/20295

It can be run on mira (which IIRC has HDDs) like so: `teuthology-suite -k distro --verbose --ceph-repo https://github.com/ceph/ceph.git --ceph master --newest 10 --suite-repo https://github.com/smithfarm/ceph.git --suite-branch wip-20925-reproducer --suite rbd/singleton --filter="issue-20925" --machine-type mira --priority 101 --email ncutler@suse.com`
