### PR TITLE
os/bluestore/bluestore_tool: add log-dump command to dump bluefs's log

### DIFF
--- a/src/os/bluestore/BlueFS.h
+++ b/src/os/bluestore/BlueFS.h
@@ -309,7 +309,7 @@ private:
 
   int _open_super();
   int _write_super();
-  int _replay(bool noop); ///< replay journal
+  int _replay(bool noop, bool to_stdout = false); ///< replay journal
 
   FileWriter *_create_writer(FileRef f);
   void _close_writer(FileWriter *h);
@@ -331,6 +331,11 @@ public:
   int mkfs(uuid_d osd_uuid);
   int mount();
   void umount();
+  
+  int log_dump(
+    CephContext *cct,
+    const string& path,
+    const vector<string>& devs);
 
   void collect_metadata(map<string,string> *pm);
   int fsck();


### PR DESCRIPTION
./bin/ceph-bluestore-tool --command bluefs-log-dump --path dev/osd0/
...
log_dump log_fnode file(ino 1 size 0x1000 mtime 0.000000 bdev 0 extents [0:0x100000+400000])
log_dump 0x0: txn(seq 1 len 0x37 crc 0x3d91dc32)
log_dump 0x0:  op_init
log_dump 0x0:  op_alloc_add  0:0x1000~3e7ff000
...

Signed-off-by: Yang Honggang <joseph.yang@xtaotech.com>