### PR TITLE
librbd: don't read metadata twice on image open

### DIFF
--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -274,6 +274,11 @@ struct C_InvalidateCache : public Context {
     trace_endpoint.copy_name(pname);
     perf_start(pname);
 
+    assert(image_watcher == NULL);
+    image_watcher = new ImageWatcher<>(*this);
+  }
+
+  void ImageCtx::init_cache() {
     if (cache) {
       Mutex::Locker l(cache_lock);
       ldout(cct, 20) << "enabling caching..." << dendl;
@@ -290,9 +295,9 @@ struct C_InvalidateCache : public Context {
 		     << " max_dirty_age="
 		     << cache_max_dirty_age << dendl;
 
-      object_cacher = new ObjectCacher(cct, pname, *writeback_handler, cache_lock,
-				       NULL, NULL,
-				       cache_size,
+      object_cacher = new ObjectCacher(cct, perfcounter->get_name(),
+                                       *writeback_handler, cache_lock, NULL,
+                                       NULL, cache_size,
 				       10,  /* reset this in init */
 				       init_max_dirty,
 				       cache_target_dirty,
@@ -845,8 +850,7 @@ struct C_InvalidateCache : public Context {
   }
 
   void ImageCtx::register_watch(Context *on_finish) {
-    assert(image_watcher == NULL);
-    image_watcher = new ImageWatcher<>(*this);
+    assert(image_watcher != NULL);
     image_watcher->register_watch(on_finish);
   }
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -228,6 +228,7 @@ namespace librbd {
 	     const char *snap, IoCtx& p, bool read_only);
     ~ImageCtx();
     void init();
+    void init_cache();
     void shutdown();
     void init_layout();
     void perf_start(std::string name);

--- a/src/librbd/image/OpenRequest.h
+++ b/src/librbd/image/OpenRequest.h
@@ -55,14 +55,11 @@ private:
    *            V2_GET_CREATE_TIMESTAMP             |
    *                |                               |
    *                v                               |
-   *            V2_GET_DATA_POOL                    |
-   *                |                               |
-   *                v                               |
-   *      /---> V2_APPLY_METADATA -------------> REGISTER_WATCH (skip if
-   *      |         |                               |            read-only)
-   *      \---------/                               v
-   *                                             REFRESH
+   *            V2_GET_DATA_POOL --------------> REFRESH
    *                                                |
+   *                                                v
+   *                                             REGISTER_WATCH (skip if
+   *                                                |            read-only)
    *                                                v
    *                                             SET_SNAP (skip if no snap)
    *                                                |
@@ -83,9 +80,6 @@ private:
 
   bufferlist m_out_bl;
   int m_error_result;
-
-  std::string m_last_metadata_key;
-  std::map<std::string, bufferlist> m_metadata;
 
   void send_v1_detect_header();
   Context *handle_v1_detect_header(int *result);
@@ -114,14 +108,11 @@ private:
   void send_v2_get_data_pool();
   Context *handle_v2_get_data_pool(int *result);
 
-  void send_v2_apply_metadata();
-  Context *handle_v2_apply_metadata(int *result);
-
-  void send_register_watch();
-  Context *handle_register_watch(int *result);
-
   void send_refresh();
   Context *handle_refresh(int *result);
+
+  Context *send_register_watch(int *result);
+  Context *handle_register_watch(int *result);
 
   Context *send_set_snap(int *result);
   Context *handle_set_snap(int *result);

--- a/src/librbd/image/RefreshRequest.cc
+++ b/src/librbd/image/RefreshRequest.cc
@@ -11,6 +11,7 @@
 #include "cls/rbd/cls_rbd_client.h"
 #include "librbd/ExclusiveLock.h"
 #include "librbd/ImageCtx.h"
+#include "librbd/ImageWatcher.h"
 #include "librbd/Journal.h"
 #include "librbd/ObjectMap.h"
 #include "librbd/Utils.h"
@@ -345,7 +346,8 @@ Context *RefreshRequest<I>::handle_v2_get_metadata(int *result) {
     }
   }
 
-  m_image_ctx.apply_metadata(m_metadata, false);
+  bool thread_safe = m_image_ctx.image_watcher->is_unregistered();
+  m_image_ctx.apply_metadata(m_metadata, thread_safe);
 
   send_v2_get_flags();
   return nullptr;

--- a/src/test/librbd/image/test_mock_RefreshRequest.cc
+++ b/src/test/librbd/image/test_mock_RefreshRequest.cc
@@ -4,6 +4,7 @@
 #include "test/librbd/test_mock_fixture.h"
 #include "test/librbd/test_support.h"
 #include "test/librbd/mock/MockImageCtx.h"
+#include "test/librbd/mock/MockImageWatcher.h"
 #include "test/librbd/mock/MockJournal.h"
 #include "test/librbd/mock/MockJournalPolicy.h"
 #include "test/librbd/mock/MockObjectMap.h"
@@ -162,6 +163,8 @@ public:
       expect.WillOnce(Return(r));
     } else {
       expect.WillOnce(DoDefault());
+      EXPECT_CALL(*mock_image_ctx.image_watcher, is_unregistered())
+        .WillOnce(Return(false));
     }
   }
 

--- a/src/test/librbd/mock/MockImageWatcher.h
+++ b/src/test/librbd/mock/MockImageWatcher.h
@@ -12,6 +12,7 @@ namespace librbd {
 
 struct MockImageWatcher {
   MOCK_METHOD0(is_registered, bool());
+  MOCK_METHOD0(is_unregistered, bool());
   MOCK_METHOD0(unregister_watch, void());
   MOCK_METHOD1(flush, void(Context *));
 


### PR DESCRIPTION
After adding get_metadata to RefreshRequest it has become redundant
in OpenRequest.

Signed-off-by: Mykola Golub <to.my.trociny@gmail.com>