### PR TITLE
rados: make ceph_perf_msgr_client work for multiple jobs

### DIFF
--- a/src/test/msgr/perf_msgr_client.cc
+++ b/src/test/msgr/perf_msgr_client.cc
@@ -136,12 +136,12 @@ class MessengerClient {
     for (int i = 0; i < jobs; ++i) {
       Messenger *msgr = Messenger::create(g_ceph_context, type, entity_name_t::CLIENT(0), "client", getpid()+i, 0);
       msgr->set_default_policy(Messenger::Policy::lossless_client(0));
+      msgr->start();
       entity_inst_t inst(entity_name_t::OSD(0), addr);
       ConnectionRef conn = msgr->get_connection(inst);
       ClientThread *t = new ClientThread(msgr, c, conn, msg_len, ops, think_time_us);
       msgrs.push_back(msgr);
       clients.push_back(t);
-      msgr->start();
     }
     usleep(1000*1000);
   }


### PR DESCRIPTION
Move the invocation of msgr->start() before a client initiates a connection.
So the nonce is probably initialized and the server side is able to differenciate
the connections from different Messengers from the same client.

Fixes: http://tracker.ceph.com/issues/22103
Signed-off-by: Jeegn Chen <jeegnchen@gmail.com>