### PR TITLE
compressor/zstd: improvements

### DIFF
--- a/src/compressor/zstd/CMakeLists.txt
+++ b/src/compressor/zstd/CMakeLists.txt
@@ -1,7 +1,7 @@
 # zstd
 
 # libzstd - build it statically
-set(ZSTD_C_FLAGS -fPIC -Wno-unused-variable -O3)
+set(ZSTD_C_FLAGS "-fPIC -Wno-unused-variable -O3")
 
 include(ExternalProject)
 ExternalProject_Add(zstd_ext

--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -15,7 +15,9 @@
 #ifndef CEPH_ZSTDCOMPRESSOR_H
 #define CEPH_ZSTDCOMPRESSOR_H
 
+#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd/lib/zstd.h"
+
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "compressor/Compressor.h"
@@ -35,7 +37,7 @@ class ZstdCompressor : public Compressor {
     outbuf.pos = 0;
 
     ZSTD_CStream *s = ZSTD_createCStream();
-    ZSTD_initCStream(s, COMPRESSION_LEVEL);
+    ZSTD_initCStream_srcSize(s, COMPRESSION_LEVEL, src.length());
     auto p = src.begin();
     size_t left = src.length();
     while (left) {
@@ -47,9 +49,12 @@ class ZstdCompressor : public Compressor {
       left -= inbuf.size;
     }
     assert(p.end());
-    ZSTD_flushStream(s, &outbuf);
-    ZSTD_endStream(s, &outbuf);
+    int r = ZSTD_endStream(s, &outbuf);
     ZSTD_freeCStream(s);
+    if (ZSTD_isError(r)) {
+      return -EINVAL;
+    }
+    assert(r == 0); // we should have had enough room in the output buffer.
 
     // prefix with decompressed length
     ::encode((uint32_t)src.length(), dst);
@@ -85,7 +90,8 @@ class ZstdCompressor : public Compressor {
       }
       ZSTD_inBuffer_s inbuf;
       inbuf.pos = 0;
-      inbuf.size = p.get_ptr_and_advance(compressed_len, (const char**)&inbuf.src);
+      inbuf.size = p.get_ptr_and_advance(compressed_len,
+					 (const char**)&inbuf.src);
       ZSTD_decompressStream(s, &outbuf, &inbuf);
       compressed_len -= inbuf.size;
     }


### PR DESCRIPTION
- static linking #define to get the advanced stuff
- hint src size to compressor
- no flush needed before end
- check for error

It's about twice as 25% faster now for 16KB chunks.

Note that a quick test to use resetCStream and reusing the same stream
did not appear to have any effect.

Signed-off-by: Sage Weil <sage@redhat.com>