### PR TITLE
osd: Deleting dead code PrimaryLogPG.cc

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4950,10 +4950,6 @@ int PrimaryLogPG::do_sparse_read(OpContext *ctx, OSDOp& osd_op) {
       last = miter->first + r;
     }
 
-    if (r < 0) {
-      return r;
-    }
-
     // verify trailing hole?
     if (cct->_conf->osd_verify_sparse_read_holes) {
       uint64_t end = MIN(op.extent.offset + op.extent.length, oi.size);


### PR DESCRIPTION
Fixes the coverity issue:

** 1415775 Logically dead code
>Here r cannot be less than 0. Means `return 0` is dead code.
>CID 1415775 (#1 of 1): Logically dead code (DEADCODE)
>dead_error_line: Execution cannot reach this statement: return r;

Signed-off-by: Amit Kumar <amitkuma@redhat.com>