### PR TITLE
examples: fix link order in librados example Makefile

### DIFF
--- a/examples/librados/Makefile
+++ b/examples/librados/Makefile
@@ -3,13 +3,13 @@ CXX?=g++
 CXX_FLAGS?=-std=c++11 -Wall -Wextra -Werror -g
 CXX_LIBS?=-lboost_system -lrados -lradosstriper
 CXX_INC?=$(LOCAL_LIBRADOS_INC)
-CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS) $(CXX_LIBS)
+CXX_CC=$(CXX) $(CXX_FLAGS) $(CXX_INC) $(LOCAL_LIBRADOS)
 
 CC?=gcc
 CC_FLAGS=-Wall -Wextra -Werror -g
 CC_INC=$(LOCAL_LIBRADOS_INC)
 CC_LIBS?=-lrados
-CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS) $(CC_LIBS)
+CC_CC=$(CC) $(CC_FLAGS) $(CC_INC) $(LOCAL_LIBRADOS)
 
 # Relative path to the Ceph source:
 CEPH_SRC_HOME?=../../src
@@ -26,13 +26,13 @@ all-system: LOCAL_LIBRADOS_INC=
 all-system: all
 
 hello_world_cpp: hello_world.cc
-	$(CXX_CC) -o hello_world_cpp hello_world.cc
+	$(CXX_CC) -o hello_world_cpp hello_world.cc $(CXX_LIBS)
 
 hello_radosstriper_cpp: hello_radosstriper.cc
-	$(CXX_CC) -o hello_radosstriper_cpp hello_radosstriper.cc
+	$(CXX_CC) -o hello_radosstriper_cpp hello_radosstriper.cc $(CXX_LIBS)
 
 hello_world_c: hello_world_c.c
-	$(CC_CC) -o hello_world_c hello_world_c.c
+	$(CC_CC) -o hello_world_c hello_world_c.c $(CC_LIBS)
 
 clean:
 	rm -f hello_world_cpp hello_radosstriper_cpp hello_world_c

--- a/examples/librados/hello_world.readme
+++ b/examples/librados/hello_world.readme
@@ -6,7 +6,7 @@ build tree (ie. using relative paths). If you would like to build the examples a
 your system librados and headers, use "make all-system".
 
 And executed using
-./librados_hello_world -c ../../src/ceph.conf
+./hello_world_cpp -c ../../src/ceph.conf
 (or whatever path to a ceph.conf is appropriate to you, or
 by explicitly specifying monitors, user id, and keys).
 


### PR DESCRIPTION
The library link order in librados example Makefile is incorrect
and as a result 'make' throws an error. This change fixes the order.

Signed-off-by: Mahati Chamarthy <mahati.chamarthy@intel.com>