### PR TITLE
make-dist,cmake: Try multiple URLs to download boost before failing

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -82,11 +82,20 @@ function(do_build_boost version)
   elseif(version VERSION_GREATER 1.63)
     message(FATAL_ERROR "Unknown BOOST_REQUESTED_VERSION: ${version}")
   else()
-    message(STATUS "boost will be downloaded from sf.net")
+    message(STATUS "boost will be downloaded...")
+    # NOTE: If you change this version number make sure the package is available
+    # at the three URLs below (may involve uploading to download.ceph.com)
     set(boost_version 1.63.0)
     set(boost_md5 1c837ecd990bb022d07e7aab32b09847)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
-    set(boost_url https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2)
+    set(boost_url 
+      https://dl.bintray.com/boostorg/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
+    if(CMAKE_VERSION VERSION_GREATER 3.7)
+      set(boost_url
+        "${boost_url} http://downloads.sourceforge.net/project/boost/boost/${boost_version}/boost_${boost_version_underscore}.tar.bz2")
+      set(boost_url
+        "${boost_url} https://download.ceph.com/qa/boost_${boost_version_underscore}.tar.bz2")
+    endif()
     set(source_dir
       URL ${boost_url}
       URL_MD5 ${boost_md5})

--- a/make-dist
+++ b/make-dist
@@ -22,19 +22,30 @@ fi
 
 download_boost() {
     boost_version=$1
-    boost_md5=$2
+    shift
+    boost_md5=$1
+    shift
     boost_version_underscore=$(echo $boost_version | sed 's/\./_/g')
     boost_fname=boost_${boost_version_underscore}.tar.bz2
-    echo "downloading boost_$boost_version..."
-    wget --no-verbose -O $boost_fname \
-         https://download.ceph.com/qa/$boost_fname
-    if [ $? != 0 -o ! -e $boost_fname ]; then
-        echo "Error: failed to download boost."
-        exit 1
-    elif [ $(md5sum $boost_fname | awk '{print $1}') != $boost_md5 ]; then
-        echo "Error: failed to download boost: MD5 mismatch."
-        exit 1
-    fi
+    set +e
+    while true; do
+        url_base=$1
+        shift
+        if [ -z $url_base ]; then
+            echo "Error: failed to download boost."
+            exit
+        fi
+        url=$url_base/$boost_fname
+        wget -c --no-verbose -O $boost_fname $url
+        if [ $? != 0 -o ! -e $boost_fname ]; then
+            echo "Download of $url failed"
+        elif [ $(md5sum $boost_fname | awk '{print $1}') != $boost_md5 ]; then
+            echo "Error: failed to download boost: MD5 mismatch."
+        else
+            break
+        fi
+    done
+    set -e
     tar xjf $boost_fname -C src
     mv src/boost_${boost_version_underscore} src/boost
     tar cf ${outfile}.boost.tar src/boost
@@ -70,7 +81,13 @@ else
 	rpm_release=0
 fi
 
-download_boost 1.63.0 1c837ecd990bb022d07e7aab32b09847
+# NOTE: If you change this version number make sure the package is available
+# at the three URLs referenced below (may involve uploading to download.ceph.com)
+boost_version=1.63.0
+download_boost $boost_version 1c837ecd990bb022d07e7aab32b09847 \
+               https://dl.bintray.com/boostorg/release/$boost_version/source \
+               https://downloads.sourceforge.net/project/boost/boost/$boost_version \
+               https://download.ceph.com/qa
 
 for spec in ceph.spec.in alpine/APKBUILD.in; do
     cat $spec |


### PR DESCRIPTION
Remove SPOF during boost download for make-dist and later cmake > 3.7

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>

The download URLs are in the order they are because, at least in my testing, dl.bintray.com is three to four times faster than the others. download.ceph.com is last because it should, IMHO, be the last resort as it is not an authoritative source. 