### PR TITLE
cmake: WITH_SPDK=ON by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,7 +219,12 @@ if(WITH_ZFS)
   set(HAVE_LIBZFS ${ZFS_FOUND})
 endif()
 
-option(WITH_SPDK "Enable SPDK" OFF)
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|amd64|x86_64|AMD64")
+  option(WITH_SPDK "Enable SPDK" ON)
+else()
+  option(WITH_SPDK "Enable SPDK" OFF)
+endif()
+
 if(WITH_SPDK)
   set(HAVE_SPDK TRUE)
 endif(WITH_SPDK)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,6 @@ endif()
 
 option(WITH_SPDK "Enable SPDK" OFF)
 if(WITH_SPDK)
-  find_package(dpdk REQUIRED)
   set(HAVE_SPDK TRUE)
 endif(WITH_SPDK)
 

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -183,6 +183,7 @@ BuildRequires:	keyutils-libs-devel
 BuildRequires:	libibverbs-devel
 BuildRequires:  openldap-devel
 BuildRequires:  openssl-devel
+BuildRequires:  CUnit-devel
 BuildRequires:  redhat-lsb-core
 BuildRequires:	Cython
 BuildRequires:	python-prettytable

--- a/cmake/modules/BuildDPDK.cmake
+++ b/cmake/modules/BuildDPDK.cmake
@@ -1,25 +1,26 @@
-if (CMAKE_SYSTEM_NAME MATCHES "Linux")
-  set(dpdk_env  "x86_64-native-linuxapp-gcc")
-  MESSAGE(STATUS "current platform: Linux ")
-elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+if(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "i386")
+    set(dpdk_env  "x86_x32-native-linuxapp-gcc")
+  else()
+    set(dpdk_env  "x86_64-native-linuxapp-gcc")
+  endif()
+elseif(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
   set(dpdk_env "x86_64-native-bsdapp-gcc")
-  MESSAGE(STATUS "current platform: FreeBSD")
-else ()
+else()
   set(dpdk_env "x86_64-native-linuxapp-gcc")
-  MESSAGE(STATUS "other platform: ${CMAKE_SYSTEM_NAME}")
 endif (CMAKE_SYSTEM_NAME MATCHES "Linux")
 
 include(ExternalProject) 
 ExternalProject_Add(build_dpdk
   SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
   CONFIGURE_COMMAND ""
-  BUILD_COMMAND make EXTRA_CFLAGS=-fPIC
+  BUILD_COMMAND $(MAKE) EXTRA_CFLAGS=-fPIC
   BUILD_IN_SOURCE 1
   INSTALL_COMMAND "")                                                                                                                                                                        
 
 ExternalProject_Add_Step(build_dpdk before_build
   DEPENDERS configure
   DEPENDERS build
-  COMMAND make config T=${dpdk_env}
+  COMMAND $(MAKE) config T=${dpdk_env}
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
   ALWAYS 1)

--- a/cmake/modules/BuildDpdk.cmake
+++ b/cmake/modules/BuildDpdk.cmake
@@ -1,0 +1,25 @@
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  set(dpdk_env  "x86_64-native-linuxapp-gcc")
+  MESSAGE(STATUS "current platform: Linux ")
+elseif (CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+  set(dpdk_env "x86_64-native-bsdapp-gcc")
+  MESSAGE(STATUS "current platform: FreeBSD")
+else ()
+  set(dpdk_env "x86_64-native-linuxapp-gcc")
+  MESSAGE(STATUS "other platform: ${CMAKE_SYSTEM_NAME}")
+endif (CMAKE_SYSTEM_NAME MATCHES "Linux")
+
+include(ExternalProject) 
+ExternalProject_Add(build_dpdk
+  SOURCE_DIR ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND make EXTRA_CFLAGS=-fPIC
+  BUILD_IN_SOURCE 1
+  INSTALL_COMMAND "")                                                                                                                                                                        
+
+ExternalProject_Add_Step(build_dpdk before_build
+  DEPENDERS configure
+  DEPENDERS build
+  COMMAND make config T=${dpdk_env}
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
+  ALWAYS 1)

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -32,6 +32,7 @@ rm -rf build && ./do_cmake.sh "$*" \
 	-D WITH_CEPHFS=OFF \
 	-D WITH_EMBEDDED=OFF \
 	-D WITH_MGR=YES \
+	-D WITH_SPDK=OFF \
 	2>&1 | tee cmake.log
 
 echo start building 

--- a/install-deps.sh
+++ b/install-deps.sh
@@ -32,6 +32,7 @@ if [ x`uname`x = xFreeBSDx ]; then
         devel/gperf \
         devel/gmake \
         devel/cmake \
+        devel/cunit \
         devel/yasm \
         devel/boost-all \
         devel/boost-python-libs \
@@ -80,7 +81,7 @@ else
     debian|ubuntu|devuan)
         echo "Using apt-get to install dependencies"
         $SUDO apt-get install -y lsb-release devscripts equivs
-        $SUDO apt-get install -y dpkg-dev gcc
+        $SUDO apt-get install -y dpkg-dev gcc libcunit1-dev
         if ! test -r debian/control ; then
             echo debian/control is not a readable file
             exit 1
@@ -112,6 +113,7 @@ else
             builddepcmd="dnf -y builddep --allowerasing"
         fi
         echo "Using $yumdnf to install dependencies"
+        $SUDO $yumdnf install -y CUnit-devel
         $SUDO $yumdnf install -y redhat-lsb-core
         case $(lsb_release -si) in
             Fedora)

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -69,6 +69,14 @@ endif()
 
 add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)
 
