### PR TITLE
messages: Silence uninitialized member warnings

### DIFF
--- a/src/messages/MClientReply.h
+++ b/src/messages/MClientReply.h
@@ -97,18 +97,18 @@ struct DirStat {
 
 struct InodeStat {
   vinodeno_t vino;
-  uint32_t rdev;
-  version_t version;
-  version_t xattr_version;
+  uint32_t rdev = 0;
+  version_t version = 0;
+  version_t xattr_version = 0;
   ceph_mds_reply_cap cap;
   file_layout_t layout;
   utime_t ctime, btime, mtime, atime;
-  uint32_t time_warp_seq;
-  uint64_t size, max_size;
-  uint64_t change_attr;
-  uint64_t truncate_size;
-  uint32_t truncate_seq;
-  uint32_t mode, uid, gid, nlink;
+  uint32_t time_warp_seq = 0;
+  uint64_t size = 0, max_size = 0;
+  uint64_t change_attr = 0;
+  uint64_t truncate_size = 0;
+  uint32_t truncate_seq = 0;
+  uint32_t mode = 0, uid = 0, gid = 0, nlink = 0;
   frag_info_t dirstat;
   nest_info_t rstat;
 
@@ -202,7 +202,7 @@ struct InodeStat {
 class MClientReply : public Message {
   // reply data
 public:
-  struct ceph_mds_reply_head head;
+  struct ceph_mds_reply_head head {};
   bufferlist trace_bl;
   bufferlist extra_bl;
   bufferlist snapbl;


### PR DESCRIPTION
Fixes the coverity issues:

** 717263 Uninitialized scalar field
>2. uninit_member: Non-static class member field head.op is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field head.result is not initialized
in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member field head.mdsmap_epoch is not
initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field head.safe is not initialized
 in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field head.is_dentry is not
initialized in this constructor nor in any functions that it calls.
>CID 717263 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>12. uninit_member: Non-static class member field head.is_target is not
initialized in this constructor nor in any functions that it calls.

** 717264 Uninitialized scalar field
>2. uninit_member: Non-static class member rdev is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member version is not initialized
in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member xattr_version is not
initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field cap.caps is not
initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field cap.wanted is not
initialized in this constructor nor in any functions that it calls.
>12. uninit_member: Non-static class member field cap.cap_id is not
initialized in this constructor nor in any functions that it calls.
>14. uninit_member: Non-static class member field cap.seq is not
initialized in this constructor nor in any functions that it calls.
>16. uninit_member: Non-static class member field cap.mseq is not
initialized in this constructor nor in any functions that it calls.
>18. uninit_member: Non-static class member field cap.realm is not
initialized in this constructor nor in any functions that it calls.
>20. uninit_member: Non-static class member field cap.flags is not
initialized in this constructor nor in any functions that it calls.
>22. uninit_member: Non-static class member time_warp_seq is not
initialized in this constructor nor in any functions that it calls.
>24. uninit_member: Non-static class member size is not initialized
in this constructor nor in any functions that it calls.
>26. uninit_member: Non-static class member max_size is not initialized
in this constructor nor in any functions that it calls.
>28. uninit_member: Non-static class member change_attr is not initialized
in this constructor nor in any functions that it calls.
>30. uninit_member: Non-static class member truncate_size is not
initialized in this constructor nor in any functions that it calls.
>32. uninit_member: Non-static class member truncate_seq is not initialized
in this constructor nor in any functions that it calls.
>34. uninit_member: Non-static class member mode is not initialized in
this constructor nor in any functions that it calls.
>36. uninit_member: Non-static class member uid is not initialized in this
constructor nor in any functions that it calls.
>38. uninit_member: Non-static class member gid is not initialized in this
constructor nor in any functions that it calls.
>40. uninit_member: Non-static class member nlink is not initialized in
this constructor nor in any functions that it calls.
>42. uninit_member: Non-static class member field dir_layout.dl_dir_hash
is not initialized in this constructor nor in any functions that it calls.
>44. uninit_member: Non-static class member field dir_layout.dl_unused1
is not initialized in this constructor nor in any functions that it calls.
>46. uninit_member: Non-static class member field dir_layout.dl_unused2 is
not initialized in this constructor nor in any functions that it calls.
>48. uninit_member: Non-static class member field dir_layout.dl_unused3 is
not initialized in this constructor nor in any functions that it calls.
>CID 717264 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>50. uninit_member: Non-static class member inline_version is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>