### PR TITLE
rgw: Remove unused Parameter in Function RGWConf::init()

### DIFF
--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -385,7 +385,7 @@ class RGWEnv;
 class RGWConf {
   friend class RGWEnv;
 protected:
-  void init(CephContext *cct, RGWEnv* env);
+  void init(CephContext *cct);
 public:
   RGWConf()
     : enable_ops_log(1),

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -14,7 +14,7 @@
 
 void RGWEnv::init(CephContext *cct)
 {
-  conf.init(cct, this);
+  conf.init(cct);
 }
 
 void RGWEnv::set(const boost::string_ref& name, const boost::string_ref& val)
@@ -127,7 +127,7 @@ void RGWEnv::remove(const char *name)
     env_map.erase(iter);
 }
 
-void RGWConf::init(CephContext *cct, RGWEnv *env)
+void RGWConf::init(CephContext *cct)
 {
   enable_ops_log = cct->_conf->rgw_enable_ops_log;
   enable_usage_log = cct->_conf->rgw_enable_usage_log;


### PR DESCRIPTION
Signed-off-by: Wen Zhang <zhangwen1@unionpay.com>