### PR TITLE
os/bluestore: fix dirty_range on _do_clone_range

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10928,7 +10928,7 @@ int BlueStore::_do_clone_range(
       // make sure it is shared
       if (!blob.is_shared()) {
 	c->make_blob_shared(_assign_blobid(txc), e.blob);
-	if (dirty_range_begin == 0) {
+	if (dirty_range_begin == 0 && dirty_range_end == 0) {
           dirty_range_begin = e.logical_offset;
         }
         assert(e.logical_end() > 0);


### PR DESCRIPTION
If we are cloning several extents that start from logical offset 0, we may
need to dirty those extents on the source object if they are being made
shared.  However, if there are two or more such extents, and the first
starts at 0, the current code will adjust dirty_range_start to the
second extent because the second time around the loop dirty_range_begin
is still 0.

Fix by adjusting the condition to be dirty_range_begin and dirty_range_end
== 0 so that it only triggers on the first pass.

Fixes: http://tracker.ceph.com/issues/20810
Signed-off-by: Sage Weil <sage@redhat.com>