### PR TITLE
mgr: tell injectargs command support

### DIFF
--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -1224,6 +1224,22 @@ bool DaemonServer::handle_command(MCommand *m)
     ss << std::endl;
     cmdctx->reply(r, ss);
     return true;
+  } else if (prefix == "injectargs") {
+    vector<string> argsvec;
+    cmd_getval(g_ceph_context, cmdctx->cmdmap, "injected_args", argsvec);
+
+    if (argsvec.empty()) {
+      r = -EINVAL;
+      ss << "ignoring empty injectargs";
+      cmdctx->reply(r, ss);
+      return true;
+    }
+    string args = argsvec.front();
+    for (auto it = ++argsvec.begin(); it != argsvec.end(); ++it)
+      args += " " + *it;
+    r = g_ceph_context->_conf->injectargs(args, &ss);
+    cmdctx->reply(r, ss);
+    return true;
   } else {
     r = cluster_state.with_pgmap([&](const PGMap& pg_map) {
 	return cluster_state.with_osdmap([&](const OSDMap& osdmap) {

--- a/src/mgr/MgrCommands.h
+++ b/src/mgr/MgrCommands.h
@@ -127,6 +127,12 @@ COMMAND("osd repair " \
 	"initiate repair on osd <who>, or use <all|any|*> to repair all", \
         "osd", "rw", "cli,rest")
 
+COMMAND("injectargs " \
+	"name=injected_args,type=CephString,n=N",
+	"inject configuration arguments into running MGR",
+	"mgr", "rw", "cli,rest")
+
+
 COMMAND("service dump",
         "dump service map", "service", "r", "cli,rest")
 COMMAND("service status",


### PR DESCRIPTION
add this to support injectargs command, so that we can live update log level for debuging.
```
~# ceph tell mgr injectargs --debug_mgr 20
```


Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>