### PR TITLE
Small cleanups and less racy mountedness checks for libcephfs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5677,6 +5677,8 @@ int Client::mount(const std::string &mount_root, const UserPerm& perms,
     return 0;
   }
 
+  unmounting = false;
+
   int r = authenticate();
   if (r < 0) {
     lderr(cct) << "authentication failed: " << cpp_strerror(r) << dendl;

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -251,7 +251,7 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     last_tid(0), oldest_tid(0), last_flush_tid(1),
     initialized(false),
     mounted(false), unmounting(false), blacklisted(false),
-    local_osd(-1), local_osd_epoch(0),
+    local_osd(-ENXIO), local_osd_epoch(0),
     unsafe_sync_write(0),
     client_lock("Client::client_lock")
 {
@@ -12868,9 +12868,7 @@ int Client::enumerate_layout(int fd, vector<ObjectExtent>& result,
 }
 
 
-/*
- * find an osd with the same ip.  -1 if none.
- */
+/* find an osd with the same ip.  -ENXIO if none. */
 int Client::get_local_osd()
 {
   Mutex::Locker lock(client_lock);

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -142,9 +142,6 @@ void Inode::get_cap_ref(int cap)
 
 int Inode::put_cap_ref(int cap)
 {
-  // if cap is always a single bit (which it seems to be)
-  // all this logic is equivalent to:
-  // if (--cap_refs[c]) return false; else return true;
   int last = 0;
   int n = 0;
   while (cap) {


### PR DESCRIPTION
This patchset is a small set of preparatory patches for some work I'm doing on delegations.

Along the way, I took a hard look at the way we're handling checks for "mountedness" on the ceph_mount_info, and I think there are potential races there. This should make things a little safer in that regard.

The ulterior motive here is getting the code ready for a world where we may forcibly unmount the client if it doesn't return a delegation in the proper manner. There are also some small interface and comment cleanups.

Pulpito run is going now:

    http://pulpito.ceph.com/jlayton-2017-08-18_15:50:15-fs-wip-jlayton-21025-distro-basic-smithi/

...a few failures there but they don't seem likely to be related to this set.