### PR TITLE
qa/tasks/ceph: debug osd setup

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -693,6 +693,7 @@ def cluster(ctx, config):
                     '-p',
                     mnt_point,
                 ])
+            log.info(str(roles_to_devs))
             log.info(str(roles_to_journals))
             log.info(role)
             if roles_to_devs.get(role):


### PR DESCRIPTION
I've seen a couple rbd runs that seem to skip the next block :/

Signed-off-by: Sage Weil <sage@redhat.com>