### PR TITLE
doc: "mds blacklist interval" vs manually blacklisting

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -97,7 +97,12 @@
 
 ``mds blacklist interval``
 
-:Description: The blacklist duration for failed MDSs in the OSD map.
+:Description: The blacklist duration for failed MDSs in the OSD map. Note,
+              this controls how long failed MDS daemons will stay in the
+              OSDMap blacklist. It has no effect on how long something is
+              blacklisted when the administrator blacklists it manually. For
+              example, ``ceph osd blacklist add`` will still use the default
+              blacklist time.)
 :Type:  Float
 :Default: ``24.0*60.0``
 


### PR DESCRIPTION
The `mds blacklist interval` setting has no effect on the time that the `ceph osd blacklist` command will use by default. Clarify this in the docs.

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>