### PR TITLE
librbd: address coverity false positives

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -1642,7 +1642,7 @@ struct C_RefreshTags : public Context {
   Context *on_finish = nullptr;
 
   Mutex lock;
-  uint64_t tag_tid;
+  uint64_t tag_tid = 0;
   journal::TagData tag_data;
 
   C_RefreshTags(util::AsyncOpTracker &async_op_tracker)

--- a/src/librbd/operation/ObjectMapIterate.h
+++ b/src/librbd/operation/ObjectMapIterate.h
@@ -49,7 +49,7 @@ private:
   ProgressContext &m_prog_ctx;
   ObjectIterateWork<ImageCtxT> m_handle_mismatch;
   std::atomic_flag m_invalidate = ATOMIC_FLAG_INIT;
-  State m_state;
+  State m_state = STATE_VERIFY_OBJECTS;
 
   void send_verify_objects();
   void send_invalidate_object_map();

--- a/src/librbd/operation/RenameRequest.h
+++ b/src/librbd/operation/RenameRequest.h
@@ -68,7 +68,7 @@ private:
   std::string m_source_oid;
   std::string m_dest_oid;
 
-  State m_state;
+  State m_state = STATE_READ_SOURCE_HEADER;
 
   bufferlist m_header_bl;
 


### PR DESCRIPTION
Fixes the coverity issues:

** 1396177 Uninitialized scalar field
>CID 1396177 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_state is not initialized
in this constructor nor in any functions that it calls.

** 1396178 Uninitialized scalar field
>CID 1396178 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member tag_tid is not initialized
in this constructor nor in any functions that it calls.

** 1396203 Uninitialized scalar field
>CID 1396203 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member m_state is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>