### PR TITLE
luminous: mon/OSDMonitor: do not send_pg_creates with stale info

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3261,6 +3261,13 @@ epoch_t OSDMonitor::send_pg_creates(int osd, Connection *con, epoch_t next) cons
   dout(30) << __func__ << " osd." << osd << " next=" << next
 	   << " " << creating_pgs_by_osd_epoch << dendl;
   std::lock_guard<std::mutex> l(creating_pgs_lock);
+  if (creating_pgs_epoch == 0 ||
+      creating_pgs_epoch < mapping.get_epoch()) {
+    dout(20) << __func__
+	     << " not using stale creating_pgs@" << creating_pgs_epoch << dendl;
+    // the subscribers will be updated when the mapping is completed anyway
+    return next;
+  }
   auto creating_pgs_by_epoch = creating_pgs_by_osd_epoch.find(osd);
   if (creating_pgs_by_epoch == creating_pgs_by_osd_epoch.end())
     return next;

--- a/src/osd/OSDMapMapping.h
+++ b/src/osd/OSDMapMapping.h
@@ -243,7 +243,7 @@ private:
   mempool::osdmap_mapping::vector<
     mempool::osdmap_mapping::vector<pg_t>> acting_rmap;  // osd -> pg
   //unused: mempool::osdmap_mapping::vector<std::vector<pg_t>> up_rmap;  // osd -> pg
-  epoch_t epoch;
+  epoch_t epoch = 0;
   uint64_t num_pgs = 0;
 
   void _init_mappings(const OSDMap& osdmap);


### PR DESCRIPTION
we reset the "creating_pgs" with the newly accepted paxos proposal, but
the creating_pgs_by_osd_epoch is out-of-sync with the new creating_pgs.
so we are at risk of using stale creating_pgs_by_osd_epoch along with
the new creating_pgs.pgs. to avoid this racing, we need to check the
creating_pgs_epoch before sending pg-creates using
creating_pgs_by_osd_epoch.

Fixes: http://tracker.ceph.com/issues/20785
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 689cf03f5515bb116ddf3966ef57550baf97eee9)