### PR TITLE
osd/PrimaryLogPG: handle block_for_clean ops more carefully

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7000,6 +7000,7 @@ PG::RecoveryState::Clean::Clean(my_context ctx)
 
   pg->share_pg_info();
   pg->publish_stats_to_osd();
+  pg->objects_blocked_clean_to_primary_repair.clear();
   pg->requeue_ops(pg->waiting_for_clean_to_primary_repair);
 }
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1192,6 +1192,7 @@ protected:
 			     waiting_for_blocked_object;
 
   set<hobject_t> objects_blocked_on_cache_full;
+  set<hobject_t> objects_blocked_clean_to_primary_repair;
   map<hobject_t,snapid_t> objects_blocked_on_degraded_snap;
   map<hobject_t,ObjectContextRef> objects_blocked_on_snap_promotion;
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -641,6 +641,7 @@ void PrimaryLogPG::block_for_clean(
 {
   dout(20) << __func__ << ": blocking object " << oid
 	   << " on primary repair" << dendl;
+  objects_blocked_clean_to_primary_repair.insert(oid);
   waiting_for_clean_to_primary_repair.push_back(op);
   op->mark_delayed("waiting for clean to repair");
 }
@@ -1989,6 +1990,12 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
 	   << " flags " << ceph_osd_flag_string(m->get_flags())
 	   << dendl;
 
+  // object currently blocked clean for repairing?
+  if (objects_blocked_clean_to_primary_repair.count(head)) {
+    block_for_clean(head, op);
+    return;
+  }
+
   // missing object?
   if (is_unreadable_object(head)) {
     if (!is_primary()) {
@@ -2134,6 +2141,13 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
       return;
     }
   } else if (r == 0) {
+    if (objects_blocked_clean_to_primary_repair.count(obc->obs.oi.soid)) {
+      dout(10) << __func__ << ": clone " << obc->obs.oi.soid
+	       << " is blocked waiting clean for primary repairing" << dendl;
+      block_for_clean(obc->obs.oi.soid, op);
+      return;
+    }
+
     if (is_unreadable_object(obc->obs.oi.soid)) {
       dout(10) << __func__ << ": clone " << obc->obs.oi.soid
 	       << " is unreadable, waiting" << dendl;
@@ -10847,6 +10861,13 @@ void PrimaryLogPG::on_change(ObjectStore::Transaction *t)
   cancel_copy_ops(is_primary());
   cancel_flush_ops(is_primary());
   cancel_proxy_ops(is_primary());
+
+  if (is_primary()) {
+    requeue_ops(waiting_for_clean_to_primary_repair);
+  } else {
+    waiting_for_clean_to_primary_repair.clear();
+  }
+  objects_blocked_clean_to_primary_repair.clear();
 
   // requeue object waiters
   for (auto& p : waiting_for_unreadable_object) {


### PR DESCRIPTION
    osd/PrimaryLogPG: handle block_for_clean ops more carefully
    
    1. they are read ops, thus any follow-up ops reading the same object
       shall be blocked until they are finished.
    2. clean up or requeue these ops on interval change, otherwise they
       are potentially left hanging.
    
    Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>