### PR TITLE
luminous: src/messages/MOSDMap: reencode OSDMap for older clients

### DIFF
--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -86,7 +86,8 @@ public:
 	(features & CEPH_FEATURE_PGPOOL3) == 0 ||
 	(features & CEPH_FEATURE_OSDENC) == 0 ||
         (features & CEPH_FEATURE_OSDMAP_ENC) == 0 ||
-	(features & CEPH_FEATURE_MSG_ADDR2) == 0) {
+	(features & CEPH_FEATURE_MSG_ADDR2) == 0 ||
+	!HAVE_FEATURE(features, SERVER_LUMINOUS)) {
       if ((features & CEPH_FEATURE_PGID64) == 0 ||
 	  (features & CEPH_FEATURE_PGPOOL3) == 0)
 	header.version = 1;  // old old_client version


### PR DESCRIPTION
http://tracker.ceph.com/issues/21692