### PR TITLE
luminous: osd/PG: fix recovery op leak due to recovery preemption

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -6423,7 +6423,11 @@ PG::RecoveryState::Backfilling::react(const DeferBackfill &c)
     }
   }
 
-  pg->waiting_on_backfill.clear();
+
+  if (!pg->waiting_on_backfill.empty()) {
+    pg->waiting_on_backfill.clear();
+    pg->finish_recovery_op(hobject_t::get_max());
+  }
 
   pg->schedule_backfill_retry(c.delay);
   return transit<NotBackfilling>();
@@ -6452,8 +6456,10 @@ PG::RecoveryState::Backfilling::react(const RemoteReservationRejected &)
     }
   }
 
-  pg->waiting_on_backfill.clear();
-  pg->finish_recovery_op(hobject_t::get_max());
+  if (!pg->waiting_on_backfill.empty()) {
+    pg->waiting_on_backfill.clear();
+    pg->finish_recovery_op(hobject_t::get_max());
+  }
 
   pg->schedule_backfill_retry(pg->cct->_conf->osd_recovery_retry_interval);
   return transit<NotBackfilling>();


### PR DESCRIPTION
This was fixed in master in a different patch, but are not yet ready to
backport the bits there that came before this.  For now, fix it
specifically for luminous.  We can either sort out the conflicts later
or revert this and backport the master parts conflict-free.

Signed-off-by: Sage Weil <sage@redhat.com>