### PR TITLE
pybind/rados: allow bytearray as data input

### DIFF
--- a/src/pybind/rados/rados.pyx
+++ b/src/pybind/rados/rados.pyx
@@ -1913,7 +1913,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_set_flags(self.write_op, _flags)
 
-    @requires(('to_write', bytes))
+    @requires(('to_write', (bytes, bytearray)))
     def append(self, to_write):
         """
         Append data to an object synchronously
@@ -1928,7 +1928,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_append(self.write_op, _to_write, length)
 
-    @requires(('to_write', bytes))
+    @requires(('to_write', (bytes, bytearray)))
     def write_full(self, to_write):
         """
         Write whole object, atomically replacing it.
@@ -1943,7 +1943,7 @@ cdef class WriteOp(object):
         with nogil:
             rados_write_op_write_full(self.write_op, _to_write, length)
 
-    @requires(('to_write', bytes), ('offset', int))
+    @requires(('to_write', (bytes, bytearray)), ('offset', int))
     def write(self, to_write, offset=0):
         """
         Write to offset.
@@ -2161,7 +2161,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error stating %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_write', bytes), ('offset', int),
+    @requires(('object_name', str_type), ('to_write', (bytes, bytearray)), ('offset', int),
               ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
     def aio_write(self, object_name, to_write, offset=0,
                   oncomplete=None, onsafe=None):
@@ -2206,7 +2206,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error writing object %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_write', bytes), ('oncomplete', opt(Callable)),
+    @requires(('object_name', str_type), ('to_write', (bytes, bytearray)), ('oncomplete', opt(Callable)),
               ('onsafe', opt(Callable)))
     def aio_write_full(self, object_name, to_write,
                        oncomplete=None, onsafe=None):
@@ -2251,7 +2251,7 @@ cdef class Ioctx(object):
             raise make_ex(ret, "error writing object %s" % object_name)
         return completion
 
-    @requires(('object_name', str_type), ('to_append', bytes), ('oncomplete', opt(Callable)),
+    @requires(('object_name', str_type), ('to_append', (bytes, bytearray)), ('oncomplete', opt(Callable)),
               ('onsafe', opt(Callable)))
     def aio_append(self, object_name, to_append, oncomplete=None, onsafe=None):
         """
@@ -2359,7 +2359,7 @@ cdef class Ioctx(object):
         return completion
 
     @requires(('object_name', str_type), ('cls', str_type), ('method', str_type),
-              ('data', bytes), ('length', int),
+              ('data', (bytes, bytearray)), ('length', int),
               ('oncomplete', opt(Callable)), ('onsafe', opt(Callable)))
     def aio_execute(self, object_name, cls, method, data,
                     length=8192, oncomplete=None, onsafe=None):
@@ -2587,7 +2587,7 @@ cdef class Ioctx(object):
             self.state = "closed"
 
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str_type), ('data', (bytes, bytearray)))
     def write(self, key, data, offset=0):
         """
         Write data to an object synchronously
@@ -2623,7 +2623,7 @@ cdef class Ioctx(object):
             raise LogicError("Ioctx.write(%s): rados_write \
 returned %d, but should return zero on success." % (self.name, ret))
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str_type), ('data', (bytes, bytearray)))
     def write_full(self, key, data):
         """
         Write an entire object synchronously.
@@ -2658,7 +2658,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             raise LogicError("Ioctx.write_full(%s): rados_write_full \
 returned %d, but should return zero on success." % (self.name, ret))
 
-    @requires(('key', str_type), ('data', bytes))
+    @requires(('key', str_type), ('data', (bytes, bytearray)))
     def append(self, key, data):
         """
         Append data to an object synchronously
@@ -2734,7 +2734,7 @@ returned %d, but should return zero on success." % (self.name, ret))
             # itself and set ret_s to NULL, hence XDECREF).
             ref.Py_XDECREF(ret_s)
 
-    @requires(('key', str_type), ('cls', str_type), ('method', str_type), ('data', bytes))
+    @requires(('key', str_type), ('cls', str_type), ('method', str_type), ('data', (bytes, bytearray)))
     def execute(self, key, cls, method, data, length=8192):
         """
         Execute an OSD class method on an object.
@@ -2975,7 +2975,7 @@ returned %d, but should return zero on success." % (self.name, ret))
         self.require_ioctx_open()
         return XattrIterator(self, oid)
 
