### PR TITLE
os/bluestore: fix dirty_shard off-by-one

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2676,7 +2676,10 @@ void BlueStore::ExtentMap::dirty_range(
     return;
   }
   auto start = seek_shard(offset);
-  auto last = seek_shard(offset + length);
+  if (length == 0) {
+    length = 1;
+  }
+  auto last = seek_shard(offset + length - 1);
   if (start < 0)
     return;
 


### PR DESCRIPTION
If we dirty an extent that abuts the end of a
shard, we should not dirty the next shard too.

Signed-off-by: Sage Weil <sage@redhat.com>