### PR TITLE
qa/suites/rados/perf: add workloads

### DIFF
--- a/qa/suites/rados/perf/workloads/fio_4K_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4K_rand_read.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4096]
+        time: 60
+        mode: ['randread']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 128
+          pgp_size: 128
+          replication: 3

--- a/qa/suites/rados/perf/workloads/fio_4K_rand_rw.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4K_rand_rw.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4096]
+        time: 60
+        mode: ['randrw']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 128
+          pgp_size: 128
+          replication: 3

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_read.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4194304]
+        time: 60
+        mode: ['randread']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 128
+          pgp_size: 128
+          replication: 3

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_rw.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_rw.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4194304]
+        time: 60
+        mode: ['randrw']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 128
+          pgp_size: 128
+          replication: 3

--- a/qa/suites/rados/perf/workloads/fio_4M_rand_write.yaml
+++ b/qa/suites/rados/perf/workloads/fio_4M_rand_write.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      librbdfio:
+        op_size: [4194304]
+        time: 60
+        mode: ['randwrite']
+        norandommap: True
+        vol_size: 4096
+        procs_per_volume: [1]
+        volumes_per_client: [2]
+        iodepth: [32]
+        osd_ra: [4096]
+        pool_profile: 'rbd'
+        log_avg_msec: 100
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        rbd:
+          pg_size: 128
+          pgp_size: 128
+          replication: 3

--- a/qa/suites/rados/perf/workloads/radosbench_4K_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4K_rand_read.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4096]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 60
+        write_only: false
+        readmode: 'rand'
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'

--- a/qa/suites/rados/perf/workloads/radosbench_4K_seq_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4K_seq_read.yaml
@@ -1,0 +1,23 @@
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4096]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 60
+        write_only: false
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'

--- a/qa/suites/rados/perf/workloads/radosbench_4M_rand_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_rand_read.yaml
@@ -1,0 +1,24 @@
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4194304]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 60
+        write_only: false
+        readmode: 'rand'
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'

--- a/qa/suites/rados/perf/workloads/radosbench_4M_seq_read.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_seq_read.yaml
@@ -1,0 +1,23 @@
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4194304]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 60
+        write_only: false
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'

--- a/qa/suites/rados/perf/workloads/radosbench_4M_write.yaml
+++ b/qa/suites/rados/perf/workloads/radosbench_4M_write.yaml
@@ -1,0 +1,23 @@
+tasks:
+- cbt:
+    benchmarks:
+      radosbench:
+        concurrent_ops: 4
+        concurrent_procs: 2
+        op_size: [4194304]
+        pool_monitoring_list:
+        - collectl
+        pool_profile: 'replicated'
+        run_monitoring_list:
+        - collectl
+        time: 60
+        write_only: true
+    cluster:
+      user: 'ubuntu'
+      osds_per_node: 3
+      iterations: 1
+      pool_profiles:
+        replicated:
+          pg_size: 256
+          pgp_size: 256
+          replication: 'replicated'


### PR DESCRIPTION
Add the following workloads to the perf suite:

- radosbench
  - 4K sequential read
  - 4K random read
  - 4M write
  - 4M sequential read
  - 4M random read


- librbdfio
  - 4K random read
  - 4K random readwrite
  - 4M random write
  - 4M random read
  - 4M random readwrite


Signed-off-by: Neha Ojha <nojha@redhat.com>