### PR TITLE
luminous: ceph_release: luminous is now 'stable' (12.2.x)

### DIFF
--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
 12
 luminous
-rc
+stable


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>