### PR TITLE
rbd-mirror: sync image metadata when transfering remote image

### DIFF
--- a/qa/workunits/rbd/rbd_mirror.sh
+++ b/qa/workunits/rbd/rbd_mirror.sh
@@ -13,6 +13,8 @@ testlog "TEST: add image and test replay"
 start_mirror ${CLUSTER1}
 image=test
 create_image ${CLUSTER2} ${POOL} ${image}
+set_image_meta ${CLUSTER2} ${POOL} ${image} "key1" "value1"
+set_image_meta ${CLUSTER2} ${POOL} ${image} "key2" "value2"
 wait_for_image_replay_started ${CLUSTER1} ${POOL} ${image}
 write_image ${CLUSTER2} ${POOL} ${image} 100
 wait_for_replay_complete ${CLUSTER1} ${CLUSTER2} ${POOL} ${image}
@@ -21,6 +23,8 @@ if [ -z "${RBD_MIRROR_USE_RBD_MIRROR}" ]; then
   wait_for_status_in_pool_dir ${CLUSTER2} ${POOL} ${image} 'down+unknown'
 fi
 compare_images ${POOL} ${image}
+compare_image_meta ${CLUSTER1} ${POOL} ${image} "key1" "value1"
+compare_image_meta ${CLUSTER1} ${POOL} ${image} "key2" "value2"
 
 testlog "TEST: stop mirror, add image, start mirror and test replay"
 stop_mirror ${CLUSTER1}

--- a/qa/workunits/rbd/rbd_mirror_helpers.sh
+++ b/qa/workunits/rbd/rbd_mirror_helpers.sh
@@ -593,6 +593,17 @@ set_image_meta()
     rbd --cluster ${cluster} -p ${pool} image-meta set ${image} $key $val
 }
 
