### PR TITLE
osd: update info only if new_interval

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4441,23 +4441,23 @@ void OSD::build_initial_pg_history(
       &debug);
     if (new_interval) {
       h->same_interval_since = e;
-    }
-    if (up != new_up) {
-      h->same_up_since = e;
-    }
-    if (acting_primary != new_acting_primary) {
-      h->same_primary_since = e;
-    }
-    if (pgid.pgid.is_split(lastmap->get_pg_num(pgid.pgid.pool()),
-			   osdmap->get_pg_num(pgid.pgid.pool()),
-			   nullptr)) {
-      h->last_epoch_split = e;
+      if (up != new_up) {
+        h->same_up_since = e;
+      }
+      if (acting_primary != new_acting_primary) {
+        h->same_primary_since = e;
+      }
+      if (pgid.pgid.is_split(lastmap->get_pg_num(pgid.pgid.pool()),
+                             osdmap->get_pg_num(pgid.pgid.pool()),
+                             nullptr)) {
+        h->last_epoch_split = e;
+      }
+      up = new_up;
+      acting = new_acting;
+      up_primary = new_up_primary;
+      acting_primary = new_acting_primary;
     }
     lastmap = osdmap;
-    up_primary = new_up_primary;
-    acting_primary = new_acting_primary;
-    up = new_up;
-    acting = new_acting;
   }
   dout(20) << __func__ << " " << debug.str() << dendl;
   dout(10) << __func__ << " " << *h << " " << *pi


### PR DESCRIPTION
http://tracker.ceph.com/issues/21236

refactor OSD::build_initial_pg_history() so we update the info only if a
new interval is identified. also, this is consistent with
OSD::build_past_intervals_parallel().

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 4ae053439e526fab0451d1502576dce89eb6b44f)