### PR TITLE
rgw: modify s3 type subuser access permissions fail through admin rest api

### DIFF
--- a/src/rgw/rgw_rest_user.cc
+++ b/src/rgw/rgw_rest_user.cc
@@ -418,8 +418,12 @@ void RGWOp_Subuser_Modify::execute()
 
   op_state.set_user_id(uid);
   op_state.set_subuser(subuser);
-  op_state.set_secret_key(secret_key);
-  op_state.set_gen_secret();
+
+  if (!secret_key.empty())
+    op_state.set_secret_key(secret_key);
+
+  if (gen_secret)
+    op_state.set_gen_secret();
 
   if (!key_type_str.empty()) {
     if (key_type_str.compare("swift") == 0)


### PR DESCRIPTION
hi, 
i create a s3 type subuser as follow command:

radosgw-admin subuser create --uid=tdktest01 --subuser=read-tdktest01 --access-key=read-tdktest01 --secret=read-tdktest01 --key-type=s3 --access=read

and modify the access permission through admin rest api(radosgw-admin user create --uid=admin --display-name=admin --access-key=admin --secret-key=admin --caps="users=*;buckets=*;metadata=*;usage=*;zone=*")

```
< POST /admin/user?subuser&format=json&uid=tdktest01&subuser=read-tdktest01&key-type=s3&access=write HTTP/1.1
< Host: 127.0.0.1:8000
< Content-Length: 0
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.6.0 CPython/2.7.5 Linux/3.10.0-327.el7.x86_64
< Connection: keep-alive
< date: Tue, 31 Oct 2017 05:36:15 GMT
< Authorization: AWS admin:+G5HWWklSbZNVkSyqSxJUEuvfks=
<

> HTTP/1.1 403 Forbidden
> content-length: 123
> accept-ranges: bytes
> connection: Keep-Alive
> x-amz-request-id: tx000000000000000000002-0059f80bcf-1010-default
> date: Tue, 31 Oct 2017 05:43:57 GMT
> content-type: application/json
>
{"Code":"InvalidAccessKeyId","RequestId":"tx000000000000000000002-0059f80bcf-1010-default","HostId":"1010-default-default"}
```

while in jewel branch, it success modify s3 type subuser access permissions
```
< POST /admin/user?subuser&format=json&uid=yly&subuser=yly2&key-type=s3&access=read HTTP/1.1
< Host: 127.0.0.1:80
< Content-Length: 0
< Accept-Encoding: gzip, deflate
< Accept: */*
< User-Agent: python-requests/2.6.0 CPython/2.7.5 Linux/3.10.0-514.el7.x86_64
< Connection: keep-alive
< date: Tue, 31 Oct 2017 06:16:53 GMT
< Authorization: AWS yly:t5JLf9zObOH+iIniiRAQm472WwE=
<

> HTTP/1.1 200 OK
> date: Tue, 31 Oct 2017 06:16:53 GMT
> content-length: 78
> x-amz-request-id: tx000000000000000000008-0059f81555-107b-oNest2-zgp1-z1
> connection: Keep-Alive
>
[{"id":"yly:yly","permissions":"read"},{"id":"yly:yly2","permissions":"read"}]
```

fix: http://tracker.ceph.com/issues/21983

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>