### PR TITLE
luminous: osd: build_initial_pg_history doesn't update up/acting/etc 

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4454,6 +4454,10 @@ void OSD::build_initial_pg_history(
       h->last_epoch_split = e;
     }
     lastmap = osdmap;
+    up_primary = new_up_primary;
+    acting_primary = new_acting_primary;
+    up = new_up;
+    acting = new_acting;
   }
   dout(20) << __func__ << " " << debug.str() << dendl;
   dout(10) << __func__ << " " << *h << " " << *pi


### PR DESCRIPTION
http://tracker.ceph.com/issues/21236