### PR TITLE
mon/pgmap: update pool nearfull display

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3068,7 +3068,7 @@ void PGMap::get_health_checks(
     }
     if (nearfull_pools) {
       ostringstream ss;
-      ss << nearfull_pools << " pools full";
+      ss << nearfull_pools << " pools nearfull";
       auto& d = checks->add("POOL_NEAR_FULL", HEALTH_WARN, ss.str());
       d.detail.swap(nearfull_detail);
     }


### PR DESCRIPTION
if "pool full" and "pool nearfull" show the same, 
we will not be able to distinguish between these two scenes in health check.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>