### PR TITLE
osd: adjust osd_min_pg_log_entries

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2510,7 +2510,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_min_pg_log_entries", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
-    .set_default(1500)
+    .set_default(3000)
     .set_description("minimum number of entries to maintain in the PG log")
     .add_service("osd")
     .add_see_also("osd_max_pg_log_entries")


### PR DESCRIPTION
Return osd_min_pg_log_entries to its original values, which matches
osd_pg_log_dups_tracked, so the extended dup log is not used in the
general case.

This helps address: http://tracker.ceph.com/issues/21026

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>
(cherry picked from commit 1c4df03394312fe67f36448613d8b54cb1a0e2c9)