### PR TITLE
jewel: common/config: set rocksdb_cache_size to OPT_U64

### DIFF
--- a/src/common/config_opts.h
+++ b/src/common/config_opts.h
@@ -857,7 +857,7 @@ OPTION(kinetic_use_ssl, OPT_BOOL, false) // whether to secure kinetic traffic wi
 OPTION(rocksdb_separate_wal_dir, OPT_BOOL, false) // use $path.wal for wal
 OPTION(rocksdb_db_paths, OPT_STR, "")   // path,size( path,size)*
 OPTION(rocksdb_log_to_ceph_log, OPT_BOOL, true)  // log to ceph log
-OPTION(rocksdb_cache_size, OPT_INT, 128*1024*1024)  // default leveldb cache size
+OPTION(rocksdb_cache_size, OPT_U64, 128*1024*1024)  // default rocksdb cache size
 OPTION(rocksdb_block_size, OPT_INT, 4*1024)  // default rocksdb block size
 // rocksdb options that will be used for omap(if omap_backend is rocksdb)
 OPTION(filestore_rocksdb_options, OPT_STR, "")


### PR DESCRIPTION
backport tracker: http://tracker.ceph.com/issues/22104

jewel: common/config: set rocksdb_cache_size to OPT_U64
OPT_INT is not enough for abundant RAM.

Signed-off-by: liuhongtong <hongtong.liu@istuary.com>
Signed-off-by: Vikhyat Umrao <vumrao@redhat.com>

 Conflicts:
	src/common/config_opts.h
        Removed master branch rocksdb options which are not
        part of this backport.