### PR TITLE
cephfs: Do not check auth gid when not specified

### DIFF
--- a/src/mds/MDSAuthCaps.cc
+++ b/src/mds/MDSAuthCaps.cc
@@ -116,19 +116,21 @@ bool MDSCapMatch::match(const std::string &target_path,
   if (uid != MDS_AUTH_UID_ANY) {
     if (uid != caller_uid)
       return false;
-    bool gid_matched = false;
-    if (std::find(gids.begin(), gids.end(), caller_gid) != gids.end())
-      gid_matched = true;
-    if (caller_gid_list) {
-      for (auto i = caller_gid_list->begin(); i != caller_gid_list->end(); ++i) {
-	if (std::find(gids.begin(), gids.end(), *i) != gids.end()) {
-	  gid_matched = true;
-	  break;
+    if (!gids.empty()) {
+      bool gid_matched = false;
+      if (std::find(gids.begin(), gids.end(), caller_gid) != gids.end())
+	gid_matched = true;
+      if (caller_gid_list) {
+	for (auto i = caller_gid_list->begin(); i != caller_gid_list->end(); ++i) {
+	  if (std::find(gids.begin(), gids.end(), *i) != gids.end()) {
+	    gid_matched = true;
+	    break;
+	  }
 	}
       }
+      if (!gid_matched)
+	return false;
     }
-    if (!gid_matched)
-      return false;
   }
 
   if (!match_path(target_path)) {

--- a/src/test/mds/TestMDSAuthCaps.cc
+++ b/src/test/mds/TestMDSAuthCaps.cc
@@ -116,6 +116,19 @@ TEST(MDSAuthCaps, AllowAll) {
 
 TEST(MDSAuthCaps, AllowUid) {
   MDSAuthCaps cap(g_ceph_context);
+  ASSERT_TRUE(cap.parse(g_ceph_context, "allow * uid=10", NULL));
+  ASSERT_FALSE(cap.allow_all());
+
+  // uid/gid must be valid
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 0, 0, NULL, MAY_READ, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 0, NULL, MAY_READ, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 10, NULL, MAY_READ, 0, 0));
+  ASSERT_FALSE(cap.is_capable("foo", 0, 0, 0777, 12, 12, NULL, MAY_READ, 0, 0));
+  ASSERT_TRUE(cap.is_capable("foo", 0, 0, 0777, 10, 13, NULL, MAY_READ, 0, 0));
+}
+
+TEST(MDSAuthCaps, AllowUidGid) {
+  MDSAuthCaps cap(g_ceph_context);
   ASSERT_TRUE(cap.parse(g_ceph_context, "allow * uid=10 gids=10,11,12; allow * uid=12 gids=12,10", NULL));
   ASSERT_FALSE(cap.allow_all());
 


### PR DESCRIPTION
For auth caps that omit the gid, do not check for a gid match.

Fixes: http://tracker.ceph.com/issues/22009
Signed-off-by: Douglas Fuller <dfuller@redhat.com>