### PR TITLE
rgw_lc: add support for optional filter argument and make ID optional

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -67,7 +67,14 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
     op.mp_expiration = rule->get_mp_expiration().get_days();
   }
   op.dm_expiration = rule->get_dm_expiration();
-  auto ret = prefix_map.insert(pair<string, lc_op>(rule->get_prefix(), op));
+
+  std::string prefix;
+  if (rule->get_filter().has_prefix()){
+    prefix = rule->get_filter().get_prefix();
+  } else {
+    prefix = rule->get_prefix();
+  }
+  auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
   return ret.second;
 }
 

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -26,6 +26,25 @@ public:
   string& to_str() { return data; }
 };
 
+class LCFilter_S3 : public LCFilter, public XMLObj
+{
+ public:
+  ~LCFilter_S3() override {}
+  string& to_str() { return data; }
+  void to_xml(ostream& out){
+    out << "<Filter>";
+      if (!prefix.empty())
+        out << "<Prefix>" << prefix << "<Prefix>";
+    out << "</Filter>";
+  }
+  void dump_xml(Formatter *f) const {
+    f->open_object_section("Filter");
+    if (!prefix.empty())
+      encode_xml("Prefix", prefix, f);
+    f->close_section(); // Filter
+  }
+};
+
 class LCStatus_S3 : public XMLObj
 {
 public:
@@ -150,7 +169,13 @@ public:
   void dump_xml(Formatter *f) const {
     f->open_object_section("Rule");
     encode_xml("ID", id, f);
-    encode_xml("Prefix", prefix, f);
+    // In case of an empty filter and an empty Prefix, we defer to Prefix.
+    if (!filter.empty()) {
+      const LCFilter_S3& lc_filter = static_cast<const LCFilter_S3&>(filter);
+      lc_filter.dump_xml(f);
+    } else {
+      encode_xml("Prefix", prefix, f);
+    }
     encode_xml("Status", status, f);
     if (!expiration.empty() || dm_expiration) {
       LCExpiration_S3 expir(expiration.get_days_str(), expiration.get_date(), dm_expiration);
@@ -164,6 +189,7 @@ public:
       const LCMPExpiration_S3& mp_expir = static_cast<const LCMPExpiration_S3&>(mp_expiration);
       mp_expir.dump_xml(f);
     }
+
     f->close_section(); // Rule
   }
 };


### PR DESCRIPTION
Support Filter tag in Lifecycle XML similar to AWS S3, while S3 docs
mention that this tag is mandatory, older clients still default to
Prefix, and S3 itself seems to relaxed in enforcing the rule, this
implementation also follows a similar pattern. Filter optionally
supports filtering via (multiple) Object Tags, this is still a TODO. The
current implementation of object tags is still as an object xattr, and
since the LC processing still iterates over the bucket index which
currently doesn't have any info. on tags, this requires some thought
into for implementing without a larger performance penalty

Fixes: http://tracker.ceph.com/issues/20872 & http://tracker.ceph.com/issues/19587
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>