### PR TITLE
rgw: Initialization of epoch,len

### DIFF
--- a/src/rgw/rgw_file.h
+++ b/src/rgw/rgw_file.h
@@ -265,6 +265,8 @@ namespace rgw {
       : fs(_fs), bucket(nullptr), parent(nullptr), variant_type{directory()},
 	depth(0), flags(FLAG_NONE)
       {
+        fh.fh_hk.bucket = 0;
+        fh.fh_hk.object = 0;
 	/* root */
 	fh.fh_type = RGW_FS_TYPE_DIRECTORY;
 	variant_type = directory();

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -2022,7 +2022,7 @@ public:
 };
 
 class RGWPutBucketPolicy : public RGWOp {
-  int len;
+  int len = 0;
   char *data = nullptr;
 public:
   RGWPutBucketPolicy() = default;

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -947,7 +947,7 @@ struct RGWRawObjState {
   bool exists{false};
   uint64_t size{0};
   ceph::real_time mtime;
-  uint64_t epoch;
+  uint64_t epoch{0};
   bufferlist obj_tag;
   bool has_data{false};
   bufferlist data;


### PR DESCRIPTION
Fixes the coverity issues:

** 1402628 Uninitialized scalar field
>CID 1402628 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member epoch is not initialized
in this constructor nor in any functions that it calls.

** 1409841 Uninitialized scalar field
>CID 1409841 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member len is not initialized
in this constructor nor in any functions that it calls.

** 1416594 Uninitialized scalar field
>CID 1416594 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member field fh.fh_hk is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>