### PR TITLE
mgr/prometheus: add missing 'deep' state to PG_STATES in ceph-mgr prometheus plugin

### DIFF
--- a/doc/rados/operations/pg-states.rst
+++ b/doc/rados/operations/pg-states.rst
@@ -20,7 +20,10 @@ map is ``active + clean``.
   A replica with necessary data is down, so the placement group is offline.
 
 *Scrubbing*
-  Ceph is checking the placement group for inconsistencies.
+  Ceph is checking the placement group metadata for inconsistencies.
+
+*Deep*
+  Ceph is checking the placement group data against stored checksums.
 
 *Degraded*
   Ceph has not replicated some objects in the placement group the correct number of times yet.

--- a/src/pybind/mgr/prometheus/module.py
+++ b/src/pybind/mgr/prometheus/module.py
@@ -42,7 +42,7 @@ def health_status_to_number(status):
     elif status == 'HEALTH_ERR':
         return 2
 
-PG_STATES = ['creating', 'active', 'clean', 'down', 'scrubbing', 'degraded',
+PG_STATES = ['creating', 'active', 'clean', 'down', 'scrubbing', 'deep', 'degraded',
         'inconsistent', 'peering', 'repair', 'recovering', 'forced-recovery',
         'backfill', 'forced-backfill', 'wait-backfill', 'backfill-toofull',
         'incomplete', 'stale', 'remapped', 'undersized', 'peered']
@@ -266,12 +266,15 @@ class Module(MgrModule):
             try:
                 self.metrics[path].set(value)
             except KeyError:
-                self.log.warn('Skipping unknown PG State {}'.format(state))
+                self.log.warn("skipping pg in unknown state {}".format(state))
         reported_states = [s[0] for s in reported_pg_s]
         for state in PG_STATES:
             path = 'pg_{}'.format(state)
             if state not in reported_states:
-                self.metrics[path].set(0)
+                try:
+                    self.metrics[path].set(0)
+                except KeyError:
+                    self.log.warn("skipping pg in unknown state {}".format(state))
 
     def get_metadata_and_osd_status(self):
         osd_map = self.get('osd_map')


### PR DESCRIPTION
without this the endpoint throws 500s when any PG is doing a deep scrub