### PR TITLE
 common: add for_each_substr() for cheap string split

### DIFF
--- a/src/common/str_list.cc
+++ b/src/common/str_list.cc
@@ -18,48 +18,20 @@ using std::string;
 using std::vector;
 using std::set;
 using std::list;
-
-static bool get_next_token(const string &s, size_t& pos, const char *delims, string& token)
-{
-  int start = s.find_first_not_of(delims, pos);
-  int end;
-
-  if (start < 0){
-    pos = s.size();
-    return false;
-  }
-
-  end = s.find_first_of(delims, start);
-  if (end >= 0)
-    pos = end + 1;
-  else {
-    pos = end = s.size();
-  }
-
-  token = s.substr(start, end - start);
-  return true;
-}
+using ceph::for_each_substr;
 
 void get_str_list(const string& str, const char *delims, list<string>& str_list)
 {
-  size_t pos = 0;
-  string token;
-
   str_list.clear();
-
-  while (pos < str.size()) {
-    if (get_next_token(str, pos, delims, token)) {
-      if (token.size() > 0) {
-        str_list.push_back(token);
-      }
-    }
-  }
+  for_each_substr(str, delims, [&str_list] (boost::string_view token) {
+      str_list.emplace_back(token.begin(), token.end());
+    });
 }
 
 void get_str_list(const string& str, list<string>& str_list)
 {
   const char *delims = ";,= \t";
-  return get_str_list(str, delims, str_list);
+  get_str_list(str, delims, str_list);
 }
 
 list<string> get_str_list(const string& str, const char *delims)
@@ -71,23 +43,16 @@ list<string> get_str_list(const string& str, const char *delims)
 
 void get_str_vec(const string& str, const char *delims, vector<string>& str_vec)
 {
-  size_t pos = 0;
-  string token;
   str_vec.clear();
-
-  while (pos < str.size()) {
-    if (get_next_token(str, pos, delims, token)) {
-      if (token.size() > 0) {
-        str_vec.push_back(token);
-      }
-    }
-  }
+  for_each_substr(str, delims, [&str_vec] (boost::string_view token) {
+      str_vec.emplace_back(token.begin(), token.end());
+    });
 }
 
 void get_str_vec(const string& str, vector<string>& str_vec)
 {
   const char *delims = ";,= \t";
-  return get_str_vec(str, delims, str_vec);
+  get_str_vec(str, delims, str_vec);
 }
 
 vector<string> get_str_vec(const string& str, const char *delims)
@@ -99,24 +64,16 @@ vector<string> get_str_vec(const string& str, const char *delims)
 
 void get_str_set(const string& str, const char *delims, set<string>& str_set)
 {
-  size_t pos = 0;
-  string token;
-
   str_set.clear();
-
-  while (pos < str.size()) {
-    if (get_next_token(str, pos, delims, token)) {
-      if (token.size() > 0) {
-        str_set.insert(token);
-      }
-    }
-  }
+  for_each_substr(str, delims, [&str_set] (boost::string_view token) {
+      str_set.emplace(token.begin(), token.end());
+    });
 }
 
 void get_str_set(const string& str, set<string>& str_set)
 {
   const char *delims = ";,= \t";
-  return get_str_set(str, delims, str_set);
+  get_str_set(str, delims, str_set);
 }
 
 set<string> get_str_set(const string& str, const char *delims)

--- a/src/common/str_list.cc
+++ b/src/common/str_list.cc
@@ -62,6 +62,13 @@ void get_str_list(const string& str, list<string>& str_list)
   return get_str_list(str, delims, str_list);
 }
 
