### PR TITLE
kraken: core: disable skewed utilization warning by default

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -28,3 +28,7 @@
   the safe use of the "osd snap trim sleep" option, wihch defaults to 0 but
   otherwise adds the given number of seconds in delay between every dispatch
   of trim operations to the underlying system.
+
+* The 'mon_warn_osd_usage_min_max_delta' health warning has been disabled because
+  it does not address clusters undergoing recovery or CRUSH rules that do
+  not target all devices in the cluster.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -305,7 +305,7 @@ OPTION(mon_crush_min_required_version, OPT_STR, "firefly")
 OPTION(mon_warn_on_crush_straw_calc_version_zero, OPT_BOOL, true) // warn if crush straw_calc_version==0
 OPTION(mon_warn_on_osd_down_out_interval_zero, OPT_BOOL, true) // warn if 'mon_osd_down_out_interval == 0'
 OPTION(mon_warn_on_cache_pools_without_hit_sets, OPT_BOOL, true)
-OPTION(mon_warn_osd_usage_min_max_delta, OPT_FLOAT, .40) // warn if difference between min and max OSD utilizations exceeds specified amount
+OPTION(mon_warn_osd_usage_min_max_delta, OPT_FLOAT, 0) // warn if difference between min and max OSD utilizations exceeds specified amount
 OPTION(mon_min_osdmap_epochs, OPT_INT, 500)
 OPTION(mon_max_pgmap_epochs, OPT_INT, 500)
 OPTION(mon_max_log_epochs, OPT_INT, 500)


### PR DESCRIPTION
This has a few problems:

1- It does not do it's analysis over CRUSH rule roots/classes, which
means that an innocent user of classes will see skewed usage (bc hdds are
more full than ssds, say)

2- It does not take degraded clusters into account, which means the warning
will appear when a fresh OSD is added.

See http://tracker.ceph.com/issues/20730

Signed-off-by: David Zafman <dzafman@redhat.com>