### PR TITLE
Objecter: do not decode when sparse read result is empty

### DIFF
--- a/src/osdc/Objecter.h
+++ b/src/osdc/Objecter.h
@@ -333,6 +333,8 @@ struct ObjectOperation {
 				  int *prval)
       : data_bl(data_bl), extents(extents), prval(prval) {}
     void finish(int r) override {
+      if (!bl.length())
+        return;
       bufferlist::iterator iter = bl.begin();
       if (r >= 0) {
 	try {


### PR DESCRIPTION
Signed-off-by: Xinze Chi <xinze@xsky.com>