### PR TITLE
rbd-mirror: Make the data-pool used for mirrored images configurable

### DIFF
--- a/doc/rbd/rbd-mirroring.rst
+++ b/doc/rbd/rbd-mirroring.rst
@@ -36,13 +36,6 @@ Ceph clusters.
    configuration file of the same name (e.g. /etc/ceph/remote.conf).  See the
    `ceph-conf`_ documentation for how to configure multiple clusters.
 
-.. note:: Images in a given pool will be mirrored to a pool with the same name
-   on the remote cluster. Images using a separate data-pool will use a data-pool
-   with the same name on the remote cluster. E.g., if an image being mirrored is
-   in the ``rbd`` pool on the local cluster and using a data-pool called
-   ``rbd-ec``, pools called ``rbd`` and ``rbd-ec`` must exist on the remote
-   cluster and will be used for mirroring the image.
-
 Enable Mirroring
 ----------------
 
@@ -62,6 +55,21 @@ For example::
 
         rbd --cluster local mirror pool enable image-pool pool
         rbd --cluster remote mirror pool enable image-pool pool
+
+By default images using a separate data-pool will use a data-pool with the same
+name when they are mirrored, and that pool must exist. You can control the
+data-pool used by images being mirrored into a given pool by specifying the
+``--data-pool`` option when enabling mirroring.
+
+For example, to have images mirrored into ``image-pool`` use a data-pool called
+``data-pool``::
+
+        rbd --cluster local mirror pool enable --data-pool data-pool image-pool pool
+
+Alternatively, to force images mirrored into ``image-pool`` to have their data
+in ``image-pool``, regardless of the data pool they use on the remote cluster::
+
+        rbd --cluster local mirror pool enable --data-pool image-pool image-pool pool
 
 Disable Mirroring
 -----------------

--- a/src/cls/rbd/cls_rbd_client.h
+++ b/src/cls/rbd/cls_rbd_client.h
@@ -285,11 +285,14 @@ namespace librbd {
     int mirror_uuid_set(librados::IoCtx *ioctx, const std::string &uuid);
     void mirror_mode_get_start(librados::ObjectReadOperation *op);
     int mirror_mode_get_finish(bufferlist::iterator *it,
-			       cls::rbd::MirrorMode *mirror_mode);
+			       cls::rbd::MirrorMode *mirror_mode,
+			       std::string *data_pool_name = nullptr);
     int mirror_mode_get(librados::IoCtx *ioctx,
-                        cls::rbd::MirrorMode *mirror_mode);
+                        cls::rbd::MirrorMode *mirror_mode,
+			std::string *data_pool_name = nullptr);
     int mirror_mode_set(librados::IoCtx *ioctx,
-                        cls::rbd::MirrorMode mirror_mode);
+                        cls::rbd::MirrorMode mirror_mode,
+			const std::string &data_pool_name);
     int mirror_peer_list(librados::IoCtx *ioctx,
                          std::vector<cls::rbd::MirrorPeer> *peers);
     int mirror_peer_add(librados::IoCtx *ioctx, const std::string &uuid,

--- a/src/include/rbd/librbd.h
+++ b/src/include/rbd/librbd.h
@@ -279,8 +279,14 @@ CEPH_RBD_API int rbd_trash_restore(rados_ioctx_t io, const char *id,
 /* pool mirroring */
 CEPH_RBD_API int rbd_mirror_mode_get(rados_ioctx_t io_ctx,
                                      rbd_mirror_mode_t *mirror_mode);
+CEPH_RBD_API int rbd_mirror_mode_get2(rados_ioctx_t io_ctx,
+				      rbd_mirror_mode_t *mirror_mode,
+				      char *data_pool_name, size_t poolnamelen);
 CEPH_RBD_API int rbd_mirror_mode_set(rados_ioctx_t io_ctx,
                                      rbd_mirror_mode_t mirror_mode);
+CEPH_RBD_API int rbd_mirror_mode_set2(rados_ioctx_t io_ctx,
+				      rbd_mirror_mode_t mirror_mode,
+				      const char *data_pool_name);
 CEPH_RBD_API int rbd_mirror_peer_add(rados_ioctx_t io_ctx,
                                      char *uuid, size_t uuid_max_length,
                                      const char *cluster_name,

--- a/src/include/rbd/librbd.hpp
+++ b/src/include/rbd/librbd.hpp
@@ -169,8 +169,10 @@ public:
   int trash_restore(IoCtx &io_ctx, const char *id, const char *name);
 
   // RBD pool mirroring support functions
-  int mirror_mode_get(IoCtx& io_ctx, rbd_mirror_mode_t *mirror_mode);
-  int mirror_mode_set(IoCtx& io_ctx, rbd_mirror_mode_t mirror_mode);
+  int mirror_mode_get(IoCtx& io_ctx, rbd_mirror_mode_t *mirror_mode,
+		      std::string *data_pool_name = nullptr);
+  int mirror_mode_set(IoCtx& io_ctx, rbd_mirror_mode_t mirror_mode,
+		      const std::string &data_pool_name = "");
   int mirror_peer_add(IoCtx& io_ctx, std::string *uuid,
                       const std::string &cluster_name,
                       const std::string &client_name);

--- a/src/librbd/api/Mirror.h
+++ b/src/librbd/api/Mirror.h
@@ -22,8 +22,10 @@ struct Mirror {
   typedef std::map<std::string, mirror_image_status_t> IdToMirrorImageStatus;
   typedef std::map<mirror_image_status_state_t, int> MirrorImageStatusStates;
 
-  static int mode_get(librados::IoCtx& io_ctx, rbd_mirror_mode_t *mirror_mode);
-  static int mode_set(librados::IoCtx& io_ctx, rbd_mirror_mode_t mirror_mode);
+  static int mode_get(librados::IoCtx& io_ctx, rbd_mirror_mode_t *mirror_mode,
+		      std::string *data_pool_name = nullptr);
+  static int mode_set(librados::IoCtx& io_ctx, rbd_mirror_mode_t mirror_mode,
+		      const std::string &data_pool_name = "");
 
   static int peer_add(librados::IoCtx& io_ctx, std::string *uuid,
                       const std::string &cluster_name,

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -1034,7 +1034,7 @@ Skip test on FreeBSD as it generates different output there.
     -p [ --pool ] arg    pool name
   
   rbd help mirror pool enable
-  usage: rbd mirror pool enable [--pool <pool>] 
+  usage: rbd mirror pool enable [--pool <pool>] [--data-pool <data-pool>] 
                                 <pool-name> <mode> 
   
   Enable RBD mirroring by default within a pool.
@@ -1045,6 +1045,7 @@ Skip test on FreeBSD as it generates different output there.
   
   Optional arguments
     -p [ --pool ] arg    pool name
+    --data-pool arg      data pool name
   
   rbd help mirror pool info
   usage: rbd mirror pool info [--pool <pool>] [--format <format>] 

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1524,24 +1524,27 @@ TEST_F(TestClsRbd, mirror) {
   ASSERT_EQ(-EINVAL, mirror_peer_add(&ioctx, "uuid1", "cluster1", "client"));
 
   cls::rbd::MirrorMode mirror_mode;
-  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
+  std::string local_data_pool_name;
+  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode, &local_data_pool_name));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_DISABLED, mirror_mode);
 
-  ASSERT_EQ(-EINVAL, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE));
+  ASSERT_EQ(-EINVAL, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE, ""));
   ASSERT_EQ(-EINVAL, mirror_uuid_set(&ioctx, ""));
   ASSERT_EQ(0, mirror_uuid_set(&ioctx, "mirror-uuid"));
   ASSERT_EQ(0, mirror_uuid_get(&ioctx, &uuid));
   ASSERT_EQ("mirror-uuid", uuid);
 
-  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE));
-  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
+  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_IMAGE, "data-pool"));
+  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode, &local_data_pool_name));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_IMAGE, mirror_mode);
+  ASSERT_EQ("data-pool", local_data_pool_name);
 
   ASSERT_EQ(-EINVAL, mirror_uuid_set(&ioctx, "new-mirror-uuid"));
 
