### PR TITLE
mgr: implement 'osd safe-to-destroy' and 'osd ok-to-stop' commands

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -39,7 +39,7 @@ Synopsis
 
 | **ceph** **mon_status**
 
-| **ceph** **osd** [ *blacklist* \| *blocked-by* \| *create* \| *new* \| *deep-scrub* \| *df* \| *down* \| *dump* \| *erasure-code-profile* \| *find* \| *getcrushmap* \| *getmap* \| *getmaxosd* \| *in* \| *lspools* \| *map* \| *metadata* \| *out* \| *pause* \| *perf* \| *pg-temp* \| *force-create-pg* \| *primary-affinity* \| *primary-temp* \| *repair* \| *reweight* \| *reweight-by-pg* \| *rm* \| *destroy* \| *purge* \| *scrub* \| *set* \| *setcrushmap* \| *setmaxosd*  \| *stat* \| *tree* \| *unpause* \| *unset* ] ...
+| **ceph** **osd** [ *blacklist* \| *blocked-by* \| *create* \| *new* \| *deep-scrub* \| *df* \| *down* \| *dump* \| *erasure-code-profile* \| *find* \| *getcrushmap* \| *getmap* \| *getmaxosd* \| *in* \| *lspools* \| *map* \| *metadata* \| *ok-to-stop* \| *out* \| *pause* \| *perf* \| *pg-temp* \| *force-create-pg* \| *primary-affinity* \| *primary-temp* \| *repair* \| *reweight* \| *reweight-by-pg* \| *rm* \| *destroy* \| *purge* \| *safe-to-destroy* \| *scrub* \| *set* \| *setcrushmap* \| *setmaxosd*  \| *stat* \| *tree* \| *unpause* \| *unset* ] ...
 
 | **ceph** **osd** **crush** [ *add* \| *add-bucket* \| *create-or-move* \| *dump* \| *get-tunable* \| *link* \| *move* \| *remove* \| *rename-bucket* \| *reweight* \| *reweight-all* \| *reweight-subtree* \| *rm* \| *rule* \| *set* \| *set-tunable* \| *show-tunables* \| *tunables* \| *unlink* ] ...
 
@@ -874,6 +874,18 @@ Usage::
 
 	ceph osd out <ids> [<ids>...]
 
+Subcommand ``ok-to-stop`` checks whether the list of OSD(s) can be
+stopped without immediately making data unavailable.  That is, all
+data should remain readable and writeable, although data redundancy
+may be reduced as some PGs may end up in a degraded (but active)
+state.  It will return a success code if it is okay to stop the
+OSD(s), or an error code and informative message if it is not or if no
+conclusion can be drawn at the current time.
+
+Usage::
+
+  ceph osd ok-to-stop <id> [<ids>...]
+
 Subcommand ``pause`` pauses osd.
 
 Usage::
@@ -1065,6 +1077,16 @@ Subcommand ``purge`` performs a combination of ``osd destroy``,
 Usage::
 
     ceph osd purge <id> {--yes-i-really-mean-it}
+
+Subcommand ``safe-to-destroy`` checks whether it is safe to remove or
+destroy an OSD without reducing overall data redundancy or durability.
+It will return a success code if it is definitely safe, or an error
+code and informative message if it is not or if no conclusion can be
+drawn at the current time.
+
+Usage::
+
+  ceph osd safe-to-destroy <id> [<ids>...]
 
 Subcommand ``scrub`` initiates scrub on specified osd.
 

--- a/doc/release-notes.rst
+++ b/doc/release-notes.rst
@@ -211,6 +211,11 @@ Major Changes from Kraken
     - ``ceph osd {add,rm}-{noout,noin,nodown,noup}`` allow the
       `noout`, `noin`, `nodown`, and `noup` flags to be applied to
       specific OSDs.
+    - ``ceph osd safe-to-destroy <osd(s)>`` will report whether it is safe to
+      remove or destroy OSD(s) without reducing data durability or redundancy.
+    - ``ceph osd ok-to-stop <osd(s)>`` will report whether it is okay to stop
+      OSD(s) without immediately compromising availability (i.e., all PGs
+      should remain active but may be degraded).
     - ``ceph log last [n]`` will output the last *n* lines of the cluster
       log.
     - ``ceph mgr dump`` will dump the MgrMap, including the currently active

