### PR TITLE
luminous: tests: [kcephfs] test_client_pin times out waiting for dentry release from kernel

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5934,7 +5934,7 @@ std::vector<Option> get_mds_client_options() {
     .set_description("check for ceph-fuse to consider supplementary groups for permissions"),
 
     Option("client_try_dentry_invalidate", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
-    .set_default(true)
+    .set_default(false)
     .set_description(""),
 
     Option("client_die_on_failed_remount", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
http://tracker.ceph.com/issues/21486