### PR TITLE
client: skip lookupname if writing to unlinked file

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -13007,6 +13007,12 @@ Inode *Client::get_quota_root(Inode *in, const UserPerm& perms)
     if (cur == root_ancestor)
       break;
 
+    // deleted inode
+    if (cur->nlink == 0) {
+      cur = root_ancestor;
+      break;
+    }
+
     MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LOOKUPNAME);
     filepath path(cur->ino);
     req->set_filepath(path);


### PR DESCRIPTION
When a client writes to an unlinked file, get_quota_root tries to
resolve the filename via an MDS lookupname op. The op always results in
-13 permission denied for path-restricted caps or -2 no such file or
directory otherwise. More importantly, the repeated lookupname ops slow
down buffered writes significantly.

Don't do the lookupname for unlinked files; use the root_ancentor's
quota instead.

Fixes: http://tracker.ceph.com/issues/20945
Backport: jewel, luminous
Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>