### PR TITLE
messages: Initializing variable ceph_mds_reply_head

### DIFF
--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -202,7 +202,7 @@ struct InodeStat {
 class MClientReply : public Message {
   // reply data
 public:
-  struct ceph_mds_reply_head head;
+  struct ceph_mds_reply_head head {};
   bufferlist trace_bl;
   bufferlist extra_bl;
   bufferlist snapbl;


### PR DESCRIPTION
Fixes the coverity issue:

** 717263 Uninitialized scalar field
>2. uninit_member: Non-static class member field head.op is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field head.result is not
initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member field head.mdsmap_epoch is
not initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field head.safe is not
initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field head.is_dentry is
not initialized in this constructor nor in any functions that it calls.

CID 717263 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>12. uninit_member: Non-static class member field head.is_target is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com