### PR TITLE
doc/mgr/plugins: mgr accessor during init causes exception

### DIFF
--- a/doc/mgr/plugins.rst
+++ b/doc/mgr/plugins.rst
@@ -97,6 +97,9 @@ have no metadata, or vice versa.  On a healthy cluster these
 will be very rare transient states, but plugins should be written
 to cope with the possibility.
 
+Note that these accessors must not be called in the modules ``__init__``
+function. This will result in a circular locking exception.
+
 ``get(self, data_name)``
 
 Fetch named cluster-wide objects such as the OSDMap.  Valid things


### PR DESCRIPTION
Currently calling a mgr accessor during a plugins __init__ method causes
a cyclic locking exception.

Signed-off-by: Jan Fajerski <jfajerski@suse.com>