### PR TITLE
RGW: update S3 POST policy handling of Content-Type

### DIFF
--- a/src/rgw/rgw_rest_s3.cc
+++ b/src/rgw/rgw_rest_s3.cc
@@ -1609,7 +1609,11 @@ int RGWPostObj_ObjStore_S3::get_params()
   env.add_var("key", s->object.name);
 
   part_str(parts, "Content-Type", &content_type);
-  env.add_var("Content-Type", content_type);
+
+  /* AWS permits POST without Content-Type: http://tracker.ceph.com/issues/20201 */
+  if (! content_type.empty()) {
+    env.add_var("Content-Type", content_type);
+  }
 
   map<string, struct post_form_part, ltstr_nocase>::iterator piter =
     parts.upper_bound(RGW_AMZ_META_PREFIX);


### PR DESCRIPTION
    RGW: S3 POST policy should not require Content-Type
    
    In the current implementation, putting a key in the acting
    RGWPolicyEnv makes it required in RGWPolicyEnv::match_policy_vars.
    
    I'm not sure this is the intent, but in any case, add it to the env
    only if sent.
    
    Fixes: http://tracker.ceph.com/issues/20201
    
    Signed-off-by: Matt Benjamin <mbenjamin@redhat.com>
