### PR TITLE
jewel: ceph-disk: fix --runtime omission when enabling ceph-osd@$ID.service units for device-backed OSDs

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2972,7 +2972,7 @@ def systemd_start(
     osd_id,
 ):
     systemd_disable(path, osd_id)
-    if is_mounted(path):
+    if os.path.ismount(path):
         style = ['--runtime']
     else:
         style = []


### PR DESCRIPTION
http://tracker.ceph.com/issues/21522