### PR TITLE
osdc/Objecter: calculate op data length

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3171,7 +3171,11 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   }
 
   logger->inc(l_osdc_op_send);
-  logger->inc(l_osdc_op_send_bytes, m->get_data().length());
+  uint64_t op_bytes = 0;
+  for (auto &p: m->ops)
+    op_bytes += p.indata.length();
+  if (op_bytes)
+    logger->inc(l_osdc_op_send_bytes, op_bytes);
 
   return m;
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21982

Signed-off-by: huangjun <huangjun@xsky.com>