### PR TITLE
rgw: don't persist Content-Encoding

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -88,7 +88,6 @@ static const struct rgw_http_attr base_rgw_to_http_attrs[] = {
   { RGW_ATTR_EXPIRES,           "Expires" },
   { RGW_ATTR_CACHE_CONTROL,     "Cache-Control" },
   { RGW_ATTR_CONTENT_DISP,      "Content-Disposition" },
-  { RGW_ATTR_CONTENT_ENC,       "Content-Encoding" },
   { RGW_ATTR_USER_MANIFEST,     "X-Object-Manifest" },
   { RGW_ATTR_X_ROBOTS_TAG ,     "X-Robots-Tag" },
   /* RGW_ATTR_AMZ_WEBSITE_REDIRECT_LOCATION header depends on access mode:
@@ -113,7 +112,6 @@ static const struct generic_attr generic_attrs[] = {
   { "HTTP_EXPIRES",             RGW_ATTR_EXPIRES },
   { "HTTP_CACHE_CONTROL",       RGW_ATTR_CACHE_CONTROL },
   { "HTTP_CONTENT_DISPOSITION", RGW_ATTR_CONTENT_DISP },
-  { "HTTP_CONTENT_ENCODING",    RGW_ATTR_CONTENT_ENC },
   { "HTTP_X_ROBOTS_TAG",        RGW_ATTR_X_ROBOTS_TAG },
 };
 


### PR DESCRIPTION
This would fix #21128. It may be a bit overkill, though, there may be situations where content-encoding should be persisted.

Fixes: http://tracker.ceph.com/issues/21128
Signed-off-by: Alex Iribarren <alex.iribarren@cern.ch>