### PR TITLE
ceph_volume_client: fix setting caps for IDs

### DIFF
--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -1065,6 +1065,9 @@ class CephFSVolumeClient(object):
                 # occurrence of wanted auth caps and no occurrence of
                 # conflicting auth caps.
 
+                if not orig:
+                    return want
+
                 cap_tokens = set(orig.split(","))
 
                 cap_tokens.discard(unwanted)


### PR DESCRIPTION
... that have empty OSD and MDS caps. Don't add a ',' at the
start of OSD and MDS caps.

Fixes: http://tracker.ceph.com/issues/21501
Signed-off-by: Ramana Raja <rraja@redhat.com>