### PR TITLE
osd: kill snapdirs

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4346,8 +4346,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
           /* get the start and end of our scrub chunk
 	   *
 	   * Our scrub chunk has an important restriction we're going to need to
-	   * respect. We can't let head or snapdir be start or end.
-	   * Using a half-open interval means that if end == head|snapdir,
+	   * respect. We can't let head be start or end.
+	   * Using a half-open interval means that if end == head,
 	   * we'd scrub/lock head and the clone right next to head in different
 	   * chunks which would allow us to miss clones created between
 	   * scrubbing that chunk and scrubbing the chunk including head.
@@ -4373,8 +4373,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 
 	  if (!objects.empty()) {
 	    hobject_t back = objects.back();
-	    while (candidate_end.has_snapset() &&
-		      candidate_end.get_head() == back.get_head()) {
+	    while (candidate_end.is_head() &&
+		   candidate_end == back.get_head()) {
 	      candidate_end = back;
 	      objects.pop_back();
 	      if (objects.empty()) {
@@ -4384,8 +4384,8 @@ void PG::chunky_scrub(ThreadPool::TPHandle &handle)
 	      }
 	      back = objects.back();
 	    }
-	    if (candidate_end.has_snapset()) {
-	      assert(candidate_end.get_head() != back.get_head());
+	    if (candidate_end.is_head()) {
+	      assert(candidate_end != back.get_head());
 	      candidate_end = candidate_end.get_object_boundary();
 	    }
 	  } else {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3849,9 +3849,6 @@ void PG::_scan_snaps(ScrubMap &smap)
 	continue;
       }
       head = hoid.get_head();
-      // Make sure head_exists is set
-      if (hoid.is_head())
-	snapset.head_exists = true;
       continue;
     }
     if (hoid.snap < CEPH_MAXSNAP) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3834,7 +3834,8 @@ void PG::_scan_snaps(ScrubMap &smap)
     const hobject_t &hoid = i->first;
     ScrubMap::object &o = i->second;
 
-    if (hoid.is_head() || hoid.is_snapdir()) {
+    assert(!hoid.is_snapdir());
+    if (hoid.is_head()) {
       // parse the SnapSet
       bufferlist bl;
       if (o.attrs.find(SS_ATTR) == o.attrs.end()) {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -3849,7 +3849,7 @@ void PG::_scan_snaps(ScrubMap &smap)
 	continue;
       }
       head = hoid.get_head();
-      // Make sure head_exists is correct for is_legacy() check
+      // Make sure head_exists is set
       if (hoid.is_head())
 	snapset.head_exists = true;
       continue;
@@ -3862,28 +3862,13 @@ void PG::_scan_snaps(ScrubMap &smap)
 	continue;
       }
       set<snapid_t> obj_snaps;
-      if (!snapset.is_legacy()) {
-	auto p = snapset.clone_snaps.find(hoid.snap);
-	if (p == snapset.clone_snaps.end()) {
-	  derr << __func__ << " no clone_snaps for " << hoid << " in " << snapset
-	       << dendl;
-	  continue;
-	}
-	obj_snaps.insert(p->second.begin(), p->second.end());
-      } else {
-	bufferlist bl;
-	if (o.attrs.find(OI_ATTR) == o.attrs.end()) {
-	  continue;
-	}
-	bl.push_back(o.attrs[OI_ATTR]);
-	object_info_t oi;
-	try {
-	  oi.decode(bl);
-	} catch(...) {
-	  continue;
-	}
-	obj_snaps.insert(oi.legacy_snaps.begin(), oi.legacy_snaps.end());
+      auto p = snapset.clone_snaps.find(hoid.snap);
+      if (p == snapset.clone_snaps.end()) {
+	derr << __func__ << " no clone_snaps for " << hoid << " in " << snapset
+	     << dendl;
+	continue;
       }
+      obj_snaps.insert(p->second.begin(), p->second.end());
       set<snapid_t> cur_snaps;
       int r = snap_mapper.get_snaps(hoid, &cur_snaps);
       if (r != 0 && r != -ENOENT) {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1239,7 +1239,7 @@ public:
     int num_digest_updates_pending;
 
     // chunky scrub
-    hobject_t start, end;
+    hobject_t start, end;    // [start,end)
     eversion_t subset_last_update;
 
     // chunky scrub state

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -820,7 +820,8 @@ map<pg_shard_t, ScrubMap *>::const_iterator
     }
 
     // We won't pick an auth copy if the snapset is missing or won't decode.
-    if (obj.is_head() || obj.is_snapdir()) {
+    assert(!obj.is_snapdir());
+    if (obj.is_head()) {
       k = i->second.attrs.find(SS_ATTR);
       if (k == i->second.attrs.end()) {
 	shard_info.set_ss_attr_missing();

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9864,15 +9864,10 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
 	   << " legacy_snaps " << obc->obs.oi.legacy_snaps
 	   << dendl;
   snapid_t first, last;
-  if (obc->ssc->snapset.is_legacy()) {
-    first = obc->obs.oi.legacy_snaps.back();
-    last = obc->obs.oi.legacy_snaps.front();
-  } else {
-    auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);
-    assert(p != obc->ssc->snapset.clone_snaps.end());
-    first = p->second.back();
-    last = p->second.front();
-  }
+  auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);
+  assert(p != obc->ssc->snapset.clone_snaps.end());
+  first = p->second.back();
+  last = p->second.front();
   if (first <= oid.snap) {
     dout(20) << "find_object_context  " << soid << " [" << first << "," << last
 	     << "] contains " << oid.snap << " -- HIT " << obc->obs << dendl;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -676,21 +676,12 @@ void PrimaryLogPG::block_write_on_degraded_snap(
   wait_for_degraded_object(snap, op);
 }
 
-bool PrimaryLogPG::maybe_await_blocked_snapset(
+bool PrimaryLogPG::maybe_await_blocked_head(
   const hobject_t &hoid,
   OpRequestRef op)
 {
   ObjectContextRef obc;
   obc = object_contexts.lookup(hoid.get_head());
-  if (obc) {
-    if (obc->is_blocked()) {
-      wait_for_blocked_object(obc->obs.oi.soid, op);
-      return true;
-    } else {
-      return false;
-    }
-  }
-  obc = object_contexts.lookup(hoid.get_snapdir());
   if (obc) {
     if (obc->is_blocked()) {
       wait_for_blocked_object(obc->obs.oi.soid, op);
@@ -2093,7 +2084,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 
   // io blocked on obc?
   if (!m->has_flag(CEPH_OSD_FLAG_FLUSH) &&
-      maybe_await_blocked_snapset(oid, op)) {
+      maybe_await_blocked_head(oid, op)) {
     return;
   }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8539,13 +8539,9 @@ int PrimaryLogPG::start_flush(
       snapc.snaps = snapset.snaps;
     } else {
       snapid_t min_included_snap;
-      if (snapset.is_legacy()) {
-	min_included_snap = oi.legacy_snaps.back();
-      } else {
-	auto p = snapset.clone_snaps.find(soid.snap);
-	assert(p != snapset.clone_snaps.end());
-	min_included_snap = p->second.back();
-      }
+      auto p = snapset.clone_snaps.find(soid.snap);
+      assert(p != snapset.clone_snaps.end());
+      min_included_snap = p->second.back();
       snapc = snapset.get_ssc_as_of(min_included_snap - 1);
     }
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2070,7 +2070,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   }
 
   ObjectContextRef obc;
-  bool can_create = op->may_write() || op->may_cache();
+  bool can_create = op->may_write();
   hobject_t missing_oid;
 
   // kludge around the fact that LIST_SNAPS sets CEPH_SNAPDIR for LIST_SNAPS

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7548,13 +7548,9 @@ int PrimaryLogPG::do_copy_get(OpContext *ctx, bufferlist::iterator& bp,
   reply_obj.mtime = oi.mtime;
   assert(obc->ssc);
   if (soid.snap < CEPH_NOSNAP) {
-    if (obc->ssc->snapset.is_legacy()) {
-      reply_obj.snaps = oi.legacy_snaps;
-    } else {
-      auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);
-      assert(p != obc->ssc->snapset.clone_snaps.end()); // warn?
-      reply_obj.snaps = p->second;
-    }
+    auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);
+    assert(p != obc->ssc->snapset.clone_snaps.end()); // warn?
+    reply_obj.snaps = p->second;
   } else {
     reply_obj.snap_seq = obc->ssc->snapset.seq;
   }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -346,16 +346,9 @@ void PrimaryLogPG::on_local_recover(
     set<snapid_t> snaps;
     dout(20) << " snapset " << recovery_info.ss
 	     << " legacy_snaps " << recovery_info.oi.legacy_snaps << dendl;
-    if (recovery_info.ss.is_legacy() ||
-	recovery_info.ss.seq == 0 /* jewel osd doesn't populate this */) {
-      assert(recovery_info.oi.legacy_snaps.size());
-      snaps.insert(recovery_info.oi.legacy_snaps.begin(),
-		   recovery_info.oi.legacy_snaps.end());
-    } else {
-      auto p = recovery_info.ss.clone_snaps.find(hoid.snap);
-      assert(p != recovery_info.ss.clone_snaps.end());  // hmm, should we warn?
-      snaps.insert(p->second.begin(), p->second.end());
-    }
+    auto p = recovery_info.ss.clone_snaps.find(hoid.snap);
+    assert(p != recovery_info.ss.clone_snaps.end());  // hmm, should we warn?
+    snaps.insert(p->second.begin(), p->second.end());
     dout(20) << " snaps " << snaps << dendl;
     snap_mapper.add_oid(
       recovery_info.soid,

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1238,10 +1238,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	    break;
 	  }
 
