### PR TITLE
msg: Initializing class members in module msg

### DIFF
--- a/src/msg/DispatchStrategy.h
+++ b/src/msg/DispatchStrategy.h
@@ -22,7 +22,7 @@ class Messenger;
 class DispatchStrategy
 {
 protected:
-  Messenger *msgr;
+  Messenger *msgr = nullptr;
 public:
   DispatchStrategy() {}
   Messenger *get_messenger() { return msgr; }

--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -340,7 +340,7 @@ class Infiniband {
     // TODO: Cluster -> TxPool txbuf_pool
     // chunk layout fix
     //  
-    Cluster* send;// SEND
+    Cluster* send = nullptr;// SEND
     Device *device;
     ProtectionDomain *pd;
     MemPoolContext rxbuf_pool_ctx;

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -40,9 +40,9 @@ class RDMADispatcher {
 
   std::thread t;
   CephContext *cct;
-  Infiniband::CompletionQueue* tx_cq;
-  Infiniband::CompletionQueue* rx_cq;
-  Infiniband::CompletionChannel *tx_cc, *rx_cc;
+  Infiniband::CompletionQueue* tx_cq = nullptr;
+  Infiniband::CompletionQueue* rx_cq = nullptr;
+  Infiniband::CompletionChannel *tx_cc = nullptr, *rx_cc = nullptr;
   EventCallbackRef async_handler;
   bool done = false;
   std::atomic<uint64_t> num_dead_queue_pair = {0};


### PR DESCRIPTION
Fixes the coverity issues:

** 1414530 Uninitialized pointer field
>2. uninit_member: Non-static class member tx_cq is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member rx_cq is not initialized
in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member tx_cc is not initialized
in this constructor nor in any functions that it calls.
CID 1414530 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>8. uninit_member: Non-static class member rx_cc is not initialized
in this constructor nor in any functions that it calls.

** 1416369 Uninitialized pointer field
>CID 1416369 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member send is not initialized
in this constructor nor in any functions that it calls.

** 1405536 Uninitialized pointer field
>CID 1405536 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member msgr is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>