### PR TITLE
kv/KeyValueDB: add column family

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3447,6 +3447,10 @@ std::vector<Option> get_global_options() {
     .set_default("compression=kNoCompression,max_write_buffer_number=4,min_write_buffer_number_to_merge=1,recycle_log_file_num=4,write_buffer_size=268435456,writable_file_max_buffer_size=0,compaction_readahead_size=2097152")
     .set_description("Rocksdb options"),
 
+    Option("bluestore_rocksdb_cf", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("Enable use of rocksdb column families for bluestore metadata"),
+
     Option("bluestore_fsck_on_mount", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description("Run fsck at mount"),

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -15,6 +15,7 @@
 #include "common/perf_counters.h"
 
 using std::string;
+using std::vector;
 /**
  * Defines virtual interface to be implemented by key value store
  *
@@ -22,11 +23,23 @@ using std::string;
  */
 class KeyValueDB {
 public:
+  /*
+   *  See RocksDB's definition of a column family(CF) and how to use it.
+   *  The interfaces of KeyValueDB is extended, when a column family is created.
+   *  Prefix will be the name of column family to use.
+   */
+  struct ColumnFamily {
+    string name;      //< name of this individual column family
+    string option;    //< configure option string for this CF
+    ColumnFamily(const string &name, const string &option)
+      : name(name), option(option) {}
+  };
+
   class TransactionImpl {
   public:
     /// Set Keys
     void set(
-      const std::string &prefix,                 ///< [in] Prefix for keys
+      const std::string &prefix,                      ///< [in] Prefix for keys, or CF name
       const std::map<std::string, bufferlist> &to_set ///< [in] keys/values to set
     ) {
       std::map<std::string, bufferlist>::const_iterator it;
@@ -36,8 +49,8 @@ public:
 
     /// Set Keys (via encoded bufferlist)
     void set(
-      const std::string &prefix,      ///< [in] prefix
-      bufferlist& to_set_bl     ///< [in] encoded key/values to set
+      const std::string &prefix,      ///< [in] prefix, or CF name
+      bufferlist& to_set_bl           ///< [in] encoded key/values to set
       ) {
       bufferlist::iterator p = to_set_bl.begin();
       uint32_t num;
@@ -53,9 +66,9 @@ public:
 
     /// Set Key
     virtual void set(
-      const std::string &prefix,   ///< [in] Prefix for the key
+      const std::string &prefix,      ///< [in] Prefix or CF for the key
       const std::string &k,	      ///< [in] Key to set
-      const bufferlist &bl    ///< [in] Value to set
+      const bufferlist &bl            ///< [in] Value to set
       ) = 0;
     virtual void set(
       const std::string &prefix,
@@ -67,8 +80,8 @@ public:
 
     /// Removes Keys (via encoded bufferlist)
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      bufferlist &keys_bl ///< [in] Keys to remove
+      const std::string &prefix,     ///< [in] Prefix or CF to search for
+      bufferlist &keys_bl            ///< [in] Keys to remove
     ) {
       bufferlist::iterator p = keys_bl.begin();
       uint32_t num;
@@ -82,7 +95,7 @@ public:
 
     /// Removes Keys
     void rmkeys(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,        ///< [in] Prefix/CF to search for
       const std::set<std::string> &keys ///< [in] Keys to remove
     ) {
       std::set<std::string>::const_iterator it;
@@ -92,8 +105,8 @@ public:
 
     /// Remove Key
     virtual void rmkey(
-      const std::string &prefix,   ///< [in] Prefix to search for
-      const std::string &k	      ///< [in] Key to remove
+      const std::string &prefix,       ///< [in] Prefix/CF to search for
+      const std::string &k	       ///< [in] Key to remove
       ) = 0;
     virtual void rmkey(
       const std::string &prefix,   ///< [in] Prefix to search for
@@ -109,13 +122,13 @@ public:
     /// If a key is overwritten (by calling set multiple times), then the result
     /// of calling rm_single_key on this key is undefined.
     virtual void rm_single_key(
-      const std::string &prefix,   ///< [in] Prefix to search for
+      const std::string &prefix,      ///< [in] Prefix/CF to search for
       const std::string &k	      ///< [in] Key to remove
       ) { return rmkey(prefix, k);}
 
     /// Removes keys beginning with prefix
     virtual void rmkeys_by_prefix(
-      const std::string &prefix ///< [in] Prefix by which to remove keys
+      const std::string &prefix       ///< [in] Prefix/CF by which to remove keys
       ) = 0;
 
     virtual void rm_range_keys(
@@ -126,7 +139,7 @@ public:
 
     /// Merge value into key
     virtual void merge(
-      const std::string &prefix,   ///< [in] Prefix ==> MUST match some established merge operator
+      const std::string &prefix,   ///< [in] Prefix/CF ==> MUST match some established merge operator
       const std::string &key,      ///< [in] Key to be merged
       const bufferlist  &value     ///< [in] value to be merged into key
     ) { assert(0 == "Not implemented"); }
@@ -144,8 +157,16 @@ public:
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
   virtual int open(std::ostream &out) = 0;
+  virtual int open(std::ostream &out, const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented");
+  }
   virtual int create_and_open(std::ostream &out) = 0;
   virtual void close() { }
+  // vector cfs contains column families to be created when db is created.
+  virtual int create_and_open(std::ostream &out,
+			      const vector<ColumnFamily>& cfs) {
+    assert(0 == "Not implemented");
+  }
 
   virtual Transaction get_transaction() = 0;
   virtual int submit_transaction(Transaction) = 0;
@@ -155,13 +176,13 @@ public:
 
   /// Retrieve Keys
   virtual int get(
-    const std::string &prefix,        ///< [in] Prefix for key
-    const std::set<std::string> &key,      ///< [in] Key to retrieve
-    std::map<std::string, bufferlist> *out ///< [out] Key value retrieved
+    const std::string &prefix,               ///< [in] Prefix/CF for key
+    const std::set<std::string> &key,        ///< [in] Key to retrieve
+    std::map<std::string, bufferlist> *out   ///< [out] Key value retrieved
     ) = 0;
-  virtual int get(const std::string &prefix, ///< [in] prefix
+  virtual int get(const std::string &prefix, ///< [in] prefix or CF name
 		  const std::string &key,    ///< [in] key
-		  bufferlist *value) {  ///< [out] value
+		  bufferlist *value) {       ///< [out] value
     std::set<std::string> ks;
     ks.insert(key);
     std::map<std::string,bufferlist> om;
@@ -323,6 +344,14 @@ public:
       get_wholespace_iterator());
   }
 
+  void add_column_family(const std::string& cf_name, void *handle) {
+    cf_handles.insert(std::make_pair(cf_name, handle));
+  }
+
+  bool is_column_family(const std::string& prefix) {
+    return cf_handles.count(prefix);
+  }
+
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
   virtual int get_statfs(struct store_statfs_t *buf) {
     return -EOPNOTSUPP;
@@ -384,9 +413,12 @@ public:
     return nullptr;
   }
 protected:
-  /// List of matching prefixes and merge operators
+  /// List of matching prefixes/ColumnFamilies and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
+
+  /// column families in use, name->handle
+  std::unordered_map<std::string, void *> cf_handles;
 };
 
 #endif

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -180,7 +180,10 @@ public:
     return get(prefix, string(key, keylen), value);
   }
 
-  class GenericIteratorImpl {
+  // This superclass is used both by kv iterators *and* by the ObjectMap
+  // omap iterator.  The class hiearchies are unfortunatley tied together
+  // by the legacy DBOjectMap implementation :(.
+  class SimplestIteratorImpl {
   public:
     virtual int seek_to_first() = 0;
     virtual int upper_bound(const std::string &after) = 0;
@@ -190,6 +193,11 @@ public:
     virtual std::string key() = 0;
     virtual bufferlist value() = 0;
     virtual int status() = 0;
+    virtual ~SimplestIteratorImpl() {}
+  };
+
+  class GenericIteratorImpl : public SimplestIteratorImpl {
+  public:
     virtual ~GenericIteratorImpl() {}
   };
 

--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -316,12 +316,11 @@ private:
   };
 public:
 
-  WholeSpaceIterator get_iterator() {
-    return _get_iterator();
-  }
-
-  Iterator get_iterator(const std::string &prefix) {
-    return std::make_shared<PrefixIteratorImpl>(prefix, get_iterator());
+  virtual WholeSpaceIterator get_wholespace_iterator() = 0;
+  virtual Iterator get_iterator(const std::string &prefix) {
+    return std::make_shared<PrefixIteratorImpl>(
+      prefix,
+      get_wholespace_iterator());
   }
 
   virtual uint64_t get_estimated_size(std::map<std::string,uint64_t> &extra) = 0;
@@ -388,8 +387,6 @@ protected:
   /// List of matching prefixes and merge operators
   std::vector<std::pair<std::string,
 			std::shared_ptr<MergeOperator> > > merge_ops;
-
-  virtual WholeSpaceIterator _get_iterator() = 0;
 };
 
 #endif

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -56,7 +56,7 @@ public:
     return do_open(out, false);
   }
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) {
+  int create_and_open(ostream &out) override {
     return do_open(out, true);
   }
 

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -149,8 +149,7 @@ public:
   }
 
 
-protected:
-  WholeSpaceIterator _get_iterator() {
+  WholeSpaceIterator get_wholespace_iterator() {
     return std::make_shared<KineticWholeSpaceIteratorImpl>(kinetic_conn.get());
   }
 };

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -402,8 +402,7 @@ err:
   }
 
 
-protected:
-  WholeSpaceIterator _get_iterator() override {
+  WholeSpaceIterator get_wholespace_iterator() override {
     return std::make_shared<LevelDBWholeSpaceIteratorImpl>(
 	db->NewIterator(leveldb::ReadOptions()));
   }

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -201,9 +201,7 @@ public:
     return 0;
   }
 
-protected:
-
-  WholeSpaceIterator _get_iterator() override {
+  WholeSpaceIterator get_wholespace_iterator() override {
     return std::shared_ptr<KeyValueDB::WholeSpaceIteratorImpl>(
       new MDBWholeSpaceIteratorImpl(&m_map, &m_lock, &iterator_seq_no, m_using_btree));
   }

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -1005,7 +1005,7 @@ string RocksDBStore::past_prefix(const string &prefix)
   return limit;
 }
 
-RocksDBStore::WholeSpaceIterator RocksDBStore::_get_iterator()
+RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator()
 {
   return std::make_shared<RocksDBWholeSpaceIteratorImpl>(
         db->NewIterator(rocksdb::ReadOptions()));

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -34,6 +34,12 @@ using std::string;
 #undef dout_prefix
 #define dout_prefix *_dout << "rocksdb: "
 
+static bufferlist to_bufferlist(rocksdb::Slice in) {
+  bufferlist bl;
+  bl.append(bufferptr(in.data(), in.size()));
+  return bl;
+}
+
 static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
 					      vector<rocksdb::Slice> *slices)
 {

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -53,10 +53,14 @@ static rocksdb::SliceParts prepare_sliceparts(const bufferlist &bl,
 }
 
 //
-// One of these per rocksdb instance, implements the merge operator prefix stuff
+// One of these per rocksdb column family(includes the default CF),
+// implements the merge operator prefix stuff
 //
 class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperator {
   RocksDBStore& store;
+  //name of the column family associated with this merge operator
+  //only for explicit CF, not for the default CF
+  std::string cf_name;
   public:
   const char *Name() const override {
     // Construct a name that rocksDB will validate against. We want to
@@ -65,7 +69,19 @@ class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperat
     // construct a name from all of those parts.
     store.assoc_name.clear();
     map<std::string,std::string> names;
-    for (auto& p : store.merge_ops) names[p.first] = p.second->name();
+    if (cf_name.empty()) {
+      //for default column family
+      for (auto& p : store.merge_ops) names[p.first] = p.second->name();
+      for (auto& p : store.cf_handles) names.erase(p.first);
+    } else {
+      //for user created explicit column family
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(cf_name) == 0) {
+	  names[cf_name] = p.second->name();
+	  break;
+	}
+      }
+    }
     for (auto& p : names) {
       store.assoc_name += '.';
       store.assoc_name += p.first;
@@ -75,31 +91,53 @@ class RocksDBStore::MergeOperatorRouter : public rocksdb::AssociativeMergeOperat
     return store.assoc_name.c_str();
   }
 
+  //for default column family
   MergeOperatorRouter(RocksDBStore &_store) : store(_store) {}
+  //for user created explicit CF
+  MergeOperatorRouter(RocksDBStore &_store, const std::string &cf)
+    : store(_store), cf_name(cf) {}
 
   bool Merge(const rocksdb::Slice& key,
                      const rocksdb::Slice* existing_value,
                      const rocksdb::Slice& value,
                      std::string* new_value,
                      rocksdb::Logger* logger) const override {
-    // Check each prefix
-    for (auto& p : store.merge_ops) {
-      if (p.first.compare(0, p.first.length(),
-			  key.data(), p.first.length()) == 0 &&
-	  key.data()[p.first.length()] == 0) {
-        if (existing_value) {
-          p.second->merge(existing_value->data(), existing_value->size(),
-			  value.data(), value.size(),
-			  new_value);
-        } else {
-          p.second->merge_nonexistent(value.data(), value.size(), new_value);
-        }
-        break;
+    if (cf_name.empty()) {
+      // for default column family
+      // extract prefix from key and compare against each registered merge op;
+      // even though merge operator for explicit CF is included in merge_ops,
+      // it won't be picked up, since it won't match.
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(0, p.first.length(),
+			    key.data(), p.first.length()) == 0 &&
+	    key.data()[p.first.length()] == 0) {
+	  if (existing_value) {
+	    p.second->merge(existing_value->data(), existing_value->size(),
+			    value.data(), value.size(),
+			    new_value);
+	  } else {
+	    p.second->merge_nonexistent(value.data(), value.size(), new_value);
+	  }
+	  break;
+	}
+      }
+    } else {
+      //for user created explicit column family
+      for (auto& p : store.merge_ops) {
+	if (p.first.compare(cf_name) == 0) {
+	  if (existing_value) {
+	    p.second->merge(existing_value->data(), existing_value->size(),
+			    value.data(), value.size(),
+			    new_value);
+	  } else {
+	    p.second->merge_nonexistent(value.data(), value.size(), new_value);
+	  }
+	  break;
+	}
       }
     }
     return true; // OK :)
   }
-
 };
 
 int RocksDBStore::set_merge_operator(
@@ -233,7 +271,7 @@ int RocksDBStore::init(string _options_str)
   return 0;
 }
 
-int RocksDBStore::create_and_open(ostream &out)
+int RocksDBStore::create_db_dir()
 {
   if (env) {
     unique_ptr<rocksdb::Directory> dir;
@@ -248,10 +286,45 @@ int RocksDBStore::create_and_open(ostream &out)
       return r;
     }
   }
+  return 0;
+}
+
+int RocksDBStore::install_cf_mergeop(const string &cf_name,
+				  rocksdb::ColumnFamilyOptions *cf_opt)
+{
+  assert(cf_opt != nullptr);
+  bool found_mop = false;
+  for (auto &mop : merge_ops) {
+    if (mop.first.compare(cf_name) == 0) {
+      cf_opt->merge_operator.reset(new MergeOperatorRouter(*this, cf_name));
+      found_mop = true;
+      break;
+    }
+  }
+  if (!found_mop)
+      cf_opt->merge_operator.reset();
+  return 0;
+}
+
+int RocksDBStore::create_and_open(ostream &out)
+{
+  int r = create_db_dir();
+  if (r < 0)
+    return r;
   return do_open(out, true);
 }
 
-int RocksDBStore::do_open(ostream &out, bool create_if_missing)
+int RocksDBStore::create_and_open(ostream &out,
+				  const vector<ColumnFamily>& cfs)
+{
+  int r = create_db_dir();
+  if (r < 0)
+    return r;
+  return do_open(out, true, &cfs);
+}
+
+int RocksDBStore::do_open(ostream &out, bool create_if_missing,
+			  const vector<ColumnFamily>* cfs)
 {
   rocksdb::Options opt;
   rocksdb::Status status;
@@ -368,10 +441,97 @@ int RocksDBStore::do_open(ostream &out, bool create_if_missing)
 	   << dendl;
 
   opt.merge_operator.reset(new MergeOperatorRouter(*this));
-  status = rocksdb::DB::Open(opt, path, &db);
-  if (!status.ok()) {
-    derr << status.ToString() << dendl;
-    return -EINVAL;
+  if (create_if_missing) {
+    status = rocksdb::DB::Open(opt, path, &db);
+    if (!status.ok()) {
+      derr << status.ToString() << dendl;
+      return -EINVAL;
+    }
+    // create and open column families
+    if (cfs) {
+      for (auto& p : *cfs) {
+	// copy default CF settings, block cache, merge operators as
+	// the base for new CF
+	rocksdb::ColumnFamilyOptions cf_opt(opt);
+	// user input options will override the base options
+	status = rocksdb::GetColumnFamilyOptionsFromString(
+	  cf_opt, p.option, &cf_opt);
+	if (!status.ok()) {
+	  derr << __func__ << " invalid db column family option string for CF: "
+	       << p.name << dendl;
+	  return -EINVAL;
+	}
+	install_cf_mergeop(p.name, &cf_opt);
+	rocksdb::ColumnFamilyHandle *cf;
+	status = db->CreateColumnFamily(cf_opt, p.name, &cf);
+	if (!status.ok()) {
+	  derr << __func__ << " Failed to create rocksdb column family: "
+	       << p.name << dendl;
+	  return -EINVAL;
+	}
+	// store the new CF handle
+	add_column_family(p.name, static_cast<void*>(cf));
+      }
+    }
+  } else {
+    std::vector<string> existing_cfs;
+    status = rocksdb::DB::ListColumnFamilies(
+      rocksdb::DBOptions(opt),
+      path,
+      &existing_cfs);
+    dout(1) << __func__ << " column families: " << existing_cfs << dendl;
+    if (existing_cfs.empty()) {
+      // no column families
+      status = rocksdb::DB::Open(opt, path, &db);
+      if (!status.ok()) {
+	derr << status.ToString() << dendl;
+	return -EINVAL;
+      }
+    } else {
+      // we cannot change column families for a created database.  so, map
+      // what options we are given to whatever cf's already exist.
+      std::vector<rocksdb::ColumnFamilyDescriptor> column_families;
+      for (auto& n : existing_cfs) {
+	// copy default CF settings, block cache, merge operators as
+	// the base for new CF
+	rocksdb::ColumnFamilyOptions cf_opt(opt);
+	bool found = false;
+	if (cfs) {
+	  for (auto& i : *cfs) {
+	    if (i.name == n) {
+	      found = true;
+	      status = rocksdb::GetColumnFamilyOptionsFromString(
+		cf_opt, i.option, &cf_opt);
+	      if (!status.ok()) {
+		derr << __func__ << " invalid db column family options for CF '"
+		     << i.name << "': " << i.option << dendl;
+		return -EINVAL;
+	      }
+	    }
+	  }
+	}
+	if (n != rocksdb::kDefaultColumnFamilyName) {
+	  install_cf_mergeop(n, &cf_opt);
+	}
+	column_families.push_back(rocksdb::ColumnFamilyDescriptor(n, cf_opt));
+	if (!found && n != rocksdb::kDefaultColumnFamilyName) {
+	  dout(1) << __func__ << " column family '" << n
+		  << "' exists but not expected" << dendl;
+	}
+      }
+      std::vector<rocksdb::ColumnFamilyHandle*> handles;
+      status = rocksdb::DB::Open(rocksdb::DBOptions(opt),
+				 path, column_families, &handles, &db);
+      if (!status.ok()) {
+	derr << status.ToString() << dendl;
+	return -EINVAL;
+      }
+      for (unsigned i = 0; i < existing_cfs.size(); ++i) {
+	if (existing_cfs[i] != rocksdb::kDefaultColumnFamilyName) {
+	  add_column_family(existing_cfs[i], static_cast<void*>(handles[i]));
+	}
+      }
+    }
   }
   
   PerfCountersBuilder plb(g_ceph_context, "rocksdb", l_rocksdb_first, l_rocksdb_last);
@@ -418,6 +578,11 @@ RocksDBStore::~RocksDBStore()
   delete logger;
 
   // Ensure db is destroyed before dependent db_cache and filterpolicy
+  for (auto& p : cf_handles) {
+    db->DestroyColumnFamilyHandle(
+      static_cast<rocksdb::ColumnFamilyHandle*>(p.second));
+    p.second = nullptr;
+  }
   delete db;
   db = nullptr;
 
@@ -586,20 +751,23 @@ RocksDBStore::RocksDBTransactionImpl::RocksDBTransactionImpl(RocksDBStore *_db)
   db = _db;
 }
 
-static void put_bat(
-  rocksdb::WriteBatch& bat, 
-  const string &key, 
+void RocksDBStore::RocksDBTransactionImpl::put_bat(
+  rocksdb::WriteBatch& bat,
+  rocksdb::ColumnFamilyHandle *cf,
+  const string &key,
   const bufferlist &to_set_bl)
 {
   // bufferlist::c_str() is non-constant, so we can't call c_str()
   if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
-    bat.Put(rocksdb::Slice(key),
-	     rocksdb::Slice(to_set_bl.buffers().front().c_str(),
-			    to_set_bl.length()));
+    bat.Put(cf,
+	    rocksdb::Slice(key),
+	    rocksdb::Slice(to_set_bl.buffers().front().c_str(),
+			   to_set_bl.length()));
   } else {
     rocksdb::Slice key_slice(key);
     vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
-    bat.Put(nullptr, rocksdb::SliceParts(&key_slice, 1),
+    bat.Put(cf,
+	    rocksdb::SliceParts(&key_slice, 1),
             prepare_sliceparts(to_set_bl, &value_slices));
   }
 }
@@ -609,9 +777,13 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  string key = combine_strings(prefix, k);
-
-  put_bat(bat, key, to_set_bl);
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    put_bat(bat, cf, k, to_set_bl);
+  } else {
+    string key = combine_strings(prefix, k);
+    put_bat(bat, db->db->DefaultColumnFamily(), key, to_set_bl);
+  }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::set(
@@ -619,46 +791,81 @@ void RocksDBStore::RocksDBTransactionImpl::set(
   const char *k, size_t keylen,
   const bufferlist &to_set_bl)
 {
-  string key;
-  combine_strings(prefix, k, keylen, &key);
-
-  put_bat(bat, key, to_set_bl);
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    string key(k, keylen);  // fixme?
+    put_bat(bat, cf, key, to_set_bl);
+  } else {
+    string key;
+    combine_strings(prefix, k, keylen, &key);
+    put_bat(bat, cf, key, to_set_bl);
+  }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const string &k)
 {
-  bat.Delete(combine_strings(prefix, k));
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    bat.Delete(cf, rocksdb::Slice(k));
+  } else {
+    bat.Delete(combine_strings(prefix, k));
+  }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkey(const string &prefix,
 					         const char *k,
 						 size_t keylen)
 {
-  string key;
-  combine_strings(prefix, k, keylen, &key);
-  bat.Delete(key);
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    bat.Delete(cf, rocksdb::Slice(k, keylen));
+  } else {
+    string key;
+    combine_strings(prefix, k, keylen, &key);
+    bat.Delete(rocksdb::Slice(key));
+  }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rm_single_key(const string &prefix,
 					                 const string &k)
 {
-  bat.SingleDelete(combine_strings(prefix, k));
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    bat.SingleDelete(cf, k);
+  } else {
+    bat.SingleDelete(combine_strings(prefix, k));
+  }
 }
 
 void RocksDBStore::RocksDBTransactionImpl::rmkeys_by_prefix(const string &prefix)
 {
-  if (db->enable_rmrange) {
-    string endprefix = prefix;
-    endprefix.push_back('\x01');
-    bat.DeleteRange(combine_strings(prefix, string()),
-		    combine_strings(endprefix, string()));
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    if (db->enable_rmrange) {
+      string endprefix("\xff\xff\xff\xff");  // FIXME: this is cheating...
+      bat.DeleteRange(cf, string(), endprefix);
+    } else {
+      auto it = db->get_iterator(prefix);
+      for (it->seek_to_first();
+	   it->valid();
+	   it->next()) {
+	bat.Delete(cf, rocksdb::Slice(it->key()));
+      }
+    }
   } else {
-    KeyValueDB::Iterator it = db->get_iterator(prefix);
-    for (it->seek_to_first();
-	 it->valid();
-	 it->next()) {
-      bat.Delete(combine_strings(prefix, it->key()));
+    if (db->enable_rmrange) {
+      string endprefix = prefix;
+      endprefix.push_back('\x01');
+      bat.DeleteRange(combine_strings(prefix, string()),
+		      combine_strings(endprefix, string()));
+    } else {
+      auto it = db->get_iterator(prefix);
+      for (it->seek_to_first();
+	   it->valid();
+	   it->next()) {
+	bat.Delete(combine_strings(prefix, it->key()));
+      }
     }
   }
 }
@@ -667,17 +874,37 @@ void RocksDBStore::RocksDBTransactionImpl::rm_range_keys(const string &prefix,
                                                          const string &start,
                                                          const string &end)
 {
-  if (db->enable_rmrange) {
-    bat.DeleteRange(combine_strings(prefix, start), combine_strings(prefix, end));
-  } else {
-    auto it = db->get_iterator(prefix);
-    it->lower_bound(start);
-    while (it->valid()) {
-      if (it->key() >= end) {
-        break;
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    if (db->enable_rmrange) {
+      bat.DeleteRange(cf, rocksdb::Slice(start), rocksdb::Slice(end));
+    } else {
+      auto it = db->get_iterator(prefix);
+      it->lower_bound(start);
+      while (it->valid()) {
+	if (it->key() >= end) {
+	  break;
+	}
+	bat.Delete(cf, rocksdb::Slice(it->key()));
+	it->next();
       }
-      bat.Delete(combine_strings(prefix, it->key()));
-      it->next();
+    }
+  } else {
+    if (db->enable_rmrange) {
+      bat.DeleteRange(
+	db->db->DefaultColumnFamily(),
+	rocksdb::Slice(combine_strings(prefix, start)),
+	rocksdb::Slice(combine_strings(prefix, end)));
+    } else {
+      auto it = db->get_iterator(prefix);
+      it->lower_bound(start);
+      while (it->valid()) {
+	if (it->key() >= end) {
+	  break;
+	}
+	bat.Delete(combine_strings(prefix, it->key()));
+	it->next();
+      }
     }
   }
 }
@@ -687,40 +914,75 @@ void RocksDBStore::RocksDBTransactionImpl::merge(
   const string &k,
   const bufferlist &to_set_bl)
 {
-  string key = combine_strings(prefix, k);
-
-  // bufferlist::c_str() is non-constant, so we can't call c_str()
-  if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
-    bat.Merge(rocksdb::Slice(key),
-	       rocksdb::Slice(to_set_bl.buffers().front().c_str(),
-			    to_set_bl.length()));
+  auto cf = db->get_cf_handle(prefix);
+  if (cf) {
+    // bufferlist::c_str() is non-constant, so we can't call c_str()
+    if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
+      bat.Merge(
+	cf,
+	rocksdb::Slice(k),
+	rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
+    } else {
+      // make a copy
+      rocksdb::Slice key_slice(k);
+      vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
+      bat.Merge(cf, rocksdb::SliceParts(&key_slice, 1),
+		prepare_sliceparts(to_set_bl, &value_slices));
+    }
   } else {
-    // make a copy
-    rocksdb::Slice key_slice(key);
-    vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
-    bat.Merge(nullptr, rocksdb::SliceParts(&key_slice, 1),
-              prepare_sliceparts(to_set_bl, &value_slices));
+    string key = combine_strings(prefix, k);
+    // bufferlist::c_str() is non-constant, so we can't call c_str()
+    if (to_set_bl.is_contiguous() && to_set_bl.length() > 0) {
+      bat.Merge(
+	db->db->DefaultColumnFamily(),
+	rocksdb::Slice(key),
+	rocksdb::Slice(to_set_bl.buffers().front().c_str(), to_set_bl.length()));
+    } else {
+      // make a copy
+      rocksdb::Slice key_slice(key);
+      vector<rocksdb::Slice> value_slices(to_set_bl.buffers().size());
+      bat.Merge(
+	db->db->DefaultColumnFamily(),
+	rocksdb::SliceParts(&key_slice, 1),
+	prepare_sliceparts(to_set_bl, &value_slices));
+    }
   }
 }
 
-//gets will bypass RocksDB row cache, since it uses iterator
 int RocksDBStore::get(
     const string &prefix,
     const std::set<string> &keys,
     std::map<string, bufferlist> *out)
 {
   utime_t start = ceph_clock_now();
-  for (std::set<string>::const_iterator i = keys.begin();
-       i != keys.end(); ++i) {
-    std::string value;
-    std::string bound = combine_strings(prefix, *i);
-    auto status = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(bound), &value);
-    if (status.ok()) {
-      (*out)[*i].append(value);
-    } else if (status.IsIOError()) {
-      ceph_abort_msg(cct, status.ToString());
+  auto cf = get_cf_handle(prefix);
+  if (cf) {
+    for (auto& key : keys) {
+      std::string value;
+      auto status = db->Get(rocksdb::ReadOptions(),
+			    cf,
+			    rocksdb::Slice(key),
+			    &value);
+      if (status.ok()) {
+	(*out)[key].append(value);
+      } else if (status.IsIOError()) {
+	ceph_abort_msg(cct, status.ToString());
+      }
     }
-
+  } else {
+    for (auto& key : keys) {
+      std::string value;
+      string k = combine_strings(prefix, key);
+      auto status = db->Get(rocksdb::ReadOptions(),
+			    db->DefaultColumnFamily(),
+			    rocksdb::Slice(k),
+			    &value);
+      if (status.ok()) {
+	(*out)[key].append(value);
+      } else if (status.IsIOError()) {
+	ceph_abort_msg(cct, status.ToString());
+      }
+    }
   }
   utime_t lat = ceph_clock_now() - start;
   logger->inc(l_rocksdb_gets);
@@ -736,10 +998,21 @@ int RocksDBStore::get(
   assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now();
   int r = 0;
-  string value, k;
+  string value;
   rocksdb::Status s;
-  k = combine_strings(prefix, key);
-  s = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(k), &value);
+  auto cf = get_cf_handle(prefix);
+  if (cf) {
+    s = db->Get(rocksdb::ReadOptions(),
+		cf,
+		rocksdb::Slice(key),
+		&value);
+  } else {
+    string k = combine_strings(prefix, key);
+    s = db->Get(rocksdb::ReadOptions(),
+		db->DefaultColumnFamily(),
+		rocksdb::Slice(k),
+		&value);
+  }
   if (s.ok()) {
     out->append(value);
   } else if (s.IsNotFound()) {
@@ -762,10 +1035,22 @@ int RocksDBStore::get(
   assert(out && (out->length() == 0));
   utime_t start = ceph_clock_now();
   int r = 0;
-  string value, k;
-  combine_strings(prefix, key, keylen, &k);
+  string value;
   rocksdb::Status s;
-  s = db->Get(rocksdb::ReadOptions(), rocksdb::Slice(k), &value);
+  auto cf = get_cf_handle(prefix);
+  if (cf) {
+    s = db->Get(rocksdb::ReadOptions(),
+		cf,
+		rocksdb::Slice(key, keylen),
+		&value);
+  } else {
+    string k;
+    combine_strings(prefix, key, keylen, &k);
+    s = db->Get(rocksdb::ReadOptions(),
+		db->DefaultColumnFamily(),
+		rocksdb::Slice(k),
+		&value);
+  }
   if (s.ok()) {
     out->append(value);
   } else if (s.IsNotFound()) {
@@ -882,6 +1167,7 @@ void RocksDBStore::compact_range(const string& start, const string& end)
   rocksdb::Slice cend(end);
   db->CompactRange(options, &cstart, &cend);
 }
+
 RocksDBStore::RocksDBWholeSpaceIteratorImpl::~RocksDBWholeSpaceIteratorImpl()
 {
   delete dbiter;
@@ -1017,3 +1303,80 @@ RocksDBStore::WholeSpaceIterator RocksDBStore::get_wholespace_iterator()
         db->NewIterator(rocksdb::ReadOptions()));
 }
 
+class CFIteratorImpl : public KeyValueDB::IteratorImpl {
+protected:
+  string prefix;
+  rocksdb::Iterator *dbiter;
+public:
+  explicit CFIteratorImpl(const std::string& p,
+				 rocksdb::Iterator *iter)
+    : prefix(p), dbiter(iter) { }
+  ~CFIteratorImpl() {
+    delete dbiter;
+  }
+
+  int seek_to_first() override {
+    dbiter->SeekToFirst();
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int seek_to_last() override {
+    dbiter->SeekToLast();
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int upper_bound(const string &after) override {
+    lower_bound(after);
+    if (valid() && (key() == after)) {
+      next();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int lower_bound(const string &to) override {
+    rocksdb::Slice slice_bound(to);
+    dbiter->Seek(slice_bound);
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int next(bool validate=true) {
+    if (valid()) {
+      dbiter->Next();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  int prev(bool validate=true) {
+    if (valid()) {
+      dbiter->Prev();
+    }
+    return dbiter->status().ok() ? 0 : -1;
+  }
+  bool valid() override {
+    return dbiter->Valid();
+  }
+  string key() override {
+    return dbiter->key().ToString();
+  }
+  std::pair<std::string, std::string> raw_key() {
+    return make_pair(prefix, key());
+  }
+  bufferlist value() override {
+    return to_bufferlist(dbiter->value());
+  }
+  bufferptr value_as_ptr() override {
+    rocksdb::Slice val = dbiter->value();
+    return bufferptr(val.data(), val.size());
+  }
+  int status() override {
+    return dbiter->status().ok() ? 0 : -1;
+  }
+};
+
+KeyValueDB::Iterator RocksDBStore::get_iterator(const std::string& prefix)
+{
+  rocksdb::ColumnFamilyHandle *cf_handle =
+    static_cast<rocksdb::ColumnFamilyHandle*>(get_cf_handle(prefix));
+  if (cf_handle) {
+    return std::make_shared<CFIteratorImpl>(
+      prefix,
+      db->NewIterator(rocksdb::ReadOptions(), cf_handle));
+  } else {
+    return KeyValueDB::get_iterator(prefix);
+  }
+}

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -394,9 +394,11 @@ public:
   static string past_prefix(const string &prefix);
 
   class MergeOperatorRouter;
+  class MergeOperatorLinker;
   friend class MergeOperatorRouter;
-  int set_merge_operator(const std::string& prefix,
-				 std::shared_ptr<KeyValueDB::MergeOperator> mop) override;
+  int set_merge_operator(
+    const std::string& prefix,
+    std::shared_ptr<KeyValueDB::MergeOperator> mop) override;
   string assoc_name; ///< Name of associative operator
 
   uint64_t get_estimated_size(map<string,uint64_t> &extra) override {

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -81,6 +81,9 @@ class RocksDBStore : public KeyValueDB {
   uint64_t cache_size = 0;
   bool set_cache_flag = false;
 
+  bool must_close_default_cf = false;
+  rocksdb::ColumnFamilyHandle *default_cf = nullptr;
+
   int submit_common(rocksdb::WriteOptions& woptions, KeyValueDB::Transaction t);
   int install_cf_mergeop(const string &cf_name, rocksdb::ColumnFamilyOptions *cf_opt);
   int create_db_dir();

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -450,8 +450,7 @@ err:
     return 0;
   }
 
-protected:
-  WholeSpaceIterator _get_iterator() override;
+  WholeSpaceIterator get_wholespace_iterator() override;
 };
 
 

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -364,12 +364,6 @@ public:
 
   static int split_key(rocksdb::Slice in, string *prefix, string *key);
 
-  static bufferlist to_bufferlist(rocksdb::Slice in) {
-    bufferlist bl;
-    bl.append(bufferptr(in.data(), in.size()));
-    return bl;
-  }
-
   static string past_prefix(const string &prefix);
 
   class MergeOperatorRouter;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -484,7 +484,7 @@ class MonitorDBStore
   Synchronizer get_synchronizer(pair<string,string> &key,
 				set<string> &prefixes) {
     KeyValueDB::WholeSpaceIterator iter;
-    iter = db->get_iterator();
+    iter = db->get_wholespace_iterator();
 
     if (!key.first.empty() && !key.second.empty())
       iter->upper_bound(key.first, key.second);
@@ -505,7 +505,7 @@ class MonitorDBStore
 
   KeyValueDB::WholeSpaceIterator get_iterator() {
     KeyValueDB::WholeSpaceIterator iter;
-    iter = db->get_iterator();
+    iter = db->get_wholespace_iterator();
     iter->seek_to_first();
     return iter;
   }

--- a/src/os/ObjectMap.h
+++ b/src/os/ObjectMap.h
@@ -156,7 +156,7 @@ public:
 
   virtual void compact() {}
 
-  typedef KeyValueDB::GenericIteratorImpl ObjectMapIteratorImpl;
+  typedef KeyValueDB::SimplestIteratorImpl ObjectMapIteratorImpl;
   typedef ceph::shared_ptr<ObjectMapIteratorImpl> ObjectMapIterator;
   virtual ObjectMapIterator get_iterator(const ghobject_t &oid) {
     return ObjectMapIterator();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -65,6 +65,7 @@ const string PREFIX_OBJ = "O";     // object name -> onode_t
 const string PREFIX_OMAP = "M";    // u64 + keyname -> value
 const string PREFIX_DEFERRED = "L";  // id -> deferred_transaction_t
 const string PREFIX_ALLOC = "B";   // u64 offset -> u64 length (freelist)
+const string PREFIX_ALLOC_BITMAP = "b"; // (see BitmapFreelistManager)
 const string PREFIX_SHARED_BLOB = "X"; // u64 offset -> shared_blob_t
 
 // write a label in the first block.  always use this size.  note that
@@ -11550,7 +11551,7 @@ void BlueStore::generate_db_histogram(Formatter *f)
     } else if (key.first == PREFIX_DEFERRED) {
 	hist.update_hist_entry(hist.key_hist, PREFIX_DEFERRED, key_size, value_size);
 	num_deferred++;
-    } else if (key.first == PREFIX_ALLOC || key.first == "b" ) {
+    } else if (key.first == PREFIX_ALLOC || key.first == PREFIX_ALLOC_BITMAP) {
 	hist.update_hist_entry(hist.key_hist, PREFIX_ALLOC, key_size, value_size);
 	num_alloc++;
     } else if (key.first == PREFIX_SHARED_BLOB) {

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -11513,7 +11513,7 @@ void BlueStore::generate_db_histogram(Formatter *f)
 
   utime_t start = ceph_clock_now();
 
-  KeyValueDB::WholeSpaceIterator iter = db->get_iterator();
+  KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
   iter->seek_to_first();
   while (iter->valid()) {
     dout(30) << __func__ << " Key: " << iter->key() << dendl;

--- a/src/test/ObjectMap/KeyValueDBMemory.cc
+++ b/src/test/ObjectMap/KeyValueDBMemory.cc
@@ -235,7 +235,7 @@ int KeyValueDBMemory::rm_range_keys(const string &prefix, const string &start, c
   return 0;
 }
 
-KeyValueDB::WholeSpaceIterator KeyValueDBMemory::_get_iterator() {
+KeyValueDB::WholeSpaceIterator KeyValueDBMemory::get_wholespace_iterator() {
   return ceph::shared_ptr<KeyValueDB::WholeSpaceIteratorImpl>(
     new WholeSpaceMemIterator(this)
   );

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -184,6 +184,6 @@ private:
 
   friend class WholeSpaceMemIterator;
 
-protected:
-  WholeSpaceIterator _get_iterator() override;
+public:
+  WholeSpaceIterator get_wholespace_iterator() override;
 };

--- a/src/test/ObjectMap/test_keyvaluedb_iterators.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_iterators.cc
@@ -45,7 +45,7 @@ public:
   void TearDown() override { }
 
   ::testing::AssertionResult validate_db_clear(KeyValueDB *store) {
-    KeyValueDB::WholeSpaceIterator it = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator it = store->get_wholespace_iterator();
     it->seek_to_first();
     while (it->valid()) {
       pair<string,string> k = it->raw_key();
@@ -61,7 +61,7 @@ public:
   }
 
   ::testing::AssertionResult validate_db_match() {
-    KeyValueDB::WholeSpaceIterator it = db->get_iterator();
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
     it->seek_to_first();
     while (it->valid()) {
       pair<string, string> k = it->raw_key();
@@ -198,7 +198,7 @@ public:
   }
 
   void clear(KeyValueDB *store) {
-    KeyValueDB::WholeSpaceIterator it = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator it = store->get_wholespace_iterator();
     it->seek_to_first();
     KeyValueDB::Transaction t = store->get_transaction();
     while (it->valid()) {
@@ -244,7 +244,7 @@ public:
   }
 
   void print_db(KeyValueDB *store) {
-    KeyValueDB::WholeSpaceIterator it = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator it = store->get_wholespace_iterator();
     it->seek_to_first();
     print_iterator(it);
   }
@@ -310,7 +310,7 @@ public:
     store->submit_transaction_sync(tx);
 
     deque<string> key_deque;
-    KeyValueDB::WholeSpaceIterator iter = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator iter = store->get_wholespace_iterator();
     iter->seek_to_first();
 
     // check for prefix1
@@ -341,7 +341,7 @@ public:
     tx->rmkeys_by_prefix(prefix1);
     store->submit_transaction_sync(tx);
 
-    iter = store->get_iterator();
+    iter = store->get_wholespace_iterator();
     iter->seek_to_first();
 
     // check for prefix2
@@ -373,7 +373,7 @@ public:
     tx->rmkeys_by_prefix(prefix3);
     store->submit_transaction_sync(tx);
 
-    iter = store->get_iterator();
+    iter = store->get_wholespace_iterator();
     iter->seek_to_first();
 
     // check for prefix1
@@ -444,7 +444,7 @@ public:
     ASSERT_FALSE(iter->valid());
 
     // make sure those keys were removed from the store
-    KeyValueDB::WholeSpaceIterator tmp_it = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator tmp_it = store->get_wholespace_iterator();
     tmp_it->seek_to_first();
     ASSERT_TRUE(tmp_it->valid());
 
@@ -513,7 +513,7 @@ TEST_F(RmKeysTest, RmKeysByPrefixMockDB)
 TEST_F(RmKeysTest, RmKeysWhileIteratingLevelDB)
 {
   SCOPED_TRACE("LevelDB -- WholeSpaceIterator");
-  RmKeysWhileIteratingSnapshot(db.get(), db->get_iterator());
+  RmKeysWhileIteratingSnapshot(db.get(), db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
@@ -721,7 +721,7 @@ public:
 				  "zzz", _gen_val_str("zzz")));
 
     // check those values were really changed in the store
-    KeyValueDB::WholeSpaceIterator tmp_iter = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator tmp_iter = store->get_wholespace_iterator();
     tmp_iter->seek_to_first();
     ASSERT_TRUE(tmp_iter->valid());
     ASSERT_TRUE(validate_iterator(tmp_iter, prefix1,
@@ -738,28 +738,28 @@ public:
 TEST_F(SetKeysTest, DISABLED_SetKeysWhileIteratingLevelDB)
 {
   SCOPED_TRACE("LevelDB: SetKeysWhileIteratingLevelDB");
-  SetKeysWhileIterating(db.get(), db->get_iterator());
+  SetKeysWhileIterating(db.get(), db->get_wholespace_iterator());
   ASSERT_TRUE(HasFatalFailure());
 }
 
 TEST_F(SetKeysTest, SetKeysWhileIteratingMockDB)
 {
   SCOPED_TRACE("Mock DB: SetKeysWhileIteratingMockDB");
-  SetKeysWhileIterating(mock.get(), mock->get_iterator());
+  SetKeysWhileIterating(mock.get(), mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SetKeysTest, DISABLED_UpdateValuesWhileIteratingLevelDB)
 {
   SCOPED_TRACE("LevelDB: UpdateValuesWhileIteratingLevelDB");
-  UpdateValuesWhileIterating(db.get(), db->get_iterator());
+  UpdateValuesWhileIterating(db.get(), db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SetKeysTest, UpdateValuesWhileIteratingMockDB)
 {
   SCOPED_TRACE("MockDB: UpdateValuesWhileIteratingMockDB");
-  UpdateValuesWhileIterating(mock.get(), mock->get_iterator());
+  UpdateValuesWhileIterating(mock.get(), mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
@@ -1149,84 +1149,84 @@ public:
 TEST_F(BoundsTest, LowerBoundWithEmptyKeyOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Lower Bound, Empty Key, Whole-Space Iterator");
-  LowerBoundWithEmptyKeyOnWholeSpaceIterator(db->get_iterator());
+  LowerBoundWithEmptyKeyOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, LowerBoundWithEmptyKeyOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Lower Bound, Empty Key, Whole-Space Iterator");
-  LowerBoundWithEmptyKeyOnWholeSpaceIterator(mock->get_iterator());
+  LowerBoundWithEmptyKeyOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, LowerBoundWithEmptyPrefixOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Lower Bound, Empty Prefix, Whole-Space Iterator");
-  LowerBoundWithEmptyPrefixOnWholeSpaceIterator(db->get_iterator());
+  LowerBoundWithEmptyPrefixOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, LowerBoundWithEmptyPrefixOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Lower Bound, Empty Prefix, Whole-Space Iterator");
-  LowerBoundWithEmptyPrefixOnWholeSpaceIterator(mock->get_iterator());
+  LowerBoundWithEmptyPrefixOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, LowerBoundOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Lower Bound, Whole-Space Iterator");
-  LowerBoundOnWholeSpaceIterator(db->get_iterator());
+  LowerBoundOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, LowerBoundOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Lower Bound, Whole-Space Iterator");
-  LowerBoundOnWholeSpaceIterator(mock->get_iterator());
+  LowerBoundOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundWithEmptyKeyOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Upper Bound, Empty Key, Whole-Space Iterator");
-  UpperBoundWithEmptyKeyOnWholeSpaceIterator(db->get_iterator());
+  UpperBoundWithEmptyKeyOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundWithEmptyKeyOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Upper Bound, Empty Key, Whole-Space Iterator");
-  UpperBoundWithEmptyKeyOnWholeSpaceIterator(mock->get_iterator());
+  UpperBoundWithEmptyKeyOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundWithEmptyPrefixOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Upper Bound, Empty Prefix, Whole-Space Iterator");
-  UpperBoundWithEmptyPrefixOnWholeSpaceIterator(db->get_iterator());
+  UpperBoundWithEmptyPrefixOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundWithEmptyPrefixOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Upper Bound, Empty Prefix, Whole-Space Iterator");
-  UpperBoundWithEmptyPrefixOnWholeSpaceIterator(mock->get_iterator());
+  UpperBoundWithEmptyPrefixOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundOnWholeSpaceIteratorLevelDB)
 {
   SCOPED_TRACE("LevelDB: Upper Bound, Whole-Space Iterator");
-  UpperBoundOnWholeSpaceIterator(db->get_iterator());
+  UpperBoundOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(BoundsTest, UpperBoundOnWholeSpaceIteratorMockDB)
 {
   SCOPED_TRACE("MockDB: Upper Bound, Whole-Space Iterator");
-  UpperBoundOnWholeSpaceIterator(mock->get_iterator());
+  UpperBoundOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
@@ -1458,49 +1458,49 @@ public:
 
 TEST_F(SeeksTest, SeekToFirstOnWholeSpaceIteratorLevelDB) {
   SCOPED_TRACE("LevelDB: Seek To First, Whole Space Iterator");
-  SeekToFirstOnWholeSpaceIterator(db->get_iterator());
+  SeekToFirstOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToFirstOnWholeSpaceIteratorMockDB) {
   SCOPED_TRACE("MockDB: Seek To First, Whole Space Iterator");
-  SeekToFirstOnWholeSpaceIterator(mock->get_iterator());
+  SeekToFirstOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToFirstWithPrefixOnWholeSpaceIteratorLevelDB) {
   SCOPED_TRACE("LevelDB: Seek To First, With Prefix, Whole Space Iterator");
-  SeekToFirstWithPrefixOnWholeSpaceIterator(db->get_iterator());
+  SeekToFirstWithPrefixOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToFirstWithPrefixOnWholeSpaceIteratorMockDB) {
   SCOPED_TRACE("MockDB: Seek To First, With Prefix, Whole Space Iterator");
-  SeekToFirstWithPrefixOnWholeSpaceIterator(mock->get_iterator());
+  SeekToFirstWithPrefixOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToLastOnWholeSpaceIteratorLevelDB) {
   SCOPED_TRACE("LevelDB: Seek To Last, Whole Space Iterator");
-  SeekToLastOnWholeSpaceIterator(db->get_iterator());
+  SeekToLastOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToLastOnWholeSpaceIteratorMockDB) {
   SCOPED_TRACE("MockDB: Seek To Last, Whole Space Iterator");
-  SeekToLastOnWholeSpaceIterator(mock->get_iterator());
+  SeekToLastOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToLastWithPrefixOnWholeSpaceIteratorLevelDB) {
   SCOPED_TRACE("LevelDB: Seek To Last, With Prefix, Whole Space Iterator");
-  SeekToLastWithPrefixOnWholeSpaceIterator(db->get_iterator());
+  SeekToLastWithPrefixOnWholeSpaceIterator(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(SeeksTest, SeekToLastWithPrefixOnWholeSpaceIteratorMockDB) {
   SCOPED_TRACE("MockDB: Seek To Last, With Prefix, Whole Space Iterator");
-  SeekToLastWithPrefixOnWholeSpaceIterator(mock->get_iterator());
+  SeekToLastWithPrefixOnWholeSpaceIterator(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
@@ -1565,26 +1565,26 @@ public:
 TEST_F(KeySpaceIteration, ForwardIterationLevelDB)
 {
   SCOPED_TRACE("LevelDB: Forward Iteration, Whole Space Iterator");
-  ForwardIteration(db->get_iterator());
+  ForwardIteration(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(KeySpaceIteration, ForwardIterationMockDB) {
   SCOPED_TRACE("MockDB: Forward Iteration, Whole Space Iterator");
-  ForwardIteration(mock->get_iterator());
+  ForwardIteration(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(KeySpaceIteration, BackwardIterationLevelDB)
 {
   SCOPED_TRACE("LevelDB: Backward Iteration, Whole Space Iterator");
-  BackwardIteration(db->get_iterator());
+  BackwardIteration(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(KeySpaceIteration, BackwardIterationMockDB) {
   SCOPED_TRACE("MockDB: Backward Iteration, Whole Space Iterator");
-  BackwardIteration(mock->get_iterator());
+  BackwardIteration(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
@@ -1656,84 +1656,84 @@ public:
 TEST_F(EmptyStore, SeekToFirstLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Seek To First");
-  SeekToFirst(db->get_iterator());
+  SeekToFirst(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToFirstMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Seek To First");
-  SeekToFirst(mock->get_iterator());
+  SeekToFirst(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToFirstWithPrefixLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Seek To First With Prefix");
-  SeekToFirstWithPrefix(db->get_iterator());
+  SeekToFirstWithPrefix(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToFirstWithPrefixMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Seek To First With Prefix");
-  SeekToFirstWithPrefix(mock->get_iterator());
+  SeekToFirstWithPrefix(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToLastLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Seek To Last");
-  SeekToLast(db->get_iterator());
+  SeekToLast(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToLastMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Seek To Last");
-  SeekToLast(mock->get_iterator());
+  SeekToLast(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToLastWithPrefixLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Seek To Last With Prefix");
-  SeekToLastWithPrefix(db->get_iterator());
+  SeekToLastWithPrefix(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, SeekToLastWithPrefixMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Seek To Last With Prefix");
-  SeekToLastWithPrefix(mock->get_iterator());
+  SeekToLastWithPrefix(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, LowerBoundLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Lower Bound");
-  LowerBound(db->get_iterator());
+  LowerBound(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, LowerBoundMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Lower Bound");
-  LowerBound(mock->get_iterator());
+  LowerBound(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, UpperBoundLevelDB)
 {
   SCOPED_TRACE("LevelDB: Empty Store, Upper Bound");
-  UpperBound(db->get_iterator());
+  UpperBound(db->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 
 TEST_F(EmptyStore, UpperBoundMockDB)
 {
   SCOPED_TRACE("MockDB: Empty Store, Upper Bound");
-  UpperBound(mock->get_iterator());
+  UpperBound(mock->get_wholespace_iterator());
   ASSERT_FALSE(HasFatalFailure());
 }
 

--- a/src/test/objectstore/test_kv.cc
+++ b/src/test/objectstore/test_kv.cc
@@ -35,6 +35,11 @@ public:
 
   KVTest() : db(0) {}
 
+  string _bl_to_str(bufferlist val) {
+    string str(val.c_str(), val.length());
+    return str;
+  }
+
   void rm_r(string path) {
     string cmd = string("rm -r ") + path;
     cout << "==> " << cmd << std::endl;
@@ -199,7 +204,6 @@ struct AppendMOP : public KeyValueDB::MergeOperator {
     const char *ldata, size_t llen,
     const char *rdata, size_t rlen,
     std::string *new_value) override {
-
     *new_value = std::string(ldata, llen) + std::string(rdata, rlen);
   }
   // We use each operator name and each prefix to construct the
@@ -308,6 +312,160 @@ TEST_P(KVTest, RMRange) {
   fini();
 }
 
+TEST_P(KVTest, RocksDBColumnFamilyTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  cfs.push_back(KeyValueDB::ColumnFamily("cf2", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating two column families and opening them" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist value;
+    value.append("value");
+    cout << "write a transaction includes three keys in different CFs" << std::endl;
+    t->set("prefix", "key", value);
+    t->set("cf1", "key", value);
+    t->set("cf2", "key2", value);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    bufferlist v1, v2, v3;
+    cout << "reopen db and read those keys" << std::endl;
+    ASSERT_EQ(0, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, _bl_to_str(v1) != "value");
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(0, db->get("cf2", "key2", &v3));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+  }
+  {
+    cout << "delete two keys in CFs" << std::endl;
+    KeyValueDB::Transaction t = db->get_transaction();
+    t->rmkey("prefix", "key");
+    t->rmkey("cf2", "key2");
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  fini();
+
+  init();
+  ASSERT_EQ(0, db->open(cout, cfs));
+  {
+    cout << "reopen db and read keys again." << std::endl;
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(-ENOENT, db->get("prefix", "key", &v1));
+    ASSERT_EQ(0, db->get("cf1", "key", &v2));
+    ASSERT_EQ(0, _bl_to_str(v2) != "value");
+    ASSERT_EQ(-ENOENT, db->get("cf2", "key2", &v3));
+  }
+  fini();
+}
+
+TEST_P(KVTest, RocksDBIteratorTest) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist bl1;
+    bl1.append("hello");
+    bufferlist bl2;
+    bl2.append("world");
+    cout << "write some kv pairs into default and new CFs" << std::endl;
+    t->set("prefix", "key1", bl1);
+    t->set("prefix", "key2", bl2);
+    t->set("cf1", "key1", bl1);
+    t->set("cf1", "key2", bl2);
+    ASSERT_EQ(0, db->submit_transaction_sync(t));
+  }
+  {
+    cout << "iterating the default CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("prefix");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  {
+    cout << "iterating the new CF" << std::endl;
+    KeyValueDB::Iterator iter = db->get_iterator("cf1");
+    iter->seek_to_first();
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key1", iter->key());
+    ASSERT_EQ("hello", _bl_to_str(iter->value()));
+    ASSERT_EQ(0, iter->next());
+    ASSERT_EQ(1, iter->valid());
+    ASSERT_EQ("key2", iter->key());
+    ASSERT_EQ("world", _bl_to_str(iter->value()));
+  }
+  fini();
+}
+
+TEST_P(KVTest, RocksDBCFMerge) {
+  if(string(GetParam()) != "rocksdb")
+    return;
+
+  shared_ptr<KeyValueDB::MergeOperator> p(new AppendMOP);
+  int r = db->set_merge_operator("cf1",p);
+  if (r < 0)
+    return; // No merge operators for this database type
+  std::vector<KeyValueDB::ColumnFamily> cfs;
+  cfs.push_back(KeyValueDB::ColumnFamily("cf1", ""));
+  ASSERT_EQ(0, db->init(g_conf->bluestore_rocksdb_options));
+  cout << "creating one column family and opening it" << std::endl;
+  ASSERT_EQ(0, db->create_and_open(cout, cfs));
+
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist v1, v2, v3;
+    v1.append(string("1"));
+    v2.append(string("2"));
+    v3.append(string("3"));
+    t->set("P", "K1", v1);
+    t->set("cf1", "A1", v2);
+    t->rmkey("cf1", "A2");
+    t->merge("cf1", "A2", v3);
+    db->submit_transaction_sync(t);
+  }
+  {
+    bufferlist v1, v2, v3;
+    ASSERT_EQ(0, db->get("P", "K1", &v1));
+    ASSERT_EQ(tostr(v1), "1");
+    ASSERT_EQ(0, db->get("cf1", "A1", &v2));
+    ASSERT_EQ(tostr(v2), "2");
+    ASSERT_EQ(0, db->get("cf1", "A2", &v3));
+    ASSERT_EQ(tostr(v3), "?3");
+  }
+  {
+    KeyValueDB::Transaction t = db->get_transaction();
+    bufferlist v1;
+    v1.append(string("1"));
+    t->merge("cf1", "A2", v1);
+    db->submit_transaction_sync(t);
+  }
+  {
+    bufferlist v;
+    ASSERT_EQ(0, db->get("cf1", "A2", &v));
+    ASSERT_EQ(tostr(v), "?31");
+  }
+  fini();
+}
 
 INSTANTIATE_TEST_CASE_P(
   KeyValueDB,

--- a/src/tools/ceph_kvstore_tool.cc
+++ b/src/tools/ceph_kvstore_tool.cc
@@ -70,7 +70,7 @@ class StoreTool
   uint32_t traverse(const string &prefix,
                     const bool do_crc,
                     ostream *out) {
-    KeyValueDB::WholeSpaceIterator iter = db->get_iterator();
+    KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
 
     if (prefix.empty())
       iter->seek_to_first();
@@ -111,7 +111,7 @@ class StoreTool
 
   bool exists(const string &prefix) {
     assert(!prefix.empty());
-    KeyValueDB::WholeSpaceIterator iter = db->get_iterator();
+    KeyValueDB::WholeSpaceIterator iter = db->get_wholespace_iterator();
     iter->seek_to_first(prefix);
     return (iter->valid() && (iter->raw_key().first == prefix));
   }
@@ -204,7 +204,7 @@ class StoreTool
       return err;
     other.reset(other_ptr);
 
-    KeyValueDB::WholeSpaceIterator it = db->get_iterator();
+    KeyValueDB::WholeSpaceIterator it = db->get_wholespace_iterator();
     it->seek_to_first();
     uint64_t total_keys = 0;
     uint64_t total_size = 0;

--- a/src/tools/ceph_osdomap_tool.cc
+++ b/src/tools/ceph_osdomap_tool.cc
@@ -129,13 +129,13 @@ int main(int argc, char **argv) {
   std::cout << "legacy: " << (omap.state.legacy ? "true" : "false") << std::endl;
 
   if (cmd == "dump-raw-keys") {
-    KeyValueDB::WholeSpaceIterator i = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator i = store->get_wholespace_iterator();
     for (i->seek_to_first(); i->valid(); i->next()) {
       std::cout << i->raw_key() << std::endl;
     }
     return 0;
   } else if (cmd == "dump-raw-key-vals") {
-    KeyValueDB::WholeSpaceIterator i = store->get_iterator();
+    KeyValueDB::WholeSpaceIterator i = store->get_wholespace_iterator();
     for (i->seek_to_first(); i->valid(); i->next()) {
       std::cout << i->raw_key() << std::endl;
       i->value().hexdump(std::cout);


### PR DESCRIPTION
This is another iteration of Adam's squash, but it also cleans up the iterator
mess in KeyValueDB, and simplifies a bunch of the cf handle stuff in rocksdb.

- cleaned up iterators (for KeyValueDB and also the CF one)
- detect existing CFs on open
- add bluestore option to create a CF for deferred and omap 