### PR TITLE
rgw: introduce prot_flags field into opslog

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -326,7 +326,7 @@ void set_req_state_err(struct rgw_err& err,	/* out */
   }
 
   //Default to searching in s3 errors
-  is_website_redirect |= (prot_flags & RGW_REST_WEBSITE)
+  is_website_redirect |= (prot_flags & RGW_REST_S3WEBSITE)
 		&& err_no == ERR_WEBSITE_REDIRECT && err.is_clear();
   if (search_err(rgw_http_s3_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
       return;

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -129,6 +129,14 @@ rgw_http_errors rgw_http_swift_errors({
     { ERR_ZERO_IN_URL, {412, "Invalid UTF8 or contains NULL"}},
 });
 
+rgw_prot_flags_map rgw_prot_flags({
+    {RGW_REST_SWIFT, "SWIFT_REST"},
+    {RGW_REST_SWIFT_AUTH, "SWIFT_AUTH"},
+    {RGW_REST_S3, "REST"},
+    {RGW_REST_S3WEBSITE, "WEBSITE"},
+    {RGW_REST_ADMIN, "ADMIN"},
+});
+
 int rgw_perf_start(CephContext *cct)
 {
   PerfCountersBuilder plb(cct, cct->_conf->name.to_str(), l_rgw_first, l_rgw_last);

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -320,7 +320,7 @@ void set_req_state_err(struct rgw_err& err,	/* out */
   err.ret = -err_no;
   bool is_website_redirect = false;
 
-  if (prot_flags & RGW_REST_SWIFT) {
+  if (prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)) {
     if (search_err(rgw_http_swift_errors, err_no, is_website_redirect, err.http_ret, err.err_code))
       return;
   }

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -130,10 +130,11 @@ using ceph::crypto::MD5;
 #define RGW_CAP_WRITE           0x2
 #define RGW_CAP_ALL             (RGW_CAP_READ | RGW_CAP_WRITE)
 
-#define RGW_REST_SWIFT          0x1
-#define RGW_REST_SWIFT_AUTH     0x2
-#define RGW_REST_S3             0x4
-#define RGW_REST_WEBSITE     0x8
+#define RGW_REST_SWIFT          0x01
+#define RGW_REST_SWIFT_AUTH     0x02
+#define RGW_REST_S3             0x04
+#define RGW_REST_S3WEBSITE      0x08
+#define RGW_REST_ADMIN          0x10
 
 #define RGW_SUSPENDED_USER_AUID (uint64_t)-2
 

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -261,6 +261,8 @@ enum {
   l_rgw_last,
 };
 
+typedef std::map<int, std::string> rgw_prot_flags_map;
+extern rgw_prot_flags_map rgw_prot_flags;
 
  /* size should be the required string size + 1 */
 extern int gen_rand_base64(CephContext *cct, char *dest, int size);

--- a/src/rgw/rgw_log.cc
+++ b/src/rgw/rgw_log.cc
@@ -256,6 +256,7 @@ void rgw_format_ops_log_entry(struct rgw_log_entry& entry, Formatter *formatter)
   formatter->dump_int("total_time", total_time);
   formatter->dump_string("user_agent",  entry.user_agent);
   formatter->dump_string("referrer",  entry.referrer);
+  formatter->dump_string("prot_flags", rgw_prot_flags[entry.prot_flags]);
   if (entry.x_headers.size() > 0) {
     formatter->open_array_section("http_x_headers");
     for (const auto& iter: entry.x_headers) {
@@ -392,6 +393,7 @@ int rgw_log_op(RGWRados *store, RGWREST* const rest, struct req_state *s,
 
   entry.error_code = s->err.err_code;
   entry.bucket_id = bucket_id;
+  entry.prot_flags = s->prot_flags;
 
   bufferlist bl;
   ::encode(entry, bl);

--- a/src/rgw/rgw_log.h
+++ b/src/rgw/rgw_log.h
@@ -33,10 +33,11 @@ struct rgw_log_entry {
   string user_agent;
   string referrer;
   string bucket_id;
+  int prot_flags;
   headers_map x_headers;
 
   void encode(bufferlist &bl) const {
-    ENCODE_START(9, 5, bl);
+    ENCODE_START(10, 5, bl);
     ::encode(object_owner.id, bl);
     ::encode(bucket_owner.id, bl);
     ::encode(bucket, bl);
@@ -59,6 +60,7 @@ struct rgw_log_entry {
     ::encode(object_owner, bl);
     ::encode(bucket_owner, bl);
     ::encode(x_headers, bl);
+    ::encode(prot_flags, bl);
     ENCODE_FINISH(bl);
   }
   void decode(bufferlist::iterator &p) {
@@ -107,6 +109,9 @@ struct rgw_log_entry {
     }
     if (struct_v >= 9) {
       ::decode(x_headers, p);
+    }
+    if (struct_v >= 10) {
+      ::decode(prot_flags, p);
     }
     DECODE_FINISH(p);
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -466,7 +466,8 @@ void dump_etag(struct req_state* const s,
     return;
   }
 
-  if (s->prot_flags & RGW_REST_SWIFT && ! quoted) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)
+      && ! quoted) {
     return dump_header(s, "etag", etag);
   } else {
     return dump_header_quoted(s, "ETag", etag);
@@ -649,7 +650,7 @@ void dump_start(struct req_state *s)
 
 void dump_trans_id(req_state *s)
 {
-  if (s->prot_flags & RGW_REST_SWIFT) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)) {
     dump_header(s, "X-Trans-Id", s->trans_id);
     dump_header(s, "X-Openstack-Request-Id", s->trans_id);
   } else if (s->trans_id.length()) {
@@ -675,7 +676,8 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
     dump_access_control(s, op);
   }
 
-  if (s->prot_flags & RGW_REST_SWIFT && !content_type) {
+  if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH)
+      && !content_type) {
     force_content_type = true;
   }
 
@@ -697,7 +699,7 @@ void end_header(struct req_state* s, RGWOp* op, const char *content_type,
       ctype = "text/plain";
       break;
     }
-    if (s->prot_flags & RGW_REST_SWIFT)
+    if (s->prot_flags & (RGW_REST_SWIFT | RGW_REST_SWIFT_AUTH))
       ctype.append("; charset=utf-8");
     content_type = ctype.c_str();
   }

--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1825,7 +1825,7 @@ int RGWHandler_REST::allocate_formatter(struct req_state *s,
       s->formatter = new JSONFormatter(false);
       break;
     case RGW_FORMAT_HTML:
-      s->formatter = new HTMLFormatter(s->prot_flags & RGW_REST_WEBSITE);
+      s->formatter = new HTMLFormatter(s->prot_flags & RGW_REST_S3WEBSITE);
       break;
     default:
       return -EINVAL;
@@ -2171,7 +2171,7 @@ int RGWREST::preprocess(struct req_state *s, rgw::io::BasicClient* cio)
     }
 
     if (in_hosted_domain_s3website) {
-      s->prot_flags |= RGW_REST_WEBSITE;
+      s->prot_flags |= RGW_REST_S3WEBSITE;
     }
 
 

--- a/src/rgw/rgw_rest_bucket.h
+++ b/src/rgw/rgw_rest_bucket.h
@@ -28,9 +28,10 @@ public:
   RGWRESTMgr_Bucket() = default;
   ~RGWRESTMgr_Bucket() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Bucket(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_config.h
+++ b/src/rgw/rgw_rest_config.h
@@ -72,9 +72,10 @@ public:
   RGWRESTMgr_Config() = default;
   ~RGWRESTMgr_Config() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Config(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_log.h
+++ b/src/rgw/rgw_rest_log.h
@@ -325,9 +325,10 @@ public:
   RGWRESTMgr_Log() = default;
   ~RGWRESTMgr_Log() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state* const,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefixs) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Log(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_metadata.h
+++ b/src/rgw/rgw_rest_metadata.h
@@ -119,6 +119,7 @@ public:
   RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string& frontend_prefix) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Metadata(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_opstate.h
+++ b/src/rgw/rgw_rest_opstate.h
@@ -101,9 +101,10 @@ public:
   RGWRESTMgr_Opstate() = default;
   ~RGWRESTMgr_Opstate() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Opstate(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_realm.cc
+++ b/src/rgw/rgw_rest_realm.cc
@@ -289,9 +289,10 @@ RGWRESTMgr_Realm::RGWRESTMgr_Realm()
 }
 
 RGWHandler_REST*
-RGWRESTMgr_Realm::get_handler(struct req_state*,
+RGWRESTMgr_Realm::get_handler(struct req_state* const s,
                               const rgw::auth::StrategyRegistry& auth_registry,
                               const std::string&)
 {
+  s->prot_flags |= RGW_REST_ADMIN;
   return new RGWHandler_Realm(auth_registry);
 }

--- a/src/rgw/rgw_rest_realm.h
+++ b/src/rgw/rgw_rest_realm.h
@@ -10,7 +10,7 @@ class RGWRESTMgr_Realm : public RGWRESTMgr {
 public:
   RGWRESTMgr_Realm();
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override;
 };

--- a/src/rgw/rgw_rest_replica_log.h
+++ b/src/rgw/rgw_rest_replica_log.h
@@ -147,9 +147,10 @@ public:
   RGWRESTMgr_ReplicaLog() = default;
   ~RGWRESTMgr_ReplicaLog() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_ReplicaLog(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -3373,7 +3373,12 @@ RGWHandler_REST* RGWRESTMgr_S3::get_handler(struct req_state* const s,
                                             const rgw::auth::StrategyRegistry& auth_registry,
                                             const std::string& frontend_prefix)
 {
-  bool is_s3website = enable_s3website && (s->prot_flags & RGW_REST_WEBSITE);
+  bool is_s3website = enable_s3website && (s->prot_flags & RGW_REST_S3WEBSITE);
+
+  if (!is_s3website) {
+    s->prot_flags |= RGW_REST_S3;
+  }
+
   int ret =
     RGWHandler_REST_S3::init_from_header(s,
 					is_s3website ? RGW_FORMAT_HTML :
@@ -3435,7 +3440,7 @@ int RGWHandler_REST_S3Website::retarget(RGWOp* op, RGWOp** new_op) {
   *new_op = op;
   ldout(s->cct, 10) << __func__ << "Starting retarget" << dendl;
 
-  if (!(s->prot_flags & RGW_REST_WEBSITE))
+  if (!(s->prot_flags & RGW_REST_S3WEBSITE))
     return 0;
 
   RGWObjectCtx& obj_ctx = *static_cast<RGWObjectCtx *>(s->obj_ctx);

--- a/src/rgw/rgw_rest_usage.h
+++ b/src/rgw/rgw_rest_usage.h
@@ -26,9 +26,10 @@ public:
   RGWRESTMgr_Usage() = default;
   ~RGWRESTMgr_Usage() override = default;
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_Usage(auth_registry);
   }
 };

--- a/src/rgw/rgw_rest_user.h
+++ b/src/rgw/rgw_rest_user.h
@@ -28,9 +28,10 @@ public:
   RGWRESTMgr_User() = default;
   ~RGWRESTMgr_User() override = default;
 
-  RGWHandler_REST *get_handler(struct req_state*,
+  RGWHandler_REST *get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry& auth_registry,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_ADMIN;
     return new RGWHandler_User(auth_registry);
   }
 };

--- a/src/rgw/rgw_swift_auth.cc
+++ b/src/rgw/rgw_swift_auth.cc
@@ -585,8 +585,6 @@ void RGW_SWIFT_Auth_Get::execute()
   const char *key = s->info.env->get("HTTP_X_AUTH_KEY");
   const char *user = s->info.env->get("HTTP_X_AUTH_USER");
 
-  s->prot_flags |= RGW_REST_SWIFT;
-
   string user_str;
   RGWUserInfo info;
   bufferlist bl;

--- a/src/rgw/rgw_swift_auth.h
+++ b/src/rgw/rgw_swift_auth.h
@@ -306,9 +306,10 @@ public:
     return this;
   }
 
-  RGWHandler_REST* get_handler(struct req_state*,
+  RGWHandler_REST* get_handler(struct req_state* const s,
                                const rgw::auth::StrategyRegistry&,
                                const std::string&) override {
+    s->prot_flags |= RGW_REST_SWIFT_AUTH;
     return new RGWHandler_SWIFT_Auth;
   }
 };


### PR DESCRIPTION
In AWS S3, it will point out the protocol type of request in the operation field of bucket logging.
According to the reference[1], the format of operation field is:

Operation
The operation listed here is declared as SOAP.operation, REST.HTTP_method.resource_type, WEBSITE.HTTP_method.resource_type, or BATCH.DELETE.OBJECT.

Example Entry
REST.PUT.OBJECT

So we can also introduce the protocol field into opslog to point out which protocol type the operation request using.

In addition, I also cleanup the req_state::prot_flags to RGW_REST_SWIFT_AUTH when the request is a swift auth request.

[1] http://docs.aws.amazon.com/AmazonS3/latest/dev/LogFormat.html