### PR TITLE
etc/default/ceph: remove jemalloc option

### DIFF
--- a/etc/default/ceph
+++ b/etc/default/ceph
@@ -5,11 +5,3 @@
 
 # Increase tcmalloc cache size
 TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
-
-## use jemalloc instead of tcmalloc
-#
-# jemalloc is generally faster for small IO workloads and when
-# ceph-osd is backed by SSDs.  However, memory usage is usually
-# higher by 200-300mb.
-#
-#LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.1


### PR DESCRIPTION
This breaks when used with rocksdb, which is now the default.

See http://tracker.ceph.com/issues/20557

Signed-off-by: Sage Weil <sage@redhat.com>