### PR TITLE
mon: fix `osd out` clog message

### DIFF
--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -9065,7 +9065,8 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
             if (osdmap.is_up(osd)) {
               msg << ", while it was still marked up";
             } else {
-              msg << ", after it was down for " << int(down_pending_out[osd].sec())
+              auto period = ceph_clock_now() - down_pending_out[osd];
+              msg << ", after it was down for " << int(period.sec())
                   << " seconds";
             }
 


### PR DESCRIPTION
This was printing the absolute time instead of the period.

Fixes: http://tracker.ceph.com/issues/21249
Signed-off-by: John Spray <john.spray@redhat.com>