### PR TITLE
rpm: rm macros in comments

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -67,7 +67,8 @@ Release:	@RPM_RELEASE@%{?dist}
 Epoch:		2
 %endif
 
-# define %_epoch_prefix macro which will expand to the empty string if %epoch is undefined
+# define _epoch_prefix macro which will expand to the empty string if epoch is
+# undefined
 %global _epoch_prefix %{?epoch:%{epoch}:}
 
 Summary:	User space components of the Ceph file system


### PR DESCRIPTION
rpm expands all macros in a .spec file, even those in comments. Drop the percent signs so rpm will not expand these.



This change silences rpmlint's warning about macros in comments.