### PR TITLE
osd/PrimaryLogPG: kill add_interval_usage

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7171,7 +7171,7 @@ void PrimaryLogPG::make_writeable(OpContext *ctx)
       interval_set<uint64_t> &newest_overlap = ctx->new_snapset.clone_overlap.rbegin()->second;
       ctx->modified_ranges.intersection_of(newest_overlap);
       // modified_ranges is still in use by the clone
-      add_interval_usage(ctx->modified_ranges, ctx->delta_stats);
+      ctx->delta_stats.num_bytes += ctx->modified_ranges.size();
       newest_overlap.subtract(ctx->modified_ranges);
     }
   }
@@ -7210,13 +7210,6 @@ void PrimaryLogPG::write_update_size_and_usage(object_stat_sum_t& delta_stats, o
   }
   delta_stats.num_wr++;
   delta_stats.num_wr_kb += SHIFT_ROUND_UP(length, 10);
-}
-
-void PrimaryLogPG::add_interval_usage(interval_set<uint64_t>& s, object_stat_sum_t& delta_stats)
-{
-  for (interval_set<uint64_t>::const_iterator p = s.begin(); p != s.end(); ++p) {
-    delta_stats.num_bytes += p.get_len();
-  }
 }
 
 void PrimaryLogPG::complete_disconnect_watches(

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1106,8 +1106,6 @@ protected:
   void write_update_size_and_usage(object_stat_sum_t& stats, object_info_t& oi,
 				   interval_set<uint64_t>& modified, uint64_t offset,
 				   uint64_t length, bool write_full=false);
-  void add_interval_usage(interval_set<uint64_t>& s, object_stat_sum_t& st);
-
 
   enum class cache_result_t {
     NOOP,


### PR DESCRIPTION
Use inline size() member of interval_set instead, which is faster and simpler.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>