### PR TITLE
qa/suites/upgrade/jewel-x/stress-split: tolerate sloppy past_intervals

### DIFF
--- a/qa/suites/upgrade/jewel-x/stress-split/1-jewel-install/jewel.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/1-jewel-install/jewel.yaml
@@ -8,4 +8,6 @@ tasks:
 - ceph:
     skip_mgr_daemons: true
     add_osds_to_crush: true
+    log-whitelist:
+      - required past_interval bounds are empty
 - print: "**** done ceph"


### PR DESCRIPTION
This is harmless in general, esp during upgrade.

Signed-off-by: Sage Weil <sage@redhat.com>