### PR TITLE
mon: mark mon_allow_pool_delete as observed

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -444,6 +444,7 @@ const char** Monitor::get_tracked_conf_keys() const
     "mon_health_to_clog_tick_interval",
     // scrub interval
     "mon_scrub_interval",
+    "mon_allow_pool_delete",
     NULL
   };
   return KEYS;


### PR DESCRIPTION
Mark mon_allow_pool_delete as a tracked option. It is always read
from the global conf so users can inject this at runtime.

Signed-off-by: Dan van der Ster <daniel.vanderster@cern.ch>