### PR TITLE
test/journal: Initialize member variable m_work_queue

### DIFF
--- a/src/test/journal/RadosTestFixture.h
+++ b/src/test/journal/RadosTestFixture.h
@@ -64,7 +64,7 @@ public:
 
   librados::IoCtx m_ioctx;
 
-  ContextWQ *m_work_queue;
+  ContextWQ *m_work_queue = nullptr;
 
   Mutex m_timer_lock;
   SafeTimer *m_timer;


### PR DESCRIPTION
Fixes the coverity issue:

** 1396201 Uninitialized pointer field
>CID 1396201 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_work_queue is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com