### PR TITLE
luminous: OSDMap cache assert on shutdown

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4212,6 +4212,10 @@ std::vector<Option> get_global_options() {
     Option("debug_deliberately_leak_memory", Option::TYPE_BOOL, Option::LEVEL_DEV)
     .set_default(false)
     .set_description(""),
+      
+    Option("debug_asserts_on_shutdown", Option::TYPE_BOOL,Option::LEVEL_DEV)
+    .set_default(false)
+    .set_description("Enable certain asserts to check for refcounting bugs on shutdown; see http://tracker.ceph.com/issues/21738"),
   });
 }
 

--- a/src/common/shared_cache.hpp
+++ b/src/common/shared_cache.hpp
@@ -105,7 +105,9 @@ public:
       lderr(cct) << "leaked refs:\n";
       dump_weak_refs(*_dout);
       *_dout << dendl;
-      assert(weak_refs.empty());
+      if (cct->_conf->get_val<bool>("debug_asserts_on_shutdown")) {
+	assert(weak_refs.empty());
+      }
     }
   }
 


### PR DESCRIPTION
http://tracker.ceph.com/issues/21785