### PR TITLE
client: Added NULL check before dereference

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12900,6 +12900,7 @@ void Client::ms_handle_remote_reset(Connection *con)
 	}
       }
       if (mds >= 0) {
+	assert (s != NULL);
 	switch (s->state) {
 	case MetaSession::STATE_CLOSING:
 	  ldout(cct, 1) << "reset from mds we were closing; we'll call that closed" << dendl;


### PR DESCRIPTION
Fixed:

** 1405291 Explicit null dereferenced.
CID 1405291 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
10. var_deref_op: Dereferencing null pointer s.

Signed-off-by: Amit Kumar amitkuma@redhat.com