--- a/src/mgr/ClusterState.cc
+++ b/src/mgr/ClusterState.cc
@@ -70,16 +70,8 @@ void ClusterState::ingest_pgstats(MPGStats *stats)
   Mutex::Locker l(lock);
 
   const int from = stats->get_orig_source().num();
-  bool is_in = false;
-  objecter->with_osdmap([&is_in, from](const OSDMap &osd_map){
-      is_in = osd_map.is_in(from);
-  });
 
-  if (is_in) {
-    pending_inc.update_stat(from, stats->epoch, std::move(stats->osd_stat));
-  } else {
-    pending_inc.update_stat(from, stats->epoch, osd_stat_t());
-  }
+  pending_inc.update_stat(from, stats->epoch, std::move(stats->osd_stat));
 
   for (auto p : stats->pg_stat) {
     pg_t pgid = p.first;

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -924,6 +924,163 @@ bool DaemonServer::handle_command(MCommand *m)
       });
     cmdctx->reply(r, "");
     return true;
+  } else if (prefix == "osd safe-to-destroy") {
+    vector<string> ids;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "ids", ids);
+    set<int> osds;
+    int r;
+    cluster_state.with_osdmap([&](const OSDMap& osdmap) {
+	r = osdmap.parse_osd_id_list(ids, &osds, &ss);
+      });
+    if (!r && osds.empty()) {
+      ss << "must specify one or more OSDs";
+      r = -EINVAL;
+    }
+    if (r < 0) {
+      cmdctx->reply(r, ss);
+      return true;
+    }
+    set<int> active_osds, missing_stats, stored_pgs;
+    int affected_pgs = 0;
+    cluster_state.with_pgmap([&](const PGMap& pg_map) {
+	if (pg_map.num_pg_unknown > 0) {
+	  ss << pg_map.num_pg_unknown << " pgs have unknown state; cannot draw"
+	     << " any conclusions";
+	  r = -EAGAIN;
+	  return;
+	}
+	int num_active_clean = 0;
+	for (auto& p : pg_map.num_pg_by_state) {
+	  unsigned want = PG_STATE_ACTIVE|PG_STATE_CLEAN;
+	  if ((p.first & want) == want) {
+	    num_active_clean += p.second;
+	  }
+	}
+	cluster_state.with_osdmap([&](const OSDMap& osdmap) {
+	    for (auto osd : osds) {
+	      if (!osdmap.exists(osd)) {
+		continue;  // clearly safe to destroy
+	      }
+	      auto q = pg_map.num_pg_by_osd.find(osd);
+	      if (q != pg_map.num_pg_by_osd.end()) {
+		if (q->second.acting > 0 || q->second.up > 0) {
+		  active_osds.insert(osd);
+		  affected_pgs += q->second.acting + q->second.up;
+		  continue;
+		}
+	      }
+	      if (num_active_clean < pg_map.num_pg) {
+		// all pgs aren't active+clean; we need to be careful.
+		auto p = pg_map.osd_stat.find(osd);
+		if (p == pg_map.osd_stat.end()) {
+		  missing_stats.insert(osd);
+		}
+		if (p->second.num_pgs > 0) {
+		  stored_pgs.insert(osd);
+		}
+	      }
+	    }
+	  });
+      });
+    if (!r && !active_osds.empty()) {
+      ss << "OSD(s) " << active_osds << " have " << affected_pgs
+	 << " pgs currently mapped to them";
+      r = -EBUSY;
+    } else if (!missing_stats.empty()) {
+      ss << "OSD(s) " << missing_stats << " have no reported stats, and not all"
+	 << " PGs are active+clean; we cannot draw any conclusions";
+      r = -EAGAIN;
+    } else if (!stored_pgs.empty()) {
+      ss << "OSD(s) " << stored_pgs << " last reported they still store some PG"
+	 << " data, and not all PGs are active+clean; we cannot be sure they"
+	 << " aren't still needed.";
+      r = -EBUSY;
+    }
+    if (r) {
+      cmdctx->reply(r, ss);
+      return true;
+    }
+    ss << "OSD(s) " << osds << " are safe to destroy without reducing data"
+       << " durability.";
+    cmdctx->reply(0, ss);
+    return true;
+  } else if (prefix == "osd ok-to-stop") {
+    vector<string> ids;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "ids", ids);
+    set<int> osds;
+    int r;
+    cluster_state.with_osdmap([&](const OSDMap& osdmap) {
+	r = osdmap.parse_osd_id_list(ids, &osds, &ss);
+      });
+    if (!r && osds.empty()) {
+      ss << "must specify one or more OSDs";
+      r = -EINVAL;
+    }
+    if (r < 0) {
+      cmdctx->reply(r, ss);
+      return true;
+    }
+    map<pg_t,int> pg_delta;  // pgid -> net acting set size change
+    int dangerous_pgs = 0;
+    cluster_state.with_pgmap([&](const PGMap& pg_map) {
+	return cluster_state.with_osdmap([&](const OSDMap& osdmap) {
+	    if (pg_map.num_pg_unknown > 0) {
+	      ss << pg_map.num_pg_unknown << " pgs have unknown state; "
+		 << "cannot draw any conclusions";
+	      r = -EAGAIN;
+	      return;
+	    }
+	    for (auto osd : osds) {
+	      auto p = pg_map.pg_by_osd.find(osd);
+	      if (p != pg_map.pg_by_osd.end()) {
+		for (auto& pgid : p->second) {
+		  --pg_delta[pgid];
+		}
+	      }
+	    }
+	    for (auto& p : pg_delta) {
+	      auto q = pg_map.pg_stat.find(p.first);
+	      if (q == pg_map.pg_stat.end()) {
+		ss << "missing information about " << p.first << "; cannot draw"
+		   << " any conclusions";
+		r = -EAGAIN;
+		return;
+	      }
+	      if (!(q->second.state & PG_STATE_ACTIVE) ||
+		  (q->second.state & PG_STATE_DEGRADED)) {
+		// we don't currently have a good way to tell *how* degraded
+		// a degraded PG is, so we have to assume we cannot remove
+		// any more replicas/shards.
+		++dangerous_pgs;
+		continue;
+	      }
+	      const pg_pool_t *pi = osdmap.get_pg_pool(p.first.pool());
+	      if (!pi) {
+		++dangerous_pgs; // pool is creating or deleting
+	      } else {
+		if (q->second.acting.size() + p.second < pi->min_size) {
+		  ++dangerous_pgs;
+		}
+	      }
+	    }
+	  });
+      });
+    if (r) {
+      cmdctx->reply(r, ss);
+      return true;
+    }
+    if (dangerous_pgs) {
+      ss << dangerous_pgs << " PGs are already degraded or might become "
+	 << "unavailable";
+      cmdctx->reply(-EBUSY, ss);
+      return true;
+    }
+    ss << "OSD(s) " << osds << " are ok to stop without reducing"
+       << " availability, provided there are no other concurrent failures"
+       << " or interventions. " << pg_delta.size() << " PGs are likely to be"
+       << " degraded (but remain available) as a result.";
+    cmdctx->reply(0, ss);
+    return true;
   } else if (prefix == "pg force-recovery" ||
   	       prefix == "pg force-backfill" ||
   	       prefix == "pg cancel-force-recovery" ||

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -107,6 +107,13 @@ COMMAND("osd test-reweight-by-pg " \
 	"dry run of reweight OSDs by PG distribution [overload-percentage-for-consideration, default 120]", \
 	"osd", "r", "cli,rest")
 
+COMMAND("osd safe-to-destroy name=ids,type=CephString,n=N",
+	"check whether osd(s) can be safely destroyed without reducing data durability",
+	"osd", "r", "cli,rest")
+COMMAND("osd ok-to-stop name=ids,type=CephString,n=N",
+	"check whether osd(s) can be safely stopped without reducing immediate"\
+	" data availability", "osd", "r", "cli,rest")
+
 COMMAND("osd scrub " \
 	"name=who,type=CephString", \
 	"initiate scrub on osd <who>, or use <all|any|*> to scrub all", \

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -924,7 +924,8 @@ void OSDService::set_injectfull(s_names type, int64_t count)
 }
 
 osd_stat_t OSDService::set_osd_stat(const struct store_statfs_t &stbuf,
-                                    vector<int>& hb_peers)
+                                    vector<int>& hb_peers,
+				    int num_pgs)
 {
   uint64_t bytes = stbuf.total;
   uint64_t used = bytes - stbuf.available;
@@ -941,6 +942,7 @@ osd_stat_t OSDService::set_osd_stat(const struct store_statfs_t &stbuf,
     osd_stat.kb = bytes >> 10;
     osd_stat.kb_used = used >> 10;
     osd_stat.kb_avail = avail >> 10;
+    osd_stat.num_pgs = num_pgs;
     return osd_stat;
   }
 }
