### PR TITLE
rbd: Initializing varied members of librbd module

### DIFF
--- a/src/librbd/image/CloneRequest.h
+++ b/src/librbd/image/CloneRequest.h
@@ -90,7 +90,7 @@ private:
   std::string m_id;
   ImageOptions m_opts;
   ParentSpec m_pspec;
-  ImageCtxT *m_imctx;
+  ImageCtxT *m_imctx = nullptr;
   cls::rbd::MirrorMode m_mirror_mode = cls::rbd::MIRROR_MODE_DISABLED;
   const std::string m_non_primary_global_image_id;
   const std::string m_primary_mirror_uuid;
@@ -100,14 +100,14 @@ private:
 
   CephContext *m_cct;
   bool m_use_p_features;
-  uint64_t m_p_features;
-  uint64_t m_features;
+  uint64_t m_p_features = 0;
+  uint64_t m_features = 0;
   map<string, bufferlist> m_pairs;
   bufferlist m_out_bl;
-  uint64_t m_size;
+  uint64_t m_size = 0;
   int m_r_saved = 0;
-  bool m_is_primary;
-  bool m_force_non_primary;
+  bool m_is_primary = false;
+  bool m_force_non_primary = false;
 
   void validate_options();
 

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -148,8 +148,8 @@ protected:
     return "aio_read";
   }
 private:
-  char *m_buf;
-  bufferlist *m_pbl;
+  char *m_buf = nullptr;
+  bufferlist *m_pbl = nullptr;
   int m_op_flags;
 };
 

--- a/src/librbd/io/ReadResult.h
+++ b/src/librbd/io/ReadResult.h
@@ -56,7 +56,7 @@ public:
 
   template <typename ImageCtxT>
   struct C_SparseReadRequest : public C_SparseReadRequestBase {
-    ObjectReadRequest<ImageCtxT> *request;
+    ObjectReadRequest<ImageCtxT> *request = nullptr;
 
     C_SparseReadRequest(AioCompletion *aio_completion)
       : C_SparseReadRequestBase(aio_completion) {

--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -97,18 +97,18 @@ struct DirStat {
 
 struct InodeStat {
   vinodeno_t vino;
-  uint32_t rdev;
-  version_t version;
-  version_t xattr_version;
+  uint32_t rdev = 0;
+  version_t version = 0;
+  version_t xattr_version = 0;
   ceph_mds_reply_cap cap;
   file_layout_t layout;
   utime_t ctime, btime, mtime, atime;
-  uint32_t time_warp_seq;
-  uint64_t size, max_size;
-  uint64_t change_attr;
-  uint64_t truncate_size;
-  uint32_t truncate_seq;
-  uint32_t mode, uid, gid, nlink;
+  uint32_t time_warp_seq = 0;
+  uint64_t size = 0, max_size = 0;
+  uint64_t change_attr = 0;
+  uint64_t truncate_size = 0;
+  uint32_t truncate_seq = 0;
+  uint32_t mode = 0, uid = 0, gid = 0, nlink = 0;
   frag_info_t dirstat;
   nest_info_t rstat;
 
@@ -120,7 +120,7 @@ struct InodeStat {
   bufferlist xattrbl;
 
   bufferlist inline_data;
-  version_t inline_version;
+  version_t inline_version = 0;
 
   quota_info_t quota;
 
@@ -202,7 +202,7 @@ struct InodeStat {
 class MClientReply : public Message {
   // reply data
 public:
-  struct ceph_mds_reply_head head;
+  struct ceph_mds_reply_head head {};
   bufferlist trace_bl;
   bufferlist extra_bl;
   bufferlist snapbl;

--- a/src/messages/MClientRequest.h
+++ b/src/messages/MClientRequest.h
@@ -51,7 +51,7 @@ class MClientRequest : public Message {
   static const int COMPAT_VERSION = 1;
 
 public:
-  struct ceph_mds_request_head head;
+  struct ceph_mds_request_head head {};
   utime_t stamp;
 
   struct Release {


### PR DESCRIPTION
Fixes the coverity issues:

** 1401448 Uninitialized pointer field
>CID 1401448 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member request is not initialized
in this constructor nor in any functions that it calls.

** 1405535 Uninitialized pointer field
>5. uninit_member: Non-static class member m_imctx is not initialized
in this constructor nor in any functions that it calls.
>7. uninit_member: Non-static class member m_p_features is not initialized
in this constructor nor in any functions that it calls.
>9. uninit_member: Non-static class member m_features is not initialized
in this constructor nor in any functions that it calls.
>11. uninit_member: Non-static class member m_size is not initialized in
this constructor nor in any functions that it calls.
>13. uninit_member: Non-static class member m_is_primary is not initialized
in this constructor nor in any functions that it calls.
>CID 1405535 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>15. uninit_member: Non-static class member m_force_non_primary is not
initialized in this constructor nor in any functions that it calls.

** 1409840 Uninitialized pointer field
>2. uninit_member: Non-static class member m_buf is not initialized
in this constructor nor in any functions that it calls.
>CID 1409840 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member m_pbl is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar amitkuma@redhat.com