### PR TITLE
os/bluestore: delete redundant header file in KernelDevice.cc

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -26,7 +26,6 @@
 #include "common/debug.h"
 #include "common/blkdev.h"
 #include "common/align.h"
-#include "common/blkdev.h"
 
 #define dout_context cct
 #define dout_subsys ceph_subsys_bdev


### PR DESCRIPTION
Signed-off-by: Jing Li <lijing@gohighsec.com>