### PR TITLE
Delegation handling for cephfs

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -5832,10 +5832,8 @@ void Client::flush_mdlog(MetaSession *session)
 }
 
 
-void Client::unmount()
+void Client::_unmount()
 {
-  Mutex::Locker lock(client_lock);
-
   if (unmounting)
     return;
 
@@ -5954,6 +5952,12 @@ void Client::unmount()
   mounted = false;
 
   ldout(cct, 2) << "unmounted." << dendl;
+}
+
+void Client::unmount()
+{
+  Mutex::Locker lock(client_lock);
+  _unmount();
 }
 
 void Client::flush_cap_releases()

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -83,6 +83,7 @@
 #include "Client.h"
 #include "Inode.h"
 #include "Dentry.h"
+#include "Delegation.h"
 #include "Dir.h"
 #include "ClientSnapRealm.h"
 #include "Fh.h"
@@ -5061,10 +5062,17 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
   check_cap_issue(in, cap, new_caps);
 
   // update caps
-  if (old_caps & ~new_caps) { 
-    ldout(cct, 10) << "  revocation of " << ccap_string(~new_caps & old_caps) << dendl;
+  int revoked = old_caps & ~new_caps;
+  if (revoked) {
+    ldout(cct, 10) << "  revocation of " << ccap_string(revoked) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
+
+    // recall delegations if we're losing caps necessary for them
+    if (revoked & ceph_caps_for_mode(CEPH_FILE_MODE_RD))
+      in->recall_deleg(false);
+    else if (revoked & ceph_caps_for_mode(CEPH_FILE_MODE_WR))
+      in->recall_deleg(true);
 
     if (((used & ~new_caps) & CEPH_CAP_FILE_BUFFER)
         && !_flush(in, new C_Client_FlushComplete(this, in))) {
@@ -8364,6 +8372,8 @@ int Client::_release_fh(Fh *f)
   //ldout(cct, 3) << "op: open_files.erase( " << fh << " );" << dendl;
   Inode *in = f->inode.get();
   ldout(cct, 5) << "_release_fh " << f << " mode " << f->mode << " on " << *in << dendl;
+
+  in->unset_deleg(f);
 
   if (in->snapid == CEPH_NOSNAP) {
     if (in->put_open_ref(f->mode)) {
@@ -11915,8 +11925,9 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
   req->set_filepath(path);
 
   InodeRef otherin;
-
+  Inode *in;
   Dentry *de;
+
   int res = get_or_create(dir, name, &de);
   if (res < 0)
     goto fail;
@@ -11927,7 +11938,10 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
   res = _lookup(dir, name, 0, &otherin, perm);
   if (res < 0)
     goto fail;
-  req->set_other_inode(otherin.get());
+
+  in = otherin.get();
+  req->set_other_inode(in);
+  in->break_all_delegs();
   req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
 
   req->set_inode(dir);
@@ -12097,15 +12111,26 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
     res = _lookup(fromdir, fromname, 0, &oldin, perm);
     if (res < 0)
       goto fail;
-    req->set_old_inode(oldin.get());
+
+    Inode *oldinode = oldin.get();
+    oldinode->break_all_delegs();
+    req->set_old_inode(oldinode);
     req->old_inode_drop = CEPH_CAP_LINK_SHARED;
 
     res = _lookup(todir, toname, 0, &otherin, perm);
-    if (res != 0 && res != -ENOENT) {
-      goto fail;
-    } else if (res == 0) {
-      req->set_other_inode(otherin.get());
+    switch (res) {
+    case 0:
+      {
+	Inode *in = otherin.get();
+	req->set_other_inode(in);
+	in->break_all_delegs();
+      }
       req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
+      break;
+    case -ENOENT:
+      break;
+    default:
+      goto fail;
     }
 
     req->set_inode(todir);
@@ -12176,6 +12201,7 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
     return -EDQUOT;
   }
 
+  in->break_all_delegs();
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LINK);
 
   filepath path(newname, dir->ino);
@@ -13017,6 +13043,29 @@ int Client::ll_flock(Fh *fh, int cmd, uint64_t owner)
   return _flock(fh, cmd, owner);
 }
 
+int Client::ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv)
+{
+  int ret = -EINVAL;
+
+  Mutex::Locker lock(client_lock);
+
+  if (!mounted)
+    return -ENOTCONN;
+
+  Inode *inode = fh->inode.get();
+
+  switch(cmd) {
+  case CEPH_DELEGATION_RD:
+  case CEPH_DELEGATION_WR:
+    ret = inode->set_deleg(fh, (cmd == CEPH_DELEGATION_RD), cb, priv);
+    break;
+  case CEPH_DELEGATION_NONE:
+    inode->unset_deleg(fh);
+    ret = 0;
+  }
+  return ret;
+}
+
 class C_Client_RequestInterrupt : public Context  {
 private:
   Client *client;
@@ -13842,4 +13891,3 @@ void StandaloneClient::shutdown()
   objecter->shutdown();
   monclient->shutdown();
 }
-

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -48,6 +48,7 @@ using std::fstream;
 
 #include "InodeRef.h"
 #include "UserPerm.h"
+#include "Delegation.h"
 #include "include/cephfs/ceph_statx.h"
 
 class FSMap;
@@ -404,6 +405,8 @@ protected:
 public:
   entity_name_t get_myname() { return messenger->get_myname(); } 
   void _sync_write_commit(Inode *in);
+  void wait_on_list(list<Cond*>& ls);
+  void signal_cond_list(list<Cond*>& ls);
 
 protected:
   std::unique_ptr<Filer>             filer;
@@ -482,8 +485,6 @@ protected:
 
   // helpers
   void wake_inode_waiters(MetaSession *s);
-  void wait_on_list(list<Cond*>& ls);
-  void signal_cond_list(list<Cond*>& ls);
 
   void wait_on_context_list(list<Context*>& ls);
   void signal_context_list(list<Context*>& ls);
@@ -1218,6 +1219,7 @@ public:
   int ll_getlk(Fh *fh, struct flock *fl, uint64_t owner);
   int ll_setlk(Fh *fh, struct flock *fl, uint64_t owner, int sleep);
   int ll_flock(Fh *fh, int cmd, uint64_t owner);
+  int ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv);
   int ll_file_layout(Fh *fh, file_layout_t *layout);
   void ll_interrupt(void *d);
   bool ll_handle_umask() {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -495,12 +495,16 @@ protected:
   void put_inode(Inode *in, int n=1);
   void close_dir(Dir *dir);
 
+  // same as unmount() but for when the client_lock is already held
+  void _unmount();
+
   friend class C_Client_FlushComplete; // calls put_inode()
   friend class C_Client_CacheInvalidate;  // calls ino_invalidate_cb
   friend class C_Client_DentryInvalidate;  // calls dentry_invalidate_cb
   friend class C_Block_Sync; // Calls block map and protected helpers
   friend class C_Client_RequestInterrupt;
   friend class C_Client_Remount;
+  friend class C_C_Deleg_Timeout; // Asserts on client_lock, called when a delegation is unreturned
   friend void intrusive_ptr_release(Inode *in);
 
   //int get_cache_size() { return lru.lru_get_size(); }

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -5,6 +5,7 @@
 
 #include "include/xlist.h"
 #include "common/Clock.h"
+#include "common/Timer.h"
 
 #include "Fh.h"
 
@@ -44,10 +45,12 @@ private:
   // time of first recall
   utime_t			recall_time;
 
+  // timer for unreturned delegations
+  Context			*timeout_event;
 public:
   Delegation(Fh *_fh, unsigned _mode, ceph_deleg_cb_t _cb, void *_priv)
 	: inode_item(this), fh(_fh), priv(_priv), mode(_mode),
-	  recall_cb(_cb), recall_time(utime_t()) {};
+	  recall_cb(_cb), recall_time(utime_t()), timeout_event(nullptr) {};
 
   Fh *get_fh() { return fh; }
   unsigned get_mode() { return mode; }
@@ -58,6 +61,27 @@ public:
     mode = _mode;
     recall_cb = _recall_cb;
     priv = _priv;
+  }
+
+  void arm_timeout(SafeTimer *timer, Context *event, double timeout)
+  {
+    if (timeout_event) {
+      delete event;
+      return;
+    }
+
+    timeout_event = event;
+    // FIXME: make timeout tunable
+    timer->add_event_after(timeout, event);
+  }
+
+  void disarm_timeout(SafeTimer *timer)
+  {
+    if (!timeout_event)
+      return;
+
+    timer->cancel_event(timeout_event);
+    timeout_event = nullptr;
   }
 
   bool is_recalled() { return !recall_time.is_zero(); }
@@ -74,4 +98,5 @@ public:
     }
   }
 };
