### PR TITLE
os/filestore: disable rocksdb compression

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3749,7 +3749,7 @@ std::vector<Option> get_global_options() {
     // filestore
 
     Option("filestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_DEV)
-    .set_default("max_background_jobs=10,compaction_readahead_size=2097152")
+    .set_default("max_background_jobs=10,compaction_readahead_size=2097152,compression=kNoCompression")
     .set_description(""),
 
     Option("filestore_omap_backend", Option::TYPE_STR, Option::LEVEL_DEV)


### PR DESCRIPTION
Experience working with customer escalations suggests that disabling
compression improves performance, and the storage overhead is generally
not a concern for the metadata and omap data we are storing.

Signed-off-by: Sage Weil <sage@redhat.com>