### PR TITLE
build/ops: python-numpy-devel build dependency for SUSE

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -109,6 +109,7 @@ BuildRequires:	python-werkzeug
 %if 0%{?suse_version}
 BuildRequires:	python-CherryPy
 BuildRequires:	python-Werkzeug
+BuildRequires:	python-numpy-devel
 %endif
 BuildRequires:	python-pecan
 BuildRequires:	socat


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21176
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 1586f2ca9ab94af85682945a3c7c7ebbd82c6e03)