### PR TITLE
rgw/rgw_rados: Fix compilation warning in create_bucket_id

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5720,7 +5720,7 @@ void RGWRados::create_bucket_id(string *bucket_id)
   uint64_t iid = instance_id();
   uint64_t bid = next_bucket_id();
   char buf[get_zone_params().get_id().size() + 48];
-  snprintf(buf, sizeof(buf), "%s.%llu.%llu", get_zone_params().get_id().c_str(), iid, bid);
+  snprintf(buf, sizeof(buf), "%s.%" PRIu64 ".%" PRIu64, get_zone_params().get_id().c_str(), iid, bid);
   *bucket_id = buf;
 }
 


### PR DESCRIPTION
compiler warns that snprintf expects argument of type llu int in
argument 5 and 6 but iid and bid are of type uint64_t

Signed-off-by: Prashant D <pdhange@redhat.com>