### PR TITLE
rados: Intializing members class StriperTest

### DIFF
--- a/src/test/libradosstriper/TestCase.h
+++ b/src/test/libradosstriper/TestCase.h
@@ -32,9 +32,9 @@ protected:
 
   void SetUp() override;
   void TearDown() override;
-  rados_t cluster;
-  rados_ioctx_t ioctx;
-  rados_striper_t striper;
+  rados_t cluster = NULL;
+  rados_ioctx_t ioctx = NULL;
+  rados_striper_t striper = NULL;
 };
 
 class StriperTestPP : public ::testing::Test {


### PR DESCRIPTION
Fixes the coverity issue:

** 1221538 Uninitialized pointer field
>2. uninit_member: Non-static class member cluster is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member ioctx is not initialized
in this constructor nor in any functions that it calls.
>CID 1221538 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>6. uninit_member: Non-static class member striper is not initialized
in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar amitkuma@redhat.com