### PR TITLE
qa/suites/rados/multimon/tasks/mon_lock_with_skew: whitelist PG_

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -12,6 +12,7 @@ tasks:
     - overall HEALTH_
     - \(MON_CLOCK_SKEW\)
     - \(MGR_DOWN\)
+    - \(PG_
     - No standby daemons available
 - mon_clock_skew_check:
     expect-skew: true


### PR DESCRIPTION
Default pool pgs not up because mons too broken for OSDs to peer.

Signed-off-by: Sage Weil <sage@redhat.com>