### PR TITLE
os/bluestore: enlarege aligned_size avoid too many vector(> IOV_MAX)

### DIFF
--- a/src/common/buffer.cc
+++ b/src/common/buffer.cc
@@ -1756,9 +1756,15 @@ public:
   }
   
   bool buffer::list::rebuild_aligned_size_and_memory(unsigned align_size,
-  						   unsigned align_memory)
+						    unsigned align_memory,
+						    unsigned max_buffers)
   {
     unsigned old_memcopy_count = _memcopy_count;
+
+    if (max_buffers && _buffers.size() > max_buffers
+	&& _len > (max_buffers * align_size)) {
+      align_size = ROUND_UP_TO(ROUND_UP_TO(_len, max_buffers) / max_buffers, align_size);
+    }
     std::list<ptr>::iterator p = _buffers.begin();
     while (p != _buffers.end()) {
       // keep anything that's already align and sized aligned

--- a/src/include/buffer.h
+++ b/src/include/buffer.h
@@ -780,8 +780,11 @@ namespace buffer CEPH_BUFFER_API {
     void rebuild();
     void rebuild(ptr& nb);
     bool rebuild_aligned(unsigned align);
+    // max_buffers = 0 mean don't care _buffers.size(), other
+    // must make _buffers.size() <= max_buffers after rebuilding.
     bool rebuild_aligned_size_and_memory(unsigned align_size,
-					 unsigned align_memory);
+					 unsigned align_memory,
+					 unsigned max_buffers = 0);
     bool rebuild_page_aligned();
 
     void reserve(size_t prealloc);

--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -593,7 +593,7 @@ int KernelDevice::write(
   assert(is_valid_io(off, len));
 
   if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size)) {
+      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
   dout(40) << "data: ";
@@ -620,7 +620,7 @@ int KernelDevice::aio_write(
   assert(off + len <= size);
 
   if ((!buffered || bl.get_num_buffers() >= IOV_MAX) &&
-      bl.rebuild_aligned_size_and_memory(block_size, block_size)) {
+      bl.rebuild_aligned_size_and_memory(block_size, block_size, IOV_MAX)) {
     dout(20) << __func__ << " rebuilding buffer to be aligned" << dendl;
   }
   dout(40) << "data: ";


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/21932
Signed-off-by: Jianpeng Ma <jianpeng.ma@intel.com>