### PR TITLE
mon/PGMap: nice numbers for 'data' section of 'ceph df' command

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -172,11 +172,11 @@ void PGMapDigest::print_summary(Formatter *f, ostream *out) const
     *out << "    pools:   " << pg_pool_sum.size() << " pools, "
          << num_pg << " pgs\n";
     *out << "    objects: " << si_t(pg_sum.stats.sum.num_objects) << " objects, "
-         << prettybyte_t(pg_sum.stats.sum.num_bytes) << "\n";
+         << si_t(pg_sum.stats.sum.num_bytes) << "\n";
     *out << "    usage:   "
-         << kb_t(osd_sum.kb_used) << " used, "
-         << kb_t(osd_sum.kb_avail) << " / "
-         << kb_t(osd_sum.kb) << " avail\n";
+         << si_t(osd_sum.kb_used << 10) << " used, "
+         << si_t(osd_sum.kb_avail << 10) << " / "
+         << si_t(osd_sum.kb << 10) << " avail\n";
     *out << "    pgs:     ";
   }
 


### PR DESCRIPTION
Was:
```
---------------------------------------------------
  data:
    pools:   3 pools, 32 pgs
    objects: 311 objects, 1156 MB
    usage:   10024 MB used, 51799 MB / 61823 MB avail
    pgs:     32 active+clean
```

Now:
```
---------------------------------------------------
  data:
    pools:   3 pools, 32 pgs
    objects: 311 objects, 1.13G
    usage:   9.78G used, 50.6G / 60.4G avail
    pgs:     32 active+clean
```

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>