### PR TITLE
pybind/rados: add support open_ioctx2 API

### DIFF
--- a/doc/rados/api/python.rst
+++ b/doc/rados/api/python.rst
@@ -162,14 +162,22 @@ Input/Output Context
 --------------------
 
 Reading from and writing to the Ceph Storage Cluster requires an input/output
-context (ioctx). You can create an ioctx with the ``open_ioctx()`` method of the
-``Rados`` class. The ``ioctx_name`` parameter is the name of the  pool you wish
-to use.
+context (ioctx). You can create an ioctx with the ``open_ioctx()`` or
+``open_ioctx2()`` method of the ``Rados`` class. The ``ioctx_name`` parameter
+is the name of the  pool and ``pool_id`` is the ID of the pool you wish to use.
 
 .. code-block:: python
    :linenos:
 
 	ioctx = cluster.open_ioctx('data')
+
+
+or
+
+.. code-block:: python
+   :linenos:
+
+        ioctx = cluster.open_ioctx(pool_id)
 
 
 Once you have an I/O context, you can read/write objects, extended attributes,
@@ -316,9 +324,9 @@ Input/Output Context API
 ========================
 
 To write data to and read data from the Ceph Object Store, you must create
-an Input/Output context (ioctx). The `Rados` class provides a `open_ioctx()`
-method. The remaining ``ioctx`` operations involve invoking methods of the
-`Ioctx` and other classes.
+an Input/Output context (ioctx). The `Rados` class provides `open_ioctx()`
+and `open_ioctx2()` methods. The remaining ``ioctx`` operations involve
+invoking methods of the `Ioctx` and other classes.
 
 .. automethod:: Rados.open_ioctx(ioctx_name)
 .. automethod:: Ioctx.require_ioctx_open()

--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -193,6 +193,7 @@ cdef extern from "rados/librados.h" nogil:
     int rados_wait_for_latest_osdmap(rados_t cluster)
 
     int rados_ioctx_create(rados_t cluster, const char *pool_name, rados_ioctx_t *ioctx)
+    int rados_ioctx_create2(rados_t cluster, int64_t pool_id, rados_ioctx_t *ioctx)
     void rados_ioctx_destroy(rados_ioctx_t io)
     int rados_ioctx_pool_set_auid(rados_ioctx_t io, uint64_t auid)
     void rados_ioctx_locator_set_key(rados_ioctx_t io, const char *key)
@@ -1192,6 +1193,32 @@ Rados object in state %s." % self.state)
         if ret < 0:
             raise make_ex(ret, "error opening pool '%s'" % ioctx_name)
         io = Ioctx(ioctx_name)
+        io.io = ioctx
+        return io
+
+    @requires(('pool_id', int))
+    def open_ioctx2(self, pool_id):
+        """
+        Create an io context
+
+        The io context allows you to perform operations within a particular
+        pool.
+
+        :param pool_id: ID of the pool
+        :type pool_id: int
+
+        :raises: :class:`TypeError`, :class:`Error`
+        :returns: Ioctx - Rados Ioctx object
+        """
+        self.require_state("connected")
+        cdef:
+            rados_ioctx_t ioctx
+            int64_t _pool_id = pool_id
+        with nogil:
+            ret = rados_ioctx_create2(self.cluster, _pool_id, &ioctx)
+        if ret < 0:
+            raise make_ex(ret, "error opening pool id '%s'" % pool_id)
+        io = Ioctx(str(pool_id))
         io.io = ioctx
         return io
 

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -891,6 +891,49 @@ class TestIoctx(object):
         self.ioctx.application_metadata_remove("app1", "key1")
         eq([("key2", "val2")], self.ioctx.application_metadata_list("app1"))
 
+
+class TestIoctx2(object):
+
+    def setUp(self):
+        self.rados = Rados(conffile='')
+        self.rados.connect()
+        self.rados.create_pool('test_pool')
+        assert self.rados.pool_exists('test_pool')
+        pool_id = self.rados.pool_lookup('test_pool')
+        assert pool_id > 0
+        self.ioctx2 = self.rados.open_ioctx2(pool_id)
+
+    def tearDown(self):
+        cmd = {"prefix": "osd unset", "key": "noup"}
+        self.rados.mon_command(json.dumps(cmd), b'')
+        self.ioctx2.close()
+        self.rados.delete_pool('test_pool')
+        self.rados.shutdown()
+
+    def test_get_last_version(self):
+        version = self.ioctx2.get_last_version()
+        assert version >= 0
+
+    def test_get_stats(self):
+        stats = self.ioctx2.get_stats()
+        eq(stats, {'num_objects_unfound': 0,
+                   'num_objects_missing_on_primary': 0,
+                   'num_object_clones': 0,
+                   'num_objects': 0,
+                   'num_object_copies': 0,
+                   'num_bytes': 0,
+                   'num_rd_kb': 0,
+                   'num_wr_kb': 0,
+                   'num_kb': 0,
+                   'num_wr': 0,
+                   'num_objects_degraded': 0,
+                   'num_rd': 0})
+
+    def test_change_auid(self):
+        self.ioctx2.change_auid(ANONYMOUS_AUID)
+        self.ioctx2.change_auid(ADMIN_AUID)
+
+
 class TestObject(object):
 
     def setUp(self):


### PR DESCRIPTION
Can use `client.open_ioct2(pool_id)` to open an IO.

Signed-off-by: songweibin <song.weibin@zte.com.cn>