### PR TITLE
config: diff file and local

### DIFF
--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -554,6 +554,43 @@ ________
 Optional: upper and lower (inclusive) bounds on valid settings.
 
 
+Finding differences between configurations
+==========================================
+
+You may need to check what settings in your configuration are different from
+defaults, or what setting values are different from on-disk configuration
+due to manual changes at runtime. You can use "config diff" commands for that.
+There are 4 different incarnations of that command, computing differences
+between different objects.
+
+::
+
+	ceph daemon {daemon-type}.{id} config diff | less
+
+Shows the differences between current, in-memory configuration and Ceph defaults.
+
+::
+
+	ceph daemon {daemon-type}.{id} config diff get "{option}" | less
+
+Shows the difference between current, in-memory configuration and Ceph defaults
+for specified {option}.
+
+::
+
+	ceph daemon {daemon-type}.{id} config diff local | less
+
+Shows the difference between current, in-memory configuration and configuration
+file used upon initialization.
+
+::
+
+	ceph daemon {daemon-type}.{id} config diff file "{file}" | less
+
+Shows the difference between current, in-memory configuration and specified
+configuration file. Note that {file} needs to be on local (for that daemon)
+disk.
+
 
 
 Running Multiple Clusters

--- a/src/common/ConfUtils.cc
+++ b/src/common/ConfUtils.cc
@@ -72,6 +72,7 @@ void ConfFile::
 clear()
 {
   sections.clear();
+  config_filename = "";
 }
 
 /* We load the whole file into memory and then parse it.  Although this is not
@@ -143,6 +144,7 @@ parse_file(const std::string &fname, std::deque<std::string> *errors,
     }
   }
 
+  config_filename = fname;
   load_from_buffer(buf, sz, errors, warnings);
   ret = 0;
 
@@ -271,6 +273,16 @@ std::ostream &operator<<(std::ostream &oss, const ConfFile &cf)
     }
   }
   return oss;
+}
+
+/*
+ * Returns a filename of current config file. If empty, it was read from
+ * buffer.
+ */
+std::string ConfFile::
+get_config_filename() const
+{
+  return config_filename;
 }
 
 void ConfFile::

--- a/src/common/ConfUtils.h
+++ b/src/common/ConfUtils.h
@@ -73,6 +73,7 @@ public:
   static void trim_whitespace(std::string &str, bool strip_internal);
   static std::string normalize_key_name(const std::string &key);
   friend std::ostream &operator<<(std::ostream &oss, const ConfFile &cf);
+  std::string get_config_filename() const;
 
 private:
   void load_from_buffer(const char *buf, size_t sz,
@@ -81,6 +82,7 @@ private:
 			        std::deque<std::string> *errors);
 
   std::map <std::string, ConfSection> sections;
+  std::string config_filename;
 };
 
 #endif

--- a/src/common/ceph_context.h
+++ b/src/common/ceph_context.h
@@ -128,6 +128,7 @@ public:
    */
   void do_command(std::string command, cmdmap_t& cmdmap, std::string format,
 		  ceph::bufferlist *out);
+  void config_diff_with(const char* file, std::stringstream* errors, Formatter* f, const std::string& other_name);
 
   template<typename T>
   void lookup_or_create_singleton_object(T*& p, const std::string &name) {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1389,3 +1389,7 @@ void md_config_t::complain_about_parse_errors(CephContext *cct)
   ::complain_about_parse_errors(cct, &parse_errors);
 }
 
+std::string md_config_t::get_config_file() const
+{
+  return cf.get_config_filename();
+}

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -904,8 +904,7 @@ md_config_t::_get_val_generic(const std::string &key) const
 int md_config_t::_get_val(const std::string &key, std::string *value) const {
   assert(lock.is_locked());
 
-  std::string normalized_key(ConfFile::normalize_key_name(key));
-  auto& config_value = _get_val_generic(normalized_key.c_str());
+  auto& config_value = _get_val_generic(key);
   if (!boost::get<boost::blank>(&config_value)) {
     ostringstream oss;
     if (auto *flag = boost::get<bool>(&config_value)) {

--- a/src/common/config.cc
+++ b/src/common/config.cc
@@ -1352,17 +1352,15 @@ void md_config_t::diff_helper(
   char other_buf[4096];
   set<string> checked_opts;
 
-  for (const auto &i : schema) {
-    const Option &opt = i.second;
-    if (!setting.empty()) {
-      if (setting == opt.name) {
-	checked_opts.insert(opt.name);
-	break;
-      } else {
-        continue;
-      }
+  if (setting.empty()) {
+    for (const auto &i : schema) {
+      checked_opts.insert(i.second.name);
     }
-    checked_opts.insert(opt.name);
+  } else {
+    const auto i = schema.find(setting);
+    if (i != schema.end()) {
+      checked_opts.insert(setting);
+    }
   }
 
   for (size_t o = 0; o < subsys.get_num(); o++) {

--- a/src/common/config.h
+++ b/src/common/config.h
@@ -194,6 +194,9 @@ public:
   /// print/log warnings/errors from parsing the config
   void complain_about_parse_errors(CephContext *cct);
 
+  /// returns the filename of config file used, empty string if not read from file
+  std::string get_config_file() const;
+
 private:
   void validate_schema();
   void validate_default_settings();


### PR DESCRIPTION
This patchset adds a possibility to compare current, in-memory daemon configuration with configs stored on disk. "config diff local" shows the differences between config used upon startup and current config, and "config diff file" shows the differences between specified config file and current config.
During creation of this PR, I realized that original "config diff" doesn't take debug levels under consideration and this PR fixes this, and also there was no docs, so this PR documents them all.

Signed-off-by: Piotr Dałek <piotr.dalek@corp.ovh.com>