### PR TITLE
osd: collect SMART data from all physical devices

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -1606,6 +1606,15 @@ std::vector<Option> get_global_options() {
     .set_default(true)
     .set_description(""),
 
+    Option("osd_smart_report_interval", Option::TYPE_FLOAT, Option::LEVEL_ADVANCED)
+    //.set_default(86400) // change back when finished!!
+    .set_default(0)
+    .set_description("Frequency (in seconds) for OSD to run smarctl, default is set to 86400"),
+
+    Option("osd_smart_report_timeout", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
+    .set_default(5)
+    .set_description("Timeout (in seconds) for smarctl to run, default is set to 5"),
+
     Option("osd_max_backfills", Option::TYPE_UINT, Option::LEVEL_ADVANCED)
     .set_default(1)
     .set_description(""),

--- a/src/osd/OSD.h
+++ b/src/osd/OSD.h
@@ -1285,6 +1285,7 @@ private:
   void write_superblock();
   void write_superblock(ObjectStore::Transaction& t);
   int read_superblock();
+  int probe_smart(const char *device, int timeout);
 
   void clear_temp_objects();
 

--- a/src/osd/osd_types.cc
+++ b/src/osd/osd_types.cc
@@ -4549,7 +4549,7 @@ void pg_hit_set_history_t::generate_test_instances(list<pg_hit_set_history_t*>& 
 
 void OSDSuperblock::encode(bufferlist &bl) const
 {
-  ENCODE_START(8, 5, bl);
+  ENCODE_START(9, 5, bl);
   ::encode(cluster_fsid, bl);
   ::encode(whoami, bl);
   ::encode(current_epoch, bl);
@@ -4562,12 +4562,13 @@ void OSDSuperblock::encode(bufferlist &bl) const
   ::encode(osd_fsid, bl);
   ::encode((epoch_t)0, bl);  // epoch_t last_epoch_marked_full
   ::encode((uint32_t)0, bl);  // map<int64_t,epoch_t> pool_last_epoch_marked_full
+  ::encode(last_smart_report, bl);
   ENCODE_FINISH(bl);
 }
 
 void OSDSuperblock::decode(bufferlist::iterator &bl)
 {
-  DECODE_START_LEGACY_COMPAT_LEN(8, 5, 5, bl);
+  DECODE_START_LEGACY_COMPAT_LEN(9, 5, 5, bl);
   if (struct_v < 3) {
     string magic;
     ::decode(magic, bl);
@@ -4595,6 +4596,8 @@ void OSDSuperblock::decode(bufferlist::iterator &bl)
     map<int64_t,epoch_t> pool_last_map_marked_full;
     ::decode(pool_last_map_marked_full, bl);
   }
+  if (struct_v >= 9)
+    ::decode(last_smart_report, bl); 
   DECODE_FINISH(bl);
 }
 
@@ -4612,6 +4615,7 @@ void OSDSuperblock::dump(Formatter *f) const
   f->close_section();
   f->dump_int("clean_thru", clean_thru);
   f->dump_int("last_epoch_mounted", mounted);
+  f->dump_int("last_smart_report", last_smart_report);
 }
 
 void OSDSuperblock::generate_test_instances(list<OSDSuperblock*>& o)

--- a/src/osd/osd_types.h
+++ b/src/osd/osd_types.h
@@ -4392,6 +4392,8 @@ public:
   epoch_t mounted;     // last epoch i mounted
   epoch_t clean_thru;  // epoch i was active and clean thru
 
+  utime_t last_smart_report; // when i last ran smartctl 
+
   OSDSuperblock() : 
     whoami(-1), 
     current_epoch(0), oldest_map(0), newest_map(0), weight(0),


### PR DESCRIPTION
SMART data collection is done by running smartctl via a SubProcessTimed object. It's controlled by two options in common/options.cc: osd_smart_report_interval (default will be 24h) and osd_smart_report_timeout (default is 5s). All devices which start with 'dm-*' are ignored. Still need to handle RAID cases: currently smartctl will be called for each of the devices.
We expect smartctl output to be in a JSON format. Currently the data retrieved is not saved or sent anywhere.

Signed-of-by: Yaarit Hatuka <yaarithatuka@gmail.com>