### PR TITLE
common, libcephfs: Fixes for LibCephFS.ShutdownRace test failures

### DIFF
--- a/src/common/ceph_argparse.cc
+++ b/src/common/ceph_argparse.cc
@@ -98,10 +98,20 @@ void env_to_vec(std::vector<const char*>& args, const char *name)
 
   std::vector<const char*> env_options;
   std::vector<const char*> env_arguments;
-  static vector<string> str_vec;
   std::vector<const char*> env;
-  str_vec.clear();
-  get_str_vec(p, " ", str_vec);
+
+  static std::mutex str_vec_lock;
+  static vector<string> str_vec;
+
+  /*
+   * We can only populate str_vec once. Other threads could hold pointers into
+   * it, so clearing it out and replacing it is not currently safe.
+   */
+  str_vec_lock.lock();
+  if (str_vec.empty())
+    get_str_vec(p, " ", str_vec);
+  str_vec_lock.unlock();
+
   for (vector<string>::iterator i = str_vec.begin();
        i != str_vec.end();
        ++i)

--- a/src/common/ceph_argparse.h
+++ b/src/common/ceph_argparse.h
@@ -41,6 +41,7 @@ public:
 
 /////////////////////// Functions ///////////////////////
 extern void string_to_vec(std::vector<std::string>& args, std::string argstr);
+extern void clear_g_str_vec();
 extern void env_to_vec(std::vector<const char*>& args, const char *name=NULL);
 extern void argv_to_vec(int argc, const char **argv,
                  std::vector<const char*>& args);

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -51,7 +51,8 @@ static ceph::unordered_map<pthread_t, map<int,BackTrace*> > held;
 static char follows[MAX_LOCKS][MAX_LOCKS/8]; // follows[a][b] means b taken after a
 static BackTrace *follows_bt[MAX_LOCKS][MAX_LOCKS];
 unsigned current_maxid;
-int last_freed_id;
+int last_freed_id = -1;
+static bool free_ids_inited;
 
 static bool lockdep_force_backtrace()
 {
@@ -73,10 +74,10 @@ void lockdep_register_ceph_context(CephContext *cct)
     g_lockdep = true;
     g_lockdep_ceph_ctx = cct;
     lockdep_dout(1) << "lockdep start" << dendl;
-    current_maxid = 0;
-	last_freed_id = -1;
-
-    memset((void*) &free_ids[0], 255, sizeof(free_ids));
+    if (!free_ids_inited) {
+      free_ids_inited = true;
+      memset((void*) &free_ids[0], 255, sizeof(free_ids));
+    }
   }
   pthread_mutex_unlock(&lockdep_mutex);
 }
@@ -100,12 +101,8 @@ void lockdep_unregister_ceph_context(CephContext *cct)
     held.clear();
     lock_names.clear();
     lock_ids.clear();
-    lock_refs.clear();
-    memset((void*)&free_ids[0], 0, sizeof(free_ids));
     memset((void*)&follows[0][0], 0, current_maxid * MAX_LOCKS/8);
     memset((void*)&follows_bt[0][0], 0, sizeof(BackTrace*) * current_maxid * MAX_LOCKS);
-    current_maxid = 0;
-    last_freed_id = -1;
   }
   pthread_mutex_unlock(&lockdep_mutex);
 }
@@ -215,40 +212,38 @@ void lockdep_unregister(int id)
   }
 
   pthread_mutex_lock(&lockdep_mutex);
-  if (!g_lockdep) {
-    pthread_mutex_unlock(&lockdep_mutex);
-    return;
-  }
 
+  std::string name;
   map<int, std::string>::iterator p = lock_names.find(id);
-  if (p == lock_names.end()) {
-    pthread_mutex_unlock(&lockdep_mutex);
-    return;
-  }
+  if (p == lock_names.end())
+    name = { "unknown" };
+  else
+    name = p->second;
 
   int &refs = lock_refs[id];
   if (--refs == 0) {
-    // reset dependency ordering
-    memset((void*)&follows[id][0], 0, MAX_LOCKS/8);
-    for (unsigned i=0; i<current_maxid; ++i) {
-      delete follows_bt[id][i];
-      follows_bt[id][i] = NULL;
+    if (p != lock_names.end()) {
+      // reset dependency ordering
+      memset((void*)&follows[id][0], 0, MAX_LOCKS/8);
+      for (unsigned i=0; i<current_maxid; ++i) {
+        delete follows_bt[id][i];
+        follows_bt[id][i] = NULL;
 
-      delete follows_bt[i][id];
-      follows_bt[i][id] = NULL;
-      follows[i][id / 8] &= 255 - (1 << (id % 8));
+        delete follows_bt[i][id];
+        follows_bt[i][id] = NULL;
+        follows[i][id / 8] &= 255 - (1 << (id % 8));
+      }
+
+      lockdep_dout(10) << "unregistered '" << name << "' from " << id << dendl;
+      lock_ids.erase(p->second);
+      lock_names.erase(id);
     }
-
-    lockdep_dout(10) << "unregistered '" << p->second << "' from " << id
-                     << dendl;
-    lock_ids.erase(p->second);
-    lock_names.erase(id);
     lock_refs.erase(id);
     free_ids[id/8] |= (1 << (id % 8));
-	last_freed_id = id;
-  } else {
-    lockdep_dout(20) << "have " << refs << " of '" << p->second << "' "
-                     << "from " << id << dendl;
+    last_freed_id = id;
+  } else if (g_lockdep) {
+    lockdep_dout(20) << "have " << refs << " of '" << name << "' " <<
+			"from " << id << dendl;
   }
   pthread_mutex_unlock(&lockdep_mutex);
 }

