### PR TITLE
crush,mon: fix weight-set vs crush device classes

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -155,4 +155,35 @@ ceph osd crush weight-set create-compat
 ceph osd crush weight-set ls | grep '(compat)'
 ceph osd crush weight-set rm-compat
 
+# weight set vs device classes
+ceph osd pool create cool 2
+ceph osd pool create cold 2
+ceph osd pool set cold size 2
+ceph osd crush weight-set create-compat
+ceph osd crush weight-set create cool flat
+ceph osd crush weight-set create cold positional
+ceph osd crush rm-device-class osd.0
+ceph osd crush weight-set reweight-compat osd.0 10.5
+ceph osd crush weight-set reweight cool osd.0 11.5
+ceph osd crush weight-set reweight cold osd.0 12.5 12.4
+ceph osd crush set-device-class fish osd.0
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep fish | grep 10\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep fish | grep 11\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep fish | grep 12\\.
+ceph osd crush rm-device-class osd.0
+ceph osd crush set-device-class globster osd.0
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 10\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 11\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 12\\.
+ceph osd crush weight-set reweight-compat osd.0 7.5
+ceph osd crush weight-set reweight cool osd.0 8.5
+ceph osd crush weight-set reweight cold osd.0 6.5 6.6
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 7\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 8\\.
+ceph osd crush tree --show-shadow | grep osd\\.0 | grep globster | grep 6\\.
+ceph osd crush rm-device-class osd.0
+ceph osd pool rm cool cool --yes-i-really-really-mean-it
+ceph osd pool rm cold cold --yes-i-really-really-mean-it
+ceph osd crush weight-set rm-compat
+
 echo OK

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1785,15 +1785,23 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
       assert(weight_set->size - 1 == new_size);
       for (__u32 k = position; k < new_size; k++)
 	weight_set->weights[k] = weight_set->weights[k+1];
