### PR TITLE
mon: increase mon_lease to avoid timeouts

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -976,7 +976,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_lease", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(5)
+    .set_default(30)
     .set_description(""),
 
     Option("mon_lease_renew_interval_factor", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
This PR increases the value of `mon_lease` with the aim of avoiding timeouts during pool creation smoke test.

Fixes: http://tracker.ceph.com/issues/20909
Signed-off-by: Neha Ojha <nojha@redhat.com>