### PR TITLE
messages: Initialization of members MMDSCacheRejion

### DIFF
--- a/src/messages/MMDSCacheRejoin.h
+++ b/src/messages/MMDSCacheRejoin.h
@@ -45,9 +45,9 @@ class MMDSCacheRejoin : public Message {
 
   // -- types --
   struct inode_strong { 
-    uint32_t nonce;
-    int32_t caps_wanted;
-    int32_t filelock, nestlock, dftlock;
+    uint32_t nonce = 0;
+    int32_t caps_wanted = 0;
+    int32_t filelock = 0, nestlock = 0, dftlock = 0;
     inode_strong() {}
     inode_strong(int n, int cw, int dl, int nl, int dftl) :
       nonce(n), caps_wanted(cw),
@@ -70,8 +70,8 @@ class MMDSCacheRejoin : public Message {
   WRITE_CLASS_ENCODER(inode_strong)
 
   struct dirfrag_strong {
-    uint32_t nonce;
-    int8_t  dir_rep;
+    uint32_t nonce = 0;
+    int8_t  dir_rep = 0;
     dirfrag_strong() {}
     dirfrag_strong(int n, int dr) : nonce(n), dir_rep(dr) {}
     void encode(bufferlist &bl) const {


### PR DESCRIPTION
Fixes the coverity issues:

** 717283 Uninitialized scalar field
>2. uninit_member: Non-static class member nonce is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member caps_wanted is not initialized
in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member filelock is not initialized
in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member nestlock is not initialized
in this constructor nor in any functions that it calls.
>CID 717283 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>10. uninit_member: Non-static class member dftlock is not
initialized in this constructor nor in any functions that it calls.

** 717284 Uninitialized scalar field
>2. uninit_member: Non-static class member nonce is not initialized
in this constructor nor in any functions that it calls.
>CID 717284 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member dir_rep is not initialized
in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar <amitkuma@redhat.com>