### PR TITLE
unittest_crypto: Don't exceed limit for getentropy

### DIFF
--- a/src/test/crypto.cc
+++ b/src/test/crypto.cc
@@ -121,7 +121,7 @@ TEST(AES, Loop) {
   bufferptr secret(16);
   random.get_bytes(secret.c_str(), secret.length());
 
-  bufferptr orig_plaintext(1024);
+  bufferptr orig_plaintext(256);
   random.get_bytes(orig_plaintext.c_str(), orig_plaintext.length());
 
   bufferlist plaintext;


### PR DESCRIPTION
CryptoRandom::get_bytes calls getentropy directly if available and it
enforces a limit of 256 bytes.

Signed-off-by: Brad Hubbard <bhubbard@redhat.com>