### PR TITLE
Fixes Bug #21904

### DIFF
--- a/src/pybind/mgr/zabbix/module.py
+++ b/src/pybind/mgr/zabbix/module.py
@@ -174,7 +174,10 @@ class Module(MgrModule):
 
         osd_stats = self.get('osd_stats')
         for osd in osd_stats['osd_stats']:
-            osd_fill.append((float(osd['kb_used']) / float(osd['kb'])) * 100)
+            if osd['kb'] == 0:
+                osd_fill.append(0)
+            else:
+                osd_fill.append((float(osd['kb_used']) / float(osd['kb'])) * 100)
             osd_apply_latency.append(osd['perf_stat']['apply_latency_ms'])
             osd_commit_latency.append(osd['perf_stat']['commit_latency_ms'])
 


### PR DESCRIPTION
Fixes [Bug #21904](http://tracker.ceph.com/issues/21904)
zabbix module fails to send data when osd['kb'] for some reason is zero.