### PR TITLE
rgw: remove placement_rule from rgw_link_bucket()

### DIFF
--- a/src/cls/user/cls_user.cc
+++ b/src/cls/user/cls_user.cc
@@ -157,12 +157,6 @@ static int cls_user_set_buckets_info(cls_method_context_t hctx, bufferlist *in, 
     CLS_LOG(20, "storing entry for key=%s size=%lld count=%lld",
             key.c_str(), (long long)update_entry.size, (long long)update_entry.count);
 
-    // Update bucket's placement rule info only when linking bucket, not on
-    // usage stats change. */
-    if (op.add) {
-      entry.placement_rule = update_entry.placement_rule;
-    }
-
     // sync entry stats when not an op.add, as when the case is op.add if its a
     // new entry we already have copied update_entry earlier, OTOH, for an existing entry
     // we end up clobbering the existing stats for the bucket

--- a/src/cls/user/cls_user_types.cc
+++ b/src/cls/user/cls_user_types.cc
@@ -39,7 +39,6 @@ void cls_user_bucket_entry::dump(Formatter *f) const
   encode_json("creation_time", utime_t(creation_time), f);
   encode_json("count", count, f);
   encode_json("user_stats_sync", user_stats_sync, f);
-  encode_json("placement_rule", placement_rule, f);
 }
 
 void cls_user_gen_test_bucket_entry(cls_user_bucket_entry *entry, int i)

--- a/src/rgw/rgw_bucket.h
+++ b/src/rgw/rgw_bucket.h
@@ -180,7 +180,6 @@ extern int rgw_link_bucket(RGWRados* store,
                            const rgw_user& user_id,
                            rgw_bucket& bucket,
                            ceph::real_time creation_time,
-                           std::string placement_rule,
                            bool update_entrypoint = true);
 extern int rgw_unlink_bucket(RGWRados *store, const rgw_user& user_id,
                              const string& tenant_name, const string& bucket_name, bool update_entrypoint = true);

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -1910,8 +1910,7 @@ struct RGWBucketEnt {
       size(e.size),
       size_rounded(e.size_rounded),
       creation_time(e.creation_time),
-      count(e.count),
-      placement_rule(std::move(e.placement_rule)) {
+      count(e.count) {
   }
 
   RGWBucketEnt& operator=(const RGWBucketEnt&) = default;

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -2778,7 +2778,7 @@ void RGWCreateBucket::execute()
   }
 
   op_ret = rgw_link_bucket(store, s->user->user_id, s->bucket,
-			   info.creation_time, info.placement_rule, false);
+			   info.creation_time, false);
   if (op_ret && !existed && op_ret != -EEXIST) {
     /* if it exists (or previously existed), don't remove it! */
     op_ret = rgw_unlink_bucket(store, s->user->user_id, s->bucket.tenant,
@@ -6308,8 +6308,8 @@ int RGWBulkUploadOp::handle_dir(const boost::string_ref path)
     bucket = out_info.bucket;
   }
 
-  op_ret = rgw_link_bucket(store, s->user->user_id,bucket, out_info.creation_time,
-                           out_info.placement_rule, false);
+  op_ret = rgw_link_bucket(store, s->user->user_id, bucket,
+                           out_info.creation_time, false);
   if (op_ret && !existed && op_ret != -EEXIST) {
     /* if it exists (or previously existed), don't remove it! */
     op_ret = rgw_unlink_bucket(store, s->user->user_id,

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -12128,6 +12128,10 @@ int RGWRados::update_containers_stats(map<string, RGWBucketEnt>& m)
         ent.size_rounded += stats.total_size_rounded;
       }
     }
+
+    // fill in placement_rule from the bucket instance for use in swift's
+    // per-storage policy statistics
+    ent.placement_rule = std::move(bucket_info.placement_rule);
   }
 
   return m.size();


### PR DESCRIPTION
The `placement_rule` field was added to `cls_user_bucket_entry` as part of swift's per-storage policy stats in https://github.com/ceph/ceph/pull/12704. But whenever swift needs to consume those stats, it also calls through `RGWRados::update_containers_stats()`, which reads the bucket instance info. So we can get the `placement_rule` from the bucket instance there, instead of threading it through `rgw_link_bucket()` and `cls_user_bucket_entry`.

This removes the dependency between bucket entrypoint metadata and its bucket instance, leading to races during multisite sync.

Fixes: http://tracker.ceph.com/issues/21990