### PR TITLE
rgw: Complete multipart should return verison id if versioning is enabled

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -2573,6 +2573,9 @@ void RGWCompleteMultipart_ObjStore_S3::send_response()
 {
   if (op_ret)
     set_req_state_err(s, op_ret);
+  if (!version_id.empty()) {
+    dump_header(s, "x-amz-version-id", version_id);
+  }
   dump_errno(s);
   dump_header_if_nonempty(s, "x-amz-version-id", version_id);
   end_header(s, this, "application/xml");


### PR DESCRIPTION
Complete multipart should return version id when versioning is enabled

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>