### PR TITLE
messages: Initialize member variables

### DIFF
--- a/src/messages/MMonHealth.h
+++ b/src/messages/MMonHealth.h
@@ -26,8 +26,8 @@ struct MMonHealth : public MMonQuorumService
     OP_TELL = 1,
   };
 
-  int service_type;
-  int service_op;
+  int service_type = 0;
+  int service_op = 0;
 
   // service specific data
   DataStats data_stats;

--- a/src/messages/MMonSync.h
+++ b/src/messages/MMonSync.h
@@ -53,9 +53,9 @@ public:
     }
   }
 
-  uint32_t op;
-  uint64_t cookie;
-  version_t last_committed;
+  uint32_t op = 0;
+  uint64_t cookie = 0;
+  version_t last_committed = 0;
   pair<string,string> last_key;
   bufferlist chunk_bl;
   entity_inst_t reply_to;

--- a/src/messages/MOSDMarkMeDown.h
+++ b/src/messages/MOSDMarkMeDown.h
@@ -25,8 +25,8 @@ class MOSDMarkMeDown : public PaxosServiceMessage {
  public:
   uuid_d fsid;
   entity_inst_t target_osd;
-  epoch_t epoch;
-  bool request_ack;          // ack requested
+  epoch_t epoch = 0;
+  bool request_ack = false;          // ack requested
 
   MOSDMarkMeDown()
     : PaxosServiceMessage(MSG_OSD_MARK_ME_DOWN, 0,

--- a/src/messages/MTimeCheck.h
+++ b/src/messages/MTimeCheck.h
@@ -25,9 +25,9 @@ struct MTimeCheck : public Message
     OP_REPORT = 3,
   };
 
-  int op;
-  version_t epoch;
-  version_t round;
+  int op = 0;
+  version_t epoch = 0;
+  version_t round = 0;
 
   utime_t timestamp;
   map<entity_inst_t, double> skews;


### PR DESCRIPTION
Fixes the coverity Issues:

** 1019615 Uninitialized scalar field
>2. uninit_member: Non-static class member service_type is not initialized
 in this constructor nor in any functions that it calls.
>CID 1019615 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member service_op is not initialized
 in this constructor nor in any functions that it calls.

** 1019618 Uninitialized scalar field
>2. uninit_member: Non-static class member op is not initialized in this
 constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member cookie is not initialized in
 this constructor nor in any functions that it calls.
>CID 1019618 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member last_committed is not initialized
 in this constructor nor in any functions that it calls.

** 1019620 Uninitialized scalar field
>2. uninit_member: Non-static class member epoch is not initialized in this
 constructor nor in any functions that it calls.
>CID 1019620 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member request_ack is not initialized
in this constructor nor in any functions that it calls.

** 1019621 Uninitialized scalar field
>2. uninit_member: Non-static class member epoch is not initialized in this
constructor nor in any functions that it calls.
>CID 1019621 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member round is not initialized in this
constructor nor in any functions that it calls

Signed-off-by: Amit Kumar amitkuma@redhat.com