### PR TITLE
common/Timer: add cycle timer event api

### DIFF
--- a/src/common/Timer.h
+++ b/src/common/Timer.h
@@ -37,6 +37,7 @@ class SafeTimer
 
   std::multimap<utime_t, Context*> schedule;
   std::map<Context*, std::multimap<utime_t, Context*>::iterator> events;
+  std::map<Context*, double> cycle_events;
   bool stopping;
 
   void dump(const char *caller = 0) const;
@@ -72,6 +73,7 @@ public:
    * Call with the event_lock LOCKED */
   bool add_event_after(double seconds, Context *callback);
   bool add_event_at(utime_t when, Context *callback);
+  bool add_cycle_event_after(double seconds, Context *callback);
 
   /* Cancel an event.
    * Call with the event_lock LOCKED

--- a/src/include/Context.h
+++ b/src/include/Context.h
@@ -60,12 +60,10 @@ class Context {
   Context(const Context& other);
   const Context& operator=(const Context& other);
 
- protected:
-  virtual void finish(int r) = 0;
-
  public:
   Context() {}
   virtual ~Context() {}       // we want a virtual destructor!!!
+  virtual void finish(int r) = 0;
   virtual void complete(int r) {
     finish(r);
     delete this;

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -2283,9 +2283,8 @@ void Monitor::health_tick_start()
       if (r < 0)
         return;
       do_health_to_clog();
-      health_tick_start();
-    });
-  timer.add_event_after(cct->_conf->mon_health_to_clog_tick_interval,
+  });
+  timer.add_cycle_event_after(cct->_conf->mon_health_to_clog_tick_interval,
                         health_tick_event);
 }
 


### PR DESCRIPTION
    in current timer,  callback Context was delete when timer events occurs in Context::complete(),
 if one wants a timer events that run every several seconds, here i call it cycle timer event, he has to new a new callback Context  every time in callback. i think this is unnecessary, we can reuse the 
callback Context, and avoid delete and new  it every time.
   1.new /delete involves memory allocate/free and the constructor/destructor, the fewer the better
   2.this cycle timer event api makes it  easy to define an event which callback every several second, you can new the callback Conext one time in timer start,it was delete only when you cancel the event.


   

  




Signed-off-by: wang yang <yang.wang@easystack.cn>