### PR TITLE
RGW:change the return value when delete not exist bucket

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1220,7 +1220,7 @@ void RGWCreateBucket_ObjStore_S3::send_response()
 void RGWDeleteBucket_ObjStore_S3::send_response()
 {
   int r = op_ret;
-  if (!r)
+  if (!r || r == -ERR_NO_SUCH_BUCKET)
     r = STATUS_NO_CONTENT;
 
   set_req_state_err(s, r);


### PR DESCRIPTION
when user delete not exist bucket, we use STATUS_NO_CONTENT instead of 
ERR_NO_SUCH_BUCKET, which is similar to delete not exist object.

Signed-off-by: Sibei Gao  <gaosb@inspur.com>