### PR TITLE
qa/standalone/scrub/osd-scrub-repair.sh: drop omap_digest flag

### DIFF
--- a/qa/standalone/scrub/osd-scrub-repair.sh
+++ b/qa/standalone/scrub/osd-scrub-repair.sh
@@ -649,7 +649,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:ce3f1d6a:::ROBJ1:head(47'54 osd.0.0:53 dirty|omap|data_digest|omap_digest|extents s 7 uv 3 dd 2ddbf8f5 od f5fba2c6 alloc_hint [0 0 0])",
+      "selected_object_info": "3:ce3f1d6a:::ROBJ1:head(47'54 osd.0.0:53 dirty|omap|data_digest|extents s 7 uv 3 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "size_mismatch_oi",
         "obj_size_oi_mismatch"
@@ -681,7 +681,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:bc819597:::ROBJ12:head(47'52 osd.0.0:51 dirty|omap|data_digest|omap_digest|extents s 7 uv 36 dd 2ddbf8f5 od 67f306a alloc_hint [0 0 0])",
+      "selected_object_info": "3:bc819597:::ROBJ12:head(47'52 osd.0.0:51 dirty|omap|data_digest|extents s 7 uv 36 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "stat_error"
       ],
@@ -710,7 +710,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:d60617f9:::ROBJ13:head(47'55 osd.0.0:54 dirty|omap|data_digest|omap_digest|extents s 7 uv 39 dd 2ddbf8f5 od 6441854d alloc_hint [0 0 0])",
+      "selected_object_info": "3:d60617f9:::ROBJ13:head(47'55 osd.0.0:54 dirty|omap|data_digest|extents s 7 uv 39 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "stat_error"
       ],
@@ -810,7 +810,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:30259878:::ROBJ15:head(47'46 osd.0.0:45 dirty|omap|data_digest|omap_digest|extents s 7 uv 45 dd 2ddbf8f5 od 2d2a4d6e alloc_hint [0 0 0])",
+      "selected_object_info": "3:30259878:::ROBJ15:head(47'46 osd.0.0:45 dirty|omap|data_digest|extents s 7 uv 45 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "oi_attr_missing"
       ],
@@ -890,7 +890,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:f2a5b2a4:::ROBJ3:head(47'57 osd.0.0:56 dirty|omap|data_digest|omap_digest|extents s 7 uv 9 dd 2ddbf8f5 od b35dfd alloc_hint [0 0 0])",
+      "selected_object_info": "3:f2a5b2a4:::ROBJ3:head(47'57 osd.0.0:56 dirty|omap|data_digest|extents s 7 uv 9 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "missing"
       ],
@@ -962,7 +962,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:86586531:::ROBJ8:head(82'62 client.4351.0:1 dirty|omap|data_digest|omap_digest|extents s 7 uv 66 dd 2ddbf8f5 od d6be81dc alloc_hint [0 0 0])",
+      "selected_object_info": "3:86586531:::ROBJ8:head(82'62 client.4351.0:1 dirty|omap|data_digest|extents s 7 uv 66 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [],
       "errors": [
         "attr_value_mismatch",
@@ -979,14 +979,14 @@ function TEST_corrupt_scrub_replicated() {
     {
       "shards": [
         {
-          "object_info": "3:ffdb2004:::ROBJ9:head(102'63 client.4433.0:1 dirty|omap|data_digest|omap_digest|extents s 1 uv 67 dd 2b63260d od 2eecc539 alloc_hint [0 0 0])",
+          "object_info": "3:ffdb2004:::ROBJ9:head(102'63 client.4433.0:1 dirty|omap|data_digest|extents s 1 uv 67 dd 2b63260d alloc_hint [0 0 0])",
           "size": 1,
           "errors": [],
           "osd": 0,
           "primary": false
         },
         {
-          "object_info": "3:ffdb2004:::ROBJ9:head(47'60 osd.0.0:59 dirty|omap|data_digest|omap_digest|extents s 7 uv 27 dd 2ddbf8f5 od 2eecc539 alloc_hint [0 0 0])",
+          "object_info": "3:ffdb2004:::ROBJ9:head(47'60 osd.0.0:59 dirty|omap|data_digest|extents s 7 uv 27 dd 2ddbf8f5 alloc_hint [0 0 0])",
           "size": 1,
           "errors": [
             "obj_size_oi_mismatch"
@@ -995,7 +995,7 @@ function TEST_corrupt_scrub_replicated() {
           "primary": true
         }
       ],
-      "selected_object_info": "3:ffdb2004:::ROBJ9:head(102'63 client.4433.0:1 dirty|omap|data_digest|omap_digest|extents s 1 uv 67 dd 2b63260d od 2eecc539 alloc_hint [0 0 0])",
+      "selected_object_info": "3:ffdb2004:::ROBJ9:head(102'63 client.4433.0:1 dirty|omap|data_digest|extents s 1 uv 67 dd 2b63260d alloc_hint [0 0 0])",
       "union_shard_errors": [
          "obj_size_oi_mismatch"
       ],
@@ -1084,7 +1084,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:ce3f1d6a:::ROBJ1:head(47'54 osd.0.0:53 dirty|omap|data_digest|omap_digest|extents s 7 uv 3 dd 2ddbf8f5 od f5fba2c6 alloc_hint [0 0 0])",
+      "selected_object_info": "3:ce3f1d6a:::ROBJ1:head(47'54 osd.0.0:53 dirty|omap|data_digest|extents s 7 uv 3 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "data_digest_mismatch_oi",
         "size_mismatch_oi",
@@ -1106,42 +1106,6 @@ EOF
       "shards": [
         {
           "data_digest": "0x2ddbf8f5",
-          "omap_digest": "0xa8dd5adc",
-          "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
-          "osd": 0,
-          "primary": false
-        },
-        {
-          "data_digest": "0x2ddbf8f5",
-          "omap_digest": "0xa8dd5adc",
-          "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
-          "osd": 1,
-          "primary": true
-        }
-      ],
-      "selected_object_info": "3:b1f19cbd:::ROBJ10:head(47'51 osd.0.0:50 dirty|omap|data_digest|omap_digest|extents s 7 uv 30 dd 2ddbf8f5 od c2025a24 alloc_hint [0 0 0])",
-      "union_shard_errors": [
-        "omap_digest_mismatch_oi"
-      ],
-      "errors": [],
-      "object": {
-        "version": 30,
-        "snap": "head",
-        "locator": "",
-        "nspace": "",
-        "name": "ROBJ10"
-      }
-    },
-    {
-      "shards": [
-        {
-          "data_digest": "0x2ddbf8f5",
           "omap_digest": "0xa03cef03",
           "size": 7,
           "errors": [],
@@ -1157,7 +1121,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:87abbf36:::ROBJ11:head(47'48 osd.0.0:47 dirty|omap|data_digest|omap_digest|extents s 7 uv 33 dd 2ddbf8f5 od a03cef03 alloc_hint [0 0 0])",
+      "selected_object_info": "3:87abbf36:::ROBJ11:head(47'48 osd.0.0:47 dirty|omap|data_digest|extents s 7 uv 33 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "read_error"
       ],
@@ -1188,7 +1152,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:bc819597:::ROBJ12:head(47'52 osd.0.0:51 dirty|omap|data_digest|omap_digest|extents s 7 uv 36 dd 2ddbf8f5 od 67f306a alloc_hint [0 0 0])",
+      "selected_object_info": "3:bc819597:::ROBJ12:head(47'52 osd.0.0:51 dirty|omap|data_digest|extents s 7 uv 36 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "stat_error"
       ],
@@ -1327,7 +1291,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:30259878:::ROBJ15:head(47'46 osd.0.0:45 dirty|omap|data_digest|omap_digest|extents s 7 uv 45 dd 2ddbf8f5 od 2d2a4d6e alloc_hint [0 0 0])",
+      "selected_object_info": "3:30259878:::ROBJ15:head(47'46 osd.0.0:45 dirty|omap|data_digest|extents s 7 uv 45 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "oi_attr_missing"
       ],
@@ -1416,7 +1380,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:e97ce31e:::ROBJ2:head(47'56 osd.0.0:55 dirty|omap|data_digest|omap_digest|extents s 7 uv 6 dd 2ddbf8f5 od f8e11918 alloc_hint [0 0 0])",
+      "selected_object_info": "3:e97ce31e:::ROBJ2:head(47'56 osd.0.0:55 dirty|omap|data_digest|extents s 7 uv 6 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "data_digest_mismatch_oi"
       ],
@@ -1449,7 +1413,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:f2a5b2a4:::ROBJ3:head(47'57 osd.0.0:56 dirty|omap|data_digest|omap_digest|extents s 7 uv 9 dd 2ddbf8f5 od b35dfd alloc_hint [0 0 0])",
+      "selected_object_info": "3:f2a5b2a4:::ROBJ3:head(47'57 osd.0.0:56 dirty|omap|data_digest|extents s 7 uv 9 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "missing"
       ],
@@ -1468,9 +1432,7 @@ EOF
           "data_digest": "0x2ddbf8f5",
           "omap_digest": "0xd7178dfe",
           "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
+          "errors": [],
           "osd": 0,
           "primary": false
         },
@@ -1483,10 +1445,8 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:f4981d31:::ROBJ4:head(47'58 osd.0.0:57 dirty|omap|data_digest|omap_digest|extents s 7 uv 12 dd 2ddbf8f5 od e2d46ea4 alloc_hint [0 0 0])",
-      "union_shard_errors": [
-        "omap_digest_mismatch_oi"
-      ],
+      "selected_object_info": "3:f4981d31:::ROBJ4:head(47'58 osd.0.0:57 dirty|omap|data_digest|extents s 7 uv 12 dd 2ddbf8f5 alloc_hint [0 0 0])",
+      "union_shard_errors": [],
       "errors": [
         "omap_digest_mismatch"
       ],
@@ -1512,17 +1472,13 @@ EOF
           "data_digest": "0x2ddbf8f5",
           "omap_digest": "0x06cac8f6",
           "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
+          "errors": [],
           "osd": 1,
           "primary": true
         }
       ],
-      "selected_object_info": "3:f4bfd4d1:::ROBJ5:head(47'59 osd.0.0:58 dirty|omap|data_digest|omap_digest|extents s 7 uv 15 dd 2ddbf8f5 od 1a862a41 alloc_hint [0 0 0])",
-      "union_shard_errors": [
-        "omap_digest_mismatch_oi"
-      ],
+      "selected_object_info": "3:f4bfd4d1:::ROBJ5:head(47'59 osd.0.0:58 dirty|omap|data_digest|extents s 7 uv 15 dd 2ddbf8f5 alloc_hint [0 0 0])",
+      "union_shard_errors": [],
       "errors": [
         "omap_digest_mismatch"
       ],
@@ -1540,9 +1496,7 @@ EOF
           "data_digest": "0x2ddbf8f5",
           "omap_digest": "0x689ee887",
           "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
+          "errors": [],
           "osd": 0,
           "primary": false
         },
@@ -1555,10 +1509,8 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:a53c12e8:::ROBJ6:head(47'50 osd.0.0:49 dirty|omap|data_digest|omap_digest|extents s 7 uv 18 dd 2ddbf8f5 od 179c919f alloc_hint [0 0 0])",
-      "union_shard_errors": [
-        "omap_digest_mismatch_oi"
-      ],
+      "selected_object_info": "3:a53c12e8:::ROBJ6:head(47'50 osd.0.0:49 dirty|omap|data_digest|extents s 7 uv 18 dd 2ddbf8f5 alloc_hint [0 0 0])",
+      "union_shard_errors": [],
       "errors": [
         "omap_digest_mismatch"
       ],
@@ -1584,17 +1536,13 @@ EOF
           "data_digest": "0x2ddbf8f5",
           "omap_digest": "0x6a73cc07",
           "size": 7,
-          "errors": [
-            "omap_digest_mismatch_oi"
-          ],
+          "errors": [],
           "osd": 1,
           "primary": true
         }
       ],
-      "selected_object_info": "3:8b55fa4b:::ROBJ7:head(47'49 osd.0.0:48 dirty|omap|data_digest|omap_digest|extents s 7 uv 21 dd 2ddbf8f5 od efced57a alloc_hint [0 0 0])",
-      "union_shard_errors": [
-        "omap_digest_mismatch_oi"
-      ],
+      "selected_object_info": "3:8b55fa4b:::ROBJ7:head(47'49 osd.0.0:48 dirty|omap|data_digest|extents s 7 uv 21 dd 2ddbf8f5 alloc_hint [0 0 0])",
+      "union_shard_errors": [],
       "errors": [
         "omap_digest_mismatch"
       ],
@@ -1669,7 +1617,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:86586531:::ROBJ8:head(82'62 client.4351.0:1 dirty|omap|data_digest|omap_digest|extents s 7 uv 66 dd 2ddbf8f5 od d6be81dc alloc_hint [0 0 0])",
+      "selected_object_info": "3:86586531:::ROBJ8:head(82'62 client.4351.0:1 dirty|omap|data_digest|extents s 7 uv 66 dd 2ddbf8f5 alloc_hint [0 0 0])",
       "union_shard_errors": [],
       "errors": [
         "attr_value_mismatch",
@@ -1686,7 +1634,7 @@ EOF
     {
       "shards": [
         {
-          "object_info": "3:ffdb2004:::ROBJ9:head(47'60 osd.0.0:59 dirty|omap|data_digest|omap_digest|extents s 7 uv 27 dd 2ddbf8f5 od 2eecc539 alloc_hint [0 0 0])",
+          "object_info": "3:ffdb2004:::ROBJ9:head(47'60 osd.0.0:59 dirty|omap|data_digest|extents s 7 uv 27 dd 2ddbf8f5 alloc_hint [0 0 0])",
           "data_digest": "0x1f26fb26",
           "omap_digest": "0x2eecc539",
           "size": 3,
@@ -1697,7 +1645,7 @@ EOF
           "primary": false
         },
         {
-          "object_info": "3:ffdb2004:::ROBJ9:head(122'64 client.4532.0:1 dirty|omap|data_digest|omap_digest|extents s 3 uv 68 dd 1f26fb26 od 2eecc539 alloc_hint [0 0 0])",
+          "object_info": "3:ffdb2004:::ROBJ9:head(122'64 client.4532.0:1 dirty|omap|data_digest|extents s 3 uv 68 dd 1f26fb26 alloc_hint [0 0 0])",
           "data_digest": "0x1f26fb26",
           "omap_digest": "0x2eecc539",
           "size": 3,
@@ -1706,7 +1654,7 @@ EOF
           "primary": true
         }
       ],
-      "selected_object_info": "3:ffdb2004:::ROBJ9:head(122'64 client.4532.0:1 dirty|omap|data_digest|omap_digest|extents s 3 uv 68 dd 1f26fb26 od 2eecc539 alloc_hint [0 0 0])",
+      "selected_object_info": "3:ffdb2004:::ROBJ9:head(122'64 client.4532.0:1 dirty|omap|data_digest|extents s 3 uv 68 dd 1f26fb26 alloc_hint [0 0 0])",
       "union_shard_errors": [
         "obj_size_oi_mismatch"
       ],


### PR DESCRIPTION
This is no longer set if we are backed by bluestore, which we are by
default.  See be078c8b7b131764caa28bc44452b8c5c2339623

Signed-off-by: Sage Weil <sage@redhat.com>
Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>