### PR TITLE
test: Initialization of *comp_racing_read class CopyFromOp

### DIFF
--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1833,7 +1833,7 @@ public:
   librados::ObjectWriteOperation op;
   librados::ObjectReadOperation rd_op;
   librados::AioCompletion *comp;
-  librados::AioCompletion *comp_racing_read;
+  librados::AioCompletion *comp_racing_read = nullptr;
   ceph::shared_ptr<int> in_use;
   int snap;
   int done;


### PR DESCRIPTION
Fixes the coverity issue:

** 1396111 Uninitialized pointer field
>CID 1396111 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member comp_racing_read is
not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>