-	  // skip snapdir objects
-	  if (candidate.snap == CEPH_SNAPDIR)
-	    continue;
-
 	  if (candidate.snap != CEPH_NOSNAP)
 	    continue;
 
@@ -1396,10 +1392,6 @@ void PrimaryLogPG::do_pg_op(OpRequestRef op)
 	    next = candidate;
 	    break;
 	  }
-
-	  // skip snapdir objects
-	  if (candidate.snap == CEPH_SNAPDIR)
-	    continue;
 
 	  if (candidate.snap != CEPH_NOSNAP)
 	    continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2232,17 +2232,6 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 
   OpContext *ctx = new OpContext(op, m->get_reqid(), &m->ops, obc, this);
 
-  if (!obc->obs.exists)
-    ctx->snapset_obc = get_object_context(obc->obs.oi.soid.get_snapdir(), false);
-
-  /* Due to obc caching, we might have a cached non-existent snapset_obc
-   * for the snapdir.  If so, we can ignore it.  Subsequent parts of the
-   * do_op pipeline make decisions based on whether snapset_obc is
-   * populated.
-   */
-  if (ctx->snapset_obc && !ctx->snapset_obc->obs.exists)
-    ctx->snapset_obc = ObjectContextRef();
-
   if (m->has_flag(CEPH_OSD_FLAG_SKIPRWLOCKS)) {
     dout(20) << __func__ << ": skipping rw locks" << dendl;
   } else if (m->get_flags() & CEPH_OSD_FLAG_FLUSH) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6854,7 +6854,6 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
 	t->remove(soid);
       }
       t->clone(soid, rollback_to_sobject);
-      snapset.head_exists = true;
       t->add_obc(rollback_to);
 
       map<snapid_t, interval_set<uint64_t> >::iterator iter =
@@ -6895,8 +6894,6 @@ int PrimaryLogPG::_rollback_to(OpContext *ctx, ceph_osd_op& op)
 	dout(10) << __func__ << " clearing omap flag on " << obs.oi.soid << dendl;
 	obs.oi.clear_flag(object_info_t::FLAG_OMAP);
       }
-
-      snapset.head_exists = true;
     }
   }
   return ret;
@@ -8314,7 +8311,6 @@ void PrimaryLogPG::finish_promote(int r, CopyResults *results,
       results->snapset,
       get_osdmap()->require_osd_release < CEPH_RELEASE_LUMINOUS);
   }
-  tctx->new_snapset.head_exists = true;
   dout(20) << __func__ << " new_snapset " << tctx->new_snapset << dendl;
 
   // take RWWRITE lock for duration of our local write.  ignore starvation.
@@ -12282,7 +12278,6 @@ void PrimaryLogPG::hit_set_persist()
 
   ctx->new_obs = obc->obs;
 
