### PR TITLE
MDS: add null check before we push_back "onfinish"

### DIFF
--- a/src/mds/MDSTable.cc
+++ b/src/mds/MDSTable.cc
@@ -60,7 +60,8 @@ void MDSTable::save(MDSInternalContextBase *onfinish, version_t v)
   if (v > 0 && v <= committing_version) {
     dout(10) << "save v " << version << " - already saving "
 	     << committing_version << " >= needed " << v << dendl;
-    waitfor_save[v].push_back(onfinish);
+    if (onfinish)
+      waitfor_save[v].push_back(onfinish);
     return;
   }
   


### PR DESCRIPTION
Fix: finish_context does not expect a null pointer, would cause crash.