### PR TITLE
common: Check this->data.op_size before use

### DIFF
--- a/src/common/obj_bencher.cc
+++ b/src/common/obj_bencher.cc
@@ -525,10 +525,12 @@ int ObjBencher::write_bench(int secondsToRun,
     lock.Lock();
     ++data.started;
     ++data.in_flight;
-    if (max_objects &&
-	data.started >= (int)((data.object_size * max_objects + data.op_size - 1) /
-			     data.op_size))
-      break;
+    if (data.op_size) {
+      if (max_objects &&
+	  data.started >= (int)((data.object_size * max_objects + data.op_size - 1) /
+			       data.op_size))
+        break;
+    }
   }
   lock.Unlock();
 


### PR DESCRIPTION
Fixes the coverity issue:
CID 1394853 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
>29. divide_by_zero: In expression (this->data.object_size * max_objects
>+ this->data.op_size - 1UL) / this->data.op_size, division by expression
>this->data.op_size which may be zero has undefined behavior.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>