@@ -955,7 +957,7 @@ void OSDService::update_osd_stat(vector<int>& hb_peers)
     return;
   }
 
-  auto new_stat = set_osd_stat(stbuf, hb_peers);
+  auto new_stat = set_osd_stat(stbuf, hb_peers, osd->get_num_pgs());
   dout(20) << "update_osd_stat " << new_stat << dendl;
   assert(new_stat.kb);
   float ratio = ((float)new_stat.kb_used) / ((float)new_stat.kb);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1047,7 +1047,8 @@ public:
 
   void update_osd_stat(vector<int>& hb_peers);
   osd_stat_t set_osd_stat(const struct store_statfs_t &stbuf,
-                          vector<int>& hb_peers);
+                          vector<int>& hb_peers,
+			  int num_pgs);
   osd_stat_t get_osd_stat() {
     Mutex::Locker l(stat_lock);
     ++seq;
@@ -1950,6 +1951,11 @@ protected:
 
 public:
   PG   *lookup_lock_pg(spg_t pgid);
+
+  int get_num_pgs() {
+    RWLock::RLocker l(pg_map_lock);
+    return pg_map.size();
+  }
 
 protected:
   PG   *_open_lock_pg(OSDMapRef createmap,

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4641,3 +4641,23 @@ void OSDMap::check_health(health_check_map_t *checks) const
     }
   }
 }
