### PR TITLE
qa: do not "ceph fs get cephfs" w/o a cephfs fs

### DIFF
--- a/qa/workunits/cephtool/test.sh
+++ b/qa/workunits/cephtool/test.sh
@@ -614,7 +614,6 @@ function test_auth_profiles()
   ceph -n client.xx-profile-ro -k client.xx.keyring osd dump
   ceph -n client.xx-profile-ro -k client.xx.keyring pg dump
   ceph -n client.xx-profile-ro -k client.xx.keyring mon dump
-  ceph -n client.xx-profile-ro -k client.xx.keyring fs get cephfs
   # read-only gets access denied for rw commands or auth commands
   ceph -n client.xx-profile-ro -k client.xx.keyring log foo >& $TMPFILE || true
   check_response "EACCES: access denied"


### PR DESCRIPTION
introduced by 183646c

it addresses the failures in http://pulpito.ceph.com/kchai-2017-10-25_10:30:53-rados-wip-kefu-testing-2017-10-25-1600-distro-basic-mira/

Signed-off-by: Kefu Chai <kchai@redhat.com>