### PR TITLE
build/ops: rpm: move ceph-*-tool binaries out of ceph-test subpackage

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -932,6 +932,7 @@ rm -rf %{buildroot}
 %{_bindir}/crushtool
 %{_bindir}/monmaptool
 %{_bindir}/osdmaptool
+%{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
 %{_bindir}/ceph-detect-init
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
@@ -984,6 +985,7 @@ rm -rf %{buildroot}
 %{_mandir}/man8/crushtool.8*
 %{_mandir}/man8/osdmaptool.8*
 %{_mandir}/man8/monmaptool.8*
+%{_mandir}/man8/ceph-kvstore-tool.8*
 #set up placeholder directories
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/tmp
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-osd
@@ -1239,6 +1241,7 @@ fi
 %files mon
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-rest-api
+%{_bindir}/ceph-monstore-tool
 %{_mandir}/man8/ceph-mon.8*
 %{_mandir}/man8/ceph-rest-api.8*
 %{python_sitelib}/ceph_rest_api.py*
@@ -1407,6 +1410,7 @@ fi
 %{_bindir}/ceph-clsinfo
 %{_bindir}/ceph-bluestore-tool
 %{_bindir}/ceph-objectstore-tool
+%{_bindir}/ceph-osdomap-tool
 %{_bindir}/ceph-osd
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_udevrulesdir}
@@ -1632,12 +1636,8 @@ fi
 %{_bindir}/ceph_tpbench
 %{_bindir}/ceph_xattr_bench
 %{_bindir}/ceph-coverage
-%{_bindir}/ceph-monstore-tool
-%{_bindir}/ceph-osdomap-tool
-%{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-debugpack
 %{_mandir}/man8/ceph-debugpack.8*
-%{_mandir}/man8/ceph-kvstore-tool.8*
 %dir %{_libdir}/ceph
 %{_libdir}/ceph/ceph-monstore-update-crush.sh
 %endif

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -5,6 +5,7 @@ usr/bin/ceph-run
 usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool
+usr/bin/ceph-kvstore-tool
 usr/lib/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/python*/dist-packages/ceph_detect_init*
@@ -19,3 +20,4 @@ usr/share/man/man8/ceph-run.8
 usr/share/man/man8/crushtool.8
 usr/share/man/man8/monmaptool.8
 usr/share/man/man8/osdmaptool.8
+usr/share/man/man8/ceph-kvstore-tool.8

--- a/debian/ceph-mon.install
+++ b/debian/ceph-mon.install
@@ -1,4 +1,5 @@
 usr/bin/ceph-mon
+usr/bin/ceph-monstore-tool
 usr/bin/ceph-rest-api
 usr/lib/python*/dist-packages/ceph_rest_api.py*
 usr/share/man/man8/ceph-mon.8

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -3,6 +3,7 @@ lib/udev/rules.d/95-ceph-osd.rules
 usr/bin/ceph-bluestore-tool
 usr/bin/ceph-clsinfo
 usr/bin/ceph-objectstore-tool
+usr/bin/ceph-osdomap-tool
 usr/bin/ceph-osd
 usr/bin/ceph_objectstore_bench
 usr/lib/ceph/ceph-osd-prestart.sh

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -1,8 +1,5 @@
 usr/bin/ceph-client-debug
 usr/bin/ceph-coverage
-usr/bin/ceph-kvstore-tool
-usr/bin/ceph-monstore-tool
-usr/bin/ceph-osdomap-tool
 usr/bin/ceph_bench_log
 usr/bin/ceph_erasure_code
 usr/bin/ceph_erasure_code_benchmark
@@ -28,4 +25,3 @@ usr/bin/ceph_tpbench
 usr/bin/ceph_xattr_bench
 usr/lib/ceph/ceph-monstore-update-crush.sh
 usr/share/java/libcephfs-test.jar
-usr/share/man/man8/ceph-kvstore-tool.8


### PR DESCRIPTION
ceph-osdomap-tool into ceph-osd subpackage
ceph-monstore-tool into ceph-mon subpackage
ceph-kvstore-tool into ceph-base

Fixes: http://tracker.ceph.com/issues/21762
Signed-off-by: Nathan Cutler <ncutler@suse.com>

Thanks to @vumrao for the proposal, to @ktdreyer for the suggestion to put ceph-kvstore-tool in ceph-base, and to @tchaikov for bringing the ceph-kvstore-tool manpage to my attention!