### PR TITLE
build/ops: rpm: do not create librbd.so.1 symlink in /usr/lib64/qemu

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1528,10 +1528,7 @@ fi
 %{_libdir}/librbd_tp.so.*
 %endif
 
-%post -n librbd1
-/sbin/ldconfig
-mkdir -p /usr/lib64/qemu/
-ln -sf %{_libdir}/librbd.so.1 /usr/lib64/qemu/librbd.so.1
+%post -n librbd1 -p /sbin/ldconfig
 
 %postun -n librbd1 -p /sbin/ldconfig
 


### PR DESCRIPTION
As reported by Ademar de Souza Reis Jr <areis@redhat.com>:

This symlink should not be necessary anymore. QEMU is properly linked to
ceph/librbd these days (look at the qemu-block-rbd sub-package in Fedora and
the respective package in RHEL).

The symlink was a hack from a time when librbd was distributed and supported by
ceph and the rbd driver would be enabled at runtime only when/if the symlink
was present.

So the right fix is to actually get rid of the symlink altogether and never
touch (much less own) /usr/lib64/qemu.

Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit be4d6b1a74a0612621c3ad2cedebaa1fa40ffbab)