-  obc->ssc->snapset.head_exists = true;
   ctx->new_snapset = obc->ssc->snapset;
 
   ctx->delta_stats.num_objects++;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9716,27 +9716,19 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
  
   // head?
   if (oid.snap > ssc->snapset.seq) {
-    if (ssc->snapset.head_exists) {
-      ObjectContextRef obc = get_object_context(head, false);
-      dout(10) << "find_object_context  " << head
-	       << " want " << oid.snap << " > snapset seq " << ssc->snapset.seq
-	       << " -- HIT " << obc->obs
-	       << dendl;
-      if (!obc->ssc)
-	obc->ssc = ssc;
-      else {
-	assert(ssc == obc->ssc);
-	put_snapset_context(ssc);
-      }
-      *pobc = obc;
-      return 0;
-    }
+    ObjectContextRef obc = get_object_context(head, false);
     dout(10) << "find_object_context  " << head
 	     << " want " << oid.snap << " > snapset seq " << ssc->snapset.seq
-	     << " but head dne -- DNE"
+	     << " -- HIT " << obc->obs
 	     << dendl;
-    put_snapset_context(ssc);
-    return -ENOENT;
+    if (!obc->ssc)
+      obc->ssc = ssc;
+    else {
+      assert(ssc == obc->ssc);
+      put_snapset_context(ssc);
+    }
+    *pobc = obc;
+    return 0;
   }
 
   // which clone would it be?

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7298,7 +7298,7 @@ int PrimaryLogPG::prepare_transaction(OpContext *ctx)
   return result;
 }
 
