### PR TITLE
librgw_file: remove unused `using` statement.

### DIFF
--- a/src/test/librgw_file.cc
+++ b/src/test/librgw_file.cc
@@ -61,8 +61,6 @@ TEST(LibRGW, MOUNT) {
 
 TEST(LibRGW, GETATTR_ROOT) {
   if (do_getattr) {
-    using std::get;
-
     if (! fs)
       return;
 


### PR DESCRIPTION
librgw_file: remove the unused using statement.

Signed-off-by: Yao Zongyou <yaozongyou@vip.qq.com>