### PR TITLE
messages,test,msg: Initializing h,reply_type,owner

### DIFF
--- a/src/messages/MStatfsReply.h
+++ b/src/messages/MStatfsReply.h
@@ -18,7 +18,7 @@
 
 class MStatfsReply : public Message {
 public:
-  struct ceph_mon_statfs_reply h;
+  struct ceph_mon_statfs_reply h{};
 
   MStatfsReply() : Message(CEPH_MSG_STATFS_REPLY) {}
   MStatfsReply(uuid_d &f, ceph_tid_t t, epoch_t epoch) : Message(CEPH_MSG_STATFS_REPLY) {

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -155,7 +155,7 @@ class EventCenter {
   std::string type;
   int nevent;
   // Used only to external event
-  pthread_t owner;
+  pthread_t owner = 0;
   std::mutex external_lock;
   std::atomic_ulong external_num_events;
   deque<EventCallbackRef> external_events;

--- a/src/test/mon/test-mon-msg.cc
+++ b/src/test/mon/test-mon-msg.cc
@@ -219,7 +219,7 @@ class MonMsgTest : public MonClientHelper,
                    public ::testing::Test
 {
 protected:
-  int reply_type;
+  int reply_type = 0;
   Message *reply_msg = nullptr;
   Mutex lock;
   Cond cond;


### PR DESCRIPTION
Fixes the coverity issues:

** 717326 Uninitialized scalar field
>2. uninit_member: Non-static class member field h.fsid is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member field h.version is not initialized
in this constructor nor in any functions that it calls.
>CID 717326 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member field h.st is not initialized in
this constructor nor in any functions that it calls.

** 1244199 Uninitialized scalar field
>CID 1244199 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member reply_type is not initialized
in this constructor nor in any functions that it calls.

** 1249637 Uninitialized scalar field
>CID 1249637 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member owner is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>