### PR TITLE
messages: Initializing uninitialized members MOSDAlive

### DIFF
--- a/src/messages/MOSDAlive.h
+++ b/src/messages/MOSDAlive.h
@@ -21,7 +21,7 @@
 
 class MOSDAlive : public PaxosServiceMessage {
  public:
-  epoch_t want;
+  epoch_t want = 0;
 
   MOSDAlive(epoch_t h, epoch_t w) : PaxosServiceMessage(MSG_OSD_ALIVE, h), want(w) { }
   MOSDAlive() : PaxosServiceMessage(MSG_OSD_ALIVE, 0) {}


### PR DESCRIPTION
Fixes coverity Issue:

>** 717300 Uninitialized scalar field
>CID 717300 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member want is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com