### PR TITLE
mgr/balancer: make crush-compat mode work

### DIFF
--- a/qa/suites/rados/thrash/d-balancer/crush-compat.yaml
+++ b/qa/suites/rados/thrash/d-balancer/crush-compat.yaml
@@ -1,0 +1,7 @@
+tasks:
+- exec:
+    mon.a:
+      - ceph mgr module enable balancer
+      - while ! ceph balancer status ; do sleep 1 ; done
+      - ceph balancer mode crush-compat
+      - ceph balancer on

--- a/qa/suites/rados/thrash/d-balancer/upmap.yaml
+++ b/qa/suites/rados/thrash/d-balancer/upmap.yaml
@@ -1,0 +1,7 @@
+tasks:
+- exec:
+    mon.a:
+      - ceph mgr module enable balancer
+      - while ! ceph balancer status ; do sleep 1 ; done
+      - ceph balancer mode upmap
+      - ceph balancer on

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -749,46 +749,6 @@ class Module(MgrModule):
         self.log.debug('weight_set weights %s' % weight_set)
         return weight_set
 
-    def get_util(self, cost_mode, pools, osds):
-        if cost_mode == 'pg' or \
-           cost_mode == 'pg_bytes' or \
-           cost_mode == 'pg_objects':
-            util_map = {}
-            for osd in osds:
-                util_map[osd] = 0
-            dump = self.get('pg_dump')
-            #self.log.info('dump %s' % dump)
-            self.log.info('osds %s' % osds)
-            for pg in dump['pg_stats']:
-                inpool = False
-                for pool in pools:
-                    if pg['pgid'].startswith(str(pool) + '.'):
-                        inpool = True
-                        break
-                if not inpool:
-                    self.log.info('skipping %s' % pg['pgid'])
-                    continue
-                self.log.info('pg %s osds %s' % (pg['pgid'], pg['up']))
-                for osd in [int(a) for a in pg['up']]:
-                    if osd in osds:
-                        if cost_mode == 'pg':
-                            util_map[osd] += 1
-                        elif cost_mode == 'pg_bytes':
-                            util_map[osd] += pg['stat_sum']['num_bytes']
-                        elif cost_mode == 'pg_objects':
-                            util_map[osd] += pg['stat_sum']['num_objects']
-            return util_map
-        else:
-            raise RuntimeError('unsupported cost mode %s' % cost_mode)
-
-    def get_target(self, util_map):
-        total = 0
-        count = 0
-        for k, v in util_map.iteritems():
-            total += v;
-            count += 1
-        return total / count
-
     def do_crush(self):
         self.log.info('do_crush (not yet implemented)')
 

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -693,13 +693,15 @@ class Module(MgrModule):
                 self.log.debug('Step misplaced %f > max %f, reducing step to %f',
                                next_misplaced, max_misplaced, step)
             else:
-                if next_pe.score > cur_pe.score * 1.01:
+                if next_pe.score > cur_pe.score * 1.0001:
                     step /= 2.0
                     self.log.debug('Score got worse, trying smaller step %f',
                                    step)
                 else:
                     cur_pe = next_pe
                     best_ws = next_ws
+                    if cur_pe.score == 0:
+                        break
             left -= 1
 
         if cur_pe.score < pe.score:

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -646,6 +646,18 @@ class Module(MgrModule):
                                    new_weight)
                     next_ws[osd] = new_weight
 
+                # normalize weights under this root
+                root_weight = crush.get_item_weight(pe.root_ids[root])
+                root_sum = sum(b for a,b in next_ws.iteritems()
+                               if a in target.keys())
+                if root_sum > 0 and root_weight > 0:
+                    factor = root_sum / root_weight
+                    self.log.debug('normalizing root %s %d, weight %f, ws sum %f, factor %f',
+                                   root, pe.root_ids[root], root_weight,
+                                   root_sum, factor)
+                    for osd in actual.keys():
+                        next_ws[osd] = next_ws[osd] / factor
+
             # recalc
             plan.compat_ws = copy.deepcopy(next_ws)
             next_ms = plan.final_state()

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -80,6 +80,7 @@ class Plan:
 
 
 class Eval:
+    root_ids = {}        # root name -> id
     pool_name = {}       # pool id -> pool name
     pool_id = {}         # pool name -> id
     pool_roots = {}      # pool name -> root name
@@ -356,6 +357,7 @@ class Module(MgrModule):
         roots = []
         for rootid in rootids:
             root = ms.crush.get_item_name(rootid)
