### PR TITLE
rbdmap: fix umount when multiple mounts use the same RBD

### DIFF
--- a/src/rbdmap
+++ b/src/rbdmap
@@ -58,19 +58,19 @@ do_map() {
 
 unmount_unmap() {
 	local rbd_dev=$1
-	local mnt=$(findmnt --mtab --source ${rbd_dev} --noheadings \
+	local mnts=$(findmnt --mtab --source ${rbd_dev} --noheadings \
 							| awk '{print $1'})
 
 	logger -p "daemon.debug" -t rbdmap "Unmapping '${rbd_dev}'"
-	if [ -n "${mnt}" ]; then
+	for mnt in ${mnts}; do
 	    logger -p "daemon.debug" -t rbdmap "Unmounting '${mnt}'"
 	    umount "${mnt}" >>/dev/null 2>&1
-	fi
-	if mountpoint -q "${mnt}"; then
-	    ## Un-mounting failed.
-	    logger -p "daemon.warning" -t rbdmap "Failed to unmount '${mnt}'"
-	    return 1
-	fi
+	    if mountpoint -q "${mnt}"; then
+		  ## Un-mounting failed.
+		  logger -p "daemon.warning" -t rbdmap "Failed to unmount '${mnt}'"
+		  return 1
+	    fi
+	done
 	## Un-mapping.
 	rbd unmap $rbd_dev >>/dev/null 2>&1
 	if [ $? -ne 0 ]; then


### PR DESCRIPTION
When a Kubernetes Pod consumes a RBD it is mounted two
times on the same host. When the host shutdown umount will
fail leading to a hung system

Signed-off-by: Alexandre Marangone <amarango@redhat.com>