### PR TITLE
client: use unsigned trim_caps count

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4064,14 +4064,14 @@ void Client::_invalidate_kernel_dcache()
   }
 }
 
-void Client::trim_caps(MetaSession *s, int max)
+void Client::trim_caps(MetaSession *s, uint64_t max)
 {
   mds_rank_t mds = s->mds_num;
-  int caps_size = s->caps.size();
+  uint64_t caps_size = s->caps.size();
   ldout(cct, 10) << "trim_caps mds." << mds << " max " << max 
     << " caps " << caps_size << dendl;
 
-  int trimmed = 0;
+  uint64_t trimmed = 0;
   xlist<Cap*>::iterator p = s->caps.begin();
   while ((caps_size - trimmed) > max && !p.end()) {
     Cap *cap = *p;

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -534,7 +534,7 @@ protected:
   void trim_cache(bool trim_kernel_dcache=false);
   void trim_cache_for_reconnect(MetaSession *s);
   void trim_dentry(Dentry *dn);
-  void trim_caps(MetaSession *s, int max);
+  void trim_caps(MetaSession *s, uint64_t max);
   void _invalidate_kernel_dcache();
   
   void dump_inode(Formatter *f, Inode *in, set<Inode*>& did, bool disconnected);


### PR DESCRIPTION
Resolves gcc warning:

    /home/pdonnell/ceph/src/client/Client.cc: In member function ‘void Client::trim_caps(MetaSession*, int)’:
    /home/pdonnell/ceph/src/client/Client.cc:4120:22: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (s->caps.size() > max)
                          ^

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>