### PR TITLE
jewel: osd: default osd_scrub_during_recovery=false

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,9 @@
 * The 'mon_warn_osd_usage_min_max_delta' health warning has been disabled because
   it does not address clusters undergoing recovery or CRUSH rules that do
   not target all devices in the cluster.
+
+* The OSDs now avoid starting new scrubs while recovery is in progress.  To
+  revert to the old behavior (and do not let recovery activity affect the
+  scrub scheduling) you can set the following option::
+
+    osd scrub during recovery = true

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -767,7 +767,7 @@ OPTION(osd_max_push_cost, OPT_U64, 8<<20)  // max size of push message
 OPTION(osd_max_push_objects, OPT_U64, 10)  // max objects in single push op
 OPTION(osd_recovery_forget_lost_objects, OPT_BOOL, false)   // off for now
 OPTION(osd_max_scrubs, OPT_INT, 1)
-OPTION(osd_scrub_during_recovery, OPT_BOOL, true) // Allow new scrubs to start while recovery is active on the OSD
+OPTION(osd_scrub_during_recovery, OPT_BOOL, false) // Allow new scrubs to start while recovery is active on the OSD
 OPTION(osd_scrub_begin_hour, OPT_INT, 0)
 OPTION(osd_scrub_end_hour, OPT_INT, 24)
 OPTION(osd_scrub_load_threshold, OPT_FLOAT, 0.5)


### PR DESCRIPTION
This is a more friendly behavior.  Tell users in the release notes how to
get the old behavior.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 8dca17c067b51050308c5f1cb5eddd400fd6f3f0)

 Conflicts:
	PendingReleaseNotes "trivial resolution"

	