### PR TITLE
mon: check monitor address configuration

### DIFF
--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -635,7 +635,9 @@ int main(int argc, const char **argv)
 	       << " does not match monmap file" << std::endl
 	       << "         continuing with monmap configuration" << dendl;
         }
-      }
+      } else
+          derr << "WARNING: invalid 'mon addr' config option" << std::endl
+               << "         continuing with monmap configuration" << dendl;
     }
   } else {
     dout(0) << g_conf->name << " does not exist in monmap, will attempt to join an existing cluster" << dendl;

--- a/src/ceph_mon.cc
+++ b/src/ceph_mon.cc
@@ -627,10 +627,14 @@ int main(int argc, const char **argv)
     std::string mon_addr_str;
     if (g_conf->get_val_from_conf_file(my_sections, "mon addr",
 				       mon_addr_str, true) == 0) {
-      if (conf_addr.parse(mon_addr_str.c_str()) && (ipaddr != conf_addr)) {
-	derr << "WARNING: 'mon addr' config option " << conf_addr
-	     << " does not match monmap file" << std::endl
-	     << "         continuing with monmap configuration" << dendl;
+      if (conf_addr.parse(mon_addr_str.c_str())) {
+        if (conf_addr.get_port() == 0)
+          conf_addr.set_port(CEPH_MON_PORT);
+        if (ipaddr != conf_addr) {
+	  derr << "WARNING: 'mon addr' config option " << conf_addr
+	       << " does not match monmap file" << std::endl
+	       << "         continuing with monmap configuration" << dendl;
+        }
       }
     }
   } else {

--- a/src/msg/msg_types.cc
+++ b/src/msg/msg_types.cc
@@ -140,6 +140,9 @@ bool entity_addr_t::parse(const char *s, const char **end)
     // parse a port, too!
     p++;
     int port = atoi(p);
+    if (port > MAX_PORT_NUMBER) {
+      return false;
+    }
     set_port(port);
     while (*p && *p >= '0' && *p <= '9')
       p++;

--- a/src/msg/msg_types.h
+++ b/src/msg/msg_types.h
@@ -22,6 +22,8 @@
 #include "include/blobhash.h"
 #include "include/encoding.h"
 
+#define MAX_PORT_NUMBER 65535
+
 namespace ceph {
   class Formatter;
 }


### PR DESCRIPTION
1 check the validity of monitor port configuration
2 use default monitor port when not specified in ceph.conf