### PR TITLE
OSD auth caps enhancements for CephFS

### DIFF
--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -50,6 +50,9 @@ Note that if a client's read access is restricted to a path, they will only
 be able to mount the filesystem when specifying a readable path in the
 mount command (see below).
 
+Supplying ``all`` or ``*`` as the filesystem name will grant access to every
+file system. Note that it is usually necessary to quote ``*`` to protect it from
+the shell.
 
 See `User Management - Add a User to a Keyring`_. for additional details on user management
 

--- a/doc/cephfs/client-auth.rst
+++ b/doc/cephfs/client-auth.rst
@@ -33,6 +33,14 @@ for example, to restrict client ``foo`` to writing only in the ``bar`` directory
 
  ceph fs authorize cephfs client.foo / r /bar rw
 
+ results in:
+
+ client.foo
+   key: *key*
+   caps: [mds] allow r, allow rw path=/bar
+   caps: [mon] allow r
+   caps: [osd] allow rw tag cephfs data=cephfs_a
+
 To completely restrict the client to the ``bar`` directory, omit the
 root directory ::
 
@@ -81,8 +89,8 @@ This restricts all the attributes that are set by special extended attributes
 with a "ceph." prefix, as well as restricting other means of setting
 these fields (such as openc operations with layouts).
 
-For example, in the following snippet client.0 can modify layouts and quotas, 
-but client.1 cannot.
+For example, in the following snippet client.0 can modify layouts and quotas
+on the filesystem cephfs_a, but client.1 cannot.
 
 ::
 
@@ -90,13 +98,13 @@ but client.1 cannot.
         key: AQAz7EVWygILFRAAdIcuJ12opU/JKyfFmxhuaw==
         caps: [mds] allow rwp
         caps: [mon] allow r
-        caps: [osd] allow rw pool=data
+        caps: [osd] allow rw tag cephfs data=cephfs_a
 
     client.1
         key: AQAz7EVWygILFRAAdIcuJ12opU/JKyfFmxhuaw==
         caps: [mds] allow rw
         caps: [mon] allow r
-        caps: [osd] allow rw pool=data
+        caps: [osd] allow rw tag cephfs data=cephfs_a
 
 
 .. _User Management - Add a User to a Keyring: ../../rados/operations/user-management/#add-a-user-to-a-keyring

--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -139,9 +139,9 @@ In general, an osd capability follows the grammar::
 
         osdcap  := grant[,grant...]
         grant   := allow (match capspec | capspec match)
-        match   := [pool[=]<poolname> | object_prefix <prefix>
-                    | tag <application-name> <key>=<value> 
-                    | namespace[=]<rados-namespace> ]
+        match   := [ pool[=]<poolname> | object_prefix <prefix>
+                    | namespace[=]<rados-namespace>
+                    | tag <application-name> <key>=<value> ]
         capspec := * | [r][w][x] [class-read] [class-write]
 
 The capspec determines what kind of operations the entity can perform::

--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -151,7 +151,7 @@ The capspec determines what kind of operations the entity can perform::
     x           = can call any class method (same as class-read class-write)
     class-read  = can call class methods that are reads
     class-write = can call class methods that are writes
-    *           = equivalent to rwx, plus the ability to run osd admin commands,
+    * or "all"  = equivalent to rwx, plus the ability to run osd admin commands,
                   i.e. ceph osd tell ...
 
 The match criteria restrict a grant based on the pool being accessed.

--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -139,7 +139,8 @@ In general, an osd capability follows the grammar::
 
         osdcap  := grant[,grant...]
         grant   := allow (match capspec | capspec match)
-        match   := [pool[=]<poolname> | object_prefix <prefix>]
+        match   := [pool[=]<poolname> | object_prefix <prefix>
+                    | tag <application-name> <key>=<value> ]
         capspec := * | [r][w][x] [class-read] [class-write]
 
 The capspec determines what kind of operations the entity can perform::

--- a/doc/man/8/ceph-authtool.rst
+++ b/doc/man/8/ceph-authtool.rst
@@ -140,7 +140,8 @@ In general, an osd capability follows the grammar::
         osdcap  := grant[,grant...]
         grant   := allow (match capspec | capspec match)
         match   := [pool[=]<poolname> | object_prefix <prefix>
-                    | tag <application-name> <key>=<value> ]
+                    | tag <application-name> <key>=<value> 
+                    | namespace[=]<rados-namespace> ]
         capspec := * | [r][w][x] [class-read] [class-write]
 
 The capspec determines what kind of operations the entity can perform::

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -222,7 +222,7 @@ Application Tags
 
 Access may be restricted to specific pools as defined by their application
 metadata. The ``*`` wildcard may be used for the ``key`` argument, the
