### PR TITLE
mds: fix CDir::log_mark_dirty()

### DIFF
--- a/src/mds/CDir.cc
+++ b/src/mds/CDir.cc
@@ -1416,7 +1416,7 @@ void CDir::mark_clean()
 // caller should hold auth pin of this
 void CDir::log_mark_dirty()
 {
-  if (is_dirty() || is_projected())
+  if (is_dirty() || projected_version > get_version())
     return; // noop if it is already dirty or will be dirty
 
   version_t pv = pre_dirty();


### PR DESCRIPTION
the 'will dirty' check is wrong because we don't always project fnode.

Fixes: http://tracker.ceph.com/issues/21584
Signed-off-by: "Yan, Zheng" <zyan@redhat.com>