### PR TITLE
mon: cleanup unused option mon_health_data_update_interval

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -272,7 +272,6 @@ OPTION(mon_reweight_min_pgs_per_osd, OPT_U64)   // min pgs per osd for reweight-
 OPTION(mon_reweight_min_bytes_per_osd, OPT_U64)   // min bytes per osd for reweight-by-utilization command
 OPTION(mon_reweight_max_osds, OPT_INT)   // max osds to change per reweight-by-* command
 OPTION(mon_reweight_max_change, OPT_DOUBLE)
-OPTION(mon_health_data_update_interval, OPT_FLOAT)
 OPTION(mon_health_to_clog, OPT_BOOL)
 OPTION(mon_health_to_clog_interval, OPT_INT)
 OPTION(mon_health_to_clog_tick_interval, OPT_DOUBLE)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1174,10 +1174,6 @@ std::vector<Option> get_global_options() {
     .set_default(0.05)
     .set_description(""),
 
-    Option("mon_health_data_update_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(60.0)
-    .set_description(""),
-
     Option("mon_health_to_clog", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),


### PR DESCRIPTION
The config option **mon_health_data_update_interval** seems to be unused now.

Signed-off-by: Yao Guotao <yaoguot@gmail.com>