### PR TITLE
suites/cephmetrics: Add Centos 7

### DIFF
--- a/qa/suites/cephmetrics/1-distros/centos_latest.yaml
+++ b/qa/suites/cephmetrics/1-distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../distros/supported/centos_latest.yaml

--- a/qa/suites/cephmetrics/1-distros/ubuntu_16.04.yaml
+++ b/qa/suites/cephmetrics/1-distros/ubuntu_16.04.yaml
@@ -1,2 +1,0 @@
-os_type: ubuntu
-os_version: "16.04"

--- a/qa/suites/cephmetrics/1-distros/ubuntu_latest.yaml
+++ b/qa/suites/cephmetrics/1-distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
Once https://github.com/ceph/cephmetrics/pull/149 is merged, it'll at least be worth seeing CentOS results. Half the CentOS jobs passed here:

http://pulpito.ceph.com/zack-2017-10-26_22:32:24-cephmetrics-master-distro-basic-vps/