### PR TITLE
test: silence warning from -Wsign-compare

### DIFF
--- a/src/test/librados/tier.cc
+++ b/src/test/librados/tier.cc
@@ -1357,12 +1357,12 @@ TEST_F(LibRadosTwoPoolsPP, ListSnap){
       0, NULL));
     completion->wait_for_safe();
     ASSERT_EQ(0, snap_ret);
-    ASSERT_LT(0, snap_set.clones.size());
+    ASSERT_LT(0u, snap_set.clones.size());
     for (vector<librados::clone_info_t>::const_iterator r = snap_set.clones.begin();
 	r != snap_set.clones.end();
 	++r) {
       if (r->cloneid != librados::SNAP_HEAD) {
-	ASSERT_LT(0, r->snaps.size());
+	ASSERT_LT(0u, r->snaps.size());
       }
     }
   }

--- a/src/test/test_xlist.cc
+++ b/src/test/test_xlist.cc
@@ -43,14 +43,14 @@ protected:
 TEST_F(XlistTest, capability) {
   ItemList list;
   ASSERT_TRUE(list.empty());
-  ASSERT_EQ(list.size(), 0);
+  ASSERT_EQ(0u, list.size());
 
   std::copy(refs.begin(), refs.end(), std::back_inserter(list));
   ASSERT_EQ((size_t)list.size(), refs.size());
 
   list.clear();
   ASSERT_TRUE(list.empty());
-  ASSERT_EQ(list.size(), 0);
+  ASSERT_EQ(0u, list.size());
 }
 
 TEST_F(XlistTest, traverse) {


### PR DESCRIPTION
Fixed warnings:
```
In file included from ceph/src/test/test_xlist.cc:6:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int]’:
ceph/src/googletest/googletest/include/gtest/gtest.h:1421:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<lhs_is_null_literal>::Compare(const char*, const char*, const T1&, const T2&) [with T1 = long unsigned int; T2 = int; bool lhs_is_null_literal = false]’
ceph/src/test/test_xlist.cc:46:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```

```
In file included from ceph/src/test/librados/tier.cc:3:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperLT(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]’:
ceph/src/test/librados/tier.cc:1360:5:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1526:28: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:7:
   if (val1 op val2) {\
       ~~~~~~~~~             
ceph/src/googletest/googletest/include/gtest/gtest.h:1526:28:
 GTEST_IMPL_CMP_HELPER_(LT, <);
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:12: note: in definition of macro ‘GTEST_IMPL_CMP_HELPER_’
   if (val1 op val2) {\
            ^~
```

```
In file included from ceph/src/test/librados/tier.cc:3:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperLT(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = long unsigned int]’:
ceph/src/test/librados/tier.cc:1365:2:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1526:28: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:7:
   if (val1 op val2) {\
       ~~~~~~~~~             
ceph/src/googletest/googletest/include/gtest/gtest.h:1526:28:
 GTEST_IMPL_CMP_HELPER_(LT, <);
ceph/src/googletest/googletest/include/gtest/gtest.h:1510:12: note: in definition of macro ‘GTEST_IMPL_CMP_HELPER_’
   if (val1 op val2) {\
```
Signed-off-by: Jos Collin <jcollin@redhat.com>