### PR TITLE
pybind: fix block's pool sub menu

### DIFF
--- a/src/pybind/mgr/dashboard/base.html
+++ b/src/pybind/mgr/dashboard/base.html
@@ -389,9 +389,9 @@
                 <li rv-each-pool="rbd_pools">
                   <a rv-href="pool.url"><i class="fa fa-circle-o"></i> {pool.name}</a>
                 </li>
+                <li class="ceph-none-found" rv-hide="rbd_pools | length">None found</li>
               </ul>
             </li>
-            <li class="ceph-none-found" rv-hide="rbd_pools | length">None found</li>
           </ul>
         </li>
         <li class="treeview{%if path_info.startswith(('/filesystem/', '/clients/'))%} active{%endif%}">


### PR DESCRIPTION
Signed-off-by: Yixing Yan yanyx@umcloud.com
If there is no rbd_pool, the block's pool sub menu should have a "None found" item, but the item belong with the block menu .
![image](https://user-images.githubusercontent.com/12455492/28908098-2891fa04-7854-11e7-85cb-2c44a40a90d1.png)
Fixed as blew:
![image](https://user-images.githubusercontent.com/12455492/28908064-ff9523a6-7853-11e7-9619-05058284ad31.png)
