### PR TITLE
test/osd: silence warnings from -Wsign-compare

### DIFF
--- a/src/test/osd/TestOSDMap.cc
+++ b/src/test/osd/TestOSDMap.cc
@@ -453,20 +453,20 @@ TEST_F(OSDMapTest, parse_osd_id_list) {
   osdmap.get_all_osds(all);
 
   ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0"}, &out, &cout));
-  ASSERT_EQ(1, out.size());
+  ASSERT_EQ(1u, out.size());
   ASSERT_EQ(0, *out.begin());
 
   ASSERT_EQ(0, osdmap.parse_osd_id_list({"1"}, &out, &cout));
-  ASSERT_EQ(1, out.size());
+  ASSERT_EQ(1u, out.size());
   ASSERT_EQ(1, *out.begin());
 
   ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0","osd.1"}, &out, &cout));
-  ASSERT_EQ(2, out.size());
+  ASSERT_EQ(2u, out.size());
   ASSERT_EQ(0, *out.begin());
   ASSERT_EQ(1, *out.rbegin());
 
   ASSERT_EQ(0, osdmap.parse_osd_id_list({"osd.0","1"}, &out, &cout));
-  ASSERT_EQ(2, out.size());
+  ASSERT_EQ(2u, out.size());
   ASSERT_EQ(0, *out.begin());
   ASSERT_EQ(1, *out.rbegin());
 


### PR DESCRIPTION
The following warning appears during build:
```
In file included from ceph/src/test/osd/TestOSDMap.cc:2:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of 'testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]':
ceph/src/googletest/googletest/include/gtest/gtest.h:1421:23:   required from 'static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int; bool lhs_is_null_literal = false]'
ceph/src/test/osd/TestOSDMap.cc:456:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
           ^
```
Signed-off-by: Jos Collin <jcollin@redhat.com>