### PR TITLE
qa/workunits/rbd: test data pool is mirrored correctly

### DIFF
--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -867,6 +867,16 @@ request_resync_image()
     rbd --cluster=${cluster} -p ${pool} mirror image resync ${image}
 }
 
+get_image_data_pool()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+
+    rbd --cluster ${cluster} -p ${pool} info ${image} |
+        awk '$1 == "data_pool:" {print $2}'
+}
+
 #
 # Main
 #


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@mirantis.com>
(cherry picked from commit c4c7075029f20f238585145c464a8c972d9ad038)