### PR TITLE
config: Remove _get_val

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -262,7 +262,7 @@ public:
     }
 
     if (changed.find("log_coarse_timestamps") != changed.end()) {
-      log->set_coarse_timestamps(conf->_get_val<bool>("log_coarse_timestamps"));
+      log->set_coarse_timestamps(conf->get_val<bool>("log_coarse_timestamps"));
     }
 
     // metadata

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -162,7 +162,6 @@ public:
   int _get_val(const std::string &key, char **buf, int len) const;
   const Option::value_t& get_val_generic(const std::string &key) const;
   template<typename T> const T& get_val(const std::string &key) const;
-  template<typename T> const T& _get_val(const std::string &key) const;
 
   void get_all_keys(std::vector<std::string> *keys) const;
 
@@ -322,11 +321,6 @@ public:
 template<typename T>
 const T& md_config_t::get_val(const std::string &key) const {
   return boost::get<T>(this->get_val_generic(key));
-}
-
-template<typename T>
-const T& md_config_t::_get_val(const std::string &key) const {
-  return boost::get<T>(this->_get_val_generic(key));
 }
 
 inline std::ostream& operator<<(std::ostream& o, const boost::blank& ) {


### PR DESCRIPTION
I added this originally to prevent a deadlock when reading a new-style
configuration variable from a called observer. I didn't realize at the
time that the config mutex was recursive, so this change was
superfluous.