### PR TITLE
DNM tests - Added cluster compatibility settings

### DIFF
--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/1-install/hammer-client-x.yaml
@@ -9,3 +9,4 @@ upgrade_workload:
       exclude_packages: ['ceph-test-dbg']
       client.0:
   - print: "**** done install.upgrade client.0"
+

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_api_tests.yaml
@@ -16,6 +16,11 @@ tasks:
     - "cp --force $TESTDIR/ceph_test_librbd_api $(which ceph_test_librbd_api)"
     - "rm -rf $TESTDIR/ceph_test_librbd_api"
 - print: "**** done reverting to hammer ceph_test_librbd_api"
+- exec:
+    mon.a:
+    - ceph osd set-require-min-compat-client hammer
+    - ceph osd crush tunables hammer
+- print: '**** done set cluster for clients compatibility'
 - workunit:
     branch: hammer
     clients:

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_cli_import_export.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/basic/2-workload/rbd_cli_import_export.yaml
@@ -3,6 +3,11 @@ tasks:
   - upgrade_workload
 - ceph: 
 - print: "**** done ceph"
+- exec:
+    mon.a:
+    - ceph osd set-require-min-compat-client hammer
+    - ceph osd crush tunables hammer
+- print: '**** done set cluster for clients compatibility'
 - workunit:
     branch: hammer
     clients:

--- a/qa/suites/upgrade/client-upgrade/hammer-client-x/rbd/1-install/hammer-client-x.yaml
+++ b/qa/suites/upgrade/client-upgrade/hammer-client-x/rbd/1-install/hammer-client-x.yaml
@@ -9,3 +9,8 @@ tasks:
 - print: "**** done install.upgrade client.1"
 - ceph:
 - print: "**** done ceph"
+- exec:
+    mon.a:
+      - ceph osd set-require-min-compat-client hammer
+      - ceph osd crush tunables hammer
+- print: "**** done set cluster for clients compatibility"


### PR DESCRIPTION
Set cluster to have settings:

@ceph set min-compat-client hammer@, @ceph osd crush tunables hammer@

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>