### PR TITLE
os/ObjectStore: fix get_data_alignment return -1 causing problem in msg header

### DIFF
--- a/src/os/ObjectStore.h
+++ b/src/os/ObjectStore.h
@@ -853,7 +853,7 @@ public:
     /// offset of buffer as aligned to destination within object.
     int get_data_alignment() {
       if (!data.largest_data_len)
-	return -1;
+	return 0;
       return (0 - get_data_offset()) & ~CEPH_PAGE_MASK;
     }
     /// Is the Transaction empty (no operations)


### PR DESCRIPTION
sizeof(data_off) in ceph_msg_header is uint16_t, so -1 will be 65535. When peer
side receive MOSDRepOp message, it will allocate extra 1 byte buffer to store
nonexisted buffer.

Signed-off-by: Haomai Wang <haomai@xsky.com>