### PR TITLE
[DNM] jewel: mon: implement max pg per osd limit

### DIFF
--- a/PendingReleaseNotes
+++ b/PendingReleaseNotes
@@ -1,3 +1,4 @@
+
 * The 'mon_warn_osd_usage_min_max_delta' health warning has been disabled because
   it does not address clusters undergoing recovery or CRUSH rules that do
   not target all devices in the cluster.
@@ -15,3 +16,14 @@
 * The RBD C API's rbd_discard method and the C++ API's Image::discard method
   now enforce a maximum length of 2GB. This restriction prevents overflow of
   the result code.
+
+* The maximum number of PGs per OSD before the monitor issues a
+  warning has been reduced from 300 to 200 PGs.  200 is still twice
+  the generally recommended target of 100 PGs per OSD.  This limit can
+  be adjusted via the ``mon_pg_warn_max_per_osd`` option on the
+  monitors.
+
+* Creating pools or adjusting pg_num will now fail if the change would
+  make the number of PGs per OSD exceed the configured
+  ``mon_pg_warn_max_per_osd`` limit.  The option can be adjusted if it
+  is really necessary to create a pool with more PGs.

--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -255,7 +255,7 @@ OPTION(mon_pg_create_interval, OPT_FLOAT, 30.0) // no more than every 30s
 OPTION(mon_pg_stuck_threshold, OPT_INT, 300) // number of seconds after which pgs can be considered inactive, unclean, or stale (see doc/control.rst under dump_stuck for more info)
 OPTION(mon_pg_min_inactive, OPT_U64, 1) // the number of PGs which have to be inactive longer than 'mon_pg_stuck_threshold' before health goes into ERR. 0 means disabled, never go into ERR.
 OPTION(mon_pg_warn_min_per_osd, OPT_INT, 30)  // min # pgs per (in) osd before we warn the admin
-OPTION(mon_pg_warn_max_per_osd, OPT_INT, 300)  // max # pgs per (in) osd before we warn the admin
+OPTION(mon_pg_warn_max_per_osd, OPT_INT, 200)  // max # pgs per (in) osd before we warn the admin
 OPTION(mon_pg_warn_max_object_skew, OPT_FLOAT, 10.0) // max skew few average in objects per pg
 OPTION(mon_pg_warn_min_objects, OPT_INT, 10000)  // do not warn below this object #
 OPTION(mon_pg_warn_min_pool_objects, OPT_INT, 1000)  // do not warn on pools below this object #

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4781,6 +4781,35 @@ int OSDMonitor::get_crush_ruleset(const string &ruleset_name,
   return 0;
 }
 
