### PR TITLE
os/bluestore: add partial backpointer to shared_blob_t

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -465,7 +465,11 @@ struct shard_id_t {
   void decode(bufferlist::iterator &bl) {
     ::decode(id, bl);
   }
+  DENC(shard_id_t, v, p) {
+    denc(v.id, p);
+  }
 };
+WRITE_CLASS_DENC(shard_id_t)
 WRITE_CLASS_ENCODER(shard_id_t)
 WRITE_EQ_OPERATORS_1(shard_id_t, id)
 WRITE_CMP_OPERATORS_1(shard_id_t, id)

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1360,7 +1360,7 @@ public:
     //  loaded = SharedBlob::shared_blob_t is loaded from kv store
     void open_shared_blob(uint64_t sbid, BlobRef b);
     void load_shared_blob(SharedBlobRef sb);
-    void make_blob_shared(uint64_t sbid, BlobRef b);
+    void make_blob_shared(uint64_t sbid, BlobRef b, const ghobject_t& oid);
     uint64_t make_blob_unshared(SharedBlob *sb);
 
     BlobRef new_blob() {

--- a/src/os/bluestore/bluestore_types.cc
+++ b/src/os/bluestore/bluestore_types.cc
@@ -1021,6 +1021,11 @@ void bluestore_shared_blob_t::generate_test_instances(
 ostream& operator<<(ostream& out, const bluestore_shared_blob_t& sb)
 {
   out << "(sbid 0x" << std::hex << sb.sbid << std::dec;
+  if (sb.pool >= 0) {
+    out << " " << ghobject_t(hobject_t(object_t(), string(), CEPH_NOSNAP, sb.hash,
+				       sb.pool, string()),
+			     ghobject_t::NO_GEN, sb.shard);
+  }
   out << " " << sb.ref_map << ")";
   return out;
 }

--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -908,14 +908,29 @@ struct bluestore_shared_blob_t {
   uint64_t sbid;                       ///> shared blob id
   bluestore_extent_ref_map_t ref_map;  ///< shared blob extents
 
+  // approximate backpointer for who created us
+  shard_id_t shard;
+  int64_t pool = -1;
+  uint32_t hash = 0;
+
   bluestore_shared_blob_t(uint64_t _sbid) : sbid(_sbid) {}
 
   DENC(bluestore_shared_blob_t, v, p) {
-    DENC_START(1, 1, p);
+    DENC_START(2, 1, p);
     denc(v.ref_map, p);
+    if (struct_v >= 2) {
+      denc(v.shard, p);
+      denc(v.pool, p);
+      denc(v.hash, p);
+    }
     DENC_FINISH(p);
   }
 
+  void set_partial_backpointer(const ghobject_t& oid) {
+    shard = oid.shard_id;
+    pool = oid.hobj.pool;
+    hash = oid.hobj.get_hash();
+  }
 
   void dump(Formatter *f) const;
   static void generate_test_instances(list<bluestore_shared_blob_t*>& ls);


### PR DESCRIPTION
This is just enough to be able to efficiently locate the referring objects,
but no more.  It will assist fsck repair.

Signed-off-by: Sage Weil <sage@redhat.com>