### PR TITLE
os/kstore: Drop unused function declaration

### DIFF
--- a/src/os/kstore/KStore.h
+++ b/src/os/kstore/KStore.h
@@ -573,10 +573,6 @@ private:
   // --------------------------------------------------------
   // write ops
 
-  int _do_transaction(Transaction *t,
-		      TransContext *txc,
-		      ThreadPool::TPHandle *handle);
-
   int _write(TransContext *txc,
 	     CollectionRef& c,
 	     OnodeRef& o,


### PR DESCRIPTION
Dropped unnecessary function declaration _do_transaction() in KStore.h
This is created as a follow up of the review of https://github.com/ceph/ceph/pull/18075.

Signed-off-by: Jos Collin <jcollin@redhat.com>