### PR TITLE
osd: fix recovery reservation bugs, and implement remote reservation preemption

### DIFF
--- a/src/messages/MBackfillReserve.h
+++ b/src/messages/MBackfillReserve.h
@@ -29,6 +29,7 @@ public:
     REJECT = 2,    // replica->primary: sorry, try again later (*)
     RELEASE = 3,   // primary->replcia: release the slot i reserved before
     TOOFULL = 4,   // replica->primary: too full, stop backfilling
+    REVOKE = 5,    // replica->primary: i'm taking back the slot i gave you
     // (*) NOTE: prior to luminous, REJECT was overloaded to also mean release
   };
   uint32_t type;
@@ -66,6 +67,9 @@ public:
     case TOOFULL:
       out << "TOOFULL ";
       break;
+    case REVOKE:
+      out << "REVOKE ";
+      break;
     }
     out << " pgid: " << pgid << ", query_epoch: " << query_epoch;
     if (type == REQUEST) out << ", prio: " << priority;
@@ -87,7 +91,7 @@ public:
       header.compat_version = 3;
       ::encode(pgid.pgid, payload);
       ::encode(query_epoch, payload);
-      ::encode((type == RELEASE || type == TOOFULL) ?
+      ::encode((type == RELEASE || type == TOOFULL || type == REVOKE) ?
 	       REJECT : type, payload);
       ::encode(priority, payload);
       ::encode(pgid.shard, payload);

--- a/src/messages/MRecoveryReserve.h
+++ b/src/messages/MRecoveryReserve.h
@@ -18,7 +18,7 @@
 #include "msg/Message.h"
 
 class MRecoveryReserve : public Message {
-  static const int HEAD_VERSION = 2;
+  static const int HEAD_VERSION = 3;
   static const int COMPAT_VERSION = 2;
 public:
   spg_t pgid;
@@ -28,17 +28,19 @@ public:
     GRANT = 1,
     RELEASE = 2,
   };
-  int type;
+  uint32_t type;
+  uint32_t priority = 0;
 
   MRecoveryReserve()
     : Message(MSG_OSD_RECOVERY_RESERVE, HEAD_VERSION, COMPAT_VERSION),
       query_epoch(0), type(-1) {}
   MRecoveryReserve(int type,
 		   spg_t pgid,
-		   epoch_t query_epoch)
+		   epoch_t query_epoch,
+		   unsigned prio = 0)
     : Message(MSG_OSD_RECOVERY_RESERVE, HEAD_VERSION, COMPAT_VERSION),
       pgid(pgid), query_epoch(query_epoch),
-      type(type) {}
+      type(type), priority(prio) {}
 
   const char *get_type_name() const override {
     return "MRecoveryReserve";
@@ -58,6 +60,7 @@ public:
       break;
     }
     out << " e" << query_epoch << ")";
+    if (type == REQUEST) out << ", prio: " << priority;
     return;
   }
 
@@ -67,6 +70,9 @@ public:
     ::decode(query_epoch, p);
     ::decode(type, p);
     ::decode(pgid.shard, p);
+    if (header.version >= 3) {
+      ::decode(priority, p);
+    }
   }
 
   void encode_payload(uint64_t features) override {
@@ -74,6 +80,7 @@ public:
     ::encode(query_epoch, payload);
     ::encode(type, payload);
     ::encode(pgid.shard, payload);
+    ::encode(priority, payload);
   }
 };
 

