### PR TITLE
librbd,test: address coverity false positives

### DIFF
--- a/src/librbd/operation/ObjectMapIterate.cc
+++ b/src/librbd/operation/ObjectMapIterate.cc
@@ -68,7 +68,7 @@ private:
   std::atomic_flag *m_invalidate;
 
   librados::snap_set_t m_snap_set;
-  int m_snap_list_ret;
+  int m_snap_list_ret = 0;
 
   bool should_complete(int r) {
     I &image_ctx = this->m_image_ctx;

--- a/src/test/common/test_sharedptr_registry.cc
+++ b/src/test/common/test_sharedptr_registry.cc
@@ -300,7 +300,7 @@ public:
     TellDie() { died = NO; }
     ~TellDie() { died = YES; }
     
-    int value;
+    int value = 0;
   };
 
   void SetUp() override {

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -25,8 +25,8 @@ TEST(BitAllocator, test_bmap_iter)
   int off = 2;
 
   class BmapEntityTmp {
-      int64_t m_num;
-      int64_t m_len;
+      int64_t m_num = 0;
+      int64_t m_len = 0;
     public:
       void init(int index) {
         m_num = index;


### PR DESCRIPTION
Fixes the coverity issues:

** 1396105 Uninitialized scalar field
>CID 1396105 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_snap_list_ret is not
initialized in this constructor nor in any functions that it calls.

** 1396141 Uninitialized scalar field
>CID 1396141 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member value is not initialized
in this constructor nor in any functions that it calls.

** 1396162 Uninitialized scalar field
>2. uninit_member: Non-static class member m_num is not initialized
in this constructor nor in any functions that it calls.
>CID 1396162 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member m_len is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>