### PR TITLE
rbd: eager-thick provisioning support

### DIFF
--- a/doc/man/8/rbd.rst
+++ b/doc/man/8/rbd.rst
@@ -197,9 +197,12 @@ Commands
   Copy the content of a src-image into the newly created dest-image.
   dest-image will have the same size, object size, and image format as src-image.
 
-:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--object-size *size-in-B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--image-feature *feature-name*]... [--image-shared] *image-spec*
+:command:`create` (-s | --size *size-in-M/G/T*) [--image-format *format-id*] [--object-size *size-in-B/K/M*] [--stripe-unit *size-in-B/K/M* --stripe-count *num*] [--thick-provision] [--no-progress] [--image-feature *feature-name*]... [--image-shared] *image-spec*
   Will create a new rbd image. You must also specify the size via --size.  The
   --stripe-unit and --stripe-count arguments are optional, but must be used together.
+  If the --thick-provision is enabled, it will fully allocate storage for
+  the image at creation time. It will take a long time to do.
+  Note: thick provisioning requires zeroing the contents of the entire image.
 
 :command:`deep cp` (*src-image-spec* | *src-snap-spec*) *dest-image-spec*
   Deep copy the content of a src-image into the newly created dest-image.

--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -540,6 +540,58 @@ test_clone_v2() {
     rbd rm test2
 }
 
+test_thick_provision() {
+    echo "testing thick provision..."
+    remove_images
+
+    # Try to create small and large thick-pro image and
+    # check actual size. (64M and 4G)
+
+    # Small thick-pro image test
+    rbd create $RBD_CREATE_ARGS --thick-provision -s 64M test1
+    count=0
+    ret=""
+    while [ $count -lt 10 ]
+    do
+        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^64M' && ret=$?
+        if [ "$ret" = "0" ]
+        then
+            break;
+        fi
+        count=`expr $count + 1`
+        sleep 2
+    done
+    rbd du
+    if [ "$ret" != "0" ]
+    then
+        exit 1
+    fi
+    rbd rm test1
+    rbd ls | grep test1 | wc -l | grep '^0$'
+
+    # Large thick-pro image test
+    rbd create $RBD_CREATE_ARGS --thick-provision -s 4G test1
+    count=0
+    ret=""
+    while [ $count -lt 10 ]
+    do
+        rbd du|grep test1|tr -s " "|cut -d " " -f 3|grep '^4G' && ret=$?
+        if [ "$ret" = "0" ]
+        then
+            break;
+        fi
+        count=`expr $count + 1`
+        sleep 2
+    done
+    rbd du
+    if [ "$ret" != "0" ]
+    then
+        exit 1
+    fi
+    rbd rm test1
+    rbd ls | grep test1 | wc -l | grep '^0$'
+}
+
 test_pool_image_args
 test_rename
 test_ls
@@ -547,6 +599,7 @@ test_remove
 RBD_CREATE_ARGS=""
 test_others
 test_locking
+test_thick_provision
 RBD_CREATE_ARGS="--image-format 2"
 test_others
 test_locking
@@ -555,5 +608,6 @@ test_trash
 test_purge
 test_deep_copy_clone
 test_clone_v2
+test_thick_provision
 
 echo OK

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6356,6 +6356,10 @@ static std::vector<Option> get_rbd_options() {
     Option("rbd_qos_iops_limit", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("the desired limit of IO operations per second"),
+
+    Option("rbd_discard_on_zeroed_write_same", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description("discard data on zeroed write same instead of writing zero"),
   });
 }
 

--- a/src/librbd/librbd.cc
+++ b/src/librbd/librbd.cc
@@ -1800,7 +1800,8 @@ namespace librbd {
       return -EINVAL;
     }
 
