### PR TITLE
rgw_file: explicit NFSv3 open() emulation

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1943,8 +1943,14 @@ int rgw_write(struct rgw_fs *rgw_fs,
   if (! rgw_fh->is_file())
     return -EISDIR;
 
-  if (! rgw_fh->is_open())
-    return -EPERM;
+  if (! rgw_fh->is_open()) {
+    if (flags & RGW_OPEN_FLAG_V3) {
+      rc = rgw_fh->open(flags);
+      if (!! rc)
+	return rc;
+    } else
+      return -EPERM;
+  }
 
   rc = rgw_fh->write(offset, length, bytes_written, buffer);
 


### PR DESCRIPTION
Expect RGW_OPEN_FLAG_V3 in rgw_write(), and if present, attempt
a stateless open inline.

Required by Ganesha v2.5 and later

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>