### PR TITLE
osd,messages: Initialize read_length,options,send_reply

### DIFF
--- a/src/messages/MOSDForceRecovery.h
+++ b/src/messages/MOSDForceRecovery.h
@@ -38,7 +38,7 @@ struct MOSDForceRecovery : public Message {
 
   uuid_d fsid;
   vector<pg_t> forced_pgs;
-  uint8_t options;
+  uint8_t options = 0;
 
   MOSDForceRecovery() : Message(MSG_OSD_FORCE_RECOVERY, HEAD_VERSION, COMPAT_VERSION) {}
   MOSDForceRecovery(const uuid_d& f, char opts) :

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4604,7 +4604,7 @@ int PrimaryLogPG::finish_checksum(OSDOp& osd_op,
 struct C_ExtentCmpRead : public Context {
   PrimaryLogPG *primary_log_pg;
   OSDOp &osd_op;
-  ceph_le64 read_length;
+  ceph_le64 read_length{};
   bufferlist read_bl;
   Context *fill_extent_ctx;
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -573,7 +573,7 @@ public:
       on_committed.emplace_back(std::forward<F>(f));
     }
 
-    bool sent_reply;
+    bool sent_reply = false;
 
     // pending async reads <off, len, op_flags> -> <outbl, outr>
     list<pair<boost::tuple<uint64_t, uint64_t, unsigned>,


### PR DESCRIPTION
Fixes the coverity issues:

** 1415776 Uninitialized scalar field
>CID 1415776 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member field read_length.v is
not initialized in this constructor nor in any functions that it calls.

** 1415811 Uninitialized scalar field
>CID 1415811 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member options is not initialized
in this constructor nor in any functions that it calls.

** 1415850 Uninitialized scalar field
>CID 1415850 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member sent_reply is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>