### PR TITLE
messages: Initializing uninitialized members MMonPaxos

### DIFF
--- a/src/messages/MMonPaxos.h
+++ b/src/messages/MMonPaxos.h
@@ -47,18 +47,18 @@ class MMonPaxos : public Message {
     }
   }
 
-  epoch_t epoch;   // monitor epoch
-  __s32 op;          // paxos op
+  epoch_t epoch = 0;   // monitor epoch
+  __s32 op = 0;          // paxos op
 
-  version_t first_committed;  // i've committed to
-  version_t last_committed;  // i've committed to
-  version_t pn_from;         // i promise to accept after
-  version_t pn;              // with with proposal
-  version_t uncommitted_pn;     // previous pn, if we are a LAST with an uncommitted value
+  version_t first_committed = 0;  // i've committed to
+  version_t last_committed = 0;  // i've committed to
+  version_t pn_from = 0;         // i promise to accept after
+  version_t pn = 0;              // with with proposal
+  version_t uncommitted_pn = 0;     // previous pn, if we are a LAST with an uncommitted value
   utime_t lease_timestamp;
   utime_t sent_timestamp;
 
-  version_t latest_version;
+  version_t latest_version = 0;
   bufferlist latest_value;
 
   map<version_t,bufferlist> values;


### PR DESCRIPTION
Fixes coverity Issue:

>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member first_committed is not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member last_committed is not initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member pn_from is not initialized in this constructor nor in any functions that it calls.
>12. uninit_member: Non-static class member pn is not initialized in this constructor nor in any functions that it calls.
>14. uninit_member: Non-static class member uncommitted_pn is not initialized in this constructor nor in any functions that it calls.

>CID 717298 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>16. uninit_member: Non-static class member latest_version is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com