### PR TITLE
qa: fix the potential delay of pg state change

### DIFF
--- a/qa/tasks/lost_unfound.py
+++ b/qa/tasks/lost_unfound.py
@@ -169,8 +169,8 @@ def task(ctx, config):
         assert not err
 
     # see if osd.1 can cope
-    manager.revive_osd(1)
     manager.mark_in_osd(1)
+    manager.revive_osd(1)
     manager.wait_till_osd_is_up(1)
     manager.wait_for_clean()
     run.wait(procs)

--- a/qa/tasks/rep_lost_unfound_delete.py
+++ b/qa/tasks/rep_lost_unfound_delete.py
@@ -169,8 +169,8 @@ def task(ctx, config):
         assert err
 
     # see if osd.1 can cope
-    manager.revive_osd(1)
     manager.mark_in_osd(1)
+    manager.revive_osd(1)
     manager.wait_till_osd_is_up(1)
     manager.wait_for_clean()
     run.wait(procs)


### PR DESCRIPTION
If start osd process first and then mark it in, the
pg state may remain all active+clean when doing
wait_for_clean() check, which may fail the next
osd_scrub_pgs() process.
So faster pg state change by marking osd in first.

Signed-off-by: huangjun <huangjun@xsky.com>