### PR TITLE
tools/crushtool: skip device id if no name exists

### DIFF
--- a/src/crush/CrushCompiler.cc
+++ b/src/crush/CrushCompiler.cc
@@ -314,10 +314,12 @@ int CrushCompiler::decompile(ostream &out)
 
   out << "\n# devices\n";
   for (int i=0; i<crush.get_max_devices(); i++) {
-    out << "device " << i << " ";
-    print_item_name(out, i, crush);
-    print_item_class(out, i, crush);
-    out << "\n";
+    const char *name = crush.get_item_name(i);
+    if (name) {
+      out << "device " << i << " " << name;
+      print_item_class(out, i, crush);
+      out << "\n";
+    }
   }
   
   out << "\n# types\n";

--- a/src/test/cli/osdmaptool/create-racks.t
+++ b/src/test/cli/osdmaptool/create-racks.t
@@ -16,7 +16,6 @@
   tunable allowed_bucket_algs 54
   
   # devices
-  device 0 device0
   device 1 osd.1
   device 2 osd.2
   device 3 osd.3


### PR DESCRIPTION
When an OSD with an id < max_id is removed, i.e. the osd ids are not
continuous, crushtool decompile prints bogus info. Skip any device ids
without a name.

Fixes: http://tracker.ceph.com/issues/22117

Signed-off-by: Jan Fajerski <jfajerski@suse.com>