### PR TITLE
jewel: tests: make upgrade tests use supported distros

### DIFF
--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros
@@ -1,0 +1,1 @@
+../../../../../distros/supported

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/ubuntu_14.04.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/distros/ubuntu_14.04.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/ubuntu_14.04.yaml

--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros
@@ -1,0 +1,1 @@
+../../../../../distros/supported

--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos.yaml
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/ubuntu_14.04.yaml
+++ b/qa/suites/upgrade/client-upgrade/infernalis-client-x/basic/distros/ubuntu_14.04.yaml
@@ -1,1 +1,0 @@
-../../../../../../distros/all/ubuntu_14.04.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos.yaml
@@ -1,1 +1,0 @@
-../../../../../distros/all/centos.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml


### PR DESCRIPTION
Linking the upgrade tests to qa/distros/supported instead of to explicit
versions makes this suite easier to maintain.

Signed-off-by: Nathan Cutler <ncutler@suse.com>

Conflicts:
    This is not cherry-pickable because the upgrade suites are very different
    in master.