### PR TITLE
qa/tasks/cephfs: Whitelist POOL_APP_NOT_ENABLED for test_misc

### DIFF
--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -7,3 +7,4 @@ overrides:
   ceph:
     log-whitelist:
       - evicting unresponsive client
+      - POOL_APP_NOT_ENABLED


### PR DESCRIPTION
test_misc verifies that ceph fs new will not create a filesystem
on a pool that already contains objects. As part of the test, it
inserts a dummy object into a pool and then attempts to use it for
CephFS. This triggers POOL_APP_NOT_ENABLED. Setting the application
metadata for the pool (and having ceph fs new fail because of the
existing metadata) would then exercise a different failure case.

Signed-off-by: Douglas Fuller <dfuller@redhat.com>