### PR TITLE
common/options: enable multiple rocksdb compaction threads for filestore

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3673,7 +3673,7 @@ std::vector<Option> get_global_options() {
     // filestore
 
     Option("filestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("compaction_readahead_size=2097152")
+    .set_default("max_background_compactions=8;compaction_readahead_size=2097152")
     .set_description(""),
 
     Option("filestore_omap_backend", Option::TYPE_STR, Option::LEVEL_DEV)


### PR DESCRIPTION
One of the major benefits of rocksdb over leveldb is multithreaded
compaction. The default of 1 thread does not provide much benefit, and
is insufficient for heavy rgw workloads.

For high-write and delete omap workloads I've seen up to 8 compaction
threads be used.  There's little overhead to having a higher max than
are needed, so set the default to 8.

Signed-off-by: Josh Durgin <jdurgin@redhat.com>