### PR TITLE
msg/asyc/rmda: fix the bug of assert when Infiniband::recv_msg receives disconnect message

### DIFF
--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -200,7 +200,7 @@ int RDMAConnectedSocketImpl::try_connect(const entity_addr_t& peer_addr, const S
 void RDMAConnectedSocketImpl::handle_connection() {
   ldout(cct, 20) << __func__ << " QP: " << my_msg.qpn << " tcp_fd: " << tcp_fd << " notify_fd: " << notify_fd << dendl;
   int r = infiniband->recv_msg(cct, tcp_fd, peer_msg);
-  if (r < 0) {
+  if (r <= 0) {
     if (r != -EAGAIN) {
       dispatcher->perf_logger->inc(l_msgr_rdma_handshake_errors);
       ldout(cct, 1) << __func__ << " recv handshake msg failed." << dendl;


### PR DESCRIPTION
If the ` Infiniband::recv_msg ` receives disconnect message from tcp socket, then read function inside it will return 0. It means the `peer_msg` cannot be read and the value of all members inside `peer_msg` are zeros by default. 
the call of `ibv_modify_qp` will return Invalid Argument error when the values of peer qpn, psn, gid are all zeros

Signed-off-by: Jin Cai <caijin.caij@alibaba-inc.com>