### PR TITLE
messages: Initializing uninitialized members module messages

### DIFF
--- a/src/messages/MOSDFailure.h
+++ b/src/messages/MOSDFailure.h
@@ -33,9 +33,9 @@ class MOSDFailure : public PaxosServiceMessage {
   
   uuid_d fsid;
   entity_inst_t target_osd;
-  __u8 flags;
-  epoch_t       epoch;
-  int32_t failed_for;  // known to be failed since at least this long
+  __u8 flags = 0;
+  epoch_t       epoch = 0;
+  int32_t failed_for = 0;  // known to be failed since at least this long
 
   MOSDFailure() : PaxosServiceMessage(MSG_OSD_FAILURE, 0, HEAD_VERSION) { }
   MOSDFailure(const uuid_d &fs, const entity_inst_t& f, int duration, epoch_t e)

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -28,7 +28,7 @@ class MOSDMap : public Message {
   uuid_d fsid;
   map<epoch_t, bufferlist> maps;
   map<epoch_t, bufferlist> incremental_maps;
-  epoch_t oldest_map, newest_map;
+  epoch_t oldest_map =0, newest_map = 0;
 
   epoch_t get_first() const {
     epoch_t e = 0;

--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -37,11 +37,11 @@ class MOSDOp : public MOSDFastDispatchOp {
   static const int COMPAT_VERSION = 3;
 
 private:
-  uint32_t client_inc;
-  __u32 osdmap_epoch;
-  __u32 flags;
+  uint32_t client_inc = 0;
+  __u32 osdmap_epoch = 0;
+  __u32 flags = 0;
   utime_t mtime;
-  int32_t retry_attempt;   // 0 is first attempt.  -1 if we don't know.
+  int32_t retry_attempt = -1;   // 0 is first attempt.  -1 if we don't know.
 
   hobject_t hobj;
   spg_t pgid;

--- a/src/messages/MOSDOpReply.h
+++ b/src/messages/MOSDOpReply.h
@@ -38,13 +38,13 @@ class MOSDOpReply : public Message {
   object_t oid;
   pg_t pgid;
   vector<OSDOp> ops;
-  int64_t flags;
+  int64_t flags = 0;
   errorcode32_t result;
   eversion_t bad_replay_version;
   eversion_t replay_version;
-  version_t user_version;
-  epoch_t osdmap_epoch;
-  int32_t retry_attempt;
+  version_t user_version = 0;
+  epoch_t osdmap_epoch = 0;
+  int32_t retry_attempt = -1;
   bool do_redirect;
   request_redirect_t redirect;
 

--- a/src/messages/MOSDPGBackfill.h
+++ b/src/messages/MOSDPGBackfill.h
@@ -35,8 +35,8 @@ public:
     }
   }
 
-  __u32 op;
-  epoch_t map_epoch, query_epoch;
+  __u32 op = 0;
+  epoch_t map_epoch = 0, query_epoch = 0;
   spg_t pgid;
   hobject_t last_backfill;
   pg_stat_t stats;

--- a/src/messages/MOSDPGCreate.h
+++ b/src/messages/MOSDPGCreate.h
@@ -28,7 +28,7 @@ struct MOSDPGCreate : public Message {
   const static int HEAD_VERSION = 3;
   const static int COMPAT_VERSION = 3;
 
-  version_t          epoch;
+  version_t          epoch = 0;
   map<pg_t,pg_create_t> mkpg;
   map<pg_t,utime_t> ctimes;
 


### PR DESCRIPTION
Fixes coverity Issue:

>** 2. uninit_member: Non-static class member flags is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717301 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member failed_for is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member oldest_map is not initialized in this constructor nor in any functions that it calls.
>CID 717302 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member newest_map is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member client_inc is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member osdmap_epoch is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member flags is not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member retry_attempt is not initialized in this constructor nor in any functions that it calls.
>CID 717303 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>10. uninit_member: Non-static class member features is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member flags is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member user_version is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member osdmap_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717304 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>8. uninit_member: Non-static class member retry_attempt is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717305 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member query_epoch is not initialized in this constructor nor in any functions that it calls.

>CID 717306 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com