### PR TITLE
qa/suites/rados/mgr/tasks/failover: whitelist

### DIFF
--- a/qa/suites/rados/mgr/tasks/failover.yaml
+++ b/qa/suites/rados/mgr/tasks/failover.yaml
@@ -9,6 +9,8 @@ tasks:
         - overall HEALTH_
         - \(MGR_DOWN\)
         - \(PG_
+        - replacing it with standby
+        - No standby daemons available
   - cephfs_test_runner:
       modules:
         - tasks.mgr.test_failover

--- a/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
+++ b/qa/suites/rados/monthrash/workloads/rados_api_tests.yaml
@@ -4,11 +4,13 @@ overrides:
       - reached quota
       - overall HEALTH_
       - \(CACHE_POOL_NO_HIT_SET\)
+      - \(CACHE_POOL_NEAR_FULL\)
       - \(POOL_FULL\)
       - \(REQUEST_SLOW\)
       - \(MON_DOWN\)
       - \(PG_
       - \(POOL_APP_NOT_ENABLED\)
+      - \(SMALLER_PGP_NUM\)
     conf:
       global:
         debug objecter: 20


### PR DESCRIPTION
remote/smithi025/log/ceph.log.gz:2017-08-03 07:02:15.049074 mon.b mon.0 172.21.15.25:6789/0 197 : cluster [INF] Manager daemon x is unresponsive, replacing it with standby daemon y
remote/smithi025/log/ceph.log.gz:2017-08-03 07:03:10.078032 mon.b mon.0 172.21.15.25:6789/0 226 : cluster [WRN] Manager daemon x is unresponsive.  No standby daemons available.

x and y may be swapped, so whitelist the rest of the string.

Signed-off-by: Sage Weil <sage@redhat.com>