### PR TITLE
osd/PG: drop unused variable "oldest_update" in PG.h

### DIFF
--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -724,7 +724,6 @@ protected:
   
   bool        need_up_thru;
   set<pg_shard_t>    stray_set;   // non-acting osds that have PG data.
-  eversion_t  oldest_update; // acting: lowest (valid) last_update in active set
   map<pg_shard_t, pg_info_t>    peer_info;   // info from peers (stray or prior)
   set<pg_shard_t> peer_purged; // peers purged
   map<pg_shard_t, pg_missing_t> peer_missing;


### PR DESCRIPTION
Signed-off-by: songweibin <song.weibin@zte.com.cn>