### PR TITLE
mon, doc: standardize argument as role

### DIFF
--- a/doc/man/8/ceph.rst
+++ b/doc/man/8/ceph.rst
@@ -33,7 +33,7 @@ Synopsis
 
 | **ceph** **log** *<logtext>* [ *<logtext>*... ]
 
-| **ceph** **mds** [ *compat* \| *deactivate* \| *fail* \| *rm* \| *rmfailed* \| *set_state* \| *stat* \| *tell* ] ...
+| **ceph** **mds** [ *compat* \| *deactivate* \| *fail* \| *rm* \| *rmfailed* \| *set_state* \| *stat* \| *repaired* ] ...
 
 | **ceph** **mon** [ *add* \| *dump* \| *getmap* \| *remove* \| *stat* ] ...
 
@@ -61,7 +61,7 @@ Synopsis
 
 | **ceph** **sync** **force** {--yes-i-really-mean-it} {--i-know-what-i-am-doing}
 
-| **ceph** **tell** *<name (type.id)> <args> [<args>...]*
+| **ceph** **tell** *<name (type.id)> <command> [options...]*
 
 | **ceph** **version**
 
@@ -375,13 +375,13 @@ Subcommand ``deactivate`` stops mds.
 
 Usage::
 
-	ceph mds deactivate <who>
+	ceph mds deactivate <role>
 
 Subcommand ``fail`` forces mds to status fail.
 
 Usage::
 
-	ceph mds fail <who>
+	ceph mds fail <role|gid>
 
 Subcommand ``rm`` removes inactive mds.
 
@@ -407,11 +407,11 @@ Usage::
 
 	ceph mds stat
 
-Subcommand ``tell`` sends command to particular mds.
+Subcommand ``repaired`` mark a damaged MDS rank as no longer damaged.
 
 Usage::
 
-	ceph mds tell <who> <args> [<args>...]
+	ceph mds repaired <role>
 
 mon
 ---
@@ -1402,7 +1402,7 @@ Sends a command to a specific daemon.
 
 Usage::
 
-	ceph tell <name (type.id)> <args> [<args>...]
+	ceph tell <name (type.id)> <command> [options...]
 
 
 List all available commands.

