### PR TITLE
rgw: return 'Access-Control-Allow-Origin' header when the set bucket versioning through XMLHttpRequest

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -962,7 +962,7 @@ void RGWSetBucketVersioning_ObjStore_S3::send_response()
   if (op_ret)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s);
+  end_header(s, this, "application/xml");
 }
 
 int RGWSetBucketWebsite_ObjStore_S3::get_params()


### PR DESCRIPTION
hi,
  when i use the javascript sdk [aws-sdk-js](https://github.com/aws/aws-sdk-js) to set bucket versioning,and this is my test html
enablebucketversion-master.html
```
<!DOCTYPE html>
<html>
  <head>
    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.100.0.min.js"></script>
  </head>
  <body>
    <h1>App</h1>
    <div id="app"></div>
    </div>
<div id="status"></div>
<ul id="objects"></ul>
  </body>
<script type="text/javascript">
var s3 = new AWS.S3({
    apiVersion: '2006-03-01',
    accessKeyId: "website",
    secretAccessKey: "website",
    endpoint: "192.168.153.165:8000",
    s3ForcePathStyle: true,
    sslEnabled: false,
    signatureVersion: 'v2'
});
var params = {
Bucket: "website01",
VersioningConfiguration: {
    Status: "Enabled"
  }
};
s3.putBucketVersioning(params, function(err, data) {
if (err) {
      document.getElementById('status').innerHTML =
        'error';
    } else {
      document.getElementById('status').innerHTML =
        'ok';
      document.getElementById('objects').innerHTML +=
          data;
      console.log(data);
    }
});
</script>
</html>
```
and i get the error
```
XMLHttpRequest cannot load http://192.168.153.165:8000/website01?versioning. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://192.168.153.165' is therefore not allowed access.
```

and then i sent a request though python script which set  Origin and Referer in header
```
[root@k1 ~]# python cors-version-put.py
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 192.168.153.165
DEBUG:requests.packages.urllib3.connectionpool:"PUT /website01/?versioning HTTP/1.1" 200 0
< PUT /website01/?versioning HTTP/1.1
< Host: 192.168.153.165:8000
< Connection: keep-alive
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.11.1
< Origin: http://192.168.153.165
< DNT: 1
< Referer: http://192.168.153.165/getobject-master.html
< Content-Length: 123
< date: Mon, 11 Sep 2017 07:36:03 GMT
< Authorization: AWS website:xrvd9ndE1HqpgFCzR60K7izTX3o=
<
< <VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Status>Enabled</Status></VersioningConfiguration>
> HTTP/1.1 200 OK
> x-amz-request-id: tx000000000000000000001-0059b63ce3-1016-default
> Content-Length: 0
> Date: Mon, 11 Sep 2017 07:36:03 GMT
> Connection: Keep-Alive
>
```
the response did not contain the `Access-Control-Allow-Origin` which cause the aws-sdk-js error, but the same code work in amazon s3, so we need to add  Access-Control-Allow-Origin header in response for bucket versioning setting.




   


Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>