### PR TITLE
os/bluestore/BlueFS: sanity check that alloc->allocate() won't return 0

### DIFF
--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -195,10 +195,11 @@ int BlueFS::reclaim_blocks(unsigned id, uint64_t want,
   assert(r == 0); // caller shouldn't ask for more than they can get
   int64_t got = alloc[id]->allocate(want, cct->_conf->bluefs_alloc_size, 0,
 				    extents);
+  assert(got != 0);
   if (got < (int64_t)want) {
     alloc[id]->unreserve(want - MAX(0, got));
   }
-  if (got <= 0) {
+  if (got < 0) {
     derr << __func__ << " failed to allocate space to return to bluestore"
 	 << dendl;
     alloc[id]->dump();


### PR DESCRIPTION
If alloc[id]->allocate() returns 0, no space is actually reclaimed.
But BlueStore treats returning 0 as success and will keep reclaiming
space from BlueFS until hit the given threshold, which turns out to
be deadloop-prone.

For now, Bitmap and Stupid never return 0-length allocated space
(which is instead converted to -ENOSPC to suggest an error to caller),
so sanity checking against result code 0 will suffice.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>