### PR TITLE
Revert "bluestore/fio: Fixed problem with all objects having the same…

### DIFF
--- a/src/test/fio/fio_ceph_objectstore.cc
+++ b/src/test/fio/fio_ceph_objectstore.cc
@@ -179,9 +179,7 @@ struct Object {
   Collection& coll;
 
   Object(const char* name, Collection& coll)
-    : oid(hobject_t(name, "", CEPH_NOSNAP,
-                    ceph_str_hash(CEPH_STR_HASH_RJENKINS, name, strlen(name)),
-                    coll.pg.pool(), "")),
+    : oid(hobject_t(name, "", CEPH_NOSNAP, coll.pg.ps(), coll.pg.pool(), "")),
       coll(coll) {}
 };
 


### PR DESCRIPTION
… hash"

This reverts commit 0eb5359273df2c92fa525683f88586878f57bb4b.

The commit is causing assertion failure in `BlueStore::OnodeRef BlueStore::Collection::get_onode()` when `osd pool default pg num > 1`.