### PR TITLE
mgr/dashboard: correct raw usage chart's backgroud color

### DIFF
--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -159,7 +159,7 @@
                                 content_data.df.stats.total_used_bytes,
                                 content_data.df.stats.total_avail_bytes
                             ],
-                            backgroundColor: ["#424d52", "#222d32"]
+                            backgroundColor: ["#424d52", "#00bb00"]
                             }
                         ]
                     },


### PR DESCRIPTION
Signed-off-by: Yixing Yan <yanyx@umcloud.com>

the raw usage chart's backgroud color is same as the box's backgroup color
![1](https://user-images.githubusercontent.com/12455492/28868901-7bbf866c-77ad-11e7-8a4f-9fd0372a2dd8.png)
After change the chart's backgroud color to #00bb00, it shows as blew:
![2](https://user-images.githubusercontent.com/12455492/28868910-87098a54-77ad-11e7-8d56-19f8b2315a3b.png)
