### PR TITLE
qa/suites/rados/singleton/all/mon-seesaw: whitelist MON_DOWN

### DIFF
--- a/qa/suites/rados/singleton/all/mon-seesaw.yaml
+++ b/qa/suites/rados/singleton/all/mon-seesaw.yaml
@@ -17,6 +17,10 @@ tasks:
       osd:
         debug monc: 1
         debug ms: 1
+    log-whitelist:
+      - overall HEALTH
+      - Manager daemon
+      - \(MGR_DOWN\)
 - mon_seesaw:
 - ceph_manager.create_pool:
     kwargs:


### PR DESCRIPTION
Mgr can get marked down when mon weirdness is happening.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit 0a886bc9f3e9805de04c8c60bd3d78b937737b96)