### PR TITLE
doc: Fixes rbd snapshot flatten example

### DIFF
--- a/doc/rbd/rbd-snapshot.rst
+++ b/doc/rbd/rbd-snapshot.rst
@@ -294,7 +294,7 @@ a snapshot, you must flatten the child images first. ::
 
 For example:: 
 
-	rbd flatten rbd/my-image
+	rbd flatten rbd/new-image
 
 .. note:: Since a flattened image contains all the information from the snapshot, 
    a flattened image will take up more storage space than a layered clone.


### PR DESCRIPTION
Snapshot flatten example has incorrect image name, fixing the same.