### PR TITLE
luminous: tests: [cephfs] test_filtered_df: assert 0.9 < ratio < 1.1

### DIFF
--- a/qa/tasks/cephfs/test_misc.py
+++ b/qa/tasks/cephfs/test_misc.py
@@ -147,5 +147,5 @@ class TestMisc(CephFSTestCase):
         fs_avail = output.split('\n')[1].split()[3]
         fs_avail = float(fs_avail) * 1024
 
-        ratio = (raw_avail / pool_size) / fs_avail
+        ratio = raw_avail / fs_avail
         assert 0.9 < ratio < 1.1


### PR DESCRIPTION
http://tracker.ceph.com/issues/21437