### PR TITLE
doc: replace injectargs usage with "config set"

### DIFF
--- a/doc/dev/config.rst
+++ b/doc/dev/config.rst
@@ -12,7 +12,7 @@ How can the configuration be set? Well, there are several sources:
     --debug-ms=1
     --debug-pg=10
     etc.
- - arguments injected at runtime by using injectargs
+ - arguments injected at runtime using "injectargs" or "config set"
 
 
 The Configuration File

--- a/doc/rados/configuration/ceph-conf.rst
+++ b/doc/rados/configuration/ceph-conf.rst
@@ -430,19 +430,19 @@ useful for increasing/decreasing logging output, enabling/disabling debug
 settings, and even for runtime optimization. The following reflects runtime
 configuration usage::
 
-	ceph tell {daemon-type}.{id or *} injectargs --{name} {value} [--{name} {value}]
+	ceph tell {daemon-type}.{id or *} config set {name} {value}
 	
 Replace ``{daemon-type}`` with one of ``osd``, ``mon`` or ``mds``. You may apply
 the  runtime setting to all daemons of a particular type with ``*``, or specify
 a specific  daemon's ID (i.e., its number or letter). For example, to increase
 debug logging for a ``ceph-osd`` daemon named ``osd.0``, execute the following::
 
-	ceph tell osd.0 injectargs --debug-osd 20 --debug-ms 1
+	ceph tell osd.0 config set debug_osd 20
 
 In your ``ceph.conf`` file, you may use spaces when specifying a
 setting name.  When specifying a setting name on the command line,
 ensure that you use an underscore or hyphen (``_`` or ``-``) between
-terms (e.g., ``debug osd`` becomes ``--debug-osd``).
+terms (e.g., ``debug osd`` becomes ``debug_osd``).
 
 
 Viewing a Configuration at Runtime

--- a/doc/rados/operations/control.rst
+++ b/doc/rados/operations/control.rst
@@ -286,11 +286,11 @@ MDS Subsystem
 
 Change configuration parameters on a running mds. ::
 
-	ceph tell mds.{mds-id} injectargs --{switch} {value} [--{switch} {value}]
+	ceph tell mds.{mds-id} config set {setting} {value}
 
 Example::
 
-	ceph tell mds.0 injectargs --debug_ms 1 --debug_mds 10
+	ceph tell mds.0 config set debug_ms 1
 
 Enables debug messages. ::
 

--- a/doc/rados/operations/crush-map.rst
+++ b/doc/rados/operations/crush-map.rst
@@ -882,7 +882,7 @@ To make this warning go away, you have two options:
    For the change to take effect, you will need to restart the monitors, or
    apply the option to running monitors with::
 
-      ceph tell mon.\* injectargs --no-mon-warn-on-legacy-crush-tunables
+      ceph tell mon.\* config set mon_warn_on_legacy_crush_tunables false
 
 
 A few important points

--- a/doc/rados/operations/monitoring.rst
+++ b/doc/rados/operations/monitoring.rst
@@ -343,7 +343,7 @@ runtime. See `Viewing a Configuration at Runtime`_ for details.
 
 Additionally, you can set configuration values at runtime directly (i.e., the
 admin socket bypasses the monitor, unlike ``ceph tell {daemon-type}.{id}
-injectargs``, which relies on the monitor but doesn't require you to login
+config set``, which relies on the monitor but doesn't require you to login
 directly to the host in question ).
 
 .. _Viewing a Configuration at Runtime: ../../configuration/ceph-conf#ceph-runtime-config

--- a/doc/rados/troubleshooting/log-and-debug.rst
+++ b/doc/rados/troubleshooting/log-and-debug.rst
@@ -43,14 +43,14 @@ For example,::
 To activate Ceph's debugging output (*i.e.*, ``dout()``) at runtime,  use the
 ``ceph tell`` command to inject arguments into the runtime configuration:: 
 
-	ceph tell {daemon-type}.{daemon id or *} injectargs --{name} {value} [--{name} {value}]
+	ceph tell {daemon-type}.{daemon id or *} config set {name} {value}
 	
 Replace ``{daemon-type}`` with one of ``osd``, ``mon`` or ``mds``. You may apply
 the runtime setting to all daemons of a particular type with ``*``, or specify
 a specific daemon's ID. For example, to increase
 debug logging for a ``ceph-osd`` daemon named ``osd.0``, execute the following:: 
 
-	ceph tell osd.0 injectargs --debug-osd 0/5
+	ceph tell osd.0 config set debug_osd 0/5
 
 The ``ceph tell`` command goes through the monitors. If you cannot bind to the
 monitor, you can still make the change by logging into the host of the daemon

--- a/doc/rados/troubleshooting/troubleshooting-mon.rst
+++ b/doc/rados/troubleshooting/troubleshooting-mon.rst
@@ -521,11 +521,11 @@ You have quorum
 
   Either inject the debug option into the monitor you want to debug::
 
-        ceph tell mon.FOO injectargs --debug_mon 10/10
+        ceph tell mon.FOO config set debug_mon 10/10
 
   or into all monitors at once::
 
-        ceph tell mon.* injectargs --debug_mon 10/10
+        ceph tell mon.* config set debug_mon 10/10
 
 No quourm
 

--- a/doc/rbd/iscsi-requirements.rst
+++ b/doc/rbd/iscsi-requirements.rst
@@ -28,12 +28,12 @@ cluster::
 
    ::
 
-       ceph tell <daemon_type>.<id> injectargs '--<parameter_name> <new_value>'
+       ceph tell <daemon_type>.<id> config set <parameter_name> <new_value>
 
    ::
 
-       ceph tell osd.0 injectargs '--osd_heartbeat_grace 20'
-       ceph tell osd.0 injectargs '--osd_heartbeat_interval 5'
+       ceph tell osd.0 config set osd_heartbeat_grace 20
+       ceph tell osd.0 config set osd_heartbeat_interval 5
 
 -  Online Updating on the OSD Node
 


### PR DESCRIPTION
Cleaner and easier.  Also implicitly documents
the config set command, which hadn't been explicitly
called out in the docs before.

Signed-off-by: John Spray <john.spray@redhat.com>