### PR TITLE
luminous: prometheus module generates invalid output when counter names contain non-alphanum characters

### DIFF
--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -76,7 +76,7 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            return path.replace('.', '_').replace('-', '_')
+            return path.replace('.', '_').replace('-', '_minus').replace('+', '_plus') 
 
         def floatstr(value):
             ''' represent as Go-compatible float '''

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -76,7 +76,16 @@ class Metric(object):
 
         def promethize(path):
             ''' replace illegal metric name characters '''
-            return path.replace('.', '_').replace('-', '_minus').replace('+', '_plus') 
+            result = path.replace('.', '_').replace('+', '_plus') 
+
+            # Hyphens usually turn into underscores, unless they are
+            # trailing
+            if result.endswith("-"):
+                result = result[0:-1] + "_minus"
+            else:
+                result = result.replace("-", "_")
+
+            return result
 
         def floatstr(value):
             ''' represent as Go-compatible float '''


### PR DESCRIPTION
http://tracker.ceph.com/issues/21452