### PR TITLE
luminous: Disable messenger logging (debug ms = 0/0) for clients unless overridden.

### DIFF
--- a/src/common/common_init.cc
+++ b/src/common/common_init.cc
@@ -58,6 +58,10 @@ CephContext *common_preinit(const CephInitParameters &iparams,
     conf->set_val_or_die("err_to_stderr", "false");
     conf->set_val_or_die("log_flush_on_exit", "false");
   }
+  if (code_env != CODE_ENVIRONMENT_DAEMON) {
+    // NOTE: disable ms subsystem gathering in clients by default
+    conf->set_val_or_die("debug_ms", "0/0");
+  }
 
   return cct;
 }


### PR DESCRIPTION
http://tracker.ceph.com/issues/21918