### PR TITLE
luminous: build/ops: ceph-fuse RPM should require fusermount

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -341,6 +341,7 @@ Summary:	Ceph fuse-based client
 %if 0%{?suse_version}
 Group:		System/Filesystems
 %endif
+Requires:       fuse
 %description fuse
 FUSE based client for Ceph distributed network file system
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/21104