### PR TITLE
mon/pgmap: Fixed setting quota threshold

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1459,11 +1459,11 @@ std::vector<Option> get_global_options() {
     .set_default(65536)
     .set_description(""),
 
-    Option("mon_pool_quota_warn_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_pool_quota_warn_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description(""),
 
-    Option("mon_pool_quota_crit_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_pool_quota_crit_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description(""),
 


### PR DESCRIPTION
set option "mon_pool_quota_warn_threshold && mon_pool_quota_crit_threshold" fail
Fixes: http://tracker.ceph.com/issues/21002

Signed-off-by: huanwen ren ren.huanwen@zte.com.cn