### PR TITLE
luminous: rocksdb,cmake:  build portable binaries

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -811,13 +811,8 @@ if (NOT WITH_SYSTEM_ROCKSDB)
     list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_COMPILER=${CMAKE_CXX_COMPILER})
   endif(WITH_CCACHE AND CCACHE_FOUND)
 
-  # We really want to have the CRC32 calculation in RocksDB accelerated
-  # with SSE 4.2. For details refer to rocksdb/util/crc32c.cc.
-  if (HAVE_INTEL_SSE4_2)
-    list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_CXX_FLAGS=${SIMD_COMPILE_FLAGS})
-  else()
-    list(APPEND ROCKSDB_CMAKE_ARGS -DWITH_SSE42=OFF)
-  endif()
+  # SSE 4.2 is enabled by default in rocksdb's crc32c. For details refer to
+  # rocksdb/util/crc32c.cc.
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_AR=${CMAKE_AR})
   list(APPEND ROCKSDB_CMAKE_ARGS -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE})
 


### PR DESCRIPTION
backport of #17388

- pick up changes in rocksdb so it won't enable SSE42 globally
- do not add `-msse42` to rocksdb's CFLAGS

Fixes: http://tracker.ceph.com/issues/20529
Backports: http://tracker.ceph.com/issues/21396