### PR TITLE
rgw:multisite: don't sync olh attr to slave zone

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7282,6 +7282,10 @@ public:
       JSONDecoder::decode_json("attrs", src_attrs, &jp);
 
       src_attrs.erase(RGW_ATTR_COMPRESSION);
+      src_attrs.erase(RGW_ATTR_OLH_INFO);
+      src_attrs.erase(RGW_ATTR_OLH_VER);
+      src_attrs.erase(RGW_ATTR_OLH_ID_TAG);
+      src_attrs.erase(RGW_ATTR_OLH_PENDING_PREFIX);
       src_attrs.erase(RGW_ATTR_MANIFEST); // not interested in original object layout
     }
 


### PR DESCRIPTION
obj's olh xattr is not obj_instance's metadata, should not sync to slave zone.

Fixes: http://tracker.ceph.com/issues/21210

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>