### PR TITLE
osd: move clone_overlap modification out of the "is_present_clone" condition block

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7237,12 +7237,13 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
      * it's not included in the stats */
     hobject_t last_clone_oid = soid;
     last_clone_oid.snap = ctx->new_snapset.clone_overlap.rbegin()->first;
+    interval_set<uint64_t> &newest_overlap = ctx->new_snapset.clone_overlap.rbegin()->second;
+    ctx->modified_ranges.intersection_of(newest_overlap);
+    newest_overlap.subtract(ctx->modified_ranges);
+
     if (is_present_clone(last_clone_oid)) {
-      interval_set<uint64_t> &newest_overlap = ctx->new_snapset.clone_overlap.rbegin()->second;
-      ctx->modified_ranges.intersection_of(newest_overlap);
       // modified_ranges is still in use by the clone
       add_interval_usage(ctx->modified_ranges, ctx->delta_stats);
-      newest_overlap.subtract(ctx->modified_ranges);
     }
   }
   


### PR DESCRIPTION
osd: move clone_overlap modification out of the "is_present_clone"
condition block

"is_present_clone" should be used to determine whether the OP
should be included in the stats, not to determine whether the
clone_overlap should be modified.

Fixes: http://tracker.ceph.com/issues/20896
Signed-off-by: Xuehan Xu <xxhdx1985126@163.com>