### PR TITLE
osd: get loadavg per cpu for scrub load threshold check

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -13,7 +13,7 @@
  *
  */
 #include "acconfig.h"
-
+#include <unistd.h>
 #include <fstream>
 #include <iostream>
 #include <errno.h>
@@ -7099,8 +7099,10 @@ bool OSD::scrub_load_below_threshold()
   }
 
   // allow scrub if below configured threshold
-  if (loadavgs[0] < cct->_conf->osd_scrub_load_threshold) {
-    dout(20) << __func__ << " loadavg " << loadavgs[0]
+  long cpus = sysconf(_SC_NPROCESSORS_ONLN);
+  double loadavg_per_cpu = cpus > 0 ? loadavgs[0] / cpus : loadavgs[0];
+  if (loadavg_per_cpu < cct->_conf->osd_scrub_load_threshold) {
+    dout(20) << __func__ << " loadavg per cpu " << loadavg_per_cpu
 	     << " < max " << cct->_conf->osd_scrub_load_threshold
 	     << " = yes" << dendl;
     return true;


### PR DESCRIPTION
getloadavg return the system cpu loads, it's the total load of all cpus. the  _conf->osd_scrub_load_threshold is 0.5 default,  it's very little for multi cores system, if use  loadavg[0] to compare with 0.5,  loadavg[0] > 0.5 is always true in most of time even cluster has no ios from client.
so i think the loadavg[0] per cpu is larger than  0.5 may be what we want to judge the system is in high load, we then not do scrub.
@yangdongsheng 
