### PR TITLE
Fix a dead lock when doing rdma performance test by fio

### DIFF
--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -99,8 +99,11 @@ void RDMADispatcher::polling_start()
 
 void RDMADispatcher::polling_stop()
 {
-  Mutex::Locker l(lock);
-  done = true;
+  {
+    Mutex::Locker l(lock);
+    done = true;
+  }
+
   if (!t.joinable())
     return;
 


### PR DESCRIPTION
"RDMADispatcher::polling_stop" hold the lock and wait "RDMADispatcher::polling" ending, then RDMADispatcher::polling can't hold the lock and can't end its work.

Signed-off-by: Wang Chuanhong <chuanhong.wang@163.com>