### PR TITLE
test/unittest_pg_log: silence gcc warning

### DIFF
--- a/src/test/osd/TestPGLog.cc
+++ b/src/test/osd/TestPGLog.cc
@@ -2700,6 +2700,7 @@ struct PGLogTrimTest :
 {
   CephContext *cct = g_ceph_context;
 
+  using ::testing::Test::SetUp;
   void SetUp(unsigned min_entries, unsigned max_entries, unsigned dup_track) {
     constexpr size_t size = 10;
 


### PR DESCRIPTION
this silences following warning:

In file included from ceph/src/test/osd/TestPGLog.cc:24:0:
ceph/src/googletest/googletest/include/gtest/gtest.h:430:16:
warning: ‘virtual void testing::Test::SetUp()’ was hidden
[-Woverloaded-virtual]
   virtual void SetUp();
                ^~~~~
ceph/src/test/osd/TestPGLog.cc:2703:8: warning:   by ‘void
PGLogTrimTest::SetUp(unsigned int, unsigned int, unsigned int)’
[-Woverloaded-virtual]
   void SetUp(unsigned min_entries, unsigned max_entries, unsigned
dup_track) {
        ^~~~~

Signed-off-by: Kefu Chai <kchai@redhat.com>