### PR TITLE
os/bluestore: move aio_callback and aio_callback_priv to base class BlockDevice

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -115,7 +115,7 @@ public:
   uint64_t get_size() const { return size; }
   uint64_t get_block_size() const { return block_size; }
 
-  virtual int collect_metadata(std::string prefix, std::map<std::string,std::string> *pm) const = 0;
+  virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 
   virtual int read(
     uint64_t off,

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -82,6 +82,7 @@ public:
 class BlockDevice {
 public:
   CephContext* cct;
+  typedef void (*aio_callback_t)(void *handle, void *aio);
 private:
   std::mutex ioc_reap_lock;
   std::vector<IOContext*> ioc_reap_queue;
@@ -91,15 +92,18 @@ protected:
   uint64_t size;
   uint64_t block_size;
   bool rotational = true;
+  aio_callback_t aio_callback;
+  void *aio_callback_priv;
 
 public:
-  BlockDevice(CephContext* cct) 
+  BlockDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
   : cct(cct),
     size(0),
-    block_size(0)
+    block_size(0),
+    aio_callback(cb),
+    aio_callback_priv(cbpriv)
  {}
   virtual ~BlockDevice() = default;
-  typedef void (*aio_callback_t)(void *handle, void *aio);
 
   static BlockDevice *create(
     CephContext* cct, const std::string& path, aio_callback_t cb, void *cbpriv);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -34,14 +34,12 @@
 #define dout_prefix *_dout << "bdev(" << this << " " << path << ") "
 
 KernelDevice::KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
-  : BlockDevice(cct),
+  : BlockDevice(cct, cb, cbpriv),
     fd_direct(-1),
     fd_buffered(-1),
     fs(NULL), aio(false), dio(false),
     debug_lock("KernelDevice::debug_lock"),
     aio_queue(cct->_conf->bdev_aio_max_queue_depth),
-    aio_callback(cb),
-    aio_callback_priv(cbpriv),
     aio_stop(false),
     aio_thread(this),
     injecting_crash(0)

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -198,7 +198,7 @@ static string get_dev_property(const char *dev, const char *property)
   return val;
 }
 
-int KernelDevice::collect_metadata(string prefix, map<string,string> *pm) const
+int KernelDevice::collect_metadata(const string& prefix, map<string,string> *pm) const
 {
   (*pm)[prefix + "rotational"] = stringify((int)(bool)rotational);
   (*pm)[prefix + "size"] = stringify(get_size());

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -36,8 +36,6 @@ class KernelDevice : public BlockDevice {
   std::mutex flush_mutex;
 
   aio_queue_t aio_queue;
-  aio_callback_t aio_callback;
-  void *aio_callback_priv;
   bool aio_stop;
 
   struct AioCompletionThread : public Thread {

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -75,7 +75,7 @@ public:
 
   void aio_submit(IOContext *ioc) override;
 
-  int collect_metadata(std::string prefix, map<std::string,std::string> *pm) const override;
+  int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -855,12 +855,10 @@ void io_complete(void *t, const struct spdk_nvme_cpl *completion)
 #define dout_prefix *_dout << "bdev(" << name << ") "
 
 NVMEDevice::NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
-  :   BlockDevice(cct),
+  :   BlockDevice(cct, cb, cbpriv),
       driver(nullptr),
       aio_stop(false),
-      buffer_lock("NVMEDevice::buffer_lock"),
-      aio_callback(cb),
-      aio_callback_priv(cbpriv)
+      buffer_lock("NVMEDevice::buffer_lock")
 {
 }
 

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -929,7 +929,7 @@ void NVMEDevice::close()
   dout(1) << __func__ << " end" << dendl;
 }
 
-int NVMEDevice::collect_metadata(string prefix, map<string,string> *pm) const
+int NVMEDevice::collect_metadata(const string& prefix, map<string,string> *pm) const
 {
   (*pm)[prefix + "rotational"] = "0";
   (*pm)[prefix + "size"] = stringify(get_size());

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -227,7 +227,7 @@ class NVMEDevice : public BlockDevice {
   int invalidate_cache(uint64_t off, uint64_t len) override;
   int open(const string& path) override;
   void close() override;
-  int collect_metadata(string prefix, map<string,string> *pm) const override;
+  int collect_metadata(const string& prefix, map<string,string> *pm) const override;
 };
 
 #endif

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -34,7 +34,7 @@
 #define dout_prefix *_dout << "bdev-PMEM("  << path << ") "
 
 PMEMDevice::PMEMDevice(CephContext *cct, aio_callback_t cb, void *cbpriv)
-  : BlockDevice(cct),
+  : BlockDevice(cct, cb, cbpriv),
     fd(-1), addr(0),
     debug_lock("PMEMDevice::debug_lock"),
     injecting_crash(0)

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -146,7 +146,7 @@ static string get_dev_property(const char *dev, const char *property)
   return val;
 }
 
-int PMEMDevice::collect_metadata(string prefix, map<string,string> *pm) const
+int PMEMDevice::collect_metadata(const string& prefix, map<string,string> *pm) const
 {
   (*pm)[prefix + "rotational"] = stringify((int)(bool)rotational);
   (*pm)[prefix + "size"] = stringify(get_size());

--- a/src/os/bluestore/PMEMDevice.h
+++ b/src/os/bluestore/PMEMDevice.h
@@ -41,7 +41,7 @@ public:
 
   void aio_submit(IOContext *ioc) override;
 
-  int collect_metadata(std::string prefix, map<std::string,std::string> *pm) const override;
+  int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,


### PR DESCRIPTION
os/bluestore: move aio_callback and aio_callback_priv to class BlockDevice  
os/bluestore: function collect_metadata, use 'const string&' to reduce copy