### PR TITLE
osd: Initialization of pointer cls

### DIFF
--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -36,7 +36,7 @@ public:
   };
 
   struct ClassFilter {
-    struct ClassHandler::ClassData *cls;
+    struct ClassHandler::ClassData *cls = nullptr;
     std::string name;
     cls_cxx_filter_factory_t fn;
 


### PR DESCRIPTION
Fixes the coverity issue:

** 1322812 Uninitialized pointer field
>CID 1322812 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member cls is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com