### PR TITLE
rgw: add a OLHLogOp op to remove OLH_PENDING

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1454,8 +1454,10 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
     }
     if (removing) {
       olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, op.olh_epoch);
+    } else {
+      olh.update_log(CLS_RGW_OLH_OP_REMOVE_PENDING, op.op_tag, op.key, false, op.olh_epoch);
     }
-    return 0;
+    return olh.write();
   }
 
   if (olh_found) {
@@ -1611,9 +1613,10 @@ static int rgw_bucket_unlink_instance(cls_method_context_t hctx, bufferlist *in,
 
     if (!obj.is_delete_marker()) {
       olh.update_log(CLS_RGW_OLH_OP_REMOVE_INSTANCE, op.op_tag, op.key, false, op.olh_epoch);
+    } else {
+      olh.update_log(CLS_RGW_OLH_OP_REMOVE_PENDING, op.op_tag, op.key, false, op.olh_epoch);
     }
-
-    return 0;
+    return olh.write();
   }
 
   rgw_bucket_olh_entry& olh_entry = olh.get_entry();

--- a/src/cls/rgw/cls_rgw_types.cc
+++ b/src/cls/rgw/cls_rgw_types.cc
@@ -319,6 +319,9 @@ void rgw_bucket_olh_log_entry::dump(Formatter *f) const
     case CLS_RGW_OLH_OP_REMOVE_INSTANCE:
       op_str = "remove_instance";
       break;
+    case CLS_RGW_OLH_OP_REMOVE_PENDING:
+      op_str = "remove_pending";
+      break;
     default:
       op_str = "unknown";
   }
@@ -339,6 +342,8 @@ void rgw_bucket_olh_log_entry::decode_json(JSONObj *obj)
     op = CLS_RGW_OLH_OP_UNLINK_OLH;
   } else if (op_str == "remove_instance") {
     op = CLS_RGW_OLH_OP_REMOVE_INSTANCE;
+  } else if (op_str == "remove_pending") {
+    op = CLS_RGW_OLH_OP_REMOVE_PENDING;
   } else {
     op = CLS_RGW_OLH_OP_UNKNOWN;
   }

--- a/src/cls/rgw/cls_rgw_types.h
+++ b/src/cls/rgw/cls_rgw_types.h
@@ -422,6 +422,7 @@ enum OLHLogOp {
   CLS_RGW_OLH_OP_LINK_OLH        = 1,
   CLS_RGW_OLH_OP_UNLINK_OLH      = 2, /* object does not exist */
   CLS_RGW_OLH_OP_REMOVE_INSTANCE = 3,
+  CLS_RGW_OLH_OP_REMOVE_PENDING  = 4,
 };
 
 struct rgw_bucket_olh_log_entry {

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -11161,6 +11161,8 @@ int RGWRados::apply_olh_log(RGWObjectCtx& obj_ctx, RGWObjState& state, const RGW
         need_to_remove = true;
         need_to_link = false;
         break;
+      case CLS_RGW_OLH_OP_REMOVE_PENDING:
+        break;
       default:
         ldout(cct, 0) << "ERROR: apply_olh_log: invalid op: " << (int)entry.op << dendl;
         return -EIO;


### PR DESCRIPTION
For versioned bucket, if olh cannot start_modify, we should remove the link/unlink pending attr. So here I add an op to do the removing.

Write olh if it is updated

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>