### PR TITLE
qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject: sleep longer

### DIFF
--- a/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
+++ b/qa/suites/rados/singleton-nomsgr/all/multi-backfill-reject.yaml
@@ -40,3 +40,5 @@ tasks:
 - exec:
     client.0:
       - sudo ceph osd pool set foo size 2
+- sleep:
+    duration: 300


### PR DESCRIPTION
I saw a failure where the 30% backfill probability was enough that we
just didn't manage to backfill all of the pgs during the 5 minute recovery
timeout during ceph.py shutdown.  Build in some additional time for the
test to recover.

http://pulpito.ceph.com/sage-2017-08-01_15:32:10-rados-wip-sage-testing-distro-basic-smithi/1469184

Signed-off-by: Sage Weil <sage@redhat.com>