### PR TITLE
luminous: doc add ceph-volume and ceph-volume-systemd man pages to CMakeLists file

### DIFF
--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -23,6 +23,8 @@ set(osd_srcs
   ceph-clsinfo.rst
   ceph-detect-init.rst
   ceph-disk.rst
+  ceph-volume.rst
+  ceph-volume-systemd.rst
   ceph-osd.rst
   osdmaptool.rst)
 


### PR DESCRIPTION
Cherry-pick from the one CMakeList change missing in Luminous

Just went into master: https://github.com/ceph/ceph/pull/17168