### PR TITLE
rgw: fix rewrite a versioning object create a new object bug

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -8178,7 +8178,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   append_rand_alpha(cct, tag, tag, 32);
 
   RGWPutObjProcessor_Atomic processor(obj_ctx,
-                                      dest_bucket_info, dest_obj.bucket, dest_obj.get_oid(),
+                                      dest_bucket_info, dest_obj.bucket, dest_obj.key.name,
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
   if (version_id) {
     processor.set_version_id(*version_id);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21984

1. List RADOS objects
$ rados -p default.rgw.buckets.data ls

9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_.18ZhpkdUXTChpNln9fh0_mi0mx6KjSW_1
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_.18ZhpkdUXTChpNln9fh0_mi0mx6KjSW_2
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1_ver-10M
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_ver-10M

2. Rewrite a versioning object

$ radosgw-admin object rewrite --bucket=111 --object=ver-10M --object-version=LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx

3. List RADOS object again

$ rados -p default.rgw.buckets.data ls

9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_.18ZhpkdUXTChpNln9fh0_mi0mx6KjSW_1
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_.18ZhpkdUXTChpNln9fh0_mi0mx6KjSW_2
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:pnOhOGbanucAF03xUyf6UrH5oFlCtqu_.SQROg_PoS4P2cXFEU2j3uJ0m4maalQU_1
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__shadow:pnOhOGbanucAF03xUyf6UrH5oFlCtqu_.SQROg_PoS4P2cXFEU2j3uJ0m4maalQU_2
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__:pnOhOGbanucAF03xUyf6UrH5oFlCtqu_ver-10M
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1_ver-10M
9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1__:LAFUOuLB.Cq2k.-VwXfrtAlf5Y.xicx_ver-10M

4. List all objects in bucket 111

$ s3cmd ls s3://111

2017-10-31 07:52  10485760   s3://111/ver-10M

5. Check the object info of current version object which is recorded in head obj

$ radosgw-admin object stat --object 9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1_ver-10M

`...
"manifest": {
        "objs": [],
        "obj_size": 10485760,
        "explicit_objs": "false",
        "head_size": 4194304,
        "max_head_size": 4194304,
        "prefix": ".SQROg_PoS4P2cXFEU2j3uJ0m4maalQU_",
        "rules": [
            {
                "key": 0,
                "val": {
                    "start_part_num": 0,
                    "start_ofs": 4194304,
                    "part_size": 0,
                    "stripe_max_size": 4194304,
                    "override_prefix": ""
                }
            }
        ],
        "tail_instance": "pnOhOGbanucAF03xUyf6UrH5oFlCtqu",
        "tail_placement": {
            "bucket": {
                "name": "111",
                "marker": "9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1",
                "bucket_id": "9e2c2a59-bf9f-4caa-b4e5-53bb1f8394eb.4120.1",
                "tenant": "",
                "explicit_placement": {
                    "data_pool": "",
                    "data_extra_pool": "",
                    "index_pool": ""
                }
            },
            "placement_rule": "default-placement"
        }
...`