-  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_POOL));
-  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
+  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_POOL, "data-pool"));
+  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode, &local_data_pool_name));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_POOL, mirror_mode);
+  ASSERT_EQ("data-pool", local_data_pool_name);
 
   ASSERT_EQ(-EINVAL, mirror_peer_add(&ioctx, "mirror-uuid", "cluster1", "client"));
   ASSERT_EQ(0, mirror_peer_add(&ioctx, "uuid1", "cluster1", "client"));
@@ -1576,7 +1579,7 @@ TEST_F(TestClsRbd, mirror) {
     {"uuid1", "cluster1", "new client", -1},
     {"uuid3", "new cluster", "admin", 123}};
   ASSERT_EQ(expected_peers, peers);
-  ASSERT_EQ(-EBUSY, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED));
+  ASSERT_EQ(-EBUSY, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED, ""));
 
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid3"));
   ASSERT_EQ(0, mirror_peer_remove(&ioctx, "uuid1"));
@@ -1584,8 +1587,8 @@ TEST_F(TestClsRbd, mirror) {
   expected_peers = {};
   ASSERT_EQ(expected_peers, peers);
 
-  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED));
-  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode));
+  ASSERT_EQ(0, mirror_mode_set(&ioctx, cls::rbd::MIRROR_MODE_DISABLED, ""));
+  ASSERT_EQ(0, mirror_mode_get(&ioctx, &mirror_mode, &local_data_pool_name));
   ASSERT_EQ(cls::rbd::MIRROR_MODE_DISABLED, mirror_mode);
   ASSERT_EQ(-ENOENT, mirror_uuid_get(&ioctx, &uuid));
 }

--- a/src/test/librbd/operation/test_mock_DisableFeaturesRequest.cc
+++ b/src/test/librbd/operation/test_mock_DisableFeaturesRequest.cc
@@ -179,12 +179,12 @@ public:
     PoolMirrorModeEnabler(librados::IoCtx &ioctx) : m_ioctx(ioctx) {
       EXPECT_EQ(0, librbd::cls_client::mirror_uuid_set(&m_ioctx, "test-uuid"));
       EXPECT_EQ(0, librbd::cls_client::mirror_mode_set(
-		  &m_ioctx, cls::rbd::MIRROR_MODE_POOL));
+		  &m_ioctx, cls::rbd::MIRROR_MODE_POOL, "test-data-pool-name"));
     }
 
     ~PoolMirrorModeEnabler() {
       EXPECT_EQ(0, librbd::cls_client::mirror_mode_set(
-		&m_ioctx, cls::rbd::MIRROR_MODE_DISABLED));
+		  &m_ioctx, cls::rbd::MIRROR_MODE_DISABLED, ""));
     }
   private:
     librados::IoCtx &m_ioctx;

