### PR TITLE
log: Use the coarse real time clock in log timestamps

### DIFF
--- a/src/common/Graylog.cc
+++ b/src/common/Graylog.cc
@@ -77,7 +77,8 @@ void Graylog::log_entry(Entry const * const e)
     m_formatter->dump_string("host", m_hostname);
     m_formatter->dump_string("short_message", s);
     m_formatter->dump_string("_app", "ceph");
-    m_formatter->dump_float("timestamp", e->m_stamp.sec() + (e->m_stamp.usec() / 1000000.0));
+    auto t = ceph::logging::log_clock::to_timeval(e->m_stamp);
+    m_formatter->dump_float("timestamp", t.tv_sec + (t.tv_usec / 1000000.0));
     m_formatter->dump_unsigned("_thread", (uint64_t)e->m_thread);
     m_formatter->dump_int("_level", e->m_prio);
     if (m_subs != NULL)

--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -208,6 +208,7 @@ public:
       "err_to_graylog",
       "log_graylog_host",
       "log_graylog_port",
+      "log_coarse_timestamps",
       "fsid",
       "host",
       NULL
@@ -258,6 +259,10 @@ public:
 
     if (log->graylog() && (changed.count("log_graylog_host") || changed.count("log_graylog_port"))) {
       log->graylog()->set_destination(conf->log_graylog_host, conf->log_graylog_port);
+    }
+
+    if (changed.find("log_coarse_timestamps") != changed.end()) {
+      log->set_coarse_timestamps(conf->_get_val<bool>("log_coarse_timestamps"));
     }
 
     // metadata

--- a/src/common/ceph_time.cc
+++ b/src/common/ceph_time.cc
@@ -84,25 +84,6 @@ namespace ceph {
 
   }
 
-  namespace logging {
-    void log_clock::to_ceph_timespec(const time_point& t,
-				     struct ceph_timespec& ts) {
-      ts.tv_sec = to_time_t(t);
-      ts.tv_nsec = (t.time_since_epoch() %std::chrono::seconds(1)).count();
-    }
-    struct ceph_timespec log_clock::to_ceph_timespec(
-      const time_point& t) {
-      struct ceph_timespec ts;
-      to_ceph_timespec(t, ts);
-      return ts;
-    }
-    log_clock::time_point log_clock::from_ceph_timespec(
-      const struct ceph_timespec& ts) {
-      return time_point(std::chrono::seconds(ts.tv_sec) +
-			std::chrono::nanoseconds(ts.tv_nsec));
-    }
-  }
-
   using std::chrono::duration_cast;
   using std::chrono::seconds;
   using std::chrono::microseconds;
