### PR TITLE
client: fix a bug in lseek

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -8537,25 +8537,32 @@ loff_t Client::_lseek(Fh *f, loff_t offset, int whence)
 {
   Inode *in = f->inode.get();
   int r;
+  loff_t pos = -1;
 
   switch (whence) {
   case SEEK_SET:
-    f->pos = offset;
+    pos = offset;
     break;
 
   case SEEK_CUR:
-    f->pos += offset;
+    pos += offset;
     break;
 
   case SEEK_END:
     r = _getattr(in, CEPH_STAT_CAP_SIZE, f->actor_perms);
     if (r < 0)
       return r;
-    f->pos = in->size + offset;
+    pos = in->size + offset;
     break;
 
   default:
     ceph_abort();
+  }
+
+  if (pos < 0) {
+    return -EINVAL;
+  } else {
+    f->pos = pos;
   }
 
   ldout(cct, 3) << "_lseek(" << f << ", " << offset << ", " << whence << ") = " << f->pos << dendl;


### PR DESCRIPTION
If offset less than 0,the lseek may cause f->pos less than 0.
So read or write may error.

Signed-off-by: Duan Zhang <zhangduan@inspur.com>