### PR TITLE
rgw: pull up beast submodule and update frontend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,10 +538,6 @@ if(WITH_MGR)
 	list(APPEND BOOST_COMPONENTS python)
 endif()
 
-if(WITH_RADOSGW_BEAST_FRONTEND)
-	list(APPEND BOOST_COMPONENTS coroutine context)
-endif()
-
 set(Boost_USE_MULTITHREADED ON)
 # require minimally the bundled version
 if(WITH_SYSTEM_BOOST)

--- a/src/rgw/CMakeLists.txt
+++ b/src/rgw/CMakeLists.txt
@@ -174,11 +174,6 @@ endif (WITH_RADOSGW_BEAST_FRONTEND)
 add_library(radosgw_a STATIC ${radosgw_srcs}
   $<TARGET_OBJECTS:civetweb_common_objs>)
 target_link_libraries(radosgw_a rgw_a ${SSL_LIBRARIES})
-if(WITH_RADOSGW_BEAST_FRONTEND)
-  target_link_libraries(radosgw_a
-    Boost::coroutine
-    Boost::context)
-endif()
 
 add_executable(radosgw rgw_main.cc)
 target_link_libraries(radosgw radosgw_a librados

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -3,7 +3,6 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/asio/write.hpp>
-#include <beast/http/read.hpp>
 
 #include "rgw_asio_client.h"
 
@@ -17,7 +16,7 @@ using namespace rgw::asio;
 
 ClientIO::ClientIO(tcp::socket& socket,
                    parser_type& parser,
-                   beast::flat_streambuf& buffer)
+                   beast::flat_buffer& buffer)
   : socket(socket), parser(parser), buffer(buffer), txbuf(*this)
 {
 }
@@ -29,20 +28,21 @@ void ClientIO::init_env(CephContext *cct)
   env.init(cct);
 
   const auto& request = parser.get();
