### PR TITLE
test/librbd/fsx: Add break in case OP_WRITESAME and OP_COMPARE_AND_WRITE

### DIFF
--- a/src/test/librbd/fsx.cc
+++ b/src/test/librbd/fsx.cc
@@ -2393,12 +2393,14 @@ test(void)
 			log4(OP_SKIPPED, OP_WRITESAME, offset, size);
 			goto out;
 		}
+		break;
         case OP_COMPARE_AND_WRITE:
                 /* compare_and_write not implemented */
                 if (!ops->compare_and_write) {
                         log4(OP_SKIPPED, OP_COMPARE_AND_WRITE, offset, size);
                         goto out;
                 }
+		break;
 	}
 
 	switch (op) {


### PR DESCRIPTION
Add break in case OP_WRITESAME and OP_COMPARE_AND_WRITE

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>