### PR TITLE
test: Checking fd for negative before closing

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -219,6 +219,7 @@ TEST(Buffer, constructors) {
     snprintf(cmd, sizeof(cmd), "echo ABC > %s", FILENAME);
     EXPECT_EQ(0, ::system(cmd));
     int fd = ::open(FILENAME, O_RDONLY);
+    assert (fd >= 0);
     bufferptr ptr(buffer::create_zero_copy(zc_len, fd, NULL));
     history_alloc_bytes += zc_len;
     history_alloc_num++;


### PR DESCRIPTION
Fixes the coverity issue:

>** 1395317 Argument cannot be negative
>161. negative_return_fn: Function open("bufferlist", 0) returns a
negative number.
>162. var_assign: Assigning: signed variable fd = open.

Signed-off-by: Amit Kumar amitkuma@redhat.com