+int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
+{
+  int64_t max_pgs_per_osd = g_conf->mon_pg_warn_max_per_osd;
+  int64_t max_pgs = max_pgs_per_osd * osdmap.get_num_in_osds();
+  int64_t projected = 0;
+  if (pool < 0) {
+    projected += pg_num * size;
+  }
+  for (const auto& i : osdmap.get_pools()) {
+    if (i.first == pool) {
+      projected += pg_num * size;
+    } else {
+      projected += i.second.get_pg_num() * i.second.get_size();
+    }
+  }
+  if (projected > max_pgs) {
+    if (pool >= 0) {
+      *ss << "pool id " << pool;
+    }
+    *ss << " pg_num " << pg_num << " size " << size
+	<< " would mean " << projected
+	<< " total pgs, which exceeds max " << max_pgs
+	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
+	<< " * num_in_osds " << osdmap.get_num_in_osds() << ")";
+    return -ERANGE;
+  }
+  return 0;
+}
+
 /**
  * @param name The name of the new pool
  * @param auid The auid of the pool owner. Can be -1
@@ -4850,6 +4879,11 @@ int OSDMonitor::prepare_new_pool(string& name, uint64_t auid,
   }
   unsigned size, min_size;
   r = prepare_pool_size(pool_type, erasure_code_profile, &size, &min_size, ss);
+  if (r) {
+    dout(10) << " prepare_pool_size returns " << r << dendl;
+    return r;
+  }
+  r = check_pg_num(-1, pg_num, size, ss);
   if (r) {
     dout(10) << " prepare_pool_size returns " << r << dendl;
     return r;
@@ -5078,6 +5112,10 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
       ss << "pool size must be between 1 and 10";
       return -EINVAL;
     }
+    int r = check_pg_num(pool, p.get_pg_num(), n, &ss);
+    if (r < 0) {
+      return r;
+    }
     p.size = n;
     if (n < p.min_size)
       p.min_size = n;
@@ -5146,6 +5184,10 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
          << g_conf->mon_max_pool_pg_num
          << " (you may adjust 'mon max pool pg num' for higher values)";
       return -ERANGE;
+    }
+    int r = check_pg_num(pool, n, p.get_size(), &ss);
+    if (r) {
+      return r;
     }
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5141,6 +5141,12 @@ int OSDMonitor::prepare_command_pool_set(map<string,cmd_vartype> &cmdmap,
 	return -EEXIST;
       return 0;
     }
+    if (n > (unsigned)g_conf->mon_max_pool_pg_num) {
+      ss << "'pg_num' must be greater than 0 and less than or equal to "
+         << g_conf->mon_max_pool_pg_num
+         << " (you may adjust 'mon max pool pg num' for higher values)";
+      return -ERANGE;
+    }
     string force;
     cmd_getval(g_ceph_context,cmdmap, "force", force);
     if (p.cache_mode != pg_pool_t::CACHEMODE_NONE &&

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -4784,7 +4784,8 @@ int OSDMonitor::get_crush_ruleset(const string &ruleset_name,
 int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 {
   int64_t max_pgs_per_osd = g_conf->mon_pg_warn_max_per_osd;
-  int64_t max_pgs = max_pgs_per_osd * osdmap.get_num_in_osds();
+  int num_osds = MAX(osdmap.get_num_in_osds(), 3);   // assume min cluster size 3
+  int64_t max_pgs = max_pgs_per_osd * num_osds;
   int64_t projected = 0;
   if (pool < 0) {
     projected += pg_num * size;
@@ -4804,7 +4805,7 @@ int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 	<< " would mean " << projected
 	<< " total pgs, which exceeds max " << max_pgs
 	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
-	<< " * num_in_osds " << osdmap.get_num_in_osds() << ")";
+	<< " * num_in_osds " << num_osds << ")";
     return -ERANGE;
   }
   return 0;

--- a/src/mon/OSDMonitor.h
+++ b/src/mon/OSDMonitor.h
@@ -315,6 +315,7 @@ private:
 				const string &erasure_code_profile,
 				unsigned *stripe_width,
 				ostream *ss);
+  int check_pg_num(int64_t pool, int pg_num, int size, ostream* ss);
   int prepare_new_pool(string& name, uint64_t auid,
 		       int crush_ruleset,
 		       const string &crush_ruleset_name,

--- a/src/test/mon/osd-pool-create.sh
+++ b/src/test/mon/osd-pool-create.sh
@@ -276,7 +276,7 @@ function TEST_utf8_cli() {
     # the fix for http://tracker.ceph.com/issues/7387.  If it turns out
     # to not be OK (when is the default encoding *not* UTF-8?), maybe
     # the character '黄' can be replaced with the escape $'\xe9\xbb\x84'
-    ceph osd pool create 黄 1024 2>&1 | \
+    ceph osd pool create 黄 16 2>&1 | \
         grep "pool '黄' created" || return 1
     ceph osd lspools 2>&1 | \
         grep "黄" || return 1


### PR DESCRIPTION
This mirrors the master commits, except that we do not rename the config option
mon_pg_warn_max_per_osd -> monmax_pg_per_osd like we do in luminous; I think it's
better to leave the option rename to the luminous upgrade than to a jewel point
release upgrade.  We do enforce the limit, however--the option name is just somewhat
misleading.