### PR TITLE
ceph-disk bluestore, the block symlink would be incorrectly mapped

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2364,10 +2364,12 @@ class PrepareSpace(object):
                 self.space_symlink = getattr(self.args, self.name)
                 return
 
-        self.space_symlink = '/dev/disk/by-partuuid/{uuid}'.format(
-            uuid=getattr(self.args, self.name + '_uuid'))
 
-        if self.args.dmcrypt:
+       self.space_symlink = '/dev/disk/by-parttypeuuid/{osd_fsid}.{uuid}'.format(
+            osd_fsid=PTYPE['mpath']['block']['ready'], 
+            uuid=getattr(self.args,self.name + '_uuid'))
+       
+       if self.args.dmcrypt:
             self.space_dmcrypt = self.space_symlink
             self.space_symlink = '/dev/mapper/{uuid}'.format(
                 uuid=getattr(self.args, self.name + '_uuid'))


### PR DESCRIPTION
for multipath devices.

Instead of picking the aggregated device /dev/dm-XX, the block symlink would point to a single path.
/dev/part-byuuid only lists 1 device per part-uuid, ignoring any multipath devices.

Signed-off-by: Justin Mammarella <justin.mammarella@unimelb.edu.au>