-void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc)
+void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type)
 {
   const hobject_t& soid = ctx->obs->oi.soid;
   dout(20) << __func__ << " " << soid << " " << ctx
@@ -7382,9 +7382,7 @@ void PrimaryLogPG::finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc
   // apply new object state.
   ctx->obc->obs = ctx->new_obs;
 
-  if (soid.is_head() &&
-      !ctx->obc->obs.exists &&
-      (!maintain_ssc || ctx->cache_evict)) {
+  if (soid.is_head() && !ctx->obc->obs.exists) {
     ctx->obc->ssc->exists = false;
     ctx->obc->ssc->snapset = SnapSet();
   } else {
@@ -12776,7 +12774,7 @@ bool PrimaryLogPG::agent_maybe_evict(ObjectContextRef& obc, bool after_flush)
   if (obc->obs.oi.is_dirty())
     --ctx->delta_stats.num_objects_dirty;
   assert(r == 0);
-  finish_ctx(ctx.get(), pg_log_entry_t::DELETE, false);
+  finish_ctx(ctx.get(), pg_log_entry_t::DELETE);
   simple_opc_submit(std::move(ctx));
   osd->logger->inc(l_osd_tier_evict);
   osd->logger->inc(l_osd_agent_evict);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9100,16 +9100,13 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
 
   ctx->obc->ondisk_write_lock();
 
-  bool unlock_head_obc = false;
   ctx->op_t->add_obc(ctx->obc);
   if (ctx->clone_obc) {
     ctx->clone_obc->ondisk_write_lock();
     ctx->op_t->add_obc(ctx->clone_obc);
   }
-  if (ctx->head_obc &&
-      ctx->head_obc->obs.oi.soid != ctx->obc->obs.oi.soid) {
+  if (ctx->head_obc) {
     ctx->head_obc->ondisk_write_lock();
-    unlock_head_obc = true;
     ctx->op_t->add_obc(ctx->head_obc);
   }
 
@@ -9118,7 +9115,7 @@ void PrimaryLogPG::issue_repop(RepGather *repop, OpContext *ctx)
   Context *onapplied_sync = new C_OSD_OndiskWriteUnlock(
     ctx->obc,
     ctx->clone_obc,
-    unlock_head_obc ? ctx->head_obc : ObjectContextRef());
+    ctx->head_obc);
   if (!(ctx->log.empty())) {
     assert(ctx->at_version >= projected_last_update);
     projected_last_update = ctx->at_version;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3767,10 +3767,9 @@ int PrimaryLogPG::trim_object(
   dout(10) << coid << " new snapset " << snapset << " on "
 	   << head_obc->obs.oi << dendl;
   if (snapset.clones.empty() &&
-      (!snapset.head_exists ||
-       (head_obc->obs.oi.is_whiteout() &&
-	!(head_obc->obs.oi.is_dirty() && pool.info.is_tier()) &&
-	!head_obc->obs.oi.is_cache_pinned()))) {
+      (head_obc->obs.oi.is_whiteout() &&
+       !(head_obc->obs.oi.is_dirty() && pool.info.is_tier()) &&
+       !head_obc->obs.oi.is_cache_pinned())) {
     // NOTE: this arguably constitutes minor interference with the
     // tiering agent if this is a cache tier since a snap trim event
     // is effectively evicting a whiteout we might otherwise want to
@@ -3787,22 +3786,20 @@ int PrimaryLogPG::trim_object(
 	ctx->mtime,
 	0)
       );
-    if (head_oid.is_head()) {
-      derr << "removing snap head" << dendl;
-      object_info_t& oi = ctx->snapset_obc->obs.oi;
-      ctx->delta_stats.num_objects--;
-      if (oi.is_dirty()) {
-	ctx->delta_stats.num_objects_dirty--;
-      }
-      if (oi.is_omap())
-	ctx->delta_stats.num_objects_omap--;
-      if (oi.is_whiteout()) {
-	dout(20) << __func__ << " trimming whiteout on " << oi.soid << dendl;
-	ctx->delta_stats.num_whiteouts--;
-      }
-      if (oi.is_cache_pinned()) {
-	ctx->delta_stats.num_objects_pinned--;
-      }
+    derr << "removing snap head" << dendl;
+    object_info_t& oi = ctx->snapset_obc->obs.oi;
+    ctx->delta_stats.num_objects--;
+    if (oi.is_dirty()) {
+      ctx->delta_stats.num_objects_dirty--;
+    }
+    if (oi.is_omap())
+      ctx->delta_stats.num_objects_omap--;
+    if (oi.is_whiteout()) {
+      dout(20) << __func__ << " trimming whiteout on " << oi.soid << dendl;
+      ctx->delta_stats.num_whiteouts--;
+    }
+    if (oi.is_cache_pinned()) {
+      ctx->delta_stats.num_objects_pinned--;
     }
     ctx->snapset_obc->obs.exists = false;
     ctx->snapset_obc->obs.oi = object_info_t(head_oid);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6680,25 +6680,20 @@ inline int PrimaryLogPG::_delete_oid(
       && !try_no_whiteout) {
     whiteout = true;
   }
-  bool legacy;
-  if (get_osdmap()->require_osd_release >= CEPH_RELEASE_LUMINOUS) {
-    legacy = false;
-    // in luminous or later, we can't delete the head if there are
-    // clones. we trust the caller passing no_whiteout has already
-    // verified they don't exist.
-    if (!snapset.clones.empty() ||
-	(!ctx->snapc.snaps.empty() && ctx->snapc.snaps[0] > snapset.seq)) {
-      if (no_whiteout) {
-	dout(20) << __func__ << " has or will have clones but no_whiteout=1"
-		 << dendl;
-      } else {
-	dout(20) << __func__ << " has or will have clones; will whiteout"
-		 << dendl;
-	whiteout = true;
-      }
+
+  // in luminous or later, we can't delete the head if there are
+  // clones. we trust the caller passing no_whiteout has already
+  // verified they don't exist.
+  if (!snapset.clones.empty() ||
+      (!ctx->snapc.snaps.empty() && ctx->snapc.snaps[0] > snapset.seq)) {
+    if (no_whiteout) {
+      dout(20) << __func__ << " has or will have clones but no_whiteout=1"
+	       << dendl;
+    } else {
+      dout(20) << __func__ << " has or will have clones; will whiteout"
+	       << dendl;
+      whiteout = true;
     }
-  } else {
-    legacy = false;
   }
   dout(20) << __func__ << " " << soid << " whiteout=" << (int)whiteout
 	   << " no_whiteout=" << (int)no_whiteout
@@ -6756,9 +6751,6 @@ inline int PrimaryLogPG::_delete_oid(
   }
   if (oi.is_cache_pinned()) {
     ctx->delta_stats.num_objects_pinned--;
-  }
-  if ((legacy || snapset.is_legacy()) && soid.is_head()) {
-    snapset.head_exists = false;
   }
   obs.exists = false;
   return 0;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8268,9 +8268,6 @@ void PrimaryLogPG::finish_promote(int r, CopyResults *results,
 
   tctx->extra_reqids = results->reqids;
 
-  bool legacy_snapset = tctx->new_snapset.is_legacy() ||
-    get_osdmap()->require_osd_release < CEPH_RELEASE_LUMINOUS;
-
   if (whiteout) {
     // create a whiteout
     tctx->op_t->create(soid);
@@ -8300,13 +8297,7 @@ void PrimaryLogPG::finish_promote(int r, CopyResults *results,
     tctx->new_obs.oi.truncate_size = results->truncate_size;
 
     if (soid.snap != CEPH_NOSNAP) {
-      if (legacy_snapset) {
-	tctx->new_obs.oi.legacy_snaps = results->snaps;
-	assert(!tctx->new_obs.oi.legacy_snaps.empty());
-      } else {
-	// it's already in the snapset
-	assert(obc->ssc->snapset.clone_snaps.count(soid.snap));
-      }
+      assert(obc->ssc->snapset.clone_snaps.count(soid.snap));
       assert(obc->ssc->snapset.clone_size.count(soid.snap));
       assert(obc->ssc->snapset.clone_size[soid.snap] ==
 	     results->object_size);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2080,7 +2080,14 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   ObjectContextRef obc;
   bool can_create = op->may_write() || op->may_cache();
   hobject_t missing_oid;
-  const hobject_t& oid = m->get_hobj();
+
+  // kludge around the fact that LIST_SNAPS sets CEPH_SNAPDIR for LIST_SNAPS
+  hobject_t _oid_head;
+  if (m->get_snapid() == CEPH_SNAPDIR) {
+    _oid_head = m->get_hobj().get_head();
+  }
+  const hobject_t& oid =
+    m->get_snapid() == CEPH_SNAPDIR ? _oid_head : m->get_hobj();
 
   // make sure LIST_SNAPS is on CEPH_SNAPDIR and nothing else
   for (vector<OSDOp>::iterator p = m->ops.begin(); p != m->ops.end(); ++p) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5421,10 +5421,10 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	  ssc = ctx->obc->ssc = get_snapset_context(soid, false);
         }
         assert(ssc);
+	dout(20) << " snapset " << ssc->snapset << dendl;
 
         int clonecount = ssc->snapset.clones.size();
-        if (ssc->snapset.head_exists)
-          clonecount++;
+	clonecount++;  // for head
         resp.clones.reserve(clonecount);
         for (auto clone_iter = ssc->snapset.clones.begin();
 	     clone_iter != ssc->snapset.clones.end(); ++clone_iter) {
@@ -5482,8 +5482,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	if (result < 0) {
 	  break;
 	}	  
-        if (ssc->snapset.head_exists &&
-	    !ctx->obc->obs.oi.is_whiteout()) {
+        if (!ctx->obc->obs.oi.is_whiteout()) {
           assert(obs.exists);
           clone_info ci;
           ci.cloneid = CEPH_NOSNAP;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -344,8 +344,7 @@ void PrimaryLogPG::on_local_recover(
   if (!is_delete && recovery_info.soid.is_snap()) {
     OSDriver::OSTransaction _t(osdriver.get_transaction(t));
     set<snapid_t> snaps;
-    dout(20) << " snapset " << recovery_info.ss
-	     << " legacy_snaps " << recovery_info.oi.legacy_snaps << dendl;
+    dout(20) << " snapset " << recovery_info.ss << dendl;
     auto p = recovery_info.ss.clone_snaps.find(hoid.snap);
     assert(p != recovery_info.ss.clone_snaps.end());  // hmm, should we warn?
     snaps.insert(p->second.begin(), p->second.end());
@@ -9775,7 +9774,6 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
   // clone
   dout(20) << "find_object_context  " << soid
 	   << " snapset " << obc->ssc->snapset
-	   << " legacy_snaps " << obc->obs.oi.legacy_snaps
 	   << dendl;
   snapid_t first, last;
   auto p = obc->ssc->snapset.clone_snaps.find(soid.snap);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2059,20 +2059,6 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     return;
   }
 
-  // missing snapdir?
-  hobject_t snapdir = head.get_snapdir();
-
-  if (is_unreadable_object(snapdir)) {
-    wait_for_unreadable_object(snapdir, op);
-    return;
-  }
-
-  // degraded object?
-  if (write_ordered && is_degraded_or_backfilling_object(snapdir)) {
-    wait_for_degraded_object(snapdir, op);
-    return;
-  }
-
   // dup/resent?
   if (op->may_write() || op->may_cache()) {
     // warning: we will get back *a* request for this reqid, but not

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5489,7 +5489,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	     * in the ObjectContext, so we aren't performing an actual read unless
 	     * the clone obc is not already loaded (in which case, it cannot have
 	     * an in progress write).  We also do not risk exposing uncommitted
-	     * state since we do have a read lock on the head object or snapdir,
+	     * state since we do have a read lock on the head object,
 	     * which we would have to write lock in order to make user visible
 	     * modifications to the snapshot state (snap trim related mutations
 	     * are not user visible).

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -8623,7 +8623,7 @@ int PrimaryLogPG::start_flush(
    * for snaps [7, 6] which has been trimmed since they no longer exist.
    * In the base pool, we'd have 5:[4,3,2]:[4(4,3,2)]+head.  When we submit
    * the delete, the snap will be promoted to 5, and the head will become
-   * a snapdir.  When the copy-from goes through, we'll end up with
+   * a whiteout.  When the copy-from goes through, we'll end up with
    * 8:[8,4,3,2]:[4(4,3,2)]+head.
    *
    * Another complication is the case where there is an interval change

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9937,12 +9937,11 @@ void PrimaryLogPG::add_object_context_to_pg_stat(ObjectContextRef obc, pg_stat_t
   object_info_t& oi = obc->obs.oi;
 
   dout(10) << "add_object_context_to_pg_stat " << oi.soid << dendl;
+  assert(!oi.soid.is_snapdir());
+
   object_stat_sum_t stat;
-
   stat.num_bytes += oi.size;
-
-  if (oi.soid.snap != CEPH_SNAPDIR)
-    stat.num_objects++;
+  stat.num_objects++;
   if (oi.is_dirty())
     stat.num_objects_dirty++;
   if (oi.is_whiteout())
@@ -9952,7 +9951,7 @@ void PrimaryLogPG::add_object_context_to_pg_stat(ObjectContextRef obc, pg_stat_t
   if (oi.is_cache_pinned())
     stat.num_objects_pinned++;
 
-  if (oi.soid.snap && oi.soid.snap != CEPH_NOSNAP && oi.soid.snap != CEPH_SNAPDIR) {
+  if (oi.soid.is_snap()) {
     stat.num_object_clones++;
 
     if (!obc->ssc)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11536,12 +11536,6 @@ uint64_t PrimaryLogPG::recover_replicas(uint64_t max, ThreadPool::TPHandle &hand
 	continue;
       }
 
-      if (soid.is_snap() && pg_log.get_missing().is_missing(soid.get_snapdir())) {
-	dout(10) << __func__ << ": " << soid.get_snapdir()
-		 << " still missing on primary" << dendl;
-	continue;
-      }
-
       if (pg_log.get_missing().is_missing(soid)) {
 	dout(10) << __func__ << ": " << soid << " still missing on primary" << dendl;
 	continue;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7046,8 +7046,10 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
     coid.snap = snapc.seq;
     
     unsigned l;
-    for (l=1; l<snapc.snaps.size() && snapc.snaps[l] > ctx->new_snapset.seq; l++) ;
-    
+    for (l = 1;
+	 l < snapc.snaps.size() && snapc.snaps[l] > ctx->new_snapset.seq;
+	 l++) ;
+
     vector<snapid_t> snaps(l);
     for (unsigned i=0; i<l; i++)
       snaps[i] = snapc.snaps[i];
@@ -7057,7 +7059,8 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
     object_info_t *snap_oi;
     if (is_primary()) {
       ctx->clone_obc = object_contexts.lookup_or_create(static_snap_oi.soid);
-      ctx->clone_obc->destructor_callback = new C_PG_ObjectContext(this, ctx->clone_obc.get());
+      ctx->clone_obc->destructor_callback =
+	new C_PG_ObjectContext(this, ctx->clone_obc.get());
       ctx->clone_obc->obs.oi = static_snap_oi;
       ctx->clone_obc->obs.exists = true;
       ctx->clone_obc->ssc = ctx->obc->ssc;
@@ -7113,10 +7116,11 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
 	     << " to " << coid << " v " << ctx->at_version
 	     << " snaps=" << snaps
 	     << " snapset=" << ctx->new_snapset << dendl;
-    ctx->log.push_back(pg_log_entry_t(pg_log_entry_t::CLONE, coid, ctx->at_version,
-				      ctx->obs->oi.version,
-				      ctx->obs->oi.user_version,
-				      osd_reqid_t(), ctx->new_obs.oi.mtime, 0));
+    ctx->log.push_back(pg_log_entry_t(
+			 pg_log_entry_t::CLONE, coid, ctx->at_version,
+			 ctx->obs->oi.version,
+			 ctx->obs->oi.user_version,
+			 osd_reqid_t(), ctx->new_obs.oi.mtime, 0));
     ::encode(snaps, ctx->log.back().snaps);
 
     ctx->at_version.version++;
@@ -7124,12 +7128,13 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
 
   // update most recent clone_overlap and usage stats
   if (ctx->new_snapset.clones.size() > 0) {
-    /* we need to check whether the most recent clone exists, if it's been evicted,
-     * it's not included in the stats */
+    // we need to check whether the most recent clone exists, if it's
+    // been evicted, it's not included in the stats
     hobject_t last_clone_oid = soid;
     last_clone_oid.snap = ctx->new_snapset.clone_overlap.rbegin()->first;
     if (is_present_clone(last_clone_oid)) {
-      interval_set<uint64_t> &newest_overlap = ctx->new_snapset.clone_overlap.rbegin()->second;
+      interval_set<uint64_t> &newest_overlap =
+	ctx->new_snapset.clone_overlap.rbegin()->second;
       ctx->modified_ranges.intersection_of(newest_overlap);
       // modified_ranges is still in use by the clone
       add_interval_usage(ctx->modified_ranges, ctx->delta_stats);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13851,19 +13851,8 @@ void PrimaryLogPG::scrub_snapshot_metadata(
 			 << " obc->obs.oi.soid: " << obc->obs.oi.soid;
       continue;
     }
-    ObjectContextRef snapset_obc;
-    if (!obc->obs.exists) {
-      snapset_obc = get_object_context(p.first.get_snapdir(), false);
-      if (!snapset_obc) {
-	osd->clog->error() << info.pgid << " " << mode
-			   << " cannot get object context for "
-			   << p.first.get_snapdir();
-	continue;
-      }
-    }
     OpContextUPtr ctx = simple_opc_create(obc);
     PGTransaction *t = ctx->op_t.get();
-    ctx->snapset_obc = snapset_obc;
     ctx->at_version = get_next_version();
     ctx->mtime = utime_t();      // do not update mtime
     ctx->new_snapset = p.second;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -9743,29 +9743,6 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
 
   hobject_t head = oid.get_head();
 
-  // want the snapdir?
-  if (oid.snap == CEPH_SNAPDIR) {
-    // return head or snapdir, whichever exists.
-    ObjectContextRef headobc = get_object_context(head, can_create);
-    ObjectContextRef obc = headobc;
-    if (!obc || !obc->obs.exists)
-      obc = get_object_context(oid, can_create);
-    if (!obc || !obc->obs.exists) {
-      // if we have neither, we would want to promote the head.
-      if (pmissing)
-	*pmissing = head;
-      if (pobc)
-	*pobc = headobc; // may be null
-      return -ENOENT;
-    }
-    dout(10) << "find_object_context " << oid
-	     << " @" << oid.snap
-	     << " oi=" << obc->obs.oi
-	     << dendl;
-    *pobc = obc;
-
-  }
-
   // we want a snap
   if (!map_snapid_to_clone && pool.info.is_removed_snap(oid.snap)) {
     dout(10) << __func__ << " snap " << oid.snap << " is removed" << dendl;

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13635,23 +13635,6 @@ void PrimaryLogPG::scrub_snapshot_metadata(
 	    head_error.set_snapset_mismatch();
           }
 	}
-
-	if (soid.is_head() && !snapset->head_exists) {
-	  osd->clog->error() << mode << " " << info.pgid << " " << soid
-			  << " snapset.head_exists=false, but head exists";
-	  ++scrubber.shallow_errors;
-	  head_error.set_head_mismatch();
-	  // Fix head_exists locally so is_legacy() returns correctly
-          snapset->head_exists = true;
-	}
-	if (soid.is_snapdir() && snapset->head_exists) {
-	  osd->clog->error() << mode << " " << info.pgid << " " << soid
-			  << " snapset.head_exists=true, but snapdir exists";
-	  ++scrubber.shallow_errors;
-	  head_error.set_head_mismatch();
-	  // For symmetry fix this too, but probably doesn't matter
-          snapset->head_exists = false;
-	}
       }
     } else {
       assert(soid.is_snap());

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -5293,7 +5293,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	result = _delete_oid(ctx, true, false);
 	if (result >= 0) {
 	  // mark that this is a cache eviction to avoid triggering normal
-	  // make_writeable() clone or snapdir object creation in finish_ctx()
+	  // make_writeable() clone creation in finish_ctx()
 	  ctx->cache_evict = true;
 	}
 	osd->logger->inc(l_osd_tier_evict);

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7809,8 +7809,7 @@ void PrimaryLogPG::start_copy(CopyCallback *cb, ObjectContextRef obc,
 	   << (mirror_snapset ? " mirror_snapset" : "")
 	   << dendl;
 
-  assert(!mirror_snapset || (src.snap == CEPH_NOSNAP ||
-			     src.snap == CEPH_SNAPDIR));
+  assert(!mirror_snapset || src.snap == CEPH_NOSNAP);
 
   // cancel a previous in-progress copy?
   if (copy_ops.count(dest)) {

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2119,6 +2119,13 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     m->has_flag(CEPH_OSD_FLAG_MAP_SNAP_CLONE),
     &missing_oid);
 
+  // LIST_SNAPS needs the ssc too
+  if (obc &&
+      m->get_snapid() == CEPH_SNAPDIR &&
+      !obc->ssc) {
+    obc->ssc = get_snapset_context(oid, true);
+  }
+
   if (r == -EAGAIN) {
     // If we're not the primary of this OSD, we just return -EAGAIN. Otherwise,
     // we have to wait for the object.
@@ -9757,11 +9764,6 @@ int PrimaryLogPG::find_object_context(const hobject_t& oid,
 	     << dendl;
     *pobc = obc;
 
-    // always populate ssc for SNAPDIR...
-    if (!obc->ssc)
-      obc->ssc = get_snapset_context(
-	oid, true);
-    return 0;
   }
 
   // we want a snap

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -10023,15 +10023,11 @@ SnapSetContext *PrimaryLogPG::get_snapset_context(
     bufferlist bv;
     if (!attrs) {
       int r = -ENOENT;
-      if (!(oid.is_head() && !oid_existed))
+      if (!(oid.is_head() && !oid_existed)) {
 	r = pgbackend->objects_get_attr(oid.get_head(), SS_ATTR, &bv);
-      if (r < 0) {
-	// try _snapset
-	if (!(oid.is_snapdir() && !oid_existed))
-	  r = pgbackend->objects_get_attr(oid.get_snapdir(), SS_ATTR, &bv);
-	if (r < 0 && !can_create)
-	  return NULL;
       }
+      if (r < 0 && !can_create)
+	return NULL;
     } else {
       assert(attrs->count(SS_ATTR));
       bv = attrs->find(SS_ATTR)->second;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -536,7 +536,7 @@ public:
     interval_set<uint64_t> modified_ranges;
     ObjectContextRef obc;
     ObjectContextRef clone_obc;    // if we created a clone
-    ObjectContextRef snapset_obc;  // if we created/deleted a snapdir
+    ObjectContextRef head_obc;     // if we also update snapset (see trim_object)
 
     // FIXME: we may want to kill this msgr hint off at some point!
     boost::optional<int> data_off = boost::none;
@@ -756,7 +756,7 @@ protected:
    * @return true on success, false if we are queued
    */
   bool get_rw_locks(bool write_ordered, OpContext *ctx) {
-    /* If snapset_obc, !obc->obs->exists and we will always take the
+    /* If head_obc, !obc->obs->exists and we will always take the
      * snapdir lock *before* the head lock.  Since all callers will do
      * this (read or write) if we get the first we will be guaranteed
      * to get the second.
@@ -770,12 +770,12 @@ protected:
       ctx->lock_type = ObjectContext::RWState::RWREAD;
     }
 
-    if (ctx->snapset_obc) {
+    if (ctx->head_obc) {
       assert(!ctx->obc->obs.exists);
       if (!ctx->lock_manager.get_lock_type(
 	    ctx->lock_type,
-	    ctx->snapset_obc->obs.oi.soid,
-	    ctx->snapset_obc,
+	    ctx->head_obc->obs.oi.soid,
+	    ctx->head_obc,
 	    ctx->op)) {
 	ctx->lock_type = ObjectContext::RWState::RWNONE;
 	return false;
@@ -788,7 +788,7 @@ protected:
 	  ctx->op)) {
       return true;
     } else {
-      assert(!ctx->snapset_obc);
+      assert(!ctx->head_obc);
       ctx->lock_type = ObjectContext::RWState::RWNONE;
       return false;
     }

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1097,7 +1097,7 @@ protected:
     const hobject_t& head, const hobject_t& coid,
     object_info_t *poi);
   void execute_ctx(OpContext *ctx);
-  void finish_ctx(OpContext *ctx, int log_op_type, bool maintain_ssc=true);
+  void finish_ctx(OpContext *ctx, int log_op_type);
   void reply_ctx(OpContext *ctx, int err);
   void reply_ctx(OpContext *ctx, int err, eversion_t v, version_t uv);
   void make_writeable(OpContext *ctx);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1745,7 +1745,7 @@ public:
     const hobject_t& oid, ObjectContextRef obc, OpRequestRef op);
   void block_write_on_degraded_snap(const hobject_t& oid, OpRequestRef op);
 
-  bool maybe_await_blocked_snapset(const hobject_t &soid, OpRequestRef op);
+  bool maybe_await_blocked_head(const hobject_t &soid, OpRequestRef op);
   void wait_for_blocked_object(const hobject_t& soid, OpRequestRef op);
   void kick_object_context_blocked(ObjectContextRef obc);
 

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1410,10 +1410,7 @@ void ReplicatedBackend::prepare_pull(
   ObcLockManager lock_manager;
 
   if (soid.is_snap()) {
-    assert(!get_parent()->get_local_missing().is_missing(
-	     soid.get_head()) ||
-	   !get_parent()->get_local_missing().is_missing(
-	     soid.get_snapdir()));
+    assert(!get_parent()->get_local_missing().is_missing(soid.get_head()));
     assert(headctx);
     // check snapset
     SnapSetContext *ssc = headctx->ssc;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -1491,13 +1491,6 @@ int ReplicatedBackend::prep_push_to_replica(
       dout(15) << "push_to_replica missing head " << head << ", pushing raw clone" << dendl;
       return prep_push(obc, soid, peer, pop, cache_dont_need);
     }
-    hobject_t snapdir = head;
-    snapdir.snap = CEPH_SNAPDIR;
-    if (get_parent()->get_local_missing().is_missing(snapdir)) {
-      dout(15) << "push_to_replica missing snapdir " << snapdir
-	       << ", pushing raw clone" << dendl;
-      return prep_push(obc, soid, peer, pop, cache_dont_need);
-    }
 
     SnapSetContext *ssc = obc->ssc;
     assert(ssc);

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4717,18 +4717,8 @@ void SnapSet::generate_test_instances(list<SnapSet*>& o)
 
 ostream& operator<<(ostream& out, const SnapSet& cs)
 {
-  if (cs.is_legacy()) {
-    out << cs.seq << "=" << cs.snaps << ":"
-	<< cs.clones
-	<< (cs.head_exists ? "+head":"");
-    if (!cs.clone_snaps.empty()) {
-      out << "+stray_clone_snaps=" << cs.clone_snaps;
-    }
-    return out;
-  } else {
-    return out << cs.seq << "=" << cs.snaps << ":"
-	       << cs.clone_snaps;
-  }
+  return out << cs.seq << "=" << cs.snaps << ":"
+	     << cs.clone_snaps;
 }
 
 void SnapSet::from_snap_set(const librados::snap_set_t& ss, bool legacy)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4452,7 +4452,7 @@ struct SnapSet {
   map<snapid_t, uint64_t> clone_size;
   map<snapid_t, vector<snapid_t>> clone_snaps; // descending
 
-  SnapSet() : seq(0), head_exists(false) {}
+  SnapSet() : seq(0), head_exists(true) {}
   explicit SnapSet(bufferlist& bl) {
     bufferlist::iterator p = bl.begin();
     decode(p);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4639,9 +4639,6 @@ struct object_info_t {
     return get_flag_string(flags);
   }
 
-  /// [clone] descending. pre-luminous; moved to SnapSet
-  vector<snapid_t> legacy_snaps;
-
   uint64_t truncate_seq, truncate_size;
 
   map<pair<uint64_t, entity_name_t>, watch_info_t> watchers;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4458,10 +4458,6 @@ struct SnapSet {
     decode(p);
   }
 
-  bool is_legacy() const {
-    return clone_snaps.size() < clones.size() || !head_exists;
-  }
-
   /// populate SnapSet from a librados::snap_set_t
   void from_snap_set(const librados::snap_set_t& ss, bool legacy);
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4445,14 +4445,13 @@ inline ostream& operator<<(ostream& out, const OSDSuperblock& sb)
  */
 struct SnapSet {
   snapid_t seq;
-  bool head_exists;
   vector<snapid_t> snaps;    // descending
   vector<snapid_t> clones;   // ascending
   map<snapid_t, interval_set<uint64_t> > clone_overlap;  // overlap w/ next newest
   map<snapid_t, uint64_t> clone_size;
   map<snapid_t, vector<snapid_t>> clone_snaps; // descending
 
-  SnapSet() : seq(0), head_exists(true) {}
+  SnapSet() : seq(0) {}
   explicit SnapSet(bufferlist& bl) {
     bufferlist::iterator p = bl.begin();
     decode(p);

--- a/src/test/librados/pool.cc
+++ b/src/test/librados/pool.cc
@@ -19,10 +19,13 @@ TEST(LibRadosPools, PoolList) {
   ASSERT_LT(rados_pool_list(cluster, NULL, POOL_LIST_BUF_SZ), POOL_LIST_BUF_SZ);
 
   bool found_pool = false;
+  int firstlen = 0;
   while (buf[0] != '\0') {
     if ((found_pool == false) && (strcmp(buf, pool_name.c_str()) == 0)) {
       found_pool = true;
     }
+    if (!firstlen)
+      firstlen = strlen(buf) + 1;
     buf += strlen(buf) + 1;
   }
   ASSERT_EQ(found_pool, true);
@@ -30,9 +33,9 @@ TEST(LibRadosPools, PoolList) {
   // make sure we honor the buffer size limit
   buf = pool_list_buf;
   memset(buf, 0, POOL_LIST_BUF_SZ);
-  ASSERT_LT(rados_pool_list(cluster, buf, 20), POOL_LIST_BUF_SZ);
+  ASSERT_LT(rados_pool_list(cluster, buf, firstlen), POOL_LIST_BUF_SZ);
   ASSERT_NE(0, buf[0]);  // include at least one pool name
-  ASSERT_EQ(0, buf[20]);  // but don't touch the stopping point
+  ASSERT_EQ(0, buf[firstlen]);  // but don't touch the stopping point
 
   ASSERT_EQ(0, destroy_one_pool(pool_name, &cluster));
 }

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2086,14 +2086,6 @@ int clear_snapset(ObjectStore *store, coll_t coll, ghobject_t &ghobj,
   if (ret < 0)
     return ret;
 
-  // Use "head" to set head_exists incorrectly
-  if (arg == "corrupt" || arg == "head")
-    ss.head_exists = !ghobj.hobj.is_head();
-  else if (ss.head_exists != ghobj.hobj.is_head()) {
-    cerr << "Correcting head_exists, set to "
-         << (ghobj.hobj.is_head() ? "true" : "false") << std::endl;
-    ss.head_exists = ghobj.hobj.is_head();
-  }
   // Use "corrupt" to clear entire SnapSet
   // Use "seq" to just corrupt SnapSet.seq
   if (arg == "corrupt" || arg == "seq")

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -835,60 +835,38 @@ int get_attrs(
 
   // This could have been handled in the caller if we didn't need to
   // support exports that didn't include object_info_t in object_begin.
-  if (hoid.generation == ghobject_t::NO_GEN) {
-    if (hoid.hobj.snap < CEPH_MAXSNAP) {
-      map<string,bufferlist>::iterator mi = as.data.find(OI_ATTR);
-      if (mi != as.data.end()) {
-	object_info_t oi(mi->second);
-
-	if (debug)
-	  cerr << "object_info " << oi << std::endl;
-
-	OSDriver::OSTransaction _t(driver.get_transaction(t));
-	set<snapid_t> oi_snaps(oi.legacy_snaps.begin(), oi.legacy_snaps.end());
-	if (!oi_snaps.empty()) {
+  if (hoid.generation == ghobject_t::NO_GEN &&
+      hoid.hobj.is_head()) {
+    map<string,bufferlist>::iterator mi = as.data.find(SS_ATTR);
+    if (mi != as.data.end()) {
+      SnapSet snapset;
+      auto p = mi->second.begin();
+      snapset.decode(p);
+      cout << "snapset " << snapset << std::endl;
+      for (auto& p : snapset.clone_snaps) {
+	ghobject_t clone = hoid;
+	clone.hobj.snap = p.first;
+	set<snapid_t> snaps(p.second.begin(), p.second.end());
+	if (!store->exists(coll, clone)) {
+	  // no clone, skip.  this is probably a cache pool.  this works
+	  // because we use a separate transaction per object and clones
+	  // come before head in the archive.
 	  if (debug)
-	    cerr << "\tsetting legacy snaps " << oi_snaps << std::endl;
-	  snap_mapper.add_oid(hoid.hobj, oi_snaps, &_t);
+	    cerr << "\tskipping missing " << clone << " (snaps "
+		 << snaps << ")" << std::endl;
+	  continue;
 	}
+	if (debug)
+	  cerr << "\tsetting " << clone.hobj << " snaps " << snaps
+	       << std::endl;
+	OSDriver::OSTransaction _t(driver.get_transaction(t));
+	assert(!snaps.empty());
+	snap_mapper.add_oid(clone.hobj, snaps, &_t);
       }
     } else {
-      if (hoid.hobj.is_head()) {
-	map<string,bufferlist>::iterator mi = as.data.find(SS_ATTR);
-	if (mi != as.data.end()) {
-	  SnapSet snapset;
-	  auto p = mi->second.begin();
-	  snapset.decode(p);
-	  cout << "snapset " << snapset << std::endl;
-	  if (!snapset.is_legacy()) {
-	    for (auto& p : snapset.clone_snaps) {
-	      ghobject_t clone = hoid;
-	      clone.hobj.snap = p.first;
-	      set<snapid_t> snaps(p.second.begin(), p.second.end());
-	      if (!store->exists(coll, clone)) {
-		// no clone, skip.  this is probably a cache pool.  this works
-		// because we use a separate transaction per object and clones
-		// come before head in the archive.
-		if (debug)
-		  cerr << "\tskipping missing " << clone << " (snaps "
-		       << snaps << ")" << std::endl;
-		continue;
-	      }
-	      if (debug)
-		cerr << "\tsetting " << clone.hobj << " snaps " << snaps
-		     << std::endl;
-	      OSDriver::OSTransaction _t(driver.get_transaction(t));
-	      assert(!snaps.empty());
-	      snap_mapper.add_oid(clone.hobj, snaps, &_t);
-	    }
-	  }
-	} else {
-	  cerr << "missing SS_ATTR on " << hoid << std::endl;
-	}
-      }
+      cerr << "missing SS_ATTR on " << hoid << std::endl;
     }
   }
-
   return 0;
 }
 


### PR DESCRIPTION
These are gone after luminous.  This rips out all of the compat code from the 
conversion and also simplifies most of hte original code now that head is
always present.

I think SnapSetContext could probably also be removed (use head obc instead),
but haven't tackled that one yet.

Broken into small patches to make each change easier to review.  This will need
a careful look!