### PR TITLE
qa/suites/upgrade/jewel-x: Changed typo ('hammer' to 'jewel')

### DIFF
--- a/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/6.5-crush-compat.yaml
@@ -1,7 +1,7 @@
 tasks:
 - exec:
     mon.a:
-      - ceph osd set-require-min-compat-client hammer
+      - ceph osd set-require-min-compat-client jewel
       - ceph osd crush set-all-straw-buckets-to-straw2
       - ceph osd crush weight-set create-compat
       - ceph osd crush weight-set reweight-compat osd.0 .9


### PR DESCRIPTION
See typo 
https://github.com/ceph/ceph/commit/18a99f5f6b4976f87dcd0d4fe7e34fddd90de22b

Fixes http://tracker.ceph.com/issues/21978
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>