### PR TITLE
erasure-code: refactor the interfaces to hide internals from public

### DIFF
--- a/src/erasure-code/ErasureCode.cc
+++ b/src/erasure-code/ErasureCode.cc
@@ -88,7 +88,7 @@ int ErasureCode::chunk_index(unsigned int i) const
   return chunk_mapping.size() > i ? chunk_mapping[i] : i;
 }
 
-int ErasureCode::minimum_to_decode(const set<int> &want_to_read,
+int ErasureCode::_minimum_to_decode(const set<int> &want_to_read,
                                    const set<int> &available_chunks,
                                    set<int> *minimum)
 {
@@ -112,7 +112,7 @@ int ErasureCode::minimum_to_decode(const set<int> &want_to_read,
                                    map<int, vector<pair<int, int>>> *minimum)
 {
   set<int> minimum_shard_ids;
-  int r = minimum_to_decode(want_to_read, available_chunks, &minimum_shard_ids);
+  int r = _minimum_to_decode(want_to_read, available_chunks, &minimum_shard_ids);
   if (r != 0) {
     return r;
   }
@@ -133,7 +133,7 @@ int ErasureCode::minimum_to_decode_with_cost(const set<int> &want_to_read,
        i != available.end();
        ++i)
     available_chunks.insert(i->first);
-  return minimum_to_decode(want_to_read, available_chunks, minimum);
+  return _minimum_to_decode(want_to_read, available_chunks, minimum);
 }
 
 int ErasureCode::encode_prepare(const bufferlist &raw,
@@ -197,9 +197,9 @@ int ErasureCode::encode_chunks(const set<int> &want_to_encode,
   assert("ErasureCode::encode_chunks not implemented" == 0);
 }
  
-int ErasureCode::decode(const set<int> &want_to_read,
-                        const map<int, bufferlist> &chunks,
-                        map<int, bufferlist> *decoded)
+int ErasureCode::_decode(const set<int> &want_to_read,
+			 const map<int, bufferlist> &chunks,
+			 map<int, bufferlist> *decoded)
 {
   vector<int> have;
   have.reserve(chunks.size());
@@ -236,7 +236,7 @@ int ErasureCode::decode(const set<int> &want_to_read,
                         const map<int, bufferlist> &chunks,
                         map<int, bufferlist> *decoded, int chunk_size)
 {
-  return decode(want_to_read, chunks, decoded);
+  return _decode(want_to_read, chunks, decoded);
 }
 
 int ErasureCode::decode_chunks(const set<int> &want_to_read,
@@ -336,7 +336,7 @@ int ErasureCode::decode_concat(const map<int, bufferlist> &chunks,
     want_to_read.insert(chunk_index(i));
   }
   map<int, bufferlist> decoded_map;
-  int r = decode(want_to_read, chunks, &decoded_map);
+  int r = _decode(want_to_read, chunks, &decoded_map);
   if (r == 0) {
     for (unsigned int i = 0; i < get_data_chunk_count(); i++) {
       decoded->claim_append(decoded_map[chunk_index(i)]);

--- a/src/erasure-code/ErasureCode.h
+++ b/src/erasure-code/ErasureCode.h
@@ -60,13 +60,13 @@ namespace ceph {
       return 1;
     }
 
-    virtual int minimum_to_decode(const std::set<int> &want_to_read,
-                                  const std::set<int> &available_chunks,
-                                  std::set<int> *minimum);
+    virtual int _minimum_to_decode(const std::set<int> &want_to_read,
+				   const std::set<int> &available_chunks,
+				   std::set<int> *minimum);
 
-    virtual int minimum_to_decode(const std::set<int> &want_to_read,
-                                  const std::set<int> &available,
-                                  std::map<int, std::vector<std::pair<int, int>>> *minimum)override;
+    int minimum_to_decode(const std::set<int> &want_to_read,
+			  const std::set<int> &available,
+			  std::map<int, std::vector<std::pair<int, int>>> *minimum) final override;
 
     int minimum_to_decode_with_cost(const std::set<int> &want_to_read,
                                             const std::map<int, int> &available,
@@ -82,13 +82,13 @@ namespace ceph {
     int encode_chunks(const std::set<int> &want_to_encode,
                               std::map<int, bufferlist> *encoded) override;
 
-    virtual int decode(const std::set<int> &want_to_read,
-                       const std::map<int, bufferlist> &chunks,
-                       std::map<int, bufferlist> *decoded);
-
     int decode(const std::set<int> &want_to_read,
                 const std::map<int, bufferlist> &chunks,
-                std::map<int, bufferlist> *decoded, int chunk_size) override;
+                std::map<int, bufferlist> *decoded, int chunk_size) override final;
+
+    virtual int _decode(const std::set<int> &want_to_read,
+			const std::map<int, bufferlist> &chunks,
+			std::map<int, bufferlist> *decoded);
 
     int decode_chunks(const std::set<int> &want_to_read,
                               const std::map<int, bufferlist> &chunks,

--- a/src/erasure-code/lrc/ErasureCodeLrc.cc
+++ b/src/erasure-code/lrc/ErasureCodeLrc.cc
@@ -569,9 +569,9 @@ unsigned int ErasureCodeLrc::get_chunk_size(unsigned int object_size) const
 
 void p(const set<int> &s) { cerr << s; } // for gdb
 
-int ErasureCodeLrc::minimum_to_decode(const set<int> &want_to_read,
-				      const set<int> &available_chunks,
-				      set<int> *minimum)
+int ErasureCodeLrc::_minimum_to_decode(const set<int> &want_to_read,
+				       const set<int> &available_chunks,
+				       set<int> *minimum)
 {
   dout(20) << __func__ << " want_to_read " << want_to_read
 	   << " available_chunks " << available_chunks << dendl;

--- a/src/erasure-code/lrc/ErasureCodeLrc.h
+++ b/src/erasure-code/lrc/ErasureCodeLrc.h
@@ -44,7 +44,7 @@
 #define ERROR_LRC_K_MODULO		-(MAX_ERRNO + 20)
 #define ERROR_LRC_M_MODULO		-(MAX_ERRNO + 21)
 
-class ErasureCodeLrc : public ErasureCode {
+class ErasureCodeLrc final : public ErasureCode {
 public:
   static const std::string DEFAULT_KML;
 
@@ -87,9 +87,9 @@ public:
   std::set<int> get_erasures(const std::set<int> &need,
 			const std::set<int> &available) const;
 
-  int minimum_to_decode(const std::set<int> &want_to_read,
-				const std::set<int> &available,
-				std::set<int> *minimum) override;
+  int _minimum_to_decode(const std::set<int> &want_to_read,
+			 const std::set<int> &available,
+			 std::set<int> *minimum) override;
 
   int create_rule(const std::string &name,
 			     CrushWrapper &crush,

--- a/src/erasure-code/shec/ErasureCodeShec.cc
+++ b/src/erasure-code/shec/ErasureCodeShec.cc
@@ -66,7 +66,7 @@ unsigned int ErasureCodeShec::get_chunk_size(unsigned int object_size) const
   return padded_length / k;
 }
 
-int ErasureCodeShec::minimum_to_decode(const set<int> &want_to_read,
+int ErasureCodeShec::_minimum_to_decode(const set<int> &want_to_read,
 				       const set<int> &available_chunks,
 				       set<int> *minimum_chunks)
 {
@@ -131,7 +131,7 @@ int ErasureCodeShec::minimum_to_decode_with_cost(const set<int> &want_to_read,
        ++i)
     available_chunks.insert(i->first);
 
-  return minimum_to_decode(want_to_read, available_chunks, minimum_chunks);
+  return _minimum_to_decode(want_to_read, available_chunks, minimum_chunks);
 }
 
 int ErasureCodeShec::encode(const set<int> &want_to_encode,
@@ -168,7 +168,7 @@ int ErasureCodeShec::encode_chunks(const set<int> &want_to_encode,
   return 0;
 }
 
-int ErasureCodeShec::decode(const set<int> &want_to_read,
+int ErasureCodeShec::_decode(const set<int> &want_to_read,
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded)
 {

--- a/src/erasure-code/shec/ErasureCodeShec.h
+++ b/src/erasure-code/shec/ErasureCodeShec.h
@@ -71,9 +71,9 @@ public:
 
   unsigned int get_chunk_size(unsigned int object_size) const override;
 
-  int minimum_to_decode(const set<int> &want_to_read,
-				const set<int> &available_chunks,
-				set<int> *minimum);
+  int _minimum_to_decode(const std::set<int> &want_to_read,
+			 const std::set<int> &available_chunks,
+			 std::set<int> *minimum);
 
   int minimum_to_decode_with_cost(const set<int> &want_to_read,
 					  const map<int, int> &available,
@@ -85,9 +85,9 @@ public:
   int encode_chunks(const set<int> &want_to_encode,
 			    map<int, bufferlist> *encoded) override;
 
-  int decode(const set<int> &want_to_read,
-		     const map<int, bufferlist> &chunks,
-		     map<int, bufferlist> *decoded);
+  int _decode(const std::set<int> &want_to_read,
+	      const std::map<int, bufferlist> &chunks,
+	      std::map<int, bufferlist> *decoded) override;
   int decode_chunks(const set<int> &want_to_read,
 			    const map<int, bufferlist> &chunks,
 			    map<int, bufferlist> *decoded) override;
@@ -119,7 +119,7 @@ private:
                                         int *minimum);
 };
 
-class ErasureCodeShecReedSolomonVandermonde : public ErasureCodeShec {
+class ErasureCodeShecReedSolomonVandermonde final : public ErasureCodeShec {
 public:
 
   ErasureCodeShecReedSolomonVandermonde(ErasureCodeShecTableCache &_tcache,

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -46,21 +46,6 @@ public:
 				 "indep", pg_pool_t::TYPE_ERASURE, ss);
   }
 
-  int _minimum_to_decode(const set<int> &want_to_read,
-                                const set<int> &available_chunks,
-                                set<int> *minimum) override {
-    if (includes(available_chunks.begin(), available_chunks.end(),
-		 want_to_read.begin(), want_to_read.end())) {
-      *minimum = want_to_read;
-      return 0;
-    } else if (available_chunks.size() >= MINIMUM_TO_RECOVER) {
-      *minimum = available_chunks;
-      return 0;
-    } else {
-      return -EIO;
-    }
-  }
-
   int minimum_to_decode_with_cost(const set<int> &want_to_read,
                                           const map<int, int> &available,
                                           set<int> *minimum) override {

--- a/src/test/erasure-code/ErasureCodeExample.h
+++ b/src/test/erasure-code/ErasureCodeExample.h
@@ -35,7 +35,7 @@
 
 #define MINIMUM_TO_RECOVER 2u
 
-class ErasureCodeExample : public ErasureCode {
+class ErasureCodeExample final : public ErasureCode {
 public:
   ~ErasureCodeExample() override {}
 
@@ -45,10 +45,10 @@ public:
     return crush.add_simple_rule(name, "default", "host", "",
 				 "indep", pg_pool_t::TYPE_ERASURE, ss);
   }
-  
-  int minimum_to_decode(const set<int> &want_to_read,
+
+  int _minimum_to_decode(const set<int> &want_to_read,
                                 const set<int> &available_chunks,
-                                set<int> *minimum) {
+                                set<int> *minimum) override {
     if (includes(available_chunks.begin(), available_chunks.end(),
 		 want_to_read.begin(), want_to_read.end())) {
       *minimum = want_to_read;
@@ -88,7 +88,7 @@ public:
 	 i != c2c.end();
 	 ++i)
       available_chunks.insert(i->first);
-    return minimum_to_decode(want_to_read, available_chunks, minimum);
+    return _minimum_to_decode(want_to_read, available_chunks, minimum);
   }
 
   unsigned int get_chunk_count() const override {
@@ -144,9 +144,9 @@ public:
     return 0;
   }
 
-  int decode(const set<int> &want_to_read,
-                     const map<int, bufferlist> &chunks,
-                     map<int, bufferlist> *decoded) {
+  int _decode(const set<int> &want_to_read,
+	      const map<int, bufferlist> &chunks,
+	      map<int, bufferlist> *decoded) {
     //
     // All chunks have the same size
     //

--- a/src/test/erasure-code/TestErasureCodeExample.cc
+++ b/src/test/erasure-code/TestErasureCodeExample.cc
@@ -35,7 +35,7 @@ TEST(ErasureCodeExample, minimum_to_decode)
   want_to_read.insert(1);
   {
     set<int> minimum;
-    EXPECT_EQ(-EIO, example.minimum_to_decode(want_to_read,
+    EXPECT_EQ(-EIO, example._minimum_to_decode(want_to_read,
                                               available_chunks,
                                               &minimum));
   }
@@ -43,9 +43,9 @@ TEST(ErasureCodeExample, minimum_to_decode)
   available_chunks.insert(2);
   {
     set<int> minimum;
-    EXPECT_EQ(0, example.minimum_to_decode(want_to_read,
-                                           available_chunks,
-                                           &minimum));
+    EXPECT_EQ(0, example._minimum_to_decode(want_to_read,
+					    available_chunks,
+					    &minimum));
     EXPECT_EQ(available_chunks, minimum);
     EXPECT_EQ(2u, minimum.size());
     EXPECT_EQ(1u, minimum.count(0));
@@ -54,9 +54,9 @@ TEST(ErasureCodeExample, minimum_to_decode)
   {
     set<int> minimum;
     available_chunks.insert(1);
-    EXPECT_EQ(0, example.minimum_to_decode(want_to_read,
-                                           available_chunks,
-                                           &minimum));
+    EXPECT_EQ(0, example._minimum_to_decode(want_to_read,
+					    available_chunks,
+					    &minimum));
     EXPECT_EQ(1u, minimum.size());
     EXPECT_EQ(1u, minimum.count(1));
   }
@@ -132,9 +132,9 @@ TEST(ErasureCodeExample, encode_decode)
   {
     int want_to_decode[] = { 0, 1 };
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, example.decode(set<int>(want_to_decode, want_to_decode+2),
-                                encoded,
-                                &decoded));
+    EXPECT_EQ(0, example._decode(set<int>(want_to_decode, want_to_decode+2),
+				 encoded,
+				 &decoded));
     EXPECT_EQ(2u, decoded.size());
     EXPECT_EQ(3u, decoded[0].length());
     EXPECT_EQ('A', decoded[0][0]);
@@ -151,9 +151,9 @@ TEST(ErasureCodeExample, encode_decode)
     EXPECT_EQ(2u, degraded.size());
     int want_to_decode[] = { 0, 1 };
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, example.decode(set<int>(want_to_decode, want_to_decode+2),
-                                degraded,
-                                &decoded));
+    EXPECT_EQ(0, example._decode(set<int>(want_to_decode, want_to_decode+2),
+				 degraded,
+				 &decoded));
     EXPECT_EQ(2u, decoded.size());
     EXPECT_EQ(3u, decoded[0].length());
     EXPECT_EQ('A', decoded[0][0]);

--- a/src/test/erasure-code/TestErasureCodeIsa.cc
+++ b/src/test/erasure-code/TestErasureCodeIsa.cc
@@ -73,9 +73,9 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
   {
     int want_to_decode[] = {0, 1};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 2),
-                            encoded,
-                            &decoded));
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 2),
+			     encoded,
+			     &decoded));
     EXPECT_EQ(2u, decoded.size());
     EXPECT_EQ(chunk_size, decoded[0].length());
     compare_chunks(in, decoded);
@@ -91,9 +91,9 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
     EXPECT_EQ(3u, degraded.size());
     int want_to_decode[] = {1};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 1),
-                            degraded,
-                            &decoded));
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 1),
+			     degraded,
+			     &decoded));
     // always decode all, regardless of want_to_decode
     EXPECT_EQ(4u, decoded.size());
     EXPECT_EQ(chunk_size, decoded[1].length());
@@ -110,7 +110,7 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
     EXPECT_EQ(3u, degraded.size());
     int want_to_decode[] = {3};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 1),
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 1),
                             degraded,
                             &decoded));
     // always decode all, regardless of want_to_decode
@@ -129,9 +129,9 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
     EXPECT_EQ(3u, degraded.size());
     int want_to_decode[] = {2};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 1),
-                            degraded,
-                            &decoded));
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 1),
+			     degraded,
+			     &decoded));
     // always decode all, regardless of want_to_decode
     EXPECT_EQ(4u, decoded.size());
     EXPECT_EQ(chunk_size, decoded[2].length());
@@ -149,9 +149,9 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
     EXPECT_EQ(2u, degraded.size());
     int want_to_decode[] = {1, 3};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 2),
-                            degraded,
-                            &decoded));
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 2),
+			     degraded,
+			     &decoded));
     // always decode all, regardless of want_to_decode
     EXPECT_EQ(4u, decoded.size());
     EXPECT_EQ(chunk_size, decoded[1].length());
