### PR TITLE
tools/ceph_objectstore_tool: fix 'dup' unable to duplicate meta PG

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5968,10 +5968,8 @@ void PG::update_store_on_load()
     // legacy filestore didn't store collection bit width; fix.
     int bits = osd->store->collection_bits(coll);
     if (bits < 0) {
-      if (coll.is_meta())
-	bits = 0;
-      else
-	bits = info.pgid.get_split_bits(pool.info.get_pg_num());
+      assert(!coll.is_meta()); // otherwise OSD::load_pgs() did a bad thing
+      bits = info.pgid.get_split_bits(pool.info.get_pg_num());
       lderr(cct) << __func__ << " setting bit width to " << bits << dendl;
       ObjectStore::Transaction t;
       t.collection_set_bits(coll, bits);

--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -2286,9 +2286,13 @@ int dup(string srcpath, ObjectStore *src, string dstpath, ObjectStore *dst)
       ObjectStore::Transaction t;
       int bits = src->collection_bits(cid);
       if (bits < 0) {
-	cerr << "cannot get bit count for collection " << cid << ": "
-	     << cpp_strerror(bits) << std::endl;
-	goto out;
+        if (src->get_type() == "filestore" && cid.is_meta()) {
+          bits = 0;
+        } else {
+          cerr << "cannot get bit count for collection " << cid << ": "
+               << cpp_strerror(bits) << std::endl;
+          goto out;
+        }
       }
       t.create_collection(cid, bits);
       dst->apply_transaction(&osr, std::move(t));


### PR DESCRIPTION
Recently we plan to bring a Jewel cluster into Luminous.
After that is done, which turns out to be a big success,
we then try to transform all FileStore osds into BlueStore ones
offline but with no luck. The ceph_objectstore_tool keeps complaining:


--------------------------------------------------------------------
dup from filestore: /var/lib/ceph/osd/ceph-20.old
      to bluestore: /var/lib/ceph/osd/ceph-20
fsid d444b253-337d-4d15-9d63-86ae134ec9ac
65 collections
1/65 meta
cannot get bit count for collection meta: (61) No data available


--------------------------------------------------------------------

The root cause is that for FileStore Luminous will always try to rewrite
pg "bits" as a file attribute on "Load" if that is not available.
But since meta pg is never loaded (we skip it during OSD::load_pgs()),
we actually never get the chance to do so; hence making the
dup method from ceph_objectstore_tool very unhappy since it always
expects to see such a attribute from underlying store.

Fix the above problem by manually skipping loading the "bits" attribute
if underlying OS is FileStore for dup.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>

(cherry picked from commit af2c4847e42945a878e2864319185d795b0664a5)