### PR TITLE
arch/arm: set ceph_arch_aarch64_crc32 only if the build host supports crc32cx

### DIFF
--- a/src/arch/arm.c
+++ b/src/arch/arm.c
@@ -1,3 +1,4 @@
+#include "acconfig.h"
 #include "arch/probe.h"
 
 /* flags we export */
@@ -45,10 +46,8 @@ int ceph_arch_arm_probe(void)
 	ceph_arch_neon = (get_hwcap() & HWCAP_NEON) == HWCAP_NEON;
 #elif __aarch64__ && __linux__
 	ceph_arch_neon = (get_hwcap() & HWCAP_ASIMD) == HWCAP_ASIMD;
-# ifdef HWCAP_CRC32
+# if defined(HAVE_ARMV8_CRC) && defined(HWCAP_CRC32)
 	ceph_arch_aarch64_crc32 = (get_hwcap() & HWCAP_CRC32) == HWCAP_CRC32;
-# else
-	ceph_arch_aarch64_crc32 = 0;  // sorry!
 # endif
 #else
 	if (0)


### PR DESCRIPTION
HWCAP_CRC32 is defined by the linux kernel source. so it's defined as
long as the linux kernel source is new enough. but the compiler on the
building host is not necessarily able to build the `crc32cx`
instruction. if we happen to have an incapable compiler on a machine with
recent linux kernel source, the dummy "ceph_crc32c_aarch64()" will be
selected by `ceph_choose_crc32()`. and it always return 0.

See-also: http://tracker.ceph.com/issues/19705
Signed-off-by: Kefu Chai <kchai@redhat.com>