### PR TITLE
mon: show feature flags when printing MonSession

### DIFF
--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -225,9 +225,10 @@ struct MonSessionMap {
 
 inline ostream& operator<<(ostream& out, const MonSession& s)
 {
-  out << "MonSession(" << s.inst << " is "
-      << (s.closed ? "closed" : "open");
-  out << " " << s.caps << ")";
+  out << "MonSession(" << s.inst << " is " << (s.closed ? "closed" : "open")
+      << " " << s.caps << ", features 0x" << std::hex << s.con_features << std::dec
+      <<  " (" << ceph_release_name(ceph_release_from_features(s.con_features))
+      << "))";
   return out;
 }
 


### PR DESCRIPTION
This is meant to be used for the `sessions` ceph-mon command, the new output looks like this:

```
    "MonSession(client.256938257 XXXXXX:0/1565106796 is open allow r, features 0xff8eea4fffb (firefly))",
    "MonSession(client.201746016 XXXXXX:0/3756355047 is open allow profile mgr, features 0x1ffddff8eea4fffb (luminous))",
```

Useful to identify from where older clients connect to the cluster as `ceph features` only tells you about their existence. Would be nicer to have this integrated in `ceph features` somehow, but that looked significantly more complicated...

Signed-off-by: Paul Emmerich <paul.emmerich@croit.io>