### PR TITLE
client: clean up C_SafeCond on early return

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12686,6 +12686,7 @@ int Client::ll_write_block(Inode *in, uint64_t blockid,
   client_lock.Lock();
   if (unmounting) {
     client_lock.Unlock();
+    delete onsafe;
     return -ENOTCONN;
   }
 


### PR DESCRIPTION
Fix for: CID 1417473:  Resource leaks  (RESOURCE_LEAK)

Signed-off-by: Greg Farnum <gfarnum@redhat.com>