### PR TITLE
test: silence warnings from -Wsign-compare

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -2147,8 +2147,8 @@ TEST(BufferList, claim_prepend_misc) {
   EXPECT_EQ((unsigned)(11-3), src_buf.length());
   src_buf.claim_prepend(b3);
   EXPECT_EQ((unsigned)(8+7), src_buf.length());
-  EXPECT_EQ(0, b3.get_num_buffers());
-  EXPECT_EQ(0, b3.length());
+  EXPECT_EQ(0u, b3.get_num_buffers());
+  EXPECT_EQ(0u, b3.length());
   src_buf.copy(0, src_buf.length(), dest_buf);
   EXPECT_EQ(3u, dest_buf.get_num_buffers()); 
 }


### PR DESCRIPTION
Fixed the warnings:

```
In file included from ceph/src/test/bufferlist.cc:35:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = unsigned int]’:
ceph/src/googletest/googletest/include/gtest/gtest.h:1459:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<true>::Compare(const char*, const char*, const T1&, const T2&, typename testing::internal::EnableIf<(! testing::internal::is_pointer<T2>::value)>::type*) [with T1 = int; T2 = unsigned int; typename testing::internal::EnableIf<(! testing::internal::is_pointer<T2>::value)>::type = void]’
ceph/src/test/bufferlist.cc:2150:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```

```
In file included from ceph/src/test/bufferlist.cc:35:0:
ceph/src/googletest/googletest/include/gtest/gtest.h: In instantiation of ‘testing::AssertionResult testing::internal::CmpHelperEQ(const char*, const char*, const T1&, const T2&) [with T1 = int; T2 = unsigned int]’:
ceph/src/googletest/googletest/include/gtest/gtest.h:1459:23:   required from ‘static testing::AssertionResult testing::internal::EqHelper<true>::Compare(const char*, const char*, const T1&, const T2&, typename testing::internal::EnableIf<(! testing::internal::is_pointer<T2>::value)>::type*) [with T1 = int; T2 = unsigned int; typename testing::internal::EnableIf<(! testing::internal::is_pointer<T2>::value)>::type = void]’
ceph/src/test/bufferlist.cc:2151:3:   required from here
ceph/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
   if (lhs == rhs) {
       ~~~~^~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>