### PR TITLE
ceph.in: pass RADOS inst to LibCephFS

### DIFF
--- a/src/pybind/ceph_argparse.py
+++ b/src/pybind/ceph_argparse.py
@@ -1284,9 +1284,7 @@ def send_command(cluster, target=('mon', ''), cmd=None, inbuf=b'', timeout=0,
             except ImportError:
                 raise RuntimeError("CephFS unavailable, have you installed libcephfs?")
 
-            filesystem = LibCephFS(cluster.conf_defaults, cluster.conffile)
-            filesystem.conf_parse_argv(cluster.parsed_args)
-
+            filesystem = LibCephFS(rados_inst=cluster)
             filesystem.init()
             ret, outbuf, outs = \
                 filesystem.mds_command(mds_spec, cmd, inbuf)


### PR DESCRIPTION
This avoids multiple instances of the admin socket and other redundancies.

Fixes: http://tracker.ceph.com/issues/21967
Fixes: http://tracker.ceph.com/issues/21406

Signed-off-by: Patrick Donnelly <pdonnell@redhat.com>
(cherry picked from commit 76a950b2ec473741ed3cffca5c198e8c56f32a1c)