### PR TITLE
compressor: conditionalize on HAVE_LZ4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,7 +274,7 @@ find_package(snappy REQUIRED)
 
 option(WITH_LZ4 "LZ4 compression support" OFF)
 if(WITH_LZ4)
-  find_package(LZ4 REQUIRED)
+  find_package(LZ4 1.7 REQUIRED)
   set(HAVE_LZ4 ${LZ4_FOUND})
 endif(WITH_LZ4)
 

--- a/cmake/modules/FindLZ4.cmake
+++ b/cmake/modules/FindLZ4.cmake
@@ -5,11 +5,30 @@
 # LZ4_FOUND
 # LZ4_INCLUDE_DIR
 # LZ4_LIBRARY
+# LZ4_VERSION_STRING
+# LZ4_VERSION_MAJOR
+# LZ4_VERSION_MINOR
+# LZ4_VERSION_RELEASE
 
 find_path(LZ4_INCLUDE_DIR NAMES lz4.h)
+
+if(LZ4_INCLUDE_DIR AND EXISTS "${LZ4_INCLUDE_DIR}/lz4.h")
+  foreach(ver "MAJOR" "MINOR" "RELEASE")
+    file(STRINGS "${LZ4_INCLUDE_DIR}/lz4.h" LZ4_VER_${ver}_LINE
+      REGEX "^#define[ \t]+LZ4_VERSION_${ver}[ \t]+[0-9]+[ \t]+.*$")
+    string(REGEX REPLACE "^#define[ \t]+LZ4_VERSION_${ver}[ \t]+([0-9]+)[ \t]+.*$"
+      "\\1" LZ4_VERSION_${ver} "${LZ4_VER_${ver}_LINE}")
+    unset(${LZ4_VER_${ver}_LINE})
+  endforeach()
+  set(LZ4_VERSION_STRING
+    "${LZ4_VERSION_MAJOR}.${LZ4_VERSION_MINOR}.${LZ4_VERSION_RELEASE}")
+endif()
+
 find_library(LZ4_LIBRARY NAMES lz4)
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(LZ4 DEFAULT_MSG LZ4_LIBRARY LZ4_INCLUDE_DIR)
+find_package_handle_standard_args(LZ4
+  REQUIRED_VARS LZ4_LIBRARY LZ4_INCLUDE_DIR
+  VERSION_VAR LZ4_VERSION_STRING)
 
 mark_as_advanced(LZ4_INCLUDE_DIR LZ4_LIBRARY)

--- a/src/compressor/Compressor.cc
+++ b/src/compressor/Compressor.cc
@@ -27,7 +27,9 @@ const char * Compressor::get_comp_alg_name(int a) {
   case COMP_ALG_SNAPPY: return "snappy";
   case COMP_ALG_ZLIB: return "zlib";
   case COMP_ALG_ZSTD: return "zstd";
+#ifdef HAVE_LZ4
   case COMP_ALG_LZ4: return "lz4";
+#endif
   default: return "???";
   }
 }
@@ -39,8 +41,10 @@ boost::optional<Compressor::CompressionAlgorithm> Compressor::get_comp_alg_type(
     return COMP_ALG_ZLIB;
   if (s == "zstd")
     return COMP_ALG_ZSTD;
+#ifdef HAVE_LZ4
   if (s == "lz4")
     return COMP_ALG_LZ4;
+#endif
   if (s == "" || s == "none")
     return COMP_ALG_NONE;
 

--- a/src/compressor/Compressor.h
+++ b/src/compressor/Compressor.h
@@ -34,7 +34,9 @@ public:
     COMP_ALG_SNAPPY = 1,
     COMP_ALG_ZLIB = 2,
     COMP_ALG_ZSTD = 3,
+#ifdef HAVE_LZ4
     COMP_ALG_LZ4 = 4,
+#endif
     COMP_ALG_LAST	//the last value for range checks
   };
   // compression options


### PR DESCRIPTION
do not enable lz4 compressor plugin unless HAVE_LZ4 is ON. so, for
example, when the compressor type is "random", the compressor factory
won't complain with:

load failed dlopen(): "/usr/lib64/ceph/compressor/libceph_lz4.so: cannot
open shared object file: No such file or directory"

anymore.

Signed-off-by: Kefu Chai <kchai@redhat.com>