### PR TITLE
common/config.h: osd_pool_default_size must be larger than 1

### DIFF
--- a/src/common/config.h
+++ b/src/common/config.h
@@ -306,6 +306,7 @@ public:
   unsigned get_osd_pool_default_min_size() const {
     auto min_size = get_val<uint64_t>("osd_pool_default_min_size");
     auto size = get_val<uint64_t>("osd_pool_default_size");
+    assert(size > 1 && "osd_pool_default_size must be larger than 1");
     return min_size ? std::min(min_size, size) : (size - size / 2);
   }
 


### PR DESCRIPTION
In case that, if user sets `osd_pool_default_size` to 1 and `osd_pool_default_min_size` to 0, `get_osd_pool_default_min_size` returns 0.

Signed-off-by: Shinobu Kinjo <shinobu@redhat.com>