### PR TITLE
os/bluestore: release disk extents in bulky manner

### DIFF
--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -48,15 +48,7 @@ public:
 
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
-  virtual void release(const interval_set<uint64_t>& release_set) {
-    /* TODO(rzarzynski): make this pure virtual and eradicate the single-op
-     * release() after switching all allocators. */
-    for (interval_set<uint64_t>::const_iterator p = release_set.begin();
-	 p != release_set.end();
-	 ++p) {
-      release(p.get_start(), p.get_len());
-    }
-  }
+  virtual void release(const interval_set<uint64_t>& release_set) = 0;
 
   virtual void dump() = 0;
 

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -43,9 +43,6 @@ public:
     return allocate(want_size, alloc_unit, want_size, hint, extents);
   }
 
-  virtual void release(
-    uint64_t offset, uint64_t length) = 0;
-
   /* Bulk release. Implementations may override this method to handle the whole
    * set at once. This could save e.g. unnecessary mutex dance. */
   virtual void release(const interval_set<uint64_t>& release_set) = 0;

--- a/src/os/bluestore/Allocator.h
+++ b/src/os/bluestore/Allocator.h
@@ -46,6 +46,18 @@ public:
   virtual void release(
     uint64_t offset, uint64_t length) = 0;
 
+  /* Bulk release. Implementations may override this method to handle the whole
+   * set at once. This could save e.g. unnecessary mutex dance. */
+  virtual void release(const interval_set<uint64_t>& release_set) {
+    /* TODO(rzarzynski): make this pure virtual and eradicate the single-op
+     * release() after switching all allocators. */
+    for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+	 p != release_set.end();
+	 ++p) {
+      release(p.get_start(), p.get_len());
+    }
+  }
+
   virtual void dump() = 0;
 
   virtual void init_add_free(uint64_t offset, uint64_t length) = 0;

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -154,6 +154,21 @@ void BitMapAllocator::release(
   insert_free(offset, length);
 }
 
