### PR TITLE
MDS: Make standby-replay mds avoid initiating subtree export

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6522,7 +6522,7 @@ bool MDCache::trim(int max, int count)
       if (!diri->is_auth() && !diri->is_base() &&
 	  dir->get_num_head_items() == 0) {
 	if (dir->state_test(CDir::STATE_EXPORTING) ||
-	    dir->is_freezing() || dir->is_frozen())
+	    dir->is_freezing() || dir->is_frozen() || !mds->is_active())
 	  continue;
 
 	migrator->export_empty_import(dir);

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -793,6 +793,10 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
     //ceph_abort();
     return;
   }
+  if (!mds->is_active()) {
+    dout(7) << "i'm not active, no exports for now" << dendl;
+    return;
+  }
 
   if (!dir->inode->is_base() && dir->inode->get_projected_parent_dir()->inode->is_stray() &&
       dir->inode->get_projected_parent_dir()->get_parent_dir()->ino() != MDS_INO_MDSDIR(dest)) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21222
Signed-off-by: "Jianyu Li" joannyli@tencent.com