### PR TITLE
jewel: rgw: multisite: lock is not released when RGWMetaSyncShardCR::full_sync() fails to write marker

### DIFF
--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1473,6 +1473,8 @@ public:
 
         if (retcode < 0) {
           ldout(sync_env->cct, 0) << "ERROR: failed to set sync marker: retcode=" << retcode << dendl;
+          yield lease_cr->go_down();
+          drain_all();
           return retcode;
         }
       }


### PR DESCRIPTION
http://tracker.ceph.com/issues/20641