### PR TITLE
rgw.iam: change '1' to '1ULL' in function print_actions

### DIFF
--- a/src/rgw/rgw_iam_policy.cc
+++ b/src/rgw/rgw_iam_policy.cc
@@ -1416,13 +1416,13 @@ ostream& print_actions(ostream& m, const uint64_t a) {
   bool begun = false;
   m << "[ ";
   for (auto i = 0U; i < s3Count; ++i) {
-    if (a & (1 << i)) {
+    if (a & (1ULL << i)) {
       if (begun) {
-	m << ", ";
+        m << ", ";
       } else {
-	begun = true;
+        begun = true;
       }
-      m << action_bit_string(1 << i);
+      m << action_bit_string(1ULL << i);
     }
   }
   if (begun) {


### PR DESCRIPTION
* IAM has 54 operations corresponding to 54 bits. 1 is a signed integer
* which can cover 31 operations, so we need 1ULL here.

Signed-off-by: Bingyin Zhang <zhangbingyin@cloudin.cn>