### PR TITLE
src/msg/rdma: fixes failure on assert in notify()

### DIFF
--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -610,7 +610,10 @@ void RDMAConnectedSocketImpl::cleanup() {
 
 void RDMAConnectedSocketImpl::notify()
 {
-  int i = 1;
+  // note: notify_fd is an event fd (man eventfd)
+  // write argument must be a 64bit integer
+  uint64_t i = 1;
+
   assert(sizeof(i) == write(notify_fd, &i, sizeof(i)));
 }
 


### PR DESCRIPTION
@yuyuyu101 @amitkumar50 
The commit fixes incorrect eventfd handling introduced in
2e75b876d1e8e9c2ac556808f958fcbfeaad7d52 PR https://github.com/ceph/ceph/pull/16664

Signed-off-by: Alex Mikheev <alexm@mellanox.com>