### PR TITLE
ceph-rest-api: when port=0 use the DEFAULT_PORT instead

### DIFF
--- a/src/pybind/ceph_rest_api.py
+++ b/src/pybind/ceph_rest_api.py
@@ -118,8 +118,8 @@ def api_setup(app, conf, cluster, clientname, clientid, args):
     addr = app.ceph_cluster.conf_get('public_addr') or DEFAULT_ADDR
 
     if addr == '-':
-        addr = None
-        port = None
+        addr = DEFAULT_ADDR
+        port = int(DEFAULT_PORT)
     else:
         # remove the type prefix from the conf value if any
         for t in ('legacy:', 'msgr2:'):
@@ -129,9 +129,7 @@ def api_setup(app, conf, cluster, clientname, clientid, args):
         # remove any nonce from the conf value
         addr = addr.split('/')[0]
         addr, port = addr.rsplit(':', 1)
-    addr = addr or DEFAULT_ADDR
-    port = port or DEFAULT_PORT
-    port = int(port)
+        port = int(port) or int(DEFAULT_PORT)
 
     loglevel = app.ceph_cluster.conf_get('restapi_log_level') \
         or DEFAULT_LOG_LEVEL


### PR DESCRIPTION
When `/etc/ceph/ceph.conf` with below settings:

```
[global]
public_addr = 10.153.55.135
```

in this case, port for ceph-rest-api would get a random port for rest service. Take `public_addr = 10.153.55.135` as an example, the original code would get a random port for rest-api service.

```
    addr = app.ceph_cluster.conf_get('public_addr') or DEFAULT_ADDR  # <-- addr = 10.153.55.135:0/0

    if addr == '-':
        addr = None
        port = None
    else:
        # remove the type prefix from the conf value if any
        for t in ('legacy:', 'msgr2:'):
            if addr.startswith(t):
                addr = addr[len(t):]
                break
        # remove any nonce from the conf value
        addr = addr.split('/')[0]
        addr, port = addr.rsplit(':', 1)   # addr = 10.153.55.135, port = '0'
    addr = addr or DEFAULT_ADDR
    port = port or DEFAULT_PORT  # <-- if port == '0', the port would be 0, ceph-rest-api would get a random port instead of 5000.
    port = int(port)
```

This patch mainly wants to use the default port `5000` for this case.

Signed-off-by: You Ji <youji@ebay.com>