### PR TITLE
qa: revert "qa: use config_path property instead of literal"

### DIFF
--- a/qa/tasks/vstart_runner.py
+++ b/qa/tasks/vstart_runner.py
@@ -635,7 +635,7 @@ class LocalCephCluster(CephCluster):
         # In teuthology, we have the honour of writing the entire ceph.conf, but
         # in vstart land it has mostly already been written and we need to carefully
         # append to it.
-        conf_path = self.config_path
+        conf_path = "./ceph.conf"
         banner = "\n#LOCAL_TEST\n"
         existing_str = open(conf_path).read()
 
@@ -715,7 +715,7 @@ class LocalFilesystem(Filesystem, LocalMDSCluster):
 
         # Hack: cheeky inspection of ceph.conf to see what MDSs exist
         self.mds_ids = set()
-        for line in open(self.config_path).readlines():
+        for line in open("ceph.conf").readlines():
             match = re.match("^\[mds\.(.+)\]$", line)
             if match:
                 self.mds_ids.add(match.group(1))
@@ -849,7 +849,7 @@ class LocalContext(object):
         # Shove some LocalDaemons into the ctx.daemons DaemonGroup instance so that any
         # tests that want to look these up via ctx can do so.
         # Inspect ceph.conf to see what roles exist
-        for conf_line in open(self.config_path).readlines():
+        for conf_line in open("ceph.conf").readlines():
             for svc_type in ["mon", "osd", "mds", "mgr"]:
                 if svc_type not in self.daemons.daemons:
                     self.daemons.daemons[svc_type] = {}


### PR DESCRIPTION
This reverts commit f95798b3adb30c866725ef26aee75c4811655752.

The config_path method wasn't available through inheritance as I thought. Oops.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>