### PR TITLE
rgw: Fix closing tag for Prefix

### DIFF
--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -34,7 +34,7 @@ class LCFilter_S3 : public LCFilter, public XMLObj
   void to_xml(ostream& out){
     out << "<Filter>";
       if (!prefix.empty())
-        out << "<Prefix>" << prefix << "<Prefix>";
+        out << "<Prefix>" << prefix << "</Prefix>";
     out << "</Filter>";
   }
   void dump_xml(Formatter *f) const {


### PR DESCRIPTION
Fixed `<Prefix>` missing a closing tag in `LCFilter_S3::to_xml()`.
Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>