### PR TITLE
mon: NULL check of logger before use

### DIFF
--- a/src/mon/Monitor.cc
+++ b/src/mon/Monitor.cc
@@ -3832,8 +3832,7 @@ void Monitor::remove_all_sessions()
   while (!session_map.sessions.empty()) {
     MonSession *s = session_map.sessions.front();
     remove_session(s);
-    if (logger)
-      logger->inc(l_mon_session_rm);
+    logger->inc(l_mon_session_rm);
   }
   if (logger)
     logger->set(l_mon_num_sessions, session_map.get_size());


### PR DESCRIPTION
Fixes the coverity issue:
>CID 1316234 (#1 of 1): Dereference after null check (FORWARD_NULL)
6. var_deref_model: remove_session dereferences null this->logger

Signed-off-by: Amit Kumar <amitkuma@redhat.com>