### PR TITLE
client: NULL check before append value to bufferlist

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -10679,6 +10679,7 @@ int Client::_do_setxattr(Inode *in, const char *name, const void *value,
   req->head.args.setxattr.flags = xattr_flags;
 
   bufferlist bl;
+  assert (value || size == 0);
   bl.append((const char*)value, size);
   req->set_data(bl);
 


### PR DESCRIPTION
Fixes the Coverity Scan Report:

```
** 1405275 Dereference after null check
CID 1405275 (#1 of 1): Dereference after null check (FORWARD_NULL)
5. var_deref_model: Passing null pointer value to append, which dereferences it.
```
Signed-off-by: Amit Kumar amitkuma@redhat.com