### PR TITLE
osd/PrimaryLogPG: do_osd_ops - propagate EAGAIN/EINPROGRESS on failok

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6765,7 +6765,8 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   fail:
     osd_op.rval = result;
     tracepoint(osd, do_osd_op_post, soid.oid.name.c_str(), soid.snap.val, op.op, ceph_osd_op_name(op.op), op.flags, result);
-    if (result < 0 && (op.flags & CEPH_OSD_OP_FLAG_FAILOK))
+    if (result < 0 && (op.flags & CEPH_OSD_OP_FLAG_FAILOK) &&
+        result != -EAGAIN && result != -EINPROGRESS)
       result = 0;
 
     if (result < 0)


### PR DESCRIPTION
These are not real errors and ignoring these error codes can
cause potential problems.

Propagating these errors to high-level callers such as execute_ctx()
where they can be taken good care of should instead be the preferred
option.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>