### PR TITLE
rgw: Initialize is_master, max_aio, size

### DIFF
--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -199,7 +199,7 @@ struct RGWBucketAdminOpState {
   bool fix_index;
   bool delete_child_objects;
   bool bucket_stored;
-  int max_aio;
+  int max_aio = 0;
 
   rgw_bucket bucket;
 

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -1450,7 +1450,7 @@ WRITE_CLASS_ENCODER(RGWZoneGroupPlacementTarget)
 struct RGWZoneGroup : public RGWSystemMetaObj {
   string api_name;
   list<string> endpoints;
-  bool is_master;
+  bool is_master = false;
 
   string master_zone;
   map<string, RGWZone> zones;

--- a/src/rgw/rgw_sync_module.h
+++ b/src/rgw/rgw_sync_module.h
@@ -109,7 +109,7 @@ protected:
   rgw_obj_key key;
 
   ceph::real_time mtime;
-  uint64_t size;
+  uint64_t size = 0;
   map<string, bufferlist> attrs;
 public:
   RGWStatRemoteObjCBCR(RGWDataSyncEnv *_sync_env,


### PR DESCRIPTION
Fixes the coverity issue:

** 1396142 Uninitialized scalar field
>CID 1396142 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member max_aio is not initialized in
this constructor nor in any functions that it calls.

** 1396205 Uninitialized scalar field
>CID 1396205 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member is_master is not initialized
in this constructor nor in any functions that it calls.

** 1396150 Uninitialized scalar field
>CID 1396150 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member size is not initialized in
this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com