+void BitMapAllocator::release(
+  const interval_set<uint64_t>& release_set)
+{
+  for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+       p != release_set.end();
+       ++p) {
+    const auto offset = p.get_start();
+    const auto length = p.get_len();
+    dout(10) << __func__ << " 0x"
+             << std::hex << offset << "~" << length << std::dec
+             << dendl;
+    insert_free(offset, length);
+  }
+}
+
 uint64_t BitMapAllocator::get_free()
 {
   assert(m_bit_alloc->total_blocks() >= m_bit_alloc->get_used_blocks());

--- a/src/os/bluestore/BitMapAllocator.cc
+++ b/src/os/bluestore/BitMapAllocator.cc
@@ -146,15 +146,6 @@ int64_t BitMapAllocator::allocate_dis(
 }
 
 void BitMapAllocator::release(
-  uint64_t offset, uint64_t length)
-{
-  dout(10) << __func__ << " 0x"
-           << std::hex << offset << "~" << length << std::dec
-           << dendl;
-  insert_free(offset, length);
-}
-
-void BitMapAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
   for (interval_set<uint64_t>::const_iterator p = release_set.begin();

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -37,6 +37,8 @@ public:
 
   void release(
     uint64_t offset, uint64_t length) override;
+  void release(
+    const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;
 

--- a/src/os/bluestore/BitMapAllocator.h
+++ b/src/os/bluestore/BitMapAllocator.h
@@ -36,8 +36,6 @@ public:
     int64_t hint, mempool::bluestore_alloc::vector<AllocExtent> *extents) override;
 
   void release(
-    uint64_t offset, uint64_t length) override;
-  void release(
     const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -1455,8 +1455,9 @@ int BlueFS::_flush_and_sync_log(std::unique_lock<std::mutex>& l,
   }
 
   for (unsigned i = 0; i < to_release.size(); ++i) {
-    for (auto p = to_release[i].begin(); p != to_release[i].end(); ++p) {
-      alloc[i]->release(p.get_start(), p.get_len());
+    if (!to_release[i].empty()) {
+      /* OK, now we have the guarantee alloc[i] won't be null. */
+      alloc[i]->release(to_release[i]);
     }
   }
 

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8198,12 +8198,17 @@ void BlueStore::_txc_finish(TransContext *txc)
 
 void BlueStore::_txc_release_alloc(TransContext *txc)
 {
-  // update allocator with full released set
+  interval_set<uint64_t> bulk_release_extents;
+  // it's expected we're called with lazy_release_lock already taken!
   if (!cct->_conf->bluestore_debug_no_reuse_blocks) {
     dout(10) << __func__ << " " << txc << " " << txc->released << dendl;
-    alloc->release(txc->released);
+    // interval_set seems to be too costly for inserting things in
+    // bstore_kv_final. We could serialize in simpler format and perform
+    // the merge separately, maybe even in a dedicated thread.
+    bulk_release_extents.insert(txc->released);
   }
 
+  alloc->release(bulk_release_extents);
   txc->allocated.clear();
   txc->released.clear();
 }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8201,11 +8201,7 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
   // update allocator with full released set
   if (!cct->_conf->bluestore_debug_no_reuse_blocks) {
     dout(10) << __func__ << " " << txc << " " << txc->released << dendl;
-    for (interval_set<uint64_t>::iterator p = txc->released.begin();
-	 p != txc->released.end();
-	 ++p) {
-      alloc->release(p.get_start(), p.get_len());
-    }
+    alloc->release(txc->released);
   }
 
   txc->allocated.clear();
@@ -8564,14 +8560,9 @@ void BlueStore::_kv_sync_thread()
 	if (!bluefs_gift_extents.empty()) {
 	  _commit_bluefs_freespace(bluefs_gift_extents);
 	}
-	for (auto p = bluefs_extents_reclaiming.begin();
-	     p != bluefs_extents_reclaiming.end();
-	     ++p) {
-	  dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
-		   << p.get_start() << "~" << p.get_len() << std::dec
-		   << dendl;
-	  alloc->release(p.get_start(), p.get_len());
-	}
+	dout(20) << __func__ << " releasing old bluefs 0x" << std::hex
+		 << bluefs_extents_reclaiming << std::dec << dendl;
+	alloc->release(bluefs_extents_reclaiming);
 	bluefs_extents_reclaiming.clear();
       }
 

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -251,6 +251,22 @@ void StupidAllocator::release(
   num_free += length;
 }
 
+void StupidAllocator::release(
+  const interval_set<uint64_t>& release_set)
+{
+  std::lock_guard<std::mutex> l(lock);
+  for (interval_set<uint64_t>::const_iterator p = release_set.begin();
+       p != release_set.end();
+       ++p) {
+    const auto offset = p.get_start();
+    const auto length = p.get_len();
+    ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
+		   << std::dec << dendl;
+    _insert_free(offset, length);
+    num_free += length;
+  }
+}
+
 uint64_t StupidAllocator::get_free()
 {
   std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -242,16 +242,6 @@ int64_t StupidAllocator::allocate(
 }
 
 void StupidAllocator::release(
-  uint64_t offset, uint64_t length)
-{
-  std::lock_guard<std::mutex> l(lock);
-  ldout(cct, 10) << __func__ << " 0x" << std::hex << offset << "~" << length
-	   	 << std::dec << dendl;
-  _insert_free(offset, length);
-  num_free += length;
-}
-
-void StupidAllocator::release(
   const interval_set<uint64_t>& release_set)
 {
   std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -48,6 +48,8 @@ public:
 
   void release(
     uint64_t offset, uint64_t length) override;
+  void release(
+    const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;
 

--- a/src/os/bluestore/StupidAllocator.h
+++ b/src/os/bluestore/StupidAllocator.h
@@ -47,8 +47,6 @@ public:
     uint64_t *offset, uint32_t *length);
 
   void release(
-    uint64_t offset, uint64_t length) override;
-  void release(
     const interval_set<uint64_t>& release_set) override;
 
   uint64_t get_free() override;


### PR DESCRIPTION
This PR is the version of #17490 without the *lazy* part.