### PR TITLE
qa: add cbt repo parameter

### DIFF
--- a/qa/tasks/cbt.py
+++ b/qa/tasks/cbt.py
@@ -78,13 +78,13 @@ class CBT(Task):
 
     def checkout_cbt(self):
         testdir = misc.get_testdir(self.ctx)
+        repo = self.config.get('repo', 'https://github.com/ceph/cbt.git')
         branch = self.config.get('branch', 'master')
         branch = self.config.get('force-branch', branch)
         sha1 = self.config.get('sha1')
         self.first_mon.run(
             args=[
-                'git', 'clone', '-b', branch,
-                'https://github.com/ceph/cbt.git',
+                'git', 'clone', '-b', branch, repo,
                 '{tdir}/cbt'.format(tdir=testdir)
             ]
         )


### PR DESCRIPTION
This change lets you specify the CBT repo to be used, in the task config, which is helpful for development.

Signed-off-by: Neha Ojha <nojha@redhat.com>