### PR TITLE
osd_types: optimized version of pg_pool_t::build_removed_snaps

### DIFF
--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1562,6 +1562,7 @@ public:
    * explicit removed_snaps set.
    */
   void build_removed_snaps(interval_set<snapid_t>& rs) const;
+  bool build_removed_snaps_and_check_intersect(interval_set<snapid_t>& rs, interval_set<snapid_t>& cached) const;
   snapid_t snap_exists(const char *s) const;
   void add_snap(const char *n, utime_t stamp);
   void add_unmanaged_snap(uint64_t& snapid);


### PR DESCRIPTION
Previous version iterated over entire range 1..get_snap_seq, and each time over entire snaps map (which is lg*snaps.size, making it M*lgN), adding each missing snap by one (up to M*lgN). Reduce that  considerably by iterating only over existing snaps and adding missing ones as ranges instead of relying on interval_set.insert(el) to coalesce them on-fly.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>