### PR TITLE
messages: Initialization of member variables

### DIFF
--- a/src/messages/MInodeFileCaps.h
+++ b/src/messages/MInodeFileCaps.h
@@ -18,7 +18,7 @@
 
 class MInodeFileCaps : public Message {
   inodeno_t ino;
-  __u32     caps;
+  __u32     caps = 0;
 
  public:
   inodeno_t get_ino() { return ino; }

--- a/src/messages/MLock.h
+++ b/src/messages/MLock.h
@@ -20,11 +20,11 @@
 #include "mds/locks.h"
 
 class MLock : public Message {
-  int32_t     action;  // action type
-  int32_t     asker;  // who is initiating this request
+  int32_t     action = 0;  // action type
+  int32_t     asker = 0;  // who is initiating this request
   metareqid_t reqid;  // for remote lock requests
   
-  __u16      lock_type;  // lock object type
+  __u16      lock_type = 0;  // lock object type
   MDSCacheObjectInfo object_info;  
   
   bufferlist lockdata;  // and possibly some data

--- a/src/messages/MLogAck.h
+++ b/src/messages/MLogAck.h
@@ -18,7 +18,7 @@
 class MLogAck : public Message {
 public:
   uuid_d fsid;
-  version_t last;
+  version_t last = 0;
   std::string channel;
 
   MLogAck() : Message(MSG_LOGACK) {}


### PR DESCRIPTION
Fixes the coverity issues:

** 717279 Uninitialized scalar field
>CID 717279 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member caps is not initialized
in this constructor nor in any functions that it calls.

** 717280 Uninitialized scalar field
>2. uninit_member: Non-static class member action is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member asker is not initialized
in this constructor nor in any functions that it calls.
>CID 717280 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member lock_type is not initialized
in this constructor nor in any functions that it calls.

** 717281 Uninitialized scalar field
>CID 717281 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member last is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>