### PR TITLE
osd/PrimaryLogPG: add condition "is_chunky_scrub_active" to check obj…

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2026,7 +2026,7 @@ void PrimaryLogPG::do_op(OpRequestRef& op)
     return;
   }
 
-  if (write_ordered &&
+  if (write_ordered && scrubber.is_chunky_scrub_active() &&
       scrubber.write_blocked_by_scrub(head)) {
     dout(20) << __func__ << ": waiting for scrub" << dendl;
     waiting_for_scrub.push_back(op);


### PR DESCRIPTION
…ect in chunky_scrub.

Avoid every time call scrubber.write_block_by_scrub. Most time scrubber
is inactive. And compare to write_block_by_scrub, is_chunky_scrub_active
is light.

Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>