### PR TITLE
common/options.cc: Set Filestore rocksdb compaction readahead option.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3639,7 +3639,7 @@ std::vector<Option> get_global_options() {
     // filestore
 
     Option("filestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("")
+    .set_default("compaction_readahead_size=2097152")
     .set_description(""),
 
     Option("filestore_omap_backend", Option::TYPE_STR, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
See: https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h#L680

While RocksDB code comments mention HDDs specifically, we also saw improved CPU usage due to fewer read calls with readahead enabled on NVMe (Atleast with BlueFS, milleage may vary with filestore and rocksdb using posix). In any event, reads are all entirely sequential as verified by blktrace so there doesn't appear to be any real downside to enabling this.

Signed-off-by: Mark Nelson <mnelson@redhat.com>