### PR TITLE
Wip 20985 divergent handling luminous

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3599,7 +3599,7 @@ void Monitor::handle_command(MonOpRequestRef op)
 
     mdsmon()->count_metadata("ceph_version", &mds);
     f->open_object_section("mds");
-    for (auto& p : mon) {
+    for (auto& p : mds) {
       f->dump_int(p.first.c_str(), p.second);
       overall[p.first] += p.second;
     }


### PR DESCRIPTION
This makes the OSD much more precise about asserts and cases
when rebuilding missing sets and handling divergent priors, so that they're no longer broken.

We also fix the "ceph versions" command so that it doesn't repeat the monitor data in
the mds section.