### PR TITLE
luminous: qa: ignorable MDS_READ_ONLY warning

### DIFF
--- a/qa/suites/kcephfs/recovery/tasks/auto-repair.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/auto-repair.yaml
@@ -4,6 +4,7 @@ overrides:
       - force file system read-only
       - bad backtrace
       - MDS in read-only mode
+      - \(MDS_READ_ONLY\)
 
 
 tasks:


### PR DESCRIPTION
http://tracker.ceph.com/issues/21464