### PR TITLE
cmake: enable lz4 by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,7 +272,7 @@ endif(WITH_LEVELDB)
 
 find_package(snappy REQUIRED)
 
-option(WITH_LZ4 "LZ4 compression support" OFF)
+option(WITH_LZ4 "LZ4 compression support" ON)
 if(WITH_LZ4)
   find_package(LZ4 REQUIRED)
   set(HAVE_LZ4 ${LZ4_FOUND})

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -23,3 +23,8 @@
   as net/ceph. Future development releases will be available via net/ceph-devel
 
   More details about this port are in: README.FreeBSD
+
+* The Ceph LZ4 compression plugin is now built by default if the required
+  version of the LZ4 library is available. LZ4 is not enabled in the official
+  Ceph releases due to some distros shipping with a very old releases of the
+  LZ4 library which does not have the required LZ4 streaming function.


### PR DESCRIPTION
Enabled building LZ4 compressor support by default.

PR brief discussion with @yuyuyu101 via original LZ4 support https://github.com/ceph/ceph/pull/15434 PR there doesn't seem to be any reason why not to enabled LZ4 by default.