### PR TITLE
common/buffer: off-by-one error in max iov length blocking

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -2382,7 +2382,7 @@ int buffer::list::write_fd(int fd) const
     }
     ++p;
 
-    if (iovlen == IOV_MAX-1 ||
+    if (iovlen == IOV_MAX ||
 	p == _buffers.end()) {
       iovec *start = iov;
       int num = iovlen;


### PR DESCRIPTION
The loop in write_fd stops at IOV_MAX-1; it could go to IOV_MAX
and write in more-natural sizes without extra tail writes.

Fixes: http://tracker.ceph.com/issues/20907
Signed-off-by: Dan Mick <dan.mick@redhat.com>