### PR TITLE
mailmap: update affiliation for Mykola Golub

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -34,7 +34,7 @@ renhwztetecs huanwen ren <ren.huanwen@zte.com.cn>
 smithfarm Nathan Cutler <ncutler@suse.com>
 tchaikov Kefu Chai <kchai@redhat.com>
 theanalyst Abhishek Lekshmanan <abhishek.lekshmanan@gmail.com>
-trociny Mykola Golub <mgolub@mirantis.com>
+trociny Mykola Golub <to.my.trociny@gmail.com>
 ukernel Zheng Yan <zyan@redhat.com>
 vasukulkarni Vasu Kulkarni <vasu@redhat.com>
 vuhuong Vu Pham <vuhuong@mellanox.com>

--- a/.mailmap
+++ b/.mailmap
@@ -277,6 +277,7 @@ MingXin Liu <mingxin.liu@kylin-cloud.com> <mingxinliu@ubuntukylin.com>
 Mingqiao Wu <wumingqiao@inspur.com>
 Mingyue Zhao <zhao.mingyue@h3c.com>
 Mykola Golub <mgolub@mirantis.com> <mgolub@zhuzha.mirantis.lviv.net>
+Mykola Golub <to.my.trociny@gmail.com>
 Myoungwon Oh <omwmw@sk.com>
 Nathan Cutler <ncutler@suse.com>
 Nathan Cutler <ncutler@suse.com> <nculter@suse.com>

--- a/.organizationmap
+++ b/.organizationmap
@@ -658,6 +658,7 @@ Unaffiliated <no@organization.net> Michael Nelson <mikenel@tnld.net>
 Unaffiliated <no@organization.net> Michael Riederer <michael@riederer.org>
 Unaffiliated <no@organization.net> Michael Sevilla <mikesevilla3@gmail.com>
 Unaffiliated <no@organization.net> Michal Jarzabek <stiopa@gmail.com>
+Unaffiliated <no@organization.net> Mykola Golub <to.my.trociny@gmail.com>
 Unaffiliated <no@organization.net> Neha Ummareddy <nehaummareddy@gmail.com>
 Unaffiliated <no@organization.net> Nick Fisk <nick@fisk.me.uk>
 Unaffiliated <no@organization.net> Nicolas Yong <nicolas.yong93@gmail.com>

--- a/.peoplemap
+++ b/.peoplemap
@@ -35,6 +35,7 @@ Loic Dachary <ldachary@redhat.com> Loic Dachary <loic-201408@dachary.org>
 Loic Dachary <ldachary@redhat.com> Loic Dachary <loic@dachary.org>
 Mark Nelson <mnelson@redhat.com> Mark Nelson <mark.nelson@inktank.com>
 Mark Nelson <mnelson@redhat.com> Mark Nelson <mark.nelson@dreamhost.com>
+Mykola Golub <to.my.trociny@gmail.com> Mykola Golub <mgolub@mirantis.com>
 Neil Levine <nlevine@redhat.com> Neil Levine <neil.levine@inktank.com>
 Noah Watkins <nwatkins@redhat.com> Noah Watkins <noah.watkins@inktank.com>
 Patrick McGarry <pmcgarry@redhat.com> Patrick McGarry <patrick@inktank.com>


### PR DESCRIPTION
Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>