### PR TITLE
Delegation support for libcephfs

### DIFF
--- a/src/client/CMakeLists.txt
+++ b/src/client/CMakeLists.txt
@@ -7,6 +7,7 @@ set(libclient_srcs
   ClientSnapRealm.cc
   MetaSession.cc
   Trace.cc
-  posix_acl.cc)
+  posix_acl.cc
+  Delegation.cc)
 add_library(client STATIC ${libclient_srcs})
 target_link_libraries(client osdc)

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -2675,6 +2675,9 @@ void Client::handle_mds_map(MMDSMap* m)
     }
   }
 
+  utime_t session_timeout = mdsmap->get_session_timeout();
+  if ((session_timeout - 1.0) <= deleg_timeout)
+    deleg_timeout = session_timeout - 1.0;
   // kick any waiting threads
   signal_cond_list(waiting_for_mdsmap);
 
@@ -13849,7 +13852,11 @@ void Client::handle_conf_change(const struct md_config_t *conf,
       acl_type = POSIX_ACL;
   }
   if (changed.count("client_deleg_timeout")) {
+    utime_t session_timeout = mdsmap->get_session_timeout();
+
     deleg_timeout = cct->_conf->get_val<double>("client_deleg_timeout");
+    if (session_timeout && ((session_timeout - 1.0) <= deleg_timeout))
+      deleg_timeout = session_timeout - 1.0;
   }
   if (changed.count("client_deleg_break_on_open")) {
     deleg_break_on_open = cct->_conf->get_val<bool>("client_deleg_break_on_open");

--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -83,6 +83,7 @@
 #include "Client.h"
 #include "Inode.h"
 #include "Dentry.h"
+#include "Delegation.h"
 #include "Dir.h"
 #include "ClientSnapRealm.h"
 #include "Fh.h"
@@ -272,6 +273,9 @@ Client::Client(Messenger *m, MonClient *mc, Objecter *objecter_)
     acl_type = POSIX_ACL;
 
   lru.lru_set_midpoint(cct->_conf->client_cache_mid);
+
+  deleg_timeout = cct->_conf->get_val<double>("client_deleg_timeout");
+  deleg_break_on_open = cct->_conf->get_val<bool>("client_deleg_break_on_open");
 
   // file handles
   free_fd_set.insert(10, 1<<30);
@@ -5065,10 +5069,17 @@ void Client::handle_cap_grant(MetaSession *session, Inode *in, Cap *cap, MClient
   check_cap_issue(in, cap, new_caps);
 
   // update caps
-  if (old_caps & ~new_caps) { 
-    ldout(cct, 10) << "  revocation of " << ccap_string(~new_caps & old_caps) << dendl;
+  int revoked = old_caps & ~new_caps;
+  if (revoked) {
+    ldout(cct, 10) << "  revocation of " << ccap_string(revoked) << dendl;
     cap->issued = new_caps;
     cap->implemented |= new_caps;
+
+    // recall delegations if we're losing caps necessary for them
+    if (revoked & ceph_deleg_caps_for_type(CEPH_DELEGATION_RD))
+      in->recall_deleg(false);
+    else if (revoked & ceph_deleg_caps_for_type(CEPH_DELEGATION_WR))
+      in->recall_deleg(true);
 
     if (((used & ~new_caps) & CEPH_CAP_FILE_BUFFER)
         && !_flush(in, new C_Client_FlushComplete(this, in))) {
@@ -5828,10 +5839,8 @@ void Client::flush_mdlog(MetaSession *session)
 }
 
 
-void Client::unmount()
+void Client::_unmount()
 {
-  Mutex::Locker lock(client_lock);
-
   if (unmounting)
     return;
 
@@ -5949,6 +5958,12 @@ void Client::unmount()
   mounted = false;
 
   ldout(cct, 2) << "unmounted." << dendl;
+}
+
+void Client::unmount()
+{
+  Mutex::Locker lock(client_lock);
+  _unmount();
 }
 
 void Client::flush_cap_releases()
@@ -8368,6 +8383,8 @@ int Client::_release_fh(Fh *f)
   Inode *in = f->inode.get();
   ldout(cct, 5) << "_release_fh " << f << " mode " << f->mode << " on " << *in << dendl;
 
+  in->unset_deleg(f);
+
   if (in->snapid == CEPH_NOSNAP) {
     if (in->put_open_ref(f->mode)) {
       _flush(in, new C_Client_FlushComplete(this, in));
@@ -8419,11 +8436,12 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
 
   in->get_open_ref(cmode);  // make note of pending open, since it effects _wanted_ caps.
 
-  if ((flags & O_TRUNC) == 0 &&
-      in->caps_issued_mask(want)) {
+  if ((flags & O_TRUNC) == 0 && in->caps_issued_mask(want)) {
     // update wanted?
     check_caps(in, CHECK_CAPS_NODELAY);
   } else {
+    int need = 0, have;
+
     MetaRequest *req = new MetaRequest(CEPH_MDS_OP_OPEN);
     filepath path;
     in->make_nosnap_relative_path(path);
@@ -8434,10 +8452,28 @@ int Client::_open(Inode *in, int flags, mode_t mode, Fh **fhp,
     if (cct->_conf->client_debug_getattr_caps)
       req->head.args.open.mask = DEBUG_GETATTR_CAPS;
     else
-      req->head.args.open.mask = 0;
+      req->head.args.open.mask = need;
     req->head.args.open.old_size = in->size;   // for O_TRUNC
     req->set_inode(in);
     result = make_request(req, perms);
+
+    /* Wait on minimal caps, just to break delegations */
+    if (deleg_break_on_open) {
+      if (cmode & CEPH_FILE_MODE_WR)
+        need |= CEPH_CAP_FILE_WR;
+      if (cmode & CEPH_FILE_MODE_RD)
+        need |= CEPH_CAP_FILE_RD;
+
+      result = get_caps(in, need, want, &have, -1);
+      if (result < 0) {
+	ldout(cct, 1) << "Unable to get caps after open of inode " << *in <<
+			  " forcibly unmounting client: " <<
+			  cpp_strerror(result) << dendl;
+	_unmount();
+      } else {
+	put_cap_ref(in, need);
+      }
+    }
   }
 
   // success?
@@ -11926,8 +11962,9 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
   req->set_filepath(path);
 
   InodeRef otherin;
-
+  Inode *in;
   Dentry *de;
+
   int res = get_or_create(dir, name, &de);
   if (res < 0)
     goto fail;
@@ -11938,7 +11975,10 @@ int Client::_unlink(Inode *dir, const char *name, const UserPerm& perm)
   res = _lookup(dir, name, 0, &otherin, perm);
   if (res < 0)
     goto fail;
-  req->set_other_inode(otherin.get());
+
+  in = otherin.get();
+  req->set_other_inode(in);
+  in->break_all_delegs();
   req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
 
   req->set_inode(dir);
@@ -12108,15 +12148,26 @@ int Client::_rename(Inode *fromdir, const char *fromname, Inode *todir, const ch
     res = _lookup(fromdir, fromname, 0, &oldin, perm);
     if (res < 0)
       goto fail;
-    req->set_old_inode(oldin.get());
+
+    Inode *oldinode = oldin.get();
+    oldinode->break_all_delegs();
+    req->set_old_inode(oldinode);
     req->old_inode_drop = CEPH_CAP_LINK_SHARED;
 
     res = _lookup(todir, toname, 0, &otherin, perm);
-    if (res != 0 && res != -ENOENT) {
-      goto fail;
-    } else if (res == 0) {
-      req->set_other_inode(otherin.get());
+    switch (res) {
+    case 0:
+      {
+	Inode *in = otherin.get();
+	req->set_other_inode(in);
+	in->break_all_delegs();
+      }
       req->other_inode_drop = CEPH_CAP_LINK_SHARED | CEPH_CAP_LINK_EXCL;
+      break;
+    case -ENOENT:
+      break;
+    default:
+      goto fail;
     }
 
     req->set_inode(todir);
@@ -12187,6 +12238,7 @@ int Client::_link(Inode *in, Inode *dir, const char *newname, const UserPerm& pe
     return -EDQUOT;
   }
 
+  in->break_all_delegs();
   MetaRequest *req = new MetaRequest(CEPH_MDS_OP_LINK);
 
   filepath path(newname, dir->ino);
@@ -13029,6 +13081,33 @@ int Client::ll_flock(Fh *fh, int cmd, uint64_t owner)
   return _flock(fh, cmd, owner);
 }
 
+int Client::ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv)
+{
+  int ret = -EINVAL;
+
+  Mutex::Locker lock(client_lock);
+
+  if (!mounted)
+    return -ENOTCONN;
+
+  Inode *inode = fh->inode.get();
+
+  switch(cmd) {
+  case CEPH_DELEGATION_NONE:
+    inode->unset_deleg(fh);
+    ret = 0;
+    break;
+  default:
+    try {
+      ret = inode->set_deleg(fh, cmd, cb, priv);
+    } catch (std::bad_alloc) {
+      ret = -ENOMEM;
+    }
+    break;
+  }
+  return ret;
+}
+
 class C_Client_RequestInterrupt : public Context  {
 private:
   Client *client;
@@ -13749,6 +13828,8 @@ const char** Client::get_tracked_conf_keys() const
     "client_cache_size",
     "client_cache_mid",
     "client_acl_type",
+    "client_deleg_timeout",
+    "client_deleg_break_on_open",
     NULL
   };
   return keys;
@@ -13766,6 +13847,12 @@ void Client::handle_conf_change(const struct md_config_t *conf,
     acl_type = NO_ACL;
     if (cct->_conf->client_acl_type == "posix_acl")
       acl_type = POSIX_ACL;
+  }
+  if (changed.count("client_deleg_timeout")) {
+    deleg_timeout = cct->_conf->get_val<double>("client_deleg_timeout");
+  }
+  if (changed.count("client_deleg_break_on_open")) {
+    deleg_break_on_open = cct->_conf->get_val<bool>("client_deleg_break_on_open");
   }
 }
 
@@ -13852,4 +13939,3 @@ void StandaloneClient::shutdown()
   objecter->shutdown();
   monclient->shutdown();
 }
-

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -507,7 +507,7 @@ protected:
   friend class C_Block_Sync; // Calls block map and protected helpers
   friend class C_Client_RequestInterrupt;
   friend class C_Client_Remount;
-  friend class C_C_Deleg_Timeout; // Asserts on client_lock, called when a delegation is unreturned
+  friend class C_Deleg_Timeout; // Asserts on client_lock, called when a delegation is unreturned
   friend void intrusive_ptr_release(Inode *in);
 
   //int get_cache_size() { return lru.lru_get_size(); }

--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -139,6 +139,9 @@ typedef int (*client_getgroups_callback_t)(void *handle, gid_t **sgids);
 typedef void(*client_switch_interrupt_callback_t)(void *handle, void *data);
 typedef mode_t (*client_umask_callback_t)(void *handle);
 
+/* Callback for delegation recalls */
+typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
+
 struct client_callback_args {
   void *handle;
   client_ino_callback_t ino_cb;
@@ -389,6 +392,7 @@ protected:
   bool   mounted;
   bool   unmounting;
   bool   blacklisted;
+  bool	 deleg_break_on_open;
 
   // When an MDS has sent us a REJECT, remember that and don't
   // contact it again.  Remember which inst rejected us, so that
@@ -404,6 +408,8 @@ protected:
 public:
   entity_name_t get_myname() { return messenger->get_myname(); } 
   void _sync_write_commit(Inode *in);
+  void wait_on_list(list<Cond*>& ls);
+  void signal_cond_list(list<Cond*>& ls);
 
 protected:
   std::unique_ptr<Filer>             filer;
@@ -482,8 +488,6 @@ protected:
 
   // helpers
   void wake_inode_waiters(MetaSession *s);
-  void wait_on_list(list<Cond*>& ls);
-  void signal_cond_list(list<Cond*>& ls);
 
   void wait_on_context_list(list<Context*>& ls);
   void signal_context_list(list<Context*>& ls);
@@ -494,12 +498,16 @@ protected:
   void put_inode(Inode *in, int n=1);
   void close_dir(Dir *dir);
 
+  // same as unmount() but for when the client_lock is already held
+  void _unmount();
+
   friend class C_Client_FlushComplete; // calls put_inode()
   friend class C_Client_CacheInvalidate;  // calls ino_invalidate_cb
   friend class C_Client_DentryInvalidate;  // calls dentry_invalidate_cb
   friend class C_Block_Sync; // Calls block map and protected helpers
   friend class C_Client_RequestInterrupt;
   friend class C_Client_Remount;
+  friend class C_C_Deleg_Timeout; // Asserts on client_lock, called when a delegation is unreturned
   friend void intrusive_ptr_release(Inode *in);
 
   //int get_cache_size() { return lru.lru_get_size(); }
@@ -731,6 +739,7 @@ protected:
   // fs ops.
 private:
 
+  double deleg_timeout;
   void fill_dirent(struct dirent *de, const char *name, int type, uint64_t ino, loff_t next_off);
 
   // some readdir helpers
@@ -1237,6 +1246,8 @@ public:
   const char** get_tracked_conf_keys() const override;
   void handle_conf_change(const struct md_config_t *conf,
 	                          const std::set <std::string> &changed) override;
+  int ll_delegation(Fh *fh, unsigned cmd, ceph_deleg_cb_t cb, void *priv);
+  double get_deleg_timeout() { return deleg_timeout; }
 };
 
 /**

--- a/src/client/Delegation.cc
+++ b/src/client/Delegation.cc
@@ -63,10 +63,10 @@ Delegation::~Delegation()
 
 void Delegation::reinit(unsigned _type, ceph_deleg_cb_t _recall_cb, void *_priv)
 {
-  Inode *inode = fh->inode.get();
-
   /* update cap refs -- note that we do a get first to avoid any going to 0 */
   if (type != _type) {
+    Inode *inode = fh->inode.get();
+
     inode->client->get_cap_ref(inode, ceph_deleg_caps_for_type(_type));
     inode->client->put_cap_ref(inode, ceph_deleg_caps_for_type(type));
     type = _type;

--- a/src/client/Delegation.cc
+++ b/src/client/Delegation.cc
@@ -1,0 +1,115 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#include "common/Clock.h"
+#include "common/Timer.h"
+
+#include "Client.h"
+#include "Inode.h"
+#include "Fh.h"
+#include "Delegation.h"
+
+/**
+ * ceph_deleg_caps_for_type - what caps are necessary for a delegation?
+ * @type: delegation request type
+ *
+ * Determine what caps are necessary in order to grant a delegation of a given
+ * type. For read delegations, we need whatever we require in order to do
+ * cached reads, plus AsLs to cover metadata changes that should trigger a
+ * recall. We also grab Xs since changing xattrs usually alters the mtime and
+ * so would trigger a recall.
+ *
+ * For write delegations, we need whatever read delegations need plus the
+ * caps to allow writing to the file (Fbwx).
+ *
+ * FIXME: Unfortunately, the MDS will begin recalling caps and then reply to
+ * the open, before caps are returned by a client. This means that write
+ * delegations are not currently being broken by conflicting opens. You have
+ * to wait for an actual attempt at conflicting access. The workaround for now
+ * is to have write delegations request AxXx.
+ */
+int ceph_deleg_caps_for_type(unsigned type)
+{
+	int caps = CEPH_CAP_PIN;
+
+	switch (type) {
+	case CEPH_DELEGATION_WR:
+		caps |= CEPH_CAP_FILE_EXCL |
+			CEPH_CAP_FILE_WR | CEPH_CAP_FILE_BUFFER;
+		/* Fallthrough */
+	case CEPH_DELEGATION_RD:
+		caps |= CEPH_CAP_FILE_SHARED |
+			CEPH_CAP_FILE_RD | CEPH_CAP_FILE_CACHE |
+			CEPH_CAP_XATTR_SHARED |
+			CEPH_CAP_LINK_SHARED | CEPH_CAP_AUTH_SHARED;
+		break;
+	default:
+		// Should never happen
+		assert(false);
+	}
+	return caps;
+}
+
+/*
+ * A delegation is a container for holding caps on behalf of a client that
+ * wants to be able to rely on them until recalled.
+ */
+Delegation::Delegation(Fh *_fh, unsigned _type, ceph_deleg_cb_t _cb, void *_priv)
+	: fh(_fh), priv(_priv), type(_type), recall_cb(_cb),
+	  recall_time(utime_t()), timeout_event(nullptr)
+{
+  Inode *inode = _fh->inode.get();
+  inode->client->get_cap_ref(inode, ceph_deleg_caps_for_type(_type));
+};
+
+Delegation::~Delegation()
+{
+  Inode *inode = fh->inode.get();
+  inode->client->put_cap_ref(inode, ceph_deleg_caps_for_type(type));
+}
+
+void Delegation::reinit(unsigned _type, ceph_deleg_cb_t _recall_cb, void *_priv)
+{
+  Inode *inode = fh->inode.get();
+
+  /* update cap refs -- note that we do a get first to avoid any going to 0 */
+  if (type != _type) {
+    inode->client->get_cap_ref(inode, ceph_deleg_caps_for_type(_type));
+    inode->client->put_cap_ref(inode, ceph_deleg_caps_for_type(type));
+    type = _type;
+  }
+
+  recall_cb = _recall_cb;
+  priv = _priv;
+}
+
+void Delegation::arm_timeout(SafeTimer *timer, Context *event, double timeout)
+{
+  if (timeout_event) {
+    delete event;
+    return;
+  }
+
+  timeout_event = event;
+  timer->add_event_after(timeout, event);
+}
+
+void Delegation::disarm_timeout(SafeTimer *timer)
+{
+  if (!timeout_event)
+    return;
+
+  timer->cancel_event(timeout_event);
+  timeout_event = nullptr;
+}
+
+void Delegation::recall(bool skip_read)
+{
+  /* If skip_read is true, don't break read delegations */
+  if (skip_read && type == CEPH_DELEGATION_RD)
+    return;
+
+  if (!is_recalled()) {
+    recall_cb(fh, priv);
+    recall_time = ceph_clock_now();
+  }
+}

--- a/src/client/Delegation.cc
+++ b/src/client/Delegation.cc
@@ -20,12 +20,6 @@
  *
  * For write delegations, we need whatever read delegations need plus the
  * caps to allow writing to the file (Fbwx).
- *
- * FIXME: Unfortunately, the MDS will begin recalling caps and then reply to
- * the open, before caps are returned by a client. This means that write
- * delegations are not currently being broken by conflicting opens. You have
- * to wait for an actual attempt at conflicting access. The workaround for now
- * is to have write delegations request AxXx.
  */
 int ceph_deleg_caps_for_type(unsigned type)
 {

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -1,0 +1,60 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+#ifndef _CEPH_CLIENT_DELEGATION_H
+#define _CEPH_CLIENT_DELEGATION_H
+
+#include "common/Clock.h"
+#include "common/Timer.h"
+
+class Fh;
+
+/* Commands for manipulating delegation state */
+#ifndef CEPH_DELEGATION_NONE
+# define CEPH_DELEGATION_NONE	0
+# define CEPH_DELEGATION_RD	1
+# define CEPH_DELEGATION_WR	2
+#endif
+
+/* Callback for delegation recalls */
+typedef void (*ceph_deleg_cb_t)(Fh *fh, void *priv);
+
+/* Converts CEPH_DELEGATION_* to cap mask */
+int ceph_deleg_caps_for_type(unsigned type);
+
+/*
+ * A delegation is a container for holding caps on behalf of a client that
+ * wants to be able to rely on them until recalled.
+ */
+class Delegation {
+public:
+  Delegation(Fh *_fh, unsigned _type, ceph_deleg_cb_t _cb, void *_priv);
+  ~Delegation();
+  Fh *get_fh() { return fh; }
+  unsigned get_type() { return type; }
+  bool is_recalled() { return !recall_time.is_zero(); }
+
+  void reinit(unsigned _type, ceph_deleg_cb_t _recall_cb, void *_priv);
+  void arm_timeout(SafeTimer *timer, Context *event, double timeout);
+  void disarm_timeout(SafeTimer *timer);
+  void recall(bool skip_read);
+private:
+  // Filehandle against which it was acquired
+  Fh				*fh;
+
+  // opaque token that will be passed to the callback
+  void				*priv;
+
+  // CEPH_DELEGATION_* type
+  unsigned			type;
+
+  // callback into application to recall delegation
+  ceph_deleg_cb_t		recall_cb;
+
+  // time of first recall
+  utime_t			recall_time;
+
+  // timer for unreturned delegations
+  Context			*timeout_event;
+};
+
+#endif /* _CEPH_CLIENT_DELEGATION_H */

--- a/src/client/Delegation.h
+++ b/src/client/Delegation.h
@@ -34,8 +34,6 @@ public:
   bool is_recalled() { return !recall_time.is_zero(); }
 
   void reinit(unsigned _type, ceph_deleg_cb_t _recall_cb, void *_priv);
-  void arm_timeout(SafeTimer *timer, Context *event, double timeout);
-  void disarm_timeout(SafeTimer *timer);
   void recall(bool skip_read);
 private:
   // Filehandle against which it was acquired
@@ -55,6 +53,9 @@ private:
 
   // timer for unreturned delegations
   Context			*timeout_event;
+
+  void arm_timeout();
+  void disarm_timeout();
 };
 
 #endif /* _CEPH_CLIENT_DELEGATION_H */

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -581,6 +581,7 @@ bool Inode::has_recalled_deleg()
   if (delegations.empty())
     return false;
 
+  // Either all delegations are recalled or none are. Just check the first.
   Delegation& deleg = delegations.front();
   return deleg.is_recalled();
 }

--- a/src/client/Inode.cc
+++ b/src/client/Inode.cc
@@ -8,6 +8,7 @@
 #include "Fh.h"
 #include "MetaSession.h"
 #include "ClientSnapRealm.h"
+#include "Delegation.h"
 
 #include "mds/flock.h"
 
@@ -25,6 +26,12 @@ Inode::~Inode()
     lsubdout(client->cct, client, 0) << __func__ << ": leftover objects on inode 0x"
       << std::hex << ino << std::dec << dendl;
     assert(oset.objects.empty());
+  }
+
+  if (!delegations.empty()) {
+    lsubdout(client->cct, client, 0) << __func__ << ": leftover delegations on inode 0x"
+      << std::hex << ino << std::dec << dendl;
+    assert(delegations.empty());
   }
 }
 
@@ -113,6 +120,7 @@ void Inode::make_nosnap_relative_path(filepath& p)
 void Inode::get_open_ref(int mode)
 {
   open_by_mode[mode]++;
+  break_deleg(!(mode & CEPH_FILE_MODE_WR));
 }
 
 bool Inode::put_open_ref(int mode)
@@ -549,3 +557,175 @@ void Inode::set_async_err(int r)
   }
 }
 
+class C_C_Deleg_Timeout : public Context {
+  Delegation *deleg;
+public:
+  explicit C_C_Deleg_Timeout(Delegation *d) : deleg(d) {}
+  void finish(int r) override {
+    Inode *in = deleg->get_fh()->inode.get();
+    Client *client = in->client;
+
+    // Called back via Timer, which takes client_lock for us
+    assert(client->client_lock.is_locked_by_me());
+
+    lsubdout(client->cct, client, 0) << __func__ <<
+	  ": delegation return timeout for inode 0x" <<
+	  std::hex << in->ino << "forcibly unmounting client "<<
+	  client << std::dec << dendl;
+    client->_unmount();
+  }
+};
+
+bool Inode::has_recalled_deleg()
+{
+  if (delegations.empty())
+    return false;
+
+  Delegation& deleg = delegations.front();
+  return deleg.is_recalled();
+}
+
+void Inode::recall_deleg(bool skip_read)
+{
+  if (delegations.empty())
+    return;
+
+  // Issue any recalls
+  for (list<Delegation>::iterator d = delegations.begin();
+       d != delegations.end(); ++d) {
+
+    Delegation& deleg = *d;
+    Context *timeout_event = new C_C_Deleg_Timeout(&deleg);
+    deleg.recall(skip_read);
+    deleg.arm_timeout(&client->timer, timeout_event,
+		      client->get_deleg_timeout());
+  }
+}
+
+bool Inode::delegations_broken(bool skip_read)
+{
+  if (delegations.empty()) {
+    lsubdout(client->cct, client, 10) <<
+	  __func__ << ": delegations empty on " << *this << dendl;
+    return true;
+  }
+
+  if (skip_read) {
+    Delegation& deleg = delegations.front();
+    lsubdout(client->cct, client, 10) <<
+	__func__ << ": read delegs only on " << *this << dendl;
+    if (deleg.get_type() == CEPH_FILE_MODE_RD) {
+	return true;
+    }
+  }
+  lsubdout(client->cct, client, 10) <<
+	__func__ << ": not broken" << *this << dendl;
+  return false;
+}
+
+void Inode::break_deleg(bool skip_read)
+{
+  lsubdout(client->cct, client, 10) <<
+	  __func__ << ": breaking delegs on " << *this << dendl;
+
+  recall_deleg(skip_read);
+
+  while (!delegations_broken(skip_read))
+    client->wait_on_list(waitfor_deleg);
+}
+
+/**
+ * set_deleg: request a delegation on an open Fh
+ * @fh: filehandle on which to acquire it
+ * @type: delegation request type
+ * @cb: delegation recall callback function
+ * @priv: private pointer to be passed to callback
+ *
+ * Attempt to acquire a delegation on an open file handle. If there are no
+ * conflicts and we have the right caps, allocate a new delegation, fill it
+ * out and return 0. Return an error if we can't get one for any reason.
+ */
+int Inode::set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv)
+{
+  lsubdout(client->cct, client, 10) <<
+	  __func__ << ": inode " << *this << dendl;
+
+  // Just say no if we have any recalled delegs still outstanding
+  if (has_recalled_deleg()) {
+    lsubdout(client->cct, client, 10) << __func__ <<
+	  ": has_recalled_deleg" << dendl;
+    return -EAGAIN;
+  }
+
+  // check vs. currently open files on this inode
+  switch (type) {
+  case CEPH_DELEGATION_RD:
+    if (open_count_for_write()) {
+      lsubdout(client->cct, client, 10) << __func__ <<
+	    ": open for write" << dendl;
+      return -EAGAIN;
+    }
+    break;
+  case CEPH_DELEGATION_WR:
+    if (open_count() > 1) {
+      lsubdout(client->cct, client, 10) << __func__ << ": open" << dendl;
+      return -EAGAIN;
+    }
+    break;
+  default:
+    return -EINVAL;
+  }
+
+  /*
+   * A delegation is essentially a long-held container for cap references that
+   * we delegate to the client until recalled. The caps required depend on the
+   * type of delegation (read vs. rw). This is entirely an opportunistic thing.
+   * If we don't have the necessary caps for the delegation, then we just don't
+   * grant one.
+   *
+   * In principle we could request the caps from the MDS, but a delegation is
+   * usually requested just after an open. If we don't have the necessary caps
+   * already, then it's likely that there is some sort of conflicting access.
+   *
+   * In the future, we may need to add a way to have this request caps more
+   * aggressively -- for instance, to handle WANT_DELEGATION for NFSv4.1+.
+   */
+  int need = ceph_deleg_caps_for_type(type);
+  if (!caps_issued_mask(need)) {
+    lsubdout(client->cct, client, 10) << __func__ << ": cap mismatch, have="
+      << ccap_string(caps_issued()) << " need=" << ccap_string(need) << dendl;
+    return -EAGAIN;
+  }
+
+  for (list<Delegation>::iterator d = delegations.begin();
+       d != delegations.end(); ++d) {
+    Delegation& deleg = *d;
+    if (deleg.get_fh() == fh) {
+      deleg.reinit(type, cb, priv);
+      return 0;
+    }
+  }
+
+  delegations.emplace_back(fh, type, cb, priv);
+  return 0;
+}
+
+/**
+ * unset_deleg - remove a delegation that was previously set
+ * @fh: file handle to clear delegation of
+ *
+ * Unlink delegation from the Inode (if there is one), put caps and free it.
+ */
+void Inode::unset_deleg(Fh *fh)
+{
+  for (list<Delegation>::iterator d = delegations.begin();
+       d != delegations.end(); ++d) {
+    Delegation& deleg = *d;
+    if (deleg.get_fh() == fh) {
+      deleg.disarm_timeout(&client->timer);
+      delegations.erase(d);
+      client->signal_cond_list(waitfor_deleg);
+      break;
+    }
+  }
+}

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -311,14 +311,14 @@ struct Inode {
   int set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv);
   void unset_deleg(Fh *fh);
 
-  // does anything have this Inode open for write?
+  // how many opens for write on this Inode?
   long open_count_for_write()
   {
     return (long)(open_by_mode[CEPH_FILE_MODE_RDWR] +
 		  open_by_mode[CEPH_FILE_MODE_WR]);
   };
 
-  // how many opens currently vs. this inode
+  // how many opens of any sort on this inode?
   long open_count()
   {
     return (long) std::accumulate(open_by_mode.begin(), open_by_mode.end(), 0,

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -4,6 +4,8 @@
 #ifndef CEPH_CLIENT_INODE_H
 #define CEPH_CLIENT_INODE_H
 
+#include <numeric>
+
 #include "include/types.h"
 #include "include/xlist.h"
 
@@ -15,6 +17,7 @@
 
 #include "InodeRef.h"
 #include "UserPerm.h"
+#include "Delegation.h"
 
 class Client;
 struct MetaSession;
@@ -198,6 +201,7 @@ struct Inode {
 
   list<Cond*>       waitfor_caps;
   list<Cond*>       waitfor_commit;
+  list<Cond*>	    waitfor_deleg;
 
   Dentry *get_first_parent() {
     assert(!dn_set.empty());
@@ -225,6 +229,8 @@ struct Inode {
   // file locks
   std::unique_ptr<ceph_lock_state_t> fcntl_locks;
   std::unique_ptr<ceph_lock_state_t> flock_locks;
+
+  list<Delegation> delegations;
 
   xlist<MetaRequest*> unsafe_ops;
 
@@ -291,6 +297,34 @@ struct Inode {
   void rm_fh(Fh *f) {fhs.erase(f);}
   void set_async_err(int r);
   void dump(Formatter *f) const;
+
+  bool has_recalled_deleg();
+  void recall_deleg(bool skip_read);
+  void break_deleg(bool skip_read);
+
+  void break_all_delegs()
+  {
+    break_deleg(false);
+  };
+
+  bool delegations_broken(bool skip_read);
+  int set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv);
+  void unset_deleg(Fh *fh);
+
+  // does anything have this Inode open for write?
+  long open_count_for_write()
+  {
+    return (long)(open_by_mode[CEPH_FILE_MODE_RDWR] +
+		  open_by_mode[CEPH_FILE_MODE_WR]);
+  };
+
+  // how many opens currently vs. this inode
+  long open_count()
+  {
+    return (long) std::accumulate(open_by_mode.begin(), open_by_mode.end(), 0,
+				  [] (int value, const std::map<int, int>::value_type& p)
+                   { return value + p.second; });
+  };
 };
 
 ostream& operator<<(ostream &out, const Inode &in);

--- a/src/client/Inode.h
+++ b/src/client/Inode.h
@@ -298,19 +298,14 @@ struct Inode {
   void set_async_err(int r);
   void dump(Formatter *f) const;
 
-  bool has_recalled_deleg();
+  void break_all_delegs() { break_deleg(false); };
+
   void recall_deleg(bool skip_read);
-  void break_deleg(bool skip_read);
-
-  void break_all_delegs()
-  {
-    break_deleg(false);
-  };
-
-  bool delegations_broken(bool skip_read);
+  bool has_recalled_deleg();
   int set_deleg(Fh *fh, unsigned type, ceph_deleg_cb_t cb, void *priv);
   void unset_deleg(Fh *fh);
 
+private:
   // how many opens for write on this Inode?
   long open_count_for_write()
   {
@@ -325,6 +320,10 @@ struct Inode {
 				  [] (int value, const std::map<int, int>::value_type& p)
                    { return value + p.second; });
   };
+
+  void break_deleg(bool skip_read);
+  bool delegations_broken(bool skip_read);
+
 };
 
 ostream& operator<<(ostream &out, const Inode &in);

--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -24,8 +24,7 @@
 #define STRINGIFY(x) _STR(x)
 
 CephContext *common_preinit(const CephInitParameters &iparams,
-			    enum code_environment_t code_env, int flags,
-			    const char *data_dir_option)
+			    enum code_environment_t code_env, int flags)
 {
   // set code environment
   ANNOTATE_BENIGN_RACE_SIZED(&g_code_env, sizeof(g_code_env), "g_code_env");
@@ -39,9 +38,6 @@ CephContext *common_preinit(const CephInitParameters &iparams,
 
   // Set up our entity name.
   conf->name = iparams.name;
-
-  if (data_dir_option)
-    conf->data_dir_option = data_dir_option;
 
   // different default keyring locations for osd and mds.  this is
   // for backward compatibility.  moving forward, we want all keyrings

--- a/src/common/common_init.h
+++ b/src/common/common_init.h
@@ -57,8 +57,7 @@ enum common_init_flags_t {
  * Your library may also supply functions to read a configuration file.
  */
 CephContext *common_preinit(const CephInitParameters &iparams,
-			    enum code_environment_t code_env, int flags,
-			    const char *data_dir_option = 0);
+			    enum code_environment_t code_env, int flags);
 
 /* Print out some parse errors. */
 void complain_about_parse_errors(CephContext *cct,

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5981,6 +5981,14 @@ std::vector<Option> get_mds_client_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("client_deleg_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    .set_default(75.0)
+    .set_description("time (in seconds) that application has to return delegation after recall"),
+
+    Option("client_deleg_break_on_open", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description("should the client break delegations when opening a file?"),
+
     Option("fuse_use_invalidate_cb", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5982,7 +5982,7 @@ std::vector<Option> get_mds_client_options() {
     .set_description(""),
 
     Option("client_deleg_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(75.0)
+    .set_default(59.0)
     .set_description("time (in seconds) that application has to return delegation after recall"),
 
     Option("client_deleg_break_on_open", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)

--- a/src/global/global_init.cc
+++ b/src/global/global_init.cc
@@ -84,14 +84,13 @@ static int chown_path(const std::string &pathname, const uid_t owner, const gid_
 void global_pre_init(std::vector < const char * > *alt_def_args,
 		     std::vector < const char* >& args,
 		     uint32_t module_type, code_environment_t code_env,
-		     int flags,
-		     const char *data_dir_option)
+		     int flags)
 {
   std::string conf_file_list;
   std::string cluster = "";
   CephInitParameters iparams = ceph_argparse_early_args(args, module_type,
 							&cluster, &conf_file_list);
-  CephContext *cct = common_preinit(iparams, code_env, flags, data_dir_option);
+  CephContext *cct = common_preinit(iparams, code_env, flags);
   cct->_conf->cluster = cluster;
   global_init_set_globals(cct);
   md_config_t *conf = cct->_conf;

--- a/src/global/global_init.h
+++ b/src/global/global_init.h
@@ -46,8 +46,7 @@ void intrusive_ptr_release(CephContext* cct);
 void global_pre_init(std::vector < const char * > *alt_def_args,
 		     std::vector < const char* >& args,
 		     uint32_t module_type, code_environment_t code_env,
-		     int flags,
-		     const char *data_dir_option = 0);
+		     int flags);
 
 /*
  * perform all of the steps that global_init_daemonize performs just prior

--- a/src/include/cephfs/libcephfs.h
+++ b/src/include/cephfs/libcephfs.h
@@ -1572,6 +1572,51 @@ int ceph_ll_getlk(struct ceph_mount_info *cmount,
 int ceph_ll_setlk(struct ceph_mount_info *cmount,
 		  Fh *fh, struct flock *fl, uint64_t owner, int sleep);
 
+/*
+ * Delegation support
+ *
+ * Delegations are way for an application to request exclusive or
+ * semi-exclusive access to an Inode. The client requests the delegation and
+ * if it's successful it can reliably cache file data and metadata until the
+ * delegation is recalled.
+ *
+ * Recalls are issued via a callback function, provided by the application.
+ * Callback functions should act something like signal handlers.  You want to
+ * do as little as possible in the callback. Any major work should be deferred
+ * in some fashion as it's difficult to predict the context in which this
+ * function will be called.
+ *
+ * Once the delegation has been recalled, the application should return it as
+ * soon as possible. The application has client_deleg_timeout seconds to
+ * return it, after which the cmount structure is forcibly unmounted and
+ * further calls into it fail.
+ *
+ * The application can set the client_deleg_timeout config option to suit its
+ * needs, but it should take care to choose a value that allows it to avoid
+ * forcible eviction from the cluster in the event of an application bug.
+ */
+typedef void (*ceph_deleg_cb_t)(struct Fh *fh, void *priv);
+
+/* Commands for manipulating delegation state */
+#ifndef CEPH_DELEGATION_NONE
+# define CEPH_DELEGATION_NONE	0
+# define CEPH_DELEGATION_RD	1
+# define CEPH_DELEGATION_WR	2
+#endif
+
+/**
+ * Request a delegation on an open Fh
+ * @param cmount the ceph mount handle to use.
+ * @param fh file handle
+ * @param cmd CEPH_DELEGATION_* command
+ * @param cb callback function for recalling delegation
+ * @param priv opaque token passed back during recalls
+ *
+ * Returns 0 if the delegation was granted, -EAGAIN if there was a conflict
+ * and other error codes if there is a fatal error of some sort (e.g. -ENOMEM)
+ */
+int ceph_ll_delegation(struct ceph_mount_info *cmount, Fh *fh,
+		       unsigned int cmd, ceph_deleg_cb_t cb, void *priv);
 #ifdef __cplusplus
 }
 #endif

--- a/src/libcephfs.cc
+++ b/src/libcephfs.cc
@@ -1723,6 +1723,12 @@ extern "C" int ceph_ll_setlk(struct ceph_mount_info *cmount,
   return (cmount->get_client()->ll_setlk(fh, fl, owner, sleep));
 }
 
+extern "C" int ceph_ll_delegation(struct ceph_mount_info *cmount, Fh *fh,
+				  unsigned cmd, ceph_deleg_cb_t cb, void *priv)
+{
+  return (cmount->get_client()->ll_delegation(fh, cmd, cb, priv));
+}
+
 extern "C" uint32_t ceph_ll_stripe_unit(class ceph_mount_info *cmount,
 					Inode *in)
 {

--- a/src/test/libcephfs/CMakeLists.txt
+++ b/src/test/libcephfs/CMakeLists.txt
@@ -8,6 +8,7 @@ if(${WITH_CEPHFS})
     recordlock.cc
     acl.cc
     main.cc
+    deleg.cc
   )
   set_target_properties(ceph_test_libcephfs PROPERTIES COMPILE_FLAGS
     ${UNITTEST_CXX_FLAGS})

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -1,0 +1,298 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Tests for Ceph delegation handling
+ *
+ * (c) 2017, Jeff Layton <jlayton@redhat.com>
+ */
+
+#include "gtest/gtest.h"
+#include "include/cephfs/libcephfs.h"
+#include "include/stat.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <dirent.h>
+#include <sys/xattr.h>
+#include <sys/uio.h>
+
+#ifdef __linux__
+#include <limits.h>
+#endif
+
+#include <map>
+#include <vector>
+#include <thread>
+#include <atomic>
+
+static void dummy_deleg_cb(Fh *fh, void *priv)
+{
+  std::atomic_bool *recalled = (std::atomic_bool *)priv;
+  recalled->store(true);
+}
+
+static void open_breaker_func(struct ceph_mount_info *cmount, const char *filename, int flags, std::atomic_bool *opened)
+{
+  bool do_shutdown = false;
+
+  if (!cmount) {
+    ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+    ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+    ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_break_on_open", "true"), 0);
+    ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+    do_shutdown = true;
+  }
+
+  Inode *root, *file;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  ASSERT_EQ(ceph_ll_lookup(cmount, root, filename, &file, &stx, 0, 0, perms), 0);
+  int ret;
+  for (;;) {
+    ret = ceph_ll_open(cmount, file, flags, &fh, perms);
+    if (ret != -EAGAIN)
+      break;
+    usleep(1000);
+  }
+  ASSERT_EQ(ret, 0);
+  opened->store(true);
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+
+  if (do_shutdown)
+    ceph_shutdown(cmount);
+}
+
+enum {
+  DelegTestLink,
+  DelegTestRename,
+  DelegTestUnlink
+};
+
+static void namespace_breaker_func(struct ceph_mount_info *cmount, int cmd, const char *oldname, const char *newname)
+{
+  bool do_shutdown = false;
+
+  if (!cmount) {
+    ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+    ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+    ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_break_on_open", "true"), 0);
+    ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+    do_shutdown = true;
+  }
+
+  Inode *root, *file = nullptr;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  int ret;
+  for (;;) {
+    switch (cmd) {
+    case DelegTestRename:
+      ret = ceph_ll_rename(cmount, root, oldname, root, newname, perms);
+      break;
+    case DelegTestLink:
+      if (!file)
+	ASSERT_EQ(ceph_ll_lookup(cmount, root, oldname, &file, &stx, 0, 0, perms), 0);
+      ret = ceph_ll_link(cmount, file, root, newname, perms);
+      break;
+    case DelegTestUnlink:
+      ret = ceph_ll_unlink(cmount, root, oldname, perms);
+      break;
+    default:
+      // Bad command
+      assert(false);
+    }
+    if (ret != -EAGAIN)
+      break;
+    usleep(1000);
+  }
+  ASSERT_EQ(ret, 0);
+
+  if (do_shutdown)
+    ceph_shutdown(cmount);
+}
+
+static void simple_deleg_test(struct ceph_mount_info *cmount, struct ceph_mount_info *tcmount)
+{
+  Inode *root, *file;
+
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  char filename[32];
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  std::atomic_bool recalled(false);
+  std::atomic_bool opened(false);
+
+  // ensure r/w open breaks a r/w delegation
+  sprintf(filename, "deleg.rwrw.%x", getpid());
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker1(open_breaker_func, tcmount, filename, O_RDWR, &opened);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(opened.load(), false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker1.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+
+  // ensure r/o open breaks a r/w delegation
+  recalled.store(false);
+  opened.store(false);
+  sprintf(filename, "deleg.rorw.%x", getpid());
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker2(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(opened.load(), false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker2.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+
+  // ensure r/o open does not break a r/o delegation
+  sprintf(filename, "deleg.rwro.%x", getpid());
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDONLY|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  recalled.store(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker3(open_breaker_func, tcmount, filename, O_RDONLY, &opened);
+  breaker3.join();
+  ASSERT_EQ(recalled.load(), false);
+
+  // ensure that r/w open breaks r/o delegation
+  opened.store(false);
+  std::thread breaker4(open_breaker_func, tcmount, filename, O_WRONLY, &opened);
+  while (!recalled.load())
+    usleep(1000);
+  usleep(1000);
+  ASSERT_EQ(opened.load(), false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker4.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+
+  // ensure hardlinking breaks a r/w delegation
+  recalled.store(false);
+  char newname[32];
+  sprintf(filename, "deleg.old.%x", getpid());
+  sprintf(newname, "deleg.new.%x", getpid());
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker5(namespace_breaker_func, tcmount, DelegTestLink, filename, newname);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker5.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, filename, perms), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, newname, perms), 0);
+
+  // ensure renaming breaks a r/w delegation
+  recalled.store(false);
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker6(namespace_breaker_func, tcmount, DelegTestRename, filename, newname);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker6.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_unlink(cmount, root, newname, perms), 0);
+
+  // ensure unlinking breaks a r/w delegation
+  recalled.store(false);
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_WR, dummy_deleg_cb, &recalled), 0);
+  std::thread breaker7(namespace_breaker_func, tcmount, DelegTestUnlink, filename, nullptr);
+  while (!recalled.load())
+    usleep(1000);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_NONE, dummy_deleg_cb, &recalled), 0);
+  breaker7.join();
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+}
+
+TEST(LibCephFS, DelegMultiClient) {
+  struct ceph_mount_info *cmount;
+
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_break_on_open", "true"), 0);
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  simple_deleg_test(cmount, nullptr);
+
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, DelegSingleClient) {
+  struct ceph_mount_info *cmount;
+
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_break_on_open", "true"), 0);
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  simple_deleg_test(cmount, cmount);
+
+  ceph_shutdown(cmount);
+}
+
+TEST(LibCephFS, DelegTimeout) {
+  struct ceph_mount_info *cmount;
+  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+  ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_break_on_open", "true"), 0);
+  // tweak timeout to run quickly, since we don't plan to return it anyway
+  ASSERT_EQ(ceph_conf_set(cmount, "client_deleg_timeout", "2.0"), 0);
+  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+
+  Inode *root, *file;
+  ASSERT_EQ(ceph_ll_lookup_root(cmount, &root), 0);
+
+  char filename[32];
+  sprintf(filename, "delegtimeo%x", getpid());
+
+  Fh *fh;
+  struct ceph_statx stx;
+  UserPerm *perms = ceph_mount_perms(cmount);
+
+  ASSERT_EQ(ceph_ll_create(cmount, root, filename, 0666,
+		    O_RDWR|O_CREAT|O_EXCL, &file, &fh, &stx, 0, 0, perms), 0);
+
+  /* Reopen read-only */
+  ASSERT_EQ(ceph_ll_close(cmount, fh), 0);
+  ASSERT_EQ(ceph_ll_open(cmount, file, O_RDONLY, &fh, perms), 0);
+
+  std::atomic_bool recalled(false);
+  ASSERT_EQ(ceph_ll_delegation(cmount, fh, CEPH_DELEGATION_RD, dummy_deleg_cb, &recalled), 0);
+  std::atomic_bool opened(false);
+  std::thread breaker1(open_breaker_func, nullptr, filename, O_RDWR, &opened);
+  breaker1.join();
+  ASSERT_EQ(recalled.load(), true);
+  ASSERT_EQ(ceph_ll_getattr(cmount, root, &stx, 0, 0, perms), -ENOTCONN);
+  ceph_release(cmount);
+}

--- a/src/test/libcephfs/deleg.cc
+++ b/src/test/libcephfs/deleg.cc
@@ -101,8 +101,9 @@ static void namespace_breaker_func(struct ceph_mount_info *cmount, int cmd, cons
       ret = ceph_ll_rename(cmount, root, oldname, root, newname, perms);
       break;
     case DelegTestLink:
-      if (!file)
+      if (!file) {
 	ASSERT_EQ(ceph_ll_lookup(cmount, root, oldname, &file, &stx, 0, 0, perms), 0);
+      }
       ret = ceph_ll_link(cmount, file, root, newname, perms);
       break;
     case DelegTestUnlink:


### PR DESCRIPTION
This is a revised patchset to add delegation support to libcephfs.

It starts with a small, unrelated cleanup patch for common_preinit and global_pre_init.

From there, I reworked the set to do much less pointer and list handling, and changed it over to use exceptions to catch allocation failures.


I've also reworked the interface to use its own set of command constants for requesting delegated state. Along the way, I squashed most of the patches down into a smaller number of patches -- it was too hard to do the rework and keep the patches small.

Since ceph doesn't naturally break delegations on open, this patchset adds a tunable that allows the client to request that behaviour, in addition to setting the delegation timeout. This is implemented by having the client explicitly wait on some caps after the open call.

The tunables also use the observer to watch for config changes now, which is more efficient than calling get_val on every delegation break and open (for instance).

Finally, the testcases have been expanded to cover link, unlink and rename events as well as opens.