+if(WITH_BLUEFS)
+  add_library(bluefs SHARED
+    bluestore/BlueRocksEnv.cc)
+  target_include_directories(bluefs PUBLIC ${ROCKSDB_INCLUDE_DIR})
+  target_link_libraries(bluefs global)
+  install(TARGETS bluefs DESTINATION lib)
+endif(WITH_BLUEFS)
+
 if(HAVE_LIBAIO)
   target_link_libraries(os ${AIO_LIBRARIES})
 endif(HAVE_LIBAIO)
@@ -91,7 +99,7 @@ if(WITH_SPDK)
                        ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_mempool.a
                        ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_ring.a
                        ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_mempool_ring.a)
-   set(DPDK_LIBRARIES -Wl,--whole-archive ${check_LIBRARIES} -Wl,--no-whole-archive)
+   set(DPDK_LIBRARIES -Wl,--whole-archive ${check_LIBRARIES} -Wl,--no-whole-archive -lrt)
    target_link_libraries(os
     ${SPDK_LIBRARIES}
     ${DPDK_LIBRARIES})
@@ -120,11 +128,11 @@ if(HAVE_LIBAIO)
 endif()
 
 if(WITH_SPDK)
-  include(BuildDpdk)
+  include(BuildDPDK)
   include_directories("${CMAKE_SOURCE_DIR}/src/spdk/include")
   add_custom_target(build_spdk
     COMMAND
-	$(MAKE) DPDK_DIR=${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build
+    $(MAKE) DPDK_DIR=${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build
     DEPENDS build_dpdk
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk
     COMMENT "spdk building")
@@ -132,8 +140,8 @@ if(WITH_SPDK)
   # if INTERFACE is supported.
   foreach(lib nvme log env_dpdk util)
     add_library(spdk_${lib} STATIC IMPORTED)
-    add_dependencies(spdk_${lib} build_dpdk build_spdk)
-    target_link_libraries(os PRIVATE spdk_${lib})
+    add_dependencies(spdk_${lib} build_spdk)
+    target_link_libraries(os spdk_${lib})
     set_target_properties(spdk_${lib} PROPERTIES
       IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/src/spdk/build/lib/libspdk_${lib}.a"
       INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_SOURCE_DIR}/src/spdk/include")

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -69,14 +69,6 @@ endif()
 
 add_library(os STATIC ${libos_srcs} $<TARGET_OBJECTS:kv_objs>)
 
-if(WITH_BLUEFS)
-  add_library(bluefs SHARED 
-    bluestore/BlueRocksEnv.cc)
-  target_include_directories(bluefs PUBLIC ${ROCKSDB_INCLUDE_DIR})
-  target_link_libraries(bluefs global)
-  install(TARGETS bluefs DESTINATION lib)
-endif(WITH_BLUEFS)
-
 if(HAVE_LIBAIO)
   target_link_libraries(os ${AIO_LIBRARIES})
 endif(HAVE_LIBAIO)
@@ -97,7 +89,8 @@ if(WITH_SPDK)
    set(DPDK_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/include)
    set(check_LIBRARIES ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_eal.a
                        ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_mempool.a
-                       ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_ring.a)
+                       ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_ring.a
+                       ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_mempool_ring.a)
    set(DPDK_LIBRARIES -Wl,--whole-archive ${check_LIBRARIES} -Wl,--no-whole-archive)
    target_link_libraries(os
     ${SPDK_LIBRARIES}
@@ -127,15 +120,12 @@ if(HAVE_LIBAIO)
 endif()
 
 if(WITH_SPDK)
+  include(BuildDpdk)
   include_directories("${CMAKE_SOURCE_DIR}/src/spdk/include")
-  add_custom_target(build_dpdk
-    COMMAND
-    make config T=x86_64-native-linuxapp-gcc && make EXTRA_CFLAGS="-fPIC"
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
-    COMMENT "dpdk building")
   add_custom_target(build_spdk
     COMMAND
-    $(MAKE) DPDK_DIR=${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build
+	$(MAKE) DPDK_DIR=${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build
+    DEPENDS build_dpdk
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk
     COMMENT "spdk building")
   # TODO: should use add_library(spdk INTERFACE IMPORTED) instead in new cmake,

--- a/src/os/CMakeLists.txt
+++ b/src/os/CMakeLists.txt
@@ -94,7 +94,12 @@ if(HAVE_LIBZFS)
 endif()
 
 if(WITH_SPDK)
-  target_link_libraries(os
+   set(DPDK_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/include)
+   set(check_LIBRARIES ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_eal.a
+                       ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_mempool.a
+                       ${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build/lib/librte_ring.a)
+   set(DPDK_LIBRARIES -Wl,--whole-archive ${check_LIBRARIES} -Wl,--no-whole-archive)
+   target_link_libraries(os
     ${SPDK_LIBRARIES}
     ${DPDK_LIBRARIES})
   target_include_directories(os
@@ -123,16 +128,21 @@ endif()
 
 if(WITH_SPDK)
   include_directories("${CMAKE_SOURCE_DIR}/src/spdk/include")
+  add_custom_target(build_dpdk
+    COMMAND
+    make config T=x86_64-native-linuxapp-gcc && make EXTRA_CFLAGS="-fPIC"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk/dpdk
+    COMMENT "dpdk building")
   add_custom_target(build_spdk
     COMMAND
-    $(MAKE) DPDK_INC_DIR=${DPDK_INCLUDE_DIR}
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk/lib
+    $(MAKE) DPDK_DIR=${CMAKE_SOURCE_DIR}/src/spdk/dpdk/build
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/spdk
     COMMENT "spdk building")
   # TODO: should use add_library(spdk INTERFACE IMPORTED) instead in new cmake,
   # if INTERFACE is supported.
   foreach(lib nvme log env_dpdk util)
     add_library(spdk_${lib} STATIC IMPORTED)
-    add_dependencies(spdk_${lib} build_spdk)
+    add_dependencies(spdk_${lib} build_dpdk build_spdk)
     target_link_libraries(os PRIVATE spdk_${lib})
     set_target_properties(spdk_${lib} PROPERTIES
       IMPORTED_LOCATION "${CMAKE_SOURCE_DIR}/src/spdk/build/lib/libspdk_${lib}.a"


### PR DESCRIPTION
Before this change, the process compile ceph+spdk is a little difficult, the developer should:
1) config, compile and install dpdk first
2) compile spdk manualy
3) ./do_cmake.sh + turn on WITH_SPDK

Since we've updated spdk to 17.07,  and dpdk is a submodule of spdk now, we want to enhance the cmake files to make it easier. After my change, only ./do_cmake.sh, and spdk related will be compiled by default.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Ziye Yang <optimistyzy@gmail.com>