### PR TITLE
mon: remove mdsmap-derived perf counters

### DIFF
--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -119,7 +119,6 @@ void MDSMonitor::update_from_paxos(bool *need_bootstrap)
   }
 
   check_subs();
-  update_logger();
 }
 
 void MDSMonitor::init()
@@ -257,26 +256,6 @@ version_t MDSMonitor::get_trim_to()
   if (last - get_first_committed() > max && floor < last - max)
     return last - max;
   return floor;
-}
-
-void MDSMonitor::update_logger()
-{
-  dout(10) << "update_logger" << dendl;
-
-  uint64_t up = 0;
-  uint64_t in = 0;
-  uint64_t failed = 0;
-  for (const auto &i : fsmap.filesystems) {
-    const MDSMap &mds_map = i.second->mds_map;
-
-    up += mds_map.get_num_up_mds();
-    in += mds_map.get_num_in_mds();
-    failed += mds_map.get_num_failed_mds();
-  }
-  mon->cluster_logger->set(l_cluster_num_mds_up, up);
-  mon->cluster_logger->set(l_cluster_num_mds_in, in);
-  mon->cluster_logger->set(l_cluster_num_mds_failed, failed);
-  mon->cluster_logger->set(l_cluster_mds_epoch, fsmap.get_epoch());
 }
 
 bool MDSMonitor::preprocess_query(MonOpRequestRef op)
@@ -823,7 +802,6 @@ void MDSMonitor::_updated(MonOpRequestRef op)
 void MDSMonitor::on_active()
 {
   tick();
-  update_logger();
 
   if (mon->is_leader()) {
     mon->clog->debug() << "fsmap " << fsmap;

--- a/src/mon/MDSMonitor.h
+++ b/src/mon/MDSMonitor.h
@@ -76,7 +76,6 @@ class MDSMonitor : public PaxosService {
 
   // my helpers
   void print_map(FSMap &m, int dbl=7);
-  void update_logger();
 
   void _updated(MonOpRequestRef op);
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -586,10 +586,6 @@ int Monitor::preinit()
     pcb.add_u64(l_cluster_num_object_misplaced, "num_object_misplaced", "Misplaced (wrong location in the cluster) objects");
     pcb.add_u64(l_cluster_num_object_unfound, "num_object_unfound", "Unfound objects");
     pcb.add_u64(l_cluster_num_bytes, "num_bytes", "Size of all objects");
-    pcb.add_u64(l_cluster_num_mds_up, "num_mds_up", "MDSs that are up");
-    pcb.add_u64(l_cluster_num_mds_in, "num_mds_in", "MDS in state \"in\" (they are in cluster)");
-    pcb.add_u64(l_cluster_num_mds_failed, "num_mds_failed", "Failed MDS");
-    pcb.add_u64(l_cluster_mds_epoch, "mds_epoch", "Current epoch of MDS map");
     cluster_logger = pcb.create_perf_counters();
   }
 

--- a/src/mon/Monitor.h
+++ b/src/mon/Monitor.h
@@ -76,10 +76,6 @@ enum {
   l_cluster_num_object_misplaced,
   l_cluster_num_object_unfound,
   l_cluster_num_bytes,
-  l_cluster_num_mds_up,
-  l_cluster_num_mds_in,
-  l_cluster_num_mds_failed,
-  l_cluster_mds_epoch,
   l_cluster_last,
 };
 


### PR DESCRIPTION
Stats collectors that want this kind of information should
be looking at the cluster maps to get it.

Reasoning:
 - It's confusing to have two places to get at this sort of status
 - In the CephFS case, these counters were not that useful as they
   globbed all filesystems together.
 - It's awkward to have these stats output as perf counters of
   ceph-mon daemons, where a naive TSDB collector will not understand
   that they are really cluster-wide things.

Inspired by: http://tracker.ceph.com/issues/21311

Signed-off-by: John Spray <john.spray@redhat.com>