### PR TITLE
build: remove PGMap.cc from libcommon

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -476,7 +476,6 @@ set(libcommon_files
   msg/simple/Accepter.cc
   msg/DispatchQueue.cc
   msg/Message.cc
-  mon/PGMap.cc
   mgr/ServiceMap.cc
   osd/ECMsgTypes.cc
   osd/HitSet.cc


### PR DESCRIPTION
Not needed.

Signed-off-by: Sage Weil <sage@redhat.com>