### PR TITLE
os/bluestore: implement BlueRocksEnv::AreFilesSame()

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.cc
+++ b/src/os/bluestore/BlueRocksEnv.cc
@@ -499,6 +499,29 @@ rocksdb::Status BlueRocksEnv::LinkFile(
   ceph_abort();
 }
 
+rocksdb::Status BlueRocksEnv::AreFilesSame(
+  const std::string& first,
+  const std::string& second, bool* res)
+{
+  for (auto& path : {first, second}) {
+    if (fs->dir_exists(path)) {
+      continue;
+    }
+    std::string dir, file;
+    split(path, &dir, &file);
+    int r = fs->stat(dir, file, nullptr, nullptr);
+    if (!r) {
+      continue;
+    } else if (r == -ENOENT) {
+      return rocksdb::Status::NotFound("AreFilesSame", path);
+    } else {
+      return err_to_status(r);
+    }
+  }
+  *res = (first == second);
+  return rocksdb::Status::OK();
+}
+
 rocksdb::Status BlueRocksEnv::LockFile(
   const std::string& fname,
   rocksdb::FileLock** lock)

--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -114,6 +114,10 @@ public:
   // Hard Link file src to target.
   rocksdb::Status LinkFile(const std::string& src, const std::string& target) override;
 
+  // Tell if two files are identical
+  rocksdb::Status AreFilesSame(const std::string& first,
+			       const std::string& second, bool* res) override;
+
   // Lock the specified file.  Used to prevent concurrent access to
   // the same db by multiple processes.  On failure, stores nullptr in
   // *lock and returns non-OK.


### PR DESCRIPTION
it is used by the "repair" feature to dedup the files to be searched for
MANIFEST-* files. the default implementation is the POSIX one, which
tries to look at the local fs, but we should be looking for the files in
the bluefs. in this very use case, wal and db do not share the same device,
so we can just compare the paths. actually, it should aways return
"false". as the files being compared are always "db" and "db.wal".

Fixes: http://tracker.ceph.com/issues/21842
Signed-off-by: Kefu Chai <kchai@redhat.com>