### PR TITLE
test: Check to avoid divide by zero

### DIFF
--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -115,7 +115,9 @@ int KvStoreBench::setup(int argc, const char** argv) {
       } else if (strcmp(args[i], "--cache-size") == 0) {
 	cache_size = atoi(args[i+1]);
       } else if (strcmp(args[i], "--cache-refresh") == 0) {
-	cache_refresh = 100 / atoi(args[i+1]);
+	auto temp = atoi(args[i+1]);
+	assert (temp != 0);
+	cache_refresh = 100 / temp;
       } else if (strcmp(args[i], "-t") == 0) {
 	max_ops_in_flight = atoi(args[i+1]);
       } else if (strcmp(args[i], "--clients") == 0) {


### PR DESCRIPTION
Fixes the coverity issue:

** 1219467 Division or modulo by zero
>CID 1219467 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
>74. divide_by_zero: In expression 100 / atoi(args[i + 1U]), division
 by expression atoi(args[i + 1U]) which may be zero has undefined behavior.

Signed-off-by: Amit Kumar amitkuma@redhat.com