### PR TITLE
osd: Initialization of data members

### DIFF
--- a/src/osd/ClassHandler.h
+++ b/src/osd/ClassHandler.h
@@ -59,7 +59,7 @@ public:
     ClassHandler *handler;
     void *handle;
 
-    bool whitelisted;
+    bool whitelisted = false;
 
     map<string, ClassMethod> methods_map;
     map<string, ClassFilter> filters_map;

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1220,7 +1220,7 @@ public:
     bool must_scrub, must_deep_scrub, must_repair;
 
     // Priority to use for scrub scheduling
-    unsigned priority;
+    unsigned priority = 0;
 
     // this flag indicates whether we would like to do auto-repair of the PG or not
     bool auto_repair;


### PR DESCRIPTION
Fixes the coverity issues:

** 717336 Uninitialized scalar field
>CID 717336 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member whitelisted is not initialized
in this constructor nor in any functions that it calls.

** 728001 Uninitialized scalar field
>CID 728001 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member priority is not initialized
in this constructor nor in any functions that it calls.

** 1405358 Uninitialized scalar field
>CID 1405358 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member field read_length.v is
not initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>