--- a/src/test/librbd/operation/test_mock_EnableFeaturesRequest.cc
+++ b/src/test/librbd/operation/test_mock_EnableFeaturesRequest.cc
@@ -174,12 +174,12 @@ public:
     PoolMirrorModeEnabler(librados::IoCtx &ioctx) : m_ioctx(ioctx) {
       EXPECT_EQ(0, librbd::cls_client::mirror_uuid_set(&m_ioctx, "test-uuid"));
       EXPECT_EQ(0, librbd::cls_client::mirror_mode_set(
-                  &m_ioctx, cls::rbd::MIRROR_MODE_POOL));
+                  &m_ioctx, cls::rbd::MIRROR_MODE_POOL, "data-pool-name"));
     }
 
     ~PoolMirrorModeEnabler() {
       EXPECT_EQ(0, librbd::cls_client::mirror_mode_set(
-                &m_ioctx, cls::rbd::MIRROR_MODE_DISABLED));
+		  &m_ioctx, cls::rbd::MIRROR_MODE_DISABLED, ""));
     }
   private:
     librados::IoCtx &m_ioctx;

--- a/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_BootstrapRequest.cc
@@ -135,6 +135,7 @@ struct CreateImageRequest<librbd::MockTestImageCtx> {
                                     const std::string &local_image_name,
 				    const std::string &local_image_id,
                                     librbd::MockTestImageCtx *remote_image_ctx,
+				    const std::string &local_data_pool_name,
                                     Context *on_finish) {
     assert(s_instance != nullptr);
     s_instance->on_finish = on_finish;
@@ -448,6 +449,7 @@ public:
                                        const std::string &global_image_id,
                                        const std::string &local_mirror_uuid,
                                        const std::string &remote_mirror_uuid,
+				       const std::string &local_data_pool_name,
                                        Context *on_finish) {
     return new MockBootstrapRequest(m_local_io_ctx,
                                     m_remote_io_ctx,
@@ -463,7 +465,8 @@ public:
                                     remote_mirror_uuid,
                                     &mock_journaler,
                                     &m_mirror_peer_client_meta,
-                                    on_finish, &m_do_resync);
+                                    on_finish, &m_do_resync,
+				    local_data_pool_name);
   }
 
   librbd::ImageCtx *m_remote_image_ctx;
@@ -523,7 +526,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, NonPrimaryRemoteSyncingState) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-EREMOTEIO, ctx.wait());
 }
@@ -599,7 +602,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, RemoteDemotePromote) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -685,7 +688,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, MultipleRemoteDemotePromotes) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -759,7 +762,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, LocalDemoteRemotePromote) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -832,7 +835,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, SplitBrainForcePromote) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-EEXIST, ctx.wait());
   ASSERT_EQ(NULL, m_local_test_image_ctx);
@@ -893,7 +896,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, ResyncRequested) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, mock_local_image_ctx.id,
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   m_do_resync = false;
   request->send();
   ASSERT_EQ(0, ctx.wait());
@@ -970,7 +973,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemote) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, "",
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -1058,7 +1061,7 @@ TEST_F(TestMockImageReplayerBootstrapRequest, PrimaryRemoteLocalDeleted) {
   MockBootstrapRequest *request = create_request(
     &mock_instance_watcher, mock_journaler, "",
     mock_remote_image_ctx.id, "global image id", "local mirror uuid",
-    "remote mirror uuid", &ctx);
+    "remote mirror uuid", "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }

--- a/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
+++ b/src/test/rbd_mirror/image_replayer/test_mock_CreateImageRequest.cc
@@ -315,11 +315,13 @@ public:
                                          const std::string &local_image_name,
 					 const std::string &local_image_id,
                                          librbd::MockTestImageCtx &mock_remote_image_ctx,
+					 const std::string &local_data_pool_name,
                                          Context *on_finish) {
     return new MockCreateImageRequest(m_local_io_ctx, m_threads->work_queue,
                                       global_image_id, remote_mirror_uuid,
                                       local_image_name, local_image_id,
-                                      &mock_remote_image_ctx, on_finish);
+                                      &mock_remote_image_ctx, local_data_pool_name,
+				      on_finish);
   }
 
   librbd::ImageCtx *m_remote_image_ctx;
@@ -335,7 +337,8 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Create) {
   C_SaferCond ctx;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
-                                                   mock_remote_image_ctx, &ctx);
+                                                   mock_remote_image_ctx,
+						   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -350,7 +353,8 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CreateError) {
   C_SaferCond ctx;
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
-                                                   mock_remote_image_ctx, &ctx);
+                                                   mock_remote_image_ctx,
+						   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -394,7 +398,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, Clone) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+						   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -419,7 +423,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneGetGlobalImageIdError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -445,7 +449,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneGetLocalParentImageIdError)
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -476,7 +480,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenRemoteParentError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -517,7 +521,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneOpenLocalParentError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -560,7 +564,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneSnapSetError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-ENOENT, ctx.wait());
 }
@@ -604,7 +608,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(-EINVAL, ctx.wait());
 }
