### PR TITLE
os/bluestore: implement AreFilesSame function in BlueRocksEnv

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -499,6 +499,13 @@ rocksdb::Status BlueRocksEnv::LinkFile(
   ceph_abort();
 }
 
+rocksdb::Status BlueRocksEnv::AreFilesSame(
+  const std::string& first,
+  const std::string& second,
+  bool* res) {
+  return rocksdb::Status::NotSupported("AreFilesSame is not supported for this Env");
+}
+
 rocksdb::Status BlueRocksEnv::LockFile(
   const std::string& fname,
   rocksdb::FileLock** lock)

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -114,6 +114,9 @@ public:
   // Hard Link file src to target.
   rocksdb::Status LinkFile(const std::string& src, const std::string& target) override;
 
+  rocksdb::Status AreFilesSame(const std::string& first,
+                               const std::string& second, bool* res) override;
+
   // Lock the specified file.  Used to prevent concurrent access to
   // the same db by multiple processes.  On failure, stores nullptr in
   // *lock and returns non-OK.


### PR DESCRIPTION
This patch could fix `ceph-kvstore-tool repair` workunit. see  https://github.com/ceph/ceph/pull/16745 http://tracker.ceph.com/issues/21842

@tchaikov @liewegas 

Signed-off-by: Chang Liu <liuchang0812@gmail.com>