### PR TITLE
mds: reset Formatter on error

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1937,6 +1937,7 @@ bool MDSRankDispatcher::handle_asok_command(
 
     if (r != 0) {
       ss << "Failed to dump cache: " << cpp_strerror(r);
+      f->reset();
     }
   } else if (command == "dump tree") {
     string root;
@@ -1949,6 +1950,7 @@ bool MDSRankDispatcher::handle_asok_command(
       int r = mdcache->dump_cache(root, depth, f);
       if (r != 0) {
         ss << "Failed to dump tree: " << cpp_strerror(r);
+        f->reset();
       }
     }
   } else if (command == "force_readonly") {


### PR DESCRIPTION
This prevents partial results from concatenating with the error message.

Fixes: http://tracker.ceph.com/issues/21252

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>