### PR TITLE
cls/rgw: Initialization of uninitialized members

### DIFF
--- a/src/cls/rgw/cls_rgw_ops.h
+++ b/src/cls/rgw/cls_rgw_ops.h
@@ -1100,7 +1100,7 @@ WRITE_CLASS_ENCODER(cls_rgw_lc_get_head_ret)
 
 struct cls_rgw_lc_list_entries_op {
   string marker;
-  uint32_t max_entries;
+  uint32_t max_entries = 0;
 
   cls_rgw_lc_list_entries_op() {}
 

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -1045,7 +1045,7 @@ WRITE_CLASS_ENCODER(cls_rgw_gc_obj_info)
 
 struct cls_rgw_lc_obj_head
 {
-  time_t start_date;
+  time_t start_date = 0;
   string marker;
 
   cls_rgw_lc_obj_head() {}


### PR DESCRIPTION
Fixes the coverity issues:

** 1396131 Uninitialized scalar field
>CID 1396131 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member max_entries is not initialized
in this constructor nor in any functions that it calls.

** 1396125 Uninitialized scalar field
>CID 1396125 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member start_date is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com