### PR TITLE
test: assert check for negative returns

### DIFF
--- a/src/test/objectstore/chain_xattr.cc
+++ b/src/test/objectstore/chain_xattr.cc
@@ -348,6 +348,7 @@ TEST(chain_xattr, fskip_chain_cleanup_and_ensure_single_attr)
   const char *file = FILENAME;
   ::unlink(file);
   int fd = ::open(file, O_CREAT|O_RDWR|O_TRUNC, 0700);
+  assert(fd >= 0);
 
   std::size_t existing_xattrs = get_xattrs(fd).size();
   char buf[800];
@@ -392,6 +393,7 @@ TEST(chain_xattr, skip_chain_cleanup_and_ensure_single_attr)
   const char *file = FILENAME;
   ::unlink(file);
   int fd = ::open(file, O_CREAT|O_RDWR|O_TRUNC, 0700);
+  assert(fd >= 0);
   std::size_t existing_xattrs = get_xattrs(fd).size();
   ::close(fd);
 


### PR DESCRIPTION
Fixes the coverity issue:

** 1395371 Argument cannot be negative
>1. negative_return_fn: Function open(file, 578, 448) returs a negative number.
>2. var_assign: Assigning: signed variable fd = open

** 1395427 Argument cannot be negative
>1. negative_return_fn: Function open(file, 578, 448) returns a negative number.
>2. var_assign: Assigning: signed variable fd = open

Signed-off-by: Amit Kumar <amitkuma@redhat.com>