@@ -648,7 +652,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneLocalParentCloseError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }
@@ -692,7 +696,7 @@ TEST_F(TestMockImageReplayerCreateImageRequest, CloneRemoteParentCloseError) {
   MockCreateImageRequest *request = create_request("global uuid", "remote uuid",
                                                    "image name", "101241a7c4c9",
                                                    mock_remote_clone_image_ctx,
-                                                   &ctx);
+                                                   "local data pool name", &ctx);
   request->send();
   ASSERT_EQ(0, ctx.wait());
 }

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -149,7 +149,8 @@ public:
     m_replayer = new ImageReplayerT(
         m_threads.get(), m_image_deleter.get(), m_instance_watcher,
         rbd::mirror::RadosRef(new librados::Rados(m_local_ioctx)),
-        m_local_mirror_uuid, m_local_ioctx.get_id(), m_global_image_id);
+        m_local_mirror_uuid, m_local_ioctx.get_id(), m_local_data_pool_name,
+	m_global_image_id);
     m_replayer->add_peer("peer uuid", m_remote_ioctx);
   }
 
@@ -394,6 +395,7 @@ public:
   int64_t m_remote_pool_id;
   std::string m_remote_image_id;
   std::string m_global_image_id;
+  std::string m_local_data_pool_name;
   rbd::mirror::ImageReplayer<> *m_replayer;
   C_WatchCtx *m_watch_ctx;
   uint64_t m_watch_handle;

--- a/src/test/rbd_mirror/test_mock_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_ImageReplayer.cc
@@ -181,6 +181,7 @@ struct BootstrapRequest<librbd::MockTestImageCtx> {
       ::journal::MockJournalerProxy *journaler,
       librbd::journal::MirrorPeerClientMeta *client_meta,
       Context *on_finish, bool *do_resync,
+      const std::string &local_data_pool_name,
       rbd::mirror::ProgressContext *progress_ctx = nullptr) {
     assert(s_instance != nullptr);
     s_instance->image_ctx = local_image_ctx;
@@ -563,7 +564,7 @@ public:
     m_image_replayer = new MockImageReplayer(
       &mock_threads, &mock_image_deleter, &m_instance_watcher,
       rbd::mirror::RadosRef(new librados::Rados(m_local_io_ctx)),
-      "local_mirror_uuid", m_local_io_ctx.get_id(), "global image id");
+      "local_mirror_uuid", m_local_io_ctx.get_id(), "", "global image id");
     m_image_replayer->add_peer("peer_uuid", m_remote_io_ctx);
   }
 

