### PR TITLE
doc: client.cinder requires rwx permission against images pool

### DIFF
--- a/doc/rbd/rbd-openstack.rst
+++ b/doc/rbd/rbd-openstack.rst
@@ -129,7 +129,7 @@ and Glance. Execute the following::
 
 If you run an OpenStack version before Mitaka, create the following ``client.cinder`` key::
 
-    ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rx pool=images'
+    ceph auth get-or-create client.cinder mon 'allow r' osd 'allow class-read object_prefix rbd_children, allow rwx pool=volumes, allow rwx pool=vms, allow rwx pool=images'
 
 Since Mitaka introduced the support of RBD snapshots while doing a snapshot of a Nova instance,
 we need to allow the ``client.cinder`` key write access to the ``images`` pool; therefore, create the following key::


### PR DESCRIPTION
doc/rbd/rbd-openstack.rst: ``client.cinder`` requires ``rwx`` permission against images pool otherwise snapshot process fails.

NOTE: ``rbd-openstack.rst`` in ``master`` shows different method.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>