### PR TITLE
osd/OSDMap: upmap should respect the osd reweights

### DIFF
--- a/src/osd/OSDMap.cc
+++ b/src/osd/OSDMap.cc
@@ -3835,8 +3835,9 @@ int OSDMap::calc_pg_upmaps(
       tmp.crush->get_rule_weight_osd_map(ruleno, &pmap);
       ldout(cct,30) << __func__ << " pool " << i.first << " ruleno " << ruleno << dendl;
       for (auto p : pmap) {
-	osd_weight[p.first] += p.second;
-	osd_weight_total += p.second;
+	auto adjusted_weight = tmp.get_weightf(p.first) * p.second;
+	osd_weight[p.first] += adjusted_weight;
+	osd_weight_total += adjusted_weight;
       }
     }
     for (auto& i : osd_weight) {

--- a/src/test/cli/osdmaptool/help.t
+++ b/src/test/cli/osdmaptool/help.t
@@ -8,6 +8,7 @@
      --test-map-pgs-dump-all [--pool <poolid>] map all pgs to osds
      --health                dump health checks
      --mark-up-in            mark osds up and in (but do not persist)
+     --mark-out <osdid>      mark an osd as out (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp
      --test-random           do random placements

--- a/src/test/cli/osdmaptool/missing-argument.t
+++ b/src/test/cli/osdmaptool/missing-argument.t
@@ -8,6 +8,7 @@
      --test-map-pgs-dump-all [--pool <poolid>] map all pgs to osds
      --health                dump health checks
      --mark-up-in            mark osds up and in (but do not persist)
+     --mark-out <osdid>      mark an osd as out (but do not persist)
      --with-default-pool     include default pool when creating map
      --clear-temp            clear pg_temp and primary_temp
      --test-random           do random placements

--- a/src/test/cli/osdmaptool/upmap-out.t
+++ b/src/test/cli/osdmaptool/upmap-out.t
@@ -1,0 +1,23 @@
+  $ osdmaptool --create-from-conf om -c $TESTDIR/ceph.conf.withracks --with-default-pool
+  osdmaptool: osdmap file 'om'
+  osdmaptool: writing epoch 1 to om
+  $ osdmaptool om --mark-up-in --mark-out 147 --upmap-max 11 --upmap c
+  osdmaptool: osdmap file 'om'
+  marking all OSDs up and in
+  marking OSD@147 as out
+  writing upmap command output to: c
+  checking for upmap cleanups
+  upmap, max-count 11, max deviation 0.01
+  $ cat c
+  ceph osd pg-upmap-items 1.7 142 145
+  ceph osd pg-upmap-items 1.8 219 223 99 103
+  ceph osd pg-upmap-items 1.17 171 173 201 202
+  ceph osd pg-upmap-items 1.1a 201 202 115 114
+  ceph osd pg-upmap-items 1.1c 171 173 201 202 127 130
+  ceph osd pg-upmap-items 1.20 88 87 201 202
+  ceph osd pg-upmap-items 1.21 207 206 142 145
+  ceph osd pg-upmap-items 1.51 201 202 65 64 186 189
+  ceph osd pg-upmap-items 1.62 219 223
+  ceph osd pg-upmap-items 1.6f 219 223 108 111
+  ceph osd pg-upmap-items 1.82 219 223 157 158 6 3
+  $ rm -f om c


### PR DESCRIPTION
upmap currently ignores reweighted osds. In other words, out osds, or those with some fractional reweight, get items upmapped to them, which is counter productive when trying to balance OSDs.
In particular, out OSDs will continually get PGs upmapped to them since they have 0 PGs by design.

To demonstrate we added a --mark-out option to osdmaptool, add a new upmap-out test, and fix the problem in OSDMap::calc_pg_upmaps.