### PR TITLE
os/bluestore: Revert "os/bluestore: allow multiple DeferredBatches in flight at once"

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1629,7 +1629,7 @@ public:
 		       bufferlist::const_iterator& p);
 
     void aio_finish(BlueStore *store) override {
-      store->_deferred_aio_finish(this);
+      store->_deferred_aio_finish(osr);
     }
   };
 
@@ -1647,7 +1647,7 @@ public:
 
     boost::intrusive::list_member_hook<> deferred_osr_queue_item;
 
-    deque<DeferredBatch*> deferred_running;
+    DeferredBatch *deferred_running = nullptr;
     DeferredBatch *deferred_pending = nullptr;
 
     Sequencer *parent;
@@ -2035,9 +2035,9 @@ private:
 
   bluestore_deferred_op_t *_get_deferred_op(TransContext *txc, OnodeRef o);
   void _deferred_queue(TransContext *txc);
-  void deferred_submit_all();
+  void deferred_try_submit();
   void _deferred_submit_unlock(OpSequencer *osr);
-  void _deferred_aio_finish(DeferredBatch *b);
+  void _deferred_aio_finish(OpSequencer *osr);
   int _deferred_replay();
 
 public:


### PR DESCRIPTION
This reverts commit ca32d575eb2673737198a63643d5d1923151eba3.

If we have multiple batches in flight then we have to worry about writes
to the same blocks reordering.

Also, 3c6a6c46d5808d6c42ed4dcfb441bad64366686b is sufficient to avoid the
stall/deadlock in http://tracker.ceph.com/issues/20295.


Fixes: http://tracker.ceph.com/issues/20925
Signed-off-by: Sage Weil <sage@redhat.com>