### PR TITLE
msg: Remove unused variable perf_counter in RDMAStack

### DIFF
--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -300,7 +300,6 @@ class RDMAServerSocketImpl : public ServerSocketImpl {
 class RDMAStack : public NetworkStack {
   vector<std::thread> threads;
   RDMADispatcher *dispatcher;
-  PerfCounters *perf_counter;
 
   std::atomic<bool> fork_finished = {false};
 


### PR DESCRIPTION
Fixes:

>1414515 Uninitialized pointer field
>CID 1414515 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>22. uninit_member: Non-static class member perf_counter is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com