-    if (mem_is_zero(bl.c_str(), bl.length())) {
+    bool discard_zero = ictx->cct->_conf->get_val<bool>("rbd_discard_on_zeroed_write_same");
+    if (discard_zero && mem_is_zero(bl.c_str(), bl.length())) {
       int r = ictx->io_work_queue->discard(ofs, len, false);
       tracepoint(librbd, writesame_exit, r);
       return r;
@@ -1931,7 +1932,8 @@ namespace librbd {
       return -EINVAL;
     }
 
-    if (mem_is_zero(bl.c_str(), bl.length())) {
+    bool discard_zero = ictx->cct->_conf->get_val<bool>("rbd_discard_on_zeroed_write_same");
+    if (discard_zero && mem_is_zero(bl.c_str(), bl.length())) {
       ictx->io_work_queue->aio_discard(get_aio_completion(c), off, len, false);
       tracepoint(librbd, aio_writesame_exit, 0);
       return 0;
@@ -3936,7 +3938,8 @@ extern "C" ssize_t rbd_writesame(rbd_image_t image, uint64_t ofs, size_t len,
     return -EINVAL;
   }
 
-  if (mem_is_zero(buf, data_len)) {
+  bool discard_zero = ictx->cct->_conf->get_val<bool>("rbd_discard_on_zeroed_write_same");
+  if (discard_zero && mem_is_zero(buf, data_len)) {
     int r = ictx->io_work_queue->discard(ofs, len, false);
     tracepoint(librbd, writesame_exit, r);
     return r;
@@ -4157,7 +4160,8 @@ extern "C" int rbd_aio_writesame(rbd_image_t image, uint64_t off, size_t len,
     return -EINVAL;
   }
 
-  if (mem_is_zero(buf, data_len)) {
+  bool discard_zero = ictx->cct->_conf->get_val<bool>("rbd_discard_on_zeroed_write_same");
+  if (discard_zero && mem_is_zero(buf, data_len)) {
     ictx->io_work_queue->aio_discard(get_aio_completion(comp), off, len, false);
     tracepoint(librbd, aio_writesame_exit, 0);
     return 0;

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -264,7 +264,8 @@
                     [--stripe-count <stripe-count>] [--data-pool <data-pool>] 
                     [--journal-splay-width <journal-splay-width>] 
                     [--journal-object-size <journal-object-size>] 
-                    [--journal-pool <journal-pool>] --size <size> 
+                    [--journal-pool <journal-pool>] 
+                    [--thick-provision] --size <size> [--no-progress] 
                     <image-spec> 
   
   Create an empty image.
@@ -291,7 +292,9 @@
     --journal-splay-width arg number of active journal objects
     --journal-object-size arg size of journal objects
     --journal-pool arg        pool for journal objects
+    --thick-provision         fully allocate storage and zero image
     -s [ --size ] arg         image size (in M/G/T) [default: M]
+    --no-progress             disable progress output
   
   Image Features:
     (*) supports enabling/disabling on existing images

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -71,6 +71,7 @@ static const std::string IMAGE_STRIPE_UNIT("stripe-unit");
 static const std::string IMAGE_STRIPE_COUNT("stripe-count");
 static const std::string IMAGE_DATA_POOL("data-pool");
 static const std::string IMAGE_SPARSE_SIZE("sparse-size");
+static const std::string IMAGE_THICK_PROVISION("thick-provision");
 
 static const std::string JOURNAL_OBJECT_SIZE("journal-object-size");
 static const std::string JOURNAL_SPLAY_WIDTH("journal-splay-width");

--- a/src/tools/rbd/action/Create.cc
+++ b/src/tools/rbd/action/Create.cc
@@ -7,6 +7,8 @@
 #include "common/errno.h"
 #include <iostream>
 #include <boost/program_options.hpp>
+#include "common/Cond.h"
+#include "common/Mutex.h"
 
 namespace rbd {
 namespace action {
@@ -25,7 +27,172 @@ void get_arguments(po::options_description *positional,
                    po::options_description *options) {
   at::add_image_spec_options(positional, options, at::ARGUMENT_MODIFIER_NONE);
   at::add_create_image_options(options, true);
+  options->add_options()
+    (at::IMAGE_THICK_PROVISION.c_str(), po::bool_switch(), "fully allocate storage and zero image");
   at::add_size_option(options);
+  at::add_no_progress_option(options);
+}
+
+void thick_provision_writer_completion(rbd_completion_t, void *);
+
+struct thick_provision_writer {
+  librbd::Image *image;
+  Mutex lock;
+  Cond cond;
+  bufferlist bl;
+  uint64_t chunk_size;
+  const int block_size;
+  uint64_t concurr;
+  struct {
+    uint64_t in_flight;
+    int io_error;
+  } io_status;
+
+  // Constructor
+  explicit thick_provision_writer(librbd::Image *i, librbd::ImageOptions &o)
+    : image(i),
+      lock("thick_provision_writer::lock"),
+      block_size(512) // 512 Bytes
+  {
+    // If error cases occur, the code is aborted, because
+    // constructor cannot return error value.
+    assert(g_conf != nullptr);
+    bl.append_zero(block_size);
+
+    librbd::image_info_t info;
+    int r = image->stat(info, sizeof(info));
+    assert(r >= 0);
+    uint64_t order;
+    if (info.order == 0) {
+      order = g_conf->get_val<int64_t>("rbd_default_order");
+    } else {
+      order = info.order;
+    }
+    chunk_size = (1ull << order);
+    if (image->get_stripe_unit() < chunk_size) {
+      chunk_size = image->get_stripe_unit();
+    }
+
+    concurr = g_conf->get_val<int64_t>("rbd_concurrent_management_ops");
+    io_status.in_flight = 0;
+    io_status.io_error = 0;
+  }
+
+  int start_io(uint64_t write_offset)
+  {
+    {
+      Mutex::Locker l(lock);
+      io_status.in_flight++;
+      if (io_status.in_flight > concurr) {
+        io_status.in_flight--;
+        return -EINVAL;
+      }
+    }
+
+    librbd::RBD::AioCompletion *c;
+    c = new librbd::RBD::AioCompletion(this, thick_provision_writer_completion);
+    int r;
+    r = image->aio_writesame(write_offset, chunk_size, bl, c, LIBRADOS_OP_FLAG_FADVISE_SEQUENTIAL);
+    if (r < 0) {
+      Mutex::Locker l(lock);
+      io_status.io_error = r;
+    }
+    return r;
+  }
+
+  int wait_for(uint64_t max) {
+    Mutex::Locker l(lock);
+    int r = io_status.io_error;
+
+    while (io_status.in_flight > max) {
+      utime_t dur;
+      dur.set_from_double(.2);
+      cond.WaitInterval(lock, dur);
+    }
+    return r;
+  }
+};
+
+void thick_provision_writer_completion(rbd_completion_t rc, void *pc) {
+  librbd::RBD::AioCompletion *ac = (librbd::RBD::AioCompletion *)rc;
+  thick_provision_writer *tc = static_cast<thick_provision_writer *>(pc);
+
+  int r = ac->get_return_value();
+  tc->lock.Lock();
+  if (r < 0 &&  tc->io_status.io_error >= 0) {
+    tc->io_status.io_error = r;
+  }
+  tc->io_status.in_flight--;
+  tc->cond.Signal();
+  tc->lock.Unlock();
+  ac->release();
+}
+
+int write_data(librbd::Image &image, librbd::ImageOptions &opts,
+               bool no_progress) {
+  uint64_t image_size;
+  int r = 0;
+  utils::ProgressContext pc("Thick provisioning", no_progress);
+
+  if (image.size(&image_size) != 0) {
+    return -EINVAL;
+  }
+
+  thick_provision_writer tpw(&image, opts);
+  uint64_t off;
+  uint64_t i;
+  for (off = 0; off < image_size;) {
+    i = 0;
+    while (i < tpw.concurr && off < image_size) {
+      tpw.wait_for(tpw.concurr - 1);
+      r = tpw.start_io(off);
+      if (r != 0) {
+        goto err_writesame;
+      }
+      ++i;
+      off += tpw.chunk_size;
+      pc.update_progress(off, image_size);
+    }
+  }
+
+  tpw.wait_for(0);
+  r = image.flush();
+  if (r < 0) {
+    std::cerr << "rbd: failed to flush at the end: " << cpp_strerror(r)
+              << std::endl;
+    goto err_writesame;
+  }
+  pc.finish();
+
+  return r;
+
+err_writesame:
+  tpw.wait_for(0);
+  pc.fail();
+
+  return r;
+}
+
+int thick_write(const std::string &image_name,librados::IoCtx &io_ctx,
+                librbd::ImageOptions &opts, bool no_progress) {
+  int r = 0;
+  librbd::Image image;
+
+  // To prevent writesame from discarding data, thick_write sets
+  // the rbd_discard_on_zeroed_write_same option to false.
+  assert(g_conf != nullptr);
+  r = g_conf->set_val("rbd_discard_on_zeroed_write_same", "false");
+  assert(r == 0);
+  r = utils::open_image(io_ctx, image_name, false, &image);
+  if (r < 0) {
+    return r;
+  }
+
+  r = write_data(image, opts, no_progress);
+
+  image.close();
+
+  return r;
 }
 
 int execute(const po::variables_map &vm,
@@ -65,6 +232,15 @@ int execute(const po::variables_map &vm,
   if (r < 0) {
     std::cerr << "rbd: create error: " << cpp_strerror(r) << std::endl;
     return r;
+  }
+
+  if (vm.count(at::IMAGE_THICK_PROVISION) && vm[at::IMAGE_THICK_PROVISION].as<bool>()) {
+    r = thick_write(image_name, io_ctx, opts, vm[at::NO_PROGRESS].as<bool>());
+    if (r < 0) {
+      std::cerr << "rbd: image created but error encountered during thick provisioning: "
+                << cpp_strerror(r) << std::endl;
+      return r;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
This patch series adds eager-thick provisioning function to rbd command.
The eager-thick means that an rbd image is created with zero data.
This function is suitable for followings:
(1) Avoid performance degradation caused by allocating new object
(2) Avoid operational problems caused by thin-provisioned rbd image,
    such as shortage of actual disk


Hitoshi Kamei (2):
  rbd: eager-thick provisioning support
  rbd: manpage for eager-thick provisioning

 doc/man/8/rbd.rst              |  4 ++-
 src/tools/rbd/ArgumentTypes.cc |  3 +-
 src/tools/rbd/ArgumentTypes.h  |  1 +
 src/tools/rbd/Utils.cc         | 69 ++++++++++++++++++++++++++++++++++++++++++
 src/tools/rbd/Utils.h          |  3 ++
 src/tools/rbd/action/Create.cc | 10 ++++++
 6 files changed, 88 insertions(+), 2 deletions(-)