### PR TITLE
rbd: Initializing m_finalize_ctx

### DIFF
--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -214,7 +214,7 @@ private:
   const std::string m_image_name;
 
   librbd::Image m_image;
-  Context *m_finalize_ctx;
+  Context *m_finalize_ctx = nullptr;
 
   librbd::mirror_image_info_t m_mirror_image_info;
 


### PR DESCRIPTION
Fixes the coverity issue:

** 1402625 Uninitialized pointer field
>CID undefined (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_finalize_ctx is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>