### PR TITLE
osd/PGBackend: delete reply if fails to complete delete request

### DIFF
--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -140,6 +140,8 @@ void PGBackend::handle_recovery_delete(OpRequestRef op)
     [=](int r) {
       if (r != -EAGAIN) {
 	get_parent()->send_message_osd_cluster(reply, conn.get());
+      } else {
+	delete reply;
       }
     }));
   gather.activate();


### PR DESCRIPTION
if any of the objects fails to be deleted due to pg reset after latest
osdmap, the pg recovery delete reply won't be sent to the primary OSD.
in that case, we should delete the reply.

Fixes: http://tracker.ceph.com/issues/20913
Signed-off-by: Kefu Chai <kchai@redhat.com>