### PR TITLE
osd: silence warning from -Wint-in-bool-context

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -476,13 +476,13 @@ public:
     }
 
     void index(pg_log_dup_t& e) {
-      if (PGLOG_INDEXED_DUPS) {
+      if (indexed_data & PGLOG_INDEXED_DUPS) {
 	dup_index[e.reqid] = &e;
       }
     }
 
     void unindex(const pg_log_dup_t& e) {
-      if (PGLOG_INDEXED_DUPS) {
+      if (indexed_data & PGLOG_INDEXED_DUPS) {
 	auto i = dup_index.find(e.reqid);
 	if (i != dup_index.end()) {
 	  dup_index.erase(i);


### PR DESCRIPTION
The following warning appears during build:
```
ceph/src/osd/PGLog.h: In member function ‘void PGLog::IndexedLog::index(pg_log_dup_t&)’:
ceph/src/osd/PGLog.h:29:43: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
 #define PGLOG_INDEXED_DUPS             (1 << 3)
                                        ~~~^~~~~
ceph/src/osd/PGLog.h:29:43: note: in definition of macro ‘PGLOG_INDEXED_DUPS’
 #define PGLOG_INDEXED_DUPS             (1 << 3)
                                           ^~
ceph/src/osd/PGLog.h: In member function ‘void PGLog::IndexedLog::unindex(const pg_log_dup_t&)’:
ceph/src/osd/PGLog.h:29:43: warning: ‘<<’ in boolean context, did you mean ‘<’ ? [-Wint-in-bool-context]
 #define PGLOG_INDEXED_DUPS             (1 << 3)
                                        ~~~^~~~~
ceph/src/osd/PGLog.h:29:43: note: in definition of macro ‘PGLOG_INDEXED_DUPS’
 #define PGLOG_INDEXED_DUPS             (1 << 3)
                                           ^~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>