### PR TITLE
rgw: S3 Bucket Policy Conditions IpAddress and NotIpAddress do not work

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -900,14 +900,14 @@ bool ParseState::array_end() {
 ostream& operator <<(ostream& m, const MaskedIP& ip) {
   // I have a theory about why std::bitset is the way it is.
   if (ip.v6) {
-    for (int i = 15; i >= 0; --i) {
-      uint8_t b = 0;
-      for (int j = 7; j >= 0; --j) {
-	b |= (ip.addr[(i * 8) + j] << j);
+    for (int i = 7; i >= 0; --i) {
+      uint16_t hextet = 0;
+      for (int j = 15; j >= 0; --j) {
+	hextet |= (ip.addr[(i * 16) + j] << j);
       }
-      m << hex << b;
+      m << hex << (unsigned int) hextet;
       if (i != 0) {
-	m << "::";
+	m << ":";
       }
     }
   } else {
@@ -923,7 +923,7 @@ ostream& operator <<(ostream& m, const MaskedIP& ip) {
       }
     }
   }
-  m << "/" << ip.prefix;
+  m << "/" << dec << ip.prefix;
   // It would explain a lot
   return m;
 }
@@ -1077,27 +1077,27 @@ optional<MaskedIP> Condition::as_network(const string& s) {
   }
 
   if (m.v6) {
-    struct sockaddr_in6 a;
-    if (inet_pton(AF_INET6, p->c_str(), static_cast<void*>(&a.sin6_addr)) != 1) {
+    struct in6_addr a;
+    if (inet_pton(AF_INET6, p->c_str(), static_cast<void*>(&a)) != 1) {
       return none;
     }
 
-    m.addr |= Address(a.sin6_addr.s6_addr[0]) << 0;
-    m.addr |= Address(a.sin6_addr.s6_addr[1]) << 8;
-    m.addr |= Address(a.sin6_addr.s6_addr[2]) << 16;
-    m.addr |= Address(a.sin6_addr.s6_addr[3]) << 24;
-    m.addr |= Address(a.sin6_addr.s6_addr[4]) << 32;
-    m.addr |= Address(a.sin6_addr.s6_addr[5]) << 40;
-    m.addr |= Address(a.sin6_addr.s6_addr[6]) << 48;
-    m.addr |= Address(a.sin6_addr.s6_addr[7]) << 56;
-    m.addr |= Address(a.sin6_addr.s6_addr[8]) << 64;
-    m.addr |= Address(a.sin6_addr.s6_addr[9]) << 72;
-    m.addr |= Address(a.sin6_addr.s6_addr[10]) << 80;
-    m.addr |= Address(a.sin6_addr.s6_addr[11]) << 88;
-    m.addr |= Address(a.sin6_addr.s6_addr[12]) << 96;
-    m.addr |= Address(a.sin6_addr.s6_addr[13]) << 104;
-    m.addr |= Address(a.sin6_addr.s6_addr[14]) << 112;
-    m.addr |= Address(a.sin6_addr.s6_addr[15]) << 120;
+    m.addr |= Address(a.s6_addr[15]) << 0;
+    m.addr |= Address(a.s6_addr[14]) << 8;
+    m.addr |= Address(a.s6_addr[13]) << 16;
+    m.addr |= Address(a.s6_addr[12]) << 24;
+    m.addr |= Address(a.s6_addr[11]) << 32;
+    m.addr |= Address(a.s6_addr[10]) << 40;
+    m.addr |= Address(a.s6_addr[9]) << 48;
+    m.addr |= Address(a.s6_addr[8]) << 56;
+    m.addr |= Address(a.s6_addr[7]) << 64;
+    m.addr |= Address(a.s6_addr[6]) << 72;
+    m.addr |= Address(a.s6_addr[5]) << 80;
+    m.addr |= Address(a.s6_addr[4]) << 88;
+    m.addr |= Address(a.s6_addr[3]) << 96;
+    m.addr |= Address(a.s6_addr[2]) << 104;
+    m.addr |= Address(a.s6_addr[1]) << 112;
+    m.addr |= Address(a.s6_addr[0]) << 120;
   } else {
     struct in_addr a;
     if (inet_pton(AF_INET, p->c_str(), static_cast<void*>(&a)) != 1) {

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -917,7 +917,7 @@ ostream& operator <<(ostream& m, const MaskedIP& ip) {
       for (int j = 7; j >= 0; --j) {
 	b |= (ip.addr[(i * 8) + j] << j);
       }
-      m << b;
+      m << (unsigned int) b;
       if (i != 0) {
 	m << ".";
       }
@@ -1018,8 +1018,24 @@ bool Condition::eval(const Environment& env) const {
     return shortible(std::equal_to<MaskedIP>(), as_network, s, vals);
 
   case TokenID::NotIpAddress:
-    return shortible(ceph::not_fn(std::equal_to<MaskedIP>()), as_network, s,
-		     vals);
+    {
+      auto xc = as_network(s);
+      if (!xc) {
+	return false;
+      }
+
+      for (const string& d : vals) {
+	auto xd = as_network(d);
+	if (!xd) {
+	  continue;
+	}
+
+	if (xc == xd) {
+	  return false;
+	}
+      }
+      return true;
+    }
 
 #if 0
     // Amazon Resource Names! (Does S3 need this?)
@@ -1083,11 +1099,12 @@ optional<MaskedIP> Condition::as_network(const string& s) {
     m.addr |= Address(a.sin6_addr.s6_addr[14]) << 112;
     m.addr |= Address(a.sin6_addr.s6_addr[15]) << 120;
   } else {
-    struct sockaddr_in a;
-    if (inet_pton(AF_INET, p->c_str(), static_cast<void*>(&a.sin_addr)) != 1) {
+    struct in_addr a;
+    if (inet_pton(AF_INET, p->c_str(), static_cast<void*>(&a)) != 1) {
       return none;
     }
-    m.addr = ntohl(a.sin_addr.s_addr);
+
+    m.addr = ntohl(a.s_addr);
   }
 
   return m;

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -249,8 +249,9 @@ struct MaskedIP {
 std::ostream& operator <<(std::ostream& m, const MaskedIP& ip);
 
 inline bool operator ==(const MaskedIP& l, const MaskedIP& r) {
-  auto shift = std::max((l.v6 ? 128 : 32) - l.prefix,
-			(r.v6 ? 128 : 32) - r.prefix);
+  auto shift = std::max((l.v6 ? 128 : 32) - ((int) l.prefix),
+			(r.v6 ? 128 : 32) - ((int) r.prefix));
+  ceph_assert(shift >= 0);
   return (l.addr >> shift) == (r.addr >> shift);
 }
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -607,7 +607,16 @@ rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
     i = m.find("REMOTE_ADDR");
   }
   if (i != m.end()) {
-    e.emplace("aws:SourceIp", i->second);
+    const string* ip = &(i->second);
+    string temp;
+    if (remote_addr_param == "HTTP_X_FORWARDED_FOR") {
+      const auto comma = ip->find(',');
+      if (comma != string::npos) {
+	temp.assign(*ip, 0, comma);
+	ip = &temp;
+      }
+    }
+    e.emplace("aws:SourceIp", *ip);
   }
 
   i = m.find("HTTP_USER_AGENT"); {

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -600,7 +600,12 @@ rgw::IAM::Environment rgw_build_iam_environment(RGWRados* store,
     e.emplace("aws:SecureTransport", "true");
   }
 
-  i = m.find("REMOTE_ADDR");
+  const auto remote_addr_param = s->cct->_conf->rgw_remote_addr_param;
+  if (remote_addr_param.length()) {
+    i = m.find(remote_addr_param);
+  } else {
+    i = m.find("REMOTE_ADDR");
+  }
   if (i != m.end()) {
     e.emplace("aws:SourceIp", i->second);
   }

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -106,7 +106,7 @@ public:
   }
 
   void to_str(std::ostream& out) const override {
-    abort();
+    out << id;
   }
 
   bool is_identity(const flat_set<Principal>& ids) const override {

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -19,6 +19,7 @@
 
 #include <gtest/gtest.h>
 
+#include "include/stringify.h"
 #include "common/code_environment.h"
 #include "common/ceph_context.h"
 #include "global/global_init.h"
@@ -511,6 +512,297 @@ string PolicyTest::example3 = R"(
       "Condition": {"Bool": {"aws:MultiFactorAuthPresent": "true"}}
     }
   ]
+}
+)";
+
+class IPPolicyTest : public ::testing::Test {
+protected:
+  intrusive_ptr<CephContext> cct;
+  static const string arbitrary_tenant;
+  static string ip_address_allow_example;
+  static string ip_address_deny_example;
+  static string ip_address_full_example;
+  // 192.168.1.0/24
+  const rgw::IAM::MaskedIP allowedIPv4Range = { false, rgw::IAM::Address("11000000101010000000000100000000"), 24 };
+  // 192.168.1.1/32
+  const rgw::IAM::MaskedIP blacklistedIPv4 = { false, rgw::IAM::Address("11000000101010000000000100000001"), 32 };
+  // 2001:db8:85a3:0:0:8a2e:370:7334/128
+  const rgw::IAM::MaskedIP allowedIPv6 = { true, rgw::IAM::Address("00100000000000010000110110111000100001011010001100000000000000000000000000000000100010100010111000000011011100000111001100110100"), 128 };
+  // ::1
+  const rgw::IAM::MaskedIP blacklistedIPv6 = { true, rgw::IAM::Address(1), 128 };
+  // 2001:db8:85a3:0:0:8a2e:370:7330/124
+  const rgw::IAM::MaskedIP allowedIPv6Range = { true, rgw::IAM::Address("00100000000000010000110110111000100001011010001100000000000000000000000000000000100010100010111000000011011100000111001100110000"), 124 };
+public:
+  IPPolicyTest() {
+    cct = new CephContext(CEPH_ENTITY_TYPE_CLIENT);
+  }
+};
+const string IPPolicyTest::arbitrary_tenant = "arbitrary_tenant";
+
+TEST_F(IPPolicyTest, MaskedIPOperations) {
+  EXPECT_EQ(stringify(allowedIPv4Range), "192.168.1.0/24");
+  EXPECT_EQ(stringify(blacklistedIPv4), "192.168.1.1/32");
+  EXPECT_EQ(stringify(allowedIPv6), "2001:db8:85a3:0:0:8a2e:370:7334/128");
+  EXPECT_EQ(stringify(allowedIPv6Range), "2001:db8:85a3:0:0:8a2e:370:7330/124");
+  EXPECT_EQ(stringify(blacklistedIPv6), "0:0:0:0:0:0:0:1/128");
+  EXPECT_EQ(allowedIPv4Range, blacklistedIPv4);
+  EXPECT_EQ(allowedIPv6Range, allowedIPv6);
+}
+
+TEST_F(IPPolicyTest, asNetworkIPv4Range) {
+  auto actualIPv4Range = rgw::IAM::Condition::as_network("192.168.1.0/24");
+  ASSERT_TRUE(actualIPv4Range.is_initialized());
+  EXPECT_EQ(*actualIPv4Range, allowedIPv4Range);
+}
+
+TEST_F(IPPolicyTest, asNetworkIPv4) {
+  auto actualIPv4 = rgw::IAM::Condition::as_network("192.168.1.1");
+  ASSERT_TRUE(actualIPv4.is_initialized());
+  EXPECT_EQ(*actualIPv4, blacklistedIPv4);
+}
+
+TEST_F(IPPolicyTest, asNetworkIPv6Range) {
+  auto actualIPv6Range = rgw::IAM::Condition::as_network("2001:db8:85a3:0:0:8a2e:370:7330/124");
+  ASSERT_TRUE(actualIPv6Range.is_initialized());
+  EXPECT_EQ(*actualIPv6Range, allowedIPv6Range);
+}
+
+TEST_F(IPPolicyTest, asNetworkIPv6) {
+  auto actualIPv6 = rgw::IAM::Condition::as_network("2001:db8:85a3:0:0:8a2e:370:7334");
+  ASSERT_TRUE(actualIPv6.is_initialized());
+  EXPECT_EQ(*actualIPv6, allowedIPv6);
+}
+
+TEST_F(IPPolicyTest, asNetworkInvalid) {
+  EXPECT_FALSE(rgw::IAM::Condition::as_network(""));
+  EXPECT_FALSE(rgw::IAM::Condition::as_network("192.168.1.1/33"));
+  EXPECT_FALSE(rgw::IAM::Condition::as_network("2001:db8:85a3:0:0:8a2e:370:7334/129"));
+  EXPECT_FALSE(rgw::IAM::Condition::as_network("192.168.1.1:"));
+  EXPECT_FALSE(rgw::IAM::Condition::as_network("1.2.3.10000"));
+}
+
+TEST_F(IPPolicyTest, ParseIPAddress) {
+  optional<Policy> p;
+
+  ASSERT_NO_THROW(p = Policy(cct.get(), arbitrary_tenant,
+			     bufferlist::static_from_string(ip_address_full_example)));
+  ASSERT_TRUE(p);
+
+  EXPECT_EQ(p->text, ip_address_full_example);
+  EXPECT_EQ(p->version, Version::v2012_10_17);
+  EXPECT_EQ(*p->id, "S3IPPolicyTest");
+  EXPECT_FALSE(p->statements.empty());
+  EXPECT_EQ(p->statements.size(), 1U);
+  EXPECT_EQ(*p->statements[0].sid, "IPAllow");
+  EXPECT_FALSE(p->statements[0].princ.empty());
+  EXPECT_EQ(p->statements[0].princ.size(), 1U);
+  EXPECT_EQ(*p->statements[0].princ.begin(),
+	    Principal::wildcard());
+  EXPECT_TRUE(p->statements[0].noprinc.empty());
+  EXPECT_EQ(p->statements[0].effect, Effect::Allow);
+  EXPECT_EQ(p->statements[0].action, s3ListBucket);
+  EXPECT_EQ(p->statements[0].notaction, s3None);
+  ASSERT_FALSE(p->statements[0].resource.empty());
+  ASSERT_EQ(p->statements[0].resource.size(), 2U);
+  EXPECT_EQ(p->statements[0].resource.begin()->partition, Partition::aws);
+  EXPECT_EQ(p->statements[0].resource.begin()->service, Service::s3);
+  EXPECT_TRUE(p->statements[0].resource.begin()->region.empty());
+  EXPECT_EQ(p->statements[0].resource.begin()->account, arbitrary_tenant);
+  EXPECT_EQ(p->statements[0].resource.begin()->resource, "example_bucket");
+  EXPECT_EQ((p->statements[0].resource.begin() + 1)->resource, "example_bucket/*");
+  EXPECT_TRUE(p->statements[0].notresource.empty());
+  ASSERT_FALSE(p->statements[0].conditions.empty());
+  ASSERT_EQ(p->statements[0].conditions.size(), 2U);
+  EXPECT_EQ(p->statements[0].conditions[0].op, TokenID::IpAddress);
+  EXPECT_EQ(p->statements[0].conditions[0].key, "aws:SourceIp");
+  ASSERT_FALSE(p->statements[0].conditions[0].vals.empty());
+  EXPECT_EQ(p->statements[0].conditions[0].vals.size(), 2U);
+  EXPECT_EQ(p->statements[0].conditions[0].vals[0], "192.168.1.0/24");
+  EXPECT_EQ(p->statements[0].conditions[0].vals[1], "::1");
+  optional<rgw::IAM::MaskedIP> convertedIPv4 = rgw::IAM::Condition::as_network(p->statements[0].conditions[0].vals[0]);
+  EXPECT_TRUE(convertedIPv4.is_initialized());
+  if (convertedIPv4.is_initialized()) {
+    EXPECT_EQ(*convertedIPv4, allowedIPv4Range);
+  }
+
+  EXPECT_EQ(p->statements[0].conditions[1].op, TokenID::NotIpAddress);
+  EXPECT_EQ(p->statements[0].conditions[1].key, "aws:SourceIp");
+  ASSERT_FALSE(p->statements[0].conditions[1].vals.empty());
+  EXPECT_EQ(p->statements[0].conditions[1].vals.size(), 2U);
+  EXPECT_EQ(p->statements[0].conditions[1].vals[0], "192.168.1.1/32");
+  EXPECT_EQ(p->statements[0].conditions[1].vals[1], "2001:0db8:85a3:0000:0000:8a2e:0370:7334");
+  optional<rgw::IAM::MaskedIP> convertedIPv6 = rgw::IAM::Condition::as_network(p->statements[0].conditions[1].vals[1]);
+  EXPECT_TRUE(convertedIPv6.is_initialized());
+  if (convertedIPv6.is_initialized()) {
+    EXPECT_EQ(*convertedIPv6, allowedIPv6);
+  }
+}
+
+TEST_F(IPPolicyTest, EvalIPAddress) {
+  auto allowp  = Policy(cct.get(), arbitrary_tenant,
+			bufferlist::static_from_string(ip_address_allow_example));
+  auto denyp  = Policy(cct.get(), arbitrary_tenant,
+		       bufferlist::static_from_string(ip_address_deny_example));
+  auto fullp  = Policy(cct.get(), arbitrary_tenant,
+		   bufferlist::static_from_string(ip_address_full_example));
+  Environment e;
+  Environment allowedIP, blacklistedIP, allowedIPv6, blacklistedIPv6;
+  allowedIP["aws:SourceIp"] = "192.168.1.2";
+  allowedIPv6["aws:SourceIp"] = "::1";
+  blacklistedIP["aws:SourceIp"] = "192.168.1.1";
+  blacklistedIPv6["aws:SourceIp"] = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+
+  auto trueacct = FakeIdentity(
+    Principal::tenant("ACCOUNT-ID-WITHOUT-HYPHENS"));
+  // Without an IP address in the environment then evaluation will always pass
+  EXPECT_EQ(allowp.eval(e, trueacct, s3ListBucket,
+			ARN(Partition::aws, Service::s3,
+			    "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+  EXPECT_EQ(fullp.eval(e, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Pass);
+
+  EXPECT_EQ(allowp.eval(allowedIP, trueacct, s3ListBucket,
+			ARN(Partition::aws, Service::s3,
+			    "", arbitrary_tenant, "example_bucket")),
+	    Effect::Allow);
+  EXPECT_EQ(allowp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+			ARN(Partition::aws, Service::s3,
+			    "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+
+
+  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Deny);
+  EXPECT_EQ(denyp.eval(allowedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Deny);
+
+  EXPECT_EQ(denyp.eval(blacklistedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+  EXPECT_EQ(denyp.eval(blacklistedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Pass);
+
+  EXPECT_EQ(denyp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+  EXPECT_EQ(denyp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Pass);
+  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Deny);
+  EXPECT_EQ(denyp.eval(allowedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Deny);
+
+  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Allow);
+  EXPECT_EQ(fullp.eval(allowedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Allow);
+
+  EXPECT_EQ(fullp.eval(blacklistedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+  EXPECT_EQ(fullp.eval(blacklistedIP, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Pass);
+
+  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Allow);
+  EXPECT_EQ(fullp.eval(allowedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Allow);
+
+  EXPECT_EQ(fullp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket")),
+	    Effect::Pass);
+  EXPECT_EQ(fullp.eval(blacklistedIPv6, trueacct, s3ListBucket,
+		       ARN(Partition::aws, Service::s3,
+			   "", arbitrary_tenant, "example_bucket/myobject")),
+	    Effect::Pass);
+}
+
+string IPPolicyTest::ip_address_allow_example = R"(
+{
+  "Version": "2012-10-17",
+  "Id": "S3SimpleIPPolicyTest",
+  "Statement": [{
+    "Sid": "1",
+    "Effect": "Allow",
+    "Principal": {"AWS": ["arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:root"]},
+    "Action": "s3:ListBucket",
+    "Resource": [
+      "arn:aws:s3:::example_bucket"
+    ],
+    "Condition": {
+      "IpAddress": {"aws:SourceIp": "192.168.1.0/24"}
+    }
+  }]
+}
+)";
+
+string IPPolicyTest::ip_address_deny_example = R"(
+{
+  "Version": "2012-10-17",
+  "Id": "S3IPPolicyTest",
+  "Statement": {
+    "Effect": "Deny",
+    "Sid": "IPDeny",
+    "Action": "s3:ListBucket",
+    "Principal": {"AWS": ["arn:aws:iam::ACCOUNT-ID-WITHOUT-HYPHENS:root"]},
+    "Resource": [
+      "arn:aws:s3:::example_bucket",
+      "arn:aws:s3:::example_bucket/*"
+    ],
+    "Condition": {
+      "NotIpAddress": {"aws:SourceIp": ["192.168.1.1/32", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]}
+    }
+  }
+}
+)";
+
+string IPPolicyTest::ip_address_full_example = R"(
+{
+  "Version": "2012-10-17",
+  "Id": "S3IPPolicyTest",
+  "Statement": {
+    "Effect": "Allow",
+    "Sid": "IPAllow",
+    "Action": "s3:ListBucket",
+    "Principal": "*",
+    "Resource": [
+      "arn:aws:s3:::example_bucket",
+      "arn:aws:s3:::example_bucket/*"
+    ],
+    "Condition": {
+      "IpAddress": {"aws:SourceIp": ["192.168.1.0/24", "::1"]},
+      "NotIpAddress": {"aws:SourceIp": ["192.168.1.1/32", "2001:0db8:85a3:0000:0000:8a2e:0370:7334"]}
+    }
+  }
 }
 )";
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -109,7 +109,10 @@ public:
   }
 
   bool is_identity(const flat_set<Principal>& ids) const override {
-    return ids.find(id) != ids.end();
+    if (id.is_wildcard() && (!ids.empty())) {
+      return true;
+    }
+    return ids.find(id) != ids.end() || ids.find(Principal::wildcard()) != ids.end();
   }
 };
 

--- a/src/test/rgw/test_rgw_iam_policy.cc
+++ b/src/test/rgw/test_rgw_iam_policy.cc
@@ -613,6 +613,12 @@ TEST_F(IPPolicyTest, IPEnvironment) {
   ip = iam_env.find("aws:SourceIp");
   ASSERT_NE(ip, iam_env.end());
   EXPECT_EQ(ip->second, "192.168.1.3");
+
+  rgw_env.set("HTTP_X_FORWARDED_FOR", "192.168.1.4, 4.3.2.1, 2001:db8:85a3:8d3:1319:8a2e:370:7348");
+  iam_env = rgw_build_iam_environment(&rgw_rados, &rgw_req_state);
+  ip = iam_env.find("aws:SourceIp");
+  ASSERT_NE(ip, iam_env.end());
+  EXPECT_EQ(ip->second, "192.168.1.4");
 }
 
 TEST_F(IPPolicyTest, ParseIPAddress) {


### PR DESCRIPTION
This fixes bugs in rgw's support for the bucket policy conditions IpAddress and NotIpAddress.

The only concern I have with the patch is getting the correct byte order for the ip addresses themselves on big endian architectures. (Although I don't know if ceph actually suppports big endian architectures.)

http://tracker.ceph.com/issues/20991