### PR TITLE
mgr/DaemonServer.cc: add 'is_valid=false' when decode caps error

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -175,6 +175,7 @@ bool DaemonServer::ms_verify_authorizer(Connection *con,
 	::decode(str, p);
       }
       catch (buffer::error& e) {
+        is_valid = false;
       }
       bool success = s->caps.parse(str);
       if (success) {


### PR DESCRIPTION
Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>