### PR TITLE
luminous: tests: ceph_manager: bad AssertionError: failed to recover before timeout expired

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -2217,6 +2217,8 @@ class CephManager:
                 else:
                     self.log("no progress seen, keeping timeout for now")
                     if now - start >= timeout:
+			if self.is_recovered():
+			    break
                         self.log('dumping pgs')
                         out = self.raw_cluster_cmd('pg', 'dump')
                         self.log(out)


### PR DESCRIPTION
http://tracker.ceph.com/issues/21548