### PR TITLE
qa/overrides/2-size-2-min-size: whitelist REQUEST_STUCK

### DIFF
--- a/qa/overrides/2-size-2-min-size.yaml
+++ b/qa/overrides/2-size-2-min-size.yaml
@@ -4,3 +4,5 @@ overrides:
       global:
         osd_pool_default_size: 2
         osd_pool_default_min_size: 2
+    log-whitelist:
+      - \(REQUEST_STUCK\)


### PR DESCRIPTION
With min_size == size things can get stuck a very long time.

Signed-off-by: Sage Weil <sage@redhat.com>