### PR TITLE
Fix trash_move docstring formatting

### DIFF
--- a/src/pybind/rbd/rbd.pyx
+++ b/src/pybind/rbd/rbd.pyx
@@ -898,13 +898,12 @@ class RBD(object):
     def trash_move(self, ioctx, name, delay=0):
         """
         Move an RBD image to the trash.
-
         :param ioctx: determines which RADOS pool the image is in
         :type ioctx: :class:`rados.Ioctx`
         :param name: the name of the image to remove
         :type name: str
         :param delay: time delay in seconds before the image can be deleted
-                      from trash
+        from trash
         :type delay: int
         :raises: :class:`ImageNotFound`
         """


### PR DESCRIPTION
This fixes an issue where the admin/build-doc script fails because the trash_move docstring formatting causes a warning that it treats as an error