### PR TITLE
vstart.sh: quote command only when necessary

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -366,13 +366,24 @@ fi
 
 ARGS="-c $conf_fn"
 
+quoted_print() {
+    for s in "$@"; do
+        if [[ "$s" =~ \  ]]; then
+            printf -- "'%s' " "$s"
+        else
+            printf -- "$s "
+        fi
+    done
+    printf '\n'
+}
+
 prunb() {
-    printf "'%s' " "$@"; echo '&'
+    quoted_print $* '&'
     "$@" &
 }
 
 prun() {
-    printf "'%s' " "$@"; echo
+    quoted_print $*
     "$@"
 }
 


### PR DESCRIPTION
we quote the command args, so it's easier to copy and paste it to rerun
the command. but it's annoying to read the echod command with the
quotes. so quote them only if the arg has space in it, it'd easier for
eyes.

Signed-off-by: Kefu Chai <kchai@redhat.com>