### PR TITLE
osd/PrimaryLogPG: prepare_transaction - fix EDQUOT vs ENOSPC

### DIFF
--- a/qa/workunits/rados/test_rados_tool.sh
+++ b/qa/workunits/rados/test_rados_tool.sh
@@ -346,7 +346,7 @@ test_rmobj() {
     $CEPH_TOOL osd pool set-quota $p max_objects 1
     V1=`mktemp fooattrXXXXXXX`
     $RADOS_TOOL put $OBJ $V1 -p $p
-    while ! $CEPH_TOOL osd dump | grep 'full_no_quota max_objects'
+    while ! $CEPH_TOOL osd dump | grep 'full_quota max_objects'
     do
 	sleep 2
     done

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -975,7 +975,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	}
 	if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL) &&
 	    full_pool_ids.empty()) {
-	  if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+	  if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
 	    // set by EQUOTA, skipping
 	    continue;
 	  }
@@ -1010,7 +1010,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	  continue;
 	}
 	if (!tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL) ||
-	    tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+	    tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
 	  // don't touch if currently is not full
 	  // or is running out of quota (and hence considered as full)
 	  continue;
@@ -1029,7 +1029,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	  // skip pools we have already considered as full above
 	  continue;
 	}
-	if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+	if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
 	  // make sure FLAG_FULL is truly set, so we are safe not
 	  // to set a extra (redundant) FLAG_BACKFILLFULL flag
 	  assert(tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL));
@@ -1072,7 +1072,7 @@ void OSDMonitor::encode_pending(MonitorDBStore::TransactionRef t)
 	if (full_pool_ids.count(p) || backfillfull_pool_ids.count(p)) {
 	  continue;
 	}
-	if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+	if (tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
 	  // make sure FLAG_FULL is truly set, so we are safe not
 	  // to set a extra (redundant) FLAG_NEARFULL flag
 	  assert(tmp.get_pg_pool(p)->has_flag(pg_pool_t::FLAG_FULL));
@@ -4893,7 +4893,7 @@ bool OSDMonitor::update_pools_status()
       (pool.quota_max_bytes > 0 && (uint64_t)sum.num_bytes >= pool.quota_max_bytes) ||
       (pool.quota_max_objects > 0 && (uint64_t)sum.num_objects >= pool.quota_max_objects);
 
-    if (pool.has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+    if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
       if (pool_is_full)
         continue;
 
@@ -4902,7 +4902,7 @@ bool OSDMonitor::update_pools_status()
       // below we cancel FLAG_FULL too, we'll set it again in
       // OSDMonitor::encode_pending if it still fails the osd-full checking.
       clear_pool_flags(it->first,
-                       pg_pool_t::FLAG_FULL_NO_QUOTA | pg_pool_t::FLAG_FULL);
+                       pg_pool_t::FLAG_FULL_QUOTA | pg_pool_t::FLAG_FULL);
       ret = true;
     } else {
       if (!pool_is_full)
@@ -4920,11 +4920,11 @@ bool OSDMonitor::update_pools_status()
                          << " (reached quota's max_objects: "
                          << pool.quota_max_objects << ")";
       }
-      // set both FLAG_FULL_NO_QUOTA and FLAG_FULL
+      // set both FLAG_FULL_QUOTA and FLAG_FULL
       // note that below we try to cancel FLAG_BACKFILLFULL/NEARFULL too
       // since FLAG_FULL should always take precedence
       set_pool_flags(it->first,
-                     pg_pool_t::FLAG_FULL_NO_QUOTA | pg_pool_t::FLAG_FULL);
+                     pg_pool_t::FLAG_FULL_QUOTA | pg_pool_t::FLAG_FULL);
       clear_pool_flags(it->first,
                        pg_pool_t::FLAG_NEARFULL |
                        pg_pool_t::FLAG_BACKFILLFULL);

--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -4683,10 +4683,10 @@ void OSDMap::check_health(health_check_map_t *checks) const
       const string& pool_name = get_pool_name(it.first);
       if (pool.has_flag(pg_pool_t::FLAG_FULL)) {
 	stringstream ss;
-        if (pool.has_flag(pg_pool_t::FLAG_FULL_NO_QUOTA)) {
+        if (pool.has_flag(pg_pool_t::FLAG_FULL_QUOTA)) {
           // may run out of space too,
           // but we want EQUOTA taking precedence
-          ss << "pool '" << pool_name << "' is full (no quota)";
+          ss << "pool '" << pool_name << "' is full (running out of quota)";
         } else {
           ss << "pool '" << pool_name << "' is full (no space)";
         }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7399,7 +7399,7 @@ int PrimaryLogPG::prepare_transaction(OpContext *ctx)
     } else if (m->has_flag(CEPH_OSD_FLAG_FULL_TRY)) {
       // they tried, they failed.
       dout(20) << __func__ << " full, replying to FULL_TRY op" << dendl;
-      return pool.info.has_flag(pg_pool_t::FLAG_FULL) ? -EDQUOT : -ENOSPC;
+      return pool.info.has_flag(pg_pool_t::FLAG_FULL_QUOTA) ? -EDQUOT : -ENOSPC;
     } else {
       // drop request
       dout(20) << __func__ << " full, dropping request (bad client)" << dendl;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1154,7 +1154,7 @@ struct pg_pool_t {
     FLAG_WRITE_FADVISE_DONTNEED = 1<<7, // write mode with LIBRADOS_OP_FLAG_FADVISE_DONTNEED
     FLAG_NOSCRUB = 1<<8, // block periodic scrub
     FLAG_NODEEP_SCRUB = 1<<9, // block periodic deep-scrub
-    FLAG_FULL_NO_QUOTA = 1<<10, // pool is currently running out of quota, will set FLAG_FULL too
+    FLAG_FULL_QUOTA = 1<<10, // pool is currently running out of quota, will set FLAG_FULL too
     FLAG_NEARFULL = 1<<11, // pool is nearfull
     FLAG_BACKFILLFULL = 1<<12, // pool is backfillfull
   };
@@ -1171,7 +1171,7 @@ struct pg_pool_t {
     case FLAG_WRITE_FADVISE_DONTNEED: return "write_fadvise_dontneed";
     case FLAG_NOSCRUB: return "noscrub";
     case FLAG_NODEEP_SCRUB: return "nodeep-scrub";
-    case FLAG_FULL_NO_QUOTA: return "full_no_quota";
+    case FLAG_FULL_QUOTA: return "full_quota";
     case FLAG_NEARFULL: return "nearfull";
     case FLAG_BACKFILLFULL: return "backfillfull";
     default: return "???";
@@ -1212,8 +1212,8 @@ struct pg_pool_t {
       return FLAG_NOSCRUB;
     if (name == "nodeep-scrub")
       return FLAG_NODEEP_SCRUB;
-    if (name == "full_no_quota")
-      return FLAG_FULL_NO_QUOTA;
+    if (name == "full_quota")
+      return FLAG_FULL_QUOTA;
     if (name == "nearfull")
       return FLAG_NEARFULL;
     if (name == "backfillfull")


### PR DESCRIPTION
We now set full flag if a pool is currently running out of space and
set both full and full_quota flags if it is running out of quota.
Therefore the full_quota flag should be instead used to uniquely
identify whether we are running out of quota or not.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>