### PR TITLE
mds: Initializing uninitialized members SnapServer

### DIFF
--- a/src/mds/SnapServer.h
+++ b/src/mds/SnapServer.h
@@ -23,7 +23,7 @@ class MonClient;
 
 class SnapServer : public MDSTableServer {
 protected:
-  MonClient *mon_client;
+  MonClient *mon_client = nullptr;
   snapid_t last_snap;
   map<snapid_t, SnapInfo> snaps;
   map<int, set<snapid_t> > need_to_purge;


### PR DESCRIPTION
Fixes the coverity issue:

** 1316251 Uninitialized pointer field
>CID 1316251 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member mon_client is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com