### PR TITLE
qa/tests: use ceph-luminous branch for s3tests

### DIFF
--- a/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/multifs/tasks/rgw_s3tests.yaml
@@ -4,7 +4,7 @@ tasks:
 - rgw: [client.0]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-luminous
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
+++ b/qa/suites/rgw/thrash/workload/rgw_s3tests.yaml
@@ -1,7 +1,7 @@
 tasks:
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-luminous
       rgw_server: client.0
 overrides:
   ceph:

--- a/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
+++ b/qa/suites/rgw/verify/tasks/rgw_s3tests.yaml
@@ -10,7 +10,7 @@ tasks:
       valgrind: [--tool=memcheck]
 - s3tests:
     client.0:
-      force-branch: ceph-master
+      force-branch: ceph-luminous
       rgw_server: client.0
 overrides:
   ceph:


### PR DESCRIPTION
use ceph-luminous branch for s3tests

Signed-off-by: Vasu Kulkarni <vasu@redhat.com>