### PR TITLE
ceph.spec.in: Include and own /usr/lib64/qemu contents in librbd1

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -914,6 +914,9 @@ mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rgw
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-mgr
 mkdir -p %{buildroot}%{_localstatedir}/lib/ceph/bootstrap-rbd
 
+mkdir -p %{buildroot}/usr/lib64/qemu
+ln -s %{_libdir}/librbd.so.1 %{buildroot}/usr/lib64/qemu/librbd.so.1
+
 %if 0%{?suse_version}
 # create __pycache__ directories and their contents
 %py3_compile %{buildroot}%{python3_sitelib}
@@ -1529,11 +1532,10 @@ fi
 %if %{with lttng}
 %{_libdir}/librbd_tp.so.*
 %endif
+%dir /usr/lib64/qemu
+/usr/lib64/qemu/librbd.so.1
 
-%post -n librbd1
-/sbin/ldconfig
-mkdir -p /usr/lib64/qemu/
-ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
+%post -n librbd1 -p /sbin/ldconfig
 
 %postun -n librbd1 -p /sbin/ldconfig
 


### PR DESCRIPTION
Instead of creating in %post. See also https://bugzilla.redhat.com/show_bug.cgi?id=1483796