### PR TITLE
luminous: messages/MOSDMap: do compat reencode of crush map, too

### DIFF
--- a/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
@@ -1,0 +1,7 @@
+tasks:
+- exec:
+    mon.a:
+      - ceph osd crush set-all-straw-buckets-to-straw2
+      - ceph osd crush weight-set create-compat
+      - ceph osd crush weight-set reweight-compat osd.0 .9
+      - ceph osd crush weight-set reweight-compat osd.1 1.2

--- a/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
@@ -1,6 +1,7 @@
 tasks:
 - exec:
     mon.a:
+      - ceph osd set-require-min-compat-client hammer
       - ceph osd crush set-all-straw-buckets-to-straw2
       - ceph osd crush weight-set create-compat
       - ceph osd crush weight-set reweight-compat osd.0 .9

--- a/qa/suites/upgrade/jewel-x/parallel/8-jewel-workload.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/8-jewel-workload.yaml
@@ -1,0 +1,1 @@
+5-workload.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split/6.5-crush-compat.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/6.5-crush-compat.yaml
@@ -1,0 +1,1 @@
+../parallel/6.5-crush-compat.yaml

--- a/src/crush/CrushWrapper.cc
+++ b/src/crush/CrushWrapper.cc
@@ -1839,6 +1839,16 @@ int CrushWrapper::bucket_remove_item(crush_bucket *bucket, int item)
   return 0;
 }
 
+int CrushWrapper::bucket_set_alg(int bid, int alg)
+{
+  crush_bucket *b = get_bucket(bid);
+  if (!b) {
+    return -ENOENT;
+  }
+  b->alg = alg;
+  return 0;
+}
+
 int CrushWrapper::update_device_class(int id,
                                       const string& class_name,
                                       const string& name,

--- a/src/crush/CrushWrapper.h
+++ b/src/crush/CrushWrapper.h
@@ -1208,6 +1208,7 @@ public:
     crush_finalize(crush);
     have_uniform_rules = !has_legacy_rulesets();
   }
+  int bucket_set_alg(int id, int alg);
 
   int update_device_class(int id, const string& class_name, const string& name, ostream *ss);
   int remove_device_class(CephContext *cct, int id, ostream *ss);

--- a/src/messages/MOSDMap.h
+++ b/src/messages/MOSDMap.h
@@ -113,6 +113,14 @@ public:
 	  inc.fullmap.clear();
 	  m.encode(inc.fullmap, features | CEPH_FEATURE_RESERVED);
 	}
+	if (inc.crush.length()) {
+	  // embedded crush map
+	  CrushWrapper c;
+	  auto p = inc.crush.begin();
+	  c.decode(p);
+	  inc.crush.clear();
+	  c.encode(inc.crush, features);
+	}
 	inc.encode(p->second, features | CEPH_FEATURE_RESERVED);
       }
       for (map<epoch_t,bufferlist>::iterator p = maps.begin();

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -548,6 +548,9 @@ COMMAND("osd crush add " \
 	"name=args,type=CephString,n=N,goodchars=[A-Za-z0-9-_.=]", \
 	"add or update crushmap position and weight for <name> with <weight> and location <args>", \
 	"osd", "rw", "cli,rest")
+COMMAND("osd crush set-all-straw-buckets-to-straw2",
+        "convert all CRUSH current straw buckets to use the straw2 algorithm",
+	"osd", "rw", "cli,rest")
 COMMAND("osd crush set-device-class " \
         "name=class,type=CephString " \
 	"name=ids,type=CephString,n=N", \

--- a/src/mon/OSDMonitor.cc
+++ b/src/mon/OSDMonitor.cc
@@ -7686,6 +7686,26 @@ bool OSDMonitor::prepare_command_impl(MonOpRequestRef op,
     ss << osdmap.get_crush_version() + 1;
     goto update;
 
+  } else if (prefix == "osd crush set-all-straw-buckets-to-straw2") {
+    CrushWrapper newcrush;
+    _get_pending_crush(newcrush);
+    for (int b = 0; b < newcrush.get_max_buckets(); ++b) {
+      int bid = -1 - b;
+      if (newcrush.bucket_exists(bid) &&
+	  newcrush.get_bucket_alg(bid)) {
+	dout(20) << " bucket " << bid << " is straw, can convert" << dendl;
+	newcrush.bucket_set_alg(bid, CRUSH_BUCKET_STRAW2);
+      }
+    }
+    if (!validate_crush_against_features(&newcrush, ss)) {
+      err = -EINVAL;
+      goto reply;
+    }
+    pending_inc.crush.clear();
+    newcrush.encode(pending_inc.crush, mon->get_quorum_con_features());
+    wait_for_finished_proposal(op, new Monitor::C_Command(mon, op, 0, rs,
+					      get_last_committed() + 1));
+    return true;
   } else if (prefix == "osd crush set-device-class") {
     if (osdmap.require_osd_release < CEPH_RELEASE_LUMINOUS) {
       ss << "you must complete the upgrade and 'ceph osd require-osd-release "


### PR DESCRIPTION
Plus we update the jewel-x upgrade suite so that some jewel clients try to operate against
the cluster.  (This doesn't actually test the patch unfortunately since it is an incremental
map update that was missed, but it's still progress.)