### PR TITLE
osd/PGPool::update: optimize with std::vector for intersection results

### DIFF
--- a/src/include/abs_interval_set.hpp
+++ b/src/include/abs_interval_set.hpp
@@ -1,0 +1,569 @@
+#ifndef CEPH_ABS_INTERVAL_SET_H
+#define CEPH_ABS_INTERVAL_SET_H
+
+#include <iterator>
+#include <ostream>
+#include <utility>
+
+#include "include/assert.h"
+
+namespace abs_interval_set {
+
+  namespace iter_wrappers {
+
+    template<class Iter>
+    inline void* copy(const void* iter) {
+      return reinterpret_cast<void*>(new Iter(
+          *reinterpret_cast<const Iter*>(iter)));
+    }
+
+    template<class Iter>
+    inline void assign(void* lhs, const void* rhs) {
+      *reinterpret_cast<Iter*>(lhs) = *reinterpret_cast<const Iter*>(rhs);
+    }
+
+    template<class Iter>
+    inline void del (void* iter) {
+      delete reinterpret_cast<Iter*>(iter);
+    }
+
+    template<class Iter>
+    inline bool eq(const void* iter, const void* rhs) {
+      return *reinterpret_cast<const Iter*>(iter) ==
+          *reinterpret_cast<const Iter*>(rhs);
+    }
+
+    template<class Iter>
+    inline void inc(void* iter) {
+      ++(*reinterpret_cast<Iter*>(iter));
+    }
+
+    template<class Iter>
+    inline void dec(void* iter) {
+      --(*reinterpret_cast<Iter*>(iter));
+    }
+
+    template<class Key, class T, class Iter>
+    inline std::pair<const Key, T> deref(const void* iter) {
+      return *(*reinterpret_cast<const Iter*>(iter));
+    }
+
+    template<class T, class Iter>
+    inline T get_len(const void* iter) {
+      return (*(*reinterpret_cast<const Iter*>(iter))).second;
+    }
+
+    template<class Key, class Iter>
+    inline Key get_start(const void* iter) {
+      return (*(*reinterpret_cast<const Iter*>(iter))).first;
+    }
+
+    template<class Key, class Iter>
+    inline Key get_end(const void* iter) {
+      return (*(*reinterpret_cast<const Iter*>(iter))).first +
+          (*(*reinterpret_cast<const Iter*>(iter))).second;
+    }
+
+    template<class T, class Iter>
+    inline void set_len(void* iter, const T& value) {
+      (*reinterpret_cast<Iter*>(iter))->second = value;
+    }
+  }
+
+  template<class Key, class T>
+  struct iter_funcs {
+    void* (*copy)(const void*);
+    void (*assign)(void*, const void*);
+    void (*del)(void*);
+    bool (*eq)(const void*, const void*);
+    void (*inc)(void*);
+    void (*dec)(void*);
+    /*
+     * Dereference is return by value, as a means to hide differences
+     * between pair<const Key,T> used by map and pair<Key,T> used by
+     * vector (vector elements are not allowed to contain const
+     * members). Copy elision (RVO) will optimize away unecessary
+     * copies when possible.
+     */
+    std::pair<const Key, T>(*deref)(const void*);
+    T(*get_len)(const void*);
+    Key(*get_start)(const void*);
+    Key(*get_end)(const void*);
+    void (*set_len)(void*, const T&);
+  };
+
+  template<class Key, class T, class Iter>
+  iter_funcs<Key,T>* mut_iter_funcs() {
+    static iter_funcs<Key,T> funcs{
+      iter_wrappers::copy<Iter>,
+      iter_wrappers::assign<Iter>,
+      iter_wrappers::del<Iter>,
+      iter_wrappers::eq<Iter>,
+      iter_wrappers::inc<Iter>,
+      iter_wrappers::dec<Iter>,
+      iter_wrappers::deref<Key,T,Iter>,
+      iter_wrappers::get_len<T,Iter>,
+      iter_wrappers::get_start<Key,Iter>,
+      iter_wrappers::get_end<Key,Iter>,
+      iter_wrappers::set_len<T,Iter>
+    };
+    return &funcs;
+  }
+
+  template<class Key, class T, class Iter>
+  iter_funcs<Key,T>* const_iter_funcs() {
+    static iter_funcs<Key,T> funcs{
+      iter_wrappers::copy<Iter>,
+      iter_wrappers::assign<Iter>,
+      iter_wrappers::del<Iter>,
+      iter_wrappers::eq<Iter>,
+      iter_wrappers::inc<Iter>,
+      iter_wrappers::dec<Iter>,
+      iter_wrappers::deref<Key,T,Iter>,
+      iter_wrappers::get_len<T,Iter>,
+      iter_wrappers::get_start<Key,Iter>,
+      iter_wrappers::get_end<Key,Iter>,
+      NULL
+    };
+    return &funcs;
+  }
+
+  template<class Key, class T>
+  class iterator: public std::iterator <
+      std::forward_iterator_tag, std::pair<const Key, T>> {
+
+    public:
+      iterator(): _iter(NULL), _funcs(NULL) {}
+      template<class Iter>
+      explicit iterator(const Iter& impl):
+          _iter(reinterpret_cast<void*>(new Iter(impl))),
+          _funcs(mut_iter_funcs<Key,T,Iter>()) {}
+
+      iterator(const iterator& iter) {
+        if (iter._funcs != NULL)
+          _iter = iter._funcs->copy(iter._iter);
+        else
+          _iter = NULL;
+        _funcs = iter._funcs;
+      }
+
+      iterator &operator=(const iterator &iter) {
+        if (_funcs != NULL) {
+          if (_funcs == iter._funcs) {
+            _funcs->assign(_iter, &iter);
+            return *this;
+          }
+          else
+            _funcs->del(_iter);
+        }
+        _funcs = iter._funcs;
+        if (_funcs != NULL)
+          _iter = _funcs->copy(iter._iter);
+        else
+          _iter = NULL;
+        return *this;
+      }
+
+      template<class Iter>
+      iterator &operator=(const Iter &iter) {
+        assert(_funcs != NULL);
+        _funcs->assign(_iter, &iter);
+        return *this;
+      }
+
+      ~iterator() {
+        if (_funcs != NULL)
+          _funcs->del(_iter);
+      }
+
+      bool operator==(const iterator<Key,T>& rhs) const {
+        return _funcs->eq(_iter, rhs._iter);
+      }
+
+      bool operator!=(const iterator<Key,T>& rhs) const {
+        return !_funcs->eq(_iter, rhs._iter);
+      }
+
+      std::pair<const Key, T> operator*() const {
+        return _funcs->deref(_iter);
+      }
+
+     /*
+      * -> is not supported because deref is
+      * return by value
+      */
+     /*
+      std::pair<const Key, T> *operator->() {
+        return &(_funcs->deref(_iter));
+      }
+      */
+
+      Key get_start() const {
+        return _funcs->get_start(_iter);
+      }
+
+      Key get_end() const {
+        return _funcs->get_end(_iter);
+      }
+
+      T get_len() const {
+        return _funcs->get_len(_iter);
+      }
+
+      void set_len(T value) {
+        _funcs->set_len(_iter, value);
+      }
+
+      iterator<Key,T> &operator++() {
+        _funcs->inc(_iter);
+        return *this;
+      }
+
+      iterator<Key,T> operator++(int) {
+        iterator<Key,T> prev(*this);
+        _funcs->inc(_iter);
+        return prev;
+      }
+
+      iterator<Key,T> &operator--() {
+        _funcs->dec(_iter);
+        return *this;
+      }
+
+      iterator<Key,T> operator--(int) {
+        iterator<Key,T> prev(*this);
+        _funcs->dec(_iter);
+        return prev;
+      }
+
+      const void* get_impl() const {
+        return _iter;
+      }
+
+    private:
+      void *_iter;                    // dynamically allocated
+      iter_funcs<Key,T>* _funcs;      // statically allocated
+  };
+
+  template<class Key, class T>
+  class const_iterator:
+      public std::iterator <
+          std::forward_iterator_tag, std::pair<const Key, T>> {
+
+    public:
+      const_iterator(): _iter(NULL), _funcs(NULL) {}
+
+     /*
+      * Support implicit conversion from mutable iterator, since
+      * the interval_set lower_bound method can return a mutable
+      * iterator when we attempt to assign to a const_iterator
+      * variable.
+      */
+      template<class Iter>
+      const_iterator(const Iter& impl):
+          _iter(reinterpret_cast<void*>(new Iter(impl))),
+          _funcs(const_iter_funcs<Key,T,Iter>()) {}
+
+      const_iterator(const const_iterator& iter) {
+        if (iter._funcs != NULL)
+          _iter = iter._funcs->copy(iter._iter);
+        else
+          _iter = NULL;
+        _funcs = iter._funcs;
+      }
+
+      const_iterator &operator=(const const_iterator &iter) {
+        if (_funcs != NULL)
+          _funcs->del(_iter);
+        _funcs = iter._funcs;
+        if (_funcs != NULL)
+          _iter = _funcs->copy(iter._iter);
+        else
+          _iter = NULL;
+        return *this;
+      }
+
+      ~const_iterator() {
+        if (_funcs != NULL)
+          _funcs->del(_iter);
+      }
+
+      bool operator==(const const_iterator<Key,T>& rhs) const {
+        return _funcs->eq(_iter, rhs._iter);
+      }
+
+      bool operator!=(const const_iterator<Key,T>& rhs) const {
+        return !_funcs->eq(_iter, rhs._iter);
+      }
+
+      const std::pair<const Key, T> operator*() const {
+        return _funcs->deref(_iter);
+      }
+
+     /*
+      * -> is not supported because deref is
+      * return by value
+      */
+     /*
+      std::pair<const Key, T> *operator->() {
+        return &(_funcs->deref(_iter));
+      }
+      */
+
+      Key get_start() const {
+        return _funcs->get_start(_iter);
+      }
+
+      Key get_end() const {
+        return _funcs->get_end(_iter);
+      }
+
+      T get_len() const {
+        return _funcs->get_len(_iter);
+      }
+
+      const_iterator<Key,T> &operator++() {
+        _funcs->inc(_iter);
+        return *this;
+      }
+
+      const_iterator<Key,T> operator++(int) {
+        const_iterator<Key,T> prev(*this);
+        _funcs->inc(_iter);
+        return prev;
+      }
+
+      const_iterator<Key,T> &operator--() {
+        _funcs->dec(_iter);
+        return *this;
+      }
+
+      const_iterator<Key,T> operator--(int) {
+        const_iterator<Key,T> prev(*this);
+        _funcs->dec(_iter);
+        return prev;
+      }
+
+      const void* get_impl() const {
+        return _iter;
+      }
+
+    private:
+      void *_iter;                  // dynamically allocated
+      iter_funcs<Key,T>* _funcs;    // statically allocated
+  };
+
+
+  template<typename T>
+  class interval_set {
+    public:
+      virtual ~interval_set() {}
+      typedef std::pair<const T, T> value_type;
+      typedef abs_interval_set::iterator<T,T> iterator;
+      typedef abs_interval_set::const_iterator<T,T> const_iterator;
+      virtual iterator begin() = 0;
+      virtual iterator end() = 0;
+      virtual const_iterator begin() const = 0;
+      virtual const_iterator end() const = 0;
+      virtual int64_t size() const = 0;
+      virtual int num_intervals() const = 0;
+      virtual void clear() = 0;
+      virtual bool empty() const = 0;
+      virtual T range_start() const = 0;
+      virtual T range_end() const = 0;
+
+      /*
+       * Allow comparison of pair<const T, T> with pair<T, T>, since
+       * vector does not allow elements to contain const members.
+       */
+      template <class ValueTypeA, class ValueTypeB>
+      static bool item_equiv(const ValueTypeA& lhs, const ValueTypeB& rhs) {
+        return lhs.first == rhs.first && lhs.second == rhs.second;
+      }
+
+      template <class ISet>
+      bool operator==(const ISet &rhs) const {
+        if (size() != rhs.size() || num_intervals() != rhs.num_intervals())
+          return false;
+        auto rhsi = rhs.get_raw_data().begin();
+        auto rhs_end = rhs.get_raw_data().end();
+        for (auto i = begin(); rhsi != rhs_end; ++i, ++rhsi)
+          if (!item_equiv(*i, *rhsi))
+            return false;
+        return true;
+      }
+
+      template <class ISet>
+      bool operator!=(const ISet &rhs) const {
+        return !(*this == rhs);
+      }
+
+     /*
+      * NOTE: Callers, like swap and union_of methods, need to use templates
+      * in order to give this method access to the get_raw_data() method of
+      * the derived type. Due to covariance, the get_raw_data() method cannot
+      * be virtual.
+      */
+      template <class ISet>
+      interval_set& operator=(const ISet &rhs) {
+        clear();
+        iterator i = begin();
+        const auto rhs_end = rhs.get_raw_data().end();
+        for (auto rhsi = rhs.get_raw_data().begin(); rhsi != rhs_end; ++rhsi)
+          insert(i, *rhsi);
+        return *this;
+      }
+
+      template <class ISetA, class ISetB>
+      void intersection_of(const ISetA &a, const ISetB &b) {
+        assert(&a != this);
+        assert(&b != this);
+        clear();
+
+        const interval_set *s, *l;
+
+        if (a.size() < b.size()) {
+          s = reinterpret_cast<const interval_set*>(&a);
+          l = reinterpret_cast<const interval_set*>(&b);
+        } else {
+          s = reinterpret_cast<const interval_set*>(&b);
+          l = reinterpret_cast<const interval_set*>(&a);
+        }
+
+        if (!s->size())
+          return;
+
+        /*
+         * Use the lower_bound algorithm for larger size ratios
+         * where it performs better, but not for smaller size
+         * ratios where sequential search performs better.
+         */
+        if (l->size() / s->size() >= 10) {
+          /*
+           * Maximize performance by passing through derived types so
+           * that get_raw_data() can be used to access the underlying
+           * iterator types.
+           */
+          if (s == &a)
+            intersection_size_asym(*reinterpret_cast<const ISetA*>(s),
+                *reinterpret_cast<const ISetB*>(l));
+          else
+            intersection_size_asym(*reinterpret_cast<const ISetB*>(s),
+                *reinterpret_cast<const ISetA*>(l));
+          return;
+        }
+
+        auto pa = a.get_raw_data().begin();
+        auto pb = b.get_raw_data().begin();
+        const auto a_end = a.get_raw_data().end();
+        const auto b_end = b.get_raw_data().end();
+        iterator mi = begin();
+
+        while (pa != a_end && pb != b_end) {
+          // passing?
+          if (pa->first + pa->second <= pb->first)
+            { ++pa;  continue; }
+          if (pb->first + pb->second <= pa->first)
+            { ++pb;  continue; }
+
+          if (item_equiv(*pa, *pb)) {
+            do {
+              insert(mi, *pa);
+              ++pa;
+              ++pb;
+            } while (pa != a_end && pb != b_end && item_equiv(*pa, *pb));
+            continue;
+          }
+
+          T start = std::max<T>(pa->first, pb->first);
+          T en = std::min<T>(pa->first+pa->second, pb->first+pb->second);
+          assert(en > start);
+          insert(mi, {start, en - start});
+          if (pa->first+pa->second > pb->first+pb->second)
+            ++pb;
+          else
+            ++pa;
+        }
+      }
+
+    protected:
+      virtual void insert(iterator&, const value_type&) = 0;
+
+    private:
+
+      template <class ISetA, class ISetB>
+      void intersection_size_asym(const ISetA &s, const ISetB &l) {
+        auto ps = s.get_raw_data().begin();
+        const auto s_end = s.get_raw_data().end();
+        const auto l_end = l.get_raw_data().end();
+        auto pl = l.get_raw_data().begin();
+        assert(ps != s_end);
+        T offset = ps->first, prev_offset;
+        bool first = true;
+        iterator mi = begin();
+
+        while (1) {
+          if (first)
+            first = false;
+          else
+            assert(offset > prev_offset);
+          pl = l.find_inc(offset);
+          prev_offset = offset;
+          if (pl == l_end)
+            break;
+          while (ps != s_end && ps->first + ps->second <= pl->first)
+            ++ps;
+          if (ps == s_end)
+            break;
+          offset = pl->first + pl->second;
+          if (offset <= ps->first) {
+            offset = ps->first;
+            continue;
+          }
+
+          if (item_equiv(*ps, *pl)) {
+            do {
+              insert(mi, *ps);
+              ++ps;
+              ++pl;
+            } while (ps != s_end && pl != l_end && item_equiv(*ps, *pl));
+            if (ps == s_end)
+              break;
+            offset = ps->first;
+            continue;
+          }
+
+          T start = std::max<T>(ps->first, pl->first);
+          T en = std::min<T>(ps->first + ps->second, offset);
+          assert(en > start);
+          insert(mi, {start, en - start});
+          if (ps->first + ps->second <= offset) {
+            ++ps;
+            if (ps == s_end)
+              break;
+            offset = ps->first;
+          }
+        }
+      }
+  };
+
+
+  template<class T>
+  inline std::ostream& operator<<(std::ostream& out, const interval_set<T> &s) {
+    const auto s_end = s.end();
+    out << "[";
+    const char *prequel = "";
+    for (typename interval_set<T>::const_iterator i = s.begin();
+         i != s_end;
+         ++i)
+    {
+      out << prequel << i.get_start() << "~" << i.get_len();
+      prequel = ",";
+    }
+    out << "]";
+    return out;
+  }
+
+}
+
+#endif

