### PR TITLE
rgw: Add a command that deletes objects leaked from multipart retries

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -74,6 +74,7 @@ void _usage()
   cout << "  bucket rm                  remove bucket\n";
   cout << "  bucket check               check bucket index\n";
   cout << "  bucket reshard             reshard bucket\n";
+  cout << "  bucket fixmpleak           remove leaked multipart objects that have accumulated from retries\n";
   cout << "  bi get                     retrieve bucket index object entries\n";
   cout << "  bi put                     store bucket index object entries\n";
   cout << "  bi list                    list raw bucket index entries\n";
@@ -301,6 +302,7 @@ enum {
   OPT_BUCKET_UNLINK,
   OPT_BUCKET_STATS,
   OPT_BUCKET_CHECK,
+  OPT_BUCKET_FIXMPLEAK,
   OPT_BUCKET_SYNC_STATUS,
   OPT_BUCKET_SYNC_INIT,
   OPT_BUCKET_SYNC_RUN,
@@ -513,6 +515,8 @@ static int get_cmd(const char *cmd, const char *prev_cmd, const char *prev_prev_
       return OPT_BUCKET_RESHARD;
     if (strcmp(cmd, "check") == 0)
       return OPT_BUCKET_CHECK;
+    if (strcmp(cmd, "fixmpleak") == 0)
+      return OPT_BUCKET_FIXMPLEAK;
     if (strcmp(cmd, "sync") == 0) {
       *need_more = true;
       return 0;
@@ -5289,6 +5293,13 @@ next:
       do_check_object_locator(tenant, bucket_name, fix, remove_bad, formatter);
     } else {
       RGWBucketAdminOp::check_index(store, bucket_op, f);
+    }
+  }
+
+  if (opt_cmd == OPT_BUCKET_FIXMPLEAK) {
+    int ret = RGWBucketAdminOp::fix_multipart_leak(store, bucket_op, f);
+    if (ret < 0) {
+      return -ret;
     }
   }
 

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -310,7 +310,7 @@ public:
 
   static int check_index(RGWRados *store, RGWBucketAdminOpState& op_state,
                   RGWFormatterFlusher& flusher);
-
+  static int fix_multipart_leak(RGWRados *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher);
   static int remove_bucket(RGWRados *store, RGWBucketAdminOpState& op_state, bool bypass_gc = false, bool keep_index_consistent = true);
   static int remove_object(RGWRados *store, RGWBucketAdminOpState& op_state);
   static int info(RGWRados *store, RGWBucketAdminOpState& op_state, RGWFormatterFlusher& flusher);

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -24,6 +24,7 @@
     bucket rm                  remove bucket
     bucket check               check bucket index
     bucket reshard             reshard bucket
+    bucket fixmpleak           remove leaked multipart objects that have accumulated from retries
     bi get                     retrieve bucket index object entries
     bi put                     store bucket index object entries
     bi list                    list raw bucket index entries


### PR DESCRIPTION
This patch only partially fixes 16767.  It does not prevent multipart retry leakage; instead, it provides a tool to clean up existing leaked multipart namespace objects.

NOTE: This code will not work on master because many of the structures used were obsoleted.  This should work for users of Hammer and Jewel.  The idea behind this needs to be ported to the later versions of Ceph.  Please review the code to ensure it does not have unintended consequences.

Reference to old PR for history: https://github.com/ceph/ceph/pull/17323

Backport: hammer, jewel
Assists: http://tracker.ceph.com/issues/16767
Signed-off-by: William Schroeder <william.schroeder@ctl.io>