### PR TITLE
mon: tidy up mds_blacklist_interval

### DIFF
--- a/doc/cephfs/eviction.rst
+++ b/doc/cephfs/eviction.rst
@@ -136,10 +136,3 @@ eviction command to each active daemon.  When blacklisting is enabled
 (the default), sending an eviction to command to just a single
 MDS is sufficient, because the blacklist propagates it to the others.
 
-Advanced options
-================
-
-``mds_blacklist_interval`` - this setting controls how many seconds
-entries will remain in the blacklist for.
-
-

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -433,7 +433,6 @@ OPTION(mds_decay_halflife, OPT_FLOAT)
 OPTION(mds_beacon_interval, OPT_FLOAT)
 OPTION(mds_beacon_grace, OPT_FLOAT)
 OPTION(mds_enforce_unique_name, OPT_BOOL)
-OPTION(mds_blacklist_interval, OPT_FLOAT)  // how long to blacklist failed nodes
 
 OPTION(mds_session_timeout, OPT_FLOAT)    // cap bits and leases time out if client idle
 OPTION(mds_session_blacklist_on_timeout, OPT_BOOL)    // whether to blacklist clients whose sessions are dropped due to timeout

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1365,7 +1365,14 @@ std::vector<Option> get_global_options() {
 
     Option("mon_osd_blacklist_default_expire", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
     .set_default(1_hr)
-    .set_description(""),
+    .set_description("Duration in seconds that blacklist entries for clients "
+                     "remain in the OSD map"),
+
+    Option("mds_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    .set_default(1_day)
+    .set_min(1_hr)
+    .set_description("Duration in seconds that blacklist entries for MDS "
+                     "daemons remain in the OSD map"),
 
     Option("mon_osd_crush_smoke_test", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
@@ -5453,10 +5460,6 @@ std::vector<Option> get_mds_options() {
 
     Option("mds_enforce_unique_name", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
-    .set_description(""),
-
-    Option("mds_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
-    .set_default(24.0*60.0)
     .set_description(""),
 
     Option("mds_session_timeout", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1368,7 +1368,7 @@ std::vector<Option> get_global_options() {
     .set_description("Duration in seconds that blacklist entries for clients "
                      "remain in the OSD map"),
 
-    Option("mds_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
+    Option("mon_mds_blacklist_interval", Option::TYPE_FLOAT, Option::LEVEL_DEV)
     .set_default(1_day)
     .set_min(1_hr)
     .set_description("Duration in seconds that blacklist entries for MDS "

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -684,7 +684,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
               << info.rank << " damaged" << dendl;
 
       utime_t until = ceph_clock_now();
-      until += g_conf->mds_blacklist_interval;
+      until += g_conf->get_val<double>("mds_blacklist_interval");
       const auto blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
       request_proposal(mon->osdmon());
       pending_fsmap.damaged(gid, blacklist_epoch);
@@ -1138,7 +1138,7 @@ bool MDSMonitor::fail_mds_gid(mds_gid_t gid)
   epoch_t blacklist_epoch = 0;
   if (info.rank >= 0 && info.state != MDSMap::STATE_STANDBY_REPLAY) {
     utime_t until = ceph_clock_now();
-    until += g_conf->mds_blacklist_interval;
+    until += g_conf->get_val<double>("mds_blacklist_interval");
     blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
   }
 

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -684,7 +684,7 @@ bool MDSMonitor::prepare_beacon(MonOpRequestRef op)
               << info.rank << " damaged" << dendl;
 
       utime_t until = ceph_clock_now();
-      until += g_conf->get_val<double>("mds_blacklist_interval");
+      until += g_conf->get_val<double>("mon_mds_blacklist_interval");
       const auto blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
       request_proposal(mon->osdmon());
       pending_fsmap.damaged(gid, blacklist_epoch);
@@ -1138,7 +1138,7 @@ bool MDSMonitor::fail_mds_gid(mds_gid_t gid)
   epoch_t blacklist_epoch = 0;
   if (info.rank >= 0 && info.state != MDSMap::STATE_STANDBY_REPLAY) {
     utime_t until = ceph_clock_now();
-    until += g_conf->get_val<double>("mds_blacklist_interval");
+    until += g_conf->get_val<double>("mon_mds_blacklist_interval");
     blacklist_epoch = mon->osdmon()->blacklist(info.addr, until);
   }
 


### PR DESCRIPTION
Remove the misleading reference to this from the client
eviction page, it was never the right option to mention
there (my mistake).

Demote the option from LEVEL_ADVANCED to LEVEL_DEV as it
is hard to imagine a good reason for the user to change it.

Set a hard minimum of one hour, to make it harder to
corrupt` a system by setting it close to zero.

Remove the legacy definition of the field while we're at it.

Fixes: http://tracker.ceph.com/issues/21821
Signed-off-by: John Spray <john.spray@redhat.com>