### PR TITLE
mds/prometheus: Fix for MDS metrics

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -76,7 +76,7 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            return path.replace('.', '_').replace('-', '_')
+            return path.replace('.', '_').replace('-', '_minus').replace('+', '_plus')
 
         def floatstr(value):
             ''' represent as Go-compatible float '''

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -76,7 +76,7 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            return path.replace('.', '_').replace('-', '_minus').replace('+', '_plus')
+            return path.replace('.', '_').replace('-', '_minus').replace('+', '_plus') 
 
         def floatstr(value):
             ''' represent as Go-compatible float '''


### PR DESCRIPTION

MDS metrics come in these forms: 

mds_mem_dir  #Directories
mds_mem_dir+ #Directories opened
mds_mem_dir-  #Directories closed

In this case, continuing the trend of replacing all illegal characters with '_' results in…

mds_mem_dir   #Directories
mds_mem_dir_ #Directories opened
mds_mem_dir_ #Directories closed

which is palpably a bad idea.

Suggested replacement for '+' = '_plus' seems fine, and a perusal of all metrics indicate that only MDS metrics end in '-' or '+' at this time.

Replacing '-' with '_minus' is probably less good for the general case, if anyone has a better idea…

I suppose another alternative would be to change MDS metrics so they don't use 'illegal' characters, but this also seems cumbersome and would break more third parties.

Also https://github.com/ceph/ceph/compare/master...jermudgeon:patch-1


Fixes: http://tracker.ceph.com/issues/20899
Signed-off-by: Jeremy H Austin <jhaustin@gmail.com>