### PR TITLE
mds: support limiting cache by memory

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,2 +1,11 @@
 >= 12.2.0
 ---------
+
+- *CephFS*:
+
+  * Limiting MDS cache via a memory limit is now supported using the new
+    mds_cache_memory_limit config option (1GB by default).  A cache reservation
+    can also be specified using mds_cache_reservation as a percentage of the
+    limit (5% by default). Limits by inode count are still supported using
+    mds_cache_size. Setting mds_cache_size to 0 (the default) disables the
+    inode limit.

--- a/doc/cephfs/health-messages.rst
+++ b/doc/cephfs/health-messages.rst
@@ -73,14 +73,14 @@ so at all.  This message appears if a client has taken longer than
 
 Message: "Client *name* failing to respond to cache pressure"
 Code: MDS_HEALTH_CLIENT_RECALL, MDS_HEALTH_CLIENT_RECALL_MANY
-Description: Clients maintain a metadata cache.  Items (such as inodes)
-in the client cache are also pinned in the MDS cache, so when the MDS
-needs to shrink its cache (to stay within ``mds_cache_size``), it
-sends messages to clients to shrink their caches too.  If the client
-is unresponsive or buggy, this can prevent the MDS from properly staying
-within its ``mds_cache_size`` and it may eventually run out of memory
-and crash.  This message appears if a client has taken more than
-``mds_recall_state_timeout`` (default 60s) to comply.
+Description: Clients maintain a metadata cache.  Items (such as inodes) in the
+client cache are also pinned in the MDS cache, so when the MDS needs to shrink
+its cache (to stay within ``mds_cache_size`` or ``mds_cache_memory_limit``), it
+sends messages to clients to shrink their caches too.  If the client is
+unresponsive or buggy, this can prevent the MDS from properly staying within
+its cache limits and it may eventually run out of memory and crash.  This
+message appears if a client has taken more than ``mds_recall_state_timeout``
+(default 60s) to comply.
 
 Message: "Client *name* failing to advance its oldest client/flush tid"
 Code: MDS_HEALTH_CLIENT_OLDEST_TID, MDS_HEALTH_CLIENT_OLDEST_TID_MANY
@@ -121,9 +121,9 @@ This message appears if any client requests have taken longer than
 
 Message: "Too many inodes in cache"
 Code: MDS_HEALTH_CACHE_OVERSIZED
-Description: The MDS is not succeeding in trimming its cache to comply
-with the limit set by the administrator.  If the MDS cache becomes too large,
-the daemon may exhaust available memory and crash.
-This message appears if the actual cache size (in inodes) is at least 50%
-greater than ``mds_cache_size`` (default 100000).
-
+Description: The MDS is not succeeding in trimming its cache to comply with the
+limit set by the administrator.  If the MDS cache becomes too large, the daemon
+may exhaust available memory and crash.  By default, this message appears if
+the actual cache size (in inodes or memory) is at least 50% greater than
+``mds_cache_size`` (default 100000) or ``mds_cache_memory_limit`` (default
+1GB). Modify ``mds_health_cache_threshold`` to set the warning ratio.

--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -19,13 +19,30 @@
 :Type:  64-bit Integer Unsigned
 :Default:  ``1ULL << 40``
 
+``mds cache memory limit``
+
+:Description: The memory limit the MDS should enforce for its cache.
+              Administrators should use this instead of ``mds cache size``.
+:Type:  64-bit Integer Unsigned
+:Default: ``1073741824``
+
+``mds cache reservation``
+
+:Description: The cache reservation (memory or inodes) for the MDS cache to maintain.
+              Once the MDS begins dipping into its reservation, it will recall
+              client state until its cache size shrinks to restore the
+              reservation.
+:Type:  Float
+:Default: ``0.05``
 
 ``mds cache size``
 
-:Description: The number of inodes to cache.
+:Description: The number of inodes to cache. A value of 0 indicates an
+              unlimited number. It is recommended to use
+              ``mds_cache_memory_limit`` to limit the amount of memory the MDS
+              cache uses.
 :Type:  32-bit Integer
-:Default: ``100000``
-
+:Default: ``0``
 
 ``mds cache mid``
 

--- a/qa/suites/fs/basic_functional/tasks/client-limits.yaml
+++ b/qa/suites/fs/basic_functional/tasks/client-limits.yaml
@@ -9,6 +9,7 @@ overrides:
       - failing to respond to cache pressure
       - slow requests are blocked
       - failing to respond to capability release
+      - MDS cache is too large
       - \(MDS_CLIENT_OLDEST_TID\)
       - \(MDS_CACHE_OVERSIZED\)
 

--- a/qa/tasks/cephfs/test_client_limits.py
+++ b/qa/tasks/cephfs/test_client_limits.py
@@ -81,12 +81,12 @@ class TestClientLimits(CephFSTestCase):
             pass
 
         # The remaining caps should comply with the numbers sent from MDS in SESSION_RECALL message,
-        # which depend on the cache size and overall ratio
+        # which depend on the caps outstanding, cache size and overall ratio
         self.wait_until_equal(
             lambda: self.get_session(mount_a_client_id)['num_caps'],
-            int(cache_size * 0.8),
-            timeout=600,
-            reject_fn=lambda x: x < int(cache_size*.8))
+            int(open_files * 0.2),
+            timeout=30,
+            reject_fn=lambda x: x < int(open_files*0.2))
 
     @needs_trimming
     def test_client_pin_root(self):

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -272,7 +272,6 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
   if (cct->_conf->client_acl_type == "posix_acl")
     acl_type = POSIX_ACL;
 
-  lru.lru_set_max(cct->_conf->client_cache_size);
   lru.lru_set_midpoint(cct->_conf->client_cache_mid);
 
   // file handles
@@ -332,7 +331,6 @@ void Client::tear_down_cache()
   // *** FIXME ***
 
   // empty lru
-  lru.lru_set_max(0);
   trim_cache();
   assert(lru.lru_get_size() == 0);
 
