### PR TITLE
luminous: mon/OSDMonitor: check creating_pgs.last_scan_epoch instead when sending creates

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3261,8 +3261,7 @@ epoch_t OSDMonitor::send_pg_creates(int osd, Connection *con, epoch_t next) cons
   dout(30) << __func__ << " osd." << osd << " next=" << next
 	   << " " << creating_pgs_by_osd_epoch << dendl;
   std::lock_guard<std::mutex> l(creating_pgs_lock);
-  if (creating_pgs_epoch == 0 ||
-      creating_pgs_epoch < mapping.get_epoch()) {
+  if (creating_pgs_epoch <= creating_pgs.last_scan_epoch) {
     dout(20) << __func__
 	     << " not using stale creating_pgs@" << creating_pgs_epoch << dendl;
     // the subscribers will be updated when the mapping is completed anyway


### PR DESCRIPTION
backport of #17248 

Fixes: http://tracker.ceph.com/issues/20785
Signed-off-by: Kefu Chai kchai@redhat.com