### PR TITLE
qa/suites/rados/perf: whitelist health warnings

### DIFF
--- a/qa/suites/rados/perf/ceph.yaml
+++ b/qa/suites/rados/perf/ceph.yaml
@@ -5,4 +5,9 @@ tasks:
 - ceph:
     fs: xfs
     wait-for-scrub: false
+    log-whitelist:
+      - \(PG_
+      - \(OSD_
+      - \(OBJECT_
+      - overall HEALTH
 - ssh_keys:


### PR DESCRIPTION
We may see these as cluster stabilizes.

Signed-off-by: Sage Weil <sage@redhat.com>