### PR TITLE
qa: ignore evicted client in client-recovery

### DIFF
--- a/qa/suites/kcephfs/recovery/tasks/client-recovery.yaml
+++ b/qa/suites/kcephfs/recovery/tasks/client-recovery.yaml
@@ -6,6 +6,7 @@ overrides:
     log-whitelist:
       - but it is still running
       - slow request
+      - evicting unresponsive client
 
 tasks:
   - cephfs_test_runner:


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21508

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>