### PR TITLE
rgw_file:  set s->obj_size from bytes_written

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -1425,7 +1425,7 @@ namespace rgw {
     struct timespec omtime = rgw_fh->get_mtime();
     real_time appx_t = real_clock::now();
 
-    s->obj_size = ofs; // XXX check ofs
+    s->obj_size = bytes_written;
     perfcounter->inc(l_rgw_put_b, s->obj_size);
 
     op_ret = get_store()->check_quota(s->bucket_owner.get_id(), s->bucket,
@@ -1434,7 +1434,8 @@ namespace rgw {
       goto done;
     }
 
-    op_ret = get_store()->check_bucket_shards(s->bucket_info, s->bucket, bucket_quota);
+    op_ret = get_store()->check_bucket_shards(s->bucket_info, s->bucket,
+					      bucket_quota);
     if (op_ret < 0) {
       goto done;
     }


### PR DESCRIPTION
Required to store correct final accounted_size of objects in
RGWWriteWriteRequest::write_finish.

Fixes: http://tracker.ceph.com/issues/21940

Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>