### PR TITLE
doc: add osd_max_object_size in osd configuration

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -76,6 +76,12 @@ that Ceph uses the entire partition for the journal.
 :Default: ``90``
 
 
+``osd max object size``
+:Description: The maximum size of a RADOS object in bytes.
+:Type: 32-bit Unsigned Integer
+:Default: 128MB
+
+
 ``osd client message size cap`` 
 
 :Description: The largest client data message allowed in memory.


### PR DESCRIPTION
Having osd_max_write_size in the doc without osd_max_object_size
is confusing.
    
Signed-off-by: Mohamad Gebai <mgebai@suse.com>