### PR TITLE
osd: add an external operation queue

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -684,6 +684,8 @@ OPTION(osd_op_num_shards_ssd, OPT_INT)
 // also works to ienforce fairness between clients. "debug_random"
 // chooses among all four with equal probability.
 OPTION(osd_op_queue, OPT_STR)
+OPTION(osd_ex_op_queue, OPT_STR)
+OPTION(osd_use_ex_op_queue, OPT_BOOL)
 
 OPTION(osd_op_queue_cut_off, OPT_STR) // Min priority to go to strict queue. (low, high)
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1948,12 +1948,25 @@ std::vector<Option> get_global_options() {
     .set_long_description("which operation queue algorithm to use; mclock_opclass and mclock_client are currently experimental")
     .add_see_also("osd_op_queue_cut_off"),
 
+    Option("osd_ex_op_queue", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .set_default("wpq")
+    .set_enum_allowed( { "wpq", "prioritized", "mclock_opclass", "mclock_client", "debug_random" } )
+    .set_description("which external operation queue algorithm to use")
+    .set_long_description("which external operation queue algorithm to use; mclock_opclass and mclock_client are currently experimental")
+    .add_see_also("osd_use_ex_op_queue")
+    .add_see_also("osd_op_queue_cut_off"),
+
+    Option("osd_use_ex_op_queue", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(false)
+    .set_description(""),
+
     Option("osd_op_queue_cut_off", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("low")
     .set_enum_allowed( { "low", "high", "debug_random" } )
     .set_description("the threshold between high priority ops and low priority ops")
     .set_long_description("the threshold between high priority ops that use strict priority ordering and low priority ops that use a fairness algorithm that may or may not incorporate priority")
-    .add_see_also("osd_op_queue"),
+    .add_see_also("osd_op_queue")
+    .add_see_also("osd_ex_op_queue"),
 
     Option("osd_op_queue_mclock_client_op_res", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1000.0)


### PR DESCRIPTION
As in the number of shards in Op Queue (https://github.com/ceph/ceph/pull/16369), 
an external operation queue was introduced to solve deepening of the dmClock queue depth problem due to multiple sharded op queue. (https://www.slideshare.net/ssusercee823/implementing-distributed-mclock-in-ceph#13)

As a result of measuring the performance of the external operation queue, there was no significant difference in performance from when the external operation queue was not used.

1. FIO 4KB Random Write without external operation queue, bluestore (original)
137352 IOPs

2. FIO 4KB Random Write with external operation queue, bluestore (external opqueue: WPQ, internal sharded opqueue: WPQ)
136914 IOPs