### PR TITLE
common: use mono clock for HeartbeatMap

### DIFF
--- a/src/common/HeartbeatMap.h
+++ b/src/common/HeartbeatMap.h
@@ -18,9 +18,9 @@
 #include <list>
 #include <atomic>
 #include <string>
-
 #include <pthread.h>
 
+#include "common/ceph_time.h"
 #include "RWLock.h"
 
 class CephContext;
@@ -41,6 +41,7 @@ namespace ceph {
 struct heartbeat_handle_d {
   const std::string name;
   pthread_t thread_id;
+  // TODO: use atomic<time_point>, once we can ditch GCC 4.8
   std::atomic<unsigned> timeout = { 0 }, suicide_timeout = { 0 };
   time_t grace, suicide_grace;
   std::list<heartbeat_handle_d*>::iterator list_item;
@@ -57,7 +58,9 @@ class HeartbeatMap {
   void remove_worker(const heartbeat_handle_d *h);
 
   // reset the timeout so that it expects another touch within grace amount of time
-  void reset_timeout(heartbeat_handle_d *h, time_t grace, time_t suicide_grace);
+  void reset_timeout(heartbeat_handle_d *h,
+		     ceph::coarse_mono_clock::rep grace,
+		     ceph::coarse_mono_clock::rep suicide_grace);
   // clear the timeout so that it's not checked on
   void clear_timeout(heartbeat_handle_d *h);
 
@@ -79,12 +82,13 @@ class HeartbeatMap {
  private:
   CephContext *m_cct;
   RWLock m_rwlock;
-  time_t m_inject_unhealthy_until;
+  ceph::coarse_mono_clock::time_point m_inject_unhealthy_until;
   std::list<heartbeat_handle_d*> m_workers;
   std::atomic<unsigned> m_unhealthy_workers = { 0 };
   std::atomic<unsigned> m_total_workers = { 0 };
 
-  bool _check(const heartbeat_handle_d *h, const char *who, time_t now);
+  bool _check(const heartbeat_handle_d *h, const char *who,
+	      ceph::coarse_mono_clock::rep now);
 };
 
 }

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -42,8 +42,8 @@ public:
     friend class ThreadPool;
     CephContext *cct;
     heartbeat_handle_d *hb;
-    time_t grace;
-    time_t suicide_grace;
+    ceph::coarse_mono_clock::rep grace;
+    ceph::coarse_mono_clock::rep suicide_grace;
   public:
     TPHandle(
       CephContext *cct,


### PR DESCRIPTION
to avoid problems when admin sets system clock.

Signed-off-by: Kefu Chai <kchai@redhat.com>
Signed-off-by: Xinze Chi <xinze@xsky.com>