### PR TITLE
osd/PG: switch default objectstore to bluestore

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3008,7 +3008,7 @@ std::vector<Option> get_global_options() {
     .set_description(""),
 
     Option("osd_objectstore", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("filestore")
+    .set_default("bluestore")
     .set_description(""),
 
     Option("osd_objectstore_tracing", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
maybe we should switch default objectstore to bluestore in config file, since from luminous v12.2.0  the release notes: [see](https://github.com/ceph/ceph/pull/16915/files#diff-d31d1b025d45818c51583cfa5f76c9c9R26)

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>