### PR TITLE
common/util: do not print error if VERSION_ID is missing

### DIFF
--- a/src/common/util.cc
+++ b/src/common/util.cc
@@ -186,7 +186,7 @@ static void distro_detect(map<string, string> *m, CephContext *cct)
     lderr(cct) << "distro_detect - /etc/os-release is required" << dendl;
   }
 
-  for (const char* rk: {"distro", "distro_version"}) {
+  for (const char* rk: {"distro", "distro_description"}) {
     if (m->find(rk) == m->end())
       lderr(cct) << "distro_detect - can't detect " << rk << dendl;
   }


### PR DESCRIPTION
per os-release(5), VERSION_ID is optional.

Signed-off-by: Kefu Chai <kchai@redhat.com>