### PR TITLE
luminous: rgw_file: full enumeration needs new readdir whence strategy, plus recursive rm side-effect of FLAG_EXACT_MATCH found

### DIFF
--- a/src/rgw/rgw_file.cc
+++ b/src/rgw/rgw_file.cc
@@ -201,6 +201,8 @@ namespace rgw {
 	  if (req.matched) {
 	    /* we need rgw object's key name equal to file name, if
 	     * not return NULL */
+#if 0 /* original behavior which motivated FLAG_EXACT_MATCH
+       * no longer reproduces */
 	    if ((flags & RGWFileHandle::FLAG_EXACT_MATCH) &&
 		!req.exact_matched) {
 	      lsubdout(get_context(), rgw, 15)
@@ -209,6 +211,7 @@ namespace rgw {
 		<< path << dendl;
 	      goto done;
 	    }
+#endif
 	    fhr = lookup_fh(parent, path,
 			    RGWFileHandle::FLAG_CREATE|
 			    ((req.is_dir) ?


### PR DESCRIPTION
http://tracker.ceph.com/issues/21919