### PR TITLE
client: allocate and free UserPerm gid lists with malloc/free

### DIFF
--- a/src/client/UserPerm.h
+++ b/src/client/UserPerm.h
@@ -25,14 +25,18 @@ private:
   bool alloced_gids;
   void deep_copy_from(const UserPerm& b) {
     if (alloced_gids) {
-      delete[] gids;
+      free(gids);
       alloced_gids = false;
     }
     m_uid = b.m_uid;
     m_gid = b.m_gid;
     gid_count = b.gid_count;
     if (gid_count) {
-      gids = new gid_t[gid_count];
+      gids = (gid_t *) malloc(gid_count * sizeof(gid_t));
+      if (!gids) {
+	throw std::bad_alloc();
+	return;
+      }
       alloced_gids = true;
       for (int i = 0; i < gid_count; ++i) {
 	gids[i] = b.gids[i];
@@ -59,7 +63,7 @@ public:
   }
   ~UserPerm() {
     if (alloced_gids)
-      delete[] gids;
+      free(gids);
   }
   UserPerm& operator=(const UserPerm o) {
     deep_copy_from(o);

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -287,7 +287,15 @@ static void do_out_buffer(string& outbl, char **outbuf, size_t *outbuflen)
 extern "C" UserPerm *ceph_userperm_new(uid_t uid, gid_t gid, int ngids,
 				       gid_t *gidlist)
 {
-  return new (std::nothrow) UserPerm(uid, gid, ngids, gidlist);
+  UserPerm *perms = nullptr;
+  try {
+    perms = new UserPerm(uid, gid, ngids, gidlist);
+  }
+  catch (std::bad_alloc) {
+    delete perms;
+    perms = nullptr;
+  }
+  return perms;
 }
 
 extern "C" void ceph_userperm_destroy(UserPerm *perm)


### PR DESCRIPTION
Valgrind is unhappy about our turning on supplimentary group handling
with fuse by default. The problem is that we end up calling delete to
free the supplimentary gids list, but fuse uses malloc to allocate it.

We could just convert ceph-fuse to use new/delete instead, but C
programs like ganesha can call ceph_userperm_new() to allocate a new
UserPerm, and they just pass in a pointer to a list of gids, often
malloced.

Convert the UserPerm constructor/destructors to use malloc and free to
handle creating and freeing gid lists. If we end up failing to allocate
a gids list when we need one, just throw a std::bad_alloc exception.

While we're at it, fix ceph_userperm_new to catch that exception instead
of trying to do a std::nothrow exception (as that won't work anyway).

Signed-off-by: Jeff Layton <jlayton@redhat.com>