### PR TITLE
bluestore/NVMeDevice: Make db, wal, block path can share the disk.

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1014,8 +1014,17 @@ OPTION(bluestore_bluefs_balance_interval, OPT_FLOAT) // how often (sec) to balan
 // with "spdk:" prefix.
 // Users can use 'lspci -vvv -d 8086:0953 | grep "Device Serial Number"' to
 // get the serial number of Intel(R) Fultondale NVMe controllers.
+// The format is:  bluestore_XXX_path = spdk:sn[:offset]
+// XXX can be: block or block_db  or block_wal.
+// offset is optional. If not provided, the default value is 0. The offset indicates
+// the beginning offset in bytes to be used in the NVMe SSD, the offset value provided
+// should be in hexformat.
 // Example:
-// bluestore_block_path = spdk:55cd2e404bd73932
+// bluestore_block_path = spdk:55cd2e404bd73932:40000000
+// It means that the block area will use the space in NVMe SDD from offset=1GB,
+// defintely the size is determined by the bluestore_block_size.
+// You can put db, wal, block in the NVMe SSD, but you need to make sure the allocated
+// space is not overlapped.
 // If you want to run multiple SPDK instances per node, you must specify the
 // amount of dpdk memory size in MB each instance will use, to make sure each
 // instance uses its own dpdk memory

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4994,6 +4994,15 @@ int BlueStore::_setup_block_symlink_or_file(
       string serial_number = epath.substr(strlen(SPDK_PREFIX));
       r = ::write(fd, serial_number.c_str(), serial_number.size());
       assert(r == (int)serial_number.size());
+      string::size_type pos = serial_number.find(":");
+      char buf[40];
+      if (pos == serial_number.npos) {
+        snprintf(buf, sizeof(buf), ":0:%" PRIx64, size);
+      } else {
+        snprintf(buf, sizeof(buf), ":%" PRIx64, size);
+      }
+
+      r = ::write(fd, buf, strlen(buf));
       dout(1) << __func__ << " created " << name << " symlink to "
               << epath << dendl;
       VOID_TEMP_FAILURE_RETRY(::close(fd));

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -52,6 +52,8 @@ class NVMEDevice : public BlockDevice {
   SharedDriverData *get_driver() { return driver; }
 
  public:
+  uint64_t offset;
+
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   bool supported_bdev_label() override { return false; }


### PR DESCRIPTION
The new format of file is spdk:SN[:offset],
:offset is optional but should be hex format, if used, it can use the partition from the offset in the NVMe device.  For example, we can set:
bluestore_block_db_path = spdk:55cd2e404be053be:0 (offset=0)
bluestore_block_wal_path = spdk:55cd2e404be053be:40000000 (offset=1G)
bluestore_block_path = spdk:55cd2e404be053be:80000000 (offset=2G)

Signed-off-by: Ziye Yang <optimistyzy@gmail.com>
Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>