### PR TITLE
libradosstriper: conditional compile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,13 @@ if(WITH_DPDK)
   endif()
 endif()
 
+option(WITH_LIBRADOSSTRIPER "Build with libradosstriper support." ON)
+if(WITH_LIBRADOSSTRIPER)
+  message(STATUS "Enabling libradosstriper in \"rados\" tool.")
+else()
+  message(STATUS "Disabling libradosstriper support in \"rados\" tool.")
+endif()
+
 option(WITH_BLKIN "Use blkin to emit LTTng tracepoints for Zipkin" OFF)
 if(WITH_BLKIN)
   set(BLKIN_LIBRARIES blkin ${LTTNGUST_LIBRARIES} lttng-ust-fork)
@@ -638,3 +645,5 @@ add_tags(ctags
   EXCLUDE_OPTS ${CTAG_EXCLUDES}
   EXCLUDES "*.js" "*.css")
 add_custom_target(tags DEPENDS ctags)
+
+

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -25,6 +25,7 @@
 %bcond_without selinux
 %bcond_without ceph_test_package
 %bcond_without cephfs_java
+%bcond_without libradosstriper
 %bcond_without lttng
 %global _remote_tarball_prefix https://download.ceph.com/tarballs/
 %endif
@@ -37,8 +38,10 @@
 %global _fillupdir /var/adm/fillup-templates
 %endif
 %if 0%{?is_opensuse}
+%bcond_without libradosstriper
 %bcond_without lttng
 %else
+%bcond_with libradosstriper
 %ifarch x86_64 aarch64
 %bcond_without lttng
 %else
@@ -295,6 +298,9 @@ Group:		System/Filesystems
 %endif
 Requires:	librbd1 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
+%if 0%{with libradosstriper}
+Requires:	libradosstriper1 = %{_epoch_prefix}%{version}-%{release}
+%endif
 Requires:	libcephfs2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rados = %{_epoch_prefix}%{version}-%{release}
 Requires:	python%{_python_buildid}-rbd = %{_epoch_prefix}%{version}-%{release}
@@ -566,6 +572,7 @@ Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 This package contains Python 3 libraries for interacting with Cephs RADOS
 object store.
 
+%if 0%{with libradosstriper}
 %package -n libradosstriper1
 Summary:	RADOS striping interface
 %if 0%{?suse_version}
@@ -590,6 +597,7 @@ Obsoletes:	libradosstriper1-devel < %{_epoch_prefix}%{version}-%{release}
 %description -n libradosstriper-devel
 This package contains libraries and headers needed to develop programs
 that use RADOS striping interface.
+%endif
 
 %package -n librbd1
 Summary:	RADOS block device client library
@@ -922,6 +930,11 @@ cmake .. \
     -DWITH_BOOST_CONTEXT=ON \
 %else
     -DWITH_BOOST_CONTEXT=OFF \
+%endif
+%if 0%{with libradosstriper}
+    -DWITH_LIBRADOSSTRIPER=ON \
+%else
+    -DWITH_LIBRADOSSTRIPER=OFF \
 %endif
     -DBOOST_J=$CEPH_SMP_NCPUS
 
@@ -1615,6 +1628,7 @@ fi
 %{python3_sitearch}/rados.cpython*.so
 %{python3_sitearch}/rados-*.egg-info
 
+%if 0%{with libradosstriper}
 %files -n libradosstriper1
 %{_libdir}/libradosstriper.so.*
 
@@ -1627,6 +1641,7 @@ fi
 %{_includedir}/radosstriper/libradosstriper.h
 %{_includedir}/radosstriper/libradosstriper.hpp
 %{_libdir}/libradosstriper.so
+%endif
 
 %files -n librbd1
 %{_libdir}/librbd.so.*

--- a/src/include/config-h.in.cmake
+++ b/src/include/config-h.in.cmake
@@ -129,7 +129,6 @@
 /* Accelio conditional compilation */
 #cmakedefine HAVE_XIO
 
-
 /* AsyncMessenger RDMA conditional compilation */
 #cmakedefine HAVE_RDMA
 
@@ -332,5 +331,8 @@
 
 /* Defined if boost::context is available */
 #cmakedefine HAVE_BOOST_CONTEXT
