### PR TITLE
lixos/bluestore, PoC, DNM: release disk extents in lazy and bulky manner

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -48,15 +48,7 @@ public:
 
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
-  virtual void release(const interval_set<uint64_t>& release_set) {
-    /* TODO(rzarzynski): make this pure virtual and eradicate the single-op
-     * release() after switching all allocators. */
-    for (interval_set<uint64_t>::const_iterator p = release_set.begin();
-	 p != release_set.end();
-	 ++p) {
-      release(p.get_start(), p.get_len());
-    }
-  }
+  virtual void release(const interval_set<uint64_t>& release_set) = 0;
 
   virtual void dump() = 0;
 

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,9 +43,6 @@ public:
     return allocate(want_size, alloc_unit, want_size, hint, extents);
   }
 
-  virtual void release(
-    uint64_t offset, uint64_t length) = 0;
-
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
   virtual void release(const interval_set<uint64_t>& release_set) = 0;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -46,6 +46,18 @@ public:
   virtual void release(
     uint64_t offset, uint64_t length) = 0;
 
+  /* Bulk release. Implementations may override this method to handle the whole
+   * set at once. This could save e.g. unnecessary mutex dance. */
+  virtual void release(const interval_set<uint64_t>& release_set) {
+    /* TODO(rzarzynski): make this pure virtual and eradicate the single-op
+     * release() after switching all allocators. */
+    for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+	 p != release_set.end();
+	 ++p) {
+      release(p.get_start(), p.get_len());
+    }
+  }
+
   virtual void dump() = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -154,6 +154,21 @@ void BitMapAllocator::release(
   insert_free(offset, length);
 }
 
