### PR TITLE
mailmap: Fixed maintenance guide URL

### DIFF
--- a/.githubmap
+++ b/.githubmap
@@ -1,6 +1,6 @@
 #
 # More information at
-#  https://wiki.ceph.com/Community/Ceph_contributors_list_maintenance_guide
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
 #
 # See .mailmap for name and mail normalization.
 # See .organizationmap for organization affiliation

--- a/.mailmap
+++ b/.mailmap
@@ -1,6 +1,6 @@
 #
 # More information at
-#  https://wiki.ceph.com/Community/Ceph_contributors_list_maintenance_guide
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
 #
 # See .githubmap for GitHub username contributors
 # See .organizationmap for organization affiliation

--- a/.organizationmap
+++ b/.organizationmap
@@ -1,6 +1,6 @@
 #
 # More information at
-#  https://wiki.ceph.com/Community/Ceph_contributors_list_maintenance_guide
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
 #
 # See .githubmap for GitHub username contributors
 # See .mailmap for name and mail normalization.

--- a/.peoplemap
+++ b/.peoplemap
@@ -1,6 +1,6 @@
 #
 # More information at
-#  https://wiki.ceph.com/Community/Ceph_contributors_list_maintenance_guide
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
 #
 # See .githubmap for GitHub username contributors
 # See .mailmap for name and mail normalization.


### PR DESCRIPTION
Fixed the Contributors List Maintenance Guide URL in .mailmap, .organizationmap, .githubmap and .peoplemap

Signed-off-by: Jos Collin <jcollin@redhat.com>