### PR TITLE
osd/ReplicatedPG: add omap write bytes to delta_stats

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -6513,6 +6513,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
 	}
 	t->omap_setkeys(soid, to_set_bl);
 	ctx->delta_stats.num_wr++;
+        ctx->delta_stats.num_wr_kb += SHIFT_ROUND_UP(to_set_bl.length(), 10);
       }
       obs.oi.set_flag(object_info_t::FLAG_OMAP);
       obs.oi.clear_omap_digest();


### PR DESCRIPTION
under rgw case, it will consume lots of omap read/write but we can't see the
statistics.

Signed-off-by: Haomai Wang <haomai@xsky.com>