### PR TITLE
qa/objectstore/bluestore*: less debug output

### DIFF
--- a/qa/objectstore/bluestore-bitmap.yaml
+++ b/qa/objectstore/bluestore-bitmap.yaml
@@ -8,8 +8,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true
@@ -28,8 +27,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true

--- a/qa/objectstore/bluestore-comp.yaml
+++ b/qa/objectstore/bluestore-comp.yaml
@@ -8,8 +8,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore compression mode: aggressive

--- a/qa/objectstore/bluestore.yaml
+++ b/qa/objectstore/bluestore.yaml
@@ -8,8 +8,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true
@@ -27,8 +26,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true


### PR DESCRIPTION
Let's see if this makes the spurious MON_DOWN failures go away?  (See
http://tracker.ceph.com/issues/20910)

Signed-off-by: Sage Weil <sage@redhat.com>