### PR TITLE
msg: drop the unnecessary polling_stop()

### DIFF
--- a/src/msg/async/rdma/RDMAStack.cc
+++ b/src/msg/async/rdma/RDMAStack.cc
@@ -547,8 +547,6 @@ RDMAStack::~RDMAStack()
   if (cct->_conf->ms_async_rdma_enable_hugepage) {
     unsetenv("RDMAV_HUGEPAGES_SAFE");	//remove env variable on destruction
   }
-
-  dispatcher.polling_stop();
 }
 
 void RDMAStack::spawn_worker(unsigned i, std::function<void ()> &&func)


### PR DESCRIPTION
Drop the unnecessary polling_stop() in the ~RDMAStack(). The RDMADispatcher object contained in
RDMAStack will get distroyed when RDMAStack gets distroyed. Thus ~RDMADispatcher() will be
called automatically and executes the polling_stop().

Fixes:
The below coverity scan reports.
```
1. CID 1416590:  Memory - corruptions (USE_AFTER_FREE)
    Calling "~RDMADispatcher" frees pointer "this->dispatcher.rx_cq" which has already been freed.
2. CID 1416593:  Memory - illegal accesses (USE_AFTER_FREE)
    Calling "~RDMADispatcher" dereferences freed pointer "this->dispatcher.tx_cc".
3. CID 1416595:  Memory - corruptions (USE_AFTER_FREE)
    Calling "~RDMADispatcher" frees pointer "this->dispatcher.tx_cq" which has already been freed.
4. CID 1416597:  Memory - illegal accesses (USE_AFTER_FREE)
    Calling "~RDMADispatcher" dereferences freed pointer "this->dispatcher.rx_cc".
```
Signed-off-by: Jos Collin <jcollin@redhat.com>