### PR TITLE
fuse: use c++ allocations for group list

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -112,14 +112,15 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
     return 0;
   }
 
-  *sgids = (gid_t*)malloc(c*sizeof(**sgids));
-  if (!*sgids) {
+  gid_t *gids = new (std::nothrow) gid_t[c];
+  if (!gids) {
     return -ENOMEM;
   }
-  c = fuse_req_getgroups(req, c, *sgids);
+  c = fuse_req_getgroups(req, c, gids);
   if (c < 0) {
-    free(*sgids);
-    return c;
+    delete gids;
+  } else {
+    *sgids = gids;
   }
   return c;
 #endif


### PR DESCRIPTION
Valgrind is unhappy about our turning on supplimentary group handling
with fuse by default. The problem is that we end up calling delete to
free the supplimentary gids list, but fuse uses malloc to allocate it.

Note that I was initially concerned that I needed to use malloc and
free there to handle the case of userland calling ceph_userperm_new,
but we leave freeing the pointer up to the caller in that case.

Convert fuse to use new/delete to allocate and free the group lists
instead.

Signed-off-by: Jeff Layton <jlayton@redhat.com>