### PR TITLE
doc: move glance_api_version option to the right place

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -292,6 +292,7 @@ specify the pool name for the block device. On your OpenStack node, edit
     [DEFAULT]
     ...
     enabled_backends = ceph
+    glance_api_version = 2
     ...
     [ceph]
     volume_driver = cinder.volume.drivers.rbd.RBDDriver
@@ -302,7 +303,6 @@ specify the pool name for the block device. On your OpenStack node, edit
     rbd_max_clone_depth = 5
     rbd_store_chunk_size = 4
     rados_connect_timeout = -1
-    glance_api_version = 2
 
 If you are using `cephx authentication`_, also configure the user and uuid of
 the secret you added to ``libvirt`` as documented earlier::


### PR DESCRIPTION
doc: move glance_api_version option to the right place

OpenStack treat `glance_api_version` as a common option:
```c++
CONF.import_opt('glance_api_version', 'cinder.common.config')
```
So ``glance_api_version=2`` should be in the ``[DEFAULT]`` section just like @jdurgin 's note below.
```
Note that if you are configuring multiple cinder back ends, glance_api_version = 2 must be in the [DEFAULT] section.
```
Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>