### PR TITLE
mon/PGMap: 'unclean' does not imply damaged

### DIFF
--- a/src/mon/PGMap.cc
+++ b/src/mon/PGMap.cc
@@ -2145,8 +2145,7 @@ void PGMap::get_health_checks(
     { PG_STATE_UNDERSIZED,       {DEGRADED,    [](const pg_stat_t &p){return p.last_fullsized;} } },
     { PG_STATE_STALE,            {UNAVAILABLE, [](const pg_stat_t &p){return p.last_unstale;}   } },
     // Delayed and inverted reports
-    { PG_STATE_ACTIVE,           {UNAVAILABLE, [](const pg_stat_t &p){return p.last_active;}, true} },
-    { PG_STATE_CLEAN,            {DEGRADED,    [](const pg_stat_t &p){return p.last_clean;}, true} }
+    { PG_STATE_ACTIVE,           {UNAVAILABLE, [](const pg_stat_t &p){return p.last_active;}, true} }
   };
 
   // Specialized state printer that takes account of inversion of


### PR DESCRIPTION
Everything (that I can think of) that would lead to a PG being unclean is
already reported via another health message.  And there are cases where a
PG is unclean (e.g., because it is backfilling) where we are not degraded.

Fix by ignoring this flag in the health checks.

Signed-off-by: Sage Weil <sage@redhat.com>