### PR TITLE
rados: Initialization of alignment

### DIFF
--- a/src/test/librados/TestCase.h
+++ b/src/test/librados/TestCase.h
@@ -118,7 +118,7 @@ protected:
   void TearDown() override;
   librados::Rados &cluster;
   librados::IoCtx ioctx;
-  uint64_t alignment;
+  uint64_t alignment = 0;
   bool cleanup;
 };
 
@@ -230,7 +230,7 @@ protected:
   librados::IoCtx ioctx;
   bool cleanup;
   std::string nspace;
-  uint64_t alignment;
+  uint64_t alignment = 0;
 };
 
 /**


### PR DESCRIPTION
Fixes the coverity issues:

** 1409700 Uninitialized scalar field
>CID 1409700 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member alignment is not initialized
in this constructor nor in any functions that it calls.

** 1409702 Uninitialized scalar field
>CID 1409702 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member alignment is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>