### PR TITLE
osd/PrimaryLogPG: _delete_oid - fix incorrect 'legacy' flag

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6794,7 +6794,7 @@ inline int PrimaryLogPG::_delete_oid(
       }
     }
   } else {
-    legacy = false;
+    legacy = true;
   }
   dout(20) << __func__ << " " << soid << " whiteout=" << (int)whiteout
 	   << " no_whiteout=" << (int)no_whiteout


### PR DESCRIPTION
For pre-Luminous created objects, we shall default 'legacy' flag
to true.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>