### PR TITLE
rgw: Drop #warning TODO

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -35,8 +35,6 @@ using namespace rgw;
 /**
  * Encryption in CTR mode. offset is used as IV for each block.
  */
-#warning "TODO: move this code to auth/Crypto for others to reuse."
-
 class AES_256_CTR : public BlockCrypt {
 public:
   static const size_t AES_256_KEYSIZE = 256 / 8;
@@ -244,7 +242,6 @@ CryptoAccelRef get_crypto_accel(CephContext *cct)
  * 6. (Special case) If m == 0 then last n bytes are xor-ed with pattern
  *    obtained by CBC ENCRYPTION of {0} with IV derived from offset
  */
-#warning "TODO: use auth/Crypto instead of reimplementing."
 class AES_256_CBC : public BlockCrypt {
 public:
   static const size_t AES_256_KEYSIZE = 256 / 8;


### PR DESCRIPTION
Drop "#warning TODO" from rgw_crypt.cc,  as the tracker is created for this requirement and the
corresponding PR is in progress for a long time.

Tracker: http://tracker.ceph.com/issues/19851
PR: https://github.com/ceph/ceph/pull/14498

The below warning is displayed during build:
```
ceph/src/rgw/rgw_crypt.cc:38:2: warning: #warning "TODO: move this code to auth/Crypto for others to reuse." [-Wcpp]
 #warning "TODO: move this code to auth/Crypto for others to reuse."
  ^
ceph/src/rgw/rgw_crypt.cc:247:2: warning: #warning "TODO: use auth/Crypto instead of reimplementing." [-Wcpp]
 #warning "TODO: use auth/Crypto instead of reimplementing."
  ^
```
Signed-off-by: Jos Collin <jcollin@redhat.com>