### PR TITLE
rgw: fix version bucket stats

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -1433,13 +1433,15 @@ static int rgw_bucket_link_olh(cls_method_context_t hctx, bufferlist *in, buffer
       if (ret < 0) {
         return ret;
       }
+    }
+
+    removing = existed && op.delete_marker;
+    if (!removing) {
       ret = other_obj.unlink();
       if (ret < 0) {
         return ret;
       }
     }
-
-    removing = existed && op.delete_marker;
   } else {
     removing = (existed && !obj.is_delete_marker() && op.delete_marker);
   }


### PR DESCRIPTION
when link a null version delete_marker and the null version instance exists, the existing null version idx should not unlinked in rgw_bucket_link_olh. It will be removed in delete_obj.

Fixes: http://tracker.ceph.com/issues/21429

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>