### PR TITLE
qa/tests/rados: Remove unsupported 2-size-1-min-size config

### DIFF
--- a/qa/suites/rados/thrash/0-size-min-size-overrides/2-size-1-min-size.yaml
+++ b/qa/suites/rados/thrash/0-size-min-size-overrides/2-size-1-min-size.yaml
@@ -1,1 +1,0 @@
-../../../../overrides/2-size-1-min-size.yaml


### PR DESCRIPTION
Remove the unsupported 2-size-1-min-size config item

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>