### PR TITLE
qa/suites/rados/perf: create pool with lower pg_num

### DIFF
--- a/qa/suites/rados/perf/workloads/sample_fio.yaml
+++ b/qa/suites/rados/perf/workloads/sample_fio.yaml
@@ -19,6 +19,6 @@ tasks:
       iterations: 1
       pool_profiles:
         rbd:
-          pg_size: 512
-          pgp_size: 512
+          pg_size: 128
+          pgp_size: 128
           replication: 3

--- a/qa/suites/rados/perf/workloads/sample_radosbench.yaml
+++ b/qa/suites/rados/perf/workloads/sample_radosbench.yaml
@@ -18,6 +18,6 @@ tasks:
       iterations: 1
       pool_profiles:
         replicated:
-          pg_size: 512
-          pgp_size: 512
+          pg_size: 256
+          pgp_size: 256
           replication: 'replicated'


### PR DESCRIPTION
Reduce the value of `pg_num` while creating pools, in order to avoid exceeding cluster pg limit.

Signed-off-by: Neha Ojha <nojha@redhat.com>