### PR TITLE
rbd: Initialization of Context pointer

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -58,7 +58,7 @@ template <>
 class ImageCopyRequest<librbd::MockTestImageCtx> {
 public:
   static ImageCopyRequest* s_instance;
-  Context *on_finish;
+  Context *on_finish = nullptr;
 
   static ImageCopyRequest* create(librbd::MockTestImageCtx *local_image_ctx,
                                   librbd::MockTestImageCtx *remote_image_ctx,


### PR DESCRIPTION
** 1396106 Uninitialized pointer field

>CID 1396106 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com