### PR TITLE
qa/tasks/thrashosds-health.yaml: ignore MON_DOWN

### DIFF
--- a/qa/tasks/thrashosds-health.yaml
+++ b/qa/tasks/thrashosds-health.yaml
@@ -11,3 +11,4 @@ overrides:
       - \(OBJECT_
       - \(REQUEST_SLOW\)
       - \(TOO_FEW_PGS\)
+      - \(MON_DOWN\)


### PR DESCRIPTION
See http://tracker.ceph.com/issues/20910

It's not clear why this is happening (it could just be load on the
test machines) but it's very noisy, so silencing it for now on
the luminous branch.

Signed-off-by: Sage Weil <sage@redhat.com>