### PR TITLE
messages: Initializing uninitialized members MMonGetVersion

### DIFF
--- a/src/messages/MMonGetVersion.h
+++ b/src/messages/MMonGetVersion.h
@@ -48,7 +48,7 @@ public:
     ::decode(what, p);
   }
 
-  ceph_tid_t handle;
+  ceph_tid_t handle = 0;
   string what;
 
 private:


### PR DESCRIPTION
Fixes coverity Issue:

>** 717296 Uninitialized scalar field
>CID 717296 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member handle is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com