### PR TITLE
osd/OSDMap: fix the message for full related option

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4448,21 +4448,21 @@ void OSDMap::check_health(health_check_map_t *checks) const
     if (br < nr) {
       ostringstream ss;
       ss << "backfillfull_ratio (" << br
-	 << ") < nearfull_ratio (" << nr << "), increased";
+	 << ") < nearfull_ratio (" << nr << "), should increase backfillfull_ratio";
       detail.push_back(ss.str());
       br = nr;
     }
     if (fr < br) {
       ostringstream ss;
       ss << "full_ratio (" << fr << ") < backfillfull_ratio (" << br
-	 << "), increased";
+	 << "), should increase full_ratio";
       detail.push_back(ss.str());
       fr = br;
     }
     if (fsr < fr) {
       ostringstream ss;
       ss << "osd_failsafe_full_ratio (" << fsr << ") < full_ratio (" << fr
-	 << "), increased";
+	 << "), should increase osd_failsafe_full_ratio";
       detail.push_back(ss.str());
     }
     if (!detail.empty()) {


### PR DESCRIPTION
I modified 
        osd failsafe full ratio = .30
        mon osd nearfull ratio = .30
        mon osd full ratio = .30

and used vstart.sh to create cluster.

ceph -s got error:
  cluster:
    id:     769a7350-5ec2-4f17-beea-a28a1f1bfb7b
    health: HEALTH_ERR
            full ratio(s) out of order

ceph health detail:
OSD_OUT_OF_ORDER_FULL full ratio(s) out of order
    full_ratio (0.3) < backfillfull_ratio (0.99), increased
    osd_failsafe_full_ratio (0.3) < full_ratio (0.99), increased

"increased" is mis-understanding.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>