+
+int OSDMap::parse_osd_id_list(const vector<string>& ls, set<int> *out,
+			      ostream *ss) const
+{
+  out->clear();
+  for (auto i = ls.begin(); i != ls.end(); ++i) {
+    if (i == ls.begin() &&
+	(*i == "any" || *i == "all" || *i == "*")) {
+      get_all_osds(*out);
+      break;
+    }
+    long osd = parse_osd_id(i->c_str(), ss);
+    if (osd < 0) {
+      *ss << "invalid osd id '" << *i << "'";
+      return -EINVAL;
+    }
+    out->insert(osd);
+  }
+  return 0;
+}

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1369,6 +1369,10 @@ public:
   bool check_new_blacklist_entries() const { return new_blacklist_entries; }
 
   void check_health(health_check_map_t *checks) const;
+
+  int parse_osd_id_list(const vector<string>& ls,
+			set<int> *out,
+			ostream *ss) const;
 };
 WRITE_CLASS_ENCODER_FEATURES(OSDMap)
 WRITE_CLASS_ENCODER_FEATURES(OSDMap::Incremental)

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -309,6 +309,7 @@ void osd_stat_t::dump(Formatter *f) const
 {
   f->dump_unsigned("up_from", up_from);
   f->dump_unsigned("seq", seq);
+  f->dump_unsigned("num_pgs", num_pgs);
   f->dump_unsigned("kb", kb);
   f->dump_unsigned("kb_used", kb_used);
   f->dump_unsigned("kb_avail", kb_avail);
@@ -328,7 +329,7 @@ void osd_stat_t::dump(Formatter *f) const
 
 void osd_stat_t::encode(bufferlist &bl) const
 {
-  ENCODE_START(6, 2, bl);
+  ENCODE_START(7, 2, bl);
   ::encode(kb, bl);
   ::encode(kb_used, bl);
   ::encode(kb_avail, bl);
@@ -340,6 +341,7 @@ void osd_stat_t::encode(bufferlist &bl) const
   ::encode(os_perf_stat, bl);
   ::encode(up_from, bl);
   ::encode(seq, bl);
+  ::encode(num_pgs, bl);
   ENCODE_FINISH(bl);
 }
 
@@ -361,6 +363,9 @@ void osd_stat_t::decode(bufferlist::iterator &bl)
   if (struct_v >= 6) {
     ::decode(up_from, bl);
     ::decode(seq, bl);
+  }
+  if (struct_v >= 7) {
+    ::decode(num_pgs, bl);
   }
   DECODE_FINISH(bl);
 }

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -904,6 +904,8 @@ struct osd_stat_t {
   epoch_t up_from = 0;
   uint64_t seq = 0;
 
+  uint32_t num_pgs = 0;
+
   osd_stat_t() : kb(0), kb_used(0), kb_avail(0),
 		 snap_trim_queue_len(0), num_snap_trimming(0) {}
 
@@ -915,6 +917,7 @@ struct osd_stat_t {
     num_snap_trimming += o.num_snap_trimming;
     op_queue_age_hist.add(o.op_queue_age_hist);
     os_perf_stat.add(o.os_perf_stat);
+    num_pgs += o.num_pgs;
   }
   void sub(const osd_stat_t& o) {
     kb -= o.kb;
@@ -924,6 +927,7 @@ struct osd_stat_t {
     num_snap_trimming -= o.num_snap_trimming;
     op_queue_age_hist.sub(o.op_queue_age_hist);
     os_perf_stat.sub(o.os_perf_stat);
+    num_pgs -= o.num_pgs;
   }
 
   void dump(Formatter *f) const;
@@ -941,7 +945,8 @@ inline bool operator==(const osd_stat_t& l, const osd_stat_t& r) {
     l.num_snap_trimming == r.num_snap_trimming &&
     l.hb_peers == r.hb_peers &&
     l.op_queue_age_hist == r.op_queue_age_hist &&
-    l.os_perf_stat == r.os_perf_stat;
+    l.os_perf_stat == r.os_perf_stat &&
+    l.num_pgs == r.num_pgs;
 }
 inline bool operator!=(const osd_stat_t& l, const osd_stat_t& r) {
   return !(l == r);

--- a/src/test/osd/CMakeLists.txt
+++ b/src/test/osd/CMakeLists.txt
@@ -17,6 +17,9 @@ install(TARGETS
   ceph_test_rados
   DESTINATION ${CMAKE_INSTALL_BINDIR})
 
+# scripts
+add_ceph_test(osd-bench.sh ${CMAKE_CURRENT_SOURCE_DIR}/safe-to-destroy.sh)
+
 # unittest_osdmap
 add_executable(unittest_osdmap
   TestOSDMap.cc

--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -446,6 +446,44 @@ TEST_F(OSDMapTest, PrimaryAffinity) {
   }
 }
 
+TEST_F(OSDMapTest, parse_osd_id_list) {
+  set_up_map();
+  set<int> out;
+  set<int> all;
+  osdmap.get_all_osds(all);
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0"}, &out, &cout));
+  ASSERT_EQ(1, out.size());
+  ASSERT_EQ(0, *out.begin());
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"1"}, &out, &cout));
+  ASSERT_EQ(1, out.size());
+  ASSERT_EQ(1, *out.begin());
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0","osd.1"}, &out, &cout));
+  ASSERT_EQ(2, out.size());
+  ASSERT_EQ(0, *out.begin());
+  ASSERT_EQ(1, *out.rbegin());
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0","1"}, &out, &cout));
+  ASSERT_EQ(2, out.size());
+  ASSERT_EQ(0, *out.begin());
+  ASSERT_EQ(1, *out.rbegin());
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"*"}, &out, &cout));
+  ASSERT_EQ(all.size(), out.size());
+  ASSERT_EQ(all, out);
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"all"}, &out, &cout));
+  ASSERT_EQ(all, out);
+
+  ASSERT_EQ(0, osdmap.parse_osd_id_list({"any"}, &out, &cout));
+  ASSERT_EQ(all, out);
+
+  ASSERT_EQ(-EINVAL, osdmap.parse_osd_id_list({"foo"}, &out, &cout));
+  ASSERT_EQ(-EINVAL, osdmap.parse_osd_id_list({"-12"}, &out, &cout));
+}
+
 TEST(PGTempMap, basic)
 {
   PGTempMap m;
@@ -461,3 +499,4 @@ TEST(PGTempMap, basic)
   ASSERT_EQ(m.find(b), m.end());
   ASSERT_EQ(998u, m.size());
 }
