### PR TITLE
pybind: remove unused get_ceph_version()

### DIFF
--- a/src/pybind/rados/setup.py
+++ b/src/pybind/rados/setup.py
@@ -21,20 +21,7 @@ from distutils.sysconfig import customize_compiler
 
 # PEP 440 versioning of the Rados package on PyPI
 # Bump this version, after every changeset
-# NOTE: This version is not the same as get_ceph_version()
-
 __version__ = '2.0.0'
-
-
-def get_ceph_version():
-    try:
-        for line in open(os.path.join(os.path.dirname(__file__), "..", "..", "ceph_ver.h")):
-            if "CEPH_GIT_NICE_VER" in line:
-                return line.split()[2].strip('"')
-        else:
-            return "0"
-    except IOError:
-        return "0"
 
 
 def get_python_flags():


### PR DESCRIPTION
get_ceph_version() was get_version() before 7b04e7ff. and after that
change, the version number of the python extension is hardwired to
`__version__`. because pybind is a wrapper around the public APIs
exposed by librados, librbd and libcephfs, which are versioned
separately from ceph daemons and tools, it's reasonable not to use the
version number in ceph_ver.h. thus, it's safe to drop this function.

Signed-off-by: Kefu Chai <kchai@redhat.com>