### PR TITLE
rgw: Fix bug that policy verify procedure. And action wrong spelling

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2025,12 +2025,16 @@ void RGWStatAccount::execute()
 int RGWGetBucketVersioning::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3GetBucketVersioning,
-			    ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+             	     rgw::IAM::s3GetBucketVersioning,
+             	     ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny){
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;
@@ -2050,12 +2054,16 @@ void RGWGetBucketVersioning::execute()
 int RGWSetBucketVersioning::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3PutBucketVersioning,
-			    ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+             	     rgw::IAM::s3PutBucketVersioning,
+             	     ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;
@@ -2101,12 +2109,16 @@ void RGWSetBucketVersioning::execute()
 int RGWGetBucketWebsite::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-                           rgw::IAM::s3GetBucketWebsite,
-                           ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+                     rgw::IAM::s3GetBucketWebsite,
+                     ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
 
@@ -2128,12 +2140,16 @@ void RGWGetBucketWebsite::execute()
 int RGWSetBucketWebsite::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-                           rgw::IAM::s3PutBucketWebsite,
-                           ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+                     rgw::IAM::s3PutBucketWebsite,
+                     ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
 
@@ -2336,12 +2352,16 @@ int RGWGetBucketLogging::verify_permission()
 int RGWGetBucketLocation::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3GetBucketLocation,
-			    ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+             	     rgw::IAM::s3GetBucketLocation,
+             	     ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;
@@ -4972,12 +4992,16 @@ void RGWDeleteLC::execute()
 int RGWGetCORS::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3PutBucketCORS,
-			    ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+         			  rgw::IAM::s3GetBucketCORS,
+         			  ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;
@@ -4999,12 +5023,16 @@ void RGWGetCORS::execute()
 int RGWPutCORS::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3PutBucketCORS,
-			    ARN(s->bucket)) == Effect::Allow) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+             		 rgw::IAM::s3PutBucketCORS,
+             		 ARN(s->bucket));
+    if (e == Effect::Allow) {
       return 0;
+    }else if (e == Effect::Deny) {
+      return -EACCES;
     }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;
@@ -5152,12 +5180,16 @@ void RGWGetRequestPayment::execute()
 int RGWSetRequestPayment::verify_permission()
 {
   if (s->iam_policy) {
-    if (s->iam_policy->eval(s->env, *s->auth.identity,
-			    rgw::IAM::s3PutBucketRequestPayment,
-			    ARN(s->bucket)) == Effect::Allow) {
-      return 0;
-    }
-  } else if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
+    auto e = s->iam_policy->eval(s->env, *s->auth.identity,
+             	     rgw::IAM::s3PutBucketRequestPayment,
+             	     ARN(s->bucket));
+   if (e == Effect::Allow) {
+     return 0;
+   }else if (e == Effect::Deny) {
+     return -EACCESS;
+   }
+  }
+  if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {
     return 0;
   }
   return -EACCES;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -5186,7 +5186,7 @@ int RGWSetRequestPayment::verify_permission()
    if (e == Effect::Allow) {
      return 0;
    }else if (e == Effect::Deny) {
-     return -EACCESS;
+     return -EACCES;
    }
   }
   if (s->auth.identity->is_owner_of(s->bucket_owner.get_id())) {


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21901
There exists logical error in verify_permission function. 
For example:
  s3cmd setpolicy file s3://first 
  s3cmd info s3://first //will return access denied.
There also exists wrong spelling :
  int RGWGetCORS::verify_permission(){} 
In this function, policy evaluates "s3PutBucketCORS" action which should be s3GetBucketCORS.
Signed-off-by: Wen Zhang zhangwen1@unionpay.com