### PR TITLE
rgw: Putobj should return version id if versioning is enabled

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3615,6 +3615,9 @@ void RGWPutObj::execute()
       goto done;
     }
   }
+  if (!multipart) {
+    version_id = (static_cast<RGWPutObjProcessor_Atomic *>(processor))->get_version_id();
+  }
 
 done:
   dispose_processor(processor);

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -2660,6 +2660,7 @@ int RGWPutObjProcessor_Atomic::prepare(RGWRados *store, string *oid_rand)
     head_obj.key.set_instance(version_id);
   } else if (versioned_object) {
     store->gen_rand_obj_instance_name(&head_obj);
+    version_id = head_obj.key.instance;
   }
 
   manifest.set_trivial_rule(max_chunk_size, store->ctx()->_conf->rgw_obj_stripe_size);

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -3917,6 +3917,10 @@ public:
   void set_version_id(const string& vid) {
     version_id = vid;
   }
+
+  string get_version_id() const {
+    return version_id;
+  }
 }; /* RGWPutObjProcessor_Atomic */
 
 #define MP_META_SUFFIX ".meta"

--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1383,6 +1383,9 @@ void RGWPutObj_ObjStore_S3::send_response()
       dump_errno(s);
       dump_etag(s, etag);
       dump_content_length(s, 0);
+      if (!version_id.empty()) {
+        dump_header(s, "x-amz-version-id", version_id);
+      }
       for (auto &it : crypt_http_responses)
         dump_header(s, it.first, it.second);
     } else {


### PR DESCRIPTION
Put object should return version id if bucket versioning is enabled.
Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>