### PR TITLE
debian: fix package relationships after 40caf6a6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -103,10 +103,10 @@ Recommends: btrfs-tools,
             ntp | time-daemon,
 Replaces: ceph (<< 10),
           ceph-common (<< 0.78-500),
-          ceph-test (<< 0.94-1322),
+          ceph-test (<< 12.2.2),
           python-ceph (<< 0.92-1223),
 Breaks: ceph (<< 10),
-        ceph-test (<< 0.94-1322),
+        ceph-test (<< 12.2.2),
         python-ceph (<< 0.92-1223),
 Description: common ceph daemon libraries and management tools
  Ceph is a massively scalable, open-source, distributed
@@ -204,8 +204,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common,
-Replaces: ceph (<< 10),
-Breaks: ceph (<< 10),
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
 Description: monitor server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
@@ -237,8 +237,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${python:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common (= ${binary:Version}),
-Replaces: ceph (<< 10),
-Breaks: ceph (<< 10),
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
 Description: OSD server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,

--- a/debian/control
+++ b/debian/control
@@ -712,6 +712,8 @@ Depends: ceph-common,
          xmlstarlet,
          ${misc:Depends},
          ${shlibs:Depends},
+Replaces: ceph-base (<< 11)
+Breaks: ceph-base (<< 1)
 Description: Ceph test and benchmarking tools
  This package contains tools for testing and benchmarking Ceph.
 


### PR DESCRIPTION
we have issues when running upgrade tests:

dpkg: error processing archive /var/cache/apt/archives/ceph-osd_13.0.0-2201-g6cc0b41-1trusty_amd64.deb (--unpack):
trying to overwrite '/usr/bin/ceph-osdomap-tool', which is also in package ceph-test 10.2.10-14-gcbaddae-1trusty

in 40caf6a6, we moves some tools from ceph-test out into ceph-osd,
ceph-mon and ceph-base respectively. but didn't update the relationships
between these packages accordingly. this causes the upgrade failure.

see https://www.debian.org/doc/debian-policy/#document-ch-relationships
for more details on "Breaks" and "Conflicts".

Signed-off-by: Kefu Chai <kchai@redhat.com>