### PR TITLE
tools: Modify "rados df" header's alignment

### DIFF
--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -2036,17 +2036,17 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
     if (!formatter) {
       tab.define_column("POOL_NAME", TextTable::LEFT, TextTable::LEFT);
-      tab.define_column("USED", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("OBJECTS", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("CLONES", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("COPIES", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("MISSING_ON_PRIMARY", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("DEGRADED", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("RD_OPS", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("RD", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("WR_OPS", TextTable::LEFT, TextTable::RIGHT);
-      tab.define_column("WR", TextTable::LEFT, TextTable::RIGHT);
+      tab.define_column("USED", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("OBJECTS", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("CLONES", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("COPIES", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("MISSING_ON_PRIMARY", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("UNFOUND", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("DEGRADED", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("RD_OPS", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("RD", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("WR_OPS", TextTable::RIGHT, TextTable::RIGHT);
+      tab.define_column("WR", TextTable::RIGHT, TextTable::RIGHT);
     } else {
       formatter->open_object_section("stats");
       formatter->open_array_section("pools");


### PR DESCRIPTION
Except for the first column，Other columns should remain the RIGHT alignment，Note the first line `RD` `WR`

before:
```
root@9d02aec4a204:~/ceph-12.2.0/build# rados df
2017-09-07 08:40:41.150406 7ff82598ef80 -1 WARNING: all dangerous and experimental features are enabled.
2017-09-07 08:40:41.150703 7ff82598ef80 -1 WARNING: all dangerous and experimental features are enabled.
2017-09-07 08:40:41.153671 7ff82598ef80 -1 WARNING: all dangerous and experimental features are enabled.
POOL_NAME           USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS RD     WR_OPS WR    
.rgw.root           1113       4      0     12                  0       0        0    252   168k      4  4096 
cephfs_data_a          0       0      0      0                  0       0        0      0      0      0     0 
cephfs_metadata_a   2246      21      0     63                  0       0        0      0      0     42  8192 
default.rgw.control    0       8      0     24                  0       0        0      0      0      0     0 
default.rgw.log        0     191      0    573                  0       0        0  38609 38418k  19638     0 
default.rgw.meta    2593      14      0     42                  0       0        0      0      0     22 15360 

total_objects    238
total_used       3277M
total_avail      27634M
total_space      30911M
root@9d02aec4a204:~/ceph-12.2.0/build#
```

after:
```
root@ca340671cbb8:~/ceph/build# ./bin/rados df
2017-09-07 09:51:40.001495 7f07219fef80 -1 WARNING: all dangerous and experimental features are enabled.
2017-09-07 09:51:40.001747 7f07219fef80 -1 WARNING: all dangerous and experimental features are enabled.
2017-09-07 09:51:40.004527 7f07219fef80 -1 WARNING: all dangerous and experimental features are enabled.
POOL_NAME            USED OBJECTS CLONES COPIES MISSING_ON_PRIMARY UNFOUND DEGRADED RD_OPS    RD WR_OPS  WR 
.rgw.root           1.09K       4      0     12                  0       0        0    252  168K      4  4K 
cephfs_data_a           0       0      0      0                  0       0        0      0     0      0   0 
cephfs_metadata_a   2.19K      21      0     63                  0       0        0      0     0     42  8K 
default.rgw.control     0       8      0     24                  0       0        0      0     0      0   0 
default.rgw.log         0     207      0    621                  0       0        0  69205 67.4M  35278   0 
default.rgw.meta    2.53K      14      0     42                  0       0        0      0     0     22 15K 

total_objects    254
total_used       3.20G
total_avail      27.0G
total_space      30.2G
root@ca340671cbb8:~/ceph/build#
```

Signed-off-by: iliul <liul124@chinaunicom.cn>