### PR TITLE
doc: update Component Technical Leads and maintainers to canonical location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,27 +4,7 @@ Sage Weil <sage@redhat.com>
 
 Component Technical Leads
 -------------------------
-Core, RADOS     - Josh Durgin <jdurgin@redhat.com>
-RBD             - Jason Dillaman <dillaman@redhat.com>
-RBD (kernel)    - Ilya Dryomov <idryomov@redhat.com>
-RGW             - Yehuda Sadeh <yehuda@redhat.com>
-                  Matt Benjamin <mbenjami@redhat.com>
-CephFS          - Patrick Donnelly <pdonnell@redhat.com>
-CephFS (kernel) - Yan, Zheng <zyan@redhat.com>
-Deployment      - Alfredo Deza <adeza@redhat.com>
-Teuthology      - Zack Cerza <zack@redhat.com>
-Calamari        - Gregory Meno <gmeno@redhat.com>
-Chef Cookbook   - Guilhem Lettron <guilhem@lettron.fr>
-
-Release Manager
----------------
-Abhishek Lekshmanan <abhishek@suse.com>
-
-Backport Team
--------------
-Nathan Cutler <ncutler@suse.cz>
-Shinobu Kinjo <shinobu@redhat.com>
-Abhishek Lekshmanan <abhishek@suse.com>
+For a full list of CTLs and maintainers visit: http://ceph.com/team/
 
 Contributors
 ------------


### PR DESCRIPTION
…l location of ceph.com.

Signed-off-by: Patrick McGarry <pmcgarry@redhat.com>