### PR TITLE
doc: Fixed the build issue while running 'admin/build-doc'

### DIFF
--- a/admin/build-doc
+++ b/admin/build-doc
@@ -22,7 +22,11 @@ if command -v dpkg >/dev/null; then
 elif command -v yum >/dev/null; then
     for package in python-devel python-pip python-virtualenv doxygen ditaa ant libxml2-devel libxslt-devel Cython graphviz; do
 	if ! rpm -q $package >/dev/null ; then
-		missing="${missing:+$missing }$package"
+		command -v `echo $package | tr '[:upper:]' '[:lower:]' | awk -F "-" '{ if ($2 == "") print $1; else print $2}'`   > /dev/null;
+		ret_code=$?
+		if [ $ret_code -ne 0 ]; then
+			missing="${missing:+$missing }$package"
+		fi
 	fi
     done
     if [ -n "$missing" ]; then


### PR DESCRIPTION
'admin/build-doc' gives error of missing packages for 'python-virtualenv'
and 'Cython', inspite of packages being installed.

Following error is reported when 'admin/build-doc' is ran :
```
$ admin/build-doc
admin/build-doc: missing required packages, please install them:
yum install python-virtualenv Cython

$ which virtualenv
/usr/bin/virtualenv
$ which cython
/usr/bin/cython

$ rpm -qa | grep virtualenv
python2-virtualenv-15.0.3-2.fc25.noarch
$ rpm -qa | grep Cython
python3-Cython-0.25.2-3.fc25.x86_64
python2-Cython-0.25.2-3.fc25.x86_64
```


Signed-off-by: Ashish Singh <assingh@redhat.com>