### PR TITLE
mds: trim 'N' log segments according to how many log segments are there

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -454,7 +454,6 @@ OPTION(mds_log_max_events, OPT_INT)
 OPTION(mds_log_events_per_segment, OPT_INT)
 OPTION(mds_log_segment_size, OPT_INT)  // segment size for mds log, default to default file_layout_t
 OPTION(mds_log_max_segments, OPT_U32)
-OPTION(mds_log_max_expiring, OPT_INT)
 OPTION(mds_bal_export_pin, OPT_BOOL)  // allow clients to pin directory trees to ranks
 OPTION(mds_bal_sample_interval, OPT_DOUBLE)  // every 3 seconds
 OPTION(mds_bal_replicate_threshold, OPT_FLOAT)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5624,10 +5624,6 @@ std::vector<Option> get_mds_options() {
     .set_default(30)
     .set_description(""),
 
-    Option("mds_log_max_expiring", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(20)
-    .set_description(""),
-
     Option("mds_bal_export_pin", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
     .set_default(true)
     .set_description(""),


### PR DESCRIPTION
Config 'mds_log_max_expiring' is 20 by default. It means that at most
20 log segments get trimmed in each tick. For busy cluster, this can
cause mds behind on trimming log segments.

Signed-off-by: "Yan, Zheng" <zyan@redhat.com>