### PR TITLE
common/types: make numbers a bit nicer when displaying space usage

### DIFF
--- a/qa/standalone/mon/test_pool_quota.sh
+++ b/qa/standalone/mon/test_pool_quota.sh
@@ -50,14 +50,14 @@ function TEST_pool_quota() {
 
     objects=`ceph df detail | grep -w $poolname|awk '{print $3}'`
     bytes=`ceph df detail | grep -w $poolname|awk '{print $4}'`
+   
+    if [ $objects != '1000' ] || [ $bytes != '1K' ] ;
+      then
+      return 1
+    fi
 
-     if [ $objects != '1000' ] || [ $bytes != '1024' ] ;
-       then
-       return 1
-     fi
-
-     ceph osd pool delete  $poolname $poolname  --yes-i-really-really-mean-it
-     teardown $dir || return 1
+    ceph osd pool delete  $poolname $poolname  --yes-i-really-really-mean-it
+    teardown $dir || return 1
 }
 
 main testpoolquota

--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -1744,7 +1744,7 @@ function test_mon_osd_pool_quota()
   # get quotas
   #
   ceph osd pool get-quota tmp-quota-pool | grep 'max bytes.*10B'
-  ceph osd pool get-quota tmp-quota-pool | grep 'max objects.*10240k objects'
+  ceph osd pool get-quota tmp-quota-pool | grep 'max objects.*10M objects'
   #
   # get quotas in json-pretty format
   #

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -147,8 +147,8 @@ test_ls() {
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
     # look for fields in output of ls -l without worrying about space
-    rbd ls -l | grep 'test1.*1024k.*1'
-    rbd ls -l | grep 'test2.*1024k.*1'
+    rbd ls -l | grep 'test1.*1M.*1'
+    rbd ls -l | grep 'test2.*1M.*1'
 
     rbd rm test1
     rbd rm test2
@@ -158,8 +158,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1024k.*2'
-    rbd ls -l | grep 'test2.*1024k.*2'
+    rbd ls -l | grep 'test1.*1M.*2'
+    rbd ls -l | grep 'test2.*1M.*2'
 
     rbd rm test1
     rbd rm test2
@@ -169,8 +169,8 @@ test_ls() {
     rbd ls | grep test1
     rbd ls | grep test2
     rbd ls | wc -l | grep 2
-    rbd ls -l | grep 'test1.*1024k.*2'
-    rbd ls -l | grep 'test2.*1024k.*1'
+    rbd ls -l | grep 'test1.*1M.*2'
+    rbd ls -l | grep 'test2.*1M.*1'
     remove_images
 	
     # test that many images can be shown by ls

--- a/qa/workunits/rbd/import_export.sh
+++ b/qa/workunits/rbd/import_export.sh
@@ -158,7 +158,7 @@ dd if=/dev/urandom bs=1M count=1 of=${TMPDIR}/sparse2; truncate ${TMPDIR}/sparse
 # 1M sparse, 1M data
 rbd rm sparse1 || true
 rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse1
-rbd ls -l | grep sparse1 | grep -i '2048k'
+rbd ls -l | grep sparse1 | grep -i '2M'
 [ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
 
 # export, compare contents and on-disk size
@@ -170,7 +170,7 @@ rbd rm sparse1
 # 1M data, 1M sparse
 rbd rm sparse2 || true
 rbd import $RBD_CREATE_ARGS --order 20 ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -i '2048k'
+rbd ls -l | grep sparse2 | grep -i '2M'
 [ $tiered -eq 1 -o "$(objects sparse2)" = '0' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out
@@ -181,7 +181,7 @@ rbd rm sparse2
 truncate ${TMPDIR}/sparse1 -s 10M
 # import from stdin just for fun, verify still sparse
 rbd import $RBD_CREATE_ARGS --order 20 - sparse1 < ${TMPDIR}/sparse1
-rbd ls -l | grep sparse1 | grep -i '10240k'
+rbd ls -l | grep sparse1 | grep -i '10M'
 [ $tiered -eq 1 -o "$(objects sparse1)" = '1' ]
 rbd export sparse1 ${TMPDIR}/sparse1.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse1 ${TMPDIR}/sparse1.out
@@ -192,7 +192,7 @@ rbd rm sparse1
 dd if=/dev/urandom bs=2M count=1 of=${TMPDIR}/sparse2 oflag=append conv=notrunc
 # again from stding
 rbd import $RBD_CREATE_ARGS --order 20 - sparse2 < ${TMPDIR}/sparse2
-rbd ls -l | grep sparse2 | grep -i '4096k'
+rbd ls -l | grep sparse2 | grep -i '4M'
 [ $tiered -eq 1 -o "$(objects sparse2)" = '0 2 3' ]
 rbd export sparse2 ${TMPDIR}/sparse2.out
 compare_files_and_ondisk_sizes ${TMPDIR}/sparse2 ${TMPDIR}/sparse2.out

--- a/src/test/cli-integration/rbd/formatted-output.t
+++ b/src/test/cli-integration/rbd/formatted-output.t
@@ -550,15 +550,15 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     <name>quuy</name>
   </images>
   $ rbd list -l
-  NAME       SIZE PARENT FMT PROT LOCK 
-  foo       1024M          1           
-  foo@snap  1024M          1           
-  quux      1024k          1      excl 
-  bar       1024M          2           
-  bar@snap   512M          2 yes       
-  bar@snap2 1024M          2           
-  baz       2048M          2      shr  
-  quuy      2048M          2           
+  NAME      SIZE PARENT FMT PROT LOCK 
+  foo         1G          1           
+  foo@snap    1G          1           
+  quux        1M          1      excl 
+  bar         1G          2           
+  bar@snap  512M          2 yes       
+  bar@snap2   1G          2           
+  baz         2G          2      shr  
+  quuy        2G          2           
   $ rbd list -l --format json | python -mjson.tool | sed 's/,$/, /'
   [
       {
@@ -886,12 +886,12 @@ whenever it is run. grep -v to ignore it, but still work on other distros.
     </snapshot>
   </snapshots>
   $ rbd disk-usage --pool rbd_other 2>/dev/null
-  NAME                    PROVISIONED  USED 
-  child@snap                     512M     0 
-  child                          512M 4096k 
-  deep-flatten-child@snap        512M     0 
-  deep-flatten-child             512M     0 
-  <TOTAL>                       1024M 4096k 
+  NAME                    PROVISIONED USED 
+  child@snap                     512M    0 
+  child                          512M   4M 
+  deep-flatten-child@snap        512M    0 
+  deep-flatten-child             512M    0 
+  <TOTAL>                          1G   4M 
   $ rbd disk-usage --pool rbd_other --format json | python -mjson.tool | sed 's/,$/, /'
   {
       "images": [


### PR DESCRIPTION
Was:
```
----------------------------------------------------------------------------
GLOBAL:
    SIZE       AVAIL      RAW USED     %RAW USED
    30911M     27050M        3861M         12.49
POOLS:
    NAME                  ID     USED        %USED     MAX AVAIL     OBJECTS
    rbd                   0      101216k      1.10         8913M        1178
    cephfs_data_a         1            0         0         8913M           0
    cephfs_metadata_a     2          892         0         8913M          21
----------------------------------------------------------------------------
```

Now:
```
----------------------------------------------------------------------------
GLOBAL:
    SIZE      AVAIL     RAW USED     %RAW USED
    30.2G     26.4G        3.77G         12.50
POOLS:
    NAME                  ID     USED      %USED     MAX AVAIL     OBJECTS
    rbd                   0      99.2M      1.10         8.70G        1180
    cephfs_data_a         1          0         0         8.70G           0
    cephfs_metadata_a     2        892         0         8.70G          21
----------------------------------------------------------------------------
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>