### PR TITLE
qa/rgw: disable lifecycle tests because of expiration failures

### DIFF
--- a/qa/tasks/s3tests.py
+++ b/qa/tasks/s3tests.py
@@ -228,7 +228,7 @@ def run_tests(ctx, config):
     """
     assert isinstance(config, dict)
     testdir = teuthology.get_testdir(ctx)
-    attrs = ["!fails_on_rgw"]
+    attrs = ["!fails_on_rgw", "!lifecycle"]
     for client, client_config in config.iteritems():
         args = [
             'S3TEST_CONF={tdir}/archive/s3-tests.{client}.conf'.format(tdir=testdir, client=client),


### PR DESCRIPTION
lifecycle expiration tests are too reliant on timing, and have been failing consistently for a long time