### PR TITLE
luminous: ceph-bluestore-tool: prime-osd-dir: update symlinks instead of bailing

### DIFF
--- a/doc/man/8/ceph-bluestore-tool.rst
+++ b/doc/man/8/ceph-bluestore-tool.rst
@@ -17,7 +17,7 @@ Synopsis
   [ --deep ]
 | **ceph-bluestore-tool** fsck|repair --path *osd path* [ --deep ]
 | **ceph-bluestore-tool** show-label --dev *device* ...
-| **ceph-bluestore-tool** prime-osd-dev --dev *device* --path *osd path*
+| **ceph-bluestore-tool** prime-osd-dir --dev *device* --path *osd path*
 | **ceph-bluestore-tool** bluefs-export --path *osd path* --out-dir *dir*
 | **ceph-bluestore-tool** bluefs-export --path *osd path* --out-dir *dir*
 

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -332,7 +332,6 @@ int main(int argc, char **argv)
 	v += label.meta["whoami"];
 	v += "]\nkey = " + i->second;
       }
-      v += "\n";
       if (k.find("path_") == 0) {
 	p = path + "/" + k.substr(5);
 	int r = ::symlink(v.c_str(), p.c_str());
@@ -342,6 +341,7 @@ int main(int argc, char **argv)
 	  exit(EXIT_FAILURE);
 	}
       } else {
+	v += "\n";
 	int fd = ::open(p.c_str(), O_CREAT|O_TRUNC|O_WRONLY, 0600);
 	if (fd < 0) {
 	  cerr << "error writing " << p << ": " << cpp_strerror(errno)

--- a/src/os/bluestore/bluestore_tool.cc
+++ b/src/os/bluestore/bluestore_tool.cc
@@ -183,7 +183,7 @@ int main(int argc, char **argv)
       exit(EXIT_FAILURE);
     }
   }
-  if (action == "prime-osd-dev") {
+  if (action == "prime-osd-dir") {
     if (devs.size() != 1) {
       cerr << "must specify the main bluestore device" << std::endl;
       exit(EXIT_FAILURE);


### PR DESCRIPTION
If the symlink points to the right location, do nothing.  If it doesn't,
replace it.  If it's not a symlink, bail with EEXIST.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit de8dc42d42218bc1a1779e1bcc5831c567853c8d)