### PR TITLE
luminous: osd/PrimaryLogPG: kick off recovery on backoffing a degraded object

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2041,6 +2041,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
   if (write_ordered && is_degraded_or_backfilling_object(head)) {
     if (can_backoff && g_conf->osd_backoff_on_degraded) {
       add_backoff(session, head, head);
+      maybe_kick_recovery(head);
     } else {
       wait_for_degraded_object(head, op);
     }


### PR DESCRIPTION
As we are now blocking frontend ops from accessing that very object!

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>
(cherry picked from commit db20328b456d70d6728fd27f17da6f2f3546e84b)