### PR TITLE
rgw_op: Drop the Old LifecycleConfiguration from logs

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4753,12 +4753,6 @@ void RGWPutLC::execute()
     return;
   }
 
-  if (s->cct->_conf->subsys.should_gather(ceph_subsys_rgw, 15)) {
-    ldout(s->cct, 15) << "Old LifecycleConfiguration:";
-    config->to_xml(*_dout);
-    *_dout << dendl;
-  }
-
   op_ret = config->rebuild(store, new_config);
   if (op_ret < 0)
     return;


### PR DESCRIPTION
Since we're not printing the actual existing LifeCylceConfiguration
merely printing the parsed XML vs the Validated XML, and the supplied
XML is already printed in the previous line, which makes this sort of
redundant. We could print the existing LC configuration from the bucket
attrs if necessary

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>