--- a/src/test/ceph_argparse.cc
+++ b/src/test/ceph_argparse.cc
@@ -373,17 +373,21 @@ TEST(CephArgParse, env_to_vec) {
     std::vector<const char*> args;
     unsetenv("CEPH_ARGS");
     unsetenv("WHATEVER");
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(0u, args.size());
+    clear_g_str_vec();
     env_to_vec(args, "WHATEVER");
     EXPECT_EQ(0u, args.size());
     args.push_back("a");
     setenv("CEPH_ARGS", "b c", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(3u, args.size());
     EXPECT_EQ(string("b"), args[1]);
     EXPECT_EQ(string("c"), args[2]);
     setenv("WHATEVER", "d e", 0);
+    clear_g_str_vec();
     env_to_vec(args, "WHATEVER");
     EXPECT_EQ(5u, args.size());
     EXPECT_EQ(string("d"), args[3]);
@@ -396,6 +400,7 @@ TEST(CephArgParse, env_to_vec) {
     args.push_back("--");
     args.push_back("c");
     setenv("CEPH_ARGS", "b -- d", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(5u, args.size());
     EXPECT_EQ(string("a"), args[0]);
@@ -410,6 +415,7 @@ TEST(CephArgParse, env_to_vec) {
     args.push_back("a");
     args.push_back("--");
     setenv("CEPH_ARGS", "b -- c", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("a"), args[0]);
@@ -423,6 +429,7 @@ TEST(CephArgParse, env_to_vec) {
     args.push_back("--");
     args.push_back("c");
     setenv("CEPH_ARGS", "b -- d", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("b"), args[0]);
@@ -435,6 +442,7 @@ TEST(CephArgParse, env_to_vec) {
     unsetenv("CEPH_ARGS");
     args.push_back("b");
     setenv("CEPH_ARGS", "c -- d", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("b"), args[0]);
@@ -449,6 +457,7 @@ TEST(CephArgParse, env_to_vec) {
     args.push_back("--");
     args.push_back("c");
     setenv("CEPH_ARGS", "-- d", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("a"), args[0]);
@@ -463,6 +472,7 @@ TEST(CephArgParse, env_to_vec) {
     args.push_back("--");
     args.push_back("c");
     setenv("CEPH_ARGS", "d", 0);
+    clear_g_str_vec();
     env_to_vec(args);
     EXPECT_EQ(4u, args.size());
     EXPECT_EQ(string("a"), args[0]);

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -1862,23 +1862,26 @@ TEST(LibCephFS, OperationsOnRoot)
   ceph_shutdown(cmount);
 }
 
-#define NTHREADS 128
-
 static void shutdown_racer_func()
 {
+  const int niter = 32;
   struct ceph_mount_info *cmount;
+  int i;
 
-  ASSERT_EQ(ceph_create(&cmount, NULL), 0);
-  ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
-  ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
-  ASSERT_EQ(ceph_mount(cmount, "/"), 0);
-  ceph_shutdown(cmount);
+  for (i = 0; i < niter; ++i) {
+    ASSERT_EQ(ceph_create(&cmount, NULL), 0);
+    ASSERT_EQ(ceph_conf_read_file(cmount, NULL), 0);
+    ASSERT_EQ(0, ceph_conf_parse_env(cmount, NULL));
+    ASSERT_EQ(ceph_mount(cmount, "/"), 0);
+    ceph_shutdown(cmount);
+  }
 }
 
 // See tracker #20988
 TEST(LibCephFS, ShutdownRace)
 {
-  std::thread threads[NTHREADS];
+  const int nthreads = 128;
+  std::thread threads[nthreads];
 
   // Need a bunch of fd's for this test
   struct rlimit rold, rnew;
@@ -1887,10 +1890,10 @@ TEST(LibCephFS, ShutdownRace)
   rnew.rlim_cur = rnew.rlim_max;
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rnew), 0);
 
-  for (int i = 0; i < NTHREADS; ++i)
+  for (int i = 0; i < nthreads; ++i)
     threads[i] = std::thread(shutdown_racer_func);
 
-  for (int i = 0; i < NTHREADS; ++i)
+  for (int i = 0; i < nthreads; ++i)
     threads[i].join();
   ASSERT_EQ(setrlimit(RLIMIT_NOFILE, &rold), 0);
 }


### PR DESCRIPTION
@batrick pointed my attention at some ShutdownRace test failures here:

http://tracker.ceph.com/issues/21512

The reported problem should be fixed by the first patch in the series. While testing that, I beefed up the ShutdownRace test a bit, and found and fixed another issue with lockdep:

The main problem there is that lockdep hands out ids that get attached to a Mutex or RWLock. Since those survive lockdep being shut down, we end up with collisions and false positives for lock recursion.

When lockdep is shut down, we can clear out most of the state, but we do need to keep track of which ids are currently assigned out. For that, we need to keep the free ids table, and the refcounting for it persistent past the shutdown.

That means that we need to take a little extra care in lockdep_unregister to clear out the ids in the right way when we're handed one after lockdep has been shut down. Once all locks allocated a valid ID are freed, the lock_refs map should be cleared out naturally.