### PR TITLE
cmake: warn if libstdc++ older than 5.1.0 is used

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -166,6 +166,21 @@ else()
   set(C_STANDARD_REQUIRED ON)
 endif()
 
+include(CheckCXXSourceCompiles)
+CHECK_CXX_SOURCE_COMPILES("
+int main() {
+#ifdef __GLIBCXX__
+#if __GLIBCXX__ < 20150422ul /* libstdc++ < 5.1.0 */
+#error libstdc++ < 5.1.0 does not confirm to C++11
+#endif
+#endif
+}
+" HAVE_SANE_GLIBCXX)
+if(NOT HAVE_SANE_GLIBCXX)
+  # libstdc++ 4.9 has O(n) list::size(), and its regex is buggy
+  message(WARNING "performance regression is expected due to an O(n) implementation of 'std::list::size()' in libstdc++ older than 5.1.0")
+endif()
+
 ## Handle diagnostics color if compiler supports them.
 CHECK_C_COMPILER_FLAG("-fdiagnostics-color=always"
   COMPILER_SUPPORTS_DIAGNOSTICS_COLOR)


### PR DESCRIPTION
`__GLIBCPP__` is used before 3.4.0, and gcc 4.8.0 and up is required to
build c++11 source, hence it's safe to check `__GLIBCXX__`. for the
versioning of libstdc++, see
https://gcc.gnu.org/onlinedocs/libstdc++/manual/abi.html#abi.versioning,
for the magic number of 20150422ul see
https://gcc.gnu.org/develop.html#timeline.
for the reason why we want to have this warning, see
https://github.com/ceph/ceph/pull/18755#issuecomment-342736554 .

Signed-off-by: Kefu Chai <kchai@redhat.com>