### PR TITLE
os/bluestore/NVMEDevice: Remove using dpdk thread

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3164,7 +3164,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("bluestore_spdk_coremask", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("0x3")
+    .set_default("0x1")
     .set_description(""),
 
     Option("bluestore_spdk_max_io_completion", Option::TYPE_UINT, Option::LEVEL_DEV)

--- a/src/os/bluestore/NVMEDevice.h
+++ b/src/os/bluestore/NVMEDevice.h
@@ -38,6 +38,7 @@ enum class IOCommand {
 };
 
 class SharedDriverData;
+class SharedDriverQueueData;
 
 class NVMEDevice : public BlockDevice {
   /**
@@ -49,9 +50,9 @@ class NVMEDevice : public BlockDevice {
   string name;
 
  public:
+  std::atomic_int queue_number = {0};
   SharedDriverData *get_driver() { return driver; }
 
- public:
   NVMEDevice(CephContext* cct, aio_callback_t cb, void *cbpriv);
 
   bool supported_bdev_label() override { return false; }


### PR DESCRIPTION
Do not use DPDK's thread but use the run in complete mode,
thus we do not need to bind two cores for SPDK.

Signed-off-by: Ziye Yang <optimistyzy@gmail.com>
Signed-off-by: Pan Liu <wanjun.lp@alibaba-inc.com>