### PR TITLE
rados: Initializing members of librados/TestCase.h

### DIFF
--- a/src/test/librados/TestCase.h
+++ b/src/test/librados/TestCase.h
@@ -32,8 +32,8 @@ protected:
 
   void SetUp() override;
   void TearDown() override;
-  rados_t cluster;
-  rados_ioctx_t ioctx;
+  rados_t cluster = nullptr;
+  rados_ioctx_t ioctx = nullptr;
   bool cleanup;
 };
 
@@ -94,9 +94,9 @@ protected:
 
   void SetUp() override;
   void TearDown() override;
-  rados_t cluster;
-  rados_ioctx_t ioctx;
-  uint64_t alignment;
+  rados_t cluster = nullptr; 
+  rados_ioctx_t ioctx = nullptr;
+  uint64_t alignment = 0;
   bool cleanup;
 };
 
@@ -148,8 +148,8 @@ protected:
 
   void SetUp() override;
   void TearDown() override;
-  rados_t cluster;
-  rados_ioctx_t ioctx;
+  rados_t cluster = nullptr;
+  rados_ioctx_t ioctx = nullptr;
   std::string nspace;
   bool cleanup;
 };
@@ -207,11 +207,11 @@ protected:
 
   void SetUp() override;
   void TearDown() override;
-  rados_t cluster;
-  rados_ioctx_t ioctx;
+  rados_t cluster = nullptr;
+  rados_ioctx_t ioctx = nullptr;
   bool cleanup;
   std::string nspace;
-  uint64_t alignment;
+  uint64_t alignment = 0;
 };
 
 class RadosTestECPP : public RadosTestPP {


### PR DESCRIPTION
Fixes the coverity issues:

** 1409698 Uninitialized pointer field
>2. uninit_member: Non-static class member cluster is not initialized in
this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member ioctx is not initialized in
this constructor nor in any functions that it calls.
>CID 1409698 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>6. uninit_member: Non-static class member alignment is not initialized
in this constructor nor in any functions that it calls.

** 1409699 Uninitialized pointer field
>2. uninit_member: Non-static class member cluster is not initialized in
 this constructor nor in any functions that it calls.
>CID 1409699 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member ioctx is not initialized in
this constructor nor in any functions that it calls.

** 1409701 Uninitialized pointer field
>2. uninit_member: Non-static class member cluster is not initialized in
this constructor nor in any functions that it calls.
>CID 1409701 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member ioctx is not initialized in
this constructor nor in any functions that it calls.

** 1409703 Uninitialized pointer field
>2. uninit_member: Non-static class member cluster is not initialized in
this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member ioctx is not initialized in
this constructor nor in any functions that it calls.
>CID 1409703 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>6. uninit_member: Non-static class member alignment is not initialized in
this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com