### PR TITLE
rgw: http client cleanup, streaming writes

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -6235,7 +6235,7 @@ next:
 
     RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
     RGWHTTPManager http(store->ctx(), crs.get_completion_mgr());
-    int ret = http.set_threaded();
+    int ret = http.start();
     if (ret < 0) {
       cerr << "failed to initialize http client with " << cpp_strerror(ret) << std::endl;
       return -ret;

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1619,7 +1619,7 @@ static int send_to_url(const string& url, const string& access,
   key.key = secret;
 
   param_vec_t params;
-  RGWRESTSimpleRequest req(g_ceph_context, url, NULL, &params);
+  RGWRESTSimpleRequest req(g_ceph_context, info.method, url, NULL, &params);
 
   bufferlist response;
   int ret = req.forward_request(key, info, MAX_REST_RESPONSE, &in_data, &response);

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1041,6 +1041,7 @@ public:
   explicit StoreDestructor(RGWRados *_s) : store(_s) {}
   ~StoreDestructor() {
     RGWStoreManager::close_storage(store);
+    rgw_http_client_cleanup();
   }
 };
 
@@ -2944,6 +2945,7 @@ int main(int argc, const char **argv)
 
   rgw_user_init(store);
   rgw_bucket_init(store->meta_mgr);
+  rgw_http_client_init(g_ceph_context);
 
   StoreDestructor store_destructor(store);
 

--- a/src/rgw/rgw_auth_keystone.cc
+++ b/src/rgw/rgw_auth_keystone.cc
@@ -70,7 +70,7 @@ TokenEngine::get_from_keystone(const std::string& token) const
   /* The container for plain response obtained from Keystone. It will be
    * parsed token_envelope_t::parse method. */
   ceph::bufferlist token_body_bl;
-  RGWValidateKeystoneToken validate(cct, &token_body_bl);
+  RGWValidateKeystoneToken validate(cct, "GET", "", &token_body_bl);
 
   std::string url = config.get_endpoint_url();
   if (url.empty()) {
@@ -94,7 +94,9 @@ TokenEngine::get_from_keystone(const std::string& token) const
   validate.append_header("X-Auth-Token", admin_token);
   validate.set_send_length(0);
 
-  int ret = validate.process(url.c_str());
+  validate.set_url(url);
+
+  int ret = validate.process();
   if (ret < 0) {
     throw ret;
   }
@@ -322,7 +324,7 @@ EC2Engine::get_from_keystone(const boost::string_view& access_key_id,
   /* The container for plain response obtained from Keystone. It will be
    * parsed token_envelope_t::parse method. */
   ceph::bufferlist token_body_bl;
-  RGWValidateKeystoneToken validate(cct, &token_body_bl);
+  RGWValidateKeystoneToken validate(cct, "POST", keystone_url, &token_body_bl);
 
   /* set required headers for keystone request */
   validate.append_header("X-Auth-Token", admin_token);
@@ -347,7 +349,7 @@ EC2Engine::get_from_keystone(const boost::string_view& access_key_id,
   validate.set_send_length(os.str().length());
 
   /* send request */
-  ret = validate.process("POST", keystone_url.c_str());
+  ret = validate.process();
   if (ret < 0) {
     ldout(cct, 2) << "s3 keystone: token validation ERROR: "
                   << token_body_bl.c_str() << dendl;

--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -860,11 +860,11 @@ static int request_key_from_barbican(CephContext *cct,
   secret_url += "v1/secrets/" + std::string(key_id);
 
   bufferlist secret_bl;
-  RGWHTTPTransceiver secret_req(cct, &secret_bl);
+  RGWHTTPTransceiver secret_req(cct, "GET", secret_url, &secret_bl);
   secret_req.append_header("Accept", "application/octet-stream");
   secret_req.append_header("X-Auth-Token", barbican_token);
 
-  res = secret_req.process("GET", secret_url.c_str());
+  res = secret_req.process();
   if (res < 0) {
     return res;
   }

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -619,9 +619,9 @@ int RGWRemoteDataLog::init(const string& _source_zone, RGWRESTConn *_conn, RGWSy
     return 0;
   }
 
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
 
@@ -640,9 +640,9 @@ int RGWRemoteDataLog::read_sync_status(rgw_data_sync_status *sync_status)
   // cannot run concurrently with run_sync(), so run in a separate manager
   RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
   RGWHTTPManager http_manager(store->ctx(), crs.get_completion_mgr());
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
   RGWDataSyncEnv sync_env_local = sync_env;
@@ -657,9 +657,9 @@ int RGWRemoteDataLog::init_sync_status(int num_shards)
   rgw_data_sync_status sync_status;
   RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
   RGWHTTPManager http_manager(store->ctx(), crs.get_completion_mgr());
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
   RGWDataSyncEnv sync_env_local = sync_env;
@@ -2852,9 +2852,9 @@ int RGWBucketSyncStatusManager::init()
     return -EINVAL;
   }
 
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
 

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -263,7 +263,7 @@ class RGWHTTPManager {
   CephContext *cct;
   RGWCompletionManager *completion_mgr;
   void *multi_handle;
-  bool is_threaded;
+  bool is_started;
   std::atomic<unsigned> going_down { 0 };
   std::atomic<unsigned> is_stopped { 0 };
 
@@ -307,7 +307,7 @@ public:
   RGWHTTPManager(CephContext *_cct, RGWCompletionManager *completion_mgr = NULL);
   ~RGWHTTPManager();
 
-  int set_threaded();
+  int start();
   void stop();
 
   int add_request(RGWHTTPClient *client, bool send_data_hint = false);

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -14,6 +14,9 @@
 using param_pair_t = pair<string, string>;
 using param_vec_t = vector<param_pair_t>;
 
+void rgw_http_client_init(CephContext *cct);
+void rgw_http_client_cleanup();
+
 struct rgw_http_req_data;
 class RGWHTTPManager;
 
@@ -317,4 +320,10 @@ public:
   int complete_requests();
 };
 
+class RGWHTTP
+{
+public:
+  static int send(RGWHTTPClient *req);
+  static int process(RGWHTTPClient *req);
+};
 #endif

--- a/src/rgw/rgw_http_client.h
+++ b/src/rgw/rgw_http_client.h
@@ -313,11 +313,6 @@ public:
   int add_request(RGWHTTPClient *client, bool send_data_hint = false);
   int remove_request(RGWHTTPClient *client);
   int set_request_state(RGWHTTPClient *client, RGWHTTPRequestSetState state);
-
-  /* only for non threaded case */
-  int process_requests(bool wait_for_data, bool *done);
-
-  int complete_requests();
 };
 
 class RGWHTTP

--- a/src/rgw/rgw_keystone.h
+++ b/src/rgw/rgw_keystone.h
@@ -109,8 +109,10 @@ public:
   class RGWKeystoneHTTPTransceiver : public RGWHTTPTransceiver {
   public:
     RGWKeystoneHTTPTransceiver(CephContext * const cct,
+                               const string& method,
+                               const string& url,
                                bufferlist * const token_body_bl)
-      : RGWHTTPTransceiver(cct, token_body_bl,
+      : RGWHTTPTransceiver(cct, method, url, token_body_bl,
                            cct->_conf->rgw_keystone_verify_ssl,
                            { "X-Subject-Token" }) {
     }

--- a/src/rgw/rgw_main.cc
+++ b/src/rgw/rgw_main.cc
@@ -319,8 +319,8 @@ int main(int argc, const char **argv)
   }
 
   rgw_init_resolver();
-  
-  curl_global_init(CURL_GLOBAL_ALL);
+
+  rgw_http_client_init(g_ceph_context);
   
 #if defined(WITH_RADOSGW_FCGI_FRONTEND)
   FCGX_Init();
@@ -596,7 +596,7 @@ int main(int argc, const char **argv)
 
   rgw_tools_cleanup();
   rgw_shutdown_resolver();
-  curl_global_cleanup();
+  rgw_http_client_cleanup();
 
   rgw_perf_stop(g_ceph_context);
 

--- a/src/rgw/rgw_period_pusher.cc
+++ b/src/rgw/rgw_period_pusher.cc
@@ -136,8 +136,8 @@ class RGWPeriodPusher::CRThread {
       http(cct, coroutines.get_completion_mgr()),
       push_all(new PushAllCR(cct, &http, std::move(period), std::move(conns)))
   {
-    http.set_threaded();
-    // must spawn the CR thread after set_threaded
+    http.start();
+    // must spawn the CR thread after start
     thread = std::thread([this] { coroutines.run(push_all.get()); });
   }
   ~CRThread()

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7899,7 +7899,7 @@ int RGWRados::copy_obj_to_remote_dest(RGWObjState *astate,
 {
   string etag;
 
-  RGWRESTStreamWriteRequest *out_stream_req;
+  RGWRESTStreamS3PutObj *out_stream_req;
 
   int ret = rest_master_conn->put_obj_init(user_id, dest_obj, astate->size, src_attrs, &out_stream_req);
   if (ret < 0) {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2913,7 +2913,7 @@ class RGWMetaNotifierManager : public RGWCoroutinesManager {
 public:
   RGWMetaNotifierManager(RGWRados *_store) : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()), store(_store),
                                              http_manager(store->ctx(), completion_mgr) {
-    http_manager.set_threaded();
+    http_manager.start();
   }
 
   int notify_all(map<string, RGWRESTConn *>& conn_map, set<int>& shards) {
@@ -2940,7 +2940,7 @@ class RGWDataNotifierManager : public RGWCoroutinesManager {
 public:
   RGWDataNotifierManager(RGWRados *_store) : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()), store(_store),
                                              http_manager(store->ctx(), completion_mgr) {
-    http_manager.set_threaded();
+    http_manager.start();
   }
 
   int notify_all(map<string, RGWRESTConn *>& conn_map, map<int, set<string> >& shards) {
@@ -3260,7 +3260,7 @@ public:
   {}
 
   int init() override {
-    return http.set_threaded();
+    return http.start();
   }
   int process() override {
     list<RGWCoroutinesStack*> stacks;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -777,15 +777,30 @@ int RGWRESTStreamRWRequest::receive_data(void *ptr, size_t len)
   return len;
 }
 
-int RGWRESTStreamRWRequest::send_data(void *ptr, size_t len)
+void RGWRESTStreamRWRequest::add_send_data(bufferlist& bl)
 {
+  Mutex::Locker req_locker(get_req_lock());
+  Mutex::Locker wl(write_lock);
+  outbl.claim_append(bl);
+  _set_write_paused(false);
+}
+
+int RGWRESTStreamRWRequest::send_data(void *ptr, size_t len, bool *pause)
+{
+  Mutex::Locker wl(write_lock);
+
   if (outbl.length() == 0) {
+    *pause = true;
     return 0;
   }
 
-  uint64_t send_size = min(len, (size_t)(outbl.length() - write_ofs));
+  len = std::min(len, (size_t)outbl.length());
+
+  bufferlist bl;
+  outbl.splice(0, len, &bl);
+  uint64_t send_size = bl.length();
   if (send_size > 0) {
-    memcpy(ptr, outbl.c_str() + write_ofs, send_size);
+    memcpy(ptr, bl.c_str(), send_size);
     write_ofs += send_size;
   }
   return send_size;

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -102,8 +102,9 @@ static void get_new_date_str(string& date_str)
   date_str = rgw_to_asctime(ceph_clock_now());
 }
 
-int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const char *resource)
+int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *_method, const char *resource)
 {
+  method = _method;
   string new_url = url;
   string new_resource = resource;
 
@@ -114,6 +115,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const c
     new_resource.append(resource);
   }
   new_url.append(new_resource);
+  url = new_url;
 
   string date_str;
   get_new_date_str(date_str);
@@ -122,8 +124,8 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const c
   string canonical_header;
   map<string, string> meta_map;
   map<string, string> sub_resources;
-  rgw_create_s3_canonical_header(method, NULL, NULL, date_str.c_str(),
-                            meta_map, new_url.c_str(), sub_resources,
+  rgw_create_s3_canonical_header(method.c_str(), NULL, NULL, date_str.c_str(),
+                            meta_map, url.c_str(), sub_resources,
                             canonical_header);
 
   string digest;
@@ -138,7 +140,7 @@ int RGWRESTSimpleRequest::execute(RGWAccessKey& key, const char *method, const c
   ldout(cct, 15) << "generated auth header: " << auth_hdr << dendl;
 
   headers.push_back(pair<string, string>("AUTHORIZATION", auth_hdr));
-  int r = process(method, new_url.c_str());
+  int r = process();
   if (r < 0)
     return r;
 
@@ -292,7 +294,10 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
     set_send_length(inbl->length());
   }
 
-  int r = process(new_info.method, new_url.c_str());
+  method = new_info.method;
+  url = new_url;
+
+  int r = process();
   if (r < 0){
     if (r == -EINVAL){
       // curl_easy has errored, generally means the service is not available
@@ -492,7 +497,10 @@ int RGWRESTStreamWriteRequest::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uin
 
   set_send_length(obj_size);
 
-  int r = http_manager.add_request(this, new_info.method, new_url.c_str());
+  method = new_info.method;
+  url = new_url;
+
+  int r = http_manager.add_request(this);
   if (r < 0)
     return r;
 
@@ -654,7 +662,7 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
     new_env.set(iter->first.c_str(), iter->second.c_str());
   }
 
-  new_info.method = method;
+  new_info.method = method.c_str();
 
   new_info.script_uri = "/";
   new_info.script_uri.append(new_resource);
@@ -676,7 +684,7 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
 
   bool send_data_hint = false;
   if (send_data) {
-    outbl.claim(*send_data);
+    set_outbl(*send_data);
     send_data_hint = true;
   }
 
@@ -685,7 +693,10 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
     pmanager = mgr;
   }
 
-  int r = pmanager->add_request(this, new_info.method, new_url.c_str(), send_data_hint);
+  method = new_info.method;
+  url = new_url;
+
+  int r = pmanager->add_request(this, send_data_hint);
   if (r < 0)
     return r;
 
@@ -750,7 +761,7 @@ int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uin
   return status;
 }
 
-int RGWRESTStreamRWRequest::handle_header(const string& name, const string& val)
+int RGWHTTPStreamRWRequest::handle_header(const string& name, const string& val)
 {
   if (name == "RGWX_EMBEDDED_METADATA_LEN") {
     string err;
@@ -765,7 +776,7 @@ int RGWRESTStreamRWRequest::handle_header(const string& name, const string& val)
   return 0;
 }
 
-int RGWRESTStreamRWRequest::receive_data(void *ptr, size_t len)
+int RGWHTTPStreamRWRequest::receive_data(void *ptr, size_t len)
 {
   bufferptr bp((const char *)ptr, len);
   bufferlist bl;
@@ -777,12 +788,12 @@ int RGWRESTStreamRWRequest::receive_data(void *ptr, size_t len)
   return len;
 }
 
-void RGWRESTStreamRWRequest::set_stream_write(bool s) {
+void RGWHTTPStreamRWRequest::set_stream_write(bool s) {
   Mutex::Locker wl(write_lock);
   stream_writes = s;
 }
 
-void RGWRESTStreamRWRequest::add_send_data(bufferlist& bl)
+void RGWHTTPStreamRWRequest::add_send_data(bufferlist& bl)
 {
   Mutex::Locker req_locker(get_req_lock());
   Mutex::Locker wl(write_lock);
@@ -790,7 +801,7 @@ void RGWRESTStreamRWRequest::add_send_data(bufferlist& bl)
   _set_write_paused(false);
 }
 
-void RGWRESTStreamRWRequest::finish_write()
+void RGWHTTPStreamRWRequest::finish_write()
 {
   Mutex::Locker req_locker(get_req_lock());
   Mutex::Locker wl(write_lock);
@@ -798,7 +809,7 @@ void RGWRESTStreamRWRequest::finish_write()
   _set_write_paused(false);
 }
 
-int RGWRESTStreamRWRequest::send_data(void *ptr, size_t len, bool *pause)
+int RGWHTTPStreamRWRequest::send_data(void *ptr, size_t len, bool *pause)
 {
   Mutex::Locker wl(write_lock);
 

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -777,6 +777,11 @@ int RGWRESTStreamRWRequest::receive_data(void *ptr, size_t len)
   return len;
 }
 
+void RGWRESTStreamRWRequest::set_stream_write(bool s) {
+  Mutex::Locker wl(write_lock);
+  stream_writes = s;
+}
+
 void RGWRESTStreamRWRequest::add_send_data(bufferlist& bl)
 {
   Mutex::Locker req_locker(get_req_lock());
@@ -785,12 +790,22 @@ void RGWRESTStreamRWRequest::add_send_data(bufferlist& bl)
   _set_write_paused(false);
 }
 
+void RGWRESTStreamRWRequest::finish_write()
+{
+  Mutex::Locker req_locker(get_req_lock());
+  Mutex::Locker wl(write_lock);
+  write_stream_complete = true;
+  _set_write_paused(false);
+}
+
 int RGWRESTStreamRWRequest::send_data(void *ptr, size_t len, bool *pause)
 {
   Mutex::Locker wl(write_lock);
 
   if (outbl.length() == 0) {
-    *pause = true;
+    if (stream_writes && !write_stream_complete) {
+      *pause = true;
+    }
     return 0;
   }
 

--- a/src/rgw/rgw_rest_client.cc
+++ b/src/rgw/rgw_rest_client.cc
@@ -316,9 +316,9 @@ int RGWRESTSimpleRequest::forward_request(RGWAccessKey& key, req_info& info, siz
 }
 
 class RGWRESTStreamOutCB : public RGWGetDataCB {
-  RGWRESTStreamWriteRequest *req;
+  RGWRESTStreamS3PutObj *req;
 public:
-  explicit RGWRESTStreamOutCB(RGWRESTStreamWriteRequest *_req) : req(_req) {}
+  explicit RGWRESTStreamOutCB(RGWRESTStreamS3PutObj *_req) : req(_req) {}
   int handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len) override; /* callback for object iteration when sending data */
 };
 
@@ -326,34 +326,21 @@ int RGWRESTStreamOutCB::handle_data(bufferlist& bl, off_t bl_ofs, off_t bl_len)
 {
   dout(20) << "RGWRESTStreamOutCB::handle_data bl.length()=" << bl.length() << " bl_ofs=" << bl_ofs << " bl_len=" << bl_len << dendl;
   if (!bl_ofs && bl_len == bl.length()) {
-    return req->add_output_data(bl);
+    req->add_send_data(bl);
+    return 0;
   }
 
   bufferptr bp(bl.c_str() + bl_ofs, bl_len);
   bufferlist new_bl;
   new_bl.push_back(bp);
 
-  return req->add_output_data(new_bl);
+  req->add_send_data(new_bl);
+  return 0;
 }
 
-RGWRESTStreamWriteRequest::~RGWRESTStreamWriteRequest()
+RGWRESTStreamS3PutObj::~RGWRESTStreamS3PutObj()
 {
-  delete cb;
-}
-
-int RGWRESTStreamWriteRequest::add_output_data(bufferlist& bl)
-{
-  lock.Lock();
-  if (status < 0) {
-    int ret = status;
-    lock.Unlock();
-    return ret;
-  }
-  pending_send.push_back(bl);
-  lock.Unlock();
-
-  bool done;
-  return http_manager.process_requests(false, &done);
+  delete out_cb;
 }
 
 static void grants_by_type_add_one_grant(map<int, string>& grants_by_type, int perm, ACLGrant& grant)
@@ -426,7 +413,7 @@ static void add_grants_headers(map<int, string>& grants, RGWEnv& env, map<string
   }
 }
 
-int RGWRESTStreamWriteRequest::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uint64_t obj_size, map<string, bufferlist>& attrs)
+int RGWRESTStreamS3PutObj::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uint64_t obj_size, map<string, bufferlist>& attrs)
 {
   string resource = obj.bucket.name + "/" + obj.get_oid();
   string new_url = url;
@@ -493,65 +480,19 @@ int RGWRESTStreamWriteRequest::put_obj_init(RGWAccessKey& key, rgw_obj& obj, uin
     headers.emplace_back(kv);
   }
 
-  cb = new RGWRESTStreamOutCB(this);
+  out_cb = new RGWRESTStreamOutCB(this);
 
   set_send_length(obj_size);
 
   method = new_info.method;
   url = new_url;
 
-  int r = http_manager.add_request(this);
+  int r = RGWHTTP::send(this);
   if (r < 0)
     return r;
 
   return 0;
 }
-
-int RGWRESTStreamWriteRequest::send_data(void *ptr, size_t len)
-{
-  uint64_t sent = 0;
-
-  dout(20) << "RGWRESTStreamWriteRequest::send_data()" << dendl;
-  lock.Lock();
-  if (pending_send.empty() || status < 0) {
-    lock.Unlock();
-    return status;
-  }
-
-  list<bufferlist>::iterator iter = pending_send.begin();
-  while (iter != pending_send.end() && len > 0) {
-    bufferlist& bl = *iter;
-    
-    list<bufferlist>::iterator next_iter = iter;
-    ++next_iter;
-    lock.Unlock();
-
-    uint64_t send_len = min(len, (size_t)bl.length());
-
-    memcpy(ptr, bl.c_str(), send_len);
-
-    ptr = (char *)ptr + send_len;
-    len -= send_len;
-    sent += send_len;
-
-    lock.Lock();
-
-    bufferlist new_bl;
-    if (bl.length() > send_len) {
-      bufferptr bp(bl.c_str() + send_len, bl.length() - send_len);
-      new_bl.append(bp);
-    }
-    pending_send.pop_front(); /* need to do this after we copy data from bl */
-    if (new_bl.length()) {
-      pending_send.push_front(new_bl);
-    }
-    iter = next_iter;
-  }
-  lock.Unlock();
-
-  return sent;
-}
-
 
 void set_str_from_headers(map<string, string>& out_headers, const string& header_name, string& str)
 {
@@ -594,26 +535,6 @@ static int parse_rgwx_mtime(CephContext *cct, const string& s, ceph::real_time *
   return 0;
 }
 
-int RGWRESTStreamWriteRequest::complete(string& etag, real_time *mtime)
-{
-  int ret = http_manager.complete_requests();
-  if (ret < 0)
-    return ret;
-
-  set_str_from_headers(out_headers, "ETAG", etag);
-
-  if (mtime) {
-    string mtime_str;
-    set_str_from_headers(out_headers, "RGWX_MTIME", mtime_str);
-
-    ret = parse_rgwx_mtime(cct, mtime_str, mtime);
-    if (ret < 0) {
-      return ret;
-    }
-  }
-  return status;
-}
-
 int RGWRESTStreamRWRequest::send_request(RGWAccessKey& key, map<string, string>& extra_headers, rgw_obj& obj, RGWHTTPManager *mgr)
 {
   string urlsafe_bucket, urlsafe_object;
@@ -621,11 +542,11 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey& key, map<string, string>&
   url_encode(obj.key.name, urlsafe_object);
   string resource = urlsafe_bucket + "/" + urlsafe_object;
 
-  return send_request(&key, extra_headers, resource, nullptr, mgr);
+  return send_request(&key, extra_headers, resource, mgr);
 }
 
 int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>& extra_headers, const string& resource,
-                                         bufferlist *send_data, RGWHTTPManager *mgr)
+                                         RGWHTTPManager *mgr, bufferlist *send_data)
 {
   string new_url = url;
   if (new_url[new_url.size() - 1] != '/')
@@ -688,29 +609,26 @@ int RGWRESTStreamRWRequest::send_request(RGWAccessKey *key, map<string, string>&
     send_data_hint = true;
   }
 
-  RGWHTTPManager *pmanager = &http_manager;
-  if (mgr) {
-    pmanager = mgr;
-  }
-
   method = new_info.method;
   url = new_url;
 
-  int r = pmanager->add_request(this, send_data_hint);
+  if (!mgr) {
+    return RGWHTTP::send(this);
+  }
+
+  int r = mgr->add_request(this, send_data_hint);
   if (r < 0)
     return r;
-
-  if (!mgr) {
-    r = pmanager->complete_requests();
-    if (r < 0)
-      return r;
-  }
 
   return 0;
 }
 
 int RGWRESTStreamRWRequest::complete_request(string& etag, real_time *mtime, uint64_t *psize, map<string, string>& attrs)
 {
+  int ret = wait();
+  if (ret < 0) {
+    return ret;
+  }
   set_str_from_headers(out_headers, "ETAG", etag);
   if (status >= 0) {
     if (mtime) {

--- a/src/rgw/rgw_rest_client.h
+++ b/src/rgw/rgw_rest_client.h
@@ -94,6 +94,8 @@ class RGWRESTStreamRWRequest : public RGWRESTSimpleRequest {
   const char *method;
   uint64_t write_ofs{0};
   bool send_paused{false};
+  bool stream_writes{false};
+  bool write_stream_complete{false};
 protected:
   int handle_header(const string& name, const string& val) override;
 public:
@@ -117,6 +119,11 @@ public:
   void set_in_cb(RGWGetDataCB *_cb) { cb = _cb; }
 
   void add_send_data(bufferlist& bl);
+
+  void set_stream_write(bool s);
+
+  /* finish streaming writes */
+  void finish_write();
 };
 
 class RGWRESTStreamReadRequest : public RGWRESTStreamRWRequest {

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -105,7 +105,7 @@ public:
 };
 
 int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_size,
-                                      map<string, bufferlist>& attrs, RGWRESTStreamWriteRequest **req)
+                                      map<string, bufferlist>& attrs, RGWRESTStreamS3PutObj **req)
 {
   string url;
   int ret = get_url(url);
@@ -114,7 +114,7 @@ int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_si
 
   param_vec_t params;
   populate_params(params, &uid, self_zone_group);
-  RGWRESTStreamWriteRequest *wr = new RGWRESTStreamWriteRequest(cct, "PUT", url, NULL, &params);
+  RGWRESTStreamS3PutObj *wr = new RGWRESTStreamS3PutObj(cct, "PUT", url, NULL, &params);
   ret = wr->put_obj_init(key, obj, obj_size, attrs);
   if (ret < 0) {
     delete wr;
@@ -124,9 +124,10 @@ int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_si
   return 0;
 }
 
-int RGWRESTConn::complete_request(RGWRESTStreamWriteRequest *req, string& etag, real_time *mtime)
+int RGWRESTConn::complete_request(RGWRESTStreamS3PutObj *req, string& etag, real_time *mtime)
 {
-  int ret = req->complete(etag, mtime);
+  map<string, string> attrs;
+  int ret = req->complete_request(etag, mtime, nullptr, attrs);
   delete req;
 
   return ret;
@@ -212,7 +213,7 @@ int RGWRESTConn::get_obj(const rgw_user& uid, req_info *info /* optional */, rgw
     set_header(mod_pg_ver, extra_headers, "HTTP_DEST_PG_VER");
   }
 
-  int r = (*req)->send_request(key, extra_headers, obj);
+  int r = (*req)->send_request(key, extra_headers, obj, nullptr);
   if (r < 0) {
     delete *req;
     *req = nullptr;
@@ -259,7 +260,7 @@ int RGWRESTConn::get_resource(const string& resource,
     headers.insert(extra_headers->begin(), extra_headers->end());
   }
 
-  ret = req.send_request(&key, headers, resource, send_data, mgr);
+  ret = req.send_request(&key, headers, resource, mgr, send_data);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -306,7 +307,7 @@ void RGWRESTReadResource::init_common(param_vec_t *extra_headers)
 
 int RGWRESTReadResource::read()
 {
-  int ret = req.send_request(&conn->get_key(), headers, resource, nullptr, mgr);
+  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -319,7 +320,7 @@ int RGWRESTReadResource::read()
 
 int RGWRESTReadResource::aio_read()
 {
-  int ret = req.send_request(&conn->get_key(), headers, resource, nullptr, mgr);
+  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -367,7 +368,7 @@ void RGWRESTSendResource::init_common(param_vec_t *extra_headers)
 int RGWRESTSendResource::send(bufferlist& outbl)
 {
   req.set_outbl(outbl);
-  int ret = req.send_request(&conn->get_key(), headers, resource, nullptr, mgr);
+  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;
@@ -381,7 +382,7 @@ int RGWRESTSendResource::send(bufferlist& outbl)
 int RGWRESTSendResource::aio_send(bufferlist& outbl)
 {
   req.set_outbl(outbl);
-  int ret = req.send_request(&conn->get_key(), headers, resource, nullptr, mgr);
+  int ret = req.send_request(&conn->get_key(), headers, resource, mgr);
   if (ret < 0) {
     ldout(cct, 5) << __func__ << ": send_request() resource=" << resource << " returned ret=" << ret << dendl;
     return ret;

--- a/src/rgw/rgw_rest_conn.cc
+++ b/src/rgw/rgw_rest_conn.cc
@@ -94,7 +94,7 @@ int RGWRESTConn::forward(const rgw_user& uid, req_info& info, obj_version *objv,
     snprintf(buf, sizeof(buf), "%lld", (long long)objv->ver);
     params.push_back(param_pair_t(RGW_SYS_PARAM_PREFIX "ver", buf));
   }
-  RGWRESTSimpleRequest req(cct, url, NULL, &params);
+  RGWRESTSimpleRequest req(cct, info.method, url, NULL, &params);
   return req.forward_request(key, info, max_response, inbl, outbl);
 }
 
@@ -114,7 +114,7 @@ int RGWRESTConn::put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_si
 
   param_vec_t params;
   populate_params(params, &uid, self_zone_group);
-  RGWRESTStreamWriteRequest *wr = new RGWRESTStreamWriteRequest(cct, url, NULL, &params);
+  RGWRESTStreamWriteRequest *wr = new RGWRESTStreamWriteRequest(cct, "PUT", url, NULL, &params);
   ret = wr->put_obj_init(key, obj, obj_size, attrs);
   if (ret < 0) {
     delete wr;

--- a/src/rgw/rgw_rest_conn.h
+++ b/src/rgw/rgw_rest_conn.h
@@ -87,8 +87,8 @@ public:
 
   /* async request */
   int put_obj_init(const rgw_user& uid, rgw_obj& obj, uint64_t obj_size,
-                   map<string, bufferlist>& attrs, RGWRESTStreamWriteRequest **req);
-  int complete_request(RGWRESTStreamWriteRequest *req, string& etag, ceph::real_time *mtime);
+                   map<string, bufferlist>& attrs, RGWRESTStreamS3PutObj **req);
+  int complete_request(RGWRESTStreamS3PutObj *req, string& etag, ceph::real_time *mtime);
 
   int get_obj(const rgw_user& uid, req_info *info /* optional */, rgw_obj& obj,
               const ceph::real_time *mod_ptr, const ceph::real_time *unmod_ptr,

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -375,11 +375,11 @@ ExternalTokenEngine::authenticate(const std::string& token,
   char url_buf[auth_url.size() + 1 + token.length() + 1];
   sprintf(url_buf, "%s/%s", auth_url.c_str(), token.c_str());
 
-  RGWHTTPHeadersCollector validator(cct, { "X-Auth-Groups", "X-Auth-Ttl" });
+  RGWHTTPHeadersCollector validator(cct, "GET", url_buf, { "X-Auth-Groups", "X-Auth-Ttl" });
 
   ldout(cct, 10) << "rgw_swift_validate_token url=" << url_buf << dendl;
 
-  int ret = validator.process(url_buf);
+  int ret = validator.process();
   if (ret < 0) {
     throw ret;
   }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -276,9 +276,9 @@ int RGWRemoteMetaLog::init()
 {
   conn = store->rest_master_conn;
 
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
 
@@ -1909,9 +1909,9 @@ int RGWRemoteMetaLog::read_sync_status(rgw_meta_sync_status *sync_status)
   // cannot run concurrently with run_sync(), so run in a separate manager
   RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
   RGWHTTPManager http_manager(store->ctx(), crs.get_completion_mgr());
-  int ret = http_manager.set_threaded();
+  int ret = http_manager.start();
   if (ret < 0) {
-    ldout(store->ctx(), 0) << "failed in http_manager.set_threaded() ret=" << ret << dendl;
+    ldout(store->ctx(), 0) << "failed in http_manager.start() ret=" << ret << dendl;
     return ret;
   }
   RGWMetaSyncEnv sync_env_local = sync_env;

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -23,7 +23,7 @@ TEST(HTTPManager, SignalThread)
   auto cct = g_ceph_context;
   RGWHTTPManager http(cct);
 
-  ASSERT_EQ(0, http.set_threaded());
+  ASSERT_EQ(0, http.start());
 
   // default pipe buffer size according to man pipe
   constexpr size_t max_pipe_buffer_size = 65536;

--- a/src/test/rgw/test_http_manager.cc
+++ b/src/test/rgw/test_http_manager.cc
@@ -38,8 +38,8 @@ TEST(HTTPManager, SignalThread)
   constexpr size_t num_requests = max_requests + 1;
 
   for (size_t i = 0; i < num_requests; i++) {
-    RGWHTTPClient client{cct};
-    http.add_request(&client, "PUT", "http://127.0.0.1:80");
+    RGWHTTPClient client{cct, "PUT", "http://127.0.0.1:80"};
+    http.add_request(&client);
   }
 }
 


### PR DESCRIPTION
 - remove the non-threaded case for http manager
 - have a global http manager instance (used instead of the non-threaded case)
 - api modifications, cleanups
 - new http client api that supports streaming writes