### PR TITLE
RDMA: Remove inflight counter

### DIFF
--- a/src/msg/async/rdma/Infiniband.h
+++ b/src/msg/async/rdma/Infiniband.h
@@ -134,7 +134,6 @@ enum {
   l_msgr_rdma_dispatcher_first = 94000,
 
   l_msgr_rdma_polling,
-  l_msgr_rdma_inflight_tx_chunks,
   l_msgr_rdma_rx_bufs_in_use,
   l_msgr_rdma_rx_bufs_total,
 

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -117,8 +117,6 @@ class RDMADispatcher {
   void handle_tx_event(ibv_wc *cqe, int n);
   void post_tx_buffer(std::vector<Chunk*> &chunks);
 
-  std::atomic<uint64_t> inflight = {0};
-
   void post_chunk_to_pool(Chunk* chunk); 
 
 };


### PR DESCRIPTION
 The patch reduces CPU usage in RDMA "polling" thread.

 "set" function uses spin lock and any update of inflight counter
  spends CPU cycles.

Signed-off-by: Adir lev <adirl@mellanox.com>
Signed-off-by: Sasha Kotchubievsky <sashakot@mellanox.com>