### PR TITLE
rgw: include SSE-KMS headers in encrypted upload response

### DIFF
--- a/src/rgw/rgw_crypt.cc
+++ b/src/rgw/rgw_crypt.cc
@@ -1105,6 +1105,9 @@ int rgw_s3_prepare_encrypt(struct req_state* s,
         *block_crypt = std::move(aes);
       }
       actual_key.replace(0, actual_key.length(), actual_key.length(), '\000');
+
+      crypt_http_responses["x-amz-server-side-encryption"] = "aws:kms";
+      crypt_http_responses["x-amz-server-side-encryption-aws-kms-key-id"] = key_id.to_string();
       return 0;
     }
 


### PR DESCRIPTION
tested with boto3 against a vstart.sh cluster:
```python
import boto3
session = boto3.session.Session()
s3 = session.client('s3', aws_access_key_id='0555b35654ad1656d804', aws_secret_access_key='h7GhxuBLTrlhVUyxSPUKUV8r/2EI4ngqJxD7iBdBYLhwluN30JaT3Q==', endpoint_url='http://localhost:8000')
s3.put_object(Bucket='bucket', Key='foo', Body='abcdefg', ServerSideEncryption='aws:kms', SSEKMSKeyId='testkey-1')
```
without this patch, the response is missing the expected encryption headers:
> {u'ETag': '"7ac66c0f148de9519b8bd264312c4d64"', 'ResponseMetadata': {'HTTPStatusCode': 200, 'RetryAttempts': 0, 'HostId': '', 'RequestId': 'tx000000000000000000002-0059cbf0e9-100a-default', 'HTTPHeaders': {'date': 'Wed, 27 Sep 2017 18:41:46 GMT', 'content-length': '0', 'etag': '"7ac66c0f148de9519b8bd264312c4d64"', 'accept-ranges': 'bytes', 'x-amz-request-id': 'tx000000000000000000002-0059cbf0e9-100a-default'}}}

with this patch applied, the headers are included:
> {u'SSEKMSKeyId': 'testkey-1', u'ETag': '"7ac66c0f148de9519b8bd264312c4d64"', 'ResponseMetadata': {'HTTPStatusCode': 200, 'RetryAttempts': 0, 'HostId': '', 'RequestId': 'tx000000000000000000002-0059cbec74-100a-default', 'HTTPHeaders': {'content-length': '0', 'accept-ranges': 'bytes', 'x-amz-server-side-encryption-aws-kms-key-id': 'testkey-1', 'etag': '"7ac66c0f148de9519b8bd264312c4d64"', 'x-amz-request-id': 'tx000000000000000000002-0059cbec74-100a-default', 'date': 'Wed, 27 Sep 2017 18:22:45 GMT', 'x-amz-server-side-encryption': 'aws:kms'}}, u'ServerSideEncryption': 'aws:kms'}

Fixes: http://tracker.ceph.com/issues/21576