### PR TITLE
mon: return directly after health_events_cleanup

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2359,6 +2359,7 @@ void Monitor::health_to_clog_update_conf(const std::set<std::string> &changed)
   if (changed.count("mon_health_to_clog")) {
     if (!cct->_conf->mon_health_to_clog) {
       health_events_cleanup();
+      return;
     } else {
       if (!health_tick_event) {
         health_tick_start();


### PR DESCRIPTION
when mon_health_to_clog was set false, all health events was cleanup,
no need to judge the change of mon_health_to_clog_interval and
mon_health_to_clog_tick_interval.

Signed-off-by: wang yang <yang.wang@easystack.cn>