### PR TITLE
luminous: osd/PrimaryLogPG: _delete_oid - fix incorrect 'legacy' flag

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6864,7 +6864,7 @@ inline int PrimaryLogPG::_delete_oid(
       }
     }
   } else {
-    legacy = false;
+    legacy = true;
   }
   dout(20) << __func__ << " " << soid << " whiteout=" << (int)whiteout
 	   << " no_whiteout=" << (int)no_whiteout


### PR DESCRIPTION
For pre-Luminous created objects, we shall default 'legacy' flag
to true, so we can still create a snapdir object properly if necessary
for Luminous backward compatibility.
    
Note that this patch is not going to land on master first
(and hence can not be cherry-picked from master) because it will
finally be deprecated by https://github.com/ceph/ceph/pull/17579,
in which we are going to kill the snapdir object completely for Mimic.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn