### PR TITLE
osd: enumerate device names in a simple way

### DIFF
--- a/src/common/blkdev.cc
+++ b/src/common/blkdev.cc
@@ -263,6 +263,38 @@ int get_device_by_fd(int fd, char *partition, char *device, size_t max)
   return 0;
 }
 
+static int easy_readdir(const std::string& dir, std::set<std::string> *out)
+{
+  DIR *h = ::opendir(dir.c_str());
+  if (!h) {
+    return -errno;
+  }
+  struct dirent *de = nullptr;
+  while ((de = ::readdir(h))) {
+    if (strcmp(de->d_name, ".") == 0 ||
+	strcmp(de->d_name, "..") == 0) {
+      continue;
+    }
+    out->insert(de->d_name);
+  }
+  closedir(h);
+  return 0;
+}
+
+void get_dm_parents(const std::string& dev, std::set<std::string> *ls)
+{
+  std::string p = std::string("/sys/block/") + dev + "/slaves";
+  std::set<std::string> parents;
+  easy_readdir(p, &parents);
+  for (auto& d : parents) {
+    ls->insert(d);
+    // recurse in case it is dm-on-dm
+    if (d.find("dm-") == 0) {
+      get_dm_parents(d, ls);
+    }
+  }
+}
+
 #elif defined(__APPLE__)
 #include <sys/disk.h>
 
@@ -301,6 +333,11 @@ int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
 {
   return -EOPNOTSUPP;
 }
+
+void get_dm_parents(const string& dev, set<string> *ls)
+{
+}
+
 #elif defined(__FreeBSD__)
 #include <sys/disk.h>
 
@@ -336,6 +373,11 @@ int get_device_by_fd(int fd, char *partition, char *device, size_t max)
 {
   return -EOPNOTSUPP;
 }
