### PR TITLE
[RFC]os/bluestore/BlueFS: for wal write with directio mode.

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3223,6 +3223,10 @@ std::vector<Option> get_global_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("bluefs_wal_direct_io", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description(""),
+
     Option("bluestore_bluefs", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(true)
     .add_tag("mkfs")

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -38,9 +38,15 @@ enum {
   l_bluefs_last,
 };
 
-class BlueFS {
+class BlueFS : public md_config_obs_t {
 public:
   CephContext* cct;
+
+  // config observer
+  const char** get_tracked_conf_keys() const override;
+  void handle_conf_change(const struct md_config_t *conf,
+                                  const std::set<std::string> &changed) override;
+
   static constexpr unsigned MAX_BDEV = 3;
   static constexpr unsigned BDEV_WAL = 0;
   static constexpr unsigned BDEV_DB = 1;
@@ -241,6 +247,8 @@ private:
   FileRef new_log = nullptr;
   FileWriter *new_log_writer = nullptr;
 
+  // WAL read&write whether use directIO
+  bool wal_use_directio = false;
   /*
    * There are up to 3 block devices:
    *


### PR DESCRIPTION
In commit:7d1d689a, it used directio for wal write.
But in 52fa3ba9, Mark Nelson revert commit 7d1d689a because 7d1d689a can
cause performance decrease much.

Now from my tests, i found directio mode can increase performane for
1ssd:2osd. It also cause perfomrnace decreaed for 1ssd:1OSD.

So i reopen this commit and add a option bluefs_wal_direct_io to
control.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>