### PR TITLE
rgw: fix lc process only schdule the first item of lc objects

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -195,8 +195,10 @@ bool RGWLC::if_already_run_today(time_t& start_date)
   localtime_r(&start_date, &bdt);
 
   if (cct->_conf->rgw_lc_debug_interval > 0) {
-	  /* We're debugging, so say we can run */
-	  return false;
+    if (now - start_date < cct->_conf->rgw_lc_debug_interval)
+      return true;
+    else
+      return false;
   }
 
   bdt.tm_hour = 0;
@@ -667,13 +669,11 @@ int RGWLC::process(int index, int max_lock_secs)
     l.unlock(&store->lc_pool_ctx, obj_names[index]);
     ret = bucket_lc_process(entry.first);
     bucket_lc_post(index, max_lock_secs, entry, ret);
-    return 0;
+  }while(1);
+
 exit:
     l.unlock(&store->lc_pool_ctx, obj_names[index]);
     return 0;
-
-  }while(1);
-
 }
 
 void RGWLC::start_processor()


### PR DESCRIPTION
If more than two bucket hash to the same lc object, only the first bucket will do lifecycle operation. Other buckets lifecycle will never be schduled.

Fixes: http://tracker.ceph.com/issues/21022

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>