### PR TITLE
mgr: preventing blank hostname in DaemonState

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -390,14 +390,18 @@ bool DaemonServer::handle_report(MMgrReport *m)
     dout(20) << "updating existing DaemonState for " << key << dendl;
     daemon = daemon_state.get(key);
   } else {
-    dout(4) << "constructing new DaemonState for " << key << dendl;
-    daemon = std::make_shared<DaemonState>(daemon_state.types);
-    // FIXME: crap, we don't know the hostname at this stage.
-    daemon->key = key;
-    daemon_state.insert(daemon);
-    // FIXME: we should avoid this case by rejecting MMgrReport from
-    // daemons without sessions, and ensuring that session open
-    // always contains metadata.
+    // we don't know the hostname at this stage, reject MMgrReport here.
+    dout(1) << "rejecting report from " << key << ", since we do not have its metadata now."
+	    << dendl;
+    // kill session
+    MgrSessionRef session(static_cast<MgrSession*>(m->get_connection()->get_priv()));
+    if (!session) {
+      return false;
+    }
+    m->get_connection()->mark_down();
+    session->put();
+
+    return false;
   }
   assert(daemon != nullptr);
   auto &daemon_counters = daemon->perf_counters;

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -410,7 +410,7 @@ void Mgr::handle_osd_map()
    * reload the metadata.
    */
   objecter->with_osdmap([this, &names_exist](const OSDMap &osd_map) {
-    for (unsigned int osd_id = 0; osd_id < osd_map.get_num_osds(); ++osd_id) {
+    for (unsigned int osd_id = 0; osd_id < osd_map.get_max_osd(); ++osd_id) {
       if (!osd_map.exists(osd_id)) {
         continue;
       }


### PR DESCRIPTION
see https://github.com/ceph/ceph/blob/a40d8e4a836f79a75878ca8b85626e8c0eca7db9/src/mgr/Mgr.cc#L123,
we do not update daemon_meta's hostname even the existing DaemonState's hostname is "". MMgrReport
will insert a DaemonState which contains blank hostname.
see https://github.com/ceph/ceph/blob/a40d8e4a836f79a75878ca8b85626e8c0eca7db9/src/mgr/DaemonServer.cc#L396

This commit also simple the logical of MetadataUpdate.

Fixes: http://tracker.ceph.com/issues/20887
Fixes: http://tracker.ceph.com/issues/21060

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>
Signed-off-by: Yanhu Cao <gmayyyha@gmail.com>