### PR TITLE
ceph-disk: Do not start services that are not enabled

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -4146,10 +4146,11 @@ def main_activate_space(name, args):
             reactivate=args.reactivate,
         )
 
-        start_daemon(
-            cluster=cluster,
-            osd_id=osd_id,
-        )
+        if not args.no_start_daemon:
+            start_daemon(
+                cluster=cluster,
+                osd_id=osd_id,
+            )
 
 
 ###########################
@@ -4188,10 +4189,11 @@ def main_activate_all(args):
                         dmcrypt=False,
                         dmcrypt_key_dir='',
                     )
-                    start_daemon(
-                        cluster=cluster,
-                        osd_id=osd_id,
-                    )
+                    if not args.no_start_daemon:
+                        start_daemon(
+                            cluster=cluster,
+                            osd_id=osd_id,
+                        )
 
                 except Exception as e:
                     print(
@@ -4774,6 +4776,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate',
+                '--no-start-daemon',
                 args.dev,
             ]
         )
@@ -4784,6 +4787,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate',
+                '--no-start-daemon',
                 '--dmcrypt',
                 args.dev,
             ]
@@ -4795,6 +4799,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate-journal',
+                '--no-start-daemon',
                 args.dev,
             ]
         )
@@ -4805,6 +4810,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate-journal',
+                '--no-start-daemon',
                 '--dmcrypt',
                 args.dev,
             ]
@@ -4820,6 +4826,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate-block',
+                '--no-start-daemon',
                 args.dev,
             ]
         )
@@ -4834,6 +4841,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate-block',
+                '--no-start-daemon',
                 '--dmcrypt',
                 args.dev,
             ]
@@ -4845,6 +4853,7 @@ def main_trigger(args):
             ceph_disk +
             [
                 'activate-lockbox',
+                '--no-start-daemon',
                 args.dev,
             ]
         )
@@ -5333,6 +5342,11 @@ def make_activate_lockbox_parser(subparsers):
         help='directory where dm-crypt keys are stored',
     )
     parser.add_argument(
+        '--no-start-daemon',
+        action='store_true', default=None,
+        help='do not start the daemon',
+    )
+    parser.add_argument(
         'path',
         metavar='PATH',
         help='path to block device',
@@ -5384,6 +5398,11 @@ def make_activate_space_parser(name, subparsers):
         choices=INIT_SYSTEMS,
     )
     activate_space_parser.add_argument(
+        '--no-start-daemon',
+        action='store_true', default=None,
+        help='do not start the daemon',
+    )
+    activate_space_parser.add_argument(
         '--dmcrypt',
         action='store_true', default=None,
         help=('map data and/or auxiliariy (journal, etc.) '
@@ -5429,6 +5448,11 @@ def make_activate_all_parser(subparsers):
         help='init system to manage this dir',
         default='auto',
         choices=INIT_SYSTEMS,
+    )
+    activate_all_parser.add_argument(
+        '--no-start-daemon',
+        action='store_true', default=None,
+        help='do not start the daemon',
     )
     activate_all_parser.set_defaults(
         activate_key_template='{statedir}/bootstrap-osd/{cluster}.keyring',


### PR DESCRIPTION
Currently, we start the daemons when calling activate from main_trigger.
That makes us disrespect the rules of the init systems. -- the services 
are started on boot regardless of whether they are enabled/disabled.

This fixes up the behaviour by adding --no-start-daemon to the activate
calls and keeping the osd start to the init systems.

If the OSD will be started too early (before ceph-disk completes), the
unit systems will try to restart it after 20 seconds as per our
definitions in the init scripts until it succeeds (or times out).

Signed-off-by: Boris Ranto <branto@redhat.com>

Related bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1482201