### PR TITLE
Add a warning to "rados put"

### DIFF
--- a/doc/man/8/rados.rst
+++ b/doc/man/8/rados.rst
@@ -97,6 +97,8 @@ Pool specific commands
 
 :command:`put` *name* *infile* [--offset offset]
   Write object name with start offset (default:0) to the cluster with contents from infile.
+  
+  **Warning:** Please be aware that this directly creates a single object at the RADOS layer directly. This can interfere with data distribution across the OSDs and even overload the cluster when trying to replicate it. Consider using the frontend protocols like S3, RBD, CephFS instead, which all stripe the data properly.
 
 :command:`append` *name* *infile*
   Append object name to the cluster with contents from infile.


### PR DESCRIPTION
Too many users try using "rados put" as an interface for uploading large objects, with predictable results (if you know what it does). Hopefully, adding a warning to the command might help reduce the support load this causes.