### PR TITLE
mon: safe check for 'ceph osd crush swap-bucket'

### DIFF
--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1035,6 +1035,15 @@ int CrushWrapper::detach_bucket(CephContext *cct, int item)
   return bucket_weight;
 }
 
+bool CrushWrapper::check_bucket_relation(crush_bucket *f, crush_bucket *tar){
+  if(!f->size)return false;
+  for(unsigned i=0; i<f->size; ++i){
+	if(f->items[i] == tar->id  ||  check_bucket_relation(get_bucket(f->items[i]), tar))
+	  return true;
+  }
+  return false;
+}
+
 int CrushWrapper::swap_bucket(CephContext *cct, int src, int dst)
 {
   if (src >= 0 || dst >= 0)
@@ -1043,6 +1052,11 @@ int CrushWrapper::swap_bucket(CephContext *cct, int src, int dst)
     return -EINVAL;
   crush_bucket *a = get_bucket(src);
   crush_bucket *b = get_bucket(dst);
+  
+  if(check_bucket_relation(a, b) || check_bucket_relation(b, a)){
+	return -EINVAL;
+  }
+
   unsigned aw = a->weight;
   unsigned bw = b->weight;
 

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -775,6 +775,7 @@ public:
    * @param dst bucket b
    * @return 0 for success, negative on error
    */
+  bool check_bucket_relation(crush_bucket *f, crush_bucket *tar);
   int swap_bucket(CephContext *cct, int src, int dst);
 
   /**


### PR DESCRIPTION
The swap method is just swap the two buckets'weight,son and name.So there is a problem when we swap parent and children. When swap two buckets,one should not be ancestor of the other,or there will be a loop,which would destory the structure.

Last version was with some unexpecting fault,so I went back and made it again.
[last time](https://github.com/ceph/ceph/pull/17335)

Signed-off-by: Carudy <zhaoyang.han@easystack.cn>