### PR TITLE
luminous: .gitignore: allow debian .patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@
 *.tmp
 *.orig
 *.patch
+!debian/patches/*.patch
 *.rej
 *.rpm
 *.pyc


### PR DESCRIPTION
The Ubuntu packaging layout with git-buildpackage assumes a "debian/patches/" directory with several .patch files in it.

When upstream's .gitignore tells Git to ignore .patch files, we have to edit that line out downstream. When we forget to do that downstream, it can lead to missing patches and broken downstream builds.

Allow patches in the /debian/patches directory so it's easier to maintain an Ubuntu package based on upstream's Git repo.

(cherry picked from commit c734b0c0296152721b658af7b699a64b3a49d251)