### PR TITLE
jewel: librbd: reacquire lock should update lock owner client id

### DIFF
--- a/src/librbd/ExclusiveLock.cc
+++ b/src/librbd/ExclusiveLock.cc
@@ -603,6 +603,10 @@ void ExclusiveLock<I>::handle_reacquire_lock(int r) {
     }
   } else {
     m_cookie = m_new_cookie;
+
+    m_lock.Unlock();
+    m_image_ctx.image_watcher->notify_acquired_lock();
+    m_lock.Lock();
   }
 
   complete_active_action(STATE_LOCKED, 0);

--- a/src/test/librbd/test_mock_ExclusiveLock.cc
+++ b/src/test/librbd/test_mock_ExclusiveLock.cc
@@ -709,6 +709,7 @@ TEST_F(TestMockExclusiveLock, ReacquireLock) {
   MockReacquireRequest mock_reacquire_request;
   C_SaferCond reacquire_ctx;
   expect_reacquire_lock(mock_image_ctx, mock_reacquire_request, 0);
+  expect_notify_acquired_lock(mock_image_ctx);
   {
     RWLock::RLocker owner_locker(mock_image_ctx.owner_lock);
     exclusive_lock.reacquire_lock(&reacquire_ctx);


### PR DESCRIPTION
http://tracker.ceph.com/issues/19957