### PR TITLE
rgw: evaluate the correct bucket action for GetACL bucket operation

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4498,7 +4498,7 @@ int RGWGetACLs::verify_permission()
 				    rgw::IAM::s3GetObjectAcl :
 				    rgw::IAM::s3GetObjectVersionAcl);
   } else {
-    perm = verify_bucket_permission(s, rgw::IAM::s3GetObjectAcl);
+    perm = verify_bucket_permission(s, rgw::IAM::s3GetBucketAcl);
   }
   if (!perm)
     return -EACCES;


### PR DESCRIPTION
We currently evaluate s3:GetObjectAcl instead of s3:GetBucketAcl for
getting BucketACL

Fixes: http://tracker.ceph.com/issues/21013
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>