### PR TITLE
rgw: honor the tenant part of rgw_bucket during comparisons.

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1066,10 +1066,16 @@ struct rgw_bucket {
   static void generate_test_instances(list<rgw_bucket*>& o);
 
   bool operator<(const rgw_bucket& b) const {
-    return name.compare(b.name) < 0;
+    if (tenant == b.tenant) {
+      return name < b.name;
+    } else {
+      return tenant < b.tenant;
+    }
   }
+
   bool operator==(const rgw_bucket& b) const {
-    return (name == b.name) && (bucket_id == b.bucket_id);
+    return (tenant == b.tenant) && (name == b.name) && \
+           (bucket_id == b.bucket_id);
   }
 };
 WRITE_CLASS_ENCODER(rgw_bucket)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20897
Signed-off-by: Radoslaw Zarzynski <rzarzyns@redhat.com>