### PR TITLE
os/bluestore: ExtentMap::reshard - fix wrong shard length

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2133,7 +2133,7 @@ void BlueStore::ExtentMap::reshard(
 	     << needs_reshard_end << ")" << std::dec << dendl;
   }
 
-  fault_range(db, needs_reshard_begin, needs_reshard_end);
+  fault_range(db, needs_reshard_begin, (needs_reshard_end - needs_reshard_begin));
 
   // we may need to fault in a larger interval later must have all
   // referring extents for spanning blobs loaded in order to have


### PR DESCRIPTION
 os/bluestore:reshard-fix wrong shard length

change fault_range parameter from 'needs_reshard_end' to 'needs_reshard_end-needs_reshard_begin'
be given needs_reshard_end may be out of bounds