### PR TITLE
rgw: Drop unnecessary return

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -3445,7 +3445,7 @@ int main(int argc, const char **argv)
         formatter->flush(cout);
         cout << std::endl;
       }
-      return 0;
+      break;
 
     case OPT_ZONEGROUP_ADD:
       {


### PR DESCRIPTION
Dropped unnecessary return, as it is returning [after the switch](https://github.com/iliul/ceph/blob/ac23940e0983de2ae9f4f1a771255fd85228ee97/src/rgw/rgw_admin.cc#L4315). This matches with the other
cases in the same switch.

Found while reviewing https://github.com/ceph/ceph/pull/17434

Signed-off-by: Jos Collin <jcollin@redhat.com>