### PR TITLE
client,osd,test: Initialize fuse_req_key,snap,who,seq

### DIFF
--- a/src/client/fuse_ll.cc
+++ b/src/client/fuse_ll.cc
@@ -93,7 +93,7 @@ public:
   ceph::unordered_map<uint64_t,int> snap_stag_map;
   ceph::unordered_map<int,uint64_t> stag_snap_map;
 
-  pthread_key_t fuse_req_key;
+  pthread_key_t fuse_req_key = 0;
   void set_fuse_req(fuse_req_t);
   fuse_req_t get_fuse_req();
 

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -774,8 +774,8 @@ struct Payload {
     PING = 0,
     PONG = 1,
   };
-  uint8_t who;
-  uint64_t seq;
+  uint8_t who = 0;
+  uint64_t seq = 0;
   bufferlist data;
 
   Payload(Who who, uint64_t seq, const bufferlist& data)

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -2314,7 +2314,7 @@ public:
   string oid;
   bool dirty;
   ObjectDesc old_value;
-  int snap;
+  int snap = 0;
   ceph::shared_ptr<int> in_use;
 
   IsDirtyOp(int n,


### PR DESCRIPTION
Fixes the coverity issues:

** 1351735 Uninitialized scalar field
>CID 1351735 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member fuse_req_key is not
initialized in this constructor nor in any functions that it calls.

** 1396108 Uninitialized scalar field
>CID 1396108 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member snap is not initialized
in this constructor nor in any functions that it calls.

** 1396115 Uninitialized scalar field
>2. uninit_member: Non-static class member who is not initialized
in this constructor nor in any functions that it calls.
>CID 1396115 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member seq is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>