### PR TITLE
common/cmdparse.cc: remove unused variable 'argnum' in dump_cmd_to_json()

### DIFF
--- a/src/common/cmdparse.cc
+++ b/src/common/cmdparse.cc
@@ -55,12 +55,10 @@ dump_cmd_to_json(Formatter *f, const string& cmd)
   // elements are: "name", meaning "the typeless name that means a literal"
   // an object {} with key:value pairs representing an argument
 
-  int argnum = 0;
   stringstream ss(cmd);
   std::string word;
 
   while (std::getline(ss, word, ' ')) {
-    argnum++;
     // if no , or =, must be a plain word to put out
     if (word.find_first_of(",=") == string::npos) {
       f->dump_string("arg", word);


### PR DESCRIPTION
Common: Variable 'argnum' is modified but its new value is never used.

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>