### PR TITLE
doc: include ceph-disk and ceph-disk-volume man pages in index

### DIFF
--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -23,6 +23,8 @@ set(osd_srcs
   ceph-clsinfo.rst
   ceph-detect-init.rst
   ceph-disk.rst
+  ceph-volume.rst
+  ceph-volume-systemd.rst
   ceph-osd.rst
   osdmaptool.rst)
 

--- a/doc/rados/man/index.rst
+++ b/doc/rados/man/index.rst
@@ -6,6 +6,8 @@
    :maxdepth: 1
 
    ../../man/8/ceph-disk.rst
+   ../../man/8/ceph-volume.rst
+   ../../man/8/ceph-volume-systemd.rst
    ../../man/8/ceph.rst
    ../../man/8/ceph-deploy.rst
    ../../man/8/ceph-rest-api.rst


### PR DESCRIPTION
This should fix the following:

    dh_install: ceph-osd missing files: usr/share/man/man8/ceph-volume.8
    dh_install: ceph-osd missing files: usr/share/man/man8/ceph-volume-systemd.8

And:

    File not found by glob: /home/jenkins-build/build/workspace/ceph-dev-new-build/ARCH/x86_64/AVAILABLE_ARCH/x86_64/AVAILABLE_DIST/centos7/DIST/centos7/MACHINE_SIZE/huge/release/12.1.2-999-gfdf1ec4/rpm/el7/BUILDROOT/ceph-12.1.2-999.gfdf1ec4.el7.x86_64/usr/share/man/man8/ceph-volume.8*