### PR TITLE
[DNM]common: add new line break when get command descriptions

### DIFF
--- a/src/common/admin_socket.cc
+++ b/src/common/admin_socket.cc
@@ -536,7 +536,7 @@ public:
   explicit GetdescsHook(AdminSocket *as) : m_as(as) {}
   bool call(string command, cmdmap_t &cmdmap, string format, bufferlist& out) override {
     int cmdnum = 0;
-    JSONFormatter jf(false);
+    JSONFormatter jf;
     jf.open_object_section("command_descriptions");
     for (map<string,string>::iterator p = m_as->m_descs.begin();
 	 p != m_as->m_descs.end();
@@ -550,6 +550,7 @@ public:
       cmdnum++;
     }
     jf.close_section(); // command_descriptions
+    jf.enable_line_break();
     ostringstream ss;
     jf.flush(ss);
     out.append(ss.str());


### PR DESCRIPTION
fixed http://tracker.ceph.com/issues/21019
The result show of CLI command of `ceph daemon osd.0 get_command_descriptions` (the same as mon.\*\/mds.\*\) should have a line break at end.
This pr based on PR https://github.com/ceph/ceph/pull/16687
```
[root@s248 build]# ./bin/ceph daemon osd.0 get_command_descriptions
{"cmd000":{"sig":["0"],"help":""}, ...... "help":"get ceph version"}}[root@s248 build]# 
[root@s248 build]# 
```
Signed-off-by: songweibin <song.weibin@zte.com.cn>