### PR TITLE
osd: add processed_subop_count for cls_cxx_subop_version()

### DIFF
--- a/qa/workunits/cls/test_cls_log.sh
+++ b/qa/workunits/cls/test_cls_log.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -e
+
+ceph_test_cls_log
+
+exit 0

--- a/src/objclass/class_api.cc
+++ b/src/objclass/class_api.cc
@@ -677,7 +677,7 @@ int cls_current_subop_num(cls_method_context_t hctx)
 {
   PrimaryLogPG::OpContext *ctx = *(PrimaryLogPG::OpContext **)hctx;
 
-  return ctx->current_osd_subop_num;
+  return ctx->processed_subop_count;
 }
 
 uint64_t cls_get_features(cls_method_context_t hctx)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -4955,7 +4955,7 @@ int PrimaryLogPG::do_osd_ops(OpContext *ctx, vector<OSDOp>& ops)
   dout(10) << "do_osd_op " << soid << " " << ops << dendl;
 
   ctx->current_osd_subop_num = 0;
-  for (vector<OSDOp>::iterator p = ops.begin(); p != ops.end(); ++p, ctx->current_osd_subop_num++) {
+  for (auto p = ops.begin(); p != ops.end(); ++p, ctx->current_osd_subop_num++, ctx->processed_subop_count++) {
     OSDOp& osd_op = *p;
     ceph_osd_op& op = osd_op.op;
 

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -536,7 +536,10 @@ public:
     eversion_t at_version;       // pg's current version pointer
     version_t user_at_version;   // pg's current user version pointer
 
+    /// index of the current subop - only valid inside of do_osd_ops()
     int current_osd_subop_num;
+    /// total number of subops processed in this context for cls_cxx_subop_version()
+    int processed_subop_count = 0;
 
     PGTransactionUPtr op_t;
     vector<pg_log_entry_t> log;

--- a/src/test/cls_log/CMakeLists.txt
+++ b/src/test/cls_log/CMakeLists.txt
@@ -14,4 +14,6 @@ target_link_libraries(ceph_test_cls_log
   ${CRYPTO_LIBS}
   ${EXTRALIBS}
   )
-
+install(TARGETS
+  ceph_test_cls_log
+  DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
cls_log_add() relies on cls_cxx_subop_version() to generate unique keys
for log entries with the same timestamp. because cls calls back into
do_osd_ops(), resetting current_osd_subop_num means that cls_log_add()
will keep seeing the same subop version and generating the same keys.
this causes the following failure in ceph_test_cls_log:
```
[ RUN      ] cls_rgw.test_log_add_same_time
/home/cbodley/ceph/src/test/cls_log/test_cls_log.cc:144: Failure
      Expected: 10
To be equal to: (int)entries.size()
      Which is: 1
[  FAILED  ] cls_rgw.test_log_add_same_time (1180 ms)
```
Fixes: http://tracker.ceph.com/issues/21964