### PR TITLE
qa: timeout when waiting for mgr to be available in healthy()

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1225,9 +1225,9 @@ def healthy(ctx, config):
     log.info('Waiting until %s daemons up and pgs clean...', cluster_name)
     manager = ctx.managers[cluster_name]
     try:
-        manager.wait_for_mgr_available()
-    except run.CommandFailedError:
-        log.info('ignoring mgr wait error, probably testing upgrade')
+        manager.wait_for_mgr_available(timeout=30)
+    except (run.CommandFailedError, AssertionError) as e:
+        log.info('ignoring mgr wait error, probably testing upgrade: %s', e)
 
     firstmon = teuthology.get_first_mon(ctx, config, cluster_name)
     (mon0_remote,) = ctx.cluster.only(firstmon).remotes.keys()


### PR DESCRIPTION
Otherwise during upgrades we wait forever.

This fixes some of the upgrade-jewel-x failures, the remaining ones are the cli not getting a correct list of commands and failing to 'pg dump' with EINVAL.