### PR TITLE
scripts: fix bash path in shebangs (part 2)

### DIFF
--- a/bin/git-archive-all.sh
+++ b/bin/git-archive-all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -
+#!/usr/bin/env bash
 #
 # File:        git-archive-all.sh
 #

--- a/qa/standalone/scrub/osd-recovery-scrub.sh
+++ b/qa/standalone/scrub/osd-recovery-scrub.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # Copyright (C) 2017 Red Hat <contact@redhat.com>
 #

--- a/src/test/osd/safe-to-destroy.sh
+++ b/src/test/osd/safe-to-destroy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 

--- a/src/test/rbd-ggate.sh
+++ b/src/test/rbd-ggate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/usr/bin/env bash
 #
 # Copyright (C) 2014, 2015 Red Hat <contact@redhat.com>
 # Copyright (C) 2013 Cloudwatt <libre.licensing@cloudwatt.com>
@@ -15,6 +15,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # GNU Library Public License for more details.
 #
+set -ex
 source $(dirname $0)/detect-build-env-vars.sh
 
 test `uname` = FreeBSD

--- a/src/test/smoke.sh
+++ b/src/test/smoke.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $CEPH_ROOT/qa/standalone/ceph-helpers.sh
 


### PR DESCRIPTION
/bin/bash is a Linuxism.  Other operating systems install bash to
different paths.  Use /usr/bin/env in shebangs to find bash.

Signed-off-by: Alan Somers <asomers@gmail.com>