### PR TITLE
jewel: core: kv: let ceph_logger destructed after db reset

### DIFF
--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -143,10 +143,10 @@ LevelDBStore::~LevelDBStore()
 {
   close();
   delete logger;
-  delete ceph_logger;
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
   db.reset();
+  delete ceph_logger;
 }
 
 void LevelDBStore::close()


### PR DESCRIPTION
backport tracker: http://tracker.ceph.com/issues/21358

if ceph_logger is deleted earlier than db, it may still be used by db, which cause a segment fault.

Fixes: http://tracker.ceph.com/issues/21336

Signed-off-by: wumingqiao <wumingqiao@inspur.com>
(cherry picked from commit a5cd03c643d6cb9074dfd2952cde83435de1b9dd)