### PR TITLE
rgw multisite: automated trimming for bucket index logs

### DIFF
--- a/qa/tasks/rgw_multisite.py
+++ b/qa/tasks/rgw_multisite.py
@@ -187,7 +187,8 @@ class Cluster(multisite.Cluster):
         """ radosgw-admin command """
         args = args or []
         args += ['--cluster', self.name]
-        args += ['--debug-rgw', '0']
+        args += ['--debug-rgw', str(kwargs.pop('debug_rgw', 0))]
+        args += ['--debug-ms', str(kwargs.pop('debug_ms', 0))]
         if kwargs.pop('read_only', False):
             args += ['--rgw-cache-enabled', 'false']
         kwargs['decode'] = False

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -4,6 +4,7 @@
 #include "include/str_list.h"
 #include "include/rados/librados.hpp"
 #include "cls_rgw_ops.h"
+#include "cls_rgw_const.h"
 #include "common/RefCountedObj.h"
 #include "include/compat.h"
 #include "common/ceph_time.h"

--- a/src/cls/rgw/cls_rgw_client.h
+++ b/src/cls/rgw/cls_rgw_client.h
@@ -218,6 +218,15 @@ public:
     }
     return 0;
   }
+
+  // trim the '<shard-id>#' prefix from a single shard marker if present
+  static std::string get_shard_marker(const std::string& marker) {
+    auto p = marker.find(KEY_VALUE_SEPARATOR);
+    if (p == marker.npos) {
+      return marker;
+    }
+    return marker.substr(p + 1);
+  }
 };
 
 /* bucket index */

