### PR TITLE
qa/suite/rados: fix balancer vs firefly tunables failures

### DIFF
--- a/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
+++ b/qa/suites/rados/thrash/workloads/cache-agent-small.yaml
@@ -1,6 +1,5 @@
 overrides:
   ceph:
-    crush_tunables: firefly
     log-whitelist:
       - must scrub before tier agent can activate
 tasks:

--- a/src/pybind/mgr/balancer/module.py
+++ b/src/pybind/mgr/balancer/module.py
@@ -656,6 +656,8 @@ class Module(MgrModule):
 
         # get current compat weight-set weights
         orig_ws = self.get_compat_weight_set_weights()
+        if orig_ws is None:
+            return False
         orig_ws = { a: b for a, b in orig_ws.iteritems() if a >= 0 }
 
         # Make sure roots don't overlap their devices.  If so, we


### PR DESCRIPTION
The crush-compat balancer mode requires straw2 buckets, so we can't test it
against firefly crush tunables.