### PR TITLE
NVMeDevice: Make WAL and block path can share the disk.

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4981,6 +4981,11 @@ int BlueStore::_setup_block_symlink_or_file(
       string serial_number = epath.substr(strlen(SPDK_PREFIX));
       r = ::write(fd, serial_number.c_str(), serial_number.size());
       assert(r == (int)serial_number.size());
+#if 0
+      char buf[20];
+      snprintf(buf, sizeof(buf), ":%" PRIx64, size);
+      r = ::write(fd, buf, strlen(buf));
+#endif
       dout(1) << __func__ << " created " << name << " symlink to "
               << epath << dendl;
       VOID_TEMP_FAILURE_RETRY(::close(fd));

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -201,6 +201,7 @@ class NVMEDevice : public BlockDevice {
  public:
   aio_callback_t aio_callback;
   void *aio_callback_priv;
+  uint64_t offset;
 
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 


### PR DESCRIPTION
The new format of file is spdk:SN[:offset],
:offset is optional but should be hex format,
if used, it can use the partition from the offset in the NVMe device.
For example, we can set:

bluestore_block_path = spdk:55cd2e404be053be:80000000 (offset=2G)
bluestore_block_wal_path = spdk:55cd2e404be053be:0 (offset=0)

Signed-off-by: Ziye Yang <optimistyzy@gmail.com>
Signed-off-by: Pan Liu wanjun.lp@alibaba-inc.com