### PR TITLE
osd/PrimaryLogPG: do not use approx_size() for log trimming

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1539,10 +1539,11 @@ void PrimaryLogPG::calc_trim_to()
   eversion_t limit = MIN(
     min_last_complete_ondisk,
     pg_log.get_can_rollback_to());
+  size_t log_size = pg_log.get_log().log.size();
   if (limit != eversion_t() &&
       limit != pg_trim_to &&
-      pg_log.get_log().approx_size() > target) {
-    size_t num_to_trim = pg_log.get_log().approx_size() - target;
+      log_size > target) {
+    size_t num_to_trim = log_size - target;
     if (num_to_trim < cct->_conf->osd_pg_log_trim_min) {
       return;
     }


### PR DESCRIPTION
There might be holes on log versions, thus the approx_size()
should (almost) always overestimate the actual number of log entries.
As a result, we might be at the risk of accessing violation (though it's rare)
while searching for the oldest log entry to keep in the log list later.

Fix the above problem by counting the precise number of current
log entries instead.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>