### PR TITLE
PG: fix name of WaitActingChange

### DIFF
--- a/src/osd/PG.cc
+++ b/src/osd/PG.cc
@@ -8018,7 +8018,7 @@ void PG::RecoveryState::GetLog::exit()
 /*------WaitActingChange--------*/
 PG::RecoveryState::WaitActingChange::WaitActingChange(my_context ctx)
   : my_base(ctx),
-    NamedState(context< RecoveryMachine >().pg, "Started/Primary/Peering/WaitActingChange")
+    NamedState(context< RecoveryMachine >().pg, "Started/Primary/WaitActingChange")
 {
   context< RecoveryMachine >().log_enter(state_name);
 }


### PR DESCRIPTION
the parent state of WaitActingChange is Primary, not Peering.

Signed-off-by: wumingqiao <wumingqiao@inspur.com>