### PR TITLE
osd/PrimaryLogPG: fix incorrect ondisk_read_lock scope for ec-reads 

### DIFF
--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -279,18 +279,6 @@ int ReplicatedBackend::objects_read_sync(
   return store->read(ch, ghobject_t(hoid), off, len, *bl, op_flags);
 }
 
-struct AsyncReadCallback : public GenContext<ThreadPool::TPHandle&> {
-  int r;
-  Context *c;
-  AsyncReadCallback(int r, Context *c) : r(r), c(c) {}
-  void finish(ThreadPool::TPHandle&) override {
-    c->complete(r);
-    c = NULL;
-  }
-  ~AsyncReadCallback() override {
-    delete c;
-  }
-};
 void ReplicatedBackend::objects_read_async(
   const hobject_t &hoid,
   const list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
@@ -298,29 +286,7 @@ void ReplicatedBackend::objects_read_async(
   Context *on_complete,
   bool fast_read)
 {
-  // There is no fast read implementation for replication backend yet
-  assert(!fast_read);
-
-  int r = 0;
-  for (list<pair<boost::tuple<uint64_t, uint64_t, uint32_t>,
-		 pair<bufferlist*, Context*> > >::const_iterator i =
-	   to_read.begin();
-       i != to_read.end() && r >= 0;
-       ++i) {
-    int _r = store->read(ch, ghobject_t(hoid), i->first.get<0>(),
-			 i->first.get<1>(), *(i->second.first),
-			 i->first.get<2>());
-    if (i->second.second) {
-      get_parent()->schedule_recovery_work(
-	get_parent()->bless_gencontext(
-	  new AsyncReadCallback(_r, i->second.second)));
-    }
-    if (_r < 0)
-      r = _r;
-  }
-  get_parent()->schedule_recovery_work(
-    get_parent()->bless_gencontext(
-      new AsyncReadCallback(r, on_complete)));
+  assert(0 == "not implemented");
 }
 
 class C_OSD_OnOpCommit : public Context {


### PR DESCRIPTION
Reads from an EC pool are asynchronous, thus the ondisk_read_lock
shall be grabbed until the corresponding reads are truly completed.
    
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>