### PR TITLE
mon/Elector: force election epoch bump on start

### DIFF
--- a/qa/suites/upgrade/kraken-x/stress-split/0-cluster/start.yaml
+++ b/qa/suites/upgrade/kraken-x/stress-split/0-cluster/start.yaml
@@ -6,6 +6,10 @@ meta:
 overrides:
   ceph:
     fs: xfs
+    log-whitelist:
+      - overall HEALTH_
+      - \(MON_DOWN\)
+      - \(MGR_DOWN\)
     conf:
       global:
         enable experimental unrecoverable data corrupting features: "*"


### PR DESCRIPTION
http://tracker.ceph.com/issues/20949

Also a kraken-x upgrade whitelist adjustment.