### PR TITLE
githubmap: define merge conflict resolution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.githubmap merge=union


### PR DESCRIPTION
Use "union" merge to automatically resolve trivial append merge conflicts from
using ptl-tool.py.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>