### PR TITLE
put all lib*_tp.so* in a separate debian package 

### DIFF
--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -6,8 +6,6 @@ usr/bin/ceph-objectstore-tool
 usr/bin/ceph-osd
 usr/bin/ceph_objectstore_bench
 usr/lib/ceph/ceph-osd-prestart.sh
-usr/lib/libos_tp.so*
-usr/lib/libosd_tp.so*
 usr/lib/python*/dist-packages/ceph_disk*
 usr/sbin/ceph-disk
 usr/share/man/man8/ceph-clsinfo.8

--- a/debian/ceph-trace.install
+++ b/debian/ceph-trace.install
@@ -1,0 +1,1 @@
+usr/lib/lib*_tp.so*

--- a/debian/control
+++ b/debian/control
@@ -232,6 +232,7 @@ Description: debugging symbols for ceph-mon
 Package: ceph-osd
 Architecture: linux-any
 Depends: ceph-base (= ${binary:Version}),
+         ceph-trace (= ${binary:Version}),
          parted,
          ${misc:Depends},
          ${python:Depends},
@@ -474,6 +475,14 @@ Description: debugging symbols for librados
  store using a simple file-like interface.
  .
  This package contains debugging symbols for librados.
+
+Package: ceph-trace
+Architecture: linux-any
+Section: libs
+Depends: ${misc:Depends}, ${shlibs:Depends}
+Description: ceph lttng trace library
+ All lttng trace event library are contained in this package including
+ user added.
 
 Package: librados-dev
 Architecture: linux-any

--- a/debian/librados-dev.install
+++ b/debian/librados-dev.install
@@ -10,5 +10,4 @@ usr/include/rados/page.h
 usr/include/rados/rados_types.h
 usr/include/rados/rados_types.hpp
 usr/lib/librados.so
-usr/lib/librados_tp.so
 usr/share/man/man8/librados-config.8

--- a/debian/librados2.install
+++ b/debian/librados2.install
@@ -1,3 +1,2 @@
 usr/lib/ceph/libceph-common.so*
 usr/lib/librados.so.*
-usr/lib/librados_tp.so.*

--- a/debian/librbd-dev.install
+++ b/debian/librbd-dev.install
@@ -2,4 +2,3 @@ usr/include/rbd/features.h
 usr/include/rbd/librbd.h
 usr/include/rbd/librbd.hpp
 usr/lib/librbd.so
-usr/lib/librbd_tp.so

--- a/debian/librbd1.install
+++ b/debian/librbd1.install
@@ -1,2 +1,1 @@
 usr/lib/librbd.so.*
-usr/lib/librbd_tp.so.*


### PR DESCRIPTION
current debian package not install libeventtrace_tp.so* , libpg_tp.so*, libobjectstore_tp.so*  etc. and other user added lib*_tp.so*,  to solve this problem completely, move all lib*_tp.so* in ceph-trace.install, so all lib*_tp.so* library will be put in a separate package, then debian package will automatically install all lib*_tp.so*  to /usr/lib/.

Signed-off-by: chunmei <chunmei.liu@intel.com>