### PR TITLE
client: Fixed Non-array delete in getgroups()

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -118,7 +118,7 @@ static int getgroups(fuse_req_t req, gid_t **sgids)
   }
   c = fuse_req_getgroups(req, c, gids);
   if (c < 0) {
-    delete gids;
+    delete[] gids;
   } else {
     *sgids = gids;
   }


### PR DESCRIPTION
Fixed Non-array delete in getgroups() as reported by the coverity scan CID1417061.

The following is reported by the coverity scan:
```
120       if (c < 0) {
>>>     CID 1417061:  Compiler dependency  (DELETE_ARRAY)
>>>     Deleting array variable "gids" with non-array delete in "delete gids".
121         delete gids;
```
Signed-off-by: Jos Collin <jcollin@redhat.com>