### PR TITLE
githubmap: Fixed typo

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -38,7 +38,7 @@ ukernel Zheng Yan <zyan@redhat.com>
 vasukulkarni Vasu Kulkarni <vasu@redhat.com>
 vuhuong Vu Pham <vuhuong@mellanox.com>
 wjwithagen Willem Jan Withagen <wjw@digiware.nl>
-xiexingguo xie xingguo <xie.xingguo@zte.com.cn>
+xiexingguo Xie Xingguo <xie.xingguo@zte.com.cn>
 yangdongsheng Dongsheng Yang <dongsheng.yang@easystack.cn>
 yuyuyu101 Haomai Wang <haomai@xsky.com>
 jtlayton Jeff Layton <jlayton@redhat.com>


### PR DESCRIPTION
Fixed Xie Xingguo, as per the name appears in the github home page. This is better for searching
in .githubmap. The other small letter names in githubmap are matching with the corresponding names in github. So leaving them.

Signed-off-by: Jos Collin <jcollin@redhat.com>