### PR TITLE
librbd,os: address coverity false positives

### DIFF
--- a/src/librbd/io/ObjectRequest.h
+++ b/src/librbd/io/ObjectRequest.h
@@ -294,7 +294,7 @@ protected:
   librados::ObjectWriteOperation m_write;
   uint64_t m_snap_seq;
   std::vector<librados::snap_t> m_snaps;
-  bool m_object_exist;
+  bool m_object_exist = false;
   bool m_guard = true;
 
   virtual void add_write_ops(librados::ObjectWriteOperation *wr,

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -977,8 +977,8 @@ public:
     int64_t expected_for_release = 0;      ///< alloc units currently used by
                                            ///< compressed blobs that might
                                            ///< gone after GC
-    uint64_t gc_start_offset;              ///starting offset for GC
-    uint64_t gc_end_offset;                ///ending offset for GC
+    uint64_t gc_start_offset = 0;              ///starting offset for GC
+    uint64_t gc_end_offset = 0;                ///ending offset for GC
 
   protected:
     void process_protrusive_extents(const BlueStore::ExtentMap& extent_map, 

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -95,7 +95,7 @@ public:
   struct PageSetObject;
   struct Collection : public CollectionImpl {
     coll_t cid;
-    int bits;
+    int bits = 0;
     CephContext *cct;
     bool use_page_set;
     ceph::unordered_map<ghobject_t, ObjectRef> object_hash;  ///< for lookup


### PR DESCRIPTION
Fixes the coverity issues:

** 1401444 Uninitialized scalar field
>2. uninit_member: Non-static class member gc_start_offset is not
initialized in this constructor nor in any functions that it calls.
>CID 1401444 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member gc_end_offset is not
initialized in this constructor nor in any functions that it calls.

** 1405091 Uninitialized scalar field
>CID 1405091 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member bits is not initialized
in this constructor nor in any functions that it calls.

** 1409842 Uninitialized scalar field
>CID 1409842 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_object_exist is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>