### PR TITLE
ceph-volume Persist non-lv devices for journals

### DIFF
--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -18,7 +18,10 @@ def activate_filestore(lvs):
     # blow up with a KeyError if this doesn't exist
     osd_fsid = osd_lv.tags['ceph.osd_fsid']
     if not osd_journal_lv:
-        osd_journal = osd_lv.tags.get('ceph.journal_device')
+        # must be a pv, by quering lvm by the uuid we are ensuring that the
+        # device path is always correct
+        osd_journal_pv = api.get_pv(pv_uuid=osd_lv.tags['journal_uuid'])
+        osd_journal = osd_journal_pv.pv_name
     else:
         osd_journal = osd_journal.lv_path
 

--- a/src/ceph-volume/ceph_volume/devices/lvm/activate.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/activate.py
@@ -2,7 +2,7 @@ from __future__ import print_function
 import argparse
 from textwrap import dedent
 from ceph_volume import process, conf, decorators
-from ceph_volume.util import system
+from ceph_volume.util import system, disk
 from ceph_volume.systemd import systemctl
 from . import api
 
@@ -17,12 +17,11 @@ def activate_filestore(lvs):
     # blow up with a KeyError if this doesn't exist
     osd_fsid = osd_lv.tags['ceph.osd_fsid']
     if not osd_journal_lv:
-        # must be a pv, by quering lvm by the uuid we are ensuring that the
+        # must be a disk partition, by quering blkid by the uuid we are ensuring that the
         # device path is always correct
-        osd_journal_pv = api.get_pv(pv_uuid=osd_lv.tags['ceph.journal_uuid'])
-        osd_journal = osd_journal_pv.pv_name
+        osd_journal = disk.get_device_from_partuuid(osd_lv.tags['ceph.journal_uuid'])
     else:
-        osd_journal = osd_journal.lv_path
+        osd_journal = osd_lv.tags['ceph.journal_device']
 
     if not osd_journal:
         raise RuntimeError('unable to detect an lv or device journal for OSD %s' % osd_id)

--- a/src/ceph-volume/ceph_volume/devices/lvm/api.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/api.py
@@ -124,6 +124,21 @@ def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_tags=None):
     return lvs.get(lv_name=lv_name, vg_name=vg_name, lv_path=lv_path, lv_tags=lv_tags)
 
 
+def create_pv(device):
+    """
+    Create a physical volume from a device, useful when devices need to be later mapped
+    to journals.
+    """
+    process.run([
+        'sudo',
+        'pvcreate',
+        '-v',  # verbose
+        '-f',  # force it
+        '--yes', # answer yes to any prompts
+        device
+    ])
+
+
 def create_lv(name, group, size=None, **tags):
     """
     Create a Logical Volume in a Volume Group. Command looks like::

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -51,6 +51,24 @@ class Prepare(object):
     def __init__(self, argv):
         self.argv = argv
 
+    def get_journal_pv(self, argument):
+        # it is safe to get the pv by its name
+        device = api.get_pv(pv_name=argument)
+        if device:
+            # means this has an existing uuid, so we can use it without
+            # recreating it
+            if device.pv_uuid:
+                return device
+            # otherwise, we need to create it as a 'pv', ask back again for it
+            # as a pv, and return that
+            api.create_pv(argument)
+            return api.get_pv(pv_name=argument)
+        # if we get to this point, this should be a red flag, `prepare` probably is
+        # out of options to use anything so raise an error
+        raise RuntimeError(
+            '--journal specified an invalid or non-existent device: %s' % argument
+        )
+
     def get_journal_lv(self, argument):
         """
         Perform some parsing of the value of ``--journal`` so that the process
@@ -87,28 +105,30 @@ class Prepare(object):
 
             if not args.journal:
                 raise RuntimeError('--journal is required when using --filestore')
-            journal_device = None
-            journal_lv = self.get_journal_lv(args.journal)
 
