### PR TITLE
luminous: Include front/back interface names in OSD metadata

### DIFF
--- a/src/common/ipaddr.cc
+++ b/src/common/ipaddr.cc
@@ -27,7 +27,7 @@ static void netmask_ipv4(const struct in_addr *addr,
 }
 
 
-const struct sockaddr *find_ipv4_in_subnet(const struct ifaddrs *addrs,
+const struct ifaddrs *find_ipv4_in_subnet(const struct ifaddrs *addrs,
 					   const struct sockaddr_in *net,
 					   unsigned int prefix_len) {
   struct in_addr want, temp;
@@ -49,7 +49,7 @@ const struct sockaddr *find_ipv4_in_subnet(const struct ifaddrs *addrs,
     netmask_ipv4(cur, prefix_len, &temp);
 
     if (temp.s_addr == want.s_addr) {
-      return addrs->ifa_addr;
+      return addrs;
     }
   }
 
@@ -71,7 +71,7 @@ static void netmask_ipv6(const struct in6_addr *addr,
 }
 
 
-const struct sockaddr *find_ipv6_in_subnet(const struct ifaddrs *addrs,
+const struct ifaddrs *find_ipv6_in_subnet(const struct ifaddrs *addrs,
 					   const struct sockaddr_in6 *net,
 					   unsigned int prefix_len) {
   struct in6_addr want, temp;
@@ -93,14 +93,14 @@ const struct sockaddr *find_ipv6_in_subnet(const struct ifaddrs *addrs,
     netmask_ipv6(cur, prefix_len, &temp);
 
     if (IN6_ARE_ADDR_EQUAL(&temp, &want))
-      return addrs->ifa_addr;
+      return addrs;
   }
 
   return NULL;
 }
 
 
-const struct sockaddr *find_ip_in_subnet(const struct ifaddrs *addrs,
+const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
 					 const struct sockaddr *net,
 					 unsigned int prefix_len) {
   switch (net->sa_family) {

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -31,6 +31,12 @@ class CephContext;
 void pick_addresses(CephContext *cct, int needs);
 
 /**
+ * Find a network interface whose address matches the address/netmask
+ * in `network`.
+ */
+std::string pick_iface(CephContext *cct, const struct sockaddr_storage &network);
+
+/**
  * check for a locally configured address
  *
  * check if any of the listed addresses is configured on the local host.

--- a/src/include/ipaddr.h
+++ b/src/include/ipaddr.h
@@ -7,7 +7,7 @@
   If there are multiple matches, the first one is returned; this order
   is system-dependent and should not be relied on.
  */
-const struct sockaddr *find_ip_in_subnet(const struct ifaddrs *addrs,
+const struct ifaddrs *find_ip_in_subnet(const struct ifaddrs *addrs,
 					 const struct sockaddr *net,
 					 unsigned int prefix_len);
 

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -45,6 +45,7 @@
 #include "common/ceph_time.h"
 #include "common/version.h"
 #include "common/io_priority.h"
+#include "common/pick_address.h"
 
 #include "os/ObjectStore.h"
 #ifdef HAVE_LIBFUSE
@@ -5900,6 +5901,17 @@ void OSD::_collect_metadata(map<string,string> *pm)
   store->collect_metadata(pm);
 
   collect_sys_info(pm, cct);
+
+  std::string front_iface, back_iface;
+  /*
+  pick_iface(cct,
+      CEPH_PICK_ADDRESS_PUBLIC | CEPH_PICK_ADDRESS_CLUSTER,
+      &front_iface, &back_iface);
+      */
+  (*pm)["front_iface"] = pick_iface(cct,
+      client_messenger->get_myaddr().get_sockaddr_storage());
+  (*pm)["back_iface"] = pick_iface(cct,
+      cluster_messenger->get_myaddr().get_sockaddr_storage());
 
   dout(10) << __func__ << " " << *pm << dendl;
 }

--- a/src/test/test_ipaddr.cc
+++ b/src/test/test_ipaddr.cc
@@ -34,7 +34,7 @@ TEST(CommonIPAddr, TestNotFound)
   struct sockaddr_in a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -60,7 +60,7 @@ TEST(CommonIPAddr, TestV4_Simple)
   struct sockaddr_in a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -77,7 +77,7 @@ TEST(CommonIPAddr, TestV4_Simple)
   ipv4(&net, "10.11.12.42");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 24);
-  ASSERT_EQ((struct sockaddr*)&a_one, result);
+  ASSERT_EQ((struct sockaddr*)&a_one, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV4_Prefix25)
@@ -86,7 +86,7 @@ TEST(CommonIPAddr, TestV4_Prefix25)
   struct sockaddr_in a_one;
   struct sockaddr_in a_two;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -103,7 +103,7 @@ TEST(CommonIPAddr, TestV4_Prefix25)
   ipv4(&net, "10.11.12.128");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 25);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV4_Prefix16)
@@ -112,7 +112,7 @@ TEST(CommonIPAddr, TestV4_Prefix16)
   struct sockaddr_in a_one;
   struct sockaddr_in a_two;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -129,7 +129,7 @@ TEST(CommonIPAddr, TestV4_Prefix16)
   ipv4(&net, "10.2.0.0");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 16);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV4_PrefixTooLong)
