### PR TITLE
osd: move sched_scrub to tick func

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5082,6 +5082,11 @@ void OSD::tick()
 
   do_waiters();
 
+  if (is_active()) {
+    if (!scrub_random_backoff()) {
+      sched_scrub();
+    }
+  }
   tick_timer.add_event_after(OSD_TICK_INTERVAL, new C_Tick(this));
 }
 
@@ -5119,9 +5124,6 @@ void OSD::tick_without_osd_lock()
   }
 
   if (is_active()) {
-    if (!scrub_random_backoff()) {
-      sched_scrub();
-    }
     service.promote_throttle_recalibrate();
     bool need_send_beacon = false;
     const auto now = ceph::coarse_mono_clock::now();


### PR DESCRIPTION
Because osdmap is used in sched_scrub which should be protected by osd_lock.
So calling it in tick func works more well.

Signed-off-by: Xinze Chi <xinze@xsky.com>