### PR TITLE
qa/tasks/cram: include /usr/sbin in the PATH for all commands

### DIFF
--- a/qa/tasks/cram.py
+++ b/qa/tasks/cram.py
@@ -144,6 +144,7 @@ def _run_tests(ctx, role):
         args=[
             run.Raw('CEPH_REF={ref}'.format(ref=ceph_ref)),
             run.Raw('CEPH_ID="{id}"'.format(id=id_)),
+            run.Raw('PATH=$PATH:/usr/sbin'),
             'adjust-ulimits',
             'ceph-coverage',
             '{tdir}/archive/coverage'.format(tdir=testdir),


### PR DESCRIPTION
/usr/sbin is not in non-login PATH on centos.  We already do this for
workunits, see commit 0e53f5f38b0c ("workunit: include /usr/sbin in the
PATH for all commands").

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>