### PR TITLE
rgw: Error check on return of read_line()

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -1419,6 +1419,9 @@ int RGWPostObj_ObjStore::read_form_part_header(struct post_form_part* const part
     }
 
     r = read_line(bl, chunk_size, reached_boundary, done);
+    if (r < 0) {
+      return r;
+    }
   }
 
   return 0;


### PR DESCRIPTION
Fixes the coverity issue:

** 1406089 Unused value
>CID 1406089 (#1 of 1): Unused value (UNUSED_VALUE)
returned_value: Assigning value from this->read_line
(bl, chunk_size, reached_boundary, done) to r here,
but that stored value is overwritten before it can be used.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>