### PR TITLE
messages: Initialize member variables

### DIFF
--- a/src/messages/MMonScrub.h
+++ b/src/messages/MMonScrub.h
@@ -35,8 +35,8 @@ public:
     }
   }
 
-  op_type_t op;
-  version_t version;
+  op_type_t op = OP_SCRUB;
+  version_t version = 0;
   ScrubResult result;
   int32_t num_keys;
   pair<string,string> key;

--- a/src/messages/MOSDPGPull.h
+++ b/src/messages/MOSDPGPull.h
@@ -26,7 +26,7 @@ class MOSDPGPull : public MOSDFastDispatchOp {
 public:
   pg_shard_t from;
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   uint64_t cost;
 
   epoch_t get_map_epoch() const override {

--- a/src/messages/MOSDPGPush.h
+++ b/src/messages/MOSDPGPush.h
@@ -24,7 +24,7 @@ class MOSDPGPush : public MOSDFastDispatchOp {
 public:
   pg_shard_t from;
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   vector<PushOp> pushes;
 
 private:

--- a/src/messages/MOSDPGPushReply.h
+++ b/src/messages/MOSDPGPushReply.h
@@ -24,7 +24,7 @@ class MOSDPGPushReply : public MOSDFastDispatchOp {
 public:
   pg_shard_t from;
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   vector<PushReplyOp> replies;
   uint64_t cost;
 


### PR DESCRIPTION
Fixes coverity issues:

** 1054864 Uninitialized scalar field
>2. uninit_member: Non-static class member op is not initialized
in this constructor nor in any functions that it calls.
>CID 1054864 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member version is not initialized
in this constructor nor in any functions that it calls.

** 1054865 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1054865 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

** 1054866 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1054866 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

** 1054867 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1054867 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com