### PR TITLE
rgw: fix sync_info miss the num_shards in data sync init cmd

### DIFF
--- a/src/rgw/rgw_data_sync.cc
+++ b/src/rgw/rgw_data_sync.cc
@@ -683,6 +683,7 @@ int RGWRemoteDataLog::init_sync_status(int num_shards)
   }
   RGWDataSyncEnv sync_env_local = sync_env;
   sync_env_local.http_manager = &http_manager;
+  sync_status.sync_info.num_shards = num_shards;
   auto instance_id = ceph::util::generate_random_number<uint64_t>();
   ret = crs.run(new RGWInitDataSyncStatusCoroutine(&sync_env_local, num_shards, instance_id, tn, &sync_status));
   http_manager.stop();


### PR DESCRIPTION
Signed-off-by: Tianshan Qu <tianshan@xsky.com>