### PR TITLE
rgw: Returning when dst_ioctx.operate() returns error

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -6386,6 +6386,9 @@ int RGWRados::move_rados_obj(librados::IoCtx& src_ioctx,
     }
     wop.write(ofs, data);
     ret = dst_ioctx.operate(dst_oid, &wop);
+    if (ret < 0) {
+      goto done_err;
+    }
     ofs += data.length();
     done = data.length() != chunk_size;
   } while (!done);
@@ -6402,6 +6405,7 @@ int RGWRados::move_rados_obj(librados::IoCtx& src_ioctx,
   return 0;
 
 done_err:
+  // TODO: clean up dst_oid if we created it
   lderr(cct) << "ERROR: failed to copy " << src_oid << " -> " << dst_oid << dendl;
   return ret;
 }


### PR DESCRIPTION
** 1396179 Unused value
>CID 1396179 (#1 of 1): Unused value (UNUSED_VALUE)
returned_value: Assigning value from dst_ioctx->operate(dst_oid, &wop)
to ret here, but that stored value is overwritten before it can be used.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>