### PR TITLE
cls/log: cls_log_list always returns next marker

### DIFF
--- a/src/cls/log/cls_log.cc
+++ b/src/cls/log/cls_log.cc
@@ -200,9 +200,7 @@ static int cls_log_list(cls_method_context_t hctx, bufferlist *in, bufferlist *o
     }
   }
 
-  if (ret.truncated) {
-    ret.marker = marker;
-  }
+  ret.marker = marker;
 
   ::encode(ret, *out);
 


### PR DESCRIPTION
commit 5334622a8365520fa4247241f97422c044cbf5b2 changed cls_log_list()
to only return the next marker if the results were truncated

this broke RGWMetaSyncShardCR in rgw_sync.cc, which relies on
cls_log_list() to track its max_marker

Fixes: http://tracker.ceph.com/issues/20906