### PR TITLE
librbd: address coverity false positives

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -104,7 +104,7 @@ struct C_GetTagOwner : public Context {
   Journaler journaler;
   cls::journal::Client client;
   journal::ImageClientMeta client_meta;
-  uint64_t tag_tid;
+  uint64_t tag_tid = 0;
   journal::TagData tag_data;
 
   C_GetTagOwner(librados::IoCtx &io_ctx, const std::string &image_id,

--- a/src/librbd/api/Mirror.cc
+++ b/src/librbd/api/Mirror.cc
@@ -82,7 +82,7 @@ struct C_ImageGetInfo : public Context {
   Context *on_finish;
 
   cls::rbd::MirrorImage mirror_image;
-  mirror::PromotionState promotion_state;
+  mirror::PromotionState promotion_state = mirror::PROMOTION_STATE_PRIMARY;
 
   C_ImageGetInfo(mirror_image_info_t *mirror_image_info, Context *on_finish)
     : mirror_image_info(mirror_image_info), on_finish(on_finish) {

--- a/src/librbd/mirror/DemoteRequest.h
+++ b/src/librbd/mirror/DemoteRequest.h
@@ -59,7 +59,7 @@ private:
   bool m_blocked_requests = false;
 
   cls::rbd::MirrorImage m_mirror_image;
-  PromotionState m_promotion_state;
+  PromotionState m_promotion_state = PROMOTION_STATE_PRIMARY;
 
   void get_info();
   void handle_get_info(int r);

--- a/src/librbd/mirror/PromoteRequest.h
+++ b/src/librbd/mirror/PromoteRequest.h
@@ -55,7 +55,7 @@ private:
   Context *m_on_finish;
 
   cls::rbd::MirrorImage m_mirror_image;
-  PromotionState m_promotion_state;
+  PromotionState m_promotion_state = PROMOTION_STATE_PRIMARY;
 
   void get_info();
   void handle_get_info(int r);


### PR DESCRIPTION
Fixes the coverity issues:

** 1402627 Uninitialized scalar field
>CID 1402627 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member promotion_state is not
initialized in this constructor nor in any functions that it calls.

** 1402630 Uninitialized scalar field
>CID 1402630 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_promotion_state is not
initialized in this constructor nor in any functions that it calls.

** 1402631 Uninitialized scalar field
>CID 1402631 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_promotion_state is not
initialized in this constructor nor in any functions that it calls.

** 1402632 Uninitialized scalar field
>CID 1402632 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member tag_tid is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>