### PR TITLE
Modify mgr-influx module database check to not require admin privileges

### DIFF
--- a/doc/mgr/influx.rst
+++ b/doc/mgr/influx.rst
@@ -51,7 +51,7 @@ For example, a typical configuration might look like this:
 Additional optional configuration settings are:
 
 :interval: Time between reports to InfluxDB.  Default 5 seconds.
-:database: InfluxDB database name.  Default "ceph"
+:database: InfluxDB database name.  Default "ceph".  You will need to create this database and grant write privileges to the configured username or the username must have admin privileges to create it.  
 :port: InfluxDB server port.  Default 8086
     
 

--- a/src/pybind/mgr/influx/module.py
+++ b/src/pybind/mgr/influx/module.py
@@ -83,7 +83,7 @@ class Module(MgrModule):
                 value = counter_info['value']
 
                 data.append({
-                    "measurement": "ceph_osd_stats",
+                    "measurement": "ceph_daemon_stats",
                     "tags": {
                         "ceph_daemon": daemon,
                         "type_instance": path,


### PR DESCRIPTION
- existing check tried to list all DB and fails even if DB exists if user is not admin level
- still tries to create database if not found and user has privs
- modified measurement for daemon stats to be ceph_daemon_stats (was _osd_)

Signed-off-by: Benjeman Meekhof <bmeekhof@umich.edu>