### PR TITLE
test: return if BlueFS::FileWriter* is NULL

### DIFF
--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -199,6 +199,7 @@ void write_single_file(BlueFS &fs, uint64_t rationed_bytes)
     rationed_bytes -= ALLOC_SIZE;
     while (1) {
       ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+      assert(h);
       bufferlist bl;
       char *buf = gen_buffer(ALLOC_SIZE);
       bufferptr bp = buffer::claim_char(ALLOC_SIZE, buf);


### PR DESCRIPTION
Fixes the coverity issue:

>CID 1396173 (#1-2 of 2): Use after free (USE_AFTER_FREE)
>13. pass_freed_arg: Passing freed pointer h as an argument
to append.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>