### PR TITLE
os/bluestore: avoid excessive ops in _txc_release_alloc

### DIFF
--- a/src/os/bluestore/BlueStore.cc
+++ b/src/os/bluestore/BlueStore.cc
@@ -8327,17 +8327,11 @@ void BlueStore::_txc_finish(TransContext *txc)
 
 void BlueStore::_txc_release_alloc(TransContext *txc)
 {
-  interval_set<uint64_t> bulk_release_extents;
   // it's expected we're called with lazy_release_lock already taken!
-  if (!cct->_conf->bluestore_debug_no_reuse_blocks) {
+  if (likely(!cct->_conf->bluestore_debug_no_reuse_blocks)) {
     dout(10) << __func__ << " " << txc << " " << txc->released << dendl;
-    // interval_set seems to be too costly for inserting things in
-    // bstore_kv_final. We could serialize in simpler format and perform
-    // the merge separately, maybe even in a dedicated thread.
-    bulk_release_extents.insert(txc->released);
+    alloc->release(txc->released);
   }
-
-  alloc->release(bulk_release_extents);
   txc->allocated.clear();
   txc->released.clear();
 }


### PR DESCRIPTION
Signed-off-by: Igor Fedotov <ifedotov@suse.com>