### PR TITLE
core: suppress warning of Clang unknown pragma

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -297,7 +297,9 @@ inline void encode(const boost::optional<T> &p, bufferlist &bl)
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
+#if !defined(__clang__)
 #pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+#endif
 template<typename T>
 inline void decode(boost::optional<T> &p, bufferlist::iterator &bp)
 {


### PR DESCRIPTION
Clang does not have the same pramas as GCC:
```
/home/jenkins/workspace/ceph-master/src/include/encoding.h:301:32: warning: unknown warning group '-Wmaybe-uninitialized', ignored [-Wunknown-warning-option]
                               ^
1 warning generated.
```

Signed-off-by: Willem Jan Withagen <wjw@digiware.nl>