### PR TITLE
osd/PrimaryLogPG: clear pin_stats_invalid bit properly on scrub-repair completion

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -13604,6 +13604,7 @@ void PrimaryLogPG::_scrub_finish()
       info.stats.omap_stats_invalid = false;
       info.stats.hitset_stats_invalid = false;
       info.stats.hitset_bytes_stats_invalid = false;
+      info.stats.pin_stats_invalid = false;
       publish_stats_to_osd();
       share_pg_info();
     }


### PR DESCRIPTION

We have done audit of stats and the numbers should be all ok by then.
Actually the pin_stats_invalid bit is never set true, so forgetting
to clear pin_stats_invalid here generally does harm. Also we could simply
kill the pin_stats_invalid bit instead but let's not bother with that
complexity either.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>