### PR TITLE
systemd: rbd-mirror does not start on reboot

### DIFF
--- a/systemd/ceph-rbd-mirror@.service
+++ b/systemd/ceph-rbd-mirror@.service
@@ -2,6 +2,7 @@
 Description=Ceph rbd mirror daemon
 After=network-online.target local-fs.target
 Wants=network-online.target local-fs.target
+PartOf=ceph-rbd-mirror.target
 
 [Service]
 LimitNOFILE=1048576


### PR DESCRIPTION
The current systemd unit file misses 'PartOf=ceph-rbd-mirror.target',
which results in the unit not starting after reboot.
If you have ceph-rbd-mirror@rbd-mirror.ceph-rbd-mirror0, it won't start
after reboot even if enabled.
Adding 'PartOf=ceph-rbd-mirror.target' will enable
ceph-rbd-mirror.target when ceph-rbd-mirror@rbd-mirror.ceph-rbd-mirror0
gets enabled.

Seen in https://github.com/ceph/ceph-ansible/pull/1939
Signed-off-by: Sébastien Han <seb@redhat.com>