### PR TITLE
doc: improve misleading description of application enable

### DIFF
--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -962,7 +962,7 @@ COMMAND("osd pool application enable " \
         "name=pool,type=CephPoolname " \
         "name=app,type=CephString,goodchars=[A-Za-z0-9-_.] " \
 	"name=force,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-        "enable use of an application <app> [cephfs,rbd,rgw] on pool <poolname>",
+        "enable use of an application <app> [cephfs,rbd,rgw] on pool <poolname>.  --yes-i-really-mean-it is optional, unless you want enable multi-application to the same pool",
         "osd", "rw", "cli,rest")
 COMMAND("osd pool application disable " \
         "name=pool,type=CephPoolname " \


### PR DESCRIPTION
As the doc[1] don't mention `--yes-i-really-mean-it` option,but the
cli usage description does:

```
 Monitor commands:
 =================
osd pool application disable <poolname> <app> {--yes-i-really-mean- disables use of an application <app> on pool <poolname>
 it}
osd pool application enable <poolname> <app> {--yes-i-really-mean-  enable use of an application <app> [cephfs,rbd,rgw] on pool
 it}                                                                 <poolname>
osd pool application get {<poolname>} {<app>} {<key>}               get value of key <key> of application <app> on pool <poolname>
osd pool application rm <poolname> <app> <key>                      removes application <app> metadata key <key> on pool <poolname>
osd pool application set <poolname> <app> <key> <value>             sets application <app> metadata key <key> to <value> on pool
                                                                     <poolname>
```

It would mislead user to use `--yes-i-really-mean-it` anyway.

+ [1] http://docs.ceph.com/docs/master/rados/operations/pools/#associate-pool-to-application

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>