### PR TITLE
osdc/Objecter: fix objecter op_send_bytes perf counter always 0 problem

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3170,9 +3170,6 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
     m->set_reqid(op->reqid);
   }
 
-  logger->inc(l_osdc_op_send);
-  logger->inc(l_osdc_op_send_bytes, m->get_data().length());
-
   return m;
 }
 
@@ -3248,6 +3245,9 @@ void Objecter::_send_op(Op *op, MOSDOp *m)
     m->trace.init("op msg", nullptr, &op->trace);
   }
   op->session->con->send_message(m);
+
+  logger->inc(l_osdc_op_send);
+  logger->inc(l_osdc_op_send_bytes, m->get_payload().length());
 }
 
 int Objecter::calc_op_budget(Op *op)


### PR DESCRIPTION
When logger->inc() is called in Objecter::_prepare_osd_op,
m->data is 0 sized, and m->playload is not filled yet.
This patch try to fix this, by move inc() after send_message().

Fixes: http://tracker.ceph.com/issues/21982
Signed-off-by: Yang Honggang <joseph.yang@xtaotech.com>