### PR TITLE
luminous: librbd: default localize parent reads to false

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5085,7 +5085,7 @@ static std::vector<Option> get_rbd_options() {
     .set_description(""),
 
     Option("rbd_localize_parent_reads", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description(""),
 
     Option("rbd_readahead_trigger_requests", Option::TYPE_INT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20941
Signed-off-by: Jason Dillaman <dillaman@redhat.com>
(cherry picked from commit cfc3d4603668e23232c2f0b9af6fd838040f47ec)