### PR TITLE
rgw:add the missing response headers when using KMS encryption.

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1105,6 +1105,8 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         *block_crypt = std::move(aes);
       }
       actual_key.replace(0, actual_key.length(), actual_key.length(), '\000');
+      crypt_http_responses["x-amz-server-side-encryption"] = "aws:kms";
+      crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] = key_id.to_string();
       return 0;
     }
 


### PR DESCRIPTION
we should return header "x-amz-server-side-encryption" and "x-amz-server-side-encryption-aws-kms-key-id" accoding to http://docs.aws.amazon.com/AmazonS3/latest/API/RESTObjectPUT.html

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>