### PR TITLE
rgw: return 'Access-Control-Allow-Origin' header when the set and delete bucket website through XMLHttpRequest

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1014,7 +1014,7 @@ void RGWSetBucketWebsite_ObjStore_S3::send_response()
   if (op_ret < 0)
     set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s);
+  end_header(s, this, "application/xml");
 }
 
 void RGWDeleteBucketWebsite_ObjStore_S3::send_response()
@@ -1024,7 +1024,7 @@ void RGWDeleteBucketWebsite_ObjStore_S3::send_response()
   }
   set_req_state_err(s, op_ret);
   dump_errno(s);
-  end_header(s);
+  end_header(s, this, "application/xml");
 }
 
 void RGWGetBucketWebsite_ObjStore_S3::send_response()


### PR DESCRIPTION
hi,
when i use the javascript sdk aws-sdk-js to set bucket website,and this is my test html
setwebsite-master.html
```
[root@dev html]# cat setwebsite-master.html
<!DOCTYPE html>
<html>
  <head>
    <script src="https://sdk.amazonaws.com/js/aws-sdk-2.100.0.min.js"></script>
  </head>
  <body>
    <h1>App</h1>
    <div id="app"></div>
    </div>
<div id="status"></div>
<ul id="result"></ul>
  </body>
<script type="text/javascript">
var s3 = new AWS.S3({
    apiVersion: '2006-03-01',
    accessKeyId: "website",
    secretAccessKey: "website",
    endpoint: "192.168.153.165:8000",
    s3ForcePathStyle: true,
    sslEnabled: false,
    signatureVersion: 'v2'
});
var params = {
Bucket: "website01",
 WebsiteConfiguration: {
   ErrorDocument: {
    Key: "error.html"
   },
   IndexDocument: {
    Suffix: "index.html"
   }
  }
};
s3.putBucketWebsite(params, function(err, data) {
if (err) {
      document.getElementById('status').innerHTML =
        'error';
    } else {
      document.getElementById('status').innerHTML =
        'ok';
      console.log(data);
    }
});
</script>
</html>
```
and i get error 
```
XMLHttpRequest cannot load http://192.168.153.165:8000/website01?website. No 'Access-Control-Allow-Origin' header is present on the requested resource. Origin 'http://192.168.153.165' is therefore not allowed access.
```

the response did not contain the Access-Control-Allow-Origin which cause the aws-sdk-js error, but the same code work in amazon s3, so we need to add Access-Control-Allow-Origin header in response for bucket website setting.

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>