### PR TITLE
luminous: MDS: standby-replay mds should avoid initiating subtree export

### DIFF
--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6522,7 +6522,7 @@ bool MDCache::trim(int max, int count)
       if (!diri->is_auth() && !diri->is_base() &&
 	  dir->get_num_head_items() == 0) {
 	if (dir->state_test(CDir::STATE_EXPORTING) ||
-	    dir->is_freezing() || dir->is_frozen())
+	    dir->is_freezing() || dir->is_frozen() || !mds->is_active())
 	  continue;
 
 	migrator->export_empty_import(dir);

--- a/src/mds/MDCache.cc
+++ b/src/mds/MDCache.cc
@@ -6522,7 +6522,8 @@ bool MDCache::trim(int max, int count)
       if (!diri->is_auth() && !diri->is_base() &&
 	  dir->get_num_head_items() == 0) {
 	if (dir->state_test(CDir::STATE_EXPORTING) ||
-	    dir->is_freezing() || dir->is_frozen() || !mds->is_active())
+	    !(mds->is_active() || mds->is_stopping()) ||
+	    dir->is_freezing() || dir->is_frozen())
 	  continue;
 
 	migrator->export_empty_import(dir);

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -776,6 +776,10 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   assert(dir->is_auth());
   assert(dest != mds->get_nodeid());
    
+  if (!(mds->is_active() || mds->is_stopping())) {
+    dout(7) << "i'm not active, no exports for now" << dendl;
+    return;
+  }
   if (mds->mdcache->is_readonly()) {
     dout(7) << "read-only FS, no exports for now" << dendl;
     return;
@@ -791,10 +795,6 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
   if (dir->inode->is_system()) {
     dout(7) << "i won't export system dirs (root, mdsdirs, stray, /.ceph, etc.)" << dendl;
     //ceph_abort();
-    return;
-  }
-  if (!mds->is_active()) {
-    dout(7) << "i'm not active, no exports for now" << dendl;
     return;
   }
 

--- a/src/mds/Migrator.cc
+++ b/src/mds/Migrator.cc
@@ -793,6 +793,10 @@ void Migrator::export_dir(CDir *dir, mds_rank_t dest)
     //ceph_abort();
     return;
   }
+  if (!mds->is_active()) {
+    dout(7) << "i'm not active, no exports for now" << dendl;
+    return;
+  }
 
   if (!dir->inode->is_base() && dir->inode->get_projected_parent_dir()->inode->is_stray() &&
       dir->inode->get_projected_parent_dir()->get_parent_dir()->ino() != MDS_INO_MDSDIR(dest)) {


### PR DESCRIPTION
http://tracker.ceph.com/issues/21322
http://tracker.ceph.com/issues/21385