### PR TITLE
librbd: remove unused variables from ReadResult refactor

### DIFF
--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -148,8 +148,6 @@ protected:
     return "aio_read";
   }
 private:
-  char *m_buf;
-  bufferlist *m_pbl;
   int m_op_flags;
 };
 


### PR DESCRIPTION
Signed-off-by: Jason Dillaman <dillaman@redhat.com>