### PR TITLE
rbd: Initialization uninitialized member variables

### DIFF
--- a/src/test/rbd_mirror/test_mock_ImageSync.cc
+++ b/src/test/rbd_mirror/test_mock_ImageSync.cc
@@ -91,7 +91,7 @@ template <>
 class SnapshotCopyRequest<librbd::MockTestImageCtx> {
 public:
   static SnapshotCopyRequest* s_instance;
-  Context *on_finish;
+  Context *on_finish = nullptr;
 
   static SnapshotCopyRequest* create(librbd::MockTestImageCtx *local_image_ctx,
                                      librbd::MockTestImageCtx *remote_image_ctx,
@@ -123,7 +123,7 @@ template <>
 class SyncPointCreateRequest<librbd::MockTestImageCtx> {
 public:
   static SyncPointCreateRequest *s_instance;
-  Context *on_finish;
+  Context *on_finish = nullptr;
 
   static SyncPointCreateRequest* create(librbd::MockTestImageCtx *remote_image_ctx,
                                         const std::string &mirror_uuid,
@@ -145,8 +145,8 @@ template <>
 class SyncPointPruneRequest<librbd::MockTestImageCtx> {
 public:
   static SyncPointPruneRequest *s_instance;
-  Context *on_finish;
-  bool sync_complete;
+  Context *on_finish = nullptr;
+  bool sync_complete = false;
 
   static SyncPointPruneRequest* create(librbd::MockTestImageCtx *remote_image_ctx,
                                        bool sync_complete,


### PR DESCRIPTION
Fixes the coverity issues:

** 1396107 Uninitialized pointer field
>2. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.
>CID 1396107 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member sync_complete is not initialized
in this constructor nor in any functions that it calls.

** 1396113 Uninitialized pointer field
>CID 1396113 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

** 1396114 Uninitialized pointer field
>CID 1396114 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com