### PR TITLE
mds/mgr: fix handling of filesystem removal

### DIFF
--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -132,6 +132,7 @@ public:
       standby_daemons(rhs.standby_daemons),
       standby_epochs(rhs.standby_epochs)
   {
+    filesystems.clear();
     for (const auto &i : rhs.filesystems) {
       const auto &fs = i.second;
       filesystems[fs->fscid] = std::make_shared<Filesystem>(*fs);
@@ -149,6 +150,7 @@ public:
     standby_daemons = rhs.standby_daemons;
     standby_epochs = rhs.standby_epochs;
 
+    filesystems.clear();
     for (const auto &i : rhs.filesystems) {
       const auto &fs = i.second;
       filesystems[fs->fscid] = std::make_shared<Filesystem>(*fs);

--- a/src/pybind/mgr/dashboard/filesystem.html
+++ b/src/pybind/mgr/dashboard/filesystem.html
@@ -11,6 +11,10 @@
                 $.get("{{ url_prefix }}/filesystem_data/" + content_data.fs_status.filesystem.id  + "/", function(data) {
                     _.extend(content_data.fs_status, data);
                     setTimeout(refresh, 5000);
+                }).fail(function() {
+                    // Perhaps the filesystem we're viewing no longer exists.
+                    // Go back to home.
+                    window.location.href = "{{ url_prefix }}/";
                 });
             };
 

--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -255,6 +255,10 @@ class Module(MgrModule):
                 filesystem = fs
                 break
 
+        if filesystem is None:
+            raise cherrypy.HTTPError(404,
+                "Filesystem id {0} not found".format(fs_id))
+
         rank_table = []
 
         mdsmap = filesystem['mdsmap']


### PR DESCRIPTION
The principal bug here was the FSMap constructor -- the dashboard fixes just make things a bit nicer.

Fixes: http://tracker.ceph.com/issues/21599