### PR TITLE
rbd: replace trash delay option, add rbd trash purge command

### DIFF
--- a/qa/workunits/rbd/cli_generic.sh
+++ b/qa/workunits/rbd/cli_generic.sh
@@ -172,7 +172,7 @@ test_ls() {
     rbd ls -l | grep 'test1.*1M.*2'
     rbd ls -l | grep 'test2.*1M.*1'
     remove_images
-	
+
     # test that many images can be shown by ls
     for i in $(seq -w 00 99); do
 	rbd create image.$i -s 1
@@ -180,7 +180,7 @@ test_ls() {
     rbd ls | wc -l | grep 100
     rbd ls -l | grep image | wc -l | grep 100
     for i in $(seq -w 00 99); do
-	rbd rm image.$i 
+	rbd rm image.$i
     done
 
     for i in $(seq -w 00 99); do
@@ -189,7 +189,7 @@ test_ls() {
     rbd ls | wc -l | grep 100
     rbd ls -l | grep image |  wc -l | grep 100
     for i in $(seq -w 00 99); do
-	rbd rm image.$i 
+	rbd rm image.$i
     done
 }
 
@@ -417,7 +417,7 @@ test_trash() {
     rbd ls | wc -l | grep 1
     rbd ls -l | grep 'test2.*2.*'
 
-    rbd trash mv test2 --delay 3600
+    rbd trash mv test2 --expires-at "3600 sec"
     rbd trash ls | grep test2
     rbd trash ls | wc -l | grep 1
     rbd trash ls -l | grep 'test2.*USER.*protected until'
@@ -453,6 +453,35 @@ test_trash() {
     remove_images
 }
 
+test_purge(){
+    echo "testing trash purge..."
+    remove_images
+
+    for i in {1..3};
+    do
+        rbd create   "test$i" -s 4
+        rbd bench    "test$i" --io-total 4M --io-type write > /dev/null
+        rbd trash mv "test$i"
+    done
+
+    rbd trash purge --threshold 1 | grep "Nothing to do"
+
+    rbd trash purge --threshold 0
+    rbd trash ls | wc -l | grep 0
+
+    rbd create foo -s 1
+    rbd create bar -s 1
+
+    rbd trash mv foo --expires-at "10 sec"
+    rbd trash mv bar --expires-at "30 sec"
+
+    rbd trash purge --expired-before "now + 10 sec"
+    rbd trash ls | grep -v foo | wc -l | grep 1
+    rbd trash ls | grep bar
+
+    LAST_IMG=$(rbd trash ls | grep bar | awk '{print $1;}')
+    rbd trash rm $LAST_IMG --force --no-progress | grep -v '.' | wc -l | grep 0
+}
 
 test_pool_image_args
 test_rename
@@ -466,5 +495,6 @@ test_others
 test_locking
 test_clone
 test_trash
+test_purge
 
 echo OK

--- a/src/test/cli/rbd/help.t
+++ b/src/test/cli/rbd/help.t
@@ -105,6 +105,7 @@ Skip test on FreeBSD as it generates different output there.
       status                            Show the status of this image.
       trash list (trash ls)             List trash images.
       trash move (trash mv)             Move an image to the trash.
+      trash purge                       Remove all expired images from trash.
       trash remove (trash rm)           Remove an image from trash.
       trash restore                     Restore an image from trash.
       unmap                             Unmap a rbd device that was used by the
@@ -1567,19 +1568,39 @@ Skip test on FreeBSD as it generates different output there.
     --pretty-format      pretty formatting (json and xml)
   
   rbd help trash move
-  usage: rbd trash move [--pool <pool>] [--image <image>] [--delay <delay>] 
+  usage: rbd trash move [--pool <pool>] [--image <image>] 
+                        [--expires-at <expires-at>] 
                         <image-spec> 
   
   Move an image to the trash.
   
   Positional arguments
-    <image-spec>         image specification
-                         (example: [<pool-name>/]<image-name>)
+    <image-spec>            image specification
+                            (example: [<pool-name>/]<image-name>)
   
   Optional arguments
-    -p [ --pool ] arg    pool name
-    --image arg          image name
-    --delay arg          time delay in seconds until effectively remove the image
+    -p [ --pool ] arg       pool name
+    --image arg             image name
+    --expires-at arg (=now) set the expiration time of an image so it can be
+                            purged when it is stale
+  
+  rbd help trash purge
+  usage: rbd trash purge [--pool <pool>] [--no-progress] 
+                         [--expired-before <expired-before>] 
+                         [--threshold <threshold>] 
+                         <pool-name> 
+  
+  Remove all expired images from trash.
+  
+  Positional arguments
+    <pool-name>           pool name
+  
+  Optional arguments
+    -p [ --pool ] arg     pool name
+    --no-progress         disable progress output
+    --expired-before date purges images that expired before the given date
+    --threshold arg       purges images until the current pool data usage is
+                          reduced to X%, value range: 0.0-1.0
   
   rbd help trash remove
   usage: rbd trash remove [--pool <pool>] [--image-id <image-id>] 

--- a/src/tools/rbd/ArgumentTypes.h
+++ b/src/tools/rbd/ArgumentTypes.h
@@ -81,8 +81,6 @@ static const std::string PRETTY_FORMAT("pretty-format");
 static const std::string VERBOSE("verbose");
 static const std::string NO_ERROR("no-error");
 
-static const std::string DELAY("delay");
-
 static const std::string LIMIT("limit");
 
 static const std::set<std::string> SWITCH_ARGUMENTS = {


### PR DESCRIPTION
There was a discussion about the trash delay option (that is in seconds) to be replaced with something else. @dvanders proposes a `/bin/date` style input of the form of `2017-12-30`, `now`, `1 week ago`, etc. It is a human-readable text and it can't be confused with something like `60*24*7`. This pull request implements it, by calling `/bin/date` safely ([exec](https://linux.die.net/man/3/exec)*).

There is also a need for a batch removal of images in the trash that have expired. It can be used on Openstack as a cron job. The name of the command is "purge" and deletes every image with expired deferment end time from the defined pool. There is also an option `--older-than` implemented to remove images with deferment end time older than a given date.

This pull request is still a work in progress and we would like to get some feedback possibly from @dillaman and @rjfd  


Thanks