### PR TITLE
do_{cmake,freebsd}: Don't invoke nproc(1) on FreeBSD

### DIFF
--- a/do_cmake.sh
+++ b/do_cmake.sh
@@ -13,7 +13,8 @@ fi
 
 mkdir build
 cd build
-cmake -DBOOST_J=$(nproc) $ARGS "$@" ..
+NPROC=${NPROC:-$(nproc)}
+cmake -DBOOST_J=$NPROC $ARGS "$@" ..
 
 # minimal config to find plugins
 cat <<EOF > ceph.conf

--- a/do_freebsd.sh
+++ b/do_freebsd.sh
@@ -1,14 +1,6 @@
 #!/bin/sh -xve
-NPROC=`sysctl -n hw.ncpu`
+export NPROC=`sysctl -n hw.ncpu`
 
-# we need bash first otherwise almost nothing will work
-if [ ! -L /bin/bash ]; then
-    echo install bash and link /bin/bash to /usr/local/bin/bash
-    echo Run:
-    echo     sudo pkg install bash
-    echo     ln -s /usr/local/bin/bash /bin/bash
-    exit 1
-fi
 if [ x"$1"x = x"--deps"x ]; then
     sudo ./install-deps.sh
 fi


### PR DESCRIPTION
Use sysctl(8) instead.  Also, there's no longer any need for /bin/bash
on FreeBSD