### PR TITLE
os/bluestore: silence -Wreturn-type warning

### DIFF
--- a/src/os/bluestore/bluestore_types.h
+++ b/src/os/bluestore/bluestore_types.h
@@ -661,6 +661,7 @@ public:
       ++p;
     }
     assert(0 == "we should not get here");
+    return false;
   }
 
   /// return true if the entire range is allocated


### PR DESCRIPTION
this silences following warning:

ceph/src/os/bluestore/bluestore_types.h: In member function ‘bool bluestore_blob_t::_validate_range(uint64_t, uint64_t, bool) const’:
ceph/src/os/bluestore/bluestore_types.h:664:3: warning: control reaches end of non-void function [-Wreturn-type]
   }
   ^

Signed-off-by: Kefu Chai <kchai@redhat.com>