### PR TITLE
bluestore: drop unused friend class in SharedDriverQueueData

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -102,7 +102,6 @@ class SharedDriverQueueData {
   uint32_t queueid;
   struct spdk_nvme_qpair *qpair;
   std::function<void ()> run_func;
-  friend class AioCompletionThread;
 
   bool aio_stop = false;
   void _aio_thread();


### PR DESCRIPTION
AioCompletionThread is defined in KernelDevice.h, and no relation with NVMEDevice

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>