### PR TITLE
docs: Do not use "min size = 1" as an example

### DIFF
--- a/doc/install/manual-deployment.rst
+++ b/doc/install/manual-deployment.rst
@@ -230,8 +230,8 @@ The procedure is as follows:
 	auth service required = cephx
 	auth client required = cephx
 	osd journal size = 1024
-	osd pool default size = 2
-	osd pool default min size = 1
+	osd pool default size = 3
+	osd pool default min size = 2
 	osd pool default pg num = 333
 	osd pool default pgp num = 333
 	osd crush chooseleaf type = 1

--- a/doc/install/manual-freebsd-deployment.rst
+++ b/doc/install/manual-freebsd-deployment.rst
@@ -279,8 +279,8 @@ The procedure is as follows:
 	auth service required = cephx
 	auth client required = cephx
 	osd journal size = 1024
-	osd pool default size = 2
-	osd pool default min size = 1
+	osd pool default size = 3
+	osd pool default min size = 2
 	osd pool default pg num = 333
 	osd pool default pgp num = 333	
 	osd crush chooseleaf type = 1

--- a/doc/rados/configuration/pool-pg-config-ref.rst
+++ b/doc/rados/configuration/pool-pg-config-ref.rst
@@ -10,7 +10,7 @@ recommend** overridding some of the defaults. Specifically, we recommend setting
 a pool's replica size and overriding the default number of placement groups. You
 can specifically set these values when running `pool`_ commands. You can also
 override the defaults by adding new ones in the ``[global]`` section of  your
-Ceph configuration file. 
+Ceph configuration file.
 
 
 .. literalinclude:: pool-pg.conf
@@ -25,18 +25,18 @@ Ceph configuration file.
 :Default: ``65536``
 
 
-``mon pg create interval`` 
+``mon pg create interval``
 
-:Description: Number of seconds between PG creation in the same 
+:Description: Number of seconds between PG creation in the same
               Ceph OSD Daemon.
 
 :Type: Float
 :Default: ``30.0``
 
 
-``mon pg stuck threshold`` 
+``mon pg stuck threshold``
 
-:Description: Number of seconds after which PGs can be considered as 
+:Description: Number of seconds after which PGs can be considered as
               being stuck.
 
 :Type: 32-bit Integer
@@ -127,7 +127,7 @@ Ceph configuration file.
 
 :Description: Placement group bits per Ceph OSD Daemon.
 :Type: 32-bit Integer
-:Default: ``6`` 
+:Default: ``6``
 
 
 ``osd pgp bits``
@@ -139,7 +139,7 @@ Ceph configuration file.
 
 ``osd crush chooseleaf type``
 
-:Description: The bucket type to use for ``chooseleaf`` in a CRUSH rule. Uses 
+:Description: The bucket type to use for ``chooseleaf`` in a CRUSH rule. Uses
               ordinal rank rather than name.
 
 :Type: 32-bit Integer
@@ -156,7 +156,7 @@ Ceph configuration file.
           See `Weighting Bucket Items`_ for details.
 
 
-``osd pool default crush replicated ruleset`` 
+``osd pool default crush replicated ruleset``
 
 :Description: The default CRUSH ruleset to use when creating a replicated pool.
 :Type: 8-bit Integer
@@ -191,30 +191,30 @@ Ceph configuration file.
 
 ``osd pool default min size``
 
-:Description: Sets the minimum number of written replicas for objects in the 
-             pool in order to acknowledge a write operation to the client. 
-             If minimum is not met, Ceph will not acknowledge the write to the 
-             client. This setting ensures a minimum number of replicas when 
-             operating in ``degraded`` mode.
+:Description: Sets the minimum number of written replicas for objects in the
+             pool in order to acknowledge a write operation to the client.  If
+             minimum is not met, Ceph will not acknowledge the write to the
+             client, **which may result in data loss**. This setting ensures
+             a minimum number of replicas when operating in ``degraded`` mode.
 
 :Type: 32-bit Integer
-:Default: ``0``, which means no particular minimum. If ``0``, 
+:Default: ``0``, which means no particular minimum. If ``0``,
           minimum is ``size - (size / 2)``.
 
 
-``osd pool default pg num`` 
+``osd pool default pg num``
 
-:Description: The default number of placement groups for a pool. The default 
+:Description: The default number of placement groups for a pool. The default
               value is the same as ``pg_num`` with ``mkpool``.
 
 :Type: 32-bit Integer
-:Default: ``8`` 
+:Default: ``8``
 
 
-``osd pool default pgp num`` 
+``osd pool default pgp num``
 
-:Description: The default number of placement groups for placement for a pool. 
-              The default value is the same as ``pgp_num`` with ``mkpool``. 
+:Description: The default number of placement groups for placement for a pool.
+              The default value is the same as ``pgp_num`` with ``mkpool``.
               PG and PGP should be equal (for now).
 
 :Type: 32-bit Integer
@@ -223,14 +223,14 @@ Ceph configuration file.
 
 ``osd pool default flags``
 
-:Description: The default flags for new pools. 
+:Description: The default flags for new pools.
 :Type: 32-bit Integer
 :Default: ``0``
 
 
 ``osd max pgls``
 
-:Description: The maximum number of placement groups to list. A client 
+:Description: The maximum number of placement groups to list. A client
               requesting a large number can tie up the Ceph OSD Daemon.
 
 :Type: Unsigned 64-bit Integer
@@ -238,9 +238,9 @@ Ceph configuration file.
 :Note: Default should be fine.
 
 
-``osd min pg log entries`` 
+``osd min pg log entries``
 
-:Description: The minimum number of placement group logs to maintain 
+:Description: The minimum number of placement group logs to maintain
               when trimming log files.
 
 :Type: 32-bit Int Unsigned

--- a/doc/rados/configuration/pool-pg.conf
+++ b/doc/rados/configuration/pool-pg.conf
@@ -1,17 +1,17 @@
 [global]
 
-	# By default, Ceph makes 3 replicas of objects. If you want to make four 
-	# copies of an object the default value--a primary copy and three replica 
+	# By default, Ceph makes 3 replicas of objects. If you want to make four
+	# copies of an object the default value--a primary copy and three replica
 	# copies--reset the default values as shown in 'osd pool default size'.
-	# If you want to allow Ceph to write a lesser number of copies in a degraded 
+	# If you want to allow Ceph to write a lesser number of copies in a degraded
 	# state, set 'osd pool default min size' to a number less than the
 	# 'osd pool default size' value.
 
-	osd pool default size = 4  # Write an object 4 times.
-	osd pool default min size = 1 # Allow writing one copy in a degraded state.
+	osd pool default size = 3  # Write an object 3 times.
+	osd pool default min size = 2 # Allow writing two copies in a degraded state.
 
 	# Ensure you have a realistic number of placement groups. We recommend
-	# approximately 100 per OSD. E.g., total number of OSDs multiplied by 100 
+	# approximately 100 per OSD. E.g., total number of OSDs multiplied by 100
 	# divided by the number of replicas (i.e., osd pool default size). So for
 	# 10 OSDs and osd pool default size = 4, we'd recommend approximately
 	# (100 * 10) / 4 = 250.


### PR DESCRIPTION
Because it is easy to assume it is a normal setting, although there is significant potential for data loss.

Check rule added to ceph-medic at:  https://github.com/ceph/ceph-medic/issues/11 to warn when this is set to 1