### PR TITLE
mds: Added NULL check before dereference

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -3095,9 +3095,11 @@ void Server::handle_client_lookup_ino(MDRequestRef& mdr,
     if (!mds->locker->acquire_locks(mdr, rdlocks, wrlocks, xlocks))
       return;
 
-    // need read access to directory inode
-    if (!check_access(mdr, diri, MAY_READ))
-      return;
+    if (diri != NULL) {
+      // need read access to directory inode
+      if (!check_access(mdr, diri, MAY_READ))
+        return;
+    }
   }
 
   if (want_parent) {


### PR DESCRIPTION
Fixes the Coverity Scan Report:
```
** 1405280 Explicit null dereferenced
CID 1405280 (#1 of 1): Explicit null dereferenced (FORWARD_NULL)
20. var_deref_model: Passing null pointer diri to check_access, which dereferences it.
```
Signed-off-by: Amit Kumar amitkuma@redhat.com