### PR TITLE
qa/workunits/rbd: pool create may fail for small cluster

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -290,7 +290,7 @@ test_pool_image_args() {
     remove_images
 
     ceph osd pool delete test test --yes-i-really-really-mean-it || true
-    ceph osd pool create test 100
+    ceph osd pool create test 32
     rbd pool init test
     truncate -s 1 /tmp/empty /tmp/empty@snap
 

--- a/qa/workunits/rbd/permissions.sh
+++ b/qa/workunits/rbd/permissions.sh
@@ -4,9 +4,9 @@ set -ex
 IMAGE_FEATURES="layering,exclusive-lock,object-map,fast-diff"
 
 create_pools() {
-    ceph osd pool create images 100
+    ceph osd pool create images 32
     rbd pool init images
-    ceph osd pool create volumes 100
+    ceph osd pool create volumes 32
     rbd pool init volumes
 }
 

--- a/qa/workunits/rbd/rbd-ggate.sh
+++ b/qa/workunits/rbd/rbd-ggate.sh
@@ -55,7 +55,7 @@ setup()
     TEMPDIR=`mktemp -d`
     DATA=${TEMPDIR}/data
     dd if=/dev/urandom of=${DATA} bs=1M count=${SIZE}
-    ceph osd pool create ${POOL} 64 64
+    ceph osd pool create ${POOL} 32
     rbd --dest-pool ${POOL} --no-progress import ${DATA} ${IMAGE}
 }
 

--- a/qa/workunits/rbd/verify_pool.sh
+++ b/qa/workunits/rbd/verify_pool.sh
@@ -1,7 +1,7 @@
 #!/bin/sh -ex
 
 POOL_NAME=rbd_test_validate_pool
-PG_NUM=100
+PG_NUM=32
 
 tear_down () {
   ceph osd pool delete $POOL_NAME $POOL_NAME --yes-i-really-really-mean-it || true


### PR DESCRIPTION
ceph osd pool create test 100
Error ERANGE:  pg_num 100 size 3 would mean 648 total pgs, which exceeds max 600 (mon_max_pg_per_osd 200 * num_in_osds 3)

Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>