### PR TITLE
URL for Ceph Object Store is pointing to radosgw instead of rados

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -81,7 +81,7 @@ about Ceph, see our `Architecture`_ section.
 
 
 
-.. _Ceph Object Store: radosgw
+.. _Ceph Object Store: rados
 .. _Ceph Block Device: rbd
 .. _Ceph Filesystem: cephfs
 .. _Getting Started: start


### PR DESCRIPTION
two character change to fix link.