### PR TITLE
testing-ptl-tool2: fix error messages in RGWAccessKeyPool::modify_key()

### DIFF
--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -1033,14 +1033,14 @@ int RGWAccessKeyPool::modify_key(RGWUserAdminOpState& op_state, std::string *err
   case KEY_TYPE_S3:
     id = op_state.get_access_key();
     if (id.empty()) {
-      set_err_msg(err_msg, "no access key specified");
+      set_err_msg(err_msg, "testing ptl-tool: no S3 key specified");
       return -ERR_INVALID_ACCESS_KEY;
     }
     break;
   case KEY_TYPE_SWIFT:
     id = op_state.build_default_swift_kid();
     if (id.empty()) {
-      set_err_msg(err_msg, "no subuser specified");
+      set_err_msg(err_msg, "testing ptl-tool: no swift key specified");
       return -EINVAL;
     }
     break;


### PR DESCRIPTION
**Do not merge this**. This PR is created for testing [ptl-tool.py](https://github.com/ceph/ceph/pull/18032)

Signed-off-by: Jos Collin <jcollin@redhat.com>