### PR TITLE
test: address coverity false positives

### DIFF
--- a/src/test/librados_test_stub/TestIoCtxImpl.h
+++ b/src/test/librados_test_stub/TestIoCtxImpl.h
@@ -185,9 +185,9 @@ private:
   };
 
   TestRadosClient *m_client;
-  int64_t m_pool_id;
+  int64_t m_pool_id = 0;
   std::string m_pool_name;
-  snap_t m_snap_seq;
+  snap_t m_snap_seq = 0;
   SnapContext m_snapc;
   std::atomic<uint64_t> m_refcount = { 0 };
   std::atomic<uint64_t> m_pending_ops = { 0 };

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -23,7 +23,7 @@ namespace io {
 template <>
 struct ImageRequest<librbd::MockTestImageCtx> {
   static ImageRequest* s_instance;
-  AioCompletion *aio_comp;
+  AioCompletion *aio_comp = nullptr;
 
   static ImageRequest* create_write_request(librbd::MockTestImageCtx &image_ctx,
                                             AioCompletion *aio_comp,

--- a/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/ObjectCopyRequest.h
@@ -116,7 +116,7 @@ private:
   std::string m_remote_oid;
 
   librados::snap_set_t m_snap_set;
-  int m_snap_ret;
+  int m_snap_ret = 0;
 
   bool m_retry_missing_read = false;
   librados::snap_set_t m_retry_snap_set;


### PR DESCRIPTION
Fixes the coverity issues:

** 1414517 Uninitialized pointer field
>CID 1414517 (#1 of 1): Uninitialized pointer field (UNINIT_CTOR)
>2. uninit_member: Non-static class member aio_comp is not initialized
in this constructor nor in any functions that it calls.

** 1274324 Uninitialized scalar field
>2. uninit_member: Non-static class member m_pool_id is not initialized
in this constructor nor in any functions that it calls.
>CID 1274324 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member m_snap_seq is not initialized
in this constructor nor in any functions that it calls.

** 1356906 Uninitialized scalar field
>CID 1356906 (#1-2 of 2): Uninitialized scalar field (UNINIT_CTOR)
>5. uninit_member: Non-static class member m_snap_ret is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>