### PR TITLE
bluestore: fixed compilation error when enable spdk with gcc 4.8.5

### DIFF
--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -65,8 +65,6 @@ endif()
 if(WITH_SPDK)
   list(APPEND libos_srcs
     bluestore/NVMEDevice.cc)
-  ADD_DEFINITIONS(-D__SSE4_2__ -D__SSE4_1__ -D__SSSE3__ -D__SSE3__)
-  add_compile_options(-mcrc32 -msse3 -mssse3 -msse4.1 -msse4.2)
 endif()
 
 add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)


### PR DESCRIPTION
The change is induced by my commit https://github.com/ceph/ceph/pull/12672.

At that time, "add_compile_options" is needed to fix compile error.
But since we've updated spdk to 17.07 and related spdk/dpdk.git, add_compile_options is no longer needed. 

If we leave it in CMakelists.txt, "add_compile_options" can not be identified by low gcc version, and the developer has to upgrade gcc to 6.X.X. 

By this reason, I revert this change.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Ziye Yang <optimistyzy@gmail.com>