### PR TITLE
RGW: support for tagging in lifecycle policies

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -74,6 +74,10 @@ bool RGWLifecycleConfiguration::_add_rule(LCRule *rule)
   } else {
     prefix = rule->get_prefix();
   }
+
+  if (rule->get_filter().has_tags()){
+    op.obj_tags = rule->get_filter().get_tags();
+  }
   auto ret = prefix_map.emplace(std::move(prefix), std::move(op));
   return ret.second;
 }
@@ -318,6 +322,15 @@ int RGWLC::handle_multipart_expiration(RGWRados::Bucket *target, const map<strin
   return 0;
 }
 
+static int read_obj_tags(RGWRados *store, RGWBucketInfo& bucket_info, rgw_obj& obj, RGWObjectCtx& ctx, bufferlist& tags_bl)
+{
+  RGWRados::Object op_target(store, bucket_info, ctx, obj);
+  RGWRados::Object::Read read_op(&op_target);
+
+  return read_op.get_attr(RGW_ATTR_TAGS, tags_bl);
+}
+
+
 int RGWLC::bucket_lc_process(string& shard_id)
 {
   RGWLifecycleConfiguration  config(cct);
@@ -355,7 +368,7 @@ int RGWLC::bucket_lc_process(string& shard_id)
   try {
       config.decode(iter);
     } catch (const buffer::error& e) {
-      ldout(cct, 0) << __func__ <<  "decode life cycle config failed" << dendl;
+      ldout(cct, 0) << __func__ <<  "() decode life cycle config failed" << dendl;
       return -1;
     }
 
@@ -388,6 +401,34 @@ int RGWLC::bucket_lc_process(string& shard_id)
         bool is_expired;
         for (auto obj_iter = objs.begin(); obj_iter != objs.end(); ++obj_iter) {
           rgw_obj_key key(obj_iter->key);
+          RGWObjState *state;
+          rgw_obj obj(bucket_info.bucket, key);
+          RGWObjectCtx rctx(store);
+          if (prefix_iter->second.obj_tags != boost::none) {
+            bufferlist tags_bl;
+            int ret = read_obj_tags(store, bucket_info, obj, rctx, tags_bl);
+            if (ret < 0) {
+              if (ret != -ENODATA)
+                ldout(cct, 5) << "ERROR: read_obj_tags returned r=" << ret << dendl;
+              continue;
+            }
+            RGWObjTags dest_obj_tags;
+            try {
+              auto iter = tags_bl.begin();
+              dest_obj_tags.decode(iter);
+            } catch (buffer::error& err) {
+               ldout(cct,0) << "ERROR: caught buffer::error, couldn't decode TagSet" << dendl;
+              return -EIO;
+            }
+
+            if (!includes(dest_obj_tags.get_tags().begin(),
+                          dest_obj_tags.get_tags().end(),
+                          prefix_iter->second.obj_tags->get_tags().begin(),
+                          prefix_iter->second.obj_tags->get_tags().end())){
+              ldout(cct, 20) << __func__ << "() skipping obj " << key << " as tags do not match" << dendl;
+              continue;
+            }
+          }
 
           if (!key.ns.empty()) {
             continue;
@@ -399,15 +440,15 @@ int RGWLC::bucket_lc_process(string& shard_id)
             is_expired = obj_has_expired(now - ceph::real_clock::to_time_t(obj_iter->meta.mtime), prefix_iter->second.expiration);
           }
           if (is_expired) {
-            RGWObjectCtx rctx(store);
-            rgw_obj obj(bucket_info.bucket, key);
-            RGWObjState *state;
             int ret = store->get_obj_state(&rctx, bucket_info, obj, &state, false);
             if (ret < 0) {
               return ret;
             }
-            if (state->mtime != obj_iter->meta.mtime)//Check mtime again to avoid delete a recently update object as much as possible
+            if (state->mtime != obj_iter->meta.mtime) {
+              //Check mtime again to avoid delete a recently update object as much as possible
+              ldout(cct, 20) << __func__ << "() skipping removal: state->mtime " << state->mtime << " obj->mtime " << obj_iter->meta.mtime << dendl;
               continue;
+            }
             ret = remove_expired_obj(bucket_info, obj_iter->key, true);
             if (ret < 0) {
               ldout(cct, 0) << "ERROR: remove_expired_obj " << dendl;
@@ -578,7 +619,7 @@ int RGWLC::list_lc_progress(const string& marker, uint32_t max_entries, map<stri
     int ret = cls_rgw_lc_list(store->lc_pool_ctx, obj_names[index], marker, max_entries, entries);
     if (ret < 0) {
       if (ret == -ENOENT) {
-        dout(10) << __func__ << " ignoring unfound lc object="
+        dout(10) << __func__ << "() ignoring unfound lc object="
                              << obj_names[index] << dendl;
         continue;
       } else {

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -67,6 +67,36 @@ bool RGWLifecycleConfiguration_S3::xml_end(const char *el) {
   return true;
 }
 
+bool LCFilter_S3::xml_end(const char* el) {
+
+  XMLObj *o = find_first("And");
+  bool single_cond = false;
+  int num_conditions = 0;
+  // If there is an AND condition, every tag is a child of and
+  // else we only support single conditions and return false if we see multiple
+
+  if (o == nullptr){
+    o = this;
+    single_cond = true;
+  }
+
+  RGWXMLDecoder::decode_xml("Prefix", prefix, o);
+  if (!prefix.empty())
+    num_conditions++;
+  auto tags_iter = o->find("Tag");
+  obj_tags.clear();
+  while (auto tag_xml =tags_iter.get_next()){
+    std::string _key,_val;
+    RGWXMLDecoder::decode_xml("Key", _key, tag_xml);
+    RGWXMLDecoder::decode_xml("Value", _val, tag_xml);
+    obj_tags.emplace_tag(std::move(_key), std::move(_val));
+    num_conditions++;
+  }
+
+  return !(single_cond && num_conditions > 1);
+}
+
+
 bool LCRule_S3::xml_end(const char *el) {
   LCID_S3 *lc_id;
   LCPrefix_S3 *lc_prefix;
@@ -74,7 +104,7 @@ bool LCRule_S3::xml_end(const char *el) {
   LCExpiration_S3 *lc_expiration;
   LCNoncurExpiration_S3 *lc_noncur_expiration;
   LCMPExpiration_S3 *lc_mp_expiration;
-
+  LCFilter_S3 *lc_filter;
   id.clear();
   prefix.clear();
   status.clear();
@@ -91,12 +121,10 @@ bool LCRule_S3::xml_end(const char *el) {
   }
 
 
-  XMLObj *obj = find_first("Filter");
+  lc_filter = static_cast<LCFilter_S3 *>(find_first("Filter"));
 
-  if (obj){
-    string _prefix;
-    RGWXMLDecoder::decode_xml("Prefix", _prefix, obj);
-    filter.set_prefix(std::move(_prefix));
+  if (lc_filter){
+    filter = *lc_filter;
   } else {
     // Ideally the following code should be deprecated and we should return
     // False here, The new S3 LC configuration xml spec. makes Filter mandatory
@@ -190,6 +218,8 @@ int RGWLifecycleConfiguration_S3::rebuild(RGWRados *store, RGWLifecycleConfigura
   return ret;
 }
 
+
+
 void RGWLifecycleConfiguration_S3::dump_xml(Formatter *f) const
 {
 	f->open_object_section_in_ns("LifecycleConfiguration", XMLNS_AWS_S3);
@@ -213,6 +243,8 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
     obj = new LCID_S3();
   } else if (strcmp(el, "Prefix") == 0) {
     obj = new LCPrefix_S3();
+  } else if (strcmp(el, "Filter") == 0) {
+    obj = new LCFilter_S3();
   } else if (strcmp(el, "Status") == 0) {
     obj = new LCStatus_S3();
   } else if (strcmp(el, "Expiration") == 0) {

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -9,6 +9,7 @@
 #include "include/str_list.h"
 #include "rgw_lc.h"
 #include "rgw_xml.h"
+#include "rgw_tag_s3.h"
 
 class LCID_S3 : public XMLObj
 {
@@ -33,16 +34,41 @@ class LCFilter_S3 : public LCFilter, public XMLObj
   string& to_str() { return data; }
   void to_xml(ostream& out){
     out << "<Filter>";
-      if (!prefix.empty())
-        out << "<Prefix>" << prefix << "</Prefix>";
+    stringstream ss;
+    if (has_prefix())
+      out << "<Prefix>" << prefix << "</Prefix>";
+    if (has_tags()){
+      for (const auto&kv : obj_tags.get_tags()){
+        ss << "<Tag>";
+        ss << "<Key>" << kv.first << "</Key>";
+        ss << "<Value>" << kv.second << "</Value>";
+        ss << "</Tag>";
+      }
+    }
+
+    if (has_multi_condition()) {
+      out << "<And>" << ss.str() << "</And>";
+    } else {
+      out << ss.str();
+    }
+
     out << "</Filter>";
   }
   void dump_xml(Formatter *f) const {
     f->open_object_section("Filter");
+    if (has_multi_condition())
+      f->open_object_section("And");
     if (!prefix.empty())
       encode_xml("Prefix", prefix, f);
+    if (has_tags()){
+      const auto& tagset_s3 = static_cast<const RGWObjTagSet_S3 &>(obj_tags);
+      tagset_s3.dump_xml(f);
+    }
+    if (has_multi_condition())
+      f->close_section(); // And;
     f->close_section(); // Filter
   }
+  bool xml_end(const char *el) override;
 };
 
 class LCStatus_S3 : public XMLObj

--- a/src/rgw/rgw_tag.cc
+++ b/src/rgw/rgw_tag.cc
@@ -15,6 +15,10 @@ bool RGWObjTags::add_tag(const string&key, const string& val){
   return tag_map.emplace(std::make_pair(key,val)).second;
 }
 
+bool RGWObjTags::emplace_tag(std::string&& key, std::string&& val){
+  return tag_map.emplace(std::move(key), std::move(val)).second;
+}
+
 int RGWObjTags::check_and_add_tag(const string&key, const string& val){
   if (tag_map.size() == MAX_OBJ_TAGS ||
       key.size() > MAX_TAG_KEY_SIZE ||

--- a/src/rgw/rgw_tag.h
+++ b/src/rgw/rgw_tag.h
@@ -30,9 +30,12 @@ class RGWObjTags
 
   void dump(Formatter *f) const;
   bool add_tag(const std::string& key, const std::string& val="");
+  bool emplace_tag(std::string&& key, std::string&& val);
   int check_and_add_tag(const std::string& key, const std::string& val="");
   size_t count() const {return tag_map.size();}
   int set_from_string(const std::string& input);
+  void clear() { tag_map.clear(); }
+  bool empty() const noexcept { return tag_map.empty(); }
   const tag_map_t& get_tags() const {return tag_map;}
 };
 WRITE_CLASS_ENCODER(RGWObjTags)

--- a/src/rgw/rgw_tag_s3.cc
+++ b/src/rgw/rgw_tag_s3.cc
@@ -56,7 +56,7 @@ bool RGWObjTagging_S3::xml_end(const char*){
 
 }
 
-void RGWObjTagSet_S3::dump_xml(Formatter *f){
+void RGWObjTagSet_S3::dump_xml(Formatter *f) const {
   for (const auto& tag: tag_map){
     f->open_object_section("Tag");
     f->dump_string("Key", tag.first);

--- a/src/rgw/rgw_tag_s3.h
+++ b/src/rgw/rgw_tag_s3.h
@@ -41,7 +41,7 @@ class RGWObjTagSet_S3: public RGWObjTags, public XMLObj
 {
 public:
   bool xml_end(const char*) override;
-  void dump_xml(Formatter *f);
+  void dump_xml(Formatter *f) const;
   int rebuild(RGWObjTags& dest);
 };
 


### PR DESCRIPTION
This PR adds support for tagging in object lifecycle policies, if a lifecycle policy has a tag attribute, then while processing objects in the bucket we additionally retrieve the objects tags to check whether all the tags in LC policy are contained in the object's tags.

- [x]  Fix the mtime issue with tagging (#17400)
- [ ]  Refactor list objects within LC to already filter out based on params & tagging (so that ops like mp_expire do not need to C-c C-v the same code) - I'll do this when we tackle expiration and tagging
- [x] Add S3 tests (for functionality, we first need to fix the timing of LC ops itself) (https://github.com/ceph/s3-tests/pull/188)