--- a/src/messages/MRecoveryReserve.h
+++ b/src/messages/MRecoveryReserve.h
@@ -24,9 +24,9 @@ public:
   spg_t pgid;
   epoch_t query_epoch;
   enum {
-    REQUEST = 0,
-    GRANT = 1,
-    RELEASE = 2,
+    REQUEST = 0,   // primary->replica: please reserve slot
+    GRANT = 1,     // replica->primary: ok, i reserved it
+    RELEASE = 2,   // primary->replica: release the slot i reserved before
   };
   uint32_t type;
   uint32_t priority = 0;

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8596,7 +8596,7 @@ void OSD::handle_pg_recovery_reserve(OpRequestRef op)
       new PG::CephPeeringEvt(
 	m->query_epoch,
 	m->query_epoch,
-	PG::RequestRecovery()));
+	PG::RequestRecoveryPrio(m->priority)));
   } else if (m->type == MRecoveryReserve::GRANT) {
     evt = PG::CephPeeringEvtRef(
       new PG::CephPeeringEvt(

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8569,6 +8569,12 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 	m->query_epoch,
 	m->query_epoch,
 	PG::RemoteReservationRevokedTooFull()));
+  } else if (m->type == MBackfillReserve::REVOKE) {
+    evt = PG::CephPeeringEvtRef(
+      new PG::CephPeeringEvt(
+	m->query_epoch,
+	m->query_epoch,
+	PG::RemoteReservationRevoked()));
   } else {
     ceph_abort();
   }

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8555,7 +8555,7 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 	m->query_epoch,
 	m->query_epoch,
 	PG::RemoteReservationRejected()));
-  } else if (m->type == MBackfillReserve::CANCEL) {
+  } else if (m->type == MBackfillReserve::RELEASE) {
     evt = PG::CephPeeringEvtRef(
       new PG::CephPeeringEvt(
 	m->query_epoch,

--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -8550,6 +8550,8 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
     // NOTE: this is replica -> primary "i reject your request"
     //      and also primary -> replica "cancel my previously-granted request"
     //                                  (for older peers)
+    //      and also replica -> primary "i revoke your reservation"
+    //                                  (for older peers)
     evt = PG::CephPeeringEvtRef(
       new PG::CephPeeringEvt(
 	m->query_epoch,
@@ -8561,6 +8563,12 @@ void OSD::handle_pg_backfill_reserve(OpRequestRef op)
 	m->query_epoch,
 	m->query_epoch,
 	PG::RemoteReservationCanceled()));
+  } else if (m->type == MBackfillReserve::TOOFULL) {
+    evt = PG::CephPeeringEvtRef(
+      new PG::CephPeeringEvt(
+	m->query_epoch,
+	m->query_epoch,
+	PG::RemoteReservationRevokedTooFull()));
   } else {
     ceph_abort();
   }

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7001,7 +7001,6 @@ boost::statechart::result
 PG::RecoveryState::Recovering::react(const AllReplicasRecovered &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
-  pg->state_clear(PG_STATE_RECOVERING);
   pg->state_clear(PG_STATE_FORCED_RECOVERY);
   release_reservations();
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
@@ -7012,7 +7011,6 @@ boost::statechart::result
 PG::RecoveryState::Recovering::react(const RequestBackfill &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
-  pg->state_clear(PG_STATE_RECOVERING);
   pg->state_clear(PG_STATE_FORCED_RECOVERY);
   release_reservations();
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
@@ -7024,7 +7022,6 @@ PG::RecoveryState::Recovering::react(const DeferRecovery &evt)
 {
   PG *pg = context< RecoveryMachine >().pg;
   ldout(pg->cct, 10) << "defer recovery, retry delay " << evt.delay << dendl;
-  pg->state_clear(PG_STATE_RECOVERING);
   pg->state_set(PG_STATE_RECOVERY_WAIT);
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
   release_reservations(true);
@@ -7038,7 +7035,6 @@ PG::RecoveryState::Recovering::react(const UnfoundRecovery &evt)
   PG *pg = context< RecoveryMachine >().pg;
   ldout(pg->cct, 10) << "recovery has unfound, can't continue" << dendl;
   pg->state_set(PG_STATE_RECOVERY_UNFOUND);
-  pg->state_clear(PG_STATE_RECOVERING);
   pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
   release_reservations(true);
   return transit<NotRecovering>();
@@ -7049,6 +7045,7 @@ void PG::RecoveryState::Recovering::exit()
   context< RecoveryMachine >().log_exit(state_name, enter_time);
   PG *pg = context< RecoveryMachine >().pg;
   utime_t dur = ceph_clock_now() - enter_time;
+  pg->state_clear(PG_STATE_RECOVERING);
   pg->osd->recoverystate_perf->tinc(rs_recovering_latency, dur);
 }
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6872,7 +6872,8 @@ PG::RecoveryState::WaitRemoteRecoveryReserved::react(const RemoteRecoveryReserve
         new MRecoveryReserve(
 	  MRecoveryReserve::REQUEST,
 	  spg_t(pg->info.pgid.pgid, remote_recovery_reservation_it->shard),
-	  pg->get_osdmap()->get_epoch()),
+	  pg->get_osdmap()->get_epoch(),
+	  pg->get_recovery_priority()),
 	con.get());
     }
     ++remote_recovery_reservation_it;

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7015,7 +7015,8 @@ PG::RecoveryState::Recovering::react(const RequestBackfill &evt)
   pg->state_clear(PG_STATE_RECOVERING);
   pg->state_clear(PG_STATE_FORCED_RECOVERY);
   release_reservations();
-  return transit<WaitRemoteBackfillReserved>();
+  pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
+  return transit<WaitLocalBackfillReserved>();
 }
 
 boost::statechart::result

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -7004,6 +7004,7 @@ PG::RecoveryState::Recovering::react(const AllReplicasRecovered &evt)
   pg->state_clear(PG_STATE_RECOVERING);
   pg->state_clear(PG_STATE_FORCED_RECOVERY);
   release_reservations();
+  pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
   return transit<Recovered>();
 }
 
