### PR TITLE
luminous: client: fix locking in Client::getcwd

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -9378,11 +9378,11 @@ int Client::chdir(const char *relpath, std::string &new_cwd,
     cwd.swap(in);
   ldout(cct, 3) << "chdir(" << relpath << ")  cwd now " << cwd->ino << dendl;
 
-  getcwd(new_cwd, perms);
+  _getcwd(new_cwd, perms);
   return 0;
 }
 
-void Client::getcwd(string& dir, const UserPerm& perms)
+void Client::_getcwd(string& dir, const UserPerm& perms)
 {
   filepath path;
   ldout(cct, 10) << "getcwd " << *cwd << dendl;
@@ -9420,6 +9420,12 @@ void Client::getcwd(string& dir, const UserPerm& perms)
   }
   dir = "/";
   dir += path.get_path();
+}
+
+void Client::getcwd(string& dir, const UserPerm& perms)
+{
+  Mutex::Locker l(client_lock);
+  _getcwd(dir, perms);
 }
 
 int Client::statfs(const char *path, struct statvfs *stbuf,

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -956,6 +956,7 @@ public:
 
   // crap
   int chdir(const char *s, std::string &new_cwd, const UserPerm& perms);
+  void _getcwd(std::string& cwd, const UserPerm& perms);
   void getcwd(std::string& cwd, const UserPerm& perms);
 
   // namespace ops


### PR DESCRIPTION
backport: http://tracker.ceph.com/issues/21098