### PR TITLE
ceph-rest-api:fix json.dump error when request for /api/v0.1/osd/df.json?output_method=tree if some osd is out of cluster

### DIFF
--- a/src/pybind/ceph_rest_api.py
+++ b/src/pybind/ceph_rest_api.py
@@ -318,7 +318,7 @@ def make_response(fmt, output, statusmsg, errorcode):
     if fmt:
         if 'json' in fmt:
             try:
-                native_output = json.loads(output or '[]')
+                native_output = json.loads(output.replace('-nan','"-nan"') or '[]')
                 response = json.dumps({"output": native_output,
                                        "status": statusmsg})
             except:


### PR DESCRIPTION
hi,
   when there is a osd out of cluster, the request /api/v0.1/osd/df.json?output_method=tree will response

Error decoding JSON from...

and i found this is because when this a osd out of cluster ,this will -nan in output string and the json.loads can not  process -nan, we need to replace -nan with "-nan"

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>