### PR TITLE
os/bluestore: rocksdb expects rename in rocksdb::Env is atomic

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -486,6 +486,7 @@ rocksdb::Status BlueRocksEnv::RenameFile(
   int r = fs->rename(old_dir, old_file, new_dir, new_file);
   if (r < 0)
     return err_to_status(r);
+  fs->flush_log();
   return rocksdb::Status::OK();
 }
 


### PR DESCRIPTION
rocksdb::repairdb will create a new MANIFEST file and update CURRENT to point
to new MANIFEST via rename function. Current our BlueRocksEnv's rename will
not invoke flush_log immediately. so rename operation is not flushed actually,
rocksdb will got a wrong CURRENT file and can't find its table files.

We could reproduce it via:

1. create a file called foo in bluefs, and rename it to bar;
2. umount bluefs;
3. re-mount bluefs, there is a file called foo, not bar.

Fixes: http://tracker.ceph.com/issues/21611

Signed-off-by: Chang Liu <liuchang@gmail.com>