### PR TITLE
include,messages,rbd: Initialize counter,group_pool

### DIFF
--- a/src/cls/rbd/cls_rbd_types.h
+++ b/src/cls/rbd/cls_rbd_types.h
@@ -256,7 +256,7 @@ struct GroupSnapshotNamespace {
 							group_id(_group_id),
 							snapshot_id(_snapshot_id) {}
 
-  int64_t group_pool;
+  int64_t group_pool = 0;
   string group_id;
   snapid_t snapshot_id;
 

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -593,7 +593,6 @@ namespace buffer CEPH_BUFFER_API {
 
     class page_aligned_appender {
       bufferlist *pbl;
-      size_t offset;
       unsigned min_alloc;
       ptr buffer;
       char *pos, *end;

--- a/src/messages/MDataPing.h
+++ b/src/messages/MDataPing.h
@@ -36,7 +36,7 @@ class MDataPing : public Message {
   static const int COMPAT_VERSION = 1;
 
   std::string tag;
-  uint32_t counter;
+  uint32_t counter = 0;
   mdata_hook_func mdata_hook;
   struct xio_reg_mem mp;
   bool free_data;


### PR DESCRIPTION
Fixes the coverity issues:

** 1396182 Uninitialized scalar field
>CID 1396182 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member counter is not initialized
in this constructor nor in any functions that it calls.

** 1396194 Uninitialized scalar field
>CID 1396194 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member group_pool is not initialized
in this constructor nor in any functions that it calls

Signed-off-by: Amit Kumar <amitkuma@redhat.com>