### PR TITLE
mon/MDSMonitor: fix a bug at preprocess_beacon

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -321,7 +321,8 @@ bool MDSMonitor::preprocess_beacon(MonOpRequestRef op)
 
   // check privileges, ignore if fails
   MonSession *session = m->get_session();
-  assert(session);
+  if (!session)
+    goto ignore;
   if (!session->is_capable("mds", MON_CAP_X)) {
     dout(0) << "preprocess_beacon got MMDSBeacon from entity with insufficient privileges "
 	    << session->caps << dendl;


### PR DESCRIPTION
when a mds node reboot, mon deal beacon message from this mds.
The connection between mon and MDS has been released.This will cause Session is empty.Then this mon will assert(session);

BTW in mon/OSDMonitor.cc,this bug is fixed.

Signed-off-by: wangshuguang <wangshugaung@inspur.com>