### PR TITLE
qa/standalone: prevent matched on wrong coredumps

### DIFF
--- a/qa/run-standalone.sh
+++ b/qa/run-standalone.sh
@@ -16,12 +16,12 @@ if [ `uname` = FreeBSD ]; then
     export PYTHONPATH=/usr/local/lib/python2.7/site-packages
     exec_mode=+111
     KERNCORE="kern.corefile"
-    COREPATTERN="core.%N.%P"
+    COREPATTERN="%N.%P"
 else
     export PYTHONPATH=/usr/lib/python2.7/dist-packages
     exec_mode=/111
     KERNCORE="kernel.core_pattern"
-    COREPATTERN="core.%e.%p.%t"
+    COREPATTERN="%e.%p.%t"
 fi
 
 PATH=$(pwd)/bin:$PATH
@@ -46,7 +46,7 @@ count=0
 errors=0
 userargs=""
 precore="$(sysctl -n $KERNCORE)"
-sudo sysctl -w ${KERNCORE}=${COREPATTERN}
+sudo sysctl -w ${KERNCORE}="core."${COREPATTERN}
 ulimit -c unlimited
 for f in $(cd $location ; find . -perm $exec_mode -type f)
 do


### PR DESCRIPTION
 - scripts will fail unexpectedly if build/src/test contains core
   from other test. e.g. from unittests.
   So make sure that we can recognise cores if they belong
   to this test.

   this is more evident on FreeBSD since the unittest-cores are not
   cleared automatically. And thus clobber the test directory.

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>