@@ -166,9 +166,9 @@ void IsaErasureCodeTest::encode_decode(unsigned object_size)
     EXPECT_EQ(2u, degraded.size());
     int want_to_decode[] = {0, 1};
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, Isa.decode(set<int>(want_to_decode, want_to_decode + 2),
-                            degraded,
-                            &decoded));
+    EXPECT_EQ(0, Isa._decode(set<int>(want_to_decode, want_to_decode + 2),
+			     degraded,
+			     &decoded));
     // always decode all, regardless of want_to_decode
     EXPECT_EQ(4u, decoded.size());
     EXPECT_EQ(chunk_size, decoded[0].length());
@@ -203,9 +203,9 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
     set<int> available_chunks;
     set<int> minimum;
 
-    EXPECT_EQ(0, Isa.minimum_to_decode(want_to_read,
-                                       available_chunks,
-                                       &minimum));
+    EXPECT_EQ(0, Isa._minimum_to_decode(want_to_read,
+					available_chunks,
+					&minimum));
     EXPECT_TRUE(minimum.empty());
   }
   //
@@ -218,9 +218,9 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
 
     want_to_read.insert(0);
 
-    EXPECT_EQ(-EIO, Isa.minimum_to_decode(want_to_read,
-                                          available_chunks,
-                                          &minimum));
+    EXPECT_EQ(-EIO, Isa._minimum_to_decode(want_to_read,
+					   available_chunks,
+					   &minimum));
   }
   //
   // Reading a subset of the available chunks is always possible.
