### PR TITLE
bluestore:  comp_min_blob_size init error

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -3662,8 +3662,8 @@ void BlueStore::_set_compression()
     return;
   }
 
-  if (cct->_conf->bluestore_compression_max_blob_size) {
-    comp_min_blob_size = cct->_conf->bluestore_compression_max_blob_size;
+  if (cct->_conf->bluestore_compression_min_blob_size) {
+    comp_min_blob_size = cct->_conf->bluestore_compression_min_blob_size;
   } else {
     assert(bdev);
     if (bdev->is_rotational()) {


### PR DESCRIPTION
using bluestore_compression_min_blob_size instead of bluestore_compression_max_blob_size to config comp_min_blob_size

Signed-off-by: linbing <linbing@t2cloud.net>