### PR TITLE
vstart.sh: should quote the parameters to get them quoted

### DIFF
--- a/src/vstart.sh
+++ b/src/vstart.sh
@@ -378,12 +378,12 @@ quoted_print() {
 }
 
 prunb() {
-    quoted_print $* '&'
+    quoted_print "$@" '&'
     "$@" &
 }
 
 prun() {
-    quoted_print $*
+    quoted_print "$@"
     "$@"
 }
 


### PR DESCRIPTION
Signed-off-by: Kefu Chai <kchai@redhat.com>