+void BitMapAllocator::release(
+  const interval_set<uint64_t>& release_set)
+{
+  for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+       p != release_set.end();
+       ++p) {
+    const auto offset = p.get_start();
+    const auto length = p.get_len();
+    dout(10) << __func__ << " 0x"
+             << std::hex << offset << "~" << length << std::dec
+             << dendl;
+    insert_free(offset, length);
+  }
+}
+
 uint64_t BitMapAllocator::get_free()
 {
   assert(m_bit_alloc->total_blocks() >= m_bit_alloc->get_used_blocks());

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -146,15 +146,6 @@ int64_t BitMapAllocator::allocate_dis(
 }
 
 void BitMapAllocator::release(
-  uint64_t offset, uint64_t length)
-{
-  dout(10) << __func__ << " 0x"
-           << std::hex << offset << "~" << length << std::dec
-           << dendl;
-  insert_free(offset, length);
-}
-
-void BitMapAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
   for (interval_set<uint64_t>::const_iterator p = release_set.begin();

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -37,6 +37,8 @@ public:
 
   void release(
     uint64_t offset, uint64_t length) override;
+  void release(
+    const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;
 

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -36,8 +36,6 @@ public:
     int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents) override;
 
   void release(
-    uint64_t offset, uint64_t length) override;
-  void release(
     const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1893,8 +1893,9 @@ void BlueFS::sync_metadata()
     flush_bdev(); // FIXME?
     _flush_and_sync_log(l);
     for (unsigned i = 0; i < to_release.size(); ++i) {
-      for (auto p = to_release[i].begin(); p != to_release[i].end(); ++p) {
-	alloc[i]->release(p.get_start(), p.get_len());
+      if (!to_release[i].empty()) {
+        /* OK, now we have the guarantee alloc[i] won't be null. */
+        alloc[i]->release(to_release[i]);
       }
     }
     utime_t end = ceph_clock_now();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8126,11 +8126,7 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
   // update allocator with full released set
   if (!cct->_conf->bluestore_debug_no_reuse_blocks) {
     dout(10) << __func__ << " " << txc << " " << txc->released << dendl;
-    for (interval_set<uint64_t>::iterator p = txc->released.begin();
-	 p != txc->released.end();
-	 ++p) {
-      alloc->release(p.get_start(), p.get_len());
-    }
+    alloc->release(txc->released);
   }
 
   txc->allocated.clear();
@@ -8489,14 +8485,9 @@ void BlueStore::_kv_sync_thread()
 	if (!bluefs_gift_extents.empty()) {
 	  _commit_bluefs_freespace(bluefs_gift_extents);
 	}
-	for (auto p = bluefs_extents_reclaiming.begin();
-	     p != bluefs_extents_reclaiming.end();
-	     ++p) {
-	  dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
-		   << p.get_start() << "~" << p.get_len() << std::dec
-		   << dendl;
-	  alloc->release(p.get_start(), p.get_len());
-	}
+	dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
+		 << bluefs_extents_reclaiming << std::dec << dendl;
+	alloc->release(bluefs_extents_reclaiming);
 	bluefs_extents_reclaiming.clear();
       }
 

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1841,6 +1841,9 @@ private:
   interval_set<uint64_t> bluefs_extents;  ///< block extents owned by bluefs
   interval_set<uint64_t> bluefs_extents_reclaiming; ///< currently reclaiming
 
+  interval_set<uint64_t> lazy_release_extents;
+  std::mutex lazy_release_lock;
+
   std::mutex deferred_lock;
   std::atomic<uint64_t> deferred_seq = {0};
   deferred_osr_queue_t deferred_queue; ///< osr's with deferred io pending
@@ -2023,7 +2026,7 @@ private:
   void _txc_applied_kv(TransContext *txc);
   void _txc_committed_kv(TransContext *txc);
   void _txc_finish(TransContext *txc);
-  void _txc_release_alloc(TransContext *txc);
+  void _txc_release_alloc_locked(TransContext *txc);
 
   void _osr_drain_preceding(TransContext *txc);
   void _osr_drain_all();

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -251,6 +251,22 @@ void StupidAllocator::release(
   num_free += length;
 }
 
+void StupidAllocator::release(
+  const interval_set<uint64_t>& release_set)
+{
+  std::lock_guard<std::mutex> l(lock);
+  for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+       p != release_set.end();
+       ++p) {
+    const auto offset = p.get_start();
+    const auto length = p.get_len();
+    ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
+		   << std::dec << dendl;
+    _insert_free(offset, length);
+    num_free += length;
+  }
+}
+
 uint64_t StupidAllocator::get_free()
 {
   std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -242,16 +242,6 @@ int64_t StupidAllocator::allocate(
 }
 
 void StupidAllocator::release(
-  uint64_t offset, uint64_t length)
-{
-  std::lock_guard<std::mutex> l(lock);
-  ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
-	   	 << std::dec << dendl;
-  _insert_free(offset, length);
-  num_free += length;
-}
-
-void StupidAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
   std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -48,6 +48,8 @@ public:
 
   void release(
     uint64_t offset, uint64_t length) override;
+  void release(
+    const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;
 

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -47,8 +47,6 @@ public:
     uint64_t *offset, uint32_t *length);
 
   void release(
-    uint64_t offset, uint64_t length) override;
-  void release(
     const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;


### PR DESCRIPTION
Rough performance tests
----------------------------------

### After the change
```
Jobs: 20 (f=1280): [w(20)][14.3%][r=0KiB/s,w=729MiB/s][r=0,w=186k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][19.0%][r=0KiB/s,w=726MiB/s][r=0,w=186k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][23.8%][r=0KiB/s,w=720MiB/s][r=0,w=184k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][28.6%][r=0KiB/s,w=724MiB/s][r=0,w=185k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][33.3%][r=0KiB/s,w=702MiB/s][r=0,w=180k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][38.1%][r=0KiB/s,w=722MiB/s][r=0,w=185k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][42.9%][r=0KiB/s,w=730MiB/s][r=0,w=187k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][47.6%][r=0KiB/s,w=733MiB/s][r=0,w=188k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][52.4%][r=0KiB/s,w=719MiB/s][r=0,w=184k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][57.1%][r=0KiB/s,w=725MiB/s][r=0,w=186k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][61.9%][r=0KiB/s,w=708MiB/s][r=0,w=181k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][66.7%][r=0KiB/s,w=735MiB/s][r=0,w=188k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][71.4%][r=0KiB/s,w=730MiB/s][r=0,w=187k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][76.2%][r=0KiB/s,w=722MiB/s][r=0,w=185k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][81.0%][r=0KiB/s,w=704MiB/s][r=0,w=180k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][85.7%][r=0KiB/s,w=695MiB/s][r=0,w=178k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][90.5%][r=0KiB/s,w=709MiB/s][r=0,w=181k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][95.2%][r=0KiB/s,w=726MiB/s][r=0,w=186k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][100.0%][r=0KiB/s,w=723MiB/s][r=0,w=185k IOPS][eta 00

```

### Before the change
Tested on relatively fresh `master` (dd4cc66673df048d0840d31fb0bacc514ad481df, `Fri Sep 1 03:36:42 2017 +0000`).
```
Jobs: 20 (f=1280): [w(20)][14.3%][r=0KiB/s,w=497MiB/s][r=0,w=127k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][19.0%][r=0KiB/s,w=481MiB/s][r=0,w=123k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][23.8%][r=0KiB/s,w=504MiB/s][r=0,w=129k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][28.6%][r=0KiB/s,w=466MiB/s][r=0,w=119k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][33.3%][r=0KiB/s,w=501MiB/s][r=0,w=128k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][38.1%][r=0KiB/s,w=467MiB/s][r=0,w=120k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][42.9%][r=0KiB/s,w=490MiB/s][r=0,w=125k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][47.6%][r=0KiB/s,w=497MiB/s][r=0,w=127k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][52.4%][r=0KiB/s,w=492MiB/s][r=0,w=126k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][57.1%][r=0KiB/s,w=479MiB/s][r=0,w=123k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][61.9%][r=0KiB/s,w=473MiB/s][r=0,w=121k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][66.7%][r=0KiB/s,w=484MiB/s][r=0,w=124k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][71.4%][r=0KiB/s,w=487MiB/s][r=0,w=125k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][76.2%][r=0KiB/s,w=485MiB/s][r=0,w=124k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][81.0%][r=0KiB/s,w=488MiB/s][r=0,w=125k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][85.7%][r=0KiB/s,w=491MiB/s][r=0,w=126k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][90.5%][r=0KiB/s,w=480MiB/s][r=0,w=123k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][95.2%][r=0KiB/s,w=487MiB/s][r=0,w=125k IOPS][eta 00m
Jobs: 20 (f=1280): [w(20)][100.0%][r=0KiB/s,w=476MiB/s][r=0,w=122k IOPS][eta 00
```

### The configuration
```
$ cat ceph-bluestore.fio 
# Runs a 64k random write test against the ceph BlueStore.
[global]
ioengine=libfio_ceph_objectstore.so # must be found in your LD_LIBRARY_PATH

conf=ceph-bluestore.conf # must point to a valid ceph configuration file
directory=/work/bluestore_testing # directory for osd_data

rw=randwrite
iodepth=16

time_based=1
runtime=20s
numjobs=20

[bluestore]
nr_files=64
size=256k
bs=4k
```

```
$ cat ceph-bluestore.conf 
# example configuration file for ceph-bluestore.fio

[global]
	debug bluestore = 0/0
	debug bluefs = 0/0
	debug bdev = 0/0
	debug rocksdb = 0/0
	# spread objects over 8 collections
	osd pool default pg num = 8
	# increasing shards can help when scaling number of collections
	osd op num shards = 5
	bluestore block create = false
	bluestore block path = /dev/nvme0n1p4
	bluestore_debug_omit_block_device_write = true
	bluestore_debug_omit_kv_commit = true
	bluestore_allocator = stupid # bitmap
	bluestore_min_alloc_size = 4096 #16384


[osd]
	osd objectstore = bluestore

	# use directory= option from fio job file
	osd data = ${fio_dir}

	# log inside fio_dir
	log file = ${fio_dir}/log
```