### PR TITLE
osd_types: define max in eversion_t::max() to static

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -795,10 +795,8 @@ public:
 
   explicit eversion_t(bufferlist& bl) : __pad(0) { decode(bl); }
 
-  static eversion_t max() {
-    eversion_t max;
-    max.version -= 1;
-    max.epoch -= 1;
+  static const eversion_t& max() {
+    static const eversion_t max(-1,-1);
     return max;
   }
 


### PR DESCRIPTION
max in eversion_t::max() can be static, no need to re constructs
it every time when calling eversion_t::max(), and max can be
constructed using eversion_t(epoch_t e, version_t v), it better than
firstly construct it by eversion_t() and then reassign it to (-1,-1)

Change-Id: I85de5685024e61ebc2d1816b0969be67bdaf45f5
Signed-off-by: yang.wang yang.wang@easystack.cn