### PR TITLE
[DNM] Remove crush rulesets

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -18,7 +18,7 @@ bool CrushWrapper::has_legacy_rule_ids() const
   for (unsigned i=0; i<crush->max_rules; i++) {
     crush_rule *r = crush->rules[i];
     if (r &&
-	r->mask.ruleset != i) {
+	r->mask.rule_id != i) {
       return true;
     }
   }
@@ -30,9 +30,9 @@ std::map<int, int> CrushWrapper::renumber_rules()
   std::map<int, int> result;
   for (unsigned i=0; i<crush->max_rules; i++) {
     crush_rule *r = crush->rules[i];
-    if (r && r->mask.ruleset != i) {
-      result[r->mask.ruleset] = i;
-      r->mask.ruleset = i;
+    if (r && r->mask.rule_id != i) {
+      result[r->mask.rule_id] = i;
+      r->mask.rule_id = i;
     }
   }
   return result;
@@ -1454,7 +1454,7 @@ int CrushWrapper::add_simple_rule_at(
   string failure_domain_name,
   string device_class,
   string mode, int rule_type,
-  int rno,
+  int rule_id,
   ostream *err)
 {
   if (rule_exists(name)) {
@@ -1462,20 +1462,20 @@ int CrushWrapper::add_simple_rule_at(
       *err << "rule " << name << " exists";
     return -EEXIST;
   }
-  if (rno >= 0) {
-    if (rule_exists(rno)) {
+  if (rule_id >= 0) {
+    if (rule_exists(rule_id)) {
       if (err)
-        *err << "rule with ruleno " << rno << " exists";
+        *err << "rule with ruleno " << rule_id << " exists";
       return -EEXIST;
     }
-    if (ruleset_exists(rno)) {
+    if (rule_id_exists(rule_id)) {
       if (err)
-        *err << "ruleset " << rno << " exists";
+        *err << "rule id " << rule_id << " exists";
       return -EEXIST;
     }
   } else {
-    for (rno = 0; rno < get_max_rules(); rno++) {
-      if (!rule_exists(rno) && !ruleset_exists(rno))
+    for (rule_id = 0; rule_id < get_max_rules(); rule_id++) {
+      if (!rule_exists(rule_id) && !rule_id_exists(rule_id))
         break;
     }
   }
@@ -1521,8 +1521,7 @@ int CrushWrapper::add_simple_rule_at(
     steps = 5;
   int min_rep = mode == "firstn" ? 1 : 3;
   int max_rep = mode == "firstn" ? 10 : 20;
-  //set the ruleset the same as rule_id(rno)
-  crush_rule *rule = crush_make_rule(steps, rno, rule_type, min_rep, max_rep);
+  crush_rule *rule = crush_make_rule(steps, rule_id, rule_type, min_rep, max_rep);
   assert(rule);
   int step = 0;
   if (mode == "indep") {
@@ -1544,14 +1543,14 @@ int CrushWrapper::add_simple_rule_at(
 			0);
   crush_rule_set_step(rule, step++, CRUSH_RULE_EMIT, 0, 0);
 
-  int ret = crush_add_rule(crush, rule, rno);
+  int ret = crush_add_rule(crush, rule, rule_id);
   if(ret < 0) {
-    *err << "failed to add rule " << rno << " because " << cpp_strerror(ret);
+    *err << "failed to add rule " << rule_id << " because " << cpp_strerror(ret);
     return ret;
   }
-  set_rule_name(rno, name);
+  set_rule_name(rule_id, name);
   have_rmaps = false;
-  return rno;
+  return rule_id;
 }
 
 int CrushWrapper::add_simple_rule(
@@ -2642,27 +2641,27 @@ void CrushWrapper::dump_rules(Formatter *f) const
   }
 }
 
-void CrushWrapper::dump_rule(int ruleset, Formatter *f) const
+void CrushWrapper::dump_rule(int rule_id, Formatter *f) const
 {
   f->open_object_section("rule");
-  f->dump_int("rule_id", ruleset);
-  if (get_rule_name(ruleset))
-    f->dump_string("rule_name", get_rule_name(ruleset));
-  f->dump_int("ruleset", get_rule_mask_ruleset(ruleset));
-  f->dump_int("type", get_rule_mask_type(ruleset));
-  f->dump_int("min_size", get_rule_mask_min_size(ruleset));
-  f->dump_int("max_size", get_rule_mask_max_size(ruleset));
+  f->dump_int("rule_id", rule_id);
+  if (get_rule_name(rule_id))
+    f->dump_string("rule_name", get_rule_name(rule_id));
+  f->dump_int("rule_id", get_rule_mask_rule_id(rule_id));
+  f->dump_int("type", get_rule_mask_type(rule_id));
+  f->dump_int("min_size", get_rule_mask_min_size(rule_id));
+  f->dump_int("max_size", get_rule_mask_max_size(rule_id));
   f->open_array_section("steps");
-  for (int j=0; j<get_rule_len(ruleset); j++) {
+  for (int j=0; j<get_rule_len(rule_id); j++) {
     f->open_object_section("step");
-    switch (get_rule_op(ruleset, j)) {
+    switch (get_rule_op(rule_id, j)) {
     case CRUSH_RULE_NOOP:
       f->dump_string("op", "noop");
       break;
     case CRUSH_RULE_TAKE:
       f->dump_string("op", "take");
       {
-        int item = get_rule_arg1(ruleset, j);
+        int item = get_rule_arg1(rule_id, j);
         f->dump_int("item", item);
 
         const char *name = get_item_name(item);
@@ -2674,36 +2673,36 @@ void CrushWrapper::dump_rule(int ruleset, Formatter *f) const
       break;
     case CRUSH_RULE_CHOOSE_FIRSTN:
       f->dump_string("op", "choose_firstn");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
-      f->dump_string("type", get_type_name(get_rule_arg2(ruleset, j)));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
+      f->dump_string("type", get_type_name(get_rule_arg2(rule_id, j)));
       break;
     case CRUSH_RULE_CHOOSE_INDEP:
       f->dump_string("op", "choose_indep");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
-      f->dump_string("type", get_type_name(get_rule_arg2(ruleset, j)));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
+      f->dump_string("type", get_type_name(get_rule_arg2(rule_id, j)));
       break;
     case CRUSH_RULE_CHOOSELEAF_FIRSTN:
       f->dump_string("op", "chooseleaf_firstn");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
-      f->dump_string("type", get_type_name(get_rule_arg2(ruleset, j)));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
+      f->dump_string("type", get_type_name(get_rule_arg2(rule_id, j)));
       break;
     case CRUSH_RULE_CHOOSELEAF_INDEP:
       f->dump_string("op", "chooseleaf_indep");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
-      f->dump_string("type", get_type_name(get_rule_arg2(ruleset, j)));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
+      f->dump_string("type", get_type_name(get_rule_arg2(rule_id, j)));
       break;
     case CRUSH_RULE_SET_CHOOSE_TRIES:
       f->dump_string("op", "set_choose_tries");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
       break;
     case CRUSH_RULE_SET_CHOOSELEAF_TRIES:
       f->dump_string("op", "set_chooseleaf_tries");
-      f->dump_int("num", get_rule_arg1(ruleset, j));
+      f->dump_int("num", get_rule_arg1(rule_id, j));
       break;
     default:
-      f->dump_int("opcode", get_rule_op(ruleset, j));
-      f->dump_int("arg1", get_rule_arg1(ruleset, j));
-      f->dump_int("arg2", get_rule_arg2(ruleset, j));
+      f->dump_int("opcode", get_rule_op(rule_id, j));
+      f->dump_int("arg1", get_rule_arg1(rule_id, j));
+      f->dump_int("arg2", get_rule_arg2(rule_id, j));
     }
     f->close_section();
   }
@@ -2854,20 +2853,20 @@ void CrushWrapper::generate_test_instances(list<CrushWrapper*>& o)
 }
 
 /**
- * Determine the default CRUSH ruleset ID to be used with
+ * Determine the default CRUSH rule ID to be used with
  * newly created replicated pools.
  *
- * @returns a ruleset ID (>=0) or -1 if no suitable ruleset found
+ * @returns a rule ID (>=0) or -1 if no suitable ID is available
  */
-int CrushWrapper::get_osd_pool_default_crush_replicated_ruleset(CephContext *cct)
+int CrushWrapper::get_osd_pool_default_crush_replicated_rule(CephContext *cct)
 {
-  int crush_ruleset = cct->_conf->osd_pool_default_crush_rule;
-  if (crush_ruleset < 0) {
-    crush_ruleset = find_first_ruleset(pg_pool_t::TYPE_REPLICATED);
-  } else if (!ruleset_exists(crush_ruleset)) {
-    crush_ruleset = -1; // match find_first_ruleset() retval
+  int crush_rule = cct->_conf->osd_pool_default_crush_rule;
+  if (crush_rule < 0) {
+    crush_rule = find_first_rule(pg_pool_t::TYPE_REPLICATED);
+  } else if (!rule_exists(crush_rule)) {
+    crush_rule = -1; // match find_first_rule() retval
   }
-  return crush_ruleset;
+  return crush_rule;
 }
 
 bool CrushWrapper::is_valid_crush_name(const string& s)

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -120,14 +120,25 @@ public:
     set_tunables_default();
   }
 
-  /// true if any rule has a ruleset != the rule id
-  bool has_legacy_rulesets() const;
+  /**
+   * true if any rule has a rule id != its position in the array
+   *
+   * These indicate "ruleset" IDs that were created by older versions
+   * of Ceph.  They are cleaned up in renumber_rules so that eventually
+   * we can remove the code for handling them.
+   */
+  bool has_legacy_rule_ids() const;
 
-  /// fix rules whose ruleid != ruleset
-  int renumber_rules_by_ruleset();
-
-  /// true if any ruleset has more than 1 rule
-  bool has_multirule_rulesets() const;
+  /**
+   * fix rules whose ruleid != ruleset
+   *
+   * These rules were created in older versions of Ceph.  The concept
+   * of a ruleset no longer exists.
+   *
+   * Return a map of old ID -> new ID.  Caller must update OSDMap
+   * to use new IDs.
+   */
+  std::map<int, int> renumber_rules();
 
   /// true if any buckets that aren't straw2
   bool has_non_straw2_buckets() const;
@@ -1203,7 +1214,7 @@ public:
   void finalize() {
     assert(crush);
     crush_finalize(crush);
-    have_uniform_rules = !has_legacy_rulesets();
+    have_uniform_rules = !has_legacy_rule_ids();
   }
 
   int update_device_class(int id, const string& class_name, const string& name, ostream *ss);
@@ -1277,7 +1288,7 @@ public:
   /**
    * Return the lowest numbered ruleset of type `type`
    *
-   * @returns a ruleset ID, or -1 if no matching rulesets found.
+   * @returns a ruleset ID, or -1 if no matching rules found.
    */
   int find_first_ruleset(int type) const {
     int result = -1;

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -986,10 +986,10 @@ public:
     if (IS_ERR(r)) return PTR_ERR(r);
     return r->len;
   }
-  int get_rule_mask_ruleset(unsigned ruleno) const {
+  int get_rule_mask_rule_id(unsigned ruleno) const {
     crush_rule *r = get_rule(ruleno);
     if (IS_ERR(r)) return -1;
-    return r->mask.ruleset;
+    return r->mask.rule_id;
   }
   int get_rule_mask_type(unsigned ruleno) const {
     crush_rule *r = get_rule(ruleno);
@@ -1263,21 +1263,29 @@ public:
     crush->max_devices = m;
   }
 
-  int find_rule(int ruleset, int type, int size) const {
+  int find_rule(int rule_id, int type, int size) const {
     if (!crush) return -1;
     if (!have_uniform_rules) {
-      return crush_find_rule(crush, ruleset, type, size);
+      // Apply legacy "ruleset" logic for old maps where multiple
+      // rules have the same rule_id and we must select among them
+      // based on pool size.
+      return crush_find_rule(crush, rule_id, type, size);
     } else {
-      if (ruleset < (int)crush->max_rules &&
-	  crush->rules[ruleset])
-	return ruleset;
+      if (rule_id < (int)crush->max_rules &&
+	  crush->rules[rule_id])
+	return rule_id;
       return -1;
     }
   }
 
-  bool ruleset_exists(const int ruleset) const {
+  /**
+   * This check handles legacy ruleset case where we have multiple
+   * rules with the same ID and/or rules with an ID not equal to
+   * their location in the array.
+   */
+  bool rule_id_exists(const int rule_id) const {
     for (size_t i = 0; i < crush->max_rules; ++i) {
-      if (rule_exists(i) && crush->rules[i]->mask.ruleset == ruleset) {
+      if (rule_exists(i) && crush->rules[i]->mask.rule_id == rule_id) {
 	return true;
       }
     }
@@ -1286,18 +1294,18 @@ public:
   }
 
   /**
-   * Return the lowest numbered ruleset of type `type`
+   * Return the lowest numbered rule_id of type `type`
    *
-   * @returns a ruleset ID, or -1 if no matching rules found.
+   * @returns a rule ID, or -1 if no matching rules found.
    */
-  int find_first_ruleset(int type) const {
+  int find_first_rule_id(int type) const {
     int result = -1;
 
     for (size_t i = 0; i < crush->max_rules; ++i) {
       if (crush->rules[i]
           && crush->rules[i]->mask.type == type
-          && (crush->rules[i]->mask.ruleset < result || result == -1)) {
-        result = crush->rules[i]->mask.ruleset;
+          && (crush->rules[i]->mask.rule_id < result || result == -1)) {
+        result = crush->rules[i]->mask.rule_id;
       }
     }
 
@@ -1470,13 +1478,16 @@ public:
     const vector<int>& orig,
     vector<int> *out) const;
 
-  bool check_crush_rule(int ruleset, int type, int size,  ostream& ss) {
+  bool check_crush_rule(int rule_id, int type, int size,  ostream& ss) {
     assert(crush);
 
     __u32 i;
+    // Iterate through rules rather than looking up rule_id directly,
+    // to handle legacy maps with "rulesets" where rule_id != the
+    // array offset.
     for (i = 0; i < crush->max_rules; i++) {
       if (crush->rules[i] &&
-	  crush->rules[i]->mask.ruleset == ruleset &&
+	  crush->rules[i]->mask.rule_id == rule_id &&
 	  crush->rules[i]->mask.type == type) {
 
         if (crush->rules[i]->mask.min_size <= size &&
@@ -1500,7 +1511,7 @@ public:
   void decode_crush_bucket(crush_bucket** bptr, bufferlist::iterator &blp);
   void dump(Formatter *f) const;
   void dump_rules(Formatter *f) const;
-  void dump_rule(int ruleset, Formatter *f) const;
+  void dump_rule(int rule_id, Formatter *f) const;
   void dump_tunables(Formatter *f) const;
   void dump_choose_args(Formatter *f) const;
   void list_rules(Formatter *f) const;
@@ -1516,7 +1527,7 @@ public:
 		 const CrushTreeDumper::name_map_t& ws) const;
   static void generate_test_instances(list<CrushWrapper*>& o);
 
-  int get_osd_pool_default_crush_replicated_ruleset(CephContext *cct);
+  int get_osd_pool_default_crush_replicated_rule(CephContext *cct);
 
   static bool is_valid_crush_name(const string& s);
   static bool is_valid_crush_loc(CephContext *cct,

--- a/src/crush/crush.h
+++ b/src/crush/crush.h
@@ -24,8 +24,8 @@
 #define CRUSH_MAGIC 0x00010000ul   /* for detecting algorithm revisions */
 
 #define CRUSH_MAX_DEPTH 10  /* max crush hierarchy depth */
-#define CRUSH_MAX_RULESET (1<<8)  /* max crush ruleset number */
-#define CRUSH_MAX_RULES CRUSH_MAX_RULESET  /* should be the same as max rulesets */
+#define CRUSH_MAX_RULE (1<<8)  /* max crush rule number */
+#define CRUSH_MAX_RULES CRUSH_MAX_RULE  /* should be the same as max rules */
 
 #define CRUSH_MAX_DEVICE_WEIGHT (100u * 0x10000u)
 #define CRUSH_MAX_BUCKET_WEIGHT (65535u * 0x10000u)

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -73,7 +73,7 @@ int ErasureCodeLrc::create_rule(const string &name,
 
   int rno = 0;
   for (rno = 0; rno < crush.get_max_rules(); rno++) {
-    if (!crush.rule_exists(rno) && !crush.ruleset_exists(rno))
+    if (!crush.rule_exists(rno) && !crush.rule_id_exists(rno))
        break;
   }
 

--- a/src/include/ceph_fs.h
+++ b/src/include/ceph_fs.h
@@ -50,7 +50,7 @@ struct ceph_file_layout {
 
 	/* object -> pg layout */
 	__le32 fl_unused;       /* unused; used to be preferred primary for pg (-1 for none) */
-	__le32 fl_pg_pool;      /* namespace, crush ruleset, rep level */
+	__le32 fl_pg_pool;      /* namespace, crush rule, rep level */
 } __attribute__ ((packed));
 
 #define CEPH_MIN_STRIPE_UNIT 65536

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -71,7 +71,7 @@ struct ceph_file_layout {
 
 	/* object -> pg layout */
 	uint32_t fl_pg_preferred; /* preferred primary for pg (-1 for none) */
-	uint32_t fl_pg_pool;      /* namespace, crush ruleset, rep level */
+	uint32_t fl_pg_pool;      /* namespace, crush rule, rep level */
 } __attribute__ ((packed));
 
 

--- a/src/librados/RadosClient.h
+++ b/src/librados/RadosClient.h
@@ -120,8 +120,8 @@ public:
 
   /*
   -1 was set as the default value and monitor will pickup the right crush rule with below order:
-    a) osd pool default crush replicated ruleset
-    b) the first ruleset in crush ruleset
+    a) osd pool default crush replicated rule
+    b) the first rule in crush map
     c) error out if no value find
   */
   int pool_create(string& name, unsigned long long auid=0, int16_t crush_rule=-1);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8558,7 +8558,7 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
       // FIXME: this is ok in some situations, but let's not bother with that
       // complexity now.
       int ruleset = newcrush.get_rule_mask_ruleset(ruleno);
-      if (osdmap.crush_ruleset_in_use(ruleset)) {
+      if (osdmap.crush_rule_in_use(ruleset)) {
 	ss << "crush ruleset " << name << " " << ruleset << " is in use";
 	err = -EBUSY;
 	goto reply;

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3311,7 +3311,7 @@ int OSDMap::build_simple_optioned(CephContext *cct, epoch_t e, uuid_d &fsid,
 
   int poolbase = get_max_osd() ? get_max_osd() : 1;
 
-  const int default_replicated_rule = crush->get_osd_pool_default_crush_replicated_ruleset(cct);
+  const int default_replicated_rule = crush->get_osd_pool_default_crush_replicated_rule(cct);
   assert(default_replicated_rule >= 0);
 
   if (default_pool) {
@@ -3495,7 +3495,7 @@ int OSDMap::build_simple_crush_rules(
   const string& root,
   ostream *ss)
 {
-  int crush_rule = crush.get_osd_pool_default_crush_replicated_ruleset(cct);
+  int crush_rule = crush.get_osd_pool_default_crush_replicated_rule(cct);
   string failure_domain =
     crush.get_type_name(cct->_conf->osd_crush_chooseleaf_type);
 

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3250,10 +3250,10 @@ void OSDMap::print_oneline_summary(ostream& out) const
     out << " nearfull";
 }
 
-bool OSDMap::crush_ruleset_in_use(int ruleset) const
+bool OSDMap::crush_rule_in_use(int rule_id) const
 {
   for (const auto &pool : pools) {
-    if (pool.second.crush_rule == ruleset)
+    if (pool.second.crush_rule == rule_id)
       return true;
   }
   return false;

--- a/src/osd/OSDMap.h
+++ b/src/osd/OSDMap.h
@@ -1329,7 +1329,7 @@ public:
     const string& root,
     ostream *ss);
 
-  bool crush_ruleset_in_use(int ruleset) const;
+  bool crush_rule_in_use(int rule_id) const;
 
   void clear_temp() {
     pg_temp->clear();

--- a/src/sample.ceph.conf
+++ b/src/sample.ceph.conf
@@ -127,7 +127,7 @@
     # (Default: 8)
     ;osd pool default pgp num   = 128
 
-    # The default CRUSH ruleset to use when creating a pool
+    # The default CRUSH rule to use when creating a pool
     # Type: 32-bit Integer
     # (Default: 0)
     ;osd pool default crush rule = 0


### PR DESCRIPTION
(DNM because haven't even compiled it yet...)

The existing migration code was a bit of a soft touch, and potentially still left ruleset-ish crush maps in place (albeit with a health message complaining about them).

This change adds a new forceful migration, so that we can later remove all support for rulesets, and also changes the code terminology in lots of places that still talked about rulesets.

Also, change the rule's min_size/max_size fields to be called min_pool_size and max_pool_size, so that people are less likely to confuse the min_size with pg_pool_t's min_size.