### PR TITLE
libradosstriper: Initialize member variable m_writeRc in WriteCompletionData

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -274,7 +274,7 @@ WriteCompletionData::WriteCompletionData
  librados::AioCompletionImpl *userCompletion,
  int n) :
   CompletionData(striper, soid, lockCookie, userCompletion, n), m_safe(0),
-  m_unlockCompletion(0) {
+  m_unlockCompletion(0), m_writeRc(0) {
   if (userCompletion) {
     m_safe = new librados::IoCtxImpl::C_aio_Complete(userCompletion);
   }


### PR DESCRIPTION
Fixes the Coverity Scan Report:

>** 1414521 Uninitialized scalar field
CID 1414521 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>3. uninit_member: Non-static class member m_writeRc is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com