### PR TITLE
osd/PGLog: avoid infinite loop if missing version is corrupted

### DIFF
--- a/src/osd/PGLog.h
+++ b/src/osd/PGLog.h
@@ -758,6 +758,7 @@ public:
 	   missing.get_items().at(
 	     missing.get_rmissing().begin()->second
 	     ).need) {
+      assert(log.complete_to != log.log.end());
       ++log.complete_to;
     }
     assert(log.complete_to != log.log.end());


### PR DESCRIPTION
Signed-off-by: Josh Durgin <jdurgin@redhat.com>