--- a/src/mgr/DaemonServer.cc
+++ b/src/mgr/DaemonServer.cc
@@ -436,7 +436,7 @@ bool DaemonServer::handle_report(MMgrReport *m)
 
       } else if (key.first == "mds") {
         c->set_default("addr", stringify(m->get_source_addr()));
-        oss << "{\"prefix\": \"mds metadata\", \"who\": \""
+        oss << "{\"prefix\": \"mds metadata\", \"role\": \""
             << key.second << "\"}";
  
       } else {

--- a/src/mgr/Mgr.cc
+++ b/src/mgr/Mgr.cc
@@ -567,7 +567,7 @@ void Mgr::handle_fs_map(MFSMap* m)
       c->set_default("addr", stringify(info.addr));
 
       std::ostringstream cmd;
-      cmd << "{\"prefix\": \"mds metadata\", \"who\": \""
+      cmd << "{\"prefix\": \"mds metadata\", \"role\": \""
           << info.name << "\"}";
       monc->start_mon_command(
           {cmd.str()},

--- a/src/mon/MDSMonitor.cc
+++ b/src/mon/MDSMonitor.cc
@@ -912,7 +912,7 @@ bool MDSMonitor::preprocess_command(MonOpRequestRef op)
       f.reset(Formatter::create("json-pretty"));
 
     string who;
-    bool all = !cmd_getval(g_ceph_context, cmdmap, "who", who);
+    bool all = !cmd_getval(g_ceph_context, cmdmap, "role", who);
     dout(1) << "all = " << all << dendl;
     if (all) {
       r = 0;
@@ -1290,7 +1290,7 @@ int MDSMonitor::filesystem_command(
   op->mark_mdsmon_event(__func__);
   int r = 0;
   string whostr;
-  cmd_getval(g_ceph_context, cmdmap, "who", whostr);
+  cmd_getval(g_ceph_context, cmdmap, "role", whostr);
 
   if (prefix == "mds deactivate") {
     mds_role_t role;
@@ -1350,7 +1350,7 @@ int MDSMonitor::filesystem_command(
     }
   } else if (prefix == "mds fail") {
     string who;
-    cmd_getval(g_ceph_context, cmdmap, "who", who);
+    cmd_getval(g_ceph_context, cmdmap, "role_or_gid", who);
 
     MDSMap::mds_info_t failed_info;
     r = fail_mds(ss, who, &failed_info);
@@ -1396,7 +1396,7 @@ int MDSMonitor::filesystem_command(
     }
     
     std::string role_str;
-    cmd_getval(g_ceph_context, cmdmap, "who", role_str);
+    cmd_getval(g_ceph_context, cmdmap, "role", role_str);
     mds_role_t role;
     int r = parse_role(role_str, &role, ss);
     if (r < 0) {
@@ -1447,7 +1447,7 @@ int MDSMonitor::filesystem_command(
     r = 0;
   } else if (prefix == "mds repaired") {
     std::string role_str;
-    cmd_getval(g_ceph_context, cmdmap, "rank", role_str);
+    cmd_getval(g_ceph_context, cmdmap, "role", role_str);
     mds_role_t role;
     r = parse_role(role_str, &role, ss);
     if (r < 0) {

--- a/src/mon/MonCommands.h
+++ b/src/mon/MonCommands.h
@@ -291,8 +291,8 @@ COMMAND("fs dump "
 COMMAND_WITH_FLAG("mds getmap " \
 	"name=epoch,type=CephInt,req=false,range=0", \
 	"get MDS map, optionally from epoch", "mds", "r", "cli,rest", FLAG(OBSOLETE))
-COMMAND("mds metadata name=who,type=CephString,req=false",
-	"fetch metadata for mds <who>",
+COMMAND("mds metadata name=role,type=CephString,req=false",
+	"fetch metadata for mds <role>",
 	"mds", "r", "cli,rest")
 COMMAND("mds count-metadata name=property,type=CephString",
 	"count MDSs by metadata field property",
@@ -306,9 +306,9 @@ COMMAND_WITH_FLAG("mds tell " \
 	"send command to particular mds", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
 COMMAND("mds compat show", "show mds compatibility settings", \
 	"mds", "r", "cli,rest")
-COMMAND_WITH_FLAG("mds stop name=who,type=CephString", "stop mds", \
+COMMAND_WITH_FLAG("mds stop name=role,type=CephString", "stop mds", \
 	"mds", "rw", "cli,rest", FLAG(OBSOLETE))
-COMMAND("mds deactivate name=who,type=CephString",
+COMMAND("mds deactivate name=role,type=CephString",
         "clean up specified MDS rank (use with `set max_mds` to shrink cluster)", \
 	"mds", "rw", "cli,rest")
 COMMAND_WITH_FLAG("mds set_max_mds " \
@@ -327,15 +327,15 @@ COMMAND("mds set_state " \
 	"name=gid,type=CephInt,range=0 " \
 	"name=state,type=CephInt,range=0|20", \
 	"set mds state of <gid> to <numeric-state>", "mds", "rw", "cli,rest")
-COMMAND("mds fail name=who,type=CephString", \
+COMMAND("mds fail name=role_or_gid,type=CephString", \
 	"Mark MDS failed: trigger a failover if a standby is available",
         "mds", "rw", "cli,rest")
-COMMAND("mds repaired name=rank,type=CephString", \
+COMMAND("mds repaired name=role,type=CephString", \
 	"mark a damaged MDS rank as no longer damaged", "mds", "rw", "cli,rest")
 COMMAND("mds rm " \
 	"name=gid,type=CephInt,range=0", \
 	"remove nonactive mds", "mds", "rw", "cli,rest")
-COMMAND("mds rmfailed name=who,type=CephString name=confirm,type=CephString,req=false", \
+COMMAND("mds rmfailed name=role,type=CephString name=confirm,type=CephString,req=false", \
 	"remove failed mds", "mds", "rw", "cli,rest")
 COMMAND_WITH_FLAG("mds cluster_down", "take MDS cluster down", "mds", "rw", "cli,rest", FLAG(OBSOLETE))
 COMMAND_WITH_FLAG("mds cluster_up", "bring MDS cluster up", "mds", "rw", "cli,rest", FLAG(OBSOLETE))

--- a/src/test/pybind/test_ceph_argparse.py
+++ b/src/test/pybind/test_ceph_argparse.py
@@ -335,18 +335,6 @@ class TestMDS(TestArgparse):
     def test_stat(self):
         self.check_no_arg('mds', 'stat')
 
-    def test_tell(self):
-        self.assert_valid_command(['mds', 'tell',
-                                   'someone',
-                                   'something'])
-        self.assert_valid_command(['mds', 'tell',
-                                   'someone',
-                                   'something',
-                                   'something else'])
-        assert_equal({}, validate_command(sigdict, ['mds', 'tell']))
-        assert_equal({}, validate_command(sigdict, ['mds', 'tell',
-                                                    'someone']))
-
     def test_compat_show(self):
         self.assert_valid_command(['mds', 'compat', 'show'])
         assert_equal({}, validate_command(sigdict, ['mds', 'compat']))


### PR DESCRIPTION
`ceph rmfailed` refers to its argument as "who" and `ceph repaired` refers to its argument as "rank". We should make these commands and others consistent by standardizing the argument as "role".

Fixes: http://tracker.ceph.com/issues/21393

Signed-off-by: Jos Collin <jcollin@redhat.com>