### PR TITLE
kv: unify {create_and_,}open() methods

### DIFF
--- a/src/kv/KeyValueDB.h
+++ b/src/kv/KeyValueDB.h
@@ -156,17 +156,11 @@ public:
   /// test whether we can successfully initialize; may have side effects (e.g., create)
   static int test_init(const std::string& type, const std::string& dir);
   virtual int init(string option_str="") = 0;
-  virtual int open(std::ostream &out) = 0;
-  virtual int open(std::ostream &out, const vector<ColumnFamily>& cfs) {
-    assert(0 == "Not implemented");
-  }
-  virtual int create_and_open(std::ostream &out) = 0;
-  virtual void close() { }
+  virtual int open(std::ostream &out, const vector<ColumnFamily>& cfs = {}) = 0;
   // vector cfs contains column families to be created when db is created.
   virtual int create_and_open(std::ostream &out,
-			      const vector<ColumnFamily>& cfs) {
-    assert(0 == "Not implemented");
-  }
+			      const vector<ColumnFamily>& cfs = {}) = 0;
+  virtual void close() { }
 
   virtual Transaction get_transaction() = 0;
   virtual int submit_transaction(Transaction) = 0;

--- a/src/kv/KineticStore.cc
+++ b/src/kv/KineticStore.cc
@@ -45,6 +45,22 @@ int KineticStore::_test_init(CephContext *c)
   return status.ok() ? 0 : -EIO;
 }
 
+int KineticStore::open(ostream &out, const vector<ColumnFamily>& cfs)
+{
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, false);
+}
+
+int KineticStore::create_and_open(ostream &out, const vector<ColumnFamily>& cfs)
+{
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, true);
+}
+
 int KineticStore::do_open(ostream &out, bool create_if_missing)
 {
   kinetic::KineticConnectionFactory conn_factory =

--- a/src/kv/KineticStore.h
+++ b/src/kv/KineticStore.h
@@ -52,13 +52,9 @@ public:
   int init();
 
   /// Opens underlying db
-  int open(ostream &out) {
-    return do_open(out, false);
-  }
+  int open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) override {
-    return do_open(out, true);
-  }
+  int create_and_open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
 
   void close();
 

--- a/src/kv/LevelDBStore.cc
+++ b/src/kv/LevelDBStore.cc
@@ -61,6 +61,20 @@ int LevelDBStore::init(string option_str)
   return 0;
 }
 
+int LevelDBStore::open(ostream &out, const vector<ColumnFamily>& cfs)  {
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, false);
+}
+
+int LevelDBStore::create_and_open(ostream &out, const vector<ColumnFamily>& cfs) {
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, true);
+}
+
 int LevelDBStore::do_open(ostream &out, bool create_if_missing)
 {
   leveldb::Options ldoptions;

--- a/src/kv/LevelDBStore.h
+++ b/src/kv/LevelDBStore.h
@@ -174,13 +174,9 @@ public:
   int init(string option_str="") override;
 
   /// Opens underlying db
-  int open(ostream &out) override {
-    return do_open(out, false);
-  }
+  int open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) override {
-    return do_open(out, true);
-  }
+  int create_and_open(ostream &out, const std::vector<ColumnFamily>& = {}) override;
 
   void close() override;
 

--- a/src/kv/MemDB.cc
+++ b/src/kv/MemDB.cc
@@ -167,6 +167,20 @@ int MemDB::do_open(ostream &out, bool create)
   return _init(create);
 }
 
+int MemDB::open(ostream &out, const vector<ColumnFamily>& cfs) {
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, false);
+}
+
+int MemDB::create_and_open(ostream &out, const vector<ColumnFamily>& cfs) {
+  if (!cfs.empty()) {
+    assert(0 == "Not implemented");
+  }
+  return do_open(out, true);
+}
+
 MemDB::~MemDB()
 {
   close();

--- a/src/kv/MemDB.h
+++ b/src/kv/MemDB.h
@@ -122,8 +122,9 @@ public:
   int _init(bool format);
 
   int do_open(ostream &out, bool create);
-  int open(ostream &out) override { return do_open(out, false); }
-  int create_and_open(ostream &out) override { return do_open(out, true); }
+  int open(ostream &out, const std::vector<ColumnFamily>&) override;
+  int create_and_open(ostream &out, const std::vector<ColumnFamily>&) override;
+  using KeyValueDB::create_and_open;
 
   KeyValueDB::Transaction get_transaction() override {
     return std::shared_ptr<MDBTransactionImpl>(new MDBTransactionImpl(this));

--- a/src/kv/RocksDBStore.cc
+++ b/src/kv/RocksDBStore.cc
@@ -309,21 +309,17 @@ int RocksDBStore::install_cf_mergeop(
   return 0;
 }
 
-int RocksDBStore::create_and_open(ostream &out)
-{
-  int r = create_db_dir();
-  if (r < 0)
-    return r;
-  return do_open(out, true);
-}
-
 int RocksDBStore::create_and_open(ostream &out,
 				  const vector<ColumnFamily>& cfs)
 {
   int r = create_db_dir();
   if (r < 0)
     return r;
-  return do_open(out, true, &cfs);
+  if (cfs.empty()) {
+    return do_open(out, true, nullptr);
+  } else {
+    return do_open(out, true, &cfs);
+  }
 }
 
 int RocksDBStore::do_open(ostream &out, bool create_if_missing,

--- a/src/kv/RocksDBStore.h
+++ b/src/kv/RocksDBStore.h
@@ -157,16 +157,12 @@ public:
 
   static bool check_omap_dir(string &omap_dir);
   /// Opens underlying db
-  int open(ostream &out) override {
-    return do_open(out, false);
-  }
-  int open(ostream &out, const vector<ColumnFamily>& cfs) override {
+  int open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
     return do_open(out, false, &cfs);
   }
   /// Creates underlying db if missing and opens it
-  int create_and_open(ostream &out) override;
   int create_and_open(ostream &out,
-		      const vector<ColumnFamily>& cfs) override;
+		      const vector<ColumnFamily>& cfs = {}) override;
 
   void close() override;
 

--- a/src/test/ObjectMap/KeyValueDBMemory.h
+++ b/src/test/ObjectMap/KeyValueDBMemory.h
@@ -22,10 +22,10 @@ public:
   int init(string _opt) override {
     return 0;
   }
-  int open(ostream &out) override {
+  int open(std::ostream &out, const vector<ColumnFamily>& cfs = {}) override {
     return 0;
   }
-  int create_and_open(ostream &out) override {
+  int create_and_open(ostream &out, const vector<ColumnFamily>& cfs = {}) override {
     return 0;
   }
 


### PR DESCRIPTION
this silences the warning of "-Woverloaded-virtual" where create() and
create_and_open() from KeyValueDB are hidden from the ones defined in
derived classes.

Signed-off-by: Kefu Chai <kchai@redhat.com>