### PR TITLE
rgw: multisite compressed data sync

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4540,6 +4540,10 @@ std::vector<Option> rgw_options = {
   Option("rgw_reshard_thread_interval", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
   .set_default(60 * 10)
   .set_description(""),
+
+  Option("rgw_enable_compressed_transmission", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+  .set_default(false)
+  .set_description(""),
 };
 
 std::vector<Option> rbd_options = {

--- a/src/rgw/rgw_compression.cc
+++ b/src/rgw/rgw_compression.cc
@@ -69,7 +69,7 @@ RGWGetObj_Decompress::RGWGetObj_Decompress(CephContext* cct_,
 int RGWGetObj_Decompress::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   ldout(cct, 10) << "Compression for rgw is enabled, decompress part "
-      << "bl_ofs="<< bl_ofs << bl_len << dendl;
+      << "bl_ofs="<< bl_ofs << " bl_len=" << bl_len << dendl;
 
   if (!compressor.get()) {
     // if compressor isn't available - error, because cannot return decompressed data?

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -579,7 +579,7 @@ int RGWAsyncStatRemoteObj::_send_request()
                        nullptr); /* string *petag, */
 
   if (r < 0) {
-    ldout(store->ctx(), 0) << "store->fetch_remote_obj() returned r=" << r << dendl;
+    ldout(store->ctx(), 0) << "store->stat_remote_obj() returned r=" << r << dendl;
   }
   return r;
 }

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7290,7 +7290,8 @@ public:
       src_attrs.erase(RGW_ATTR_MANIFEST); // not interested in original object layout
     }
 
-    if (plugin && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()) {
+    if (plugin && src_attrs.find(RGW_ATTR_CRYPT_MODE) == src_attrs.end()
+               && src_attrs.find(RGW_ATTR_COMPRESSION) == src_attrs.end()) {
       //do not compress if object is encrypted
       compressor = boost::in_place(cct, plugin, filter);
       filter = &*compressor;

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -179,6 +179,10 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw
     const string& instance = obj.key.instance;
     params.push_back(param_pair_t("versionId", instance));
   }
+  if (cct->_conf->get_val<bool>("rgw_enable_compressed_transmission")) {
+    params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "skip-decompress", ""));
+  }
+
   if (get_op) {
     *req = new RGWRESTStreamReadRequest(cct, url, cb, NULL, &params);
   } else {

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -246,7 +246,7 @@ int RGWGetObj_ObjStore_S3::send_response_data(bufferlist& bl, off_t bl_ofs,
 
   if (! op_ret) {
     if (! lo_etag.empty()) {
-      /* Handle etag of Swift API's large objects (DLO/SLO). It's entirerly
+      /* Handle etag of Swift API's large objects (DLO/SLO). It's entirely
        * legit to perform GET on them through S3 API. In such situation,
        * a client should receive the composited content with corresponding
        * etag value. */


### PR DESCRIPTION
http://tracker.ceph.com/issues/20936

Currently, during multisite data sync, the objects are transferred in original size, even if the compressed objects in master zone, they are decompressed before being transferred to slave zone. 

In this PR, I implement the function of transferring compressed object during multisite data sync, which will reduce the consumption of network bandwidth and lower the data sync cost.

The compressed transmission can be enabled by the configuration item "rgw_enable_compressed_transmission" in ceph/src/common/options.cc, which is set to false by default.

If the "rgw_enable_compressed_transmission" is set to true in slave zone, the objects, which are compressed stored in master zone, will skip the decompression process and transfer to slave zone in compressed state.

In slave zone, the objects will be stored in the same state with the master zone, it is to say, if the objects are compressed stored in master zone, they will also be stored in compressed state in slave zone; if the objects are un-compressed stored in master zone, they will also be stored in original size in slave zone.

The result of bucket stats is:

#small object#
master zone:
{
&emsp;"bucket": "1111",
&emsp;"zonegroup": "4f520309-b853-4542-9d96-81e8b73114bf",
&emsp;... 
&emsp;"id": "f9385fb3-dfdf-4dbf-9425-592799e8eed0.4447.1",
&emsp;"marker": "f9385fb3-dfdf-4dbf-9425-592799e8eed0.4447.1",
&emsp;...
&emsp;"usage": {
&emsp;&emsp;"rgw.main": {
&emsp;&emsp;&emsp;"size": 1882,
&emsp;&emsp;&emsp;"size_actual": 4096,
&emsp;&emsp;&emsp;"size_utilized": 857,
&emsp;&emsp;&emsp;"size_kb": 2,
&emsp;&emsp;&emsp;"size_kb_actual": 4,
&emsp;&emsp;&emsp;"size_kb_utilized": 1,
&emsp;&emsp;&emsp;"num_objects": 1
&emsp;&emsp;}
&emsp;},
&emsp;...
}

slave zone:
{
&emsp;"bucket": "1111",
    &emsp;"zonegroup": "4f520309-b853-4542-9d96-81e8b73114bf",
    &emsp;...
    &emsp;"id": "f9385fb3-dfdf-4dbf-9425-592799e8eed0.4447.1",
    &emsp;"marker": "f9385fb3-dfdf-4dbf-9425-592799e8eed0.4447.1",
   &emsp; ...
    &emsp;"usage": {
       &emsp;&emsp; "rgw.main": {
           &emsp;&emsp;&emsp; "size": 1882,
         &emsp;&emsp; &emsp;  "size_actual": 4096,
        &emsp;&emsp; &emsp;   "size_utilized": 857,
         &emsp;&emsp; &emsp;  "size_kb": 2,
        &emsp;&emsp;  &emsp;  "size_kb_actual": 4,
       &emsp;&emsp;  &emsp;   "size_kb_utilized": 1,
         &emsp;&emsp; &emsp;  "num_objects": 1
      &emsp;&emsp;  }
   &emsp; },
   &emsp; ...
}

#object compressed in multi-chunks#
master zone:
{
    &emsp;"bucket": "888",
 &emsp;   "zonegroup": "3fce63a6-8a07-4aef-bd45-f87b1d9d2eed",
   &emsp; ...
   &emsp; "id": "b01e3924-13b6-407e-99a7-f748191779ff.4345.1",
  &emsp;  "marker": "b01e3924-13b6-407e-99a7-f748191779ff.4345.1",
  &emsp;  ...
  &emsp;  "usage": {
     &emsp;&emsp;     "rgw.main": {
     &emsp;&emsp;    &emsp;   "size": 15562977,
    &emsp;&emsp;    &emsp;    "size_actual": 15564800,
    &emsp;&emsp;    &emsp;    "size_utilized": 15464597,
     &emsp;&emsp;   &emsp;    "size_kb": 15199,
  &emsp;&emsp;    &emsp;      "size_kb_actual": 15200,
  &emsp;&emsp;    &emsp;      "size_kb_utilized": 15103,
  &emsp;&emsp;    &emsp;      "num_objects": 1
 &emsp;&emsp;       }
 &emsp;   },
  &emsp;  ...
}

slave zone:
{
 &emsp;   "bucket": "888",
 &emsp;   "zonegroup": "3fce63a6-8a07-4aef-bd45-f87b1d9d2eed",
&emsp;    ...
  &emsp;  "id": "b01e3924-13b6-407e-99a7-f748191779ff.4345.1",
 &emsp;   "marker": "b01e3924-13b6-407e-99a7-f748191779ff.4345.1",
 &emsp;   ...
  &emsp;  "usage": {
  &emsp;  &emsp;    "rgw.main": {
  &emsp;&emsp;      &emsp;    "size": 15562977,
   &emsp;&emsp;      &emsp;   "size_actual": 15564800,
  &emsp;&emsp;      &emsp;    "size_utilized": 15464597,
      &emsp;&emsp;  &emsp;    "size_kb": 15199,
     &emsp;&emsp;   &emsp;    "size_kb_actual": 15200,
   &emsp;&emsp;    &emsp;     "size_kb_utilized": 15103,
   &emsp;&emsp;     &emsp;    "num_objects": 1
   &emsp;&emsp;     }
 &emsp;   },
  &emsp;  ...
}

#multipart uploaded object#
master zone:
{
   &emsp; "bucket": "999",
 &emsp;   "zonegroup": "3fce63a6-8a07-4aef-bd45-f87b1d9d2eed",
  &emsp;  ...
 &emsp;   "id": "b01e3924-13b6-407e-99a7-f748191779ff.4345.2",
 &emsp;   "marker": "b01e3924-13b6-407e-99a7-f748191779ff.4345.2",
 &emsp;   ...
  &emsp;  "usage": {
  &emsp;&emsp;      "rgw.main": {
       &emsp;&emsp;   &emsp;  "size": 60904375,
      &emsp;&emsp;   &emsp;   "size_actual": 60907520,
    &emsp;&emsp;    &emsp;    "size_utilized": 60875815,
     &emsp;&emsp;  &emsp;    "size_kb": 59477,
    &emsp;&emsp;    &emsp;    "size_kb_actual": 59480,
   &emsp;&emsp;     &emsp;    "size_kb_utilized": 59450,
   &emsp;&emsp;     &emsp;    "num_objects": 1
 &emsp;&emsp;       },
 &emsp;...
  &emsp;  },
   &emsp; ...
}

non-master zone:
{
  &emsp;  "bucket": "999",
  &emsp;  "zonegroup": "3fce63a6-8a07-4aef-bd45-f87b1d9d2eed",
 &emsp;   ...
 &emsp;   "id": "b01e3924-13b6-407e-99a7-f748191779ff.4345.2",
 &emsp;   "marker": "b01e3924-13b6-407e-99a7-f748191779ff.4345.2",
 &emsp;   ...
&emsp;    "usage": {
  &emsp;&emsp;      "rgw.main": {
   &emsp;&emsp;   &emsp;      "size": 60904375,
    &emsp;&emsp;  &emsp;      "size_actual": 60907520,
    &emsp;&emsp;    &emsp;    "size_utilized": 60875815,
     &emsp;&emsp;    &emsp;  "size_kb": 59477,
     &emsp;&emsp;    &emsp;   "size_kb_actual": 59480,
      &emsp;&emsp;  &emsp;    "size_kb_utilized": 59450,
      &emsp;&emsp;  &emsp;    "num_objects": 1
     &emsp;&emsp;   }
   &emsp; },
   &emsp; ...
}

TODO list:
1. Implement the compressed transmission for the objects which are stored without being compressed in master zone.
2. Amend the compressed transmission configuration item as a zone placement param instead of a configuration item in ceph/src/common/options.cc, just like the --compression param.