### PR TITLE
luminous: os/filestore: disable rocksdb compression

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -3670,7 +3670,7 @@ std::vector<Option> get_global_options() {
     // filestore
 
     Option("filestore_rocksdb_options", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("max_background_compactions=8;compaction_readahead_size=2097152")
+    .set_default("max_background_compactions=8,compaction_readahead_size=2097152,compression=kNoCompression")
     .set_description(""),
 
     Option("filestore_omap_backend", Option::TYPE_STR, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
Experience working with customer escalations suggests that disabling
compression improves performance, and the storage overhead is generally
not a concern for the metadata and omap data we are storing.

Signed-off-by: Sage Weil <sage@redhat.com>
(cherry picked from commit b878ead071b328e5fe7309a2368383e67679e9f7)