### PR TITLE
common: lockdep fixes

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4118,7 +4118,8 @@ void Client::trim_caps(MetaSession *s, int max)
     }
   }
 
-  if (s->caps.size() > max)
+  caps_size = s->caps.size();
+  if (caps_size > max)
     _invalidate_kernel_dcache();
 }
 

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -163,11 +163,10 @@ int lockdep_get_free_id(void)
   return -1;
 }
 
-int lockdep_register(const char *name)
+static int _lockdep_register(const char *name)
 {
   int id;
 
-  pthread_mutex_lock(&lockdep_mutex);
   ceph::unordered_map<std::string, int>::iterator p = lock_ids.find(name);
   if (p == lock_ids.end()) {
     id = lockdep_get_free_id();
@@ -191,8 +190,17 @@ int lockdep_register(const char *name)
   }
 
   ++lock_refs[id];
-  pthread_mutex_unlock(&lockdep_mutex);
 
+  return id;
+}
+
+int lockdep_register(const char *name)
+{
+  int id;
+
+  pthread_mutex_lock(&lockdep_mutex);
+  id = _lockdep_register(name);
+  pthread_mutex_unlock(&lockdep_mutex);
   return id;
 }
 
@@ -269,9 +277,10 @@ static bool does_follow(int a, int b)
 int lockdep_will_lock(const char *name, int id, bool force_backtrace)
 {
   pthread_t p = pthread_self();
-  if (id < 0) id = lockdep_register(name);
 
   pthread_mutex_lock(&lockdep_mutex);
+  if (id < 0)
+    id = _lockdep_register(name);
   lockdep_dout(20) << "_will_lock " << name << " (" << id << ")" << dendl;
 
   // check dependency graph
@@ -343,9 +352,10 @@ int lockdep_locked(const char *name, int id, bool force_backtrace)
 {
   pthread_t p = pthread_self();
 
-  if (id < 0) id = lockdep_register(name);
-
   pthread_mutex_lock(&lockdep_mutex);
+  if (id < 0)
+    id = _lockdep_register(name);
+
   lockdep_dout(20) << "_locked " << name << dendl;
   if (force_backtrace || lockdep_force_backtrace())
     held[p][id] = new BackTrace(BACKTRACE_SKIP);

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -33,7 +33,7 @@ namespace std {
 #define BACKTRACE_SKIP 2
 
 /******* Globals **********/
-int g_lockdep = 0;
+bool g_lockdep;
 struct lockdep_stopper_t {
   // disable lockdep when this module destructs.
   ~lockdep_stopper_t() {

--- a/src/common/lockdep.h
+++ b/src/common/lockdep.h
@@ -17,7 +17,7 @@
 
 class CephContext;
 
-extern int g_lockdep;
+extern bool g_lockdep;
 
 extern void lockdep_register_ceph_context(CephContext *cct);
 extern void lockdep_unregister_ceph_context(CephContext *cct);


### PR DESCRIPTION
This is mostly intended as a fix for this tracker bug:

http://tracker.ceph.com/issues/20988

...though there are a couple of other small fixes in here too, and a new testcase.

The fix for 20988 is basically to ensure that when we find that we've raced with the lockdep cct being deregistered that we handle it sanely. There's also a small optimization in here, where we were taking a mutex twice in succession instead of doing all of the work under the same lock, a compile-time fix for a warning, and a cleanup of a testcase that was manipulating g_lockdep unsafely.

This should be backportable as well.