### PR TITLE
osd: allow FULL_TRY after failsafe

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1978,7 +1978,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   // We can't allow OSD to become non-startable even if mds
   // could be writing as part of file removals.
   ostringstream ss;
-  if (write_ordered && osd->check_failsafe_full(ss)) {
+  if (write_ordered && osd->check_failsafe_full(ss) && !m->has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
     dout(10) << __func__ << " fail-safe full check failed, dropping request"
              << ss.str()
 	     << dendl;


### PR DESCRIPTION
In https://github.com/ceph/ceph/pull/12627 and https://github.com/ceph/ceph/pull/14193, I've supported "rbd rm" when osd is full. But I find that support is not enough: only when the "full osd" is not primary, "rbd rm" could work. I did experiment: use vstart to create only one osd, and write until full, then rm, it still hangs there. This fix in this pr could resolve it.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>