### PR TITLE
common/common_init: disable ms subsystem log gathering for clients

### DIFF
--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -58,6 +58,10 @@ CephContext *common_preinit(const CephInitParameters &iparams,
     conf->set_val_or_die("err_to_stderr", "false");
     conf->set_val_or_die("log_flush_on_exit", "false");
   }
+  if (code_env != CODE_ENVIRONMENT_DAEMON) {
+    // NOTE: disable ms subsystem gathering in clients by default
+    conf->set_val_or_die("debug_ms", "0/0");
+  }
 
   return cct;
 }


### PR DESCRIPTION
The log gathering causes large performance degradation to clients
with high message throughputs. This is hopefully a short-term
workaround until per-message logging can be replaced with an
efficient data recording system for post-incident analysis
use-cases.

Fixes: http://tracker.ceph.com/issues/21860
Signed-off-by: Jason Dillaman <dillaman@redhat.com>