### PR TITLE
rgw: add logs if get_data returns error in RGWPutObj::execute.

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -3456,6 +3456,7 @@ void RGWPutObj::execute()
     }
     if (len < 0) {
       op_ret = len;
+      ldout(s->cct, 20) << "get_data() returned ret=" << op_ret << dendl;
       goto done;
     }
 


### PR DESCRIPTION

Signed-off-by: Zhang Shaowen <zhangshaowen@cmss.chinamobile.com>