### PR TITLE
osd/PrimaryLogPG: track last_update, not last_complete, for backfill targets last_complete_ondisk

### DIFF
--- a/src/osd/ECBackend.cc
+++ b/src/osd/ECBackend.cc
@@ -1088,7 +1088,8 @@ void ECBackend::handle_sub_write_reply(
     assert(i->second.pending_commit.count(from));
     i->second.pending_commit.erase(from);
     if (from != get_parent()->whoami_shard()) {
-      get_parent()->update_peer_last_complete_ondisk(from, op.last_complete);
+      get_parent()->update_peer_last_complete_ondisk(from, op.last_complete,
+						     i->second.version);
     }
   }
   if (op.applied) {

--- a/src/osd/PGBackend.h
+++ b/src/osd/PGBackend.h
@@ -235,7 +235,8 @@ typedef ceph::shared_ptr<const OSDMap> OSDMapRef;
 
      virtual void update_peer_last_complete_ondisk(
        pg_shard_t fromosd,
-       eversion_t lcod) = 0;
+       eversion_t lcod,
+       eversion_t v) = 0;
 
      virtual void update_last_complete_ondisk(
        eversion_t lcod) = 0;

--- a/src/osd/ReplicatedBackend.cc
+++ b/src/osd/ReplicatedBackend.cc
@@ -672,7 +672,7 @@ void ReplicatedBackend::do_repop_reply(OpRequestRef op)
 
     parent->update_peer_last_complete_ondisk(
       from,
-      r->get_last_complete_ondisk());
+      r->get_last_complete_ondisk(), ip_op.v);
 
     if (ip_op.waiting_for_applied.empty() &&
         ip_op.on_applied) {


### PR DESCRIPTION
We trim the PG log based on the min_last_complete_ondisk.  Nobody
else uses the value.

If we have a backfill target, but not backfilling, then the last_complete
on the backfill target(s) do not advance, and our pg log trimming is
effectively stalled indefinitely.  For example, for this pg,

    "up": [
        92,
        18,
        26
    ],
    "acting": [
        92,
        18
    ],
    "backfill_targets": [
        "26"
    ],
    "actingbackfill": [
        "18",
        "26",
        "92"
    ],

in state active+recovery_wait+undersized+degraded+remapped.  The peer
infos are up to date for the backfill target,

            "peer": "26",
            "pgid": "0.36",
            "last_update": "832429'3721336",
            "last_complete": "832429'3721336",

but the PG will not trim because the last_complete on the peer itself is
0'0, and we update peer_last_complete_ondisk[] based on that.

Fix this by updating the peer lcod value to last_complete for acting
peers and last_update for backfill targets.  This makes sense because
last_complete is pretty meaningless for backfill targets since they are
already incomplete and backfilling; it doesn't matter if we trim the pg
log past what they are/were complete to.  All that matters is they persist
the new log entries (hence, use the last_update reported in the write
reply).

Note that this is probably one other source of the "OSDs use more
memory during recovery" meme.

Signed-off-by: Sage Weil <sage@redhat.com>