### PR TITLE
messages: Initialization of member variables

### DIFF
--- a/src/messages/MDirUpdate.h
+++ b/src/messages/MDirUpdate.h
@@ -19,10 +19,10 @@
 #include "msg/Message.h"
 
 class MDirUpdate : public Message {
-  mds_rank_t from_mds;
+  mds_rank_t from_mds = -1;
   dirfrag_t dirfrag;
-  int32_t dir_rep;
-  int32_t discover;
+  int32_t dir_rep = 5;
+  int32_t discover = 5;
   compact_set<int32_t> dir_rep_by;
   filepath path;
   int tried_discover;

--- a/src/messages/MDiscover.h
+++ b/src/messages/MDiscover.h
@@ -29,8 +29,8 @@ class MDiscover : public Message {
   snapid_t        snapid;
   filepath        want;   // ... [/]need/this/stuff
 
-  bool want_base_dir;
-  bool want_xlocked;
+  bool want_base_dir = true;
+  bool want_xlocked = false;
 
  public:
   inodeno_t get_base_ino() { return base_ino; }

--- a/src/messages/MDiscoverReply.h
+++ b/src/messages/MDiscoverReply.h
@@ -70,20 +70,20 @@ class MDiscoverReply : public Message {
   // info about original request
   inodeno_t base_ino;
   frag_t base_dir_frag;  
-  bool wanted_base_dir;
-  bool wanted_xlocked;
+  bool wanted_base_dir = false;
+  bool wanted_xlocked = false;
   snapid_t wanted_snapid;
 
   // and the response
-  bool flag_error_dn;
-  bool flag_error_dir;
+  bool flag_error_dn = false;
+  bool flag_error_dir = false;
   std::string error_dentry;   // dentry that was not found (to trigger waiters on asker)
-  bool unsolicited;
+  bool unsolicited = false;
 
-  mds_rank_t dir_auth_hint;
+  mds_rank_t dir_auth_hint = 0;
 
  public:
-  __u8 starts_with;
+  __u8 starts_with = 0;
   bufferlist trace;
 
   enum { DIR, DENTRY, INODE };

--- a/src/messages/MExportDirDiscover.h
+++ b/src/messages/MExportDirDiscover.h
@@ -19,7 +19,7 @@
 #include "include/types.h"
 
 class MExportDirDiscover : public Message {
-  mds_rank_t from;
+  mds_rank_t from = -1;
   dirfrag_t dirfrag;
   filepath path;
 


### PR DESCRIPTION
Fixes the coverity issues:

** 717271 Uninitialized scalar field
>2. uninit_member: Non-static class member from_mds is not initialized
 in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member dir_rep is not initialized
 in this constructor nor in any functions that it calls.
>CID 717271 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member discover is not initialized
 in this constructor nor in any functions that it calls.

** 717272 Uninitialized scalar field
>2. uninit_member: Non-static class member want_base_dir is not initialized
in this constructor nor in any functions that it calls.
>CID 717272 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member want_xlocked is not initialized
in this constructor nor in any functions that it calls.

** 717274 Uninitialized scalar field
>2. uninit_member: Non-static class member wanted_base_dir is not initialized
 in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member wanted_xlocked is not initialized
 in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member flag_error_dn is not initialized
 in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member flag_error_dir is not initialized
 in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member unsolicited is not initialized
 in this constructor nor in any functions that it calls.
>12. uninit_member: Non-static class member dir_auth_hint is not initialized
 in this constructor nor in any functions that it calls.
>CID 717274 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>14. uninit_member: Non-static class member starts_with is not initialized
in this constructor nor in any functions that it calls.

** 717275 Uninitialized scalar field
>CID 717275 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member from is not initialized in this
constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com