### PR TITLE
rgw: Fix getter function names in RGWEnv

### DIFF
--- a/src/rgw/rgw_common.cc
+++ b/src/rgw/rgw_common.cc
@@ -273,9 +273,9 @@ req_state::req_state(CephContext* _cct, RGWEnv* e, RGWUserInfo* u)
   : cct(_cct), cio(NULL), op(OP_UNKNOWN), user(u), has_acl_header(false),
     info(_cct, e)
 {
-  enable_ops_log = e->rgw_conf_get_enable_ops_log();
-  enable_usage_log = e->rgw_conf_get_enable_usage_log();
-  defer_to_bucket_acls = e->rgw_conf_get_defer_to_bucket_acls();
+  enable_ops_log = e->get_enable_ops_log();
+  enable_usage_log = e->get_enable_usage_log();
+  defer_to_bucket_acls = e->get_defer_to_bucket_acls();
   content_started = false;
   format = 0;
   formatter = NULL;

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -412,15 +412,15 @@ public:
   bool exists_prefix(const char *prefix) const;
   void remove(const char *name);
   const std::map<string, string, ltstr_nocase>& get_map() const { return env_map; }
-  int rgw_conf_get_enable_ops_log() const {
+  int get_enable_ops_log() const {
     return conf.enable_ops_log;
   }
 
-  int rgw_conf_get_enable_usage_log() const {
+  int get_enable_usage_log() const {
     return conf.enable_usage_log;
   }
 
-  int rgw_conf_get_defer_to_bucket_acls() const {
+  int get_defer_to_bucket_acls() const {
     return conf.defer_to_bucket_acls;
   }
 };


### PR DESCRIPTION
Fixed the getter function names as per the review comment in
https://github.com/ceph/ceph/pull/17432

Signed-off-by: Jos Collin <jcollin@redhat.com>