### PR TITLE
messages: Initializing uninitialized members MMonGetVersionReply

### DIFF
--- a/src/messages/MMonGetVersionReply.h
+++ b/src/messages/MMonGetVersionReply.h
@@ -53,9 +53,9 @@ public:
       ::decode(oldest_version, p);
   }
 
-  ceph_tid_t handle;
-  version_t version;
-  version_t oldest_version;
+  ceph_tid_t handle = 0;
+  version_t version = 0;
+  version_t oldest_version = 0;
 
 private:
   ~MMonGetVersionReply() override {}


### PR DESCRIPTION
Fixes coverity Issue:

>** 717297 Uninitialized scalar field
>2. uninit_member: Non-static class member handle is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member version is not initialized in this constructor nor in any functions that it calls.

>CID 717297 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member oldest_version is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com