### PR TITLE
rgw_file:  fix LRU lane lock in evict_block()

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -136,6 +136,7 @@ namespace cohort {
 	for (int ix = 0; ix < n_lanes; ++ix,
 	       lane_ix = next_evict_lane()) {
 	  Lane& lane = qlane[lane_ix];
+	  lane.lock.lock();
 	  /* if object at LRU has refcnt==1, it may be reclaimable */
 	  Object* o = &(lane.q.back());
 	  if (can_reclaim(o)) {
@@ -156,7 +157,6 @@ namespace cohort {
 	      return o;
 	    } else {
 	      // XXX can't make unreachable (means what?)
-	      lane.lock.lock();
 	      --(o->lru_refcnt);
 	      o->lru_flags &= ~FLAG_EVICTING;
 	      /* unlock in next block */


### PR DESCRIPTION
Found by "Supriti Singh" <Supriti.Singh@suse.com>.

Fixes http://tracker.ceph.com/issues/21141

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>