### PR TITLE
DNM osd: speed up get_key_name

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -918,14 +918,9 @@ int pg_string_state(const std::string& state)
 string eversion_t::get_key_name() const
 {
   char key[32];
-  // Below is equivalent of sprintf("%010u.%020llu");
-  key[31] = 0;
-  ritoa<uint64_t, 10, 20>(version, key + 31);
-  key[10] = '.';
-  ritoa<uint32_t, 10, 10>(epoch, key + 10);
+  get_key_name(key);
   return string(key);
 }
-
 
 // -- pool_snap_info_t --
 void pool_snap_info_t::dump(Formatter *f) const
@@ -4125,9 +4120,13 @@ ostream& operator<<(ostream& out, const pg_log_entry_t& e)
 
 // -- pg_log_dup_t --
 
-string pg_log_dup_t::get_key_name() const
+std::string pg_log_dup_t::get_key_name() const
 {
-  return "dup_" + version.get_key_name();
+  alignas(4) static char prefix[] = { 'd', 'u', 'p', '_' };
+  alignas(4) char key[36];
+  memcpy(key, prefix, 4);
+  version.get_key_name(key + 4);
+  return std::string(key);
 }
 
 void pg_log_dup_t::encode(bufferlist &bl) const

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -811,6 +811,15 @@ public:
 
   string get_key_name() const;
 
+  // key must point to the beginning of a block of 32 chars
+  inline void get_key_name(char* key) const {
+    // Below is equivalent of sprintf("%010u.%020llu");
+    key[31] = 0;
+    ritoa<uint64_t, 10, 20>(version, key + 31);
+    key[10] = '.';
+    ritoa<uint32_t, 10, 10>(epoch, key + 10);
+  }
+
   void encode(bufferlist &bl) const {
 #if defined(CEPH_LITTLE_ENDIAN)
     bl.append((char *)this, sizeof(version_t) + sizeof(epoch_t));

--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2980,6 +2980,24 @@ TEST_F(PGLogTest, _merge_object_divergent_entries) {
   }
 }
 
+
+TEST(eversion_t, get_key_name) {
+  eversion_t a(1234, 5678);
+  std::string a_key_name = a.get_key_name();
+  EXPECT_EQ("0000001234.00000000000000005678", a_key_name);
+}
+
+
+TEST(pg_log_dup_t, get_key_name) {
+  pg_log_dup_t a(eversion_t(1234, 5678),
+		 13,
+		 osd_reqid_t(entity_name_t::CLIENT(777), 8, 999),
+		 15);
+  std::string a_key_name = a.get_key_name();
+  EXPECT_EQ("dup_0000001234.00000000000000005678", a_key_name);
+}
+
+
 // Local Variables:
 // compile-command: "cd ../.. ; make unittest_pglog ; ./unittest_pglog --log-to-stderr=true  --debug-osd=20 # --gtest_filter=*.* "
 // End:


### PR DESCRIPTION
To help address issues of http://tracker.ceph.com/issues/21026

Reduce string manipulation and creation of an extra string by
streamlining code for get_key_name in both eversion_t and
pg_log_dup_t.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>