### PR TITLE
rgw cleanup: some unnecessary function called and repeated assignment

### DIFF
--- a/src/rgw/rgw_admin.cc
+++ b/src/rgw/rgw_admin.cc
@@ -4139,13 +4139,17 @@ int main(int argc, const char **argv)
           need_zone_update = true;
         }
 
-        for (auto add : tier_config_add) {
-          zone.tier_config[add.first] = add.second;
+        if (tier_config_add.size() > 0) {
+          for (auto add : tier_config_add) {
+            zone.tier_config[add.first] = add.second;
+          }
           need_zone_update = true;
         }
 
-        for (auto rm : tier_config_rm) {
-          zone.tier_config.erase(rm.first);
+        if (tier_config_rm.size() > 0) {
+          for (auto rm : tier_config_rm) {
+            zone.tier_config.erase(rm.first);
+          }
           need_zone_update = true;
         }
 

--- a/src/rgw/rgw_rados.cc
+++ b/src/rgw/rgw_rados.cc
@@ -374,18 +374,18 @@ int RGWZoneGroup::add_zone(const RGWZoneParams& zone_params, bool *is_master, bo
 
   if (is_master) {
     if (*is_master) {
-      if (!master_zone.empty() && master_zone != zone_params.get_id()) {
+      if (!master_zone.empty() && master_zone != zone_id) {
         ldout(cct, 0) << "NOTICE: overriding master zone: " << master_zone << dendl;
       }
-      master_zone = zone_params.get_id();
-    } else if (master_zone == zone_params.get_id()) {
+      master_zone = zone_id;
+    } else if (master_zone == zone_id) {
       master_zone.clear();
     }
   }
 
-  RGWZone& zone = zones[zone_params.get_id()];
-  zone.name = zone_params.get_name();
-  zone.id = zone_params.get_id();
+  RGWZone& zone = zones[zone_id];
+  zone.name = zone_name;
+  zone.id = zone_id;
   if (!endpoints.empty()) {
     zone.endpoints = endpoints;
   }


### PR DESCRIPTION
When I go through the code I notice that there are some unnecessary function called in RGWZoneGroup::add_zone. What's more, in zone modify command, the `need_zone_update ` is
assigned repeatedly in for loop.

Signed-off-by: Enming Zhang <enming.zhang@umcloud.com>