### PR TITLE
migrate rand() to new random number library

### DIFF
--- a/src/auth/cephx/CephxProtocol.cc
+++ b/src/auth/cephx/CephxProtocol.cc
@@ -17,12 +17,11 @@
 #include "common/config.h"
 #include "common/debug.h"
 #include "include/buffer.h"
+#include "include/random.h"
 
 #define dout_subsys ceph_subsys_auth
 #undef dout_prefix
 #define dout_prefix *_dout << "cephx: "
-
-
 
 void cephx_calc_client_server_challenge(CephContext *cct, CryptoKey& secret, uint64_t server_challenge, 
 		  uint64_t client_challenge, uint64_t *key, std::string &error)
@@ -296,7 +295,8 @@ CephXAuthorizer *CephXTicketHandler::build_authorizer(uint64_t global_id) const
 {
   CephXAuthorizer *a = new CephXAuthorizer(cct);
   a->session_key = session_key;
-  a->nonce = ((uint64_t)rand() << 32) + rand();
+  a->nonce = ceph::util::generate_random_number() + 
+              (static_cast<uint64_t>(ceph::util::generate_random_number()) << 32);
 
   __u8 authorizer_v = 1;
   encode(authorizer_v, a->bl);

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -414,7 +414,7 @@ int SyntheticClient::run()
         iargs.pop_front();
         if (run_me()) {
           ceph::util::randomize_rng();
-          sleep(ceph::util::generate_random_number(iarg1));
+          sleep(ceph::util::generate_random_number(iarg1 - 1));
         }
 	did_run_me();
       }
