### PR TITLE
doc: rm stray ")" character from mds config ref

### DIFF
--- a/doc/cephfs/mds-config-ref.rst
+++ b/doc/cephfs/mds-config-ref.rst
@@ -102,7 +102,7 @@
               OSDMap blacklist. It has no effect on how long something is
               blacklisted when the administrator blacklists it manually. For
               example, ``ceph osd blacklist add`` will still use the default
-              blacklist time.)
+              blacklist time.
 :Type:  Float
 :Default: ``24.0*60.0``
 


### PR DESCRIPTION
I accidentally introduced this in 4fb89a63172d2dc6ce8f4702fe90904f9a8fd7bd

Signed-off-by: Ken Dreyer <kdreyer@redhat.com>