### PR TITLE
rgw: rgw_op: exit early if object has no attrs in GetObjectTagging

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -720,6 +720,12 @@ void RGWGetObjTags::execute()
   store->set_atomic(s->obj_ctx, obj);
 
   op_ret = get_obj_attrs(store, s, obj, attrs);
+  if (op_ret < 0) {
+    ldout(s->cct, 0) << "ERROR: failed to get obj attrs, obj=" << obj
+		     << " ret=" << op_ret << dendl;
+    return;
+  }
+
   auto tags = attrs.find(RGW_ATTR_TAGS);
   if(tags != attrs.end()){
     has_tags = true;


### PR DESCRIPTION
Check for the return value of get_obj_attrs and exit earlier in case of
errors

Fixes: http://tracker.ceph.com/issues/21010
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>