### PR TITLE
qa/smoke: add rgw crypto config for s3tests

### DIFF
--- a/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_ec_s3tests.yaml
@@ -15,3 +15,5 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl: false

--- a/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
+++ b/qa/suites/smoke/basic/tasks/rgw_s3tests.yaml
@@ -11,3 +11,5 @@ overrides:
     conf:
       client:
         rgw lc debug interval: 10
+        rgw crypt s3 kms encryption keys: testkey-1=YmluCmJvb3N0CmJvb3N0LWJ1aWxkCmNlcGguY29uZgo= testkey-2=aWIKTWFrZWZpbGUKbWFuCm91dApzcmMKVGVzdGluZwo=
+        rgw crypt require ssl: false


### PR DESCRIPTION
fix for failing encryption s3tests in smoke suite