### PR TITLE
messages: Initialization of variable beat

### DIFF
--- a/src/messages/MHeartbeat.h
+++ b/src/messages/MHeartbeat.h
@@ -21,7 +21,7 @@
 
 class MHeartbeat : public Message {
   mds_load_t load;
-  __s32        beat;
+  __s32        beat = 0;
   map<mds_rank_t, float> import_map;
 
  public:


### PR DESCRIPTION
Fixes the coverity issue:

** 717278 Uninitialized scalar field
>CID 717278 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member beat is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>