@@ -233,9 +233,9 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
     want_to_read.insert(0);
     available_chunks.insert(0);
 
-    EXPECT_EQ(0, Isa.minimum_to_decode(want_to_read,
-                                       available_chunks,
-                                       &minimum));
+    EXPECT_EQ(0, Isa._minimum_to_decode(want_to_read,
+					available_chunks,
+					&minimum));
     EXPECT_EQ(want_to_read, minimum);
   }
   //
@@ -251,9 +251,9 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
     want_to_read.insert(1);
     available_chunks.insert(0);
 
-    EXPECT_EQ(-EIO, Isa.minimum_to_decode(want_to_read,
-                                          available_chunks,
-                                          &minimum));
+    EXPECT_EQ(-EIO, Isa._minimum_to_decode(want_to_read,
+					   available_chunks,
+					   &minimum));
   }
   //
   // When chunks are not available, the minimum can be made of any
@@ -275,9 +275,9 @@ TEST_F(IsaErasureCodeTest, minimum_to_decode)
     available_chunks.insert(2);
     available_chunks.insert(3);
 
-    EXPECT_EQ(0, Isa.minimum_to_decode(want_to_read,
-                                       available_chunks,
-                                       &minimum));
+    EXPECT_EQ(0, Isa._minimum_to_decode(want_to_read,
+					available_chunks,
+					&minimum));
     EXPECT_EQ(2u, minimum.size());
     EXPECT_EQ(0u, minimum.count(3));
   }
