### PR TITLE
Cleaned up distros

### DIFF
--- a/qa/suites/upgrade/jewel-x/parallel/distro/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/distro/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/upgrade/jewel-x/parallel/distro/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/parallel/distro/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/jewel-x/parallel/distros
+++ b/qa/suites/upgrade/jewel-x/parallel/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/upgrade/jewel-x/point-to-point-x/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/point-to-point-x/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split-erasure-code/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split/distros
+++ b/qa/suites/upgrade/jewel-x/stress-split/distros
@@ -1,1 +1,0 @@
-../../../../distros/supported/

--- a/qa/suites/upgrade/jewel-x/stress-split/distros/centos_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/distros/centos_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/centos_latest.yaml

--- a/qa/suites/upgrade/jewel-x/stress-split/distros/ubuntu_latest.yaml
+++ b/qa/suites/upgrade/jewel-x/stress-split/distros/ubuntu_latest.yaml
@@ -1,0 +1,1 @@
+../../../../../distros/supported/ubuntu_latest.yaml


### PR DESCRIPTION
Use centos_latest.yaml and ubuntu_latest.yaml instead of fixed distro versions.
Removed ubuntu 14.04

Signed-off-by: Yuri Weinstein <yweinste@redhat.com>