### PR TITLE
mon/PGMap: let pg_string_state() return boost::optional<> 

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2959,13 +2959,13 @@ int process_pg_map_command(
         state = -1;
         break;
       } else {
-        int64_t filter = pg_string_state(state_str);
-        if (filter < 0) {
+        auto filter = pg_string_state(state_str);
+        if (!filter) {
           *ss << "'" << state_str << "' is not a valid pg state,"
               << " available choices: " << pg_state_string(0xFFFFFFFF);
           return -EINVAL;
         }
-        state |= filter;
+        state |= *filter;
       }
 
       states.pop_back();

--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1991,7 +1991,7 @@ void PGMap::generate_test_instances(list<PGMap*>& o)
   }
 }
 
-void PGMap::get_filtered_pg_stats(uint32_t state, int64_t poolid, int64_t osdid,
+void PGMap::get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,
                                   bool primary, set<pg_t>& pgs) const
 {
   for (auto i = pg_stat.begin();
@@ -2950,7 +2950,7 @@ int process_pg_map_command(
     if (states.empty())
       states.push_back("all");
 
-    uint32_t state = 0;
+    uint64_t state = 0;
 
     while (!states.empty()) {
       string state_str = states.back();

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -436,7 +436,7 @@ public:
   void dump_osd_blocked_by_stats(Formatter *f) const;
   void print_osd_blocked_by_stats(std::ostream *ss) const;
 
-  void get_filtered_pg_stats(uint32_t state, int64_t poolid, int64_t osdid,
+  void get_filtered_pg_stats(uint64_t state, int64_t poolid, int64_t osdid,
                              bool primary, set<pg_t>& pgs) const;
 
   void get_health_checks(

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -853,9 +853,9 @@ std::string pg_state_string(uint64_t state)
   return ret;
 }
 
-int64_t pg_string_state(const std::string& state)
+boost::optional<uint64_t> pg_string_state(const std::string& state)
 {
-  int64_t type;
+  boost::optional<uint64_t> type;
   if (state == "active")
     type = PG_STATE_ACTIVE;
   else if (state == "clean")
@@ -909,7 +909,7 @@ int64_t pg_string_state(const std::string& state)
   else if (state == "snaptrim_error")
     type = PG_STATE_SNAPTRIM_ERROR;
   else
-    type = -1;
+    type = boost::none;
   return type;
 }
 

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -1008,7 +1008,7 @@ inline ostream& operator<<(ostream& out, const osd_stat_t& s) {
 
 std::string pg_state_string(uint64_t state);
 std::string pg_vector_string(const vector<int32_t> &a);
-int64_t pg_string_state(const std::string& state);
+boost::optional<uint64_t> pg_string_state(const std::string& state);
 
 
 /*


### PR DESCRIPTION
this is a follow-up of #18058, which is halfway to uint64_t pg state.