### PR TITLE
ceph-objectstore-tool: skip object with generated version

### DIFF
--- a/src/tools/ceph_objectstore_tool.cc
+++ b/src/tools/ceph_objectstore_tool.cc
@@ -629,7 +629,7 @@ int ObjectStoreTool::export_files(ObjectStore *store, coll_t coll)
 	 i != objects.end();
 	 ++i) {
       assert(!i->hobj.is_meta());
-      if (i->is_pgmeta() || i->hobj.is_temp()) {
+      if (i->is_pgmeta() || i->hobj.is_temp() || !i->is_no_gen()) {
 	continue;
       }
       r = export_file(store, coll, *i);


### PR DESCRIPTION
The object with generated vesion from clonerange2 will be deleted
or used as rollback source, but this object dont include OI_ATTR.

Signed-off-by: huangjun <huangjun@xsky.com>