### PR TITLE
client: Removing dead code from Client.cc

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12373,11 +12373,7 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
     flock.Unlock();
   }
 
-  if (r < 0) {
-    return r;
-  } else {
-    return length;
-  }
+  return length;
 }
 
 int Client::ll_commit_blocks(Inode *in,


### PR DESCRIPTION
Fixes the coverity issue:

** 1405268 Logically dead code
>`int r = 0;` done at beginning of function.
> Then no value is assigned to r.
> `if (r < 0)` is logically dead. Control will not reach inside this condition.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>