### PR TITLE
build/ops: rpm: recommend python-influxdb with ceph-mgr

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -330,6 +330,7 @@ Requires:       pyOpenSSL
 Requires: 	python-CherryPy
 Requires:       python-Werkzeug
 Requires:       python-pyOpenSSL
+Recommends:     python-influxdb
 %endif
 Requires:       python-pecan
 %description mgr


### PR DESCRIPTION
The influxdb module won't run if python-influxdb is not present (but it will be
graceful about not running). That means python-influxdb is a dependency of
that module, not mgr itself. However, we are not (yet) packaging the modules
separately. (When we do, this could become a Requires: of the module.)
 
RPM itself does not support "Recommends", and ignores this line. Higher-level
tools may or may not support it, so put this line in a SUSE-only conditional
since we know that zypper supports it.
