### PR TITLE
DNM qa/suites/rados/multimon/mon_clock_with_skews: stop ntpd

### DIFF
--- a/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
+++ b/qa/suites/rados/multimon/tasks/mon_clock_with_skews.yaml
@@ -2,7 +2,12 @@ tasks:
 - install:
 - exec:
     mon.b:
+    - sudo systemctl stop ntpd || sudo /etc/init.d/ntp stop
     - date -u -s @$(expr $(date -u +%s) + 10)
+- full_sequential_finally:
+  - exec:
+      mon.b:
+        - sudo systemctl start ntpd || sudo /etc/init.d/ntp start
 - ceph:
     wait-for-healthy: false
     log-whitelist:


### PR DESCRIPTION
If we don't stop ntpd our date change might get rolled back before the
mon notices.

Signed-off-by: Sage Weil <sage@redhat.com>