### PR TITLE
client: remove redundant judgment

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -7567,8 +7567,6 @@ int Client::_readdir_cache_cb(dir_result_t *dirp, add_dirent_cb_t cb, void *p,
 
   string dn_name;
   while (true) {
-    if (!dirp->inode->is_complete_and_ordered())
-      return -EAGAIN;
     if (pd == dir->readdir_cache.end())
       break;
     Dentry *dn = *pd;


### PR DESCRIPTION
Have two reason remove "dirp->inode->is_complete_and_ordered()":
1. Each while the loop to determine the cycle is unnecessary, only need 
    to determine the removal of the global can;
2. In the function readdir_r_cb() has been judged on the "dirp->inode->is_complete_and_ordered()" 
reduce the unnecessary judgments, the speed of readdir have some advantages, although not obvious.

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>