### PR TITLE
cephfs-journal-tool: Adding [--repair] option for cephfs-journal-tool make it can recover all journal as much as possible.

### DIFF
--- a/src/tools/cephfs/JournalScanner.h
+++ b/src/tools/cephfs/JournalScanner.h
@@ -56,6 +56,7 @@ class JournalScanner
     pointer_valid(false),
     header_present(false),
     header_valid(false),
+    repair_corrupted_entry(false),
     header(NULL) {};
 
   JournalScanner(
@@ -71,6 +72,7 @@ class JournalScanner
     pointer_valid(false),
     header_present(false),
     header_valid(false),
+    repair_corrupted_entry(false),
     header(NULL) {};
 
   ~JournalScanner();
@@ -80,10 +82,14 @@ class JournalScanner
   int scan_pointer();
   int scan_header();
   int scan_events();
+  bool buf_is_available(bufferlist& buf);
+  void repair_journal(bufferlist& buf, uint64_t offset);
   void report(std::ostream &out) const;
 
   std::string obj_name(uint64_t offset) const;
   std::string obj_name(inodeno_t ino, uint64_t offset) const;
+
+  bool repair_corrupted_entry;
 
   // The results of the scan
   inodeno_t ino;  // Corresponds to journal ino according their type

--- a/src/tools/cephfs/JournalTool.cc
+++ b/src/tools/cephfs/JournalTool.cc
@@ -67,7 +67,8 @@ void JournalTool::usage()
     << "                              the only filesystem otherwise.)\n"
     << "  --journal=<mdlog|purge_queue>  Journal type (purge_queue means\n"
     << "                                 this journal is used to queue for purge operation,\n"
-    << "                                 default is mdlog, and only mdlog support event mode)\n" 
+    << "                                 default is mdlog, and only mdlog support event mode)\n"
+    << "  --repair repair entry size or start_ptr of the damaged journal entry.\n"
     << "\n"
     << "Special options\n"
     << "  --alternate-pool <name>     Alternative metadata pool to target\n"
@@ -340,6 +341,7 @@ int JournalTool::main_header(std::vector<const char*> &argv)
 int JournalTool::main_event(std::vector<const char*> &argv)
 {
   int r;
+  bool repair_corrupted_entry = false;
 
   std::vector<const char*>::iterator arg = argv.begin();
 
@@ -365,6 +367,15 @@ int JournalTool::main_event(std::vector<const char*> &argv)
   r = filter.parse_args(argv, arg);
   if (r) {
     return r;
+  }
+
+  // Check if need to repair
+  for (const auto& s : argv) {
+    if (strcmp(s, "--repair") ==0) {
+      repair_corrupted_entry = true;
+      arg++;
+      break;
+    }
   }
 
   // Parse output options
@@ -399,7 +410,10 @@ int JournalTool::main_event(std::vector<const char*> &argv)
 
   // Execute command
   // ===============
-  JournalScanner js(input, rank, type, filter);
+  JournalScanner js(input, rank, filter);
+  if (repair_corrupted_entry)
+    js.repair_corrupted_entry = true;
+
   if (command == "get") {
     r = js.scan();
     if (r) {


### PR DESCRIPTION

If entry size is corrupt may lost more than one journal event.

Fixes: http://tracker.ceph.com/issues/21888
Signed-off-by: Guan yunfei <yunfei.guan@xtaotech.com>