### PR TITLE
mds: pass a reference of function to sanitize() not a copy

### DIFF
--- a/src/mds/FSMap.cc
+++ b/src/mds/FSMap.cc
@@ -621,7 +621,7 @@ void FSMap::decode(bufferlist::iterator& p)
   DECODE_FINISH(p);
 }
 
-void FSMap::sanitize(std::function<bool(int64_t pool)> pool_exists)
+void FSMap::sanitize(const std::function<bool(int64_t pool)>& pool_exists)
 {
   for (auto &fs : filesystems) {
     fs.second->mds_map.sanitize(pool_exists);

--- a/src/mds/FSMap.h
+++ b/src/mds/FSMap.h
@@ -493,7 +493,7 @@ public:
     bufferlist::iterator p = bl.begin();
     decode(p);
   }
-  void sanitize(std::function<bool(int64_t pool)> pool_exists);
+  void sanitize(const std::function<bool(int64_t pool)>& pool_exists);
 
   void print(ostream& out) const;
   void print_summary(Formatter *f, ostream *out) const;

--- a/src/mds/MDSMap.cc
+++ b/src/mds/MDSMap.cc
@@ -637,7 +637,7 @@ void MDSMap::encode(bufferlist& bl, uint64_t features) const
   ENCODE_FINISH(bl);
 }
 
-void MDSMap::sanitize(std::function<bool(int64_t pool)> pool_exists)
+void MDSMap::sanitize(const std::function<bool(int64_t pool)>& pool_exists)
 {
   /* Before we did stricter checking, it was possible to remove a data pool
    * without also deleting it from the MDSMap. Check for that here after

--- a/src/mds/MDSMap.h
+++ b/src/mds/MDSMap.h
@@ -660,7 +660,7 @@ public:
     bufferlist::iterator p = bl.begin();
     decode(p);
   }
-  void sanitize(std::function<bool(int64_t pool)> pool_exists);
+  void sanitize(const std::function<bool(int64_t pool)>& pool_exists);
 
   void print(ostream& out) const;
   void print_summary(Formatter *f, ostream *out) const;


### PR DESCRIPTION
to save the overhead of creating and destoying a copy of the function
closure.

Signed-off-by: Kefu Chai <kchai@redhat.com>