### PR TITLE
osd/PG: PGPool::update: avoid expensive union_of

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -241,8 +241,9 @@ void PGPool::update(OSDMapRef map)
     interval_set<snapid_t> intersection;
     intersection.intersection_of(newly_removed_snaps, cached_removed_snaps);
     if (intersection == cached_removed_snaps) {
-        newly_removed_snaps.subtract(cached_removed_snaps);
-        cached_removed_snaps.union_of(newly_removed_snaps);
+        cached_removed_snaps.swap(newly_removed_snaps);
+        newly_removed_snaps = cached_removed_snaps;
+        newly_removed_snaps.subtract(intersection);
     } else {
         lgeneric_subdout(cct, osd, 0) << __func__
           << " cached_removed_snaps shrank from " << cached_removed_snaps


### PR DESCRIPTION
Achieve the same result using a swap (constant complexity),
and an assignment (linear complexity).

Similar to https://github.com/ceph/ceph/pull/17121.

@tchaikov

