### PR TITLE
rgw: mrgw.sh uses instance name 'client.rgw'

### DIFF
--- a/src/mrgw.sh
+++ b/src/mrgw.sh
@@ -27,4 +27,4 @@ logfile=$run_root/out/radosgw.${port}.log
 
 $vstart_path/mstop.sh $name radosgw $port
 
-$vstart_path/mrun $name radosgw --rgw-frontends="civetweb port=$port" --pid-file=$pidfile --admin-socket=$asokfile "$@" --log-file=$logfile
+$vstart_path/mrun $name radosgw --rgw-frontends="civetweb port=$port" -n client.rgw --pid-file=$pidfile --admin-socket=$asokfile "$@" --log-file=$logfile


### PR DESCRIPTION
in vstart.sh, rgw config was moved into the `[client.rgw]` section (see #18331), which vstart always uses as the radosgw instance name. this broke the multisite tests in `test/rgw/test_multi.py` (`test_encrypted_object_sync` depends on setting `rgw crypt require ssl = false`) because they use mrgw.sh to start the gateways instead