### PR TITLE
ceph-disk: unlock all partitions when activate

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -3761,23 +3761,18 @@ def main_activate(args):
             osd_data = get_mount_point(cluster, osd_id)
 
             args.cluster = cluster
-
-            # Check if encrypted block device in journal
-
-            block_dmcrypt_path = os.path.join(osd_data, 'block_dmcrypt')
-
-            if args.dmcrypt and os.path.exists(block_dmcrypt_path):
-                partition = DevicePartition.factory(
-                    path=None,
-                    dev=os.path.join(osd_data, 'block_dmcrypt'),
-                    args=args)
-
-                partition.osd_dm_key = get_dmcrypt_key(
-                    get_partition_uuid(args.path),
-                    args.dmcrypt_key_dir,
-                    CryptHelpers.get_dmcrypt_type(args) == "luks")
-
-                partition.map()
+            if args.dmcrypt:
+                for name in Space.NAMES:
+                    # Check if encrypted device in journal
+                    dev_path = os.path.join(osd_data, name + '_dmcrypt')
+                    if not os.path.exists(dev_path):
+                        continue
+                    partition = DevicePartition.factory(
+                        path=None,
+                        dev=dev_path,
+                        args=args)
+                    partition.rawdev = args.path
+                    partition.map()
 
         elif stat.S_ISDIR(mode):
             (cluster, osd_id) = activate_dir(


### PR DESCRIPTION
should unlock all dmcrypted partitions when activating a device.

Signed-off-by: Kefu Chai <kchai@redhat.com>