### PR TITLE
rgw: distinguish different get_usage for usage log

### DIFF
--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -757,7 +757,7 @@ public:
 
   virtual bool should_get_stats() { return false; }
 
-  const char* name() const override { return "get_usage"; }
+  const char* name() const override { return "get_self_usage"; }
   uint32_t op_mask() override { return RGW_OP_TYPE_READ; }
 };
 


### PR DESCRIPTION
get_usage op via s3 endpoint are not the same as get_usage
via admin endpoint in the rgw usage log categories.

Signed-off-by: Jiaying Ren <jiaying.ren@umcloud.com>