### PR TITLE
doc: fixes syntax in osd-config-ref

### DIFF
--- a/doc/rados/configuration/osd-config-ref.rst
+++ b/doc/rados/configuration/osd-config-ref.rst
@@ -77,6 +77,7 @@ that Ceph uses the entire partition for the journal.
 
 
 ``osd max object size``
+
 :Description: The maximum size of a RADOS object in bytes.
 :Type: 32-bit Unsigned Integer
 :Default: 128MB


### PR DESCRIPTION
* Fix syntax in osd max object size section.

Fixes: http://tracker.ceph.com/issues/21733
Signed-off-by: Joshua Schmid <jschmid@suse.de>