### PR TITLE
cli: rados: support for high precision time using stat2

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -60,7 +60,8 @@ Options
 .. option:: --striper
 
    Uses the striping API of rados rather than the default one.
-   Available for stat, get, put, append, truncate, rm, ls and all xattr related operation
+   Available for stat, stat2, get, put, append, truncate, rm, ls
+   and all xattr related operation
 
 
 Global commands
@@ -151,6 +152,12 @@ Pool specific commands
 
 :command:`rmxattr` *name* *attr*
   Remove *attr* from the extended attributes of an object.
+
+:command:`stat` *name*
+   Get stat (ie. mtime, size) of given object
+
+:command:`stat2` *name*
+   Get stat (similar to stat, but with high precision time) of given object
 
 :command:`listomapkeys` *name*
   List all the keys stored in the object map of object name.

--- a/src/bash_completion/rados
+++ b/src/bash_completion/rados
@@ -32,7 +32,7 @@ _rados()
                 return 0
                 ;;
             rados)
-                COMPREPLY=( $(compgen -W "lspools mkpool rmpool df ls chown get put create rm listxattr getxattr setxattr rmxattr stat mapext lssnap mksnap rmsnap rollback bench" -- ${cur}) )
+                COMPREPLY=( $(compgen -W "lspools mkpool rmpool df ls chown get put create rm listxattr getxattr setxattr rmxattr stat stat2 mapext lssnap mksnap rmsnap rollback bench" -- ${cur}) )
                 return 0
             ;;
         esac

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -94,6 +94,7 @@ void usage(ostream& out)
 "   setxattr <obj-name> attr val\n"
 "   rmxattr <obj-name> attr\n"
 "   stat <obj-name>                  stat the named object\n"
+"   stat2 <obj-name>                 stat2 the named object (with high precision time)\n"
 "   mapext <obj-name>\n"
 "   rollback <obj-name> <snap-name>  roll back object to snap <snap-name>\n"
 "\n"
@@ -2251,6 +2252,27 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       utime_t t(mtime, 0);
       cout << pool_name << "/" << oid
            << " mtime " << t << ", size " << size << std::endl;
+    }
+  }
+  else if (strcmp(nargs[0], "stat2") == 0) {
+    if (!pool_name || nargs.size() < 2)
+      usage_exit();
+    string oid(nargs[1]);
+    uint64_t size;
+    struct timespec mtime;
+    if (use_striper) {
+      ret = striper.stat2(oid, &size, &mtime);
+    } else {
+      ret = io_ctx.stat2(oid, &size, &mtime);
+    }
+    if (ret < 0) {
+      cerr << " error stat-ing " << pool_name << "/" << oid << ": "
+	   << cpp_strerror(ret) << std::endl;
+      goto out;
+    } else {
+      utime_t t(mtime);
+      cout << pool_name << "/" << oid
+	   << " mtime " << t << ", size " << size << std::endl;
     }
   }
   else if (strcmp(nargs[0], "get") == 0) {


### PR DESCRIPTION
This commit introduces `stat2` option for the rados cli, which is
similar to `stat` except that it returns the mtime in high precision,
which is useful for inspecting objects, for example, if the application
had used the related librados api calls (like radosgw using `mtime2`)

Fixes: http://tracker.ceph.com/issues/21199
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>