### PR TITLE
rbd-fuse: make sure PATH_MAX is defined

### DIFF
--- a/src/rbd_fuse/rbd-fuse.cc
+++ b/src/rbd_fuse/rbd-fuse.cc
@@ -20,6 +20,7 @@
 #include <assert.h>
 #include <string>
 #include <mutex>
+#include <limits.h>
 
 #if defined(__FreeBSD__)
 #include <sys/param.h>


### PR DESCRIPTION
On systems without glibc, as Alpine Linux, you might lack definition of
PATH_MAX. This patch adds the limits.h header to solve this issue.