### PR TITLE
tests: rbd: reproducer for rbd-on-EC issue

### DIFF
--- a/qa/suites/rbd/singleton-bluestore/all/issue-20295.yaml
+++ b/qa/suites/rbd/singleton-bluestore/all/issue-20295.yaml
@@ -1,0 +1,14 @@
+roles:
+- [mon.a, mgr.x, osd.0, osd.1, osd.2, client.0]
+- [mon.b, mgr.y, osd.3, osd.4, osd.5]
+- [mon.c, mgr.z, osd.6, osd.7, osd.8]
+- [osd.9, osd.10, osd.11]
+tasks:
+- install:
+- ceph:
+    log-whitelist:
+      - 'application not enabled'
+- workunit:
+    timeout: 30m
+    clients:
+      all: [rbd/issue-20295.sh]

--- a/qa/suites/rbd/singleton-bluestore/objectstore/bluestore-comp.yaml
+++ b/qa/suites/rbd/singleton-bluestore/objectstore/bluestore-comp.yaml
@@ -1,0 +1,1 @@
+../../../../objectstore/bluestore-comp.yaml

--- a/qa/suites/rbd/singleton-bluestore/objectstore/bluestore.yaml
+++ b/qa/suites/rbd/singleton-bluestore/objectstore/bluestore.yaml
@@ -1,0 +1,1 @@
+../../../../objectstore/bluestore.yaml

--- a/qa/suites/rbd/singleton-bluestore/openstack.yaml
+++ b/qa/suites/rbd/singleton-bluestore/openstack.yaml
@@ -1,0 +1,4 @@
+openstack:
+  - volumes: # attached to each instance
+      count: 3
+      size: 30 # GB

--- a/qa/workunits/rbd/issue-20295.sh
+++ b/qa/workunits/rbd/issue-20295.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -ex
+
+TEST_POOL=ecpool
+TEST_IMAGE=test1
+PGS=12
+
+ceph osd pool create $TEST_POOL $PGS $PGS erasure
+ceph osd pool application enable $TEST_POOL rbd
+ceph osd pool set $TEST_POOL allow_ec_overwrites true
+rbd --data-pool $TEST_POOL create --size 1024G $TEST_IMAGE
+rbd bench \
+    --io-type write \
+    --io-size 4096 \
+    --io-pattern=rand \
+    --io-total 100M \
+    $TEST_IMAGE
+
+echo "OK"


### PR DESCRIPTION
This introduces a new "rbd/singleton-bluestore" suite because creating an rbd
on an EC-backed datapool will fail on filestore.

References: http://tracker.ceph.com/issues/20295

N.B.: The issue only reproduces on HDDs, hence `--machine-type mira`

Also, counter-intuitively, it does not reproduce when bluestore compression is on.