### PR TITLE
doc: Fix typo and URL

### DIFF
--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -76,10 +76,10 @@ Licensing
 Ceph is free software.
 
 Unless stated otherwise, the Ceph source code is distributed under the terms of
-the LGPL2.1. For full details, see `the file COPYING in the top-level
-directory of the source-code tree`_.
+the LGPL2.1. For full details, see the file `COPYING`_ in the top-level
+directory of the source-code tree.
 
-.. _`the file COPYING in the top-level directory of the source-code tree`:
+.. _`COPYING`:
   https://github.com/ceph/ceph/blob/master/COPYING
 
 Source code repositories

--- a/doc/dev/index.rst
+++ b/doc/dev/index.rst
@@ -152,10 +152,10 @@ Submitting patches
 ------------------
 
 The canonical instructions for submitting patches are contained in the
-`the file CONTRIBUTING.rst in the top-level directory of the source-code
-tree`_. There may be some overlap between this guide and that file.
+file `CONTRIBUTING.rst`_ in the top-level directory of the source-code
+tree. There may be some overlap between this guide and that file.
 
-.. _`the file CONTRIBUTING.rst in the top-level directory of the source-code tree`:
+.. _`CONTRIBUTING.rst`:
   https://github.com/ceph/ceph/blob/master/CONTRIBUTING.rst
 
 All newcomers are encouraged to read that file carefully.


### PR DESCRIPTION
**Submitting patches**
Dropped the repeated `the` in the paragraph and Fixed the unnecessary URL format in the text. Modify the URL formatting to highlight only the file name seems better.

**Licensing**
Modified the URL formatting to highlight only the file name.

Signed-off-by: Jos Collin <jcollin@redhat.com>