### PR TITLE
Changing 'int const' to 'const int'

### DIFF
--- a/src/cls/lua/cls_lua.cc
+++ b/src/cls/lua/cls_lua.cc
@@ -643,7 +643,7 @@ static const luaL_Reg clslua_lib[] = {
 };
 
 /*
- * Set int const in table at top of stack
+ * Set const int in table at top of stack
  */
 #define SET_INT_CONST(var) do { \
   lua_pushinteger(L, var); \

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1262,7 +1262,7 @@ public:
     }
   }
 
-  bool ruleset_exists(int const ruleset) const {
+  bool ruleset_exists(const int ruleset) const {
     for (size_t i = 0; i < crush->max_rules; ++i) {
       if (rule_exists(i) && crush->rules[i]->mask.ruleset == ruleset) {
 	return true;

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -905,7 +905,7 @@ void MDLog::_recovery_thread(MDSInternalContextBase *completion)
   // If the pointer object is not present, then create it with
   // front = default ino and back = null
   JournalPointer jp(mds->get_nodeid(), mds->mdsmap->get_metadata_pool());
-  int const read_result = jp.load(mds->objecter);
+  const int read_result = jp.load(mds->objecter);
   if (read_result == -ENOENT) {
     inodeno_t const default_log_ino = MDS_INO_LOG_OFFSET + mds->get_nodeid();
     jp.front = default_log_ino;

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -826,7 +826,7 @@ void Session::notify_cap_release(size_t n_caps)
  * in order to generate health metrics if the session doesn't see
  * a commensurate number of calls to ::notify_cap_release
  */
-void Session::notify_recall_sent(int const new_limit)
+void Session::notify_recall_sent(const int new_limit)
 {
   if (recalled_at.is_zero()) {
     // Entering recall phase, set up counters so we can later

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -148,7 +148,7 @@ public:
   interval_set<inodeno_t> pending_prealloc_inos; // journaling prealloc, will be added to prealloc_inos
 
   void notify_cap_release(size_t n_caps);
-  void notify_recall_sent(int const new_limit);
+  void notify_recall_sent(const int new_limit);
   void clear_recalled_at();
 
   inodeno_t next_ino() const {

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -202,7 +202,7 @@ void MDSMonitor::encode_pending(MonitorDBStore::TransactionRef t)
       health.decode(bl_i);
     }
     for (const auto &metric : health.metrics) {
-      int const rank = info.rank;
+      const int rank = info.rank;
       health_check_t *check = &new_checks.get_or_add(
 	mds_metric_name(metric.type),
 	metric.sev,
@@ -850,7 +850,7 @@ void MDSMonitor::get_health(list<pair<health_status_t, string> >& summary,
     health.decode(bl_i);
 
     for (const auto &metric : health.metrics) {
-      int const rank = info.rank;
+      const int rank = info.rank;
       std::ostringstream message;
       message << "mds" << rank << ": " << metric.message;
       summary.push_back(std::make_pair(metric.sev, message.str()));

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3311,7 +3311,7 @@ int OSDMap::build_simple_optioned(CephContext *cct, epoch_t e, uuid_d &fsid,
 
   int poolbase = get_max_osd() ? get_max_osd() : 1;
 
-  int const default_replicated_rule = crush->get_osd_pool_default_crush_replicated_ruleset(cct);
+  const int default_replicated_rule = crush->get_osd_pool_default_crush_replicated_ruleset(cct);
   assert(default_replicated_rule >= 0);
 
   if (default_pool) {

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -1326,7 +1326,7 @@ void Objecter::handle_osd_map(MOSDMap *m)
     if (!op->session) {
       _calc_target(&op->target, nullptr);
       OSDSession *s = NULL;
-      int const r = _get_session(op->target.osd, &s, sul);
+      const int r = _get_session(op->target.osd, &s, sul);
       assert(r == 0);
       assert(s != NULL);
       op->session = s;

--- a/src/tools/cephfs/Dumper.cc
+++ b/src/tools/cephfs/Dumper.cc
@@ -63,7 +63,7 @@ int Dumper::recover_journal(Journaler *journaler)
   lock.Lock();
   journaler->recover(&cond);
   lock.Unlock();
-  int const r = cond.wait();
+  const int r = cond.wait();
 
   if (r < 0) { // Error
     derr << "error on recovery: " << cpp_strerror(r) << dendl;

--- a/src/tools/cephfs/JournalScanner.h
+++ b/src/tools/cephfs/JournalScanner.h
@@ -35,7 +35,7 @@ class JournalScanner
   librados::IoCtx &io;
 
   // Input constraints
-  int const rank;
+  const int rank;
   JournalFilter const filter;
 
   void gap_advance();


### PR DESCRIPTION
As per coding Guidelines 'const int' is recommended over 'int const'
See
> The C++ Core Guidelines
> https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md

Section

> NL.26: Use conventional const notation
Example:
const int x = 7;    // OK
int const y = 9;    // bad

>The C++ Core Guidelines are a collaborative effort led by Bjarne Stroustrup, much like the C++ language itself.
Note We are well aware that you could claim the **"bad" examples more logical** than the ones marked "OK", but they also confuse more people, especially novices relying on teaching material using the far more common, conventional OK style.

**As ever, remember** that the aim of these naming and layout rules is consistency and that aesthetics vary immensely.

Enforcement
Flag const used as a suffix for a type.

Signed-off-by: Amit Kumar amitkuma@redhat.com