### PR TITLE
rgw: Initialize member variables

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -200,7 +200,7 @@ namespace rgw {
       uint64_t nlink;
       uint32_t owner_uid; /* XXX need Unix attr */
       uint32_t owner_gid; /* XXX need Unix attr */
-      mode_t unix_mode;
+      mode_t unix_mode = MAGIC;
       struct timespec ctime;
       struct timespec mtime;
       struct timespec atime;
@@ -2200,7 +2200,7 @@ public:
   boost::optional<RGWPutObj_Compress> compressor;
   CompressorRef plugin;
   buffer::list data;
-  uint64_t timer_id;
+  uint64_t timer_id = 0;
   MD5 hash;
   off_t real_ofs;
   size_t bytes_written;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1450,7 +1450,7 @@ WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)
 struct RGWZoneGroup : public RGWSystemMetaObj {
   string api_name;
   list<string> endpoints;
-  bool is_master;
+  bool is_master = false;
 
   string master_zone;
   map<string, RGWZone> zones;
@@ -2188,8 +2188,8 @@ struct bucket_info_entry {
 
 struct tombstone_entry {
   ceph::real_time mtime;
-  uint32_t zone_short_id;
-  uint64_t pg_ver;
+  uint32_t zone_short_id = 0;
+  uint64_t pg_ver = 0;
 
   tombstone_entry() = default;
   tombstone_entry(const RGWObjState& state)


### PR DESCRIPTION
Fixes the coverity issues:

** 1396118 Uninitialized scalar field
>CID 1396118 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member unix_mode is not initialized
in this constructor nor in any functions that it calls.

** 1396121 Uninitialized scalar field
>CID 1396121 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member is_master is not initialized
in this constructor nor in any functions that it calls.

** 1396137 Uninitialized scalar field
>CID 1396137 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>3. uninit_member: Non-static class member timer_id is not initialized
in this constructor nor in any functions that it calls.

** 1396138 Uninitialized scalar field
>2. uninit_member: Non-static class member zone_short_id is not initialized
in this constructor nor in any functions that it calls.
CID 1396138 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member pg_ver is not initialized in this
constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com