### PR TITLE
rbd: Drop unused member variable reopen in C_OpenComplete

### DIFF
--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -104,7 +104,6 @@ struct C_AioCompletion : public Context {
 struct C_OpenComplete : public C_AioCompletion {
   librbd::ImageCtx *ictx;
   void **ictxp;
-  bool reopen;
   C_OpenComplete(librbd::ImageCtx *ictx, librbd::io::AioCompletion* comp,
 		 void **ictxp)
     : C_AioCompletion(ictx, librbd::io::AIO_TYPE_OPEN, comp),


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
** CID 1402141 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member reopen is not initialized in this constructor nor in any functions that it calls.
```
Signed-off-by: Amit Kumar amitkuma@redhat.com