### PR TITLE
rgw: Torrents are not supported for objects encrypted using SSE-C

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -1640,6 +1640,11 @@ void RGWGetObj::execute()
   /* start gettorrent */
   if (torrent.get_flag())
   {
+    attr_iter = attrs.find(RGW_ATTR_CRYPT_MODE);
+    if (attr_iter != attrs.end() && attr_iter->second.to_str() == "SSE-C-AES256") {
+      op_ret = -ERR_INVALID_REQUEST;
+      goto done_err;
+    }
     torrent.init(s, store);
     op_ret = torrent.get_torrent_file(read_op, total_len, bl, obj);
     if (op_ret < 0)


### PR DESCRIPTION
Getting torrents should return error if the object is encrypted using SSE-C according to S3 doc. https://docs.aws.amazon.com/AmazonS3/latest/dev/ServerSideEncryptionCustomerKeys.html

Fixes: http://tracker.ceph.com/issues/21720

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>