### PR TITLE
qa/suites/rados/multimon: whitelist mgr down vs clock skew test

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -10,6 +10,8 @@ tasks:
     - .*clock.*skew.*
     - clocks not synchronized
     - overall HEALTH_
-    - (MON_CLOCK_SKEW)
+    - \(MON_CLOCK_SKEW\)
+    - \(MGR_DOWN\)
+    - No standby daemons available
 - mon_clock_skew_check:
     expect-skew: true


### PR DESCRIPTION
Clock skew might make us fail the mgr.

Signed-off-by: Sage Weil <sage@redhat.com>