### PR TITLE
luminous: tests: test_misc creates metadata pool with dummy object resulting in WRN: POOL_APP_NOT_ENABLED

### DIFF
--- a/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
+++ b/qa/suites/fs/multiclient/tasks/cephfs_misc_tests.yaml
@@ -7,3 +7,4 @@ overrides:
   ceph:
     log-whitelist:
       - evicting unresponsive client
+      - POOL_APP_NOT_ENABLED


### PR DESCRIPTION
http://tracker.ceph.com/issues/21449