### PR TITLE
luminous: os/bluestore: allocate entire write in one go

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2452,6 +2452,10 @@ private:
       bool mark_unused;
       bool new_blob; ///< whether new blob was created
 
+      bool compressed = false;
+      bufferlist compressed_bl;
+      size_t compressed_len = 0;
+
       write_item(
 	uint64_t logical_offs,
         BlobRef b,


### PR DESCRIPTION
On the first pass through the writes, compress data and calculate a final
amount of space we need to allocate.  On the second pass, assign the
extents to blobs and queue the writes.

This allows us to do a single allocation for all blobs, which will lead
to less fragmentation and a much better write pattern.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit e200f358499af8e3acb6ac4f675cc167433b53ec)