@@ -601,12 +599,13 @@ void Client::shutdown()
 
 void Client::trim_cache(bool trim_kernel_dcache)
 {
-  ldout(cct, 20) << "trim_cache size " << lru.lru_get_size() << " max " << lru.lru_get_max() << dendl;
+  uint64_t max = cct->_conf->client_cache_size;
+  ldout(cct, 20) << "trim_cache size " << lru.lru_get_size() << " max " << max << dendl;
   unsigned last = 0;
   while (lru.lru_get_size() != last) {
     last = lru.lru_get_size();
 
-    if (lru.lru_get_size() <= lru.lru_get_max())  break;
+    if (!unmounting && lru.lru_get_size() <= max)  break;
 
     // trim!
     Dentry *dn = static_cast<Dentry*>(lru.lru_get_next_expire());
@@ -616,7 +615,7 @@ void Client::trim_cache(bool trim_kernel_dcache)
     trim_dentry(dn);
   }
 
-  if (trim_kernel_dcache && lru.lru_get_size() > lru.lru_get_max())
+  if (trim_kernel_dcache && lru.lru_get_size() > max)
     _invalidate_kernel_dcache();
 
   // hose root?
@@ -5921,7 +5920,6 @@ void Client::unmount()
   wait_sync_caps(last_flush_tid);
 
   // empty lru cache
-  lru.lru_set_max(0);
   trim_cache();
 
   while (lru.lru_get_size() > 0 ||
@@ -13751,9 +13749,7 @@ void Client::handle_conf_change(const struct md_config_t *conf,
 {
   Mutex::Locker lock(client_lock);
 
-  if (changed.count("client_cache_size") ||
-      changed.count("client_cache_mid")) {
-    lru.lru_set_max(cct->_conf->client_cache_size);
+  if (changed.count("client_cache_mid")) {
     lru.lru_set_midpoint(cct->_conf->client_cache_mid);
   }
   if (changed.count("client_acl_type")) {

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -503,7 +503,6 @@ protected:
   friend void intrusive_ptr_release(Inode *in);
 
   //int get_cache_size() { return lru.lru_get_size(); }
-  //void set_cache_size(int m) { lru.lru_set_max(m); }
 
   /**
    * Don't call this with in==NULL, use get_or_create for that

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -438,8 +438,6 @@ OPTION(mds_data, OPT_STR)
 OPTION(mds_max_file_size, OPT_U64) // Used when creating new CephFS. Change with 'ceph mds set max_file_size <size>' afterwards
 // max xattr kv pairs size for each dir/file
 OPTION(mds_max_xattr_pairs_size, OPT_U32)
-OPTION(mds_cache_size, OPT_INT)
-OPTION(mds_cache_mid, OPT_FLOAT)
 OPTION(mds_max_file_recover, OPT_U32)
 OPTION(mds_dir_max_commit_size, OPT_INT) // MB
 OPTION(mds_dir_keys_per_op, OPT_INT)
@@ -459,7 +457,6 @@ OPTION(mds_recall_state_timeout, OPT_FLOAT)    // detect clients which aren't tr
 OPTION(mds_freeze_tree_timeout, OPT_FLOAT)    // detecting freeze tree deadlock
 OPTION(mds_session_autoclose, OPT_FLOAT) // autoclose idle session
 OPTION(mds_health_summarize_threshold, OPT_INT) // collapse N-client health metrics to a single 'many'
-OPTION(mds_health_cache_threshold, OPT_FLOAT) // warn on cache size if it exceeds mds_cache_size by this factor
 OPTION(mds_reconnect_timeout, OPT_FLOAT)  // seconds to wait for clients during mds restart
 	      //  make it (mds_session_timeout - mds_beacon_grace)
 OPTION(mds_tick_interval, OPT_FLOAT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5309,8 +5309,22 @@ std::vector<Option> get_mds_options() {
     .set_description(""),
 
     Option("mds_cache_size", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(100000)
-    .set_description(""),
+    .set_default(0)
+    .set_description("maximum number of inodes in MDS cache (<=0 is unlimited)")
+    .set_long_description("This tunable is no longer recommended. Use mds_cache_memory_limit."),
+
+    Option("mds_cache_memory_limit", Option::TYPE_UINT, Option::LEVEL_BASIC)
+    .set_default(1*(1LL<<30))
+    .set_description("target maximum memory usage of MDS cache")
+    .set_long_description("This sets a target maximum memory usage of the MDS cache and is the primary tunable to limit the MDS memory usage. The MDS will try to stay under a reservation of this limit (by default 95%; 1 - mds_cache_reservation) by trimming unused metadata in its cache and recalling cached items in the client caches. It is possible for the MDS to exceed this limit due to slow recall from clients. The mds_health_cache_threshold (150%) sets a cache full threshold for when the MDS signals a cluster health warning."),
+
+    Option("mds_cache_reservation", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(.05)
+    .set_description("amount of memory to reserve"),
+
+    Option("mds_health_cache_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(1.5)
+    .set_description("threshold for cache size to generate health warning"),
 
     Option("mds_cache_mid", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(.7)
@@ -5382,10 +5396,6 @@ std::vector<Option> get_mds_options() {
 
     Option("mds_health_summarize_threshold", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(10)
-    .set_description(""),
-
-    Option("mds_health_cache_threshold", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(1.5)
     .set_description(""),
 
     Option("mds_reconnect_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -30,6 +30,10 @@
 #include <sys/mount.h>
 #endif
 
+#include <string>
+
+#include <stdio.h>
+
 int64_t unit_to_bytesize(string val, ostream *pss)
 {
   if (val.empty()) {
@@ -301,4 +305,16 @@ string cleanbin(string &str)
   if (base64)
     result = "Base64:" + result;
   return result;
+}
+
+std::string bytes2str(uint64_t count) {
+  static char s[][2] = {"\0", "k", "M", "G", "T", "P", "E", "\0"};
+  int i = 0;
+  while (count >= 1024 && *s[i+1]) {
+    count >>= 10;
+    i++;
+  }
+  char str[128];
+  snprintf(str, sizeof str, "%" PRIu64 "%sB", count, s[i]);
+  return std::string(str);
 }

--- a/src/include/alloc_ptr.h
+++ b/src/include/alloc_ptr.h
@@ -1,0 +1,91 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat, Inc.
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef CEPH_ALLOC_PTR_H
+#define CEPH_ALLOC_PTR_H
+
+#include <memory>
+
+template <class T>
+class alloc_ptr
+{
+public:
+    typedef typename std::pointer_traits< std::unique_ptr<T> >::pointer pointer;
+    typedef typename std::pointer_traits< std::unique_ptr<T> >::element_type element_type;
+
+    alloc_ptr() : ptr() {}
+
+    template<class U>
+      alloc_ptr(U&& u) : ptr(std::forward<U>(u)) {}
+
+    alloc_ptr(alloc_ptr<pointer>&& rhs) : ptr(std::move(rhs.ptr)) {}
+    alloc_ptr(const alloc_ptr<pointer>& rhs) = delete;
+    alloc_ptr& operator=(const alloc_ptr<pointer>&& rhs) {
+        ptr = rhs.ptr;
+    }
+    alloc_ptr& operator=(const alloc_ptr<pointer>& rhs) {
+        ptr = rhs.ptr;
+    }
+
+    void swap (alloc_ptr<pointer>& rhs) {
+        ptr.swap(rhs.ptr);
+    }
+    element_type* release() {
+        return ptr.release();
+    }
+    void reset(element_type *p = nullptr) {
+        ptr.reset(p);
+    }
+    element_type* get() const {
+        if (!ptr)
+          ptr.reset(new element_type);
+        return ptr.get();
+    }
+    element_type& operator*() const {
+        if (!ptr)
+          ptr.reset(new element_type);
+        return *ptr;
+    }
+    element_type* operator->() const {
+        if (!ptr)
+          ptr.reset(new element_type);
+        return ptr.get();
+    }
+    operator bool() const {
+        return !!ptr;
+    }
+
+    friend bool operator< (const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return std::less<element_type>(*lhs, *rhs);
+    }
+    friend bool operator<=(const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return std::less_equal<element_type>(*lhs, *rhs);
+    }
+    friend bool operator> (const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return std::greater<element_type>(*lhs, *rhs);
+    }
+    friend bool operator>=(const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return std::greater_equal<element_type>(*lhs, *rhs);
+    }
+    friend bool operator==(const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return *lhs == *rhs;
+    }
+    friend bool operator!=(const alloc_ptr& lhs, const alloc_ptr& rhs) {
+        return *lhs != *rhs;
+    }
+private:
+    mutable std::unique_ptr<element_type> ptr;
+};
+
+#endif

--- a/src/include/compact_map.h
+++ b/src/include/compact_map.h
@@ -61,6 +61,9 @@ protected:
       --it;
       return *this;
     }
+    const std::pair<const Key,T>& operator*() {
+      return *it;
+    }
     const std::pair<const Key,T>* operator->() {
       return it.operator->();
     }
@@ -102,6 +105,9 @@ protected:
     iterator_base& operator--() {
       --it;
       return *this;
+    }
+    std::pair<const Key,T>& operator*() {
+      return *it;
     }
     std::pair<const Key,T>* operator->() {
       return it.operator->();

--- a/src/include/counter.h
+++ b/src/include/counter.h
@@ -15,6 +15,8 @@
 #ifndef CEPH_COUNTER_H
 #define CEPH_COUNTER_H
 
+#include <atomic>
+
 template <typename T>
 class Counter {
 public:
@@ -30,23 +32,23 @@ public:
   ~Counter() {
     _count()--;
   }
-  static unsigned long count() {
+  static uint64_t count() {
     return _count();
   }
-  static unsigned long increments() {
+  static uint64_t increments() {
     return _increments();
   }
-  static unsigned long decrements() {
+  static uint64_t decrements() {
     return increments()-count();
   }
 
 private:
-  static unsigned long &_count() {
-    static unsigned long c;
+  static std::atomic<uint64_t> &_count() {
+    static std::atomic<uint64_t> c;
     return c;
   }
-  static unsigned long &_increments() {
-    static unsigned long i;
+  static std::atomic<uint64_t> &_increments() {
+    static std::atomic<uint64_t> i;
     return i;
   }
 };

--- a/src/include/lru.h
+++ b/src/include/lru.h
@@ -17,283 +17,164 @@
 #ifndef CEPH_LRU_H
 #define CEPH_LRU_H
 
+#include <math.h>
 #include <stdint.h>
 
 #include "common/config.h"
-
-
+#include "xlist.h"
 
 class LRUObject {
- private:
-  LRUObject *lru_next, *lru_prev;
-  bool lru_pinned;
-  class LRU *lru;
-  class LRUList *lru_list;
-
- public:
-  LRUObject() {
-    lru_next = lru_prev = NULL;
-    lru_list = 0;
-    lru_pinned = false;
-    lru = 0;
-  }
+public:
+  LRUObject() : lru(), lru_link(this), lru_pinned(false) { }
+  ~LRUObject();
 
   // pin/unpin item in cache
-  void lru_pin(); 
+  void lru_pin();
   void lru_unpin();
   bool lru_is_expireable() const { return !lru_pinned; }
 
   friend class LRU;
-  friend class LRUList;
+private:
+  class LRU *lru;
+  xlist<LRUObject *>::item lru_link;
+  bool lru_pinned;
 };
-
-
-class LRUList {
- private:
-  LRUObject *head, *tail;
-  uint32_t len;
-
- public:
-  LRUList() {
-    head = tail = 0;
-    len = 0;
-  }
-  
-  uint32_t  get_length() const { return len; }
-
-  LRUObject *get_head() {
-    return head;
-  }
-  LRUObject *get_tail() {
-    return tail;
-  }
-
-  void clear() {
-    while (len > 0) {
-      remove(get_head());
-    }
-  }
-
-  void insert_head(LRUObject *o) {
-    o->lru_next = head;
-    o->lru_prev = NULL;
-    if (head) {
-      head->lru_prev = o;
-    } else {
-      tail = o;
-    }
-    head = o;
-    o->lru_list = this;
-    len++;
-  }
-  void insert_tail(LRUObject *o) {
-    o->lru_next = NULL;
-    o->lru_prev = tail;
-    if (tail) {
-      tail->lru_next = o;
-    } else {
-      head = o;
-    }
-    tail = o;
-    o->lru_list = this;
-    len++;
-  }
-
-  void remove(LRUObject *o) {
-    assert(o->lru_list == this);
-    if (o->lru_next)
-      o->lru_next->lru_prev = o->lru_prev;
-    else
-      tail = o->lru_prev;
-    if (o->lru_prev)
-      o->lru_prev->lru_next = o->lru_next;
-    else
-      head = o->lru_next;
-    o->lru_next = o->lru_prev = NULL;
-    o->lru_list = 0;
-    assert(len>0);
-    len--;
-  }
-  
-};
-
 
 class LRU {
- protected:
-  LRUList lru_top, lru_bot, lru_pintail;
-  uint32_t lru_num, lru_num_pinned;
-  uint32_t lru_max;   // max items
-  double lru_midpoint;
+public:
+  LRU() : num_pinned(0), midpoint(0.6) {}
 
-  friend class LRUObject;
-  //friend class MDCache; // hack
-  
- public:
-  LRU(int max = 0) {
-    lru_num = 0;
-    lru_num_pinned = 0;
-    lru_midpoint = .6;
-    lru_max = max;
-  }
+  uint64_t lru_get_size() const { return lru_get_top()+lru_get_bot()+lru_get_pintail(); }
+  uint64_t lru_get_top() const { return top.size(); }
+  uint64_t lru_get_bot() const{ return bottom.size(); }
+  uint64_t lru_get_pintail() const { return pintail.size(); }
+  uint64_t lru_get_num_pinned() const { return num_pinned; }
 
-  uint32_t lru_get_size() const { return lru_num; }
-  uint32_t lru_get_top() const { return lru_top.get_length(); }
-  uint32_t lru_get_bot() const{ return lru_bot.get_length(); }
-  uint32_t lru_get_pintail() const { return lru_pintail.get_length(); }
-  uint32_t lru_get_max() const { return lru_max; }
-  uint32_t lru_get_num_pinned() const { return lru_num_pinned; }
-
-  void lru_set_max(uint32_t m) { lru_max = m; }
-  void lru_set_midpoint(float f) { lru_midpoint = f; }
+  void lru_set_midpoint(double f) { midpoint = fmin(1.0, fmax(0.0, f)); }
   
   void lru_clear() {
-    lru_top.clear();
-    lru_bot.clear();
-    lru_pintail.clear();
-    lru_num = 0;
+    while (!top.empty()) {
+      lru_remove(top.front());
+    }
+    while (!bottom.empty()) {
+      lru_remove(bottom.front());
+    }
+    while (!pintail.empty()) {
+      lru_remove(pintail.front());
+    }
+    assert(num_pinned == 0);
   }
 
   // insert at top of lru
   void lru_insert_top(LRUObject *o) {
-    //assert(!o->lru_in_lru);
-    //o->lru_in_lru = true;
     assert(!o->lru);
     o->lru = this;
-    lru_top.insert_head( o );
-    lru_num++;
-    if (o->lru_pinned) lru_num_pinned++;
-    lru_adjust();
+    top.push_front(&o->lru_link);
+    if (o->lru_pinned) num_pinned++;
+    adjust();
   }
 
   // insert at mid point in lru
   void lru_insert_mid(LRUObject *o) {
-    //assert(!o->lru_in_lru);
-    //o->lru_in_lru = true;
     assert(!o->lru);
     o->lru = this;
-    lru_bot.insert_head(o);
-    lru_num++;
-    if (o->lru_pinned) lru_num_pinned++;
+    bottom.push_front(&o->lru_link);
+    if (o->lru_pinned) num_pinned++;
+    adjust();
   }
 
   // insert at bottom of lru
   void lru_insert_bot(LRUObject *o) {
     assert(!o->lru);
     o->lru = this;
-    lru_bot.insert_tail(o);
-    lru_num++;
-    if (o->lru_pinned) lru_num_pinned++;
+    bottom.push_back(&o->lru_link);
+    if (o->lru_pinned) num_pinned++;
+    adjust();
   }
-
-  /*
-  // insert at bottom of lru
-  void lru_insert_pintail(LRUObject *o) {
-    assert(!o->lru);
-    o->lru = this;
-    
-    assert(o->lru_pinned);
-
-    lru_pintail.insert_head(o);
-    lru_num++;
-    lru_num_pinned += o->lru_pinned;
-  }
-  */
-
-  
-
-
-  // adjust top/bot balance, as necessary
-  void lru_adjust() {
-    if (!lru_max) return;
-
-    unsigned toplen = lru_top.get_length();
-    unsigned topwant = (unsigned)(lru_midpoint * ((double)lru_max - lru_num_pinned));
-    while (toplen > 0 && 
-           toplen > topwant) {
-      // remove from tail of top, stick at head of bot
-      // FIXME: this could be way more efficient by moving a whole chain of items.
-
-      LRUObject *o = lru_top.get_tail();
-      lru_top.remove(o);
-      lru_bot.insert_head(o);
-      toplen--;
-    }
-  }
-
 
   // remove an item
   LRUObject *lru_remove(LRUObject *o) {
-    // not in list
-    //assert(o->lru_in_lru);
-    //if (!o->lru_in_lru) return o;  // might have expired and been removed that way.
     if (!o->lru) return o;
-
-    assert((o->lru_list == &lru_pintail) ||
-           (o->lru_list == &lru_top) ||
-           (o->lru_list == &lru_bot));
-    o->lru_list->remove(o);
-
-    lru_num--;
-    if (o->lru_pinned) lru_num_pinned--;
-    o->lru = 0;
+    auto list = o->lru_link.get_list();
+    assert(list == &top || list == &bottom || list == &pintail);
+    o->lru_link.remove_myself();
+    if (o->lru_pinned) num_pinned--;
+    o->lru = nullptr;
+    adjust();
     return o;
   }
 
   // touch item -- move to head of lru
   bool lru_touch(LRUObject *o) {
-    lru_remove(o);
-    lru_insert_top(o);
+    if (!o->lru) {
+      lru_insert_top(o);
+    } else {
+      assert(o->lru == this);
+      auto list = o->lru_link.get_list();
+      assert(list == &top || list == &bottom || list == &pintail);
+      top.push_front(&o->lru_link);
+      adjust();
+    }
     return true;
   }
 
   // touch item -- move to midpoint (unless already higher)
   bool lru_midtouch(LRUObject *o) {
-    if (o->lru_list == &lru_top) return false;
-    
-    lru_remove(o);
-    lru_insert_mid(o);
+    if (!o->lru) {
+      lru_insert_mid(o);
+    } else {
+      assert(o->lru == this);
+      auto list = o->lru_link.get_list();
+      assert(list == &top || list == &bottom || list == &pintail);
+      if (list == &top) return false;
+      bottom.push_front(&o->lru_link);
+      adjust();
+    }
     return true;
   }
 
   // touch item -- move to bottom
   bool lru_bottouch(LRUObject *o) {
-    lru_remove(o);
-    lru_insert_bot(o);
+    if (!o->lru) {
+      lru_insert_bot(o);
+    } else {
+      assert(o->lru == this);
+      auto list = o->lru_link.get_list();
+      assert(list == &top || list == &bottom || list == &pintail);
+      bottom.push_back(&o->lru_link);
+      adjust();
+    }
     return true;
   }
 
   void lru_touch_entire_pintail() {
     // promote entire pintail to the top lru
-    while (lru_pintail.get_length() > 0) {
-      LRUObject *o = lru_pintail.get_head();
-      lru_pintail.remove(o);
-      lru_top.insert_tail(o);
+    while (pintail.size() > 0) {
+      top.push_back(&pintail.front()->lru_link);
+      adjust();
     }
   }
 
-
   // expire -- expire a single item
   LRUObject *lru_get_next_expire() {
-    LRUObject *p;
-    
     // look through tail of bot
-    while (lru_bot.get_length()) {
-      p = lru_bot.get_tail();
+    while (bottom.size()) {
+      LRUObject *p = bottom.back();
       if (!p->lru_pinned) return p;
 
       // move to pintail
-      lru_bot.remove(p);
-      lru_pintail.insert_head(p);
+      pintail.push_front(&p->lru_link);
+      adjust();
     }
 
     // ok, try head then
-    while (lru_top.get_length()) {
-      p = lru_top.get_tail();
+    while (top.size()) {
+      LRUObject *p = top.back();
       if (!p->lru_pinned) return p;
 
       // move to pintail
-      lru_top.remove(p);
-      lru_pintail.insert_head(p);
+      pintail.push_front(&p->lru_link);
+      adjust();
     }
     
     // no luck!
@@ -307,32 +188,55 @@ class LRU {
     return NULL;
   }
 
-
   void lru_status() {
-    //generic_dout(10) << "lru: " << lru_num << " items, " << lru_top.get_length() << " top, " << lru_bot.get_length() << " bot, " << lru_pintail.get_length() << " pintail" << dendl;
+    //generic_dout(10) << "lru: " << lru_get_size() << " items, " << top.size() << " top, " << bottom.size() << " bot, " << pintail.size() << " pintail" << dendl;
   }
 
+protected:
+  // adjust top/bot balance, as necessary
+  void adjust() {
+    uint64_t toplen = top.size();
+    uint64_t topwant = (midpoint * (double)(lru_get_size() - num_pinned));
+    /* move items from below midpoint (bottom) to top: move midpoint forward */
+    for (uint64_t i = toplen; i < topwant; i++) {
+      top.push_back(&bottom.front()->lru_link);
+    }
+    /* or: move items from above midpoint (top) to bottom: move midpoint backwards */
+    for (uint64_t i = toplen; i > topwant; i--) {
+      bottom.push_front(&top.back()->lru_link);
+    }
+  }
+
+  uint64_t num_pinned;
+  double midpoint;
+
+  friend class LRUObject;
+private:
+  typedef xlist<LRUObject *> LRUList;
+  LRUList top, bottom, pintail;
 };
 
+inline LRUObject::~LRUObject() {
+  if (lru) {
+    lru->lru_remove(this);
+  }
+}
 
 inline void LRUObject::lru_pin() {
   if (lru && !lru_pinned) {
-    lru->lru_num_pinned++;
-    lru->lru_adjust();
+    lru->num_pinned++;
   }
   lru_pinned = true;
 }
 
 inline void LRUObject::lru_unpin() {
   if (lru && lru_pinned) {
-    lru->lru_num_pinned--;
+    lru->num_pinned--;
 
     // move from pintail -> bot
-    if (lru_list == &lru->lru_pintail) {
-      lru->lru_pintail.remove(this);
-      lru->lru_bot.insert_tail(this);
+    if (lru_link.get_list() == &lru->pintail) {
+      lru->lru_bottouch(this);
     }
-    lru->lru_adjust();
   }
   lru_pinned = false;
 }

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -160,6 +160,7 @@ namespace mempool {
   f(osdmap)			      \
   f(osdmap_mapping)		      \
   f(pgmap)			      \
+  f(mds_co)			      \
   f(unittest_1)			      \
   f(unittest_2)
 

--- a/src/include/mempool.h
+++ b/src/include/mempool.h
@@ -100,6 +100,12 @@ BlueStore::Onode, we need to do
 (This is just because we need to name some static variables and we
 can't use :: in a variable name.)
 
+XXX Note: the new operator hard-codes the allocation size to the size of the
+object given in MEMPOOL_DEFINE_OBJECT_FACTORY. For this reason, you cannot
+incorporate mempools into a base class without also defining a helper/factory
+for the child class as well (as the base class is usually smaller than the
+child class).
+
 In order to use the STL containers, simply use the namespaced variant
 of the container type.  For example,
 

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -19,6 +19,8 @@
 
 int64_t unit_to_bytesize(string val, ostream *pss);
 
+std::string bytes2str(uint64_t count);
+
 struct ceph_data_stats
 {
   uint64_t byte_total;

--- a/src/include/xlist.h
+++ b/src/include/xlist.h
@@ -63,7 +63,7 @@ public:
 
 private:
   item *_front, *_back;
-  int _size;
+  size_t _size;
 
 public:
   xlist(const xlist& other) {
@@ -79,7 +79,7 @@ public:
     assert(_back == 0);
   }
 
-  int size() const {
+  size_t size() const {
     assert((bool)_front == (bool)_size);
     return _size;
   }

--- a/src/mds/Beacon.cc
+++ b/src/mds/Beacon.cc
@@ -15,6 +15,7 @@
 
 #include "common/dout.h"
 #include "common/HeartbeatMap.h"
+
 #include "include/stringify.h"
 #include "include/util.h"
 
@@ -475,11 +476,10 @@ void Beacon::notify_health(MDSRank const *mds)
   }
 
   // Report if we have significantly exceeded our cache size limit
-  if (mds->mdcache->get_cache_size() >
-        g_conf->mds_cache_size * g_conf->mds_health_cache_threshold) {
+  if (mds->mdcache->cache_overfull()) {
     std::ostringstream oss;
-    oss << "Too many inodes in cache (" << mds->mdcache->get_cache_size()
-        << "/" << g_conf->mds_cache_size << "), "
+    oss << "MDS cache is too large (" << bytes2str(mds->mdcache->cache_size())
+        << "/" << bytes2str(mds->mdcache->cache_limit_memory()) << "); "
         << mds->mdcache->num_inodes_with_caps << " inodes in use by clients, "
         << mds->mdcache->get_num_strays() << " stray files";
 

--- a/src/mds/CDentry.cc
+++ b/src/mds/CDentry.cc
@@ -620,3 +620,5 @@ std::string CDentry::linkage_t::get_remote_d_type_string() const
     default: ceph_abort(); return "";
   }
 }
+
+MEMPOOL_DEFINE_OBJECT_FACTORY(CDentry, co_dentry, mds_co);

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -49,6 +49,7 @@ bool operator<(const CDentry& l, const CDentry& r);
 // dentry
 class CDentry : public MDSCacheObject, public LRUObject, public Counter<CDentry> {
 public:
+  MEMPOOL_CLASS_HELPERS();
   friend class CDir;
 
   struct linkage_t {

--- a/src/mds/CDentry.h
+++ b/src/mds/CDentry.h
@@ -266,7 +266,7 @@ public:
     ::encode(version, bl);
     ::encode(projected_version, bl);
     ::encode(lock, bl);
-    ::encode(replica_map, bl);
+    ::encode(get_replicas(), bl);
     get(PIN_TEMPEXPORTING);
   }
   void finish_export() {
@@ -288,14 +288,14 @@ public:
     ::decode(version, blp);
     ::decode(projected_version, blp);
     ::decode(lock, blp);
-    ::decode(replica_map, blp);
+    ::decode(get_replicas(), blp);
 
     // twiddle
     state &= MASK_STATE_IMPORT_KEPT;
     state_set(CDentry::STATE_AUTH);
     if (nstate & STATE_DIRTY)
       _mark_dirty(ls);
-    if (!replica_map.empty())
+    if (is_replicated())
       get(PIN_REPLICATED);
     replica_nonce = 0;
   }

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -932,7 +932,7 @@ void CDir::finish_old_fragment(list<MDSInternalContextBase*>& waiters, bool repl
 
 void CDir::init_fragment_pins()
 {
-  if (!replica_map.empty())
+  if (is_replicated())
     get(PIN_REPLICATED);
   if (state_test(STATE_DIRTY))
     get(PIN_DIRTY);
@@ -976,7 +976,7 @@ void CDir::split(int bits, list<CDir*>& subs, list<MDSInternalContextBase*>& wai
   for (list<frag_t>::iterator p = frags.begin(); p != frags.end(); ++p) {
     CDir *f = new CDir(inode, *p, cache, is_auth());
     f->state_set(state & (MASK_STATE_FRAGMENT_KEPT | STATE_COMPLETE));
-    f->replica_map = replica_map;
+    f->get_replicas() = get_replicas();
     f->dir_auth = dir_auth;
     f->init_fragment_pins();
     f->set_version(get_version());
@@ -1085,12 +1085,10 @@ void CDir::merge(list<CDir*>& subs, list<MDSInternalContextBase*>& waiters, bool
       steal_dentry(dir->items.begin()->second);
     
     // merge replica map
-    for (compact_map<mds_rank_t,unsigned>::iterator p = dir->replicas_begin();
-	 p != dir->replicas_end();
-	 ++p) {
-      unsigned cur = replica_map[p->first];
-      if (p->second > cur)
-	replica_map[p->first] = p->second;
+    for (const auto &p : dir->get_replicas()) {
+      unsigned cur = get_replicas()[p.first];
+      if (p.second > cur)
+	get_replicas()[p.first] = p.second;
     }
 
     // merge version
@@ -2432,7 +2430,7 @@ void CDir::encode_export(bufferlist& bl)
   ::encode(pop_auth_subtree, bl);
 
   ::encode(dir_rep_by, bl);  
-  ::encode(replica_map, bl);
+  ::encode(get_replicas(), bl);
 
   get(PIN_TEMPEXPORTING);
 }
@@ -2473,8 +2471,8 @@ void CDir::decode_import(bufferlist::iterator& blp, utime_t now, LogSegment *ls)
   pop_auth_subtree_nested.add(now, cache->decayrate, pop_auth_subtree);
 
   ::decode(dir_rep_by, blp);
-  ::decode(replica_map, blp);
-  if (!replica_map.empty()) get(PIN_REPLICATED);
+  ::decode(get_replicas(), blp);
+  if (is_replicated()) get(PIN_REPLICATED);
 
   replica_nonce = 0;  // no longer defined
 

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -3293,3 +3293,4 @@ bool CDir::should_split_fast() const
   return effective_size > fast_limit;
 }
 
+MEMPOOL_DEFINE_OBJECT_FACTORY(CDir, co_dir, mds_co);

--- a/src/mds/CDir.h
+++ b/src/mds/CDir.h
@@ -46,6 +46,7 @@ class CDir : public MDSCacheObject, public Counter<CDir> {
   friend ostream& operator<<(ostream& out, const class CDir& dir);
 
 public:
+  MEMPOOL_CLASS_HELPERS();
   // -- pins --
   static const int PIN_DNWAITER =     1;
   static const int PIN_INOWAITER =    2;

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -3622,7 +3622,7 @@ void CInode::encode_export(bufferlist& bl)
 
   ::encode(pop, bl);
 
-  ::encode(replica_map, bl);
+  ::encode(get_replicas(), bl);
 
   // include scatterlock info for any bounding CDirs
   bufferlist bounding;
@@ -3687,8 +3687,8 @@ void CInode::decode_import(bufferlist::iterator& p,
 
   ::decode(pop, ceph_clock_now(), p);
 
-  ::decode(replica_map, p);
-  if (!replica_map.empty())
+  ::decode(get_replicas(), p);
+  if (is_replicated())
     get(PIN_REPLICATED);
   replica_nonce = 0;
 

--- a/src/mds/CInode.cc
+++ b/src/mds/CInode.cc
@@ -4523,3 +4523,5 @@ bool CInode::is_exportable(mds_rank_t dest) const
     return true;
   }
 }
+
+MEMPOOL_DEFINE_OBJECT_FACTORY(CInode, co_inode, mds_co);

--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -143,6 +143,7 @@ WRITE_CLASS_ENCODER_FEATURES(InodeStoreBare)
 // cached inode wrapper
 class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CInode> {
  public:
+  MEMPOOL_CLASS_HELPERS();
   // -- pins --
   static const int PIN_DIRFRAG =         -1; 
   static const int PIN_CAPS =             2;  // client caps

--- a/src/mds/Locker.cc
+++ b/src/mds/Locker.cc
@@ -130,28 +130,24 @@ void Locker::tick()
 
 void Locker::send_lock_message(SimpleLock *lock, int msg)
 {
-  for (compact_map<mds_rank_t,unsigned>::iterator it = lock->get_parent()->replicas_begin();
-       it != lock->get_parent()->replicas_end();
-       ++it) {
+  for (const auto &it : lock->get_parent()->get_replicas()) {
     if (mds->is_cluster_degraded() &&
-	mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
+	mds->mdsmap->get_state(it.first) < MDSMap::STATE_REJOIN)
       continue;
     MLock *m = new MLock(lock, msg, mds->get_nodeid());
-    mds->send_message_mds(m, it->first);
+    mds->send_message_mds(m, it.first);
   }
 }
 
 void Locker::send_lock_message(SimpleLock *lock, int msg, const bufferlist &data)
 {
-  for (compact_map<mds_rank_t,unsigned>::iterator it = lock->get_parent()->replicas_begin();
-       it != lock->get_parent()->replicas_end();
-       ++it) {
+  for (const auto &it : lock->get_parent()->get_replicas()) {
     if (mds->is_cluster_degraded() &&
-	mds->mdsmap->get_state(it->first) < MDSMap::STATE_REJOIN) 
+	mds->mdsmap->get_state(it.first) < MDSMap::STATE_REJOIN)
       continue;
     MLock *m = new MLock(lock, msg, mds->get_nodeid());
     m->set_data(data);
-    mds->send_message_mds(m, it->first);
+    mds->send_message_mds(m, it.first);
   }
 }
 

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -202,10 +202,8 @@ MDCache::MDCache(MDSRank *m, PurgeQueue &purge_queue_) :
   cap_imports_num_opening = 0;
 
   opening_root = open = false;
-  lru.lru_set_max(g_conf->mds_cache_size);
   lru.lru_set_midpoint(g_conf->mds_cache_mid);
 
-  bottom_lru.lru_set_max(0);
   bottom_lru.lru_set_midpoint(0);
 
   decayrate.set_halflife(g_conf->mds_decay_halflife);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -11820,6 +11820,18 @@ void MDCache::show_cache()
     show_func(p.second);
 }
 
+int MDCache::cache_status(Formatter *f)
+{
+  f->open_object_section("cache");
+
+  f->open_object_section("pool");
+  mempool::get_pool(mempool::mds_co::id).dump(f);
+  f->close_section();
+
+  f->close_section();
+  return 0;
+}
+
 int MDCache::dump_cache(std::string const &file_name)
 {
   return dump_cache(file_name.c_str(), NULL);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -4538,9 +4538,10 @@ void MDCache::rejoin_scour_survivor_replicas(mds_rank_t from, MMDSCacheRejoin *a
 	 p != dfs.end();
 	 ++p) {
       CDir *dir = *p;
+      if (!dir->is_auth())
+	continue;
       
-      if (dir->is_auth() &&
-	  dir->is_replica(from) &&
+      if (dir->is_replica(from) &&
 	  (ack == NULL || ack->strong_dirfrags.count(dir->dirfrag()) == 0)) {
 	dir->remove_replica(from);
 	dout(10) << " rem " << *dir << dendl;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1146,6 +1146,8 @@ public:
   int dump_cache(Formatter *f);
   int dump_cache(const std::string& dump_root, int depth, Formatter *f);
 
+  int cache_status(Formatter *f);
+
   void dump_resolve_status(Formatter *f) const;
   void dump_rejoin_status(Formatter *f) const;
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -672,8 +672,6 @@ public:
   CInode *get_root() { return root; }
   CInode *get_myin() { return myin; }
 
-  // cache
-  void set_cache_size(size_t max) { lru.lru_set_max(max); }
   size_t get_cache_size() { return lru.lru_get_size(); }
 
   // trimming

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -147,6 +147,38 @@ class MDCache {
   bool exceeded_size_limit;
 
 public:
+  static uint64_t cache_limit_inodes(void) {
+    return g_conf->get_val<int64_t>("mds_cache_size");
+  }
+  static uint64_t cache_limit_memory(void) {
+    return g_conf->get_val<uint64_t>("mds_cache_memory_limit");
+  }
+  static double cache_reservation(void) {
+    return g_conf->get_val<double>("mds_cache_reservation");
+  }
+  static double cache_mid(void) {
+    return g_conf->get_val<double>("mds_cache_mid");
+  }
+  static double cache_health_threshold(void) {
+    return g_conf->get_val<double>("mds_health_cache_threshold");
+  }
+  double cache_toofull_ratio(void) const {
+    uint64_t inode_limit = cache_limit_inodes();
+    double inode_reserve = inode_limit*(1.0-cache_reservation());
+    double memory_reserve = cache_limit_memory()*(1.0-cache_reservation());
+    return fmax(0.0, fmax((cache_size()-memory_reserve)/memory_reserve, inode_limit == 0 ? 0.0 : (CInode::count()-inode_reserve)/inode_reserve));
+  }
+  bool cache_toofull(void) const {
+    return cache_toofull_ratio() > 0.0;
+  }
+  uint64_t cache_size(void) const {
+    return mempool::get_pool(mempool::mds_co::id).allocated_bytes();
+  }
+  bool cache_overfull(void) const {
+    uint64_t inode_limit = cache_limit_inodes();
+    return (inode_limit > 0 && CInode::count() > inode_limit*cache_health_threshold()) || (cache_size() > cache_limit_memory()*cache_health_threshold());
+  }
+
   void advance_stray() {
     stray_index = (stray_index+1)%NUM_STRAY;
   }
@@ -675,7 +707,9 @@ public:
   size_t get_cache_size() { return lru.lru_get_size(); }
 
   // trimming
-  bool trim(int max=-1, int count=-1);   // trim cache
+  bool trim(uint64_t count=0);
+private:
+  void trim_lru(uint64_t count, map<mds_rank_t, MCacheExpire*>& expiremap);
   bool trim_dentry(CDentry *dn, map<mds_rank_t, MCacheExpire*>& expiremap);
   void trim_dirfrag(CDir *dir, CDir *con,
 		    map<mds_rank_t, MCacheExpire*>& expiremap);
@@ -683,6 +717,7 @@ public:
 		  map<mds_rank_t,class MCacheExpire*>& expiremap);
   void send_expire_messages(map<mds_rank_t, MCacheExpire*>& expiremap);
   void trim_non_auth();      // trim out trimmable non-auth items
+public:
   bool trim_non_auth_subtree(CDir *directory);
   void standby_trim_segment(LogSegment *ls);
   void try_trim_non_auth_subtree(CDir *dir);

--- a/src/mds/MDLog.cc
+++ b/src/mds/MDLog.cc
@@ -1446,7 +1446,7 @@ void MDLog::standby_trim_segments()
 
   if (removed_segment) {
     dout(20) << " calling mdcache->trim!" << dendl;
-    mds->mdcache->trim(-1);
+    mds->mdcache->trim();
   } else {
     dout(20) << " removed no segments!" << dendl;
   }

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -8,7 +8,7 @@
 uint64_t MDSCacheObject::last_wait_seq = 0;
 
 void MDSCacheObject::finish_waiting(uint64_t mask, int result) {
-  list<MDSInternalContextBase*> finished;
+  std::list<MDSInternalContextBase*> finished;
   take_waiting(mask, finished);
   finish_contexts(g_ceph_context, finished, result);
 }

--- a/src/mds/MDSCacheObject.cc
+++ b/src/mds/MDSCacheObject.cc
@@ -21,12 +21,10 @@ void MDSCacheObject::dump(Formatter *f) const
   f->open_object_section("auth_state");
   {
     f->open_object_section("replicas");
-    const compact_map<mds_rank_t,unsigned>& replicas = get_replicas();
-    for (compact_map<mds_rank_t,unsigned>::const_iterator i = replicas.begin();
-         i != replicas.end(); ++i) {
+    for (const auto &it : get_replicas()) {
       std::ostringstream rank_str;
-      rank_str << i->first;
-      f->dump_int(rank_str.str().c_str(), i->second);
+      rank_str << it.first;
+      f->dump_int(rank_str.str().c_str(), it.second);
     }
     f->close_section();
   }

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -1,17 +1,17 @@
 #ifndef CEPH_MDSCACHEOBJECT_H
 #define CEPH_MDSCACHEOBJECT_H
 
-#include <set>
-#include <map>
 #include <ostream>
-using namespace std;
-
 
 #include "common/config.h"
+
+#include "include/Context.h"
+#include "include/alloc_ptr.h"
 #include "include/assert.h"
+#include "include/mempool.h"
 #include "include/types.h"
 #include "include/xlist.h"
-#include "include/Context.h"
+
 #include "mdstypes.h"
 
 #define MDS_REF_SET      // define me for improved debug output, sanity checking
@@ -145,7 +145,7 @@ class MDSCacheObject {
 protected:
   __s32      ref;       // reference count
 #ifdef MDS_REF_SET
-  std::map<int,int> ref_map;
+  mempool::mds_co::map<int,int> ref_map;
 #endif
 
  public:
@@ -226,7 +226,7 @@ protected:
   int auth_pins;
   int nested_auth_pins;
 #ifdef MDS_AUTHPIN_SET
-  multiset<void*> auth_pin_set;
+  mempool::mds_co::multiset<void*> auth_pin_set;
 #endif
 
   public:
@@ -253,43 +253,46 @@ protected:
   // replication (across mds cluster)
  protected:
   unsigned		replica_nonce; // [replica] defined on replica
-  compact_map<mds_rank_t,unsigned>	replica_map;   // [auth] mds -> nonce
+  typedef mempool::mds_co::map<mds_rank_t,unsigned> replica_map_type;
+  alloc_ptr<replica_map_type> replica_map;   // [auth] mds -> nonce
 
  public:
-  bool is_replicated() const { return !replica_map.empty(); }
-  bool is_replica(mds_rank_t mds) const { return replica_map.count(mds); }
-  int num_replicas() const { return replica_map.size(); }
+  bool is_replicated() const { return !get_replicas().empty(); }
+  bool is_replica(mds_rank_t mds) const { return get_replicas().count(mds); }
+  int num_replicas() const { return get_replicas().size(); }
   unsigned add_replica(mds_rank_t mds) {
-    if (replica_map.count(mds)) 
-      return ++replica_map[mds];  // inc nonce
-    if (replica_map.empty()) 
+    if (get_replicas().count(mds))
+      return ++get_replicas()[mds];  // inc nonce
+    if (get_replicas().empty())
       get(PIN_REPLICATED);
-    return replica_map[mds] = 1;
+    return get_replicas()[mds] = 1;
   }
   void add_replica(mds_rank_t mds, unsigned nonce) {
-    if (replica_map.empty()) 
+    if (get_replicas().empty())
       get(PIN_REPLICATED);
-    replica_map[mds] = nonce;
+    get_replicas()[mds] = nonce;
   }
   unsigned get_replica_nonce(mds_rank_t mds) {
-    assert(replica_map.count(mds));
-    return replica_map[mds];
+    assert(get_replicas().count(mds));
+    return get_replicas()[mds];
   }
   void remove_replica(mds_rank_t mds) {
-    assert(replica_map.count(mds));
-    replica_map.erase(mds);
-    if (replica_map.empty())
+    assert(get_replicas().count(mds));
+    get_replicas().erase(mds);
+    if (get_replicas().empty()) {
       put(PIN_REPLICATED);
+      replica_map.reset();
+    }
   }
   void clear_replica_map() {
-    if (!replica_map.empty())
+    if (!get_replicas().empty())
       put(PIN_REPLICATED);
-    replica_map.clear();
+    replica_map.reset();
   }
-  compact_map<mds_rank_t,unsigned>& get_replicas() { return replica_map; }
-  const compact_map<mds_rank_t,unsigned>& get_replicas() const { return replica_map; }
+  replica_map_type& get_replicas() { return *replica_map; }
+  const replica_map_type& get_replicas() const { return *replica_map; }
   void list_replicas(std::set<mds_rank_t>& ls) const {
-    for (const auto &p : replica_map) {
+    for (const auto &p : get_replicas()) {
       ls.insert(p.first);
     }
   }
@@ -301,7 +304,7 @@ protected:
   // ---------------------------------------------
   // waiting
  protected:
-  compact_multimap<uint64_t, pair<uint64_t, MDSInternalContextBase*> > waiting;
+  alloc_ptr<mempool::mds_co::multimap<uint64_t, std::pair<uint64_t, MDSInternalContextBase*>>> waiting;
   static uint64_t last_wait_seq;
 
  public:
@@ -311,8 +314,8 @@ protected:
       while (min & (min-1))  // if more than one bit is set
 	min &= min-1;        //  clear LSB
     }
-    for (auto p = waiting.lower_bound(min);
-	 p != waiting.end();
+    for (auto p = waiting->lower_bound(min);
+	 p != waiting->end();
 	 ++p) {
       if (p->first & mask) return true;
       if (p->first > mask) return false;
@@ -320,7 +323,7 @@ protected:
     return false;
   }
   virtual void add_waiter(uint64_t mask, MDSInternalContextBase *c) {
-    if (waiting.empty())
+    if (waiting->empty())
       get(PIN_WAITER);
 
     uint64_t seq = 0;
@@ -328,7 +331,7 @@ protected:
       seq = ++last_wait_seq;
       mask &= ~WAIT_ORDERED;
     }
-    waiting.insert(pair<uint64_t, pair<uint64_t, MDSInternalContextBase*> >(
+    waiting->insert(pair<uint64_t, pair<uint64_t, MDSInternalContextBase*> >(
 			    mask,
 			    pair<uint64_t, MDSInternalContextBase*>(seq, c)));
 //    pdout(10,g_conf->debug_mds) << (mdsco_db_line_prefix(this)) 
@@ -337,41 +340,40 @@ protected:
 //			       << dendl;
     
   }
-  virtual void take_waiting(uint64_t mask, list<MDSInternalContextBase*>& ls) {
-    if (waiting.empty()) return;
+  virtual void take_waiting(uint64_t mask, std::list<MDSInternalContextBase*>& ls) {
+    if (waiting->empty()) return;
 
     // process ordered waiters in the same order that they were added.
     std::map<uint64_t, MDSInternalContextBase*> ordered_waiters;
 
-    for (auto it = waiting.begin();
-	 it != waiting.end(); ) {
+    for (auto it = waiting->begin(); it != waiting->end(); ) {
       if (it->first & mask) {
-
-	if (it->second.first > 0)
-	  ordered_waiters.insert(it->second);
-	else
-	  ls.push_back(it->second.second);
+	    if (it->second.first > 0) {
+	      ordered_waiters.insert(it->second);
+	    } else {
+	      ls.push_back(it->second.second);
+        }
 //	pdout(10,g_conf->debug_mds) << (mdsco_db_line_prefix(this))
 //				   << "take_waiting mask " << hex << mask << dec << " took " << it->second
 //				   << " tag " << hex << it->first << dec
 //				   << " on " << *this
 //				   << dendl;
-	waiting.erase(it++);
+        waiting->erase(it++);
       } else {
 //	pdout(10,g_conf->debug_mds) << "take_waiting mask " << hex << mask << dec << " SKIPPING " << it->second
 //				   << " tag " << hex << it->first << dec
 //				   << " on " << *this 
 //				   << dendl;
-	++it;
+	      ++it;
       }
     }
-    for (auto it = ordered_waiters.begin();
-	 it != ordered_waiters.end();
-	 ++it) {
+    for (auto it = ordered_waiters.begin(); it != ordered_waiters.end(); ++it) {
       ls.push_back(it->second);
     }
-    if (waiting.empty())
+    if (waiting->empty()) {
       put(PIN_WAITER);
+      waiting.release();
+    }
   }
   void finish_waiting(uint64_t mask, int result = 0);
 

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -286,14 +286,12 @@ protected:
       put(PIN_REPLICATED);
     replica_map.clear();
   }
-  compact_map<mds_rank_t,unsigned>::iterator replicas_begin() { return replica_map.begin(); }
-  compact_map<mds_rank_t,unsigned>::iterator replicas_end() { return replica_map.end(); }
+  compact_map<mds_rank_t,unsigned>& get_replicas() { return replica_map; }
   const compact_map<mds_rank_t,unsigned>& get_replicas() const { return replica_map; }
   void list_replicas(std::set<mds_rank_t>& ls) const {
-    for (compact_map<mds_rank_t,unsigned>::const_iterator p = replica_map.begin();
-	 p != replica_map.end();
-	 ++p)
-      ls.insert(p->first);
+    for (const auto &p : replica_map) {
+      ls.insert(p.first);
+    }
   }
 
   unsigned get_replica_nonce() const { return replica_nonce; }

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -301,7 +301,7 @@ protected:
 
   // ---------------------------------------------
   // waiting
- protected:
+ private:
   alloc_ptr<mempool::mds_co::multimap<uint64_t, std::pair<uint64_t, MDSInternalContextBase*>>> waiting;
   static uint64_t last_wait_seq;
 
@@ -310,13 +310,13 @@ protected:
     if (!min) {
       min = mask;
       while (min & (min-1))  // if more than one bit is set
-	min &= min-1;        //  clear LSB
+        min &= min-1;        //  clear LSB
     }
-    for (auto p = waiting->lower_bound(min);
-	 p != waiting->end();
-	 ++p) {
-      if (p->first & mask) return true;
-      if (p->first > mask) return false;
+    if (waiting) {
+      for (auto p = waiting->lower_bound(min); p != waiting->end(); ++p) {
+        if (p->first & mask) return true;
+        if (p->first > mask) return false;
+      }
     }
     return false;
   }
@@ -339,7 +339,7 @@ protected:
     
   }
   virtual void take_waiting(uint64_t mask, std::list<MDSInternalContextBase*>& ls) {
-    if (waiting->empty()) return;
+    if (!waiting || waiting->empty()) return;
 
     // process ordered waiters in the same order that they were added.
     std::map<uint64_t, MDSInternalContextBase*> ordered_waiters;

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -253,8 +253,8 @@ protected:
   // replication (across mds cluster)
  protected:
   unsigned		replica_nonce; // [replica] defined on replica
-  typedef mempool::mds_co::map<mds_rank_t,unsigned> replica_map_type;
-  alloc_ptr<replica_map_type> replica_map;   // [auth] mds -> nonce
+  typedef compact_map<mds_rank_t,unsigned> replica_map_type;
+  replica_map_type replica_map;   // [auth] mds -> nonce
 
  public:
   bool is_replicated() const { return !get_replicas().empty(); }
@@ -281,16 +281,14 @@ protected:
     get_replicas().erase(mds);
     if (get_replicas().empty()) {
       put(PIN_REPLICATED);
-      replica_map.reset();
     }
   }
   void clear_replica_map() {
     if (!get_replicas().empty())
       put(PIN_REPLICATED);
-    replica_map.reset();
   }
-  replica_map_type& get_replicas() { return *replica_map; }
-  const replica_map_type& get_replicas() const { return *replica_map; }
+  replica_map_type& get_replicas() { return replica_map; }
+  const replica_map_type& get_replicas() const { return replica_map; }
   void list_replicas(std::set<mds_rank_t>& ls) const {
     for (const auto &p : get_replicas()) {
       ls.insert(p.first);

--- a/src/mds/MDSCacheObject.h
+++ b/src/mds/MDSCacheObject.h
@@ -286,6 +286,7 @@ protected:
   void clear_replica_map() {
     if (!get_replicas().empty())
       put(PIN_REPLICATED);
+    replica_map.clear();
   }
   replica_map_type& get_replicas() { return replica_map; }
   const replica_map_type& get_replicas() const { return replica_map; }

--- a/src/mds/MDSDaemon.cc
+++ b/src/mds/MDSDaemon.cc
@@ -242,6 +242,11 @@ void MDSDaemon::set_up_admin_socket()
                                      asok_hook,
                                      "dump metadata cache (optionally to a file)");
   assert(r == 0);
+  r = admin_socket->register_command("cache status",
+                                     "cache status",
+                                     asok_hook,
+                                     "show cache status");
+  assert(r == 0);
   r = admin_socket->register_command("dump tree",
 				     "dump tree "
 				     "name=root,type=CephString,req=true "
@@ -316,6 +321,7 @@ void MDSDaemon::clean_up_admin_socket()
   admin_socket->unregister_command("flush_path");
   admin_socket->unregister_command("export dir");
   admin_socket->unregister_command("dump cache");
+  admin_socket->unregister_command("cache status");
   admin_socket->unregister_command("dump tree");
   admin_socket->unregister_command("session evict");
   admin_socket->unregister_command("osdmap barrier");

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1938,6 +1938,12 @@ bool MDSRankDispatcher::handle_asok_command(
     if (r != 0) {
       ss << "Failed to dump cache: " << cpp_strerror(r);
     }
+  } else if (command == "cache status") {
+    Mutex::Locker l(mds_lock);
+    int r = mdcache->cache_status(f);
+    if (r != 0) {
+      ss << "Failed to get cache status: " << cpp_strerror(r);
+    }
   } else if (command == "dump tree") {
     string root;
     int64_t depth;

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -2007,7 +2007,7 @@ void Migrator::export_finish(CDir *dir)
   cache->show_subtrees();
   audit();
 
-  cache->trim(-1, num_dentries); // try trimming exported dentries
+  cache->trim(num_dentries); // try trimming exported dentries
 
   // send pending import_maps?
   mds->mdcache->maybe_send_pending_resolves();
@@ -2650,7 +2650,7 @@ void Migrator::import_reverse(CDir *dir)
   // log our failure
   mds->mdlog->start_submit_entry(new EImportFinish(dir, false));	// log failure
 
-  cache->trim(-1, num_dentries); // try trimming dentries
+  cache->trim(num_dentries); // try trimming dentries
 
   // notify bystanders; wait in aborting state
   import_notify_abort(dir, bounds);

--- a/src/mds/Server.h
+++ b/src/mds/Server.h
@@ -133,7 +133,7 @@ public:
   void reconnect_tick();
   void recover_filelocks(CInode *in, bufferlist locks, int64_t client);
 
-  void recall_client_state(float ratio);
+  void recall_client_state(void);
   void force_clients_readonly();
 
   // -- requests --

--- a/src/mds/SessionMap.cc
+++ b/src/mds/SessionMap.cc
@@ -826,7 +826,7 @@ void Session::notify_cap_release(size_t n_caps)
  * in order to generate health metrics if the session doesn't see
  * a commensurate number of calls to ::notify_cap_release
  */
-void Session::notify_recall_sent(const int new_limit)
+void Session::notify_recall_sent(const size_t new_limit)
 {
   if (recalled_at.is_zero()) {
     // Entering recall phase, set up counters so we can later

--- a/src/mds/SessionMap.h
+++ b/src/mds/SessionMap.h
@@ -148,7 +148,7 @@ public:
   interval_set<inodeno_t> pending_prealloc_inos; // journaling prealloc, will be added to prealloc_inos
 
   void notify_cap_release(size_t n_caps);
-  void notify_recall_sent(const int new_limit);
+  void notify_recall_sent(const size_t new_limit);
   void clear_recalled_at();
 
   inodeno_t next_ino() const {

--- a/src/mds/SimpleLock.h
+++ b/src/mds/SimpleLock.h
@@ -373,10 +373,9 @@ public:
   }
 
   void init_gather() {
-    for (compact_map<mds_rank_t,unsigned>::iterator p = parent->replicas_begin();
-	 p != parent->replicas_end();
-	 ++p)
-      more()->gather_set.insert(p->first);
+    for (const auto p : parent->get_replicas()) {
+      more()->gather_set.insert(p.first);
+    }
   }
   bool is_gathering() const {
     return have_more() && !more()->gather_set.empty();


### PR DESCRIPTION
    This introduces two config parameters:
    
        mds_cache_memory_limit: Sets the soft maximum of the cache to the given
        byte count. (Like mds_cache_size, this doesn't actually limit the maximum
        size of the cache. It just dictates the steady-state size.)
    
        mds_cache_reservation: This replaces mds_health_cache_threshold everywhere
        except the Beacon heartbeat sent to the mons. The idea here is to specify a
        reservation of memory (5% by default) for operations and the MDS tries to
        always maintain that reservation. So, the MDS will recall caps from clients
        when it begins dipping into its reservation of memory.
    
    mds_cache_size still limits the cache by Inode count but is now by-default 0
    (i.e. unlimited). The new preferred way of specifying cache limits is by memory
    size. The default is 1GB.
    
    Fixes: http://tracker.ceph.com/issues/20594
    Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1464976