### PR TITLE
osd: fix build_initial_pg_history

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4436,6 +4436,10 @@ void OSD::build_initial_pg_history(
       h->last_epoch_split = e;
     }
     lastmap = osdmap;
+    up_primary = new_up_primary;
+    acting_primary = new_acting_primary;
+    up = new_up;
+    acting = new_acting;
   }
   dout(20) << __func__ << " " << debug.str() << dendl;
   dout(10) << __func__ << " " << *h << " " << *pi


### PR DESCRIPTION
We need to update our info about the previous interval in order to
detect interval changes properly.

Fixes: http://tracker.ceph.com/issues/21203

Reported-by: w11979 <wang.wenfeng@h3c.com>
Signed-off-by: Sage Weil <sage@redhat.com>