### PR TITLE
blkin: link against lttng-ust-fork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,7 @@ endif(WITH_DPDK)
 
 option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
 if(WITH_BLKIN)
-  set(BLKIN_LIBRARIES blkin lttng-ust)
+  set(BLKIN_LIBRARIES blkin ${LTTNGUST_LIBRARIES} lttng-ust-fork)
   include_directories(src/blkin/blkin-lib)
 endif(WITH_BLKIN)
 


### PR DESCRIPTION
Tracing with LTTng doesn't work if an application clone()s other
threads. This is an LTTng-related issue and the fix is LD_PRELOAD'ing
liblttng-ust-fork to override calls to fork().
We don't have this issue with "regular" tracepoints (see WITH_LTTNG)
because the tracepoints are loaded using dlopen() at runtime by each
Ceph process.

Signed-off-by: Mohamad Gebai <mgebai@suse.com>