### PR TITLE
os/filestore: fix device/partition metadata detection

### DIFF
--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -687,8 +687,7 @@ void FileStore::collect_metadata(map<string,string> *pm)
   (*pm)["filestore_f_type"] = ss.str();
 
   if (cct->_conf->filestore_collect_device_partition_information) {
-    rc = get_device_by_uuid(get_fsid(), "PARTUUID", partition_path,
-          dev_node);
+    rc = get_device_by_fd(fsid_fd, partition_path, dev_node, PATH_MAX);
   } else {
     rc = -EINVAL;
   }


### PR DESCRIPTION
The UUID thing (a) relies on partition labels to work, which isn't
always true (and won't be true for ceph-volume going forward), and
(b) reportedly doesn't work anyway.  The fd-based helper works
just fine (even for vstart).

Fixes: http://tracker.ceph.com/issues/20944
Signed-off-by: Sage Weil <sage@redhat.com>