### PR TITLE
rgw: swift: configurable enforcement of container naming rules

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1344,6 +1344,7 @@ OPTION(rgw_swift_auth_entry, OPT_STR)  // entry point for which a url is conside
 OPTION(rgw_swift_tenant_name, OPT_STR)  // tenant name to use for swift access
 OPTION(rgw_swift_account_in_url, OPT_BOOL)  // assume that URL always contain the account (aka tenant) part
 OPTION(rgw_swift_enforce_content_length, OPT_BOOL)  // enforce generation of Content-Length even in cost of performance or scalability
+OPTION(rgw_swift_enforce_bucket_names, OPT_BOOL) // enforce adherence to swift container naming restrictions
 OPTION(rgw_keystone_url, OPT_STR)  // url for keystone server
 OPTION(rgw_keystone_admin_token, OPT_STR)  // keystone admin token (shared secret)
 OPTION(rgw_keystone_admin_user, OPT_STR)  // keystone admin user name

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4379,6 +4379,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(false)
     .set_description(""),
 
+    Option("rgw_swift_enforce_bucket_names", Option::TYPE_BOOL, Option::LEVEL_BASIC)
+    .set_default(true)
+    .set_description("Enforce adherence to swift container name restrictions"),
+
     Option("rgw_keystone_url", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("")
     .set_description(""),

--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -1843,7 +1843,16 @@ std::string rgw_bucket::get_key(char tenant_delim, char id_delim) const
     key.append(tenant);
     key.append(1, tenant_delim);
   }
-  key.append(name);
+
+  // A more cleaner solution would've been to not have introduced colons when
+  // empty tenant names were encountered in rgw_bucket_instance_key_to_oid
+  // but such a change would no longer be backwards compatible
+  if (name[0] == '/'){
+    key.append(1, tenant_delim);
+    key.append(name.substr(1));
+  } else {
+    key.append(name);
+  }
   if (!bucket_id.empty() && id_delim) {
     key.append(1, id_delim);
     key.append(bucket_id);

--- a/src/rgw/rgw_rest_swift.cc
+++ b/src/rgw/rgw_rest_swift.cc
@@ -2749,10 +2749,8 @@ int RGWHandler_REST_SWIFT::validate_bucket_name(const string& bucket)
   if (check_utf8(bucket.c_str(), len))
     return -ERR_INVALID_UTF8;
 
-  const char *s = bucket.c_str();
-
-  for (size_t i = 0; i < len; ++i, ++s) {
-    if (*(unsigned char *)s == 0xff)
+  if (g_conf->rgw_swift_enforce_bucket_names) {
+    if (bucket.find_first_of("/") != string::npos)
       return -ERR_INVALID_BUCKET_NAME;
   }
 


### PR DESCRIPTION
This is a patchset addressing two issues

* rgw: allow buckets created with / to be useable

 Previously we didn't restrict "/" in bucket names created via swift api
 though swift client itself had a restriction, and cases like misconfigured
 keystone urls would cause swift client also to prepend a
 "/" before the bucket name. The problem is that create bucket succeeds such
 a call and rgw_get_bucket_instance_info() and related functions would fail
 because we replace the first encountered "/" with a ":" assuming that this
 was a(n empty) tenant name. Make these buckets useable/ deleteable by
 making sure that when we retreive the key back we replace the beginning /
 with a colon as this was used in storing the bucket info. A non backwards
 compatible cleaner change would be to make rgw_bucket_instance_key_to_oid not
 replace slashes when 0 sized tenants were encountered. python-swiftclient/swift cli are
 still broken when uploading objects etc. as they do not prepend the / in
 PUT object requests whereas do in create bucket requests. However this
 patch makes it possible to use/delete these created buckets when using the
 rest api.

 Note that however there is still an edge case which cannot be addressed,
 which is, currently an object upload request of the form `PUT /bucket/foo`
 would end up with another bucket with the name `/bucket/foo` being created.
 With this patch however we ensure that a `PUT /bucket/foo` is indeed
 considered as an object request, however this introduces the problem where
 previously a bucket was created with such a name which would no longer be
 accessible. There is no way to address this since object names are allowed
 to contain slashes and we are now just allowing the case where a prefix
 slash at bucket name is allowed (since we hadn't restricted that before), a
 slash in the middle would end up with the part after being considered as an
 object request, which is the convention.

 Fixes: http://tracker.ceph.com/issues/21679

* rgw: add a configurable for enforcing swift bucket name validation

 Swift containers are declared in the upstream documentation as 1-256 bytes
 of UTF-8, and the only forbidden character is '/'.

 We did not previously enforce the no-slash rule.

 Adding a configurable `rgw_swift_enforce_bucket_names` which validates
 according to swift container naming restrictions (which currently forbids
 "/" in container names), also dropping the 0xff check that we previously
 had since check_utf8 should already catch that

 Making this as a configurable with the default that we enforce the swift
 naming rules of no slash, the configurable is useful in cases where when
 previously created buckets with slashes exists and need to be used

 See-Also:
 https://docs.openstack.org/developer/swift/api/object_api_v1_overview.html
 Fixes: http://tracker.ceph.com/issues/19264

*edit: formatting fixes*