### PR TITLE
ceph_volume_client: perform snapshot operations based on config setting 'client_snapdir'

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -31,7 +31,6 @@ class RadosError(Exception):
 
 
 RADOS_TIMEOUT = 10
-SNAP_DIR = ".snap"
 
 log = logging.getLogger(__name__)
 
@@ -1296,7 +1295,7 @@ class CephFSVolumeClient(object):
 
     def _snapshot_path(self, dir_path, snapshot_name):
         return os.path.join(
-            dir_path, SNAP_DIR, snapshot_name
+            dir_path, self.rados.conf_get('client_snapdir'), snapshot_name
         )
 
     def _snapshot_create(self, dir_path, snapshot_name):


### PR DESCRIPTION
... client configured snap directory name, instead of in hard-coded
'.snap' directory.

Fixes: http://tracker.ceph.com/issues/21476

Signed-off-by: Ramana Raja <rraja@redhat.com>