### PR TITLE
rgw: add missing override in list_keys_init()

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2161,8 +2161,7 @@ public:
     pool = store->get_zone_params().domain_root;
   }
 
-  int list_keys_init(RGWRados *store, const string& marker, void **phandle)
-  {
+  int list_keys_init(RGWRados *store, const string& marker, void **phandle) override {
     list_keys_info *info = new list_keys_info;
 
     info->store = store;


### PR DESCRIPTION
Added missing override in list_keys_init(). It is also for maintaining consistency with the
other definitions of list_keys_init() in rgw_bucket.cc.

Found this in the review of https://github.com/ceph/ceph/pull/17249

Signed-off-by: Jos Collin <jcollin@redhat.com>