### PR TITLE
common: Using this pointer after freeing

### DIFF
--- a/src/common/RefCountedObj.h
+++ b/src/common/RefCountedObj.h
@@ -59,7 +59,7 @@ public:
     } else {
       ANNOTATE_HAPPENS_BEFORE(&nref);
     }
-    if (local_cct)
+    if (local_cct && (v != 0))
       lsubdout(local_cct, refs, 1) << "RefCountedObject::put " << this << " "
 				   << (v + 1) << " -> " << v
 				   << dendl;


### PR DESCRIPTION
Fixes the coverity issue:

>CID 1401652 (#1 of 1): Use after free (USE_AFTER_FREE)
>7. pass_freed_arg: Passing freed pointer this as an
argument to operator <<.

Signed-off-by: Amit Kumar amitkuma@redhat.com