### PR TITLE
qa/suites/rados/basic/tasks/rados_python: POOL_APP_NOT_ENABLED

### DIFF
--- a/qa/suites/rados/basic/tasks/rados_python.yaml
+++ b/qa/suites/rados/basic/tasks/rados_python.yaml
@@ -7,6 +7,7 @@ overrides:
     - \(PG_
     - \(OSD_
     - \(OBJECT_
+    - \(POOL_APP_NOT_ENABLED\)
 tasks:
 - workunit:
     clients:


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>