### PR TITLE
messages: Initialization of left members

### DIFF
--- a/src/messages/MMDSBeacon.h
+++ b/src/messages/MMDSBeacon.h
@@ -182,7 +182,7 @@ class MMDSBeacon : public PaxosServiceMessage {
   string name;
 
   MDSMap::DaemonState state;
-  version_t seq;
+  version_t seq = 0;
 
   mds_rank_t      standby_for_rank;
   string          standby_for_name;

--- a/src/messages/MMDSFindInoReply.h
+++ b/src/messages/MMDSFindInoReply.h
@@ -19,7 +19,7 @@
 #include "include/filepath.h"
 
 struct MMDSFindInoReply : public Message {
-  ceph_tid_t tid;
+  ceph_tid_t tid = 0;
   filepath path;
 
   MMDSFindInoReply() : Message(MSG_MDS_FINDINOREPLY) {}

--- a/src/messages/MMDSFragmentNotify.h
+++ b/src/messages/MMDSFragmentNotify.h
@@ -20,7 +20,7 @@
 class MMDSFragmentNotify : public Message {
   inodeno_t ino;
   frag_t basefrag;
-  int8_t bits;
+  int8_t bits = 0;
 
  public:
   inodeno_t get_ino() { return ino; }

--- a/src/messages/MMDSMap.h
+++ b/src/messages/MMDSMap.h
@@ -26,7 +26,7 @@ class MMDSMap : public Message {
 public:
 
   uuid_d fsid;
-  epoch_t epoch;
+  epoch_t epoch = 0;
   bufferlist encoded;
 
   version_t get_epoch() const { return epoch; }


### PR DESCRIPTION
Fixes the coverity issues:

** 717282 Uninitialized scalar field
>CID 717282 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member seq is not initialized
in this constructor nor in any functions that it calls.

** 717287 Uninitialized scalar field
>CID 717287 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member tid is not initialized
in this constructor nor in any functions that it calls.

** 717288 Uninitialized scalar field
>CID 717288 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member bits is not initialized
in this constructor nor in any functions that it calls.

** 717290 Uninitialized scalar field
>CID 717290 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>