### PR TITLE
luminous: mon/PGMap: fix "0 stuck requests are blocked > 4096 sec" warn

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3188,7 +3188,7 @@ void PGMap::get_health_checks(
     }
     if (!error_detail.empty()) {
       ostringstream ss;
-      ss << warn << " stuck requests are blocked > "
+      ss << error << " stuck requests are blocked > "
 	 << err_age << " sec";
       auto& d = checks->add("REQUEST_STUCK", HEALTH_ERR, ss.str());
       d.detail.swap(error_detail);


### PR DESCRIPTION
backport #17099