### PR TITLE
ceph-volume lvm list 

### DIFF
--- a/doc/ceph-volume/index.rst
+++ b/doc/ceph-volume/index.rst
@@ -29,3 +29,4 @@ technologies, including plain disks.
    lvm/create
    lvm/scan
    lvm/systemd
+   lvm/list

--- a/doc/ceph-volume/lvm/index.rst
+++ b/doc/ceph-volume/lvm/index.rst
@@ -11,6 +11,10 @@ Implements the functionality needed to deploy OSDs from the ``lvm`` subcommand:
 
 * :ref:`ceph-volume-lvm-activate`
 
+* :ref:`ceph-volume-lvm-create`
+
+* :ref:`ceph-volume-lvm-list`
+
 .. not yet implemented
 .. * :ref:`ceph-volume-lvm-scan`
 

--- a/doc/ceph-volume/lvm/list.rst
+++ b/doc/ceph-volume/lvm/list.rst
@@ -1,0 +1,173 @@
+.. _ceph-volume-lvm-list:
+
+``list``
+========
+This subcommand will list any devices (logical and physical) that may be
+associated with a Ceph cluster, as long as they contain enough metadata to
+allow for that discovery.
+
+Output is grouped by the OSD ID associated with the devices, and unlike
+``ceph-disk`` it does not provide any information for devices that aren't
+associated with Ceph.
+
+Command line options:
+
+* ``--format`` Allows a ``json`` or ``pretty`` value. Defaults to ``pretty``
+  which will group the device information in a human-readable format.
+
+Full Reporting
+--------------
+When no positional arguments are used, a full reporting will be presented. This
+means that all devices and logical volumes found in the system will be
+displayed.
+
+Full ``pretty`` reporting for two OSDs, one with a lv as a journal, and another
+one with a physical device may look similar to::
+
+    # ceph-volume lvm list
+
+
+    ====== osd.1 =======
+
+      [journal]    /dev/journals/journal1
+
+          journal uuid              C65n7d-B1gy-cqX3-vZKY-ZoE0-IEYM-HnIJzs
+          osd id                    1
+          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
+          type                      journal
+          osd fsid                  661b24f8-e062-482b-8110-826ffe7f13fa
+          data uuid                 SlEgHe-jX1H-QBQk-Sce0-RUls-8KlY-g8HgcZ
+          journal device            /dev/journals/journal1
+          data device               /dev/test_group/data-lv2
+
+      [data]    /dev/test_group/data-lv2
+
+          journal uuid              C65n7d-B1gy-cqX3-vZKY-ZoE0-IEYM-HnIJzs
+          osd id                    1
+          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
+          type                      data
+          osd fsid                  661b24f8-e062-482b-8110-826ffe7f13fa
+          data uuid                 SlEgHe-jX1H-QBQk-Sce0-RUls-8KlY-g8HgcZ
+          journal device            /dev/journals/journal1
+          data device               /dev/test_group/data-lv2
+
+    ====== osd.0 =======
+
+      [data]    /dev/test_group/data-lv1
+
+          journal uuid              cd72bd28-002a-48da-bdf6-d5b993e84f3f
+          osd id                    0
+          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
+          type                      data
+          osd fsid                  943949f0-ce37-47ca-a33c-3413d46ee9ec
+          data uuid                 TUpfel-Q5ZT-eFph-bdGW-SiNW-l0ag-f5kh00
+          journal device            /dev/sdd1
+          data device               /dev/test_group/data-lv1
+
+      [journal]    /dev/sdd1
+
+          PARTUUID                  cd72bd28-002a-48da-bdf6-d5b993e84f3f
+
+.. note:: Tags are displayed in a readable format. The ``osd id`` key is stored
+          as a ``ceph.osd_id`` tag. For more information on lvm tag conventions
+          see :ref:`ceph-volume-lvm-tag-api`
+
+Single Reporting
+----------------
+Single reporting can consume both devices and logical volumes as input
+(positional parameters). For logical volumes, it is required to use the group
+name as well as the logical volume name.
+
+For example the ``data-lv2`` logical volume, in the ``test_group`` volume group
+can be listed in the following way::
+
+    # ceph-volume lvm list test_group/data-lv2
+
+
+    ====== osd.1 =======
+
+      [data]    /dev/test_group/data-lv2
+
+          journal uuid              C65n7d-B1gy-cqX3-vZKY-ZoE0-IEYM-HnIJzs
+          osd id                    1
+          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
+          type                      data
+          osd fsid                  661b24f8-e062-482b-8110-826ffe7f13fa
+          data uuid                 SlEgHe-jX1H-QBQk-Sce0-RUls-8KlY-g8HgcZ
+          journal device            /dev/journals/journal1
+          data device               /dev/test_group/data-lv2
+
+
+.. note:: Tags are displayed in a readable format. The ``osd id`` key is stored
+          as a ``ceph.osd_id`` tag. For more information on lvm tag conventions
+          see :ref:`ceph-volume-lvm-tag-api`
+
+
+For plain disks, the full path to the device is required. For example, for
+a device like ``/dev/sdd1`` it can look like::
+
+
+    # ceph-volume lvm list /dev/sdd1
+
+
+    ====== osd.0 =======
+
+      [journal]    /dev/sdd1
+
+          PARTUUID                  cd72bd28-002a-48da-bdf6-d5b993e84f3f
+
+
+
+``json`` output
+---------------
+All output using ``--format=json`` will show everything the system has stored
+as metadata for the devices, including tags.
+
+No changes for readability are done with ``json`` reporting, and all
+information is presented as-is. Full output as well as single devices can be
+listed.
+
+For brevity, this is how a single logical volume would look with ``json``
+output (note how tags aren't modified)::
+
+    # ceph-volume lvm list --format=json test_group/data-lv1
+    {
+        "0": [
+            {
+                "lv_name": "data-lv1",
+                "lv_path": "/dev/test_group/data-lv1",
+                "lv_tags": "ceph.cluster_fsid=ce454d91-d748-4751-a318-ff7f7aa18ffd,ceph.data_device=/dev/test_group/data-lv1,ceph.data_uuid=TUpfel-Q5ZT-eFph-bdGW-SiNW-l0ag-f5kh00,ceph.journal_device=/dev/sdd1,ceph.journal_uuid=cd72bd28-002a-48da-bdf6-d5b993e84f3f,ceph.osd_fsid=943949f0-ce37-47ca-a33c-3413d46ee9ec,ceph.osd_id=0,ceph.type=data",
+                "lv_uuid": "TUpfel-Q5ZT-eFph-bdGW-SiNW-l0ag-f5kh00",
+                "name": "data-lv1",
+                "path": "/dev/test_group/data-lv1",
+                "tags": {
+                    "ceph.cluster_fsid": "ce454d91-d748-4751-a318-ff7f7aa18ffd",
+                    "ceph.data_device": "/dev/test_group/data-lv1",
+                    "ceph.data_uuid": "TUpfel-Q5ZT-eFph-bdGW-SiNW-l0ag-f5kh00",
+                    "ceph.journal_device": "/dev/sdd1",
+                    "ceph.journal_uuid": "cd72bd28-002a-48da-bdf6-d5b993e84f3f",
+                    "ceph.osd_fsid": "943949f0-ce37-47ca-a33c-3413d46ee9ec",
+                    "ceph.osd_id": "0",
+                    "ceph.type": "data"
+                },
+                "type": "data",
+                "vg_name": "test_group"
+            }
+        ]
+    }
+
+
+Synchronized information
+------------------------
+Before any listing type, the lvm API is queried to ensure that physical devices
+that may be in use haven't changed naming. It is possible that non-persistent
+devices like ``/dev/sda1`` could change to ``/dev/sdb1``.
+
+The detection is possible because the ``PARTUUID`` is stored as part of the
+metadata in the logical volume for the data lv. Even in the case of a journal
+that is a physical device, this information is still stored on the data logical
+volume associated with it.
+
+If the name is no longer the same (as reported by ``blkid`` when using the
+``PARTUUID``), the tag will get updated and the report will use the newly
+refreshed information.

--- a/src/ceph-volume/ceph_volume/devices/lvm/api.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/api.py
@@ -597,6 +597,15 @@ class Volume(object):
     def __repr__(self):
         return self.__str__()
 
+    def as_dict(self):
+        obj = {}
+        obj.update(self.lv_api)
+        obj['tags'] = self.tags
+        obj['name'] = self.name
+        obj['type'] = self.tags['ceph.type']
+        obj['path'] = self.lv_path
+        return obj
+
     def set_tags(self, tags):
         """
         :param tags: A dictionary of tag names and values, like::

--- a/src/ceph-volume/ceph_volume/devices/lvm/api.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/api.py
@@ -131,6 +131,19 @@ def get_api_pvs():
     return _output_parser(stdout, fields)
 
 
+def get_lv_from_argument(argument):
+    """
+    Helper proxy function that consumes a possible logical volume passed in from the CLI
+    in the form of `vg/lv`, but with some validation so that an argument that is a full
+    path to a device can be ignored
+    """
+    try:
+        vg_name, lv_name = argument.split('/')
+    except (ValueError, AttributeError):
+        return None
+    return get_lv(lv_name=lv_name, vg_name=vg_name)
+
+
 def get_lv(lv_name=None, vg_name=None, lv_path=None, lv_uuid=None, lv_tags=None):
     """
     Return a matching lv for the current system, requiring ``lv_name``,

--- a/src/ceph-volume/ceph_volume/devices/lvm/listing.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/listing.py
@@ -1,0 +1,232 @@
+from __future__ import print_function
+import argparse
+import json
+import logging
+from textwrap import dedent
+from ceph_volume import decorators
+from ceph_volume.util import disk
+from . import api
+
+logger = logging.getLogger(__name__)
+
+
+osd_list_header_template = """\n
+{osd_id:=^20}"""
+
+
+osd_device_header_template = """
+
+  [{type: >4}]    {path}
+"""
+
+device_metadata_item_template = """
+      {tag_name: <25} {value}"""
+
+
+def readable_tag(tag):
+    actual_name = tag.split('.')[-1]
+    return actual_name.replace('_', ' ')
+
+
+def pretty_report(report):
+    output = []
+    for _id, devices in report.items():
+        output.append(
+            osd_list_header_template.format(osd_id=" osd.%s " % _id)
+        )
+        for device in devices:
+            output.append(
+                osd_device_header_template.format(
+                    type=device['type'],
+                    path=device['path']
+                )
+            )
+            for tag_name, value in device.get('tags', {}).items():
+                output.append(
+                    device_metadata_item_template.format(
+                        tag_name=readable_tag(tag_name),
+                        value=value
+                    )
+                )
+    print(''.join(output))
+
+
+class List(object):
+
+    help = 'list logical volumes and devices associated with Ceph'
+
+    def __init__(self, argv):
+        self.argv = argv
+
+    @decorators.needs_root
+    def list(self, args):
+        # ensure everything is up to date before calling out
+        # to list lv's
+        self.update()
+        report = self.generate(args)
+        if args.format == 'json':
+            # If the report is empty, we don't return a non-zero exit status
+            # because it is assumed this is going to be consumed by automated
+            # systems like ceph-ansible which would be forced to ignore the
+            # non-zero exit status if all they need is the information in the
+            # JSON object
+            print(json.dumps(report, indent=4, sort_keys=True))
+        else:
+            if not report:
+                raise SystemExit('No valid Ceph devices found')
+            pretty_report(report)
+
+    def update(self):
+        """
+        Ensure all journal devices are up to date if they aren't a logical
+        volume
+        """
+        lvs = api.Volumes()
+        for lv in lvs:
+            try:
+                lv.tags['ceph.osd_id']
+            except KeyError:
+                # only consider ceph-based logical volumes, everything else
+                # will get ignored
+                continue
+
+            journal_uuid = lv.tags['ceph.journal_uuid']
+            # query blkid for the UUID, if it matches we have a physical device
+            # which needs to be compared to ensure it is up to date
+            journal_device = disk.get_device_from_partuuid(journal_uuid)
+            if journal_device:
+                if lv.tags['ceph.journal_device'] != journal_device:
+                    # this means that the device has changed, so it must be updated
+                    # on the API to reflect this
+                    lv.set_tags({'ceph.journal_device': journal_device})
+
+    def generate(self, args):
+        """
+        Generate reports for an individual device or for all Ceph-related
+        devices, logical or physical, as long as they have been prepared by
+        this tool before and contain enough metadata.
+        """
+        if args.device:
+            return self.single_report(args.device)
+        else:
+            return self.full_report()
+
+    def single_report(self, device):
+        """
+        Generate a report for a single device. This can be either a logical
+        volume in the form of vg/lv or a device with an absolute path like
+        /dev/sda1
+        """
+        lvs = api.Volumes()
+        report = {}
+        lv = api.get_lv_from_argument(device)
+        if lv:
+            try:
+                _id = lv.tags['ceph.osd_id']
+            except KeyError:
+                logger.warning('device is not part of ceph: %s', device)
+                return report
+
+            report.setdefault(_id, [])
+            report[_id].append(
+                lv.as_dict()
+            )
+
+        else:
+            # this has to be a journal device (not a logical volume) so try
+            # to find the PARTUUID that should be stored in the OSD logical
+            # volume
+            associated_lv = lvs.get(lv_tags={'ceph.journal_device': device})
+            if associated_lv:
+                _id = associated_lv.tags['ceph.osd_id']
+                uuid = associated_lv.tags['ceph.journal_uuid']
+
+                report.setdefault(_id, [])
+                report[_id].append(
+                    {
+                        'tags': {'PARTUUID': uuid},
+                        'type': 'journal',
+                        'path': device,
+                    }
+                )
+        return report
+
+    def full_report(self):
+        """
+        Generate a report for all the logical volumes and associated devices
+        that have been previously prepared by Ceph
+        """
+        lvs = api.Volumes()
+        report = {}
+        for lv in lvs:
+            try:
+                _id = lv.tags['ceph.osd_id']
+            except KeyError:
+                # only consider ceph-based logical volumes, everything else
+                # will get ignored
+                continue
+
+            report.setdefault(_id, [])
+            report[_id].append(
+                lv.as_dict()
+            )
+
+            journal_uuid = lv.tags['ceph.journal_uuid']
+            if not api.get_lv(lv_uuid=journal_uuid):
+                # means we have a regular device, so query blkid
+                journal_device = disk.get_device_from_partuuid(journal_uuid)
+                if journal_device:
+                    report[_id].append(
+                        {
+                            'tags': {'PARTUUID': journal_uuid},
+                            'type': 'journal',
+                            'path': journal_device,
+                        }
+                    )
+
+        return report
+
+    def main(self):
+        sub_command_help = dedent("""
+        List devices or logical volumes associated with Ceph. An association is
+        determined if a device has information relating to an OSD. This is
+        verified by querying LVM's metadata and correlating it with devices.
+
+        The lvs associated with the OSD need to have been prepared previously,
+        so that all needed tags and metadata exist.
+
+        Full listing of all system devices associated with a cluster::
+
+            ceph-volume lvm list
+
+        List a particular device, reporting all metadata about it::
+
+            ceph-volume lvm list /dev/sda1
+
+        List a logical volume, along with all its metadata (vg is a volume
+        group, and lv the logical volume name)::
+
+            ceph-volume lvm list {vg/lv}
+        """)
+        parser = argparse.ArgumentParser(
+            prog='ceph-volume lvm list',
+            formatter_class=argparse.RawDescriptionHelpFormatter,
+            description=sub_command_help,
+        )
+
+        parser.add_argument(
+            'device',
+            metavar='DEVICE',
+            nargs='?',
+            help='Path to an lv (as vg/lv) or to a device like /dev/sda1'
+        )
+
+        parser.add_argument(
+            '--format',
+            help='output format, defaults to "pretty"',
+            default='pretty',
+            choices=['json', 'pretty'],
+        )
+
+        args = parser.parse_args(self.argv)
+        self.list(args)

--- a/src/ceph-volume/ceph_volume/devices/lvm/main.py
+++ b/src/ceph-volume/ceph_volume/devices/lvm/main.py
@@ -5,6 +5,7 @@ from . import activate
 from . import prepare
 from . import create
 from . import trigger
+from . import listing
 
 
 class LVM(object):
@@ -22,6 +23,7 @@ class LVM(object):
         'prepare': prepare.Prepare,
         'create': create.Create,
         'trigger': trigger.Trigger,
+        'list': listing.List,
     }
 
     def __init__(self, argv):

