### PR TITLE
messages: Initialize members in MMDSTableRequest

### DIFF
--- a/src/messages/MMDSTableRequest.h
+++ b/src/messages/MMDSTableRequest.h
@@ -21,9 +21,9 @@
 
 class MMDSTableRequest : public Message {
  public:
-  __u16 table;
-  __s16 op;
-  uint64_t reqid;
+  __u16 table = 0;
+  __s16 op = 0;
+  uint64_t reqid = 0;
   bufferlist bl;
 
   MMDSTableRequest() : Message(MSG_MDS_TABLE_REQUEST) {}


### PR DESCRIPTION
Fixes coverity Issue:

>** 717293 Uninitialized scalar field
>2. uninit_member: Non-static class member table is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.

>CID 717293 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member reqid is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com