--- a/src/include/array_interval_set.hpp
+++ b/src/include/array_interval_set.hpp
@@ -1,0 +1,455 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2004-2006 Sage Weil <sage@newdream.net>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+
+#ifndef CEPH_ARRAY_INTERVAL_SET_H
+#define CEPH_ARRAY_INTERVAL_SET_H
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "abs_interval_set.hpp"
+
+template<typename T>
+class array_interval_set: public abs_interval_set::interval_set<T> {
+ private:
+  typedef std::pair<T,T> map_value_t;
+  typedef std::vector<map_value_t> map_t;
+ public:
+  using typename abs_interval_set::interval_set<T>::value_type;
+  using typename abs_interval_set::interval_set<T>::iterator;
+  using typename abs_interval_set::interval_set<T>::const_iterator;
+  using abs_interval_set::interval_set<T>::operator==;
+  using abs_interval_set::interval_set<T>::intersection_of;
+
+  array_interval_set() : _size(0) {}
+
+  int num_intervals() const
+  {
+    return m.size();
+  }
+
+  typename array_interval_set<T>::iterator begin() {
+    return typename array_interval_set<T>::iterator(m.begin());
+  }
+
+  typename array_interval_set<T>::iterator lower_bound(T start) {
+    return typename array_interval_set<T>::iterator(find_inc_m(start));
+  }
+
+  typename array_interval_set<T>::iterator end() {
+    return typename array_interval_set<T>::iterator(m.end());
+  }
+
+  typename array_interval_set<T>::const_iterator begin() const {
+    return typename array_interval_set<T>::const_iterator(m.begin());
+  }
+
+  typename array_interval_set<T>::const_iterator lower_bound(T start) const {
+    return typename array_interval_set<T>::const_iterator(find_inc(start));
+  }
+
+  typename array_interval_set<T>::const_iterator end() const {
+    return typename array_interval_set<T>::const_iterator(m.end());
+  }
+
+  /*
+   * Allows template methods to access the underlying
+   * iterator type, for maximum performance.
+   */
+  const std::vector<map_value_t>& get_raw_data() const {
+    return m;
+  }
+
+ // base class calls protected helpers
+ friend class abs_interval_set::interval_set<T>;
+
+ // helpers
+ protected:
+  void insert(iterator &mi,
+        const typename abs_interval_set::interval_set<T>::value_type &value) {
+   /*
+    * An upper_bound call like the following would be redundant, since
+    * our intention is only to insert at the end position:
+    *
+    * auto pos = std::upper_bound(
+    *      *reinterpret_cast<const typename decltype(m)::iterator*>(
+    *      mi.get_impl()), m.end(), v);
+    */
+    auto pos = m.end();
+    _size += value.second;
+    typename decltype(m)::value_type v(value);
+    mi = m.insert(pos, std::move(v));
+  }
+
+  typename map_t::const_iterator find_inc(T start) const {
+    auto p = std::lower_bound<typename map_t::const_iterator,map_value_t>(
+        m.begin(), m.end(), {start, 0});  // p->first >= start
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might overlap?
+      if (p->first + p->second <= start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+ private:
+  typename map_t::iterator find_inc_m(T start) {
+    auto p = std::lower_bound<typename map_t::iterator,map_value_t>(
+        m.begin(), m.end(), {start, 0});
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might overlap?
+      if (p->first + p->second <= start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  typename map_t::const_iterator find_adj(T start) const {
+    auto p = std::lower_bound<typename map_t::const_iterator,map_value_t>(
+        m.begin(), m.end(), {start, 0});
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might touch?
+      if (p->first + p->second < start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+  typename map_t::iterator find_adj_m(T start) {
+    auto p = std::lower_bound<typename map_t::iterator,map_value_t>(
+        m.begin(), m.end(), {start, 0});
+    if (p != m.begin() &&
+        (p == m.end() || p->first > start)) {
+      --p;   // might touch?
+      if (p->first + p->second < start)
+        ++p; // it doesn't.
+    }
+    return p;
+  }
+
+ public:
+  bool operator==(const array_interval_set& other) const {
+    return _size == other._size && m == other.m;
+  }
+
+  int64_t size() const {
+    return _size;
+  }
+
+  void clear() {
+    m.clear();
+    _size = 0;
+  }
+
+  void reserve(size_t new_cap) {
+    m.reserve(new_cap);
+  }
+
+  template <class ISet>
+  typename abs_interval_set::interval_set<T>& operator=(const ISet &rhs) {
+    reserve(rhs.num_intervals());
+    return abs_interval_set::interval_set<T>::operator=(rhs);
+  }
+
+  bool contains(T i, T *pstart=0, T *plen=0) const {
+    typename map_t::const_iterator p = find_inc(i);
+    if (p == m.end()) return false;
+    if (p->first > i) return false;
+    if (p->first+p->second <= i) return false;
+    assert(p->first <= i && p->first+p->second > i);
+    if (pstart)
+      *pstart = p->first;
+    if (plen)
+      *plen = p->second;
+    return true;
+  }
+  bool contains(T start, T len) const {
+    typename map_t::const_iterator p = find_inc(start);
+    if (p == m.end()) return false;
+    if (p->first > start) return false;
+    if (p->first+p->second <= start) return false;
+    assert(p->first <= start && p->first+p->second > start);
+    if (p->first+p->second < start+len) return false;
+    return true;
+  }
+  bool intersects(T start, T len) const {
+    array_interval_set a;
+    a.insert(start, len);
+    array_interval_set i;
+    i.intersection_of( *this, a );
+    if (i.empty()) return false;
+    return true;
+  }
+
+  // outer range of set
+  bool empty() const {
+    return m.empty();
+  }
+  T range_start() const {
+    assert(!empty());
+    typename map_t::const_iterator p = m.begin();
+    return p->first;
+  }
+  T range_end() const {
+    assert(!empty());
+    typename map_t::const_iterator p = m.end();
+    --p;
+    return p->first+p->second;
+  }
+
+  // interval start after p (where p not in set)
+  bool starts_after(T i) const {
+    assert(!contains(i));
+    typename map_t::const_iterator p = find_inc(i);
+    if (p == m.end()) return false;
+    return true;
+  }
+  T start_after(T i) const {
+    assert(!contains(i));
+    typename map_t::const_iterator p = find_inc(i);
+    return p->first;
+  }
+
+  // interval end that contains start
+  T end_after(T start) const {
+    assert(contains(start));
+    typename map_t::const_iterator p = find_inc(start);
+    return p->first+p->second;
+  }
+
+  void insert(T val) {
+    insert(val, 1);
+  }
+
+  void insert(T start, T len, T *pstart=0, T *plen=0) {
+    //cout << "insert " << start << "~" << len << endl;
+    assert(len > 0);
+    map_value_t interval(start, len);
+    _size += len;
+    typename map_t::iterator p = find_adj_m(start);
+    if (p == m.end()) {
+      m.insert(p, interval); // new interval
+      if (pstart)
+	*pstart = start;
+      if (plen)
+	*plen = len;
+    } else {
+      if (p->first < start) {
+
+        if (p->first + p->second != start) {
+          //cout << "p is " << p->first << "~" << p->second << ", start is " << start << ", len is " << len << endl;
+          ceph_abort();
+        }
+
+        p->second += len;               // append to end
+
+        typename map_t::iterator n = p;
+        ++n;
+	if (pstart)
+	  *pstart = p->first;
+        if (n != m.end() &&
+            start+len == n->first) {   // combine with next, too!
+          p->second += n->second;
+	  if (plen)
+	    *plen = p->second;
+          m.erase(n);
+        } else {
+	  if (plen)
+	    *plen = p->second;
+	}
+      } else {
+        if (start+len == p->first) {
+	  if (pstart)
+	    *pstart = start;
+	  if (plen)
+	    *plen = len + p->second;
+          interval.second += p->second; // append to front
+          m[p-m.begin()] = interval;
+        } else {
+          assert(p->first > start+len);
+	  if (pstart)
+	    *pstart = start;
+	  if (plen)
+	    *plen = len;
+          m.insert(p, interval);        // new interval
+        }
+      }
+    }
+  }
+
+  template <class ISet>
+  void swap(ISet &other) {
+    array_interval_set temp;
+    swap(temp);
+    *this = other;
+    other = temp;
+  }
+
+  void swap(array_interval_set<T>& other) {
+    m.swap(other.m);
+    std::swap(_size, other._size);
+  }
+
+  void erase(iterator &i) {
+    _size -= i.get_len();
+    assert(_size >= 0);
+    m.erase(*reinterpret_cast<const typename decltype(m)::iterator*>(
+        i.get_impl()));
+  }
+
+  void erase(T val) {
+    erase(val, 1);
+  }
+
+  void erase(T start, T len) {
+    typename map_t::iterator p = find_inc_m(start);
+
+    _size -= len;
+    assert(_size >= 0);
+
+    assert(p != m.end());
+    assert(p->first <= start);
+
+    T before = start - p->first;
+    assert(p->second >= before+len);
+    T after = p->second - before - len;
+
+    if (before)
+      p->second = before;        // shorten bit before
+    else
+      m.erase(p);
+    if (after) {
+      _size -= after;
+      insert(start+len, after);
+    }
+  }
+
+
+  void subtract(const array_interval_set &a) {
+    for (typename map_t::const_iterator p = a.m.begin();
+         p != a.m.end();
+         ++p)
+      erase(p->first, p->second);
+  }
+
+  template<class ISet>
+  void subtract(const ISet &a) {
+    const auto a_end = a.get_raw_data().end();
+    for (auto p = a.get_raw_data().begin();
+         p != a_end;
+         ++p)
+      erase(p->first, p->second);
+  }
+
+  void insert(const array_interval_set &a) {
+    for (typename map_t::const_iterator p = a.m.begin();
+         p != a.m.end();
+         ++p)
+      insert(p->first, p->second);
+  }
+
+  template <class ISetA, class ISetB>
+  void intersection_of(const ISetA &a, const ISetB &b) {
+    reserve(std::max(a.num_intervals(), b.num_intervals()));
+    abs_interval_set::interval_set<T>::intersection_of(a, b);
+  }
+
+  template <class ISet>
+  void intersection_of(const ISet &b) {
+    array_interval_set a;
+    swap(a);
+    intersection_of(a, b);
+  }
+
+  template <class ISetA, class ISetB>
+  void union_of(const ISetA &a, const ISetB &b) {
+    assert(&a != this);
+    assert(&b != this);
+
+    // a
+    *this = a;
+
+    // - (a*b)
+    array_interval_set ab;
+    ab.intersection_of(a, b);
+    subtract(ab);
+
+    // + b
+    insert(b);
+    return;
+  }
+
+  template <class ISet>
+  void union_of(const ISet &b) {
+    array_interval_set a;
+    swap(a);
+    union_of(a, b);
+  }
+
+  template <class ISet>
+  bool subset_of(const ISet &big) const {
+    for (typename map_t::const_iterator i = m.begin();
+         i != m.end();
+         ++i)
+      if (!big.contains(i->first, i->second)) return false;
+    return true;
+  }
+
+  /*
+   * build a subset of @other, starting at or after @start, and including
+   * @len worth of values, skipping holes.  e.g.,
+   *  span_of([5~10,20~5], 8, 5) -> [8~2,20~3]
+   */
+  void span_of(const array_interval_set &other, T start, T len) {
+    clear();
+    typename map_t::const_iterator p = other.find_inc(start);
+    if (p == other.m.end())
+      return;
+    if (p->first < start) {
+      if (p->first + p->second < start)
+	return;
+      if (p->first + p->second < start + len) {
+	T howmuch = p->second - (start - p->first);
+	insert(start, howmuch);
+	len -= howmuch;
+	++p;
+      } else {
+	insert(start, len);
+	return;
+      }
+    }
+    while (p != other.m.end() && len > 0) {
+      if (p->second < len) {
+	insert(p->first, p->second);
+	len -= p->second;
+	++p;
+      } else {
+	insert(p->first, len);
+	return;
+      }
+    }
+  }
+
+private:
+  // data
+  int64_t _size;
+  map_t m;   // map start -> len
+};
+
+#endif

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -58,6 +58,7 @@
 
 #include "common/BackTrace.h"
 #include "common/EventTrace.h"
+#include "include/array_interval_set.hpp"
 
 #ifdef WITH_LTTNG
 #define TRACEPOINT_DEFINE
@@ -236,7 +237,12 @@ void PGPool::update(OSDMapRef map)
       (pi->get_snap_epoch() == map->get_epoch())) {
     updated = true;
     pi->build_removed_snaps(newly_removed_snaps);
-    interval_set<snapid_t> intersection;
+   /*
+    * Use array_interval_set for the intersection variable, since
+    * std::vector outperforms std::map for all operations that
+    * this variable is involved in.
+    */
+    array_interval_set<snapid_t> intersection;
     intersection.intersection_of(newly_removed_snaps, cached_removed_snaps);
     if (intersection == cached_removed_snaps) {
         cached_removed_snaps.swap(newly_removed_snaps);

--- a/src/test/common/test_interval_set.cc
+++ b/src/test/common/test_interval_set.cc
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include "include/interval_set.h"
 #include "include/btree_interval_set.h"
+#include "include/array_interval_set.hpp"
 
 using namespace ceph;
 
@@ -29,7 +30,9 @@ class IntervalSetTest : public ::testing::Test {
   typedef T ISet;
 };
 
-typedef ::testing::Types< interval_set<IntervalValueType> ,  btree_interval_set<IntervalValueType> > IntervalSetTypes;
+typedef ::testing::Types< interval_set<IntervalValueType>,
+                          btree_interval_set<IntervalValueType>,
+                          array_interval_set<IntervalValueType> > IntervalSetTypes;
 
 TYPED_TEST_CASE(IntervalSetTest, IntervalSetTypes);
 


### PR DESCRIPTION
Use array_interval_set (based on std::vector) to store intersection
results, since it performs better than interval_set (based on std::map)
for all operations that this variable is involved in.

The following benchmark program shows a 20% increase in performance:
```c++
#include <iostream>
#include <chrono>
#include "include/interval_set.h"
#include "include/array_interval_set.hpp"

#define NANOSECONDS(d) \
    std::chrono::duration_cast<std::chrono::nanoseconds>(d).count()

typedef uint64_t snapid_t;
typedef std::chrono::steady_clock::duration duration;

template<class IntersectionSet>
duration PGPool_update(const interval_set<snapid_t> &rs) {
  std::chrono::steady_clock::time_point start, end;
  interval_set<snapid_t> newly_removed_snaps, cached_removed_snaps;

  // initialize state
  cached_removed_snaps = rs;

  // start timed simulation
  start = std::chrono::steady_clock::now();

  {
    newly_removed_snaps = cached_removed_snaps;
    IntersectionSet intersection;
    intersection.intersection_of(newly_removed_snaps, cached_removed_snaps);

    assert(intersection == cached_removed_snaps);
    cached_removed_snaps.swap(newly_removed_snaps);
    newly_removed_snaps = cached_removed_snaps;
    newly_removed_snaps.subtract(intersection);
  }

  // end timed simulation
  end = std::chrono::steady_clock::now();

  return end - start;
}

int main(int argc, char *argv[])
{
  assert(argc == 3);
  const int sample_count = std::stoi(argv[1]);
  const int interval_count = std::stoi(argv[2]);
  const int interval_distance = 4;
  const int interval_size = 2;
  const int max_offset = interval_count * interval_distance;
  interval_set<snapid_t> removed_snaps;

  for (int i = 0; i < max_offset; i += interval_distance)
    removed_snaps.insert(i, interval_size);

  duration old_delta(0), new_delta(0);

  for (int i = 0; i < sample_count; ++i) {
    old_delta += PGPool_update<interval_set<snapid_t>>(removed_snaps);
    new_delta += PGPool_update<array_interval_set<snapid_t>>(removed_snaps);
  }

  float ratio = float(NANOSECONDS(new_delta)) / NANOSECONDS(old_delta);

  std::cout << ratio << std::endl;
}
```