### PR TITLE
jewel: rgw: replace '+' with "%20" in canonical query string for s3 v4 auth.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3734,6 +3734,8 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s)
 
   if (!s->aws4_auth->canonical_qs.empty()) {
 
+    boost::replace_all(s->aws4_auth->canonical_qs, "+", "%20");
+
     /* handle case when query string exists. Step 3 in
      * http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html */
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20501

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>
Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>