@@ -384,9 +384,9 @@ DecodeAndVerify(ErasureCodeIsaDefault& Isa, map<int, bufferlist> &degraded, set<
   bool ok;
 
   // decode as requested
-  ok = Isa.decode(want_to_decode,
-                  degraded,
-                  &decoded);
+  ok = Isa._decode(want_to_decode,
+		   degraded,
+		   &decoded);
 
   for (int i = 0; i < (int) decoded.size(); i++) {
     // compare all the buffers with their original

--- a/src/test/erasure-code/TestErasureCodeJerasure.cc
+++ b/src/test/erasure-code/TestErasureCodeJerasure.cc
@@ -98,9 +98,9 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
     {
       int want_to_decode[] = { 0, 1 };
       map<int, bufferlist> decoded;
-      EXPECT_EQ(0, jerasure.decode(set<int>(want_to_decode, want_to_decode+2),
-				   encoded,
-				   &decoded));
+      EXPECT_EQ(0, jerasure._decode(set<int>(want_to_decode, want_to_decode+2),
+				    encoded,
+				    &decoded));
       EXPECT_EQ(2u, decoded.size()); 
       EXPECT_EQ(length, decoded[0].length());
       EXPECT_EQ(0, memcmp(decoded[0].c_str(), in.c_str(), length));
@@ -116,9 +116,9 @@ TYPED_TEST(ErasureCodeTest, encode_decode)
       EXPECT_EQ(2u, degraded.size());
       int want_to_decode[] = { 0, 1 };
       map<int, bufferlist> decoded;
-      EXPECT_EQ(0, jerasure.decode(set<int>(want_to_decode, want_to_decode+2),
-				   degraded,
-				   &decoded));
+      EXPECT_EQ(0, jerasure._decode(set<int>(want_to_decode, want_to_decode+2),
+				    degraded,
+				    &decoded));
       // always decode all, regardless of want_to_decode
       EXPECT_EQ(4u, decoded.size()); 
       EXPECT_EQ(length, decoded[0].length());
@@ -147,9 +147,9 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
     set<int> available_chunks;
     set<int> minimum;
 
-    EXPECT_EQ(0, jerasure.minimum_to_decode(want_to_read,
-					    available_chunks,
-					    &minimum));
+    EXPECT_EQ(0, jerasure._minimum_to_decode(want_to_read,
+					     available_chunks,
+					     &minimum));
     EXPECT_TRUE(minimum.empty());
   }
   //
@@ -162,9 +162,9 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
 
     want_to_read.insert(0);
 
-    EXPECT_EQ(-EIO, jerasure.minimum_to_decode(want_to_read,
-					       available_chunks,
-					       &minimum));
+    EXPECT_EQ(-EIO, jerasure._minimum_to_decode(want_to_read,
+						available_chunks,
+						&minimum));
   }
   //
   // Reading a subset of the available chunks is always possible.
@@ -177,9 +177,9 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
     want_to_read.insert(0);
     available_chunks.insert(0);
 
-    EXPECT_EQ(0, jerasure.minimum_to_decode(want_to_read,
-					    available_chunks,
-					    &minimum));
+    EXPECT_EQ(0, jerasure._minimum_to_decode(want_to_read,
+					     available_chunks,
+					     &minimum));
     EXPECT_EQ(want_to_read, minimum);
   }
   //
