### PR TITLE
tools: Initialization of *server, command variables

### DIFF
--- a/src/tools/rbd_nbd/rbd-nbd.cc
+++ b/src/tools/rbd_nbd/rbd-nbd.cc
@@ -159,11 +159,11 @@ private:
   struct IOContext
   {
     xlist<IOContext*>::item item;
-    NBDServer *server;
+    NBDServer *server = nullptr;
     struct nbd_request request;
     struct nbd_reply reply;
     bufferlist data;
-    int command;
+    int command = 0;
 
     IOContext()
       : item(this)


### PR DESCRIPTION
** 1351688 Uninitialized pointer field

>2. uninit_member: Non-static class member server is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field request.magic is not
initialized in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member field request.type is not
initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field request.from is not
initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field request.len is not
initialized in this constructor nor in any functions that it calls.
>12. uninit_member: Non-static class member field reply.magic is not
initialized in this constructor nor in any functions that it calls.
>14. uninit_member: Non-static class member field reply.error is not
initialized in this constructor nor in any functions that it calls.

CID 1351688 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>16. uninit_member: Non-static class member command is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com