### PR TITLE
qa/suites/krbd: enable generic/050 and generic/448

### DIFF
--- a/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
+++ b/qa/suites/krbd/singleton/tasks/rbd_xfstests.yaml
@@ -26,11 +26,9 @@ tasks:
         - generic/046
         - generic/223
         - ext4/304
-        - generic/050  # krbd BLKROSET bug
         - generic/388
         - generic/405
         - generic/422
-        - generic/448
         - shared/298  # lockdep false positive
         randomize: true
     client.1:


### PR DESCRIPTION
generic/448 has been failing on ext4 and is now fixed upstream.
The fix for generic/050 is in testing, scheduled for 4.15-rc1.

Signed-off-by: Ilya Dryomov <idryomov@gmail.com>