### PR TITLE
osd: make the PG's SORTBITWISE assert a more generous shutdown

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -5318,8 +5318,6 @@ void PG::on_new_interval()
     upacting_features &= osdmap->get_xinfo(*p).features;
   }
 
-  assert(osdmap->test_flag(CEPH_OSDMAP_SORTBITWISE));
-
   _on_new_interval();
 }
 


### PR DESCRIPTION
We want to stop working if we get activated while sortbitwise is not set
on the cluster, but we might have old maps where it wasn't if the flag
was changed recently. Instead, if SORTBITWISE is not set, further check
if the OSD is active and the map we are now looking at is newer than
when the OSD booted. Do a more polite shutdown with logged error message
instead of asserting.

Fixes: http://tracker.ceph.com/issues/20416

Signed-off-by: Greg Farnum <gfarnum@redhat.com>