### PR TITLE
test: Avoid divide by zero in libradosstriper

### DIFF
--- a/src/test/libradosstriper/striping.cc
+++ b/src/test/libradosstriper/striping.cc
@@ -46,12 +46,14 @@ protected:
     ASSERT_LT(0, ioctx.getxattr(firstOid, "striper.layout.stripe_unit", xattrbl));
     std::string s_xattr(xattrbl.c_str(), xattrbl.length()); // adds 0 byte at the end
     uint64_t stripe_unit = strtoll(s_xattr.c_str(), NULL, 10);
+    assert(stripe_unit!=0);
     ASSERT_LT((unsigned)0, stripe_unit);
     ASSERT_EQ(stripe_unit, exp_stripe_unit);
     xattrbl.clear();
     ASSERT_LT(0, ioctx.getxattr(firstOid, "striper.layout.stripe_count", xattrbl));
     s_xattr = std::string(xattrbl.c_str(), xattrbl.length()); // adds 0 byte at the end
     uint64_t stripe_count = strtoll(s_xattr.c_str(), NULL, 10);
+    assert(stripe_count!=0);
     ASSERT_LT(0U, stripe_count);
     ASSERT_EQ(stripe_count, exp_stripe_count);
     xattrbl.clear();


### PR DESCRIPTION
Fixes the coverity issue:

** 1394838 Division or modulo by zero
>CID 1394838 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
>33. divide_by_zero: In expression object_size / stripe_unit, division
by expression stripe_unit which may be zero has undefined behavior.

** 1394840 Division or modulo by zero
>CID 1394840 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
>34. divide_by_zero: In expression stripe_in_object_set % stripe_count,
modulo by expression stripe_count which may be zero has undefined behavior.

Signed-off-by: Amit Kumar amitkuma@redhat.com