### PR TITLE
msg: Checking argument to be negative before using

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1029,7 +1029,12 @@ retry:
   sprintf(msg, "%04x:%08x:%08x:%08x:%s", im.lid, im.qpn, im.psn, im.peer_qpn, gid);
   ldout(cct, 10) << __func__ << " sending: " << im.lid << ", " << im.qpn << ", " << im.psn
                  << ", " << im.peer_qpn << ", "  << gid  << dendl;
+  if (sd <= 0){
+    ldout(cct, 0) << __func__ << " socket in bad state" << dendl;
+    return -EBADFD;
+  }
   r = ::write(sd, msg, sizeof(msg));
+
   // Drop incoming qpt
   if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
     if (rand() % cct->_conf->ms_inject_socket_failures == 0) {


### PR DESCRIPTION
Fixes the coverity issue:

>** 1414522 Argument cannot be negative
>CID 1414522 (#1 of 1): Argument cannot be negative (REVERSE_NEGATIVE)
check_after_sink: You might be using variable sd before verifying that it is >= 0.

Signed-off-by: Amit Kumar amitkuma@redhat.com