### PR TITLE
luminous: baixuyeyu refcnt

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8138,9 +8138,11 @@ int RGWRados::copy_obj(RGWObjectCtx& obj_ctx,
     if (tail_placement.bucket.name.empty()) {
       manifest.set_tail_placement(tail_placement.placement_rule, src_obj.bucket);
     }
+    string ref_tag;
     for (; miter != astate->manifest.obj_end(); ++miter) {
       ObjectWriteOperation op;
-      cls_refcount_get(op, tag, true);
+      ref_tag = tag + '\0';
+      cls_refcount_get(op, ref_tag, true);
       const rgw_raw_obj& loc = miter.get_location().get_raw_obj(this);
       ref.ioctx.locator_set_key(loc.loc);
 
@@ -9724,7 +9726,6 @@ int RGWRados::set_attrs(void *ctx, const RGWBucketInfo& bucket_info, rgw_obj& ob
       return r;
 
     bl.append(tag.c_str(), tag.size() + 1);
-
     op.setxattr(RGW_ATTR_ID_TAG,  bl);
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/21937

upload obj to bucket1
s3cmd put obj s3://bucket1
cp obj from bucket1 to bucket2
s3cmd cp s3://bucket1/obj s3://bucket2
del obj from bucket1 and bucket2
s3cmd del s3://bucket1/obj
s3cmd del s3://bucket2/obj
you can see the pool 'default.rgw.buckets.data', the data of obj can not deleted.
ceph df | grep default.rgw.buckets.data

Fixes: http://tracker.ceph.com/issues/21819

Signed-off-by: Xueyu Bai baixueyu@inspur.com
(cherry picked from commit 2e11545077c485d5c155ab932b6274a8ac863e61)