### PR TITLE
doc/rados/operations/bluestore-migration: update docs a bit

### DIFF
--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -55,7 +55,7 @@ more data migration than should be necessary, so it is not optimal.
 
 #. Wait for the data to migrate off the OSD in question::
 
-     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+     while ! ceph osd safe-to-destroy $ID ; sleep 60 ; done
 
 #. Stop the OSD::
 
@@ -168,7 +168,7 @@ the data migrating only once.
 
 #. Wait for data migration to complete::
 
-     while ! ceph health | grep HEALTH_OK ; do sleep 60 ; done
+     while ! ceph osd safe-to-destroy $(ceph osd ls-tree $OLDHOST); do sleep 60 ; done
 
 #. Stop all old OSDs on the now-empty ``$OLDHOST``::
 
@@ -178,7 +178,7 @@ the data migrating only once.
 
 #. Destroy and purge the old OSDs::
 
-     for osd in `ceph osd crush ls $OLDHOST`; do
+     for osd in `ceph osd ls-tree $OLDHOST`; do
          ceph osd purge $osd --yes-i-really-mean-it
      done
 

--- a/doc/rados/operations/bluestore-migration.rst
+++ b/doc/rados/operations/bluestore-migration.rst
@@ -142,9 +142,9 @@ the data migrating only once.
      $ bin/ceph osd tree
      ID CLASS WEIGHT  TYPE NAME     STATUS REWEIGHT PRI-AFF
      -5             0 host newhost
-     10   ssd 1.00000     osd.0         up  1.00000 1.00000
-     11   ssd 1.00000     osd.1         up  1.00000 1.00000
-     12   ssd 1.00000     osd.2         up  1.00000 1.00000
+     10   ssd 1.00000     osd.10        up  1.00000 1.00000
+     11   ssd 1.00000     osd.11        up  1.00000 1.00000
+     12   ssd 1.00000     osd.12        up  1.00000 1.00000
      -1       3.00000 root default
      -2       3.00000     host oldhost1
       0   ssd 1.00000         osd.0     up  1.00000 1.00000


### PR DESCRIPTION
- use new safe-to-destroy command
- use ls-tree to enumerate osd ids