### PR TITLE
tests: unittest_throttle fix core dump before destruct

### DIFF
--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -423,12 +423,12 @@ TEST(BackoffThrottle, oversaturated)
 TEST(OrderedThrottle, destruct) {
   EXPECT_DEATH({
       auto throttle = ceph::make_unique<OrderedThrottle>(1, false);
-      throttle->start_op(nullptr);
+      throttle->start_op(new FunctionContext(NULL));
       {
 	auto& t = *throttle;
 	std::thread([&t]() {
 	    usleep(5);
-	    t.start_op(nullptr);
+	    t.start_op(new FunctionContext(NULL));
 	  });
       }
       // No equivalent of get_or_fail()


### PR DESCRIPTION
OrderedThrottle::start_op(Context *on_finish) will core dump
if on_finish is null, it will not execute the whole destruct test.

i think core in start_op arg check not the purpose of this test,
@adamemerson plese have a look
