### PR TITLE
test/librbd: fix valgrind memory leak warning

### DIFF
--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -107,6 +107,7 @@ void SnapshotRemoveRequest<I>::send_remove_object_map() {
     if (image_ctx.snap_info.find(m_snap_id) == image_ctx.snap_info.end()) {
       lderr(cct) << this << " " << __func__ << ": snapshot doesn't exist"
                  << dendl;
+      m_state = STATE_ERROR;
       this->async_complete(-ENOENT);
       return;
     }

--- a/src/test/run-rbd-valgrind-unit-tests.sh
+++ b/src/test/run-rbd-valgrind-unit-tests.sh
@@ -5,7 +5,7 @@
 
 source $(dirname $0)/detect-build-env-vars.sh
 
-RBD_FEATURES=13 valgrind --tool=memcheck --leak-check=full \
+RBD_FEATURES=13 valgrind --tool=memcheck --leak-check=full --error-exitcode=1 \
 	    --suppressions=${CEPH_ROOT}/src/valgrind.supp unittest_librbd
 
 echo OK


### PR DESCRIPTION
Signed-off-by: Mykola Golub <mgolub@mirantis.com>

```
==947== 16 bytes in 1 blocks are definitely lost in loss record 4 of 16
==947==    at 0x4C2E0EF: operator new(unsigned long) (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==947==    by 0x6122A7: create_context_callback<librbd::ExclusiveLock<librbd::(anonymous namespace)::MockExclusiveLockImageCtx>, &librbd::ExclusiveLock<librbd::(anonymous namespace)::MockExclusiveLockImageCtx>::handle_post_acquiring_lock> (Utils.h:133)
==947==    by 0x6122A7: librbd::ExclusiveLock<librbd::(anonymous namespace)::MockExclusiveLockImageCtx>::post_acquire_lock_handler(int, Context*) (ExclusiveLock.cc:242)
==947==    by 0x61271C: librbd::TestMockExclusiveLock::when_post_acquire_lock_handler(librbd::ManagedLock<librbd::(anonymous namespace)::MockExclusiveLockImageCtx>&, int) [clone .isra.883] [clone .constprop.1348] (test_mock_ExclusiveLock.cc:304)
==947==    by 0x617836: librbd::TestMockExclusiveLock_ReacquireLock_Test::TestBody() (test_mock_ExclusiveLock.cc:630)
==947==    by 0xC0A5B2: HandleSehExceptionsInMethodIfSupported<testing::Test, void> (gtest.cc:2402)
==947==    by 0xC0A5B2: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (gtest.cc:2438)
==947==    by 0xC01F99: testing::Test::Run() (gtest.cc:2475)
==947==    by 0xC020E7: testing::TestInfo::Run() (gtest.cc:2656)
==947==    by 0xC021C4: testing::TestCase::Run() (gtest.cc:2774)
==947==    by 0xC0249E: testing::internal::UnitTestImpl::RunAllTests() (gtest.cc:4649)
==947==    by 0xC0AA92: HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool> (gtest.cc:2402)
==947==    by 0xC0AA92: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (gtest.cc:2438)
==947==    by 0xC027D3: testing::UnitTest::Run() (gtest.cc:4257)
==947==    by 0x5A7721: RUN_ALL_TESTS (gtest.h:2233)
==947==    by 0x5A7721: main (test_main.cc:57)
```