### PR TITLE
qa: add "restful" to ceph_mgr_modules in ceph-ansible suite

### DIFF
--- a/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
+++ b/qa/suites/ceph-ansible/smoke/basic/2-ceph/ceph_ansible.yaml
@@ -18,6 +18,9 @@ overrides:
         osd_auto_discovery: false
         ceph_origin: repository
         ceph_repository: dev
+        ceph_mgr_modules:
+          - status
+          - restful
         cephfs_pools:
           - name: "cephfs_data"
             pgs: "64"


### PR DESCRIPTION
backport of https://github.com/ceph/ceph/pull/18634

Signed-off-by: Kefu Chai <kchai@redhat.com>
(cherry picked from commit caf9ee5c60d999951979d0b67afda8d56e1cd91d)
Signed-off-by: Yuri Weinstein <yweinste@redhat.com>