+
+void get_dm_parents(const string& dev, set<string> *ls)
+{
+}
+
 #else
 int get_block_device_size(int fd, int64_t *psize)
 {
@@ -366,5 +408,8 @@ int get_device_by_uuid(uuid_d dev_uuid, const char* label, char* partition,
 int get_device_by_fd(int fd, char *partition, char *device, size_t max)
 {
   return -EOPNOTSUPP;
+}
+void get_dm_parents(const string& dev, set<string> *ls)
+{
 }
 #endif

--- a/src/common/blkdev.h
+++ b/src/common/blkdev.h
@@ -1,6 +1,9 @@
 #ifndef __CEPH_COMMON_BLKDEV_H
 #define __CEPH_COMMON_BLKDEV_H
 
+#include <set>
+#include <string>
+
 /* for testing purposes */
 extern void set_block_device_sandbox_dir(const char *dir);
 
@@ -25,5 +28,7 @@ extern int64_t get_block_device_string_property(
 extern bool block_device_support_discard(const char *devname);
 extern bool block_device_is_rotational(const char *devname);
 extern int block_device_model(const char *devname, char *model, size_t max);
+
+extern void get_dm_parents(const std::string& dev, std::set<std::string> *ls);
 
 #endif

--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -1562,6 +1562,11 @@ public:
   virtual bool wants_journal() = 0;  //< prefers a journal
   virtual bool allows_journal() = 0; //< allows a journal
 
+  /// enumerate hardware devices (by 'devname', e.g., 'sda' as in /sys/block/sda)
+  virtual int get_devices(std::set<string> *devls) {
+    return -EOPNOTSUPP;
+  }
+
   /**
    * is_rotational
    *

--- a/src/os/bluestore/BlockDevice.h
+++ b/src/os/bluestore/BlockDevice.h
@@ -128,6 +128,17 @@ public:
 
   virtual int collect_metadata(const std::string& prefix, std::map<std::string,std::string> *pm) const = 0;
 
+  virtual int get_devname(string *out) {
+    return -ENOENT;
+  }
+  virtual int get_devices(set<string> *ls) {
+    string s;
+    if (get_devname(&s) == 0) {
+      ls->insert(s);
+    }
+    return 0;
+  }
+
   virtual int read(
     uint64_t off,
     uint64_t len,

--- a/src/os/bluestore/BlueFS.cc
+++ b/src/os/bluestore/BlueFS.cc
@@ -459,6 +459,15 @@ void BlueFS::collect_metadata(map<string,string> *pm, unsigned skip_bdev_id)
     bdev[BDEV_WAL]->collect_metadata("bluefs_wal_", pm);
 }
 
+void BlueFS::get_devices(set<string> *ls)
+{
+  for (unsigned i = 0; i < MAX_BDEV; ++i) {
+    if (bdev[i]) {
+      bdev[i]->get_devices(ls);
+    }
+  }
+}
+
 int BlueFS::fsck()
 {
   std::lock_guard<std::mutex> l(lock);

--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -338,6 +338,7 @@ public:
     const vector<string>& devs);
 
   void collect_metadata(map<string,string> *pm, unsigned skip_bdev_id);
+  void get_devices(set<string> *ls);
   int fsck();
 
   uint64_t get_fs_usage();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -6239,6 +6239,15 @@ void BlueStore::collect_metadata(map<string,string> *pm)
   }
 }
 
+int BlueStore::get_devices(set<string> *ls)
+{
+  bdev->get_devices(ls);
+  if (bluefs) {
+    bluefs->get_devices(ls);
+  }
+  return 0;
+}
+
 int BlueStore::statfs(struct store_statfs_t *buf)
 {
   buf->reset();

--- a/src/os/bluestore/BlueStore.h
+++ b/src/os/bluestore/BlueStore.h
@@ -2122,6 +2122,8 @@ public:
   bool wants_journal() override { return false; };
   bool allows_journal() override { return false; };
 
+  int get_devices(set<string> *ls) override;
+
   bool is_rotational() override;
   bool is_journal_rotational() override;
 

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -137,6 +137,7 @@ int KernelDevice::open(const string& p)
     } else {
       dout(20) << __func__ << " devname " << devname << dendl;
       rotational = block_device_is_rotational(devname);
+      this->devname = devname;
     }
   }
 
@@ -168,6 +169,18 @@ int KernelDevice::open(const string& p)
   VOID_TEMP_FAILURE_RETRY(::close(fd_direct));
   fd_direct = -1;
   return r;
+}
+
+int KernelDevice::get_devices(std::set<std::string> *ls)
+{
+  if (devname.empty()) {
+    return 0;
+  }
+  ls->insert(devname);
+  if (devname.find("dm-") == 0) {
+    get_dm_parents(devname, ls);
+  }
+  return 0;
 }
 
 void KernelDevice::close()

--- a/src/os/bluestore/KernelDevice.h
+++ b/src/os/bluestore/KernelDevice.h
@@ -29,6 +29,8 @@ class KernelDevice : public BlockDevice {
   FS *fs;
   bool aio, dio;
 
+  std::string devname;  ///< kernel dev name (/sys/block/$devname), if any
+
   Mutex debug_lock;
   interval_set<uint64_t> debug_inflight;
 
@@ -76,6 +78,14 @@ public:
   void aio_submit(IOContext *ioc) override;
 
   int collect_metadata(const std::string& prefix, map<std::string,std::string> *pm) const override;
+  int get_devname(std::string *s) override {
+    if (devname.empty()) {
+      return -ENOENT;
+    }
+    *s = devname;
+    return 0;
+  }
+  int get_devices(std::set<std::string> *ls) override;
 
   int read(uint64_t off, uint64_t len, bufferlist *pbl,
 	   IOContext *ioc,

--- a/src/os/filestore/FileStore.cc
+++ b/src/os/filestore/FileStore.cc
@@ -708,6 +708,21 @@ void FileStore::collect_metadata(map<string,string> *pm)
   }
 }
 
+int FileStore::get_devices(set<string> *ls)
+{
+  char partition_path[PATH_MAX];
+  char dev_node[PATH_MAX];
+  int rc = 0;
+  rc = get_device_by_fd(fsid_fd, partition_path, dev_node, PATH_MAX);
+  if (rc == 0) {
+    ls->insert(dev_node);
+    if (strncmp(dev_node, "dm-", 3) == 0) {
+      get_dm_parents(dev_node, ls);
+    }
+  }
+  return 0;
+}
+
 int FileStore::statfs(struct store_statfs_t *buf0)
 {
   struct statfs buf;

--- a/src/os/filestore/FileStore.h
+++ b/src/os/filestore/FileStore.h
@@ -502,6 +502,7 @@ public:
   }
 
   void collect_metadata(map<string,string> *pm) override;
+  int get_devices(set<string> *ls) override;
 
   int statfs(struct store_statfs_t *buf) override;
 

--- a/src/os/memstore/MemStore.h
+++ b/src/os/memstore/MemStore.h
@@ -280,6 +280,11 @@ public:
     return false;
   }
 
+  int get_devices(set<string> *ls) override {
+    // no devices for us!
+    return 0;
+  }
+
   int statfs(struct store_statfs_t *buf) override;
 
   bool exists(const coll_t& cid, const ghobject_t& oid) override;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -5711,6 +5711,9 @@ void OSD::_collect_metadata(map<string,string> *pm)
   (*pm)["back_iface"] = pick_iface(cct,
       cluster_messenger->get_myaddr().get_sockaddr_storage());
 
+  set<string> devnames;
+  store->get_devices(&devnames);
+  (*pm)["devices"] = stringify(devnames);
   dout(10) << __func__ << " " << *pm << dendl;
 }
 


### PR DESCRIPTION
This adds a 'devices' metadata key that is a comma-separated list of device names (e.g., "sdc", "dm-1", "nvme0n1").  If there is a dm device in there, we also include all of the parent/consituent devices that it is built out of.  For example, for my simple LV, I get

    "devices": "dm-3,sdc",

This will simplify the mgr's efforts to correlate devices and osds.  It will also be useful for the OSD code that queries SMART info.

What it doesn't do is distinguish between "primary" and "secondary" devices.  So if you have a shared SSD with journals on it, all OSDs using it will include it in their list.

TODO:
- [x] implement for FileStore
- [ ] add a primary_device key too?
