### PR TITLE
qa: Remove dangling link

### DIFF
--- a/qa/suites/rados/thrash-erasure-code-big/workloads/ec-rados-plugin=jerasure-k=4-m=2.yaml
+++ b/qa/suites/rados/thrash-erasure-code-big/workloads/ec-rados-plugin=jerasure-k=4-m=2.yaml
@@ -1,1 +1,0 @@
-../../../../erasure-code/ec-rados-plugin=jerasure-k=4-m=2.yaml


### PR DESCRIPTION
Couldn't schedule teuthology rados suite with this broken link in the tree.