### PR TITLE
client: fix locking in Client::getcwd

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9380,11 +9380,11 @@ int Client::chdir(const char *relpath, std::string &new_cwd,
     cwd.swap(in);
   ldout(cct, 3) << "chdir(" << relpath << ")  cwd now " << cwd->ino << dendl;
 
-  getcwd(new_cwd, perms);
+  _getcwd(new_cwd, perms);
   return 0;
 }
 
-void Client::getcwd(string& dir, const UserPerm& perms)
+void Client::_getcwd(string& dir, const UserPerm& perms)
 {
   filepath path;
   ldout(cct, 10) << "getcwd " << *cwd << dendl;
@@ -9422,6 +9422,12 @@ void Client::getcwd(string& dir, const UserPerm& perms)
   }
   dir = "/";
   dir += path.get_path();
+}
+
+void Client::getcwd(string& dir, const UserPerm& perms)
+{
+  Mutex::Locker l(client_lock);
+  _getcwd(dir, perms);
 }
 
 int Client::statfs(const char *path, struct statvfs *stbuf,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -956,6 +956,7 @@ public:
 
   // crap
   int chdir(const char *s, std::string &new_cwd, const UserPerm& perms);
+  void _getcwd(std::string& cwd, const UserPerm& perms);
   void getcwd(std::string& cwd, const UserPerm& perms);
 
   // namespace ops


### PR DESCRIPTION
Currently, it doesn't take the client_lock at all, which is problematic
as make_request may very well end up unlocking it. Rename the current
function to _getcwd, and add a new getcwd wrapper that takes the mutex
before calling _getcwd.

Signed-off-by: Jeff Layton <jlayton@redhat.com>