@@ -195,9 +195,9 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
     want_to_read.insert(1);
     available_chunks.insert(0);
 
-    EXPECT_EQ(-EIO, jerasure.minimum_to_decode(want_to_read,
-					       available_chunks,
-					       &minimum));
+    EXPECT_EQ(-EIO, jerasure._minimum_to_decode(want_to_read,
+						available_chunks,
+						&minimum));
   }
   //
   // When chunks are not available, the minimum can be made of any
@@ -219,9 +219,9 @@ TYPED_TEST(ErasureCodeTest, minimum_to_decode)
     available_chunks.insert(2);
     available_chunks.insert(3);
 
-    EXPECT_EQ(0, jerasure.minimum_to_decode(want_to_read,
-					    available_chunks,
-					    &minimum));
+    EXPECT_EQ(0, jerasure._minimum_to_decode(want_to_read,
+					     available_chunks,
+					     &minimum));
     EXPECT_EQ(2u, minimum.size());
     EXPECT_EQ(0u, minimum.count(3));
   }

--- a/src/test/erasure-code/TestErasureCodeLrc.cc
+++ b/src/test/erasure-code/TestErasureCodeLrc.cc
@@ -469,7 +469,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
     available_chunks.insert(1);
     available_chunks.insert(2);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(want_to_read, minimum);
   }
   // locally repairable erasure
