### PR TITLE
qa/suites/rados/monthrash: tolerate PG_AVAILABILITY during mon thrashing

### DIFF
--- a/qa/suites/rados/monthrash/ceph.yaml
+++ b/qa/suites/rados/monthrash/ceph.yaml
@@ -9,6 +9,8 @@ overrides:
       - daemon x is unresponsive
       - overall HEALTH_
       - \(MGR_DOWN\)
+# slow mons -> slow peering -> PG_AVAILABILITY
+      - \(PG_AVAILABILITY)
 tasks:
 - install:
 - ceph:


### PR DESCRIPTION
Signed-off-by: Sage Weil <sage@redhat.com>