### PR TITLE
os/bluestore: do not assert if BlueFS rebalance is unable to allocate sufficient space

### DIFF
--- a/src/include/interval_set.h
+++ b/src/include/interval_set.h
@@ -520,7 +520,8 @@ class interval_set {
     erase(val, 1);
   }
 
-  void erase(T start, T len) {
+  void erase(T start, T len, 
+    std::function<bool(T, T)> post_process = {}) {
     typename Map::iterator p = find_inc_m(start);
 
     _size -= len;
@@ -532,15 +533,15 @@ class interval_set {
     T before = start - p->first;
     assert(p->second >= before+len);
     T after = p->second - before - len;
-    
-    if (before) 
+    if (before && (post_process ? post_process(p->first, before) : true)) {
       p->second = before;        // shorten bit before
-    else
+    } else {
       m.erase(p);
-    if (after)
-      m[start+len] = after;
+    }
+    if (after && (post_process ? post_process(start + len, after) : true)) {
+      m[start + len] = after;
+    }
   }
-
 
   void subtract(const interval_set &a) {
     for (typename Map::const_iterator p = a.m.begin();

--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -5086,12 +5086,19 @@ int BlueStore::_balance_bluefs_freespace(PExtentVector *extents)
     int64_t alloc_len = alloc->allocate(gift, cct->_conf->bluefs_alloc_size,
 					0, 0, &exts);
 
-    if (alloc_len < (int64_t)gift) {
-      derr << __func__ << " allocate failed on 0x" << std::hex << gift
-           << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
+    if (alloc_len <= 0) {
+      dout(1) << __func__ << " no allocate on 0x" << std::hex << gift
+              << " min_alloc_size 0x" << min_alloc_size << std::dec << dendl;
+      alloc->unreserve(gift);
       alloc->dump();
-      assert(0 == "allocate failed, wtf");
-      return -ENOSPC;
+      return 0;
+    } else if (alloc_len < (int64_t)gift) {
+      dout(1) << __func__ << " insufficient allocate on 0x" << std::hex << gift
+              << " min_alloc_size 0x" << min_alloc_size 
+	      << " allocated 0x" << alloc_len
+	      << std::dec << dendl;
+      alloc->unreserve(gift - alloc_len);
+      alloc->dump();
     }
     for (auto& p : exts) {
       bluestore_pextent_t e = bluestore_pextent_t(p);
@@ -5603,7 +5610,6 @@ int BlueStore::_mount(bool kv_only, bool open_db)
     goto out_stop;
 
   mempool_thread.init();
-
 
   mounted = true;
   return 0;
@@ -8427,7 +8433,8 @@ void BlueStore::_txc_release_alloc(TransContext *txc)
 {
   // it's expected we're called with lazy_release_lock already taken!
   if (likely(!cct->_conf->bluestore_debug_no_reuse_blocks)) {
-    dout(10) << __func__ << " " << txc << " " << txc->released << dendl;
+    dout(10) << __func__ << " " << txc << " " << std::hex
+             << txc->released << std::dec << dendl;
     alloc->release(txc->released);
   }
   txc->allocated.clear();

--- a/src/test/objectstore/store_test.cc
+++ b/src/test/objectstore/store_test.cc
@@ -44,6 +44,7 @@
 
 typedef boost::mt11213b gen_type;
 
+const uint64_t DEF_STORE_TEST_BLOCKDEV_SIZE = 10240000000;
 #define dout_context g_ceph_context
 
 #if GTEST_HAS_PARAM_TEST
@@ -6478,6 +6479,108 @@ TEST_P(StoreTestSpecificAUSize, SmallWriteOnShardedExtents) {
   g_conf->set_val("bluestore_csum_type", "crc32c");
 }
 
+TEST_P(StoreTestSpecificAUSize, ExcessiveFragmentation) {
+  if (string(GetParam()) != "bluestore")
+    return;
+
+  g_conf->set_val("bluestore_block_size",
+    stringify((uint64_t)2048 * 1024 * 1024));
+
+  ASSERT_EQ(g_conf->get_val<uint64_t>("bluefs_alloc_size"),
+	    1024 * 1024);
+
+  size_t block_size = 0x10000;
+  StartDeferred(block_size);
+
+  ObjectStore::Sequencer osr("test");
+  int r;
+  coll_t cid;
+  ghobject_t hoid1(hobject_t(sobject_t("Object 1", CEPH_NOSNAP)));
+  ghobject_t hoid2(hobject_t(sobject_t("Object 2", CEPH_NOSNAP)));
+
+  {
+    ObjectStore::Transaction t;
+    t.create_collection(cid, 0);
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    // create 2x400MB objects in a way that their pextents are interleaved
+    ObjectStore::Transaction t;
+    bufferlist bl;
+
+    bl.append(std::string(block_size * 4, 'a')); // 256KB
+    uint64_t offs = 0;
+    while(offs < (uint64_t)400 * 1024 * 1024) {
+      t.write(cid, hoid1, offs, bl.length(), bl, 0);
+      t.write(cid, hoid2, offs, bl.length(), bl, 0);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      offs += bl.length();
+      if( (offs % (100 * 1024 * 1024)) == 0) {
+       std::cout<<"written " << offs << std::endl;
+      }
+    }
+  }
+  std::cout<<"written 800MB"<<std::endl;
+  {
+    // Partially overwrite objects with 100MB each leaving space
+    // fragmented and occuping still unfragmented space at the end
+    // So we'll have enough free space but it'll lack long enough (e.g. 1MB)
+    // contiguous pextents.
+    ObjectStore::Transaction t;
+    bufferlist bl;
+
+    bl.append(std::string(block_size * 4, 'a'));
+    uint64_t offs = 0;
+    while(offs < 112 * 1024 * 1024) {
+      t.write(cid, hoid1, offs, bl.length(), bl, 0);
+      t.write(cid, hoid2, offs, bl.length(), bl, 0);
+      r = apply_transaction(store, &osr, std::move(t));
+      ASSERT_EQ(r, 0);
+      // this will produce high fragmentation if original allocations
+      // were contiguous
+      offs += bl.length();
+      if( (offs % (10 * 1024 * 1024)) == 0) {
+       std::cout<<"written " << offs << std::endl;
+      }
+    }
+  }
+  {
+    // remove one of the object producing much free space
+    // and hence triggering bluefs rebalance.
+    // Which should fail as there is no long enough pextents.
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid2);
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+
+  auto to_sleep = 5 *
+    (int)g_conf->get_val<double>("bluestore_bluefs_balance_interval");
+  std::cout<<"sleeping... " << std::endl;
+  sleep(to_sleep);
+
+  {
+    // touch another object to triggerrebalance
+    ObjectStore::Transaction t;
+    t.touch(cid, hoid1);
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  {
+    ObjectStore::Transaction t;
+    t.remove(cid, hoid1);
+    t.remove(cid, hoid2);
+    t.remove_collection(cid);
+    cerr << "Cleaning" << std::endl;
+    r = apply_transaction(store, &osr, std::move(t));
+    ASSERT_EQ(r, 0);
+  }
+  g_conf->set_val("bluestore_block_size",
+    stringify(DEF_STORE_TEST_BLOCKDEV_SIZE));
+}
+
 #endif //#if defined(WITH_BLUESTORE)
 
 TEST_P(StoreTest, KVDBHistogramTest) {
@@ -6802,7 +6905,8 @@ int main(int argc, char **argv) {
   g_ceph_context->_conf->set_val("bdev_debug_aio", "true");
 
   // specify device size
-  g_ceph_context->_conf->set_val("bluestore_block_size", "10240000000");
+  g_ceph_context->_conf->set_val("bluestore_block_size",
+    stringify(DEF_STORE_TEST_BLOCKDEV_SIZE));
 
   g_ceph_context->_conf->set_val(
     "enable_experimental_unrecoverable_data_corrupting_features", "*");


### PR DESCRIPTION
Under some(many?) conditions StupidAllocator can use free extents from bins greater than necessary that results in high fragmentation. Two related issues were fixed:
1) (minor) init_rm_free doesn't demote extent to lower bin.
2) Allocation hint preserved in StupidAllocator internally might result in an allocation from a bin higher than it's really needed. E.g. following sequence causes that on a clear store:
  - step 1: allocate small extents (len=0x1000) multiple times. This effectively increases the hint to the offset following the highest allocated extent.
  - step 2: release some of the allocated extents.
  - step 3: allocate small extent(s) again - due to the preserved hint and lower_bound(hint) call when searching bins up one will skip lower bin(s) as it(they) contains offsets below the hint value only. Hence we allocate from the highest bin instead of reusing short available extents and fragment the space this way. Besides this increases the hint again causing any next allocations to drain the highest bin first over and over. 
The scenario above (or similar variations) looks pretty repetitive and draining the topmost bin first seems to be quite a common case. 
As a result one can face an assert when allocator is unable to return 1Mb long extent(s) for BlueFS while reported free space is much much longer.
Partial fix is to remove assert on insufficient allocation during BlueFS rebalance..