### PR TITLE
rgw: dont reuse stale RGWObjectCtx for get_bucket_info()

### DIFF
--- a/src/rgw/rgw_bucket.cc
+++ b/src/rgw/rgw_bucket.cc
@@ -2127,8 +2127,9 @@ public:
 
     /* link bucket */
     if (be.linked) {
+      RGWObjectCtx ctx(store);
       RGWBucketInfo bucket_info;
-      ret = store->get_bucket_info(obj_ctx, tenant_name, bucket_name,
+      ret = store->get_bucket_info(ctx, tenant_name, bucket_name,
                                    bucket_info, nullptr, nullptr);
       if (ret < 0) {
         return ret;


### PR DESCRIPTION
if the earlier call to store->get_bucket_entrypoint_info() failed with
ENOENT, the obj_ctx will cache exists=false.
put_bucket_entrypoint_info() doesn't invalidate that, so this call to
get_bucket_info() was reading from a stale cache and failing with ENOENT

these failures were causing multisite's metadata sync to stall

Fixes: http://tracker.ceph.com/issues/21506