-  const auto& headers = request.fields;
+  const auto& headers = request;
   for (auto header = headers.begin(); header != headers.end(); ++header) {
-    const auto& name = header->name();
+    const auto& field = header->name(); // enum type for known headers
+    const auto& name = header->name_string();
     const auto& value = header->value();
 
-    if (boost::algorithm::iequals(name, "content-length")) {
+    if (field == beast::http::field::content_length) {
       env.set("CONTENT_LENGTH", value);
       continue;
     }
-    if (boost::algorithm::iequals(name, "content-type")) {
+    if (field == beast::http::field::content_type) {
       env.set("CONTENT_TYPE", value);
       continue;
     }
-    if (boost::algorithm::iequals(name, "connection")) {
+    if (field == beast::http::field::connection) {
       conn_keepalive = boost::algorithm::iequals(value, "keep-alive");
       conn_close = boost::algorithm::iequals(value, "close");
     }
@@ -63,15 +63,15 @@ void ClientIO::init_env(CephContext *cct)
     env.set(buf, value);
   }
 
-  int major = request.version / 10;
-  int minor = request.version % 10;
+  int major = request.version() / 10;
+  int minor = request.version() % 10;
   std::string http_version = std::to_string(major) + '.' + std::to_string(minor);
   env.set("HTTP_VERSION", http_version);
 
-  env.set("REQUEST_METHOD", request.method);
+  env.set("REQUEST_METHOD", request.method_string());
 
   // split uri from query
-  auto url = boost::string_ref{request.url};
+  auto url = request.target();
   auto pos = url.find('?');
   auto query = url.substr(pos + 1);
   url = url.substr(0, pos);
@@ -104,20 +104,20 @@ size_t ClientIO::write_data(const char* buf, size_t len)
 size_t ClientIO::read_data(char* buf, size_t max)
 {
   auto& message = parser.get();
-  auto& body_remaining = message.body;
-  body_remaining = boost::asio::mutable_buffer{buf, max};
-
-  boost::system::error_code ec;
+  auto& body_remaining = message.body();
+  body_remaining.data = buf;
+  body_remaining.size = max;
 
   dout(30) << this << " read_data for " << max << " with "
       << buffer.size() << " bytes buffered" << dendl;
 
-  while (boost::asio::buffer_size(body_remaining) && !parser.is_complete()) {
-    auto bytes = beast::http::read_some(socket, buffer, parser, ec);
-    buffer.consume(bytes);
+  while (body_remaining.size && !parser.is_done()) {
+    boost::system::error_code ec;
+    beast::http::read_some(socket, buffer, parser, ec);
     if (ec == boost::asio::error::connection_reset ||
         ec == boost::asio::error::eof ||
-        ec == beast::http::error::partial_message) {
+        ec == beast::http::error::partial_message ||
+        ec == beast::http::error::need_buffer) {
       break;
     }
     if (ec) {
@@ -125,7 +125,7 @@ size_t ClientIO::read_data(char* buf, size_t max)
       throw rgw::io::Exception(ec.value(), std::system_category());
     }
   }
-  return max - boost::asio::buffer_size(body_remaining);
+  return max - body_remaining.size;
 }
 
 size_t ClientIO::complete_request()

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -39,10 +39,6 @@ void ClientIO::init_env(CephContext *cct)
       env.set("CONTENT_TYPE", value);
       continue;
     }
-    if (field == beast::http::field::connection) {
-      conn_keepalive = boost::algorithm::iequals(value, "keep-alive");
-      conn_close = boost::algorithm::iequals(value, "close");
-    }
 
     static const boost::string_ref HTTP_{"HTTP_"};
 
@@ -175,10 +171,10 @@ size_t ClientIO::complete_header()
     sent += txbuf.sputn(timestr, strlen(timestr));
   }
 
-  if (conn_keepalive) {
+  if (parser.is_keep_alive()) {
     constexpr char CONN_KEEP_ALIVE[] = "Connection: Keep-Alive\r\n";
     sent += txbuf.sputn(CONN_KEEP_ALIVE, sizeof(CONN_KEEP_ALIVE) - 1);
-  } else if (conn_close) {
+  } else {
     constexpr char CONN_KEEP_CLOSE[] = "Connection: close\r\n";
     sent += txbuf.sputn(CONN_KEEP_CLOSE, sizeof(CONN_KEEP_CLOSE) - 1);
   }

--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -9,9 +9,6 @@
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
 
-#undef dout_prefix
-#define dout_prefix (*_dout << "asio: ")
-
 using namespace rgw::asio;
 
 ClientIO::ClientIO(tcp::socket& socket,
@@ -114,9 +111,7 @@ size_t ClientIO::read_data(char* buf, size_t max)
   while (body_remaining.size && !parser.is_done()) {
     boost::system::error_code ec;
     beast::http::read_some(socket, buffer, parser, ec);
-    if (ec == boost::asio::error::connection_reset ||
-        ec == boost::asio::error::eof ||
-        ec == beast::http::error::partial_message ||
+    if (ec == beast::http::error::partial_message ||
         ec == beast::http::error::need_buffer) {
       break;
     }

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -38,8 +38,6 @@ class ClientIO : public io::RestfulClient,
            beast::flat_buffer& buffer);
   ~ClientIO() override;
 
-  bool get_conn_close() const { return conn_close; }
-
   void init_env(CephContext *cct) override;
   size_t complete_request() override;
   void flush() override;

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -24,8 +24,6 @@ class ClientIO : public io::RestfulClient,
   parser_type& parser;
   beast::flat_buffer& buffer; //< parse buffer
 
-  bool conn_keepalive{false};
-  bool conn_close{false};
   RGWEnv env;
 
   rgw::io::StaticOutputBufferer<> txbuf;

--- a/src/rgw/rgw_asio_client.h
+++ b/src/rgw/rgw_asio_client.h
@@ -4,9 +4,8 @@
 #define RGW_ASIO_CLIENT_H
 
 #include <boost/asio/ip/tcp.hpp>
-#include <beast/http/message.hpp>
-#include <beast/http/message_parser.hpp>
-#include <beast/core/flat_streambuf.hpp>
+#include <boost/beast/core.hpp>
+#include <boost/beast/http.hpp>
 #include "include/assert.h"
 
 #include "rgw_client_io.h"
@@ -14,40 +13,8 @@
 namespace rgw {
 namespace asio {
 
-/// streaming message body interface
-struct streaming_body {
-  using value_type = boost::asio::mutable_buffer;
-
-  class reader {
-    value_type& buffer;
-   public:
-    using mutable_buffers_type = boost::asio::mutable_buffers_1;
-
-    static const bool is_direct{true}; // reads directly into user buffer
-
-    template<bool isRequest, class Fields>
-    explicit reader(beast::http::message<isRequest, streaming_body, Fields>& m)
-      : buffer(m.body)
-    {}
-
-    void init() {}
-    void init(uint64_t content_length) {}
-    void finish() {}
-
-    mutable_buffers_type prepare(size_t n) {
-      n = std::min(n, boost::asio::buffer_size(buffer));
-      auto position = boost::asio::buffer_cast<char*>(buffer);
-      return {position, n};
-    }
-
-    void commit(size_t n) {
-      buffer = buffer + n;
-    }
-  };
-};
-
-using header_type = beast::http::fields;
-using parser_type = beast::http::message_parser<true, streaming_body, header_type>;
+namespace beast = boost::beast;
+using parser_type = beast::http::request_parser<beast::http::buffer_body>;
 
 class ClientIO : public io::RestfulClient,
                  public io::BuffererSink {
@@ -55,7 +22,7 @@ class ClientIO : public io::RestfulClient,
   using tcp = boost::asio::ip::tcp;
   tcp::socket& socket;
   parser_type& parser;
-  beast::flat_streambuf& buffer; //< parse buffer
+  beast::flat_buffer& buffer; //< parse buffer
 
   bool conn_keepalive{false};
   bool conn_close{false};
@@ -68,7 +35,7 @@ class ClientIO : public io::RestfulClient,
 
  public:
   ClientIO(tcp::socket& socket, parser_type& parser,
-           beast::flat_streambuf& buffer);
+           beast::flat_buffer& buffer);
   ~ClientIO() override;
 
   bool get_conn_close() const { return conn_close; }

--- a/src/rgw/rgw_asio_frontend.cc
+++ b/src/rgw/rgw_asio_frontend.cc
@@ -1,21 +1,18 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <atomic>
 #include <condition_variable>
 #include <mutex>
 #include <thread>
 #include <vector>
 
 #include <boost/asio.hpp>
-#include <boost/asio/spawn.hpp>
 
 #include "rgw_asio_client.h"
 #include "rgw_asio_frontend.h"
 
 #define dout_subsys ceph_subsys_rgw
-
-//#undef dout_prefix
-//#define dout_prefix (*_dout << "asio: ")
 
 namespace {
 
@@ -65,67 +62,102 @@ void Pauser::wait()
 using tcp = boost::asio::ip::tcp;
 namespace beast = boost::beast;
 
-// coroutine to handle a client connection to completion
-static void handle_connection(RGWProcessEnv& env, tcp::socket socket,
-                              boost::asio::yield_context yield)
-{
-  auto cct = env.store->ctx();
-  boost::system::error_code ec;
+class Connection {
+  RGWProcessEnv& env;
+  boost::asio::strand strand;
+  tcp::socket socket;
 
-  // limit header to 4k, since we read it all into a single buffer
-  constexpr size_t header_limit = 4096;
+  // references are bound to callbacks for async operations. if a callback
+  // function returns without issuing another operation, the reference is
+  // dropped and the Connection is deleted/closed
+  std::atomic<int> nref{0};
+  using Ref = boost::intrusive_ptr<Connection>;
+
+  // limit header to 4k, since we read it all into a single flat_buffer
+  static constexpr size_t header_limit = 4096;
   // don't impose a limit on the body, since we read it in pieces
-  constexpr size_t body_limit = std::numeric_limits<size_t>::max();
+  static constexpr size_t body_limit = std::numeric_limits<size_t>::max();
 
   beast::flat_buffer buffer;
+  boost::optional<rgw::asio::parser_type> parser;
 
-  // read messages from the socket until eof
-  for (;;) {
+  using bad_response_type = beast::http::response<beast::http::empty_body>;
+  boost::optional<bad_response_type> response;
+
+  CephContext* ctx() const { return env.store->ctx(); }
+
+  void read_header() {
     // configure the parser
-    rgw::asio::parser_type parser;
-    parser.header_limit(header_limit);
-    parser.body_limit(body_limit);
+    parser.emplace();
+    parser->header_limit(header_limit);
+    parser->body_limit(body_limit);
 
     // parse the header
-    beast::http::async_read_header(socket, buffer, parser, yield[ec]);
+    beast::http::async_read_header(socket, buffer, *parser, strand.wrap(
+            std::bind(&Connection::on_header, Ref{this},
+                      std::placeholders::_1)));
+  }
 
+  void on_write_error(boost::system::error_code ec) {
+    if (ec) {
+      ldout(ctx(), 5) << "failed to write response: " << ec.message() << dendl;
+    }
+  }
+
+  void on_header(boost::system::error_code ec) {
     if (ec == boost::asio::error::connection_reset ||
-        ec == boost::asio::error::eof) {
+        ec == beast::http::error::end_of_stream) {
       return;
     }
     if (ec) {
-      auto& message = parser.get();
-      ldout(cct, 1) << "read failed: " << ec.message() << dendl;
-      ldout(cct, 1) << "====== req done http_status=400 ======" << dendl;
-      beast::http::response<beast::http::string_body> response;
-      response.result(beast::http::status::bad_request);
-      response.reason("Bad Request");
-      response.version(message.version() == 10 ? 10 : 11);
-      response.prepare_payload();
-      beast::http::async_write(socket, response, yield[ec]);
-      // ignore ec
+      auto& message = parser->get();
+      ldout(ctx(), 1) << "failed to read header: " << ec.message() << dendl;
+      ldout(ctx(), 1) << "====== req done http_status=400 ======" << dendl;
+      response.emplace();
+      response->result(beast::http::status::bad_request);
+      response->version(message.version() == 10 ? 10 : 11);
+      response->prepare_payload();
+      beast::http::async_write(socket, *response, strand.wrap(
+            std::bind(&Connection::on_write_error, Ref{this},
+                      std::placeholders::_1)));
       return;
     }
 
     // process the request
     RGWRequest req{env.store->get_new_req_id()};
 
-    rgw::asio::ClientIO real_client{socket, parser, buffer};
+    rgw::asio::ClientIO real_client{socket, *parser, buffer};
 
     auto real_client_io = rgw::io::add_reordering(
-                            rgw::io::add_buffering(cct,
+                            rgw::io::add_buffering(ctx(),
                               rgw::io::add_chunking(
                                 rgw::io::add_conlen_controlling(
                                   &real_client))));
-    RGWRestfulIO client(cct, &real_client_io);
+    RGWRestfulIO client(ctx(), &real_client_io);
     process_request(env.store, env.rest, &req, env.uri_prefix,
                     *env.auth_registry, &client, env.olog);
 
-    if (real_client.get_conn_close()) {
-      return;
+    if (!real_client.get_conn_close()) {
+      // read next header
+      read_header();
     }
   }
-}
+
+ public:
+  Connection(RGWProcessEnv& env, tcp::socket&& socket)
+    : env(env), strand(socket.get_io_service()), socket(std::move(socket)) {}
+
+  void on_connect() {
+    read_header();
+  }
+
+  void get() { ++nref; }
+  void put() { if (nref.fetch_sub(1) == 1) { delete this; } }
+
+  friend void intrusive_ptr_add_ref(Connection *c) { c->get(); }
+  friend void intrusive_ptr_release(Connection *c) { c->put(); }
+};
+
 
 class AsioFrontend {
   RGWProcessEnv env;
@@ -190,15 +222,14 @@ void AsioFrontend::accept(boost::system::error_code ec)
     throw ec;
   }
   auto socket = std::move(peer_socket);
-  // spawn a coroutine to handle the connection
-  boost::asio::spawn(service,
-                     [&] (boost::asio::yield_context yield) {
-                       handle_connection(env, std::move(socket), yield);
-                     });
   acceptor.async_accept(peer_socket,
                         [this] (boost::system::error_code ec) {
                           return accept(ec);
                         });
+
+  boost::intrusive_ptr<Connection> conn{new Connection(env, std::move(socket))};
+  conn->on_connect();
+  // reference drops here, but on_connect() takes another
 }
 
 int AsioFrontend::run()

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -19,7 +19,7 @@ void RGWEnv::init(CephContext *cct)
 
 void RGWEnv::set(const boost::string_ref& name, const boost::string_ref& val)
 {
-  env_map[std::string{name}] = std::string{val};
+  env_map[name.to_string()] = val.to_string();
 }
 
 void RGWEnv::init(CephContext *cct, char **envp)


### PR DESCRIPTION
updates the Beast submodule to point at v116, which is the current master branch of https://github.com/boostorg/beast. our fork at https://github.com/ceph/beast/ has been updated to match

after updating the beast frontend, swift and s3tests are still passing