### PR TITLE
jewel: ceph-disk: Use stdin for 'config-key put' command

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1846,6 +1846,12 @@ function test_mon_cephdf_commands()
   expect_false test $cal_raw_used_size != $raw_used_size
 }
 
+function test_mon_stdin_stdout()
+{
+  echo foo | ceph config-key put test_key -i -
+  ceph config-key get test_key -o - | grep -c foo | grep -q 1
+}
+
 #
 # New tests should be added to the TESTS array below
 #
@@ -1884,6 +1890,8 @@ MON_TESTS+=" mon_crushmap_validation"
 MON_TESTS+=" mon_ping"
 MON_TESTS+=" mon_deprecated_commands"
 MON_TESTS+=" mon_caps"
+MON_TESTS+=" mon_stdin_stdout"
+
 OSD_TESTS+=" osd_bench"
 OSD_TESTS+=" osd_negative_filestore_merge_threshold"
 OSD_TESTS+=" tiering_agent"

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -427,6 +427,26 @@ def command(arguments, **kwargs):
     return _bytes2str(out), _bytes2str(err), process.returncode
 
 
+def command_with_stdin(arguments, stdin):
+    LOG.info("Running command with stdin: " + " ".join(arguments))
+    process = subprocess.Popen(
+        arguments,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    out, err = process.communicate(stdin)
+    LOG.debug(out)
+    if process.returncode != 0:
+        LOG.error(err)
+        raise SystemExit(
+            "'{cmd}' failed with status code {returncode}".format(
+                cmd=arguments,
+                returncode=process.returncode,
+            )
+        )
+    return out
+
+
 def _bytes2str(string):
     return string.decode('utf-8') if isinstance(string, bytes) else string
 

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2362,17 +2362,18 @@ class Lockbox(object):
         cluster = self.args.cluster
         bootstrap = self.args.prepare_key_template.format(cluster=cluster,
                                                           statedir=STATEDIR)
-        command_check_call(
+        command_with_stdin(
             [
                 'ceph',
                 '--cluster', cluster,
                 '--name', 'client.bootstrap-osd',
                 '--keyring', bootstrap,
+                '-i', '-',
                 'config-key',
                 'put',
                 'dm-crypt/osd/' + self.args.osd_uuid + '/luks',
-                base64_key,
             ],
+            base64_key
         )
         keyring, stderr, ret = command(
             [

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -202,9 +202,9 @@ def parse_cmdargs(args=None, target=''):
     parser.add_argument('-c', '--conf', dest='cephconf',
                         help='ceph configuration file')
     parser.add_argument('-i', '--in-file', dest='input_file',
-                        help='input file')
+                        help='input file, or "-" for stdin')
     parser.add_argument('-o', '--out-file', dest='output_file',
-                        help='output file')
+                        help='output file, or "-" for stdout')
 
     parser.add_argument('--id', '--user', dest='client_id',
                         help='client id for authentication')
@@ -785,8 +785,11 @@ def main():
     inbuf = ''
     if parsed_args.input_file:
         try:
-            with open(parsed_args.input_file, 'r') as f:
-                inbuf = f.read()
+            if parsed_args.input_file == '-':
+                inbuf = sys.stdin.read()
+            else:
+                with open(parsed_args.input_file, 'rb') as f:
+                    inbuf = f.read()
         except Exception as e:
             print('Can\'t open input file {0}: {1}'.format(parsed_args.input_file, e), file=sys.stderr)
             return 1
@@ -794,7 +797,10 @@ def main():
     # prepare output file, if any
     if parsed_args.output_file:
         try:
-            outf = open(parsed_args.output_file, 'w')
+            if parsed_args.output_file == '-':
+                outf = sys.stdout
+            else:
+                outf = open(parsed_args.output_file, 'wb')
         except Exception as e:
             print('Can\'t open output file {0}: {1}'.format(parsed_args.output_file, e), file=sys.stderr)
             return 1
@@ -936,7 +942,7 @@ def main():
 
         sys.stdout.flush()
 
-    if (parsed_args.output_file):
+    if parsed_args.output_file and parsed_args.output_file != '-':
         outf.close()
 
     if final_ret:


### PR DESCRIPTION
Use '-i -' so we avoid logging the dmcrypt key.

Fixes: http://tracker.ceph.com/issues/21059

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>