+
 #endif /* _CEPH_CLIENT_DELEGATION_H */

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -1,0 +1,77 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef _CEPH_CLIENT_DELEGATION_H
+#define _CEPH_CLIENT_DELEGATION_H
+
+#include "include/xlist.h"
+#include "common/Clock.h"
+
+#include "Fh.h"
+
+/* Commands for manipulating delegation state */
+#ifndef CEPH_DELEGATION_NONE
+# define CEPH_DELEGATION_NONE	0
+# define CEPH_DELEGATION_RD	1
+# define CEPH_DELEGATION_WR	2
+#endif
+
+typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
+
+/*
+ * A delegation is a container for holding caps on behalf of a client that
+ * wants to be able to rely on them until recalled.
+ */
+class Delegation {
+protected:
+  // per-inode linkage
+  xlist<Delegation*>::item	inode_item;
+
+  friend class Inode;
+
+private:
+  // Filehandle against which it was acquired
+  Fh				*fh;
+
+  // opaque token that will be passed to the callback
+  void				*priv;
+
+  // Delegation mode (CEPH_FILE_MODE_RD, CEPH_FILE_MODE_RDWR) (other flags later?)
+  unsigned			mode;
+
+  // callback into application to recall delegation
+  ceph_deleg_cb_t		recall_cb;
+
+  // time of first recall
+  utime_t			recall_time;
+
+public:
+  Delegation(Fh *_fh, unsigned _mode, ceph_deleg_cb_t _cb, void *_priv)
+	: inode_item(this), fh(_fh), priv(_priv), mode(_mode),
+	  recall_cb(_cb), recall_time(utime_t()) {};
+
+  Fh *get_fh() { return fh; }
+  unsigned get_mode() { return mode; }
+
+  /* Update existing deleg with new mode, cb, and priv value */
+  void reinit(unsigned _mode, ceph_deleg_cb_t _recall_cb, void *_priv)
+  {
+    mode = _mode;
+    recall_cb = _recall_cb;
+    priv = _priv;
+  }
+
+  bool is_recalled() { return !recall_time.is_zero(); }
+
+  void recall(bool skip_read)
+  {
+    /* If ro is true, don't break read delegations */
+    if (skip_read && mode == CEPH_FILE_MODE_RD)
+      return;
+
+    if (!is_recalled()) {
+      recall_cb(fh, priv);
+      recall_time = ceph_clock_now();
+    }
+  }
+};
+#endif /* _CEPH_CLIENT_DELEGATION_H */

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -394,6 +394,7 @@ OPTION(client_metadata, OPT_STR)
 OPTION(client_acl_type, OPT_STR)
 OPTION(client_permissions, OPT_BOOL)
 OPTION(client_dirsize_rbytes, OPT_BOOL)
