### PR TITLE
test/throttle: kill tests exercising dtor of Throttle classes

### DIFF
--- a/src/test/common/Throttle.cc
+++ b/src/test/common/Throttle.cc
@@ -35,7 +35,6 @@
 #include "common/Throttle.h"
 #include "common/ceph_argparse.h"
 #include "common/backport14.h"
-#include "include/coredumpctl.h"
 
 class ThrottleTest : public ::testing::Test {
 protected:
@@ -214,32 +213,6 @@ TEST_F(ThrottleTest, wait) {
   } while(!waited);
 }
 
-TEST_F(ThrottleTest, destructor) {
-  PrCtl unset_dumpable;
-  EXPECT_DEATH({
-      int64_t throttle_max = 10;
-      auto throttle = ceph::make_unique<Throttle>(g_ceph_context, "throttle",
-						  throttle_max);
-
-
-      ASSERT_FALSE(throttle->get(5));
-      unique_ptr<Thread_get> t = ceph::make_unique<Thread_get>(*throttle, 7);
-      t->create("t_throttle");
-      bool blocked;
-      useconds_t delay = 1;
-      do {
-	usleep(delay);
-	if (throttle->get_or_fail(1)) {
-	  throttle->put(1);
-	  blocked = false;
-	} else {
-	  blocked = true;
-	}
-	delay *= 2;
-      } while (!blocked);
-    }, ".*");
-}
-
 std::pair<double, std::chrono::duration<double> > test_backoff(
   double low_threshhold,
   double high_threshhold,
@@ -349,26 +322,6 @@ std::pair<double, std::chrono::duration<double> > test_backoff(
     wait_time / waits);
 }
 
-TEST(BackoffThrottle, destruct) {
-  PrCtl unset_dumpable;
-  EXPECT_DEATH({
-      auto throttle = ceph::make_unique<BackoffThrottle>(
-	g_ceph_context, "destructor test", 10);
-      ASSERT_TRUE(throttle->set_params(0.4, 0.6, 1000, 2, 10, 6, nullptr));
-
-      throttle->get(5);
-      {
-	auto& t = *throttle;
-	std::thread([&t]() {
-	    usleep(5);
-	    t.get(6);
-	  });
-      }
-      // No equivalent of get_or_fail()
-      std::this_thread::sleep_for(std::chrono::milliseconds(250));
-    }, ".*");
-}
-
 TEST(BackoffThrottle, undersaturated)
 {
   auto results = test_backoff(
@@ -423,28 +376,11 @@ TEST(BackoffThrottle, oversaturated)
   ASSERT_GT(results.second.count(), 0.0005);
 }
 
-TEST(OrderedThrottle, destruct) {
-  PrCtl unset_dumpable;
-  EXPECT_DEATH({
-      auto throttle = ceph::make_unique<OrderedThrottle>(1, false);
-      throttle->start_op(nullptr);
-      {
-	auto& t = *throttle;
-	std::thread([&t]() {
-	    usleep(5);
-	    t.start_op(nullptr);
-	  });
-      }
-      // No equivalent of get_or_fail()
-      std::this_thread::sleep_for(std::chrono::milliseconds(250));
-    }, ".*");
-}
-
 /*
  * Local Variables:
  * compile-command: "cd ../.. ;
  *   make unittest_throttle ;
- *   ./unittest_throttle # --gtest_filter=ThrottleTest.destructor \
+ *   ./unittest_throttle # --gtest_filter=ThrottleTest.take \
  *       --log-to-stderr=true --debug-filestore=20
  * "
  * End:


### PR DESCRIPTION
quote from Adam,

> let's just remove all the destructor tests. Since it's just exercising
> an assertion, it's most likely to be complexity that doesn't buy us
> much.

Signed-off-by: Kefu Chai <kchai@redhat.com>