### PR TITLE
luminous: mon/MgrMonitor: handle cmd descs to/from disk in the absence of active mgr

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -85,8 +85,9 @@ void MgrMonitor::update_from_paxos(bool *need_bootstrap)
     check_subs();
 
     if (version == 1
-	|| (map.get_available()
-	    && (!old_available || old_gid != map.get_active_gid()))) {
+        || command_descs.empty()
+        || (map.get_available()
+            && (!old_available || old_gid != map.get_active_gid()))) {
       dout(4) << "mkfs or daemon transitioned to available, loading commands"
 	      << dendl;
       bufferlist loaded_commands;

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -108,6 +108,16 @@ void MgrMonitor::create_pending()
 {
   pending_map = map;
   pending_map.epoch++;
+
+  if (map.get_epoch() == 1 &&
+      command_descs.empty() &&
+      pending_command_descs.empty()) {
+    // we've been through the initial map and we haven't populated the
+    // command_descs vector. This likely means we came from kraken, where
+    // we wouldn't populate the vector, nor would we write it to disk, on
+    // create_initial().
+    create_initial();
+  }
 }
 
 health_status_t MgrMonitor::should_warn_about_mgr_down()


### PR DESCRIPTION
This PR contains two commits, one of which is targeting specifically luminous (and we have no way around it), and the other is a cherry-pick from master.

Signed-off-by: `Joao Eduardo Luis <joao@suse.de>`