### PR TITLE
luminous: build/ops: move ceph-*-tool binaries out of ceph-test subpackage

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -932,6 +932,7 @@ rm -rf %{buildroot}
 %{_bindir}/crushtool
 %{_bindir}/monmaptool
 %{_bindir}/osdmaptool
+%{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-run
 %{_bindir}/ceph-detect-init
 %{_libexecdir}/systemd/system-preset/50-ceph.preset
@@ -984,6 +985,7 @@ rm -rf %{buildroot}
 %{_mandir}/man8/crushtool.8*
 %{_mandir}/man8/osdmaptool.8*
 %{_mandir}/man8/monmaptool.8*
+%{_mandir}/man8/ceph-kvstore-tool.8*
 #set up placeholder directories
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/tmp
 %attr(750,ceph,ceph) %dir %{_localstatedir}/lib/ceph/bootstrap-osd
@@ -1239,6 +1241,7 @@ fi
 %files mon
 %{_bindir}/ceph-mon
 %{_bindir}/ceph-rest-api
+%{_bindir}/ceph-monstore-tool
 %{_mandir}/man8/ceph-mon.8*
 %{_mandir}/man8/ceph-rest-api.8*
 %{python_sitelib}/ceph_rest_api.py*
@@ -1407,6 +1410,7 @@ fi
 %{_bindir}/ceph-clsinfo
 %{_bindir}/ceph-bluestore-tool
 %{_bindir}/ceph-objectstore-tool
+%{_bindir}/ceph-osdomap-tool
 %{_bindir}/ceph-osd
 %{_libexecdir}/ceph/ceph-osd-prestart.sh
 %dir %{_udevrulesdir}
@@ -1639,9 +1643,6 @@ fi
 %{_bindir}/ceph_tpbench
 %{_bindir}/ceph_xattr_bench
 %{_bindir}/ceph-coverage
-%{_bindir}/ceph-monstore-tool
-%{_bindir}/ceph-osdomap-tool
-%{_bindir}/ceph-kvstore-tool
 %{_bindir}/ceph-debugpack
 %{_mandir}/man8/ceph-debugpack.8*
 %dir %{_libdir}/ceph

--- a/debian/ceph-base.install
+++ b/debian/ceph-base.install
@@ -5,6 +5,7 @@ usr/bin/ceph-run
 usr/bin/crushtool
 usr/bin/monmaptool
 usr/bin/osdmaptool
+usr/bin/ceph-kvstore-tool
 usr/lib/ceph/ceph_common.sh
 usr/lib/ceph/erasure-code/*
 usr/lib/python*/dist-packages/ceph_detect_init*
@@ -19,3 +20,4 @@ usr/share/man/man8/ceph-run.8
 usr/share/man/man8/crushtool.8
 usr/share/man/man8/monmaptool.8
 usr/share/man/man8/osdmaptool.8
+usr/share/man/man8/ceph-kvstore-tool.8

--- a/debian/ceph-mon.install
+++ b/debian/ceph-mon.install
@@ -1,4 +1,5 @@
 usr/bin/ceph-mon
+usr/bin/ceph-monstore-tool
 usr/bin/ceph-rest-api
 usr/lib/python*/dist-packages/ceph_rest_api.py*
 usr/share/man/man8/ceph-mon.8

--- a/debian/ceph-osd.install
+++ b/debian/ceph-osd.install
@@ -3,6 +3,7 @@ lib/udev/rules.d/95-ceph-osd.rules
 usr/bin/ceph-bluestore-tool
 usr/bin/ceph-clsinfo
 usr/bin/ceph-objectstore-tool
+usr/bin/ceph-osdomap-tool
 usr/bin/ceph-osd
 usr/bin/ceph_objectstore_bench
 usr/lib/ceph/ceph-osd-prestart.sh

--- a/debian/ceph-test.install
+++ b/debian/ceph-test.install
@@ -1,8 +1,5 @@
 usr/bin/ceph-client-debug
 usr/bin/ceph-coverage
-usr/bin/ceph-kvstore-tool
-usr/bin/ceph-monstore-tool
-usr/bin/ceph-osdomap-tool
 usr/bin/ceph_bench_log
 usr/bin/ceph_erasure_code
 usr/bin/ceph_erasure_code_benchmark

--- a/debian/control
+++ b/debian/control
@@ -103,10 +103,10 @@ Recommends: btrfs-tools,
             ntp | time-daemon,
 Replaces: ceph (<< 10),
           ceph-common (<< 0.78-500),
-          ceph-test (<< 0.94-1322),
+          ceph-test (<< 12.2.2),
           python-ceph (<< 0.92-1223),
 Breaks: ceph (<< 10),
-        ceph-test (<< 0.94-1322),
+        ceph-test (<< 12.2.2),
         python-ceph (<< 0.92-1223),
 Description: common ceph daemon libraries and management tools
  Ceph is a massively scalable, open-source, distributed
@@ -204,8 +204,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common,
-Replaces: ceph (<< 10),
-Breaks: ceph (<< 10),
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
 Description: monitor server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,
@@ -237,8 +237,8 @@ Depends: ceph-base (= ${binary:Version}),
          ${python:Depends},
          ${shlibs:Depends},
 Recommends: ceph-common (= ${binary:Version}),
-Replaces: ceph (<< 10),
-Breaks: ceph (<< 10),
+Replaces: ceph (<< 10), ceph-test (<< 12.2.2)
+Breaks: ceph (<< 10), ceph-test (<< 12.2.2)
 Description: OSD server for the ceph storage system
  Ceph is a massively scalable, open-source, distributed
  storage system that runs on commodity hardware and delivers object,

--- a/debian/control
+++ b/debian/control
@@ -712,6 +712,8 @@ Depends: ceph-common,
          xmlstarlet,
          ${misc:Depends},
          ${shlibs:Depends},
+Replaces: ceph-base (<< 11)
+Breaks: ceph-base (<< 1)
 Description: Ceph test and benchmarking tools
  This package contains tools for testing and benchmarking Ceph.
 

--- a/doc/man/8/CMakeLists.txt
+++ b/doc/man/8/CMakeLists.txt
@@ -3,6 +3,7 @@ set(client_srcs
   ceph-conf.rst
   ceph.rst
   ceph-authtool.rst
+  ceph-kvstore-tool.rst
   rados.rst
   ceph-post-file.rst
   ceph-dencoder.rst)

--- a/doc/man/8/ceph-kvstore-tool.rst
+++ b/doc/man/8/ceph-kvstore-tool.rst
@@ -1,0 +1,85 @@
+:orphan:
+
+=====================================================
+ ceph-kvstore-tool -- ceph kvstore manipulation tool
+=====================================================
+
+.. program:: ceph-kvstore-tool
+
+Synopsis
+========
+
+| **ceph-kvstore-tool** <leveldb|rocksdb|bluestore-kv> <store path> *command* [args...]
+
+
+Description
+===========
+
+:program:`ceph-kvstore-tool` is a kvstore manipulation tool. It allows users to manipule
+leveldb/rocksdb's data (like OSD's omap) offline.
+
+Commands
+========
+
+:program:`ceph-kvstore-tool` utility uses many commands for debugging purpose
+which are as follows:
+
+:command:`list [prefix]`
+    Print key of all KV pairs stored with the URL encoded prefix.
+
+:command:`list-crc [prefix]`
+    Print CRC of all KV pairs stored with the URL encoded prefix.
+
+:command:`exists <prefix> [key]`
+    Check if there is any KV pair stored with the URL encoded prefix. If key
+    is also specified, check for the key with the prefix instead.
+
+:command:`get <prefix> <key> [out <file>]`
+    Get the value of the KV pair stored with the URL encoded prefix and key.
+    If file is also specified, write the value to the file.
+
+:command:`crc <prefix> <key>`
+    Get the CRC of the KV pair stored with the URL encoded prefix and key. 
+
+:command:`get-size [<prefix> <key>]`
+    Get estimated store size or size of value specified by prefix and key.
+
+:command:`set <prefix> <key> [ver <N>|in <file>]`
+    Set the value of the KV pair stored with the URL encoded prefix and key. 
+    The value could be *version_t* or text.
+
+:command:`rm <prefix> <key>`
+    Remove the KV pair stored with the URL encoded prefix and key.
+
+:command:`rm-prefix <prefix>`
+    Remove all KV pairs stored with the URL encoded prefix.
+
+:command:`store-copy <path> [num-keys-per-tx]`
+    Copy all KV pairs to another directory specified by ``path``. 
+    [num-keys-per-tx] is the number of KV pairs copied for a transaction.
+
+:command:`store-crc <path>`
+    Store CRC of all KV pairs to a file specified by ``path``.
+
+:command:`compact`
+    Subcommand ``compact`` is used to compact all data of kvstore. It will open
+    the database, and trigger a database's compaction. After compaction, some 
+    disk space may be released.
+
+:command:`compact-prefix <prefix>`
+    Compact all entries specified by the URL encoded prefix. 
+   
+:command:`compact-range <prefix> <start> <end>`
+    Compact some entries specified by the URL encoded prefix and range.
+
+Availability
+============
+
+**ceph-kvstore-tool** is part of Ceph, a massively scalable, open-source, distributed storage system. Please refer to
+the Ceph documentation at http://ceph.com/docs for more information.
+
+
+See also
+========
+
+:doc:`ceph <ceph>`\(8)

--- a/doc/rados/man/index.rst
+++ b/doc/rados/man/index.rst
@@ -18,6 +18,7 @@
    ../../man/8/ceph-dencoder.rst
    ../../man/8/ceph-mon.rst
    ../../man/8/ceph-osd.rst
+   ../../man/8/ceph-kvstore-tool.rst
    ../../man/8/ceph-run.rst
    ../../man/8/ceph-syn.rst
    ../../man/8/crushtool.rst


### PR DESCRIPTION
http://tracker.ceph.com/issues/21869