### PR TITLE
os/bluestore/BlueFS: compact log even when sync_metadata sees no work

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1882,18 +1882,21 @@ void BlueFS::sync_metadata()
   std::unique_lock<std::mutex> l(lock);
   if (log_t.empty()) {
     dout(10) << __func__ << " - no pending log events" << dendl;
-    return;
-  }
-  dout(10) << __func__ << dendl;
-  utime_t start = ceph_clock_now();
-  vector<interval_set<uint64_t>> to_release(pending_release.size());
-  to_release.swap(pending_release);
-  flush_bdev(); // FIXME?
-  _flush_and_sync_log(l);
-  for (unsigned i = 0; i < to_release.size(); ++i) {
-    for (auto p = to_release[i].begin(); p != to_release[i].end(); ++p) {
-      alloc[i]->release(p.get_start(), p.get_len());
+  } else {
+    dout(10) << __func__ << dendl;
+    utime_t start = ceph_clock_now();
+    vector<interval_set<uint64_t>> to_release(pending_release.size());
+    to_release.swap(pending_release);
+    flush_bdev(); // FIXME?
+    _flush_and_sync_log(l);
+    for (unsigned i = 0; i < to_release.size(); ++i) {
+      for (auto p = to_release[i].begin(); p != to_release[i].end(); ++p) {
+	alloc[i]->release(p.get_start(), p.get_len());
+      }
     }
+    utime_t end = ceph_clock_now();
+    utime_t dur = end - start;
+    dout(10) << __func__ << " done in " << dur << dendl;
   }
 
   if (_should_compact_log()) {
@@ -1903,10 +1906,6 @@ void BlueFS::sync_metadata()
       _compact_log_async(l);
     }
   }
-
-  utime_t end = ceph_clock_now();
-  utime_t dur = end - start;
-  dout(10) << __func__ << " done in " << dur << dendl;
 }
 
 int BlueFS::open_for_write(


### PR DESCRIPTION
It's possible that when sync_metadata() is called there won't be any new
log data to flush because it was already flushed for other reasons (e.g.,
because fsync was called).  However, the log may still be large and in
need of compaction.

Signed-off-by: Sage Weil <sage@redhat.com>