### PR TITLE
common: osd_hearbeat with seprate link through  network segment configuration

### DIFF
--- a/src/ceph_osd.cc
+++ b/src/ceph_osd.cc
@@ -447,7 +447,8 @@ flushjournal_out:
   }
 
   pick_addresses(g_ceph_context, CEPH_PICK_ADDRESS_PUBLIC
-                                |CEPH_PICK_ADDRESS_CLUSTER);
+                                |CEPH_PICK_ADDRESS_CLUSTER
+                                |CEPH_PICK_ADDRESS_HEARTBEAT);
 
   if (g_conf->public_addr.is_blank_ip() && !g_conf->cluster_addr.is_blank_ip()) {
     derr << TEXT_YELLOW

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -17,8 +17,10 @@ OPTION(host, OPT_STR) // "" means that ceph will use short hostname
 OPTION(public_addr, OPT_ADDR)
 OPTION(public_bind_addr, OPT_ADDR)
 OPTION(cluster_addr, OPT_ADDR)
+OPTION(osd_heartbeat_addr, OPT_ADDR)
 OPTION(public_network, OPT_STR)
 OPTION(cluster_network, OPT_STR)
+OPTION(osd_heartbeat_network, OPT_STR)
 OPTION(lockdep, OPT_BOOL)
 OPTION(lockdep_force_backtrace, OPT_BOOL) // always gather current backtrace at every lock
 OPTION(run_dir, OPT_STR)       // the "/var/run/ceph" dir, created on daemon startup
@@ -720,7 +722,6 @@ OPTION(osd_remove_thread_timeout, OPT_INT)
 OPTION(osd_remove_thread_suicide_timeout, OPT_INT)
 OPTION(osd_command_thread_timeout, OPT_INT)
 OPTION(osd_command_thread_suicide_timeout, OPT_INT)
-OPTION(osd_heartbeat_addr, OPT_ADDR)
 OPTION(osd_heartbeat_interval, OPT_INT)       // (seconds) how often we ping peers
 
 // (seconds) how long before we decide a peer has failed

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -178,6 +178,10 @@ std::vector<Option> get_global_options() {
     .add_service("osd")
     .add_tag("network"),
 
+    Option("osd_heartbeat_addr", Option::TYPE_ADDR, Option::LEVEL_ADVANCED)
+    .set_default(entity_addr_t())
+    .set_description(""),
+
     Option("public_network", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .add_service({"mon", "mds", "osd", "mgr"})
     .add_tag("network")
@@ -199,6 +203,17 @@ std::vector<Option> get_global_options() {
     .add_tag("network")
     .set_description("Interface name(s) from which to choose an address from a cluster_network to bind to; cluster_network must also be specified.")
     .add_see_also("cluster_network"),
+
+    Option("osd_heartbeat_network", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .add_service("osd")
+    .add_tag("network")
+    .set_description("Network(s) from which to choose a osd heartbeat network address to bind to"),
+
+    Option("osd_heartbeat_network_interface", Option::TYPE_STR, Option::LEVEL_ADVANCED)
+    .add_service({"mon", "mds", "osd", "mgr"})
+    .add_tag("network")
+    .set_description("Interface name(s) from which to choose an address from a osd_heartbeat_network to bind to; osd_heartbeat_network must also be specified.")
+    .add_see_also("osd_heartbeat_network"),
 
     Option("monmap", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_description("path to MonMap file")
@@ -2349,10 +2364,6 @@ std::vector<Option> get_global_options() {
 
     Option("osd_command_thread_suicide_timeout", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(15_min)
-    .set_description(""),
-
-    Option("osd_heartbeat_addr", Option::TYPE_ADDR, Option::LEVEL_ADVANCED)
-    .set_default(entity_addr_t())
     .set_description(""),
 
     Option("osd_heartbeat_interval", Option::TYPE_INT, Option::LEVEL_ADVANCED)

--- a/src/common/pick_address.cc
+++ b/src/common/pick_address.cc
@@ -191,6 +191,14 @@ void pick_addresses(CephContext *cct, int needs)
     }
   }
 
+  if ((needs & CEPH_PICK_ADDRESS_HEARTBEAT)
+	  && cct->_conf->osd_heartbeat_addr.is_blank_ip()
+	  && !cct->_conf->osd_heartbeat_network.empty()) {
+	fill_in_one_address(cct, ifa, cct->_conf->osd_heartbeat_network,
+			cct->_conf->get_val<string>("osd_heartbeat_network_interface"),
+			"osd_heartbeat_addr");
+  }
+
   freeifaddrs(ifa);
 }
 

--- a/src/common/pick_address.h
+++ b/src/common/pick_address.h
@@ -8,6 +8,7 @@ class CephContext;
 
 #define CEPH_PICK_ADDRESS_PUBLIC     0x01
 #define CEPH_PICK_ADDRESS_CLUSTER    0x02
+#define CEPH_PICK_ADDRESS_HEARTBEAT  0x03
 
 /*
   Pick addresses based on subnets if needed.


### PR DESCRIPTION
In the function of osd heartbeat messages sented through a separate link,this modification add osd_heartbeat_network segment configuration, making the clustering realize the function by configuring network segment, to ensure that each node cluster configuration files are the same. It can make maintenance and management become convenient.Note: This function was realized by configuring the specific IP, which would result in different configuration files of the cluster nodes and the difficulty of cluster maintenance.

Signed-off-by: shangfufei@inspur.com <shangfufei@inspur.com>