### PR TITLE
msg/async/rdma: fix a potential coredump when handling tx_buffers under heavy RDMA

### DIFF
--- a/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
+++ b/src/msg/async/rdma/RDMAConnectedSocketImpl.cc
@@ -467,9 +467,9 @@ ssize_t RDMAConnectedSocketImpl::submit(bool more)
         total_copied += r;
         bytes -= r;
         if (current_chunk->full()){
-          current_chunk = tx_buffers[++chunk_idx];
-          if (chunk_idx == tx_buffers.size())
+          if (++chunk_idx == tx_buffers.size())
             return total_copied;
+          current_chunk = tx_buffers[chunk_idx];
         }
       }
       ++start;


### PR DESCRIPTION
traffic, there are chances to access a current_chunk which can be beyond the
range of pre-allocated Tx buffer pool thus causes a coredump.

Signed-off-by: Yan Lei <yongyou.yl@alibaba-inc.com>