### PR TITLE
test/librbd: TestMirroringWatcher unit tests should ignore duplicates

### DIFF
--- a/src/test/librbd/test_MirroringWatcher.cc
+++ b/src/test/librbd/test_MirroringWatcher.cc
@@ -32,6 +32,7 @@ struct MockMirroringWatcher : public MirroringWatcher<> {
 } // anonymous namespace
 
 using ::testing::_;
+using ::testing::AtLeast;
 using ::testing::Invoke;
 using ::testing::StrEq;
 using ::testing::WithArg;
@@ -72,10 +73,13 @@ public:
 };
 
 TEST_F(TestMirroringWatcher, ModeUpdated) {
-  EXPECT_CALL(*m_image_watcher, handle_mode_updated(cls::rbd::MIRROR_MODE_DISABLED));
+  EXPECT_CALL(*m_image_watcher,
+              handle_mode_updated(cls::rbd::MIRROR_MODE_DISABLED))
+    .Times(AtLeast(1));
 
   C_SaferCond ctx;
-  MockMirroringWatcher::notify_mode_updated(m_ioctx, cls::rbd::MIRROR_MODE_DISABLED, &ctx);
+  MockMirroringWatcher::notify_mode_updated(
+    m_ioctx, cls::rbd::MIRROR_MODE_DISABLED, &ctx);
   ASSERT_EQ(0, ctx.wait());
 }
 
@@ -83,12 +87,13 @@ TEST_F(TestMirroringWatcher, ImageStatusUpdated) {
   EXPECT_CALL(*m_image_watcher,
               handle_image_updated(cls::rbd::MIRROR_IMAGE_STATE_ENABLED,
                                    StrEq("image id"),
-                                   StrEq("global image id")));
+                                   StrEq("global image id")))
+    .Times(AtLeast(1));
 
   C_SaferCond ctx;
-  MockMirroringWatcher::notify_image_updated(m_ioctx,
-                                             cls::rbd::MIRROR_IMAGE_STATE_ENABLED,
-                                             "image id", "global image id", &ctx);
+  MockMirroringWatcher::notify_image_updated(
+    m_ioctx, cls::rbd::MIRROR_IMAGE_STATE_ENABLED, "image id",
+    "global image id", &ctx);
   ASSERT_EQ(0, ctx.wait());
 }
 


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21029
Signed-off-by: Jason Dillaman <dillaman@redhat.com>