### PR TITLE
rgw: lifecycle can not be completely deleted

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4849,7 +4849,7 @@ void RGWDeleteLC::execute()
             << " returned err=" << op_ret << dendl;
     return;
   }
-  string shard_id = s->bucket.name + ':' +s->bucket.bucket_id;
+  string shard_id = s->bucket.tenant + ':' + s->bucket.name + ':' +s->bucket.bucket_id;
   pair<string, int> entry(shard_id, lc_uninitial);
   string oid; 
   get_lc_oid(s, oid);


### PR DESCRIPTION
when executing the command: "s3cmd dellifecycle s3://***" or "s3cmd rm s3://***",
radosgw-admin can still list the lifecycle of the bucket

For example 
(1) # ./bin/radosgw-admin lc list
[]

(2)# s3cmd setlifecycle  /home/xhw/Downloads/lc.xml s3://test --signature-v2
s3://test/: Lifecycle Policy updated

(3) # ./bin/radosgw-admin lc list
[
    {
        "bucket": ":test:f2b2cd49-73b8-444e-9df2-6e1fde4c90d4.4161.1",
        "status": "COMPLETE"
    }
]

(4) # s3cmd dellifecycle  s3://test 
s3://test/: Lifecycle Policy deleted

(5) # s3cmd rb s3://test
Bucket 's3://test/' removed

(6)# ./bin/radosgw-admin lc list
[
    {
        "bucket": ":test:f2b2cd49-73b8-444e-9df2-6e1fde4c90d4.4161.1",
        "status": "COMPLETE"
    }
]

Fixes: http://tracker.ceph.com/issues/19632

Signed-off-by: dengxiafubi <xhwcqupt@sina.com>