### PR TITLE
msg/async: fix bug of data type conversion when uint64_t -> int -> uint64_t

### DIFF
--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -52,7 +52,7 @@ class C_time_wakeup : public EventCallback {
 
  public:
   explicit C_time_wakeup(AsyncConnectionRef c): conn(c) {}
-  void do_request(int fd_or_id) override {
+  void do_request(uint64_t fd_or_id) override {
     conn->wakeup_from(fd_or_id);
   }
 };
@@ -62,7 +62,7 @@ class C_handle_read : public EventCallback {
 
  public:
   explicit C_handle_read(AsyncConnectionRef c): conn(c) {}
-  void do_request(int fd_or_id) override {
+  void do_request(uint64_t fd_or_id) override {
     conn->process();
   }
 };
@@ -72,7 +72,7 @@ class C_handle_write : public EventCallback {
 
  public:
   explicit C_handle_write(AsyncConnectionRef c): conn(c) {}
-  void do_request(int fd) override {
+  void do_request(uint64_t fd) override {
     conn->handle_write();
   }
 };
@@ -81,7 +81,7 @@ class C_clean_handler : public EventCallback {
   AsyncConnectionRef conn;
  public:
   explicit C_clean_handler(AsyncConnectionRef c): conn(c) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     conn->cleanup();
     delete this;
   }
@@ -92,7 +92,7 @@ class C_tick_wakeup : public EventCallback {
 
  public:
   explicit C_tick_wakeup(AsyncConnectionRef c): conn(c) {}
-  void do_request(int fd_or_id) override {
+  void do_request(uint64_t fd_or_id) override {
     conn->tick(fd_or_id);
   }
 };
@@ -2351,7 +2351,7 @@ void AsyncConnection::handle_ack(uint64_t seq)
   }
 }
 
-void AsyncConnection::DelayedDelivery::do_request(int id)
+void AsyncConnection::DelayedDelivery::do_request(uint64_t id)
 {
   Message *m = nullptr;
   {

--- a/src/msg/async/AsyncConnection.h
+++ b/src/msg/async/AsyncConnection.h
@@ -158,7 +158,7 @@ class AsyncConnection : public Connection {
       assert(delay_queue.empty());
     }
     void set_center(EventCenter *c) { center = c; }
-    void do_request(int id) override;
+    void do_request(uint64_t id) override;
     void queue(double delay_period, utime_t release, Message *m) {
       std::lock_guard<std::mutex> l(delay_lock);
       delay_queue.push_back(std::make_pair(release, m));

--- a/src/msg/async/AsyncMessenger.cc
+++ b/src/msg/async/AsyncMessenger.cc
@@ -50,7 +50,7 @@ class Processor::C_processor_accept : public EventCallback {
 
  public:
   explicit C_processor_accept(Processor *p): pro(p) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     pro->accept();
   }
 };
@@ -232,7 +232,7 @@ class C_handle_reap : public EventCallback {
 
   public:
   explicit C_handle_reap(AsyncMessenger *m): msgr(m) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     // judge whether is a time event
     msgr->reap_dead();
   }

--- a/src/msg/async/Event.cc
+++ b/src/msg/async/Event.cc
@@ -41,7 +41,7 @@ class C_handle_notify : public EventCallback {
 
  public:
   C_handle_notify(EventCenter *c, CephContext *cc): center(c), cct(cc) {}
-  void do_request(int fd_or_id) override {
+  void do_request(uint64_t fd_or_id) override {
     char c[256];
     int r = 0;
     do {

--- a/src/msg/async/Event.h
+++ b/src/msg/async/Event.h
@@ -54,7 +54,7 @@ class EventCenter;
 class EventCallback {
 
  public:
-  virtual void do_request(int fd_or_id) = 0;
+  virtual void do_request(uint64_t fd_or_id) = 0;
   virtual ~EventCallback() {}       // we want a virtual destructor!!!
 };
 
@@ -223,7 +223,7 @@ class EventCenter {
    public:
     C_submit_event(func &&_f, bool nw)
       : f(std::move(_f)), nonwait(nw) {}
-    void do_request(int id) override {
+    void do_request(uint64_t id) override {
       f();
       lock.lock();
       cond.notify_all();

--- a/src/msg/async/Stack.cc
+++ b/src/msg/async/Stack.cc
@@ -190,7 +190,7 @@ class C_drain : public EventCallback {
   explicit C_drain(size_t c)
       : drain_lock("C_drain::drain_lock"),
         drain_count(c) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     Mutex::Locker l(drain_lock);
     drain_count--;
     if (drain_count == 0) drain_cond.Signal();

--- a/src/msg/async/dpdk/ARP.h
+++ b/src/msg/async/dpdk/ARP.h
@@ -161,7 +161,7 @@ class arp_for : public arp_for_protocol {
    public:
     C_handle_arp_timeout(arp_for *a, l3addr addr, bool first):
         arp(a), paddr(addr), first_request(first) {}
-    void do_request(int r) {
+    void do_request(uint64_t r) {
       arp->send_query(paddr);
       auto &res = arp->_in_progress[paddr];
 

--- a/src/msg/async/dpdk/DPDK.cc
+++ b/src/msg/async/dpdk/DPDK.cc
@@ -601,7 +601,7 @@ class C_handle_dev_stats : public EventCallback {
   DPDKQueuePair *_qp;
  public:
   C_handle_dev_stats(DPDKQueuePair *qp): _qp(qp) { }
-  void do_request(int id) {
+  void do_request(uint64_t id) {
     _qp->handle_stats();
   }
 };

--- a/src/msg/async/dpdk/IP.cc
+++ b/src/msg/async/dpdk/IP.cc
@@ -63,7 +63,7 @@ class C_handle_frag_timeout : public EventCallback {
 
  public:
   C_handle_frag_timeout(ipv4 *i): _ipv4(i) {}
-  void do_request(int fd_or_id) {
+  void do_request(uint64_t fd_or_id) {
     _ipv4->frag_timeout();
   }
 };

--- a/src/msg/async/dpdk/Packet.cc
+++ b/src/msg/async/dpdk/Packet.cc
@@ -79,7 +79,7 @@ class C_free_on_cpu : public EventCallback {
  public:
   C_free_on_cpu(deleter &&d, std::function<void()> &&c):
       del(std::move(d)), cb(std::move(c)) {}
-  void do_request(int fd) {
+  void do_request(uint64_t fd) {
     // deleter needs to be moved from lambda capture to be destroyed here
     // otherwise deleter destructor will be called on a cpu that called
     // create_external_event when work_item is destroyed.

--- a/src/msg/async/dpdk/TCP.h
+++ b/src/msg/async/dpdk/TCP.h
@@ -235,7 +235,7 @@ class tcp {
 
    public:
     C_handle_delayed_ack(tcb *t): tc(t) { }
-    void do_request(int r) {
+    void do_request(uint64_t r) {
       tc->_nr_full_seg_received = 0;
       tc->output();
     }
@@ -246,7 +246,7 @@ class tcp {
 
    public:
     C_handle_retransmit(tcb *t): tc(t) { }
-    void do_request(int r) {
+    void do_request(uint64_t r) {
       tc->retransmit();
     }
   };
@@ -256,7 +256,7 @@ class tcp {
 
    public:
     C_handle_persist(tcb *t): tc(t) { }
-    void do_request(int r) {
+    void do_request(uint64_t r) {
       tc->persist();
     }
   };
@@ -266,7 +266,7 @@ class tcp {
 
    public:
     C_all_data_acked(tcb *t): tc(t) {}
-    void do_request(int fd_or_id) {
+    void do_request(uint64_t fd_or_id) {
       tc->close_final_cleanup();
     }
   };
@@ -275,7 +275,7 @@ class tcp {
     lw_shared_ptr<tcb> tc;
    public:
     C_actual_remove_tcb(tcb *t): tc(t->shared_from_this()) {}
-    void do_request(int r) {
+    void do_request(uint64_t r) {
       delete this;
     }
   };

--- a/src/msg/async/dpdk/net.cc
+++ b/src/msg/async/dpdk/net.cc
@@ -112,7 +112,7 @@ class C_handle_l2forward : public EventCallback {
  public:
   C_handle_l2forward(std::shared_ptr<DPDKDevice> &p, unsigned &qd, Packet pkt, unsigned target)
       : sdev(p), queue_depth(qd), p(std::move(pkt)), dst(target) {}
-  void do_request(int fd) {
+  void do_request(uint64_t fd) {
     sdev->l2receive(dst, std::move(p));
     queue_depth--;
     delete this;
@@ -184,7 +184,7 @@ class C_arp_learn : public EventCallback {
  public:
   C_arp_learn(DPDKWorker *w, ethernet_address l2, ipv4_address l3)
       : worker(w), l2_addr(l2), l3_addr(l3) {}
-  void do_request(int id) {
+  void do_request(uint64_t id) {
     worker->arp_learn(l2_addr, l3_addr);
     delete this;
   }

--- a/src/msg/async/rdma/RDMAStack.h
+++ b/src/msg/async/rdma/RDMAStack.h
@@ -81,7 +81,7 @@ class RDMADispatcher {
     RDMADispatcher *dispatcher;
    public:
     C_handle_cq_async(RDMADispatcher *w): dispatcher(w) {}
-    void do_request(int fd) {
+    void do_request(uint64_t fd) {
       // worker->handle_tx_event();
       dispatcher->handle_async_event();
     }
@@ -139,7 +139,7 @@ class RDMAWorker : public Worker {
     RDMAWorker *worker;
     public:
     C_handle_cq_tx(RDMAWorker *w): worker(w) {}
-    void do_request(int fd) {
+    void do_request(uint64_t fd) {
       worker->handle_pending_message();
     }
   };
@@ -227,7 +227,7 @@ class RDMAConnectedSocketImpl : public ConnectedSocketImpl {
     bool active;
    public:
     C_handle_connection(RDMAConnectedSocketImpl *w): csi(w), active(true) {}
-    void do_request(int fd) {
+    void do_request(uint64_t fd) {
       if (active)
         csi->handle_connection();
     }

--- a/src/test/msgr/test_async_driver.cc
+++ b/src/test/msgr/test_async_driver.cc
@@ -254,7 +254,7 @@ TEST_P(EventDriverTest, NetworkSocketTest) {
 class FakeEvent : public EventCallback {
 
  public:
-  void do_request(int fd_or_id) override {}
+  void do_request(uint64_t fd_or_id) override {}
 };
 
 TEST(EventCenterTest, FileEventExpansion) {
@@ -302,7 +302,7 @@ class CountEvent: public EventCallback {
 
  public:
   CountEvent(std::atomic<unsigned> *atomic, Mutex *l, Cond *c): count(atomic), lock(l), cond(c) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     lock->Lock();
     (*count)--;
     cond->Signal();

--- a/src/test/msgr/test_async_networkstack.cc
+++ b/src/test/msgr/test_async_networkstack.cc
@@ -83,7 +83,7 @@ class NetworkWorkerTest : public ::testing::TestWithParam<const char*> {
     std::atomic_bool done;
    public:
     C_dispatch(Worker *w, func &&_f): worker(w), f(std::move(_f)), done(false) {}
-    void do_request(int id) override {
+    void do_request(uint64_t id) override {
       f(worker);
       done = true;
     }
@@ -120,7 +120,7 @@ class C_poll : public EventCallback {
 
  public:
   C_poll(EventCenter *c): center(c), woken(false) {}
-  void do_request(int r) override {
+  void do_request(uint64_t r) override {
     woken = true;
   }
   bool poll(int milliseconds) {
@@ -626,7 +626,7 @@ class StressFactory {
     T *ctxt;
    public:
     C_delete(T *c): ctxt(c) {}
-    void do_request(int id) override {
+    void do_request(uint64_t id) override {
       delete ctxt;
       delete this;
     }
@@ -651,7 +651,7 @@ class StressFactory {
       Client *c;
      public:
       Client_read_handle(Client *_c): c(_c) {}
-      void do_request(int id) override {
+      void do_request(uint64_t id) override {
         c->do_read_request();
       }
     } read_ctxt;
@@ -660,7 +660,7 @@ class StressFactory {
       Client *c;
      public:
       Client_write_handle(Client *_c): c(_c) {}
-      void do_request(int id) override {
+      void do_request(uint64_t id) override {
         c->do_write_request();
       }
     } write_ctxt;
@@ -790,7 +790,7 @@ class StressFactory {
       Server *s;
      public:
       Server_read_handle(Server *_s): s(_s) {}
-      void do_request(int id) override {
+      void do_request(uint64_t id) override {
         s->do_read_request();
       }
     } read_ctxt;
@@ -799,7 +799,7 @@ class StressFactory {
       Server *s;
      public:
       Server_write_handle(Server *_s): s(_s) {}
-      void do_request(int id) override {
+      void do_request(uint64_t id) override {
         s->do_write_request();
       }
     } write_ctxt;
@@ -903,7 +903,7 @@ class StressFactory {
    public:
     C_accept(StressFactory *f, ServerSocket s, ThreadData *data, Worker *w)
         : factory(f), bind_socket(std::move(s)), t_data(data), worker(w) {}
-    void do_request(int id) override {
+    void do_request(uint64_t id) override {
       while (true) {
         entity_addr_t cli_addr;
         ConnectedSocket srv_socket;

--- a/src/test/perf_local.cc
+++ b/src/test/perf_local.cc
@@ -488,7 +488,7 @@ class CountEvent: public EventCallback {
 
  public:
   explicit CountEvent(std::atomic<int64_t> *atomic): count(atomic) {}
-  void do_request(int id) override {
+  void do_request(uint64_t id) override {
     (*count)--;
   }
 };


### PR DESCRIPTION
There is "uint64_t a -> int b ->uint64_t c" data type conversion in the code, when the length of "a" is greater than 32 bits, the conversion of "uint64_t a" to "int b" results in data overflow, when the length of "a" is less than 32 bits and a >= 0x80000000, change "uint64_t a" to "int b" will lead "b" to be a negative number of 32 bits, then change " int b" to " uint64_t c" , the variable "c" is not equal to the variable “a” at this situation.    

Signed-off-by: shangfufei <shangfufei@inspur.com>