### PR TITLE
mgr/dashboard: ignore 'rbd_directory' ObjectNotFound in some pools

### DIFF
--- a/src/pybind/mgr/dashboard/rbd_ls.py
+++ b/src/pybind/mgr/dashboard/rbd_ls.py
@@ -19,8 +19,10 @@ class RbdPoolLs(RemoteViewCache):
                 ioctx = self._module.rados.open_ioctx(pool)
                 ioctx.stat("rbd_directory")
                 rbd_pools.append(pool)
-            except (rados.PermissionError, rados.ObjectNotFound):
-                self.log.debug("No RBD directory in " + pool)
+            except rados.ObjectNotFound:
+                pass
+            except rados.PermissionError:
+                self.log.debug("Permission Error on " + pool)
             except:
                 self.log.exception("Failed to open pool " + pool)
 


### PR DESCRIPTION
always No RBD directory in these pools
```
2017-08-09 13:01:06.485288 7f68b4212700 20 mgr[dashboard] No RBD directory in cephfs_data_a
2017-08-09 13:01:06.487922 7f68b4212700 20 mgr[dashboard] No RBD directory in cephfs_metadata_a
2017-08-09 13:01:06.490652 7f68b4212700 20 mgr[dashboard] No RBD directory in .rgw.root
2017-08-09 13:01:06.493231 7f68b4212700 20 mgr[dashboard] No RBD directory in default.rgw.control
2017-08-09 13:01:06.495787 7f68b4212700 20 mgr[dashboard] No RBD directory in default.rgw.meta
2017-08-09 13:01:06.498206 7f68b4212700 20 mgr[dashboard] No RBD directory in default.rgw.log
```

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>