### PR TITLE
os/bluestore: Add lat record of deferred_queued and deferred_aio_wait

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8628,6 +8628,9 @@ void BlueStore::_deferred_submit_unlock(OpSequencer *osr)
   assert(!osr->deferred_running);
 
   auto b = osr->deferred_pending;
+  for (auto& txc : b->txcs) {
+    txc.log_state_latency(logger, l_bluestore_state_deferred_queued_lat);
+  }
   deferred_queue_size -= b->seq_bytes.size();
   assert(deferred_queue_size >= 0);
 
@@ -8700,6 +8703,7 @@ void BlueStore::_deferred_aio_finish(OpSequencer *osr)
     std::lock_guard<std::mutex> l2(osr->qlock);
     for (auto& i : b->txcs) {
       TransContext *txc = &i;
+      txc->log_state_latency(logger, l_bluestore_state_deferred_aio_wait_lat);
       txc->state = TransContext::STATE_DEFERRED_CLEANUP;
       costs += txc->cost;
     }


### PR DESCRIPTION
Originally bluestore defines the two lat deferred_queued_lat and
deferred_aio_wait_lat, but doesn't use it.
This patch is to add the records that each TXC stays on deferred queue
deferred ios.

Signed-off-by: Xiaoyan Li xiaoyan.li@intel.com