### PR TITLE
luminous: rbd-mirror: align use of uint64_t in service_daemon::AttributeType

### DIFF
--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -333,9 +333,9 @@ void InstanceReplayer<I>::start_image_replayers(int r) {
     return;
   }
 
-  size_t image_count = 0;
-  size_t warning_count = 0;
-  size_t error_count = 0;
+  uint64_t image_count = 0;
+  uint64_t warning_count = 0;
+  uint64_t error_count = 0;
   for (auto it = m_image_replayers.begin();
        it != m_image_replayers.end();) {
     auto current_it(it);

--- a/src/tools/rbd_mirror/PoolWatcher.h
+++ b/src/tools/rbd_mirror/PoolWatcher.h
@@ -52,7 +52,7 @@ public:
   void init(Context *on_finish = nullptr);
   void shut_down(Context *on_finish);
 
-  inline size_t get_image_count() const {
+  inline uint64_t get_image_count() const {
     Mutex::Locker locker(m_lock);
     return m_image_ids.size();
   }


### PR DESCRIPTION
size_t on a 32-bit architecture is a 32 bit unsigned int which
created ambiguity when casting to bool, uint64_t or std::string
(which are boost::variants for service_daemon::AttributeType).

Align to use of uint64_t to resolve compilation failures in
all 32-bit architectures.

Signed-off-by: James Page <james.page@ubuntu.com>
(cherry picked from commit 87fe8e81bc8c9b55c6bef4144714a33e042dc2f7)