### PR TITLE
mon/PGMap: reweight::by_utilization - skip DNE osds

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -4567,6 +4567,9 @@ int reweight::by_utilization(
       if (pools && pools->count(pg.first.pool()) == 0)
 	continue;
       for (const auto acting : pg.second.acting) {
+        if (!osdmap.exists(acting)) {
+          continue;
+        }
 	if (acting >= (int)pgs_by_osd.size())
 	  pgs_by_osd.resize(acting);
 	if (pgs_by_osd[acting] == 0) {


### PR DESCRIPTION
EC could set one or more members of acting set to CRUSH_ITEM_NONE,
which as a result can cause pgs_by_osd.resize() attempt to apply
for a large amount of memory which we can not afford.

Fix the above problem by always excluding a current DNE osd from
acting set.

Fixes: http://tracker.ceph.com/issues/20970
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>