### PR TITLE
RGW:S3 operators may return error with json formatter

### DIFF
--- a/src/rgw/rgw_rest.cc
+++ b/src/rgw/rgw_rest.cc
@@ -2310,9 +2310,6 @@ RGWHandler_REST* RGWREST::get_handler(
   int* const init_error
 ) {
   *init_error = preprocess(s, rio);
-  if (*init_error < 0) {
-    return nullptr;
-  }
 
   RGWRESTMgr *m = mgr.get_manager(s, frontend_prefix, s->decoded_uri,
                                   &s->relative_uri);
@@ -2326,6 +2323,9 @@ RGWHandler_REST* RGWREST::get_handler(
   }
 
   RGWHandler_REST* handler = m->get_handler(s, auth_registry, frontend_prefix);
+  if (*init_error < 0) {
+    return nullptr;
+  }
   if (! handler) {
     *init_error = -ERR_METHOD_NOT_ALLOWED;
     return NULL;


### PR DESCRIPTION
we use s3 to operate rgw.
If the rgw return error before parse the type(s3, swift or other types), then this bug will occurs.

Fixes:http://tracker.ceph.com/issues/21767

Signed-off-by:  Yonggang Hu <huygbj@inspur.com>