### PR TITLE
os/bluestore: print aio in batch

### DIFF
--- a/src/os/bluestore/KernelDevice.cc
+++ b/src/os/bluestore/KernelDevice.cc
@@ -522,10 +522,7 @@ void KernelDevice::aio_submit(IOContext *ioc)
   if (cct->_conf->bdev_debug_aio) {
     list<aio_t>::iterator p = ioc->running_aios.begin();
     while (p != e) {
-      for (auto& io : p->iov)
-	dout(30) << __func__ << "   iov " << (void*)io.iov_base
-		 << " len " << io.iov_len << dendl;
-
+      dout(30) << __func__ << " " << *p << dendl;
       std::lock_guard<std::mutex> l(debug_queue_lock);
       debug_aio_link(*p++);
     }
@@ -645,10 +642,7 @@ int KernelDevice::aio_write(
       ++injecting_crash;
     } else {
       bl.prepare_iov(&aio.iov);
-      for (unsigned i=0; i<aio.iov.size(); ++i) {
-	dout(30) << "aio " << i << " " << aio.iov[i].iov_base
-		 << " " << aio.iov[i].iov_len << dendl;
-      }
+      dout(30) << aio << dendl;
       aio.bl.claim_append(bl);
       aio.pwritev(off, len);
     }
@@ -712,10 +706,7 @@ int KernelDevice::aio_read(
     ++ioc->num_pending;
     aio_t& aio = ioc->pending_aios.back();
     aio.pread(off, len);
-    for (unsigned i=0; i<aio.iov.size(); ++i) {
-      dout(30) << "aio " << i << " " << aio.iov[i].iov_base
-	       << " " << aio.iov[i].iov_len << dendl;
-    }
+    dout(30) << aio << dendl;
     pbl->append(aio.bl);
     dout(5) << __func__ << " 0x" << std::hex << off << "~" << len
 	    << std::dec << " aio " << &aio << dendl;

--- a/src/os/bluestore/aio.cc
+++ b/src/os/bluestore/aio.cc
@@ -5,6 +5,17 @@
 
 #if defined(HAVE_LIBAIO)
 
+std::ostream& operator<<(std::ostream& os, const aio_t& aio)
+{
+  unsigned i = 0;
+  os << "aio: ";
+  for (auto& iov : aio.iov) {
+    os << "\n [" << i++ << "] 0x"
+       << std::hex << iov.iov_base << "~" << iov.iov_len << std::dec;
+  }
+  return os;
+}
+
 int aio_queue_t::submit_batch(aio_iter begin, aio_iter end, 
 			      uint16_t aios_size, void *priv, 
 			      int *retries)

--- a/src/os/bluestore/aio.h
+++ b/src/os/bluestore/aio.h
@@ -45,6 +45,8 @@ struct aio_t {
   }
 };
 
+std::ostream& operator<<(std::ostream& os, const aio_t& aio);
+
 typedef boost::intrusive::list<
   aio_t,
   boost::intrusive::member_hook<


### PR DESCRIPTION
KernelDevice::aio_{submit,write,read}() are critical paths. calling
cct->_conf->subsys.should_gather() multi-times is not optimal. the
downside of this issue is that if the aio is printed, the size of
buffer in PrebufferedStreambuf could be large if the number of iov is
large, that could be a heavy load to the memory subsystem.

Signed-off-by: Kefu Chai <kchai@redhat.com>