### PR TITLE
submodule: make libmpem as a submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -58,3 +58,6 @@
 [submodule "src/rapidjson"]
 	path = src/rapidjson
 	url = https://github.com/ceph/rapidjson
+[submodule "src/nvml"]
+	path = src/nvml
+	url = https://github.com/ceph/nvml.git


### PR DESCRIPTION
#15102 already merged into master. But most distro don't include this libpmem. So add nvml as submodule.  @liewegas , how to fork [nvml](https://github.com/pmem/nvml/) as a submodule ? Thanks!