### PR TITLE
vstart.sh: fix mstop.sh can not stop rgw

### DIFF
--- a/src/mstop.sh
+++ b/src/mstop.sh
@@ -36,8 +36,9 @@ for pidfile in $pfiles; do
   echo pid=$pid
   extra_check=""
   entity=`echo $fname | sed 's/\..*//g'`
+  name=`echo $fname | sed 's/\.pid$//g'`
   [ "$entity" == "radosgw" ] && extra_check="-e lt-radosgw"
-  echo entity=$entity pid=$pid
+  echo entity=$entity pid=$pid name=$name
   while ps -p $pid -o args= | grep -q -e $entity $extracheck ; do
     cmd="kill $signal $pid"
     printf "$cmd..."

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -1016,8 +1016,9 @@ do_rgw()
     n=$(($CEPH_NUM_RGW - 1))
     i=0
     for rgw in j k l m n o p q r s t u v; do
-        echo start rgw on http${CEPH_RGW_HTTPS}://localhost:$((CEPH_RGW_PORT_NUM + i))
-        run 'rgw' $RGWSUDO $CEPH_BIN/radosgw -c $conf_fn --log-file=${CEPH_OUT_DIR}/rgw.$rgw.log ${RGWDEBUG} --debug-ms=1 -n client.rgw "--rgw_frontends=${rgw_frontend} port=$((CEPH_RGW_PORT_NUM + i))${CEPH_RGW_HTTPS}"
+        current_port=$((CEPH_RGW_PORT_NUM + i))
+        echo start rgw on http${CEPH_RGW_HTTPS}://localhost:${current_port}
+        run 'rgw' $RGWSUDO $CEPH_BIN/radosgw -c $conf_fn --log-file=${CEPH_OUT_DIR}/radosgw.${current_port}.log --admin-socket=${CEPH_OUT_DIR}/radosgw.${current_port}.asok --pid-file=${CEPH_OUT_DIR}/radosgw.${current_port}.pid ${RGWDEBUG} --debug-ms=1 -n client.rgw "--rgw_frontends=${rgw_frontend} port=${current_port}${CEPH_RGW_HTTPS}"
         i=$(($i + 1))
         [ $i -eq $CEPH_NUM_RGW ] && break
     done


### PR DESCRIPTION
+ As mstop.sh find rgw processes by looking for pid file, so we need to
  specify the --pid-file option to let rgw create it.
+ Use rgw port instead of meaningless 'j k' in the file name
+ Add rgw asok support
+ Make vstart.sh respect 'radosgw' prefix (defined in mrgw.sh) instead of 'rgw'

before:

```
[root@ceph-node1]~/jiaying/ceph/build# ../src/mrun j ceph -w
2017-08-31 16:34:05.413931 7f69081e7700 -1 WARNING: all dangerous and experimental features are enabled.
2017-08-31 16:34:05.445024 7f69081e7700 -1 WARNING: all dangerous and experimental features are enabled.
  cluster:
    id:     9952bf4f-0829-49e3-b893-abe858b690e5
    health: HEALTH_OK

  services:
    mon: 1 daemons, quorum a
    mgr: x(active)
    mds: cephfs_a-1/1/1 up  {0=a=up:active}
    osd: 1 osds: 1 up, 1 in
    rgw: 1 daemon active

  data:
    pools:   6 pools, 48 pgs
    objects: 254 objects, 5964 bytes
    usage:   24549 MB used, 26625 MB / 51175 MB avail
    pgs:     48 active+clean

  io:
    client:   10919 B/s rd, 0 B/s wr, 10 op/s rd, 5 op/s wr

[root@ceph-node1]~/jiaying/ceph/build# ../src/mstop.sh j
2645521
pid=2645521
entity=mds pid=2645521
kill  2645521...2645132
pid=2645132
entity=mgr pid=2645132
kill  2645132...2645008
pid=2645008
entity=mon pid=2645008
kill  2645008...2645326
pid=2645326
entity=osd pid=2645326
kill  2645326...kill  2645326...#
[root@ceph-node1]~/jiaying/ceph/build# ps aux| grep radosg
root     2645832  1.0  0.0 1668120 40088 ?       Ssl  16:32   0:01 /root/jiaying/ceph/build/bin/radosgw -c /root/jiaying/ceph/build/run/j/ceph.conf --log-file=/root/jiaying/ceph/build/run/j/out/rgw.j.log --debug-ms=1 -n client.rgw --rgw_frontends=civetweb port=8001
root     2646217  0.0  0.0 112648   964 pts/3    S+   16:34   0:00 grep --color=auto radosg
```

after:

```
[root@ceph-node1]~ CEPH_NUM_MON=1 CEPH_NUM_OSD=1 CEPH_NUM_MDS=1 CEPH_NUM_MGR=1  CEPH_NUM_RGW=2 ../src/mstart.sh j  -n -X -l

[root@ceph-node1]~/jiaying/ceph/build# ../src/mstop.sh  j
2760395
pid=2760395
entity=mds pid=2760395 name=mds.a
kill  2760395...2760007
pid=2760007
entity=mgr pid=2760007 name=mgr.x
kill  2760007...2759883
pid=2759883
entity=mon pid=2759883 name=mon.a
kill  2759883...2760201
pid=2760201
entity=osd pid=2760201 name=osd.0
kill  2760201...kill  2760201...2760707
pid=2760707
entity=radosgw pid=2760707 name=radosgw.8001
kill  2760707...kill  2760707...2760714
pid=2760714
entity=radosgw pid=2760714 name=radosgw.8002
kill  2760714...kill  2760714...#
```

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>
