### PR TITLE
RFC bluestore/testing: for test, do not accumulate Onode's to onode_map

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1556,7 +1556,7 @@ void BlueStore::OnodeSpace::clear()
   std::lock_guard<std::recursive_mutex> l(cache->lock);
   ldout(cache->cct, 10) << __func__ << dendl;
   for (auto &p : onode_map) {
-    //cache->_rm_onode(p.second);
+    cache->_rm_onode(p.second);
   }
   onode_map.clear();
 }
@@ -3186,6 +3186,13 @@ uint64_t BlueStore::Collection::make_blob_unshared(SharedBlob *sb)
   return sbid;
 }
 
+int getxxx(){
+  return atoi(getenv("N"));
+}
+
+int xxx=getxxx();
+
+
 BlueStore::OnodeRef BlueStore::Collection::get_onode(
   const ghobject_t& oid,
   bool create)
@@ -3240,7 +3247,8 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
     }
   }
   o.reset(on);
-  return o;//onode_map.add(oid, o);
+  if (onode_map.onode_map.size()>=xxx) return o;
+  return onode_map.add(oid, o);
 }
 
 void BlueStore::Collection::split_cache(

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -1520,7 +1520,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::add(const ghobject_t& oid, OnodeRef o
   }
   ldout(cache->cct, 30) << __func__ << " " << oid << " " << o << dendl;
   onode_map[oid] = o;
-  cache->_add_onode(o, 1);
+  //cache->_add_onode(o, 1);
   return o;
 }
 
@@ -1529,7 +1529,6 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
   ldout(cache->cct, 30) << __func__ << dendl;
   OnodeRef o;
   bool hit = false;
-
   {
     std::lock_guard<std::recursive_mutex> l(cache->lock);
     ceph::unordered_map<ghobject_t,OnodeRef>::iterator p = onode_map.find(oid);
@@ -1538,7 +1537,7 @@ BlueStore::OnodeRef BlueStore::OnodeSpace::lookup(const ghobject_t& oid)
     } else {
       ldout(cache->cct, 30) << __func__ << " " << oid << " hit " << p->second
 			    << dendl;
-      cache->_touch_onode(p->second);
+      //cache->_touch_onode(p->second);
       hit = true;
       o = p->second;
     }
@@ -1557,7 +1556,7 @@ void BlueStore::OnodeSpace::clear()
   std::lock_guard<std::recursive_mutex> l(cache->lock);
   ldout(cache->cct, 10) << __func__ << dendl;
   for (auto &p : onode_map) {
-    cache->_rm_onode(p.second);
+    //cache->_rm_onode(p.second);
   }
   onode_map.clear();
 }
@@ -1586,7 +1585,7 @@ void BlueStore::OnodeSpace::rename(
   if (pn != onode_map.end()) {
     ldout(cache->cct, 30) << __func__ << "  removing target " << pn->second
 			  << dendl;
-    cache->_rm_onode(pn->second);
+    //cache->_rm_onode(pn->second);
     onode_map.erase(pn);
   }
   OnodeRef o = po->second;
@@ -1594,11 +1593,11 @@ void BlueStore::OnodeSpace::rename(
   // install a non-existent onode at old location
   oldo.reset(new Onode(o->c, old_oid, o->key));
   po->second = oldo;
-  cache->_add_onode(po->second, 1);
+  //cache->_add_onode(po->second, 1);
 
   // add at new position and fix oid, key
   onode_map.insert(make_pair(new_oid, o));
-  cache->_touch_onode(o);
+  //cache->_touch_onode(o);
   o->oid = new_oid;
   o->key = new_okey;
 }
@@ -3201,7 +3200,6 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
       ceph_abort();
     }
   }
-
   OnodeRef o = onode_map.lookup(oid);
   if (o)
     return o;
@@ -3242,7 +3240,7 @@ BlueStore::OnodeRef BlueStore::Collection::get_onode(
     }
   }
   o.reset(on);
-  return onode_map.add(oid, o);
+  return o;//onode_map.add(oid, o);
 }
 
 void BlueStore::Collection::split_cache(
@@ -11475,8 +11473,8 @@ void BlueStore::_flush_cache()
     assert(i->empty());
   }
   for (auto& p : coll_map) {
-    assert(p.second->onode_map.empty());
-    assert(p.second->shared_blob_set.empty());
+    //assert(p.second->onode_map.empty());
+    //assert(p.second->shared_blob_set.empty());
   }
   coll_map.clear();
 }

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1031,8 +1031,22 @@ public:
       ++nref;
     }
     void put() {
-      if (--nref == 0)
-	delete this;
+      if (--nref == 0) {
+ 	delete this;
+ 	return;
+      }
+      if (nref == 1)
+        {
+          std::lock_guard<std::recursive_mutex> l(c->cache->lock);
+          if(nref == 1) {
+            if (c->onode_map.onode_map.count(this->oid)>0 )
+            {
+              c->cache->_rm_onode(this);
+              c->onode_map.remove(this->oid);
+            }
+          }
+        }
+
     }
   };
   typedef boost::intrusive_ptr<Onode> OnodeRef;
@@ -1054,6 +1068,7 @@ public:
 
     virtual void _add_onode(OnodeRef& o, int level) = 0;
     virtual void _rm_onode(OnodeRef& o) = 0;
+    virtual void _rm_onode(Onode* o) = 0;
     virtual void _touch_onode(OnodeRef& o) = 0;
 
     virtual void _add_buffer(Buffer *b, int level, Buffer *near) = 0;
@@ -1141,6 +1156,11 @@ public:
       auto q = onode_lru.iterator_to(*o);
       onode_lru.erase(q);
     }
+    void _rm_onode(Onode* o) override {
+          auto q = onode_lru.iterator_to(*o);
+          if (q != onode_lru.end())
+          onode_lru.erase(q);
+        }
     void _touch_onode(OnodeRef& o) override;
 
     uint64_t _get_buffer_bytes() override {
@@ -1243,9 +1263,18 @@ public:
 	onode_lru.push_back(*o);
     }
     void _rm_onode(OnodeRef& o) override {
+      if(o->lru_item.is_linked()) {
       auto q = onode_lru.iterator_to(*o);
       onode_lru.erase(q);
+      }
     }
+    void _rm_onode(Onode* o) override {
+
+        if(o->lru_item.is_linked()) {
+          auto q = onode_lru.iterator_to(*o);
+          onode_lru.erase(q);
+        }
+        }
     void _touch_onode(OnodeRef& o) override;
 
     uint64_t _get_buffer_bytes() override {
@@ -1297,8 +1326,9 @@ public:
     Cache *cache;
 
     /// forward lookups
+  public:
     mempool::bluestore_cache_other::unordered_map<ghobject_t,OnodeRef> onode_map;
-
+  private:
     friend class Collection; // for split_cache()
 
   public:


### PR DESCRIPTION
It seems that having multitude active elements in Collection.onode_map causes significant performance drop. In this patch, onode_map never gets any elements. Cache is not filled.
For read operations this makes huge drop in performance (8x).
For write operations when multiple objects are in collection, there is huge boost (2x).

I would like to start a discussion if keeping onode_map minimal & keeping cached data attached to something else (extents?) is possible.

Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>