### PR TITLE
messages: Initializing uninitialized members MMonProbe

### DIFF
--- a/src/messages/MMonProbe.h
+++ b/src/messages/MMonProbe.h
@@ -47,14 +47,14 @@ public:
   }
   
   uuid_d fsid;
-  int32_t op;
+  int32_t op = 0;
   string name;
   set<int32_t> quorum;
   bufferlist monmap_bl;
-  version_t paxos_first_version;
-  version_t paxos_last_version;
-  bool has_ever_joined;
-  uint64_t required_features;
+  version_t paxos_first_version = 0;
+  version_t paxos_last_version = 0;
+  bool has_ever_joined = 0;
+  uint64_t required_features = 0;
 
   MMonProbe()
     : Message(MSG_MON_PROBE, HEAD_VERSION, COMPAT_VERSION) {}


### PR DESCRIPTION
Fixes coverity Issue:

>** 717299 Uninitialized scalar field
>2. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member paxos_first_version is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member paxos_last_version is not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member has_ever_joined is not initialized in this constructor nor in any functions that it calls.

>CID 717299 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>10. uninit_member: Non-static class member required_features is not initialized in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar amitkuma@redhat.com