### PR TITLE
doc: change cn mirror to ustc domain 

### DIFF
--- a/doc/install/mirrors.rst
+++ b/doc/install/mirrors.rst
@@ -24,7 +24,7 @@ These mirrors are available on the following locations:
 - **UK: UK**: http://uk.ceph.com
 - **US-East: US East Coast**: http://us-east.ceph.com/
 - **US-West: US West Coast**: http://us-west.ceph.com/
-- **CN: China**: http://cn.ceph.com/
+- **CN: China**: http://mirrors.ustc.edu.cn/ceph/
 
 You can replace all download.ceph.com URLs with any of the mirrors, for example:
 

--- a/mirroring/MIRRORS
+++ b/mirroring/MIRRORS
@@ -8,4 +8,3 @@ us-east.ceph.com: Tyler Bishop <tyler.bishop@beyondhosting.net>
 hk.ceph.com: Mart van Santen <mart@greenhost.nl>
 fr.ceph.com: Adrien Gillard <gillard.adrien@gmail.com>
 uk.ceph.com: Tim Bishop <T.D.Bishop@kent.ac.uk>
-cn.ceph.com: USTC LUG <lug@ustc.edu.cn>


### PR DESCRIPTION
Sorry we can't serve cn.ceph.com anymore, according to the regulation in China,
corresponding email is at http://lists.ceph.com/pipermail/ceph-users-ceph.com/2017-October/021200.html

Reverts ceph/ceph#15089