### PR TITLE
Decreased amount of jobs on master, kraken, luminous runs

### DIFF
--- a/qa/machine_types/schedule_subset.sh
+++ b/qa/machine_types/schedule_subset.sh
@@ -25,8 +25,8 @@
 
 echo "Scheduling " $2 " branch"
 if [ $2 = "master" ] ; then
-        # run master branch with --newest option looking for good sha1 7 builds back
-        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/28 --newest 7 -e $5 $6
+        # run master branch with --newest option looking for good sha1 7 builds back with /999 jobs
+        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/999 --newest 7 -e $5 $6
 elif [ $2 = "hammer" ] ; then
         # run hammer branch with less jobs
         teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/56 -e $5 $6
@@ -34,11 +34,11 @@ elif [ $2 = "jewel" ] ; then
         # run jewel branch with /40 jobs
         teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/40 -e $5 $6
 elif [ $2 = "kraken" ] ; then
-        # run kraken branch with /40 jobs
-        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/40 -e $5 $6
+        # run kraken branch with /999 jobs
+        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/999 -e $5 $6
 elif [ $2 = "luminous" ] ; then
-        # run luminous branch with /40 jobs
-        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/40 -e $5 $6
+        # run luminous branch with /999 jobs
+        teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/999 -e $5 $6
 else
         # run NON master branches without --newest 
         teuthology-suite -v -c $2 -m $3 -k distro -s $4 --subset $(echo "(($(date +%U) % 4) * 7) + $1" | bc)/28 -e $5 $6


### PR DESCRIPTION
Needs backport to luminous and kraken

Old value in `--subset` produced ~1,800 jobs which is unmanageable

New value `--subset` /999 produced "scheduled 193 jobs"

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>