### PR TITLE
/etc/sysconfig/ceph: remove jemalloc option

### DIFF
--- a/etc/sysconfig/ceph
+++ b/etc/sysconfig/ceph
@@ -6,14 +6,6 @@
 # Increase tcmalloc cache size
 TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES=134217728
 
-## use jemalloc instead of tcmalloc
-#
-# jemalloc is generally faster for small IO workloads and when
-# ceph-osd is backed by SSDs.  However, memory usage is usually
-# higher by 200-300mb.
-#
-#LD_PRELOAD=/usr/lib64/libjemalloc.so.1
-
 ## automatically restart systemd units on upgrade
 #
 # By default, it is left to the administrator to restart


### PR DESCRIPTION
This breaks when used with rocksdb, which is now the default.

See http://tracker.ceph.com/issues/20557

Signed-off-by: Sage Weil <sage@redhat.com>