### PR TITLE
luminous: client: fix compat version on MStatfs

### DIFF
--- a/src/messages/MStatfs.h
+++ b/src/messages/MStatfs.h
@@ -22,13 +22,13 @@
 class MStatfs : public PaxosServiceMessage {
 
   static const int HEAD_VERSION = 2;
-  static const int COMPAT_VERSION = 0;
+  static const int COMPAT_VERSION = 1;
 
 public:
   uuid_d fsid;
   boost::optional<int64_t> data_pool;
 
-  MStatfs() : PaxosServiceMessage(CEPH_MSG_STATFS, 0, HEAD_VERSION) {}
+  MStatfs() : PaxosServiceMessage(CEPH_MSG_STATFS, 0, HEAD_VERSION, COMPAT_VERSION) {}
   MStatfs(const uuid_d& f, ceph_tid_t t, boost::optional<int64_t> _data_pool,
 	      version_t v) : PaxosServiceMessage(CEPH_MSG_STATFS, v,
                                             HEAD_VERSION, COMPAT_VERSION),


### PR DESCRIPTION
backport: http://tracker.ceph.com/issues/21099