### PR TITLE
tests: point-to-point-x: upgrade client.1 to -x along with cluster nodes

### DIFF
--- a/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/point-to-point-upgrade.yaml
@@ -76,7 +76,8 @@ tasks:
 - install.upgrade:
     mon.a:
     mon.b:
-- print: "**** done branch: -x install.upgrade on mon.a and mon.b"
+    client.1:
+- print: "**** done branch: -x install.upgrade on mon.a, mon.b, and client.1"
 - parallel:
    - workload_x
    - upgrade-sequence_x
@@ -85,8 +86,6 @@ tasks:
     osd.0:
       - ceph osd set-require-min-compat-client luminous
 # Run librados tests on the -x upgraded cluster
-- install.upgrade:
-    client.1:
 - workunit:
     branch: jewel
     clients:


### PR DESCRIPTION
The client.1 rgw in workload_x had not been upgraded to -x.

Found in Jewel v10.2.10 QE testing.

Fixes: http://tracker.ceph.com/issues/21499