### PR TITLE
rgw: fix opslog operation field as per Amazon s3

### DIFF
--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -383,7 +383,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
 
   entry.uri = std::move(uri);
 
-  set_param_str(s, "REQUEST_METHOD", entry.op);
+  entry.op = op_name;
 
   /* custom header logging */
   if (rest) {


### PR DESCRIPTION
According to Amazon s3[1], current Operation field are using
http method, which should be operation name.

[1] http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html

Fixes: http://tracker.ceph.com/issues/20978

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>