### PR TITLE
rgw: Fix the keysword of bucket policy. And remove ',' at last line which violates json grammar

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1576,9 +1576,8 @@ ostream& operator <<(ostream& m, const Policy& p) {
   }
 
   if (!p.statements.empty()) {
-    m << "Statements: ";
+    m << "Statement: ";
     print_array(m, p.statements.cbegin(), p.statements.cend());
-    m << ", ";
   }
   return m << " }";
 }


### PR DESCRIPTION
rgw: Fix the keysword of bucket policy. And remove ',' at last line which violates json grammar
Signed-off-by: Wen Zhang zhangwen1@unionpay.com