@@ -153,6 +134,4 @@ namespace ceph {
   operator<< <coarse_mono_clock>(std::ostream& m, const coarse_mono_time& t);
   template std::ostream&
   operator<< <coarse_real_clock>(std::ostream& m, const coarse_real_time& t);
-  template std::ostream&
-  operator<< <logging::log_clock>(std::ostream& m, const logging::log_time& t);
 }

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -726,8 +726,16 @@ void md_config_t::_apply_changes(std::ostream *oss)
 void md_config_t::call_all_observers()
 {
   std::map<md_config_obs_t*,std::set<std::string> > obs;
+  // Have the scope of the lock extend to the scope of
+  // handle_conf_change since that function expects to be called with
+  // the lock held. (And the comment in config.h says that is the
+  // expected behavior.)
+  //
+  // An alternative might be to pass a std::unique_lock to
+  // handle_conf_change and have a version of get_var that can take it
+  // by reference and lock as appropriate.
+  Mutex::Locker l(lock);
   {
-    Mutex::Locker l(lock);
 
     expand_all_meta();
 

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -162,6 +162,7 @@ public:
   int _get_val(const std::string &key, char **buf, int len) const;
   Option::value_t get_val_generic(const std::string &key) const;
   template<typename T> T get_val(const std::string &key) const;
+  template<typename T> T _get_val(const std::string &key) const;
 
   void get_all_keys(std::vector<std::string> *keys) const;
 
@@ -334,6 +335,12 @@ struct get_typed_value_visitor : public boost::static_visitor<T> {
 
 template<typename T> T md_config_t::get_val(const std::string &key) const {
   Option::value_t generic_val = this->get_val_generic(key);
+  get_typed_value_visitor<T> gtv;
+  return boost::apply_visitor(gtv, generic_val);
+}
+
+template<typename T> T md_config_t::_get_val(const std::string &key) const {
+  Option::value_t generic_val = this->_get_val(key);
   get_typed_value_visitor<T> gtv;
   return boost::apply_visitor(gtv, generic_val);
 }

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -389,6 +389,13 @@ std::vector<Option> get_global_options() {
     .set_description("port number for the remote graylog server")
     .add_see_also("log_graylog_host"),
 
+    Option("log_coarse_timestamps", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("timestamp log entries from coarse system clock "
+		     "to improve performance")
+    .add_service("common")
+    .add_tag("performance")
+    .add_tag("service"),
 
 
     // unmodified

--- a/src/log/Entry.h
+++ b/src/log/Entry.h
@@ -4,17 +4,17 @@
 #ifndef __CEPH_LOG_ENTRY_H
 #define __CEPH_LOG_ENTRY_H
 
-#include "include/utime.h"
 #include "common/PrebufferedStreambuf.h"
 #include <pthread.h>
 #include <string>
+#include "log/LogClock.h"
 
 
 namespace ceph {
 namespace logging {
 
 struct Entry {
-  utime_t m_stamp;
+  log_time m_stamp;
   pthread_t m_thread;
   short m_prio, m_subsys;
   Entry *m_next;
@@ -31,7 +31,7 @@ struct Entry {
       m_buf_len(sizeof(m_static_buf)),
       m_exp_len(NULL)
   {}
-  Entry(utime_t s, pthread_t t, short pr, short sub,
+  Entry(log_time s, pthread_t t, short pr, short sub,
   const char *msg = NULL)
       : m_stamp(s), m_thread(t), m_prio(pr), m_subsys(sub),
         m_next(NULL),
@@ -40,11 +40,11 @@ struct Entry {
         m_exp_len(NULL)
     {
       if (msg) {
-        ostream os(&m_streambuf);
+	std::ostream os(&m_streambuf);
         os << msg;
       }
     }
-  Entry(utime_t s, pthread_t t, short pr, short sub, char* buf, size_t buf_len, size_t* exp_len,
+  Entry(log_time s, pthread_t t, short pr, short sub, char* buf, size_t buf_len, size_t* exp_len,
 	const char *msg = NULL)
     : m_stamp(s), m_thread(t), m_prio(pr), m_subsys(sub),
       m_next(NULL),
@@ -53,7 +53,7 @@ struct Entry {
       m_exp_len(exp_len)
   {
     if (msg) {
-      ostream os(&m_streambuf);
+      std::ostream os(&m_streambuf);
       os << msg;
     }
   }
@@ -74,7 +74,7 @@ struct Entry {
   }
 
   void set_str(const std::string &s) {
-    ostream os(&m_streambuf);
+    std::ostream os(&m_streambuf);
     os << s;
   }
 

--- a/src/log/Log.cc
+++ b/src/log/Log.cc
@@ -222,12 +222,12 @@ void Log::submit_entry(Entry *e)
 }
 
 
-Entry *Log::create_entry(int level, int subsys)
+Entry *Log::create_entry(int level, int subsys, const char* msg)
 {
   if (true) {
     return new Entry(ceph_clock_now(),
 		     pthread_self(),
-		     level, subsys);
+		     level, subsys, msg);
   } else {
     // kludge for perf testing
     Entry *e = m_recent.dequeue();

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -82,7 +82,7 @@ public:
 
   shared_ptr<Graylog> graylog() { return m_graylog; }
 
-  Entry *create_entry(int level, int subsys);
+  Entry *create_entry(int level, int subsys, const char* msg = nullptr);
   Entry *create_entry(int level, int subsys, size_t* expected_size);
   void submit_entry(Entry *e);
 

--- a/src/log/Log.h
+++ b/src/log/Log.h
@@ -18,6 +18,7 @@ class Entry;
 class Log : private Thread
 {
   Log **m_indirect_this;
+  log_clock clock;
 
   SubsystemMap *m_subs;
 
@@ -58,11 +59,12 @@ class Log : private Thread
   void _log_message(const char *s, bool crash);
 
 public:
-  explicit Log(SubsystemMap *s);
+  Log(SubsystemMap *s);
   ~Log() override;
 
   void set_flush_on_exit();
 
+  void set_coarse_timestamps(bool coarse);
   void set_max_new(int n);
   void set_max_recent(int n);
   void set_log_file(std::string fn);

--- a/src/log/LogClock.h
+++ b/src/log/LogClock.h
@@ -1,0 +1,136 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#ifndef CEPH_LOG_CLOCK_H
+#define CEPH_LOG_CLOCK_H
+
+#include <cstdio>
+#include <chrono>
+#include <ctime>
+#include <sys/time.h>
+
+#include "include/assert.h"
+#include "common/ceph_time.h"
+
+namespace ceph {
+namespace logging {
+class log_clock {
+public:
+  using duration = timespan;
+  using rep = duration::rep;
+  using period = duration::period;
+  // The second template parameter defaults to the clock's duration
+  // type.
+  using time_point = std::chrono::time_point<log_clock>;
+  static constexpr const bool is_steady = false;
+
+  void coarsen() {
+    appropriate_now = coarse_now;
+  }
+
+  void refine() {
+    appropriate_now = fine_now;
+  }
+
+  time_point now() noexcept {
+    return appropriate_now();
+  }
+
+  static bool is_zero(const time_point& t) {
+    return (t == time_point::min());
+  }
+
+  // Allow conversion to/from any clock with the same interface as
+  // std::chrono::system_clock)
+  template<typename Clock, typename Duration>
+  static time_point to_system_time_point(
+    const std::chrono::time_point<Clock, Duration>& t) {
+    return time_point(seconds(Clock::to_time_t(t)) +
+		      std::chrono::duration_cast<duration>(
+			t.time_since_epoch() % std::chrono::seconds(1)));
+  }
+  template<typename Clock, typename Duration>
+  static std::chrono::time_point<Clock, Duration> to_system_time_point(
+    const time_point& t) {
+    return (Clock::from_time_t(to_time_t(t)) +
+	    std::chrono::duration_cast<Duration>(t.time_since_epoch() %
+						 std::chrono::seconds(1)));
+  }
+
+  static time_t to_time_t(const time_point& t) noexcept {
+    return std::chrono::duration_cast<std::chrono::seconds>(
+      t.time_since_epoch()).count();
+  }
+  static time_point from_time_t(const time_t& t) noexcept {
+    return time_point(std::chrono::seconds(t));
+  }
+
+  static void to_timespec(const time_point& t, struct timespec& ts) {
+    ts.tv_sec = to_time_t(t);
+    ts.tv_nsec = (t.time_since_epoch() % std::chrono::seconds(1)).count();
+  }
+  static struct timespec to_timespec(const time_point& t) {
+    struct timespec ts;
+    to_timespec(t, ts);
+    return ts;
+  }
+  static time_point from_timespec(const struct timespec& ts) {
+    return time_point(std::chrono::seconds(ts.tv_sec) +
+		      std::chrono::nanoseconds(ts.tv_nsec));
+  }
+
+  static void to_ceph_timespec(const time_point& t,
+			       struct ceph_timespec& ts);
+  static struct ceph_timespec to_ceph_timespec(const time_point& t);
+  static time_point from_ceph_timespec(const struct ceph_timespec& ts);
+
+  static void to_timeval(const time_point& t, struct timeval& tv) {
+    tv.tv_sec = to_time_t(t);
+    tv.tv_usec = std::chrono::duration_cast<std::chrono::microseconds>(
+      t.time_since_epoch() % std::chrono::seconds(1)).count();
+  }
+  static struct timeval to_timeval(const time_point& t) {
+    struct timeval tv;
+    to_timeval(t, tv);
+    return tv;
+  }
+  static time_point from_timeval(const struct timeval& tv) {
+    return time_point(std::chrono::seconds(tv.tv_sec) +
+		      std::chrono::microseconds(tv.tv_usec));
+  }
+
+  static double to_double(const time_point& t) {
+    return std::chrono::duration<double>(t.time_since_epoch()).count();
+  }
+  static time_point from_double(const double d) {
+    return time_point(std::chrono::duration_cast<duration>(
+			std::chrono::duration<double>(d)));
+  }
+private:
+  static time_point coarse_now() {
+    return time_point(coarse_real_clock::now().time_since_epoch());
+  }
+  static time_point fine_now() {
+    return time_point(real_clock::now().time_since_epoch());
+  }
+  time_point(*appropriate_now)() = coarse_now;
+};
+using log_time = log_clock::time_point;
+inline int append_time(const log_time& t, char *out, int outlen) {
+  auto tv = log_clock::to_timeval(t);
+  std::tm bdt;
+  localtime_r(&tv.tv_sec, &bdt);
+
+  auto r = std::snprintf(out, outlen,
+			 "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
+			 bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+			 bdt.tm_hour, bdt.tm_min, bdt.tm_sec, tv.tv_usec);
+  // Since our caller just adds the return value to something without
+  // checking it…
+  ceph_assert(r >= 0);
+  return r;
+}
+}
+}
+
+#endif

--- a/src/log/LogClock.h
+++ b/src/log/LogClock.h
@@ -14,15 +14,86 @@
 
 namespace ceph {
 namespace logging {
+namespace _logclock {
+// Because the underlying representations of a duration can be any
+// arithmetic type we wish, slipping a coarseness tag there is the
+// least hacky way to tag them. I'd also considered doing bit-stealing
+// and just setting the low bit of the representation unconditionally
+// to mark it as fine, BUT that would cut our nanosecond precision in
+// half which sort of obviates the point of 'fine'…admittedly real
+// computers probably don't care. More to the point it wouldn't be
+// durable under arithmetic unless we wrote a whole class to support
+// it /anyway/, and if I'm going to do that I may as well add a bool.
+
+// (Yes I know we don't do arithmetic on log timestamps, but I don't
+// want everything to suddenly break because someone did something
+// that the std::chrono::timepoint contract actually supports.)
+struct taggedrep {
+  uint64_t count;
+  bool coarse;
+
+  explicit taggedrep(uint64_t count) : count(count), coarse(true) {}
+  taggedrep(uint64_t count, bool coarse) : count(count), coarse(coarse) {}
+
+  explicit operator uint64_t() {
+    return count;
+  }
+};
+
+// Proper significant figure support would be a bit excessive. Also
+// we'd have to know the precision of the clocks on Linux and FreeBSD
+// and whatever else we want to support.
+inline taggedrep operator +(const taggedrep& l, const taggedrep& r) {
+  return { l.count + r.count, l.coarse || r.coarse };
+}
+inline taggedrep operator -(const taggedrep& l, const taggedrep& r) {
+  return { l.count - r.count, l.coarse || r.coarse };
+}
+inline taggedrep operator *(const taggedrep& l, const taggedrep& r) {
+  return { l.count * r.count, l.coarse || r.coarse };
+}
+inline taggedrep operator /(const taggedrep& l, const taggedrep& r) {
+  return { l.count / r.count, l.coarse || r.coarse };
+}
+inline taggedrep operator %(const taggedrep& l, const taggedrep& r) {
+  return { l.count % r.count, l.coarse || r.coarse };
+}
+
+// You can compare coarse and fine time. You shouldn't do so in any
+// case where ordering actually MATTERS but in practice people won't
+// actually ping-pong their logs back and forth between them.
+inline bool operator ==(const taggedrep& l, const taggedrep& r) {
+  return l.count == r.count;
+}
+inline bool operator !=(const taggedrep& l, const taggedrep& r) {
+  return l.count != r.count;
+}
+inline bool operator <(const taggedrep& l, const taggedrep& r) {
+  return l.count < r.count;
+}
+inline bool operator <=(const taggedrep& l, const taggedrep& r) {
+  return l.count <= r.count;
+}
+inline bool operator >=(const taggedrep& l, const taggedrep& r) {
+  return l.count >= r.count;
+}
+inline bool operator >(const taggedrep& l, const taggedrep& r) {
+  return l.count > r.count;
+}
+}
 class log_clock {
 public:
-  using duration = timespan;
-  using rep = duration::rep;
-  using period = duration::period;
+  using rep = _logclock::taggedrep;
+  using period = std::nano;
+  using duration = std::chrono::duration<rep, period>;
   // The second template parameter defaults to the clock's duration
   // type.
   using time_point = std::chrono::time_point<log_clock>;
   static constexpr const bool is_steady = false;
+
+  time_point now() noexcept {
+    return appropriate_now();
+  }
 
   void coarsen() {
     appropriate_now = coarse_now;
@@ -32,99 +103,45 @@ public:
     appropriate_now = fine_now;
   }
 
-  time_point now() noexcept {
-    return appropriate_now();
-  }
-
-  static bool is_zero(const time_point& t) {
-    return (t == time_point::min());
-  }
-
-  // Allow conversion to/from any clock with the same interface as
-  // std::chrono::system_clock)
-  template<typename Clock, typename Duration>
-  static time_point to_system_time_point(
-    const std::chrono::time_point<Clock, Duration>& t) {
-    return time_point(seconds(Clock::to_time_t(t)) +
-		      std::chrono::duration_cast<duration>(
-			t.time_since_epoch() % std::chrono::seconds(1)));
-  }
-  template<typename Clock, typename Duration>
-  static std::chrono::time_point<Clock, Duration> to_system_time_point(
-    const time_point& t) {
-    return (Clock::from_time_t(to_time_t(t)) +
-	    std::chrono::duration_cast<Duration>(t.time_since_epoch() %
-						 std::chrono::seconds(1)));
-  }
-
-  static time_t to_time_t(const time_point& t) noexcept {
-    return std::chrono::duration_cast<std::chrono::seconds>(
-      t.time_since_epoch()).count();
-  }
-  static time_point from_time_t(const time_t& t) noexcept {
-    return time_point(std::chrono::seconds(t));
-  }
-
-  static void to_timespec(const time_point& t, struct timespec& ts) {
-    ts.tv_sec = to_time_t(t);
-    ts.tv_nsec = (t.time_since_epoch() % std::chrono::seconds(1)).count();
-  }
-  static struct timespec to_timespec(const time_point& t) {
-    struct timespec ts;
-    to_timespec(t, ts);
-    return ts;
-  }
-  static time_point from_timespec(const struct timespec& ts) {
-    return time_point(std::chrono::seconds(ts.tv_sec) +
-		      std::chrono::nanoseconds(ts.tv_nsec));
-  }
-
-  static void to_ceph_timespec(const time_point& t,
-			       struct ceph_timespec& ts);
-  static struct ceph_timespec to_ceph_timespec(const time_point& t);
-  static time_point from_ceph_timespec(const struct ceph_timespec& ts);
-
-  static void to_timeval(const time_point& t, struct timeval& tv) {
-    tv.tv_sec = to_time_t(t);
-    tv.tv_usec = std::chrono::duration_cast<std::chrono::microseconds>(
-      t.time_since_epoch() % std::chrono::seconds(1)).count();
-  }
-  static struct timeval to_timeval(const time_point& t) {
-    struct timeval tv;
-    to_timeval(t, tv);
-    return tv;
-  }
-  static time_point from_timeval(const struct timeval& tv) {
-    return time_point(std::chrono::seconds(tv.tv_sec) +
-		      std::chrono::microseconds(tv.tv_usec));
-  }
-
-  static double to_double(const time_point& t) {
-    return std::chrono::duration<double>(t.time_since_epoch()).count();
-  }
-  static time_point from_double(const double d) {
-    return time_point(std::chrono::duration_cast<duration>(
-			std::chrono::duration<double>(d)));
+  // Since our formatting is done in microseconds and we're using it
+  // anyway, we may as well keep this one
+  static timeval to_timeval(time_point t) {
+    auto rep = t.time_since_epoch().count();
+    timespan ts(rep.count);
+    return { std::chrono::duration_cast<std::chrono::seconds>(ts).count(),
+	     std::chrono::duration_cast<std::chrono::microseconds>(
+	       ts % std::chrono::seconds(1)).count() };
   }
 private:
   static time_point coarse_now() {
-    return time_point(coarse_real_clock::now().time_since_epoch());
+    return time_point(
+      duration(_logclock::taggedrep(coarse_real_clock::now()
+				    .time_since_epoch().count(), true)));
   }
   static time_point fine_now() {
-    return time_point(real_clock::now().time_since_epoch());
+    return time_point(
+      duration(_logclock::taggedrep(real_clock::now()
+				    .time_since_epoch().count(), false)));
   }
   time_point(*appropriate_now)() = coarse_now;
 };
 using log_time = log_clock::time_point;
 inline int append_time(const log_time& t, char *out, int outlen) {
+  bool coarse = t.time_since_epoch().count().coarse;
   auto tv = log_clock::to_timeval(t);
   std::tm bdt;
   localtime_r(&tv.tv_sec, &bdt);
 
-  auto r = std::snprintf(out, outlen,
-			 "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
-			 bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
-			 bdt.tm_hour, bdt.tm_min, bdt.tm_sec, tv.tv_usec);
+  int r;
+  if (coarse) {
+    r = std::snprintf(out, outlen, "%04d-%02d-%02d %02d:%02d:%02d.%03ld",
+		      bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+		      bdt.tm_hour, bdt.tm_min, bdt.tm_sec, tv.tv_usec / 1000);
+  } else {
+    r = std::snprintf(out, outlen, "%04d-%02d-%02d %02d:%02d:%02d.%06ld",
+		      bdt.tm_year + 1900, bdt.tm_mon + 1, bdt.tm_mday,
+		      bdt.tm_hour, bdt.tm_min, bdt.tm_sec, tv.tv_usec);
+  }
   // Since our caller just adds the return value to something without
   // checking it…
   ceph_assert(r >= 0);

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -229,3 +229,25 @@ TEST(Log, LargeLog)
   log.flush();
   log.stop();
 }
+
+// Make sure nothing bad happens when we switch
+
+TEST(Log, TimeSwitch)
+{
+  SubsystemMap subs;
+  subs.add(1, "foo", 20, 10);
+  Log log(&subs);
+  log.start();
+  log.set_log_file("/tmp/time_switch_log");
+  log.reopen_log_file();
+  int l = 10;
+  bool coarse = true;
+  for (auto i = 0U; i < 300; ++i) {
+    log.submit_entry(
+      log.create_entry(l, 1, "SQUID THEFT! PUNISHABLE BY DEATH!"));
+    if (i % 50)
+      log.set_coarse_timestamps(coarse = !coarse);
+  }
+  log.flush();
+  log.stop();
+}

--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -251,3 +251,26 @@ TEST(Log, TimeSwitch)
   log.flush();
   log.stop();
 }
+
+TEST(Log, TimeFormat)
+{
+  static constexpr auto buflen = 128u;
+  char buf[buflen];
+  ceph::logging::log_clock clock;
+  {
+    clock.coarsen();
+    auto t = clock.now();
+    ceph::logging::append_time(t, buf, buflen);
+    auto c = std::strrchr(buf, '.');
+    ASSERT_NE(c, nullptr);
+    ASSERT_EQ(strlen(c + 1), 3);
+  }
+  {
+    clock.refine();
+    auto t = clock.now();
+    ceph::logging::append_time(t, buf, buflen);
+    auto c = std::strrchr(buf, '.');
+    ASSERT_NE(c, nullptr);
+    ASSERT_EQ(std::strlen(c + 1), 6);
+  }
+}


### PR DESCRIPTION
With an option to use the higher resolution clock if we want to.

This address a Trello Card or whatever.