### PR TITLE
test/librbd: initialize on_finish,locker,force,snap_id

### DIFF
--- a/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
+++ b/src/test/librbd/exclusive_lock/test_mock_PostAcquireRequest.cc
@@ -37,7 +37,7 @@ namespace image {
 template<>
 struct RefreshRequest<librbd::MockTestImageCtx> {
   static RefreshRequest *s_instance;
-  Context *on_finish;
+  Context *on_finish = nullptr;
 
   static RefreshRequest *create(librbd::MockTestImageCtx &image_ctx,
                                 bool acquire_lock_refresh,

--- a/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
+++ b/src/test/librbd/managed_lock/test_mock_AcquireRequest.cc
@@ -52,8 +52,8 @@ struct BreakRequest<librbd::MockImageCtx> {
 
 template <>
 struct GetLockerRequest<librbd::MockImageCtx> {
-  Locker *locker;
-  Context *on_finish;
+  Locker *locker = nullptr;
+  Context *on_finish = nullptr;
 
   static GetLockerRequest *s_instance;
   static GetLockerRequest* create(librados::IoCtx& ioctx,

--- a/src/test/librbd/object_map/mock/MockInvalidateRequest.h
+++ b/src/test/librbd/object_map/mock/MockInvalidateRequest.h
@@ -12,9 +12,9 @@ namespace object_map {
 template <typename I>
 struct MockInvalidateRequestBase {
   static std::list<InvalidateRequest<I>*> s_requests;
-  uint64_t snap_id;
-  bool force;
-  Context *on_finish;
+  uint64_t snap_id = 0;
+  bool force = false;
+  Context *on_finish = nullptr;
 
   static InvalidateRequest<I>* create(I &image_ctx, uint64_t snap_id,
                                       bool force, Context *on_finish) {


### PR DESCRIPTION
Fixes the coverity issues:

** 396154 Uninitialized pointer field
>CID 1396154 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

** 1396158 Uninitialized pointer field
>2. uninit_member: Non-static class member snap_id is not initialized
in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member force is not initialized
in this constructor nor in any functions that it calls.
>CID 1396158 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>6. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

** 1399593 Uninitialized pointer field
>2. uninit_member: Non-static class member locker is not initialized
in this constructor nor in any functions that it calls.
>CID 1399593 (#2 of 2): Uninitialized pointer field (UNINIT_CTOR)
>4. uninit_member: Non-static class member on_finish is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>