### PR TITLE
rgw: drop unused variable in copy_obj_data()

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8165,9 +8165,6 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
                string *ptag,
                ceph::buffer::list *petag)
 {
-  bufferlist first_chunk;
-  RGWObjManifest manifest;
-
   string tag;
   append_rand_alpha(cct, tag, tag, 32);
 


### PR DESCRIPTION
cleanup unused variable in the function copy_obj_data