### PR TITLE
rbd-mirror: Set the data pool correctly when creating images

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -36,6 +36,13 @@ Ceph clusters.
    configuration file of the same name (e.g. /etc/ceph/remote.conf).  See the
    `ceph-conf`_ documentation for how to configure multiple clusters.
 
+.. note:: Images in a given pool will be mirrored to a pool with the same name
+   on the remote cluster. Images using a separate data-pool will use a data-pool
+   with the same name on the remote cluster. E.g., if an image being mirrored is
+   in the ``rbd`` pool on the local cluster and using a data-pool called
+   ``rbd-ec``, pools called ``rbd`` and ``rbd-ec`` must exist on the remote
+   cluster and will be used for mirroring the image.
+
 Enable Mirroring
 ----------------
 

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.cc
@@ -74,6 +74,8 @@ void CreateImageRequest<I>::create_image() {
                     m_remote_image_ctx->stripe_unit);
   image_options.set(RBD_IMAGE_OPTION_STRIPE_COUNT,
                     m_remote_image_ctx->stripe_count);
+  image_options.set(RBD_IMAGE_OPTION_DATA_POOL,
+		    m_remote_image_ctx->data_ctx.get_pool_name());
 
   librbd::image::CreateRequest<I> *req = librbd::image::CreateRequest<I>::create(
     m_local_io_ctx, m_local_image_name, m_local_image_id,


### PR DESCRIPTION
Previously the data-pool option was ignored by rbd-mirror, so when using
erasure coding data for the image on the secondary site would end up in
the metadata pool.

Configure the data-pool using the data-pool's name from the primary site
when creating images on the secondary site.

Fixes: http://tracker.ceph.com/issues/20567

Signed-off-by: Adam Wolfe Gordon <awg@digitalocean.com>