### PR TITLE
rgw: fix resource leak in rgw_bucket.cc and rgw_user.cc

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -12,6 +12,7 @@
 
 #include "common/errno.h"
 #include "common/ceph_json.h"
+#include "common/backport14.h"
 #include "rgw_rados.h"
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h"
@@ -2162,7 +2163,7 @@ public:
   }
 
   int list_keys_init(RGWRados *store, const string& marker, void **phandle) override {
-    list_keys_info *info = new list_keys_info;
+    auto info = ceph::make_unique<list_keys_info>();
 
     info->store = store;
 
@@ -2171,7 +2172,7 @@ public:
     if (ret < 0) {
       return ret;
     }
-    *phandle = (void *)info;
+    *phandle = (void *)info.release();
 
     return 0;
   }
@@ -2361,7 +2362,7 @@ public:
   }
 
   int list_keys_init(RGWRados *store, const string& marker, void **phandle) override {
-    list_keys_info *info = new list_keys_info;
+    auto info = ceph::make_unique<list_keys_info>();
 
     info->store = store;
 
@@ -2370,7 +2371,7 @@ public:
     if (ret < 0) {
       return ret;
     }
-    *phandle = (void *)info;
+    *phandle = (void *)info.release();
 
     return 0;
   }

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -11,6 +11,7 @@
 #include "common/Formatter.h"
 #include "common/ceph_json.h"
 #include "common/RWLock.h"
+#include "common/backport14.h"
 #include "rgw_rados.h"
 #include "rgw_acl.h"
 
@@ -2774,7 +2775,7 @@ public:
 
   int list_keys_init(RGWRados *store, const string& marker, void **phandle) override
   {
-    list_keys_info *info = new list_keys_info;
+    auto info = ceph::make_unique<list_keys_info>();
 
     info->store = store;
 
@@ -2784,7 +2785,7 @@ public:
       return ret;
     }
 
-    *phandle = (void *)info;
+    *phandle = (void *)info.release();
 
     return 0;
   }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21214
This PR is the same as #17249 and rebased again.
Fix coverity check:

CID 1416847 (#1 of 1): Resource leak (RESOURCE_LEAK)
4. leaked_storage: Variable info going out of scope leaks the storage it points to.

CID 1416844 (#1 of 1): Resource leak (RESOURCE_LEAK)
4. leaked_storage: Variable info going out of scope leaks the storage it points to.

CID 1416843 (#1 of 1): Resource leak (RESOURCE_LEAK)
4. leaked_storage: Variable info going out of scope leaks the storage it points to.

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>