### PR TITLE
rgw: move dump_usage_categories_info to common

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1888,3 +1888,22 @@ bool match_policy(boost::string_view pattern, boost::string_view input,
     last_pos_input = cur_pos_input + 1;
   }
 }
+
+
+void rgw_dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
+{
+  formatter->open_array_section("categories");
+  for (const auto& uiter: entry.usage_map) {
+    if (categories && !categories->empty() && !categories->count(uiter.first))
+      continue;
+    const rgw_usage_data& usage = uiter.second;
+    formatter->open_object_section("entry");
+    formatter->dump_string("category", uiter.first);
+    formatter->dump_int("bytes_sent", usage.bytes_sent);
+    formatter->dump_int("bytes_received", usage.bytes_received);
+    formatter->dump_int("ops", usage.ops);
+    formatter->dump_int("successful_ops", usage.successful_ops);
+    formatter->close_section(); // entry
+  }
+  formatter->close_section(); // categories
+}

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -2325,4 +2325,6 @@ static constexpr uint32_t MATCH_POLICY_STRING = 0x08;
 extern bool match_policy(boost::string_view pattern, boost::string_view input,
                          uint32_t flag);
 
+extern void rgw_dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories);
+
 #endif

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -496,25 +496,6 @@ int RGWGetUsage_ObjStore_S3::get_params()
   return 0;
 }
 
-static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
-{
-  formatter->open_array_section("categories");
-  map<string, rgw_usage_data>::const_iterator uiter;
-  for (uiter = entry.usage_map.begin(); uiter != entry.usage_map.end(); ++uiter) {
-    if (categories && !categories->empty() && !categories->count(uiter->first))
-      continue;
-    const rgw_usage_data& usage = uiter->second;
-    formatter->open_object_section("Entry");
-    formatter->dump_string("Category", uiter->first);
-    formatter->dump_int("BytesSent", usage.bytes_sent);
-    formatter->dump_int("BytesReceived", usage.bytes_received);
-    formatter->dump_int("Ops", usage.ops);
-    formatter->dump_int("SuccessfulOps", usage.successful_ops);
-    formatter->close_section(); // Entry
-  }
-  formatter->close_section(); // Category
-}
-
 static void dump_usage_bucket_info(Formatter *formatter, const std::string& name, const cls_user_bucket_entry& entry)
 {
   formatter->open_object_section("Entry");
@@ -565,7 +546,7 @@ void RGWGetUsage_ObjStore_S3::send_response()
       utime_t ut(entry.epoch, 0);
       ut.gmtime(formatter->dump_stream("Time"));
       formatter->dump_int("Epoch", entry.epoch);
-      dump_usage_categories_info(formatter, entry, &categories);
+      rgw_dump_usage_categories_info(formatter, entry, &categories);
       formatter->close_section(); // bucket
     }
 
@@ -587,7 +568,7 @@ void RGWGetUsage_ObjStore_S3::send_response()
        const rgw_usage_log_entry& entry = siter->second;
        formatter->open_object_section("User");
        formatter->dump_string("User", siter->first);
-       dump_usage_categories_info(formatter, entry, &categories);
+       rgw_dump_usage_categories_info(formatter, entry, &categories);
        rgw_usage_data total_usage;
        entry.sum(total_usage, categories);
        formatter->open_object_section("Total");

--- a/src/rgw/rgw_usage.cc
+++ b/src/rgw/rgw_usage.cc
@@ -10,26 +10,6 @@
 
 using namespace std;
 
-
-static void dump_usage_categories_info(Formatter *formatter, const rgw_usage_log_entry& entry, map<string, bool> *categories)
-{
-  formatter->open_array_section("categories");
-  map<string, rgw_usage_data>::const_iterator uiter;
-  for (uiter = entry.usage_map.begin(); uiter != entry.usage_map.end(); ++uiter) {
-    if (categories && !categories->empty() && !categories->count(uiter->first))
-      continue;
-    const rgw_usage_data& usage = uiter->second;
-    formatter->open_object_section("entry");
-    formatter->dump_string("category", uiter->first);
-    formatter->dump_int("bytes_sent", usage.bytes_sent);
-    formatter->dump_int("bytes_received", usage.bytes_received);
-    formatter->dump_int("ops", usage.ops);
-    formatter->dump_int("successful_ops", usage.successful_ops);
-    formatter->close_section(); // entry
-  }
-  formatter->close_section(); // categories
-}
-
 int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
 		   uint64_t end_epoch, bool show_log_entries, bool show_log_sum,
 		   map<string, bool> *categories,
@@ -94,7 +74,7 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
         if (!payer.empty() && payer != owner) {
           formatter->dump_string("payer", payer);
         }
-        dump_usage_categories_info(formatter, entry, categories);
+        rgw_dump_usage_categories_info(formatter, entry, categories);
         formatter->close_section(); // bucket
         flusher.flush();
       }
@@ -117,7 +97,7 @@ int RGWUsage::show(RGWRados *store, rgw_user& uid, uint64_t start_epoch,
       const rgw_usage_log_entry& entry = siter->second;
       formatter->open_object_section("user");
       formatter->dump_string("user", siter->first);
-      dump_usage_categories_info(formatter, entry, categories);
+      rgw_dump_usage_categories_info(formatter, entry, categories);
       rgw_usage_data total_usage;
       entry.sum(total_usage, *categories);
       formatter->open_object_section("total");


### PR DESCRIPTION
Since the same function is used in both rgw_usage & rgw_rest_s3, move
this to common

Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>