### PR TITLE
rgw: Ignoring the returned error

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -1483,6 +1483,10 @@ int do_check_object_locator(const string& tenant_name, const string& bucket_name
 
 	if (ret >= 0) {
           ret = check_obj_tail_locator_underscore(bucket_info, obj, key, fix, f);
+          if (ret < 0) {
+              cerr << "ERROR: check_obj_tail_locator_underscore(): " << cpp_strerror(-ret) << std::endl;
+              return -ret;
+          }
 	}
       }
     }


### PR DESCRIPTION
** 1396191 Unused value
>CID 1396191 (#1 of 1): Unused value (UNUSED_VALUE)
returned_value: Assigning value from check_obj_tail_locator_underscore
(bucket_info, obj, key, fix, f) to ret here, but that stored value is
overwritten before it can be used.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>