### PR TITLE
mds/MDSDaemon: add 'is_valid=false' when failed to parse caps

### DIFF
--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -1357,12 +1357,14 @@ bool MDSDaemon::ms_verify_authorizer(Connection *con, int peer_type,
 		<< " parsing '" << auth_cap_str << "'" << dendl;
 	clog->warn() << name << " mds cap '" << auth_cap_str
 		     << "' does not parse: " << errstr.str();
+        is_valid = false;
       }
     } catch (buffer::error& e) {
       // Assume legacy auth, defaults to:
       //  * permit all filesystem ops
       //  * permit no `tell` ops
       dout(1) << __func__ << ": cannot decode auth caps bl of length " << caps_info.caps.length() << dendl;
+      is_valid = false;
     }
   }
 


### PR DESCRIPTION
Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>