### PR TITLE
qa/cephfs: kill mount if it gets evicted by mds

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -124,9 +124,7 @@ class TestMisc(CephFSTestCase):
         self.assert_session_count(2, ls_data)
 
         self.mount_a.kill()
-        self.mount_a.kill()
-        self.mount_b.kill_cleanup()
-        self.mount_b.kill_cleanup()
+        self.mount_a.kill_cleanup()
 
         time.sleep(self.mds_session_autoclose * 1.5)
         ls_data = self.fs.mds_asok(['session', 'ls'])


### PR DESCRIPTION
otherwise, teardown() hange at umount