### PR TITLE
osd/PG: force rebuild of missing set on jewel upgrade

### DIFF
--- a/qa/suites/upgrade/jewel-x/parallel/1-jewel-install/jewel.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/1-jewel-install/jewel.yaml
@@ -31,10 +31,3 @@ tasks:
     mon.a:
     mon.b:
 - print: "**** done install.upgrade mon.a and mon.b"
-- parallel:
-    - workload
-    - upgrade-sequence
-- print: "**** done parallel"
-- install.upgrade:
-    client.0:
-- print: "**** done install.upgrade on client.0"

--- a/qa/suites/upgrade/jewel-x/parallel/1.5-thrash-layout/yes.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/1.5-thrash-layout/yes.yaml
@@ -1,0 +1,19 @@
+tasks:
+- thrashosds:
+    timeout: 1200
+    chance_down: 0
+    disable_objectstore_tool_tests: true
+    chance_thrash_pg_upmap: 0
+    chance_thrash_pg_upmap_items: 0
+    chance_thrash_cluster_full: 0
+    dump_ops_enable: false
+    sighup_delay: 0
+overrides:
+  ceph:
+    log-whitelist:
+      - overall HEALTH_
+      - \(OSDMAP_FLAGS\)
+      - \(SMALLER_PGP_NUM\)
+      - \(OBJECT_
+      - \(REQUEST_SLOW\)
+      - \(TOO_FEW_PGS\)

--- a/qa/suites/upgrade/jewel-x/parallel/1.7-workload-and-upgrade.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/1.7-workload-and-upgrade.yaml
@@ -1,0 +1,8 @@
+tasks:
+- parallel:
+    - workload
+    - upgrade-sequence
+- print: "**** done parallel"
+- install.upgrade:
+    client.0:
+- print: "**** done install.upgrade on client.0"

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -328,7 +328,9 @@ int get_log(ObjectStore *fs, __u8 struct_ver,
     PGLog::read_log_and_missing(fs, coll,
 		    struct_ver >= 8 ? coll : coll_t::meta(),
 		    struct_ver >= 8 ? pgid.make_pgmeta_oid() : log_oid,
-		    info, log, missing, oss,
+		    info, log, missing,
+				struct_ver < 9,
+				oss,
 		    g_ceph_context->_conf->osd_ignore_stale_divergent_priors);
     if (debug && oss.str().size())
       cerr << oss.str() << std::endl;


### PR DESCRIPTION
Previously we were detecting the need to rebuild missing based on
whether the "divergent_priors" omap key was present.  Unfortunately,
jewel does not always set this, so it is not a reliable indicator.
(It only gets set if you actually have a divergent prior at some
point in the PG's life time on that OSD.)

Fix by using the info_struct_v on the PG to detect whether we need
to do the conversion.  We didn't bump the value when we adding
the missing persistence, but the fastinfo was also added during
the same period between jewel and kraken, so it will work just as
well.

Fixes: http://tracker.ceph.com/issues/20958
Signed-off-by: Sage Weil <sage@redhat.com>