### PR TITLE
osd/PG: two cleanups

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1297,12 +1297,12 @@ void PG::calc_replicated_acting(
     const pg_info_t &cur_info = all_info.find(acting_cand)->second;
     if (cur_info.is_incomplete() ||
 	cur_info.last_update < primary->second.log_tail) {
-      ss << " shard " << acting_cand << " (stray) REJECTED "
+      ss << " shard " << acting_cand << " (acting) REJECTED "
 	       << cur_info << std::endl;
     } else {
       want->push_back(*i);
       acting_backfill->insert(acting_cand);
-      ss << " shard " << acting_cand << " (stray) accepted "
+      ss << " shard " << acting_cand << " (acting) accepted "
 	 << cur_info << std::endl;
       usable++;
     }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1142,7 +1142,6 @@ void PG::calc_ec_acting(
 {
   vector<int> want(size, CRUSH_ITEM_NONE);
   map<shard_id_t, set<pg_shard_t> > all_info_by_shard;
-  unsigned usable = 0;
   for (map<pg_shard_t, pg_info_t>::const_iterator i = all_info.begin();
        i != all_info.end();
        ++i) {
@@ -1156,7 +1155,6 @@ void PG::calc_ec_acting(
 	auth_log_shard->second.log_tail) {
       ss << " selecting up[i]: " << pg_shard_t(up[i], shard_id_t(i)) << std::endl;
       want[i] = up[i];
-      ++usable;
       continue;
     }
     if (up.size() > (unsigned)i && up[i] != CRUSH_ITEM_NONE) {
@@ -1171,7 +1169,6 @@ void PG::calc_ec_acting(
 	auth_log_shard->second.log_tail) {
       ss << " selecting acting[i]: " << pg_shard_t(acting[i], shard_id_t(i)) << std::endl;
       want[i] = acting[i];
-      ++usable;
     } else if (!restrict_to_up_acting) {
       for (set<pg_shard_t>::iterator j = all_info_by_shard[shard_id_t(i)].begin();
 	   j != all_info_by_shard[shard_id_t(i)].end();
@@ -1182,7 +1179,6 @@ void PG::calc_ec_acting(
 	    auth_log_shard->second.log_tail) {
 	  ss << " selecting stray: " << *j << std::endl;
 	  want[i] = j->osd;
-	  ++usable;
 	  break;
 	}
       }


### PR DESCRIPTION
 "all_info" includes peers from up and acting sets too, thus
 deduplication is still needed here when calculating want_acting set.