### PR TITLE
NVMDevice: fix issued caused by #17002

### DIFF
--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -92,10 +92,10 @@ protected:
   uint64_t size;
   uint64_t block_size;
   bool rotational = true;
-  aio_callback_t aio_callback;
-  void *aio_callback_priv;
 
 public:
+  aio_callback_t aio_callback;
+  void *aio_callback_priv;
   BlockDevice(CephContext* cct, aio_callback_t cb, void *cbpriv)
   : cct(cct),
     size(0),

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -199,9 +199,6 @@ class NVMEDevice : public BlockDevice {
   SharedDriverData *get_driver() { return driver; }
 
  public:
-  aio_callback_t aio_callback;
-  void *aio_callback_priv;
-
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   bool supported_bdev_label() override { return false; }


### PR DESCRIPTION
Patch #17002 breaks running osd when using spdk, and
this patch can fix this.