### PR TITLE
Revert "ceph_context: re-expand admin_socket metavariables in child p…

### DIFF
--- a/src/common/ceph_context.cc
+++ b/src/common/ceph_context.cc
@@ -741,19 +741,6 @@ void CephContext::start_service_thread()
   if (_conf->log_flush_on_exit)
     _log->set_flush_on_exit();
 
-  if (_conf->admin_socket.length()) {
-    // Reset admin_socket raw value if it is defined in conffile.
-    // Just in case it used metavarirables (e.g, $pid) which could be expanded 
-    // again to the correct value here in child process.
-    std::vector <std::string> my_sections;
-    std::string admin_socket;
-    _conf->get_my_sections(my_sections);
-    if (_conf->get_val_from_conf_file(my_sections, "admin_socket",
-        admin_socket, false) == 0) {
-      _conf->set_val("admin_socket", admin_socket);
-    }
-  }
-
   // Trigger callbacks on any config observers that were waiting for
   // it to become safe to start threads.
   _conf->set_val("internal_safe_to_start_threads", "true");


### PR DESCRIPTION
…rocess"

This commit introduces a regression where the admin socket specified in
ceph.conf overrides command line arguments or environment variables.

This reverts commit 1630f4bbef3a3ff6efb56acbaa9b8786b945b1e6.

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>