-            # check if we have an actual path to a device, which is allowed
-            if not journal_lv:
-                if os.path.exists(args.journal):
-                    journal_device = args.journal
-                else:
-                    raise RuntimeError(
-                        '--journal specified an invalid or non-existent device: %s' % args.journal
-                    )
-            # Otherwise the journal_device is the path to the lv
-            else:
+            journal_lv = self.get_journal_lv(args.journal)
+            if journal_lv:
                 journal_device = journal_lv.lv_path
+                journal_uuid = journal_lv.lv_uuid
+                # we can only set tags on an lv, the pv (if any) can't as we
+                # aren't making it part of an lvm group (vg)
                 journal_lv.set_tags({
                     'ceph.type': 'journal',
                     'ceph.osd_fsid': fsid,
                     'ceph.osd_id': osd_id,
                     'ceph.cluster_fsid': cluster_fsid,
                     'ceph.journal_device': journal_device,
+                    'ceph.journal_uuid': journal_uuid,
                     'ceph.data_device': data_lv.lv_path,
+                    'ceph.data_uuid': data_lv.lv_uuid,
                 })
+
+            # otherwise assume this is a regular disk, that will need to be
+            # created as a 'pv'
+            else:
+                journal_pv = self.get_journal_pv(args.journal)
+                journal_device = journal_pv.pv_name
+                journal_uuid = journal_pv.pv_uuid
 
             data_lv.set_tags({
                 'ceph.type': 'data',
@@ -116,7 +136,9 @@ class Prepare(object):
                 'ceph.osd_id': osd_id,
                 'ceph.cluster_fsid': cluster_fsid,
                 'ceph.journal_device': journal_device,
+                'ceph.journal_uuid': journal_uuid,
                 'ceph.data_device': data_lv.lv_path,
+                'ceph.data_uuid': data_lv.lv_uuid,
             })
 
             prepare_filestore(

--- a/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/prepare.py
@@ -3,8 +3,8 @@ import json
 import os
 from textwrap import dedent
 from ceph_volume.util import prepare as prepare_utils
-from ceph_volume.util import system
-from ceph_volume import conf, decorators
+from ceph_volume.util import system, disk
+from ceph_volume import conf, decorators, terminal
 from . import api
 from .common import prepare_parser
 
@@ -51,23 +51,12 @@ class Prepare(object):
     def __init__(self, argv):
         self.argv = argv
 
-    def get_journal_pv(self, argument):
-        # it is safe to get the pv by its name
-        device = api.get_pv(pv_name=argument)
-        if device:
-            # means this has an existing uuid, so we can use it without
-            # recreating it
-            if device.pv_uuid:
-                return device
-            # otherwise, we need to create it as a 'pv', ask back again for it
-            # as a pv, and return that
-            api.create_pv(argument)
-            return api.get_pv(pv_name=argument)
-        # if we get to this point, this should be a red flag, `prepare` probably is
-        # out of options to use anything so raise an error
-        raise RuntimeError(
-            '--journal specified an invalid or non-existent device: %s' % argument
-        )
+    def get_journal_ptuuid(self, argument):
+        uuid = disk.get_partuuid(argument)
+        if not uuid:
+            terminal.error('blkid could not detect a PARTUUID for device: %s' % argument)
+            raise RuntimeError('unable to use device for a journal')
+        return uuid
 
     def get_journal_lv(self, argument):
         """
@@ -123,12 +112,15 @@ class Prepare(object):
                     'ceph.data_uuid': data_lv.lv_uuid,
                 })
 
-            # otherwise assume this is a regular disk, that will need to be
-            # created as a 'pv'
+            # allow a file
+            elif os.path.isfile(args.journal):
+                journal_uuid = ''
+                journal_device = args.journal
+
+            # otherwise assume this is a regular disk partition
             else:
-                journal_pv = self.get_journal_pv(args.journal)
-                journal_device = journal_pv.pv_name
-                journal_uuid = journal_pv.pv_uuid
+                journal_uuid = self.get_journal_ptuuid(args.journal)
+                journal_device = args.journal
 
             data_lv.set_tags({
                 'ceph.type': 'data',

--- a/src/ceph-volume/ceph_volume/exceptions.py
+++ b/src/ceph-volume/ceph_volume/exceptions.py
@@ -50,6 +50,16 @@ class SuperUserError(Exception):
         return 'This command needs to be executed with sudo or as root'
 
 
+class MultiplePVsError(Exception):
+
+    def __init__(self, pv_name):
+        self.pv_name = pv_name
+
+    def __str__(self):
+        msg = "Got more than 1 result looking for physical volume: %s" % self.pv_name
+        return msg
+
+
 class MultipleLVsError(Exception):
 
     def __init__(self, lv_name, lv_path):

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_api.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_api.py
@@ -77,6 +77,14 @@ def volumes(monkeypatch):
 
 
 @pytest.fixture
+def pvolumes(monkeypatch):
+    monkeypatch.setattr(process, 'call', lambda x: ('', '', 0))
+    pvolumes = api.PVolumes()
+    pvolumes._purge()
+    return pvolumes
+
+
+@pytest.fixture
 def volume_groups(monkeypatch):
     monkeypatch.setattr(process, 'call', lambda x: ('', '', 0))
     vgs = api.VolumeGroups()
@@ -96,6 +104,40 @@ class TestGetLV(object):
         monkeypatch.setattr(api, 'Volumes', lambda: volumes)
         assert api.get_lv(lv_name='foo') == FooVolume
 
+    def test_single_lv_is_matched_by_uuid(self, volumes, monkeypatch):
+        FooVolume = api.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo',
+            lv_uuid='1111', lv_tags="ceph.type=data")
+        volumes.append(FooVolume)
+        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        assert api.get_lv(lv_uuid='1111') == FooVolume
+
+
+class TestGetPV(object):
+
+    def test_nothing_is_passed_in(self):
+        # so we return a None
+        assert api.get_pv() is None
+
+    def test_single_pv_is_not_matched(self, pvolumes, monkeypatch):
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={})
+        pvolumes.append(FooPVolume)
+        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
+        assert api.get_pv(pv_uuid='foo') is None
+
+    def test_single_pv_is_matched(self, pvolumes, monkeypatch):
+        FooPVolume = api.PVolume(pv_name='/dev/sda', pv_uuid="0000", pv_tags={})
+        pvolumes.append(FooPVolume)
+        monkeypatch.setattr(api, 'PVolumes', lambda: pvolumes)
+        assert api.get_pv(pv_uuid='0000') == FooPVolume
+
+    def test_single_pv_is_matched_by_uuid(self, volumes, monkeypatch):
+        FooVolume = api.Volume(
+            lv_name='foo', lv_path='/dev/vg/foo',
+            lv_uuid='1111', lv_tags="ceph.type=data")
+        volumes.append(FooVolume)
+        monkeypatch.setattr(api, 'Volumes', lambda: volumes)
+        assert api.get_lv(lv_uuid='1111') == FooVolume
 
 class TestGetVG(object):
 
@@ -160,6 +202,23 @@ class TestVolumes(object):
         volumes.filter(lv_path='/dev/volume1')
         assert len(volumes) == 1
         assert volumes[0].lv_name == 'volume1'
+
+    def test_filter_by_lv_uuid(self, volumes):
+        osd = api.Volume(lv_name='volume1', lv_path='/dev/volume1', lv_uuid='1111', lv_tags='')
+        journal = api.Volume(lv_name='volume2', lv_path='/dev/volume2', lv_uuid='', lv_tags='')
+        volumes.append(osd)
+        volumes.append(journal)
+        volumes.filter(lv_uuid='1111')
+        assert len(volumes) == 1
+        assert volumes[0].lv_name == 'volume1'
+
+    def test_filter_by_lv_uuid_nothing_found(self, volumes):
+        osd = api.Volume(lv_name='volume1', lv_path='/dev/volume1', lv_uuid='1111', lv_tags='')
+        journal = api.Volume(lv_name='volume2', lv_path='/dev/volume2', lv_uuid='', lv_tags='')
+        volumes.append(osd)
+        volumes.append(journal)
+        volumes.filter(lv_uuid='22222')
+        assert volumes == []
 
     def test_filter_requires_params(self, volumes):
         with pytest.raises(TypeError):

--- a/src/ceph-volume/ceph_volume/tests/functional/centos7/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/centos7/create/group_vars/all
@@ -8,12 +8,18 @@ monitor_interface: eth1
 journal_size: 100
 osd_objectstore: "filestore"
 osd_scenario: lvm
+ceph_origin: 'repository'
+ceph_repository: 'dev'
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
-  - data: test_volume
-    journal: /dev/sdc
+  - data: data-lv1
+    journal: /dev/sdc1
     data_vg: test_group
+  - data: data-lv2
+    journal: journal1
+    data_vg: test_group
+    journal_vg: journals
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/tests/functional/tox.ini
+++ b/src/ceph-volume/ceph_volume/tests/functional/tox.ini
@@ -15,7 +15,7 @@ setenv=
   VAGRANT_CWD = {changedir}
   CEPH_VOLUME_DEBUG = 1
 deps=
-  ansible==2.2.3
+  ansible==2.3.1
   testinfra==1.6.0
   pytest-xdist
 changedir=

--- a/src/ceph-volume/ceph_volume/tests/functional/xenial/create/group_vars/all
+++ b/src/ceph-volume/ceph_volume/tests/functional/xenial/create/group_vars/all
@@ -8,12 +8,18 @@ monitor_interface: eth1
 journal_size: 100
 osd_objectstore: "filestore"
 osd_scenario: lvm
+ceph_origin: 'repository'
+ceph_repository: 'dev'
 copy_admin_key: true
 # test-volume is created by tests/functional/lvm_setup.yml from /dev/sda
 lvm_volumes:
-  - data: test_volume
-    journal: /dev/sdc
+  - data: data-lv1
+    journal: /dev/sdc1
     data_vg: test_group
+  - data: data-lv2
+    journal: journal1
+    data_vg: test_group
+    journal_vg: journals
 os_tuning_params:
   - { name: kernel.pid_max, value: 4194303 }
   - { name: fs.file-max, value: 26234859 }

--- a/src/ceph-volume/ceph_volume/util/disk.py
+++ b/src/ceph-volume/ceph_volume/util/disk.py
@@ -1,0 +1,24 @@
+from ceph_volume import process
+
+
+def get_partuuid(device):
+    """
+    If a device is a partition, it will probably have a PARTUUID on it that
+    will persist and can be queried against `blkid` later to detect the actual
+    device
+    """
+    out, err, rc = process.call(
+        ['sudo', 'blkid', '-s', 'PARTUUID', '-o', 'value', device]
+    )
+    return ' '.join(out).strip()
+
+
+def get_device_from_partuuid(partuuid):
+    """
+    If a device has a partuuid, query blkid so that it can tell us what that
+    device is
+    """
+    out, err, rc = process.call(
+        ['sudo', 'blkid', '-t', 'PARTUUID="%s"' % partuuid, '-o', 'device']
+    )
+    return ' '.join(out).strip()


### PR DESCRIPTION
To be able to persist regular (non-lv) devices we will have to require partitions so that the `PARTUUID` can be stored in the OSD lv and later queried via `blkid`

The following changes will survive a system reboot that changes device names (e.g. /dev/sda to /dev/sdb)

See: https://bugzilla.redhat.com/show_bug.cgi?id=1485011