### PR TITLE
doc: fix missing blank line

### DIFF
--- a/doc/radosgw/adminops.rst
+++ b/doc/radosgw/adminops.rst
@@ -436,7 +436,8 @@ If successful, the response contains the user information.
 :Type: Container
 
 ``tenant``
-:Description: The tenant which user is a part of
+
+:Description: The tenant which user is a part of.
 :Type: String
 :Parent: ``user``
 


### PR DESCRIPTION
Add missing blank line in `doc/radosgw/adminops.rst` : 


<img width="603" alt="error-format" src="https://user-images.githubusercontent.com/13533742/32403276-cc03c1de-c103-11e7-8bb5-953b40221dec.png">
