### PR TITLE
[RFC]osd/PG: release pg lock when read data for deep-scrub.

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -4148,8 +4148,17 @@ int PG::build_scrub_map_chunk(
     return ret;
   }
 
-
+  if (deep) {
+    scrub_queued = true;
+    unlock();
+  }
   get_pgbackend()->be_scan_list(map, ls, deep, seed, handle);
+  if (deep) {
+    handle.suspend_tp_timeout();
+    lock();
+    scrub_queued = false;
+    handle.reset_tp_timeout();
+  }
   _scan_rollback_obs(rollback_obs, handle);
   _scan_snaps(map);
   _repair_oinfo_oid(map);


### PR DESCRIPTION
@liewegas . We talked this in https://www.spinics.net/lists/ceph-devel/msg23372.html. I review code again. I think drop lock in deepscrub-read is safe. To void requeue scrub in this process, i set scrub_queued = true.