### PR TITLE
rgw: RGWEnv::set() takes std::string

### DIFF
--- a/src/rgw/rgw_asio_client.cc
+++ b/src/rgw/rgw_asio_client.cc
@@ -32,11 +32,11 @@ void ClientIO::init_env(CephContext *cct)
     const auto& value = header->value();
 
     if (field == beast::http::field::content_length) {
-      env.set("CONTENT_LENGTH", value);
+      env.set("CONTENT_LENGTH", value.to_string());
       continue;
     }
     if (field == beast::http::field::content_type) {
-      env.set("CONTENT_TYPE", value);
+      env.set("CONTENT_TYPE", value.to_string());
       continue;
     }
 
@@ -53,15 +53,14 @@ void ClientIO::init_env(CephContext *cct)
     }
     *dest = '\0';
 
-    env.set(buf, value);
+    env.set(buf, value.to_string());
   }
 
   int major = request.version() / 10;
   int minor = request.version() % 10;
-  std::string http_version = std::to_string(major) + '.' + std::to_string(minor);
-  env.set("HTTP_VERSION", http_version);
+  env.set("HTTP_VERSION", std::to_string(major) + '.' + std::to_string(minor));
 
-  env.set("REQUEST_METHOD", request.method_string());
+  env.set("REQUEST_METHOD", request.method_string().to_string());
 
   // split uri from query
   auto url = request.target();
@@ -69,9 +68,9 @@ void ClientIO::init_env(CephContext *cct)
   auto query = url.substr(pos + 1);
   url = url.substr(0, pos);
 
-  env.set("REQUEST_URI", url);
-  env.set("QUERY_STRING", query);
-  env.set("SCRIPT_URI", url); /* FIXME */
+  env.set("REQUEST_URI", url.to_string());
+  env.set("QUERY_STRING", query.to_string());
+  env.set("SCRIPT_URI", url.to_string()); /* FIXME */
 
   char port_buf[16];
   snprintf(port_buf, sizeof(port_buf), "%d", socket.local_endpoint().port());

--- a/src/rgw/rgw_common.h
+++ b/src/rgw/rgw_common.h
@@ -403,7 +403,7 @@ class RGWEnv {
 public:
   void init(CephContext *cct);
   void init(CephContext *cct, char **envp);
-  void set(const boost::string_ref& name, const boost::string_ref& val);
+  void set(std::string name, std::string val);
   const char *get(const char *name, const char *def_val = nullptr) const;
   int get_int(const char *name, int def_val = 0) const;
   bool get_bool(const char *name, bool def_val = 0);

--- a/src/rgw/rgw_env.cc
+++ b/src/rgw/rgw_env.cc
@@ -17,9 +17,9 @@ void RGWEnv::init(CephContext *cct)
   conf.init(cct);
 }
 
-void RGWEnv::set(const boost::string_ref& name, const boost::string_ref& val)
+void RGWEnv::set(std::string name, std::string val)
 {
-  env_map[name.to_string()] = val.to_string();
+  env_map[std::move(name)] = std::move(val);
 }
 
 void RGWEnv::init(CephContext *cct, char **envp)


### PR DESCRIPTION
fixes a compilation failure with boost version 1.64 or later
Fixes: http://tracker.ceph.com/issues/22101

the beast frontend will either pass a string_ref or a string_view, depending on the boost version. we can't overload RGWEnv::set() for both, because a call to env.set(const char*) would be ambiguous

both string_ref and string_view have a to_string() member function, so RGWEnv::set() now takes a std::string by value and moves it into the map. this involes a single string copy, whether we pass a temporary std::string (in beast) or a const char* (in civetweb)
