### PR TITLE
vstart.sh: quote cmd params when display executing cmd

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -360,12 +360,12 @@ fi
 ARGS="-c $conf_fn"
 
 prunb() {
-    echo "$* &"
+    printf "'%s' " "$@"; echo '&'
     "$@" &
 }
 
 prun() {
-    echo "$*"
+    printf "'%s' " "$@"; echo
     "$@"
 }
 


### PR DESCRIPTION
vstart.sh will echo executed cmd to the stdout:

```
/root/jiaying/ceph/build/bin/radosgw -c /root/jiaying/ceph/build/ceph.conf --log-file=/root/jiaying/ceph/build/out/rgw.j.log --debug-ms=1 -n client.rgw --rgw_frontends=civetweb port=8000
```

As params contains whitespaces, paste the above cmd into the shell didn't start rgw
on the port 8000. Now the vstart.sh output is like the following:

```
'/root/jiaying/ceph/build/bin/radosgw' '-c' '/root/jiaying/ceph/build/ceph.conf' '--log-file=/root/jiaying/ceph/build/out/rgw.j.log' '--debug-ms=1' '-n' 'client.rgw' '--rgw_frontends=civetweb port=8000'
```

We can paste following cmd to the shell to restart rgw, it's more convenient for debug.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>