### PR TITLE
tests: fix uninitialized value found by coverity scan

### DIFF
--- a/src/test/common/test_mclock_priority_queue.cc
+++ b/src/test/common/test_mclock_priority_queue.cc
@@ -21,7 +21,9 @@
 
 struct Request {
   int value;
-  Request() = default;
+  Request() :
+    value(0)
+  {}
   Request(const Request& o) = default;
   Request(int value) :
     value(value)


### PR DESCRIPTION
Unit test for mclock priority queue had a default constructor that
didn't initialize a value.

Signed-off-by: J. Eric Ivancich <ivancich@redhat.com>