### PR TITLE
librbd: initialization of state member variables

### DIFF
--- a/src/librbd/object_map/SnapshotCreateRequest.h
+++ b/src/librbd/object_map/SnapshotCreateRequest.h
@@ -56,7 +56,7 @@ protected:
   bool should_complete(int r) override;
 
 private:
-  State m_state;
+  State m_state = STATE_READ_MAP;
   ceph::BitVector<2> &m_object_map;
 
   bufferlist m_read_bl;

--- a/src/librbd/object_map/SnapshotRemoveRequest.h
+++ b/src/librbd/object_map/SnapshotRemoveRequest.h
@@ -66,7 +66,7 @@ protected:
   }
 
 private:
-  State m_state;
+  State m_state = STATE_LOAD_MAP;
   ceph::BitVector<2> &m_object_map;
   uint64_t m_snap_id;
   uint64_t m_next_snap_id;

--- a/src/librbd/object_map/SnapshotRollbackRequest.h
+++ b/src/librbd/object_map/SnapshotRollbackRequest.h
@@ -56,7 +56,7 @@ protected:
   bool should_complete(int r) override;
 
 private:
-  State m_state;
+  State m_state = STATE_READ_MAP;
   uint64_t m_snap_id;
   int m_ret_val;
 

--- a/src/librbd/operation/TrimRequest.h
+++ b/src/librbd/operation/TrimRequest.h
@@ -79,7 +79,7 @@ protected:
 
   bool should_complete(int r) override;
 
-  State m_state;
+  State m_state = STATE_PRE_COPYUP;
 
 private:
   uint64_t m_delete_start;
@@ -88,8 +88,8 @@ private:
   uint64_t m_new_size;
   ProgressContext &m_prog_ctx;
 
-  uint64_t m_copyup_start;
-  uint64_t m_copyup_end;
+  uint64_t m_copyup_start = 0;
+  uint64_t m_copyup_end = 0;
 
   TrimRequest(ImageCtxT &image_ctx, Context *on_finish,
 	      uint64_t original_size, uint64_t new_size,


### PR DESCRIPTION
Fixes the coverity issues:

** 1351715 Uninitialized scalar field
>5. uninit_member: Non-static class member m_state is not initialized in this
constructor nor in any functions that it calls.
>7. uninit_member: Non-static class member m_copyup_start is not initialized
in this constructor nor in any functions that it calls.
>CID 1351715 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>9. uninit_member: Non-static class member m_copyup_end is not initialized
in this constructor nor in any functions that it calls.

** 1351724 Uninitialized scalar field
>CID 1351724 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_state is not initialized in
this constructor nor in any functions that it calls.

** 1351725 Uninitialized scalar field
>CID 1351725 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_state is not initialized in
this constructor nor in any functions that it calls.

** 1351726 Uninitialized scalar field
>CID 1351726 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>3. uninit_member: Non-static class member m_state is not initialized in
this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com