### PR TITLE
mon/OSDMonitor: implement cluster pg limit

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -9,3 +9,14 @@
     limit (5% by default). Limits by inode count are still supported using
     mds_cache_size. Setting mds_cache_size to 0 (the default) disables the
     inode limit.
+
+* The maximum number of PGs per OSD before the monitor issues a
+  warning has been reduced from 300 to 200 PGs.  200 is still twice
+  the generally recommended target of 100 PGs per OSD.  This limit can
+  be adjusted via the ``mon_pg_warn_max_per_osd`` option on the
+  monitors.
+
+* Creating pools or adjusting pg_num will now fail if the change would
+  make the number of PGs per OSD exceed the configured
+  ``mon_pg_warn_max_per_osd`` limit.  The option can be adjusted if it
+  is really necessary to create a pool with more PGs.

--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -13,10 +13,10 @@
 * The maximum number of PGs per OSD before the monitor issues a
   warning has been reduced from 300 to 200 PGs.  200 is still twice
   the generally recommended target of 100 PGs per OSD.  This limit can
-  be adjusted via the ``mon_pg_warn_max_per_osd`` option on the
-  monitors.
+  be adjusted via the ``mon_max_pg_per_osd`` option on the
+  monitors.  The older ``mon_pg_warn_max_per_osd`` option has been removed.
 
 * Creating pools or adjusting pg_num will now fail if the change would
   make the number of PGs per OSD exceed the configured
-  ``mon_pg_warn_max_per_osd`` limit.  The option can be adjusted if it
+  ``mon_max_pg_per_osd`` limit.  The option can be adjusted if it
   is really necessary to create a pool with more PGs.

--- a/doc/rados/operations/health-checks.rst
+++ b/doc/rados/operations/health-checks.rst
@@ -335,17 +335,20 @@ TOO_MANY_PGS
 ____________
 
 The number of PGs in use in the cluster is above the configurable
-threshold of ``mon_pg_warn_max_per_osd`` PGs per OSD.  This can lead
+threshold of ``mon_max_pg_per_osd`` PGs per OSD.  If this threshold is
+exceed the cluster will not allow new pools to be created, pool `pg_num` to
+be increased, or pool replication to be increased (any of which would lead to
+more PGs in the cluster).  A large number of PGs can lead
 to higher memory utilization for OSD daemons, slower peering after
 cluster state changes (like OSD restarts, additions, or removals), and
 higher load on the Manager and Monitor daemons.
 
-The ``pg_num`` value for existing pools cannot currently be reduced.
-However, the ``pgp_num`` value can, which effectively collocates some
-PGs on the same sets of OSDs, mitigating some of the negative impacts
-described above.  The ``pgp_num`` value can be adjusted with::
+The simplest way to mitigate the problem is to increase the number of
+OSDs in the cluster by adding more hardware.  Note that the OSD count
+used for the purposes of this health check is the number of "in" OSDs,
+so marking "out" OSDs "in" (if there are any) can also help::
 
-  ceph osd pool set <pool> pgp_num <value>
+  ceph osd in <osd id(s)>
 
 Please refer to :ref:`choosing-number-of-placement-groups` for more
 information.
@@ -365,7 +368,6 @@ This is normally resolved by setting ``pgp_num`` to match ``pg_num``,
 triggering the data migration, with::
 
   ceph osd pool set <pool> pgp_num <pg-num-value>
-
 
 MANY_OBJECTS_PER_PG
 ___________________

