### PR TITLE
rgw: add cors header rule check in cors option request

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -887,6 +887,20 @@ static bool validate_cors_rule_method(RGWCORSRule *rule, const char *req_meth) {
   return true;
 }
 
+static bool validate_cors_rule_header(RGWCORSRule *rule, const char *req_hdrs) {
+  if (req_hdrs) {
+    vector<string> hdrs;
+    get_str_vec(req_hdrs, hdrs);
+    for (const auto& hdr : hdrs) {
+      if (!rule->is_header_allowed(hdr.c_str(), hdr.length())) {
+        dout(5) << "Header " << hdr << " is not registered in this rule" << dendl;
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
 int RGWOp::read_bucket_cors()
 {
   bufferlist bl;
@@ -5089,6 +5103,11 @@ int RGWOptionsCORS::validate_cors_request(RGWCORSConfiguration *cc) {
   if (!validate_cors_rule_method(rule, req_meth)) {
     return -ENOENT;
   }
+
+  if (!validate_cors_rule_header(rule, req_hdrs)) {
+    return -ENOENT;
+  }
+
   return 0;
 }
 


### PR DESCRIPTION
hi, 

```
i set cors on bucket test1 as follow

<?xml version="1.0" encoding="UTF-8"?>
<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
    <CORSRule>
        <AllowedOrigin>*</AllowedOrigin>
        <AllowedMethod>GET</AllowedMethod>
	<AllowedHeader>header1</AllowedHeader>
    </CORSRule>
</CORSConfiguration>

and

curl -v -X OPTIONS  http://10.139.13.205/test1/1.txt   --header "Origin: example.com" --header "Access-Control-Request-Headers: header2" --header "Access-Control-Request-Method: GET"

and the output

* About to connect() to 10.139.13.205 port 80 (#0)
*   Trying 10.139.13.205...
* Connected to 10.139.13.205 (10.139.13.205) port 80 (#0)
> OPTIONS /test1/1.txt HTTP/1.1
> User-Agent: curl/7.29.0
> Host: 10.139.13.205
> Accept: */*
> Origin: example.com
> Access-Control-Request-Headers: header2
> Access-Control-Request-Method: GET
>
< HTTP/1.1 200 OK
< Access-Control-Allow-Origin: example.com  <===== here should not return
< Vary: Origin
< Access-Control-Allow-Methods: GET    <===== here should not return
< x-amz-request-id: tx000000000000000000196-0059f1a358-3715-default
< Content-Length: 0
< Date: Thu, 26 Oct 2017 08:56:56 GMT
<
* Connection #0 to host 10.139.13.205 left intact

and  follow is what aws s3 response

* Connected to testbyyly.s3.amazonaws.com (52.216.1.32) port 80 (#0)
> OPTIONS /1.txt HTTP/1.1
> User-Agent: curl/7.29.0
> Host: testbyyly.s3.amazonaws.com
> Accept: */*
> Origin:    example.com
> Access-Control-Request-Headers: header2
> Access-Control-Request-Method: GET
>
< HTTP/1.1 403 Forbidden
< x-amz-request-id: 013834B2B978805D
< x-amz-id-2: yOLwwhUGiNhAsI2IU4USP9cbFr5wCm/CRxOqHLZ68+0vCViq0GJ1dwlMv3spcCy9WhkIw+VEPEg=
< Content-Type: application/xml
< Transfer-Encoding: chunked
< Date: Thu, 26 Oct 2017 08:58:52 GMT
< Server: AmazonS3
<
<?xml version="1.0" encoding="UTF-8"?>
* Connection #0 to host testbyyly.s3.amazonaws.com left intact
<Error><Code>AccessForbidden</Code><Message>CORSResponse: This CORS request is not allowed. This is usually because the evalution of Origin, request method / Access-Control-Request-Method orAccess-Control-Request-Headers are not whitelisted by the resource's CORS spec.</Message><Method>GET</Method><ResourceType>OBJECT</ResourceType><RequestId>013834B2B978805D</RequestId><HostId>yOLwwhUGiNhAsI2IU4USP9cbFr5wCm/CRxOqHLZ68+0vCViq0GJ1dwlMv3spcCy9WhkIw+VEPEg=</HostId></Error>

```

we need to add cors header rule check in cors option request

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>