### PR TITLE
qa/rgw: use 'ceph osd pool application enable' on created pools

### DIFF
--- a/qa/tasks/rgw.py
+++ b/qa/tasks/rgw.py
@@ -142,12 +142,12 @@ def create_pools(ctx, clients):
 
         if ctx.rgw.ec_data_pool:
             create_ec_pool(remote, data_pool, client, 64,
-                           ctx.rgw.erasure_code_profile, cluster_name)
+                           ctx.rgw.erasure_code_profile, cluster_name, 'rgw')
         else:
-            create_replicated_pool(remote, data_pool, 64, cluster_name)
+            create_replicated_pool(remote, data_pool, 64, cluster_name, 'rgw')
         if ctx.rgw.cache_pools:
             create_cache_pool(remote, data_pool, data_pool + '.cache', 64,
-                              64*1024*1024, cluster_name)
+                              64*1024*1024, cluster_name, 'rgw')
     log.debug('Pools created')
     yield
 

--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -409,9 +409,9 @@ def create_zone_pools(ctx, zone):
         pool_name = pool_config['val']['data_pool']
         if ctx.rgw.ec_data_pool:
             create_ec_pool(gateway.remote, pool_name, zone.name, 64,
-                           ctx.rgw.erasure_code_profile, cluster.name)
+                           ctx.rgw.erasure_code_profile, cluster.name, 'rgw')
         else:
-            create_replicated_pool(gateway.remote, pool_name, 64, cluster.name)
+            create_replicated_pool(gateway.remote, pool_name, 64, cluster.name, 'rgw')
 
 def configure_zone_compression(zone, compression):
     """ Set compression type in the zone's default-placement """

--- a/qa/tasks/util/rados.py
+++ b/qa/tasks/util/rados.py
@@ -24,20 +24,28 @@ def rados(ctx, remote, cmd, wait=True, check_status=False):
     else:
         return proc
 
-def create_ec_pool(remote, name, profile_name, pgnum, profile={}, cluster_name="ceph"):
+def create_ec_pool(remote, name, profile_name, pgnum, profile={}, cluster_name="ceph", application=None):
     remote.run(args=['sudo', 'ceph'] +
                cmd_erasure_code_profile(profile_name, profile) + ['--cluster', cluster_name])
     remote.run(args=[
         'sudo', 'ceph', 'osd', 'pool', 'create', name,
         str(pgnum), str(pgnum), 'erasure', profile_name, '--cluster', cluster_name
         ])
+    if application:
+        remote.run(args=[
+            'sudo', 'ceph', 'osd', 'pool', 'application', 'enable', name, application, '--cluster', cluster_name
+        ])
 
-def create_replicated_pool(remote, name, pgnum, cluster_name="ceph"):
+def create_replicated_pool(remote, name, pgnum, cluster_name="ceph", application=None):
     remote.run(args=[
         'sudo', 'ceph', 'osd', 'pool', 'create', name, str(pgnum), str(pgnum), '--cluster', cluster_name
         ])
+    if application:
+        remote.run(args=[
+            'sudo', 'ceph', 'osd', 'pool', 'application', 'enable', name, application, '--cluster', cluster_name
+        ])
 
-def create_cache_pool(remote, base_name, cache_name, pgnum, size, cluster_name="ceph"):
+def create_cache_pool(remote, base_name, cache_name, pgnum, size, cluster_name="ceph", application=None):
     remote.run(args=[
         'sudo', 'ceph', 'osd', 'pool', 'create', cache_name, str(pgnum), '--cluster', cluster_name
     ])
@@ -45,6 +53,10 @@ def create_cache_pool(remote, base_name, cache_name, pgnum, size, cluster_name="
         'sudo', 'ceph', 'osd', 'tier', 'add-cache', base_name, cache_name,
         str(size), '--cluster', cluster_name
     ])
+    if application:
+        remote.run(args=[
+            'sudo', 'ceph', 'osd', 'pool', 'application', 'enable', name, application, '--cluster', cluster_name
+        ])
 
 def cmd_erasure_code_profile(profile_name, profile):
     """


### PR DESCRIPTION
attempts to resolve a cluster log warning in teuthology runs of the rgw-multisite suite:
> cluster [WRN] Health check failed: application not enabled on 1 pool(s) (POOL_APP_NOT_ENABLED)