### PR TITLE
qa/tasks/ceph_manager: revive osds before doing final rerr reset

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -1031,6 +1031,7 @@ class Thrasher:
                         Scrubber(self.ceph_manager, self.config)
             self.choose_action()()
             time.sleep(delay)
+        self.all_up()
         if self.random_eio > 0:
             self.ceph_manager.raw_cluster_cmd('tell', 'osd.'+str(self.rerrosd),
                           'injectargs', '--', '--filestore_debug_random_read_err=0.0')


### PR DESCRIPTION
We assume below that rerrosd is up, but it may not be when we exit the
loop.

Fixes: http://tracker.ceph.com/issues/21206
Signed-off-by: Sage Weil <sage@redhat.com>