### PR TITLE
rgw: use ceph::timer for RGWCoroutine::wait()

### DIFF
--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -664,7 +664,7 @@ int RGWContinuousLeaseCR::operate()
         return set_state(RGWCoroutine_Error, retcode);
       }
       set_locked(true);
-      yield wait(utime_t(interval / 2, 0));
+      yield wait(std::chrono::seconds(interval / 2));
     }
     set_locked(false); /* moot at this point anyway */
     yield call(new RGWSimpleRadosUnlockCR(async_rados, store, obj, lock_name, cookie));

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -533,6 +533,7 @@ public:
 // DataLogTrimCR factory function
 extern RGWCoroutine* create_data_log_trim_cr(RGWRados *store,
                                              RGWHTTPManager *http,
-                                             int num_shards, utime_t interval);
+                                             int num_shards,
+                                             uint32_t interval_sec);
 
 #endif

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3247,16 +3247,16 @@ class RGWSyncLogTrimThread : public RGWSyncProcessorThread
   RGWCoroutinesManager crs;
   RGWRados *store;
   RGWHTTPManager http;
-  const utime_t trim_interval;
+  const uint32_t trim_interval_sec;
 
   uint64_t interval_msec() override { return 0; }
   void stop_process() override { crs.stop(); }
 public:
-  RGWSyncLogTrimThread(RGWRados *store, int interval)
+  RGWSyncLogTrimThread(RGWRados *store, uint32_t interval_sec)
     : RGWSyncProcessorThread(store, "sync-log-trim"),
       crs(store->ctx(), store->get_cr_registry()), store(store),
       http(store->ctx(), crs.get_completion_mgr()),
-      trim_interval(interval, 0)
+      trim_interval_sec(interval_sec)
   {}
 
   int init() override {
@@ -3267,13 +3267,13 @@ public:
     auto meta = new RGWCoroutinesStack(store->ctx(), &crs);
     meta->call(create_meta_log_trim_cr(store, &http,
                                        cct->_conf->rgw_md_log_max_shards,
-                                       trim_interval));
+                                       trim_interval_sec));
     stacks.push_back(meta);
 
     auto data = new RGWCoroutinesStack(store->ctx(), &crs);
     data->call(create_data_log_trim_cr(store, &http,
                                        cct->_conf->rgw_data_log_num_shards,
-                                       trim_interval));
+                                       trim_interval_sec));
     stacks.push_back(data);
 
     crs.run(stacks);

--- a/src/rgw/rgw_sync.h
+++ b/src/rgw/rgw_sync.h
@@ -454,7 +454,7 @@ public:
 
 // MetaLogTrimCR factory function
 RGWCoroutine* create_meta_log_trim_cr(RGWRados *store, RGWHTTPManager *http,
-                                      int num_shards, utime_t interval);
+                                      int num_shards, uint32_t interval_sec);
 
 // factory function for mdlog trim via radosgw-admin
 RGWCoroutine* create_admin_meta_log_trim_cr(RGWRados *store,


### PR DESCRIPTION
this replaces the use of SafeTimer with ceph::timer in RGWCompletionManager, allowing RGWCoroutine::wait() to take a ceph::timespan or std::chrono::duration instead of utime_t. this has the small added benefit that RGWCompletionManager::wait_interval() no longer has to allocate a WaitContext for its completion