### PR TITLE
bluestore/NVMEDevice: accurate the latency perf counter of queue latency

### DIFF
--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -474,10 +474,7 @@ void SharedDriverQueueData::_aio_thread()
  again:
     dout(40) << __func__ << " polling" << dendl;
     if (inflight) {
-      if (!spdk_nvme_qpair_process_completions(qpair, g_conf->bluestore_spdk_max_io_completion)) {
-        dout(30) << __func__ << " idle, have a pause" << dendl;
-        _mm_pause();
-      }
+      spdk_nvme_qpair_process_completions(qpair, g_conf->bluestore_spdk_max_io_completion);
     }
 
     for (; t; t = t->next) {

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -764,7 +764,7 @@ int NVMEManager::try_get(const string &sn_tag, SharedDriverData **driver)
         int r;
 
         spdk_env_opts_init(&opts);
-        opts.name = "ceph-osd";
+        opts.name = "nvme-device-manager";
         opts.core_mask = coremask_arg;
         opts.master_core = m_core_arg;
         opts.mem_size = mem_size_arg;

--- a/src/os/bluestore/NVMEDevice.cc
+++ b/src/os/bluestore/NVMEDevice.cc
@@ -507,7 +507,7 @@ void SharedDriverQueueData::_aio_thread()
             ceph_abort();
           }
           cur = ceph::coarse_real_clock::now();
-          auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);
+          auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - t->start);
           logger->tinc(l_bluestore_nvmedevice_write_queue_lat, dur);
           break;
         }
@@ -530,7 +530,7 @@ void SharedDriverQueueData::_aio_thread()
             ceph_abort();
           } else {
             cur = ceph::coarse_real_clock::now();
-            auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);
+            auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - t->start);
             logger->tinc(l_bluestore_nvmedevice_read_queue_lat, dur);
           }
           break;
@@ -546,7 +546,7 @@ void SharedDriverQueueData::_aio_thread()
             ceph_abort();
           } else {
             cur = ceph::coarse_real_clock::now();
-            auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);
+            auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - t->start);
             logger->tinc(l_bluestore_nvmedevice_flush_queue_lat, dur);
           }
           break;
@@ -581,7 +581,7 @@ void SharedDriverQueueData::_aio_thread()
 
         Mutex::Locker l(queue_lock);
         if (queue_empty.load()) {
-	  cur = ceph::coarse_real_clock::now();
+          cur = ceph::coarse_real_clock::now();
           auto dur = std::chrono::duration_cast<std::chrono::nanoseconds>(cur - start);
           logger->tinc(l_bluestore_nvmedevice_polling_lat, dur);
           if (aio_stop)


### PR DESCRIPTION
accurate the latency perf counter of queue latency:
In old code, start is the beginning of _aio_thread. Indeed, it should be the start time of each Task.

Also contains several other small changes.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Ziye Yang <optimistyzy@gmail.com>