### PR TITLE
rbd:use different logic to disturb thread's offset in bench seq test

### DIFF
--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -221,9 +221,14 @@ int do_bench(librbd::Image& image, io_type_t io_type,
   uint64_t i;
   uint64_t start_pos;
 
-  // disturb all thread's offset, used by seq IO
+  uint64_t unit_len = size/io_size/io_threads;
+  // disturb all thread's offset
   for (i = 0; i < io_threads; i++) {
-    start_pos = (rand() % (size / io_size)) * io_size;
+    if (random) {
+      start_pos = (rand() % (size / io_size)) * io_size;
+    } else {
+      start_pos = unit_len * i * io_size;
+    }
     thread_offset.push_back(start_pos);
   }
 


### PR DESCRIPTION
if we do rbd bench seq test, it'better that we initial the thread's offset by dividing the image size in average, instead of using rand() function just like  what rbd bench rand test does

Signed-off-by: PCzhangPC <pengcheng.zhang@easystack.cn>