### PR TITLE
qa/task/ceph: Dont compress since pull_directory does the gzip compression

### DIFF
--- a/qa/tasks/ceph.py
+++ b/qa/tasks/ceph.py
@@ -207,29 +207,6 @@ def ceph_log(ctx, config):
         if ctx.archive is not None and \
                 not (ctx.config.get('archive-on-error') and ctx.summary['success']):
             # and logs
-            log.info('Compressing logs...')
-            run.wait(
-                ctx.cluster.run(
-                    args=[
-                        'sudo',
-                        'find',
-                        '/var/log/ceph',
-                        '-name',
-                        '*.log',
-                        '-print0',
-                        run.Raw('|'),
-                        'sudo',
-                        'xargs',
-                        '-0',
-                        '--no-run-if-empty',
-                        '--',
-                        'gzip',
-                        '--',
-                    ],
-                    wait=False,
-                ),
-            )
-
             log.info('Archiving logs...')
             path = os.path.join(ctx.archive, 'remote')
             os.makedirs(path)


### PR DESCRIPTION
the call to pull_directory does gzip compression so in effect we are running it twice. when we uncompress log from any teuthology run, it is still compressed and a binary file instead of a text file(ceph.log), one has to uncompress again gzip -d. 

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>