### PR TITLE
rgw: remove weak ciphers

### DIFF
--- a/doc/radosgw/frontends.rst
+++ b/doc/radosgw/frontends.rst
@@ -76,6 +76,22 @@ Options
 :Default: None
 
 
+``ssl_protocol_version``
+
+:Description: The SSL version. ``4`` is TLS 1.2.
+
+:Type: Integer
+:Default: ``4``
+
+
+``ssl_cipher_list``
+
+:Description: Which ciphers to use. See OpenSSL's cipher documentation.
+
+:Type: String
+:Default: ``EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!LOW:!RC4:!MD5:!3DES``
+
+
 A complete list of supported options can be found in the `Civetweb User Manual`_.
 
 

--- a/src/rgw/rgw_civetweb_frontend.cc
+++ b/src/rgw/rgw_civetweb_frontend.cc
@@ -59,6 +59,8 @@ int RGWCivetWebFrontend::run()
   set_conf_default(conf_map, "validate_http_method", "no");
   set_conf_default(conf_map, "canonicalize_url_path", "no");
   set_conf_default(conf_map, "enable_auth_domain_check", "no");
+  set_conf_default(conf_map, "ssl_protocol_version", "4");
+  set_conf_default(conf_map, "ssl_cipher_list", "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH:!LOW:!RC4:!MD5:!3DES");
   conf->get_val("port", "80", &port_str);
   std::replace(port_str.begin(), port_str.end(), '+', ',');
   conf_map["listening_ports"] = port_str;


### PR DESCRIPTION
This commit deactivates weak ciphers by default in civetweb.

Fixes: http://tracker.ceph.com/issues/18593
Signed-off-by: Nick Erdmann &lt;n@nirf.de&gt;