### PR TITLE
common: logically dead code inside shunique_lock.h

### DIFF
--- a/src/common/shunique_lock.h
+++ b/src/common/shunique_lock.h
@@ -323,7 +323,6 @@ public:
     }
     throw std::system_error((int)std::errc::operation_not_permitted,
 			    std::generic_category());
-    return unique_lock_type();
   }
 
   shared_lock_type release_to_shared() {


### PR DESCRIPTION
Fixes the coverity issue:

** 1352097 Structurally dead code
>CID 1352097 (#1 of 1): Structurally dead code (UNREACHABLE)
>unreachable: This code cannot be reached: return ceph::shunique_lock<...

Signed-off-by: Amit Kumar <amitkuma@redhat.com>