### PR TITLE
librbd: snapshots should be created/removed against data pool

### DIFF
--- a/src/librbd/operation/SnapshotCreateRequest.cc
+++ b/src/librbd/operation/SnapshotCreateRequest.cc
@@ -129,7 +129,7 @@ void SnapshotCreateRequest<I>::send_allocate_snap_id() {
   librados::AioCompletion *rados_completion = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_allocate_snap_id>(this);
-  image_ctx.md_ctx.aio_selfmanaged_snap_create(&m_snap_id, rados_completion);
+  image_ctx.data_ctx.aio_selfmanaged_snap_create(&m_snap_id, rados_completion);
   rados_completion->release();
 }
 
@@ -255,7 +255,7 @@ void SnapshotCreateRequest<I>::send_release_snap_id() {
   librados::AioCompletion *rados_completion = create_rados_callback<
     SnapshotCreateRequest<I>,
     &SnapshotCreateRequest<I>::handle_release_snap_id>(this);
-  image_ctx.md_ctx.aio_selfmanaged_snap_remove(m_snap_id, rados_completion);
+  image_ctx.data_ctx.aio_selfmanaged_snap_remove(m_snap_id, rados_completion);
   rados_completion->release();
 }
 

--- a/src/librbd/operation/SnapshotRemoveRequest.cc
+++ b/src/librbd/operation/SnapshotRemoveRequest.cc
@@ -205,7 +205,7 @@ void SnapshotRemoveRequest<I>::send_release_snap_id() {
 
   librados::AioCompletion *rados_completion =
     this->create_callback_completion();
-  image_ctx.md_ctx.aio_selfmanaged_snap_remove(m_snap_id, rados_completion);
+  image_ctx.data_ctx.aio_selfmanaged_snap_remove(m_snap_id, rados_completion);
   rados_completion->release();
 }
 

--- a/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotCreateRequest.cc
@@ -43,7 +43,7 @@ public:
   }
 
   void expect_allocate_snap_id(MockImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                selfmanaged_snap_create(_));
     if (r < 0 && r != -ESTALE) {
       expect.WillOnce(Return(r));
@@ -53,7 +53,7 @@ public:
   }
 
   void expect_release_snap_id(MockImageCtx &mock_image_ctx, int r) {
-    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    auto &expect = EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                selfmanaged_snap_remove(_));
     if (r < 0) {
       expect.WillOnce(Return(r));

--- a/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
+++ b/src/test/librbd/operation/test_mock_SnapshotRemoveRequest.cc
@@ -110,7 +110,7 @@ public:
   }
 
   void expect_release_snap_id(MockImageCtx &mock_image_ctx) {
-    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.md_ctx),
+    EXPECT_CALL(get_mock_io_ctx(mock_image_ctx.data_ctx),
                                 selfmanaged_snap_remove(_))
                                   .WillOnce(DoDefault());
   }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21567
Signed-off-by: Jason Dillaman <dillaman@redhat.com>