### PR TITLE
os: add compile option to build libbluefs.so 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,6 +237,8 @@ if(WITH_PMEM)
   set(HAVE_PMEM ${PMEM_FOUND})
 endif(WITH_PMEM)
 
+option(WITH_BLUEFS "libbluefs library" OFF)
+
 # needs mds and? XXX
 option(WITH_LIBCEPHFS "libcephfs client library" ON)
 

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -71,6 +71,14 @@ endif()
 
 add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)
 
+if(WITH_BLUEFS)
+  add_library(bluefs SHARED 
+    bluestore/BlueRocksEnv.cc)
+  target_include_directories(bluefs PUBLIC ${ROCKSDB_INCLUDE_DIR})
+  target_link_libraries(bluefs global)
+  install(TARGETS bluefs DESTINATION lib)
+endif(WITH_BLUEFS)
+
 if(HAVE_LIBAIO)
   target_link_libraries(os ${AIO_LIBRARIES})
 endif(HAVE_LIBAIO)


### PR DESCRIPTION
bluefs is an amazing feature for us to not only used in bluestore, it could also be an useful library to combine with rocksdb(or other apps). We would like to generate a shared library for bluefs, and test it seperately.