### PR TITLE
rgw: set num_shards on 'radosgw-admin data sync init'

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -674,6 +674,8 @@ int RGWRemoteDataLog::read_sync_status(rgw_data_sync_status *sync_status)
 int RGWRemoteDataLog::init_sync_status(int num_shards)
 {
   rgw_data_sync_status sync_status;
+  sync_status.sync_info.num_shards = num_shards;
+
   RGWCoroutinesManager crs(store->ctx(), store->get_cr_registry());
   RGWHTTPManager http_manager(store->ctx(), crs.get_completion_mgr());
   int ret = http_manager.set_threaded();

--- a/src/rgw/rgw_data_sync.h
+++ b/src/rgw/rgw_data_sync.h
@@ -83,6 +83,7 @@ struct rgw_data_sync_info {
     JSONDecoder::decode_json("num_shards", num_shards, obj);
     JSONDecoder::decode_json("instance_id", num_shards, obj);
   }
+  static void generate_test_instances(std::list<rgw_data_sync_info*>& o);
 
   rgw_data_sync_info() : state((int)StateInit), num_shards(0) {}
 };
@@ -144,6 +145,7 @@ struct rgw_data_sync_marker {
     JSONDecoder::decode_json("timestamp", t, obj);
     timestamp = t.to_real_time();
   }
+  static void generate_test_instances(std::list<rgw_data_sync_marker*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_data_sync_marker)
 
@@ -175,6 +177,7 @@ struct rgw_data_sync_status {
     JSONDecoder::decode_json("info", sync_info, obj);
     JSONDecoder::decode_json("markers", sync_markers, obj);
   }
+  static void generate_test_instances(std::list<rgw_data_sync_status*>& o);
 };
 WRITE_CLASS_ENCODER(rgw_data_sync_status)
 

--- a/src/rgw/rgw_dencoder.cc
+++ b/src/rgw/rgw_dencoder.cc
@@ -7,6 +7,8 @@
 #include "rgw_acl.h"
 #include "rgw_acl_s3.h"
 #include "rgw_cache.h"
+#include "rgw_meta_sync_status.h"
+#include "rgw_data_sync.h"
 
 #include "common/Formatter.h"
 
@@ -497,3 +499,51 @@ void rgw_obj::generate_test_instances(list<rgw_obj*>& o)
   o.push_back(new rgw_obj);
 }
 
+void rgw_meta_sync_info::generate_test_instances(list<rgw_meta_sync_info*>& o)
+{
+  auto info = new rgw_meta_sync_info;
+  info->state = rgw_meta_sync_info::StateBuildingFullSyncMaps;
+  info->period = "periodid";
+  info->realm_epoch = 5;
+  o.push_back(info);
+  o.push_back(new rgw_meta_sync_info);
+}
+
+void rgw_meta_sync_marker::generate_test_instances(list<rgw_meta_sync_marker*>& o)
+{
+  auto marker = new rgw_meta_sync_marker;
+  marker->state = rgw_meta_sync_marker::IncrementalSync;
+  marker->marker = "01234";
+  marker->realm_epoch = 5;
+  o.push_back(marker);
+  o.push_back(new rgw_meta_sync_marker);
+}
+
+void rgw_meta_sync_status::generate_test_instances(list<rgw_meta_sync_status*>& o)
+{
+  o.push_back(new rgw_meta_sync_status);
+}
+
+void rgw_data_sync_info::generate_test_instances(list<rgw_data_sync_info*>& o)
+{
+  auto info = new rgw_data_sync_info;
+  info->state = rgw_data_sync_info::StateBuildingFullSyncMaps;
+  info->num_shards = 8;
+  o.push_back(info);
+  o.push_back(new rgw_data_sync_info);
+}
+
+void rgw_data_sync_marker::generate_test_instances(list<rgw_data_sync_marker*>& o)
+{
+  auto marker = new rgw_data_sync_marker;
+  marker->state = rgw_data_sync_marker::IncrementalSync;
+  marker->marker = "01234";
+  marker->pos = 5;
+  o.push_back(marker);
+  o.push_back(new rgw_data_sync_marker);
+}
+
+void rgw_data_sync_status::generate_test_instances(list<rgw_data_sync_status*>& o)
+{
+  o.push_back(new rgw_data_sync_status);
+}

--- a/src/rgw/rgw_meta_sync_status.h
+++ b/src/rgw/rgw_meta_sync_status.h
@@ -39,6 +39,7 @@ struct rgw_meta_sync_info {
 
   void decode_json(JSONObj *obj);
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_meta_sync_info*>& ls);
 
   rgw_meta_sync_info() : state((int)StateInit), num_shards(0) {}
 };
@@ -87,6 +88,7 @@ struct rgw_meta_sync_marker {
 
   void decode_json(JSONObj *obj);
   void dump(Formatter *f) const;
+  static void generate_test_instances(std::list<rgw_meta_sync_marker*>& ls);
 };
 WRITE_CLASS_ENCODER(rgw_meta_sync_marker)
 
@@ -112,6 +114,7 @@ struct rgw_meta_sync_status {
 
   void dump(Formatter *f) const;
   void decode_json(JSONObj *obj);
+  static void generate_test_instances(std::list<rgw_meta_sync_status*>& ls);
 };
 WRITE_CLASS_ENCODER(rgw_meta_sync_status)
 

--- a/src/test/encoding/types.h
+++ b/src/test/encoding/types.h
@@ -388,6 +388,16 @@ TYPE(rgw_obj)
 #include "rgw/rgw_log.h"
 TYPE(rgw_log_entry)
 
+#include "rgw/rgw_sync.h"
+TYPE(rgw_meta_sync_info)
+TYPE(rgw_meta_sync_marker)
+TYPE(rgw_meta_sync_status)
+
+#include "rgw/rgw_data_sync.h"
+TYPE(rgw_data_sync_info)
+TYPE(rgw_data_sync_marker)
+TYPE(rgw_data_sync_status)
+
 #ifdef WITH_RBD
 #include "cls/rbd/cls_rbd.h"
 TYPE(cls_rbd_parent)


### PR DESCRIPTION
Fixes: http://tracker.ceph.com/issues/22083 (see also https://github.com/ceph/ceph/pull/18852)

adds ceph-dencoder support for rgw sync status types, used to validate the fix

without the fix:
```
$ bin/radosgw-admin -c run/c2/ceph.conf data sync init --source-zone a1
$ bin/rados -c run/c2/ceph.conf -p a2.rgw.log get datalog.sync-status.c00ae4fb-6819-4efc-815d-1e30dfcd24df data.sync-status
$ bin/ceph-dencoder type rgw_data_sync_info import data.sync-status decode dump_json
{
    "status": "building-full-sync-maps",
    "num_shards": 0,
    "instance_id": 988322046502566107
}
```

with the fix:
```
$ bin/radosgw-admin -c run/c2/ceph.conf data sync init --source-zone a1
$ bin/rados -c run/c2/ceph.conf -p a2.rgw.log get datalog.sync-status.1b6d8d3f-fbdb-402a-a92b-f19e5b474c1e data.sync-status
$ bin/ceph-dencoder type rgw_data_sync_info import data.sync-status decode dump_json                                                             
{
    "status": "building-full-sync-maps",
    "num_shards": 128,
    "instance_id": 14612016681866375495
}
```