### PR TITLE
luminous: mds: keep CInode::STATE_QUEUEDEXPORTPIN state when exporting inode

### DIFF
--- a/src/mds/CInode.h
+++ b/src/mds/CInode.h
@@ -208,7 +208,7 @@ class CInode : public MDSCacheObject, public InodeStoreBase, public Counter<CIno
   static const int MASK_STATE_EXPORTED =
     (STATE_DIRTY|STATE_NEEDSRECOVER|STATE_DIRTYPARENT|STATE_DIRTYPOOL);
   static const int MASK_STATE_EXPORT_KEPT =
-    (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS);
+    (STATE_FROZEN|STATE_AMBIGUOUSAUTH|STATE_EXPORTINGCAPS|STATE_QUEUEDEXPORTPIN);
 
   // -- waiters --
   static const uint64_t WAIT_DIR         = (1<<0);


### PR DESCRIPTION
http://tracker.ceph.com/issues/21806