### PR TITLE
mon/OSDMonitor: add location option for "crush add-bucket" command

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -78,6 +78,14 @@ ceph osd tree | grep -c host1 | grep -q 0
 expect_false ceph osd crush rm bar   # not empty
 ceph osd crush unlink host2
 
+ceph osd crush add-bucket host-for-test host root=root-for-test rack=rack-for-test
+ceph osd tree | grep host-for-test
+ceph osd tree | grep rack-for-test
+ceph osd tree | grep root-for-test
+ceph osd crush rm host-for-test
+ceph osd crush rm rack-for-test
+ceph osd crush rm root-for-test
+
 # reference foo and bar with a rule
 ceph osd crush rule create-simple foo-rule foo host firstn
 expect_false ceph osd crush rm foo

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -524,8 +524,10 @@ COMMAND("osd crush set name=prior_version,type=CephInt,req=false", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd crush add-bucket " \
 	"name=name,type=CephString,goodchars=[A-Za-z0-9-_.] " \
-	"name=type,type=CephString", \
-	"add no-parent (probably root) crush bucket <name> of type <type>", \
+        "name=type,type=CephString " \
+        "name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=],req=false", \
+	"add no-parent (probably root) crush bucket <name> of type <type> " \
+        "to location <args>", \
 	"osd", "rw", "cli,rest")
 COMMAND("osd crush rename-bucket " \
 	"name=srcname,type=CephString,goodchars=[A-Za-z0-9-_.] " \

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -613,13 +613,11 @@ class TestOSD(TestArgparse):
     def test_crush_add_bucket(self):
         self.assert_valid_command(['osd', 'crush', 'add-bucket',
                                    'name', 'type'])
+        self.assert_valid_command(['osd', 'crush', 'add-bucket',
+                                   'name', 'type', 'root=foo-root', 'host=foo-host'])
         assert_equal({}, validate_command(sigdict, ['osd', 'crush']))
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
                                                     'add-bucket']))
-        assert_equal({}, validate_command(sigdict, ['osd', 'crush',
-                                                    'add-bucket', 'name',
-                                                    'type',
-                                                    'toomany']))
         assert_equal({}, validate_command(sigdict, ['osd', 'crush',
                                                     'add-bucket', '^^^',
                                                     'type']))


### PR DESCRIPTION
So we can combine "crush add-bucket" with "crush move" command,
and hence avoid making two separate changes to the osdmap
and slow down map-epoch generation a bit.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>