### PR TITLE
mgr: set explicit thread name

### DIFF
--- a/src/ceph_mgr.cc
+++ b/src/ceph_mgr.cc
@@ -16,7 +16,10 @@
 
 #include <Python.h>
 
+#include <pthread.h>
+
 #include "include/types.h"
+#include "include/compat.h"
 #include "common/config.h"
 #include "common/ceph_argparse.h"
 #include "common/errno.h"
@@ -38,6 +41,8 @@ static void usage()
  */
 int main(int argc, const char **argv)
 {
+  ceph_pthread_setname(pthread_self(), "ceph-mgr");
+
   vector<const char*> args;
   argv_to_vec(argc, argv, args);
   env_to_vec(args);


### PR DESCRIPTION
This gets used as our process name in some situations
when respawning.  This is the same as what commit 4f177bb6b
did for the MDS.

Fixes: http://tracker.ceph.com/issues/21404
Signed-off-by: John Spray <john.spray@redhat.com>