### PR TITLE
src/include/types.h: kill kb_t, use si_t instead

### DIFF
--- a/src/include/types.h
+++ b/src/include/types.h
@@ -405,26 +405,6 @@ inline ostream& operator<<(ostream& out, const pretty_si_t& b)
   return out << b.v << " ";
 }
 
-struct kb_t {
-  uint64_t v;
-  // cppcheck-suppress noExplicitConstructor
-  kb_t(uint64_t _v) : v(_v) {}
-};
-
-inline ostream& operator<<(ostream& out, const kb_t& kb)
-{
-  uint64_t bump_after = 100;
-  if (kb.v > bump_after << 40)
-    return out << (kb.v >> 40) << " PB";    
-  if (kb.v > bump_after << 30)
-    return out << (kb.v >> 30) << " TB";    
-  if (kb.v > bump_after << 20)
-    return out << (kb.v >> 20) << " GB";    
-  if (kb.v > bump_after << 10)
-    return out << (kb.v >> 10) << " MB";
-  return out << kb.v << " kB";
-}
-
 inline ostream& operator<<(ostream& out, const ceph_mon_subscribe_item& i)
 {
   return out << i.start

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -296,10 +296,10 @@ void PGMapDigest::print_oneline_summary(Formatter *f, ostream *out) const
   if (out)
     *out << num_pg << " pgs: "
          << states << "; "
-         << prettybyte_t(pg_sum.stats.sum.num_bytes) << " data, "
-         << kb_t(osd_sum.kb_used) << " used, "
-         << kb_t(osd_sum.kb_avail) << " / "
-         << kb_t(osd_sum.kb) << " avail";
+         << si_t(pg_sum.stats.sum.num_bytes) << " data, "
+         << si_t(osd_sum.kb_used << 10) << " used, "
+         << si_t(osd_sum.kb_avail << 10) << " / "
+         << si_t(osd_sum.kb << 10) << " avail";
   if (f) {
     f->dump_unsigned("num_pgs", num_pg);
     f->dump_unsigned("num_bytes", pg_sum.stats.sum.num_bytes);

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -962,9 +962,9 @@ inline bool operator!=(const osd_stat_t& l, const osd_stat_t& r) {
 
 
 inline ostream& operator<<(ostream& out, const osd_stat_t& s) {
-  return out << "osd_stat(" << kb_t(s.kb_used) << " used, "
-	     << kb_t(s.kb_avail) << " avail, "
-	     << kb_t(s.kb) << " total, "
+  return out << "osd_stat(" << si_t(s.kb_used << 10) << " used, "
+	     << si_t(s.kb_avail << 10) << " avail, "
+	     << si_t(s.kb << 10) << " total, "
 	     << "peers " << s.hb_peers
 	     << " op hist " << s.op_queue_age_hist.h
 	     << ")";


### PR DESCRIPTION
This is good for two reasons:
(1) less code redundancy;
(2) si_t prints a more human-readable result.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>