+list<string> get_str_list(const string& str, const char *delims)
+{
+  list<string> result;
+  get_str_list(str, delims, result);
+  return result;
+}
+
 void get_str_vec(const string& str, const char *delims, vector<string>& str_vec)
 {
   size_t pos = 0;
@@ -81,6 +88,13 @@ void get_str_vec(const string& str, vector<string>& str_vec)
 {
   const char *delims = ";,= \t";
   return get_str_vec(str, delims, str_vec);
+}
+
+vector<string> get_str_vec(const string& str, const char *delims)
+{
+  vector<string> result;
+  get_str_vec(str, delims, result);
+  return result;
 }
 
 void get_str_set(const string& str, const char *delims, set<string>& str_set)
@@ -103,4 +117,11 @@ void get_str_set(const string& str, set<string>& str_set)
 {
   const char *delims = ";,= \t";
   return get_str_set(str, delims, str_set);
+}
+
+set<string> get_str_set(const string& str, const char *delims)
+{
+  set<string> result;
+  get_str_set(str, delims, result);
+  return result;
 }

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -26,6 +26,9 @@ extern void get_str_list(const std::string& str,
                          const char *delims,
 			 std::list<std::string>& str_list);
 
+std::list<std::string> get_str_list(const std::string& str,
+                                    const char *delims = ";,= \t");
+
 /**
  * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_vec**.
  * 
@@ -46,6 +49,8 @@ extern void get_str_vec(const std::string& str,
                          const char *delims,
 			 std::vector<std::string>& str_vec);
 
+std::vector<std::string> get_str_vec(const std::string& str,
+                                     const char *delims = ";,= \t");
 /**
  * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_list**.
  * 
@@ -65,6 +70,9 @@ extern void get_str_set(const std::string& str,
 extern void get_str_set(const std::string& str,
                         const char *delims,
 			std::set<std::string>& str_list);
+
+std::set<std::string> get_str_set(const std::string& str,
+                                  const char *delims = ";,= \t");
 
 /**
  * Return a String containing the vector **v** joined with **sep**
@@ -88,14 +96,6 @@ inline std::string str_join(const std::vector<std::string>& v, const std::string
     r += *i;
   }
   return r;
-}
-
-static inline std::vector<std::string> get_str_vec(const std::string& str)
-{
-  std::vector<std::string> str_vec;
-  const char *delims = ";,= \t";
-  get_str_vec(str, delims, str_vec);
-  return str_vec;
 }
 
 #endif

--- a/src/include/str_list.h
+++ b/src/include/str_list.h
@@ -5,6 +5,26 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <boost/utility/string_view.hpp>
+
+
+namespace ceph {
+
+/// Split a string using the given delimiters, passing each piece as a
+/// (non-null-terminated) boost::string_view to the callback.
+template <typename Func> // where Func(boost::string_view) is a valid call
+void for_each_substr(boost::string_view s, const char *delims, Func&& f)
+{
+  auto pos = s.find_first_not_of(delims);
+  while (pos != s.npos) {
+    s.remove_prefix(pos); // trim delims from the front
+    auto end = s.find_first_of(delims);
+    f(s.substr(0, end));
+    pos = s.find_first_not_of(delims, end);
+  }
+}
+
+} // namespace ceph
 
 /**
  * Split **str** into a list of strings, using the ";,= \t" delimiters and output the result in **str_list**.


### PR DESCRIPTION
adds a new templated `for_each_substr()` function for string split:
* using `boost::string_view` avoids copies (and potential allocation) of the substrings
* using a callback model avoids baking in the container type, along with the copies and allocations required for insertion
* this interface is ideal for cases where you just want to iterate over the substrings, and don't actually need to store them in a container

example usage:
```c++
const char* input = "a b c d e f";
ceph::for_each_substr(input, " ",
  [] (boost::string_view s) {
    std::cout << "token: " << s << std::endl;
  });
```

by reimplementing `get_str_list()` and `get_str_vec()` in terms of `for_each_substr()`, benchmark results show a speedup of ~30% (where the `Small` variants use tokens small enough for the small string optimization)

before:
```
Benchmark                          Time           CPU Iterations
-----------------------------------------------------------------
BenchStrList/SmallStrList        882 ns        880 ns     749334
BenchStrList/LargeStrList       2015 ns       2012 ns     345552
BenchStrVec/SmallStrVec          600 ns        599 ns    1146149
BenchStrVec/LargeStrVec         1813 ns       1810 ns     381603
```
after:
```
Benchmark                          Time           CPU Iterations    [Speedup]
-----------------------------------------------------------------
BenchStrList/SmallStrList        650 ns        648 ns     929445    1.35
BenchStrList/LargeStrList       1498 ns       1495 ns     441588    1.35
BenchStrVec/SmallStrVec          445 ns        444 ns    1520766    1.34
BenchStrVec/LargeStrVec         1419 ns       1416 ns     462015    1.27
```

(this pr adds a submodule for the google benchmark library, https://github.com/google/benchmark. we don't necessarily need to merge that or the benchmark itself)