### PR TITLE
qa/suites/rados/verify/validater/valgrind: whitelist PG_

### DIFF
--- a/qa/suites/rados/verify/validater/valgrind.yaml
+++ b/qa/suites/rados/verify/validater/valgrind.yaml
@@ -12,6 +12,10 @@ overrides:
         osd heartbeat grace: 40
       mon:
         mon osd crush smoke test: false
+    log-whitelist:
+      - overall HEALTH_
+# valgrind is slow.. we might get PGs stuck peering etc
+      - \(PG_
     valgrind:
       mon: [--tool=memcheck, --leak-check=full, --show-reachable=yes]
       osd: [--tool=memcheck]


### PR DESCRIPTION
Peering might be slow due to valgrind.

Signed-off-by: Sage Weil <sage@redhat.com>