### PR TITLE
mgr/dashboard: fix pool size base conversion

### DIFF
--- a/src/pybind/mgr/dashboard/filesystem.html
+++ b/src/pybind/mgr/dashboard/filesystem.html
@@ -246,8 +246,8 @@
                         <tr rv-each-pool="filesystem.pools">
                             <td>{pool.pool}</td>
                             <td>{pool.type}</td>
-                            <td>{pool.used | dimless}</td>
-                            <td>{pool.avail | dimless}</td>
+                            <td>{pool.used | dimless_binary}</td>
+                            <td>{pool.avail | dimless_binary}</td>
                             <td>
                                 <div class="progress"
                                      style="width: 100px; height: 20px;">

--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -332,7 +332,7 @@
                             </thead>
                             <tbody>
                             <tr rv-each-pool="pools">
-                                <td style="text-align: right;">
+                                <td>
                                     {pool.pool_name}
                                 </td>
                                 <td rv-style="pool.pg_status | pg_status_style">

--- a/src/pybind/mgr/dashboard/health.html
+++ b/src/pybind/mgr/dashboard/health.html
@@ -339,8 +339,8 @@
                                     {pool.pg_status | pg_status}
                                 </td>
                                 <td>
-                                    {pool.stats.bytes_used.latest | dimless} /
-                                    {pool.stats.max_avail.latest | dimless }
+                                    {pool.stats.bytes_used.latest | dimless_binary } /
+                                    {pool.stats.max_avail.latest | dimless_binary }
                                 </td>
                                 <td>
                                     {pool.stats.rd_bytes.rate | dimless } rd, {


### PR DESCRIPTION
Signed-off-by: Yixing Yan yanyx@umcloud.com
the origin is as blew
![image](https://user-images.githubusercontent.com/12455492/28905384-f8b72914-7842-11e7-87a5-49ef7e152eee.png)

![image](https://user-images.githubusercontent.com/12455492/28905414-1b9feeb6-7843-11e7-8b31-52edda456c72.png)
The pool size is not same as ceph df 

After using the dimless_binary function, the pool size is correct. 
![image](https://user-images.githubusercontent.com/12455492/28905487-81714cda-7843-11e7-90fe-6b572fead808.png)