--- a/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
+++ b/src/test/rbd_mirror/test_mock_InstanceReplayer.cc
@@ -74,6 +74,7 @@ struct ImageReplayer<librbd::MockTestImageCtx> {
     ImageDeleter<librbd::MockTestImageCtx>* image_deleter,
     InstanceWatcher<librbd::MockTestImageCtx> *instance_watcher,
     RadosRef local, const std::string &local_mirror_uuid, int64_t local_pool_id,
+    const std::string &local_data_pool_name,
     const std::string &global_image_id) {
     assert(s_instance != nullptr);
     s_instance->global_image_id = global_image_id;
@@ -180,7 +181,7 @@ TEST_F(TestMockInstanceReplayer, AcquireReleaseImage) {
   MockInstanceReplayer instance_replayer(
     &mock_threads, &mock_service_daemon, &mock_image_deleter,
     rbd::mirror::RadosRef(new librados::Rados(m_local_io_ctx)),
-    "local_mirror_uuid", m_local_io_ctx.get_id());
+    "local_mirror_uuid", m_local_io_ctx.get_id(), "");
   std::string global_image_id("global_image_id");
 
   EXPECT_CALL(mock_image_replayer, get_global_image_id())
@@ -251,7 +252,7 @@ TEST_F(TestMockInstanceReplayer, RemoveFinishedImage) {
   MockInstanceReplayer instance_replayer(
     &mock_threads, &mock_service_daemon, &mock_image_deleter,
     rbd::mirror::RadosRef(new librados::Rados(m_local_io_ctx)),
-    "local_mirror_uuid", m_local_io_ctx.get_id());
+    "local_mirror_uuid", m_local_io_ctx.get_id(), "");
   std::string global_image_id("global_image_id");
 
   EXPECT_CALL(mock_image_replayer, get_global_image_id())

--- a/src/tools/rbd/action/MirrorPool.cc
+++ b/src/tools/rbd/action/MirrorPool.cc
@@ -661,9 +661,12 @@ void get_enable_arguments(po::options_description *positional,
   at::add_pool_options(positional, options);
   positional->add_options()
     ("mode", "mirror mode [image or pool]");
+  options->add_options()
+    ("data-pool", po::value<std::string>(), "data pool name");
 }
 
 int execute_enable_disable(const std::string &pool_name,
+			   const std::string &data_pool_name,
                            rbd_mirror_mode_t next_mirror_mode,
                            const std::string &mode) {
   librados::Rados rados;
@@ -701,7 +704,7 @@ int execute_enable_disable(const std::string &pool_name,
               << std::endl;
   }
 
-  r = rbd.mirror_mode_set(io_ctx, next_mirror_mode);
+  r = rbd.mirror_mode_set(io_ctx, next_mirror_mode, data_pool_name);
   if (r < 0) {
     return r;
   }
@@ -712,7 +715,7 @@ int execute_disable(const po::variables_map &vm) {
   size_t arg_index = 0;
   std::string pool_name = utils::get_pool_name(vm, &arg_index);
 
-  return execute_enable_disable(pool_name, RBD_MIRROR_MODE_DISABLED,
+  return execute_enable_disable(pool_name, "", RBD_MIRROR_MODE_DISABLED,
                                 "disabled");
 }
 
@@ -731,7 +734,12 @@ int execute_enable(const po::variables_map &vm) {
     return -EINVAL;
   }
 
-  return execute_enable_disable(pool_name, mirror_mode, mode);
+  std::string data_pool_name;
+  if (vm.count("data-pool")) {
+    data_pool_name = vm["data-pool"].as<std::string>();
+  }
+
+  return execute_enable_disable(pool_name, data_pool_name, mirror_mode, mode);
 }
 
 void get_info_arguments(po::options_description *positional,
@@ -764,7 +772,8 @@ int execute_info(const po::variables_map &vm) {
 
   librbd::RBD rbd;
   rbd_mirror_mode_t mirror_mode;
-  r = rbd.mirror_mode_get(io_ctx, &mirror_mode);
+  std::string data_pool_name;
+  r = rbd.mirror_mode_get(io_ctx, &mirror_mode, &data_pool_name);
   if (r < 0) {
     return r;
   }
@@ -794,8 +803,12 @@ int execute_info(const po::variables_map &vm) {
   if (formatter != nullptr) {
     formatter->open_object_section("mirror");
     formatter->dump_string("mode", mirror_mode_desc);
+    formatter->dump_string("data_pool_name", data_pool_name);
   } else {
     std::cout << "Mode: " << mirror_mode_desc << std::endl;
+    if (data_pool_name.length() != 0) {
+      std::cout << "Data pool: " << data_pool_name << std::endl;
+    }
   }
 
   if (mirror_mode != RBD_MIRROR_MODE_DISABLED) {

--- a/src/tools/rbd_mirror/ClusterWatcher.h
+++ b/src/tools/rbd_mirror/ClusterWatcher.h
@@ -30,7 +30,7 @@ template <typename> class ServiceDaemon;
 class ClusterWatcher {
 public:
   typedef std::set<peer_t> Peers;
-  typedef std::map<int64_t, Peers>  PoolPeers;
+  typedef std::map<int64_t, pool_config_t> PoolConfigs;
   typedef std::set<std::string> PoolNames;
 
   ClusterWatcher(RadosRef cluster, Mutex &lock,
@@ -41,7 +41,7 @@ public:
 
   // Caller controls frequency of calls
   void refresh_pools();
-  const PoolPeers& get_pool_peers() const;
+  const PoolConfigs& get_pool_configs() const;
 
 private:
   typedef std::unordered_map<int64_t, service_daemon::CalloutId> ServicePools;
@@ -51,9 +51,9 @@ private:
   ServiceDaemon<librbd::ImageCtx>* m_service_daemon;
 
   ServicePools m_service_pools;
-  PoolPeers m_pool_peers;
+  PoolConfigs m_pool_configs;
 
-  void read_pool_peers(PoolPeers *pool_peers, PoolNames *pool_names);
+  void read_pool_configs(PoolConfigs *pool_configs, PoolNames *pool_names);
 };
 
 } // namespace mirror

--- a/src/tools/rbd_mirror/ImageReplayer.cc
+++ b/src/tools/rbd_mirror/ImageReplayer.cc
@@ -263,6 +263,7 @@ ImageReplayer<I>::ImageReplayer(Threads<I> *threads,
                                 RadosRef local,
                                 const std::string &local_mirror_uuid,
                                 int64_t local_pool_id,
+				const std::string &local_data_pool_name,
                                 const std::string &global_image_id) :
   m_threads(threads),
   m_image_deleter(image_deleter),
@@ -270,6 +271,7 @@ ImageReplayer<I>::ImageReplayer(Threads<I> *threads,
   m_local(local),
   m_local_mirror_uuid(local_mirror_uuid),
   m_local_pool_id(local_pool_id),
+  m_local_data_pool_name(local_data_pool_name),
   m_global_image_id(global_image_id),
   m_lock("rbd::mirror::ImageReplayer " + stringify(local_pool_id) + " " +
 	 global_image_id),
@@ -520,7 +522,7 @@ void ImageReplayer<I>::bootstrap() {
     m_global_image_id, m_threads->work_queue, m_threads->timer,
     &m_threads->timer_lock, m_local_mirror_uuid, m_remote_image.mirror_uuid,
     m_remote_journaler, &m_client_meta, ctx, &m_resync_requested,
-    &m_progress_cxt);
+    m_local_data_pool_name, &m_progress_cxt);
 
   {
     Mutex::Locker locker(m_lock);

--- a/src/tools/rbd_mirror/ImageReplayer.h
+++ b/src/tools/rbd_mirror/ImageReplayer.h
@@ -65,10 +65,11 @@ public:
     Threads<ImageCtxT> *threads, ImageDeleter<ImageCtxT>* image_deleter,
     InstanceWatcher<ImageCtxT> *instance_watcher,
     RadosRef local, const std::string &local_mirror_uuid, int64_t local_pool_id,
+    const std::string &local_data_pool_name,
     const std::string &global_image_id) {
     return new ImageReplayer(threads, image_deleter, instance_watcher,
                              local, local_mirror_uuid, local_pool_id,
-                             global_image_id);
+			     local_data_pool_name, global_image_id);
   }
   void destroy() {
     delete this;
@@ -78,7 +79,8 @@ public:
                 ImageDeleter<ImageCtxT>* image_deleter,
                 InstanceWatcher<ImageCtxT> *instance_watcher,
                 RadosRef local, const std::string &local_mirror_uuid,
-                int64_t local_pool_id, const std::string &global_image_id);
+                int64_t local_pool_id, const std::string &local_data_pool_name,
+		const std::string &global_image_id);
   virtual ~ImageReplayer();
   ImageReplayer(const ImageReplayer&) = delete;
   ImageReplayer& operator=(const ImageReplayer&) = delete;
@@ -285,6 +287,7 @@ private:
   RadosRef m_local;
   std::string m_local_mirror_uuid;
   int64_t m_local_pool_id;
+  std::string m_local_data_pool_name;
   std::string m_local_image_id;
   std::string m_global_image_id;
   std::string m_name;

--- a/src/tools/rbd_mirror/InstanceReplayer.cc
+++ b/src/tools/rbd_mirror/InstanceReplayer.cc
@@ -35,10 +35,12 @@ template <typename I>
 InstanceReplayer<I>::InstanceReplayer(
     Threads<I> *threads, ServiceDaemon<I>* service_daemon,
     ImageDeleter<I>* image_deleter, RadosRef local_rados,
-    const std::string &local_mirror_uuid, int64_t local_pool_id)
+    const std::string &local_mirror_uuid, int64_t local_pool_id,
+    const std::string &local_data_pool_name)
   : m_threads(threads), m_service_daemon(service_daemon),
     m_image_deleter(image_deleter), m_local_rados(local_rados),
     m_local_mirror_uuid(local_mirror_uuid), m_local_pool_id(local_pool_id),
+    m_local_data_pool_name(local_data_pool_name),
     m_lock("rbd::mirror::InstanceReplayer " + stringify(local_pool_id)) {
 }
 
@@ -143,7 +145,8 @@ void InstanceReplayer<I>::acquire_image(InstanceWatcher<I> *instance_watcher,
   if (it == m_image_replayers.end()) {
     auto image_replayer = ImageReplayer<I>::create(
         m_threads, m_image_deleter, instance_watcher, m_local_rados,
-        m_local_mirror_uuid, m_local_pool_id, global_image_id);
+        m_local_mirror_uuid, m_local_pool_id, m_local_data_pool_name,
+	global_image_id);
 
     dout(20) << global_image_id << ": creating replayer " << image_replayer
              << dendl;

--- a/src/tools/rbd_mirror/InstanceReplayer.h
+++ b/src/tools/rbd_mirror/InstanceReplayer.h
@@ -31,9 +31,10 @@ public:
       ServiceDaemon<ImageCtxT>* service_daemon,
       ImageDeleter<ImageCtxT>* image_deleter,
       RadosRef local_rados, const std::string &local_mirror_uuid,
-      int64_t local_pool_id) {
+      int64_t local_pool_id, const std::string &local_data_pool_name) {
     return new InstanceReplayer(threads, service_daemon, image_deleter,
-                                local_rados, local_mirror_uuid, local_pool_id);
+                                local_rados, local_mirror_uuid, local_pool_id,
+				local_data_pool_name);
   }
   void destroy() {
     delete this;
@@ -43,7 +44,8 @@ public:
                    ServiceDaemon<ImageCtxT>* service_daemon,
 		   ImageDeleter<ImageCtxT>* image_deleter,
 		   RadosRef local_rados, const std::string &local_mirror_uuid,
-		   int64_t local_pool_id);
+		   int64_t local_pool_id,
+		   const std::string &local_data_pool_name);
   ~InstanceReplayer();
 
   int init();
@@ -90,6 +92,7 @@ private:
   RadosRef m_local_rados;
   std::string m_local_mirror_uuid;
   int64_t m_local_pool_id;
+  std::string m_local_data_pool_name;
 
   Mutex m_lock;
   AsyncOpTracker m_async_op_tracker;

--- a/src/tools/rbd_mirror/Mirror.h
+++ b/src/tools/rbd_mirror/Mirror.h
@@ -51,10 +51,10 @@ public:
   void release_leader();
 
 private:
-  typedef ClusterWatcher::PoolPeers PoolPeers;
+  typedef ClusterWatcher::PoolConfigs PoolConfigs;
   typedef std::pair<int64_t, peer_t> PoolPeer;
 
-  void update_pool_replayers(const PoolPeers &pool_peers);
+  void update_pool_replayers(const PoolConfigs &pool_configs);
 
   CephContext *m_cct;
   std::vector<const char*> m_args;

--- a/src/tools/rbd_mirror/PoolReplayer.cc
+++ b/src/tools/rbd_mirror/PoolReplayer.cc
@@ -213,12 +213,15 @@ private:
 PoolReplayer::PoolReplayer(Threads<librbd::ImageCtx> *threads,
                            ServiceDaemon<librbd::ImageCtx>* service_daemon,
 			   ImageDeleter<>* image_deleter,
-			   int64_t local_pool_id, const peer_t &peer,
+			   int64_t local_pool_id,
+			   const std::string &local_data_pool_name,
+			   const peer_t &peer,
 			   const std::vector<const char*> &args) :
   m_threads(threads),
   m_service_daemon(service_daemon),
   m_image_deleter(image_deleter),
   m_local_pool_id(local_pool_id),
+  m_local_data_pool_name(local_data_pool_name),
   m_peer(peer),
   m_args(args),
   m_lock(stringify("rbd::mirror::PoolReplayer ") + stringify(peer)),
@@ -312,7 +315,7 @@ void PoolReplayer::init()
 
   m_instance_replayer.reset(InstanceReplayer<>::create(
     m_threads, m_service_daemon, m_image_deleter, m_local_rados,
-    local_mirror_uuid, m_local_pool_id));
+    local_mirror_uuid, m_local_pool_id, m_local_data_pool_name));
   m_instance_replayer->init();
   m_instance_replayer->add_peer(m_peer.uuid, m_remote_io_ctx);
 

