### PR TITLE
qa: Replaced centos_7.3.yaml with centos_latest.yaml

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_7.3.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_7.3.yaml
@@ -1,2 +1,0 @@
-os_type: centos
-os_version: "7.3"

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_latest.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_16.04.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_16.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "16.04"

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_latest.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests.yaml
@@ -1,5 +1,5 @@
 os_type: centos
-os_version: "7.3"
+os_version: "7.4"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_defaults.yaml
@@ -1,5 +1,5 @@
 os_type: centos
-os_version: "7.3"
+os_version: "7.4"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
+++ b/qa/suites/rbd/valgrind/workloads/python_api_tests_with_journaling.yaml
@@ -1,5 +1,5 @@
 os_type: centos
-os_version: "7.3"
+os_version: "7.4"
 tasks:
 - workunit:
     clients:

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_7.3.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_7.3.yaml
@@ -1,1 +1,0 @@
-../../../../../distros/all/centos_7.3.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/ubuntu_14.04.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/ubuntu_14.04.yaml
@@ -1,1 +1,0 @@
-../../../../../distros/all/ubuntu_14.04.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
Changed 7.3 to 7.4 for rbd (hardcoded @dillaman FYI)
And upgrade/jewel-x/point-to-point-x/distros/ubuntu_14.04.yaml

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>