+OPTION(client_deleg_timeout, OPT_DOUBLE)
 
 // note: the max amount of "in flight" dirty data is roughly (max - target)
 OPTION(fuse_use_invalidate_cb, OPT_BOOL) // use fuse 2.8+ invalidate callback to keep page cache consistent

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5892,6 +5892,10 @@ std::vector<Option> get_mds_client_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("client_deleg_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(75.0)
+    .set_description("time (in seconds) that application has to return delegation after recall"),
+
     Option("fuse_use_invalidate_cb", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1587,7 +1587,13 @@ int ceph_ll_setlk(struct ceph_mount_info *cmount,
  * function will be called.
  *
  * Once the delegation has been recalled, the application should return it as
- * soon as possible.
+ * soon as possible. The application has client_deleg_timeout seconds to
+ * return it, after which the cmount structure is forcibly unmounted and
+ * further calls into it fail.
+ *
+ * The application can frob the client_deleg_timeout config option to suit its
+ * needs, but it should take care to choose a value that allows it to avoid
+ * forcible eviction from the cluster in the event of an application bug.
  */
 typedef void (*ceph_deleg_cb_t)(struct Fh *fh, void *priv);
 

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1723,6 +1723,12 @@ extern "C" int ceph_ll_setlk(struct ceph_mount_info *cmount,
   return (cmount->get_client()->ll_setlk(fh, fl, owner, sleep));
 }
 
+extern "C" int ceph_ll_delegation(struct ceph_mount_info *cmount, Fh *fh,
+				  unsigned cmd, ceph_deleg_cb_t cb, void *priv)
+{
+  return (cmount->get_client()->ll_delegation(fh, cmd, cb, priv));
+}
+
 extern "C" uint32_t ceph_ll_stripe_unit(class ceph_mount_info *cmount,
 					Inode *in)
 {

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -8,6 +8,7 @@ if(${WITH_CEPHFS})
     recordlock.cc
     acl.cc
     main.cc
+    deleg.cc
   )
   set_target_properties(ceph_test_libcephfs PROPERTIES COMPILE_FLAGS
     ${UNITTEST_CXX_FLAGS})

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -1,0 +1,143 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Tests for Ceph delegation handling
+ *
+ * (c) 2017, Jeff Layton <jlayton@redhat.com>
+ */
+
+#include "gtest/gtest.h"
+#include "include/cephfs/libcephfs.h"
+#include "include/stat.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <sys/xattr.h>
+#include <sys/uio.h>
+
+#ifdef __linux__
+#include <limits.h>
+#endif
+
+#include <map>
+#include <vector>
+#include <thread>
+#include <atomic>
+
+static void dummy_deleg_cb(Fh *fh, void *priv)
+{
+  std::atomic_bool *recalled = (std::atomic_bool *)priv;
+  recalled->store(true);
+}
+
+static void breaker_func(struct ceph_mount_info *cmount, const char *filename, int flags)
+{
+  bool do_shutdown = false;
+
+  if (!cmount) {
+    ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+    ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+    ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+    do_shutdown = true;
+  }
+
+  Inode *root, *file;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  ASSERT_EQ(ceph_ll_lookup(cmount, root, filename, &file, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_open(cmount, file, flags, &fh, perms), 0);
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+
+  if (do_shutdown)
+    ceph_shutdown(cmount);
+}
+
+static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_info *tcmount)
+{
+  Inode *root, *file;
+
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  char filename[32];
+  sprintf(filename, "delegation%x", getpid());
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  // ensure r/w open breaks a r/w delegation
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+
+  std::atomic_bool recalled(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker1(breaker_func, tcmount, filename, O_RDWR);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker1.join();
+
+  // ensure r/o open breaks a r/w delegation
+  recalled.store(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker2(breaker_func, tcmount, filename, O_RDONLY);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker2.join();
+
+  // close file, reopen r/o
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_open(cmount, file, O_RDONLY, &fh, perms), 0);
+
+  // ensure r/o open does not break a r/o delegation
+  recalled.store(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker3(breaker_func, tcmount, filename, O_RDONLY);
+  breaker3.join();
+  ASSERT_EQ(recalled.load(), false);
+
+  // ensure that r/w open breaks r/o delegation
+  std::thread breaker4(breaker_func, tcmount, filename, O_WRONLY);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker4.join();
+
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+}
+
+TEST(LibCephFS, DelegMultiClient) {
+  struct ceph_mount_info *cmount;
+
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  simple_deleg_test(cmount, nullptr);
+
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, DelegSingleClient) {
+  struct ceph_mount_info *cmount;
+
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  simple_deleg_test(cmount, cmount);
+
+  ceph_shutdown(cmount);
+}


### PR DESCRIPTION
This patchset adds delegation/lease support for cephfs. The basic idea is to map delegations on top of the caps subsystem. It adds a new ceph_delegation() call to libcephfs that is used to request and return delegations. If we have all of the requisite caps to make a delegation, then ceph will grant it when one is requested. When the necessary caps are recalled, it will call back into the application to request their return. If they're returned in a timely fashion, then great. Otherwise the cmount is forcibly unmounted such that further calls into libcephfs with it return an error.

This patchset is based on top of this PR:

    https://github.com/ceph/ceph/pull/17095

...as it has a patch that is needed to make this work.

This is still a very early draft of this work. I'm mostly just looking for feedback on the basic interface now. Do we need anything more elaborate? Before we merge anything, I plan to at least make a first stab at hooking ganesha up to this to ensure that the interface is indeed what's needed.