### PR TITLE
osd/osd_types: object_info_t: remove unused function

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4915,19 +4915,6 @@ void object_info_t::copy_user_bits(const object_info_t& other)
   omap_digest = other.omap_digest;
 }
 
-ps_t object_info_t::legacy_object_locator_to_ps(const object_t &oid, 
-						const object_locator_t &loc) {
-  ps_t ps;
-  if (loc.key.length())
-    // Hack, we don't have the osd map, so we don't really know the hash...
-    ps = ceph_str_hash(CEPH_STR_HASH_RJENKINS, loc.key.c_str(), 
-		       loc.key.length());
-  else
-    ps = ceph_str_hash(CEPH_STR_HASH_RJENKINS, oid.name.c_str(),
-		       oid.name.length());
-  return ps;
-}
-
 void object_info_t::encode(bufferlist& bl, uint64_t features) const
 {
   object_locator_t myoloc(soid);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4667,9 +4667,6 @@ struct object_info_t {
 
   void copy_user_bits(const object_info_t& other);
 
-  static ps_t legacy_object_locator_to_ps(const object_t &oid, 
-					  const object_locator_t &loc);
-
   bool test_flag(flag_t f) const {
     return (flags & f) == f;
   }


### PR DESCRIPTION
legacy_object_locator_to_ps() is not used anymore, so drop it.

Signed-off-by: Kefu Chai <kchai@redhat.com>