### PR TITLE
client: silence warning from -Wsign-compare

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -4118,7 +4118,7 @@ void Client::trim_caps(MetaSession *s, uint64_t max)
     }
   }
 
-  if (s->caps.size() > max)
+  if (static_cast<int>(s->caps.size()) > max)
     _invalidate_kernel_dcache();
 }
 


### PR DESCRIPTION
Fixed the following warning:
```
ceph/src/client/Client.cc: In member function ‘void Client::trim_caps(MetaSession*, int)’:
ceph/src/client/Client.cc:4121:24: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (s->caps.size() > max)
                        ^
```
Signed-off-by: Jos Collin <jcollin@redhat.com>