### PR TITLE
messages: Initializing members in MOSDPGUpdateLogMissing

### DIFF
--- a/src/messages/MOSDPGUpdateLogMissing.h
+++ b/src/messages/MOSDPGUpdateLogMissing.h
@@ -25,10 +25,10 @@ class MOSDPGUpdateLogMissing : public MOSDFastDispatchOp {
 
 
 public:
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   spg_t pgid;
   shard_id_t from;
-  ceph_tid_t rep_tid;
+  ceph_tid_t rep_tid = 0;
   mempool::osd_pglog::list<pg_log_entry_t> entries;
 
   epoch_t get_epoch() const { return map_epoch; }

--- a/src/messages/MOSDPGUpdateLogMissingReply.h
+++ b/src/messages/MOSDPGUpdateLogMissingReply.h
@@ -25,10 +25,10 @@ class MOSDPGUpdateLogMissingReply : public MOSDFastDispatchOp {
 
 
 public:
-  epoch_t map_epoch, min_epoch;
+  epoch_t map_epoch = 0, min_epoch = 0;
   spg_t pgid;
   shard_id_t from;
-  ceph_tid_t rep_tid;
+  ceph_tid_t rep_tid = 0;
 
   epoch_t get_epoch() const { return map_epoch; }
   spg_t get_pgid() const { return pgid; }


### PR DESCRIPTION
Fixes the coverity issues:

** 1355242 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.
CID 1355242 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member rep_tid is not initialized
in this constructor nor in any functions that it calls.

** 1355243 Uninitialized scalar field
>2. uninit_member: Non-static class member map_epoch is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member min_epoch is not initialized
in this constructor nor in any functions that it calls.
CID 1355243 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member rep_tid is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com