--- a/src/tools/rbd_mirror/PoolReplayer.h
+++ b/src/tools/rbd_mirror/PoolReplayer.h
@@ -43,8 +43,8 @@ public:
   PoolReplayer(Threads<librbd::ImageCtx> *threads,
                ServiceDaemon<librbd::ImageCtx>* service_daemon,
 	       ImageDeleter<>* image_deleter,
-	       int64_t local_pool_id, const peer_t &peer,
-	       const std::vector<const char*> &args);
+	       int64_t local_pool_id, const std::string &local_data_pool_name,
+	       const peer_t &peer, const std::vector<const char*> &args);
   ~PoolReplayer();
   PoolReplayer(const PoolReplayer&) = delete;
   PoolReplayer& operator=(const PoolReplayer&) = delete;
@@ -111,6 +111,7 @@ private:
   ServiceDaemon<librbd::ImageCtx>* m_service_daemon;
   ImageDeleter<>* m_image_deleter;
   int64_t m_local_pool_id = -1;
+  std::string m_local_data_pool_name;
   peer_t m_peer;
   std::vector<const char*> m_args;
 

--- a/src/tools/rbd_mirror/ServiceDaemon.cc
+++ b/src/tools/rbd_mirror/ServiceDaemon.cc
@@ -89,12 +89,15 @@ int ServiceDaemon<I>::init() {
 }
 
 template <typename I>
