### PR TITLE
encoding: reset optional<> if it is uninitialized

### DIFF
--- a/src/include/encoding.h
+++ b/src/include/encoding.h
@@ -297,16 +297,16 @@ inline void encode(const boost::optional<T> &p, bufferlist &bl)
 #pragma GCC diagnostic ignored "-Wpragmas"
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 template<typename T>
 inline void decode(boost::optional<T> &p, bufferlist::iterator &bp)
 {
   __u8 present;
   ::decode(present, bp);
   if (present) {
-    T t;
-    p = t;
+    p = T{};
     decode(p.get(), bp);
+  } else {
+    p = boost::none;
   }
 }
 #pragma GCC diagnostic pop


### PR DESCRIPTION
* should reset it, in case we reuse it after initializing it.
* initialize the value of `p` using the C++11 style initializer, so it
  is zero-initialized.
* revert 2a83ef3c which disables a warning of:
 ./include/encoding.h:317:7: warning: 't' may be used uninitialized in
    this function [-Wmaybe-uninitialized]
 where the `t` is the temporary variable for initializing the value of
 `p`.

Signed-off-by: Kefu Chai <kchai@redhat.com>