### PR TITLE
osdc/Objecter: record correctly value for l_osdc_op_send_bytes.

### DIFF
--- a/src/osdc/Objecter.cc
+++ b/src/osdc/Objecter.cc
@@ -3168,7 +3168,11 @@ MOSDOp *Objecter::_prepare_osd_op(Op *op)
   }
 
   logger->inc(l_osdc_op_send);
-  logger->inc(l_osdc_op_send_bytes, m->get_data().length());
+  ssize_t sum = 0;
+  for (unsigned i = 0; i < m->ops.size(); i++) {
+    sum += m->ops[i].indata.length();
+  }
+  logger->inc(l_osdc_op_send_bytes, sum);
 
   return m;
 }


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21982
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>