### PR TITLE
osd/PrimaryLogPG: apply_stats - fix scrub_cstat leak

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7604,12 +7604,12 @@ void PrimaryLogPG::apply_stats(
   }
 
   if (is_primary() && scrubber.active) {
-    if (soid < scrubber.start) {
-      dout(20) << __func__ << " " << soid << " < [" << scrubber.start
+    if (soid < scrubber.start || soid >= scrubber.end) {
+      dout(20) << __func__ << " " << soid << " escapes [" << scrubber.start
 	       << "," << scrubber.end << ")" << dendl;
       scrub_cstat.add(delta_stats);
     } else {
-      dout(20) << __func__ << " " << soid << " >= [" << scrubber.start
+      dout(20) << __func__ << " " << soid << " trapped in [" << scrubber.start
 	       << "," << scrubber.end << ")" << dendl;
     }
   }


### PR DESCRIPTION
Chunky-scrub only blocks ops operating objects in
[scrubber.start, scrubber.end), thus we still have
to update scrub_cstat if soid >= scrubber.end.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>