### PR TITLE
qa/standalone/scrub/osd-scrub-repair: no -y to diff

### DIFF
--- a/qa/standalone/ceph-helpers.sh
+++ b/qa/standalone/ceph-helpers.sh
@@ -32,15 +32,9 @@ fi
 
 if [ `uname` = FreeBSD ]; then
     SED=gsed
-    DIFFCOLOPTS=""
     KERNCORE="kern.corefile"
 else
     SED=sed
-    termwidth=$(stty -a | head -1 | sed -e 's/.*columns \([0-9]*\).*/\1/')
-    if [ -n "$termwidth" -a "$termwidth" != "0" ]; then
-        termwidth="-W ${termwidth}"
-    fi
-    DIFFCOLOPTS="-y $termwidth"
     KERNCORE="kernel.core_pattern"
 fi
 


### PR DESCRIPTION
With -y you can't see the entire line when it is long, which is
needed to identify the diff failure in
http://tracker.ceph.com/issues/21618

Signed-off-by: Sage Weil <sage@redhat.com>