### PR TITLE
qa/tasks/ceph: wait longer for scrub

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1029,8 +1029,8 @@ def osd_scrub_pgs(ctx, config):
     indicate the last scrub completed.  Time out if no progess is made
     here after two minutes.
     """
-    retries = 20
-    delays = 10
+    retries = 40
+    delays = 20
     cluster_name = config['cluster']
     manager = ctx.managers[cluster_name]
     all_clean = False


### PR DESCRIPTION
I saw a couple failures where nothing appeared to be wrong but scrub hadn't finished yet.