### PR TITLE
os/bluestore: add bluestore_prefer_deferred_size_hdd/ssd to tracked keys

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3538,6 +3538,8 @@ const char **BlueStore::get_tracked_conf_keys() const
     "bluestore_compression_required_ratio",
     "bluestore_max_alloc_size",
     "bluestore_prefer_deferred_size",
+    "bluestore_prefer_deferred_size_hdd",
+    "bluestore_prefer_deferred_size_ssd",
     "bluestore_deferred_batch_ops",
     "bluestore_deferred_batch_ops_hdd",
     "bluestore_deferred_batch_ops_ssd",
@@ -3577,6 +3579,8 @@ void BlueStore::handle_conf_change(const struct md_config_t *conf,
     }
   }
   if (changed.count("bluestore_prefer_deferred_size") ||
+      changed.count("bluestore_prefer_deferred_size_hdd") ||
+      changed.count("bluestore_prefer_deferred_size_ssd") ||
       changed.count("bluestore_max_alloc_size") ||
       changed.count("bluestore_deferred_batch_ops") ||
       changed.count("bluestore_deferred_batch_ops_hdd") ||


### PR DESCRIPTION
To make these two keys can be changed online:

./bin/ceph tell osd.* injectargs "--bluestore_prefer_deferred_size_hdd 0"
osd.0: bluestore_prefer_deferred_size_hdd = '0' (not observed, change may require restart)
osd.1: bluestore_prefer_deferred_size_hdd = '0' (not observed, change may require restart)
osd.2: bluestore_prefer_deferred_size_hdd = '0' (not observed, change may require restart)

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
(cherry picked from commit cd1225634cf4d20e485f7c30d5a0438febc7ddcc)