### PR TITLE
mon/OSDMonitor: make 'osd crush rule rename' idempotent

### DIFF
--- a/qa/workunits/mon/crush_ops.sh
+++ b/qa/workunits/mon/crush_ops.sh
@@ -38,12 +38,14 @@ ceph osd pool rm ec-foo ec-foo --yes-i-really-really-mean-it
 ceph osd crush rule ls | grep foo
 
 ceph osd crush rule rename foo foo-asdf
+ceph osd crush rule rename foo foo-asdf # idempotent
 ceph osd crush rule rename bar bar-asdf
 ceph osd crush rule ls | grep 'foo-asdf'
 ceph osd crush rule ls | grep 'bar-asdf'
 ceph osd crush rule rm foo 2>&1 | grep 'does not exist'
 ceph osd crush rule rm bar 2>&1 | grep 'does not exist'
 ceph osd crush rule rename foo-asdf foo
+ceph osd crush rule rename foo-asdf foo # idempotent
 ceph osd crush rule rename bar-asdf bar
 ceph osd crush rule ls | expect_false grep 'foo-asdf'
 ceph osd crush rule ls | expect_false grep 'bar-asdf'

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -8627,6 +8627,15 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     CrushWrapper newcrush;
     _get_pending_crush(newcrush);
+    if (!newcrush.rule_exists(srcname) && newcrush.rule_exists(dstname)) {
+      // srcname does not exist and dstname already exists
+      // suppose this is a replay and return success
+      // (so this command is idempotent)
+      ss << "already renamed to '" << dstname << "'";
+      err = 0;
+      goto reply;
+    }
+
     err = newcrush.rename_rule(srcname, dstname, &ss);
     if (err < 0) {
       // ss has reason for failure


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21162
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>