-    @requires(('key', str_type), ('xattr_name', str_type), ('xattr_value', bytes))
+    @requires(('key', str_type), ('xattr_name', str_type), ('xattr_value', (bytes, bytearray)))
     def set_xattr(self, key, xattr_name, xattr_value):
         """
         Set an extended attribute on an object.
@@ -3892,4 +3892,3 @@ class MonitorLog(object):
         self.arg = arg
         self.cluster = cluster
         self.cluster.monitor_log(level, callback, arg)
-

--- a/src/test/pybind/test_rados.py
+++ b/src/test/pybind/test_rados.py
@@ -329,6 +329,28 @@ class TestIoctx(object):
         self.ioctx.append('abc', b'c')
         eq(self.ioctx.read('abc'), b'abc')
 
+    def test_bytearray(self):
+        self.ioctx.write('abc', bytearray(b'ab'))
+        self.ioctx.append('abc', bytearray(b'c'))
+        eq(self.ioctx.read('abc'), b'abc')
+
+        self.ioctx.write_full('abc', bytearray(b'ab'))
+        eq(self.ioctx.read('abc'), b'ab')
+
+        comp = self.ioctx.aio_write("abc", bytearray(b'abc'))
+        comp.wait_for_complete()
+        comp.wait_for_safe()
+        comp = self.ioctx.aio_append("abc", bytearray(b'd'))
+        comp.wait_for_complete()
+        comp.wait_for_safe()
+        eq(self.ioctx.read('abc'), b'abcd')
+
+        comp = self.ioctx.aio_write_full('abc', bytearray(b'cd'))
+        comp.wait_for_complete()
+        comp.wait_for_safe()
+        eq(self.ioctx.read('abc'), b'cd')
+
+
     def test_write_zeros(self):
         self.ioctx.write('abc', b'a\0b\0c')
         eq(self.ioctx.read('abc'), b'a\0b\0c')
@@ -369,7 +391,8 @@ class TestIoctx(object):
                 ('ns1', 'ns1-c'), ('ns1', 'ns1-d')])
 
     def test_xattrs(self):
-        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0')
+        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0',
+                      f=bytearray(b'abc'))
         self.ioctx.write('abc', b'')
         for key, value in xattrs.items():
             self.ioctx.set_xattr('abc', key, value)
@@ -380,7 +403,8 @@ class TestIoctx(object):
         eq(stored_xattrs, xattrs)
 
     def test_obj_xattrs(self):
-        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0')
+        xattrs = dict(a=b'1', b=b'2', c=b'3', d=b'a\0b', e=b'\0',
+                      f=bytearray(b'abc'))
         self.ioctx.write('abc', b'')
         obj = list(self.ioctx.list_objects())[0]
         for key, value in xattrs.items():
@@ -446,26 +470,28 @@ class TestIoctx(object):
         self.ioctx.remove_object("inhead")
 
     def test_set_omap(self):
-        keys = ("1", "2", "3", "4")
-        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
+        keys = ("1", "2", "3", "4", "5")
+        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04",
+                  bytearray(b'abc'))
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             write_op.set_flags(LIBRADOS_OPERATION_SKIPRWLOCKS)
             self.ioctx.operate_write_op(write_op, "hw")
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
+            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 5)
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             next(iter)
-            eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
+            eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04"),
+                            ("5", b"abc")])
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals(read_op, "2", "", 4)
+            iter, ret = self.ioctx.get_omap_vals(read_op, "2", "", 5)
             eq(ret, 0)
             self.ioctx.operate_read_op(read_op, "hw")
             eq(("3", b"ccc"), next(iter))
-            eq(list(iter), [("4", b"\x04\x04\x04\x04")])
+            eq(list(iter), [("4", b"\x04\x04\x04\x04"), ("5", b"abc")])
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals(read_op, "", "2", 4)
+            iter, ret = self.ioctx.get_omap_vals(read_op, "", "2", 5)
             eq(ret, 0)
             read_op.set_flags(LIBRADOS_OPERATION_BALANCE_READS)
             self.ioctx.operate_read_op(read_op, "hw")
@@ -480,8 +506,8 @@ class TestIoctx(object):
                 lock.notify()
             return 0
 
-        keys = ("1", "2", "3", "4")
-        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04")
+        keys = ("1", "2", "3", "4", "5")
+        values = (b"aaa", b"bbb", b"ccc", b"\x04\x04\x04\x04", bytearray(b'abc'))
         with WriteOpCtx(self.ioctx) as write_op:
             self.ioctx.set_omap(write_op, keys, values)
             comp = self.ioctx.operate_aio_write_op(write_op, "hw", cb, cb)
@@ -493,7 +519,7 @@ class TestIoctx(object):
             eq(comp.get_return_value(), 0)
 
         with ReadOpCtx(self.ioctx) as read_op:
-            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 4)
+            iter, ret = self.ioctx.get_omap_vals(read_op, "", "", 5)
             eq(ret, 0)
             comp = self.ioctx.operate_aio_read_op(read_op, "hw", cb, cb)
             comp.wait_for_complete()
@@ -503,7 +529,8 @@ class TestIoctx(object):
                     lock.wait()
             eq(comp.get_return_value(), 0)
             next(iter)
-            eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04")])
+            eq(list(iter), [("2", b"bbb"), ("3", b"ccc"), ("4", b"\x04\x04\x04\x04"),
+                            ("5", b"abc")])
 
     def test_write_ops(self):
         with WriteOpCtx(self.ioctx) as write_op:


### PR DESCRIPTION
rados python binding currently allow only immutable byte array (bytes).

This change adds support for mutable byte array (bytearray).

Signed-off-by: Mehdi Abaakouk <sileht@sileht.net>