-void ServiceDaemon<I>::add_pool(int64_t pool_id, const std::string& pool_name) {
-  dout(20) << "pool_id=" << pool_id << ", pool_name=" << pool_name << dendl;
+void ServiceDaemon<I>::add_pool(int64_t pool_id, const std::string& pool_name,
+				const std::string& data_pool_name) {
+  dout(20) << "pool_id=" << pool_id
+	   << ", pool_name=" << pool_name
+	   << ", data_pool_name=" << data_pool_name << dendl;
 
   {
     Mutex::Locker locker(m_lock);
-    m_pools.insert({pool_id, {pool_name}});
+    m_pools.insert({pool_id, {pool_name, data_pool_name}});
   }
   schedule_update_status();
 }
@@ -217,6 +220,7 @@ void ServiceDaemon<I>::update_status() {
     for (auto& pool_pair : m_pools) {
       f.open_object_section(stringify(pool_pair.first).c_str());
       f.dump_string("name", pool_pair.second.name);
+      f.dump_string("data_pool_name", pool_pair.second.data_pool_name);
       f.open_object_section("callouts");
       for (auto& callout : pool_pair.second.callouts) {
         f.open_object_section(stringify(callout.first).c_str());

--- a/src/tools/rbd_mirror/ServiceDaemon.h
+++ b/src/tools/rbd_mirror/ServiceDaemon.h
@@ -27,7 +27,8 @@ public:
 
   int init();
 
-  void add_pool(int64_t pool_id, const std::string& pool_name);
+  void add_pool(int64_t pool_id, const std::string& pool_name,
+		const std::string& data_pool_name);
   void remove_pool(int64_t pool_id);
 
   uint64_t add_or_update_callout(int64_t pool_id, uint64_t callout_id,
@@ -55,10 +56,12 @@ private:
 
   struct Pool {
     std::string name;
+    std::string data_pool_name;
     Callouts callouts;
     Attributes attributes;
 
-    Pool(const std::string& name) : name(name) {
+    Pool(const std::string& name, const std::string& data_pool_name)
+      : name(name), data_pool_name(data_pool_name) {
     }
   };
 

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.cc
@@ -54,6 +54,7 @@ BootstrapRequest<I>::BootstrapRequest(
         MirrorPeerClientMeta *client_meta,
         Context *on_finish,
         bool *do_resync,
+	const std::string &local_data_pool_name,
         rbd::mirror::ProgressContext *progress_ctx)
   : BaseRequest("rbd::mirror::image_replayer::BootstrapRequest",
 		reinterpret_cast<CephContext*>(local_io_ctx.cct()), on_finish),
@@ -65,7 +66,7 @@ BootstrapRequest<I>::BootstrapRequest(
     m_local_mirror_uuid(local_mirror_uuid),
     m_remote_mirror_uuid(remote_mirror_uuid), m_journaler(journaler),
     m_client_meta(client_meta), m_progress_ctx(progress_ctx),
-    m_do_resync(do_resync),
+    m_do_resync(do_resync), m_local_data_pool_name(local_data_pool_name),
     m_lock(unique_lock_name("BootstrapRequest::m_lock", this)) {
 }
 
@@ -478,7 +479,8 @@ void BootstrapRequest<I>::create_local_image() {
       this);
   CreateImageRequest<I> *request = CreateImageRequest<I>::create(
     m_local_io_ctx, m_work_queue, m_global_image_id, m_remote_mirror_uuid,
-    image_name, m_local_image_id, m_remote_image_ctx, ctx);
+    image_name, m_local_image_id, m_remote_image_ctx, m_local_data_pool_name,
+    ctx);
   request->send();
 }
 

--- a/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/BootstrapRequest.h
@@ -56,6 +56,7 @@ public:
         MirrorPeerClientMeta *client_meta,
         Context *on_finish,
         bool *do_resync,
+	const std::string &local_data_pool_name,
         ProgressContext *progress_ctx = nullptr) {
     return new BootstrapRequest(local_io_ctx, remote_io_ctx,
                                 instance_watcher, local_image_ctx,
@@ -63,7 +64,7 @@ public:
                                 global_image_id, work_queue, timer, timer_lock,
                                 local_mirror_uuid, remote_mirror_uuid,
                                 journaler, client_meta, on_finish, do_resync,
-                                progress_ctx);
+				local_data_pool_name, progress_ctx);
   }
 
   BootstrapRequest(librados::IoCtx &local_io_ctx,
@@ -77,7 +78,8 @@ public:
                    const std::string &local_mirror_uuid,
                    const std::string &remote_mirror_uuid, Journaler *journaler,
                    MirrorPeerClientMeta *client_meta, Context *on_finish,
-                   bool *do_resync, ProgressContext *progress_ctx = nullptr);
+                   bool *do_resync, const std::string &local_data_pool_name,
+		   ProgressContext *progress_ctx = nullptr);
   ~BootstrapRequest() override;
 
   bool is_syncing() const;
@@ -162,6 +164,7 @@ private:
   MirrorPeerClientMeta *m_client_meta;
   ProgressContext *m_progress_ctx;
   bool *m_do_resync;
+  std::string m_local_data_pool_name;
 
   mutable Mutex m_lock;
   bool m_canceled = false;

--- a/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
+++ b/src/tools/rbd_mirror/image_replayer/CreateImageRequest.h
@@ -28,10 +28,12 @@ public:
                                     const std::string &local_image_name,
 				    const std::string &local_image_id,
                                     ImageCtxT *remote_image_ctx,
+				    const std::string &local_data_pool_name,
                                     Context *on_finish) {
     return new CreateImageRequest(local_io_ctx, work_queue, global_image_id,
                                   remote_mirror_uuid, local_image_name,
-                                  local_image_id, remote_image_ctx, on_finish);
+                                  local_image_id, remote_image_ctx,
+				  local_data_pool_name, on_finish);
   }
 
   CreateImageRequest(librados::IoCtx &local_io_ctx, ContextWQ *work_queue,
@@ -40,6 +42,7 @@ public:
                      const std::string &local_image_name,
 		     const std::string &local_image_id,
                      ImageCtxT *remote_image_ctx,
+		     const std::string &local_data_pool_name,
                      Context *on_finish);
 
   void send();
