### PR TITLE
vstart: create MDSs before filesystems

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -690,24 +690,6 @@ EOF
 }
 
 start_mds() {
-    if [ $new -eq 1 ]; then
-        if [ "$CEPH_NUM_FS" -gt "0" ] ; then
-            if [ "$CEPH_NUM_FS" -gt "1" ] ; then
-                ceph_adm fs flag set enable_multiple true --yes-i-really-mean-it
-            fi
-
-            local fs=0
-            for name in a b c d e f g h i j k l m n o p
-            do
-                ceph_adm osd pool create "cephfs_data_${name}" 8
-                ceph_adm osd pool create "cephfs_metadata_${name}" 8
-                ceph_adm fs new "cephfs_${name}" "cephfs_metadata_${name}" "cephfs_data_${name}"
-                fs=$(($fs + 1))
-                [ $fs -eq $CEPH_NUM_FS ] && break
-            done
-        fi
-    fi
-
     local mds=0
     for name in a b c d e f g h i j k l m n o p
     do
@@ -749,6 +731,25 @@ EOF
         #$CEPH_BIN/ceph-mds -d $ARGS --mds_thrash_fragments 0 --mds_thrash_exports 0 #--debug_ms 20
         #ceph_adm mds set max_mds 2
     done
+
+    if [ $new -eq 1 ]; then
+        if [ "$CEPH_NUM_FS" -gt "0" ] ; then
+            if [ "$CEPH_NUM_FS" -gt "1" ] ; then
+                ceph_adm fs flag set enable_multiple true --yes-i-really-mean-it
+            fi
+
+            local fs=0
+            for name in a b c d e f g h i j k l m n o p
+            do
+                ceph_adm osd pool create "cephfs_data_${name}" 8
+                ceph_adm osd pool create "cephfs_metadata_${name}" 8
+                ceph_adm fs new "cephfs_${name}" "cephfs_metadata_${name}" "cephfs_data_${name}"
+                fs=$(($fs + 1))
+                [ $fs -eq $CEPH_NUM_FS ] && break
+            done
+        fi
+    fi
+
 }
 
 if [ "$debug" -eq 0 ]; then


### PR DESCRIPTION
This avoids spurious complaints about not
enough MDS daemons in the logs.

Signed-off-by: John Spray <john.spray@redhat.com>