### PR TITLE
librbd: journal should ignore -EILSEQ errors from compare-and-write

### DIFF
--- a/src/librbd/Journal.cc
+++ b/src/librbd/Journal.cc
@@ -766,19 +766,19 @@ uint64_t Journal<I>::append_write_event(uint64_t offset, size_t length,
   } while (bytes_remaining > 0);
 
   return append_io_events(journal::EVENT_TYPE_AIO_WRITE, bufferlists, requests,
-                          offset, length, flush_entry);
+                          offset, length, flush_entry, 0);
 }
 
 template <typename I>
 uint64_t Journal<I>::append_io_event(journal::EventEntry &&event_entry,
                                      const IOObjectRequests &requests,
                                      uint64_t offset, size_t length,
-                                     bool flush_entry) {
+                                     bool flush_entry, int filter_ret_val) {
   bufferlist bl;
   event_entry.timestamp = ceph_clock_now();
   ::encode(event_entry, bl);
   return append_io_events(event_entry.get_event_type(), {bl}, requests, offset,
-                          length, flush_entry);
+                          length, flush_entry, filter_ret_val);
 }
 
 template <typename I>
@@ -786,7 +786,7 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
                                       const Bufferlists &bufferlists,
                                       const IOObjectRequests &requests,
                                       uint64_t offset, size_t length,
-                                      bool flush_entry) {
+                                      bool flush_entry, int filter_ret_val) {
   assert(!bufferlists.empty());
 
   uint64_t tid;
@@ -806,7 +806,7 @@ uint64_t Journal<I>::append_io_events(journal::EventType event_type,
 
   {
     Mutex::Locker event_locker(m_event_lock);
-    m_events[tid] = Event(futures, requests, offset, length);
+    m_events[tid] = Event(futures, requests, offset, length, filter_ret_val);
   }
 
   CephContext *cct = m_image_ctx.cct;
@@ -1165,6 +1165,10 @@ void Journal<I>::complete_event(typename Events::iterator it, int r) {
                  << "r=" << r << dendl;
 
   Event &event = it->second;
+  if (r < 0 && r == event.filter_ret_val) {
+    // ignore allowed error codes
+    r = 0;
+  }
   if (r < 0) {
     // event recorded to journal but failed to update disk, we cannot
     // commit this IO event. this event must be replayed.

--- a/src/librbd/Journal.h
+++ b/src/librbd/Journal.h
@@ -142,7 +142,7 @@ public:
   uint64_t append_io_event(journal::EventEntry &&event_entry,
                            const IOObjectRequests &requests,
                            uint64_t offset, size_t length,
-                           bool flush_entry);
+                           bool flush_entry, int filter_ret_val);
   void commit_io_event(uint64_t tid, int r);
   void commit_io_event_extent(uint64_t tid, uint64_t offset, uint64_t length,
                               int r);
@@ -193,6 +193,7 @@ private:
     IOObjectRequests aio_object_requests;
     Contexts on_safe_contexts;
     ExtentInterval pending_extents;
+    int filter_ret_val = 0;
     bool committed_io = false;
     bool safe = false;
     int ret_val = 0;
@@ -200,8 +201,9 @@ private:
     Event() {
     }
     Event(const Futures &_futures, const IOObjectRequests &_requests,
-          uint64_t offset, size_t length)
-      : futures(_futures), aio_object_requests(_requests) {
+          uint64_t offset, size_t length, int filter_ret_val)
+      : futures(_futures), aio_object_requests(_requests),
+        filter_ret_val(filter_ret_val) {
       if (length > 0) {
         pending_extents.insert(offset, length);
       }
@@ -334,7 +336,8 @@ private:
   uint64_t append_io_events(journal::EventType event_type,
                             const Bufferlists &bufferlists,
                             const IOObjectRequests &requests,
-                            uint64_t offset, size_t length, bool flush_entry);
+                            uint64_t offset, size_t length, bool flush_entry,
+                            int filter_ret_val);
   Future wait_event(Mutex &lock, uint64_t tid, Context *on_safe);
 
   void create_journaler();

--- a/src/librbd/io/ImageRequest.cc
+++ b/src/librbd/io/ImageRequest.cc
@@ -605,7 +605,7 @@ uint64_t ImageDiscardRequest<I>::append_journal_event(
                                                              this->m_skip_partial_discard));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              requests, extent.first,
-                                             extent.second, synchronous);
+                                             extent.second, synchronous, 0);
   }
 
   AioCompletion *aio_comp = this->m_aio_comp;
@@ -723,7 +723,7 @@ void ImageFlushRequest<I>::send_request() {
     // in-flight ops are flushed prior to closing the journal
     uint64_t journal_tid = image_ctx.journal->append_io_event(
       journal::EventEntry(journal::AioFlushEvent()),
-      ObjectRequests(), 0, 0, false);
+      ObjectRequests(), 0, 0, false, 0);
 
     aio_comp->set_request_count(1);
     aio_comp->associate_journal_event(journal_tid);
@@ -822,7 +822,7 @@ uint64_t ImageWriteSameRequest<I>::append_journal_event(
                                                                m_data_bl));
     tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                              requests, extent.first,
-                                             extent.second, synchronous);
+                                             extent.second, synchronous, 0);
   }
 
   if (image_ctx.object_cacher == NULL) {
@@ -923,7 +923,7 @@ uint64_t ImageCompareAndWriteRequest<I>::append_journal_event(
                                                                    m_cmp_bl, m_bl));
   tid = image_ctx.journal->append_io_event(std::move(event_entry),
                                            requests, extent.first,
-                                           extent.second, synchronous);
+                                           extent.second, synchronous, -EILSEQ);
 
   AioCompletion *aio_comp = this->m_aio_comp;
   aio_comp->associate_journal_event(tid);

--- a/src/test/librbd/journal/test_Replay.cc
+++ b/src/test/librbd/journal/test_Replay.cc
@@ -51,7 +51,7 @@ public:
     {
       RWLock::RLocker owner_locker(ictx->owner_lock);
       uint64_t tid = ictx->journal->append_io_event(std::move(event_entry),
-                                                    requests, 0, 0, true);
+                                                    requests, 0, 0, true, 0);
       ictx->journal->wait_event(tid, &ctx);
     }
     ASSERT_EQ(0, ctx.wait());

--- a/src/test/librbd/mock/MockJournal.h
+++ b/src/test/librbd/mock/MockJournal.h
@@ -71,16 +71,16 @@ struct MockJournal {
   MOCK_METHOD5(append_write_event, uint64_t(uint64_t, size_t,
                                             const bufferlist &,
                                             const ObjectRequests &, bool));
-  MOCK_METHOD5(append_io_event_mock, uint64_t(const journal::EventEntry&,
+  MOCK_METHOD6(append_io_event_mock, uint64_t(const journal::EventEntry&,
                                               const ObjectRequests &,
-                                              uint64_t, size_t, bool));
+                                              uint64_t, size_t, bool, int));
   uint64_t append_io_event(journal::EventEntry &&event_entry,
                            const ObjectRequests &requests,
                            uint64_t offset, size_t length,
-                           bool flush_entry) {
+                           bool flush_entry, int filter_ret_val) {
     // googlemock doesn't support move semantics
     return append_io_event_mock(event_entry, requests, offset, length,
-                                flush_entry);
+                                flush_entry, filter_ret_val);
   }
 
   MOCK_METHOD3(append_op_event_mock, void(uint64_t, const journal::EventEntry&,


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21628
Signed-off-by: Jason Dillaman <dillaman@redhat.com>