### PR TITLE
.githubmap: Add wjwithagen as a known Ceph reviewer

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -37,6 +37,7 @@ trociny Mykola Golub <mgolub@mirantis.com>
 ukernel Zheng Yan <zyan@redhat.com>
 vasukulkarni Vasu Kulkarni <vasu@redhat.com>
 vuhuong Vu Pham <vuhuong@mellanox.com>
+wjwithagen Willem Jan Withagen <wjw@digiware.nl>
 xiexingguo xie xingguo <xie.xingguo@zte.com.cn>
 yangdongsheng Dongsheng Yang <dongsheng.yang@easystack.cn>
 yuyuyu101 Haomai Wang <haomai@xsky.com>


### PR DESCRIPTION
Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>