### PR TITLE
PGPool::update: optimize removed_snaps comparison when possible

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -1301,6 +1301,16 @@ void pg_pool_t::build_removed_snaps(interval_set<snapid_t>& rs) const
   }
 }
 
+bool pg_pool_t::maybe_updated_removed_snaps(const interval_set<snapid_t>& cached) const
+{
+  if (is_unmanaged_snaps_mode()) { // remove_unmanaged_snap increments range_end
+    if (removed_snaps.empty() || cached.empty()) // range_end is undefined
+      return removed_snaps.empty() != cached.empty();
+    return removed_snaps.range_end() != cached.range_end();
+  }
+  return true;
+}
+
 snapid_t pg_pool_t::snap_exists(const char *s) const
 {
   for (map<snapid_t,pool_snap_info_t>::const_iterator p = snaps.begin();

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1572,6 +1572,7 @@ public:
    * explicit removed_snaps set.
    */
   void build_removed_snaps(interval_set<snapid_t>& rs) const;
+  bool maybe_updated_removed_snaps(const interval_set<snapid_t>& cached) const;
   snapid_t snap_exists(const char *s) const;
   void add_snap(const char *n, utime_t stamp);
   void add_unmanaged_snap(uint64_t& snapid);


### PR DESCRIPTION
In self/unmanaged snaps mode, optimize removed_snaps comparison
for cases where removed_snaps has not changed. This exploits the
fact that remove_unmanaged_snap adds a dummy removed snapshot
to the end of removed_snaps, allowing for inexpensive detection
of changes. In cases where removed_snaps is very large, this
optimization improves performance dramatically.

Signed-off-by: Zac Medico <zmedico@gmail.com>