### PR TITLE
rgw: Initialize of member variable admin_specified in RGWUserAdminOpState

### DIFF
--- a/src/rgw/rgw_user.h
+++ b/src/rgw/rgw_user.h
@@ -199,7 +199,7 @@ struct RGWUserAdminOpState {
   bool op_mask_specified;
   bool caps_specified;
   bool suspension_op;
-  bool admin_specified;
+  bool admin_specified = false;
   bool system_specified;
   bool key_op;
   bool temp_url_key_specified;


### PR DESCRIPTION
Fixes the coverity issue:

** 1054870 Uninitialized scalar field
>CID 1054870 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member admin_specified is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com