@@ -824,7 +824,7 @@ int SyntheticClient::run()
         int count = iargs.front();  iargs.pop_front();
         if (run_me()) {
           for (int i=0; i<count; i++) {
-            int fd = client->open("test", ceph::util::generate_random_number(2) ?
+            int fd = client->open("test", ceph::util::generate_random_number(1) ?
 				  (O_WRONLY|O_CREAT) : O_RDONLY,
 				  perms);
             if (fd > 0) client->close(fd);
@@ -959,7 +959,7 @@ int SyntheticClient::join_thread()
 
 bool roll_die(float p) 
 {
-  float r = static_cast<float>(ceph::util::generate_random_number(100000) / 100000.0);
+  float r = static_cast<float>(ceph::util::generate_random_number(100000 - 1) / 100000.0);
   if (r < p) 
     return true;
   else 
@@ -2351,7 +2351,7 @@ int SyntheticClient::object_rw(int nobj, int osize, int wrpc,
     if (time_to_stop()) break;
     
     // read or write?
-    bool write = ceph::util::generate_random_number(100) < wrpc;
+    bool write = ceph::util::generate_random_number(100 - 1) < wrpc;
 
     // choose object
     double r = ceph::util::generate_random_number<double>(0.0, 1.0);
@@ -2444,7 +2444,7 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
     }
     
     if (read) {
-        offset= ceph::util::generate_random_number(chunks + 1);
+        offset= ceph::util::generate_random_number(chunks);
         dout(2) << "reading block " << offset << "/" << chunks << dendl;
 
         int r = client->read(fd, buf, rdsize, offset*rdsize);
@@ -2459,7 +2459,7 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
       // 64 bits : client id
       // = 128 bits (16 bytes)
 
-      offset= ceph::util::generate_random_number(chunks + 1);
+      offset= ceph::util::generate_random_number(chunks);
       uint64_t *p = (uint64_t*)buf;
       while ((char*)p < buf + rdsize) {
 	*p = offset*rdsize + (char*)p - buf;      
@@ -2526,7 +2526,7 @@ int normdist(int min, int max, int stdev) /* specifies input values */
   for (int c = iterate; c != 0; c--) /* loop through iterations */
     {
       //  result += (uniform (1, 100) * stdev) / 100; /* calculate and
-      result += ((ceph::util::generate_random_number(100) + 1)  * stdev) / 100;
+      result += (ceph::util::generate_random_number(100) * stdev) / 100;
       // printf("result=%d\n", result );
     }
   printf("\n final result=%d\n", result );
@@ -2582,10 +2582,10 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
 	// 64 bits : client id
 	// = 128 bits (16 bytes)
 	
-	int count = ceph::util::generate_random_number(10);
+	int count = ceph::util::generate_random_number(10 - 1);
 	
 	for ( int j=0;j<count; j++ ) {
-	  offset=ceph::util::generate_random_number(chunks + 1);
+	  offset=ceph::util::generate_random_number(chunks);
 	  uint64_t *p = (uint64_t*)buf;
 	  while ((char*)p < buf + rdsize) {
 	    *p = offset*rdsize + (char*)p - buf;      
@@ -2815,7 +2815,7 @@ void SyntheticClient::make_dir_mess(const char *basedir, int n)
   // create dirs
   for (int i=0; i<n; i++) {
     // pick a dir
-    int k = ceph::util::generate_random_number(dirs.size());
+    int k = ceph::util::generate_random_number(dirs.size() - 1);
     string parent = dirs[k];
     
     // pick a name
@@ -2901,7 +2901,7 @@ void SyntheticClient::foo()
     // open some files
     ceph::util::randomize_rng();
     for (int i=0; i<20; i++) {
-      constexpr int s = 5;
+      constexpr int s = 4;
       int a = ceph::util::generate_random_number(s);
       int b = ceph::util::generate_random_number(s);
       int c = ceph::util::generate_random_number(s);
@@ -2917,7 +2917,7 @@ void SyntheticClient::foo()
     // link fun
     ceph::util::randomize_rng();
     for (int i=0; i<100; i++) {
-      constexpr int s = 5;
+      constexpr int s = 4;
       int a = ceph::util::generate_random_number(s);
       int b = ceph::util::generate_random_number(s);
       int c = ceph::util::generate_random_number(s);
@@ -2932,7 +2932,7 @@ void SyntheticClient::foo()
 
     ceph::util::randomize_rng();
     for (int i=0; i<100; i++) {
-      constexpr int s = 5;
+      constexpr int s = 4;
       int a = ceph::util::generate_random_number(s);
       int b = ceph::util::generate_random_number(s);
       int c = ceph::util::generate_random_number(s);
@@ -3023,14 +3023,14 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
     bool renames = true; // thrash renames too?
     for (int k=0; k<n; k++) {
       
-      if (renames && ceph::util::generate_random_number(10) == 0) {
+      if (renames && ceph::util::generate_random_number(10 - 1) == 0) {
 	// rename some directories.  whee!
-	int dep = ceph::util::generate_random_number(depth) + 1;
+	int dep = ceph::util::generate_random_number(1, depth);
 	string src = basedir;
 	{
 	  char t[80];
 	  for (int d=0; d<dep; d++) {
-	    int a = ceph::util::generate_random_number(dirs);
+	    int a = ceph::util::generate_random_number(dirs - 1);
 	    snprintf(t, sizeof(t), "/dir.%d", a);
 	    src += t;
 	  }
@@ -3039,7 +3039,7 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
 	{
 	  char t[80];
 	  for (int d=0; d<dep; d++) {
-	    int a = ceph::util::generate_random_number(dirs);
+	    int a = ceph::util::generate_random_number(dirs - 1);
 	    snprintf(t, sizeof(t), "/dir.%d", a);
 	    dst += t;
 	  }
@@ -3057,11 +3057,11 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       {
 	char t[80];
 	for (int d=0; d<depth; d++) {
-	  int a = ceph::util::generate_random_number(dirs);
+	  int a = ceph::util::generate_random_number(dirs - 1);
 	  snprintf(t, sizeof(t), "/dir.%d", a);
 	  src += t;
 	}
-	int a = ceph::util::generate_random_number(files);
+	int a = ceph::util::generate_random_number(files - 1);
 	snprintf(t, sizeof(t), "/file.%d", a);
 	src += t;
       }
@@ -3069,11 +3069,11 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       {
 	char t[80];
 	for (int d=0; d<depth; d++) {
-	  int a = ceph::util::generate_random_number(dirs);
+	  int a = ceph::util::generate_random_number(dirs - 1);
 	  snprintf(t, sizeof(t), "/dir.%d", a);
 	  dst += t;
 	}
-	int a = ceph::util::generate_random_number(files);
+	int a = ceph::util::generate_random_number(files - 1);
 	snprintf(t, sizeof(t), "/file.%d", a);
 	dst += t;
       }
@@ -3109,9 +3109,9 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       string file = basedir;
       
       if (depth) {
-	int d = ceph::util::generate_random_number(depth + 1);
+	int d = ceph::util::generate_random_number(depth);
 	for (int k=0; k<d; k++) {
-	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs));
+	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs - 1));
 	  file += f;
 	}
       }
@@ -3121,9 +3121,9 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       // pick a dir for our link
       string ln = basedir;
       if (depth) {
-	int d = ceph::util::generate_random_number(depth + 1);
+	int d = ceph::util::generate_random_number(depth);
 	for (int k=0; k<d; k++) {
-	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs));
+	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs - 1));
 	  ln += f;
 	}
       }

--- a/src/client/SyntheticClient.cc
+++ b/src/client/SyntheticClient.cc
@@ -23,7 +23,7 @@
 #include "osdc/Objecter.h"
 #include "osdc/Filer.h"
 
-
+#include "include/random.h"
 #include "include/filepath.h"
 #include "common/perf_counters.h"
 
@@ -413,8 +413,8 @@ int SyntheticClient::run()
         int iarg1 = iargs.front();
         iargs.pop_front();
         if (run_me()) {
-          srand(time(0) + getpid() + client->whoami.v);
-          sleep(rand() % iarg1);
+          ceph::util::randomize_rng();
+          sleep(ceph::util::generate_random_number(iarg1));
         }
 	did_run_me();
       }
@@ -824,7 +824,7 @@ int SyntheticClient::run()
         int count = iargs.front();  iargs.pop_front();
         if (run_me()) {
           for (int i=0; i<count; i++) {
-            int fd = client->open("test", (rand()%2) ?
+            int fd = client->open("test", ceph::util::generate_random_number(2) ?
 				  (O_WRONLY|O_CREAT) : O_RDONLY,
 				  perms);
             if (fd > 0) client->close(fd);
@@ -959,7 +959,7 @@ int SyntheticClient::join_thread()
 
 bool roll_die(float p) 
 {
-  float r = (float)(rand() % 100000) / 100000.0;
+  float r = static_cast<float>(ceph::util::generate_random_number(100000) / 100000.0);
   if (r < p) 
     return true;
   else 
@@ -2351,10 +2351,10 @@ int SyntheticClient::object_rw(int nobj, int osize, int wrpc,
     if (time_to_stop()) break;
     
     // read or write?
-    bool write = (rand() % 100) < wrpc;
+    bool write = ceph::util::generate_random_number(100) < wrpc;
 
     // choose object
-    double r = drand48(); // [0..1)
+    double r = ceph::util::generate_random_number<double>(0.0, 1.0);
     long o;
     if (write) {
       o = (long)trunc(pow(r, wskew) * (double)nobj);  // exponentially skew towards 0
@@ -2425,12 +2425,9 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
 
     bool read=false;
 
-    time_t seconds;
-    time( &seconds);
-    srand(seconds);
+    ceph::util::randomize_rng();
 
-    // use rand instead ??
-    double x = drand48();
+    double x = ceph::util::generate_random_number<double>();
 
     // cleanup before call 'new'
     if (buf != NULL) {
@@ -2447,7 +2444,7 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
     }
     
     if (read) {
-        offset=(rand())%(chunks+1);
+        offset= ceph::util::generate_random_number(chunks + 1);
         dout(2) << "reading block " << offset << "/" << chunks << dendl;
 
         int r = client->read(fd, buf, rdsize, offset*rdsize);
@@ -2462,7 +2459,7 @@ int SyntheticClient::read_random(string& fn, int size, int rdsize)   // size is 
       // 64 bits : client id
       // = 128 bits (16 bytes)
 
-      offset=(rand())%(chunks+1);
+      offset= ceph::util::generate_random_number(chunks + 1);
       uint64_t *p = (uint64_t*)buf;
       while ((char*)p < buf + rdsize) {
 	*p = offset*rdsize + (char*)p - buf;      
@@ -2509,9 +2506,7 @@ int normdist(int min, int max, int stdev) /* specifies input values */
   /* min: Minimum value; max: Maximum value; stdev: degree of deviation */
   
   //int min, max, stdev; {
-  time_t seconds;
-  time( &seconds);
-  srand(seconds);
+  ceph::util::randomize_rng();
   
   int range, iterate, result;
   /* declare range, iterate and result as integers, to avoid the need for
@@ -2531,7 +2526,7 @@ int normdist(int min, int max, int stdev) /* specifies input values */
   for (int c = iterate; c != 0; c--) /* loop through iterations */
     {
       //  result += (uniform (1, 100) * stdev) / 100; /* calculate and
-      result += ( (rand()%100 + 1)  * stdev) / 100;
+      result += ((ceph::util::generate_random_number(100) + 1)  * stdev) / 100;
       // printf("result=%d\n", result );
     }
   printf("\n final result=%d\n", result );
@@ -2554,12 +2549,8 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
     
     bool read=false;
     
-    time_t seconds;
-    time( &seconds);
-    srand(seconds);
-    
     // use rand instead ??
-    double x = drand48();
+    double x = ceph::util::generate_random_number<double>(0.0, 1.0);
     
     // cleanup before call 'new'
     if (buf != NULL) {
@@ -2591,10 +2582,10 @@ int SyntheticClient::read_random_ex(string& fn, int size, int rdsize)   // size 
 	// 64 bits : client id
 	// = 128 bits (16 bytes)
 	
-	int count = rand()%10;
+	int count = ceph::util::generate_random_number(10);
 	
 	for ( int j=0;j<count; j++ ) {
-	  offset=(rand())%(chunks+1);
+	  offset=ceph::util::generate_random_number(chunks + 1);
 	  uint64_t *p = (uint64_t*)buf;
 	  while ((char*)p < buf + rdsize) {
 	    *p = offset*rdsize + (char*)p - buf;      
@@ -2712,29 +2703,6 @@ int SyntheticClient::random_walk(int num_req)
     
     if (op == CEPH_MDS_OP_SYMLINK) {
     }
-    /*
-    if (op == CEPH_MDS_OP_CHMOD) {
-      if (contents.empty())
-        op = CEPH_MDS_OP_READDIR;
-      else
-        r = client->chmod(get_random_sub(), rand() & 0755, perms);
-    }
-    
-    if (op == CEPH_MDS_OP_CHOWN) {
-      if (contents.empty())         r = client->chown(cwd.c_str(), rand(), rand(), perms);
-      else
-        r = client->chown(get_random_sub(), rand(), rand(), perms);
-    }
-     
-    if (op == CEPH_MDS_OP_UTIME) {
-      struct utimbuf b;
-      memset(&b, 1, sizeof(b));
-      if (contents.empty()) 
-        r = client->utime(cwd.c_str(), &b, perms);
-      else
-        r = client->utime(get_random_sub(), &b, perms);
-    }
-    */
     if (op == CEPH_MDS_OP_LINK) {
     }
     
@@ -2847,7 +2815,7 @@ void SyntheticClient::make_dir_mess(const char *basedir, int n)
   // create dirs
   for (int i=0; i<n; i++) {
     // pick a dir
-    int k = rand() % dirs.size();
+    int k = ceph::util::generate_random_number(dirs.size());
     string parent = dirs[k];
     
     // pick a name
@@ -2931,12 +2899,12 @@ void SyntheticClient::foo()
   }
   if (1) {
     // open some files
-    srand(0);
+    ceph::util::randomize_rng();
     for (int i=0; i<20; i++) {
-      int s = 5;
-      int a = rand() % s;
-      int b = rand() % s;
-      int c = rand() % s;
+      constexpr int s = 5;
+      int a = ceph::util::generate_random_number(s);
+      int b = ceph::util::generate_random_number(s);
+      int c = ceph::util::generate_random_number(s);
       char src[80];
       snprintf(src, sizeof(src), "syn.0.0/dir.%d/dir.%d/file.%d", a, b, c);
       //int fd = 
@@ -2946,51 +2914,31 @@ void SyntheticClient::foo()
     return;
   }
 
-  if (0) {
-    // rename fun
-    for (int i=0; i<100; i++) {
-      int s = 5;
-      int a = rand() % s;
-      int b = rand() % s;
-      int c = rand() % s;
-      int d = rand() % s;
-      int e = rand() % s;
-      int f = rand() % s;
-      char src[80];
-      char dst[80];
-      snprintf(src, sizeof(src), "syn.0.0/dir.%d/dir.%d/file.%d", a, b, c);
-      snprintf(dst, sizeof(dst), "syn.0.0/dir.%d/dir.%d/file.%d", d, e, f);
-      client->rename(src, dst, perms);
-    }
-    return;
-  }
-
-  if (1) {
     // link fun
-    srand(0);
+    ceph::util::randomize_rng();
     for (int i=0; i<100; i++) {
-      int s = 5;
-      int a = rand() % s;
-      int b = rand() % s;
-      int c = rand() % s;
-      int d = rand() % s;
-      int e = rand() % s;
-      int f = rand() % s;
+      constexpr int s = 5;
+      int a = ceph::util::generate_random_number(s);
+      int b = ceph::util::generate_random_number(s);
+      int c = ceph::util::generate_random_number(s);
+      int d = ceph::util::generate_random_number(s);
+      int e = ceph::util::generate_random_number(s);
+      int f = ceph::util::generate_random_number(s);
       char src[80];
       char dst[80];
       snprintf(src, sizeof(src), "syn.0.0/dir.%d/dir.%d/file.%d", a, b, c);
       snprintf(dst, sizeof(dst), "syn.0.0/dir.%d/dir.%d/newlink.%d", d, e, f);
       client->link(src, dst, perms);
-    }
-    srand(0);
+
+    ceph::util::randomize_rng();
     for (int i=0; i<100; i++) {
-      int s = 5;
-      int a = rand() % s;
-      int b = rand() % s;
-      int c = rand() % s;
-      int d = rand() % s;
-      int e = rand() % s;
-      int f = rand() % s;
+      constexpr int s = 5;
+      int a = ceph::util::generate_random_number(s);
+      int b = ceph::util::generate_random_number(s);
+      int c = ceph::util::generate_random_number(s);
+      int d = ceph::util::generate_random_number(s);
+      int e = ceph::util::generate_random_number(s);
+      int f = ceph::util::generate_random_number(s);
       char src[80];
       char dst[80];
       snprintf(src, sizeof(src), "syn.0.0/dir.%d/dir.%d/file.%d", a, b, c);
@@ -3070,19 +3018,19 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
 
   UserPerm perms = client->pick_my_perms();
 
-  srand(0);
+  ceph::util::randomize_rng();
   if (1) {
     bool renames = true; // thrash renames too?
     for (int k=0; k<n; k++) {
       
-      if (renames && rand() % 10 == 0) {
+      if (renames && ceph::util::generate_random_number(10) == 0) {
 	// rename some directories.  whee!
-	int dep = (rand() % depth) + 1;
+	int dep = ceph::util::generate_random_number(depth) + 1;
 	string src = basedir;
 	{
 	  char t[80];
 	  for (int d=0; d<dep; d++) {
-	    int a = rand() % dirs;
+	    int a = ceph::util::generate_random_number(dirs);
 	    snprintf(t, sizeof(t), "/dir.%d", a);
 	    src += t;
 	  }
@@ -3091,7 +3039,7 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
 	{
 	  char t[80];
 	  for (int d=0; d<dep; d++) {
-	    int a = rand() % dirs;
+	    int a = ceph::util::generate_random_number(dirs);
 	    snprintf(t, sizeof(t), "/dir.%d", a);
 	    dst += t;
 	  }
@@ -3109,11 +3057,11 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       {
 	char t[80];
 	for (int d=0; d<depth; d++) {
-	  int a = rand() % dirs;
+	  int a = ceph::util::generate_random_number(dirs);
 	  snprintf(t, sizeof(t), "/dir.%d", a);
 	  src += t;
 	}
-	int a = rand() % files;
+	int a = ceph::util::generate_random_number(files);
 	snprintf(t, sizeof(t), "/file.%d", a);
 	src += t;
       }
@@ -3121,16 +3069,16 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       {
 	char t[80];
 	for (int d=0; d<depth; d++) {
-	  int a = rand() % dirs;
+	  int a = ceph::util::generate_random_number(dirs);
 	  snprintf(t, sizeof(t), "/dir.%d", a);
 	  dst += t;
 	}
-	int a = rand() % files;
+	int a = ceph::util::generate_random_number(files);
 	snprintf(t, sizeof(t), "/file.%d", a);
 	dst += t;
       }
       
-      int o = rand() % 4;
+      int o = ceph::util::generate_random_number(4);
       switch (o) {
       case 0: 
 	client->mknod(src.c_str(), 0755, perms);
@@ -3161,21 +3109,21 @@ int SyntheticClient::thrash_links(const char *basedir, int dirs, int files, int 
       string file = basedir;
       
       if (depth) {
-	int d = rand() % (depth+1);
+	int d = ceph::util::generate_random_number(depth + 1);
 	for (int k=0; k<d; k++) {
-	  snprintf(f, sizeof(f), "/dir.%d", rand() % dirs);
+	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs));
 	  file += f;
 	}
       }
-      snprintf(f, sizeof(f), "/file.%d", rand() % files);
+      snprintf(f, sizeof(f), "/file.%d", ceph::util::generate_random_number(files));
       file += f;
       
       // pick a dir for our link
       string ln = basedir;
       if (depth) {
-	int d = rand() % (depth+1);
+	int d = ceph::util::generate_random_number(depth + 1);
 	for (int k=0; k<d; k++) {
-	  snprintf(f, sizeof(f), "/dir.%d", rand() % dirs);
+	  snprintf(f, sizeof(f), "/dir.%d", ceph::util::generate_random_number(dirs));
 	  ln += f;
 	}
       }

--- a/src/client/SyntheticClient.h
+++ b/src/client/SyntheticClient.h
@@ -126,7 +126,7 @@ class SyntheticClient {
   }
 
   int get_random_fh() {
-    int r = ceph::util::generate_random_number(open_files.size());
+    int r = ceph::util::generate_random_number(open_files.size() - 1);
     set<int>::iterator it = open_files.begin();
     while (r--) ++it;
     return *it;
@@ -136,7 +136,7 @@ class SyntheticClient {
   filepath n1;
   const char *get_random_subdir() {
     assert(!subdirs.empty());
-    int r = (ceph::util::generate_random_number(subdirs.size()) + ceph::util::generate_random_number(subdirs.size())) / 2;  // non-uniform distn
+    int r = (ceph::util::generate_random_number(subdirs.size() - 1) + ceph::util::generate_random_number(subdirs.size() - 1)) / 2;  // non-uniform distn
     set<string>::iterator it = subdirs.begin();
     while (r--) ++it;
 
@@ -147,7 +147,7 @@ class SyntheticClient {
   filepath n2;
   const char *get_random_sub() {
     assert(!contents.empty());
-    int r = (ceph::util::generate_random_number(contents.size()) + ceph::util::generate_random_number(contents.size())) / 2;  // non-uniform distn
+    int r = (ceph::util::generate_random_number(contents.size() - 1) + ceph::util::generate_random_number(contents.size() - 1)) / 2;  // non-uniform distn
     if (cwd.depth() && cwd.last_dentry().length()) 
       r += cwd.last_dentry().c_str()[0];                                         // slightly permuted
     r %= contents.size();
@@ -163,7 +163,7 @@ class SyntheticClient {
   filepath sub;
   char sub_s[50];
   const char *make_sub(const char *base) {
-    snprintf(sub_s, sizeof(sub_s), "%s.%d", base, ceph::util::generate_random_number(100));
+    snprintf(sub_s, sizeof(sub_s), "%s.%d", base, ceph::util::generate_random_number(100 - 1));
     string f = sub_s;
     sub = cwd;
     sub.push_dentry(f);

--- a/src/client/SyntheticClient.h
+++ b/src/client/SyntheticClient.h
@@ -23,6 +23,8 @@
 
 #include "Trace.h"
 
+#include "include/random.h"
+
 #define SYNCLIENT_FIRST_POOL	0
 
 #define SYNCLIENT_MODE_RANDOMWALK  1
@@ -124,7 +126,7 @@ class SyntheticClient {
   }
 
   int get_random_fh() {
-    int r = rand() % open_files.size();
+    int r = ceph::util::generate_random_number(open_files.size());
     set<int>::iterator it = open_files.begin();
     while (r--) ++it;
     return *it;
@@ -134,7 +136,7 @@ class SyntheticClient {
   filepath n1;
   const char *get_random_subdir() {
     assert(!subdirs.empty());
-    int r = ((rand() % subdirs.size()) + (rand() % subdirs.size())) / 2;  // non-uniform distn
+    int r = (ceph::util::generate_random_number(subdirs.size()) + ceph::util::generate_random_number(subdirs.size())) / 2;  // non-uniform distn
     set<string>::iterator it = subdirs.begin();
     while (r--) ++it;
 
@@ -145,7 +147,7 @@ class SyntheticClient {
   filepath n2;
   const char *get_random_sub() {
     assert(!contents.empty());
-    int r = ((rand() % contents.size()) + (rand() % contents.size())) / 2;  // non-uniform distn
+    int r = (ceph::util::generate_random_number(contents.size()) + ceph::util::generate_random_number(contents.size())) / 2;  // non-uniform distn
     if (cwd.depth() && cwd.last_dentry().length()) 
       r += cwd.last_dentry().c_str()[0];                                         // slightly permuted
     r %= contents.size();
@@ -161,7 +163,7 @@ class SyntheticClient {
   filepath sub;
   char sub_s[50];
   const char *make_sub(const char *base) {
-    snprintf(sub_s, sizeof(sub_s), "%s.%d", base, rand() % 100);
+    snprintf(sub_s, sizeof(sub_s), "%s.%d", base, ceph::util::generate_random_number(100));
     string f = sub_s;
     sub = cwd;
     sub.push_dentry(f);

--- a/src/common/WeightedPriorityQueue.h
+++ b/src/common/WeightedPriorityQueue.h
@@ -17,11 +17,15 @@
 
 #include "OpQueue.h"
 
+#include "include/random.h"
+
 #include <boost/intrusive/list.hpp>
 #include <boost/intrusive/rbtree.hpp>
 #include <boost/intrusive/avl_set.hpp>
 
 namespace bi = boost::intrusive;
+
+using ceph::util::generate_random_number;
 
 template <typename T, typename S>
 class MapKey
@@ -227,7 +231,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
 	  if (queues.size() > 1) {
 	    while (true) {
 	      // Pick a new priority out of the total priority.
-	      unsigned prio = rand() % total_prio + 1;
+	      unsigned prio = generate_random_number() % total_prio + 1;
 	      unsigned tp = total_prio - i->key;
 	      // Find the priority coresponding to the picked number.
 	      // Subtract high priorities to low priorities until the picked number
@@ -242,7 +246,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
 	      // The next op's cost is multiplied by .9 and subtracted from the
 	      // max cost seen. Ops with lower costs will have a larger value
 	      // and allow them to be selected easier than ops with high costs.
-	      if (max_cost == 0 || rand() % max_cost <=
+	      if (max_cost == 0 || generate_random_number() % max_cost <=
 		  (max_cost - ((i->get_cost() * 9) / 10))) {
 		break;
 	      }
@@ -287,7 +291,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
       strict(),
       normal()
       {
-	std::srand(time(0));
+		ceph::util::randomize_rng();
       }
     unsigned length() const final {
       return strict.size + normal.size;

--- a/src/common/WeightedPriorityQueue.h
+++ b/src/common/WeightedPriorityQueue.h
@@ -23,9 +23,19 @@
 #include <boost/intrusive/rbtree.hpp>
 #include <boost/intrusive/avl_set.hpp>
 
+#include "OpQueue.h"
+
+#include "include/random.h"
+
+// clobber other asserts:
+#include "include/assert.h"
+
 namespace bi = boost::intrusive;
 
 using ceph::util::generate_random_number;
+
+// Re-include our assert to clobber boost's:
+#include "include/assert.h"
 
 template <typename T, typename S>
 class MapKey
@@ -231,7 +241,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
 	  if (queues.size() > 1) {
 	    while (true) {
 	      // Pick a new priority out of the total priority.
-	      unsigned prio = generate_random_number() % total_prio + 1;
+	      unsigned prio = generate_random_number(1, total_prio - 1);
 	      unsigned tp = total_prio - i->key;
 	      // Find the priority coresponding to the picked number.
 	      // Subtract high priorities to low priorities until the picked number

--- a/src/common/WeightedPriorityQueue.h
+++ b/src/common/WeightedPriorityQueue.h
@@ -256,7 +256,7 @@ class WeightedPriorityQueue :  public OpQueue <T, K>
 	      // The next op's cost is multiplied by .9 and subtracted from the
 	      // max cost seen. Ops with lower costs will have a larger value
 	      // and allow them to be selected easier than ops with high costs.
-	      if (max_cost == 0 || generate_random_number() % max_cost <=
+	      if (max_cost == 0 || generate_random_number(max_cost - 1) <=
 		  (max_cost - ((i->get_cost() * 9) / 10))) {
 		break;
 	      }

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -503,7 +503,8 @@ void BitVector<_b>::generate_test_instances(std::list<BitVector *> &o) {
 
   b->resize(size);
   for (uint64_t i = 0; i < size; ++i) {
-    (*b)[i] = rand() % radix;
+    // mod appears to be required here:
+    (*b)[i] = ceph::util::generate_random_number<uint64_t>() % radix;
   }
   o.push_back(b);
 }

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -11,10 +11,19 @@
 #ifndef BIT_VECTOR_HPP
 #define BIT_VECTOR_HPP
 
+#include <list>
+#include <cmath>
+#include <vector>
+#include <utility>
+#include <cstdint>
+
+#include <boost/static_assert.hpp>
+
 #include "common/Formatter.h"
+
+#include "include/random.h"
 #include "include/assert.h"
 #include "include/encoding.h"
-#include <utility>
 
 namespace ceph {
 
@@ -503,7 +512,6 @@ void BitVector<_b>::generate_test_instances(std::list<BitVector *> &o) {
 
   b->resize(size);
   for (uint64_t i = 0; i < size; ++i) {
-    // mod appears to be required here:
     (*b)[i] = ceph::util::generate_random_number<uint64_t>() % radix;
   }
   o.push_back(b);

--- a/src/common/bit_vector.hpp
+++ b/src/common/bit_vector.hpp
@@ -11,13 +11,7 @@
 #ifndef BIT_VECTOR_HPP
 #define BIT_VECTOR_HPP
 
-#include <list>
-#include <cmath>
-#include <vector>
 #include <utility>
-#include <cstdint>
-
-#include <boost/static_assert.hpp>
 
 #include "common/Formatter.h"
 
@@ -511,8 +505,14 @@ void BitVector<_b>::generate_test_instances(std::list<BitVector *> &o) {
   const uint64_t size = 1024;
 
   b->resize(size);
+
+  // The test code depends on the RNG generating the same numbers each
+  // time the program is run-- thus, we must seed with the same value
+  // each time we generate these:
+  ceph::util::random_number_generator<int> rng(42);
+
   for (uint64_t i = 0; i < size; ++i) {
-    (*b)[i] = ceph::util::generate_random_number<uint64_t>() % radix;
+   (*b)[i] = rng() % radix;
   }
   o.push_back(b);
 }

--- a/src/common/bloom_filter.hpp
+++ b/src/common/bloom_filter.hpp
@@ -26,6 +26,7 @@
 
 #include "include/mempool.h"
 #include "include/encoding.h"
+#include "include/random.h"
 
 static const std::size_t bits_per_char = 0x08;    // 8 bits in 1 char(unsigned)
 static const unsigned char bit_mask[bits_per_char] = {
@@ -430,10 +431,14 @@ protected:
     {
       std::copy(predef_salt,predef_salt + predef_salt_count,
 		std::back_inserter(salt_));
-      srand(static_cast<unsigned int>(random_seed_));
+   
+      // Since we have special seeding, we use a unique RNG: 
+      auto rng = ceph::util::random_number_generator<int>(random_seed_); 
+ 
       while (salt_.size() < salt_count_)
       {
-        bloom_type current_salt = static_cast<bloom_type>(rand()) * static_cast<bloom_type>(rand());
+        bloom_type current_salt = static_cast<bloom_type>(rng()) * 
+                                  static_cast<bloom_type>(rng());
         if (0 == current_salt)
 	  continue;
         if (salt_.end() == std::find(salt_.begin(), salt_.end(), current_salt))

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -886,7 +886,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
   if (data.op_size)
     writes_per_object = data.object_size / data.op_size;
 
-  srand (time(NULL));
+  ceph::util::randomize_rng();
 
   r = completions_init(concurrentios);
   if (r < 0)

--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -15,9 +15,22 @@
  * try and bench on a pool you don't have permission to access
  * it will just loop forever.
  */
-#include "include/compat.h"
+
+#include <ctime>
+#include <vector>
+#include <cerrno>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
 #include <pthread.h>
+
+#include "include/compat.h"
+#include "include/random.h"
+
 #include "common/Cond.h"
+
 #include "obj_bencher.h"
 
 const std::string BENCH_LASTRUN_METADATA = "benchmark_last_metadata";
@@ -987,7 +1000,7 @@ int ObjBencher::rand_read_bench(int seconds_to_run, int num_objects, int concurr
       }
     } 
 
-    rand_id = rand() % num_objects;
+    rand_id = ceph::util::generate_random_number(num_objects);
     newName = generate_object_name(rand_id / writes_per_object, pid);
     index[slot] = rand_id;
     release_completion(slot);

--- a/src/crush/CrushTester.cc
+++ b/src/crush/CrushTester.cc
@@ -77,7 +77,7 @@ int CrushTester::get_maximum_affected_by_rule(int ruleno)
    * get the smallest number of buckets available of any type as this is our upper bound on
    * the number of replicas we can place
   */
-  int max_affected = max( crush.get_max_buckets(), crush.get_max_devices() );
+  int max_affected = std::max( crush.get_max_buckets(), crush.get_max_devices() );
 
   for(std::vector<int>::iterator it = affected_types.begin(); it != affected_types.end(); ++it){
     if (max_devices_of_type[*it] > 0 && max_devices_of_type[*it] < max_affected )

--- a/src/include/Distribution.h
+++ b/src/include/Distribution.h
@@ -42,7 +42,11 @@ class Distribution {
   void random() {
     float sum = 0.0;
     for (unsigned i=0; i<p.size(); i++) {
+<<<<<<< HEAD
       p[i] = (float)(rand() % 10000);
+=======
+      p[i] = static_cast<float>(ceph::util::generate_random_number(10000));
+>>>>>>> f265ae2caf... include/random: enhance random library
       sum += p[i];
     }
     for (unsigned i=0; i<p.size(); i++) 
@@ -50,7 +54,7 @@ class Distribution {
   }
 
   int sample() {
-    float s = (float)(rand() % 10000) / 10000.0;
+    float s = static_cast<float>(ceph::util::generate_random_number(10000)) / 10000.0;
     for (unsigned i=0; i<p.size(); i++) {
       if (s < p[i]) return v[i];
       s -= p[i];

--- a/src/include/Distribution.h
+++ b/src/include/Distribution.h
@@ -46,7 +46,7 @@ class Distribution {
   void random() {
     float sum = 0.0;
     for (unsigned i=0; i<p.size(); i++) {
-      p[i] = static_cast<float>(ceph::util::generate_random_number(10000));
+      p[i] = static_cast<float>(ceph::util::generate_random_number(10000 - 1));
       sum += p[i];
     }
     for (unsigned i=0; i<p.size(); i++) 
@@ -54,7 +54,7 @@ class Distribution {
   }
 
   int sample() {
-    float s = ceph::util::generate_random_number(10000) / 10000.0;
+    float s = ceph::util::generate_random_number(10000 - 1) / 10000.0;
     for (unsigned i=0; i<p.size(); i++) {
       if (s < p[i]) return v[i];
       s -= p[i];

--- a/src/include/Distribution.h
+++ b/src/include/Distribution.h
@@ -18,6 +18,10 @@
 
 #include <vector>
 
+#include "include/random.h"
+
+using namespace std;
+
 class Distribution {
   vector<float> p;
   vector<int> v;
@@ -42,11 +46,7 @@ class Distribution {
   void random() {
     float sum = 0.0;
     for (unsigned i=0; i<p.size(); i++) {
-<<<<<<< HEAD
-      p[i] = (float)(rand() % 10000);
-=======
       p[i] = static_cast<float>(ceph::util::generate_random_number(10000));
->>>>>>> f265ae2caf... include/random: enhance random library
       sum += p[i];
     }
     for (unsigned i=0; i<p.size(); i++) 
@@ -54,7 +54,7 @@ class Distribution {
   }
 
   int sample() {
-    float s = static_cast<float>(ceph::util::generate_random_number(10000)) / 10000.0;
+    float s = ceph::util::generate_random_number(10000) / 10000.0;
     for (unsigned i=0; i<p.size(); i++) {
       if (s < p[i]) return v[i];
       s -= p[i];

--- a/src/include/random.h
+++ b/src/include/random.h
@@ -20,8 +20,6 @@
 #include <optional>
 #include <type_traits>
 
-#include "common/backport_std.h"
-
 // Basic random number facility, adapted from N3551:
 namespace ceph::util {
 

--- a/src/include/random.h
+++ b/src/include/random.h
@@ -17,23 +17,46 @@
 
 #include <mutex>
 #include <random>
-#include <type_traits>
+#include <optional>
 
-#include "boost/optional.hpp"
+#include "common/backport_std.h"
 
 // Basic random number facility, adapted from N3551:
 namespace ceph {
 namespace util {
 
-inline namespace version_1_0 {
+inline namespace version_1_0_1 {
+
+namespace detail {
+
+// Choose default distribution for appropriate types:
+template <typename NumberT, 
+          bool IsIntegral>
+struct select_distribution
+{
+ using type = std::uniform_int_distribution<NumberT>;
+};
+
+template <typename NumberT>
+struct select_distribution<NumberT, false>
+{
+ using type = std::uniform_real_distribution<NumberT>;
+};
+
+template <typename NumberT>
+using default_distribution = typename
+	select_distribution<NumberT, std::is_integral<NumberT>::value>::type;
+
+} // namespace detail
 
 namespace detail {
 
 template <typename EngineT>
 EngineT& engine();
 
-template <typename MutexT, typename EngineT>
-void randomize_rng(const int seed, MutexT& m, EngineT& e)
+template <typename MutexT, typename EngineT, 
+          typename SeedT = typename EngineT::result_type>
+void randomize_rng(const SeedT seed, MutexT& m, EngineT& e)
 {
   std::lock_guard<MutexT> lg(m);
   e.seed(seed);
@@ -48,8 +71,9 @@ void randomize_rng(MutexT& m, EngineT& e)
   e.seed(rd());
 }
 
-template <typename EngineT = std::default_random_engine>
-void randomize_rng(const int n)
+template <typename EngineT = std::default_random_engine,
+          typename SeedT = typename EngineT::result_type>
+void randomize_rng(const SeedT n)
 {
   detail::engine<EngineT>().seed(n);
 }
@@ -64,7 +88,7 @@ void randomize_rng()
 template <typename EngineT>
 EngineT& engine()
 {
-  thread_local boost::optional<EngineT> rng_engine;
+  thread_local std::optional<EngineT> rng_engine;
 
   if (!rng_engine) {
     rng_engine.emplace(EngineT());
@@ -79,12 +103,12 @@ EngineT& engine()
 namespace detail {
 
 template <typename NumberT,
-          typename DistributionT,
+          typename DistributionT = detail::default_distribution<NumberT>,
           typename EngineT>
 NumberT generate_random_number(const NumberT min, const NumberT max,
                                EngineT& e)
 {
-  thread_local DistributionT d { min, max };
+  DistributionT d { min, max };
 
   using param_type = typename DistributionT::param_type;
   return d(e, param_type { min, max });
@@ -92,12 +116,12 @@ NumberT generate_random_number(const NumberT min, const NumberT max,
 
 template <typename NumberT,
           typename MutexT,
-          typename DistributionT,
+          typename DistributionT = detail::default_distribution<NumberT>,
           typename EngineT>
 NumberT generate_random_number(const NumberT min, const NumberT max,
                                MutexT& m, EngineT& e)
 {
-  thread_local DistributionT d { min, max };
+  DistributionT d { min, max };
  
   using param_type = typename DistributionT::param_type;
  
@@ -106,7 +130,7 @@ NumberT generate_random_number(const NumberT min, const NumberT max,
 }
 
 template <typename NumberT,
-          typename DistributionT,
+          typename DistributionT = detail::default_distribution<NumberT>,
           typename EngineT>
 NumberT generate_random_number(const NumberT min, const NumberT max)
 {
@@ -114,14 +138,20 @@ NumberT generate_random_number(const NumberT min, const NumberT max)
           (min, max, detail::engine<EngineT>());
 }
 
-template <typename MutexT, typename EngineT,
-          int min = 0,
-          int max = std::numeric_limits<int>::max(), 
-          typename DistributionT = std::uniform_int_distribution<int>>
-int generate_random_number(MutexT& m, EngineT& e)
+template <typename MutexT, 
+          typename EngineT,
+          typename NumberT = int,
+          typename DistributionT = detail::default_distribution<NumberT>>
+NumberT generate_random_number(MutexT& m, EngineT& e)
 {
-  return detail::generate_random_number<int, MutexT, DistributionT, EngineT>
-          (min, max, m, e);
+  return detail::generate_random_number<NumberT, MutexT, DistributionT, EngineT>
+          (0, std::numeric_limits<NumberT>::max(), m, e);
+}
+
+template <typename NumberT, typename MutexT, typename EngineT>
+NumberT generate_random_number(const NumberT max, MutexT& m, EngineT& e)
+{
+  return generate_random_number<NumberT>(0, max, m, e);
 }
 
 } // namespace detail
@@ -132,105 +162,39 @@ void randomize_rng()
   detail::randomize_rng<EngineT>();
 }
 
-template <typename IntegerT = int,
-          typename DistributionT = std::uniform_int_distribution<IntegerT>,
+template <typename NumberT = int,
+          typename DistributionT = detail::default_distribution<NumberT>,
           typename EngineT = std::default_random_engine>
-IntegerT generate_random_number()
+NumberT generate_random_number()
 {
-  using limits = std::numeric_limits<IntegerT>;
-  return detail::generate_random_number<IntegerT, DistributionT, EngineT>
-          (limits::min(), limits::max());
+  return detail::generate_random_number<NumberT, DistributionT, EngineT>
+          (0, std::numeric_limits<NumberT>::max());
 }
 
-template <typename IntegerT>
-IntegerT generate_random_number(const IntegerT min, const IntegerT max,
-                                std::enable_if_t<std::is_integral<IntegerT>::value>* = nullptr)
+template <typename NumberT>
+NumberT generate_random_number(const NumberT min, const NumberT max)
 {
-  return detail::generate_random_number<IntegerT,
-                                        std::uniform_int_distribution<IntegerT>,
+  return detail::generate_random_number<NumberT,
+                                        detail::default_distribution<NumberT>,
                                         std::default_random_engine>
                                        (min, max); 
 }
 
-namespace detail {
-
-template <typename IntegerT, typename MutexT, typename EngineT>
-int generate_random_number(const IntegerT min, const IntegerT max,
-                           MutexT& m, EngineT& e,
-                           std::enable_if_t<std::is_integral<IntegerT>::value>* = nullptr)
+template <typename NumberT,
+          typename DistributionT,
+          typename EngineT>
+NumberT generate_random_number(const NumberT min, const NumberT max,
+                               EngineT& e)
 {
-  return detail::generate_random_number<IntegerT, MutexT,
-                                        std::uniform_int_distribution<IntegerT>,
-                                        EngineT>
-                                       (min, max, m, e);
+ return detail::generate_random_number<NumberT,
+				       DistributionT,
+				       EngineT>(min, max, e);
 }
 
-template <typename IntegerT, typename MutexT, typename EngineT>
-int generate_random_number(const IntegerT max,
-                           MutexT& m, EngineT& e,
-                           std::enable_if_t<std::is_integral<IntegerT>::value>* = nullptr)
+template <typename NumberT>
+NumberT generate_random_number(const NumberT max)
 {
-  constexpr IntegerT zero = 0;
-  return generate_random_number(zero, max, m, e);
-}
-
-} // namespace detail
-
-template <typename IntegerT>
-int generate_random_number(const IntegerT max,
-                           std::enable_if_t<std::is_integral<IntegerT>::value>* = nullptr)
-{
-  constexpr IntegerT zero = 0;   
-  return generate_random_number(zero, max);
-}
-
-template <typename RealT>
-RealT generate_random_number(const RealT min, const RealT max, 
-                             std::enable_if_t<std::is_floating_point<RealT>::value>* = nullptr)
-{
-  return detail::generate_random_number<RealT,
-                                        std::uniform_real_distribution<RealT>, 
-                                        std::default_random_engine>
-                                       (min, max);
-} 
-
-namespace detail {
-
-template <typename RealT, typename MutexT>
-RealT generate_random_number(const RealT max, MutexT& m,
-                             std::enable_if_t<std::is_floating_point<RealT>::value>* = nullptr)
-{
-  constexpr RealT zero = 0.0;
-  return generate_random_number(zero, max, m);
-}
-
-template <typename RealT, typename MutexT, typename EngineT>
-RealT generate_random_number(const RealT min, const RealT max, MutexT& m, EngineT& e,
-                             std::enable_if_t<std::is_floating_point<RealT>::value>* = nullptr)
-{
-  return detail::generate_random_number<RealT, MutexT, 
-                                        std::uniform_real_distribution<RealT>,
-                                        EngineT>
-                                       (min, max, m, e);
-}
-
-
-template <typename RealT, typename MutexT, typename EngineT>
-RealT generate_random_number(const RealT max, MutexT& m, EngineT& e,
-                             std::enable_if_t<std::is_floating_point<RealT>::value>* = nullptr)
-{
-  constexpr RealT zero = 0.0;
-  return generate_random_number(zero, max, m, e);
-}
-
-} // namespace detail
-
-template <typename RealT>
-RealT generate_random_number(const RealT max,
-                             std::enable_if_t<std::is_floating_point<RealT>::value>* = nullptr)
-{
-  constexpr RealT zero = 0.0;
-  return generate_random_number(zero, max);
+ return generate_random_number<NumberT>(0, max);
 }
 
 // Function object:
@@ -240,16 +204,24 @@ class random_number_generator final
   std::mutex l;
   std::random_device rd;
   std::default_random_engine e;
+
+  using seed_type = typename decltype(e)::result_type;
  
   public:
-  using number_type = NumberT;
+  using number_type			= NumberT;
+  using random_engine_type	= decltype(e);
+  using random_device_type	= decltype(rd);
+
+  public:
+  random_device_type& random_device() noexcept { return rd; } 
+  random_engine_type& random_engine() noexcept { return e; }
  
   public:
   random_number_generator() {
     detail::randomize_rng(l, e);
   }
  
-  explicit random_number_generator(const int seed) {
+  explicit random_number_generator(const seed_type seed) {
     detail::randomize_rng(seed, l, e);
   }
 
@@ -267,20 +239,20 @@ class random_number_generator final
   }
  
   NumberT operator()(const NumberT max) { 
-    return detail::generate_random_number(max, l, e); 
+    return detail::generate_random_number<NumberT>(max, l, e); 
   }
  
   NumberT operator()(const NumberT min, const NumberT max) { 
-    return detail::generate_random_number(min, max, l, e); 
+    return detail::generate_random_number<NumberT>(min, max, l, e); 
   }
  
   public:
-  void seed(const int n) { 
+  void seed(const seed_type n) { 
     detail::randomize_rng(n, l, e); 
   }
 };
 
-} // inline namespace version_1_0
+} // inline namespace version_*
 
 }} // namespace ceph::util
 

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -7,11 +7,11 @@
 
 #include "encoding.h"
 #include <ostream>
+#include <algorithm>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
-#include <boost/random/random_device.hpp>
 
 struct uuid_d {
   boost::uuids::uuid uuid;
@@ -26,9 +26,8 @@ struct uuid_d {
   }
 
   void generate_random() {
-    boost::random::random_device rng("/dev/urandom");
-    boost::uuids::basic_random_generator<boost::random::random_device> gen(&rng);
-    uuid = gen();
+    auto n = ceph::util::generate_random_number();
+    memcpy(&uuid, &n, sizeof(uuid));
   }
   
   bool parse(const char *s) {

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -6,15 +6,14 @@
  */
 
 #include <ostream>
-#include <algorithm>
 
 #include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/random/random_device.hpp>
 
+#include "random.h"
 #include "encoding.h"
-
-#include "include/random.h"
 
 struct uuid_d {
   boost::uuids::uuid uuid;
@@ -29,8 +28,9 @@ struct uuid_d {
   }
 
   void generate_random() {
-    auto n = ceph::util::generate_random_number();
-    memcpy(&uuid, &n, sizeof(uuid));
+    thread_local ceph::util::random_number_generator<int> rng;
+    boost::uuids::basic_random_generator gen(rng.random_device());
+    uuid = gen();
   }
   
   bool parse(const char *s) {

--- a/src/include/uuid.h
+++ b/src/include/uuid.h
@@ -5,13 +5,16 @@
  * Thin C++ wrapper around libuuid.
  */
 
-#include "encoding.h"
 #include <ostream>
 #include <algorithm>
 
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+
+#include "encoding.h"
+
+#include "include/random.h"
 
 struct uuid_d {
   boost::uuids::uuid uuid;

--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -11,25 +11,30 @@
  * Foundation.  See file COPYING.
  */
 
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <climits>
+#include <sstream>
+#include <cstdlib>
+#include <iostream>
+#include <iterator>
+
+#include "include/types.h"
+#include "include/random.h"
+#include "include/rados/librados.hpp"
+
+#include "common/ceph_context.h"
+#include "common/Clock.h"
+
 #include "key_value_store/key_value_structure.h"
 #include "key_value_store/kv_flat_btree_async.h"
 #include "key_value_store/kvs_arg_types.h"
-#include "include/rados/librados.hpp"
+
 #include "/usr/include/asm-generic/errno.h"
 #include "/usr/include/asm-generic/errno-base.h"
-#include "common/ceph_context.h"
-#include "common/Clock.h"
-#include "include/types.h"
 
-
-#include <string>
-#include <iostream>
-#include <cassert>
-#include <climits>
-#include <cmath>
-#include <sstream>
-#include <stdlib.h>
-#include <iterator>
+using namespace std;
 
 using ceph::bufferlist;
 
@@ -154,14 +159,14 @@ int KvFlatBtreeAsync::nothing() {
 }
 
 int KvFlatBtreeAsync::wait() {
-  if (rand() % 10 == 0) {
+  if (ceph::util::generate_random_number(10) == 0) {
     usleep(wait_ms);
   }
   return 0;
 }
 
 int KvFlatBtreeAsync::suicide() {
-  if (rand() % 10 == 0) {
+  if (ceph::util::generate_random_number(10) == 0) {
     if (verbose) cout << client_name << " is suiciding" << std::endl;
     return 1;
   }

--- a/src/key_value_store/kv_flat_btree_async.cc
+++ b/src/key_value_store/kv_flat_btree_async.cc
@@ -159,14 +159,14 @@ int KvFlatBtreeAsync::nothing() {
 }
 
 int KvFlatBtreeAsync::wait() {
-  if (ceph::util::generate_random_number(10) == 0) {
+  if (ceph::util::generate_random_number(10 - 1) == 0) {
     usleep(wait_ms);
   }
   return 0;
 }
 
 int KvFlatBtreeAsync::suicide() {
-  if (ceph::util::generate_random_number(10) == 0) {
+  if (ceph::util::generate_random_number(10 - 1) == 0) {
     if (verbose) cout << client_name << " is suiciding" << std::endl;
     return 1;
   }

--- a/src/librbd/Utils.cc
+++ b/src/librbd/Utils.cc
@@ -51,7 +51,7 @@ std::string generate_image_id(librados::IoCtx &ioctx) {
   librados::Rados rados(ioctx);
 
   uint64_t bid = rados.get_instance_id();
-  uint32_t extra = rand() % 0xFFFFFFFF;
+  uint32_t extra = ceph::util::generate_random_number(0xFFFFFFFF);
 
   ostringstream bid_ss;
   bid_ss << std::hex << bid << std::hex << extra;

--- a/src/librbd/api/Group.cc
+++ b/src/librbd/api/Group.cc
@@ -12,6 +12,8 @@
 #include "librbd/Utils.h"
 #include "librbd/io/AioCompletion.h"
 
+#include "include/random.h"
+
 #define dout_subsys ceph_subsys_rbd
 #undef dout_prefix
 #define dout_prefix *_dout << "librbd::api::Group: " << __func__ << ": "
@@ -50,7 +52,7 @@ string generate_uuid(librados::IoCtx& io_ctx)
   Rados rados(io_ctx);
   uint64_t bid = rados.get_instance_id();
 
-  uint32_t extra = rand() % 0xFFFFFFFF;
+  uint32_t extra = ceph::util::generate_random_number(0xFFFFFFFF);
   ostringstream bid_ss;
   bid_ss << std::hex << bid << std::hex << extra;
   return bid_ss.str();

--- a/src/librbd/internal.cc
+++ b/src/librbd/internal.cc
@@ -5,16 +5,22 @@
 #include <errno.h>
 #include <limits.h>
 
+#include <boost/scope_exit.hpp>
+#include <boost/variant.hpp>
+
 #include "include/types.h"
 #include "include/uuid.h"
+#include "include/util.h"
+#include "include/random.h"
+#include "include/stringify.h"
+
 #include "common/ceph_context.h"
 #include "common/dout.h"
 #include "common/errno.h"
 #include "common/Throttle.h"
 #include "common/event_socket.h"
-#include "cls/lock/cls_lock_client.h"
-#include "include/stringify.h"
 
+#include "cls/lock/cls_lock_client.h"
 #include "cls/rbd/cls_rbd.h"
 #include "cls/rbd/cls_rbd_types.h"
 #include "cls/rbd/cls_rbd_client.h"
@@ -50,8 +56,6 @@
 
 #include "journal/Journaler.h"
 
-#include <boost/scope_exit.hpp>
-#include <boost/variant.hpp>
 #include "include/assert.h"
 
 #define dout_subsys ceph_subsys_rbd
@@ -156,7 +160,7 @@ bool compare_by_name(const child_info_t& c1, const child_info_t& c2)
   {
     uint32_t hi = bid >> 32;
     uint32_t lo = bid & 0xFFFFFFFF;
-    uint32_t extra = rand() % 0xFFFFFFFF;
+    uint32_t extra = ceph::util::generate_random_number(0xFFFFFFFF);
     memset(&ondisk, 0, sizeof(ondisk));
 
     memcpy(&ondisk.text, RBD_HEADER_TEXT, sizeof(RBD_HEADER_TEXT));

--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -35,6 +35,8 @@
 #include "osdc/Objecter.h"
 
 #include "common/config.h"
+
+#include "include/random.h"
 #include "include/assert.h"
 #include "include/compat.h"
 

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -12,8 +12,6 @@
  * 
  */
 
-
-
 #ifndef CEPH_MDCACHE_H
 #define CEPH_MDCACHE_H
 
@@ -22,6 +20,7 @@
 #include "include/types.h"
 #include "include/filepath.h"
 #include "include/elist.h"
+#include "include/random.h"
 
 #include "osdc/Filer.h"
 #include "CInode.h"
@@ -1193,7 +1192,7 @@ public:
 
   CInode *hack_pick_random_inode() {
     assert(!inode_map.empty());
-    int n = rand() % inode_map.size();
+    int n = ceph::util::generate_random_number(inode_map.size());
     auto p = inode_map.begin();
     while (n--) ++p;
     return p->second;

--- a/src/mds/MDCache.h
+++ b/src/mds/MDCache.h
@@ -1192,7 +1192,7 @@ public:
 
   CInode *hack_pick_random_inode() {
     assert(!inode_map.empty());
-    int n = ceph::util::generate_random_number(inode_map.size());
+    int n = ceph::util::generate_random_number(inode_map.size() - 1);
     auto p = inode_map.begin();
     while (n--) ++p;
     return p->second;

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -36,6 +36,7 @@
 #include "common/HeartbeatMap.h"
 #include "ScrubStack.h"
 
+#include "include/random.h"
 
 #include "MDSRank.h"
 
@@ -605,7 +606,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
     in->get_dirfrags(ls);
     if (!ls.empty()) {	// must be an open dir.
       list<CDir*>::iterator p = ls.begin();
-      int n = rand() % ls.size();
+      int n = ceph::util::generate_random_number(ls.size());
       while (n--)
         ++p;
       CDir *dir = *p;
@@ -614,7 +615,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
 
       mds_rank_t dest;
       do {
-        int k = rand() % s.size();
+        int k = ceph::util::generate_random_number(s.size());
         set<mds_rank_t>::iterator p = s.begin();
         while (k--) ++p;
         dest = *p;
@@ -639,7 +640,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
     if (!dir->is_auth()) continue;           // must be auth.
     frag_t fg = dir->get_frag();
     if (mdsmap->allows_dirfrags()) {
-      if ((fg == frag_t() || (rand() % (1 << fg.bits()) == 0))) {
+      if (fg == frag_t() || (ceph::util::generate_random_number(1 << fg.bits()) == 0)) {
         mdcache->split_dir(dir, 1);
       } else {
         balancer->queue_merge(dir);

--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -606,7 +606,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
     in->get_dirfrags(ls);
     if (!ls.empty()) {	// must be an open dir.
       list<CDir*>::iterator p = ls.begin();
-      int n = ceph::util::generate_random_number(ls.size());
+      int n = ceph::util::generate_random_number(ls.size() - 1);
       while (n--)
         ++p;
       CDir *dir = *p;
@@ -615,7 +615,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
 
       mds_rank_t dest;
       do {
-        int k = ceph::util::generate_random_number(s.size());
+        int k = ceph::util::generate_random_number(s.size() - 1);
         set<mds_rank_t>::iterator p = s.begin();
         while (k--) ++p;
         dest = *p;
@@ -640,7 +640,7 @@ bool MDSRank::_dispatch(Message *m, bool new_msg)
     if (!dir->is_auth()) continue;           // must be auth.
     frag_t fg = dir->get_frag();
     if (mdsmap->allows_dirfrags()) {
-      if (fg == frag_t() || (ceph::util::generate_random_number(1 << fg.bits()) == 0)) {
+      if (fg == frag_t() || (ceph::util::generate_random_number((1 << fg.bits()) - 1) == 0)) {
         mdcache->split_dir(dir, 1);
       } else {
         balancer->queue_merge(dir);

--- a/src/mds/Server.cc
+++ b/src/mds/Server.cc
@@ -12,9 +12,14 @@
  *
  */
 
-#include <boost/lexical_cast.hpp>
-#include "include/assert.h"  // lexical_cast includes system assert.h
+#include <list>
+#include <cerrno>
+#include <iostream>
+#include <string_view>
 
+#include <fcntl.h>
+
+#include <boost/lexical_cast.hpp>
 #include <boost/config/warning_disable.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 
@@ -50,20 +55,20 @@
 #include "events/EOpen.h"
 #include "events/ECommitted.h"
 
+#include "include/random.h"
 #include "include/filepath.h"
 #include "common/errno.h"
 #include "common/Timer.h"
 #include "common/perf_counters.h"
 #include "include/compat.h"
 #include "osd/OSDMap.h"
-
-#include <errno.h>
-
-#include <list>
-#include <iostream>
-#include <string_view>
+#include "include/random.h"
 
 #include "common/config.h"
+
+#include "include/assert.h"  // clobber boost's assert()
+
+using namespace std;
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_mds
@@ -1519,7 +1524,7 @@ void Server::set_trace_dist(Session *session, MClientReply *reply,
   // skip doing this for debugging purposes?
   if (g_conf->mds_inject_traceless_reply_probability &&
       mdr->ls && !mdr->o_trunc &&
-      (rand() % 10000 < g_conf->mds_inject_traceless_reply_probability * 10000.0)) {
+      (ceph::util::generate_random_number(10000) < g_conf->mds_inject_traceless_reply_probability * 10000.0)) {
     dout(5) << "deliberately skipping trace for " << *reply << dendl;
     return;
   }

--- a/src/mon/Elector.cc
+++ b/src/mon/Elector.cc
@@ -20,6 +20,8 @@
 #include "messages/MMonElection.h"
 
 #include "common/config.h"
+#include "include/random.h"
+
 #include "include/assert.h"
 
 #define dout_subsys ceph_subsys_mon
@@ -89,7 +91,7 @@ void Elector::start()
   } else {
     // do a trivial db write just to ensure it is writeable.
     auto t(std::make_shared<MonitorDBStore::Transaction>());
-    t->put(Monitor::MONITOR_NAME, "election_writeable_test", rand());
+    t->put(Monitor::MONITOR_NAME, "election_writeable_test", ceph::util::generate_random_number());
     int r = mon->store->apply_transaction(t);
     assert(r >= 0);
   }

--- a/src/mon/MonClient.cc
+++ b/src/mon/MonClient.cc
@@ -29,6 +29,9 @@
 
 #include "messages/MMonSubscribe.h"
 #include "messages/MMonSubscribeAck.h"
+
+#include "include/random.h"
+
 #include "common/errno.h"
 #include "common/LogClient.h"
 
@@ -48,6 +51,7 @@
 MonClient::MonClient(CephContext *cct_) :
   Dispatcher(cct_),
   messenger(NULL),
+  cur_con(NULL),
   monc_lock("MonClient::monc_lock"),
   timer(cct_, monc_lock),
   finisher(cct_),

--- a/src/mon/MonClient.h
+++ b/src/mon/MonClient.h
@@ -25,6 +25,11 @@
 #include "common/Finisher.h"
 #include "common/config.h"
 
+#include "auth/AuthClientHandler.h"
+#include "auth/RotatingKeyRing.h"
+
+#include "include/util.h"
+#include "include/random.h"
 
 class MMonMap;
 class MMonGetVersionReply;
@@ -152,6 +157,9 @@ private:
 
   std::unique_ptr<MonConnection> active_con;
   std::map<entity_addr_t, MonConnection> pending_cons;
+
+  string cur_mon;
+  ConnectionRef cur_con;
 
   EntityName entity_name;
 

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -18,10 +18,14 @@
 #include <signal.h>
 #include <limits.h>
 #include <cstring>
+
 #include <boost/scope_exit.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 
 #include "Monitor.h"
+
+#include "include/random.h"
+
 #include "common/version.h"
 
 #include "osd/OSDMap.h"
@@ -66,6 +70,7 @@
 #include "include/color.h"
 #include "include/ceph_fs.h"
 #include "include/str_list.h"
+#include "include/random.h"
 
 #include "OSDMonitor.h"
 #include "MDSMonitor.h"
@@ -5123,7 +5128,7 @@ bool Monitor::_scrub(ScrubResult *r,
       continue;
 
     if (cct->_conf->mon_scrub_inject_missing_keys > 0.0 &&
-        (rand() % 10000 < cct->_conf->mon_scrub_inject_missing_keys*10000.0)) {
+        (ceph::util::generate_random_number(10000) < cct->_conf->mon_scrub_inject_missing_keys*10000.0)) {
       dout(10) << __func__ << " inject missing key, skipping (" << k << ")"
                << dendl;
       continue;
@@ -5143,7 +5148,7 @@ bool Monitor::_scrub(ScrubResult *r,
     r->prefix_crc[k.first] = bl.crc32c(r->prefix_crc[k.first]);
 
     if (cct->_conf->mon_scrub_inject_crc_mismatch > 0.0 &&
-        (rand() % 10000 < cct->_conf->mon_scrub_inject_crc_mismatch*10000.0)) {
+        (ceph::util::generate_random_number(10000) < cct->_conf->mon_scrub_inject_crc_mismatch*10000.0)) {
       dout(10) << __func__ << " inject failure at (" << k << ")" << dendl;
       r->prefix_crc[k.first] += 1;
     }

--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -5128,7 +5128,7 @@ bool Monitor::_scrub(ScrubResult *r,
       continue;
 
     if (cct->_conf->mon_scrub_inject_missing_keys > 0.0 &&
-        (ceph::util::generate_random_number(10000) < cct->_conf->mon_scrub_inject_missing_keys*10000.0)) {
+        (ceph::util::generate_random_number(10000 - 1) < cct->_conf->mon_scrub_inject_missing_keys*10000.0)) {
       dout(10) << __func__ << " inject missing key, skipping (" << k << ")"
                << dendl;
       continue;
@@ -5148,7 +5148,7 @@ bool Monitor::_scrub(ScrubResult *r,
     r->prefix_crc[k.first] = bl.crc32c(r->prefix_crc[k.first]);
 
     if (cct->_conf->mon_scrub_inject_crc_mismatch > 0.0 &&
-        (ceph::util::generate_random_number(10000) < cct->_conf->mon_scrub_inject_crc_mismatch*10000.0)) {
+        (ceph::util::generate_random_number(10000 - 1) < cct->_conf->mon_scrub_inject_crc_mismatch*10000.0)) {
       dout(10) << __func__ << " inject failure at (" << k << ")" << dendl;
       r->prefix_crc[k.first] += 1;
     }

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -13,14 +13,16 @@
 #ifndef CEPH_MONITOR_DB_STORE_H
 #define CEPH_MONITOR_DB_STORE_H
 
-#include "include/types.h"
-#include "include/buffer.h"
 #include <set>
 #include <map>
 #include <string>
-#include <boost/scoped_ptr.hpp>
 #include <sstream>
 #include <fstream>
+
+#include <boost/scoped_ptr.hpp>
+
+#include "include/types.h"
+#include "include/buffer.h"
 #include "kv/KeyValueDB.h"
 
 #include "include/assert.h"
@@ -331,10 +333,10 @@ class MonitorDBStore
        * to applying the transaction as it won't break the model.
        */
       double delay_prob = g_conf->mon_inject_transaction_delay_probability;
-      if (delay_prob && (rand() % 10000 < delay_prob * 10000.0)) {
+      if (delay_prob && (ceph::util::generate_random_number(10000) < delay_prob * 10000.0)) {
         utime_t delay;
         double delay_max = g_conf->mon_inject_transaction_delay_max;
-        delay.set_from_double(delay_max * (double)(rand() % 10000) / 10000.0);
+        delay.set_from_double(delay_max * ceph::util::generate_random_number<double>(10000.0) / 10000.0);
         lsubdout(g_ceph_context, mon, 1)
           << "apply_transaction will be delayed for " << delay
           << " seconds" << dendl;

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -25,13 +25,15 @@
 #include "include/buffer.h"
 #include "kv/KeyValueDB.h"
 
-#include "include/assert.h"
+#include "include/random.h"
+
 #include "common/Formatter.h"
 #include "common/Finisher.h"
 #include "common/errno.h"
 #include "common/debug.h"
 #include "common/safe_io.h"
 
+#include "include/assert.h"
 #define dout_context g_ceph_context
 
 class MonitorDBStore

--- a/src/mon/MonitorDBStore.h
+++ b/src/mon/MonitorDBStore.h
@@ -335,10 +335,10 @@ class MonitorDBStore
        * to applying the transaction as it won't break the model.
        */
       double delay_prob = g_conf->mon_inject_transaction_delay_probability;
-      if (delay_prob && (ceph::util::generate_random_number(10000) < delay_prob * 10000.0)) {
+      if (delay_prob && (ceph::util::generate_random_number(10000 - 1) < delay_prob * 10000.0)) {
         utime_t delay;
         double delay_max = g_conf->mon_inject_transaction_delay_max;
-        delay.set_from_double(delay_max * ceph::util::generate_random_number<double>(10000.0) / 10000.0);
+        delay.set_from_double(delay_max * ceph::util::generate_random_number<double>(10000.0 - 1.0) / 10000.0);
         lsubdout(g_ceph_context, mon, 1)
           << "apply_transaction will be delayed for " << delay
           << " seconds" << dendl;

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -159,7 +159,7 @@ struct MonSessionMap {
     // ok, this isn't actually random, but close enough.
     if (by_osd.empty())
       return 0;
-    int n = by_osd.rbegin()->first + 1;
+    int n = by_osd.rbegin()->first;
     int r = ceph::util::generate_random_number(n);
 
     multimap<int,MonSession*>::iterator p = by_osd.lower_bound(r);

--- a/src/mon/Session.h
+++ b/src/mon/Session.h
@@ -15,7 +15,10 @@
 #ifndef CEPH_MON_SESSION_H
 #define CEPH_MON_SESSION_H
 
+#include "include/util.h"
 #include "include/xlist.h"
+#include "include/random.h"
+
 #include "msg/msg_types.h"
 #include "mon/mon_types.h"
 
@@ -157,7 +160,7 @@ struct MonSessionMap {
     if (by_osd.empty())
       return 0;
     int n = by_osd.rbegin()->first + 1;
-    int r = rand() % n;
+    int r = ceph::util::generate_random_number(n);
 
     multimap<int,MonSession*>::iterator p = by_osd.lower_bound(r);
     if (p == by_osd.end())

--- a/src/msg/DispatchQueue.cc
+++ b/src/msg/DispatchQueue.cc
@@ -13,8 +13,12 @@
  */
 
 #include "msg/Message.h"
+
 #include "DispatchQueue.h"
 #include "Messenger.h"
+
+#include "include/random.h"
+
 #include "common/ceph_context.h"
 
 #define dout_subsys ceph_subsys_ms
@@ -161,7 +165,7 @@ void DispatchQueue::entry()
       if (qitem.is_code()) {
 	if (cct->_conf->ms_inject_internal_delays &&
 	    cct->_conf->ms_inject_delay_probability &&
-	    (rand() % 10000)/10000.0 < cct->_conf->ms_inject_delay_probability) {
+	    (ceph::util::generate_random_number(10000))/10000.0 < cct->_conf->ms_inject_delay_probability) {
 	  utime_t t;
 	  t.set_from_double(cct->_conf->ms_inject_internal_delays);
 	  ldout(cct, 1) << "DispatchQueue::entry  inject delay of " << t

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -203,7 +203,7 @@ ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
 ssize_t AsyncConnection::_try_send(bool more)
 {
   if (async_msgr->cct->_conf->ms_inject_socket_failures && cs) {
-    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
+    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures - 1) == 0) {
       ldout(async_msgr->cct, 0) << __func__ << " injecting socket failure" << dendl;
       cs.shutdown();
     }
@@ -249,7 +249,7 @@ ssize_t AsyncConnection::read_until(unsigned len, char *p)
                              << state_offset << dendl;
 
   if (async_msgr->cct->_conf->ms_inject_socket_failures && cs) {
-    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
+    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures - 1) == 0) {
       ldout(async_msgr->cct, 0) << __func__ << " injecting socket failure" << dendl;
       cs.shutdown();
     }
@@ -768,8 +768,8 @@ void AsyncConnection::process()
           logger->tinc(l_msgr_running_recv_time, fast_dispatch_time - recv_start_time);
           if (delay_state) {
             double delay_period = 0;
-            if (ceph::util::generate_random_number(10000) < async_msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
-              delay_period = async_msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number(10000.0) / 10000.0;
+            if (ceph::util::generate_random_number(10000 - 1) < async_msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
+              delay_period = async_msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number(10000.0 - 1.0) / 10000.0;
               ldout(async_msgr->cct, 1) << "queue_received will delay after " << (ceph_clock_now() + delay_period)
 					<< " on " << message << " " << *message << dendl;
             }
@@ -974,7 +974,7 @@ ssize_t AsyncConnection::_process_connection()
         lock.unlock();
         async_msgr->learned_addr(peer_addr_for_me);
         if (async_msgr->cct->_conf->ms_inject_internal_delays) {
-          if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
+          if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures - 1) == 0) {
             ldout(msgr->cct, 10) << __func__ << " sleep for "
                                  << async_msgr->cct->_conf->ms_inject_internal_delays << dendl;
             utime_t t;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -16,15 +16,18 @@
 
 #include <unistd.h>
 
+#include "include/random.h"
 #include "include/Context.h"
 #include "include/random.h"
+
 #include "common/errno.h"
+#include "common/EventTrace.h"
+
 #include "AsyncMessenger.h"
 #include "AsyncConnection.h"
 
 #include "messages/MOSDOp.h"
 #include "messages/MOSDOpReply.h"
-#include "common/EventTrace.h"
 
 // Constant to limit starting sequence number to 2^31.  Nothing special about it, just a big number.  PLR
 #define SEQ_MASK  0x7fffffff 
@@ -200,7 +203,7 @@ ssize_t AsyncConnection::read_bulk(char *buf, unsigned len)
 ssize_t AsyncConnection::_try_send(bool more)
 {
   if (async_msgr->cct->_conf->ms_inject_socket_failures && cs) {
-    if (rand() % async_msgr->cct->_conf->ms_inject_socket_failures == 0) {
+    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
       ldout(async_msgr->cct, 0) << __func__ << " injecting socket failure" << dendl;
       cs.shutdown();
     }
@@ -246,7 +249,7 @@ ssize_t AsyncConnection::read_until(unsigned len, char *p)
                              << state_offset << dendl;
 
   if (async_msgr->cct->_conf->ms_inject_socket_failures && cs) {
-    if (rand() % async_msgr->cct->_conf->ms_inject_socket_failures == 0) {
+    if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
       ldout(async_msgr->cct, 0) << __func__ << " injecting socket failure" << dendl;
       cs.shutdown();
     }
@@ -971,7 +974,7 @@ ssize_t AsyncConnection::_process_connection()
         lock.unlock();
         async_msgr->learned_addr(peer_addr_for_me);
         if (async_msgr->cct->_conf->ms_inject_internal_delays) {
-          if (rand() % async_msgr->cct->_conf->ms_inject_socket_failures == 0) {
+          if (ceph::util::generate_random_number(async_msgr->cct->_conf->ms_inject_socket_failures) == 0) {
             ldout(msgr->cct, 10) << __func__ << " sleep for "
                                  << async_msgr->cct->_conf->ms_inject_internal_delays << dendl;
             utime_t t;

--- a/src/msg/async/AsyncConnection.cc
+++ b/src/msg/async/AsyncConnection.cc
@@ -765,8 +765,8 @@ void AsyncConnection::process()
           logger->tinc(l_msgr_running_recv_time, fast_dispatch_time - recv_start_time);
           if (delay_state) {
             double delay_period = 0;
-            if (rand() % 10000 < async_msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
-              delay_period = async_msgr->cct->_conf->ms_inject_delay_max * (double)(rand() % 10000) / 10000.0;
+            if (ceph::util::generate_random_number(10000) < async_msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
+              delay_period = async_msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number(10000.0) / 10000.0;
               ldout(async_msgr->cct, 1) << "queue_received will delay after " << (ceph_clock_now() + delay_period)
 					<< " on " << message << " " << *message << dendl;
             }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1059,7 +1059,7 @@ int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
   ssize_t r = ::read(sd, &msg, sizeof(msg));
   // Drop incoming qpt
   if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
-    if (rand() % cct->_conf->ms_inject_socket_failures == 0) {
+    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures - 1) == 0) {
       ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
       return -EINVAL;
     }
@@ -1183,7 +1183,7 @@ retry:
   r = ::write(sd, msg, sizeof(msg));
   // Drop incoming qpt
   if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
-    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures) == 0) {
+    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures - 1) == 0) {
       ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
       return -EINVAL;
     }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -14,12 +14,16 @@
  *
  */
 
-#include "Infiniband.h"
-#include "common/errno.h"
-#include "common/debug.h"
-#include "RDMAStack.h"
 #include <sys/time.h>
 #include <sys/resource.h>
+
+#include "Infiniband.h"
+#include "RDMAStack.h"
+
+#include "include/random.h"
+
+#include "common/errno.h"
+#include "common/debug.h"
 
 #define dout_subsys ceph_subsys_ms
 #undef dout_prefix
@@ -1093,6 +1097,93 @@ retry:
   // Drop incoming qpt
   if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
     if (rand() % cct->_conf->ms_inject_socket_failures == 0) {
+      ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
+      return -EINVAL;
+    }
+  }
+
+  if ((size_t)r != sizeof(msg)) {
+    // FIXME need to handle EAGAIN instead of retry
+    if (r < 0 && (errno == EINTR || errno == EAGAIN) && retry < 3) {
+      retry++;
+      goto retry;
+    }
+    if (r < 0)
+      lderr(cct) << __func__ << " send returned error " << errno << ": "
+                 << cpp_strerror(errno) << dendl;
+    else
+      lderr(cct) << __func__ << " send got bad length (" << r << ") " << cpp_strerror(errno) << dendl;
+    return -errno;
+  }
+  return 0;
+}
+
+void Infiniband::wire_gid_to_gid(const char *wgid, union ibv_gid *gid)
+{
+  char tmp[9];
+  uint32_t v32;
+  int i;
+
+  for (tmp[8] = 0, i = 0; i < 4; ++i) {
+    memcpy(tmp, wgid + i * 8, 8);
+    sscanf(tmp, "%x", &v32);
+    *(uint32_t *)(&gid->raw[i * 4]) = ntohl(v32);
+  }
+}
+
+void Infiniband::gid_to_wire_gid(const union ibv_gid *gid, char wgid[])
+{
+  for (int i = 0; i < 4; ++i)
+    sprintf(&wgid[i * 8], "%08x", htonl(*(uint32_t *)(gid->raw + i * 4)));
+}
+
+// 1 means no valid buffer read, 0 means got enough buffer
+// else return < 0 means error
+int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
+{
+  char msg[TCP_MSG_LEN];
+  char gid[33];
+  ssize_t r = ::read(sd, &msg, sizeof(msg));
+  // Drop incoming qpt
+  if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
+    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures) == 0) {
+      ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
+      return -EINVAL;
+    }
+  }
+  if (r < 0) {
+    r = -errno;
+    lderr(cct) << __func__ << " got error " << errno << ": "
+               << cpp_strerror(errno) << dendl;
+  } else if (r == 0) { // valid disconnect message of length 0
+    ldout(cct, 10) << __func__ << " got disconnect message " << dendl;
+  } else if ((size_t)r != sizeof(msg)) { // invalid message
+    ldout(cct, 1) << __func__ << " got bad length (" << r << "): " << cpp_strerror(errno) << dendl;
+    r = -EINVAL;
+  } else { // valid message
+    sscanf(msg, "%hu:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
+    wire_gid_to_gid(gid, &(im.gid));
+    ldout(cct, 5) << __func__ << " recevd: " << im.lid << ", " << im.qpn << ", " << im.psn << ", " << im.peer_qpn << ", " << gid  << dendl;
+  }
+  return r;
+}
+
+int Infiniband::send_msg(CephContext *cct, int sd, IBSYNMsg& im)
+{
+  int retry = 0;
+  ssize_t r;
+
+  char msg[TCP_MSG_LEN];
+  char gid[33];
+retry:
+  gid_to_wire_gid(&(im.gid), gid);
+  sprintf(msg, "%04x:%08x:%08x:%08x:%s", im.lid, im.qpn, im.psn, im.peer_qpn, gid);
+  ldout(cct, 10) << __func__ << " sending: " << im.lid << ", " << im.qpn << ", " << im.psn
+                 << ", " << im.peer_qpn << ", "  << gid  << dendl;
+  r = ::write(sd, msg, sizeof(msg));
+  // Drop incoming qpt
+  if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
+    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures) == 0) {
       ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
       return -EINVAL;
     }

--- a/src/msg/async/rdma/Infiniband.cc
+++ b/src/msg/async/rdma/Infiniband.cc
@@ -1066,12 +1066,12 @@ int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
   }
   if (r < 0) {
     r = -errno;
-    lderr(cct) << __func__ << " got error " << r << ": "
-               << cpp_strerror(r) << dendl;
+    lderr(cct) << __func__ << " got error " << errno << ": "
+               << cpp_strerror(errno) << dendl;
   } else if (r == 0) { // valid disconnect message of length 0
     ldout(cct, 10) << __func__ << " got disconnect message " << dendl;
   } else if ((size_t)r != sizeof(msg)) { // invalid message
-    ldout(cct, 1) << __func__ << " got bad length (" << r << ") " << dendl;
+    ldout(cct, 1) << __func__ << " got bad length (" << r << "): " << cpp_strerror(errno) << dendl;
     r = -EINVAL;
   } else { // valid message
     sscanf(msg, "%hu:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
@@ -1079,43 +1079,6 @@ int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
     ldout(cct, 5) << __func__ << " recevd: " << im.lid << ", " << im.qpn << ", " << im.psn << ", " << im.peer_qpn << ", " << gid  << dendl;
   }
   return r;
-}
-
-int Infiniband::send_msg(CephContext *cct, int sd, IBSYNMsg& im)
-{
-  int retry = 0;
-  ssize_t r;
-
-  char msg[TCP_MSG_LEN];
-  char gid[33];
-retry:
-  gid_to_wire_gid(&(im.gid), gid);
-  sprintf(msg, "%04x:%08x:%08x:%08x:%s", im.lid, im.qpn, im.psn, im.peer_qpn, gid);
-  ldout(cct, 10) << __func__ << " sending: " << im.lid << ", " << im.qpn << ", " << im.psn
-                 << ", " << im.peer_qpn << ", "  << gid  << dendl;
-  r = ::write(sd, msg, sizeof(msg));
-  // Drop incoming qpt
-  if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
-    if (rand() % cct->_conf->ms_inject_socket_failures == 0) {
-      ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
-      return -EINVAL;
-    }
-  }
-
-  if ((size_t)r != sizeof(msg)) {
-    // FIXME need to handle EAGAIN instead of retry
-    if (r < 0 && (errno == EINTR || errno == EAGAIN) && retry < 3) {
-      retry++;
-      goto retry;
-    }
-    if (r < 0)
-      lderr(cct) << __func__ << " send returned error " << errno << ": "
-                 << cpp_strerror(errno) << dendl;
-    else
-      lderr(cct) << __func__ << " send got bad length (" << r << ") " << cpp_strerror(errno) << dendl;
-    return -errno;
-  }
-  return 0;
 }
 
 void Infiniband::wire_gid_to_gid(const char *wgid, union ibv_gid *gid)
@@ -1137,36 +1100,6 @@ void Infiniband::gid_to_wire_gid(const union ibv_gid *gid, char wgid[])
     sprintf(&wgid[i * 8], "%08x", htonl(*(uint32_t *)(gid->raw + i * 4)));
 }
 
-// 1 means no valid buffer read, 0 means got enough buffer
-// else return < 0 means error
-int Infiniband::recv_msg(CephContext *cct, int sd, IBSYNMsg& im)
-{
-  char msg[TCP_MSG_LEN];
-  char gid[33];
-  ssize_t r = ::read(sd, &msg, sizeof(msg));
-  // Drop incoming qpt
-  if (cct->_conf->ms_inject_socket_failures && sd >= 0) {
-    if (ceph::util::generate_random_number(cct->_conf->ms_inject_socket_failures) == 0) {
-      ldout(cct, 0) << __func__ << " injecting socket failure" << dendl;
-      return -EINVAL;
-    }
-  }
-  if (r < 0) {
-    r = -errno;
-    lderr(cct) << __func__ << " got error " << errno << ": "
-               << cpp_strerror(errno) << dendl;
-  } else if (r == 0) { // valid disconnect message of length 0
-    ldout(cct, 10) << __func__ << " got disconnect message " << dendl;
-  } else if ((size_t)r != sizeof(msg)) { // invalid message
-    ldout(cct, 1) << __func__ << " got bad length (" << r << "): " << cpp_strerror(errno) << dendl;
-    r = -EINVAL;
-  } else { // valid message
-    sscanf(msg, "%hu:%x:%x:%x:%s", &(im.lid), &(im.qpn), &(im.psn), &(im.peer_qpn),gid);
-    wire_gid_to_gid(gid, &(im.gid));
-    ldout(cct, 5) << __func__ << " recevd: " << im.lid << ", " << im.qpn << ", " << im.psn << ", " << im.peer_qpn << ", " << gid  << dendl;
-  }
-  return r;
-}
 
 int Infiniband::send_msg(CephContext *cct, int sd, IBSYNMsg& im)
 {
@@ -1203,25 +1136,6 @@ retry:
     return -errno;
   }
   return 0;
-}
-
-void Infiniband::wire_gid_to_gid(const char *wgid, union ibv_gid *gid)
-{
-  char tmp[9];
-  uint32_t v32;
-  int i;
-
-  for (tmp[8] = 0, i = 0; i < 4; ++i) {
-    memcpy(tmp, wgid + i * 8, 8);
-    sscanf(tmp, "%x", &v32);
-    *(uint32_t *)(&gid->raw[i * 4]) = ntohl(v32);
-  }
-}
-
-void Infiniband::gid_to_wire_gid(const union ibv_gid *gid, char wgid[])
-{
-  for (int i = 0; i < 4; ++i)
-    sprintf(&wgid[i * 8], "%08x", htonl(*(uint32_t *)(gid->raw + i * 4)));
 }
 
 Infiniband::QueuePair::~QueuePair()

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -1761,9 +1761,9 @@ void Pipe::reader()
 
       if (delay_thread) {
         utime_t release;
-        if (ceph::util::generate_random_number(10000) < msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
+        if (ceph::util::generate_random_number(10000 - 1) < msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
           release = m->get_recv_stamp();
-          release += msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number<double>(10000.0) / 10000.0;
+          release += msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number<double>(10000.0 - 1.0) / 10000.0;
           lsubdout(msgr->cct, ms, 1) << "queue_received will delay until " << release << " on " << m << " " << *m << dendl;
         }
         delay_thread->queue(release, m);
@@ -2462,7 +2462,7 @@ int Pipe::tcp_read(char *buf, unsigned len)
   while (len > 0) {
 
     if (msgr->cct->_conf->ms_inject_socket_failures && sd >= 0) {
-      if (ceph::util::generate_random_number(msgr->cct->_conf->ms_inject_socket_failures) == 0) {
+      if (ceph::util::generate_random_number(msgr->cct->_conf->ms_inject_socket_failures - 1) == 0) {
 	ldout(msgr->cct, 0) << "injecting socket failure" << dendl;
 	::shutdown(sd, SHUT_RDWR);
       }

--- a/src/msg/simple/Pipe.cc
+++ b/src/msg/simple/Pipe.cc
@@ -25,6 +25,8 @@
 #include "Pipe.h"
 #include "SimpleMessenger.h"
 
+#include "include/random.h"
+
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/valgrind.h"
@@ -1759,9 +1761,9 @@ void Pipe::reader()
 
       if (delay_thread) {
         utime_t release;
-        if (rand() % 10000 < msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
+        if (ceph::util::generate_random_number(10000) < msgr->cct->_conf->ms_inject_delay_probability * 10000.0) {
           release = m->get_recv_stamp();
-          release += msgr->cct->_conf->ms_inject_delay_max * (double)(rand() % 10000) / 10000.0;
+          release += msgr->cct->_conf->ms_inject_delay_max * ceph::util::generate_random_number<double>(10000.0) / 10000.0;
           lsubdout(msgr->cct, ms, 1) << "queue_received will delay until " << release << " on " << m << " " << *m << dendl;
         }
         delay_thread->queue(release, m);
@@ -2460,7 +2462,7 @@ int Pipe::tcp_read(char *buf, unsigned len)
   while (len > 0) {
 
     if (msgr->cct->_conf->ms_inject_socket_failures && sd >= 0) {
-      if (rand() % msgr->cct->_conf->ms_inject_socket_failures == 0) {
+      if (ceph::util::generate_random_number(msgr->cct->_conf->ms_inject_socket_failures) == 0) {
 	ldout(msgr->cct, 0) << "injecting socket failure" << dendl;
 	::shutdown(sd, SHUT_RDWR);
       }
@@ -2610,7 +2612,7 @@ int Pipe::tcp_write(const char *buf, unsigned len)
 #endif
 
   if (msgr->cct->_conf->ms_inject_socket_failures && sd >= 0) {
-    if (rand() % msgr->cct->_conf->ms_inject_socket_failures == 0) {
+    if (ceph::util::generate_random_number(msgr->cct->_conf->ms_inject_socket_failures) == 0) {
       ldout(msgr->cct, 0) << "injecting socket failure" << dendl;
       ::shutdown(sd, SHUT_RDWR);
     }

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -2206,7 +2206,7 @@ bid_t BlueStore::ExtentMap::allocate_spanning_blob_id()
   if (bid >= 0)
     return bid;
   // Find next unused bid;
-  bid = rand() % (numeric_limits<bid_t>::max() + 1);
+  bid = ceph::util::generate_random_number(0, numeric_limits<bid_t>::max());
   const auto begin_bid = bid;
   do {
     if (!spanning_blob_map.count(bid))
@@ -4394,7 +4394,7 @@ int BlueStore::_open_fm(bool create)
       bool stop = false;
 
       while (!stop && start < end) {
-	uint64_t l = (rand() % max_b + 1) * min_alloc_size;
+	uint64_t l = ceph::util::generate_random_number(max_b + 1) * min_alloc_size;
 	if (start + l > end) {
 	  l = end - start;
           l = p2align(l, min_alloc_size);
@@ -6623,9 +6623,8 @@ int BlueStore::read(
     r = -EIO;
     derr << __func__ << " " << c->cid << " " << oid << " INJECT EIO" << dendl;
   } else if (oid.hobj.pool > 0 &&  /* FIXME, see #23029 */
-	     cct->_conf->bluestore_debug_random_read_err &&
-	     (rand() % (int)(cct->_conf->bluestore_debug_random_read_err *
-			     100.0)) == 0) {
+    cct->_conf->bluestore_debug_random_read_err &&
+    ceph::util::generate_random_number((int)(cct->_conf->bluestore_debug_random_read_err * 100.0) - 1) == 0) {
     dout(0) << __func__ << ": inject random EIO" << dendl;
     r = -EIO;
   }
@@ -7940,7 +7939,7 @@ void BlueStore::_txc_state_proc(TransContext *txc)
 	  dout(20) << __func__ << " prior txc(s) with unstable ios "
 		   << txc->osr->txc_with_unstable_io.load() << dendl;
 	} else if (cct->_conf->bluestore_debug_randomize_serial_transaction &&
-		   rand() % cct->_conf->bluestore_debug_randomize_serial_transaction
+           ceph::util::generate_random_number(cct->_conf->bluestore_debug_randomize_serial_transaction - 1)
 		   == 0) {
 	  dout(20) << __func__ << " DEBUG randomly forcing submit via kv thread"
 		   << dendl;

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -4394,7 +4394,7 @@ int BlueStore::_open_fm(bool create)
       bool stop = false;
 
       while (!stop && start < end) {
-	uint64_t l = ceph::util::generate_random_number(max_b + 1) * min_alloc_size;
+	uint64_t l = ceph::util::generate_random_number(max_b) * min_alloc_size;
 	if (start + l > end) {
 	  l = end - start;
           l = p2align(l, min_alloc_size);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -12,11 +12,15 @@
  *
  */
 
+#include <cstdlib>
+
+#include <fcntl.h>
 #include <unistd.h>
-#include <stdlib.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
+
+#include "include/random.h"
 
 #include "KernelDevice.h"
 #include "include/types.h"
@@ -547,7 +551,7 @@ int KernelDevice::_sync_write(uint64_t off, bufferlist &bl, bool buffered)
   dout(5) << __func__ << " 0x" << std::hex << off << "~" << len
 	  << std::dec << " buffered" << dendl;
   if (cct->_conf->bdev_inject_crash &&
-      rand() % cct->_conf->bdev_inject_crash == 0) {
+      ceph::util::generate_random_number(cct->_conf->bdev_inject_crash) == 0) {
     derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	 << off << "~" << len << std::dec << dendl;
     ++injecting_crash;
@@ -632,7 +636,7 @@ int KernelDevice::aio_write(
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     if (cct->_conf->bdev_inject_crash &&
-	rand() % cct->_conf->bdev_inject_crash == 0) {
+	    ceph::util::generate_random_number(cct->_conf->bdev_inject_crash) == 0) {
       derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	   << off << "~" << len << std::dec
 	   << dendl;

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -551,7 +551,7 @@ int KernelDevice::_sync_write(uint64_t off, bufferlist &bl, bool buffered)
   dout(5) << __func__ << " 0x" << std::hex << off << "~" << len
 	  << std::dec << " buffered" << dendl;
   if (cct->_conf->bdev_inject_crash &&
-      ceph::util::generate_random_number(cct->_conf->bdev_inject_crash) == 0) {
+      ceph::util::generate_random_number(cct->_conf->bdev_inject_crash - 1) == 0) {
     derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	 << off << "~" << len << std::dec << dendl;
     ++injecting_crash;
@@ -636,7 +636,7 @@ int KernelDevice::aio_write(
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     if (cct->_conf->bdev_inject_crash &&
-	    ceph::util::generate_random_number(cct->_conf->bdev_inject_crash) == 0) {
+	    ceph::util::generate_random_number(cct->_conf->bdev_inject_crash - 1) == 0) {
       derr << __func__ << " bdev_inject_crash: dropping io 0x" << std::hex
 	   << off << "~" << len << std::dec
 	   << dendl;

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -165,7 +165,7 @@ int64_t StupidAllocator::allocate_int(
   *length = std::min(std::max(alloc_unit, want_size), p2align((p.get_len() - skew), alloc_unit));
   if (cct->_conf->bluestore_debug_small_allocations) {
     uint64_t max =
-      alloc_unit * ceph::util::generate_random_number(cct->_conf->bluestore_debug_small_allocations);
+      alloc_unit * ceph::util::generate_random_number(cct->_conf->bluestore_debug_small_allocations - 1);
     if (max && *length > max) {
       ldout(cct, 10) << __func__ << " shortening allocation of 0x" << std::hex
 	       	     << *length << " -> 0x"

--- a/src/os/bluestore/StupidAllocator.cc
+++ b/src/os/bluestore/StupidAllocator.cc
@@ -3,6 +3,9 @@
 
 #include "StupidAllocator.h"
 #include "bluestore_types.h"
+
+#include "include/random.h"
+
 #include "common/debug.h"
 
 #define dout_context cct
@@ -162,7 +165,7 @@ int64_t StupidAllocator::allocate_int(
   *length = std::min(std::max(alloc_unit, want_size), p2align((p.get_len() - skew), alloc_unit));
   if (cct->_conf->bluestore_debug_small_allocations) {
     uint64_t max =
-      alloc_unit * (rand() % cct->_conf->bluestore_debug_small_allocations);
+      alloc_unit * ceph::util::generate_random_number(cct->_conf->bluestore_debug_small_allocations);
     if (max && *length > max) {
       ldout(cct, 10) << __func__ << " shortening allocation of 0x" << std::hex
 	       	     << *length << " -> 0x"

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -12,26 +12,27 @@
  * Foundation.  See file COPYING.
  *
  */
-#include "include/compat.h"
-#include "include/int_types.h"
-#include "boost/tuple/tuple.hpp"
 
+
+#include <map>
+#include <cerrno>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <iostream>
+
+#include <fcntl.h>
 #include <unistd.h>
-#include <stdlib.h>
+#include <dirent.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <fcntl.h>
 #include <sys/file.h>
-#include <errno.h>
-#include <dirent.h>
 #include <sys/ioctl.h>
 
 #if defined(__linux__)
 #include <linux/fs.h>
 #endif
-
-#include <iostream>
-#include <map>
 
 #include "include/linux_fiemap.h"
 
@@ -43,9 +44,9 @@
 #include <sys/mount.h>
 #endif
 
-
-#include <fstream>
-#include <sstream>
+#include "include/compat.h"
+#include "include/int_types.h"
+#include "boost/tuple/tuple.hpp"
 
 #include "FileStore.h"
 #include "GenericFileStoreBackend.h"
@@ -75,6 +76,8 @@
 #include "common/ceph_crypto.h"
 using ceph::crypto::SHA1;
 
+#include "include/util.h"
+#include "include/random.h"
 #include "include/assert.h"
 
 #include "common/config.h"
@@ -1225,7 +1228,7 @@ int FileStore::_detect_fs()
 
   // test xattrs
   char fn[PATH_MAX];
-  int x = rand();
+  int x = ceph::util::generate_random_number();
   int y = x+1;
   snprintf(fn, sizeof(fn), "%s/xattr_test", basedir.c_str());
   int tmpfd = ::open(fn, O_CREAT|O_WRONLY|O_TRUNC, 0700);

--- a/src/os/filestore/LFNIndex.cc
+++ b/src/os/filestore/LFNIndex.cc
@@ -24,13 +24,16 @@
 #endif
 
 #include "osd/osd_types.h"
-#include "include/object.h"
 #include "common/config.h"
 #include "common/debug.h"
-#include "include/buffer.h"
 #include "common/ceph_crypto.h"
 #include "include/compat.h"
 #include "chain_xattr.h"
+
+#include "include/util.h"
+#include "include/buffer.h"
+#include "include/object.h"
+#include "include/random.h"
 
 #include "LFNIndex.h"
 using ceph::crypto::SHA1;
@@ -51,9 +54,8 @@ const int LFNIndex::FILENAME_PREFIX_LEN =  FILENAME_SHORT_LEN - FILENAME_HASH_LE
 void LFNIndex::maybe_inject_failure()
 {
   if (error_injection_enabled) {
-    if (current_failure > last_failure &&
-	(((double)(rand() % 10000))/((double)(10000))
-	 < error_injection_probability)) {
+    if (current_failure > last_failure && 
+        (ceph::util::generate_random_number(10000.0) / 10000.0) < error_injection_probability) {
       last_failure = current_failure;
       current_failure = 0;
       throw RetryException();

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -140,6 +140,7 @@
 
 #include "common/cmdparse.h"
 #include "include/str_list.h"
+#include "include/random.h"
 #include "include/util.h"
 
 #include "include/assert.h"
@@ -163,6 +164,12 @@
 
 
 const double OSD::OSD_TICK_INTERVAL = 1.0;
+
+namespace {
+
+constexpr auto rand_max_double = static_cast<double>(RAND_MAX);
+
+} // namespace
 
 static ostream& _prefix(std::ostream* _dout, int whoami, epoch_t epoch) {
   return *_dout << "osd." << whoami << " " << epoch << " ";
@@ -4586,7 +4593,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	    break;
 	  }
 	} else if (cct->_conf->osd_debug_drop_ping_probability >
-	           ((((double)(rand()%100))/100.0))) {
+               (ceph::util::generate_random_number(100.0d) / 100.0d)) {
 	  heartbeat_drop =
 	    debug_heartbeat_drops_remaining.insert(std::make_pair(from,
 	                     cct->_conf->osd_debug_drop_ping_duration)).first;
@@ -4708,7 +4715,9 @@ void OSD::heartbeat_entry()
   while (!heartbeat_stop) {
     heartbeat();
 
-    double wait = .5 + ((float)(rand() % 10)/10.0) * (float)cct->_conf->osd_heartbeat_interval;
+    double wait = .5 + 
+                  ceph::util::generate_random_number(10.0f) * 
+                  static_cast<float>(cct->_conf->osd_heartbeat_interval);
     utime_t w;
     w.set_from_double(wait);
     dout(30) << "heartbeat_entry sleeping for " << wait << dendl;
@@ -6092,8 +6101,8 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       char nm[30];
       unsigned offset = 0;
       if (onum && osize) {
-	snprintf(nm, sizeof(nm), "disk_bw_test_%d", (int)(rand() % onum));
-	offset = rand() % (osize / bsize) * bsize;
+	snprintf(nm, sizeof(nm), "disk_bw_test_%d", static_cast<int>(ceph::util::generate_random_number(onum)));
+	offset = ceph::util::generate_random_number((osize / bsize) * bsize);
       } else {
 	snprintf(nm, sizeof(nm), "disk_bw_test_%lld", (long long)pos);
       }
@@ -6710,8 +6719,9 @@ void OSD::handle_scrub(MOSDScrub *m)
 
 bool OSD::scrub_random_backoff()
 {
-  bool coin_flip = (rand() / (double)RAND_MAX >=
-		    cct->_conf->osd_scrub_backoff_ratio);
+  bool coin_flip = (ceph::util::generate_random_number(rand_max_double) / rand_max_double) 
+                   >= cct->_conf->osd_scrub_backoff_ratio;
+
   if (!coin_flip) {
     dout(20) << "scrub_random_backoff lost coin flip, randomly backing off" << dendl;
     return true;
@@ -6736,7 +6746,9 @@ OSDService::ScrubJob::ScrubJob(CephContext* cct,
       pool_scrub_max_interval : cct->_conf->osd_scrub_max_interval;
 
     sched_time += scrub_min_interval;
-    double r = rand() / (double)RAND_MAX;
+
+    double r = ceph::util::generate_random_number(rand_max_double) / rand_max_double;
+
     sched_time +=
       scrub_min_interval * cct->_conf->osd_scrub_interval_randomize_ratio * r;
     if (scrub_max_interval == 0) {
@@ -7240,7 +7252,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 
       bool injected_failure = false;
       if (cct->_conf->osd_inject_bad_map_crc_probability > 0 &&
-	  (rand() % 10000) < cct->_conf->osd_inject_bad_map_crc_probability*10000.0) {
+         ceph::util::generate_random_number(10000.0) < cct->_conf->osd_inject_bad_map_crc_probability*10000.0) {
 	derr << __func__ << " injecting map crc failure" << dendl;
 	injected_failure = true;
       }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4593,7 +4593,7 @@ void OSD::handle_osd_ping(MOSDPing *m)
 	    break;
 	  }
 	} else if (cct->_conf->osd_debug_drop_ping_probability >
-               (ceph::util::generate_random_number(100.0d) / 100.0d)) {
+               (ceph::util::generate_random_number(100.0d - 1.0d) / 100.0d)) {
 	  heartbeat_drop =
 	    debug_heartbeat_drops_remaining.insert(std::make_pair(from,
 	                     cct->_conf->osd_debug_drop_ping_duration)).first;
@@ -4716,7 +4716,7 @@ void OSD::heartbeat_entry()
     heartbeat();
 
     double wait = .5 + 
-                  ceph::util::generate_random_number(10.0f) * 
+                  ceph::util::generate_random_number(10.0f - 1.0f) * 
                   static_cast<float>(cct->_conf->osd_heartbeat_interval);
     utime_t w;
     w.set_from_double(wait);
@@ -6102,7 +6102,7 @@ void OSD::do_command(Connection *con, ceph_tid_t tid, vector<string>& cmd, buffe
       unsigned offset = 0;
       if (onum && osize) {
 	snprintf(nm, sizeof(nm), "disk_bw_test_%d", static_cast<int>(ceph::util::generate_random_number(onum)));
-	offset = ceph::util::generate_random_number((osize / bsize) * bsize);
+	offset = ceph::util::generate_random_number(((osize / bsize) * bsize) - 1);
       } else {
 	snprintf(nm, sizeof(nm), "disk_bw_test_%lld", (long long)pos);
       }
@@ -7252,7 +7252,7 @@ void OSD::handle_osd_map(MOSDMap *m)
 
       bool injected_failure = false;
       if (cct->_conf->osd_inject_bad_map_crc_probability > 0 &&
-         ceph::util::generate_random_number(10000.0) < cct->_conf->osd_inject_bad_map_crc_probability*10000.0) {
+         ceph::util::generate_random_number(10000.0 - 1.0) < cct->_conf->osd_inject_bad_map_crc_probability*10000.0) {
 	derr << __func__ << " injecting map crc failure" << dendl;
 	injected_failure = true;
       }

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -719,7 +719,7 @@ public:
   bool promote_throttle() {
     // NOTE: lockless!  we rely on the probability being a single word.
     promote_counter.attempt();
-    if (static_cast<unsigned>(ceph::util::generate_random_number(1000)) > promote_probability_millis)
+    if (static_cast<unsigned>(ceph::util::generate_random_number(1000 - 1)) > promote_probability_millis)
       return true;  // yes throttle (no promote)
     if (promote_max_objects &&
 	promote_counter.objects > promote_max_objects)
@@ -2156,7 +2156,7 @@ private:
 					 io_queue::mclock_opclass,
 					 io_queue::mclock_client };
       constexpr int range = sizeof(index_lookup) / sizeof(index_lookup[0]);
-      int which = ceph::util::generate_random_number(range);
+      int which = ceph::util::generate_random_number(range - 1);
       return index_lookup[which];
     } else if (cct->_conf->osd_op_queue == "prioritized") {
       return io_queue::prioritized;
@@ -2172,7 +2172,7 @@ private:
 
   unsigned int get_io_prio_cut() const {
     if (cct->_conf->osd_op_queue_cut_off == "debug_random") {
-      return (ceph::util::generate_random_number(2) < 1) ? CEPH_MSG_PRIO_HIGH : CEPH_MSG_PRIO_LOW;
+      return (ceph::util::generate_random_number(1) < 1) ? CEPH_MSG_PRIO_HIGH : CEPH_MSG_PRIO_LOW;
     } else if (cct->_conf->osd_op_queue_cut_off == "high") {
       return CEPH_MSG_PRIO_HIGH;
     } else {

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -2155,8 +2155,8 @@ private:
 					 io_queue::weightedpriority,
 					 io_queue::mclock_opclass,
 					 io_queue::mclock_client };
-      constexpr range = sizeof(index_lookup) / sizeof(index_lookup[0]);
-      auto which = ceph::util::generate_random_number(range);
+      constexpr int range = sizeof(index_lookup) / sizeof(index_lookup[0]);
+      int which = ceph::util::generate_random_number(range);
       return index_lookup[which];
     } else if (cct->_conf->osd_op_queue == "prioritized") {
       return io_queue::prioritized;

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -15,37 +15,45 @@
 #ifndef CEPH_OSD_H
 #define CEPH_OSD_H
 
+#include <map>
+#include <atomic>
+#include <memory>
+
 #include "PG.h"
+#include "OSDCap.h" 
+#include "Session.h"
+#include "OpRequest.h"
 
-#include "msg/Dispatcher.h"
+#include "include/memory.h"
+#include "include/random.h"
+#include "include/CompatSet.h"
+#include "include/unordered_map.h"
 
+#include "common/Timer.h"
 #include "common/Mutex.h"
 #include "common/RWLock.h"
-#include "common/Timer.h"
 #include "common/WorkQueue.h"
-#include "common/AsyncReserver.h"
+#include "common/EventTrace.h"
 #include "common/ceph_context.h"
 #include "common/config_cacher.h"
 #include "common/zipkin_trace.h"
+#include "common/AsyncReserver.h"
+#include "common/shared_cache.hpp"
+#include "common/simple_cache.hpp"
+#include "common/PrioritizedQueue.h"
+#include "common/sharedptr_registry.hpp"
+#include "common/WeightedPriorityQueue.h"
+
+#include "msg/Dispatcher.h"
 
 #include "mgr/MgrClient.h"
 
 #include "os/ObjectStore.h"
-#include "OSDCap.h" 
  
 #include "auth/KeyRing.h"
-#include "osd/ClassHandler.h"
-
-#include "include/CompatSet.h"
-
-#include "OpRequest.h"
-#include "Session.h"
 
 #include "osd/OpQueueItem.h"
 
-#include <atomic>
-#include <map>
-#include <memory>
 #include "include/memory.h"
 
 #include "include/unordered_map.h"
@@ -55,10 +63,14 @@
 #include "common/sharedptr_registry.hpp"
 #include "common/WeightedPriorityQueue.h"
 #include "common/PrioritizedQueue.h"
+
+#include "osd/ClassHandler.h"
 #include "osd/mClockOpClassQueue.h"
 #include "osd/mClockClientQueue.h"
+
 #include "messages/MOSDOp.h"
-#include "common/EventTrace.h"
+
+using namespace std;
 
 #define CEPH_OSD_PROTOCOL    10 /* cluster internal */
 
@@ -707,7 +719,7 @@ public:
   bool promote_throttle() {
     // NOTE: lockless!  we rely on the probability being a single word.
     promote_counter.attempt();
-    if ((unsigned)rand() % 1000 > promote_probability_millis)
+    if (static_cast<unsigned>(ceph::util::generate_random_number(1000)) > promote_probability_millis)
       return true;  // yes throttle (no promote)
     if (promote_max_objects &&
 	promote_counter.objects > promote_max_objects)
@@ -2143,8 +2155,8 @@ private:
 					 io_queue::weightedpriority,
 					 io_queue::mclock_opclass,
 					 io_queue::mclock_client };
-      srand(time(NULL));
-      unsigned which = rand() % (sizeof(index_lookup) / sizeof(index_lookup[0]));
+      constexpr range = sizeof(index_lookup) / sizeof(index_lookup[0]);
+      auto which = ceph::util::generate_random_number(range);
       return index_lookup[which];
     } else if (cct->_conf->osd_op_queue == "prioritized") {
       return io_queue::prioritized;
@@ -2160,8 +2172,7 @@ private:
 
   unsigned int get_io_prio_cut() const {
     if (cct->_conf->osd_op_queue_cut_off == "debug_random") {
-      srand(time(NULL));
-      return (rand() % 2 < 1) ? CEPH_MSG_PRIO_HIGH : CEPH_MSG_PRIO_LOW;
+      return (ceph::util::generate_random_number(2) < 1) ? CEPH_MSG_PRIO_HIGH : CEPH_MSG_PRIO_LOW;
     } else if (cct->_conf->osd_op_queue_cut_off == "high") {
       return CEPH_MSG_PRIO_HIGH;
     } else {

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2850,7 +2850,7 @@ void PG::_update_blocked_by()
   for (set<int>::iterator p = blocked_by.begin();
        p != blocked_by.end() && keep > 0;
        ++p) {
-    if (skip > 0 && ceph::util::generate_random_number(skip + keep) < skip) {
+    if (skip > 0 && ceph::util::generate_random_number<unsigned>(skip + keep) < skip) {
       --skip;
     } else {
       info.stats.blocked_by[pos++] = *p;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2850,7 +2850,7 @@ void PG::_update_blocked_by()
   for (set<int>::iterator p = blocked_by.begin();
        p != blocked_by.end() && keep > 0;
        ++p) {
-    if (skip > 0 && (ceph::util::generate_random_number(skip + keep) < skip)) {
+    if (skip > 0 && ceph::util::generate_random_number(skip + keep) < skip) {
       --skip;
     } else {
       info.stats.blocked_by[pos++] = *p;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2852,7 +2852,7 @@ void PG::_update_blocked_by()
   for (set<int>::iterator p = blocked_by.begin();
        p != blocked_by.end() && keep > 0;
        ++p) {
-    if (skip > 0 && (rand() % (skip + keep) < skip)) {
+    if (skip > 0 && ceph::util::generate_random_number(static_cast<unsigned>(skip + keep)) < skip)) {
       --skip;
     } else {
       info.stats.blocked_by[pos++] = *p;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2850,7 +2850,7 @@ void PG::_update_blocked_by()
   for (set<int>::iterator p = blocked_by.begin();
        p != blocked_by.end() && keep > 0;
        ++p) {
-    if (skip > 0 && ceph::util::generate_random_number<unsigned>(skip + keep) < skip) {
+    if (skip > 0 && ceph::util::generate_random_number<unsigned>((skip + keep) - 1) < skip) {
       --skip;
     } else {
       info.stats.blocked_by[pos++] = *p;
@@ -3739,7 +3739,7 @@ bool PG::sched_scrub()
   bool deep_coin_flip = false;
   // Only add random deep scrubs when NOT user initiated scrub
   if (!scrubber.must_scrub)
-      deep_coin_flip = ceph::util::generate_random_number(100) < cct->_conf->osd_deep_scrub_randomize_ratio * 100;
+      deep_coin_flip = ceph::util::generate_random_number(100 - 1) < cct->_conf->osd_deep_scrub_randomize_ratio * 100;
   dout(20) << __func__ << ": time_for_deep=" << time_for_deep << " deep_coin_flip=" << deep_coin_flip << dendl;
 
   time_for_deep = (time_for_deep || deep_coin_flip);
@@ -7011,7 +7011,7 @@ PG::RecoveryState::RepNotRecovering::react(const RequestBackfillPrio &evt)
   ostringstream ss;
 
   if (pg->cct->_conf->osd_debug_reject_backfill_probability > 0 &&
-      (ceph::util::generate_random_number(1000) < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
+      (ceph::util::generate_random_number(1000 - 1) < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected: failure injection"
 		       << dendl;
     post_event(RejectRemoteReservation());
@@ -7081,7 +7081,7 @@ PG::RecoveryState::RepWaitBackfillReserved::react(const RemoteBackfillReserved &
 
   ostringstream ss;
   if (pg->cct->_conf->osd_debug_reject_backfill_probability > 0 &&
-      (ceph::util::generate_random_number(1000) < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
+      (ceph::util::generate_random_number(1000 - 1) < (pg->cct->_conf->osd_debug_reject_backfill_probability*1000.0))) {
     ldout(pg->cct, 10) << "backfill reservation rejected after reservation: "
 		       << "failure injection" << dendl;
     post_event(RejectRemoteReservation());

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -15,18 +15,23 @@
  *
  */
 
-
-#include "common/errno.h"
-#include "common/scrub_types.h"
-#include "ReplicatedBackend.h"
-#include "ScrubStore.h"
+#include "OSD.h"
+#include "PGLog.h"
+#include "OSDMap.h"
 #include "ECBackend.h"
 #include "PGBackend.h"
-#include "OSD.h"
-#include "erasure-code/ErasureCodePlugin.h"
-#include "OSDMap.h"
-#include "PGLog.h"
+#include "ScrubStore.h"
+#include "ReplicatedBackend.h"
+
+#include "include/util.h"
+#include "include/random.h"
+
+#include "common/errno.h"
 #include "common/LogClient.h"
+#include "common/scrub_types.h"
+
+#include "erasure-code/ErasureCodePlugin.h"
+
 #include "messages/MOSDPGRecoveryDelete.h"
 #include "messages/MOSDPGRecoveryDeleteReply.h"
 

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -1042,8 +1042,8 @@ void PGBackend::be_compare_scrubmaps(
       }
       if (auth_object.digest_present && auth_object.omap_digest_present &&
 	  cct->_conf->osd_debug_scrub_chance_rewrite_digest &&
-	  (((unsigned)rand() % 100) >
-	   cct->_conf->osd_debug_scrub_chance_rewrite_digest)) {
+	  (static_cast<unsigned>(ceph::util::generate_random_number(100) >
+	   cct->_conf->osd_debug_scrub_chance_rewrite_digest))) {
 	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
 	update = MAYBE;
       }

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -1048,7 +1048,7 @@ void PGBackend::be_compare_scrubmaps(
       if (auth_object.digest_present && auth_object.omap_digest_present &&
 	  cct->_conf->osd_debug_scrub_chance_rewrite_digest &&
 	  (ceph::util::generate_random_number<
-		decltype(cct->_conf->osd_debug_scrub_chance_rewrite_digest)>(100) >
+		decltype(cct->_conf->osd_debug_scrub_chance_rewrite_digest)>(100 - 1) >
 	   cct->_conf->osd_debug_scrub_chance_rewrite_digest)) {
 	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
 	update = MAYBE;

--- a/src/osd/PGBackend.cc
+++ b/src/osd/PGBackend.cc
@@ -1047,8 +1047,9 @@ void PGBackend::be_compare_scrubmaps(
       }
       if (auth_object.digest_present && auth_object.omap_digest_present &&
 	  cct->_conf->osd_debug_scrub_chance_rewrite_digest &&
-	  (static_cast<unsigned>(ceph::util::generate_random_number(100) >
-	   cct->_conf->osd_debug_scrub_chance_rewrite_digest))) {
+	  (ceph::util::generate_random_number<
+		decltype(cct->_conf->osd_debug_scrub_chance_rewrite_digest)>(100) >
+	   cct->_conf->osd_debug_scrub_chance_rewrite_digest)) {
 	dout(20) << __func__ << " randomly updating digest on " << *k << dendl;
 	update = MAYBE;
       }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -15,8 +15,14 @@
  *
  */
 
+
+#include <cerrno>
+#include <sstream>
+#include <utility>
+
 #include "boost/tuple/tuple.hpp"
 #include "boost/intrusive_ptr.hpp"
+
 #include "PG.h"
 #include "PrimaryLogPG.h"
 #include "OSD.h"
@@ -24,6 +30,8 @@
 #include "ScrubStore.h"
 #include "Session.h"
 #include "objclass/objclass.h"
+
+#include "include/random.h"
 
 #include "common/errno.h"
 #include "common/scrub_types.h"
@@ -67,12 +75,6 @@ template <typename T>
 static ostream& _prefix(std::ostream *_dout, T *pg) {
   return *_dout << pg->gen_prefix();
 }
-
-
-#include <sstream>
-#include <utility>
-
-#include <errno.h>
 
 MEMPOOL_DEFINE_OBJECT_FACTORY(PrimaryLogPG, replicatedpg, osd);
 
@@ -13335,7 +13337,7 @@ void PrimaryLogPG::agent_setup()
     agent_state->position.pool = info.pgid.pool();
     agent_state->position.set_hash(pool.info.get_random_pg_position(
       info.pgid.pgid,
-      rand()));
+      ceph::util::generate_random_number()));
     agent_state->start = agent_state->position;
 
     dout(10) << __func__ << " allocated new state, position "

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -2926,7 +2926,7 @@ int Objecter::_calc_target(op_target_t *t, Connection *con, bool any_change)
       int osd;
       bool read = is_read && !is_write;
       if (read && (t->flags & CEPH_OSD_FLAG_BALANCE_READS)) {
-	int p = ceph::util::generate_random_number(acting.size());
+	int p = ceph::util::generate_random_number(acting.size() - 1);
 	if (p)
 	  t->used_replica = true;
 	osd = acting[p];

--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -12,6 +12,8 @@
  *
  */
 
+#include <errno.h>
+
 #include "Objecter.h"
 #include "osd/OSDMap.h"
 #include "Filer.h"
@@ -42,14 +44,14 @@
 
 #include "messages/MWatchNotify.h"
 
-#include <errno.h>
-
 #include "common/config.h"
 #include "common/perf_counters.h"
 #include "common/scrub_types.h"
 #include "include/str_list.h"
 #include "common/errno.h"
 #include "common/EventTrace.h"
+
+#include "include/random.h"
 
 using ceph::real_time;
 using ceph::real_clock;
@@ -2924,7 +2926,7 @@ int Objecter::_calc_target(op_target_t *t, Connection *con, bool any_change)
       int osd;
       bool read = is_read && !is_write;
       if (read && (t->flags & CEPH_OSD_FLAG_BALANCE_READS)) {
-	int p = rand() % acting.size();
+	int p = ceph::util::generate_random_number(acting.size());
 	if (p)
 	  t->used_replica = true;
 	osd = acting[p];

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -7,6 +7,8 @@
 #include "common/Throttle.h"
 #include "common/errno.h"
 
+#include "include/random.h"
+
 #include "rgw_common.h"
 #include "rgw_rados.h"
 #include "rgw_sync.h"
@@ -2446,7 +2448,7 @@ public:
             goto done;
           }
           if (error_injection &&
-              rand() % 10000 < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
+              ceph::util::generate_random_number(10000) < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
             tn->log(0, SSTR(": injecting data sync error on key=" << key.name));
             retcode = -EIO;
           } else if (op == CLS_RGW_OP_ADD ||

--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -2448,7 +2448,7 @@ public:
             goto done;
           }
           if (error_injection &&
-              ceph::util::generate_random_number(10000) < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
+              ceph::util::generate_random_number(10000 - 1) < cct->_conf->rgw_sync_data_inject_err_probability * 10000.0) {
             tn->log(0, SSTR(": injecting data sync error on key=" << key.name));
             retcode = -EIO;
           } else if (op == CLS_RGW_OP_ADD ||

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -16,6 +16,8 @@
 
 #include "common/escape.h"
 #include "common/Formatter.h"
+#include "common/backport_std.h"
+
 #include "rgw/rgw_common.h"
 #include "rgw/rgw_formats.h"
 #include "rgw/rgw_rest.h"

--- a/src/rgw/rgw_formats.cc
+++ b/src/rgw/rgw_formats.cc
@@ -16,7 +16,6 @@
 
 #include "common/escape.h"
 #include "common/Formatter.h"
-#include "common/backport_std.h"
 
 #include "rgw/rgw_common.h"
 #include "rgw/rgw_formats.h"

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -1,15 +1,27 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "include/compat.h"
 #include <errno.h>
 #include <stdlib.h>
+
+#include <map>
+#include <list>
+#include <vector>
+#include <atomic>
+#include <cerrno>
+#include <string>
+#include <cstdlib>
+#include <iostream>
+
 #include <sys/types.h>
-#include <boost/algorithm/string.hpp>
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>
+#include <boost/algorithm/string.hpp>
 #include <boost/utility/in_place_factory.hpp>
+
+#include "include/compat.h"
+#include "include/random.h"
 
 #include "common/ceph_json.h"
 #include "common/utf8.h"
@@ -60,6 +72,8 @@ using namespace librados;
 #include <list>
 #include <map>
 #include "include/random.h"
+
+#include "auth/Crypto.h" // get_random_bytes()
 
 #include "rgw_log.h"
 
@@ -1719,7 +1733,7 @@ rgw_pool fix_zone_pool_dup(set<rgw_pool> pools,
     return pool;
   } else {
     while(true) {
-      pool =  prefix + "_" + std::to_string(std::rand()) + suffix;
+      pool= prefix + "_" + std::to_string(ceph::util::generate_random_number(RAND_MAX)) + suffix;
       if (pools.find(pool) == pools.end()) {
 	return pool;
       }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -11,6 +11,8 @@
 #include "common/admin_socket.h"
 #include "common/errno.h"
 
+#include "include/random.h"
+
 #include "rgw_common.h"
 #include "rgw_rados.h"
 #include "rgw_sync.h"
@@ -1219,7 +1221,7 @@ int RGWMetaSyncSingleEntryCR::operate() {
 #define NUM_TRANSIENT_ERROR_RETRIES 10
 
     if (error_injection &&
-        rand() % 10000 < cct->_conf->rgw_sync_meta_inject_err_probability * 10000.0) {
+        ceph::util::generate_random_number(10000) < cct->_conf->rgw_sync_meta_inject_err_probability * 10000.0) {
       ldout(sync_env->cct, 0) << __FILE__ << ":" << __LINE__ << ": injecting meta sync error on key=" << raw_key << dendl;
       return set_cr_error(-EIO);
     }

--- a/src/rgw/rgw_sync.cc
+++ b/src/rgw/rgw_sync.cc
@@ -1221,7 +1221,7 @@ int RGWMetaSyncSingleEntryCR::operate() {
 #define NUM_TRANSIENT_ERROR_RETRIES 10
 
     if (error_injection &&
-        ceph::util::generate_random_number(10000) < cct->_conf->rgw_sync_meta_inject_err_probability * 10000.0) {
+        ceph::util::generate_random_number(10000 - 1) < cct->_conf->rgw_sync_meta_inject_err_probability * 10000.0) {
       ldout(sync_env->cct, 0) << __FILE__ << ":" << __LINE__ << ": injecting meta sync error on key=" << raw_key << dendl;
       return set_cr_error(-EIO);
     }

--- a/src/test/ObjectMap/test_keyvaluedb_atomicity.cc
+++ b/src/test/ObjectMap/test_keyvaluedb_atomicity.cc
@@ -1,16 +1,26 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include <pthread.h>
-#include "include/buffer.h"
-#include "kv/KeyValueDB.h"
-#include <sys/types.h>
-#include <dirent.h>
+
 #include <string>
 #include <vector>
-#include "include/memory.h"
-#include <boost/scoped_ptr.hpp>
 #include <iostream>
 #include <sstream>
+
+#include <sys/types.h>
+
+#include <dirent.h>
+#include <pthread.h>
+
+#include <boost/scoped_ptr.hpp>
+
+#include "include/util.h"
+#include "include/random.h"
+#include "include/memory.h"
+#include "include/buffer.h"
+
+#include "kv/KeyValueDB.h"
+
 #include "stdlib.h"
+
 #include "global/global_context.h"
 
 using namespace std;
@@ -61,7 +71,7 @@ void *write(void *_db) {
     if (!(i % 10)) {
       std::cout << "Iteration: " << i << std::endl;
     }
-    int key_num = rand();
+    int key_num = ceph::util::generate_random_number();
     stringstream key;
     key << key_num << std::endl;
     map<string, bufferlist> to_set;

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -1,20 +1,30 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include "include/memory.h"
+
 #include <map>
 #include <set>
+
 #include <boost/scoped_ptr.hpp>
 
+#include <dirent.h>
+#include <sys/types.h>
+
+#include "include/random.h"
 #include "include/buffer.h"
+#include "include/memory.h"
+
 #include "test/ObjectMap/KeyValueDBMemory.h"
+
 #include "kv/KeyValueDB.h"
+
 #include "os/filestore/DBObjectMap.h"
 #include "os/filestore/HashIndex.h"
-#include <sys/types.h>
+
 #include "global/global_init.h"
+
 #include "common/ceph_argparse.h"
-#include <dirent.h>
 
 #include "gtest/gtest.h"
+
 #include "stdlib.h"
 
 using namespace std;
@@ -24,7 +34,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = rand() % cont.size();
+  int index = ceph::util::generate_random_number(cont.size());
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -983,7 +993,7 @@ TEST_F(ObjectMapTest, OddEvenOldClone) {
 TEST_F(ObjectMapTest, RandomTest) {
   tester.def_init();
   for (unsigned i = 0; i < 5000; ++i) {
-    unsigned val = rand();
+    unsigned val = ceph::util::generate_random_number();
     val <<= 8;
     val %= 100;
     if (!(i%100))

--- a/src/test/ObjectMap/test_object_map.cc
+++ b/src/test/ObjectMap/test_object_map.cc
@@ -34,7 +34,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = ceph::util::generate_random_number(cont.size());
+  int index = ceph::util::generate_random_number(cont.size() - 1);
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;

--- a/src/test/bufferlist.cc
+++ b/src/test/bufferlist.cc
@@ -19,23 +19,28 @@
  *
  */
 
-#include "include/memory.h"
-#include <limits.h>
-#include <errno.h>
-#include <sys/uio.h>
+#include <cerrno>
+#include <climits>
+#include <cstdlib>
 
-#include "include/buffer.h"
+#include <fcntl.h>
+#include <sys/uio.h>
+#include <sys/stat.h>
+
+#include "include/util.h"
 #include "include/utime.h"
-#include "include/coredumpctl.h"
+#include "include/memory.h"
+#include "include/buffer.h"
+#include "include/random.h"
 #include "include/encoding.h"
+#include "include/coredumpctl.h"
+
 #include "common/environment.h"
 #include "common/Clock.h"
 #include "common/safe_io.h"
 
 #include "gtest/gtest.h"
-#include "stdlib.h"
-#include "fcntl.h"
-#include "sys/stat.h"
+
 #include "include/crc32c.h"
 #include "common/sctp_crc32.h"
 
@@ -2633,11 +2638,11 @@ TEST(BufferList, crc32c_append) {
   for (int j = 0; j < 200; ++j) {
     bufferlist bl;
     for (int i = 0; i < 200; ++i) {
-      char x = rand();
+      char x = ceph::util::generate_random_number();
       bl.append(x);
       bl1.append(x);
     }
-    bl.crc32c(rand()); // mess with the cached bufferptr crc values
+    bl.crc32c(ceph::util::generate_random_number()); // mess with the cached bufferptr crc values
     bl2.append(bl);
   }
   ASSERT_EQ(bl1.crc32c(0), bl2.crc32c(0));

--- a/src/test/cls_rbd/test_cls_rbd.cc
+++ b/src/test/cls_rbd/test_cls_rbd.cc
@@ -1,26 +1,30 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <cerrno>
+#include <string>
+#include <vector>
+
+#include "include/types.h"
+#include "include/encoding.h"
+#include "include/random.h"
+#include "include/rbd_types.h"
+#include "include/stringify.h"
+#include "include/rados/librados.h"
+#include "include/rbd/object_map_types.h"
+
+#include "common/Clock.h"
 #include "common/ceph_context.h"
 #include "common/config.h"
 #include "common/snap_types.h"
-#include "common/Clock.h"
-#include "include/encoding.h"
-#include "include/types.h"
-#include "include/rados/librados.h"
-#include "include/rbd/object_map_types.h"
-#include "include/rbd_types.h"
-#include "include/stringify.h"
+
 #include "cls/rbd/cls_rbd.h"
 #include "cls/rbd/cls_rbd_client.h"
 #include "cls/rbd/cls_rbd_types.h"
 
 #include "gtest/gtest.h"
-#include "test/librados/test.h"
 
-#include <errno.h>
-#include <string>
-#include <vector>
+#include "test/librados/test.h"
 
 using namespace std;
 using namespace librbd::cls_client;
@@ -60,8 +64,12 @@ static int old_snapshot_add(librados::IoCtx *ioctx, const std::string &oid,
 static char *random_buf(size_t len)
 {
   char *b = new char[len];
-  for (size_t i = 0; i < len; i++)
-    b[i] = (rand() % (128 - 32)) + 32;
+
+  std::transform(b, len + b, b, [](char) {
+      constexpr auto n = std::numeric_limits<char>::max();
+      return static_cast<char>(ceph::util::generate_random_number(n));
+  });
+
   return b;
 }
 

--- a/src/test/common/CMakeLists.txt
+++ b/src/test/common/CMakeLists.txt
@@ -203,6 +203,7 @@ target_link_libraries(unittest_interval_set ceph-common)
 add_executable(unittest_weighted_priority_queue
   test_weighted_priority_queue.cc
   )
+target_link_libraries(unittest_weighted_priority_queue ceph-common)
 add_ceph_unittest(unittest_weighted_priority_queue)
 
 # unittest_mutex_debug

--- a/src/test/common/test_bit_vector.cc
+++ b/src/test/common/test_bit_vector.cc
@@ -9,9 +9,13 @@
  */
 
 #include <gtest/gtest.h>
+
 #include <cmath>
-#include "common/bit_vector.hpp"
 #include <boost/assign/list_of.hpp>
+
+#include "include/random.h"
+
+#include "common/bit_vector.hpp"
 
 using namespace ceph;
 
@@ -73,8 +77,9 @@ TYPED_TEST(BitVectorTest, get_set) {
   bit_vector.resize(size);
   ref.resize(size);
   for (size_t i = 0; i < size; ++i) {
-    uint64_t v = rand() % radix;
-    ref[i] = v;
+    // Note that mod is important here on account of bit-binning:
+    uint64_t v = ceph::util::generate_random_number(RAND_MAX) % radix;	
+    ref[i] = v;	
     bit_vector[i] = v;
   }
 

--- a/src/test/common/test_bit_vector.cc
+++ b/src/test/common/test_bit_vector.cc
@@ -8,14 +8,15 @@
  * LGPL2.1 (see COPYING-LGPL2.1) or later
  */
 
-#include <gtest/gtest.h>
-
 #include <cmath>
-#include <boost/assign/list_of.hpp>
 
 #include "include/random.h"
 
 #include "common/bit_vector.hpp"
+
+#include <boost/assign/list_of.hpp>
+
+#include <gtest/gtest.h>
 
 using namespace ceph;
 

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -1,19 +1,20 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <cstring>
 #include <iostream>
-#include <string.h>
 
 #include "include/types.h"
 #include "include/crc32c.h"
 #include "include/utime.h"
+
 #include "common/Clock.h"
-
-#include "gtest/gtest.h"
-
+#include "common/backport_std.h"
 #include "common/sctp_crc32.h"
 #include "common/crc32c_intel_baseline.h"
 #include "common/crc32c_aarch64.h"
+
+#include "gtest/gtest.h"
 
 TEST(Crc32c, Small) {
   const char *a = "foo bar baz";
@@ -293,7 +294,7 @@ double estimate_clock_resolution()
   double v = *(head++);
   double range=0;
   while (head != tail) {
-    range = max(range, *head - v);
+    range = std::max(range, *head - v);
     v = *head;
     head++;
   }

--- a/src/test/common/test_crc32c.cc
+++ b/src/test/common/test_crc32c.cc
@@ -9,7 +9,6 @@
 #include "include/utime.h"
 
 #include "common/Clock.h"
-#include "common/backport_std.h"
 #include "common/sctp_crc32.h"
 #include "common/crc32c_intel_baseline.h"
 #include "common/crc32c_aarch64.h"

--- a/src/test/common/test_random.cc
+++ b/src/test/common/test_random.cc
@@ -86,6 +86,25 @@ TEST(util, test_random)
        ASSERT_NE(a, b);
      }
   }
+
+  // Check that the nullary version accepts different numeric types:
+  {
+	long def = ceph::util::generate_random_number();
+	long l = ceph::util::generate_random_number<long>();
+	int64_t i = ceph::util::generate_random_number<int64_t>();
+	double d = ceph::util::generate_random_number<double>();
+
+	swallow_values(def, l, i, d);
+  }
+
+  // (optimistically) Check that the nullary and unary versions never return < 0:
+  {
+	for(long i = 0; 1000000 != i; i++) {
+	 ASSERT_LE(0, ceph::util::generate_random_number());
+	 ASSERT_LE(0, ceph::util::generate_random_number(1));
+	 ASSERT_LE(0, ceph::util::generate_random_number<float>(1.0));
+	}
+  }
  
   {
   auto a = ceph::util::generate_random_number(1, std::numeric_limits<int>::max());
@@ -100,11 +119,16 @@ TEST(util, test_random)
   }
  
   for (auto n = 100000; n; --n) {
-     constexpr int min = 0, max = 6;
-     int a = ceph::util::generate_random_number(min, max);
+     int a = ceph::util::generate_random_number(0, 6);
      ASSERT_GT(a, -1);
      ASSERT_LT(a, 7);
    }
+
+  // Check bounding on zero (checking appropriate value for zero compiles and works):
+  for (auto n = 10; n; --n) {
+	ASSERT_EQ(0, ceph::util::generate_random_number<int>(0, 0));
+	ASSERT_EQ(0, ceph::util::generate_random_number<float>(0, 0));
+  }
  
   // Multiple types (integral):
   {

--- a/src/test/common/test_random.cc
+++ b/src/test/common/test_random.cc
@@ -127,7 +127,7 @@ TEST(util, test_random)
   // Check bounding on zero (checking appropriate value for zero compiles and works):
   for (auto n = 10; n; --n) {
 	ASSERT_EQ(0, ceph::util::generate_random_number<int>(0, 0));
-	ASSERT_EQ(0, ceph::util::generate_random_number<float>(0, 0));
+	ASSERT_EQ(0, ceph::util::generate_random_number<float>(0.0, 0.0));
   }
  
   // Multiple types (integral):
@@ -156,6 +156,37 @@ TEST(util, test_random)
   {
     float min = 1.0, max = 0.0;
     type_check_ok(min, max);
+  }
+
+  // When combining types, everything should convert to the largest type:
+  {
+    // Check with integral types:
+    {
+	int x = 0;
+	long long y = 1;
+
+	auto z = ceph::util::generate_random_number(x, y);
+
+    bool result = std::is_same_v<decltype(z), decltype(y)>;
+
+    ASSERT_TRUE(result);
+	}
+
+    // Check with floating-point types:
+    {
+	float x = 0.0;
+	long double y = 1.0;
+
+	auto z = ceph::util::generate_random_number(x, y);
+
+    bool result = std::is_same_v<decltype(z), decltype(y)>;
+
+    ASSERT_TRUE(result);
+	}
+
+	// It would be nice to have a test to check that mixing integral and floating point
+    // numbers should not compile, however we currently have no good way I know of
+    // to do such negative tests.
   }
 }
 

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -1,19 +1,19 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <numeric>
-#include <vector>
 #include <map>
 #include <list>
 #include <tuple>
-
-#include "gtest/gtest.h"
+#include <vector>
+#include <numeric>
 
 #include "include/util.h"
 #include "include/random.h"
 
 #include "common/Formatter.h"
 #include "common/WeightedPriorityQueue.h"
+
+#include "gtest/gtest.h"
 
 #define CEPH_OP_CLASS_STRICT	0
 #define CEPH_OP_CLASS_NORMAL	0
@@ -43,16 +43,16 @@ protected:
     for (unsigned i = 1; i <= item_size; ++i) {
       // Choose priority, class, cost and 'op' for this op.
       if (randomize) {
-        p = ceph::util::generate_random_number(max_prios) * 64;
-        k = ceph::util::generate_random_number(klasses);
-        c = ceph::util::generate_random_number(1<<22);  // 4M cost
+        p = ceph::util::generate_random_number(max_prios - 1) * 64;
+        k = ceph::util::generate_random_number(klasses - 1);
+        c = ceph::util::generate_random_number((1<<22( - 1);  // 4M cost
         // Make some of the costs 0, but make sure small costs
         // still work ok.
         if (c > (1<<19) && c < (1<<20)) {
           c = 0;
 	}
-        op_queue = ceph::util::generate_random_number(10);
-        fob = ceph::util::generate_random_number(10);
+        op_queue = ceph::util::generate_random_number(10 - 1);
+        fob = ceph::util::generate_random_number(10 - 1);
       } else {
         p = (i % max_prios) * 64;
         k = i % klasses;
@@ -60,7 +60,7 @@ protected:
         op_queue = i % 7; // Use prime numbers to
         fob = i % 11;     // get better coverage
       }
-      o = ceph::util::generate_random_number(1<<16);
+      o = ceph::util::generate_random_number((1<<16) - 1);
       // Choose how to enqueue this op.
       switch (op_queue) {
       case 6 :
@@ -198,7 +198,7 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
-  test_queue(ceph::util::generate_random_number(500 + 500), true);
+  test_queue(ceph::util::generate_random_number(1, 1000), true);
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class_null) {

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -1,15 +1,19 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include "gtest/gtest.h"
-#include "common/Formatter.h"
-#include "common/WeightedPriorityQueue.h"
-
 #include <numeric>
 #include <vector>
 #include <map>
 #include <list>
 #include <tuple>
+
+#include "gtest/gtest.h"
+
+#include "include/util.h"
+#include "include/random.h"
+
+#include "common/Formatter.h"
+#include "common/WeightedPriorityQueue.h"
 
 #define CEPH_OP_CLASS_STRICT	0
 #define CEPH_OP_CLASS_NORMAL	0
@@ -39,16 +43,16 @@ protected:
     for (unsigned i = 1; i <= item_size; ++i) {
       // Choose priority, class, cost and 'op' for this op.
       if (randomize) {
-        p = (rand() % max_prios) * 64;
-        k = rand() % klasses;
-        c = rand() % (1<<22);  // 4M cost
+        p = ceph::util::generate_random_number(max_prios) * 64;
+        k = ceph::util::generate_random_number(klasses);
+        c = ceph::util::generate_random_number(1<<22);  // 4M cost
         // Make some of the costs 0, but make sure small costs
         // still work ok.
         if (c > (1<<19) && c < (1<<20)) {
           c = 0;
 	}
-        op_queue = rand() % 10;
-        fob = rand() % 10;
+        op_queue = ceph::util::generate_random_number(10);
+        fob = ceph::util::generate_random_number(10);
       } else {
         p = (i % max_prios) * 64;
         k = i % klasses;
@@ -56,7 +60,7 @@ protected:
         op_queue = i % 7; // Use prime numbers to
         fob = i % 11;     // get better coverage
       }
-      o = rand() % (1<<16);
+      o = ceph::util::generate_random_number(1<<16);
       // Choose how to enqueue this op.
       switch (op_queue) {
       case 6 :
@@ -153,8 +157,8 @@ protected:
     }
   }
 
-  void SetUp() override {
-    srand(time(0));
+  virtual void SetUp() {
+    ceph::util::randomize_rng();
   }
   void TearDown() override {
   }
@@ -194,7 +198,7 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
-  test_queue(rand() % 500 + 500, true);
+  test_queue(ceph::util::generate_random_number(500 + 500), true);
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class_null) {

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -197,7 +197,6 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
   test_queue(1000);
 } 
 
-TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
   test_queue(generate_random_number(500, 1500 - 1), true);
 } 
 

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -7,7 +7,6 @@
 #include <vector>
 #include <numeric>
 
-#include "include/util.h"
 #include "include/random.h"
 
 #include "common/Formatter.h"
@@ -19,6 +18,8 @@
 #define CEPH_OP_CLASS_NORMAL	0
 #define CEPH_OP_QUEUE_BACK	0
 #define CEPH_OP_QUEUE_FRONT	0
+
+using namespace ceph::util;
 
 class WeightedPriorityQueueTest : public testing::Test
 {
@@ -43,16 +44,16 @@ protected:
     for (unsigned i = 1; i <= item_size; ++i) {
       // Choose priority, class, cost and 'op' for this op.
       if (randomize) {
-        p = ceph::util::generate_random_number(max_prios - 1) * 64;
-        k = ceph::util::generate_random_number(klasses - 1);
-        c = ceph::util::generate_random_number((1<<22( - 1);  // 4M cost
+        p = generate_random_number(max_prios - 1) * 64;
+        k = generate_random_number(klasses - 1); 
+        c = generate_random_number((1 << 22) - 1); // 4M cost
         // Make some of the costs 0, but make sure small costs
         // still work ok.
         if (c > (1<<19) && c < (1<<20)) {
           c = 0;
 	}
-        op_queue = ceph::util::generate_random_number(10 - 1);
-        fob = ceph::util::generate_random_number(10 - 1);
+        op_queue = generate_random_number(10 - 1);
+        fob = generate_random_number(10 - 1);
       } else {
         p = (i % max_prios) * 64;
         k = i % klasses;
@@ -60,7 +61,7 @@ protected:
         op_queue = i % 7; // Use prime numbers to
         fob = i % 11;     // get better coverage
       }
-      o = ceph::util::generate_random_number((1<<16) - 1);
+      o = generate_random_number((1 << 16) - 1); 
       // Choose how to enqueue this op.
       switch (op_queue) {
       case 6 :
@@ -157,8 +158,7 @@ protected:
     }
   }
 
-  virtual void SetUp() {
-    ceph::util::randomize_rng();
+  void SetUp() override {
   }
   void TearDown() override {
   }
@@ -198,7 +198,7 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
-  test_queue(ceph::util::generate_random_number(1, 1000), true);
+  test_queue(generate_random_number(500, 1500 - 1), true);
 } 
 
 TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class_null) {

--- a/src/test/common/test_weighted_priority_queue.cc
+++ b/src/test/common/test_weighted_priority_queue.cc
@@ -21,6 +21,8 @@
 
 using namespace ceph::util;
 
+using ceph::util::generate_random_number;
+
 class WeightedPriorityQueueTest : public testing::Test
 {
 protected:
@@ -36,6 +38,7 @@ protected:
   typedef std::map<Prio, KlassItem> LQ;
   typedef std::list<Item> Removed;
   const unsigned max_prios = 5; // (0-4) * 64
+
   const unsigned klasses = 37;  // Make prime to help get good coverage
 
   void fill_queue(WQ &wq, LQ &strictq, LQ &normq,
@@ -197,6 +200,7 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_static) {
   test_queue(1000);
 } 
 
+TEST_F(WeightedPriorityQueueTest, wpq_test_random) {
   test_queue(generate_random_number(500, 1500 - 1), true);
 } 
 
@@ -214,7 +218,7 @@ TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class_null) {
 TEST_F(WeightedPriorityQueueTest, wpq_test_remove_by_class) {
   WQ wq(0, 0);
   LQ strictq, normq;
-  unsigned num_items = 1000;
+  unsigned num_items = 100;
   fill_queue(wq, strictq, normq, num_items);
   unsigned num_to_remove = 0;
   const Klass k = 5;

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -115,13 +115,13 @@ TEST_P(CompressorTest, big_round_trip_randomish)
   const char *alphabet = "abcdefghijklmnopqrstuvwxyz";
   if (false) {
     while (orig.length() < len) {
-      orig.append(alphabet[ceph::util::generate_random_number(10)]);
+      orig.append(alphabet[ceph::util::generate_random_number(10 - 1)]);
     }
   } else {
     bufferptr bp(len);
     char *p = bp.c_str();
     for (unsigned i=0; i<len; ++i) {
-      p[i] = alphabet[ceph::util::generate_random_number(10)];
+      p[i] = alphabet[ceph::util::generate_random_number(10 - 1)];
     }
     orig.append(bp);
   }
@@ -358,7 +358,7 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
   char test[101];
   ceph::util::randomize_rng();
   for (int i=0; i<100; ++i)
-    test[i] = 'a' + ceph::util::generate_random_number(26);
+    test[i] = 'a' + ceph::util::generate_random_number(26 - 1);
   test[100] = '\0';
   int len = strlen(test);
   bufferlist in, out;
@@ -425,12 +425,12 @@ TEST(ZlibCompressor, isal_compress_zlib_decompress_random)
   for (int cnt=0; cnt<100; cnt++)
   {
     ceph::util::randomize_rng();
-    int log2 = ceph::util::generate_random_number(18) + 1;
-    int size = ceph::util::generate_random_number(1 << log2) + 1;
+    int log2 = ceph::util::generate_random_number(1, 17);
+    int size = ceph::util::generate_random_number(1, (1 << log2) - 1);
 
     char test[size];
     for (int i=0; i<size; ++i)
-      test[i] = ceph::util::generate_random_number(256);
+      test[i] = ceph::util::generate_random_number(255);
     bufferlist in, out;
     in.append(test, size);
 
@@ -461,15 +461,15 @@ TEST(ZlibCompressor, isal_compress_zlib_decompress_walk)
   for (int cnt=0; cnt<100; cnt++)
   {
     ceph::util::randomize_rng();
-    int log2 = ceph::util::generate_random_number(18) + 1;
-    int size = ceph::util::generate_random_number(1 << log2) + 1;
+    int log2 = ceph::util::generate_random_number(1, 17);
+    int size = ceph::util::generate_random_number(1, (1 << log2) - 1);
 
     int range = 1;
 
     char test[size];
-    test[0] = ceph::util::generate_random_number(256);
+    test[0] = ceph::util::generate_random_number(255);
     for (int i=1; i<size; ++i)
-      test[i] = test[i-1] + ceph::util::generate_random_number(range*2+1) - range;
+      test[i] = test[i-1] + ceph::util::generate_random_number(range*2) - range;
     bufferlist in, out;
     in.append(test, size);
 

--- a/src/test/compressor/test_compression.cc
+++ b/src/test/compressor/test_compression.cc
@@ -17,8 +17,12 @@
 #include <errno.h>
 #include <signal.h>
 #include <stdlib.h>
+
 #include "gtest/gtest.h"
+
+#include "include/util.h"
 #include "common/config.h"
+#include "include/random.h"
 #include "compressor/Compressor.h"
 #include "compressor/CompressionPlugin.h"
 #include "global/global_context.h"
@@ -111,13 +115,13 @@ TEST_P(CompressorTest, big_round_trip_randomish)
   const char *alphabet = "abcdefghijklmnopqrstuvwxyz";
   if (false) {
     while (orig.length() < len) {
-      orig.append(alphabet[rand() % 10]);
+      orig.append(alphabet[ceph::util::generate_random_number(10)]);
     }
   } else {
     bufferptr bp(len);
     char *p = bp.c_str();
     for (unsigned i=0; i<len; ++i) {
-      p[i] = alphabet[rand() % 10];
+      p[i] = alphabet[ceph::util::generate_random_number(10)];
     }
     orig.append(bp);
   }
@@ -352,9 +356,9 @@ TEST(ZlibCompressor, zlib_isal_compatibility)
   g_ceph_context->_conf->apply_changes(NULL);
   CompressorRef zlib = Compressor::create(g_ceph_context, "zlib");
   char test[101];
-  srand(time(0));
+  ceph::util::randomize_rng();
   for (int i=0; i<100; ++i)
-    test[i] = 'a' + rand()%26;
+    test[i] = 'a' + ceph::util::generate_random_number(26);
   test[100] = '\0';
   int len = strlen(test);
   bufferlist in, out;
@@ -420,13 +424,13 @@ TEST(ZlibCompressor, isal_compress_zlib_decompress_random)
 
   for (int cnt=0; cnt<100; cnt++)
   {
-    srand(cnt + 1000);
-    int log2 = (rand()%18) + 1;
-    int size = (rand() % (1 << log2)) + 1;
+    ceph::util::randomize_rng();
+    int log2 = ceph::util::generate_random_number(18) + 1;
+    int size = ceph::util::generate_random_number(1 << log2) + 1;
 
     char test[size];
     for (int i=0; i<size; ++i)
-      test[i] = rand()%256;
+      test[i] = ceph::util::generate_random_number(256);
     bufferlist in, out;
     in.append(test, size);
 
@@ -456,16 +460,16 @@ TEST(ZlibCompressor, isal_compress_zlib_decompress_walk)
 
   for (int cnt=0; cnt<100; cnt++)
   {
-    srand(cnt + 1000);
-    int log2 = (rand()%18) + 1;
-    int size = (rand() % (1 << log2)) + 1;
+    ceph::util::randomize_rng();
+    int log2 = ceph::util::generate_random_number(18) + 1;
+    int size = ceph::util::generate_random_number(1 << log2) + 1;
 
     int range = 1;
 
     char test[size];
-    test[0] = rand()%256;
+    test[0] = ceph::util::generate_random_number(256);
     for (int i=1; i<size; ++i)
-      test[i] = test[i-1] + rand()%(range*2+1) - range;
+      test[i] = test[i-1] + ceph::util::generate_random_number(range*2+1) - range;
     bufferlist in, out;
     in.append(test, size);
 

--- a/src/test/confutils.cc
+++ b/src/test/confutils.cc
@@ -11,20 +11,25 @@
  * Foundation.  See file COPYING.
  *
  */
+
+#include <cerrno>
+#include <iostream>
+#include <cstdlib>
+#include <sstream>
+#include <cstdint>
+#include <sys/stat.h>
+#include <sys/types.h>
+
 #include "common/ConfUtils.h"
 #include "common/config.h"
 #include "common/errno.h"
-#include "gtest/gtest.h"
-#include "include/buffer.h"
 
-#include <errno.h>
-#include <iostream>
-#include <stdlib.h>
-#include <sstream>
-#include <stdint.h>
-#include <sys/stat.h>
-#include <sys/types.h>
+#include "gtest/gtest.h"
+
+#include "include/util.h"
+#include "include/buffer.h"
 #include "include/memory.h"
+#include "include/random.h"
 
 using ceph::bufferlist;
 using std::cerr;
@@ -44,9 +49,9 @@ static std::string get_temp_dir()
     const char *tmpdir = getenv("TMPDIR");
     if (!tmpdir)
       tmpdir = "/tmp";
-    srand(time(NULL));
+    ceph::util::randomize_rng();
     ostringstream oss;
-    oss << tmpdir << "/confutils_test_dir." << rand() << "." << getpid();
+    oss << tmpdir << "/confutils_test_dir." << ceph::util::generate_random_number() << "." << getpid();
     umask(022);
     int res = mkdir(oss.str().c_str(), 01777);
     if (res) {

--- a/src/test/crush/crush.cc
+++ b/src/test/crush/crush.cc
@@ -8,16 +8,18 @@
  * LGPL2.1 (see COPYING-LGPL2.1) or later
  */
 
+#include <set>
 #include <iostream>
 #include <memory>
+
 #include <gtest/gtest.h>
 
+#include "include/util.h"
+#include "include/random.h"
 #include "include/stringify.h"
 
 #include "crush/CrushWrapper.h"
 #include "osd/osd_types.h"
-
-#include <set>
 
 std::unique_ptr<CrushWrapper> build_indep_map(CephContext *cct, int num_rack,
                               int num_host, int num_osd)
@@ -564,7 +566,7 @@ TEST(CRUSH, straw2_reweight) {
   EXPECT_EQ(0, rule0);
 
   int changed = 1;
-  weights[changed] = weights[changed] / 10 * (rand() % 10);
+  weights[changed] = weights[changed] / 10 * ceph::util::generate_random_number(10);
 
   string root_name1("root1");
   int root1;
@@ -602,7 +604,6 @@ TEST(CRUSH, straw2_reweight) {
     ASSERT_EQ(1u, out1.size());
 
     sum[out1[0]]++;
-    //sum[rand()%n]++;
 
     if (out1[0] == changed) {
       ASSERT_EQ(changed, out0[0]);

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -315,7 +315,7 @@ int ErasureCodeBench::decode()
       for (int j = 0; j < erasures; j++) {
 	int erasure;
 	do {
-	  erasure = ceph::util::generate_random_number(k + m);
+	  erasure = ceph::util::generate_random_number((k + m) - 1);
 	} while(chunks.count(erasure) == 0);
 	chunks.erase(erasure);
       }

--- a/src/test/erasure-code/ceph_erasure_code_benchmark.cc
+++ b/src/test/erasure-code/ceph_erasure_code_benchmark.cc
@@ -29,7 +29,11 @@
 #include "common/ceph_argparse.h"
 #include "common/config.h"
 #include "common/Clock.h"
+
+#include "include/util.h"
 #include "include/utime.h"
+#include "include/random.h"
+
 #include "erasure-code/ErasureCodePlugin.h"
 #include "erasure-code/ErasureCode.h"
 #include "ceph_erasure_code_benchmark.h"
@@ -311,7 +315,7 @@ int ErasureCodeBench::decode()
       for (int j = 0; j < erasures; j++) {
 	int erasure;
 	do {
-	  erasure = rand() % ( k + m );
+	  erasure = ceph::util::generate_random_number(k + m);
 	} while(chunks.count(erasure) == 0);
 	chunks.erase(erasure);
       }

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -174,7 +174,7 @@ int ErasureCodeNonRegression::run_create()
   unsigned payload_chunk_size = 37;
   string payload;
   for (unsigned j = 0; j < payload_chunk_size; ++j)
-    payload.push_back('a' + ceph::util::generate_random_number(26));
+    payload.push_back('a' + ceph::util::generate_random_number(26 - 1));
   bufferlist in;
   for (unsigned j = 0; j < stripe_width; j += payload_chunk_size)
     in.append(payload);

--- a/src/test/erasure-code/ceph_erasure_code_non_regression.cc
+++ b/src/test/erasure-code/ceph_erasure_code_non_regression.cc
@@ -32,6 +32,9 @@
 #include "common/config.h"
 #include "erasure-code/ErasureCodePlugin.h"
 
+#include "include/util.h"
+#include "include/random.h"
+
 namespace po = boost::program_options;
 using namespace std;
 
@@ -171,7 +174,7 @@ int ErasureCodeNonRegression::run_create()
   unsigned payload_chunk_size = 37;
   string payload;
   for (unsigned j = 0; j < payload_chunk_size; ++j)
-    payload.push_back('a' + (rand() % 26));
+    payload.push_back('a' + ceph::util::generate_random_number(26));
   bufferlist in;
   for (unsigned j = 0; j < stripe_width; j += payload_chunk_size)
     in.append(payload);

--- a/src/test/kv_store_bench.cc
+++ b/src/test/kv_store_bench.cc
@@ -11,7 +11,7 @@
 #include "include/rados/librados.hpp"
 #include "test/omap_bench.h"
 #include "common/ceph_argparse.h"
-
+#include "include/random.h"
 
 #include <string>
 #include <climits>
@@ -59,7 +59,7 @@ KvStoreBench::~KvStoreBench()
 int KvStoreBench::setup(int argc, const char** argv) {
   vector<const char*> args;
   argv_to_vec(argc,argv,args);
-  srand(time(NULL));
+  ceph::util::randomize_rng();
 
   stringstream help;
   help
@@ -145,7 +145,7 @@ int KvStoreBench::setup(int argc, const char** argv) {
       } else if (strcmp(args[i], "--name") == 0) {
 	client_name = args[i+1];
       } else if (strcmp(args[i], "-r") == 0) {
-	srand(atoi(args[i+1]));
+	this->rng.seed(atoi(args[i+1]));
       }
     } else if (strcmp(args[i], "--verbosity-on") == 0) {
       verbose = true;
@@ -218,7 +218,7 @@ string KvStoreBench::random_string(int len) {
       "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
       "abcdefghijklmnopqrstuvwxyz";
   for (int i = 0; i < len; ++i) {
-    ret.push_back(alphanum[rand() % (alphanum.size() - 1)]);
+    ret.push_back(alphanum[rng(alphanum.size() - 1)]);
   }
 
   return ret;
@@ -372,7 +372,7 @@ int KvStoreBench::test_teuthology_aio(next_gen_t distr,
 	<< ops << std::endl;
     timed_args * cb_args = new timed_args(this);
     pair<string, bufferlist> kv;
-    int random = (rand() % 100);
+    int random = rng(100);
     cb_args->op = probs.lower_bound(random)->second;
     switch (cb_args->op) {
     case 'i':
@@ -452,7 +452,7 @@ int KvStoreBench::test_teuthology_sync(next_gen_t distr,
     cout << "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t" << i + 1 << " / "
 	<< ops << std::endl;
     pair<string, bufferlist> kv;
-    int random = (rand() % 100);
+    int random = rng(100);
     d.first = probs.lower_bound(random)->second;
     switch (d.first) {
     case 'i':

--- a/src/test/kv_store_bench.h
+++ b/src/test/kv_store_bench.h
@@ -26,6 +26,8 @@
 #include <cfloat>
 #include <iostream>
 
+#include "include/random.h"
+
 using namespace std;
 using ceph::bufferlist;
 
@@ -121,6 +123,7 @@ protected:
   Cond op_avail;//signaled when an op completes
   int ops_in_flight;//number of operations currently in progress
   Mutex ops_in_flight_lock;
+  ceph::util::random_number_generator<int> rng;
   //these are used for cleanup and setup purposes - they are NOT passed to kvs!
   librados::Rados rados;
   string rados_id;

--- a/src/test/libcephfs/access.cc
+++ b/src/test/libcephfs/access.cc
@@ -12,28 +12,35 @@
  *
  */
 
+#include <vector>
+#include <cerrno>
+#include <iostream>
+
+#include <fcntl.h>
+#include <dirent.h>
+#include <unistd.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/xattr.h>
+#include <sys/uio.h>
+
 #include "gtest/gtest.h"
+
 #include "common/ceph_argparse.h"
+
+#include "include/random.h"
 #include "include/buffer.h"
 #include "include/stringify.h"
 #include "include/cephfs/libcephfs.h"
 #include "include/rados/librados.h"
-#include <errno.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <dirent.h>
-#include <sys/xattr.h>
-#include <sys/uio.h>
-#include <iostream>
-#include <vector>
+#include "include/util.h"
+
 #include "json_spirit/json_spirit.h"
 
 #ifdef __linux__
 #include <limits.h>
 #endif
-
 
 rados_t cluster;
 
@@ -72,12 +79,12 @@ int do_mon_command(string s, string *key)
 
 string get_unique_dir()
 {
-  return string("/ceph_test_libcephfs_access.") + stringify(rand());
+  return string("/ceph_test_libcephfs_access.") + stringify(ceph::util::generate_random_number());
 }
 
 TEST(AccessTest, Foo) {
   string dir = get_unique_dir();
-  string user = "libcephfs_foo_test." + stringify(rand());
+  string user = "libcephfs_foo_test." + stringify(ceph::util::generate_random_number());
   // admin mount to set up test
   struct ceph_mount_info *admin;
   ASSERT_EQ(0, ceph_create(&admin, NULL));
@@ -111,7 +118,7 @@ TEST(AccessTest, Foo) {
 TEST(AccessTest, Path) {
   string good = get_unique_dir();
   string bad = get_unique_dir();
-  string user = "libcephfs_path_test." + stringify(rand());
+  string user = "libcephfs_path_test." + stringify(ceph::util::generate_random_number());
   struct ceph_mount_info *admin;
   ASSERT_EQ(0, ceph_create(&admin, NULL));
   ASSERT_EQ(0, ceph_conf_read_file(admin, NULL));
@@ -197,7 +204,7 @@ TEST(AccessTest, Path) {
 TEST(AccessTest, ReadOnly) {
   string dir = get_unique_dir();
   string dir2 = get_unique_dir();
-  string user = "libcephfs_readonly_test." + stringify(rand());
+  string user = "libcephfs_readonly_test." + stringify(ceph::util::generate_random_number());
   struct ceph_mount_info *admin;
   ASSERT_EQ(0, ceph_create(&admin, NULL));
   ASSERT_EQ(0, ceph_conf_read_file(admin, NULL));
@@ -240,7 +247,7 @@ TEST(AccessTest, ReadOnly) {
 
 TEST(AccessTest, User) {
   string dir = get_unique_dir();
-  string user = "libcephfs_user_test." + stringify(rand());
+  string user = "libcephfs_user_test." + stringify(ceph::util::generate_random_number());
 
   // admin mount to set up test
   struct ceph_mount_info *admin;
@@ -366,8 +373,6 @@ int main(int argc, char **argv)
     exit(1);
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  srand(getpid());
 
   r = rados_create(&cluster, NULL);
   if (r < 0)

--- a/src/test/libcephfs/main.cc
+++ b/src/test/libcephfs/main.cc
@@ -14,6 +14,8 @@
  */
 
 #include "gtest/gtest.h"
+
+#include "include/random.h"
 #include "include/cephfs/libcephfs.h"
 
 static int update_root_mode()
@@ -42,8 +44,6 @@ int main(int argc, char **argv)
     exit(1);
 
   ::testing::InitGoogleTest(&argc, argv);
-
-  srand(getpid());
 
   return RUN_ALL_TESTS();
 }

--- a/src/test/libcephfs/test.cc
+++ b/src/test/libcephfs/test.cc
@@ -12,27 +12,30 @@
  *
  */
 
-#include "gtest/gtest.h"
-#include "include/cephfs/libcephfs.h"
-#include "include/stat.h"
-#include <errno.h>
+
+#include <map>
+#include <vector>
+#include <cerrno>
+#include <thread>
+#include <climits>
+
 #include <fcntl.h>
 #include <unistd.h>
+#include <dirent.h>
+
 #include <sys/types.h>
 #include <sys/stat.h>
-#include <dirent.h>
 #include <sys/xattr.h>
 #include <sys/uio.h>
 #include <sys/time.h>
 #include <sys/resource.h>
 
-#ifdef __linux__
-#include <limits.h>
-#endif
+#include "include/util.h"
+#include "include/stat.h"
+#include "include/random.h"
+#include "include/cephfs/libcephfs.h"
 
-#include <map>
-#include <vector>
-#include <thread>
+#include "gtest/gtest.h"
 
 TEST(LibCephFS, OpenEmptyComponent) {
 
@@ -285,7 +288,7 @@ TEST(LibCephFS, DirLs) {
 
   // insert files into directory and test open
   char bazstr[256];
-  int i = 0, r = rand() % 4096;
+  int i = 0, r = ceph::util::generate_random_number(4096);
   if (getenv("LIBCEPHFS_RAND")) {
     r = atoi(getenv("LIBCEPHFS_RAND"));
   }

--- a/src/test/librados/misc.cc
+++ b/src/test/librados/misc.cc
@@ -1,26 +1,34 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
-#include "gtest/gtest.h"
 
-#include "mds/mdstypes.h"
+#include <map>
+#include <regex>
+#include <string>
+#include <cerrno>
+#include <sstream>
+
+#include <boost/regex.hpp>
+
 #include "include/err.h"
+#include "include/util.h"
+#include "include/random.h"
 #include "include/buffer.h"
 #include "include/rbd_types.h"
 #include "include/rados.h"
 #include "include/rados/librados.h"
 #include "include/rados/librados.hpp"
 #include "include/stringify.h"
+
 #include "common/Checksummer.h"
+
 #include "global/global_context.h"
+
+#include "mds/mdstypes.h"
+
 #include "test/librados/test.h"
 #include "test/librados/TestCase.h"
-#include "gtest/gtest.h"
 
-#include <errno.h>
-#include <map>
-#include <sstream>
-#include <string>
-#include <regex>
+#include "gtest/gtest.h"
 
 using namespace librados;
 using std::map;
@@ -108,7 +116,7 @@ TEST(LibRadosMiscPool, PoolCreationRace) {
   ASSERT_EQ(0, rados_connect(cluster_b));
 
   char poolname[80];
-  snprintf(poolname, sizeof(poolname), "poolrace.%d", rand());
+  snprintf(poolname, sizeof(poolname), "poolrace.%d", ceph::util::generate_random_number());
   rados_pool_create(cluster_a, poolname);
   rados_ioctx_t a, b;
   rados_ioctx_create(cluster_a, poolname, &a);
@@ -117,7 +125,7 @@ TEST(LibRadosMiscPool, PoolCreationRace) {
   rados_ioctx_create2(cluster_b, poolid+1, &b);
 
   char pool2name[80];
-  snprintf(pool2name, sizeof(pool2name), "poolrace2.%d", rand());
+  snprintf(pool2name, sizeof(pool2name), "poolrace2.%d", ceph::util::generate_random_number());
   rados_pool_create(cluster_a, pool2name);
 
   list<rados_completion_t> cls;

--- a/src/test/librbd/object_map/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/object_map/test_mock_RefreshRequest.cc
@@ -10,6 +10,8 @@
 #include "librbd/ObjectMap.h"
 #include "librbd/object_map/RefreshRequest.h"
 #include "librbd/object_map/LockRequest.h"
+#include "include/util.h"
+#include "include/random.h"
 
 namespace librbd {
 
@@ -138,7 +140,7 @@ public:
       mock_image_ctx.layout, mock_image_ctx.image_ctx->size);
     object_map->resize(num_objs);
     for (uint64_t i = 0; i < num_objs; ++i) {
-      (*object_map)[i] = rand() % 3;
+      (*object_map)[i] = ceph::util::generate_random_number(3);
     }
   }
 };

--- a/src/test/librbd/object_map/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/object_map/test_mock_RefreshRequest.cc
@@ -140,7 +140,7 @@ public:
       mock_image_ctx.layout, mock_image_ctx.image_ctx->size);
     object_map->resize(num_objs);
     for (uint64_t i = 0; i < num_objs; ++i) {
-      (*object_map)[i] = ceph::util::generate_random_number(3);
+      (*object_map)[i] = ceph::util::generate_random_number(2);
     }
   }
 };

--- a/src/test/librbd/test_librbd.cc
+++ b/src/test/librbd/test_librbd.cc
@@ -43,8 +43,6 @@
 #include "test/librados/test.h"
 #include "test/librbd/test_support.h"
 #include "common/event_socket.h"
-
-#include "include/random.h"
 #include "include/interval_set.h"
 #include "include/stringify.h"
 
@@ -67,11 +65,6 @@ using std::chrono::seconds;
   } while(0)
 
 void register_test_librbd() {
-}
-
-char random_char()
-{
- return ceph::util::generate_random_number(126 - 33) + static_cast<char>(33);
 }
 
 static int get_features(bool *old_format, uint64_t *features)
@@ -1900,7 +1893,7 @@ TEST_F(TestLibRBD, TestIO)
   uint64_t mismatch_offset;
 
   for (i = 0; i < TEST_IO_SIZE; ++i) {
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   }
   test_data[TEST_IO_SIZE] = '\0';
   memset(zero_data, 0, sizeof(zero_data));
@@ -2021,7 +2014,7 @@ TEST_F(TestLibRBD, TestIOWithIOHint)
   uint64_t mismatch_offset;
 
   for (i = 0; i < TEST_IO_SIZE; ++i) {
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   }
   test_data[TEST_IO_SIZE] = '\0';
   memset(zero_data, 0, sizeof(zero_data));
@@ -2183,7 +2176,7 @@ TEST_F(TestLibRBD, TestDataPoolIO)
   int i;
 
   for (i = 0; i < TEST_IO_SIZE; ++i) {
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   }
   test_data[TEST_IO_SIZE] = '\0';
   memset(zero_data, 0, sizeof(zero_data));
@@ -2596,7 +2589,7 @@ TEST_F(TestLibRBD, TestIOPP)
     uint64_t mismatch_offset;
 
     for (i = 0; i < TEST_IO_SIZE; ++i) {
-      test_data[i] = random_char();
+      test_data[i] = (char) (rand() % (126 - 33) + 33);
     }
     test_data[TEST_IO_SIZE] = '\0';
     memset(zero_data, 0, sizeof(zero_data));
@@ -2685,7 +2678,7 @@ TEST_F(TestLibRBD, TestIOPPWithIOHint)
     int i;
 
     for (i = 0; i < TEST_IO_SIZE; ++i) {
-      test_data[i] = random_char();
+      test_data[i] = (char) (rand() % (126 - 33) + 33);
     }
     memset(zero_data, 0, sizeof(zero_data));
 
@@ -3114,152 +3107,6 @@ TEST_F(TestLibRBD, TestClone2)
   ASSERT_EQ(0, rbd_close(child));
   ASSERT_EQ(0, rbd_close(parent));
   rados_ioctx_destroy(ioctx);
-}
-
-TEST_F(TestLibRBD, TestCoR)
-{
-  std::string config_value;
-  ASSERT_EQ(0, _rados.conf_get("rbd_clone_copy_on_read", config_value));
-  if (config_value == "false") {
-    std::cout << "SKIPPING due to disabled rbd_copy_on_read" << std::endl;
-    return;
-  }
-
-  rados_ioctx_t ioctx;
-  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
-
-  int features = RBD_FEATURE_LAYERING;
-  rbd_image_t parent, child;
-  int order = 12; // smallest object size is 4K
-  const uint64_t image_size = 4<<20;
-  const int object_size = 1<<12;
-  const int object_num = image_size / object_size;
-  map<uint64_t, uint64_t> write_tracker;
-  set<string> obj_checker;
-  rbd_image_info_t p_info, c_info;
-  rados_list_ctx_t list_ctx;
-  const char *entry;
-
-  // make a parent to clone from
-  ASSERT_EQ(0, create_image_full(ioctx, "parent", image_size, &order, false, features));
-  ASSERT_EQ(0, rbd_open(ioctx, "parent", &parent, NULL));
-  printf("made parent image \"parent\": %ldK (%d * %dK)\n",
-         (unsigned long)image_size, object_num, object_size/1024);
-
-  // write something into parent
-  char test_data[TEST_IO_SIZE + 1];
-  char zero_data[TEST_IO_SIZE + 1];
-  int i;
-  int count = 0;
-
-  for (i = 0; i < TEST_IO_SIZE; ++i) 
-    test_data[i] = random_char();
-  test_data[TEST_IO_SIZE] = '\0';
-  memset(zero_data, 0, sizeof(zero_data));
-
-  // generate a random map which covers every objects with random offset
-  while (count < 100) {
-    uint64_t ono = ceph::util::generate_random_number(object_num);
-    if (write_tracker.find(ono) == write_tracker.end()) {
-      uint64_t offset = ceph::util::generate_random_number(object_size - TEST_IO_SIZE);
-      write_tracker.insert(pair<uint64_t, uint64_t>(ono, offset));
-      count++;
-    }
-  }
-
-  printf("generated random write map:\n");
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-       itr != write_tracker.end(); ++itr)
-    printf("\t [%-8ld, %-8ld]\n",
-	   (unsigned long)itr->first, (unsigned long)itr->second);
-
-  printf("write data based on random map\n");
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-       itr != write_tracker.end(); ++itr) {
-    printf("\twrite object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(write_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-         itr != write_tracker.end(); ++itr) {
-    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(read_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  // find out what objects the parent image has generated
-  ASSERT_EQ(0, rbd_stat(parent, &p_info, sizeof(p_info)));
-
-  int64_t data_pool_id = rbd_get_data_pool_id(parent);
-  rados_ioctx_t d_ioctx;
-  rados_ioctx_create2(_cluster, data_pool_id, &d_ioctx);
-
-  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
-  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
-    if (strstr(entry, p_info.block_name_prefix)) {
-      const char *block_name_suffix = entry + strlen(p_info.block_name_prefix) + 1;
-      obj_checker.insert(block_name_suffix);
-    }
-  }
-  rados_nobjects_list_close(list_ctx);
-  ASSERT_EQ(obj_checker.size(), write_tracker.size());
-
-  // create a snapshot, reopen as the parent we're interested in and protect it
-  ASSERT_EQ(0, rbd_snap_create(parent, "parent_snap"));
-  ASSERT_EQ(0, rbd_close(parent));
-  ASSERT_EQ(0, rbd_open(ioctx, "parent", &parent, "parent_snap"));
-  ASSERT_EQ(0, rbd_snap_protect(parent, "parent_snap"));
-  ASSERT_PASSED(validate_object_map, parent);
-  ASSERT_EQ(0, rbd_close(parent));
-  printf("made snapshot \"parent@parent_snap\" and protect it\n");
-
-  // create a copy-on-read clone and open it
-  ASSERT_EQ(0, rbd_clone(ioctx, "parent", "parent_snap", ioctx, "child",
-	    features, &order));
-  ASSERT_EQ(0, rbd_open(ioctx, "child", &child, NULL));
-  printf("made and opened clone \"child\"\n");
-
-  printf("read from \"child\"\n");
-  {
-    map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(read_test_data, child, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-       itr != write_tracker.end(); ++itr) {
-    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(read_test_data, child, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  printf("read again reversely\n");
-  for (map<uint64_t, uint64_t>::iterator itr = --write_tracker.end();
-     itr != write_tracker.begin(); --itr) {
-    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(read_test_data, child, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  // close child to flush all copy-on-read
-  ASSERT_EQ(0, rbd_close(child));
-
-  printf("check whether child image has the same set of objects as parent\n");
-  ASSERT_EQ(0, rbd_open(ioctx, "child", &child, NULL));
-  ASSERT_EQ(0, rbd_stat(child, &c_info, sizeof(c_info)));
-  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
-  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
-    if (strstr(entry, c_info.block_name_prefix)) {
-      const char *block_name_suffix = entry + strlen(c_info.block_name_prefix) + 1;
-      set<string>::iterator it = obj_checker.find(block_name_suffix);
-      ASSERT_TRUE(it != obj_checker.end());
-      obj_checker.erase(it);
-    }
-  }
-  rados_nobjects_list_close(list_ctx);
-  ASSERT_TRUE(obj_checker.empty());
-  ASSERT_PASSED(validate_object_map, child);
-  ASSERT_EQ(0, rbd_close(child));
-
-  rados_ioctx_destroy(ioctx);
-  rados_ioctx_destroy(d_ioctx);
 }
 
 static void test_list_children(rbd_image_t image, ssize_t num_expected, ...)
@@ -3791,13 +3638,13 @@ TEST_F(TestLibRBD, FlushAio)
   char test_data[TEST_IO_SIZE + 1];
   size_t i;
   for (i = 0; i < TEST_IO_SIZE; ++i) {
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   }
 
   rbd_completion_t write_comps[num_aios];
   for (i = 0; i < num_aios; ++i) {
     ASSERT_EQ(0, rbd_aio_create_completion(NULL, NULL, &write_comps[i]));
-    uint64_t offset = ceph::util::generate_random_number(size - TEST_IO_SIZE);
+    uint64_t offset = rand() % (size - TEST_IO_SIZE);
     ASSERT_EQ(0, rbd_aio_write(image, offset, TEST_IO_SIZE, test_data,
 			       write_comps[i]));
   }
@@ -3839,7 +3686,7 @@ TEST_F(TestLibRBD, FlushAioPP)
     char test_data[TEST_IO_SIZE + 1];
     size_t i;
     for (i = 0; i < TEST_IO_SIZE; ++i) {
-      test_data[i] = random_char();
+      test_data[i] = (char) (rand() % (126 - 33) + 33);
     }
     test_data[TEST_IO_SIZE] = '\0';
 
@@ -3848,7 +3695,7 @@ TEST_F(TestLibRBD, FlushAioPP)
     for (i = 0; i < num_aios; ++i) {
       bls[i].append(test_data, strlen(test_data));
       write_comps[i] = new librbd::RBD::AioCompletion(NULL, NULL);
-      uint64_t offset = ceph::util::generate_random_number(size - TEST_IO_SIZE);
+      uint64_t offset = rand() % (size - TEST_IO_SIZE);
       ASSERT_EQ(0, image.aio_write(offset, TEST_IO_SIZE, bls[i],
 				   write_comps[i]));
     }
@@ -3894,9 +3741,9 @@ void scribble(librbd::Image& image, int n, int max, bool skip_discard,
   interval_set<uint64_t> exists_at_start = *exists;
 
   for (int i=0; i<n; i++) {
-    uint64_t off = ceph::util::generate_random_number(size - max + 1);
-    uint64_t len = 1 + ceph::util::generate_random_number(max);
-    if (!skip_discard && ceph::util::generate_random_number(4) == 0) {
+    uint64_t off = rand() % (size - max + 1);
+    uint64_t len = 1 + rand() % max;
+    if (!skip_discard && rand() % 4 == 0) {
       ASSERT_EQ((int)len, image.discard(off, len));
       interval_set<uint64_t> w;
       w.insert(off, len);
@@ -4509,14 +4356,14 @@ TEST_F(TestLibRBD, TestPendingAio)
 
   char test_data[TEST_IO_SIZE];
   for (size_t i = 0; i < TEST_IO_SIZE; ++i) {
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   }
 
   size_t num_aios = 256;
   rbd_completion_t comps[num_aios];
   for (size_t i = 0; i < num_aios; ++i) {
     ASSERT_EQ(0, rbd_aio_create_completion(NULL, NULL, &comps[i]));
-    uint64_t offset = ceph::util::generate_random_number(size - TEST_IO_SIZE);
+    uint64_t offset = rand() % (size - TEST_IO_SIZE);
     ASSERT_EQ(0, rbd_aio_write(image, offset, TEST_IO_SIZE, test_data,
                                comps[i]));
   }
@@ -4528,7 +4375,7 @@ TEST_F(TestLibRBD, TestPendingAio)
 
   for (size_t i = 0; i < num_aios; ++i) {
     ASSERT_EQ(0, rbd_aio_create_completion(NULL, NULL, &comps[i]));
-    uint64_t offset = ceph::util::generate_random_number(size - TEST_IO_SIZE);
+    uint64_t offset = rand() % (size - TEST_IO_SIZE);
     ASSERT_LE(0, rbd_aio_read(image, offset, TEST_IO_SIZE, test_data,
                               comps[i]));
   }
@@ -4587,138 +4434,6 @@ TEST_F(TestLibRBD, Flatten)
   ASSERT_TRUE(bl.contents_equal(read_bl));
 
   ASSERT_PASSED(validate_object_map, clone_image);
-}
-
-TEST_F(TestLibRBD, FlattenNoEmptyObjects)
-{
-  REQUIRE_FEATURE(RBD_FEATURE_LAYERING);
-
-  rados_ioctx_t ioctx;
-  rados_ioctx_create(_cluster, m_pool_name.c_str(), &ioctx);
-
-  librbd::RBD rbd;
-  std::string parent_name = get_temp_image_name();
-  uint64_t size = 4 << 20;
-  int order = 12; // smallest object size is 4K
-
-  bool old_format;
-  uint64_t features;
-  ASSERT_EQ(0, get_features(&old_format, &features));
-  ASSERT_FALSE(old_format);
-
-  // make a parent to clone from
-  ASSERT_EQ(0, create_image_full(ioctx, parent_name.c_str(), size, &order,
-                                 false, features));
-
-  rbd_image_t parent;
-  const int object_size = 1 << order;
-  const int object_num = size / object_size;
-  ASSERT_EQ(0, rbd_open(ioctx, parent_name.c_str(), &parent, NULL));
-  printf("made parent image \"%s\": %ldK (%d * %dK)\n", parent_name.c_str(),
-         (unsigned long)size, object_num, object_size/1024);
-
-  // write something into parent
-  char test_data[TEST_IO_SIZE + 1];
-  char zero_data[TEST_IO_SIZE + 1];
-  int i;
-  for (i = 0; i < TEST_IO_SIZE; ++i)
-    test_data[i] = random_char();
-  test_data[TEST_IO_SIZE] = '\0';
-  memset(zero_data, 0, sizeof(zero_data));
-
-  // generate a random map which covers every objects with random
-  // offset
-  int count = 0;
-  map<uint64_t, uint64_t> write_tracker;
-  while (count < 10) {
-    uint64_t ono = ceph::util::generate_random_number(object_num);
-    if (write_tracker.find(ono) == write_tracker.end()) {
-      uint64_t offset = ceph::util::generate_random_number(object_size - TEST_IO_SIZE);
-      write_tracker.insert(pair<uint64_t, uint64_t>(ono, offset));
-      count++;
-    }
-  }
-
-  printf("generated random write map:\n");
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-       itr != write_tracker.end(); ++itr)
-    printf("\t [%-8ld, %-8ld]\n",
-	   (unsigned long)itr->first, (unsigned long)itr->second);
-
-  printf("write data based on random map\n");
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-       itr != write_tracker.end(); ++itr) {
-    printf("\twrite object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(write_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  for (map<uint64_t, uint64_t>::iterator itr = write_tracker.begin();
-         itr != write_tracker.end(); ++itr) {
-    printf("\tread object-%-4ld\t", (unsigned long)itr->first);
-    ASSERT_PASSED(read_test_data, parent, test_data, itr->first * object_size + itr->second, TEST_IO_SIZE, 0);
-  }
-
-  // find out what objects the parent image has generated
-  rbd_image_info_t p_info;
-  ASSERT_EQ(0, rbd_stat(parent, &p_info, sizeof(p_info)));
-
-  int64_t data_pool_id = rbd_get_data_pool_id(parent);
-  rados_ioctx_t d_ioctx;
-  rados_ioctx_create2(_cluster, data_pool_id, &d_ioctx);
-
-  const char *entry;
-  set<string> obj_checker;
-  rados_list_ctx_t list_ctx;
-  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
-  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
-    if (strstr(entry, p_info.block_name_prefix)) {
-      const char *block_name_suffix = entry + strlen(p_info.block_name_prefix) + 1;
-      obj_checker.insert(block_name_suffix);
-    }
-  }
-  rados_nobjects_list_close(list_ctx);
-  ASSERT_EQ(obj_checker.size(), write_tracker.size());
-
-  // create a snapshot, reopen as the parent we're interested in and protect it
-  ASSERT_EQ(0, rbd_snap_create(parent, "parent_snap"));
-  ASSERT_EQ(0, rbd_close(parent));
-  ASSERT_EQ(0, rbd_open(ioctx, parent_name.c_str(), &parent, "parent_snap"));
-  ASSERT_EQ(0, rbd_snap_protect(parent, "parent_snap"));
-  ASSERT_PASSED(validate_object_map, parent);
-  ASSERT_EQ(0, rbd_close(parent));
-  printf("made snapshot and protected: \"%s@parent_snap\"\n", parent_name.c_str());
-
-  std::string child_name = get_temp_image_name();
-  // create a copy-on-read clone and open it
-  ASSERT_EQ(0, rbd_clone(ioctx, parent_name.c_str(), "parent_snap", ioctx,
-                         child_name.c_str(), features, &order));
-
-  rbd_image_t child;
-  ASSERT_EQ(0, rbd_open(ioctx, child_name.c_str(), &child, NULL));
-  printf("made and opened clone \"%s\"\n", child_name.c_str());
-
-  printf("flattening clone: \"%s\"\n", child_name.c_str());
-  ASSERT_EQ(0, rbd_flatten(child));
-
-  printf("check whether child image has the same set of objects as parent\n");
-  rbd_image_info_t c_info;
-  ASSERT_EQ(0, rbd_stat(child, &c_info, sizeof(c_info)));
-  ASSERT_EQ(0, rados_nobjects_list_open(d_ioctx, &list_ctx));
-  while (rados_nobjects_list_next(list_ctx, &entry, NULL, NULL) != -ENOENT) {
-    if (strstr(entry, c_info.block_name_prefix)) {
-      const char *block_name_suffix = entry + strlen(c_info.block_name_prefix) + 1;
-      set<string>::iterator it = obj_checker.find(block_name_suffix);
-      ASSERT_TRUE(it != obj_checker.end());
-      obj_checker.erase(it);
-    }
-  }
-  rados_nobjects_list_close(list_ctx);
-  ASSERT_TRUE(obj_checker.empty());
-  ASSERT_PASSED(validate_object_map, child);
-  ASSERT_EQ(0, rbd_close(child));
-
-  rados_ioctx_destroy(ioctx);
-  rados_ioctx_destroy(d_ioctx);
 }
 
 TEST_F(TestLibRBD, SnapshotLimit)
@@ -6277,7 +5992,7 @@ TEST_F(TestLibRBD, ImagePollIO)
   int i;
 
   for (i = 0; i < TEST_IO_SIZE; ++i)
-    test_data[i] = random_char();
+    test_data[i] = (char) (rand() % (126 - 33) + 33);
   test_data[TEST_IO_SIZE] = '\0';
   memset(zero_data, 0, sizeof(zero_data));
 
@@ -6556,7 +6271,7 @@ TEST_F(TestLibRBD, ExclusiveLock)
 	  lock_guard<mutex> locker(lock);
 	  owner_id = m_id;
 	}
-	usleep(ceph::util::generate_random_number(50000));
+	usleep(rand() % 50000);
       }
 
       lock_guard<mutex> locker(lock);

--- a/src/test/msgr/test_msgr.cc
+++ b/src/test/msgr/test_msgr.cc
@@ -30,6 +30,7 @@
 #include "msg/Connection.h"
 #include "messages/MPing.h"
 #include "messages/MCommand.h"
+#include "include/random.h"
 
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
@@ -1185,7 +1186,7 @@ TEST_P(MessengerTest, SyntheticStressTest) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 1000 + 500);
+      usleep(ceph::util::generate_random_number(1000) + 500);
     }
   }
   test_msg.wait_for_done();
@@ -1214,7 +1215,7 @@ TEST_P(MessengerTest, SyntheticStressTest1) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 1000 + 500);
+      usleep(ceph::util::generate_random_number(1000) + 500);
     }
   }
   test_msg.wait_for_done();
@@ -1248,7 +1249,7 @@ TEST_P(MessengerTest, SyntheticInjectTest) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 500 + 100);
+      usleep(ceph::util::generate_random_number(500) + 100);
     }
   }
   test_msg.wait_for_done();
@@ -1283,7 +1284,7 @@ TEST_P(MessengerTest, SyntheticInjectTest2) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 500 + 100);
+      usleep(ceph::util::generate_random_number(500) + 100);
     }
   }
   test_msg.wait_for_done();
@@ -1316,7 +1317,7 @@ TEST_P(MessengerTest, SyntheticInjectTest3) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 500 + 100);
+      usleep(ceph::util::generate_random_number(500) + 100);
     }
   }
   test_msg.wait_for_done();
@@ -1353,7 +1354,7 @@ TEST_P(MessengerTest, SyntheticInjectTest4) {
     } else if (val > 10) {
       test_msg.send_message();
     } else {
-      usleep(rand() % 500 + 100);
+      usleep(ceph::util::generate_random_number(500) + 100);
     }
   }
   test_msg.wait_for_done();
@@ -1403,7 +1404,7 @@ class MarkdownDispatcher : public Dispatcher {
     }
 
     last_mark = true;
-    usleep(rand() % 500);
+    usleep(ceph::util::generate_random_number(500));
     for (set<ConnectionRef>::iterator it = conns.begin(); it != conns.end(); ++it) {
       if ((*it) != m->get_connection().get()) {
         (*it)->mark_down();
@@ -1420,7 +1421,7 @@ class MarkdownDispatcher : public Dispatcher {
     lderr(g_ceph_context) << __func__ << " " << con << dendl;
     Mutex::Locker l(lock);
     conns.erase(con);
-    usleep(rand() % 500);
+    usleep(ceph::util::generate_random_number(500));
     return true;
   }
   void ms_handle_remote_reset(Connection *con) override {

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -413,7 +413,7 @@ TEST(BitAllocator, test_bmap_alloc)
     g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", val.str());
 
     // choose randomized span_size
-    int64_t span_size = 512ull << ceph::util::generate_random_number(4);
+    int64_t span_size = 512ull << ceph::util::generate_random_number(3);
     val.str("");
     val << span_size;
     g_conf->set_val("bluestore_bitmapallocator_span_size", val.str());

--- a/src/test/objectstore/BitAllocator_test.cc
+++ b/src/test/objectstore/BitAllocator_test.cc
@@ -5,12 +5,17 @@
  * Author: Ramesh Chander, Ramesh.Chander@sandisk.com
  */
 
-#include "include/Context.h"
-#include "os/bluestore/BitAllocator.h"
-#include <stdio.h>
-#include <assert.h>
-#include <math.h>
+#include <cmath>
+#include <cstdio>
+#include <cassert>
 #include <sstream>
+
+#include "include/util.h"
+#include "include/random.h"
+#include "include/Context.h"
+
+#include "os/bluestore/BitAllocator.h"
+
 #include <gtest/gtest.h>
 
 
@@ -408,7 +413,7 @@ TEST(BitAllocator, test_bmap_alloc)
     g_conf->set_val("bluestore_bitmapallocator_blocks_per_zone", val.str());
 
     // choose randomized span_size
-    int64_t span_size = 512ull << (rand() % 4);
+    int64_t span_size = 512ull << ceph::util::generate_random_number(4);
     val.str("");
     val << span_size;
     g_conf->set_val("bluestore_bitmapallocator_span_size", val.str());

--- a/src/test/objectstore/FileStoreTracker.cc
+++ b/src/test/objectstore/FileStoreTracker.cc
@@ -1,10 +1,16 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include "FileStoreTracker.h"
-#include <stdlib.h>
+
+#include <cstdlib>
 #include <iostream>
+
 #include <boost/scoped_ptr.hpp>
+
+#include "include/random.h"
 #include "include/Context.h"
+
 #include "common/Mutex.h"
+
+#include "FileStoreTracker.h"
 
 class OnApplied : public Context {
   FileStoreTracker *tracker;
@@ -87,10 +93,10 @@ void FileStoreTracker::write(const pair<coll_t, string> &obj,
   std::cerr << "Writing " << obj << std::endl;
   ObjectContents contents = get_current_content(obj);
 
-  uint64_t offset = rand() % (SIZE/2);
-  uint64_t len = rand() % (SIZE/2);
+  uint64_t offset = ceph::util::generate_random_number(SIZE/2);
+  uint64_t len = ceph::util::generate_random_number(SIZE/2);
   if (!len) len = 10;
-  contents.write(rand(), offset, len);
+  contents.write(ceph::util::generate_random_number(), offset, len);
 
   bufferlist to_write;
   ObjectContents::Iterator iter = contents.get_iterator();
@@ -140,8 +146,8 @@ void FileStoreTracker::clone_range(const pair<coll_t, string> &from,
 
   uint64_t new_size = from_contents.size();
   interval_set<uint64_t> interval_to_clone;
-  uint64_t offset = rand() % (new_size/2);
-  uint64_t len = rand() % (new_size/2);
+  uint64_t offset = ceph::util::generate_random_number(new_size/2);
+  uint64_t len = ceph::util::generate_random_number(new_size/2);
   if (!len) len = 10;
   interval_to_clone.insert(offset, len);
   to_contents.clone_range(from_contents, interval_to_clone);

--- a/src/test/objectstore/FileStoreTracker.cc
+++ b/src/test/objectstore/FileStoreTracker.cc
@@ -93,8 +93,8 @@ void FileStoreTracker::write(const pair<coll_t, string> &obj,
   std::cerr << "Writing " << obj << std::endl;
   ObjectContents contents = get_current_content(obj);
 
-  uint64_t offset = ceph::util::generate_random_number(SIZE/2);
-  uint64_t len = ceph::util::generate_random_number(SIZE/2);
+  uint64_t offset = ceph::util::generate_random_number((SIZE/2) - 1);
+  uint64_t len = ceph::util::generate_random_number((SIZE/2) - 1);
   if (!len) len = 10;
   contents.write(ceph::util::generate_random_number(), offset, len);
 
@@ -146,8 +146,8 @@ void FileStoreTracker::clone_range(const pair<coll_t, string> &from,
 
   uint64_t new_size = from_contents.size();
   interval_set<uint64_t> interval_to_clone;
-  uint64_t offset = ceph::util::generate_random_number(new_size/2);
-  uint64_t len = ceph::util::generate_random_number(new_size/2);
+  uint64_t offset = ceph::util::generate_random_number((new_size/2) - 1);
+  uint64_t len = ceph::util::generate_random_number((new_size/2) - 1);
   if (!len) len = 10;
   interval_to_clone.insert(offset, len);
   to_contents.clone_range(from_contents, interval_to_clone);

--- a/src/test/objectstore/ObjectStoreTransactionBenchmark.cc
+++ b/src/test/objectstore/ObjectStoreTransactionBenchmark.cc
@@ -21,6 +21,8 @@
 
 using namespace std;
 
+#include "include/random.h"
+
 #include "common/ceph_argparse.h"
 #include "common/debug.h"
 #include "common/Cycles.h"
@@ -153,7 +155,9 @@ class PerfCase {
 
   ghobject_t create_object() {
     bufferlist bl = generate_random(100, 1);
-    return ghobject_t(hobject_t(string("obj_")+string(bl.c_str()), string(), rand() & 2 ? CEPH_NOSNAP : rand(), rand() & 0xFF, 0, ""));
+    return ghobject_t(hobject_t(string("obj_")+string(bl.c_str()), string(), 
+                      ceph::util::generate_random_number() & 2 ? CEPH_NOSNAP : ceph::util::generate_random_number(), 
+                      ceph::util::generate_random_number() & 0xFF, 0, ""));
   }
 
 
@@ -166,7 +170,7 @@ class PerfCase {
     for (int i = 0; i < frag; i++ ) {
       bufferptr bp(per_frag);
       for (unsigned int j = 0; j < len; j++) {
-        bp[j] = alphanum[rand() % (sizeof(alphanum) - 1)];
+        bp[j] = alphanum[ceph::util::generate_random_number(sizeof(alphanum) - 1)];
       }
       bl.append(bp);
     }

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -102,7 +102,7 @@ int queue_transaction(
   T &store,
   ObjectStore::CollectionHandle ch,
   ObjectStore::Transaction &&t) {
-  if (ceph::util::generate_random_number(2)) {
+  if (ceph::util::generate_random_number(1)) {
     ObjectStore::Transaction t2;
     t2.append(t);
     return store->queue_transaction(ch, std::move(t2));
@@ -3558,7 +3558,7 @@ public:
     bufferptr bp(size);
     for (unsigned int i = 0; i < size - 1; i++) {
       // severely limit entropy so we can compress...
-      bp[i] = alphanum[ceph::util::generate_random_number(10)]; //(sizeof(alphanum) - 1)];
+      bp[i] = alphanum[ceph::util::generate_random_number(10 - 1)]; //(sizeof(alphanum) - 1)];
     }
     bp[size - 1] = '\0';
 

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -12,46 +12,35 @@
  *
  */
 
-#include <ctime>
-#include <cstdio>
-#include <cstring>
+#include <glob.h>
+#include <stdio.h>
+#include <string.h>
 #include <iostream>
-
+#include <time.h>
+#include <sys/mount.h>
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/binomial_distribution.hpp>
-
-#include <sys/mount.h>
-
-#include <glob.h>
-
-#include "global/global_init.h"
+#include <gtest/gtest.h>
 
 #include "os/ObjectStore.h"
 #include "os/filestore/FileStore.h"
 #if defined(WITH_BLUESTORE)
 #include "os/bluestore/BlueStore.h"
 #endif
-
-#include "include/util.h"
-#include "include/random.h"
 #include "include/Context.h"
-#include "include/stringify.h"
-#include "include/coredumpctl.h"
-#include "include/unordered_map.h"
-
 #include "common/ceph_argparse.h"
+#include "global/global_init.h"
 #include "common/Mutex.h"
 #include "common/Cond.h"
 #include "common/errno.h"
+#include "include/stringify.h"
+#include "include/coredumpctl.h"
 
+#include "include/unordered_map.h"
 #include "store_test_fixture.h"
 
-// Clobber other assert() to use our own:
-#include "include/assert.h"
-
-#include <gtest/gtest.h>
 
 typedef boost::mt11213b gen_type;
 

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1,28 +1,21 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <ctime>
-#include <thread>
-#include <cstdio>
-#include <cstring>
+#include <stdio.h>
+#include <string.h>
 #include <iostream>
-#include <algorithm>
-
+#include <time.h>
 #include <fcntl.h>
 #include <unistd.h>
-
+#include <thread>
 #include "global/global_init.h"
-
-#include "include/random.h"
+#include "common/ceph_argparse.h"
 #include "include/stringify.h"
 #include "include/scope_guard.h"
-
 #include "common/errno.h"
-#include "common/ceph_argparse.h"
+#include <gtest/gtest.h>
 
 #include "os/bluestore/BlueFS.h"
-
-#include <gtest/gtest.h>
 
 string get_temp_bdev(uint64_t size)
 {

--- a/src/test/objectstore/test_bluefs.cc
+++ b/src/test/objectstore/test_bluefs.cc
@@ -1,21 +1,28 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
-#include <stdio.h>
-#include <string.h>
+#include <ctime>
+#include <thread>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
-#include <time.h>
+#include <algorithm>
+
 #include <fcntl.h>
 #include <unistd.h>
-#include <thread>
+
 #include "global/global_init.h"
-#include "common/ceph_argparse.h"
+
+#include "include/random.h"
 #include "include/stringify.h"
 #include "include/scope_guard.h"
+
 #include "common/errno.h"
-#include <gtest/gtest.h>
+#include "common/ceph_argparse.h"
 
 #include "os/bluestore/BlueFS.h"
+
+#include <gtest/gtest.h>
 
 string get_temp_bdev(uint64_t size)
 {

--- a/src/test/objectstore/test_idempotent.cc
+++ b/src/test/objectstore/test_idempotent.cc
@@ -43,7 +43,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = ceph::util::generate_random_number(cont.size());
+  int index = ceph::util::generate_random_number(cont.size() - 1);
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;

--- a/src/test/objectstore/test_idempotent.cc
+++ b/src/test/objectstore/test_idempotent.cc
@@ -14,15 +14,24 @@
 
 #include <iostream>
 #include <sstream>
+
 #include <boost/scoped_ptr.hpp>
-#include "os/filestore/FileStore.h"
+
 #include "global/global_init.h"
+
+#include "include/random.h"
+
 #include "common/ceph_argparse.h"
 #include "common/debug.h"
+
 #include "test/common/ObjectContents.h"
+
 #include "FileStoreTracker.h"
+
 #include "kv/KeyValueDB.h"
+
 #include "os/ObjectStore.h"
+#include "os/filestore/FileStore.h"
 
 void usage(const string &name) {
   std::cerr << "Usage: " << name << " [new|continue] store_path store_journal db_path"
@@ -34,7 +43,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = rand() % cont.size();
+  int index = ceph::util::generate_random_number(cont.size());
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -98,7 +107,7 @@ int main(int argc, char **argv) {
   while (1) {
     FileStoreTracker::Transaction t;
     for (unsigned j = 0; j < 100; ++j) {
-      int val = rand() % 100;
+      int val = ceph::util::generate_random_number(100);
       if (val < 30) {
 	t.write(coll, *rand_choose(objects));
       } else if (val < 60) {

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -251,7 +251,7 @@ void WorkloadGenerator::get_filled_byte_array(bufferlist& bl, size_t size)
   bufferptr bp(size);
   if (false) {
     for (unsigned int i = 0; i < size - 1; i++) {
-      bp[i] = alphanum[ceph::util::generate_random_number(sizeof(alphanum))];
+      bp[i] = alphanum[ceph::util::generate_random_number(sizeof(alphanum) - 1)];
     }
     bp[size - 1] = '\0';
   } else {

--- a/src/test/objectstore/workload_generator.cc
+++ b/src/test/objectstore/workload_generator.cc
@@ -1,0 +1,595 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+/*
+ * Ceph - scalable distributed file system
+ *
+ * Copyright (C) 2012 New Dream Network
+ *
+ * This is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License version 2.1, as published by the Free Software
+ * Foundation.  See file COPYING.
+ */
+
+#include <ctime>
+#include <cstdio>
+#include <cctype>
+#include <cerrno>
+#include <cstring>
+#include <cassert>
+#include <cstdlib>
+#include <iostream>
+
+#include <boost/scoped_ptr.hpp>
+#include <boost/lexical_cast.hpp>
+
+#include <signal.h>
+
+#include <sys/time.h>
+
+#include "os/ObjectStore.h"
+
+#include "common/ceph_argparse.h"
+
+#include "global/global_init.h"
+
+#include "common/debug.h"
+
+#include "workload_generator.h"
+
+#include "TestObjectStoreState.h"
+
+#include "include/util.h"
+#include "include/random.h"
+#include "include/assert.h"
+
+#define dout_context g_ceph_context
+
+static const char *our_name = NULL;
+void usage();
+
+boost::scoped_ptr<WorkloadGenerator> wrkldgen;
+
+#define dout_subsys ceph_subsys_
+
+
+WorkloadGenerator::WorkloadGenerator(vector<const char*> args)
+  : TestObjectStoreState(NULL),
+    m_max_in_flight(def_max_in_flight),
+    m_num_ops(-1),
+    m_destroy_coll_every_nr_runs(def_destroy_coll_every_nr_runs),
+    m_num_colls(def_num_colls),
+    m_write_data_bytes(0), m_write_xattr_obj_bytes(0),
+    m_write_xattr_coll_bytes(0), m_write_pglog_bytes(0),
+    m_suppress_write_data(false), m_suppress_write_xattr_obj(false),
+    m_suppress_write_xattr_coll(false), m_suppress_write_log(false),
+    m_do_stats(false),
+    m_stats_finished_txs(0),
+    m_stats_lock("WorldloadGenerator::m_stats_lock"),
+    m_stats_show_secs(5),
+    m_stats_total_written(0),
+    m_stats_begin()
+{
+  int err = 0;
+
+  m_nr_runs = 0;
+
+  init_args(args);
+  dout(0) << "data            = " << g_conf->osd_data << dendl;
+  dout(0) << "journal         = " << g_conf->osd_journal << dendl;
+  dout(0) << "journal size    = " << g_conf->osd_journal_size << dendl;
+
+  err = ::mkdir(g_conf->osd_data.c_str(), 0755);
+  ceph_assert(err == 0 || (err < 0 && errno == EEXIST));
+  ObjectStore *store_ptr = ObjectStore::create(g_ceph_context,
+                                               g_conf->osd_objectstore,
+                                               g_conf->osd_data,
+                                               g_conf->osd_journal);
+  m_store.reset(store_ptr);
+  err = m_store->mkfs();
+  ceph_assert(err == 0);
+  err = m_store->mount();
+  ceph_assert(err == 0);
+
+  set_max_in_flight(m_max_in_flight);
+  set_num_objs_per_coll(def_num_obj_per_coll);
+
+  init(m_num_colls, 0);
+
+  dout(0) << "#colls          = " << m_num_colls << dendl;
+  dout(0) << "#objs per coll  = " << m_num_objs_per_coll << dendl;
+  dout(0) << "#txs per destr  = " << m_destroy_coll_every_nr_runs << dendl;
+
+}
+
+size_t WorkloadGenerator::_parse_size_or_die(std::string& val)
+{
+  size_t s = 0;
+  int multiplier = 0;
+  size_t i = 0;
+
+  if (val.empty()) // this should never happen, but catch it anyway.
+    goto die;
+
+
+  for (i = 0; i < val.length(); i++) {
+    if (!isdigit(val[i])) {
+      if (isalpha(val[i])) {
+        val[i] = tolower(val[i]);
+        switch (val[i]) {
+        case 'b': break;
+        case 'k': multiplier = 10; break;
+        case 'm': multiplier = 20; break;
+        case 'g': multiplier = 30; break;
+        default:
+          goto die;
+        }
+        val[i] = '\0';
+        break;
+      } else {
+        goto die;
+      }
+    }
+  }
+
+  s = strtoll(val.c_str(), NULL, 10) * (1 << multiplier);
+  return s;
+
+die:
+  usage();
+  exit(1);
+}
+
+void WorkloadGenerator::_suppress_ops_or_die(std::string& val)
+{
+  for (size_t i = 0; i < val.length(); i++) {
+    switch (val[i]) {
+    case 'c': m_suppress_write_xattr_coll = true; break;
+    case 'o': m_suppress_write_xattr_obj = true; break;
+    case 'l': m_suppress_write_log = true; break;
+    case 'd': m_suppress_write_data = true; break;
+    default:
+      usage();
+      exit(1);
+    }
+  }
+}
+
+void WorkloadGenerator::init_args(vector<const char*> args)
+{
+  for (std::vector<const char*>::iterator i = args.begin(); i != args.end();) {
+    string val;
+
+    if (ceph_argparse_double_dash(args, i)) {
+      break;
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-num-colls", (char*) NULL)) {
+      m_num_colls = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-objs-per-coll", (char*) NULL)) {
+      m_num_objs_per_coll = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-destroy-coll-per-N-trans", (char*) NULL)) {
+      m_destroy_coll_every_nr_runs = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-num-ops", (char*) NULL)) {
+      m_num_ops = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-max-in-flight", (char*) NULL)) {
+      m_max_in_flight = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-write-data-size", (char*) NULL)) {
+      m_write_data_bytes = _parse_size_or_die(val);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-write-xattr-obj-size", (char*) NULL)) {
+      m_write_xattr_obj_bytes = _parse_size_or_die(val);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-write-xattr-coll-size", (char*) NULL)) {
+      m_write_xattr_coll_bytes = _parse_size_or_die(val);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-write-pglog-size", (char*) NULL)) {
+      m_write_pglog_bytes = _parse_size_or_die(val);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-suppress-ops", (char*) NULL)) {
+      _suppress_ops_or_die(val);
+    } else if (ceph_argparse_witharg(args, i, &val,
+        "--test-show-stats-period", (char*) NULL)) {
+      m_stats_show_secs = strtoll(val.c_str(), NULL, 10);
+    } else if (ceph_argparse_flag(args, i, "--test-show-stats", (char*) NULL)) {
+      m_do_stats = true;
+    } else if (ceph_argparse_flag(args, i, "--help", (char*) NULL)) {
+      usage();
+      exit(0);
+    }
+  }
+}
+
+int WorkloadGenerator::get_uniform_random_value(int min, int max)
+{
+  boost::uniform_int<> value(min, max);
+  return value(m_rng);
+}
+
+TestObjectStoreState::coll_entry_t *WorkloadGenerator::get_rnd_coll_entry(bool erase = false)
+{
+  int index = get_uniform_random_value(0, m_collections_ids.size()-1);
+  coll_entry_t *entry = get_coll_at(index, erase);
+  return entry;
+}
+
+hobject_t *WorkloadGenerator::get_rnd_obj(coll_entry_t *entry)
+{
+  assert(entry != NULL);
+
+  bool create =
+      (get_uniform_random_value(0,100) < 50 || !entry->m_objects.size());
+
+  if (create && ((int) entry->m_objects.size() < m_num_objs_per_coll)) {
+    return (entry->touch_obj(entry->m_next_object_id++));
+  }
+
+  int idx = get_uniform_random_value(0, entry->m_objects.size()-1);
+  return entry->get_obj_at(idx);
+}
+
+/**
+ * We'll generate a random amount of bytes, ranging from a single byte up to
+ * a couple of MB.
+ */
+size_t WorkloadGenerator::get_random_byte_amount(size_t min, size_t max)
+{
+  size_t diff = max - min;
+  return (size_t) (min + ceph::util::generate_random_number(diff));
+}
+
+void WorkloadGenerator::get_filled_byte_array(bufferlist& bl, size_t size)
+{
+  static const char alphanum[] = "0123456789"
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    "abcdefghijklmnopqrstuvwxyz";
+
+  bufferptr bp(size);
+  if (false) {
+    for (unsigned int i = 0; i < size - 1; i++) {
+      bp[i] = alphanum[ceph::util::generate_random_number(sizeof(alphanum))];
+    }
+    bp[size - 1] = '\0';
+  } else {
+    bp.zero();
+  }
+  bl.append(bp);
+}
+
+void WorkloadGenerator::do_write_object(ObjectStore::Transaction *t,
+					coll_t coll, hobject_t obj,
+					C_StatState *stat)
+{
+  if (m_suppress_write_data) {
+    dout(5) << __func__ << " suppressed" << dendl;
+    return;
+  }
+
+  size_t size = m_write_data_bytes;
+  if (!size)
+    size = get_random_byte_amount(min_write_bytes, max_write_bytes);
+
+  bufferlist bl;
+  get_filled_byte_array(bl, size);
+
+  dout(2) << __func__ << " " << coll << "/" << obj
+	  << " size " << bl.length() << dendl;
+
+  if (m_do_stats && (stat != NULL))
+    stat->written_data += bl.length();
+
+  t->write(coll, ghobject_t(obj), 0, bl.length(), bl);
+}
+
+void WorkloadGenerator::do_setattr_object(ObjectStore::Transaction *t,
+					  coll_t coll, hobject_t obj,
+					  C_StatState *stat)
+{
+  if (m_suppress_write_xattr_obj) {
+    dout(5) << __func__ << " suppressed" << dendl;
+    return;
+  }
+
+  size_t size = m_write_xattr_obj_bytes;
+  if (!size)
+    size = get_random_byte_amount(min_xattr_obj_bytes, max_xattr_obj_bytes);
+
+  bufferlist bl;
+  get_filled_byte_array(bl, size);
+
+  dout(2) << __func__ << " " << coll << "/" << obj << " size " << size << dendl;
+
+  if (m_do_stats && (stat != NULL))
+      stat->written_data += bl.length();
+
+  t->setattr(coll, ghobject_t(obj), "objxattr", bl);
+}
+
+void WorkloadGenerator::do_pgmeta_omap_set(ObjectStore::Transaction *t, spg_t pgid,
+					   coll_t coll, C_StatState *stat)
+{
+  if (m_suppress_write_xattr_coll) {
+    dout(5) << __func__ << " suppressed" << dendl;
+    return;
+  }
+
+  size_t size = m_write_xattr_coll_bytes;
+  if (!size)
+    size = get_random_byte_amount(min_xattr_coll_bytes, max_xattr_coll_bytes);
+
+  bufferlist bl;
+  get_filled_byte_array(bl, size);
+  dout(2) << __func__ << " coll " << coll << " size " << size << dendl;
+
+  if (m_do_stats && (stat != NULL))
+      stat->written_data += bl.length();
+
+  ghobject_t pgmeta(pgid.make_pgmeta_oid());
+  map<string,bufferlist> values;
+  values["_"].claim(bl);
+  t->omap_setkeys(coll, pgmeta, values);
+}
+
+
+void WorkloadGenerator::do_append_log(ObjectStore::Transaction *t,
+                                      coll_entry_t *entry, C_StatState *stat)
+{
+  if (m_suppress_write_log) {
+    dout(5) << __func__ << " suppressed" << dendl;
+    return;
+  }
+
+  size_t size = (m_write_pglog_bytes ? m_write_pglog_bytes : log_append_bytes);
+
+  bufferlist bl;
+  get_filled_byte_array(bl, size);
+  ghobject_t log_obj = entry->m_meta_obj;
+
+  dout(2) << __func__ << " coll " << entry->m_coll << " "
+      << coll_t::meta() << " /" << log_obj << " (" << bl.length() << ")" << dendl;
+
+  if (m_do_stats && (stat != NULL))
+      stat->written_data += bl.length();
+
+  uint64_t s = pg_log_size[entry->m_coll];
+  t->write(coll_t::meta(), log_obj, s, bl.length(), bl);
+  pg_log_size[entry->m_coll] += bl.length();
+}
+
+void WorkloadGenerator::do_destroy_collection(ObjectStore::Transaction *t,
+					      coll_entry_t *entry,
+					      C_StatState *stat)
+{  
+  m_nr_runs = 0;
+  entry->m_osr.flush();
+  vector<ghobject_t> ls;
+  m_store->collection_list(entry->m_coll, ghobject_t(), ghobject_t::get_max(),
+			   INT_MAX, &ls, NULL);
+  dout(2) << __func__ << " coll " << entry->m_coll
+      << " (" << ls.size() << " objects)" << dendl;
+
+  for (vector<ghobject_t>::iterator it = ls.begin(); it < ls.end(); ++it) {
+    t->remove(entry->m_coll, *it);
+  }
+
+  t->remove_collection(entry->m_coll);
+  t->remove(coll_t::meta(), entry->m_meta_obj);
+}
+
+TestObjectStoreState::coll_entry_t
+*WorkloadGenerator::do_create_collection(ObjectStore::Transaction *t,
+                                         C_StatState *stat)
+{
+  coll_entry_t *entry = coll_create(m_next_coll_nr++);
+  if (!entry) {
+    dout(0) << __func__ << " failed to create coll id "
+        << m_next_coll_nr << dendl;
+    return NULL;
+  }
+  m_collections.insert(make_pair(entry->m_id, entry));
+
+  dout(2) << __func__ << " id " << entry->m_id << " coll " << entry->m_coll << dendl;
+  t->create_collection(entry->m_coll, 32);
+  dout(2) << __func__ << " meta " << coll_t::meta() << "/" << entry->m_meta_obj << dendl;
+  t->touch(coll_t::meta(), entry->m_meta_obj);
+  return entry;
+}
+
+void WorkloadGenerator::do_stats()
+{
+  utime_t now = ceph_clock_now();
+  m_stats_lock.Lock();
+
+  utime_t duration = (now - m_stats_begin);
+
+  // when cast to double, a utime_t behaves properly
+  double throughput = (m_stats_total_written / ((double) duration));
+  double tx_throughput (m_stats_finished_txs / ((double) duration));
+
+  dout(0) << __func__
+	  << " written: " << m_stats_total_written
+	  << " duration: " << duration << " sec"
+	  << " bandwidth: " << prettybyte_t(throughput) << "/s"
+	  << " iops: " << tx_throughput << "/s"
+	  << dendl;
+
+  m_stats_lock.Unlock();
+}
+
+void WorkloadGenerator::run()
+{
+  bool create_coll = false;
+  int ops_run = 0;
+
+  utime_t stats_interval(m_stats_show_secs, 0);
+  utime_t now = ceph_clock_now();
+  utime_t stats_time = now;
+  m_stats_begin = now;
+
+  do {
+    C_StatState *stat_state = NULL;
+
+    if (m_num_ops && (ops_run == m_num_ops))
+      break;
+
+    if (!create_coll && !m_collections.size()) {
+      dout(0) << "We ran out of collections!" << dendl;
+      break;
+    }
+
+    dout(5) << __func__
+        << " m_finished_lock is-locked: " << m_finished_lock.is_locked()
+        << " in-flight: " << m_in_flight.load()
+        << dendl;
+
+    wait_for_ready();
+
+    ObjectStore::Transaction *t = new ObjectStore::Transaction;
+    Context *c;
+    bool destroy_collection = false;
+    TestObjectStoreState::coll_entry_t *entry = NULL;
+
+
+    if (m_do_stats) {
+      utime_t now = ceph_clock_now();
+      utime_t elapsed = now - stats_time;
+      if (elapsed >= stats_interval) {
+	do_stats();
+	stats_time = now;
+      }
+      stat_state = new C_StatState(this, now);
+    }
+
+    if (create_coll) {
+      create_coll = false;
+
+      entry = do_create_collection(t, stat_state);
+      if (!entry) {
+        dout(0) << __func__ << " something went terribly wrong creating coll" << dendl;
+        break;
+      }
+
+      c = new C_OnReadable(this);
+      goto queue_tx;
+    }
+
+    destroy_collection = should_destroy_collection();
+    entry = get_rnd_coll_entry(destroy_collection);
+    assert(entry != NULL);
+
+    if (destroy_collection) {
+      do_destroy_collection(t, entry, stat_state);
+      c = new C_OnDestroyed(this, entry);
+      if (!m_num_ops)
+        create_coll = true;
+    } else {
+      hobject_t *obj = get_rnd_obj(entry);
+
+      do_write_object(t, entry->m_coll, *obj, stat_state);
+      do_setattr_object(t, entry->m_coll, *obj, stat_state);
+      do_pgmeta_omap_set(t, entry->m_pgid, entry->m_coll, stat_state);
+      do_append_log(t, entry, stat_state);
+
+      c = new C_OnReadable(this);
+    }
+
+queue_tx:
+
+    if (m_do_stats) {
+      Context *tmp = c;
+      c = new C_StatWrapper(stat_state, tmp);
+    }
+
+    m_store->queue_transaction(&(entry->m_osr), std::move(*t), c);
+    delete t;
+
+    inc_in_flight();
+
+    ops_run ++;
+
+  } while (true);
+
+  dout(2) << __func__ << " waiting for "
+	  << m_in_flight.load() << " in-flight transactions" << dendl;
+
+  wait_for_done();
+
+  do_stats();
+
+  dout(0) << __func__ << " finishing" << dendl;
+}
+
+void usage()
+{
+  cout << "usage: " << our_name << "[options]" << std::endl;
+
+  cout << "\
+\n\
+Global Options:\n\
+  -c FILE                             Read configuration from FILE\n\
+  --osd-objectstore TYPE              Set OSD ObjectStore type\n\
+  --osd-data PATH                     Set OSD Data path\n\
+  --osd-journal PATH                  Set OSD Journal path\n\
+  --osd-journal-size VAL              Set Journal size\n\
+  --help                              This message\n\
+\n\
+Test-specific Options:\n\
+  --test-num-colls VAL                Set the number of collections\n\
+  --test-num-objs-per-coll VAL        Set the number of objects per collection\n\
+  --test-destroy-coll-per-N-trans VAL Set how many transactions to run before\n\
+                                      destroying a collection.\n\
+  --test-num-ops VAL                  Run a certain number of operations\n\
+                                      (a VAL of 0 runs the test forever)\n\
+   --test-max-in-flight VAL           Maximum number of in-flight transactions\n\
+                                      (default: 50)\n\
+   --test-suppress-ops OPS            Suppress ops specified in OPS\n\
+   --test-write-data-size SIZE        Specify SIZE for all data writes\n\
+   --test-write-xattr-obj-size SIZE   Specify SIZE for all xattrs on objects\n\
+   --test-write-xattr-coll-size SIZE  Specify SIZE for all xattrs on colls\n\
+   --test-write-pglog-size SIZE       Specify SIZE for all pglog writes\n\
+   --test-show-stats                  Show stats as we go\n\
+   --test-show-stats-period SECS      Show stats every SECS (default: 5)\n\
+\n\
+   SIZE is a numeric value that can be assumed as being bytes, or may be any\n\
+   other unit if specified: B or b, K or k, M or m, G or g.\n\
+      e.g., 1G = 1024M = 1048576k = 1073741824\n\
+\n\
+   OPS can be one or more of the following options:\n\
+      c    writes on collection's xattrs\n\
+      o    writes on object's xattr\n\
+      l    writes on pglog\n\
+      d    data writes on objects\n\
+\n\
+" << std::endl;
+}
+
+int main(int argc, const char *argv[])
+{
+  vector<const char*> def_args;
+  vector<const char*> args;
+
+  our_name = argv[0];
+
+  def_args.push_back("--osd-journal-size");
+  def_args.push_back("400");
+//  def_args.push_back("--osd-data");
+//  def_args.push_back("workload_gen_dir");
+//  def_args.push_back("--osd-journal");
+//  def_args.push_back("workload_gen_dir/journal");
+  argv_to_vec(argc, argv, args);
+
+  auto cct = global_init(&def_args, args,
+			 CEPH_ENTITY_TYPE_CLIENT, CODE_ENVIRONMENT_UTILITY,
+			 CINIT_FLAG_NO_DEFAULT_CONFIG_FILE);
+  common_init_finish(g_ceph_context);
+  g_ceph_context->_conf->apply_changes(NULL);
+
+  WorkloadGenerator *wrkldgen_ptr = new WorkloadGenerator(args);
+  wrkldgen.reset(wrkldgen_ptr);
+  wrkldgen->run();
+  return 0;
+}

--- a/src/test/old/test_short_seek_read.c
+++ b/src/test/old/test_short_seek_read.c
@@ -52,7 +52,7 @@ int main(int argc, char **argv)
       if (r < 0) cout << "r = " << r << " " << strerror(errno) << endl;
 
       int range = 1000000/4096;
-      so = o + 4096*ceph::util::generate_random_number(range);//- range/2);
+      so = o + 4096*ceph::util::generate_random_number(range - 1);//- range/2);
       //cout << o << " " << so << " " << (so-o) << endl;
 
       utime_t start = ceph_clock_now();

--- a/src/test/old/test_short_seek_read.c
+++ b/src/test/old/test_short_seek_read.c
@@ -1,5 +1,6 @@
-#include "include/types.h"
-#include "common/Clock.h"
+
+#include <cerrno>
+#include <cstring>
 
 #include <linux/fs.h>
 #include <unistd.h>
@@ -7,8 +8,12 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include <string.h>
-#include <errno.h>
+
+#include "include/util.h"
+#include "include/types.h"
+#include "include/random.h"
+
+#include "common/Clock.h"
 
 int main(int argc, char **argv)
 {
@@ -47,7 +52,7 @@ int main(int argc, char **argv)
       if (r < 0) cout << "r = " << r << " " << strerror(errno) << endl;
 
       int range = 1000000/4096;
-      so = o + 4096*((rand() % range) );//- range/2);
+      so = o + 4096*ceph::util::generate_random_number(range);//- range/2);
       //cout << o << " " << so << " " << (so-o) << endl;
 
       utime_t start = ceph_clock_now();

--- a/src/test/old/testcounter.cc
+++ b/src/test/old/testcounter.cc
@@ -42,12 +42,12 @@ int main(int argc, char **argv)
 
   for (int ms=0; ms < 300*1000; ms++) {
 	if (ms % 30000 == 0) {
-	  target = 1 + ceph::util::generate_random_number(10) * 10;
+	  target = 1 + ceph::util::generate_random_number(9) * 10;
 	  if (ms > 200000) target = 0;
 	}
 
 	if (target &&
-		(ceph::util::generate_random_number(1000/target) == 0)) {
+		(ceph::util::generate_random_number((1000/target) - 1) == 0)) {
 	  dc.hit();
 	  rc.hit(ms);
 	}

--- a/src/test/old/testcounter.cc
+++ b/src/test/old/testcounter.cc
@@ -1,7 +1,10 @@
 
+#include "include/random.h"
+
 #include "common/DecayCounter.h"
 
 #include <list>
+
 using namespace std;
 
 struct RealCounter {
@@ -39,12 +42,12 @@ int main(int argc, char **argv)
 
   for (int ms=0; ms < 300*1000; ms++) {
 	if (ms % 30000 == 0) {
-	  target = 1 + (rand() % 10) * 10;
+	  target = 1 + ceph::util::generate_random_number(10) * 10;
 	  if (ms > 200000) target = 0;
 	}
 
 	if (target &&
-		(rand() % (1000/target) == 0)) {
+		(ceph::util::generate_random_number(1000/target) == 0)) {
 	  dc.hit();
 	  rc.hit(ms);
 	}

--- a/src/test/old/testmpi.cc
+++ b/src/test/old/testmpi.cc
@@ -42,7 +42,7 @@ int main(int argc, char **argv) {
   for (int i=0; i<10000; i++) {
     
     // ping random nodes
-    int d = ceph::util::generate_random_number(world);
+    int d = ceph::util::generate_random_number(world - 1);
     if (d != myrank) {
       //cout << "sending " << i << " to " << d << endl;
       p->messenger->send_message(new MPing(), d);

--- a/src/test/old/testmpi.cc
+++ b/src/test/old/testmpi.cc
@@ -1,11 +1,17 @@
-#include <sys/stat.h>
 #include <iostream>
 #include <string>
+
+#include <sys/stat.h>
+
 using namespace std;
 
+#include "include/util.h"
+#include "include/random.h"
+
 #include "common/config.h"
-#include "messages/MPing.h"
 #include "common/Mutex.h"
+
+#include "messages/MPing.h"
 
 #include "msg/MPIMessenger.h"
 
@@ -36,7 +42,7 @@ int main(int argc, char **argv) {
   for (int i=0; i<10000; i++) {
     
     // ping random nodes
-    int d = rand() % world;
+    int d = ceph::util::generate_random_number(world);
     if (d != myrank) {
       //cout << "sending " << i << " to " << d << endl;
       p->messenger->send_message(new MPing(), d);

--- a/src/test/old/testnewbuffers.cc
+++ b/src/test/old/testnewbuffers.cc
@@ -21,8 +21,8 @@ using namespace std;
 	  // thrash it a bit.
 	  for (int n=0; n<10000; n++) {
 		bufferlist bl2;
-		unsigned off = ceph::util::generate_random_number(bl.length() - 1);
-		unsigned len = 1 + ceph::util::generate_random_number(bl.length() - off - 1);
+		unsigned off = ceph::util::generate_random_number(bl.length() - 2);
+		unsigned len = 1 + ceph::util::generate_random_number(bl.length() - off - 2);
 		bl2.substr_of(bl, off, len);
 		bufferlist bl3;
 		bl3.append(bl);

--- a/src/test/old/testnewbuffers.cc
+++ b/src/test/old/testnewbuffers.cc
@@ -1,11 +1,12 @@
 
 #include <list>
 #include <iostream>
+
 using namespace std;
 
-
+#include "include/util.h"
+#include "include/random.h"
 #include "include/newbuffer.h"
-//#include "include/bufferlist.h"
 
 #include "common/Thread.h"
 
@@ -20,8 +21,8 @@ using namespace std;
 	  // thrash it a bit.
 	  for (int n=0; n<10000; n++) {
 		bufferlist bl2;
-		unsigned off = rand() % (bl.length() -1);
-		unsigned len = 1 + rand() % (bl.length() - off - 1);
+		unsigned off = ceph::util::generate_random_number(bl.length() - 1);
+		unsigned len = 1 + ceph::util::generate_random_number(bl.length() - off - 1);
 		bl2.substr_of(bl, off, len);
 		bufferlist bl3;
 		bl3.append(bl);

--- a/src/test/old/testtree.cc
+++ b/src/test/old/testtree.cc
@@ -23,13 +23,13 @@ int main()
   cout << t << endl;
 
   for (int k=0; k<10000; k++) {
-    if (ceph::util::generate_random_number(2)) {
+    if (ceph::util::generate_random_number(1)) {
       cout << "adding" << endl;
       nodes.push_back( t.add_node(1) );
     } else {
       if (!nodes.empty()) {
         //for (int i=0; i<nodes.size(); i++) {
-        int p = ceph::util::generate_random_number(nodes.size());
+        int p = ceph::util::generate_random_number(nodes.size() - 1);
         int n = nodes[p];
         assert (t.exists(n));
         cout << "removing " << n << endl;

--- a/src/test/old/testtree.cc
+++ b/src/test/old/testtree.cc
@@ -1,10 +1,11 @@
+#include <vector>
+#include <iostream>
 
+#include "include/random.h"
 
 #include "../crush/BinaryTree.h"
-using namespace crush;
 
-#include <iostream>
-#include <vector>
+using namespace crush;
 using namespace std;
 
 int main() 
@@ -22,13 +23,13 @@ int main()
   cout << t << endl;
 
   for (int k=0; k<10000; k++) {
-    if (rand() % 2) {
+    if (ceph::util::generate_random_number(2)) {
       cout << "adding" << endl;
       nodes.push_back( t.add_node(1) );
     } else {
       if (!nodes.empty()) {
         //for (int i=0; i<nodes.size(); i++) {
-        int p = rand() % nodes.size();
+        int p = ceph::util::generate_random_number(nodes.size());
         int n = nodes[p];
         assert (t.exists(n));
         cout << "removing " << n << endl;

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -11,21 +11,27 @@
  * Foundation.  See file COPYING.
  */
 
+#include <cmath>
+#include <string>
+#include <cassert>
+#include <climits>
+#include <iostream>
+
 #include "include/rados/librados.hpp"
 #include "include/Context.h"
+
 #include "common/ceph_context.h"
 #include "common/Mutex.h"
 #include "common/Cond.h"
-#include "include/utime.h"
-#include "global/global_context.h"
 #include "common/ceph_argparse.h"
-#include "test/omap_bench.h"
 
-#include <string>
-#include <iostream>
-#include <cassert>
-#include <climits>
-#include <cmath>
+#include "include/util.h"
+#include "include/utime.h"
+#include "include/random.h"
+
+#include "global/global_context.h"
+
+#include "test/omap_bench.h"
 
 using namespace std;
 using ceph::bufferlist;
@@ -212,7 +218,7 @@ string OmapBench::random_string(int len) {
       "abcdefghijklmnopqrstuvwxyz";
 
   for (int i = 0; i < len; ++i) {
-    ret.push_back(alphanum[rand() % (alphanum.size() - 1)]);
+    ret.push_back(alphanum[ceph::util::generate_random_number(alphanum.size() - 1)]);
   }
 
   return ret;
@@ -333,9 +339,9 @@ int OmapBench::generate_non_uniform_omap(const int omap_entries,
     std::map<std::string,bufferlist> * out_omap) {
   bufferlist bl;
 
-  int num_entries = rand() % omap_entries + 1;
-  int key_len = rand() % key_size +1;
-  int val_len = rand() % value_size +1;
+  int num_entries = ceph::util::generate_random_number(omap_entries) + 1;
+  int key_len = ceph::util::generate_random_number(key_size) + 1;
+  int val_len = ceph::util::generate_random_number(value_size) + 1;
 
   //setup omap
   for (int i = 0; i < num_entries; i++) {

--- a/src/test/omap_bench.cc
+++ b/src/test/omap_bench.cc
@@ -339,9 +339,9 @@ int OmapBench::generate_non_uniform_omap(const int omap_entries,
     std::map<std::string,bufferlist> * out_omap) {
   bufferlist bl;
 
-  int num_entries = ceph::util::generate_random_number(omap_entries) + 1;
-  int key_len = ceph::util::generate_random_number(key_size) + 1;
-  int val_len = ceph::util::generate_random_number(value_size) + 1;
+  int num_entries = ceph::util::generate_random_number(1, omap_entries);
+  int key_len = ceph::util::generate_random_number(1, key_size); 
+  int val_len = ceph::util::generate_random_number(1, value_size);
 
   //setup omap
   for (int i = 0; i < num_entries; i++) {

--- a/src/test/osd/Object.cc
+++ b/src/test/osd/Object.cc
@@ -1,10 +1,14 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
-#include "include/interval_set.h"
-#include "include/buffer.h"
-#include <list>
+
 #include <map>
 #include <set>
+#include <list>
 #include <iostream>
+
+#include "include/util.h"
+#include "include/buffer.h"
+#include "include/random.h"
+#include "include/interval_set.h"
 
 #include "Object.h"
 
@@ -45,7 +49,7 @@ void AppendGenerator::get_ranges_map(
   uint64_t limit = off + get_append_size(cont);
   while (pos < limit) {
     uint64_t segment_length = round_up(
-      rand() % (max_append_size - min_append_size),
+      ceph::util::generate_random_number(max_append_size - min_append_size),
       alignment) + min_append_size;
     assert(segment_length >= min_append_size);
     if (segment_length + pos > limit) {
@@ -65,7 +69,7 @@ void VarLenGenerator::get_ranges_map(
   uint64_t limit = get_length(cont);
   bool include = false;
   while (pos < limit) {
-    uint64_t segment_length = (rand() % (max_stride_size - min_stride_size)) + min_stride_size;
+    uint64_t segment_length = (ceph::util::generate_random_number(max_stride_size - min_stride_size)) + min_stride_size;
     assert(segment_length < max_stride_size);
     assert(segment_length >= min_stride_size);
     if (segment_length + pos > limit) {

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -1,14 +1,17 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
-#include "include/interval_set.h"
-#include "include/buffer.h"
-#include "include/encoding.h"
+
+#ifndef OBJECT_H
+#define OBJECT_H
+
 #include <list>
 #include <map>
 #include <set>
 #include <random>
 
-#ifndef OBJECT_H
-#define OBJECT_H
+#include "include/interval_set.h"
+#include "include/buffer.h"
+#include "include/encoding.h"
+#include "include/random.h"
 
 class ContDesc {
 public:
@@ -171,7 +174,7 @@ public:
     char current;
     iterator_impl(const ContDesc &cont, RandGenerator *cont_gen) : 
       pos(0), cont(cont), rand(cont.seqnum), cont_gen(cont_gen) {
-      current = rand();
+      current = ceph::util::generate_random_number();
     }
 
     ContDesc get_cont() const override { return cont; }
@@ -179,7 +182,7 @@ public:
 
     iterator_impl &operator++() override {
       pos++;
-      current = rand();
+      current = ceph::util::generate_random_number();
       return *this;
     }
 
@@ -236,7 +239,7 @@ public:
     RandWrap rand(in.seqnum);
     if (max_length == 0)
       return 0;
-    return (rand() % (max_length/2)) + ((max_length - 1)/2) + 1;
+    return (ceph::util::generate_random_number(max_length/2)) + ((max_length - 1)/2) + 1;
   }
 };
 
@@ -254,9 +257,9 @@ public:
     RandWrap rand(in.seqnum);
     // make some attrs big
     if (in.seqnum & 3)
-      return (rand() % max_len);
+      return ceph::util::generate_random_number(max_len);
     else
-      return (rand() % big_max_len);
+      return ceph::util::generate_random_number(big_max_len);
   }
   bufferlist gen_bl(const ContDesc &in) {
     bufferlist bl;
@@ -297,7 +300,7 @@ public:
   }
   uint64_t get_append_size(const ContDesc &in) {
     RandWrap rand(in.seqnum);
-    return round_up(rand() % max_append_total, alignment);
+    return round_up(ceph::util::generate_random_number(max_append_total), alignment);
   }
   uint64_t get_length(const ContDesc &in) override {
     return off + get_append_size(in);

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -239,7 +239,8 @@ public:
     RandWrap rand(in.seqnum);
     if (max_length == 0)
       return 0;
-    return (ceph::util::generate_random_number((max_length/2) - 1) + ((max_length - 1)/2) + 1;
+
+    return 1 + ceph::util::generate_random_number((max_length/2) - 1) + ((max_length - 1)/2);
   }
 };
 

--- a/src/test/osd/Object.h
+++ b/src/test/osd/Object.h
@@ -239,7 +239,7 @@ public:
     RandWrap rand(in.seqnum);
     if (max_length == 0)
       return 0;
-    return (ceph::util::generate_random_number(max_length/2)) + ((max_length - 1)/2) + 1;
+    return (ceph::util::generate_random_number((max_length/2) - 1) + ((max_length - 1)/2) + 1;
   }
 };
 
@@ -257,9 +257,9 @@ public:
     RandWrap rand(in.seqnum);
     // make some attrs big
     if (in.seqnum & 3)
-      return ceph::util::generate_random_number(max_len);
+      return ceph::util::generate_random_number(max_len - 1);
     else
-      return ceph::util::generate_random_number(big_max_len);
+      return ceph::util::generate_random_number(big_max_len - 1);
   }
   bufferlist gen_bl(const ContDesc &in) {
     bufferlist bl;

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -46,7 +46,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = ceph::util::generate_random_number(cont.size());
+  int index = ceph::util::generate_random_number(cont.size() - 1);
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -1183,7 +1183,7 @@ public:
     context->state_lock.Unlock();
 
     int r = 0;
-    if (ceph::util::generate_random_number(2)) {
+    if (ceph::util::generate_random_number(1)) {
       librados::ObjectWriteOperation op;
       op.assert_exists();
       op.remove();
@@ -1263,7 +1263,7 @@ public:
     uint64_t len = 0;
     if (old_value.has_contents())
       len = old_value.most_recent_gen()->get_length(old_value.most_recent());
-    if (context->no_sparse || ceph::util::generate_random_number(2)) {
+    if (context->no_sparse || ceph::util::generate_random_number(1)) {
       is_sparse_read[index] = false;
       read_op.read(0,
 		   len,
@@ -1286,7 +1286,7 @@ public:
   void _begin() override
   {
     context->state_lock.Lock();
-    if (!(ceph::util::generate_random_number(4)) && !context->snaps.empty()) {
+    if (!(ceph::util::generate_random_number(3)) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -1332,10 +1332,10 @@ public:
     for (map<string, ContDesc>::iterator i = old_value.attrs.begin();
 	 i != old_value.attrs.end();
 	 ++i) {
-      if (ceph::util::generate_random_number(2)) {
+      if (ceph::util::generate_random_number(1)) {
 	string key = i->first;
-	if (ceph::util::generate_random_number(2))
-	  key.push_back(ceph::util::generate_random_number(26) + 'a');
+	if (ceph::util::generate_random_number(1))
+	  key.push_back(ceph::util::generate_random_number(25) + 'a');
 	omap_requested_keys.insert(key);
       }
     }
@@ -1901,7 +1901,7 @@ public:
       context->oid_not_in_use.erase(oid_src);
 
       // choose source snap
-      if (0 && !ceph::util::generate_random_number(4) && !context->snaps.empty()) {
+      if (0 && !ceph::util::generate_random_number(2) && !context->snaps.empty()) {
 	snap = rand_choose(context->snaps)->first;
 	in_use = context->snaps_in_use.lookup_or_create(snap, snap);
       } else {
@@ -2740,7 +2740,7 @@ public:
 	done = true;
       } else {
 	cerr << num << ": hitsets are " << ls << std::endl;
-	int r = ceph::util::generate_random_number(ls.size());
+	int r = ceph::util::generate_random_number(ls.size() - 1);
 	std::list<pair<time_t,time_t> >::iterator p = ls.begin();
 	while (r--)
 	  ++p;
@@ -2863,7 +2863,7 @@ public:
   {
     context->state_lock.Lock();
 
-    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(3) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -2961,7 +2961,7 @@ public:
   {
     context->state_lock.Lock();
 
-    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(3) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -3062,7 +3062,7 @@ public:
     context->state_lock.Lock();
 
     int snap;
-    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(3) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {

--- a/src/test/osd/RadosModel.h
+++ b/src/test/osd/RadosModel.h
@@ -1,31 +1,40 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*- 
 // vim: ts=8 sw=2 smarttab
+
+#ifndef RADOSMODEL_H
+#define RADOSMODEL_H
+
+#include <map>
+#include <set>
+#include <list>
+#include <ctime>
+#include <cerrno>
+#include <string>
+#include <cstring>
+#include <sstream>
+#include <cstdlib>
+#include <iostream>
+
 #include "include/int_types.h"
 
 #include "common/Mutex.h"
 #include "common/Cond.h"
+
 #include "include/rados/librados.hpp"
 
-#include <iostream>
-#include <sstream>
-#include <map>
-#include <set>
-#include <list>
-#include <string>
-#include <string.h>
-#include <stdlib.h>
-#include <errno.h>
-#include <time.h>
 #include "Object.h"
 #include "TestOpStat.h"
+
 #include "test/librados/test.h"
+
+#include "include/util.h"
 #include "include/memory.h"
+#include "include/random.h"
+
 #include "common/sharedptr_registry.hpp"
 #include "common/errno.h"
-#include "osd/HitSet.h"
 
-#ifndef RADOSMODEL_H
-#define RADOSMODEL_H
+#include "osd/HitSet.h"
 
 using namespace std;
 
@@ -37,7 +46,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = rand() % cont.size();
+  int index = ceph::util::generate_random_number(cont.size());
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -592,7 +601,7 @@ public:
       context->oid_in_use.insert(oid);
       context->oid_not_in_use.erase(oid);
 
-      if (rand() % 30) {
+      if (ceph::util::generate_random_number(30)) {
 	ContentsGenerator::iterator iter = context->attr_gen.get_iterator(cont);
 	for (map<string, ContDesc>::iterator i = obj.attrs.begin();
 	     i != obj.attrs.end();
@@ -1174,7 +1183,7 @@ public:
     context->state_lock.Unlock();
 
     int r = 0;
-    if (rand() % 2) {
+    if (ceph::util::generate_random_number(2)) {
       librados::ObjectWriteOperation op;
       op.assert_exists();
       op.remove();
@@ -1254,7 +1263,7 @@ public:
     uint64_t len = 0;
     if (old_value.has_contents())
       len = old_value.most_recent_gen()->get_length(old_value.most_recent());
-    if (context->no_sparse || rand() % 2) {
+    if (context->no_sparse || ceph::util::generate_random_number(2)) {
       is_sparse_read[index] = false;
       read_op.read(0,
 		   len,
@@ -1277,7 +1286,7 @@ public:
   void _begin() override
   {
     context->state_lock.Lock();
-    if (!(rand() % 4) && !context->snaps.empty()) {
+    if (!(ceph::util::generate_random_number(4)) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -1323,10 +1332,10 @@ public:
     for (map<string, ContDesc>::iterator i = old_value.attrs.begin();
 	 i != old_value.attrs.end();
 	 ++i) {
-      if (rand() % 2) {
+      if (ceph::util::generate_random_number(2)) {
 	string key = i->first;
-	if (rand() % 2)
-	  key.push_back((rand() % 26) + 'a');
+	if (ceph::util::generate_random_number(2))
+	  key.push_back(ceph::util::generate_random_number(26) + 'a');
 	omap_requested_keys.insert(key);
       }
     }
@@ -1892,7 +1901,7 @@ public:
       context->oid_not_in_use.erase(oid_src);
 
       // choose source snap
-      if (0 && !(rand() % 4) && !context->snaps.empty()) {
+      if (0 && !ceph::util::generate_random_number(4) && !context->snaps.empty()) {
 	snap = rand_choose(context->snaps)->first;
 	in_use = context->snaps_in_use.lookup_or_create(snap, snap);
       } else {
@@ -2731,7 +2740,7 @@ public:
 	done = true;
       } else {
 	cerr << num << ": hitsets are " << ls << std::endl;
-	int r = rand() % ls.size();
+	int r = ceph::util::generate_random_number(ls.size());
 	std::list<pair<time_t,time_t> >::iterator p = ls.begin();
 	while (r--)
 	  ++p;
@@ -2854,7 +2863,7 @@ public:
   {
     context->state_lock.Lock();
 
-    if (!(rand() % 4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -2952,7 +2961,7 @@ public:
   {
     context->state_lock.Lock();
 
-    if (!(rand() % 4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {
@@ -3053,7 +3062,7 @@ public:
     context->state_lock.Lock();
 
     int snap;
-    if (!(rand() % 4) && !context->snaps.empty()) {
+    if (!ceph::util::generate_random_number(4) && !context->snaps.empty()) {
       snap = rand_choose(context->snaps)->first;
       in_use = context->snaps_in_use.lookup_or_create(snap, snap);
     } else {

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -228,7 +228,7 @@ public:
 	  max_len = contents2.most_recent_gen()->get_length(contents2.most_recent());
 	}
 	uint32_t rand_offset = generate_random_number(max_len - 1);
-	uint32_t rand_length = generate_random_number(max_len);
+	uint32_t rand_length = generate_random_number(max_len - 1);
 
 	rand_offset = rand_offset - (rand_offset % 512);
 	rand_length = rand_length - (rand_length % 512);

--- a/src/test/osd/TestRados.cc
+++ b/src/test/osd/TestRados.cc
@@ -98,7 +98,7 @@ public:
     }
 
     while (retval == NULL) {
-      unsigned int rand_val = generate_random_numberr(m_total_weight);
+      unsigned int rand_val = generate_random_number(m_total_weight);
 
       time_t now = time(0);
       if (m_seconds && now - m_start > m_seconds)
@@ -235,7 +235,7 @@ public:
 
 	while (rand_offset + rand_length > max_len || rand_length == 0) {
 	  rand_offset = generate_random_number(max_len - 1);
-	  rand_length = r generate_random_number(max_len - 1);
+	  rand_length = generate_random_number(max_len - 1);
 
 	  rand_offset = rand_offset - (rand_offset % 512);
 	  rand_length = rand_length - (rand_length % 512);

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -1079,8 +1079,8 @@ TEST(pg_pool_t_test, get_random_pg_position) {
     pg_pool_t p;
     p.set_pg_num(1 + ceph::util::generate_random_number(1000));
     p.set_pgp_num(p.get_pg_num());
-    pg_t pgid(ceph::util::generate_random_number(p.get_pg_num()), 1);
-    uint32_t h = p.get_random_pg_position(pgid, ceph::util::generate_random_number());
+    pg_t pgid(generate_random_number(p.get_pg_num() - 1), 1);
+    uint32_t h = p.get_random_pg_position(pgid, generate_random_number());
     uint32_t ps = p.raw_hash_to_pg(h);
     cout << p.get_pg_num() << " " << pgid << ": "
 	 << h << " -> " << pg_t(ps, 1) << std::endl;

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -17,21 +17,15 @@
 
 #include <sstream>
 
-#include "include/util.h"
 #include "include/types.h"
 #include "include/random.h"
 #include "include/stringify.h"
-
 #include "include/coredumpctl.h"
-#include "include/stringify.h"
 
 #include "common/Thread.h"
 
-#include "osd/osd_types.h"
 #include "osd/OSDMap.h"
-
-#include "common/Thread.h"
-
+#include "osd/osd_types.h"
 #include "osd/ReplicatedBackend.h"
 
 #include "gtest/gtest.h"
@@ -1075,9 +1069,11 @@ TEST(pg_pool_t_test, get_pg_num_divisor) {
 }
 
 TEST(pg_pool_t_test, get_random_pg_position) {
+  using ceph::util::generate_random_number;
+
   for (int i = 0; i < 100; ++i) {
     pg_pool_t p;
-    p.set_pg_num(1 + ceph::util::generate_random_number(1000));
+    p.set_pg_num(generate_random_number(1, 999)); 
     p.set_pgp_num(p.get_pg_num());
     pg_t pgid(generate_random_number(p.get_pg_num() - 1), 1);
     uint32_t h = p.get_random_pg_position(pgid, generate_random_number());

--- a/src/test/osd/types.cc
+++ b/src/test/osd/types.cc
@@ -15,16 +15,26 @@
  *
  */
 
+#include <sstream>
+
+#include "include/util.h"
 #include "include/types.h"
+#include "include/random.h"
+#include "include/stringify.h"
+
+#include "include/coredumpctl.h"
+#include "include/stringify.h"
+
+#include "common/Thread.h"
+
 #include "osd/osd_types.h"
 #include "osd/OSDMap.h"
-#include "gtest/gtest.h"
-#include "include/coredumpctl.h"
+
 #include "common/Thread.h"
-#include "include/stringify.h"
+
 #include "osd/ReplicatedBackend.h"
 
-#include <sstream>
+#include "gtest/gtest.h"
 
 TEST(hobject, prefixes0)
 {
@@ -1065,13 +1075,12 @@ TEST(pg_pool_t_test, get_pg_num_divisor) {
 }
 
 TEST(pg_pool_t_test, get_random_pg_position) {
-  srand(getpid());
   for (int i = 0; i < 100; ++i) {
     pg_pool_t p;
-    p.set_pg_num(1 + (rand() % 1000));
+    p.set_pg_num(1 + ceph::util::generate_random_number(1000));
     p.set_pgp_num(p.get_pg_num());
-    pg_t pgid(rand() % p.get_pg_num(), 1);
-    uint32_t h = p.get_random_pg_position(pgid, rand());
+    pg_t pgid(ceph::util::generate_random_number(p.get_pg_num()), 1);
+    uint32_t h = p.get_random_pg_position(pgid, ceph::util::generate_random_number());
     uint32_t ps = p.raw_hash_to_pg(h);
     cout << p.get_pg_num() << " " << pgid << ": "
 	 << h << " -> " << pg_t(ps, 1) << std::endl;

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -1,0 +1,761 @@
+// -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
+// vim: ts=8 sw=2 smarttab
+
+#include "test/rbd_mirror/test_mock_fixture.h"
+#include "include/util.h"
+#include "include/random.h"
+#include "include/interval_set.h"
+#include "include/rbd/librbd.hpp"
+#include "include/rbd/object_map_types.h"
+#include "librbd/ImageCtx.h"
+#include "librbd/ImageState.h"
+#include "librbd/internal.h"
+#include "librbd/Operations.h"
+#include "librbd/io/ImageRequestWQ.h"
+#include "librbd/io/ReadResult.h"
+#include "test/librados_test_stub/MockTestMemIoCtxImpl.h"
+#include "test/librbd/mock/MockImageCtx.h"
+#include "tools/rbd_mirror/Threads.h"
+#include "tools/rbd_mirror/image_sync/ObjectCopyRequest.h"
+
+namespace librbd {
+namespace {
+
+struct MockTestImageCtx : public librbd::MockImageCtx {
+  MockTestImageCtx(librbd::ImageCtx &image_ctx)
+    : librbd::MockImageCtx(image_ctx) {
+  }
+};
+
+} // anonymous namespace
+} // namespace librbd
+
+// template definitions
+#include "tools/rbd_mirror/image_sync/ObjectCopyRequest.cc"
+template class rbd::mirror::image_sync::ObjectCopyRequest<librbd::MockTestImageCtx>;
+
+bool operator==(const SnapContext& rhs, const SnapContext& lhs) {
+  return (rhs.seq == lhs.seq && rhs.snaps == lhs.snaps);
+}
+
+namespace rbd {
+namespace mirror {
+namespace image_sync {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::DoDefault;
+using ::testing::InSequence;
+using ::testing::Invoke;
+using ::testing::Return;
+using ::testing::ReturnNew;
+using ::testing::WithArg;
+
+namespace {
+
+void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size,
+              interval_set<uint64_t> *what)
+{
+  uint64_t object_size = 1 << image_ctx->order;
+  for (int i=0; i<num_ops; i++) {
+    uint64_t off = ceph::util::generate_random_number(object_size - max_size + 1);
+    uint64_t len = 1 + ceph::util::generate_random_number(max_size);
+
+    bufferlist bl;
+    bl.append(std::string(len, '1'));
+
+    int r = image_ctx->io_work_queue->write(off, len, std::move(bl), 0);
+    ASSERT_EQ(static_cast<int>(len), r);
+
+    interval_set<uint64_t> w;
+    w.insert(off, len);
+    what->union_of(w);
+  }
+  std::cout << " wrote " << *what << std::endl;
+}
+
+} // anonymous namespace
+
+class TestMockImageSyncObjectCopyRequest : public TestMockFixture {
+public:
+  typedef ObjectCopyRequest<librbd::MockTestImageCtx> MockObjectCopyRequest;
+
+  void SetUp() override {
+    TestMockFixture::SetUp();
+
+    librbd::RBD rbd;
+    ASSERT_EQ(0, create_image(rbd, m_remote_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_remote_io_ctx, m_image_name, &m_remote_image_ctx));
+
+    ASSERT_EQ(0, create_image(rbd, m_local_io_ctx, m_image_name, m_image_size));
+    ASSERT_EQ(0, open_image(m_local_io_ctx, m_image_name, &m_local_image_ctx));
+  }
+
+  void expect_start_op(librbd::MockExclusiveLock &mock_exclusive_lock) {
+    EXPECT_CALL(mock_exclusive_lock, start_op()).WillOnce(
+      ReturnNew<FunctionContext>([](int) {}));
+  }
+
+  void expect_list_snaps(librbd::MockTestImageCtx &mock_image_ctx,
+                         librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                         const librados::snap_set_t &snap_set) {
+    expect_set_snap_read(mock_io_ctx, CEPH_SNAPDIR);
+    EXPECT_CALL(mock_io_ctx,
+                list_snaps(mock_image_ctx.image_ctx->get_object_name(0), _))
+      .WillOnce(DoAll(WithArg<1>(Invoke([&snap_set](librados::snap_set_t *out_snap_set) {
+                          *out_snap_set = snap_set;
+                        })),
+                      Return(0)));
+  }
+
+  void expect_list_snaps(librbd::MockTestImageCtx &mock_image_ctx,
+                         librados::MockTestMemIoCtxImpl &mock_io_ctx, int r) {
+    expect_set_snap_read(mock_io_ctx, CEPH_SNAPDIR);
+    auto &expect = EXPECT_CALL(mock_io_ctx,
+                               list_snaps(mock_image_ctx.image_ctx->get_object_name(0),
+                                          _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_get_object_name(librbd::MockTestImageCtx &mock_image_ctx) {
+    EXPECT_CALL(mock_image_ctx, get_object_name(0))
+                  .WillOnce(Return(mock_image_ctx.image_ctx->get_object_name(0)));
+  }
+
+  MockObjectCopyRequest *create_request(librbd::MockTestImageCtx &mock_remote_image_ctx,
+                                        librbd::MockTestImageCtx &mock_local_image_ctx,
+                                        Context *on_finish) {
+    expect_get_object_name(mock_local_image_ctx);
+    expect_get_object_name(mock_remote_image_ctx);
+    return new MockObjectCopyRequest(&mock_local_image_ctx,
+                                     &mock_remote_image_ctx, &m_snap_map,
+                                     0, on_finish);
+  }
+
+  void expect_set_snap_read(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                            uint64_t snap_id) {
+    EXPECT_CALL(mock_io_ctx, set_snap_read(snap_id));
+  }
+
+  void expect_sparse_read(librados::MockTestMemIoCtxImpl &mock_io_ctx, uint64_t offset,
+                          uint64_t length, int r) {
+
+    auto &expect = EXPECT_CALL(mock_io_ctx, sparse_read(_, offset, length, _, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_sparse_read(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                   const interval_set<uint64_t> &extents, int r) {
+    for (auto extent : extents) {
+      expect_sparse_read(mock_io_ctx, extent.first, extent.second, r);
+      if (r < 0) {
+        break;
+      }
+    }
+  }
+
+  void expect_write(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                    uint64_t offset, uint64_t length,
+                    const SnapContext &snapc, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, write(_, _, length, offset, snapc));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_write(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                    const interval_set<uint64_t> &extents,
+                    const SnapContext &snapc, int r) {
+    for (auto extent : extents) {
+      expect_write(mock_io_ctx, extent.first, extent.second, snapc, r);
+      if (r < 0) {
+        break;
+      }
+    }
+  }
+
+  void expect_truncate(librados::MockTestMemIoCtxImpl &mock_io_ctx,
+                       uint64_t offset, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, truncate(_, offset, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_remove(librados::MockTestMemIoCtxImpl &mock_io_ctx, int r) {
+    auto &expect = EXPECT_CALL(mock_io_ctx, remove(_, _));
+    if (r < 0) {
+      expect.WillOnce(Return(r));
+    } else {
+      expect.WillOnce(DoDefault());
+    }
+  }
+
+  void expect_update_object_map(librbd::MockTestImageCtx &mock_image_ctx,
+                                librbd::MockObjectMap &mock_object_map,
+                                librados::snap_t snap_id, uint8_t state,
+                                int r) {
+    if (mock_image_ctx.image_ctx->object_map != nullptr) {
+      auto &expect = EXPECT_CALL(mock_object_map, aio_update(snap_id, 0, 1, state, _, _, _));
+      if (r < 0) {
+        expect.WillOnce(DoAll(WithArg<6>(Invoke([this, r](Context *ctx) {
+                                  m_threads->work_queue->queue(ctx, r);
+                                })),
+                              Return(true)));
+      } else {
+        expect.WillOnce(DoAll(WithArg<6>(Invoke([&mock_image_ctx, snap_id, state, r](Context *ctx) {
+                                  assert(mock_image_ctx.image_ctx->snap_lock.is_locked());
+                                  assert(mock_image_ctx.image_ctx->object_map_lock.is_wlocked());
+                                  mock_image_ctx.image_ctx->object_map->aio_update<Context>(
+                                    snap_id, 0, 1, state, boost::none, {}, ctx);
+                                })),
+                              Return(true)));
+      }
+    }
+  }
+
+  using TestFixture::create_snap;
+  int create_snap(const char* snap_name) {
+    librados::snap_t remote_snap_id;
+    int r = create_snap(m_remote_image_ctx, snap_name, &remote_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    librados::snap_t local_snap_id;
+    r = create_snap(m_local_image_ctx, snap_name, &local_snap_id);
+    if (r < 0) {
+      return r;
+    }
+
+    // collection of all existing snaps in local image
+    MockObjectCopyRequest::SnapIds local_snap_ids({local_snap_id});
+    if (!m_snap_map.empty()) {
+      local_snap_ids.insert(local_snap_ids.end(),
+                            m_snap_map.rbegin()->second.begin(),
+                            m_snap_map.rbegin()->second.end());
+    }
+    m_snap_map[remote_snap_id] = local_snap_ids;
+    m_remote_snap_ids.push_back(remote_snap_id);
+    m_local_snap_ids.push_back(local_snap_id);
+
+    return 0;
+  }
+
+  std::string get_snap_name(librbd::ImageCtx *image_ctx,
+                            librados::snap_t snap_id) {
+    auto it = std::find_if(image_ctx->snap_ids.begin(),
+                           image_ctx->snap_ids.end(),
+                           [snap_id](const std::pair<std::pair<cls::rbd::SnapshotNamespace,
+							       std::string>,
+						     librados::snap_t> &pair) {
+        return (pair.second == snap_id);
+      });
+    if (it == image_ctx->snap_ids.end()) {
+      return "";
+    }
+    return it->first.second;
+  }
+
+  int compare_objects() {
+    MockObjectCopyRequest::SnapMap snap_map(m_snap_map);
+    if (snap_map.empty()) {
+      return -ENOENT;
+    }
+
+    int r;
+    uint64_t object_size = 1 << m_remote_image_ctx->order;
+    while (!snap_map.empty()) {
+      librados::snap_t remote_snap_id = snap_map.begin()->first;
+      librados::snap_t local_snap_id = *snap_map.begin()->second.begin();
+      snap_map.erase(snap_map.begin());
+
+      std::string snap_name = get_snap_name(m_remote_image_ctx, remote_snap_id);
+      if (snap_name.empty()) {
+        return -ENOENT;
+      }
+
+      std::cout << "comparing '" << snap_name << " (" << remote_snap_id
+                << " to " << local_snap_id << ")" << std::endl;
+
+      r = librbd::snap_set(m_remote_image_ctx,
+			   cls::rbd::UserSnapshotNamespace(),
+			   snap_name.c_str());
+      if (r < 0) {
+        return r;
+      }
+
+      r = librbd::snap_set(m_local_image_ctx,
+			   cls::rbd::UserSnapshotNamespace(),
+			   snap_name.c_str());
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist remote_bl;
+      remote_bl.append(std::string(object_size, '1'));
+      r = m_remote_image_ctx->io_work_queue->read(
+        0, object_size, librbd::io::ReadResult{&remote_bl}, 0);
+      if (r < 0) {
+        return r;
+      }
+
+      bufferlist local_bl;
+      local_bl.append(std::string(object_size, '1'));
+      r = m_local_image_ctx->io_work_queue->read(
+        0, object_size, librbd::io::ReadResult{&local_bl}, 0);
+      if (r < 0) {
+        return r;
+      }
+
+      if (!remote_bl.contents_equal(local_bl)) {
+        return -EBADMSG;
+      }
+    }
+
+    r = librbd::snap_set(m_remote_image_ctx,
+			 cls::rbd::UserSnapshotNamespace(),
+			 nullptr);
+    if (r < 0) {
+      return r;
+    }
+    r = librbd::snap_set(m_local_image_ctx,
+			 cls::rbd::UserSnapshotNamespace(),
+			 nullptr);
+    if (r < 0) {
+      return r;
+    }
+
+    return 0;
+  }
+
+  librbd::ImageCtx *m_remote_image_ctx;
+  librbd::ImageCtx *m_local_image_ctx;
+
+  MockObjectCopyRequest::SnapMap m_snap_map;
+  std::vector<librados::snap_t> m_remote_snap_ids;
+  std::vector<librados::snap_t> m_local_snap_ids;
+};
+
+TEST_F(TestMockImageSyncObjectCopyRequest, DNE) {
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, -ENOENT);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Write) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[0], OBJECT_EXISTS, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, ReadMissingStaleSnapSet) {
+  ASSERT_EQ(0, create_snap("one"));
+  ASSERT_EQ(0, create_snap("two"));
+
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+  ASSERT_EQ(0, create_snap("three"));
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  librados::clone_info_t dummy_clone_info;
+  dummy_clone_info.cloneid = librados::SNAP_HEAD;
+  dummy_clone_info.size = 123;
+
+  librados::snap_set_t dummy_snap_set1;
+  dummy_snap_set1.clones.push_back(dummy_clone_info);
+
+  dummy_clone_info.size = 234;
+  librados::snap_set_t dummy_snap_set2;
+  dummy_snap_set2.clones.push_back(dummy_clone_info);
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, dummy_snap_set1);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[3]);
+  expect_sparse_read(mock_remote_io_ctx, 0, 123, -ENOENT);
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, dummy_snap_set2);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[3]);
+  expect_sparse_read(mock_remote_io_ctx, 0, 234, -ENOENT);
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[3]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(),
+               {m_local_snap_ids[1], {m_local_snap_ids[1],
+                                      m_local_snap_ids[0]}},
+                0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[2], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[3], OBJECT_EXISTS_CLEAN, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, ReadMissingUpToDateSnapMap) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), -ENOENT);
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+
+  request->send();
+  ASSERT_EQ(-ENOENT, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, ReadError) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(),  -EINVAL);
+
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, WriteError) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), {0, {}}, -EINVAL);
+
+  request->send();
+  ASSERT_EQ(-EINVAL, ctx.wait());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, WriteSnaps) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+  ASSERT_EQ(0, create_snap("one"));
+
+  interval_set<uint64_t> two;
+  scribble(m_remote_image_ctx, 10, 102400, &two);
+  ASSERT_EQ(0, create_snap("two"));
+
+  if (one.range_end() < two.range_end()) {
+    interval_set<uint64_t> resize_diff;
+    resize_diff.insert(one.range_end(), two.range_end() - one.range_end());
+    two.union_of(resize_diff);
+  }
+
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[2]);
+  expect_sparse_read(mock_remote_io_ctx, two, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, two,
+               {m_local_snap_ids[0], {m_local_snap_ids[0]}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[0], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[1], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[2], OBJECT_EXISTS_CLEAN, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Trim) {
+  ASSERT_EQ(0, m_remote_image_ctx->operations->metadata_set(
+              "conf_rbd_skip_partial_discard", "false"));
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+  ASSERT_EQ(0, create_snap("one"));
+
+  // trim the object
+  uint64_t trim_offset = ceph::util::generate_random_number(one.range_end());
+  ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(
+    trim_offset, one.range_end() - trim_offset, m_remote_image_ctx->skip_partial_discard));
+  ASSERT_EQ(0, create_snap("sync"));
+
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[0]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_truncate(mock_local_io_ctx, trim_offset, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[0], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[1], OBJECT_EXISTS, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+TEST_F(TestMockImageSyncObjectCopyRequest, Remove) {
+  // scribble some data
+  interval_set<uint64_t> one;
+  scribble(m_remote_image_ctx, 10, 102400, &one);
+  ASSERT_EQ(0, create_snap("one"));
+  ASSERT_EQ(0, create_snap("two"));
+
+  // remove the object
+  uint64_t object_size = 1 << m_remote_image_ctx->order;
+  ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(0, object_size, m_remote_image_ctx->skip_partial_discard));
+  ASSERT_EQ(0, create_snap("sync"));
+  librbd::MockTestImageCtx mock_remote_image_ctx(*m_remote_image_ctx);
+  librbd::MockTestImageCtx mock_local_image_ctx(*m_local_image_ctx);
+
+  librbd::MockExclusiveLock mock_exclusive_lock;
+  mock_local_image_ctx.exclusive_lock = &mock_exclusive_lock;
+
+  librbd::MockObjectMap mock_object_map;
+  mock_local_image_ctx.object_map = &mock_object_map;
+
+  expect_test_features(mock_local_image_ctx);
+
+  C_SaferCond ctx;
+  MockObjectCopyRequest *request = create_request(mock_remote_image_ctx,
+                                                  mock_local_image_ctx, &ctx);
+
+  librados::MockTestMemIoCtxImpl &mock_remote_io_ctx(get_mock_io_ctx(
+    request->get_remote_io_ctx()));
+  librados::MockTestMemIoCtxImpl &mock_local_io_ctx(get_mock_io_ctx(
+    request->get_local_io_ctx()));
+
+  InSequence seq;
+  expect_list_snaps(mock_remote_image_ctx, mock_remote_io_ctx, 0);
+  expect_set_snap_read(mock_remote_io_ctx, m_remote_snap_ids[1]);
+  expect_sparse_read(mock_remote_io_ctx, 0, one.range_end(), 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_write(mock_local_io_ctx, 0, one.range_end(), {0, {}}, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_remove(mock_local_io_ctx, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[0], OBJECT_EXISTS, 0);
+  expect_start_op(mock_exclusive_lock);
+  expect_update_object_map(mock_local_image_ctx, mock_object_map,
+                           m_local_snap_ids[1], OBJECT_EXISTS_CLEAN, 0);
+
+  request->send();
+  ASSERT_EQ(0, ctx.wait());
+  ASSERT_EQ(0, compare_objects());
+}
+
+} // namespace image_sync
+} // namespace mirror
+} // namespace rbd

--- a/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
+++ b/src/test/rbd_mirror/image_sync/test_mock_ObjectCopyRequest.cc
@@ -58,8 +58,8 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size,
 {
   uint64_t object_size = 1 << image_ctx->order;
   for (int i=0; i<num_ops; i++) {
-    uint64_t off = ceph::util::generate_random_number(object_size - max_size + 1);
-    uint64_t len = 1 + ceph::util::generate_random_number(max_size);
+    uint64_t off = ceph::util::generate_random_number(object_size - max_size);
+    uint64_t len = ceph::util::generate_random_number(max_size);
 
     bufferlist bl;
     bl.append(std::string(len, '1'));
@@ -660,7 +660,7 @@ TEST_F(TestMockImageSyncObjectCopyRequest, Trim) {
   ASSERT_EQ(0, create_snap("one"));
 
   // trim the object
-  uint64_t trim_offset = ceph::util::generate_random_number(one.range_end());
+  uint64_t trim_offset = ceph::util::generate_random_number(one.range_end() - 1);
   ASSERT_LE(0, m_remote_image_ctx->io_work_queue->discard(
     trim_offset, one.range_end() - trim_offset, m_remote_image_ctx->skip_partial_discard));
   ASSERT_EQ(0, create_snap("sync"));

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -132,8 +132,8 @@ void write_image(librbd::Image &image) {
         io_modulo += MAX_IO_SIZE;
       }
 
-      uint32_t io_size = ((ceph::util::generate_random_number(io_modulo) + MIN_IO_SIZE) * 1024);
-      thread_offset[i] = ceph::util::generate_random_number(((size / io_size) - 1) * io_size;
+      uint32_t io_size = ((ceph::util::generate_random_number(io_modulo - 1) + MIN_IO_SIZE) * 1024);
+      thread_offset[i] = ceph::util::generate_random_number((size / io_size) - 1) * io_size;
       if (!b.start_write(NUM_THREADS, thread_offset[i], io_size, bl,
                          LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
         break;

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -116,7 +116,7 @@ void write_image(librbd::Image &image) {
 
   // disturb all thread's offset, used by seq write
   for (i = 0; i < NUM_THREADS; i++) {
-    start_pos = ceph::util::generate_random_number(size / max_io_bytes) * max_io_bytes;
+    start_pos = ceph::util::generate_random_number((size / max_io_bytes) - 1) * max_io_bytes;
     thread_offset.push_back(start_pos);
   }
 
@@ -128,12 +128,12 @@ void write_image(librbd::Image &image) {
     for (uint32_t i = 0; i < NUM_THREADS; ++i) {
       // mostly small writes with a small chance of large writes
       uint32_t io_modulo = MIN_IO_SIZE + 1;
-      if (ceph::util::generate_random_number(30) == 0) {
+      if (ceph::util::generate_random_number(30 - 1) == 0) {
         io_modulo += MAX_IO_SIZE;
       }
 
       uint32_t io_size = ((ceph::util::generate_random_number(io_modulo) + MIN_IO_SIZE) * 1024);
-      thread_offset[i] = ceph::util::generate_random_number(size / io_size) * io_size;
+      thread_offset[i] = ceph::util::generate_random_number(((size / io_size) - 1) * io_size;
       if (!b.start_write(NUM_THREADS, thread_offset[i], io_size, bl,
                          LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
         break;

--- a/src/test/rbd_mirror/random_write.cc
+++ b/src/test/rbd_mirror/random_write.cc
@@ -1,16 +1,21 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
 // vim: ts=8 sw=2 smarttab
 
+#include <string>
+#include <vector>
+
 #include "common/ceph_argparse.h"
 #include "common/config.h"
 #include "common/debug.h"
 #include "common/errno.h"
 #include "common/Cond.h"
+
+#include "include/util.h"
+#include "include/random.h"
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
+
 #include "global/global_init.h"
-#include <string>
-#include <vector>
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rbd_mirror
@@ -95,11 +100,9 @@ void rbd_bencher_completion(void *vc, void *pc) {
 }
 
 void write_image(librbd::Image &image) {
-  srand(time(NULL) % (unsigned long) -1);
-
   uint64_t max_io_bytes = MAX_IO_SIZE * 1024;
   bufferptr bp(max_io_bytes);
-  memset(bp.c_str(), rand() & 0xff, bp.length());
+  memset(bp.c_str(), ceph::util::generate_random_number() & 0xff, bp.length());
   bufferlist bl;
   bl.push_back(bp);
 
@@ -113,7 +116,7 @@ void write_image(librbd::Image &image) {
 
   // disturb all thread's offset, used by seq write
   for (i = 0; i < NUM_THREADS; i++) {
-    start_pos = (rand() % (size / max_io_bytes)) * max_io_bytes;
+    start_pos = ceph::util::generate_random_number(size / max_io_bytes) * max_io_bytes;
     thread_offset.push_back(start_pos);
   }
 
@@ -125,12 +128,12 @@ void write_image(librbd::Image &image) {
     for (uint32_t i = 0; i < NUM_THREADS; ++i) {
       // mostly small writes with a small chance of large writes
       uint32_t io_modulo = MIN_IO_SIZE + 1;
-      if (rand() % 30 == 0) {
+      if (ceph::util::generate_random_number(30) == 0) {
         io_modulo += MAX_IO_SIZE;
       }
 
-      uint32_t io_size = (((rand() % io_modulo) + MIN_IO_SIZE) * 1024);
-      thread_offset[i] = (rand() % (size / io_size)) * io_size;
+      uint32_t io_size = ((ceph::util::generate_random_number(io_modulo) + MIN_IO_SIZE) * 1024);
+      thread_offset[i] = ceph::util::generate_random_number(size / io_size) * io_size;
       if (!b.start_write(NUM_THREADS, thread_offset[i], io_size, bl,
                          LIBRADOS_OP_FLAG_FADVISE_RANDOM)) {
         break;

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -14,6 +14,8 @@
  *
  */
 
+#include "include/util.h"
+#include "include/random.h"
 #include "include/rados/librados.hpp"
 #include "include/rbd/librbd.hpp"
 #include "include/stringify.h"
@@ -354,7 +356,7 @@ public:
 
   void generate_test_data() {
     for (int i = 0; i < TEST_IO_SIZE; ++i) {
-      m_test_data[i] = (char) (rand() % (126 - 33) + 33);
+      m_test_data[i] = (char) (ceph::util::generate_random_number(126 - 33) + 33);
     }
     m_test_data[TEST_IO_SIZE] = '\0';
   }

--- a/src/test/rbd_mirror/test_ImageReplayer.cc
+++ b/src/test/rbd_mirror/test_ImageReplayer.cc
@@ -356,7 +356,7 @@ public:
 
   void generate_test_data() {
     for (int i = 0; i < TEST_IO_SIZE; ++i) {
-      m_test_data[i] = (char) (ceph::util::generate_random_number(126 - 33) + 33);
+      m_test_data[i] = (char) (ceph::util::generate_random_number(126 - 32) + 33);
     }
     m_test_data[TEST_IO_SIZE] = '\0';
   }

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -2,6 +2,8 @@
 // vim: ts=8 sw=2 smarttab
 
 #include "test/rbd_mirror/test_fixture.h"
+#include "include/util.h"
+#include "include/random.h"
 #include "include/stringify.h"
 #include "include/rbd/librbd.hpp"
 #include "journal/Journaler.h"
@@ -30,10 +32,10 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size)
 {
   max_size = std::min(image_ctx->size, max_size);
   for (int i=0; i<num_ops; i++) {
-    uint64_t off = rand() % (image_ctx->size - max_size + 1);
-    uint64_t len = 1 + rand() % max_size;
+    uint64_t off = ceph::util::generate_random_number(image_ctx->size - max_size + 1);
+    uint64_t len = 1 + ceph::util::generate_random_number(max_size);
 
-    if (rand() % 4 == 0) {
+    if (ceph::util::generate_random_number(4) == 0) {
       ASSERT_EQ((int)len, image_ctx->io_work_queue->discard(off, len, image_ctx->skip_partial_discard));
     } else {
       bufferlist bl;
@@ -244,7 +246,7 @@ TEST_F(TestImageSync, SnapshotStress) {
     scribble(m_remote_image_ctx, 10, 102400);
 
     librbd::NoOpProgressContext no_op_progress_ctx;
-    uint64_t size = 1 + rand() % m_image_size;
+    uint64_t size = 1 + ceph::util::generate_random_number(m_image_size);
     ASSERT_EQ(0, m_remote_image_ctx->operations->resize(size, true,
                                                         no_op_progress_ctx));
     ASSERT_EQ(0, m_remote_image_ctx->state->refresh());

--- a/src/test/rbd_mirror/test_ImageSync.cc
+++ b/src/test/rbd_mirror/test_ImageSync.cc
@@ -32,10 +32,10 @@ void scribble(librbd::ImageCtx *image_ctx, int num_ops, size_t max_size)
 {
   max_size = std::min(image_ctx->size, max_size);
   for (int i=0; i<num_ops; i++) {
-    uint64_t off = ceph::util::generate_random_number(image_ctx->size - max_size + 1);
-    uint64_t len = 1 + ceph::util::generate_random_number(max_size);
+    uint64_t off = ceph::util::generate_random_number(image_ctx->size - max_size);
+    uint64_t len = ceph::util::generate_random_number(static_cast<size_t>(1), max_size - 1);
 
-    if (ceph::util::generate_random_number(4) == 0) {
+    if (ceph::util::generate_random_number(3) == 0) {
       ASSERT_EQ((int)len, image_ctx->io_work_queue->discard(off, len, image_ctx->skip_partial_discard));
     } else {
       bufferlist bl;
@@ -246,7 +246,7 @@ TEST_F(TestImageSync, SnapshotStress) {
     scribble(m_remote_image_ctx, 10, 102400);
 
     librbd::NoOpProgressContext no_op_progress_ctx;
-    uint64_t size = 1 + ceph::util::generate_random_number(m_image_size);
+    uint64_t size = ceph::util::generate_random_number(1, m_image_size - 1);
     ASSERT_EQ(0, m_remote_image_ctx->operations->resize(size, true,
                                                         no_op_progress_ctx));
     ASSERT_EQ(0, m_remote_image_ctx->state->refresh());

--- a/src/test/rbd_mirror/test_fixture.cc
+++ b/src/test/rbd_mirror/test_fixture.cc
@@ -3,6 +3,7 @@
 
 #include "cls/rbd/cls_rbd_types.h"
 #include "test/rbd_mirror/test_fixture.h"
+#include "include/random.h"
 #include "include/stringify.h"
 #include "include/rbd/librbd.hpp"
 #include "librbd/ImageCtx.h"
@@ -59,13 +60,6 @@ void TestFixture::TearDownTestCase() {
 }
 
 void TestFixture::SetUp() {
-  static bool seeded = false;
-  if (!seeded) {
-    seeded = true;
-    int seed = getpid();
-    cout << "seed " << seed << std::endl;
-    srand(seed);
-  }
 
   ASSERT_EQ(0, _rados->ioctx_create(_local_pool_name.c_str(), m_local_io_ctx));
   ASSERT_EQ(0, _rados->ioctx_create(_remote_pool_name.c_str(), m_remote_io_ctx));

--- a/src/test/system/rados_list_parallel.cc
+++ b/src/test/system/rados_list_parallel.cc
@@ -93,7 +93,7 @@ public:
     while (true) {
       if (to_delete.empty())
 	break;
-      int r = ceph::util::generate_random_number(to_delete.size());
+      int r = ceph::util::generate_random_number(to_delete.size() - 1);
       std::map <int, std::string>::iterator d = to_delete.begin();
       for (int i = 0; i < r; ++i)
 	++d;
@@ -178,7 +178,7 @@ public:
     while (true) {
       if (to_add.empty())
 	break;
-      int r = ceph::util::generate_random_number(to_add.size());
+      int r = ceph::util::generate_random_number(to_add.size() - 1);
       std::map <int, std::string>::iterator d = to_add.begin();
       for (int i = 0; i < r; ++i)
 	++d;

--- a/src/test/system/rados_list_parallel.cc
+++ b/src/test/system/rados_list_parallel.cc
@@ -12,27 +12,34 @@
 *
 */
 
+#include <map>
+#include <ctime>
+#include <cstdio>
+#include <cerrno>
+#include <string>
+#include <vector>
+#include <sstream>
+#include <cstdarg>
+#include <cstdlib>
+
+#include <unistd.h>
+
+#include <sys/types.h>
+
+#include <pthread.h>
+#include <semaphore.h>
+
 #include "cross_process_sem.h"
+
+#include "include/util.h"
+#include "include/random.h"
 #include "include/rados/librados.h"
 #include "include/stringify.h"
+
 #include "st_rados_create_pool.h"
 #include "st_rados_list_objects.h"
 #include "systest_runnable.h"
 #include "systest_settings.h"
-
-#include <errno.h>
-#include <map>
-#include <pthread.h>
-#include <semaphore.h>
-#include <sstream>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string>
-#include <time.h>
-#include <vector>
-#include <sys/types.h>
-#include <unistd.h>
 
 using std::ostringstream;
 using std::string;
@@ -86,7 +93,7 @@ public:
     while (true) {
       if (to_delete.empty())
 	break;
-      int r = rand() % to_delete.size();
+      int r = ceph::util::generate_random_number(to_delete.size());
       std::map <int, std::string>::iterator d = to_delete.begin();
       for (int i = 0; i < r; ++i)
 	++d;
@@ -171,7 +178,7 @@ public:
     while (true) {
       if (to_add.empty())
 	break;
-      int r = rand() % to_add.size();
+      int r = ceph::util::generate_random_number(to_add.size());
       std::map <int, std::string>::iterator d = to_add.begin();
       for (int i = 0; i < r; ++i)
 	++d;

--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -39,7 +39,7 @@ std::string StRadosCreatePool::
 get_random_buf(int sz)
 {
   ostringstream oss;
-  int size = ceph::util::generate_random_number(sz);
+  int size = ceph::util::generate_random_number(sz - 1);
   for (int i = 0; i < size; ++i) {
     oss << ".";
   }

--- a/src/test/system/st_rados_create_pool.cc
+++ b/src/test/system/st_rados_create_pool.cc
@@ -12,19 +12,26 @@
 *
 */
 
+#include <cerrno>
+#include <cstdio>
+#include <string>
+#include <cstdlib>
+#include <cstdarg>
+#include <cstring>
+#include <sstream>
+
+#include <unistd.h>
+
 #include "cross_process_sem.h"
+
+#include "include/util.h"
+#include "include/random.h"
 #include "include/rados/librados.h"
+
 #include "st_rados_create_pool.h"
+
 #include "systest_runnable.h"
 #include "systest_settings.h"
-
-#include <errno.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <unistd.h>
-#include <sstream>
-#include <string>
 
 using std::ostringstream;
 
@@ -32,7 +39,7 @@ std::string StRadosCreatePool::
 get_random_buf(int sz)
 {
   ostringstream oss;
-  int size = rand() % sz; // yep, it's not very random
+  int size = ceph::util::generate_random_number(sz);
   for (int i = 0; i < size; ++i) {
     oss << ".";
   }

--- a/src/test/test_filejournal.cc
+++ b/src/test/test_filejournal.cc
@@ -1,18 +1,25 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include <gtest/gtest.h>
-#include <stdlib.h>
-#include <limits.h>
+
+#include <cstdlib>
+#include <climits>
+
+#include "global/global_init.h"
 
 #include "common/ceph_argparse.h"
 #include "common/common_init.h"
-#include "global/global_init.h"
 #include "common/config.h"
 #include "common/Finisher.h"
-#include "os/filestore/FileJournal.h"
-#include "include/Context.h"
 #include "common/Mutex.h"
 #include "common/safe_io.h"
+
+#include "include/util.h"
+#include "include/random.h"
+#include "include/Context.h"
+
+#include "os/filestore/FileJournal.h"
 #include "os/filestore/JournalingObjectStore.h"
+
+#include <gtest/gtest.h>
 
 Finisher *finisher;
 Cond sync_cond;
@@ -94,8 +101,7 @@ int main(int argc, char **argv) {
     }
   }
   if ( path[0] == '\0') {
-    srand(getpid() + time(0));
-    snprintf(path, sizeof(path), "/var/tmp/ceph_test_filejournal.tmp.%d", rand());
+    snprintf(path, sizeof(path), "/var/tmp/ceph_test_filejournal.tmp.%d", ceph::util::generate_random_number());
   }
   cout << "path " << path << std::endl;
 

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -26,7 +26,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = ceph::util::generate_random_number(cont.size());
+  int index = ceph::util::generate_random_number(cont.size() - 1);
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -37,7 +37,7 @@ string random_string(size_t size)
 {
   string name;
   for (size_t j = 0; j < size; ++j) {
-    name.push_back('a' + ceph::util::generate_random_number(26));
+    name.push_back('a' + ceph::util::generate_random_number(26 - 1));
   }
   return name;
 }
@@ -132,8 +132,8 @@ private:
 	for (list<Op>::iterator i = ops.begin();
 	     i != ops.end();
 	     ops.erase(i++)) {
-	  if (!ceph::util::generate_random_number(3))
-	    usleep(1+ceph::util::generate_random_number(5000));
+	  if (!ceph::util::generate_random_number(2))
+	    usleep(ceph::util::generate_random_number(1, 5000));
 	  Mutex::Locker l(parent->lock);
 	  (*i)->operate(&(parent->store));
 	}
@@ -425,7 +425,7 @@ TEST_F(MapCacherTest, Random)
     if (!(i % 50)) {
       std::cout << "On iteration " << i << std::endl;
     }
-    switch (ceph::util::generate_random_number(4)) {
+    switch (ceph::util::generate_random_number(3)) {
     case 0:
       get();
       break;
@@ -464,11 +464,11 @@ public:
 
   hobject_t random_hobject() {
     return hobject_t(
-      random_string(1+ceph::util::generate_random_number(16)),
-      random_string(1+ceph::util::generate_random_number(16)),
-      snapid_t(ceph::util::generate_random_number(1000)),
+      random_string(ceph::util::generate_random_number(1, 16)),
+      random_string(ceph::util::generate_random_number(1, 16)),
+      snapid_t(ceph::util::generate_random_number(1000 - 1)),
       (ceph::util::generate_random_number() & ((~0)<<bits)) | (mask & ~((~0)<<bits)),
-      0, random_string(ceph::util::generate_random_number(16)));
+      0, random_string(ceph::util::generate_random_number(15)));
   }
 
   void choose_random_snaps(int num, set<snapid_t> *snaps) {
@@ -494,7 +494,7 @@ public:
     } while (hobject_to_snap.count(obj));
 
     set<snapid_t> &snaps = hobject_to_snap[obj];
-    choose_random_snaps(1 + ceph::util::generate_random_number(20), &snaps);
+    choose_random_snaps(ceph::util::generate_random_number(1, 19), &snaps);
     for (set<snapid_t>::iterator i = snaps.begin();
 	 i != snaps.end();
 	 ++i) {
@@ -519,7 +519,7 @@ public:
 
     vector<hobject_t> hoids;
     while (mapper->get_next_objects_to_trim(
-	     snap->first, ceph::util::generate_random_number(5) + 1, &hoids) == 0) {
+	     snap->first, ceph::util::generate_random_number(1, 4), &hoids) == 0) {
       for (auto &&hoid: hoids) {
 	assert(!hoid.is_max());
 	assert(hobjects.count(hoid));
@@ -628,7 +628,7 @@ protected:
     for (int i = 0; i < 5000; ++i) {
       if (!(i % 50))
 	std::cout << i << std::endl;
-      switch (ceph::util::generate_random_number(5)) {
+      switch (ceph::util::generate_random_number(4)) {
       case 0:
 	get_tester().create_snap();
 	break;

--- a/src/test/test_snap_mapper.cc
+++ b/src/test/test_snap_mapper.cc
@@ -1,13 +1,20 @@
 // -*- mode:C++; tab-width:8; c-basic-offset:2; indent-tabs-mode:t -*-
-#include "include/memory.h"
+
 #include <map>
 #include <set>
-#include <boost/scoped_ptr.hpp>
-#include <sys/types.h>
 #include <cstdlib>
 
+#include <boost/scoped_ptr.hpp>
+
+#include <sys/types.h>
+
+#include "include/util.h"
+#include "include/memory.h"
 #include "include/buffer.h"
+#include "include/random.h"
+
 #include "common/map_cacher.hpp"
+
 #include "osd/SnapMapper.h"
 
 #include "gtest/gtest.h"
@@ -19,7 +26,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = rand() % cont.size();
+  int index = ceph::util::generate_random_number(cont.size());
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;
@@ -30,7 +37,7 @@ string random_string(size_t size)
 {
   string name;
   for (size_t j = 0; j < size; ++j) {
-    name.push_back('a' + (rand() % 26));
+    name.push_back('a' + ceph::util::generate_random_number(26));
   }
   return name;
 }
@@ -125,8 +132,8 @@ private:
 	for (list<Op>::iterator i = ops.begin();
 	     i != ops.end();
 	     ops.erase(i++)) {
-	  if (!(rand()%3))
-	    usleep(1+(rand() % 5000));
+	  if (!ceph::util::generate_random_number(3))
+	    usleep(1+ceph::util::generate_random_number(5000));
 	  Mutex::Locker l(parent->lock);
 	  (*i)->operate(&(parent->store));
 	}
@@ -279,7 +286,7 @@ public:
   }
   void random_bl(size_t size, bufferlist *bl) {
     for (size_t i = 0; i < size; ++i) {
-      bl->append(rand());
+      bl->append(ceph::util::generate_random_number());
     }
   }
   void do_set() {
@@ -418,7 +425,7 @@ TEST_F(MapCacherTest, Random)
     if (!(i % 50)) {
       std::cout << "On iteration " << i << std::endl;
     }
-    switch (rand() % 4) {
+    switch (ceph::util::generate_random_number(4)) {
     case 0:
       get();
       break;
@@ -457,11 +464,11 @@ public:
 
   hobject_t random_hobject() {
     return hobject_t(
-      random_string(1+(rand() % 16)),
-      random_string(1+(rand() % 16)),
-      snapid_t(rand() % 1000),
-      (rand() & ((~0)<<bits)) | (mask & ~((~0)<<bits)),
-      0, random_string(rand() % 16));
+      random_string(1+ceph::util::generate_random_number(16)),
+      random_string(1+ceph::util::generate_random_number(16)),
+      snapid_t(ceph::util::generate_random_number(1000)),
+      (ceph::util::generate_random_number() & ((~0)<<bits)) | (mask & ~((~0)<<bits)),
+      0, random_string(ceph::util::generate_random_number(16)));
   }
 
   void choose_random_snaps(int num, set<snapid_t> *snaps) {
@@ -487,7 +494,7 @@ public:
     } while (hobject_to_snap.count(obj));
 
     set<snapid_t> &snaps = hobject_to_snap[obj];
-    choose_random_snaps(1 + (rand() % 20), &snaps);
+    choose_random_snaps(1 + ceph::util::generate_random_number(20), &snaps);
     for (set<snapid_t>::iterator i = snaps.begin();
 	 i != snaps.end();
 	 ++i) {
@@ -512,7 +519,7 @@ public:
 
     vector<hobject_t> hoids;
     while (mapper->get_next_objects_to_trim(
-	     snap->first, rand() % 5 + 1, &hoids) == 0) {
+	     snap->first, ceph::util::generate_random_number(5) + 1, &hoids) == 0) {
       for (auto &&hoid: hoids) {
 	assert(!hoid.is_max());
 	assert(hobjects.count(hoid));
@@ -621,7 +628,7 @@ protected:
     for (int i = 0; i < 5000; ++i) {
       if (!(i % 50))
 	std::cout << i << std::endl;
-      switch (rand() % 5) {
+      switch (ceph::util::generate_random_number(5)) {
       case 0:
 	get_tester().create_snap();
 	break;

--- a/src/test/testmsgr.cc
+++ b/src/test/testmsgr.cc
@@ -12,24 +12,31 @@
  * 
  */
 
-#include <sys/stat.h>
 #include <iostream>
 #include <string>
-using namespace std;
 
-#include "common/config.h"
+#include <sys/stat.h>
 
 #include "mon/MonMap.h"
 #include "mon/MonClient.h"
+
 #include "msg/Messenger.h"
+
 #include "messages/MPing.h"
 
+#include "common/config.h"
 #include "common/Timer.h"
-#include "global/global_init.h"
 #include "common/ceph_argparse.h"
 
-#include <sys/types.h>
+#include "include/util.h"
+#include "include/random.h"
+
+#include "global/global_init.h"
+
 #include <fcntl.h>
+#include <sys/types.h>
+
+using namespace std;
 
 #define dout_subsys ceph_subsys_ms
 
@@ -121,11 +128,11 @@ int main(int argc, const char **argv, const char *envp[]) {
       cond.Wait(test_lock);
     }
 
-    int t = rand() % mc.get_num_mon();
+    int t = ceph::util::generate_random_number(mc.get_num_mon());
     if (t == whoami)
       continue;
     
-    if (rand() % 10 == 0) {
+    if (ceph::util::generate_random_number(10) == 0) {
       //cerr << "mark_down " << t << std::endl;
       dout(0) << "mark_down " << t << dendl;
       messenger->mark_down(mc.get_mon_addr(t));

--- a/src/test/testmsgr.cc
+++ b/src/test/testmsgr.cc
@@ -128,11 +128,11 @@ int main(int argc, const char **argv, const char *envp[]) {
       cond.Wait(test_lock);
     }
 
-    int t = ceph::util::generate_random_number(mc.get_num_mon());
+    int t = ceph::util::generate_random_number(mc.get_num_mon() - 1);
     if (t == whoami)
       continue;
     
-    if (ceph::util::generate_random_number(10) == 0) {
+    if (ceph::util::generate_random_number(10 - 1) == 0) {
       //cerr << "mark_down " << t << std::endl;
       dout(0) << "mark_down " << t << dendl;
       messenger->mark_down(mc.get_mon_addr(t));

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -12,24 +12,31 @@
  *
  */
 
-#include <stdio.h>
-#include <time.h>
-#include <string.h>
+#include <ctime>
+#include <cstdio>
+#include <cstring>
 #include <iostream>
 #include <sstream>
-#include "os/filestore/FileStore.h"
-#include "include/Context.h"
-#include "common/ceph_argparse.h"
-#include "global/global_init.h"
-#include "common/Mutex.h"
-#include "common/Cond.h"
+
 #include <boost/scoped_ptr.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/uniform_int.hpp>
 #include <boost/random/binomial_distribution.hpp>
-#include <gtest/gtest.h>
 
+#include "global/global_init.h"
+
+#include "include/util.h"
+#include "include/random.h"
+#include "include/Context.h"
 #include "include/unordered_map.h"
+
+#include "common/Mutex.h"
+#include "common/Cond.h"
+#include "common/ceph_argparse.h"
+
+#include "os/filestore/FileStore.h"
+
+#include <gtest/gtest.h>
 
 void usage(const string &name) {
   std::cerr << "Usage: " << name << " [xattr|omap] store_path store_journal"
@@ -43,7 +50,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = rand() % cont.size();
+  int index = ceph::util::generate_random_number(cont.size());
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;

--- a/src/test/xattr_bench.cc
+++ b/src/test/xattr_bench.cc
@@ -50,7 +50,7 @@ typename T::iterator rand_choose(T &cont) {
   if (cont.size() == 0) {
     return cont.end();
   }
-  int index = ceph::util::generate_random_number(cont.size());
+  int index = ceph::util::generate_random_number(cont.size() - 1);
   typename T::iterator retval = cont.begin();
 
   for (; index > 0; --index) ++retval;

--- a/src/tools/ceph_monstore_tool.cc
+++ b/src/tools/ceph_monstore_tool.cc
@@ -10,28 +10,38 @@
 * License version 2.1, as published by the Free Software
 * Foundation. See file COPYING.
 */
+#include <string>
+#include <cstdlib>
+
 #include <boost/program_options/variables_map.hpp>
 #include <boost/program_options/parsers.hpp>
 #include <boost/scope_exit.hpp>
 
-#include <stdlib.h>
-#include <string>
+#include "include/util.h"
+#include "include/random.h"
+#include "include/stringify.h"
 
 #include "common/Formatter.h"
 #include "common/errno.h"
 
 #include "auth/KeyRing.h"
 #include "auth/cephx/CephxKeyServer.h"
+
 #include "global/global_init.h"
-#include "include/stringify.h"
+
 #include "mgr/mgr_commands.h"
+
 #include "mon/AuthMonitor.h"
 #include "mon/MonitorDBStore.h"
 #include "mon/Paxos.h"
 #include "mon/MonMap.h"
-#include "mds/FSMap.h"
 #include "mon/MgrMap.h"
+
+#include "mds/MDSMap.h"
+#include "mds/FSMap.h"
+
 #include "osd/OSDMap.h"
+
 #include "crush/CrushCompiler.h"
 
 namespace po = boost::program_options;
@@ -1261,7 +1271,7 @@ int main(int argc, char **argv) {
 	stringstream os;
 	os << num;
 	bufferlist bl;
-	for (unsigned k = 0; k < tvalsize; ++k) bl.append(rand());
+	for (unsigned k = 0; k < tvalsize; ++k) bl.append(ceph::util::generate_random_number());
 	t->put(prefix, os.str(), bl);
 	++num;
       }

--- a/src/tools/monmaptool.cc
+++ b/src/tools/monmaptool.cc
@@ -13,11 +13,14 @@
  */
 #include <string>
 
+#include "include/random.h"
+#include "include/str_list.h"
+
 #include "common/ceph_argparse.h"
 #include "common/errno.h"
 
 #include "global/global_init.h"
-#include "include/str_list.h"
+
 #include "mon/MonMap.h"
 
 
@@ -308,7 +311,7 @@ int main(int argc, const char **argv)
     monmap.epoch = 0;
     monmap.created = ceph_clock_now();
     monmap.last_changed = monmap.created;
-    srand(getpid() + time(0));
+
     if (g_conf->get_val<uuid_d>("fsid").is_zero()) {
       monmap.generate_fsid();
       cout << me << ": generated fsid " << monmap.fsid << std::endl;

--- a/src/tools/osdmaptool.cc
+++ b/src/tools/osdmaptool.cc
@@ -15,6 +15,9 @@
 #include <string>
 #include <sys/stat.h>
 
+#include "include/util.h"
+#include "include/random.h"
+
 #include "common/ceph_argparse.h"
 #include "common/errno.h"
 #include "common/safe_io.h"
@@ -485,7 +488,7 @@ int main(int argc, const char **argv)
     vector<int> primary_count(n, 0);
     vector<int> size(30, 0);
     if (test_random)
-      srand(getpid());
+      ceph::util::randomize_rng();
     auto& pools = osdmap.get_pools();
     for (auto p = pools.begin(); p != pools.end(); ++p) {
       if (pool != -1 && p->first != pool)
@@ -503,7 +506,7 @@ int main(int argc, const char **argv)
 	if (test_random) {
 	  osds.resize(p->second.size);
 	  for (unsigned i=0; i<osds.size(); ++i) {
-	    osds[i] = rand() % osdmap.get_max_osd();
+	    osds[i] = ceph::util::generate_random_number(osdmap.get_max_osd());
 	  }
 	  primary = osds[0];
 	} else if (test_map_pgs_dump_all) {

--- a/src/tools/rados/rados.cc
+++ b/src/tools/rados/rados.cc
@@ -760,10 +760,10 @@ void LoadGen::gen_op(LoadGenOp *op)
   obj_info& info = objs[i];
   op->oid = info.name;
 
-  size_t len = generate_random_number(min_op_len, max_op_len);
+  size_t len = generate_random_number(min_op_len, max_op_len - 1);
   if (len > info.len)
     len = info.len;
-  size_t off = generate_random_number<size_t>(0, info.len);
+  size_t off = generate_random_number<size_t>(0, info.len - 1);
 
   if (off + len > info.len)
     off = info.len - len;

--- a/src/tools/rbd/action/Bench.cc
+++ b/src/tools/rbd/action/Bench.cc
@@ -290,7 +290,7 @@ int do_bench(librbd::Image& image, io_type_t io_type,
       b.start_io(io_threads, thread_offset[i], io_size, op_flags, read_flag);
 
       if (random) {
-        thread_offset[i] = ceph::util::generate_random_number(size / io_size) * io_size;
+        thread_offset[i] = ceph::util::generate_random_number((size / io_size) - 1) * io_size;
       } else {
         thread_offset[i] += io_size;
         if (thread_offset[i] + io_size > size)


### PR DESCRIPTION
Migrates call sites to the new random number library. Should affect any rand() calls, as well as calls to Boost random and other random number generation. Also includes enhancements to Ceph random number library to allow parametric parameters to the default calls, along with simplifications to the implementation (could make a separate PR if desired).

Please check to see if I have migrated things appropriately, there were lots of moving parts in some of these!

Thank you!