### PR TITLE
osd: build_past_intervals_parallel: Ignore new partially created PGs

### DIFF
--- a/src/osd/OSD.cc
+++ b/src/osd/OSD.cc
@@ -4074,6 +4074,11 @@ void OSD::build_past_intervals_parallel()
         ++i) {
       PG *pg = i->second;
 
+      // Ignore PGs only partially created (DNE)
+      if (pg->info.dne()) {
+	continue;
+      }
+
       auto rpib = pg->get_required_past_interval_bounds(
 	pg->info,
 	superblock.oldest_map);


### PR DESCRIPTION
In some situations PGs with DNE can be left behind especially with lots of crashes.  These PGs don't need past_intervals rebuilt because there is nothing there.  Skip those.  This no longer applies in master branch.