### PR TITLE
os/bluestore: default journal media to store media if bluefs is disabled

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4398,7 +4398,11 @@ bool BlueStore::is_rotational()
 
 bool BlueStore::is_journal_rotational()
 {
-  assert(bluefs);
+  if (!bluefs) {
+    dout(5) << __func__ << " bluefs disabled, default to store media type"
+            << dendl;
+    return is_rotational();
+  }
   dout(10) << __func__ << " " << (int)bluefs->wal_is_rotational() << dendl;
   return bluefs->wal_is_rotational();
 }


### PR DESCRIPTION
So we won't prevent bluestore-without-bluefs backed OSDs from booting:
```
0> 2017-08-06 18:28:07.431316 7ffa1c95fd00 -1 /home/xxg/build/ceph-dev/src/os/bluestore/BlueStore.cc: In function
'virtual bool BlueStore::is_journal_rotational()' thread 7ffa1c95fd00 time 2017-08-06 18:28:07.428503
/home/xxg/build/ceph-dev/src/os/bluestore/BlueStore.cc: 4401: FAILED assert(bluefs)
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>