### PR TITLE
mds: print subtrees only after merge

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -941,9 +941,9 @@ void MDCache::try_subtree_merge_at(CDir *dir, set<CInode*> *to_eval)
 
     if (to_eval && dir->get_inode()->is_auth())
       to_eval->insert(dir->get_inode());
-  } 
 
-  show_subtrees(15);
+    show_subtrees(15);
+  }
 }
 
 void MDCache::subtree_merge_writebehind_finish(CInode *in, MutationRef& mut)


### PR DESCRIPTION
During up:resolve, the MDS tries to merge each subtree with its parent. During
testing, QE found that many thousands of subtrees in a directory (made possible
using pins) would cause the MDS to spend minutes printing out subtree maps to
the debug log. This causes the heartbeat code to consider the MDS as stalled so
beacons are no longer sent to the mons resulting in the MDS being removed from
the rank.

A more complete solution to this problem is to selectively print subtrees
relating to the operation (e.g. the subtree and its parents).

Fixes: http://tracker.ceph.com/issues/21221
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1485783

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>