### PR TITLE
doc: fix typo on specify db block device

### DIFF
--- a/doc/rados/configuration/bluestore-config-ref.rst
+++ b/doc/rados/configuration/bluestore-config-ref.rst
@@ -49,7 +49,7 @@ A single-device BlueStore OSD can be provisioned with::
 
 To specify a WAL device and/or DB device, ::
 
-  ceph-disk prepare --bluestore <device> --block.wal <wal-device> --block-db <db-device>
+  ceph-disk prepare --bluestore <device> --block.wal <wal-device> --block.db <db-device>
 
 Cache size
 ==========


### PR DESCRIPTION
Should use block.db instead of block-db

Signed-off-by: Xiaoxi Chen <xiaoxchen@ebay.com>