### PR TITLE
os/bluestore: shrink aio submit size to pending value

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -520,7 +520,7 @@ void KernelDevice::aio_submit(IOContext *ioc)
   void *priv = static_cast<void*>(ioc);
   int r, retries = 0;
   r = aio_queue.submit_batch(ioc->running_aios.begin(), e, 
-			     ioc->num_running.load(), priv, &retries);
+			     pending, priv, &retries);
   
   if (retries)
     derr << __func__ << " retries " << retries << dendl;

--- a/src/os/bluestore/aio.cc
+++ b/src/os/bluestore/aio.cc
@@ -46,6 +46,7 @@ int aio_queue_t::submit_batch(aio_iter begin, aio_iter end,
     ++left;
     ++cur;
   }
+  assert(aios_size >= left);
   int done = 0;
   while (left > 0) {
     int r = io_submit(ctx, left, piocb + done);


### PR DESCRIPTION
running_aios size may be very large in high work load, because we only submit pending aios, so we better apply pending aios size array in aio_queue_t::submit_batch.
@yangdongsheng 

@liewegas need a review,please