### PR TITLE
common,os: Initializing commit_data,cmount,iocb

### DIFF
--- a/src/common/cohort_lru.h
+++ b/src/common/cohort_lru.h
@@ -305,7 +305,7 @@ namespace cohort {
       struct Latch {
 	Partition* p;
 	LK* lock;
-	insert_commit_data commit_data;
+	insert_commit_data commit_data{};
 
 	Latch() : p(nullptr), lock(nullptr) {}
       };

--- a/src/os/bluestore/aio.h
+++ b/src/os/bluestore/aio.h
@@ -14,7 +14,7 @@
 #include "include/types.h"
 
 struct aio_t {
-  struct iocb iocb;  // must be first element; see shenanigans in aio_queue_t
+  struct iocb iocb{};  // must be first element; see shenanigans in aio_queue_t
   void *priv;
   int fd;
   boost::container::small_vector<iovec,4> iov;

--- a/src/tools/cephfs/PgFiles.h
+++ b/src/tools/cephfs/PgFiles.h
@@ -30,7 +30,7 @@ class PgFiles
 {
 private:
   Objecter *objecter;
-  struct ceph_mount_info *cmount;
+  struct ceph_mount_info *cmount = nullptr;
 
   std::set<pg_t> pgs;
   std::set<uint64_t> pools;


### PR DESCRIPTION
Fixes the coverity issues:

** 1396166 Uninitialized pointer field
>2. uninit_member: Non-static class member field commit_data.link_left
is not initialized in this constructor nor in any functions that it calls.
>CID 1396166 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member field commit_data.node is not
initialized in this constructor nor in any functions that it calls.

** 1405353 Uninitialized pointer field
>CID 1405353 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>3. uninit_member: Non-static class member cmount is not initialized
in this constructor nor in any functions that it calls.

** 1405848 Uninitialized pointer field
>2. uninit_member: Non-static class member field iocb.data is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field iocb.key is not initialized
in this constructor nor in any functions that it calls.
>6. uninit_member: Non-static class member field iocb.__pad2 is not
initialized in this constructor nor in any functions that it calls.
>8. uninit_member: Non-static class member field iocb.aio_lio_opcode
is not initialized in this constructor nor in any functions that it calls.
>10. uninit_member: Non-static class member field iocb.aio_reqprio is not
initialized in this constructor nor in any functions that it calls.
>CID 1405848 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>12. uninit_member: Non-static class member field iocb.aio_fildes is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>