### PR TITLE
mstart.sh: support read CLUSTERS_LIST from env var

### DIFF
--- a/src/mstart.sh
+++ b/src/mstart.sh
@@ -25,10 +25,13 @@ elif [ -e $root_path/../build/CMakeCache.txt ]; then
     root_path=$PWD
 fi
 RUN_ROOT_PATH=${root_path}/run
-CLUSTERS_LIST=$RUN_ROOT_PATH/.clusters.list
 
 mkdir -p $RUN_ROOT_PATH
 
+if [ "$CLUSTERS_LIST" == "" ]
+then
+  CLUSTERS_LIST=$RUN_ROOT_PATH/.clusters.list
+fi
 
 if [ ! -f $CLUSTERS_LIST ]; then
 touch $CLUSTERS_LIST


### PR DESCRIPTION
so that we can avoid port conflict when we're creating serveral
clusters with different version of Ceph source code at the same
host and at the same time.

It's very convenient for several colleagues using the same compiling host, 
but both of them has their source code directory.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>