### PR TITLE
mon/PGMap: drop DISK LOG column

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2011,7 +2011,6 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
   tab.define_column("UNFOUND", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("BYTES", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("LOG", TextTable::LEFT, TextTable::RIGHT);
-  tab.define_column("DISK_LOG", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("STATE", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("STATE_STAMP", TextTable::LEFT, TextTable::RIGHT);
   tab.define_column("VERSION", TextTable::LEFT, TextTable::RIGHT);
@@ -2039,7 +2038,6 @@ void PGMap::dump_filtered_pg_stats(ostream& ss, set<pg_t>& pgs) const
         << st.stats.sum.num_objects_unfound
         << st.stats.sum.num_bytes
         << st.log_size
-        << st.ondisk_log_size
         << pg_state_string(st.state)
         << st.last_change
         << st.version


### PR DESCRIPTION
We can re-add it if/when it differs from LOG.

Signed-off-by: Sage Weil <sage@redhat.com>