### PR TITLE
osd/PG: revert approx size

### DIFF
--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -1547,11 +1547,10 @@ void PrimaryLogPG::calc_trim_to()
   eversion_t limit = MIN(
     min_last_complete_ondisk,
     pg_log.get_can_rollback_to());
-  size_t log_size = pg_log.get_log().log.size();
   if (limit != eversion_t() &&
       limit != pg_trim_to &&
-      log_size > target) {
-    size_t num_to_trim = log_size - target;
+      pg_log.get_log().approx_size() > target) {
+    size_t num_to_trim = pg_log.get_log().approx_size() - target;
     if (num_to_trim < cct->_conf->osd_pg_log_trim_min) {
       return;
     }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -711,7 +711,7 @@ void PrimaryLogPG::maybe_force_recovery()
 		  PG_STATE_BACKFILL_TOOFULL))
     return;
 
-  if (pg_log.get_log().log.size() <
+  if (pg_log.get_log().approx_size() <
       cct->_conf->osd_max_pg_log_entries *
         cct->_conf->osd_force_recovery_pg_log_entries_factor)
     return;

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -3597,6 +3597,10 @@ public:
     return head.version == 0 && head.epoch == 0;
   }
 
+  size_t approx_size() const {
+    return head.version - tail.version;
+  }
+
   static void filter_log(spg_t import_pgid, const OSDMap &curmap,
     const string &hit_set_namespace, const pg_log_t &in,
     pg_log_t &out, pg_log_t &reject);


### PR DESCRIPTION
http://tracker.ceph.com/issues/22654


This pull request is result of binary search on master branch to find why lately I got worse performance from incerta07.

I narrowed it to commit 024b5bcbf0259eeecba234cff882564947c3a525.

Test: 600s FIO/rbd 4K random write.

When enabled:
OSD0 consumed: 1h33:33
OSD1 consumed 1h38:49
FIO/rbd has iops: 29172

When it is reverted:
OSD0 consumed: 56:45
OSD1 consumed: 1h02:53
FIO/rbd has iops: 38344

It is possible that this change was a critical one, yet I am amazed by the scope in performance it caused.
