### PR TITLE
dmclock: silence warning from -Wmaybe-uninitialized

### DIFF
--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -940,7 +940,7 @@ namespace crimson {
 
       // data_mtx should be held when called
       NextReq do_next_request(Time now) {
-	NextReq result;
+	NextReq result{};
 
 	// if reservation queue is empty, all are empty (i.e., no active clients)
 	if(resv_heap.empty()) {


### PR DESCRIPTION
The following warning appears during build using gcc (GCC) 7.1.1.

```
ceph/src/dmclock/src/dmclock_server.h:948:11: warning: ‘*((void*)& result +8)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    return result;
           ^~~~~~
ceph/src/dmclock/src/dmclock_server.h:1024:11: warning: ‘*((void*)& result +8)’ may be used uninitialized in this function [-Wmaybe-uninitialized]
    return result;
           ^~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>