### PR TITLE
msg/async/rdma: uninitialized variable fix

### DIFF
--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -30,7 +30,7 @@ static const uint32_t MAX_INLINE_DATA = 0;
 static const uint32_t TCP_MSG_LEN = sizeof("0000:00000000:00000000:00000000:00000000000000000000000000000000");
 static const uint32_t CQ_DEPTH = 30000;
 
-Port::Port(CephContext *cct, struct ibv_context* ictxt, uint8_t ipn): ctxt(ictxt), port_num(ipn), port_attr(new ibv_port_attr)
+Port::Port(CephContext *cct, struct ibv_context* ictxt, uint8_t ipn): ctxt(ictxt), port_num(ipn), port_attr(new ibv_port_attr), gid_idx(0)
 {
 #ifdef HAVE_IBV_EXP
   union ibv_gid cgid;


### PR DESCRIPTION
When port constructor is called gid_idx variable stays uninitialized if
"#else" case is acting.

Signed-off-by: Vasily Philipov <vasilyf@mellanox.com>