### PR TITLE
rgw: 'return' placed on 1st line of rgw_writev

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -2020,9 +2020,6 @@ int rgw_readv(struct rgw_fs *rgw_fs,
 int rgw_writev(struct rgw_fs *rgw_fs, struct rgw_file_handle *fh,
 	      rgw_uio *uio, uint32_t flags)
 {
-
-  return -ENOTSUP;
-
   CephContext* cct = static_cast<CephContext*>(rgw_fs->rgw);
   RGWLibFS *fs = static_cast<RGWLibFS*>(rgw_fs->fs_private);
   RGWFileHandle* rgw_fh = get_rgwfh(fh);


### PR DESCRIPTION
Fixes the coverity issue:

** 1396171 Structurally dead code
>Don't know whether return is placed intentionally or
>missed as part of wrong commit.
>But return on 1st line makes whole function of no use.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>