### PR TITLE
client: rip out return InodeRef pointer handling from setattr codepaths

### DIFF
--- a/src/client/Client.h
+++ b/src/client/Client.h
@@ -789,16 +789,16 @@ private:
   int _mknod(Inode *dir, const char *name, mode_t mode, dev_t rdev,
 	     const UserPerm& perms, InodeRef *inp = 0);
   int _do_setattr(Inode *in, struct ceph_statx *stx, int mask,
-		  const UserPerm& perms, InodeRef *inp);
+		  const UserPerm& perms);
   void stat_to_statx(struct stat *st, struct ceph_statx *stx);
   int __setattrx(Inode *in, struct ceph_statx *stx, int mask,
-		 const UserPerm& perms, InodeRef *inp = 0);
+		 const UserPerm& perms);
   int _setattrx(InodeRef &in, struct ceph_statx *stx, int mask,
 		const UserPerm& perms);
   int _setattr(InodeRef &in, struct stat *attr, int mask,
 	       const UserPerm& perms);
   int _ll_setattrx(Inode *in, struct ceph_statx *stx, int mask,
-		   const UserPerm& perms, InodeRef *inp = 0);
+		   const UserPerm& perms);
   int _getattr(Inode *in, int mask, const UserPerm& perms, bool force=false);
   int _getattr(InodeRef &in, int mask, const UserPerm& perms, bool force=false) {
     return _getattr(in.get(), mask, perms, force);


### PR DESCRIPTION
We've had a report of the assertion in ll_setattr and ll_setattrx
being tripped [1]. Evidently we made a call to the server and that got
us back a trace with a different inode than the one we passed down.

In practice, nothing uses the pointer we're passing in to _do_setattr,
save the assertions, which I think are actually wrong. There's nothing
that prevents a concurrent rename or something from another client
while this setattr is in flight.

Since these assertions are questionable anyway, let's just remove them.

[1]: https://github.com/nfs-ganesha/nfs-ganesha/issues/215

Tracker: http://tracker.ceph.com/issues/21748
Signed-off-by: Jeff Layton <jlayton@redhat.com>