### PR TITLE
DNM: zstd: hack test reusing cstream

### DIFF
--- a/src/compressor/zstd/ZstdCompressor.h
+++ b/src/compressor/zstd/ZstdCompressor.h
@@ -15,7 +15,9 @@
 #ifndef CEPH_ZSTDCOMPRESSOR_H
 #define CEPH_ZSTDCOMPRESSOR_H
 
+#define ZSTD_STATIC_LINKING_ONLY
 #include "zstd/lib/zstd.h"
+
 #include "include/buffer.h"
 #include "include/encoding.h"
 #include "compressor/Compressor.h"
@@ -35,7 +37,7 @@ class ZstdCompressor : public Compressor {
     outbuf.pos = 0;
 
     ZSTD_CStream *s = ZSTD_createCStream();
-    ZSTD_initCStream(s, COMPRESSION_LEVEL);
+    ZSTD_initCStream_srcSize(s, COMPRESSION_LEVEL, src.length());
     auto p = src.begin();
     size_t left = src.length();
     while (left) {
@@ -47,9 +49,12 @@ class ZstdCompressor : public Compressor {
       left -= inbuf.size;
     }
     assert(p.end());
-    ZSTD_flushStream(s, &outbuf);
-    ZSTD_endStream(s, &outbuf);
+    int r = ZSTD_endStream(s, &outbuf);
     ZSTD_freeCStream(s);
+    if (ZSTD_isError(r)) {
+      return -EINVAL;
+    }
+    assert(r == 0); // we should have had enough room in the output buffer.
 
     // prefix with decompressed length
     ::encode((uint32_t)src.length(), dst);
@@ -85,7 +90,8 @@ class ZstdCompressor : public Compressor {
       }
       ZSTD_inBuffer_s inbuf;
       inbuf.pos = 0;
-      inbuf.size = p.get_ptr_and_advance(compressed_len, (const char**)&inbuf.src);
+      inbuf.size = p.get_ptr_and_advance(compressed_len,
+					 (const char**)&inbuf.src);
       ZSTD_decompressStream(s, &outbuf, &inbuf);
       compressed_len -= inbuf.size;
     }


### PR DESCRIPTION
@Cyan4973: to reproduce,
git checkout, sudo ./install-deps.sh, ./do_cmake.sh, cd build, make ceph_zstd ceph_zlib ceph_snappy unittest_compression (this will take forever, sorry), bin/unittest_compression --gtest_filter=*compress_16*
