### PR TITLE
librbd: Initializing members image,operation,journal

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -64,7 +64,7 @@ struct C_IsTagOwner : public Context {
   Journaler *journaler;
   cls::journal::Client client;
   journal::ImageClientMeta client_meta;
-  uint64_t tag_tid;
+  uint64_t tag_tid = 0;
   journal::TagData tag_data;
 
   C_IsTagOwner(librados::IoCtx &io_ctx, const std::string &image_id,

--- a/src/librbd/image/CreateRequest.h
+++ b/src/librbd/image/CreateRequest.h
@@ -124,13 +124,13 @@ private:
   Context *m_on_finish;
 
   CephContext *m_cct;
-  int m_r_saved;  // used to return actual error after cleanup
+  int m_r_saved = 0;  // used to return actual error after cleanup
   bool m_force_non_primary;
   file_layout_t m_layout;
   std::string m_id_obj, m_header_obj, m_objmap_name;
 
   bufferlist m_outbl;
-  rbd_mirror_mode_t m_mirror_mode;
+  rbd_mirror_mode_t m_mirror_mode = RBD_MIRROR_MODE_DISABLED;
   cls::rbd::MirrorImage m_mirror_image_internal;
 
   void validate_pool();

--- a/src/librbd/image/RefreshRequest.h
+++ b/src/librbd/image/RefreshRequest.h
@@ -122,11 +122,11 @@ private:
 
   bufferlist m_out_bl;
 
-  uint8_t m_order;
-  uint64_t m_size;
-  uint64_t m_features;
-  uint64_t m_incompatible_features;
-  uint64_t m_flags;
+  uint8_t m_order = 0;
+  uint64_t m_size = 0;
+  uint64_t m_features = 0;
+  uint64_t m_incompatible_features = 0;
+  uint64_t m_flags = 0;
   std::string m_object_prefix;
   ParentInfo m_parent_md;
   cls::rbd::GroupSpec m_group_spec;
@@ -143,7 +143,7 @@ private:
   std::map<rados::cls::lock::locker_id_t,
            rados::cls::lock::locker_info_t> m_lockers;
   std::string m_lock_tag;
-  bool m_exclusive_locked;
+  bool m_exclusive_locked = false;
 
   bool m_blocked_writes = false;
   bool m_incomplete_update = false;


### PR DESCRIPTION
Fixes the coverity issues:

** 1398907 Uninitialized scalar field
>CID 1398907 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member tag_tid is not initialized in
this constructor nor in any functions that it calls.

** 1398906 Uninitialized scalar field
>22. uninit_member: Non-static class member m_r_saved is not initialized in
this constructor nor in any functions that it calls.
>CID 1398906 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>24. uninit_member: Non-static class member m_mirror_mode is not initialized
in this constructor nor in any functions that it calls.

** 1399592 Uninitialized scalar field
>2. uninit_member: Non-static class member m_order is not initialized in this
constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member m_size is not initialized in this
constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member m_features is not initialized in
this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member m_incompatible_features is not
initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member m_flags is not initialized in
this constructor nor in any functions that it calls.
>CID 1399592 (#1-2 of 2): Uninitialized scalar field (UNINIT_CTOR)
>12. uninit_member: Non-static class member m_exclusive_locked is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com