### PR TITLE
qa/tasks/ceph.py: tolerate flush pg stats exception

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -1248,8 +1248,8 @@ def healthy(ctx, config):
 
     try:
         manager.flush_all_pg_stats()
-    except run.CommandFailedError:
-        log.info('ignoring flush pg stats error, probably testing upgrade')
+    except (run.CommandFailedError, Exception) as e:
+        log.info('ignoring flush pg stats error, probably testing upgrade: %s', e)
     manager.wait_for_clean()
 
     log.info('Waiting until ceph cluster %s is healthy...', cluster_name)


### PR DESCRIPTION
If the OSD doesn't see IO, it won't flush more pg/osd stats when the
luminous flag is not yet set (legacy pgmonitor mode).

Signed-off-by: Sage Weil <sage@redhat.com>