### PR TITLE
rgw: unreachable return in RGWRados::trim_bi_log_entries

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -12457,8 +12457,6 @@ int RGWRados::trim_bi_log_entries(RGWBucketInfo& bucket_info, int shard_id, stri
 
   return CLSRGWIssueBILogTrim(index_ctx, start_marker_mgr, end_marker_mgr, bucket_objs,
 			      cct->_conf->rgw_bucket_index_max_aio)();
-
-  return r;
 }
 
 int RGWRados::resync_bi_log_entries(RGWBucketInfo& bucket_info, int shard_id)


### PR DESCRIPTION
Fixes the coverity issue:

** 1412618 Structurally dead code
>CID 1412618 (#1 of 1): Structurally dead code (UNREACHABLE)
>unreachable: This code cannot be reached: return r;

Signed-off-by: Amit Kumar <amitkuma@redhat.com>