### PR TITLE
osd/PG: fix recovery op leak

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -2209,7 +2209,6 @@ void PG::start_recovery_op(const hobject_t& soid)
   assert(recovery_ops_active >= 0);
   recovery_ops_active++;
 #ifdef DEBUG_RECOVERY_OIDS
-  assert(recovering_oids.count(soid) == 0);
   recovering_oids.insert(soid);
 #endif
   osd->start_recovery_op(this, soid);
@@ -2226,7 +2225,7 @@ void PG::finish_recovery_op(const hobject_t& soid, bool dequeue)
   recovery_ops_active--;
 #ifdef DEBUG_RECOVERY_OIDS
   assert(recovering_oids.count(soid));
-  recovering_oids.erase(soid);
+  recovering_oids.erase(recovering_oids.find(soid));
 #endif
   osd->finish_recovery_op(this, soid, dequeue);
 

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -840,7 +840,7 @@ protected:
   int recovery_ops_active;
   set<pg_shard_t> waiting_on_backfill;
 #ifdef DEBUG_RECOVERY_OIDS
-  set<hobject_t> recovering_oids;
+  multiset<hobject_t> recovering_oids;
 #endif
 
 protected:

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2201,13 +2201,16 @@ protected:
       typedef boost::mpl::list<
 	boost::statechart::custom_reaction< RemoteBackfillReserved >,
 	boost::statechart::custom_reaction< RemoteReservationRejected >,
+	boost::statechart::custom_reaction< RemoteReservationRevoked >,
 	boost::statechart::transition< AllBackfillsReserved, Backfilling >
 	> reactions;
       set<pg_shard_t>::const_iterator backfill_osd_it;
       explicit WaitRemoteBackfillReserved(my_context ctx);
+      void retry();
       void exit();
       boost::statechart::result react(const RemoteBackfillReserved& evt);
       boost::statechart::result react(const RemoteReservationRejected& evt);
+      boost::statechart::result react(const RemoteReservationRevoked& evt);
     };
 
     struct WaitLocalBackfillReserved : boost::statechart::state< WaitLocalBackfillReserved, Active >, NamedState {

--- a/src/osd/PG.h
+++ b/src/osd/PG.h
@@ -2193,6 +2193,7 @@ protected:
       boost::statechart::result react(const RemoteReservationRevoked& evt);
       boost::statechart::result react(const DeferBackfill& evt);
       boost::statechart::result react(const UnfoundBackfill& evt);
+      void cancel_backfill();
       void exit();
     };
 


### PR DESCRIPTION
This fixes a recovery op leak recently intorduced by the recovery preemption
changes and the new DeferRecovery stuff.  Or possibly a bit early?  Either way, I think this fixes it.

/a/sage-2017-10-24_22:15:33-rados-wip-sage-testing-2017-10-24-1544-distro-basic-smithi/1771206
