### PR TITLE
auth: add err reason for log info in load function

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -232,7 +232,7 @@ int KeyRing::load(CephContext *cct, const std::string &filename)
     decode(iter);
   }
   catch (const buffer::error& err) {
-    lderr(cct) << "error parsing file " << filename << dendl;
+    lderr(cct) << "error parsing file " << filename << ": " << err.what() << dendl;
     return -EIO;
   }
 


### PR DESCRIPTION
auth: add err reason for log info in load function

We need the error reason to catch the useful info.

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>