### PR TITLE
include/rados: fix typo in librados.h

### DIFF
--- a/src/include/rados/librados.h
+++ b/src/include/rados/librados.h
@@ -109,7 +109,7 @@ enum {
 
 /**
  * @name Operation Flags
- * Flags for rados_read_op_opeprate(), rados_write_op_operate(),
+ * Flags for rados_read_op_operate(), rados_write_op_operate(),
  * rados_aio_read_op_operate(), and rados_aio_write_op_operate().
  * See librados.hpp for details.
  * @{


### PR DESCRIPTION
Fixed typo in librados.h. opeprate -> operate

Signed-off-by: wumingqiao <wumingqiao@inspur.com>