### PR TITLE
Revert "submodule: make libmpem as a submodule."

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -55,6 +55,3 @@
 [submodule "src/rapidjson"]
 	path = src/rapidjson
 	url = https://github.com/ceph/rapidjson
-[submodule "src/nvml"]
-	path = src/nvml
-	url = https://github.com/ceph/nvml.git


### PR DESCRIPTION
This reverts commit 6a14159ee4b910bf83b38316f98ef07edf5f9a01.
Using ExternalProject_Add::GIT to download nvml source .

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>