### PR TITLE
mon: fix the core dump when use the mgr command

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -859,6 +859,13 @@ void MgrMonitor::init()
   if (digest_event == nullptr) {
     send_digests();  // To get it to schedule its own event
   }
+  
+  mgr_command_descs = mgr_commands;
+  //set the mgr flag for the mgr command
+  //otherwise it will result in mon core dump
+  for (auto& p : mgr_command_descs) {
+      p.set_flag(MonCommand::FLAG_MGR);
+  }
 }
 
 void MgrMonitor::on_shutdown()
@@ -926,7 +933,7 @@ const std::vector<MonCommand> &MgrMonitor::get_command_descs() const
 {
   if (command_descs.empty()) {
     // must have just upgraded; fallback to static commands
-    return mgr_commands;
+    return mgr_command_descs;
   } else {
     return command_descs;
   }

--- a/src/mon/MgrMonitor.h
+++ b/src/mon/MgrMonitor.h
@@ -64,7 +64,8 @@ class MgrMonitor: public PaxosService
   // Command descriptions we've learned from the active mgr
   std::vector<MonCommand> command_descs;
   std::vector<MonCommand> pending_command_descs;
-
+  //mgr command descriptions with mgr flag
+  std::vector<MonCommand> mgr_command_descs;
 public:
   MgrMonitor(Monitor *mn, Paxos *p, const string& service_name)
     : PaxosService(mn, p, service_name)


### PR DESCRIPTION
When mon reply the commnd to client,if it do not set

mgr flag.The command will send to mon.But the mon can

not handle some commands.this will result in mon core

dump.

Fixes:   http://tracker.ceph.com/issues/21770

Signed-off-by: song baisen <linghucongsong@163.com>