+compare_image_meta()
+{
+    local cluster=$1
+    local pool=$2
+    local image=$3
+    local key=$4
+    local value=$5
+
+    test `rbd --cluster ${cluster} -p ${pool} image-meta get ${image} ${key}` = "${value}"
+}
+
 rename_image()
 {
     local cluster=$1

--- a/src/test/rbd_mirror/CMakeLists.txt
+++ b/src/test/rbd_mirror/CMakeLists.txt
@@ -30,6 +30,7 @@ add_executable(unittest_rbd_mirror
   image_replayer/test_mock_PrepareLocalImageRequest.cc
   image_replayer/test_mock_PrepareRemoteImageRequest.cc
   image_sync/test_mock_ImageCopyRequest.cc
+  image_sync/test_mock_MetadataCopyRequest.cc
   image_sync/test_mock_ObjectCopyRequest.cc
   image_sync/test_mock_SnapshotCopyRequest.cc
   image_sync/test_mock_SnapshotCreateRequest.cc

--- a/src/test/rbd_mirror/image_sync/test_mock_MetadataCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_MetadataCopyRequest.cc
@@ -1,0 +1,176 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/rbd/librbd.hpp"
+#include "include/stringify.h"
+#include "librbd/ImageCtx.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "tools/rbd_mirror/image_sync/MetadataCopyRequest.h"
+#include <map>
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/MetadataCopyRequest.cc"
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::StrEq;
+using ::testing::WithArg;
+
+class TestMockImageSyncMetadataCopyRequest : public TestMockFixture {
+public:
+  typedef MetadataCopyRequest<librbd::MockTestImageCtx> MockMetadataCopyRequest;
+  typedef std::map<std::string, bufferlist> Metadata;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_metadata_list(librbd::MockTestImageCtx &mock_image_ctx,
+                            const Metadata& metadata, int r) {
+    bufferlist out_bl;
+    ::encode(metadata, out_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                     StrEq("metadata_list"), _, _, _))
+                  .WillOnce(DoAll(WithArg<5>(CopyInBufferlist(out_bl)),
+                                  Return(r)));
+  }
+
+  void expect_metadata_set(librbd::MockTestImageCtx &mock_image_ctx,
+                           const Metadata& metadata, int r) {
+    bufferlist in_bl;
+    ::encode(metadata, in_bl);
+
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+                exec(mock_image_ctx.header_oid, _, StrEq("rbd"),
+                     StrEq("metadata_set"), ContentsEqual(in_bl), _, _))
+                  .WillOnce(Return(r));
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+};
+
+TEST_F(TestMockImageSyncMetadataCopyRequest, Success) {
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  size_t idx = 1;
+  Metadata key_values_1;
+  for (; idx <= 128; ++idx) {
+    bufferlist bl;
+    bl.append("value" + stringify(idx));
+    key_values_1.emplace("key" + stringify(idx), bl);
+  }
+
+  Metadata key_values_2;
+  for (; idx <= 255; ++idx) {
+    bufferlist bl;
+    bl.append("value" + stringify(idx));
+    key_values_2.emplace("key" + stringify(idx), bl);
+  }
+
+  InSequence seq;
+  expect_metadata_list(mock_remote_image_ctx, key_values_1, 0);
+  expect_metadata_set(mock_local_image_ctx, key_values_1, 0);
+  expect_metadata_list(mock_remote_image_ctx, key_values_2, 0);
+  expect_metadata_set(mock_local_image_ctx, key_values_2, 0);
+
+  C_SaferCond ctx;
+  auto request = MockMetadataCopyRequest::create(&mock_local_image_ctx,
+                                                 &mock_remote_image_ctx,
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncMetadataCopyRequest, Empty) {
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  Metadata key_values;
+
+  InSequence seq;
+  expect_metadata_list(mock_remote_image_ctx, key_values, 0);
+
+  C_SaferCond ctx;
+  auto request = MockMetadataCopyRequest::create(&mock_local_image_ctx,
+                                                 &mock_remote_image_ctx,
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncMetadataCopyRequest, MetadataListError) {
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  Metadata key_values;
+
+  InSequence seq;
+  expect_metadata_list(mock_remote_image_ctx, key_values, -EINVAL);
+
+  C_SaferCond ctx;
+  auto request = MockMetadataCopyRequest::create(&mock_local_image_ctx,
+                                                 &mock_remote_image_ctx,
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncMetadataCopyRequest, MetadataSetError) {
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  Metadata key_values;
+  bufferlist bl;
+  bl.append("value");
+  key_values.emplace("key", bl);
+
+  InSequence seq;
+  expect_metadata_list(mock_remote_image_ctx, key_values, 0);
+  expect_metadata_set(mock_local_image_ctx, key_values, -EINVAL);
+
+  C_SaferCond ctx;
+  auto request = MockMetadataCopyRequest::create(&mock_local_image_ctx,
+                                                 &mock_remote_image_ctx,
+                                                 &ctx);
+  request->send();
+
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/test_mock_fixture.h
+++ b/src/test/rbd_mirror/test_mock_fixture.h
@@ -21,6 +21,10 @@ namespace librbd {
 class MockImageCtx;
 }
 
+ACTION_P(CopyInBufferlist, str) {
+  arg0->append(str);
+}
+
 ACTION_P(CompleteContext, r) {
   arg0->complete(r);
 }

--- a/src/tools/rbd_mirror/CMakeLists.txt
+++ b/src/tools/rbd_mirror/CMakeLists.txt
@@ -33,6 +33,7 @@ set(rbd_mirror_internal
   image_replayer/PrepareRemoteImageRequest.cc
   image_replayer/ReplayStatusFormatter.cc
   image_sync/ImageCopyRequest.cc
+  image_sync/MetadataCopyRequest.cc
   image_sync/ObjectCopyRequest.cc
   image_sync/SnapshotCopyRequest.cc
   image_sync/SnapshotCreateRequest.cc

--- a/src/tools/rbd_mirror/ImageSync.h
+++ b/src/tools/rbd_mirror/ImageSync.h
@@ -90,8 +90,11 @@ private:
    *    v                                 .
    * REFRESH_OBJECT_MAP (skip if object   .
    *    |                map disabled)    .
-   *    v
+   *    v                                 .
    * PRUNE_SYNC_POINTS                    . (image sync canceled)
+   *    |                                 .
+   *    v                                 .
+   * COPY_METADATA                        .
    *    |                                 .
    *    v                                 .
    * <finish> < . . . . . . . . . . . . . .
@@ -145,6 +148,9 @@ private:
 
   void send_prune_sync_points();
   void handle_prune_sync_points(int r);
+
+  void send_copy_metadata();
+  void handle_copy_metadata(int r);
 
   void update_progress(const std::string &description);
 };

--- a/src/tools/rbd_mirror/image_sync/MetadataCopyRequest.cc
+++ b/src/tools/rbd_mirror/image_sync/MetadataCopyRequest.cc
@@ -1,0 +1,119 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "tools/rbd_mirror/image_sync/MetadataCopyRequest.h"
+#include "common/dout.h"
+#include "common/errno.h"
+#include "cls/rbd/cls_rbd_client.h"
+#include "librbd/Utils.h"
+
+#define dout_context g_ceph_context
+#define dout_subsys ceph_subsys_rbd_mirror
+#undef dout_prefix
+#define dout_prefix *_dout << "rbd::mirror::image_sync::MetadataCopyRequest: " \
+                           << this << " " << __func__ << ": "
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+namespace {
+
+const uint64_t MAX_METADATA_ITEMS = 128;
+
+} // anonymous namespace
+
+using librbd::util::create_rados_callback;
+
+template <typename I>
+void MetadataCopyRequest<I>::send() {
+  list_remote_metadata();
+}
+
+template <typename I>
+void MetadataCopyRequest<I>::list_remote_metadata() {
+  dout(20) << "start_key=" << m_last_metadata_key << dendl;
+
+  librados::ObjectReadOperation op;
+  librbd::cls_client::metadata_list_start(&op, m_last_metadata_key, MAX_METADATA_ITEMS);
+
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    MetadataCopyRequest<I>,
+    &MetadataCopyRequest<I>::handle_list_remote_data>(this);
+  m_out_bl.clear();
+  m_remote_image_ctx->md_ctx.aio_operate(m_remote_image_ctx->header_oid,
+                                         aio_comp, &op, &m_out_bl);
+  aio_comp->release();
+}
+
+template <typename I>
+void MetadataCopyRequest<I>::handle_list_remote_data(int r) {
+  dout(20) << "r=" << r << dendl;
+
+  Metadata metadata;
+  if (r == 0) {
+    bufferlist::iterator it = m_out_bl.begin();
+    r = librbd::cls_client::metadata_list_finish(&it, &metadata);
+  }
+
+  if (r < 0) {
+    derr << "failed to retrieve metadata: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (metadata.empty()) {
+    finish(0);
+    return;
+  }
+
+  m_last_metadata_key = metadata.rbegin()->first;
+  m_more_metadata = (metadata.size() >= MAX_METADATA_ITEMS);
+  set_local_metadata(metadata);
+}
+
+template <typename I>
+void MetadataCopyRequest<I>::set_local_metadata(const Metadata& metadata) {
+  dout(20) << "count=" << metadata.size() << dendl;
+
+  librados::ObjectWriteOperation op;
+  librbd::cls_client::metadata_set(&op, metadata);
+
+  librados::AioCompletion *aio_comp = create_rados_callback<
+    MetadataCopyRequest<I>,
+    &MetadataCopyRequest<I>::handle_set_local_metadata>(this);
+  m_local_image_ctx->md_ctx.aio_operate(m_local_image_ctx->header_oid, aio_comp,
+                                        &op);
+  aio_comp->release();
+}
+
+template <typename I>
+void MetadataCopyRequest<I>::handle_set_local_metadata(int r) {
+  dout(20) << "r=" << r << dendl;
+
+  if (r < 0) {
+    derr << "failed to set metadata: " << cpp_strerror(r) << dendl;
+    finish(r);
+    return;
+  }
+
+  if (m_more_metadata) {
+    list_remote_metadata();
+    return;
+  }
+
+  finish(0);
+}
+
+template <typename I>
+void MetadataCopyRequest<I>::finish(int r) {
+  dout(20) << "r=" << r << dendl;
+  m_on_finish->complete(r);
+  delete this;
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+template class rbd::mirror::image_sync::MetadataCopyRequest<librbd::ImageCtx>;

--- a/src/tools/rbd_mirror/image_sync/MetadataCopyRequest.h
+++ b/src/tools/rbd_mirror/image_sync/MetadataCopyRequest.h
@@ -1,0 +1,82 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef RBD_MIRROR_IMAGE_SYNC_METADATA_COPY_REQUEST_H
+#define RBD_MIRROR_IMAGE_SYNC_METADATA_COPY_REQUEST_H
+
+#include "include/int_types.h"
+#include "include/buffer.h"
+#include "include/rados/librados.hpp"
+#include "librbd/ImageCtx.h"
+#include <map>
+#include <string>
+
+class Context;
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+template <typename ImageCtxT = librbd::ImageCtx>
+class MetadataCopyRequest {
+public:
+  static MetadataCopyRequest* create(ImageCtxT *local_image_ctx,
+                                     ImageCtxT *remote_image_ctx,
+                                     Context *on_finish) {
+    return new MetadataCopyRequest(local_image_ctx, remote_image_ctx,
+                                   on_finish);
+  }
+
+  MetadataCopyRequest(ImageCtxT *local_image_ctx, ImageCtxT *remote_image_ctx,
+                      Context *on_finish)
+    : m_local_image_ctx(local_image_ctx), m_remote_image_ctx(remote_image_ctx),
+      m_on_finish(on_finish) {
+  }
+
+  void send();
+
+private:
+  /**
+   * @verbatim
+   *
+   * <start>
+   *    |
+   *    v
+   * LIST_REMOTE_METADATA <-----\
+   *    |                       | (repeat if additional
+   *    v                       |  metadata)
+   * SET_LOCAL_METADATA --------/
+   *    |
+   *    v
+   * <finish>
+   *
+   * @endverbatim
+   */
+  typedef std::map<std::string, bufferlist> Metadata;
+
+  ImageCtxT *m_local_image_ctx;
+  ImageCtxT *m_remote_image_ctx;
+  Context *m_on_finish;
+
+  bufferlist m_out_bl;
+
+  std::string m_last_metadata_key;
+  bool m_more_metadata = false;
+
+  void list_remote_metadata();
+  void handle_list_remote_data(int r);
+
+  void set_local_metadata(const Metadata& metadata);
+  void handle_set_local_metadata(int r);
+
+  void finish(int r);
+
+};
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd
+
+extern template class rbd::mirror::image_sync::MetadataCopyRequest<librbd::ImageCtx>;
+
+#endif // RBD_MIRROR_IMAGE_SYNC_METADATA_COPY_REQUEST_H


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21535
Signed-off-by: Jason Dillaman <dillaman@redhat.com>