### PR TITLE
rgw: fix dead lock in RGWSyncTraceManager finish_node

### DIFF
--- a/src/rgw/rgw_sync_trace.cc
+++ b/src/rgw/rgw_sync_trace.cc
@@ -15,10 +15,9 @@ using namespace std;
 #define dout_subsys ceph_subsys_rgw_sync
 
 RGWSyncTraceNode::RGWSyncTraceNode(CephContext *_cct, RGWSyncTraceManager *_manager,
-                                   const RGWSyncTraceNodeRef& _parent,
+                                   const RGWSyncTraceNodeRef& parent,
                                    const string& _type, const string& _id) : cct(_cct),
                                                                              manager(_manager),
-                                                                             parent(_parent),
                                                                              type(_type),
                                                                              id(_id), history(cct->_conf->rgw_sync_trace_per_node_log_size)
 {

--- a/src/rgw/rgw_sync_trace.h
+++ b/src/rgw/rgw_sync_trace.h
@@ -34,7 +34,6 @@ class RGWSyncTraceNode {
   CephContext *cct;
 
   RGWSyncTraceManager *manager{nullptr};
-  RGWSyncTraceNodeRef parent;
 
   uint16_t state{0};
   std::string status;


### PR DESCRIPTION
complete_nodes is circular_buffer, when weed out and destroy first node,
will release parent count, may trigger another finish_node.

fixes: http://tracker.ceph.com/issues/22001
Signed-off-by: Tianshan Qu <tianshan@xsky.com>