### PR TITLE
messages: Initialize member variables

### DIFF
--- a/src/messages/MOSDPGInfo.h
+++ b/src/messages/MOSDPGInfo.h
@@ -23,7 +23,7 @@ class MOSDPGInfo : public Message {
   static const int HEAD_VERSION = 5;
   static const int COMPAT_VERSION = 1;
 
-  epoch_t epoch;
+  epoch_t epoch = 0;
 
 public:
   vector<pair<pg_notify_t,PastIntervals> > pg_list;

--- a/src/messages/MOSDPGLog.h
+++ b/src/messages/MOSDPGLog.h
@@ -23,12 +23,12 @@ class MOSDPGLog : public Message {
   static const int HEAD_VERSION = 5;
   static const int COMPAT_VERSION = 2;
 
-  epoch_t epoch;
+  epoch_t epoch = 0;
   /// query_epoch is the epoch of the query being responded to, or
   /// the current epoch if this is not being sent in response to a
   /// query. This allows the recipient to disregard responses to old
   /// queries.
-  epoch_t query_epoch;
+  epoch_t query_epoch = 0;
 
 public:
   shard_id_t to;

--- a/src/messages/MOSDPGNotify.h
+++ b/src/messages/MOSDPGNotify.h
@@ -28,7 +28,7 @@ class MOSDPGNotify : public Message {
   static const int HEAD_VERSION = 6;
   static const int COMPAT_VERSION = 2;
 
-  epoch_t epoch;
+  epoch_t epoch = 0;
   /// query_epoch is the epoch of the query being responded to, or
   /// the current epoch if this is not being sent in response to a
   /// query. This allows the recipient to disregard responses to old

--- a/src/messages/MOSDPGQuery.h
+++ b/src/messages/MOSDPGQuery.h
@@ -27,7 +27,7 @@ class MOSDPGQuery : public Message {
   static const int HEAD_VERSION = 4;
   static const int COMPAT_VERSION = 3;
 
-  version_t epoch;
+  version_t epoch = 0;
 
  public:
   version_t get_epoch() const { return epoch; }

--- a/src/messages/MOSDPGRemove.h
+++ b/src/messages/MOSDPGRemove.h
@@ -25,7 +25,7 @@ class MOSDPGRemove : public Message {
   static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 2;
 
-  epoch_t epoch;
+  epoch_t epoch = 0;
 
  public:
   vector<spg_t> pg_list;

--- a/src/messages/MOSDPGScan.h
+++ b/src/messages/MOSDPGScan.h
@@ -35,8 +35,8 @@ public:
     }
   }
 
-  __u32 op;
-  epoch_t map_epoch, query_epoch;
+  __u32 op = 0;
+  epoch_t map_epoch = 0, query_epoch = 0;
   pg_shard_t from;
   spg_t pgid;
   hobject_t begin, end;

--- a/src/messages/MOSDPGTemp.h
+++ b/src/messages/MOSDPGTemp.h
@@ -21,7 +21,7 @@
 
 class MOSDPGTemp : public PaxosServiceMessage {
  public:
-  epoch_t map_epoch;
+  epoch_t map_epoch = 0;
   map<pg_t, vector<int32_t> > pg_temp;
 
   MOSDPGTemp(epoch_t e) : PaxosServiceMessage(MSG_OSD_PGTEMP, e), map_epoch(e) { }

--- a/src/messages/MOSDPGTrim.h
+++ b/src/messages/MOSDPGTrim.h
@@ -23,7 +23,7 @@ class MOSDPGTrim : public Message {
   static const int COMPAT_VERSION = 2;
 
 public:
-  epoch_t epoch;
+  epoch_t epoch = 0;
   spg_t pgid;
   eversion_t trim_to;
 

--- a/src/messages/MOSDPing.h
+++ b/src/messages/MOSDPing.h
@@ -59,8 +59,8 @@ class MOSDPing : public Message {
   }
 
   uuid_d fsid;
-  epoch_t map_epoch;
-  __u8 op;
+  epoch_t map_epoch = 0;
+  __u8 op = 0;
   utime_t stamp;
   uint32_t min_message_size;
 

--- a/src/messages/MOSDRepScrub.h
+++ b/src/messages/MOSDRepScrub.h
@@ -30,7 +30,7 @@ struct MOSDRepScrub : public MOSDFastDispatchOp {
   spg_t pgid;             // PG to scrub
   eversion_t scrub_from; // only scrub log entries after scrub_from
   eversion_t scrub_to;   // last_update_applied when message sent
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   bool chunky;           // true for chunky scrubs
   hobject_t start;       // lower bound of scrub, inclusive
   hobject_t end;         // upper bound of scrub, exclusive

--- a/src/messages/MOSDScrub.h
+++ b/src/messages/MOSDScrub.h
@@ -29,8 +29,8 @@ struct MOSDScrub : public Message {
 
   uuid_d fsid;
   vector<pg_t> scrub_pgs;
-  bool repair;
-  bool deep;
+  bool repair = false;
+  bool deep = false;
 
   MOSDScrub() : Message(MSG_OSD_SCRUB, HEAD_VERSION, COMPAT_VERSION) {}
   MOSDScrub(const uuid_d& f, bool r, bool d) :

--- a/src/messages/MOSDSubOp.h
+++ b/src/messages/MOSDSubOp.h
@@ -30,7 +30,7 @@ class MOSDSubOp : public MOSDFastDispatchOp {
   static const int COMPAT_VERSION = 7;
 
 public:
-  epoch_t map_epoch;
+  epoch_t map_epoch = 0;
   
   // metadata from original request
   osd_reqid_t reqid;
@@ -41,14 +41,14 @@ public:
   hobject_t poid;
   object_locator_t oloc;
   
-  __u8 acks_wanted;
+  __u8 acks_wanted = 0;
 
   // op to exec
   vector<OSDOp> ops;
   utime_t mtime;
 
-  bool old_exists;
-  uint64_t old_size;
+  bool old_exists = false;
+  uint64_t old_size = 0;
   eversion_t old_version;
 
   SnapSet snapset;
@@ -71,7 +71,7 @@ public:
   interval_set<uint64_t> data_subset;
   map<hobject_t, interval_set<uint64_t>> clone_subsets;
 
-  bool first, complete;
+  bool first = false, complete = false;
 
   interval_set<uint64_t> data_included;
   ObjectRecoveryInfo recovery_info;

--- a/src/messages/MOSDSubOpReply.h
+++ b/src/messages/MOSDSubOpReply.h
@@ -33,7 +33,7 @@ class MOSDSubOpReply : public MOSDFastDispatchOp {
   static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 public:
-  epoch_t map_epoch;
+  epoch_t map_epoch = 0;
   
   // subop metadata
   osd_reqid_t reqid;
@@ -44,8 +44,8 @@ public:
   vector<OSDOp> ops;
 
   // result
-  __u8 ack_type;
-  int32_t result;
+  __u8 ack_type = 0;
+  int32_t result = 0;
   
   // piggybacked osd state
   eversion_t last_complete_ondisk;

--- a/src/messages/MPGStats.h
+++ b/src/messages/MPGStats.h
@@ -23,7 +23,7 @@ public:
   uuid_d fsid;
   map<pg_t,pg_stat_t> pg_stat;
   osd_stat_t osd_stat;
-  epoch_t epoch;
+  epoch_t epoch = 0;
   utime_t had_map_for;
   
   MPGStats() : PaxosServiceMessage(MSG_PGSTATS, 0) {}

--- a/src/messages/MPoolOp.h
+++ b/src/messages/MPoolOp.h
@@ -25,12 +25,12 @@ class MPoolOp : public PaxosServiceMessage {
 
 public:
   uuid_d fsid;
-  __u32 pool;
+  __u32 pool = 0;
   string name;
-  __u32 op;
-  uint64_t auid;
+  __u32 op = 0;
+  uint64_t auid = 0;
   snapid_t snapid;
-  __s16 crush_rule;
+  __s16 crush_rule = 0;
 
   MPoolOp()
     : PaxosServiceMessage(CEPH_MSG_POOLOP, 0, HEAD_VERSION, COMPAT_VERSION) { }

--- a/src/messages/MPoolOpReply.h
+++ b/src/messages/MPoolOpReply.h
@@ -20,8 +20,8 @@
 class MPoolOpReply : public PaxosServiceMessage {
 public:
   uuid_d fsid;
-  __u32 replyCode;
-  epoch_t epoch;
+  __u32 replyCode = 0;
+  epoch_t epoch = 0;
   bufferlist response_data;
 
   MPoolOpReply() : PaxosServiceMessage(CEPH_MSG_POOLOP_REPLY, 0)


### PR DESCRIPTION
Fixes coverity Issue:
>CID 717307 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717308 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member query_epoch is not initialized in this constructor nor in any functions that it calls.

>CID 717310 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717311 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.

>CID 717312 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717313 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member query_epoch is not initialized in this constructor nor in any functions that it calls.

>CID 717314 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717315 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717316 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>CID 717317 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized in this constructor nor in any functions that it calls.
>2. uninit_member: Non-static class member repair is not initialized in this constructor nor in any functions that it calls.

>CID 717318 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member deep is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member acks_wanted is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member old_exists is not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member old_size is not initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member first is not initialized in this constructor nor in any functions that it calls.
>CID 717319 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>12. uninit_member: Non-static class member complete is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member map_epoch is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member ack_type is not initialized in this constructor nor in any functions that it calls.
>CID 717320 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member result is not initialized in this constructor nor in any functions that it calls.
>CID 717321 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls
>2. uninit_member: Non-static class member pool is not initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member op is not initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member auid is not initialized in this constructor nor in any functions that it calls.
>CID 717322 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>8. uninit_member: Non-static class member crush_rule is not initialized in this constructor nor in any functions that it calls.

>2. uninit_member: Non-static class member replyCode is not initialized in this constructor nor in any functions that it calls.
>CID 717323 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member epoch is not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com