### PR TITLE
osd/OSD: tolerate any 'set-device-class' error on OSD startup

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -3539,14 +3539,12 @@ int OSD::update_crush_device_class()
     string("\"ids\": [\"") + stringify(whoami) + string("\"]}");
 
   r = mon_cmd_maybe_osd_create(cmd);
-  // we may not have a real osdmap on first boot, so we can't check if
-  // require-osd-release is set to luminous yet. Instead, ignore
-  // EINVAL.
-  if (r == -EPERM || r == -EINVAL) {
-    r = 0;
-  }
-
-  return r;
+  // the above cmd can fail for various reasons, e.g.:
+  //   (1) we are connecting to a pre-luminous monitor
+  //   (2) user manually specify a class other than
+  //       'ceph-disk prepare --crush-device-class'
+  // simply skip result-checking for now
+  return 0;
 }
 
 void OSD::write_superblock(ObjectStore::Transaction& t)


### PR DESCRIPTION
We might use 'ceph-disk prepare --crush-device-class' to specify a class
for an OSD and then manually change its class to quite another.

This will prevent OSD from booting on next startup:

```
mon_cmd_maybe_osd_create fail: 'osd.2 has already bound to class 'class2', can not reset class to 'class1'; use 'ceph osd crush rm-device-cl
ass <osd>' to remove old class first': (16) Device or resource busy
2017-08-04 15:52:41.997158 7f7c55aa4d00 -1 osd.2 231 init unable to update_crush_device_class: (16) Device or resource busy
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>