### PR TITLE
mon: use ceph_clock_now if message is self-generated

### DIFF
--- a/src/mon/MonOpRequest.h
+++ b/src/mon/MonOpRequest.h
@@ -88,7 +88,7 @@ private:
   MonOpRequest(Message *req, OpTracker *tracker) :
     TrackedOp(tracker,
       req->get_recv_stamp().is_zero() ?
-      req->get_recv_stamp() : ceph_clock_now()),
+      ceph_clock_now() : req->get_recv_stamp()),
     request(req),
     session(NULL),
     con(NULL),


### PR DESCRIPTION
Signed-off-by: huangjun <huangjun@xsky.com>
(cherry picked from commit 56e8031dac7ee65d54e831e7e372e8771fa0f94a)