### PR TITLE
mon: dump servicemap along with MgrStatMonitor dump info

### DIFF
--- a/src/mon/MgrStatMonitor.h
+++ b/src/mon/MgrStatMonitor.h
@@ -60,7 +60,7 @@ public:
 
   void update_logger();
 
-  const ServiceMap& get_service_map() {
+  const ServiceMap& get_service_map() const {
     return service_map;
   }
 
@@ -83,6 +83,7 @@ public:
   }
   void dump_info(Formatter *f) const {
     digest.dump(f);
+    f->dump_object("servicemap", get_service_map());
   }
   void dump_fs_stats(stringstream *ss,
 		     Formatter *f,


### PR DESCRIPTION
`ceph report` contains more useful and detailed information for customizing cluster monitoring than `ceph status`, except not having serivcemap info, so dump it into `ceph report`.

Signed-off-by: Zhi Zhang <zhangz.david@outlook.com>