### PR TITLE
qa/tasks/rbd: run all xfstests runs to completion

### DIFF
--- a/qa/tasks/rbd.py
+++ b/qa/tasks/rbd.py
@@ -5,6 +5,7 @@ import contextlib
 import logging
 import os
 import tempfile
+import sys
 
 from cStringIO import StringIO
 from teuthology.orchestra import run
@@ -342,6 +343,16 @@ def run_xfstests(ctx, config):
     with parallel() as p:
         for role, properties in config.items():
             p.spawn(run_xfstests_one_client, ctx, role, properties)
+        exc_info = None
+        while True:
+            try:
+                p.next()
+            except StopIteration:
+                break
+            except:
+                exc_info = sys.exc_info()
+        if exc_info:
+            raise exc_info[0], exc_info[1], exc_info[2]
     yield
 
 def run_xfstests_one_client(ctx, role, properties):


### PR DESCRIPTION
rbd.xfstests task allows spawning xfstests runs on multiple nodes.
Don't unwind task contexts if one of the runs fails -- let the other
runs finish.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>