### PR TITLE
jewel: common/config_opts.h: Set Filestore rocksdb compaction readahead option.

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -860,7 +860,7 @@ OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
 OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default leveldb cache size
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
-OPTION(filestore_rocksdb_options, OPT_STR, "")
+OPTION(filestore_rocksdb_options, OPT_STR, "compaction_readahead_size=2097152")
 // rocksdb options that will be used in monstore
 OPTION(mon_rocksdb_options, OPT_STR, "write_buffer_size=33554432,compression=kNoCompression")
 


### PR DESCRIPTION
See: https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L680

While RocksDB code comments mention HDDs specifically, we also saw improved CPU usage due to fewer read calls with readahead enabled on NVMe (Atleast with BlueFS, milleage may vary with filestore and rocksdb using posix).  In any event, reads are all entirely sequential as verified by blktrace so there doesn't appear to be any real downside to enabling this.

Signed-off-by: Mark Nelson <mnelson@redhat.com>