@@ -499,7 +499,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
 	available_chunks.insert(i);
       // _____DDDDc can recover c
       set<int> minimum;
-      EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+      EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
       set<int> expected_minimum;
       expected_minimum.insert(5);
       expected_minimum.insert(6);
@@ -514,7 +514,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       for (int i = 1; i < (int)lrc.get_chunk_count(); i++)
 	available_chunks.insert(i);
       set<int> minimum;
-      EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+      EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
       set<int> expected_minimum;
       expected_minimum.insert(2);
       expected_minimum.insert(3);
@@ -555,7 +555,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       // missing             (7)
       // missing             (8)
       set<int> minimum;
-      EXPECT_EQ(-EIO, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+      EXPECT_EQ(-EIO, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     }
     //
     // We want to read chunk 8 and encoding was done with
@@ -594,7 +594,7 @@ TEST(ErasureCodeLrc, minimum_to_decode)
       // missing             (7)
       // missing             (8)
       set<int> minimum;
-      EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+      EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
       EXPECT_EQ(available_chunks, minimum);
     }
   }
@@ -648,14 +648,14 @@ TEST(ErasureCodeLrc, encode_decode)
     available_chunks.insert(5);
     available_chunks.insert(6);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     // only need three chunks from the second local layer
     EXPECT_EQ(3U, minimum.size());
     EXPECT_EQ(1U, minimum.count(4));
     EXPECT_EQ(1U, minimum.count(5));
     EXPECT_EQ(1U, minimum.count(6));
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, chunks, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, chunks, &decoded));
     string s(chunk_size, 'D');
     EXPECT_EQ(s, string(decoded[7].c_str(), chunk_size));
   }
@@ -675,12 +675,12 @@ TEST(ErasureCodeLrc, encode_decode)
     available_chunks.insert(6);
     available_chunks.insert(7);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(5U, minimum.size());
     EXPECT_EQ(available_chunks, minimum);
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, encoded, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, encoded, &decoded));
     string s(chunk_size, 'A');
     EXPECT_EQ(s, string(decoded[2].c_str(), chunk_size));
   }
@@ -701,7 +701,7 @@ TEST(ErasureCodeLrc, encode_decode)
     encoded.erase(3);
     encoded.erase(6);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(4U, minimum.size());
     // only need two chunks from the first local layer
     EXPECT_EQ(1U, minimum.count(0));
@@ -714,7 +714,7 @@ TEST(ErasureCodeLrc, encode_decode)
     EXPECT_EQ(1U, minimum.count(5));
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, encoded, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, encoded, &decoded));
     {
       string s(chunk_size, 'B');
       EXPECT_EQ(s, string(decoded[3].c_str(), chunk_size));
@@ -784,7 +784,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     available_chunks.insert(6);
     available_chunks.insert(7);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(4U, minimum.size());
     EXPECT_EQ(1U, minimum.count(1));
     EXPECT_EQ(1U, minimum.count(4));
@@ -792,7 +792,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     EXPECT_EQ(1U, minimum.count(6));
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, chunks, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, chunks, &decoded));
     string s(chunk_size, 'A');
     EXPECT_EQ(s, string(decoded[0].c_str(), chunk_size));
   }
@@ -813,7 +813,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     available_chunks.insert(6);
     available_chunks.insert(7);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(5U, minimum.size());
     EXPECT_EQ(1U, minimum.count(1));
     EXPECT_EQ(1U, minimum.count(3));
@@ -822,7 +822,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     EXPECT_EQ(1U, minimum.count(7));
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, chunks, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, chunks, &decoded));
     {
       string s(chunk_size, 'A');
       EXPECT_EQ(s, string(decoded[0].c_str(), chunk_size));
@@ -857,7 +857,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     available_chunks.insert(6);
     available_chunks.insert(7);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(5U, minimum.size());
     EXPECT_EQ(1U, minimum.count(1));
     EXPECT_EQ(1U, minimum.count(3));
@@ -866,7 +866,7 @@ TEST(ErasureCodeLrc, encode_decode_2)
     EXPECT_EQ(1U, minimum.count(7));
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, chunks, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, chunks, &decoded));
     {
       string s(chunk_size, 'A');
       EXPECT_EQ(s, string(decoded[0].c_str(), chunk_size));
@@ -900,11 +900,11 @@ TEST(ErasureCodeLrc, encode_decode_2)
     available_chunks.insert(5);
     available_chunks.insert(7);
     set<int> minimum;
-    EXPECT_EQ(0, lrc.minimum_to_decode(want_to_read, available_chunks, &minimum));
+    EXPECT_EQ(0, lrc._minimum_to_decode(want_to_read, available_chunks, &minimum));
     EXPECT_EQ(available_chunks, minimum);
 
     map<int, bufferlist> decoded;
-    EXPECT_EQ(0, lrc.decode(want_to_read, chunks, &decoded));
+    EXPECT_EQ(0, lrc._decode(want_to_read, chunks, &decoded));
   }
 }
 

