### PR TITLE
rgw: fix total_time to msec as per AWS S3

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -5049,7 +5049,7 @@ int main(int argc, const char **argv)
         formatter->open_array_section("log_entries");
 
       do {
-	uint64_t total_time =  entry.total_time.sec() * 1000000LL + entry.total_time.usec();
+	uint64_t total_time =  entry.total_time.to_msec();
 
         agg_time += total_time;
         agg_bytes_sent += entry.bytes_sent;

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -251,7 +251,7 @@ void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)
   formatter->dump_int("bytes_sent", entry.bytes_sent);
   formatter->dump_int("bytes_received", entry.bytes_received);
   formatter->dump_int("object_size", entry.obj_size);
-  uint64_t total_time =  entry.total_time.sec() * 1000000LL + entry.total_time.usec();
+  uint64_t total_time =  entry.total_time.to_msec();
 
   formatter->dump_int("total_time", total_time);
   formatter->dump_string("user_agent",  entry.user_agent);


### PR DESCRIPTION
As AWS log format[1] are using millisecond as unit, change rgw total_time
unit from usec to msec.

[1] http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>