### PR TITLE
os: Initializing uninitialized members aio_info

### DIFF
--- a/src/os/filestore/FileJournal.h
+++ b/src/os/filestore/FileJournal.h
@@ -251,7 +251,7 @@ private:
   /// state associated with an in-flight aio request
   /// Protected by aio_lock
   struct aio_info {
-    struct iocb iocb;
+    struct iocb iocb {};
     bufferlist bl;
     struct iovec *iov;
     bool done;


### PR DESCRIPTION
Fixes the coverity issue:

** 717332 Uninitialized pointer field
>2. uninit_member: Non-static class member field iocb.data is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field iocb.key is not
initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member field iocb.__pad2 is not
initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field iocb.aio_lio_opcode
is not initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field iocb.aio_reqprio
is not initialized in this constructor nor in any functions that it calls.

CID 717332 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>12. uninit_member: Non-static class member field iocb.aio_fildes is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com