### PR TITLE
rgw: fix rewrite a versioning object create a new object bug

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -7445,7 +7445,9 @@ int RGWRados::rewrite_obj(RGWBucketInfo& dest_bucket_info, rgw_obj& obj)
   attrset.erase(RGW_ATTR_TAIL_TAG);
 
   return copy_obj_data(rctx, dest_bucket_info, read_op, obj_size - 1, obj, NULL, mtime, attrset,
-                       0, real_time(), NULL, NULL);
+                       0, real_time(),
+                       (obj.key.instance.empty() ? NULL : &(obj.key.instance)),
+                       NULL);
 }
 
 struct obj_time_weight {
@@ -8232,7 +8234,7 @@ int RGWRados::copy_obj_data(RGWObjectCtx& obj_ctx,
   append_rand_alpha(cct, tag, tag, 32);
 
   RGWPutObjProcessor_Atomic processor(obj_ctx,
-                                      dest_bucket_info, dest_obj.bucket, dest_obj.get_oid(),
+                                      dest_bucket_info, dest_obj.bucket, dest_obj.key.name,
                                       cct->_conf->rgw_obj_stripe_size, tag, dest_bucket_info.versioning_enabled());
   if (version_id) {
     processor.set_version_id(*version_id);


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21984

1. List RADOS objects

`$ rados -p default.rgw.buckets.data ls`

cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_1
cad03102-431e-4820-942e-efab29247df8.4120.1_ver-10M
cad03102-431e-4820-942e-efab29247df8.4120.1__:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_ver-10M
cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_2

2. Rewrite a versioning object

`$ radosgw-admin object rewrite --bucket=111 --object=ver-10M  --object-version=cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7`

3. List RADOS objects again

`$ rados -p default.rgw.buckets.data ls`

cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_1
cad03102-431e-4820-942e-efab29247df8.4120.1_ver-10M
cad03102-431e-4820-942e-efab29247df8.4120.1__:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_ver-10M
cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.osEcr1uHdcP8V6AzRJhzItAtnAUkrCT_2
cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_2
cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.osEcr1uHdcP8V6AzRJhzItAtnAUkrCT_1

4. List all objects in bucket 111 by s3cmd

`$ s3cmd ls s3://111`

2017-11-01 07:05  10485760   s3://111/ver-10M

5. List all entries of garbage collection objects

`$ radosgw-admin gc list --include-all`

[
    {
        "tag": "cad03102-431e-4820-942e-efab29247df8.4120.5\u0000",
        "time": "2017-11-01 17:07:37.0.587706s",
        "objs": [
            {
                "pool": "default.rgw.buckets.data",
                "oid": "cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_1",
                "key": "",
                "instance": ""
            },
            {
                "pool": "default.rgw.buckets.data",
                "oid": "cad03102-431e-4820-942e-efab29247df8.4120.1__shadow:cmhtSYIYdexIZfwSvZQdRQZSVF4i8q7_.74jv0KaZ03PqoWU5st8pEESl9VWCdC6_2",
                "key": "",
                "instance": ""
            }
        ]
    }
]