### PR TITLE
build: Add target to build .clang_complete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ GTAGS
 
 # editor backup files etc.
 \#*\#
+
+# used by completion/correction/navigation tools
+.clang_complete

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1119,3 +1119,7 @@ add_subdirectory(script)
 if(WITH_EMBEDDED)
   add_subdirectory(libcephd)
 endif()
+
+add_custom_target(clang_complete
+  COMMAND sh -c "echo ${CMAKE_CXX_FLAGS} | tr \\  \\\\n > ${CMAKE_SOURCE_DIR}/.clang_complete"
+  VERBATIM)


### PR DESCRIPTION
This file is used by libclang-based development tools to specify the
language standard, include paths, and warnings for a project.

To use, simply type:

```
make clang_complete
```

Obviously it works better if you're using clang, but it works pretty
well even if you've configured cmake with gcc, since you still get all
the include paths and the language standard.