### PR TITLE
mon/mgr: sync "mgr_command_descs","osd_metadata" and "mgr_metadata" prefixes to new mons

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -54,6 +54,13 @@ void MgrMonitor::create_initial()
 	   << dendl;
 }
 
+void MgrMonitor::get_store_prefixes(std::set<string>& s) const
+{
+  s.insert(service_name);
+  s.insert(command_descs_prefix);
+  s.insert(MGR_METADATA_PREFIX);
+}
+
 void MgrMonitor::update_from_paxos(bool *need_bootstrap)
 {
   version_t version = get_last_committed();

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -79,6 +79,7 @@ public:
   bool in_use() const { return map.epoch > 0; }
 
   void create_initial() override;
+  void get_store_prefixes(std::set<string>& s) const override;
   void update_from_paxos(bool *need_bootstrap) override;
   void create_pending() override;
   void encode_pending(MonitorDBStore::TransactionRef t) override;

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -268,6 +268,7 @@ void OSDMonitor::get_store_prefixes(std::set<string>& s) const
 {
   s.insert(service_name);
   s.insert(OSD_PG_CREATING_PREFIX);
+  s.insert(OSD_METADATA_PREFIX);
 }
 
 void OSDMonitor::update_from_paxos(bool *need_bootstrap)


### PR DESCRIPTION
"mgr_command_descs","osd_metadata" and "mgr_metadata" tables can not be achieved between multiple mon synchronization, so need add to get_store_prefixes()  to achieve synchronization.

Fixes: http://tracker.ceph.com/issues/21527

Signed-off-by: huanwen ren <ren.huanwen@zte.com.cn>