### PR TITLE
log: silence warning from -Wsign-compare

### DIFF
--- a/src/log/test.cc
+++ b/src/log/test.cc
@@ -263,7 +263,7 @@ TEST(Log, TimeFormat)
     ceph::logging::append_time(t, buf, buflen);
     auto c = std::strrchr(buf, '.');
     ASSERT_NE(c, nullptr);
-    ASSERT_EQ(strlen(c + 1), 3);
+    ASSERT_EQ(3u, strlen(c + 1));
   }
   {
     clock.refine();
@@ -271,6 +271,6 @@ TEST(Log, TimeFormat)
     ceph::logging::append_time(t, buf, buflen);
     auto c = std::strrchr(buf, '.');
     ASSERT_NE(c, nullptr);
-    ASSERT_EQ(std::strlen(c + 1), 6);
+    ASSERT_EQ(6u, std::strlen(c + 1));
   }
 }


### PR DESCRIPTION
This warning appears in jenkins build:
```    
    /home/jenkins-build/build/workspace/ceph-pull-requests/src/log/test.cc:266:232:   required from here
    /home/jenkins-build/build/workspace/ceph-pull-requests/src/googletest/googletest/include/gtest/gtest.h:1392:11: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
       if (lhs == rhs) {
```
Signed-off-by: Jos Collin <jcollin@redhat.com>