### PR TITLE
mon/MonCommands: fix copy-and-paste error

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -510,7 +510,7 @@ COMMAND_WITH_FLAG("osd crush rule list", "list crush rules", "osd", "r", "cli,re
 		  FLAG(DEPRECATED))
 COMMAND("osd crush rule ls", "list crush rules", "osd", "r", "cli,rest")
 COMMAND("osd crush rule ls-by-class " \
-        "name=class,type=CephString,goodchars=[A-Za-z0-9-_.],req=false", \
+        "name=class,type=CephString,goodchars=[A-Za-z0-9-_.]", \
         "list all crush rules that reference the same <class>", \
         "osd", "r", "cli,rest")
 COMMAND("osd crush rule dump " \


### PR DESCRIPTION
Class is definitely required by default for the "crush rule ls-by-class"
command.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>