### PR TITLE
os/bluestore: make BlueStore opened by start_kv_only umountable

### DIFF
--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -1859,6 +1859,7 @@ private:
   KVSyncThread kv_sync_thread;
   std::mutex kv_lock;
   std::condition_variable kv_cond;
+  bool _kv_only = false;
   bool kv_sync_started = false;
   bool kv_stop = false;
   bool kv_finalize_started = false;


### PR DESCRIPTION
ceph-kvstore-tool use start_kv_only to debug the kvstore. we
will get a crash when we try to umount bluestore in kvstore-tool.

Fixes: http://tracker.ceph.com/issues/21624

Signed-off-by: Chang Liu <liuchang0812@gmail.com>