### PR TITLE
rgw: Access RGWConf through RGWEnv

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -269,9 +269,9 @@ req_state::req_state(CephContext* _cct, RGWEnv* e, RGWUserInfo* u)
   : cct(_cct), cio(NULL), op(OP_UNKNOWN), user(u), has_acl_header(false),
     info(_cct, e)
 {
-  enable_ops_log = e->conf.enable_ops_log;
-  enable_usage_log = e->conf.enable_usage_log;
-  defer_to_bucket_acls = e->conf.defer_to_bucket_acls;
+  enable_ops_log = e->rgw_conf_get_enable_ops_log();
+  enable_usage_log = e->rgw_conf_get_enable_usage_log();
+  defer_to_bucket_acls = e->rgw_conf_get_defer_to_bucket_acls();
   content_started = false;
   format = 0;
   formatter = NULL;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -384,7 +384,9 @@ class RGWEnv;
 
 class RGWConf {
   friend class RGWEnv;
-protected:
+  int enable_ops_log;
+  int enable_usage_log;
+  uint8_t defer_to_bucket_acls;
   void init(CephContext *cct);
 public:
   RGWConf()
@@ -392,17 +394,12 @@ public:
       enable_usage_log(1),
       defer_to_bucket_acls(0) {
   }
-
-  int enable_ops_log;
-  int enable_usage_log;
-  uint8_t defer_to_bucket_acls;
 };
 
 class RGWEnv {
   std::map<string, string, ltstr_nocase> env_map;
-public:
   RGWConf conf;
-
+public:
   void init(CephContext *cct);
   void init(CephContext *cct, char **envp);
   void set(const boost::string_ref& name, const boost::string_ref& val);
@@ -412,10 +409,19 @@ public:
   size_t get_size(const char *name, size_t def_val = 0) const;
   bool exists(const char *name) const;
   bool exists_prefix(const char *prefix) const;
-
   void remove(const char *name);
-
   const std::map<string, string, ltstr_nocase>& get_map() const { return env_map; }
+  int rgw_conf_get_enable_ops_log() const {
+    return conf.enable_ops_log;
+  }
+
+  int rgw_conf_get_enable_usage_log() const {
+    return conf.enable_usage_log;
+  }
+
+  int rgw_conf_get_defer_to_bucket_acls() const {
+    return conf.defer_to_bucket_acls;
+  }
 };
 
 enum http_op {


### PR DESCRIPTION
Created functions rgw_conf_get_enable_ops_log(), rgw_conf_get_enable_usage_log() and
rgw_conf_get_defer_to_bucket_acls() and the necessary changes to provide the access of RGWConf through RGWEnv.

We could have do the same just by making `req_state` a friend of `RGWConf`. But I think the
current change is inline with the original design.

This PR is created as a follow up of my review in https://github.com/ceph/ceph/pull/17129

Signed-off-by: Jos Collin <jcollin@redhat.com>