### PR TITLE
rgw: fix null pointer exception

### DIFF
--- a/src/rgw/rgw_aclparser.cc
+++ b/src/rgw/rgw_aclparser.cc
@@ -43,18 +43,17 @@ int main(int argc, char **argv) {
     string id="79a59df900b949e55d96a1e698fbacedfd6e09d98eacf8f8d5218e7cd47ef2be";
     dout(10) << hex << policy->get_perm(g_ceph_context, id, RGW_PERM_ALL) << dec << dendl;
     policy->to_xml(cout);
+    cout << parser.get_xml() << endl;
+
+    bufferlist bl;
+    policy->encode(bl);
+
+    RGWAccessControlPolicy newpol;
+    bufferlist::iterator iter = bl.begin();
+    newpol.decode(iter);
+
+    newpol.to_xml(cout);
   }
-
-  cout << parser.get_xml() << endl;
-
-  bufferlist bl;
-  policy->encode(bl);
-
-  RGWAccessControlPolicy newpol;
-  bufferlist::iterator iter = bl.begin();
-  newpol.decode(iter);
-
-  newpol.to_xml(cout);
 
   exit(0);
 }


### PR DESCRIPTION
“policy” might be null when use  policy->encode(bl). The reason is policy->encode(bl) is outside of the "if(policy)".
Signed-off-by: Sibei Gao  <gaosb@inspur.com>