### PR TITLE
osd/PrimaryLogPG: fix dup stat for async read

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -7445,7 +7445,8 @@ int PrimaryLogPG::prepare_transaction(OpContext *ctx)
 
   // read-op?  write-op noop? done?
   if (ctx->op_t->empty() && !ctx->modify) {
-    unstable_stats.add(ctx->delta_stats);
+    if (ctx->pending_async_reads.empty())
+      unstable_stats.add(ctx->delta_stats);
     if (ctx->op->may_write() &&
 	get_osdmap()->require_osd_release >= CEPH_RELEASE_KRAKEN) {
       ctx->update_log_only = true;


### PR DESCRIPTION
The async read would call do_osd_ops twice.

Signed-off-by: Xinze Chi <xinze@xsky.com>