### PR TITLE
githubmap: add some known Ceph reviewers

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -8,15 +8,35 @@
 #
 #
 ajarr Ramana Raja <rraja@redhat.com>
+amitkumar50 Amit Kumar <amitkuma@redhat.com>
+athanatos Samuel Just <sjust@redhat.com>
+badone Brad Hubbard <bhubbard@redhat.com>
+bassamtabbara Bassam Tabbara <bassam.tabbara@quantum.com>
 batrick Patrick Donnelly <pdonnell@redhat.com>
+branch-predictor Piotr Dałek <piotr.dalek@corp.ovh.com>
+chhabaramesh Ramesh Chander <Ramesh.Chander@sandisk.com>
+dvanders Dan van der Ster <daniel.vanderster@cern.ch>
 fullerdj Douglas Fuller <dfuller@redhat.com>
 gregsfortytwo Gregory Farnum <gfarnum@redhat.com>
+ifed01 Igor Fedotov <ifedotov@mirantis.com>
+ivancich J. Eric Ivancich <ivancich@redhat.com>
 jcsp John Spray <john.spray@redhat.com>
 jlayton Jeff Layton <jlayton@redhat.com>
 joscollin Jos Collin <jcollin@redhat.com>
+leseb Sébastien Han <seb@redhat.com>
 liewegas Sage Weil <sage@redhat.com>
+liupan1111 Pan Liu <liupan1111@gmail.com>
+majianpeng Jianpeng Ma <jianpeng.ma@intel.com>
+markhpc Mark Nelson <mnelson@redhat.com>
+rchagam Anjaneya Chagam <anjaneya.chagam@intel.com>
 renhwztetecs huanwen ren <ren.huanwen@zte.com.cn>
 smithfarm Nathan Cutler <ncutler@suse.com>
 tchaikov Kefu Chai <kchai@redhat.com>
 theanalyst Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>
+trociny Mykola Golub <mgolub@mirantis.com>
 ukernel Zheng Yan <zyan@redhat.com>
+vasukulkarni Vasu Kulkarni <vasu@redhat.com>
+vuhuong Vu Pham <vuhuong@mellanox.com>
+xiexingguo xie xingguo <xie.xingguo@zte.com.cn>
+yangdongsheng Dongsheng Yang <dongsheng.yang@easystack.cn>
+yuyuyu101 Haomai Wang <haomai@xsky.com>


### PR DESCRIPTION
Selection from [1] where the GitHub username is available.

[1] http://pad.ceph.com/p/reviewers

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>