+

--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
+
+set -e
+
+function run() {
+    local dir=$1
+    shift
+
+    export CEPH_MON="127.0.0.1:7227" # git grep '\<7227\>' : there must be only one
+    export CEPH_ARGS
+    CEPH_ARGS+="--fsid=$(uuidgen) --auth-supported=none "
+    CEPH_ARGS+="--mon-host=$CEPH_MON "
+    set -e
+
+    local funcs=${@:-$(set | sed -n -e 's/^\(TEST_[0-9a-z_]*\) .*/\1/p')}
+    for func in $funcs ; do
+        setup $dir || return 1
+	$func $dir || return 1
+        teardown $dir || return 1
+    done
+}
+
+function TEST_safe_to_destroy() {
+    local dir=$1
+
+    run_mon $dir a
+    run_mgr $dir x
+    run_osd $dir 0
+    run_osd $dir 1
+    run_osd $dir 2
+    run_osd $dir 3
+
+    flush_pg_stats
+
+    ceph osd safe-to-destroy 0
+    ceph osd safe-to-destroy 1
+    ceph osd safe-to-destroy 2
+    ceph osd safe-to-destroy 3
+
+    ceph osd pool create foo 128
+    sleep 2
+    flush_pg_stats
+    wait_for_clean
+
+    expect_failure $dir 'pgs currently' osd safe-to-destroy 0
+    expect_failure $dir 'pgs currently' ceph osd safe-to-destroy 1
+    expect_failure $dir 'pgs currently' ceph osd safe-to-destroy 2
+    expect_failure $dir 'pgs currently' ceph osd safe-to-destroy 3
+
+    ceph osd out 0
+    sleep 2
+    flush_pg_stats
+    wait_for_clean
+
+    ceph osd safe-to-destroy 0
+
+    # even osds without osd_stat are ok if all pgs are active+clean
+    id=`ceph osd create`
+    ceph osd safe-to-destroy $id
+}
+
+function TEST_ok_to_stop() {
+    local dir=$1
+
+    run_mon $dir a
+    run_mgr $dir x
+    run_osd $dir 0
+    run_osd $dir 1
+    run_osd $dir 2
+    run_osd $dir 3
+
+    ceph osd pool create foo 128
+    ceph osd pool set foo size 3
+    ceph osd pool set foo min_size 2
+    sleep 1
+    flush_pg_stats
+    wait_for_clean
+
+    ceph osd ok-to-stop 0
+    ceph osd ok-to-stop 1
+    ceph osd ok-to-stop 2
+    ceph osd ok-to-stop 3
+    expect_failure $dir degraded ceph osd ok-to-stop 0 1
+
+    ceph osd pool set foo min_size 1
+    sleep 1
+    flush_pg_stats
+    wait_for_clean
+    ceph osd ok-to-stop 0 1
+    ceph osd ok-to-stop 1 2
+    ceph osd ok-to-stop 2 3
+    ceph osd ok-to-stop 3 4
+    expect_failure $dir degraded ceph osd ok-to-stop 0 1 2
+    expect_failure $dir degraded ceph osd ok-to-stop 0 1 2 3
+}
+
+main safe-to-destroy "$@"


### PR DESCRIPTION
An osd is safe to destroy if

- we have osd_stat for it
- osd_stat indicates no pgs stored
- all pgs are known
- no pgs map to it
- i.e., overall data *durability* will not be affected

An OSD is ok to stop if

- we have the pg stats we need
- no PGs will drop below min_size
- i.e., *availability* won't be immediately compromised