### PR TITLE
osd: use dmclock library client_info_f function dynamically

### DIFF
--- a/src/common/mClockPriorityQueue.h
+++ b/src/common/mClockPriorityQueue.h
@@ -206,7 +206,7 @@ namespace ceph {
 
     SubQueues high_queue;
 
-    dmc::PullPriorityQueue<K,T> queue;
+    dmc::PullPriorityQueue<K,T,true> queue;
 
     // when enqueue_front is called, rather than try to re-calc tags
     // to put in mClock priority queue, we'll just keep a separate
@@ -217,7 +217,7 @@ namespace ceph {
   public:
 
     mClockQueue(
-      const typename dmc::PullPriorityQueue<K,T>::ClientInfoFunc& info_func) :
+      const typename dmc::PullPriorityQueue<K,T,true>::ClientInfoFunc& info_func) :
       queue(info_func, true)
     {
       // empty


### PR DESCRIPTION
Use dmclock library client_info_f function dynamically to be able to apply QoS parameter changes at run-time in Ceph and brings in related dmclock library changes.