### PR TITLE
rbd: Initializing librbd module member variables

### DIFF
--- a/src/librbd/journal/CreateRequest.h
+++ b/src/librbd/journal/CreateRequest.h
@@ -71,10 +71,10 @@ private:
   CephContext *m_cct;
   cls::journal::Tag m_tag;
   bufferlist m_bl;
-  Journaler *m_journaler;
-  SafeTimer *m_timer;
-  Mutex *m_timer_lock;
-  int m_r_saved;
+  Journaler *m_journaler = nullptr;
+  SafeTimer *m_timer = nullptr;
+  Mutex *m_timer_lock = nullptr;
+  int m_r_saved = 0;
 
   int64_t m_pool_id = -1;
 

--- a/src/librbd/journal/RemoveRequest.h
+++ b/src/librbd/journal/RemoveRequest.h
@@ -56,10 +56,10 @@ private:
   Context *m_on_finish;
 
   CephContext *m_cct;
-  Journaler *m_journaler;
-  SafeTimer *m_timer;
-  Mutex *m_timer_lock;
-  int m_r_saved;
+  Journaler *m_journaler = nullptr;
+  SafeTimer *m_timer = nullptr;
+  Mutex *m_timer_lock = nullptr;
+  int m_r_saved = 0;
 
   void stat_journal();
   Context *handle_stat_journal(int *result);

--- a/src/test/librbd/test_mock_Journal.cc
+++ b/src/test/librbd/test_mock_Journal.cc
@@ -160,8 +160,8 @@ MockCreate *MockCreate::s_instance = nullptr;
 template<>
 class OpenRequest<MockJournalImageCtx> {
 public:
-  TagData *tag_data;
-  Context *on_finish;
+  TagData *tag_data = nullptr;
+  Context *on_finish = nullptr;
   static OpenRequest *s_instance;
   static OpenRequest *create(MockJournalImageCtx *image_ctx,
                              ::journal::MockJournalerProxy *journaler,


### PR DESCRIPTION
Fixes the coverity issues:

** 1396110 Uninitialized pointer field
>2. uninit_member: Non-static class member tag_data is not initialized
in this constructor nor in any functions that it calls.
>CID 1396110 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

** 1396135 Uninitialized pointer field
>2. uninit_member: Non-static class member m_journaler is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member m_timer is not initialized in
this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member m_timer_lock is not initialized
in this constructor nor in any functions that it calls.
>CID 1396135 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>8. uninit_member: Non-static class member m_r_saved is not initialized in
this constructor nor in any functions that it calls.

** 1396136 Uninitialized pointer field
>2. uninit_member: Non-static class member m_journaler is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member m_timer is not initialized in
this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member m_timer_lock is not initialized
in this constructor nor in any functions that it calls.
>CID 1396136 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>8. uninit_member: Non-static class member m_r_saved is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com