### PR TITLE
libradosstriper: silence warning from -Wreorder

### DIFF
--- a/src/libradosstriper/RadosStriperImpl.cc
+++ b/src/libradosstriper/RadosStriperImpl.cc
@@ -247,10 +247,10 @@ void ReadCompletionData::complete_unlock(int r) {
 struct WriteCompletionData : CompletionData {
   /// safe completion handler
   librados::IoCtxImpl::C_aio_Complete *m_safe;
-  /// return code of write completion, to be remembered until unlocking happened
-  int m_writeRc;
   /// completion object for the unlocking of the striped object at the end of the write
   librados::AioCompletion *m_unlockCompletion;
+  /// return code of write completion, to be remembered until unlocking happened
+  int m_writeRc;
   /// constructor
   WriteCompletionData(libradosstriper::RadosStriperImpl * striper,
 		      const std::string& soid,


### PR DESCRIPTION
```
warning: '{anonymous}::WriteCompletionData::m_unlockCompletion' will be initialized after [-Wreorder]
   librados::AioCompletion *m_unlockCompletion;
                            ^
/home/ceph-dev/src/libradosstriper/RadosStriperImpl.cc:252:7: warning:  'int {anonymous}::WriteCompletionData::m_writeRc' [-Wreorder]
   int m_writeRc;
       ^
/home/ceph-dev/src/libradosstriper/RadosStriperImpl.cc:271:1: warning:   when initialized here [-Wreorder]
 WriteCompletionData::WriteCompletionData
 ^
```
Signed-off-by: songweibin <song.weibin@zte.com.cn>