### PR TITLE
os/bluestore:  clearer comments, not slower code.

### DIFF
--- a/src/os/bluestore/BitmapFreelistManager.cc
+++ b/src/os/bluestore/BitmapFreelistManager.cc
@@ -191,10 +191,10 @@ int get_next_clear_bit(bufferlist& bl, int start)
   const char *p = bl.c_str();
   int bits = bl.length() << 3;
   while (start < bits) {
-    int which_byte = start / 8;
-    int which_bit = start % 8;
-    unsigned char byte_mask = 1 << which_bit;
-    if ((p[which_byte] & byte_mask) == 0) {
+    // byte = start / 8 (or start >> 3)
+    // bit = start % 8 (or start & 7)
+    unsigned char byte_mask = 1 << (start & 7);
+    if ((p[start >> 3] & byte_mask) == 0) {
       return start;
     }
     ++start;


### PR DESCRIPTION
This PR reverts some of the changes introduced in #12719.  In the worst case, #12719 exchanges a bitshift and logical and in the original code for a division and modulo operation.  In many cases, the compiler can optimize for this internally. In this case however, because start is an int rather than uint, the original code will likely be faster than what the compiler can generate.  This PR reverts the operation changes while providing comments to show what's going on instead.