### PR TITLE
test/librados: Initialize member variables in aio.cc

### DIFF
--- a/src/test/librados/aio.cc
+++ b/src/test/librados/aio.cc
@@ -68,7 +68,7 @@ public:
     return "";
   }
 
-  sem_t *m_sem;
+  sem_t *m_sem = nullptr;
   rados_t m_cluster;
   rados_ioctx_t m_ioctx;
   std::string m_pool_name;
@@ -131,7 +131,7 @@ public:
     return "";
   }
 
-  sem_t *m_sem;
+  sem_t *m_sem = nullptr;
   Rados m_cluster;
   IoCtx m_ioctx;
   std::string m_pool_name;
@@ -2570,7 +2570,7 @@ public:
     return "";
   }
 
-  sem_t *m_sem;
+  sem_t *m_sem = nullptr;
   Rados m_cluster;
   IoCtx m_ioctx;
   std::string m_pool_name;


### PR DESCRIPTION
Fixes the coverity Issue:

** 1322815 Uninitialized pointer field
>CID 1322815 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_sem is not initialized
in this constructor nor in any functions that it calls.

** 1322816 Uninitialized pointer field
>CID 1322816 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_sem is not initialized
in this constructor nor in any functions that it calls.

** 1322817 Uninitialized pointer field
>CID 1322817 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_sem is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com