### PR TITLE
test: NULL Checking to avoid use after free

### DIFF
--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -152,6 +152,9 @@ void write_data(BlueFS &fs, uint64_t rationed_bytes)
       string file = "file.";
       file.append(to_string(j));
       ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+      if (!h) {
+         break;
+      }
       bufferlist bl;
       char *buf = gen_buffer(ALLOC_SIZE);
       bufferptr bp = buffer::claim_char(ALLOC_SIZE, buf);
@@ -367,6 +370,9 @@ TEST(BlueFS, test_simple_compaction_sync) {
           string file = "file.";
 	  file.append(to_string(j));
           ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+          if (!h) {
+             break;
+          }
           bufferlist bl;
           char *buf = gen_buffer(4096);
 	  bufferptr bp = buffer::claim_char(4096, buf);
@@ -419,6 +425,9 @@ TEST(BlueFS, test_simple_compaction_async) {
           string file = "file.";
 	  file.append(to_string(j));
           ASSERT_EQ(0, fs.open_for_write(dir, file, &h, false));
+          if (!h) {
+             break;
+	  }
           bufferlist bl;
           char *buf = gen_buffer(4096);
 	  bufferptr bp = buffer::claim_char(4096, buf);


### PR DESCRIPTION
** 1396190 Use after free
>CID 1396190 (#1-2 of 2): Use after free (USE_AFTER_FREE)
>16. pass_freed_arg: Passing freed pointer h as an argument to append.

** 1396198 Use after free
>CID 1396198 (#1-2 of 2): Use after free (USE_AFTER_FREE)
>24. pass_freed_arg: Passing freed pointer h as an argument to append.

** 1396216 Use after free
>CID 1396216 (#1-2 of 2): Use after free (USE_AFTER_FREE)
>24. pass_freed_arg: Passing freed pointer h as an argument to append.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>