### PR TITLE
osd: silence warnings from -Wsign-compare

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3275,9 +3275,10 @@ int OSDMap::validate_crush_rules(CrushWrapper *newcrush,
       *ss << "pool " << i.first << " type does not match rule " << ruleno;
       return -EINVAL;
     }
-    if (pool.get_size() < (int)newcrush->get_rule_mask_min_size(ruleno) ||
-	pool.get_size() > (int)newcrush->get_rule_mask_max_size(ruleno)) {
-      *ss << "pool " << i.first << " size " << pool.get_size() << " does not"
+    int poolsize = pool.get_size();
+    if (poolsize < newcrush->get_rule_mask_min_size(ruleno) ||
+	poolsize > newcrush->get_rule_mask_max_size(ruleno)) {
+      *ss << "pool " << i.first << " size " << poolsize << " does not"
 	  << " fall within rule " << ruleno
 	  << " min_size " << newcrush->get_rule_mask_min_size(ruleno)
 	  << " and max_size " << newcrush->get_rule_mask_max_size(ruleno);


### PR DESCRIPTION
Fixed the warning :
```
ceph/src/osd/OSDMap.cc: In member function ‘int OSDMap::validate_crush_rules(CrushWrapper*, std::ostream*) const’:
ceph/src/osd/OSDMap.cc:3278:25: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if (pool.get_size() < (int)newcrush->get_rule_mask_min_size(ruleno) ||
         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
ceph/src/osd/OSDMap.cc:3279:18: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
  pool.get_size() > (int)newcrush->get_rule_mask_max_size(ruleno)) {
  ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
I think introducing a variable `poolsize` is better than calling `get_size()` many times. It fixes the warning too.

Signed-off-by: Jos Collin <jcollin@redhat.com>