### PR TITLE
os/bluestore: Dropped override of AreFilesSame

### DIFF
--- a/src/os/bluestore/BlueRocksEnv.h
+++ b/src/os/bluestore/BlueRocksEnv.h
@@ -116,7 +116,7 @@ public:
 
   // Tell if two files are identical
   rocksdb::Status AreFilesSame(const std::string& first,
-			       const std::string& second, bool* res) override;
+			       const std::string& second, bool* res);
 
   // Lock the specified file.  Used to prevent concurrent access to
   // the same db by multiple processes.  On failure, stores nullptr in


### PR DESCRIPTION
The following error appears during build:
```
In file included from ceph/src/os/bluestore/BlueRocksEnv.cc:4:0:
ceph/src/os/bluestore/BlueRocksEnv.h:118:19: error: ‘rocksdb::Status BlueRocksEnv::AreFilesSame(const string&, const string&, bool*)’ marked ‘override’, but does not override
   rocksdb::Status AreFilesSame(const std::string& first,
                   ^~~~~~~~~~~~
```
Signed-off-by: Jos Collin <jcollin@redhat.com>