### PR TITLE
common/event_socket.h: include <errno.h> to use errno

### DIFF
--- a/src/common/event_socket.h
+++ b/src/common/event_socket.h
@@ -18,7 +18,7 @@
 #define CEPH_COMMON_EVENT_SOCKET_H
 
 #include <unistd.h>
-#if defined(__FreeBSD__)
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <errno.h>
 #endif
 #include "include/event_type.h"

--- a/src/common/lockdep.cc
+++ b/src/common/lockdep.cc
@@ -216,7 +216,7 @@ void lockdep_unregister(int id)
   std::string name;
   map<int, std::string>::iterator p = lock_names.find(id);
   if (p == lock_names.end())
-    name = { "unknown" };
+    name = "unknown" ;
   else
     name = p->second;
 


### PR DESCRIPTION
OSX needs this also.

Signed-off-by: Kefu Chai <kchai@redhat.com>