### PR TITLE
rgw: add "Accept-Ranges" to response header of Swift API

### DIFF
--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -174,6 +174,7 @@ void RGWListBuckets_ObjStore_SWIFT::send_response_begin(bool has_buckets)
             user_quota,
             static_cast<RGWAccessControlPolicy_SWIFTAcct&>(*s->user_acl));
     dump_errno(s);
+    dump_header(s, "Accept-Ranges", "bytes");
     end_header(s, NULL, NULL, NO_CONTENT_LENGTH, true);
   }
 


### PR DESCRIPTION
"Accept-ranges" is missing in the Response header of swift API
returned by Ceph rgw.

Fixes: http://tracker.ceph.com/issues/21554

Signed-off-by: Tone Zhang <tone.zhang@linaro.org>