### PR TITLE
cmake: set supported language the right way

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8.11)
 
-project(ceph)
+project(ceph CXX C ASM)
 set(VERSION 12.1.2)
 
 if(POLICY CMP0046)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,5 @@
 include(GetGitRevisionDescription)
 
-enable_language(C ASM)
 include(GNUInstallDirs)
 # for erasure and compressor plugins
 set(CMAKE_INSTALL_PKGLIBDIR ${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME})


### PR DESCRIPTION
the second param of enable_launage() is not used, we should call it
multiple times to enable more than one language. switch to project()
command for simplicity.

Signed-off-by: Kefu Chai <kchai@redhat.com>