### PR TITLE
test: Fix and enable test_pidfile.sh

### DIFF
--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -567,10 +567,7 @@ if(WITH_RBD)
 endif(WITH_RBD)
 add_ceph_test(run-cli-tests ${CMAKE_CURRENT_SOURCE_DIR}/run-cli-tests)
 add_ceph_test(test_objectstore_memstore.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_objectstore_memstore.sh)
-
-# buggy, see http://tracker.ceph.com/issues/20975
-#add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
-
+add_ceph_test(test_pidfile.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_pidfile.sh)
 add_ceph_test(test_subman.sh ${CMAKE_CURRENT_SOURCE_DIR}/test_subman.sh)
 add_ceph_test(smoke.sh ${CMAKE_CURRENT_SOURCE_DIR}/smoke.sh)
 add_ceph_test(unittest_bufferlist.sh ${CMAKE_SOURCE_DIR}/src/unittest_bufferlist.sh)

--- a/src/test/test_pidfile.sh
+++ b/src/test/test_pidfile.sh
@@ -33,10 +33,10 @@ function TEST_without_pidfile() {
         --mkfs \
         --mon-data=$data \
         --run-dir=$dir || return 1
-    sleep 1
     expect_failure $dir "ignore empty --pid-file" ceph-mon \
         -f \
         --log-to-stderr \
+	--log_flush_on_exit \
         --pid-file= \
         --id $id \
         --mon-data=$data \
@@ -50,9 +50,11 @@ function TEST_pidfile() {
 
     # no daemon can use a pidfile that is owned by another daemon
     run_mon $dir a || return 1
+    sleep 2
     run_mon $dir a --log-to-stderr -f 2>&1 | grep "failed to lock pidfile" || return 1
 
     run_osd $dir 0 || return 1
+    sleep 2
     activate_osd $dir 0 --log-to-stderr -f 2>&1 | grep "failed to lock pidfile" || return 1
 
     # when a daemon shutdown, it will not unlink a path different from


### PR DESCRIPTION
Increase delay so daemonized process can make progress and write/lock pidfile
Add --log_flush_on_exit to ensure log gets flushed for TEST_without_pidfile test

Fixes: http://tracker.ceph.com/issues/20770