### PR TITLE
msg: Initialize member variables in Infiniband

### DIFF
--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -217,14 +217,14 @@ class Infiniband {
   };
 
  private:
-  uint32_t max_send_wr;
-  uint32_t max_recv_wr;
-  uint32_t max_sge;
-  uint8_t  ib_physical_port;
-  MemoryManager* memory_manager;
-  ibv_srq* srq;             // shared receive work queue
-  Device *device;
-  ProtectionDomain *pd;
+  uint32_t max_send_wr = 0;
+  uint32_t max_recv_wr = 0;
+  uint32_t max_sge = 0;
+  uint8_t  ib_physical_port = 0;
+  MemoryManager* memory_manager = nullptr;
+  ibv_srq* srq = nullptr;             // shared receive work queue
+  Device *device = NULL;
+  ProtectionDomain *pd = NULL;
   DeviceList *device_list = nullptr;
   RDMADispatcher *dispatcher = nullptr;
   void wire_gid_to_gid(const char *wgid, union ibv_gid *gid);


### PR DESCRIPTION
Fixes:

>1414516 Uninitialized pointer field
>2. uninit_member: Non-static class member max_send_wr is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member max_recv_wr is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member max_sge is not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member ib_physical_port is not initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member memory_manager is not initialized in this constructor nor in any functions that it calls.
>12. uninit_member: Non-static class member srq is not initialized in this constructor nor in any functions that it calls.
>14. uninit_member: Non-static class member device is not initialized in this constructor nor in any functions that it calls.

>CID 1414516 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>16. uninit_member: Non-static class member pd is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com