### PR TITLE
MOSDPGRecoveryDelete[Reply]: bump header version

### DIFF
--- a/src/messages/MOSDPGRecoveryDelete.h
+++ b/src/messages/MOSDPGRecoveryDelete.h
@@ -12,7 +12,7 @@
 
 struct MOSDPGRecoveryDelete : public MOSDFastDispatchOp {
 
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
   pg_shard_t from;

--- a/src/messages/MOSDPGRecoveryDeleteReply.h
+++ b/src/messages/MOSDPGRecoveryDeleteReply.h
@@ -7,7 +7,7 @@
 #include "MOSDFastDispatchOp.h"
 
 struct MOSDPGRecoveryDeleteReply : public MOSDFastDispatchOp {
-  static const int HEAD_VERSION = 1;
+  static const int HEAD_VERSION = 2;
   static const int COMPAT_VERSION = 1;
 
   pg_shard_t from;


### PR DESCRIPTION
This matches the encoding workaround in luminous. Keep compat_version
at 1 since this still works with 12.2.0, but does not need to handle
any earlier encodings.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>