### PR TITLE
os/bluestore: do not core dump when BlueRocksEnv gets EEXIST error

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -16,6 +16,7 @@ rocksdb::Status err_to_status(int r)
   case -EINVAL:
     return rocksdb::Status::InvalidArgument(rocksdb::Status::kNone);
   case -EIO:
+  case -EEXIST:
     return rocksdb::Status::IOError(rocksdb::Status::kNone);
   default:
     // FIXME :(


### PR DESCRIPTION
in `rocksdb::repairdb`, rocksdb needs create a directory `lost` to archive all files.
we will get a EEXIST error when there is a `lost` directory already.

Fixes: http://tracker.ceph.com/issues/20871

Signed-off-by: liuchang0812 <liuchang0812@gmail.com>

