### PR TITLE
mon/OSDMonitor: make 'osd crush class rename' idempotent

### DIFF
--- a/qa/standalone/crush/crush-classes.sh
+++ b/qa/standalone/crush/crush-classes.sh
@@ -209,6 +209,7 @@ function TEST_mon_classes() {
     ceph osd crush tree --show-shadow | grep 'class_1' || return 1
     ceph osd crush rule create-replicated class_1_rule default host class_1 || return 1
     ceph osd crush class rename class_1 class_2
+    ceph osd crush class rename class_1 class_2 # idempotent
     ceph osd crush class ls | grep 'class_1' && return 1
     ceph osd crush tree --show-shadow | grep 'class_1' && return 1
     ceph osd crush class ls | grep 'class_2' || return 1

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7528,16 +7528,11 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
 
     CrushWrapper newcrush;
     _get_pending_crush(newcrush);
-
-    if (!newcrush.class_exists(srcname)) {
-      err = -ENOENT;
-      ss << "class '" << srcname << "' does not exist";
-      goto reply;
-    }
-
-    if (newcrush.class_exists(dstname)) {
-      err = -EEXIST;
-      ss << "class '" << dstname << "' already exists";
+    if (!newcrush.class_exists(srcname) && newcrush.class_exists(dstname)) {
+      // suppose this is a replay and return success
+      // so command is idempotent
+      ss << "already renamed to '" << dstname << "'";
+      err = 0;
       goto reply;
     }
 


### PR DESCRIPTION
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
(cherry picked from commit 2ee80aead88c90388871ee65d4ed31a2fa47f532)