### PR TITLE
mon/OSDMonitor: add plain output for "crush class ls-osd" command

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5034,14 +5034,24 @@ bool OSDMonitor::preprocess_command(MonOpRequestRef op)
   } else if (prefix == "osd crush class ls-osd") {
     string name;
     cmd_getval(g_ceph_context, cmdmap, "class", name);
-    boost::scoped_ptr<Formatter> f(Formatter::create(format, "json-pretty", "json-pretty"));
     set<int> osds;
     osdmap.crush->get_devices_by_class(name, &osds);
-    f->open_array_section("osds");
-    for (auto& osd : osds)
-      f->dump_int("osd", osd);
-    f->close_section();
-    f->flush(rdata);
+    if (f) {
+      f->open_array_section("osds");
+      for (auto &osd: osds)
+        f->dump_int("osd", osd);
+      f->close_section();
+      f->flush(rdata);
+    } else {
+      bool first = true;
+      for (auto &osd : osds) {
+        if (!first)
+          ds << "\n";
+        first = false;
+        ds << osd;
+      }
+      rdata.append(ds);
+    }
   } else if (prefix == "osd erasure-code-profile ls") {
     const auto &profiles = osdmap.get_erasure_code_profiles();
     if (f)


### PR DESCRIPTION
Was:
ceph osd crush rm-device-class `ceph osd crush class ls-osd pool_bar`
Error EINVAL: Expected option value to be integer, got '[', unable to parse osd id:"[".

Now:
ceph osd crush rm-device-class `ceph osd crush class ls-osd pool_bar`
done removing class of osd(s): 0,2,4

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>