### PR TITLE
luminous: fuse: use c++ allocations for group list

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -112,14 +112,15 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
     return 0;
   }
 
-  *sgids = (gid_t*)malloc(c*sizeof(**sgids));
-  if (!*sgids) {
+  gid_t *gids = new (std::nothrow) gid_t[c];
+  if (!gids) {
     return -ENOMEM;
   }
-  c = fuse_req_getgroups(req, c, *sgids);
+  c = fuse_req_getgroups(req, c, gids);
   if (c < 0) {
-    free(*sgids);
-    return c;
+    delete gids;
+  } else {
+    *sgids = gids;
   }
   return c;
 #endif


### PR DESCRIPTION
backport: http://tracker.ceph.com/issues/21100