### PR TITLE
osd, mds, tools: drop the invalid comment and some unused variables

### DIFF
--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -618,9 +618,7 @@ void Server::finish_force_open_sessions(map<client_t,entity_inst_t>& cm,
 	   << " initial v " << mds->sessionmap.get_version() << dendl;
   
 
-  int sessions_inserted = 0;
   for (map<client_t,entity_inst_t>::iterator p = cm.begin(); p != cm.end(); ++p) {
-    sessions_inserted++;
 
     Session *session = mds->sessionmap.get_session(p->second.name);
     assert(session);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2393,7 +2393,6 @@ void PrimaryLogPG::record_write_error(OpRequestRef op, const hobject_t &soid,
   dout(20) << __func__ << " r=" << r << dendl;
   assert(op->may_write());
   const osd_reqid_t &reqid = static_cast<const MOSDOp*>(op->get_req())->get_reqid();
-  ObjectContextRef obc;
   mempool::osd_pglog::list<pg_log_entry_t> entries;
   entries.push_back(pg_log_entry_t(pg_log_entry_t::ERROR, soid,
 				   get_next_version(), eversion_t(), 0,

--- a/src/osd/ReplicatedBackend.h
+++ b/src/osd/ReplicatedBackend.h
@@ -58,7 +58,6 @@ public:
 
   void check_recovery_sources(const OSDMapRef& osdmap) override;
 
-  /// @see PGBackend::delay_message_until_active
   bool can_handle_while_inactive(OpRequestRef op) override;
 
   /// @see PGBackend::handle_message

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -27,7 +27,7 @@ using namespace std;
 
 int main(int argc, char **argv) {
   po::options_description desc("Allowed options");
-  string store_path, cmd, out_path, oid;
+  string store_path, cmd, oid;
   bool debug = false;
   desc.add_options()
     ("help", "produce help message")


### PR DESCRIPTION
osd, mds, tools: drop the invalid comment and some unused variables

invalid comment: 
/// @ see PGBackend::delay_message_until_active
---- This method（PGBackend::delay_message_until_active） does not exist any more.

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>