### PR TITLE
luminous: os/bluestore: handle compressed extents in blob unsharing checks

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -10691,10 +10691,14 @@ int BlueStore::_do_remove(
     if (b.is_shared() &&
 	sb->loaded &&
 	maybe_unshared_blobs.count(sb)) {
-      b.map(e.blob_offset, e.length, [&](uint64_t off, uint64_t len) {
-        expect[sb].get(off, len);
-	return 0;
-      });
+      if (b.is_compressed()) {
+	expect[sb].get(0, b.get_ondisk_length());
+      } else {
+	b.map(e.blob_offset, e.length, [&](uint64_t off, uint64_t len) {
+	    expect[sb].get(off, len);
+	    return 0;
+	  });
+      }
     }
   }
 


### PR DESCRIPTION
If the blob is compressed, we aren't mapping to a range within
the allocated extents, but rather referencing the entire blob.

Fixes: http://tracker.ceph.com/issues/21766
Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit eb26cfbfbb2b9b9fe84dfe9c999e2d67fd2661c0)