### PR TITLE
ceph-volume: tests add tests for the is_mounted utility

### DIFF
--- a/src/ceph-volume/ceph_volume/tests/util/test_system.py
+++ b/src/ceph-volume/ceph_volume/tests/util/test_system.py
@@ -1,6 +1,7 @@
 import os
 import pwd
 import getpass
+from textwrap import dedent
 from ceph_volume.util import system
 
 
@@ -32,3 +33,57 @@ class TestMkdirP(object):
         system.mkdir_p(path, chown=False)
         assert os.path.isdir(path)
 
+
+class TestIsMounted(object):
+
+    def test_not_mounted(self, tmpdir, monkeypatch):
+        PROCDIR = str(tmpdir)
+        proc_path = os.path.join(PROCDIR, 'mounts')
+        with open(proc_path, 'w') as f:
+            f.write('')
+        monkeypatch.setattr(system, 'PROCDIR', PROCDIR)
+        assert system.is_mounted('sdb') is False
+
+    def test_is_mounted_(self, tmpdir, monkeypatch):
+        PROCDIR = str(tmpdir)
+        proc_path = os.path.join(PROCDIR, 'mounts')
+        with open(proc_path, 'w') as f:
+            f.write(dedent("""nfsd /proc/fs/nfsd nfsd rw,relatime 0 0
+                    /dev/sdc2 /boot xfs rw,seclabel,relatime,attr2,inode64,noquota 0 0
+                    tmpfs /run/user/1000 tmpfs rw,seclabel,mode=700,uid=1000,gid=1000 0 0"""))
+        monkeypatch.setattr(system, 'PROCDIR', PROCDIR)
+        monkeypatch.setattr(os.path, 'exists', lambda x: True)
+        assert system.is_mounted('/dev/sdc2') is True
+
+    def test_ignores_two_fields(self, tmpdir, monkeypatch):
+        PROCDIR = str(tmpdir)
+        proc_path = os.path.join(PROCDIR, 'mounts')
+        with open(proc_path, 'w') as f:
+            f.write(dedent("""nfsd /proc/fs/nfsd nfsd rw,relatime 0 0
+                    /dev/sdc2 /boot
+                    tmpfs /run/user/1000 tmpfs rw,seclabel,mode=700,uid=1000,gid=1000 0 0"""))
+        monkeypatch.setattr(system, 'PROCDIR', PROCDIR)
+        monkeypatch.setattr(os.path, 'exists', lambda x: True)
+        assert system.is_mounted('/dev/sdc2') is False
+
+    def test_not_mounted_at_destination(self, tmpdir, monkeypatch):
+        PROCDIR = str(tmpdir)
+        proc_path = os.path.join(PROCDIR, 'mounts')
+        with open(proc_path, 'w') as f:
+            f.write(dedent("""nfsd /proc/fs/nfsd nfsd rw,relatime 0 0
+                    /dev/sdc2 /var/lib/ceph/osd/ceph-9 xfs rw,attr2,inode64,noquota 0 0
+                    tmpfs /run/user/1000 tmpfs rw,seclabel,mode=700,uid=1000,gid=1000 0 0"""))
+        monkeypatch.setattr(system, 'PROCDIR', PROCDIR)
+        monkeypatch.setattr(os.path, 'exists', lambda x: True)
+        assert system.is_mounted('/dev/sdc2', '/var/lib/ceph/osd/ceph-0') is False
+
+    def test_is_mounted_at_destination(self, tmpdir, monkeypatch):
+        PROCDIR = str(tmpdir)
+        proc_path = os.path.join(PROCDIR, 'mounts')
+        with open(proc_path, 'w') as f:
+            f.write(dedent("""nfsd /proc/fs/nfsd nfsd rw,relatime 0 0
+                    /dev/sdc2 /var/lib/ceph/osd/ceph-0 xfs rw,attr2,inode64,noquota 0 0
+                    tmpfs /run/user/1000 tmpfs rw,seclabel,mode=700,uid=1000,gid=1000 0 0"""))
+        monkeypatch.setattr(system, 'PROCDIR', PROCDIR)
+        monkeypatch.setattr(os.path, 'exists', lambda x: True)
+        assert system.is_mounted('/dev/sdc2', '/var/lib/ceph/osd/ceph-0') is True

--- a/src/ceph-volume/ceph_volume/util/__init__.py
+++ b/src/ceph-volume/ceph_volume/util/__init__.py
@@ -1,0 +1,10 @@
+
+def as_string(string):
+    """
+    Ensure that whatever type of string is incoming, it is returned as an
+    actual string, versus 'bytes' which Python 3 likes to use.
+    """
+    if isinstance(string, bytes):
+        # we really ignore here if we can't properly decode with utf-8
+        return string.decode('utf-8', 'ignore')
+    return string

--- a/src/ceph-volume/ceph_volume/util/system.py
+++ b/src/ceph-volume/ceph_volume/util/system.py
@@ -4,6 +4,7 @@ import pwd
 import platform
 import uuid
 from ceph_volume import process
+from . import as_string
 
 
 # TODO: get these out of here and into a common area for others to consume
@@ -94,10 +95,10 @@ def is_mounted(source, destination=None):
             mounted_path = fields[1]
             if os.path.isabs(mounted_device) and os.path.exists(mounted_device):
                 mounted_device = os.path.realpath(mounted_device)
-                if mounted_device == dev:
+                if as_string(mounted_device) == dev:
                     if destination:
                         destination = os.path.realpath(destination)
-                        return destination == os.path.realpath(mounted_path)
+                        return destination == as_string(os.path.realpath(mounted_path))
                     else:
                         return True
     return False


### PR DESCRIPTION
To get tests passing, the actual commits that have the functionality this PR tests went into PR #16919 

A bit of the logic to look into `mounts` came from ceph-disk, we are adapting a bit to make it a boolean, and we added actual unit tests too.

It fixes an issue with Python3 where `is_mounted` would not work because it was comparing bytes to strings.