### PR TITLE
jewel: radosgw: fix awsv4 header line sort order.

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -9,8 +9,11 @@
 #include "common/utf8.h"
 #include "common/ceph_json.h"
 #include "common/safe_io.h"
+#include <map>
+#include <set>
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/replace.hpp>
+#include <boost/algorithm/string/join.hpp>
 
 #include "rgw_rest.h"
 #include "rgw_rest_s3.h"
@@ -3807,8 +3810,7 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s, bool force_b
   }
 
   /* craft canonical headers */
-
-  map<string, string> canonical_hdrs_map;
+  std::set<std::string> canonical_hdrs_set;
   istringstream sh(s->aws4_auth->signedheaders);
   string token;
   string port = s->info.env->get("SERVER_PORT", "");
@@ -3847,12 +3849,14 @@ int RGW_Auth_S3::authorize_v4(RGWRados *store, struct req_state *s, bool force_b
 	  token_value = token_value + ":" + port;
       }
     }
-    canonical_hdrs_map[token] = rgw_trim_whitespace(token_value);
+    canonical_hdrs_set.insert(
+      boost::algorithm::join(std::vector<std::string>(
+	{std::string(token), rgw_trim_whitespace(token_value)} ), ":"));
   }
 
-  for (map<string, string>::iterator it = canonical_hdrs_map.begin();
-      it != canonical_hdrs_map.end(); ++it) {
-    s->aws4_auth->canonical_hdrs.append(it->first + ":" + it->second + "\n");
+  for (const auto& header : canonical_hdrs_set) {
+    s->aws4_auth->canonical_hdrs.append(header.data(), header.length())
+      .append("\n", std::strlen("\n"));
   }
 
   dout(10) << "canonical headers format = " << s->aws4_auth->canonical_hdrs << dendl;


### PR DESCRIPTION
The awsv4 signature calculation includes a list of header lines, which
are supposed to be sorted.  The existing code sorts by header name, but
it appears that in fact it is necessary to sort the whole header *line*,
not just the field name.  Sorting by just the field name usually works,
but not always.  The s3-tests teuthology suite includes
s3tests.functional.test_s3.test_object_header_acl_grants
s3tests.functional.test_s3.test_bucket_header_acl_grants
which include the following header lines,

x-amz-grant-read-acp:id=56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234
x-amz-grant-read:id=56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234
x-amz-grant-write-acp:id=56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234
x-amz-grant-write:id=56789abcdef0123456789abcdef0123456789abcdef0123456789abcdef01234

in this case, note that ':' needs to sort after '-'.

Fixes: http://tracker.ceph.com/issues/21607
Resolves (reappearance of): rhbz#1456060

Signed-off-by: Marcus Watts <mwatts@redhat.com>
(cherry picked from commit c11485e1b3a58631628644152816d9b22a17d8bd)
Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>