### PR TITLE
rgw: fix bilog entries on multipart complete

### DIFF
--- a/src/cls/rgw/cls_rgw.cc
+++ b/src/cls/rgw/cls_rgw.cc
@@ -935,6 +935,7 @@ int rgw_bucket_complete_op(cls_method_context_t hctx, bufferlist *in, bufferlist
     unaccount_entry(header, remove_entry);
 
     if (op.log_op && !header.syncstopped) {
+      ++header.ver; // increment index version, or we'll overwrite keys previously written
       rc = log_index_operation(hctx, remove_key, CLS_RGW_OP_DEL, op.tag, remove_entry.meta.mtime,
                                remove_entry.ver, CLS_RGW_STATE_COMPLETE, header.ver, header.max_marker, op.bilog_flags, NULL, NULL, &op.zones_trace);
       if (rc < 0)


### PR DESCRIPTION
The `rgw_bucket_complete_op()` cls call for the `RGWCompleteMultipart` op includes a list of multipart parts to remove from the index in `remove_objs`. The removal of these bucket index entries are also logged to the bucket index log. However, they were using the same index version for all of these log entries, which meant that they all wrote to the same key. This overwrites the initial completion of the multipart object itself, so other zones would never try to sync it because they don't see it complete.

Fixes: http://tracker.ceph.com/issues/21772