### PR TITLE
doc: Remove additional arguments when replacing OSD

### DIFF
--- a/doc/rados/operations/add-or-rm-osds.rst
+++ b/doc/rados/operations/add-or-rm-osds.rst
@@ -184,9 +184,9 @@ need to be keep intact after the OSD is destroyed for replacement.
 
 #. Prepare the disk for replacement by using the previously destroyed OSD id::
 
-     ceph-disk prepare --bluestore /dev/sdX  --osd-id {id} --osd-uuid `uuidgen`
+     ceph-disk prepare --osd-id {id} /dev/sdX
 
-#. And activate the OSD::
+#. And activate the OSD (if not done automatically)::
 
      ceph-disk activate /dev/sdX1
 


### PR DESCRIPTION
It's not required to provide the --bluestore nor --osd-uuid option
to ceph-disk.

Using BlueStore is the default on master (e.g. Luminous) and thus
this option is not required.

When no OSD UUID is supplied ceph-disk will generate one, so we do
not need to supply one generated by uuidgen.

Signed-off-by: Wido den Hollander <wido@42on.com>