### PR TITLE
tests - ceph-ansible vars additions

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_7.3.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_7.3.yaml
@@ -1,2 +1,0 @@
-os_type: centos
-os_version: "7.3"

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_latest.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_16.04.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_16.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "16.04"

--- a/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_latest.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/1-distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
@@ -8,6 +8,9 @@ overrides:
           global:
             osd default pool size: 2
             mon pg warn min per osd: 2
+            osd pool default pg num: 64
+            osd pool default pgp num: 64
+            mon_max_pg_per_osd: 1024
         ceph_test: true
         ceph_stable_release: luminous
         osd_scenario: collocated
@@ -15,6 +18,11 @@ overrides:
         osd_auto_discovery: false
         ceph_origin: repository
         ceph_repository: dev
+        cephfs_pools:
+          - name: "cephfs_data"
+            pgs: "64"
+          - name: "cephfs_metadata"
+            pgs: "64"
 tasks:
 - ssh-keys:
 - ceph_ansible:


### PR DESCRIPTION
added symlinks for distros

This is cherry-pick of https://github.com/ceph/ceph/pull/18363, we don't run `ceph-ansible` on master ATM

Fixes http://tracker.ceph.com/issues/21822
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>
(cherry picked from commit f30e9a5e6bd47129f8a35c1f9067216cfe8a6a70)
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>