### PR TITLE
bluestore/NVMeDevice: Make db, wal, block path share the disk.

### DIFF
--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -201,6 +201,7 @@ class NVMEDevice : public BlockDevice {
  public:
   aio_callback_t aio_callback;
   void *aio_callback_priv;
+  uint64_t offset;
 
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 


### PR DESCRIPTION
The new format of file is spdk:SN[:offset],
:offset is optional but should be hex format,
if used, it can use the partition from the offset in the NVMe device.
For example, we can set:

bluestore_block_db_path = spdk:55cd2e404be053be:0 (offset=0)
bluestore_block_wal_path = spdk:55cd2e404be053be:40000000 (offset=1G)
bluestore_block_path = spdk:55cd2e404be053be:80000000 (offset=2G)

Signed-off-by: Ziye Yang <optimistyzy@gmail.com>
Signed-off-by: Pan Liu wanjun.lp@alibaba-inc.com