--- a/src/common/bounded_key_counter.h
+++ b/src/common/bounded_key_counter.h
@@ -1,0 +1,187 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat, Inc
+ *
+ * Author: Casey Bodley <cbodley@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ *
+ */
+
+#ifndef BOUNDED_KEY_COUNTER_H
+#define BOUNDED_KEY_COUNTER_H
+
+#include <algorithm>
+#include <map>
+#include <tuple>
+#include <vector>
+
+#include "include/assert.h"
+
+/**
+ * BoundedKeyCounter
+ *
+ * A data structure that counts the number of times a given key is inserted,
+ * and can return the keys with the highest counters. The number of unique keys
+ * is bounded by the given constructor argument, meaning that new keys will be
+ * rejected if they would exceed this bound.
+ *
+ * It is optimized for use where insertion is frequent, but sorted listings are
+ * both infrequent and tend to request a small subset of the available keys.
+ */
+template <typename Key, typename Count>
+class BoundedKeyCounter {
+  /// map type to associate keys with their counter values
+  using map_type = std::map<Key, Count>;
+  using value_type = typename map_type::value_type;
+
+  /// view type used for sorting key-value pairs by their counter value
+  using view_type = std::vector<const value_type*>;
+
+  /// maximum number of counters to store at once
+  const size_t bound;
+
+  /// map of counters, with a maximum size given by 'bound'
+  map_type counters;
+
+  /// storage for sorted key-value pairs
+  view_type sorted;
+
+  /// remembers how much of the range is actually sorted
+  typename view_type::iterator sorted_position;
+
+  /// invalidate view of sorted entries
+  void invalidate_sorted()
+  {
+    sorted_position = sorted.begin();
+    sorted.clear();
+  }
+
+  /// value_type comparison function for sorting in descending order
+  static bool value_greater(const value_type *lhs, const value_type *rhs)
+  {
+    return lhs->second > rhs->second;
+  }
+
+  /// map iterator that adapts value_type to value_type*
+  struct const_pointer_iterator : public map_type::const_iterator {
+    const_pointer_iterator(typename map_type::const_iterator i)
+      : map_type::const_iterator(i) {}
+    const value_type* operator*() const {
+      return &map_type::const_iterator::operator*();
+    }
+  };
+
+ protected:
+  /// return the number of sorted entries. marked protected for unit testing
+  size_t get_num_sorted() const
+  {
+    using const_iterator = typename view_type::const_iterator;
+    return std::distance<const_iterator>(sorted.begin(), sorted_position);
+  }
+
+ public:
+  BoundedKeyCounter(size_t bound)
+    : bound(bound)
+  {
+    sorted.reserve(bound);
+    sorted_position = sorted.begin();
+  }
+
+  /// return the number of keys stored
+  size_t size() const noexcept { return counters.size(); }
+
+  /// return the maximum number of keys
+  size_t capacity() const noexcept { return bound; }
+
+  /// increment a counter for the given key and return its value. if the key was
+  /// not present, insert it. if the map is full, return 0
+  Count insert(const Key& key, Count n = 1)
+  {
+    typename map_type::iterator i;
+
+    if (counters.size() < bound) {
+      // insert new entries at count=0
+      bool inserted;
+      std::tie(i, inserted) = counters.emplace(key, 0);
+      if (inserted) {
+        sorted.push_back(&*i);
+      }
+    } else {
+      // when full, refuse to insert new entries
+      i = counters.find(key);
+      if (i == counters.end()) {
+        return 0;
+      }
+    }
+
+    i->second += n; // add to the counter
+
+    // update sorted position if necessary. use a binary search for the last
+    // element in the sorted range that's greater than this counter
+    sorted_position = std::lower_bound(sorted.begin(), sorted_position,
+                                       &*i, &value_greater);
+
+    return i->second;
+  }
+
+  /// remove the given key from the map of counters
+  void erase(const Key& key)
+  {
+    auto i = counters.find(key);
+    if (i == counters.end()) {
+      return;
+    }
+    // removing the sorted entry would require linear search; invalidate instead
+    invalidate_sorted();
+
+    counters.erase(i);
+  }
+
+  /// query the highest N key-value pairs sorted by counter value, passing each
+  /// in order to the given callback with arguments (Key, Count)
+  template <typename Callback>
+  void get_highest(size_t count, Callback&& cb)
+  {
+    if (sorted.empty()) {
+      // initialize the vector with pointers to all key-value pairs
+      sorted.assign(const_pointer_iterator{counters.cbegin()},
+                    const_pointer_iterator{counters.cend()});
+      // entire range is unsorted
+      assert(sorted_position == sorted.begin());
+    }
+
+    const size_t sorted_count = get_num_sorted();
+    if (sorted_count < count) {
+      // move sorted_position to cover the requested number of entries
+      sorted_position = sorted.begin() + std::min(count, sorted.size());
+
+      // sort all entries in descending order up to the given position
+      std::partial_sort(sorted.begin(), sorted_position, sorted.end(),
+                        &value_greater);
+    }
+
+    // return the requested range via callback
+    for (const auto& pair : sorted) {
+      if (count-- == 0) {
+        return;
+      }
+      cb(pair->first, pair->second);
+    }
+  }
+
+  /// remove all keys and counters and invalidate the sorted range
+  void clear()
+  {
+    invalidate_sorted();
+    counters.clear();
+  }
+};
+
+#endif // BOUNDED_KEY_COUNTER_H

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5012,15 +5012,26 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_sync_log_trim_max_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(16)
-    .set_description("Maximum number of buckets to trim per interval"),
+    .set_description("Maximum number of buckets to trim per interval")
+    .set_long_description("The maximum number of buckets to consider for bucket index log trimming each trim interval, regardless of the number of bucket index shards. Priority is given to buckets with the most sync activity over the last trim interval.")
+    .add_see_also("rgw_sync_log_trim_interval")
+    .add_see_also("rgw_sync_log_trim_min_cold_buckets")
+    .add_see_also("rgw_sync_log_trim_concurrent_buckets"),
 
     Option("rgw_sync_log_trim_min_cold_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(4)
-    .set_description("Minimum number of cold buckets to trim per interval"),
+    .set_description("Minimum number of cold buckets to trim per interval")
+    .set_long_description("Of the `rgw_sync_log_trim_max_buckets` selected for bucket index log trimming each trim interval, at least this many of them must be 'cold' buckets. These buckets are selected in order from the list of all bucket instances, to guarantee that all buckets will be visited eventually.")
+    .add_see_also("rgw_sync_log_trim_interval")
+    .add_see_also("rgw_sync_log_trim_max_buckets")
+    .add_see_also("rgw_sync_log_trim_concurrent_buckets"),
 
     Option("rgw_sync_log_trim_concurrent_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(4)
-    .set_description("Maximum number of buckets to trim in parallel"),
+    .set_description("Maximum number of buckets to trim in parallel")
+    .add_see_also("rgw_sync_log_trim_interval")
+    .add_see_also("rgw_sync_log_trim_max_buckets")
+    .add_see_also("rgw_sync_log_trim_min_cold_buckets"),
 
     Option("rgw_sync_data_inject_err_probability", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5010,6 +5010,18 @@ std::vector<Option> get_rgw_options() {
     .set_default(1200)
     .set_description(""),
 
+    Option("rgw_sync_log_trim_max_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(16)
+    .set_description("Maximum number of buckets to trim per interval"),
+
+    Option("rgw_sync_log_trim_min_cold_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(4)
+    .set_description("Minimum number of cold buckets to trim per interval"),
+
+    Option("rgw_sync_log_trim_concurrent_buckets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(4)
+    .set_description("Maximum number of buckets to trim in parallel"),
+
     Option("rgw_sync_data_inject_err_probability", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(0)
     .set_description(""),

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -76,6 +76,7 @@ set(rgw_a_srcs
   rgw_sync_module_es.cc
   rgw_sync_module_es_rest.cc
   rgw_sync_module_log.cc
+  rgw_sync_log_trim.cc
   rgw_sync_trace.cc
   rgw_period_history.cc
   rgw_period_puller.cc

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1728,6 +1728,7 @@ struct rgw_obj_key {
     DECODE_FINISH(bl);
   }
   void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_obj_key)
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -482,10 +482,10 @@ bool RGWOmapAppend::finish() {
 int RGWAsyncGetBucketInstanceInfo::_send_request()
 {
   RGWObjectCtx obj_ctx(store);
-  int r = store->get_bucket_instance_info(obj_ctx, bucket, *bucket_info, NULL, NULL);
+  int r = store->get_bucket_instance_from_oid(obj_ctx, oid, *bucket_info, NULL, NULL);
   if (r < 0) {
     ldout(store->ctx(), 0) << "ERROR: failed to get bucket instance info for "
-        << bucket << dendl;
+        << oid << dendl;
     return r;
   }
 

--- a/src/rgw/rgw_cr_rados.cc
+++ b/src/rgw/rgw_cr_rados.cc
@@ -492,25 +492,14 @@ int RGWAsyncGetBucketInstanceInfo::_send_request()
   return 0;
 }
 
-static std::string normalize_shard_marker(const std::string& marker)
-{
-  // markers may be formatted with '<shard-id>#' at the beginning.
-  // CLSRGWIssueBILogTrim would fix this for us, but it's synchronous
-  auto p = marker.find(BucketIndexShardsManager::KEY_VALUE_SEPARATOR);
-  if (p == marker.npos) {
-    return marker;
-  }
-  return marker.substr(p + 1);
-}
-
 RGWRadosBILogTrimCR::RGWRadosBILogTrimCR(RGWRados *store,
                                          const RGWBucketInfo& bucket_info,
                                          int shard_id,
                                          const std::string& start_marker,
                                          const std::string& end_marker)
   : RGWSimpleCoroutine(store->ctx()), bs(store),
-    start_marker(normalize_shard_marker(start_marker)),
-    end_marker(normalize_shard_marker(end_marker))
+    start_marker(BucketIndexShardsManager::get_shard_marker(start_marker)),
+    end_marker(BucketIndexShardsManager::get_shard_marker(end_marker))
 {
   bs.init(bucket_info, shard_id);
 }

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -1154,4 +1154,23 @@ class RGWStatObjCR : public RGWSimpleCoroutine {
   int request_complete() override;
 };
 
+/// coroutine wrapper for IoCtx::aio_notify()
+class RGWRadosNotifyCR : public RGWSimpleCoroutine {
+  RGWRados *const store;
+  const rgw_raw_obj obj;
+  bufferlist request;
+  const uint64_t timeout_ms;
+  bufferlist *response;
+  rgw_rados_ref ref;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+
+public:
+  RGWRadosNotifyCR(RGWRados *store, const rgw_raw_obj& obj,
+                   bufferlist& request, uint64_t timeout_ms,
+                   bufferlist *response);
+
+  int send_request() override;
+  int request_complete() override;
+};
+
 #endif

--- a/src/rgw/rgw_cr_rados.h
+++ b/src/rgw/rgw_cr_rados.h
@@ -716,6 +716,20 @@ public:
   }
 };
 
+class RGWRadosBILogTrimCR : public RGWSimpleCoroutine {
+  RGWRados::BucketShard bs;
+  std::string start_marker;
+  std::string end_marker;
+  boost::intrusive_ptr<RGWAioCompletionNotifier> cn;
+ public:
+  RGWRadosBILogTrimCR(RGWRados *store, const RGWBucketInfo& bucket_info,
+                      int shard_id, const std::string& start_marker,
+                      const std::string& end_marker);
+
+  int send_request() override;
+  int request_complete() override;
+};
+
 class RGWAsyncFetchRemoteObj : public RGWAsyncRadosRequest {
   RGWRados *store;
   string source_zone;

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -3106,6 +3106,61 @@ string RGWBucketSyncStatusManager::status_oid(const string& source_zone,
   return bucket_status_oid_prefix + "." + source_zone + ":" + bs.get_key();
 }
 
+class RGWCollectBucketSyncStatusCR : public RGWShardCollectCR {
+  static constexpr int max_concurrent_shards = 16;
+  RGWRados *const store;
+  RGWDataSyncEnv *const env;
+  const int num_shards;
+  rgw_bucket_shard bs;
+
+  using Vector = std::vector<rgw_bucket_shard_sync_info>;
+  Vector::iterator i, end;
+
+ public:
+  RGWCollectBucketSyncStatusCR(RGWRados *store, RGWDataSyncEnv *env,
+                               int num_shards, const rgw_bucket& bucket,
+                               Vector *status)
+    : RGWShardCollectCR(store->ctx(), max_concurrent_shards),
+      store(store), env(env), num_shards(num_shards),
+      bs(bucket, num_shards > 0 ? 0 : -1), // start at shard 0 or -1
+      i(status->begin()), end(status->end())
+  {}
+
+  bool spawn_next() override {
+    if (i == end) {
+      return false;
+    }
+    spawn(new RGWReadBucketSyncStatusCoroutine(env, bs, &*i), false);
+    ++i;
+    ++bs.shard_id;
+    return true;
+  }
+};
+
+int rgw_bucket_sync_status(RGWRados *store, const std::string& source_zone,
+                           const rgw_bucket& bucket,
+                           std::vector<rgw_bucket_shard_sync_info> *status)
+{
+  // read the bucket instance info for num_shards
+  RGWObjectCtx ctx(store);
+  RGWBucketInfo info;
+  int ret = store->get_bucket_instance_info(ctx, bucket, info, nullptr, nullptr);
+  if (ret < 0) {
+    return ret;
+  }
+  status->clear();
+  status->resize(std::max<size_t>(1, info.num_shards));
+
+  RGWDataSyncEnv env;
+  RGWSyncModuleInstanceRef module; // null sync module
+  env.init(store->ctx(), store, nullptr, store->get_async_rados(),
+           nullptr, nullptr, nullptr, source_zone, module);
+
+  RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
+  return crs.run(new RGWCollectBucketSyncStatusCR(store, &env, info.num_shards,
+                                                  bucket, status));
+}
+
 
 // TODO: move into rgw_data_sync_trim.cc
 #undef dout_prefix

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -11,6 +11,9 @@
 #include "common/RWLock.h"
 #include "common/ceph_json.h"
 
+namespace rgw {
+class BucketChangeObserver;
+}
 
 struct rgw_datalog_info {
   uint32_t num_shards;
@@ -218,13 +221,15 @@ struct RGWDataSyncEnv {
   RGWSyncTraceManager *sync_tracer{nullptr};
   string source_zone;
   RGWSyncModuleInstanceRef sync_module{nullptr};
+  rgw::BucketChangeObserver *observer{nullptr};
 
   RGWDataSyncEnv() {}
 
   void init(CephContext *_cct, RGWRados *_store, RGWRESTConn *_conn,
             RGWAsyncRadosProcessor *_async_rados, RGWHTTPManager *_http_manager,
             RGWSyncErrorLogger *_error_logger, RGWSyncTraceManager *_sync_tracer,
-            const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module) {
+            const string& _source_zone, RGWSyncModuleInstanceRef& _sync_module,
+            rgw::BucketChangeObserver *_observer) {
     cct = _cct;
     store = _store;
     conn = _conn;
@@ -234,6 +239,7 @@ struct RGWDataSyncEnv {
     sync_tracer = _sync_tracer;
     source_zone = _source_zone;
     sync_module = _sync_module;
+    observer = _observer;
   }
 
   string shard_obj_name(int shard_id);
@@ -243,6 +249,7 @@ struct RGWDataSyncEnv {
 class RGWRemoteDataLog : public RGWCoroutinesManager {
   RGWRados *store;
   RGWAsyncRadosProcessor *async_rados;
+  rgw::BucketChangeObserver *observer;
   RGWHTTPManager http_manager;
 
   RGWDataSyncEnv sync_env;
@@ -255,9 +262,10 @@ class RGWRemoteDataLog : public RGWCoroutinesManager {
   bool initialized;
 
 public:
-  RGWRemoteDataLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados)
+  RGWRemoteDataLog(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
+                   rgw::BucketChangeObserver *observer)
     : RGWCoroutinesManager(_store->ctx(), _store->get_cr_registry()),
-      store(_store), async_rados(async_rados),
+      store(_store), async_rados(async_rados), observer(observer),
       http_manager(store->ctx(), completion_mgr),
       lock("RGWRemoteDataLog::lock"), data_sync_cr(NULL),
       initialized(false) {}
@@ -295,10 +303,11 @@ class RGWDataSyncStatusManager {
 
 public:
   RGWDataSyncStatusManager(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                           const string& _source_zone)
+                           const string& _source_zone,
+                           rgw::BucketChangeObserver *observer = nullptr)
     : store(_store), source_zone(_source_zone), conn(NULL), error_logger(NULL),
       sync_module(nullptr),
-      source_log(store, async_rados), num_shards(0) {}
+      source_log(store, async_rados, observer), num_shards(0) {}
   ~RGWDataSyncStatusManager() {
     finalize();
   }

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -530,6 +530,11 @@ public:
   int run();
 };
 
+/// read the sync status of all bucket shards from the given source zone
+int rgw_bucket_sync_status(RGWRados *store, const std::string& source_zone,
+                           const rgw_bucket& bucket,
+                           std::vector<rgw_bucket_shard_sync_info> *status);
+
 class RGWDefaultSyncModule : public RGWSyncModule {
 public:
   RGWDefaultSyncModule() {}

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -356,10 +356,8 @@ struct rgw_bucket_shard_full_sync_marker {
      DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
-    encode_json("position", position, f);
-    encode_json("count", count, f);
-  }
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 };
 WRITE_CLASS_ENCODER(rgw_bucket_shard_full_sync_marker)
 
@@ -382,9 +380,8 @@ struct rgw_bucket_shard_inc_sync_marker {
      DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
-    encode_json("position", position, f);
-  }
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 
   bool operator<(const rgw_bucket_shard_inc_sync_marker& m) const {
     return (position < m.position);
@@ -423,26 +420,8 @@ struct rgw_bucket_shard_sync_info {
      DECODE_FINISH(bl);
   }
 
-  void dump(Formatter *f) const {
-    string s;
-    switch ((SyncState)state) {
-      case StateInit:
-	s = "init";
-	break;
-      case StateFullSync:
-	s = "full-sync";
-	break;
-      case StateIncrementalSync:
-	s = "incremental-sync";
-	break;
-      default:
-	s = "unknown";
-	break;
-    }
-    encode_json("status", s, f);
-    encode_json("full_marker", full_marker, f);
-    encode_json("inc_marker", inc_marker, f);
-  }
+  void dump(Formatter *f) const;
+  void decode_json(JSONObj *obj);
 
   rgw_bucket_shard_sync_info() : state((int)StateInit) {}
 

--- a/src/rgw/rgw_json_enc.cc
+++ b/src/rgw/rgw_json_enc.cc
@@ -11,6 +11,7 @@
 #include "rgw_keystone.h"
 #include "rgw_basic_types.h"
 #include "rgw_op.h"
+#include "rgw_data_sync.h"
 #include "rgw_sync.h"
 #include "rgw_orphan.h"
 
@@ -790,6 +791,13 @@ void rgw_obj_key::dump(Formatter *f) const
   encode_json("ns", ns, f);
 }
 
+void rgw_obj_key::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("name", name, obj);
+  JSONDecoder::decode_json("instance", instance, obj);
+  JSONDecoder::decode_json("ns", ns, obj);
+}
+
 void RGWBucketEnt::dump(Formatter *f) const
 {
   encode_json("bucket", bucket, f);
@@ -1342,6 +1350,65 @@ void rgw_sync_error_info::dump(Formatter *f) const {
   encode_json("source_zone", source_zone, f);
   encode_json("error_code", error_code, f);
   encode_json("message", message, f);
+}
+
+void rgw_bucket_shard_full_sync_marker::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("position", position, obj);
+  JSONDecoder::decode_json("count", count, obj);
+}
+
+void rgw_bucket_shard_full_sync_marker::dump(Formatter *f) const
+{
+  encode_json("position", position, f);
+  encode_json("count", count, f);
+}
+
+void rgw_bucket_shard_inc_sync_marker::decode_json(JSONObj *obj)
+{
+  JSONDecoder::decode_json("position", position, obj);
+}
+
+void rgw_bucket_shard_inc_sync_marker::dump(Formatter *f) const
+{
+  encode_json("position", position, f);
+}
+
+void rgw_bucket_shard_sync_info::decode_json(JSONObj *obj)
+{
+  std::string s;
+  JSONDecoder::decode_json("status", s, obj);
+  if (s == "full-sync") {
+    state = StateFullSync;
+  } else if (s == "incremental-sync") {
+    state = StateIncrementalSync;
+  } else {
+    state = StateInit;
+  }
+  JSONDecoder::decode_json("full_marker", full_marker, obj);
+  JSONDecoder::decode_json("inc_marker", inc_marker, obj);
+}
+
+void rgw_bucket_shard_sync_info::dump(Formatter *f) const
+{
+  const char *s{nullptr};
+  switch ((SyncState)state) {
+    case StateInit:
+    s = "init";
+    break;
+  case StateFullSync:
+    s = "full-sync";
+    break;
+  case StateIncrementalSync:
+    s = "incremental-sync";
+    break;
+  default:
+    s = "unknown";
+    break;
+  }
+  encode_json("status", s, f);
+  encode_json("full_marker", full_marker, f);
+  encode_json("inc_marker", inc_marker, f);
 }
 
 /* This utility function shouldn't conflict with the overload of std::to_string

--- a/src/rgw/rgw_metadata.cc
+++ b/src/rgw/rgw_metadata.cc
@@ -844,12 +844,13 @@ struct list_keys_handle {
   RGWMetadataHandler *handler;
 };
 
-int RGWMetadataManager::list_keys_init(string& section, void **handle)
+int RGWMetadataManager::list_keys_init(const string& section, void **handle)
 {
   return list_keys_init(section, string(), handle);
 }
 
-int RGWMetadataManager::list_keys_init(string& section, const string& marker, void **handle)
+int RGWMetadataManager::list_keys_init(const string& section,
+                                       const string& marker, void **handle)
 {
   string entry;
   RGWMetadataHandler *handler;

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -353,8 +353,8 @@ public:
           obj_version *existing_version = NULL);
   int remove(string& metadata_key);
 
-  int list_keys_init(string& section, void **phandle);
-  int list_keys_init(string& section, const string& marker, void **phandle);
+  int list_keys_init(const string& section, void **phandle);
+  int list_keys_init(const string& section, const string& marker, void **phandle);
   int list_keys_next(void *handle, int max, list<string>& keys, bool *truncated);
   void list_keys_complete(void *handle);
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -3153,8 +3153,10 @@ class RGWDataSyncProcessorThread : public RGWSyncProcessorThread
   }
 public:
   RGWDataSyncProcessorThread(RGWRados *_store, RGWAsyncRadosProcessor *async_rados,
-                             const string& _source_zone)
-    : RGWSyncProcessorThread(_store, "data-sync"), sync(_store, async_rados, _source_zone),
+                             const string& _source_zone,
+                             rgw::BucketChangeObserver *observer)
+    : RGWSyncProcessorThread(_store, "data-sync"),
+      sync(_store, async_rados, _source_zone, observer),
       initialized(false) {}
 
   void wakeup_sync_shards(map<int, set<string> >& shard_ids) {
@@ -4517,7 +4519,8 @@ int RGWRados::init_complete()
     Mutex::Locker dl(data_sync_thread_lock);
     for (auto iter : zone_data_sync_from_map) {
       ldout(cct, 5) << "starting data sync thread for zone " << iter.first << dendl;
-      RGWDataSyncProcessorThread *thread = new RGWDataSyncProcessorThread(this, async_rados, iter.first);
+      auto *thread = new RGWDataSyncProcessorThread(this, async_rados, iter.first,
+                                                    &*bucket_trim);
       ret = thread->init();
       if (ret < 0) {
         ldout(cct, 0) << "ERROR: failed to initialize data sync thread" << dendl;

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6516,6 +6516,21 @@ int RGWRados::BucketShard::init(const rgw_bucket& _bucket, int sid)
   return 0;
 }
 
+int RGWRados::BucketShard::init(const RGWBucketInfo& bucket_info, int sid)
+{
+  bucket = bucket_info.bucket;
+  shard_id = sid;
+
+  int ret = store->open_bucket_index_shard(bucket_info, index_ctx, shard_id, &bucket_obj);
+  if (ret < 0) {
+    ldout(store->ctx(), 0) << "ERROR: open_bucket_index_shard() returned ret=" << ret << dendl;
+    return ret;
+  }
+  ldout(store->ctx(), 20) << " bucket index object: " << bucket_obj << dendl;
+
+  return 0;
+}
+
 
 /* Execute @handler on last item in bucket listing for bucket specified
  * in @bucket_info. @obj_prefix and @obj_delim narrow down the listing

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -2708,6 +2708,7 @@ public:
     explicit BucketShard(RGWRados *_store) : store(_store), shard_id(-1) {}
     int init(const rgw_bucket& _bucket, const rgw_obj& obj);
     int init(const rgw_bucket& _bucket, int sid);
+    int init(const RGWBucketInfo& bucket_info, int sid);
   };
 
   class Object {

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -23,6 +23,7 @@
 #include "rgw_meta_sync_status.h"
 #include "rgw_period_puller.h"
 #include "rgw_sync_module.h"
+#include "rgw_sync_log_trim.h"
 
 class RGWWatcher;
 class SafeTimer;
@@ -2280,6 +2281,7 @@ class RGWRados
   RGWSyncTraceManager *sync_tracer;
   map<string, RGWDataSyncProcessorThread *> data_sync_processor_threads;
 
+  boost::optional<rgw::BucketTrimManager> bucket_trim;
   RGWSyncLogTrimThread *sync_log_trimmer{nullptr};
 
   Mutex meta_sync_thread_lock;

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -1,0 +1,44 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat, Inc
+ *
+ * Author: Casey Bodley <cbodley@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include "rgw_sync_log_trim.h"
+
+#define dout_subsys ceph_subsys_rgw
+
+#undef dout_prefix
+#define dout_prefix (*_dout << "trim: ")
+
+using rgw::BucketTrimConfig;
+
+namespace rgw {
+
+class BucketTrimManager::Impl {
+ public:
+  RGWRados *const store;
+  const BucketTrimConfig config;
+
+  Impl(RGWRados *store, const BucketTrimConfig& config)
+    : store(store), config(config)
+  {}
+};
+
+BucketTrimManager::BucketTrimManager(RGWRados *store,
+                                     const BucketTrimConfig& config)
+  : impl(new Impl(store, config))
+{
+}
+BucketTrimManager::~BucketTrimManager() = default;
+
+} // namespace rgw

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -14,9 +14,13 @@
  */
 
 #include <mutex>
+#include <boost/container/flat_map.hpp>
 
 #include "common/bounded_key_counter.h"
+#include "common/errno.h"
 #include "rgw_sync_log_trim.h"
+#include "rgw_rados.h"
+#include "include/assert.h"
 
 #define dout_subsys ceph_subsys_rgw
 
@@ -26,6 +30,127 @@
 using rgw::BucketTrimConfig;
 using BucketChangeCounter = BoundedKeyCounter<std::string, int>;
 
+
+// watch/notify api for gateways to coordinate about which buckets to trim
+enum TrimNotifyType {
+};
+WRITE_RAW_ENCODER(TrimNotifyType);
+
+struct TrimNotifyHandler {
+  virtual ~TrimNotifyHandler() = default;
+
+  virtual void handle(bufferlist::iterator& input, bufferlist& output) = 0;
+};
+
+/// rados watcher for bucket trim notifications
+class BucketTrimWatcher : public librados::WatchCtx2 {
+  RGWRados *const store;
+  const rgw_raw_obj& obj;
+  rgw_rados_ref ref;
+  uint64_t handle{0};
+
+  using HandlerPtr = std::unique_ptr<TrimNotifyHandler>;
+  boost::container::flat_map<TrimNotifyType, HandlerPtr> handlers;
+
+ public:
+  BucketTrimWatcher(RGWRados *store, const rgw_raw_obj& obj)
+    : store(store), obj(obj)
+  {
+  }
+
+  ~BucketTrimWatcher()
+  {
+    stop();
+  }
+
+  int start()
+  {
+    int r = store->get_raw_obj_ref(obj, &ref);
+    if (r < 0) {
+      return r;
+    }
+
+    // register a watch on the realm's control object
+    r = ref.ioctx.watch2(ref.oid, &handle, this);
+    if (r == -ENOENT) {
+      constexpr bool exclusive = true;
+      r = ref.ioctx.create(ref.oid, exclusive);
+      if (r == -EEXIST || r == 0) {
+        r = ref.ioctx.watch2(ref.oid, &handle, this);
+      }
+    }
+    if (r < 0) {
+      lderr(store->ctx()) << "Failed to watch " << ref.oid
+          << " with " << cpp_strerror(-r) << dendl;
+      ref.ioctx.close();
+      return r;
+    }
+
+    ldout(store->ctx(), 10) << "Watching " << ref.oid << dendl;
+    return 0;
+  }
+
+  int restart()
+  {
+    int r = ref.ioctx.unwatch2(handle);
+    if (r < 0) {
+      lderr(store->ctx()) << "Failed to unwatch on " << ref.oid
+          << " with " << cpp_strerror(-r) << dendl;
+    }
+    r = ref.ioctx.watch2(ref.oid, &handle, this);
+    if (r < 0) {
+      lderr(store->ctx()) << "Failed to restart watch on " << ref.oid
+          << " with " << cpp_strerror(-r) << dendl;
+      ref.ioctx.close();
+    }
+    return r;
+  }
+
+  void stop()
+  {
+    ref.ioctx.unwatch2(handle);
+    ref.ioctx.close();
+  }
+
+  /// respond to bucket trim notifications
+  void handle_notify(uint64_t notify_id, uint64_t cookie,
+                     uint64_t notifier_id, bufferlist& bl) override
+  {
+    if (cookie != handle) {
+      return;
+    }
+    bufferlist reply;
+    try {
+      auto p = bl.begin();
+      TrimNotifyType type;
+      ::decode(type, p);
+
+      auto handler = handlers.find(type);
+      if (handler != handlers.end()) {
+        handler->second->handle(p, reply);
+      } else {
+        lderr(store->ctx()) << "no handler for notify type " << type << dendl;
+      }
+    } catch (const buffer::error& e) {
+      lderr(store->ctx()) << "Failed to decode notification: " << e.what() << dendl;
+    }
+    ref.ioctx.notify_ack(ref.oid, notify_id, cookie, reply);
+  }
+
+  /// reestablish the watch if it gets disconnected
+  void handle_error(uint64_t cookie, int err) override
+  {
+    if (cookie != handle) {
+      return;
+    }
+    if (err == -ENOTCONN) {
+      ldout(store->ctx(), 4) << "Disconnected watch on " << ref.oid << dendl;
+      restart();
+    }
+  }
+};
+
+
 namespace rgw {
 
 class BucketTrimManager::Impl {
@@ -33,15 +158,22 @@ class BucketTrimManager::Impl {
   RGWRados *const store;
   const BucketTrimConfig config;
 
+  const rgw_raw_obj status_obj;
+
   /// count frequency of bucket instance entries in the data changes log
   BucketChangeCounter counter;
 
-  /// protect data shared between data sync and trim threads
+  /// serve the bucket trim watch/notify api
+  BucketTrimWatcher watcher;
+
+  /// protect data shared between data sync, trim, and watch/notify threads
   std::mutex mutex;
 
   Impl(RGWRados *store, const BucketTrimConfig& config)
     : store(store), config(config),
-      counter(config.counter_size)
+      status_obj(store->get_zone_params().log_pool, "bilog.trim"),
+      counter(config.counter_size),
+      watcher(store, status_obj)
   {}
 };
 
@@ -51,6 +183,11 @@ BucketTrimManager::BucketTrimManager(RGWRados *store,
 {
 }
 BucketTrimManager::~BucketTrimManager() = default;
+
+int BucketTrimManager::init()
+{
+  return impl->watcher.start();
+}
 
 void BucketTrimManager::on_bucket_changed(const boost::string_view& bucket)
 {

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -18,10 +18,10 @@
 
 #include "common/bounded_key_counter.h"
 #include "common/errno.h"
+#include "rgw_sync_log_trim.h"
 #include "rgw_cr_rados.h"
 #include "rgw_metadata.h"
 #include "rgw_rados.h"
-#include "rgw_sync_log_trim.h"
 #include "rgw_sync.h"
 
 #include <boost/asio/yield.hpp>
@@ -34,6 +34,9 @@
 
 using rgw::BucketTrimConfig;
 using BucketChangeCounter = BoundedKeyCounter<std::string, int>;
+
+const std::string rgw::BucketTrimStatus::oid = "bilog.trim";
+using rgw::BucketTrimStatus;
 
 
 // watch/notify api for gateways to coordinate about which buckets to trim
@@ -614,7 +617,7 @@ class BucketTrimManager::Impl : public TrimCounters::Server {
 
   Impl(RGWRados *store, const BucketTrimConfig& config)
     : store(store), config(config),
-      status_obj(store->get_zone_params().log_pool, "bilog.trim"),
+      status_obj(store->get_zone_params().log_pool, BucketTrimStatus::oid),
       counter(config.counter_size),
       watcher(store, status_obj, this)
   {}

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -737,6 +737,25 @@ class RecentEventList {
 
 namespace rgw {
 
+// read bucket trim configuration from ceph context
+void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config)
+{
+  auto conf = cct->_conf;
+
+  config.trim_interval_sec =
+      conf->get_val<int64_t>("rgw_sync_log_trim_interval");
+  config.counter_size = 512;
+  config.buckets_per_interval =
+      conf->get_val<int64_t>("rgw_sync_log_trim_max_buckets");
+  config.min_cold_buckets_per_interval =
+      conf->get_val<int64_t>("rgw_sync_log_trim_min_cold_buckets");
+  config.concurrent_buckets =
+      conf->get_val<int64_t>("rgw_sync_log_trim_concurrent_buckets");
+  config.notify_timeout_ms = 10;
+  config.recent_size = 128;
+  config.recent_duration = std::chrono::hours(2);
+}
+
 class BucketTrimManager::Impl : public TrimCounters::Server,
                                 public BucketTrimObserver {
  public:

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -840,4 +840,11 @@ RGWCoroutine* BucketTrimManager::create_bucket_trim_cr()
                               impl.get(), impl->status_obj);
 }
 
+RGWCoroutine* BucketTrimManager::create_admin_bucket_trim_cr()
+{
+  // return the trim coroutine without any polling
+  return new BucketTrimCR(impl->store, impl->config,
+                          impl.get(), impl->status_obj);
+}
+
 } // namespace rgw

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -61,7 +61,7 @@ struct TrimNotifyHandler {
 struct TrimCounters {
   /// counter for a single bucket
   struct BucketCounter {
-    std::string bucket;
+    std::string bucket; //< bucket instance metadata key
     int count{0};
 
     BucketCounter() = default;

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -797,8 +797,10 @@ int BucketTrimCR::operate()
 
       set_status("listing cold buckets for trim");
       yield {
+        // capture a reference so 'this' remains valid in the callback
+        auto ref = boost::intrusive_ptr<RGWCoroutine>{this};
         // list cold buckets to consider for trim
-        auto cb = [this] (std::string&& bucket, std::string&& marker) {
+        auto cb = [this, ref] (std::string&& bucket, std::string&& marker) {
           // filter out keys that we trimmed recently
           if (observer->trimmed_recently(bucket)) {
             return true;

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -295,8 +295,10 @@ class BucketTrimWatcher : public librados::WatchCtx2 {
 
   void stop()
   {
-    ref.ioctx.unwatch2(handle);
-    ref.ioctx.close();
+    if (handle) {
+      ref.ioctx.unwatch2(handle);
+      ref.ioctx.close();
+    }
   }
 
   /// respond to bucket trim notifications

--- a/src/rgw/rgw_sync_log_trim.cc
+++ b/src/rgw/rgw_sync_log_trim.cc
@@ -983,7 +983,7 @@ void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config)
       conf->get_val<int64_t>("rgw_sync_log_trim_min_cold_buckets");
   config.concurrent_buckets =
       conf->get_val<int64_t>("rgw_sync_log_trim_concurrent_buckets");
-  config.notify_timeout_ms = 10;
+  config.notify_timeout_ms = 10000;
   config.recent_size = 128;
   config.recent_duration = std::chrono::hours(2);
 }

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -51,6 +51,8 @@ class BucketTrimManager : public BucketChangeObserver {
   BucketTrimManager(RGWRados *store, const BucketTrimConfig& config);
   ~BucketTrimManager();
 
+  int init();
+
   /// increment a counter for the given bucket instance
   void on_bucket_changed(const boost::string_view& bucket_instance) override;
 };

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <boost/utility/string_view.hpp>
+#include "include/encoding.h"
 
 class CephContext;
 class RGWCoroutine;
@@ -69,6 +70,27 @@ class BucketTrimManager : public BucketChangeObserver {
   RGWCoroutine* create_bucket_trim_cr();
 };
 
+/// provides persistent storage for the trim manager's current position in the
+/// list of bucket instance metadata
+struct BucketTrimStatus {
+  std::string marker; //< metadata key of current bucket instance
+
+  void encode(bufferlist& bl) const {
+    ENCODE_START(1, 1, bl);
+    ::encode(marker, bl);
+    ENCODE_FINISH(bl);
+  }
+  void decode(bufferlist::iterator& p) {
+    DECODE_START(1, p);
+    ::decode(marker, p);
+    DECODE_FINISH(p);
+  }
+
+  static const std::string oid;
+};
+
 } // namespace rgw
+
+WRITE_CLASS_ENCODER(rgw::BucketTrimStatus);
 
 #endif // RGW_SYNC_LOG_TRIM_H

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -41,6 +41,8 @@ struct BucketTrimConfig {
   size_t counter_size{0};
   /// maximum number of buckets to process each trim interval
   uint32_t buckets_per_interval{0};
+  /// minimum number of buckets to choose from the global bucket instance list
+  uint32_t min_cold_buckets_per_interval{0};
   /// maximum number of buckets to process in parallel
   uint32_t concurrent_buckets{0};
   /// timeout in ms for bucket trim notify replies

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -20,6 +20,7 @@
 #include <boost/utility/string_view.hpp>
 
 class CephContext;
+class RGWCoroutine;
 class RGWRados;
 
 namespace rgw {
@@ -33,6 +34,8 @@ struct BucketChangeObserver {
 
 /// Configuration for BucketTrimManager
 struct BucketTrimConfig {
+  /// time interval in seconds between bucket trim attempts
+  uint32_t trim_interval_sec{0};
   /// maximum number of buckets to track with BucketChangeObserver
   size_t counter_size{0};
 };
@@ -55,6 +58,9 @@ class BucketTrimManager : public BucketChangeObserver {
 
   /// increment a counter for the given bucket instance
   void on_bucket_changed(const boost::string_view& bucket_instance) override;
+
+  /// create a coroutine to run the bucket trim process every trim interval
+  RGWCoroutine* create_bucket_trim_cr();
 };
 
 } // namespace rgw

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -77,6 +77,9 @@ class BucketTrimManager : public BucketChangeObserver {
 
   /// create a coroutine to run the bucket trim process every trim interval
   RGWCoroutine* create_bucket_trim_cr();
+
+  /// create a coroutine to trim buckets directly via radosgw-admin
+  RGWCoroutine* create_admin_bucket_trim_cr();
 };
 
 /// provides persistent storage for the trim manager's current position in the

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -38,6 +38,12 @@ struct BucketTrimConfig {
   uint32_t trim_interval_sec{0};
   /// maximum number of buckets to track with BucketChangeObserver
   size_t counter_size{0};
+  /// maximum number of buckets to process each trim interval
+  uint32_t buckets_per_interval{0};
+  /// maximum number of buckets to process in parallel
+  uint32_t concurrent_buckets{0};
+  /// timeout in ms for bucket trim notify replies
+  uint64_t notify_timeout_ms{0};
 };
 
 /// fill out the BucketTrimConfig from the ceph context

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <boost/utility/string_view.hpp>
 #include "include/encoding.h"
+#include "common/ceph_time.h"
 
 class CephContext;
 class RGWCoroutine;
@@ -47,6 +48,12 @@ struct BucketTrimConfig {
   uint32_t concurrent_buckets{0};
   /// timeout in ms for bucket trim notify replies
   uint64_t notify_timeout_ms{0};
+  /// maximum number of recently trimmed buckets to remember (should be small
+  /// enough for a linear search)
+  size_t recent_size{0};
+  /// maximum duration to consider a trim as 'recent' (should be some multiple
+  /// of the trim interval, at least)
+  ceph::timespan recent_duration{0};
 };
 
 /// fill out the BucketTrimConfig from the ceph context

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -23,6 +23,7 @@
 
 class CephContext;
 class RGWCoroutine;
+class RGWHTTPManager;
 class RGWRados;
 
 namespace rgw {
@@ -76,10 +77,10 @@ class BucketTrimManager : public BucketChangeObserver {
   void on_bucket_changed(const boost::string_view& bucket_instance) override;
 
   /// create a coroutine to run the bucket trim process every trim interval
-  RGWCoroutine* create_bucket_trim_cr();
+  RGWCoroutine* create_bucket_trim_cr(RGWHTTPManager *http);
 
   /// create a coroutine to trim buckets directly via radosgw-admin
-  RGWCoroutine* create_admin_bucket_trim_cr();
+  RGWCoroutine* create_admin_bucket_trim_cr(RGWHTTPManager *http);
 };
 
 /// provides persistent storage for the trim manager's current position in the

--- a/src/rgw/rgw_sync_log_trim.h
+++ b/src/rgw/rgw_sync_log_trim.h
@@ -1,0 +1,47 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2017 Red Hat, Inc
+ *
+ * Author: Casey Bodley <cbodley@redhat.com>
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#ifndef RGW_SYNC_LOG_TRIM_H
+#define RGW_SYNC_LOG_TRIM_H
+
+#include <memory>
+
+class CephContext;
+class RGWRados;
+
+namespace rgw {
+
+/// Configuration for BucketTrimManager
+struct BucketTrimConfig {
+};
+
+/// fill out the BucketTrimConfig from the ceph context
+void configure_bucket_trim(CephContext *cct, BucketTrimConfig& config);
+
+/// Determines the buckets on which to focus trim activity, using two sources of
+/// input: the frequency of entries read from the data changes log, and a global
+/// listing of the bucket.instance metadata. This allows us to trim active
+/// buckets quickly, while also ensuring that all buckets will eventually trim
+class BucketTrimManager {
+  class Impl;
+  std::unique_ptr<Impl> impl;
+ public:
+  BucketTrimManager(RGWRados *store, const BucketTrimConfig& config);
+  ~BucketTrimManager();
+};
+
+} // namespace rgw
+
+#endif // RGW_SYNC_LOG_TRIM_H

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -271,3 +271,9 @@ add_ceph_unittest(unittest_backport14)
 add_executable(unittest_convenience test_convenience.cc)
 target_link_libraries(unittest_convenience ceph-common)
 add_ceph_unittest(unittest_convenience)
+
+add_executable(unittest_bounded_key_counter
+  test_bounded_key_counter.cc
+  $<TARGET_OBJECTS:unit-main>)
+target_link_libraries(unittest_bounded_key_counter global)
+add_ceph_unittest(unittest_bounded_key_counter)

--- a/src/test/common/test_bounded_key_counter.cc
+++ b/src/test/common/test_bounded_key_counter.cc
@@ -1,0 +1,200 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2015 Red Hat
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation. See file COPYING.
+ *
+ */
+#include "common/bounded_key_counter.h"
+#include <gtest/gtest.h>
+
+namespace {
+
+// call get_highest() and return the number of callbacks
+template <typename Key, typename Count>
+size_t count_highest(BoundedKeyCounter<Key, Count>& counter, size_t count)
+{
+  size_t callbacks = 0;
+  counter.get_highest(count, [&callbacks] (const Key& key, Count count) {
+                        ++callbacks;
+                      });
+  return callbacks;
+}
+
+// call get_highest() and return the key/value pairs as a vector
+template <typename Key, typename Count,
+          typename Vector = std::vector<std::pair<Key, Count>>>
+Vector get_highest(BoundedKeyCounter<Key, Count>& counter, size_t count)
+{
+  Vector results;
+  counter.get_highest(count, [&results] (const Key& key, Count count) {
+                        results.emplace_back(key, count);
+                      });
+  return results;
+}
+
+} // anonymous namespace
+
+TEST(BoundedKeyCounter, Insert)
+{
+  BoundedKeyCounter<int, int> counter(2);
+  EXPECT_EQ(1, counter.insert(0)); // insert new key
+  EXPECT_EQ(2, counter.insert(0)); // increment counter
+  EXPECT_EQ(7, counter.insert(0, 5)); // add 5 to counter
+  EXPECT_EQ(1, counter.insert(1)); // insert new key
+  EXPECT_EQ(0, counter.insert(2)); // reject new key
+}
+
+TEST(BoundedKeyCounter, Erase)
+{
+  BoundedKeyCounter<int, int> counter(10);
+
+  counter.erase(0); // ok to erase nonexistent key
+  EXPECT_EQ(1, counter.insert(1, 1));
+  EXPECT_EQ(2, counter.insert(2, 2));
+  EXPECT_EQ(3, counter.insert(3, 3));
+  counter.erase(2);
+  counter.erase(1);
+  counter.erase(3);
+  counter.erase(3);
+  EXPECT_EQ(0u, count_highest(counter, 10));
+}
+
+TEST(BoundedKeyCounter, Size)
+{
+  BoundedKeyCounter<int, int> counter(4);
+  EXPECT_EQ(0u, counter.size());
+  EXPECT_EQ(1, counter.insert(1, 1));
+  EXPECT_EQ(1u, counter.size());
+  EXPECT_EQ(2, counter.insert(2, 2));
+  EXPECT_EQ(2u, counter.size());
+  EXPECT_EQ(3, counter.insert(3, 3));
+  EXPECT_EQ(3u, counter.size());
+  EXPECT_EQ(4, counter.insert(4, 4));
+  EXPECT_EQ(4u, counter.size());
+  EXPECT_EQ(0, counter.insert(5, 5)); // reject new key
+  EXPECT_EQ(4u, counter.size()); // size unchanged
+  EXPECT_EQ(5, counter.insert(4, 1)); // update existing key
+  EXPECT_EQ(4u, counter.size()); // size unchanged
+  counter.erase(2);
+  EXPECT_EQ(3u, counter.size());
+  counter.erase(2); // erase duplicate
+  EXPECT_EQ(3u, counter.size()); // size unchanged
+  counter.erase(4);
+  EXPECT_EQ(2u, counter.size());
+  counter.erase(1);
+  EXPECT_EQ(1u, counter.size());
+  counter.erase(3);
+  EXPECT_EQ(0u, counter.size());
+  EXPECT_EQ(6, counter.insert(6, 6));
+  EXPECT_EQ(1u, counter.size());
+  counter.clear();
+  EXPECT_EQ(0u, counter.size());
+}
+
+TEST(BoundedKeyCounter, GetHighest)
+{
+  BoundedKeyCounter<int, int> counter(10);
+  using Vector = std::vector<std::pair<int, int>>;
+
+  EXPECT_EQ(0u, count_highest(counter, 0)); // ok to request 0
+  EXPECT_EQ(0u, count_highest(counter, 10)); // empty
+  EXPECT_EQ(0u, count_highest(counter, 999)); // ok to request count >> 10
+
+  EXPECT_EQ(1, counter.insert(1, 1));
+  EXPECT_EQ(Vector({{1,1}}), get_highest(counter, 10));
+  EXPECT_EQ(2, counter.insert(2, 2));
+  EXPECT_EQ(Vector({{2,2},{1,1}}), get_highest(counter, 10));
+  EXPECT_EQ(3, counter.insert(3, 3));
+  EXPECT_EQ(Vector({{3,3},{2,2},{1,1}}), get_highest(counter, 10));
+  EXPECT_EQ(3, counter.insert(4, 3)); // insert duplicated count=3
+  // still returns 4 entries (but order of {3,3} and {4,3} is unspecified)
+  EXPECT_EQ(4u, count_highest(counter, 10));
+  counter.erase(3);
+  EXPECT_EQ(Vector({{4,3},{2,2},{1,1}}), get_highest(counter, 10));
+  EXPECT_EQ(0u, count_highest(counter, 0)); // requesting 0 still returns 0
+}
+
+TEST(BoundedKeyCounter, Clear)
+{
+  BoundedKeyCounter<int, int> counter(2);
+  EXPECT_EQ(1, counter.insert(0)); // insert new key
+  EXPECT_EQ(1, counter.insert(1)); // insert new key
+  EXPECT_EQ(2u, count_highest(counter, 2)); // return 2 entries
+
+  counter.clear();
+
+  EXPECT_EQ(0u, count_highest(counter, 2)); // return 0 entries
+  EXPECT_EQ(1, counter.insert(1)); // insert new key
+  EXPECT_EQ(1, counter.insert(2)); // insert new unique key
+  EXPECT_EQ(2u, count_highest(counter, 2)); // return 2 entries
+}
+
+// tests for partial sort and invalidation
+TEST(BoundedKeyCounter, GetNumSorted)
+{
+  struct MockCounter : public BoundedKeyCounter<int, int> {
+    using BoundedKeyCounter<int, int>::BoundedKeyCounter;
+    // expose as public for testing sort invalidations
+    using BoundedKeyCounter<int, int>::get_num_sorted;
+  };
+
+  MockCounter counter(10);
+
+  EXPECT_EQ(0u, counter.get_num_sorted());
+  EXPECT_EQ(0u, count_highest(counter, 10));
+  EXPECT_EQ(0u, counter.get_num_sorted());
+
+  EXPECT_EQ(2, counter.insert(2, 2));
+  EXPECT_EQ(3, counter.insert(3, 3));
+  EXPECT_EQ(4, counter.insert(4, 4));
+  EXPECT_EQ(0u, counter.get_num_sorted());
+
+  EXPECT_EQ(0u, count_highest(counter, 0));
+  EXPECT_EQ(0u, counter.get_num_sorted());
+  EXPECT_EQ(1u, count_highest(counter, 1));
+  EXPECT_EQ(1u, counter.get_num_sorted());
+  EXPECT_EQ(2u, count_highest(counter, 2));
+  EXPECT_EQ(2u, counter.get_num_sorted());
+  EXPECT_EQ(3u, count_highest(counter, 10));
+  EXPECT_EQ(3u, counter.get_num_sorted());
+
+  EXPECT_EQ(1, counter.insert(1, 1)); // insert at bottom does not invalidate
+  EXPECT_EQ(3u, counter.get_num_sorted());
+
+  EXPECT_EQ(4u, count_highest(counter, 10));
+  EXPECT_EQ(4u, counter.get_num_sorted());
+
+  EXPECT_EQ(5, counter.insert(5, 5)); // insert at top invalidates sort
+  EXPECT_EQ(0u, counter.get_num_sorted());
+
+  EXPECT_EQ(0u, count_highest(counter, 0));
+  EXPECT_EQ(0u, counter.get_num_sorted());
+  EXPECT_EQ(1u, count_highest(counter, 1));
+  EXPECT_EQ(1u, counter.get_num_sorted());
+  EXPECT_EQ(2u, count_highest(counter, 2));
+  EXPECT_EQ(2u, counter.get_num_sorted());
+  EXPECT_EQ(3u, count_highest(counter, 3));
+  EXPECT_EQ(3u, counter.get_num_sorted());
+  EXPECT_EQ(4u, count_highest(counter, 4));
+  EXPECT_EQ(4u, counter.get_num_sorted());
+  EXPECT_EQ(5u, count_highest(counter, 10));
+  EXPECT_EQ(5u, counter.get_num_sorted());
+
+  // updating an existing counter only invalidates entries <= that counter
+  EXPECT_EQ(2, counter.insert(1)); // invalidates {1,2} and {2,2}
+  EXPECT_EQ(3u, counter.get_num_sorted());
+
+  EXPECT_EQ(5u, count_highest(counter, 10));
+  EXPECT_EQ(5u, counter.get_num_sorted());
+
+  counter.clear(); // invalidates sort
+  EXPECT_EQ(0u, counter.get_num_sorted());
+}
+

--- a/src/test/rgw/test_multi.py
+++ b/src/test/rgw/test_multi.py
@@ -52,6 +52,8 @@ class Cluster(multisite.Cluster):
         cmd = [test_path + 'test-rgw-call.sh', 'call_rgw_admin', self.cluster_id]
         if args:
             cmd += args
+        cmd += ['--debug-rgw', str(kwargs.pop('debug_rgw', 0))]
+        cmd += ['--debug-ms', str(kwargs.pop('debug_ms', 0))]
         if kwargs.pop('read_only', False):
             cmd += ['--rgw-cache-enabled', 'false']
         return bash(cmd, **kwargs)


### PR DESCRIPTION
The bucket index logs (bilogs) used by multisite bucket sync are no longer needed once all peer zones have processed them. This patch set introduces a `BucketTrimManager` that runs in the existing `RGWSyncLogTrimThread` of `RGWRados`, and trims these unneeded bilog entries from all buckets.

The trim logic for a bucket shard is very similar to the existing trim logic for the metadata and data changes logs: query the sync status from each peer zone, calculate the minimum marker position, and trim log entries up to that position. This is implemented by `BucketTrimInstanceCR`, using a new `get_bucket_index_log_status` rest api to query the sync status.

Unlike metadata and datalog trimming, where there is a single (sharded) log for each, there are a potentially unbounded number of bucket index logs to process. So most of the complexity here comes from deciding which of those many buckets to trim. The algorithm that does this is split into two parts: one that tracks which buckets are most active (so most likely to benefit from trimming), and one that iterates over all bucket instances (to guarantee that all buckets are trimmed eventually). Each trim interval (20 minutes by default), `BucketTrimCR` will select a number of active buckets and cold buckets to trim.

The active buckets are chosen by counting their frequency of entries in the data changes log. Because this datalog is sharded and its processing is spread across the zone's gateways, these bucket counters need to be accumulated over all gateways each trim interval. A watch/notify api served by the `BucketTrimWatcher` class allows the trimming gateway to query the top bucket counters from its peer gateways. A new `BoundedKeyCounter` data structure was introduced to manage these counters, while enforcing an upper bound on the number of keys/memory usage.

For cold buckets, the `RGWMetadataManager` interface is used to iterate over bucket instance metadata. The `AsyncMetadataList` and `MetadataListCR` classes provide an asynchronous wrapper for this listing. The current marker position in the metadata list is written to rados as a `BucketTrimStatus` object, so that the listing can be resumed for the next trim interval. Once the listing reaches the end (marker=MAX), it restarts from beginning.

Once a bucket has been trimmed successfully, it is added to a `RecentEventList`. Until that event expires, the bucket is omitted from both the counting of active buckets and the listing of cold buckets.

Once all selected buckets are finished trimming, the updated `BucketTrimStatus` object is written, and the watch/notify api instructs gateways to reset their bucket counters for the next interval.

Fixes: http://tracker.ceph.com/issues/18229