### PR TITLE
rgw: data sync: set num_shards when building full maps

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -1568,6 +1568,7 @@ public:
       if  ((rgw_data_sync_info::SyncState)sync_status.sync_info.state == rgw_data_sync_info::StateBuildingFullSyncMaps) {
         tn->log(10, SSTR("building full sync maps"));
         /* call sync module init here */
+        sync_status.sync_info.num_shards = num_shards;
         yield call(data_sync_module->init_sync(sync_env));
         if (retcode < 0) {
           tn->log(0, SSTR("ERROR: sync module init_sync() failed, retcode=" << retcode));


### PR DESCRIPTION
When radosgw-admin data sync init is called on a cluster, the next run
of rgw crashes as when it processes ListBucketIndexesCR, num_shards
isn't set which is later referenced in ListBucketIndexesCR. Setting the
n sync_info.num_shards correctly to handle this case

Fixes: http://tracker.ceph.com/issues/22083
Signed-off-by: Abhishek Lekshmanan <abhishek@suse.com>