### PR TITLE
messages: Initialization of is_primary

### DIFF
--- a/src/messages/MDentryLink.h
+++ b/src/messages/MDentryLink.h
@@ -20,7 +20,7 @@ class MDentryLink : public Message {
   dirfrag_t subtree;
   dirfrag_t dirfrag;
   string dn;
-  bool is_primary;
+  bool is_primary = false;
 
  public:
   dirfrag_t get_subtree() { return subtree; }


### PR DESCRIPTION
Fixes the coverity issue:

** 717269 Uninitialized scalar field
CID 717269 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
2. uninit_member: Non-static class member is_primary is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com