### PR TITLE
rbd: fix logically dead code in function list_process_image

### DIFF
--- a/src/tools/rbd/action/List.cc
+++ b/src/tools/rbd/action/List.cc
@@ -141,7 +141,7 @@ int list_process_image(librados::Rados* rados, WorkerEntry* w, bool lflag, Forma
     }
   }
 
-  return r < 0 ? r : 0;
+  return 0;
 }
 
 int do_list(std::string &pool_name, bool lflag, int threads, Formatter *f) {


### PR DESCRIPTION
Fix CID 1416367 (#1 of 1):
Logically dead code (DEADCODE)
dead_error_line: Execution cannot reach the expression r inside this statement: return (r < 0) ? r : 0;.

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>