### PR TITLE
bluestore: add a option bluestore_allow_buffered_write

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1106,6 +1106,7 @@ OPTION(bluestore_blobid_prealloc, OPT_U64)
 OPTION(bluestore_clone_cow, OPT_BOOL)  // do copy-on-write for clones
 OPTION(bluestore_default_buffered_read, OPT_BOOL)
 OPTION(bluestore_default_buffered_write, OPT_BOOL)
+OPTION(bluestore_allow_buffered_write, OPT_BOOL)
 OPTION(bluestore_debug_misc, OPT_BOOL)
 OPTION(bluestore_debug_no_reuse_blocks, OPT_BOOL)
 OPTION(bluestore_debug_small_allocations, OPT_INT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3532,6 +3532,11 @@ std::vector<Option> get_global_options() {
     .set_safe()
     .set_description("Cache writes by default (unless hinted NOCACHE or WONTNEED)"),
 
+    Option("bluestore_allow_buffered_write", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_safe()
+    .set_description("Allow bluestore and bluefs to do buffered write"),
+
     Option("bluestore_debug_misc", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1474,10 +1474,14 @@ int BlueFS::_flush_range(FileWriter *h, uint64_t offset, uint64_t length)
   h->buffer_appender.flush();
 
   bool buffered;
-  if (h->file->fnode.ino == 1)
+  if (!cct->_conf->bluestore_allow_buffered_write) {
     buffered = false;
-  else
-    buffered = cct->_conf->bluefs_buffered_io;
+  } else {
+    if (h->file->fnode.ino == 1)
+      buffered = false;
+    else
+      buffered = cct->_conf->bluefs_buffered_io;
+  }
 
   if (offset + length <= h->pos)
     return 0;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10177,14 +10177,19 @@ void BlueStore::_choose_write_options(
    uint32_t fadvise_flags,
    WriteContext *wctx)
 {
-  if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
-    dout(20) << __func__ << " will do buffered write" << dendl;
-    wctx->buffered = true;
-  } else if (cct->_conf->bluestore_default_buffered_write &&
-	     (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
-			       CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
-    dout(20) << __func__ << " defaulting to buffered write" << dendl;
-    wctx->buffered = true;
+  if (!cct->_conf->bluestore_allow_buffered_write) {
+      dout(20) << __func__ << " buffered write is not allowed" << dendl;
+      wctx->buffered = false;
+  } else {
+    if (fadvise_flags & CEPH_OSD_OP_FLAG_FADVISE_WILLNEED) {
+      dout(20) << __func__ << " will do buffered write" << dendl;
+      wctx->buffered = true;
+    } else if (cct->_conf->bluestore_default_buffered_write &&
+	       (fadvise_flags & (CEPH_OSD_OP_FLAG_FADVISE_DONTNEED |
+				 CEPH_OSD_OP_FLAG_FADVISE_NOCACHE)) == 0) {
+      dout(20) << __func__ << " defaulting to buffered write" << dendl;
+      wctx->buffered = true;
+    }
   }
 
   // apply basic csum block size

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -276,6 +276,13 @@ int KernelDevice::flush()
     return 0;
   }
 
+  if (!cct->_conf->bluestore_allow_buffered_write) {
+    // all writes are direct write, so no need to call fdatasync.
+    dout(10) << __func__ << " no-op (buffered write is not allowd)"
+	     << dendl;
+    return 0;
+  }
+
   dout(10) << __func__ << " start" << dendl;
   if (cct->_conf->bdev_inject_crash) {
     ++injecting_crash;


### PR DESCRIPTION
```
In some baking device, the fdatasync() is very expensive operation,
such as bcache device. In this case, we should make all write as
direct write and skip the fdatasync() in flush().

We can get a significant performance improvement in our testing.

fio+librbd, bs=1M, numjobs=1, iodepth=1

bluestore_allow_buffered_write:		true		false
latency(ms):				95.24		7.13
iops:					10		140

About 10X performance improvement!

Signed-off-by: Dongsheng Yang <dongsheng.yang@easystack.cn>
```