### PR TITLE
rgw: Check payment operations in policy

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5017,6 +5017,12 @@ void RGWOptionsCORS::execute()
 
 int RGWGetRequestPayment::verify_permission()
 {
+  if (s->iam_policy &&
+      s->iam_policy->eval(s->env, *s->auth.identity,
+			  rgw::IAM::s3GetBucketRequestPayment,
+			  ARN(s->bucket)) != Effect::Allow) {
+      return -EACCES;
+  }
   return 0;
 }
 
@@ -5032,11 +5038,16 @@ void RGWGetRequestPayment::execute()
 
 int RGWSetRequestPayment::verify_permission()
 {
-  if (false == s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
-    return -EACCES;
+  if (s->iam_policy) {
+    if (s->iam_policy->eval(s->env, *s->auth.identity,
+			    rgw::IAM::s3PutBucketRequestPayment,
+			    ARN(s->bucket)) == Effect::Allow) {
+      return 0;
+    }
+  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+    return 0;
   }
-
-  return 0;
+  return -EACCES;
 }
 
 void RGWSetRequestPayment::pre_exec()


### PR DESCRIPTION
Add code to check s3:GetBucketRequestPayment and
s3:PutBucketRequestPayment operations against bucket policy.

Fixes: http://tracker.ceph.com/issues/21389
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1490278

Signed-off-by: Adam C. Emerson <aemerson@redhat.com>
(cherry picked from commit ca66a5abbfd6dc3ab0ac767a6b787db1d8d5868a)
Signed-off-by: Adam C. Emerson <aemerson@redhat.com>