### PR TITLE
qa/tasks/thrashosds: set min_in default to 4

### DIFF
--- a/qa/tasks/ceph_manager.py
+++ b/qa/tasks/ceph_manager.py
@@ -116,7 +116,7 @@ class Thrasher:
         if self.config.get('powercycle'):
             self.revive_timeout += 120
         self.clean_wait = self.config.get('clean_wait', 0)
-        self.minin = self.config.get("min_in", 3)
+        self.minin = self.config.get("min_in", 4)
         self.chance_move_pg = self.config.get('chance_move_pg', 1.0)
         self.sighup_delay = self.config.get('sighup_delay')
         self.optrack_toggle_delay = self.config.get('optrack_toggle_delay')

--- a/qa/tasks/thrashosds.py
+++ b/qa/tasks/thrashosds.py
@@ -24,7 +24,7 @@ def task(ctx, config):
 
     cluster: (default 'ceph') the name of the cluster to thrash
 
-    min_in: (default 3) the minimum number of OSDs to keep in the
+    min_in: (default 4) the minimum number of OSDs to keep in the
        cluster
 
     min_out: (default 0) the minimum number of OSDs to keep out of the


### PR DESCRIPTION
We have EC tests with k=2,m=2, so we need a min of 4.  See
/a/sage-2017-11-01_01:03:53-rados-wip-sage2-testing-2017-10-31-1354-distro-basic-smithi/1797020
for an example of a test that fails without it.

http://tracker.ceph.com/issues/21997