### PR TITLE
client: set client_try_dentry_invalidate to false by default

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5968,7 +5968,7 @@ std::vector<Option> get_mds_client_options() {
     .set_description("check for ceph-fuse to consider supplementary groups for permissions"),
 
     Option("client_try_dentry_invalidate", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description(""),
 
     Option("client_die_on_failed_remount", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
By default, ceph-fuse uses side effect of 'dentry invalidation' to
trim kernel dcache if it runs on kernel < 3.18. The implemention of
kernel function d_invalidate() changed in 3.18 kernel, the method no
longer works for upstream kernel >= 3.18.

RHEL 3.10 kernel includes backport of patches that change implemention
of d_invalidate(). So checking kernel version to decide if 'dentry
invalidation' method works is unreliable.

Fixes: http://tracker.ceph.com/issues/21423
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>