### PR TITLE
qa/suites/rados/rest/mgr-restful: whitelist more health

### DIFF
--- a/qa/suites/rados/rest/mgr-restful.yaml
+++ b/qa/suites/rados/rest/mgr-restful.yaml
@@ -6,6 +6,9 @@ tasks:
     log-whitelist:
       - overall HEALTH_
       - \(MGR_DOWN\)
+      - \(PG_
+      - \(OSD_
+      - \(OBJECT_
 - exec:
     mon.a:
       - ceph restful create-key admin


### PR DESCRIPTION
The test is fiddling with OSDs.

Signed-off-by: Sage Weil <sage@redhat.com>