### PR TITLE
mon: Change config option name for simplicity

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1031,9 +1031,9 @@ std::vector<Option> get_global_options() {
 
     Option("mon_pg_warn_min_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(30)
-    .set_description(""),
+    .set_description("Min number of PGs per OSD the cluster will allow"),
 
-    Option("mon_max_pg_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    Option("mon_pg_warn_max_per_osd", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(200)
     .set_description("Max number of PGs per OSD the cluster will allow"),
 

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -5418,7 +5418,7 @@ int OSDMonitor::get_crush_rule(const string &rule_name,
 
 int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
 {
-  int64_t max_pgs_per_osd = g_conf->get_val<int64_t>("mon_max_pg_per_osd");
+  int64_t max_pgs_per_osd = g_conf->get_val<int64_t>("mon_pg_warn_max_per_osd");
   int num_osds = MAX(osdmap.get_num_in_osds(), 3);   // assume min cluster size 3
   int64_t max_pgs = max_pgs_per_osd * num_osds;
   int64_t projected = 0;
@@ -5439,7 +5439,7 @@ int OSDMonitor::check_pg_num(int64_t pool, int pg_num, int size, ostream *ss)
     *ss << " pg_num " << pg_num << " size " << size
 	<< " would mean " << projected
 	<< " total pgs, which exceeds max " << max_pgs
-	<< " (mon_max_pg_per_osd " << max_pgs_per_osd
+	<< " (mon_pg_warn_max_per_osd " << max_pgs_per_osd
 	<< " * num_in_osds " << num_osds << ")";
     return -ERANGE;
   }

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2387,7 +2387,9 @@ void PGMap::get_health_checks(
   }
 
   // TOO_MANY_PGS
-  int64_t max_pg_per_osd = cct->_conf->get_val<int64_t>("mon_max_pg_per_osd");
+  int64_t max_pg_per_osd =
+    cct->_conf->get_val<int64_t>("mon_pg_warn_max_per_osd");
+
   if (num_in && max_pg_per_osd > 0) {
     int per = sum_pg_up / num_in;
     if (per > max_pg_per_osd) {

--- a/src/pybind/ceph_volume_client.py
+++ b/src/pybind/ceph_volume_client.py
@@ -527,7 +527,7 @@ class CephFSVolumeClient(object):
         # We can't query the actual cluster config remotely, but since this is
         # just a heuristic we'll assume that the ceph.conf we have locally reflects
         # that in use in the rest of the cluster.
-        pg_warn_max_per_osd = int(self.rados.conf_get('mon_max_pg_per_osd'))
+        pg_warn_max_per_osd = int(self.rados.conf_get('mon_pg_warn_max_per_osd'))
 
         other_pgs = 0
         for pool in osd_map['pools']:


### PR DESCRIPTION
Changed ``mon_max_pg_per_osd`` to ``mon_pg_warn_max_per_osd`` because we
have already ``mon_pg_warn_min_per_osd``.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>