### PR TITLE
rgw: lc support Content-MD5 request header and fix a rgw crash bug

### DIFF
--- a/src/rgw/rgw_lc_s3.cc
+++ b/src/rgw/rgw_lc_s3.cc
@@ -122,7 +122,7 @@ bool LCRule_S3::xml_end(const char *el) {
   if (lc_id){
     id = lc_id->get_data();
   } else {
-    gen_rand_alphanumeric_lower(nullptr, &id, LC_ID_LENGTH);
+    gen_rand_alphanumeric_lower(cct, &id, LC_ID_LENGTH);
   }
 
 
@@ -182,7 +182,7 @@ bool LCRule_S3::xml_end(const char *el) {
   return true;
 }
 
-void LCRule_S3::to_xml(CephContext *cct, ostream& out) {
+void LCRule_S3::to_xml(ostream& out) {
   out << "<Rule>" ;
   out << "<ID>" << id << "</ID>";
   if (!filter.empty()) {
@@ -243,7 +243,7 @@ XMLObj *RGWLCXMLParser_S3::alloc_obj(const char *el)
   if (strcmp(el, "LifecycleConfiguration") == 0) {
     obj = new RGWLifecycleConfiguration_S3(cct);
   } else if (strcmp(el, "Rule") == 0) {
-    obj = new LCRule_S3();
+    obj = new LCRule_S3(cct);
   } else if (strcmp(el, "ID") == 0) {
     obj = new LCID_S3();
   } else if (strcmp(el, "Prefix") == 0) {

--- a/src/rgw/rgw_lc_s3.h
+++ b/src/rgw/rgw_lc_s3.h
@@ -185,11 +185,14 @@ public:
 
 class LCRule_S3 : public LCRule, public XMLObj
 {
+private:
+  CephContext *cct;
 public:
-  LCRule_S3() {}
+  LCRule_S3(): cct(nullptr) {}
+  LCRule_S3(CephContext *_cct): cct(_cct) {}
   ~LCRule_S3() override {}
 
-  void to_xml(CephContext *cct, ostream& out);
+  void to_xml(ostream& out);
   bool xml_end(const char *el) override;
   bool xml_start(const char *el, const char **attr);
   void dump_xml(Formatter *f) const {
@@ -218,6 +221,10 @@ public:
 
     f->close_section(); // Rule
   }
+
+  void set_ctx(CephContext *ctx) {
+    cct = ctx;
+  }
 };
 
 class RGWLCXMLParser_S3 : public RGWXMLParser
@@ -243,7 +250,7 @@ public:
     multimap<string, LCRule>::iterator iter;
     for (iter = rule_map.begin(); iter != rule_map.end(); ++iter) {
       LCRule_S3& rule = static_cast<LCRule_S3&>(iter->second);
-      rule.to_xml(cct, out);
+      rule.to_xml(out);
     }
     out << "</LifecycleConfiguration>";
   }

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -4843,6 +4843,25 @@ void RGWPutLC::execute()
   RGWLCXMLParser_S3 parser(s->cct);
   RGWLifecycleConfiguration_S3 new_config(s->cct);
 
+  content_md5 = s->info.env->get("HTTP_CONTENT_MD5");
+  if (content_md5 == nullptr) {
+    op_ret = -ERR_INVALID_REQUEST;
+    s->err.message = "Missing required header for this request: Content-MD5";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    return;
+  }
+
+  std::string content_md5_bin;
+  try {
+    content_md5_bin = rgw::from_base64(boost::string_view(content_md5));
+  } catch (...) {
+    s->err.message = "Request header Content-MD5 contains character "
+                     "that is not base64 encoded.";
+    ldout(s->cct, 5) << s->err.message << dendl;
+    op_ret = -ERR_BAD_DIGEST;
+    return;
+  }
+
   if (!parser.init()) {
     op_ret = -EINVAL;
     return;
@@ -4853,6 +4872,21 @@ void RGWPutLC::execute()
     return;
 
   ldout(s->cct, 15) << "read len=" << len << " data=" << (data ? data : "") << dendl;
+
+  MD5 data_hash;
+  unsigned char data_hash_res[CEPH_CRYPTO_MD5_DIGESTSIZE];
+  data_hash.Update(reinterpret_cast<const byte*>(data), len);
+  data_hash.Final(data_hash_res);
+
+  if (memcmp(data_hash_res, content_md5_bin.c_str(), CEPH_CRYPTO_MD5_DIGESTSIZE) != 0) {
+    op_ret = -ERR_BAD_DIGEST;
+    s->err.message = "The Content-MD5 you specified did not match what we received.";
+    ldout(s->cct, 5) << s->err.message
+                     << " Specified content md5: " << content_md5
+                     << ", calculated content md5: " << data_hash_res
+                     << dendl;
+    return;
+  }
 
   if (!parser.parse(data, len, 1)) {
     op_ret = -ERR_MALFORMED_XML;

--- a/src/rgw/rgw_op.h
+++ b/src/rgw/rgw_op.h
@@ -1412,12 +1412,14 @@ class RGWPutLC : public RGWOp {
 protected:
   int len;
   char *data;
+  const char *content_md5;
   string cookie;
 
 public:
   RGWPutLC() {
     len = 0;
-    data = NULL;
+    data = nullptr;
+    content_md5 = nullptr;
   }
   ~RGWPutLC() override {
     free(data);


### PR DESCRIPTION
1、According to AWS S3, this header must be used as a message integrity check to verify that the request body was not corrupted in transit. Content-MD5 is the base64-encoded 128-bit MD5 digest of the data

2、When a putting lc config request does not include an ID tag in lc configuration xml, RGW should generate a random ID for the lc configuration.
At present RGW will crash when generate a random ID for lc configuration.

Fixes: http://tracker.ceph.com/issues/21980