### PR TITLE
ceph.in: pass RADOS inst to LibCephFS

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1285,9 +1285,7 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
             except ImportError:
                 raise RuntimeError("CephFS unavailable, have you installed libcephfs?")
 
-            filesystem = LibCephFS(cluster.conf_defaults, cluster.conffile)
-            filesystem.conf_parse_argv(cluster.parsed_args)
-
+            filesystem = LibCephFS(rados_inst=cluster)
             filesystem.init()
             ret, outbuf, outs = \
                 filesystem.mds_command(mds_spec, cmd, inbuf)


### PR DESCRIPTION
This avoids multiple instances of the admin socket and other redundancies.

Fixes: http://tracker.ceph.com/issues/21967
Fixes: http://tracker.ceph.com/issues/21406

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>