@@ -7059,7 +7060,6 @@ PG::RecoveryState::Recovered::Recovered(my_context ctx)
   context< RecoveryMachine >().log_enter(state_name);
 
   PG *pg = context< RecoveryMachine >().pg;
-  pg->osd->local_reserver.cancel_reservation(pg->info.pgid);
 
   assert(!pg->needs_recovery());
 

--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6345,7 +6345,7 @@ PG::RecoveryState::Backfilling::react(const DeferBackfill &c)
     if (con) {
       pg->osd->send_message_osd_cluster(
         new MBackfillReserve(
-	  MBackfillReserve::CANCEL,
+	  MBackfillReserve::RELEASE,
 	  spg_t(pg->info.pgid.pgid, it->shard),
 	  pg->get_osdmap()->get_epoch()),
 	con.get());
@@ -6377,7 +6377,7 @@ PG::RecoveryState::Backfilling::react(const UnfoundBackfill &c)
     if (con) {
       pg->osd->send_message_osd_cluster(
         new MBackfillReserve(
-	  MBackfillReserve::CANCEL,
+	  MBackfillReserve::RELEASE,
 	  spg_t(pg->info.pgid.pgid, it->shard),
 	  pg->get_osdmap()->get_epoch()),
 	con.get());
@@ -6405,7 +6405,7 @@ PG::RecoveryState::Backfilling::react(const RemoteReservationRejected &)
     if (con) {
       pg->osd->send_message_osd_cluster(
         new MBackfillReserve(
-	  MBackfillReserve::CANCEL,
+	  MBackfillReserve::RELEASE,
 	  spg_t(pg->info.pgid.pgid, it->shard),
 	  pg->get_osdmap()->get_epoch()),
 	con.get());
@@ -6498,7 +6498,7 @@ PG::RecoveryState::WaitRemoteBackfillReserved::react(const RemoteReservationReje
     if (con) {
       pg->osd->send_message_osd_cluster(
         new MBackfillReserve(
-	MBackfillReserve::CANCEL,
+	MBackfillReserve::RELEASE,
 	spg_t(pg->info.pgid.pgid, it->shard),
 	pg->get_osdmap()->get_epoch()),
       con.get());

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1853,6 +1853,7 @@ protected:
   TrivialEvent(RejectRemoteReservation)
   public:
   TrivialEvent(RemoteReservationRejected)
+  TrivialEvent(RemoteReservationRevokedTooFull)
   TrivialEvent(RemoteReservationCanceled)
   TrivialEvent(RequestBackfill)
   TrivialEvent(RecoveryDone)
@@ -2176,10 +2177,16 @@ protected:
 	boost::statechart::transition< Backfilled, Recovered >,
 	boost::statechart::custom_reaction< DeferBackfill >,
 	boost::statechart::custom_reaction< UnfoundBackfill >,
-	boost::statechart::custom_reaction< RemoteReservationRejected >
+	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RemoteReservationRevokedTooFull>
 	> reactions;
       explicit Backfilling(my_context ctx);
-      boost::statechart::result react(const RemoteReservationRejected& evt);
+      boost::statechart::result react(const RemoteReservationRejected& evt) {
+	// for compat with old peers
+	post_event(RemoteReservationRevokedTooFull());
+	return discard_event();
+      }
+      boost::statechart::result react(const RemoteReservationRevokedTooFull& evt);
       boost::statechart::result react(const DeferBackfill& evt);
       boost::statechart::result react(const UnfoundBackfill& evt);
       void exit();

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -1854,10 +1854,12 @@ protected:
   public:
   TrivialEvent(RemoteReservationRejected)
   TrivialEvent(RemoteReservationRevokedTooFull)
+  TrivialEvent(RemoteReservationRevoked)
   TrivialEvent(RemoteReservationCanceled)
   TrivialEvent(RequestBackfill)
   TrivialEvent(RecoveryDone)
   protected:
+  TrivialEvent(RemoteBackfillPreempted)
   TrivialEvent(BackfillTooFull)
   TrivialEvent(RecoveryTooFull)
 
@@ -2178,7 +2180,8 @@ protected:
 	boost::statechart::custom_reaction< DeferBackfill >,
 	boost::statechart::custom_reaction< UnfoundBackfill >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >,
-	boost::statechart::custom_reaction< RemoteReservationRevokedTooFull>
+	boost::statechart::custom_reaction< RemoteReservationRevokedTooFull>,
+	boost::statechart::custom_reaction< RemoteReservationRevoked>
 	> reactions;
       explicit Backfilling(my_context ctx);
       boost::statechart::result react(const RemoteReservationRejected& evt) {
@@ -2187,6 +2190,7 @@ protected:
 	return discard_event();
       }
       boost::statechart::result react(const RemoteReservationRevokedTooFull& evt);
+      boost::statechart::result react(const RemoteReservationRevoked& evt);
       boost::statechart::result react(const DeferBackfill& evt);
       boost::statechart::result react(const UnfoundBackfill& evt);
       void exit();
@@ -2286,10 +2290,12 @@ protected:
 	// for compat with old peers
 	boost::statechart::transition< RemoteReservationRejected, RepNotRecovering >,
 	boost::statechart::transition< RemoteReservationCanceled, RepNotRecovering >,
-	boost::statechart::custom_reaction< BackfillTooFull >
+	boost::statechart::custom_reaction< BackfillTooFull >,
+	boost::statechart::custom_reaction< RemoteBackfillPreempted >
 	> reactions;
       explicit RepRecovering(my_context ctx);
       boost::statechart::result react(const BackfillTooFull &evt);
+      boost::statechart::result react(const RemoteBackfillPreempted &evt);
       void exit();
     };
 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -11231,6 +11231,9 @@ bool PrimaryLogPG::start_recovery_ops(
   if (state_test(PG_STATE_RECOVERING)) {
     state_clear(PG_STATE_RECOVERING);
     state_clear(PG_STATE_FORCED_RECOVERY);
+    if (get_osdmap()->get_pg_size(info.pgid.pgid) <= acting.size()) {
+      state_clear(PG_STATE_DEGRADED);
+    }
     if (needs_backfill()) {
       dout(10) << "recovery done, queuing backfill" << dendl;
       queue_peering_event(


### PR DESCRIPTION
Bugs:
- re-schedule on recovery->backfill transition so that our priority is lowered
- respect primary's priority for remote recovery reservation

...and implement remote recovery preemption.  With this change we should always be
working on the highest priority recovery, no matter what.

The remaining gap that I see is that there is sometimes work that we *could* be doing
but aren't because of the ordered primary-then-replicas lock ordering approach.