### PR TITLE
os/bluestore: move size and block_size to the base class BlockDevice.

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -88,10 +88,16 @@ private:
   std::atomic_int ioc_reap_count = {0};
 
 protected:
+  uint64_t size;
+  uint64_t block_size;
   bool rotational = true;
 
 public:
-  BlockDevice(CephContext* cct) : cct(cct) {}
+  BlockDevice(CephContext* cct) 
+  : cct(cct),
+    size(0),
+    block_size(0)
+ {}
   virtual ~BlockDevice() = default;
   typedef void (*aio_callback_t)(void *handle, void *aio);
 
@@ -102,8 +108,8 @@ public:
 
   virtual void aio_submit(IOContext *ioc) = 0;
 
-  virtual uint64_t get_size() const = 0;
-  virtual uint64_t get_block_size() const = 0;
+  uint64_t get_size() const { return size; }
+  uint64_t get_block_size() const { return block_size; }
 
   virtual int collect_metadata(std::string prefix, std::map<std::string,std::string> *pm) const = 0;
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -37,7 +37,6 @@ KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
   : BlockDevice(cct),
     fd_direct(-1),
     fd_buffered(-1),
-    size(0), block_size(0),
     fs(NULL), aio(false), dio(false),
     debug_lock("KernelDevice::debug_lock"),
     aio_queue(cct->_conf->bdev_aio_max_queue_depth),

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -25,8 +25,6 @@
 
 class KernelDevice : public BlockDevice {
   int fd_direct, fd_buffered;
-  uint64_t size;
-  uint64_t block_size;
   std::string path;
   FS *fs;
   bool aio, dio;
@@ -78,13 +76,6 @@ public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   void aio_submit(IOContext *ioc) override;
-
-  uint64_t get_size() const override {
-    return size;
-  }
-  uint64_t get_block_size() const override {
-    return block_size;
-  }
 
   int collect_metadata(std::string prefix, map<std::string,std::string> *pm) const override;
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -858,8 +858,6 @@ void io_complete(void *t, const struct spdk_nvme_cpl *completion)
 NVMEDevice::NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
   :   BlockDevice(cct),
       driver(nullptr),
-      size(0),
-      block_size(0),
       aio_stop(false),
       buffer_lock("NVMEDevice::buffer_lock"),
       aio_callback(cb),

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -50,9 +50,6 @@ class NVMEDevice : public BlockDevice {
   SharedDriverData *driver;
   string name;
 
-  uint64_t size;
-  uint64_t block_size;
-
   bool aio_stop;
 
   struct BufferedExtents {
@@ -210,13 +207,6 @@ class NVMEDevice : public BlockDevice {
   bool supported_bdev_label() override { return false; }
 
   void aio_submit(IOContext *ioc) override;
-
-  uint64_t get_size() const override {
-    return size;
-  }
-  uint64_t get_block_size() const override {
-    return block_size;
-  }
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
            IOContext *ioc,

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -36,7 +36,6 @@
 PMEMDevice::PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv)
   : BlockDevice(cct),
     fd(-1), addr(0),
-    size(0), block_size(0),
     debug_lock("PMEMDevice::debug_lock"),
     injecting_crash(0)
 {

--- a/src/os/bluestore/PMEMDevice.h
+++ b/src/os/bluestore/PMEMDevice.h
@@ -27,8 +27,6 @@
 class PMEMDevice : public BlockDevice {
   int fd;
   char *addr; //the address of mmap
-  uint64_t size;
-  uint64_t block_size;
   std::string path;
 
   Mutex debug_lock;
@@ -42,13 +40,6 @@ public:
 
 
   void aio_submit(IOContext *ioc) override;
-
-  uint64_t get_size() const override {
-    return size;
-  }
-  uint64_t get_block_size() const override {
-    return block_size;
-  }
 
   int collect_metadata(std::string prefix, map<std::string,std::string> *pm) const override;
 


### PR DESCRIPTION
At this moment, we have NVMEDevice, KernelDevice, and PMEMDevice. All the get_size and get_block_size are totally the same. I think it is better to move the to base class.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>