### PR TITLE
mon/OSDMonitor: update osd beacon timestamp while preparing osd boot

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -2421,6 +2421,9 @@ bool OSDMonitor::prepare_boot(MonOpRequestRef op)
       }
     }
 
+    // update osd beacon timestamp
+    last_osd_report[from] = ceph_clock_now();
+
     pending_inc.new_xinfo[from] = xi;
 
     // wait


### PR DESCRIPTION
Osdmon tick found the osd beacon timestamp doesn't update for 900s,
it will mark down the osd.
Mon will ignore osd beacon message from the osd that in down state.
There exists a speical case the osd beacon alaways arrive after mon
mark down the osd,which will result osd shutdown finally.

Signed-off-by: huangjun <huangjun@xsky.com>