@@ -88,6 +91,7 @@ private:
   std::string m_local_image_name;
   std::string m_local_image_id;
   ImageCtxT *m_remote_image_ctx;
+  std::string m_local_data_pool_name;
   Context *m_on_finish;
 
   librados::IoCtx m_remote_parent_io_ctx;

--- a/src/tools/rbd_mirror/types.cc
+++ b/src/tools/rbd_mirror/types.cc
@@ -17,5 +17,17 @@ std::ostream& operator<<(std::ostream& lhs, const peer_t &peer) {
 	     << " client: " << peer.client_name;
 }
 
+std::ostream& operator<<(std::ostream& lhs, const pool_config_t &pool_config) {
+  lhs << "pool name: " << pool_config.pool_name
+      << " data pool name: " << pool_config.data_pool_name
+      << " peers: [ ";
+
+  for (auto& peer : pool_config.peers) {
+    lhs << peer << ", ";
+  }
+
+  return lhs << "]";
+}
+
 } // namespace mirror
 } // namespace rbd

--- a/src/tools/rbd_mirror/types.h
+++ b/src/tools/rbd_mirror/types.h
@@ -90,6 +90,26 @@ struct peer_t {
 
 std::ostream& operator<<(std::ostream& lhs, const peer_t &peer);
 
+struct pool_config_t {
+  pool_config_t() = default;
+  pool_config_t(const std::string &pool_name, const std::string &data_pool_name,
+		const std::set<peer_t> &peers)
+    : pool_name(pool_name), data_pool_name(data_pool_name), peers(peers)
+    {
+    }
+  std::string pool_name;
+  std::string data_pool_name;
+  std::set<peer_t> peers;
+  bool operator<(const pool_config_t &rhs) const {
+    return pool_name < rhs.pool_name;
+  }
+  bool operator==(const pool_config_t &rhs) const {
+    return pool_name == rhs.pool_name;
+  }
+};
+
+std::ostream& operator<<(std::ostream &lhs, const pool_config_t &pool_config);
+
 } // namespace mirror
 } // namespace rbd
 


### PR DESCRIPTION
Add an option, `--data-pool` to the `rbd mirror pool enable` command, allowing the user to specify which data-pool should be used for images mirrored into a given pool. This allows images to be mirrored from a cluster using replication to one using erasure coding, or vice versa.

The default behavior of using the same data-pool name on the receiving side is maintained.

Fixes: http://tracker.ceph.com/issues/21088