### PR TITLE
fix core dump caused by can_discard_replica_op()

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5699,7 +5699,7 @@ bool PG::can_discard_replica_op(OpRequestRef& op)
    * if such a replica goes down it does not cause
    * a new interval. */
   int from = m->get_source().num();
-  if (get_osdmap()->get_down_at(from) >= m->map_epoch)
+  if (!get_osdmap()->exists(from) || get_osdmap()->get_down_at(from) >= m->map_epoch)
     return true;
 
   // same pg?


### PR DESCRIPTION
fix core dump caused by can_discard_replica_op() when sending osd not exist in osdmap

please see http://tracker.ceph.com/issues/21006 for details

Signed-off-by: sheng qiu <sheng.qiu@alibaba-inc.com>