### PR TITLE
DNM osd: Remove unnecessary sdata_lock

### DIFF
--- a/src/common/Cond.h
+++ b/src/common/Cond.h
@@ -91,25 +91,25 @@ class Cond {
     int r = pthread_cond_broadcast(&_c);
     return r;
   }
-  int Signal() { 
+  int Signal(bool nolock = false) {
     // make sure signaler is holding the waiter's lock.
-    assert(waiter_mutex == NULL ||
+    assert(nolock || waiter_mutex == NULL ||
 	   waiter_mutex->is_locked());
 
     int r = pthread_cond_broadcast(&_c);
     return r;
   }
-  int SignalOne() { 
+  int SignalOne(bool nolock = false) {
     // make sure signaler is holding the waiter's lock.
-    assert(waiter_mutex == NULL ||
+    assert(nolock || waiter_mutex == NULL ||
 	   waiter_mutex->is_locked());
 
     int r = pthread_cond_signal(&_c);
     return r;
   }
-  int SignalAll() { 
+  int SignalAll(bool nolock = false) {
     // make sure signaler is holding the waiter's lock.
-    assert(waiter_mutex == NULL ||
+    assert(nolock || waiter_mutex == NULL ||
 	   waiter_mutex->is_locked());
 
     int r = pthread_cond_broadcast(&_c);

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1625,7 +1625,6 @@ private:
     : public ShardedThreadPool::ShardedWQ<OpQueueItem>
   {
     struct ShardData {
-      Mutex sdata_lock;
       Cond sdata_cond;
 
       Mutex sdata_op_ordering_lock;   ///< protects all members below
@@ -1669,11 +1668,10 @@ private:
       }
 
       ShardData(
-	string lock_name, string ordering_lock,
+	string ordering_lock,
 	uint64_t max_tok_per_prio, uint64_t min_cost, CephContext *cct,
 	io_queue opqueue)
-	: sdata_lock(lock_name.c_str(), false, true, false, cct),
-	  sdata_op_ordering_lock(ordering_lock.c_str(), false, true,
+	  : sdata_op_ordering_lock(ordering_lock.c_str(), false, true,
 				 false, cct) {
 	if (opqueue == io_queue::weightedpriority) {
 	  pqueue = std::make_unique<
@@ -1705,13 +1703,11 @@ private:
         osd(o),
         num_shards(pnum_shards) {
       for (uint32_t i = 0; i < num_shards; i++) {
-	char lock_name[32] = {0};
-	snprintf(lock_name, sizeof(lock_name), "%s.%d", "OSD:ShardedOpWQ:", i);
 	char order_lock[32] = {0};
 	snprintf(order_lock, sizeof(order_lock), "%s.%d",
 		 "OSD:ShardedOpWQ:order:", i);
 	ShardData* one_shard = new ShardData(
-	  lock_name, order_lock,
+	  order_lock,
 	  osd->cct->_conf->osd_op_pq_max_tokens_per_priority, 
 	  osd->cct->_conf->osd_op_pq_min_cost, osd->cct, osd->op_queue);
 	shard_list.push_back(one_shard);
@@ -1749,10 +1745,10 @@ private:
       for(uint32_t i = 0; i < num_shards; i++) {
 	ShardData* sdata = shard_list[i];
 	assert (NULL != sdata); 
-	sdata->sdata_lock.Lock();
+	sdata->sdata_op_ordering_lock.Lock();
 	sdata->stop_waiting = true;
-	sdata->sdata_cond.Signal();
-	sdata->sdata_lock.Unlock();
+	sdata->sdata_op_ordering_lock.Unlock();
+	sdata->sdata_cond.Signal(true);
       }
     }
 
@@ -1760,9 +1756,9 @@ private:
       for(uint32_t i = 0; i < num_shards; i++) {
 	ShardData* sdata = shard_list[i];
 	assert (NULL != sdata);
-	sdata->sdata_lock.Lock();
+	sdata->sdata_op_ordering_lock.Lock();
 	sdata->stop_waiting = false;
-	sdata->sdata_lock.Unlock();
+	sdata->sdata_op_ordering_lock.Unlock();
       }
     }
 


### PR DESCRIPTION
Although it isn't normally recommended, you don't need to hold the condition
variable lock when signalling.
