### PR TITLE
rgw: Initializes uninitialized members

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1197,7 +1197,7 @@ struct RGWBucketInfo
   bool has_website;
   RGWBucketWebsiteConf website_conf;
 
-  RGWBucketIndexType index_type;
+  RGWBucketIndexType index_type = RGWBIType_Normal;
 
   bool swift_versioning;
   string swift_ver_location;

--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -91,7 +91,7 @@ namespace rgw {
    */
   struct fh_key
   {
-    rgw_fh_hk fh_hk;
+    rgw_fh_hk fh_hk {};
     uint32_t version;
 
     static constexpr uint64_t seed = 8675309;

--- a/src/rgw/rgw_realm_watcher.h
+++ b/src/rgw/rgw_realm_watcher.h
@@ -56,7 +56,7 @@ class RGWRealmWatcher : public librados::WatchCtx2 {
   /// so that we don't miss notifications during realm reconfiguration
   librados::Rados rados;
   librados::IoCtx pool_ctx;
-  uint64_t watch_handle;
+  uint64_t watch_handle = 0;
   std::string watch_oid;
 
   int watch_start(RGWRealm& realm);


### PR DESCRIPTION
Fixes the coverity issues:

** 1352181 Uninitialized scalar field
2. uninit_member: Non-static class member field fh_hk.bucket is
not initialized in this constructor nor in any functions that it calls.
CID 1352181 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
4. uninit_member: Non-static class member field fh_hk.object is
not initialized in this constructor nor in any functions that it calls.

** 1353424 Uninitialized scalar field
CID 1353424 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
5. uninit_member: Non-static class member watch_handle is not initialized
 in this constructor nor in any functions that it calls.

** 1355240 Uninitialized scalar field
CID 1355240 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member index_type is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com