### PR TITLE
mon: handle monitor lag when killing mgrs

### DIFF
--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -115,6 +115,11 @@ public:
   void count_metadata(const string& field, std::map<string,int> *out);
 
   friend class C_Updated;
+
+  // When did the mon last call into our tick() method?  Used for detecting
+  // when the mon was not updating us for some period (e.g. during slow
+  // election) to reset last_beacon timeouts
+  ceph::coarse_mono_clock::time_point last_tick;
 };
 
 #endif


### PR DESCRIPTION

This is a shameless copy of what MDSMonitor does to handle the same situation.

Fixes: http://tracker.ceph.com/issues/20629
Signed-off-by: John Spray <john.spray@redhat.com>