### PR TITLE
kv,dmclock: Initiaze m_,reserv_heap_data,lim_heap_data,ready_heap_data

### DIFF
--- a/src/dmclock/src/dmclock_server.h
+++ b/src/dmclock/src/dmclock_server.h
@@ -296,9 +296,9 @@ namespace crimson {
 	// an idle client becoming unidle
 	double                prop_delta = 0.0;
 
-	c::IndIntruHeapData   reserv_heap_data;
-	c::IndIntruHeapData   lim_heap_data;
-	c::IndIntruHeapData   ready_heap_data;
+	c::IndIntruHeapData   reserv_heap_data{};
+	c::IndIntruHeapData   lim_heap_data{};
+	c::IndIntruHeapData   ready_heap_data{};
 #if USE_PROP_HEAP
 	c::IndIntruHeapData   prop_heap_data;
 #endif

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -30,8 +30,8 @@ class MemDB : public KeyValueDB
 {
   typedef std::pair<std::pair<std::string, std::string>, bufferlist> ms_op_t;
   std::mutex m_lock;
-  uint64_t m_total_bytes;
-  uint64_t m_allocated_bytes;
+  uint64_t m_total_bytes = 0;
+  uint64_t m_allocated_bytes = 0;
 
   typedef std::map<std::string, bufferptr> mdb_map_t;
   typedef mdb_map_t::iterator mdb_iter_t;


### PR DESCRIPTION
Fixes the coverity issues:

** 1396221 Uninitialized scalar field
>2. uninit_member: Non-static class member m_total_bytes is not initialized
in this constructor nor in any functions that it calls.
>CID 1396221 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>4. uninit_member: Non-static class member m_allocated_bytes is not initialized
in this constructor nor in any functions that it calls.

** 1418242 Uninitialized scalar field
>2. uninit_member: Non-static class member reserv_heap_data is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member lim_heap_data is not
initialized in this constructor nor in any functions that it calls.
>CID 1418242 (#1-2 of 2): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member ready_heap_data is not
initialized in this constructor nor in any functions that it calls.

** 1418244 Uninitialized scalar field
>2. uninit_member: Non-static class member reserv_heap_data is not
initialized in this constructor nor in any functions that it calls.
>4. uninit_member: Non-static class member lim_heap_data is not
initialized in this constructor nor in any functions that it calls.
>CID 1418244 (#1 of 1): Uninitialized scalar field (UNINIT_CTOR)
>6. uninit_member: Non-static class member ready_heap_data is not
initialized in this constructor nor in any functions that it calls.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>