### PR TITLE
rgw:fix list objects with marker wrong result  when bucket is enable versioning

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -445,8 +445,9 @@ int rgw_bucket_list(cls_method_context_t hctx, bufferlist *in, bufferlist *out)
         CLS_LOG(20, "entry %s[%s] is not valid\n", key.name.c_str(), key.instance.c_str());
         continue;
       }
-
-      if (!op.list_versions && !entry.is_visible()) {
+      
+      // filter out noncurrent versions, delete markers, and initial marker
+      if (!op.list_versions && (!entry.is_visible() || op.start_obj.name == key.name)) {
         CLS_LOG(20, "entry %s[%s] is not visible\n", key.name.c_str(), key.instance.c_str());
         continue;
       }


### PR DESCRIPTION
hi,
   when enable bucket versioning and upload 1.jpg 2.jpg 3.jpg to the empty bucket and then list bucket with marker 2.jpg,the return result will contain 2.jpg, as follows:
```
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
<Name>versionmarker2</Name>
<Prefix/>
<Marker>2.jpg</Marker>
<MaxKeys>1000</MaxKeys>
<IsTruncated>false</IsTruncated>
<Contents>
<Key>2.jpg</Key>
<LastModified>2017-09-21T10:12:15.639Z</LastModified>
<ETag>"690a12ad1736d2eb0b01b545bb6db887"</ETag>
<Size>143126</Size>
<StorageClass>STANDARD</StorageClass>
<Owner>
<ID>b44859444312440f8caa39cfc887de81</ID>
<DisplayName>baomihua02</DisplayName>
</Owner>
</Contents>
<Contents>
<Key>3.jpg</Key>
<LastModified>2017-09-21T10:12:24.144Z</LastModified>
<ETag>"690a12ad1736d2eb0b01b545bb6db887"</ETag>
<Size>143126</Size>
<StorageClass>STANDARD</StorageClass>
<Owner>
<ID>b44859444312440f8caa39cfc887de81</ID>
<DisplayName>baomihua02</DisplayName>
</Owner>
</Contents>
</ListBucketResult>
```
but in amazon s3
it return

```
<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
<Name>versionmarker</Name>
<Prefix/>
<Marker>2.jpg</Marker>
<MaxKeys>1000</MaxKeys>
<IsTruncated>false</IsTruncated>
<Contents>
<Key>3.jpg</Key>
<LastModified>2017-09-21T10:01:19.000Z</LastModified>
<ETag>"690a12ad1736d2eb0b01b545bb6db887"</ETag>
<Size>143126</Size>
<Owner>
<ID>d8c826aaaa5812a67e0b5ad7a7cc8e03f91e2917d9ae0418c8b2532383745e3c</ID>
<DisplayName>cmsscloud</DisplayName>
</Owner>
<StorageClass>STANDARD</StorageClass>
</Contents>
</ListBucketResult>
```

i found this is because when then marker is set 2.jpg, while the versioned object 2.jpgkS2nQv9yOlFQZCTgTvDoR0XtHAg6pDd is  included, so when marker is set , we should compare start.name and dirent.key.name,and not included it when start.name == dirent.key.name

fix: http://tracker.ceph.com/issues/21500
Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>