### PR TITLE
test/unittest_bufferlist: check retvals of syscalls

### DIFF
--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -396,10 +396,11 @@ TEST_F(TestRawPipe, buffer_list_write_fd_zero_copy) {
   EXPECT_EQ(0, bl.read_fd_zero_copy(fd, len));
   EXPECT_TRUE(bl.can_zero_copy());
   int out_fd = ::open(FILENAME, O_RDWR|O_CREAT|O_TRUNC, 0600);
+  ASSERT_NE(-1, out_fd);
   EXPECT_EQ(0, bl.write_fd_zero_copy(out_fd));
   struct stat st;
   memset(&st, 0, sizeof(st));
-  EXPECT_EQ(0, ::stat(FILENAME, &st));
+  ASSERT_EQ(0, ::stat(FILENAME, &st));
   EXPECT_EQ(len, st.st_size);
   char buf[len + 1];
   EXPECT_EQ((int)len, safe_read(out_fd, buf, len + 1));
@@ -2554,6 +2555,7 @@ TEST(BufferList, read_fd) {
   bufferlist bl;
   EXPECT_EQ(-EBADF, bl.read_fd(fd, len));
   fd = ::open(FILENAME, O_RDONLY);
+  ASSERT_NE(-1, fd);
   EXPECT_EQ(len, (unsigned)bl.read_fd(fd, len));
   //EXPECT_EQ(CEPH_BUFFER_APPEND_SIZE - len, bl.front().unused_tail_length());
   EXPECT_EQ(len, bl.length());
@@ -2570,7 +2572,7 @@ TEST(BufferList, write_file) {
   EXPECT_EQ(0, bl.write_file(FILENAME, mode));
   struct stat st;
   memset(&st, 0, sizeof(st));
-  ::stat(FILENAME, &st);
+  ASSERT_EQ(0, ::stat(FILENAME, &st));
   EXPECT_EQ((unsigned)(mode | S_IFREG), st.st_mode);
   ::unlink(FILENAME);
 }
@@ -2578,6 +2580,7 @@ TEST(BufferList, write_file) {
 TEST(BufferList, write_fd) {
   ::unlink(FILENAME);
   int fd = ::open(FILENAME, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+  ASSERT_NE(-1, fd);
   bufferlist bl;
   for (unsigned i = 0; i < IOV_MAX * 2; i++) {
     bufferptr ptr("A", 1);
@@ -2587,7 +2590,7 @@ TEST(BufferList, write_fd) {
   ::close(fd);
   struct stat st;
   memset(&st, 0, sizeof(st));
-  ::stat(FILENAME, &st);
+  ASSERT_EQ(0, ::stat(FILENAME, &st));
   EXPECT_EQ(IOV_MAX * 2, st.st_size);
   ::unlink(FILENAME);
 }
@@ -2595,6 +2598,7 @@ TEST(BufferList, write_fd) {
 TEST(BufferList, write_fd_offset) {
   ::unlink(FILENAME);
   int fd = ::open(FILENAME, O_WRONLY|O_CREAT|O_TRUNC, 0600);
+  ASSERT_NE(-1, fd);
   bufferlist bl;
   for (unsigned i = 0; i < IOV_MAX * 2; i++) {
     bufferptr ptr("A", 1);
@@ -2605,7 +2609,7 @@ TEST(BufferList, write_fd_offset) {
   ::close(fd);
   struct stat st;
   memset(&st, 0, sizeof(st));
-  ::stat(FILENAME, &st);
+  ASSERT_EQ(0, ::stat(FILENAME, &st));
   EXPECT_EQ(IOV_MAX * 2 + offset, (unsigned)st.st_size);
   ::unlink(FILENAME);
 }


### PR DESCRIPTION
so we can have better understanding of failures like

[ RUN      ] BufferList.write_fd_offset
/home/jenkins-build/build/workspace/ceph-pull-requests-arm64/src/test/bufferlist.cc:2609:
Failure
      Expected: 1024 * 2 + offset
      Which is: 2248
To be equal to: (unsigned)st.st_size
      Which is: 0
[  FAILED  ] BufferList.write_fd_offset (4 ms)

Signed-off-by: Kefu Chai <kchai@redhat.com>