### PR TITLE
[luminous] selinux: Allow getattr on lnk sysfs files

### DIFF
--- a/selinux/ceph.te
+++ b/selinux/ceph.te
@@ -106,7 +106,7 @@ files_manage_generic_locks(ceph_t)
 
 allow ceph_t sysfs_t:dir read;
 allow ceph_t sysfs_t:file { read getattr open };
-allow ceph_t sysfs_t:lnk_file read;
+allow ceph_t sysfs_t:lnk_file { read getattr };
 
 allow ceph_t random_device_t:chr_file getattr;
 allow ceph_t urandom_device_t:chr_file getattr;


### PR DESCRIPTION
This showed up during downstream testing for luminous. We are doing
getattr on the sysfs lnk files and the current policy does not allow
this.

Signed-off-by: Boris Ranto <branto@redhat.com>