### PR TITLE
messages: Initialization of uninitialized members various classes

### DIFF
--- a/src/messages/MExportDirPrepAck.h
+++ b/src/messages/MExportDirPrepAck.h
@@ -20,7 +20,7 @@
 
 class MExportDirPrepAck : public Message {
   dirfrag_t dirfrag;
-  bool success;
+  bool success = false;
 
  public:
   dirfrag_t get_dirfrag() { return dirfrag; }

--- a/src/messages/MOSDECSubOpRead.h
+++ b/src/messages/MOSDECSubOpRead.h
@@ -24,7 +24,7 @@ class MOSDECSubOpRead : public MOSDFastDispatchOp {
 
 public:
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   ECSubRead op;
 
   int get_cost() const override {

--- a/src/messages/MOSDECSubOpReadReply.h
+++ b/src/messages/MOSDECSubOpReadReply.h
@@ -24,7 +24,7 @@ class MOSDECSubOpReadReply : public MOSDFastDispatchOp {
 
 public:
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   ECSubReadReply op;
 
   int get_cost() const override {

--- a/src/messages/MOSDECSubOpWrite.h
+++ b/src/messages/MOSDECSubOpWrite.h
@@ -24,7 +24,7 @@ class MOSDECSubOpWrite : public MOSDFastDispatchOp {
 
 public:
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   ECSubWrite op;
 
   int get_cost() const override {

--- a/src/messages/MOSDECSubOpWriteReply.h
+++ b/src/messages/MOSDECSubOpWriteReply.h
@@ -24,7 +24,7 @@ class MOSDECSubOpWriteReply : public MOSDFastDispatchOp {
 
 public:
   spg_t pgid;
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   ECSubWriteReply op;
 
   int get_cost() const override {


### PR DESCRIPTION
Fixes the coverity issues:

** 1188168 Uninitialized scalar field
>CID 1188168 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member success is not initialized
in this constructor nor in any functions that it calls.

** 1188169 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1188169 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

** 1188170 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1188170 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

** 1188171 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>CID 1188171 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.

** 1188172 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
 in this constructor nor in any functions that it calls.
>CID 1188172 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
 in this constructor nor in any functions that it calls.

** 1188173 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
 in this constructor nor in any functions that it calls.
>CID 1188173 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member min_epoch is not initialized
 in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com