### PR TITLE
rgw: fix opslog uri as per Amazon s3

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -63,6 +63,11 @@ void ClientIO::init_env(CephContext *cct)
     env.set(buf, value);
   }
 
+  int major = request.version / 10;
+  int minor = request.version % 10;
+  std::string http_version = std::to_string(major) + '.' + std::to_string(minor);
+  env.set("HTTP_VERSION", http_version);
+
   env.set("REQUEST_METHOD", request.method);
 
   // split uri from query

--- a/src/rgw/rgw_civetweb.cc
+++ b/src/rgw/rgw_civetweb.cc
@@ -112,6 +112,7 @@ void RGWCivetWeb::init_env(CephContext *cct)
 
   env.set("REMOTE_ADDR", info->remote_addr);
   env.set("REQUEST_METHOD", info->request_method);
+  env.set("HTTP_VERSION", info->http_version);
   env.set("REQUEST_URI", info->request_uri); // get the full uri, we anyway handle abs uris later
   env.set("SCRIPT_URI", info->uri); /* FIXME */
   if (info->query_string) {

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -356,7 +356,23 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
     set_param_str(s, "HTTP_REFERRER", entry.referrer);
   else
     set_param_str(s, "HTTP_REFERER", entry.referrer);
-  set_param_str(s, "REQUEST_URI", entry.uri);
+
+  std::string uri(s->info.env->get("REQUEST_METHOD"));
+  uri.append(" ");
+
+  uri.append(s->info.env->get("REQUEST_URI"));
+  const char* qs = s->info.env->get("QUERY_STRING");
+  if(qs && (*qs != '\0')) {
+    uri.append("?");
+    uri.append(qs);
+  }
+
+  uri.append(" ");
+  uri.append("HTTP/");
+  uri.append(s->info.env->get("HTTP_VERSION"));
+
+  entry.uri = std::move(uri);
+
   set_param_str(s, "REQUEST_METHOD", entry.op);
 
   /* custom header logging */


### PR DESCRIPTION
According to Amazon s3[1], current Request-URI opslog entry are missing:

+ request method
+ query string
+ http version number

[1] http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html

Fixes: http://tracker.ceph.com/issues/20971

Reported-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>
Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>