--- a/src/ceph-volume/ceph_volume/process.py
+++ b/src/ceph-volume/ceph_volume/process.py
@@ -115,10 +115,12 @@ def call(command, **kw):
                              it is forcefully set to True if a return code is non-zero
     """
     terminal_verbose = kw.pop('terminal_verbose', False)
+    show_command = kw.pop('show_command', False)
     command_msg = "Running command: %s" % ' '.join(command)
     stdin = kw.pop('stdin', None)
     logger.info(command_msg)
-    terminal.write(command_msg)
+    if show_command:
+        terminal.write(command_msg)
 
     process = subprocess.Popen(
         command,

--- a/src/ceph-volume/ceph_volume/tests/conftest.py
+++ b/src/ceph-volume/ceph_volume/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
 from ceph_volume.devices.lvm import api
 
+
 class Capture(object):
 
     def __init__(self, *a, **kw):
@@ -10,6 +11,18 @@ class Capture(object):
 
     def __call__(self, *a, **kw):
         self.calls.append({'args': a, 'kwargs': kw})
+
+
+class Factory(object):
+
+    def __init__(self, **kw):
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+@pytest.fixture
+def factory():
+    return Factory
 
 
 @pytest.fixture

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_api.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_api.py
@@ -189,6 +189,20 @@ class TestVolumes(object):
         with pytest.raises(exceptions.MultipleLVsError):
             volumes.get(lv_name='foo')
 
+    def test_as_dict_infers_type_from_tags(self, volumes):
+        lv_tags = "ceph.type=data,ceph.fsid=000-aaa"
+        osd = api.Volume(lv_name='volume1', lv_path='/dev/vg/lv', lv_tags=lv_tags)
+        volumes.append(osd)
+        result = volumes.get(lv_tags={'ceph.type': 'data'}).as_dict()
+        assert result['type'] == 'data'
+
+    def test_as_dict_populates_path_from_lv_api(self, volumes):
+        lv_tags = "ceph.type=data,ceph.fsid=000-aaa"
+        osd = api.Volume(lv_name='volume1', lv_path='/dev/vg/lv', lv_tags=lv_tags)
+        volumes.append(osd)
+        result = volumes.get(lv_tags={'ceph.type': 'data'}).as_dict()
+        assert result['path'] == '/dev/vg/lv'
+
     def test_find_the_correct_one(self, volumes):
         volume1 = api.Volume(lv_name='volume1', lv_path='/dev/vg/lv', lv_tags='')
         volume2 = api.Volume(lv_name='volume2', lv_path='/dev/vg/lv', lv_tags='')

--- a/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
+++ b/src/ceph-volume/ceph_volume/tests/devices/lvm/test_listing.py
@@ -1,0 +1,149 @@
+import pytest
+from ceph_volume.devices import lvm
+
+
+class TestReadableTag(object):
+
+    def test_dots_get_replaced(self):
+        result = lvm.listing.readable_tag('ceph.foo')
+        assert result == 'foo'
+
+    def test_underscores_are_replaced_with_spaces(self):
+        result = lvm.listing.readable_tag('ceph.long_tag')
+        assert result == 'long tag'
+
+
+class TestPrettyReport(object):
+
+    def test_is_empty(self, capsys):
+        lvm.listing.pretty_report({})
+        stdout, stderr = capsys.readouterr()
+        assert stdout == '\n'
+
+    def test_type_and_path_are_reported(self, capsys):
+        lvm.listing.pretty_report({0: [{'type': 'data', 'path': '/dev/sda1'}]})
+        stdout, stderr = capsys.readouterr()
+        assert '[data]    /dev/sda1' in stdout
+
+    def test_osd_id_header_is_reported(self, capsys):
+        lvm.listing.pretty_report({0: [{'type': 'data', 'path': '/dev/sda1'}]})
+        stdout, stderr = capsys.readouterr()
+        assert '====== osd.0 =======' in stdout
+
+    def test_tags_are_included(self, capsys):
+        lvm.listing.pretty_report(
+            {0: [{
+                'type': 'data',
+                'path': '/dev/sda1',
+                'tags': {'ceph.osd_id': '0'}
+            }]}
+        )
+        stdout, stderr = capsys.readouterr()
+        assert 'osd id' in stdout
+
+
+class TestList(object):
+
+    def test_empty_full_json_zero_exit_status(self, is_root, volumes, factory, capsys):
+        args = factory(format='json', device=None)
+        lvm.listing.List([]).list(args)
+        stdout, stderr = capsys.readouterr()
+        assert stdout == '{}\n'
+
+    def test_empty_device_json_zero_exit_status(self, is_root, volumes, factory, capsys):
+        args = factory(format='json', device='/dev/sda1')
+        lvm.listing.List([]).list(args)
+        stdout, stderr = capsys.readouterr()
+        assert stdout == '{}\n'
+
+    def test_empty_full_zero_exit_status(self, is_root, volumes, factory):
+        args = factory(format='pretty', device=None)
+        with pytest.raises(SystemExit):
+            lvm.listing.List([]).list(args)
+
+    def test_empty_device_zero_exit_status(self, is_root, volumes, factory):
+        args = factory(format='pretty', device='/dev/sda1')
+        with pytest.raises(SystemExit):
+            lvm.listing.List([]).list(args)
+
+
+class TestFullReport(object):
+
+    def test_no_ceph_lvs(self, volumes, monkeypatch):
+        # ceph lvs are detected by looking into its tags
+        osd = lvm.api.Volume(lv_name='volume1', lv_path='/dev/VolGroup/lv', lv_tags={})
+        volumes.append(osd)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).full_report()
+        assert result == {}
+
+    def test_ceph_data_lv_reported(self, volumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
+        osd = lvm.api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).full_report()
+        assert result['0'][0]['name'] == 'volume1'
+
+    def test_ceph_journal_lv_reported(self, volumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
+        journal_tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=journal'
+        osd = lvm.api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        journal = lvm.api.Volume(
+            lv_name='journal', lv_uuid='x', lv_path='/dev/VolGroup/journal', lv_tags=journal_tags)
+        volumes.append(osd)
+        volumes.append(journal)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).full_report()
+        assert result['0'][0]['name'] == 'volume1'
+        assert result['0'][1]['name'] == 'journal'
+
+    def test_physical_disk_gets_reported(self, volumes, monkeypatch):
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
+        osd = lvm.api.Volume(
+            lv_name='volume1', lv_uuid='y', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(osd)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        monkeypatch.setattr(lvm.listing.disk, 'get_device_from_partuuid', lambda x: '/dev/sda1')
+        result = lvm.listing.List([]).full_report()
+        assert result['0'][1]['path'] == '/dev/sda1'
+        assert result['0'][1]['tags'] == {'PARTUUID': 'x'}
+        assert result['0'][1]['type'] == 'journal'
+
+
+class TestSingleReport(object):
+
+    def test_not_a_ceph_lv(self, volumes, monkeypatch):
+        # ceph lvs are detected by looking into its tags
+        lv = lvm.api.Volume(
+            lv_name='lv', vg_name='VolGroup', lv_path='/dev/VolGroup/lv', lv_tags={})
+        volumes.append(lv)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).single_report('VolGroup/lv')
+        assert result == {}
+
+    def test_report_a_ceph_lv(self, volumes, monkeypatch):
+        # ceph lvs are detected by looking into its tags
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data'
+        lv = lvm.api.Volume(
+            lv_name='lv', vg_name='VolGroup', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(lv)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).single_report('VolGroup/lv')
+        assert result['0'][0]['name'] == 'lv'
+        assert result['0'][0]['lv_tags'] == tags
+        assert result['0'][0]['path'] == '/dev/VolGroup/lv'
+
+    def test_report_a_ceph_journal_device(self, volumes, monkeypatch):
+        # ceph lvs are detected by looking into its tags
+        tags = 'ceph.osd_id=0,ceph.journal_uuid=x,ceph.type=data,ceph.journal_device=/dev/sda1'
+        lv = lvm.api.Volume(
+            lv_name='lv', vg_name='VolGroup', lv_path='/dev/VolGroup/lv', lv_tags=tags)
+        volumes.append(lv)
+        monkeypatch.setattr(lvm.listing.api, 'Volumes', lambda: volumes)
+        result = lvm.listing.List([]).single_report('/dev/sda1')
+        assert result['0'][0]['tags'] == {'PARTUUID': 'x'}
+        assert result['0'][0]['type'] == 'journal'
+        assert result['0'][0]['path'] == '/dev/sda1'


### PR DESCRIPTION
List all devices associated with Ceph that have been prepared by `ceph-volume lvm`. This may include both physical and logical.

Resolves: https://bugzilla.redhat.com/show_bug.cgi?id=1491250

It also allows json formatting, and single device listing.

Sample output for full listing:

    $ ceph-volume lvm list
    
    
    ====== osd.1 =======
    
      [journal]    /dev/journals/journal1
    
          journal uuid              C65n7d-B1gy-cqX3-vZKY-ZoE0-IEYM-HnIJzs
          osd id                    1
          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
          type                      journal
          osd fsid                  661b24f8-e062-482b-8110-826ffe7f13fa
          data uuid                 SlEgHe-jX1H-QBQk-Sce0-RUls-8KlY-g8HgcZ
          journal device            /dev/journals/journal1
          data device               /dev/test_group/data-lv2
    
      [data]    /dev/test_group/data-lv2
    
          journal uuid              C65n7d-B1gy-cqX3-vZKY-ZoE0-IEYM-HnIJzs
          osd id                    1
          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
          type                      data
          osd fsid                  661b24f8-e062-482b-8110-826ffe7f13fa
          data uuid                 SlEgHe-jX1H-QBQk-Sce0-RUls-8KlY-g8HgcZ
          journal device            /dev/journals/journal1
          data device               /dev/test_group/data-lv2
    

Single listing (for lv):

    $ ceph-volume lvm list test_group/data-lv1
    
    
    ====== osd.0 =======
    
      [data]    /dev/test_group/data-lv1
    
          journal uuid              cd72bd28-002a-48da-bdf6-d5b993e84f3f
          osd id                    0
          cluster fsid              ce454d91-d748-4751-a318-ff7f7aa18ffd
          type                      data
          osd fsid                  943949f0-ce37-47ca-a33c-3413d46ee9ec
          data uuid                 TUpfel-Q5ZT-eFph-bdGW-SiNW-l0ag-f5kh00
          journal device            /dev/sdd1
          data device               /dev/test_group/data-lv1

Single listing for a device:

    $ ceph-volume lvm list /dev/sdd1
    
    
    ====== osd.0 =======
    
      [journal]    /dev/sdd1
    
          PARTUUID                  cd72bd28-002a-48da-bdf6-d5b993e84f3f
