### PR TITLE
rgw: Fallback to SW crypto on crypto accelerator failure

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -377,6 +377,12 @@ public:
           result = crypto_accel->cbc_decrypt(out + offset, in + offset,
                                              process_size, iv, key);
         }
+        if (!result) {
+          ldout(cct, 5) << "Cryto Accelerator failed to perform operation. \
+                         Fall back to SW implementation " << dendl;
+          crypto_accel = NULL;
+          failed_to_get_crypto = true;
+        }
       } else {
         result = cbc_transform(
             out + offset, in + offset, process_size,


### PR DESCRIPTION
If crypto_accel fails to perform crypto operation, this change should
route future crypto operations to the SW implementation as a
fallback.

Signed-off-by: Ganesh Mahalingam <ganesh.mahalingam@intel.com>