### PR TITLE
test/fio: generate db histogram to help debug rocksdb performance

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -95,6 +95,11 @@ struct Engine {
         ostr << "FIO get_db_statistics ";
         f->flush(ostr);
       }
+      
+      ostr << "Generate db histogram: ";
+      os->generate_db_histogram(f);
+      f->flush(ostr);
+
       delete f;
       os->umount();
       dout(0) <<  ostr.str() << dendl;


### PR DESCRIPTION
The content statistic of rocksdb is very useful to tuning rocksdb. And in future, after multi column family is supported, we will need this info more to help tuning. Add this dump in code so that we don't need to add it manually every time.

Result like below:

Generate db histogram: {
  "num_onodes" : 32768,
  "num_shards" : 330539,
  "num_super": 7,
  "num_coll": 128,
  "num_omap": 0,
  "num_deferred": 0,
  "num_alloc": 262213,
  "num_stat": 1,
  "num_shared_shards": 0,
  "num_others": 0,
  "max_value_size": 1195,
  "total_key_size": 33046398,
  "total_value_size": 198801478
}

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Xiaoyan Li <xiaoyan.li@intel.com>