### PR TITLE
jewel: core: global/signal_handler.cc: fix typo

### DIFF
--- a/src/global/signal_handler.cc
+++ b/src/global/signal_handler.cc
@@ -179,7 +179,7 @@ struct SignalHandler : public Thread {
   };
 
   /// all handlers
-  safe_handler *handlers[32];
+  safe_handler *handlers[32] = {nullptr};
 
   /// to protect the handlers array
   Mutex lock;
@@ -187,9 +187,6 @@ struct SignalHandler : public Thread {
   SignalHandler()
     : stop(false), lock("SignalHandler::lock")
   {
-    for (unsigned i = 0; i < 32; i++)
-      handlers[i] = NULL;
-
     // create signal pipe
     int r = pipe(pipefd);
     assert(r == 0);
@@ -197,7 +194,7 @@ struct SignalHandler : public Thread {
     assert(r == 0);
 
     // create thread
-    create("sginal_handler");
+    create("signal_handler");
   }
 
   ~SignalHandler() {


### PR DESCRIPTION
http://tracker.ceph.com/issues/21485