### PR TITLE
qa/objectstore/bluestore*: less debug output

### DIFF
--- a/qa/objectstore/bluestore-bitmap.yaml
+++ b/qa/objectstore/bluestore-bitmap.yaml
@@ -12,6 +12,7 @@ overrides:
         debug bluefs: 20
         debug rocksdb: 10
         bluestore fsck on mount: true
+        bluestore allocator: bitmap
         # lower the full ratios since we can fill up a 100gb osd so quickly
         mon osd full ratio: .9
         mon osd backfillfull_ratio: .85

--- a/qa/objectstore/bluestore-comp.yaml
+++ b/qa/objectstore/bluestore-comp.yaml
@@ -8,8 +8,7 @@ overrides:
       osd:
         osd objectstore: bluestore
         bluestore block size: 96636764160
-        debug bluestore: 30
-        debug bdev: 20
+        debug bluestore: 20
         debug bluefs: 20
         debug rocksdb: 10
         bluestore compression mode: aggressive


### PR DESCRIPTION
Let's see if this makes the spurious MON_DOWN failures go away?  (See
http://tracker.ceph.com/issues/20910)

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 444f5aa08539cde827e7d93a514367a8ba39b122)

Conflicts:
 qa/objectstore/bluestore-bitmap.yaml
 Added bluestore-bitmap.yaml to Luminous as well