### PR TITLE
rados: support python API of "set_osdmap_full_try"

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -3509,6 +3509,10 @@ CEPH_RADOS_API int rados_blacklist_add(rados_t cluster,
 				       char *client_address,
 				       uint32_t expire_seconds);
 
+CEPH_RADOS_API void rados_set_osdmap_full_try(rados_ioctx_t io);
+
+CEPH_RADOS_API void rados_unset_osdmap_full_try(rados_ioctx_t io);
+
 /**
  * Enable an application on a pool
  *

--- a/src/librados/librados.cc
+++ b/src/librados/librados.cc
@@ -3087,6 +3087,18 @@ extern "C" int rados_blacklist_add(rados_t cluster, char *client_address,
   return radosp->blacklist_add(client_address, expire_seconds);
 }
 
+extern "C" void rados_set_osdmap_full_try(rados_ioctx_t io)
+{
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  ctx->objecter->set_osdmap_full_try();
+}
+
+extern "C" void rados_unset_osdmap_full_try(rados_ioctx_t io)
+{
+  librados::IoCtxImpl *ctx = (librados::IoCtxImpl *)io;
+  ctx->objecter->unset_osdmap_full_try();
+}
+
 extern "C" int rados_application_enable(rados_ioctx_t io, const char *app_name,
                                         int force)
 {

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -153,6 +153,8 @@ cdef extern from "rados/librados.h" nogil:
     int rados_blacklist_add(rados_t cluster, char *client_address, uint32_t expire_seconds)
     int rados_application_enable(rados_ioctx_t io, const char *app_name,
                                  int force)
+    void rados_set_osdmap_full_try(rados_ioctx_t io)
+    void rados_unset_osdmap_full_try(rados_ioctx_t io)
     int rados_application_list(rados_ioctx_t io, char *values,
                              size_t *values_len)
     int rados_application_metadata_get(rados_ioctx_t io, const char *app_name,
@@ -3575,6 +3577,20 @@ returned %d, but should return zero on success." % (self.name, ret))
             ret = rados_unlock(self.io, _key, _name, _cookie)
         if ret < 0:
             raise make_ex(ret, "Ioctx.rados_lock_exclusive(%s): failed to set lock %s on %s" % (self.name, name, key))
+
+    def set_osdmap_full_try(self):
+        """
+        Set global osdmap_full_try label to true
+        """
+        with nogil:
+            rados_set_osdmap_full_try(self.io)
+
+    def unset_osdmap_full_try(self):
+        """
+        Unset
+        """
+        with nogil:
+            rados_unset_osdmap_full_try(self.io)
 
     def application_enable(self, app_name, force=False):
         """


### PR DESCRIPTION
It's hang when using RBD python API to remove an image(e.g. `rbd_inst.remove(ioctx, 'myimage')`) which its pool was full, but cli got succeed( cause of `io_ctx.set_osdmap_full_try()` was called before `do_delete`).
If pool was full, we should set  osdmap_full_try to true before we use `rbd_inst.remove(ioctx, 'myimage')` , so the python API of `set_osdmap_full_try()` need to be supported.

Signed-off-by: songweibin <song.weibin@zte.com.cn>