### PR TITLE
make-dist,cmake: move boost tarball location to download.ceph.com

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -86,7 +86,7 @@ function(do_build_boost version)
     set(boost_version 1.63.0)
     set(boost_md5 1c837ecd990bb022d07e7aab32b09847)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
-    set(boost_url http://downloads.sourceforge.net/project/boost/boost/${boost_version}/boost_${boost_version_underscore}.tar.bz2)
+    set(boost_url https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2)
     set(source_dir
       URL ${boost_url}
       URL_MD5 ${boost_md5})

--- a/make-dist
+++ b/make-dist
@@ -27,7 +27,7 @@ download_boost() {
     boost_fname=boost_${boost_version_underscore}.tar.bz2
     echo "downloading boost_$boost_version..."
     wget --no-verbose -O $boost_fname \
-         https://downloads.sourceforge.net/project/boost/boost/$boost_version/$boost_fname
+         https://download.ceph.com/qa/$boost_fname
     if [ $? != 0 -o ! -e $boost_fname ]; then
         echo "Error: failed to download boost."
         exit 1


### PR DESCRIPTION
Sourceforge is down.  Also, we can hammer our servers instead of
theirs.

Signed-off-by: Sage Weil <sage@redhat.com>