### PR TITLE
rgw: silence warning from -Wformat=

### DIFF
--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -5720,7 +5720,8 @@ void RGWRados::create_bucket_id(string *bucket_id)
   uint64_t iid = instance_id();
   uint64_t bid = next_bucket_id();
   char buf[get_zone_params().get_id().size() + 48];
-  snprintf(buf, sizeof(buf), "%s.%llu.%llu", get_zone_params().get_id().c_str(), iid, bid);
+  snprintf(buf, sizeof(buf), "%s.%llu.%llu", get_zone_params().get_id().c_str(),
+           static_cast<long long>(iid), static_cast<long long>(bid));
   *bucket_id = buf;
 }
 


### PR DESCRIPTION
Found this during build:

```
ceph/src/rgw/rgw_rados.cc: In member function ‘void RGWRados::create_bucket_id(std::string*)’:
ceph/src/rgw/rgw_rados.cc:5723:90: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
   snprintf(buf, sizeof(buf), "%s.%llu.%llu", get_zone_params().get_id().c_str(), iid, bid);
                                                                                          ^
ceph/src/rgw/rgw_rados.cc:5723:90: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
ceph/src/rgw/rgw_rados.cc:5723:90: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 5 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
ceph/src/rgw/rgw_rados.cc:5723:90: warning: format ‘%llu’ expects argument of type ‘long long unsigned int’, but argument 6 has type ‘uint64_t {aka long unsigned int}’ [-Wformat=]
```
Signed-off-by: Jos Collin <jcollin@redhat.com>