### PR TITLE
common: silence jenkins's buiding warning in obj_bencher.cc

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -82,7 +82,7 @@ void *ObjBencher::status_printer(void *_bencher) {
   int previous_writes = 0;
   int cycleSinceChange = 0;
   double bandwidth;
-  int iops;
+  int iops = 0;
   utime_t ONE_SECOND;
   ONE_SECOND.set_from_double(1.0);
   bencher->lock.Lock();


### PR DESCRIPTION
silence jenkins's buiding warning in obj_bencher.cc:
```c++
[ 89%] Building CXX object src/test/rbd_mirror/CMakeFiles/unittest_rbd_mirror.dir/image_replayer/test_mock_CreateImageRequest.cc.o
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/obj_bencher.cc: In static member function ‘static void* ObjBencher::status_printer(void*)’:
/home/jenkins-build/build/workspace/ceph-pull-requests/src/common/obj_bencher.cc:205:3: warning: ‘iops’ may be used uninitialized in this function [-Wmaybe-uninitialized]
   if (iops < 0) {
   ^
```

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>