### PR TITLE
rgw: add rgw_zonegroup_quota_sync_enabled for user quota sync between zonegroups

### DIFF
--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1389,6 +1389,7 @@ OPTION(rgw_region_root_pool, OPT_STR)  // pool where all region info is stored
 OPTION(rgw_default_region_info_oid, OPT_STR)  // oid where default region info is stored
 OPTION(rgw_zonegroup, OPT_STR) // zone group name
 OPTION(rgw_zonegroup_root_pool, OPT_STR)  // pool where all zone group info is stored
+OPTION(rgw_zonegroup_quota_sync_enabled, OPT_BOOL) // sync quota between zonegroups
 OPTION(rgw_default_zonegroup_info_oid, OPT_STR)  // oid where default zone group info is stored
 OPTION(rgw_realm, OPT_STR) // realm name
 OPTION(rgw_realm_root_pool, OPT_STR)  // pool where all realm info is stored

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -4697,6 +4697,10 @@ std::vector<Option> get_rgw_options() {
     .set_default(".rgw.root")
     .set_description(""),
 
+    Option("rgw_zonegroup_quota_sync_enabled", Option::TYPE_BOOL, Option::LEVEL_ADVANCED)
+    .set_default(true)
+    .set_description(""),
+
     Option("rgw_default_zonegroup_info_oid", Option::TYPE_STR, Option::LEVEL_ADVANCED)
     .set_default("default.zonegroup")
     .set_description(""),

--- a/src/rgw/rgw_metadata.h
+++ b/src/rgw/rgw_metadata.h
@@ -57,7 +57,8 @@ public:
   enum sync_type_t {
     APPLY_ALWAYS,
     APPLY_UPDATES,
-    APPLY_NEWER
+    APPLY_NEWER,
+    APPLY_ALWAYS_EXCEPT_QUOTA
   };
   static bool string_to_sync_type(const string& sync_string,
                                   sync_type_t& type) {
@@ -67,6 +68,8 @@ public:
       type = APPLY_NEWER;
     else if (sync_string.compare("always") == 0)
       type = APPLY_ALWAYS;
+    else if (sync_string.compare("always-except-quota") == 0)
+      type = APPLY_ALWAYS_EXCEPT_QUOTA;
     else
       return false;
     return true;
@@ -112,6 +115,8 @@ protected:
 	return false;
       break;
     case APPLY_ALWAYS: //deliberate fall-thru -- we always apply!
+      break;
+    case APPLY_ALWAYS_EXCEPT_QUOTA:
     default: break;
     }
     return true;

--- a/src/rgw/rgw_user.cc
+++ b/src/rgw/rgw_user.cc
@@ -2731,6 +2731,11 @@ public:
       return STATUS_NO_APPLY;
     }
 
+    CephContext *cct = store->ctx();
+    if (sync_mode == RGWMetadataHandler::APPLY_ALWAYS_EXCEPT_QUOTA) {
+      uci.info.user_quota = old_info.user_quota;
+    }
+
     ret = rgw_store_user_info(store, uci.info, &old_info, &objv_tracker, mtime, false, pattrs);
     if (ret < 0) {
       return ret;


### PR DESCRIPTION
hi,
   when we set max-objects=100 and max-size=100 user quota in master zonegroup ,it will sync the user quota to slave zonegroup, the user can user n`*`100 max-objects and n`*`100  max-size which n stands for zonegroup numbers, i think it is better to set the user quota sync configurable.

Signed-off-by: yuliyang <yuliyang@cmss.chinamobile.com>