### PR TITLE
rgw: Initialize member variables in rgw_sync.h, rgw_rados.h

### DIFF
--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2855,7 +2855,7 @@ public:
         RGWObjManifest manifest;
         bool has_manifest;
         uint64_t size;
-	struct timespec mtime;
+	struct timespec mtime {};
         map<string, bufferlist> attrs;
 
         Result() : has_manifest(false), size(0) {}

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -437,7 +437,7 @@ public:
 };
 
 class RGWShardCollectCR : public RGWCoroutine {
-  int cur_shard;
+  int cur_shard = 0;
   int current_running;
   int max_concurrent;
   int status;


### PR DESCRIPTION
Fixes the coverity issues:

** 1355581 Uninitialized scalar field
>CID 1355581 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member cur_shard is not initialized in
this constructor nor in any functions that it calls.

** 1356907 Uninitialized scalar field
>2. uninit_member: Non-static class member field mtime.tv_sec is not initialized
in this constructor nor in any functions that it calls.
CID 1356907 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member field mtime.tv_nsec is not initialized
in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar amitkuma@redhat.com