### PR TITLE
Revert "os/bluestore: pass strict flag to bluestore_blob_use_tracker_t::equal()"

### DIFF
--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -488,8 +488,7 @@ void bluestore_blob_use_tracker_t::split(
 }
 
 bool bluestore_blob_use_tracker_t::equal(
-  const bluestore_blob_use_tracker_t& other,
-  bool strict) const
+  const bluestore_blob_use_tracker_t& other) const
 {
   if (!num_au && !other.num_au) {
     return total_bytes == other.total_bytes && au_size == other.au_size;
@@ -503,10 +502,6 @@ bool bluestore_blob_use_tracker_t::equal(
       }
     }
     return true;
-  }
-
-  if (strict) {
-    return false;
   }
 
   uint32_t n = num_au ? num_au : other.num_au;

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -421,8 +421,7 @@ struct bluestore_blob_use_tracker_t {
     bluestore_blob_use_tracker_t* r);
 
   bool equal(
-    const bluestore_blob_use_tracker_t& other,
-    bool strict = true) const;
+    const bluestore_blob_use_tracker_t& other) const;
     
   void bound_encode(size_t& p) const {
     denc_varint(au_size, p);

--- a/src/test/objectstore/test_bluestore_types.cc
+++ b/src/test/objectstore/test_bluestore_types.cc
@@ -1441,43 +1441,7 @@ TEST(GarbageCollector, BasicTest)
     em.clear();
     old_extents.clear();
   }
-}
-
-TEST(bluestore_blob_use_tracker_t, equal)
-{
-  bluestore_blob_use_tracker_t t1, t2, t3;
-
-  ASSERT_TRUE(t1.equal(t2));
-  ASSERT_TRUE(t1.equal(t2, false));
-
-  t1.init(0x8000, 0x1000);
-  t2.init(0x8000, 0x1000);
-  ASSERT_TRUE(t1.equal(t2));
-  ASSERT_TRUE(t1.equal(t2, false));
-
-  t1.get(0, 0x1000);
-  ASSERT_TRUE(!t1.equal(t2));
-  ASSERT_TRUE(!t1.equal(t2, false));
-  t2.get(0, 0x1000);
-  ASSERT_TRUE(t1.equal(t2));
-  ASSERT_TRUE(t1.equal(t2, false));
-
-  t1.get(0x1000, 0x1000);
-  t2.get(0x2000, 0x1000);
-  ASSERT_TRUE(!t1.equal(t2));
-  ASSERT_TRUE(!t1.equal(t2, false));
-
-  t3.init(0x8000, 0x8000);
-  t3.get(0x4000, 0x2000);
-  ASSERT_TRUE(!t3.equal(t1));
-  ASSERT_TRUE(t3.equal(t1, false));
-  ASSERT_TRUE(!t3.equal(t2));
-  ASSERT_TRUE(t3.equal(t2, false));
-
-  t1.clear();
-  t2.clear();
-  t3.clear();
-}
+ }
 
 int main(int argc, char **argv) {
   vector<const char*> args;


### PR DESCRIPTION
This reverts commit 5070999169b5733983fb74d955cb764a9066c3d8.

The existing blob may have a vector-based au because it was, say, split, while the local one
may not (because it not needed).  Use a sloppy comparison.

Fixes: http://tracker.ceph.com/issues/21293
Signed-off-by: Sage Weil <sage@redhat.com>