### PR TITLE
bluestore/KernelDevice: add perf counters.

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -67,13 +67,13 @@ int KernelDevice::open(const string& p)
   fd_direct = ::open(path.c_str(), O_RDWR | O_DIRECT);
   if (fd_direct < 0) {
     r = -errno;
-    derr << __func__ << " open got: " << cpp_strerror(r) << dendl;
+    derr << __func__ << " got: " << cpp_strerror(r) << dendl;
     return r;
   }
   fd_buffered = ::open(path.c_str(), O_RDWR);
   if (fd_buffered < 0) {
     r = -errno;
-    derr << __func__ << " open got: " << cpp_strerror(r) << dendl;
+    derr << __func__ << " got: " << cpp_strerror(r) << dendl;
     goto out_direct;
   }
   dio = true;
@@ -87,7 +87,7 @@ int KernelDevice::open(const string& p)
   r = posix_fadvise(fd_buffered, 0, 0, POSIX_FADV_RANDOM);
   if (r) {
     r = -r;
-    derr << __func__ << " open got: " << cpp_strerror(r) << dendl;
+    derr << __func__ << " got: " << cpp_strerror(r) << dendl;
     goto out_fail;
   }
 

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -38,6 +38,8 @@ class KernelDevice : public BlockDevice {
   aio_queue_t aio_queue;
   bool aio_stop;
 
+  PerfCounters *logger = nullptr;
+
   struct AioCompletionThread : public Thread {
     KernelDevice *bdev;
     explicit AioCompletionThread(KernelDevice *b) : bdev(b) {}
@@ -72,6 +74,7 @@ class KernelDevice : public BlockDevice {
 
 public:
   KernelDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
+  ~KernelDevice();
 
   void aio_submit(IOContext *ioc) override;
 

--- a/src/os/bluestore/PMEMDevice.cc
+++ b/src/os/bluestore/PMEMDevice.cc
@@ -64,7 +64,7 @@ int PMEMDevice::open(const string& p)
   fd = ::open(path.c_str(), O_RDWR);
   if (fd < 0) {
     r = -errno;
-    derr << __func__ << " open got: " << cpp_strerror(r) << dendl;
+    derr << __func__ << " got: " << cpp_strerror(r) << dendl;
     return r;
   }
 


### PR DESCRIPTION
We are working on improve the performance of NVMEDevice by using perf counters, and want to compare with KernelDevice, but find KernelDevice doesn't have perfcounters until now.

Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>
Signed-off-by: Ziye Yang <optimistyzy@gmail.com>