### PR TITLE
mon: some cleanup

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -199,7 +199,7 @@ COMMAND("auth rm " \
 /*
  * Monitor commands (Monitor.cc)
  */
-COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb storage", \
+COMMAND_WITH_FLAG("compact", "cause compaction of monitor's leveldb/rocksdb storage", \
 	     "mon", "rw", "cli,rest", \
              FLAG(NOFORWARD)|FLAG(DEPRECATED))
 COMMAND_WITH_FLAG("scrub", "scrub the monitor stores", \
@@ -264,7 +264,7 @@ COMMAND("node ls " \
  * Monitor-specific commands under module 'mon'
  */
 COMMAND_WITH_FLAG("mon compact", \
-    "cause compaction of monitor's leveldb storage", \
+    "cause compaction of monitor's leveldb/rocksdb storage", \
     "mon", "rw", "cli,rest", \
     FLAG(NOFORWARD))
 COMMAND_WITH_FLAG("mon scrub",

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -396,7 +396,7 @@ void PGMapDigest::recovery_summary(Formatter *f, list<string> *psl,
     } else {
       ostringstream ss;
       ss << delta_sum.stats.sum.num_objects_unfound
-         << "/" << delta_sum.stats.sum.num_objects << " unfound (" << b << "%)";
+         << "/" << delta_sum.stats.sum.num_objects << " objects unfound (" << b << "%)";
       psl->push_back(ss.str());
     }
   }
@@ -3097,7 +3097,7 @@ void PGMap::get_health_checks(
     snprintf(b, sizeof(b), "%.3lf", pc);
     ostringstream ss;
     ss << pg_sum.stats.sum.num_objects_unfound
-       << "/" << pg_sum.stats.sum.num_objects << " unfound (" << b << "%)";
+       << "/" << pg_sum.stats.sum.num_objects << " objects unfound (" << b << "%)";
     auto& d = checks->add("OBJECT_UNFOUND", HEALTH_WARN, ss.str());
 
     for (auto& p : pg_stat) {


### PR DESCRIPTION
1. Mon's default backend KV database is Rocksdb,
as "mon_keyvaluedb" define, and also support Leveldb.
so I add these two types of tips.

2. the objects prefix display indicates the scope of the "unfound",
like objects "misplaced" err.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>