### PR TITLE
osd/PG: fix update_snap_map remove fails if already removed or does not exist

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3374,7 +3374,10 @@ void PG::update_snap_map(
 	int r = snap_mapper.remove_oid(
 	  i->soid,
 	  &_t);
-	assert(r == 0);
+	if (!(r == 0 || r == -ENOENT)) {
+	  derr << __func__ << ": remove_oid returned " << cpp_strerror(r) << dendl;
+	  ceph_abort();
+	}
       } else if (i->is_update()) {
 	assert(i->snaps.length() > 0);
 	vector<snapid_t> snaps;


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/20974

Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>