### PR TITLE
mon: osd multi-flags set/unset in a single command

### DIFF
--- a/qa/standalone/mon/osd-crush.sh
+++ b/qa/standalone/mon/osd-crush.sh
@@ -208,6 +208,19 @@ function TEST_crush_rename_bucket() {
     ceph osd crush rename-bucket nonexistent something 2>&1 | grep "Error ENOENT" || return 1
 }
 
+function TEST_crush_ls_node() {
+    local dir=$1
+
+    run_mon $dir a || return 1
+
+    ceph osd crush add-bucket default1 root
+    ceph osd crush add-bucket host1 host
+    ceph osd crush move host1 root=default1
+
+    ceph osd crush ls default1 | grep host1 || return 1
+    ceph osd crush ls default2 2>&1 | grep "Error ENOENT" || return 1
+}
+
 function TEST_crush_reject_empty() {
     local dir=$1
     run_mon $dir a || return 1

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -725,12 +725,14 @@ COMMAND("osd erasure-code-profile ls", \
 	"list all erasure code profiles", \
 	"osd", "r", "cli,rest")
 COMMAND("osd set " \
-	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds " \
+        "name=key,type=CephString,n=N " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \
-	"set <key>", "osd", "rw", "cli,rest")
+	"set flag(s) <key> [<key>...] that is within full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent|sortbitwise|recovery_deletes|require_jewel_osds|require_kraken_osds",
+	"osd", "rw", "cli,rest")
 COMMAND("osd unset " \
-	"name=key,type=CephChoices,strings=full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent", \
-	"unset <key>", "osd", "rw", "cli,rest")
+        "name=key,type=CephString,n=N", \
+	"unset flag(s) <key> [<key>...] that is within full|pause|noup|nodown|noout|noin|nobackfill|norebalance|norecover|noscrub|nodeep-scrub|notieragent",
+	"osd", "rw", "cli,rest")
 COMMAND("osd require-osd-release "\
 	"name=release,type=CephChoices,strings=luminous|mimic " \
 	"name=sure,type=CephChoices,strings=--yes-i-really-mean-it,req=false", \

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -645,7 +645,7 @@ COMMAND("osd crush tree "
         "name=shadow,type=CephChoices,strings=--show-shadow,req=false", \
 	"dump crush buckets and items in a tree view",
 	"osd", "r", "cli,rest")
-COMMAND("osd crush ls name=node,type=CephString,goodchars=goodchars=[A-Za-z0-9-_.]",
+COMMAND("osd crush ls name=node,type=CephString,goodchars=[A-Za-z0-9-_.]",
 	"list items beneath a node in the CRUSH tree",
 	"osd", "r", "cli,rest")
 COMMAND("osd crush class ls", \

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -860,14 +860,15 @@ class TestOSD(TestArgparse):
 
     def test_set_unset(self):
         for action in ('set', 'unset'):
-            for flag in ('pause', 'noup', 'nodown', 'noout', 'noin',
-                         'nobackfill', 'norecover', 'noscrub', 'nodeep-scrub'):
-                self.assert_valid_command(['osd', action, flag])
-            assert_equal({}, validate_command(sigdict, ['osd', action]))
-            assert_equal({}, validate_command(sigdict, ['osd', action,
-                                                        'invalid']))
-            assert_equal({}, validate_command(sigdict, ['osd', action,
-                                                        'pause', 'toomany']))
+            self.check_1_or_more_string_args('osd', action)
+        flagset = ('pause', 'noup', 'nodown', 'noout', 'noin', 'norebalance',
+                   'nobackfill', 'norecover', 'noscrub', 'nodeep-scrub')
+        for i in range(1, len(flagset) + 1):
+            flags = ''
+            for j in range(0, i):
+                flags += ' ' + flagset[j]
+            self.assert_valid_command(['osd', 'set', flags])
+            self.assert_valid_command(['osd', 'unset', flags])
 
     def test_cluster_snap(self):
         assert_equal(None, validate_command(sigdict, ['osd', 'cluster_snap']))


### PR DESCRIPTION
In many cases, we want to set more than one osd flags, for example, `norecover norebalance nobackfill` flags may be set to stop the cluster's recovery io. 
this will also avoid making multi-changes to the osdmap and slow down map-epoch generation a bit.
