### PR TITLE
messages,journal: Initialization of stats_period,m_active_set

### DIFF
--- a/src/journal/JournalPlayer.h
+++ b/src/journal/JournalPlayer.h
@@ -119,7 +119,7 @@ private:
   bool m_commit_position_valid = false;
   ObjectPosition m_commit_position;
   SplayedObjectPositions m_commit_positions;
-  uint64_t m_active_set;
+  uint64_t m_active_set = 0;
 
   boost::optional<uint64_t> m_active_tag_tid = boost::none;
   boost::optional<uint64_t> m_prune_tag_tid = boost::none;

--- a/src/messages/MMgrConfigure.h
+++ b/src/messages/MMgrConfigure.h
@@ -27,7 +27,7 @@ class MMgrConfigure : public Message
   static const int COMPAT_VERSION = 1;
 
 public:
-  uint32_t stats_period;
+  uint32_t stats_period = 0;
   
   // Default 0 means if unspecified will include all stats
   uint32_t stats_threshold = 0;


### PR DESCRIPTION
Fixes the coverity issues:

** 1396212 Uninitialized scalar field
>CID 1396212 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member stats_period is not
initialized in this constructor nor in any functions that it calls.

** 1396226 Uninitialized scalar field
>CID 1396226 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member m_active_set is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>