### PR TITLE
osd: set the right msg_epoch when queuing pg query event

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8656,7 +8656,7 @@ void OSD::handle_pg_query(OpRequestRef op)
       peering_wait_for_split[pgid].push_back(
 	PG::CephPeeringEvtRef(
 	  new PG::CephPeeringEvt(
-	    it->second.epoch_sent, it->second.epoch_sent,
+	    m->get_epoch(), it->second.epoch_sent,
 	    PG::MQuery(pg_shard_t(from, it->second.from),
 		       it->second, it->second.epoch_sent))));
       continue;
@@ -8668,7 +8668,7 @@ void OSD::handle_pg_query(OpRequestRef op)
         PG *pg = 0;
         pg = _lookup_lock_pg_with_map_lock_held(pgid);
         pg->queue_query(
-            it->second.epoch_sent, it->second.epoch_sent,
+            m->get_epoch(), it->second.epoch_sent,
             pg_shard_t(from, it->second.from), it->second);
         pg->unlock();
         continue;


### PR DESCRIPTION
In PG.cc, the method PG::queue_query is declared as:
  void PG::queue_query(epoch_t msg_epoch,
		     epoch_t query_epoch,
		     pg_shard_t from, const pg_query_t& q)
literally i think there maybe a difference between msg_epoch and query_epoch. But in OSD::handle_pg_query(), the method is called like this:
   pg->queue_query(
            it->second.epoch_sent, it->second.epoch_sent,
            pg_shard_t(from, it->second.from), it->second);

I think there are some risks here, though I've not found any case in which msg_epoch is different from 
epoch_sent.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>