### PR TITLE
crush: force rebuilding shadow hierarchy after swapping buckets

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1075,7 +1075,7 @@ int CrushWrapper::swap_bucket(CephContext *cct, int src, int dst)
 
   // swap names
   swap_names(src, dst);
-  return 0;
+  return rebuild_roots_with_classes();
 }
 
 int CrushWrapper::link_bucket(


### PR DESCRIPTION
Was:
```
---------------------------------------------------------------
ID CLASS WEIGHT  TYPE NAME
-8   ssd 3.00000 root fake-root~ssd
-6   ssd 3.00000     host fake~ssd
 0   ssd 1.00000         osd.0
 1   ssd 1.00000         osd.1
 2   ssd 1.00000         osd.2
-7       3.00000 root fake-root
-5       3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic
 3   ssd 1.00000         osd.3
 4   ssd 1.00000         osd.4
 5   ssd 1.00000         osd.5
-4   ssd 3.00000 root default~ssd
-3   ssd 3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic~ssd
 3   ssd 1.00000         osd.3
 4   ssd 1.00000         osd.4
 5   ssd 1.00000         osd.5
-1       3.00000 root default
-2       3.00000     host fake
 0   ssd 1.00000         osd.0
 1   ssd 1.00000         osd.1
 2   ssd 1.00000         osd.2
```
Now:


---------------------------------------------------------------
```
ID CLASS WEIGHT  TYPE NAME
-8   ssd 3.00000 root fake-root~ssd
-7   ssd 3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic~ssd
 3   ssd 1.00000         osd.3
 4   ssd 1.00000         osd.4
 5   ssd 1.00000         osd.5
-6       3.00000 root fake-root
-5       3.00000     host gitbuilder-ceph-rpm-centos7-amd64-basic
 3   ssd 1.00000         osd.3
 4   ssd 1.00000         osd.4
 5   ssd 1.00000         osd.5
-4   ssd 3.00000 root default~ssd
-3   ssd 3.00000     host fake~ssd
 0   ssd 1.00000         osd.0
 1   ssd 1.00000         osd.1
 2   ssd 1.00000         osd.2
-1       3.00000 root default
-2       3.00000     host fake
 0   ssd 1.00000         osd.0
 1   ssd 1.00000         osd.1
 2   ssd 1.00000         osd.2
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>