### PR TITLE
msg: Initialize lkey,bound,port_cnt,num_chunk,gid_idx

### DIFF
--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -57,7 +57,7 @@ class Port {
   int port_num;
   struct ibv_port_attr* port_attr;
   uint16_t lid;
-  int gid_idx;
+  int gid_idx = 0;
   union ibv_gid gid;
 
  public:
@@ -73,7 +73,7 @@ class Port {
 class Device {
   ibv_device *device;
   const char* name;
-  uint8_t  port_cnt;
+  uint8_t  port_cnt = 0;
  public:
   explicit Device(CephContext *c, ibv_device* d);
   ~Device() {
@@ -206,9 +206,9 @@ class Infiniband {
 
      public:
       ibv_mr* mr;
-      uint32_t lkey;
+      uint32_t lkey = 0;
       uint32_t bytes;
-      uint32_t bound;
+      uint32_t bound = 0;
       uint32_t offset;
       char* buffer; // TODO: remove buffer/refactor TX
       char  data[0];
@@ -233,7 +233,7 @@ class Infiniband {
 
       MemoryManager& manager;
       uint32_t buffer_size;
-      uint32_t num_chunk;
+      uint32_t num_chunk = 0;
       Mutex lock;
       std::vector<Chunk*> free_chunks;
       char *base = nullptr;


### PR DESCRIPTION
Fixes the coverity issues:

** 1414512 Uninitialized scalar field
>2. uninit_member: Non-static class member lkey is not initialized
in this constructor nor in any functions that it calls.
>CID 1414512 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member bound is not initialized
in this constructor nor in any functions that it calls.

** 1414523 Uninitialized scalar field
>CID 1414523 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>5. uninit_member: Non-static class member port_cnt is not initialized
in this constructor nor in any functions that it calls.

** 1414524 Uninitialized scalar field
>CID 1414524 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member num_chunk is not initialized
in this constructor nor in any functions that it calls.

** 1414525 Uninitialized scalar field
>CID 1414525 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member gid_idx is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>