### PR TITLE
mgr: skip first non-zero incremental in PGMap::apply_incremental()

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -1021,6 +1021,11 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
   assert(inc.version == version+1);
   version++;
 
+  // set fake but reasonable first stamp
+  if (stamp == utime_t()){
+    stamp = utime_t(time(0) - g_conf->get_val<int64_t>("mgr_tick_period"), 0);
+  }
+
   utime_t delta_t;
   delta_t = inc.stamp;
   delta_t -= stamp;
@@ -1085,13 +1090,20 @@ void PGMap::apply_incremental(CephContext *cct, const Incremental& inc)
     }
   }
 
-  // calculate a delta, and average over the last 2 deltas.
   pool_stat_t d = pg_sum;
   d.stats.sub(pg_sum_old.stats);
-  pg_sum_deltas.push_back(make_pair(d, delta_t));
-  stamp_delta += delta_t;
 
-  pg_sum_delta.stats.add(d.stats);
+  // if mgr restarts first update of pg_sum is previous pg_sum
+  // so skip this huge value
+  if (!pg_sum_delta_skipped_first) {
+    if (!(pg_sum.stats.sum == object_stat_sum_t()))
+      pg_sum_delta_skipped_first = true;
+  } else {
+    stamp_delta += delta_t;
+    pg_sum_deltas.push_back(make_pair(d, delta_t));
+    pg_sum_delta.stats.add(d.stats);
+  }
+
   if (pg_sum_deltas.size() > (unsigned)MAX(1, cct ? cct->_conf->mon_stat_smooth_intervals : 1)) {
     pg_sum_delta.stats.sub(pg_sum_deltas.front().first.stats);
     stamp_delta -= pg_sum_deltas.front().second;

--- a/src/mon/PGMap.h
+++ b/src/mon/PGMap.h
@@ -89,6 +89,7 @@ public:
    */
   mempool::pgmap::unordered_map<uint64_t, pair<pool_stat_t,utime_t> > per_pool_sum_delta;
 
+  bool pg_sum_delta_skipped_first = false;
   pool_stat_t pg_sum_delta;
   utime_t stamp_delta;
 


### PR DESCRIPTION
After initialization of PGMap instance PGMap::stamp is zero
and this cause huge first delta.
Also after mgr restart first non-zero value coming to PGMap::apply_incremental()
is current pg_sum value so it produces unreasonably huge pg_sum_delta.
This patch introduces a workaround to save pg_sum and not update pg_sum_delta
by first non-zero incremental.

Signed-off-by: Aleksei Gutikov <aleksey.gutikov@synesis.ru>
Fixes: http://tracker.ceph.com/issues/21773