-``value`` argument, or both.
+``value`` argument, or both. ``all`` is a synony for ``*``.
 
 Namespace
 ---------

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -92,9 +92,10 @@ Authorization (Capabilities)
 
 Ceph uses the term "capabilities" (caps) to describe authorizing an
 authenticated user to exercise the functionality of the monitors, OSDs and
-metadata servers. Capabilities can also restrict access to data within a pool or
-a namespace within a pool. A Ceph administrative user sets a user's
-capabilities when creating or updating a user.
+metadata servers. Capabilities can also restrict access to data within a pool,
+a namespace within a pool, or a set of pools based on their application tags.
+A Ceph administrative user sets a user's capabilities when creating or updating
+a user.
 
 Capability syntax follows the form::
 
@@ -110,7 +111,7 @@ Capability syntax follows the form::
   ``class-write`` access settings or ``profile {name}``. Additionally, OSD
   capabilities also allow for pool and namespace settings. ::
 
-	osd 'allow {access} [pool={pool-name} [namespace={namespace-name}]]'
+	osd 'allow {access} [pool={pool-name} [namespace={namespace-name}]] [tag {application} {key}={value}]'
 	osd 'profile {name} [pool={pool-name} [namespace={namespace-name}]]'
 
 - **Metadata Server Caps:** For administrators, use ``allow *``.  For all
@@ -216,6 +217,12 @@ OpenStack, a typical deployment would have pools for volumes, images, backups
 and virtual machines, and users such as ``client.glance``, ``client.cinder``,
 etc.
 
+Application Tags
+----------------
+
+Access may be restricted to specific pools as defined by their application
+metadata. The ``*`` wildcard may be used for the ``key`` argument, the
+``value`` argument, or both.
 
 Namespace
 ---------

--- a/doc/rados/operations/user-management.rst
+++ b/doc/rados/operations/user-management.rst
@@ -248,6 +248,11 @@ namespace to the object name with out the computational overhead of a separate
 pool. Rather than creating a separate pool for a user or set of users, you may
 use a namespace. **Note:** Only available using ``librados`` at this time.
 
+Access may be restricted to specific RADOS namespaces using the ``namespace``
+capability. Limited globbing of namespaces is supported; if the last character
+of the specified namespace is ``*``, then access is granted to any namespace
+starting with the provided argument.
+
 
 Managing Users
 ==============

--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -72,6 +72,8 @@ struct MDSCapParser : qi::grammar<Iterator, MDSAuthCaps()>
     capspec = spaces >> (
         lit("*")[_val = MDSCapSpec(true, true, true, true)]
         |
+        lit("all")[_val = MDSCapSpec(true, true, true, true)]
+        |
         (lit("rwp"))[_val = MDSCapSpec(true, true, false, true)]
         |
         (lit("rw"))[_val = MDSCapSpec(true, true, false, false)]

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1300,7 +1300,7 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       }
     }
 
-    if (filesystem != "*") {
+    if (filesystem != "*" && filesystem != "all") {
       auto fs = mon->mdsmon()->get_fsmap().get_filesystem(filesystem);
       if (!fs) {
 	ss << "filesystem " << filesystem << " does not exist.";

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1325,8 +1325,8 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       for (const auto &sys_cap : wanted_caps) {
 	if (entity_auth.caps.count(sys_cap.first) == 0 ||
 	    !entity_auth.caps[sys_cap.first].contents_equal(sys_cap.second)) {
-	  ss << "key for " << entity << " exists but cap " << sys_cap.first
-	     << " does not match";
+	  ss << entity << " already has fs capabilities that differ from those supplied. To generate a new auth key for "
+	     << entity << ", first remove " << entity << " from configuration files, execute 'ceph auth rm " << entity << "', then execute this command again.";
 	  err = -EINVAL;
 	  goto done;
 	}

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1300,11 +1300,13 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       }
     }
 
-    auto fs = mon->mdsmon()->get_fsmap().get_filesystem(filesystem);
-    if (!fs) {
-      ss << "filesystem " << filesystem << " does not exist.";
-      err = -EINVAL;
-      goto done;
+    if (filesystem != "*") {
+      auto fs = mon->mdsmon()->get_fsmap().get_filesystem(filesystem);
+      if (!fs) {
+	ss << "filesystem " << filesystem << " does not exist.";
+	err = -EINVAL;
+	goto done;
+      }
     }
 
     osd_cap_string += osd_cap_string.empty()? "" : ", ";

--- a/src/mon/AuthMonitor.cc
+++ b/src/mon/AuthMonitor.cc
@@ -1307,12 +1307,10 @@ bool AuthMonitor::prepare_command(MonOpRequestRef op)
       goto done;
     }
 
-    auto data_pools = fs->mds_map.get_data_pools();
-    for (auto p : data_pools) {
-      const string &pool_name = mon->osdmon()->osdmap.get_pool_name(p);
-      osd_cap_string += osd_cap_string.empty() ? "" : ", ";
-      osd_cap_string += "allow " + osd_cap_wanted + " pool=" + pool_name;
-    }
+    osd_cap_string += osd_cap_string.empty()? "" : ", ";
+    osd_cap_string += "allow " + osd_cap_wanted
+      + " tag " + pg_pool_t::APPLICATION_NAME_CEPHFS
+      + " data=" + filesystem;
 
     std::map<string, bufferlist> wanted_caps = {
       { "mon", _encode_cap("allow r") },

--- a/src/mon/FSCommands.cc
+++ b/src/mon/FSCommands.cc
@@ -195,9 +195,11 @@ class FsNewHandler : public FileSystemCommandHandler
       return -EAGAIN;
     }
     mon->osdmon()->do_application_enable(data,
-					 pg_pool_t::APPLICATION_NAME_CEPHFS);
+					 pg_pool_t::APPLICATION_NAME_CEPHFS,
+					 "data", fs_name);
     mon->osdmon()->do_application_enable(metadata,
-					 pg_pool_t::APPLICATION_NAME_CEPHFS);
+					 pg_pool_t::APPLICATION_NAME_CEPHFS,
+					 "metadata", fs_name);
     mon->osdmon()->propose_pending();
 
     // All checks passed, go ahead and create.