+
+/* Define if libradosstriper is enabled: */
+#cmakedefine WITH_LIBRADOSSTRIPER
 
 #endif /* CONFIG_H */

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -38,7 +38,9 @@ endif(WITH_EMBEDDED)
 add_subdirectory(libcephfs)
 add_subdirectory(librados)
 add_subdirectory(librados_test_stub)
+if(WITH_LIBRADOSSTRIPER)
 add_subdirectory(libradosstriper)
+endif(WITH_LIBRADOSSTRIPER)
 if(WITH_RBD)
   add_subdirectory(librbd)
 endif(WITH_RBD)
@@ -642,12 +644,14 @@ add_ceph_unittest(unittest_workqueue)
 target_link_libraries(unittest_workqueue global)
 
 # unittest_striper
-add_executable(unittest_striper
-  test_striper.cc
-  $<TARGET_OBJECTS:unit-main>
-  )
-add_ceph_unittest(unittest_striper)
-target_link_libraries(unittest_striper global ${BLKID_LIBRARIES})
+if(WITH_LIBRADOSSTRIPER)
+  add_executable(unittest_striper
+    test_striper.cc
+    $<TARGET_OBJECTS:unit-main>
+    )
+  add_ceph_unittest(unittest_striper)
+  target_link_libraries(unittest_striper global ${BLKID_LIBRARIES})
+endif(WITH_LIBRADOSSTRIPER)
 
 # unittest_prebufferedstreambuf
 add_executable(unittest_prebufferedstreambuf

--- a/src/test/libradosstriper/CMakeLists.txt
+++ b/src/test/libradosstriper/CMakeLists.txt
@@ -1,3 +1,7 @@
+#
+# Note: only compiled if WITH_LIBRADOSSTRIPER is defined.
+#
+
 add_library(rados_striper_test STATIC TestCase.cc)
 target_link_libraries(rados_striper_test radostest)
 set_target_properties(rados_striper_test PROPERTIES COMPILE_FLAGS

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -16,8 +16,11 @@
 
 #include "include/rados/librados.hpp"
 #include "include/rados/rados_types.hpp"
+
+#ifdef WITH_LIBRADOSSTRIPER
 #include "include/radosstriper/libradosstriper.hpp"
 using namespace libradosstriper;
+#endif
 
 #include "common/config.h"
 #include "common/ceph_argparse.h"
@@ -198,10 +201,12 @@ void usage(ostream& out)
 "        Use with cp to specify the locator of the new object\n"
 "   --target-nspace\n"
 "        Use with cp to specify the namespace of the new object\n"
+#ifdef WITH_LIBRADOSSTRIPER
 "   --striper\n"
 "        Use radostriper interface rather than pure rados\n"
 "        Available for stat, get, put, truncate, rm, ls and \n"
 "        all xattr related operations\n"
+#endif
 "\n"
 "BENCH OPTIONS:\n"
 "   -t N\n"
@@ -281,6 +286,49 @@ static int dump_data(std::string const &filename, bufferlist const &data)
 }
 
 
+#ifndef WITH_LIBRADOSSTRIPER 
+static int do_get(IoCtx& io_ctx, 
+		  const char *objname, const char *outfile, unsigned op_size)
+{
+  string oid(objname);
+
+  int fd;
+  if (strcmp(outfile, "-") == 0) {
+    fd = STDOUT_FILENO;
+  } else {
+    fd = TEMP_FAILURE_RETRY(::open(outfile, O_WRONLY|O_CREAT|O_TRUNC, 0644));
+    if (fd < 0) {
+      int err = errno;
+      cerr << "failed to open file: " << cpp_strerror(err) << std::endl;
+      return -err;
+    }
+  }
+
+  uint64_t offset = 0;
+  int ret;
+  while (true) {
+    bufferlist outdata;
+    ret = io_ctx.read(oid, outdata, op_size, offset);
+    if (ret <= 0) {
+      goto out;
+    }
+    ret = outdata.write_fd(fd);
+    if (ret < 0) {
+      cerr << "error writing to file: " << cpp_strerror(ret) << std::endl;
+      goto out;
+    }
+    if (outdata.length() < op_size)
+      break;
+    offset += outdata.length();
+  }
+  ret = 0;
+
+ out:
+  if (fd != 1)
+    VOID_TEMP_FAILURE_RETRY(::close(fd));
+  return ret;
+}
+#else // WITH_LIBRADOSSTRIPER
 static int do_get(IoCtx& io_ctx, RadosStriper& striper,
 		  const char *objname, const char *outfile, unsigned op_size,
 		  bool use_striper)
@@ -303,11 +351,17 @@ static int do_get(IoCtx& io_ctx, RadosStriper& striper,
   int ret;
   while (true) {
     bufferlist outdata;
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.read(oid, outdata, op_size, offset);
+#else
     if (use_striper) {
       ret = striper.read(oid, &outdata, op_size, offset);
     } else {
       ret = io_ctx.read(oid, outdata, op_size, offset);
     }
+#endif
+
     if (ret <= 0) {
       goto out;
     }
@@ -327,6 +381,7 @@ static int do_get(IoCtx& io_ctx, RadosStriper& striper,
     VOID_TEMP_FAILURE_RETRY(::close(fd));
   return ret;
 }
+#endif
 
 static int do_copy(IoCtx& io_ctx, const char *objname,
 		   IoCtx& target_ctx, const char *target_obj)
@@ -381,6 +436,69 @@ static int do_copy_pool(Rados& rados, const char *src_pool, const char *target_p
   return 0;
 }
 
+#ifndef WITH_LIBRADOSSTRIPER 
+static int do_put(IoCtx& io_ctx, 
+		  const char *objname, const char *infile, int op_size,
+		  uint64_t obj_offset)
+{
+  string oid(objname);
+  bool stdio = (strcmp(infile, "-") == 0);
+  int ret = 0;
+  int fd = STDIN_FILENO;
+  if (!stdio)
+    fd = open(infile, O_RDONLY);
+  if (fd < 0) {
+    cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
+    return 1;
+  }
+  int count = op_size;
+  uint64_t offset = obj_offset;
+  while (count != 0) {
+    bufferlist indata;
+    count = indata.read_fd(fd, op_size);
+    if (count < 0) {
+      ret = -errno;
+      cerr << "error reading input file " << infile << ": " << cpp_strerror(ret) << std::endl;
+      goto out;
+    }
+ 
+    if (count == 0) {
+     if (offset == obj_offset) { // in case we have to create an empty object & if obj_offset > 0 do a hole
+	ret = io_ctx.write_full(oid, indata); // indata is empty
+
+	if (ret < 0) {
+	  goto out;
+	}
+
+	if (offset) {
+	    ret = io_ctx.trunc(oid, offset); // before truncate, object must be existed.
+	}
+
+	if (ret < 0) {
+	    goto out;
+	}
+     }
+    }
+
+    continue;
+
+   if (offset == 0)
+       ret = io_ctx.write_full(oid, indata);
+   else
+       ret = io_ctx.write(oid, indata, count, offset);
+
+   if (ret < 0) {
+      goto out;
+   }
+    offset += count;
+  }
+  ret = 0;
+ out:
+  if (fd != STDOUT_FILENO)
+    VOID_TEMP_FAILURE_RETRY(close(fd));
+  return ret;
+}
+#else // WITH_LIBRADOSSTRIPER
 static int do_put(IoCtx& io_ctx, RadosStriper& striper,
 		  const char *objname, const char *infile, int op_size,
 		  uint64_t obj_offset, bool use_striper)
@@ -408,20 +526,30 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
  
     if (count == 0) {
      if (offset == obj_offset) { // in case we have to create an empty object & if obj_offset > 0 do a hole
+
+#ifndef WITH_LIBRADOSSTRIPER
+	ret = io_ctx.write_full(oid, indata); // indata is empty
+#else
 	if (use_striper) {
 	  ret = striper.write_full(oid, indata); // indata is empty
 	} else {
 	  ret = io_ctx.write_full(oid, indata); // indata is empty
 	}
+#endif
 	if (ret < 0) {
 	  goto out;
 	}
+
 	if (offset) {
+#ifndef WITH_LIBRADOSSTRIPER
+	  ret = io_ctx.trunc(oid, offset); // before truncate, object must be existed.
+#else
 	  if (use_striper) {
 	    ret = striper.trunc(oid, offset); // before truncate, object must be existed.
 	  } else {
 	    ret = io_ctx.trunc(oid, offset); // before truncate, object must be existed.
 	  }
+#endif
 
 	  if (ret < 0) {
 	    goto out;
@@ -430,6 +558,13 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
       }
       continue;
     }
+
+#ifndef WITH_LIBRADOSSTRIPER
+    if (offset == 0)
+	ret = io_ctx.write_full(oid, indata);
+    else
+	ret = io_ctx.write(oid, indata, count, offset);
+#else
     if (use_striper) {
       if (offset == 0)
 	ret = striper.write_full(oid, indata);
@@ -441,6 +576,7 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
       else
 	ret = io_ctx.write(oid, indata, count, offset);
     }
+#endif
 
     if (ret < 0) {
       goto out;
@@ -453,7 +589,44 @@ static int do_put(IoCtx& io_ctx, RadosStriper& striper,
     VOID_TEMP_FAILURE_RETRY(close(fd));
   return ret;
 }
+#endif
 
+#ifndef WITH_LIBRADOSSTRIPER
+static int do_append(IoCtx& io_ctx, 
+                  const char *objname, const char *infile, int op_size)
+{
+  string oid(objname);
+  bool stdio = (strcmp(infile, "-") == 0);
+  int ret = 0;
+  int fd = STDIN_FILENO;
+  if (!stdio)
+    fd = open(infile, O_RDONLY);
+  if (fd < 0) {
+    cerr << "error reading input file " << infile << ": " << cpp_strerror(errno) << std::endl;
+    return 1;
+  }
+  int count = op_size;
+  while (count != 0) {
+    bufferlist indata;
+    count = indata.read_fd(fd, op_size);
+    if (count < 0) {
+      ret = -errno;
+      cerr << "error reading input file " << infile << ": " << cpp_strerror(ret) << std::endl;
+      goto out;
+    }
+    ret = io_ctx.append(oid, indata, count);
+
+    if (ret < 0) {
+      goto out;
+    }
+  }
+  ret = 0;
+out:
+  if (fd != STDOUT_FILENO)
+    VOID_TEMP_FAILURE_RETRY(close(fd));
+  return ret;
+}
+#else // WITH_LIBRADOSSTRIPER
 static int do_append(IoCtx& io_ctx, RadosStriper& striper,
                   const char *objname, const char *infile, int op_size,
                   bool use_striper)
@@ -477,11 +650,16 @@ static int do_append(IoCtx& io_ctx, RadosStriper& striper,
       cerr << "error reading input file " << infile << ": " << cpp_strerror(ret) << std::endl;
       goto out;
     }
+
+#ifndef WITH_LIBRADOSSTRIPER	
+    ret = io_ctx.append(oid, indata, count);
+#else
     if (use_striper) {
       ret = striper.append(oid, indata, count);
     } else {
       ret = io_ctx.append(oid, indata, count);
     }
+#endif // WITH_LIBRADOSSTRIPER
 
     if (ret < 0) {
       goto out;
@@ -493,6 +671,7 @@ out:
     VOID_TEMP_FAILURE_RETRY(close(fd));
   return ret;
 }
+#endif // WITH_LIBRADOSSTRIPER
 
 class RadosWatchCtx : public librados::WatchCtx2 {
   IoCtx& ioctx;
@@ -1628,7 +1807,9 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   bool cleanup = true;
   bool hints = true; // for rados bench
   bool no_verify = false;
+#ifdef WITH_LIBRADOSSTRIPER
   bool use_striper = false;
+#endif
   bool with_clones = false;
   const char *snapname = NULL;
   snap_t snapid = CEPH_NOSNAP;
@@ -1660,7 +1841,10 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 
   Rados rados;
   IoCtx io_ctx;
+
+#ifdef WITH_LIBRADOSSTRIPER
   RadosStriper striper;
+#endif
 
   i = opts.find("create");
   if (i != opts.end()) {
@@ -1937,6 +2121,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       }
     }
 
+#ifdef WITH_LIBRADOSSTRIPER
     // create striper interface
     if (opts.find("striper") != opts.end()) {
       ret = RadosStriper::striper_create(io_ctx, &striper);
@@ -1947,6 +2132,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       }
       use_striper = true;
     }
+#endif
+
   }
 
   // snapname?
@@ -2152,6 +2339,7 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	librados::NObjectIterator i = io_ctx.nobjects_begin();
 	librados::NObjectIterator i_end = io_ctx.nobjects_end();
 	for (; i != i_end; ++i) {
+#ifdef WITH_LIBRADOSSTRIPER
 	  if (use_striper) {
 	    // in case of --striper option, we only list striped
 	    // objects, so we only display the first object of
@@ -2160,26 +2348,35 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	    if (l <= 17 ||
 		(0 != i->get_oid().compare(l-17, 17,".0000000000000000"))) continue;
 	  }
+#endif
 	  if (!formatter) {
 	    // Only include namespace in output when wildcard specified
 	    if (wildcard)
 	      *outstream << i->get_nspace() << "\t";
+#ifdef WITH_LIBRADOSSTRIPER
 	    if (use_striper) {
 	      *outstream << i->get_oid().substr(0, i->get_oid().length()-17);
 	    } else {
 	      *outstream << i->get_oid();
 	    }
+#else
+	    *outstream << i->get_oid();
+#endif
 	    if (i->get_locator().size())
 	      *outstream << "\t" << i->get_locator();
 	    *outstream << std::endl;
 	  } else {
 	    formatter->open_object_section("object");
 	    formatter->dump_string("namespace", i->get_nspace());
+#ifdef WITH_LIBRADOSSTRIPER
 	    if (use_striper) {
 	      formatter->dump_string("name", i->get_oid().substr(0, i->get_oid().length()-17));
 	    } else {
 	      formatter->dump_string("name", i->get_oid());
 	    }
+#else
+	    formatter->dump_string("name", i->get_oid());
+#endif
 	    if (i->get_locator().size())
 	      formatter->dump_string("locator", i->get_locator());
 	    formatter->close_section(); //object
@@ -2241,11 +2438,17 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     string oid(nargs[1]);
     uint64_t size;
     time_t mtime;
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.stat(oid, &size, &mtime);
+#else // WITH_LIBRADOSSTRIPER
     if (use_striper) {
       ret = striper.stat(oid, &size, &mtime);
     } else {
       ret = io_ctx.stat(oid, &size, &mtime);
     }
+#endif
+
     if (ret < 0) {
       cerr << " error stat-ing " << pool_name << "/" << oid << ": "
            << cpp_strerror(ret) << std::endl;
@@ -2262,11 +2465,16 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     string oid(nargs[1]);
     uint64_t size;
     struct timespec mtime;
+
+#ifdef WITH_LIBRADOSSTRIPER
     if (use_striper) {
       ret = striper.stat2(oid, &size, &mtime);
     } else {
       ret = io_ctx.stat2(oid, &size, &mtime);
     }
+#else
+    ret = io_ctx.stat2(oid, &size, &mtime);
+#endif
     if (ret < 0) {
       cerr << " error stat-ing " << pool_name << "/" << oid << ": "
 	   << cpp_strerror(ret) << std::endl;
@@ -2305,7 +2513,13 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   else if (strcmp(nargs[0], "get") == 0) {
     if (!pool_name || nargs.size() < 3)
       usage_exit();
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = do_get(io_ctx, nargs[1], nargs[2], op_size);
+#else
     ret = do_get(io_ctx, striper, nargs[1], nargs[2], op_size, use_striper);
+#endif
+
     if (ret < 0) {
       cerr << "error getting " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2314,7 +2528,13 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   else if (strcmp(nargs[0], "put") == 0) {
     if (!pool_name || nargs.size() < 3)
       usage_exit();
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = do_put(io_ctx, nargs[1], nargs[2], op_size, obj_offset);
+#else
     ret = do_put(io_ctx, striper, nargs[1], nargs[2], op_size, obj_offset, use_striper);
+#endif
+
     if (ret < 0) {
       cerr << "error putting " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2323,7 +2543,13 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
   else if (strcmp(nargs[0], "append") == 0) {
     if (!pool_name || nargs.size() < 3)
       usage_exit();
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = do_append(io_ctx, nargs[1], nargs[2], op_size);
+#else
     ret = do_append(io_ctx, striper, nargs[1], nargs[2], op_size, use_striper);
+#endif
+
     if (ret < 0) {
       cerr << "error appending " << pool_name << "/" << nargs[1] << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2345,11 +2571,17 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       cerr << "error, cannot truncate to negative value" << std::endl;
       usage_exit();
     }
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.trunc(oid, size);
+#else
     if (use_striper) {
       ret = striper.trunc(oid, size);
     } else {
       ret = io_ctx.trunc(oid, size);
     }
+#endif
+
     if (ret < 0) {
       cerr << "error truncating oid "
 	   << oid << " to " << size << ": "
@@ -2376,11 +2608,16 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
       } while (ret > 0);
     }
 
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.setxattr(oid, attr_name.c_str(), bl);
+#else
     if (use_striper) {
       ret = striper.setxattr(oid, attr_name.c_str(), bl);
     } else {
       ret = io_ctx.setxattr(oid, attr_name.c_str(), bl);
     }
+#endif
+ 
     if (ret < 0) {
       cerr << "error setting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2396,11 +2633,17 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     string attr_name(nargs[2]);
 
     bufferlist bl;
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.getxattr(oid, attr_name.c_str(), bl);
+#else
     if (use_striper) {
       ret = striper.getxattr(oid, attr_name.c_str(), bl);
     } else {
       ret = io_ctx.getxattr(oid, attr_name.c_str(), bl);
     }
+#endif
+
     if (ret < 0) {
       cerr << "error getting xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2416,11 +2659,16 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     string oid(nargs[1]);
     string attr_name(nargs[2]);
 
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.rmxattr(oid, attr_name.c_str());
+#else
     if (use_striper) {
       ret = striper.rmxattr(oid, attr_name.c_str());
     } else {
       ret = io_ctx.rmxattr(oid, attr_name.c_str());
     }
+#endif
+
     if (ret < 0) {
       cerr << "error removing xattr " << pool_name << "/" << oid << "/" << attr_name << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2432,11 +2680,17 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     string oid(nargs[1]);
     map<std::string, bufferlist> attrset;
     bufferlist bl;
+
+#ifndef WITH_LIBRADOSSTRIPER
+    ret = io_ctx.getxattrs(oid, attrset);
+#else
     if (use_striper) {
       ret = striper.getxattrs(oid, attrset);
     } else {
       ret = io_ctx.getxattrs(oid, attrset);
     }
+#endif
+
     if (ret < 0) {
       cerr << "error getting xattr set " << pool_name << "/" << oid << ": " << cpp_strerror(ret) << std::endl;
       goto out;
@@ -2697,6 +2951,14 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
     ++iter;
     for (; iter != nargs.end(); ++iter) {
       const string & oid = *iter;
+
+#ifndef WITH_LIBRADOSSTRIPER
+      if (forcefull) {
+          ret = io_ctx.remove(oid, CEPH_OSD_FLAG_FULL_FORCE);
+      } else {
+          ret = io_ctx.remove(oid);
+      }
+#else
       if (use_striper) {
 	if (forcefull) {
 	  ret = striper.remove(oid, CEPH_OSD_FLAG_FULL_FORCE);
@@ -2710,6 +2972,8 @@ static int rados_tool_common(const std::map < std::string, std::string > &opts,
 	  ret = io_ctx.remove(oid);
 	}
       }
+#endif
+
       if (ret < 0) {
         string name = (nspace.size() ? nspace + "/" : "" ) + oid;
         cerr << "error removing " << pool_name << ">" << name << ": " << cpp_strerror(ret) << std::endl;
@@ -3764,8 +4028,10 @@ int main(int argc, const char **argv)
       opts["target_locator"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--target-nspace" , (char *)NULL)) {
       opts["target_nspace"] = val;
+#ifdef WITH_LIBRADOSSTRIPER
     } else if (ceph_argparse_flag(args, i, "--striper" , (char *)NULL)) {
       opts["striper"] = "true";
+#endif
     } else if (ceph_argparse_witharg(args, i, &val, "-t", "--concurrent-ios", (char*)NULL)) {
       opts["concurrent-ios"] = val;
     } else if (ceph_argparse_witharg(args, i, &val, "--block-size", (char*)NULL)) {


### PR DESCRIPTION
This PR affects the "rados" tool:
1) enables support for libradosstriper features by default (unchanged from current feature);
2) adds a new do_cmake.sh and cmake switch called "WITH_LIBRADOSSTRIPER", set to ON by default;
3) if [2] is enabled, libradosstriper features are enabled in the "rados" tool. If disabled, libradosstriper features are disabled in the "rados" tool.
4) modifies the RPM spec file to set WITH_LIBRADOSSTRIPER as needed

Please note that this PR is not meant to affect whether libradosstriper itself is built or linked, it is limited to governing the exposed features in the tool.

Fixes: https://tracker.ceph.com/issues/22750