### PR TITLE
doc: Added CHAP configuration instructions for iSCSI

### DIFF
--- a/doc/rbd/iscsi-initiator-linux.rst
+++ b/doc/rbd/iscsi-initiator-linux.rst
@@ -53,6 +53,9 @@ Install the iSCSI initiator and multipath tools:
 
 **iSCSI Discovery and Setup:**
 
+#. If CHAP was setup on the iSCSI gateway, provide a CHAP username and
+   password by updating the ``/etc/iscsi/iscsid.conf`` file accordingly.
+
 #. Discover the target portals:
 
    ::


### PR DESCRIPTION
Added details to specify the CHAP username and password while
discovering/login the iSCSI target.

Signed-off-by: Ashish Singh <assingh@redhat.com>