@@ -522,7 +524,9 @@ class AddDataPoolHandler : public FileSystemCommandHandler
       mon->osdmon()->wait_for_writeable(op, new PaxosService::C_RetryMessage(mon->mdsmon(), op));
       return -EAGAIN;
     }
-    mon->osdmon()->do_application_enable(poolid, pg_pool_t::APPLICATION_NAME_CEPHFS);
+    mon->osdmon()->do_application_enable(poolid,
+					 pg_pool_t::APPLICATION_NAME_CEPHFS,
+					 "data", poolname);
     mon->osdmon()->propose_pending();
 
     fsmap.modify_filesystem(

--- a/src/mon/MonCap.cc
+++ b/src/mon/MonCap.cc
@@ -530,6 +530,7 @@ struct MonCapParser : qi::grammar<Iterator, MonCap()>
     // rwxa := * | [r][w][x]
     rwxa =
       (lit("*")[_val = MON_CAP_ANY]) |
+      (lit("all")[_val = MON_CAP_ANY]) |
       ( eps[_val = 0] >>
 	( lit('r')[_val |= MON_CAP_R] ||
 	  lit('w')[_val |= MON_CAP_W] ||

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -6157,6 +6157,20 @@ int OSDMonitor::prepare_command_pool_application(const string &prefix,
   cmd_getval(cct, cmdmap, "app", app);
   bool app_exists = (p.application_metadata.count(app) > 0);
 
+  string key;
+  cmd_getval(cct, cmdmap, "key", key);
+  if (key == "all") {
+    ss << "key cannot be 'all'";
+    return -EINVAL;
+  }
+
+  string value;
+  cmd_getval(cct, cmdmap, "value", value);
+  if (value == "all") {
+    ss << "value cannot be 'all'";
+    return -EINVAL;
+  }
+
   if (boost::algorithm::ends_with(prefix, "enable")) {
     if (app.empty()) {
       ss << "application name must be provided";

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -3130,7 +3130,9 @@ void OSDMonitor::check_pg_creates_sub(Subscription *sub)
 }
 
 void OSDMonitor::do_application_enable(int64_t pool_id,
-                                       const std::string &app_name)
+                                       const std::string &app_name,
+				       const std::string &app_key,
+				       const std::string &app_value)
 {
   assert(paxos->is_plugged() && is_writeable());
 
@@ -3147,7 +3149,11 @@ void OSDMonitor::do_application_enable(int64_t pool_id,
     p = pending_inc.new_pools[pool_id];
   }
 
-  p.application_metadata.insert({app_name, {}});
+  if (app_key.empty()) {
+    p.application_metadata.insert({app_name, {}});
+  } else {
+    p.application_metadata.insert({app_name, {{app_key, app_value}}});
+  }
   p.last_change = pending_inc.epoch;
   pending_inc.new_pools[pool_id] = p;
 }

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -539,7 +539,9 @@ public:
   void check_osdmap_sub(Subscription *sub);
   void check_pg_creates_sub(Subscription *sub);
 
-  void do_application_enable(int64_t pool_id, const std::string &app_name);
+  void do_application_enable(int64_t pool_id, const std::string &app_name,
+			     const std::string &app_key="",
+			     const std::string &app_value="");
 
   void add_flag(int flag) {
     if (!(osdmap.flags & flag)) {

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6701,11 +6701,13 @@ bool OSD::ms_verify_authorizer(Connection *con, int peer_type,
       catch (buffer::error& e) {
         isvalid = false;
       }
-      bool success = s->caps.parse(str);
+      stringstream ss;
+      bool success = s->caps.parse(str, &ss);
       if (success)
 	dout(10) << " session " << s << " " << s->entity_name << " has caps " << s->caps << " '" << str << "'" << dendl;
       else {
 	dout(10) << " session " << s << " " << s->entity_name << " failed to parse caps '" << str << "'" << dendl;
+	dout(20) << "parser returned " << ss.str() << dendl;
         isvalid = false;
       }
     }

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -398,6 +398,8 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
 
     spaces = +ascii::space;
 
+    wildcard = (lit('*') | lit("all")) [_val = "*"];
+
     pool_name %= -(spaces >> lit("pool") >> (lit('=') | spaces) >> str);
     nspace %= (spaces >> lit("namespace")
 	       >> (lit('=') | spaces)
@@ -408,8 +410,8 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
     object_prefix %= -(spaces >> lit("object_prefix") >> spaces >> str);
     pooltag %= (spaces >> lit("tag")
 		>> spaces >> str // application
-		>> spaces >> (str | char_('*')) // key
-		>> -spaces >> lit('=') >> -spaces >> (str | char_('*'))); // value
+		>> spaces >> (wildcard | str) // key
+		>> -spaces >> lit('=') >> -spaces >> (wildcard | str)); // value
 
     match = (
       pooltag                                 [_val = phoenix::construct<OSDCapMatch>(_1)] |
@@ -421,7 +423,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
 
     // rwxa := * | [r][w][x] [class-read] [class-write]
     rwxa =
-      (spaces >> lit("*")[_val = OSD_CAP_ANY]) |
+      (spaces >> wildcard[_val = OSD_CAP_ANY]) |
       ( eps[_val = 0] >>
 	(
 	 spaces >>
@@ -459,6 +461,7 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
   qi::rule<Iterator, string()> quoted_string, equoted_string;
   qi::rule<Iterator, string()> unquoted_word;
   qi::rule<Iterator, string()> str, estr;
+  qi::rule<Iterator, string()> wildcard;
   qi::rule<Iterator, int()> auid;
   qi::rule<Iterator, string()> class_name;
   qi::rule<Iterator, string()> class_cap;

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -82,9 +82,13 @@ ostream& operator<<(ostream& out, const OSDCapMatch& m)
 {
   if (m.auid != -1LL) {
     out << "auid " << m.auid << " ";
-  } else if (!m.pool_namespace.pool_name.empty() || m.pool_namespace.nspace) {
+  }
+
+  if (!m.pool_namespace.pool_name.empty() || m.pool_namespace.nspace) {
     out << m.pool_namespace;
-  } else if (!m.pool_tag.application.empty()) {
+  }
+
+  if (!m.pool_tag.application.empty()) {
     out << m.pool_tag;
   }
 
@@ -351,8 +355,9 @@ bool OSDCap::is_capable(const string& pool_name, const string& ns,
 {
   std::vector<bool> class_allowed(classes.size(), false);
   for (auto &grant : grants) {
-    if (grant.is_capable(pool_name, ns, pool_auid, application_metadata, object, op_may_read,
-                         op_may_write, classes, &class_allowed)) {
+    if (grant.is_capable(pool_name, ns, pool_auid, application_metadata,
+			 object, op_may_read, op_may_write, classes,
+			 &class_allowed)) {
       return true;
     }
   }
@@ -408,9 +413,11 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
 
     match = (
       pooltag                                 [_val = phoenix::construct<OSDCapMatch>(_1)] |
+      (nspace >> pooltag)                     [_val = phoenix::construct<OSDCapMatch>(_1, _2)] |
       (auid >> object_prefix)                 [_val = phoenix::construct<OSDCapMatch>(_1, _2)] |
       (pool_name >> nspace >> object_prefix)  [_val = phoenix::construct<OSDCapMatch>(_1, _2, _3)] |
-      (pool_name >> object_prefix)            [_val = phoenix::construct<OSDCapMatch>(_1, _2)]);
+      (pool_name >> object_prefix)            [_val = phoenix::construct<OSDCapMatch>(_1, _2)]
+    );
 
     // rwxa := * | [r][w][x] [class-read] [class-write]
     rwxa =
@@ -487,4 +494,3 @@ bool OSDCap::parse(const string& str, ostream *err)
 
   return false; 
 }
-

--- a/src/osd/OSDCap.cc
+++ b/src/osd/OSDCap.cc
@@ -16,6 +16,7 @@
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/phoenix_operator.hpp>
 #include <boost/spirit/include/phoenix.hpp>
+#include <boost/algorithm/string/predicate.hpp>
 
 #include "OSDCap.h"
 #include "common/config.h"
@@ -109,6 +110,11 @@ bool OSDCapPoolNamespace::is_match(const std::string& pn,
     }
   }
   if (nspace) {
+    if ((*nspace)[nspace->length() - 1] == '*' &&
+	boost::starts_with(ns, nspace->substr(0, nspace->length() - 1))) {
+      return true;
+    }
+
     if (*nspace != ns) {
       return false;
     }
@@ -388,7 +394,9 @@ struct OSDCapParser : qi::grammar<Iterator, OSDCap()>
     spaces = +ascii::space;
 
     pool_name %= -(spaces >> lit("pool") >> (lit('=') | spaces) >> str);
-    nspace %= (spaces >> lit("namespace") >> (lit('=') | spaces) >> estr);
+    nspace %= (spaces >> lit("namespace")
+	       >> (lit('=') | spaces)
+	       >> estr >> -char_('*'));
 
     // match := [pool[=]<poolname> [namespace[=]<namespace>] | auid <123>] [object_prefix <prefix>]
     auid %= (spaces >> lit("auid") >> spaces >> int_);

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -139,6 +139,8 @@ struct OSDCapMatch {
   OSDCapMatch(const std::string& dummy, const std::string& app,
 	      const std::string& key, const std::string& val)
     : pool_tag(app, key, val) {}
+  OSDCapMatch(const std::string& ns, const OSDCapPoolTag& pt)
+    : pool_namespace("", ns), pool_tag(pt) {}
 
   /**
    * check if given request parameters match our constraints

--- a/src/osd/OSDCap.h
+++ b/src/osd/OSDCap.h
@@ -36,6 +36,7 @@ using std::ostream;
 #include <list>
 #include <vector>
 #include <boost/optional.hpp>
+#include <boost/fusion/include/adapt_struct.hpp>
 
 static const __u8 OSD_CAP_R     = (1 << 1);      // read
 static const __u8 OSD_CAP_W     = (1 << 2);      // write
@@ -95,14 +96,38 @@ struct OSDCapPoolNamespace {
 
 ostream& operator<<(ostream& out, const OSDCapPoolNamespace& pns);
 
+struct OSDCapPoolTag {
+  typedef std::map<std::string, std::map<std::string, std::string> > app_map_t;
+  std::string application;
+  std::string key;
+  std::string value;
+
+  OSDCapPoolTag () {}
+  OSDCapPoolTag(const std::string& application, const std::string& key,
+		const std::string& value) :
+    application(application), key(key), value(value) {}
+
+  bool is_match(const app_map_t& app_map) const;
+  bool is_match_all() const;
+};
+// adapt for parsing with boost::spirit::qi in OSDCapParser
+BOOST_FUSION_ADAPT_STRUCT(OSDCapPoolTag,
+			  (std::string, application)
+			  (std::string, key)
+			  (std::string, value))
+
+ostream& operator<<(ostream& out, const OSDCapPoolTag& pt);
 
 struct OSDCapMatch {
+  typedef std::map<std::string, std::map<std::string, std::string> > app_map_t;
   // auid and pool_name/nspace are mutually exclusive
   int64_t auid = CEPH_AUTH_UID_DEFAULT;
   OSDCapPoolNamespace pool_namespace;
+  OSDCapPoolTag pool_tag;
   std::string object_prefix;
 
   OSDCapMatch() {}
+  OSDCapMatch(const OSDCapPoolTag& pt) : pool_tag(pt) {}
   OSDCapMatch(const OSDCapPoolNamespace& pns) : pool_namespace(pns) {}
   OSDCapMatch(const std::string& pl, const std::string& pre)
     : pool_namespace(pl), object_prefix(pre) {}
@@ -111,6 +136,9 @@ struct OSDCapMatch {
     : pool_namespace(pl, ns), object_prefix(pre) {}
   OSDCapMatch(uint64_t auid, const std::string& pre)
     : auid(auid), object_prefix(pre) {}
+  OSDCapMatch(const std::string& dummy, const std::string& app,
+	      const std::string& key, const std::string& val)
+    : pool_tag(app, key, val) {}
 
   /**
    * check if given request parameters match our constraints
@@ -122,7 +150,8 @@ struct OSDCapMatch {
    * @return true if we match, false otherwise
    */
   bool is_match(const std::string& pool_name, const std::string& nspace_name,
-                int64_t pool_auid, const std::string& object) const;
+                int64_t pool_auid, const app_map_t& app_map,
+		const std::string& object) const;
   bool is_match_all() const;
 };
 
@@ -165,6 +194,7 @@ struct OSDCapGrant {
 
   bool allow_all() const;
   bool is_capable(const string& pool_name, const string& ns, int64_t pool_auid,
+		  const OSDCapPoolTag::app_map_t& application_metadata,
                   const string& object, bool op_may_read, bool op_may_write,
                   const std::vector<OpRequest::ClassInfo>& classes,
                   std::vector<bool>* class_allowed) const;
@@ -202,6 +232,7 @@ struct OSDCap {
    * @return true if the operation is allowed, false otherwise
    */
   bool is_capable(const string& pool_name, const string& ns, int64_t pool_auid,
+		  const OSDCapPoolTag::app_map_t& application_metadata,
 		  const string& object, bool op_may_read, bool op_may_write,
 		  const std::vector<OpRequest::ClassInfo>& classes) const;
 };

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -1881,7 +1881,9 @@ bool PG::op_has_sufficient_caps(OpRequestRef& op)
     req->get_hobj().get_key();
 
   bool cap = caps.is_capable(pool.name, req->get_hobj().nspace,
-                             pool.auid, key,
+                             pool.auid,
+			     pool.info.application_metadata,
+			     key,
 			     op->need_read_cap(),
 			     op->need_write_cap(),
 			     op->classes());
@@ -1891,6 +1893,7 @@ bool PG::op_has_sufficient_caps(OpRequestRef& op)
            << " pool=" << pool.id << " (" << pool.name
            << " " << req->get_hobj().nspace
 	   << ") owner=" << pool.auid
+	   << " pool_app_metadata=" << pool.info.application_metadata
 	   << " need_read_cap=" << op->need_read_cap()
 	   << " need_write_cap=" << op->need_write_cap()
 	   << " classes=" << op->classes()

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -79,6 +79,7 @@ const char *parse_good[] = {
   "allow rwx tag application key =value",
   "allow rwx tag application key= value",
   "allow rwx tag application key  =   value",
+  "allow all tag application all=all",
   0
 };
 
@@ -909,7 +910,11 @@ TEST(OSDCap, OutputParsed)
     {"allow rwx tag application key=value",
      "osdcap[grant(app application key key val value rwx)]"},
     {"allow rwx namespace ns* tag application key=value",
-     "osdcap[grant(namespace ns* app application key key val value rwx)]"}
+     "osdcap[grant(namespace ns* app application key key val value rwx)]"},
+	 {"allow all",
+	  "osdcap[grant(*)]"},
+	 {"allow rwx tag application all=all",
+	  "osdcap[grant(app application key * val * rwx)]"}
   };
 
   size_t num_tests = sizeof(test_values) / sizeof(*test_values);

--- a/src/test/osd/osdcap.cc
+++ b/src/test/osd/osdcap.cc
@@ -71,6 +71,11 @@ const char *parse_good[] = {
   "allow pool foo namespace=\"\" rwx; allow pool bar namespace='' object_prefix rbd r",
   "allow pool foo namespace \"\" rwx; allow pool bar namespace '' object_prefix rbd r",
   "profile abc, profile abc pool=bar, profile abc pool=bar namespace=foo",
+  "allow rwx tag application key=value",
+  "allow rwx tag application key = value",
+  "allow rwx tag application key =value",
+  "allow rwx tag application key= value",
+  "allow rwx tag application key  =   value",
   0
 };
 
@@ -105,6 +110,7 @@ const char *parse_bad[] = {
   "allow namespace=foo",
   "allow rwx auid 123 namespace asdf",
   "allow wwx pool ''",
+  "allow rwx tag application key value",
   0
 };
 
@@ -151,16 +157,23 @@ TEST(OSDCap, AllowAll) {
 
   ASSERT_TRUE(cap.parse("allow *", NULL));
   ASSERT_TRUE(cap.allow_all());
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "asdf", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, "asdf", true, true, {{"cls", true, true, true}}));
-
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, true}}));
   // 'allow *' overrides whitelist
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "asdf", true, true, {{"cls", true, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("foo", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "anamespace", 0, {{"application", {{"key", "value"}}}}, "asdf", true, true, {{"cls", true, true, false}}));
 }
 
 TEST(OSDCap, AllowPool) {
@@ -168,14 +181,21 @@ TEST(OSDCap, AllowPool) {
   bool r = cap.parse("allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
   // true->false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "", true, true, {{"cls", true, true, true}}));
+
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, AllowPools) {
@@ -183,20 +203,30 @@ TEST(OSDCap, AllowPools) {
   bool r = cap.parse("allow rwx pool foo, allow r pool bar", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, true, {{"cls", true, true, true}}));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, "", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {}, "", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "ns", 0, {{"application", {{"key", "value"}}}}, "", true, false, {}));
 }
 
 TEST(OSDCap, AllowPools2) {
@@ -204,12 +234,12 @@ TEST(OSDCap, AllowPools2) {
   bool r = cap.parse("allow r, allow rwx pool foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "", true, true, {{"cls", true, true, true}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "", true, false, {}));
 }
 
 TEST(OSDCap, ObjectPrefix) {
@@ -217,17 +247,17 @@ TEST(OSDCap, ObjectPrefix) {
   bool r = cap.parse("allow rwx object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo_bar", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "food", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo_bar", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "_foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, " foo ", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "fo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "_foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, " foo ", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "fo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, ObjectPoolAndPrefix) {
@@ -235,412 +265,544 @@ TEST(OSDCap, ObjectPoolAndPrefix) {
   bool r = cap.parse("allow rwx pool bar object_prefix foo", NULL);
   ASSERT_TRUE(r);
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo_bar", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, true}}));
   // true-false for classes not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "food", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo_bar", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "food", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo_bar", true, true, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "food", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "fo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "food", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "fo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, BasicR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow r", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, BasicW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow w", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, BasicX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow x", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
   // true->false when class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, BasicRW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, BasicRX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, true, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, BasicWX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow wx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, BasicRWX) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false for class not on whitelist
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
 }
 
 TEST(OSDCap, BasicRWClassRClassW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow rw class-read class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
 }
 
 TEST(OSDCap, ClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, ClassW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, ClassRW) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class-read class-write", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
 }
 
 TEST(OSDCap, BasicRClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow r class-read", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "any", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "any", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "any", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, PoolClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar r class-read, allow pool foo rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
 }
 
 TEST(OSDCap, PoolClassRNS) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow pool bar namespace='' r class-read, allow pool foo namespace=ns rwx", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("bar", "other", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "other", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("baz", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("baz", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
 }
 
 TEST(OSDCap, NSClassR) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow namespace '' rw class-read class-write, allow namespace test r", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, false, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", false, true, {{"cls", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, false, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, true}}));
   // true->false when class not whitelisted
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, false, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", false, true, {{"cls", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, false, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {{"cls", true, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "test", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "test", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("bar", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_TRUE(cap.is_capable("foo", "test", 0, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {}));
 
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, "foo", true, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, "foo", true, true, {{"cls", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, "foo", false, true, {{"cls", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "test", 0, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "test", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
 
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, "foo", true, false, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, "foo", false, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, "foo", false, false, {{"cls", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {}, "foo", false, false, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "bad", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {{"cls", false, true, true}}));
+}
+
+TEST(OSDCap, PoolTagBasic)
+{
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow rwx tag application key=value", NULL));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "ns", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, false, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "ns", 0, {}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, false, true}}));
+  // true->false when class not whitelisted
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", false, true, {{"cls", false, true, false}}));
+
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", false, true, {{"cls", false, false, true}}));
+}
+
+TEST(OSDCap, PoolTagWildK)
+{
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow rwx tag application *=value", NULL));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+}
+
+TEST(OSDCap, PoolTagWildV)
+{
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow rwx tag application key=*", NULL));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+}
+
+TEST(OSDCap, PoolTagWildKV)
+{
+  OSDCap cap;
+  ASSERT_TRUE(cap.parse("allow rwx tag application *=*", NULL));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key", "value"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
+
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"key2", "value"}}}}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {{"app2", {{"key", "value"}}}}, "foo", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "foo", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {{"application", {{"foo", "bar"}, {"key2", "value"}}}, {"app2", {{"foo", "bar"}}}}, "foo", true, true, {}));
 }
 
 TEST(OSDCap, OutputParsed)
@@ -689,7 +851,9 @@ TEST(OSDCap, OutputParsed)
     {"allow pool images r, allow pool rbd rwx",
      "osdcap[grant(pool images r),grant(pool rbd rwx)]"},
     {"allow class-read object_prefix rbd_children, allow pool libvirt-pool-test rwx",
-     "osdcap[grant(object_prefix rbd_children  class-read),grant(pool libvirt-pool-test rwx)]"}
+     "osdcap[grant(object_prefix rbd_children  class-read),grant(pool libvirt-pool-test rwx)]"},
+    {"allow rwx tag application key=value",
+     "osdcap[grant(app application key key val value rwx)]"}
   };
 
   size_t num_tests = sizeof(test_values) / sizeof(*test_values);
@@ -706,39 +870,39 @@ TEST(OSDCap, AllowClass) {
   ASSERT_TRUE(cap.parse("allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
 }
 
 TEST(OSDCap, AllowClass2) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
 }
 
 TEST(OSDCap, AllowClassRWX) {
@@ -746,22 +910,22 @@ TEST(OSDCap, AllowClassRWX) {
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call any method on class foo regardless of whitelist status
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}}));
 
   // does not permit invoking class bar
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, false}}));
 
   // allows class bar if it is whitelisted
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"bar", true, true, true}}));
 }
 
 TEST(OSDCap, AllowClassMulti) {
@@ -770,155 +934,155 @@ TEST(OSDCap, AllowClassMulti) {
 
   // can call any method on foo, but not bar, so the entire op is rejected
   // bar with whitelist is rejected because it still needs rwx/class-read,write
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
 
   // these are OK because 'bar' is on the whitelist BUT the calls don't read or write
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
 
   // can call any method on foo or bar regardless of whitelist status
   OSDCap cap2;
   ASSERT_TRUE(cap2.parse("allow class foo, allow class bar", NULL));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
-  ASSERT_TRUE(cap2.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap2.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
 }
 
 TEST(OSDCap, AllowClassMultiRWX) {
@@ -926,112 +1090,112 @@ TEST(OSDCap, AllowClassMultiRWX) {
   ASSERT_TRUE(cap.parse("allow rwx, allow class foo", NULL));
 
   // can call anything on foo, but only whitelisted methods on bar
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, true}}));
 
   // fails because bar not whitelisted
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", true, false, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, true, false}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, true}, {"bar", false, false, false}}));
 
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
-  ASSERT_TRUE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, true}}));
+  ASSERT_TRUE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, true}}));
 
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
-  ASSERT_FALSE(cap.is_capable("bar", "", 0, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", true, false, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, true, false}}));
+  ASSERT_FALSE(cap.is_capable("bar", "", 0, {}, "foo", false, false, {{"foo", false, false, false}, {"bar", false, false, false}}));
 }
 
 TEST(OSDCap, AllowProfile) {
   OSDCap cap;
   ASSERT_TRUE(cap.parse("profile read-only, profile read-write pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "asdf", true, true, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "asdf", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("abc", "", 0, "asdf", false, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "asdf", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", false, true, {}));
 
   // RBD
   cap.grants.clear();
   ASSERT_TRUE(cap.parse("profile rbd pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "asdf", true, true, {}));
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "rbd_children", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("foo", "", 0, "rbd_children", false, false,
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "asdf", true, true, {}));
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("foo", "", 0, {}, "rbd_children", false, false,
                              {{"rbd", true, false, true}}));
-  ASSERT_TRUE(cap.is_capable("abc", "", 0, "asdf", true, true,
+  ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, true,
                              {{"rbd", true, true, true}}));
 
   cap.grants.clear();
   ASSERT_TRUE(cap.parse("profile rbd-read-only pool abc", NULL));
   ASSERT_FALSE(cap.allow_all());
-  ASSERT_FALSE(cap.is_capable("foo", "", 0, "rbd_children", true, false, {}));
-  ASSERT_TRUE(cap.is_capable("abc", "", 0, "asdf", true, false,
+  ASSERT_FALSE(cap.is_capable("foo", "", 0, {}, "rbd_children", true, false, {}));
+  ASSERT_TRUE(cap.is_capable("abc", "", 0, {}, "asdf", true, false,
                              {{"rbd", true, false, true}}));
 }
 

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -768,6 +768,7 @@ EOF
                 ceph_adm osd pool create "cephfs_data_${name}" 8
                 ceph_adm osd pool create "cephfs_metadata_${name}" 8
                 ceph_adm fs new "cephfs_${name}" "cephfs_metadata_${name}" "cephfs_data_${name}"
+					 ceph_adm fs authorize "cephfs_${name}" "client.fs_${name}" / rwp
                 fs=$(($fs + 1))
                 [ $fs -eq $CEPH_NUM_FS ] && break
             done

--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -584,6 +584,12 @@ start_mon() {
 			--cap mgr 'allow *' \
 			"$keyring_fn"
 
+		prun $SUDO "$CEPH_BIN/ceph-authtool" --gen-key --name=client.fs --set-uid=0 \
+		   --cap mon 'allow r' \
+			--cap osd 'allow rw tag cephfs data=*' \
+			--cap mds 'allow rwp' \
+			"$keyring_fn"
+
 		prun $SUDO "$CEPH_BIN/ceph-authtool" --gen-key --name=client.rgw \
 		    --cap mon 'allow rw' \
 		    --cap osd 'allow rwx' \
@@ -731,7 +737,7 @@ EOF
 EOF
 	        fi
 	        prun $SUDO "$CEPH_BIN/ceph-authtool" --create-keyring --gen-key --name="mds.$name" "$key_fn"
-	        ceph_adm -i "$key_fn" auth add "mds.$name" mon 'allow profile mds' osd 'allow *' mds 'allow' mgr 'allow profile mds'
+	        ceph_adm -i "$key_fn" auth add "mds.$name" mon 'allow profile mds' osd 'allow rw tag cephfs *=*' mds 'allow' mgr 'allow profile mds'
 	        if [ "$standby" -eq 1 ]; then
 			    prun $SUDO "$CEPH_BIN/ceph-authtool" --create-keyring --gen-key --name="mds.${name}s" \
 				     "$CEPH_DEV_DIR/mds.${name}s/keyring"


### PR DESCRIPTION
* Tag CephFS pools with data and metadata tags at filesystem creation time
* Extend the OSD auth caps syntax to include RADOS pool tags.
-- Example: allow rw tag cephfs data=cephfs_a
* Modify "ceph fs authorize" to use the pool tag syntax
* Allow namespace globbing
* Make "all" a synonym for "*" throughout the auth caps syntax