--- a/qa/standalone/mon/osd-pool-create.sh
+++ b/qa/standalone/mon/osd-pool-create.sh
@@ -200,7 +200,7 @@ function TEST_utf8_cli() {
     # the fix for http://tracker.ceph.com/issues/7387.  If it turns out
     # to not be OK (when is the default encoding *not* UTF-8?), maybe
     # the character '黄' can be replaced with the escape $'\xe9\xbb\x84'
-    ceph osd pool create 黄 1024 || return 1
+    ceph osd pool create 黄 16 || return 1
     ceph osd lspools 2>&1 | \
         grep "黄" || return 1
     ceph -f json-pretty osd dump | \

--- a/qa/tasks/cephfs/test_volume_client.py
+++ b/qa/tasks/cephfs/test_volume_client.py
@@ -355,11 +355,11 @@ vc.disconnect()
         :return:
         """
 
-        # Because the teuthology config template sets mon_pg_warn_max_per_osd to
+        # Because the teuthology config template sets mon_max_pg_per_osd to
         # 10000 (i.e. it just tries to ignore health warnings), reset it to something
         # sane before using volume_client, to avoid creating pools with absurdly large
         # numbers of PGs.
-        self.set_conf("global", "mon pg warn max per osd", "300")
+        self.set_conf("global", "mon max pg per osd", "300")
         for mon_daemon_state in self.ctx.daemons.iter_daemons_of_role('mon'):
             mon_daemon_state.restart()
 
@@ -368,7 +368,7 @@ vc.disconnect()
 
         # Calculate how many PGs we'll expect the new volume pool to have
         osd_map = json.loads(self.fs.mon_manager.raw_cluster_cmd('osd', 'dump', '--format=json-pretty'))
-        max_per_osd = int(self.fs.get_config('mon_pg_warn_max_per_osd'))
+        max_per_osd = int(self.fs.get_config('mon_max_pg_per_osd'))
         osd_count = len(osd_map['osds'])
         max_overall = osd_count * max_per_osd
 

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -237,7 +237,6 @@ OPTION(mon_timecheck_skew_interval, OPT_FLOAT) // on leader, timecheck (clock dr
 OPTION(mon_pg_stuck_threshold, OPT_INT) // number of seconds after which pgs can be considered stuck inactive, unclean, etc (see doc/control.rst under dump_stuck for more info)
 OPTION(mon_pg_min_inactive, OPT_U64) // the number of PGs which have to be inactive longer than 'mon_pg_stuck_threshold' before health goes into ERR. 0 means disabled, never go into ERR.
 OPTION(mon_pg_warn_min_per_osd, OPT_INT)  // min # pgs per (in) osd before we warn the admin
-OPTION(mon_pg_warn_max_per_osd, OPT_INT)  // max # pgs per (in) osd before we warn the admin
 OPTION(mon_pg_warn_max_object_skew, OPT_FLOAT) // max skew few average in objects per pg
 OPTION(mon_pg_warn_min_objects, OPT_INT)  // do not warn below this object #
 OPTION(mon_pg_warn_min_pool_objects, OPT_INT)  // do not warn on pools below this object #

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1031,7 +1031,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("mon_pg_warn_max_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(300)
+    .set_default(200)
     .set_description(""),
 
     Option("mon_pg_warn_max_object_skew", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1030,9 +1030,9 @@ std::vector<Option> get_global_options() {
     .set_default(30)
     .set_description(""),
 
-    Option("mon_pg_warn_max_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_max_pg_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(200)
-    .set_description(""),
+    .set_description("Max number of PGs per OSD the cluster will allow"),
 
     Option("mon_pg_warn_max_object_skew", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(10.0)

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5541,7 +5541,7 @@ int OSDMonitor::get_crush_rule(const string &rule_name,
 
 int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 {
-  int64_t max_pgs_per_osd = g_conf->mon_pg_warn_max_per_osd;
+  int64_t max_pgs_per_osd = g_conf->get_val<int64_t>("mon_max_pg_per_osd");
   int num_osds = MAX(osdmap.get_num_in_osds(), 3);   // assume min cluster size 3
   int64_t max_pgs = max_pgs_per_osd * num_osds;
   int64_t projected = 0;
@@ -5562,7 +5562,7 @@ int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
     *ss << " pg_num " << pg_num << " size " << size
 	<< " would mean " << projected
 	<< " total pgs, which exceeds max " << max_pgs
-	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
+	<< " (mon_max_pg_per_osd " << max_pgs_per_osd
 	<< " * num_in_osds " << num_osds << ")";
     return -ERANGE;
   }

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5539,6 +5539,35 @@ int OSDMonitor::get_crush_rule(const string &rule_name,
   return 0;
 }
 
+int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
+{
+  int64_t max_pgs_per_osd = g_conf->mon_pg_warn_max_per_osd;
+  int64_t max_pgs = max_pgs_per_osd * osdmap.get_num_in_osds();
+  int64_t projected = 0;
+  if (pool < 0) {
+    projected += pg_num * size;
+  }
+  for (const auto& i : osdmap.get_pools()) {
+    if (i.first == pool) {
+      projected += pg_num * size;
+    } else {
+      projected += i.second.get_pg_num() * i.second.get_size();
+    }
+  }
+  if (projected > max_pgs) {
+    if (pool >= 0) {
+      *ss << "pool id " << pool;
+    }
+    *ss << " pg_num " << pg_num << " size " << size
+	<< " would mean " << projected
+	<< " total pgs, which exceeds max " << max_pgs
+	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
+	<< " * num_in_osds " << osdmap.get_num_in_osds() << ")";
+    return -ERANGE;
+  }
+  return 0;
+}
+
 /**
  * @param name The name of the new pool
  * @param auid The auid of the pool owner. Can be -1
@@ -5614,6 +5643,11 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   }
   unsigned size, min_size;
   r = prepare_pool_size(pool_type, erasure_code_profile, &size, &min_size, ss);
+  if (r) {
+    dout(10) << " prepare_pool_size returns " << r << dendl;
+    return r;
+  }
+  r = check_pg_num(-1, pg_num, size, ss);
   if (r) {
     dout(10) << " prepare_pool_size returns " << r << dendl;
     return r;
@@ -5794,6 +5828,10 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
       ss << "pool size must be between 1 and 10";
       return -EINVAL;
     }
+    int r = check_pg_num(pool, p.get_pg_num(), n, &ss);
+    if (r < 0) {
+      return r;
+    }
     p.size = n;
     if (n < p.min_size)
       p.min_size = n;
@@ -5862,6 +5900,10 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
          << g_conf->mon_max_pool_pg_num
          << " (you may adjust 'mon max pool pg num' for higher values)";
       return -ERANGE;
+    }
+    int r = check_pg_num(pool, n, p.get_size(), &ss);
+    if (r) {
+      return r;
     }
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5542,7 +5542,8 @@ int OSDMonitor::get_crush_rule(const string &rule_name,
 int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 {
   int64_t max_pgs_per_osd = g_conf->mon_pg_warn_max_per_osd;
-  int64_t max_pgs = max_pgs_per_osd * osdmap.get_num_in_osds();
+  int num_osds = MAX(osdmap.get_num_in_osds(), 3);   // assume min cluster size 3
+  int64_t max_pgs = max_pgs_per_osd * num_osds;
   int64_t projected = 0;
   if (pool < 0) {
     projected += pg_num * size;
@@ -5562,7 +5563,7 @@ int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 	<< " would mean " << projected
 	<< " total pgs, which exceeds max " << max_pgs
 	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
-	<< " * num_in_osds " << osdmap.get_num_in_osds() << ")";
+	<< " * num_in_osds " << num_osds << ")";
     return -ERANGE;
   }
   return 0;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -346,6 +346,7 @@ private:
 				const string &erasure_code_profile,
 				unsigned *stripe_width,
 				ostream *ss);
+  int check_pg_num(int64_t pool, int pg_num, int size, ostream* ss);
   int prepare_new_pool(string& name, uint64_t auid,
 		       int crush_rule,
 		       const string &crush_rule_name,

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2387,12 +2387,13 @@ void PGMap::get_health_checks(
   }
 
   // TOO_MANY_PGS
-  if (num_in && cct->_conf->mon_pg_warn_max_per_osd > 0) {
+  int64_t max_pg_per_osd = cct->_conf->get_val<int64_t>("mon_max_pg_per_osd");
+  if (num_in && max_pg_per_osd > 0) {
     int per = sum_pg_up / num_in;
-    if (per > cct->_conf->mon_pg_warn_max_per_osd) {
+    if (per > max_pg_per_osd) {
       ostringstream ss;
       ss << "too many PGs per OSD (" << per
-	 << " > max " << cct->_conf->mon_pg_warn_max_per_osd << ")";
+	 << " > max " << max_pg_per_osd << ")";
       checks->add("TOO_MANY_PGS", HEALTH_WARN, ss.str());
     }
   }

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -529,7 +529,7 @@ class CephFSVolumeClient(object):
         # We can't query the actual cluster config remotely, but since this is
         # just a heuristic we'll assume that the ceph.conf we have locally reflects
         # that in use in the rest of the cluster.
-        pg_warn_max_per_osd = int(self.rados.conf_get('mon_pg_warn_max_per_osd'))
+        pg_warn_max_per_osd = int(self.rados.conf_get('mon_max_pg_per_osd'))
 
         other_pgs = 0
         for pool in osd_map['pools']:


### PR DESCRIPTION
Prevent total pg count from exceeding a max per osd value.  Guard pg create, pg_num change, and size change.
<pre>
gnit:build (wip-pg-num-limits) 03:50 PM $ bin/ceph osd pool create foo 66
pool 'foo' created
gnit:build (wip-pg-num-limits) 03:50 PM $ bin/ceph osd pool set foo size 4
Error ERANGE:  pg_num 66 size 4 would mean 462 total pgs, which exceeds max 400 (mon_pg_warn_max_per_osd 200 * num_in_osds 2)
gnit:build (wip-pg-num-limits) 03:50 PM $ bin/ceph osd pool set foo size 4
set pool 1 size to 4
gnit:build (wip-pg-num-limits) 03:50 PM $ bin/ceph osd pool set foo pg_num 99
set pool 1 pg_num to 99
gnit:build (wip-pg-num-limits) 03:51 PM $ bin/ceph osd pool set foo pg_num 133
set pool 1 pg_num to 133
gnit:build (wip-pg-num-limits) 03:51 PM $ bin/ceph osd pool set foo pg_num 200
Error ERANGE: pool id 1 pg_num 200 size 4 would mean 800 total pgs, which exceeds max 600 (mon_pg_warn_max_per_osd 200 * num_in_osds 3)
</pre>