--- a/src/test/erasure-code/TestErasureCodeShec.cc
+++ b/src/test/erasure-code/TestErasureCodeShec.cc
@@ -977,8 +977,8 @@ TEST(ErasureCodeShec, minimum_to_decode_8)
     available_chunks.insert(i);
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
@@ -1013,8 +1013,8 @@ TEST(ErasureCodeShec, minimum_to_decode_9)
     available_chunks.insert(i);
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
@@ -1049,8 +1049,8 @@ TEST(ErasureCodeShec, minimum_to_decode_10)
     available_chunks.insert(i);
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_EQ(-EIO, r);
 
   delete shec;
@@ -1085,8 +1085,8 @@ TEST(ErasureCodeShec, minimum_to_decode_11)
     available_chunks.insert(i);
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_EQ(-EIO, r);
 
   delete shec;
@@ -1119,7 +1119,7 @@ TEST(ErasureCodeShec, minimum_to_decode_12)
     available_chunks.insert(i);
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks, NULL);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks, NULL);
   EXPECT_EQ(-EINVAL, r);
 
   delete shec;
@@ -1151,14 +1151,14 @@ TEST(ErasureCodeShec, minimum_to_decode_13)
     want_to_decode.insert(i);
     available_chunks.insert(i);
   }
-  shec->minimum_to_decode(want_to_decode, available_chunks, &minimum_chunks);
+  shec->_minimum_to_decode(want_to_decode, available_chunks, &minimum_chunks);
   minimum = minimum_chunks;		//normal value
   for (int i = 100; i < 120; ++i) {
     minimum_chunks.insert(i);	//insert extra data
   }
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(minimum, minimum_chunks);
@@ -1193,8 +1193,8 @@ TEST(ErasureCodeShec, minimum_to_decode2_1)
   available_chunks.insert(1);
   available_chunks.insert(2);
 
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_TRUE(minimum_chunks.size());
@@ -1239,8 +1239,8 @@ TEST(ErasureCodeShec, minimum_to_decode2_3)
   }
   sleep(1);
   printf("*** test start ***\n");
-  int r = shec->minimum_to_decode(want_to_decode, available_chunks,
-				  &minimum_chunks);
+  int r = shec->_minimum_to_decode(want_to_decode, available_chunks,
+				   &minimum_chunks);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(want_to_decode, minimum_chunks);
@@ -1375,10 +1375,10 @@ TEST(ErasureCodeShec, encode_1)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
   decoded.clear();
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2),
-		   encoded,
-		   &decoded);
-  EXPECT_TRUE(shec->matrix != NULL);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2),
+		    encoded,
+		    &decoded);
+  EXPECT_NE(nullptr, shec->matrix);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
   EXPECT_EQ(32u, decoded[0].length());
@@ -1434,8 +1434,8 @@ TEST(ErasureCodeShec, encode_2)
   //decode
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -1489,7 +1489,7 @@ TEST(ErasureCodeShec, encode_3)
   //decode
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
 		   &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
@@ -1548,8 +1548,8 @@ TEST(ErasureCodeShec, encode_4)
   //decode
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -1679,8 +1679,8 @@ TEST(ErasureCodeShec, encode2_1)
   //decode
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -1750,8 +1750,8 @@ TEST(ErasureCodeShec, encode2_3)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -1812,8 +1812,8 @@ TEST(ErasureCodeShec, decode_1)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
   map<int, bufferlist> decoded;
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(7u, decoded.size());
@@ -1878,8 +1878,8 @@ TEST(ErasureCodeShec, decode_8)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6, 7 }; //more than k+m
   map<int, bufferlist> decoded;
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 8), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 8), encoded,
+		    &decoded);
   EXPECT_EQ(0, r);
   EXPECT_EQ(7u, decoded.size());
   EXPECT_EQ(shec->get_chunk_size(in.length()), encoded[0].length());
@@ -1949,8 +1949,8 @@ TEST(ErasureCodeShec, decode_9)
   buf.append("abc");
   encoded[100] = buf;
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 10), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 10), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(7u, decoded.size());
@@ -2025,8 +2025,8 @@ TEST(ErasureCodeShec, decode_10)
     inchunks.insert(make_pair(i, encoded[i]));
   }
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 7), inchunks,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 7), inchunks,
+		    &decoded);
   EXPECT_EQ(-1, r);
 
   delete shec;
@@ -2075,8 +2075,8 @@ TEST(ErasureCodeShec, decode_11)
     inchunks.insert(make_pair(i, encoded[i]));
   }
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 5), inchunks,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 5), inchunks,
+		    &decoded);
   EXPECT_EQ(-1, r);
 
   delete shec;
@@ -2123,8 +2123,8 @@ TEST(ErasureCodeShec, decode_12)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6 };
 
   //decoded = NULL
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
-		   NULL);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
+		    NULL);
   EXPECT_NE(0, r);
 
   delete shec;
