### PR TITLE
rgw: update usage() with status

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -194,6 +194,7 @@ void usage()
   cout << "  role-policy delete         delete policy attached to a role\n";
   cout << "  reshard add                schedule a resharding of a bucket\n";
   cout << "  reshard list               list all bucket resharding or scheduled to be reshared\n";
+  cout << "  reshard status             read bucket resharding status\n";
   cout << "  reshard process            process of scheduled reshard jobs\n";
   cout << "  reshard cancel             cancel resharding a bucket\n";
   cout << "options:\n";

--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -193,7 +193,7 @@ void usage()
   cout << "  role-policy get            get the specified inline policy document embedded with the given role\n";
   cout << "  role-policy delete         delete policy attached to a role\n";
   cout << "  reshard add                schedule a resharding of a bucket\n";
-  cout << "  reshard list               list all bucket resharding or scheduled to be reshared\n";
+  cout << "  reshard list               list all bucket resharding or scheduled to be resharded\n";
   cout << "  reshard status             read bucket resharding status\n";
   cout << "  reshard process            process of scheduled reshard jobs\n";
   cout << "  reshard cancel             cancel resharding a bucket\n";

--- a/src/test/cli/radosgw-admin/help.t
+++ b/src/test/cli/radosgw-admin/help.t
@@ -137,7 +137,8 @@
     role-policy get            get the specified inline policy document embedded with the given role
     role-policy delete         delete policy attached to a role
     reshard add                schedule a resharding of a bucket
-    reshard list               list all bucket resharding or scheduled to be reshared
+    reshard list               list all bucket resharding or scheduled to be resharded
+    reshard status             read bucket resharding status
     reshard process            process of scheduled reshard jobs
     reshard cancel             cancel resharding a bucket
   options:


### PR DESCRIPTION
'status' was missing in the usage(). Fixed it.
Found during the review of https://github.com/ceph/ceph/pull/18175.

Also Fixed typos and status in help.t.

Signed-off-by: Jos Collin <jcollin@redhat.com>