### PR TITLE
os/bluestore/BlueFS: Reduce unnecessary operations in collect_metadata

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -456,14 +456,12 @@ void BlueFS::umount()
   _shutdown_logger();
 }
 
-void BlueFS::collect_metadata(map<string,string> *pm)
+void BlueFS::collect_metadata(map<string,string> *pm, unsigned skip_bdev_id)
 {
-  if (bdev[BDEV_DB])
+  if (skip_bdev_id != BDEV_DB && bdev[BDEV_DB])
     bdev[BDEV_DB]->collect_metadata("bluefs_db_", pm);
   if (bdev[BDEV_WAL])
     bdev[BDEV_WAL]->collect_metadata("bluefs_wal_", pm);
-  if (bdev[BDEV_SLOW])
-    bdev[BDEV_SLOW]->collect_metadata("bluefs_slow_", pm);
 }
 
 int BlueFS::fsck()

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -333,7 +333,7 @@ public:
   int mount();
   void umount();
 
-  void collect_metadata(map<string,string> *pm);
+  void collect_metadata(map<string,string> *pm, unsigned skip_bdev_id);
   int fsck();
 
   uint64_t get_fs_usage();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6121,7 +6121,7 @@ void BlueStore::collect_metadata(map<string,string> *pm)
   if (bluefs) {
     (*pm)["bluefs"] = "1";
     (*pm)["bluefs_single_shared_device"] = stringify((int)bluefs_single_shared_device);
-    bluefs->collect_metadata(pm);
+    bluefs->collect_metadata(pm, bluefs_shared_bdev);
   } else {
     (*pm)["bluefs"] = "0";
   }


### PR DESCRIPTION
Since we have already collected BlueStore metadata in BlueStore::collect_metadata, so:

1. When DB device shared with BlueStore, skip collect metadata
2. When DB device is independent, report the metadata
3. Slow device always equal to BlueStore, so skip collect metadata

Signed-off-by: Luo Kexue <luo.kexue@zte.com.cn>