### PR TITLE
librbd: initialize member variables

### DIFF
--- a/src/librbd/WatchNotifyTypes.h
+++ b/src/librbd/WatchNotifyTypes.h
@@ -228,7 +228,7 @@ struct SnapRenamePayload : public SnapPayloadBase {
 		    const std::string &dst_name)
     : SnapPayloadBase(cls::rbd::UserSnapshotNamespace(), dst_name), snap_id(src_snap_id) {}
 
-  uint64_t snap_id;
+  uint64_t snap_id = 0;
 
   void encode(bufferlist &bl) const;
   void decode(__u8 version, bufferlist::iterator &iter);

--- a/src/librbd/operation/FlattenRequest.h
+++ b/src/librbd/operation/FlattenRequest.h
@@ -73,7 +73,7 @@ private:
   uint64_t m_overlap_objects;
   ::SnapContext m_snapc;
   ProgressContext &m_prog_ctx;
-  State m_state;
+  State m_state = STATE_FLATTEN_OBJECTS;
 
   ParentSpec m_parent_spec;
   bool m_ignore_enoent;

--- a/src/librbd/operation/RebuildObjectMapRequest.h
+++ b/src/librbd/operation/RebuildObjectMapRequest.h
@@ -63,7 +63,7 @@ private:
 
   ImageCtxT &m_image_ctx;
   ProgressContext &m_prog_ctx;
-  State m_state;
+  State m_state = STATE_RESIZE_OBJECT_MAP;
   bool m_attempted_trim;
 
   void send_resize_object_map();


### PR DESCRIPTION
Fixes the coverity issues:

** 1351727 Uninitialized scalar field
>CID 1351727 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_state is not initialized in
this constructor nor in any functions that it calls.

** 1351728 Uninitialized scalar field
>CID 1351728 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_state is not initialized in
this constructor nor in any functions that it calls.

** 1351733 Uninitialized scalar field
>CID 1351733 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member snap_id is not initialized in
this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com