### PR TITLE
ceph-disk:  Fix symlink created by ceph-disk to point at by-parttypeuuid

### DIFF
--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2364,22 +2364,6 @@ class PrepareSpace(object):
                 self.space_symlink = getattr(self.args, self.name)
                 return
 
-        self.space_symlink = '/dev/disk/by-parttypeuuid/{ptype}.{uuid}'.format(
-            ptype=PTYPE['mpath']['block']['ready'],
-            uuid=getattr(self.args, self.name + '_uuid'))
-
-        if self.args.dmcrypt:
-            self.space_dmcrypt = self.space_symlink
-            self.space_symlink = '/dev/mapper/{uuid}'.format(
-                uuid=getattr(self.args, self.name + '_uuid'))
-
-        if reusing_partition:
-            # confirm that the space_symlink exists. It should since
-            # this was an active space
-            # in the past. Continuing otherwise would be futile.
-            assert os.path.exists(self.space_symlink)
-            return
-
         num = self.desired_partition_number()
 
         if num == 0:
@@ -2395,6 +2379,22 @@ class PrepareSpace(object):
             num=num)
 
         partition = device.get_partition(num)
+
+        self.space_symlink = '/dev/disk/by-parttypeuuid/{ptype}.{uuid}'.format(
+            ptype=partition.get_ptype(),
+            uuid=getattr(self.args, self.name + '_uuid'))
+
+        if self.args.dmcrypt:
+            self.space_dmcrypt = self.space_symlink
+            self.space_symlink = '/dev/mapper/{uuid}'.format(
+                uuid=getattr(self.args, self.name + '_uuid'))
+
+        if reusing_partition:
+            # confirm that the space_symlink exists. It should since
+            # this was an active space
+            # in the past. Continuing otherwise would be futile.
+            assert os.path.exists(self.space_symlink)
+            return
 
         LOG.debug('%s is GPT partition %s',
                   self.name.capitalize(),

--- a/src/ceph-disk/ceph_disk/main.py
+++ b/src/ceph-disk/ceph_disk/main.py
@@ -2364,7 +2364,8 @@ class PrepareSpace(object):
                 self.space_symlink = getattr(self.args, self.name)
                 return
 
-        self.space_symlink = '/dev/disk/by-partuuid/{uuid}'.format(
+        self.space_symlink = '/dev/disk/by-parttypeuuid/{ptype}.{uuid}'.format(
+            ptype=PTYPE['mpath']['block']['ready'],
             uuid=getattr(self.args, self.name + '_uuid'))
 
         if self.args.dmcrypt:


### PR DESCRIPTION
This is a fix for the PR at https://github.com/ceph/ceph/pull/17132
There does not seem to be any communication from the author of that PR regarding comments made on it.  His commit is included in this PR.  

Multipath devices do not have entries in /dev/disk/by-partuuid so the symlink that ceph-disk creates to the bluestore block device is invalid - it links to a sub-device of a multipath device instead of a dm-X device.  This doesn't work since the subdevices change, and of course also does not utilize all paths to a device.  

However those devices, along with more typical single devices, do all show up in /dev/disk/by-parttypeuuid.  This PR modifies ceph-disk to create the link to devices in that location. 

If there's a better solution to the issue I'd be more than happy to implement and test...we need this issue fixed to be able to use bluestore devices on our hardware.   