+            pe.root_ids[root] = rootid
             roots.append(root)
             ls = ms.osdmap.get_pools_by_take(rootid)
             pe.root_pools[root] = []

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -711,21 +711,6 @@ class Module(MgrModule):
                           pe.score)
             return False
 
-    def compat_weight_set_reweight(self, osd, new_weight):
-        self.log.debug('ceph osd crush weight-set reweight-compat')
-        result = CommandResult('')
-        self.send_command(result, 'mon', '', json.dumps({
-            'prefix': 'osd crush weight-set reweight-compat',
-            'format': 'json',
-            'item': 'osd.%d' % osd,
-            'weight': [new_weight],
-        }), '')
-        r, outb, outs = result.wait()
-        if r != 0:
-            self.log.error('Error setting compat weight-set osd.%d to %f' %
-            (osd, new_weight))
-            return
-
     def get_compat_weight_set_weights(self):
         # enable compat weight-set
         self.log.debug('ceph osd crush weight-set create-compat')

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -377,11 +377,13 @@ class Module(MgrModule):
     def calc_eval(self, ms):
         pe = Eval(ms)
         pool_rule = {}
+        pool_info = {}
         for p in ms.osdmap_dump.get('pools',[]):
             pe.pool_name[p['pool']] = p['pool_name']
             pe.pool_id[p['pool_name']] = p['pool']
             pool_rule[p['pool_name']] = p['crush_rule']
             pe.pool_roots[p['pool_name']] = []
+            pool_info[p['pool_name']] = p
         pools = pe.pool_id.keys()
         if len(pools) == 0:
             return pe
@@ -433,9 +435,7 @@ class Module(MgrModule):
         self.log.debug('target_by_root %s' % pe.target_by_root)
 
         # pool and root actual
-        for pool in pools:
-            pi = [p for p in ms.osdmap_dump.get('pools',[])
-                  if p['pool_name'] == pool][0]
+        for pool, pi in pool_info.iteritems():
             poolid = pi['pool']
             pm = ms.pg_up_by_poolid[poolid]
             pgs = 0

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -613,7 +613,7 @@ class Module(MgrModule):
         max_iterations = self.get_config('crush_compat_max_iterations', 25)
         if max_iterations < 1:
             return False
-        step = self.get_config('crush_compat_step', .2)
+        step = self.get_config('crush_compat_step', .5)
         if step <= 0 or step >= 1.0:
             return False
         max_misplaced = float(self.get_config('max_misplaced',

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -15,7 +15,7 @@ from threading import Event
 # available modes: 'none', 'crush', 'crush-compat', 'upmap', 'osd_weight'
 default_mode = 'none'
 default_sleep_interval = 60   # seconds
-default_max_misplaced = .03   # max ratio of pgs replaced at a time
+default_max_misplaced = .05    # max ratio of pgs replaced at a time
 
 TIME_FORMAT = '%Y-%m-%d_%H:%M:%S'
 

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -705,7 +705,7 @@ class Module(MgrModule):
                         next_ws[osd] = new_weight
                         if ow < 1.0:
                             new_ow = min(1.0, max(step + (1.0 - step) * ow,
-                                                  ow + .002))
+                                                  ow + .005))
                             self.log.debug('Reweight osd.%d reweight %f -> %f',
                                            osd, ow, new_ow)
                             next_ow[osd] = new_ow

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -574,11 +574,11 @@ class Module(MgrModule):
         if unknown > 0.0:
             self.log.info('Some PGs (%f) are unknown; waiting', unknown)
         elif degraded > 0.0:
-            self.log.info('Some PGs (%f) are degraded; waiting', degraded)
+            self.log.info('Some objects (%f) are degraded; waiting', degraded)
         elif inactive > 0.0:
             self.log.info('Some PGs (%f) are inactive; waiting', inactive)
         elif misplaced >= max_misplaced:
-            self.log.info('Too many PGs (%f > %f) are misplaced; waiting',
+            self.log.info('Too many objects (%f > %f) are misplaced; waiting',
                           misplaced, max_misplaced)
         else:
             if plan.mode == 'upmap':


### PR DESCRIPTION
This is starting to work!

- [x] better throttling on max_misplaced
- [x] handle 'out' osds
- [x] transparently phase out old osd_weights, if present

My only concern here is that when it breaks (throws an exception in serve()) we don't get a run failure because we don't have mgr health alerts for crashed modules yet.  I don't think that should prevent us from merging, though.  I've done some spot checks and it appears to be doing fine.
