### PR TITLE
qa/clusters/fixed-[23]: 4 osds per node, not 3

### DIFF
--- a/qa/clusters/fixed-2.yaml
+++ b/qa/clusters/fixed-2.yaml
@@ -3,7 +3,7 @@ roles:
 - [mon.b, mgr.x, osd.4, osd.5, osd.6, osd.7, client.1]
 openstack:
 - volumes: # attached to each instance
-    count: 3
+    count: 4
     size: 10 # GB
 overrides:
   ceph:

--- a/qa/clusters/fixed-3.yaml
+++ b/qa/clusters/fixed-3.yaml
@@ -1,10 +1,10 @@
 roles:
-- [mon.a, mon.c, mgr.x, osd.0, osd.1, osd.2]
-- [mon.b, mgr.y, osd.3, osd.4, osd.5]
+- [mon.a, mon.c, mgr.x, osd.0, osd.1, osd.2, osd.3]
+- [mon.b, mgr.y, osd.4, osd.5, osd.6, osd.7]
 - [client.0]
 openstack:
 - volumes: # attached to each instance
-    count: 3
+    count: 4
     size: 10 # GB
 overrides:
   ceph:

--- a/qa/suites/rbd/librbd/clusters/openstack.yaml
+++ b/qa/suites/rbd/librbd/clusters/openstack.yaml
@@ -1,4 +1,4 @@
 openstack:
   - volumes: # attached to each instance
-      count: 3
+      count: 4
       size: 30 # GB

--- a/qa/suites/rbd/qemu/clusters/openstack.yaml
+++ b/qa/suites/rbd/qemu/clusters/openstack.yaml
@@ -4,5 +4,5 @@ openstack:
       ram: 30000 # MB
       cpus: 1
     volumes: # attached to each instance
-      count: 3
+      count: 4
       size: 30 # GB

--- a/qa/suites/smoke/basic/clusters/openstack.yaml
+++ b/qa/suites/smoke/basic/clusters/openstack.yaml
@@ -4,5 +4,5 @@ openstack:
       ram: 8000 # MB
       cpus: 1
     volumes: # attached to each instance
-      count: 3
+      count: 4
       size: 10 # GB


### PR DESCRIPTION
Smithi have 4 nvme partitions available for use.

Signed-off-by: Sage Weil <sage@redhat.com>