### PR TITLE
jewel: rgw: release cls lock if taken in RGWCompleteMultipart 

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4234,7 +4234,7 @@ void RGWCompleteMultipart::execute()
   meta_obj.set_in_extra_data(true);
   meta_obj.index_hash_source = s->object.name;
 
-  auto raw_oid = meta_obj.bucket.bucket_id + "_" + meta_obj.get_object();
+  auto raw_oid = meta_obj.bucket.marker + "_" + meta_obj.get_object();
 
   /*take a cls lock on meta_obj to prevent racing completions (or retries)
     from deleting the parts*/


### PR DESCRIPTION
Backport tracker: http://tracker.ceph.com/issues/21873

Follows Casey's proposal to conditionally release the lock in
::complete(), in order to avoid duplicated code in various early
return cases.

Fixes: http://tracker.ceph.com/issues/21596

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
(cherry picked from commit 704f793f08a02760d23eb5778b738bb07be0e7cf)
Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>