### PR TITLE
rbd: null check before pool_name use

### DIFF
--- a/src/tools/rbd/Utils.cc
+++ b/src/tools/rbd/Utils.cc
@@ -442,7 +442,7 @@ int get_pool_image_snapshot_names(const po::variables_map &vm,
   //Validate pool name while creating/renaming/copying/cloning/importing/etc
   if (spec_validation == SPEC_VALIDATION_FULL) {
     boost::regex pattern("^[^@/]+?$");
-    if (!boost::regex_match (*pool_name, pattern)) {
+    if ((pool_name != nullptr) && !boost::regex_match (*pool_name, pattern)) {
       std::cerr << "rbd: invalid pool name '" << *pool_name << "'" << std::endl;
       return -EINVAL;
     }


### PR DESCRIPTION
Fixes the coverity issue:

CID 1394846 (#1 of 1): Dereference after null check (FORWARD_NULL)
>15. var_deref_model: Passing null pointer pool_name to regex_match,
which dereferences it.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>