### PR TITLE
rgw: disable dynamic reshading for 1st L point release

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4927,7 +4927,7 @@ std::vector<Option> get_rgw_options() {
     .set_description(""),
 
     Option("rgw_dynamic_resharding", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description(""),
 
     Option("rgw_max_objs_per_shard", Option::TYPE_INT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Temporarily default RGW dynamic bucket resharding to OFF (usability
standup).

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>