### PR TITLE
osd/osd_types.cc: copy extents map too while making clone

### DIFF
--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4900,6 +4900,7 @@ void object_info_t::copy_user_bits(const object_info_t& other)
   user_version = other.user_version;
   data_digest = other.data_digest;
   omap_digest = other.omap_digest;
+  extents = other.extents;
 }
 
 void object_info_t::encode(bufferlist& bl, uint64_t features) const


### PR DESCRIPTION
Otherwise we'll lost tracking of logical space usage
if we successfully rollback to clones later.

Signed-off-by: xie xingguo <xie.xingguo@zte.com.cn>