### PR TITLE
rpm: ceph-fuse requires fuse package

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -342,6 +342,7 @@ Summary:	Ceph fuse-based client
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
+Requires:       fuse
 %description fuse
 FUSE based client for Ceph distributed network file system
 


### PR DESCRIPTION
The `ceph-fuse(8)` man page describes using the `fusermount` tool to mount CephFS. This utility is in the `fuse` package. Prior to this change, the ceph-fuse RPM only depended on `fuse-libs`, not `fuse`.

The Debian packaging has always depended on the full `fuse` (previously `fuse-utils`) package, so we should make the RPM packaging do the same.

Fixes: http://tracker.ceph.com/issues/21057