### PR TITLE
ceph: wait for maps before doing 'ceph tell ... help'

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -355,6 +355,9 @@ def do_extended_help(parser, args, target, partial):
                          partial=partial))
 
     def help_for_target(target, partial=None):
+        # wait for osdmap because we know this is sent after the mgrmap
+        # and monmap (it's alphabetical).
+        cluster_handle.wait_for_latest_osdmap()
         ret, outbuf, outs = json_command(cluster_handle, target=target,
                                          prefix='get_command_descriptions',
                                          timeout=10)


### PR DESCRIPTION
If we don't have a mgrmap yet (usually we do, but it's racy) MgrClient
will assume EACCES if we try to send a command.  This can lead to
EACCES from 'ceph tell mgr help'.

The mon sends maps in alphanumeric order, so waiting for osdmap will
include mgrmap and fsmap.  That's everything (current) except servicemap,
but we can't 'tell' those anyway.

Fixes: http://tracker.ceph.com/issues/20113
Signed-off-by: Sage Weil <sage@redhat.com>