### PR TITLE
mon/MgrMonitor: read cmd descs if empty on update_from_paxos()

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -84,8 +84,9 @@ void MgrMonitor::update_from_paxos(bool *need_bootstrap)
     check_subs();
 
     if (version == 1
-	|| (map.get_available()
-	    && (!old_available || old_gid != map.get_active_gid()))) {
+        || command_descs.empty()
+        || (map.get_available()
+            && (!old_available || old_gid != map.get_active_gid()))) {
       dout(4) << "mkfs or daemon transitioned to available, loading commands"
 	      << dendl;
       bufferlist loaded_commands;


### PR DESCRIPTION
If the MgrMonitor's `command_descs` is empty, the monitor will not send
the mgr commands to clients on `get_descriptions`. This, in turn, has
the clients sending the commands to the monitors, which will have no
idea how to handle them.

Therefore, make sure to read the `command_descs` from disk if the vector
is empty.

Fixes: http://tracker.ceph.com/issues/21300

Signed-off-by: `Joao Eduardo Luis <joao@suse.de>`