### PR TITLE
libceph: Avoiding divide by zero

### DIFF
--- a/src/client/Client.cc
+++ b/src/client/Client.cc
@@ -12292,9 +12292,12 @@ int Client::ll_get_stripe_osd(Inode *in, uint64_t blockno,
   uint32_t su = layout->stripe_unit;
   uint32_t stripe_count = layout->stripe_count;
   uint64_t stripes_per_object = object_size / su;
+  uint64_t stripeno = 0, stripepos = 0;
 
-  uint64_t stripeno = blockno / stripe_count;    // which horizontal stripe        (Y)
-  uint64_t stripepos = blockno % stripe_count;   // which object in the object set (X)
+  if(stripe_count) {
+      stripeno = blockno / stripe_count;    // which horizontal stripe        (Y)
+      stripepos = blockno % stripe_count;   // which object in the object set (X)
+  }
   uint64_t objectsetno = stripeno / stripes_per_object;       // which object set
   uint64_t objectno = objectsetno * stripe_count + stripepos;  // object id
 


### PR DESCRIPTION
Fixes the coverity issue:
CID 1405270 (#1 of 1): Division or modulo by zero (DIVIDE_BY_ZERO)
>2. divide_by_zero: In function call ll_get_stripe_osd,
>division by expression l.stripe_count which may be zero has
>undefined behavior.

Signed-off-by: Amit Kumar <amitkuma@redhat.com>