### PR TITLE
bluestore/fio: Fixed problem with all objects having the same hash

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -179,7 +179,9 @@ struct Object {
   Collection& coll;
 
   Object(const char* name, Collection& coll)
-    : oid(hobject_t(name, "", CEPH_NOSNAP, coll.pg.ps(), coll.pg.pool(), "")),
+    : oid(hobject_t(name, "", CEPH_NOSNAP,
+                    ceph_str_hash(CEPH_STR_HASH_RJENKINS, name, strlen(name)),
+                    coll.pg.pool(), "")),
       coll(coll) {}
 };
 


### PR DESCRIPTION
This was fatal for unordered_map, as it turned it to list.
The change is so huge, that I expect that most 'perf' results obtained before are useless.
Signed-off-by: Adam Kupczyk <akupczyk@redhat.com>