### PR TITLE
mgr/dashboard: use rel="icon" for favicon

### DIFF
--- a/src/pybind/mgr/dashboard/base.html
+++ b/src/pybind/mgr/dashboard/base.html
@@ -156,7 +156,7 @@
         });
       </script>
 
-      <link rel="shortcut icon" href="{{ url_prefix }}/static/favicon.ico">
+      <link rel="icon" href="{{ url_prefix }}/static/favicon.ico">
 
     <style>
         div.box {


### PR DESCRIPTION
shortcut is not a standard compliant link type, see
https://www.w3.org/TR/html5/links.html#linkTypes.

Signed-off-by: Kefu Chai <kchai@redhat.com>