### PR TITLE
rgw: Initialization of sync_tracer,rgwx_stat,calc_md5

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3646,7 +3646,7 @@ void RGWPostObj::execute()
    * is capable to handle multiple files in single form. */
   do {
     std::unique_ptr<RGWPutObjDataProcessor> encrypt;
-    char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1];
+    char calc_md5[CEPH_CRYPTO_MD5_DIGESTSIZE * 2 + 1] = "";
     unsigned char m[CEPH_CRYPTO_MD5_DIGESTSIZE];
     MD5 hash;
     ceph::buffer::list bl, aclbl;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -208,7 +208,7 @@ protected:
   utime_t gc_invalidate_time;
   bool is_slo;
   string lo_etag;
-  bool rgwx_stat; /* extended rgw stat operation */
+  bool rgwx_stat = false; /* extended rgw stat operation */
   string version_id;
 
   // compression attrs

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2266,7 +2266,7 @@ class RGWRados
   RGWMetaNotifier *meta_notifier;
   RGWDataNotifier *data_notifier;
   RGWMetaSyncProcessorThread *meta_sync_processor_thread;
-  RGWSyncTraceManager *sync_tracer;
+  RGWSyncTraceManager *sync_tracer = nullptr;
   map<string, RGWDataSyncProcessorThread *> data_sync_processor_threads;
 
   RGWSyncLogTrimThread *sync_log_trimmer{nullptr};


### PR DESCRIPTION
Fixes the coverity issues:

** 717382 Uninitialized pointer field
>CID 717382 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member sync_tracer is not
initialized in this constructor nor in any functions that it calls.

** 717379 Uninitialized scalar field
>CID 717379 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member rgwx_stat is not initialized
in this constructor nor in any functions that it calls.

** 1414873 Uninitialized scalar variable
>CID 1414873 (#1 of 1): Uninitialized scalar variable (UNINIT)
>25. uninit_use_in_call: Using uninitialized element of array
calc_md5 when calling strcmp.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>