### PR TITLE
rgw:lc fix expiration time

### DIFF
--- a/src/include/utime.h
+++ b/src/include/utime.h
@@ -171,6 +171,17 @@ public:
     return utime_t(tt, 0);
   }
 
+  utime_t round_to_day() {
+    struct tm bdt;
+    time_t tt = sec();
+    localtime_r(&tt, &bdt);
+    bdt.tm_sec = 0;
+    bdt.tm_min = 0;
+    bdt.tm_hour = 0;
+    tt = mktime(&bdt);
+    return utime_t(tt, 0);
+  }
+
   // cast to double
   operator double() const {
     return (double)sec() + ((double)nsec() / 1000000000.0L);

--- a/src/rgw/rgw_lc.h
+++ b/src/rgw/rgw_lc.h
@@ -363,7 +363,7 @@ class RGWLC {
 
   private:
   int remove_expired_obj(RGWBucketInfo& bucket_info, rgw_obj_key obj_key, bool remove_indeed = true);
-  bool obj_has_expired(double timediff, int days);
+  bool obj_has_expired(ceph::real_time mtime, int days);
   int handle_multipart_expiration(RGWRados::Bucket *target, const map<string, lc_op>& prefix_map);
 };
 

--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -32,7 +32,12 @@ bool LCExpiration_S3::xml_end(const char * el) {
   } else {
     date = lc_date->get_data();
     //We need return xml error according to S3
-    if (boost::none == ceph::from_iso_8601(date)) {
+    boost::optional<ceph::real_time> expiration_date = ceph::from_iso_8601(date);
+    if (boost::none == expiration_date) {
+      return false;
+    }
+    struct timespec expiration_time = ceph::real_clock::to_timespec(*expiration_date);
+    if (expiration_time.tv_sec % (24*60*60) || expiration_time.tv_nsec) {
       return false;
     }
   }


### PR DESCRIPTION
1、According to S3, expiration_date must be midnight.
2、Amazon S3 calculates the expiration time by adding the number of days specified in the rule to the object creation time and rounding the resulting time to the next day midnight.
So rgw should using the rounding down midnight time to compare with the object creation time to check obj expiration.

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>