### PR TITLE
rgw: Delete to_string functions. stringify defined in include/stringify.h can provide the same feature.

### DIFF
--- a/src/rgw/rgw_basic_types.cc
+++ b/src/rgw/rgw_basic_types.cc
@@ -33,10 +33,5 @@ ostream& operator <<(ostream& m, const Principal& p) {
   }
   return m << (p.is_user() ? "user/" : "role/") << p.get_id();
 }
-string to_string(const Principal& p) {
-  stringstream s;
-  s << p;
-  return s.str();
-}
 }
 }

--- a/src/rgw/rgw_basic_types.h
+++ b/src/rgw/rgw_basic_types.h
@@ -177,7 +177,6 @@ public:
 };
 
 std::ostream& operator <<(std::ostream& m, const Principal& p);
-std::string to_string(const Principal& p);
 }
 }
 

--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -951,12 +951,6 @@ ostream& operator <<(ostream& m, const MaskedIP& ip) {
   return m;
 }
 
-string to_string(const MaskedIP& m) {
-  stringstream ss;
-  ss << m;
-  return ss.str();
-}
-
 bool Condition::eval(const Environment& env) const {
   auto i = env.find(key);
   if (op == TokenID::Null) {
@@ -1240,12 +1234,6 @@ ostream& operator <<(ostream& m, const Condition& c) {
   m << ": { " << c.key;
   print_array(m, c.vals.cbegin(), c.vals.cend());
   return m << "}";
-}
-
-string to_string(const Condition& c) {
-  stringstream ss;
-  ss << c;
-  return ss.str();
 }
 
 Effect Statement::eval(const Environment& e,
@@ -1541,12 +1529,6 @@ ostream& operator <<(ostream& m, const Statement& s) {
   return m << " }";
 }
 
-string to_string(const Statement& s) {
-  stringstream m;
-  m << s;
-  return m.str();
-}
-
 Policy::Policy(CephContext* cct, const string& tenant,
 	       const bufferlist& _text)
   : text(_text.to_str()) {
@@ -1595,12 +1577,6 @@ ostream& operator <<(ostream& m, const Policy& p) {
     m << ", ";
   }
   return m << " }";
-}
-
-string to_string(const Policy& p) {
-  stringstream s;
-  s << p;
-  return s.str();
 }
 
 }

--- a/src/rgw/rgw_iam_policy.h
+++ b/src/rgw/rgw_iam_policy.h
@@ -247,7 +247,6 @@ struct MaskedIP {
 };
 
 std::ostream& operator <<(std::ostream& m, const MaskedIP& ip);
-string to_string(const MaskedIP& m);
 
 inline bool operator ==(const MaskedIP& l, const MaskedIP& r) {
   auto shift = std::max((l.v6 ? 128 : 32) - l.prefix,
@@ -398,8 +397,6 @@ struct Condition {
 
 std::ostream& operator <<(std::ostream& m, const Condition& c);
 
-std::string to_string(const Condition& c);
-
 struct Statement {
   boost::optional<std::string> sid = boost::none;
 
@@ -424,7 +421,6 @@ struct Statement {
 };
 
 std::ostream& operator <<(ostream& m, const Statement& s);
-std::string to_string(const Statement& s);
 
 struct PolicyParseException : public std::exception {
   rapidjson::ParseResult pr;
@@ -452,7 +448,6 @@ struct Policy {
 };
 
 std::ostream& operator <<(ostream& m, const Policy& p);
-std::string to_string(const Policy& p);
 }
 }
 


### PR DESCRIPTION
Signed-off-by: Wen Zhang zhangwen1@unionpay.com