@@ -137,7 +137,7 @@ TEST(CommonIPAddr, TestV4_PrefixTooLong)
   struct ifaddrs one;
   struct sockaddr_in a_one;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -158,7 +158,7 @@ TEST(CommonIPAddr, TestV4_PrefixZero)
   struct sockaddr_in6 a_one;
   struct sockaddr_in a_two;
   struct sockaddr_in net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -175,7 +175,7 @@ TEST(CommonIPAddr, TestV4_PrefixZero)
   ipv4(&net, "255.0.1.2");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 0);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV6_Simple)
@@ -184,7 +184,7 @@ TEST(CommonIPAddr, TestV6_Simple)
   struct sockaddr_in a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in6 net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
   
@@ -201,7 +201,7 @@ TEST(CommonIPAddr, TestV6_Simple)
   ipv6(&net, "2001:1234:5678:90ab::dead:beef");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 64);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV6_Prefix57)
@@ -210,7 +210,7 @@ TEST(CommonIPAddr, TestV6_Prefix57)
   struct sockaddr_in6 a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in6 net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -227,7 +227,7 @@ TEST(CommonIPAddr, TestV6_Prefix57)
   ipv6(&net, "2001:1234:5678:90ab::dead:beef");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 57);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, TestV6_PrefixTooLong)
@@ -235,7 +235,7 @@ TEST(CommonIPAddr, TestV6_PrefixTooLong)
   struct ifaddrs one;
   struct sockaddr_in6 a_one;
   struct sockaddr_in6 net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   memset(&net, '0', sizeof(net));
 
@@ -256,7 +256,7 @@ TEST(CommonIPAddr, TestV6_PrefixZero)
   struct sockaddr_in a_one;
   struct sockaddr_in6 a_two;
   struct sockaddr_in6 net;
-  const struct sockaddr *result;
+  const struct ifaddrs *result;
 
   one.ifa_next = &two;
   one.ifa_addr = (struct sockaddr*)&a_one;
@@ -271,7 +271,7 @@ TEST(CommonIPAddr, TestV6_PrefixZero)
   ipv6(&net, "ff00::1");
 
   result = find_ip_in_subnet(&one, (struct sockaddr*)&net, 0);
-  ASSERT_EQ((struct sockaddr*)&a_two, result);
+  ASSERT_EQ((struct sockaddr*)&a_two, result->ifa_addr);
 }
 
 TEST(CommonIPAddr, ParseNetwork_Empty)


### PR DESCRIPTION
http://tracker.ceph.com/issues/21048