### PR TITLE
qa/tasks/ceph_manager: avoid test_map_discontinuity stall with too few in osds

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -998,7 +998,8 @@ class Thrasher:
                     self.ceph_manager.raw_cluster_cmd('osd', 'reweight',
                                                       str(osd), str(1))
                 if random.uniform(0, 1) < float(
-                        self.config.get('chance_test_map_discontinuity', 0)):
+                        self.config.get('chance_test_map_discontinuity', 0)) \
+                        and len(self.live_osds) > 5: # avoid m=2,k=2 stall, w/ some buffer for crush being picky
                     self.test_map_discontinuity()
                 else:
                     self.ceph_manager.wait_for_recovery(


### PR DESCRIPTION
Some tests have m=2,k=2 and this will break them.

We don't have an easy way from here to see what the min in osds for healthy
is...  basically this map discontinuity test just sucks.

Signed-off-by: Sage Weil <sage@redhat.com>