-      weight_set->weights = (__u32*)realloc(weight_set->weights,
-					    new_size * sizeof(__u32));
+      if (new_size) {
+	weight_set->weights = (__u32*)realloc(weight_set->weights,
+					      new_size * sizeof(__u32));
+      } else {
+	weight_set->weights = NULL;
+      }
       weight_set->size = new_size;
     }
     if (arg->ids_size) {
       assert(arg->ids_size - 1 == new_size);
       for (__u32 k = position; k < new_size; k++)
 	arg->ids[k] = arg->ids[k+1];
-      arg->ids = (__s32 *)realloc(arg->ids, new_size * sizeof(__s32));
+      if (new_size) {
+	arg->ids = (__s32 *)realloc(arg->ids, new_size * sizeof(__s32));
+      } else {
+	arg->ids = NULL;
+      }
       arg->ids_size = new_size;
     }
   }

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -510,13 +510,13 @@ int CrushWrapper::_remove_item_under(
     if (id == item) {
       ldout(cct, 5) << "_remove_item_under removing item " << item
 		    << " from bucket " << b->id << dendl;
-      bucket_remove_item(b, item);
       for (auto& p : choose_args) {
 	// weight down each weight-set to 0 before we remove the item
 	vector<int> weightv(get_choose_args_positions(p.second), 0);
 	_choose_args_adjust_item_weight_in_bucket(
 	  cct, p.second, b->id, item, weightv, nullptr);
       }
+      bucket_remove_item(b, item);
       adjust_item_weight(cct, b->id, b->weight);
       ret = 0;
     } else if (id < 0) {

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -364,11 +364,8 @@ bool CrushWrapper::_maybe_remove_last_instance(CephContext *cct, int item, bool 
   return true;
 }
 
-int CrushWrapper::remove_root(int item, bool unused)
+int CrushWrapper::remove_root(int item)
 {
-  if (unused && _bucket_is_in_use(item))
-    return 0;
-
   crush_bucket *b = get_bucket(item);
   if (IS_ERR(b)) {
     // should be idempotent
@@ -383,7 +380,7 @@ int CrushWrapper::remove_root(int item, bool unused)
   for (unsigned n = 0; n < b->size; n++) {
     if (b->items[n] >= 0)
       continue;
-    int r = remove_root(b->items[n], unused);
+    int r = remove_root(b->items[n]);
     if (r < 0)
       return r;
   }
@@ -1426,14 +1423,14 @@ int CrushWrapper::populate_classes(
   return 0;
 }
 
-int CrushWrapper::trim_roots_with_class(bool unused)
+int CrushWrapper::trim_roots_with_class()
 {
   set<int> roots;
   find_shadow_roots(roots);
   for (auto &r : roots) {
     if (r >= 0)
       continue;
-    int res = remove_root(r, unused);
+    int res = remove_root(r);
     if (res)
       return res;
   }
@@ -1972,7 +1969,7 @@ int CrushWrapper::rebuild_roots_with_classes()
 {
   std::map<int32_t, map<int32_t, int32_t> > old_class_bucket = class_bucket;
   cleanup_dead_classes();
-  int r = trim_roots_with_class(false);
+  int r = trim_roots_with_class();
   if (r < 0)
     return r;
   class_bucket.clear();

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -2019,9 +2019,15 @@ bool CrushWrapper::_class_is_dead(int class_id)
 
 void CrushWrapper::cleanup_dead_classes()
 {
-  for (auto &c: class_name) {
-    if (_class_is_dead(c.first))
-      remove_class_name(c.second);
+  auto p = class_name.begin();
+  while (p != class_name.end()) {
+    if (_class_is_dead(p->first)) {
+      string n = p->second;
+      ++p;
+      remove_class_name(n);
+    } else {
+      ++p;
+    }
   }
 }
 

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1739,6 +1739,10 @@ int CrushWrapper::add_bucket(
 int CrushWrapper::bucket_add_item(crush_bucket *bucket, int item, int weight)
 {
   __u32 new_size = bucket->size + 1;
+  int r = crush_bucket_add_item(crush, bucket, item, weight);
+  if (r < 0) {
+    return r;
+  }
   for (auto w : choose_args) {
     crush_choose_arg_map arg_map = w.second;
     crush_choose_arg *arg = &arg_map.args[-1-bucket->id];
@@ -1757,7 +1761,7 @@ int CrushWrapper::bucket_add_item(crush_bucket *bucket, int item, int weight)
       arg->ids_size = new_size;
     }
   }
-  return crush_bucket_add_item(crush, bucket, item, weight);
+  return 0;
 }
 
 int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
@@ -1768,6 +1772,10 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
     if (bucket->items[position] == item)
       break;
   assert(position != bucket->size);
+  int r = crush_bucket_remove_item(crush, bucket, item);
+  if (r < 0) {
+    return r;
+  }
   for (auto w : choose_args) {
     crush_choose_arg_map arg_map = w.second;
     crush_choose_arg *arg = &arg_map.args[-1-bucket->id];
@@ -1788,7 +1796,7 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
       arg->ids_size = new_size;
     }
   }
-  return crush_bucket_remove_item(crush, bucket, item);
+  return 0;
 }
 
 int CrushWrapper::update_device_class(int id,

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1212,7 +1212,8 @@ public:
     int original, int device_class,
     const std::map<int32_t, map<int32_t, int32_t>>& old_class_bucket,
     const std::set<int32_t>& used_ids,
-    int *clone);
+    int *clone,
+    map<int,map<int,vector<int>>> *cmap_item_weight);
   int rename_class(const string& srcname, const string& dstname);
   int populate_classes(
     const std::map<int32_t, map<int32_t, int32_t>>& old_class_bucket);

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -834,10 +834,9 @@ public:
    * when a bucket is in use.
    *
    * @param item id to remove
-   * @param unused true if only unused items should be removed
    * @return 0 on success, negative on error
    */
-  int remove_root(int item, bool unused);
+  int remove_root(int item);
 
   /**
    * remove all instances of an item nested beneath a certain point from the map
@@ -1221,7 +1220,7 @@ public:
   void cleanup_dead_classes();
   int rebuild_roots_with_classes();
   /* remove unused roots generated for class devices */
-  int trim_roots_with_class(bool unused);
+  int trim_roots_with_class();
 
   void start_choose_profile() {
     free(crush->choose_tries);

--- a/src/crush/builder.c
+++ b/src/crush/builder.c
@@ -1030,12 +1030,11 @@ int crush_remove_straw_bucket_item(struct crush_map *map,
 
 	for (i = 0; i < bucket->h.size; i++) {
 		if (bucket->h.items[i] == item) {
-			bucket->h.size--;
 			if (bucket->item_weights[i] < bucket->h.weight)
 				bucket->h.weight -= bucket->item_weights[i];
 			else
 				bucket->h.weight = 0;
-			for (j = i; j < bucket->h.size; j++) {
+			for (j = i; j < bucket->h.size - 1; j++) {
 				bucket->h.items[j] = bucket->h.items[j+1];
 				bucket->item_weights[j] = bucket->item_weights[j+1];
 			}
@@ -1044,7 +1043,11 @@ int crush_remove_straw_bucket_item(struct crush_map *map,
 	}
 	if (i == bucket->h.size)
 		return -ENOENT;
-	
+	bucket->h.size--;
+	if (bucket->h.size == 0) {
+		/* don't bother reallocating */
+		return 0;
+	}
 	void *_realloc = NULL;
 
 	if ((_realloc = realloc(bucket->h.items, sizeof(__s32)*newsize)) == NULL) {
@@ -1074,12 +1077,11 @@ int crush_remove_straw2_bucket_item(struct crush_map *map,
 
 	for (i = 0; i < bucket->h.size; i++) {
 		if (bucket->h.items[i] == item) {
-			bucket->h.size--;
 			if (bucket->item_weights[i] < bucket->h.weight)
 				bucket->h.weight -= bucket->item_weights[i];
 			else
 				bucket->h.weight = 0;
-			for (j = i; j < bucket->h.size; j++) {
+			for (j = i; j < bucket->h.size - 1; j++) {
 				bucket->h.items[j] = bucket->h.items[j+1];
 				bucket->item_weights[j] = bucket->item_weights[j+1];
 			}
@@ -1088,6 +1090,12 @@ int crush_remove_straw2_bucket_item(struct crush_map *map,
 	}
 	if (i == bucket->h.size)
 		return -ENOENT;
+
+	bucket->h.size--;
+	if (!newsize) {
+		/* don't bother reallocating a 0-length array. */
+		return 0;
+	}
 
 	void *_realloc = NULL;
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -11366,6 +11366,16 @@ int OSDMonitor::_prepare_remove_pool(
       pending_inc.old_pg_upmap_items.insert(p.first);
     }
   }
+
+  // remove any choose_args for this pool
+  CrushWrapper newcrush;
+  _get_pending_crush(newcrush);
+  if (newcrush.have_choose_args(pool)) {
+    dout(10) << __func__ << " removing choose_args for pool " << pool << dendl;
+    newcrush.rm_choose_args(pool);
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, mon->get_quorum_con_features());
+  }
   return 0;
 }
 

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1061,7 +1061,7 @@ TEST(CrushWrapper, choose_args_compat) {
   }
 }
 
-TEST(CrushWrapper, remove_unused_root) {
+TEST(CrushWrapper, remove_root) {
   CrushWrapper c;
   c.create();
   c.set_type_name(1, "host");
@@ -1087,9 +1087,9 @@ TEST(CrushWrapper, remove_unused_root) {
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("r11"));
   ASSERT_TRUE(c.name_exists("r12"));
-  ASSERT_EQ(c.remove_root(c.get_item_id("default"), true), 0);
+  ASSERT_EQ(c.remove_root(c.get_item_id("default")), 0);
   ASSERT_FALSE(c.name_exists("default"));
-  ASSERT_TRUE(c.name_exists("r11"));
+  ASSERT_FALSE(c.name_exists("r11"));
   ASSERT_FALSE(c.name_exists("r12"));
 }
 
@@ -1118,11 +1118,7 @@ TEST(CrushWrapper, trim_roots_with_class) {
 
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("default~ssd"));
-  c.trim_roots_with_class(true); // do nothing because still in use
-  ASSERT_TRUE(c.name_exists("default"));
-  ASSERT_TRUE(c.name_exists("default~ssd"));
-  c.class_bucket.clear();
-  c.trim_roots_with_class(true); // do nothing because still in use
+  c.trim_roots_with_class();
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_FALSE(c.name_exists("default~ssd"));
 }

--- a/src/test/crush/CrushWrapper.cc
+++ b/src/test/crush/CrushWrapper.cc
@@ -1111,10 +1111,11 @@ TEST(CrushWrapper, trim_roots_with_class) {
   int root_id = c.get_item_id("default");
   int clone_id;
   map<int32_t, map<int32_t, int32_t>> old_class_bucket;
+  map<int,map<int,vector<int>>> cmap_item_weight; // cargs -> bno -> weights
   set<int32_t> used_ids;
 
   ASSERT_EQ(c.device_class_clone(root_id, cl, old_class_bucket, used_ids,
-				 &clone_id), 0);
+				 &clone_id, &cmap_item_weight), 0);
 
   ASSERT_TRUE(c.name_exists("default"));
   ASSERT_TRUE(c.name_exists("default~ssd"));
@@ -1145,11 +1146,12 @@ TEST(CrushWrapper, device_class_clone) {
   c.reweight(g_ceph_context);
 
   map<int32_t, map<int32_t, int32_t>> old_class_bucket;
+  map<int,map<int,vector<int>>> cmap_item_weight; // cargs -> bno -> weights
   set<int32_t> used_ids;
   int root_id = c.get_item_id("default");
   int clone_id;
   ASSERT_EQ(c.device_class_clone(root_id, cl, old_class_bucket, used_ids,
-				 &clone_id), 0);
+				 &clone_id, &cmap_item_weight), 0);
   ASSERT_TRUE(c.name_exists("default~ssd"));
   ASSERT_EQ(clone_id, c.get_item_id("default~ssd"));
   ASSERT_TRUE(c.subtree_contains(clone_id, item));
@@ -1160,13 +1162,13 @@ TEST(CrushWrapper, device_class_clone) {
   // cloning again does nothing and returns the existing one
   int other_clone_id;
   ASSERT_EQ(c.device_class_clone(root_id, cl, old_class_bucket, used_ids,
-				 &other_clone_id), 0);
+				 &other_clone_id, &cmap_item_weight), 0);
   ASSERT_EQ(clone_id, other_clone_id);
   // invalid arguments
   ASSERT_EQ(c.device_class_clone(12345, cl, old_class_bucket, used_ids,
-				 &other_clone_id), -ECHILD);
+				 &other_clone_id, &cmap_item_weight), -ECHILD);
   ASSERT_EQ(c.device_class_clone(root_id, 12345, old_class_bucket, used_ids,
-				 &other_clone_id), -EBADF);
+				 &other_clone_id, &cmap_item_weight), -EBADF);
 }
 
 TEST(CrushWrapper, split_id_class) {
@@ -1184,11 +1186,12 @@ TEST(CrushWrapper, split_id_class) {
   c.class_map[item] = class_id;
 
   map<int32_t, map<int32_t, int32_t>> old_class_bucket;
+  map<int,map<int,vector<int>>> cmap_item_weight; // cargs -> bno -> weights
   set<int32_t> used_ids;
   int item_id = c.get_item_id("default");
   int clone_id;
   ASSERT_EQ(c.device_class_clone(item_id, class_id, old_class_bucket, used_ids,
-				 &clone_id), 0);
+				 &clone_id, &cmap_item_weight), 0);
   int retrieved_item_id;
   int retrieved_class_id;
   ASSERT_EQ(c.split_id_class(clone_id, &retrieved_item_id, &retrieved_class_id), 0);


### PR DESCRIPTION
- rebuild weight-sets along with shadow hierarchy
- remove old choose_args when we delete the pool

Fixes http://tracker.ceph.com/issues/20939