### PR TITLE
rgw: limits lc days to positive integers

### DIFF
--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -24,6 +24,11 @@ bool LCExpiration_S3::xml_end(const char * el) {
   }
   if (lc_days) {
     days = lc_days->get_data();
+    string err;
+    strict_strtol(days.c_str(), 10, &err);
+    if (!err.empty()) {
+      return false;
+    }
   } else if (lc_dm) {
     dm_expiration = lc_dm->get_data().compare("true") == 0;
     if (!dm_expiration) {
@@ -50,6 +55,11 @@ bool LCNoncurExpiration_S3::xml_end(const char *el) {
     return false;
   }
   days = lc_noncur_days->get_data();
+  string err;
+  strict_strtol(days.c_str(), 10, &err);
+  if (!err.empty()) {
+    return false;
+  }
   return true;
 }
 
@@ -59,6 +69,11 @@ bool LCMPExpiration_S3::xml_end(const char *el) {
     return false;
   }
   days = lc_mp_days->get_data();
+  string err;
+  strict_strtol(days.c_str(), 10, &err);
+  if (!err.empty()) {
+    return false;
+  }
   return true;
 }
 


### PR DESCRIPTION
return MalformedXML if days is not interger, return EINVAL if days is 0 or negative intergers.

Signed-off-by: Shasha Lu <lu.shasha@eisoo.com>