### PR TITLE
os/filestore: print out the error if do_read_entry() fails

### DIFF
--- a/src/os/filestore/FileJournal.cc
+++ b/src/os/filestore/FileJournal.cc
@@ -1973,6 +1973,8 @@ bool FileJournal::read_entry(
         journaled_seq = seq;
       return true;
     }
+  } else {
+    derr << "do_read_entry(" << pos << "): " << ss.str() << dendl;
   }
 
   if (seq && seq < header.committed_up_to) {
@@ -1988,7 +1990,6 @@ bool FileJournal::read_entry(
     }
   }
 
-  dout(25) << ss.str() << dendl;
   dout(2) << "No further valid entries found, journal is most likely valid"
 	  << dendl;
   return false;


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit 42e85fe35d2fe8f3e99bd110021fd5157cf589d7)