### PR TITLE
rgw: cleanup req_state::prot_flags to RGW_REST_SWIFT_AUTH for swift_auth

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -320,7 +320,7 @@ void set_req_state_err(struct rgw_err& err,	/* out */
   err.ret = -err_no;
   bool is_website_redirect = false;
 
-  if (prot_flags & RGW_REST_SWIFT) {
+  if (prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)) {
     if (search_err(rgw_http_swift_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
       return;
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -466,7 +466,8 @@ void dump_etag(struct req_state* const s,
     return;
   }
 
-  if (s->prot_flags & RGW_REST_SWIFT && ! quoted) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)
+      && ! quoted) {
     return dump_header(s, "etag", etag);
   } else {
     return dump_header_quoted(s, "ETag", etag);
@@ -649,7 +650,7 @@ void dump_start(struct req_state *s)
 
 void dump_trans_id(req_state *s)
 {
-  if (s->prot_flags & RGW_REST_SWIFT) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)) {
     dump_header(s, "X-Trans-Id", s->trans_id);
     dump_header(s, "X-Openstack-Request-Id", s->trans_id);
   } else if (s->trans_id.length()) {
@@ -675,7 +676,8 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
     dump_access_control(s, op);
   }
 
-  if (s->prot_flags & RGW_REST_SWIFT && !content_type) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)
+      && !content_type) {
     force_content_type = true;
   }
 
@@ -697,7 +699,7 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
       ctype = "text/plain";
       break;
     }
-    if (s->prot_flags & RGW_REST_SWIFT)
+    if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH))
       ctype.append("; charset=utf-8");
     content_type = ctype.c_str();
   }

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -585,8 +585,6 @@ void RGW_SWIFT_Auth_Get::execute()
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");
 
-  s->prot_flags |= RGW_REST_SWIFT;
-
   string user_str;
   RGWUserInfo info;
   bufferlist bl;

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -306,9 +306,10 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_SWIFT_AUTH;
     return new RGWHandler_SWIFT_Auth;
   }
 };


### PR DESCRIPTION
For swift auth request, the req_state::prot_flags should be set to RGW_REST_SWIFT_AUTH

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>