### PR TITLE
misc: address coverity false positives

### DIFF
--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -296,9 +296,9 @@ namespace crimson {
 	// an idle client becoming unidle
 	double                prop_delta = 0.0;
 
-	c::IndIntruHeapData   reserv_heap_data;
-	c::IndIntruHeapData   lim_heap_data;
-	c::IndIntruHeapData   ready_heap_data;
+	c::IndIntruHeapData   reserv_heap_data{};
+	c::IndIntruHeapData   lim_heap_data{};
+	c::IndIntruHeapData   ready_heap_data{};
 #if USE_PROP_HEAP
 	c::IndIntruHeapData   prop_heap_data;
 #endif

--- a/src/librbd/managed_lock/BreakRequest.h
+++ b/src/librbd/managed_lock/BreakRequest.h
@@ -78,7 +78,7 @@ private:
   bufferlist m_out_bl;
 
   std::list<obj_watch_t> m_watchers;
-  int m_watchers_ret_val;
+  int m_watchers_ret_val = 0;
 
   Locker m_refreshed_locker;
 

--- a/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.h
+++ b/src/tools/rbd_mirror/image_sync/SnapshotCreateRequest.h
@@ -74,7 +74,7 @@ private:
   ImageCtxT *m_local_image_ctx;
   std::string m_snap_name;
   cls::rbd::SnapshotNamespace m_snap_namespace;
-  uint64_t m_size;
+  uint64_t m_size = 0;
   librbd::ParentSpec m_parent_spec;
   uint64_t m_parent_overlap;
   Context *m_on_finish;


### PR DESCRIPTION
Fixes the coverity issues:

** 1409838 Uninitialized scalar field
>CID 1409838 (#1-2 of 2): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_watchers_ret_val is
not initialized in this constructor nor in any functions that it calls.

** 1405850 Uninitialized scalar field
>2. uninit_member: Non-static class member reserv_heap_data is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member lim_heap_data is not
initialized in this constructor nor in any functions that it calls.
>CID 1405850 (#1-3 of 3): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member ready_heap_data is not
initialized in this constructor nor in any functions that it calls.

** 1413774 Uninitialized scalar field
>CID 1413774 (#1-2 of 2): Uninitialized scalar field (UNINIT_CTOR)
>2. uninit_member: Non-static class member m_size is not initialized
in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>