### PR TITLE
test/rgw: fix test_encrypted_object_sync for 3+ zones

### DIFF
--- a/src/test/rgw/rgw_multi/tests.py
+++ b/src/test/rgw/rgw_multi/tests.py
@@ -935,7 +935,7 @@ def test_encrypted_object_sync():
     zonegroup = realm.master_zonegroup()
     zonegroup_conns = ZonegroupConns(zonegroup)
 
-    (zone1, zone2,) = zonegroup_conns.rw_zones
+    (zone1, zone2) = zonegroup_conns.rw_zones[0:2]
 
     # create a bucket on the first zone
     bucket_name = gen_bucket_name()


### PR DESCRIPTION
new test is failing in the multisite suite with `three-zone.yaml` because I can't write python:
```
======================================================================
ERROR: tasks.rgw_multi.tests.test_encrypted_object_sync
----------------------------------------------------------------------
2017-08-30T03:28:21.255 INFO:tasks.rgw_multisite_tests:Traceback (most recent call last):
  File "/home/teuthworker/src/git.ceph.com_git_teuthology_master/virtualenv/local/lib/python2.7/site-packages/nose/case.py", line 197, in runTest
    self.test(*self.arg)
  File "/home/teuthworker/src/github.com_ceph_ceph-c_wip-yuri-testing4_2017_8_30/qa/tasks/rgw_multi/tests.py", line 938, in test_encrypted_object_sync
    (zone1, zone2,) = zonegroup_conns.rw_zones
ValueError: too many values to unpack

---------------------------------------------------------------------
```