### PR TITLE
osd/PG: skip journal osd_max_write_size check for bluestore

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1979,7 +1979,8 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     }
 
     // too big?
-    if (cct->_conf->osd_max_write_size &&
+    if (osd->store->get_type() != "bluestore" &&
+        cct->_conf->osd_max_write_size &&
         m->get_data_len() > cct->_conf->osd_max_write_size << 20) {
       // journal can't hold commit!
       derr << "do_op msg data len " << m->get_data_len()


### PR DESCRIPTION
no need to do this check if we switch to bluestore, since it uses journal for small unalinged block-size overwrites only. bigdata applications such as hadoop might be benefit from this change since they are tending to use large writes.

Signed-off-by: Yan Jun <yan.jun8@zte.com.cn>