@@ -2178,8 +2178,8 @@ TEST(ErasureCodeShec, decode_13)
     decoded[i] = buf;
   }
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 7), encoded,
+		    &decoded);
   EXPECT_NE(0, r);
 
   delete shec;
@@ -2226,8 +2226,8 @@ TEST(ErasureCodeShec, decode2_1)
   int want_to_decode[] = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
   map<int, bufferlist> decoded;
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -2290,8 +2290,8 @@ TEST(ErasureCodeShec, decode2_3)
   }
   sleep(1);
   printf("*** test start ***\n");
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		    &decoded);
   EXPECT_TRUE(shec->matrix != NULL);
   EXPECT_EQ(0, r);
   EXPECT_EQ(2u, decoded.size());
@@ -2353,8 +2353,8 @@ TEST(ErasureCodeShec, decode2_4)
   map<int, bufferlist> degraded;
   degraded[0] = encoded[0];
 
-  r = shec->decode(set<int>(want_to_decode, want_to_decode + 2), degraded,
-		   &decoded);
+  r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2), degraded,
+		    &decoded);
   EXPECT_EQ(-1, r);
 
   delete shec;
@@ -2681,7 +2681,7 @@ void* thread1(void* pParam)
   printf("*** thread loop start ***\n");
   g_flag = 1;
   while (g_flag == 1) {
-    shec->minimum_to_decode(want_to_decode, available_chunks, &minimum_chunks);
+    shec->_minimum_to_decode(want_to_decode, available_chunks, &minimum_chunks);
   }
   printf("*** thread loop end ***\n");
 
@@ -2810,8 +2810,8 @@ void* thread5(void* pParam)
   printf("*** thread loop start ***\n");
   g_flag = 1;
   while (g_flag == 1) {
-    shec->decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
-		 &decoded);
+    shec->_decode(set<int>(want_to_decode, want_to_decode + 2), encoded,
+		  &decoded);
     decoded.clear();
   }
   printf("*** thread loop end ***\n");

--- a/src/test/erasure-code/TestErasureCodeShec_all.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_all.cc
@@ -122,8 +122,8 @@ TEST_P(ParameterTest, parameter_all)
 	}
       }
 
-      result = shec->minimum_to_decode(want_to_decode, available_chunks,
-				       &minimum_chunks);
+      result = shec->_minimum_to_decode(want_to_decode, available_chunks,
+					&minimum_chunks);
 
       if (result == 0){
 	EXPECT_EQ(0, result);
@@ -194,8 +194,8 @@ TEST_P(ParameterTest, parameter_all)
     want_to_decode2[i] = i;
   }
 
-  result = shec->decode(set<int>(want_to_decode2, want_to_decode2 + 2),
-			encoded, &decoded);
+  result = shec->_decode(set<int>(want_to_decode2, want_to_decode2 + 2),
+			 encoded, &decoded);
   EXPECT_EQ(0, result);
   EXPECT_EQ(2u, decoded.size());
   EXPECT_EQ(c_size, decoded[0].length());

--- a/src/test/erasure-code/TestErasureCodeShec_arguments.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_arguments.cc
@@ -230,7 +230,8 @@ TEST(ParameterTest, combination_all)
   }
   EXPECT_FALSE(out1 == in);
 
-  set<int> want_to_read, available_chunks, minimum_chunks, want_to_read_without_avails;
+  set<int> want_to_read, available_chunks, want_to_read_without_avails;
+  map<int, vector<pair<int,int>>> minimum_chunks;
   set<int>::iterator itr;
   int array_want_to_read[shec->get_chunk_count()];
   int array_available_chunks[shec->get_chunk_count()];
@@ -273,7 +274,8 @@ TEST(ParameterTest, combination_all)
 
           result = shec->minimum_to_decode(want_to_read, available_chunks,
 				           &minimum_chunks);
-          dresult = shec->decode(want_to_read, inchunks, &decoded);
+          dresult = shec->decode(want_to_read, inchunks, &decoded,
+				 shec->get_chunk_size(kObjectSize));
           ++count_num;
           minimum_count = 0;
 

--- a/src/test/erasure-code/TestErasureCodeShec_thread.cc
+++ b/src/test/erasure-code/TestErasureCodeShec_thread.cc
@@ -173,9 +173,9 @@ void* thread1(void* pParam)
     }
 
     //decode
-    r = shec->decode(set<int>(want_to_decode, want_to_decode + 2),
-		     encoded,
-		     &decoded);
+    r = shec->_decode(set<int>(want_to_decode, want_to_decode + 2),
+		      encoded,
+		      &decoded);
 
     EXPECT_EQ(0, r);
     EXPECT_EQ(2u, decoded.size());


### PR DESCRIPTION
after the arraycode change, the old encode() and minimum_to_decode() are
actually replaced by the new counterparts, and are only used by the
ErasureCode itself. so they can be marked `private`, and to avoid the
`-Woverloaded-virtual` warnings, because the new methods share the same
names with the old ones. an underscore is used as the prefix of the
internal methods.

Signed-off-by: Kefu Chai <kchai@redhat.com>