### PR TITLE
mds: fix race in PurgeQueue::wait_for_recovery()

### DIFF
--- a/src/mds/MDSRank.cc
+++ b/src/mds/MDSRank.cc
@@ -1097,7 +1097,7 @@ void MDSRank::boot_start(BootStep step, int r)
 	MDSGatherBuilder gather(g_ceph_context,
 	    new C_MDS_BootStart(this, MDS_BOOT_REPLAY_DONE));
 
-	if (!standby_replaying && !purge_queue.is_recovered()) {
+	if (!standby_replaying) {
 	  dout(2) << "boot_start " << step << ": waiting for purge queue recovered" << dendl;
 	  purge_queue.wait_for_recovery(new C_IO_Wrapper(this, gather.new_sub()));
 	}

--- a/src/mds/PurgeQueue.cc
+++ b/src/mds/PurgeQueue.cc
@@ -180,16 +180,13 @@ void PurgeQueue::open(Context *completion)
   }));
 }
 
-bool PurgeQueue::is_recovered()
-{
-  Mutex::Locker l(lock);
-  return recovered;
-}
-
 void PurgeQueue::wait_for_recovery(Context* c)
 {
   Mutex::Locker l(lock);
-  waiting_for_recovery.push_back(c);
+  if (recovered)
+    c->complete(0);
+  else
+    waiting_for_recovery.push_back(c);
 }
 
 void PurgeQueue::_recover()

--- a/src/mds/PurgeQueue.h
+++ b/src/mds/PurgeQueue.h
@@ -146,7 +146,6 @@ public:
   // Read the Journaler header for an existing queue and start consuming
   void open(Context *completion);
 
-  bool is_recovered();
   void wait_for_recovery(Context *c);
 
   // Submit one entry to the work queue.  Call back when it is persisted


### PR DESCRIPTION
After PurgeQueue::wait_for_recovery() locks the mutex, purge queue
may have already been recovered.

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>