### PR TITLE
luminous: mon/OSDMonitor: deleting pool while pgs are being created leads to assert(p != pools.end) in update_creating_pgs()

### DIFF
--- a/src/mon/CreatingPGs.h
+++ b/src/mon/CreatingPGs.h
@@ -60,6 +60,7 @@ struct creating_pgs_t {
     auto last = pgs.lower_bound(pg_t{0, (uint64_t)removed_pool + 1});
     pgs.erase(first, last);
     created_pools.erase(removed_pool);
+    queue.erase(removed_pool);
     return total - pgs.size();
   }
   void encode(bufferlist& bl) const {

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5867,7 +5867,7 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
       *ss << "crush test failed with " << r << ": " << err.str();
       return r;
     }
-    dout(10) << __func__ << " crush somke test duration: "
+    dout(10) << __func__ << " crush smoke test duration: "
              << duration << dendl;
   }
   unsigned size, min_size;


### PR DESCRIPTION
http://tracker.ceph.com/issues/21341