### PR TITLE
tests: CentOS 7.4 is now the latest

### DIFF
--- a/qa/distros/all/centos_7.4.yaml
+++ b/qa/distros/all/centos_7.4.yaml
@@ -1,0 +1,2 @@
+os_type: centos
+os_version: "7.4"

--- a/qa/distros/supported/centos_7.3.yaml
+++ b/qa/distros/supported/centos_7.3.yaml
@@ -1,1 +1,0 @@
-../all/centos_7.3.yaml

--- a/qa/distros/supported/centos_latest.yaml
+++ b/qa/distros/supported/centos_latest.yaml
@@ -1,0 +1,1 @@
+../all/centos_7.4.yaml


### PR DESCRIPTION
Signed-off-by: Nathan Cutler <ncutler@suse.com>
(cherry picked from commit 2311b64025cdb6131035aaf01e7c97486da12e15)

Conflicts
    qa/distros/supported/centos_latest.yaml (renamed from centos_7.3.yaml)