### PR TITLE
mds: fix StrayManager::truncate()

### DIFF
--- a/src/mds/StrayManager.cc
+++ b/src/mds/StrayManager.cc
@@ -728,6 +728,7 @@ void StrayManager::truncate(CDentry *dn)
   assert(to > 0);
 
   PurgeItem item;
+  item.action = PurgeItem::TRUNCATE_FILE;
   item.ino = in->inode.ino;
   item.layout = in->inode.layout;
   item.snapc = *snapc;


### PR DESCRIPTION
old code does not set PurgeItem::action

Fixes: http://tracker.ceph.com/issues/21091
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>