### PR TITLE
rgw: fix opslog cannot record remote_addr

### DIFF
--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -110,6 +110,7 @@ void RGWCivetWeb::init_env(CephContext *cct)
     env.set(buf, value);
   }
 
+  env.set("REMOTE_ADDR", info->remote_addr);
   env.set("REQUEST_METHOD", info->request_method);
   env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later
   env.set("SCRIPT_URI", info->uri); /* FIXME */


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20931

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>