### PR TITLE
mon: Compress the warnings of pgs not scrubbed or deep-scrubbed

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -3216,6 +3216,9 @@ void PGMap::get_health_checks(
     if (cct->_conf->mon_warn_not_scrubbed ||
         cct->_conf->mon_warn_not_deep_scrubbed) {
       list<string> detail, deep_detail;
+      int detail_max = max, deep_detail_max = max;
+      int detail_more = 0, deep_detail_more = 0;
+      int detail_total = 0, deep_detail_total = 0;
       const double age = cct->_conf->mon_warn_not_scrubbed +
         cct->_conf->mon_scrub_interval;
       utime_t cutoff = now;
@@ -3227,30 +3230,60 @@ void PGMap::get_health_checks(
       for (auto& p : pg_stat) {
         if (cct->_conf->mon_warn_not_scrubbed &&
             p.second.last_scrub_stamp < cutoff) {
-	  ostringstream ss;
-	  ss << "pg " << p.first << " not scrubbed since "
-	     << p.second.last_scrub_stamp;
-          detail.push_back(ss.str());
+          if (detail_max > 0) {
+            ostringstream ss;
+            ss << "pg " << p.first << " not scrubbed since "
+               << p.second.last_scrub_stamp;
+            detail.push_back(ss.str());
+            --detail_max;
+          } else {
+            ++detail_more;
+          }
+          ++detail_total;
         }
         if (cct->_conf->mon_warn_not_deep_scrubbed &&
             p.second.last_deep_scrub_stamp < deep_cutoff) {
-	  ostringstream ss;
-	  ss << "pg " << p.first << " not deep-scrubbed since "
-	     << p.second.last_deep_scrub_stamp;
-          deep_detail.push_back(ss.str());
+          if (deep_detail_max > 0) {
+            ostringstream ss;
+            ss << "pg " << p.first << " not deep-scrubbed since "
+               << p.second.last_deep_scrub_stamp;
+            deep_detail.push_back(ss.str());
+            --deep_detail_max;
+          } else {
+            ++deep_detail_more;
+          }
+          ++deep_detail_total;
+        } 
+      }
+      if (detail_total) {
+        ostringstream ss;
+        ss << detail_total << " pgs not scrubbed for " << age;
+        auto& d = checks->add("PG_NOT_SCRUBBED", HEALTH_WARN, ss.str());
+
+        if (!detail.empty()) {
+          d.detail.swap(detail);
+
+          if (detail_more) {
+            ostringstream ss;
+            ss << detail_more << " more pgs... ";
+            d.detail.push_back(ss.str());
+          }
         }
       }
-      if (!detail.empty()) {
+      if (deep_detail_total) {
         ostringstream ss;
-        ss << detail.size() << " pgs not scrubbed for " << age;
-        auto& d = checks->add("PG_NOT_SCRUBBED", HEALTH_WARN, ss.str());
-        d.detail.swap(detail);
-      }
-      if (!deep_detail.empty()) {
-        ostringstream ss;
-        ss << deep_detail.size() << " pgs not deep-scrubbed for " << deep_age;
+        ss << deep_detail_total << " pgs not deep-scrubbed for " << deep_age;
         auto& d = checks->add("PG_NOT_DEEP_SCRUBBED", HEALTH_WARN, ss.str());
-        d.detail.swap(deep_detail);
+
+        if (!deep_detail.empty()) {
+          d.detail.swap(deep_detail);
+
+          if (deep_detail_more) {
+            ostringstream ss;
+            ss << deep_detail_more << " more pgs... ";
+            d.detail.push_back(ss.str());
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
If a cluster's PG number is very large, the warnings of pgs not scrubbed or deep-scrubbed in 'ceph health detail' will contain massive lines.  For example, our cluster usually havs 5000+ PGs. The warnings about this contains 10000+ lines. 

I think we can compress such warnings for one PG having one line only, because such warning is just giving us an overview about PG scrub status. This will reduce half lines of warnings compared with before.

Within this change, new output will be like this.
```
cluster:
    id:     63dd6fd2-78d5-49b0-9b3f-5b69fcbd4b25
    health: HEALTH_WARN
            noscrub,nodeep-scrub flag(s) set
            8192 pgs not (deep-)scrubbed for 86400
``` 
```
HEALTH_WARN noscrub,nodeep-scrub flag(s) set; 8192 pgs not (deep-)scrubbed for 86400
OSDMAP_FLAGS noscrub,nodeep-scrub flag(s) set
PG_NOT_(DEEP-)SCRUBBED 8192 pgs not (deep-)scrubbed for 86400
    pg 4.3ff not scrubbed / deep-scrubbed since 2017-08-01 19:30:36.535428 / 2017-08-01 19:30:36.535428
    pg 4.3fe not scrubbed / deep-scrubbed since 2017-08-01 23:54:51.227688 / 2017-07-28 13:37:07.805858
    pg 4.3fd not deep-scrubbed since 2017-07-29 04:12:02.335030
    pg 4.3fc not scrubbed since 2017-08-01 06:47:44.461400
...
```

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>