### PR TITLE
ceph-dencoder: simplify decoding/encoding cephfs inode

### DIFF
--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3775,6 +3775,14 @@ void InodeStore::generate_test_instances(list<InodeStore*> &ls)
   ls.push_back(populated);
 }
 
+void InodeStoreBare::generate_test_instances(list<InodeStoreBare*> &ls)
+{
+  InodeStoreBare *populated = new InodeStoreBare;
+  populated->inode.ino = 0xdeadbeef;
+  populated->symlink = "rhubarb";
+  ls.push_back(populated);
+}
+
 void CInode::validate_disk_state(CInode::validated_data *results,
                                  MDSInternalContext *fin)
 {

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -127,6 +127,19 @@ public:
 };
 WRITE_CLASS_ENCODER_FEATURES(InodeStore)
 
+// just for ceph-dencoder
+class InodeStoreBare : public InodeStore {
+public:
+  void encode(bufferlist &bl, uint64_t features) const {
+    InodeStore::encode_bare(bl, features);
+  }
+  void decode(bufferlist::iterator &bl) {
+    InodeStore::decode_bare(bl);
+  }
+  static void generate_test_instances(std::list<InodeStoreBare*>& ls);
+};
+WRITE_CLASS_ENCODER_FEATURES(InodeStoreBare)
+
 // cached inode wrapper
 class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CInode> {
  public:

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -211,6 +211,7 @@ TYPE_FEATUREFUL(file_layout_t)
 
 #include "mds/CInode.h"
 TYPE_FEATUREFUL(InodeStore)
+TYPE_FEATUREFUL(InodeStoreBare)
 
 #include "mds/MDSMap.h"
 TYPE_FEATUREFUL(MDSMap)


### PR DESCRIPTION
With this patch, we can dump inode embeded in dirfrag by:

rados -p cephfs_metadata getomapval 1.00000000 test_head /tmp/inode
ceph-dencoder type InodeStoreBare skip 9 import /tmp/inode decode dump_json

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>