### PR TITLE
os/bluestore: Decrease code path in _kv_finalize_thread

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -64,6 +64,9 @@ enum {
   l_bluestore_state_aio_wait_lat,
   l_bluestore_state_io_done_lat,
   l_bluestore_state_kv_queued_lat,
+  l_bluestore_state_kv_submitted_all_lat,
+  l_bluestore_state_kv_deferred_lat,
+  l_bluestore_state_kv_begin_finalize_lat,
   l_bluestore_state_kv_committing_lat,
   l_bluestore_state_kv_done_lat,
   l_bluestore_state_deferred_queued_lat,
@@ -1506,6 +1509,9 @@ public:
       case l_bluestore_state_aio_wait_lat: return "aio_wait";
       case l_bluestore_state_io_done_lat: return "io_done";
       case l_bluestore_state_kv_queued_lat: return "kv_queued";
+      case l_bluestore_state_kv_submitted_all_lat: return "kv_submitted_all";
+      case l_bluestore_state_kv_begin_finalize_lat: return "kv_begin_finalize_lat";
+      case l_bluestore_state_kv_deferred_lat: return "kv_deferred_lat";
       case l_bluestore_state_kv_committing_lat: return "kv_committing";
       case l_bluestore_state_kv_done_lat: return "kv_done";
       case l_bluestore_state_deferred_queued_lat: return "deferred_queued";


### PR DESCRIPTION
I added more state latency measurements in BlueStore.cc.
https://github.com/lixiaoy1/ceph/commit/62b8e100e8a8a298f97e6e63447538af6c2ac587

Run 4k randrom write with bluestore fio, it has following latency stats:

unit: us
state_prepare_lat	1060
state_aio_wait_lat	112
state_io_done_lat	40
state_kv_queued_lat	4849
state_kv_submitted_all_lat	2153
state_kv_deferred_lat	573
state_kv_begin_finalize_lat	28247
state_kv_commiting_lat	0
state_kv_done_lat	0

The time state_kv_begin_finalize_lat is big, it starts from putting the txc into finalize_queue, to the time when _kv_finalize_thread handles the txc. 

I found that during IO running the finalize_queue becomes longer and longer, 
the length is bigger than 1000. Some thing in the function takes time.
_kv_finalize_thread calls _txc_state_rpoc for each txc. And this function calls _txc_finish() which takes time. The time of _txc_finish() takes about 60us in my case.

In this patch it adds a new thread to run _kv_finish instead of in _kv_finalize_thread.

Some tests results are appended later. 

Signed-off-by: Xiaoyan Li xiaoyan.li@intel.com