### PR TITLE
osd: make scrub no deadline when max interval is zero

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -6808,7 +6808,12 @@ OSDService::ScrubJob::ScrubJob(CephContext* cct,
     double r = rand() / (double)RAND_MAX;
     sched_time +=
       scrub_min_interval * cct->_conf->osd_scrub_interval_randomize_ratio * r;
-    deadline += scrub_max_interval;
+    if (scrub_max_interval == 0) {
+      deadline = utime_t();
+    } else {
+      deadline += scrub_max_interval;
+    }
+
   }
 }
 
@@ -6911,7 +6916,7 @@ void OSD::sched_scrub()
 	break;
       }
 
-      if ((scrub.deadline >= now) && !(time_permit && load_is_low)) {
+      if ((scrub.deadline.is_zero() || scrub.deadline >= now) && !(time_permit && load_is_low)) {
         dout(10) << __func__ << " not scheduling scrub for " << scrub.pgid << " due to "
                  << (!time_permit ? "time not permit" : "high load") << dendl;
         continue;


### PR DESCRIPTION
some times, we only want scrub at out permitted time, avoid
scrub mainly deep scrub affecting business io. this patch make no scrub deadline 
when osd_scrub_max_interval == 0, make sure scrub can only do in
expect time.

Signed-off-by: kungf <yang.wang@easystack.cn>
@yangdongsheng 

