### PR TITLE
os: Removing dead code from LFNIndex.cc

### DIFF
--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -1042,7 +1042,7 @@ int LFNIndex::lfn_parse_object_name_keyless(const string &long_name, ghobject_t 
   out->hobj.pool = pool;
   if (!r) return -EINVAL;
   string temp = lfn_generate_object_name(*out);
-  return r ? 0 : -EINVAL;
+  return 0;
 }
 
 static bool append_unescaped(string::const_iterator begin,


### PR DESCRIPTION
Fixes the coverity issue:

** 1394832 Logically dead code
> After `if (!r) return -EINVAL;` r cannot be zero.
> If r !=0 `return r ? 0 : -EINVAL;` will always return 0
> Hence ternary operator is dead code.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>