### PR TITLE
[DNM] librbd: implement bandwidth limiting

### DIFF
--- a/src/common/Throttle.h
+++ b/src/common/Throttle.h
@@ -374,8 +374,8 @@ TokenBucketThrottle(CephContext *cct, uint64_t capacity, uint64_t avg,
 
 ~TokenBucketThrottle();
 
-template <typename T, typename I, void(T::*MF)(int, I*)>
-bool get(uint64_t c, T *handler, I *item) {
+template <typename T, typename I, void(T::*MF)(int, I*, uint64_t)>
+bool get(uint64_t c, T *handler, I *item, uint64_t flag) {
   if (0 == m_throttle.max)
     return false;
 
@@ -388,8 +388,8 @@ bool get(uint64_t c, T *handler, I *item) {
   }
   if (got < c) {
     // Not enough tokens, add a blocker for it.
-    Context *ctx = new FunctionContext([this, handler, item](int r) {
-	(handler->*MF)(r, item);
+    Context *ctx = new FunctionContext([this, handler, item, flag](int r) {
+	(handler->*MF)(r, item, flag);
       });
     Mutex::Locker blockers_lock(m_blockers_lock);
     m_blockers.emplace_back(c - got, ctx);

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5419,6 +5419,10 @@ static std::vector<Option> get_rbd_options() {
     Option("rbd_journal_max_concurrent_object_sets", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("maximum number of object sets a journal client can be behind before it is automatically unregistered"),
+
+    Option("rbd_qos_iops_limit", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired limit of IO operations per second"),
   });
 }
 

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5423,6 +5423,10 @@ static std::vector<Option> get_rbd_options() {
     Option("rbd_qos_iops_limit", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(0)
     .set_description("the desired limit of IO operations per second"),
+
+    Option("rbd_qos_bps_limit", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(0)
+    .set_description("the desired limit of IO bandwidth per second"),
   });
 }
 

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1003,7 +1003,8 @@ struct C_InvalidateCache : public Context {
         "rbd_journal_max_concurrent_object_sets", false)(
         "rbd_mirroring_resync_after_disconnect", false)(
         "rbd_mirroring_replay_delay", false)(
-        "rbd_skip_partial_discard", false);
+        "rbd_skip_partial_discard", false)(
+	"rbd_qos_iops_limit", false);
 
     md_config_t local_config_t;
     std::map<std::string, bufferlist> res;
@@ -1064,6 +1065,7 @@ struct C_InvalidateCache : public Context {
     ASSIGN_OPTION(mirroring_replay_delay, int64_t);
     ASSIGN_OPTION(skip_partial_discard, bool);
     ASSIGN_OPTION(blkin_trace_all, bool);
+    ASSIGN_OPTION(qos_iops_limit, uint64_t);
 
     if (thread_safe) {
       ASSIGN_OPTION(journal_pool, std::string);
@@ -1072,6 +1074,8 @@ struct C_InvalidateCache : public Context {
     if (sparse_read_threshold_bytes == 0) {
       sparse_read_threshold_bytes = get_object_size();
     }
+
+    io_work_queue->apply_qos_iops_limit(qos_iops_limit);
   }
 
   ExclusiveLock<ImageCtx> *ImageCtx::create_exclusive_lock() {

--- a/src/librbd/ImageCtx.cc
+++ b/src/librbd/ImageCtx.cc
@@ -1004,7 +1004,8 @@ struct C_InvalidateCache : public Context {
         "rbd_mirroring_resync_after_disconnect", false)(
         "rbd_mirroring_replay_delay", false)(
         "rbd_skip_partial_discard", false)(
-	"rbd_qos_iops_limit", false);
+	"rbd_qos_iops_limit", false)(
+	"rbd_qos_bps_limit", false);
 
     md_config_t local_config_t;
     std::map<std::string, bufferlist> res;
@@ -1066,6 +1067,7 @@ struct C_InvalidateCache : public Context {
     ASSIGN_OPTION(skip_partial_discard, bool);
     ASSIGN_OPTION(blkin_trace_all, bool);
     ASSIGN_OPTION(qos_iops_limit, uint64_t);
+    ASSIGN_OPTION(qos_bps_limit, uint64_t);
 
     if (thread_safe) {
       ASSIGN_OPTION(journal_pool, std::string);
@@ -1076,6 +1078,7 @@ struct C_InvalidateCache : public Context {
     }
 
     io_work_queue->apply_qos_iops_limit(qos_iops_limit);
+    io_work_queue->apply_qos_bps_limit(qos_bps_limit);
   }
 
   ExclusiveLock<ImageCtx> *ImageCtx::create_exclusive_lock() {

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -199,6 +199,7 @@ namespace librbd {
     bool skip_partial_discard;
     bool blkin_trace_all;
     uint64_t qos_iops_limit;
+    uint64_t qos_bps_limit;
 
     LibrbdAdminSocketHook *asok_hook;
 

--- a/src/librbd/ImageCtx.h
+++ b/src/librbd/ImageCtx.h
@@ -198,6 +198,7 @@ namespace librbd {
     int mirroring_replay_delay;
     bool skip_partial_discard;
     bool blkin_trace_all;
+    uint64_t qos_iops_limit;
 
     LibrbdAdminSocketHook *asok_hook;
 

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -99,6 +99,14 @@ public:
     return m_trace;
   }
 
+  bool was_throttled() {
+    return m_throttled;
+  }
+
+  void set_throttled() {
+    m_throttled = true;
+  }
+
 protected:
   typedef std::list<ObjectRequestHandle *> ObjectRequests;
 
@@ -107,6 +115,7 @@ protected:
   Extents m_image_extents;
   ZTracer::Trace m_trace;
   bool m_bypass_image_cache = false;
+  bool m_throttled = false;
 
   ImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                Extents &&image_extents, const char *trace_name,

--- a/src/librbd/io/ImageRequest.h
+++ b/src/librbd/io/ImageRequest.h
@@ -24,6 +24,9 @@ class AioCompletion;
 class ObjectRequestHandle;
 class ReadResult;
 
+#define RBD_IMAGE_IOPS_THROTTLE			1 << 0
+#define RBD_IMAGE_BPS_THROTTLE			1 << 1
+
 template <typename ImageCtxT = ImageCtx>
 class ImageRequest {
 public:
@@ -99,12 +102,16 @@ public:
     return m_trace;
   }
 
-  bool was_throttled() {
-    return m_throttled;
+  bool was_throttled(uint64_t flag) {
+    return m_throttled_flag & flag;
   }
 
-  void set_throttled() {
-    m_throttled = true;
+  void set_throttled(uint64_t flag) {
+    m_throttled_flag |= flag;
+  }
+
+  uint64_t get_length() {
+    return m_length;
   }
 
 protected:
@@ -115,7 +122,8 @@ protected:
   Extents m_image_extents;
   ZTracer::Trace m_trace;
   bool m_bypass_image_cache = false;
-  bool m_throttled = false;
+  uint64_t m_throttled_flag = 0;
+  uint64_t m_length = 0;
 
   ImageRequest(ImageCtxT &image_ctx, AioCompletion *aio_comp,
                Extents &&image_extents, const char *trace_name,
@@ -124,6 +132,10 @@ protected:
       m_image_extents(std::move(image_extents)),
       m_trace(util::create_trace(image_ctx, trace_name, parent_trace)) {
     m_trace.event("start");
+    auto &extents = this->m_image_extents;
+    for (auto &extent : extents) {
+      m_length += extent.second;
+    }
   }
   
 

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -6,6 +6,7 @@
 
 #include "include/Context.h"
 #include "common/RWLock.h"
+#include "common/Throttle.h"
 #include "common/WorkQueue.h"
 #include "librbd/io/Types.h"
 
@@ -28,6 +29,7 @@ class ImageRequestWQ
 public:
   ImageRequestWQ(ImageCtxT *image_ctx, const string &name, time_t ti,
                  ThreadPool *tp);
+  ~ImageRequestWQ();
 
   ssize_t read(uint64_t off, uint64_t len, ReadResult &&read_result,
                int op_flags);
@@ -70,6 +72,8 @@ public:
 
   void set_require_lock(Direction direction, bool enabled);
 
+  void apply_qos_iops_limit(uint64_t limit);
+
 protected:
   void *_void_dequeue() override;
   void process(ImageRequest<ImageCtxT> *req) override;
@@ -92,6 +96,8 @@ private:
   std::atomic<unsigned> m_in_flight_ios { 0 };
   std::atomic<unsigned> m_in_flight_writes { 0 };
   std::atomic<unsigned> m_io_blockers { 0 };
+
+  TokenBucketThrottle *iops_throttle;
 
   bool m_shutdown = false;
   Context *m_on_shutdown = nullptr;
@@ -119,6 +125,8 @@ private:
   void handle_acquire_lock(int r, ImageRequest<ImageCtxT> *req);
   void handle_refreshed(int r, ImageRequest<ImageCtxT> *req);
   void handle_blocked_writes(int r);
+
+  void handle_iops_throttle_ready(int r, ImageRequest<ImageCtxT> *item);
 };
 
 } // namespace io

--- a/src/librbd/io/ImageRequestWQ.h
+++ b/src/librbd/io/ImageRequestWQ.h
@@ -73,6 +73,7 @@ public:
   void set_require_lock(Direction direction, bool enabled);
 
   void apply_qos_iops_limit(uint64_t limit);
+  void apply_qos_bps_limit(uint64_t limit);
 
 protected:
   void *_void_dequeue() override;
@@ -98,6 +99,7 @@ private:
   std::atomic<unsigned> m_io_blockers { 0 };
 
   TokenBucketThrottle *iops_throttle;
+  TokenBucketThrottle *bps_throttle;
 
   bool m_shutdown = false;
   Context *m_on_shutdown = nullptr;
@@ -126,7 +128,7 @@ private:
   void handle_refreshed(int r, ImageRequest<ImageCtxT> *req);
   void handle_blocked_writes(int r);
 
-  void handle_iops_throttle_ready(int r, ImageRequest<ImageCtxT> *item);
+  void handle_throttle_ready(int r, ImageRequest<ImageCtxT> *item, uint64_t flag);
 };
 
 } // namespace io

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -44,8 +44,9 @@ struct ImageRequest<librbd::MockTestImageCtx> {
   MOCK_CONST_METHOD0(start_op, void());
   MOCK_CONST_METHOD0(send, void());
   MOCK_CONST_METHOD1(fail, void(int));
-  MOCK_CONST_METHOD0(was_throttled, bool());
-  MOCK_CONST_METHOD0(set_throttled, void());
+  MOCK_CONST_METHOD1(was_throttled, bool(uint64_t));
+  MOCK_CONST_METHOD1(set_throttled, void(uint64_t));
+  MOCK_CONST_METHOD0(get_length, uint64_t());
 
   ImageRequest() {
     s_instance = this;

--- a/src/test/librbd/io/test_mock_ImageRequestWQ.cc
+++ b/src/test/librbd/io/test_mock_ImageRequestWQ.cc
@@ -44,6 +44,8 @@ struct ImageRequest<librbd::MockTestImageCtx> {
   MOCK_CONST_METHOD0(start_op, void());
   MOCK_CONST_METHOD0(send, void());
   MOCK_CONST_METHOD1(fail, void(int));
+  MOCK_CONST_METHOD0(was_throttled, bool());
+  MOCK_CONST_METHOD0(set_throttled, void());
 
   ImageRequest() {
     s_instance = this;


### PR DESCRIPTION
this is based on https://github.com/ceph/ceph/pull/17032

Hi @dillaman this PR is implementing the bandwidth limiting in librbd.

![1](https://user-images.githubusercontent.com/3012925/32276303-8d06dad6-bf49-11e7-9711-01402b85e625.png)

This is the result in my testing. 
(rbd bench --io-type read --io-size 4096 --io-threads 1 test)
Stage1: iops_limit=500, bps_limit=0
Stage2: iops_limit=500, bps_limit=409600
Stage3: iops_limit=50, bps_limit=409600

So the iops_limit and bps_limit will be working at the same time, but the lower one will affect the result.